### PR TITLE
feat(rotate): replace `rotate` with `balanced` (weighted random)

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -52,7 +52,7 @@ interface ExecCommandActionOptions {
   verbose?: boolean;
   timeout?: string;
   fallback?: string;
-  rotate?: boolean;
+  balanced?: boolean;
   strategy?: string;
   acp?: boolean;
 }
@@ -62,12 +62,12 @@ function isValidAgent(agent: string): agent is AgentId {
   return VALID_AGENTS.includes(agent);
 }
 
-/** Build a one-line banner describing which version the rotation picked. */
-function formatRotationBanner(result: RotateResult): string {
+/** Build a one-line banner describing which version the strategy picked. */
+function formatRotationBanner(result: RotateResult, verb: string = 'balanced'): string {
   const { picked, healthy, excluded } = result;
   const label = picked.email ? `${picked.email} · ${picked.agent}@${picked.version}` : `${picked.agent}@${picked.version}`;
   const ratio = `${healthy.length} of ${healthy.length + excluded.length} healthy`;
-  return `[agents] rotation picked ${label} (${ratio})`;
+  return `[agents] ${verb} picked ${label} (${ratio})`;
 }
 
 /** Register the `agents run <agent> [prompt]` command. */
@@ -108,12 +108,12 @@ export function registerRunCommand(program: Command): void {
       'Comma-separated agents to try on rate-limit failure. Each entry accepts an optional @version pin (e.g., codex@0.116.0,gemini). The primary runs first; if it exits with a rate-limit error, the next agent picks up via /continue handoff.',
     )
     .option(
-      '-r, --rotate',
-      'Shortcut for --strategy rotate. Ignored when @version is pinned.',
+      '-b, --balanced',
+      'Shortcut for --strategy balanced. Ignored when @version is pinned.',
     )
     .option(
       '--strategy <strategy>',
-      'Version/account selection strategy: pinned | available | rotate. Defaults to run.<agent>.strategy, then pinned.',
+      'Version/account selection strategy: pinned | available | balanced. Defaults to run.<agent>.strategy, then pinned. (Legacy `rotate` accepted as alias for `balanced`.)',
     )
     .option(
       '--acp',
@@ -128,18 +128,20 @@ Run strategy:
   pinned     Use the workspace/global pinned version from agents.yaml.
   available  Use the pinned version if it has usage available; otherwise switch
              to another signed-in version with usage available.
-  rotate     Pick the signed-in account with usage available and the most
-             headroom; last-active breaks ties.
+  balanced   Distribute traffic across healthy accounts using weighted random
+             by remaining capacity — fresher accounts get more, near-exhausted
+             ones get less. Avoids bursting any single account.
   Configure with run.<agent>.strategy in agents.yaml, or override with
-  --strategy. --rotate is kept as a shortcut for --strategy rotate.
+  --strategy. --balanced is kept as a shortcut for --strategy balanced.
+  Legacy "rotate" is accepted as an alias for "balanced".
   Ignored when @version is pinned, when a profile is used, or with --fallback.
 
 Examples:
   # Interactive with the pinned default version
   agents run claude
 
-  # Interactive, rotate to the least-used healthy account
-  agents run claude --strategy rotate
+  # Interactive, distribute load across healthy accounts
+  agents run claude --strategy balanced
 
   # Headless, switch away from the pinned version when usage is unavailable
   agents run claude "summarize recent git commits" --mode plan --strategy available
@@ -207,15 +209,15 @@ Examples:
         console.error(chalk.red(`Invalid strategy: ${options.strategy}. Use ${RUN_STRATEGIES.join(', ')}.`));
         process.exit(1);
       }
-      if (options.rotate && explicitStrategy && explicitStrategy !== 'rotate') {
-        console.error(chalk.red('--rotate conflicts with --strategy. Use one strategy override.'));
+      if (options.balanced && explicitStrategy && explicitStrategy !== 'balanced') {
+        console.error(chalk.red('--balanced conflicts with --strategy. Use one strategy override.'));
         process.exit(1);
       }
-      const strategy = options.rotate ? 'rotate' : explicitStrategy ?? configuredStrategy;
+      const strategy = options.balanced ? 'balanced' : explicitStrategy ?? configuredStrategy;
 
       // Strategy only applies to bare agent invocations. Explicit @version,
       // profiles, and fallback chains already define their execution target.
-      if (strategy !== 'pinned' || options.rotate || explicitStrategy) {
+      if (strategy !== 'pinned' || options.balanced || explicitStrategy) {
         if (version) {
           process.stderr.write(chalk.yellow(`[agents] strategy ${strategy} ignored: version ${version} is pinned\n`));
         } else if (fromProfile) {
@@ -228,9 +230,7 @@ Examples:
             if (resolved.version) {
               version = resolved.version;
               if (resolved.rotation) {
-                const banner = strategy === 'available'
-                  ? formatRotationBanner(resolved.rotation).replace('rotation picked', 'available picked')
-                  : formatRotationBanner(resolved.rotation);
+                const banner = formatRotationBanner(resolved.rotation, strategy);
                 process.stderr.write(chalk.gray(banner + '\n'));
               }
             } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,12 @@ process.on('SIGINT', () => process.exit(130));
 // (e.g. `agents sessions | head`, or when stdout is captured by another process).
 process.on('SIGPIPE', () => {});
 
+// Suppress the Node.js ExperimentalWarning for node:sqlite (it's stable enough for our use).
+process.on('warning', (warning) => {
+  if (warning.name === 'ExperimentalWarning' && warning.message.includes('SQLite')) return;
+  process.stderr.write(`${warning.name}: ${warning.message}\n`);
+});
+
 // Get version from package.json
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageJsonPath = path.join(__dirname, '..', 'package.json');

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,12 +23,6 @@ process.on('SIGINT', () => process.exit(130));
 // (e.g. `agents sessions | head`, or when stdout is captured by another process).
 process.on('SIGPIPE', () => {});
 
-// Suppress the Node.js ExperimentalWarning for node:sqlite (it's stable enough for our use).
-process.on('warning', (warning) => {
-  if (warning.name === 'ExperimentalWarning' && warning.message.includes('SQLite')) return;
-  process.stderr.write(`${warning.name}: ${warning.message}\n`);
-});
-
 // Get version from package.json
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageJsonPath = path.join(__dirname, '..', 'package.json');

--- a/src/lib/__tests__/rotate.test.ts
+++ b/src/lib/__tests__/rotate.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   normalizeRunStrategy,
   pickAvailableCandidate,
-  pickRotateCandidate,
+  pickBalancedCandidate,
   type RotateCandidate,
 } from '../rotate.js';
 import type { UsageSnapshot } from '../usage.js';
@@ -72,9 +72,9 @@ function cand(overrides: Partial<RotateCandidate>): RotateCandidate {
   };
 }
 
-describe('pickRotateCandidate', () => {
+describe('pickBalancedCandidate', () => {
   it('returns null when nothing is signed in', () => {
-    const result = pickRotateCandidate([
+    const result = pickBalancedCandidate([
       cand({ version: '1.0.0', email: null }),
       cand({ version: '2.0.0', email: null }),
     ]);
@@ -82,7 +82,7 @@ describe('pickRotateCandidate', () => {
   });
 
   it('returns null when every signed-in account is out of credits', () => {
-    const result = pickRotateCandidate([
+    const result = pickBalancedCandidate([
       cand({ version: '1.0.0', usageStatus: 'out_of_credits' }),
       cand({ version: '2.0.0', usageStatus: 'out_of_credits' }),
     ]);
@@ -90,33 +90,22 @@ describe('pickRotateCandidate', () => {
   });
 
   it('returns null for an empty list', () => {
-    expect(pickRotateCandidate([])).toBeNull();
+    expect(pickBalancedCandidate([])).toBeNull();
   });
 
-  it('picks the least-recently-active healthy candidate when usage is unknown', () => {
-    const newest = cand({ version: '2.1.113', email: 'a@x.com', lastActive: new Date('2026-04-20T10:00:00Z') });
-    const middle = cand({ version: '2.1.112', email: 'b@x.com', lastActive: new Date('2026-04-20T05:00:00Z') });
-    const oldest = cand({ version: '2.1.92', email: 'c@x.com', lastActive: new Date('2026-04-16T00:00:00Z') });
-
-    const result = pickRotateCandidate([newest, middle, oldest]);
-    expect(result).not.toBeNull();
-    expect(result!.picked.version).toBe('2.1.92');
-    expect(result!.healthy.map((c) => c.version)).toEqual(['2.1.92', '2.1.112', '2.1.113']);
-  });
-
-  it('treats never-used versions (null lastActive) as oldest', () => {
-    const used = cand({ version: '2.1.113', lastActive: new Date('2026-04-20T10:00:00Z') });
-    const fresh = cand({ version: '2.1.120', lastActive: null });
-
-    const result = pickRotateCandidate([used, fresh]);
-    expect(result!.picked.version).toBe('2.1.120');
+  it('always picks the only healthy candidate', () => {
+    const only = cand({ version: '2.1.113', email: 'a@x.com', usageSnapshot: usage(50) });
+    for (let i = 0; i < 50; i++) {
+      const result = pickBalancedCandidate([only]);
+      expect(result!.picked.version).toBe('2.1.113');
+    }
   });
 
   it('excludes out-of-credits but keeps them reported', () => {
     const healthy = cand({ version: '2.1.113', lastActive: new Date('2026-04-20T10:00:00Z') });
     const dead = cand({ version: '2.1.85', usageStatus: 'out_of_credits', lastActive: new Date('2026-04-15T00:00:00Z') });
 
-    const result = pickRotateCandidate([healthy, dead]);
+    const result = pickBalancedCandidate([healthy, dead]);
     expect(result!.picked.version).toBe('2.1.113');
     expect(result!.healthy).toHaveLength(1);
     expect(result!.excluded).toHaveLength(1);
@@ -127,7 +116,7 @@ describe('pickRotateCandidate', () => {
     const healthy = cand({ version: '2.1.113' });
     const notAuthed = cand({ version: '2.1.120', email: null, lastActive: null });
 
-    const result = pickRotateCandidate([healthy, notAuthed]);
+    const result = pickBalancedCandidate([healthy, notAuthed]);
     expect(result!.picked.version).toBe('2.1.113');
     expect(result!.excluded).toHaveLength(1);
   });
@@ -136,18 +125,18 @@ describe('pickRotateCandidate', () => {
     const valid = cand({ version: '2.1.110', lastActive: new Date('2026-04-20T10:00:00Z') });
     const expired = cand({ version: '2.1.112', authValid: false, lastActive: new Date('2026-04-15T00:00:00Z') });
 
-    const result = pickRotateCandidate([valid, expired]);
+    const result = pickBalancedCandidate([valid, expired]);
     expect(result!.picked.version).toBe('2.1.110');
     expect(result!.healthy).toHaveLength(1);
     expect(result!.excluded).toHaveLength(1);
     expect(result!.excluded[0].version).toBe('2.1.112');
   });
 
-  it('excludes rate-limited accounts from rotation', () => {
-    const rateLimited = cand({ version: '2.1.113', email: 'a@x.com', usageStatus: 'rate_limited', lastActive: new Date('2026-04-15T00:00:00Z') });
-    const newer = cand({ version: '2.1.112', email: 'b@x.com', lastActive: new Date('2026-04-20T10:00:00Z') });
+  it('excludes rate-limited accounts from selection', () => {
+    const rateLimited = cand({ version: '2.1.113', email: 'a@x.com', usageStatus: 'rate_limited' });
+    const newer = cand({ version: '2.1.112', email: 'b@x.com' });
 
-    const result = pickRotateCandidate([rateLimited, newer]);
+    const result = pickBalancedCandidate([rateLimited, newer]);
     expect(result!.picked.version).toBe('2.1.112');
     expect(result!.healthy).toHaveLength(1);
     expect(result!.excluded.map((c) => c.version)).toContain('2.1.113');
@@ -165,67 +154,47 @@ describe('pickRotateCandidate', () => {
       version: '2.1.118',
       email: 'trp@example.com',
       usageStatus: 'available',
-      usageSnapshot: usage(30),
+      usageSnapshot: usage(95),
       lastActive: new Date('2026-04-15T00:00:00Z'),
     });
 
-    const result = pickRotateCandidate([staleFlag, busier]);
-    expect(result!.picked.version).toBe('2.1.121');
-    expect(result!.healthy.map((c) => c.version)).toEqual(['2.1.121', '2.1.118']);
-  });
-
-  it('picks the account with the most usage headroom before last-active', () => {
-    const oldest = cand({
-      version: '2.1.113',
-      email: 'a@x.com',
-      usageSnapshot: usage(80),
-      lastActive: new Date('2026-04-15T00:00:00Z'),
-    });
-    const newest = cand({
-      version: '2.1.112',
-      email: 'b@x.com',
-      usageSnapshot: usage(30),
-      lastActive: new Date('2026-04-20T10:00:00Z'),
-    });
-
-    const result = pickRotateCandidate([oldest, newest]);
-    expect(result!.picked.version).toBe('2.1.112');
-    expect(result!.healthy.map((c) => c.version)).toEqual(['2.1.112', '2.1.113']);
-  });
-
-  it('does not let a full session window outweigh lower weekly usage', () => {
-    const icloud = cand({
-      version: '2.1.112',
-      email: 'muqsitnawaz@icloud.com',
-      usageSnapshot: claudeUsage(100, 15, 0),
-      lastActive: new Date('2026-04-20T10:00:00Z'),
-    });
-    const trp = cand({
-      version: '2.1.110',
-      email: 'muqsit@trp.so',
-      usageSnapshot: claudeUsage(15, 19, 7),
-      lastActive: new Date('2026-04-15T00:00:00Z'),
-    });
-
-    const result = pickRotateCandidate([icloud, trp]);
-    expect(result!.picked.version).toBe('2.1.112');
-    expect(result!.healthy.map((c) => c.version)).toEqual(['2.1.112', '2.1.110']);
+    // Both eligible — stale flag overridden by live snapshot at 15% used.
+    const result = pickBalancedCandidate([staleFlag, busier]);
+    expect(result!.healthy).toHaveLength(2);
+    expect(result!.healthy.map((c) => c.version).sort()).toEqual(['2.1.118', '2.1.121']);
   });
 
   it('excludes accounts whose live usage windows are exhausted', () => {
     const exhausted = cand({ version: '2.1.113', email: 'a@x.com', usageSnapshot: usage(100) });
     const available = cand({ version: '2.1.112', email: 'b@x.com', usageSnapshot: usage(60) });
 
-    const result = pickRotateCandidate([exhausted, available]);
+    const result = pickBalancedCandidate([exhausted, available]);
     expect(result!.picked.version).toBe('2.1.112');
     expect(result!.excluded.map((c) => c.version)).toContain('2.1.113');
   });
 
-  it('distributes across tied candidates so parallel callers fan out', () => {
-    // All four fresh installs with distinct emails (lastActive: null → all
-    // sort to time 0). Without jitter, every caller picks the same version.
-    // With jitter, each version should be picked at least 5% of the time
-    // over 1000 runs.
+  it('weights selection by remaining capacity — fresher account wins more often', () => {
+    // 10% used vs 90% used → weights 90 vs 10. Over 2000 trials, 10%-used
+    // should win ~9× more often than 90%-used. Allow generous tolerance.
+    const fresh = cand({ version: '2.1.113', email: 'a@x.com', usageSnapshot: usage(10) });
+    const tired = cand({ version: '2.1.112', email: 'b@x.com', usageSnapshot: usage(90) });
+
+    const counts: Record<string, number> = { '2.1.113': 0, '2.1.112': 0 };
+    const iterations = 2000;
+    for (let i = 0; i < iterations; i++) {
+      const result = pickBalancedCandidate([fresh, tired]);
+      counts[result!.picked.version] += 1;
+    }
+    // Expected: fresh wins ~90% of trials. Allow [80%, 95%].
+    const freshRatio = counts['2.1.113'] / iterations;
+    expect(freshRatio).toBeGreaterThan(0.8);
+    expect(freshRatio).toBeLessThan(0.95);
+    // Tired is still picked sometimes — never zero.
+    expect(counts['2.1.112']).toBeGreaterThan(0);
+  });
+
+  it('distributes roughly evenly across equal-capacity candidates', () => {
+    // Four candidates all at 0% used → equal weights → uniform random.
     const accounts = [
       { version: '2.1.110', email: 'a@x.com' },
       { version: '2.1.111', email: 'b@x.com' },
@@ -235,29 +204,79 @@ describe('pickRotateCandidate', () => {
     const counts: Record<string, number> = {};
     for (const a of accounts) counts[a.version] = 0;
 
-    const iterations = 1000;
+    const iterations = 2000;
     for (let i = 0; i < iterations; i++) {
-      const result = pickRotateCandidate(
-        accounts.map((a) => cand({ version: a.version, email: a.email, lastActive: null })),
+      const result = pickBalancedCandidate(
+        accounts.map((a) => cand({ version: a.version, email: a.email, usageSnapshot: usage(0) })),
       );
       counts[result!.picked.version] += 1;
     }
 
+    // Expected: ~25% each. Allow [15%, 35%].
     for (const a of accounts) {
       const ratio = counts[a.version] / iterations;
-      expect(ratio).toBeGreaterThan(0.05);
+      expect(ratio).toBeGreaterThan(0.15);
+      expect(ratio).toBeLessThan(0.35);
     }
   });
 
+  it('still picks a near-exhausted-but-eligible account occasionally', () => {
+    // 99% used has weight 1; 0% used has weight 100. The 99% account should
+    // be picked roughly 1% of the time — small but nonzero.
+    const almost = cand({ version: '2.1.113', email: 'a@x.com', usageSnapshot: usage(99) });
+    const fresh = cand({ version: '2.1.112', email: 'b@x.com', usageSnapshot: usage(0) });
+
+    const counts: Record<string, number> = { '2.1.113': 0, '2.1.112': 0 };
+    const iterations = 5000;
+    for (let i = 0; i < iterations; i++) {
+      const result = pickBalancedCandidate([almost, fresh]);
+      counts[result!.picked.version] += 1;
+    }
+    // Sanity: never zero. The fresh one dominates but we don't starve the other.
+    expect(counts['2.1.113']).toBeGreaterThan(0);
+    expect(counts['2.1.112']).toBeGreaterThan(counts['2.1.113'] * 10);
+  });
+
+  it('uses the highest non-session window for capacity weighting', () => {
+    // session=100 should NOT exclude the candidate or zero its weight; weekly
+    // is what matters for routing. A high session% with low week% remains a
+    // valid, high-weight pick.
+    const sessionMaxed = cand({
+      version: '2.1.112',
+      email: 'icloud@example.com',
+      usageSnapshot: claudeUsage(100, 15, 0),
+      lastActive: new Date('2026-04-20T10:00:00Z'),
+    });
+    const weeklyBusy = cand({
+      version: '2.1.110',
+      email: 'trp@example.com',
+      usageSnapshot: claudeUsage(15, 80, 7),
+      lastActive: new Date('2026-04-15T00:00:00Z'),
+    });
+
+    // sessionMaxed: routing usage = max(15, 0) = 15 → weight 85
+    // weeklyBusy:    routing usage = max(80, 7) = 80 → weight 20
+    // Expected: sessionMaxed wins ~85/(85+20) = 81% of trials.
+    const counts: Record<string, number> = { '2.1.112': 0, '2.1.110': 0 };
+    const iterations = 2000;
+    for (let i = 0; i < iterations; i++) {
+      const result = pickBalancedCandidate([sessionMaxed, weeklyBusy]);
+      counts[result!.picked.version] += 1;
+    }
+    const sessionMaxedRatio = counts['2.1.112'] / iterations;
+    expect(sessionMaxedRatio).toBeGreaterThan(0.7);
+    expect(sessionMaxedRatio).toBeLessThan(0.92);
+  });
+
   it('dedupes by email — same account on two versions collapses to one candidate', () => {
-    // Real scenario: user-a@example.com installed under 2.1.118 and 2.1.110.
-    // Without dedup, two parallel pods could "rotate" to different versions
-    // but hit the same Anthropic account and both 429.
+    // user-a@example.com installed under 2.1.118 and 2.1.110. Without dedup,
+    // weighted random could pick 2.1.118 OR 2.1.110 even though they're the
+    // same Anthropic account — both calls would land on the same quota.
     const a = cand({ version: '2.1.110', email: 'user-a@example.com', lastActive: new Date('2026-04-20T10:00:00Z') });
     const b = cand({ version: '2.1.118', email: 'user-a@example.com', lastActive: new Date('2026-04-20T05:00:00Z') });
     const c = cand({ version: '2.1.111', email: 'other@x.com', lastActive: new Date('2026-04-20T08:00:00Z') });
 
-    const result = pickRotateCandidate([a, b, c]);
+    const result = pickBalancedCandidate([a, b, c]);
     expect(result!.healthy).toHaveLength(2);
     const emails = result!.healthy.map((x) => x.email).sort();
     expect(emails).toEqual(['other@x.com', 'user-a@example.com']);
@@ -268,10 +287,9 @@ describe('pickRotateCandidate', () => {
     expect(survivor!.version).toBe('2.1.118');
   });
 
-  it('parallel rotation fans out across unique accounts even when versions share emails', () => {
-    // 6 versions, 5 unique accounts (user-a@example.com on 2.1.118 + 2.1.110).
-    // After dedup, 5 candidates fan out. The duplicated email should still
-    // appear ~1/5 of the time (not 2/6) because it dedupes to one slot.
+  it('parallel selection fans out across unique accounts even when versions share emails', () => {
+    // 6 versions, 5 unique accounts. After dedup, 5 candidates with equal
+    // capacity (no usage data) get ~20% each.
     const candidates = [
       { version: '2.1.118', email: 'user-a@example.com' },
       { version: '2.1.110', email: 'user-a@example.com' },
@@ -281,16 +299,16 @@ describe('pickRotateCandidate', () => {
       { version: '2.1.109', email: 'user-e@example.org' },
     ];
     const emailCounts: Record<string, number> = {};
-    const iterations = 2000;
+    const iterations = 2500;
     for (let i = 0; i < iterations; i++) {
-      const result = pickRotateCandidate(
-        candidates.map((c) => cand({ version: c.version, email: c.email, lastActive: null })),
+      const result = pickBalancedCandidate(
+        candidates.map((c) => cand({ version: c.version, email: c.email, usageSnapshot: usage(0) })),
       );
       const email = result!.picked.email!;
       emailCounts[email] = (emailCounts[email] ?? 0) + 1;
     }
 
-    // 5 unique accounts -> expected ~20% each. Allow each to land within [10%, 35%].
+    // 5 unique accounts → expected ~20% each. Allow each to land within [10%, 35%].
     expect(Object.keys(emailCounts)).toHaveLength(5);
     for (const email of Object.keys(emailCounts)) {
       const ratio = emailCounts[email] / iterations;
@@ -351,7 +369,11 @@ describe('normalizeRunStrategy', () => {
   it('accepts supported strategies', () => {
     expect(normalizeRunStrategy('pinned')).toBe('pinned');
     expect(normalizeRunStrategy('available')).toBe('available');
-    expect(normalizeRunStrategy('rotate')).toBe('rotate');
+    expect(normalizeRunStrategy('balanced')).toBe('balanced');
+  });
+
+  it('aliases the deprecated `rotate` to `balanced` for backward compat', () => {
+    expect(normalizeRunStrategy('rotate')).toBe('balanced');
   });
 
   it('rejects unknown strategies', () => {

--- a/src/lib/rotate.ts
+++ b/src/lib/rotate.ts
@@ -39,13 +39,19 @@ export interface RotateResult {
   excluded: RotateCandidate[];
 }
 
-export const RUN_STRATEGIES: RunStrategy[] = ['pinned', 'available', 'rotate'];
+export const RUN_STRATEGIES: RunStrategy[] = ['pinned', 'available', 'balanced'];
 
-/** Return a run strategy when the input is valid, otherwise null. */
+/**
+ * Return a run strategy when the input is valid, otherwise null.
+ *
+ * `'rotate'` is accepted as a deprecated alias for `'balanced'` so old yaml
+ * configs and `--strategy rotate` invocations keep working. The legacy alias
+ * normalizes to `'balanced'` and uses the weighted-random algorithm.
+ */
 export function normalizeRunStrategy(value: unknown): RunStrategy | null {
-  return typeof value === 'string' && RUN_STRATEGIES.includes(value as RunStrategy)
-    ? value as RunStrategy
-    : null;
+  if (typeof value !== 'string') return null;
+  if (value === 'rotate') return 'balanced';
+  return RUN_STRATEGIES.includes(value as RunStrategy) ? value as RunStrategy : null;
 }
 
 /** Read project-local run strategy from the nearest agents.yaml, if present. */
@@ -149,23 +155,29 @@ function dedupeAndSortCandidates(candidates: RotateCandidate[]): RotateCandidate
 }
 
 /**
- * Pure selection: given a set of candidates, return the best one for the
- * next run. Kept separate from I/O so it can be unit-tested with fixtures.
+ * Pick a healthy candidate using weighted random by remaining capacity.
  *
- * Eligibility: signed in (email present) and not out of credits.
- * Dedupe: when multiple versions share an email (same Anthropic account
- * installed under several agent versions), collapse to one candidate per
- * email — the least-recently-active version. Without this, two parallel
- * pods could "rotate" to different versions but hit the same account and
- * both 429 against the same Anthropic quota.
- * Primary order: lowest live usage utilization wins. Least-recently-active is
- * the tie-breaker when usage is equal or unavailable. Never-used versions sort
- * oldest so fresh installs are tried before recently-used ones.
- * Tie-break: random — when two candidates share a `lastActive` timestamp
- * (common when N pods read the same snapshot), distribute across them so
- * parallel callers fan out instead of all picking the same version.
+ * Each healthy candidate gets weight = max(1, 100 - usedPercent) where
+ * usedPercent is the highest-utilized non-session window (week / sonnet_week
+ * for Claude). An account at 10% used gets weight 90; one at 90% used gets
+ * weight 10 — so the fresher account is 9× more likely to be picked. Over N
+ * calls, traffic distributes across healthy accounts proportional to their
+ * headroom, with no stampede on the lowest-usage one. Stateless — parallel
+ * callers naturally fan out via the random roll.
+ *
+ * Eligibility: signed in (email present), auth valid, and usage available
+ * (any non-session window strictly under 100%, or local flag not exhausted
+ * when no live snapshot exists).
+ *
+ * Dedupe: when multiple versions share an email, collapse to one candidate
+ * per email (the least-recently-active version). Prevents two parallel pods
+ * from "balancing" to different versions but hitting the same Anthropic
+ * account and both 429ing.
+ *
+ * Returns null if no candidate is eligible — callers fall back to the pinned
+ * version so behavior stays predictable.
  */
-export function pickRotateCandidate(candidates: RotateCandidate[]): RotateResult | null {
+export function pickBalancedCandidate(candidates: RotateCandidate[]): RotateResult | null {
   const healthy: RotateCandidate[] = [];
   const excluded: RotateCandidate[] = [];
   for (const c of candidates) {
@@ -184,7 +196,31 @@ export function pickRotateCandidate(candidates: RotateCandidate[]): RotateResult
     if (!deduped.has(c)) excluded.push(c);
   }
 
-  return { picked: sorted[0], healthy: sorted, excluded };
+  const picked = weightedRandomByCapacity(sorted);
+  return { picked, healthy: sorted, excluded };
+}
+
+/**
+ * Pick one candidate from `sorted` using weights proportional to remaining
+ * routing capacity. Floor each weight at 1 so a near-exhausted-but-still-
+ * eligible candidate can still be picked occasionally. When usage is unknown
+ * (no live snapshot), treat the candidate as full-capacity (weight 100) — we
+ * have no signal to deprioritize it.
+ */
+function weightedRandomByCapacity(sorted: RotateCandidate[]): RotateCandidate {
+  const weights = sorted.map((c) => {
+    const used = getRoutingUsedPercent(c.usageSnapshot);
+    if (used === null) return 100;
+    return Math.max(1, 100 - used);
+  });
+  const total = weights.reduce((sum, w) => sum + w, 0);
+  if (total <= 0) return sorted[0];
+  let roll = Math.random() * total;
+  for (let i = 0; i < sorted.length; i++) {
+    roll -= weights[i];
+    if (roll <= 0) return sorted[i];
+  }
+  return sorted[sorted.length - 1];
 }
 
 /**
@@ -261,20 +297,18 @@ async function collectRunCandidates(agent: AgentId): Promise<RotateCandidate[]> 
 }
 
 /**
- * Rotate across installed versions of an agent and pick the best one for the
- * next run. "Best" means: signed in, usage available, and lowest usage
- * utilization, with least-recently-active as a tie-breaker.
+ * Pick a healthy version for `agent` using weighted random by remaining
+ * capacity. See `pickBalancedCandidate` for algorithm details.
  *
- * No external state: rotation and health are both read off per-version
- * AccountInfo — the same data `agents view` already surfaces. `lastActive`
- * advances naturally after each run, so the cursor is self-maintaining.
+ * No external state — health and capacity are both read off per-version
+ * AccountInfo (same data `agents view` surfaces). The weighted random roll
+ * keeps parallel callers fanned out without rotation files or locks.
  *
- * Returns null if no installed version is eligible (either nothing installed
- * or every account is exhausted / not signed in). Callers fall back to the
+ * Returns null if no installed version is eligible. Callers fall back to the
  * global default so behavior stays predictable — we never refuse to run.
  */
-export async function selectRotateVersion(agent: AgentId): Promise<RotateResult | null> {
-  return pickRotateCandidate(await collectRunCandidates(agent));
+export async function selectBalancedVersion(agent: AgentId): Promise<RotateResult | null> {
+  return pickBalancedCandidate(await collectRunCandidates(agent));
 }
 
 /** Select the configured version if available, otherwise another available version. */
@@ -327,17 +361,21 @@ export async function resolveRunVersion(agent: AgentId, strategy: RunStrategy, c
 
   const rotation = strategy === 'available'
     ? await selectAvailableVersion(agent, fallback)
-    : await selectRotateVersion(agent);
+    : await selectBalancedVersion(agent);
 
   if (rotation) {
-    // If another process just picked the same version (within 60s), try the
-    // next healthy candidate to distribute load across accounts.
-    const recentPick = readRotationStamp(agent);
-    if (recentPick === rotation.picked.version && rotation.healthy.length > 1) {
-      const alt = rotation.healthy.find(c => c.version !== recentPick);
-      if (alt) rotation.picked = alt;
+    // `available` is sticky to the pinned default when healthy. Use the 60s
+    // anti-collision stamp to nudge parallel callers off the same version.
+    // `balanced` doesn't need this — its weighted random roll already
+    // distributes naturally across healthy accounts.
+    if (strategy === 'available') {
+      const recentPick = readRotationStamp(agent);
+      if (recentPick === rotation.picked.version && rotation.healthy.length > 1) {
+        const alt = rotation.healthy.find(c => c.version !== recentPick);
+        if (alt) rotation.picked = alt;
+      }
+      recordRotationPick(agent, rotation.picked.version);
     }
-    recordRotationPick(agent, rotation.picked.version);
     return { version: rotation.picked.version, rotation };
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,7 +10,7 @@
 export type AgentId = 'claude' | 'codex' | 'gemini' | 'cursor' | 'opencode' | 'openclaw' | 'copilot' | 'amp' | 'kiro' | 'goose' | 'roo';
 
 /** How `agents run <agent>` chooses an installed version when none is pinned. */
-export type RunStrategy = 'pinned' | 'available' | 'rotate';
+export type RunStrategy = 'pinned' | 'available' | 'balanced';
 
 /** Preview features that users can opt into via `agents beta`. */
 export type BetaFeatureName = 'drive' | 'factory';


### PR DESCRIPTION
## Summary

- Replaces the `rotate` strategy with `balanced` — weighted random by remaining capacity
- Old algorithm was join-shortest-queue: every parallel call piles onto whichever account has the most headroom, then they all shift together when it ties
- New algorithm: each healthy candidate gets weight `max(1, 100 - usedPercent)`, each call rolls a weighted die. Traffic distributes proportional to headroom, no stampede on the leader, no starvation
- Stateless — no rotation stamp file needed for `balanced` (the random roll handles parallel callers). Stamp is kept for `available` since that strategy is still default-first

## Backward compatibility

- `normalizeRunStrategy('rotate')` returns `'balanced'`. Existing `~/.agents-system/agents.yaml` configs and `--strategy rotate` invocations keep working.
- `--rotate` flag renamed to `--balanced`. Long-form `--strategy rotate` still works via the alias.

## Why

The user noticed the old `rotate` strategy was biased — picking the lowest-usage account every call meant load chasing, not load balancing. `available` was even worse for this concern, sticking to the pinned default until it exhausted. `balanced` solves both: real distribution across healthy accounts, weighted by capacity so fresher accounts naturally get more traffic without starving the busier ones.

## Test plan

- [x] Unit: 23 tests in `src/lib/__tests__/rotate.test.ts` covering distribution shape, eligibility, dedup, edge cases
  - Distribution check: 10%-used vs 90%-used → fresh wins ~90% of 2000 trials
  - Equal-capacity uniformity across 4 accounts (~25% each, tolerance [15%, 35%])
  - Near-exhausted account at 99% used: still picked occasionally over 5000 trials, never starved
  - Highest non-session window drives weighting (session=100, week=15 stays weighty)
  - All eligibility/dedup/exclusion behaviors preserved from old `pickRotateCandidate`
  - Legacy `'rotate'` → `'balanced'` alias verified
- [x] Full vitest suite: 956 pass / 4 pre-existing failures (MCP tests, unrelated)
- [x] Type-check clean (`bunx tsc --noEmit`)
- [x] Build clean (`bun run build`)
- [x] End-to-end: 5 sequential `agents run claude --strategy balanced` calls on a 4-account install picked 3 distinct accounts (`trp.so`, `gmail.com`, `getrush.ai`). Old `rotate` would have picked the lowest-usage one every time.
- [x] Legacy `--strategy rotate` still resolves and runs via the alias

## Files

- `src/lib/types.ts` — `RunStrategy` union: `'rotate'` -> `'balanced'`
- `src/lib/rotate.ts` — new `pickBalancedCandidate` + `weightedRandomByCapacity`; `selectBalancedVersion`; `resolveRunVersion` skips stamp for `balanced`; `normalizeRunStrategy` aliases `'rotate'` -> `'balanced'`
- `src/commands/exec.ts` — `--rotate` flag -> `--balanced`; banner formatter takes a verb; help text updated
- `src/lib/__tests__/rotate.test.ts` — rewritten for the new algorithm

🤖 Generated with [Claude Code](https://claude.com/claude-code)