### PR TITLE
feat(rotate): default strategy = `available` instead of `pinned`

### DIFF
--- a/src/lib/rotate.ts
+++ b/src/lib/rotate.ts
@@ -76,11 +76,18 @@ export function getProjectRunStrategy(agent: AgentId, startPath: string): RunStr
   return null;
 }
 
-/** Resolve the configured strategy: project agents.yaml, then ~/.agents-system/agents.yaml, then pinned. */
+/**
+ * Resolve the configured strategy. Lookup order:
+ *   1. project-local agents.yaml (nearest to `startPath`)
+ *   2. ~/.agents-system/agents.yaml
+ *   3. default: `available` (use the pinned default version when healthy,
+ *      otherwise fall through to a healthy account so a single rate-limited
+ *      account doesn't block the run).
+ */
 export function getConfiguredRunStrategy(agent: AgentId, startPath: string = process.cwd()): RunStrategy {
   return getProjectRunStrategy(agent, startPath)
     ?? normalizeRunStrategy(readMeta().run?.[agent]?.strategy)
-    ?? 'pinned';
+    ?? 'available';
 }
 
 /** Persist the global run strategy used by bare `agents run <agent>`. */


### PR DESCRIPTION
## Summary

Single-line change in `getConfiguredRunStrategy` — fall back to `'available'` instead of `'pinned'` when neither project nor user agents.yaml configures a strategy.

## Why

`pinned` is too strict as a default. If a user has 4 signed-in accounts and the pinned default version hits a rate limit, `agents run claude` fails the run instead of seamlessly switching to a healthy account. That's not what most users want from a one-shot CLI invocation.

`available` is a better baseline: it prefers the pinned default version when it has usage headroom (so behavior matches `pinned` in the common case), and only falls through to another healthy account when the default is unavailable. Users who explicitly want `pinned` can still set it:

```yaml
run:
  claude:
    strategy: pinned
```

## Diff

```diff
-/** Resolve the configured strategy: project agents.yaml, then ~/.agents-system/agents.yaml, then pinned. */
+/**
+ * Resolve the configured strategy. Lookup order:
+ *   1. project-local agents.yaml (nearest to startPath)
+ *   2. ~/.agents-system/agents.yaml
+ *   3. default: available (use pinned default when healthy, otherwise fall
+ *      through to a healthy account)
+ */
 export function getConfiguredRunStrategy(agent: AgentId, startPath: string = process.cwd()): RunStrategy {
   return getProjectRunStrategy(agent, startPath)
     ?? normalizeRunStrategy(readMeta().run?.[agent]?.strategy)
-    ?? 'pinned';
+    ?? 'available';
 }
```

No other logic changed. The `available` strategy itself (`pickAvailableCandidate` in the same file) is unchanged.

## Test plan

- [x] All 23 rotate tests pass.
- [x] Full suite: 1021 pass / 1 pre-existing flake (`teams registry concurrency`, fails on main HEAD too — verified by stashing this PR's diff and running the test in isolation).
- [x] `bunx tsc` clean.
- [x] No tests asserted the old `'pinned'` default — only `normalizeRunStrategy('pinned')` which tests the input parser, not the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)