### PR TITLE
feat(browser): support custom binary path for Electron apps

### DIFF
--- a/src/lib/browser/chrome.ts
+++ b/src/lib/browser/chrome.ts
@@ -19,6 +19,7 @@ const BROWSER_PATHS: Record<string, Record<BrowserType, string[]>> = {
     chromium: ['/Applications/Chromium.app/Contents/MacOS/Chromium'],
     brave: ['/Applications/Brave Browser.app/Contents/MacOS/Brave Browser'],
     edge: ['/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge'],
+    custom: [],
   },
   linux: {
     chrome: ['/usr/bin/google-chrome', '/usr/bin/google-chrome-stable'],
@@ -26,6 +27,7 @@ const BROWSER_PATHS: Record<string, Record<BrowserType, string[]>> = {
     chromium: ['/usr/bin/chromium', '/usr/bin/chromium-browser', '/snap/bin/chromium'],
     brave: ['/usr/bin/brave-browser', '/usr/bin/brave'],
     edge: ['/usr/bin/microsoft-edge'],
+    custom: [],
   },
   win32: {
     chrome: [
@@ -40,11 +42,23 @@ const BROWSER_PATHS: Record<string, Record<BrowserType, string[]>> = {
     edge: [
       'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
     ],
+    custom: [],
   },
 };
 
 
-export function findBrowserPath(browserType: BrowserType): string {
+export function findBrowserPath(browserType: BrowserType, customBinary?: string): string {
+  if (customBinary) {
+    if (!fs.existsSync(customBinary)) {
+      throw new Error(`Custom binary not found: ${customBinary}`);
+    }
+    return customBinary;
+  }
+
+  if (browserType === 'custom') {
+    throw new Error('browser: custom requires a binary path in the profile');
+  }
+
   const platform = os.platform();
   const platformPaths = BROWSER_PATHS[platform];
   if (!platformPaths) {
@@ -72,9 +86,10 @@ export async function launchBrowser(
   browserType: BrowserType,
   port: number,
   options: ChromeOptions = {},
-  secrets?: string
+  secrets?: string,
+  customBinary?: string
 ): Promise<LaunchResult> {
-  const browserPath = findBrowserPath(browserType);
+  const browserPath = findBrowserPath(browserType, customBinary);
 
   const runtimeDir = getProfileRuntimeDir(profileName);
   const userDataDir = path.join(runtimeDir, 'chrome-data');

--- a/src/lib/browser/drivers/local.ts
+++ b/src/lib/browser/drivers/local.ts
@@ -33,7 +33,8 @@ export async function connectLocal(
       profile.browser,
       newPort,
       profile.chrome,
-      profile.secrets
+      profile.secrets,
+      profile.binary
     );
     const cdp = new CDPClient();
     await cdp.connect(wsUrl);

--- a/src/lib/browser/drivers/ssh.ts
+++ b/src/lib/browser/drivers/ssh.ts
@@ -27,7 +27,7 @@ export async function connectSSH(
   const localPort = allocatePort();
 
   try {
-    await ensureRemoteBrowser(user, host, profile.browser, remotePort);
+    await ensureRemoteBrowser(user, host, profile.browser, remotePort, profile.binary);
   } catch {
     // Browser may already be running, continue
   }
@@ -130,7 +130,8 @@ async function ensureRemoteBrowser(
   user: string,
   host: string,
   browserType: string,
-  port: number
+  port: number,
+  customBinary?: string
 ): Promise<void> {
   const browserPaths: Record<string, string> = {
     chrome: '/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome',
@@ -140,9 +141,16 @@ async function ensureRemoteBrowser(
     edge: '/Applications/Microsoft\\ Edge.app/Contents/MacOS/Microsoft\\ Edge',
   };
 
-  const browserPath = browserPaths[browserType];
-  if (!browserPath) {
-    throw new Error(`Unknown browser type: ${browserType}`);
+  let browserPath: string;
+  if (customBinary) {
+    browserPath = customBinary.replace(/ /g, '\\ ');
+  } else if (browserType === 'custom') {
+    throw new Error('browser: custom requires a binary path in the profile');
+  } else {
+    browserPath = browserPaths[browserType];
+    if (!browserPath) {
+      throw new Error(`Unknown browser type: ${browserType}`);
+    }
   }
 
   const remoteCmd = `${browserPath} --remote-debugging-port=${port} '--remote-allow-origins=*' --disable-background-timer-throttling --user-data-dir=/tmp/agents-browser-${port} </dev/null >/dev/null 2>&1 &`;

--- a/src/lib/browser/types.ts
+++ b/src/lib/browser/types.ts
@@ -1,9 +1,10 @@
-export type BrowserType = 'chrome' | 'comet' | 'chromium' | 'brave' | 'edge';
+export type BrowserType = 'chrome' | 'comet' | 'chromium' | 'brave' | 'edge' | 'custom';
 
 export interface BrowserProfile {
   name: string;
   description?: string;
   browser: BrowserType;
+  binary?: string;
   endpoints: string[];
   chrome?: ChromeOptions;
   secrets?: string;


### PR DESCRIPTION
## Summary

- Add `binary` field to `BrowserProfile` for custom executable paths
- Add `custom` browser type for non-standard browsers (Electron apps)
- Update SSH and local drivers to use custom binary when provided

## Usage

```yaml
name: rush-app
browser: custom
binary: /Applications/Rush.app/Contents/MacOS/Rush
endpoints:
  - ssh://mac-mini?port=9222
```

Or with existing browser types, override the path:

```yaml
name: my-chrome
browser: chrome
binary: /path/to/custom/chrome
endpoints:
  - cdp://localhost:9222
```

## Test plan

- [ ] Create profile with `browser: custom` and `binary` set
- [ ] Verify SSH driver launches the custom binary
- [ ] Verify local driver launches the custom binary
- [ ] Verify error when `browser: custom` without `binary`

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)