### PR TITLE
refactor(permissions): rename sets -> presets to match rules/presets

### DIFF
--- a/src/lib/__tests__/sync-manifest.test.ts
+++ b/src/lib/__tests__/sync-manifest.test.ts
@@ -42,7 +42,7 @@ vi.mock('../rules/compile.js', () => ({
 }));
 
 vi.mock('../permissions.js', () => ({
-  getActivePermissionSetName: () => null,
+  getActivePermissionPresetName: () => null,
 }));
 
 import { loadSyncManifest, saveSyncManifest, buildManifest, isSyncStale } from '../sync-manifest.js';

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -192,26 +192,26 @@ export function getTotalPermissionRuleCount(): number {
 }
 
 /**
- * A permission set recipe — names a set and lists which groups it composes.
- * Lives at ~/.agents/permissions/sets/<name>.yaml.
+ * A permission preset recipe — names a preset and lists which groups it composes.
+ * Lives at ~/.agents/permissions/presets/<name>.yaml.
  */
-export interface PermissionSetRecipe {
+export interface PermissionPresetRecipe {
   name: string;
   description?: string;
   includes: string[];
 }
 
 /** Env var that selects which set recipe to apply at sync time. */
-export const PERMISSION_SET_ENV_VAR = 'AGENTS_PERMISSION_SET';
+export const PERMISSION_PRESET_ENV_VAR = 'AGENTS_PERMISSION_PRESET';
 
 /**
- * Read a permission set recipe by name from ~/.agents/permissions/sets/.
+ * Read a permission preset recipe by name from ~/.agents/permissions/presets/.
  * Returns null if the recipe file is missing or malformed.
  */
-export function readPermissionSetRecipe(name: string): PermissionSetRecipe | null {
-  const setsDir = path.join(getPermissionsDir(), 'sets');
+export function readPermissionPresetRecipe(name: string): PermissionPresetRecipe | null {
+  const presetsDir = path.join(getPermissionsDir(), 'presets');
   for (const ext of ['.yaml', '.yml']) {
-    const filePath = safeJoin(setsDir, name + ext);
+    const filePath = safeJoin(presetsDir, name + ext);
     if (!fs.existsSync(filePath)) continue;
     try {
       const content = fs.readFileSync(filePath, 'utf-8');
@@ -231,11 +231,11 @@ export function readPermissionSetRecipe(name: string): PermissionSetRecipe | nul
 }
 
 /**
- * Return the active permission set name from AGENTS_PERMISSION_SET env var,
+ * Return the active permission preset name from AGENTS_PERMISSION_PRESET env var,
  * or null if unset. Caller decides the default behavior when null.
  */
-export function getActivePermissionSetName(): string | null {
-  const v = process.env[PERMISSION_SET_ENV_VAR];
+export function getActivePermissionPresetName(): string | null {
+  const v = process.env[PERMISSION_PRESET_ENV_VAR];
   return v && v.trim() ? v.trim() : null;
 }
 

--- a/src/lib/sync-manifest.ts
+++ b/src/lib/sync-manifest.ts
@@ -43,7 +43,7 @@ import {
 import { resolveResource } from './resources.js';
 import { listMcpServerConfigs } from './mcp.js';
 import { isRulesStale } from './rules/compile.js';
-import { getActivePermissionSetName } from './permissions.js';
+import { getActivePermissionPresetName } from './permissions.js';
 import { listInstalledSubagents } from './subagents.js';
 import { safeJoin } from './paths.js';
 
@@ -76,7 +76,7 @@ interface RulesEntry {
 /** Permissions: all group files across all scopes (merged). */
 interface PermEntry {
   groups:        Record<string, FileEntry>; // key = group name, first-wins per name
-  permissionSet: string | null;             // AGENTS_PERMISSION_SET env var at sync time
+  permissionPreset: string | null;          // AGENTS_PERMISSION_PRESET env var at sync time
 }
 
 export interface SyncManifest {
@@ -368,7 +368,7 @@ export function buildManifest(
     mcp,
     permissions: {
       groups:        permGroups,
-      permissionSet: getActivePermissionSetName(),
+      permissionPreset: getActivePermissionPresetName(),
     },
     subagents,
   };
@@ -444,7 +444,7 @@ export function isSyncStale(
   }
 
   // ── Permissions ───────────────────────────────────────────────────────────
-  if (manifest.permissions.permissionSet !== getActivePermissionSetName()) return true;
+  if (manifest.permissions.permissionPreset !== getActivePermissionPresetName()) return true;
   const currentGroups = collectPermissionGroupFiles();
   if (nameSetDiffers(Object.keys(manifest.permissions.groups), Object.keys(currentGroups))) return true;
   for (const [name, filePath] of Object.entries(currentGroups)) {

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -27,7 +27,7 @@ import type { AgentId, VersionResources } from './types.js';
 import { getVersionsDir, getShimsDir, ensureAgentsDir, readMeta, writeMeta, getCommandsDir, getSkillsDir, getHooksDir, getResolvedRulesDir, getUserRulesDir, getPermissionsDir, getSubagentsDir, clearVersionResources, getVersionResources, recordVersionResources, getMcpDir, getProjectAgentsDir, getPromptcutsPath, getUserPromptcutsPath, getEnabledExtraRepos, getAgentsDir, getOptionalUserAgentsDir, getUserAgentsDir, getTrashVersionsDir, getActiveRulesPreset } from './state.js';
 import { resolveResource } from './resources.js';
 import { AGENTS, getAccountEmail, MCP_CAPABLE_AGENTS, COMMANDS_CAPABLE_AGENTS, getMcpConfigPathForHome, parseMcpConfig, resolveAgentName, formatAgentError } from './agents.js';
-import { getDefaultPermissionSet, applyPermissionsToVersion as applyPermsToVersion, PERMISSIONS_CAPABLE_AGENTS, discoverPermissionGroups, getTotalPermissionRuleCount, buildPermissionsFromGroups, CODEX_RULES_FILENAME, getActivePermissionSetName, readPermissionSetRecipe, PERMISSION_SET_ENV_VAR } from './permissions.js';
+import { getDefaultPermissionSet, applyPermissionsToVersion as applyPermsToVersion, PERMISSIONS_CAPABLE_AGENTS, discoverPermissionGroups, getTotalPermissionRuleCount, buildPermissionsFromGroups, CODEX_RULES_FILENAME, getActivePermissionPresetName, readPermissionPresetRecipe, PERMISSION_PRESET_ENV_VAR } from './permissions.js';
 import { installMcpServers, parseMcpServerConfig } from './mcp.js';
 import { markdownToToml } from './convert.js';
 import { createVersionedAlias, removeVersionedAlias, switchConfigSymlink, getConfigSymlinkVersion, ensureClaudeInsideSymlink } from './shims.js';
@@ -1804,37 +1804,37 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
 
   // Apply permissions (if agent supports them).
   // Groups live in ~/.agents/permissions/groups/. Optional recipes in
-  // ~/.agents/permissions/sets/<name>.yaml pick a subset via `includes:`.
-  // If AGENTS_PERMISSION_SET is set, we resolve that recipe and use its
+  // ~/.agents/permissions/presets/<name>.yaml pick a subset via `includes:`.
+  // If AGENTS_PERMISSION_PRESET is set, we resolve that recipe and use its
   // includes list as the group filter (intersected with groups on disk).
   const permissionGroups = discoverPermissionGroups();
   const allGroupNames = permissionGroups.map(g => g.name);
-  const activeSetName = getActivePermissionSetName();
-  let setFilteredGroups: string[] | null = null;
-  if (activeSetName) {
-    const recipe = readPermissionSetRecipe(activeSetName);
+  const activePresetName = getActivePermissionPresetName();
+  let presetFilteredGroups: string[] | null = null;
+  if (activePresetName) {
+    const recipe = readPermissionPresetRecipe(activePresetName);
     if (recipe) {
       const available = new Set(allGroupNames);
-      setFilteredGroups = recipe.includes.filter(g => available.has(g));
+      presetFilteredGroups = recipe.includes.filter(g => available.has(g));
     } else {
-      console.warn(`${PERMISSION_SET_ENV_VAR}=${activeSetName} but no recipe at ~/.agents/permissions/sets/${activeSetName}.yaml — falling back to all groups`);
+      console.warn(`${PERMISSION_PRESET_ENV_VAR}=${activePresetName} but no recipe at ~/.agents/permissions/presets/${activePresetName}.yaml — falling back to all groups`);
     }
   }
   let permsToSync: string[];
   if (selection) {
     permsToSync = resolveSelection(selection.permissions, allGroupNames);
-    // If a set recipe is active, the recipe's includes list always wins —
+    // If a preset recipe is active, the recipe's includes list always wins —
     // even when the caller passed an explicit array via selection. Without
     // this intersection, `agents add`'s buildAutomaticSelection would pass
     // every group name discovered on disk (including 99-deny), bypassing
     // the sandbox filter.
-    if (setFilteredGroups) {
-      const filterSet = new Set(setFilteredGroups);
+    if (presetFilteredGroups) {
+      const filterSet = new Set(presetFilteredGroups);
       permsToSync = permsToSync.filter(g => filterSet.has(g));
     }
   } else {
     permsToSync = PERMISSIONS_CAPABLE_AGENTS.includes(agent)
-      ? (setFilteredGroups ?? allGroupNames)
+      ? (presetFilteredGroups ?? allGroupNames)
       : [];
   }
 


### PR DESCRIPTION
## Summary

Rename `permissions/sets/` → `permissions/presets/` for consistency with `rules/presets/` (which already uses that convention for named bundles like `cautious.md`, `proactive.md`, `minimal.md`).

## API rename

| Before | After |
|---|---|
| `PermissionSetRecipe` | `PermissionPresetRecipe` |
| `readPermissionSetRecipe()` | `readPermissionPresetRecipe()` |
| `getActivePermissionSetName()` | `getActivePermissionPresetName()` |
| `PERMISSION_SET_ENV_VAR` | `PERMISSION_PRESET_ENV_VAR` |
| `AGENTS_PERMISSION_SET` env var | `AGENTS_PERMISSION_PRESET` |
| `SyncManifest.permissions.permissionSet` | `permissionPreset` |
| `~/.agents/permissions/sets/<name>.yaml` | `~/.agents/permissions/presets/<name>.yaml` |

The `PermissionSet` data type (the `{ allow: [], deny: [] }` container) is intentionally unchanged.

## Companion change

The matching directory rename in the system repo lives in phnx-labs/.agents-system#1. Land both together so users on `AGENTS_PERMISSION_PRESET=sandbox` find their recipe at the new path.
