### PR TITLE
refactor: read system hooks from agents.yaml

### DIFF
--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -676,12 +676,12 @@ export function listCentralHooks(): HookEntry[] {
 export function parseHookManifest(): Record<string, ManifestHook> {
   const merged: Record<string, ManifestHook> = {};
 
-  // System layer: standalone hooks.yaml (npm-shipped, separate repo).
-  const systemPath = path.join(getAgentsDir(), 'hooks.yaml');
+  // System layer: hooks: section of agents.yaml (npm-shipped, separate repo).
+  const systemPath = path.join(getSystemAgentsDir(), 'agents.yaml');
   if (fs.existsSync(systemPath)) {
     try {
-      const parsed = yaml.parse(fs.readFileSync(systemPath, 'utf-8')) as Record<string, ManifestHook> | null;
-      if (parsed) for (const [name, def] of Object.entries(parsed)) merged[name] = def;
+      const meta = yaml.parse(fs.readFileSync(systemPath, 'utf-8')) as { hooks?: Record<string, ManifestHook> } | null;
+      if (meta?.hooks) for (const [name, def] of Object.entries(meta.hooks)) merged[name] = def;
     } catch { /* skip unreadable manifest */ }
   }
 


### PR DESCRIPTION
## Summary
- Unifies hook config format between system and user layers
- Both now use `agents.yaml` with a `hooks:` section instead of standalone `hooks.yaml`

## Changes
- Update `parseHookManifest()` to read from `agents.yaml` at system level
- Uses `getSystemAgentsDir()` and reads `meta.hooks` like user layer

## Related
Requires corresponding change in `.agents-system` repo to create `agents.yaml` and delete `hooks.yaml`.

## Test plan
- [ ] Verify hooks still fire after change
- [ ] Check system + user hook merging works
