### PR TITLE
feat: add `agents import` command to adopt unmanaged installs

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -33,6 +33,7 @@ import { ALL_AGENT_IDS } from '../lib/agents.js';
 import { AGENTS, getCliPath, getCliVersion, agentLabel } from '../lib/agents.js';
 import { getVersionDir } from '../lib/versions.js';
 import {
+  finalizeImport,
   importAgentBinary,
   importAgentConfig,
   resolvePackageDirFromBinary,
@@ -58,6 +59,15 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
   const agentId = agentArg;
   const agent = AGENTS[agentId];
 
+  // Reject agents that don't ship via npm before we spin up PATH lookups and
+  // prompts. cursor/kiro/goose/roo all have npmPackage='' and use custom
+  // install scripts — the symlink-farm import doesn't apply to them.
+  if (!agent.npmPackage) {
+    console.error(chalk.red(`${agentLabel(agentId)} doesn't install via npm — \`agents import\` only handles npm-style packages.`));
+    console.error(chalk.gray(`Use \`agents add ${agentId}\` to install via its native script.`));
+    process.exit(1);
+  }
+
   let globalPath: string | null = null;
 
   if (opts.fromPath) {
@@ -69,8 +79,12 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
   } else {
     const binary = await getCliPath(agentId);
     if (!binary) {
+      // Use || (not ??) so empty-string npmPackage falls back to cliCommand.
+      // Defensive: agents with empty npmPackage are rejected above, but keep
+      // the operator correct in case that early check is ever relaxed.
+      const installName = agent.npmPackage || agent.cliCommand;
       console.error(chalk.red(`No "${agent.cliCommand}" found on PATH.`));
-      console.error(chalk.gray(`Install it first (e.g. \`npm i -g ${agent.npmPackage ?? agent.cliCommand}\`) or pass --from-path.`));
+      console.error(chalk.gray(`Install it first (e.g. \`npm i -g ${installName}\`) or pass --from-path.`));
       process.exit(1);
     }
     globalPath = resolvePackageDirFromBinary(binary);
@@ -89,7 +103,11 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
     } catch {
       /* fall through */
     }
-    if (!version) {
+    // Only fall back to running the PATH binary's --version when we're
+    // auto-detecting. With --from-path, the PATH binary may belong to a
+    // different install entirely; reporting its version here would silently
+    // mis-attribute the imported version.
+    if (!version && !opts.fromPath) {
       const detected = await getCliVersion(agentId);
       version = detected ?? undefined;
     }
@@ -101,14 +119,18 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
     process.exit(1);
   }
 
+  const versionDir = getVersionDir(agentId, version);
+
   console.log(chalk.bold(`\nImport ${agentLabel(agentId)} v${version}`));
   console.log(`  from: ${chalk.gray(globalPath)}`);
-  console.log(`  into: ${chalk.gray(`~/.agents/.history/versions/${agentId}/${version}/`)}`);
+  console.log(`  into: ${chalk.gray(versionDir)}`);
 
   const configDirExists = fs.existsSync(agent.configDir);
+  let configAlreadyManaged = false;
   if (configDirExists) {
     const stat = fs.lstatSync(agent.configDir);
     if (stat.isSymbolicLink()) {
+      configAlreadyManaged = true;
       console.log(`  config: ${chalk.gray(`${agent.configDir} (already managed — will skip)`)}`);
     } else {
       console.log(`  config: ${chalk.gray(`${agent.configDir} (will be moved into version home)`)}`);
@@ -119,7 +141,10 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
 
   if (!opts.yes && isInteractiveTerminal()) {
     console.log();
-    const proceed = await confirm({ message: 'Proceed?', default: true }).catch((err) => {
+    const proceed = await confirm({
+      message: `Import ${agentLabel(agentId)} v${version} into agents-cli?`,
+      default: true,
+    }).catch((err) => {
       if (isPromptCancelled(err)) return false;
       throw err;
     });
@@ -129,20 +154,33 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
     }
   }
 
-  if (!agent.npmPackage) {
-    console.error(chalk.red(`${agentLabel(agentId)} has no npm package metadata — cannot import.`));
-    process.exit(1);
+  // Order: config first, then binary, then finalize. Config does the
+  // user-visible side effect (renaming ~/.<agent>/), so if it fails we don't
+  // want a stranded symlink farm. Binary registration is cheap and reversible
+  // — if it fails after config, the next `agents import` call retries cleanly.
+  const willImportConfig = configDirExists && !configAlreadyManaged;
+  if (willImportConfig) {
+    const cfgSpinner = ora(`Importing config dir for ${agentLabel(agentId)} v${version}...`).start();
+    const cfgResult = await importAgentConfig(agentId, version);
+    if (cfgResult.success) {
+      cfgSpinner.succeed(`Config imported (${agent.configDir} -> ${versionDir}/home/.${agentId})`);
+    } else if (cfgResult.skipped) {
+      cfgSpinner.warn(`Config: ${cfgResult.error}`);
+    } else {
+      cfgSpinner.fail(`Config: ${cfgResult.error}`);
+      process.exit(1);
+    }
   }
 
-  const binSpinner = ora('Registering binary...').start();
+  const binSpinner = ora(`Registering ${agentLabel(agentId)} v${version} binary...`).start();
   const binResult = importAgentBinary(
     { agentId, npmPackage: agent.npmPackage, cliCommand: agent.cliCommand },
     version,
     globalPath,
-    getVersionDir(agentId, version)
+    versionDir
   );
   if (binResult.success) {
-    binSpinner.succeed('Binary registered');
+    binSpinner.succeed(`Binary registered (${agent.cliCommand} -> ${globalPath})`);
   } else if (binResult.skipped) {
     binSpinner.warn(`Binary: ${binResult.error}`);
   } else {
@@ -150,20 +188,16 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
     process.exit(1);
   }
 
-  if (configDirExists) {
-    const stat = fs.lstatSync(agent.configDir);
-    if (!stat.isSymbolicLink()) {
-      const cfgSpinner = ora('Importing config dir...').start();
-      const cfgResult = await importAgentConfig(agentId, version);
-      if (cfgResult.success) {
-        cfgSpinner.succeed('Config imported');
-      } else if (cfgResult.skipped) {
-        cfgSpinner.warn(`Config: ${cfgResult.error}`);
-      } else {
-        cfgSpinner.fail(`Config: ${cfgResult.error}`);
-        process.exit(1);
-      }
-    }
+  // Wire the imported version into the resolver: global default, main shim,
+  // versioned alias, home-file symlinks. Idempotent — safe to call even if
+  // importAgentConfig already set the global default.
+  const finalizeSpinner = ora(`Wiring ${agentLabel(agentId)} v${version} as the active version...`).start();
+  try {
+    finalizeImport(agentId, version);
+    finalizeSpinner.succeed(`${agentLabel(agentId)} v${version} set as default with shim + alias`);
+  } catch (err) {
+    finalizeSpinner.fail(`Finalize: ${(err as Error).message}`);
+    process.exit(1);
   }
 
   console.log();
@@ -176,8 +210,20 @@ export function registerImportCommand(program: Command): void {
     .command('import')
     .argument('<agent>', 'Agent id (e.g. openclaw, claude, codex)')
     .description('Import an existing unmanaged agent install into agents-cli')
-    .option('--version <version>', 'Pin a version label (otherwise read from package.json or --version output)')
+    .option('--version <version>', 'Pin a version label (otherwise read from package.json)')
     .option('--from-path <path>', 'Path to the npm package dir (otherwise auto-detected from PATH)')
     .option('-y, --yes', 'Skip the confirmation prompt')
+    .addHelpText('after', `
+Examples:
+  $ agents import openclaw                          Auto-detect via PATH
+  $ agents import openclaw --version 2026.3.8       Pin a version label
+  $ agents import openclaw --from-path /opt/homebrew/lib/node_modules/openclaw
+
+When to use:
+  When an agent CLI is already installed globally via npm or homebrew and you
+  want to bring it under agents-cli management without reinstalling. Creates a
+  symlink farm pointing at the existing install — nothing is copied or moved
+  (except the agent's config dir, which is moved into the version's home).
+`)
     .action(runImport);
 }

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -31,6 +31,7 @@ import { confirm } from '@inquirer/prompts';
 import type { AgentId } from '../lib/types.js';
 import { ALL_AGENT_IDS } from '../lib/agents.js';
 import { AGENTS, getCliPath, getCliVersion, agentLabel } from '../lib/agents.js';
+import { getVersionDir } from '../lib/versions.js';
 import {
   importAgentBinary,
   importAgentConfig,
@@ -128,8 +129,18 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
     }
   }
 
+  if (!agent.npmPackage) {
+    console.error(chalk.red(`${agentLabel(agentId)} has no npm package metadata — cannot import.`));
+    process.exit(1);
+  }
+
   const binSpinner = ora('Registering binary...').start();
-  const binResult = importAgentBinary(agentId, version, globalPath);
+  const binResult = importAgentBinary(
+    { agentId, npmPackage: agent.npmPackage, cliCommand: agent.cliCommand },
+    version,
+    globalPath,
+    getVersionDir(agentId, version)
+  );
   if (binResult.success) {
     binSpinner.succeed('Binary registered');
   } else if (binResult.skipped) {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,0 +1,172 @@
+/**
+ * `agents import` — adopt an existing unmanaged agent install into agents-cli.
+ *
+ * Three forms:
+ *
+ *   agents import openclaw
+ *     Auto-detect via the binary on PATH. Resolves the npm package directory,
+ *     reads its version, and registers it under
+ *     ~/.agents/.history/versions/<agent>/<version>/.
+ *
+ *   agents import openclaw --version 2026.3.8
+ *     Same auto-detect, but pin the version label rather than reading it from
+ *     the package. Useful when the package metadata is stale or you want a
+ *     canonical name.
+ *
+ *   agents import openclaw --from-path /opt/homebrew/lib/node_modules/openclaw
+ *     Skip detection entirely. The given path must be a directory containing
+ *     a valid package.json with a `bin` entry.
+ *
+ * In all forms, the agent's config dir (e.g. ~/.openclaw) is also moved under
+ * management — same behavior as the first-run `agents setup` import flow.
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import * as fs from 'fs';
+import * as path from 'path';
+import { confirm } from '@inquirer/prompts';
+
+import type { AgentId } from '../lib/types.js';
+import { ALL_AGENT_IDS } from '../lib/agents.js';
+import { AGENTS, getCliPath, getCliVersion, agentLabel } from '../lib/agents.js';
+import {
+  importAgentBinary,
+  importAgentConfig,
+  resolvePackageDirFromBinary,
+} from '../lib/import.js';
+import { isPromptCancelled, isInteractiveTerminal } from './utils.js';
+
+interface ImportOptions {
+  version?: string;
+  fromPath?: string;
+  yes?: boolean;
+}
+
+function isValidAgentId(value: string): value is AgentId {
+  return (ALL_AGENT_IDS as string[]).includes(value);
+}
+
+async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
+  if (!isValidAgentId(agentArg)) {
+    console.error(chalk.red(`Unknown agent: ${agentArg}`));
+    console.error(chalk.gray(`Known agents: ${ALL_AGENT_IDS.join(', ')}`));
+    process.exit(1);
+  }
+  const agentId = agentArg;
+  const agent = AGENTS[agentId];
+
+  let globalPath: string | null = null;
+
+  if (opts.fromPath) {
+    globalPath = path.resolve(opts.fromPath);
+    if (!fs.existsSync(globalPath)) {
+      console.error(chalk.red(`Path does not exist: ${globalPath}`));
+      process.exit(1);
+    }
+  } else {
+    const binary = await getCliPath(agentId);
+    if (!binary) {
+      console.error(chalk.red(`No "${agent.cliCommand}" found on PATH.`));
+      console.error(chalk.gray(`Install it first (e.g. \`npm i -g ${agent.npmPackage ?? agent.cliCommand}\`) or pass --from-path.`));
+      process.exit(1);
+    }
+    globalPath = resolvePackageDirFromBinary(binary);
+    if (!globalPath) {
+      console.error(chalk.red(`Could not resolve npm package for binary: ${binary}`));
+      console.error(chalk.gray('Pass --from-path <dir> with the package directory explicitly.'));
+      process.exit(1);
+    }
+  }
+
+  let version = opts.version;
+  if (!version) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(path.join(globalPath, 'package.json'), 'utf8'));
+      version = typeof pkg.version === 'string' ? pkg.version : undefined;
+    } catch {
+      /* fall through */
+    }
+    if (!version) {
+      const detected = await getCliVersion(agentId);
+      version = detected ?? undefined;
+    }
+  }
+
+  if (!version) {
+    console.error(chalk.red(`Could not determine version for ${agentLabel(agentId)}.`));
+    console.error(chalk.gray('Pass --version <version> explicitly.'));
+    process.exit(1);
+  }
+
+  console.log(chalk.bold(`\nImport ${agentLabel(agentId)} v${version}`));
+  console.log(`  from: ${chalk.gray(globalPath)}`);
+  console.log(`  into: ${chalk.gray(`~/.agents/.history/versions/${agentId}/${version}/`)}`);
+
+  const configDirExists = fs.existsSync(agent.configDir);
+  if (configDirExists) {
+    const stat = fs.lstatSync(agent.configDir);
+    if (stat.isSymbolicLink()) {
+      console.log(`  config: ${chalk.gray(`${agent.configDir} (already managed — will skip)`)}`);
+    } else {
+      console.log(`  config: ${chalk.gray(`${agent.configDir} (will be moved into version home)`)}`);
+    }
+  } else {
+    console.log(`  config: ${chalk.gray(`${agent.configDir} (does not exist — will skip)`)}`);
+  }
+
+  if (!opts.yes && isInteractiveTerminal()) {
+    console.log();
+    const proceed = await confirm({ message: 'Proceed?', default: true }).catch((err) => {
+      if (isPromptCancelled(err)) return false;
+      throw err;
+    });
+    if (!proceed) {
+      console.log(chalk.gray('Aborted.'));
+      return;
+    }
+  }
+
+  const binSpinner = ora('Registering binary...').start();
+  const binResult = importAgentBinary(agentId, version, globalPath);
+  if (binResult.success) {
+    binSpinner.succeed('Binary registered');
+  } else if (binResult.skipped) {
+    binSpinner.warn(`Binary: ${binResult.error}`);
+  } else {
+    binSpinner.fail(`Binary: ${binResult.error}`);
+    process.exit(1);
+  }
+
+  if (configDirExists) {
+    const stat = fs.lstatSync(agent.configDir);
+    if (!stat.isSymbolicLink()) {
+      const cfgSpinner = ora('Importing config dir...').start();
+      const cfgResult = await importAgentConfig(agentId, version);
+      if (cfgResult.success) {
+        cfgSpinner.succeed('Config imported');
+      } else if (cfgResult.skipped) {
+        cfgSpinner.warn(`Config: ${cfgResult.error}`);
+      } else {
+        cfgSpinner.fail(`Config: ${cfgResult.error}`);
+        process.exit(1);
+      }
+    }
+  }
+
+  console.log();
+  console.log(chalk.green(`${agentLabel(agentId)} v${version} is now managed.`));
+  console.log(chalk.gray(`Verify: agents view ${agentId}`));
+}
+
+export function registerImportCommand(program: Command): void {
+  program
+    .command('import')
+    .argument('<agent>', 'Agent id (e.g. openclaw, claude, codex)')
+    .description('Import an existing unmanaged agent install into agents-cli')
+    .option('--version <version>', 'Pin a version label (otherwise read from package.json or --version output)')
+    .option('--from-path <path>', 'Path to the npm package dir (otherwise auto-detected from PATH)')
+    .option('-y, --yes', 'Skip the confirmation prompt')
+    .action(runImport);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import { registerRulesCommands } from './commands/rules.js';
 import { registerPermissionsCommands } from './commands/permissions.js';
 import { registerMcpCommands } from './commands/mcp.js';
 import { registerVersionsCommands } from './commands/versions.js';
+import { registerImportCommand } from './commands/import.js';
 import { registerPackagesCommands } from './commands/packages.js';
 import { registerDaemonCommands } from './commands/daemon.js';
 import { registerRoutinesCommands } from './commands/routines.js';
@@ -107,6 +108,7 @@ Quick start:
 
 Agent versions:
   add <agent>[@version]           Install an agent CLI (e.g. agents add codex)
+  import <agent>                  Adopt an existing global install (npm/homebrew) into agents-cli
   remove <agent>[@version]        Uninstall a version
   use <agent>@<version>           Set the default version
   prune [target]                  Remove orphan resources and older duplicate version installs (targets: commands, sessions, runs, trash)
@@ -496,6 +498,7 @@ registerSubagentsCommands(program);
 registerPluginsCommands(program);
 registerWorkflowsCommands(program);
 registerVersionsCommands(program);
+registerImportCommand(program);
 registerPackagesCommands(program);
 registerDaemonCommands(program);
 registerRoutinesCommands(program);

--- a/src/lib/__tests__/import.test.ts
+++ b/src/lib/__tests__/import.test.ts
@@ -1,38 +1,43 @@
 /**
  * Tests for the lib/import helpers backing the `agents import` command.
  *
- * Scope: pure-function coverage only.
- *
- * - resolvePackageDirFromBinary is pure (filesystem reads only, no state),
- *   so it's straightforward to exercise.
- *
- * - importAgentBinary is intentionally NOT tested here. It depends on
- *   getVersionDir() from versions.js, which routes through state.js's
- *   module-cached HISTORY_DIR. Mocking those modules under bun (the project's
- *   test runner) leaks across files because vi.mock isn't file-scoped in bun.
- *   Setting $HOME in beforeEach has no effect because the path constants
- *   are already cached. Integration coverage for importAgentBinary should
- *   land in a follow-up that either (a) injects versionDir via a parameter or
- *   (b) runs the test under vitest where vi.mock isolation works as designed.
+ * - resolvePackageDirFromBinary is pure (filesystem reads only, no state).
+ * - importAgentBinary is exercised with the optional versionDirOverride
+ *   parameter pointing at a temp dir, so we never touch the real
+ *   ~/.agents/.history/versions/. This avoids needing vi.mock on
+ *   state.ts / versions.ts — bun's vi.mock isn't file-scoped and would
+ *   leak failures into hooks/versions tests.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
-import { resolvePackageDirFromBinary } from '../import.js';
+import { resolvePackageDirFromBinary, importAgentBinary } from '../import.js';
 
-function makeFakeNpmPkg(root: string, name: string, version: string, cliCommand: string): {
+const OPENCLAW_SPEC = { agentId: 'openclaw', npmPackage: 'openclaw', cliCommand: 'openclaw' };
+
+interface FakePkg {
   pkgDir: string;
   binDir: string;
   binarySource: string;
-} {
+}
+
+function makeFakeNpmPkg(
+  root: string,
+  name: string,
+  version: string,
+  cliCommand: string,
+  opts: { binEntry?: string | Record<string, string> | null } = {}
+): FakePkg {
   const pkgDir = path.join(root, 'fake-global', 'node_modules', name);
   fs.mkdirSync(pkgDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(pkgDir, 'package.json'),
-    JSON.stringify({ name, version, bin: { [cliCommand]: 'dist/index.js' } }, null, 2)
-  );
+
+  const binEntry = opts.binEntry === undefined ? { [cliCommand]: 'dist/index.js' } : opts.binEntry;
+  const pkgJson: Record<string, unknown> = { name, version };
+  if (binEntry !== null) pkgJson.bin = binEntry;
+  fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify(pkgJson, null, 2));
+
   const distDir = path.join(pkgDir, 'dist');
   fs.mkdirSync(distDir, { recursive: true });
   const binarySource = path.join(distDir, 'index.js');
@@ -82,5 +87,93 @@ describe('resolvePackageDirFromBinary', () => {
   it('returns null when the binary path itself does not exist', () => {
     const resolved = resolvePackageDirFromBinary(path.join(tmp, 'does-not-exist'));
     expect(resolved).toBeNull();
+  });
+});
+
+describe('importAgentBinary', () => {
+  let tmp: string;
+  let versionDir: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-import-binary-'));
+    // Point the import at a tmp version dir instead of ~/.agents/.history/versions/...
+    versionDir = path.join(tmp, '.agents', '.history', 'versions', 'openclaw', '2026.3.8');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('creates a non-destructive symlink farm under the managed version dir', () => {
+    const { pkgDir, binarySource } = makeFakeNpmPkg(tmp, 'openclaw', '2026.3.8', 'openclaw');
+
+    const result = importAgentBinary(OPENCLAW_SPEC, '2026.3.8', pkgDir, versionDir);
+    expect(result.success).toBe(true);
+    expect(result.resolvedFromPath).toBe(pkgDir);
+
+    const managedBinary = path.join(versionDir, 'node_modules', '.bin', 'openclaw');
+    const managedPkg = path.join(versionDir, 'node_modules', 'openclaw');
+    const marker = path.join(versionDir, 'package.json');
+
+    // All targets are symlinks pointing at the original install — nothing copied.
+    expect(fs.lstatSync(managedBinary).isSymbolicLink()).toBe(true);
+    expect(fs.realpathSync(managedBinary)).toBe(fs.realpathSync(binarySource));
+    expect(fs.lstatSync(managedPkg).isSymbolicLink()).toBe(true);
+    expect(fs.realpathSync(managedPkg)).toBe(fs.realpathSync(pkgDir));
+
+    // Marker package.json records provenance and is marked private.
+    const markerJson = JSON.parse(fs.readFileSync(marker, 'utf8'));
+    expect(markerJson.imported).toBe(true);
+    expect(markerJson.from).toBe(pkgDir);
+    expect(markerJson.private).toBe(true);
+
+    // Empty home dir is created for the isolated $HOME.
+    expect(fs.existsSync(path.join(versionDir, 'home'))).toBe(true);
+  });
+
+  it('returns skipped=true on a second import of the same version', () => {
+    const { pkgDir } = makeFakeNpmPkg(tmp, 'openclaw', '2026.3.8', 'openclaw');
+    const first = importAgentBinary(OPENCLAW_SPEC, '2026.3.8', pkgDir, versionDir);
+    expect(first.success).toBe(true);
+
+    const second = importAgentBinary(OPENCLAW_SPEC, '2026.3.8', pkgDir, versionDir);
+    expect(second.success).toBe(false);
+    expect(second.skipped).toBe(true);
+    expect(second.error).toMatch(/already installed/);
+  });
+
+  it('fails cleanly when the path is not an npm package', () => {
+    const notAPkg = path.join(tmp, 'not-a-package');
+    fs.mkdirSync(notAPkg, { recursive: true });
+
+    const result = importAgentBinary(OPENCLAW_SPEC, '2026.3.8', notAPkg, versionDir);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/no package\.json/);
+  });
+
+  it('fails cleanly when the package has no bin entry for the cli command', () => {
+    const { pkgDir } = makeFakeNpmPkg(tmp, 'openclaw', '2026.3.8', 'openclaw', { binEntry: null });
+
+    const result = importAgentBinary(OPENCLAW_SPEC, '2026.3.8', pkgDir, versionDir);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/no bin entry/);
+  });
+
+  it('fails when --from-path does not exist', () => {
+    const result = importAgentBinary(OPENCLAW_SPEC, '2026.3.8', path.join(tmp, 'does-not-exist'), versionDir);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Path does not exist/);
+  });
+
+  it('honors a string-form bin entry (bin: "dist/index.js")', () => {
+    const { pkgDir, binarySource } = makeFakeNpmPkg(tmp, 'openclaw', '2026.3.8', 'openclaw', {
+      binEntry: 'dist/index.js',
+    });
+
+    const result = importAgentBinary(OPENCLAW_SPEC, '2026.3.8', pkgDir, versionDir);
+    expect(result.success).toBe(true);
+
+    const managedBinary = path.join(versionDir, 'node_modules', '.bin', 'openclaw');
+    expect(fs.realpathSync(managedBinary)).toBe(fs.realpathSync(binarySource));
   });
 });

--- a/src/lib/__tests__/import.test.ts
+++ b/src/lib/__tests__/import.test.ts
@@ -159,6 +159,18 @@ describe('importAgentBinary', () => {
     expect(result.error).toMatch(/no bin entry/);
   });
 
+  it('fails strictly when bin object is missing the cliCommand key (no fallback)', () => {
+    // Multi-bin packages must NOT silently get a wrong bin chosen by
+    // Object.values()[0] ordering. Require an exact match on cliCommand.
+    const { pkgDir } = makeFakeNpmPkg(tmp, 'openclaw', '2026.3.8', 'openclaw', {
+      binEntry: { 'something-else': 'dist/other.js', 'helper': 'dist/helper.js' },
+    });
+
+    const result = importAgentBinary(OPENCLAW_SPEC, '2026.3.8', pkgDir, versionDir);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/no bin entry for "openclaw"/);
+  });
+
   it('fails when --from-path does not exist', () => {
     const result = importAgentBinary(OPENCLAW_SPEC, '2026.3.8', path.join(tmp, 'does-not-exist'), versionDir);
     expect(result.success).toBe(false);

--- a/src/lib/__tests__/import.test.ts
+++ b/src/lib/__tests__/import.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for the lib/import helpers backing the `agents import` command.
+ *
+ * Scope: pure-function coverage only.
+ *
+ * - resolvePackageDirFromBinary is pure (filesystem reads only, no state),
+ *   so it's straightforward to exercise.
+ *
+ * - importAgentBinary is intentionally NOT tested here. It depends on
+ *   getVersionDir() from versions.js, which routes through state.js's
+ *   module-cached HISTORY_DIR. Mocking those modules under bun (the project's
+ *   test runner) leaks across files because vi.mock isn't file-scoped in bun.
+ *   Setting $HOME in beforeEach has no effect because the path constants
+ *   are already cached. Integration coverage for importAgentBinary should
+ *   land in a follow-up that either (a) injects versionDir via a parameter or
+ *   (b) runs the test under vitest where vi.mock isolation works as designed.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+import { resolvePackageDirFromBinary } from '../import.js';
+
+function makeFakeNpmPkg(root: string, name: string, version: string, cliCommand: string): {
+  pkgDir: string;
+  binDir: string;
+  binarySource: string;
+} {
+  const pkgDir = path.join(root, 'fake-global', 'node_modules', name);
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name, version, bin: { [cliCommand]: 'dist/index.js' } }, null, 2)
+  );
+  const distDir = path.join(pkgDir, 'dist');
+  fs.mkdirSync(distDir, { recursive: true });
+  const binarySource = path.join(distDir, 'index.js');
+  fs.writeFileSync(binarySource, '#!/usr/bin/env node\nconsole.log("fake");\n');
+  fs.chmodSync(binarySource, 0o755);
+
+  // Mirror the homebrew layout: /opt/homebrew/bin/<cmd> -> ../lib/node_modules/<pkg>/dist/index.js
+  const binDir = path.join(root, 'fake-global', 'bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.symlinkSync(binarySource, path.join(binDir, cliCommand));
+
+  return { pkgDir, binDir, binarySource };
+}
+
+describe('resolvePackageDirFromBinary', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-import-resolve-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('resolves a homebrew-style symlinked binary to its package dir', () => {
+    const { pkgDir, binDir } = makeFakeNpmPkg(tmp, 'openclaw', '2026.3.8', 'openclaw');
+    const binaryPath = path.join(binDir, 'openclaw');
+
+    const resolved = resolvePackageDirFromBinary(binaryPath);
+    // resolvePackageDirFromBinary uses realpathSync internally — match on
+    // both sides so macOS /var → /private/var doesn't trip the assertion.
+    expect(resolved).toBe(fs.realpathSync(pkgDir));
+  });
+
+  it('returns null for a binary that has no package.json on the walk-up', () => {
+    const bareDir = path.join(tmp, 'bare');
+    fs.mkdirSync(bareDir, { recursive: true });
+    const binaryPath = path.join(bareDir, 'standalone');
+    fs.writeFileSync(binaryPath, '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(binaryPath, 0o755);
+
+    const resolved = resolvePackageDirFromBinary(binaryPath);
+    expect(resolved).toBeNull();
+  });
+
+  it('returns null when the binary path itself does not exist', () => {
+    const resolved = resolvePackageDirFromBinary(path.join(tmp, 'does-not-exist'));
+    expect(resolved).toBeNull();
+  });
+});

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -98,7 +98,17 @@ export function importAgentBinary(
   const versionDir = getVersionDir(agentId, version);
   const binaryLink = path.join(versionDir, 'node_modules', '.bin', agent.cliCommand);
 
-  if (fs.existsSync(binaryLink)) {
+  // lstat — we want to detect the symlink itself, not follow it. fs.existsSync
+  // can return false on dangling symlinks, which would incorrectly let us
+  // proceed to symlinkSync below and throw EEXIST.
+  let alreadyExists = false;
+  try {
+    fs.lstatSync(binaryLink);
+    alreadyExists = true;
+  } catch {
+    /* not present */
+  }
+  if (alreadyExists) {
     return { success: false, skipped: true, error: `${version} already installed`, resolvedFromPath: globalPath };
   }
 

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -22,7 +22,7 @@ import * as path from 'path';
 import type { AgentId } from './types.js';
 import { AGENTS } from './agents.js';
 import { getVersionsDir } from './state.js';
-import { getVersionDir, setGlobalDefault } from './versions.js';
+import { setGlobalDefault } from './versions.js';
 import { ensureShimCurrent, switchHomeFileSymlinks } from './shims.js';
 
 export interface ImportConfigResult {
@@ -74,6 +74,21 @@ export async function importAgentConfig(
 }
 
 /**
+ * Agent metadata needed by importAgentBinary. Taking these as explicit
+ * inputs (rather than looking up AGENTS internally) decouples the symlink
+ * farm from the AGENTS registry, which keeps the function pure and avoids
+ * fragile coupling in test setups that stub `lib/agents.ts`.
+ */
+export interface AgentBinarySpec {
+  /** Agent id used in the marker package.json (`agents-{agentId}-{version}`). */
+  agentId: string;
+  /** npm package name (e.g. `openclaw`) — used as the `node_modules/<name>` dir. */
+  npmPackage: string;
+  /** Binary name on PATH (e.g. `openclaw`) — used as the `.bin/<name>` entry. */
+  cliCommand: string;
+}
+
+/**
  * Register an existing global npm package install under the managed version
  * path so the shim resolver finds it.
  *
@@ -86,17 +101,12 @@ export async function importAgentConfig(
  *     node_modules/.bin/{cliCommand} -> {binaryEntry}
  */
 export function importAgentBinary(
-  agentId: AgentId,
+  spec: AgentBinarySpec,
   version: string,
-  globalPath: string
+  globalPath: string,
+  versionDir: string
 ): ImportBinaryResult {
-  const agent = AGENTS[agentId];
-  if (!agent.npmPackage) {
-    return { success: false, error: `Agent "${agentId}" has no npm package` };
-  }
-
-  const versionDir = getVersionDir(agentId, version);
-  const binaryLink = path.join(versionDir, 'node_modules', '.bin', agent.cliCommand);
+  const binaryLink = path.join(versionDir, 'node_modules', '.bin', spec.cliCommand);
 
   // lstat — we want to detect the symlink itself, not follow it. fs.existsSync
   // can return false on dangling symlinks, which would incorrectly let us
@@ -127,14 +137,14 @@ export function importAgentBinary(
     if (typeof pkg.bin === 'string') {
       pkgBinEntry = pkg.bin;
     } else if (pkg.bin && typeof pkg.bin === 'object') {
-      pkgBinEntry = pkg.bin[agent.cliCommand] ?? Object.values(pkg.bin)[0] as string;
+      pkgBinEntry = pkg.bin[spec.cliCommand] ?? Object.values(pkg.bin)[0] as string;
     }
   } catch (err) {
     return { success: false, error: `Failed to read package.json: ${(err as Error).message}` };
   }
 
   if (!pkgBinEntry) {
-    return { success: false, error: `package.json has no bin entry for "${agent.cliCommand}"` };
+    return { success: false, error: `package.json has no bin entry for "${spec.cliCommand}"` };
   }
 
   const binaryTarget = path.resolve(globalPath, pkgBinEntry);
@@ -148,10 +158,10 @@ export function importAgentBinary(
 
     fs.writeFileSync(
       path.join(versionDir, 'package.json'),
-      JSON.stringify({ name: `agents-${agentId}-${version}`, version: '1.0.0', private: true, imported: true, from: globalPath }, null, 2)
+      JSON.stringify({ name: `agents-${spec.agentId}-${version}`, version: '1.0.0', private: true, imported: true, from: globalPath }, null, 2)
     );
 
-    const pkgLink = path.join(versionDir, 'node_modules', agent.npmPackage);
+    const pkgLink = path.join(versionDir, 'node_modules', spec.npmPackage);
     fs.mkdirSync(path.dirname(pkgLink), { recursive: true });
     if (!fs.existsSync(pkgLink)) {
       fs.symlinkSync(globalPath, pkgLink);

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -1,0 +1,185 @@
+/**
+ * Import existing unmanaged agent installations into agents-cli.
+ *
+ * Two flavors:
+ *
+ *  1. Config-only import — moves an agent's config dir (e.g. ~/.openclaw)
+ *     into the version structure and symlinks it back. Used by `agents setup`
+ *     on first-run when an agent was previously installed via npm/homebrew.
+ *
+ *  2. Full import — also registers an existing binary install (e.g. a global
+ *     `npm i -g openclaw`) under the managed version path so the shim
+ *     resolver can find it. This is what `agents import <agent>` does.
+ *
+ * The binary side never moves files. It creates a thin symlink farm under
+ * `~/.agents/.history/versions/<agent>/<version>/` pointing at the original
+ * global install, plus a package.json marker so `isVersionInstalled` returns
+ * true.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { AgentId } from './types.js';
+import { AGENTS } from './agents.js';
+import { getVersionsDir } from './state.js';
+import { getVersionDir, setGlobalDefault } from './versions.js';
+import { ensureShimCurrent, switchHomeFileSymlinks } from './shims.js';
+
+export interface ImportConfigResult {
+  success: boolean;
+  skipped?: boolean;
+  error?: string;
+}
+
+export interface ImportBinaryResult {
+  success: boolean;
+  skipped?: boolean;
+  error?: string;
+  resolvedFromPath?: string;
+}
+
+/**
+ * Move an agent's config dir into the managed version structure and symlink it
+ * back to its original location.
+ *
+ * No-op (returns skipped=true) if the version's config dir is already created.
+ * Caller is expected to call `setGlobalDefault` separately when appropriate —
+ * we do it here too for backward compatibility with the existing setup flow.
+ */
+export async function importAgentConfig(
+  agentId: AgentId,
+  version: string
+): Promise<ImportConfigResult> {
+  const agent = AGENTS[agentId];
+  const configDir = agent.configDir;
+  const versionsDir = getVersionsDir();
+  const versionHome = path.join(versionsDir, agentId, version, 'home');
+  const versionConfigDir = path.join(versionHome, `.${agentId}`);
+
+  if (fs.existsSync(versionConfigDir)) {
+    return { success: false, skipped: true, error: `${version} already installed` };
+  }
+
+  try {
+    fs.mkdirSync(versionHome, { recursive: true });
+    fs.renameSync(configDir, versionConfigDir);
+    fs.symlinkSync(versionConfigDir, configDir);
+    setGlobalDefault(agentId, version);
+    switchHomeFileSymlinks(agentId, version);
+    ensureShimCurrent(agentId);
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}
+
+/**
+ * Register an existing global npm package install under the managed version
+ * path so the shim resolver finds it.
+ *
+ * Layout produced (everything is a symlink, nothing is copied):
+ *
+ *   {versionDir}/
+ *     package.json                          # marker so isVersionInstalled() is true
+ *     home/                                 # empty isolated $HOME for this version
+ *     node_modules/{npmPackage}    -> {globalPath}
+ *     node_modules/.bin/{cliCommand} -> {binaryEntry}
+ */
+export function importAgentBinary(
+  agentId: AgentId,
+  version: string,
+  globalPath: string
+): ImportBinaryResult {
+  const agent = AGENTS[agentId];
+  if (!agent.npmPackage) {
+    return { success: false, error: `Agent "${agentId}" has no npm package` };
+  }
+
+  const versionDir = getVersionDir(agentId, version);
+  const binaryLink = path.join(versionDir, 'node_modules', '.bin', agent.cliCommand);
+
+  if (fs.existsSync(binaryLink)) {
+    return { success: false, skipped: true, error: `${version} already installed`, resolvedFromPath: globalPath };
+  }
+
+  if (!fs.existsSync(globalPath)) {
+    return { success: false, error: `Path does not exist: ${globalPath}` };
+  }
+
+  const globalPkgJson = path.join(globalPath, 'package.json');
+  if (!fs.existsSync(globalPkgJson)) {
+    return { success: false, error: `Not an npm package (no package.json): ${globalPath}` };
+  }
+
+  let pkgBinEntry: string | undefined;
+  try {
+    const pkg = JSON.parse(fs.readFileSync(globalPkgJson, 'utf8'));
+    if (typeof pkg.bin === 'string') {
+      pkgBinEntry = pkg.bin;
+    } else if (pkg.bin && typeof pkg.bin === 'object') {
+      pkgBinEntry = pkg.bin[agent.cliCommand] ?? Object.values(pkg.bin)[0] as string;
+    }
+  } catch (err) {
+    return { success: false, error: `Failed to read package.json: ${(err as Error).message}` };
+  }
+
+  if (!pkgBinEntry) {
+    return { success: false, error: `package.json has no bin entry for "${agent.cliCommand}"` };
+  }
+
+  const binaryTarget = path.resolve(globalPath, pkgBinEntry);
+  if (!fs.existsSync(binaryTarget)) {
+    return { success: false, error: `Binary entry missing: ${binaryTarget}` };
+  }
+
+  try {
+    fs.mkdirSync(path.join(versionDir, 'home'), { recursive: true });
+    fs.mkdirSync(path.join(versionDir, 'node_modules', '.bin'), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(versionDir, 'package.json'),
+      JSON.stringify({ name: `agents-${agentId}-${version}`, version: '1.0.0', private: true, imported: true, from: globalPath }, null, 2)
+    );
+
+    const pkgLink = path.join(versionDir, 'node_modules', agent.npmPackage);
+    fs.mkdirSync(path.dirname(pkgLink), { recursive: true });
+    if (!fs.existsSync(pkgLink)) {
+      fs.symlinkSync(globalPath, pkgLink);
+    }
+
+    fs.symlinkSync(binaryTarget, binaryLink);
+
+    return { success: true, resolvedFromPath: globalPath };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}
+
+/**
+ * Resolve the on-disk npm package directory for an agent's CLI binary by
+ * walking up from the binary, following any symlinks. Returns null if the
+ * package can't be identified.
+ *
+ * Handles the homebrew/global-npm pattern where:
+ *   /opt/homebrew/bin/{cli}  ->  ../lib/node_modules/{pkg}/dist/index.js
+ */
+export function resolvePackageDirFromBinary(binaryPath: string): string | null {
+  try {
+    let real = fs.realpathSync(binaryPath);
+    let dir = path.dirname(real);
+
+    // Walk up looking for the nearest package.json
+    for (let i = 0; i < 6; i++) {
+      const pkg = path.join(dir, 'package.json');
+      if (fs.existsSync(pkg)) {
+        return dir;
+      }
+      const parent = path.dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -23,7 +23,7 @@ import type { AgentId } from './types.js';
 import { AGENTS } from './agents.js';
 import { getVersionsDir } from './state.js';
 import { setGlobalDefault } from './versions.js';
-import { ensureShimCurrent, switchHomeFileSymlinks } from './shims.js';
+import { createShim, createVersionedAlias, ensureShimCurrent, switchHomeFileSymlinks } from './shims.js';
 
 export interface ImportConfigResult {
   success: boolean;
@@ -40,11 +40,11 @@ export interface ImportBinaryResult {
 
 /**
  * Move an agent's config dir into the managed version structure and symlink it
- * back to its original location.
+ * back to its original location. Sets the imported version as the global
+ * default and refreshes the shim so the user's PATH lookup hits the managed
+ * version.
  *
  * No-op (returns skipped=true) if the version's config dir is already created.
- * Caller is expected to call `setGlobalDefault` separately when appropriate —
- * we do it here too for backward compatibility with the existing setup flow.
  */
 export async function importAgentConfig(
   agentId: AgentId,
@@ -71,6 +71,29 @@ export async function importAgentConfig(
   } catch (err) {
     return { success: false, error: (err as Error).message };
   }
+}
+
+/**
+ * Wire an imported version into the rest of the system so it behaves the same
+ * as a freshly installed version:
+ *
+ *   - registered as the global default in agents.yaml (so `agents view`
+ *     reports it correctly and resolvers find it),
+ *   - main shim refreshed (`~/.agents/.cache/shims/<cli>`),
+ *   - versioned alias created (`~/.agents/.cache/shims/<cli>@<version>`),
+ *   - home-file symlinks (CLAUDE.md / AGENTS.md / etc.) repointed at this
+ *     version's home dir.
+ *
+ * Without this, the binary-only import path would leave the version stranded:
+ * isVersionInstalled returns true, but the resolver never picks it. Safe to
+ * call multiple times — each underlying function is idempotent.
+ */
+export function finalizeImport(agentId: AgentId, version: string): void {
+  setGlobalDefault(agentId, version);
+  createShim(agentId);
+  createVersionedAlias(agentId, version);
+  switchHomeFileSymlinks(agentId, version);
+  ensureShimCurrent(agentId);
 }
 
 /**
@@ -137,14 +160,17 @@ export function importAgentBinary(
     if (typeof pkg.bin === 'string') {
       pkgBinEntry = pkg.bin;
     } else if (pkg.bin && typeof pkg.bin === 'object') {
-      pkgBinEntry = pkg.bin[spec.cliCommand] ?? Object.values(pkg.bin)[0] as string;
+      // Strict: only accept the exact cliCommand key. Multi-bin packages
+      // (e.g. @anthropic-ai/claude-code ships several bins) would otherwise
+      // silently get a wrong binary chosen by Object.values() ordering.
+      pkgBinEntry = pkg.bin[spec.cliCommand];
     }
   } catch (err) {
     return { success: false, error: `Failed to read package.json: ${(err as Error).message}` };
   }
 
   if (!pkgBinEntry) {
-    return { success: false, error: `package.json has no bin entry for "${spec.cliCommand}"` };
+    return { success: false, error: `package.json has no bin entry for "${spec.cliCommand}" — pass --from-path to a package that ships it` };
   }
 
   const binaryTarget = path.resolve(globalPath, pkgBinEntry);


### PR DESCRIPTION
## Summary

Adds `agents import <agent>` to adopt an existing global npm/homebrew install into agents-cli management without reinstalling.

```bash
agents import openclaw                          # auto-detect via PATH
agents import openclaw --version 2026.3.8       # pin version label
agents import openclaw --from-path /opt/homebrew/lib/node_modules/openclaw
```

Previously, the import-from-unmanaged flow existed only inside `runSetup`'s first-run path (`importAgent` at `src/commands/setup.ts:30`, gated behind the `alreadyConfigured` check). Once setup completes there was no public command to import additional agents later — `agents add` only installs fresh from npm. Also, `getUnmanagedAgentInstalls` at `src/lib/agents.ts:547` hardcodes detection to `['claude', 'codex', 'gemini']`, so the existing flow wouldn't have found openclaw or any other agent regardless.

## Changes

- **New** `src/lib/import.ts` — `importAgentConfig` (config-dir adoption, extracted logic from setup.ts), `importAgentBinary` (symlink farm under managed version dir so `isVersionInstalled` returns true), `resolvePackageDirFromBinary` (PATH binary → npm package dir).
- **New** `src/commands/import.ts` — command + `--version`, `--from-path`, `--yes` flags.
- `src/index.ts` — register the command and help-text entry under "Agent versions".
- **New** `src/lib/__tests__/import.test.ts` — tests for `resolvePackageDirFromBinary`.

Binary registration is non-destructive: only creates symlinks under `~/.agents/.history/versions/<agent>/<version>/`. Nothing is moved or copied from the upstream package directory.

## Test plan

- [x] `npx tsc --noEmit -p .` clean
- [x] `bun test src/lib/__tests__/import.test.ts` — 3/3 pass
- [x] Full suite shows same 103 fail / 12 errors as `main` (pre-existing `vi.hoisted`/bun mismatch, not introduced here)
- [x] `bun src/index.ts import --help` renders cleanly
- [x] Unknown agent → friendly error with list of known agents
- [x] Missing `--from-path` → friendly error
- [ ] Smoke test on a real machine with global openclaw — would appreciate a reviewer try

## Out of scope

- Refactoring `runSetup` to use the new helpers (kept identical to minimize risk).
- Integration coverage for `importAgentBinary` — depends on `versions.ts` → `state.ts` module-cached `HISTORY_DIR`. Mocking under bun leaks across files; should land in a follow-up that either takes a `versionDir` parameter for DI or runs under vitest where `vi.mock` isolation works as designed.
- Extending `getUnmanagedAgentInstalls` candidate list — bypassed via `--from-path`.