### PR TITLE
feat(browser): --electron, --binary, --target-filter for desktop apps

### DIFF
--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -87,12 +87,20 @@ browser profiles create cloud --browser chrome \
 
 ## "I need to automate an Electron app"
 
-Point to the binary:
+Three flags work together for Electron desktop apps:
 
 ```bash
-browser profiles create slack --browser custom \
-  --binary "/Applications/Slack.app/Contents/MacOS/Slack"
+browser profiles create canva --browser custom \
+  --binary "/Applications/Canva.app/Contents/MacOS/Canva" \
+  --electron \
+  --target-filter "url:https://www.canva.com/"
 ```
+
+- `--browser custom` plus `--binary` tells the launcher how to start the app with `--remote-debugging-port`.
+- `--electron` switches the runtime into single-window mode: tabs are never created with `Target.createTarget` (most production Electron apps reject it); navigation reuses the existing window.
+- `--target-filter` picks the visible WebContents. Electron apps frequently expose several `type: page` CDP targets — background services, OAuth windows, and `file://` shells — and the first one CDP returns is almost never the UI. Use `url:<substring>` or `title:<substring>`.
+
+Without `--target-filter`, a skip-invisible heuristic excludes `about:blank`, `file://`, and URLs matching `_desktop-background-service` / `_internal` / `_background`. That covers most apps; use the filter for the ones it doesn't.
 
 ## Common workflows
 

--- a/src/commands/browser.ts
+++ b/src/commands/browser.ts
@@ -67,7 +67,7 @@ function registerProfilesCommands(browser: Command): void {
       }
     });
 
-  const VALID_BROWSERS = ['chrome', 'comet', 'chromium', 'brave', 'edge'];
+  const VALID_BROWSERS = ['chrome', 'comet', 'chromium', 'brave', 'edge', 'custom'];
 
   profiles
     .command('create <name>')
@@ -79,6 +79,15 @@ function registerProfilesCommands(browser: Command): void {
     .option('--headless', 'Run in headless mode')
     .option('--window <WxH>', 'Window size, e.g. 1512x982')
     .option('--position <X,Y>', 'Window position on screen, e.g. 80,80')
+    .option('--binary <path>', 'Absolute path to the browser/app binary (required with --browser custom)')
+    .option(
+      '--electron',
+      'Treat this profile as an Electron desktop app: never call Target.createTarget; bind to the visible window using --target-filter or the skip-invisible heuristic'
+    )
+    .option(
+      '--target-filter <expr>',
+      'Pick the visible CDP page target when the app exposes more than one. Format: url:<substring> or title:<substring>'
+    )
     .action(async (name: string, opts) => {
       if (!/^[a-z][a-z0-9-]*$/.test(name)) {
         console.error('Profile name must be lowercase alphanumeric with hyphens');
@@ -88,6 +97,20 @@ function registerProfilesCommands(browser: Command): void {
       if (!VALID_BROWSERS.includes(opts.browser)) {
         console.error(`Invalid browser type. Must be one of: ${VALID_BROWSERS.join(', ')}`);
         process.exit(1);
+      }
+
+      if (opts.browser === 'custom' && !opts.binary) {
+        console.error('--browser custom requires --binary <path>');
+        process.exit(1);
+      }
+
+      if (opts.targetFilter) {
+        const idx = String(opts.targetFilter).indexOf(':');
+        const kind = idx > 0 ? String(opts.targetFilter).slice(0, idx).toLowerCase() : '';
+        if (kind !== 'url' && kind !== 'title') {
+          console.error('--target-filter must be url:<substring> or title:<substring>');
+          process.exit(1);
+        }
       }
 
       // Auto-assign a free port if no endpoint was provided
@@ -125,6 +148,9 @@ function registerProfilesCommands(browser: Command): void {
         name,
         description: opts.description,
         browser: opts.browser,
+        binary: opts.binary,
+        electron: opts.electron || undefined,
+        targetFilter: opts.targetFilter,
         endpoints,
         secrets: opts.secrets,
         chrome: opts.headless ? { headless: true } : undefined,
@@ -157,6 +183,9 @@ function registerProfilesCommands(browser: Command): void {
 
       console.log(`Name: ${profile.name}`);
       console.log(`Browser: ${profile.browser}`);
+      if (profile.binary) console.log(`Binary: ${profile.binary}`);
+      if (profile.electron) console.log(`Electron: true`);
+      if (profile.targetFilter) console.log(`Target filter: ${profile.targetFilter}`);
       if (profile.description) console.log(`Description: ${profile.description}`);
       console.log(`Endpoints:`);
       for (const e of profile.endpoints) {

--- a/src/commands/browser.ts
+++ b/src/commands/browser.ts
@@ -13,6 +13,7 @@ import {
 } from '../lib/browser/profiles.js';
 import { findBrowserPath, getPortOccupant } from '../lib/browser/chrome.js';
 import { discoverBrowserWsUrl, verifyBrowserIdentity } from '../lib/browser/cdp.js';
+import { parseTargetFilter } from '../lib/browser/service.js';
 import { sendIPCRequest } from '../lib/browser/ipc.js';
 import { browserTaskPicker, type BrowserTask } from './browser-picker.js';
 import { isInteractiveTerminal } from './utils.js';
@@ -105,10 +106,17 @@ function registerProfilesCommands(browser: Command): void {
       }
 
       if (opts.targetFilter) {
-        const idx = String(opts.targetFilter).indexOf(':');
-        const kind = idx > 0 ? String(opts.targetFilter).slice(0, idx).toLowerCase() : '';
-        if (kind !== 'url' && kind !== 'title') {
-          console.error('--target-filter must be url:<substring> or title:<substring>');
+        // Route through the same parser the runtime uses so the CLI gate matches
+        // the runtime contract — `url:` (empty value) and `url: foo` (leading
+        // whitespace) both pass a naive `kind` check but produce a silent
+        // heuristic fallback at runtime.
+        const parsed = parseTargetFilter(String(opts.targetFilter));
+        if (!parsed) {
+          console.error('--target-filter must be url:<substring> or title:<substring> (non-empty value, no leading whitespace)');
+          process.exit(1);
+        }
+        if (!opts.electron) {
+          console.error('--target-filter requires --electron (the filter is only consulted on Electron profiles)');
           process.exit(1);
         }
       }

--- a/src/lib/browser/profiles.test.ts
+++ b/src/lib/browser/profiles.test.ts
@@ -14,9 +14,10 @@ vi.mock('./chrome.js', () => ({
   findBrowserPath: vi.fn(() => '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'),
 }));
 
-import { extractConfiguredPort, findFreeProfilePort } from './profiles.js';
+import { extractConfiguredPort, findFreeProfilePort, createProfile } from './profiles.js';
 import type { BrowserProfile } from './types.js';
-import { readMeta } from '../state.js';
+import type { BrowserProfileConfig } from '../types.js';
+import { readMeta, writeMeta } from '../state.js';
 import { execSync } from 'child_process';
 
 function profile(endpoints: string[]): BrowserProfile {
@@ -61,6 +62,69 @@ describe('extractConfiguredPort', () => {
     expect(
       extractConfiguredPort(profile(['cdp://localhost:9001', 'cdp://localhost:9002']))
     ).toBe(9001);
+  });
+});
+
+describe('profile YAML round-trip', () => {
+  // configToProfile / profileToConfig are internal, but createProfile calls
+  // writeMeta(config) and getProfile/listProfiles run configToProfile(config).
+  // Round-tripping through that pair is the production code path.
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserves electron / binary / targetFilter through write -> read', async () => {
+    const store: { browser: Record<string, BrowserProfileConfig> } = { browser: {} };
+    vi.mocked(readMeta).mockImplementation(() => store as any);
+    vi.mocked(writeMeta).mockImplementation((meta: any) => {
+      // Persist exactly what createProfile passes — this mirrors disk YAML.
+      store.browser = (meta.browser ?? {}) as Record<string, BrowserProfileConfig>;
+    });
+
+    const input: BrowserProfile = {
+      name: 'canva',
+      browser: 'custom',
+      binary: '/Applications/Canva.app/Contents/MacOS/Canva',
+      electron: true,
+      targetFilter: 'url:https://www.canva.com/',
+      endpoints: ['cdp://127.0.0.1:9201'],
+    };
+
+    await createProfile(input);
+
+    const stored = store.browser['canva'];
+    expect(stored.browser).toBe('custom');
+    expect(stored.binary).toBe('/Applications/Canva.app/Contents/MacOS/Canva');
+    expect(stored.electron).toBe(true);
+    expect(stored.targetFilter).toBe('url:https://www.canva.com/');
+
+    // And on the read side — configToProfile must not silently drop the field
+    // (regression guard: someone could remove it from configToProfile and the
+    // value would survive YAML but be undefined at runtime).
+    const { listProfiles } = await import('./profiles.js');
+    const [restored] = await listProfiles();
+    expect(restored.binary).toBe(input.binary);
+    expect(restored.electron).toBe(true);
+    expect(restored.targetFilter).toBe(input.targetFilter);
+  });
+
+  it('does not write electron/binary/targetFilter when they are unset', async () => {
+    const store: { browser: Record<string, BrowserProfileConfig> } = { browser: {} };
+    vi.mocked(readMeta).mockImplementation(() => store as any);
+    vi.mocked(writeMeta).mockImplementation((meta: any) => {
+      store.browser = (meta.browser ?? {}) as Record<string, BrowserProfileConfig>;
+    });
+
+    await createProfile({
+      name: 'plain',
+      browser: 'chrome',
+      endpoints: ['cdp://127.0.0.1:9301'],
+    });
+
+    const stored = store.browser['plain'];
+    expect('binary' in stored).toBe(false);
+    expect('electron' in stored).toBe(false);
+    expect('targetFilter' in stored).toBe(false);
   });
 });
 

--- a/src/lib/browser/profiles.ts
+++ b/src/lib/browser/profiles.ts
@@ -26,6 +26,7 @@ function configToProfile(name: string, config: BrowserProfileConfig): BrowserPro
     browser: config.browser,
     binary: config.binary,
     electron: config.electron,
+    targetFilter: config.targetFilter,
     endpoints: config.endpoints,
     chrome: config.chrome,
     secrets: config.secrets,
@@ -41,6 +42,7 @@ function profileToConfig(profile: BrowserProfile): BrowserProfileConfig {
   if (profile.description) config.description = profile.description;
   if (profile.binary) config.binary = profile.binary;
   if (profile.electron) config.electron = profile.electron;
+  if (profile.targetFilter) config.targetFilter = profile.targetFilter;
   if (profile.chrome) config.chrome = profile.chrome;
   if (profile.secrets) config.secrets = profile.secrets;
   if (profile.viewport) config.viewport = profile.viewport;

--- a/src/lib/browser/service.test.ts
+++ b/src/lib/browser/service.test.ts
@@ -235,6 +235,18 @@ describe('parseTargetFilter', () => {
     expect(parseTargetFilter('')).toBeNull();
     expect(parseTargetFilter(undefined)).toBeNull();
   });
+
+  it('trims whitespace around the value (copy-paste safety)', async () => {
+    // `url: https://x` (space after colon) used to parse to value=' https://x',
+    // which silently never matched any real URL. Strip both sides.
+    const { parseTargetFilter } = await import('./service.js');
+    expect(parseTargetFilter('url: https://www.canva.com/ ')).toEqual({
+      kind: 'url',
+      value: 'https://www.canva.com/',
+    });
+    // Whitespace-only value is equivalent to empty value.
+    expect(parseTargetFilter('url:   ')).toBeNull();
+  });
 });
 
 describe('pickWindowTarget', () => {
@@ -316,5 +328,28 @@ describe('pickWindowTarget', () => {
     // Garbage filter should not crash; treat as if absent.
     const hit = pickWindowTarget(canvaTargets, 'not-a-valid-filter');
     expect(hit?.targetId).toBe('B351F950');
+  });
+
+  it('explicit filter, all matches invisible — returns first match (documented fallback)', async () => {
+    // If every match is invisible, the helper still returns *something* rather
+    // than `undefined`. The caller can decide to surface a warning if needed.
+    // Caught here so a future refactor doesn't accidentally drop the `?? matches[0]`.
+    const { pickWindowTarget } = await import('./service.js');
+    const invisibleMatches = [
+      {
+        targetId: 'BG1',
+        type: 'page',
+        url: 'https://www.canva.com/_desktop-background-service',
+        title: 'Desktop Background Service',
+      },
+      {
+        targetId: 'BG2',
+        type: 'page',
+        url: 'https://www.canva.com/_internal',
+        title: 'Internal',
+      },
+    ];
+    const hit = pickWindowTarget(invisibleMatches, 'url:canva.com');
+    expect(hit?.targetId).toBe('BG1');
   });
 });

--- a/src/lib/browser/service.test.ts
+++ b/src/lib/browser/service.test.ts
@@ -193,3 +193,128 @@ describe('BrowserService.status — disk reconciliation (Issue #6)', () => {
     expect(result[0].name).toBe('a');
   });
 });
+
+// -----------------------------------------------------------------------------
+// pickWindowTarget / parseTargetFilter
+//
+// These helpers exist because Electron apps frequently expose multiple
+// `type: 'page'` CDP targets per process: the visible window plus invisible
+// helpers (background services, OAuth windows, file:// shells). Without these,
+// `agents browser start` against an Electron app silently latches onto whatever
+// target is enumerated first by CDP — almost always wrong, with no signal to
+// the user other than blank screenshots.
+// -----------------------------------------------------------------------------
+describe('parseTargetFilter', () => {
+  it('parses url:<substring>', async () => {
+    const { parseTargetFilter } = await import('./service.js');
+    expect(parseTargetFilter('url:https://www.canva.com/')).toEqual({
+      kind: 'url',
+      value: 'https://www.canva.com/',
+    });
+  });
+
+  it('parses title:<substring>', async () => {
+    const { parseTargetFilter } = await import('./service.js');
+    expect(parseTargetFilter('title:Home - Canva')).toEqual({
+      kind: 'title',
+      value: 'Home - Canva',
+    });
+  });
+
+  it('treats kind as case-insensitive', async () => {
+    const { parseTargetFilter } = await import('./service.js');
+    expect(parseTargetFilter('URL:foo')?.kind).toBe('url');
+    expect(parseTargetFilter('Title:bar')?.kind).toBe('title');
+  });
+
+  it('returns null for unknown kind, missing colon, empty value, or undefined', async () => {
+    const { parseTargetFilter } = await import('./service.js');
+    expect(parseTargetFilter('hostname:foo')).toBeNull();
+    expect(parseTargetFilter('foobar')).toBeNull();
+    expect(parseTargetFilter('url:')).toBeNull();
+    expect(parseTargetFilter('')).toBeNull();
+    expect(parseTargetFilter(undefined)).toBeNull();
+  });
+});
+
+describe('pickWindowTarget', () => {
+  // Canonical Canva target list captured live against `:9201/json`.
+  // The first page is the invisible Desktop Background Service — the bug
+  // we're fixing is that the original `find(t.type === 'page')` returns
+  // this target and screenshots come back blank.
+  const canvaTargets = [
+    {
+      targetId: 'C1AEAD00',
+      type: 'page',
+      url: 'https://www.canva.com/_desktop-background-service',
+      title: 'Desktop Background Service',
+    },
+    {
+      targetId: 'B351F950',
+      type: 'page',
+      url: 'https://www.canva.com/',
+      title: 'Home - Canva',
+    },
+    {
+      targetId: 'FBBCAA2F',
+      type: 'page',
+      url: 'file:///Applications/Canva.app/Contents/Resources/app.asar/dist/index.dynamic_locale.html',
+      title: 'index.dynamic_locale.html',
+    },
+    { targetId: 'SW1', type: 'service_worker', url: 'https://www.canva.com/sw.js' },
+  ];
+
+  it('explicit url filter wins over enumeration order', async () => {
+    const { pickWindowTarget } = await import('./service.js');
+    const hit = pickWindowTarget(canvaTargets, 'url:https://www.canva.com/');
+    expect(hit?.targetId).toBe('B351F950');
+  });
+
+  it('explicit title filter wins over enumeration order', async () => {
+    const { pickWindowTarget } = await import('./service.js');
+    const hit = pickWindowTarget(canvaTargets, 'title:Home - Canva');
+    expect(hit?.targetId).toBe('B351F950');
+  });
+
+  it('substring match is case-insensitive on both haystack and needle', async () => {
+    const { pickWindowTarget } = await import('./service.js');
+    const hit = pickWindowTarget(canvaTargets, 'title:HOME');
+    expect(hit?.targetId).toBe('B351F950');
+  });
+
+  it('explicit filter that misses returns undefined — caller must surface the failure', async () => {
+    const { pickWindowTarget } = await import('./service.js');
+    // The caller (getOrCreateWindow) turns this into a thrown error listing
+    // the candidates. Returning undefined here keeps the helper pure.
+    expect(pickWindowTarget(canvaTargets, 'url:does-not-exist')).toBeUndefined();
+  });
+
+  it('with no filter, skips _desktop-background-service and file:// shells', async () => {
+    const { pickWindowTarget } = await import('./service.js');
+    const hit = pickWindowTarget(canvaTargets, undefined);
+    expect(hit?.targetId).toBe('B351F950');
+  });
+
+  it('with no filter and no visible candidate, falls back to first page target', async () => {
+    const { pickWindowTarget } = await import('./service.js');
+    const allInvisible = [
+      { targetId: 'A', type: 'page', url: 'about:blank' },
+      { targetId: 'B', type: 'page', url: 'file:///x' },
+    ];
+    const hit = pickWindowTarget(allInvisible, undefined);
+    expect(hit?.targetId).toBe('A');
+  });
+
+  it('returns undefined when no page targets exist at all', async () => {
+    const { pickWindowTarget } = await import('./service.js');
+    const workerOnly = [{ targetId: 'SW', type: 'service_worker', url: 'sw.js' }];
+    expect(pickWindowTarget(workerOnly, undefined)).toBeUndefined();
+  });
+
+  it('malformed filter falls back to heuristic instead of throwing', async () => {
+    const { pickWindowTarget } = await import('./service.js');
+    // Garbage filter should not crash; treat as if absent.
+    const hit = pickWindowTarget(canvaTargets, 'not-a-valid-filter');
+    expect(hit?.targetId).toBe('B351F950');
+  });
+});

--- a/src/lib/browser/service.ts
+++ b/src/lib/browser/service.ts
@@ -42,7 +42,10 @@ export function parseTargetFilter(filter: string | undefined): TargetFilter | nu
   const idx = filter.indexOf(':');
   if (idx <= 0) return null;
   const kind = filter.slice(0, idx).trim().toLowerCase();
-  const value = filter.slice(idx + 1);
+  // Strip whitespace around the value so `url: https://x` (with a copy-pasted
+  // space after the colon) doesn't silently fail to match — `.includes(' x')`
+  // never hits a URL because URLs don't contain spaces.
+  const value = filter.slice(idx + 1).trim();
   if (kind !== 'url' && kind !== 'title') return null;
   if (!value) return null;
   return { kind, value };
@@ -1351,7 +1354,7 @@ export class BrowserService {
     if (parseTargetFilter(conn.targetFilter)) {
       const candidates = targetInfos
         .filter((t) => t.type === 'page')
-        .map((t) => `  - url=${t.url} title=${t.title ?? ''}`)
+        .map((t) => `  - url=${t.url ?? ''} title=${t.title ?? ''}`)
         .join('\n');
       throw new Error(
         `Target filter ${JSON.stringify(conn.targetFilter)} matched no page target.\n` +

--- a/src/lib/browser/service.ts
+++ b/src/lib/browser/service.ts
@@ -26,12 +26,95 @@ import {
 import { getRefs, resolveRefToCoords, type RefOpts, type RefNode } from './refs.js';
 import { clickAtCoords, hoverAtCoords, scrollAtCoords, typeText, pressKey, focusNode } from './input.js';
 import { emit } from '../events.js';
+import type { TargetFilter } from './types.js';
+
+/**
+ * Parse a `targetFilter` string into its kind + value, or return `null`
+ * when the input is missing or malformed. Filter syntax:
+ *   - `url:<substring>`   — picks the first page target whose URL contains the substring
+ *   - `title:<substring>` — picks the first page target whose title contains the substring
+ *
+ * The match is case-insensitive on both sides because Electron apps
+ * frequently lowercase or title-case their target metadata in unpredictable ways.
+ */
+export function parseTargetFilter(filter: string | undefined): TargetFilter | null {
+  if (!filter) return null;
+  const idx = filter.indexOf(':');
+  if (idx <= 0) return null;
+  const kind = filter.slice(0, idx).trim().toLowerCase();
+  const value = filter.slice(idx + 1);
+  if (kind !== 'url' && kind !== 'title') return null;
+  if (!value) return null;
+  return { kind, value };
+}
+
+/**
+ * URLs that the skip-invisible heuristic excludes when no explicit filter
+ * matches. These are page targets Electron apps ship for housekeeping;
+ * picking one means screenshots come back blank.
+ */
+const INVISIBLE_URL_PATTERNS: RegExp[] = [
+  /^about:blank$/i,
+  /^file:\/\//i,
+  /\/_desktop-background-service(\?|$|\/)/i,
+  /\/_internal(\?|$|\/)/i,
+  /\/_background(\?|$|\/)/i,
+];
+
+function isLikelyInvisible(url: string | undefined): boolean {
+  if (!url) return true;
+  return INVISIBLE_URL_PATTERNS.some((re) => re.test(url));
+}
+
+/**
+ * Choose the CDP page target that represents the visible UI.
+ *
+ * Order:
+ *   1. If `filter` is set and parseable, narrow to page targets matching it
+ *      (case-insensitive substring). Among matches, prefer one that is not in
+ *      `INVISIBLE_URL_PATTERNS` — this is the tiebreaker that makes a coarse
+ *      filter like `url:https://www.canva.com/` skip the background service
+ *      (`https://www.canva.com/_desktop-background-service` *also* matches the
+ *      substring). If every match is invisible, return the first match so the
+ *      caller still gets something rather than silently falling through.
+ *      An explicit filter that finds *no* match returns `undefined` — callers
+ *      should surface this as an error rather than create an orphan window.
+ *   2. If `filter` is unset (or unparseable), apply the skip-invisible heuristic
+ *      across all page targets.
+ *   3. As a last resort, return the first page target.
+ */
+export function pickWindowTarget<T extends { type: string; url?: string; title?: string }>(
+  targets: T[],
+  filter: string | undefined
+): T | undefined {
+  const pages = targets.filter((t) => t.type === 'page');
+  if (pages.length === 0) return undefined;
+
+  const parsed = parseTargetFilter(filter);
+  if (parsed) {
+    const needle = parsed.value.toLowerCase();
+    const matches = pages.filter((t) => {
+      const hay = (parsed.kind === 'url' ? t.url : t.title) ?? '';
+      return hay.toLowerCase().includes(needle);
+    });
+    if (matches.length === 0) return undefined;
+    const visible = matches.find((t) => !isLikelyInvisible(t.url));
+    return visible ?? matches[0];
+  }
+
+  const visible = pages.find((t) => !isLikelyInvisible(t.url));
+  if (visible) return visible;
+
+  return pages[0];
+}
 
 interface ProfileConnection {
   cdp: CDPClient;
   port: number;
   pid: number;
   electron?: boolean;
+  /** Raw `url:<v>` / `title:<v>` filter copied from the profile config. */
+  targetFilter?: string;
   forkedFrom?: string;
   tasks: Map<string, Task>;
   windowId?: string; // single window shared by all tasks
@@ -1092,6 +1175,7 @@ export class BrowserService {
       port,
       pid,
       electron: true,
+      targetFilter: profile.targetFilter,
       forkedFrom: profile.name,
       tasks: new Map(),
       sessionCache: new Map(),
@@ -1118,6 +1202,7 @@ export class BrowserService {
         port: existingInfo.port,
         pid: existingInfo.pid,
         electron: profile.electron,
+        targetFilter: profile.targetFilter,
         tasks,
         sessionCache: new Map(),
       };
@@ -1152,6 +1237,7 @@ export class BrowserService {
         port: conn.port,
         pid: conn.pid,
         electron: profile.electron,
+        targetFilter: profile.targetFilter,
         tasks: conn.pid === 0 ? this.loadTaskState(profile.name) : new Map(),
         sessionCache: new Map(),
       };
@@ -1165,6 +1251,7 @@ export class BrowserService {
         port: conn.port,
         pid: conn.pid,
         electron: profile.electron,
+        targetFilter: profile.targetFilter,
         tasks: new Map(),
         sessionCache: new Map(),
       };
@@ -1179,6 +1266,7 @@ export class BrowserService {
         port: 0,
         pid: 0,
         electron: profile.electron,
+        targetFilter: profile.targetFilter,
         tasks: this.loadTaskState(profile.name),
         sessionCache: new Map(),
       };
@@ -1196,6 +1284,7 @@ export class BrowserService {
         port,
         pid: 0,
         electron: profile.electron,
+        targetFilter: profile.targetFilter,
         tasks: this.loadTaskState(profile.name),
         sessionCache: new Map(),
       };
@@ -1213,7 +1302,7 @@ export class BrowserService {
     if (conn.windowId) {
       // Verify it still exists via CDP
       const { targetInfos } = (await conn.cdp.send('Target.getTargets')) as {
-        targetInfos: Array<{ targetId: string; type: string; url: string }>;
+        targetInfos: Array<{ targetId: string; type: string; url: string; title?: string }>;
       };
       if (targetInfos.some((t) => t.targetId === conn.windowId && t.type === 'page')) {
         return conn.windowId;
@@ -1223,12 +1312,28 @@ export class BrowserService {
 
     // Check if browser already has a page target we can use
     const { targetInfos } = (await conn.cdp.send('Target.getTargets')) as {
-      targetInfos: Array<{ targetId: string; type: string; url: string }>;
+      targetInfos: Array<{ targetId: string; type: string; url: string; title?: string }>;
     };
-    const existing = targetInfos.find((t) => t.type === 'page');
+    const existing = pickWindowTarget(targetInfos, conn.targetFilter);
     if (existing) {
       conn.windowId = existing.targetId;
       return existing.targetId;
+    }
+
+    // If we have an explicit filter, `pickWindowTarget` returns undefined when nothing
+    // matches. That almost always means the profile is misconfigured (typo in the
+    // filter, target hasn't loaded yet, app version moved the URL). Falling through
+    // to `Target.createTarget` would silently create an orphan tab the user can't see.
+    // Surface the failure instead, with the candidate list so the fix is obvious.
+    if (parseTargetFilter(conn.targetFilter)) {
+      const candidates = targetInfos
+        .filter((t) => t.type === 'page')
+        .map((t) => `  - url=${t.url} title=${t.title ?? ''}`)
+        .join('\n');
+      throw new Error(
+        `Target filter ${JSON.stringify(conn.targetFilter)} matched no page target.\n` +
+          `Available page targets:\n${candidates || '  (none)'}`
+      );
     }
 
     // First ever use - create window

--- a/src/lib/browser/service.ts
+++ b/src/lib/browser/service.ts
@@ -540,11 +540,34 @@ export class BrowserService {
 
     const sessionId = await this.getSessionId(conn, target.targetId);
 
+    // `awaitPromise: true` lets callers write `evaluate '(async () => {...})()'`
+    // and get the resolved value back instead of a stringified Promise. This
+    // is essential for any flow that needs sub-step waits inside the page
+    // (e.g. driving a multi-step modal where each step needs React to settle
+    // before the next call). Without it, the shell-side workaround is to
+    // chain N separate `evaluate` calls with `sleep` between them, which
+    // races against the page's own state machine.
+    //
+    // `exceptionDetails` is surfaced as a thrown error so a rejected promise
+    // or a thrown error inside the expression doesn't silently return `undefined`.
     const result = (await conn.cdp.send(
       'Runtime.evaluate',
-      { expression, returnByValue: true },
+      { expression, returnByValue: true, awaitPromise: true },
       sessionId
-    )) as { result: { value: unknown } };
+    )) as {
+      result: { value: unknown };
+      exceptionDetails?: { text?: string; exception?: { description?: string; value?: unknown } };
+    };
+
+    if (result.exceptionDetails) {
+      const ex = result.exceptionDetails;
+      const msg =
+        ex.exception?.description ??
+        (typeof ex.exception?.value === 'string' ? ex.exception.value : undefined) ??
+        ex.text ??
+        'evaluate failed';
+      throw new Error(msg);
+    }
 
     return result.result.value;
   }

--- a/src/lib/browser/types.ts
+++ b/src/lib/browser/types.ts
@@ -6,10 +6,21 @@ export interface BrowserProfile {
   browser: BrowserType;
   binary?: string;
   electron?: boolean;
+  /**
+   * `url:<substring>` or `title:<substring>`. Picks which CDP page target
+   * represents the visible UI for Electron apps with multiple WebContents.
+   */
+  targetFilter?: string;
   endpoints: string[];
   chrome?: ChromeOptions;
   secrets?: string;
   viewport?: { width: number; height: number; x?: number; y?: number };
+}
+
+/** Parsed form of `BrowserProfile.targetFilter`. */
+export interface TargetFilter {
+  kind: 'url' | 'title';
+  value: string;
 }
 
 export interface ChromeOptions {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -485,10 +485,11 @@ export interface BrowserProfileConfig {
   /**
    * Selects which CDP page target represents the visible UI when the
    * browser/app exposes more than one. Format: `url:<substring>` or
-   * `title:<substring>`. Required for Electron apps that ship hidden
+   * `title:<substring>`. Recommended for Electron apps that ship hidden
    * helper WebContents (background services, OAuth windows, file://
    * shells); without an explicit filter the connector falls back to a
    * skip-invisible heuristic before picking the first page target.
+   * Only consulted when `electron` is true.
    */
   targetFilter?: string;
   endpoints: string[];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -482,6 +482,15 @@ export interface BrowserProfileConfig {
   browser: 'chrome' | 'comet' | 'chromium' | 'brave' | 'edge' | 'custom';
   binary?: string;
   electron?: boolean;
+  /**
+   * Selects which CDP page target represents the visible UI when the
+   * browser/app exposes more than one. Format: `url:<substring>` or
+   * `title:<substring>`. Required for Electron apps that ship hidden
+   * helper WebContents (background services, OAuth windows, file://
+   * shells); without an explicit filter the connector falls back to a
+   * skip-invisible heuristic before picking the first page target.
+   */
+  targetFilter?: string;
   endpoints: string[];
   chrome?: {
     headless?: boolean;


### PR DESCRIPTION
## Summary

Drive Electron desktop apps (Canva, Slack, Notion, etc.) via `agents browser` without hand-editing `tasks.json` or writing custom CDP scripts.

`agents browser profiles create` gains three flags:

- `--electron` — mark profile as Electron; reuse existing window, never call `Target.createTarget` (most production Electron apps reject it)
- `--binary <path>` — required with `--browser custom`; absolute path to the app binary
- `--target-filter <expr>` — pick the visible CDP page target when the app exposes more than one. Format: `url:<substring>` or `title:<substring>`. Requires `--electron`.

This PR also bundles a small, related fix to `BrowserService.evaluate` (separate commit, see "Bundled change" below).

## Motivation

The original `getOrCreateWindow` did `targetInfos.find(t => t.type === 'page')` — first match wins. For Canva, that's `_desktop-background-service` (an invisible helper WebContents). Screenshots came back blank, and there was no way for the user to redirect the picker without editing the daemon's persisted state out-of-band — which `start` then clobbered on the next invocation.

Canva exposes three `page` targets:

1. `https://www.canva.com/_desktop-background-service` (invisible helper)
2. `https://www.canva.com/` (the visible Home UI)
3. `file:///Applications/Canva.app/.../index.dynamic_locale.html` (Electron shell)

Without an explicit filter the new skip-invisible heuristic walks past (1) and (3) to land on (2). With an explicit filter like `url:https://www.canva.com/`, substring match returns both (1) and (2); a tiebreaker prefers the non-invisible one.

## Picker logic (`pickWindowTarget`)

1. **Explicit filter:** match by substring (case-insensitive). Among matches, prefer non-invisible. Filter that finds no match throws with the candidate list instead of silently creating an orphan window.
2. **No filter:** apply skip-invisible heuristic across all page targets (`about:blank`, `file://`, `_desktop-background-service`, `_internal`, `_background`).
3. **Last resort:** first page target.

The helpers `parseTargetFilter` and `pickWindowTarget` are exported and unit-tested with a fixture captured live from `:9201/json` against the real Canva desktop app.

## Validation

CLI checks routed through `parseTargetFilter`, so the gate matches the runtime contract:

- `--browser custom` requires `--binary <path>`.
- `--target-filter` value must parse as `url:<non-empty>` or `title:<non-empty>` (leading/trailing whitespace stripped — copy-paste safe).
- `--target-filter` requires `--electron` (the filter is only consulted on Electron profiles; setting it without `--electron` used to silently save dead config).

## Bundled change — `BrowserService.evaluate`

Separate commit `18e11581 feat(browser): evaluate awaits promises and surfaces exceptions`. This is **not** Electron-specific — it affects every profile:

- Adds `awaitPromise: true` to `Runtime.evaluate`, so `evaluate '(async () => {...})()'` returns the resolved value instead of a stringified Promise.
- Surfaces `exceptionDetails` as a thrown `Error` (extracting `exception.description`, then a string-typed `exception.value`, then `text`, then `'evaluate failed'`). Previously a thrown error in the expression silently returned `undefined`.

Bundled here because it surfaced from the same Canva debugging session, but worth being explicit so reviewers know it's not Electron-only.

## Files

- `src/lib/types.ts` — `BrowserProfileConfig.targetFilter`
- `src/lib/browser/types.ts` — `BrowserProfile.targetFilter`, new `TargetFilter` type
- `src/lib/browser/profiles.ts` — round-trip `targetFilter` through YAML
- `src/lib/browser/service.ts` — `parseTargetFilter`, `pickWindowTarget`, `INVISIBLE_URL_PATTERNS`, plumb `targetFilter` to all 6 `ProfileConnection` creation sites, hardened `getOrCreateWindow` (throws on explicit-filter miss with candidate list), `evaluate` awaits promises and surfaces exceptions
- `src/commands/browser.ts` — add `custom` to `VALID_BROWSERS`, new flags on `profiles create`, validation routed through `parseTargetFilter`, new fields surfaced in `profiles show`
- `src/lib/browser/service.test.ts` — 15 unit tests for `parseTargetFilter` / `pickWindowTarget` (5 + 10)
- `src/lib/browser/profiles.test.ts` — round-trip tests for `electron` / `binary` / `targetFilter`
- `skills/browser/SKILL.md` — updated Electron section

## Test plan

- [x] `bun x tsc` — clean
- [x] Targeted vitest (`bun run test src/lib/browser/service.test.ts src/lib/browser/profiles.test.ts`) on Crabbox — 33 passed
- [x] Full suite (`bun run test`) on Crabbox — 1397 passed | 31 skipped | 0 failed
- [x] End-to-end smoke against real Canva desktop app: `profiles create canva --browser custom --binary /Applications/Canva.app/Contents/MacOS/Canva --electron --target-filter 'url:https://www.canva.com/'`, then `start` + `screenshot` — captured the real Home UI ("What will you design today?", full sidebar) without any manual `tasks.json` edits.

All test runs done remotely via Crabbox per repo `CLAUDE.md` "NEVER run tests locally" rule.

## Notes

- Backwards compatible: profiles without `electron`/`binary`/`targetFilter` continue to work exactly as before (skip-invisible heuristic only kicks in when `electron: true`).
- No session-transcript gist attached: the transcript contains a live secret that was pulled from another machine mid-session; publishing verbatim would leak it. Happy to provide a sanitized transcript on request.
