### PR TITLE
fix: suppress auto-update prompt in non-interactive environments (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**
+
+- Auto-update prompt no longer hangs in non-interactive environments (CI, k8s pods, cloud sandbox factories). The TTY check now requires both stdin and stdout to be terminals before prompting, and `AGENTS_CLI_DISABLE_AUTO_UPDATE=1` forces the check off entirely for headless deploys. ([#15](https://github.com/phnx-labs/agents-cli/issues/15))
+
 ## 1.17.1
 
 **Agent management**

--- a/README.md
+++ b/README.md
@@ -588,6 +588,8 @@ The installer tries Bun first (faster), falls back to npm. Node 18+ required at 
 
 Yes -- `agents run` is non-interactive by default. `--yes` auto-accepts prompts, `--json` for structured output. Pass explicit names and IDs instead of relying on interactive pickers.
 
+The auto-update prompt is suppressed automatically when stdin or stdout isn't a TTY. For headless environments where TTY detection misfires (k8s pods that allocate a PTY for stdout, cloud sandbox factories), set `AGENTS_CLI_DISABLE_AUTO_UPDATE=1` to skip the update check entirely -- no prompt, no network call.
+
 ### What happens to my config when I switch versions?
 
 Each version has its own isolated config directory. Switching just repoints a symlink — your per-version config stays untouched. On first migration (if you had a real `~/.claude/` directory before using agents-cli), that gets backed up once to `~/.agents-system/backups/`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ import { registerUsageCommand } from './commands/usage.js';
 import { registerAliasCommand } from './commands/alias.js';
 import { registerBetaCommands } from './commands/beta.js';
 import { applyGlobalHelpConventions } from './lib/help.js';
-import { isPromptCancelled } from './commands/utils.js';
+import { isInteractiveTerminal, isPromptCancelled } from './commands/utils.js';
 import { getAgentsDir } from './lib/state.js';
 import { AGENTS } from './lib/agents.js';
 import { getGlobalDefault, listInstalledVersions } from './lib/versions.js';
@@ -263,7 +263,7 @@ function saveUpdateCheck(latestVersion: string): void {
 
 /** Present an interactive upgrade prompt (TTY) or a one-line hint (non-TTY). */
 async function promptUpgrade(latestVersion: string): Promise<void> {
-  if (!process.stdout.isTTY) {
+  if (!isInteractiveTerminal()) {
     console.error(chalk.yellow(`Update available: ${VERSION} -> ${latestVersion}. Run: npm install -g @phnx-labs/agents-cli@latest`));
     return;
   }
@@ -334,6 +334,8 @@ function refreshUpdateCacheInBackground(): void {
 
 /** Check for available updates using the local cache. Triggers a background refresh if stale. */
 async function checkForUpdates(): Promise<void> {
+  if (process.env.AGENTS_CLI_DISABLE_AUTO_UPDATE) return;
+
   const cache = readUpdateCache();
 
   // Kick off network refresh in background if stale. Does not block.

--- a/tests/non-interactive.test.ts
+++ b/tests/non-interactive.test.ts
@@ -76,16 +76,26 @@ function writeLocalPackageRepo(): string {
   return repo;
 }
 
-function runAgents(home: string, args: string[]) {
+function runAgents(home: string, args: string[], extraEnv: Record<string, string> = {}) {
   return spawnSync('node', ['--import', 'tsx', 'src/index.ts', ...args], {
     cwd: REPO_ROOT,
     env: {
       ...process.env,
       HOME: home,
       SHELL: '/bin/zsh',
+      ...extraEnv,
     },
     encoding: 'utf-8',
   });
+}
+
+function seedNewerUpdateCache(home: string, futureVersion: string): void {
+  const cacheDir = path.join(home, '.agents', '.cache');
+  fs.mkdirSync(cacheDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(cacheDir, '.update-check'),
+    JSON.stringify({ lastCheck: Date.now(), latestVersion: futureVersion }),
+  );
 }
 
 const tempHomes: string[] = [];
@@ -282,5 +292,28 @@ describe('non-interactive CLI usage', () => {
     expect(log).toContain(path.join(home, '.agents', '.history', 'versions', 'codex', '0.2.0', 'home'));
     expect(log).toContain('mcp remove demo');
     expect(log).not.toContain(path.join(home, '.agents', '.history', 'versions', 'codex', '0.1.0', 'home'));
+  });
+
+  it('AGENTS_CLI_DISABLE_AUTO_UPDATE skips the update check when a newer version is cached', () => {
+    const home = makeTempHome();
+    tempHomes.push(home);
+    seedNewerUpdateCache(home, '99.0.0');
+
+    const result = runAgents(home, ['view'], { AGENTS_CLI_DISABLE_AUTO_UPDATE: '1' });
+    const combined = `${result.stdout}\n${result.stderr}`;
+
+    expect(combined).not.toContain('Update available');
+  });
+
+  it('prints the non-TTY hint (not an interactive picker) when a newer version is cached', () => {
+    const home = makeTempHome();
+    tempHomes.push(home);
+    seedNewerUpdateCache(home, '99.0.0');
+
+    const result = runAgents(home, ['view']);
+    const combined = `${result.stdout}\n${result.stderr}`;
+
+    expect(combined).toContain(`Update available: ${PACKAGE_VERSION.version} -> 99.0.0`);
+    expect(combined).not.toContain('Upgrade now');
   });
 });


### PR DESCRIPTION
## Summary

- Tighten the auto-update TTY guard to require both stdin and stdout to be terminals (the previous `!process.stdout.isTTY` check passed in k8s pods that allocate a PTY for stdout only, and the prompt hung)
- Add `AGENTS_CLI_DISABLE_AUTO_UPDATE=1` as an explicit opt-out — skips both the prompt and the background registry refresh, for cloud sandbox factories and other headless deploys
- Document the env var in `README.md` (the "Can I use it in CI?" section) and add a `CHANGELOG.md` Unreleased entry

Closes [#15](https://github.com/phnx-labs/agents-cli/issues/15).

## Files

- `src/index.ts` — import `isInteractiveTerminal`; early-return in `checkForUpdates()` when `AGENTS_CLI_DISABLE_AUTO_UPDATE` is set; swap the predicate in `promptUpgrade()`
- `tests/non-interactive.test.ts` — two new cases (env-var suppresses, non-TTY hint prints instead of picker)
- `README.md`, `CHANGELOG.md` — docs

## Test plan

- [x] `node ./node_modules/vitest/vitest.mjs run tests/non-interactive.test.ts` — 9/9 pass (the two new ones included)
- [x] End-to-end against the built `dist/index.js` with a temp `HOME` seeded with `latestVersion: 99.0.0`:
  - No env var, stdin `</dev/null` → prints yellow one-liner, no picker
  - `AGENTS_CLI_DISABLE_AUTO_UPDATE=1` → no "Update available" output at all
- [ ] Repro the docker repro from the issue and confirm it returns instead of hanging (reviewers can run the `docker run` block from the issue against this branch)

## Session Context

[Session transcript](https://gist.github.com/muqsitnawaz/f5a664023f50b44edf261b01a605e27b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
