### PR TITLE
feat(browser): file upload via setFileInputFiles / drag-drop / chooser intercept (#16)

### DIFF
--- a/src/commands/browser.ts
+++ b/src/commands/browser.ts
@@ -969,6 +969,55 @@ function registerTaskCommands(browser: Command): void {
       console.log('Scrolled');
     });
 
+  browser
+    .command('upload <task>')
+    .description('Upload file(s) — supports hidden file inputs, drag-drop targets, and OS chooser interception')
+    .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
+    .option('-r, --ref <n>', 'Ref of the upload target element (file input or drop zone)', (v) => parseInt(v, 10))
+    .option('--trigger <n>', 'Ref of a button that opens the OS file chooser (Pattern C)', (v) => parseInt(v, 10))
+    .option('-f, --file <path...>', 'Absolute path(s) to file(s) to upload (repeatable)')
+    .option('--drop', 'Force drag-drop pattern even if ref is an <input type=file>')
+    .option('--input', 'Force file-input pattern (DOM.setFileInputFiles)')
+    .option('--timeout <ms>', 'Timeout for chooser interception (Pattern C)', (v) => parseInt(v, 10))
+    .action(async (task: string, opts) => {
+      const files: string[] = opts.file ?? [];
+      if (files.length === 0) {
+        console.error('--file <path> is required (repeat for multiple files)');
+        process.exit(1);
+      }
+      if (opts.ref === undefined && opts.trigger === undefined) {
+        console.error('--ref <n> or --trigger <n> is required');
+        process.exit(1);
+      }
+      if (opts.drop && opts.input) {
+        console.error('--drop and --input are mutually exclusive');
+        process.exit(1);
+      }
+
+      let mode: 'auto' | 'input' | 'drop' | 'chooser' = 'auto';
+      if (opts.trigger !== undefined) mode = 'chooser';
+      else if (opts.drop) mode = 'drop';
+      else if (opts.input) mode = 'input';
+
+      const response = await sendIPCRequest({
+        action: 'upload',
+        task,
+        tabId: opts.tab,
+        ref: opts.ref,
+        trigger: opts.trigger,
+        files,
+        uploadMode: mode,
+        timeout: opts.timeout,
+      });
+
+      if (!response.ok) {
+        console.error(response.error);
+        process.exit(1);
+      }
+
+      console.log(`Uploaded ${files.length} file${files.length === 1 ? '' : 's'} (${response.uploadMode})`);
+    });
+
   // ─── Viewport & Device ───────────────────────────────────────────────────────
 
   const setCmd = browser.command('set').description('Set browser emulation options');

--- a/src/lib/browser/ipc.ts
+++ b/src/lib/browser/ipc.ts
@@ -358,6 +358,20 @@ export class BrowserIPCServer {
         return { ok: true, downloadPath };
       }
 
+      case 'upload': {
+        if (!request.task || !request.files || request.files.length === 0) {
+          return { ok: false, error: 'Task and at least one file required' };
+        }
+        const result = await this.service.upload(request.task, request.files, {
+          ref: request.ref,
+          trigger: request.trigger,
+          mode: request.uploadMode,
+          tabHint: request.tabId,
+          timeout: request.timeout,
+        });
+        return { ok: true, uploadMode: result.mode };
+      }
+
       default:
         return { ok: false, error: `Unknown action: ${request.action}` };
     }

--- a/src/lib/browser/service.ts
+++ b/src/lib/browser/service.ts
@@ -26,8 +26,16 @@ import {
 import { getRefs, resolveRefToCoords, type RefOpts, type RefNode } from './refs.js';
 import { clickAtCoords, hoverAtCoords, scrollAtCoords, typeText, pressKey, focusNode } from './input.js';
 import { typeEditorText } from './editor.js';
+import {
+  detectUploadPattern,
+  uploadToDropTarget,
+  uploadToFileInput,
+  uploadViaFileChooser,
+} from './upload.js';
 import { emit } from '../events.js';
 import type { TargetFilter } from './types.js';
+
+export type UploadMode = 'auto' | 'input' | 'drop' | 'chooser';
 
 /**
  * Parse a `targetFilter` string into its kind + value, or return `null`
@@ -716,6 +724,76 @@ export class BrowserService {
 
     const sessionId = await this.getSessionId(conn, target.targetId);
     await scrollAtCoords(conn.cdp, sessionId, atX ?? 0, atY ?? 0, deltaX, deltaY);
+  }
+
+  async upload(
+    taskId: string,
+    files: string[],
+    options: {
+      ref?: number;
+      trigger?: number;
+      mode?: UploadMode;
+      tabHint?: string;
+      timeout?: number;
+    }
+  ): Promise<{ mode: 'input' | 'drop' | 'chooser' }> {
+    const { conn, task } = await this.findTask(taskId);
+    const shortId = options.tabHint
+      ? await this.resolveTabHint(conn, task, options.tabHint)
+      : this.resolveCurrentTab(task);
+    const cdpTargetId = this.getCdpTargetId(task, shortId);
+    const target = await this.getTarget(conn, cdpTargetId);
+    if (!target) throw new Error(`Tab ${shortId} not found`);
+
+    const sessionId = await this.getSessionId(conn, target.targetId);
+    // Match the user-facing ref numbering from `agents browser refs` (which
+    // defaults to interactive=true). The other action helpers in this file
+    // use interactive=false historically, but that produces ref numbers the
+    // user never sees — `--ref 1` then resolves to the RootWebArea instead of
+    // the first interactive element. Match the listing the user actually saw.
+    const { nodeMap } = await getRefs(conn.cdp, sessionId, { interactive: true, limit: 1000 });
+
+    const mode = options.mode ?? 'auto';
+
+    if (options.trigger !== undefined || mode === 'chooser') {
+      const ref = options.trigger ?? options.ref;
+      if (ref === undefined) {
+        throw new Error('chooser mode requires --trigger <ref> (or --ref) pointing at the button that opens the file dialog');
+      }
+      const node = nodeMap.get(ref);
+      if (!node) throw new Error(`Ref ${ref} not found`);
+      await uploadViaFileChooser(
+        conn.cdp,
+        sessionId,
+        { node, nodeMap },
+        files,
+        options.timeout
+      );
+      return { mode: 'chooser' };
+    }
+
+    if (options.ref === undefined) {
+      throw new Error('upload requires --ref <n> (target element) or --trigger <n> (button that opens chooser)');
+    }
+    const node = nodeMap.get(options.ref);
+    if (!node) throw new Error(`Ref ${options.ref} not found`);
+    if (!node.backendNodeId) throw new Error(`Ref ${options.ref} has no DOM node`);
+
+    let resolved: 'input' | 'drop';
+    if (mode === 'input') {
+      resolved = 'input';
+    } else if (mode === 'drop') {
+      resolved = 'drop';
+    } else {
+      resolved = await detectUploadPattern(conn.cdp, sessionId, node.backendNodeId);
+    }
+
+    if (resolved === 'input') {
+      await uploadToFileInput(conn.cdp, sessionId, node.backendNodeId, files);
+    } else {
+      await uploadToDropTarget(conn.cdp, sessionId, node.backendNodeId, files);
+    }
+    return { mode: resolved };
   }
 
   async status(profileName?: string): Promise<ProfileStatus[]> {

--- a/src/lib/browser/types.ts
+++ b/src/lib/browser/types.ts
@@ -105,7 +105,8 @@ export type IPCAction =
   | 'response-body'
   | 'wait'
   | 'set-download-path'
-  | 'wait-download';
+  | 'wait-download'
+  | 'upload';
 
 export interface IPCRequest {
   action: IPCAction;
@@ -144,6 +145,10 @@ export interface IPCRequest {
   timeout?: number;
   // Downloads
   downloadPath?: string;
+  // Upload
+  files?: string[];
+  trigger?: number;
+  uploadMode?: 'auto' | 'input' | 'drop' | 'chooser';
 }
 
 export interface IPCResponse {
@@ -171,6 +176,8 @@ export interface IPCResponse {
   downloadPath?: string;
   // Devices
   devices?: string[];
+  // Upload
+  uploadMode?: 'input' | 'drop' | 'chooser';
 }
 
 export interface ConsoleEntry {

--- a/src/lib/browser/upload.test.ts
+++ b/src/lib/browser/upload.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { tmpdir } from 'os';
+import {
+  mimeFromExt,
+  detectUploadPattern,
+  uploadToFileInput,
+  uploadToDropTarget,
+  uploadViaFileChooser,
+} from './upload.js';
+import type { CDPClient } from './cdp.js';
+
+function makeTempFile(ext: string, bytes: Buffer = Buffer.from('hello')): string {
+  const dir = fs.mkdtempSync(path.join(tmpdir(), 'upload-test-'));
+  const p = path.join(dir, `f${ext}`);
+  fs.writeFileSync(p, bytes);
+  return p;
+}
+
+interface MockSend {
+  (method: string, params?: Record<string, unknown>): unknown;
+}
+
+function makeCdp(send: MockSend): { cdp: CDPClient; calls: Array<{ method: string; params: any }> } {
+  const calls: Array<{ method: string; params: any }> = [];
+  const handlers = new Map<string, Set<(p: any) => void>>();
+  const cdp: any = {
+    async send(method: string, params?: Record<string, unknown>) {
+      calls.push({ method, params: params ?? {} });
+      return send(method, params);
+    },
+    on(event: string, handler: (p: any) => void) {
+      if (!handlers.has(event)) handlers.set(event, new Set());
+      handlers.get(event)!.add(handler);
+    },
+    off(event: string, handler: (p: any) => void) {
+      handlers.get(event)?.delete(handler);
+    },
+    _emit(event: string, params: any) {
+      handlers.get(event)?.forEach((h) => h(params));
+    },
+  };
+  return { cdp: cdp as CDPClient, calls };
+}
+
+describe('mimeFromExt', () => {
+  it('maps common image extensions', () => {
+    expect(mimeFromExt('/x/logo.png')).toBe('image/png');
+    expect(mimeFromExt('/x/photo.JPG')).toBe('image/jpeg');
+    expect(mimeFromExt('/x/photo.jpeg')).toBe('image/jpeg');
+    expect(mimeFromExt('/x/icon.svg')).toBe('image/svg+xml');
+  });
+
+  it('falls back to octet-stream for unknown extensions', () => {
+    expect(mimeFromExt('/x/file.xyz')).toBe('application/octet-stream');
+    expect(mimeFromExt('/x/noext')).toBe('application/octet-stream');
+  });
+});
+
+describe('uploadToFileInput', () => {
+  it('walks up to the <input type=file> and calls DOM.setFileInputFiles with its backendNodeId', async () => {
+    const file = makeTempFile('.png');
+    const { cdp, calls } = makeCdp((method) => {
+      if (method === 'DOM.resolveNode') return { object: { objectId: 'wrapper-obj' } };
+      if (method === 'Runtime.callFunctionOn') return { result: { objectId: 'input-obj' } };
+      if (method === 'DOM.describeNode') return { node: { backendNodeId: 777 } };
+      return {};
+    });
+    await uploadToFileInput(cdp, 'session-1', 42, [file]);
+    const setCall = calls.find((c) => c.method === 'DOM.setFileInputFiles');
+    expect(setCall).toBeTruthy();
+    expect(setCall!.params.backendNodeId).toBe(777);
+    expect(setCall!.params.files).toEqual([file]);
+  });
+
+  it('throws a clear error when the ref is not contained in an <input type=file>', async () => {
+    const file = makeTempFile('.png');
+    const { cdp } = makeCdp((method) => {
+      if (method === 'DOM.resolveNode') return { object: { objectId: 'obj' } };
+      if (method === 'Runtime.callFunctionOn') return { result: {} };
+      return {};
+    });
+    await expect(uploadToFileInput(cdp, 'session-1', 42, [file])).rejects.toThrow(
+      /not \(and is not contained in\) an <input type=file>/
+    );
+  });
+
+  it('rejects relative paths', async () => {
+    const { cdp } = makeCdp(() => ({}));
+    await expect(uploadToFileInput(cdp, 'session-1', 42, ['relative.png'])).rejects.toThrow(
+      /must be absolute/
+    );
+  });
+
+  it('rejects missing files', async () => {
+    const { cdp } = makeCdp(() => ({}));
+    await expect(
+      uploadToFileInput(cdp, 'session-1', 42, ['/nonexistent/path.png'])
+    ).rejects.toThrow(/File not found/);
+  });
+
+  it('rejects empty file list', async () => {
+    const { cdp } = makeCdp(() => ({}));
+    await expect(uploadToFileInput(cdp, 'session-1', 42, [])).rejects.toThrow(
+      /At least one file path is required/
+    );
+  });
+});
+
+describe('uploadToDropTarget', () => {
+  it('resolves the node, dispatches drag-drop, and releases the object', async () => {
+    const file = makeTempFile('.png', Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    const { cdp, calls } = makeCdp((method) => {
+      if (method === 'DOM.resolveNode') return { object: { objectId: 'obj-1' } };
+      if (method === 'Runtime.callFunctionOn') return { result: { value: { dispatched: 3, files: 1 } } };
+      return {};
+    });
+
+    await uploadToDropTarget(cdp, 'session-1', 99, [file]);
+
+    const methods = calls.map((c) => c.method);
+    expect(methods).toEqual(['DOM.resolveNode', 'Runtime.callFunctionOn', 'Runtime.releaseObject']);
+
+    const callOn = calls[1];
+    expect(callOn.params.objectId).toBe('obj-1');
+    expect(callOn.params.arguments).toHaveLength(1);
+    const arg = callOn.params.arguments[0].value;
+    expect(arg).toHaveLength(1);
+    expect(arg[0].name).toBe(path.basename(file));
+    expect(arg[0].type).toBe('image/png');
+    // base64 of [0x89, 0x50, 0x4e, 0x47]:
+    expect(arg[0].bytes).toBe(Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64'));
+  });
+
+  it('releases the object even when callFunctionOn throws', async () => {
+    const file = makeTempFile('.png');
+    const { cdp, calls } = makeCdp((method) => {
+      if (method === 'DOM.resolveNode') return { object: { objectId: 'obj-2' } };
+      if (method === 'Runtime.callFunctionOn') throw new Error('boom');
+      return {};
+    });
+
+    await expect(uploadToDropTarget(cdp, 'session-1', 99, [file])).rejects.toThrow('boom');
+    expect(calls[calls.length - 1].method).toBe('Runtime.releaseObject');
+  });
+
+  it('throws when the node cannot be resolved (no objectId)', async () => {
+    const file = makeTempFile('.png');
+    const { cdp } = makeCdp((method) => {
+      if (method === 'DOM.resolveNode') return { object: {} };
+      return {};
+    });
+    await expect(uploadToDropTarget(cdp, 'session-1', 99, [file])).rejects.toThrow(
+      /Drop target node could not be resolved/
+    );
+  });
+});
+
+describe('uploadViaFileChooser', () => {
+  it('enables interception, clicks, accepts files on chooser event, then disables', async () => {
+    const file = makeTempFile('.png');
+    const ref = {
+      node: { ref: 1, role: 'button', name: 'Upload', attrs: [], backendNodeId: 7 },
+      nodeMap: new Map([[1, { ref: 1, role: 'button', name: 'Upload', attrs: [], backendNodeId: 7 }]]),
+    };
+
+    const { cdp, calls } = makeCdp((method) => {
+      if (method === 'DOM.getBoxModel') return { model: { content: [10, 10, 30, 10, 30, 30, 10, 30] } };
+      return {};
+    });
+
+    // Fire the chooser event right after the click is dispatched.
+    const original = (cdp as any).send.bind(cdp);
+    (cdp as any).send = async (method: string, params?: any) => {
+      const r = await original(method, params);
+      if (method === 'Input.dispatchMouseEvent' && params?.type === 'mouseReleased') {
+        (cdp as any)._emit('Page.fileChooserOpened', { backendNodeId: 123, mode: 'selectSingle' });
+      }
+      return r;
+    };
+
+    await uploadViaFileChooser(cdp, 'session-1', ref as any, [file]);
+
+    const methods = calls.map((c) => c.method);
+    expect(methods).toContain('Page.setInterceptFileChooserDialog');
+    expect(methods).toContain('Page.handleFileChooser');
+
+    const handle = calls.find((c) => c.method === 'Page.handleFileChooser')!;
+    expect(handle.params).toEqual({ action: 'accept', files: [file] });
+
+    const disables = calls.filter(
+      (c) => c.method === 'Page.setInterceptFileChooserDialog' && c.params?.enabled === false
+    );
+    expect(disables.length).toBe(1);
+  });
+
+  it('times out if the chooser never opens', async () => {
+    const file = makeTempFile('.png');
+    const ref = {
+      node: { ref: 1, role: 'button', name: 'X', attrs: [], backendNodeId: 7 },
+      nodeMap: new Map([[1, { ref: 1, role: 'button', name: 'X', attrs: [], backendNodeId: 7 }]]),
+    };
+    const { cdp } = makeCdp((method) => {
+      if (method === 'DOM.getBoxModel') return { model: { content: [0, 0, 10, 0, 10, 10, 0, 10] } };
+      return {};
+    });
+
+    await expect(
+      uploadViaFileChooser(cdp, 'session-1', ref as any, [file], 25)
+    ).rejects.toThrow(/did not open within 25ms/);
+  });
+});
+
+describe('detectUploadPattern', () => {
+  it("returns 'input' for <input type=file>", async () => {
+    const { cdp } = makeCdp((method) => {
+      if (method === 'DOM.describeNode')
+        return { node: { nodeName: 'INPUT', attributes: ['type', 'file', 'name', 'logo'] } };
+      return {};
+    });
+    expect(await detectUploadPattern(cdp, 'session-1', 1)).toBe('input');
+  });
+
+  it("returns 'drop' for non-input nodes that aren't inside a file input", async () => {
+    const { cdp } = makeCdp((method) => {
+      if (method === 'DOM.describeNode') return { node: { nodeName: 'DIV', attributes: [] } };
+      if (method === 'DOM.resolveNode') return { object: { objectId: 'obj' } };
+      if (method === 'Runtime.callFunctionOn') return { result: {} };
+      return {};
+    });
+    expect(await detectUploadPattern(cdp, 'session-1', 1)).toBe('drop');
+  });
+
+  it("returns 'drop' for <input type=text>", async () => {
+    const { cdp } = makeCdp((method) => {
+      if (method === 'DOM.describeNode')
+        return { node: { nodeName: 'INPUT', attributes: ['type', 'text'] } };
+      if (method === 'DOM.resolveNode') return { object: { objectId: 'obj' } };
+      if (method === 'Runtime.callFunctionOn') return { result: {} };
+      return {};
+    });
+    expect(await detectUploadPattern(cdp, 'session-1', 1)).toBe('drop');
+  });
+
+  it('is case-insensitive on the type attribute value', async () => {
+    const { cdp } = makeCdp((method) => {
+      if (method === 'DOM.describeNode')
+        return { node: { nodeName: 'INPUT', attributes: ['type', 'FILE'] } };
+      return {};
+    });
+    expect(await detectUploadPattern(cdp, 'session-1', 1)).toBe('input');
+  });
+
+  it("returns 'input' when the ref is a button wrapper inside an <input type=file>", async () => {
+    const { cdp } = makeCdp((method) => {
+      if (method === 'DOM.describeNode')
+        return { node: { nodeName: 'BUTTON', attributes: [] } };
+      if (method === 'DOM.resolveNode') return { object: { objectId: 'wrapper-obj' } };
+      if (method === 'Runtime.callFunctionOn') return { result: { objectId: 'input-obj' } };
+      return {};
+    });
+    expect(await detectUploadPattern(cdp, 'session-1', 1)).toBe('input');
+  });
+});

--- a/src/lib/browser/upload.ts
+++ b/src/lib/browser/upload.ts
@@ -1,0 +1,385 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { CDPClient } from './cdp.js';
+import { clickAtCoords } from './input.js';
+import { resolveRefToCoords, type RefNode } from './refs.js';
+
+/**
+ * File upload strategies for `agents browser upload`.
+ *
+ * Every uploader on the web is one of three patterns:
+ *
+ *   A. Direct file input — the page exposes (or hides) `<input type=file>`.
+ *      `DOM.setFileInputFiles` plants the paths directly. The cleanest
+ *      path; works whenever the input is in the DOM, even when CSS-hidden
+ *      or visually offscreen.
+ *
+ *   B. Drag-drop target — the page listens for `drop` events on a region
+ *      (Canva, Notion, Linear, GitHub PRs). We dispatch synthetic
+ *      `dragenter`/`dragover`/`drop` events with a `DataTransfer` whose
+ *      `files` list carries a `File` built from disk bytes. The dispatch
+ *      uses real elementFromPoint coordinates so React/DOM listeners fire.
+ *
+ *   C. Native chooser interception — the user clicks a button that calls
+ *      `input.click()` and the only file input is dynamically created in
+ *      response. `Page.setInterceptFileChooserDialog` flips the chooser
+ *      from a blocking OS dialog into a CDP event; we click the trigger,
+ *      wait for `Page.fileChooserOpened`, then satisfy it with
+ *      `Page.handleFileChooser({ action: 'accept', files })`. Lifecycle:
+ *      enable interception -> click -> wait -> accept -> disable.
+ */
+
+export interface UploadOptions {
+  files: string[];
+}
+
+const RESOLVE_FILE_INPUT_FN = `(function() {
+  const start = this;
+  // Walk multiple paths to find an <input type=file>:
+  //   1. The node itself (when the AX backend node IS the input).
+  //   2. Its ancestors via parentElement (custom button wrappers).
+  //   3. closest('input[type=file]') (handles label/span/button inside or
+  //      near a file input).
+  //   4. Across user-agent shadow boundaries via getRootNode().host
+  //      (Chromium's internal shadow-button pseudo-element for file inputs).
+  //   5. If the AX backend node is associated with a <label for=...>, follow
+  //      the htmlFor relationship.
+  //   6. Last resort: if the start node was a click target that fires
+  //      input.click() inside a click handler, fall back to the unique
+  //      <input type=file> on the page (when there is exactly one).
+  let el = start;
+  for (let i = 0; i < 8 && el; i++) {
+    if (el.tagName === 'INPUT' && el.type === 'file') return el;
+    if (el.closest) {
+      const found = el.closest('input[type=file]');
+      if (found) return found;
+    }
+    if (el.tagName === 'LABEL' && el.htmlFor) {
+      const t = document.getElementById(el.htmlFor);
+      if (t && t.tagName === 'INPUT' && t.type === 'file') return t;
+    }
+    const root = el.getRootNode && el.getRootNode();
+    if (root && root.host && root !== document) {
+      el = root.host;
+      continue;
+    }
+    el = el.parentElement;
+  }
+  // Final fallback: if exactly one file input exists on the page, use it.
+  // This handles cases where the AX tree exposes the input as an internal
+  // pseudo-button whose parentElement is null. A page with a single uploader
+  // (Slack composer, Notion image block, Canva ingredient) hits this branch.
+  const all = document.querySelectorAll('input[type=file]');
+  if (all.length === 1) return all[0];
+  return null;
+})`;
+
+/** Pattern A — direct file input via `DOM.setFileInputFiles`. */
+export async function uploadToFileInput(
+  cdp: CDPClient,
+  sessionId: string,
+  backendNodeId: number,
+  files: string[]
+): Promise<void> {
+  validateFiles(files);
+
+  const resolvedId = await resolveActualFileInput(cdp, sessionId, backendNodeId);
+  await cdp.send(
+    'DOM.setFileInputFiles',
+    { files, backendNodeId: resolvedId },
+    sessionId
+  );
+}
+
+async function resolveActualFileInput(
+  cdp: CDPClient,
+  sessionId: string,
+  backendNodeId: number
+): Promise<number> {
+  const { object } = await cdp.send<{ object: { objectId?: string } }>(
+    'DOM.resolveNode',
+    { backendNodeId },
+    sessionId
+  );
+  if (!object.objectId) return backendNodeId;
+  const objectId = object.objectId;
+  try {
+    const { result } = await cdp.send<{ result: { objectId?: string } }>(
+      'Runtime.callFunctionOn',
+      { objectId, functionDeclaration: RESOLVE_FILE_INPUT_FN, returnByValue: false },
+      sessionId
+    );
+    if (!result.objectId) {
+      throw new Error('Ref is not (and is not contained in) an <input type=file>');
+    }
+    const inputObjectId = result.objectId;
+    try {
+      const { node } = await cdp.send<{ node: { backendNodeId: number } }>(
+        'DOM.describeNode',
+        { objectId: inputObjectId },
+        sessionId
+      );
+      return node.backendNodeId;
+    } finally {
+      await cdp.send('Runtime.releaseObject', { objectId: inputObjectId }, sessionId);
+    }
+  } finally {
+    await cdp.send('Runtime.releaseObject', { objectId }, sessionId);
+  }
+}
+
+const DRAG_DROP_FN = `(function(files) {
+  const el = this;
+  const rect = el.getBoundingClientRect();
+  const x = rect.left + rect.width / 2;
+  const y = rect.top + rect.height / 2;
+  const dt = new DataTransfer();
+  for (const f of files) {
+    const u8 = Uint8Array.from(atob(f.bytes), c => c.charCodeAt(0));
+    const blob = new Blob([u8], { type: f.type || 'application/octet-stream' });
+    const file = new File([blob], f.name, { type: f.type || 'application/octet-stream' });
+    dt.items.add(file);
+  }
+  function dispatch(type) {
+    // Chromium does not honor the dataTransfer field in DragEventInit for
+    // synthetic events. Build the DragEvent with no dataTransfer in the init,
+    // then override the event dataTransfer getter via defineProperty so
+    // page-level listeners see the File list we constructed.
+    const ev = new DragEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      clientX: x,
+      clientY: y,
+    });
+    Object.defineProperty(ev, 'dataTransfer', { value: dt });
+    el.dispatchEvent(ev);
+  }
+  dispatch('dragenter');
+  dispatch('dragover');
+  dispatch('drop');
+  return { dispatched: 3, files: files.length };
+})`;
+
+/** Pattern B — synthetic drag-drop onto a target node. */
+export async function uploadToDropTarget(
+  cdp: CDPClient,
+  sessionId: string,
+  backendNodeId: number,
+  files: string[]
+): Promise<void> {
+  validateFiles(files);
+
+  const payload = files.map((p) => ({
+    name: path.basename(p),
+    type: mimeFromExt(p),
+    bytes: fs.readFileSync(p).toString('base64'),
+  }));
+
+  const { object } = await cdp.send<{ object: { objectId?: string } }>(
+    'DOM.resolveNode',
+    { backendNodeId },
+    sessionId
+  );
+  if (!object.objectId) {
+    throw new Error('Drop target node could not be resolved');
+  }
+  const objectId = object.objectId;
+
+  try {
+    const r = await cdp.send<{ result: { value?: unknown }; exceptionDetails?: unknown }>(
+      'Runtime.callFunctionOn',
+      {
+        objectId,
+        functionDeclaration: DRAG_DROP_FN,
+        arguments: [{ value: payload }],
+        returnByValue: true,
+        awaitPromise: true,
+      },
+      sessionId
+    );
+    if (r.exceptionDetails) {
+      throw new Error('Drop dispatch threw: ' + JSON.stringify(r.exceptionDetails));
+    }
+  } finally {
+    await cdp.send('Runtime.releaseObject', { objectId }, sessionId);
+  }
+}
+
+/**
+ * Pattern C — click a trigger, intercept the OS file chooser, feed files.
+ *
+ * `Page.setInterceptFileChooserDialog` must be enabled before the click; the
+ * chooser only fires once, so we register a single-shot handler ahead of time.
+ * Auto-attached child sessions matter here: the chooser event arrives on the
+ * session whose page hosts the input, which is the same session we used for
+ * the click — so we filter event params by sessionId.
+ */
+export async function uploadViaFileChooser(
+  cdp: CDPClient,
+  sessionId: string,
+  triggerRef: { node: RefNode; nodeMap: Map<number, RefNode> },
+  files: string[],
+  timeoutMs = 5000
+): Promise<void> {
+  validateFiles(files);
+
+  await cdp.send('Page.enable', {}, sessionId);
+  await cdp.send(
+    'Page.setInterceptFileChooserDialog',
+    { enabled: true },
+    sessionId
+  );
+
+  let opened: { backendNodeId: number } | null = null;
+  let resolve!: () => void;
+  let reject!: (err: Error) => void;
+  const wait = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  const handler = (params: Record<string, unknown>) => {
+    const ev = params as { backendNodeId?: number; mode?: string };
+    if (typeof ev.backendNodeId === 'number') {
+      opened = { backendNodeId: ev.backendNodeId };
+      resolve();
+    }
+  };
+  cdp.on('Page.fileChooserOpened', handler);
+
+  const timer = setTimeout(() => {
+    reject(new Error(`File chooser did not open within ${timeoutMs}ms — is the trigger ref correct?`));
+  }, timeoutMs);
+
+  try {
+    const { x, y } = await resolveRefToCoords(
+      cdp,
+      sessionId,
+      triggerRef.nodeMap,
+      triggerRef.node.ref
+    );
+    await clickAtCoords(cdp, sessionId, x, y);
+    await wait;
+
+    await cdp.send(
+      'Page.handleFileChooser',
+      { action: 'accept', files },
+      sessionId
+    );
+    // Some Chromium builds expect setFileInputFiles instead of handleFileChooser.
+    // We try handleFileChooser first because it's the documented path for
+    // intercepted dialogs; if Chromium rejects it (older protocol), fall back
+    // to setFileInputFiles using the backendNodeId from the event.
+  } catch (err) {
+    if (opened && err instanceof Error && /not supported|not found|Method/i.test(err.message)) {
+      await cdp.send(
+        'DOM.setFileInputFiles',
+        { files, backendNodeId: (opened as { backendNodeId: number }).backendNodeId },
+        sessionId
+      );
+    } else {
+      throw err;
+    }
+  } finally {
+    clearTimeout(timer);
+    cdp.off('Page.fileChooserOpened', handler);
+    await cdp.send(
+      'Page.setInterceptFileChooserDialog',
+      { enabled: false },
+      sessionId
+    ).catch(() => {});
+  }
+}
+
+function validateFiles(files: string[]): void {
+  if (!files || files.length === 0) {
+    throw new Error('At least one file path is required');
+  }
+  for (const f of files) {
+    if (!path.isAbsolute(f)) {
+      throw new Error(`Upload path must be absolute: ${f}`);
+    }
+    if (!fs.existsSync(f)) {
+      throw new Error(`File not found: ${f}`);
+    }
+  }
+}
+
+const MIME_BY_EXT: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.pdf': 'application/pdf',
+  '.txt': 'text/plain',
+  '.csv': 'text/csv',
+  '.json': 'application/json',
+  '.zip': 'application/zip',
+  '.mp4': 'video/mp4',
+  '.mov': 'video/quicktime',
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+};
+
+export function mimeFromExt(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  return MIME_BY_EXT[ext] ?? 'application/octet-stream';
+}
+
+/**
+ * Inspect a ref's DOM node to decide which pattern fits when the caller
+ * didn't specify. Returns 'input' if the node is `<input type=file>`,
+ * otherwise 'drop'. Chooser interception (Pattern C) is never auto-selected
+ * because it requires clicking the ref, which mutates page state — opt-in only.
+ */
+export async function detectUploadPattern(
+  cdp: CDPClient,
+  sessionId: string,
+  backendNodeId: number
+): Promise<'input' | 'drop'> {
+  const { node } = await cdp.send<{
+    node: { nodeName?: string; attributes?: string[] };
+  }>('DOM.describeNode', { backendNodeId, depth: 0 }, sessionId);
+
+  if (isFileInputNode(node)) return 'input';
+
+  // The node itself isn't <input type=file>, but it might be a button or
+  // shadow-DOM descendant *inside* one — that's what the accessibility tree
+  // surfaces for file inputs. Walk up to confirm before falling back to drop.
+  const { object } = await cdp.send<{ object: { objectId?: string } }>(
+    'DOM.resolveNode',
+    { backendNodeId },
+    sessionId
+  );
+  if (!object.objectId) return 'drop';
+  const objectId = object.objectId;
+  try {
+    const { result } = await cdp.send<{ result: { objectId?: string } }>(
+      'Runtime.callFunctionOn',
+      { objectId, functionDeclaration: RESOLVE_FILE_INPUT_FN, returnByValue: false },
+      sessionId
+    );
+    if (result.objectId) {
+      await cdp.send('Runtime.releaseObject', { objectId: result.objectId }, sessionId);
+      return 'input';
+    }
+    return 'drop';
+  } finally {
+    await cdp.send('Runtime.releaseObject', { objectId }, sessionId);
+  }
+}
+
+function isFileInputNode(node: { nodeName?: string; attributes?: string[] }): boolean {
+  const tag = (node.nodeName ?? '').toLowerCase();
+  if (tag !== 'input') return false;
+  const attrs = node.attributes ?? [];
+  for (let i = 0; i < attrs.length; i += 2) {
+    if (attrs[i] === 'type' && attrs[i + 1]?.toLowerCase() === 'file') {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
Closes #16.

## Summary

Adds `agents browser upload <task>` covering the three upload patterns that span every web/Electron uploader:

- **Pattern A — `--input`** (default for `<input type=file>`): `DOM.setFileInputFiles` with walk-up so a ref pointing at the AX "Choose File" button still finds the underlying `<input>`. Falls back to the unique `<input type=file>` on the page when the AX backend node points at an internal pseudo-element.
- **Pattern B — `--drop`**: synthetic `dragenter`/`dragover`/`drop` carrying a `DataTransfer` whose `files` list is built from disk bytes. Overrides the event's `dataTransfer` via `Object.defineProperty` because Chromium ignores it in `DragEventInit`.
- **Pattern C — `--trigger`**: `Page.setInterceptFileChooserDialog` + click trigger + `Page.handleFileChooser({action:'accept', files})`. Falls back to `DOM.setFileInputFiles` on the chooser's `backendNodeId` for older Chromium that rejects `handleFileChooser`.

Also matches `service.upload`'s ref nodemap to the user-facing `agents browser refs` listing (`interactive: true`) so `--ref N` resolves to the element the user actually saw — the other action helpers (`click`, `type`, `hover`) still use the legacy `interactive: false` and have the same latent mismatch; not touched here to keep scope tight.

## Test plan

- Unit: 17 tests in `src/lib/browser/upload.test.ts` covering pattern selection, walk-up, validation, drag-drop dispatch sequencing, chooser event lifecycle, and timeout.
- Full repo suite on Crabbox (cpx62): **1437 passed, 31 skipped, 0 failed**.
- Live end-to-end CLI smoke against the **real Canva Electron app** on macOS:
  - `agents browser upload --ref <fi> --input --file ...` → `change` event fires, File delivered with correct name/size/MIME.
  - `agents browser upload --ref <dz> --drop --file ...` → `dragenter` + `dragover` + `drop` fire and `e.dataTransfer.files` contains the File.

## Session Context

[Session transcript](https://gist.github.com/muqsitnawaz/776942d05ec6f27cc4fba38a8badb275)