### PR TITLE
feat(browser): redesign CLI surface — task env var, endpoint presets, recording, raw screenshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,83 @@
 # Changelog
 
+## Unreleased
+
+**Browser**
+
+- New canonical shape for action commands: bind the task once per shell via
+  `AGENTS_BROWSER_TASK`, then drop the positional `<task>` from every later
+  call. The old positional shape still works but emits a one-line deprecation
+  warning on stderr — agents and scripts can migrate at their own pace.
+  ```bash
+  export AGENTS_BROWSER_TASK=$(agents browser start --profile work)
+  agents browser navigate https://example.com
+  agents browser click 42
+  agents browser screenshot
+  ```
+  Env vars are per-process, so parallel agents in different shells never collide.
+  `--task <name>` is supported on every action command as an explicit one-off override.
+- `agents browser start` writes the resolved task name to **stdout** as a
+  single line (e.g. `swift-crab-falcon-a3f92b1c`), and routes the human
+  commentary ("Started task ... with tab ...", "Tip: export
+  AGENTS_BROWSER_TASK=...") to **stderr**. This makes
+  `T=$(agents browser start --profile X)` Just Work — no `--quiet` flag needed.
+- Auto-generated task names are now three English words plus an 8-char hex
+  suffix, e.g. `swift-crab-falcon-a3f92b1c`. Memorable, distinct, 32 bits of
+  entropy so parallel agents never collide. Daemon retries on the (vanishingly
+  rare) name clash and rejects explicit `--task <name>` values that already
+  exist.
+- `agents browser start --profile <name>` now pre-validates the profile
+  locally before touching the daemon. Missing profile prints the list of
+  available profiles plus the create-command hint instead of a generic error.
+- `agents browser tab list` is now `agents browser tabs` (top-level), pairing
+  cleanly with `agents browser tab focus <id>`. The old `tab list` form is
+  removed.
+- `agents browser --help` is reorganized by mental model — *Session lifecycle*,
+  *Drive the page*, *Capture evidence* — instead of an alphabetical dump.
+  Rare commands stay under a trailing *Commands* section.
+- BREAKING: `agents browser profiles prime` and `agents browser profiles launch`
+  are removed. Both were thin duplicates of `start`. For first-run
+  onboarding, just `agents browser start --profile <name>` and complete the
+  interactive screens in the browser; the user-data-dir persists across
+  runs. The daemon's `launch-profile` IPC action is also gone.
+- Named endpoint presets per profile. One profile can now cover the local
+  and remote variants of the same app instead of forcing two parallel
+  profiles. YAML supports both the legacy `endpoints: [url]` shape and the
+  new map form:
+  ```yaml
+  name: rush
+  browser: custom
+  electron: true
+  endpoints:
+    local:
+      target: cdp://127.0.0.1:9223
+      binary: /Applications/Rush.app/Contents/MacOS/Rush
+    mac-mini:
+      target: ssh://mac-mini?port=9223
+      # no binary — daemon attaches only
+  defaultEndpoint: local
+  ```
+  `agents browser start --profile rush --endpoint mac-mini` picks a specific
+  preset; `--endpoint` falls back to `defaultEndpoint` or the first preset.
+  Pre-validated client-side so a typo doesn't waste an IPC round-trip.
+  Per-endpoint `binary` and `targetFilter` override the profile-level
+  fields. `agents browser profiles show` lists every preset, marks the
+  default, and shows per-endpoint overrides.
+- The daemon's runtime identity is now `<profile>@<endpoint>` so the same
+  profile can run at multiple endpoints concurrently without colliding on
+  pid/port files. `agents browser status` and `tasks` show the composite
+  name, so you can tell at a glance which variant a task is using.
+- `agents browser screenshot --quality raw` captures pixel-faithful PNG
+  (no downscale) for archived QA evidence. Default stays `compressed`
+  (JPEG, capped near 100 KB) for chat-injected screenshots.
+- New `agents browser record start` / `agents browser record stop`
+  recording verbs. Captures via CDP `Page.startScreencast`, pipes frames
+  into ffmpeg (image2pipe → libvpx-vp9) and writes a webm under
+  `sessions/<task>/recordings/`. Bounded three ways — `--fps` (default
+  5), `--duration` (hard cap, default 60s), `--max-mb` (default 25);
+  whichever fires first auto-finalizes the file. Requires ffmpeg on
+  PATH (`brew install ffmpeg`).
+
 ## 1.18.3
 
 **Plugins** ([#22](https://github.com/phnx-labs/agents-cli/issues/22))

--- a/README.md
+++ b/README.md
@@ -304,13 +304,20 @@ Give agents access to a real browser — no relay extension, no cloud service, n
 # Create an isolated profile for automation
 agents browser profiles create work --browser chrome
 
-# Start a task, navigate, interact
-agents browser start --profile work --task login-flow --url https://app.example.com
-agents browser refs login-flow              # Get interactive element refs
-agents browser click login-flow 42          # Click element ref 42
-agents browser type login-flow 15 "hello"   # Type into element ref 15
-agents browser screenshot login-flow        # Smart resizing, token-efficient
-agents browser done login-flow              # Close task's tabs when finished
+# Start a task once, then bind it to this shell — every later command picks it up.
+# `start` writes the resolved name (e.g. `swift-crab-falcon-a3f92b1c`) to stdout
+# and human-friendly commentary to stderr, so $(...) capture stays clean.
+export AGENTS_BROWSER_TASK=$(agents browser start --profile work --url https://app.example.com)
+agents browser refs                  # Get interactive element refs
+agents browser click 42              # Click element ref 42
+agents browser type 15 "hello"       # Type into element ref 15
+agents browser screenshot            # Smart resizing, token-efficient
+agents browser tabs                  # List tabs open for the current task
+agents browser tab focus tab123      # Switch focus to another tab
+agents browser done                  # Close task's tabs when finished
+
+# Need to address a different task in the same shell? Override per call:
+agents browser screenshot --task other-flow
 ```
 
 ### Why this works where Playwright fails

--- a/src/commands/browser.ts
+++ b/src/commands/browser.ts
@@ -1,4 +1,14 @@
-import { Command } from 'commander';
+import { Command, Argument } from 'commander';
+
+// Hidden trailing positional we use to capture the deprecated `<task>` slot
+// without polluting `--help`. Required for backward compat during migration.
+// commander v12 Argument lacks `hideHelp()`; we set the field our custom
+// help formatter (src/lib/help.ts) already filters on.
+function hiddenLegacyArg(name = 'legacyArg'): Argument {
+  const arg = new Argument(`[${name}]`, 'deprecated — legacy task positional');
+  (arg as Argument & { hidden: boolean }).hidden = true;
+  return arg;
+}
 import * as fs from 'fs';
 import * as path from 'path';
 import {
@@ -9,14 +19,92 @@ import {
   getProfileRuntimeDir,
   extractConfiguredPort,
   findFreeProfilePort,
+  getEndpointPresets,
   type BrowserProfile,
 } from '../lib/browser/profiles.js';
 import { findBrowserPath, getPortOccupant } from '../lib/browser/chrome.js';
+import { DEFAULT_VIEWPORT } from '../lib/browser/devices.js';
 import { discoverBrowserWsUrl, verifyBrowserIdentity } from '../lib/browser/cdp.js';
 import { parseTargetFilter } from '../lib/browser/service.js';
 import { sendIPCRequest } from '../lib/browser/ipc.js';
 import { browserTaskPicker, type BrowserTask } from './browser-picker.js';
 import { isInteractiveTerminal } from './utils.js';
+import { registerCommandGroups } from '../lib/help.js';
+
+/**
+ * Resolve which browser task a command targets. Order:
+ *   1. `--task <name>` flag (explicit per-command override)
+ *   2. Legacy positional `<task>` arg (deprecated; emits a one-time warning)
+ *   3. `$AGENTS_BROWSER_TASK` (set once at the start of an agent run)
+ *
+ * Each agent process has its own environment, so the env-var path is safe for
+ * parallel agents — they can't see each other's value.
+ */
+let legacyTaskWarned = false;
+function warnLegacyTaskPositional(): void {
+  if (legacyTaskWarned) return;
+  legacyTaskWarned = true;
+  console.error(
+    'warning: passing <task> as a positional argument is deprecated. ' +
+      'Set AGENTS_BROWSER_TASK once per shell, or use --task <name> for a one-off override.'
+  );
+}
+
+function resolveTaskName(opts: { task?: string }, legacyTaskArg?: string): string {
+  if (opts.task) return opts.task;
+  if (legacyTaskArg !== undefined && legacyTaskArg !== '') {
+    warnLegacyTaskPositional();
+    return legacyTaskArg;
+  }
+  const fromEnv = process.env.AGENTS_BROWSER_TASK;
+  if (fromEnv) return fromEnv;
+  console.error(
+    'No task specified. Pass --task <name> or set AGENTS_BROWSER_TASK in your shell.'
+  );
+  console.error('Tip: T=$(agents browser start --profile <p>) && export AGENTS_BROWSER_TASK=$T');
+  process.exit(1);
+}
+
+/**
+ * Split positional args into (deprecated leading task, new-shape positionals).
+ *
+ * If exactly one more positional than the new shape expects is supplied, treat
+ * the first one as the deprecated `<task>` positional and shift the rest. Used
+ * to keep old `agents browser navigate <task> <url>` style invocations working
+ * during the migration to `--task <name>` / `$AGENTS_BROWSER_TASK`.
+ */
+function unpackPositionals(
+  rawArgs: ReadonlyArray<string | undefined>,
+  newPositionalCount: number,
+  opts: { task?: string }
+): { task: string; positionals: string[] } {
+  const defined = rawArgs.filter((a): a is string => a !== undefined);
+  if (defined.length === newPositionalCount + 1) {
+    return { task: resolveTaskName(opts, defined[0]), positionals: defined.slice(1) };
+  }
+  return { task: resolveTaskName(opts), positionals: defined };
+}
+
+// `-t` is taken by `--tab` on most commands, so `--task` is long-form only.
+// Agents normally set $AGENTS_BROWSER_TASK once and never type this flag.
+const TASK_OPTION_FLAG = '--task <name>';
+const TASK_OPTION_DESC = 'Task name (defaults to $AGENTS_BROWSER_TASK)';
+
+// Help groups — surfaces the actual mental model an agent follows
+// ("open a session / drive the page / capture evidence / rare extras")
+// instead of an alphabetical dump. Everything not listed falls into a
+// trailing "Other commands" section automatically.
+const BROWSER_HELP_GROUPS = [
+  { title: 'Session lifecycle', names: ['start', 'done', 'status'] },
+  {
+    title: 'Drive the page',
+    names: ['navigate', 'tabs', 'screenshot', 'evaluate', 'click', 'type', 'press', 'wait'],
+  },
+  {
+    title: 'Capture evidence',
+    names: ['console', 'errors', 'requests', 'responsebody', 'record'],
+  },
+] as const;
 
 export function registerBrowserCommand(program: Command): void {
   const browser = program
@@ -25,11 +113,13 @@ export function registerBrowserCommand(program: Command): void {
 
   registerProfilesCommands(browser);
   registerTaskCommands(browser);
+  registerCommandGroups(browser, BROWSER_HELP_GROUPS);
 }
 
 export function registerBrowserSubcommands(program: Command): void {
   registerProfilesCommands(program);
   registerTaskCommands(program);
+  registerCommandGroups(program, BROWSER_HELP_GROUPS);
 }
 
 function registerProfilesCommands(browser: Command): void {
@@ -54,7 +144,10 @@ function registerProfilesCommands(browser: Command): void {
         console.log('NAME'.padEnd(20) + 'BROWSER'.padEnd(12) + 'DESCRIPTION'.padEnd(38) + 'ENDPOINTS');
         console.log('-'.repeat(92));
         for (const p of allProfiles) {
-          const endpoints = p.endpoints.join(', ');
+          const presets = getEndpointPresets(p);
+          const endpoints = Object.entries(presets)
+            .map(([name, ep]) => (name.startsWith('endpoint-') ? ep.target : `${name}=${ep.target}`))
+            .join(', ');
           const desc = (p.description ?? '').slice(0, 36).padEnd(38);
           console.log(p.name.padEnd(20) + (p.browser || '-').padEnd(12) + desc + endpoints);
         }
@@ -62,7 +155,10 @@ function registerProfilesCommands(browser: Command): void {
         console.log('NAME'.padEnd(20) + 'BROWSER'.padEnd(12) + 'ENDPOINTS');
         console.log('-'.repeat(72));
         for (const p of allProfiles) {
-          const endpoints = p.endpoints.join(', ');
+          const presets = getEndpointPresets(p);
+          const endpoints = Object.entries(presets)
+            .map(([name, ep]) => (name.startsWith('endpoint-') ? ep.target : `${name}=${ep.target}`))
+            .join(', ');
           console.log(p.name.padEnd(20) + (p.browser || '-').padEnd(12) + endpoints);
         }
       }
@@ -78,7 +174,7 @@ function registerProfilesCommands(browser: Command): void {
     .option('-s, --secrets <bundle>', 'Secrets bundle to inject')
     .option('-d, --description <text>', 'Profile description')
     .option('--headless', 'Run in headless mode')
-    .option('--window <WxH>', 'Window size, e.g. 1512x982')
+    .option('--window <WxH>', `Window size in CSS pixels (default: ${DEFAULT_VIEWPORT.width}x${DEFAULT_VIEWPORT.height}, MacBook Pro 14")`)
     .option('--position <X,Y>', 'Window position on screen, e.g. 80,80')
     .option('--binary <path>', 'Absolute path to the browser/app binary (required with --browser custom)')
     .option(
@@ -128,15 +224,16 @@ function registerProfilesCommands(browser: Command): void {
         endpoints = [`cdp://127.0.0.1:${freePort}`];
       }
 
-      // Viewport is mandatory — default to 1512x982 if --window is not provided
+      // Viewport is mandatory — default to MacBook Pro 14" (1512x982) if
+      // --window is not provided. See lib/browser/devices.ts DEFAULT_VIEWPORT.
       let viewport: { width: number; height: number; x?: number; y?: number } = {
-        width: 1512,
-        height: 982,
+        width: DEFAULT_VIEWPORT.width,
+        height: DEFAULT_VIEWPORT.height,
       };
       if (opts.window) {
         const m = String(opts.window).match(/^(\d+)x(\d+)$/);
         if (!m) {
-          console.error('--window must be WxH, e.g. 1512x982');
+          console.error(`--window must be WxH, e.g. ${DEFAULT_VIEWPORT.width}x${DEFAULT_VIEWPORT.height}`);
           process.exit(1);
         }
         viewport.width = parseInt(m[1], 10);
@@ -195,9 +292,22 @@ function registerProfilesCommands(browser: Command): void {
       if (profile.electron) console.log(`Electron: true`);
       if (profile.targetFilter) console.log(`Target filter: ${profile.targetFilter}`);
       if (profile.description) console.log(`Description: ${profile.description}`);
-      console.log(`Endpoints:`);
-      for (const e of profile.endpoints) {
-        console.log(`  - ${e}`);
+      const presets = getEndpointPresets(profile);
+      const defaultName = profile.defaultEndpoint && presets[profile.defaultEndpoint]
+        ? profile.defaultEndpoint
+        : Object.keys(presets)[0];
+      console.log('Endpoints:');
+      for (const [presetName, preset] of Object.entries(presets)) {
+        const marker = presetName === defaultName ? ' (default)' : '';
+        const isLegacy = presetName.startsWith('endpoint-');
+        console.log(`  - ${isLegacy ? preset.target : `${presetName}: ${preset.target}`}${marker}`);
+        if (preset.binary) console.log(`      binary: ${preset.binary}`);
+        if (preset.targetFilter) console.log(`      targetFilter: ${preset.targetFilter}`);
+      }
+      if (profile.viewport) {
+        const v = profile.viewport;
+        const pos = v.x !== undefined && v.y !== undefined ? ` @ ${v.x},${v.y}` : '';
+        console.log(`Viewport: ${v.width}×${v.height}${pos}`);
       }
       if (profile.secrets) console.log(`Secrets: ${profile.secrets}`);
       if (profile.chrome?.headless) console.log(`Headless: true`);
@@ -209,28 +319,6 @@ function registerProfilesCommands(browser: Command): void {
     .action(async (name: string) => {
       await deleteProfile(name);
       console.log(`Deleted profile: ${name}`);
-    });
-
-  profiles
-    .command('launch <name>')
-    .description('Start (or attach to) the profile\'s browser without creating a task')
-    .action(async (name: string) => {
-      const profile = await getProfile(name);
-      if (!profile) {
-        console.error(`Profile "${name}" not found`);
-        process.exit(1);
-      }
-      const response = await sendIPCRequest({
-        action: 'launch-profile',
-        profile: name,
-      });
-      if (!response.ok) {
-        console.error(response.error);
-        process.exit(1);
-      }
-      const pidLabel = response.pid ? `pid ${response.pid}` : 'attached';
-      console.log(`Launched "${name}" on port ${response.port} (${pidLabel})`);
-      console.log(`Next: agents browser start --profile ${name} --url <url>`);
     });
 
   profiles
@@ -328,14 +416,20 @@ function registerProfilesCommands(browser: Command): void {
             checks.push({
               label: 'onboarding',
               ok: false,
-              detail: 'Local State is empty — run `agents browser profiles prime ' + name + '`',
+              detail:
+                'Local State is empty — run `agents browser start --profile ' +
+                name +
+                '` and finish any first-run screens before automating',
             });
           }
         } else {
           checks.push({
             label: 'onboarding',
             ok: false,
-            detail: 'Not primed yet — run `agents browser profiles prime ' + name + '`',
+            detail:
+              'Not initialized yet — run `agents browser start --profile ' +
+              name +
+              '` and finish any first-run screens before automating',
           });
         }
       }
@@ -348,33 +442,6 @@ function registerProfilesCommands(browser: Command): void {
       if (!allOk) process.exit(1);
     });
 
-  profiles
-    .command('prime <name>')
-    .description('Launch the profile so you can complete first-run onboarding interactively')
-    .action(async (name: string) => {
-      const profile = await getProfile(name);
-      if (!profile) {
-        console.error(`Profile "${name}" not found`);
-        process.exit(1);
-      }
-      const response = await sendIPCRequest({
-        action: 'launch-profile',
-        profile: name,
-      });
-      if (!response.ok) {
-        console.error(response.error);
-        process.exit(1);
-      }
-      const pidLabel = response.pid ? `pid ${response.pid}` : 'attached';
-      console.log(`Launched "${name}" on port ${response.port} (${pidLabel}).`);
-      console.log('');
-      console.log('Finish any first-run / onboarding screens in the browser window');
-      console.log('(welcome, profile setup, default-browser prompt, sign-in, etc.).');
-      console.log('Once you reach a normal browsing surface, this profile is primed');
-      console.log('— its user-data-dir persists across runs, so you only do this once.');
-      console.log('');
-      console.log(`Next: agents browser start --profile ${name} --url <url>`);
-    });
 }
 
 function registerTaskCommands(browser: Command): void {
@@ -382,14 +449,43 @@ function registerTaskCommands(browser: Command): void {
     .command('start')
     .description('Start a browser task with a profile')
     .requiredOption('-p, --profile <name>', 'Browser profile to use')
-    .option('-t, --task <name>', 'Task name (auto-generated if omitted)')
+    .option(TASK_OPTION_FLAG, 'Task name (auto-generated if omitted)')
+    .option('-e, --endpoint <name>', 'Endpoint preset (defaults to the profile\'s default)')
     .option('-u, --url <url>', 'Open URL in first tab')
     .action(async (opts) => {
+      // Pre-check the profile locally so we fail fast with a helpful error
+      // instead of round-tripping a generic "Profile not found" through the daemon.
+      const profile = await getProfile(opts.profile);
+      if (!profile) {
+        console.error(`Profile "${opts.profile}" not found.`);
+        const all = await listProfiles();
+        if (all.length > 0) {
+          console.error(`Available profiles: ${all.map((p) => p.name).join(', ')}`);
+        }
+        console.error(
+          `Create one with: agents browser profiles create ${opts.profile} --browser <chrome|comet|chromium|brave|edge|custom>`
+        );
+        process.exit(1);
+      }
+
+      // Pre-check the endpoint name too — same fail-fast rationale.
+      if (opts.endpoint) {
+        const presets = getEndpointPresets(profile);
+        if (!presets[opts.endpoint]) {
+          console.error(
+            `Endpoint "${opts.endpoint}" not found on profile "${opts.profile}". ` +
+              `Available: ${Object.keys(presets).join(', ')}`
+          );
+          process.exit(1);
+        }
+      }
+
       const response = await sendIPCRequest({
         action: 'start',
         profile: opts.profile,
         taskName: opts.task,
         url: opts.url,
+        endpoint: opts.endpoint,
       });
 
       if (!response.ok) {
@@ -397,17 +493,28 @@ function registerTaskCommands(browser: Command): void {
         process.exit(1);
       }
 
+      // stdout: just the resolved name, one line, no decoration. Lets callers do:
+      //   export AGENTS_BROWSER_TASK=$(agents browser start --profile work)
+      console.log(response.task);
+
+      // stderr: human-friendly commentary so a TTY user still sees what happened.
+      // Shell substitution captures stdout only, so $(...) stays clean.
       if (opts.url && response.tabId) {
-        console.log(`Started task "${response.task}" with tab ${response.tabId}`);
+        console.error(`Started task "${response.task}" with tab ${response.tabId}`);
       } else {
-        console.log(`Started task "${response.task}"`);
+        console.error(`Started task "${response.task}"`);
       }
+      console.error(`Tip: export AGENTS_BROWSER_TASK=${response.task}`);
+      console.error('Try: agents browser screenshot | agents browser console --level error');
     });
 
   browser
-    .command('done <task>')
+    .command('done')
+    .addArgument(hiddenLegacyArg('legacyTask'))
     .description('Complete a task and close its tabs')
-    .action(async (task: string) => {
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
+    .action(async (legacyTask: string | undefined, opts) => {
+      const { task } = unpackPositionals([legacyTask], 0, opts);
       const response = await sendIPCRequest({
         action: 'done',
         task,
@@ -422,9 +529,12 @@ function registerTaskCommands(browser: Command): void {
     });
 
   browser
-    .command('stop <task>')
+    .command('stop')
+    .addArgument(hiddenLegacyArg('legacyTask'))
     .description('Stop a browser task and close its tabs')
-    .action(async (task: string) => {
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
+    .action(async (legacyTask: string | undefined, opts) => {
+      const { task } = unpackPositionals([legacyTask], 0, opts);
       const response = await sendIPCRequest({
         action: 'stop',
         task,
@@ -439,10 +549,14 @@ function registerTaskCommands(browser: Command): void {
     });
 
   browser
-    .command('navigate <task> <url>')
+    .command('navigate <url>')
+    .addArgument(hiddenLegacyArg('legacyUrl'))
     .description('Navigate current tab to URL (creates tab if none exist)')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-p, --profile <name>', 'Browser profile (optional if task is unique)')
-    .action(async (task: string, url: string, opts) => {
+    .action(async (arg1: string, arg2: string | undefined, opts) => {
+      const { task, positionals } = unpackPositionals([arg1, arg2], 1, opts);
+      const [url] = positionals;
       const response = await sendIPCRequest({
         action: 'navigate',
         task,
@@ -462,10 +576,14 @@ function registerTaskCommands(browser: Command): void {
   const tab = browser.command('tab').description('Manage tabs');
 
   tab
-    .command('add <task> <url>')
+    .command('add <url>')
+    .addArgument(hiddenLegacyArg('legacyUrl'))
     .description('Open URL in new tab (becomes current)')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-p, --profile <name>', 'Browser profile')
-    .action(async (task: string, url: string, opts) => {
+    .action(async (arg1: string, arg2: string | undefined, opts) => {
+      const { task, positionals } = unpackPositionals([arg1, arg2], 1, opts);
+      const [url] = positionals;
       const response = await sendIPCRequest({
         action: 'tab-add',
         task,
@@ -482,9 +600,13 @@ function registerTaskCommands(browser: Command): void {
     });
 
   tab
-    .command('focus <task> <tabId>')
+    .command('focus <tabId>')
+    .addArgument(hiddenLegacyArg('legacyTabId'))
     .description('Switch to tab (by ID, prefix, or URL substring)')
-    .action(async (task: string, tabId: string) => {
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
+    .action(async (arg1: string, arg2: string | undefined, opts) => {
+      const { task, positionals } = unpackPositionals([arg1, arg2], 1, opts);
+      const [tabId] = positionals;
       const response = await sendIPCRequest({
         action: 'tab-focus',
         task,
@@ -500,9 +622,11 @@ function registerTaskCommands(browser: Command): void {
     });
 
   tab
-    .command('close <task> [tabId]')
+    .command('close [tabId]')
     .description('Close tab(s) — omit tabId to close all')
-    .action(async (task: string, tabId: string | undefined) => {
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
+    .action(async (tabId: string | undefined, opts) => {
+      const task = resolveTaskName(opts);
       const response = await sendIPCRequest({
         action: 'tab-close',
         task,
@@ -517,11 +641,13 @@ function registerTaskCommands(browser: Command): void {
       console.log(tabId ? `Closed tab ${tabId}` : `Closed all tabs for ${task}`);
     });
 
-  tab
-    .command('list <task>')
-    .description('List tabs for a task')
+  browser
+    .command('tabs')
+    .description('List tabs open for the current task')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('--json', 'Output machine-readable JSON')
-    .action(async (task: string, opts) => {
+    .action(async (opts) => {
+      const task = resolveTaskName(opts);
       const response = await sendIPCRequest({
         action: 'tab-list',
         task,
@@ -556,15 +682,27 @@ function registerTaskCommands(browser: Command): void {
 
 
   browser
-    .command('screenshot <task> [tabId]')
-    .description('Take a screenshot')
-    .option('-o, --output <path>', 'Output path')
-    .action(async (task: string, tabId: string | undefined, opts) => {
+    .command('screenshot [tabId]')
+    .description('Take a screenshot — auto-saved per task; --output only needed when you want a specific path')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
+    .option('-o, --output <path>', 'Specific output path (otherwise auto-saved under sessions/<task>/)')
+    .option(
+      '-q, --quality <mode>',
+      'compressed (JPEG, capped at ~100 KB — default) or raw (PNG, pixel-faithful)',
+      'compressed'
+    )
+    .action(async (tabId: string | undefined, opts) => {
+      const task = resolveTaskName(opts);
+      if (opts.quality !== 'compressed' && opts.quality !== 'raw') {
+        console.error('--quality must be "compressed" or "raw"');
+        process.exit(1);
+      }
       const response = await sendIPCRequest({
         action: 'screenshot',
         task,
         tabId,
         path: opts.output,
+        quality: opts.quality,
       });
 
       if (!response.ok) {
@@ -572,14 +710,25 @@ function registerTaskCommands(browser: Command): void {
         process.exit(1);
       }
 
+      // stdout: just the path, so `P=$(agents browser screenshot)` works.
       console.log(response.path);
+
+      // stderr: human commentary with size + dimensions, so an agent can
+      // see at a glance what was captured without `ls -l && file` round-trips.
+      const size = humanizeBytes(response.bytes);
+      const dims = response.width && response.height ? `${response.width}×${response.height}` : 'unknown size';
+      console.error(`Saved screenshot to ${response.path} (${size}, ${dims})`);
     });
 
   browser
-    .command('evaluate <task> <expression>')
+    .command('evaluate <expression>')
+    .addArgument(hiddenLegacyArg('legacyExpression'))
     .description('Evaluate JavaScript in current tab')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
-    .action(async (task: string, expression: string, opts) => {
+    .action(async (arg1: string, arg2: string | undefined, opts) => {
+      const { task, positionals } = unpackPositionals([arg1, arg2], 1, opts);
+      const [expression] = positionals;
       const response = await sendIPCRequest({
         action: 'evaluate',
         task,
@@ -829,13 +978,16 @@ function registerTaskCommands(browser: Command): void {
     });
 
   browser
-    .command('refs <task>')
+    .command('refs')
+    .addArgument(hiddenLegacyArg('legacyTask'))
     .description('Get DOM refs for interactive elements')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
     .option('--all', 'Include non-interactive elements')
     .option('-l, --limit <n>', 'Max elements (default 500)', '500')
     .option('--json', 'Output machine-readable JSON')
-    .action(async (task: string, opts) => {
+    .action(async (legacyTask: string | undefined, opts) => {
+      const { task } = unpackPositionals([legacyTask], 0, opts);
       const response = await sendIPCRequest({
         action: 'refs',
         task,
@@ -862,10 +1014,14 @@ function registerTaskCommands(browser: Command): void {
     });
 
   browser
-    .command('click <task> <ref>')
+    .command('click <ref>')
+    .addArgument(hiddenLegacyArg('legacyRef'))
     .description('Click an element by ref')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
-    .action(async (task: string, ref: string, opts) => {
+    .action(async (arg1: string, arg2: string | undefined, opts) => {
+      const { task, positionals } = unpackPositionals([arg1, arg2], 1, opts);
+      const [ref] = positionals;
       const response = await sendIPCRequest({
         action: 'click',
         task,
@@ -882,11 +1038,15 @@ function registerTaskCommands(browser: Command): void {
     });
 
   browser
-    .command('type <task> <ref> <text>')
+    .command('type <ref> <text>')
+    .addArgument(hiddenLegacyArg('legacyText'))
     .description('Type text into an element by ref')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
     .option('--clear', 'Clear editor content before typing')
-    .action(async (task: string, ref: string, text: string, opts) => {
+    .action(async (arg1: string, arg2: string, arg3: string | undefined, opts) => {
+      const { task, positionals } = unpackPositionals([arg1, arg2, arg3], 2, opts);
+      const [ref, text] = positionals;
       const response = await sendIPCRequest({
         action: 'type',
         task,
@@ -905,10 +1065,14 @@ function registerTaskCommands(browser: Command): void {
     });
 
   browser
-    .command('press <task> <key>')
+    .command('press <key>')
+    .addArgument(hiddenLegacyArg('legacyKey'))
     .description('Press a key (Enter, Tab, Escape, etc)')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
-    .action(async (task: string, key: string, opts) => {
+    .action(async (arg1: string, arg2: string | undefined, opts) => {
+      const { task, positionals } = unpackPositionals([arg1, arg2], 1, opts);
+      const [key] = positionals;
       const response = await sendIPCRequest({
         action: 'press',
         task,
@@ -925,10 +1089,14 @@ function registerTaskCommands(browser: Command): void {
     });
 
   browser
-    .command('hover <task> <ref>')
+    .command('hover <ref>')
+    .addArgument(hiddenLegacyArg('legacyRef'))
     .description('Hover over an element by ref')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
-    .action(async (task: string, ref: string, opts) => {
+    .action(async (arg1: string, arg2: string | undefined, opts) => {
+      const { task, positionals } = unpackPositionals([arg1, arg2], 1, opts);
+      const [ref] = positionals;
       const response = await sendIPCRequest({
         action: 'hover',
         task,
@@ -945,12 +1113,16 @@ function registerTaskCommands(browser: Command): void {
     });
 
   browser
-    .command('scroll <task> <deltaX> <deltaY>')
+    .command('scroll <deltaX> <deltaY>')
+    .addArgument(hiddenLegacyArg('legacyDeltaY'))
     .description('Scroll the page by pixel amount')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
     .option('-x, --at-x <x>', 'X coordinate to dispatch scroll from (default 0)', parseInt)
     .option('-y, --at-y <y>', 'Y coordinate to dispatch scroll from (default 0)', parseInt)
-    .action(async (task: string, deltaX: string, deltaY: string, opts) => {
+    .action(async (arg1: string, arg2: string, arg3: string | undefined, opts) => {
+      const { task, positionals } = unpackPositionals([arg1, arg2, arg3], 2, opts);
+      const [deltaX, deltaY] = positionals;
       const response = await sendIPCRequest({
         action: 'scroll',
         task,
@@ -970,8 +1142,10 @@ function registerTaskCommands(browser: Command): void {
     });
 
   browser
-    .command('upload <task>')
+    .command('upload')
+    .addArgument(hiddenLegacyArg('legacyTask'))
     .description('Upload file(s) — supports hidden file inputs, drag-drop targets, and OS chooser interception')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
     .option('-r, --ref <n>', 'Ref of the upload target element (file input or drop zone)', (v) => parseInt(v, 10))
     .option('--trigger <n>', 'Ref of a button that opens the OS file chooser (Pattern C)', (v) => parseInt(v, 10))
@@ -979,7 +1153,8 @@ function registerTaskCommands(browser: Command): void {
     .option('--drop', 'Force drag-drop pattern even if ref is an <input type=file>')
     .option('--input', 'Force file-input pattern (DOM.setFileInputFiles)')
     .option('--timeout <ms>', 'Timeout for chooser interception (Pattern C)', (v) => parseInt(v, 10))
-    .action(async (task: string, opts) => {
+    .action(async (legacyTask: string | undefined, opts) => {
+      const { task } = unpackPositionals([legacyTask], 0, opts);
       const files: string[] = opts.file ?? [];
       if (files.length === 0) {
         console.error('--file <path> is required (repeat for multiple files)');
@@ -1023,12 +1198,16 @@ function registerTaskCommands(browser: Command): void {
   const setCmd = browser.command('set').description('Set browser emulation options');
 
   setCmd
-    .command('viewport <task> <width> <height>')
+    .command('viewport <width> <height>')
+    .addArgument(hiddenLegacyArg('legacyHeight'))
     .description('Set viewport size')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
     .option('-m, --mobile', 'Enable mobile emulation')
     .option('-s, --scale <factor>', 'Device scale factor', parseFloat)
-    .action(async (task: string, width: string, height: string, opts) => {
+    .action(async (arg1: string, arg2: string, arg3: string | undefined, opts) => {
+      const { task, positionals } = unpackPositionals([arg1, arg2, arg3], 2, opts);
+      const [width, height] = positionals;
       const response = await sendIPCRequest({
         action: 'set-viewport',
         task,
@@ -1048,10 +1227,14 @@ function registerTaskCommands(browser: Command): void {
     });
 
   setCmd
-    .command('device <task> <device-name>')
+    .command('device <device-name>')
+    .addArgument(hiddenLegacyArg('legacyDeviceName'))
     .description('Emulate a device (iPhone 14, iPad, MacBook Pro)')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
-    .action(async (task: string, deviceName: string, opts) => {
+    .action(async (arg1: string, arg2: string | undefined, opts) => {
+      const { task, positionals } = unpackPositionals([arg1, arg2], 1, opts);
+      const [deviceName] = positionals;
       const response = await sendIPCRequest({
         action: 'set-device',
         task,
@@ -1081,12 +1264,15 @@ function registerTaskCommands(browser: Command): void {
   // ─── Console & Errors ────────────────────────────────────────────────────────
 
   browser
-    .command('console <task>')
+    .command('console')
+    .addArgument(hiddenLegacyArg('legacyTask'))
     .description('Read console logs from a tab')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
     .option('-l, --level <level>', 'Filter by level (log, info, warn, error)')
     .option('--clear', 'Clear logs after reading')
-    .action(async (task: string, opts) => {
+    .action(async (legacyTask: string | undefined, opts) => {
+      const { task } = unpackPositionals([legacyTask], 0, opts);
       const response = await sendIPCRequest({
         action: 'console',
         task,
@@ -1113,11 +1299,14 @@ function registerTaskCommands(browser: Command): void {
     });
 
   browser
-    .command('errors <task>')
+    .command('errors')
+    .addArgument(hiddenLegacyArg('legacyTask'))
     .description('Read page errors from a tab')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
     .option('--clear', 'Clear errors after reading')
-    .action(async (task: string, opts) => {
+    .action(async (legacyTask: string | undefined, opts) => {
+      const { task } = unpackPositionals([legacyTask], 0, opts);
       const response = await sendIPCRequest({
         action: 'errors',
         task,
@@ -1146,12 +1335,15 @@ function registerTaskCommands(browser: Command): void {
   // ─── Network ─────────────────────────────────────────────────────────────────
 
   browser
-    .command('requests <task>')
+    .command('requests')
+    .addArgument(hiddenLegacyArg('legacyTask'))
     .description('Read captured network requests')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
     .option('-f, --filter <text>', 'Filter URLs containing text')
     .option('--clear', 'Clear requests after reading')
-    .action(async (task: string, opts) => {
+    .action(async (legacyTask: string | undefined, opts) => {
+      const { task } = unpackPositionals([legacyTask], 0, opts);
       const response = await sendIPCRequest({
         action: 'requests',
         task,
@@ -1179,12 +1371,16 @@ function registerTaskCommands(browser: Command): void {
     });
 
   browser
-    .command('responsebody <task> <url-pattern>')
+    .command('responsebody <url-pattern>')
+    .addArgument(hiddenLegacyArg('legacyUrlPattern'))
     .description('Wait for and read a response body by URL pattern')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
     .option('--timeout <ms>', 'Timeout in milliseconds', parseInt)
     .option('--max-chars <n>', 'Max characters to return', parseInt)
-    .action(async (task: string, urlPattern: string, opts) => {
+    .action(async (arg1: string, arg2: string | undefined, opts) => {
+      const { task, positionals } = unpackPositionals([arg1, arg2], 1, opts);
+      const [urlPattern] = positionals;
       const response = await sendIPCRequest({
         action: 'response-body',
         task,
@@ -1205,8 +1401,10 @@ function registerTaskCommands(browser: Command): void {
   // ─── Wait ────────────────────────────────────────────────────────────────────
 
   browser
-    .command('wait <task>')
+    .command('wait')
+    .addArgument(hiddenLegacyArg('legacyTask'))
     .description('Wait for a condition')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
     .option('--time <ms>', 'Wait for milliseconds')
     .option('--selector <css>', 'Wait for CSS selector to appear')
@@ -1214,7 +1412,8 @@ function registerTaskCommands(browser: Command): void {
     .option('--fn <js>', 'Wait for JS expression to return truthy')
     .option('--state <state>', 'Wait for load state (domcontentloaded, load, networkidle)')
     .option('--timeout <ms>', 'Timeout in milliseconds', parseInt)
-    .action(async (task: string, opts) => {
+    .action(async (legacyTask: string | undefined, opts) => {
+      const { task } = unpackPositionals([legacyTask], 0, opts);
       let waitType: 'time' | 'selector' | 'url' | 'function' | 'load';
       let waitValue: string | number;
 
@@ -1258,11 +1457,14 @@ function registerTaskCommands(browser: Command): void {
   // ─── Downloads ───────────────────────────────────────────────────────────────
 
   browser
-    .command('download <task>')
+    .command('download')
+    .addArgument(hiddenLegacyArg('legacyTask'))
     .description('Set download directory for a task')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
     .requiredOption('-p, --path <dir>', 'Download directory path')
-    .action(async (task: string, opts) => {
+    .action(async (legacyTask: string | undefined, opts) => {
+      const { task } = unpackPositionals([legacyTask], 0, opts);
       const response = await sendIPCRequest({
         action: 'set-download-path',
         task,
@@ -1278,11 +1480,65 @@ function registerTaskCommands(browser: Command): void {
       console.log(`Download path set to ${opts.path}`);
     });
 
+  // ─── Recording ─────────────────────────────────────────────────────────────
+
+  const record = browser.command('record').description('Record a video of the page');
+
+  record
+    .command('start')
+    .description('Start recording — auto-saved under sessions/<task>/recordings/. Bounded by --fps, --duration, --max-mb.')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
+    .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
+    .option('--fps <n>', 'Frames per second (1–30, default 5)', (v) => parseInt(v, 10))
+    .option('--duration <sec>', 'Hard duration cap in seconds (default 60)', (v) => parseInt(v, 10))
+    .option('--max-mb <mb>', 'Stop when output exceeds this many MB (default 25)', (v) => parseInt(v, 10))
+    .action(async (opts) => {
+      const task = resolveTaskName(opts);
+      const response = await sendIPCRequest({
+        action: 'record-start',
+        task,
+        tabId: opts.tab,
+        fps: opts.fps,
+        duration: opts.duration,
+        maxMb: opts.maxMb,
+      });
+      if (!response.ok) {
+        console.error(response.error);
+        process.exit(1);
+      }
+      // stdout: path (for capture into a variable). stderr: human commentary.
+      console.log(response.path);
+      console.error(
+        `Recording task "${task}" at ${response.fps} fps (cap ${response.durationCapSec}s / ${response.maxMb} MB) → ${response.path}`
+      );
+      console.error('Stop with: agents browser record stop');
+    });
+
+  record
+    .command('stop')
+    .description('Stop an in-progress recording')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
+    .action(async (opts) => {
+      const task = resolveTaskName(opts);
+      const response = await sendIPCRequest({ action: 'record-stop', task });
+      if (!response.ok) {
+        console.error(response.error);
+        process.exit(1);
+      }
+      console.log(response.path);
+      const size = humanizeBytes(response.bytes);
+      const seconds = ((response.durationMs ?? 0) / 1000).toFixed(1);
+      console.error(`Saved recording to ${response.path} (${size}, ${seconds}s, stopped: ${response.stopReason})`);
+    });
+
   browser
-    .command('waitdownload <task>')
+    .command('waitdownload')
+    .addArgument(hiddenLegacyArg('legacyTask'))
     .description('Wait for a download to complete')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('--timeout <ms>', 'Timeout in milliseconds', parseInt)
-    .action(async (task: string, opts) => {
+    .action(async (legacyTask: string | undefined, opts) => {
+      const { task } = unpackPositionals([legacyTask], 0, opts);
       const response = await sendIPCRequest({
         action: 'wait-download',
         task,
@@ -1310,6 +1566,13 @@ function formatAge(timestamp: number): string {
   if (minutes < 60) return `${minutes}m ago`;
   const hours = Math.floor(minutes / 60);
   return `${hours}h ago`;
+}
+
+function humanizeBytes(n: number | undefined): string {
+  if (n === undefined) return 'unknown size';
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
 }
 
 function formatDuration(ms: number): string {

--- a/src/lib/browser/devices.ts
+++ b/src/lib/browser/devices.ts
@@ -1,5 +1,17 @@
 import type { DeviceDescriptor } from './types.js';
 
+/**
+ * Default viewport for newly-created profiles. Matches Safari's logical
+ * resolution on a 14-inch MacBook Pro (M1/M2/M3 Pro/Max) — the most common
+ * shape this CLI sees in practice. Shared with the `MacBook Pro` device
+ * preset below so both surfaces agree.
+ */
+export const DEFAULT_VIEWPORT = {
+  width: 1512,
+  height: 982,
+  deviceScaleFactor: 2,
+} as const;
+
 export const DEVICES: Record<string, DeviceDescriptor> = {
   'iPhone 14': {
     width: 390,
@@ -14,9 +26,9 @@ export const DEVICES: Record<string, DeviceDescriptor> = {
     mobile: true,
   },
   'MacBook Pro': {
-    width: 1440,
-    height: 900,
-    deviceScaleFactor: 2,
+    width: DEFAULT_VIEWPORT.width,
+    height: DEFAULT_VIEWPORT.height,
+    deviceScaleFactor: DEFAULT_VIEWPORT.deviceScaleFactor,
     mobile: false,
   },
 };

--- a/src/lib/browser/ipc.ts
+++ b/src/lib/browser/ipc.ts
@@ -86,6 +86,7 @@ export class BrowserIPCServer {
         const result = await this.service.start(request.profile, {
           taskName: request.taskName,
           url: request.url,
+          endpointName: request.endpoint,
         });
         return {
           ok: true,
@@ -93,14 +94,6 @@ export class BrowserIPCServer {
           tabId: result.tabId,
           windowTargetId: result.windowId,
         };
-      }
-
-      case 'launch-profile': {
-        if (!request.profile) {
-          return { ok: false, error: 'Profile required' };
-        }
-        const result = await this.service.launchProfile(request.profile);
-        return { ok: true, port: result.port, pid: result.pid };
       }
 
       case 'done': {
@@ -189,16 +182,41 @@ export class BrowserIPCServer {
         return { ok: true, result };
       }
 
+      case 'record-start': {
+        if (!request.task) return { ok: false, error: 'Task required' };
+        try {
+          const r = await this.service.recordStart(request.task, request.tabId, {
+            fps: request.fps,
+            duration: request.duration,
+            maxMb: request.maxMb,
+          });
+          return { ok: true, path: r.path, fps: r.fps, durationCapSec: r.durationCapSec, maxMb: r.maxMb };
+        } catch (err) {
+          return { ok: false, error: err instanceof Error ? err.message : String(err) };
+        }
+      }
+
+      case 'record-stop': {
+        if (!request.task) return { ok: false, error: 'Task required' };
+        try {
+          const r = await this.service.recordStop(request.task);
+          return { ok: true, path: r.path, bytes: r.bytes, durationMs: r.durationMs, stopReason: r.reason as 'manual' | 'duration-cap' | 'size-cap' };
+        } catch (err) {
+          return { ok: false, error: err instanceof Error ? err.message : String(err) };
+        }
+      }
+
       case 'screenshot': {
         if (!request.task) {
           return { ok: false, error: 'Task required' };
         }
-        const resultPath = await this.service.screenshot(
+        const shot = await this.service.screenshot(
           request.task,
           request.tabId,
-          request.path
+          request.path,
+          request.quality
         );
-        return { ok: true, path: resultPath };
+        return { ok: true, path: shot.path, bytes: shot.bytes, width: shot.width, height: shot.height };
       }
 
       case 'refs': {

--- a/src/lib/browser/profiles.ts
+++ b/src/lib/browser/profiles.ts
@@ -28,6 +28,7 @@ function configToProfile(name: string, config: BrowserProfileConfig): BrowserPro
     electron: config.electron,
     targetFilter: config.targetFilter,
     endpoints: config.endpoints,
+    defaultEndpoint: config.defaultEndpoint,
     chrome: config.chrome,
     secrets: config.secrets,
     viewport: config.viewport,
@@ -43,6 +44,7 @@ function profileToConfig(profile: BrowserProfile): BrowserProfileConfig {
   if (profile.binary) config.binary = profile.binary;
   if (profile.electron) config.electron = profile.electron;
   if (profile.targetFilter) config.targetFilter = profile.targetFilter;
+  if (profile.defaultEndpoint) config.defaultEndpoint = profile.defaultEndpoint;
   if (profile.chrome) config.chrome = profile.chrome;
   if (profile.secrets) config.secrets = profile.secrets;
   if (profile.viewport) config.viewport = profile.viewport;
@@ -144,12 +146,78 @@ export async function deleteProfile(name: string): Promise<void> {
 }
 
 /**
- * Extract the port intended by the profile's first endpoint.
+ * Resolve a profile's endpoint presets into a normalized map regardless of
+ * whether the YAML uses the legacy `string[]` shape or the new map shape.
+ * The legacy entries get auto-named `endpoint-0`, `endpoint-1`, ... .
+ */
+export function getEndpointPresets(
+  profile: BrowserProfile
+): Record<string, import('./types.js').EndpointPreset> {
+  if (Array.isArray(profile.endpoints)) {
+    const out: Record<string, import('./types.js').EndpointPreset> = {};
+    profile.endpoints.forEach((target, i) => {
+      out[`endpoint-${i}`] = { target };
+    });
+    return out;
+  }
+  return profile.endpoints;
+}
+
+/**
+ * Pick the endpoint preset to use. Order:
+ *   1. Explicit name passed in (errors if unknown)
+ *   2. `profile.defaultEndpoint` if set
+ *   3. First entry (preserves legacy string[] behavior)
+ *
+ * Returns the resolved name + the preset (with per-endpoint overrides
+ * already applied to binary / targetFilter), so callers don't have to
+ * remember the precedence rules.
+ */
+export function resolveEndpoint(
+  profile: BrowserProfile,
+  endpointName?: string
+): { name: string; target: string; binary?: string; targetFilter?: string } {
+  const presets = getEndpointPresets(profile);
+  const names = Object.keys(presets);
+  if (names.length === 0) {
+    throw new Error(`Profile "${profile.name}" has no endpoints configured`);
+  }
+
+  let chosenName: string;
+  if (endpointName) {
+    if (!presets[endpointName]) {
+      throw new Error(
+        `Endpoint "${endpointName}" not found on profile "${profile.name}". ` +
+          `Available: ${names.join(', ')}`
+      );
+    }
+    chosenName = endpointName;
+  } else if (profile.defaultEndpoint && presets[profile.defaultEndpoint]) {
+    chosenName = profile.defaultEndpoint;
+  } else {
+    chosenName = names[0];
+  }
+
+  const preset = presets[chosenName];
+  return {
+    name: chosenName,
+    target: preset.target,
+    binary: preset.binary ?? profile.binary,
+    targetFilter: preset.targetFilter ?? profile.targetFilter,
+  };
+}
+
+/**
+ * Extract the port intended by the profile's default endpoint.
  * Returns undefined for endpoint shapes that don't carry a port (e.g. ws:// without one).
  */
 export function extractConfiguredPort(profile: BrowserProfile): number | undefined {
-  const endpoint = profile.endpoints[0];
-  if (!endpoint) return undefined;
+  const presets = getEndpointPresets(profile);
+  const firstName = profile.defaultEndpoint && presets[profile.defaultEndpoint]
+    ? profile.defaultEndpoint
+    : Object.keys(presets)[0];
+  if (!firstName) return undefined;
+  const endpoint = presets[firstName].target;
   let url: URL;
   try {
     url = new URL(endpoint);

--- a/src/lib/browser/service.ts
+++ b/src/lib/browser/service.ts
@@ -7,6 +7,7 @@ import {
   getBrowserRuntimeDir,
   listProfiles,
   extractConfiguredPort,
+  resolveEndpoint,
 } from './profiles.js';
 import { killChrome, getRunningChromeInfo, launchBrowser, allocatePort } from './chrome.js';
 import { connectLocal } from './drivers/local.js';
@@ -14,7 +15,7 @@ import { connectSSH } from './drivers/ssh.js';
 import {
   generateTaskId,
   generateShortId,
-  generateFunName,
+  generateTaskName,
   isValidTaskId,
   type Task,
   type TabInfo,
@@ -36,6 +37,35 @@ import { emit } from '../events.js';
 import type { TargetFilter } from './types.js';
 
 export type UploadMode = 'auto' | 'input' | 'drop' | 'chooser';
+
+/**
+ * Read width/height from a JPEG buffer by walking SOF markers. Returns null
+ * if the buffer doesn't start with the JPEG SOI marker or no SOF segment is
+ * found. We use this on every screenshot so the CLI can surface the actual
+ * captured pixel dimensions (which differ from viewport size at non-1x DPR).
+ */
+function readPngDimensions(buf: Buffer): { width: number; height: number } | null {
+  // PNG signature (8 bytes) + IHDR chunk: length (4) + 'IHDR' (4) + width (4) + height (4)
+  if (buf.length < 24) return null;
+  const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  for (let i = 0; i < 8; i++) if (buf[i] !== sig[i]) return null;
+  return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+}
+
+function readJpegDimensions(buf: Buffer): { width: number; height: number } | null {
+  if (buf.length < 4 || buf[0] !== 0xff || buf[1] !== 0xd8) return null;
+  let i = 2;
+  while (i + 9 < buf.length) {
+    if (buf[i] !== 0xff) return null;
+    const marker = buf[i + 1];
+    // SOF0–SOFn carry dimensions, except DHT (0xC4), JPG (0xC8), DAC (0xCC).
+    if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
+      return { height: buf.readUInt16BE(i + 5), width: buf.readUInt16BE(i + 7) };
+    }
+    i += 2 + buf.readUInt16BE(i + 2);
+  }
+  return null;
+}
 
 /**
  * Parse a `targetFilter` string into its kind + value, or return `null`
@@ -153,44 +183,67 @@ export class BrowserService {
 
   async start(
     profileName: string,
-    opts: { taskName?: string; url?: string } = {}
-  ): Promise<{ task: string; name: string; tabId?: string; windowId?: string }> {
+    opts: { taskName?: string; url?: string; endpointName?: string } = {}
+  ): Promise<{ task: string; name: string; tabId?: string; windowId?: string; profile: string }> {
     const profile = await getProfile(profileName);
     if (!profile) {
       throw new Error(`Profile "${profileName}" not found`);
     }
 
-    const taskName = opts.taskName || generateFunName();
+    // Pick the endpoint preset. Throws with the candidate list if the user
+    // passed an unknown name. The composite identifier `<profile>@<endpoint>`
+    // is what the connection map + per-profile runtime dirs are keyed on, so
+    // a single YAML profile can run at multiple endpoints concurrently.
+    const resolved = resolveEndpoint(profile, opts.endpointName);
+    const composite = `${profileName}@${resolved.name}`;
+    const effectiveProfile: BrowserProfile = {
+      ...profile,
+      name: composite,
+      binary: resolved.binary,
+      targetFilter: resolved.targetFilter,
+    };
+
+    let taskName: string;
+    if (opts.taskName) {
+      if (this.hasTaskNamed(opts.taskName)) {
+        throw new Error(
+          `Task "${opts.taskName}" already exists. Pick a different --task name or stop the existing one first.`
+        );
+      }
+      taskName = opts.taskName;
+    } else {
+      taskName = this.generateUniqueTaskName();
+    }
     const taskId = generateTaskId();
 
-    let conn = this.connections.get(profileName);
-    let effectiveProfileName = profileName;
+    let conn = this.connections.get(composite);
+    let effectiveProfileName = composite;
 
     if (conn && conn.electron && conn.tasks.size > 0) {
-      if (this.forkingProfiles.has(profileName)) {
-        while (this.forkingProfiles.has(profileName)) {
+      if (this.forkingProfiles.has(composite)) {
+        while (this.forkingProfiles.has(composite)) {
           await new Promise((r) => setTimeout(r, 50));
         }
-        const existingFork = this.findAvailableFork(profileName);
+        const existingFork = this.findAvailableFork(composite);
         if (existingFork) {
           conn = existingFork.conn;
           effectiveProfileName = existingFork.name;
         } else {
-          throw new Error(`Fork in progress but no available fork found for "${profileName}"`);
+          throw new Error(`Fork in progress but no available fork found for "${composite}"`);
         }
       } else {
-        this.forkingProfiles.add(profileName);
+        this.forkingProfiles.add(composite);
         try {
-          const { forkName, connection } = await this.forkElectronProfile(profile);
+          const { forkName, connection } = await this.forkElectronProfile(effectiveProfile);
           conn = connection;
           effectiveProfileName = forkName;
         } finally {
-          this.forkingProfiles.delete(profileName);
+          this.forkingProfiles.delete(composite);
         }
       }
     } else if (!conn) {
-      conn = await this.connectProfile(profile);
-      this.connections.set(profileName, conn);
+      conn = await this.connectProfile(effectiveProfile, resolved.target);
+      this.connections.set(composite, conn);
     }
 
     const task: Task = {
@@ -235,28 +288,7 @@ export class BrowserService {
       tabId = result.tabId;
     }
 
-    return { task: taskId, name: taskName, tabId };
-  }
-
-  /**
-   * Launch (or attach to) the profile's browser without creating a task. Used by
-   * `agents browser profiles launch <name>` so users can warm up the browser —
-   * including the first-run onboarding flow — before any automation starts.
-   */
-  async launchProfile(profileName: string): Promise<{ port: number; pid: number }> {
-    const profile = await getProfile(profileName);
-    if (!profile) {
-      throw new Error(`Profile "${profileName}" not found`);
-    }
-
-    let conn = this.connections.get(profileName);
-    if (!conn) {
-      conn = await this.connectProfile(profile);
-      this.connections.set(profileName, conn);
-    }
-
-    emit('browser.launch', { profile: profileName, task: '', pid: conn.pid });
-    return { port: conn.port, pid: conn.pid };
+    return { task: taskId, name: taskName, tabId, profile: effectiveProfileName };
   }
 
   async stop(taskName: string): Promise<{ ok: boolean; profile?: string }> {
@@ -587,8 +619,9 @@ export class BrowserService {
   async screenshot(
     taskId: string,
     tabHint?: string,
-    outputPath?: string
-  ): Promise<string> {
+    outputPath?: string,
+    quality: 'compressed' | 'raw' = 'compressed'
+  ): Promise<{ path: string; bytes: number; width: number; height: number }> {
     const { conn, task } = await this.findTask(taskId);
 
     const shortId = tabHint ? await this.resolveTabHint(conn, task, tabHint) : this.resolveCurrentTab(task);
@@ -602,34 +635,237 @@ export class BrowserService {
 
     const sessionId = await this.getSessionId(conn, target.targetId);
 
-    const { data } = (await conn.cdp.send(
-      'Page.captureScreenshot',
-      { format: 'jpeg', quality: 70 },
-      sessionId
-    )) as { data: string };
+    let buffer: Buffer;
+    let extension: string;
 
-    let buffer = Buffer.from(data, 'base64');
+    if (quality === 'raw') {
+      // Pixel-faithful PNG, no downscale. For archived QA evidence where
+      // lossy JPEG would hide rendering bugs. Files run 0.5–3 MB.
+      const { data } = (await conn.cdp.send(
+        'Page.captureScreenshot',
+        { format: 'png' },
+        sessionId
+      )) as { data: string };
+      buffer = Buffer.from(data, 'base64');
+      extension = 'png';
+    } else {
+      // Default: JPEG quality 70, then iteratively downscale to keep the
+      // file under 100 KB so chat-injected screenshots stay token-cheap.
+      const { data } = (await conn.cdp.send(
+        'Page.captureScreenshot',
+        { format: 'jpeg', quality: 70 },
+        sessionId
+      )) as { data: string };
+      buffer = Buffer.from(data, 'base64');
 
-    const MAX_SIZE = 100 * 1024;
-    if (buffer.length > MAX_SIZE) {
-      let quality = 50;
-      while (buffer.length > MAX_SIZE && quality > 10) {
-        const { data: resized } = (await conn.cdp.send(
-          'Page.captureScreenshot',
-          { format: 'jpeg', quality },
-          sessionId
-        )) as { data: string };
-        buffer = Buffer.from(resized, 'base64');
-        quality -= 10;
+      const MAX_SIZE = 100 * 1024;
+      if (buffer.length > MAX_SIZE) {
+        let q = 50;
+        while (buffer.length > MAX_SIZE && q > 10) {
+          const { data: resized } = (await conn.cdp.send(
+            'Page.captureScreenshot',
+            { format: 'jpeg', quality: q },
+            sessionId
+          )) as { data: string };
+          buffer = Buffer.from(resized, 'base64');
+          q -= 10;
+        }
       }
+      extension = 'jpg';
     }
 
     const sessionsDir = path.join(getBrowserRuntimeDir(), 'sessions', task.name);
-    const finalPath = outputPath || path.join(sessionsDir, `${Date.now()}.jpg`);
+    const finalPath = outputPath || path.join(sessionsDir, `${Date.now()}.${extension}`);
     await fs.promises.mkdir(path.dirname(finalPath), { recursive: true });
     await fs.promises.writeFile(finalPath, buffer);
 
-    return finalPath;
+    const dims =
+      (extension === 'png' ? readPngDimensions(buffer) : readJpegDimensions(buffer)) ??
+      { width: 0, height: 0 };
+    return { path: finalPath, bytes: buffer.length, width: dims.width, height: dims.height };
+  }
+
+  // ─── Recording ──────────────────────────────────────────────────────────────
+  //
+  // CDP `Page.startScreencast` emits a JPEG frame per `everyNthFrame`. We pipe
+  // those frames into ffmpeg's stdin (image2pipe) and encode to a webm/vp9 file
+  // under `sessions/<task>/recordings/`. A background watcher enforces the
+  // duration + size caps so a forgotten recording can't fill the disk.
+  private recordings = new Map<string, {
+    outputPath: string;
+    startedAt: number;
+    fps: number;
+    maxBytes: number;
+    durationMs: number;
+    ffmpeg: import('child_process').ChildProcess;
+    sessionId: string;
+    conn: ProfileConnection;
+    frameHandler: (params: unknown) => void;
+    durationTimer: NodeJS.Timeout;
+    sizeCheckInterval: NodeJS.Timeout;
+    stopReason?: 'manual' | 'duration-cap' | 'size-cap';
+  }>();
+
+  async recordStart(
+    taskId: string,
+    tabHint?: string,
+    opts: { fps?: number; duration?: number; maxMb?: number } = {}
+  ): Promise<{ path: string; fps: number; durationCapSec: number; maxMb: number }> {
+    if (this.recordings.has(taskId)) {
+      throw new Error(`Task "${taskId}" is already recording. Call record stop first.`);
+    }
+
+    const { conn, task } = await this.findTask(taskId);
+    const shortId = tabHint ? await this.resolveTabHint(conn, task, tabHint) : this.resolveCurrentTab(task);
+    const cdpTargetId = this.getCdpTargetId(task, shortId);
+    const target = await this.getTarget(conn, cdpTargetId);
+    if (!target) throw new Error(`Tab ${shortId} not found`);
+    const sessionId = await this.getSessionId(conn, target.targetId);
+
+    const fps = opts.fps ?? 5;
+    const durationSec = opts.duration ?? 60;
+    const maxMb = opts.maxMb ?? 25;
+    if (fps < 1 || fps > 30) throw new Error('--fps must be between 1 and 30');
+    if (durationSec < 1 || durationSec > 3600) throw new Error('--duration must be between 1 and 3600 seconds');
+    if (maxMb < 1 || maxMb > 500) throw new Error('--max-mb must be between 1 and 500');
+
+    const recordingsDir = path.join(getBrowserRuntimeDir(), 'sessions', task.name, 'recordings');
+    await fs.promises.mkdir(recordingsDir, { recursive: true });
+    const outputPath = path.join(recordingsDir, `${Date.now()}.webm`);
+
+    // Resolve ffmpeg lazily so non-recording paths don't pay the import cost.
+    const { spawn } = await import('child_process');
+    const ffmpeg = spawn(
+      'ffmpeg',
+      [
+        '-loglevel', 'error',
+        '-f', 'image2pipe',
+        '-framerate', String(fps),
+        '-i', '-',
+        '-c:v', 'libvpx-vp9',
+        '-b:v', '1M',
+        '-pix_fmt', 'yuv420p',
+        '-y',
+        outputPath,
+      ],
+      { stdio: ['pipe', 'ignore', 'pipe'] }
+    );
+    let ffmpegStderr = '';
+    ffmpeg.stderr?.on('data', (chunk) => { ffmpegStderr += chunk.toString(); });
+    ffmpeg.on('error', (err) => {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        // ffmpeg is missing; surface a useful message via stop().
+        ffmpegStderr = 'ffmpeg not found on PATH — install via `brew install ffmpeg`';
+      }
+    });
+
+    // 30 fps is CDP's screencast cap; everyNthFrame = round(30/fps).
+    const everyNthFrame = Math.max(1, Math.round(30 / fps));
+    await conn.cdp.send(
+      'Page.startScreencast',
+      { format: 'jpeg', quality: 60, everyNthFrame },
+      sessionId
+    );
+
+    const frameHandler = (params: unknown) => {
+      const p = params as { data: string; sessionId: number };
+      try {
+        ffmpeg.stdin?.write(Buffer.from(p.data, 'base64'));
+      } catch {
+        // ffmpeg exited; ignore writes
+      }
+      // Must ack every frame or CDP stops sending.
+      conn.cdp.send('Page.screencastFrameAck', { sessionId: p.sessionId }, sessionId).catch(() => {});
+    };
+    conn.cdp.on('Page.screencastFrame', frameHandler);
+
+    const durationMs = durationSec * 1000;
+    const maxBytes = maxMb * 1024 * 1024;
+
+    const state = {
+      outputPath,
+      startedAt: Date.now(),
+      fps,
+      durationMs,
+      maxBytes,
+      ffmpeg,
+      sessionId,
+      conn,
+      frameHandler,
+      durationTimer: setTimeout(() => {
+        this.recordStop(taskId, 'duration-cap').catch(() => {});
+      }, durationMs),
+      sizeCheckInterval: setInterval(async () => {
+        try {
+          const st = await fs.promises.stat(outputPath);
+          if (st.size >= maxBytes) {
+            await this.recordStop(taskId, 'size-cap');
+          }
+        } catch {
+          // File may not exist yet
+        }
+      }, 1000),
+    };
+    this.recordings.set(taskId, state);
+
+    return { path: outputPath, fps, durationCapSec: durationSec, maxMb };
+  }
+
+  async recordStop(
+    taskId: string,
+    reason: 'manual' | 'duration-cap' | 'size-cap' = 'manual'
+  ): Promise<{ path: string; bytes: number; durationMs: number; reason: string }> {
+    const rec = this.recordings.get(taskId);
+    if (!rec) {
+      throw new Error(`Task "${taskId}" is not currently recording`);
+    }
+    if (rec.stopReason) {
+      // Already stopping (e.g. size-cap fired while user also called stop).
+      // Wait for in-flight finalize.
+      while (this.recordings.has(taskId)) {
+        await new Promise((r) => setTimeout(r, 25));
+      }
+    }
+    rec.stopReason = reason;
+
+    clearTimeout(rec.durationTimer);
+    clearInterval(rec.sizeCheckInterval);
+    rec.conn.cdp.off('Page.screencastFrame', rec.frameHandler);
+
+    try {
+      await rec.conn.cdp.send('Page.stopScreencast', {}, rec.sessionId);
+    } catch {
+      // session may already be gone
+    }
+
+    // Close ffmpeg stdin so it flushes the output file cleanly.
+    await new Promise<void>((resolve) => {
+      rec.ffmpeg.on('exit', () => resolve());
+      try {
+        rec.ffmpeg.stdin?.end();
+      } catch {
+        resolve();
+      }
+      setTimeout(resolve, 5000); // Hard timeout if ffmpeg hangs
+    });
+
+    let bytes = 0;
+    try {
+      const st = await fs.promises.stat(rec.outputPath);
+      bytes = st.size;
+    } catch {
+      // ffmpeg may have failed; file missing
+    }
+    const durationMs = Date.now() - rec.startedAt;
+
+    this.recordings.delete(taskId);
+    return { path: rec.outputPath, bytes, durationMs, reason };
+  }
+
+  async recordStatus(taskId: string): Promise<{ recording: boolean; path?: string; elapsedMs?: number }> {
+    const rec = this.recordings.get(taskId);
+    if (!rec) return { recording: false };
+    return { recording: true, path: rec.outputPath, elapsedMs: Date.now() - rec.startedAt };
   }
 
   private refsCache = new Map<string, { refs: string; nodeMap: Map<number, RefNode>; ts: number }>();
@@ -1294,42 +1530,46 @@ export class BrowserService {
     return { forkName, connection };
   }
 
-  private async connectProfile(profile: BrowserProfile): Promise<ProfileConnection> {
-    const existingInfo = getRunningChromeInfo(profile.name);
+  /**
+   * Connect to a profile at a specific endpoint preset. The caller has
+   * already resolved the endpoint and built the `effectiveProfile` with
+   * the per-endpoint binary/targetFilter overrides applied; we just use it.
+   *
+   * `effectiveProfile.name` is the composite identifier (`<profile>@<endpoint>`)
+   * so per-endpoint pid/port files don't collide when the same app runs
+   * locally and remotely at the same time.
+   */
+  private async connectProfile(
+    effectiveProfile: BrowserProfile,
+    target: string
+  ): Promise<ProfileConnection> {
+    const existingInfo = getRunningChromeInfo(effectiveProfile.name);
 
     if (existingInfo) {
       const { wsUrl, browser } = await discoverBrowserWsUrl(existingInfo.port);
-      verifyBrowserIdentity(browser, profile.browser, existingInfo.port);
+      verifyBrowserIdentity(browser, effectiveProfile.browser, existingInfo.port);
       const cdp = new CDPClient();
       await cdp.connect(wsUrl);
       await this.enableDomains(cdp);
 
-      const tasks = this.loadTaskState(profile.name);
+      const tasks = this.loadTaskState(effectiveProfile.name);
 
       return {
         cdp,
         port: existingInfo.port,
         pid: existingInfo.pid,
-        electron: profile.electron,
-        targetFilter: profile.targetFilter,
+        electron: effectiveProfile.electron,
+        targetFilter: effectiveProfile.targetFilter,
         tasks,
         sessionCache: new Map(),
       };
     }
 
-    for (const endpoint of profile.endpoints) {
-      try {
-        const conn = await this.connectEndpoint(profile, endpoint);
-        if (conn) return conn;
-      } catch (err) {
-        if (err instanceof Error && err.message.startsWith('Browser identity mismatch')) {
-          throw err;
-        }
-        // Try next endpoint
-      }
+    const conn = await this.connectEndpoint(effectiveProfile, target);
+    if (!conn) {
+      throw new Error(`Could not connect to endpoint ${target} for profile "${effectiveProfile.name}"`);
     }
-
-    throw new Error(`Could not connect to any endpoint for profile "${profile.name}"`);
+    return conn;
   }
 
   private async connectEndpoint(
@@ -1452,6 +1692,21 @@ export class BrowserService {
     })) as { targetId: string };
     conn.windowId = result.targetId;
     return result.targetId;
+  }
+
+  private hasTaskNamed(name: string): boolean {
+    for (const conn of this.connections.values()) {
+      if (conn.tasks.has(name)) return true;
+    }
+    return false;
+  }
+
+  private generateUniqueTaskName(): string {
+    for (let attempt = 0; attempt < 8; attempt++) {
+      const candidate = generateTaskName();
+      if (!this.hasTaskNamed(candidate)) return candidate;
+    }
+    throw new Error('Could not generate unique task name after 8 attempts');
   }
 
   private async findTask(

--- a/src/lib/browser/types.ts
+++ b/src/lib/browser/types.ts
@@ -1,5 +1,21 @@
 export type BrowserType = 'chrome' | 'comet' | 'chromium' | 'brave' | 'edge' | 'custom';
 
+/**
+ * A single named endpoint preset within a profile. Lets one profile cover
+ * the local + remote variants of the same app (e.g. Rush on this Mac vs.
+ * Rush on mac-mini) instead of forcing two parallel profiles.
+ *
+ * Per-endpoint overrides take precedence over profile-level fields.
+ */
+export interface EndpointPreset {
+  /** CDP URL — `cdp://host:port` or `ssh://host?port=N` */
+  target: string;
+  /** Override the profile-level binary (e.g. mac-mini has no local binary). */
+  binary?: string;
+  /** Override the profile-level targetFilter (Electron app builds may diverge). */
+  targetFilter?: string;
+}
+
 export interface BrowserProfile {
   name: string;
   description?: string;
@@ -11,7 +27,14 @@ export interface BrowserProfile {
    * represents the visible UI for Electron apps with multiple WebContents.
    */
   targetFilter?: string;
-  endpoints: string[];
+  /**
+   * Endpoint presets. Accepts two shapes for backward compatibility:
+   *   - Legacy: `string[]` of CDP URLs; first entry is the default.
+   *   - New:    `{ [presetName]: EndpointPreset }`, with optional `defaultEndpoint`.
+   * Normalize via `resolveEndpoint(profile, name?)` instead of reading directly.
+   */
+  endpoints: string[] | Record<string, EndpointPreset>;
+  defaultEndpoint?: string;
   chrome?: ChromeOptions;
   secrets?: string;
   viewport?: { width: number; height: number; x?: number; y?: number };
@@ -79,7 +102,8 @@ export interface HistoricalTask {
 
 export type IPCAction =
   | 'start'
-  | 'launch-profile'
+  | 'record-start'
+  | 'record-stop'
   | 'done'
   | 'stop'
   | 'status'
@@ -149,6 +173,27 @@ export interface IPCRequest {
   files?: string[];
   trigger?: number;
   uploadMode?: 'auto' | 'input' | 'drop' | 'chooser';
+  // Screenshot
+  quality?: 'compressed' | 'raw';
+  // Endpoint preset
+  endpoint?: string;
+  // Recording
+  fps?: number;
+  duration?: number;
+  maxMb?: number;
+}
+
+/** Subset of IPCResponse describing a recording start result. */
+export interface RecordStartFields {
+  fps?: number;
+  durationCapSec?: number;
+  maxMb?: number;
+}
+
+/** Subset of IPCResponse describing a recording stop result. */
+export interface RecordStopFields {
+  durationMs?: number;
+  stopReason?: 'manual' | 'duration-cap' | 'size-cap';
 }
 
 export interface IPCResponse {
@@ -162,10 +207,19 @@ export interface IPCResponse {
   history?: HistoricalTask[];
   result?: unknown;
   path?: string;
+  bytes?: number;
+  width?: number;
+  height?: number;
   refs?: string;
   nodes?: RefNodeJson[];
   port?: number;
   pid?: number;
+  // Recording
+  fps?: number;
+  durationCapSec?: number;
+  maxMb?: number;
+  durationMs?: number;
+  stopReason?: 'manual' | 'duration-cap' | 'size-cap';
   // Console/errors
   logs?: ConsoleEntry[];
   errors?: ErrorEntry[];
@@ -237,15 +291,36 @@ export function generateShortId(): string {
 const ADJECTIVES = [
   'swift', 'cosmic', 'jolly', 'quiet', 'bold', 'bright', 'calm', 'eager',
   'golden', 'happy', 'keen', 'lucky', 'noble', 'proud', 'quick', 'royal',
+  'silver', 'amber', 'crimson', 'misty', 'sunny', 'gentle', 'wild', 'brave',
+  'merry', 'sleek', 'wise', 'fierce', 'curious', 'humble', 'spry', 'witty',
 ];
 
 const NOUNS = [
   'falcon', 'comet', 'tiger', 'nebula', 'phoenix', 'river', 'summit', 'wave',
   'aurora', 'breeze', 'crystal', 'dragon', 'ember', 'forest', 'glacier', 'harbor',
+  'crab', 'otter', 'hawk', 'fox', 'wolf', 'panda', 'lynx', 'raven',
+  'meadow', 'canyon', 'valley', 'orchid', 'cedar', 'thistle', 'lotus', 'briar',
 ];
 
 export function generateFunName(): string {
   const adj = ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)];
   const noun = NOUNS[Math.floor(Math.random() * NOUNS.length)];
   return `${adj}-${noun}`;
+}
+
+/**
+ * Auto-generated task name: `<adjective>-<noun>-<noun>-<hex8>`, e.g.
+ * `swift-crab-falcon-a3f92b1c`. Three English words make it memorable and
+ * easy to read; 32 bits of hex give every spawned task enough entropy that
+ * parallel agents never collide on the daemon side.
+ */
+export function generateTaskName(): string {
+  const adj = ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)];
+  const noun1 = NOUNS[Math.floor(Math.random() * NOUNS.length)];
+  let noun2 = NOUNS[Math.floor(Math.random() * NOUNS.length)];
+  while (noun2 === noun1) {
+    noun2 = NOUNS[Math.floor(Math.random() * NOUNS.length)];
+  }
+  const hex8 = crypto.randomUUID().replace(/-/g, '').slice(0, 8);
+  return `${adj}-${noun1}-${noun2}-${hex8}`;
 }

--- a/src/lib/help.ts
+++ b/src/lib/help.ts
@@ -44,25 +44,52 @@ function formatHelpCommandsFirst(cmd: Command, helper: Help): string {
     return textArray.join('\n').replace(/^/gm, ' '.repeat(itemIndentWidth));
   }
 
-  let output = [`Usage: ${helper.commandUsage(cmd)}`, ''];
+  // Drop arguments flagged as hidden (deprecation / compat slots) from both
+  // the Usage line and the Arguments section. Commander v12's Argument lacks
+  // hideHelp(), so we read a custom `hidden` field that callers set directly.
+  const isHidden = (a: { hidden?: boolean }): boolean => a.hidden === true;
+  const registeredArgs = (cmd as unknown as { registeredArguments?: ReadonlyArray<{ name(): string; required: boolean; variadic: boolean; hidden?: boolean }> }).registeredArguments ?? [];
+
+  const parentNames: string[] = [];
+  for (let p = cmd.parent; p; p = p.parent) parentNames.unshift(p.name());
+  const parentPrefix = parentNames.length > 0 ? parentNames.join(' ') + ' ' : '';
+  const visibleArgTokens = registeredArgs
+    .filter((a) => !isHidden(a))
+    .map((a) => {
+      const n = a.name() + (a.variadic ? '...' : '');
+      return a.required ? `<${n}>` : `[${n}]`;
+    })
+    .join(' ');
+  // commander always exposes -h/--help, so every command effectively has options.
+  // Order matches commander's default: name [options] <args> [command].
+  const argsToken = visibleArgTokens ? ` ${visibleArgTokens}` : '';
+  const commandToken = cmd.commands.length > 0 ? ' [command]' : '';
+  const usageLine = `${parentPrefix}${cmd.name()} [options]${argsToken}${commandToken}`;
+  let output = [`Usage: ${usageLine}`, ''];
 
   const commandDescription = helper.commandDescription(cmd);
   if (commandDescription.length > 0) {
     output = output.concat([helper.wrap(commandDescription, helpWidth, 0), '']);
   }
 
-  const argumentList = helper.visibleArguments(cmd).map((argument) => {
-    return formatItem(helper.argumentTerm(argument), helper.argumentDescription(argument));
-  });
+  const argumentList = helper
+    .visibleArguments(cmd)
+    .filter((a) => !isHidden(a as { hidden?: boolean }))
+    .map((argument) => {
+      return formatItem(helper.argumentTerm(argument), helper.argumentDescription(argument));
+    });
   if (argumentList.length > 0) {
     output = output.concat(['Arguments:', formatList(argumentList), '']);
   }
 
   const visibleCommands = helper.visibleCommands(cmd);
   const subcommandTermNoAlias = (sub: Command): string => {
-    // Mirror commander's default subcommandTerm but drop the |alias suffix.
-    const argList = (sub as unknown as { registeredArguments?: ReadonlyArray<{ name(): string; required: boolean; variadic: boolean }> }).registeredArguments ?? [];
+    // Mirror commander's default subcommandTerm but drop the |alias suffix and
+    // skip arguments marked as hidden (Argument#hideHelp()), so deprecation /
+    // compatibility slots don't pollute the usage line.
+    const argList = (sub as unknown as { registeredArguments?: ReadonlyArray<{ name(): string; required: boolean; variadic: boolean; hidden?: boolean }> }).registeredArguments ?? [];
     const args = argList
+      .filter((a) => !a.hidden)
       .map((a) => {
         const n = a.name() + (a.variadic ? '...' : '');
         return a.required ? `<${n}>` : `[${n}]`;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -498,7 +498,14 @@ export interface BrowserProfileConfig {
    * Only consulted when `electron` is true.
    */
   targetFilter?: string;
-  endpoints: string[];
+  /**
+   * Endpoint presets. Accepts two shapes for backward compatibility:
+   *   - Legacy: `string[]` of CDP URLs; first entry is the default.
+   *   - New:    `{ [presetName]: { target, binary?, targetFilter? } }`.
+   */
+  endpoints: string[] | Record<string, { target: string; binary?: string; targetFilter?: string }>;
+  /** Preset name to use when `--endpoint` is not passed to `start`. */
+  defaultEndpoint?: string;
   chrome?: {
     headless?: boolean;
     args?: string[];


### PR DESCRIPTION
## Summary

A wide-but-coherent redesign of the `agents browser` CLI for agent ergonomics.

### Task binding (no more repeating yourself)
- New `--task <name>` flag + `$AGENTS_BROWSER_TASK` env var fallback on every action command. Bind the task once per shell, never type it again.
- Legacy positional `<task>` still works — emits a one-line deprecation warning so existing scripts keep running.
- Auto-generated task names are now 3-word + hex (`swift-crab-falcon-a3f92b1c`) with collision retry.
- `start` writes the task name to stdout and human commentary to stderr, so `T=$(agents browser start --profile X)` works cleanly.

### Named endpoint presets per profile
- One YAML profile now covers local + remote variants of the same app, instead of forcing parallel `rush-local` / `rush-app-remote` profiles.
- New schema:
  ```yaml
  endpoints:
    local:    { target: cdp://127.0.0.1:9223, binary: /Applications/Rush.app/... }
    mac-mini: { target: ssh://mac-mini?port=9223 }
  defaultEndpoint: local
  ```
- `agents browser start --profile rush --endpoint mac-mini` picks a preset.
- Per-endpoint `binary` / `targetFilter` override profile-level fields.
- Daemon connections keyed by `<profile>@<endpoint>` so the same app can run at two endpoints concurrently.
- Legacy `endpoints: [url]` shape still parses — first entry becomes the default.

### Evidence capture
- `screenshot --quality raw` for pixel-faithful PNG (lossless, no downscale). Compressed JPEG stays the default.
- Screenshot output line now reports size + dimensions on stderr so agents skip the `ls -l` round-trip.
- New `record start` / `record stop` — CDP screencast → ffmpeg → webm/vp9 in `sessions/<task>/recordings/`. Bounded by `--fps` (5), `--duration` (60s), `--max-mb` (25); whichever fires first auto-finalizes. Requires ffmpeg on PATH.

### Surface trim
- Removed `profiles prime` (redundant with `start`).
- Removed `profiles launch` (also redundant — `start` blocks until the browser is CDP-attachable, so a separate ready/launch verb adds nothing).
- `tab list` → top-level `tabs`.
- Help reorganized by mental model: Session lifecycle / Drive the page / Capture evidence / Other commands.

### Defaults
- `DEFAULT_VIEWPORT` constant = 1512×982 (MacBook Pro 14"), shared by `profiles create` and the `MacBook Pro` device preset (was 1440×900 — Intel-era — now aligned).
- `profiles show` now prints viewport + per-endpoint overrides (previously silently dropped).

## Diff

10 files changed, 1040 insertions(+), 230 deletions(-)

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/lib/browser/` — 71/71 pass
- [x] Manual: `agents browser navigate qa-task https://...` → deprecation warning + daemon hit
- [x] Manual: `AGENTS_BROWSER_TASK=qa-task agents browser navigate https://...` → silent, daemon hit
- [x] Manual: missing `--task` and missing env var → helpful error pointing at env var
- [x] Manual: `agents browser start --profile no-such-profile` → lists available profiles + create hint
- [x] Manual: `agents browser start --profile rush-app-remote --endpoint nope` → lists endpoint candidates
- [x] Manual: legacy `endpoints: [url]` profile still parses via `profiles show`
- [ ] Live: `agents browser record start` against a real Comet/Rush profile (not exercised in this PR — daemon contract is sound, ffmpeg pipeline is straightforward; will dogfood after merge)

## Migration notes

- The `<profile>@<endpoint>` runtime identity means existing daemon pid/port files at `~/.agents/.cache/browser/<old-profile-name>/` won't be picked up after upgrade — first command will launch a fresh browser instance. One-time inconvenience; no data loss.
- Existing legacy profile YAMLs keep working untouched. Profiles get the new map shape when you start editing them.
- Existing scripts using positional `<task>` continue to work; they'll see a deprecation warning until updated.