### PR TITLE
fix(browser): make basic CDP actually work — liveness, tunnel binding, orphan reaping

### DIFF
--- a/src/commands/browser.ts
+++ b/src/commands/browser.ts
@@ -23,6 +23,11 @@ import {
   type BrowserProfile,
 } from '../lib/browser/profiles.js';
 import { findBrowserPath, getPortOccupant } from '../lib/browser/chrome.js';
+import {
+  listProfileCacheDirs,
+  removeProfileCache,
+  listAllProfileSnapshots,
+} from '../lib/browser/runtime-state.js';
 import { DEFAULT_VIEWPORT } from '../lib/browser/devices.js';
 import { discoverBrowserWsUrl, verifyBrowserIdentity } from '../lib/browser/cdp.js';
 import { parseTargetFilter } from '../lib/browser/service.js';
@@ -315,10 +320,30 @@ function registerProfilesCommands(browser: Command): void {
 
   profiles
     .command('delete <name>')
-    .description('Delete a browser profile')
-    .action(async (name: string) => {
+    .description('Delete a browser profile (drops YAML config + all cached runtime dirs)')
+    .option('--keep-cache', "Leave ~/.agents/.cache/browser/<name>* dirs in place (don't wipe chrome-data)")
+    .action(async (name: string, opts: { keepCache?: boolean }) => {
       await deleteProfile(name);
-      console.log(`Deleted profile: ${name}`);
+      // The composite naming change introduced multiple cache dirs per
+      // profile (`<name>`, `<name>@endpoint-0`, …). Sweep them all unless
+      // the user explicitly wants the chrome-data preserved (e.g. for
+      // re-import into a freshly-created profile of the same name).
+      let removed = 0;
+      if (!opts.keepCache) {
+        for (const _ of listProfileCacheDirs(name)) removed++;
+        for (const dir of listProfileCacheDirs(name)) {
+          // `removeProfileCache` operates by profile-name; for the
+          // composite dirs we already have the absolute path. Use rmSync
+          // directly so we don't depend on naming round-trips.
+          try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+        }
+        // The canonical wipe also covers the legacy dir if present.
+        removeProfileCache(name);
+      }
+      console.log(
+        `Deleted profile: ${name}` +
+          (removed > 0 ? ` (and ${removed} cache dir${removed === 1 ? '' : 's'})` : '')
+      );
     });
 
   profiles
@@ -345,11 +370,29 @@ function registerProfilesCommands(browser: Command): void {
         });
       }
 
-      // 2. Configured port: free, or already serving the expected browser?
+      // 2. Configured port. For local cdp:// we check the local port. For
+      //    ssh:// the port lives on a remote host — doctor's previous
+      //    behavior was to lsof the LOCAL port number, which was both
+      //    misleading and arbitrary (after the SSH-binds-locally change
+      //    the local port now matches the remote, so a positive answer
+      //    is plausible; but doctor still shouldn't report on remote
+      //    state without an --remote-probe explicitly).
       const port = extractConfiguredPort(profile);
       let attachingToExistingBrowser = false;
+      const firstEndpointTarget = (() => {
+        const presets = getEndpointPresets(profile);
+        const first = Object.keys(presets)[0];
+        return first ? presets[first].target : undefined;
+      })();
+      const isSshEndpoint = firstEndpointTarget?.startsWith('ssh://') ?? false;
       if (port === undefined) {
         checks.push({ label: 'port', ok: true, detail: 'no port in endpoint' });
+      } else if (isSshEndpoint) {
+        checks.push({
+          label: 'port',
+          ok: true,
+          detail: `${port} (remote on ${firstEndpointTarget}) — skipping local check`,
+        });
       } else {
         const occupant = getPortOccupant(port);
         if (!occupant) {
@@ -531,10 +574,28 @@ function registerTaskCommands(browser: Command): void {
   browser
     .command('stop')
     .addArgument(hiddenLegacyArg('legacyTask'))
-    .description('Stop a browser task and close its tabs')
+    .description('Stop a browser task and close its tabs; with --profile, detach the whole profile (close browser + drop cached connection)')
     .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
+    .option('-p, --profile <name>', 'Detach the whole profile (incl. composite "name@endpoint") instead of stopping a single task')
     .action(async (legacyTask: string | undefined, opts) => {
+      if (opts.profile) {
+        const response = await sendIPCRequest({
+          action: 'stop',
+          profile: opts.profile,
+        });
+        if (!response.ok) {
+          console.error(response.error);
+          process.exit(1);
+        }
+        console.log(`Stopped profile: ${opts.profile}`);
+        return;
+      }
+
       const { task } = unpackPositionals([legacyTask], 0, opts);
+      if (!task) {
+        console.error('Either --task or --profile is required.');
+        process.exit(1);
+      }
       const response = await sendIPCRequest({
         action: 'stop',
         task,
@@ -743,6 +804,80 @@ function registerTaskCommands(browser: Command): void {
 
       console.log(JSON.stringify(response.result, null, 2));
     });
+
+  browser
+    .command('ps')
+    .description('List every browser/electron/tunnel process agents has tracked (alive or stale) — works without the daemon')
+    .option('--json', 'Output machine-readable JSON')
+    .action((opts: { json?: boolean }) => {
+      const snapshots = listAllProfileSnapshots();
+      // Cross-check against what's actually listening locally so we can
+      // surface "port claimed by us but nothing is listening" (= leaked
+      // cache file) and "port listening but not in our records" (= someone
+      // else owns it; a new profile pointing here would collide).
+      const portOwners = new Map<number, { pid: number; command: string }>();
+      const conflicts: string[] = [];
+      for (const s of snapshots) {
+        const port = s.meta?.port;
+        if (!port) continue;
+        const occupant = getPortOccupant(port);
+        if (!occupant) {
+          if (s.pidAlive || s.tunnelAlive) {
+            conflicts.push(`${s.name}: port ${port} marked active but nothing is listening`);
+          }
+          continue;
+        }
+        const ourPid = s.meta?.tunnelPid && s.meta.kind === 'tunnel'
+          ? s.meta.tunnelPid
+          : s.meta?.pid;
+        if (ourPid && occupant.pid !== ourPid) {
+          conflicts.push(
+            `${s.name}: port ${port} listened on by ${occupant.command} (pid ${occupant.pid}) but our record says pid ${ourPid}`
+          );
+        }
+        portOwners.set(port, occupant);
+      }
+
+      if (opts.json) {
+        console.log(JSON.stringify({ snapshots, conflicts }, null, 2));
+        return;
+      }
+
+      if (snapshots.length === 0) {
+        console.log('No tracked browser state. Run `agents browser start --profile <name>` to spawn one.');
+        return;
+      }
+
+      console.log('PROFILE                                  KIND      PID    TUNNEL  PORT   ALIVE  TASKS  OWNER');
+      console.log('-----------------------------------------------------------------------------------------------');
+      for (const s of snapshots) {
+        const kind = s.meta?.kind ?? '-';
+        const pid = s.meta?.pid ?? '-';
+        const tunnelPid = s.meta?.tunnelPid ?? '-';
+        const port = s.meta?.port ?? '-';
+        const alive = aliveLabel(s);
+        const owner = s.meta?.daemonPid
+          ? `daemon${s.daemonAlive ? '' : '(dead)'}=${s.meta.daemonPid}`
+          : '-';
+        console.log(
+          `${s.name.padEnd(40)} ${String(kind).padEnd(9)} ${String(pid).padEnd(6)} ${String(tunnelPid).padEnd(7)} ${String(port).padEnd(6)} ${alive.padEnd(6)} ${String(s.taskCount).padEnd(6)} ${owner}`
+        );
+      }
+
+      if (conflicts.length > 0) {
+        console.log('');
+        console.log('Conflicts / leaks detected:');
+        for (const c of conflicts) console.log(`  - ${c}`);
+        console.log('');
+        console.log('Run `agents browser stop --profile <name>` to clean up a specific profile, or restart the daemon to trigger the orphan reaper.');
+      }
+    });
+
+  function aliveLabel(s: { pidAlive: boolean; tunnelAlive: boolean; meta: { kind?: string } | null }): string {
+    const k = s.meta?.kind;
+    if (k === 'tunnel') return s.tunnelAlive ? 'yes' : 'stale';
+    return s.pidAlive ? 'yes' : 'stale';
+  }
 
   browser
     .command('status')

--- a/src/commands/browser.ts
+++ b/src/commands/browser.ts
@@ -330,8 +330,9 @@ function registerProfilesCommands(browser: Command): void {
       // re-import into a freshly-created profile of the same name).
       let removed = 0;
       if (!opts.keepCache) {
-        for (const _ of listProfileCacheDirs(name)) removed++;
-        for (const dir of listProfileCacheDirs(name)) {
+        const cacheDirs = listProfileCacheDirs(name);
+        removed = cacheDirs.length;
+        for (const dir of cacheDirs) {
           // `removeProfileCache` operates by profile-name; for the
           // composite dirs we already have the absolute path. Use rmSync
           // directly so we don't depend on naming round-trips.

--- a/src/lib/browser/cdp.ts
+++ b/src/lib/browser/cdp.ts
@@ -28,7 +28,15 @@ export class CDPClient {
     sessionId?: string
   ): Promise<T> {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
-      throw new Error('CDP connection not open');
+      // Reached when the underlying browser was killed externally between
+      // the daemon establishing the connection and a CDP call going out.
+      // The service-layer healthcheck normally catches this on the next
+      // `start`, so seeing this in the wild means a request landed against
+      // an in-flight conn that just died — tell the user how to recover.
+      throw new Error(
+        'CDP connection not open — the browser was likely closed externally. ' +
+          'Run `agents browser stop --profile <name>` (or restart the daemon) and try again.'
+      );
     }
 
     const id = ++this.messageId;

--- a/src/lib/browser/chrome.ts
+++ b/src/lib/browser/chrome.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import { getProfileRuntimeDir } from './profiles.js';
 import { discoverBrowserWsUrl } from './cdp.js';
 import { readBundle, resolveBundleEnv, bundleExists } from '../secrets/bundles.js';
+import { writeProfileRuntime, readProfileRuntime } from './runtime-state.js';
 import type { ChromeOptions } from './types.js';
 
 import type { BrowserType } from './types.js';
@@ -87,13 +88,31 @@ export async function launchBrowser(
   port: number,
   options: ChromeOptions = {},
   secrets?: string,
-  customBinary?: string
+  customBinary?: string,
+  // `electron: true` distinguishes Notion / VS Code-style apps from
+  // regular Chrome — purely informational, stored in meta.json so the
+  // orphan reaper and `agents browser status` can label processes.
+  isElectron: boolean = false
 ): Promise<LaunchResult> {
   const browserPath = findBrowserPath(browserType, customBinary);
 
   const runtimeDir = getProfileRuntimeDir(profileName);
   const userDataDir = path.join(runtimeDir, 'chrome-data');
   fs.mkdirSync(userDataDir, { recursive: true });
+
+  // First-launch seed: stamp the user-data-dir's Default/Preferences with
+  // the agents-cli profile name so Chromium's UI shows "<profile>" instead
+  // of its default "Person 1". Done only when the file doesn't exist —
+  // subsequent launches inherit whatever Chrome wrote in the meantime.
+  seedDefaultProfileName(userDataDir, profileName);
+
+  // Chromium on macOS coordinates instances via the SingletonLock file
+  // *inside* each user-data-dir. Direct binary spawn with a fresh
+  // --user-data-dir creates a fully independent process — the user's
+  // normal browser (running under their default user-data-dir) and our
+  // sandboxed one coexist as two real processes. The macOS Dock collapses
+  // them into one icon per .app bundle, which makes it look like a single
+  // instance, but `ps -ww` will show both.
 
   const viewport = options.viewport ?? { width: 1512, height: 982 };
   const args = [
@@ -103,6 +122,12 @@ export async function launchBrowser(
     '--disable-background-timer-throttling',
     '--disable-backgrounding-occluded-windows',
     '--disable-renderer-backgrounding',
+    // First-run + default-browser modals block automation: when targetFilter
+    // matches by URL, the onboarding page (`chrome://welcome/`) isn't a
+    // match and start fails with "no page target". Suppress them.
+    '--no-first-run',
+    '--no-default-browser-check',
+    '--disable-features=DefaultBrowserSetting,ChromeWhatsNewUI',
     ...(options.headless ? ['--headless=new'] : []),
     `--window-size=${viewport.width},${viewport.height}`,
     ...(viewport.x !== undefined && viewport.y !== undefined
@@ -130,8 +155,13 @@ export async function launchBrowser(
   child.unref();
 
   const pid = child.pid!;
-  fs.writeFileSync(path.join(runtimeDir, 'pid'), String(pid));
-  fs.writeFileSync(path.join(runtimeDir, 'port'), String(port));
+  writeProfileRuntime(profileName, {
+    pid,
+    port,
+    command: path.basename(browserPath),
+    userDataDir,
+    kind: isElectron ? 'electron' : 'browser',
+  });
 
   let wsUrl: string | null = null;
   for (let i = 0; i < 30; i++) {
@@ -168,36 +198,32 @@ export function killChrome(pid: number): void {
 export function getRunningChromeInfo(
   profileName: string
 ): { pid: number; port: number } | null {
-  const runtimeDir = getProfileRuntimeDir(profileName);
-  const pidFile = path.join(runtimeDir, 'pid');
-  const portFile = path.join(runtimeDir, 'port');
-
-  if (!fs.existsSync(pidFile) || !fs.existsSync(portFile)) {
-    return null;
-  }
-
-  const pid = parseInt(fs.readFileSync(pidFile, 'utf-8').trim(), 10);
-  const port = parseInt(fs.readFileSync(portFile, 'utf-8').trim(), 10);
-
-  if (!isProcessRunning(pid)) {
-    fs.unlinkSync(pidFile);
-    fs.unlinkSync(portFile);
-    return null;
-  }
-
-  return { pid, port };
+  // Delegate to runtime-state, which auto-cleans stale files and verifies
+  // the live pid still runs the command we recorded — so a recycled pid
+  // doesn't masquerade as our browser.
+  const rt = readProfileRuntime(profileName);
+  if (!rt) return null;
+  return { pid: rt.pid, port: rt.port };
 }
 
-function isProcessRunning(pid: number): boolean {
+/**
+ * Stamp `<userDataDir>/Default/Preferences` with our profile name so
+ * Chrome's UI labels the window with the agents-cli name rather than the
+ * default "Person 1". Only writes when the file is absent (first launch).
+ * Best-effort: any I/O hiccup is silently ignored; missing the rename is
+ * cosmetic, not functional.
+ */
+function seedDefaultProfileName(userDataDir: string, profileName: string): void {
+  const defaultDir = path.join(userDataDir, 'Default');
+  const prefsPath = path.join(defaultDir, 'Preferences');
+  if (fs.existsSync(prefsPath)) return;
   try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err: any) {
-    // EPERM means the process exists but we lack permission to signal it —
-    // treat as alive. ESRCH means the process does not exist.
-    if (err && err.code === 'EPERM') return true;
-    return false;
-  }
+    fs.mkdirSync(defaultDir, { recursive: true });
+    fs.writeFileSync(
+      prefsPath,
+      JSON.stringify({ profile: { name: profileName } })
+    );
+  } catch { /* not critical */ }
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/lib/browser/drivers/local.ts
+++ b/src/lib/browser/drivers/local.ts
@@ -1,11 +1,23 @@
 import { CDPClient, discoverBrowserWsUrl, verifyBrowserIdentity } from '../cdp.js';
 import { launchBrowser, getPortOccupant } from '../chrome.js';
+import { parseEndpointUrl } from '../profiles.js';
 import type { BrowserProfile } from '../types.js';
 
 export interface LocalConnection {
   cdp: CDPClient;
   port: number;
   pid: number;
+}
+
+/**
+ * Local-port listeners we refuse to attach through. These forward CDP traffic
+ * to a remote host — silently using them would let a `cdp://127.0.0.1:N`
+ * profile drive a browser on a different machine without the caller realizing.
+ */
+const TUNNEL_PROCESS_NAMES = new Set(['ssh', 'autossh', 'mosh-client', 'socat']);
+
+function isTunnelProcess(command: string): boolean {
+  return TUNNEL_PROCESS_NAMES.has(command.toLowerCase());
 }
 
 export async function connectLocal(
@@ -18,7 +30,27 @@ export async function connectLocal(
     throw new Error(`Invalid local endpoint: ${endpoint}`);
   }
 
-  const port = parseInt(url.port, 10) || 9222;
+  // Share the parser with the SSH driver and the collision-detection code
+  // path so `cdp://host:N` and `cdp://host?port=N` behave identically.
+  const parsed = parseEndpointUrl(endpoint);
+  const port = parsed?.port ?? 9222;
+
+  // Refuse to attach through an SSH tunnel before we even try to speak CDP.
+  // `verifyBrowserIdentity` only inspects what comes back over the wire — it
+  // can't tell whether the browser actually lives on this machine or on the
+  // far end of an `ssh -L` tunnel. A stale tunnel from a prior session
+  // (common when an SSH-driven profile is deleted before the daemon exits)
+  // will silently hijack any "local" profile bound to the same port.
+  const preOccupant = getPortOccupant(port);
+  if (preOccupant && isTunnelProcess(preOccupant.command)) {
+    throw new Error(
+      `Port ${port} is held by ${preOccupant.command} (pid ${preOccupant.pid}), an SSH ` +
+        `tunnel forwarding to a remote host. Profile "${profile.name}" is configured as ` +
+        `local (${endpoint}) but traffic would round-trip to another machine. Either kill ` +
+        `the tunnel (\`kill ${preOccupant.pid}\`) and retry, or switch the profile to an ` +
+        `ssh:// endpoint to drive the remote browser explicitly.`
+    );
+  }
 
   try {
     const { wsUrl, browser } = await discoverBrowserWsUrl(port);
@@ -54,7 +86,8 @@ export async function connectLocal(
       newPort,
       chromeOpts,
       profile.secrets,
-      profile.binary
+      profile.binary,
+      profile.electron === true
     );
     const cdp = new CDPClient();
     await cdp.connect(wsUrl);

--- a/src/lib/browser/drivers/ssh.ts
+++ b/src/lib/browser/drivers/ssh.ts
@@ -1,7 +1,9 @@
-import { spawn, type ChildProcess } from 'child_process';
+import { spawn, execSync, type ChildProcess } from 'child_process';
 import * as net from 'net';
 import { CDPClient, discoverBrowserWsUrl, verifyBrowserIdentity } from '../cdp.js';
-import { allocatePort } from '../chrome.js';
+import { getPortOccupant } from '../chrome.js';
+import { parseEndpointUrl } from '../profiles.js';
+import { writeProfileRuntime, clearProfileRuntime } from '../runtime-state.js';
 import type { BrowserProfile } from '../types.js';
 
 export interface SSHConnection {
@@ -22,9 +24,34 @@ export async function connectSSH(
   }
 
   const user = url.username || process.env.USER || 'root';
-  const host = url.hostname;
-  const remotePort = url.port ? parseInt(url.port, 10) : 9222;
-  const localPort = allocatePort();
+  // Use the shared parser so the documented `ssh://host?port=N` form works
+  // identically to `ssh://host:N`. Previously `url.port` alone meant every
+  // `?port=`-style profile silently fell back to 9222.
+  const parsed = parseEndpointUrl(endpoint);
+  if (!parsed) {
+    throw new Error(`Could not extract host:port from SSH endpoint: ${endpoint}`);
+  }
+  const host = parsed.host;
+  const remotePort = parsed.port;
+
+  // Bind the tunnel to the SAME local port the user configured. Using an
+  // allocated port instead made `status` print confusing rows like
+  // `port 9200 (configured 10005)` and made it impossible to predict which
+  // local port a profile would land on. Now `ssh://host?port=N` => local N.
+  const localPort = remotePort;
+
+  // Preflight: if the local port is busy with something that isn't our
+  // own SSH tunnel for this very target, bail with a clear error. Letting
+  // ssh -L race ahead would either silently succeed (binding to a second
+  // port via fail-safe) or fail with cryptic stderr.
+  const occupant = getPortOccupant(localPort);
+  if (occupant && !isOwnTunnel(occupant.pid, host, remotePort)) {
+    throw new Error(
+      `Local port ${localPort} (needed for SSH tunnel to ${host}:${remotePort}) ` +
+        `is already in use by ${occupant.command} (pid ${occupant.pid}). ` +
+        `Either kill that process (\`kill ${occupant.pid}\`) or change the profile's port.`
+    );
+  }
 
   try {
     await ensureRemoteBrowser(user, host, profile.browser, remotePort, profile.binary);
@@ -32,7 +59,13 @@ export async function connectSSH(
     // Browser may already be running, continue
   }
 
-  let tunnel = await startSSHTunnel(user, host, localPort, remotePort);
+  let tunnel: ChildProcess;
+  if (occupant) {
+    // Reuse the existing tunnel rather than spawning a duplicate.
+    tunnel = { pid: occupant.pid, kill: () => { try { process.kill(occupant.pid); } catch { /* gone */ } } } as ChildProcess;
+  } else {
+    tunnel = await startSSHTunnel(user, host, localPort, remotePort);
+  }
 
   try {
     await waitForPort(localPort, 8000);
@@ -51,13 +84,29 @@ export async function connectSSH(
   const cdp = new CDPClient();
   await cdp.connect(wsUrl);
 
+  // Record the tunnel in the profile's runtime so a future daemon — or
+  // the orphan reaper after a crash — can find and clean it up. The
+  // `kind: 'tunnel'` flag distinguishes it from a locally-launched
+  // browser process.
+  const tunnelPid = tunnel.pid ?? 0;
+  if (tunnelPid > 0) {
+    writeProfileRuntime(profile.name, {
+      pid: 0,
+      port: localPort,
+      command: 'ssh',
+      kind: 'tunnel',
+      tunnelPid,
+    });
+  }
+
   return {
     cdp,
     port: localPort,
-    pid: tunnel.pid || 0,
+    pid: tunnelPid,
     cleanup: () => {
       cdp.close();
       tunnel.kill();
+      clearProfileRuntime(profile.name);
     },
   };
 }
@@ -214,4 +263,28 @@ function runSSHCommand(user: string, host: string, cmd: string): Promise<void> {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Identify whether a pid listening on our target local port is an SSH
+ * tunnel WE would have spawned for `host:remotePort`. Used so that two
+ * agents-browser invocations of the same SSH profile share a tunnel
+ * rather than failing the second one with "port in use".
+ *
+ * Best-effort match against the ssh -L command line via `ps`. If we
+ * can't read the cmd or the args don't look like ours, treat as not-ours.
+ */
+function isOwnTunnel(pid: number, host: string, remotePort: number): boolean {
+  try {
+    const out = execSync(`ps -p ${pid} -o command=`, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toString().trim();
+    if (!out.startsWith('ssh')) return false;
+    if (!out.includes(host)) return false;
+    if (!out.includes(`:${remotePort}`) && !out.includes(`:127.0.0.1:${remotePort}`)) return false;
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/src/lib/browser/ipc.ts
+++ b/src/lib/browser/ipc.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { getHelpersDir } from '../state.js';
 import { BrowserService } from './service.js';
 import { startDaemon } from '../daemon.js';
+import { getCliVersion } from '../version.js';
 import type { IPCRequest, IPCResponse, RefNodeJson } from './types.js';
 
 const SOCKET_NAME = 'browser.sock';
@@ -79,6 +80,10 @@ export class BrowserIPCServer {
 
   private async handleRequest(request: IPCRequest): Promise<IPCResponse> {
     switch (request.action) {
+      case 'version': {
+        return { ok: true, version: getCliVersion() };
+      }
+
       case 'start': {
         if (!request.profile) {
           return { ok: false, error: 'Profile required' };
@@ -412,7 +417,45 @@ export class BrowserIPCServer {
   }
 }
 
+let versionCheckedThisProcess = false;
+
+/**
+ * Check the daemon's version against ours and warn loudly when they
+ * differ. Fires at most once per CLI process — successive calls in the
+ * same `agents browser ...` invocation are cheap. The whole reason this
+ * code exists: a launchd-managed registry daemon kept serving stale code
+ * to a dev-build CLI for an entire session and nothing surfaced it.
+ */
+async function maybeWarnVersionMismatch(): Promise<void> {
+  if (versionCheckedThisProcess) return;
+  versionCheckedThisProcess = true;
+  try {
+    const resp = await sendRawIPCRequest({ action: 'version' });
+    const daemon = resp.version;
+    const client = getCliVersion();
+    if (!daemon || daemon === 'unknown' || daemon === client) return;
+    process.stderr.write(
+      `\nwarning: browser daemon is on ${daemon} but this CLI is on ${client}.\n` +
+        `         Run \`agents daemon restart\` to load the current code.\n\n`
+    );
+  } catch {
+    // daemon might be an older build that doesn't speak 'version' — that's
+    // itself a hint, but a noisy one. Stay silent on this path.
+  }
+}
+
 export async function sendIPCRequest(request: IPCRequest): Promise<IPCResponse> {
+  const result = await sendRawIPCRequest(request);
+  // Run the version check after the user's request returns — keeps the
+  // critical path zero-overhead and ensures `start` doesn't get blocked
+  // on a daemon-restart warning that the user hasn't read yet.
+  if (request.action !== 'version') {
+    maybeWarnVersionMismatch().catch(() => {});
+  }
+  return result;
+}
+
+async function sendRawIPCRequest(request: IPCRequest): Promise<IPCResponse> {
   const socketPath = getSocketPath();
 
   if (!fs.existsSync(socketPath)) {

--- a/src/lib/browser/local.test.ts
+++ b/src/lib/browser/local.test.ts
@@ -51,7 +51,8 @@ describe('connectLocal', () => {
       9335, // must be the endpoint port, not any other port
       expect.anything(),
       undefined,
-      undefined
+      undefined,
+      false // isElectron defaults to false for chrome
     );
   });
 
@@ -98,5 +99,55 @@ describe('connectLocal', () => {
       /kill 1234/
     );
     expect(launchBrowser).not.toHaveBeenCalled();
+  });
+
+  // Regression: a `cdp://127.0.0.1:N` profile must not silently drive the
+  // remote browser sitting on the far end of an SSH tunnel. Verified before
+  // CDP connect — `verifyBrowserIdentity` only checks what comes back over
+  // the wire, so it happily accepts the remote browser's identity.
+  it('refuses to attach when an SSH tunnel holds the local port', async () => {
+    const profile = makeProfile({ browser: 'comet', endpoints: ['cdp://127.0.0.1:9200'] });
+
+    vi.mocked(getPortOccupant).mockReturnValue({ pid: 40117, command: 'ssh' });
+    // discoverBrowserWsUrl WOULD succeed (mac-mini's Comet/Chrome responds
+    // through the tunnel) — make sure we bail before we even ask.
+    vi.mocked(discoverBrowserWsUrl).mockResolvedValue({
+      wsUrl: 'ws://localhost:9200/devtools/browser/abc',
+      browser: 'chrome',
+    });
+
+    await expect(connectLocal('cdp://127.0.0.1:9200', profile)).rejects.toThrow(
+      /forwarding to a remote host/
+    );
+    await expect(connectLocal('cdp://127.0.0.1:9200', profile)).rejects.toThrow(
+      /kill 40117/
+    );
+    expect(discoverBrowserWsUrl).not.toHaveBeenCalled();
+    expect(launchBrowser).not.toHaveBeenCalled();
+  });
+
+  it('detects autossh and socat as tunnel processes too', async () => {
+    const profile = makeProfile({ endpoints: ['cdp://127.0.0.1:9200'] });
+
+    vi.mocked(getPortOccupant).mockReturnValue({ pid: 12, command: 'autossh' });
+    await expect(connectLocal('cdp://127.0.0.1:9200', profile)).rejects.toThrow(
+      /autossh.*forwarding to a remote host/s
+    );
+
+    vi.mocked(getPortOccupant).mockReturnValue({ pid: 34, command: 'socat' });
+    await expect(connectLocal('cdp://127.0.0.1:9200', profile)).rejects.toThrow(
+      /socat.*forwarding to a remote host/s
+    );
+  });
+
+  it('tunnel-process check is case-insensitive', async () => {
+    const profile = makeProfile({ endpoints: ['cdp://127.0.0.1:9200'] });
+
+    // Different platforms (or wrapped binaries) sometimes return "SSH" in
+    // upper-case from lsof. The guard must still catch it.
+    vi.mocked(getPortOccupant).mockReturnValue({ pid: 99, command: 'SSH' });
+    await expect(connectLocal('cdp://127.0.0.1:9200', profile)).rejects.toThrow(
+      /forwarding to a remote host/
+    );
   });
 });

--- a/src/lib/browser/profiles.test.ts
+++ b/src/lib/browser/profiles.test.ts
@@ -14,7 +14,12 @@ vi.mock('./chrome.js', () => ({
   findBrowserPath: vi.fn(() => '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'),
 }));
 
-import { extractConfiguredPort, findFreeProfilePort, createProfile } from './profiles.js';
+import {
+  extractConfiguredPort,
+  extractConfiguredEndpoint,
+  findFreeProfilePort,
+  createProfile,
+} from './profiles.js';
 import type { BrowserProfile } from './types.js';
 import type { BrowserProfileConfig } from '../types.js';
 import { readMeta, writeMeta } from '../state.js';
@@ -24,12 +29,19 @@ function profile(endpoints: string[]): BrowserProfile {
   return { name: 'test', browser: 'chrome', endpoints };
 }
 
+function profileMap(
+  endpoints: Record<string, { target: string }>,
+  defaultEndpoint?: string
+): BrowserProfile {
+  return { name: 'test', browser: 'chrome', endpoints, defaultEndpoint };
+}
+
 describe('extractConfiguredPort', () => {
   it('extracts explicit port from cdp://', () => {
     expect(extractConfiguredPort(profile(['cdp://localhost:9333']))).toBe(9333);
   });
 
-  it('extracts explicit port from ssh:// with ?port=', () => {
+  it('extracts explicit port from ssh://', () => {
     expect(extractConfiguredPort(profile(['ssh://mac-mini:9444']))).toBe(9444);
   });
 
@@ -58,10 +70,158 @@ describe('extractConfiguredPort', () => {
     expect(extractConfiguredPort(profile(['not-a-url']))).toBeUndefined();
   });
 
-  it('uses only the first endpoint', () => {
+  it('uses only the first endpoint in legacy array shape', () => {
     expect(
       extractConfiguredPort(profile(['cdp://localhost:9001', 'cdp://localhost:9002']))
     ).toBe(9001);
+  });
+});
+
+describe('extractConfiguredEndpoint', () => {
+  it('normalizes localhost to 127.0.0.1 for cdp://', () => {
+    expect(extractConfiguredEndpoint(profile(['cdp://localhost:9333']))).toEqual({
+      host: '127.0.0.1',
+      port: 9333,
+    });
+  });
+
+  it('preserves 127.0.0.1 verbatim for cdp://', () => {
+    expect(extractConfiguredEndpoint(profile(['cdp://127.0.0.1:9333']))).toEqual({
+      host: '127.0.0.1',
+      port: 9333,
+    });
+  });
+
+  it('preserves remote host for ssh://', () => {
+    expect(extractConfiguredEndpoint(profile(['ssh://mac-mini:9222']))).toEqual({
+      host: 'mac-mini',
+      port: 9222,
+    });
+  });
+
+  it('strips username from ssh://user@host:port', () => {
+    expect(extractConfiguredEndpoint(profile(['ssh://muqsit@mac-mini:9222']))).toEqual({
+      host: 'mac-mini',
+      port: 9222,
+    });
+  });
+
+  it('defaults port to 9222 when omitted for cdp:// and ssh://', () => {
+    expect(extractConfiguredEndpoint(profile(['cdp://localhost']))).toEqual({
+      host: '127.0.0.1',
+      port: 9222,
+    });
+    expect(extractConfiguredEndpoint(profile(['ssh://mac-mini']))).toEqual({
+      host: 'mac-mini',
+      port: 9222,
+    });
+  });
+
+  it('extracts host:port from ws:// and wss://', () => {
+    expect(extractConfiguredEndpoint(profile(['ws://example.com:9555']))).toEqual({
+      host: 'example.com',
+      port: 9555,
+    });
+    expect(extractConfiguredEndpoint(profile(['wss://example.com:9666']))).toEqual({
+      host: 'example.com',
+      port: 9666,
+    });
+  });
+
+  it('returns undefined for ws:// without an explicit port', () => {
+    // Unlike cdp:// / ssh://, ws:// has no implicit default — caller has no
+    // way to know which port the remote service listens on.
+    expect(extractConfiguredEndpoint(profile(['ws://example.com']))).toBeUndefined();
+  });
+
+  it('returns undefined for empty / malformed / missing endpoints', () => {
+    expect(extractConfiguredEndpoint(profile([]))).toBeUndefined();
+    expect(extractConfiguredEndpoint(profile(['not-a-url']))).toBeUndefined();
+  });
+
+  it('uses first entry of legacy string[] shape', () => {
+    expect(
+      extractConfiguredEndpoint(profile(['cdp://localhost:9001', 'cdp://localhost:9002']))
+    ).toEqual({ host: '127.0.0.1', port: 9001 });
+  });
+
+  it('uses first entry of map shape when no defaultEndpoint set', () => {
+    expect(
+      extractConfiguredEndpoint(
+        profileMap({
+          first: { target: 'cdp://127.0.0.1:9001' },
+          second: { target: 'cdp://127.0.0.1:9002' },
+        })
+      )
+    ).toEqual({ host: '127.0.0.1', port: 9001 });
+  });
+
+  it('honors defaultEndpoint over insertion order in map shape', () => {
+    expect(
+      extractConfiguredEndpoint(
+        profileMap(
+          {
+            local: { target: 'cdp://127.0.0.1:9001' },
+            remote: { target: 'ssh://mac-mini:9222' },
+          },
+          'remote'
+        )
+      )
+    ).toEqual({ host: 'mac-mini', port: 9222 });
+  });
+
+  it('falls back to first entry when defaultEndpoint references unknown preset', () => {
+    expect(
+      extractConfiguredEndpoint(
+        profileMap(
+          { local: { target: 'cdp://127.0.0.1:9001' } },
+          'does-not-exist'
+        )
+      )
+    ).toEqual({ host: '127.0.0.1', port: 9001 });
+  });
+
+  it('extracts port from ssh URL even with username and explicit port', () => {
+    expect(
+      extractConfiguredEndpoint(profile(['ssh://root@mac-studio:18805']))
+    ).toEqual({ host: 'mac-studio', port: 18805 });
+  });
+
+  it('reads the documented ssh://host?port=N query-string form', () => {
+    // Regression: types.ts documents `ssh://host?port=N` as the canonical
+    // SSH endpoint shape, but WHATWG URL parsing exposes it via searchParams
+    // only — `url.port` is empty. Without the searchParams fallback every
+    // `?port=`-style profile silently collapses to 9222.
+    expect(
+      extractConfiguredEndpoint(profile(['ssh://mac-mini?port=18805']))
+    ).toEqual({ host: 'mac-mini', port: 18805 });
+  });
+
+  it('reads ssh://user@host?port=N (query-string form with username)', () => {
+    expect(
+      extractConfiguredEndpoint(profile(['ssh://muqsit@mac-mini?port=18805']))
+    ).toEqual({ host: 'mac-mini', port: 18805 });
+  });
+
+  it('prefers explicit :port over ?port= when both are present', () => {
+    expect(
+      extractConfiguredEndpoint(profile(['ssh://mac-mini:9300?port=18805']))
+    ).toEqual({ host: 'mac-mini', port: 9300 });
+  });
+
+  it('rejects non-numeric ?port= value and falls back to ssh default', () => {
+    expect(
+      extractConfiguredEndpoint(profile(['ssh://mac-mini?port=abc']))
+    ).toEqual({ host: 'mac-mini', port: 9222 });
+  });
+
+  it('returns the same port for cdp://localhost and cdp://127.0.0.1 (collision detection)', () => {
+    // Regression guard: two profiles using these two forms point at the same
+    // local port and must be detected as conflicting. Normalizing localhost
+    // to 127.0.0.1 makes the tuples compare equal.
+    const a = extractConfiguredEndpoint(profile(['cdp://localhost:9222']));
+    const b = extractConfiguredEndpoint(profile(['cdp://127.0.0.1:9222']));
+    expect(a).toEqual(b);
   });
 });
 
@@ -163,5 +323,120 @@ describe('findFreeProfilePort', () => {
 
     const port = await findFreeProfilePort();
     expect(port).toBe(9223);
+  });
+
+  it('treats SSH profile ports as occupied locally now that tunnels bind on the same port', async () => {
+    // SSH profile points at 9222 on mac-mini, but our tunnel will bind
+    // local 9222 → mac-mini:9222, so the local port is claimed and the
+    // allocator must skip it.
+    vi.mocked(readMeta).mockReturnValue({
+      browser: {
+        'ssh-remote': { browser: 'comet', endpoints: ['ssh://mac-mini:9222'] },
+      },
+    } as any);
+    vi.mocked(execSync).mockImplementation(() => { throw new Error('no process'); });
+
+    const port = await findFreeProfilePort();
+    expect(port).toBe(9223);
+  });
+});
+
+describe('createProfile port collision (local-port-scoped)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects two local cdp:// profiles on the same port', async () => {
+    const store: { browser: Record<string, BrowserProfileConfig> } = {
+      browser: {
+        existing: { browser: 'chrome', endpoints: ['cdp://127.0.0.1:9222'] },
+      },
+    };
+    vi.mocked(readMeta).mockImplementation(() => store as any);
+
+    await expect(
+      createProfile({
+        name: 'new',
+        browser: 'chrome',
+        endpoints: ['cdp://127.0.0.1:9222'],
+      })
+    ).rejects.toThrow(/Local port 9222 is already used by profile "existing"/);
+  });
+
+  it('rejects cdp://127.0.0.1:9222 against ssh://mac-mini:9222 because the SSH tunnel binds locally', async () => {
+    // After the SSH-tunnel-port change, ssh://host?port=N binds local N too,
+    // so cdp://127.0.0.1:N and ssh://host?port=N do collide locally even
+    // though their (host, port) tuples differ.
+    const store: { browser: Record<string, BrowserProfileConfig> } = {
+      browser: {
+        remote: { browser: 'comet', endpoints: ['ssh://mac-mini:9222'] },
+      },
+    };
+    vi.mocked(readMeta).mockImplementation(() => store as any);
+
+    await expect(
+      createProfile({
+        name: 'local',
+        browser: 'chrome',
+        endpoints: ['cdp://127.0.0.1:9222'],
+      })
+    ).rejects.toThrow(/Local port 9222 is already used by profile "remote"/);
+  });
+
+  it('rejects two ssh:// profiles on the same port even across different hosts', async () => {
+    // mac-mini's 9222 tunnel binds local 9222; mac-studio's tunnel would
+    // want local 9222 too. Local resource, single owner.
+    const store: { browser: Record<string, BrowserProfileConfig> } = {
+      browser: {
+        mini: { browser: 'comet', endpoints: ['ssh://mac-mini:9222'] },
+      },
+    };
+    vi.mocked(readMeta).mockImplementation(() => store as any);
+
+    await expect(
+      createProfile({
+        name: 'studio',
+        browser: 'comet',
+        endpoints: ['ssh://mac-studio:9222'],
+      })
+    ).rejects.toThrow(/Local port 9222 is already used by profile "mini"/);
+  });
+
+  it('allows ssh:// profiles on different ports to the same host', async () => {
+    const store: { browser: Record<string, BrowserProfileConfig> } = {
+      browser: {
+        first: { browser: 'comet', endpoints: ['ssh://mac-mini?port=9222'] },
+      },
+    };
+    vi.mocked(readMeta).mockImplementation(() => store as any);
+    vi.mocked(writeMeta).mockImplementation((meta: any) => {
+      store.browser = (meta.browser ?? {}) as Record<string, BrowserProfileConfig>;
+    });
+
+    await expect(
+      createProfile({
+        name: 'second',
+        browser: 'comet',
+        endpoints: ['ssh://mac-mini?port=9300'],
+      })
+    ).resolves.toBeUndefined();
+    expect(store.browser['second']).toBeTruthy();
+  });
+
+  it('rejects two ssh:// profiles on the same remote host:port', async () => {
+    const store: { browser: Record<string, BrowserProfileConfig> } = {
+      browser: {
+        first: { browser: 'comet', endpoints: ['ssh://mac-mini:9222'] },
+      },
+    };
+    vi.mocked(readMeta).mockImplementation(() => store as any);
+
+    await expect(
+      createProfile({
+        name: 'second',
+        browser: 'comet',
+        endpoints: ['ssh://mac-mini:9222'],
+      })
+    ).rejects.toThrow(/Local port 9222 is already used by profile "first"/);
   });
 });

--- a/src/lib/browser/profiles.ts
+++ b/src/lib/browser/profiles.ts
@@ -72,14 +72,39 @@ export async function getProfile(name: string): Promise<BrowserProfile | null> {
 }
 
 /**
- * Find a port in 9222–9399 that is not already claimed by another profile
- * and is not currently in use by any OS process.
+ * Compute the LOCAL port a profile will occupy at runtime:
+ *   - `cdp://127.0.0.1:N` → N (we listen on N directly)
+ *   - `ssh://host?port=N` → N (the SSH tunnel binds local N → remote N now)
+ *   - `ws[s]://`, `http[s]://` → undefined (we don't claim a local port)
+ *
+ * This is what callers should compare to detect collisions; the (host,
+ * port) tuple is no longer enough because SSH profiles do compete with
+ * cdp:// profiles for local ports under the new tunnel scheme.
+ */
+export function effectiveLocalPort(profile: BrowserProfile): number | undefined {
+  const presets = getEndpointPresets(profile);
+  const firstName = profile.defaultEndpoint && presets[profile.defaultEndpoint]
+    ? profile.defaultEndpoint
+    : Object.keys(presets)[0];
+  if (!firstName) return undefined;
+  const target = presets[firstName].target;
+  let url: URL;
+  try { url = new URL(target); } catch { return undefined; }
+  if (url.protocol !== 'cdp:' && url.protocol !== 'ssh:') return undefined;
+  return parseEndpointUrl(target)?.port;
+}
+
+/**
+ * Find a port in 9222–9399 that is not already claimed by ANY existing
+ * profile (cdp:// or ssh://) and is not in use by any OS process. The
+ * SSH change to bind locally on `?port=N` means we no longer get to
+ * skip remote profiles in this scan.
  */
 export async function findFreeProfilePort(): Promise<number> {
   const profiles = await listProfiles();
   const usedByProfile = new Set<number>();
   for (const p of profiles) {
-    const port = extractConfiguredPort(p);
+    const port = effectiveLocalPort(p);
     if (port !== undefined) usedByProfile.add(port);
   }
 
@@ -103,16 +128,21 @@ export async function createProfile(profile: BrowserProfile): Promise<void> {
     throw new Error(`Profile "${profile.name}" already exists`);
   }
 
-  // Check for port collision with existing profiles
-  const newPort = extractConfiguredPort(profile);
-  if (newPort !== undefined && meta.browser) {
+  // Collision check. Every CDP/SSH profile ends up listening on (or
+  // tunneling to) the same LOCAL port number as the one configured in the
+  // endpoint URL — SSH profiles now reuse `?port=N` locally so we no
+  // longer need to scope by host. Two profiles that would need the same
+  // local port can't both run at the same time.
+  const newLocal = effectiveLocalPort(profile);
+  if (newLocal !== undefined && meta.browser) {
     for (const [existingName, existingConfig] of Object.entries(meta.browser)) {
       const existingProfile = configToProfile(existingName, existingConfig);
-      const existingPort = extractConfiguredPort(existingProfile);
-      if (existingPort === newPort) {
+      const existingLocal = effectiveLocalPort(existingProfile);
+      if (existingLocal === newLocal) {
         throw new Error(
-          `Port ${newPort} is already used by profile "${existingName}". ` +
-            `Each profile must own a unique port. Use a different port or omit --endpoint to auto-assign.`
+          `Local port ${newLocal} is already used by profile "${existingName}". ` +
+            `Each profile must own a unique local port (SSH tunnels now bind ` +
+            `to their configured port locally too). Pick a different port.`
         );
       }
     }
@@ -212,24 +242,91 @@ export function resolveEndpoint(
 }
 
 /**
- * Extract the port intended by the profile's default endpoint.
+ * Extract the (host, port) pair intended by the profile's default endpoint.
  * Returns undefined for endpoint shapes that don't carry a port (e.g. ws:// without one).
+ *
+ * Ports are scoped by host: a `cdp://127.0.0.1:9222` profile (local Chrome on
+ * this machine) and an `ssh://mac-mini:9222` profile (Comet on mac-mini)
+ * point at different physical ports — the host disambiguates them.
+ *
+ * Accepts both `scheme://host:port` and `scheme://host?port=N` shapes (the
+ * latter is the documented form in `types.ts` for `ssh://`). Without this,
+ * `ssh://mac-mini?port=18805` would silently fall back to 9222 and every
+ * `?port=`-style SSH profile would collide on creation.
  */
-export function extractConfiguredPort(profile: BrowserProfile): number | undefined {
+export function extractConfiguredEndpoint(
+  profile: BrowserProfile
+): { host: string; port: number } | undefined {
   const presets = getEndpointPresets(profile);
   const firstName = profile.defaultEndpoint && presets[profile.defaultEndpoint]
     ? profile.defaultEndpoint
     : Object.keys(presets)[0];
   if (!firstName) return undefined;
-  const endpoint = presets[firstName].target;
+  return parseEndpointUrl(presets[firstName].target);
+}
+
+/**
+ * Shared endpoint parser used by both the collision-detection code path and
+ * the connection drivers. Returning a single normalized `(host, port)` here
+ * keeps `extractConfiguredEndpoint` and the SSH driver from drifting on URL
+ * conventions (which is how `?port=N` ended up being silently ignored).
+ */
+export function parseEndpointUrl(
+  endpoint: string
+): { host: string; port: number } | undefined {
   let url: URL;
   try {
     url = new URL(endpoint);
   } catch {
     return undefined;
   }
-  if (url.port) return parseInt(url.port, 10);
-  if (url.protocol === 'cdp:') return 9222;
-  // SSH endpoints tunnel to a remote port — they don't own a local port
+  const host = normalizeHost(url.hostname, url.protocol);
+  if (!host) return undefined;
+  const port = extractPortFromUrl(url);
+  if (port !== undefined) return { host, port };
+  // SSH endpoints tunnel to a remote port AND bind that same port locally,
+  // so they do "own" a local port — the host-scoped collision check used
+  // to disagree, but we want the local-port-scoped semantics now.
+  if (url.protocol === 'cdp:' || url.protocol === 'ssh:') return { host, port: 9222 };
   return undefined;
+}
+
+function extractPortFromUrl(url: URL): number | undefined {
+  if (url.port) {
+    const n = parseInt(url.port, 10);
+    if (Number.isFinite(n)) return n;
+  }
+  // `scheme://host?port=N` — the form documented for SSH endpoints in
+  // `types.ts`. WHATWG URL parsing surfaces it via searchParams only.
+  const qp = url.searchParams.get('port');
+  if (qp) {
+    const n = parseInt(qp, 10);
+    if (Number.isFinite(n)) return n;
+  }
+  return undefined;
+}
+
+/**
+ * Extract the port intended by the profile's default endpoint.
+ * Returns undefined for endpoint shapes that don't carry a port (e.g. ws:// without one).
+ *
+ * Note: this loses the host dimension — for collision detection use
+ * `extractConfiguredEndpoint` instead, which returns the (host, port) pair.
+ */
+export function extractConfiguredPort(profile: BrowserProfile): number | undefined {
+  return extractConfiguredEndpoint(profile)?.port;
+}
+
+function normalizeHost(hostname: string, protocol: string): string | undefined {
+  if (!hostname) {
+    // cdp:// and ssh:// without an explicit host imply localhost.
+    if (protocol === 'cdp:' || protocol === 'ssh:') return '127.0.0.1';
+    return undefined;
+  }
+  if (hostname === 'localhost') return '127.0.0.1';
+  return hostname;
+}
+
+export function isLocalHost(host: string): boolean {
+  return host === '127.0.0.1' || host === 'localhost' || host === '::1';
 }

--- a/src/lib/browser/runtime-state.test.ts
+++ b/src/lib/browser/runtime-state.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import {
+  writeProfileRuntime,
+  readProfileRuntime,
+  readProfileRuntimeMeta,
+  clearProfileRuntime,
+  removeProfileCache,
+  listProfileCacheDirs,
+  isProcessAlive,
+  reapOrphanedProcesses,
+} from './runtime-state.js';
+import { getBrowserRuntimeDir, getProfileRuntimeDir } from './profiles.js';
+
+// `state.ts` resolves CACHE_DIR from HOME at module-load time, so we can't
+// redirect with process.env.HOME from a test. Instead each test uses a
+// random profile-name prefix; we track everything we touch and clean it
+// up in afterEach.
+let prefix: string;
+const created: string[] = [];
+
+function uniq(base: string): string {
+  const name = `${prefix}-${base}`;
+  created.push(name);
+  return name;
+}
+
+beforeEach(() => {
+  prefix = `tst-${crypto.randomBytes(6).toString('hex')}`;
+});
+
+afterEach(() => {
+  const root = getBrowserRuntimeDir();
+  for (const name of created) {
+    const dir = path.join(root, name);
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  created.length = 0;
+});
+
+describe('writeProfileRuntime + readProfileRuntime', () => {
+  it('round-trips pid/port/command for a live process', () => {
+    const name = uniq('p1');
+    writeProfileRuntime(name, { pid: process.pid, port: 9222, command: 'node' });
+    const got = readProfileRuntime(name);
+    expect(got).toEqual({ pid: process.pid, port: 9222, command: 'node' });
+  });
+
+  it('returns null and removes files when the pid is dead', () => {
+    const name = uniq('p2');
+    writeProfileRuntime(name, { pid: 999999, port: 9222 });
+    const got = readProfileRuntime(name);
+    expect(got).toBeNull();
+    const dir = getProfileRuntimeDir(name);
+    expect(fs.existsSync(path.join(dir, 'pid'))).toBe(false);
+    expect(fs.existsSync(path.join(dir, 'port'))).toBe(false);
+  });
+
+  it('returns null when the live pid runs a different command (pid-reuse defense)', () => {
+    const name = uniq('p3');
+    writeProfileRuntime(name, { pid: process.pid, port: 9222, command: 'ImpossibleBrowserName' });
+    expect(readProfileRuntime(name)).toBeNull();
+  });
+
+  it('returns the runtime when pid:0 (attached to externally-launched browser)', () => {
+    const name = uniq('p4');
+    writeProfileRuntime(name, { pid: 0, port: 9222 });
+    expect(readProfileRuntime(name)).toEqual({ pid: 0, port: 9222 });
+  });
+
+  it('returns null when no files exist', () => {
+    expect(readProfileRuntime(uniq('never-written'))).toBeNull();
+  });
+});
+
+describe('clearProfileRuntime', () => {
+  it('removes pid/port/command but not chrome-data', () => {
+    const name = uniq('p5');
+    const dir = getProfileRuntimeDir(name);
+    fs.mkdirSync(path.join(dir, 'chrome-data'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'chrome-data', 'Local State'), '{}');
+    writeProfileRuntime(name, { pid: process.pid, port: 9222, command: 'node' });
+
+    clearProfileRuntime(name);
+
+    expect(fs.existsSync(path.join(dir, 'pid'))).toBe(false);
+    expect(fs.existsSync(path.join(dir, 'port'))).toBe(false);
+    expect(fs.existsSync(path.join(dir, 'command'))).toBe(false);
+    expect(fs.existsSync(path.join(dir, 'chrome-data', 'Local State'))).toBe(true);
+  });
+
+  it('is a no-op when files are already gone', () => {
+    expect(() => clearProfileRuntime(uniq('does-not-exist'))).not.toThrow();
+  });
+});
+
+describe('removeProfileCache', () => {
+  it('removes the entire profile directory including chrome-data', () => {
+    const name = uniq('p6');
+    const dir = getProfileRuntimeDir(name);
+    fs.mkdirSync(path.join(dir, 'chrome-data'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'chrome-data', 'Local State'), '{}');
+
+    removeProfileCache(name);
+
+    expect(fs.existsSync(dir)).toBe(false);
+  });
+});
+
+describe('listProfileCacheDirs', () => {
+  it('matches the legacy non-composite dir AND every composite variant', () => {
+    const base = uniq('multi');
+    const root = getBrowserRuntimeDir();
+    fs.mkdirSync(path.join(root, base), { recursive: true });
+    fs.mkdirSync(path.join(root, `${base}@endpoint-0`), { recursive: true });
+    fs.mkdirSync(path.join(root, `${base}@remote`), { recursive: true });
+    created.push(`${base}@endpoint-0`, `${base}@remote`);
+
+    const found = listProfileCacheDirs(base).map((p) => path.basename(p)).sort();
+    expect(found).toEqual([base, `${base}@endpoint-0`, `${base}@remote`].sort());
+  });
+
+  it('returns an empty list when no matching dir exists', () => {
+    expect(listProfileCacheDirs(uniq('absent'))).toEqual([]);
+  });
+
+  it('does not match profiles whose names share a prefix', () => {
+    const base = uniq('exact');
+    const root = getBrowserRuntimeDir();
+    fs.mkdirSync(path.join(root, base), { recursive: true });
+    fs.mkdirSync(path.join(root, `${base}-other`), { recursive: true });
+    created.push(`${base}-other`);
+
+    const found = listProfileCacheDirs(base).map((p) => path.basename(p));
+    expect(found).toEqual([base]);
+  });
+});
+
+describe('readProfileRuntimeMeta', () => {
+  it('returns the full JSON record including daemonPid and spawnedAt', () => {
+    const name = uniq('meta');
+    writeProfileRuntime(name, {
+      pid: process.pid,
+      port: 9222,
+      command: 'node',
+      kind: 'browser',
+      userDataDir: '/tmp/nope',
+    });
+    const meta = readProfileRuntimeMeta(name);
+    expect(meta?.pid).toBe(process.pid);
+    expect(meta?.kind).toBe('browser');
+    expect(meta?.userDataDir).toBe('/tmp/nope');
+    expect(meta?.daemonPid).toBe(process.pid);
+    expect(typeof meta?.spawnedAt).toBe('number');
+  });
+
+  it('returns null when meta.json is missing', () => {
+    expect(readProfileRuntimeMeta(uniq('absent'))).toBeNull();
+  });
+});
+
+describe('reapOrphanedProcesses', () => {
+  it('leaves records owned by THIS daemon alone', () => {
+    const name = uniq('mine');
+    writeProfileRuntime(name, {
+      pid: 999999, // dead, but daemonPid is us so we skip
+      port: 9222,
+      command: 'node',
+    });
+    const result = reapOrphanedProcesses();
+    expect(result.reaped).toBe(0);
+    // Meta file still there:
+    expect(readProfileRuntimeMeta(name)).not.toBeNull();
+  });
+
+  it('reaps records whose daemonPid is dead', () => {
+    const name = uniq('orphan');
+    // Manually write a meta.json owned by a dead daemon pid.
+    const dir = getProfileRuntimeDir(name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'meta.json'),
+      JSON.stringify({
+        pid: 999998, // dead — kill is a no-op but cleanup must still happen
+        port: 9222,
+        command: 'node',
+        daemonPid: 999997, // also dead
+        spawnedAt: Date.now() - 10_000,
+      })
+    );
+
+    reapOrphanedProcesses();
+    // Cleanup should have removed the orphan's runtime files even if the
+    // recorded pid was already gone.
+    expect(readProfileRuntimeMeta(name)).toBeNull();
+  });
+});
+
+describe('isProcessAlive', () => {
+  it('returns true for the current process', () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+  });
+
+  it('returns true for the current process when command matches', () => {
+    expect(isProcessAlive(process.pid, 'node')).toBe(true);
+  });
+
+  it('returns false for the current process when command does NOT match', () => {
+    expect(isProcessAlive(process.pid, 'NotARealBinary123')).toBe(false);
+  });
+
+  it('returns true for pid 0 (sentinel for "attached, not owned")', () => {
+    expect(isProcessAlive(0)).toBe(true);
+  });
+
+  it('returns false for a definitely-dead pid', () => {
+    expect(isProcessAlive(999999)).toBe(false);
+  });
+});

--- a/src/lib/browser/runtime-state.ts
+++ b/src/lib/browser/runtime-state.ts
@@ -1,0 +1,306 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import { getProfileRuntimeDir, getBrowserRuntimeDir } from './profiles.js';
+
+/**
+ * Per-profile runtime files we persist under
+ * `~/.agents/.cache/browser/<composite>/`:
+ *
+ *  - `pid`     — child process ID we spawned (or 0 if attached to an
+ *                already-running browser)
+ *  - `port`    — CDP port we ended up speaking on
+ *  - `command` — basename of the executable so we can defend against pid
+ *                reuse (`process.kill(pid, 0)` only proves *some* process
+ *                with that id exists; if the OS recycled it for an
+ *                unrelated daemon, we'd happily attach to garbage)
+ *  - `meta.json` — richer record: which daemon spawned us, when, the
+ *                user-data-dir we wrote into, optional tunnel PID. This
+ *                is the file the orphan reaper reads on daemon startup.
+ *  - `tasks.json` — open task state (managed elsewhere by service.ts)
+ *
+ * The one-value-per-file fields are kept for backward compat with older
+ * builds; `meta.json` is additive and consulted preferentially.
+ */
+export interface ProfileRuntime {
+  pid: number;
+  port: number;
+  command?: string;
+  /** Full path of the user-data-dir we passed to --user-data-dir, used by the reaper to confirm. */
+  userDataDir?: string;
+  /** PID of the daemon that spawned this. When the daemon dies, the next one reaps. */
+  daemonPid?: number;
+  /** Wall-clock time of spawn — useful for diagnostics and TTL-based cleanup. */
+  spawnedAt?: number;
+  /** What kind of process: 'browser' (Chrome-family), 'electron' (Notion etc.), or 'tunnel' (ssh -L). */
+  kind?: 'browser' | 'electron' | 'tunnel';
+  /** Local ssh -L PID, if this profile is SSH-backed. Distinct from `pid` (which is the remote browser, normally 0). */
+  tunnelPid?: number;
+}
+
+const PID_FILE = 'pid';
+const PORT_FILE = 'port';
+const COMMAND_FILE = 'command';
+const META_FILE = 'meta.json';
+
+function readNumberFile(p: string): number | null {
+  try {
+    const n = parseInt(fs.readFileSync(p, 'utf-8').trim(), 10);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+function readStringFile(p: string): string | null {
+  try {
+    return fs.readFileSync(p, 'utf-8').trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save the runtime record atomically. We write the legacy one-value-per-
+ * file fields plus a JSON meta blob so future code can read either.
+ * The cache directory may not exist yet (first launch); we create it.
+ */
+export function writeProfileRuntime(
+  profileName: string,
+  runtime: ProfileRuntime
+): void {
+  const dir = getProfileRuntimeDir(profileName);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, PID_FILE), String(runtime.pid));
+  fs.writeFileSync(path.join(dir, PORT_FILE), String(runtime.port));
+  if (runtime.command) {
+    fs.writeFileSync(path.join(dir, COMMAND_FILE), runtime.command);
+  }
+  const meta: ProfileRuntime = {
+    ...runtime,
+    daemonPid: runtime.daemonPid ?? process.pid,
+    spawnedAt: runtime.spawnedAt ?? Date.now(),
+  };
+  fs.writeFileSync(path.join(dir, META_FILE), JSON.stringify(meta));
+}
+
+/** Read just the JSON meta record. Returns null when absent or malformed. */
+export function readProfileRuntimeMeta(profileName: string): ProfileRuntime | null {
+  const dir = getProfileRuntimeDir(profileName);
+  try {
+    const raw = fs.readFileSync(path.join(dir, META_FILE), 'utf-8');
+    const obj = JSON.parse(raw);
+    if (typeof obj !== 'object' || obj === null) return null;
+    return obj as ProfileRuntime;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the runtime triple. Returns null when the files are missing OR when
+ * the recorded pid no longer points at the same process we launched —
+ * stale data is auto-cleaned to keep the next caller from acting on it.
+ */
+export function readProfileRuntime(profileName: string): ProfileRuntime | null {
+  const dir = getProfileRuntimeDir(profileName);
+  const pid = readNumberFile(path.join(dir, PID_FILE));
+  const port = readNumberFile(path.join(dir, PORT_FILE));
+  const command = readStringFile(path.join(dir, COMMAND_FILE)) ?? undefined;
+
+  if (pid === null || port === null) return null;
+
+  if (!isProcessAlive(pid, command)) {
+    clearProfileRuntime(profileName);
+    return null;
+  }
+
+  return { pid, port, command };
+}
+
+/** Remove the pid/port/command/meta files. Leaves chrome-data + tasks.json intact. */
+export function clearProfileRuntime(profileName: string): void {
+  const dir = getProfileRuntimeDir(profileName);
+  for (const f of [PID_FILE, PORT_FILE, COMMAND_FILE, META_FILE]) {
+    try { fs.unlinkSync(path.join(dir, f)); } catch { /* not present */ }
+  }
+}
+
+/**
+ * Recursively remove the whole profile cache (chrome-data, tasks.json,
+ * everything). Used by `profiles delete` so an old profile name doesn't
+ * leak its history into a freshly-recreated one.
+ */
+export function removeProfileCache(profileName: string): void {
+  const dir = getProfileRuntimeDir(profileName);
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* gone */ }
+}
+
+/**
+ * Find every cache directory belonging to a given profile. The composite
+ * naming (`<name>@<endpoint>`) means a single agents-cli profile can have
+ * multiple runtime dirs side by side; this finds them all plus the legacy
+ * non-composite dir from older builds.
+ */
+export function listProfileCacheDirs(profileName: string): string[] {
+  const root = getBrowserRuntimeDir();
+  if (!fs.existsSync(root)) return [];
+  const matches: string[] = [];
+  for (const entry of fs.readdirSync(root)) {
+    if (entry === profileName) matches.push(path.join(root, entry));
+    else if (entry.startsWith(`${profileName}@`)) matches.push(path.join(root, entry));
+  }
+  return matches;
+}
+
+/**
+ * `process.kill(pid, 0)` answers "is a process with this id alive?" — but
+ * pid reuse is real on long-uptime machines, and a stale cache pointing
+ * at a since-reassigned pid would happily call the imposter ours.
+ *
+ * Strategy: if we recorded the executable basename when we launched, ask
+ * `ps` what command the live pid is running and compare. No command on
+ * record means we fall back to the existence check (older cache entries
+ * or `pid:0` for "attached to an externally-launched browser").
+ */
+export function isProcessAlive(pid: number, expectedCommand?: string): boolean {
+  if (pid === 0) return true;
+  try {
+    process.kill(pid, 0);
+  } catch (err: any) {
+    if (err && err.code === 'EPERM') {
+      // exists but we can't signal it — count it as alive
+      return !expectedCommand || matchesCommand(pid, expectedCommand);
+    }
+    return false;
+  }
+  if (!expectedCommand) return true;
+  return matchesCommand(pid, expectedCommand);
+}
+
+/**
+ * Snapshot of one tracked profile, suitable for `agents browser ps` output.
+ * Combines the on-disk meta record with live-process probes so callers can
+ * tell at a glance which entries are alive, stale, or have outright leaked.
+ */
+export interface ProfileSnapshot {
+  /** Composite name as the cache dir is keyed: `<profile>` or `<profile>@<endpoint>`. */
+  name: string;
+  /** Absolute path of the cache dir. */
+  dir: string;
+  meta: ProfileRuntime | null;
+  /** Live-process probe: does the recorded pid still exist + match command? */
+  pidAlive: boolean;
+  /** Live-process probe for the tunnel pid (SSH profiles). */
+  tunnelAlive: boolean;
+  /** True iff the daemon that started this is still alive. False == orphaned. */
+  daemonAlive: boolean;
+  /** Number of tasks recorded in tasks.json (open browser tabs). */
+  taskCount: number;
+}
+
+/**
+ * Read every profile cache directory and produce a structured snapshot.
+ * Works without the daemon — `agents browser ps` uses this to render a
+ * complete state view even when the IPC server is down. The caller can
+ * post-process to detect conflicts (e.g. two profiles with the same port,
+ * or a port someone else is listening on).
+ */
+export function listAllProfileSnapshots(): ProfileSnapshot[] {
+  const root = getBrowserRuntimeDir();
+  if (!fs.existsSync(root)) return [];
+  const out: ProfileSnapshot[] = [];
+  for (const name of fs.readdirSync(root).sort()) {
+    const dir = path.join(root, name);
+    let stat;
+    try { stat = fs.statSync(dir); } catch { continue; }
+    if (!stat.isDirectory()) continue;
+
+    const meta = readProfileRuntimeMeta(name);
+    const taskCount = readTaskCount(dir);
+
+    const pidAlive = meta ? isProcessAlive(meta.pid, meta.command) : false;
+    const tunnelAlive = meta?.tunnelPid ? isProcessAlive(meta.tunnelPid, 'ssh') : false;
+    const daemonAlive = meta?.daemonPid ? isProcessAlive(meta.daemonPid) : false;
+
+    out.push({ name, dir, meta, pidAlive, tunnelAlive, daemonAlive, taskCount });
+  }
+  return out;
+}
+
+function readTaskCount(dir: string): number {
+  try {
+    const raw = fs.readFileSync(path.join(dir, 'tasks.json'), 'utf-8');
+    const obj = JSON.parse(raw);
+    if (Array.isArray(obj)) return obj.length;
+    if (obj && typeof obj === 'object') return Object.keys(obj).length;
+    return 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Reap browser + tunnel processes spawned by daemons that no longer exist.
+ * Call once on daemon startup. The idea: every process we spawn records
+ * its daemonPid in meta.json. If that daemon is dead (crashed, SIGKILL),
+ * its children were left rootless — kill them now so they don't hijack
+ * the next session's local ports.
+ *
+ * We're conservative: a record with no daemonPid (older builds) is left
+ * alone — we'd rather leak than wrongly kill a user-owned process that
+ * happens to share metadata.
+ */
+export function reapOrphanedProcesses(): { reaped: number; details: string[] } {
+  const root = getBrowserRuntimeDir();
+  if (!fs.existsSync(root)) return { reaped: 0, details: [] };
+
+  let reaped = 0;
+  const details: string[] = [];
+
+  for (const profileName of fs.readdirSync(root)) {
+    const meta = readProfileRuntimeMeta(profileName);
+    if (!meta) continue;
+    if (!meta.daemonPid) continue;
+    if (meta.daemonPid === process.pid) continue;
+    // Owning daemon still alive — leave its kids alone.
+    if (isProcessAlive(meta.daemonPid)) continue;
+
+    // Kill what the dead daemon left behind. Best-effort.
+    const kill = (pid?: number, label?: string): void => {
+      if (!pid || pid === 0) return;
+      // Only kill if it matches the recorded command — guards against
+      // pid reuse handing us an unrelated process to murder.
+      if (meta.command && !matchesCommand(pid, meta.command) &&
+          !matchesCommand(pid, 'ssh')) return;
+      try {
+        process.kill(pid, 'SIGTERM');
+        reaped++;
+        details.push(`reaped ${label ?? 'pid'} ${pid} (profile ${profileName})`);
+      } catch { /* already gone */ }
+    };
+
+    kill(meta.pid, 'browser');
+    kill(meta.tunnelPid, 'tunnel');
+    clearProfileRuntime(profileName);
+  }
+
+  return { reaped, details };
+}
+
+function matchesCommand(pid: number, expectedCommand: string): boolean {
+  try {
+    const out = execSync(`ps -p ${pid} -o comm=`, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (!out) return false;
+    // Match on the basename only — `/Applications/Comet.app/Contents/MacOS/Comet`
+    // vs the recorded `Comet`, vs `Google\ Chrome`. Case-insensitive.
+    const live = path.basename(out).toLowerCase();
+    const want = path.basename(expectedCommand).toLowerCase();
+    return live === want || live.startsWith(want) || want.startsWith(live);
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/browser/service.ts
+++ b/src/lib/browser/service.ts
@@ -202,6 +202,36 @@ function expandHome(p: string): string {
   return p;
 }
 
+/** Remove the per-profile pid/port files (leaves chrome-data + tasks.json). */
+function clearProfileRuntimeFiles(profileName: string): void {
+  const runtimeDir = getProfileRuntimeDir(profileName);
+  for (const f of ['pid', 'port']) {
+    const fp = path.join(runtimeDir, f);
+    try { fs.unlinkSync(fp); } catch { /* not present */ }
+  }
+}
+
+/**
+ * Probe a cached connection before reuse. A WebSocket can quietly transition
+ * to CLOSED without anyone noticing — most commonly when the user kills the
+ * browser process by hand. `Browser.getVersion` is the lightest CDP call we
+ * can make; if it doesn't round-trip within 1s the connection is dead.
+ */
+async function isConnHealthy(conn: ProfileConnection, timeoutMs = 1000): Promise<boolean> {
+  if (!conn.cdp.isOpen) return false;
+  try {
+    await Promise.race([
+      conn.cdp.send('Browser.getVersion'),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('healthcheck timeout')), timeoutMs)
+      ),
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 interface ProfileConnection {
   cdp: CDPClient;
   port: number;
@@ -214,6 +244,13 @@ interface ProfileConnection {
   windowId?: string; // single window shared by all tasks
   targetCache?: { targets: TargetInfo[]; ts: number };
   sessionCache: Map<string, string>;
+  /**
+   * Connection-specific teardown (e.g. killing the SSH tunnel for an ssh://
+   * profile). Must be called whenever the connection is removed from
+   * `this.connections`, otherwise the tunnel leaks across daemon restarts
+   * and hijacks future `cdp://127.0.0.1:N` profiles on the same local port.
+   */
+  cleanup?: () => void;
 }
 
 type TargetInfo = {
@@ -275,6 +312,18 @@ export class BrowserService {
 
     let conn = this.connections.get(composite);
     let effectiveProfileName = composite;
+
+    // If we have a cached connection, confirm it's still usable before any
+    // caller relies on it. A browser killed externally (Cmd-Q, crash, or a
+    // user clearing the profile by hand) leaves a closed WebSocket here.
+    // Without this check the next `cdp.send` throws "CDP connection not
+    // open" and the user has no way to recover short of killing the daemon.
+    if (conn && !(await isConnHealthy(conn))) {
+      try { conn.cdp.close(); } catch { /* already closed */ }
+      conn.cleanup?.();
+      this.connections.delete(composite);
+      conn = undefined;
+    }
 
     if (conn && conn.electron && conn.tasks.size > 0) {
       if (this.forkingProfiles.has(composite)) {
@@ -397,6 +446,7 @@ export class BrowserService {
         if (conn.forkedFrom && conn.tasks.size === 0) {
           conn.cdp.close();
           killChrome(conn.pid);
+          conn.cleanup?.();
           this.connections.delete(profileName);
         }
 
@@ -416,6 +466,7 @@ export class BrowserService {
     if (conn) {
       conn.cdp.close();
       killChrome(conn.pid);
+      conn.cleanup?.();
       this.connections.delete(profileName);
     }
 
@@ -1631,6 +1682,7 @@ export class BrowserService {
 
     for (const [, conn] of this.connections) {
       conn.cdp.close();
+      conn.cleanup?.();
     }
     this.connections.clear();
   }
@@ -1663,7 +1715,8 @@ export class BrowserService {
       port,
       chromeOpts,
       profile.secrets,
-      profile.binary
+      profile.binary,
+      profile.electron === true
     );
 
     const cdp = new CDPClient();
@@ -1701,23 +1754,33 @@ export class BrowserService {
     const existingInfo = getRunningChromeInfo(effectiveProfile.name);
 
     if (existingInfo) {
-      const { wsUrl, browser } = await discoverBrowserWsUrl(existingInfo.port);
-      verifyBrowserIdentity(browser, effectiveProfile.browser, existingInfo.port);
-      const cdp = new CDPClient();
-      await cdp.connect(wsUrl);
-      await this.enableDomains(cdp);
+      try {
+        const { wsUrl, browser } = await discoverBrowserWsUrl(existingInfo.port);
+        verifyBrowserIdentity(browser, effectiveProfile.browser, existingInfo.port);
+        const cdp = new CDPClient();
+        await cdp.connect(wsUrl);
+        await this.enableDomains(cdp);
 
-      const tasks = this.loadTaskState(effectiveProfile.name);
+        const tasks = this.loadTaskState(effectiveProfile.name);
 
-      return {
-        cdp,
-        port: existingInfo.port,
-        pid: existingInfo.pid,
-        electron: effectiveProfile.electron,
-        targetFilter: effectiveProfile.targetFilter,
-        tasks,
-        sessionCache: new Map(),
-      };
+        return {
+          cdp,
+          port: existingInfo.port,
+          pid: existingInfo.pid,
+          electron: effectiveProfile.electron,
+          targetFilter: effectiveProfile.targetFilter,
+          tasks,
+          sessionCache: new Map(),
+        };
+      } catch (err) {
+        // pid file says a process is alive on that port, but nothing is
+        // actually responding to CDP — most commonly because the user
+        // changed the configured endpoint port after a previous launch,
+        // or because the OS reused the pid for an unrelated process.
+        // Wipe the stale runtime files and fall through to a fresh
+        // connect against the profile's currently-configured endpoint.
+        clearProfileRuntimeFiles(effectiveProfile.name);
+      }
     }
 
     const conn = await this.connectEndpoint(effectiveProfile, target);
@@ -1758,6 +1821,7 @@ export class BrowserService {
         targetFilter: profile.targetFilter,
         tasks: new Map(),
         sessionCache: new Map(),
+        cleanup: conn.cleanup,
       };
     }
 

--- a/src/lib/browser/service.ts
+++ b/src/lib/browser/service.ts
@@ -15,6 +15,7 @@ import {
 import { killChrome, getRunningChromeInfo, launchBrowser, allocatePort } from './chrome.js';
 import { connectLocal } from './drivers/local.js';
 import { connectSSH } from './drivers/ssh.js';
+import { clearProfileRuntime } from './runtime-state.js';
 import {
   generateTaskId,
   generateShortId,
@@ -202,14 +203,6 @@ function expandHome(p: string): string {
   return p;
 }
 
-/** Remove the per-profile pid/port files (leaves chrome-data + tasks.json). */
-function clearProfileRuntimeFiles(profileName: string): void {
-  const runtimeDir = getProfileRuntimeDir(profileName);
-  for (const f of ['pid', 'port']) {
-    const fp = path.join(runtimeDir, f);
-    try { fs.unlinkSync(fp); } catch { /* not present */ }
-  }
-}
 
 /**
  * Probe a cached connection before reuse. A WebSocket can quietly transition
@@ -1779,7 +1772,7 @@ export class BrowserService {
         // or because the OS reused the pid for an unrelated process.
         // Wipe the stale runtime files and fall through to a fresh
         // connect against the profile's currently-configured endpoint.
-        clearProfileRuntimeFiles(effectiveProfile.name);
+        clearProfileRuntime(effectiveProfile.name);
       }
     }
 

--- a/src/lib/browser/types.ts
+++ b/src/lib/browser/types.ts
@@ -135,7 +135,8 @@ export type IPCAction =
   | 'set-download-path'
   | 'wait-download'
   | 'upload'
-  | 'getAppLogs';
+  | 'getAppLogs'
+  | 'version';
 
 export interface IPCRequest {
   action: IPCAction;
@@ -246,6 +247,12 @@ export interface IPCResponse {
   uploadMode?: 'input' | 'drop' | 'chooser';
   // App logs
   appLogs?: any[];
+  // Version handshake — daemon answers with the package version it was
+  // built from so the client can warn when the daemon is older than the
+  // caller (the failure mode that produced this whole patch series: a
+  // launchd-managed registry daemon silently serving old code to a
+  // dev-build CLI client).
+  version?: string;
 }
 
 export interface ConsoleEntry {

--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -180,6 +180,23 @@ export async function runDaemon(): Promise<void> {
     log('INFO', `  ${job.name} -> next: ${job.nextRun?.toISOString() || 'unknown'}`);
   }
 
+  // Before the BrowserService comes up, reap browser + tunnel processes
+  // spawned by previous daemons that are no longer alive. Without this,
+  // a daemon hard-crash (SIGKILL, OOM) would leak every browser and SSH
+  // tunnel it had open — and the next session would either hijack those
+  // (cdp:// profile silently driven via stale ssh tunnel) or fail to
+  // bind because the ports are still claimed.
+  try {
+    const { reapOrphanedProcesses } = await import('./browser/runtime-state.js');
+    const result = reapOrphanedProcesses();
+    if (result.reaped > 0) {
+      log('INFO', `Reaped ${result.reaped} orphan process(es) from prior daemon(s)`);
+      for (const d of result.details) log('INFO', `  ${d}`);
+    }
+  } catch (err) {
+    log('ERROR', `Orphan reaper failed: ${(err as Error).message}`);
+  }
+
   const browserService = new BrowserService();
   const browserIPC = new BrowserIPCServer(browserService);
   try {
@@ -270,6 +287,13 @@ WantedBy=default.target`;
 }
 
 function getAgentsBinPath(): string {
+  // Prefer the binary actively executing this code. `which agents` returns
+  // whatever happens to be first on PATH, which means a side-by-side dev
+  // build at ~/.local/bin would silently spawn the registry-installed
+  // daemon and run stale code. process.argv[1] is the absolute path of
+  // the JS entrypoint the user actually invoked.
+  const argv1 = process.argv[1];
+  if (argv1 && fs.existsSync(argv1)) return argv1;
   try {
     return execSync('which agents', { encoding: 'utf-8' }).trim();
   } catch {
@@ -313,13 +337,18 @@ function startDaemonLocked(): { pid: number | null; method: string } {
       try {
         execFileSync('launchctl', ['unload', plistPath], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
       } catch { /* not loaded, expected */ }
-      execFileSync('launchctl', ['load', plistPath], { encoding: 'utf-8' });
-
+      // launchctl prints `Load failed:` and exits 0 when the label is in a
+      // stuck state from a prior session — so a zero exit code isn't proof
+      // of success. If no pid materializes within the window, give up on
+      // launchd and fall through to a plain detached spawn.
+      execFileSync('launchctl', ['load', plistPath], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
       const pid = waitForPid(3000);
-      return { pid, method: 'launchd' };
+      if (pid) return { pid, method: 'launchd' };
+      // launchctl claimed success but nothing ran. Fall through.
     } catch {
-      return startDetached();
+      // load threw — fall through to detached spawn
     }
+    return startDetached();
   }
 
   if (platform === 'linux') {

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,26 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+let cached: string | null = null;
+
+/**
+ * Resolve the CLI version from the shipping package.json. Used by the daemon
+ * to answer `IPCAction: 'version'` and by the client to detect daemon drift —
+ * a dev-build CLI talking to a launchd-managed registry daemon would silently
+ * get stale behavior without this check.
+ */
+export function getCliVersion(): string {
+  if (cached) return cached;
+  try {
+    const pkgPath = path.join(__dirname, '..', '..', 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    cached = String(pkg.version || 'unknown');
+  } catch {
+    cached = 'unknown';
+  }
+  return cached;
+}


### PR DESCRIPTION
## Summary

Rebuilds the browser runtime-state spine so the daemon knows what it spawned, recovers when it didn't shut down cleanly, and refuses to silently lie. Every reported failure in the recent browser session is now reproducible end-to-end against the fix.

- **Liveness check** before reusing any cached CDP connection (\`Browser.getVersion\` probe with 1s timeout) — kills off the universal "CDP connection not open" failure when the browser is killed externally.
- **PID-reuse defense** in runtime-state: records the executable basename on launch and compares against \`ps\` on read.
- **SSH tunnel binds the configured port locally** (was: random allocation). Preflight check refuses to spawn over an unrelated port owner; reuses our own existing tunnel.
- **Orphan reaper** on daemon startup kills browsers + tunnels left behind by daemons that died (kill -9, OOM, host reboot).
- **\`agents browser ps\`** — new command that reads runtime-state directly and works *without* the daemon. Lists every tracked process with kind / pid / port / alive / owner / task count, plus a Conflicts section.
- **\`agents browser stop --profile <name>\`** exposed — the only CLI path that triggers cleanup.
- **Daemon ↔ CLI version handshake** via new \`version\` IPC action. Client warns to stderr when daemon drift is detected.
- **Daemon binary path** uses \`process.argv[1]\` (was: \`which agents\`, which silently routed dev-build CLIs to the registry daemon).
- **\`launchctl load\` exit-0-on-failure** fixed — falls through to \`startDetached\` when no pid materializes.
- **Chromium first-run + onboarding modals** suppressed via \`--no-first-run --no-default-browser-check --disable-features=DefaultBrowserSetting,ChromeWhatsNewUI\` and seeded \`Default/Preferences\` with the profile name (kills the "Person 1" titlebar).
- **Profile delete** sweeps every \`<name>\` and \`<name>@*\` cache dir (with \`--keep-cache\` opt-out).
- **Collision detection** in \`createProfile\` switched to local-port-scoped semantics (host-scoped no longer correct now that SSH binds locally).
- New \`src/lib/browser/runtime-state.ts\` + 20 unit tests; total suite 130 tests.

## Test plan

- [x] \`bun run test\` — 130/130 passing
- [x] \`bun run build\` clean
- [x] End-to-end: start → kill -9 daemon → new daemon → reaper log "Reaped 1 orphan process(es)" → leaked browser gone
- [x] End-to-end: kill browser externally → next \`start\` recovers (no "CDP connection not open")
- [x] End-to-end: SSH profile \`ssh://host?port=9222\` → tunnel \`9222:127.0.0.1:9222\`
- [x] End-to-end: \`agents browser ps\` runs without the daemon
- [x] End-to-end: two Comet processes coexist (sandbox + user's normal) — verified via \`ps aux\`