### PR TITLE
fix: harden plugins install/update and import --version against injection/traversal

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -36,6 +36,7 @@ import {
   finalizeImport,
   importAgentBinary,
   importAgentConfig,
+  isValidImportVersion,
   resolvePackageDirFromBinary,
 } from '../lib/import.js';
 import { isPromptCancelled, isInteractiveTerminal } from './utils.js';
@@ -116,6 +117,11 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
   if (!version) {
     console.error(chalk.red(`Could not determine version for ${agentLabel(agentId)}.`));
     console.error(chalk.gray('Pass --version <version> explicitly.'));
+    process.exit(1);
+  }
+  if (!isValidImportVersion(version)) {
+    console.error(chalk.red(`Invalid version: ${version}`));
+    console.error(chalk.gray('Version must be "latest" or 1-64 letters, numbers, dots, underscores, plus signs, or hyphens.'));
     process.exit(1);
   }
 

--- a/src/lib/import.test.ts
+++ b/src/lib/import.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { importAgentConfig, isValidImportVersion } from './import.js';
+
+describe('isValidImportVersion', () => {
+  it.each(['1.0.0; rm -rf /', '../../etc'])('rejects invalid version %j', (version) => {
+    expect(isValidImportVersion(version)).toBe(false);
+  });
+
+  it.each(['2.1.140', 'latest'])('accepts valid version %j', (version) => {
+    expect(isValidImportVersion(version)).toBe(true);
+  });
+});
+
+describe('importAgentConfig version validation', () => {
+  it('rejects invalid versions at the function boundary', async () => {
+    await expect(importAgentConfig('claude', '1.0.0; rm -rf /')).resolves.toMatchObject({
+      success: false,
+      error: 'Invalid version: "1.0.0; rm -rf /"',
+    });
+  });
+});

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -38,6 +38,12 @@ export interface ImportBinaryResult {
   resolvedFromPath?: string;
 }
 
+const IMPORT_VERSION_RE = /^(?:latest|[A-Za-z0-9._+-]{1,64})$/;
+
+export function isValidImportVersion(version: string): boolean {
+  return IMPORT_VERSION_RE.test(version);
+}
+
 /**
  * Move an agent's config dir into the managed version structure and symlink it
  * back to its original location. Sets the imported version as the global
@@ -50,6 +56,10 @@ export async function importAgentConfig(
   agentId: AgentId,
   version: string
 ): Promise<ImportConfigResult> {
+  if (!isValidImportVersion(version)) {
+    return { success: false, error: `Invalid version: ${JSON.stringify(version)}` };
+  }
+
   const agent = AGENTS[agentId];
   const configDir = agent.configDir;
   const versionsDir = getVersionsDir();

--- a/src/lib/plugins.test.ts
+++ b/src/lib/plugins.test.ts
@@ -5,7 +5,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import {
   loadPluginManifest,
@@ -16,6 +16,7 @@ import {
   loadUserConfig,
   saveUserConfig,
   checkPluginDependencies,
+  validatePluginName,
   parseInstallSpec,
 } from './plugins.js';
 import type { DiscoveredPlugin, PluginManifest } from './types.js';
@@ -268,21 +269,23 @@ describe('loadUserConfig / saveUserConfig', () => {
   });
 
   it('saveUserConfig writes valid JSON, loadUserConfig reads it back', async () => {
-    // Write directly to the expected path (using the real getPluginsDir would
-    // touch real FS state, so we test the round-trip via save then load).
-    // This is an integration test against the real FS path.
     const pluginName = `_test-plugin-${Date.now()}`;
     const testConfig = { api_key: 'abc123', region: 'eu-west-1' };
+    const pluginsDir = path.join(tmpDir, 'plugins');
 
-    saveUserConfig(pluginName, testConfig);
-    const loaded = loadUserConfig(pluginName);
-    expect(loaded).toEqual(testConfig);
-
-    // Cleanup
-    const { getPluginsDir } = await import('./state.js');
-    const pluginDir = path.join(getPluginsDir(), pluginName);
-    if (fs.existsSync(pluginDir)) {
-      fs.rmSync(pluginDir, { recursive: true, force: true });
+    vi.resetModules();
+    vi.doMock('./state.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('./state.js')>();
+      return { ...actual, getPluginsDir: () => pluginsDir };
+    });
+    try {
+      const { saveUserConfig: save, loadUserConfig: load } = await import('./plugins.js');
+      save(pluginName, testConfig);
+      const loaded = load(pluginName);
+      expect(loaded).toEqual(testConfig);
+    } finally {
+      vi.doUnmock('./state.js');
+      vi.resetModules();
     }
   });
 });
@@ -340,6 +343,73 @@ describe('parseInstallSpec', () => {
     const result = parseInstallSpec('rush-toolkit@~/Projects/rush-toolkit');
     expect(result.name).toBe('rush-toolkit');
     expect(result.source).toBe('~/Projects/rush-toolkit');
+  });
+});
+
+// ─── installPlugin validation ────────────────────────────────────────────────
+
+describe('installPlugin validation', () => {
+  let tmpDir: string;
+  let pluginsDir: string;
+  let execFileSyncMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-test-'));
+    pluginsDir = path.join(tmpDir, 'plugins');
+    execFileSyncMock = vi.fn();
+    vi.resetModules();
+    vi.doMock('./state.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('./state.js')>();
+      return { ...actual, getPluginsDir: () => pluginsDir };
+    });
+    vi.doMock('child_process', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('child_process')>();
+      return { ...actual, execFileSync: execFileSyncMock };
+    });
+  });
+
+  afterEach(() => {
+    vi.doUnmock('./state.js');
+    vi.doUnmock('child_process');
+    vi.resetModules();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it.each(['../etc', 'foo/bar', 'foo\\bar', '..', 'foo\\0bar', 'foo\0bar', ''])(
+    'rejects invalid plugin name %j',
+    (name) => {
+      expect(validatePluginName(name)).toBe(false);
+    }
+  );
+
+  it('accepts a simple plugin name', () => {
+    expect(validatePluginName('safe-plugin_1.0')).toBe(true);
+  });
+
+  it.each([
+    'evil; rm -rf /tmp/SHOULD_NOT_DELETE',
+    '$(touch /tmp/SHOULD_NOT_EXIST)',
+    '`touch /tmp/SHOULD_NOT_EXIST`',
+  ])('passes git clone input through execFileSync argv form: %s', async (source) => {
+    const { installPlugin } = await import('./plugins.js');
+
+    await expect(installPlugin(`safe@${source}`)).rejects.toThrow('Installed source has no valid .claude-plugin/plugin.json');
+
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      'git',
+      ['clone', '--depth', '1', source, path.join(pluginsDir, 'safe')],
+      { stdio: 'pipe' }
+    );
+  });
+
+  it('rejects path-traversal plugin names before copying a local source', async () => {
+    const sourceRoot = makePluginRoot(tmpDir, { name: 'safe' });
+    const { installPlugin } = await import('./plugins.js');
+
+    await expect(installPlugin(`../../foo@${sourceRoot}`)).rejects.toThrow('Invalid plugin name: ../../foo');
+
+    expect(fs.existsSync(path.resolve(pluginsDir, '../../foo'))).toBe(false);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -11,7 +11,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import type { AgentId, DiscoveredPlugin, PluginManifest } from './types.js';
 import { getPluginsDir, getTrashPluginsDir } from './state.js';
 import { listInstalledVersions, getVersionHomePath } from './versions.js';
@@ -93,12 +93,30 @@ export function loadPluginManifest(pluginRoot: string): PluginManifest | null {
     const content = fs.readFileSync(manifestPath, 'utf-8');
     const parsed = JSON.parse(content) as PluginManifest;
     if (!parsed.name || !parsed.version) return null;
-    if (/[/\\]/.test(parsed.name) || parsed.name.includes('..') || parsed.name.includes('\0')) {
+    if (!validatePluginName(parsed.name)) {
       return null;
     }
     return parsed;
   } catch {
     return null;
+  }
+}
+
+export function validatePluginName(name: string): boolean {
+  return name.length > 0
+    && !/[/\\]/.test(name)
+    && !name.includes('..')
+    && !name.includes('\0');
+}
+
+export function assertPluginTargetContained(targetRoot: string, pluginsDir: string): void {
+  const resolvedPluginsDir = path.resolve(pluginsDir);
+  const resolvedTargetRoot = path.resolve(targetRoot);
+  if (
+    resolvedTargetRoot !== resolvedPluginsDir
+    && !resolvedTargetRoot.startsWith(`${resolvedPluginsDir}${path.sep}`)
+  ) {
+    throw new Error(`Plugin install target escapes plugins directory: ${targetRoot}`);
   }
 }
 
@@ -939,8 +957,12 @@ export async function installPlugin(spec: string): Promise<{ name: string; root:
       targetName = path.basename(resolvedSource).replace(/\.git$/, '');
     }
   }
+  if (!validatePluginName(targetName)) {
+    throw new Error(`Invalid plugin name: ${targetName}`);
+  }
 
   const targetRoot = path.join(pluginsDir, targetName);
+  assertPluginTargetContained(targetRoot, pluginsDir);
   const isNew = !fs.existsSync(targetRoot);
 
   if (isLocalPath) {
@@ -954,7 +976,7 @@ export async function installPlugin(spec: string): Promise<{ name: string; root:
     if (fs.existsSync(targetRoot)) {
       fs.rmSync(targetRoot, { recursive: true, force: true });
     }
-    execSync(`git clone --depth 1 ${JSON.stringify(resolvedSource)} ${JSON.stringify(targetRoot)}`, {
+    execFileSync('git', ['clone', '--depth', '1', resolvedSource, targetRoot], {
       stdio: 'pipe',
     });
   }
@@ -996,7 +1018,7 @@ export async function updatePlugin(name: string): Promise<{ success: boolean; er
 
   try {
     if (sourceInfo.isGit) {
-      execSync(`git -C ${JSON.stringify(plugin.root)} pull --ff-only`, { stdio: 'pipe' });
+      execFileSync('git', ['-C', plugin.root, 'pull', '--ff-only'], { stdio: 'pipe' });
     } else {
       const resolvedSource = sourceInfo.source.replace(/^~/, process.env.HOME || '~');
       if (!fs.existsSync(resolvedSource)) {


### PR DESCRIPTION
## Summary
- Harden plugin install/update against shell injection and traversal before filesystem writes.
- Validate import --version before using it in version paths, with a defense-in-depth check at importAgentConfig.

## Findings Fixed
- A1: src/lib/plugins.ts previously cloned via an interpolated shell command at git clone call site; now uses execFileSync('git', ['clone', '--depth', '1', resolvedSource, targetRoot], { stdio: 'pipe' }).
- A2: src/lib/plugins.ts previously joined targetName into pluginsDir before manifest-name validation; now validates targetName and checks targetRoot containment before rmSync/cpSync/clone.
- B1: src/lib/plugins.ts previously updated with an interpolated git -C shell command; now uses execFileSync('git', ['-C', plugin.root, 'pull', '--ff-only'], { stdio: 'pipe' }).
- B2: src/commands/import.ts and src/lib/import.ts now reject invalid version strings before getVersionDir/path joins and at importAgentConfig boundary.

## Tests
- Added plugin validation tests for invalid names, shell-metacharacter git sources, and traversal rejection before copy.
- Added import version validation tests for invalid and valid version labels.
- Verified: bun run test src/lib/plugins.test.ts src/lib/import.test.ts
- Verified: ./node_modules/.bin/tsc --noEmit
- Full bun run test was executed but has unrelated sandbox/dist failures writing under /Users/muqsit/.agents, /Users/muqsit/.agents-system, and missing dist artifacts.

## Breaking Changes
None expected. Invalid plugin names and invalid import version labels are rejected earlier.

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/7c824d064225d1a973fc98ece64345cf)