### PR TITLE
fix(cloud): prevent path traversal in cloud session cache via server-controlled execution_id

### DIFF
--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -860,7 +860,7 @@ async function runCloudSessions(query: string | undefined, options: SessionsOpti
   const cachedSpinner = options.json ? null : ora('Fetching session...').start();
   let cachedPath: string;
   try {
-    cachedPath = await ensureCloudSessionCached(meta.id, meta.filePath);
+    cachedPath = await ensureCloudSessionCached(meta.id);
   } catch (err: any) {
     cachedSpinner?.stop();
     console.error(chalk.red(`Failed to fetch session: ${err?.message || err}`));

--- a/src/lib/session/cloud.test.ts
+++ b/src/lib/session/cloud.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cloud-cache-test-'));
+const cacheRoot = path.join(tmpRoot, 'cache');
+const originalHome = process.env.HOME;
+
+vi.mock('../state.js', () => ({
+  getCacheDir: () => cacheRoot,
+}));
+
+describe('cloud session cache path safety', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    process.env.HOME = tmpRoot;
+    fs.mkdirSync(path.join(tmpRoot, '.rush'), { recursive: true });
+    fs.writeFileSync(path.join(tmpRoot, '.rush', 'user.yaml'), 'session:\n  access_token: test-token\n');
+
+    globalThis.fetch = vi.fn(async () => new Response('{"role":"user"}\n', {
+      headers: { 'X-Session-Format': 'rush' },
+    })) as any;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+  });
+
+  it('writes a valid UUID execution id inside the cloud cache', async () => {
+    const { ensureCloudSessionCached } = await import('./cloud.js');
+
+    const cachedPath = await ensureCloudSessionCached('c07ec355-d841-45fc-b2eb-f500355e15c6');
+
+    expect(cachedPath).toBe(path.join(cacheRoot, 'cloud-runs', 'c07ec355-d841-45fc-b2eb-f500355e15c6', 'session.rush.jsonl'));
+    expect(fs.readFileSync(cachedPath, 'utf-8')).toBe('{"role":"user"}\n');
+  });
+
+  it('rejects invalid execution ids returned by cloud listing', async () => {
+    const { discoverCloudSessions } = await import('./cloud.js');
+    globalThis.fetch = vi.fn(async () => Response.json({
+      executions: [
+        {
+          execution_id: '../escape',
+          agent: 'rush',
+          status: 'completed',
+        },
+      ],
+    })) as any;
+
+    await expect(discoverCloudSessions()).rejects.toThrow('Invalid cloud execution_id');
+  });
+
+  it.each([
+    '../escape',
+    '..\\escape',
+    '/etc/passwd',
+    'bad\0id',
+    '.hidden',
+  ])('rejects invalid execution id %j before any filesystem write', async (executionId) => {
+    const { ensureCloudSessionCached } = await import('./cloud.js');
+
+    await expect(ensureCloudSessionCached(executionId)).rejects.toThrow('Invalid cloud execution_id');
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(fs.existsSync(cacheRoot)).toBe(false);
+  });
+
+  it('rejects caller supplied destination paths outside the cloud cache', async () => {
+    const { ensureCloudSessionCached } = await import('./cloud.js');
+    const outside = path.join(tmpRoot, 'outside', 'session.rush.jsonl');
+
+    await expect(
+      ensureCloudSessionCached('c07ec355-d841-45fc-b2eb-f500355e15c6', outside),
+    ).rejects.toThrow('Path escapes cloud session cache');
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(fs.existsSync(outside)).toBe(false);
+  });
+
+  it('normalizes caller supplied destination paths before filesystem IO', async () => {
+    const { ensureCloudSessionCached } = await import('./cloud.js');
+    const linkLikePath = path.join(cacheRoot, 'cloud-runs', 'link', '..', '..', 'outside', 'session.rush.jsonl');
+
+    await expect(
+      ensureCloudSessionCached('c07ec355-d841-45fc-b2eb-f500355e15c6', linkLikePath),
+    ).rejects.toThrow('Path escapes cloud session cache');
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(tmpRoot, 'outside', 'session.rush.jsonl'))).toBe(false);
+  });
+});

--- a/src/lib/session/cloud.ts
+++ b/src/lib/session/cloud.ts
@@ -20,6 +20,7 @@ import { getCacheDir } from '../state.js';
 const PROXY_BASE = process.env.RUSH_PROXY_BASE ?? 'https://api.prix.dev';
 const USER_YAML = path.join(os.homedir(), '.rush', 'user.yaml');
 const CLOUD_CACHE_DIR = path.join(getCacheDir(), 'cloud-runs');
+const CLOUD_EXECUTION_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
 
 interface UserYaml {
   session?: {
@@ -69,6 +70,27 @@ function agentToFormat(agent: string): SessionAgentId | null {
   return null;
 }
 
+export function assertContained(candidate: string, rootDir: string): string {
+  const root = path.resolve(rootDir);
+  const resolved = path.resolve(root, candidate);
+  if (!resolved.startsWith(root + path.sep)) {
+    throw new Error(`Path escapes cloud session cache: ${candidate}`);
+  }
+  return resolved;
+}
+
+export function validateCloudExecutionId(executionId: string): string {
+  if (!CLOUD_EXECUTION_ID_RE.test(executionId)) {
+    throw new Error(`Invalid cloud execution_id: ${JSON.stringify(executionId)}`);
+  }
+  return executionId;
+}
+
+function cachePathForExecution(executionId: string, agent: SessionAgentId): string {
+  const id = validateCloudExecutionId(executionId);
+  return assertContained(path.join(id, `session.${agent}.jsonl`), CLOUD_CACHE_DIR);
+}
+
 /**
  * List cloud executions the user has captured sessions for. Includes
  * completed + needs_review + failed; an empty session_path means capture
@@ -90,14 +112,14 @@ export async function discoverCloudSessions(options?: {
   for (const row of rows) {
     const agent = agentToFormat(row.agent);
     if (!agent) continue;
-    const id = row.execution_id;
+    const id = validateCloudExecutionId(row.execution_id);
     const timestamp = row.updated_at || row.created_at || new Date().toISOString();
     const project = row.repo_owner && row.repo_name ? `${row.repo_owner}/${row.repo_name}` : undefined;
 
     // filePath doubles as the sink path for the cached jsonl. parseSession
     // dispatches on detectAgent which recognizes the `session.<format>.jsonl`
     // suffix — so the local cache file name must preserve it.
-    const filePath = path.join(CLOUD_CACHE_DIR, id, `session.${agent}.jsonl`);
+    const filePath = cachePathForExecution(id, agent);
 
     out.push({
       id,
@@ -124,8 +146,10 @@ export async function ensureCloudSessionCached(
   executionId: string,
   destPath?: string,
 ): Promise<string> {
+  const id = validateCloudExecutionId(executionId);
+  const callerPath = destPath ? assertContained(destPath, CLOUD_CACHE_DIR) : undefined;
   const token = readToken();
-  const res = await api('GET', `/api/v1/cloud-runs/${encodeURIComponent(executionId)}/session.jsonl`, token);
+  const res = await api('GET', `/api/v1/cloud-runs/${encodeURIComponent(id)}/session.jsonl`, token);
   if (!res.ok) {
     const body = await res.text().catch(() => '');
     throw new Error(`session.jsonl fetch ${res.status}: ${body.slice(0, 200)}`);
@@ -135,7 +159,7 @@ export async function ensureCloudSessionCached(
     throw new Error(`Unknown X-Session-Format on cloud response: "${format}"`);
   }
 
-  const finalPath = destPath ?? path.join(CLOUD_CACHE_DIR, executionId, `session.${format}.jsonl`);
+  const finalPath = callerPath ?? cachePathForExecution(id, format as SessionAgentId);
   fs.mkdirSync(path.dirname(finalPath), { recursive: true });
   const body = Buffer.from(await res.arrayBuffer());
   fs.writeFileSync(finalPath, body);
@@ -144,7 +168,9 @@ export async function ensureCloudSessionCached(
 
 /** True if filePath points into the cloud session cache dir. */
 export function isCloudSessionPath(filePath: string): boolean {
-  return filePath.startsWith(CLOUD_CACHE_DIR);
+  const root = path.resolve(CLOUD_CACHE_DIR);
+  const resolved = path.resolve(filePath);
+  return resolved.startsWith(root + path.sep);
 }
 
 /** Extract execution_id from a cloud cache path. */
@@ -152,5 +178,9 @@ export function executionIdFromCloudPath(filePath: string): string | null {
   if (!isCloudSessionPath(filePath)) return null;
   const rel = path.relative(CLOUD_CACHE_DIR, filePath);
   const parts = rel.split(path.sep);
-  return parts[0] || null;
+  try {
+    return parts[0] ? validateCloudExecutionId(parts[0]) : null;
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary
- Validate Rush Cloud `execution_id` values before using them as local cache path segments.
- Enforce `CLOUD_CACHE_DIR` containment for computed and caller-supplied session cache paths.
- Stop passing the server-derived `meta.filePath` back into the cache writer from `agents sessions --cloud`.

## Security
A malicious cloud listing could previously influence `path.join(CLOUD_CACHE_DIR, execution_id, ...)`. This change accepts only `/^[A-Za-z0-9_-]{1,128}$/` IDs and resolves every cache write destination under `CLOUD_CACHE_DIR` before filesystem writes.

## Verification
- `HOME=/private/tmp TMPDIR=/private/tmp bun run test -- src/lib/session/cloud.test.ts` => `Test Files  1 passed (1)`, `Tests  9 passed (9)`
- `HOME=/private/tmp TMPDIR=/private/tmp node ./node_modules/typescript/bin/tsc --noEmit` => passed
- `bun run test` was attempted. Remote Crabbox was unavailable because `hetzner.com` is missing and no `HCLOUD_TOKEN`/`HETZNER_TOKEN` is configured. Local full-suite runs are blocked by pre-existing environment/setup issues: missing Playwright browser binaries, missing `agents setup` state, process-command detection assumptions, and tests expecting generated `dist/` files. The changed cloud test passed in the full local run.

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/0361fb3345ee97e8e9509891b2120e52)
