### PR TITLE
fix(state): prevent agents.yaml race-corruption under concurrent processes

### DIFF
--- a/src/lib/__tests__/state.test.ts
+++ b/src/lib/__tests__/state.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { execFileSync } from 'child_process';
+import { execFileSync, spawn } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { pathToFileURL } from 'url';
 
 import {
   getBackupsDir,
@@ -80,6 +81,47 @@ describe('readMeta merges agents.yaml from both repos', () => {
     return JSON.parse(result);
   }
 
+  function runStateScript(home: string, script: string): string {
+    return execFileSync('bun', ['-e', script], {
+      cwd: process.cwd(),
+      env: { ...process.env, HOME: home },
+      stdio: 'pipe',
+      encoding: 'utf8',
+    }).trim();
+  }
+
+  function runStateScriptWithNode(home: string, script: string): string {
+    return execFileSync('node', ['--import', 'tsx', '--input-type=module', '-e', script], {
+      cwd: process.cwd(),
+      env: { ...process.env, HOME: home },
+      stdio: 'pipe',
+      encoding: 'utf8',
+    }).trim();
+  }
+
+  function spawnStateScript(home: string, script: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const child = spawn('bun', ['-e', script], {
+        cwd: process.cwd(),
+        env: { ...process.env, HOME: home },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk.toString();
+      });
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk.toString();
+      });
+      child.on('error', reject);
+      child.on('close', (code) => {
+        if (code === 0) resolve();
+        else reject(new Error(`state script exited ${code}\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+      });
+    });
+  }
+
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'state-test-'));
     userDir = path.join(testDir, '.agents');
@@ -137,5 +179,94 @@ describe('readMeta merges agents.yaml from both repos', () => {
     const agents = meta.agents as Record<string, string>;
 
     expect(agents.claude).toBe('2.0.0');
+  });
+
+  it('does not lose concurrent updateMeta callback writes', async () => {
+    const makeUpdate = (agent: string, version: string) => `
+      const { updateMeta } = await import(${JSON.stringify(modulePath)});
+      updateMeta((meta) => {
+        const block = new Int32Array(new SharedArrayBuffer(4));
+        Atomics.wait(block, 0, 0, 250);
+        return {
+          ...meta,
+          agents: {
+            ...(meta.agents ?? {}),
+            ${JSON.stringify(agent)}: ${JSON.stringify(version)},
+          },
+        };
+      });
+    `;
+
+    await Promise.all([
+      spawnStateScript(testDir, makeUpdate('claude', '1.0.0')),
+      spawnStateScript(testDir, makeUpdate('codex', '2.0.0')),
+    ]);
+
+    const meta = runReadMeta(testDir);
+    expect(meta.agents).toMatchObject({
+      claude: '1.0.0',
+      codex: '2.0.0',
+    });
+  });
+
+  it('keeps the original agents.yaml when rename fails after writing the temp file', () => {
+    const moduleUrl = pathToFileURL(modulePath).href;
+    fs.writeFileSync(
+      path.join(userDir, 'agents.yaml'),
+      'agents:\n  claude: "1.0.0"\n',
+      'utf-8',
+    );
+
+    const output = runStateScriptWithNode(testDir, `
+      import fs from 'fs';
+      import path from 'path';
+      import { syncBuiltinESMExports } from 'module';
+
+      const target = path.join(process.env.HOME, '.agents', 'agents.yaml');
+      const originalRename = fs.renameSync;
+      fs.renameSync = (from, to) => {
+        if (to === target) throw new Error('simulated rename failure');
+        return originalRename(from, to);
+      };
+      syncBuiltinESMExports();
+
+      const { writeMeta } = await import(${JSON.stringify(moduleUrl)});
+      try {
+        writeMeta({ agents: { claude: '9.9.9' } });
+      } catch (err) {
+        console.log(String(err.message));
+      }
+      console.log(fs.readFileSync(target, 'utf-8'));
+    `);
+
+    expect(output).toContain('simulated rename failure');
+    expect(output).toContain('claude: "1.0.0"');
+    expect(output).not.toContain('9.9.9');
+    expect(fs.readdirSync(userDir).filter((entry) => entry.includes('.tmp-'))).toEqual([]);
+  });
+
+  it('breaks a stale agents.yaml lock older than five seconds', () => {
+    fs.writeFileSync(
+      path.join(userDir, 'agents.yaml'),
+      'agents:\n  claude: "1.0.0"\n',
+      'utf-8',
+    );
+    fs.mkdirSync(path.join(userDir, 'agents.yaml.lock'));
+    const staleTime = new Date(Date.now() - 10_000);
+    fs.utimesSync(path.join(userDir, 'agents.yaml.lock'), staleTime, staleTime);
+
+    runStateScript(testDir, `
+      const { updateMeta } = await import(${JSON.stringify(modulePath)});
+      updateMeta((meta) => ({
+        ...meta,
+        agents: { ...(meta.agents ?? {}), codex: '2.0.0' },
+      }));
+    `);
+
+    const meta = runReadMeta(testDir);
+    expect(meta.agents).toMatchObject({
+      claude: '1.0.0',
+      codex: '2.0.0',
+    });
   });
 });

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -7,11 +7,19 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as yaml from 'yaml';
+import { randomBytes } from 'crypto';
+import lockfile from 'proper-lockfile';
 import type { Manifest } from './types.js';
 import { safeJoin } from './paths.js';
 
 /** Canonical filename for the manifest in any agents repo or project root. */
 export const MANIFEST_FILENAME = 'agents.yaml';
+const MANIFEST_LOCK_STALE_MS = 5_000;
+const MANIFEST_LOCK_RETRIES = 5;
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
 
 /** Parse a YAML string into a typed Manifest object. */
 export function parseManifest(content: string): Manifest {
@@ -33,11 +41,52 @@ export function readManifest(repoPath: string): Manifest | null {
   return parseManifest(content);
 }
 
+function ensureLockTarget(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  if (fs.existsSync(filePath)) return;
+  try {
+    fs.writeFileSync(filePath, '', { encoding: 'utf-8', flag: 'wx' });
+  } catch (err: any) {
+    if (err?.code !== 'EEXIST') throw err;
+  }
+}
+
+function atomicWriteFileSync(filePath: string, content: string): void {
+  const tmpPath = `${filePath}.tmp-${process.pid}-${randomBytes(8).toString('hex')}`;
+  fs.writeFileSync(tmpPath, content, 'utf-8');
+  try {
+    fs.renameSync(tmpPath, filePath);
+  } catch (err) {
+    try { fs.unlinkSync(tmpPath); } catch { /* best-effort cleanup */ }
+    throw err;
+  }
+}
+
 /** Write a Manifest object to agents.yaml in the given directory. */
 export function writeManifest(repoPath: string, manifest: Manifest): void {
   const manifestPath = safeJoin(repoPath, MANIFEST_FILENAME);
   const content = serializeManifest(manifest);
-  fs.writeFileSync(manifestPath, content, 'utf-8');
+  ensureLockTarget(manifestPath);
+  let release: (() => void) | null = null;
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= MANIFEST_LOCK_RETRIES; attempt++) {
+    try {
+      release = lockfile.lockSync(manifestPath, { stale: MANIFEST_LOCK_STALE_MS });
+      break;
+    } catch (err) {
+      lastError = err;
+      if (attempt < MANIFEST_LOCK_RETRIES) sleepSync(50 * (attempt + 1));
+    }
+  }
+  if (!release) {
+    const message = lastError instanceof Error ? lastError.message : String(lastError);
+    throw new Error(`Could not acquire lock for ${manifestPath}: ${message}`);
+  }
+  try {
+    atomicWriteFileSync(manifestPath, content);
+  } finally {
+    release();
+  }
 }
 
 /** Create a Manifest with sensible defaults for a fresh agents repo. */

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -23,6 +23,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as yaml from 'yaml';
+import { randomBytes } from 'crypto';
+import lockfile from 'proper-lockfile';
 import type { Meta, RegistryType } from './types.js';
 import { SEEDED_REGISTRIES } from './types.js';
 
@@ -477,6 +479,77 @@ export function createDefaultMeta(): Meta {
 }
 
 let metaCache: { mtime: number; meta: Meta } | null = null;
+let metaLockDepth = 0;
+const META_LOCK_STALE_MS = 5_000;
+const META_LOCK_RETRIES = 5;
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function ensureLockTarget(filePath: string, initialContent: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  if (fs.existsSync(filePath)) return;
+  try {
+    fs.writeFileSync(filePath, initialContent, { encoding: 'utf-8', flag: 'wx' });
+  } catch (err: any) {
+    if (err?.code !== 'EEXIST') throw err;
+  }
+}
+
+function atomicWriteFileSync(filePath: string, content: string): void {
+  const tmpPath = `${filePath}.tmp-${process.pid}-${randomBytes(8).toString('hex')}`;
+  fs.writeFileSync(tmpPath, content, 'utf-8');
+  try {
+    fs.renameSync(tmpPath, filePath);
+  } catch (err) {
+    try { fs.unlinkSync(tmpPath); } catch { /* best-effort cleanup */ }
+    throw err;
+  }
+}
+
+function withMetaLock<T>(fn: () => T): T {
+  ensureAgentsDir();
+  if (metaLockDepth > 0) {
+    metaLockDepth++;
+    try {
+      return fn();
+    } finally {
+      metaLockDepth--;
+    }
+  }
+
+  ensureLockTarget(META_FILE, META_HEADER + yaml.stringify(createDefaultMeta()));
+  let release: (() => void) | null = null;
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= META_LOCK_RETRIES; attempt++) {
+    try {
+      release = lockfile.lockSync(META_FILE, { stale: META_LOCK_STALE_MS });
+      break;
+    } catch (err) {
+      lastError = err;
+      if (attempt < META_LOCK_RETRIES) sleepSync(50 * (attempt + 1));
+    }
+  }
+  if (!release) {
+    const message = lastError instanceof Error ? lastError.message : String(lastError);
+    throw new Error(`Could not acquire lock for ${META_FILE}: ${message}`);
+  }
+
+  metaLockDepth = 1;
+  try {
+    return fn();
+  } finally {
+    metaLockDepth = 0;
+    release();
+  }
+}
+
+function writeMetaUnlocked(meta: Meta): void {
+  const content = META_HEADER + yaml.stringify(meta);
+  atomicWriteFileSync(META_FILE, content);
+  metaCache = null;
+}
 
 function applyRegistrySeeds(meta: Meta): boolean {
   const seeded = new Set(meta.seededPresets || []);
@@ -611,18 +684,19 @@ export function readMeta(): Meta {
 
 /** Serialize and write agents.yaml to the user repo, invalidating the in-memory cache. */
 export function writeMeta(meta: Meta): void {
-  ensureAgentsDir();
-  const content = META_HEADER + yaml.stringify(meta);
-  fs.writeFileSync(META_FILE, content, 'utf-8');
-  metaCache = null;
+  withMetaLock(() => writeMetaUnlocked(meta));
 }
 
-/** Shallow-merge updates into agents.yaml and return the new state. */
-export function updateMeta(updates: Partial<Meta>): Meta {
-  const meta = readMeta();
-  const newMeta = { ...meta, ...updates };
-  writeMeta(newMeta);
-  return newMeta;
+/** Update agents.yaml under lock and return the new state. */
+export function updateMeta(updates: Partial<Meta> | ((meta: Meta) => Meta)): Meta {
+  return withMetaLock(() => {
+    const meta = readMeta();
+    const newMeta = typeof updates === 'function'
+      ? updates(meta)
+      : { ...meta, ...updates };
+    writeMetaUnlocked(newMeta);
+    return newMeta;
+  });
 }
 
 /** Derive a filesystem-safe local clone path for a package source URL. */


### PR DESCRIPTION
## Summary

Closes HN-readiness finding **B5 HIGH** — `agents.yaml` and project-manifest writes were unlocked and non-atomic, while `proper-lockfile` was already a dep and used correctly at \`src/lib/teams/registry.ts:39-77\`.

## Findings closed

- B5 HIGH — \`src/lib/state.ts:612-625\` \`writeMeta\` direct \`fs.writeFileSync\` (no lock, no atomic rename)
- B5 HIGH — \`src/lib/state.ts:620-625\` \`updateMeta\` read-modify-write lost-update race
- B5 HIGH — \`src/lib/manifest.ts:36-40\` \`writeManifest\` same pattern

## Approach

Adopted the canonical pattern from \`src/lib/teams/registry.ts\`:
- Acquire exclusive lock via \`proper-lockfile.lock(...)\`
- Write YAML to \`\${target}.tmp-\${pid}-\${random}\`
- \`fs.renameSync(tmp, target)\` (atomic on POSIX)
- Release lock in \`finally\`

## Tests

3 files modified, 266 lines added (mostly tests):
- \`src/lib/__tests__/state.test.ts\` — concurrent updateMeta, crash-mid-write, stale lock breakage
- \`src/lib/state.ts\`, \`src/lib/manifest.ts\` — implementation

Generated by the \`hn-fix\` agents team. Full audit context at \`/tmp/hn-readiness-findings.md\` on dispatcher.