### PR TITLE
fix(security): harden subprocess execution against shell injection across subsystems

### DIFF
--- a/src/commands/routines.ts
+++ b/src/commands/routines.ts
@@ -654,10 +654,10 @@ Examples:
     .option('-f, --follow', 'Stream log output in real time (like tail -f)')
     .action(async (options) => {
       if (options.follow) {
-        const { exec: execCb } = await import('child_process');
+        const { spawn } = await import('child_process');
         const { getDaemonDir } = await import('../lib/state.js');
         const logPath = path.join(getDaemonDir(), 'logs.jsonl');
-        const child = execCb(`tail -f "${logPath}"`);
+        const child = spawn('tail', ['-f', logPath]);
         child.stdout?.pipe(process.stdout);
         child.stderr?.pipe(process.stderr);
         child.on('exit', () => process.exit(0));

--- a/src/lib/browser/chrome.ts
+++ b/src/lib/browser/chrome.ts
@@ -1,4 +1,4 @@
-import { spawn, execSync } from 'child_process';
+import { spawn, execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -236,7 +236,7 @@ export function allocatePort(): number {
 
   for (let port = base; port < max; port++) {
     try {
-      execSync(`lsof -i :${port}`, { stdio: 'ignore' });
+      execFileSync('lsof', ['-i', `:${port}`], { stdio: 'ignore' });
     } catch {
       return port;
     }
@@ -257,7 +257,7 @@ export interface PortOccupant {
  */
 export function getPortOccupant(port: number): PortOccupant | null {
   try {
-    const out = execSync(`lsof -nP -iTCP:${port} -sTCP:LISTEN -Fpcn`, {
+    const out = execFileSync('lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-Fpcn'], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
     });

--- a/src/lib/browser/drivers/ssh.ts
+++ b/src/lib/browser/drivers/ssh.ts
@@ -1,4 +1,4 @@
-import { spawn, execSync, type ChildProcess } from 'child_process';
+import { spawn, execFileSync, type ChildProcess } from 'child_process';
 import * as net from 'net';
 import { CDPClient, discoverBrowserWsUrl, verifyBrowserIdentity } from '../cdp.js';
 import { getPortOccupant } from '../chrome.js';
@@ -11,6 +11,11 @@ export interface SSHConnection {
   port: number;
   pid: number;
   cleanup: () => void;
+}
+
+export function shellQuote(s: string): string {
+  if (/^[A-Za-z0-9_./:=@%+-]+$/.test(s)) return s;
+  return "'" + s.replace(/'/g, "'\\''") + "'";
 }
 
 export async function connectSSH(
@@ -189,16 +194,16 @@ async function ensureRemoteBrowser(
   customBinary?: string
 ): Promise<void> {
   const browserPaths: Record<string, string> = {
-    chrome: '/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome',
+    chrome: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
     comet: '/Applications/Comet.app/Contents/MacOS/Comet',
     chromium: '/Applications/Chromium.app/Contents/MacOS/Chromium',
-    brave: '/Applications/Brave\\ Browser.app/Contents/MacOS/Brave\\ Browser',
-    edge: '/Applications/Microsoft\\ Edge.app/Contents/MacOS/Microsoft\\ Edge',
+    brave: '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+    edge: '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
   };
 
   let browserPath: string;
   if (customBinary) {
-    browserPath = customBinary.replace(/ /g, '\\ ');
+    browserPath = customBinary;
   } else if (browserType === 'custom') {
     throw new Error('browser: custom requires a binary path in the profile');
   } else {
@@ -208,7 +213,14 @@ async function ensureRemoteBrowser(
     }
   }
 
-  const remoteCmd = `${browserPath} --remote-debugging-port=${port} '--remote-allow-origins=*' --disable-background-timer-throttling --user-data-dir=/tmp/agents-browser-${port} </dev/null >/dev/null 2>&1 &`;
+  const remoteCmd = [
+    shellQuote(browserPath),
+    `--remote-debugging-port=${port}`,
+    shellQuote('--remote-allow-origins=*'),
+    '--disable-background-timer-throttling',
+    `--user-data-dir=/tmp/agents-browser-${port}`,
+    '</dev/null >/dev/null 2>&1 &',
+  ].join(' ');
 
   return new Promise((resolve, reject) => {
     const child = spawn(
@@ -240,7 +252,7 @@ export async function restartRemoteBrowser(
   customBinary?: string
 ): Promise<void> {
   // Kill any process using the remote debugging port
-  const killCmd = `lsof -ti :${port} | xargs kill -9 2>/dev/null || true`;
+  const killCmd = `pids=$(lsof -ti ${shellQuote(`:${port}`)} 2>/dev/null); [ -z "$pids" ] || kill -9 $pids 2>/dev/null || true`;
   await runSSHCommand(user, host, killCmd);
   await sleep(500);
   await ensureRemoteBrowser(user, host, browserType, port, customBinary);
@@ -276,7 +288,7 @@ function sleep(ms: number): Promise<void> {
  */
 function isOwnTunnel(pid: number, host: string, remotePort: number): boolean {
   try {
-    const out = execSync(`ps -p ${pid} -o command=`, {
+    const out = execFileSync('ps', ['-p', String(pid), '-o', 'command='], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
     }).toString().trim();

--- a/src/lib/browser/profiles.test.ts
+++ b/src/lib/browser/profiles.test.ts
@@ -7,7 +7,7 @@ vi.mock('../state.js', () => ({
 }));
 
 vi.mock('child_process', () => ({
-  execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
 vi.mock('./chrome.js', () => ({
@@ -23,7 +23,7 @@ import {
 import type { BrowserProfile } from './types.js';
 import type { BrowserProfileConfig } from '../types.js';
 import { readMeta, writeMeta } from '../state.js';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 function profile(endpoints: string[]): BrowserProfile {
   return { name: 'test', browser: 'chrome', endpoints };
@@ -286,6 +286,56 @@ describe('profile YAML round-trip', () => {
     expect('electron' in stored).toBe(false);
     expect('targetFilter' in stored).toBe(false);
   });
+
+  it('allows spaces in browser binaries used by ssh endpoints', async () => {
+    const store: { browser: Record<string, BrowserProfileConfig> } = { browser: {} };
+    vi.mocked(readMeta).mockImplementation(() => store as any);
+    vi.mocked(writeMeta).mockImplementation((meta: any) => {
+      store.browser = (meta.browser ?? {}) as Record<string, BrowserProfileConfig>;
+    });
+
+    await expect(
+      createProfile({
+        name: 'remote-comet',
+        browser: 'custom',
+        binary: '/Applications/Comet Beta.app/Contents/MacOS/Comet Beta',
+        endpoints: ['ssh://mac-mini:9222'],
+      })
+    ).resolves.toBeUndefined();
+    expect(store.browser['remote-comet'].binary).toBe('/Applications/Comet Beta.app/Contents/MacOS/Comet Beta');
+  });
+
+  it('rejects shell metacharacters in browser binaries used by ssh endpoints', async () => {
+    const store: { browser: Record<string, BrowserProfileConfig> } = { browser: {} };
+    vi.mocked(readMeta).mockImplementation(() => store as any);
+
+    await expect(
+      createProfile({
+        name: 'remote-bad',
+        browser: 'custom',
+        binary: '/Applications/Comet.app/Contents/MacOS/Comet; touch /tmp/pwned',
+        endpoints: ['ssh://mac-mini:9222'],
+      })
+    ).rejects.toThrow(/Remote browser binary contains shell metacharacters/);
+  });
+
+  it('rejects shell metacharacters in per-endpoint ssh binary overrides', async () => {
+    const store: { browser: Record<string, BrowserProfileConfig> } = { browser: {} };
+    vi.mocked(readMeta).mockImplementation(() => store as any);
+
+    await expect(
+      createProfile({
+        name: 'remote-bad-override',
+        browser: 'custom',
+        endpoints: {
+          remote: {
+            target: 'ssh://mac-mini:9222',
+            binary: '/Applications/Comet.app/Contents/MacOS/Comet && say bad',
+          },
+        },
+      })
+    ).rejects.toThrow(/Remote browser binary contains shell metacharacters/);
+  });
 });
 
 describe('findFreeProfilePort', () => {
@@ -303,8 +353,8 @@ describe('findFreeProfilePort', () => {
         'p4': { browser: 'chrome', endpoints: ['cdp://127.0.0.1:9225'] },
       },
     } as any);
-    // All OS ports are free (execSync throws = nothing listening)
-    vi.mocked(execSync).mockImplementation(() => { throw new Error('no process'); });
+    // All OS ports are free (execFileSync throws = nothing listening)
+    vi.mocked(execFileSync).mockImplementation(() => { throw new Error('no process'); });
 
     const port = await findFreeProfilePort();
     expect(port).toBe(9226);
@@ -313,11 +363,10 @@ describe('findFreeProfilePort', () => {
   it('skips OS-in-use ports and returns first OS-free port', async () => {
     // No profiles
     vi.mocked(readMeta).mockReturnValue({ browser: {} } as any);
-    // 9222 is in use on the OS (execSync succeeds = something listening)
-    // 9223 is free (execSync throws)
-    vi.mocked(execSync).mockImplementation((_cmd: any) => {
-      const cmd = String(_cmd);
-      if (cmd.includes(':9222')) return '' as any;
+    // 9222 is in use on the OS (execFileSync succeeds = something listening)
+    // 9223 is free (execFileSync throws)
+    vi.mocked(execFileSync).mockImplementation((_cmd: any, args: any) => {
+      if (Array.isArray(args) && args.includes(':9222')) return '' as any;
       throw new Error('no process');
     });
 
@@ -334,7 +383,7 @@ describe('findFreeProfilePort', () => {
         'ssh-remote': { browser: 'comet', endpoints: ['ssh://mac-mini:9222'] },
       },
     } as any);
-    vi.mocked(execSync).mockImplementation(() => { throw new Error('no process'); });
+    vi.mocked(execFileSync).mockImplementation(() => { throw new Error('no process'); });
 
     const port = await findFreeProfilePort();
     expect(port).toBe(9223);

--- a/src/lib/browser/profiles.ts
+++ b/src/lib/browser/profiles.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import {
   getBrowserRuntimeDir as getBrowserRuntimeDirRoot,
   readMeta,
@@ -20,6 +20,7 @@ export function getProfileRuntimeDir(name: string): string {
 }
 
 function configToProfile(name: string, config: BrowserProfileConfig): BrowserProfile {
+  validateRemoteBrowserBinaries(config);
   return {
     name,
     description: config.description,
@@ -38,6 +39,7 @@ function configToProfile(name: string, config: BrowserProfileConfig): BrowserPro
 }
 
 function profileToConfig(profile: BrowserProfile): BrowserProfileConfig {
+  validateRemoteBrowserBinaries(profile);
   const config: BrowserProfileConfig = {
     browser: profile.browser,
     endpoints: profile.endpoints,
@@ -111,7 +113,7 @@ export async function findFreeProfilePort(): Promise<number> {
   for (let port = 9222; port <= 9399; port++) {
     if (usedByProfile.has(port)) continue;
     try {
-      execSync(`lsof -i :${port}`, { stdio: 'ignore' });
+      execFileSync('lsof', ['-i', `:${port}`], { stdio: 'ignore' });
       // lsof succeeded → something is listening → port is in use
     } catch {
       // lsof threw → nothing on this port → it's free
@@ -120,6 +122,40 @@ export async function findFreeProfilePort(): Promise<number> {
   }
 
   throw new Error('No available ports in range 9222-9399');
+}
+
+function validateRemoteBrowserBinaries(
+  profile: Pick<BrowserProfileConfig, 'binary' | 'endpoints'>
+): void {
+  if (!hasSshEndpoint(profile.endpoints)) return;
+  validateRemoteBrowserBinary(profile.binary);
+  if (!Array.isArray(profile.endpoints)) {
+    for (const preset of Object.values(profile.endpoints)) {
+      validateRemoteBrowserBinary(preset.binary);
+    }
+  }
+}
+
+function validateRemoteBrowserBinary(binary: string | undefined): void {
+  if (!binary) return;
+  if (/[\0\r\n;&|`$<>]/.test(binary)) {
+    throw new Error(
+      `Remote browser binary contains shell metacharacters: ${binary}`
+    );
+  }
+}
+
+function hasSshEndpoint(endpoints: BrowserProfileConfig['endpoints']): boolean {
+  const targets = Array.isArray(endpoints)
+    ? endpoints
+    : Object.values(endpoints).map((preset) => preset.target);
+  return targets.some((target) => {
+    try {
+      return new URL(target).protocol === 'ssh:';
+    } catch {
+      return false;
+    }
+  });
 }
 
 export async function createProfile(profile: BrowserProfile): Promise<void> {

--- a/src/lib/browser/runtime-state.ts
+++ b/src/lib/browser/runtime-state.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { getProfileRuntimeDir, getBrowserRuntimeDir } from './profiles.js';
 
 /**
@@ -290,7 +290,7 @@ export function reapOrphanedProcesses(): { reaped: number; details: string[] } {
 
 function matchesCommand(pid: number, expectedCommand: string): boolean {
   try {
-    const out = execSync(`ps -p ${pid} -o comm=`, {
+    const out = execFileSync('ps', ['-p', String(pid), '-o', 'comm='], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();

--- a/src/lib/browser/service.logs.test.ts
+++ b/src/lib/browser/service.logs.test.ts
@@ -42,7 +42,12 @@ vi.mock('./profiles.js', async (importOriginal) => {
   };
 });
 
-const { BrowserService, parseSinceUntil, readNewestMatchingFile } = await import('./service.js');
+const {
+  BrowserService,
+  parseSinceUntil,
+  readNewestMatchingFile,
+  readNewestMatchingRemoteFileCommand,
+} = await import('./service.js');
 
 function reset(): void {
   try {
@@ -122,6 +127,14 @@ describe('readNewestMatchingFile', () => {
     const out = readNewestMatchingFile(TEST_LOG_DIR, 'rush-app-', 2);
     const parsed = out.split('\n').filter(Boolean).map((l) => JSON.parse(l));
     expect(parsed).toEqual([{ n: 4 }, { n: 5 }]);
+  });
+});
+
+describe('readNewestMatchingRemoteFileCommand', () => {
+  it('shell-quotes the remote log directory before globbing', () => {
+    const cmd = readNewestMatchingRemoteFileCommand('/tmp/log dir', 'rush-app-', 25);
+    expect(cmd).toContain("'/tmp/log dir'/rush-app-*.jsonl");
+    expect(cmd).toContain('tail -n 25 "$latest"');
   });
 });
 

--- a/src/lib/browser/service.ts
+++ b/src/lib/browser/service.ts
@@ -14,7 +14,7 @@ import {
 } from './profiles.js';
 import { killChrome, getRunningChromeInfo, launchBrowser, allocatePort } from './chrome.js';
 import { connectLocal } from './drivers/local.js';
-import { connectSSH } from './drivers/ssh.js';
+import { connectSSH, shellQuote } from './drivers/ssh.js';
 import { clearProfileRuntime } from './runtime-state.js';
 import {
   generateTaskId,
@@ -176,6 +176,15 @@ async function execSSH(host: string, cmd: string): Promise<string> {
     maxBuffer: 10_000_000,
   });
   return stdout;
+}
+
+export function readNewestMatchingRemoteFileCommand(
+  dir: string,
+  prefix: string,
+  tailLines: number
+): string {
+  const glob = `${shellQuote(dir)}/${prefix}*.jsonl`;
+  return `latest=$(ls -1t ${glob} 2>/dev/null | head -1); if [ -n "$latest" ]; then tail -n ${tailLines} "$latest"; fi`;
 }
 
 export function readNewestMatchingFile(dir: string, prefix: string, tailLines: number): string {
@@ -1489,7 +1498,7 @@ export class BrowserService {
         if (profile.logHost) {
           return execSSH(
             profile.logHost,
-            `ls -1t ${logDir}/${prefix}*.jsonl 2>/dev/null | head -1 | xargs -r tail -n ${tailN}`
+            readNewestMatchingRemoteFileCommand(logDir, prefix, tailN)
           );
         }
         return readNewestMatchingFile(logDir, prefix, tailN);

--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -7,7 +7,7 @@
  * log output, reload (SIGHUP), and graceful shutdown are handled here.
  */
 
-import { spawn, execSync, execFileSync } from 'child_process';
+import { spawn, execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -295,7 +295,7 @@ function getAgentsBinPath(): string {
   const argv1 = process.argv[1];
   if (argv1 && fs.existsSync(argv1)) return argv1;
   try {
-    return execSync('which agents', { encoding: 'utf-8' }).trim();
+    return execFileSync('which', ['agents'], { encoding: 'utf-8' }).trim();
   } catch {
     return 'agents';
   }
@@ -360,9 +360,9 @@ function startDaemonLocked(): { pid: number | null; method: string } {
       }
       fs.writeFileSync(unitPath, generateSystemdUnit(), 'utf-8');
 
-      execSync('systemctl --user daemon-reload', { encoding: 'utf-8' });
-      execSync(`systemctl --user enable ${SYSTEMD_UNIT}`, { encoding: 'utf-8' });
-      execSync(`systemctl --user start ${SYSTEMD_UNIT}`, { encoding: 'utf-8' });
+      execFileSync('systemctl', ['--user', 'daemon-reload'], { encoding: 'utf-8' });
+      execFileSync('systemctl', ['--user', 'enable', SYSTEMD_UNIT], { encoding: 'utf-8' });
+      execFileSync('systemctl', ['--user', 'start', SYSTEMD_UNIT], { encoding: 'utf-8' });
 
       const pid = waitForPid(3000);
       return { pid, method: 'systemd' };
@@ -421,8 +421,8 @@ export function stopDaemon(): boolean {
 
   if (platform === 'linux') {
     try {
-      execSync(`systemctl --user stop ${SYSTEMD_UNIT}`, { encoding: 'utf-8' });
-      execSync(`systemctl --user disable ${SYSTEMD_UNIT}`, { encoding: 'utf-8' });
+      execFileSync('systemctl', ['--user', 'stop', SYSTEMD_UNIT], { encoding: 'utf-8' });
+      execFileSync('systemctl', ['--user', 'disable', SYSTEMD_UNIT], { encoding: 'utf-8' });
     } catch (err: any) {
       if (process.env.AGENTS_DEBUG) {
         console.error(`[debug] systemctl stop failed: ${err.message}`);

--- a/src/lib/session/__tests__/parse-opencode-subprocess.test.ts
+++ b/src/lib/session/__tests__/parse-opencode-subprocess.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test, vi } from 'vitest';
+import { execFileSync } from 'child_process';
+
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn(() => 'user|||text|||{"text":"hello"}|||0\n'),
+}));
+
+const { parseOpenCode } = await import('../parse.js');
+
+describe('parseOpenCode subprocess execution', () => {
+  test('passes sqlite path and query as argv instead of a shell command', () => {
+    const dbPath = '/tmp/opencode "; touch /tmp/pwned.db';
+    const events = parseOpenCode(`${dbPath}#session-1`);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].content).toBe('hello');
+    expect(execFileSync).toHaveBeenCalledWith(
+      'sqlite3',
+      expect.arrayContaining(['-separator', '|||', dbPath]),
+      expect.objectContaining({ encoding: 'utf-8' })
+    );
+  });
+});

--- a/src/lib/session/parse.ts
+++ b/src/lib/session/parse.ts
@@ -8,7 +8,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import type { SessionAgentId, SessionEvent } from './types.js';
 
 /**
@@ -668,10 +668,12 @@ export function parseOpenCode(filePath: string): SessionEvent[] {
       ORDER BY m.time_created ASC, p.time_created ASC;
     `.replace(/\n/g, ' ');
 
-    const out = execSync(
-      `sqlite3 -separator '|||' "${dbPath}"`,
-      { encoding: 'utf-8', input: query, stdio: ['pipe', 'pipe', 'ignore'], timeout: 10000 },
-    );
+    const out = execFileSync('sqlite3', ['-separator', '|||', dbPath, query], {
+      encoding: 'utf-8',
+      timeout: 10000,
+      maxBuffer: 32 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
 
     for (const line of out.split('\n')) {
       if (!line.trim()) continue;

--- a/src/lib/teams/agents.ts
+++ b/src/lib/teams/agents.ts
@@ -327,7 +327,7 @@ export function checkCliAvailable(agentType: AgentType): [boolean, string | null
   }
 
   try {
-    const whichPath = execSync(`which ${executable}`, { encoding: 'utf-8' }).trim();
+    const whichPath = execFileSync('which', [executable], { encoding: 'utf-8' }).trim();
     return [true, whichPath];
   } catch {
     return [false, `CLI tool '${executable}' not found in PATH. Install it first.`];


### PR DESCRIPTION
## Summary

Closes 3 hard findings + several smaller shell-string call sites — class-fix for `execSync` with interpolated values across the touched modules.

## Findings closed
- **B6 HIGH** — `src/lib/browser/drivers/ssh.ts:199-220` SSH custom-binary injection (`customBinary` only escaped spaces, not other metachars)
- **B7 HIGH** — `src/lib/session/parse.ts:671-672` OpenCode parser shell exec with `${dbPath}` interpolation
- **C6 MEDIUM** — `src/lib/browser/service.ts:1489-1492` SSH log retrieval with profile-controlled `logDir`
- Smaller sites: `chrome.ts:239/:260`, `profiles.ts:114`, `runtime-state.ts:293`, `ssh.ts:279`, `daemon.ts:364-425`, `teams/agents.ts:330`, `routines.ts:660`

## Approach
Argv-form `execFileSync('cmd', [args...])` with `shell: false`. For genuine remote-shell cases (SSH), added `shellQuote()` helper + profile-load-time validation of metacharacters.

Generated by the \`hn-fix\` agents team.