### PR TITLE
fix(shims): prevent PATH-shadow attack on generated shim helper calls

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -7,11 +7,17 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as readline from 'readline';
+import { fileURLToPath } from 'url';
 
 const HOME = os.homedir();
 const SHIMS_DIR = path.join(HOME, '.agents', '.cache', 'shims');
 const SYSTEM_DIR = path.join(HOME, '.agents-system');
 const USER_DIR = path.join(HOME, '.agents');
+const AGENTS_BIN = fileURLToPath(new URL('../dist/index.js', import.meta.url));
+
+function shellQuote(value) {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
 
 // For local installs, create directories and show a message
 const isGlobalInstall = process.env.npm_config_global || process.argv.includes('-g');
@@ -111,14 +117,14 @@ const exportLine = shellName === 'fish'
   ? `fish_add_path ${SHIMS_DIR}`
   : `export PATH="${SHIMS_DIR}:$PATH"`;
 
-// Shorthands that delegate to `agents <name>` — written unconditionally on install.
+// Shorthands that delegate to the installed agents-cli entrypoint.
 const ALIASES = ['sessions', 'secrets', 'browser', 'pty', 'teams'];
 
 function writeAliasShims() {
   const written = [];
   for (const name of ALIASES) {
     const target = path.join(SHIMS_DIR, name);
-    const script = `#!/bin/sh\nexec agents ${name} "$@"\n`;
+    const script = `#!/bin/sh\nAGENTS_BIN=${shellQuote(AGENTS_BIN)}\nif [ -z "$AGENTS_BIN" ] || [ ! -x "$AGENTS_BIN" ]; then\n  echo "agents: agents-cli entrypoint missing or not executable: $AGENTS_BIN" >&2\n  exit 127\nfi\nexec "$AGENTS_BIN" ${name} "$@"\n`;
     fs.writeFileSync(target, script, { mode: 0o755 });
     written.push(name);
   }

--- a/scripts/postinstall.test.ts
+++ b/scripts/postinstall.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const tempDirs: string[] = [];
+
+function makeTempHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-postinstall-test-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('postinstall alias shims', () => {
+  it('writes aliases that exec the absolute agents-cli entrypoint', () => {
+    const home = makeTempHome();
+    const result = spawnSync(process.execPath, [path.join(REPO_ROOT, 'scripts', 'postinstall.js')], {
+      env: {
+        ...process.env,
+        HOME: home,
+        npm_config_global: 'true',
+        AGENTS_INIT_SHELL: '0',
+        SHELL: '/bin/sh',
+      },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+
+    const aliasPath = path.join(home, '.agents', '.cache', 'shims', 'sessions');
+    const script = fs.readFileSync(aliasPath, 'utf-8');
+    const match = script.match(/^AGENTS_BIN='([^']+)'$/m);
+
+    expect(match).not.toBeNull();
+    expect(path.isAbsolute(match![1])).toBe(true);
+    expect(match![1]).toBe(path.join(REPO_ROOT, 'dist', 'index.js'));
+    expect(script).toContain('if [ -z "$AGENTS_BIN" ] || [ ! -x "$AGENTS_BIN" ]; then');
+    expect(script).toContain('agents: agents-cli entrypoint missing or not executable: $AGENTS_BIN');
+    expect(script).toContain('exec "$AGENTS_BIN" sessions "$@"');
+    expect(script).not.toContain('exec agents sessions "$@"');
+  });
+});

--- a/src/lib/__tests__/shims.test.ts
+++ b/src/lib/__tests__/shims.test.ts
@@ -84,8 +84,8 @@ describe('addShimsToPath', () => {
 });
 
 describe('SHIM_SCHEMA_VERSION', () => {
-  it('is 11 (shim prompts to switch when configured version not installed)', () => {
-    expect(SHIM_SCHEMA_VERSION).toBe(11);
+  it('is 12 (shim helper calls use an absolute agents-cli entrypoint)', () => {
+    expect(SHIM_SCHEMA_VERSION).toBe(12);
   });
 });
 
@@ -205,7 +205,7 @@ describe('generateShimScript', () => {
     const script = generateShimScript('claude');
     expect(script).toContain('no default set for $AGENT');
     expect(script).toContain('Set as default and continue?');
-    expect(script).toContain('agents use "$AGENT" "$LATEST"');
+    expect(script).toContain('"$AGENTS_BIN" use "$AGENT" "$LATEST"');
   });
 
   it('proposes switching to latest installed when configured version is missing', () => {
@@ -223,5 +223,25 @@ describe('generateShimScript', () => {
   it('reads answer from /dev/tty not stdin so piped input does not trigger prompt', () => {
     const script = generateShimScript('claude');
     expect(script).toContain('read -r _ans </dev/tty');
+  });
+
+  it('uses an absolute agents-cli entrypoint for helper calls', () => {
+    const script = generateShimScript('codex');
+    const match = script.match(/^AGENTS_BIN='([^']+)'$/m);
+
+    expect(match).not.toBeNull();
+    expect(path.isAbsolute(match![1])).toBe(true);
+    expect(script).toContain('"$AGENTS_BIN" refresh-rules --agent "$AGENT" --agent-version "$VERSION"');
+    expect(script).toContain('"$AGENTS_BIN" use "$AGENT" "$LATEST"');
+    expect(script).toContain('"$AGENTS_BIN" add "$AGENT@$VERSION" --yes');
+    expect(script).toContain('"$AGENTS_BIN" sync --agent "$AGENT" --agent-version "$VERSION" --project-dir "$PROJECT_AGENTS_DIR"');
+    expect(script).not.toMatch(/^\s*agents (refresh-rules|use|add|sync)\b/m);
+  });
+
+  it('fails clearly when the embedded agents-cli entrypoint is not executable', () => {
+    const script = generateShimScript('claude');
+    expect(script).toContain('if [ -z "$AGENTS_BIN" ] || [ ! -x "$AGENTS_BIN" ]; then');
+    expect(script).toContain('agents: agents-cli entrypoint missing or not executable: $AGENTS_BIN');
+    expect(script).toContain('exit 127');
   });
 });

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -11,6 +11,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { fileURLToPath } from 'url';
 import { confirm, select } from '@inquirer/prompts';
 import type { AgentId } from './types.js';
 import { getShimsDir, getVersionsDir, getBackupsDir, ensureAgentsDir } from './state.js';
@@ -204,11 +205,21 @@ async function promptConflictStrategy(
  *        .oauth_token file on Linux (keychain-less sandbox fallback).
  *   v11 — when no default is set or the configured version is not installed,
  *         interactively propose the latest already-installed version.
+ *   v12 — helper calls inside generated shims use the absolute agents-cli
+ *         entrypoint instead of PATH-resolved `agents`.
  */
-export const SHIM_SCHEMA_VERSION = 11;
+export const SHIM_SCHEMA_VERSION = 12;
 
 /** Internal marker string used to embed the schema version in shim scripts. */
 const SHIM_VERSION_MARKER = 'agents-shim-version:';
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function getAgentsBinForGeneratedShim(): string {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'index.js');
+}
 
 /**
  * Generate the full bash shim script for the given agent. The returned string
@@ -218,6 +229,7 @@ export function generateShimScript(agent: AgentId): string {
   const agentConfig = AGENTS[agent];
   const cliCommand = agentConfig.cliCommand;
   const configDirName = `.${agent}`;
+  const agentsBin = shellQuote(getAgentsBinForGeneratedShim());
   const managedEnv = agent === 'claude'
     ? `
 # Claude stores OAuth credentials in the macOS keychain. Scope them to the
@@ -249,7 +261,7 @@ export CODEX_HOME="$VERSION_DIR/home/${configDirName}"
 # Recompile rules if any rule/preset source has changed since last sync.
 # Fast-path check (~10-20ms) when nothing changed; full recompile only on
 # actual diff. Non-blocking failure — if the refresh errors, we still launch.
-agents refresh-rules --agent "$AGENT" --agent-version "$VERSION" --quiet 2>/dev/null || true
+"$AGENTS_BIN" refresh-rules --agent "$AGENT" --agent-version "$VERSION" --quiet 2>/dev/null || true
 `
     : '';
   const launchArgs = agent === 'codex' ? ' -c check_for_update_on_startup=false' : '';
@@ -261,8 +273,14 @@ agents refresh-rules --agent "$AGENT" --agent-version "$VERSION" --quiet 2>/dev/
 
 AGENTS_SYSTEM_DIR="$HOME/.agents-system"
 AGENTS_USER_DIR="$HOME/.agents"
+AGENTS_BIN=${agentsBin}
 AGENT="${agent}"
 CLI_COMMAND="${cliCommand}"
+
+if [ -z "$AGENTS_BIN" ] || [ ! -x "$AGENTS_BIN" ]; then
+  echo "agents: agents-cli entrypoint missing or not executable: $AGENTS_BIN" >&2
+  exit 127
+fi
 
 # Find project agents.yaml walking up from cwd (skip $HOME/.agents-system/agents.yaml)
 find_project_version() {
@@ -358,7 +376,7 @@ if [ -z "$VERSION" ]; then
       read -r _ans </dev/tty
       case "$_ans" in
         ""|y|Y)
-          agents use "$AGENT" "$LATEST" >/dev/null 2>&1
+          "$AGENTS_BIN" use "$AGENT" "$LATEST" >/dev/null 2>&1
           VERSION="$LATEST"
           VERSION_SOURCE="default"
           ;;
@@ -399,7 +417,7 @@ if [ ! -x "$BINARY" ]; then
     }
 
     # Run install in background with spinner
-    agents add "$AGENT@$VERSION" --yes >/dev/null 2>&1 &
+    "$AGENTS_BIN" add "$AGENT@$VERSION" --yes >/dev/null 2>&1 &
     install_pid=$!
     spin $install_pid
     wait $install_pid
@@ -420,7 +438,7 @@ if [ ! -x "$BINARY" ]; then
         read -r _ans </dev/tty
         case "$_ans" in
           ""|y|Y)
-            agents use "$AGENT" "$LATEST" >/dev/null 2>&1
+            "$AGENTS_BIN" use "$AGENT" "$LATEST" >/dev/null 2>&1
             VERSION="$LATEST"
             VERSION_DIR="$AGENTS_USER_DIR/.history/versions/$AGENT/$VERSION"
             BINARY="$VERSION_DIR/node_modules/.bin/$CLI_COMMAND"
@@ -445,7 +463,7 @@ fi
 # Sync project-scoped resources into version home if a project .agents/ is present
 PROJECT_AGENTS_DIR=$(find_project_agents_dir)
 if [ -n "$PROJECT_AGENTS_DIR" ]; then
-  agents sync --agent "$AGENT" --agent-version "$VERSION" --project-dir "$PROJECT_AGENTS_DIR" --quiet >/dev/null 2>&1
+  "$AGENTS_BIN" sync --agent "$AGENT" --agent-version "$VERSION" --project-dir "$PROJECT_AGENTS_DIR" --quiet >/dev/null 2>&1
 fi
 ${refreshRulesCall}${managedEnv}
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -373,12 +373,12 @@ describe('shims - generateShimScript', () => {
   test('includes project sync hook in shim', () => {
     const script = generateShimScript('claude');
     expect(script).toContain('find_project_agents_dir');
-    expect(script).toContain('agents sync --agent "$AGENT" --agent-version "$VERSION" --project-dir "$PROJECT_AGENTS_DIR"');
+    expect(script).toContain('"$AGENTS_BIN" sync --agent "$AGENT" --agent-version "$VERSION" --project-dir "$PROJECT_AGENTS_DIR"');
   });
 
   test('non-@-capable agents get a refresh-rules shim hook', () => {
     const script = generateShimScript('codex');
-    expect(script).toContain('agents refresh-rules --agent "$AGENT" --agent-version "$VERSION"');
+    expect(script).toContain('"$AGENTS_BIN" refresh-rules --agent "$AGENT" --agent-version "$VERSION"');
   });
 
   test('shim does not use --version flag, which collides with the top-level CLI version flag', () => {
@@ -394,9 +394,9 @@ describe('shims - generateShimScript', () => {
 
   test('@-capable agents do NOT get a refresh-rules shim hook', () => {
     const claudeScript = generateShimScript('claude');
-    expect(claudeScript).not.toContain('agents refresh-rules');
+    expect(claudeScript).not.toContain('refresh-rules');
     const geminiScript = generateShimScript('gemini');
-    expect(geminiScript).not.toContain('agents refresh-rules');
+    expect(geminiScript).not.toContain('refresh-rules');
   });
 
   test('scopes Claude keychain auth to the selected version config dir', () => {


### PR DESCRIPTION
## Summary

Closes **B4 HIGH** — generated shims and postinstall alias shims invoked bare \`agents\` (PATH-resolved) for helper calls like \`refresh-rules\`, \`use\`, \`add\`, \`sync\` before the final native binary exec. A hostile PATH could shadow those helpers. Final exec at \`src/lib/shims.ts:381-382, :452\` was already absolute and unchanged.

## Approach
- At shim-template generation time, resolve the absolute path to the installed agents-cli (\`process.execPath\` + \`dist/index.js\`) and embed as \`AGENTS_BIN\` in the shim.
- Replace every bare \`agents <subcmd>\` invocation in shim helpers with \`"$AGENTS_BIN" <subcmd>\`.
- Same for postinstall alias shims at \`scripts/postinstall.js:117-123\`.
- Defensive guard: if \`AGENTS_BIN\` is missing at run time, shim errors clearly.

Generated by the \`hn-fix\` agents team.