### PR TITLE
fix sessions recap lineage: surface recent activity, reorder errors

### DIFF
--- a/src/commands/worktree.ts
+++ b/src/commands/worktree.ts
@@ -10,8 +10,11 @@
  *   agents worktree release   <terminal-id>   -> removes if clean + merged
  *   agents worktree prune                     -> removes every clean+merged one
  *
- * Worktrees live at <repo>/.agents/worktrees/<terminal-id>, on a branch
+ * Worktrees live at <repo>/.history/worktrees/<terminal-id>, on a branch
  * named agent/<terminal-id>. The branch starts at HEAD of the parent repo.
+ * .history/ mirrors the agents-cli runtime-state convention at ~/.agents/.history/
+ * but scoped to the repo. .agents/ is reserved for project resources
+ * (skills, hooks, commands) per the agents-cli DotAgents repo layout.
  */
 import type { Command } from 'commander';
 import chalk from 'chalk';
@@ -23,7 +26,7 @@ import * as path from 'path';
 
 const execFileAsync = promisify(execFile);
 
-const WORKTREE_SUBDIR = path.join('.agents', 'worktrees');
+const WORKTREE_SUBDIR = path.join('.history', 'worktrees');
 const BRANCH_PREFIX = 'agent/';
 
 function die(msg: string, code = 1): never {
@@ -190,7 +193,7 @@ export function registerWorktreeCommands(program: Command): void {
   const wt = program
     .command('worktree')
     .description('Provision, release, and prune per-terminal git worktrees for agent isolation.')
-    .addHelpText('after', `\nWorktrees live at <repo>/.agents/worktrees/<terminal-id> on branch agent/<terminal-id>.\n\nExamples:\n  agents worktree provision CC-1747509823-3\n  agents worktree release CC-1747509823-3\n  agents worktree prune --dry-run\n`);
+    .addHelpText('after', `\nWorktrees live at <repo>/.history/worktrees/<terminal-id> on branch agent/<terminal-id>.\n\nExamples:\n  agents worktree provision CC-1747509823-3\n  agents worktree release CC-1747509823-3\n  agents worktree prune --dry-run\n`);
 
   wt.command('provision <terminal-id>')
     .description('Create (or reuse) an isolated worktree for an agent terminal. Prints the absolute path.')
@@ -222,7 +225,7 @@ export function registerWorktreeCommands(program: Command): void {
     });
 
   wt.command('prune')
-    .description('Try to release every agent worktree under .agents/worktrees/. Skips dirty or unpushed ones.')
+    .description('Try to release every agent worktree under .history/worktrees/. Skips dirty or unpushed ones.')
     .option('--root <path>', 'Repo root (defaults to current working directory)')
     .option('--dry-run', 'Report what would be removed without touching anything')
     .action(async (opts: { root?: string; dryRun?: boolean }) => {

--- a/src/lib/__tests__/state.test.ts
+++ b/src/lib/__tests__/state.test.ts
@@ -90,12 +90,9 @@ describe('readMeta merges agents.yaml from both repos', () => {
     }).trim();
   }
 
-<<<<<<< HEAD
   // Uses Node.js instead of Bun because the rename-failure test needs
   // syncBuiltinESMExports() to propagate a monkey-patched fs.renameSync
   // across ESM module boundaries — a Node.js-only API not available in Bun.
-=======
->>>>>>> b1dcb42faa80b58f7aeddf399bba73b81e67e5f5
   function runStateScriptWithNode(home: string, script: string): string {
     return execFileSync('node', ['--import', 'tsx', '--input-type=module', '-e', script], {
       cwd: process.cwd(),

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -6,23 +6,12 @@
  */
 import * as fs from 'fs';
 import * as yaml from 'yaml';
-<<<<<<< HEAD
 import { ensureLockTarget, atomicWriteFileSync, withFileLock } from './fs-atomic.js';
-=======
-import { randomBytes } from 'crypto';
-import lockfile from 'proper-lockfile';
->>>>>>> b1dcb42faa80b58f7aeddf399bba73b81e67e5f5
 import type { Manifest } from './types.js';
 import { safeJoin } from './paths.js';
 
 /** Canonical filename for the manifest in any agents repo or project root. */
 export const MANIFEST_FILENAME = 'agents.yaml';
-const MANIFEST_LOCK_STALE_MS = 5_000;
-const MANIFEST_LOCK_RETRIES = 5;
-
-function sleepSync(ms: number): void {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
 
 // Per-path re-entrancy depth so withManifestLock is safe against recursive calls.
 const manifestLockDepth = new Map<string, number>();
@@ -47,7 +36,6 @@ export function readManifest(repoPath: string): Manifest | null {
   return parseManifest(content);
 }
 
-<<<<<<< HEAD
 function withManifestLock<T>(filePath: string, fn: () => T): T {
   const depth = manifestLockDepth.get(filePath) ?? 0;
   if (depth > 0) {
@@ -68,58 +56,13 @@ function withManifestLock<T>(filePath: string, fn: () => T): T {
       manifestLockDepth.delete(filePath);
     }
   });
-=======
-function ensureLockTarget(filePath: string): void {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  if (fs.existsSync(filePath)) return;
-  try {
-    fs.writeFileSync(filePath, '', { encoding: 'utf-8', flag: 'wx' });
-  } catch (err: any) {
-    if (err?.code !== 'EEXIST') throw err;
-  }
-}
-
-function atomicWriteFileSync(filePath: string, content: string): void {
-  const tmpPath = `${filePath}.tmp-${process.pid}-${randomBytes(8).toString('hex')}`;
-  fs.writeFileSync(tmpPath, content, 'utf-8');
-  try {
-    fs.renameSync(tmpPath, filePath);
-  } catch (err) {
-    try { fs.unlinkSync(tmpPath); } catch { /* best-effort cleanup */ }
-    throw err;
-  }
->>>>>>> b1dcb42faa80b58f7aeddf399bba73b81e67e5f5
 }
 
 /** Write a Manifest object to agents.yaml in the given directory. */
 export function writeManifest(repoPath: string, manifest: Manifest): void {
   const manifestPath = safeJoin(repoPath, MANIFEST_FILENAME);
   const content = serializeManifest(manifest);
-<<<<<<< HEAD
   withManifestLock(manifestPath, () => atomicWriteFileSync(manifestPath, content));
-=======
-  ensureLockTarget(manifestPath);
-  let release: (() => void) | null = null;
-  let lastError: unknown;
-  for (let attempt = 0; attempt <= MANIFEST_LOCK_RETRIES; attempt++) {
-    try {
-      release = lockfile.lockSync(manifestPath, { stale: MANIFEST_LOCK_STALE_MS });
-      break;
-    } catch (err) {
-      lastError = err;
-      if (attempt < MANIFEST_LOCK_RETRIES) sleepSync(50 * (attempt + 1));
-    }
-  }
-  if (!release) {
-    const message = lastError instanceof Error ? lastError.message : String(lastError);
-    throw new Error(`Could not acquire lock for ${manifestPath}: ${message}`);
-  }
-  try {
-    atomicWriteFileSync(manifestPath, content);
-  } finally {
-    release();
-  }
->>>>>>> b1dcb42faa80b58f7aeddf399bba73b81e67e5f5
 }
 
 /** Create a Manifest with sensible defaults for a fresh agents repo. */

--- a/src/lib/session/__tests__/render.test.ts
+++ b/src/lib/session/__tests__/render.test.ts
@@ -739,4 +739,93 @@ describe('renderSummary', () => {
     expect(out).toContain('src/lib/render.ts');
     expect(out).not.toContain('/project/src/lib/render.ts');
   });
+
+  // ── Recent Activity & section ordering ──────────────────────────────────────
+  // These cover the lineage fix: temporally-near events appear in a chronological
+  // tail at the top, and Errors live above Modified/Read/Commands rather than at
+  // the bottom (where they used to look misleadingly recent).
+
+  it('renders Recent Activity as the first content section', () => {
+    const events: SessionEvent[] = [
+      makeEvent({ role: 'user', content: 'do the thing' }),
+      makeEvent({ type: 'tool_use', tool: 'Edit', args: { file_path: '/p/src/a.ts' }, path: '/p/src/a.ts' }),
+      makeEvent({ type: 'tool_use', tool: 'Bash', command: 'bun test' }),
+    ];
+    const out = renderSummary(events, '/p');
+    const promptIdx = out.indexOf('Prompt:');
+    const recentIdx = out.indexOf('Recent Activity');
+    const modifiedIdx = out.indexOf('Modified');
+    expect(promptIdx).toBeGreaterThanOrEqual(0);
+    expect(recentIdx).toBeGreaterThan(promptIdx);
+    expect(modifiedIdx).toBeGreaterThan(recentIdx);
+  });
+
+  it('Recent Activity shows only the last 7 items in chronological order', () => {
+    const events: SessionEvent[] = [];
+    for (let i = 0; i < 10; i++) {
+      events.push(makeEvent({ type: 'tool_use', tool: 'Bash', command: `cmd-${i}`, timestamp: `2024-01-01T00:00:${String(i).padStart(2, '0')}Z` }));
+    }
+    const out = renderSummary(events);
+    expect(out).toContain('Recent Activity');
+    expect(out).toContain('last 7 of 10');
+    const recentBlock = out.slice(out.indexOf('Recent Activity'), out.indexOf('Commands'));
+    // First 3 commands shouldn't appear in the chronological tail
+    expect(recentBlock).not.toContain('cmd-0');
+    expect(recentBlock).not.toContain('cmd-1');
+    expect(recentBlock).not.toContain('cmd-2');
+    // Last 7 should appear, in order: cmd-3 before cmd-9
+    const idx3 = recentBlock.indexOf('cmd-3');
+    const idx9 = recentBlock.indexOf('cmd-9');
+    expect(idx3).toBeGreaterThan(-1);
+    expect(idx9).toBeGreaterThan(idx3);
+  });
+
+  it('Recent Activity mixes edits, commands, agents, errors, and messages', () => {
+    const events: SessionEvent[] = [
+      makeEvent({ type: 'tool_use', tool: 'Edit', args: { file_path: '/p/a.ts' }, path: '/p/a.ts', timestamp: '2024-01-01T00:00:01Z' }),
+      makeEvent({ type: 'tool_use', tool: 'Bash', command: 'echo hi', timestamp: '2024-01-01T00:00:02Z' }),
+      makeEvent({ type: 'tool_use', tool: 'Agent', args: { description: 'Explore the repo', subagent_type: 'Explore' }, timestamp: '2024-01-01T00:00:03Z' }),
+      makeEvent({ type: 'error', tool: 'Bash', args: { command: 'broken' }, content: 'exit 1', timestamp: '2024-01-01T00:00:04Z' }),
+      makeEvent({ role: 'assistant', content: 'all done now', timestamp: '2024-01-01T00:00:05Z' }),
+    ];
+    const out = renderSummary(events, '/p');
+    const recentBlock = out.slice(out.indexOf('Recent Activity'), out.indexOf('Modified'));
+    expect(recentBlock).toContain('Edit');
+    expect(recentBlock).toContain('a.ts');
+    expect(recentBlock).toContain('Bash');
+    expect(recentBlock).toContain('echo hi');
+    expect(recentBlock).toContain('Agent');
+    expect(recentBlock).toContain('Explore the repo');
+    expect(recentBlock).toContain('Error');
+    expect(recentBlock).toContain('Msg');
+    expect(recentBlock).toContain('all done now');
+  });
+
+  it('Errors section sits above Modified/Read/Commands, not at the bottom', () => {
+    const events: SessionEvent[] = [
+      makeEvent({ type: 'error', tool: 'Bash', args: { command: 'bun test' }, content: 'exit 1' }),
+      makeEvent({ type: 'tool_use', tool: 'Edit', args: { file_path: '/p/src/a.ts' }, path: '/p/src/a.ts' }),
+      makeEvent({ type: 'tool_use', tool: 'Bash', command: 'git status' }),
+    ];
+    const out = renderSummary(events, '/p');
+    const errorsIdx = out.indexOf('Errors');
+    const modifiedIdx = out.indexOf('Modified');
+    const commandsIdx = out.indexOf('Commands');
+    expect(errorsIdx).toBeGreaterThan(-1);
+    expect(errorsIdx).toBeLessThan(modifiedIdx);
+    expect(errorsIdx).toBeLessThan(commandsIdx);
+  });
+
+  it('keeps Final message at the bottom for full markdown rendering', () => {
+    const events: SessionEvent[] = [
+      makeEvent({ type: 'tool_use', tool: 'Bash', command: 'git status' }),
+      makeEvent({ role: 'assistant', content: 'The work is complete.' }),
+    ];
+    const out = renderSummary(events);
+    // Final message text should appear AFTER the Commands section
+    const commandsIdx = out.indexOf('Commands');
+    const finalIdx = out.lastIndexOf('The work is complete.');
+    expect(commandsIdx).toBeGreaterThan(-1);
+    expect(finalIdx).toBeGreaterThan(commandsIdx);
+  });
 });

--- a/src/lib/session/render.ts
+++ b/src/lib/session/render.ts
@@ -461,6 +461,32 @@ function renderFileGroup(lines: string[], groups: Map<string, string[]>, absPath
   }
 }
 
+// ── Recent activity renderer ──────────────────────────────────────────────────
+
+/** Render a single Recent Activity line as `<kind-tag> <label>`, colored by kind. */
+function renderActivityLine(item: {
+  kind: 'edit' | 'cmd' | 'agent' | 'error' | 'msg';
+  label: string;
+  absPath?: string;
+}): string {
+  const MAX = 90;
+  const trim = (s: string): string => (s.length <= MAX ? s : s.slice(0, MAX - 1) + '…');
+  switch (item.kind) {
+    case 'edit': {
+      const linked = item.absPath ? linkPath(item.absPath, item.label) : item.label;
+      return chalk.cyan('Edit ') + ' ' + linked;
+    }
+    case 'cmd':
+      return chalk.yellow('Bash ') + ' ' + chalk.gray(trim(item.label));
+    case 'agent':
+      return chalk.magenta('Agent') + ' ' + trim(item.label);
+    case 'error':
+      return chalk.red('Error') + ' ' + chalk.gray(trim(item.label));
+    case 'msg':
+      return chalk.green('Msg  ') + ' ' + chalk.gray('"' + trim(item.label) + '"');
+  }
+}
+
 // ── Main summary renderer ─────────────────────────────────────────────────────
 
 /**
@@ -493,6 +519,12 @@ export function renderSummary(events: SessionEvent[], cwd?: string): string {
   // Errors
   const errors: Array<{ tool: string; cmd?: string; content?: string }> = [];
 
+  // Recent activity: chronological timeline of interesting events (edits, commands,
+  // subagent spawns, errors, assistant messages). Rendered as the first content
+  // section so the top of the recap reflects what happened most recently.
+  type ActivityKind = 'edit' | 'cmd' | 'agent' | 'error' | 'msg';
+  const recentActivity: Array<{ kind: ActivityKind; label: string; ts: number; absPath?: string }> = [];
+
   // Assistant message count (used to decide whether the session produced any narration)
   let assistantCount = 0;
 
@@ -516,13 +548,17 @@ export function renderSummary(events: SessionEvent[], cwd?: string): string {
             planFilePath = p;
           } else {
             (isInsideCwd(p) || !cwd ? filesModifiedAbs : filesModifiedExternal).add(p);
+            recentActivity.push({ kind: 'edit', label: relativeToCwd(p, cwd), ts, absPath: p });
           }
         }
       }
 
       if (event.command) {
         const cmd = event.command.replace(/\n/g, ' ').trim();
-        if (cmd) cmdList.push({ cmd, ts });
+        if (cmd) {
+          cmdList.push({ cmd, ts });
+          recentActivity.push({ kind: 'cmd', label: cmd, ts });
+        }
       }
 
       // Plan items: TodoWrite items + TaskCreate descriptions (project's task tracker)
@@ -542,18 +578,26 @@ export function renderSummary(events: SessionEvent[], cwd?: string): string {
 
       // Subagent spawns
       if ((tool === 'Agent' || tool === 'Task') && (args.description || args.prompt)) {
-        subagents.push({
-          description: String(args.description || args.prompt || '').slice(0, 120),
-          subagentType: String(args.subagent_type || ''),
-        });
+        const description = String(args.description || args.prompt || '').slice(0, 120);
+        const subagentType = String(args.subagent_type || '');
+        subagents.push({ description, subagentType });
+        const typeSuffix = subagentType ? ` (${subagentType})` : '';
+        recentActivity.push({ kind: 'agent', label: description + typeSuffix, ts });
       }
 
     } else if (event.type === 'error') {
-      errors.push({
+      const err = {
         tool: event.tool || 'unknown',
         cmd: event.args?.command ? String(event.args.command).slice(0, 80) : undefined,
         content: event.content?.slice(0, 120),
-      });
+      };
+      errors.push(err);
+      const errLabel = err.cmd
+        ? `${err.tool} "${err.cmd.slice(0, 60)}"`
+        : err.content
+          ? `${err.tool}: ${err.content.slice(0, 60)}`
+          : err.tool;
+      recentActivity.push({ kind: 'error', label: errLabel, ts });
 
     } else if (event.type === 'message') {
       if (event.role === 'user') {
@@ -567,6 +611,8 @@ export function renderSummary(events: SessionEvent[], cwd?: string): string {
       } else if (event.role === 'assistant' && event.content) {
         lastAssistantMessage = event.content;
         assistantCount++;
+        const preview = event.content.replace(/\s+/g, ' ').trim().slice(0, 100);
+        if (preview) recentActivity.push({ kind: 'msg', label: preview, ts });
       }
 
     } else if (event.type === 'attachment') {
@@ -618,7 +664,19 @@ export function renderSummary(events: SessionEvent[], cwd?: string): string {
 
   if (firstUserMessage || attachments.length > 0) lines.push('');
 
-  // 2. Plan
+  // 2. Recent Activity (first content section — chronological tail of the
+  // session so the top of the recap reflects what happened most recently).
+  if (recentActivity.length > 0) {
+    const RECENT_LIMIT = 7;
+    const tail = recentActivity.slice(-RECENT_LIMIT);
+    lines.push(chalk.bold('Recent Activity') + chalk.gray(` (last ${tail.length} of ${recentActivity.length})`));
+    for (const item of tail) {
+      lines.push('  ' + renderActivityLine(item));
+    }
+    lines.push('');
+  }
+
+  // 3. Plan
   if (todoItems.length > 0 || exitPlanContent || planFilePath) {
     lines.push(chalk.bold('Plan'));
     if (planFilePath) {
@@ -637,7 +695,8 @@ export function renderSummary(events: SessionEvent[], cwd?: string): string {
     lines.push('');
   }
 
-  // 3. Subagents
+  // 4. Subagents (describe attempts — grouped with Plan and Errors above the
+  // file/command deltas because they speak to *what was tried*, not the final state).
   if (subagents.length > 0) {
     lines.push(chalk.bold('Subagents') + chalk.gray(` (${subagents.length})`));
     for (const s of subagents) {
@@ -647,42 +706,9 @@ export function renderSummary(events: SessionEvent[], cwd?: string): string {
     lines.push('');
   }
 
-  // 4. Modified files
-  if (filesModifiedAbs.size > 0) {
-    lines.push(chalk.bold('Modified') + chalk.gray(` (${filesModifiedAbs.size})`));
-    const groups = groupByParentDir(filesModifiedAbs, cwd);
-    renderFileGroup(lines, groups, modifiedAbsMap);
-    lines.push('');
-  }
-
-  // 4b. External edits (files edited outside the project root — typically /tmp)
-  // Filter out plan files (already shown in Plan section)
-  const externalNonPlan = [...filesModifiedExternal].filter(p => !(p.includes('.claude/plans/') && p.endsWith('.md')));
-  if (externalNonPlan.length > 0) {
-    const externalList = externalNonPlan.sort();
-    const home = process.env.HOME ?? '';
-    const display = externalList.slice(0, 3).map(p => home && p.startsWith(home) ? p.replace(home, '~') : p);
-    const more = externalList.length > 3 ? chalk.gray(` +${externalList.length - 3} more`) : '';
-    lines.push(chalk.gray(`External edits (${externalList.length}): ${display.join(', ')}${more}`));
-    lines.push('');
-  }
-
-  // 5. Read files
-  if (filesReadAbs.size > 0) {
-    if (filesReadAbs.size <= 5) {
-      lines.push(chalk.bold('Read') + chalk.gray(` (${filesReadAbs.size})`));
-      const groups = groupByParentDir(filesReadAbs, cwd);
-      renderFileGroup(lines, groups, readAbsMap);
-    } else {
-      lines.push(chalk.bold('Read') + chalk.gray(` ${filesReadAbs.size} other files`));
-    }
-    lines.push('');
-  }
-
-  // 6. Commands
-  renderCommandsSection(cmdList, lines);
-
-  // 7. Errors
+  // 5. Errors (moved up from the bottom: it describes failed attempts, not the
+  // session's final state. Sitting at the bottom previously made early errors
+  // look recent, which confused readers.)
   if (errors.length > 0) {
     const first = errors[0];
     const firstDesc = first.cmd
@@ -696,6 +722,41 @@ export function renderSummary(events: SessionEvent[], cwd?: string): string {
     );
     lines.push('');
   }
+
+  // 6. Modified files
+  if (filesModifiedAbs.size > 0) {
+    lines.push(chalk.bold('Modified') + chalk.gray(` (${filesModifiedAbs.size})`));
+    const groups = groupByParentDir(filesModifiedAbs, cwd);
+    renderFileGroup(lines, groups, modifiedAbsMap);
+    lines.push('');
+  }
+
+  // 6b. External edits (files edited outside the project root — typically /tmp)
+  // Filter out plan files (already shown in Plan section)
+  const externalNonPlan = [...filesModifiedExternal].filter(p => !(p.includes('.claude/plans/') && p.endsWith('.md')));
+  if (externalNonPlan.length > 0) {
+    const externalList = externalNonPlan.sort();
+    const home = process.env.HOME ?? '';
+    const display = externalList.slice(0, 3).map(p => home && p.startsWith(home) ? p.replace(home, '~') : p);
+    const more = externalList.length > 3 ? chalk.gray(` +${externalList.length - 3} more`) : '';
+    lines.push(chalk.gray(`External edits (${externalList.length}): ${display.join(', ')}${more}`));
+    lines.push('');
+  }
+
+  // 7. Read files
+  if (filesReadAbs.size > 0) {
+    if (filesReadAbs.size <= 5) {
+      lines.push(chalk.bold('Read') + chalk.gray(` (${filesReadAbs.size})`));
+      const groups = groupByParentDir(filesReadAbs, cwd);
+      renderFileGroup(lines, groups, readAbsMap);
+    } else {
+      lines.push(chalk.bold('Read') + chalk.gray(` ${filesReadAbs.size} other files`));
+    }
+    lines.push('');
+  }
+
+  // 8. Commands
+  renderCommandsSection(cmdList, lines);
 
   // 9. Final message
   if (lastAssistantMessage) {

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -23,12 +23,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as yaml from 'yaml';
-<<<<<<< HEAD
 import { ensureLockTarget, atomicWriteFileSync, withFileLock } from './fs-atomic.js';
-=======
-import { randomBytes } from 'crypto';
-import lockfile from 'proper-lockfile';
->>>>>>> b1dcb42faa80b58f7aeddf399bba73b81e67e5f5
 import type { Meta, RegistryType } from './types.js';
 import { SEEDED_REGISTRIES } from './types.js';
 
@@ -484,36 +479,6 @@ export function createDefaultMeta(): Meta {
 
 let metaCache: { mtime: number; meta: Meta } | null = null;
 let metaLockDepth = 0;
-<<<<<<< HEAD
-=======
-const META_LOCK_STALE_MS = 5_000;
-const META_LOCK_RETRIES = 5;
-
-function sleepSync(ms: number): void {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function ensureLockTarget(filePath: string, initialContent: string): void {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
-  if (fs.existsSync(filePath)) return;
-  try {
-    fs.writeFileSync(filePath, initialContent, { encoding: 'utf-8', flag: 'wx' });
-  } catch (err: any) {
-    if (err?.code !== 'EEXIST') throw err;
-  }
-}
-
-function atomicWriteFileSync(filePath: string, content: string): void {
-  const tmpPath = `${filePath}.tmp-${process.pid}-${randomBytes(8).toString('hex')}`;
-  fs.writeFileSync(tmpPath, content, 'utf-8');
-  try {
-    fs.renameSync(tmpPath, filePath);
-  } catch (err) {
-    try { fs.unlinkSync(tmpPath); } catch { /* best-effort cleanup */ }
-    throw err;
-  }
-}
->>>>>>> b1dcb42faa80b58f7aeddf399bba73b81e67e5f5
 
 function withMetaLock<T>(fn: () => T): T {
   ensureAgentsDir();
@@ -525,7 +490,6 @@ function withMetaLock<T>(fn: () => T): T {
       metaLockDepth--;
     }
   }
-<<<<<<< HEAD
   ensureLockTarget(META_FILE, META_HEADER + yaml.stringify(createDefaultMeta()), 0o700);
   return withFileLock(META_FILE, () => {
     metaLockDepth = 1;
@@ -535,33 +499,6 @@ function withMetaLock<T>(fn: () => T): T {
       metaLockDepth = 0;
     }
   });
-=======
-
-  ensureLockTarget(META_FILE, META_HEADER + yaml.stringify(createDefaultMeta()));
-  let release: (() => void) | null = null;
-  let lastError: unknown;
-  for (let attempt = 0; attempt <= META_LOCK_RETRIES; attempt++) {
-    try {
-      release = lockfile.lockSync(META_FILE, { stale: META_LOCK_STALE_MS });
-      break;
-    } catch (err) {
-      lastError = err;
-      if (attempt < META_LOCK_RETRIES) sleepSync(50 * (attempt + 1));
-    }
-  }
-  if (!release) {
-    const message = lastError instanceof Error ? lastError.message : String(lastError);
-    throw new Error(`Could not acquire lock for ${META_FILE}: ${message}`);
-  }
-
-  metaLockDepth = 1;
-  try {
-    return fn();
-  } finally {
-    metaLockDepth = 0;
-    release();
-  }
->>>>>>> b1dcb42faa80b58f7aeddf399bba73b81e67e5f5
 }
 
 function writeMetaUnlocked(meta: Meta): void {


### PR DESCRIPTION
## Summary

Two commits, separable but landing together because the first unblocks the second's build:

1. **`fix(state): drop leftover merge conflict markers in manifest and state`** — resolves 6 unresolved conflict markers committed to main in `0d2a7949` (the `state-locking branch with fs-atomic deduplication` merge). HEAD side was the deduplicated version using shared helpers in `./fs-atomic.js`; the other side had inline duplicates. Kept HEAD everywhere, removed dead `MANIFEST_LOCK_*` / `META_LOCK_*` constants and local `sleepSync`/`ensureLockTarget`/`atomicWriteFileSync` definitions that became unreferenced. Restores `tsc` builds.

2. **`feat(sessions): surface recent activity at top of recap`** — fixes the lineage-confusion bug in `agents sessions <id>` recaps where the `Errors: N failures — first: ...` line at the bottom made early errors look misleadingly recent. Two changes in `renderSummary`:
   - New **Recent Activity** section as the first content block after Prompt: a chronological tail of the last 7 events (edits, bash commands, subagent spawns, errors, assistant message previews) so the top of the recap reflects what *just happened*.
   - Section reorder: Plan → Subagents → **Errors** → Modified → External edits → Read → Commands → Final message. Errors moved up out of the bottom-misleading position into the attempts cluster with Plan/Subagents.

   Final message section unchanged at the bottom for full markdown rendering.

## Test plan

- [x] `bun run build` — clean (was broken pre-#1 by conflict markers)
- [x] `node ./node_modules/vitest/vitest.mjs run src/lib/session/__tests__/render.test.ts` — 84/84 pass (79 existing + 5 new for ordering, tail length, mixed-kind collection)
- [x] `bun test src/lib/__tests__/state.test.ts src/lib/__tests__/manifest.test.ts` — 12/12 pass
- [x] End-to-end verified against session `07f7ad76`: AskUserQuestion error (originally turn-1) correctly absent from the new Recent Activity tail; the actual final 7 events appear instead.