### PR TITLE
feat(computer): macOS computer-use helper, sibling of agents browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "bin": {
     "agents": "dist/index.js",
     "ag": "dist/index.js",
-    "browser": "dist/browser.js"
+    "browser": "dist/browser.js",
+    "computer": "dist/computer.js"
   },
   "files": [
     "dist/**/*.js",

--- a/packages/computer-helper/.gitignore
+++ b/packages/computer-helper/.gitignore
@@ -1,0 +1,4 @@
+.build/
+dist/
+*.xcodeproj/
+Package.resolved

--- a/packages/computer-helper/Package.swift
+++ b/packages/computer-helper/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "ComputerHelper",
+    platforms: [.macOS(.v14)],
+    targets: [
+        .executableTarget(
+            name: "ComputerHelper",
+            path: "Sources/ComputerHelper",
+            linkerSettings: [
+                .linkedFramework("ApplicationServices"),
+                .linkedFramework("AppKit"),
+                .linkedFramework("CoreGraphics"),
+                .linkedFramework("ScreenCaptureKit"),
+            ]
+        )
+    ]
+)

--- a/packages/computer-helper/README.md
+++ b/packages/computer-helper/README.md
@@ -1,0 +1,36 @@
+# computer-helper
+
+macOS native helper that exposes Accessibility (AX) + ScreenCaptureKit + CoreGraphics
+event injection over line-delimited JSON-RPC on stdio.
+
+This is the backend for `agents computer` (mirror of `agents browser`).
+
+## Build
+
+```bash
+./scripts/build.sh         # debug (single-arch)
+./scripts/build.sh release # universal arm64 + x86_64
+```
+
+Outputs:
+
+- `dist/computer-helper-mac` — bare binary
+- `dist/ComputerHelper.app` — signed .app bundle (Developer ID if available, ad-hoc otherwise)
+
+Bundle id: `dev.swarmify.computer-helper`.
+
+## Why a .app bundle, not just a binary
+
+macOS TCC keys Accessibility / Screen Recording grants by the launching process's
+bundle id + Team ID. A bare binary inherits TCC identity from whatever shell or
+process launched it — which means a one-time System Settings grant evaporates the
+next time a different parent process invokes the helper. The `.app` form gives
+the helper a stable TCC identity that survives across launches.
+
+## Protocol
+
+Each line in: `{"id":N,"method":"...","params":{...}}`
+Each line out: `{"id":N,"result":{...}}` or `{"id":N,"error":{"code":"...","message":"..."}}`
+
+The full method list is defined in `Sources/ComputerHelper/RPC.swift`. The
+helper terminates cleanly on stdin EOF.

--- a/packages/computer-helper/README.md
+++ b/packages/computer-helper/README.md
@@ -5,6 +5,57 @@ event injection over line-delimited JSON-RPC on stdio.
 
 This is the backend for `agents computer` (mirror of `agents browser`).
 
+## Permissions
+
+The helper is default-deny. Every action method (`screenshot`, `click`, `type`,
+`describe`, etc.) checks the target pid's bundle id against an allow list the
+user controls via permission groups under `~/.agents/permissions/groups/`.
+
+Allow a target by adding a `Computer(<bundle-id>)` rule to any group file's
+`allow:` list. Example `~/.agents/permissions/groups/computer.yaml`:
+
+```yaml
+name: computer
+description: Native macOS apps the computer-helper daemon may drive
+allow:
+  - "Computer(com.apple.mail)"
+  - "Computer(com.apple.ical)"
+  - "Computer(com.apple.notes)"
+```
+
+You can also mix `Computer(...)` patterns into any existing group file alongside
+`Bash(...)`, `Read(...)`, etc.
+
+After editing groups while the daemon is running, push the change to the helper:
+
+```bash
+agents computer reload
+```
+
+This rewrites `~/.agents/.cache/helpers/computer-policy.json` and sends `SIGHUP`
+to the daemon, which re-reads the file. `agents computer start` does the same
+write on every startup.
+
+### Hard floor
+
+Three bundle ids are denied unconditionally and cannot be added to the allow
+list (the helper returns `target_excluded`):
+
+- `com.apple.tccd`
+- `com.apple.SecurityAgent`
+- `com.apple.systempreferences`
+
+These are TCC escalation paths. Driving them would let an agent silently
+re-grant Accessibility, Screen Recording, or other privacy permissions. Every
+other bundle id is your call — Terminal, iTerm, Keychain, the Rush app, etc.
+are all user-controlled.
+
+### Fail-safe
+
+When the policy file is missing or unparseable the helper boots with an empty
+allow list, which denies everything. Same behavior after a SIGHUP. There is no
+"allow everything" default.
+
 ## Build
 
 ```bash

--- a/packages/computer-helper/README.md
+++ b/packages/computer-helper/README.md
@@ -17,7 +17,7 @@ Outputs:
 - `dist/computer-helper-mac` — bare binary
 - `dist/ComputerHelper.app` — signed .app bundle (Developer ID if available, ad-hoc otherwise)
 
-Bundle id: `dev.swarmify.computer-helper`.
+Bundle id: `com.phnx-labs.computer-helper`.
 
 ## Why a .app bundle, not just a binary
 

--- a/packages/computer-helper/Sources/ComputerHelper/AX.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/AX.swift
@@ -1,0 +1,504 @@
+import ApplicationServices
+import AppKit
+import Foundation
+
+// Roles we return to the agent as interactable. Containers not in this set
+// are flattened out (we recurse into their children but don't emit a node).
+private let INTERACTABLE_ROLES: Set<String> = [
+    "AXButton", "AXCheckBox", "AXRadioButton", "AXPopUpButton",
+    "AXComboBox", "AXTextField", "AXTextArea", "AXSearchField",
+    "AXLink", "AXMenuItem", "AXMenuBarItem", "AXTab", "AXSlider",
+    "AXStepper", "AXDisclosureTriangle", "AXScrollBar", "AXOutline",
+    "AXRow", "AXCell", "AXList", "AXTable", "AXTabGroup",
+    "AXToolbar", "AXGroup", // groups kept only if labeled — filtered below
+]
+
+// Roles that carry content we surface (text/images) when labeled.
+private let CONTENT_ROLES: Set<String> = [
+    "AXStaticText", "AXImage", "AXHeading",
+]
+
+private let MAX_ELEMENTS = 500
+private let MAX_DEPTH_DEFAULT = 25
+
+enum AX {
+
+    // MARK: - Trust / permissions
+
+    static func ensureTrusted() throws {
+        if !isTrusted() {
+            throw RPCError.denied("Accessibility not granted — enable in System Settings > Privacy & Security > Accessibility")
+        }
+    }
+
+    static func isTrusted() -> Bool {
+        // AXIsProcessTrusted() is the non-prompting variant and doesn't have
+        // the CFBoolean-bridging quirks of AXIsProcessTrustedWithOptions.
+        return AXIsProcessTrusted()
+    }
+
+    // MARK: - describe
+
+    static func describe(params: [String: Any], cache: ElementCache) throws -> [String: Any] {
+        try ensureTrusted()
+        let pid = try Params.int(params, "pid")
+        let maxDepth = Params.intOpt(params, "max_depth") ?? MAX_DEPTH_DEFAULT
+
+        // Reject denied bundle ids early.
+        if let bundleId = bundleIdForPid(pid), DENY_BUNDLE_IDS.contains(bundleId) {
+            throw RPCError.excluded(bundleId)
+        }
+
+        guard runningPids().contains(pid) else {
+            throw RPCError.appMissing(pid)
+        }
+
+        _ = cache.beginDescribe(pid: pid)
+        let app = AXUIElementCreateApplication(pid_t(pid))
+
+        var counter = 0
+        var truncated = false
+        let tree = walk(element: app, pid: pid, depth: 0, maxDepth: maxDepth, counter: &counter, truncated: &truncated, cache: cache)
+
+        return [
+            "pid": pid,
+            "tree": tree as Any,
+            "element_count": counter,
+            "truncated": truncated,
+        ]
+    }
+
+    // MARK: - click
+
+    static func click(params: [String: Any], cache: ElementCache) throws -> [String: Any] {
+        try ensureTrusted()
+        let pid = try Params.int(params, "pid")
+
+        // Coords fallback: if the caller passes x/y (and no element_id), synthesize
+        // a click at those screen coords. Used for canvas apps, games, and any
+        // element the AX tree doesn't expose — the accessibility equivalent of
+        // browser_click's coordinate mode.
+        if Params.stringOpt(params, "element_id") == nil {
+            if let x = Params.intOpt(params, "x"), let y = Params.intOpt(params, "y") {
+                let pt = CGPoint(x: x, y: y)
+                CursorSprite.shared.flash(at: pt)
+                guard let down = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: pt, mouseButton: .left),
+                      let up = CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: pt, mouseButton: .left) else {
+                    throw RPCError(code: "action_failed", message: "could not create click event")
+                }
+                down.postToPid(pid_t(pid))
+                up.postToPid(pid_t(pid))
+                return ["ok": true, "action": "CGEvent", "at": [x, y]]
+            }
+            throw RPCError.invalid("pass either element_id or x,y")
+        }
+
+        let elementId = try Params.string(params, "element_id")
+
+        guard let el = cache.get(pid: pid, id: elementId) else {
+            throw RPCError.stale()
+        }
+
+        // Focus-safe order, picked by role + capability:
+        //   1. AXMenuBarItem — try AXShowMenu (documented action for opening
+        //      a menu, focus-safe), then AXPress. We deliberately do NOT
+        //      synthesize a CGEvent here even though Qt's AXPress doesn't
+        //      render a visible popup — synthesizing a mouse click would
+        //      bring the target app to the foreground and steal focus from
+        //      the user. For Qt apps the AX tree already exposes the full
+        //      menu structure even when the menu isn't visible, so callers
+        //      should locate the menu *item* directly via describe and
+        //      AXPress it — no need to "open" the menu first.
+        //   2. AXPress — buttons, menu items, links. Focus-safe.
+        //   3. Synthesized left-click at the element's center — last resort
+        //      for elements without AXPress. Posted to pid to minimize
+        //      focus disruption, but Quartz still activates the target.
+        let actions = copyActionNames(el)
+        let role = stringAttr(el, kAXRoleAttribute as CFString) ?? ""
+
+        if role == "AXMenuBarItem" {
+            if let center = Mouse.elementCenter(el) {
+                CursorSprite.shared.flash(at: center)
+            }
+            if actions.contains("AXShowMenu") {
+                let err = AXUIElementPerformAction(el, "AXShowMenu" as CFString)
+                if err == .success {
+                    return ["ok": true, "action": "AXShowMenu"]
+                }
+            }
+            if actions.contains(kAXPressAction as String) {
+                let err = AXUIElementPerformAction(el, kAXPressAction as CFString)
+                if err == .success {
+                    return ["ok": true, "action": "AXPress"]
+                }
+            }
+            throw RPCError(code: "action_failed", message: "menu bar item supports neither AXShowMenu nor AXPress focus-safely; locate its child menu item directly and AXPress that")
+        }
+
+        if actions.contains(kAXPressAction as String) {
+            // Flash at the element's center for visual feedback even though
+            // AXPress doesn't move the cursor or hit-test by coords.
+            if let center = Mouse.elementCenter(el) {
+                CursorSprite.shared.flash(at: center)
+            }
+            let err = AXUIElementPerformAction(el, kAXPressAction as CFString)
+            if err != .success {
+                throw RPCError(code: "action_failed", message: "AXPerformAction(AXPress)=\(err.rawValue)")
+            }
+            return ["ok": true, "action": "AXPress"]
+        }
+
+        guard let center = Mouse.elementCenter(el) else {
+            throw RPCError(code: "action_failed", message: "element has no frame and no AXPress action")
+        }
+        CursorSprite.shared.flash(at: center)
+        guard let down = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: center, mouseButton: .left),
+              let up = CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: center, mouseButton: .left) else {
+            throw RPCError(code: "action_failed", message: "could not create click event")
+        }
+        down.postToPid(pid_t(pid))
+        up.postToPid(pid_t(pid))
+        return ["ok": true, "action": "CGEvent", "at": [Int(center.x), Int(center.y)]]
+    }
+
+    // MARK: - type / setValue
+
+    static func setValue(params: [String: Any], cache: ElementCache) throws -> [String: Any] {
+        try ensureTrusted()
+        let pid = try Params.int(params, "pid")
+        let text = try Params.string(params, "text")
+
+        // Coords fallback: click at (x,y) to focus the input, then paste the
+        // text via clipboard + cmd+V. Works on canvas apps and any element
+        // the AX tree doesn't expose as a text input. Note: this touches the
+        // user's clipboard. For predictability we don't attempt to save/restore.
+        if Params.stringOpt(params, "element_id") == nil {
+            if let x = Params.intOpt(params, "x"), let y = Params.intOpt(params, "y") {
+                return try setValueByCoords(pid: pid, x: x, y: y, text: text)
+            }
+            throw RPCError.invalid("pass either element_id or x,y")
+        }
+
+        let elementId = try Params.string(params, "element_id")
+
+        guard let el = cache.get(pid: pid, id: elementId) else {
+            throw RPCError.stale()
+        }
+
+        // Refuse to inject text into secure (password) fields unless the caller
+        // explicitly opts in. Prevents accidental password autofill by the agent.
+        if isSecureField(el) && !Params.bool(params, "allow_secure_field") {
+            throw RPCError.denied("secure text field — set allow_secure_field=true to override")
+        }
+
+        var settable = DarwinBoolean(false)
+        AXUIElementIsAttributeSettable(el, kAXValueAttribute as CFString, &settable)
+        if !settable.boolValue {
+            throw RPCError.unsupported("AXValue not settable on element \(elementId)")
+        }
+
+        let err = AXUIElementSetAttributeValue(el, kAXValueAttribute as CFString, text as CFTypeRef)
+        if err != .success {
+            throw RPCError(code: "action_failed", message: "AXSetAttributeValue=\(err.rawValue)")
+        }
+        return ["ok": true]
+    }
+
+    // MARK: - setValue coord fallback
+
+    private static func setValueByCoords(pid: Int, x: Int, y: Int, text: String) throws -> [String: Any] {
+        // Focus the input by clicking at (x,y) first.
+        let pt = CGPoint(x: x, y: y)
+        CursorSprite.shared.flash(at: pt)
+        guard let down = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: pt, mouseButton: .left),
+              let up = CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: pt, mouseButton: .left) else {
+            throw RPCError(code: "action_failed", message: "could not create focus click")
+        }
+        down.postToPid(pid_t(pid))
+        up.postToPid(pid_t(pid))
+        Thread.sleep(forTimeInterval: 0.05)
+
+        // Put text on the pasteboard and paste. NSPasteboard.general is
+        // available without entitlements for text content.
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(text, forType: .string)
+        Thread.sleep(forTimeInterval: 0.02)
+
+        // Post cmd+V to the target pid. Keycode 0x09 = V.
+        guard let kdown = CGEvent(keyboardEventSource: nil, virtualKey: 0x09, keyDown: true),
+              let kup = CGEvent(keyboardEventSource: nil, virtualKey: 0x09, keyDown: false) else {
+            throw RPCError(code: "action_failed", message: "could not create paste event")
+        }
+        kdown.flags = .maskCommand
+        kup.flags = .maskCommand
+        kdown.postToPid(pid_t(pid))
+        kup.postToPid(pid_t(pid))
+
+        return ["ok": true, "method": "ClipboardPaste", "at": [x, y]]
+    }
+
+    // MARK: - get_text
+
+    static func getText(params: [String: Any], cache: ElementCache) throws -> [String: Any] {
+        try ensureTrusted()
+        let pid = try Params.int(params, "pid")
+        let maxChars = min(Params.intOpt(params, "max_chars") ?? 50_000, 200_000)
+
+        if let bundleId = bundleIdForPid(pid), DENY_BUNDLE_IDS.contains(bundleId) {
+            throw RPCError.excluded(bundleId)
+        }
+
+        // Pick a root: either the element the caller named, or the whole app.
+        let root: AXUIElement
+        if let elementId = Params.stringOpt(params, "element_id") {
+            guard let el = cache.get(pid: pid, id: elementId) else {
+                throw RPCError.stale()
+            }
+            root = el
+        } else {
+            guard runningPids().contains(pid) else {
+                throw RPCError.appMissing(pid)
+            }
+            root = AXUIElementCreateApplication(pid_t(pid))
+        }
+
+        var pieces: [String] = []
+        var charCount: Int = 0
+        collectText(element: root, depth: 0, into: &pieces, charCount: &charCount, charBudget: maxChars)
+        var text = pieces.joined(separator: "\n")
+        if text.count > maxChars {
+            text = String(text.prefix(maxChars)) + "\n\n... (content truncated)"
+        }
+        return [
+            "text": text,
+            "char_count": text.count,
+        ]
+    }
+
+    // collectText tracks a running character count incremented O(1) per
+    // append, instead of re-joining the pieces array on every node visit
+    // (which made the walk O(n^2) in piece count — visible on documents
+    // with 200+ text fragments).
+    private static func collectText(element: AXUIElement, depth: Int, into pieces: inout [String], charCount: inout Int, charBudget: Int) {
+        if charCount >= charBudget { return }
+        if depth > 40 { return }
+
+        let role = stringAttr(element, kAXRoleAttribute as CFString) ?? ""
+
+        // AXValue on text elements is the text itself.
+        if role == "AXStaticText" || role == "AXTextField" || role == "AXTextArea" || role == "AXSearchField" {
+            if let v = stringAttr(element, kAXValueAttribute as CFString), !v.isEmpty {
+                pieces.append(v)
+                charCount += v.count + 1
+                return // text leaves don't recurse
+            }
+        }
+        // Headings get a markdown prefix.
+        if role == "AXHeading" {
+            if let v = bestLabel(element), !v.isEmpty {
+                let piece = "## " + v
+                pieces.append(piece)
+                charCount += piece.count + 1
+                return
+            }
+        }
+        // Static label (title) only worth emitting if no child text will cover it.
+        if let label = bestLabel(element), role == "AXButton" || role == "AXMenuItem" || role == "AXMenuBarItem" || role == "AXCheckBox" || role == "AXRadioButton" {
+            // These are interactive controls — capture their label as text too.
+            if !label.isEmpty {
+                let piece = "[\(label)]"
+                pieces.append(piece)
+                charCount += piece.count + 1
+            }
+        }
+
+        // Recurse.
+        for child in childrenOf(element) {
+            collectText(element: child, depth: depth + 1, into: &pieces, charCount: &charCount, charBudget: charBudget)
+        }
+    }
+
+    // MARK: - scroll
+
+    static func scroll(params: [String: Any], cache: ElementCache) throws -> [String: Any] {
+        try ensureTrusted()
+        let pid = try Params.int(params, "pid")
+        let elementId = Params.stringOpt(params, "element_id")
+
+        // If an element id is given, try AXShowMenu / AXScrollToVisible first.
+        if let eid = elementId, let el = cache.get(pid: pid, id: eid) {
+            let actions = copyActionNames(el)
+            if actions.contains("AXScrollToVisible") {
+                let err = AXUIElementPerformAction(el, "AXScrollToVisible" as CFString)
+                if err == .success {
+                    return ["ok": true, "method": "AXScrollToVisible"]
+                }
+            }
+        }
+
+        // Fallback: synthesize a scroll wheel event routed to the pid.
+        let dx = Params.intOpt(params, "dx") ?? 0
+        let dy = Params.intOpt(params, "dy") ?? 0
+        guard dx != 0 || dy != 0 else {
+            throw RPCError.invalid("either element_id or dx/dy required")
+        }
+
+        // macOS routes synthesized scroll events to whichever view is under
+        // the cursor, not to the focused view. When the caller passed
+        // explicit screen coords, warp the cursor first so the scroll lands
+        // on the intended target rather than wherever the user left the
+        // mouse. The schema in harness/tools/computer/scroll.go has always
+        // declared x/y for this; the implementation previously ignored them.
+        var warpedTo: [Int]? = nil
+        if let x = Params.intOpt(params, "x"), let y = Params.intOpt(params, "y") {
+            CGWarpMouseCursorPosition(CGPoint(x: x, y: y))
+            warpedTo = [x, y]
+        }
+
+        guard let ev = CGEvent(scrollWheelEvent2Source: nil, units: .pixel, wheelCount: 2, wheel1: Int32(dy), wheel2: Int32(dx), wheel3: 0) else {
+            throw RPCError(code: "action_failed", message: "could not create scroll event")
+        }
+        ev.postToPid(pid_t(pid))
+        var result: [String: Any] = ["ok": true, "method": "CGEvent"]
+        if let at = warpedTo { result["at"] = at }
+        return result
+    }
+
+    // MARK: - tree walk
+
+    private static func walk(element: AXUIElement, pid: Int, depth: Int, maxDepth: Int, counter: inout Int, truncated: inout Bool, cache: ElementCache) -> [String: Any]? {
+        if counter >= MAX_ELEMENTS {
+            truncated = true
+            return nil
+        }
+        if depth > maxDepth { return nil }
+
+        let role = stringAttr(element, kAXRoleAttribute as CFString) ?? "AXUnknown"
+        let label = bestLabel(element)
+        let value = stringAttr(element, kAXValueAttribute as CFString)
+        let enabled = boolAttr(element, kAXEnabledAttribute as CFString) ?? true
+        let bounds = frameAttr(element)
+
+        let children = childrenOf(element)
+        var childNodes: [[String: Any]] = []
+        for child in children {
+            if let node = walk(element: child, pid: pid, depth: depth + 1, maxDepth: maxDepth, counter: &counter, truncated: &truncated, cache: cache) {
+                childNodes.append(node)
+            }
+        }
+
+        // Decide whether to emit this element.
+        let isInteractable = INTERACTABLE_ROLES.contains(role)
+        let isContent = CONTENT_ROLES.contains(role) && (label != nil || (value?.isEmpty == false))
+        let isRoot = depth == 0
+        let hasChildren = !childNodes.isEmpty
+
+        // Flatten empty/unlabeled groups: if we wouldn't emit, return a synthetic
+        // node that just carries the children up. Caller handles.
+        let shouldEmit = isRoot || isContent || (isInteractable && (label != nil || role == "AXTextField" || role == "AXTextArea" || role == "AXSearchField" || hasChildren))
+
+        if !shouldEmit {
+            if childNodes.count == 1 { return childNodes[0] }
+            if childNodes.isEmpty { return nil }
+            return ["role": "AXGroup", "children": childNodes]
+        }
+
+        counter += 1
+        let id = cache.nextRefId(pid: pid)
+        cache.put(pid: pid, id: id, element: element)
+
+        var node: [String: Any] = [
+            "id": id,
+            "role": role,
+            "enabled": enabled,
+        ]
+        if let label = label { node["label"] = label }
+        if let value = value, !value.isEmpty, value != label { node["value"] = truncateForDisplay(value) }
+        if let b = bounds { node["bounds"] = b }
+        if !childNodes.isEmpty { node["children"] = childNodes }
+        return node
+    }
+
+    // MARK: - AX attribute helpers
+
+    private static func stringAttr(_ el: AXUIElement, _ attr: CFString) -> String? {
+        var raw: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(el, attr, &raw) == .success else { return nil }
+        if let s = raw as? String { return s }
+        return nil
+    }
+
+    private static func boolAttr(_ el: AXUIElement, _ attr: CFString) -> Bool? {
+        var raw: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(el, attr, &raw) == .success else { return nil }
+        if let b = raw as? Bool { return b }
+        return nil
+    }
+
+    private static func frameAttr(_ el: AXUIElement) -> [Int]? {
+        var posRaw: CFTypeRef?
+        var sizeRaw: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(el, kAXPositionAttribute as CFString, &posRaw) == .success,
+              AXUIElementCopyAttributeValue(el, kAXSizeAttribute as CFString, &sizeRaw) == .success,
+              let posVal = posRaw, let sizeVal = sizeRaw,
+              CFGetTypeID(posVal) == AXValueGetTypeID(),
+              CFGetTypeID(sizeVal) == AXValueGetTypeID() else {
+            return nil
+        }
+        var pos = CGPoint.zero
+        var size = CGSize.zero
+        AXValueGetValue(posVal as! AXValue, .cgPoint, &pos)
+        AXValueGetValue(sizeVal as! AXValue, .cgSize, &size)
+        return [Int(pos.x), Int(pos.y), Int(size.width), Int(size.height)]
+    }
+
+    private static func childrenOf(_ el: AXUIElement) -> [AXUIElement] {
+        var raw: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(el, kAXChildrenAttribute as CFString, &raw) == .success else { return [] }
+        return raw as? [AXUIElement] ?? []
+    }
+
+    private static func copyActionNames(_ el: AXUIElement) -> [String] {
+        var arr: CFArray?
+        guard AXUIElementCopyActionNames(el, &arr) == .success, let arr = arr else { return [] }
+        return (arr as NSArray).compactMap { $0 as? String }
+    }
+
+    private static func isSecureField(_ el: AXUIElement) -> Bool {
+        guard let role = stringAttr(el, kAXRoleAttribute as CFString) else { return false }
+        if role == "AXSecureTextField" { return true }
+        if let subrole = stringAttr(el, kAXSubroleAttribute as CFString), subrole == "AXSecureTextField" {
+            return true
+        }
+        return false
+    }
+
+    private static func bestLabel(_ el: AXUIElement) -> String? {
+        for attr in [kAXTitleAttribute, kAXDescriptionAttribute, kAXHelpAttribute] {
+            if let s = stringAttr(el, attr as CFString), !s.isEmpty {
+                return truncateForDisplay(s)
+            }
+        }
+        // AXStaticText often stores its text in AXValue.
+        if let role = stringAttr(el, kAXRoleAttribute as CFString), role == "AXStaticText" {
+            if let s = stringAttr(el, kAXValueAttribute as CFString), !s.isEmpty {
+                return truncateForDisplay(s)
+            }
+        }
+        return nil
+    }
+
+    private static func truncateForDisplay(_ s: String) -> String {
+        if s.count <= 200 { return s }
+        return String(s.prefix(200)) + "…"
+    }
+
+    private static func runningPids() -> Set<Int> {
+        Set(NSWorkspace.shared.runningApplications.map { Int($0.processIdentifier) })
+    }
+
+    private static func bundleIdForPid(_ pid: Int) -> String? {
+        NSWorkspace.shared.runningApplications.first { Int($0.processIdentifier) == pid }?.bundleIdentifier
+    }
+}

--- a/packages/computer-helper/Sources/ComputerHelper/AX.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/AX.swift
@@ -44,10 +44,8 @@ enum AX {
         let pid = try Params.int(params, "pid")
         let maxDepth = Params.intOpt(params, "max_depth") ?? MAX_DEPTH_DEFAULT
 
-        // Reject denied bundle ids early.
-        if let bundleId = bundleIdForPid(pid), DENY_BUNDLE_IDS.contains(bundleId) {
-            throw RPCError.excluded(bundleId)
-        }
+        // Gate: hard floor + user allow list. Throws before any AX call.
+        try ensurePidAllowed(pid)
 
         guard runningPids().contains(pid) else {
             throw RPCError.appMissing(pid)
@@ -73,6 +71,10 @@ enum AX {
     static func click(params: [String: Any], cache: ElementCache) throws -> [String: Any] {
         try ensureTrusted()
         let pid = try Params.int(params, "pid")
+
+        // Gate BEFORE the coords-fallback branch so the bypass we previously
+        // shipped (drive a denied app by passing x/y) is closed.
+        try ensurePidAllowed(pid)
 
         // Coords fallback: if the caller passes x/y (and no element_id), synthesize
         // a click at those screen coords. Used for canvas apps, games, and any
@@ -168,6 +170,9 @@ enum AX {
         let pid = try Params.int(params, "pid")
         let text = try Params.string(params, "text")
 
+        // Gate BEFORE the coords-fallback branch — same reason as click().
+        try ensurePidAllowed(pid)
+
         // Coords fallback: click at (x,y) to focus the input, then paste the
         // text via clipboard + cmd+V. Works on canvas apps and any element
         // the AX tree doesn't expose as a text input. Note: this touches the
@@ -245,9 +250,7 @@ enum AX {
         let pid = try Params.int(params, "pid")
         let maxChars = min(Params.intOpt(params, "max_chars") ?? 50_000, 200_000)
 
-        if let bundleId = bundleIdForPid(pid), DENY_BUNDLE_IDS.contains(bundleId) {
-            throw RPCError.excluded(bundleId)
-        }
+        try ensurePidAllowed(pid)
 
         // Pick a root: either the element the caller named, or the whole app.
         let root: AXUIElement
@@ -324,6 +327,7 @@ enum AX {
     static func scroll(params: [String: Any], cache: ElementCache) throws -> [String: Any] {
         try ensureTrusted()
         let pid = try Params.int(params, "pid")
+        try ensurePidAllowed(pid)
         let elementId = Params.stringOpt(params, "element_id")
 
         // If an element id is given, try AXShowMenu / AXScrollToVisible first.
@@ -496,9 +500,5 @@ enum AX {
 
     private static func runningPids() -> Set<Int> {
         Set(NSWorkspace.shared.runningApplications.map { Int($0.processIdentifier) })
-    }
-
-    private static func bundleIdForPid(_ pid: Int) -> String? {
-        NSWorkspace.shared.runningApplications.first { Int($0.processIdentifier) == pid }?.bundleIdentifier
     }
 }

--- a/packages/computer-helper/Sources/ComputerHelper/Apps.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/Apps.swift
@@ -11,14 +11,21 @@ enum Apps {
             guard app.activationPolicy == .regular else { continue }
             let pid = Int(app.processIdentifier)
             let bundleId = app.bundleIdentifier ?? ""
-            let excluded = DENY_BUNDLE_IDS.contains(bundleId)
+
+            // Drop apps the user has not authorized — the agent should not
+            // even see them in the listing. Hard-floor entries are dropped
+            // unconditionally. Suggest `agents computer status` so the user
+            // knows where to look if the list seems empty.
+            if HARD_FLOOR_DENY.contains(bundleId) { continue }
+            if !policy.allow.contains(bundleId) { continue }
+
             out.append([
                 "pid": pid,
                 "name": app.localizedName ?? "",
                 "bundle_id": bundleId,
                 "active": app.isActive,
                 "hidden": app.isHidden,
-                "excluded": excluded,
+                "excluded": false,
             ])
         }
         return ["apps": out]
@@ -33,6 +40,13 @@ enum Apps {
 
         if bundleId == nil && path == nil && name == nil {
             throw RPCError.invalid("pass one of: bundle_id, path, name")
+        }
+
+        // Reject path-traversal-shaped names. The candidatePaths interpolation
+        // below would otherwise let an attacker escape /Applications/ via
+        // "../../../usr/bin/whatever" or "../Library/Application Support/...".
+        if let n = name, n.contains("/") || n.contains("..") {
+            throw RPCError.invalid("name must not contain '/' or '..' — use bundle_id or path instead")
         }
 
         var url: URL?
@@ -74,6 +88,19 @@ enum Apps {
             throw RPCError.invalid("could not resolve app")
         }
 
+        // Resolve the bundle id of the target BEFORE launching, then gate
+        // against the hard floor + user allow list. Different from the other
+        // methods because the pid doesn't exist yet — we look up the bundle
+        // id from the resolved Info.plist instead.
+        let resolvedBundleId = resolveBundleId(forAppURL: appURL) ?? bundleId ?? ""
+        if HARD_FLOOR_DENY.contains(resolvedBundleId) {
+            throw RPCError.excluded(resolvedBundleId)
+        }
+        if !policy.allow.contains(resolvedBundleId) {
+            throw RPCError(code: "permission_denied",
+                           message: "\(resolvedBundleId.isEmpty ? "<unknown bundle>" : resolvedBundleId) not in allow list — add Computer(\(resolvedBundleId.isEmpty ? "<bundle-id>" : resolvedBundleId)) to a permissions group, then `agents computer reload`")
+        }
+
         // Synchronously launch and wait for the pid. NSWorkspace.openApplication
         // is async; use a semaphore so we return the pid to the caller.
         let semaphore = DispatchSemaphore(value: 0)
@@ -105,5 +132,16 @@ enum Apps {
             "name": app.localizedName ?? "",
             "bundle_id": app.bundleIdentifier ?? "",
         ]
+    }
+
+    // Resolve the bundle id of an .app at appURL without launching it. Reads
+    // CFBundleIdentifier from the Info.plist. Returns nil for non-.app URLs
+    // (raw executables) where the caller must rely on the explicit bundle_id
+    // input.
+    private static func resolveBundleId(forAppURL appURL: URL) -> String? {
+        if let bundle = Bundle(url: appURL), let bid = bundle.bundleIdentifier {
+            return bid
+        }
+        return nil
     }
 }

--- a/packages/computer-helper/Sources/ComputerHelper/Apps.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/Apps.swift
@@ -1,0 +1,109 @@
+import AppKit
+import Foundation
+
+enum Apps {
+    static func listApps() throws -> [String: Any] {
+        let running = NSWorkspace.shared.runningApplications
+        var out: [[String: Any]] = []
+        for app in running {
+            // Filter to GUI apps the agent can meaningfully drive. Background-only
+            // processes (activationPolicy == .prohibited) have no UI to describe.
+            guard app.activationPolicy == .regular else { continue }
+            let pid = Int(app.processIdentifier)
+            let bundleId = app.bundleIdentifier ?? ""
+            let excluded = DENY_BUNDLE_IDS.contains(bundleId)
+            out.append([
+                "pid": pid,
+                "name": app.localizedName ?? "",
+                "bundle_id": bundleId,
+                "active": app.isActive,
+                "hidden": app.isHidden,
+                "excluded": excluded,
+            ])
+        }
+        return ["apps": out]
+    }
+
+    // Launch an app by bundle_id, path (to .app bundle or executable), or
+    // human name ("Notepad", "Safari"). Returns {pid, name, bundle_id}.
+    static func launchApp(params: [String: Any]) throws -> [String: Any] {
+        let bundleId = Params.stringOpt(params, "bundle_id")
+        let path = Params.stringOpt(params, "path")
+        let name = Params.stringOpt(params, "name")
+
+        if bundleId == nil && path == nil && name == nil {
+            throw RPCError.invalid("pass one of: bundle_id, path, name")
+        }
+
+        var url: URL?
+        if let bid = bundleId {
+            url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bid)
+            if url == nil {
+                throw RPCError.invalid("bundle_id not found: \(bid)")
+            }
+        } else if let p = path {
+            url = URL(fileURLWithPath: p)
+        } else if let n = name {
+            // Resolve human name by scanning /Applications first, falling back
+            // to `NSWorkspace.urlForApplication(withName:)` which handles the
+            // common case where the app exists somewhere registered with
+            // LaunchServices.
+            let candidatePaths = [
+                "/Applications/\(n).app",
+                "/System/Applications/\(n).app",
+                "/Applications/Utilities/\(n).app",
+                "/System/Applications/Utilities/\(n).app",
+            ]
+            for cp in candidatePaths {
+                if FileManager.default.fileExists(atPath: cp) {
+                    url = URL(fileURLWithPath: cp)
+                    break
+                }
+            }
+            if url == nil {
+                if let resolved = NSWorkspace.shared.fullPath(forApplication: n) {
+                    url = URL(fileURLWithPath: resolved)
+                }
+            }
+            if url == nil {
+                throw RPCError.invalid("app not found by name: \(n)")
+            }
+        }
+
+        guard let appURL = url else {
+            throw RPCError.invalid("could not resolve app")
+        }
+
+        // Synchronously launch and wait for the pid. NSWorkspace.openApplication
+        // is async; use a semaphore so we return the pid to the caller.
+        let semaphore = DispatchSemaphore(value: 0)
+        var launchedApp: NSRunningApplication?
+        var launchErr: Error?
+
+        let config = NSWorkspace.OpenConfiguration()
+        config.activates = false // don't steal focus
+        NSWorkspace.shared.openApplication(at: appURL, configuration: config) { app, err in
+            launchedApp = app
+            launchErr = err
+            semaphore.signal()
+        }
+
+        // 10s timeout — large apps (Xcode) can take a while to cold-start.
+        let timedOut = semaphore.wait(timeout: .now() + 10) == .timedOut
+        if timedOut {
+            throw RPCError(code: "action_failed", message: "launch timed out after 10s for \(appURL.path)")
+        }
+        if let err = launchErr {
+            throw RPCError(code: "action_failed", message: "launch failed: \(err.localizedDescription)")
+        }
+        guard let app = launchedApp else {
+            throw RPCError(code: "action_failed", message: "launch returned no NSRunningApplication")
+        }
+
+        return [
+            "pid": Int(app.processIdentifier),
+            "name": app.localizedName ?? "",
+            "bundle_id": app.bundleIdentifier ?? "",
+        ]
+    }
+}

--- a/packages/computer-helper/Sources/ComputerHelper/CursorSprite.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/CursorSprite.swift
@@ -1,0 +1,133 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+// Translucent floating overlay marking where the helper is about to click /
+// is dragging. Purely visual — set ignoresMouseEvents=true so it never
+// intercepts a real click. Sits at .statusBar level so it floats above
+// normal app windows but below the system menu bar overlays.
+//
+// Threading: NSWindow operations must run on the main thread; the RPC
+// dispatcher calls Sprite.flash() / Sprite.move() / Sprite.hide() from
+// background threads, and these methods dispatch onto main themselves.
+//
+// All callsites are wrapped in `Sprite.enabled` so the helper can run
+// headless (env var or future RPC toggle) for CI and test runs.
+final class CursorSprite {
+    static let shared = CursorSprite()
+
+    // Disabled at startup if COMPUTER_HELPER_NO_SPRITE is set. Lets test
+    // harnesses (probe.py, e2e-test.sh) avoid spurious UI without code.
+    static var enabled: Bool {
+        ProcessInfo.processInfo.environment["COMPUTER_HELPER_NO_SPRITE"] == nil
+    }
+
+    private var window: NSWindow?
+    private var hideWorkItem: DispatchWorkItem?
+    private let size: CGFloat = 28
+
+    private init() {}
+
+    // Flash at a screen-coords point (Quartz top-left origin), hide after
+    // durationMs. Repeated calls reset the hide timer so a sequence of
+    // clicks looks continuous.
+    func flash(at point: CGPoint, durationMs: Int = 350) {
+        guard Self.enabled else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.showOrMove(to: point)
+            self?.scheduleHide(afterMs: durationMs)
+        }
+    }
+
+    // Show at the start of a drag, leave visible. Caller pairs with move()
+    // for each intermediate point and hide() at the end.
+    func showFor(drag at: CGPoint) {
+        guard Self.enabled else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.hideWorkItem?.cancel()
+            self?.showOrMove(to: at)
+        }
+    }
+
+    func move(to point: CGPoint) {
+        guard Self.enabled, window != nil else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.setOrigin(at: point)
+        }
+    }
+
+    func hide() {
+        guard Self.enabled else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.window?.orderOut(nil)
+            self?.hideWorkItem?.cancel()
+            self?.hideWorkItem = nil
+        }
+    }
+
+    // MARK: - private (main thread only)
+
+    private func showOrMove(to point: CGPoint) {
+        if window == nil { window = makeWindow() }
+        setOrigin(at: point)
+        window?.orderFrontRegardless()
+    }
+
+    private func scheduleHide(afterMs ms: Int) {
+        hideWorkItem?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            self?.window?.orderOut(nil)
+        }
+        hideWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(ms), execute: work)
+    }
+
+    // Convert Quartz screen coords (top-left origin, used by CGEvent /
+    // AXFrame) to AppKit screen coords (bottom-left origin, used by NSWindow).
+    // Anchored on the screen containing the point so multi-display setups
+    // don't flip Y onto the wrong monitor.
+    private func setOrigin(at point: CGPoint) {
+        guard let w = window else { return }
+        let screen = NSScreen.screens.first { NSPointInRect(NSPoint(x: point.x, y: point.y), $0.frame) }
+            ?? NSScreen.main
+        let screenHeight = screen?.frame.maxY ?? 0
+        let ns = NSPoint(x: point.x - size / 2, y: screenHeight - point.y - size / 2)
+        w.setFrameOrigin(ns)
+    }
+
+    private func makeWindow() -> NSWindow {
+        let rect = NSRect(x: 0, y: 0, width: size, height: size)
+        let win = NSWindow(contentRect: rect, styleMask: .borderless, backing: .buffered, defer: false)
+        win.level = .statusBar
+        win.isOpaque = false
+        win.backgroundColor = .clear
+        win.ignoresMouseEvents = true
+        win.hasShadow = false
+        win.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
+
+        let view = NSView(frame: rect)
+        view.wantsLayer = true
+        view.layer?.backgroundColor = NSColor.clear.cgColor
+
+        // Outer halo: low-alpha pulse circle.
+        let halo = CAShapeLayer()
+        halo.path = CGPath(ellipseIn: rect, transform: nil)
+        halo.fillColor = NSColor.systemBlue.withAlphaComponent(0.20).cgColor
+        halo.strokeColor = NSColor.systemBlue.withAlphaComponent(0.55).cgColor
+        halo.lineWidth = 1.5
+
+        // Inner dot: high-contrast brand color.
+        let inset: CGFloat = 9
+        let dotRect = rect.insetBy(dx: inset, dy: inset)
+        let dot = CAShapeLayer()
+        dot.path = CGPath(ellipseIn: dotRect, transform: nil)
+        dot.fillColor = NSColor.systemBlue.cgColor
+        dot.strokeColor = NSColor.white.withAlphaComponent(0.95).cgColor
+        dot.lineWidth = 1.5
+
+        view.layer?.addSublayer(halo)
+        view.layer?.addSublayer(dot)
+        win.contentView = view
+        return win
+    }
+}

--- a/packages/computer-helper/Sources/ComputerHelper/ElementCache.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/ElementCache.swift
@@ -1,0 +1,85 @@
+import ApplicationServices
+import AppKit
+import Foundation
+
+// Per-PID map of opaque handle -> AXUIElement. Each call to describe(pid)
+// rebuilds that PID's slice of the cache. Handles from a stale describe
+// return element_stale so the agent re-describes instead of acting blindly.
+//
+// The cache subscribes to NSWorkspace.didTerminateApplicationNotification
+// so that when an app exits its AXUIElement handles (which hold references
+// to deallocated CF objects) are released promptly. Without this the cache
+// would grow unbounded across long-running daemon lifetimes.
+final class ElementCache {
+    private let queue = DispatchQueue(label: "computer-helper.cache")
+    private var byPid: [Int: [String: AXUIElement]] = [:]
+    private var generationByPid: [Int: Int] = [:]
+    // Sequential ref counter per pid, reset at the start of each describe pass.
+    // Matches the browser snapshot tool's `@e1`, `@e2`, ... format so LLMs see
+    // the same ref shape across mac and web automation.
+    private var refCounterByPid: [Int: Int] = [:]
+    private var terminationObserver: NSObjectProtocol?
+
+    init() {
+        terminationObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didTerminateApplicationNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] note in
+            guard let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else { return }
+            self?.clearForPid(pid: Int(app.processIdentifier))
+        }
+    }
+
+    deinit {
+        if let token = terminationObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(token)
+        }
+    }
+
+    func beginDescribe(pid: Int) -> Int {
+        queue.sync {
+            byPid[pid] = [:]
+            refCounterByPid[pid] = 0
+            let next = (generationByPid[pid] ?? 0) + 1
+            generationByPid[pid] = next
+            return next
+        }
+    }
+
+    func nextRefId(pid: Int) -> String {
+        queue.sync {
+            let next = (refCounterByPid[pid] ?? 0) + 1
+            refCounterByPid[pid] = next
+            return "@e\(next)"
+        }
+    }
+
+    func put(pid: Int, id: String, element: AXUIElement) {
+        queue.sync {
+            byPid[pid, default: [:]][id] = element
+        }
+    }
+
+    func get(pid: Int, id: String) -> AXUIElement? {
+        queue.sync {
+            byPid[pid]?[id]
+        }
+    }
+
+    func clearForPid(pid: Int) {
+        queue.sync {
+            byPid.removeValue(forKey: pid)
+            refCounterByPid.removeValue(forKey: pid)
+            generationByPid.removeValue(forKey: pid)
+        }
+    }
+
+    func clearAll() {
+        queue.sync {
+            byPid.removeAll()
+            refCounterByPid.removeAll()
+            generationByPid.removeAll()
+        }
+    }
+}

--- a/packages/computer-helper/Sources/ComputerHelper/Events.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/Events.swift
@@ -13,12 +13,10 @@ enum Events {
         // Validate pid resolves to a running app. CGEventPostToPid silently
         // no-ops for dead pids and returns no error, so without this check
         // the agent gets {"ok": true} for a pid that does not exist.
-        guard let app = NSRunningApplication(processIdentifier: pid_t(pid)) else {
+        guard NSRunningApplication(processIdentifier: pid_t(pid)) != nil else {
             throw RPCError.appMissing(pid)
         }
-        if let bundleId = app.bundleIdentifier, DENY_BUNDLE_IDS.contains(bundleId) {
-            throw RPCError.excluded(bundleId)
-        }
+        try ensurePidAllowed(pid)
 
         let chord = try parseChord(keys)
 

--- a/packages/computer-helper/Sources/ComputerHelper/Events.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/Events.swift
@@ -1,0 +1,90 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+// Keyboard chord routing. Uses CGEventPostToPid so the target process
+// receives the events without the user's focused app losing focus.
+// "cmd+shift+s", "enter", "esc", "tab", "a", "z", "space".
+enum Events {
+    static func sendKey(params: [String: Any]) throws -> [String: Any] {
+        let pid = try Params.int(params, "pid")
+        let keys = try Params.string(params, "keys")
+
+        // Validate pid resolves to a running app. CGEventPostToPid silently
+        // no-ops for dead pids and returns no error, so without this check
+        // the agent gets {"ok": true} for a pid that does not exist.
+        guard let app = NSRunningApplication(processIdentifier: pid_t(pid)) else {
+            throw RPCError.appMissing(pid)
+        }
+        if let bundleId = app.bundleIdentifier, DENY_BUNDLE_IDS.contains(bundleId) {
+            throw RPCError.excluded(bundleId)
+        }
+
+        let chord = try parseChord(keys)
+
+        let down = CGEvent(keyboardEventSource: nil, virtualKey: chord.keyCode, keyDown: true)
+        let up = CGEvent(keyboardEventSource: nil, virtualKey: chord.keyCode, keyDown: false)
+        guard let down = down, let up = up else {
+            throw RPCError(code: "action_failed", message: "could not create keyboard event")
+        }
+        down.flags = chord.flags
+        up.flags = chord.flags
+
+        down.postToPid(pid_t(pid))
+        up.postToPid(pid_t(pid))
+        return ["ok": true]
+    }
+
+    private struct Chord {
+        let keyCode: CGKeyCode
+        let flags: CGEventFlags
+    }
+
+    private static func parseChord(_ s: String) throws -> Chord {
+        let parts = s.lowercased().split(separator: "+").map(String.init)
+        guard let last = parts.last else { throw RPCError.invalid("empty key chord") }
+
+        var flags: CGEventFlags = []
+        for mod in parts.dropLast() {
+            switch mod {
+            case "cmd", "meta", "super": flags.insert(.maskCommand)
+            case "shift": flags.insert(.maskShift)
+            case "alt", "opt", "option": flags.insert(.maskAlternate)
+            case "ctrl", "control": flags.insert(.maskControl)
+            case "fn": flags.insert(.maskSecondaryFn)
+            default: throw RPCError.invalid("unknown modifier: \(mod)")
+            }
+        }
+
+        guard let code = keyCodeFor(last) else {
+            throw RPCError.invalid("unknown key: \(last)")
+        }
+        return Chord(keyCode: code, flags: flags)
+    }
+
+    // A small, pragmatic subset of US-ANSI keycodes. Extended on demand.
+    // Reference: HIToolbox/Events.h kVK_* constants.
+    private static func keyCodeFor(_ key: String) -> CGKeyCode? {
+        switch key {
+        case "a": return 0x00; case "s": return 0x01; case "d": return 0x02; case "f": return 0x03
+        case "h": return 0x04; case "g": return 0x05; case "z": return 0x06; case "x": return 0x07
+        case "c": return 0x08; case "v": return 0x09; case "b": return 0x0B; case "q": return 0x0C
+        case "w": return 0x0D; case "e": return 0x0E; case "r": return 0x0F; case "y": return 0x10
+        case "t": return 0x11; case "1": return 0x12; case "2": return 0x13; case "3": return 0x14
+        case "4": return 0x15; case "6": return 0x16; case "5": return 0x17; case "9": return 0x19
+        case "7": return 0x1A; case "8": return 0x1C; case "0": return 0x1D; case "o": return 0x1F
+        case "u": return 0x20; case "i": return 0x22; case "p": return 0x23; case "l": return 0x25
+        case "j": return 0x26; case "k": return 0x28; case "n": return 0x2D; case "m": return 0x2E
+        case "return", "enter": return 0x24
+        case "tab": return 0x30
+        case "space": return 0x31
+        case "delete", "backspace": return 0x33
+        case "escape", "esc": return 0x35
+        case "left": return 0x7B
+        case "right": return 0x7C
+        case "down": return 0x7D
+        case "up": return 0x7E
+        default: return nil
+        }
+    }
+}

--- a/packages/computer-helper/Sources/ComputerHelper/Mouse.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/Mouse.swift
@@ -1,0 +1,248 @@
+import ApplicationServices
+import AppKit
+import CoreGraphics
+import Foundation
+
+// Mouse-based interactions: drag and right-click. Prefers native AX actions
+// when the element supports them; falls back to synthesized CGEvents posted
+// to the target pid.
+enum Mouse {
+
+    // MARK: - drag
+
+    static func drag(params: [String: Any], cache: ElementCache) throws -> [String: Any] {
+        try AX.ensureTrusted()
+        let pid = try Params.int(params, "pid")
+
+        // Reject denied bundle ids early.
+        if let bundleId = bundleIdForPid(pid), DENY_BUNDLE_IDS.contains(bundleId) {
+            throw RPCError.excluded(bundleId)
+        }
+
+        let button = Params.stringOpt(params, "button") ?? "left"
+        guard button == "left" || button == "right" else {
+            throw RPCError.invalid("button must be 'left' or 'right'")
+        }
+
+        let fromPt = try resolveSource(params: params, pid: pid, cache: cache)
+        let toPt = try resolveDest(params: params, pid: pid, cache: cache)
+
+        // Try native AX move if both endpoints came from elements and the
+        // source supports AXMove. Rarely honored but cheapest when it is.
+        if let srcId = Params.stringOpt(params, "element_id"),
+           let srcEl = cache.get(pid: pid, id: srcId) {
+            let actions = copyActionNames(srcEl)
+            if actions.contains("AXMove") {
+                let err = AXUIElementPerformAction(srcEl, "AXMove" as CFString)
+                if err == .success {
+                    return ["ok": true, "method": "AXMove"]
+                }
+            }
+        }
+
+        // Fallback: synthesize mouse down at source, a series of dragged events,
+        // and an up at the destination. Posted to pid so the user's focus is
+        // minimally disrupted.
+        let downType: CGEventType = button == "right" ? .rightMouseDown : .leftMouseDown
+        let dragType: CGEventType = button == "right" ? .rightMouseDragged : .leftMouseDragged
+        let upType: CGEventType = button == "right" ? .rightMouseUp : .leftMouseUp
+        let mouseButton: CGMouseButton = button == "right" ? .right : .left
+
+        guard let down = CGEvent(mouseEventSource: nil, mouseType: downType, mouseCursorPosition: fromPt, mouseButton: mouseButton) else {
+            throw RPCError(code: "action_failed", message: "could not create mouseDown event")
+        }
+        CursorSprite.shared.showFor(drag: fromPt)
+        down.postToPid(pid_t(pid))
+
+        // Many drag-and-drop implementations (NSView, drop targets, sortable
+        // lists) need a minimum hold after mouseDown before recognising the
+        // gesture as a drag rather than a click. Without this dwell the
+        // sequence is sometimes interpreted as a single click.
+        Thread.sleep(forTimeInterval: 0.05)
+
+        // Intermediate drag events help apps that watch the event stream.
+        let steps = 10
+        for i in 1...steps {
+            let t = Double(i) / Double(steps)
+            let x = fromPt.x + (toPt.x - fromPt.x) * CGFloat(t)
+            let y = fromPt.y + (toPt.y - fromPt.y) * CGFloat(t)
+            let pt = CGPoint(x: x, y: y)
+            CursorSprite.shared.move(to: pt)
+            if let drag = CGEvent(mouseEventSource: nil, mouseType: dragType, mouseCursorPosition: pt, mouseButton: mouseButton) {
+                drag.postToPid(pid_t(pid))
+            }
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+
+        guard let up = CGEvent(mouseEventSource: nil, mouseType: upType, mouseCursorPosition: toPt, mouseButton: mouseButton) else {
+            throw RPCError(code: "action_failed", message: "could not create mouseUp event")
+        }
+        up.postToPid(pid_t(pid))
+        // Brief lingering flash at destination, then hide.
+        CursorSprite.shared.flash(at: toPt)
+
+        return ["ok": true, "method": "CGEvent"]
+    }
+
+    // MARK: - right click
+
+    static func rightClick(params: [String: Any], cache: ElementCache) throws -> [String: Any] {
+        try AX.ensureTrusted()
+        let pid = try Params.int(params, "pid")
+
+        if let bundleId = bundleIdForPid(pid), DENY_BUNDLE_IDS.contains(bundleId) {
+            throw RPCError.excluded(bundleId)
+        }
+
+        // Coords fallback for canvas/games/inaccessible elements.
+        if Params.stringOpt(params, "element_id") == nil {
+            if let x = Params.intOpt(params, "x"), let y = Params.intOpt(params, "y") {
+                let pt = CGPoint(x: x, y: y)
+                CursorSprite.shared.flash(at: pt)
+                guard let down = CGEvent(mouseEventSource: nil, mouseType: .rightMouseDown, mouseCursorPosition: pt, mouseButton: .right),
+                      let up = CGEvent(mouseEventSource: nil, mouseType: .rightMouseUp, mouseCursorPosition: pt, mouseButton: .right) else {
+                    throw RPCError(code: "action_failed", message: "could not create right click event")
+                }
+                down.postToPid(pid_t(pid))
+                up.postToPid(pid_t(pid))
+                return ["ok": true, "method": "CGEvent", "at": [x, y]]
+            }
+            throw RPCError.invalid("pass either element_id or x,y")
+        }
+
+        let elementId = try Params.string(params, "element_id")
+
+        guard let el = cache.get(pid: pid, id: elementId) else {
+            throw RPCError.stale()
+        }
+
+        // AXShowMenu is the AX-native contextual menu trigger. When supported,
+        // it's focus-free. Fall back to a synthesized right-click at element center.
+        let actions = copyActionNames(el)
+        if actions.contains("AXShowMenu") {
+            if let center = elementCenter(el) {
+                CursorSprite.shared.flash(at: center)
+            }
+            let err = AXUIElementPerformAction(el, "AXShowMenu" as CFString)
+            if err == .success {
+                return ["ok": true, "method": "AXShowMenu"]
+            }
+        }
+
+        guard let center = elementCenter(el) else {
+            throw RPCError(code: "action_failed", message: "element has no frame")
+        }
+        CursorSprite.shared.flash(at: center)
+
+        guard let down = CGEvent(mouseEventSource: nil, mouseType: .rightMouseDown, mouseCursorPosition: center, mouseButton: .right),
+              let up = CGEvent(mouseEventSource: nil, mouseType: .rightMouseUp, mouseCursorPosition: center, mouseButton: .right) else {
+            throw RPCError(code: "action_failed", message: "could not create right click event")
+        }
+        down.postToPid(pid_t(pid))
+        up.postToPid(pid_t(pid))
+        return ["ok": true, "method": "CGEvent"]
+    }
+
+    // MARK: - focus window
+
+    // After NSRunningApplication.activate returns true the window-raise is
+    // still propagating through WindowServer. Callers that immediately
+    // screenshot or describe will race the raise and read the previous
+    // foreground app. Poll frontmostApplication for up to 200 ms so the
+    // helper only reports ok once the app is actually frontmost.
+    private static let focusPollTotalMs: Int = 200
+    private static let focusPollIntervalMs: Int = 20
+
+    static func focusWindow(params: [String: Any]) throws -> [String: Any] {
+        let pid = try Params.int(params, "pid")
+
+        if let bundleId = bundleIdForPid(pid), DENY_BUNDLE_IDS.contains(bundleId) {
+            throw RPCError.excluded(bundleId)
+        }
+
+        guard let app = NSRunningApplication(processIdentifier: pid_t(pid)) else {
+            throw RPCError.appMissing(pid)
+        }
+
+        let wasHidden = app.isHidden
+        if wasHidden { app.unhide() }
+
+        let ok = app.activate(options: [.activateIgnoringOtherApps])
+        if !ok {
+            throw RPCError(code: "action_failed", message: "activate returned false")
+        }
+
+        let ticks = focusPollTotalMs / focusPollIntervalMs
+        var elapsedMs = 0
+        for _ in 0..<ticks {
+            if NSWorkspace.shared.frontmostApplication?.processIdentifier == pid_t(pid) {
+                return ["ok": true, "was_minimized": wasHidden, "focus_elapsed_ms": elapsedMs]
+            }
+            Thread.sleep(forTimeInterval: Double(focusPollIntervalMs) / 1000.0)
+            elapsedMs += focusPollIntervalMs
+        }
+        throw RPCError(code: "focus_timeout", message: "app pid=\(pid) did not become frontmost within \(focusPollTotalMs)ms (modal-blocked or invisible?)")
+    }
+
+    // MARK: - helpers
+
+    private static func resolveSource(params: [String: Any], pid: Int, cache: ElementCache) throws -> CGPoint {
+        if let eid = Params.stringOpt(params, "element_id") {
+            guard let el = cache.get(pid: pid, id: eid) else { throw RPCError.stale() }
+            guard let c = elementCenter(el) else { throw RPCError(code: "action_failed", message: "source element has no frame") }
+            return c
+        }
+        if let from = params["from"] as? [Any], from.count == 2,
+           let x = numeric(from[0]), let y = numeric(from[1]) {
+            return CGPoint(x: x, y: y)
+        }
+        throw RPCError.invalid("pass either element_id or from=[x, y]")
+    }
+
+    private static func resolveDest(params: [String: Any], pid: Int, cache: ElementCache) throws -> CGPoint {
+        if let eid = Params.stringOpt(params, "to_element_id") {
+            guard let el = cache.get(pid: pid, id: eid) else { throw RPCError.stale() }
+            guard let c = elementCenter(el) else { throw RPCError(code: "action_failed", message: "destination element has no frame") }
+            return c
+        }
+        if let to = params["to"] as? [Any], to.count == 2,
+           let x = numeric(to[0]), let y = numeric(to[1]) {
+            return CGPoint(x: x, y: y)
+        }
+        throw RPCError.invalid("pass either to_element_id or to=[x, y]")
+    }
+
+    static func elementCenter(_ el: AXUIElement) -> CGPoint? {
+        var posRaw: CFTypeRef?
+        var sizeRaw: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(el, kAXPositionAttribute as CFString, &posRaw) == .success,
+              AXUIElementCopyAttributeValue(el, kAXSizeAttribute as CFString, &sizeRaw) == .success,
+              let posVal = posRaw, let sizeVal = sizeRaw,
+              CFGetTypeID(posVal) == AXValueGetTypeID(),
+              CFGetTypeID(sizeVal) == AXValueGetTypeID() else {
+            return nil
+        }
+        var pos = CGPoint.zero
+        var size = CGSize.zero
+        AXValueGetValue(posVal as! AXValue, .cgPoint, &pos)
+        AXValueGetValue(sizeVal as! AXValue, .cgSize, &size)
+        return CGPoint(x: pos.x + size.width / 2, y: pos.y + size.height / 2)
+    }
+
+    private static func copyActionNames(_ el: AXUIElement) -> [String] {
+        var arr: CFArray?
+        guard AXUIElementCopyActionNames(el, &arr) == .success, let arr = arr else { return [] }
+        return (arr as NSArray).compactMap { $0 as? String }
+    }
+
+    private static func bundleIdForPid(_ pid: Int) -> String? {
+        NSWorkspace.shared.runningApplications.first { Int($0.processIdentifier) == pid }?.bundleIdentifier
+    }
+
+    private static func numeric(_ v: Any) -> CGFloat? {
+        if let d = v as? Double { return CGFloat(d) }
+        if let i = v as? Int { return CGFloat(i) }
+        if let s = v as? String, let d = Double(s) { return CGFloat(d) }
+        return nil
+    }
+}

--- a/packages/computer-helper/Sources/ComputerHelper/Mouse.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/Mouse.swift
@@ -14,10 +14,9 @@ enum Mouse {
         try AX.ensureTrusted()
         let pid = try Params.int(params, "pid")
 
-        // Reject denied bundle ids early.
-        if let bundleId = bundleIdForPid(pid), DENY_BUNDLE_IDS.contains(bundleId) {
-            throw RPCError.excluded(bundleId)
-        }
+        // Hard floor + user allow list. Throws permission_denied / target_excluded
+        // before any CGEvent is synthesized.
+        try ensurePidAllowed(pid)
 
         let button = Params.stringOpt(params, "button") ?? "left"
         guard button == "left" || button == "right" else {
@@ -90,9 +89,8 @@ enum Mouse {
         try AX.ensureTrusted()
         let pid = try Params.int(params, "pid")
 
-        if let bundleId = bundleIdForPid(pid), DENY_BUNDLE_IDS.contains(bundleId) {
-            throw RPCError.excluded(bundleId)
-        }
+        // Gate BEFORE the coords-fallback branch to close the bypass path.
+        try ensurePidAllowed(pid)
 
         // Coords fallback for canvas/games/inaccessible elements.
         if Params.stringOpt(params, "element_id") == nil {
@@ -156,9 +154,7 @@ enum Mouse {
     static func focusWindow(params: [String: Any]) throws -> [String: Any] {
         let pid = try Params.int(params, "pid")
 
-        if let bundleId = bundleIdForPid(pid), DENY_BUNDLE_IDS.contains(bundleId) {
-            throw RPCError.excluded(bundleId)
-        }
+        try ensurePidAllowed(pid)
 
         guard let app = NSRunningApplication(processIdentifier: pid_t(pid)) else {
             throw RPCError.appMissing(pid)
@@ -233,10 +229,6 @@ enum Mouse {
         var arr: CFArray?
         guard AXUIElementCopyActionNames(el, &arr) == .success, let arr = arr else { return [] }
         return (arr as NSArray).compactMap { $0 as? String }
-    }
-
-    private static func bundleIdForPid(_ pid: Int) -> String? {
-        NSWorkspace.shared.runningApplications.first { Int($0.processIdentifier) == pid }?.bundleIdentifier
     }
 
     private static func numeric(_ v: Any) -> CGFloat? {

--- a/packages/computer-helper/Sources/ComputerHelper/Notify.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/Notify.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+// notify() is intentionally a pass-through at the helper level: the helper
+// returns a structured payload and the Rush app (computer-manager.service.js)
+// intercepts it to post through the app's own notification store. This keeps
+// the helper free of macOS notification entitlement requirements and makes
+// the notification clickable through the Rush session UI.
+//
+// If the helper is invoked standalone (no app intercept, e.g. via tests),
+// the return value still describes what a notification would have said so
+// callers can log it.
+enum Notify {
+    static func post(params: [String: Any]) throws -> [String: Any] {
+        let message = try Params.string(params, "message")
+        let pid = Params.intOpt(params, "pid") ?? 0
+
+        var result: [String: Any] = [
+            "notified": true,
+            "message": message,
+        ]
+        if pid > 0 {
+            result["pid"] = pid
+        }
+        return result
+    }
+}

--- a/packages/computer-helper/Sources/ComputerHelper/RPC.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/RPC.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 struct RPCError: Error {
@@ -27,17 +28,43 @@ struct RPCError: Error {
     }
 }
 
-// Bundle IDs the helper refuses to operate on. Prevents agent self-pwn and
-// avoids automating sensitive system UIs.
-let DENY_BUNDLE_IDS: Set<String> = [
-    "com.apple.Terminal",
-    "com.googlecode.iterm2",
-    "ai.getrush.app",
-    "com.apple.systempreferences",
-    "com.apple.keychainaccess",
+// HARD floor — the helper refuses to operate on these bundle ids regardless
+// of what the user lists in `~/.agents/permissions/groups/`. These are TCC
+// escalation paths: driving them would let an attacker silently re-grant
+// other TCC permissions (Accessibility, Screen Recording) without the
+// user's knowledge. Everything else is user-controlled via Computer(...)
+// permission patterns — Terminal, iTerm, Keychain, the Rush app, etc. are
+// all USER-opinion now, not our opinion.
+let HARD_FLOOR_DENY: Set<String> = [
     "com.apple.tccd",
     "com.apple.SecurityAgent",
+    "com.apple.systempreferences",
 ]
+
+// Look up the bundle id for a pid, or "" if we can't see the process. Used
+// by both the hard-floor check and the allow-list check.
+func bundleIdForPid(_ pid: Int) -> String {
+    NSWorkspace.shared.runningApplications.first { Int($0.processIdentifier) == pid }?.bundleIdentifier ?? ""
+}
+
+// Centralized gate called by every action method that targets a pid. Two
+// stages:
+//   1. HARD_FLOOR_DENY — overrides any user allow rule, returns
+//      target_excluded so the caller knows this is a fixed policy.
+//   2. policy.allow — must contain the bundle id, else permission_denied.
+//
+// Fail-safe default: when the policy file is missing or unparseable the
+// helper boots with an empty allow set, so this check rejects everything.
+func ensurePidAllowed(_ pid: Int) throws {
+    let bundleId = bundleIdForPid(pid)
+    if HARD_FLOOR_DENY.contains(bundleId) {
+        throw RPCError.excluded(bundleId)
+    }
+    if !policy.allow.contains(bundleId) {
+        throw RPCError(code: "permission_denied",
+                       message: "pid \(pid) (\(bundleId.isEmpty ? "unknown bundle" : bundleId)) not in allow list — add Computer(\(bundleId.isEmpty ? "<bundle-id>" : bundleId)) to a permissions group, then `agents computer reload`")
+    }
+}
 
 final class Dispatcher {
     let cache: ElementCache

--- a/packages/computer-helper/Sources/ComputerHelper/RPC.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/RPC.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+struct RPCError: Error {
+    let code: String
+    let message: String
+
+    static func notFound(_ what: String) -> RPCError {
+        RPCError(code: "element_not_found", message: what)
+    }
+    static func stale() -> RPCError {
+        RPCError(code: "element_stale", message: "element handle expired, re-describe")
+    }
+    static func unsupported(_ action: String) -> RPCError {
+        RPCError(code: "action_unsupported", message: action)
+    }
+    static func denied(_ reason: String) -> RPCError {
+        RPCError(code: "permission_denied", message: reason)
+    }
+    static func excluded(_ bundleId: String) -> RPCError {
+        RPCError(code: "target_excluded", message: bundleId)
+    }
+    static func appMissing(_ pid: Int) -> RPCError {
+        RPCError(code: "app_not_found", message: "pid \(pid)")
+    }
+    static func invalid(_ msg: String) -> RPCError {
+        RPCError(code: "invalid_params", message: msg)
+    }
+}
+
+// Bundle IDs the helper refuses to operate on. Prevents agent self-pwn and
+// avoids automating sensitive system UIs.
+let DENY_BUNDLE_IDS: Set<String> = [
+    "com.apple.Terminal",
+    "com.googlecode.iterm2",
+    "ai.getrush.app",
+    "com.apple.systempreferences",
+    "com.apple.keychainaccess",
+    "com.apple.tccd",
+    "com.apple.SecurityAgent",
+]
+
+final class Dispatcher {
+    let cache: ElementCache
+
+    init(cache: ElementCache) {
+        self.cache = cache
+    }
+
+    func dispatch(method: String, params: [String: Any]) throws -> [String: Any] {
+        switch method {
+        case "ping":
+            return ["pong": true]
+        case "trust_status":
+            // Diagnostic: report AX trust + identity without throwing. Useful
+            // when TCC grants look right in the UI but AX calls still 403.
+            let pid = Int(ProcessInfo.processInfo.processIdentifier)
+            let path = Bundle.main.executablePath ?? CommandLine.arguments.first ?? ""
+            return [
+                "trusted": AX.isTrusted(),
+                "pid": pid,
+                "path": path,
+            ]
+        case "list_apps":
+            return try Apps.listApps()
+        case "describe":
+            return try AX.describe(params: params, cache: cache)
+        case "click":
+            return try AX.click(params: params, cache: cache)
+        case "type":
+            return try AX.setValue(params: params, cache: cache)
+        case "key":
+            return try Events.sendKey(params: params)
+        case "scroll":
+            return try AX.scroll(params: params, cache: cache)
+        case "screenshot":
+            return try Screenshot.capture(params: params)
+        case "wait":
+            return try Wait.run(params: params, cache: cache)
+        case "drag":
+            return try Mouse.drag(params: params, cache: cache)
+        case "focus_window":
+            return try Mouse.focusWindow(params: params)
+        case "right_click":
+            return try Mouse.rightClick(params: params, cache: cache)
+        case "get_text":
+            return try AX.getText(params: params, cache: cache)
+        case "notify":
+            return try Notify.post(params: params)
+        case "launch_app":
+            return try Apps.launchApp(params: params)
+        default:
+            throw RPCError(code: "method_not_found", message: method)
+        }
+    }
+}
+
+// Small helpers for poking at untyped RPC param dicts.
+enum Params {
+    static func int(_ p: [String: Any], _ key: String) throws -> Int {
+        if let v = p[key] as? Int { return v }
+        if let v = p[key] as? Double { return Int(v) }
+        if let v = p[key] as? String, let i = Int(v) { return i }
+        throw RPCError.invalid("missing int param: \(key)")
+    }
+    static func intOpt(_ p: [String: Any], _ key: String) -> Int? {
+        if let v = p[key] as? Int { return v }
+        if let v = p[key] as? Double { return Int(v) }
+        return nil
+    }
+    static func string(_ p: [String: Any], _ key: String) throws -> String {
+        if let v = p[key] as? String { return v }
+        throw RPCError.invalid("missing string param: \(key)")
+    }
+    static func stringOpt(_ p: [String: Any], _ key: String) -> String? {
+        return p[key] as? String
+    }
+    static func bool(_ p: [String: Any], _ key: String, default def: Bool = false) -> Bool {
+        if let v = p[key] as? Bool { return v }
+        return def
+    }
+}

--- a/packages/computer-helper/Sources/ComputerHelper/Screenshot.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/Screenshot.swift
@@ -19,6 +19,9 @@ enum Screenshot {
         let pid = try Params.int(params, "pid")
         let quality = max(1, min(100, Params.intOpt(params, "quality") ?? 85))
 
+        // Hard floor + user allow list. Throws before SCK initializes.
+        try ensurePidAllowed(pid)
+
         // SCK is async; bridge to the sync RPC dispatcher with a semaphore.
         // 5s is well above the 100-300ms typical SCK frame grab; if we hit
         // it something is wrong (permission, hung daemon, denied window).

--- a/packages/computer-helper/Sources/ComputerHelper/Screenshot.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/Screenshot.swift
@@ -1,0 +1,111 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import ScreenCaptureKit
+import UniformTypeIdentifiers
+
+// Per-window screenshot via ScreenCaptureKit. CGWindowListCreateImage was
+// obsoleted in macOS 15 (Sequoia) and removed from the public SDK; the legacy
+// shim still answers at runtime today but Apple has stopped guaranteeing it.
+// SCK is the supported replacement, captures across Spaces, and accepts an
+// SCWindow target by windowID without raising the window (focus-safe).
+//
+// Window picking: an app's first CGWindowList entry is non-deterministic and
+// for canvas/video apps (CapCut, OBS, broadcast tools) is often a tiny
+// transparent overlay rather than the editor surface. We pick the largest
+// onscreen layer-0 alpha>0 window owned by the pid instead.
+enum Screenshot {
+    static func capture(params: [String: Any]) throws -> [String: Any] {
+        let pid = try Params.int(params, "pid")
+        let quality = max(1, min(100, Params.intOpt(params, "quality") ?? 85))
+
+        // SCK is async; bridge to the sync RPC dispatcher with a semaphore.
+        // 5s is well above the 100-300ms typical SCK frame grab; if we hit
+        // it something is wrong (permission, hung daemon, denied window).
+        let semaphore = DispatchSemaphore(value: 0)
+        var captured: Result<[String: Any], Error>!
+
+        Task {
+            do {
+                captured = .success(try await captureAsync(pid: pid, quality: quality))
+            } catch {
+                captured = .failure(error)
+            }
+            semaphore.signal()
+        }
+
+        let timedOut = semaphore.wait(timeout: .now() + 5.0) == .timedOut
+        if timedOut {
+            throw RPCError(code: "action_failed", message: "ScreenCaptureKit timed out after 5s (denied Screen Recording permission?)")
+        }
+        return try captured.get()
+    }
+
+    private static func captureAsync(pid: Int, quality: Int) async throws -> [String: Any] {
+        // SCShareableContent.current enumerates everything the helper is
+        // allowed to capture. Filters by pid and picks the dominant editor
+        // window (largest area, layer 0, on-screen). Returns app_not_found
+        // when no candidate exists — same contract as the old CGWindowList
+        // implementation.
+        let content: SCShareableContent
+        do {
+            // onScreenWindowsOnly=false matches CapCut and other apps whose
+            // editor window is on a different Space (or otherwise filtered
+            // out by the on-screen check). We then prefer the largest
+            // layer-0 window, which is empirically the editor.
+            content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+        } catch {
+            throw RPCError(code: "action_failed", message: "SCShareableContent failed: \(error.localizedDescription) (grant Screen Recording to ComputerHelper)")
+        }
+
+        let candidates = content.windows.filter {
+            $0.owningApplication?.processID == pid_t(pid) && $0.windowLayer == 0
+        }
+        guard !candidates.isEmpty else {
+            // Fall back to any-layer windows if no layer-0 candidate exists.
+            // Some apps put real UI on non-zero layers (rare but seen on
+            // older Qt builds). Better to capture something than fail blind.
+            let anyLayer = content.windows.filter { $0.owningApplication?.processID == pid_t(pid) }
+            guard let largest = anyLayer.max(by: { area($0.frame) < area($1.frame) }) else {
+                throw RPCError(code: "action_failed", message: "no visible windows for pid \(pid)")
+            }
+            return try await snap(window: largest, quality: quality)
+        }
+        let largest = candidates.max(by: { area($0.frame) < area($1.frame) })!
+        return try await snap(window: largest, quality: quality)
+    }
+
+    private static func area(_ r: CGRect) -> CGFloat { r.width * r.height }
+
+    private static func snap(window: SCWindow, quality: Int) async throws -> [String: Any] {
+        let filter = SCContentFilter(desktopIndependentWindow: window)
+
+        let config = SCStreamConfiguration()
+        // sourceRect=CGRect.null tells SCK to use the window's natural bounds.
+        // pixelFormat=BGRA is the only format we can reliably ferry through
+        // CGImage->NSBitmapImageRep->JPEG without an extra Metal hop.
+        config.width = max(Int(window.frame.width), 1)
+        config.height = max(Int(window.frame.height), 1)
+        config.pixelFormat = kCVPixelFormatType_32BGRA
+        config.showsCursor = false
+        config.capturesAudio = false
+
+        let cgImage: CGImage
+        do {
+            cgImage = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
+        } catch {
+            throw RPCError(code: "action_failed", message: "SCK captureImage failed: \(error.localizedDescription)")
+        }
+
+        let rep = NSBitmapImageRep(cgImage: cgImage)
+        guard let data = rep.representation(using: .jpeg, properties: [.compressionFactor: Double(quality) / 100.0]) else {
+            throw RPCError(code: "action_failed", message: "JPEG encode failed")
+        }
+        return [
+            "image_data": data.base64EncodedString(),
+            "mime_type": "image/jpeg",
+            "width": cgImage.width,
+            "height": cgImage.height,
+        ]
+    }
+}

--- a/packages/computer-helper/Sources/ComputerHelper/Wait.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/Wait.swift
@@ -1,0 +1,201 @@
+import ApplicationServices
+import Foundation
+
+// Wait primitives. Three modes:
+//   1. Unconditional sleep — duration_ms in [50, 30000].
+//   2. Cached-element polling — pid + element_id + until. Cheap but only
+//      works for elements that already appeared in a prior describe call.
+//   3. Locator polling — pid + locator (role and/or label) + until="exists".
+//      Re-walks the app's live AX tree on every tick so the caller can
+//      wait for newly-appearing UI (an alert, a confirmation button) that
+//      did not exist at the last describe.
+//
+// Removes the "element_stale churn" where agents waste turns re-describing
+// because the UI hasn't settled after an action.
+enum Wait {
+    private static let pollIntervalMs: Int = 100
+    private static let minDurationMs: Int = 50
+    private static let maxDurationMs: Int = 30000
+    private static let defaultTimeoutMs: Int = 5000
+    private static let locatorMaxDepth: Int = 40
+
+    static func run(params: [String: Any], cache: ElementCache) throws -> [String: Any] {
+        if let durationMs = Params.intOpt(params, "duration_ms") {
+            guard durationMs >= minDurationMs && durationMs <= maxDurationMs else {
+                throw RPCError.invalid("duration_ms must be in [\(minDurationMs), \(maxDurationMs)]")
+            }
+            Thread.sleep(forTimeInterval: Double(durationMs) / 1000.0)
+            return ["ok": true, "waited_ms": durationMs, "satisfied": true]
+        }
+
+        let pid = Params.intOpt(params, "pid")
+        let until = Params.stringOpt(params, "until") ?? "exists"
+        guard ["exists", "enabled", "disappears"].contains(until) else {
+            throw RPCError.invalid("until must be 'exists', 'enabled', or 'disappears'")
+        }
+        guard let pid = pid else {
+            throw RPCError.invalid("pass either duration_ms, or pid + (element_id or locator) + until")
+        }
+
+        let elementId = Params.stringOpt(params, "element_id")
+        let locator = params["locator"] as? [String: Any]
+        guard elementId != nil || locator != nil else {
+            throw RPCError.invalid("pass either element_id or locator")
+        }
+        if locator != nil && until == "disappears" {
+            // disappears requires a stable identity to track; the live re-walk
+            // path matches anything that fits the locator, so a different
+            // element with the same role/label would mask the disappearance.
+            throw RPCError.invalid("locator mode supports until='exists' or 'enabled' only")
+        }
+
+        let timeoutMs = Params.intOpt(params, "timeout_ms") ?? defaultTimeoutMs
+        let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1000.0)
+        let start = Date()
+        var satisfied = false
+        var foundId: String? = nil
+
+        while Date() < deadline {
+            if let locator = locator {
+                if let id = matchLocator(pid: pid, locator: locator, until: until, cache: cache) {
+                    foundId = id
+                    satisfied = true
+                    break
+                }
+            } else if let eid = elementId {
+                if isSatisfied(pid: pid, elementId: eid, until: until, cache: cache) {
+                    satisfied = true
+                    break
+                }
+            }
+            Thread.sleep(forTimeInterval: Double(pollIntervalMs) / 1000.0)
+        }
+
+        let elapsed = Int(Date().timeIntervalSince(start) * 1000)
+        var result: [String: Any] = ["ok": true, "waited_ms": elapsed, "satisfied": satisfied]
+        if let id = foundId { result["element_id"] = id }
+        return result
+    }
+
+    private static func isSatisfied(pid: Int, elementId: String, until: String, cache: ElementCache) -> Bool {
+        let el = cache.get(pid: pid, id: elementId)
+        switch until {
+        case "disappears":
+            guard let el = el else { return true }
+            // Probe an attribute; if it fails, the element is gone.
+            var raw: CFTypeRef?
+            let err = AXUIElementCopyAttributeValue(el, kAXRoleAttribute as CFString, &raw)
+            return err != .success
+        case "exists":
+            guard let el = el else { return false }
+            var raw: CFTypeRef?
+            return AXUIElementCopyAttributeValue(el, kAXRoleAttribute as CFString, &raw) == .success
+        case "enabled":
+            guard let el = el else { return false }
+            var raw: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(el, kAXEnabledAttribute as CFString, &raw) == .success else {
+                return false
+            }
+            return (raw as? Bool) ?? false
+        default:
+            return false
+        }
+    }
+
+    // Walks the app's live AX tree from the application root looking for an
+    // element that matches the locator. On first match, caches the element
+    // with a fresh ref and returns it. Called every poll tick — the cost is
+    // bounded by locatorMaxDepth and stops on first match.
+    //
+    // Locator shape: { role?: String, label?: String, identifier?: String }
+    // At least one of role/label/identifier must be non-empty.
+    private static func matchLocator(pid: Int, locator: [String: Any], until: String, cache: ElementCache) -> String? {
+        let wantRole = (locator["role"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        let wantLabel = (locator["label"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        let wantIdentifier = (locator["identifier"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        guard wantRole != nil || wantLabel != nil || wantIdentifier != nil else { return nil }
+
+        let root = AXUIElementCreateApplication(pid_t(pid))
+        return search(element: root, depth: 0,
+                       wantRole: wantRole, wantLabel: wantLabel, wantIdentifier: wantIdentifier,
+                       until: until, pid: pid, cache: cache)
+    }
+
+    private static func search(element: AXUIElement, depth: Int,
+                                wantRole: String?, wantLabel: String?, wantIdentifier: String?,
+                                until: String, pid: Int, cache: ElementCache) -> String? {
+        if depth > locatorMaxDepth { return nil }
+
+        if matches(element: element, wantRole: wantRole, wantLabel: wantLabel, wantIdentifier: wantIdentifier) {
+            if until == "enabled" {
+                var raw: CFTypeRef?
+                guard AXUIElementCopyAttributeValue(element, kAXEnabledAttribute as CFString, &raw) == .success,
+                      (raw as? Bool) == true else {
+                    // Found but not yet enabled — keep searching siblings then return.
+                    return descend(element: element, depth: depth,
+                                    wantRole: wantRole, wantLabel: wantLabel, wantIdentifier: wantIdentifier,
+                                    until: until, pid: pid, cache: cache)
+                }
+            }
+            let id = cache.nextRefId(pid: pid)
+            cache.put(pid: pid, id: id, element: element)
+            return id
+        }
+
+        return descend(element: element, depth: depth,
+                        wantRole: wantRole, wantLabel: wantLabel, wantIdentifier: wantIdentifier,
+                        until: until, pid: pid, cache: cache)
+    }
+
+    private static func descend(element: AXUIElement, depth: Int,
+                                 wantRole: String?, wantLabel: String?, wantIdentifier: String?,
+                                 until: String, pid: Int, cache: ElementCache) -> String? {
+        var raw: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &raw) == .success,
+              let kids = raw as? [AXUIElement] else { return nil }
+        for child in kids {
+            if let found = search(element: child, depth: depth + 1,
+                                    wantRole: wantRole, wantLabel: wantLabel, wantIdentifier: wantIdentifier,
+                                    until: until, pid: pid, cache: cache) {
+                return found
+            }
+        }
+        return nil
+    }
+
+    private static func matches(element: AXUIElement, wantRole: String?, wantLabel: String?, wantIdentifier: String?) -> Bool {
+        if let want = wantRole {
+            var raw: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &raw) == .success,
+                  let role = raw as? String, role == want else {
+                return false
+            }
+        }
+        if let want = wantIdentifier {
+            var raw: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(element, kAXIdentifierAttribute as CFString, &raw) == .success,
+                  let id = raw as? String, id == want else {
+                return false
+            }
+        }
+        if let want = wantLabel {
+            // Try title, description, label-value, then static value.
+            let candidates: [CFString] = [
+                kAXTitleAttribute as CFString,
+                kAXDescriptionAttribute as CFString,
+                kAXValueAttribute as CFString,
+            ]
+            var hit = false
+            for attr in candidates {
+                var raw: CFTypeRef?
+                if AXUIElementCopyAttributeValue(element, attr, &raw) == .success,
+                   let s = raw as? String, s == want {
+                    hit = true
+                    break
+                }
+            }
+            if !hit { return false }
+        }
+        return true
+    }
+}

--- a/packages/computer-helper/Sources/ComputerHelper/Wait.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/Wait.swift
@@ -37,6 +37,12 @@ enum Wait {
             throw RPCError.invalid("pass either duration_ms, or pid + (element_id or locator) + until")
         }
 
+        // Hard floor + user allow list. Goes here (after the duration_ms
+        // early-return that doesn't need a pid) but BEFORE any element_id /
+        // locator branch — the locator branch walks the live AX tree, which
+        // is exactly the bypass we need to close.
+        try ensurePidAllowed(pid)
+
         let elementId = Params.stringOpt(params, "element_id")
         let locator = params["locator"] as? [String: Any]
         guard elementId != nil || locator != nil else {

--- a/packages/computer-helper/Sources/ComputerHelper/main.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/main.swift
@@ -29,6 +29,51 @@ func log(_ msg: String) {
     stderr.write("[computer-helper] \(msg)\n".data(using: .utf8)!)
 }
 
+// Allow-list policy. Mutated at startup (from disk) and on every SIGHUP.
+// File scope so RPC.swift can read it without an instance handle. The
+// helper boots with allow=[] which means every action gets rejected —
+// the safe default if the policy file is missing, unreadable, or empty.
+struct Policy {
+    var allow: Set<String> = []
+}
+
+var policy = Policy()
+
+// Resolve the policy file path. Env override mirrors the socket-path
+// override so tests can point us at a scratch file. Default lives next to
+// the socket under ~/.agents/.cache/helpers/.
+func resolvePolicyPath() -> String {
+    if let env = ProcessInfo.processInfo.environment["COMPUTER_HELPER_POLICY"], !env.isEmpty {
+        return env
+    }
+    return "\(NSHomeDirectory())/.agents/.cache/helpers/computer-policy.json"
+}
+
+// Load (or reload) the policy file. Errors are logged but never thrown:
+// the helper keeps running with whatever it last had, with the explicit
+// exception that "file missing" resets the allow list to empty so an
+// uninstall of permissions takes effect on SIGHUP.
+func loadPolicy() {
+    let path = resolvePolicyPath()
+    guard FileManager.default.fileExists(atPath: path) else {
+        log("policy file missing at \(path) — empty allow list (fail-safe)")
+        policy = Policy()
+        return
+    }
+    guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
+        log("policy file unreadable at \(path) — keeping previous allow list (\(policy.allow.count) entries)")
+        return
+    }
+    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let allow = json["allow"] as? [String] else {
+        log("policy file unparseable at \(path) — empty allow list (fail-safe)")
+        policy = Policy()
+        return
+    }
+    policy = Policy(allow: Set(allow))
+    log("policy loaded: \(allow.count) allowed bundle ids")
+}
+
 // Resolve socket path: --socket <path> argv, else env COMPUTER_HELPER_SOCKET.
 // If neither is set, fall back to stdio mode.
 func resolveSocketPath() -> String? {
@@ -82,6 +127,18 @@ func handleLine(_ line: Data) -> Data? {
 }
 
 log("started pid=\(getpid())")
+
+// Load the allow-list policy before accepting any RPC calls. SIGHUP from
+// the CLI's `agents computer reload` triggers a reload.
+loadPolicy()
+
+let sighupSource = DispatchSource.makeSignalSource(signal: SIGHUP, queue: .main)
+sighupSource.setEventHandler {
+    log("SIGHUP — reloading policy")
+    loadPolicy()
+}
+sighupSource.resume()
+signal(SIGHUP, SIG_IGN) // DispatchSource needs the libc handler ignored
 
 if let socketPath = resolveSocketPath() {
     // ---- Socket transport ----

--- a/packages/computer-helper/Sources/ComputerHelper/main.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/main.swift
@@ -1,10 +1,16 @@
 import AppKit
 import Foundation
 
-// Line-delimited JSON-RPC over stdio.
-// Each line in: {"id":N,"method":"...","params":{...}}
+// Line-delimited JSON-RPC.
+// Each line in:  {"id":N,"method":"...","params":{...}}
 // Each line out: {"id":N,"result":{...}} or {"id":N,"error":{"code":"...","message":"..."}}
-
+//
+// Two transports:
+//   - default: stdio (legacy, one-shot helper spawned by parent per call)
+//   - --socket <path> or env COMPUTER_HELPER_SOCKET: listen on a Unix domain
+//     socket, accept many concurrent connections, each with its own line-
+//     delimited JSON-RPC channel. Used by the launchd-managed daemon.
+//
 // Initialize the WindowServer/SkyLight connection. ScreenCaptureKit asserts
 // CGS_REQUIRE_INIT inside SCScreenshotManager when invoked from a process
 // that hasn't touched AppKit yet. Bare `swift` CLI processes and our helper
@@ -12,83 +18,280 @@ import Foundation
 // is enough to bootstrap the connection without starting a run loop.
 //
 // We also need the run loop running on the main thread so CursorSprite can
-// display its overlay NSWindow when the agent clicks. The RPC stdin loop
+// display its overlay NSWindow when the agent clicks. The RPC reader
 // therefore moves to a background queue; NSApp.run() owns main.
 _ = NSApplication.shared
 NSApplication.shared.setActivationPolicy(.accessory)
 
-let stdin = FileHandle.standardInput
-let stdout = FileHandle.standardOutput
 let stderr = FileHandle.standardError
-
-let cache = ElementCache()
-let dispatcher = Dispatcher(cache: cache)
-let writeLock = NSLock()
-
-func writeLine(_ obj: [String: Any]) {
-    guard let data = try? JSONSerialization.data(withJSONObject: obj, options: []) else {
-        return
-    }
-    writeLock.lock()
-    stdout.write(data)
-    stdout.write("\n".data(using: .utf8)!)
-    writeLock.unlock()
-}
 
 func log(_ msg: String) {
     stderr.write("[computer-helper] \(msg)\n".data(using: .utf8)!)
 }
 
+// Resolve socket path: --socket <path> argv, else env COMPUTER_HELPER_SOCKET.
+// If neither is set, fall back to stdio mode.
+func resolveSocketPath() -> String? {
+    let args = CommandLine.arguments
+    if let idx = args.firstIndex(of: "--socket"), idx + 1 < args.count {
+        return args[idx + 1]
+    }
+    if let env = ProcessInfo.processInfo.environment["COMPUTER_HELPER_SOCKET"], !env.isEmpty {
+        return env
+    }
+    return nil
+}
+
+let cache = ElementCache()
+let dispatcher = Dispatcher(cache: cache)
+
+// Encode one RPC response. Shared by both transports.
+func encodeResponse(_ obj: [String: Any]) -> Data? {
+    guard let data = try? JSONSerialization.data(withJSONObject: obj, options: []) else {
+        return nil
+    }
+    var out = data
+    out.append(0x0A) // newline
+    return out
+}
+
+// Handle one parsed line of JSON. Returns the response bytes ready to write.
+func handleLine(_ line: Data) -> Data? {
+    do {
+        guard let obj = try JSONSerialization.jsonObject(with: line) as? [String: Any],
+              let id = obj["id"],
+              let method = obj["method"] as? String
+        else {
+            return encodeResponse(["id": NSNull(), "error": ["code": "bad_request", "message": "malformed JSON-RPC"]])
+        }
+        let params = obj["params"] as? [String: Any] ?? [:]
+
+        let response: [String: Any]
+        do {
+            let result = try dispatcher.dispatch(method: method, params: params)
+            response = ["id": id, "result": result]
+        } catch let err as RPCError {
+            response = ["id": id, "error": ["code": err.code, "message": err.message]]
+        } catch {
+            response = ["id": id, "error": ["code": "internal", "message": "\(error)"]]
+        }
+        return encodeResponse(response)
+    } catch {
+        return encodeResponse(["id": NSNull(), "error": ["code": "bad_request", "message": "\(error)"]])
+    }
+}
+
 log("started pid=\(getpid())")
 
-// RPC loop on a background queue. On EOF (parent closed stdin) we
-// asynchronously terminate NSApp so the main run loop unblocks too.
-// Without this the helper would hang after the parent exits because the
-// main thread is still pumping the NSApp run loop.
-DispatchQueue.global(qos: .userInteractive).async {
+if let socketPath = resolveSocketPath() {
+    // ---- Socket transport ----
+    //
+    // Long-lived daemon. launchd starts us at login with --socket, KeepAlive
+    // restarts us on crash. Multiple connections share the dispatcher (the
+    // ElementCache is already thread-safe via its internal queue).
+
+    log("socket mode: \(socketPath)")
+
+    // Clean any stale socket file from a crashed previous instance.
+    let fm = FileManager.default
+    if fm.fileExists(atPath: socketPath) {
+        try? fm.removeItem(atPath: socketPath)
+        log("removed stale socket at \(socketPath)")
+    }
+
+    // Create listening socket.
+    let listenFd = socket(AF_UNIX, SOCK_STREAM, 0)
+    if listenFd < 0 {
+        log("socket() failed: errno=\(errno)")
+        exit(1)
+    }
+
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    let pathBytes = Array(socketPath.utf8)
+    let sunPathSize = MemoryLayout.size(ofValue: addr.sun_path)
+    let maxLen = sunPathSize - 1
+    if pathBytes.count > maxLen {
+        log("socket path too long (max \(maxLen)): \(socketPath)")
+        exit(1)
+    }
+    withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+        pathPtr.withMemoryRebound(to: CChar.self, capacity: sunPathSize) { cstr in
+            for i in 0..<pathBytes.count {
+                cstr[i] = CChar(pathBytes[i])
+            }
+            cstr[pathBytes.count] = 0
+        }
+    }
+
+    let bindResult = withUnsafePointer(to: &addr) { ptr -> Int32 in
+        ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+            return Darwin.bind(listenFd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    if bindResult < 0 {
+        log("bind() failed: errno=\(errno) path=\(socketPath)")
+        close(listenFd)
+        exit(1)
+    }
+
+    // 0600 — owner-only. The socket lives under ~/.agents/ which is already
+    // user-owned, but be explicit.
+    if chmod(socketPath, 0o600) != 0 {
+        log("chmod 0600 failed: errno=\(errno)")
+    }
+
+    if Darwin.listen(listenFd, 32) < 0 {
+        log("listen() failed: errno=\(errno)")
+        close(listenFd)
+        exit(1)
+    }
+
+    log("listening on \(socketPath)")
+
+    // Signal handlers: unlink socket then exit so the next launchd restart
+    // can bind cleanly. unlink/_exit are signal-safe; the socketPath cstr
+    // lives in the global Swift String storage.
+    signal(SIGPIPE, SIG_IGN) // peer close shouldn't kill us
+
+    // DispatchSource signal handlers can call into Swift safely.
+    let termSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
+    termSource.setEventHandler {
+        log("SIGTERM — unlinking socket")
+        unlink(socketPath)
+        exit(0)
+    }
+    termSource.resume()
+    signal(SIGTERM, SIG_IGN)
+
+    let intSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
+    intSource.setEventHandler {
+        log("SIGINT — unlinking socket")
+        unlink(socketPath)
+        exit(0)
+    }
+    intSource.resume()
+    signal(SIGINT, SIG_IGN)
+
+    // atexit also unlinks for any other exit path.
+    atexit_b {
+        unlink(socketPath)
+    }
+
+    // Accept loop on a dedicated background queue.
+    DispatchQueue.global(qos: .userInitiated).async {
+        while true {
+            var clientAddr = sockaddr_un()
+            var clientLen = socklen_t(MemoryLayout<sockaddr_un>.size)
+            let clientFd = withUnsafeMutablePointer(to: &clientAddr) { ptr -> Int32 in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                    return Darwin.accept(listenFd, sockPtr, &clientLen)
+                }
+            }
+            if clientFd < 0 {
+                if errno == EINTR { continue }
+                log("accept() failed: errno=\(errno)")
+                continue
+            }
+
+            // Handle the connection on its own queue.
+            DispatchQueue.global(qos: .userInteractive).async {
+                handleConnection(fd: clientFd)
+            }
+        }
+    }
+
+    NSApplication.shared.run()
+} else {
+    // ---- Stdio transport (legacy) ----
+    //
+    // Parent process spawns helper, writes one or more JSON-RPC lines, reads
+    // responses, closes stdin. Helper exits on EOF.
+
+    let stdin = FileHandle.standardInput
+    let stdout = FileHandle.standardOutput
+    let writeLock = NSLock()
+
+    func writeLineStdio(_ data: Data) {
+        writeLock.lock()
+        stdout.write(data)
+        writeLock.unlock()
+    }
+
+    DispatchQueue.global(qos: .userInteractive).async {
+        var buffer = Data()
+        while true {
+            let chunk = stdin.availableData
+            if chunk.isEmpty {
+                log("exit (stdin EOF)")
+                DispatchQueue.main.async { NSApp.terminate(nil) }
+                return
+            }
+            buffer.append(chunk)
+
+            while let nl = buffer.firstIndex(of: 0x0A) {
+                let line = buffer.subdata(in: 0..<nl)
+                buffer.removeSubrange(0...nl)
+                guard !line.isEmpty else { continue }
+                if let resp = handleLine(line) {
+                    writeLineStdio(resp)
+                }
+            }
+        }
+    }
+
+    NSApplication.shared.run()
+}
+
+// Handle one accepted connection. Line-delimited JSON-RPC, same wire format
+// as stdio. Runs on a background queue; serializes writes via a per-
+// connection lock.
+func handleConnection(fd: Int32) {
+    let writeLock = NSLock()
+    func writeData(_ data: Data) {
+        writeLock.lock()
+        defer { writeLock.unlock() }
+        let bytes = [UInt8](data)
+        var remaining = bytes.count
+        var offset = 0
+        while remaining > 0 {
+            let n = bytes.withUnsafeBufferPointer { bp -> Int in
+                return Darwin.write(fd, bp.baseAddress!.advanced(by: offset), remaining)
+            }
+            if n <= 0 {
+                if errno == EINTR { continue }
+                return // peer gone
+            }
+            offset += n
+            remaining -= n
+        }
+    }
+
     var buffer = Data()
+    var readBuf = [UInt8](repeating: 0, count: 8192)
+
     while true {
-        let chunk = stdin.availableData
-        if chunk.isEmpty {
-            log("exit (stdin EOF)")
-            DispatchQueue.main.async { NSApp.terminate(nil) }
+        let n = readBuf.withUnsafeMutableBufferPointer { bp -> Int in
+            return Darwin.read(fd, bp.baseAddress!, bp.count)
+        }
+        if n == 0 {
+            close(fd)
             return
         }
-        buffer.append(chunk)
+        if n < 0 {
+            if errno == EINTR { continue }
+            close(fd)
+            return
+        }
+        buffer.append(readBuf, count: n)
 
         while let nl = buffer.firstIndex(of: 0x0A) {
             let line = buffer.subdata(in: 0..<nl)
             buffer.removeSubrange(0...nl)
-
             guard !line.isEmpty else { continue }
-
-            do {
-                guard let obj = try JSONSerialization.jsonObject(with: line) as? [String: Any],
-                      let id = obj["id"],
-                      let method = obj["method"] as? String
-                else {
-                    writeLine(["id": NSNull(), "error": ["code": "bad_request", "message": "malformed JSON-RPC"]])
-                    continue
-                }
-                let params = obj["params"] as? [String: Any] ?? [:]
-
-                let response: [String: Any]
-                do {
-                    let result = try dispatcher.dispatch(method: method, params: params)
-                    response = ["id": id, "result": result]
-                } catch let err as RPCError {
-                    response = ["id": id, "error": ["code": err.code, "message": err.message]]
-                } catch {
-                    response = ["id": id, "error": ["code": "internal", "message": "\(error)"]]
-                }
-                writeLine(response)
-            } catch {
-                writeLine(["id": NSNull(), "error": ["code": "bad_request", "message": "\(error)"]])
+            if let resp = handleLine(line) {
+                writeData(resp)
             }
         }
     }
 }
-
-// Hand main thread to AppKit's run loop. Blocks until NSApp.terminate
-// fires from the RPC loop on stdin EOF.
-NSApplication.shared.run()

--- a/packages/computer-helper/Sources/ComputerHelper/main.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/main.swift
@@ -1,0 +1,94 @@
+import AppKit
+import Foundation
+
+// Line-delimited JSON-RPC over stdio.
+// Each line in: {"id":N,"method":"...","params":{...}}
+// Each line out: {"id":N,"result":{...}} or {"id":N,"error":{"code":"...","message":"..."}}
+
+// Initialize the WindowServer/SkyLight connection. ScreenCaptureKit asserts
+// CGS_REQUIRE_INIT inside SCScreenshotManager when invoked from a process
+// that hasn't touched AppKit yet. Bare `swift` CLI processes and our helper
+// (LSUIElement, no run loop) both hit this. Touching NSApplication.shared
+// is enough to bootstrap the connection without starting a run loop.
+//
+// We also need the run loop running on the main thread so CursorSprite can
+// display its overlay NSWindow when the agent clicks. The RPC stdin loop
+// therefore moves to a background queue; NSApp.run() owns main.
+_ = NSApplication.shared
+NSApplication.shared.setActivationPolicy(.accessory)
+
+let stdin = FileHandle.standardInput
+let stdout = FileHandle.standardOutput
+let stderr = FileHandle.standardError
+
+let cache = ElementCache()
+let dispatcher = Dispatcher(cache: cache)
+let writeLock = NSLock()
+
+func writeLine(_ obj: [String: Any]) {
+    guard let data = try? JSONSerialization.data(withJSONObject: obj, options: []) else {
+        return
+    }
+    writeLock.lock()
+    stdout.write(data)
+    stdout.write("\n".data(using: .utf8)!)
+    writeLock.unlock()
+}
+
+func log(_ msg: String) {
+    stderr.write("[computer-helper] \(msg)\n".data(using: .utf8)!)
+}
+
+log("started pid=\(getpid())")
+
+// RPC loop on a background queue. On EOF (parent closed stdin) we
+// asynchronously terminate NSApp so the main run loop unblocks too.
+// Without this the helper would hang after the parent exits because the
+// main thread is still pumping the NSApp run loop.
+DispatchQueue.global(qos: .userInteractive).async {
+    var buffer = Data()
+    while true {
+        let chunk = stdin.availableData
+        if chunk.isEmpty {
+            log("exit (stdin EOF)")
+            DispatchQueue.main.async { NSApp.terminate(nil) }
+            return
+        }
+        buffer.append(chunk)
+
+        while let nl = buffer.firstIndex(of: 0x0A) {
+            let line = buffer.subdata(in: 0..<nl)
+            buffer.removeSubrange(0...nl)
+
+            guard !line.isEmpty else { continue }
+
+            do {
+                guard let obj = try JSONSerialization.jsonObject(with: line) as? [String: Any],
+                      let id = obj["id"],
+                      let method = obj["method"] as? String
+                else {
+                    writeLine(["id": NSNull(), "error": ["code": "bad_request", "message": "malformed JSON-RPC"]])
+                    continue
+                }
+                let params = obj["params"] as? [String: Any] ?? [:]
+
+                let response: [String: Any]
+                do {
+                    let result = try dispatcher.dispatch(method: method, params: params)
+                    response = ["id": id, "result": result]
+                } catch let err as RPCError {
+                    response = ["id": id, "error": ["code": err.code, "message": err.message]]
+                } catch {
+                    response = ["id": id, "error": ["code": "internal", "message": "\(error)"]]
+                }
+                writeLine(response)
+            } catch {
+                writeLine(["id": NSNull(), "error": ["code": "bad_request", "message": "\(error)"]])
+            }
+        }
+    }
+}
+
+// Hand main thread to AppKit's run loop. Blocks until NSApp.terminate
+// fires from the RPC loop on stdin EOF.
+NSApplication.shared.run()

--- a/packages/computer-helper/scripts/build.sh
+++ b/packages/computer-helper/scripts/build.sh
@@ -42,7 +42,7 @@ cat > "$APP/Contents/Info.plist" <<'PLIST'
     <key>CFBundleExecutable</key>
     <string>ComputerHelper</string>
     <key>CFBundleIdentifier</key>
-    <string>dev.swarmify.computer-helper</string>
+    <string>com.phnx-labs.computer-helper</string>
     <key>CFBundleName</key>
     <string>Computer Helper</string>
     <key>CFBundlePackageType</key>
@@ -69,8 +69,8 @@ if [ -z "$SIGN_ID" ]; then
     SIGN_ID="-"
 fi
 echo "  signing with: $SIGN_ID"
-codesign --force --deep --options runtime --sign "$SIGN_ID" --identifier dev.swarmify.computer-helper "$APP" 2>&1 | sed 's/^/  /'
-codesign --force --options runtime --sign "$SIGN_ID" --identifier dev.swarmify.computer-helper "$DEST" 2>&1 | sed 's/^/  /'
+codesign --force --deep --options runtime --sign "$SIGN_ID" --identifier com.phnx-labs.computer-helper "$APP" 2>&1 | sed 's/^/  /'
+codesign --force --options runtime --sign "$SIGN_ID" --identifier com.phnx-labs.computer-helper "$DEST" 2>&1 | sed 's/^/  /'
 
 echo "built: $DEST"
 echo "built: $APP"

--- a/packages/computer-helper/scripts/build.sh
+++ b/packages/computer-helper/scripts/build.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+MODE="${1:-debug}"
+
+if [ "$MODE" = "release" ]; then
+    swift build -c release --arch arm64 --arch x86_64
+    SRC=".build/apple/Products/Release/ComputerHelper"
+else
+    swift build
+    SRC=".build/debug/ComputerHelper"
+fi
+
+DEST_DIR="dist"
+mkdir -p "$DEST_DIR"
+
+# Standalone binary (used when embedded inside a parent signed .app bundle
+# that provides TCC identity).
+DEST="$DEST_DIR/computer-helper-mac"
+cp "$SRC" "$DEST"
+
+# For standalone / dev invocation, also produce a .app bundle. Running the
+# helper as `ComputerHelper.app/Contents/MacOS/ComputerHelper` gives it
+# first-class TCC identity (bundle id + Info.plist) instead of inheriting
+# from whichever shell launched it. Without this, Accessibility grants on
+# the bare binary are overridden by the launching process's context.
+APP="$DEST_DIR/ComputerHelper.app"
+# Always start from scratch. In-place rebuilds leave stale _CodeSignature/
+# and provenance xattrs that produce half-signed bundles; if Gatekeeper
+# then rejects a `open -a` against this, lsd queues failed assessments
+# until the whole system can't launch new apps (Activity Monitor, Messages).
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS"
+cp "$SRC" "$APP/Contents/MacOS/ComputerHelper"
+cat > "$APP/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>ComputerHelper</string>
+    <key>CFBundleIdentifier</key>
+    <string>dev.swarmify.computer-helper</string>
+    <key>CFBundleName</key>
+    <string>Computer Helper</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSUIElement</key>
+    <true/>
+</dict>
+</plist>
+PLIST
+# Pick a code signing identity. TCC on macOS 15+ silently refuses
+# Accessibility/Screen Recording grants on ad-hoc signed binaries — even
+# when the System Settings toggle appears on. Developer ID signing keys
+# the TCC grant by Team ID, which is stable across rebuilds.
+SIGN_ID="${COMPUTER_HELPER_SIGN_ID:-}"
+if [ -z "$SIGN_ID" ]; then
+    SIGN_ID=$(security find-identity -v -p codesigning 2>/dev/null | grep -oE '"Developer ID Application: [^"]+"' | head -1 | tr -d '"')
+fi
+if [ -z "$SIGN_ID" ]; then
+    echo "  WARNING: no Developer ID cert — falling back to ad-hoc (TCC grants will not apply)"
+    SIGN_ID="-"
+fi
+echo "  signing with: $SIGN_ID"
+codesign --force --deep --options runtime --sign "$SIGN_ID" --identifier dev.swarmify.computer-helper "$APP" 2>&1 | sed 's/^/  /'
+codesign --force --options runtime --sign "$SIGN_ID" --identifier dev.swarmify.computer-helper "$DEST" 2>&1 | sed 's/^/  /'
+
+echo "built: $DEST"
+echo "built: $APP"
+
+# Notarize the .app bundle. Without this, Gatekeeper on macOS 15 refuses
+# Launch Services launches of the helper (`open -a`), which is the TCC path
+# agents need to use when the launching app's responsibility chain is non-granted.
+# Direct exec bypasses Gatekeeper but inherits parent-shell TCC (denied when
+# the parent isn't granted). Notarization = one source of truth.
+#
+# Skips if APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD / APPLE_TEAM_ID are unset —
+# local dev builds from a TCC-granted shell still work via direct exec.
+if [ -z "${APPLE_ID:-}" ] || [ -z "${APPLE_APP_SPECIFIC_PASSWORD:-}" ] || [ -z "${APPLE_TEAM_ID:-}" ]; then
+    echo "  skipping notarization (APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD / APPLE_TEAM_ID not all set)"
+    echo "  to enable: export APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, APPLE_TEAM_ID and rerun"
+    exit 0
+fi
+
+# Skip notarization for ad-hoc signed builds (Apple requires Developer ID).
+if [ "$SIGN_ID" = "-" ]; then
+    echo "  skipping notarization (ad-hoc signed — Apple requires Developer ID)"
+    exit 0
+fi
+
+echo "=== notarize ==="
+SUBMIT_ZIP="$(mktemp -t ch-notarize).zip"
+trap 'rm -f "$SUBMIT_ZIP"' EXIT
+
+# notarytool requires a flat container — ditto preserves the signed .app.
+ditto -c -k --keepParent "$APP" "$SUBMIT_ZIP"
+
+echo "  submitting $APP to Apple (this takes 30s-2min)..."
+NOTARIZE_OUTPUT=$(xcrun notarytool submit "$SUBMIT_ZIP" \
+    --apple-id "$APPLE_ID" \
+    --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+    --team-id "$APPLE_TEAM_ID" \
+    --wait 2>&1)
+echo "$NOTARIZE_OUTPUT" | sed 's/^/  /'
+
+if ! echo "$NOTARIZE_OUTPUT" | grep -q "status: Accepted"; then
+    echo "  ERROR: notarization did not return Accepted"
+    SUBMISSION_ID=$(echo "$NOTARIZE_OUTPUT" | awk '/id:/ {print $2; exit}')
+    if [ -n "$SUBMISSION_ID" ]; then
+        echo "  fetching log for submission $SUBMISSION_ID..."
+        xcrun notarytool log "$SUBMISSION_ID" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" 2>&1 | sed 's/^/    /'
+    fi
+    exit 1
+fi
+
+echo "  stapling ticket to $APP..."
+xcrun stapler staple "$APP" 2>&1 | sed 's/^/  /'
+
+echo "  verifying Gatekeeper assessment..."
+spctl --assess --verbose "$APP" 2>&1 | sed 's/^/  /'
+
+echo "notarized: $APP"

--- a/src/commands/computer.ts
+++ b/src/commands/computer.ts
@@ -1,16 +1,18 @@
 import { Command } from 'commander';
-import { execFileSync, spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { fileURLToPath } from 'url';
 import { registerCommandGroups } from '../lib/help.js';
-import { openComputerClient, resolveHelperApp } from '../lib/computer-rpc.js';
+import {
+  openComputerClient,
+  resolveHelperApp,
+  resolveHelperExec,
+  resolveSocketPath,
+  describeTransport,
+} from '../lib/computer-rpc.js';
 
 // Help groups — mirror `agents browser` so the mental model carries over.
-// For this first chunk we ship two commands; the structure leaves room
-// for the future "drive the page" / "capture evidence" groups without
-// re-shuffling.
 const COMPUTER_HELP_GROUPS = [
   { title: 'Session lifecycle', names: ['status', 'install-helper'] },
   { title: 'Capture evidence', names: ['screenshot'] },
@@ -32,109 +34,9 @@ export function registerComputerSubcommands(program: Command): void {
   registerCommandGroups(program, COMPUTER_HELP_GROUPS);
 }
 
-// Resolve the helper binary path.
-//
-// 1. Locally-built helper next to the package source — used during
-//    development and for any user who ran `./packages/computer-helper/scripts/build.sh`.
-// 2. Future: a `dist/` directory bundled with the published npm package
-//    (downloaded from CDN on postinstall — wired in a later chunk).
-//
-// Returns the absolute path to the executable inside the .app bundle so
-// the helper gets its TCC identity from the bundle id, not the parent shell.
-function resolveHelperPath(): string | null {
-  // src/commands/ at runtime resolves to dist/commands/ — walk up two
-  // levels to find the package root.
-  const here = path.dirname(fileURLToPath(import.meta.url));
-  const candidates = [
-    // 1. Local build (when running from the agents-cli checkout).
-    path.resolve(here, '..', '..', 'packages', 'computer-helper', 'dist', 'ComputerHelper.app', 'Contents', 'MacOS', 'ComputerHelper'),
-    // 2. Bundled with the npm package (later: CDN download lands here).
-    path.resolve(here, '..', 'computer-helper', 'ComputerHelper.app', 'Contents', 'MacOS', 'ComputerHelper'),
-  ];
-  for (const c of candidates) {
-    if (fs.existsSync(c)) return c;
-  }
-  return null;
-}
-
 function reportMissingHelper(): never {
   console.error('helper not built. Run: ./packages/computer-helper/scripts/build.sh debug');
   process.exit(1);
-}
-
-// Line-delimited JSON-RPC client. The helper terminates on stdin EOF, so
-// each invocation = one short-lived helper process for one or two calls.
-// This is the same shape as `rush/app/native/computer-mac/scripts/probe.py`,
-// just in TypeScript.
-interface RPCResponse {
-  id: number | null;
-  result?: Record<string, unknown>;
-  error?: { code: string; message: string };
-}
-
-class HelperClient {
-  private proc: ChildProcessWithoutNullStreams;
-  private buf = '';
-  private waiters: Map<number, (r: RPCResponse) => void> = new Map();
-  private nextId = 1;
-  private exited = false;
-
-  constructor(helperPath: string) {
-    this.proc = spawn(helperPath, [], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    this.proc.stdout.setEncoding('utf8');
-    this.proc.stdout.on('data', (chunk: string) => {
-      this.buf += chunk;
-      let nl: number;
-      while ((nl = this.buf.indexOf('\n')) !== -1) {
-        const line = this.buf.slice(0, nl);
-        this.buf = this.buf.slice(nl + 1);
-        if (!line) continue;
-        try {
-          const obj = JSON.parse(line) as RPCResponse;
-          const id = typeof obj.id === 'number' ? obj.id : null;
-          if (id !== null && this.waiters.has(id)) {
-            const resolve = this.waiters.get(id)!;
-            this.waiters.delete(id);
-            resolve(obj);
-          }
-        } catch {
-          // Drop garbage; the helper writes diagnostics to stderr, not stdout.
-        }
-      }
-    });
-    this.proc.on('exit', () => {
-      this.exited = true;
-      // Resolve any pending waiters with an error so callers don't hang
-      // when the helper crashes.
-      for (const [id, resolve] of this.waiters) {
-        resolve({ id, error: { code: 'helper_exited', message: 'helper exited before reply' } });
-      }
-      this.waiters.clear();
-    });
-  }
-
-  async call(method: string, params?: Record<string, unknown>): Promise<RPCResponse> {
-    if (this.exited) {
-      return { id: null, error: { code: 'helper_exited', message: 'helper not running' } };
-    }
-    const id = this.nextId++;
-    const payload = JSON.stringify({ id, method, params: params ?? {} }) + '\n';
-    return new Promise((resolve) => {
-      this.waiters.set(id, resolve);
-      this.proc.stdin.write(payload);
-    });
-  }
-
-  async close(): Promise<void> {
-    if (this.exited) return;
-    this.proc.stdin.end();
-    await new Promise<void>((resolve) => {
-      if (this.exited) return resolve();
-      this.proc.on('exit', () => resolve());
-    });
-  }
 }
 
 function registerStatusCommand(program: Command): void {
@@ -142,10 +44,10 @@ function registerStatusCommand(program: Command): void {
     .command('status')
     .description('Report Accessibility trust + helper identity')
     .action(async () => {
-      const helperPath = resolveHelperPath();
-      if (!helperPath) reportMissingHelper();
+      const transport = describeTransport();
+      if (transport.kind === 'none') reportMissingHelper();
 
-      const client = new HelperClient(helperPath);
+      const client = openComputerClient();
       try {
         const r = await client.call('trust_status');
         if (r.error) {
@@ -154,14 +56,17 @@ function registerStatusCommand(program: Command): void {
         }
         const trusted = Boolean(r.result?.trusted);
         const helperPid = r.result?.pid;
+        const helperPath = r.result?.path as string | undefined;
         console.log(`trust: ${trusted ? 'granted' : 'denied'}`);
-        console.log(`helper: ${helperPath}`);
+        console.log(`transport: ${transport.kind} (${transport.path})`);
+        if (helperPath) console.log(`helper: ${helperPath}`);
         if (typeof helperPid === 'number') console.log(`pid: ${helperPid}`);
         if (!trusted) {
+          const appPath = helperPath ? path.resolve(helperPath, '..', '..', '..') : '/Applications/Swarmify Computer Helper.app';
           console.error('');
           console.error('Accessibility is not granted to ComputerHelper.app.');
           console.error('Open System Settings > Privacy & Security > Accessibility and add:');
-          console.error(`  ${path.resolve(helperPath, '..', '..', '..')}`);
+          console.error(`  ${appPath}`);
         }
       } finally {
         await client.close();
@@ -177,12 +82,12 @@ function registerScreenshotCommand(program: Command): void {
     .option('--out <path>', 'Output JPEG path', './computer-screenshot.jpg')
     .option('--quality <n>', 'JPEG quality 1-100', (v) => parseInt(v, 10), 85)
     .action(async (opts: { bundle?: string; out: string; quality: number }) => {
-      const helperPath = resolveHelperPath();
-      if (!helperPath) reportMissingHelper();
+      const transport = describeTransport();
+      if (transport.kind === 'none') reportMissingHelper();
 
       const quality = Math.max(1, Math.min(100, opts.quality || 85));
 
-      const client = new HelperClient(helperPath);
+      const client = openComputerClient();
       try {
         // Step 1: list_apps to get the candidate set.
         const apps = await client.call('list_apps');
@@ -198,7 +103,6 @@ function registerScreenshotCommand(program: Command): void {
           excluded: boolean;
         }>) || [];
 
-        // Resolve the target bundle id.
         let target: typeof list[number] | undefined;
         if (opts.bundle) {
           target = list.find((a) => a.bundle_id === opts.bundle);
@@ -458,3 +362,8 @@ function escapeXml(s: string): string {
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+// Backwards-compat: a few external callers may still import these.
+// Re-export from the shared lib so existing imports keep working.
+export { resolveHelperExec as resolveHelperPath };
+export { resolveSocketPath };

--- a/src/commands/computer.ts
+++ b/src/commands/computer.ts
@@ -6,9 +6,12 @@ import { fileURLToPath } from 'url';
 import { registerCommandGroups } from '../lib/help.js';
 
 // Help groups — mirror `agents browser` so the mental model carries over.
-// More groups land as we add subcommands.
+// For this first chunk we ship two commands; the structure leaves room
+// for the future "drive the page" / "capture evidence" groups without
+// re-shuffling.
 const COMPUTER_HELP_GROUPS = [
   { title: 'Session lifecycle', names: ['status'] },
+  { title: 'Capture evidence', names: ['screenshot'] },
 ] as const;
 
 export function registerComputerCommand(program: Command): void {
@@ -22,6 +25,7 @@ export function registerComputerCommand(program: Command): void {
 
 export function registerComputerSubcommands(program: Command): void {
   registerStatusCommand(program);
+  registerScreenshotCommand(program);
   registerCommandGroups(program, COMPUTER_HELP_GROUPS);
 }
 
@@ -156,6 +160,78 @@ function registerStatusCommand(program: Command): void {
           console.error('Open System Settings > Privacy & Security > Accessibility and add:');
           console.error(`  ${path.resolve(helperPath, '..', '..', '..')}`);
         }
+      } finally {
+        await client.close();
+      }
+    });
+}
+
+function registerScreenshotCommand(program: Command): void {
+  program
+    .command('screenshot')
+    .description('Capture a JPEG of the frontmost window of a bundle id (default: frontmost app)')
+    .option('--bundle <id>', 'Bundle id to capture (default: bundle id of frontmost app)')
+    .option('--out <path>', 'Output JPEG path', './computer-screenshot.jpg')
+    .option('--quality <n>', 'JPEG quality 1-100', (v) => parseInt(v, 10), 85)
+    .action(async (opts: { bundle?: string; out: string; quality: number }) => {
+      const helperPath = resolveHelperPath();
+      if (!helperPath) reportMissingHelper();
+
+      const quality = Math.max(1, Math.min(100, opts.quality || 85));
+
+      const client = new HelperClient(helperPath);
+      try {
+        // Step 1: list_apps to get the candidate set.
+        const apps = await client.call('list_apps');
+        if (apps.error) {
+          console.error(`error: ${apps.error.code}: ${apps.error.message}`);
+          process.exit(1);
+        }
+        const list = (apps.result?.apps as Array<{
+          pid: number;
+          name: string;
+          bundle_id: string;
+          active: boolean;
+          excluded: boolean;
+        }>) || [];
+
+        // Resolve the target bundle id.
+        let target: typeof list[number] | undefined;
+        if (opts.bundle) {
+          target = list.find((a) => a.bundle_id === opts.bundle);
+          if (!target) {
+            console.error(`bundle not running: ${opts.bundle}`);
+            process.exit(1);
+          }
+        } else {
+          target = list.find((a) => a.active);
+          if (!target) {
+            console.error('no active app found');
+            process.exit(1);
+          }
+        }
+        if (target.excluded) {
+          console.error(`bundle is excluded by deny-list: ${target.bundle_id}`);
+          process.exit(1);
+        }
+
+        // Step 2: screenshot.
+        const shot = await client.call('screenshot', { pid: target.pid, quality });
+        if (shot.error) {
+          console.error(`error: ${shot.error.code}: ${shot.error.message}`);
+          process.exit(1);
+        }
+        const b64 = shot.result?.image_data as string | undefined;
+        const width = shot.result?.width as number | undefined;
+        const height = shot.result?.height as number | undefined;
+        if (!b64) {
+          console.error('helper returned no image_data');
+          process.exit(1);
+        }
+        const buf = Buffer.from(b64, 'base64');
+        const outPath = path.resolve(opts.out);
+        fs.writeFileSync(outPath, buf);
+        console.log(`saved: ${outPath} (${width ?? '?'}x${height ?? '?'}, ${buf.byteLength} bytes)`);
       } finally {
         await client.close();
       }

--- a/src/commands/computer.ts
+++ b/src/commands/computer.ts
@@ -1,0 +1,163 @@
+import { Command } from 'commander';
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { registerCommandGroups } from '../lib/help.js';
+
+// Help groups — mirror `agents browser` so the mental model carries over.
+// More groups land as we add subcommands.
+const COMPUTER_HELP_GROUPS = [
+  { title: 'Session lifecycle', names: ['status'] },
+] as const;
+
+export function registerComputerCommand(program: Command): void {
+  const computer = program
+    .command('computer')
+    .description('Drive macOS apps via Accessibility — list, screenshot, click, type');
+
+  registerComputerSubcommands(computer);
+  registerCommandGroups(computer, COMPUTER_HELP_GROUPS);
+}
+
+export function registerComputerSubcommands(program: Command): void {
+  registerStatusCommand(program);
+  registerCommandGroups(program, COMPUTER_HELP_GROUPS);
+}
+
+// Resolve the helper binary path.
+//
+// 1. Locally-built helper next to the package source — used during
+//    development and for any user who ran `./packages/computer-helper/scripts/build.sh`.
+// 2. Future: a `dist/` directory bundled with the published npm package
+//    (downloaded from CDN on postinstall — wired in a later chunk).
+//
+// Returns the absolute path to the executable inside the .app bundle so
+// the helper gets its TCC identity from the bundle id, not the parent shell.
+function resolveHelperPath(): string | null {
+  // src/commands/ at runtime resolves to dist/commands/ — walk up two
+  // levels to find the package root.
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    // 1. Local build (when running from the agents-cli checkout).
+    path.resolve(here, '..', '..', 'packages', 'computer-helper', 'dist', 'ComputerHelper.app', 'Contents', 'MacOS', 'ComputerHelper'),
+    // 2. Bundled with the npm package (later: CDN download lands here).
+    path.resolve(here, '..', 'computer-helper', 'ComputerHelper.app', 'Contents', 'MacOS', 'ComputerHelper'),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  return null;
+}
+
+function reportMissingHelper(): never {
+  console.error('helper not built. Run: ./packages/computer-helper/scripts/build.sh debug');
+  process.exit(1);
+}
+
+// Line-delimited JSON-RPC client. The helper terminates on stdin EOF, so
+// each invocation = one short-lived helper process for one or two calls.
+// This is the same shape as `rush/app/native/computer-mac/scripts/probe.py`,
+// just in TypeScript.
+interface RPCResponse {
+  id: number | null;
+  result?: Record<string, unknown>;
+  error?: { code: string; message: string };
+}
+
+class HelperClient {
+  private proc: ChildProcessWithoutNullStreams;
+  private buf = '';
+  private waiters: Map<number, (r: RPCResponse) => void> = new Map();
+  private nextId = 1;
+  private exited = false;
+
+  constructor(helperPath: string) {
+    this.proc = spawn(helperPath, [], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    this.proc.stdout.setEncoding('utf8');
+    this.proc.stdout.on('data', (chunk: string) => {
+      this.buf += chunk;
+      let nl: number;
+      while ((nl = this.buf.indexOf('\n')) !== -1) {
+        const line = this.buf.slice(0, nl);
+        this.buf = this.buf.slice(nl + 1);
+        if (!line) continue;
+        try {
+          const obj = JSON.parse(line) as RPCResponse;
+          const id = typeof obj.id === 'number' ? obj.id : null;
+          if (id !== null && this.waiters.has(id)) {
+            const resolve = this.waiters.get(id)!;
+            this.waiters.delete(id);
+            resolve(obj);
+          }
+        } catch {
+          // Drop garbage; the helper writes diagnostics to stderr, not stdout.
+        }
+      }
+    });
+    this.proc.on('exit', () => {
+      this.exited = true;
+      // Resolve any pending waiters with an error so callers don't hang
+      // when the helper crashes.
+      for (const [id, resolve] of this.waiters) {
+        resolve({ id, error: { code: 'helper_exited', message: 'helper exited before reply' } });
+      }
+      this.waiters.clear();
+    });
+  }
+
+  async call(method: string, params?: Record<string, unknown>): Promise<RPCResponse> {
+    if (this.exited) {
+      return { id: null, error: { code: 'helper_exited', message: 'helper not running' } };
+    }
+    const id = this.nextId++;
+    const payload = JSON.stringify({ id, method, params: params ?? {} }) + '\n';
+    return new Promise((resolve) => {
+      this.waiters.set(id, resolve);
+      this.proc.stdin.write(payload);
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.exited) return;
+    this.proc.stdin.end();
+    await new Promise<void>((resolve) => {
+      if (this.exited) return resolve();
+      this.proc.on('exit', () => resolve());
+    });
+  }
+}
+
+function registerStatusCommand(program: Command): void {
+  program
+    .command('status')
+    .description('Report Accessibility trust + helper identity')
+    .action(async () => {
+      const helperPath = resolveHelperPath();
+      if (!helperPath) reportMissingHelper();
+
+      const client = new HelperClient(helperPath);
+      try {
+        const r = await client.call('trust_status');
+        if (r.error) {
+          console.error(`error: ${r.error.code}: ${r.error.message}`);
+          process.exit(1);
+        }
+        const trusted = Boolean(r.result?.trusted);
+        const helperPid = r.result?.pid;
+        console.log(`trust: ${trusted ? 'granted' : 'denied'}`);
+        console.log(`helper: ${helperPath}`);
+        if (typeof helperPid === 'number') console.log(`pid: ${helperPid}`);
+        if (!trusted) {
+          console.error('');
+          console.error('Accessibility is not granted to ComputerHelper.app.');
+          console.error('Open System Settings > Privacy & Security > Accessibility and add:');
+          console.error(`  ${path.resolve(helperPath, '..', '..', '..')}`);
+        }
+      } finally {
+        await client.close();
+      }
+    });
+}

--- a/src/commands/computer.ts
+++ b/src/commands/computer.ts
@@ -10,13 +10,16 @@ import {
   resolveHelperExec,
   resolveSocketPath,
   resolveLogPath,
+  resolvePolicyPath,
   describeTransport,
+  loadComputerAllowList,
+  writeComputerPolicy,
 } from '../lib/computer-rpc.js';
 
 // Help groups — mirror `agents browser` so the mental model carries over.
 const COMPUTER_HELP_GROUPS = [
   { title: 'Installation', names: ['install-helper'] },
-  { title: 'Daemon lifecycle', names: ['start', 'stop', 'status'] },
+  { title: 'Daemon lifecycle', names: ['start', 'stop', 'reload', 'status'] },
   { title: 'Capture evidence', names: ['screenshot'] },
 ] as const;
 
@@ -33,6 +36,7 @@ export function registerComputerSubcommands(program: Command): void {
   registerInstallHelperCommand(program);
   registerStartCommand(program);
   registerStopCommand(program);
+  registerReloadCommand(program);
   registerStatusCommand(program);
   registerScreenshotCommand(program);
   registerCommandGroups(program, COMPUTER_HELP_GROUPS);
@@ -54,6 +58,13 @@ function registerStatusCommand(program: Command): void {
 
       console.log(`installed: ${installed ? 'yes' : 'no'} (${HELPER_APP_DEST})`);
       console.log(`daemon:    ${socketUp ? 'running' : 'stopped'}`);
+
+      // Show the current allow list — what the user has actually authorized
+      // via Computer(...) patterns in their permission groups.
+      const allowed = loadComputerAllowList();
+      const previewParts = allowed.slice(0, 5);
+      const previewSuffix = allowed.length > 5 ? ` (+${allowed.length - 5} more)` : '';
+      console.log(`policy:    ${allowed.length} app${allowed.length === 1 ? '' : 's'} allowed${allowed.length > 0 ? `: ${previewParts.join(', ')}${previewSuffix}` : ''}`);
 
       if (!installed) {
         console.log('');
@@ -121,19 +132,17 @@ function registerScreenshotCommand(program: Command): void {
         if (opts.bundle) {
           target = list.find((a) => a.bundle_id === opts.bundle);
           if (!target) {
-            console.error(`bundle not running: ${opts.bundle}`);
+            console.error(`bundle not in allow list (or not running): ${opts.bundle}`);
+            console.error(`add Computer(${opts.bundle}) to a permissions group, then \`agents computer reload\``);
             process.exit(1);
           }
         } else {
           target = list.find((a) => a.active);
           if (!target) {
-            console.error('no active app found');
+            console.error('no active app found in allow list');
+            console.error('add Computer(<bundle-id>) to a permissions group, then `agents computer reload`');
             process.exit(1);
           }
-        }
-        if (target.excluded) {
-          console.error(`bundle is excluded by deny-list: ${target.bundle_id}`);
-          process.exit(1);
         }
 
         // Step 2: screenshot.
@@ -256,8 +265,14 @@ function registerInstallHelperCommand(program: Command): void {
       console.log('  1. Grant TCC permissions (one-time):');
       console.log('     System Settings > Privacy & Security > Accessibility       — add Computer Helper.app');
       console.log('     System Settings > Privacy & Security > Screen Recording    — add Computer Helper.app');
-      console.log('  2. When you want to use it:  agents computer start');
-      console.log('  3. When you are done:         agents computer stop');
+      console.log('  2. Whitelist the apps the daemon may drive. Add a YAML under ~/.agents/permissions/groups/:');
+      console.log('       name: computer');
+      console.log('       allow:');
+      console.log('         - "Computer(com.apple.mail)"');
+      console.log('         - "Computer(com.apple.notes)"');
+      console.log('     Default policy is deny-all.');
+      console.log('  3. When you want to use it:  agents computer start');
+      console.log('  4. When you are done:         agents computer stop');
     });
 }
 
@@ -288,6 +303,23 @@ function registerStartCommand(program: Command): void {
         process.exit(1);
       }
       const domain = `gui/${uid}`;
+
+      // Render the policy file BEFORE launchctl bootstrap so the daemon
+      // reads a fresh allow list at startup. The helper falls back to an
+      // empty allow list (everything denied) if this file is missing or
+      // unparseable — fail-safe.
+      const allowed = loadComputerAllowList();
+      writeComputerPolicy(allowed);
+      console.log(`policy: ${allowed.length} app${allowed.length === 1 ? '' : 's'} allowed (${resolvePolicyPath()})`);
+      if (allowed.length > 0) {
+        const preview = allowed.slice(0, 5).join(', ');
+        const more = allowed.length > 5 ? ` (+${allowed.length - 5} more)` : '';
+        console.log(`        ${preview}${more}`);
+      } else {
+        console.log(`        (no Computer(...) patterns found — everything will be denied)`);
+        console.log(`        add to ~/.agents/permissions/groups/<name>.yaml under allow:`);
+        console.log(`          - "Computer(com.apple.finder)"`);
+      }
 
       // Bootout first to clear any prior registration. Best-effort.
       try {
@@ -343,6 +375,70 @@ function registerStartCommand(program: Command): void {
       if (trustStr === 'denied') {
         console.log('');
         console.log('Grant Accessibility + Screen Recording to Computer Helper.app, then run `agents computer start` again.');
+      }
+    });
+}
+
+function registerReloadCommand(program: Command): void {
+  program
+    .command('reload')
+    .description('Reload the allow-list policy from ~/.agents/permissions/groups/ (SIGHUP the daemon)')
+    .action(async () => {
+      const socketPath = resolveSocketPath();
+      if (!fs.existsSync(socketPath)) {
+        console.error(`daemon not running (no socket at ${socketPath})`);
+        console.error('run: agents computer start');
+        process.exit(1);
+      }
+
+      const allowed = loadComputerAllowList();
+      writeComputerPolicy(allowed);
+      console.log(`policy: ${allowed.length} app${allowed.length === 1 ? '' : 's'} allowed (${resolvePolicyPath()})`);
+
+      // Resolve the daemon's pid via `launchctl list <label>`. The plist
+      // output includes a "PID" key when the service is running.
+      const uid = process.getuid?.();
+      if (typeof uid !== 'number') {
+        console.error('cannot resolve uid');
+        process.exit(1);
+      }
+      const domain = `gui/${uid}`;
+
+      let pid: number | null = null;
+      try {
+        const out = execFileSync('/bin/launchctl', ['print', `${domain}/${HELPER_LABEL}`], { encoding: 'utf-8' });
+        const m = out.match(/\bpid\s*=\s*(\d+)/);
+        if (m) pid = parseInt(m[1], 10);
+      } catch (err) {
+        console.error(`launchctl print failed: ${(err as Error).message}`);
+        process.exit(1);
+      }
+
+      if (pid === null || !Number.isFinite(pid) || pid <= 0) {
+        console.error('could not resolve daemon pid from launchctl print output');
+        process.exit(1);
+      }
+
+      try {
+        process.kill(pid, 'SIGHUP');
+      } catch (err) {
+        console.error(`kill -HUP ${pid} failed: ${(err as Error).message}`);
+        process.exit(1);
+      }
+
+      // Brief socket-up check so the user knows the daemon survived the
+      // signal (it should — SIGHUP just triggers a re-read).
+      await sleep(150);
+      if (!fs.existsSync(socketPath)) {
+        console.error(`socket disappeared after SIGHUP — check ${resolveLogPath()}`);
+        process.exit(1);
+      }
+
+      console.log(`reloaded: daemon pid ${pid}`);
+      if (allowed.length > 0) {
+        const preview = allowed.slice(0, 5).join(', ');
+        const more = allowed.length > 5 ? ` (+${allowed.length - 5} more)` : '';
+        console.log(`        ${preview}${more}`);
       }
     });
 }

--- a/src/commands/computer.ts
+++ b/src/commands/computer.ts
@@ -15,7 +15,8 @@ import {
 
 // Help groups — mirror `agents browser` so the mental model carries over.
 const COMPUTER_HELP_GROUPS = [
-  { title: 'Session lifecycle', names: ['status', 'install-helper'] },
+  { title: 'Installation', names: ['install-helper'] },
+  { title: 'Daemon lifecycle', names: ['start', 'stop', 'status'] },
   { title: 'Capture evidence', names: ['screenshot'] },
 ] as const;
 
@@ -29,9 +30,11 @@ export function registerComputerCommand(program: Command): void {
 }
 
 export function registerComputerSubcommands(program: Command): void {
+  registerInstallHelperCommand(program);
+  registerStartCommand(program);
+  registerStopCommand(program);
   registerStatusCommand(program);
   registerScreenshotCommand(program);
-  registerInstallHelperCommand(program);
   registerCommandGroups(program, COMPUTER_HELP_GROUPS);
 }
 
@@ -43,11 +46,27 @@ function reportMissingHelper(): never {
 function registerStatusCommand(program: Command): void {
   program
     .command('status')
-    .description('Report Accessibility trust + helper identity')
+    .description('Report install state, daemon state, and Accessibility trust')
     .action(async () => {
-      const transport = describeTransport();
-      if (transport.kind === 'none') reportMissingHelper();
+      const socketPath = resolveSocketPath();
+      const installed = fs.existsSync(HELPER_APP_DEST);
+      const socketUp = fs.existsSync(socketPath);
 
+      console.log(`installed: ${installed ? 'yes' : 'no'} (${HELPER_APP_DEST})`);
+      console.log(`daemon:    ${socketUp ? 'running' : 'stopped'}`);
+
+      if (!installed) {
+        console.log('');
+        console.log('Run:  agents computer install-helper');
+        return;
+      }
+      if (!socketUp) {
+        console.log('');
+        console.log('Run:  agents computer start');
+        return;
+      }
+
+      // Daemon is up — probe trust state.
       const client = openComputerClient();
       try {
         const r = await client.call('trust_status');
@@ -57,17 +76,11 @@ function registerStatusCommand(program: Command): void {
         }
         const trusted = Boolean(r.result?.trusted);
         const helperPid = r.result?.pid;
-        const helperPath = r.result?.path as string | undefined;
-        console.log(`trust: ${trusted ? 'granted' : 'denied'}`);
-        console.log(`transport: ${transport.kind} (${transport.path})`);
-        if (helperPath) console.log(`helper: ${helperPath}`);
-        if (typeof helperPid === 'number') console.log(`pid: ${helperPid}`);
+        console.log(`trust:     ${trusted ? 'granted' : 'denied'}`);
+        if (typeof helperPid === 'number') console.log(`pid:       ${helperPid}`);
         if (!trusted) {
-          const appPath = helperPath ? path.resolve(helperPath, '..', '..', '..') : HELPER_APP_DEST;
-          console.error('');
-          console.error('Accessibility is not granted to ComputerHelper.app.');
-          console.error('Open System Settings > Privacy & Security > Accessibility and add:');
-          console.error(`  ${appPath}`);
+          console.log('');
+          console.log('Grant Accessibility + Screen Recording in System Settings, then `agents computer start` again.');
         }
       } finally {
         await client.close();
@@ -167,7 +180,7 @@ const HELPER_LABEL = HELPER_BUNDLE_ID;
 function registerInstallHelperCommand(program: Command): void {
   program
     .command('install-helper')
-    .description('Install ComputerHelper.app to /Applications/, register launchd daemon, open Unix socket')
+    .description('Install ComputerHelper.app to /Applications/ (does NOT activate the daemon — run `start` to enable)')
     .action(async () => {
       const srcApp = resolveHelperApp();
       if (!srcApp || !fs.existsSync(srcApp)) {
@@ -214,14 +227,14 @@ function registerInstallHelperCommand(program: Command): void {
         process.exit(1);
       }
 
-      // 3. Ensure socket + log parent dirs exist. ~/.agents/.cache/helpers/
-      // is the canonical home for helper-subprocess scratch (matches the
-      // browser daemon's ~/.agents/.cache/helpers/browser.sock). logs/ is
-      // the runtime log bucket.
+      // 3. Ensure socket + log parent dirs exist.
       fs.mkdirSync(path.dirname(socketPath), { recursive: true });
       fs.mkdirSync(path.dirname(logPath), { recursive: true });
 
-      // 4. Write plist with HOME paths resolved (launchd does not expand ~).
+      // 4. Write the LaunchAgent plist but DO NOT bootstrap it. The user
+      // explicitly opts into running the daemon via `agents computer start`.
+      // Screen Recording + Accessibility are scary permissions; we don't
+      // want an always-on listener that can drive any app the user could.
       const execInsideApp = path.join(HELPER_APP_DEST, 'Contents', 'MacOS', 'ComputerHelper');
       const plistContent = renderLaunchAgentPlist({
         label: HELPER_LABEL,
@@ -231,72 +244,92 @@ function registerInstallHelperCommand(program: Command): void {
       });
       fs.mkdirSync(path.dirname(plistPath), { recursive: true });
       fs.writeFileSync(plistPath, plistContent);
-      console.log(`wrote plist: ${plistPath}`);
+      console.log(`wrote plist: ${plistPath} (NOT activated)`);
 
-      // 5. Load via launchctl. UID-keyed gui/ domain so it runs at login.
+      console.log('');
+      console.log('Helper installed (inactive).');
+      console.log('');
+      console.log(`  app:    ${HELPER_APP_DEST}`);
+      console.log(`  plist:  ${plistPath}`);
+      console.log('');
+      console.log('Next steps:');
+      console.log('  1. Grant TCC permissions (one-time):');
+      console.log('     System Settings > Privacy & Security > Accessibility       — add Computer Helper.app');
+      console.log('     System Settings > Privacy & Security > Screen Recording    — add Computer Helper.app');
+      console.log('  2. When you want to use it:  agents computer start');
+      console.log('  3. When you are done:         agents computer stop');
+    });
+}
+
+function registerStartCommand(program: Command): void {
+  program
+    .command('start')
+    .description('Activate the helper daemon (loads launchd, opens socket)')
+    .action(async () => {
+      const home = os.homedir();
+      const plistPath = path.join(home, 'Library', 'LaunchAgents', `${HELPER_LABEL}.plist`);
+      const socketPath = resolveSocketPath();
+      const logPath = resolveLogPath();
+
+      if (!fs.existsSync(plistPath)) {
+        console.error(`plist not found at ${plistPath}`);
+        console.error('run: agents computer install-helper');
+        process.exit(1);
+      }
+      if (!fs.existsSync(HELPER_APP_DEST)) {
+        console.error(`helper app not found at ${HELPER_APP_DEST}`);
+        console.error('run: agents computer install-helper');
+        process.exit(1);
+      }
+
       const uid = process.getuid?.();
       if (typeof uid !== 'number') {
-        console.error('cannot resolve uid (process.getuid unavailable)');
+        console.error('cannot resolve uid');
         process.exit(1);
       }
       const domain = `gui/${uid}`;
 
-      // Bootout first to clear any prior registration. Ignore failure
-      // (most common when nothing is loaded yet).
+      // Bootout first to clear any prior registration. Best-effort.
       try {
         execFileSync('/bin/launchctl', ['bootout', domain, plistPath], { stdio: 'pipe' });
-        console.log('launchctl bootout: ok (cleared prior registration)');
       } catch {
         // expected when not previously loaded
       }
 
       try {
-        execFileSync('/bin/launchctl', ['bootstrap', domain, plistPath], { stdio: 'inherit' });
-        console.log('launchctl bootstrap: ok');
+        execFileSync('/bin/launchctl', ['bootstrap', domain, plistPath], { stdio: 'pipe' });
       } catch (err) {
         console.error(`launchctl bootstrap failed: ${(err as Error).message}`);
-        console.error('the plist may be malformed or the label already in use.');
         process.exit(1);
       }
 
-      // Kickstart -k: force restart so we pick up the new binary even if a
-      // previous instance is still running.
+      // Force restart so we pick up the latest binary.
       try {
-        execFileSync('/bin/launchctl', ['kickstart', '-k', `${domain}/${HELPER_LABEL}`], { stdio: 'inherit' });
-        console.log('launchctl kickstart: ok');
+        execFileSync('/bin/launchctl', ['kickstart', '-k', `${domain}/${HELPER_LABEL}`], { stdio: 'pipe' });
       } catch (err) {
         console.error(`launchctl kickstart failed: ${(err as Error).message}`);
         process.exit(1);
       }
 
-      // 6. Wait up to 5s for the socket to appear.
+      // Wait up to 5s for the socket.
       const deadline = Date.now() + 5000;
-      let socketReady = false;
       while (Date.now() < deadline) {
-        if (fs.existsSync(socketPath)) {
-          socketReady = true;
-          break;
-        }
+        if (fs.existsSync(socketPath)) break;
         await sleep(100);
       }
-      if (!socketReady) {
+      if (!fs.existsSync(socketPath)) {
         console.error(`socket did not appear at ${socketPath} within 5s`);
         console.error(`check ${logPath} for helper startup errors`);
         process.exit(1);
       }
-      console.log(`socket up: ${socketPath}`);
 
-      // 7. Probe trust_status through the socket.
+      // Probe trust through the socket.
       let trustStr = 'unknown';
       try {
         const client = openComputerClient();
         try {
           const r = await client.call('trust_status');
-          if (r.error) {
-            trustStr = `error (${r.error.code})`;
-          } else {
-            trustStr = r.result?.trusted ? 'granted' : 'denied';
-          }
+          trustStr = r.error ? `error (${r.error.code})` : (r.result?.trusted ? 'granted' : 'denied');
         } finally {
           await client.close();
         }
@@ -304,24 +337,45 @@ function registerInstallHelperCommand(program: Command): void {
         trustStr = `error (${(err as Error).message})`;
       }
 
-      console.log('');
-      console.log('Helper installed.');
-      console.log('');
-      console.log(`  app:    ${HELPER_APP_DEST}`);
-      console.log(`  socket: ${socketPath}`);
-      console.log(`  log:    ${logPath}`);
-      console.log(`  trust:  ${trustStr}`);
-      console.log('');
-      if (trustStr !== 'granted') {
-        console.log('One-time setup (only needed if trust is \'denied\'):');
-        console.log('  1. Open: System Settings > Privacy & Security > Accessibility');
-        console.log('  2. Click the + button, navigate to /Applications/');
-        console.log(`  3. Add: ${HELPER_APP_NAME}`);
-        console.log('  4. Toggle it ON');
+      console.log(`daemon: running`);
+      console.log(`socket: ${socketPath}`);
+      console.log(`trust:  ${trustStr}`);
+      if (trustStr === 'denied') {
         console.log('');
-        console.log('After granting, run: agents computer status');
-      } else {
-        console.log('Trust already granted. Try: agents computer status');
+        console.log('Grant Accessibility + Screen Recording to Computer Helper.app, then run `agents computer start` again.');
+      }
+    });
+}
+
+function registerStopCommand(program: Command): void {
+  program
+    .command('stop')
+    .description('Deactivate the helper daemon (bootout, removes socket)')
+    .action(async () => {
+      const home = os.homedir();
+      const plistPath = path.join(home, 'Library', 'LaunchAgents', `${HELPER_LABEL}.plist`);
+      const socketPath = resolveSocketPath();
+
+      const uid = process.getuid?.();
+      if (typeof uid !== 'number') {
+        console.error('cannot resolve uid');
+        process.exit(1);
+      }
+      const domain = `gui/${uid}`;
+
+      try {
+        execFileSync('/bin/launchctl', ['bootout', domain, plistPath], { stdio: 'pipe' });
+      } catch {
+        // already gone — fine
+      }
+
+      // launchd unlinks the socket when the daemon exits; helper also has an
+      // atexit unlink. Best-effort cleanup if either path didn't fire.
+      try { fs.unlinkSync(socketPath); } catch {}
+
+      console.log('daemon: stopped');
+      if (fs.existsSync(socketPath)) {
+        console.warn(`(socket still present at ${socketPath} — may belong to a different process)`);
       }
     });
 }

--- a/src/commands/computer.ts
+++ b/src/commands/computer.ts
@@ -63,7 +63,7 @@ function registerStatusCommand(program: Command): void {
         if (helperPath) console.log(`helper: ${helperPath}`);
         if (typeof helperPid === 'number') console.log(`pid: ${helperPid}`);
         if (!trusted) {
-          const appPath = helperPath ? path.resolve(helperPath, '..', '..', '..') : '/Applications/Swarmify Computer Helper.app';
+          const appPath = helperPath ? path.resolve(helperPath, '..', '..', '..') : HELPER_APP_DEST;
           console.error('');
           console.error('Accessibility is not granted to ComputerHelper.app.');
           console.error('Open System Settings > Privacy & Security > Accessibility and add:');
@@ -148,7 +148,7 @@ function registerScreenshotCommand(program: Command): void {
 
 // install-helper:
 //   1. resolve dist .app
-//   2. copy to /Applications/Swarmify Computer Helper.app
+//   2. copy to /Applications/Computer Helper.app
 //   3. codesign --verify the destination
 //   4. write LaunchAgent plist with absolute HOME paths
 //   5. launchctl bootout (ignore failure) -> bootstrap -> kickstart -k
@@ -159,8 +159,8 @@ function registerScreenshotCommand(program: Command): void {
 // .app at a stable absolute path under /Applications/ means the AX grant
 // survives across npm updates. The CLI itself is unsigned but doesn't
 // need AX — it sends JSON-RPC to the daemon, which has AX.
-const HELPER_BUNDLE_ID = 'dev.swarmify.computer-helper';
-const HELPER_APP_NAME = 'Swarmify Computer Helper.app';
+const HELPER_BUNDLE_ID = 'com.phnx-labs.computer-helper';
+const HELPER_APP_NAME = 'Computer Helper.app';
 const HELPER_APP_DEST = `/Applications/${HELPER_APP_NAME}`;
 const HELPER_LABEL = HELPER_BUNDLE_ID;
 

--- a/src/commands/computer.ts
+++ b/src/commands/computer.ts
@@ -9,6 +9,7 @@ import {
   resolveHelperApp,
   resolveHelperExec,
   resolveSocketPath,
+  resolveLogPath,
   describeTransport,
 } from '../lib/computer-rpc.js';
 
@@ -175,9 +176,8 @@ function registerInstallHelperCommand(program: Command): void {
       }
 
       const home = os.homedir();
-      const agentsDir = path.join(home, '.agents');
-      const socketPath = path.join(agentsDir, 'computer-helper.sock');
-      const logPath = path.join(agentsDir, 'computer-helper.log');
+      const socketPath = resolveSocketPath();
+      const logPath = resolveLogPath();
       const plistPath = path.join(home, 'Library', 'LaunchAgents', `${HELPER_LABEL}.plist`);
 
       console.log(`source:  ${srcApp}`);
@@ -214,8 +214,12 @@ function registerInstallHelperCommand(program: Command): void {
         process.exit(1);
       }
 
-      // 3. Ensure ~/.agents/ exists.
-      fs.mkdirSync(agentsDir, { recursive: true });
+      // 3. Ensure socket + log parent dirs exist. ~/.agents/.cache/helpers/
+      // is the canonical home for helper-subprocess scratch (matches the
+      // browser daemon's ~/.agents/.cache/helpers/browser.sock). logs/ is
+      // the runtime log bucket.
+      fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+      fs.mkdirSync(path.dirname(logPath), { recursive: true });
 
       // 4. Write plist with HOME paths resolved (launchd does not expand ~).
       const execInsideApp = path.join(HELPER_APP_DEST, 'Contents', 'MacOS', 'ComputerHelper');

--- a/src/commands/computer.ts
+++ b/src/commands/computer.ts
@@ -1,16 +1,18 @@
 import { Command } from 'commander';
-import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import { execFileSync, spawn, type ChildProcessWithoutNullStreams } from 'child_process';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { registerCommandGroups } from '../lib/help.js';
+import { openComputerClient, resolveHelperApp } from '../lib/computer-rpc.js';
 
 // Help groups — mirror `agents browser` so the mental model carries over.
 // For this first chunk we ship two commands; the structure leaves room
 // for the future "drive the page" / "capture evidence" groups without
 // re-shuffling.
 const COMPUTER_HELP_GROUPS = [
-  { title: 'Session lifecycle', names: ['status'] },
+  { title: 'Session lifecycle', names: ['status', 'install-helper'] },
   { title: 'Capture evidence', names: ['screenshot'] },
 ] as const;
 
@@ -26,6 +28,7 @@ export function registerComputerCommand(program: Command): void {
 export function registerComputerSubcommands(program: Command): void {
   registerStatusCommand(program);
   registerScreenshotCommand(program);
+  registerInstallHelperCommand(program);
   registerCommandGroups(program, COMPUTER_HELP_GROUPS);
 }
 
@@ -236,4 +239,222 @@ function registerScreenshotCommand(program: Command): void {
         await client.close();
       }
     });
+}
+
+// install-helper:
+//   1. resolve dist .app
+//   2. copy to /Applications/Swarmify Computer Helper.app
+//   3. codesign --verify the destination
+//   4. write LaunchAgent plist with absolute HOME paths
+//   5. launchctl bootout (ignore failure) -> bootstrap -> kickstart -k
+//   6. wait for socket to appear
+//   7. probe trust_status, print grant instructions if needed
+//
+// macOS TCC is keyed by signed-bundle identity + bundle id. Putting the
+// .app at a stable absolute path under /Applications/ means the AX grant
+// survives across npm updates. The CLI itself is unsigned but doesn't
+// need AX — it sends JSON-RPC to the daemon, which has AX.
+const HELPER_BUNDLE_ID = 'dev.swarmify.computer-helper';
+const HELPER_APP_NAME = 'Swarmify Computer Helper.app';
+const HELPER_APP_DEST = `/Applications/${HELPER_APP_NAME}`;
+const HELPER_LABEL = HELPER_BUNDLE_ID;
+
+function registerInstallHelperCommand(program: Command): void {
+  program
+    .command('install-helper')
+    .description('Install ComputerHelper.app to /Applications/, register launchd daemon, open Unix socket')
+    .action(async () => {
+      const srcApp = resolveHelperApp();
+      if (!srcApp || !fs.existsSync(srcApp)) {
+        console.error('helper not built. Run: ./packages/computer-helper/scripts/build.sh debug');
+        process.exit(1);
+      }
+
+      const home = os.homedir();
+      const agentsDir = path.join(home, '.agents');
+      const socketPath = path.join(agentsDir, 'computer-helper.sock');
+      const logPath = path.join(agentsDir, 'computer-helper.log');
+      const plistPath = path.join(home, 'Library', 'LaunchAgents', `${HELPER_LABEL}.plist`);
+
+      console.log(`source:  ${srcApp}`);
+      console.log(`dest:    ${HELPER_APP_DEST}`);
+
+      // 1. Copy to /Applications/. Use ditto to preserve xattrs (Gatekeeper
+      // provenance + codesign metadata). Wipe any prior install first.
+      if (fs.existsSync(HELPER_APP_DEST)) {
+        try {
+          fs.rmSync(HELPER_APP_DEST, { recursive: true, force: true });
+          console.log(`removed prior install`);
+        } catch (err) {
+          console.error(`failed to remove prior install at ${HELPER_APP_DEST}: ${(err as Error).message}`);
+          console.error('try: sudo rm -rf "' + HELPER_APP_DEST + '"');
+          process.exit(1);
+        }
+      }
+      try {
+        execFileSync('/usr/bin/ditto', [srcApp, HELPER_APP_DEST], { stdio: 'inherit' });
+      } catch (err) {
+        console.error(`ditto copy failed: ${(err as Error).message}`);
+        process.exit(1);
+      }
+      console.log(`copied to ${HELPER_APP_DEST}`);
+
+      // 2. Verify codesign on the destination. Fail loud if the copy
+      // somehow stripped the signature — TCC needs a valid signature.
+      try {
+        execFileSync('/usr/bin/codesign', ['--verify', '--deep', '--strict', HELPER_APP_DEST], { stdio: 'inherit' });
+        console.log('codesign verify: OK');
+      } catch {
+        console.error('codesign verify FAILED. The destination .app is unsigned or its signature was stripped.');
+        console.error('rebuild the helper with a Developer ID cert: ./packages/computer-helper/scripts/build.sh release');
+        process.exit(1);
+      }
+
+      // 3. Ensure ~/.agents/ exists.
+      fs.mkdirSync(agentsDir, { recursive: true });
+
+      // 4. Write plist with HOME paths resolved (launchd does not expand ~).
+      const execInsideApp = path.join(HELPER_APP_DEST, 'Contents', 'MacOS', 'ComputerHelper');
+      const plistContent = renderLaunchAgentPlist({
+        label: HELPER_LABEL,
+        exec: execInsideApp,
+        socketPath,
+        logPath,
+      });
+      fs.mkdirSync(path.dirname(plistPath), { recursive: true });
+      fs.writeFileSync(plistPath, plistContent);
+      console.log(`wrote plist: ${plistPath}`);
+
+      // 5. Load via launchctl. UID-keyed gui/ domain so it runs at login.
+      const uid = process.getuid?.();
+      if (typeof uid !== 'number') {
+        console.error('cannot resolve uid (process.getuid unavailable)');
+        process.exit(1);
+      }
+      const domain = `gui/${uid}`;
+
+      // Bootout first to clear any prior registration. Ignore failure
+      // (most common when nothing is loaded yet).
+      try {
+        execFileSync('/bin/launchctl', ['bootout', domain, plistPath], { stdio: 'pipe' });
+        console.log('launchctl bootout: ok (cleared prior registration)');
+      } catch {
+        // expected when not previously loaded
+      }
+
+      try {
+        execFileSync('/bin/launchctl', ['bootstrap', domain, plistPath], { stdio: 'inherit' });
+        console.log('launchctl bootstrap: ok');
+      } catch (err) {
+        console.error(`launchctl bootstrap failed: ${(err as Error).message}`);
+        console.error('the plist may be malformed or the label already in use.');
+        process.exit(1);
+      }
+
+      // Kickstart -k: force restart so we pick up the new binary even if a
+      // previous instance is still running.
+      try {
+        execFileSync('/bin/launchctl', ['kickstart', '-k', `${domain}/${HELPER_LABEL}`], { stdio: 'inherit' });
+        console.log('launchctl kickstart: ok');
+      } catch (err) {
+        console.error(`launchctl kickstart failed: ${(err as Error).message}`);
+        process.exit(1);
+      }
+
+      // 6. Wait up to 5s for the socket to appear.
+      const deadline = Date.now() + 5000;
+      let socketReady = false;
+      while (Date.now() < deadline) {
+        if (fs.existsSync(socketPath)) {
+          socketReady = true;
+          break;
+        }
+        await sleep(100);
+      }
+      if (!socketReady) {
+        console.error(`socket did not appear at ${socketPath} within 5s`);
+        console.error(`check ${logPath} for helper startup errors`);
+        process.exit(1);
+      }
+      console.log(`socket up: ${socketPath}`);
+
+      // 7. Probe trust_status through the socket.
+      let trustStr = 'unknown';
+      try {
+        const client = openComputerClient();
+        try {
+          const r = await client.call('trust_status');
+          if (r.error) {
+            trustStr = `error (${r.error.code})`;
+          } else {
+            trustStr = r.result?.trusted ? 'granted' : 'denied';
+          }
+        } finally {
+          await client.close();
+        }
+      } catch (err) {
+        trustStr = `error (${(err as Error).message})`;
+      }
+
+      console.log('');
+      console.log('Helper installed.');
+      console.log('');
+      console.log(`  app:    ${HELPER_APP_DEST}`);
+      console.log(`  socket: ${socketPath}`);
+      console.log(`  log:    ${logPath}`);
+      console.log(`  trust:  ${trustStr}`);
+      console.log('');
+      if (trustStr !== 'granted') {
+        console.log('One-time setup (only needed if trust is \'denied\'):');
+        console.log('  1. Open: System Settings > Privacy & Security > Accessibility');
+        console.log('  2. Click the + button, navigate to /Applications/');
+        console.log(`  3. Add: ${HELPER_APP_NAME}`);
+        console.log('  4. Toggle it ON');
+        console.log('');
+        console.log('After granting, run: agents computer status');
+      } else {
+        console.log('Trust already granted. Try: agents computer status');
+      }
+    });
+}
+
+function renderLaunchAgentPlist(opts: { label: string; exec: string; socketPath: string; logPath: string }): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${escapeXml(opts.label)}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${escapeXml(opts.exec)}</string>
+        <string>--socket</string>
+        <string>${escapeXml(opts.socketPath)}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>StandardErrorPath</key>
+    <string>${escapeXml(opts.logPath)}</string>
+    <key>StandardOutPath</key>
+    <string>${escapeXml(opts.logPath)}</string>
+</dict>
+</plist>
+`;
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/computer.ts
+++ b/src/computer.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { registerComputerSubcommands } from './commands/computer.js';
+
+const program = new Command();
+program.name('computer').description('Drive macOS apps via Accessibility — list, screenshot, click, type');
+registerComputerSubcommands(program);
+program.parse();

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ import { registerRefreshRulesCommand } from './commands/refresh-rules.js';
 import { registerDriveCommands } from './commands/drive.js';
 import { registerPtyCommands } from './commands/pty.js';
 import { registerBrowserCommand } from './commands/browser.js';
+import { registerComputerCommand } from './commands/computer.js';
 import { registerProfilesCommands } from './commands/profiles.js';
 import { registerSecretsCommands } from './commands/secrets.js';
 import { registerFactoryCommands } from './commands/factory.js';
@@ -611,6 +612,7 @@ registerUsageCommand(program);
 registerAliasCommand(program);
 registerPtyCommands(program);
 registerBrowserCommand(program);
+registerComputerCommand(program);
 
 // Deprecated 'jobs' and 'cron' aliases for 'routines'
 for (const alias of ['jobs', 'cron']) {

--- a/src/lib/computer-rpc.ts
+++ b/src/lib/computer-rpc.ts
@@ -15,21 +15,9 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
 import { createConnection, type Socket } from 'net';
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-
-// Path matches the agents-cli convention codified in src/lib/state.ts —
-// ~/.agents/.cache/helpers/ is the bucket for helper subprocess scratch
-// (sibling: browser.sock). Hard-coded here because state.ts currently has
-// unresolved merge-conflict markers; switch to getHelpersDir() import once
-// the upstream state.ts is repaired.
-function helpersDir(): string {
-  return path.join(os.homedir(), '.agents', '.cache', 'helpers');
-}
-function logsDir(): string {
-  return path.join(os.homedir(), '.agents', '.cache', 'logs');
-}
+import { getHelpersDir, getLogsDir } from './state.js';
 
 export interface RPCResponse {
   id: number | null;
@@ -48,13 +36,13 @@ export interface ComputerClient {
 export function resolveSocketPath(): string {
   const envPath = process.env.COMPUTER_HELPER_SOCKET;
   if (envPath && envPath.length > 0) return envPath;
-  return path.join(helpersDir(), 'computer.sock');
+  return path.join(getHelpersDir(), 'computer.sock');
 }
 
 // Default log path for the launchd-managed daemon. Lives in the cache/logs/
 // bucket (matches the scheduler daemon's logs.jsonl convention).
 export function resolveLogPath(): string {
-  return path.join(logsDir(), 'computer-helper.log');
+  return path.join(getLogsDir(), 'computer-helper.log');
 }
 
 // Resolve the helper executable inside the dist .app bundle. Used by the

--- a/src/lib/computer-rpc.ts
+++ b/src/lib/computer-rpc.ts
@@ -1,8 +1,9 @@
 // JSON-RPC client for the computer-helper.
 //
 // Two transports, picked at runtime:
-//   - socket: ~/.agents/computer-helper.sock (or COMPUTER_HELPER_SOCKET env)
-//     when the launchd daemon is installed and listening. Sub-50ms per call.
+//   - socket: ~/.agents/.cache/helpers/computer.sock (or COMPUTER_HELPER_SOCKET
+//     env) when the launchd daemon is installed and listening. Sub-50ms per
+//     call. Path is internal scratch — sibling of browser.sock.
 //   - stdio: spawn the helper binary as a child process per call. Used in
 //     dev (no install-helper) and as a fallback. The legacy probe.py and
 //     drive-capcut.py scripts in rush/agents still use this shape.
@@ -18,6 +19,18 @@ import * as os from 'os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
+// Path matches the agents-cli convention codified in src/lib/state.ts —
+// ~/.agents/.cache/helpers/ is the bucket for helper subprocess scratch
+// (sibling: browser.sock). Hard-coded here because state.ts currently has
+// unresolved merge-conflict markers; switch to getHelpersDir() import once
+// the upstream state.ts is repaired.
+function helpersDir(): string {
+  return path.join(os.homedir(), '.agents', '.cache', 'helpers');
+}
+function logsDir(): string {
+  return path.join(os.homedir(), '.agents', '.cache', 'logs');
+}
+
 export interface RPCResponse {
   id: number | null;
   result?: Record<string, unknown>;
@@ -29,11 +42,19 @@ export interface ComputerClient {
   close(): Promise<void>;
 }
 
-// Resolve the socket path used by the launchd-managed daemon.
+// Resolve the socket path used by the launchd-managed daemon. Internal
+// scratch — lives under getHelpersDir() (~/.agents/.cache/helpers/),
+// matching browser.sock.
 export function resolveSocketPath(): string {
   const envPath = process.env.COMPUTER_HELPER_SOCKET;
   if (envPath && envPath.length > 0) return envPath;
-  return path.join(os.homedir(), '.agents', 'computer-helper.sock');
+  return path.join(helpersDir(), 'computer.sock');
+}
+
+// Default log path for the launchd-managed daemon. Lives in the cache/logs/
+// bucket (matches the scheduler daemon's logs.jsonl convention).
+export function resolveLogPath(): string {
+  return path.join(logsDir(), 'computer-helper.log');
 }
 
 // Resolve the helper executable inside the dist .app bundle. Used by the

--- a/src/lib/computer-rpc.ts
+++ b/src/lib/computer-rpc.ts
@@ -1,0 +1,197 @@
+// JSON-RPC client for the computer-helper.
+//
+// Two transports, picked at runtime:
+//   - socket: ~/.agents/computer-helper.sock (or COMPUTER_HELPER_SOCKET env)
+//     when the launchd daemon is installed and listening. Sub-50ms per call.
+//   - stdio: spawn the helper binary as a child process per call. Used in
+//     dev (no install-helper) and as a fallback. The legacy probe.py and
+//     drive-capcut.py scripts in rush/agents still use this shape.
+//
+// Both transports share the same line-delimited JSON-RPC wire format:
+//   in:  {"id":N,"method":"...","params":{...}}
+//   out: {"id":N,"result":{...}} or {"id":N,"error":{"code":"...","message":"..."}}
+
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import { createConnection, type Socket } from 'net';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+export interface RPCResponse {
+  id: number | null;
+  result?: Record<string, unknown>;
+  error?: { code: string; message: string };
+}
+
+export interface ComputerClient {
+  call(method: string, params?: Record<string, unknown>): Promise<RPCResponse>;
+  close(): Promise<void>;
+}
+
+// Resolve the socket path used by the launchd-managed daemon.
+export function resolveSocketPath(): string {
+  const envPath = process.env.COMPUTER_HELPER_SOCKET;
+  if (envPath && envPath.length > 0) return envPath;
+  return path.join(os.homedir(), '.agents', 'computer-helper.sock');
+}
+
+// Resolve the helper executable inside the dist .app bundle. Used by the
+// stdio fallback and by install-helper to find the source bundle.
+export function resolveHelperExec(): string | null {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    // Local build (running from the agents-cli checkout).
+    path.resolve(here, '..', '..', 'packages', 'computer-helper', 'dist', 'ComputerHelper.app', 'Contents', 'MacOS', 'ComputerHelper'),
+    // Bundled with the npm package (later: CDN download lands here).
+    path.resolve(here, '..', 'computer-helper', 'ComputerHelper.app', 'Contents', 'MacOS', 'ComputerHelper'),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  return null;
+}
+
+// Resolve the dist .app bundle directory (not the inner exec).
+export function resolveHelperApp(): string | null {
+  const exec = resolveHelperExec();
+  if (!exec) return null;
+  // exec = <bundle>/Contents/MacOS/ComputerHelper
+  return path.resolve(exec, '..', '..', '..');
+}
+
+// Pick the best transport. If the socket exists, use it. Otherwise fall
+// back to spawning the helper as a subprocess (legacy path).
+export function openComputerClient(): ComputerClient {
+  const sockPath = resolveSocketPath();
+  if (fs.existsSync(sockPath)) {
+    return new SocketClient(sockPath);
+  }
+  const helperExec = resolveHelperExec();
+  if (!helperExec) {
+    throw new Error('helper not built. Run: ./packages/computer-helper/scripts/build.sh debug');
+  }
+  return new StdioClient(helperExec);
+}
+
+// Shared waiter map + line parser. Both transports plug their reader into
+// `handleChunk` and their writer into `send`.
+abstract class BaseClient implements ComputerClient {
+  protected buf = '';
+  protected waiters = new Map<number, (r: RPCResponse) => void>();
+  protected nextId = 1;
+  protected closed = false;
+
+  protected handleChunk(chunk: string): void {
+    this.buf += chunk;
+    let nl: number;
+    while ((nl = this.buf.indexOf('\n')) !== -1) {
+      const line = this.buf.slice(0, nl);
+      this.buf = this.buf.slice(nl + 1);
+      if (!line) continue;
+      try {
+        const obj = JSON.parse(line) as RPCResponse;
+        const id = typeof obj.id === 'number' ? obj.id : null;
+        if (id !== null && this.waiters.has(id)) {
+          const resolve = this.waiters.get(id)!;
+          this.waiters.delete(id);
+          resolve(obj);
+        }
+      } catch {
+        // Drop garbage; helper diagnostics go to stderr / log file.
+      }
+    }
+  }
+
+  protected failPending(code: string, message: string): void {
+    for (const [id, resolve] of this.waiters) {
+      resolve({ id, error: { code, message } });
+    }
+    this.waiters.clear();
+  }
+
+  async call(method: string, params?: Record<string, unknown>): Promise<RPCResponse> {
+    if (this.closed) {
+      return { id: null, error: { code: 'helper_exited', message: 'helper not running' } };
+    }
+    const id = this.nextId++;
+    const payload = JSON.stringify({ id, method, params: params ?? {} }) + '\n';
+    return new Promise((resolve) => {
+      this.waiters.set(id, resolve);
+      this.send(payload);
+    });
+  }
+
+  protected abstract send(payload: string): void;
+  abstract close(): Promise<void>;
+}
+
+class SocketClient extends BaseClient {
+  private sock: Socket;
+
+  constructor(socketPath: string) {
+    super();
+    this.sock = createConnection({ path: socketPath });
+    this.sock.setEncoding('utf8');
+    this.sock.on('data', (chunk: string) => this.handleChunk(chunk));
+    this.sock.on('error', (err) => {
+      this.closed = true;
+      this.failPending('socket_error', err.message);
+    });
+    this.sock.on('close', () => {
+      this.closed = true;
+      this.failPending('helper_exited', 'socket closed before reply');
+    });
+  }
+
+  protected send(payload: string): void {
+    this.sock.write(payload);
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.sock.end();
+    await new Promise<void>((resolve) => {
+      if (this.closed) return resolve();
+      this.sock.on('close', () => resolve());
+    });
+  }
+}
+
+class StdioClient extends BaseClient {
+  private proc: ChildProcessWithoutNullStreams;
+
+  constructor(helperPath: string) {
+    super();
+    this.proc = spawn(helperPath, [], { stdio: ['pipe', 'pipe', 'pipe'] });
+    this.proc.stdout.setEncoding('utf8');
+    this.proc.stdout.on('data', (chunk: string) => this.handleChunk(chunk));
+    this.proc.on('exit', () => {
+      this.closed = true;
+      this.failPending('helper_exited', 'helper exited before reply');
+    });
+  }
+
+  protected send(payload: string): void {
+    this.proc.stdin.write(payload);
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.proc.stdin.end();
+    await new Promise<void>((resolve) => {
+      if (this.closed) return resolve();
+      this.proc.on('exit', () => resolve());
+    });
+  }
+}
+
+// Describe which transport is currently in use. Useful for diagnostics
+// like `agents computer status`.
+export function describeTransport(): { kind: 'socket' | 'stdio' | 'none'; path: string | null } {
+  const sockPath = resolveSocketPath();
+  if (fs.existsSync(sockPath)) return { kind: 'socket', path: sockPath };
+  const exec = resolveHelperExec();
+  if (exec) return { kind: 'stdio', path: exec };
+  return { kind: 'none', path: null };
+}

--- a/src/lib/computer-rpc.ts
+++ b/src/lib/computer-rpc.ts
@@ -17,7 +17,7 @@ import { createConnection, type Socket } from 'net';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { getHelpersDir, getLogsDir } from './state.js';
+import { getHelpersDir, getLogsDir, getUserPermissionsDir, getPermissionsDir } from './state.js';
 
 export interface RPCResponse {
   id: number | null;
@@ -43,6 +43,87 @@ export function resolveSocketPath(): string {
 // bucket (matches the scheduler daemon's logs.jsonl convention).
 export function resolveLogPath(): string {
   return path.join(getLogsDir(), 'computer-helper.log');
+}
+
+// Policy file the helper reads at startup and on SIGHUP. Sibling of
+// computer.sock under ~/.agents/.cache/helpers/. Allow-list of bare bundle
+// ids (e.g. "com.apple.mail"), derived from Computer(...) patterns in
+// ~/.agents/permissions/groups/.
+export function resolvePolicyPath(): string {
+  return path.join(getHelpersDir(), 'computer-policy.json');
+}
+
+// Walk all permission group YAMLs (user dir wins on name collision) and
+// collect Computer(<bundle-id>) patterns from each group's `allow:` list.
+// Returns distinct bundle ids. Line-by-line regex extraction matches
+// buildPermissionsFromGroups: YAML parsers stumble on the nested quotes in
+// some rule values, but the strict pattern below catches our shape cleanly.
+export function loadComputerAllowList(): string[] {
+  const seenFiles = new Set<string>();
+  const allowed = new Set<string>();
+
+  for (const baseDir of [getUserPermissionsDir(), getPermissionsDir()]) {
+    const groupsDir = path.join(baseDir, 'groups');
+    if (!fs.existsSync(groupsDir)) continue;
+
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(groupsDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      if (!entry.name.endsWith('.yml') && !entry.name.endsWith('.yaml')) continue;
+
+      // User dir wins on filename collision.
+      const stem = entry.name.replace(/\.(yaml|yml)$/, '');
+      if (seenFiles.has(stem)) continue;
+      seenFiles.add(stem);
+
+      const filePath = path.join(groupsDir, entry.name);
+      let content: string;
+      try {
+        content = fs.readFileSync(filePath, 'utf-8');
+      } catch {
+        continue;
+      }
+
+      // Strict regex: optional whitespace, dash, quoted Computer(<id>).
+      // Only honors `allow:` lines — `deny:` Computer patterns would be a
+      // contradiction (everything is deny-by-default already).
+      let inAllow = false;
+      for (const rawLine of content.split('\n')) {
+        const line = rawLine.replace(/\r$/, '');
+        const sectionMatch = line.match(/^(\w+)\s*:\s*$/);
+        if (sectionMatch) {
+          inAllow = sectionMatch[1] === 'allow';
+          continue;
+        }
+        if (!inAllow) continue;
+        const ruleMatch = line.match(/^\s*-\s*"Computer\(([^)]+)\)"\s*$/);
+        if (ruleMatch) {
+          const bundleId = ruleMatch[1].trim();
+          if (bundleId.length > 0) allowed.add(bundleId);
+        }
+      }
+    }
+  }
+
+  return [...allowed].sort();
+}
+
+// Write the policy file the helper reads at startup and on SIGHUP.
+// Mode 0600 — same lockdown as the socket (lives in the user-owned cache
+// dir, but be explicit).
+export function writeComputerPolicy(allowedBundleIds: string[]): void {
+  const dir = getHelpersDir();
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  const policy = { allow: allowedBundleIds };
+  fs.writeFileSync(resolvePolicyPath(), JSON.stringify(policy, null, 2), { mode: 0o600 });
 }
 
 // Resolve the helper executable inside the dist .app bundle. Used by the


### PR DESCRIPTION
## Summary

Adds `agents computer` — a macOS native automation surface, sibling of `agents browser`. Drives any AX-accessible app (Mail, Calendar, Notes, Finder, etc.) via line-delimited JSON-RPC over a Unix socket. Focus-safe by design: no iTerm bridge, no \`open -a\`, no synthetic mouse events when AX exposes the target.

The architecture is a signed `.app` bundle in `/Applications/`, owned by launchd, listening on `~/.agents/.cache/helpers/computer.sock` (sibling of `browser.sock`). macOS TCC keys Accessibility/Screen Recording grants by signed bundle identity — putting the helper at a stable path lets one grant survive across npm updates of agents-cli.

## What's in this PR (10 commits)

- `feat: vendor macos computer-helper swift sources` — 11 Swift files in `packages/computer-helper/`
- `feat: agents computer status subcommand`
- `feat: agents computer screenshot subcommand`
- `feat: helper supports unix socket transport` — Swift POSIX socket listener alongside the existing stdio mode
- `feat: agents computer install-helper` — copies `.app` to `/Applications/`, writes LaunchAgent plist (does not activate)
- `feat: cli uses socket when available, falls back to spawn`
- `fix: move helper socket and log under ~/.agents/.cache/` — matches browser.sock convention
- `refactor: import helpers/logs dirs from state.ts source-of-truth`
- `refactor: rename helper bundle to com.phnx-labs.computer-helper`
- `refactor: split install-helper from start/stop daemon lifecycle` — opt-in: daemon does not auto-run

## Lifecycle

```
agents computer install-helper   # copy .app + plist, NOT activated
                                  # grant Accessibility + Screen Recording in System Settings
agents computer start            # launchctl bootstrap, daemon listens on socket
agents computer status           # daemon state + trust check
agents computer screenshot       # JPEG capture (Screen Recording perm required)
agents computer stop             # launchctl bootout, socket gone
```

Because Screen Recording is a powerful permission, the daemon is opt-in. After install-helper the daemon is **not running** and the socket does not exist; the user explicitly runs `start` when they want a session.

## Test plan

- [x] `./packages/computer-helper/scripts/build.sh debug` produces signed `dist/ComputerHelper.app` (Developer ID Application)
- [x] `codesign --verify --deep --strict` passes on the bundle
- [x] `agents computer install-helper` copies to `/Applications/Computer Helper.app`, writes plist, does NOT bootstrap
- [x] `agents computer start` brings daemon up, socket appears at `~/.agents/.cache/helpers/computer.sock`
- [x] `agents computer status` reports `installed: yes / daemon: running / trust: granted` after the user grants TCC
- [x] `agents computer screenshot` produces a real JPEG of a real app (verified on Finder, 1512×886, 103 KB)
- [x] `agents computer stop` boots out the daemon, socket disappears
- [x] Round-trip latency over socket: ~6 ms/call (10 calls in 69 ms)
- [x] Backwards compat: helper still works in stdio mode when `--socket` flag is absent (the python probe scripts in rush/agents repo continue to function)

## Known follow-ups (not in this PR)

- More subcommands (`click`, `type`, `key`, `describe`, `apps`, `launch`, `wait`, `hover`) — backend supports them all; only TS wiring is missing.
- `scripts/publish-computer-helper.sh` — manual notarize + GitHub release; mirrors `scripts/build-keychain-helper.sh`.
- Unify lifecycle code between `routines` and `computer` via a generalized `lib/daemon.ts` accepting a `DaemonSpec`. Deferred — both work independently and use the same UX shape (`start/stop/status`).