### PR TITLE
feat(sessions): pin resume to original version binary + fix stale file_path after agents remove

### DIFF
--- a/src/commands/__tests__/sessions.test.ts
+++ b/src/commands/__tests__/sessions.test.ts
@@ -825,7 +825,7 @@ describe('agents sessions (render-mode)', () => {
   });
 });
 
-describe('buildResumeCommand cross-version handoff', () => {
+describe('buildResumeCommand version-pinned resume', () => {
   const baseSession = (overrides: Partial<SessionMeta> = {}): SessionMeta => ({
     id: 'abc12345-def6-7890-1234-567890abcdef',
     shortId: 'abc12345',
@@ -835,57 +835,43 @@ describe('buildResumeCommand cross-version handoff', () => {
     ...overrides,
   });
 
-  it('uses native --resume when session version matches active version', () => {
-    const session = baseSession({ version: '2.1.113' });
-    expect(buildResumeCommand(session, '2.1.113')).toEqual([
+  it('uses version-pinned binary when claude session has a recorded version', () => {
+    const session = baseSession({ version: '2.1.138' });
+    expect(buildResumeCommand(session)).toEqual([
+      'claude@2.1.138', '--resume', session.id,
+    ]);
+  });
+
+  it('falls back to bare shim when claude session has no recorded version', () => {
+    const session = baseSession({ version: undefined });
+    expect(buildResumeCommand(session)).toEqual([
       'claude', '--resume', session.id,
     ]);
   });
 
-  it('uses /continue <id> when Claude session version differs from active version', () => {
-    const session = baseSession({ version: '2.0.65' });
-    expect(buildResumeCommand(session, '2.1.113')).toEqual([
-      'claude', `/continue ${session.id}`,
-    ]);
-  });
-
-  it('uses /continue <id> when Codex session version differs from active version', () => {
-    const session = baseSession({ agent: 'codex', version: '0.115.0' });
-    expect(buildResumeCommand(session, '0.116.0')).toEqual([
-      'codex', `/continue ${session.id}`,
-    ]);
-  });
-
-  it('uses native codex resume when versions match', () => {
+  it('uses version-pinned binary when codex session has a recorded version', () => {
     const session = baseSession({ agent: 'codex', version: '0.116.0' });
-    expect(buildResumeCommand(session, '0.116.0')).toEqual([
+    expect(buildResumeCommand(session)).toEqual([
+      'codex@0.116.0', 'resume', session.id,
+    ]);
+  });
+
+  it('falls back to bare shim when codex session has no recorded version', () => {
+    const session = baseSession({ agent: 'codex', version: undefined });
+    expect(buildResumeCommand(session)).toEqual([
       'codex', 'resume', session.id,
     ]);
   });
 
-  it('falls back to native resume when session has no recorded version', () => {
-    const session = baseSession({ version: undefined });
-    expect(buildResumeCommand(session, '2.1.113')).toEqual([
-      'claude', '--resume', session.id,
-    ]);
-  });
-
-  it('falls back to native resume when active version is unknown', () => {
-    const session = baseSession({ version: '2.0.65' });
-    expect(buildResumeCommand(session, undefined)).toEqual([
-      'claude', '--resume', session.id,
-    ]);
-  });
-
-  it('returns null for agents without resume support regardless of version', () => {
-    expect(buildResumeCommand(baseSession({ agent: 'gemini', version: '1.0.0' }), '2.0.0')).toBeNull();
-    expect(buildResumeCommand(baseSession({ agent: 'openclaw', version: '1.0.0' }), '2.0.0')).toBeNull();
-  });
-
-  it('opencode ignores version mismatch (shared SQLite DB, not isolated homes)', () => {
+  it('opencode always uses shared --session flag (not version-isolated)', () => {
     const session = baseSession({ agent: 'opencode', version: '0.5.0' });
-    expect(buildResumeCommand(session, '0.6.0')).toEqual([
+    expect(buildResumeCommand(session)).toEqual([
       'opencode', '--session', session.id,
     ]);
+  });
+
+  it('returns null for agents without resume support', () => {
+    expect(buildResumeCommand(baseSession({ agent: 'gemini', version: '1.0.0' }))).toBeNull();
+    expect(buildResumeCommand(baseSession({ agent: 'openclaw', version: '1.0.0' }))).toBeNull();
   });
 });

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -25,7 +25,7 @@ import { parseSession } from '../lib/session/parse.js';
 import { renderConversationMarkdown, renderSummary, renderSummaryHeader, computeSummaryStats, renderJson, filterEvents, parseRoleList, type FilterOptions } from '../lib/session/render.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { colorAgent, resolveAgentName } from '../lib/agents.js';
-import { resolveVersion, resolveVersionAliasLoose } from '../lib/versions.js';
+import { resolveVersionAliasLoose } from '../lib/versions.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
 import { sessionPicker, type PickedSession } from './sessions-picker.js';
 import { setHelpSections } from '../lib/help.js';
@@ -733,22 +733,13 @@ async function handlePickedSession(picked: PickedSession): Promise<void> {
     ? picked.session.cwd
     : process.cwd();
 
-  const activeVersion = resolveVersion(picked.session.agent as AgentId, cwd) ?? undefined;
-  const resume = buildResumeCommand(picked.session, activeVersion);
+  const resume = buildResumeCommand(picked.session);
   if (!resume) {
     console.log(chalk.yellow(
       `Resume is not supported for ${picked.session.agent} sessions yet. Showing summary instead.`
     ));
     await renderSession(picked.session, 'summary', {});
     return;
-  }
-
-  if (picked.session.version && activeVersion && picked.session.version !== activeVersion) {
-    console.log(chalk.gray(
-      `Cross-version handoff: session is ${picked.session.agent} ${picked.session.version}, ` +
-      `default is ${activeVersion}. Starting fresh and passing /continue so the new agent ` +
-      `reads the prior transcript via 'agents sessions'.`
-    ));
   }
 
   console.log(chalk.gray(`Resuming: ${resume.join(' ')} (cwd: ${cwd})`));
@@ -760,6 +751,18 @@ async function handlePickedSession(picked: PickedSession): Promise<void> {
       shell: false,
     });
     child.on('error', (err: any) => {
+      if (err.code === 'ENOENT' && picked.session.version) {
+        const fallback = buildFallbackCommand(picked.session);
+        if (fallback) {
+          console.log(chalk.gray(
+            `Version ${picked.session.version} is not installed. Falling back to current version via /continue...`
+          ));
+          const fb = spawn(fallback[0], fallback.slice(1), { cwd, stdio: 'inherit', shell: false });
+          fb.on('error', (e: any) => { console.error(chalk.red(`Failed: ${e.message}`)); resolve(); });
+          fb.on('close', () => resolve());
+          return;
+        }
+      }
       console.error(chalk.red(`Failed to launch ${resume[0]}: ${err.message}`));
       if (err.code === 'ENOENT') {
         console.error(chalk.gray(`Make sure '${resume[0]}' is on your PATH.`));
@@ -773,22 +776,21 @@ async function handlePickedSession(picked: PickedSession): Promise<void> {
 /**
  * Build the shell command that resumes a picked session.
  *
- * Cross-version handoff: when the session was created on a different version
- * than the one the shim will launch (activeVersion), the session file lives in
- * the other version's isolated home and `--resume <id>` would silently fail to
- * find it. Fall back to a fresh session seeded with `/continue <id>`, which is
- * wired (~/.claude/commands/continue.md) to read the prior transcript via
- * `agents sessions <id>` — that reader is version-agnostic.
+ * When the session's originating version is known, uses the version-pinned
+ * binary (e.g. `claude@2.1.138`) so the resume always runs in the same
+ * isolated HOME where the JSONL was written — regardless of which version is
+ * currently the default. Falls back to the bare shim when version is unknown.
+ *
+ * If the versioned binary is missing (version was removed), the ENOENT
+ * handler in handlePickedSession retries via buildFallbackCommand.
  */
-export function buildResumeCommand(session: SessionMeta, activeVersion?: string): string[] | null {
-  const versionMismatch = !!(session.version && activeVersion && session.version !== activeVersion);
-
+export function buildResumeCommand(session: SessionMeta): string[] | null {
   switch (session.agent) {
     case 'claude':
-      if (versionMismatch) return ['claude', `/continue ${session.id}`];
+      if (session.version) return [`claude@${session.version}`, '--resume', session.id];
       return ['claude', '--resume', session.id];
     case 'codex':
-      if (versionMismatch) return ['codex', `/continue ${session.id}`];
+      if (session.version) return [`codex@${session.version}`, 'resume', session.id];
       return ['codex', 'resume', session.id];
     case 'opencode':
       return ['opencode', '--session', session.id];
@@ -798,6 +800,15 @@ export function buildResumeCommand(session: SessionMeta, activeVersion?: string)
     case 'hermes':
       // Rush and Hermes sessions are captured artifacts, not resumable locally.
       return null;
+  }
+}
+
+/** Fallback resume command when the versioned binary is unavailable (ENOENT). */
+function buildFallbackCommand(session: SessionMeta): string[] | null {
+  switch (session.agent) {
+    case 'claude': return ['claude', `/continue ${session.id}`];
+    case 'codex':  return ['codex', `/continue ${session.id}`];
+    default: return null;
   }
 }
 

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -40,6 +40,7 @@ import {
   getGlobalDefault,
   setGlobalDefault,
   getVersionHomePath,
+  getVersionDir,
   syncResourcesToVersion,
   parseAgentSpec,
   promptResourceSelection,
@@ -67,8 +68,22 @@ import {
 } from '../lib/shims.js';
 import { isInteractiveTerminal, isPromptCancelled, requireInteractiveSelection } from './utils.js';
 import { tryAutoPull } from '../lib/git.js';
-import { getAgentsDir } from '../lib/state.js';
+import { getAgentsDir, getTrashVersionsDir } from '../lib/state.js';
 import { setHelpSections } from '../lib/help.js';
+import { updateSessionFilePaths } from '../lib/session/db.js';
+
+/**
+ * After removeVersion soft-deletes a version dir to trash, rewrite session
+ * file_path entries in the DB so reads still work from the new trash location.
+ */
+function fixSessionFilePaths(agent: AgentId, version: string, oldVersionDir: string): void {
+  const trashAgentDir = path.join(getTrashVersionsDir(), agent, version);
+  if (!fs.existsSync(trashAgentDir)) return;
+  const stamps = fs.readdirSync(trashAgentDir).sort().reverse();
+  if (stamps.length === 0) return;
+  const trashPath = path.join(trashAgentDir, stamps[0]);
+  updateSessionFilePaths(oldVersionDir, trashPath);
+}
 
 /**
  * Helper to get actual installed version for an agent.
@@ -435,7 +450,9 @@ export function registerVersionsCommands(program: Command): void {
             }
 
             for (const v of toRemove) {
+              const versionDir = getVersionDir(agent, v);
               removeVersion(agent, v);
+              fixSessionFilePaths(agent, v, versionDir);
               console.log(chalk.green(`Removed ${agentLabel(agentConfig.id)}@${v}`));
             }
 
@@ -462,7 +479,9 @@ export function registerVersionsCommands(program: Command): void {
           if (!isVersionInstalled(agent, version)) {
             console.log(chalk.gray(`${agentLabel(agentConfig.id)}@${version} not installed`));
           } else {
+            const versionDir = getVersionDir(agent, version);
             removeVersion(agent, version);
+            fixSessionFilePaths(agent, version, versionDir);
             console.log(chalk.green(`Removed ${agentLabel(agentConfig.id)}@${version}`));
 
             // Remove shim if no versions left

--- a/src/lib/__tests__/versions.test.ts
+++ b/src/lib/__tests__/versions.test.ts
@@ -6,6 +6,7 @@ import * as crypto from 'crypto';
 
 import { getProjectVersion, removeVersion } from '../versions.js';
 import { getVersionsDir, getTrashVersionsDir } from '../state.js';
+import { getDB, updateSessionFilePaths } from '../session/db.js';
 import type { AgentId } from '../types.js';
 
 let tmpDir: string;
@@ -139,4 +140,71 @@ describe('removeVersion soft-deletes the entire version dir to trash', () => {
       }
     });
   }
+});
+
+// When a version is removed, the command handler calls removeVersion then
+// updateSessionFilePaths so session reads still work from the new trash location.
+// This test verifies both pieces independently and together.
+describe('updateSessionFilePaths rewrites file_path after soft-delete to trash', () => {
+  const testVersion = `0.0.0-dbtest-${crypto.randomBytes(4).toString('hex')}`;
+  const testSessionId = `test-session-${crypto.randomBytes(8).toString('hex')}`;
+  const agent: AgentId = 'claude';
+  const binaryName = 'claude';
+
+  afterEach(() => {
+    // Clean up the test session row from the real DB
+    try {
+      const db = getDB();
+      db.prepare(`DELETE FROM session_text WHERE session_id = ?`).run(testSessionId);
+      db.prepare(`DELETE FROM sessions WHERE id = ?`).run(testSessionId);
+    } catch { /* ignore */ }
+
+    // Clean up any leftover version or trash dirs
+    const versionDir = path.join(getVersionsDir(), agent, testVersion);
+    const trashAgentDir = path.join(getTrashVersionsDir(), agent, testVersion);
+    if (fs.existsSync(versionDir)) fs.rmSync(versionDir, { recursive: true, force: true });
+    if (fs.existsSync(trashAgentDir)) fs.rmSync(trashAgentDir, { recursive: true, force: true });
+  });
+
+  it('rewrites file_path to trash location after removeVersion + updateSessionFilePaths', () => {
+    const versionDir = path.join(getVersionsDir(), agent, testVersion);
+    const sessionJsonl = path.join(versionDir, 'home', '.claude', 'projects', 'test', `${testSessionId}.jsonl`);
+
+    // Set up a minimal version dir so removeVersion has something to soft-delete
+    fs.mkdirSync(path.join(versionDir, 'node_modules', '.bin'), { recursive: true });
+    fs.writeFileSync(path.join(versionDir, 'node_modules', '.bin', binaryName), '#!/bin/sh\n');
+    fs.writeFileSync(path.join(versionDir, 'package.json'), '{}');
+    fs.writeFileSync(path.join(versionDir, 'package-lock.json'), '{}');
+    fs.mkdirSync(path.dirname(sessionJsonl), { recursive: true });
+    fs.writeFileSync(sessionJsonl, '{"type":"user"}\n');
+
+    // Insert a session row pointing at the version-dir path
+    const db = getDB();
+    db.prepare(`
+      INSERT OR REPLACE INTO sessions
+        (id, short_id, agent, timestamp, file_path, is_team_origin)
+      VALUES (?, ?, ?, ?, ?, 0)
+    `).run(testSessionId, testSessionId.slice(0, 8), 'claude', new Date().toISOString(), sessionJsonl);
+
+    // Soft-delete the version (mirrors what the command handler does)
+    expect(removeVersion(agent, testVersion)).toBe(true);
+
+    // The trash dir now holds a timestamped copy
+    const trashAgentDir = path.join(getTrashVersionsDir(), agent, testVersion);
+    const stamps = fs.readdirSync(trashAgentDir).sort().reverse();
+    expect(stamps.length).toBeGreaterThan(0);
+    const trashVersionDir = path.join(trashAgentDir, stamps[0]);
+
+    // Simulate what the command handler does: rewrite file_paths to trash location
+    const updated = updateSessionFilePaths(versionDir, trashVersionDir);
+    expect(updated).toBe(1);
+
+    // DB file_path must now point into the trash location
+    const row = db.prepare(`SELECT file_path FROM sessions WHERE id = ?`).get(testSessionId) as { file_path: string } | undefined;
+    expect(row).toBeDefined();
+    expect(row!.file_path.startsWith(trashVersionDir)).toBe(true);
+
+    // The file must actually exist at the new path
+    expect(fs.existsSync(row!.file_path)).toBe(true);
+  });
 });

--- a/src/lib/session/db.ts
+++ b/src/lib/session/db.ts
@@ -870,6 +870,34 @@ export function countSessionsOlderThan(cutoffMs: number): number {
   return row.n;
 }
 
+/**
+ * Rewrite file_path for all sessions whose path starts with oldPrefix, replacing
+ * it with newPrefix + the unchanged suffix. Also clears the matching scan_ledger
+ * entries so they are re-indexed from the new location on the next scan.
+ *
+ * Used by removeVersion after soft-deleting a version directory to trash, so
+ * that session reads (transcript view, /continue) still work from the trash path.
+ * Returns the number of session rows updated.
+ */
+export function updateSessionFilePaths(oldPrefix: string, newPrefix: string): number {
+  const db = getDB();
+  const rows = db
+    .prepare(`SELECT id, file_path FROM sessions WHERE file_path LIKE ?`)
+    .all(oldPrefix + '%') as { id: string; file_path: string }[];
+
+  if (rows.length === 0) return 0;
+
+  const txn = db.transaction(() => {
+    for (const { id, file_path } of rows) {
+      const newPath = newPrefix + file_path.slice(oldPrefix.length);
+      db.prepare(`UPDATE sessions SET file_path = ? WHERE id = ?`).run(newPath, id);
+      db.prepare(`DELETE FROM scan_ledger WHERE file_path = ?`).run(canonicalLedgerKey(file_path));
+    }
+  });
+  txn();
+  return rows.length;
+}
+
 /** Delete sessions older than the given timestamp. Returns the number of rows deleted. */
 export function deleteSessionsOlderThan(cutoffMs: number): number {
   const db = getDB();


### PR DESCRIPTION
## Summary

- **Version-pinned resume**: `buildResumeCommand` now emits `claude@2.1.138 --resume <id>` instead of bare `claude`, so resume always runs in the version's isolated HOME where the JSONL was written — regardless of which version is currently the default.
- **ENOENT auto-retry**: If the versioned binary was removed, automatically falls back to `claude /continue <id>` with the current default rather than hard-failing.
- **Stale `file_path` fix**: `agents remove` now rewrites session `file_path` entries in the sessions DB to the new trash location, so transcript reads and `/continue` keep working after a version is soft-deleted.
- **Conflict marker cleanup**: Resolves pre-existing unresolved conflict markers in `state.ts`, `manifest.ts`, and `state.test.ts` (keeping the `fs-atomic` side throughout).

## Test plan

- `bun test src/commands/__tests__/sessions.test.ts` — 6 new `buildResumeCommand` tests
- `bun test src/lib/__tests__/versions.test.ts` — integration test for `removeVersion` + `updateSessionFilePaths`
- `bun test src/lib/versions.test.ts` — 3 sync tests now pass (were broken by conflict markers)
- All 36 tests across the three changed test files pass with 0 failures

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/8629f7d17bef4ae45d8109cdc5430182)

🤖 Generated with [Claude Code](https://claude.com/claude-code)