### PR TITLE
feat(teams): support grok agent type in team runner

### DIFF
--- a/src/commands/teams.ts
+++ b/src/commands/teams.ts
@@ -65,6 +65,7 @@ const AGENT_NAMES: Record<AgentType, string> = {
   gemini: 'Gemini',
   cursor: 'Cursor',
   opencode: 'OpenCode',
+  grok: 'Grok',
 };
 
 const VALID_AGENTS = Object.keys(AGENT_NAMES) as AgentType[];

--- a/src/lib/teams/__tests__/parsers-grok.test.ts
+++ b/src/lib/teams/__tests__/parsers-grok.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Grok streaming-json parser tests.
+ *
+ * Grok's `--output-format streaming-json` emits token-level JSON objects with
+ * three event types: `thought`, `text`, and `end`. These tests pin the
+ * normalization contract so the team runner can reconstruct readable summaries
+ * from token streams.
+ */
+import { describe, expect, it } from 'vitest';
+import { normalizeEvents } from '../parsers.js';
+import { summarizeEvents } from '../summarizer.js';
+
+describe('normalizeEvents(grok)', () => {
+  it('maps thought events to thinking with content preserved', () => {
+    const events = normalizeEvents('grok', { type: 'thought', data: 'hello' });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'thinking',
+      agent: 'grok',
+      content: 'hello',
+    });
+  });
+
+  it('maps text tokens to streaming message events (complete:false)', () => {
+    const events = normalizeEvents('grok', { type: 'text', data: 'Hi' });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'message',
+      agent: 'grok',
+      content: 'Hi',
+      complete: false,
+    });
+  });
+
+  it('maps end events to a success result with sessionId', () => {
+    const events = normalizeEvents('grok', {
+      type: 'end',
+      stopReason: 'EndTurn',
+      sessionId: '019e6b6f-ede1-7f91-9297-7415bd36423e',
+      requestId: '010520c4-557f-4777-9ec9-1ac331d3e855',
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'result',
+      agent: 'grok',
+      status: 'success',
+      stop_reason: 'EndTurn',
+      session_id: '019e6b6f-ede1-7f91-9297-7415bd36423e',
+    });
+  });
+
+  it('treats non-EndTurn stop reasons as error', () => {
+    const events = normalizeEvents('grok', {
+      type: 'end',
+      stopReason: 'MaxTokens',
+      sessionId: 'abc',
+    });
+    expect(events[0]).toMatchObject({
+      type: 'result',
+      status: 'error',
+      stop_reason: 'MaxTokens',
+    });
+  });
+
+  it('drops empty thought / text payloads', () => {
+    expect(normalizeEvents('grok', { type: 'thought', data: '' })).toEqual([]);
+    expect(normalizeEvents('grok', { type: 'text', data: '' })).toEqual([]);
+  });
+
+  it('passes through unknown event types as raw', () => {
+    const events = normalizeEvents('grok', { type: 'mystery', payload: 'x' });
+    expect(events[0]).toMatchObject({
+      type: 'mystery',
+      agent: 'grok',
+    });
+  });
+});
+
+describe('summarizeEvents with grok streaming tokens', () => {
+  it('reassembles token-level message events into one finalMessage', () => {
+    // Simulates the actual stream captured from grok -p "say hi briefly":
+    //   thought... thought... text("Hi") text("!") text(" How") text(" can") ...
+    //   end
+    const tokens = ['Hi', '!', ' How', ' can', ' I', ' help', '?'];
+    const events: any[] = [];
+    for (const t of tokens) {
+      events.push(...normalizeEvents('grok', { type: 'text', data: t }));
+    }
+    events.push(...normalizeEvents('grok', {
+      type: 'end',
+      stopReason: 'EndTurn',
+      sessionId: 'sess-1',
+    }));
+
+    const summary = summarizeEvents('agent-1', 'grok', 'completed', events);
+    expect(summary.finalMessage).toBe('Hi! How can I help?');
+  });
+
+  it('does not corrupt finalMessage for non-streaming agents (claude)', () => {
+    // Whole-turn messages keep last-wins semantics: regression guard for the
+    // summarizer change that introduced complete:false accumulation.
+    const events = [
+      { type: 'message', agent: 'claude', content: 'first turn', complete: true },
+      { type: 'message', agent: 'claude', content: 'second turn', complete: true },
+    ];
+    const summary = summarizeEvents('agent-2', 'claude', 'completed', events);
+    expect(summary.finalMessage).toBe('second turn');
+  });
+});

--- a/src/lib/teams/agents.ts
+++ b/src/lib/teams/agents.ts
@@ -180,7 +180,7 @@ export function captureProcessStartTime(pid: number): string | null {
 }
 
 /** Agent types the team runner supports. */
-const TEAM_AGENT_TYPES: AgentType[] = ['codex', 'cursor', 'gemini', 'claude', 'opencode'];
+const TEAM_AGENT_TYPES: AgentType[] = ['codex', 'cursor', 'gemini', 'claude', 'opencode', 'grok'];
 
 /**
  * Reasoning-intensity knob. Passed through to `agents run --effort`, which

--- a/src/lib/teams/parsers.ts
+++ b/src/lib/teams/parsers.ts
@@ -2,14 +2,14 @@
  * Agent event stream parsers.
  *
  * Normalizes the heterogeneous JSON event formats emitted by each agent CLI
- * (Claude, Codex, Gemini, Cursor, OpenCode) into a unified event schema
+ * (Claude, Codex, Gemini, Cursor, OpenCode, Grok) into a unified event schema
  * with consistent types: init, message, tool_use, bash, file_read, file_write,
  * file_create, file_delete, result, error, and others.
  */
 import { extractFileOpsFromBash } from './file_ops.js';
 
 /** Supported agent CLI types for team spawning. */
-export type AgentType = 'codex' | 'gemini' | 'cursor' | 'claude' | 'opencode';
+export type AgentType = 'codex' | 'gemini' | 'cursor' | 'claude' | 'opencode' | 'grok';
 
 const claudeToolUseMap = new Map<string, { tool: string; command?: string; path?: string }>();
 
@@ -25,6 +25,8 @@ export function normalizeEvents(agentType: AgentType, raw: any): any[] {
     return normalizeClaude(raw);
   } else if (agentType === 'opencode') {
     return normalizeOpencode(raw);
+  } else if (agentType === 'grok') {
+    return normalizeGrok(raw);
   }
 
   const timestamp = new Date().toISOString();
@@ -847,6 +849,82 @@ function normalizeOpencode(raw: any): any[] {
   return [{
     type: eventType,
     agent: 'opencode',
+    raw: raw,
+    timestamp: timestamp,
+  }];
+}
+
+// --- Grok parsing ---
+// Grok's streaming-json mode emits one JSON object per token, with three event
+// types:
+//   {"type":"thought","data":"<chunk>"}   — reasoning tokens (many, small)
+//   {"type":"text","data":"<chunk>"}      — visible response tokens (many, small)
+//   {"type":"end","stopReason":"EndTurn","sessionId":"<uuid>","requestId":"<uuid>"}
+//
+// Tool calls are NOT exposed as separate events in this format; they appear
+// inside the `thought` text as XML-like markup. Extracting them reliably would
+// require running a streaming XML/markup parser over concatenated thought
+// chunks, which is out of scope for v1. The teams summary will show grok
+// teammates' bash/file ops as empty — known limitation, fixable later by
+// switching to grok's `agent` subcommand (richer event stream) once stable.
+//
+// Tokens are emitted as `message` events with `complete: false` so the
+// summarizer can concatenate them into a final message; `thinking` events are
+// already collapsed by the summarizer's groupAndFlattenEvents pathway.
+function normalizeGrok(raw: any): any[] {
+  if (!raw || typeof raw !== 'object') {
+    return [{
+      type: 'unknown',
+      agent: 'grok',
+      raw: raw,
+      timestamp: new Date().toISOString(),
+    }];
+  }
+
+  const eventType = raw.type || 'unknown';
+  const timestamp = new Date().toISOString();
+
+  if (eventType === 'thought') {
+    const data = typeof raw.data === 'string' ? raw.data : '';
+    if (!data) return [];
+    return [{
+      type: 'thinking',
+      agent: 'grok',
+      content: data,
+      timestamp: timestamp,
+    }];
+  }
+
+  if (eventType === 'text') {
+    const data = typeof raw.data === 'string' ? raw.data : '';
+    if (!data) return [];
+    return [{
+      type: 'message',
+      agent: 'grok',
+      content: data,
+      complete: false,
+      timestamp: timestamp,
+    }];
+  }
+
+  if (eventType === 'end') {
+    const stopReason = typeof raw.stopReason === 'string' ? raw.stopReason : '';
+    const status = stopReason === 'EndTurn' || stopReason === 'StopSequence' || stopReason === ''
+      ? 'success'
+      : 'error';
+    return [{
+      type: 'result',
+      agent: 'grok',
+      status: status,
+      stop_reason: stopReason || null,
+      session_id: typeof raw.sessionId === 'string' ? raw.sessionId : null,
+      timestamp: timestamp,
+    }];
+  }
+
+  return [{
+    type: eventType,
+    agent: 'grok',
     raw: raw,
     timestamp: timestamp,
   }];

--- a/src/lib/teams/summarizer.ts
+++ b/src/lib/teams/summarizer.ts
@@ -183,12 +183,19 @@ export function groupAndFlattenEvents(events: any[]): any[] {
     if (eventType === 'message' || eventType === 'thinking') {
       let count = 1;
       let combinedContent = event.content || '';
+      // Streaming token events (complete:false) get concatenated without a
+      // separator so tokens reassemble into readable prose. Whole-turn events
+      // get joined with newlines so distinct turns/thoughts stay separated.
+      const isStreaming = event.complete === false;
       let j = i + 1;
 
       while (j < events.length && events[j].type === eventType) {
         count++;
         if (events[j].content) {
-          combinedContent += (combinedContent ? '\n' : '') + events[j].content;
+          const sep = isStreaming || events[j].complete === false
+            ? ''
+            : (combinedContent ? '\n' : '');
+          combinedContent += sep + events[j].content;
         }
         j++;
       }
@@ -454,7 +461,15 @@ export function summarizeEvents(
     } else if (eventType === 'message') {
       const content = event.content || '';
       if (content) {
-        summary.finalMessage = content;
+        // Streaming token-by-token messages (e.g., grok) arrive as many small
+        // `message` events with complete:false; concatenate them so the final
+        // turn reads as one message. Whole-turn messages (claude, codex,
+        // gemini) keep their complete:true semantics — last one wins.
+        if (event.complete === false) {
+          summary.finalMessage = (summary.finalMessage || '') + content;
+        } else {
+          summary.finalMessage = content;
+        }
       }
     } else if (eventType === 'error') {
       let errorMsg: string | null = null;


### PR DESCRIPTION
## Summary

- Adds `grok` to the team runner's `AgentType` union and `TEAM_AGENT_TYPES` list so `agents teams add <team> grok "..."` works. Until now the team runner type-rejected grok even though `agents run grok` was wired up months ago.
- New `normalizeGrok` parser for grok's `--output-format streaming-json` (`thought` / `text` / `end` events, one JSON object per token, `sessionId` only on the terminal `end`).
- `summarizeEvents` now concatenates `complete:false` message events so token streams reassemble into readable `finalMessage` prose; whole-turn messages from claude/codex keep their last-wins semantics (regression-guarded by a test).

## Known limitations

Grok's streaming-json elides tool calls — they live inside `thought` text as XML-like markup. For v1 the team summary's `files_modified`, `bash_commands`, `tools_used` will be empty for grok teammates. Future work: switch to the `grok agent` subcommand or parse the embedded markup.

## Test plan

- [x] `npx vitest run src/lib/teams` — 6 files, 22 tests pass (8 new for grok)
- [x] `npx vitest run src/lib/__tests__/exec.test.ts src/commands` — 7 files, 115 tests pass (no regressions)
- [x] `tsc` build clean
- [x] End-to-end: `agents teams add grok-smoke grok "say hi briefly. no tools."` ran to completion in 16s, captured `remote_session_id=019e6b76-55dc-78f3-a4cf-843ca06e3180` from the `end` event, and reassembled the token stream into a clean `last_messages` entry. Final status `completed`, zero errors.

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/03549da77a78f863ab1134c6dd031fec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)