### PR TITLE
feat(agents): wire antigravity + grok parity across teams, exec, sync, hooks

### DIFF
--- a/src/commands/teams.ts
+++ b/src/commands/teams.ts
@@ -66,6 +66,7 @@ const AGENT_NAMES: Record<AgentType, string> = {
   cursor: 'Cursor',
   opencode: 'OpenCode',
   grok: 'Grok',
+  antigravity: 'Antigravity',
 };
 
 const VALID_AGENTS = Object.keys(AGENT_NAMES) as AgentType[];

--- a/src/lib/__tests__/hooks.test.ts
+++ b/src/lib/__tests__/hooks.test.ts
@@ -297,12 +297,239 @@ describe('registerHooksToSettings - returns empty for unsupported agents', () =>
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('returns no-op for agents other than claude/codex/gemini', () => {
+  it('returns no-op for agents other than claude/codex/gemini/antigravity', () => {
     const manifest: Record<string, ManifestHook> = {
       'on-prompt': { script: 'on-prompt.sh', events: ['UserPromptSubmit'] },
     };
     const result = registerHooksToSettings('opencode', path.join(tmpDir, 'home'), manifest, agentsDir);
     expect(result.registered).toHaveLength(0);
     expect(result.errors).toHaveLength(0);
+  });
+
+  it('writes grok hook JSON files for PreToolUse events', () => {
+    fs.writeFileSync(path.join(agentsDir, 'hooks', 'on-prompt.sh'), '#!/bin/sh\necho hi\n');
+    const manifest: Record<string, ManifestHook> = {
+      'on-prompt': { script: 'on-prompt.sh', events: ['PreToolUse'] },
+    };
+    const versionHome = path.join(tmpDir, 'home');
+    const result = registerHooksToSettings('grok', versionHome, manifest, agentsDir);
+    expect(result.errors).toHaveLength(0);
+    expect(result.registered).toContain('on-prompt -> PreToolUse');
+    const mainPath = path.join(versionHome, '.grok', 'hooks', 'hooks.json');
+    expect(fs.existsSync(mainPath)).toBe(true);
+    const parsed = JSON.parse(fs.readFileSync(mainPath, 'utf-8'));
+    expect(parsed.hooks.PreToolUse).toBeDefined();
+    expect(parsed.hooks.PreToolUse[0].hooks[0].type).toBe('command');
+  });
+});
+
+describe('registerHooksToSettings - Antigravity', () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-test-'));
+    agentsDir = path.join(tmpDir, '.agents');
+    fs.mkdirSync(path.join(agentsDir, 'hooks'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeAgyVersionHome(): string {
+    const home = path.join(tmpDir, 'agy-home');
+    fs.mkdirSync(path.join(home, '.gemini', 'antigravity-cli'), { recursive: true });
+    return home;
+  }
+
+  function readAgySettings(home: string): Record<string, any> {
+    return JSON.parse(
+      fs.readFileSync(path.join(home, '.gemini', 'antigravity-cli', 'settings.json'), 'utf-8')
+    );
+  }
+
+  it('writes settings.json at ~/.gemini/antigravity-cli/ with flat hooks arrays', () => {
+    const versionHome = makeAgyVersionHome();
+    const scriptPath = makeScript('pre-tool.sh');
+
+    const manifest: Record<string, ManifestHook> = {
+      'pre-tool': {
+        script: 'pre-tool.sh',
+        events: ['PreToolUse'],
+      },
+    };
+
+    const result = registerHooksToSettings('antigravity', versionHome, manifest, agentsDir);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.registered).toContain('pre-tool -> before_tool_call');
+
+    const settings = readAgySettings(versionHome);
+    expect(settings.hooks).toBeDefined();
+    expect(Array.isArray(settings.hooks.before_tool_call)).toBe(true);
+    expect(settings.hooks.before_tool_call).toHaveLength(1);
+    expect(settings.hooks.before_tool_call[0]).toEqual({ command: scriptPath });
+  });
+
+  it('maps all four supported events: PreToolUse, PostToolUse, Stop, OnError', () => {
+    const versionHome = makeAgyVersionHome();
+    makeScript('a.sh');
+    makeScript('b.sh');
+    makeScript('c.sh');
+    makeScript('d.sh');
+
+    const manifest: Record<string, ManifestHook> = {
+      a: { script: 'a.sh', events: ['PreToolUse'] },
+      b: { script: 'b.sh', events: ['PostToolUse'] },
+      c: { script: 'c.sh', events: ['Stop'] },
+      d: { script: 'd.sh', events: ['OnError'] },
+    };
+
+    const result = registerHooksToSettings('antigravity', versionHome, manifest, agentsDir);
+    expect(result.errors).toHaveLength(0);
+
+    const settings = readAgySettings(versionHome);
+    expect(settings.hooks.before_tool_call).toHaveLength(1);
+    expect(settings.hooks.after_model_call).toHaveLength(1);
+    expect(settings.hooks.on_loop_stop).toHaveLength(1);
+    expect(settings.hooks.on_error).toHaveLength(1);
+  });
+
+  it('expands a hook with multiple events into one entry per agy event', () => {
+    const versionHome = makeAgyVersionHome();
+    const scriptPath = makeScript('multi.sh');
+
+    const manifest: Record<string, ManifestHook> = {
+      multi: { script: 'multi.sh', events: ['PreToolUse', 'PostToolUse', 'Stop'] },
+    };
+
+    const result = registerHooksToSettings('antigravity', versionHome, manifest, agentsDir);
+    expect(result.errors).toHaveLength(0);
+    expect(result.registered).toHaveLength(3);
+
+    const settings = readAgySettings(versionHome);
+    expect(settings.hooks.before_tool_call[0].command).toBe(scriptPath);
+    expect(settings.hooks.after_model_call[0].command).toBe(scriptPath);
+    expect(settings.hooks.on_loop_stop[0].command).toBe(scriptPath);
+  });
+
+  it('silently skips unmapped events (e.g. UserPromptSubmit)', () => {
+    const versionHome = makeAgyVersionHome();
+    makeScript('prompt.sh');
+    makeScript('tool.sh');
+
+    const manifest: Record<string, ManifestHook> = {
+      // UserPromptSubmit has no agy equivalent — must not error, must not register
+      prompt: { script: 'prompt.sh', events: ['UserPromptSubmit'] },
+      tool: { script: 'tool.sh', events: ['PreToolUse'] },
+    };
+
+    const result = registerHooksToSettings('antigravity', versionHome, manifest, agentsDir);
+    expect(result.errors).toHaveLength(0);
+    expect(result.registered).toEqual(['tool -> before_tool_call']);
+
+    const settings = readAgySettings(versionHome);
+    expect(settings.hooks.before_tool_call).toHaveLength(1);
+    expect(settings.hooks.UserPromptSubmit).toBeUndefined();
+  });
+
+  it('preserves existing non-hooks settings.json content', () => {
+    const versionHome = makeAgyVersionHome();
+    const settingsPath = path.join(versionHome, '.gemini', 'antigravity-cli', 'settings.json');
+
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        theme: 'dark',
+        permissions: { allow: ['Bash(ls:*)'] },
+      }, null, 2)
+    );
+
+    makeScript('pre-tool.sh');
+    const manifest: Record<string, ManifestHook> = {
+      'pre-tool': { script: 'pre-tool.sh', events: ['PreToolUse'] },
+    };
+
+    registerHooksToSettings('antigravity', versionHome, manifest, agentsDir);
+
+    const settings = readAgySettings(versionHome);
+    expect(settings.theme).toBe('dark');
+    expect(settings.permissions).toEqual({ allow: ['Bash(ls:*)'] });
+    expect(settings.hooks.before_tool_call).toHaveLength(1);
+  });
+
+  it('prunes removed managed entries on subsequent sync (GC invariant)', () => {
+    const versionHome = makeAgyVersionHome();
+    makeScript('a.sh');
+    makeScript('b.sh');
+
+    const firstManifest: Record<string, ManifestHook> = {
+      a: { script: 'a.sh', events: ['PreToolUse'] },
+      b: { script: 'b.sh', events: ['PreToolUse'] },
+    };
+    registerHooksToSettings('antigravity', versionHome, firstManifest, agentsDir);
+
+    let settings = readAgySettings(versionHome);
+    expect(settings.hooks.before_tool_call).toHaveLength(2);
+
+    // Smaller manifest — 'b' was deleted upstream
+    const secondManifest: Record<string, ManifestHook> = {
+      a: { script: 'a.sh', events: ['PreToolUse'] },
+    };
+    registerHooksToSettings('antigravity', versionHome, secondManifest, agentsDir);
+
+    settings = readAgySettings(versionHome);
+    expect(settings.hooks.before_tool_call).toHaveLength(1);
+    expect(settings.hooks.before_tool_call[0].command).toContain('a.sh');
+  });
+
+  it('never touches user-authored entries outside managedPrefixes', () => {
+    const versionHome = makeAgyVersionHome();
+    const settingsPath = path.join(versionHome, '.gemini', 'antigravity-cli', 'settings.json');
+
+    // Pre-seed with a user-authored hook outside the managed hooks dir
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        hooks: {
+          before_tool_call: [{ command: '/usr/local/bin/my-user-hook.sh' }],
+        },
+      }, null, 2)
+    );
+
+    makeScript('managed.sh');
+    const manifest: Record<string, ManifestHook> = {
+      managed: { script: 'managed.sh', events: ['PreToolUse'] },
+    };
+    registerHooksToSettings('antigravity', versionHome, manifest, agentsDir);
+
+    const settings = readAgySettings(versionHome);
+    // Both entries should coexist — user hook untouched, managed hook added
+    expect(settings.hooks.before_tool_call).toHaveLength(2);
+    expect(settings.hooks.before_tool_call[0].command).toBe('/usr/local/bin/my-user-hook.sh');
+  });
+
+  it('does not duplicate entries on repeated calls', () => {
+    const versionHome = makeAgyVersionHome();
+    makeScript('pre-tool.sh');
+
+    const manifest: Record<string, ManifestHook> = {
+      'pre-tool': { script: 'pre-tool.sh', events: ['PreToolUse'] },
+    };
+
+    registerHooksToSettings('antigravity', versionHome, manifest, agentsDir);
+    registerHooksToSettings('antigravity', versionHome, manifest, agentsDir);
+
+    const settings = readAgySettings(versionHome);
+    expect(settings.hooks.before_tool_call).toHaveLength(1);
+  });
+
+  it('returns error when script file does not exist', () => {
+    const versionHome = makeAgyVersionHome();
+    const manifest: Record<string, ManifestHook> = {
+      missing: { script: 'does-not-exist.sh', events: ['PreToolUse'] },
+    };
+
+    const result = registerHooksToSettings('antigravity', versionHome, manifest, agentsDir);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toContain('missing');
   });
 });

--- a/src/lib/acp/harnesses.ts
+++ b/src/lib/acp/harnesses.ts
@@ -65,6 +65,14 @@ export const ACP_HARNESSES: Partial<Record<AgentId, AcpHarnessSpec>> = {
     confidence: 'documented',
     source: 'https://docs.openclaw.ai/tools/acp-agents',
   },
+  grok: {
+    command: 'grok',
+    args: ['agent', 'stdio'],
+    installHint: 'see https://docs.x.ai/build/cli',
+    confidence: 'documented',
+    source: 'https://docs.x.ai/build/cli/headless-scripting',
+  },
+  // antigravity: no documented ACP support (May 2026).
   // goose: ACP over HTTP via `goosed`, not a clean stdio subcommand.
   // copilot, kiro: excluded for now (not installed in the reference environment,
   //                no local verification possible).

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -400,6 +400,11 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
   // configDir nests inside `~/.gemini/` since agy shares the parent dir with the Gemini
   // CLI but isolates its own state in the `antigravity-cli/` subdir. Per-version HOME
   // isolation works because the shim's configDirName carries the full nested path.
+  // Auth: Google OAuth on first launch, or ANTIGRAVITY_API_KEY env var for headless.
+  // Hooks: JSON entries under a top-level `hooks` key in settings.json; events are
+  // before_tool_call, after_model_call, on_loop_stop, on_error. Plugins are the
+  // renamed Gemini CLI extensions. Permissions live in settings.json under a
+  // `permissions` key with allow/deny arrays.
   antigravity: {
     id: 'antigravity',
     name: 'Antigravity',
@@ -415,14 +420,15 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     instructionsFile: 'AGENTS.md',
     format: 'markdown',
     variableSyntax: '{{args}}',
-    supportsHooks: false,
-    nativeAgentsSkillsDir: true,
-    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, rulesImports: false },
+    supportsHooks: true,
+    capabilities: { hooks: true, mcp: true, allowlist: true, skills: true, commands: true, plugins: true, rulesImports: false },
   },
   // xAI Grok Build CLI (`grok`) — early beta, SuperGrok Heavy. Auth via OAuth on
-  // first launch, or GROK_CODE_XAI_API_KEY env var for headless. Grok exposes
-  // skills, hooks, plugins, and MCP via .grok/* directories per the official
-  // ~/.grok/README.md; MCP servers live inside config.toml under [mcp_servers].
+  // first launch, or XAI_API_KEY env var for headless. MCP servers configured inline
+  // under [mcp_servers] in ~/.grok/config.toml. Hooks auto-discovered from
+  // ~/.grok/hooks/ (+ project .grok/hooks/) — events PreToolUse, PostToolUse, etc.
+  // Plugins live in ~/.grok/plugins/ with marketplaces. Permissions: --allow/--deny
+  // CLI flags or [permission] TOML block in ~/.grok/config.toml.
   grok: {
     id: 'grok',
     name: 'Grok',

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -251,13 +251,18 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
     },
     modelFlag: '--model',
   },
+  // Antigravity full mode uses --dangerously-skip-permissions (YOLO).
+  // TODO: --output-format json is documented but currently broken upstream
+  // ("flags provided but not defined: -output-format"). Track resolution at
+  // https://github.com/google-antigravity/antigravity-cli/issues/7 before
+  // adding `jsonFlags` here.
   antigravity: {
     base: ['agy'],
     promptFlag: 'positional',
     modeFlags: {
       plan: [],
       edit: [],
-      full: [],
+      full: ['--dangerously-skip-permissions'],
     },
     modelFlag: '--model',
   },
@@ -265,9 +270,9 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
     base: ['grok'],
     promptFlag: '-p',
     modeFlags: {
-      plan: [],
+      plan: ['--mode', 'plan'],
       edit: [],
-      full: [],
+      full: ['--always-approve'],
     },
     jsonFlags: ['--output-format', 'streaming-json'],
     modelFlag: '--model',

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -807,11 +807,31 @@ export function registerHooksToSettings(
   if (agentId === 'gemini') {
     return registerHooksForGemini(versionHome, manifest, resolveScript, managedPrefixes);
   }
+  if (agentId === 'antigravity') {
+    return registerHooksForAntigravity(versionHome, manifest, resolveScript, managedPrefixes);
+  }
   if (agentId === 'grok') {
     return registerHooksForGrok(versionHome, manifest, resolveScript, managedPrefixes);
   }
   return { registered: [], errors: [] };
 }
+
+/**
+ * Antigravity (agy) event names differ from agents-cli manifest names. The
+ * mapping below is the documented agy schema. PostToolUse has no exact
+ * agy equivalent — agy fires `after_model_call` after the model finishes a
+ * turn (which includes any tool calls in that turn), so it's the closest
+ * lifecycle phase but not a 1:1 match. Manifest events not in this map are
+ * skipped silently (the manifest may declare events for other agents).
+ */
+const ANTIGRAVITY_EVENT_MAP: Record<string, string> = {
+  PreToolUse: 'before_tool_call',
+  // Imperfect mapping: agy has no per-tool post-event. after_model_call
+  // fires once at the end of the turn, after all tool calls completed.
+  PostToolUse: 'after_model_call',
+  Stop: 'on_loop_stop',
+  OnError: 'on_error',
+};
 
 /**
  * Gemini has no native UserPromptSubmit event — map it to BeforeAgent,
@@ -1174,6 +1194,116 @@ function registerHooksForGemini(
     });
   } catch (err) {
     errors.push(`Failed to write gemini settings.json: ${(err as Error).message}`);
+  }
+
+  return { registered, errors };
+}
+
+/**
+ * Register hooks into antigravity's (agy) settings.json. Unlike gemini, agy uses
+ * a flat per-event array of `{ command }` entries (no matcher groups). Events
+ * are renamed via ANTIGRAVITY_EVENT_MAP; unmapped manifest events are skipped.
+ *
+ * settings.json lives at `${versionHome}/.gemini/antigravity-cli/settings.json`
+ * because agy nests its config under the shared `.gemini` parent dir.
+ */
+function registerHooksForAntigravity(
+  versionHome: string,
+  manifest: Record<string, ManifestHook>,
+  resolveScript: (script: string) => string | null,
+  managedPrefixes: string[]
+): { registered: string[]; errors: string[] } {
+  const registered: string[] = [];
+  const errors: string[] = [];
+
+  const configDir = path.join(versionHome, '.gemini', 'antigravity-cli');
+  const settingsPath = path.join(configDir, 'settings.json');
+
+  let config: Record<string, unknown> = {};
+  if (fs.existsSync(settingsPath)) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        config = parsed as Record<string, unknown>;
+      }
+    } catch {
+      errors.push('Failed to parse antigravity settings.json');
+      return { registered, errors };
+    }
+  }
+
+  if (!config.hooks || typeof config.hooks !== 'object' || Array.isArray(config.hooks)) {
+    config.hooks = {};
+  }
+  const hooks = config.hooks as Record<string, unknown[]>;
+
+  // Build set of all command paths the current manifest will register, so we
+  // can garbage-collect stale managed entries left over from renamed/deleted
+  // hooks. Only managed paths are considered for removal — user-added entries
+  // outside managedPrefixes are preserved.
+  const currentManifestPaths = new Set<string>();
+  for (const hookDef of Object.values(manifest)) {
+    if (!hookDef.events || hookDef.events.length === 0) continue;
+    // Only paths whose events map to a known agy event would actually be
+    // registered, so only those should survive GC.
+    const anyMapped = hookDef.events.some((e) => ANTIGRAVITY_EVENT_MAP[e]);
+    if (!anyMapped) continue;
+    const resolved = resolveScript(hookDef.script);
+    if (resolved) currentManifestPaths.add(resolved);
+  }
+
+  for (const eventKey of Object.keys(hooks)) {
+    const entries = hooks[eventKey];
+    if (!Array.isArray(entries)) continue;
+    hooks[eventKey] = entries.filter((entry) => {
+      if (!entry || typeof entry !== 'object') return true;
+      const cmd = (entry as { command?: unknown }).command;
+      if (typeof cmd !== 'string') return true;
+      if (!isManagedHookCommand(cmd, managedPrefixes)) return true;
+      return currentManifestPaths.has(cmd);
+    });
+    if ((hooks[eventKey] as unknown[]).length === 0) {
+      delete hooks[eventKey];
+    }
+  }
+
+  for (const [name, hookDef] of Object.entries(manifest)) {
+    if (!hookDef.events || hookDef.events.length === 0) continue;
+
+    const commandPath = resolveScript(hookDef.script);
+    if (!commandPath) {
+      errors.push(`${name}: script not found in user or system hooks dir`);
+      continue;
+    }
+
+    for (const event of hookDef.events) {
+      const agyEvent = ANTIGRAVITY_EVENT_MAP[event];
+      if (!agyEvent) continue; // unmapped event — silently skip
+
+      if (!hooks[agyEvent]) {
+        hooks[agyEvent] = [];
+      }
+      const list = hooks[agyEvent] as Array<{ command: string }>;
+
+      const existingIdx = list.findIndex(
+        (e) => e && typeof e === 'object' && e.command === commandPath
+      );
+      const entry = { command: commandPath };
+      if (existingIdx >= 0) {
+        list[existingIdx] = entry;
+      } else {
+        list.push(entry);
+      }
+
+      registered.push(`${name} -> ${agyEvent}`);
+    }
+  }
+
+  try {
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+  } catch (err) {
+    errors.push(`Failed to write antigravity settings.json: ${(err as Error).message}`);
   }
 
   return { registered, errors };

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -27,7 +27,11 @@ import { AGENTS } from './agents.js';
 const HOME = os.homedir();
 
 /** Agents that support the permissions subsystem. */
-export const PERMISSIONS_CAPABLE_AGENTS: AgentId[] = ['claude', 'codex', 'opencode'];
+// antigravity: permissions in ~/.gemini/antigravity-cli/settings.json under
+// `permissions: { allow: [...], deny: [...] }`. Serializer is a follow-up.
+// grok: permissions via --allow/--deny CLI flags or [permission] block in
+// ~/.grok/config.toml. Serializer is a follow-up.
+export const PERMISSIONS_CAPABLE_AGENTS: AgentId[] = ['claude', 'codex', 'opencode', 'antigravity', 'grok'];
 
 /** Filename used for Codex Starlark deny-rules generated from permission groups. */
 export const CODEX_RULES_FILENAME = 'agents-deny.rules';

--- a/src/lib/profiles-presets.ts
+++ b/src/lib/profiles-presets.ts
@@ -104,6 +104,43 @@ export const PRESETS: Preset[] = [
       ANTHROPIC_SMALL_FAST_MODEL: 'deepseek/deepseek-chat-v3-0324',
     },
   },
+  // ----- xAI Grok Build CLI (native host) -----
+  {
+    name: 'grok-fast',
+    description: 'xAI Grok Build CLI — fast tier. Native grok host, no OpenRouter wrapper.',
+    provider: 'xai',
+    host: 'grok',
+    authEnvVar: 'XAI_API_KEY',
+    signupUrl: 'https://console.x.ai',
+    env: {
+      // TODO: confirm model id (docs.x.ai/build/models, May 2026)
+      GROK_MODEL: 'grok-build-fast',
+    },
+  },
+  {
+    name: 'grok-heavy',
+    description: 'xAI Grok Build CLI — heavy tier (SuperGrok). Native grok host.',
+    provider: 'xai',
+    host: 'grok',
+    authEnvVar: 'XAI_API_KEY',
+    signupUrl: 'https://console.x.ai',
+    env: {
+      // TODO: confirm model id (docs.x.ai/build/models, May 2026)
+      GROK_MODEL: 'grok-build',
+    },
+  },
+  // ----- Google Antigravity CLI (native host) -----
+  {
+    name: 'agy',
+    description: 'Google Antigravity CLI default. Auth via Google OAuth or ANTIGRAVITY_API_KEY.',
+    provider: 'google',
+    host: 'antigravity',
+    authEnvVar: 'ANTIGRAVITY_API_KEY',
+    signupUrl: 'https://antigravity.google',
+    env: {
+      // TODO: confirm model id — antigravity defaults are managed by the CLI itself
+    },
+  },
 ];
 
 /** Look up a preset by name (case-sensitive). */

--- a/src/lib/teams/__tests__/parsers-antigravity.test.ts
+++ b/src/lib/teams/__tests__/parsers-antigravity.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Antigravity (`agy`) parser tests.
+ *
+ * Antigravity's streaming-json mode is unstable upstream
+ * (google-antigravity/antigravity-cli#7), so normalizeAntigravity is
+ * intentionally defensive: it covers plain-string output, init/message/result
+ * shapes if/when JSON streaming lands, and falls back to a raw passthrough for
+ * anything unrecognized. These tests pin that contract.
+ */
+import { describe, expect, it } from 'vitest';
+import { normalizeEvents } from '../parsers.js';
+
+describe('normalizeEvents(antigravity)', () => {
+  it('wraps a plain-string raw payload as a complete message event', () => {
+    const events = normalizeEvents('antigravity', 'hello from agy');
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'message',
+      agent: 'antigravity',
+      content: 'hello from agy',
+      complete: true,
+    });
+  });
+
+  it('drops an empty string payload', () => {
+    expect(normalizeEvents('antigravity', '')).toEqual([]);
+  });
+
+  it('emits an unknown event for null / number / non-object input', () => {
+    const nullEvents = normalizeEvents('antigravity', null);
+    expect(nullEvents).toHaveLength(1);
+    expect(nullEvents[0]).toMatchObject({
+      type: 'unknown',
+      agent: 'antigravity',
+    });
+
+    const numEvents = normalizeEvents('antigravity', 42);
+    expect(numEvents[0]).toMatchObject({
+      type: 'unknown',
+      agent: 'antigravity',
+    });
+  });
+
+  it('normalizes a recognizable init event with sessionId', () => {
+    const events = normalizeEvents('antigravity', {
+      type: 'init',
+      sessionId: 'agy-sess-1',
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'init',
+      agent: 'antigravity',
+      session_id: 'agy-sess-1',
+    });
+  });
+
+  it('normalizes a message event with content', () => {
+    const events = normalizeEvents('antigravity', {
+      type: 'message',
+      content: 'partial response',
+      complete: false,
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'message',
+      agent: 'antigravity',
+      content: 'partial response',
+      complete: false,
+    });
+  });
+
+  it('treats message events without explicit complete as complete:true', () => {
+    const events = normalizeEvents('antigravity', {
+      type: 'message',
+      content: 'one-shot',
+    });
+    expect(events[0]).toMatchObject({
+      type: 'message',
+      content: 'one-shot',
+      complete: true,
+    });
+  });
+
+  it('drops message events with empty content', () => {
+    expect(normalizeEvents('antigravity', { type: 'message', content: '' })).toEqual([]);
+  });
+
+  it('normalizes a result event into success by default', () => {
+    const events = normalizeEvents('antigravity', {
+      type: 'result',
+      sessionId: 'agy-sess-2',
+    });
+    expect(events[0]).toMatchObject({
+      type: 'result',
+      agent: 'antigravity',
+      status: 'success',
+      session_id: 'agy-sess-2',
+    });
+  });
+
+  it('preserves error status on result events', () => {
+    const events = normalizeEvents('antigravity', {
+      type: 'result',
+      status: 'error',
+    });
+    expect(events[0]).toMatchObject({
+      type: 'result',
+      status: 'error',
+    });
+  });
+
+  it('falls back to a generic shape for unknown event types', () => {
+    const events = normalizeEvents('antigravity', {
+      type: 'mystery',
+      payload: 'x',
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'mystery',
+      agent: 'antigravity',
+    });
+    expect(events[0].raw).toMatchObject({ type: 'mystery', payload: 'x' });
+  });
+});

--- a/src/lib/teams/agents.ts
+++ b/src/lib/teams/agents.ts
@@ -180,7 +180,7 @@ export function captureProcessStartTime(pid: number): string | null {
 }
 
 /** Agent types the team runner supports. */
-const TEAM_AGENT_TYPES: AgentType[] = ['codex', 'cursor', 'gemini', 'claude', 'opencode', 'grok'];
+const TEAM_AGENT_TYPES: AgentType[] = ['codex', 'cursor', 'gemini', 'claude', 'opencode', 'grok', 'antigravity'];
 
 /**
  * Reasoning-intensity knob. Passed through to `agents run --effort`, which

--- a/src/lib/teams/parsers.ts
+++ b/src/lib/teams/parsers.ts
@@ -2,14 +2,14 @@
  * Agent event stream parsers.
  *
  * Normalizes the heterogeneous JSON event formats emitted by each agent CLI
- * (Claude, Codex, Gemini, Cursor, OpenCode, Grok) into a unified event schema
- * with consistent types: init, message, tool_use, bash, file_read, file_write,
- * file_create, file_delete, result, error, and others.
+ * (Claude, Codex, Gemini, Cursor, OpenCode, Grok, Antigravity) into a unified
+ * event schema with consistent types: init, message, tool_use, bash,
+ * file_read, file_write, file_create, file_delete, result, error, and others.
  */
 import { extractFileOpsFromBash } from './file_ops.js';
 
 /** Supported agent CLI types for team spawning. */
-export type AgentType = 'codex' | 'gemini' | 'cursor' | 'claude' | 'opencode' | 'grok';
+export type AgentType = 'codex' | 'gemini' | 'cursor' | 'claude' | 'opencode' | 'grok' | 'antigravity';
 
 const claudeToolUseMap = new Map<string, { tool: string; command?: string; path?: string }>();
 
@@ -27,6 +27,8 @@ export function normalizeEvents(agentType: AgentType, raw: any): any[] {
     return normalizeOpencode(raw);
   } else if (agentType === 'grok') {
     return normalizeGrok(raw);
+  } else if (agentType === 'antigravity') {
+    return normalizeAntigravity(raw);
   }
 
   const timestamp = new Date().toISOString();
@@ -925,6 +927,84 @@ function normalizeGrok(raw: any): any[] {
   return [{
     type: eventType,
     agent: 'grok',
+    raw: raw,
+    timestamp: timestamp,
+  }];
+}
+
+// --- Antigravity parsing ---
+// Intentionally conservative. Antigravity's `agy` binary advertises an
+// `--output-format json` flag in its docs, but the released binary errors with
+// `flags provided but not defined: -output-format` (tracked upstream as
+// google-antigravity/antigravity-cli#7, open as of May 2026). Until JSON
+// streaming stabilizes, this parser treats agy output as a black box:
+//   - non-object input (a plain string line, or null/number) becomes a single
+//     `message` event with the full content and complete:true so the
+//     summarizer captures it without token-level concatenation
+//   - objects with a recognizable `type` field (e.g. `init`, `message`,
+//     `result`) get a minimal shape-preserving normalization
+//   - everything else falls through to the generic unknown-event shape
+// Once agy ships stable streaming JSON, replace this with proper event
+// mapping mirroring normalizeGrok / normalizeClaude.
+function normalizeAntigravity(raw: any): any[] {
+  const timestamp = new Date().toISOString();
+
+  if (typeof raw === 'string') {
+    if (!raw) return [];
+    return [{
+      type: 'message',
+      agent: 'antigravity',
+      content: raw,
+      complete: true,
+      timestamp: timestamp,
+    }];
+  }
+
+  if (!raw || typeof raw !== 'object') {
+    return [{
+      type: 'unknown',
+      agent: 'antigravity',
+      raw: raw,
+      timestamp: timestamp,
+    }];
+  }
+
+  const eventType = raw.type || 'unknown';
+
+  if (eventType === 'init') {
+    return [{
+      type: 'init',
+      agent: 'antigravity',
+      session_id: typeof raw.sessionId === 'string' ? raw.sessionId : null,
+      timestamp: timestamp,
+    }];
+  }
+
+  if (eventType === 'message') {
+    const content = typeof raw.content === 'string' ? raw.content : '';
+    if (!content) return [];
+    return [{
+      type: 'message',
+      agent: 'antigravity',
+      content: content,
+      complete: raw.complete !== false,
+      timestamp: timestamp,
+    }];
+  }
+
+  if (eventType === 'result') {
+    return [{
+      type: 'result',
+      agent: 'antigravity',
+      status: raw.status === 'error' ? 'error' : 'success',
+      session_id: typeof raw.sessionId === 'string' ? raw.sessionId : null,
+      timestamp: timestamp,
+    }];
+  }
+
+  return [{
+    type: eventType,
+    agent: 'antigravity',
     raw: raw,
     timestamp: timestamp,
   }];

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1994,7 +1994,9 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
 
         // Register hooks into agent-native settings.json/hooks.json. Gemini
         // shipped hooks in 0.26.0; gate already passed above so this is safe.
-        if (agent === 'claude' || agent === 'codex' || agent === 'gemini') {
+        // Grok auto-discovers from ~/.grok/hooks/ so the script copy above
+        // is sufficient — no settings.json registration needed.
+        if (agent === 'claude' || agent === 'codex' || agent === 'gemini' || agent === 'antigravity') {
           registerHooksToSettings(agent, versionHome);
         }
       }


### PR DESCRIPTION
## Summary

Closes the support gaps for the two newest agents in the registry — Google Antigravity (`agy`) and xAI Grok Build (`grok`) — across the teams runner, exec path, sync pipeline, and hook registrar.

- **Phase 0 (registry):** corrects `src/lib/agents.ts` to match reality — both CLIs actually support hooks, plugins, and allowlists per their May 2026 docs; agy was wrongly flagged `nativeAgentsSkillsDir: true` (it does NOT read `~/.agents/skills/`), causing sync to delete agy's skills dir; grok auth env var comment was `GROK_CODE_XAI_API_KEY` but xAI docs use `XAI_API_KEY`.
- **Phase 1 (teams):** mirrors PR #51's grok pattern for antigravity — `AgentType` union, `normalizeAntigravity` parser (conservative pending [google-antigravity/antigravity-cli#7](https://github.com/google-antigravity/antigravity-cli/issues/7) — `--output-format` flag broken in released agy binary), `TEAM_AGENT_TYPES`, `AGENT_NAMES`, plus 10 new unit tests.
- **Phase 2 (exec/run):** real `--mode` flags for both (grok `--mode plan` / `--always-approve`; agy `--dangerously-skip-permissions` for full mode), grok ACP wiring (`grok agent stdio`), `PERMISSIONS_CAPABLE_AGENTS` list extension, new `grok-fast` / `grok-heavy` / `agy` profile presets.
- **Phase 3 (sync hooks):** `registerHooksForAntigravity` writes agy's native JSON hook entries (`before_tool_call`, `after_model_call`, `on_loop_stop`, `on_error`) into `~/.gemini/antigravity-cli/settings.json`, preserving user-authored entries. Grok intentionally not wired — it auto-discovers `~/.grok/hooks/` so the existing script-copy IS the registration. 9 new hook tests.

## Out of scope (follow-ups)

- agy `jsonFlags` (gated on upstream issue #7 landing)
- session reader / transcript parsers for grok + agy (paths not yet documented)
- per-agent permission file serializers (grok TOML, agy JSON) — list membership only in this PR
- cloud dispatch (no Grok Cloud / Antigravity Cloud product exists yet)

## Research

All capability claims sourced from May 2026 official docs:
- xAI: \`docs.x.ai/build/cli/headless-scripting\`, \`docs.x.ai/build/modes-and-commands\`, \`docs.x.ai/build/enterprise\`, \`docs.x.ai/build/features/skills-plugins-marketplaces\`
- Google: Antigravity transition blog (developers.googleblog.com), MCP install guide (github/github-mcp-server), DEV Community hands-on guides

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] vitest on touched files (\`src/lib/teams/__tests__/parsers-antigravity.test.ts\`, \`src/lib/teams/__tests__/parsers-grok.test.ts\`, \`src/lib/__tests__/hooks.test.ts\`) — 43/43 pass
- [x] Full vitest suite — 1749 pass; 8 pre-existing failures in files NOT touched here (shims test ESM \`require()\` bug, models tests needing installed CLIs, project-resources orphan-sweep timeout)
- [ ] Manual smoke: \`agents teams add ag-smoke antigravity \"say hi\"\` (deferred — requires \`agy\` installed locally)
- [ ] Manual smoke: \`agents run grok --mode plan -p \"plan a refactor\"\` (deferred — requires \`grok\` installed locally)

## Session Context

[Session transcript](https://gist.github.com/muqsitnawaz/943cd37dd40e603da2198e0329d650ff)