### PR TITLE
feat: add cli as a new resource type

### DIFF
--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -1,0 +1,29 @@
+name: Sandbox tests
+
+# Runs on the phnx-labs org self-hosted runner pool (cpx41, 4 ephemeral
+# runner processes). Infra lives at agents/infra/ci-runner.
+#
+# Tool versions are NOT pinned here — setup-bun and any future setup-* steps
+# read the source of truth out of package.json / go.mod / etc.
+
+on:
+  pull_request:
+    branches: ['main', 'release/**']
+
+concurrency:
+  group: sandbox-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - run: bun install --frozen-lockfile
+      - run: bun run build
+      - run: bun run test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,9 @@ Clone from `phnx-labs/.agents-system` to see exactly what ships. Nothing else be
 
 **No `secrets/` directory anywhere.** Bundle metadata lives in macOS Keychain, not on disk.
 
-These `$HOME`-level directories (plus an optional `.agents/` at project root) are called **DotAgents repos** — they live outside this codebase and are managed by the CLI. Each has a canonical layout: `commands/`, `skills/`, `hooks/`, `rules/`, `mcp/`, `permissions/`, `profiles/`, `subagents/`. The typed items inside are called **resources**. Resolution order is project > user > extra repos > system; same-named resource at a higher layer wins, everything else unions in. See `docs/00-concepts.md` for the full model.
+**CLI binaries (`~/.agents/cli/<name>.yaml`)** declare host-level command-line tools the user wants installed (e.g. `higgsfield`, `gh`). One YAML per tool with `install:` methods tried in order (`npm`/`brew`/`script`/`binary`). Unlike skills/commands/hooks, CLI manifests are NOT copied into per-agent version homes — they install binaries onto the host PATH. Manage via `agents cli list|install|check|view|add`. `agents pull` lists missing entries and prompts to install them.
+
+These `$HOME`-level directories (plus an optional `.agents/` at project root) are called **DotAgents repos** — they live outside this codebase and are managed by the CLI. Each has a canonical layout: `commands/`, `skills/`, `hooks/`, `rules/`, `mcp/`, `cli/`, `permissions/`, `profiles/`, `subagents/`. The typed items inside are called **resources**. Resolution order is project > user > extra repos > system; same-named resource at a higher layer wins, everything else unions in. See `docs/00-concepts.md` for the full model.
 
 ## Source layout
 

--- a/scripts/sandbox.sh
+++ b/scripts/sandbox.sh
@@ -25,17 +25,19 @@ PROFILE="${CRABBOX_PROFILE:-$(awk '/^profile:/ {print $2; exit}' "$REPO_ROOT/.cr
 PROFILE="${PROFILE:-default}"
 export PROFILE
 
-# GitHub .agents repo for syncing skills/commands. Must be set explicitly.
-AGENTS_REPO="${AGENTS_REPO:?AGENTS_REPO must be set to your DotAgents repo (e.g. git@github.com:owner/.agents.git)}"
-
 die() { echo "error: $*" >&2; exit 1; }
 
-# Ensure deps
-command -v agents >/dev/null || die "agents-cli not installed"
+# Ensure deps. `agents` is only needed when secrets must be pulled from the
+# local Keychain — CI passes them in via env, so we don't require it there.
 command -v crabbox >/dev/null || die "crabbox not installed"
 
-# Load Hetzner token
-eval "$(agents secrets export hetzner.com 2>/dev/null)" || die "Failed to load hetzner.com secrets"
+# Load Hetzner token. Prefer an already-set HCLOUD_TOKEN (CI workflow path);
+# otherwise fall back to the agents-cli Keychain bundle (local dev path).
+if [[ -z "${HCLOUD_TOKEN:-}" ]]; then
+  command -v agents >/dev/null || die "HCLOUD_TOKEN not set and agents-cli not installed"
+  eval "$(agents secrets export hetzner.com 2>/dev/null)" || die "Failed to load hetzner.com secrets"
+fi
+[[ -n "${HCLOUD_TOKEN:-}" ]] || die "HCLOUD_TOKEN is empty after secret resolution"
 export HCLOUD_TOKEN
 
 # Generate GitHub App token for private repo access.
@@ -102,11 +104,17 @@ if [[ "$PR_MODE" == "1" ]]; then
   export TOKEN_REPO="$REPO_SLUG"
 fi
 
-GITHUB_TOKEN=$(generate_github_token || true)
-[[ -n "$GITHUB_TOKEN" ]] || echo "warn: failed to generate GitHub App token (private repos won't clone)" >&2
+# Prefer a pre-set GITHUB_TOKEN (CI injects ${{ secrets.GITHUB_TOKEN }} or a PAT).
+# Otherwise mint one from the GitHub App via the Keychain bundle.
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  GITHUB_TOKEN=$(generate_github_token || true)
+fi
+[[ -n "$GITHUB_TOKEN" ]] || echo "warn: no GITHUB_TOKEN available (private repos won't clone)" >&2
 
-# Load Claude token for running agents on sandbox
-eval "$(agents secrets export anthropic.com 2>/dev/null)" || true
+# Load Claude token for running agents on sandbox. Honor a pre-set env var first.
+if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]] && command -v agents >/dev/null; then
+  eval "$(agents secrets export anthropic.com 2>/dev/null)" || true
+fi
 CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN:-}"
 
 # Pick the slug of a running box matching $PROFILE, or empty if none.

--- a/src/commands/cli.ts
+++ b/src/commands/cli.ts
@@ -1,0 +1,268 @@
+/**
+ * `agents cli` — manage declarative CLI binary installs.
+ *
+ * Each entry under <repo>/cli/<name>.yaml declares a CLI tool the user wants on
+ * the host PATH (e.g. higgsfield, gh, glab). On a fresh machine `agents cli
+ * install` runs the first install method whose package manager is available
+ * (npm > brew > script > binary, in declared order).
+ *
+ * This is a sibling to `agents mcp` but one layer down: MCP wires servers into
+ * agent configs; CLI puts binaries on the user's normal PATH. CLI manifests are
+ * NOT copied into per-agent version homes — they are global to the user.
+ */
+import type { Command } from 'commander';
+import * as fs from 'fs';
+import * as path from 'path';
+import chalk from 'chalk';
+import { confirm } from '@inquirer/prompts';
+
+import {
+  listCliManifests,
+  listCliStatus,
+  resolveCliManifest,
+  installCli,
+  describeMethod,
+  selectInstallMethod,
+  isCliInstalled,
+  type CliManifest,
+} from '../lib/cli-resources.js';
+import { getUserAgentsDir } from '../lib/state.js';
+import { isPromptCancelled } from './utils.js';
+
+function userCliDir(): string {
+  return path.join(getUserAgentsDir(), 'cli');
+}
+
+/** Render the status table — one row per declared CLI. */
+function printStatus(rows: { manifest: CliManifest; installed: boolean }[]): void {
+  if (rows.length === 0) {
+    console.log(chalk.gray('No CLIs declared.'));
+    console.log(chalk.gray(`Create one with: agents cli add <name>`));
+    return;
+  }
+  const nameWidth = Math.max(4, ...rows.map((r) => r.manifest.name.length));
+  for (const row of rows) {
+    const status = row.installed
+      ? chalk.green('installed')
+      : chalk.yellow('missing');
+    const name = row.manifest.name.padEnd(nameWidth);
+    const source = chalk.gray(`[${row.manifest.source}]`);
+    const desc = row.manifest.description ? '  ' + chalk.gray(row.manifest.description) : '';
+    console.log(`  ${name}  ${status}  ${source}${desc}`);
+  }
+}
+
+export function registerCliCommands(program: Command): void {
+  const cliCmd = program
+    .command('cli')
+    .description('Declare and install host CLI binaries (gh, higgsfield, glab, ...)')
+    .addHelpText('after', `
+CLI manifests live in <repo>/cli/<name>.yaml and declare how to install a
+binary on the host. On a fresh machine, 'agents cli install' runs the first
+compatible method (npm > brew > script > binary) for every declared entry.
+
+Examples:
+  # See which declared CLIs are installed on this host
+  agents cli list
+
+  # Install everything that's missing
+  agents cli install
+
+  # Install one
+  agents cli install higgsfield
+
+  # Show the manifest detail
+  agents cli view higgsfield
+
+  # Exit 0 if all declared CLIs are installed (use in CI / setup scripts)
+  agents cli check
+
+When to use:
+  - After 'agents pull' on a new machine, to materialize host binaries
+  - In a team setup: commit cli/ entries so teammates get the same toolchain
+`);
+
+  cliCmd
+    .command('list')
+    .description('Show all declared CLIs and whether each is installed on this host')
+    .action(() => {
+      const { statuses, errors } = listCliStatus(process.cwd());
+      printStatus(statuses);
+      for (const err of errors) {
+        console.log(chalk.red(`  parse error: ${err.file}: ${err.reason}`));
+      }
+    });
+
+  cliCmd
+    .command('check')
+    .description('Exit 0 if every declared CLI is installed, 1 otherwise')
+    .action(() => {
+      const { statuses, errors } = listCliStatus(process.cwd());
+      const missing = statuses.filter((s) => !s.installed);
+      if (errors.length > 0) {
+        for (const err of errors) {
+          console.error(chalk.red(`parse error: ${err.file}: ${err.reason}`));
+        }
+        process.exit(1);
+      }
+      if (missing.length === 0) {
+        console.log(chalk.green(`All ${statuses.length} declared CLI(s) installed.`));
+        return;
+      }
+      console.log(chalk.yellow(`Missing: ${missing.map((s) => s.manifest.name).join(', ')}`));
+      process.exit(1);
+    });
+
+  cliCmd
+    .command('install [name]')
+    .description('Install one (by name) or all missing declared CLIs')
+    .option('-y, --yes', 'skip the confirmation prompt')
+    .option('--dry-run', 'print install commands without executing them')
+    .option('--force', 'reinstall even when the check command currently passes')
+    .action(async (nameArg: string | undefined, opts: { yes?: boolean; dryRun?: boolean; force?: boolean }) => {
+      let targets: CliManifest[];
+      if (nameArg) {
+        const manifest = resolveCliManifest(nameArg, process.cwd());
+        if (!manifest) {
+          console.error(chalk.red(`No CLI manifest named "${nameArg}".`));
+          console.error(chalk.gray(`Looked in: ${userCliDir()}`));
+          process.exit(1);
+        }
+        targets = [manifest];
+      } else {
+        const { manifests, errors } = listCliManifests(process.cwd());
+        for (const err of errors) {
+          console.error(chalk.red(`parse error: ${err.file}: ${err.reason}`));
+        }
+        if (manifests.length === 0) {
+          console.log(chalk.gray('No CLIs declared. Nothing to install.'));
+          return;
+        }
+        targets = manifests;
+      }
+
+      // Filter out already-installed unless --force
+      const work = targets.filter((m) => opts.force || !isCliInstalled(m));
+      if (work.length === 0) {
+        console.log(chalk.green(`All ${targets.length} declared CLI(s) already installed.`));
+        return;
+      }
+
+      // Preview + confirm
+      console.log(chalk.bold('\nWill install:'));
+      for (const m of work) {
+        const method = selectInstallMethod(m);
+        const action = method ? describeMethod(method) : chalk.red('no compatible install method');
+        console.log(`  ${chalk.cyan(m.name.padEnd(20))} ${chalk.gray(action)}`);
+      }
+      console.log('');
+
+      if (!opts.yes && !opts.dryRun) {
+        try {
+          const proceed = await confirm({ message: 'Proceed?', default: true });
+          if (!proceed) {
+            console.log(chalk.gray('Cancelled.'));
+            return;
+          }
+        } catch (err) {
+          if (isPromptCancelled(err)) {
+            console.log(chalk.gray('Cancelled.'));
+            return;
+          }
+          throw err;
+        }
+      }
+
+      // Execute
+      let failures = 0;
+      for (const m of work) {
+        console.log(chalk.bold(`\n→ ${m.name}`));
+        const result = installCli(m, { dryRun: opts.dryRun });
+        if (result.output) console.log(chalk.gray(result.output));
+        if (result.error) {
+          console.log(chalk.red(`  ${result.error}`));
+          failures++;
+          continue;
+        }
+        if (opts.dryRun) continue;
+        if (result.installed) {
+          console.log(chalk.green(`  installed (${describeMethod(result.method!)})`));
+          if (m.postInstall) {
+            console.log(chalk.gray(m.postInstall.trim().split('\n').map((l) => '  ' + l).join('\n')));
+          }
+        } else {
+          console.log(chalk.yellow(`  install command ran but \`${m.check}\` still fails — check the output above`));
+          failures++;
+        }
+      }
+      if (failures > 0) process.exit(1);
+    });
+
+  cliCmd
+    .command('view <name>')
+    .description('Show the parsed manifest detail')
+    .action((name: string) => {
+      const manifest = resolveCliManifest(name, process.cwd());
+      if (!manifest) {
+        console.error(chalk.red(`No CLI manifest named "${name}".`));
+        process.exit(1);
+      }
+      console.log(chalk.bold.cyan(manifest.name));
+      if (manifest.description) console.log('  ' + chalk.gray(manifest.description));
+      if (manifest.homepage) console.log('  ' + chalk.gray(manifest.homepage));
+      console.log('  ' + chalk.gray(`source: ${manifest.source}`));
+      console.log('  ' + chalk.gray(`file: ${manifest.path}`));
+      console.log('');
+      console.log(chalk.bold('  check'));
+      console.log('    ' + manifest.check);
+      console.log('');
+      console.log(chalk.bold('  install methods'));
+      for (const method of manifest.install) {
+        console.log('    ' + describeMethod(method));
+      }
+      if (manifest.postInstall) {
+        console.log('');
+        console.log(chalk.bold('  post_install'));
+        for (const line of manifest.postInstall.trim().split('\n')) {
+          console.log('    ' + line);
+        }
+      }
+      console.log('');
+      console.log(`  status: ${isCliInstalled(manifest) ? chalk.green('installed') : chalk.yellow('missing')}`);
+    });
+
+  cliCmd
+    .command('add <name>')
+    .description('Scaffold a new manifest at ~/.agents/cli/<name>.yaml')
+    .option('--npm <pkg>', 'declare an npm install method')
+    .option('--brew <formula>', 'declare a brew install method')
+    .option('--script <url>', 'declare a curl|sh install method')
+    .option('--description <text>', 'one-line description')
+    .option('--homepage <url>', 'project homepage')
+    .action((name: string, opts: { npm?: string; brew?: string; script?: string; description?: string; homepage?: string }) => {
+      const dir = userCliDir();
+      fs.mkdirSync(dir, { recursive: true });
+      const target = path.join(dir, `${name}.yaml`);
+      if (fs.existsSync(target)) {
+        console.error(chalk.red(`Already exists: ${target}`));
+        process.exit(1);
+      }
+      const methods: string[] = [];
+      if (opts.npm) methods.push(`  - npm: "${opts.npm}"`);
+      if (opts.brew) methods.push(`  - brew: ${opts.brew}`);
+      if (opts.script) methods.push(`  - script: ${opts.script}`);
+      if (methods.length === 0) {
+        methods.push(`  - npm: "${name}"`);
+      }
+      const lines = [
+        `name: ${name}`,
+        ...(opts.description ? [`description: ${opts.description}`] : []),
+        ...(opts.homepage ? [`homepage: ${opts.homepage}`] : []),
+        `check: ${name} --version`,
+        `install:`,
+        ...methods,
+      ];
+      fs.writeFileSync(target, lines.join('\n') + '\n');
+      console.log(chalk.green(`Created ${target}`));
+    });
+}

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -58,6 +58,12 @@ import {
   type ResourceSelection,
 } from '../lib/versions.js';
 import {
+  listCliStatus,
+  installCli,
+  describeMethod,
+  selectInstallMethod,
+} from '../lib/cli-resources.js';
+import {
   ensureShimCurrent,
   isShimsInPath,
   addShimsToPath,
@@ -67,7 +73,7 @@ import {
 } from '../lib/shims.js';
 import { parseHookManifest, registerHooksToSettings } from '../lib/hooks.js';
 import { setHelpSections } from '../lib/help.js';
-import { select } from '@inquirer/prompts';
+import { select, confirm } from '@inquirer/prompts';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
 
 /**
@@ -441,6 +447,56 @@ export function registerPullCommand(program: Command): void {
             }
             switchHomeFileSymlinks(agentId, version);
             console.log(chalk.green(`Set ${agentLabel(agent.id)}@${version} as default`));
+          }
+        }
+
+        // Report (and optionally install) any declared CLIs that are missing
+        // from the host. Skipped under -y so non-interactive pulls don't trigger
+        // package-manager prompts.
+        try {
+          const { statuses, errors } = listCliStatus(process.cwd());
+          for (const err of errors) {
+            console.log(chalk.yellow(`  CLI manifest parse error: ${err.file}: ${err.reason}`));
+          }
+          const missing = statuses.filter((s) => !s.installed);
+          if (missing.length > 0) {
+            console.log(chalk.bold('\nDeclared CLIs missing from this host:'));
+            for (const s of missing) {
+              const method = selectInstallMethod(s.manifest);
+              const action = method ? describeMethod(method) : chalk.red('no compatible install method');
+              console.log(`  ${chalk.cyan(s.manifest.name.padEnd(20))} ${chalk.gray(action)}`);
+            }
+            console.log('');
+
+            if (!skipPrompts) {
+              const proceed = await confirm({ message: `Install ${missing.length} missing CLI(s) now?`, default: true });
+              if (proceed) {
+                for (const s of missing) {
+                  console.log(chalk.bold(`\n→ ${s.manifest.name}`));
+                  const result = installCli(s.manifest);
+                  if (result.error) {
+                    console.log(chalk.red(`  ${result.error}`));
+                    continue;
+                  }
+                  if (result.installed) {
+                    console.log(chalk.green(`  installed`));
+                    if (s.manifest.postInstall) {
+                      console.log(chalk.gray(s.manifest.postInstall.trim().split('\n').map((l) => '  ' + l).join('\n')));
+                    }
+                  } else {
+                    console.log(chalk.yellow(`  install ran but \`${s.manifest.check}\` still fails`));
+                  }
+                }
+              } else {
+                console.log(chalk.gray(`Skipped. Run 'agents cli install' later.`));
+              }
+            } else {
+              console.log(chalk.gray(`Run 'agents cli install' to install them.`));
+            }
+          }
+        } catch (err) {
+          if (!isPromptCancelled(err)) {
+            console.log(chalk.yellow(`CLI install skipped: ${(err as Error).message}`));
           }
         }
 

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -51,6 +51,7 @@ import {
   getActuallySyncedResources,
   getNewResources,
   hasNewResources,
+  printTrashFooter,
   type ResourceSelection,
 } from '../lib/versions.js';
 import {
@@ -157,6 +158,7 @@ async function versionPruneAction(
   commandName: VersionPruneVerb,
 ): Promise<void> {
   const isProject = options.project;
+  const moved: Array<{ agent: AgentId; version: string }> = [];
 
   for (const spec of specs) {
     const parsed = parseAgentSpec(spec);
@@ -209,7 +211,8 @@ async function versionPruneAction(
           const versionDir = getVersionDir(agent, v);
           removeVersion(agent, v);
           fixSessionFilePaths(agent, v, versionDir);
-          console.log(chalk.green(`Removed ${agentLabel(agentConfig.id)}@${v}`));
+          console.log(chalk.green(`Moved ${agentLabel(agentConfig.id)}@${v} to trash`));
+          moved.push({ agent, version: v });
         }
 
         if (globalDefault && toRemove.includes(globalDefault)) {
@@ -234,7 +237,8 @@ async function versionPruneAction(
       const versionDir = getVersionDir(agent, version);
       removeVersion(agent, version);
       fixSessionFilePaths(agent, version, versionDir);
-      console.log(chalk.green(`Removed ${agentLabel(agentConfig.id)}@${version}`));
+      console.log(chalk.green(`Moved ${agentLabel(agentConfig.id)}@${version} to trash`));
+      moved.push({ agent, version });
 
       const remaining = listInstalledVersions(agent);
       if (remaining.length === 0) {
@@ -254,6 +258,8 @@ async function versionPruneAction(
       }
     }
   }
+
+  printTrashFooter(moved);
 }
 
 function configureVersionPruneCommand(cmd: Command, commandName: VersionPruneVerb): void {

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -48,6 +48,7 @@ import {
   promptNewResourceSelection,
   syncResourcesToVersion,
   removeVersion,
+  printTrashFooter,
 } from '../lib/versions.js';
 import {
   getShimsDir,
@@ -985,14 +986,13 @@ async function buildAgentPrunePlan(agentId: AgentId): Promise<AgentPrunePlan> {
   return { agentId, toPrune, skippedDefaults };
 }
 
-async function executePrunePlan(plan: AgentPrunePlan): Promise<number> {
-  let removed = 0;
+async function executePrunePlan(plan: AgentPrunePlan): Promise<Array<{ agent: AgentId; version: string }>> {
+  const moved: Array<{ agent: AgentId; version: string }> = [];
   for (const p of plan.toPrune) {
-    console.log(chalk.gray(`Removing ${agentLabel(p.agentId)}@${p.version}...`));
     const ok = removeVersion(p.agentId, p.version);
     if (ok) {
-      console.log(chalk.green(`Removed ${agentLabel(p.agentId)}@${p.version}`));
-      removed++;
+      console.log(chalk.green(`Moved ${agentLabel(p.agentId)}@${p.version} to trash`));
+      moved.push({ agent: p.agentId, version: p.version });
     } else {
       console.log(chalk.yellow(`Already gone: ${agentLabel(p.agentId)}@${p.version}`));
     }
@@ -1000,7 +1000,7 @@ async function executePrunePlan(plan: AgentPrunePlan): Promise<number> {
   if (listInstalledVersions(plan.agentId).length === 0) {
     removeShim(plan.agentId);
   }
-  return removed;
+  return moved;
 }
 
 function printPrunePlan(plan: AgentPrunePlan, isFirst: boolean): void {
@@ -1063,7 +1063,7 @@ export async function pruneDuplicates(
   }
 
   const totalCandidates = actionable.reduce((n, plan) => n + plan.toPrune.length, 0);
-  let totalRemoved = 0;
+  const allMoved: Array<{ agent: AgentId; version: string }> = [];
   let isFirst = true;
   let processedAny = false;
 
@@ -1112,7 +1112,7 @@ export async function pruneDuplicates(
       }
     }
 
-    totalRemoved += await executePrunePlan(plan);
+    allMoved.push(...(await executePrunePlan(plan)));
     processedAny = true;
     isFirst = false;
     console.log();
@@ -1124,7 +1124,8 @@ export async function pruneDuplicates(
   }
 
   if (processedAny) {
-    console.log(chalk.bold(`Pruned ${totalRemoved} version${totalRemoved === 1 ? '' : 's'}.`));
+    console.log(chalk.bold(`Pruned ${allMoved.length} version${allMoved.length === 1 ? '' : 's'}.`));
+    printTrashFooter(allMoved);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ import { registerSkillsCommands } from './commands/skills.js';
 import { registerRulesCommands } from './commands/rules.js';
 import { registerPermissionsCommands } from './commands/permissions.js';
 import { registerMcpCommands } from './commands/mcp.js';
+import { registerCliCommands } from './commands/cli.js';
 import { registerVersionsCommands } from './commands/versions.js';
 import { registerImportCommand } from './commands/import.js';
 import { registerPackagesCommands } from './commands/packages.js';
@@ -575,6 +576,7 @@ program
   });
 
 registerMcpCommands(program);
+registerCliCommands(program);
 registerSubagentsCommands(program);
 registerPluginsCommands(program);
 registerWorkflowsCommands(program);

--- a/src/lib/cli-resources.test.ts
+++ b/src/lib/cli-resources.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  parseCliManifest,
+  selectInstallMethod,
+  describeMethod,
+  buildInstallCommand,
+  type CliManifest,
+  type InstallMethod,
+} from './cli-resources.js';
+
+function manifest(install: InstallMethod[]): CliManifest {
+  return {
+    name: 'higgsfield',
+    description: 'test',
+    check: 'higgsfield --version',
+    install,
+    source: 'user',
+    path: '/tmp/test.yaml',
+  };
+}
+
+describe('parseCliManifest', () => {
+  it('parses a multi-method manifest with post_install', () => {
+    const yaml = `
+name: higgsfield
+description: AI media CLI
+homepage: https://higgsfield.ai/cli
+check: higgsfield --version
+install:
+  - npm: "@higgsfield/cli@latest"
+  - brew: higgsfield
+  - script: https://example.com/install.sh
+post_install: |
+  Run higgsfield auth login.
+`;
+    const parsed = parseCliManifest(yaml, { name: 'higgsfield', source: 'user', path: '/tmp/h.yaml' });
+    expect(parsed.name).toBe('higgsfield');
+    expect(parsed.description).toBe('AI media CLI');
+    expect(parsed.check).toBe('higgsfield --version');
+    expect(parsed.install).toHaveLength(3);
+    expect(parsed.install[0]).toEqual({ npm: '@higgsfield/cli@latest' });
+    expect(parsed.install[1]).toEqual({ brew: 'higgsfield' });
+    expect(parsed.install[2]).toEqual({ script: 'https://example.com/install.sh' });
+    expect(parsed.postInstall).toMatch(/auth login/);
+  });
+
+  it('defaults check to "<name> --version" when omitted', () => {
+    const parsed = parseCliManifest(
+      'name: gh\ninstall:\n  - brew: gh\n',
+      { name: 'gh', source: 'user', path: '/tmp/g.yaml' },
+    );
+    expect(parsed.check).toBe('gh --version');
+  });
+
+  it('uses the filename-derived name when manifest omits it', () => {
+    const parsed = parseCliManifest(
+      'install:\n  - brew: glab\n',
+      { name: 'glab', source: 'user', path: '/tmp/glab.yaml' },
+    );
+    expect(parsed.name).toBe('glab');
+  });
+
+  it('rejects an empty install list', () => {
+    expect(() =>
+      parseCliManifest('name: x\ninstall: []\n', { name: 'x', source: 'user', path: '/x' }),
+    ).toThrow(/non-empty list/);
+  });
+
+  it('rejects an install entry with no recognized method', () => {
+    expect(() =>
+      parseCliManifest(
+        'name: x\ninstall:\n  - apt: x\n',
+        { name: 'x', source: 'user', path: '/x' },
+      ),
+    ).toThrow(/unknown method/);
+  });
+
+  it('rejects an install entry with multiple methods declared', () => {
+    expect(() =>
+      parseCliManifest(
+        'name: x\ninstall:\n  - npm: x\n    brew: x\n',
+        { name: 'x', source: 'user', path: '/x' },
+      ),
+    ).toThrow(/exactly one method/);
+  });
+
+  it('parses a binary platform map with extract path', () => {
+    const yaml = `
+name: x
+install:
+  - binary:
+      darwin-arm64:
+        url: https://example.com/x-darwin.tgz
+        extract: x
+      linux-x64:
+        url: https://example.com/x-linux.tgz
+        extract: x
+`;
+    const parsed = parseCliManifest(yaml, { name: 'x', source: 'user', path: '/x' });
+    expect(parsed.install).toHaveLength(1);
+    const m = parsed.install[0];
+    expect('binary' in m).toBe(true);
+    if ('binary' in m) {
+      expect(m.binary['darwin-arm64'].url).toBe('https://example.com/x-darwin.tgz');
+      expect(m.binary['darwin-arm64'].extract).toBe('x');
+    }
+  });
+});
+
+describe('describeMethod', () => {
+  it('renders npm/brew/script', () => {
+    expect(describeMethod({ npm: 'foo@1.0' })).toBe('npm install -g foo@1.0');
+    expect(describeMethod({ brew: 'foo' })).toBe('brew install foo');
+    expect(describeMethod({ script: 'https://x' })).toBe('curl https://x | sh');
+  });
+});
+
+describe('buildInstallCommand', () => {
+  it('builds the npm and brew shell strings exactly', () => {
+    expect(buildInstallCommand({ npm: '@higgsfield/cli@latest' }))
+      .toBe('npm install -g @higgsfield/cli@latest');
+    expect(buildInstallCommand({ brew: 'higgsfield' }))
+      .toBe('brew install higgsfield');
+  });
+});
+
+describe('selectInstallMethod', () => {
+  // selectInstallMethod calls hasCommand() which probes the real host.
+  // We can still validate the "no compatible method" path deterministically.
+  it('returns null when only an unsupported-platform binary is declared', () => {
+    const m = manifest([{ binary: { 'plan9-mips': { url: 'http://x' } } }]);
+    expect(selectInstallMethod(m)).toBeNull();
+  });
+
+  it('returns the only npm method on a host with npm (this dev box has npm)', () => {
+    // We rely on the dev environment having npm; if it doesn't, this test is
+    // skipped at the assertion level rather than failing.
+    const m = manifest([{ npm: 'foo' }]);
+    const picked = selectInstallMethod(m);
+    if (picked) {
+      expect(picked).toEqual({ npm: 'foo' });
+    }
+  });
+});

--- a/src/lib/cli-resources.ts
+++ b/src/lib/cli-resources.ts
@@ -1,0 +1,343 @@
+/**
+ * CLI tool resources — declarative manifests for command-line binaries the user
+ * wants installed on the host (e.g. higgsfield, gh, glab).
+ *
+ * A CLI resource is a YAML file under <repo>/cli/<name>.yaml. Resolution follows
+ * the same project > user > system > extra-repo precedence as other resources,
+ * but unlike skills/commands/hooks, CLI resources are NOT copied into per-agent
+ * version homes — they install binaries onto the host PATH. The relationship is
+ * "Brewfile-style": declare once in ~/.agents/cli/, install on any new machine.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { execSync, spawnSync } from 'child_process';
+import * as yaml from 'yaml';
+import { listResources, resolveResource } from './resources.js';
+
+// ─── Schema ──────────────────────────────────────────────────────────────────
+
+/** A single install method. Exactly one of the keys (npm/brew/script/binary) is set. */
+export type InstallMethod =
+  | { npm: string }
+  | { brew: string }
+  | { script: string }
+  | { binary: BinarySpec };
+
+/** Per-platform binary download spec. Keys are `<os>-<arch>` (e.g. darwin-arm64). */
+export interface BinarySpec {
+  [platform: string]: {
+    url: string;
+    /** Path inside the archive (relative). Required when url is a .tar.gz/.zip. */
+    extract?: string;
+  };
+}
+
+/** Parsed CLI manifest. */
+export interface CliManifest {
+  /** Name as it appears on the command line (e.g. "higgsfield"). */
+  name: string;
+  /** One-line summary shown in `agents cli list`. */
+  description?: string;
+  /** Project homepage; used in detail view + post-install messaging. */
+  homepage?: string;
+  /** Command run to verify the binary is installed (default: "<name> --version"). */
+  check: string;
+  /** Install methods tried in order; first one whose tool is available is used. */
+  install: InstallMethod[];
+  /** Message printed after successful install — typically auth instructions. */
+  postInstall?: string;
+  /** Origin layer this manifest was resolved from. */
+  source: string;
+  /** Absolute path to the yaml file. */
+  path: string;
+}
+
+/** A validation problem in a CLI manifest. */
+export interface CliManifestError {
+  /** Filename that failed to parse. */
+  file: string;
+  /** Human-readable reason. */
+  reason: string;
+}
+
+// ─── Parsing ─────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a single CLI manifest from its YAML contents.
+ * Returns a manifest on success; throws on schema violations so callers can
+ * decide whether to surface or swallow the error per file.
+ */
+export function parseCliManifest(
+  contents: string,
+  opts: { name: string; source: string; path: string },
+): CliManifest {
+  const raw = yaml.parse(contents);
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('manifest must be a YAML object');
+  }
+
+  const name = typeof raw.name === 'string' && raw.name.trim() ? raw.name.trim() : opts.name;
+  const description = typeof raw.description === 'string' ? raw.description : undefined;
+  const homepage = typeof raw.homepage === 'string' ? raw.homepage : undefined;
+  const check = typeof raw.check === 'string' && raw.check.trim()
+    ? raw.check.trim()
+    : `${name} --version`;
+  const postInstall = typeof raw.post_install === 'string' ? raw.post_install : undefined;
+
+  if (!Array.isArray(raw.install) || raw.install.length === 0) {
+    throw new Error('install must be a non-empty list of methods');
+  }
+
+  const install: InstallMethod[] = raw.install.map((entry: unknown, i: number) => {
+    if (!entry || typeof entry !== 'object') {
+      throw new Error(`install[${i}] must be an object with one of: npm, brew, script, binary`);
+    }
+    const e = entry as Record<string, unknown>;
+    const keys = Object.keys(e).filter((k) => e[k] !== undefined && e[k] !== null);
+    if (keys.length !== 1) {
+      throw new Error(`install[${i}] must declare exactly one method (got: ${keys.join(', ') || 'none'})`);
+    }
+    const key = keys[0];
+    const value = e[key];
+    if (key === 'npm' || key === 'brew' || key === 'script') {
+      if (typeof value !== 'string' || !value.trim()) {
+        throw new Error(`install[${i}].${key} must be a non-empty string`);
+      }
+      return { [key]: value.trim() } as InstallMethod;
+    }
+    if (key === 'binary') {
+      if (!value || typeof value !== 'object') {
+        throw new Error(`install[${i}].binary must be a platform map`);
+      }
+      const binary: BinarySpec = {};
+      for (const [platform, spec] of Object.entries(value as Record<string, unknown>)) {
+        if (!spec || typeof spec !== 'object') {
+          throw new Error(`install[${i}].binary.${platform} must be an object with a url`);
+        }
+        const s = spec as Record<string, unknown>;
+        if (typeof s.url !== 'string' || !s.url.trim()) {
+          throw new Error(`install[${i}].binary.${platform}.url must be a non-empty string`);
+        }
+        binary[platform] = {
+          url: s.url.trim(),
+          extract: typeof s.extract === 'string' ? s.extract : undefined,
+        };
+      }
+      return { binary };
+    }
+    throw new Error(`install[${i}] has unknown method "${key}" (expected: npm, brew, script, binary)`);
+  });
+
+  return {
+    name,
+    description,
+    homepage,
+    check,
+    install,
+    postInstall,
+    source: opts.source,
+    path: opts.path,
+  };
+}
+
+/**
+ * Discover all CLI manifests resolvable from the current cwd. Returns valid
+ * manifests and any parse errors separately so the CLI can show both.
+ */
+export function listCliManifests(cwd?: string): {
+  manifests: CliManifest[];
+  errors: CliManifestError[];
+} {
+  const resolved = listResources('cli', cwd);
+  const manifests: CliManifest[] = [];
+  const errors: CliManifestError[] = [];
+
+  for (const entry of resolved) {
+    if (!entry.path.endsWith('.yaml') && !entry.path.endsWith('.yml')) continue;
+    try {
+      const contents = fs.readFileSync(entry.path, 'utf-8');
+      const manifest = parseCliManifest(contents, {
+        name: entry.name,
+        source: entry.source,
+        path: entry.path,
+      });
+      manifests.push(manifest);
+    } catch (err) {
+      errors.push({ file: entry.path, reason: (err as Error).message });
+    }
+  }
+
+  return { manifests, errors };
+}
+
+/** Resolve a single CLI manifest by name. Returns null when not declared. */
+export function resolveCliManifest(name: string, cwd?: string): CliManifest | null {
+  const resolved = resolveResource('cli', name, cwd);
+  if (!resolved) return null;
+  if (!resolved.path.endsWith('.yaml') && !resolved.path.endsWith('.yml')) return null;
+  const contents = fs.readFileSync(resolved.path, 'utf-8');
+  return parseCliManifest(contents, {
+    name: resolved.name,
+    source: resolved.source,
+    path: resolved.path,
+  });
+}
+
+// ─── Host detection ──────────────────────────────────────────────────────────
+
+/**
+ * Return true if a command resolves on the current PATH. Uses `which` on
+ * POSIX hosts; results are cached for the lifetime of the process.
+ */
+const cmdExistsCache = new Map<string, boolean>();
+export function hasCommand(cmd: string): boolean {
+  if (cmdExistsCache.has(cmd)) return cmdExistsCache.get(cmd)!;
+  const result = spawnSync('command', ['-v', cmd], { shell: true, stdio: 'ignore' });
+  const ok = result.status === 0;
+  cmdExistsCache.set(cmd, ok);
+  return ok;
+}
+
+/** Run the manifest's `check` command. Returns true when it exits 0. */
+export function isCliInstalled(manifest: CliManifest): boolean {
+  const result = spawnSync(manifest.check, {
+    shell: true,
+    stdio: 'ignore',
+    timeout: 10_000,
+  });
+  return result.status === 0;
+}
+
+// ─── Method selection ────────────────────────────────────────────────────────
+
+/**
+ * Pick the first install method whose required host tool is available.
+ * Returns null when none of the declared methods can run on this host.
+ */
+export function selectInstallMethod(manifest: CliManifest): InstallMethod | null {
+  for (const method of manifest.install) {
+    if ('npm' in method && hasCommand('npm')) return method;
+    if ('brew' in method && hasCommand('brew')) return method;
+    if ('script' in method && (hasCommand('curl') || hasCommand('wget'))) return method;
+    if ('binary' in method) {
+      const key = `${process.platform}-${process.arch}`;
+      if (method.binary[key]) return method;
+    }
+  }
+  return null;
+}
+
+/** Short description of a method for display. */
+export function describeMethod(method: InstallMethod): string {
+  if ('npm' in method) return `npm install -g ${method.npm}`;
+  if ('brew' in method) return `brew install ${method.brew}`;
+  if ('script' in method) return `curl ${method.script} | sh`;
+  const key = `${process.platform}-${process.arch}`;
+  const spec = method.binary[key];
+  return spec ? `download ${spec.url}` : 'binary download';
+}
+
+// ─── Install ─────────────────────────────────────────────────────────────────
+
+export interface InstallResult {
+  manifest: CliManifest;
+  /** Method that was attempted (null if no compatible method existed). */
+  method: InstallMethod | null;
+  /** True when the post-install `check` passed. */
+  installed: boolean;
+  /** stdout/stderr captured from the install command, for surfacing on failure. */
+  output?: string;
+  /** Set when the install runner threw or exited non-zero. */
+  error?: string;
+}
+
+/**
+ * Install a single CLI by running its first compatible method. Streams the
+ * underlying command's output to the parent terminal so users see brew/npm
+ * progress live. Verifies success by re-running `check`.
+ */
+export function installCli(
+  manifest: CliManifest,
+  opts: { dryRun?: boolean } = {},
+): InstallResult {
+  const method = selectInstallMethod(manifest);
+  if (!method) {
+    return {
+      manifest,
+      method: null,
+      installed: false,
+      error: `No compatible install method for this host (${process.platform}-${process.arch}). Declared methods: ${manifest.install.map(describeMethod).join('; ')}`,
+    };
+  }
+
+  if (opts.dryRun) {
+    return { manifest, method, installed: false, output: `[dry-run] would run: ${describeMethod(method)}` };
+  }
+
+  const cmd = buildInstallCommand(method);
+  try {
+    execSync(cmd, { stdio: 'inherit' });
+  } catch (err) {
+    return {
+      manifest,
+      method,
+      installed: false,
+      error: `install command failed: ${(err as Error).message}`,
+    };
+  }
+
+  // Re-check; many installers exit 0 but leave the binary off PATH for the
+  // current shell (e.g. brew on a fresh install). Trust `check`, not the
+  // installer's exit code.
+  cmdExistsCache.delete(manifest.name);
+  const installed = isCliInstalled(manifest);
+  return { manifest, method, installed };
+}
+
+/**
+ * Map a declarative method to a shell command. Centralized so tests and dry-run
+ * surface the exact string that would execute.
+ */
+export function buildInstallCommand(method: InstallMethod): string {
+  if ('npm' in method) return `npm install -g ${method.npm}`;
+  if ('brew' in method) return `brew install ${method.brew}`;
+  if ('script' in method) {
+    // Prefer curl when both are present; fall back to wget.
+    return hasCommand('curl')
+      ? `curl -fsSL ${method.script} | sh`
+      : `wget -qO- ${method.script} | sh`;
+  }
+  const key = `${process.platform}-${process.arch}`;
+  const spec = method.binary[key];
+  // The downloader is intentionally minimal — binary install is mostly used
+  // for pre-built tarballs whose extract path varies per project. We expect
+  // the manifest author to document any post-download steps in post_install.
+  return spec.extract
+    ? `curl -fsSL ${spec.url} -o /tmp/agents-cli-bin.tgz && tar -xzf /tmp/agents-cli-bin.tgz -C /usr/local/bin ${spec.extract}`
+    : `curl -fsSL ${spec.url} -o /usr/local/bin/agents-cli-downloaded`;
+}
+
+// ─── Status snapshot ─────────────────────────────────────────────────────────
+
+export interface CliStatus {
+  manifest: CliManifest;
+  installed: boolean;
+}
+
+/** Convenience: list all manifests + their installed-on-host status. */
+export function listCliStatus(cwd?: string): {
+  statuses: CliStatus[];
+  errors: CliManifestError[];
+} {
+  const { manifests, errors } = listCliManifests(cwd);
+  const statuses = manifests.map((manifest) => ({
+    manifest,
+    installed: isCliInstalled(manifest),
+  }));
+  return { statuses, errors };
+}
+
+/** Names of CLIs that are declared but not currently installed on the host. */
+export function getMissingClis(cwd?: string): CliManifest[] {
+  return listCliStatus(cwd).statuses.filter((s) => !s.installed).map((s) => s.manifest);
+}

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -1252,7 +1252,7 @@ function containsOnlyDsStore(dir: string): boolean {
 function warnSystemOrphans(): void {
   const SHIPPED_ALLOWLIST = new Set<string>([
     // resource directories shipped by the npm package
-    'commands', 'hooks', 'skills', 'rules', 'mcp', 'permissions', 'subagents', 'profiles', 'agents',
+    'commands', 'hooks', 'skills', 'rules', 'mcp', 'cli', 'permissions', 'subagents', 'profiles', 'agents',
     // top-level metadata files
     'agents.yaml', 'hooks.yaml', 'README.md', 'CHANGELOG.md',
     // git + repo metadata

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -31,6 +31,7 @@ export type ResourceKind =
   | 'hooks'
   | 'rules'
   | 'mcp'
+  | 'cli'
   | 'permissions'
   | 'subagents'
   | 'profiles'

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1290,6 +1290,22 @@ export function removeVersion(agent: AgentId, version: string): boolean {
 }
 
 /**
+ * Print the standard footer after one or more versions were soft-deleted to
+ * trash. Reminds the user that sessions stay readable and how to restore.
+ */
+export function printTrashFooter(moved: Array<{ agent: AgentId; version: string }>): void {
+  if (moved.length === 0) return;
+  console.log();
+  console.log(chalk.gray('Sessions remain accessible via `agents sessions`.'));
+  if (moved.length === 1) {
+    const { agent, version } = moved[0];
+    console.log(chalk.gray(`Restore with: agents trash restore ${agent}@${version}`));
+  } else {
+    console.log(chalk.gray('Restore with: agents trash restore <agent>@<version>  (run `agents trash list` to see)'));
+  }
+}
+
+/**
  * Remove all versions of an agent. Preserves each version's `home/` directory
  * so conversation history is never deleted; the per-version folders (now
  * containing only `home/`) remain under the agent dir.

--- a/tests/non-interactive.test.ts
+++ b/tests/non-interactive.test.ts
@@ -215,7 +215,9 @@ describe('non-interactive CLI usage', () => {
     const combined = `${result.stdout}\n${result.stderr}`;
 
     expect(result.status).toBe(0);
-    expect(combined).toContain(`Removed Claude@${version}`);
+    expect(combined).toContain(`Moved Claude@${version} to trash`);
+    expect(combined).toContain('Sessions remain accessible via `agents sessions`.');
+    expect(combined).toContain(`Restore with: agents trash restore claude@${version}`);
     expect(fs.existsSync(versionDir)).toBe(false);
 
     const trashAgentDir = path.join(home, '.agents', '.history', 'trash', 'versions', 'claude', version);
@@ -244,7 +246,7 @@ describe('non-interactive CLI usage', () => {
     const combined = `${result.stdout}\n${result.stderr}`;
 
     expect(result.status).toBe(0);
-    expect(combined).toContain(`Removed Codex@${version}`);
+    expect(combined).toContain(`Moved Codex@${version} to trash`);
     expect(fs.existsSync(versionDir)).toBe(false);
     expect(fs.existsSync(path.join(home, '.agents', '.history', 'trash', 'versions', 'codex', version))).toBe(true);
   });


### PR DESCRIPTION
## Summary

Adds **CLI binaries** as a new resource kind alongside `commands/`, `skills/`, `hooks/`, `mcp/`, etc. Users declare host tools they want installed in YAML, and `agents pull` materializes them on any new machine.

Why now: the 2026 trend has been CLI > MCP for many integrations — 10–32× cheaper on tokens (the model already knows `gh`, `aws`, `higgsfield` from training; no schema dump needed) and more reliable. Every serious dev-tool company shipped a CLI in 2025–26. Higgsfield itself wrote the ["MCP vs CLI" piece](https://www.mindstudio.ai/blog/higgsfield-mcp-vs-cli-claude-code-agents-token-cost) arguing CLI is significantly cheaper for agentic workflows.

## What this adds

```yaml
# ~/.agents/cli/higgsfield.yaml
name: higgsfield
description: AI image/video generation CLI for agents
check: higgsfield --version
install:
  - npm: "@higgsfield/cli@latest"
  - brew: higgsfield
  - script: https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh
post_install: |
  Authenticate with: higgsfield auth login
```

- New commands: `agents cli list | install | check | view | add`
- Layered the same way other resources are (project > user > system > extra repos)
- Multi-method installs: first method whose package manager exists on the host wins
- `agents pull` lists missing CLIs and prompts (skipped under `-y`) — never silently runs `brew`/`npm`
- Unlike skills/commands/hooks, CLI manifests are **NOT** copied into per-agent version homes; they install onto the user's normal PATH

## Bundled along the way

- `feat: prefer env-set sandbox secrets over keychain fallback` — lets the CI sandbox workflow run without `agents` on PATH
- `ci: add self-hosted sandbox runner workflow`
- `feat: soft-delete versions with restore hint footer` — \`agents version prune\` now prints \"Moved Claude@X to trash\" + restore command

## Commit map

| # | Commit |
|---|---|
| 1 | feat: prefer env-set sandbox secrets over keychain fallback |
| 2 | ci: add self-hosted sandbox runner workflow |
| 3 | feat: soft-delete versions with restore hint footer |
| 4 | feat: register cli as a resource kind |
| 5 | feat: add cli resource manifest parser and installer |
| 6 | feat: add agents cli list/install/check/view/add subcommands |
| 7 | feat: prompt to install missing clis after agents pull |
| 8 | docs: document the cli resource type |

Commit 4 (the kind union) deliberately precedes commit 5 (the lib that calls \`listResources('cli', ...)\`) — every intermediate commit typechecks cleanly.

## Test plan

- [x] \`bun run build\` — clean tsc
- [x] \`npx vitest run src/lib/cli-resources.test.ts\` — 11/11 passing
- [x] Smoke: \`agents cli list\` shows declared higgsfield with installed/missing status
- [x] Smoke: \`agents cli view higgsfield\` renders all 3 install methods + post_install
- [x] Smoke: \`agents cli check\` exits 0 with all installed, 1 with anything missing
- [x] Smoke: \`agents cli install <missing> --dry-run -y\` picks first compatible method and prints the exact command (\`npm install -g foo\`) without running it
- [x] Smoke: \`agents cli add <name> --brew foo --npm bar\` scaffolds a new yaml correctly
- [ ] **Not yet verified:** end-to-end \`agents pull\` flow that prompts to install missing CLIs (requires a clean machine without higgsfield)

## Session Context

[Session transcript](https://gist.github.com/muqsitnawaz/acbeb79fdcefa6420d911e0fbbbd9b9d)