### PR TITLE
fix: green up CI by fixing 5 unrelated test breakages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
       - name: Build
         run: bun run build
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -794,7 +794,18 @@ if (firstRun) {
 // only exemption — it's the command that does the cloning.
 const SETUP_EXEMPT_COMMANDS = new Set(['setup', 'help']);
 
-if (!firstRun && requestedCommand && !SETUP_EXEMPT_COMMANDS.has(requestedCommand)) {
+// Help and version output are pure documentation — they must never gate on
+// setup, otherwise `agents <cmd> --help` becomes useless on a fresh box.
+const helpOrVersionRequested = passedArgs.some(
+  (arg) => arg === '--help' || arg === '-h' || arg === '--version' || arg === '-V',
+);
+
+if (
+  !firstRun &&
+  requestedCommand &&
+  !SETUP_EXEMPT_COMMANDS.has(requestedCommand) &&
+  !helpOrVersionRequested
+) {
   const { ensureInitialized } = await import('./commands/setup.js');
   await ensureInitialized(program);
 }

--- a/src/lib/__tests__/shims.test.ts
+++ b/src/lib/__tests__/shims.test.ts
@@ -99,7 +99,6 @@ describe('generateShimScript — configDirName derivation', () => {
   it('produces the nested ".gemini/antigravity-cli" path for antigravity', () => {
     // antigravity's configDir nests inside gemini's parent. The version-home
     // path must carry the full subpath so per-version sync lands correctly.
-    const { generateVersionedAliasScript } = require('../shims.js');
     const script = generateVersionedAliasScript('antigravity', '1.0.1');
     expect(script).toContain('versions/antigravity/1.0.1');
   });

--- a/src/lib/browser/runtime-state.test.ts
+++ b/src/lib/browser/runtime-state.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
+import { execFileSync } from 'child_process';
 import {
   writeProfileRuntime,
   readProfileRuntime,
@@ -21,7 +22,19 @@ import { getBrowserRuntimeDir, getProfileRuntimeDir } from './profiles.js';
 let prefix: string;
 const created: string[] = [];
 
+// Use whatever `ps` reports for THIS process — that's what the matcher
+// compares against at runtime. Test runners (vitest, bun) set process.title,
+// which mutates /proc/<pid>/comm on Linux, so `path.basename(process.execPath)`
+// disagrees with the live ps output. Fall back to execPath basename if `ps`
+// is unavailable.
 function currentProcessCommand(): string {
+  try {
+    const out = execFileSync('ps', ['-p', String(process.pid), '-o', 'comm='], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (out) return path.basename(out);
+  } catch { /* fall through */ }
   return path.basename(process.execPath);
 }
 

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -17,6 +17,8 @@ describe('pullRepo', () => {
     mkdirSync(REMOTE_DIR, { recursive: true });
     const remoteGit = simpleGit(REMOTE_DIR);
     await remoteGit.init(false);
+    await remoteGit.addConfig('user.name', 'Test User');
+    await remoteGit.addConfig('user.email', 'test@example.com');
     writeFileSync(join(REMOTE_DIR, 'README.md'), '# Test');
     await remoteGit.add('.');
     await remoteGit.commit('initial');

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -16,7 +16,6 @@ import {
   applyPermissionsToVersion,
   convertDenyToCodexRules,
   CODEX_RULES_FILENAME,
-  buildPermissionsFromGroups,
 } from '../src/lib/permissions.js';
 import type { PermissionSet, ClaudePermissions, OpenCodePermissions, CodexPermissions } from '../src/lib/types.js';
 
@@ -915,8 +914,13 @@ describe('applyPermissionsToVersion codex deny rules', () => {
     const codexDir = join(versionHome, '.codex');
 
     try {
-      const set = buildPermissionsFromGroups(['99-deny']);
-      expect(set.deny!.length).toBeGreaterThan(0);
+      // Inline set keeps this test hermetic — the system 99-deny.yaml is not
+      // present on CI runners and we'd hit "set.deny is undefined" otherwise.
+      const set = {
+        name: '99-deny',
+        allow: [],
+        deny: ['Bash(sudo:*)', 'Bash(git reset:*)', 'Bash(git push --force:*)'],
+      };
 
       const result = applyPermissionsToVersion('codex', set, versionHome);
       expect(result.success).toBe(true);


### PR DESCRIPTION
## Summary

CI on \`main\` has been red for 5+ consecutive runs with the same failure signature. None of the failures are related to actual code regressions — they're environmental and test-isolation issues that surface only on the Ubuntu runner. This PR fixes all five.

## What was broken

| # | File | Root cause |
|---|---|---|
| 1 | \`.github/workflows/ci.yml\` | Workflow runs \`bun install\` but never installs Playwright browsers. Browser tests fail with \`chrome-headless-shell\` not found. |
| 2 | \`src/index.ts\` | Setup gate fires for \`<cmd> --help\` because \`requestedCommand\` is the command, not \`--help\`. On fresh CI runners with no \`~/.agents-system/\`, every \`agents <cmd> --help\` exits 1. |
| 3 | \`src/lib/__tests__/shims.test.ts:102\` | Redundant \`require('../shims.js')\` next to a static \`import\` of the same symbol. The \`require\` errors under ESM. |
| 4 | \`tests/permissions.test.ts:919\` | Test calls \`buildPermissionsFromGroups(['99-deny'])\` which reads from \`~/.agents-system/permissions/groups/\`. CI runners have no such dir → \`set.deny\` is undefined → \`Cannot read properties of undefined (reading 'length')\`. |
| 5 | \`src/lib/browser/runtime-state.test.ts:222\` | Test uses \`path.basename(process.execPath)\` as the expected process name, but vitest sets \`process.title\` which mutates \`/proc/<pid>/comm\` on Linux. \`ps -p <pid> -o comm=\` returns \`vitest\` not \`node\`. Test passes on macOS because \`ps\` reads from kernel info there, not \`/proc\`. |

## Commit map

- \`ci: install playwright browsers before running tests\` — adds \`bunx playwright install --with-deps chromium\` step
- \`fix: bypass setup gate when --help or --version is requested\` — help/version output is pure documentation, must never need state
- \`test: drop esm-incompatible require in shims antigravity test\` — \`generateVersionedAliasScript\` was already statically imported; the \`require\` was dead
- \`test: derive current process command from ps to match runtime probe\` — \`currentProcessCommand()\` now asks \`ps\` for the live answer, matching what the matcher sees at runtime
- \`test: inline 99-deny fixture so codex rules test is hermetic\` — removes the implicit dependency on \`~/.agents-system/permissions/groups/99-deny.yaml\`

## Test plan

- [x] \`bun run build\` — typechecks clean
- [x] Local run of all 4 affected test files: 107/107 pass
  - \`src/lib/__tests__/shims.test.ts\` — 22/22
  - \`src/lib/browser/runtime-state.test.ts\` — 27/27
  - \`tests/prune-command.test.ts\` — 5/5
  - \`tests/permissions.test.ts\` — 53/53
- [ ] CI must turn green for the first time in 5+ pushes

## Session Context

[Session transcript](https://gist.github.com/muqsitnawaz/d8d28dfc87e7ebdc0626772c76a81f74)