### PR TITLE
Fix browser first-run and error UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,10 +353,11 @@ Plugins live in the user repo (`~/.agents/plugins/`), not inside any single vers
 Give agents access to a real browser — no relay extension, no cloud service, no Playwright getting blocked.
 
 ```bash
-# Create an isolated profile for automation
-agents browser profiles create work --browser chrome
+# First run creates an isolated "default" profile backed by bundled Chromium.
+export AGENTS_BROWSER_TASK=$(agents browser start --url https://app.example.com)
 
-# Start a task once, then bind it to this shell — every later command picks it up.
+# Or create a named profile and start it explicitly.
+agents browser profiles create work --browser chrome
 # `start` writes the resolved name (e.g. `swift-crab-falcon-a3f92b1c`) to stdout
 # and human-friendly commentary to stderr, so $(...) capture stays clean.
 export AGENTS_BROWSER_TASK=$(agents browser start --profile work --url https://app.example.com)

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@phnx-labs/agents-cli",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
+        "@playwright/browser-chromium": "1.59.1",
         "@types/proper-lockfile": "4.1.4",
         "@xterm/headless": "6.0.0",
         "@zed-industries/agent-client-protocol": "0.4.5",
@@ -17,6 +18,7 @@
         "marked-terminal": "7.3.0",
         "node-pty": "1.1.0",
         "ora": "8.2.0",
+        "playwright-core": "1.59.1",
         "proper-lockfile": "4.1.2",
         "simple-git": "3.36.0",
         "smol-toml": "1.6.1",
@@ -135,6 +137,8 @@
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.130.0", "", {}, "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q=="],
+
+    "@playwright/browser-chromium": ["@playwright/browser-chromium@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" } }, "sha512-XDwr0qOrzLXAuBAzg4WO/xctVMb+ldJ54yz9KCpFu8G8MVJzUVFO6BvK1tBtBl4DIoFcoFRKHgUGZT+8wOC8BQ=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.1", "", { "os": "android", "cpu": "arm64" }, "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "marked-terminal": "7.3.0",
         "node-pty": "1.1.0",
         "ora": "8.2.0",
-        "playwright": "1.59.1",
+        "playwright-core": "1.59.1",
         "proper-lockfile": "4.1.2",
         "simple-git": "3.36.0",
         "smol-toml": "1.6.1",
@@ -27,6 +27,7 @@
         "@types/diff": "6.0.0",
         "@types/marked-terminal": "6.1.1",
         "@types/node": "22.19.10",
+        "playwright": "1.59.1",
         "tsx": "4.22.2",
         "typescript": "5.9.3",
         "vitest": "4.1.6",
@@ -278,7 +279,7 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
@@ -468,9 +469,11 @@
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
-    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
-
     "restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "tsx/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,6 @@
       "name": "@phnx-labs/agents-cli",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
-        "@playwright/browser-chromium": "1.59.1",
         "@types/proper-lockfile": "4.1.4",
         "@xterm/headless": "6.0.0",
         "@zed-industries/agent-client-protocol": "0.4.5",
@@ -18,7 +17,7 @@
         "marked-terminal": "7.3.0",
         "node-pty": "1.1.0",
         "ora": "8.2.0",
-        "playwright-core": "1.59.1",
+        "playwright": "1.59.1",
         "proper-lockfile": "4.1.2",
         "simple-git": "3.36.0",
         "smol-toml": "1.6.1",
@@ -28,7 +27,6 @@
         "@types/diff": "6.0.0",
         "@types/marked-terminal": "6.1.1",
         "@types/node": "22.19.10",
-        "playwright": "1.59.1",
         "tsx": "4.22.2",
         "typescript": "5.9.3",
         "vitest": "4.1.6",
@@ -137,8 +135,6 @@
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.130.0", "", {}, "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q=="],
-
-    "@playwright/browser-chromium": ["@playwright/browser-chromium@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" } }, "sha512-XDwr0qOrzLXAuBAzg4WO/xctVMb+ldJ54yz9KCpFu8G8MVJzUVFO6BvK1tBtBl4DIoFcoFRKHgUGZT+8wOC8BQ=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.1", "", { "os": "android", "cpu": "arm64" }, "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg=="],
 
@@ -282,7 +278,7 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
@@ -472,11 +468,9 @@
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
     "restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
-    "tsx/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
+        "@playwright/browser-chromium": "1.59.1",
         "@types/proper-lockfile": "4.1.4",
         "@xterm/headless": "6.0.0",
         "@zed-industries/agent-client-protocol": "0.4.5",
@@ -22,6 +23,7 @@
         "marked-terminal": "7.3.0",
         "node-pty": "1.1.0",
         "ora": "8.2.0",
+        "playwright-core": "1.59.1",
         "proper-lockfile": "4.1.2",
         "simple-git": "3.36.0",
         "smol-toml": "1.6.1",
@@ -888,6 +890,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/browser-chromium": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.59.1.tgz",
+      "integrity": "sha512-XDwr0qOrzLXAuBAzg4WO/xctVMb+ldJ54yz9KCpFu8G8MVJzUVFO6BvK1tBtBl4DIoFcoFRKHgUGZT+8wOC8BQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2456,7 +2471,8 @@
     },
     "node_modules/playwright-core": {
       "version": "1.59.1",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11,7 +11,6 @@
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
-        "@playwright/browser-chromium": "1.59.1",
         "@types/proper-lockfile": "4.1.4",
         "@xterm/headless": "6.0.0",
         "@zed-industries/agent-client-protocol": "0.4.5",
@@ -23,7 +22,7 @@
         "marked-terminal": "7.3.0",
         "node-pty": "1.1.0",
         "ora": "8.2.0",
-        "playwright-core": "1.59.1",
+        "playwright": "1.59.1",
         "proper-lockfile": "4.1.2",
         "simple-git": "3.36.0",
         "smol-toml": "1.6.1",
@@ -39,7 +38,6 @@
         "@types/diff": "6.0.0",
         "@types/marked-terminal": "6.1.1",
         "@types/node": "22.19.10",
-        "playwright": "1.59.1",
         "tsx": "4.22.2",
         "typescript": "5.9.3",
         "vitest": "4.1.6"
@@ -890,19 +888,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/@playwright/browser-chromium": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.59.1.tgz",
-      "integrity": "sha512-XDwr0qOrzLXAuBAzg4WO/xctVMb+ldJ54yz9KCpFu8G8MVJzUVFO6BvK1tBtBl4DIoFcoFRKHgUGZT+8wOC8BQ==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.59.1"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1862,7 +1847,6 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2454,7 +2438,6 @@
     },
     "node_modules/playwright": {
       "version": "1.59.1",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -22,7 +22,7 @@
         "marked-terminal": "7.3.0",
         "node-pty": "1.1.0",
         "ora": "8.2.0",
-        "playwright": "1.59.1",
+        "playwright-core": "1.59.1",
         "proper-lockfile": "4.1.2",
         "simple-git": "3.36.0",
         "smol-toml": "1.6.1",
@@ -38,6 +38,7 @@
         "@types/diff": "6.0.0",
         "@types/marked-terminal": "6.1.1",
         "@types/node": "22.19.10",
+        "playwright": "1.59.1",
         "tsx": "4.22.2",
         "typescript": "5.9.3",
         "vitest": "4.1.6"
@@ -1847,6 +1848,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2438,6 +2440,7 @@
     },
     "node_modules/playwright": {
       "version": "1.59.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@playwright/browser-chromium": "1.59.1",
     "@types/proper-lockfile": "4.1.4",
     "@xterm/headless": "6.0.0",
     "@zed-industries/agent-client-protocol": "0.4.5",
@@ -87,7 +86,7 @@
     "marked-terminal": "7.3.0",
     "node-pty": "1.1.0",
     "ora": "8.2.0",
-    "playwright-core": "1.59.1",
+    "playwright": "1.59.1",
     "proper-lockfile": "4.1.2",
     "simple-git": "3.36.0",
     "smol-toml": "1.6.1",
@@ -97,7 +96,6 @@
     "@types/diff": "6.0.0",
     "@types/marked-terminal": "6.1.1",
     "@types/node": "22.19.10",
-    "playwright": "1.59.1",
     "tsx": "4.22.2",
     "typescript": "5.9.3",
     "vitest": "4.1.6"

--- a/package.json
+++ b/package.json
@@ -86,11 +86,11 @@
     "marked-terminal": "7.3.0",
     "node-pty": "1.1.0",
     "ora": "8.2.0",
-    "playwright": "1.59.1",
     "proper-lockfile": "4.1.2",
     "simple-git": "3.36.0",
     "smol-toml": "1.6.1",
-    "yaml": "2.8.3"
+    "yaml": "2.8.3",
+    "playwright-core": "1.59.1"
   },
   "devDependencies": {
     "@types/diff": "6.0.0",
@@ -98,6 +98,7 @@
     "@types/node": "22.19.10",
     "tsx": "4.22.2",
     "typescript": "5.9.3",
-    "vitest": "4.1.6"
+    "vitest": "4.1.6",
+    "playwright": "1.59.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
+    "@playwright/browser-chromium": "1.59.1",
     "@types/proper-lockfile": "4.1.4",
     "@xterm/headless": "6.0.0",
     "@zed-industries/agent-client-protocol": "0.4.5",
@@ -86,6 +87,7 @@
     "marked-terminal": "7.3.0",
     "node-pty": "1.1.0",
     "ora": "8.2.0",
+    "playwright-core": "1.59.1",
     "proper-lockfile": "4.1.2",
     "simple-git": "3.36.0",
     "smol-toml": "1.6.1",

--- a/src/commands/browser.test.ts
+++ b/src/commands/browser.test.ts
@@ -13,6 +13,7 @@ describe('browser command help', () => {
 
     expect(help).toContain('Usage:  start [options] [profile]');
     expect(help).toContain('-p, --profile <name>');
-    expect(help).toContain('defaults to bundled Chromium profile "default"');
+    expect(help).toContain('defaults to bundled Chromium profile');
+    expect(help).toContain('"default"');
   });
 });

--- a/src/commands/browser.test.ts
+++ b/src/commands/browser.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { Command } from 'commander';
+import { registerBrowserSubcommands } from './browser.js';
+
+describe('browser command help', () => {
+  it('documents start profile as optional positional with --profile alternative', () => {
+    const program = new Command();
+    registerBrowserSubcommands(program);
+
+    const start = program.commands.find((cmd) => cmd.name() === 'start');
+    expect(start).toBeDefined();
+    const help = start!.helpInformation();
+
+    expect(help).toContain('Usage:  start [options] [profile]');
+    expect(help).toContain('-p, --profile <name>');
+    expect(help).toContain('defaults to bundled Chromium profile "default"');
+  });
+});

--- a/src/commands/browser.ts
+++ b/src/commands/browser.ts
@@ -6,6 +6,7 @@ import {
   getProfile,
   createProfile,
   deleteProfile,
+  ensureDefaultBrowserProfile,
   getProfileRuntimeDir,
   extractConfiguredPort,
   findFreeProfilePort,
@@ -473,24 +474,35 @@ function registerProfilesCommands(browser: Command): void {
 
 function registerTaskCommands(browser: Command): void {
   browser
-    .command('start')
-    .description('Start a browser task with a profile')
-    .requiredOption('-p, --profile <name>', 'Browser profile to use')
+    .command('start [profile]')
+    .description('Start a browser task with a profile (defaults to bundled Chromium profile "default")')
+    .option('-p, --profile <name>', 'Browser profile to use')
     .option(TASK_OPTION_FLAG, 'Task name (auto-generated if omitted)')
     .option('-e, --endpoint <name>', 'Endpoint preset (defaults to the profile\'s default)')
     .option('-u, --url <url>', 'Open URL in first tab')
-    .action(async (opts) => {
+    .action(async (profileArg: string | undefined, opts) => {
+      let profileName = opts.profile || profileArg;
+      if (!profileName) {
+        try {
+          const defaultProfile = await ensureDefaultBrowserProfile();
+          profileName = defaultProfile.name;
+        } catch (err) {
+          console.error(err instanceof Error ? err.message : String(err));
+          process.exit(1);
+        }
+      }
+
       // Pre-check the profile locally so we fail fast with a helpful error
       // instead of round-tripping a generic "Profile not found" through the daemon.
-      const profile = await getProfile(opts.profile);
+      const profile = await getProfile(profileName);
       if (!profile) {
-        console.error(`Profile "${opts.profile}" not found.`);
+        console.error(`Profile "${profileName}" not found.`);
         const all = await listProfiles();
         if (all.length > 0) {
           console.error(`Available profiles: ${all.map((p) => p.name).join(', ')}`);
         }
         console.error(
-          `Create one with: agents browser profiles create ${opts.profile} --browser <chrome|comet|chromium|brave|edge|custom>`
+          `Create one with: agents browser profiles create ${profileName} --browser <chrome|comet|chromium|brave|edge|custom>`
         );
         process.exit(1);
       }
@@ -500,7 +512,7 @@ function registerTaskCommands(browser: Command): void {
         const presets = getEndpointPresets(profile);
         if (!presets[opts.endpoint]) {
           console.error(
-            `Endpoint "${opts.endpoint}" not found on profile "${opts.profile}". ` +
+            `Endpoint "${opts.endpoint}" not found on profile "${profileName}". ` +
               `Available: ${Object.keys(presets).join(', ')}`
           );
           process.exit(1);
@@ -509,7 +521,7 @@ function registerTaskCommands(browser: Command): void {
 
       const response = await sendIPCRequest({
         action: 'start',
-        profile: opts.profile,
+        profile: profileName,
         taskName: opts.task,
         url: opts.url,
         endpoint: opts.endpoint,

--- a/src/commands/browser.ts
+++ b/src/commands/browser.ts
@@ -21,7 +21,11 @@ import {
 import { DEFAULT_VIEWPORT } from '../lib/browser/devices.js';
 import { discoverBrowserWsUrl, verifyBrowserIdentity } from '../lib/browser/cdp.js';
 import { parseTargetFilter } from '../lib/browser/service.js';
-import { sendIPCRequest } from '../lib/browser/ipc.js';
+import {
+  BrowserDaemonNotRunningError,
+  formatBrowserDaemonNotRunningError,
+  sendIPCRequest,
+} from '../lib/browser/ipc.js';
 import { browserTaskPicker, type BrowserTask } from './browser-picker.js';
 import { isInteractiveTerminal } from './utils.js';
 import { registerCommandGroups, setHelpSections } from '../lib/help.js';
@@ -881,10 +885,24 @@ function registerTaskCommands(browser: Command): void {
     .option('-p, --profile <name>', 'Filter by profile')
     .option('--json', 'Output machine-readable JSON')
     .action(async (opts) => {
-      const response = await sendIPCRequest({
-        action: 'status',
-        profile: opts.profile,
-      });
+      let response;
+      try {
+        response = await sendIPCRequest({
+          action: 'status',
+          profile: opts.profile,
+        }, { autoStartDaemon: false });
+      } catch (err) {
+        if (err instanceof BrowserDaemonNotRunningError) {
+          const message = formatBrowserDaemonNotRunningError();
+          if (opts.json) {
+            console.log(JSON.stringify({ ok: false, error: message }));
+          } else {
+            console.error(message);
+          }
+          process.exit(1);
+        }
+        throw err;
+      }
 
       if (!response.ok) {
         if (opts.json) {

--- a/src/commands/browser.ts
+++ b/src/commands/browser.ts
@@ -384,7 +384,7 @@ function registerProfilesCommands(browser: Command): void {
           checks.push({ label: 'port', ok: true, detail: `${port} is free` });
         } else {
           try {
-            const { browser } = await discoverBrowserWsUrl(port);
+            const { browser } = await discoverBrowserWsUrl(port, 'localhost', profile.name);
             verifyBrowserIdentity(browser, profile.browser, port);
             checks.push({
               label: 'port',

--- a/src/lib/browser/cdp.test.ts
+++ b/src/lib/browser/cdp.test.ts
@@ -1,6 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { PassThrough } from 'stream';
-import { CDPClient, normalizeBrowserName, verifyBrowserIdentity } from './cdp.js';
+import {
+  BrowserCdpConnectionError,
+  CDPClient,
+  discoverBrowserWsUrl,
+  formatBrowserCdpConnectionError,
+  normalizeBrowserName,
+  verifyBrowserIdentity,
+} from './cdp.js';
 
 describe('normalizeBrowserName', () => {
   it('strips version suffix and lowercases', () => {
@@ -83,6 +90,37 @@ describe('verifyBrowserIdentity', () => {
 
   it('accepts chrome for edge (Edge reports Chrome/<version> in /json/version)', () => {
     expect(() => verifyBrowserIdentity('chrome', 'edge', 9222)).not.toThrow();
+  });
+});
+
+describe('discoverBrowserWsUrl', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('wraps unreachable Chrome endpoints with a remediation hint', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED')));
+
+    await expect(discoverBrowserWsUrl(9333, 'localhost', 'work')).rejects.toThrow(
+      BrowserCdpConnectionError
+    );
+    await expect(discoverBrowserWsUrl(9333, 'localhost', 'work')).rejects.toThrow(
+      [
+        'Could not connect to Chrome on port 9333.',
+        '- Is Chrome running with --remote-debugging-port=9333?',
+        '- Try: agents browser start --profile work',
+      ].join('\n')
+    );
+  });
+
+  it('formats non-local Chrome endpoints with host and port', () => {
+    expect(formatBrowserCdpConnectionError(9444, 'remote', 'mac-mini')).toBe(
+      [
+        'Could not connect to Chrome on mac-mini:9444.',
+        '- Is Chrome running with --remote-debugging-port=9444?',
+        '- Try: agents browser start --profile remote',
+      ].join('\n')
+    );
   });
 });
 

--- a/src/lib/browser/cdp.ts
+++ b/src/lib/browser/cdp.ts
@@ -196,13 +196,45 @@ export interface BrowserDiscovery {
   browser: string;
 }
 
+export class BrowserCdpConnectionError extends Error {
+  constructor(
+    readonly port: number,
+    readonly profileName: string = '<name>',
+    readonly host = 'localhost'
+  ) {
+    super(formatBrowserCdpConnectionError(port, profileName, host));
+    this.name = 'BrowserCdpConnectionError';
+  }
+}
+
+export function formatBrowserCdpConnectionError(
+  port: number,
+  profileName = '<name>',
+  host = 'localhost'
+): string {
+  const target = host === 'localhost' || host === '127.0.0.1'
+    ? `port ${port}`
+    : `${host}:${port}`;
+  return [
+    `Could not connect to Chrome on ${target}.`,
+    `- Is Chrome running with --remote-debugging-port=${port}?`,
+    `- Try: agents browser start --profile ${profileName}`,
+  ].join('\n');
+}
+
 export async function discoverBrowserWsUrl(
   port: number,
-  host = 'localhost'
+  host = 'localhost',
+  profileName = '<name>'
 ): Promise<BrowserDiscovery> {
-  const response = await fetch(`http://${host}:${port}/json/version`);
+  let response: Response;
+  try {
+    response = await fetch(`http://${host}:${port}/json/version`);
+  } catch {
+    throw new BrowserCdpConnectionError(port, profileName, host);
+  }
   if (!response.ok) {
-    throw new Error(`Failed to discover browser: ${response.status}`);
+    throw new BrowserCdpConnectionError(port, profileName, host);
   }
   const data = (await response.json()) as {
     webSocketDebuggerUrl: string;

--- a/src/lib/browser/chrome.ts
+++ b/src/lib/browser/chrome.ts
@@ -8,6 +8,7 @@ import { readBundle, resolveBundleEnv, bundleExists } from '../secrets/bundles.j
 import { writeProfileRuntime, readProfileRuntime } from './runtime-state.js';
 import type { ChromeOptions } from './types.js';
 import type { Readable, Writable } from 'stream';
+import { chromium as bundledChromium } from 'playwright-core';
 
 import type { BrowserType } from './types.js';
 
@@ -77,6 +78,16 @@ export function findBrowserPath(browserType: BrowserType, customBinary?: string)
   throw new Error(`Browser "${browserType}" not found. Install it first.`);
 }
 
+export function getBundledChromiumPath(): string {
+  const executablePath = bundledChromium.executablePath();
+  if (!fs.existsSync(executablePath)) {
+    throw new Error(
+      'Bundled Chromium is not installed. Reinstall agents-cli or run: npx playwright install chromium'
+    );
+  }
+  return executablePath;
+}
+
 export interface LaunchResult {
   pid: number;
   port: number;
@@ -128,6 +139,7 @@ export async function launchBrowser(
     '--no-first-run',
     '--no-default-browser-check',
     '--disable-features=DefaultBrowserSetting,ChromeWhatsNewUI',
+    '--disable-crash-reporter',
     ...(options.headless ? ['--headless=new'] : []),
     `--window-size=${viewport.width},${viewport.height}`,
     ...(viewport.x !== undefined && viewport.y !== undefined

--- a/src/lib/browser/chrome.ts
+++ b/src/lib/browser/chrome.ts
@@ -1,4 +1,5 @@
 import { spawn, execFileSync } from 'child_process';
+import { createRequire } from 'module';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -8,9 +9,11 @@ import { readBundle, resolveBundleEnv, bundleExists } from '../secrets/bundles.j
 import { writeProfileRuntime, readProfileRuntime } from './runtime-state.js';
 import type { ChromeOptions } from './types.js';
 import type { Readable, Writable } from 'stream';
-import { chromium as bundledChromium } from 'playwright';
+import { chromium as bundledChromium } from 'playwright-core';
 
 import type { BrowserType } from './types.js';
+
+const require = createRequire(import.meta.url);
 
 const BROWSER_PATHS: Record<string, Record<BrowserType, string[]>> = {
   darwin: {
@@ -80,12 +83,30 @@ export function findBrowserPath(browserType: BrowserType, customBinary?: string)
 
 export function getBundledChromiumPath(): string {
   const executablePath = bundledChromium.executablePath();
-  if (!fs.existsSync(executablePath)) {
+  if (fs.existsSync(executablePath)) {
+    return executablePath;
+  }
+
+  installBundledChromium();
+  if (fs.existsSync(executablePath)) {
+    return executablePath;
+  }
+
+  throw new Error(
+    'Bundled Chromium did not install correctly. Try: npx playwright-core install chromium'
+  );
+}
+
+function installBundledChromium(): void {
+  const cliPath = require.resolve('playwright-core/cli.js');
+  try {
+    execFileSync(process.execPath, [cliPath, 'install', 'chromium'], { stdio: 'inherit' });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
     throw new Error(
-      'Bundled Chromium is not installed. Reinstall agents-cli or run: npx playwright install chromium'
+      `Bundled Chromium is not installed and automatic install failed: ${detail}\nTry: npx playwright-core install chromium`
     );
   }
-  return executablePath;
 }
 
 export interface LaunchResult {

--- a/src/lib/browser/chrome.ts
+++ b/src/lib/browser/chrome.ts
@@ -8,7 +8,7 @@ import { readBundle, resolveBundleEnv, bundleExists } from '../secrets/bundles.j
 import { writeProfileRuntime, readProfileRuntime } from './runtime-state.js';
 import type { ChromeOptions } from './types.js';
 import type { Readable, Writable } from 'stream';
-import { chromium as bundledChromium } from 'playwright-core';
+import { chromium as bundledChromium } from 'playwright';
 
 import type { BrowserType } from './types.js';
 

--- a/src/lib/browser/drivers/local.ts
+++ b/src/lib/browser/drivers/local.ts
@@ -53,7 +53,7 @@ export async function connectLocal(
   }
 
   try {
-    const { wsUrl, browser } = await discoverBrowserWsUrl(port);
+    const { wsUrl, browser } = await discoverBrowserWsUrl(port, 'localhost', profile.name);
     verifyBrowserIdentity(browser, profile.browser, port);
     const cdp = new CDPClient();
     await cdp.connect(wsUrl);

--- a/src/lib/browser/drivers/ssh.ts
+++ b/src/lib/browser/drivers/ssh.ts
@@ -79,7 +79,7 @@ export async function connectSSH(
     throw new Error(`SSH tunnel failed to establish to ${host}`);
   }
 
-  const { wsUrl, browser } = await discoverBrowserWsUrl(localPort);
+  const { wsUrl, browser } = await discoverBrowserWsUrl(localPort, 'localhost', profile.name);
   try {
     verifyBrowserIdentity(browser, profile.browser, remotePort, host);
   } catch (err) {

--- a/src/lib/browser/ipc.test.ts
+++ b/src/lib/browser/ipc.test.ts
@@ -1,10 +1,49 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { rmSync } from 'fs';
 import * as path from 'path';
-import { getSocketPath } from './ipc.js';
+import {
+  BrowserDaemonNotRunningError,
+  formatBrowserDaemonNotRunningError,
+  getSocketPath,
+  sendIPCRequest,
+} from './ipc.js';
 import { getHelpersDir } from '../state.js';
+
+const paths = vi.hoisted(() => ({
+  helperDir: `/tmp/agents-cli-browser-ipc-${process.pid}`,
+}));
+
+vi.mock('../state.js', () => ({
+  getHelpersDir: vi.fn(() => paths.helperDir),
+}));
+
+const daemon = vi.hoisted(() => ({
+  startDaemon: vi.fn(),
+}));
+
+vi.mock('../daemon.js', () => ({
+  startDaemon: daemon.startDaemon,
+}));
+
+afterEach(() => {
+  rmSync(paths.helperDir, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
 
 describe('getSocketPath', () => {
   it('places the browser IPC socket in its own helper subdirectory', () => {
     expect(getSocketPath()).toBe(path.join(getHelpersDir(), 'browser', 'browser.sock'));
+  });
+});
+
+describe('sendIPCRequest', () => {
+  it('reports daemon-not-running without starting the daemon when autoStartDaemon is false', async () => {
+    await expect(
+      sendIPCRequest({ action: 'status' }, { autoStartDaemon: false })
+    ).rejects.toThrow(BrowserDaemonNotRunningError);
+    await expect(
+      sendIPCRequest({ action: 'status' }, { autoStartDaemon: false })
+    ).rejects.toThrow(formatBrowserDaemonNotRunningError());
+    expect(daemon.startDaemon).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/browser/ipc.ts
+++ b/src/lib/browser/ipc.ts
@@ -9,8 +9,36 @@ import type { IPCRequest, IPCResponse, RefNodeJson } from './types.js';
 
 const SOCKET_NAME = 'browser.sock';
 
+export interface IPCRequestOptions {
+  autoStartDaemon?: boolean;
+}
+
+export class BrowserDaemonNotRunningError extends Error {
+  constructor() {
+    super(formatBrowserDaemonNotRunningError());
+    this.name = 'BrowserDaemonNotRunningError';
+  }
+}
+
+export function formatBrowserDaemonNotRunningError(): string {
+  return [
+    'Browser daemon not running.',
+    'Start it with: agents browser start --profile <name>',
+    'List profiles: agents browser profiles list',
+  ].join('\n');
+}
+
 export function getSocketPath(): string {
   return path.join(getHelpersDir(), 'browser', SOCKET_NAME);
+}
+
+async function waitForSocket(socketPath: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(socketPath)) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error('Timeout waiting for browser daemon socket');
 }
 
 export class BrowserIPCServer {
@@ -474,8 +502,11 @@ async function maybeWarnVersionMismatch(): Promise<void> {
   }
 }
 
-export async function sendIPCRequest(request: IPCRequest): Promise<IPCResponse> {
-  const result = await sendRawIPCRequest(request);
+export async function sendIPCRequest(
+  request: IPCRequest,
+  opts: IPCRequestOptions = {}
+): Promise<IPCResponse> {
+  const result = await sendRawIPCRequest(request, opts);
   // Run the version check after the user's request returns — keeps the
   // critical path zero-overhead and ensures `start` doesn't get blocked
   // on a daemon-restart warning that the user hasn't read yet.
@@ -485,40 +516,22 @@ export async function sendIPCRequest(request: IPCRequest): Promise<IPCResponse> 
   return result;
 }
 
-async function sendRawIPCRequest(request: IPCRequest): Promise<IPCResponse> {
+async function sendRawIPCRequest(
+  request: IPCRequest,
+  opts: IPCRequestOptions = {}
+): Promise<IPCResponse> {
   const socketPath = getSocketPath();
+  const autoStartDaemon = opts.autoStartDaemon ?? true;
 
   if (!fs.existsSync(socketPath)) {
+    if (!autoStartDaemon) {
+      throw new BrowserDaemonNotRunningError();
+    }
     await fs.promises.mkdir(path.dirname(socketPath), { recursive: true, mode: 0o700 });
     await fs.promises.chmod(path.dirname(socketPath), 0o700);
     startDaemon();
     if (!fs.existsSync(socketPath)) {
-      await new Promise<void>((resolve, reject) => {
-        const socketDir = path.dirname(socketPath);
-        const socketName = path.basename(socketPath);
-        const watcher = fs.watch(socketDir, (_event, file) => {
-          if (file === socketName) {
-            clearTimeout(timeout);
-            watcher.close();
-            resolve();
-          }
-        });
-        watcher.on('error', (error) => {
-          clearTimeout(timeout);
-          watcher.close();
-          reject(error);
-        });
-        const timeout = setTimeout(() => {
-          watcher.close();
-          reject(new Error('Timeout waiting for browser daemon socket'));
-        }, 6000);
-
-        if (fs.existsSync(socketPath)) {
-          clearTimeout(timeout);
-          watcher.close();
-          resolve();
-        }
-      });
+      await waitForSocket(socketPath, 6000);
     }
     if (!fs.existsSync(socketPath)) {
       throw new Error('Failed to start browser daemon');
@@ -544,7 +557,11 @@ async function sendRawIPCRequest(request: IPCRequest): Promise<IPCResponse> {
       }
     });
 
-    socket.on('error', (err) => {
+    socket.on('error', (err: NodeJS.ErrnoException) => {
+      if (!autoStartDaemon && (err.code === 'ENOENT' || err.code === 'ECONNREFUSED')) {
+        reject(new BrowserDaemonNotRunningError());
+        return;
+      }
       reject(new Error(`IPC error: ${err.message}`));
     });
 

--- a/src/lib/browser/profiles.test.ts
+++ b/src/lib/browser/profiles.test.ts
@@ -12,6 +12,7 @@ vi.mock('child_process', () => ({
 
 vi.mock('./chrome.js', () => ({
   findBrowserPath: vi.fn(() => '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'),
+  getBundledChromiumPath: vi.fn(() => '/ms-playwright/chromium/chrome'),
 }));
 
 import {
@@ -19,6 +20,7 @@ import {
   extractConfiguredEndpoint,
   findFreeProfilePort,
   createProfile,
+  ensureDefaultBrowserProfile,
 } from './profiles.js';
 import type { BrowserProfile } from './types.js';
 import type { BrowserProfileConfig } from '../types.js';
@@ -285,6 +287,26 @@ describe('profile YAML round-trip', () => {
     expect('binary' in stored).toBe(false);
     expect('electron' in stored).toBe(false);
     expect('targetFilter' in stored).toBe(false);
+  });
+
+  it('creates a default profile backed by bundled Chromium on first use', async () => {
+    const store: { browser: Record<string, BrowserProfileConfig> } = { browser: {} };
+    vi.mocked(readMeta).mockImplementation(() => store as any);
+    vi.mocked(writeMeta).mockImplementation((meta: any) => {
+      store.browser = (meta.browser ?? {}) as Record<string, BrowserProfileConfig>;
+    });
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error('free port');
+    });
+
+    const profile = await ensureDefaultBrowserProfile();
+
+    expect(profile.name).toBe('default');
+    expect(profile.browser).toBe('chromium');
+    expect(profile.binary).toBe('/ms-playwright/chromium/chrome');
+    expect(profile.endpoints).toEqual(['cdp://127.0.0.1:9222']);
+    expect(store.browser.default.browser).toBe('chromium');
+    expect(store.browser.default.binary).toBe('/ms-playwright/chromium/chrome');
   });
 
   it('allows spaces in browser binaries used by ssh endpoints', async () => {

--- a/src/lib/browser/profiles.ts
+++ b/src/lib/browser/profiles.ts
@@ -7,9 +7,12 @@ import {
 } from '../state.js';
 import type { BrowserProfileConfig } from '../types.js';
 import type { BrowserProfile } from './types.js';
-import { findBrowserPath } from './chrome.js';
+import { findBrowserPath, getBundledChromiumPath } from './chrome.js';
+import { DEFAULT_VIEWPORT } from './devices.js';
 
 export type { BrowserProfile } from './types.js';
+
+export const DEFAULT_BROWSER_PROFILE_NAME = 'default';
 
 export function getBrowserRuntimeDir(): string {
   return getBrowserRuntimeDirRoot();
@@ -71,6 +74,26 @@ export async function getProfile(name: string): Promise<BrowserProfile | null> {
   const config = meta.browser?.[name];
   if (!config) return null;
   return configToProfile(name, config);
+}
+
+export async function ensureDefaultBrowserProfile(): Promise<BrowserProfile> {
+  const existing = await getProfile(DEFAULT_BROWSER_PROFILE_NAME);
+  if (existing) return existing;
+
+  const freePort = await findFreeProfilePort();
+  const profile: BrowserProfile = {
+    name: DEFAULT_BROWSER_PROFILE_NAME,
+    description: 'Default bundled Chromium profile',
+    browser: 'chromium',
+    binary: getBundledChromiumPath(),
+    endpoints: [`cdp://127.0.0.1:${freePort}`],
+    viewport: {
+      width: DEFAULT_VIEWPORT.width,
+      height: DEFAULT_VIEWPORT.height,
+    },
+  };
+  await createProfile(profile);
+  return profile;
 }
 
 /**

--- a/src/lib/browser/service.ts
+++ b/src/lib/browser/service.ts
@@ -3,7 +3,12 @@ import * as os from 'os';
 import * as path from 'path';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import { CDPClient, discoverBrowserWsUrl, verifyBrowserIdentity } from './cdp.js';
+import {
+  BrowserCdpConnectionError,
+  CDPClient,
+  discoverBrowserWsUrl,
+  verifyBrowserIdentity,
+} from './cdp.js';
 import {
   getProfile,
   getProfileRuntimeDir,
@@ -1785,7 +1790,11 @@ export class BrowserService {
 
     if (existingInfo) {
       try {
-        const { wsUrl, browser } = await discoverBrowserWsUrl(existingInfo.port);
+        const { wsUrl, browser } = await discoverBrowserWsUrl(
+          existingInfo.port,
+          'localhost',
+          effectiveProfile.name
+        );
         verifyBrowserIdentity(browser, effectiveProfile.browser, existingInfo.port);
         const cdp = new CDPClient();
         await cdp.connect(wsUrl);
@@ -1856,8 +1865,13 @@ export class BrowserService {
     }
 
     if (url.protocol === 'wss:' || url.protocol === 'ws:') {
+      const port = parseInt(url.port || (url.protocol === 'wss:' ? '443' : '80'), 10);
       const cdp = new CDPClient();
-      await cdp.connect(endpoint);
+      try {
+        await cdp.connect(endpoint);
+      } catch {
+        throw new BrowserCdpConnectionError(port, profile.name, url.hostname || 'localhost');
+      }
       await this.enableDomains(cdp);
       return {
         cdp,
@@ -1872,7 +1886,7 @@ export class BrowserService {
 
     if (url.protocol === 'http:' || url.protocol === 'https:') {
       const port = parseInt(url.port || (url.protocol === 'https:' ? '443' : '80'), 10);
-      const { wsUrl, browser } = await discoverBrowserWsUrl(port, url.hostname);
+      const { wsUrl, browser } = await discoverBrowserWsUrl(port, url.hostname, profile.name);
       verifyBrowserIdentity(browser, profile.browser, port, url.hostname);
       const cdp = new CDPClient();
       await cdp.connect(wsUrl);


### PR DESCRIPTION
## Summary
- fix `agents browser status` when the daemon is unavailable so it prints an actionable message without a Node stacktrace
- accept `agents browser start <profile>` as an alternative to `--profile`, and document the default profile behavior in help
- wrap unreachable CDP endpoints in a Chrome-port remediation hint
- create a first-run `default` profile backed by managed Playwright Chromium, with Chromium installed on first use instead of during dependency install

Closes #41
Closes #42
Closes #43
Closes #44

## Verification
- `bun run build` exited 0 in `/private/tmp/agents-cli-browser-26529`; fresh clone lacks `bin/Agents CLI.app`, so the existing macOS copy step printed `cp: bin/Agents CLI.app: No such file or directory`
- `HOME=/private/tmp/agents-cli-browser-home AGENTS_SKIP_MIGRATION=1 node dist/index.js browser status` printed `Browser daemon not running...` before daemon startup verification
- `node dist/index.js browser start --help` prints `Usage: agents browser start [options] [profile]`
- GitHub Actions on head `af2949fb756590f037a5a495c2f08af257d36dcc`: `gitleaks` completed `SUCCESS` at `2026-05-29T18:22:47Z`; `build (22)` completed `SUCCESS` at `2026-05-29T18:26:19Z`
- GitHub Actions `build (24)` is still blocked in `Install Playwright browsers` from `2026-05-29T18:23:00Z`; the same job is also stuck on `main` after #54 from `2026-05-29T17:53:00Z`, so this is not introduced by PR #55
- Crabbox was unavailable: `agents secrets exec hetzner.com -- crabbox list` reported `Secrets bundle 'hetzner.com' not found.`
- First-run default profile creation wrote `browser.default` to isolated `agents.yaml`; launching Chrome for Testing is blocked in this sandbox by macOS Crashpad/Mach permission errors, so live browser launch is verified only up to daemon/profile creation here and must rely on CI/non-sandbox runtime for full Chrome process startup

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/dad5dd1aacdfbf1f5449bbe526af7d16)
