### PR TITLE
chore: ignore .agents/scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ coverage/
 # Internal plans (not shipped)
 .agents/plans/
 .agents/worktrees/
+.agents/scratch/
 .plans/
 
 # Scrub script lists personal data strings — must not be committed to public repo


### PR DESCRIPTION
## Summary
- Single one-line addition to `.gitignore` to exclude `.agents/scratch/` (used for sprint mirror clones).
- Cherry-picked from local `fix/ci-flakes` (commit `7e660952`); the other 3 commits on that branch were dropped: `e39d3ed1` duplicates PR #55 scope, `024f5146` introduced the Superwhisper-breaking biometry helper (replaced by the canonical fix in a separate PR), and `a2471d65` was equivalent to `d461a2f4` already on `main`.

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/9f148c621db8e3046d9fdb0c861e957e)