### PR TITLE
feat(computer-helper): peer-auth on socket via LOCAL_PEERPID

### DIFF
--- a/packages/computer-helper/README.md
+++ b/packages/computer-helper/README.md
@@ -56,6 +56,23 @@ When the policy file is missing or unparseable the helper boots with an empty
 allow list, which denies everything. Same behavior after a SIGHUP. There is no
 "allow everything" default.
 
+### Peer-auth
+
+The socket lives under the user's home directory at mode 0600, so the kernel
+already restricts which UIDs can connect. The helper adds one more layer on
+top: it resolves every connecting caller's pid via `LOCAL_PEERPID` and its
+exec path via `proc_pidpath`, and refuses anything whose exec path isn't in
+`~/.agents/.cache/helpers/computer-peers.json` (`{"allow": [...]}`, mode 0600,
+same fail-safe-empty semantics as `computer-policy.json`).
+
+`agents computer start` and `agents computer reload` rewrite that file from
+`loadDefaultPeers()`: the realpath of the running CLI's Node binary, plus
+`/Applications/Rush.app/Contents/MacOS/{Rush,Electron}` if Rush is installed.
+A malicious npm postinstall that runs `nc -U socket` is refused at accept()
+— `/usr/bin/nc` is not on the list. The denial returns one structured
+`peer_denied` frame so a legitimate-but-misconfigured client sees what's
+wrong, then the connection closes.
+
 ## Build
 
 ```bash

--- a/packages/computer-helper/Sources/ComputerHelper/main.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/main.swift
@@ -39,6 +39,17 @@ struct Policy {
 
 var policy = Policy()
 
+// Peer-auth allow list — which caller executables may connect to the
+// socket. Same fail-safe semantics as `policy`: missing/unparseable file
+// means empty set means no peer is allowed to connect. The CLI rewrites
+// this file at every `start`/`reload`, so the daemon picks up new caller
+// paths (npm-global upgrades, new Rush.app installs) on SIGHUP.
+struct Peers {
+    var allow: Set<String> = []
+}
+
+var peers = Peers()
+
 // Resolve the policy file path. Env override mirrors the socket-path
 // override so tests can point us at a scratch file. Default lives next to
 // the socket under ~/.agents/.cache/helpers/.
@@ -47,6 +58,13 @@ func resolvePolicyPath() -> String {
         return env
     }
     return "\(NSHomeDirectory())/.agents/.cache/helpers/computer-policy.json"
+}
+
+func resolvePeersPath() -> String {
+    if let env = ProcessInfo.processInfo.environment["COMPUTER_HELPER_PEERS"], !env.isEmpty {
+        return env
+    }
+    return "\(NSHomeDirectory())/.agents/.cache/helpers/computer-peers.json"
 }
 
 // Load (or reload) the policy file. Errors are logged but never thrown:
@@ -72,6 +90,88 @@ func loadPolicy() {
     }
     policy = Policy(allow: Set(allow))
     log("policy loaded: \(allow.count) allowed bundle ids")
+}
+
+// Mirror of loadPolicy() for the peer-auth allow list. Same fail-safe
+// behavior: missing or unparseable = empty set = no caller may connect.
+func loadPeers() {
+    let path = resolvePeersPath()
+    guard FileManager.default.fileExists(atPath: path) else {
+        log("peers file missing at \(path) — empty allow list (fail-safe, all connections will be refused)")
+        peers = Peers()
+        return
+    }
+    guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
+        log("peers file unreadable at \(path) — keeping previous allow list (\(peers.allow.count) entries)")
+        return
+    }
+    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let allow = json["allow"] as? [String] else {
+        log("peers file unparseable at \(path) — empty allow list (fail-safe)")
+        peers = Peers()
+        return
+    }
+    peers = Peers(allow: Set(allow))
+    log("peers loaded: \(allow.count) allowed caller paths")
+}
+
+// Resolve the peer (caller) pid for an accepted client fd via the
+// LOCAL_PEERPID socket option. Returns nil if the kernel call fails —
+// caller should refuse the connection.
+private let SOL_LOCAL_C: Int32 = 0          // <sys/un.h>: SOL_LOCAL
+private let LOCAL_PEERPID_C: Int32 = 0x002  // <sys/un.h>: LOCAL_PEERPID
+private let PROC_PIDPATH_MAX: Int = 4 * 1024 // PROC_PIDPATHINFO_MAXSIZE = 4*MAXPATHLEN
+
+func peerPid(fd: Int32) -> pid_t? {
+    var pid: pid_t = 0
+    var size = socklen_t(MemoryLayout<pid_t>.size)
+    let r = withUnsafeMutablePointer(to: &pid) { ptr -> Int32 in
+        return ptr.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<pid_t>.size) { raw in
+            return getsockopt(fd, SOL_LOCAL_C, LOCAL_PEERPID_C, raw, &size)
+        }
+    }
+    if r != 0 { return nil }
+    if pid <= 0 { return nil }
+    return pid
+}
+
+// Resolve a pid to its executable path via libproc proc_pidpath(). Returns
+// nil if the process has already exited or the kernel call fails.
+func execPathForPid(_ pid: pid_t) -> String? {
+    var buf = [CChar](repeating: 0, count: PROC_PIDPATH_MAX)
+    let n = proc_pidpath(pid, &buf, UInt32(PROC_PIDPATH_MAX))
+    if n <= 0 { return nil }
+    return String(cString: buf)
+}
+
+// Check whether an accepted fd's peer is on the allow list. Logs both
+// allowed and denied outcomes for the audit trail. Sends one structured
+// error frame on denial so a legitimate-but-misconfigured client knows
+// what's wrong, then closes.
+func authorizePeer(fd: Int32) -> Bool {
+    guard let pid = peerPid(fd: fd) else {
+        log("peer-auth: LOCAL_PEERPID failed for fd=\(fd) — closing")
+        return false
+    }
+    guard let execPath = execPathForPid(pid) else {
+        log("peer-auth: proc_pidpath failed for pid=\(pid) — closing")
+        return false
+    }
+    if peers.allow.contains(execPath) {
+        log("peer-auth: pid=\(pid) exec=\(execPath) — allowed")
+        return true
+    }
+    log("peer-auth: pid=\(pid) exec=\(execPath) — DENIED (not in peers list)")
+    if let frame = encodeResponse([
+        "id": NSNull(),
+        "error": [
+            "code": "peer_denied",
+            "message": "caller exec \(execPath) (pid \(pid)) is not in the peer allow list — `agents computer reload` re-derives it from this binary",
+        ],
+    ]) {
+        _ = frame.withUnsafeBytes { Darwin.write(fd, $0.baseAddress, frame.count) }
+    }
+    return false
 }
 
 // Resolve socket path: --socket <path> argv, else env COMPUTER_HELPER_SOCKET.
@@ -128,14 +228,17 @@ func handleLine(_ line: Data) -> Data? {
 
 log("started pid=\(getpid())")
 
-// Load the allow-list policy before accepting any RPC calls. SIGHUP from
-// the CLI's `agents computer reload` triggers a reload.
+// Load the allow-list policy + peer-auth list before accepting any RPC
+// calls. SIGHUP from the CLI's `agents computer reload` triggers a reload
+// of both.
 loadPolicy()
+loadPeers()
 
 let sighupSource = DispatchSource.makeSignalSource(signal: SIGHUP, queue: .main)
 sighupSource.setEventHandler {
-    log("SIGHUP — reloading policy")
+    log("SIGHUP — reloading policy + peers")
     loadPolicy()
+    loadPeers()
 }
 sighupSource.resume()
 signal(SIGHUP, SIG_IGN) // DispatchSource needs the libc handler ignored
@@ -303,7 +406,18 @@ if let socketPath = resolveSocketPath() {
 // Handle one accepted connection. Line-delimited JSON-RPC, same wire format
 // as stdio. Runs on a background queue; serializes writes via a per-
 // connection lock.
+//
+// Peer-auth (F5): before reading any RPC bytes, resolve the connecting
+// pid via LOCAL_PEERPID and its exec path via proc_pidpath. If that path
+// isn't in `peers.allow`, send one structured `peer_denied` frame and
+// close. This blocks the obvious `nc -U socket` exfil — nc's exec path
+// won't be in the allow list — and forces the user to explicitly trust
+// any non-default caller via `agents computer trust <path>`.
 func handleConnection(fd: Int32) {
+    guard authorizePeer(fd: fd) else {
+        close(fd)
+        return
+    }
     let writeLock = NSLock()
     func writeData(_ data: Data) {
         writeLock.lock()

--- a/src/commands/computer.ts
+++ b/src/commands/computer.ts
@@ -11,9 +11,12 @@ import {
   resolveSocketPath,
   resolveLogPath,
   resolvePolicyPath,
+  resolvePeersPath,
   describeTransport,
   loadComputerAllowList,
+  loadDefaultPeers,
   writeComputerPolicy,
+  writeComputerPeers,
 } from '../lib/computer-rpc.js';
 
 // Help groups — mirror `agents browser` so the mental model carries over.
@@ -65,6 +68,9 @@ function registerStatusCommand(program: Command): void {
       const previewParts = allowed.slice(0, 5);
       const previewSuffix = allowed.length > 5 ? ` (+${allowed.length - 5} more)` : '';
       console.log(`policy:    ${allowed.length} app${allowed.length === 1 ? '' : 's'} allowed${allowed.length > 0 ? `: ${previewParts.join(', ')}${previewSuffix}` : ''}`);
+
+      const callers = loadDefaultPeers();
+      console.log(`peers:     ${callers.length} caller${callers.length === 1 ? '' : 's'} (peer-auth on socket)`);
 
       if (!installed) {
         console.log('');
@@ -321,6 +327,15 @@ function registerStartCommand(program: Command): void {
         console.log(`          - "Computer(com.apple.finder)"`);
       }
 
+      // Peer-auth allow list — which caller executables may connect to
+      // the socket. Default: this CLI's Node binary, plus Rush.app if
+      // installed. A `nc -U socket` from a malicious npm postinstall has
+      // a different exec path and gets refused at accept().
+      const callers = loadDefaultPeers();
+      writeComputerPeers(callers);
+      console.log(`peers:  ${callers.length} caller${callers.length === 1 ? '' : 's'} allowed (${resolvePeersPath()})`);
+      for (const p of callers) console.log(`        ${p}`);
+
       // Bootout first to clear any prior registration. Best-effort.
       try {
         execFileSync('/bin/launchctl', ['bootout', domain, plistPath], { stdio: 'pipe' });
@@ -394,6 +409,13 @@ function registerReloadCommand(program: Command): void {
       const allowed = loadComputerAllowList();
       writeComputerPolicy(allowed);
       console.log(`policy: ${allowed.length} app${allowed.length === 1 ? '' : 's'} allowed (${resolvePolicyPath()})`);
+
+      // Rewrite peers list too — an upgrade of the npm-global CLI moves
+      // its node path; without this the reloaded daemon would reject the
+      // very binary that just signaled it.
+      const callers = loadDefaultPeers();
+      writeComputerPeers(callers);
+      console.log(`peers:  ${callers.length} caller${callers.length === 1 ? '' : 's'} allowed (${resolvePeersPath()})`);
 
       // Resolve the daemon's pid via `launchctl list <label>`. The plist
       // output includes a "PID" key when the service is running.

--- a/src/lib/computer-rpc.ts
+++ b/src/lib/computer-rpc.ts
@@ -126,6 +126,62 @@ export function writeComputerPolicy(allowedBundleIds: string[]): void {
   fs.writeFileSync(resolvePolicyPath(), JSON.stringify(policy, null, 2), { mode: 0o600 });
 }
 
+// Peer-auth (F5): the helper reads a list of executable paths it will
+// accept connections from. Anything else — `nc`, `/usr/bin/python3`, a
+// random electron app — gets the socket closed before its first RPC.
+// File mirrors computer-policy.json: JSON, mode 0600, missing/unparseable
+// means deny-everything.
+export function resolvePeersPath(): string {
+  return path.join(getHelpersDir(), 'computer-peers.json');
+}
+
+// Default peer set: this exact `agents` CLI binary plus Rush.app if it's
+// installed. realpath() the symlink chain so we record the on-disk path
+// the helper will see via proc_pidpath, not the shim path.
+//
+// Why path-based instead of codesign-team-id? The agents CLI is unsigned
+// today (npm distribution), and even if we sign Rush.app the team-id
+// check would need a separate roundtrip. Path is concrete and fast; the
+// daemon already runs as the user so anyone who can swap a binary at
+// these paths can do worse via other means.
+export function loadDefaultPeers(): string[] {
+  const out = new Set<string>();
+  const add = (p: string) => {
+    try {
+      out.add(fs.realpathSync(p));
+    } catch {
+      out.add(p);
+    }
+  };
+
+  // The Node executable currently running the CLI. This is what
+  // proc_pidpath() will report when the CLI calls into the daemon.
+  if (process.execPath) add(process.execPath);
+
+  // Rush.app — the consumer Electron client. Both the helper-binary and
+  // the main app binary are possible callers depending on how Rush wires
+  // the RPC client.
+  const rushCandidates = [
+    '/Applications/Rush.app/Contents/MacOS/Rush',
+    '/Applications/Rush.app/Contents/MacOS/Electron',
+  ];
+  for (const p of rushCandidates) {
+    if (fs.existsSync(p)) add(p);
+  }
+
+  return [...out].sort();
+}
+
+// Write the peer-auth allow list. Same mode 0600 + atomic-ish semantics
+// as the policy file. The daemon picks it up at startup and on SIGHUP.
+export function writeComputerPeers(allowedExecPaths: string[]): void {
+  const dir = getHelpersDir();
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(resolvePeersPath(), JSON.stringify({ allow: allowedExecPaths }, null, 2), { mode: 0o600 });
+}
+
 // Resolve the helper executable inside the dist .app bundle. Used by the
 // stdio fallback and by install-helper to find the source bundle.
 export function resolveHelperExec(): string | null {


### PR DESCRIPTION
## Summary
- Helper now verifies the connecting client process via `LOCAL_PEERPID` + `proc_pidpath`, against an allow-list of known agents-cli binaries.
- Composes with the existing allow-list policy from `~/.agents/permissions` (baea2168) — peer-auth identifies the caller, allow-list authorizes the action.
- Rejects connections from unknown binaries before any RPC method executes.

## Files
- `packages/computer-helper/Sources/ComputerHelper/main.swift` — `LOCAL_PEERPID` + `proc_pidpath` allow-list
- `src/lib/computer-rpc.ts`, `src/commands/computer.ts` — client side
- `packages/computer-helper/README.md`

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/9f148c621db8e3046d9fdb0c861e957e)