### PR TITLE
feat(routines): default 10m / max 1w timeouts + workflow scheduling

### DIFF
--- a/src/commands/routines.ts
+++ b/src/commands/routines.ts
@@ -94,7 +94,7 @@ async function pickJob(
       message,
       choices: jobs.map((job) => ({
         value: job.name,
-        name: `${job.name} ${chalk.gray(`(${job.agent}, ${job.schedule})`)}`,
+        name: `${job.name} ${chalk.gray(`(${job.workflow ? `wf:${job.workflow}` : job.agent}, ${job.schedule})`)}`,
       })),
     });
   } catch (err) {
@@ -173,8 +173,11 @@ export function registerRoutinesCommands(program: Command): void {
         const enabledStr = job.enabled ? chalk.green('yes') : chalk.gray('no');
         const statusColor = lastStatus === 'completed' ? chalk.green : lastStatus === 'failed' ? chalk.red : lastStatus === 'timeout' ? chalk.yellow : chalk.gray;
 
+        const agentLabelPadded = job.workflow
+          ? chalk.magenta(`wf:${job.workflow}`.padEnd(10))
+          : (job.agent || '').padEnd(10);
         console.log(
-          `  ${chalk.cyan(job.name.padEnd(24))} ${job.agent.padEnd(10)} ${job.schedule.padEnd(20)} ${enabledStr.padEnd(10 + 10)} ${chalk.gray(nextStr.padEnd(24))} ${statusColor(lastStatus)}`
+          `  ${chalk.cyan(job.name.padEnd(24))} ${agentLabelPadded} ${job.schedule.padEnd(20)} ${enabledStr.padEnd(10 + 10)} ${chalk.gray(nextStr.padEnd(24))} ${statusColor(lastStatus)}`
         );
       }
 
@@ -187,22 +190,29 @@ export function registerRoutinesCommands(program: Command): void {
     .description('Create a new routine from a YAML file or inline flags. Starts the scheduler automatically if it is not already running.')
     .option('-s, --schedule <cron>', 'Cron schedule in standard format (5 fields: minute hour day month weekday)')
     .option('-a, --agent <agent>', 'Which agent runs this routine: claude, codex, gemini, cursor, or opencode')
+    .option('--workflow <name>', 'Run an installed workflow (~/.agents/workflows/<name>) via `agents run`. Mutually exclusive with --agent.')
     .option('-p, --prompt <prompt>', 'Task instruction for the agent')
     .option('-m, --mode <mode>', 'Execution mode: plan (read-only) or edit (can write files)', 'plan')
     .option('-e, --effort <effort>', 'Reasoning effort: low | medium | high | xhigh | max | auto', 'auto')
-    .option('-t, --timeout <timeout>', 'Kill the agent if it runs longer than this (e.g., 30m, 2h)', '30m')
+    .option('-t, --timeout <timeout>', 'Kill the agent if it runs longer than this (e.g., 10m, 2h, 3d, 1w; max 1w)', '10m')
     .option('--timezone <tz>', 'Interpret schedule in this timezone (e.g., America/Los_Angeles)')
     .option('--at <time>', 'One-shot mode: run once at this time (e.g., "14:30" or "2026-02-24 09:00"), then disable')
     .option('--disabled', 'Create the routine but keep it paused (enable later with resume)')
     .action(async (nameOrPath: string | undefined, options) => {
       // Check if inline mode (has flags) or file mode
-      const hasInlineFlags = options.schedule || options.agent || options.prompt || options.at;
+      const hasInlineFlags = options.schedule || options.agent || options.workflow || options.prompt || options.at;
 
       if (hasInlineFlags) {
         // Inline mode: create job from flags
         if (!nameOrPath) {
           console.log(chalk.red('Job name is required'));
           console.log(chalk.gray('Usage: agents routines add <name> --schedule "..." --agent <agent> --prompt "..."'));
+          process.exit(1);
+        }
+
+        // Validate mutually exclusive --agent / --workflow
+        if (options.agent && options.workflow) {
+          console.log(chalk.red('--agent and --workflow are mutually exclusive; specify exactly one'));
           process.exit(1);
         }
 
@@ -226,8 +236,8 @@ export function registerRoutinesCommands(program: Command): void {
           process.exit(1);
         }
 
-        if (!options.agent) {
-          console.log(chalk.red('Agent is required (use --agent)'));
+        if (!options.agent && !options.workflow) {
+          console.log(chalk.red('An agent or workflow is required (use --agent or --workflow)'));
           process.exit(1);
         }
 
@@ -240,6 +250,7 @@ export function registerRoutinesCommands(program: Command): void {
           name: nameOrPath,
           schedule,
           agent: options.agent,
+          ...(options.workflow ? { workflow: options.workflow } : {}),
           mode: options.mode,
           effort: options.effort,
           timeout: options.timeout,
@@ -304,7 +315,7 @@ export function registerRoutinesCommands(program: Command): void {
         const config: JobConfig = {
           mode: 'plan',
           effort: 'auto',
-          timeout: '30m',
+          timeout: '10m',
           enabled: true,
           ...parsed,
         } as JobConfig;
@@ -458,7 +469,8 @@ export function registerRoutinesCommands(program: Command): void {
         process.exit(1);
       }
 
-      console.log(chalk.bold(`Running job '${name}' (agent: ${job.agent}, mode: ${job.mode})\n`));
+      const runLabel = job.workflow ? `workflow: ${job.workflow}` : `agent: ${job.agent}`;
+      console.log(chalk.bold(`Running job '${name}' (${runLabel}, mode: ${job.mode})\n`));
       const spinner = ora('Executing...').start();
 
       try {

--- a/src/lib/__tests__/routines.timeout.test.ts
+++ b/src/lib/__tests__/routines.timeout.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { parseTimeout } from '../routines.js';
+
+describe('parseTimeout', () => {
+  it('parses 10m as 600000ms', () => {
+    expect(parseTimeout('10m')).toBe(600000);
+  });
+
+  it('parses 1h as 3600000ms', () => {
+    expect(parseTimeout('1h')).toBe(3600000);
+  });
+
+  it('parses 1h30m as 5400000ms', () => {
+    expect(parseTimeout('1h30m')).toBe(5400000);
+  });
+
+  it('parses 3d as 259200000ms', () => {
+    expect(parseTimeout('3d')).toBe(259200000);
+  });
+
+  it('parses 1w as 604800000ms', () => {
+    expect(parseTimeout('1w')).toBe(604800000);
+  });
+
+  it('returns null for 2w (over cap)', () => {
+    expect(parseTimeout('2w')).toBeNull();
+  });
+
+  it('returns null for 8d (over cap)', () => {
+    expect(parseTimeout('8d')).toBeNull();
+  });
+
+  it('returns null for 0m (zero duration)', () => {
+    expect(parseTimeout('0m')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(parseTimeout('')).toBeNull();
+  });
+
+  it('returns null for "30 minutes" (unrecognized format)', () => {
+    expect(parseTimeout('30 minutes')).toBeNull();
+  });
+});

--- a/src/lib/__tests__/routines.workflow.test.ts
+++ b/src/lib/__tests__/routines.workflow.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { validateJob } from '../routines.js';
+import type { JobConfig } from '../routines.js';
+
+function baseJob(overrides: Partial<JobConfig> = {}): Partial<JobConfig> {
+  return {
+    name: 'test-job',
+    schedule: '0 9 * * 1-5',
+    prompt: 'Pick up the task and complete it.',
+    mode: 'edit',
+    ...overrides,
+  };
+}
+
+describe('validateJob — workflow field', () => {
+  it('accepts workflow with no agent', () => {
+    const errors = validateJob(baseJob({ workflow: 'autodev' }));
+    expect(errors).toEqual([]);
+  });
+
+  it('rejects both agent and workflow set', () => {
+    const errors = validateJob(baseJob({ agent: 'claude', workflow: 'autodev' }));
+    expect(errors.some((e) => e.includes('exactly one of agent or workflow'))).toBe(true);
+  });
+
+  it('rejects neither agent nor workflow', () => {
+    const errors = validateJob(baseJob());
+    expect(errors.some((e) => e.includes('exactly one of agent or workflow'))).toBe(true);
+  });
+
+  it('rejects workflow with uppercase or spaces', () => {
+    const errors = validateJob(baseJob({ workflow: 'Bad Name' }));
+    expect(errors.some((e) => e.includes('workflow'))).toBe(true);
+  });
+});

--- a/src/lib/__tests__/runner.test.ts
+++ b/src/lib/__tests__/runner.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { buildJobCommand } from '../runner.js';
+import type { JobConfig } from '../routines.js';
+
+function baseJob(overrides: Partial<JobConfig> = {}): JobConfig {
+  return {
+    name: 'test-job',
+    schedule: '0 9 * * 1-5',
+    prompt: 'Do the task.',
+    mode: 'plan',
+    effort: 'auto',
+    timeout: '10m',
+    enabled: true,
+    agent: 'claude',
+    ...overrides,
+  } as JobConfig;
+}
+
+describe('buildJobCommand', () => {
+  it('bare-agent claude plan mode includes --permission-mode plan', () => {
+    const argv = buildJobCommand(baseJob({ agent: 'claude', mode: 'plan' }), 'Do the task.');
+    expect(argv).toContain('--permission-mode');
+    expect(argv).toContain('plan');
+  });
+
+  it('bare-agent claude edit mode includes --permission-mode acceptEdits', () => {
+    const argv = buildJobCommand(baseJob({ agent: 'claude', mode: 'edit' }), 'Do the task.');
+    expect(argv).toContain('--permission-mode');
+    expect(argv).toContain('acceptEdits');
+  });
+
+  it('workflow plan mode emits exact argv with no --non-interactive and no --permission-mode', () => {
+    const argv = buildJobCommand(
+      baseJob({ workflow: 'autodev', agent: undefined as unknown as 'claude', mode: 'plan' }),
+      '<prompt>',
+    );
+    expect(argv).toEqual(['agents', 'run', 'autodev', '<prompt>', '--mode', 'plan']);
+    expect(argv).not.toContain('--non-interactive');
+    expect(argv).not.toContain('--permission-mode');
+  });
+
+  it('workflow edit mode emits exact argv with --mode edit', () => {
+    const argv = buildJobCommand(
+      baseJob({ workflow: 'autodev', agent: undefined as unknown as 'claude', mode: 'edit' }),
+      '<prompt>',
+    );
+    expect(argv).toEqual(['agents', 'run', 'autodev', '<prompt>', '--mode', 'edit']);
+    expect(argv).not.toContain('--non-interactive');
+  });
+});

--- a/src/lib/routines.ts
+++ b/src/lib/routines.ts
@@ -27,7 +27,8 @@ export interface JobAllowConfig {
 export interface JobConfig {
   name: string;
   schedule: string;
-  agent: AgentId;
+  agent: AgentId;  // required when workflow is absent
+  workflow?: string;
   mode: 'plan' | 'edit' | 'full';
   effort: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'auto';
   timeout: string;
@@ -46,7 +47,8 @@ export interface JobConfig {
 export interface RunMeta {
   jobName: string;
   runId: string;
-  agent: AgentId;
+  agent: AgentId;  // undefined at runtime for workflow jobs
+  workflow?: string;
   pid: number | null;
   status: 'running' | 'completed' | 'failed' | 'timeout';
   startedAt: string;
@@ -58,7 +60,7 @@ export interface RunMeta {
 const JOB_DEFAULTS: Partial<JobConfig> = {
   mode: 'plan',
   effort: 'auto',
-  timeout: '30m',
+  timeout: '10m',
   enabled: true,
 };
 
@@ -115,7 +117,7 @@ export function writeJob(config: JobConfig): void {
   const output: Record<string, unknown> = { ...config };
   if (output.mode === 'plan') delete output.mode;
   if (output.effort === 'auto') delete output.effort;
-  if (output.timeout === '30m') delete output.timeout;
+  if (output.timeout === '10m') delete output.timeout;
   if (output.enabled === true) delete output.enabled;
   if (output.runOnce === false || output.runOnce === undefined) delete output.runOnce;
 
@@ -160,11 +162,20 @@ export function validateJob(config: Partial<JobConfig>): string[] {
       errors.push(`invalid cron expression: "${config.schedule}"`);
     }
   }
-  if (!config.agent || typeof config.agent !== 'string') {
-    errors.push('agent is required');
+  const hasAgent = Boolean(config.agent && typeof config.agent === 'string');
+  const hasWorkflow = Boolean(config.workflow && typeof config.workflow === 'string');
+  if (!hasAgent && !hasWorkflow) {
+    errors.push('exactly one of agent or workflow is required');
+  } else if (hasAgent && hasWorkflow) {
+    errors.push('exactly one of agent or workflow must be set (not both)');
   }
-  if (config.agent && !ALL_AGENT_IDS.includes(config.agent as AgentId)) {
+  if (hasAgent && config.agent && !ALL_AGENT_IDS.includes(config.agent as AgentId)) {
     errors.push(`agent must be one of: ${ALL_AGENT_IDS.join(', ')}`);
+  }
+  if (hasWorkflow && config.workflow) {
+    if (!/^[a-z0-9][a-z0-9_-]*$/.test(config.workflow)) {
+      errors.push('workflow must be a lowercase alphanumeric name (hyphens and underscores allowed, e.g. autodev)');
+    }
   }
   if (config.mode && !['plan', 'edit', 'full'].includes(config.mode)) {
     errors.push('mode must be plan, edit, or full');
@@ -176,7 +187,7 @@ export function validateJob(config: Partial<JobConfig>): string[] {
     errors.push('prompt is required');
   }
   if (config.timeout && !parseTimeout(config.timeout)) {
-    errors.push('timeout must be like 30m, 2h, 1h30m');
+    errors.push('timeout must be like 10m, 2h, 3d, 1w (max 1w)');
   }
 
   return errors;
@@ -227,15 +238,26 @@ export function resolveJobPrompt(config: JobConfig): string {
   return prompt;
 }
 
-/** Parse a human-readable timeout string (e.g. "30m", "2h", "1h30m") into milliseconds. */
+/** Parse a human-readable timeout string (e.g. "10m", "2h", "1h30m", "3d", "1w") into milliseconds.
+ *  Accepts combinations of w (weeks), d (days), h (hours), m (minutes).
+ *  Returns null if the string is empty, matches nothing, totals zero, or exceeds 1 week.
+ */
 export function parseTimeout(timeout: string): number | null {
-  const match = timeout.match(/^(?:(\d+)h)?(?:(\d+)m)?$/);
+  const match = timeout.match(/^(?:(\d+)w)?(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?$/);
   if (!match) return null;
 
-  const hours = parseInt(match[1] || '0', 10);
-  const minutes = parseInt(match[2] || '0', 10);
-  const ms = (hours * 60 + minutes) * 60 * 1000;
-  return ms > 0 ? ms : null;
+  const weeks = parseInt(match[1] || '0', 10);
+  const days = parseInt(match[2] || '0', 10);
+  const hours = parseInt(match[3] || '0', 10);
+  const minutes = parseInt(match[4] || '0', 10);
+
+  const ms = ((weeks * 7 + days) * 24 * 60 + hours * 60 + minutes) * 60 * 1000;
+  if (ms <= 0) return null;
+
+  const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000; // 604800000
+  if (ms > ONE_WEEK_MS) return null;
+
+  return ms;
 }
 
 /** List all run metadata entries for a job, sorted chronologically. */

--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -39,6 +39,15 @@ const AGENT_COMMANDS: Record<string, string[]> = {
 
 /** Build the full CLI argv for executing a job, applying mode, model, and permission flags. */
 export function buildJobCommand(config: JobConfig, resolvedPrompt: string): string[] {
+  // Workflow branch: delegate to `agents run <workflow>` which handles subagent
+  // injection, WORKFLOW.md orchestration, and model selection via frontmatter.
+  // appendModelAndReasoning is intentionally skipped — the workflow frontmatter
+  // owns model selection. No --timeout flag: the runner enforces its own SIGTERM/SIGKILL.
+  if (config.workflow) {
+    const cmd = ['agents', 'run', config.workflow, resolvedPrompt, '--mode', config.mode, '--non-interactive'];
+    return cmd;
+  }
+
   const template = AGENT_COMMANDS[config.agent];
   if (!template) {
     throw new Error(`Unsupported agent for daemon jobs: ${config.agent}`);
@@ -158,10 +167,15 @@ export async function executeJob(config: JobConfig): Promise<RunResult> {
     spawnEnv.TZ = config.timezone;
   }
 
+  // Workflows run via `agents run <workflow>` which delegates to claude under the hood.
+  // Use 'claude' as the effective agent for report extraction and metadata when workflow is set.
+  const effectiveAgent: AgentId = config.workflow ? 'claude' : config.agent;
+
   const meta: RunMeta = {
     jobName: config.name,
     runId,
-    agent: config.agent,
+    agent: effectiveAgent,
+    ...(config.workflow ? { workflow: config.workflow } : {}),
     pid: null,
     status: 'running',
     startedAt: new Date().toISOString(),
@@ -170,7 +184,7 @@ export async function executeJob(config: JobConfig): Promise<RunResult> {
   };
   writeRunMeta(meta);
 
-  const timeoutMs = parseTimeout(config.timeout) || 30 * 60 * 1000;
+  const timeoutMs = parseTimeout(config.timeout) || 10 * 60 * 1000;
 
   return new Promise<RunResult>((resolve) => {
     const child = spawn(cmd[0], cmd.slice(1), {
@@ -206,7 +220,7 @@ export async function executeJob(config: JobConfig): Promise<RunResult> {
       writeRunMeta(meta);
       timer.end({ status: 'timeout', runId });
 
-      const reportPath = extractAndSaveReport(stdoutPath, config.agent, runDir);
+      const reportPath = extractAndSaveReport(stdoutPath, effectiveAgent, runDir);
       resolve({ meta, reportPath });
     }, timeoutMs);
 
@@ -223,7 +237,7 @@ export async function executeJob(config: JobConfig): Promise<RunResult> {
       writeRunMeta(meta);
       timer.end({ status: meta.status, exitCode: code ?? undefined, runId });
 
-      const reportPath = extractAndSaveReport(stdoutPath, config.agent, runDir);
+      const reportPath = extractAndSaveReport(stdoutPath, effectiveAgent, runDir);
       resolve({ meta, reportPath });
     });
 
@@ -265,10 +279,13 @@ export async function executeJobDetached(config: JobConfig): Promise<RunMeta> {
     spawnEnv.TZ = config.timezone;
   }
 
+  const effectiveAgent: AgentId = config.workflow ? 'claude' : config.agent;
+
   const meta: RunMeta = {
     jobName: config.name,
     runId,
-    agent: config.agent,
+    agent: effectiveAgent,
+    ...(config.workflow ? { workflow: config.workflow } : {}),
     pid: null,
     status: 'running',
     startedAt: new Date().toISOString(),

--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -44,7 +44,7 @@ export function buildJobCommand(config: JobConfig, resolvedPrompt: string): stri
   // appendModelAndReasoning is intentionally skipped — the workflow frontmatter
   // owns model selection. No --timeout flag: the runner enforces its own SIGTERM/SIGKILL.
   if (config.workflow) {
-    const cmd = ['agents', 'run', config.workflow, resolvedPrompt, '--mode', config.mode, '--non-interactive'];
+    const cmd = ['agents', 'run', config.workflow, resolvedPrompt, '--mode', config.mode];
     return cmd;
   }
 


### PR DESCRIPTION
## Summary
- Default per-routine timeout of 10 minutes; max 1 week.
- Workflow scheduling support — \`routines\` can dispatch named workflows directly.
- Tests: \`routines.timeout.test.ts\`, \`routines.workflow.test.ts\`, \`runner.test.ts\`.
- Drops \`--non-interactive\` from workflow argv (workflows handle their own io) and adds \`buildJobCommand\` tests.

## Context
This work has shipped on a personal fork (\`muqsitnawaz/agents-cli\` PR #35) but never landed upstream on phnx-labs. Opening here for upstream parity.

Cherry-picked from \`feat/routines-timeouts-workflows\` (commits \`92c822d9\` + \`b8ef34ad\`) onto a clean origin/main base. Stacks cleanly under #61 (the polish PR) — the routines-format work is in #61, this PR is just timeouts + workflows.

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/9f148c621db8e3046d9fdb0c861e957e)