### PR TITLE
ci: migrate ci.yml + secret-scan.yml to self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     strategy:
       matrix:
         node-version: [22, 24]
@@ -39,7 +39,7 @@ jobs:
   publish:
     needs: build
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   gitleaks:
     name: gitleaks
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
Routes all three workflow jobs (build, publish, gitleaks) to the phnx-labs self-hosted runner pool. Stops requiring GitHub-hosted runner minutes (i.e. org billing).

\`sandbox.yml\` already targets \`[self-hosted, linux, x64]\` (migrated in commit \`2cc9d5967\`). This PR brings the remaining workflows in line.

## Diff
\`\`\`yaml
# ci.yml: build + publish jobs
- runs-on: ubuntu-latest
+ runs-on: [self-hosted, linux, x64]

# secret-scan.yml: gitleaks job
- runs-on: ubuntu-latest
+ runs-on: [self-hosted, linux, x64]
\`\`\`

## Prerequisite
The self-hosted runner pool (\`infra/ci-runner/\` in the agents monorepo — persistent cpx41 hosting 4 ephemeral runners) must actually be deployed and idle in the phnx-labs org runner registry. Verify at https://github.com/organizations/phnx-labs/settings/actions/runners.

If not deployed: follow \`infra/ci-runner/README.md\` — \`bash provision.sh\` then \`ssh root@<ip>\` + drop PAT + \`bash bootstrap.sh\`.

## Follow-up
Replace persistent runner pool with on-demand crabbox JIT-provisioned runners via \`crabbox actions hydrate\` (per the original design intent in session \`7f7e446a\`). Tracked separately.

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/9f148c621db8e3046d9fdb0c861e957e)