### PR TITLE
feat(copilot): wire GitHub Copilot CLI as a first-class agent

### DIFF
--- a/src/lib/__tests__/exec.test.ts
+++ b/src/lib/__tests__/exec.test.ts
@@ -127,6 +127,40 @@ describe('buildExecCommand', () => {
       expect(cmd[cmd.indexOf('--mode') + 1]).toBe('full');
     });
 
+    it('copilot plan produces --mode plan', () => {
+      const cmd = buildExecCommand(opts({ agent: 'copilot', mode: 'plan' }));
+      expect(cmd).toContain('--mode');
+      expect(cmd[cmd.indexOf('--mode') + 1]).toBe('plan');
+      expect(cmd).not.toContain('--allow-all-tools');
+      expect(cmd).not.toContain('--allow-all');
+    });
+
+    it('copilot edit produces --allow-all-tools (headless tools, scoped paths)', () => {
+      const cmd = buildExecCommand(opts({ agent: 'copilot', mode: 'edit' }));
+      expect(cmd).toContain('--allow-all-tools');
+      expect(cmd).not.toContain('--allow-all');
+      expect(cmd).not.toContain('--mode');
+    });
+
+    it('copilot full produces --allow-all (tools + paths + URLs)', () => {
+      const cmd = buildExecCommand(opts({ agent: 'copilot', mode: 'full' }));
+      expect(cmd).toContain('--allow-all');
+      expect(cmd).not.toContain('--allow-all-tools');
+    });
+
+    it('copilot uses -p (not positional) for the prompt', () => {
+      const cmd = buildExecCommand(opts({ agent: 'copilot', prompt: 'do the thing', mode: 'edit' }));
+      const idx = cmd.indexOf('-p');
+      expect(idx).toBeGreaterThan(-1);
+      expect(cmd[idx + 1]).toBe('do the thing');
+    });
+
+    it('copilot json adds --output-format json (JSONL)', () => {
+      const cmd = buildExecCommand(opts({ agent: 'copilot', json: true, mode: 'edit' }));
+      expect(cmd).toContain('--output-format');
+      expect(cmd[cmd.indexOf('--output-format') + 1]).toBe('json');
+    });
+
     it('every agent has all three mode entries', () => {
       for (const agent of ALL_AGENTS) {
         const template = AGENT_COMMANDS[agent];
@@ -415,6 +449,23 @@ describe('buildExecCommand', () => {
     it('does not inject Claude config dir for non-Claude agents', () => {
       const env = buildExecEnv(opts({ agent: 'codex', version: '0.98.0' }));
       expect(env.CLAUDE_CONFIG_DIR).toBeUndefined();
+    });
+
+    it('injects COPILOT_HOME for pinned Copilot versions', () => {
+      const env = buildExecEnv(opts({ agent: 'copilot', version: '1.0.56', mode: 'edit' }));
+      expect(env.COPILOT_HOME).toBe(
+        `${process.env.HOME}/.agents/.history/versions/copilot/1.0.56/home/.copilot`
+      );
+    });
+
+    it('strips COPILOT_HOME for non-Copilot agents', () => {
+      process.env.COPILOT_HOME = '/tmp/leaked-copilot-home';
+      try {
+        const env = buildExecEnv(opts({ agent: 'claude', version: '2.1.98' }));
+        expect(env.COPILOT_HOME).toBeUndefined();
+      } finally {
+        delete process.env.COPILOT_HOME;
+      }
     });
   });
 

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -903,6 +903,10 @@ function getSessionDir(agentId: AgentId, base: string): string | null {
       return path.join(base, '.gemini', 'tmp');
     case 'grok':
       return path.join(base, '.grok', 'sessions');
+    case 'copilot':
+      // Copilot persists sessions at ~/.copilot/session-state/<id>/events.jsonl.
+      // The events.jsonl is the canonical NDJSON event stream per session.
+      return path.join(base, '.copilot', 'session-state');
     default:
       return null;
   }
@@ -913,6 +917,7 @@ function getSessionExtension(agentId: AgentId): string | null {
   switch (agentId) {
     case 'claude':
     case 'codex':
+    case 'copilot':
       return '.jsonl';
     case 'gemini':
       return '.json';

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -71,8 +71,9 @@ export function parseExecEnv(entries: string[]): Record<string, string> | undefi
 
 /**
  * Build the process environment for an agent invocation.
- * Pins CLAUDE_CONFIG_DIR for Claude and CODEX_HOME for Codex; strips the
- * other agent's env var so it doesn't leak into unrelated invocations.
+ * Pins CLAUDE_CONFIG_DIR for Claude, CODEX_HOME for Codex, and COPILOT_HOME
+ * for GitHub Copilot; strips the other agents' env vars so they don't leak
+ * into unrelated invocations.
  */
 export function buildExecEnv(options: ExecOptions): NodeJS.ProcessEnv {
   const result: NodeJS.ProcessEnv = { ...process.env };
@@ -93,6 +94,7 @@ export function buildExecEnv(options: ExecOptions): NodeJS.ProcessEnv {
       result.CLAUDE_CONFIG_DIR = path.join(getVersionHomePath('claude', version), '.claude');
     }
     delete result.CODEX_HOME;
+    delete result.COPILOT_HOME;
   } else if (options.agent === 'codex') {
     const cwd = options.cwd || process.cwd();
     const resolvedVersion = options.version ?? resolveVersion('codex', cwd);
@@ -103,9 +105,25 @@ export function buildExecEnv(options: ExecOptions): NodeJS.ProcessEnv {
       result.CODEX_HOME = path.join(getVersionHomePath('codex', version), '.codex');
     }
     delete result.CLAUDE_CONFIG_DIR;
+    delete result.COPILOT_HOME;
+  } else if (options.agent === 'copilot') {
+    // Copilot honors COPILOT_HOME (relocates ~/.copilot, including settings,
+    // mcp-config.json, sessions, logs). Pin it at the per-version home so
+    // version switches isolate MCP servers, auth, and session history.
+    const cwd = options.cwd || process.cwd();
+    const resolvedVersion = options.version ?? resolveVersion('copilot', cwd);
+    const version = options.version
+      ? resolvedVersion
+      : (resolvedVersion && isVersionInstalled('copilot', resolvedVersion) ? resolvedVersion : null);
+    if (version) {
+      result.COPILOT_HOME = path.join(getVersionHomePath('copilot', version), '.copilot');
+    }
+    delete result.CLAUDE_CONFIG_DIR;
+    delete result.CODEX_HOME;
   } else {
     delete result.CLAUDE_CONFIG_DIR;
     delete result.CODEX_HOME;
+    delete result.COPILOT_HOME;
   }
 
   return {
@@ -202,14 +220,25 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
     jsonFlags: ['--output-format', 'stream-json'],
     modelFlag: '--model',
   },
+  // GitHub Copilot CLI (`@github/copilot`, GA 2026-02-25). Flags verified
+  // against `copilot --help` from v0.0.413+:
+  //   -p, --prompt <text>          non-interactive one-shot
+  //   --mode <interactive|plan|autopilot>
+  //   --allow-all-tools            required for non-interactive tool exec
+  //   --allow-all (alias --yolo)   tools + paths + URLs
+  //   --output-format <text|json>  json => JSONL, one object per line
+  //   --model <model>
+  // Plan mode is read-only so it does not need an allow-tools grant; edit/full
+  // need at minimum --allow-all-tools so headless runs don't stall on prompts.
   copilot: {
     base: ['copilot'],
-    promptFlag: 'positional',
+    promptFlag: '-p',
     modeFlags: {
-      plan: [],
-      edit: [],
-      full: [],
+      plan: ['--mode', 'plan'],
+      edit: ['--allow-all-tools'],
+      full: ['--allow-all'],
     },
+    jsonFlags: ['--output-format', 'json'],
     modelFlag: '--model',
   },
   amp: {

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -259,14 +259,22 @@ fi
 # written by agents-cli actually take effect.
 export CODEX_HOME="$VERSION_DIR/home/${configDirName}"
 `
-      : agent === 'grok'
+      : agent === 'copilot'
         ? `
+# GitHub Copilot CLI honors COPILOT_HOME to relocate its config and state
+# (settings.json, mcp-config.json, session-state/, logs/, plugins/). Point
+# it at the versioned home so MCP servers, custom agents, and session
+# history are isolated per copilot version.
+export COPILOT_HOME="$VERSION_DIR/home/${configDirName}"
+`
+        : agent === 'grok'
+          ? `
 # Grok Build uses GROK_HOME to isolate its entire configuration tree
 # (skills, hooks, plugins, agents, memory, sessions, config.toml, MCP, etc.).
 # This gives agents-cli full versioned isolation + resource sync for grok.
 export GROK_HOME="$VERSION_DIR/home/.grok"
 `
-        : '';
+          : '';
 
   // Agents that don't natively resolve @-imports in their rules file need
   // agents-cli to recompile when the user edits a rule/preset file. The
@@ -601,7 +609,14 @@ export CLAUDE_CONFIG_DIR="$HOME/.agents/.history/versions/${agent}/${version}/ho
 # and rules written by agents-cli actually take effect.
 export CODEX_HOME="$HOME/.agents/.history/versions/${agent}/${version}/home/${configDirName}"
 `
-      : '';
+      : agent === 'copilot'
+        ? `
+# Copilot honors COPILOT_HOME to relocate ~/.copilot (settings, mcp-config.json,
+# session-state, logs). Point direct aliases at the versioned home so per-
+# version MCP and session state are isolated.
+export COPILOT_HOME="$HOME/.agents/.history/versions/${agent}/${version}/home/${configDirName}"
+`
+        : '';
   const launchArgs = agent === 'codex' ? ' -c check_for_update_on_startup=false' : '';
 
   return `#!/bin/bash


### PR DESCRIPTION
## Summary

Brings GitHub Copilot CLI (`@github/copilot`, GA 2026-02-25) to feature parity with Claude / Codex / Gemini in `agents-cli`. Motivated by Synopsys blocking Claude Code — engineers there need an immediate alternative path and Copilot is approved.

### What changed

- **`src/lib/exec.ts`**
  - Fixed the broken `copilot` entry in `AGENT_COMMANDS`. Verified against `copilot --help` from v1.0.56:
    - `promptFlag: '-p'` (was `'positional'` — wrong; Copilot rejects positional prompts)
    - `modeFlags.plan: ['--mode', 'plan']` — read-only
    - `modeFlags.edit: ['--allow-all-tools']` — required for non-interactive tool exec
    - `modeFlags.full: ['--allow-all']` — alias `--yolo`, grants tools+paths+URLs
    - `jsonFlags: ['--output-format', 'json']` — emits JSONL, one event per line
  - `buildExecEnv()` now pins `COPILOT_HOME` to the per-version `home/.copilot` for `agents run copilot`, and strips it for non-copilot agents to prevent leakage.

- **`src/lib/shims.ts`**
  - Both the resolved shim (`generateShimScript`) and the direct versioned alias (`generateVersionedAliasScript`) emit `export COPILOT_HOME="$VERSION_DIR/home/.copilot"` so settings, MCP, session-state, logs, and plugins are isolated per Copilot version.

- **`src/lib/agents.ts`**
  - `getSessionDir` and `getSessionExtension` now know about Copilot: sessions live at `~/.copilot/session-state/<id>/events.jsonl` (NDJSON event stream). This lets `agents sessions` discover Copilot transcripts the same way it does Claude / Codex.

- **`src/lib/__tests__/exec.test.ts`**
  - Six new tests covering Copilot mode/prompt/JSON flag mapping (plan vs edit vs full, `-p` vs positional, `--output-format json`) and `COPILOT_HOME` env pinning + leak prevention.

### Smoke test (real Copilot CLI, on this branch)

```
agents add copilot@1.0.56 -y
agents run copilot "say hi in one word" --mode plan --json --quiet --timeout 15s
```

Result: GitHub MCP server connected, all skills loaded from synced `~/.copilot/skills/`, JSON event stream emitted cleanly, plan mode honored (`agentMode\":\"plan\"`), exit 0.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `bunx vitest run src/lib/__tests__/exec.test.ts` — 91 passed, all new copilot cases green
- [x] `bunx vitest run src/lib/shims.test.ts src/lib/agents.test.ts src/lib/mcp.test.ts src/lib/__tests__/exec.test.ts` — 111 passed
- [x] Full suite: 1770 passed, 5 pre-existing env-dependent failures in `models.test.ts` (untouched by this PR — `git diff HEAD~4 HEAD -- src/lib/models.ts src/lib/__tests__/models.test.ts` is empty)
- [x] End-to-end smoke run against installed Copilot 1.0.56 — connected, ran, exited 0

## Feature coverage (matches Copilot CLI capabilities verified via `copilot --help`)

| Feature | Wired |
|---|---|
| Plan / edit / full mode mapping | yes |
| Headless `-p` one-shot | yes |
| `--output-format json` NDJSON stream | yes |
| Model selection via `--model` | yes |
| MCP servers (`~/.copilot/mcp-config.json`) | already wired via `getMcpConfigPathForHome` |
| Skills (synced from `~/.agents/skills` to `~/.copilot/skills`) | yes — confirmed loaded at runtime |
| Per-version isolation via `COPILOT_HOME` | yes |
| Session discovery (`~/.copilot/session-state/<id>/events.jsonl`) | yes |
| Custom commands (`~/.copilot/commands/`) | already wired via `AGENTS.copilot.commandsDir` |
| Plugins | Copilot's plugin system (`copilot plugin` + `--plugin-dir`) — uses native plugin manager, no agents-cli sync needed |
| Browser control | Copilot has no built-in browser; users add Playwright MCP via standard MCP config |

🤖 Generated with [Claude Code](https://claude.com/claude-code)