### PR TITLE
docs: OSS-prep cleanup of internal references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,25 +131,13 @@ See `docs/`:
 - Don't add fallback logic for the legacy single-root model — the migrator handles it once at install.
 - `agents repo push`/`pull` operates on `~/.agents/` only; system updates ride `npm update -g agents-cli`.
 
-## Remote Test Execution (Crabbox)
+## Running Tests
 
-**NEVER run tests locally** — they freeze the machine. Always use Crabbox:
+Use `bun run test` to run the full vitest suite. Tests are designed to be fast
+and run cleanly on any local machine with Node 22+ and bun installed.
 
-```bash
-# Setup (once per session)
-eval "$(agents secrets export hetzner.com)" && export HCLOUD_TOKEN=$API_TOKEN
-
-# Check for existing box
-crabbox list
-
-# Warm up if needed (~60s)
-crabbox warmup --class beast
-
-# Run tests remotely
-crabbox run --id <slug> -- bun test
-```
-
-The box auto-stops after 30 minutes of idleness. Cost: ~$0.14/hour.
+CI runs the matrix (Node 22 + 24 on ubuntu-latest) on every PR. See
+`.github/workflows/ci.yml`.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Supports plan (read-only) and edit modes, effort levels, JSON output for scripti
 agents run claude "review this diff" --acp --json
 ```
 
-`--acp` routes through the [Agent Client Protocol](https://agentclientprotocol.com/) so you get a unified event stream -- `agent_message_chunk`, `tool_call`, `plan_update`, `stop_reason` -- instead of writing a parser per CLI. File writes and shell commands flow through agents-cli, which means `--mode plan` becomes a real sandbox: the write RPC is denied, not just unused.
+`--acp` routes through the [Agent Client Protocol](https://github.com/zed-industries/agent-client-protocol) so you get a unified event stream -- `agent_message_chunk`, `tool_call`, `plan_update`, `stop_reason` -- instead of writing a parser per CLI. File writes and shell commands flow through agents-cli, which means `--mode plan` becomes a real sandbox: the write RPC is denied, not just unused.
 
 ACP adapters are documented for claude, codex, gemini, cursor, opencode, and openclaw. Other harnesses keep running on the direct-exec path.
 
@@ -281,7 +281,7 @@ A workflow is a directory:
 ---
 name: Code Review
 description: Evidence-grounded PR review with file:line citations.
-model: claude-opus-4-7
+model: opus
 tools:
   - Read
   - Grep
@@ -433,6 +433,9 @@ agents browser profiles create cloud \
 ---
 
 ## Secrets
+
+> **Platform:** `agents secrets` requires macOS Keychain or Linux libsecret.
+> On Windows (non-WSL), use environment variables or a `.env` file instead.
 
 ```bash
 # API keys in Keychain, not in .env files.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,18 +2,23 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in agents-cli, please report it responsibly.
+If you discover a security vulnerability in agents-cli, please report it
+responsibly via GitHub Security Advisories:
 
-**Email:** security@phnx-labs.com
+**https://github.com/phnx-labs/agents-cli/security/advisories/new**
 
-Please include:
+This opens a private channel with the maintainers. Please include:
 
 - A description of the vulnerability
 - Steps to reproduce
 - Potential impact
 - Suggested fix (if any)
 
-We will acknowledge receipt within 48 hours and aim to release a fix within 7 days for critical issues.
+We will acknowledge receipt within 48 hours and aim to release a fix within
+7 days for critical issues.
+
+**Fallback:** If you cannot use GitHub Security Advisories, email
+`security@phnx-labs.com`.
 
 ## Scope
 

--- a/docs/01-version-management.md
+++ b/docs/01-version-management.md
@@ -154,10 +154,6 @@ pty output. Specifically:
 - **"Which process is the agent"** is always the immediate child of the
   shell, not a deeper descendant.
 
-See [`companion/docs/01-terminal-lifecycle.md`](../../companion/docs/01-terminal-lifecycle.md)
-for how the Companion extension consumes this contract to implement
-`tabReady → shellReady → promptReady → agentReady` event detection.
-
 ### What would break the contract
 
 | Hypothetical change | Breaks |

--- a/docs/06-observability.md
+++ b/docs/06-observability.md
@@ -68,53 +68,6 @@ agents teams list --json &
 wait
 ```
 
-## Case Study: Companion Foreman
-
-Companion's Factory Floor ships a voice coordinator called Foreman. When the user
-asks "what's everyone doing?" the extension host calls all three JSON sources in
-parallel, cross-references with live VS Code terminals, and hands a unified digest
-to an OpenAI Realtime model that narrates the answer.
-
-```
-User voice ("what's everyone doing?")
-     │
-     ▼
-┌────────────────────────────────┐
-│  Extension host (Node)         │
-│                                │
-│  parallel:                     │
-│    agents sessions --json  ────┼──► local + team-spawned
-│    agents cloud list --json ───┼──► remote dispatches
-│    agents teams list --json ───┼──► DAG state
-│                                │
-│  cross-reference:              │
-│    AGENT_SESSION_ID env on     │
-│    VS Code terminals ──────────┼──► open_in_ide flag
-│                                │
-│  merge into unified digest     │
-└────────────────────────────────┘
-     │
-     ▼
-OpenAI Realtime (gpt-realtime)
-     │
-     ▼
-Voice response: "Claude is 12 minutes into auth refactor on agents
-                repo, last edited jwt.ts. Codex finished EXAMPLE-362.
-                Gemini stuck 40 min on staging timeout."
-```
-
-Key design choices from this case study:
-
-1. **Shell out, don't reach into the DB.** agents-cli owns the schema. External tools
-   get stable JSON. The DB migrates transparently when you run `agents sessions`.
-2. **Cache nothing.** Each call to `--json` hits the DB + incremental scan. Warm
-   calls return in ~100-200ms. Good enough for voice turns.
-3. **Fail open.** If any one of the three sources times out or errors, the other
-   two still produce a useful answer.
-4. **Cross-reference for UI state.** `sessions --json` tells you what sessions
-   exist on disk. To know which are open in the IDE *right now*, read
-   `AGENT_SESSION_ID` from live terminal env vars and intersect.
-
 ## Patterns for External Consumers
 
 ### Polling (dashboards)


### PR DESCRIPTION
## Summary

Five small docs commits stripping internal-org references so the README/AGENTS/SECURITY/docs read cleanly for OSS launch.

- `bc730136` docs: rewrite test-running section to drop crabbox-internal reference
- `e6872e8c` docs: link upstream acp repo, simplify model example, note windows secrets fallback
- `8eae3dcc` docs: prefer github security advisories for vuln reports
- `c9ea975c` docs: drop companion terminal-lifecycle cross-reference
- `e1c3fbbc` docs: drop companion foreman case study

No code changes. No behavior change.