### PR TITLE
feat: env override for system repo, anonymize examples, cleanup brand refs

### DIFF
--- a/src/commands/factory.ts
+++ b/src/commands/factory.ts
@@ -1,19 +1,8 @@
 /**
- * Software Factory CLI -- thin client over `prix/factory/service`.
+ * Software Factory CLI — submits Linear issues to a remote orchestrator.
  *
- * One verb today:
- *
- *   agents factory submit <linear-ref>   POST /factory/submit
- *
- * Everything else (planner pod, worker dispatch, PR-merged/CI-failed
- * webhooks, retry caps, heartbeat reaper) lives server-side in
- * `agents/prix/factory/service/src/factory.ts`, driven by the
- * `factory-tick` k8s CronJob. The laptop is optional after submit.
- *
- * Future verbs (list / status / tail / cancel / message) are intentionally
- * deferred until the matching server endpoints land; they'll be thin
- * clients too. No supervisor, ledger, oracle, or `~/.agents/factory/`
- * registry on the laptop -- ever.
+ * Requires FACTORY_FLOOR_URL pointing at a Factory-compatible endpoint.
+ * Beta-gated; enable with `agents beta enable factory`.
  */
 import type { Command } from 'commander';
 import chalk from 'chalk';
@@ -81,8 +70,8 @@ export function registerFactoryCommands(program: Command): void {
     .description('Software Factory -- submit Linear tickets to the cloud orchestrator.')
     .addHelpText('after', `
 Examples:
-  agents factory submit EXAMPLE-2451
-  agents factory submit https://linear.app/example/issue/EXAMPLE-2451
+  agents factory submit PROJ-123
+  agents factory submit https://linear.app/example/issue/PROJ-123
 `);
 
   factory.hook('preAction', () => {
@@ -94,7 +83,7 @@ Examples:
 
   factory
     .command('submit <linear-ref>')
-    .description('Submit a Linear issue (EXAMPLE-123 or URL) to the Software Factory.')
+    .description('Submit a Linear issue (PROJ-123 or URL) to the Software Factory.')
     .option('--json', 'Output machine-readable JSON')
     .action(async (ref: string, opts: { json?: boolean }) => {
       const result = await postFactorySubmit(ref);

--- a/src/commands/profiles.ts
+++ b/src/commands/profiles.ts
@@ -135,7 +135,7 @@ Examples:
 
   # Add MiniMax for SWE-bench style fixes; reuses the same OpenRouter key
   agents profiles add minimax
-  agents run minimax "investigate EXAMPLE-2317 and patch the off-by-one in pagination"
+  agents run minimax "investigate PROJ-456 and patch the off-by-one in pagination"
 
   # Add DeepSeek for cheap, fast non-reasoning work
   agents profiles add deepseek

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -66,7 +66,7 @@ async function importAgent(agentId: AgentId, version: string): Promise<{ success
 }
 
 /** First-run setup. Clones ~/.agents-system/ from the system repo if needed. */
-export async function runSetup(program: Command, options: { force?: boolean; suppressFooter?: boolean } = {}): Promise<void> {
+export async function runSetup(program: Command, options: { force?: boolean; suppressFooter?: boolean; systemRepo?: boolean } = {}): Promise<void> {
   const agentsDir = getAgentsDir();
   const alreadyConfigured = isGitRepo(agentsDir);
 
@@ -84,40 +84,49 @@ export async function runSetup(program: Command, options: { force?: boolean; sup
     sessionCounts[install.agentId] = countSessionFiles(install.agentId);
   }
 
+  const systemRepo = process.env.AGENTS_SYSTEM_REPO || DEFAULT_SYSTEM_REPO;
+
   console.log(chalk.bold('\nWelcome to agents-cli.'));
-  console.log(chalk.gray(`Cloning the system repo from ${systemRepoSlug(DEFAULT_SYSTEM_REPO)} into ~/.agents-system/.\n`));
 
-  ensureAgentsDir();
-
-  const spinner = ora('Cloning system repo...').start();
-
-  if (isGitRepo(agentsDir)) {
-    // --force on an existing repo: pull instead of re-clone
-    const result = await pullRepo(agentsDir);
-    if (!result.success) {
-      spinner.fail(`Pull failed: ${result.error}`);
-      console.log(chalk.gray('Fix the issue and re-run: agents setup --force'));
-      process.exit(1);
-    }
-    spinner.succeed(`Updated to ${result.commit}`);
+  if (options.systemRepo === false) {
+    ensureAgentsDir();
+    console.log(chalk.gray('Skipping system repo clone (--no-system-repo).'));
+    console.log(chalk.gray(`Populate ~/.agents-system/ yourself before running other commands that depend on it.\n`));
   } else {
-    // Check git is available
-    try {
-      const { execSync } = await import('child_process');
-      execSync('which git', { stdio: 'ignore' });
-    } catch {
-      spinner.fail('git is not installed');
-      console.log(chalk.gray('Install git first: https://git-scm.com/downloads'));
-      process.exit(1);
-    }
+    console.log(chalk.gray(`Cloning the system repo from ${systemRepoSlug(systemRepo)} into ~/.agents-system/.\n`));
 
-    const result = await cloneIntoExisting(DEFAULT_SYSTEM_REPO, agentsDir);
-    if (!result.success) {
-      spinner.fail(`Clone failed: ${result.error}`);
-      console.log(chalk.gray('Fix the issue and re-run: agents setup --force'));
-      process.exit(1);
+    ensureAgentsDir();
+
+    const spinner = ora('Cloning system repo...').start();
+
+    if (isGitRepo(agentsDir)) {
+      // --force on an existing repo: pull instead of re-clone
+      const result = await pullRepo(agentsDir);
+      if (!result.success) {
+        spinner.fail(`Pull failed: ${result.error}`);
+        console.log(chalk.gray('Fix the issue and re-run: agents setup --force'));
+        process.exit(1);
+      }
+      spinner.succeed(`Updated to ${result.commit}`);
+    } else {
+      // Check git is available
+      try {
+        const { execSync } = await import('child_process');
+        execSync('which git', { stdio: 'ignore' });
+      } catch {
+        spinner.fail('git is not installed');
+        console.log(chalk.gray('Install git first: https://git-scm.com/downloads'));
+        process.exit(1);
+      }
+
+      const result = await cloneIntoExisting(systemRepo, agentsDir);
+      if (!result.success) {
+        spinner.fail(`Clone failed: ${result.error}`);
+        console.log(chalk.gray('Fix the issue and re-run: agents setup --force'));
+        process.exit(1);
+      }
+      spinner.succeed(`Cloned ${systemRepoSlug(systemRepo)} (${result.commit})`);
     }
-    spinner.succeed(`Cloned ${systemRepoSlug(DEFAULT_SYSTEM_REPO)} (${result.commit})`);
   }
 
   // Offer to import existing unmanaged installations
@@ -223,7 +232,8 @@ export function registerSetupCommand(program: Command): void {
   const setupCmd = program
     .command('setup')
     .description('First-time setup. Clones a config repo and installs agent CLIs.')
-    .option('-f, --force', 'Re-run setup even if ~/.agents-system/ already exists (use with caution)');
+    .option('-f, --force', 'Re-run setup even if ~/.agents-system/ already exists (use with caution)')
+    .option('--no-system-repo', 'Skip cloning the system repo (you must populate ~/.agents-system/ yourself)');
 
   setHelpSections(setupCmd, {
     examples: `

--- a/src/lib/secrets/index.ts
+++ b/src/lib/secrets/index.ts
@@ -59,8 +59,9 @@ export function serializeRef(ref: SecretRef): string {
 function assertSupportedPlatform(): void {
   if (process.platform !== 'darwin' && process.platform !== 'linux') {
     throw new Error(
-      'Secure credential storage requires macOS or Linux. ' +
-      'On Windows, use environment variables or .env files instead.'
+      'agents secrets requires macOS Keychain or Linux libsecret.\n' +
+      'Windows is not supported — use environment variables or a .env file instead.\n' +
+      'WSL2 is supported (libsecret via gnome-keyring).'
     );
   }
 }

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -1277,7 +1277,7 @@ export function getPathShadowingExecutable(agent: AgentId): string | null {
  * Delete the legacy ~/.agents/shims/<cli> file if it exists, returning whether
  * anything was removed. Pre-split installs put shims under ~/.agents/shims/;
  * the new layout uses ~/.agents-system/shims/. The leftover file causes the
- * repair-prompt loop reported in EXAMPLE-664 — `getPathShadowingExecutable` flags
+ * repair-prompt loop reported in PROJ-789 — `getPathShadowingExecutable` flags
  * it as a shadow but `addShimsToPath` only edits rc files, never the file
  * itself. Removing it ends the loop.
  */

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -90,7 +90,7 @@ const DRIVE_DIR = path.join(CACHE_DIR, 'drive');
 const TERMINALS_DIR = path.join(CACHE_DIR, 'terminals');
 const LOGS_DIR = path.join(CACHE_DIR, 'logs');
 const RUNTIME_STATE_DIR = path.join(CACHE_DIR, 'state');
-const SWARMIFY_DIR = path.join(CACHE_DIR, 'companion');
+const COMPANION_CACHE_DIR = path.join(CACHE_DIR, 'companion');
 const BROWSER_RUNTIME_DIR = path.join(CACHE_DIR, 'browser');
 const HELPERS_DIR = path.join(CACHE_DIR, 'helpers');
 const DAEMON_DIR = path.join(HELPERS_DIR, 'daemon');
@@ -356,7 +356,7 @@ export function getLogsDir(): string { return LOGS_DIR; }
 export function getRuntimeStateDir(): string { return RUNTIME_STATE_DIR; }
 
 /** Path to companion-extension scratch (~/.agents/.cache/companion/). */
-export function getCompanionDir(): string { return SWARMIFY_DIR; }
+export function getCompanionDir(): string { return COMPANION_CACHE_DIR; }
 
 /** Path to browser runtime data — chrome-data, pids (~/.agents/.cache/browser/). */
 export function getBrowserRuntimeDir(): string { return BROWSER_RUNTIME_DIR; }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -232,9 +232,12 @@ export const DEFAULT_REGISTRIES: Record<RegistryType, Record<string, RegistryCon
 };
 
 /**
- * Registries that ship pre-seeded into new users' agents.yaml once, but are
- * not "defaults" — after seeding they behave like any user-added registry
- * (listable, disable-able, removable, and gone for good once removed).
+ * Third-party registries pre-seeded on first install for discoverability.
+ *
+ * These ship into new users' agents.yaml once, but are not "defaults" — after
+ * seeding they behave like any user-added registry (listable, disable-able,
+ * removable). Removed users can `agents registry remove <name>` to opt out;
+ * once removed they don't come back.
  */
 export const SEEDED_REGISTRIES: Record<RegistryType, Record<string, RegistryConfig>> = {
   mcp: {},


### PR DESCRIPTION
## Summary

Single commit (\`88af2db4\`) prepping the codebase for OSS launch:

- Env override for the system repo path so forks can re-point it.
- Anonymized examples in docs (no internal usernames/emails/orgs).
- Stripped legacy private brand references.

Pairs naturally with agents/dx (docs cleanup) and agents/supply (supply-chain hardening) in the OSS-prep batch.