### PR TITLE
fix(plugins): use 'directory' source discriminator for marketplace registration

### DIFF
--- a/src/lib/plugin-marketplace.ts
+++ b/src/lib/plugin-marketplace.ts
@@ -24,7 +24,7 @@ import type { AgentId, DiscoveredPlugin, PluginManifest } from './types.js';
 export const MARKETPLACE_NAME = 'agents-cli';
 
 interface KnownMarketplaceEntry {
-  source: { source: 'local'; path: string };
+  source: { source: 'directory'; path: string };
   installLocation: string;
   lastUpdated: string;
 }
@@ -152,7 +152,7 @@ export function registerMarketplace(agent: AgentId, versionHome: string): void {
   }
 
   known[MARKETPLACE_NAME] = {
-    source: { source: 'local', path: root },
+    source: { source: 'directory', path: root },
     installLocation: root,
     lastUpdated: new Date().toISOString(),
   };


### PR DESCRIPTION
## Summary

Two-line fix to \`src/lib/plugin-marketplace.ts\` (lines 27 + 155): change \`source: 'local'\` to \`source: 'directory'\`.

## The bug (issue #46)

\`registerMarketplace()\` writes \`known[name].source.source = 'local'\` into \`~/.claude/plugins/known_marketplaces.json\`, but \`'local'\` is not a valid value in the Claude Code marketplace-source discriminated-union schema. Every Claude Code session after \`agents add\` errors out on \`/plugin\`:

> Marketplace configuration file is corrupted: agents-cli.source.source: Invalid input

Confirmed in Claude Code 2.1.139–2.1.143. Valid literals are: \`url\`, \`github\`, \`git\`, \`npm\`, \`file\`, \`directory\`, \`skills-dir\`, \`hostPattern\`, \`pathPattern\`. The agents-cli marketplace directory contains \`.claude-plugin/marketplace.json\`, so \`directory\` is the correct discriminator.

## Fix

\`\`\`diff
- source: { source: 'local'; path: string };  // type at line 27
+ source: { source: 'directory'; path: string };

- source: { source: 'local', path: root },     // value at line 155
+ source: { source: 'directory', path: root },
\`\`\`

Closes #46.