### PR TITLE
fix(teams): warn loudly when --after teammates have no watch process

### DIFF
--- a/src/commands/teams.ts
+++ b/src/commands/teams.ts
@@ -1044,6 +1044,16 @@ export function registerTeamsCommands(program: Command): void {
         console.log();
         if (staged) {
           console.log(chalk.gray(`Start the ready teammates:  agents teams start ${team}`));
+          if (after.length > 0) {
+            process.stderr.write(
+              chalk.yellow(
+                `\nWarning: this teammate has --after dependencies and will NEVER start on its own.\n` +
+                `  A supervisor watch process is required to launch it when its deps complete.\n` +
+                `  Run this in another terminal:\n` +
+                `    agents teams start ${team} --watch\n`
+              )
+            );
+          }
         } else {
           console.log(chalk.gray(`Check in later:  agents teams status ${team}`));
         }


### PR DESCRIPTION
## Summary
- Closes #45
- When `agents teams add` is called with `--after`, the staged teammate will never start unless a supervisor (`agents teams start <team> --watch`) is alive in a foreground terminal. Previously, users got only a vague "Start the ready teammates" hint with no explanation of `--watch`.
- This adds an explicit `stderr` warning immediately after staging, telling the user exactly what to run and why.

## Change

`src/commands/teams.ts` lines 1047–1056: after printing the existing "Start the ready teammates" hint, if `after.length > 0` we write a `chalk.yellow` warning to `stderr` explaining the `--watch` requirement.

No new flags, no new logic paths, no supervisor changes. 10 lines.

## Test plan
- [ ] `agents teams add <team> <agent> "task" --name b --after a` — should now print a yellow warning on stderr directing the user to run `agents teams start <team> --watch`
- [ ] `agents teams add <team> <agent> "task"` (no `--after`) — no warning, behavior unchanged
- [ ] `agents teams start <team> --watch` still launches staged teammates as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)