### PR TITLE
feat: auto-pick chromium-family browser when --profile omitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,11 +353,15 @@ Plugins live in the user repo (`~/.agents/plugins/`), not inside any single vers
 Give agents access to a real browser — no relay extension, no cloud service, no Playwright getting blocked.
 
 ```bash
-# Create an isolated profile pointing at a real browser on your machine
-# (chrome, comet, brave, chromium, edge, or custom).
-agents browser profiles create work --browser chrome
+# First run: omit --profile and we auto-pick the first installed Chromium-family
+# browser. macOS prefers Chrome > Brave > Edge > Chromium > Comet; Linux prefers
+# Chrome > Chromium > Brave > Edge; Windows prefers Edge (always preinstalled) >
+# Chrome > Brave. The auto-picked profile is saved as "default" for later runs.
+export AGENTS_BROWSER_TASK=$(agents browser start --url https://app.example.com)
 
-# Start a task once, then bind it to this shell — every later command picks it up.
+# Or pin a named profile to a specific browser (chrome, comet, brave, chromium,
+# edge, or custom) when you want isolation from "default".
+agents browser profiles create work --browser chrome
 # `start` writes the resolved name (e.g. `swift-crab-falcon-a3f92b1c`) to stdout
 # and human-friendly commentary to stderr, so $(...) capture stays clean.
 export AGENTS_BROWSER_TASK=$(agents browser start --profile work --url https://app.example.com)

--- a/src/commands/browser.ts
+++ b/src/commands/browser.ts
@@ -6,6 +6,7 @@ import {
   getProfile,
   createProfile,
   deleteProfile,
+  ensureDefaultBrowserProfile,
   getProfileRuntimeDir,
   extractConfiguredPort,
   findFreeProfilePort,
@@ -83,8 +84,11 @@ export function registerBrowserCommand(program: Command): void {
       # Create a Chrome profile pointed at a CDP endpoint
       agents browser profiles create work --browser chrome --endpoint http://localhost:9222
 
-      # Start a session against a profile
-      agents browser start work
+      # Start a session — auto-picks the first installed Chromium-family browser
+      agents browser start
+
+      # Or pin to a specific profile
+      agents browser start --profile work
 
       # Drive the page
       agents browser navigate https://example.com
@@ -474,13 +478,22 @@ function registerProfilesCommands(browser: Command): void {
 function registerTaskCommands(browser: Command): void {
   browser
     .command('start')
-    .description('Start a browser task with a profile')
-    .requiredOption('-p, --profile <name>', 'Browser profile to use')
+    .description('Start a browser task. Pass --profile <name>, or omit to auto-pick a Chromium-family browser already installed on this machine.')
+    .option('-p, --profile <name>', 'Browser profile to use (auto-picks from installed Chromium-family browsers if omitted)')
     .option(TASK_OPTION_FLAG, 'Task name (auto-generated if omitted)')
     .option('-e, --endpoint <name>', 'Endpoint preset (defaults to the profile\'s default)')
     .option('-u, --url <url>', 'Open URL in first tab')
     .action(async (opts) => {
-      const profileName: string = opts.profile;
+      let profileName: string = opts.profile;
+      if (!profileName) {
+        try {
+          const detected = await ensureDefaultBrowserProfile();
+          profileName = detected.name;
+        } catch (err) {
+          console.error(err instanceof Error ? err.message : String(err));
+          process.exit(1);
+        }
+      }
 
       // Pre-check the profile locally so we fail fast with a helpful error
       // instead of round-tripping a generic "Profile not found" through the daemon.

--- a/src/lib/browser/chrome.test.ts
+++ b/src/lib/browser/chrome.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const presentPaths = new Set<string>();
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    default: actual,
+    existsSync: (p: string) => presentPaths.has(p),
+  };
+});
+
+import { findFirstInstalledBrowser } from './chrome.js';
+
+describe('findFirstInstalledBrowser', () => {
+  beforeEach(() => {
+    presentPaths.clear();
+  });
+
+  it('returns the first installed browser in macOS priority order (chrome > brave > edge > chromium > comet)', () => {
+    presentPaths.add('/Applications/Brave Browser.app/Contents/MacOS/Brave Browser');
+    presentPaths.add('/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge');
+
+    const result = findFirstInstalledBrowser('darwin');
+
+    expect(result).toEqual({
+      browserType: 'brave',
+      binary: '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+    });
+  });
+
+  it('prefers Chrome on macOS when both Chrome and Brave are installed', () => {
+    presentPaths.add('/Applications/Google Chrome.app/Contents/MacOS/Google Chrome');
+    presentPaths.add('/Applications/Brave Browser.app/Contents/MacOS/Brave Browser');
+
+    const result = findFirstInstalledBrowser('darwin');
+
+    expect(result?.browserType).toBe('chrome');
+  });
+
+  it('prefers Edge on Windows since it ships preinstalled', () => {
+    presentPaths.add('C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe');
+    presentPaths.add('C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe');
+
+    const result = findFirstInstalledBrowser('win32');
+
+    expect(result?.browserType).toBe('edge');
+  });
+
+  it('walks the Linux priority list (chrome > chromium > brave > edge)', () => {
+    presentPaths.add('/usr/bin/chromium');
+    presentPaths.add('/usr/bin/brave-browser');
+
+    const result = findFirstInstalledBrowser('linux');
+
+    expect(result).toEqual({
+      browserType: 'chromium',
+      binary: '/usr/bin/chromium',
+    });
+  });
+
+  it('returns null when no priority-list browser is installed', () => {
+    expect(findFirstInstalledBrowser('darwin')).toBeNull();
+    expect(findFirstInstalledBrowser('linux')).toBeNull();
+    expect(findFirstInstalledBrowser('win32')).toBeNull();
+  });
+
+  it('returns null on unsupported platforms', () => {
+    expect(findFirstInstalledBrowser('aix')).toBeNull();
+    expect(findFirstInstalledBrowser('freebsd')).toBeNull();
+  });
+});

--- a/src/lib/browser/chrome.ts
+++ b/src/lib/browser/chrome.ts
@@ -77,6 +77,47 @@ export function findBrowserPath(browserType: BrowserType, customBinary?: string)
   throw new Error(`Browser "${browserType}" not found. Install it first.`);
 }
 
+// Per-platform Chromium-family priority list for "no --profile" auto-pick.
+// Order is: most-likely-installed-and-stable first. Safari and Firefox are
+// intentionally excluded — they don't speak the Chrome DevTools Protocol the
+// way cdp.ts expects, so they'd need separate drivers.
+const DEFAULT_BROWSER_PRIORITY: Record<string, BrowserType[]> = {
+  // macOS: Chrome leads (>70% of dev machines), then the rest of the family.
+  darwin: ['chrome', 'brave', 'edge', 'chromium', 'comet'],
+  // Linux: Chrome/Chromium first (apt/snap), then Brave/Edge if present.
+  linux: ['chrome', 'chromium', 'brave', 'edge'],
+  // Windows: Edge is preinstalled on every supported build, so it's the
+  // reliable always-there default.
+  win32: ['edge', 'chrome', 'brave'],
+};
+
+/**
+ * Walk the per-platform priority list and return the first browser that's
+ * actually installed on disk. Returns null if none of them are present.
+ *
+ * This is the auto-pick the `agents browser start` command uses when the user
+ * doesn't pass `--profile`. The intent matches "use whatever's preinstalled,"
+ * but constrained to Chromium-family binaries so CDP works without a new
+ * driver layer.
+ */
+export function findFirstInstalledBrowser(
+  platform: string = os.platform()
+): { browserType: BrowserType; binary: string } | null {
+  const priority = DEFAULT_BROWSER_PRIORITY[platform];
+  if (!priority) return null;
+  const platformPaths = BROWSER_PATHS[platform];
+  if (!platformPaths) return null;
+  for (const browserType of priority) {
+    const candidates = platformPaths[browserType] || [];
+    for (const p of candidates) {
+      if (fs.existsSync(p)) {
+        return { browserType, binary: p };
+      }
+    }
+  }
+  return null;
+}
+
 export interface LaunchResult {
   pid: number;
   port: number;

--- a/src/lib/browser/profiles.test.ts
+++ b/src/lib/browser/profiles.test.ts
@@ -12,6 +12,10 @@ vi.mock('child_process', () => ({
 
 vi.mock('./chrome.js', () => ({
   findBrowserPath: vi.fn(() => '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'),
+  findFirstInstalledBrowser: vi.fn(() => ({
+    browserType: 'chrome',
+    binary: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  })),
 }));
 
 import {
@@ -19,7 +23,9 @@ import {
   extractConfiguredEndpoint,
   findFreeProfilePort,
   createProfile,
+  ensureDefaultBrowserProfile,
 } from './profiles.js';
+import { findFirstInstalledBrowser } from './chrome.js';
 import type { BrowserProfile } from './types.js';
 import type { BrowserProfileConfig } from '../types.js';
 import { readMeta, writeMeta } from '../state.js';
@@ -335,6 +341,57 @@ describe('profile YAML round-trip', () => {
         },
       })
     ).rejects.toThrow(/Remote browser binary contains shell metacharacters/);
+  });
+});
+
+describe('ensureDefaultBrowserProfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('auto-picks the first installed browser and persists a default profile', async () => {
+    const store: { browser: Record<string, BrowserProfileConfig> } = { browser: {} };
+    vi.mocked(readMeta).mockImplementation(() => store as any);
+    vi.mocked(writeMeta).mockImplementation((meta: any) => {
+      store.browser = (meta.browser ?? {}) as Record<string, BrowserProfileConfig>;
+    });
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error('free port');
+    });
+
+    const profile = await ensureDefaultBrowserProfile();
+
+    expect(profile.name).toBe('default');
+    expect(profile.browser).toBe('chrome');
+    expect(profile.binary).toBe('/Applications/Google Chrome.app/Contents/MacOS/Google Chrome');
+    expect(profile.endpoints).toEqual(['cdp://127.0.0.1:9222']);
+    expect(store.browser.default.browser).toBe('chrome');
+  });
+
+  it('reuses an existing default profile instead of overwriting it', async () => {
+    const existing: BrowserProfileConfig = {
+      browser: 'brave',
+      binary: '/custom/path/to/brave',
+      endpoints: ['cdp://127.0.0.1:9333'],
+    };
+    const store: { browser: Record<string, BrowserProfileConfig> } = { browser: { default: existing } };
+    vi.mocked(readMeta).mockImplementation(() => store as any);
+    const writeSpy = vi.mocked(writeMeta);
+
+    const profile = await ensureDefaultBrowserProfile();
+
+    expect(profile.browser).toBe('brave');
+    expect(profile.binary).toBe('/custom/path/to/brave');
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws an actionable error when no Chromium-family browser is installed', async () => {
+    vi.mocked(readMeta).mockImplementation(() => ({ browser: {} }) as any);
+    vi.mocked(findFirstInstalledBrowser).mockReturnValueOnce(null);
+
+    await expect(ensureDefaultBrowserProfile()).rejects.toThrow(
+      /No supported browser found.*Chrome.*Brave.*Edge/
+    );
   });
 });
 

--- a/src/lib/browser/profiles.ts
+++ b/src/lib/browser/profiles.ts
@@ -7,9 +7,12 @@ import {
 } from '../state.js';
 import type { BrowserProfileConfig } from '../types.js';
 import type { BrowserProfile } from './types.js';
-import { findBrowserPath } from './chrome.js';
+import { findBrowserPath, findFirstInstalledBrowser } from './chrome.js';
+import { DEFAULT_VIEWPORT } from './devices.js';
 
 export type { BrowserProfile } from './types.js';
+
+export const DEFAULT_BROWSER_PROFILE_NAME = 'default';
 
 export function getBrowserRuntimeDir(): string {
   return getBrowserRuntimeDirRoot();
@@ -71,6 +74,46 @@ export async function getProfile(name: string): Promise<BrowserProfile | null> {
   const config = meta.browser?.[name];
   if (!config) return null;
   return configToProfile(name, config);
+}
+
+/**
+ * Ensure a `default` profile exists, auto-picking the first installed
+ * Chromium-family browser per the platform priority list in chrome.ts.
+ *
+ * Re-uses an existing `default` profile as-is (we don't second-guess the user
+ * if they've already customized it). On first run we walk the priority list
+ * (macOS: chrome > brave > edge > chromium > comet; Linux: chrome > chromium >
+ * brave > edge; Windows: edge > chrome > brave) and pin the profile to the
+ * first match. Throws an actionable error if none of those binaries are
+ * installed so the user knows exactly which browsers we'd accept.
+ */
+export async function ensureDefaultBrowserProfile(): Promise<BrowserProfile> {
+  const existing = await getProfile(DEFAULT_BROWSER_PROFILE_NAME);
+  if (existing) return existing;
+
+  const detected = findFirstInstalledBrowser();
+  if (!detected) {
+    throw new Error(
+      'No supported browser found. Install one of: Chrome, Brave, Edge, Chromium, or Comet, ' +
+      'then re-run `agents browser start`. Or create a profile explicitly with ' +
+      '`agents browser profiles create <name> --browser <chrome|comet|chromium|brave|edge|custom>`.'
+    );
+  }
+
+  const freePort = await findFreeProfilePort();
+  const profile: BrowserProfile = {
+    name: DEFAULT_BROWSER_PROFILE_NAME,
+    description: `Auto-detected ${detected.browserType} profile`,
+    browser: detected.browserType,
+    binary: detected.binary,
+    endpoints: [`cdp://127.0.0.1:${freePort}`],
+    viewport: {
+      width: DEFAULT_VIEWPORT.width,
+      height: DEFAULT_VIEWPORT.height,
+    },
+  };
+  await createProfile(profile);
+  return profile;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #78. `agents browser start` is once again usable without `--profile` — but now backed by a real installed browser instead of bundled Chromium.

## Why

After ripping bundled-Chromium in #78, `agents browser start` required `--profile <name>`. Friction for first-time users. The intent was "use whatever's preinstalled" — but on macOS that would mean Safari (no CDP, would need a whole driver), and on Linux that would mean Firefox (incomplete CDP, being deprecated). Solution: walk a per-platform Chromium-family priority list of binaries that are already installed and auto-pick the first match.

## Priority list

| Platform | Order |
|---|---|
| macOS | Chrome > Brave > Edge > Chromium > Comet |
| Linux | Chrome > Chromium > Brave > Edge |
| Windows | Edge > Chrome > Brave |

Windows gets the best UX (Edge ships preinstalled on every supported build). macOS Chrome hits >70% of dev machines. Linux Chromium is one apt-get away.

## Behavior

- `agents browser start` (no `--profile`) → walks priority list, picks first installed binary, creates/reuses a profile named `default` pinned to it, then starts a task.
- Existing `default` profile is **not** overwritten — `ensureDefaultBrowserProfile()` returns the existing one as-is.
- No supported browser installed → actionable error listing what we accept and how to create a named profile.

## Files

- `src/lib/browser/chrome.ts` — `findFirstInstalledBrowser(platform?)` + `DEFAULT_BROWSER_PRIORITY` table
- `src/lib/browser/profiles.ts` — `ensureDefaultBrowserProfile()` + `DEFAULT_BROWSER_PROFILE_NAME` constant
- `src/commands/browser.ts` — `start` action: when `opts.profile` is empty, call `ensureDefaultBrowserProfile()` first
- `src/lib/browser/chrome.test.ts` (new) — 6 tests covering priority order on macOS/Linux/Windows + no-match + unsupported-platform
- `src/lib/browser/profiles.test.ts` — 3 tests for `ensureDefaultBrowserProfile`: auto-pick, reuse-existing, actionable-error
- `README.md` — Browser section now shows the no-profile happy path first

## Verification

- \`bun run tsc --noEmit\` clean
- \`bun run test src/lib/browser src/commands/browser\` -> 153/153 pass (up from 144 in #78)
- Reinstalled via \`scripts/install.sh\`: \`agents browser start --help\` shows the updated description; \`findFirstInstalledBrowser()\` on this Mac returns \`comet\` (only Chromium-family at standard path here), confirming the priority walk works end-to-end

## Why not Safari / Firefox

Safari uses the Web Inspector + WebDriver-W3C, not CDP. Firefox CDP is being deprecated for WebDriver BiDi. Both would need new driver layers under \`src/lib/browser/\`. Out of scope here.

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/a17913469bd1bc3d5fe51fcb4e91f6f0)

Closes #44
Closes #42