### PR TITLE
fix(browser): no more stacktraces when daemon down or CDP unreachable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -854,5 +854,19 @@ try {
   if (err instanceof Error && err.name === 'ExitPromptError') {
     process.exit(130);
   }
+  // Browser-daemon-not-running and CDP-not-reachable surface as typed errors
+  // from src/lib/browser/. Don't dump a Node stacktrace for these — they are
+  // user-actionable, not engineering bugs. See issues #41 and #43.
+  if (err instanceof Error) {
+    const isBrowserDaemonNotRunning = err.name === 'BrowserDaemonNotRunningError';
+    const isBrowserCdpUnreachable = err.name === 'BrowserCdpConnectionError';
+    const isBrowserIpcDown =
+      err.message.startsWith('IPC error:') &&
+      (err.message.includes('ECONNREFUSED') || err.message.includes('ENOENT'));
+    if (isBrowserDaemonNotRunning || isBrowserCdpUnreachable || isBrowserIpcDown) {
+      console.error(err.message);
+      process.exit(1);
+    }
+  }
   throw err;
 }

--- a/src/lib/browser/cdp.ts
+++ b/src/lib/browser/cdp.ts
@@ -227,11 +227,19 @@ export async function discoverBrowserWsUrl(
   host = 'localhost',
   profileName = '<name>'
 ): Promise<BrowserDiscovery> {
+  // Node's fetch has no default timeout — a port that ACKs the TCP connect
+  // but never sends an HTTP response will hang here indefinitely. Bound the
+  // discovery probe so the caller can surface an actionable error in seconds,
+  // not minutes.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 3000);
   let response: Response;
   try {
-    response = await fetch(`http://${host}:${port}/json/version`);
+    response = await fetch(`http://${host}:${port}/json/version`, { signal: controller.signal });
   } catch {
     throw new BrowserCdpConnectionError(port, profileName, host);
+  } finally {
+    clearTimeout(timer);
   }
   if (!response.ok) {
     throw new BrowserCdpConnectionError(port, profileName, host);

--- a/src/lib/browser/drivers/local.test.ts
+++ b/src/lib/browser/drivers/local.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import * as net from 'net';
+
+import { connectLocal } from './local.js';
+import type { BrowserProfile } from '../types.js';
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      if (addr && typeof addr === 'object') {
+        const port = addr.port;
+        srv.close(() => resolve(port));
+      } else {
+        srv.close(() => reject(new Error('Failed to allocate free port')));
+      }
+    });
+  });
+}
+
+function listenOn(port: number): Promise<net.Server> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer((sock) => {
+      // Hold the connection open briefly so the probe's ACK lands cleanly.
+      sock.on('data', () => {});
+    });
+    srv.once('error', reject);
+    srv.listen(port, '127.0.0.1', () => resolve(srv));
+  });
+}
+
+describe('connectLocal — TCP probe fallback for #43', () => {
+  it('refuses to auto-launch when the configured port is held by a non-CDP TCP listener', async () => {
+    const port = await freePort();
+    const blocker = await listenOn(port);
+
+    const profile: BrowserProfile = {
+      name: 'comet-like',
+      browser: 'chrome',
+      endpoints: [`cdp://127.0.0.1:${port}`],
+    };
+
+    try {
+      // Either branch (lsof-based occupant detection or the TCP-probe fallback)
+      // is fine — the contract is: surface an actionable error that names the
+      // port + the profile, no Node stacktrace. Issue #43 is about UX, not
+      // about which detection path catches it first.
+      await expect(connectLocal(`cdp://127.0.0.1:${port}`, profile)).rejects.toThrow(
+        new RegExp(`${port}`),
+      );
+      await expect(connectLocal(`cdp://127.0.0.1:${port}`, profile)).rejects.toThrow(
+        /comet-like/,
+      );
+    } finally {
+      blocker.close();
+    }
+  });
+});

--- a/src/lib/browser/drivers/local.ts
+++ b/src/lib/browser/drivers/local.ts
@@ -1,7 +1,30 @@
+import * as net from 'net';
+
 import { CDPClient, discoverBrowserWsUrl, verifyBrowserIdentity } from '../cdp.js';
 import { launchBrowser, getPortOccupant } from '../chrome.js';
 import { parseEndpointUrl } from '../profiles.js';
 import type { BrowserProfile } from '../types.js';
+
+/**
+ * Cheap TCP-level "is something bound here?" probe. Used as a fallback when
+ * `getPortOccupant()` (lsof-based) misses the process — Comet and other
+ * Electron apps sometimes hold a TCP socket that lsof's `-sTCP:LISTEN` filter
+ * doesn't report. If anything ACKs the connection, we treat the port as taken
+ * and surface a friendly error instead of silently auto-launching a fresh
+ * browser that would then conflict.
+ */
+async function probeTcpBound(port: number, host = '127.0.0.1', timeoutMs = 500): Promise<boolean> {
+  return new Promise((resolve) => {
+    const sock = net.createConnection({ port, host });
+    const cleanup = () => {
+      sock.removeAllListeners();
+      sock.destroy();
+    };
+    const timer = setTimeout(() => { cleanup(); resolve(false); }, timeoutMs);
+    sock.once('connect', () => { clearTimeout(timer); cleanup(); resolve(true); });
+    sock.once('error', () => { clearTimeout(timer); cleanup(); resolve(false); });
+  });
+}
 
 export interface LocalConnection {
   cdp: CDPClient;
@@ -78,20 +101,44 @@ export async function connectLocal(
       );
     }
 
+    // lsof-based detection misses some Electron-family processes (Comet, custom
+    // chrome wrappers). Cheap TCP probe as a safety net: if something ACKs a
+    // connect, the port is bound — bail loudly with the profile name + endpoint
+    // rather than silently launching a duplicate browser.
+    if (await probeTcpBound(port)) {
+      throw new Error(
+        `Profile "${profile.name}" is configured for cdp://127.0.0.1:${port}, ` +
+          `but something is already bound to that port without serving the Chrome ` +
+          `DevTools Protocol. If that's your browser running without remote debugging, ` +
+          `quit it and relaunch with \`--remote-debugging-port=${port}\`. Otherwise, ` +
+          `update the profile to a free port (\`agents browser profiles list\`).`
+      );
+    }
+
     const newPort = port;
     const chromeOpts = { ...profile.chrome, viewport: profile.viewport };
-    const { pid, wsUrl } = await launchBrowser(
-      profile.name,
-      profile.browser,
-      newPort,
-      chromeOpts,
-      profile.secrets,
-      profile.binary,
-      profile.electron === true
-    );
+    let launched;
+    try {
+      launched = await launchBrowser(
+        profile.name,
+        profile.browser,
+        newPort,
+        chromeOpts,
+        profile.secrets,
+        profile.binary,
+        profile.electron === true
+      );
+    } catch (launchErr) {
+      const reason = launchErr instanceof Error ? launchErr.message : String(launchErr);
+      throw new Error(
+        `Could not start ${profile.browser} for profile "${profile.name}" on port ${newPort}: ${reason}. ` +
+          `Check that the browser binary is installed (\`agents browser profiles list\`) and ` +
+          `that no other process is holding the port.`
+      );
+    }
     const cdp = new CDPClient();
-    await cdp.connect(wsUrl);
+    await cdp.connect(launched.wsUrl);
 
-    return { cdp, port: newPort, pid };
+    return { cdp, port: newPort, pid: launched.pid };
   }
 }

--- a/src/lib/browser/ipc.ts
+++ b/src/lib/browser/ipc.ts
@@ -23,7 +23,8 @@ export class BrowserDaemonNotRunningError extends Error {
 export function formatBrowserDaemonNotRunningError(): string {
   return [
     'Browser daemon not running.',
-    'Start it with: agents browser start --profile <name>',
+    'Start it with: agents browser start (auto-picks an installed browser)',
+    'Or pin a profile: agents browser start --profile <name>',
     'List profiles: agents browser profiles list',
   ].join('\n');
 }


### PR DESCRIPTION
Closes #41
Closes #43

## Summary

Three friendly-error UX fixes for the browser subsystem, plus a global handler so future commands inherit the no-stacktrace guarantee for free.

| Symptom | Before | After |
|---|---|---|
| `agents browser status` (daemon down) | Node stacktrace from \`ipc.js:448\` | "Browser daemon not running. Start it with: …" |
| `agents browser tasks` (daemon down + auto-start race) | "Error: IPC error: connect ECONNREFUSED" stacktrace | Same friendly message via global handler |
| `agents browser start` against a port that ACKs TCP but never speaks HTTP | 30+ second hang, then raw stacktrace | 3s timeout, then port + profile name + fix instructions |

## Changes

- **\`src/index.ts\`** — Global try/catch at the CLI entry now recognizes \`BrowserDaemonNotRunningError\`, \`BrowserCdpConnectionError\`, and \`IPC error: …ECONNREFUSED/ENOENT\`. Prints the typed message + \`process.exit(1)\` instead of letting Node dump a stacktrace. Covers all 30+ browser subcommands without dotting try/catch through every one.
- **\`src/lib/browser/cdp.ts\`** — Bounded \`discoverBrowserWsUrl\`'s \`fetch()\` with a 3s AbortController. Node's fetch has no default timeout; ports that ACK the TCP connect but never respond would hang the CLI for minutes.
- **\`src/lib/browser/drivers/local.ts\`** — TCP-probe fallback when \`lsof\` (via \`getPortOccupant\`) misses an Electron-family port-binder (Comet was the original repro for #43). Also wrapped \`launchBrowser\` in try/catch with profile context so the auto-launch path never leaks a raw error.
- **\`src/lib/browser/ipc.ts\`** — \`formatBrowserDaemonNotRunningError\` now also surfaces the no-profile shortcut from #79.
- **\`src/lib/browser/drivers/local.test.ts\`** (new) — Spins up a real local TCP listener on a free port, asserts \`connectLocal\` rejects with a message that names the port + profile. No mocks.

## Verification

- \`npm run build\` clean.
- \`npm test -- src/lib/browser\` → 52/52 pass (up from 49 in #79).
- Smoke: \`rm -f .../browser.sock && node dist/index.js browser status\` → friendly 4-line message, exit 1, no stacktrace. \`browser tasks\` same path → auto-restart works; if it fails, friendly message wins.

## Closes

- #41 — \`agents browser status\` crashes with raw Node stacktrace when daemon not running (fully addressed at status + all other commands via global handler).
- #43 — \`agents browser start\` against unreachable CDP endpoint produces stacktrace, not actionable error (3s timeout + TCP-probe fallback + launchBrowser wrap).