### PR TITLE
feat(browser): --record convenience flag on `browser start`

### DIFF
--- a/src/commands/browser.ts
+++ b/src/commands/browser.ts
@@ -484,6 +484,10 @@ function registerTaskCommands(browser: Command): void {
     .option('-e, --endpoint <name>', 'Endpoint preset (defaults to the profile\'s default)')
     .option('-u, --url <url>', 'Open URL in first tab')
     .option('--no-skills', 'Skip auto-discovery of site-specific SKILL.md from ~/.agents/skills/browser/domain-skills/')
+    .option('--record', 'Start recording right after the tab opens (shorthand for `agents browser record start` as a follow-up)')
+    .option('--fps <n>', 'Recording frames per second (with --record; 1–30, default 5)', (v) => parseInt(v, 10))
+    .option('--duration <sec>', 'Recording duration cap in seconds (with --record; default 60)', (v) => parseInt(v, 10))
+    .option('--max-mb <mb>', 'Recording size cap in MB (with --record; default 25)', (v) => parseInt(v, 10))
     .action(async (opts) => {
       let profileName: string = opts.profile;
       if (!profileName) {
@@ -560,6 +564,28 @@ function registerTaskCommands(browser: Command): void {
         console.error(`--- domain-skill: ${response.skill.name} (${response.skill.hostname}) ---`);
         console.error(response.skill.content);
         console.error(`--- end domain-skill: ${response.skill.name} ---`);
+      }
+
+      // --record convenience: fire record-start right after the tab opens so
+      // the user gets a single-command capture flow. Failures here are
+      // reported but don't fail the start — the task is already running.
+      if (opts.record) {
+        const recordResponse = await sendIPCRequest({
+          action: 'record-start',
+          task: response.task,
+          tabId: response.tabId,
+          fps: opts.fps,
+          duration: opts.duration,
+          maxMb: opts.maxMb,
+        });
+        if (!recordResponse.ok) {
+          console.error(`Recording failed to start: ${recordResponse.error}`);
+        } else {
+          console.error(
+            `Recording at ${recordResponse.fps} fps (cap ${recordResponse.durationCapSec}s / ${recordResponse.maxMb} MB) -> ${recordResponse.path}`
+          );
+          console.error('Stop with: agents browser record stop');
+        }
       }
     });
 

--- a/src/commands/browser.ts
+++ b/src/commands/browser.ts
@@ -483,6 +483,7 @@ function registerTaskCommands(browser: Command): void {
     .option(TASK_OPTION_FLAG, 'Task name (auto-generated if omitted)')
     .option('-e, --endpoint <name>', 'Endpoint preset (defaults to the profile\'s default)')
     .option('-u, --url <url>', 'Open URL in first tab')
+    .option('--no-skills', 'Skip auto-discovery of site-specific SKILL.md from ~/.agents/skills/browser/domain-skills/')
     .action(async (opts) => {
       let profileName: string = opts.profile;
       if (!profileName) {
@@ -528,6 +529,7 @@ function registerTaskCommands(browser: Command): void {
         taskName: opts.task,
         url: opts.url,
         endpoint: opts.endpoint,
+        skipDomainSkill: opts.skills === false,
       });
 
       if (!response.ok) {
@@ -548,6 +550,17 @@ function registerTaskCommands(browser: Command): void {
       }
       console.error(`Tip: export AGENTS_BROWSER_TASK=${response.task}`);
       console.error('Try: agents browser screenshot | agents browser console --level error');
+
+      // Surface the matched domain-skill (if any) so an agent driving the
+      // task picks up site-specific selectors and gotchas before it starts
+      // clicking. Header is recognizable so an agent parsing the stream can
+      // extract the skill content; suffix repeats the skill name for greps.
+      if (response.skill) {
+        console.error('');
+        console.error(`--- domain-skill: ${response.skill.name} (${response.skill.hostname}) ---`);
+        console.error(response.skill.content);
+        console.error(`--- end domain-skill: ${response.skill.name} ---`);
+      }
     });
 
   browser

--- a/src/index.ts
+++ b/src/index.ts
@@ -854,5 +854,19 @@ try {
   if (err instanceof Error && err.name === 'ExitPromptError') {
     process.exit(130);
   }
+  // Browser-daemon-not-running and CDP-not-reachable surface as typed errors
+  // from src/lib/browser/. Don't dump a Node stacktrace for these — they are
+  // user-actionable, not engineering bugs. See issues #41 and #43.
+  if (err instanceof Error) {
+    const isBrowserDaemonNotRunning = err.name === 'BrowserDaemonNotRunningError';
+    const isBrowserCdpUnreachable = err.name === 'BrowserCdpConnectionError';
+    const isBrowserIpcDown =
+      err.message.startsWith('IPC error:') &&
+      (err.message.includes('ECONNREFUSED') || err.message.includes('ENOENT'));
+    if (isBrowserDaemonNotRunning || isBrowserCdpUnreachable || isBrowserIpcDown) {
+      console.error(err.message);
+      process.exit(1);
+    }
+  }
   throw err;
 }

--- a/src/lib/browser/cdp.ts
+++ b/src/lib/browser/cdp.ts
@@ -227,11 +227,19 @@ export async function discoverBrowserWsUrl(
   host = 'localhost',
   profileName = '<name>'
 ): Promise<BrowserDiscovery> {
+  // Node's fetch has no default timeout — a port that ACKs the TCP connect
+  // but never sends an HTTP response will hang here indefinitely. Bound the
+  // discovery probe so the caller can surface an actionable error in seconds,
+  // not minutes.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 3000);
   let response: Response;
   try {
-    response = await fetch(`http://${host}:${port}/json/version`);
+    response = await fetch(`http://${host}:${port}/json/version`, { signal: controller.signal });
   } catch {
     throw new BrowserCdpConnectionError(port, profileName, host);
+  } finally {
+    clearTimeout(timer);
   }
   if (!response.ok) {
     throw new BrowserCdpConnectionError(port, profileName, host);

--- a/src/lib/browser/domain-skills.test.ts
+++ b/src/lib/browser/domain-skills.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for browser domain-skill discovery.
+ *
+ * Uses a temp directory wired in via $AGENTS_BROWSER_DOMAIN_SKILLS_DIR so we
+ * don't touch the user's real ~/.agents/skills tree.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { hostnameMatchCandidates, resolveDomainSkill } from './domain-skills.js';
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'domain-skills-test-'));
+  process.env.AGENTS_BROWSER_DOMAIN_SKILLS_DIR = tmp;
+});
+
+afterEach(() => {
+  delete process.env.AGENTS_BROWSER_DOMAIN_SKILLS_DIR;
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function seed(name: string, body: string) {
+  fs.mkdirSync(path.join(tmp, name), { recursive: true });
+  fs.writeFileSync(path.join(tmp, name, 'SKILL.md'), body);
+}
+
+describe('hostnameMatchCandidates', () => {
+  it('returns the second-level label for a plain apex domain', () => {
+    expect(hostnameMatchCandidates('perplexity.ai')).toContain('perplexity');
+  });
+
+  it('strips www. before deriving candidates', () => {
+    expect(hostnameMatchCandidates('www.perplexity.ai')).toContain('perplexity');
+    expect(hostnameMatchCandidates('www.perplexity.ai')).toContain('perplexity.ai');
+  });
+
+  it('yields progressive strips for nested subdomains', () => {
+    const cs = hostnameMatchCandidates('app.slack.com');
+    expect(cs).toContain('app.slack.com');
+    expect(cs).toContain('slack.com');
+    expect(cs).toContain('slack');
+  });
+
+  it('returns empty for an empty hostname', () => {
+    expect(hostnameMatchCandidates('')).toEqual([]);
+  });
+});
+
+describe('resolveDomainSkill', () => {
+  it('matches by directory name on the second-level domain', () => {
+    seed('perplexity', '---\ndescription: perplexity skill\n---\n# Perplexity\nbody');
+    const r = resolveDomainSkill('https://www.perplexity.ai/computer/tasks/x');
+    expect(r?.name).toBe('perplexity');
+    expect(r?.content).toContain('# Perplexity');
+    expect(r?.hostname).toBe('www.perplexity.ai');
+  });
+
+  it('matches subdomain-stripped form (app.slack.com -> slack)', () => {
+    seed('slack', '---\ndescription: slack skill\n---\n# Slack');
+    const r = resolveDomainSkill('https://app.slack.com/client/T1/C1');
+    expect(r?.name).toBe('slack');
+  });
+
+  it('prefers an explicit domains: frontmatter override over the dir name', () => {
+    // dir is `gmail` but a Google-properties skill pins itself to mail.google.com
+    seed(
+      'gmail',
+      `---\ndescription: gmail\ndomains: [mail.google.com, gmail.com]\n---\n# Gmail`,
+    );
+    const r = resolveDomainSkill('https://mail.google.com/mail/u/0/');
+    expect(r?.name).toBe('gmail');
+  });
+
+  it('supports the block-list domains: yaml form', () => {
+    seed(
+      'notion',
+      `---\ndescription: notion\ndomains:\n  - notion.so\n  - www.notion.so\n---\n# Notion`,
+    );
+    const r = resolveDomainSkill('https://www.notion.so/workspace');
+    expect(r?.name).toBe('notion');
+  });
+
+  it('returns null when no directory matches', () => {
+    seed('perplexity', '---\ndescription: x\n---\nbody');
+    expect(resolveDomainSkill('https://stripe.com/dashboard')).toBeNull();
+  });
+
+  it('returns null for invalid URLs without throwing', () => {
+    seed('perplexity', '---\ndescription: x\n---\nbody');
+    expect(resolveDomainSkill('not a url')).toBeNull();
+  });
+
+  it('returns null when the skills root does not exist', () => {
+    process.env.AGENTS_BROWSER_DOMAIN_SKILLS_DIR = path.join(tmp, 'does-not-exist');
+    expect(resolveDomainSkill('https://perplexity.ai')).toBeNull();
+  });
+
+  it('skips directories that lack a SKILL.md', () => {
+    fs.mkdirSync(path.join(tmp, 'orphan'), { recursive: true });
+    seed('perplexity', '---\ndescription: x\n---\nbody');
+    const r = resolveDomainSkill('https://perplexity.ai');
+    expect(r?.name).toBe('perplexity');
+  });
+});

--- a/src/lib/browser/domain-skills.ts
+++ b/src/lib/browser/domain-skills.ts
@@ -1,0 +1,171 @@
+/**
+ * Domain-skill discovery for `agents browser start`.
+ *
+ * When a browser task opens a URL, look up a site-specific SKILL.md from
+ * `~/.agents/skills/browser/domain-skills/<dir>/SKILL.md` and surface its
+ * contents so the calling agent gets per-site operating instructions
+ * (selectors, gotchas, sign-in quirks) before it starts driving the page.
+ *
+ * Matching is intentionally simple: derive the hostname's second-level
+ * label (e.g. `perplexity` from `perplexity.ai`, `slack` from `app.slack.com`)
+ * and look for a directory of the same name. If the user wants a different
+ * mapping (e.g. `mail.google.com` -> `gmail/`), they can pin it via a
+ * `domains: [...]` array in the SKILL.md frontmatter; that override beats
+ * the directory-name match.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/** Result of resolving a URL to a domain-skill. */
+export interface ResolvedDomainSkill {
+  /** Skill identifier — the directory name under domain-skills/. */
+  name: string;
+  /** Absolute path to the SKILL.md that was matched. */
+  path: string;
+  /** Full SKILL.md contents (frontmatter included). */
+  content: string;
+  /** Hostname the match was made against (post-www strip). */
+  hostname: string;
+}
+
+/** Where domain-skills live. Override via $AGENTS_BROWSER_DOMAIN_SKILLS_DIR for tests. */
+export function domainSkillsRoot(): string {
+  const override = process.env.AGENTS_BROWSER_DOMAIN_SKILLS_DIR;
+  if (override) return override;
+  return path.join(os.homedir(), '.agents', 'skills', 'browser', 'domain-skills');
+}
+
+/**
+ * Derive match candidates from a hostname. Order matters — earlier candidates
+ * are tried first.
+ *
+ * Examples:
+ *   perplexity.ai      -> ['perplexity.ai', 'perplexity']
+ *   app.slack.com      -> ['app.slack.com', 'slack.com', 'slack']
+ *   mail.google.com    -> ['mail.google.com', 'google.com', 'google', 'mail']
+ *   higgsfield.ai      -> ['higgsfield.ai', 'higgsfield']
+ */
+export function hostnameMatchCandidates(hostname: string): string[] {
+  const cleaned = hostname.toLowerCase().replace(/^www\./, '');
+  if (!cleaned) return [];
+  const parts = cleaned.split('.').filter(Boolean);
+  const out = new Set<string>();
+  out.add(cleaned);
+  // Progressive label-stripping from the left: app.slack.com -> slack.com.
+  for (let i = 1; i < parts.length; i++) {
+    out.add(parts.slice(i).join('.'));
+  }
+  // Second-level label without TLD: app.slack.com -> slack, perplexity.ai -> perplexity.
+  if (parts.length >= 2) {
+    out.add(parts[parts.length - 2]);
+  }
+  // First label too, so mail.google.com can resolve a `mail` dir if that's how
+  // the user organized their skills. Last so explicit second-level wins.
+  if (parts.length >= 2) {
+    out.add(parts[0]);
+  }
+  return Array.from(out);
+}
+
+/** Parse a SKILL.md's frontmatter `domains:` list, if any. Best-effort, no schema. */
+function parseDomainsFrontmatter(content: string): string[] {
+  // Frontmatter must be at file start: ---\n...\n---\n
+  if (!content.startsWith('---')) return [];
+  const end = content.indexOf('\n---', 3);
+  if (end < 0) return [];
+  const fm = content.slice(3, end);
+  // Inline array form: domains: [a, b, c]
+  const inline = fm.match(/^domains:\s*\[([^\]]*)\]/m);
+  if (inline) {
+    return inline[1]
+      .split(',')
+      .map((s) => s.trim().replace(/^["']|["']$/g, '').toLowerCase())
+      .filter(Boolean);
+  }
+  // Block list form:
+  //   domains:
+  //     - a
+  //     - b
+  const block = fm.match(/^domains:\s*\n((?:\s+-\s+\S+\n?)+)/m);
+  if (block) {
+    return block[1]
+      .split('\n')
+      .map((line) => line.replace(/^\s*-\s*/, '').trim().replace(/^["']|["']$/g, '').toLowerCase())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+/**
+ * Resolve a URL to its matching domain-skill, or null if none.
+ *
+ * Two-pass strategy:
+ *   1. Index every SKILL.md in the root and read its `domains:` frontmatter.
+ *      If any pinned domain matches a candidate, return that skill.
+ *   2. Fall back to directory-name match against the candidate list.
+ *
+ * Errors (missing root, unreadable file, invalid URL) are swallowed and
+ * yield null — domain-skill discovery must never break browser start.
+ */
+export function resolveDomainSkill(url: string): ResolvedDomainSkill | null {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    return null;
+  }
+  if (!hostname) return null;
+
+  const root = domainSkillsRoot();
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  const candidates = hostnameMatchCandidates(hostname);
+  if (candidates.length === 0) return null;
+  const candidateSet = new Set(candidates);
+
+  type Indexed = { name: string; skillPath: string; content: string; pinned: string[] };
+  const indexed: Indexed[] = [];
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    const skillPath = path.join(root, e.name, 'SKILL.md');
+    let content: string;
+    try {
+      content = fs.readFileSync(skillPath, 'utf-8');
+    } catch {
+      continue;
+    }
+    indexed.push({
+      name: e.name,
+      skillPath,
+      content,
+      pinned: parseDomainsFrontmatter(content),
+    });
+  }
+
+  // Pass 1: explicit `domains:` overrides.
+  for (const s of indexed) {
+    for (const d of s.pinned) {
+      if (candidateSet.has(d)) {
+        return { name: s.name, path: s.skillPath, content: s.content, hostname };
+      }
+    }
+  }
+
+  // Pass 2: directory-name match, walking candidates in priority order.
+  const byName = new Map(indexed.map((s) => [s.name.toLowerCase(), s]));
+  for (const c of candidates) {
+    const hit = byName.get(c);
+    if (hit) {
+      return { name: hit.name, path: hit.skillPath, content: hit.content, hostname };
+    }
+  }
+
+  return null;
+}

--- a/src/lib/browser/drivers/local.test.ts
+++ b/src/lib/browser/drivers/local.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import * as net from 'net';
+
+import { connectLocal } from './local.js';
+import type { BrowserProfile } from '../types.js';
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      if (addr && typeof addr === 'object') {
+        const port = addr.port;
+        srv.close(() => resolve(port));
+      } else {
+        srv.close(() => reject(new Error('Failed to allocate free port')));
+      }
+    });
+  });
+}
+
+function listenOn(port: number): Promise<net.Server> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer((sock) => {
+      // Hold the connection open briefly so the probe's ACK lands cleanly.
+      sock.on('data', () => {});
+    });
+    srv.once('error', reject);
+    srv.listen(port, '127.0.0.1', () => resolve(srv));
+  });
+}
+
+describe('connectLocal — TCP probe fallback for #43', () => {
+  it('refuses to auto-launch when the configured port is held by a non-CDP TCP listener', async () => {
+    const port = await freePort();
+    const blocker = await listenOn(port);
+
+    const profile: BrowserProfile = {
+      name: 'comet-like',
+      browser: 'chrome',
+      endpoints: [`cdp://127.0.0.1:${port}`],
+    };
+
+    try {
+      // Either branch (lsof-based occupant detection or the TCP-probe fallback)
+      // is fine — the contract is: surface an actionable error that names the
+      // port + the profile, no Node stacktrace. Issue #43 is about UX, not
+      // about which detection path catches it first.
+      await expect(connectLocal(`cdp://127.0.0.1:${port}`, profile)).rejects.toThrow(
+        new RegExp(`${port}`),
+      );
+      await expect(connectLocal(`cdp://127.0.0.1:${port}`, profile)).rejects.toThrow(
+        /comet-like/,
+      );
+    } finally {
+      blocker.close();
+    }
+  });
+});

--- a/src/lib/browser/drivers/local.ts
+++ b/src/lib/browser/drivers/local.ts
@@ -1,7 +1,30 @@
+import * as net from 'net';
+
 import { CDPClient, discoverBrowserWsUrl, verifyBrowserIdentity } from '../cdp.js';
 import { launchBrowser, getPortOccupant } from '../chrome.js';
 import { parseEndpointUrl } from '../profiles.js';
 import type { BrowserProfile } from '../types.js';
+
+/**
+ * Cheap TCP-level "is something bound here?" probe. Used as a fallback when
+ * `getPortOccupant()` (lsof-based) misses the process — Comet and other
+ * Electron apps sometimes hold a TCP socket that lsof's `-sTCP:LISTEN` filter
+ * doesn't report. If anything ACKs the connection, we treat the port as taken
+ * and surface a friendly error instead of silently auto-launching a fresh
+ * browser that would then conflict.
+ */
+async function probeTcpBound(port: number, host = '127.0.0.1', timeoutMs = 500): Promise<boolean> {
+  return new Promise((resolve) => {
+    const sock = net.createConnection({ port, host });
+    const cleanup = () => {
+      sock.removeAllListeners();
+      sock.destroy();
+    };
+    const timer = setTimeout(() => { cleanup(); resolve(false); }, timeoutMs);
+    sock.once('connect', () => { clearTimeout(timer); cleanup(); resolve(true); });
+    sock.once('error', () => { clearTimeout(timer); cleanup(); resolve(false); });
+  });
+}
 
 export interface LocalConnection {
   cdp: CDPClient;
@@ -78,20 +101,44 @@ export async function connectLocal(
       );
     }
 
+    // lsof-based detection misses some Electron-family processes (Comet, custom
+    // chrome wrappers). Cheap TCP probe as a safety net: if something ACKs a
+    // connect, the port is bound — bail loudly with the profile name + endpoint
+    // rather than silently launching a duplicate browser.
+    if (await probeTcpBound(port)) {
+      throw new Error(
+        `Profile "${profile.name}" is configured for cdp://127.0.0.1:${port}, ` +
+          `but something is already bound to that port without serving the Chrome ` +
+          `DevTools Protocol. If that's your browser running without remote debugging, ` +
+          `quit it and relaunch with \`--remote-debugging-port=${port}\`. Otherwise, ` +
+          `update the profile to a free port (\`agents browser profiles list\`).`
+      );
+    }
+
     const newPort = port;
     const chromeOpts = { ...profile.chrome, viewport: profile.viewport };
-    const { pid, wsUrl } = await launchBrowser(
-      profile.name,
-      profile.browser,
-      newPort,
-      chromeOpts,
-      profile.secrets,
-      profile.binary,
-      profile.electron === true
-    );
+    let launched;
+    try {
+      launched = await launchBrowser(
+        profile.name,
+        profile.browser,
+        newPort,
+        chromeOpts,
+        profile.secrets,
+        profile.binary,
+        profile.electron === true
+      );
+    } catch (launchErr) {
+      const reason = launchErr instanceof Error ? launchErr.message : String(launchErr);
+      throw new Error(
+        `Could not start ${profile.browser} for profile "${profile.name}" on port ${newPort}: ${reason}. ` +
+          `Check that the browser binary is installed (\`agents browser profiles list\`) and ` +
+          `that no other process is holding the port.`
+      );
+    }
     const cdp = new CDPClient();
-    await cdp.connect(wsUrl);
+    await cdp.connect(launched.wsUrl);
 
-    return { cdp, port: newPort, pid };
+    return { cdp, port: newPort, pid: launched.pid };
   }
 }

--- a/src/lib/browser/ipc.ts
+++ b/src/lib/browser/ipc.ts
@@ -151,12 +151,14 @@ export class BrowserIPCServer {
           taskName: request.taskName,
           url: request.url,
           endpointName: request.endpoint,
+          skipDomainSkill: request.skipDomainSkill,
         });
         return {
           ok: true,
           task: result.name,
           tabId: result.tabId,
           windowTargetId: result.windowId,
+          skill: result.skill,
         };
       }
 

--- a/src/lib/browser/ipc.ts
+++ b/src/lib/browser/ipc.ts
@@ -23,7 +23,8 @@ export class BrowserDaemonNotRunningError extends Error {
 export function formatBrowserDaemonNotRunningError(): string {
   return [
     'Browser daemon not running.',
-    'Start it with: agents browser start --profile <name>',
+    'Start it with: agents browser start (auto-picks an installed browser)',
+    'Or pin a profile: agents browser start --profile <name>',
     'List profiles: agents browser profiles list',
   ].join('\n');
 }

--- a/src/lib/browser/service.ts
+++ b/src/lib/browser/service.ts
@@ -21,6 +21,7 @@ import { killChrome, getRunningChromeInfo, launchBrowser, allocatePort } from '.
 import { connectLocal } from './drivers/local.js';
 import { connectSSH, shellQuote } from './drivers/ssh.js';
 import { clearProfileRuntime } from './runtime-state.js';
+import { resolveDomainSkill, type ResolvedDomainSkill } from './domain-skills.js';
 import {
   generateTaskId,
   generateShortId,
@@ -307,8 +308,8 @@ export class BrowserService {
 
   async start(
     profileName: string,
-    opts: { taskName?: string; url?: string; endpointName?: string } = {}
-  ): Promise<{ task: string; name: string; tabId?: string; windowId?: string; profile: string }> {
+    opts: { taskName?: string; url?: string; endpointName?: string; skipDomainSkill?: boolean } = {}
+  ): Promise<{ task: string; name: string; tabId?: string; windowId?: string; profile: string; skill?: ResolvedDomainSkill }> {
     const profile = await getProfile(profileName);
     if (!profile) {
       throw new Error(`Profile "${profileName}" not found`);
@@ -424,7 +425,16 @@ export class BrowserService {
       tabId = result.tabId;
     }
 
-    return { task: taskId, name: taskName, tabId, profile: effectiveProfileName };
+    // Domain-skill discovery: when a URL is supplied, look up site-specific
+    // operating instructions and pass them back so the calling agent can pick
+    // them up alongside the task id. Failures swallowed by resolveDomainSkill.
+    let skill: ResolvedDomainSkill | undefined;
+    if (opts.url && !opts.skipDomainSkill) {
+      const resolved = resolveDomainSkill(opts.url);
+      if (resolved) skill = resolved;
+    }
+
+    return { task: taskId, name: taskName, tabId, profile: effectiveProfileName, skill };
   }
 
   async stop(taskName: string): Promise<{ ok: boolean; profile?: string }> {

--- a/src/lib/browser/types.ts
+++ b/src/lib/browser/types.ts
@@ -194,6 +194,8 @@ export interface IPCRequest {
   since?: string;
   until?: string;
   appLevel?: string;
+  // Browser start: opt out of domain-skill discovery.
+  skipDomainSkill?: boolean;
 }
 
 /** Subset of IPCResponse describing a recording start result. */
@@ -253,6 +255,15 @@ export interface IPCResponse {
   // launchd-managed registry daemon silently serving old code to a
   // dev-build CLI client).
   version?: string;
+  // Domain-skill auto-discovery result from `start` when a URL is supplied
+  // and a matching SKILL.md was found under
+  // ~/.agents/skills/browser/domain-skills/.
+  skill?: {
+    name: string;
+    path: string;
+    content: string;
+    hostname: string;
+  };
 }
 
 export interface ConsoleEntry {

--- a/src/lib/secrets/__tests__/bundles-storage.test.ts
+++ b/src/lib/secrets/__tests__/bundles-storage.test.ts
@@ -222,6 +222,55 @@ describe('listBundles', () => {
     const bundles = listBundles();
     expect(bundles.map((b) => b.name)).toEqual(['good']);
   });
+
+  it('preserves description, icloud_sync, allow_exec, and timestamps for every bundle', () => {
+    // Regression for the Touch-ID-per-bundle bug: listBundles must produce
+    // fully-populated SecretsBundle objects from the batched read, not just
+    // names. We previously delegated to readBundle in a loop; the batch path
+    // duplicates the parse logic so this guards against drift.
+    writeBundle({
+      name: 'alpha',
+      description: 'first',
+      icloud_sync: true,
+      allow_exec: true,
+      vars: { API: 'keychain:API' },
+      meta: { API: { type: 'api-key', note: 'pinned' } },
+    });
+    writeBundle({
+      name: 'beta',
+      description: 'second',
+      icloud_sync: false,
+      vars: { TOKEN: 'literal-value' },
+    });
+    const bundles = listBundles();
+    expect(bundles).toHaveLength(2);
+    const a = bundles.find((b) => b.name === 'alpha')!;
+    expect(a.description).toBe('first');
+    expect(a.icloud_sync).toBe(true);
+    expect(a.allow_exec).toBe(true);
+    expect(a.vars).toEqual({ API: 'keychain:API' });
+    expect(a.meta).toEqual({ API: { type: 'api-key', note: 'pinned' } });
+    expect(typeof a.created_at).toBe('string');
+    expect(typeof a.updated_at).toBe('string');
+    const b = bundles.find((b) => b.name === 'beta')!;
+    expect(b.description).toBe('second');
+    expect(b.icloud_sync).toBe(false);
+    expect(b.allow_exec).toBe(false);
+  });
+
+  it('scales to many bundles without dropping any (no prompt-per-bundle regression)', () => {
+    // The realistic scenario from a real user: 20+ bundles all sync to iCloud
+    // Keychain. Before the fix, this produced 20+ Touch ID prompts because
+    // readBundle was called in a loop, each spawning a fresh LAContext. The
+    // batch read must return all of them in one shot.
+    for (let i = 0; i < 25; i++) {
+      writeBundle({ name: `bundle-${String(i).padStart(2, '0')}`, vars: {} });
+    }
+    const bundles = listBundles();
+    expect(bundles).toHaveLength(25);
+    expect(bundles[0].name).toBe('bundle-00');
+    expect(bundles[24].name).toBe('bundle-24');
+  });
 });
 
 describe('readBundle errors', () => {

--- a/src/lib/secrets/bundles.ts
+++ b/src/lib/secrets/bundles.ts
@@ -267,13 +267,48 @@ export function listBundles(): SecretsBundle[] {
   const names = services
     .map((s) => s.slice(BUNDLE_META_PREFIX.length))
     .filter((n) => BUNDLE_NAME_PATTERN.test(n));
+  if (names.length === 0) return [];
+
+  // Batch all metadata reads behind ONE Touch ID prompt instead of N. Bundle
+  // metadata items carry user-presence ACLs (same as secret values), so a naive
+  // loop over readBundle() spawns a fresh LAContext per item — meaning N
+  // biometric prompts for `secrets list`. Sharing a single context across all
+  // SecItemCopyMatching calls collapses the prompt to one. Mirrors the pattern
+  // already used by resolveBundleEnv for runtime secret injection.
+  const itemsToFetch = names.map(bundleMetaItem);
+  const fetched = getKeychainTokensBatch(itemsToFetch, false, 'list secrets bundles');
+
   const out: SecretsBundle[] = [];
   for (const name of names) {
+    const json = fetched.get(bundleMetaItem(name));
+    if (json === undefined) continue;
+    let parsed: Partial<SecretsBundle>;
     try {
-      out.push(readBundle(name));
+      parsed = JSON.parse(json) as Partial<SecretsBundle>;
     } catch {
       // Skip malformed bundles; surfaced via `agents secrets view <name>`.
+      continue;
     }
+    if (!parsed || typeof parsed !== 'object') continue;
+    const bundle: SecretsBundle = {
+      name,
+      description: parsed.description,
+      allow_exec: Boolean(parsed.allow_exec),
+      icloud_sync: Boolean(parsed.icloud_sync),
+      vars: parsed.vars && typeof parsed.vars === 'object' ? parsed.vars : {},
+    };
+    if (typeof parsed.created_at === 'string') bundle.created_at = parsed.created_at;
+    if (typeof parsed.updated_at === 'string') bundle.updated_at = parsed.updated_at;
+    if (typeof parsed.last_used === 'string') bundle.last_used = parsed.last_used;
+    if (parsed.meta && typeof parsed.meta === 'object') bundle.meta = parsed.meta;
+    // Skip bundles with invalid env keys rather than throwing — same lenient
+    // posture readBundle had via the outer catch.
+    let valid = true;
+    for (const key of Object.keys(bundle.vars)) {
+      if (!ENV_KEY_PATTERN.test(key)) { valid = false; break; }
+    }
+    if (!valid) continue;
+    out.push(bundle);
   }
   return out.sort((a, b) => a.name.localeCompare(b.name));
 }


### PR DESCRIPTION
## Summary

Recording already works as `agents browser record start/stop`, but kicking it on right after `browser start` required a second command and a saved task name. Add `--record [--fps N] [--duration N] [--max-mb N]` to `browser start` so a single command spawns the task AND begins capturing.

## What you'll see

```
\$ agents browser start --url https://perplexity.ai --record --duration 30
my-task-name
Started task "my-task-name" with tab abc
Tip: export AGENTS_BROWSER_TASK=my-task-name
Try: agents browser screenshot | agents browser console --level error
Recording at 5 fps (cap 30s / 25 MB) -> /Users/.../sessions/my-task-name/recordings/2026-...mp4
Stop with: agents browser record stop
```

## Implementation

Pure ergonomic wrapper — no new capture code. Flags forward to `record-start` verbatim; defaults match the standalone `record start` subcommand (5 fps, 60s cap, 25 MB cap). Failures from `record-start` are reported on stderr but don't fail the `start` action — the task is already running.

## Test plan

- [x] `bunx tsc --noEmit` — clean.
- [x] `agents browser start --help` shows `--record`, `--fps`, `--duration`, `--max-mb`.
- [ ] Live E2E pending a daemon restart (current daemon has an in-progress user task).

## Stacked on

This branch sits on top of #84 (domain-skill auto-discovery), which sits on top of #83 (secrets-list Touch ID fix). Merge order: #83, #84, then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)