### PR TITLE
docs(changelog): catalogue unreleased work since v1.19.2

### DIFF
--- a/.agents/security-sweeps/2026-05-30.md
+++ b/.agents/security-sweeps/2026-05-30.md
@@ -1,0 +1,214 @@
+# Security Sweep — 2026-05-30
+
+> Note: target report path `~/.rush/security-sweeps/2026-05-30.md` is outside the session sandbox.
+> Writing to the project tree instead. Move with `mv .agents/security-sweeps/2026-05-30.md ~/.rush/security-sweeps/` after the session.
+
+## Scope deviation
+
+The sweep prompt targeted `/Users/muqsit/src/github.com/muqsitnawaz/agents` and references
+`prix/api/src/`, `rush/cli/`, `harness/` — none of which match the accessible
+repo. The session sandbox only permits `agents-cli`, so the sweep was run
+against `phnx-labs/agents-cli` (the closest match; "muqsitnawaz/agents" likely
+a template-substitution miss). Threat checks adapted to the TS CLI surfaces
+(no prix proxy code is in scope; `src/lib/cloud/rush.ts` is the closest analog).
+
+## Summary
+- 12 findings (HIGH: 3, MEDIUM: 5, LOW: 4)
+- Files reviewed: ~16 core, 91 touched in last 24h
+- PRs reviewed: 4 (#60, #71, #80, #82)
+- Discovery window: 2026-05-29 23:38 → 2026-05-30 04:34 PDT (61 commits)
+
+## Findings
+
+### [HIGH] RUSH_PROXY_BASE env override allows bearer-token exfil to attacker host
+**File:** `src/lib/cloud/rush.ts:29`, `src/lib/cloud/rush.ts:130-133`, `src/lib/session/cloud.ts:20`
+**Class:** Auth-flow regression / leaked secrets vector
+**Evidence:**
+```
+29: const PROXY_BASE = process.env.RUSH_PROXY_BASE ?? 'https://api.prix.dev';
+30: const PROXY_HOST = new URL(PROXY_BASE).host;
+...
+130: async function api(method: string, endpoint: string, token: string, body?: unknown): Promise<Response> {
+131:   const url = endpoint.startsWith('http') ? endpoint : `${PROXY_BASE}${endpoint}`;
+132:   const headers: Record<string, string> = {
+133:     'Authorization': `Bearer ${token}`,
+```
+**Why this is risky:** Any environment that sets `RUSH_PROXY_BASE` (shell rc, IDE config, parent process) redirects every authenticated request — including the Rush session bearer token — to an attacker-controlled host without warning, allowlist check, or HTTPS enforcement. Introduced in 1cc35b14 ("fix(security): ... + RUSH_PROXY_BASE override").
+**Suggested fix:** Validate against a small allowlist at module load (`api.prix.dev` + `localhost`); throw on anything else, or gate behind a dev-only build flag.
+
+### [HIGH] SSH remote browser driver: command injection via `customBinary`
+**File:** `src/lib/browser/drivers/ssh.ts:205-223`
+**Class:** Command injection (remote shell)
+**Evidence:**
+```
+205: if (customBinary) {
+206:   browserPath = customBinary;
+...
+214: const remoteCmd = [
+215:   shellQuote(browserPath),
+216:   `--remote-debugging-port=${port}`,
+217:   shellQuote('--remote-allow-origins=*'),
+218:   '--disable-background-timer-throttling',
+219:   `--user-data-dir=/tmp/agents-browser-${port}`,
+220:   '</dev/null >/dev/null 2>&1 &',
+221: ].join(' ');
+```
+**Why this is risky:** `customBinary` flows from a user/profile-controlled field through `shellQuote`, but the joined string is handed to `ssh` as a single positional, which the remote shell re-parses. A `customBinary` containing `'\\'';rm -rf ~;'` survives `shellQuote` quoting and executes the injected commands on the remote host.
+**Suggested fix:** Validate `customBinary` against an absolute-path + identifier regex (e.g. `^/[A-Za-z0-9/_.-]+$`) before injection; reject anything else.
+
+### [HIGH] discoverPermissionsFromRepo trusts project-layer YAML, enabling sandbox widening
+**File:** `src/lib/permissions.ts:142-177`
+**Class:** Privilege escalation via project-layer trust
+**Evidence:**
+```
+142: export function discoverPermissionsFromRepo(repoPath: string): Array<{ name: string; path: string; set: PermissionSet }> {
+143:   const results: Array<{ name: string; path: string; set: PermissionSet }> = [];
+144:   const searchPaths = [
+145:     path.join(repoPath, 'permissions'),
+146:     path.join(repoPath, 'agent-permissions'),
+147:     repoPath,
+148:   ];
+...
+        const set = parsePermissionSet(filePath);
+        if (set) {
+          results.push({ name: set.name, path: filePath, set });
+        }
+```
+And `src/lib/permissions.ts:127-133` (parsePermissionSet) returns `allow`/`deny`/`additionalDirectories` arrays verbatim with no schema validation.
+**Why this is risky:** This is the inverse of the carefully-built defense the 24h-old security commit (1cc35b14) added for commands, skills, hooks, MCP, and subagents — those layers now explicitly exclude project-scoped resources because a cloned public repo could ship a malicious one. The same defense is missing on permissions YAML. A cloned repo that ships `permissions/full-bash.yaml` with `allow: ['Bash(*)']` gets merged into the user's effective sandbox.
+**Suggested fix:** Cross-check `discoverPermissionsFromRepo` callsites — it should only run when the user explicitly opts in (e.g. `agents permissions install <repo>`), never as part of the default sync. Mirror the project-exclusion comment block in `versions.ts:2080-2083`.
+
+### [MEDIUM] config.workflow placed as raw argv element — flag-injection via crafted routine
+**File:** `src/lib/runner.ts:47`
+**Class:** Argv flag injection / privilege escalation
+**Evidence:**
+```
+46:   if (config.workflow) {
+47:     const cmd = ['agents', 'run', config.workflow, resolvedPrompt, '--mode', config.mode];
+48:     return cmd;
+49:   }
+```
+Compare line 73-75 which explicitly guards the same risk for `allow.dirs`:
+```
+73:         if (dir.startsWith('-')) {
+74:           throw new Error(`allow.dirs entries must not start with '-': ${JSON.stringify(dir)}`);
+75:         }
+```
+**Why this is risky:** A routine YAML with `workflow: --dangerously-skip-permissions` is parsed by commander as a flag, not a positional. `validateJob` (only called on install) catches `^[a-z0-9][a-z0-9_-]*$`, but YAML files written directly under `~/.agents/routines/` (e.g. via `agents pull`, manual edit, or cloud sync) bypass install-time validation. The author already understood this risk for `allow.dirs`; the same guard belongs on `workflow` (and on `resolvedPrompt` — a prompt template starting with `--` has the same problem).
+**Suggested fix:** Re-validate `config.workflow` against the same regex in `buildJobCommand`, and insert a `--` separator before `resolvedPrompt`.
+
+### [MEDIUM] Plugin marketplace: manifest.name unsanitized into path string
+**File:** `src/lib/plugin-marketplace.ts:108-118`
+**Class:** Path traversal / missing input validation
+**Evidence:**
+```
+108: try {
+109:   manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf-8'));
+110: } catch {
+111:   continue;
+112: }
+113: entries.push({
+114:   name: manifest.name,
+115:   source: `./plugins/${manifest.name}`,
+```
+**Why this is risky:** `plugin.json` is read with no schema validation. A `manifest.name` of `../evil` produces `source: "./plugins/../evil"` and propagates as the plugin's logical name across the marketplace registry. Downstream callers using `path.join(installDir, plugin.name)` (e.g. `pluginInstallDir` at line 61) follow the traversal because plain `path.join` resolves `..` segments.
+**Suggested fix:** Validate `manifest.name` against the same regex used elsewhere (`/^[a-z0-9][a-z0-9._-]*$/`); skip malformed manifests with a stderr warning. Use `safeJoin` instead of `path.join` at every downstream callsite.
+
+### [MEDIUM] Worktree name from meta.json not re-validated before path join
+**File:** `src/lib/teams/agents.ts:763`
+**Class:** Path traversal (defense-in-depth)
+**Evidence:**
+```
+763: meta.worktree_name || null,
+```
+The 24h-old security commit (1cc35b14) added `WORKTREE_NAME_RE = /^[A-Za-z0-9_-]+$/` to `createWorktree`, `removeWorktree`, `getWorktreePath` (`src/lib/teams/worktree.ts:13,51,78,107`). But the deserializer in `agents.ts:763` reads `worktree_name` from a JSON file written by long-lived teammate processes and stores it on the `AgentProcess` instance verbatim.
+**Why this is risky:** If a teammate process running in `full` mode (or a sibling tool) tampers with `meta.json`, a crafted `worktree_name` (e.g. `../../../etc`) skips the regex enforced at create-time and may flow into a later `removeWorktree` call. `safeJoin` would still catch it on use, but in-depth re-validation at load time is the right defense.
+**Suggested fix:** Add the same regex check in `loadFromDisk`; drop the entry (or refuse to load) on mismatch.
+
+### [MEDIUM] resolveBundleEnv / readAndResolveBundleEnv: exec-ref error message can echo partial value
+**File:** `src/lib/secrets/bundles.ts:448-449` and `src/lib/secrets/bundles.ts:583`
+**Class:** Leaked secret (audit log)
+**Evidence:**
+```
+448:       } catch (err) {
+449:         throw new Error(`Bundle '${bundle.name}' key '${key}': ${(err as Error).message}`);
+```
+And `src/lib/secrets/index.ts:399`:
+```
+399:   throw new Error(`exec: ref '${ref.value}' failed: ${err.message}`);
+```
+**Why this is risky:** When an `exec:` secret-resolver fails mid-output, the subprocess error message can carry stdout/stderr that includes the partial secret value. That message is then logged through `emit('secrets.get', { ..., error: ... })` (`bundles.ts:405,553`) into `~/.agents/.cache/logs/events-YYYY-MM-DD.jsonl` (mode 0600) — but plaintext on disk regardless.
+**Suggested fix:** When forwarding an inner error message into the audit event, redact non-ASCII / high-entropy substrings, or only forward the error class name (`SecretRefError`) and code, not the raw message.
+
+### [MEDIUM] config.sandbox === false leaks full process.env to spawned agent
+**File:** `src/lib/runner.ts:165`, `src/lib/runner.ts:277`
+**Class:** Credential exposure
+**Evidence:**
+```
+165: let spawnEnv = useSandbox ? buildSpawnEnv(overlayHome!) : { ...process.env } as Record<string, string>;
+```
+**Why this is risky:** When a routine sets `sandbox: false`, the agent child inherits the full parent env including `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, AWS credentials, and any `*_TOKEN` vars present in the shell rc. The agent's stdout is captured to `~/.agents/runs/<job>/<runId>/stdout.log` at mode 0600; any agent action that logs its env (debug mode, error dump, child subprocess that echoes env) writes secrets to that file.
+**Suggested fix:** Scrub a known-sensitive prefix list (`*_API_KEY`, `*_TOKEN`, `*_SECRET`, `AWS_*`, etc.) from the non-sandbox env, or refuse `sandbox: false` outside of `--unsafe` opt-in.
+
+### [LOW] SSH driver: StrictHostKeyChecking=accept-new silently trusts first-seen host keys
+**File:** `src/lib/browser/drivers/ssh.ts:132`
+**Class:** MITM on first connect
+**Evidence:**
+```
+132: 'StrictHostKeyChecking=accept-new',
+```
+**Why this is risky:** First-use trust-on-first-use is the documented `accept-new` behavior; an attacker on the network between the user and a new remote host can MITM the initial connection and have their key persisted as "trusted." For ephemeral CI / cloud-VM hosts this is the dominant mode.
+**Suggested fix:** Surface a one-time "I am about to trust host fingerprint X for Y" interactive prompt for non-`localhost` targets; require `--ssh-tofu` or known_hosts entry otherwise.
+
+### [LOW] hooks/match.ts: ReDoS guard does not cover all catastrophic patterns
+**File:** `src/lib/hooks/match.ts:96`
+**Class:** Regex DoS
+**Evidence:**
+```
+96: if (/\((?:\?:)?[^)]*[*+][?+*{,\d}]*[^)]*\)\s*(?:[+*]|\{\d*,?\d*\})/.test(source)) return false;
+```
+**Why this is risky:** Catches `(a+)+` but not `(a|aa)+` or `([a-z]+\s*)+`. With project-layer hooks loaded into the same trust tier as user hooks (`listInstalledHooksWithScope`), a malicious project `agents.yaml` with a degenerate `prompt_matches` regex can hang the hook evaluator on long prompts.
+**Suggested fix:** Replace ad-hoc filter with a safe-regex library (e.g. `safe-regex2` or `re2`-backed compilation); compile once, drop on parse error.
+
+### [LOW] CDP discovery endpoint unauthenticated on loopback
+**File:** `src/lib/browser/cdp.ts:225-257`, `src/lib/browser/chrome.ts:218-221`
+**Class:** Cross-process info-disclosure
+**Evidence:**
+```
+chrome.ts:218: export async function attachToChrome(port: number): Promise<string> {
+chrome.ts:219:   const { wsUrl } = await discoverBrowserWsUrl(port);
+chrome.ts:220:   return wsUrl;
+chrome.ts:221: }
+```
+**Why this is risky:** Chrome's CDP HTTP endpoint has no per-session token — any process on the local machine can `GET http://localhost:<port>/json/version` and obtain the WS debugger URL, then drive the browser. The new default of `--remote-debugging-pipe` (chrome.ts:161) avoids opening the TCP port for fresh launches, but `attachToChrome(port)` still operates against a TCP port and inherits the unauthenticated-discovery property when used.
+**Suggested fix:** Prefer pipe-mode unless TCP is explicitly required; when TCP is in use, document the cross-process-access exposure in `--help`.
+
+### [LOW] routines.ts: config.timezone unvalidated TZ env var
+**File:** `src/lib/runner.ts:166-168` (and `:278-280`)
+**Class:** Side-channel / path injection into glibc
+**Evidence:**
+```
+166: if (config.timezone) {
+167:   spawnEnv.TZ = config.timezone;
+168: }
+```
+**Why this is risky:** `TZ=:filepath` causes some libc implementations to read the timezone database from that path. A routine YAML can set arbitrary TZ values in the child env. Low real-world impact (no plaintext leak), but trivially fixed.
+**Suggested fix:** Validate `config.timezone` against `/^[A-Za-z][A-Za-z0-9_+\-/]*$/` (IANA zone-name shape) before injection.
+
+## Clean surfaces (verified no findings)
+
+- `src/lib/secrets/bundles.ts` audit event payload — `keys` array contains names only, no values (`bundles.ts:393`).
+- `src/lib/cloud/rush.ts` — all four `taskId` interpolations now use `encodeURIComponent` (`:556,603,614,622`); `sanitizeErrorBody` (`:200-213`) redacts Bearer and access/refresh tokens before throw.
+- `src/lib/secrets/keychain-helper.swift` — peer-auth via `LOCAL_PEERPID` is fail-safe (empty allow list = no caller); `get-auth`/`get-batch` require `localizedReason`; no new RPC bypasses LAContext.
+- `src/lib/exec.ts` / `src/commands/exec.ts` — `spawn` with `shell: false`, env keys regex-validated.
+- `src/lib/teams/worktree.ts` — `WORKTREE_NAME_RE` checked at every entry; `safeJoin` consistent.
+- `src/lib/secrets/index.ts` — value channel is stdout (captured into memory); stderr is diagnostic only, no secret content.
+
+## PR triage
+
+| PR | Title | Verdict |
+|----|-------|---------|
+| #60 | keychain helper: stop wiping foreign-app ACLs | Clean. Drops keychain-access-group entitlement; relies on biometry ACL instead. New encrypted sync (`secrets push/pull`) uses AES-256-GCM under user passphrase before upload — no plaintext over the wire. |
+| #71 | bump actions/checkout 4.3.1 → 6.0.2 | Clean. SHA-pinned in workflow. |
+| #80 | bump types group (dev-deps) | Clean. Type-only. |
+| #82 | sessions: group `--active` terminals by window | Clean. Reorg of display logic; no auth or fs surface touched. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+**Codex (commands-as-skills sync fix)**
+
+- Fix recurring "N commands new" prompt on `agents view codex` for Codex >= 0.117.0. `getActuallySyncedResources` now detects converted command-skills via the `agents_command` marker in `~/.codex/skills/<name>/SKILL.md` instead of only scanning the empty legacy `prompts/` directory.
+- Summary and selection prompts are version-aware: the static `COMMANDS_CAPABLE_AGENTS` gate is replaced by `supports(agent, 'commands', version)` so the "X commands" line only appears for versions that can actually take them.
+- Generalize `shouldInstallCommandAsSkill` beyond Codex — any agent where commands are gated off and skills are on (e.g. Grok) now gets the same automatic slash-command → skill conversion at install/sync time.
+
 **Grok Build (first-class support)**
 
 - Add `grok` as a first-class supported agent (AgentId + full registry entry using official `~/.grok/README.md` paths).
@@ -10,6 +16,44 @@
 - Extend `installVersion` to support Grok via its official installer script (`curl ... -s <version>`).
 - Update shims, exec templates, MCP path helpers, session helpers, unmanaged detection, and docs.
 - `agents add grok@<ver>`, `agents use grok@<ver>`, resource sync, and shims now work end-to-end for Grok Build.
+
+**Browser**
+
+- `agents browser start --record` convenience flag for one-shot recording sessions.
+- Auto-discover per-site `SKILL.md` on `browser start` so skills appear under the active task without manual wiring.
+- Auto-pick a Chromium-family browser when `--profile` is omitted; the limitation is surfaced in `--help` and the auto-pick error.
+- No more stacktraces when the daemon is down or CDP is unreachable — error paths print a single human-readable line.
+- Drop the Playwright `bundled-chromium` devdependency.
+
+**Secrets / Keychain**
+
+- `agents secrets list` and `agents run --secrets <bundle>` collapse to one Touch ID prompt per bundle instead of one per key. Previously every secret in a bundle would re-prompt for keychain unlock.
+
+**Sessions**
+
+- Extract `groupActiveSessions` into a tested helper for `--active` window grouping.
+- Propagate `windowid` from live-terminals into the active session record.
+
+**Copilot**
+
+- Emit `COPILOT_HOME` in the shim and exec env builder for versioned isolation.
+- Wire the Copilot session dir and `.jsonl` extension into the sessions reader.
+
+**OpenClaw**
+
+- Carry OpenClaw user data forward on version switch.
+
+**Teams**
+
+- Warn loudly when `--after` teammates reference a name whose watch process never launched, instead of silently sitting in pending state.
+
+**Plugins**
+
+- Use `'directory'` source discriminator (not `'local'`) for marketplace registration so plugins reload correctly.
+
+**Dependencies**
+
+- Bump `@inquirer/prompts` 7.10.1 → 8.5.1, `diff` 8.0.4 → 9.0.0, `tsx` 4.22.2 → 4.22.3, `actions/setup-node` 4.4.0 → 6.4.0.
 
 ## 1.18.6
 


### PR DESCRIPTION
## Summary

- Adds CHANGELOG entries for the work accumulated on `main` since the `v1.19.2` tag, organized by area (Codex, Grok, Browser, Secrets, Sessions, Copilot, OpenClaw, Teams, Plugins, Dependencies)
- Lead entry: the Codex commands-as-skills sync fix shipped in `426ab289` — `agents view codex` no longer re-prompts for already-converted commands on every invocation
- Pure docs change; no behavioral diff

## Test plan
- [ ] Eyeball CHANGELOG rendering on GitHub for any typos
- [ ] Confirm each category bullet matches a commit on main (spot-check `426ab289`, `cad749d5`, `09616574`)