### PR TITLE
feat: overdue routine detection + expanded landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-## Unreleased
+## 1.20.0
+
+**Routines (overdue detection + catchup)**
+
+- Detect routines whose most recent scheduled fire was missed (laptop off, daemon crashed, reboot). The daemon logs them on startup and pops a native desktop notification (`osascript` on macOS, `notify-send` on Linux).
+- `agents routines list` annotates overdue rows with `(overdue)` and prints a footer pointing at the catchup command.
+- New `agents routines catchup` command: lists overdue routines and fires them in the background under the scheduler. `--dry-run` lists without triggering.
+- `JobScheduler.schedule` now sets croner's `catch: true` and forwards `timezone` defensively, so a synchronous throw in one job's callback can't kill the whole cron loop.
+
+**Landing page (agents-cli.sh)**
+
+- Expanded the homepage with seven new sections: rotate accounts (`--rotate`), parallel teams (`agents teams`), browser automation, cross-agent session search, routines/cron, keychain secrets, and machine-to-machine sync (`agents drive`).
+- Rewrote meta description + lede to spell out the actual feature set (pin versions, swap models, rotate accounts, drive a browser, spawn parallel teams, schedule on cron) instead of just "same interface, on your machine."
 
 **Codex (commands-as-skills sync fix)**
 

--- a/src/commands/routines.ts
+++ b/src/commands/routines.ts
@@ -38,8 +38,9 @@ import {
 import type { JobConfig } from '../lib/routines.js';
 import { getRoutinesDir } from '../lib/state.js';
 import { safeJoin } from '../lib/paths.js';
-import { executeJob } from '../lib/runner.js';
+import { executeJob, executeJobDetached } from '../lib/runner.js';
 import { JobScheduler } from '../lib/scheduler.js';
+import { detectOverdueJobs } from '../lib/overdue.js';
 import { isInteractiveTerminal, requireInteractiveSelection } from './utils.js';
 import { setHelpSections } from '../lib/help.js';
 
@@ -159,6 +160,14 @@ export function registerRoutinesCommands(program: Command): void {
       const scheduler = new JobScheduler(async () => {});
       scheduler.loadAll();
 
+      // Build a quick lookup: which jobs are currently overdue?
+      const overdueSet = new Set<string>();
+      try {
+        for (const j of detectOverdueJobs()) overdueSet.add(j.name);
+      } catch {
+        // Best-effort indicator; never block the list on detection errors.
+      }
+
       console.log(chalk.bold('Scheduled Jobs\n'));
 
       // OSC 8 hyperlink helper — renders as a clickable link in supporting terminals.
@@ -204,12 +213,19 @@ export function registerRoutinesCommands(program: Command): void {
           : lastStatus === 'timeout' ? chalk.yellow
           : chalk.gray;
 
+        const overdueTag = overdueSet.has(job.name) ? chalk.yellow(' (overdue)') : '';
+
         const agentLabelPadded = job.workflow
           ? chalk.magenta(`wf:${job.workflow}`.padEnd(10))
           : (job.agent || '').padEnd(10);
         console.log(
-          `  ${chalk.cyan(job.name.padEnd(NAME_W))} ${agentLabelPadded} ${repoCell}${' '.repeat(repoPadding)} ${schedStr.padEnd(SCHED_W)} ${enabledStr}${' '.repeat(enabledPad)} ${chalk.gray(nextStr.padEnd(NEXT_W))} ${statusColor(lastStatus)}`
+          `  ${chalk.cyan(job.name.padEnd(NAME_W))} ${agentLabelPadded} ${repoCell}${' '.repeat(repoPadding)} ${schedStr.padEnd(SCHED_W)} ${enabledStr}${' '.repeat(enabledPad)} ${chalk.gray(nextStr.padEnd(NEXT_W))} ${statusColor(lastStatus)}${overdueTag}`
         );
+      }
+
+      if (overdueSet.size > 0) {
+        console.log();
+        console.log(chalk.yellow(`  ${overdueSet.size} routine(s) overdue — catch up with: agents routines catchup`));
       }
 
       scheduler.stopAll();
@@ -526,6 +542,54 @@ export function registerRoutinesCommands(program: Command): void {
         console.error(chalk.red((err as Error).message));
         process.exit(1);
       }
+    });
+
+  routinesCmd
+    .command('catchup')
+    .description('Run any routines that missed their last scheduled fire (e.g. because your laptop was off). Detached — runs in the background under the scheduler.')
+    .option('--dry-run', 'List overdue routines without running them')
+    .action(async (options) => {
+      const overdue = detectOverdueJobs();
+      if (overdue.length === 0) {
+        console.log(chalk.gray('No overdue routines.'));
+        return;
+      }
+
+      console.log(chalk.bold(`${overdue.length} overdue routine(s):\n`));
+      for (const job of overdue) {
+        const last = job.lastRanAt ? job.lastRanAt.toLocaleString() : 'never';
+        console.log(`  ${chalk.cyan(job.name)} — missed ${chalk.gray(job.expectedAt.toLocaleString())}, last ran ${chalk.gray(last)}`);
+      }
+
+      if (options.dryRun) {
+        console.log(chalk.gray('\n(dry run — no jobs triggered)'));
+        return;
+      }
+
+      // Need the daemon alive so spawned jobs are monitored and meta.json is
+      // finalized. Start it if it isn't already running.
+      if (!isDaemonRunning()) {
+        const started = startDaemon();
+        if (started.pid) {
+          console.log(chalk.gray(`\nStarted scheduler (PID: ${started.pid}) so catchup runs are monitored.`));
+        }
+      }
+
+      console.log(chalk.bold('\nTriggering catchup runs...'));
+      for (const job of overdue) {
+        const config = readJob(job.name);
+        if (!config) {
+          console.log(`  ${job.name} → ${chalk.red('config not found')}`);
+          continue;
+        }
+        try {
+          const meta = await executeJobDetached(config);
+          console.log(`  ${job.name} → ${chalk.green('started')} (run: ${meta.runId}, PID: ${meta.pid ?? 'n/a'})`);
+        } catch (err) {
+          console.log(`  ${job.name} → ${chalk.red('failed to start')}: ${(err as Error).message}`);
+        }
+      }
+      console.log(chalk.gray('\nTrack progress with: agents routines runs <name>'));
     });
 
   routinesCmd

--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -15,6 +15,7 @@ import { getDaemonDir as getDaemonDirRoot } from './state.js';
 import { listJobs as listAllJobs } from './routines.js';
 import { JobScheduler } from './scheduler.js';
 import { executeJobDetached, monitorRunningJobs } from './runner.js';
+import { detectOverdueJobs, notifyOverdue } from './overdue.js';
 import { BrowserService } from './browser/service.js';
 import { BrowserIPCServer } from './browser/ipc.js';
 
@@ -178,6 +179,25 @@ export async function runDaemon(): Promise<void> {
   log('INFO', `Loaded ${scheduled.length} jobs`);
   for (const job of scheduled) {
     log('INFO', `  ${job.name} -> next: ${job.nextRun?.toISOString() || 'unknown'}`);
+  }
+
+  // Backlog detection: any enabled recurring job whose most-recent expected
+  // fire is older than its most-recent recorded run is overdue. Happens when
+  // the laptop was off or the daemon crashed through a scheduled fire.
+  // We log it and pop a native notification — the user can review with
+  // `agents routines list` and run them with `agents routines catchup`.
+  try {
+    const overdue = detectOverdueJobs();
+    if (overdue.length > 0) {
+      log('WARN', `${overdue.length} routine(s) overdue:`);
+      for (const job of overdue) {
+        const last = job.lastRanAt ? job.lastRanAt.toISOString() : 'never';
+        log('WARN', `  ${job.name} -- expected ${job.expectedAt.toISOString()}, last ran ${last}`);
+      }
+      notifyOverdue(overdue);
+    }
+  } catch (err) {
+    log('ERROR', `Overdue detection failed: ${(err as Error).message}`);
   }
 
   // Before the BrowserService comes up, reap browser + tunnel processes

--- a/src/lib/overdue.ts
+++ b/src/lib/overdue.ts
@@ -1,0 +1,122 @@
+/**
+ * Overdue routine detection.
+ *
+ * When the daemon was not running (laptop off, reboot, daemon crash) at the
+ * time a job was supposed to fire, the missed schedule is lost — croner only
+ * schedules forward from "now." This module compares each enabled job's
+ * most-recent expected fire time (from its cron expression) with the start
+ * time of its most-recent recorded run; jobs whose latest run is older than
+ * their most-recent expected fire are flagged as overdue.
+ *
+ * Surfaced two ways: a desktop notification on daemon startup, and a
+ * `agents routines catchup` command that runs them on demand.
+ */
+
+import { Cron } from 'croner';
+import * as os from 'os';
+import { spawn } from 'child_process';
+import { listJobs, getLatestRun } from './routines.js';
+
+export interface OverdueJob {
+  name: string;
+  /** Most recent expected fire time per the cron expression. */
+  expectedAt: Date;
+  /** Start time of the most recent recorded run, or null if never run. */
+  lastRanAt: Date | null;
+}
+
+// Tolerance between "expected fire" and "recorded run start" — accounts for
+// the small gap between the cron tick and when the runner writes meta.json.
+const GRACE_MS = 60_000;
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Compute the most recent fire of `pattern` at or before `now`. Croner's
+ *  `previousRun()` returns the cron instance's own last fire, which is null
+ *  on a freshly-constructed instance — so we walk `nextRun(cursor)` forward
+ *  from a week ago and keep the last fire still ≤ now. */
+function previousExpectedFire(cron: Cron, now: Date): Date | null {
+  let cursor: Date = new Date(now.getTime() - ONE_WEEK_MS);
+  let last: Date | null = null;
+  // Cap iterations: even an every-minute schedule yields ≤ 10080 steps over a
+  // week; we cap at 20k as a paranoia bound against pathological patterns.
+  for (let i = 0; i < 20000; i++) {
+    const next = cron.nextRun(cursor);
+    if (!next || next.getTime() > now.getTime()) break;
+    last = next;
+    cursor = next;
+  }
+  return last;
+}
+
+/** Return every enabled, recurring job whose most recent expected fire was
+ *  missed. One-shot jobs are excluded — they fire at most once. */
+export function detectOverdueJobs(now: Date = new Date()): OverdueJob[] {
+  const overdue: OverdueJob[] = [];
+
+  for (const job of listJobs()) {
+    if (!job.enabled || job.runOnce) continue;
+
+    let expected: Date | null = null;
+    try {
+      const cronOptions: Record<string, unknown> = { paused: true };
+      if (job.timezone) cronOptions.timezone = job.timezone;
+      const cron = new Cron(job.schedule, cronOptions);
+      expected = previousExpectedFire(cron, now);
+      cron.stop();
+    } catch {
+      // Invalid cron expression — skip rather than crash the daemon.
+      continue;
+    }
+
+    if (!expected) continue;
+
+    const latest = getLatestRun(job.name);
+    const lastRanAt = latest ? new Date(latest.startedAt) : null;
+
+    const isOverdue =
+      !lastRanAt || lastRanAt.getTime() < expected.getTime() - GRACE_MS;
+
+    if (isOverdue) {
+      overdue.push({ name: job.name, expectedAt: expected, lastRanAt });
+    }
+  }
+
+  return overdue;
+}
+
+/** Fire a native desktop notification listing the overdue jobs. Best-effort —
+ *  failures (missing `osascript`/`notify-send`, no display) are swallowed. */
+export function notifyOverdue(jobs: OverdueJob[]): void {
+  if (jobs.length === 0) return;
+
+  const title =
+    jobs.length === 1
+      ? `Routine overdue: ${jobs[0].name}`
+      : `${jobs.length} routines overdue`;
+  const body =
+    jobs.length === 1
+      ? `Missed ${jobs[0].expectedAt.toLocaleString()}. Run: agents routines catchup`
+      : `${jobs.map((j) => j.name).join(', ')} — agents routines catchup`;
+
+  const platform = os.platform();
+  try {
+    if (platform === 'darwin') {
+      const safeTitle = title.replace(/"/g, '\\"');
+      const safeBody = body.replace(/"/g, '\\"');
+      const child = spawn(
+        'osascript',
+        ['-e', `display notification "${safeBody}" with title "${safeTitle}"`],
+        { detached: true, stdio: 'ignore' }
+      );
+      child.unref();
+    } else if (platform === 'linux') {
+      const child = spawn('notify-send', [title, body], {
+        detached: true,
+        stdio: 'ignore',
+      });
+      child.unref();
+    }
+  } catch {
+    // Notification is best-effort; nothing to do.
+  }
+}

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -37,7 +37,14 @@ export class JobScheduler {
   schedule(config: JobConfig): void {
     this.unschedule(config.name);
 
-    const cron = new Cron(config.schedule, async () => {
+    // catch: true — a throw from one job's callback should not kill the
+    // whole cron loop. Each invocation of onTrigger is already wrapped in
+    // try/catch, but a synchronous throw before the await would otherwise
+    // bubble up; defense in depth.
+    const cronOptions: Record<string, unknown> = { catch: true };
+    if (config.timezone) cronOptions.timezone = config.timezone;
+
+    const cron = new Cron(config.schedule, cronOptions, async () => {
       try {
         await this.onTrigger(config);
       } catch (err) {

--- a/website/bun.lock
+++ b/website/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@phnx-labs/agents-cli-landing",

--- a/website/src/landing.ts
+++ b/website/src/landing.ts
@@ -19,9 +19,9 @@ export const LANDING_HTML = `<!DOCTYPE html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>agents · the open client for AI coding agents</title>
-<meta name="description" content="The open client for AI coding agents. Run Claude, Codex, Gemini, Cursor — same interface, on your machine.">
+<meta name="description" content="The open client for AI coding agents. Pin versions, swap models, rotate accounts, drive a browser, spawn parallel teams, schedule on cron — one interface across Claude, Codex, Gemini, Cursor.">
 <meta property="og:title" content="agents · the open client for AI coding agents">
-<meta property="og:description" content="Run Claude, Codex, Gemini, Cursor — same interface, on your machine.">
+<meta property="og:description" content="One interface across Claude, Codex, Gemini, Cursor. Pin versions, swap models, rotate accounts, drive browsers, spawn parallel teams, schedule on cron.">
 <meta name="theme-color" content="#0a0a0a">
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ctext y='26' font-size='28' font-family='monospace' fill='%23a3e635'%3E%3E%3C/text%3E%3C/svg%3E">
 ${gaSnippet}
@@ -163,7 +163,7 @@ ul li code { background: #141414; border: 1px solid #222; padding: 1px 6px; bord
 </nav>
 
 <h1>agents</h1>
-<p class="lede">The open client for AI coding agents. Run Claude, Codex, Gemini, Cursor — same interface, on your machine.</p>
+<p class="lede">The open client for AI coding agents. Pin versions, swap models, rotate accounts, drive a browser, spawn parallel teams, schedule on cron — one interface across Claude, Codex, Gemini, Cursor.</p>
 
 <div class="hero-video">
   <video id="demo-video" src="/demo.mp4" poster="/demo-poster.jpg" autoplay muted loop playsinline preload="metadata"></video>
@@ -179,6 +179,16 @@ ul li code { background: #141414; border: 1px solid #222; padding: 1px 6px; bord
 </div>
 <p class="muted">Or <code>npm install -g @phnx-labs/agents-cli</code> — also available as <code>ag</code>.</p>
 
+<h2>Run any model through any CLI</h2>
+<pre><span class="dim">$</span> agents profiles add kimi
+<span class="dim">$</span> agents run kimi <span class="dim">"refactor the queue worker"</span></pre>
+<p>Keep Claude Code's interface, swap in Kimi K2.5, MiniMax M2.5, GLM 5, Qwen3 Coder, or DeepSeek through OpenRouter. One key in your Keychain, every preset wired up. Run the model you want at the price you want.</p>
+
+<h2>Rotate across accounts — never hit a usage limit</h2>
+<pre><span class="dim">$</span> agents run claude --rotate <span class="dim">"run the full test suite"</span>
+<span class="dim">$</span> agents usage</pre>
+<p>Have multiple Claude logins? <code>--rotate</code> picks the least-used one automatically. <code>agents usage</code> shows the rate-limit gauge per agent so you can plan ahead. One subscription, multiple windows, zero wasted quota.</p>
+
 <h2>Chain agents in a pipeline</h2>
 <pre><span class="dim">$</span> agents run claude <span class="dim">"Find auth vulnerabilities in src/"</span> \\
     | agents run codex  <span class="dim">"Fix the issues Claude found"</span> \\
@@ -192,11 +202,51 @@ agents:
   codex: "0.116.0"</pre>
 <p><code>cd</code> into the project and every <code>agents</code> call resolves to those versions automatically. Like <code>.nvmrc</code>, but for AI. Nobody else does this.</p>
 
+<h2>Parallel agents, one command</h2>
+<pre><span class="dim">$</span> agents teams create pricing-page
+<span class="dim">$</span> agents teams add pricing-page claude <span class="dim">"rewrite /v2/pricing endpoint"</span> --name be
+<span class="dim">$</span> agents teams add pricing-page codex  <span class="dim">"build /pricing route"</span>        --name fe
+<span class="dim">$</span> agents teams add pricing-page claude <span class="dim">"run Playwright suite"</span>       --name qa --after be,fe
+<span class="dim">$</span> agents teams start pricing-page --watch</pre>
+<p>DAG dependencies (<code>--after</code>), isolated worktrees per teammate, live status. Spawn five Claudes and two Codex on the same task, wind them down with <code>agents teams disband</code>.</p>
+
+<h2>A browser your agents can drive</h2>
+<pre><span class="dim">$</span> agents browser start work
+<span class="dim">$</span> agents browser navigate https://example.com
+<span class="dim">$</span> agents browser click <span class="dim">ref_3</span>
+<span class="dim">$</span> agents browser screenshot
+<span class="dim">$</span> agents browser console</pre>
+<p>Full Chrome DevTools Protocol — navigate, click, type, screenshot, read console + network, record video. Hook it into any agent run. Replaces a cloud browser service with a local one you already have logged in.</p>
+
+<h2>Cross-agent session search</h2>
+<pre><span class="dim">$</span> agents sessions <span class="dim">"stripe webhook signature"</span>
+<span class="dim">$</span> agents sessions a7f3e2c1 --markdown</pre>
+<p>Every transcript from every agent, indexed and searchable. Find that fix from Tuesday — doesn't matter which CLI wrote it. Replay as markdown, filter by project, stream live with <code>sessions tail</code>.</p>
+
+<h2>Schedule agents on a cron</h2>
+<pre><span class="dim">$</span> agents routines add standup \\
+    --schedule <span class="dim">"0 9 * * 1-5"</span> \\
+    --agent claude \\
+    --prompt <span class="dim">"Draft a standup from yesterday's git log"</span></pre>
+<p>Recurring background work, plus one-shot <code>--at "14:30"</code>. Scheduler auto-starts on first add. Standups, weekly digests, nightly audits — your agents working while you sleep.</p>
+
+<h2>Keychain-backed secrets</h2>
+<pre><span class="dim">$</span> agents secrets create prod
+<span class="dim">$</span> agents secrets add prod STRIPE_API_KEY
+<span class="dim">$</span> agents run claude <span class="dim">"deploy the worker"</span> --secrets prod</pre>
+<p>No plaintext <code>.env</code> files, no leaked tokens in shell history. Bundles live in macOS Keychain, iCloud-synced across your machines, injected as env vars only at run time.</p>
+
 <h2>Install skills, MCP servers, and commands once</h2>
 <pre><span class="dim">$</span> agents skills add gh:yourname/python-expert
 <span class="dim">$</span> agents install mcp:com.notion/mcp
 <span class="dim">$</span> agents commands add gh:yourname/commands</pre>
 <p>Skills, MCP servers, slash commands, hooks, permissions — installed once, synced to every active agent version. No more <code>claude mcp add</code> then <code>codex mcp add</code> then editing Gemini's config file by hand.</p>
+
+<h2>Sync your agent memory across machines</h2>
+<pre><span class="dim">$</span> agents drive remote you@desktop.local
+<span class="dim">$</span> agents drive push
+<span class="dim">$</span> agents drive attach</pre>
+<p>rsync your sessions and config between laptop, desktop, and server. <code>attach</code> points <code>~/.claude/</code> (and friends) at the synced location so sessions write directly to the shared drive.</p>
 
 <h2>One config repo, every harness</h2>
 <pre><span class="dim">$</span> tree ~/.agents

--- a/website/test/landing.test.ts
+++ b/website/test/landing.test.ts
@@ -4,7 +4,7 @@ import { LANDING_HTML } from '../src/landing';
 describe('LANDING_HTML required content (EXAMPLE-365 spec)', () => {
   it('has the "open client" lede exactly as the ticket requires', () => {
     expect(LANDING_HTML).toContain(
-      'The open client for AI coding agents. Run Claude, Codex, Gemini, Cursor — same interface, on your machine.'
+      'The open client for AI coding agents. Pin versions, swap models, rotate accounts, drive a browser, spawn parallel teams, schedule on cron — one interface across Claude, Codex, Gemini, Cursor.'
     );
   });
 


### PR DESCRIPTION
Two local commits picked up alongside the 1.19.3 release cut:

- `feat(routines): overdue detection + catchup command` — daemon flags routines whose most-recent expected fire is older than their last recorded run; `routines list` tags them and routes users to the catchup command.
- `feat(landing): expand homepage with seven feature sections` — broader meta description + body copy covering version pinning, model rotation, browser, teams, cron.