### PR TITLE
ci: fall back to ubuntu-latest while self-hosted pool is offline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     permissions: {}
     strategy:
       matrix:
@@ -40,7 +40,7 @@ jobs:
   publish:
     needs: build
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
 

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -1,7 +1,9 @@
 name: Sandbox tests
 
-# Runs on the phnx-labs org self-hosted runner pool (cpx41, 4 ephemeral
-# runner processes). Infra lives at agents/infra/ci-runner.
+# Temporary fallback to GitHub-hosted runners while the phnx-labs self-hosted
+# pool (cpx41, 4 ephemeral runner processes; infra at agents/infra/ci-runner)
+# is offline. Restore `runs-on: [self-hosted, linux, x64]` once the pool is
+# back online. Tracking: https://github.com/phnx-labs/agents-cli/issues/94
 #
 # Tool versions are NOT pinned here — setup-bun and any future setup-* steps
 # read the source of truth out of package.json / go.mod / etc.
@@ -16,7 +18,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   gitleaks:
     name: gitleaks
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary

- Flip `ci.yml`, `secret-scan.yml`, and `sandbox.yml` from `[self-hosted, linux, x64]` to `ubuntu-latest`.
- Unblocks CI execution so future PRs stop shipping with red tests.

## Why

`gh api repos/phnx-labs/agents-cli/actions/runners` returns `{"total_count":0,"runners":[]}`. The phnx-labs self-hosted runner pool (cpx41, 4 ephemeral processes; infra at `agents/infra/ci-runner`) is offline. PRs have been queueing indefinitely — recent merges (#83, #85, #86, #87, #88, #93, #95, 1.20.0) all shipped without their tests actually executing. That's how the 12 failing test files documented in #94 slipped onto main.

## Reversibility

Revert `runs-on:` back to `[self-hosted, linux, x64]` in all three files once the self-hosted pool is restored. The comment block in `sandbox.yml` references #94 so the toggle is discoverable.

## Test plan

- [ ] CI runs to completion on this PR (validates the ubuntu-latest swap works).
- [ ] Secret scan posts results.
- [ ] Sandbox tests execute.

Closes nothing — #94 stays open until the underlying 302 test failures are triaged.