### PR TITLE
chore(readme): retire pin-versions hero — lead with subscription auth + parallel teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/phnx-labs/agents-cli"><img src="https://img.shields.io/badge/github-phnx--labs%2Fagents--cli-blue?style=flat-square" alt="github" /></a>
 </p>
 
-**The missing toolchain for CLI coding agents.** Pin versions to escape regressions. Build hooks to control agent behavior, or skills to improve them. Then share your agent environment with your team, or clone it to any machine with one command.
+**The missing toolchain for CLI coding agents.** Run any agent on your existing subscription. Spawn parallel teams in isolated terminals. Schedule routines, drive browsers and Electron apps, and store secrets behind Touch ID — all from one CLI.
 
 <p align="center">
   <a href="https://github.com/anthropics/claude-code" title="Claude Code"><img src="assets/harnesses/anthropic.svg" height="32" alt="Claude Code" /></a>


### PR DESCRIPTION
## Why

The hero line still reflected the v1.12-era story:

> Pin versions to escape regressions. Build hooks to control agent behavior, or skills to improve them. Then share your agent environment with your team, or clone it to any machine with one command.

That undersells what the CLI actually does today. Pin/share are real features but they're table-stakes — they belong in the linked section, not the hero. The load-bearing primitives that justify "missing toolchain" are:

1. Running any agent on the user's existing subscription (Claude Code, Codex, Gemini, Cursor) without burning API tokens
2. Parallel agent teams in isolated terminals
3. Routines (cron-style)
4. Browser + Electron driving via CDP
5. Touch ID-secured Keychain secrets

## What

New hero:

> **The missing toolchain for CLI coding agents.** Run any agent on your existing subscription. Spawn parallel teams in isolated terminals. Schedule routines, drive browsers and Electron apps, and store secrets behind Touch ID — all from one CLI.

Single-line change. The TOC + all section bodies stay as-is — `[Pin versions per project]`, `[Teams]`, `[Browser]`, `[Secrets]`, `[Routines]` are still linked in order, so anyone scrolling for the older framing finds it intact.

## Related

Companion PR on the marketing site retires the matching "world's most powerful CLI agent" superlative from `app/layout.tsx` (title, meta, OG, Twitter, JSON-LD).