### PR TITLE
fix(install): strip prepack and prepare hooks from staged dev install tarball

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -101,6 +101,8 @@ node -e "
   const p = require('./package.json');
   p.version = '$DEV_VERSION';
   delete p.scripts?.postinstall;
+  delete p.scripts?.prepack;
+  delete p.scripts?.prepare;
   fs.writeFileSync('$STAGE_DIR/package.json', JSON.stringify(p, null, 2));
 "
 


### PR DESCRIPTION
## Summary

`scripts/install.sh` already deletes `postinstall` from the staged `package.json` before `npm pack`. Add `prepack` and `prepare` to that strip list.

## Why

The dev install tarball is staged in `$STAGE_DIR` without the source files that the package's `prepack`/`prepare` hooks reference (TypeScript builds, codegen, etc). Currently `install.sh` works around this by passing `--ignore-scripts` to `npm pack`, but that's a blunt instrument — it silently disables ALL pack-time hooks even ones we'd want.

Stripping just `prepack` and `prepare` from the staged `package.json` lets us drop `--ignore-scripts` later if we want, while keeping the dev tarball clean.

## Diff

\`\`\`diff
   const p = require('./package.json');
   p.version = '$DEV_VERSION';
   delete p.scripts?.postinstall;
+  delete p.scripts?.prepack;
+  delete p.scripts?.prepare;
   fs.writeFileSync('$STAGE_DIR/package.json', JSON.stringify(p, null, 2));
\`\`\`

## Test plan

- [ ] `./scripts/install.sh` exits 0 on a clean shell
- [ ] Staged `package.json` in `$STAGE_DIR` has no `prepack`/`prepare` keys under `scripts`

## Note

Cherry-picked from a stale branch (`fix/install-prepack-hook`) where the original commit landed but no PR was ever opened. Re-opened against fresh main as a clean 2-line change.