### PR TITLE
fix(routines): harden list cell rendering and add 7-day boundary tests

### DIFF
--- a/src/commands/routines.ts
+++ b/src/commands/routines.ts
@@ -21,7 +21,7 @@ import {
   readDaemonPid,
   readDaemonLog,
 } from '../lib/daemon.js';
-import { humanizeCron, humanizeNextRun, formatRepoLink } from '../lib/routines-format.js';
+import { humanizeCron, humanizeNextRun, formatRepoLink, REPO_DISPLAY_MAX } from '../lib/routines-format.js';
 import {
   listJobs as listAllJobs,
   deleteJob,
@@ -171,16 +171,16 @@ export function registerRoutinesCommands(program: Command): void {
       console.log(chalk.bold('Scheduled Jobs\n'));
 
       // OSC 8 hyperlink helper — renders as a clickable link in supporting terminals.
-      // In terminals that do not support OSC 8 the escape sequences are ignored and
-      // the label is displayed as plain text.
+      // Guarded on process.stdout.isTTY so that piped/redirected output never
+      // contains raw ESC ] 8 ;; ... BEL escape sequences.
       const link = (label: string, url: string | null): string =>
-        url ? `\x1b]8;;${url}\x07${label}\x1b]8;;\x07` : label;
+        url && process.stdout.isTTY ? `\x1b]8;;${url}\x07${label}\x1b]8;;\x07` : label;
 
       const now = new Date();
 
       const NAME_W = 24;
       const AGENT_W = 10;
-      const REPO_W = 24;
+      const REPO_W = REPO_DISPLAY_MAX;
       const SCHED_W = 22;
       const ENABLED_W = 10;
       const NEXT_W = 22;

--- a/src/lib/__tests__/routines-format.test.ts
+++ b/src/lib/__tests__/routines-format.test.ts
@@ -84,6 +84,22 @@ describe('humanizeNextRun', () => {
     const result = humanizeNextRun(date, NOW);
     expect(result).toMatch(/^Jun 28,/);
   });
+
+  // 7-day boundary: +6 days is still within the "weekday name" window (<7),
+  // +7 days crosses into the "full date" window (>=7).
+  it('+6 days (boundary) shows weekday name', () => {
+    // NOW is 2026-05-29 (Friday); +6 calendar days = 2026-06-04 (Thursday)
+    const date = new Date('2026-06-04T09:00:00Z');
+    const result = humanizeNextRun(date, NOW);
+    expect(result).toMatch(/^Thu /);
+  });
+
+  it('+7 days (boundary) shows full date', () => {
+    // NOW is 2026-05-29 (Friday); +7 calendar days = 2026-06-05 (Friday)
+    const date = new Date('2026-06-05T09:00:00Z');
+    const result = humanizeNextRun(date, NOW);
+    expect(result).toMatch(/^Jun 5,/);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -93,6 +109,13 @@ describe('humanizeNextRun', () => {
 describe('formatRepoLink', () => {
   it('undefined → dash, no href', () => {
     const r = formatRepoLink(undefined);
+    expect(r.display).toBe('-');
+    expect(r.href).toBeNull();
+  });
+
+  it('non-string number → dash, no href (never throws)', () => {
+    // YAML files with `repo: 12345` spread directly into JobConfig; formatRepoLink must not throw.
+    const r = formatRepoLink(12345 as any);
     expect(r.display).toBe('-');
     expect(r.href).toBeNull();
   });
@@ -110,9 +133,10 @@ describe('formatRepoLink', () => {
   });
 
   it('https URL → display hostname+path, href verbatim', () => {
-    const r = formatRepoLink('https://github.com/phnx-labs/agents-cli');
-    expect(r.display).toBe('github.com/phnx-labs/agents-cli');
-    expect(r.href).toBe('https://github.com/phnx-labs/agents-cli');
+    // Use a URL whose hostname+path fits within REPO_DISPLAY_MAX (24 chars).
+    const r = formatRepoLink('https://github.com/foo/bar');
+    expect(r.display).toBe('github.com/foo/bar');
+    expect(r.href).toBe('https://github.com/foo/bar');
   });
 
   it('http URL → display without scheme, href verbatim', () => {
@@ -131,5 +155,14 @@ describe('formatRepoLink', () => {
     const r = formatRepoLink('org/team/repo');
     expect(r.display).toBe('org/team/repo');
     expect(r.href).toBeNull();
+  });
+
+  it('long URL display is truncated to REPO_DISPLAY_MAX chars with ellipsis, href untruncated', () => {
+    // 'gitlab.example.com/path/to/project' is 34 chars, exceeds REPO_DISPLAY_MAX (24)
+    const longUrl = 'https://gitlab.example.com/path/to/project';
+    const r = formatRepoLink(longUrl);
+    expect(r.display.length).toBe(24);
+    expect(r.display.endsWith('…')).toBe(true);
+    expect(r.href).toBe(longUrl);
   });
 });

--- a/src/lib/routines-format.ts
+++ b/src/lib/routines-format.ts
@@ -159,40 +159,60 @@ export function humanizeNextRun(date: Date | null, now: Date, tz?: string): stri
 // ---------------------------------------------------------------------------
 
 /**
+ * Maximum display length for a repo cell. Display strings longer than this
+ * are truncated with an ellipsis so column alignment is preserved.
+ * Consumers that render the column should use this constant as the column width.
+ */
+export const REPO_DISPLAY_MAX = 24;
+
+/**
  * Parse a repo string into a display label and an optional hyperlink target.
  *
  * Rules:
- *   - undefined / empty          → display '-', href null
- *   - 'owner/name' (one slash)   → display 'owner/name', href 'https://github.com/owner/name/pulls'
- *   - 'https://...' or 'http://…' → display hostname+path, href the URL verbatim
- *   - anything else              → display raw string, href null
+ *   - null / undefined / empty / non-string → display '-', href null
+ *   - 'owner/name' (one slash)              → display 'owner/name', href 'https://github.com/owner/name/pulls'
+ *   - 'https://...' or 'http://...'         → display hostname+path, href the URL verbatim
+ *   - anything else                         → display raw string, href null
+ *
+ * The display string is truncated to REPO_DISPLAY_MAX characters (with a
+ * trailing '…') when it would otherwise exceed the column width. The href
+ * is always the full untruncated URL so hyperlinks remain functional.
+ *
+ * NEVER throws — mirrors the contract of humanizeCron.
  */
-export function formatRepoLink(repo: string | undefined): { display: string; href: string | null } {
-  if (!repo || repo.trim() === '') {
+export function formatRepoLink(repo: unknown): { display: string; href: string | null } {
+  if (repo == null || typeof repo !== 'string' || repo.trim() === '') {
     return { display: '-', href: null };
   }
 
   const trimmed = repo.trim();
+  let display: string;
+  let href: string | null;
 
   // Absolute URL
   if (trimmed.startsWith('https://') || trimmed.startsWith('http://')) {
     try {
       const url = new URL(trimmed);
-      const display = url.hostname + url.pathname.replace(/\/$/, '');
-      return { display, href: trimmed };
+      display = url.hostname + url.pathname.replace(/\/$/, '');
+      href = trimmed;
     } catch {
-      return { display: trimmed, href: null };
+      display = trimmed;
+      href = null;
     }
+  } else if (/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(trimmed)) {
+    // GitHub shorthand: owner/name (exactly one slash, no scheme, no extra slashes)
+    display = trimmed;
+    href = `https://github.com/${trimmed}/pulls`;
+  } else {
+    // Anything else: plain text, no link
+    display = trimmed;
+    href = null;
   }
 
-  // GitHub shorthand: owner/name (exactly one slash, no scheme, no extra slashes)
-  if (/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(trimmed)) {
-    return {
-      display: trimmed,
-      href: `https://github.com/${trimmed}/pulls`,
-    };
+  // Truncate display to column width; href stays untruncated.
+  if (display.length > REPO_DISPLAY_MAX) {
+    display = display.slice(0, REPO_DISPLAY_MAX - 1) + '…';
   }
 
-  // Anything else: plain text, no link
-  return { display: trimmed, href: null };
+  return { display, href };
 }


### PR DESCRIPTION
## Summary

Polish for `agents routines list`:

- Harden cell rendering in `src/lib/routines-format.ts` so misaligned columns and overflow don't break the table layout
- Add 7-day boundary tests so the humanized "X days ago" output doesn't regress at the week edge
- Small follow-up to PRs #61 and #62 that shipped the humanized list + workflow scheduling

## Stats

\`\`\`
src/commands/routines.ts                  | 10 +++---
src/lib/__tests__/routines-format.test.ts | 39 ++++++++++++++++++++--
src/lib/routines-format.ts                | 54 +++++++++++++++++++++----------
3 files changed, 78 insertions(+), 25 deletions(-)
\`\`\`

## Test plan

- [ ] `bun test src/lib/__tests__/routines-format.test.ts` passes
- [ ] `agents routines list` renders cleanly with mixed-length names, very-old/very-new dates, and missing repo fields

## Note

Cherry-picked from a stale local branch (`fix/routines-list-nits`) where the work was done but no PR was ever opened. Re-opened against fresh main.