### PR TITLE
security(ci): enforce keychain helper SHA verification at publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
         run: bun run test
 
       - name: Publish to npm
-        run: npm publish --provenance --access=public --ignore-scripts
+        run: |
+          npm run prepack
+          npm publish --provenance --access=public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Drops --ignore-scripts from publish step so prepack hook runs verify-keychain-helper.sh. Closes a supply-chain gap where a compromised npm token could ship a swapped helper binary without SHA re-verification.