### PR TITLE
security(browser): replace CDP origin wildcard with localhost allowlist

### DIFF
--- a/src/lib/browser/drivers/ssh.test.ts
+++ b/src/lib/browser/drivers/ssh.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const sshSrc = readFileSync(join(here, 'ssh.ts'), 'utf8');
+
+describe('ssh driver CDP launch args', () => {
+  it('never sets --remote-allow-origins=* (DNS-rebind / cross-origin CDP risk)', () => {
+    expect(sshSrc).not.toMatch(/--remote-allow-origins=\*/);
+  });
+
+  it('scopes --remote-allow-origins to a 127.0.0.1 URL with the forwarded port', () => {
+    expect(sshSrc).toMatch(/--remote-allow-origins=http:\/\/127\.0\.0\.1:\$\{port\}/);
+  });
+});

--- a/src/lib/browser/drivers/ssh.ts
+++ b/src/lib/browser/drivers/ssh.ts
@@ -216,7 +216,7 @@ async function ensureRemoteBrowser(
   const remoteCmd = [
     shellQuote(browserPath),
     `--remote-debugging-port=${port}`,
-    shellQuote('--remote-allow-origins=*'),
+    shellQuote(`--remote-allow-origins=http://127.0.0.1:${port}`),
     '--disable-background-timer-throttling',
     `--user-data-dir=/tmp/agents-browser-${port}`,
     '</dev/null >/dev/null 2>&1 &',


### PR DESCRIPTION
src/lib/browser/drivers/ssh.ts:219 launched remote Chrome with --remote-allow-origins=*. Any local browser tab or DNS-rebind attack could connect to the SSH-forwarded CDP port and drive the remote session. Replaced with explicit localhost allowlist scoped to the forwarded port.