### PR TITLE
security(exec): strip loader env vars when propagating to child agents

### DIFF
--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -12,6 +12,7 @@ import { parseTimeout } from './routines.js';
 import { getVersionHomePath, isVersionInstalled, resolveVersion } from './versions.js';
 import { resolveModel, buildReasoningFlags } from './models.js';
 import { emitStart, maybeRotate, createTimer, truncate } from './events.js';
+import { sanitizeProcessEnv } from './secrets/bundles.js';
 
 /** Agent execution modes controlling tool access and autonomy level. */
 export type ExecMode = 'plan' | 'edit' | 'full' | 'auto';
@@ -76,7 +77,7 @@ export function parseExecEnv(entries: string[]): Record<string, string> | undefi
  * into unrelated invocations.
  */
 export function buildExecEnv(options: ExecOptions): NodeJS.ProcessEnv {
-  const result: NodeJS.ProcessEnv = { ...process.env };
+  const result: NodeJS.ProcessEnv = { ...sanitizeProcessEnv(process.env) };
 
   // Config-dir env vars are agent-specific. When the caller is running inside
   // an agent-managed shell, process.env already carries one; spreading into a

--- a/src/lib/secrets/bundles.ts
+++ b/src/lib/secrets/bundles.ts
@@ -116,6 +116,16 @@ export function isLoaderOrInterpreterEnv(name: string): boolean {
     ].includes(upper);
 }
 
+export function sanitizeProcessEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const out: NodeJS.ProcessEnv = {};
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) continue;
+    if (isLoaderOrInterpreterEnv(k)) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
 /** Validate a bundle name against the allowed pattern. Throws on invalid input. */
 export function validateBundleName(name: string): void {
   if (!BUNDLE_NAME_PATTERN.test(name)) {

--- a/src/lib/teams/agents.ts
+++ b/src/lib/teams/agents.ts
@@ -20,6 +20,7 @@ import { setGeminiAutoUpdateDisabled, updateGeminiSettings } from '../gemini-set
 import type { AgentId } from '../types.js';
 import { getAgentsDir as getSystemAgentsDir } from '../state.js';
 import { AGENTS } from '../agents.js';
+import { sanitizeProcessEnv } from '../secrets/bundles.js';
 
 let lastMemoryWarnAt = 0;
 
@@ -1226,8 +1227,8 @@ export class AgentManager {
         cwd: agent.cwd || undefined,
         detached: true,
         env: agent.envOverrides
-          ? { ...process.env, ...agent.envOverrides }
-          : process.env,
+          ? { ...sanitizeProcessEnv(process.env), ...agent.envOverrides }
+          : sanitizeProcessEnv(process.env),
       });
 
       childProcess.unref();

--- a/tests/exec/sanitize-env.test.ts
+++ b/tests/exec/sanitize-env.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeProcessEnv } from '../../src/lib/secrets/bundles.js';
+
+describe('sanitizeProcessEnv', () => {
+  it('strips loader and interpreter env vars from a process.env-shaped input', () => {
+    const input: NodeJS.ProcessEnv = {
+      PATH: '/usr/bin',
+      HOME: '/home/u',
+      DYLD_INSERT_LIBRARIES: '/tmp/evil.dylib',
+      DYLD_LIBRARY_PATH: '/tmp',
+      LD_PRELOAD: '/tmp/evil.so',
+      NODE_OPTIONS: '--require /tmp/evil.js',
+      PYTHONPATH: '/tmp',
+      BASH_ENV: '/tmp/x',
+      MY_TOKEN: 'keep-me',
+    };
+
+    const out = sanitizeProcessEnv(input);
+
+    expect(out.DYLD_INSERT_LIBRARIES).toBeUndefined();
+    expect(out.DYLD_LIBRARY_PATH).toBeUndefined();
+    expect(out.LD_PRELOAD).toBeUndefined();
+    expect(out.NODE_OPTIONS).toBeUndefined();
+    expect(out.PYTHONPATH).toBeUndefined();
+    expect(out.BASH_ENV).toBeUndefined();
+    expect(out.PATH).toBe('/usr/bin');
+    expect(out.HOME).toBe('/home/u');
+    expect(out.MY_TOKEN).toBe('keep-me');
+  });
+
+  it('strips loader vars set on real process.env', () => {
+    const prevDyld = process.env.DYLD_INSERT_LIBRARIES;
+    const prevNode = process.env.NODE_OPTIONS;
+    process.env.DYLD_INSERT_LIBRARIES = '/tmp/evil.dylib';
+    process.env.NODE_OPTIONS = '--require /tmp/evil.js';
+    try {
+      const out = sanitizeProcessEnv();
+      expect(out.DYLD_INSERT_LIBRARIES).toBeUndefined();
+      expect(out.NODE_OPTIONS).toBeUndefined();
+    } finally {
+      if (prevDyld === undefined) delete process.env.DYLD_INSERT_LIBRARIES;
+      else process.env.DYLD_INSERT_LIBRARIES = prevDyld;
+      if (prevNode === undefined) delete process.env.NODE_OPTIONS;
+      else process.env.NODE_OPTIONS = prevNode;
+    }
+  });
+});


### PR DESCRIPTION
src/lib/secrets/bundles.ts blocks loader vars (DYLD_*, LD_*, NODE_OPTIONS) from being set via secrets bundles, but src/lib/exec.ts and src/lib/teams/agents.ts spread process.env wholesale into child agents — bypassing the protection if a parent already has those set. Routed both call sites through new sanitizeProcessEnv() helper.