### PR TITLE
security(cli): eliminate shell-true RCE from manifest-driven installs

### DIFF
--- a/src/commands/cli.ts
+++ b/src/commands/cli.ts
@@ -22,6 +22,7 @@ import {
   resolveCliManifest,
   installCli,
   describeMethod,
+  describeCheck,
   selectInstallMethod,
   isCliInstalled,
   type CliManifest,
@@ -191,7 +192,7 @@ When to use:
             console.log(chalk.gray(m.postInstall.trim().split('\n').map((l) => '  ' + l).join('\n')));
           }
         } else {
-          console.log(chalk.yellow(`  install command ran but \`${m.check}\` still fails — check the output above`));
+          console.log(chalk.yellow(`  install command ran but \`${describeCheck(m.check)}\` still fails — check the output above`));
           failures++;
         }
       }
@@ -214,7 +215,7 @@ When to use:
       console.log('  ' + chalk.gray(`file: ${manifest.path}`));
       console.log('');
       console.log(chalk.bold('  check'));
-      console.log('    ' + manifest.check);
+      console.log('    ' + describeCheck(manifest.check));
       console.log('');
       console.log(chalk.bold('  install methods'));
       for (const method of manifest.install) {

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -61,6 +61,7 @@ import {
   listCliStatus,
   installCli,
   describeMethod,
+  describeCheck,
   selectInstallMethod,
 } from '../lib/cli-resources.js';
 import {
@@ -484,7 +485,7 @@ export function registerPullCommand(program: Command): void {
                       console.log(chalk.gray(s.manifest.postInstall.trim().split('\n').map((l) => '  ' + l).join('\n')));
                     }
                   } else {
-                    console.log(chalk.yellow(`  install ran but \`${s.manifest.check}\` still fails`));
+                    console.log(chalk.yellow(`  install ran but \`${describeCheck(s.manifest.check)}\` still fails`));
                   }
                 }
               } else {

--- a/src/lib/auto-pull-worker.ts
+++ b/src/lib/auto-pull-worker.ts
@@ -23,6 +23,16 @@ import { lockFilePath, statusFilePath, type FetchStatusMarker } from './auto-pul
 
 const LOCK_TTL_MS = 5 * 60 * 1000;
 
+/**
+ * Background auto-pull of ~/.agents-system/ is off by default. When enabled it
+ * silently fast-forwards a tracked source tree that the CLI then reads as a
+ * source of skills, hooks, install manifests, and commands — anyone with push
+ * access to that upstream gets remote code execution on every user the next
+ * time they invoke a command that loads a system resource. Operators that
+ * really want the convenience can set AGENTS_AUTO_PULL=1.
+ */
+const ENABLE_AUTO_PULL = process.env.AGENTS_AUTO_PULL === '1';
+
 interface RepoTarget {
   alias: string;
   dir: string;
@@ -94,7 +104,14 @@ async function processTarget(target: RepoTarget): Promise<void> {
   if (!tryAcquireLock(target.alias)) return;
   try {
     if (target.mode === 'pull') {
-      await tryAutoPull(target.dir);
+      if (!ENABLE_AUTO_PULL) {
+        // Demote to a fetch + notify; the user still sees ahead/behind on the
+        // next foreground CLI invocation, but the source tree is never mutated
+        // by a detached worker.
+        await notifyRepo(target);
+      } else {
+        await tryAutoPull(target.dir);
+      }
     } else {
       await notifyRepo(target);
     }

--- a/src/lib/cli-resources.test.ts
+++ b/src/lib/cli-resources.test.ts
@@ -13,7 +13,7 @@ function manifest(install: InstallMethod[]): CliManifest {
   return {
     name: 'higgsfield',
     description: 'test',
-    check: 'higgsfield --version',
+    check: { kind: 'version', cmd: 'higgsfield', args: ['--version'] },
     install,
     source: 'user',
     path: '/tmp/test.yaml',
@@ -37,7 +37,7 @@ post_install: |
     const parsed = parseCliManifest(yaml, { name: 'higgsfield', source: 'user', path: '/tmp/h.yaml' });
     expect(parsed.name).toBe('higgsfield');
     expect(parsed.description).toBe('AI media CLI');
-    expect(parsed.check).toBe('higgsfield --version');
+    expect(parsed.check).toEqual({ kind: 'version', cmd: 'higgsfield', args: ['--version'] });
     expect(parsed.install).toHaveLength(3);
     expect(parsed.install[0]).toEqual({ npm: '@higgsfield/cli@latest' });
     expect(parsed.install[1]).toEqual({ brew: 'higgsfield' });
@@ -50,7 +50,7 @@ post_install: |
       'name: gh\ninstall:\n  - brew: gh\n',
       { name: 'gh', source: 'user', path: '/tmp/g.yaml' },
     );
-    expect(parsed.check).toBe('gh --version');
+    expect(parsed.check).toEqual({ kind: 'version', cmd: 'gh', args: ['--version'] });
   });
 
   it('uses the filename-derived name when manifest omits it', () => {

--- a/src/lib/cli-resources.ts
+++ b/src/lib/cli-resources.ts
@@ -7,12 +7,70 @@
  * but unlike skills/commands/hooks, CLI resources are NOT copied into per-agent
  * version homes — they install binaries onto the host PATH. The relationship is
  * "Brewfile-style": declare once in ~/.agents/cli/, install on any new machine.
+ *
+ * Security: every field that becomes a child-process argument is validated
+ * against a strict allowlist and dispatched via spawnSync with an argv array.
+ * Nothing here ever runs through a shell — manifests can come from project repos
+ * or pulled extras, so anything that would let a manifest author smuggle in
+ * `;`, `$(...)`, backticks, redirects, or pipe operators is a remote-code-
+ * execution sink.
  */
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
-import { execSync, spawnSync } from 'child_process';
+import { spawnSync } from 'child_process';
 import * as yaml from 'yaml';
 import { listResources, resolveResource } from './resources.js';
+
+// ─── Validation primitives ───────────────────────────────────────────────────
+
+/** Token allowed inside `check:` strings — letters, digits, underscore, dot, slash, dash. */
+const SAFE_CHECK_TOKEN = /^[a-zA-Z0-9_./-]+$/;
+
+/** npm package name with optional scope and optional version/tag. */
+const NPM_PACKAGE = /^(@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*(@[a-zA-Z0-9._-]+)?$/;
+
+/** Homebrew formula name (and optional tap prefix). */
+const BREW_FORMULA = /^([a-z0-9][a-z0-9_.-]*\/[a-z0-9][a-z0-9_.-]*\/)?[a-z0-9][a-z0-9_.+-]*$/;
+
+/** Path segment inside a tarball — no leading slash, no `..`, no shell metas. */
+const SAFE_PATH_SEGMENT = /^[a-zA-Z0-9_./-]+$/;
+
+function assertSafeCheckToken(tok: string): void {
+  if (!SAFE_CHECK_TOKEN.test(tok)) {
+    throw new Error(`check contains unsafe token: ${JSON.stringify(tok)}`);
+  }
+}
+
+function assertNpmPackage(name: string): void {
+  if (!NPM_PACKAGE.test(name)) {
+    throw new Error(`npm package name is not allowlisted: ${JSON.stringify(name)}`);
+  }
+}
+
+function assertBrewFormula(name: string): void {
+  if (!BREW_FORMULA.test(name)) {
+    throw new Error(`brew formula name is not allowlisted: ${JSON.stringify(name)}`);
+  }
+}
+
+function assertHttpsUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`url is not parseable: ${JSON.stringify(url)}`);
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`url must use https:// (got ${parsed.protocol}): ${JSON.stringify(url)}`);
+  }
+}
+
+function assertSafePathSegment(seg: string): void {
+  if (!SAFE_PATH_SEGMENT.test(seg) || seg.startsWith('/') || seg.split('/').includes('..')) {
+    throw new Error(`extract path is not allowlisted: ${JSON.stringify(seg)}`);
+  }
+}
 
 // ─── Schema ──────────────────────────────────────────────────────────────────
 
@@ -32,6 +90,17 @@ export interface BinarySpec {
   };
 }
 
+/**
+ * How to verify a CLI is installed. Structured so we can dispatch to spawnSync
+ * with an argv array — never through a shell.
+ *
+ * `which` — just check PATH for `cmd`.
+ * `version` — spawn `cmd` with `args` and require exit 0.
+ */
+export type CheckSpec =
+  | { kind: 'which'; cmd: string }
+  | { kind: 'version'; cmd: string; args: string[] };
+
 /** Parsed CLI manifest. */
 export interface CliManifest {
   /** Name as it appears on the command line (e.g. "higgsfield"). */
@@ -40,8 +109,8 @@ export interface CliManifest {
   description?: string;
   /** Project homepage; used in detail view + post-install messaging. */
   homepage?: string;
-  /** Command run to verify the binary is installed (default: "<name> --version"). */
-  check: string;
+  /** Structured check spec; never a raw shell command. */
+  check: CheckSpec;
   /** Install methods tried in order; first one whose tool is available is used. */
   install: InstallMethod[];
   /** Message printed after successful install — typically auth instructions. */
@@ -63,6 +132,51 @@ export interface CliManifestError {
 // ─── Parsing ─────────────────────────────────────────────────────────────────
 
 /**
+ * Parse a `check:` field into a CheckSpec. Accepts either a structured object
+ * (`{ kind: 'which'|'version', cmd, args? }`) or a legacy whitespace-separated
+ * string. String form is split on whitespace and each token is validated against
+ * SAFE_CHECK_TOKEN — manifests cannot smuggle in shell metacharacters.
+ */
+export function parseCheckSpec(raw: unknown, defaultName: string): CheckSpec {
+  if (raw == null) {
+    assertSafeCheckToken(defaultName);
+    return { kind: 'version', cmd: defaultName, args: ['--version'] };
+  }
+  if (typeof raw === 'string') {
+    const tokens = raw.trim().split(/\s+/).filter((t) => t.length > 0);
+    if (tokens.length === 0) {
+      assertSafeCheckToken(defaultName);
+      return { kind: 'version', cmd: defaultName, args: ['--version'] };
+    }
+    for (const tok of tokens) assertSafeCheckToken(tok);
+    const [cmd, ...args] = tokens;
+    return args.length === 0 ? { kind: 'which', cmd } : { kind: 'version', cmd, args };
+  }
+  if (typeof raw === 'object') {
+    const r = raw as Record<string, unknown>;
+    const kind = r.kind;
+    if (kind !== 'which' && kind !== 'version') {
+      throw new Error(`check.kind must be "which" or "version" (got ${JSON.stringify(kind)})`);
+    }
+    if (typeof r.cmd !== 'string' || !r.cmd.trim()) {
+      throw new Error('check.cmd must be a non-empty string');
+    }
+    const cmd = r.cmd.trim();
+    assertSafeCheckToken(cmd);
+    if (kind === 'which') return { kind: 'which', cmd };
+    const args = Array.isArray(r.args) ? r.args : [];
+    const safeArgs: string[] = [];
+    for (const a of args) {
+      if (typeof a !== 'string') throw new Error('check.args entries must be strings');
+      assertSafeCheckToken(a);
+      safeArgs.push(a);
+    }
+    return { kind: 'version', cmd, args: safeArgs };
+  }
+  throw new Error('check must be a string or an object with { kind, cmd, args? }');
+}
+
+/**
  * Parse a single CLI manifest from its YAML contents.
  * Returns a manifest on success; throws on schema violations so callers can
  * decide whether to surface or swallow the error per file.
@@ -77,11 +191,10 @@ export function parseCliManifest(
   }
 
   const name = typeof raw.name === 'string' && raw.name.trim() ? raw.name.trim() : opts.name;
+  assertSafeCheckToken(name);
   const description = typeof raw.description === 'string' ? raw.description : undefined;
   const homepage = typeof raw.homepage === 'string' ? raw.homepage : undefined;
-  const check = typeof raw.check === 'string' && raw.check.trim()
-    ? raw.check.trim()
-    : `${name} --version`;
+  const check = parseCheckSpec(raw.check, name);
   const postInstall = typeof raw.post_install === 'string' ? raw.post_install : undefined;
 
   if (!Array.isArray(raw.install) || raw.install.length === 0) {
@@ -99,11 +212,29 @@ export function parseCliManifest(
     }
     const key = keys[0];
     const value = e[key];
-    if (key === 'npm' || key === 'brew' || key === 'script') {
+    if (key === 'npm') {
       if (typeof value !== 'string' || !value.trim()) {
-        throw new Error(`install[${i}].${key} must be a non-empty string`);
+        throw new Error(`install[${i}].npm must be a non-empty string`);
       }
-      return { [key]: value.trim() } as InstallMethod;
+      const v = value.trim();
+      assertNpmPackage(v);
+      return { npm: v };
+    }
+    if (key === 'brew') {
+      if (typeof value !== 'string' || !value.trim()) {
+        throw new Error(`install[${i}].brew must be a non-empty string`);
+      }
+      const v = value.trim();
+      assertBrewFormula(v);
+      return { brew: v };
+    }
+    if (key === 'script') {
+      if (typeof value !== 'string' || !value.trim()) {
+        throw new Error(`install[${i}].script must be a non-empty string`);
+      }
+      const v = value.trim();
+      assertHttpsUrl(v);
+      return { script: v };
     }
     if (key === 'binary') {
       if (!value || typeof value !== 'object') {
@@ -118,10 +249,14 @@ export function parseCliManifest(
         if (typeof s.url !== 'string' || !s.url.trim()) {
           throw new Error(`install[${i}].binary.${platform}.url must be a non-empty string`);
         }
-        binary[platform] = {
-          url: s.url.trim(),
-          extract: typeof s.extract === 'string' ? s.extract : undefined,
-        };
+        const url = s.url.trim();
+        assertHttpsUrl(url);
+        let extract: string | undefined;
+        if (typeof s.extract === 'string' && s.extract.length > 0) {
+          assertSafePathSegment(s.extract);
+          extract = s.extract;
+        }
+        binary[platform] = { url, extract };
       }
       return { binary };
     }
@@ -186,25 +321,34 @@ export function resolveCliManifest(name: string, cwd?: string): CliManifest | nu
 // ─── Host detection ──────────────────────────────────────────────────────────
 
 /**
- * Return true if a command resolves on the current PATH. Uses `which` on
- * POSIX hosts; results are cached for the lifetime of the process.
+ * Return true if a command resolves on the current PATH. Uses POSIX `command -v`
+ * via spawn argv (no shell); results are cached for the lifetime of the process.
  */
 const cmdExistsCache = new Map<string, boolean>();
 export function hasCommand(cmd: string): boolean {
   if (cmdExistsCache.has(cmd)) return cmdExistsCache.get(cmd)!;
-  const result = spawnSync('command', ['-v', cmd], { shell: true, stdio: 'ignore' });
+  // `command` is a shell builtin on most POSIX shells; invoking `sh -c 'command -v X'`
+  // with X as an *argument* (not interpolated) is the safe path. `cmd` may be passed
+  // by callers that haven't validated it, so we route via argv to neutralize metas.
+  const result = spawnSync('sh', ['-c', 'command -v "$1" >/dev/null 2>&1', '_', cmd], {
+    stdio: 'ignore',
+  });
   const ok = result.status === 0;
   cmdExistsCache.set(cmd, ok);
   return ok;
 }
 
-/** Run the manifest's `check` command. Returns true when it exits 0. */
+/**
+ * Run the manifest's check. Dispatches on CheckSpec.kind — never invokes a
+ * shell, never interpolates strings into a command line.
+ */
 export function isCliInstalled(manifest: CliManifest): boolean {
-  const result = spawnSync(manifest.check, {
-    shell: true,
-    stdio: 'ignore',
-    timeout: 10_000,
-  });
+  const c = manifest.check;
+  if (c.kind === 'which') {
+    cmdExistsCache.delete(c.cmd);
+    return hasCommand(c.cmd);
+  }
+  const result = spawnSync(c.cmd, c.args, { stdio: 'ignore', timeout: 10_000 });
   return result.status === 0;
 }
 
@@ -225,6 +369,11 @@ export function selectInstallMethod(manifest: CliManifest): InstallMethod | null
     }
   }
   return null;
+}
+
+/** Render a CheckSpec back to a human-readable command string (display only). */
+export function describeCheck(check: CheckSpec): string {
+  return check.kind === 'which' ? check.cmd : `${check.cmd} ${check.args.join(' ')}`.trim();
 }
 
 /** Short description of a method for display. */
@@ -252,6 +401,113 @@ export interface InstallResult {
 }
 
 /**
+ * Display-only rendering of how a method would be run, for `--dry-run` and
+ * status output. Not used by installCli — execution goes through runInstallMethod
+ * which dispatches to spawnSync with argv arrays.
+ */
+export function buildInstallCommand(method: InstallMethod): string {
+  if ('npm' in method) return `npm install -g ${method.npm}`;
+  if ('brew' in method) return `brew install ${method.brew}`;
+  if ('script' in method) {
+    return hasCommand('curl')
+      ? `curl -fsSL ${method.script} | sh`
+      : `wget -qO- ${method.script} | sh`;
+  }
+  const key = `${process.platform}-${process.arch}`;
+  const spec = method.binary[key];
+  if (!spec) return 'binary download';
+  return spec.extract
+    ? `curl -fsSL ${spec.url} -o /tmp/agents-cli-bin.tgz && tar -xzf /tmp/agents-cli-bin.tgz -C /usr/local/bin ${spec.extract}`
+    : `curl -fsSL ${spec.url} -o /usr/local/bin/agents-cli-downloaded`;
+}
+
+/**
+ * Execute an install method via spawnSync with argv arrays. Each branch
+ * re-validates the relevant field — defense in depth, since callers may
+ * construct InstallMethod values without going through parseCliManifest
+ * (tests, future programmatic use).
+ *
+ * For `script`, the download is staged to a temp file and then exec'd as
+ * `sh <file>` so we never need a shell pipe (`curl | sh`).
+ */
+function runInstallMethod(method: InstallMethod): void {
+  if ('npm' in method) {
+    assertNpmPackage(method.npm);
+    const r = spawnSync('npm', ['install', '-g', method.npm], { stdio: 'inherit' });
+    if (r.status !== 0) {
+      throw new Error(`npm install -g ${method.npm} exited with status ${r.status ?? 'unknown'}`);
+    }
+    return;
+  }
+  if ('brew' in method) {
+    assertBrewFormula(method.brew);
+    const r = spawnSync('brew', ['install', method.brew], { stdio: 'inherit' });
+    if (r.status !== 0) {
+      throw new Error(`brew install ${method.brew} exited with status ${r.status ?? 'unknown'}`);
+    }
+    return;
+  }
+  if ('script' in method) {
+    assertHttpsUrl(method.script);
+    const tmp = path.join(os.tmpdir(), `agents-cli-install-${process.pid}-${Date.now()}.sh`);
+    try {
+      let dl;
+      if (hasCommand('curl')) {
+        dl = spawnSync('curl', ['-fsSL', method.script, '-o', tmp], { stdio: 'inherit' });
+      } else if (hasCommand('wget')) {
+        dl = spawnSync('wget', ['-q', '-O', tmp, method.script], { stdio: 'inherit' });
+      } else {
+        throw new Error('neither curl nor wget is available on PATH');
+      }
+      if (dl.status !== 0) {
+        throw new Error(`download of install script failed (status ${dl.status ?? 'unknown'})`);
+      }
+      const r = spawnSync('sh', [tmp], { stdio: 'inherit' });
+      if (r.status !== 0) {
+        throw new Error(`install script exited with status ${r.status ?? 'unknown'}`);
+      }
+    } finally {
+      try { fs.unlinkSync(tmp); } catch { /* best effort */ }
+    }
+    return;
+  }
+  if ('binary' in method) {
+    const key = `${process.platform}-${process.arch}`;
+    const spec = method.binary[key];
+    if (!spec) throw new Error(`no binary declared for ${key}`);
+    assertHttpsUrl(spec.url);
+    if (spec.extract) {
+      assertSafePathSegment(spec.extract);
+      const tmp = path.join(os.tmpdir(), `agents-cli-bin-${process.pid}-${Date.now()}.tgz`);
+      try {
+        const dl = spawnSync('curl', ['-fsSL', spec.url, '-o', tmp], { stdio: 'inherit' });
+        if (dl.status !== 0) {
+          throw new Error(`binary download failed (status ${dl.status ?? 'unknown'})`);
+        }
+        const x = spawnSync('tar', ['-xzf', tmp, '-C', '/usr/local/bin', spec.extract], {
+          stdio: 'inherit',
+        });
+        if (x.status !== 0) {
+          throw new Error(`tar extract failed (status ${x.status ?? 'unknown'})`);
+        }
+      } finally {
+        try { fs.unlinkSync(tmp); } catch { /* best effort */ }
+      }
+    } else {
+      const r = spawnSync(
+        'curl',
+        ['-fsSL', spec.url, '-o', '/usr/local/bin/agents-cli-downloaded'],
+        { stdio: 'inherit' },
+      );
+      if (r.status !== 0) {
+        throw new Error(`binary download failed (status ${r.status ?? 'unknown'})`);
+      }
+    }
+    return;
+  }
+}
+
+/**
  * Install a single CLI by running its first compatible method. Streams the
  * underlying command's output to the parent terminal so users see brew/npm
  * progress live. Verifies success by re-running `check`.
@@ -274,9 +530,8 @@ export function installCli(
     return { manifest, method, installed: false, output: `[dry-run] would run: ${describeMethod(method)}` };
   }
 
-  const cmd = buildInstallCommand(method);
   try {
-    execSync(cmd, { stdio: 'inherit' });
+    runInstallMethod(method);
   } catch (err) {
     return {
       manifest,
@@ -292,29 +547,6 @@ export function installCli(
   cmdExistsCache.delete(manifest.name);
   const installed = isCliInstalled(manifest);
   return { manifest, method, installed };
-}
-
-/**
- * Map a declarative method to a shell command. Centralized so tests and dry-run
- * surface the exact string that would execute.
- */
-export function buildInstallCommand(method: InstallMethod): string {
-  if ('npm' in method) return `npm install -g ${method.npm}`;
-  if ('brew' in method) return `brew install ${method.brew}`;
-  if ('script' in method) {
-    // Prefer curl when both are present; fall back to wget.
-    return hasCommand('curl')
-      ? `curl -fsSL ${method.script} | sh`
-      : `wget -qO- ${method.script} | sh`;
-  }
-  const key = `${process.platform}-${process.arch}`;
-  const spec = method.binary[key];
-  // The downloader is intentionally minimal — binary install is mostly used
-  // for pre-built tarballs whose extract path varies per project. We expect
-  // the manifest author to document any post-download steps in post_install.
-  return spec.extract
-    ? `curl -fsSL ${spec.url} -o /tmp/agents-cli-bin.tgz && tar -xzf /tmp/agents-cli-bin.tgz -C /usr/local/bin ${spec.extract}`
-    : `curl -fsSL ${spec.url} -o /usr/local/bin/agents-cli-downloaded`;
 }
 
 // ─── Status snapshot ─────────────────────────────────────────────────────────

--- a/tests/cli-resources/injection.test.ts
+++ b/tests/cli-resources/injection.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression test for the manifest-driven RCE in src/lib/cli-resources.ts.
+ *
+ * Pre-fix, both `isCliInstalled` (via spawnSync({shell:true}) on `manifest.check`)
+ * and `installCli` (via execSync of a built `npm install -g ${name}` string)
+ * concatenated free-form manifest text into a shell command — a malicious
+ * manifest could trivially smuggle `; touch /tmp/agents-rce-test`.
+ *
+ * Post-fix:
+ *  - parseCliManifest rejects unsafe `check:` tokens up front.
+ *  - isCliInstalled dispatches a structured CheckSpec to spawnSync with argv.
+ *  - installCli routes `npm` through spawnSync('npm', ['install','-g', name])
+ *    after re-validating the package name allowlist.
+ *
+ * Whichever sink an attacker hits, the canary file MUST NOT be created.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  parseCliManifest,
+  isCliInstalled,
+  installCli,
+  type CliManifest,
+  type CheckSpec,
+} from '../../src/lib/cli-resources.js';
+
+const CANARY = path.join(os.tmpdir(), `agents-rce-test-${process.pid}`);
+
+function readCanary(): boolean {
+  return fs.existsSync(CANARY);
+}
+
+beforeEach(() => {
+  try { fs.unlinkSync(CANARY); } catch { /* ignore */ }
+});
+afterEach(() => {
+  try { fs.unlinkSync(CANARY); } catch { /* ignore */ }
+});
+
+const PAYLOAD_CHECK = `echo a; touch ${CANARY}`;
+const PAYLOAD_NPM = `evil; touch ${CANARY}`;
+
+describe('cli-resources injection hardening', () => {
+  it('parseCliManifest rejects a shell-metachar payload in `check:`', () => {
+    const yaml = `name: evil\ncheck: "${PAYLOAD_CHECK}"\ninstall:\n  - brew: ok\n`;
+    expect(() =>
+      parseCliManifest(yaml, { name: 'evil', source: 'user', path: '/x' }),
+    ).toThrow(/unsafe token/);
+    expect(readCanary()).toBe(false);
+  });
+
+  it('parseCliManifest rejects a shell-metachar payload in `install.npm`', () => {
+    const yaml = `name: evil\ninstall:\n  - npm: "${PAYLOAD_NPM}"\n`;
+    expect(() =>
+      parseCliManifest(yaml, { name: 'evil', source: 'user', path: '/x' }),
+    ).toThrow(/not allowlisted/);
+    expect(readCanary()).toBe(false);
+  });
+
+  it('parseCliManifest rejects a non-https script URL', () => {
+    const yaml = `name: evil\ninstall:\n  - script: "http://evil.example.com/x.sh"\n`;
+    expect(() =>
+      parseCliManifest(yaml, { name: 'evil', source: 'user', path: '/x' }),
+    ).toThrow(/https/);
+    expect(readCanary()).toBe(false);
+  });
+
+  it('parseCliManifest rejects a path-traversal extract in a binary spec', () => {
+    const yaml =
+      `name: evil\ninstall:\n  - binary:\n      ${process.platform}-${process.arch}:\n        url: "https://example.com/x.tgz"\n        extract: "../../etc/passwd"\n`;
+    expect(() =>
+      parseCliManifest(yaml, { name: 'evil', source: 'user', path: '/x' }),
+    ).toThrow(/not allowlisted/);
+    expect(readCanary()).toBe(false);
+  });
+
+  it('isCliInstalled does not evaluate a shell payload when given a malicious CheckSpec directly', () => {
+    // Bypass parse-time validation by constructing the CheckSpec inline — this
+    // simulates a future programmatic caller and proves isCliInstalled's
+    // runtime dispatch never opens a shell.
+    const checkAsObj: CheckSpec = {
+      kind: 'version',
+      // spawnSync receives this as argv[0] — execve gets a literal program
+      // name with no shell interpretation, so `;` is part of the filename
+      // and the process simply fails to start.
+      cmd: `echo a; touch ${CANARY}`,
+      args: [],
+    };
+    const m: CliManifest = {
+      name: 'evil',
+      check: checkAsObj,
+      install: [{ brew: 'ok' }],
+      source: 'user',
+      path: '/x',
+    };
+    isCliInstalled(m);
+    expect(readCanary()).toBe(false);
+  });
+
+  it('installCli refuses a malicious npm package without running it', () => {
+    const m: CliManifest = {
+      name: 'evil',
+      check: { kind: 'which', cmd: 'evil' },
+      // Bypass parse and hand installCli a hostile method directly.
+      install: [{ npm: PAYLOAD_NPM }],
+      source: 'user',
+      path: '/x',
+    };
+    const result = installCli(m);
+    expect(result.installed).toBe(false);
+    expect(result.error ?? '').toMatch(/not allowlisted|No compatible install method/);
+    expect(readCanary()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`src/lib/cli-resources.ts` ran manifest fields through `spawnSync({shell:true})` and `execSync` of built command strings (`npm install -g ${method.npm}`, `manifest.check`). Combined with `src/lib/auto-pull-worker.ts` silently fast-forwarding `~/.agents-system/` in the background, anyone with push access to a trusted manifest source got remote code execution on every user the next time they hit `agents use`, `agents pull`, or any command that loaded a system resource.

This PR eliminates the sinks and gates the silent pull behind an opt-in env var.

## What changed

- `manifest.check` is now a structured `CheckSpec` (`which` or `version` with argv); legacy YAML strings are accepted but split + per-token validated against `/^[a-zA-Z0-9_./-]+$/`. `isCliInstalled` dispatches via `spawnSync` with an argv array — never through a shell.
- `hasCommand` drops `shell: true`; uses `sh -c 'command -v "$1"' _ cmd` so `cmd` is an `execve` argument, not interpolated.
- `installCli` routes through `runInstallMethod` which spawns `npm` / `brew` / `curl` / `wget` / `tar` with argv arrays and re-validates per branch:
  - npm: allowlist regex `^(@scope/)?name(@version)?$`
  - brew: allowlist regex (formula + optional tap prefix)
  - script: `assertHttpsUrl` + staged download + `sh <tmpfile>` (no `curl \| sh` pipe)
  - binary: `assertHttpsUrl` + `assertSafePathSegment` for the tarball extract path
- `buildInstallCommand` is retained as a display-only helper for `--dry-run`.
- `auto-pull-worker.ts` no longer mutates `~/.agents-system` unless `AGENTS_AUTO_PULL=1`; otherwise the system target is demoted to fetch+notify, matching how user/extra repos behave.
- `cli.ts` / `pull.ts` use a new `describeCheck()` helper for human-readable rendering of the structured check spec.

## Test plan

- [x] `bun test tests/cli-resources/injection.test.ts` — 6/6 green. Covers every sink with a `/tmp/agents-rce-test-<pid>` canary as the success oracle.
- [x] `bun test src/lib/cli-resources.test.ts` — 11/11 green. Pre-existing tests updated for the structured `check` shape; `buildInstallCommand` semantics for display unchanged.
- [x] Full `bun run test` — every failure (12 across `jobs.test.ts`, `project-resources-pipeline.test.ts`, `versions.test.ts`, `plugins.test.ts`, `models.test.ts`) reproduces on `origin/main` and depends on env state this clean worktree lacks. None of those files import anything I touched.