### PR TITLE
chore(github): structured issue templates + discussions redirect

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent_compat.yml
+++ b/.github/ISSUE_TEMPLATE/agent_compat.yml
@@ -1,0 +1,61 @@
+name: Agent compatibility issue
+description: An agent's CLI is broken under agents-cli (version detection, install path, sync surface, capability mismatch).
+labels: [bug, compat]
+body:
+  - type: dropdown
+    id: agent
+    attributes:
+      label: Affected agent
+      options:
+        - Claude Code
+        - Codex
+        - Gemini
+        - Cursor
+        - OpenCode
+        - Grok Build
+        - Copilot
+        - Amp
+        - Kiro
+        - Goose
+        - Roo Code
+        - OpenClaw
+    validations:
+      required: true
+  - type: input
+    id: agent_version
+    attributes:
+      label: Agent CLI version
+      placeholder: "claude-code 1.2.3"
+    validations:
+      required: true
+  - type: input
+    id: agents_cli_version
+    attributes:
+      label: agents-cli version
+      placeholder: "1.20.1"
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Which surface broke?
+      multiple: true
+      options:
+        - Install / version detection
+        - Memory file sync (AGENTS.md / CLAUDE.md / etc.)
+        - Commands / skills sync
+        - MCP server sync
+        - Hooks / permissions
+        - Sessions reader
+        - Cloud dispatch
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: detail
+    attributes:
+      label: What's wrong
+      description: What does `agents` produce vs. what should happen for this agent? Include any relevant `agents doctor` output.
+      render: shell
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Something in agents-cli is broken or behaving unexpectedly.
+labels: [bug]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: agents-cli version
+      description: Output of `agents --version`.
+      placeholder: "1.20.1"
+    validations:
+      required: true
+  - type: dropdown
+    id: agent
+    attributes:
+      label: Which agent CLI?
+      multiple: true
+      options:
+        - Claude Code
+        - Codex
+        - Gemini
+        - Cursor
+        - OpenCode
+        - Grok Build
+        - Copilot
+        - Amp
+        - Kiro
+        - Goose
+        - Roo Code
+        - OpenClaw
+        - Not agent-specific
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS + version
+      placeholder: "macOS 15.4 / Ubuntu 24.04 / Windows 11"
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Commands you ran, in order. Include `agents` invocations verbatim.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened
+      description: Paste full error output. `agents doctor` output helps too.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: Logs, screenshots, related issues, workarounds you tried.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussions
+    url: https://github.com/phnx-labs/agents-cli/discussions
+    about: Questions, ideas, "how do I…" — open a discussion instead of an issue.
+  - name: Security
+    url: https://github.com/phnx-labs/agents-cli/security/advisories/new
+    about: Report a vulnerability privately. Do not file public issues for security.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Propose a new capability or improvement to agents-cli.
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Concrete situation where today's behavior falls short. Skip the abstract.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should `agents` do? Example commands, flags, or output welcome.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other shapes you weighed, and why this one wins.
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - Single agent surface (e.g. Claude only)
+        - Cross-agent (touches multiple agents' configs)
+        - Cloud/dispatch
+        - Sessions/observability
+        - Browser / PTY / secrets
+        - Other
+    validations:
+      required: true


### PR DESCRIPTION
## Why

Currently \`.github/\` ships zero issue templates. Bug reports land without agent name, version, or OS — every triage starts with 3 round-trips. With 12 open issues already and discussions just enabled, this lowers the cost-of-good-issues and routes "how do I" questions away from the bug tracker.

## What

- \`bug_report.yml\` — required fields: agents-cli version, agent(s) involved, OS, repro steps, expected vs. actual.
- \`feature_request.yml\` — problem-first format, scope dropdown (single agent / cross-agent / cloud / sessions / browser / other).
- \`agent_compat.yml\` — dedicated form for "agent X is broken under agents-cli" with surface dropdown (memory sync, MCP, hooks, sessions, …).
- \`config.yml\` — disables blank issues, points to:
  - Discussions for questions / ideas
  - Security advisories for vulnerabilities (keeps private)

## Verification

All 4 YAMLs parse clean with js-yaml. Discussions confirmed enabled: \`gh api repos/phnx-labs/agents-cli --jq .has_discussions\` → \`true\`.