### PR TITLE
feat(feedback): add 'agents feedback' command for in-CLI feedback

### DIFF
--- a/src/commands/feedback.test.ts
+++ b/src/commands/feedback.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { Command } from 'commander';
+import { registerFeedbackCommand } from './feedback.js';
+
+function programWithFeedback(): Command {
+  const program = new Command();
+  program.exitOverride();
+  registerFeedbackCommand(program);
+  return program;
+}
+
+describe('agents feedback', () => {
+  it('registers a `feedback` subcommand with --bug, --idea, --question, --print', () => {
+    const program = programWithFeedback();
+    const cmd = program.commands.find((c) => c.name() === 'feedback');
+    expect(cmd).toBeDefined();
+    const optNames = cmd!.options.map((o) => o.long);
+    expect(optNames).toEqual(expect.arrayContaining(['--bug', '--idea', '--question', '--print']));
+  });
+
+  it('--print outputs a Discussion URL by default with category=q-a', () => {
+    const program = programWithFeedback();
+    const out: string[] = [];
+    const origLog = console.log;
+    console.log = (msg?: unknown) => out.push(String(msg ?? ''));
+    try {
+      program.parse(['node', 'agents', 'feedback', '--print', 'how', 'do', 'I', 'X'], { from: 'node' });
+    } finally {
+      console.log = origLog;
+    }
+    expect(out.length).toBe(1);
+    expect(out[0]).toMatch(/^https:\/\/github\.com\/phnx-labs\/agents-cli\/discussions\/new\?category=q-a&/);
+    expect(out[0]).toContain('title=how%20do%20I%20X');
+    expect(out[0]).toContain('body=');
+  });
+
+  it('--idea routes to Discussions Ideas category', () => {
+    const program = programWithFeedback();
+    const out: string[] = [];
+    const origLog = console.log;
+    console.log = (msg?: unknown) => out.push(String(msg ?? ''));
+    try {
+      program.parse(['node', 'agents', 'feedback', '--idea', '--print', 'add', 'XYZ'], { from: 'node' });
+    } finally {
+      console.log = origLog;
+    }
+    expect(out[0]).toContain('category=ideas');
+    expect(out[0]).toContain('title=add%20XYZ');
+  });
+
+  it('--bug routes to the issue tracker with bug_report template', () => {
+    const program = programWithFeedback();
+    const out: string[] = [];
+    const origLog = console.log;
+    console.log = (msg?: unknown) => out.push(String(msg ?? ''));
+    try {
+      program.parse(['node', 'agents', 'feedback', '--bug', '--print', 'crash', 'on', 'pull'], { from: 'node' });
+    } finally {
+      console.log = origLog;
+    }
+    expect(out[0]).toMatch(/issues\/new\?template=bug_report\.yml/);
+    expect(out[0]).toContain('title=crash%20on%20pull');
+  });
+
+  it('prefilled body URL-encodes version + os into the discussion body', () => {
+    const program = programWithFeedback();
+    const out: string[] = [];
+    const origLog = console.log;
+    console.log = (msg?: unknown) => out.push(String(msg ?? ''));
+    try {
+      program.parse(['node', 'agents', 'feedback', '--question', '--print', 'test'], { from: 'node' });
+    } finally {
+      console.log = origLog;
+    }
+    const url = out[0];
+    const body = decodeURIComponent(url.split('body=')[1] ?? '');
+    expect(body).toContain('agents-cli:');
+    expect(body).toContain('OS:');
+    expect(body).toContain('Node:');
+  });
+});

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -1,0 +1,100 @@
+/**
+ * `agents feedback` — frictionless, in-CLI feedback. Opens a Discussion
+ * pre-filled with version + OS + agent inventory; falls back to printing the
+ * URL when no browser is available.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { arch, platform, release } from 'node:os';
+import { createRequire } from 'node:module';
+import type { Command } from 'commander';
+import chalk from 'chalk';
+
+const REPO = 'phnx-labs/agents-cli';
+const DISCUSSION_BASE = `https://github.com/${REPO}/discussions/new`;
+const ISSUE_BASE = `https://github.com/${REPO}/issues/new`;
+
+type Kind = 'bug' | 'idea' | 'question';
+
+function readCliVersion(): string {
+  try {
+    const require = createRequire(import.meta.url);
+    const pkg = require('../../package.json') as { version?: string };
+    return pkg.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function openInBrowser(url: string): boolean {
+  const openers: Array<[string, string[]]> =
+    process.platform === 'darwin'
+      ? [['open', [url]]]
+      : process.platform === 'win32'
+        ? [['cmd', ['/c', 'start', '""', url]]]
+        : [
+            ['xdg-open', [url]],
+            ['gnome-open', [url]]
+          ];
+  for (const [cmd, args] of openers) {
+    const r = spawnSync(cmd, args, { stdio: 'ignore' });
+    if (r.status === 0) return true;
+  }
+  return false;
+}
+
+function buildPrefill(kind: Kind, summary: string): { url: string; body: string } {
+  const version = readCliVersion();
+  const os = `${platform()} ${release()} (${arch()})`;
+  const node = process.version;
+
+  const body = [
+    summary.trim() ? `${summary.trim()}\n` : '<!-- describe what you ran into / what you want -->\n',
+    '---',
+    '',
+    '**Environment**',
+    '',
+    `- agents-cli: \`${version}\``,
+    `- OS: \`${os}\``,
+    `- Node: \`${node}\``,
+    '',
+    '<!-- For bugs: include the exact command you ran and the full output. -->',
+    '<!-- For ideas: include a concrete use case. -->'
+  ].join('\n');
+
+  if (kind === 'bug') {
+    const url = `${ISSUE_BASE}?template=bug_report.yml&title=${encodeURIComponent(summary || 'Bug: ')}`;
+    return { url, body };
+  }
+  const category = kind === 'idea' ? 'ideas' : 'q-a';
+  const url = `${DISCUSSION_BASE}?category=${category}&title=${encodeURIComponent(summary || '')}&body=${encodeURIComponent(body)}`;
+  return { url, body };
+}
+
+export function registerFeedbackCommand(program: Command): void {
+  program
+    .command('feedback [summary...]')
+    .description('Open a pre-filled feedback Discussion or bug report')
+    .option('-b, --bug', 'File as a bug report (opens issue tracker)')
+    .option('-i, --idea', 'File as a feature idea (Discussions → Ideas)')
+    .option('-q, --question', 'Ask a question (Discussions → Q&A)')
+    .option('--print', 'Print the URL instead of opening it')
+    .action((summary: string[], opts: { bug?: boolean; idea?: boolean; question?: boolean; print?: boolean }) => {
+      const kind: Kind = opts.bug ? 'bug' : opts.idea ? 'idea' : 'question';
+      const summaryText = (summary ?? []).join(' ').trim();
+      const { url } = buildPrefill(kind, summaryText);
+
+      if (opts.print) {
+        console.log(url);
+        return;
+      }
+
+      const opened = openInBrowser(url);
+      if (opened) {
+        console.log(chalk.dim(`Opened ${kind} form in your browser:\n  ${url}`));
+      } else {
+        console.log(chalk.yellow('Could not auto-open a browser. Paste this URL:'));
+        console.log(`  ${url}`);
+      }
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ import { registerPullCommand } from './commands/pull.js';
 import { registerRepoCommands } from './commands/repo.js';
 import { registerSetupCommand, runSetup } from './commands/setup.js';
 import { registerStatusCommand } from './commands/status.js';
+import { registerFeedbackCommand } from './commands/feedback.js';
 import { registerViewCommand } from './commands/view.js';
 import { registerCommandsCommands } from './commands/commands.js';
 import { registerHooksCommands } from './commands/hooks.js';
@@ -552,6 +553,7 @@ async function maybeBootstrapShimIntegration(requestedCommand: string | undefine
 // Register all commands
 registerViewCommand(program);
 registerStatusCommand(program);
+registerFeedbackCommand(program);
 registerCommandsCommands(program);
 registerHooksCommands(program);
 registerSkillsCommands(program);


### PR DESCRIPTION
## Why

Today there's no in-CLI surface for users to file feedback. They have to find the repo, pick between Issues and Discussions, write boilerplate (version, OS, Node), and figure out which template. Every step is friction. `agents feedback "<summary>"` collapses that to one command.

## What

New command:

\`\`\`
agents feedback [summary...]
  -b, --bug       File as a bug report (opens issue tracker, bug_report.yml template)
  -i, --idea      Feature idea (Discussions → Ideas)
  -q, --question  Question (Discussions → Q&A) — default
  --print         Print the URL instead of opening it
\`\`\`

Pre-fills:

- Title from \`<summary>\` argv
- Body with \`agents-cli\` version + OS string + Node version + section hints
- Auto-opens via \`open\` (macOS) / \`xdg-open\` (Linux) / \`cmd start\` (Windows); falls back to printing the URL when no opener works

## Examples

\`\`\`
\$ agents feedback "how do I pin Claude" --question
Opened question form in your browser:
  https://github.com/phnx-labs/agents-cli/discussions/new?category=q-a&title=how%20do%20I%20pin%20Claude&body=...

\$ agents feedback --bug "agents pull silently skips"
# → opens https://github.com/phnx-labs/agents-cli/issues/new?template=bug_report.yml&title=agents%20pull%20silently%20skips
\`\`\`

## Verification

- \`bunx tsc --noEmit\` clean
- \`bun run test src/commands/feedback.test.ts\` → 5/5 pass (covers command registration, URL shape per kind, body env-var encoding)
- E2E smoke against the built binary: \`node dist/index.js feedback --print [...]\` round-trips correctly for all three kinds

## Depends on

- #113 (issue templates) — \`--bug\` mode references \`bug_report.yml\`. Order: #113 first, then this. If #113 is delayed, \`--bug\` still opens the issue form, just without auto-applying the template.
- Discussions categories \`q-a\` and \`ideas\` exist on the repo (just enabled).

## Followups (not in this PR)

- README snippet showing the command
- Telemetry consent prompt — separate decision