### PR TITLE
feat(demo): add 1.5s logo intro + brand identity block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,17 @@
+## Brand identity (read this first)
+
+**`agents-cli` is a Phoenix Labs OSS product (MIT-licensed). It is NOT part of the Rush brand.** Phoenix Horizon, Inc. owns several brands; agents-cli sits in the OSS lane, Rush sits in the consumer-product lane. Different audiences, different voice, different visual language.
+
+When working on this repo or its sibling `agent-cli-web` landing:
+
+- **Do NOT apply Rush brand styling** (gold sheen, cream paper, falcon mark, Cormorant Garamond serif, "Interface for the future" voice). Rush brand assets live in `~/.agents/plugins/rush/` — those are tools, not a brand to import.
+- **Do NOT write to `~/Rush/Brand/`** for agents-cli renders, screenshots, or videos. The Rush brand surface is for Rush product only. agents-cli assets go under `~/Phoenix/agents-cli/` (the `~/Rush/` prefix is the Google Drive sync root, not a brand) or the repo's own `assets/` / `demo/out/`.
+- **Visual language is terminal-coded** — near-black `#0a0a0a` bg, lime accent `#a3e635`, JetBrains Mono for wordmark + code, Inter for prose. See `assets/`, `demo/src/`, and `website/`.
+- **Voice is direct-developer** — name the verb, name the artifact, no marketing claims. Closer to a `man` page than a landing pitch.
+- **The composer + animator skills under `~/.agents/plugins/rush/skills/`** can be USED for agents-cli work, but ignore their §Brand voice sections — those apply only to Rush content. Override the destination dir with `~/Phoenix/agents-cli/launches/` and use this repo's color/type tokens, not Rush's.
+
+If any agent (Claude / Codex / Gemini / Cursor) starts pulling in Rush styling, Rush directory paths, or Rush voice for this project, stop and reread this block.
+
 ## Agent Spawning
 
 When asked to spawn agents or perform multi-agent tasks, use the Swarm MCP extension:

--- a/demo/src/AgentsDemo.tsx
+++ b/demo/src/AgentsDemo.tsx
@@ -104,6 +104,85 @@ const CaptionOverlay: React.FC<{
   );
 };
 
+// Intro: 1.5s logo + wordmark fade-in. Lighter cousin of Finale — no CTA,
+// no footer. Just the agents cover image + green glow + brief wordmark.
+const Intro: React.FC<{ frameInScene: number; fps: number }> = ({
+  frameInScene,
+  fps,
+}) => {
+  const logoSpring = spring({
+    frame: frameInScene,
+    fps,
+    config: { damping: 14, stiffness: 110, mass: 0.7 },
+  });
+  const wordFade = interpolate(frameInScene, [12, 28], [0, 1], {
+    extrapolateRight: "clamp",
+    extrapolateLeft: "clamp",
+  });
+  const fadeOut = interpolate(frameInScene, [36, 45], [1, 0], {
+    extrapolateRight: "clamp",
+    extrapolateLeft: "clamp",
+  });
+  const glowPulse =
+    0.5 + 0.5 * Math.sin((frameInScene / fps) * 2 * Math.PI * 1.2);
+
+  return (
+    <AbsoluteFill
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 18,
+        opacity: fadeOut,
+      }}
+    >
+      <div
+        style={{
+          width: 240,
+          height: 240,
+          position: "relative",
+          transform: `scale(${logoSpring}) translateY(${(1 - logoSpring) * 16}px)`,
+          opacity: logoSpring,
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            inset: -36,
+            background: `radial-gradient(circle, rgba(163,230,53,${0.08 + glowPulse * 0.08}) 0%, transparent 65%)`,
+            filter: "blur(18px)",
+          }}
+        />
+        <Img
+          src={staticFile("agents-logo.png")}
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "contain",
+            position: "relative",
+            filter: "drop-shadow(0 16px 32px rgba(0,0,0,0.55))",
+          }}
+        />
+      </div>
+      <div
+        style={{
+          opacity: wordFade,
+          transform: `translateY(${(1 - wordFade) * 10}px)`,
+          fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+          fontSize: 64,
+          fontWeight: 500,
+          letterSpacing: "-0.04em",
+          color: "#f5f5f5",
+          marginTop: 4,
+        }}
+      >
+        agents
+      </div>
+    </AbsoluteFill>
+  );
+};
+
 // Finale: agents 'a' mark + wordmark + CTA.
 const Finale: React.FC<{ frameInScene: number; fps: number }> = ({
   frameInScene,
@@ -270,6 +349,7 @@ export const AgentsDemo: React.FC = () => {
   const scene = SCENES[currentSceneIdx];
   const frameInScene = frame - sceneStartFrame;
   const isFinale = scene.id === "finale";
+  const isIntro = scene.id === "intro";
 
   const fadeIn = spring({
     frame: frameInScene,
@@ -298,7 +378,9 @@ export const AgentsDemo: React.FC = () => {
         }}
       />
 
-      {isFinale ? (
+      {isIntro ? (
+        <Intro frameInScene={frameInScene} fps={fps} />
+      ) : isFinale ? (
         <Finale frameInScene={frameInScene} fps={fps} />
       ) : (
         <>

--- a/demo/src/scenes.ts
+++ b/demo/src/scenes.ts
@@ -29,6 +29,16 @@ const C = '#22d3ee';  // cyan
 const R = '#f87171';  // red
 
 export const SCENES: Scene[] = [
+  // ── ACT 0: COVER ──
+  // 1.5s logo+wordmark intro. No terminal lines — rendered by AgentsDemo's
+  // isIntro branch (see AgentsDemo.tsx). Lands inside the music's `enter`
+  // section (0-4s) for the agent-cli-neon-* score variants.
+  {
+    id: 'intro',
+    title: 'agents',
+    lines: [],
+    durationFrames: 45, // 1.5s @ 30fps
+  },
   // ── ACT 1: INSTALL + VERSION SWITCH ──
   {
     id: 'install',


### PR DESCRIPTION
## Summary
- Adds a 1.5s logo-fade-in **intro scene** at the head of the demo composition. Springs in `agents-logo.png` with the lime `#a3e635` glow pulse (matching Finale styling), wordmark fades in at frame 12, fades out into the `INSTALL` terminal scene at frame 36-45. Net new total: 47.2s (was 45.7s).
- Adds a **Brand identity** block at the top of \`AGENTS.md\` clarifying that agents-cli is a Phoenix Labs OSS product, not Rush — terminal-coded visual language, direct-developer voice, render destinations under \`~/Phoenix/<product>/\` not \`~/Rush/Brand/\`. Anchors against any agent (Claude / Codex / Gemini) accidentally pulling in Rush brand styling.

## Test plan
- [ ] \`cd demo && bunx remotion render AgentsDemo /tmp/out.mp4 --scale=2\` produces 4K, 47.2s, intro logo visible 0-1.5s
- [ ] The intro fade-out at frame 36-45 cross-fades cleanly into the INSTALL terminal scene
- [ ] No regressions on the existing 11 feature scenes