### PR TITLE
test(jobs): un-break 3 stale assertions on main

### DIFF
--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -77,9 +77,9 @@ describe('validateJob', () => {
     expect(errors).toContain('schedule (cron expression) is required');
   });
 
-  it('requires agent', () => {
+  it('requires agent or workflow', () => {
     const errors = validateJob({ name: 'test', schedule: '* * * * *', prompt: 'hi' });
-    expect(errors).toContain('agent is required');
+    expect(errors).toContain('exactly one of agent or workflow is required');
   });
 
   it('requires prompt', () => {
@@ -109,7 +109,7 @@ describe('validateJob', () => {
 
   it('rejects invalid timeout', () => {
     const errors = validateJob({ ...makeConfig(), timeout: 'forever' });
-    expect(errors).toContain('timeout must be like 30m, 2h, 1h30m');
+    expect(errors).toContain('timeout must be like 10m, 2h, 3d, 1w (max 1w)');
   });
 
   it('accepts all valid job agents', () => {
@@ -236,7 +236,7 @@ describe('job CRUD', () => {
     const job = readJob(`${PREFIX}crud-defaults`)!;
     expect(job.mode).toBe('plan');
     expect(job.effort).toBe('auto');
-    expect(job.timeout).toBe('30m');
+    expect(job.timeout).toBe('10m');
     expect(job.enabled).toBe(true);
   });
 


### PR DESCRIPTION
## Why

\`tests/jobs.test.ts\` has had 3 failing assertions on \`main\` since [\`dd265b06 feat(routines): default 10m / max 1w timeouts + workflow scheduling\`](https://github.com/phnx-labs/agents-cli/commit/dd265b06) — the implementation changed but the tests were not updated. CI fails on every PR for these pre-existing reasons; merging this clears the noise.

## What changed (test only — no runtime behavior change)

| Test | Old expectation | New expectation |
|---|---|---|
| \`requires agent\` (renamed → \`requires agent or workflow\`) | \`'agent is required'\` | \`'exactly one of agent or workflow is required'\` |
| \`rejects invalid timeout\` | \`'timeout must be like 30m, 2h, 1h30m'\` | \`'timeout must be like 10m, 2h, 3d, 1w (max 1w)'\` |
| \`applies defaults for omitted fields\` | \`timeout === '30m'\` | \`timeout === '10m'\` |

All three new expectations were already in \`src/lib/routines.ts\` (lines 64, 169, 191). The tests were the stale party.

## Verification

\`\`\`
\$ bun run test tests/jobs.test.ts
 Test Files  1 passed (1)
 Tests       42 passed (42)
\`\`\`

## Not in scope

Other pre-existing CI failures on main (not addressed here, need real investigation):

- \`tests/versions.test.ts > prefers project commands over user commands\` — looks like project>user resolution may have regressed
- \`tests/project-resources-pipeline.test.ts > orphan-sweep\` (2 tests) — same area
- \`src/lib/plugins.test.ts > registers the marketplace in known_marketplaces.json\`
- \`tests/browser/*\` — \`Cannot find package 'playwright'\` (CI env, not code)
- \`src/lib/__tests__/pty-server.test.ts\` — possibly flaky