### PR TITLE
fix(copilot): user-scoped MCP path uses mcp-config.json

### DIFF
--- a/src/lib/__tests__/capabilities.test.ts
+++ b/src/lib/__tests__/capabilities.test.ts
@@ -102,6 +102,7 @@ describe('capableAgents()', () => {
     const agents = capableAgents('hooks');
     expect(agents).not.toContain('cursor');
     expect(agents).not.toContain('opencode');
+    expect(agents).not.toContain('copilot');
     expect(agents).not.toContain('amp');
   });
 });

--- a/src/lib/__tests__/mcp-paths.test.ts
+++ b/src/lib/__tests__/mcp-paths.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  getUserMcpConfigPath,
+  getMcpConfigPathForHome,
+  listInstalledMcpsWithScope,
+} from '../agents.js';
+
+describe('getUserMcpConfigPath copilot', () => {
+  it('returns mcp-config.json for copilot (not settings.json)', () => {
+    const p = getUserMcpConfigPath('copilot');
+    expect(path.basename(p)).toBe('mcp-config.json');
+    expect(p).toContain('.copilot');
+    expect(path.basename(p)).not.toBe('settings.json');
+  });
+});
+
+describe('getMcpConfigPathForHome copilot', () => {
+  it('points at <home>/.copilot/mcp-config.json', () => {
+    const home = '/tmp/fake-home';
+    const p = getMcpConfigPathForHome('copilot', home);
+    expect(p).toBe(path.join(home, '.copilot', 'mcp-config.json'));
+  });
+});
+
+describe('listInstalledMcpsWithScope copilot — round-trip via real fixture', () => {
+  it('reads user-scoped MCPs from <home>/.copilot/mcp-config.json', () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-mcp-'));
+    const tempCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-cwd-'));
+    try {
+      const copilotDir = path.join(tempHome, '.copilot');
+      fs.mkdirSync(copilotDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(copilotDir, 'mcp-config.json'),
+        JSON.stringify({
+          mcpServers: {
+            'demo-server': {
+              command: 'npx',
+              args: ['-y', 'demo-mcp@1.2.3'],
+            },
+          },
+        }),
+        'utf-8'
+      );
+
+      const mcps = listInstalledMcpsWithScope('copilot', tempCwd, { home: tempHome });
+      const userMcps = mcps.filter((m) => m.scope === 'user');
+
+      expect(userMcps).toHaveLength(1);
+      expect(userMcps[0]).toMatchObject({
+        name: 'demo-server',
+        scope: 'user',
+      });
+      expect(userMcps[0].command).toContain('npx');
+      expect(userMcps[0].command).toContain('demo-mcp@1.2.3');
+    } finally {
+      fs.rmSync(tempHome, { recursive: true, force: true });
+      fs.rmSync(tempCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('returns empty when only the wrong filename exists (settings.json regression guard)', () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-mcp-'));
+    const tempCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-cwd-'));
+    try {
+      const copilotDir = path.join(tempHome, '.copilot');
+      fs.mkdirSync(copilotDir, { recursive: true });
+      // Pre-fix behavior wrote/read here. Make sure we don't read this anymore.
+      fs.writeFileSync(
+        path.join(copilotDir, 'settings.json'),
+        JSON.stringify({
+          mcpServers: {
+            'wrong-file-server': { command: 'echo' },
+          },
+        }),
+        'utf-8'
+      );
+
+      const mcps = listInstalledMcpsWithScope('copilot', tempCwd, { home: tempHome });
+      expect(mcps.find((m) => m.name === 'wrong-file-server')).toBeUndefined();
+    } finally {
+      fs.rmSync(tempHome, { recursive: true, force: true });
+      fs.rmSync(tempCwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -1362,7 +1362,7 @@ function parseMcpFromOpenCodeConfig(configPath: string): Record<string, McpConfi
 /**
  * Get user-scoped MCP config path for an agent.
  */
-function getUserMcpConfigPath(agentId: AgentId): string {
+export function getUserMcpConfigPath(agentId: AgentId): string {
   const agent = AGENTS[agentId];
 
   switch (agentId) {
@@ -1381,6 +1381,9 @@ function getUserMcpConfigPath(agentId: AgentId): string {
     case 'openclaw':
       // OpenClaw uses openclaw.json
       return path.join(agent.configDir, 'openclaw.json');
+    case 'copilot':
+      // GitHub Copilot CLI uses mcp-config.json (matches versioned + project paths)
+      return path.join(agent.configDir, 'mcp-config.json');
     case 'antigravity':
       // agy uses mcp_config.json inside its nested config dir (~/.gemini/antigravity-cli/)
       return path.join(agent.configDir, 'mcp_config.json');


### PR DESCRIPTION
## Summary

- `getUserMcpConfigPath` (private, `src/lib/agents.ts:1365`) fell through to the `default:` branch and returned `~/.copilot/settings.json`. The matching helpers `getMcpConfigPathForHome` (line 1411) and `getProjectMcpConfigPath` (line 1448) already used `mcp-config.json` for Copilot, so this was an inconsistency.
- Net effect: `listInstalledMcpsWithScope('copilot', cwd)` returned no user-scoped servers for any Copilot install not under a version-managed home (e.g., user-installed `@github/copilot` without `.agents-version` pinning).
- Fix: add `case 'copilot':` returning `path.join(agent.configDir, 'mcp-config.json')`, mirroring the other two helpers.

## Changes

- `src/lib/agents.ts` — add the missing `case 'copilot':` in `getUserMcpConfigPath`. Also export the function so the regression test can assert the path directly (only call site is internal; export is non-breaking).
- `src/lib/__tests__/mcp-paths.test.ts` — new test file:
  - Asserts `getUserMcpConfigPath('copilot')` resolves to `mcp-config.json`, not `settings.json`.
  - Round-trips a fixture through `listInstalledMcpsWithScope` with `{ home: tempHome }` to prove a real `mcp-config.json` is read.
  - Regression guard: a `settings.json` with servers should NOT be picked up.
- `src/lib/__tests__/capabilities.test.ts` — fill in the missing `expect(agents).not.toContain('copilot')` assertion. The test title already advertised it.

## Test plan

- [x] `bun test src/lib/__tests__/mcp-paths.test.ts src/lib/__tests__/capabilities.test.ts` — 23 passing, 0 failing.
- [x] Full suite: pre-existing failures reproduce on `main` (models catalog needs installed agents on disk, browser tests, etc.) — none touch `getUserMcpConfigPath`, `copilot`, or `mcp-config`. Confirmed by running the same failing files on a clean main checkout.
- [x] `bun run build` — tsc passes.
- [x] End-to-end via built `dist/`: `node -e "require('./dist/lib/agents.js').getUserMcpConfigPath('copilot')"` returns `/Users/muqsit/.copilot/mcp-config.json`.