### PR TITLE
feat(install): sniff every resource type in install gh: + add mcp add gh: form

### DIFF
--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -27,7 +27,13 @@ import {
 } from '../lib/agents.js';
 import type { AgentId, McpServerConfig } from '../lib/types.js';
 import { readManifest, writeManifest, createDefaultManifest } from '../lib/manifest.js';
-import { listMcpServerConfigs, type InstalledMcpServer } from '../lib/mcp.js';
+import {
+  listMcpServerConfigs,
+  discoverMcpConfigsFromRepo,
+  installMcpConfigCentrally,
+  type InstalledMcpServer,
+} from '../lib/mcp.js';
+import { cloneRepo } from '../lib/git.js';
 import { getMcpDir } from '../lib/state.js';
 import {
   getEffectiveHome,
@@ -37,9 +43,11 @@ import {
   resolveInstalledAgentTargets,
   resolveConfiguredAgentTargets,
   resolveVersionAlias,
+  resolveAgentVersionTargets,
+  syncResourcesToVersion,
 } from '../lib/versions.js';
 import { getUserAgentsDir } from '../lib/state.js';
-import { isPromptCancelled, isInteractiveTerminal, requireInteractiveSelection, promptRemovalTargets, type RemovalTarget } from './utils.js';
+import { isPromptCancelled, isInteractiveTerminal, requireInteractiveSelection, promptRemovalTargets, parseCommaSeparatedList, type RemovalTarget } from './utils.js';
 import {
   showResourceList,
   buildTargetsSection,
@@ -203,6 +211,7 @@ When to use:
     .option('-a, --agents <list>', 'Targets: claude, codex@0.116.0', MCP_CAPABLE_AGENTS.join(','))
     .option('-s, --scope <scope>', 'user (global) or project (repo-specific)', 'user')
     .option('-t, --transport <type>', 'stdio (default) or http', 'stdio')
+    .option('--names <list>', 'When source is a repo: MCP server names to install (comma-separated)')
     .option('-H, --header <header>', 'HTTP header as name:value (repeatable)', (val, acc: string[]) => {
       acc.push(val);
       return acc;
@@ -217,8 +226,23 @@ Examples:
 
   # Add to manifest only (register later)
   agents mcp add db-server -- uvx postgres-mcp
+
+  # Install all MCP server configs from a repo's mcp/*.yaml
+  agents mcp add gh:user/repo --agents claude@all
+
+  # Install specific servers by name
+  agents mcp add gh:phnx-labs/.agents-system --names notion,figma --agents claude
 `)
     .action(async (name: string, commandOrUrl: string[], options) => {
+      // Repo-source form: `agents mcp add gh:user/repo [--names a,b] [--agents …]`
+      // Mirrors `agents skills add gh:…`. Discovers <repoPath>/mcp/*.yaml,
+      // copies to ~/.agents/mcp/, and syncs to selected agent versions.
+      const isRepoSource = /^(gh:|git:|ssh:|https?:\/\/)/.test(name);
+      if (isRepoSource && commandOrUrl.length === 0) {
+        await installMcpsFromRepoSource(name, options);
+        return;
+      }
+
       // Registry resolution: if the user just typed `agents mcp add <name>`,
       // try looking up `<name>` in any configured MCP registry (by default the
       // official MCP Registry at registry.modelcontextprotocol.io) and derive
@@ -611,6 +635,90 @@ Examples:
         }
       }
     });
+}
+
+async function installMcpsFromRepoSource(
+  source: string,
+  options: { names?: string; agents?: string }
+): Promise<void> {
+  const spinner = ora('Cloning repository...').start();
+  let localPath: string;
+  try {
+    const cloneResult = await cloneRepo(source);
+    localPath = cloneResult.localPath;
+  } catch (err) {
+    spinner.fail(`Failed to clone: ${(err as Error).message}`);
+    process.exit(1);
+  }
+  spinner.succeed('Repository cloned');
+
+  let discovered = discoverMcpConfigsFromRepo(localPath);
+  if (discovered.length === 0) {
+    console.log(chalk.yellow('No MCP server configs found (looking for mcp/*.yaml)'));
+    return;
+  }
+
+  const requestedNames = parseCommaSeparatedList(options.names);
+  if (requestedNames.length > 0) {
+    const discoveredNames = new Set(discovered.map((s) => s.name));
+    const missing = requestedNames.filter((n) => !discoveredNames.has(n));
+    if (missing.length > 0) {
+      console.log(chalk.red(`\nMCP server(s) not found in source: ${missing.join(', ')}`));
+      console.log(chalk.gray(`Available: ${[...discoveredNames].join(', ')}`));
+      process.exit(1);
+    }
+    discovered = discovered.filter((s) => requestedNames.includes(s.name));
+  }
+
+  console.log(chalk.bold(`\nFound ${discovered.length} MCP server config(s):`));
+  for (const s of discovered) {
+    const summary = s.config.transport === 'stdio'
+      ? `${s.config.command}${s.config.args?.length ? ' ' + s.config.args.join(' ') : ''}`
+      : s.config.url ?? '';
+    console.log(`  ${chalk.cyan(s.name)}: ${chalk.gray(summary)}`);
+  }
+
+  const installSpinner = ora('Installing MCP configs to ~/.agents/mcp/...').start();
+  let installed = 0;
+  for (const s of discovered) {
+    const result = installMcpConfigCentrally(s.path);
+    if (result.success) {
+      installed++;
+    } else {
+      installSpinner.stop();
+      console.log(chalk.red(`  Failed to install ${s.name}: ${result.error}`));
+      installSpinner.start();
+    }
+  }
+  installSpinner.succeed(`Installed ${installed} MCP config(s) to ~/.agents/mcp/`);
+
+  // Agent/version selection — same default as the non-repo form: every
+  // MCP-capable agent. resolveAgentVersionTargets is lenient with agents
+  // that have no installed versions.
+  const agentsValue = options.agents ?? MCP_CAPABLE_AGENTS.join(',');
+  let targets: ReturnType<typeof resolveAgentVersionTargets>;
+  try {
+    targets = resolveAgentVersionTargets(agentsValue, MCP_CAPABLE_AGENTS);
+  } catch (err) {
+    console.log(chalk.red((err as Error).message));
+    process.exit(1);
+  }
+
+  if (targets.versionSelections.size === 0) {
+    console.log(chalk.gray('\nStored centrally; no agent versions selected for sync.'));
+    return;
+  }
+
+  const syncSpinner = ora('Syncing to agent versions...').start();
+  const mcpNames = discovered.map((s) => s.name);
+  let synced = 0;
+  for (const [agentId, versions] of targets.versionSelections) {
+    for (const version of versions) {
+      const result = syncResourcesToVersion(agentId, version, { mcp: mcpNames });
+      if (result.mcp.length > 0) synced++;
+    }
+  }
+  syncSpinner.succeed(`Synced MCP configs to ${synced} agent version(s).`);
 }
 
 interface McpTargetPair {

--- a/src/commands/packages.ts
+++ b/src/commands/packages.ts
@@ -46,6 +46,18 @@ import {
   installHooksCentrally,
 } from '../lib/hooks.js';
 import {
+  discoverWorkflowsFromRepo,
+  installWorkflowCentrally,
+} from '../lib/workflows.js';
+import {
+  discoverSubagentsFromRepo,
+  installSubagentCentrally,
+} from '../lib/subagents.js';
+import {
+  discoverPermissionsFromRepo,
+  installPermissionSet,
+} from '../lib/permissions.js';
+import {
   listInstalledVersions,
   resolveInstalledAgentTargets,
   resolveConfiguredAgentTargets,
@@ -54,11 +66,17 @@ import {
 import {
   isInteractiveTerminal,
   isPromptCancelled,
+  parseCommaSeparatedList,
   requireDestructiveArg,
   requireInteractiveSelection,
 } from './utils.js';
 import { itemPicker } from '../lib/picker.js';
-import { registerMcpCommandToTargets, type McpCommandSpec } from '../lib/mcp.js';
+import {
+  registerMcpCommandToTargets,
+  discoverMcpConfigsFromRepo,
+  installMcpConfigCentrally,
+  type McpCommandSpec,
+} from '../lib/mcp.js';
 
 export function buildMcpPackageCommand(pkg: McpPackage): McpCommandSpec {
   const packageName = pkg.name || pkg.registry_name;
@@ -405,6 +423,14 @@ When to use:
     .command('install <identifier>')
     .description('Install a package by registry name (mcp:notion), GitHub URL (gh:user/repo), or skill identifier')
     .option('-a, --agents <list>', 'Targets: claude, codex@0.116.0, or gemini@default')
+    .option(
+      '--types <list>',
+      'When source is a repo: comma-separated resource types to install (skills,workflows,commands,hooks,permissions,subagents,mcp)'
+    )
+    .option(
+      '--names <list>',
+      'When source is a repo: comma-separated resource names within the selected types'
+    )
     .addHelpText('after', `
 Install resolves the package type (MCP server, skill, command, hook) and installs to the specified agents. Packages can come from registries (mcp:, skill:), GitHub (gh:user/repo), or direct URLs.
 
@@ -417,6 +443,12 @@ Examples:
 
   # Install using GitHub shorthand
   agents install gh:user/repo --agents claude@2.1.112
+
+  # Install only specific resource types from a multi-resource repo
+  agents install gh:phnx-labs/.agents-system --types skills,workflows --agents claude@all
+
+  # Install specific resources by name
+  agents install gh:phnx-labs/.agents-system --types skills --names animator,composer --agents claude@all
 
   # Install to all installed agents (uses defaults or prompts)
   agents install mcp:postgres
@@ -511,29 +543,83 @@ When to use:
 
           console.log(chalk.green('\nMCP server installed.'));
         } else if (resolved.type === 'git' || resolved.type === 'skill') {
-          // Install from git source (skills/commands/hooks)
+          // Install from git source: sniff every resource type the repo
+          // contains. Optional --types narrows which kinds get installed;
+          // --names narrows which specific resources within those kinds.
           console.log(chalk.bold(`\nInstalling from ${resolved.source}`));
 
           const { localPath } = await cloneRepo(resolved.source);
 
-          // Discover what's in the repo
-          const commands = discoverCommands(localPath);
-          const skills = discoverSkillsFromRepo(localPath);
-          const hooks = discoverHooksFromRepo(localPath);
+          const requestedTypes = new Set(parseCommaSeparatedList(options.types));
+          const includeType = (type: string): boolean =>
+            requestedTypes.size === 0 || requestedTypes.has(type);
 
-          const hasCommands = commands.length > 0;
-          const hasSkills = skills.length > 0;
-          const hasHooks = hooks.length > 0;
+          const requestedNames = new Set(parseCommaSeparatedList(options.names));
+          const nameFilter = <T extends { name: string }>(items: T[]): T[] => {
+            if (requestedNames.size === 0) return items;
+            return items.filter((item) => requestedNames.has(item.name));
+          };
 
-          if (!hasCommands && !hasSkills && !hasHooks) {
+          // Discover everything; filter to requested types up front so the
+          // summary table reflects what will actually be installed.
+          let commands = includeType('commands') ? discoverCommands(localPath) : [];
+          let skills = includeType('skills') ? discoverSkillsFromRepo(localPath) : [];
+          let hooks = includeType('hooks') ? discoverHooksFromRepo(localPath) : [];
+          let workflows = includeType('workflows') ? discoverWorkflowsFromRepo(localPath) : [];
+          let subagents = includeType('subagents') ? discoverSubagentsFromRepo(localPath) : [];
+          let permissions = includeType('permissions') ? discoverPermissionsFromRepo(localPath) : [];
+          let mcpServers = includeType('mcp') ? discoverMcpConfigsFromRepo(localPath) : [];
+
+          // --names filter applies across every discovered type. If the user
+          // typed a name that matched nothing, fail loud so they can fix the
+          // typo rather than silently install zero items.
+          if (requestedNames.size > 0) {
+            const allNames = new Set<string>([
+              ...commands.map((c) => c.name),
+              ...skills.map((s) => s.name),
+              ...hooks,
+              ...workflows.map((w) => w.name),
+              ...subagents.map((s) => s.name),
+              ...permissions.map((p) => p.name),
+              ...mcpServers.map((s) => s.name),
+            ]);
+            const missing = [...requestedNames].filter((n) => !allNames.has(n));
+            if (missing.length > 0) {
+              console.log(chalk.red(`\nResource(s) not found in repo: ${missing.join(', ')}`));
+              console.log(chalk.gray(`Available: ${[...allNames].sort().join(', ')}`));
+              process.exit(1);
+            }
+            commands = nameFilter(commands);
+            skills = nameFilter(skills);
+            hooks = hooks.filter((h) => requestedNames.has(h));
+            workflows = nameFilter(workflows);
+            subagents = nameFilter(subagents);
+            permissions = nameFilter(permissions);
+            mcpServers = nameFilter(mcpServers);
+          }
+
+          const summary: Array<{ kind: string; count: number }> = [
+            { kind: 'commands', count: commands.length },
+            { kind: 'skills', count: skills.length },
+            { kind: 'hooks', count: hooks.length },
+            { kind: 'workflows', count: workflows.length },
+            { kind: 'subagents', count: subagents.length },
+            { kind: 'permissions', count: permissions.length },
+            { kind: 'mcp', count: mcpServers.length },
+          ].filter((s) => s.count > 0);
+
+          if (summary.length === 0) {
             console.log(chalk.yellow('No installable content found in repository.'));
+            if (requestedTypes.size > 0 || requestedNames.size > 0) {
+              console.log(chalk.gray('Try removing --types/--names to see everything the repo offers.'));
+            }
             process.exit(1);
           }
 
           console.log(chalk.bold('\nFound:'));
-          if (hasCommands) console.log(`  ${commands.length} commands`);
-          if (hasSkills) console.log(`  ${skills.length} skills`);
-          if (hasHooks) console.log(`  ${hooks.length} hooks`);
+          for (const { kind, count } of summary) {
+            console.log(`  ${count} ${kind}`);
+          }
 
           const gitCliStates = await getAllCliStates();
           const installedAgents = ALL_AGENT_IDS.filter(
@@ -549,7 +635,7 @@ When to use:
           }
 
           // Install commands
-          if (hasCommands) {
+          if (commands.length > 0) {
             console.log(chalk.bold('\nInstalling commands...'));
             let directInstalled = 0;
             let syncedVersions = 0;
@@ -594,7 +680,7 @@ When to use:
           }
 
           // Install skills
-          if (hasSkills) {
+          if (skills.length > 0) {
             console.log(chalk.bold('\nInstalling skills...'));
             const directAgents = targets.directAgents.filter(
               (agentId) => AGENTS[agentId].capabilities.skills && gitCliStates[agentId]?.installed
@@ -625,7 +711,7 @@ When to use:
           }
 
           // Install hooks
-          if (hasHooks) {
+          if (hooks.length > 0) {
             console.log(chalk.bold('\nInstalling hooks...'));
             let syncedVersions = 0;
             const directHookAgents = targets.directAgents.filter(
@@ -648,6 +734,94 @@ When to use:
               }
             }
             console.log(`  Synced hooks to ${syncedVersions} managed version(s)`);
+          }
+
+          // Install workflows
+          if (workflows.length > 0) {
+            console.log(chalk.bold('\nInstalling workflows...'));
+            let installed = 0;
+            for (const w of workflows) {
+              const result = installWorkflowCentrally(w.path, w.name);
+              if (result.success) {
+                installed++;
+              } else {
+                console.log(`  ${chalk.red('x')} ${w.name}: ${result.error}`);
+              }
+            }
+            const workflowNames = workflows.map((w) => w.name);
+            let syncedVersions = 0;
+            for (const [agentId, versions] of targets.versionSelections) {
+              for (const version of versions) {
+                const result = syncResourcesToVersion(agentId, version, { workflows: workflowNames });
+                if (result.workflows.length > 0) syncedVersions++;
+              }
+            }
+            console.log(`  Installed ${installed} workflow(s) to ~/.agents/workflows/`);
+            console.log(`  Synced workflows to ${syncedVersions} managed version(s)`);
+          }
+
+          // Install subagents
+          if (subagents.length > 0) {
+            console.log(chalk.bold('\nInstalling subagents...'));
+            let installed = 0;
+            for (const s of subagents) {
+              const result = installSubagentCentrally(s.path, s.name);
+              if (result.success) {
+                installed++;
+              } else {
+                console.log(`  ${chalk.red('x')} ${s.name}: ${result.error}`);
+              }
+            }
+            const subagentNames = subagents.map((s) => s.name);
+            let syncedVersions = 0;
+            for (const [agentId, versions] of targets.versionSelections) {
+              for (const version of versions) {
+                const result = syncResourcesToVersion(agentId, version, { subagents: subagentNames });
+                if (result.subagents.length > 0) syncedVersions++;
+              }
+            }
+            console.log(`  Installed ${installed} subagent(s) to ~/.agents/subagents/`);
+            console.log(`  Synced subagents to ${syncedVersions} managed version(s)`);
+          }
+
+          // Install permissions
+          if (permissions.length > 0) {
+            console.log(chalk.bold('\nInstalling permission sets...'));
+            let installed = 0;
+            for (const p of permissions) {
+              const result = installPermissionSet(p.path, p.name);
+              if (result.success) {
+                installed++;
+              } else {
+                console.log(`  ${chalk.red('x')} ${p.name}: ${result.error}`);
+              }
+            }
+            console.log(`  Installed ${installed} permission set(s) to ~/.agents/permissions/`);
+            console.log(chalk.gray('  Apply with: agents permissions apply <name> --agents <selector>'));
+          }
+
+          // Install MCP server configs
+          if (mcpServers.length > 0) {
+            console.log(chalk.bold('\nInstalling MCP server configs...'));
+            let installed = 0;
+            for (const s of mcpServers) {
+              const result = installMcpConfigCentrally(s.path);
+              if (result.success) {
+                installed++;
+              } else {
+                console.log(`  ${chalk.red('x')} ${s.name}: ${result.error}`);
+              }
+            }
+            const mcpNames = mcpServers.map((s) => s.name);
+            let syncedVersions = 0;
+            for (const [agentId, versions] of targets.versionSelections) {
+              for (const version of versions) {
+                const result = syncResourcesToVersion(agentId, version, { mcp: mcpNames });
+                if (result.mcp.length > 0) syncedVersions++;
+              }
+            }
+            console.log(`  Installed ${installed} MCP config(s) to ~/.agents/mcp/`);
+            console.log(`  Synced MCP configs to ${syncedVersions} managed version(s)`);
           }
 
           console.log(chalk.green('\nPackage installed.'));

--- a/src/lib/__tests__/discover-mcp-from-repo.test.ts
+++ b/src/lib/__tests__/discover-mcp-from-repo.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for discoverMcpConfigsFromRepo + installMcpConfigCentrally.
+ *
+ * The repo-source `mcp add gh:...` form and `agents install gh:... --types mcp`
+ * both rely on these two helpers. Without them, MCP configs from
+ * multi-resource repos can't land in ~/.agents/mcp/ at all.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+let REPO_DIR: string;
+let AGENTS_DIR: string;
+
+vi.mock('../state.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../state.js')>();
+  return {
+    ...actual,
+    getUserMcpDir: () => path.join(AGENTS_DIR, 'mcp'),
+  };
+});
+
+async function loadLib() {
+  return await import('../mcp.js');
+}
+
+function writeYaml(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, 'utf-8');
+}
+
+describe('discoverMcpConfigsFromRepo', () => {
+  beforeEach(() => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-discover-'));
+    REPO_DIR = path.join(root, 'repo');
+    AGENTS_DIR = path.join(root, 'agents');
+    fs.mkdirSync(REPO_DIR, { recursive: true });
+    fs.mkdirSync(AGENTS_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (REPO_DIR) {
+      const root = path.dirname(REPO_DIR);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('returns empty when the repo has no mcp/ directory', async () => {
+    const { discoverMcpConfigsFromRepo } = await loadLib();
+    expect(discoverMcpConfigsFromRepo(REPO_DIR)).toEqual([]);
+  });
+
+  it('finds valid stdio and http configs and skips invalid ones', async () => {
+    const { discoverMcpConfigsFromRepo } = await loadLib();
+
+    writeYaml(path.join(REPO_DIR, 'mcp', 'notion.yaml'), [
+      'name: notion',
+      'transport: stdio',
+      'command: uvx',
+      'args:',
+      '  - notion-mcp',
+    ].join('\n'));
+
+    writeYaml(path.join(REPO_DIR, 'mcp', 'figma.yml'), [
+      'name: figma',
+      'transport: http',
+      'url: https://api.figma.com/mcp',
+    ].join('\n'));
+
+    // Missing transport — must be rejected by parseMcpServerConfig.
+    writeYaml(path.join(REPO_DIR, 'mcp', 'broken.yaml'), [
+      'name: broken',
+      'command: foo',
+    ].join('\n'));
+
+    // Wrong extension — must be ignored.
+    writeYaml(path.join(REPO_DIR, 'mcp', 'README.md'), '# not a config');
+
+    const discovered = discoverMcpConfigsFromRepo(REPO_DIR);
+    const names = discovered.map((d) => d.name).sort();
+
+    expect(names).toEqual(['figma', 'notion']);
+    const notion = discovered.find((d) => d.name === 'notion')!;
+    expect(notion.config.transport).toBe('stdio');
+    expect(notion.config.command).toBe('uvx');
+    expect(notion.config.args).toEqual(['notion-mcp']);
+
+    const figma = discovered.find((d) => d.name === 'figma')!;
+    expect(figma.config.transport).toBe('http');
+    expect(figma.config.url).toBe('https://api.figma.com/mcp');
+  });
+
+  it('installMcpConfigCentrally copies a discovered config into ~/.agents/mcp/', async () => {
+    const { discoverMcpConfigsFromRepo, installMcpConfigCentrally } = await loadLib();
+
+    writeYaml(path.join(REPO_DIR, 'mcp', 'notion.yaml'), [
+      'name: notion',
+      'transport: stdio',
+      'command: uvx',
+      'args:',
+      '  - notion-mcp',
+    ].join('\n'));
+
+    const [discovered] = discoverMcpConfigsFromRepo(REPO_DIR);
+    expect(discovered).toBeDefined();
+
+    const result = installMcpConfigCentrally(discovered.path);
+    expect(result.success).toBe(true);
+    expect(result.path).toBe(path.join(AGENTS_DIR, 'mcp', 'notion.yaml'));
+    expect(fs.existsSync(result.path!)).toBe(true);
+
+    const yaml = await import('yaml');
+    const round = yaml.parse(fs.readFileSync(result.path!, 'utf-8'));
+    expect(round.name).toBe('notion');
+    expect(round.transport).toBe('stdio');
+    expect(round.command).toBe('uvx');
+    expect(round.args).toEqual(['notion-mcp']);
+  });
+
+  it('installMcpConfigCentrally returns an error for invalid source files', async () => {
+    const { installMcpConfigCentrally } = await loadLib();
+    const bad = path.join(REPO_DIR, 'bad.yaml');
+    writeYaml(bad, 'name: x\n'); // missing transport
+
+    const result = installMcpConfigCentrally(bad);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid');
+  });
+});

--- a/src/lib/mcp.ts
+++ b/src/lib/mcp.ts
@@ -156,6 +156,48 @@ export function listMcpServerConfigs(cwd: string = process.cwd()): InstalledMcpS
 }
 
 /**
+ * Scan a repository for MCP server YAML configs.
+ * Looks under <repoPath>/mcp/*.yaml — same on-disk layout as ~/.agents/mcp/.
+ */
+export function discoverMcpConfigsFromRepo(repoPath: string): InstalledMcpServer[] {
+  const dir = path.join(repoPath, 'mcp');
+  if (!fs.existsSync(dir)) return [];
+
+  const results: InstalledMcpServer[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    if (!entry.name.endsWith('.yaml') && !entry.name.endsWith('.yml')) continue;
+
+    const filePath = path.join(dir, entry.name);
+    const config = parseMcpServerConfig(filePath);
+    if (config) {
+      results.push({ name: config.name, path: filePath, config, scope: 'user' });
+    }
+  }
+  return results;
+}
+
+/**
+ * Install an MCP YAML config from a source file into ~/.agents/mcp/.
+ * Re-serializes via writeMcpServerConfig so the on-disk filename is
+ * deterministic (sanitized from the server name).
+ */
+export function installMcpConfigCentrally(
+  sourcePath: string
+): { success: boolean; error?: string; path?: string } {
+  try {
+    const config = parseMcpServerConfig(sourcePath);
+    if (!config) {
+      return { success: false, error: `Invalid MCP config at ${sourcePath}` };
+    }
+    const written = writeMcpServerConfig(config);
+    return { success: true, path: written };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}
+
+/**
  * Get MCP servers by name.
  * If names is provided, returns only those servers.
  * Otherwise returns all servers.


### PR DESCRIPTION
## Summary

PR 2 of the 3-PR series started in #118.

- `agents install gh:user/repo` now sniffs **every** resource type (skills, workflows, commands, hooks, permissions, subagents, mcp) — previously it silently dropped workflows / subagents / permissions / mcp.
- New `--types` and `--names` flags on `agents install` to narrow what lands.
- New `agents mcp add gh:user/repo [--names a,b] [--agents …]` form, mirroring `skills add gh:` — clones, discovers \`mcp/*.yaml\`, copies to \`~/.agents/mcp/\`, syncs to selected agent versions. Existing \`mcp add <name> <command>\` form is unchanged.
- Two new helpers in \`src/lib/mcp.ts\`: \`discoverMcpConfigsFromRepo\` and \`installMcpConfigCentrally\`.

End-state target (the user-visible payoff for the series):

\`\`\`
agents install gh:phnx-labs/.agents-system --types skills --names animator,composer --agents claude@all
\`\`\`

## Test plan

- [x] 4 new unit tests in \`src/lib/__tests__/discover-mcp-from-repo.test.ts\` — discovery + central install pipeline, including invalid input cases.
- [x] \`bun run build\` — clean (tsc passes).
- [x] \`bunx vitest run src/lib/__tests__/ tests/registry.test.ts tests/non-interactive.test.ts\` — 38/39 test files pass; the 5 failures in \`models.test.ts\` pre-exist on \`origin/main\` (verified against a fresh \`/tmp/agents-cli-baseline\` clone) and are unrelated.
- [x] CLI surfaces verified via \`agents install --help\` and \`agents mcp add --help\`.

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/1c13cb04fd5fca12aa61adfaed4b283c)