### PR TITLE
feat(prompt): match --agents @all syntax in picker + fail loud on non-TTY

### DIFF
--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -295,7 +295,7 @@ Examples:
           versionSelections = result.versionSelections;
         } else {
           const result = await promptAgentVersionSelection(ALL_AGENT_IDS, {
-            skipPrompts: options.yes || !isInteractiveTerminal(),
+            skipPrompts: options.yes,
           });
           selectedAgents = result.selectedAgents;
           versionSelections = result.versionSelections;

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -428,7 +428,7 @@ Examples:
           versionSelections = result.versionSelections;
         } else {
           const result = await promptAgentVersionSelection(hooksCapableAgents, {
-            skipPrompts: options.yes || !isInteractiveTerminal(),
+            skipPrompts: options.yes,
           });
           selectedAgents = result.selectedAgents;
           versionSelections = result.versionSelections;

--- a/src/commands/permissions.ts
+++ b/src/commands/permissions.ts
@@ -373,7 +373,7 @@ Examples:
           } else {
             const result = await promptAgentVersionSelection(
               PERMISSIONS_CAPABLE_AGENTS,
-              { skipPrompts }
+              { skipPrompts: options.yes }
             );
             selectedAgents = result.selectedAgents;
             versionSelections = result.versionSelections;

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -393,7 +393,7 @@ Examples:
           versionSelections = result.versionSelections;
         } else {
           const result = await promptAgentVersionSelection(ALL_AGENT_IDS, {
-            skipPrompts: options.yes || !isInteractiveTerminal(),
+            skipPrompts: options.yes,
           });
           selectedAgents = result.selectedAgents;
           versionSelections = result.versionSelections;

--- a/src/commands/skills.ts
+++ b/src/commands/skills.ts
@@ -337,7 +337,7 @@ Examples:
           versionSelections = result.versionSelections;
         } else {
           const result = await promptAgentVersionSelection(SKILLS_CAPABLE_AGENTS, {
-            skipPrompts: options.yes || !isInteractiveTerminal(),
+            skipPrompts: options.yes,
           });
           selectedAgents = result.selectedAgents;
           versionSelections = result.versionSelections;

--- a/src/commands/subagents.ts
+++ b/src/commands/subagents.ts
@@ -236,7 +236,7 @@ Examples:
         versionSelections = result.versionSelections;
       } else {
         const result = await promptAgentVersionSelection(SUBAGENT_CAPABLE_AGENTS, {
-          skipPrompts: options.yes || !isInteractiveTerminal(),
+          skipPrompts: options.yes,
         });
         selectedAgents = result.selectedAgents;
         versionSelections = result.versionSelections;

--- a/src/commands/workflows.ts
+++ b/src/commands/workflows.ts
@@ -272,7 +272,7 @@ Examples:
           versionSelections = result.versionSelections;
         } else {
           const result = await promptAgentVersionSelection(WORKFLOW_CAPABLE_AGENTS, {
-            skipPrompts: options.yes || !isInteractiveTerminal(),
+            skipPrompts: options.yes,
           });
           selectedAgents = result.selectedAgents;
           versionSelections = result.versionSelections;

--- a/src/lib/__tests__/prompt-agent-version-selection.test.ts
+++ b/src/lib/__tests__/prompt-agent-version-selection.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for promptAgentVersionSelection's non-interactive behavior.
+ *
+ * The prompt path is interactive-only; previously, non-TTY callers were
+ * silently routed into the auto-pick path. That hid scripted misuse (no
+ * --agents, no --yes, piped stdin) behind a "default version" pick that
+ * users couldn't predict from the docs.
+ *
+ * After PR 3 (matches @all syntax), non-TTY + !skipPrompts must throw
+ * with a message that points at --agents claude@all / all.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+let TEST_ROOT: string;
+let VERSIONS_DIR: string;
+const defaultByAgent: Record<string, string | null> = {};
+
+vi.mock('../state.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../state.js')>();
+  return {
+    ...actual,
+    getVersionsDir: () => VERSIONS_DIR,
+    getGlobalDefault: (agent: string) => defaultByAgent[agent] ?? null,
+  };
+});
+
+async function loadPrompt() {
+  const mod = await import('../versions.js');
+  return mod.promptAgentVersionSelection;
+}
+
+function makeFakeInstall(agent: string, version: string): void {
+  const binDir = path.join(VERSIONS_DIR, agent, version, 'node_modules', '.bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  const cli = agent === 'claude' ? 'claude' : agent;
+  fs.writeFileSync(path.join(binDir, cli), '#!/bin/sh\n');
+  fs.chmodSync(path.join(binDir, cli), 0o755);
+}
+
+describe('promptAgentVersionSelection — non-interactive guards', () => {
+  let savedStdinTty: boolean | undefined;
+  let savedStdoutTty: boolean | undefined;
+
+  beforeEach(() => {
+    TEST_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'prompt-nontty-'));
+    VERSIONS_DIR = path.join(TEST_ROOT, 'versions');
+    fs.mkdirSync(VERSIONS_DIR, { recursive: true });
+    for (const k of Object.keys(defaultByAgent)) delete defaultByAgent[k];
+    savedStdinTty = process.stdin.isTTY;
+    savedStdoutTty = process.stdout.isTTY;
+  });
+
+  afterEach(() => {
+    fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: savedStdinTty, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: savedStdoutTty, configurable: true });
+    vi.resetModules();
+  });
+
+  it('throws a clear error when stdin is not a TTY and skipPrompts is not set', async () => {
+    makeFakeInstall('claude', '2.1.141');
+    defaultByAgent.claude = '2.1.141';
+
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+
+    const prompt = await loadPrompt();
+    await expect(prompt(['claude'])).rejects.toThrow(/Non-interactive shell/);
+    await expect(prompt(['claude'])).rejects.toThrow(/--agents claude@all/);
+    await expect(prompt(['claude'])).rejects.toThrow(/--yes/);
+  });
+
+  it('does not throw on non-TTY when skipPrompts is true (script with --yes)', async () => {
+    makeFakeInstall('claude', '2.1.141');
+
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+
+    const prompt = await loadPrompt();
+    // The exact version picked depends on global meta state we don't mock
+    // here. What this test guarantees is that skipPrompts: true bypasses
+    // the non-TTY throw and returns claude in the agent set.
+    const result = await prompt(['claude'], { skipPrompts: true });
+
+    expect(result.selectedAgents).toEqual(['claude']);
+    expect(result.versionSelections.size).toBeGreaterThan(0);
+  });
+
+  it('returns empty selections when no capable agents are installed', async () => {
+    // No installs at all — both interactive and non-interactive paths short-
+    // circuit before hitting the TTY check.
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+
+    const prompt = await loadPrompt();
+    const result = await prompt(['claude']);
+
+    expect(result.selectedAgents).toEqual([]);
+    expect(result.versionSelections.size).toBe(0);
+  });
+});

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -2601,8 +2601,15 @@ export async function promptAgentVersionSelection(
     const versions = listInstalledVersions(agentId);
     const defaultVer = getGlobalDefault(agentId);
     if (versions.length === 0) return `${AGENTS[agentId].name}  ${chalk.gray('(not installed)')}`;
-    if (defaultVer) return `${AGENTS[agentId].name}  ${chalk.gray(`(active: ${defaultVer})`)}`;
-    return `${AGENTS[agentId].name}  ${chalk.gray(`(${versions[0]})`)}`;
+    // Surface the version count when there's more than one — mirrors the new
+    // `--agents <agent>@all` syntax so users can see at a glance how many
+    // versions `@all` would target before the per-version prompt fires.
+    const detail = versions.length > 1
+      ? (defaultVer
+        ? `active: ${defaultVer}, ${versions.length} versions installed`
+        : `${versions.length} versions installed`)
+      : (defaultVer ?? versions[0]);
+    return `${AGENTS[agentId].name}  ${chalk.gray(`(${detail})`)}`;
   };
 
   let selectedAgents: AgentId[];
@@ -2618,6 +2625,20 @@ export async function promptAgentVersionSelection(
       }
     }
   } else {
+    // Non-TTY without an explicit --agents value used to silently fall through
+    // to default-picking inside the caller. That's surprising in scripts — fail
+    // loud and point at the new `--agents` syntax instead.
+    if (!(process.stdin.isTTY && process.stdout.isTTY)) {
+      throw new Error(
+        'Non-interactive shell: cannot prompt for agent/version selection.\n' +
+        'Pass --agents explicitly. Examples:\n' +
+        '  --agents claude              (default version)\n' +
+        '  --agents claude@all          (every installed Claude version)\n' +
+        '  --agents claude@2.1.141      (a specific version)\n' +
+        '  --agents all                 (every installed version of every capable agent)\n' +
+        'Or pass --yes to auto-pick defaults.'
+      );
+    }
     // Prompt for agent selection
     const checkboxResult = await checkbox<string>({
       message: 'Which agents should receive these resources?',
@@ -2658,7 +2679,7 @@ export async function promptAgentVersionSelection(
       const versionResult = await checkbox<string>({
         message: `Which versions of ${AGENTS[agentId].name} should receive these resources?`,
         choices: [
-          { name: chalk.bold('All versions'), value: 'all', checked: false },
+          { name: chalk.bold(`All versions (${versions.length})`), value: 'all', checked: false },
           ...versions.map((v) => {
             const base = v === defaultVer ? `${v} (default)` : v;
             let label = base.padEnd(maxLabelLen);


### PR DESCRIPTION
## Summary

PR 3 of 3 in the unified resource-install series (closes the plan started in #118 and #127).

The interactive picker now mirrors the new \`--agents\` syntax:

- **Agent rows surface install counts:** \`Claude (active: 2.1.141, 3 versions installed)\` so users can see what \`@all\` would target before the per-version follow-up prompt.
- **Per-version checkbox shows count:** \`All versions (N)\` instead of just \`All versions\`.

The previous behavior of silently auto-picking defaults when stdin/stdout are not a TTY masked scripted misuse. Now non-TTY without \`--agents\` and without \`--yes\` **throws with an explicit message** that points at:

\`\`\`
--agents claude              (default version)
--agents claude@all          (every installed Claude version)
--agents claude@2.1.141      (a specific version)
--agents all                 (every installed version, every capable agent)
--yes                        (auto-pick defaults)
\`\`\`

Callers stop OR-ing \`skipPrompts\` with \`!isInteractiveTerminal()\` — the function checks TTY itself and throws when prompting isn't possible. Behavior with \`--yes\` is unchanged.

Files touched:

- \`src/lib/versions.ts\` — picker label changes + new non-TTY guard
- 7 caller sites in \`src/commands/{commands,hooks,permissions,rules,skills,subagents,workflows}.ts\` drop the manual \`isInteractiveTerminal()\` check

## Test plan

- [x] 3 new unit tests in \`src/lib/__tests__/prompt-agent-version-selection.test.ts\` cover the non-TTY throw, the \`skipPrompts: true\` bypass, and the empty-agents short-circuit.
- [x] \`bun run build\` clean.
- [x] \`bunx vitest run src/lib/__tests__/\` — 37/38 test files pass; 4 \`models.test.ts\` failures pre-exist on \`origin/main\` (same set verified against the baseline clone for #127).
- [x] Live smoke test: \`echo \"\" | node dist/index.js workflows add /tmp/wf-fixture\` (non-TTY) throws the new clear message and points at \`claude@all\` / \`all\` / \`--yes\`.

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/c1c6093a15e7e6588718020fc55ec168)