### PR TITLE
chore: ignore local /website/ scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ scripts/scrub-history.sh
 
 # Cloudflare Worker local state
 **/.wrangler/
+
+# Local scratch / abandoned scaffold (lives in agent-cli-web, not here)
+/website/


### PR DESCRIPTION
## Summary

One-line .gitignore addition: `/website/` (root-only).

The dir is an abandoned scaffold that lives in agents-cli locally for some users (496M, contains node_modules + a 351-line src/comparison.ts HTML constant). It belongs in `agent-cli-web`, not the CLI repo. Gitignoring it stops it from showing up as untracked on every `git status` without deleting anyone's local work.

## Test plan

- [ ] `git status` no longer reports `/website/` as untracked in checkouts that have one