### PR TITLE
feat(agents): auto-install missing agent versions + unify --agents selector

### DIFF
--- a/src/commands/__tests__/auto-install-resolver.test.ts
+++ b/src/commands/__tests__/auto-install-resolver.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for resolveAgentTargetsAutoInstalling — the wrapper that catches
+ * VersionNotInstalledError, prompts (or auto-installs with --yes), and
+ * retries the underlying resolver.
+ *
+ * installVersion is the only IO-heavy dependency we mock (it shells out to
+ * npm). The rest goes through real fs in a tmpdir.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+let TEST_ROOT: string;
+let VERSIONS_DIR: string;
+const installVersionMock = vi.fn();
+
+vi.mock('../../lib/state.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/state.js')>();
+  return {
+    ...actual,
+    getVersionsDir: () => VERSIONS_DIR,
+  };
+});
+
+vi.mock('../../lib/versions.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/versions.js')>();
+  return {
+    ...actual,
+    installVersion: installVersionMock,
+  };
+});
+
+async function loadUtils() {
+  return await import('../utils.js');
+}
+
+function makeFakeInstall(agent: string, version: string): void {
+  const binDir = path.join(VERSIONS_DIR, agent, version, 'node_modules', '.bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  const cli = agent === 'claude' ? 'claude' : agent;
+  fs.writeFileSync(path.join(binDir, cli), '#!/bin/sh\n');
+  fs.chmodSync(path.join(binDir, cli), 0o755);
+}
+
+describe('resolveAgentTargetsAutoInstalling', () => {
+  let savedStdinTty: boolean | undefined;
+  let savedStdoutTty: boolean | undefined;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    TEST_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'auto-install-'));
+    VERSIONS_DIR = path.join(TEST_ROOT, 'versions');
+    fs.mkdirSync(VERSIONS_DIR, { recursive: true });
+    installVersionMock.mockReset();
+    savedStdinTty = process.stdin.isTTY;
+    savedStdoutTty = process.stdout.isTTY;
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: savedStdinTty, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: savedStdoutTty, configurable: true });
+    exitSpy.mockRestore();
+  });
+
+  it('passes through when every requested version is already installed', async () => {
+    makeFakeInstall('claude', '2.1.141');
+    const { resolveAgentTargetsAutoInstalling } = await loadUtils();
+
+    const result = await resolveAgentTargetsAutoInstalling('claude@2.1.141', ['claude'], { yes: true });
+
+    expect(result).not.toBeNull();
+    expect(result!.selectedAgents).toEqual(['claude']);
+    expect(installVersionMock).not.toHaveBeenCalled();
+  });
+
+  it('with --yes, auto-installs the missing version then resolves', async () => {
+    makeFakeInstall('claude', '2.1.141');
+    // Simulate a successful install — also materialise the version on disk
+    // so the post-install resolve() actually finds it.
+    installVersionMock.mockImplementation(async (agent: string, version: string) => {
+      makeFakeInstall(agent, version);
+      return { success: true, installedVersion: version };
+    });
+
+    const { resolveAgentTargetsAutoInstalling } = await loadUtils();
+    const result = await resolveAgentTargetsAutoInstalling('claude@2.1.999', ['claude'], { yes: true });
+
+    expect(installVersionMock).toHaveBeenCalledTimes(1);
+    expect(installVersionMock).toHaveBeenCalledWith('claude', '2.1.999', expect.any(Function));
+    expect(result).not.toBeNull();
+    expect(result!.selectedAgents).toEqual(['claude']);
+    expect(result!.versionSelections.get('claude')).toEqual(['2.1.999']);
+  });
+
+  it('in non-TTY without --yes, exits 1 instead of silently installing', async () => {
+    makeFakeInstall('claude', '2.1.141');
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+
+    const { resolveAgentTargetsAutoInstalling } = await loadUtils();
+
+    await expect(resolveAgentTargetsAutoInstalling('claude@2.1.999', ['claude'])).rejects.toThrow(/process\.exit\(1\)/);
+    expect(installVersionMock).not.toHaveBeenCalled();
+  });
+
+  it('with --yes, aborts (process.exit(1)) when installVersion reports failure', async () => {
+    makeFakeInstall('claude', '2.1.141');
+    installVersionMock.mockResolvedValue({ success: false, installedVersion: '', error: 'npm 404' });
+
+    const { resolveAgentTargetsAutoInstalling } = await loadUtils();
+
+    await expect(resolveAgentTargetsAutoInstalling('claude@2.1.999', ['claude'], { yes: true })).rejects.toThrow(/process\.exit\(1\)/);
+    expect(installVersionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('happy paths skip the install pre-flight entirely (no extra IO)', async () => {
+    makeFakeInstall('claude', '2.1.141');
+    const { resolveAgentTargetsAutoInstalling } = await loadUtils();
+
+    // bare agent, @default, @all, literal `all` — none of these are "specific missing version"
+    await resolveAgentTargetsAutoInstalling('claude', ['claude'], { yes: true });
+    await resolveAgentTargetsAutoInstalling('claude@all', ['claude'], { yes: true });
+    await resolveAgentTargetsAutoInstalling('all', ['claude'], { yes: true });
+
+    expect(installVersionMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -53,6 +53,7 @@ import {
   promptAgentVersionSelection,
   getVersionHomePath,
   resolveAgentVersionTargets,
+  resolveInstalledAgentTargets,
 } from '../lib/versions.js';
 import { recordVersionResources } from '../lib/state.js';
 import {
@@ -63,6 +64,7 @@ import {
   printWithPager,
   requireInteractiveSelection,
   promptRemovalTargets,
+  resolveAgentTargetsAutoInstalling,
   type RemovalTarget,
 } from './utils.js';
 
@@ -290,7 +292,11 @@ Examples:
         let versionSelections: Map<AgentId, string[]>;
 
         if (options.agents) {
-          const result = resolveAgentVersionTargets(options.agents, ALL_AGENT_IDS);
+          const result = await resolveAgentTargetsAutoInstalling(options.agents, ALL_AGENT_IDS, { yes: options.yes });
+          if (!result) {
+            console.log(chalk.gray('Cancelled.'));
+            return;
+          }
           selectedAgents = result.selectedAgents;
           versionSelections = result.versionSelections;
         } else {
@@ -421,11 +427,24 @@ Examples:
           continue;
         }
 
-        // Filter by --agents if specified
+        // Filter by --agents if specified. Routes through resolveInstalledAgentTargets
+        // so the same selector syntax used everywhere else (agent, agent@default,
+        // agent@x.y.z, agent@all, literal all) works here too.
         let availableTargets = cmdInfo.targets;
         if (options?.agents) {
-          const requestedAgents = new Set(options.agents.split(','));
-          availableTargets = availableTargets.filter((t) => requestedAgents.has(t.agent));
+          const requestedTargets = resolveInstalledAgentTargets(options.agents, ALL_AGENT_IDS);
+          const requested = new Set<string>();
+          for (const aid of requestedTargets.directAgents) {
+            for (const ver of listInstalledVersions(aid)) {
+              requested.add(`${aid}@${ver}`);
+            }
+          }
+          for (const [aid, versions] of requestedTargets.versionSelections) {
+            for (const ver of versions) {
+              requested.add(`${aid}@${ver}`);
+            }
+          }
+          availableTargets = availableTargets.filter((t) => requested.has(`${t.agent}@${t.version}`));
         }
 
         if (availableTargets.length === 0) {

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -44,6 +44,7 @@ import {
   promptAgentVersionSelection,
   getVersionHomePath,
   resolveAgentVersionTargets,
+  resolveInstalledAgentTargets,
 } from '../lib/versions.js';
 import { recordVersionResources } from '../lib/state.js';
 import {
@@ -53,6 +54,7 @@ import {
   printWithPager,
   requireInteractiveSelection,
   promptRemovalTargets,
+  resolveAgentTargetsAutoInstalling,
   type RemovalTarget,
 } from './utils.js';
 
@@ -423,7 +425,11 @@ Examples:
         const hooksCapableAgents = Array.from(HOOKS_CAPABLE_AGENTS) as AgentId[];
 
         if (options.agents) {
-          const result = resolveAgentVersionTargets(options.agents, hooksCapableAgents);
+          const result = await resolveAgentTargetsAutoInstalling(options.agents, hooksCapableAgents, { yes: options.yes });
+          if (!result) {
+            console.log(chalk.gray('Cancelled.'));
+            return;
+          }
           selectedAgents = result.selectedAgents;
           versionSelections = result.versionSelections;
         } else {
@@ -553,11 +559,24 @@ Examples:
           continue;
         }
 
-        // Filter by --agents if specified
+        // Filter by --agents if specified. Routes through resolveInstalledAgentTargets
+        // so the same selector syntax used everywhere else (agent, agent@default,
+        // agent@x.y.z, agent@all, literal all) works here too.
         let availableTargets = hookInfo.targets;
         if (options?.agents) {
-          const requestedAgents = new Set(options.agents.split(','));
-          availableTargets = availableTargets.filter((t) => requestedAgents.has(t.agent));
+          const requestedTargets = resolveInstalledAgentTargets(options.agents, [...HOOKS_CAPABLE_AGENTS]);
+          const requested = new Set<string>();
+          for (const aid of requestedTargets.directAgents) {
+            for (const ver of listInstalledVersions(aid)) {
+              requested.add(`${aid}@${ver}`);
+            }
+          }
+          for (const [aid, versions] of requestedTargets.versionSelections) {
+            for (const ver of versions) {
+              requested.add(`${aid}@${ver}`);
+            }
+          }
+          availableTargets = availableTargets.filter((t) => requested.has(`${t.agent}@${t.version}`));
         }
 
         if (availableTargets.length === 0) {

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -43,11 +43,21 @@ import {
   resolveInstalledAgentTargets,
   resolveConfiguredAgentTargets,
   resolveVersionAlias,
-  resolveAgentVersionTargets,
   syncResourcesToVersion,
 } from '../lib/versions.js';
 import { getUserAgentsDir } from '../lib/state.js';
-import { isPromptCancelled, isInteractiveTerminal, requireInteractiveSelection, promptRemovalTargets, parseCommaSeparatedList, type RemovalTarget } from './utils.js';
+import {
+  isPromptCancelled,
+  isInteractiveTerminal,
+  requireInteractiveSelection,
+  promptRemovalTargets,
+  parseCommaSeparatedList,
+  ensureAgentVersionsInstalled,
+  resolveAgentTargetsAutoInstalling,
+  resolveInstalledAgentTargetsAutoInstalling,
+  VersionNotInstalledError,
+  type RemovalTarget,
+} from './utils.js';
 import {
   showResourceList,
   buildTargetsSection,
@@ -55,17 +65,45 @@ import {
   type SyncTarget,
 } from './resource-view.js';
 
-/** Parse a comma-separated --agents string into validated agent IDs and optional version targets. */
+/**
+ * Parse a comma-separated --agents string into validated agent IDs and
+ * optional version targets in the manifest shape.
+ *
+ * Supports the same selector syntax as resolveAgentVersionTargets:
+ *   - bare `agent`        → manifest agents:[agent] (no version pin)
+ *   - `agent@default`     → manifest agents:[agent] (no version pin)
+ *   - `agent@x.y.z`       → manifest agentVersions[agent] = ['x.y.z']
+ *   - `agent@all`         → manifest agentVersions[agent] = every installed version
+ *   - literal `all`       → expand to all MCP-capable agents (each as `@all`)
+ *
+ * Throws VersionNotInstalledError for unknown specific versions so callers
+ * can prompt-and-install before retrying.
+ */
 function parseMcpAgentTargets(value: string): {
   agents: AgentId[];
   agentVersions?: Partial<Record<AgentId, string[]>>;
 } {
   const agents: AgentId[] = [];
   const agentVersions: Partial<Record<AgentId, string[]>> = {};
-  const targets = value
+  const rawTargets = value
     .split(',')
     .map((item) => item.trim())
     .filter(Boolean);
+
+  // Expand literal `all` / `all@all` into per-agent @all. Skip agents with no
+  // installed versions so `all` is lenient — mirrors resolveAgentVersionTargets.
+  const targets: string[] = [];
+  for (const t of rawTargets) {
+    if (t === 'all' || t === 'all@all') {
+      for (const a of MCP_CAPABLE_AGENTS) {
+        if (listInstalledVersions(a).length > 0) {
+          targets.push(`${a}@all`);
+        }
+      }
+    } else {
+      targets.push(t);
+    }
+  }
 
   for (const target of targets) {
     const atIndex = target.indexOf('@');
@@ -77,7 +115,7 @@ function parseMcpAgentTargets(value: string): {
     }
 
     if (atIndex !== -1 && !versionToken) {
-      throw new Error(`Missing version in --agents entry '${target}'. Use agent@x.y.z or agent@default.`);
+      throw new Error(`Missing version in --agents entry '${target}'. Use agent@x.y.z, agent@default, or agent@all.`);
     }
 
     const agentId = resolveAgentName(agentToken);
@@ -107,14 +145,24 @@ function parseMcpAgentTargets(value: string): {
       throw new Error(`No managed versions are installed for ${AGENTS[agentId].name}. Run: agents add ${agentId}@latest`);
     }
 
+    if (versionToken === 'all') {
+      const versions = agentVersions[agentId] || [];
+      for (const ver of installedVersions) {
+        if (!versions.includes(ver)) versions.push(ver);
+      }
+      agentVersions[agentId] = versions;
+      if (!agents.includes(agentId)) {
+        agents.push(agentId);
+      }
+      continue;
+    }
+
     const resolvedVersion = versionToken === 'latest'
       ? installedVersions[installedVersions.length - 1]
       : versionToken;
 
     if (!installedVersions.includes(resolvedVersion)) {
-      throw new Error(
-        `Version ${resolvedVersion} is not installed for ${AGENTS[agentId].name}. Installed versions: ${installedVersions.join(', ')}`
-      );
+      throw new VersionNotInstalledError(agentId, resolvedVersion, installedVersions);
     }
 
     const versions = agentVersions[agentId] || [];
@@ -212,6 +260,7 @@ When to use:
     .option('-s, --scope <scope>', 'user (global) or project (repo-specific)', 'user')
     .option('-t, --transport <type>', 'stdio (default) or http', 'stdio')
     .option('--names <list>', 'When source is a repo: MCP server names to install (comma-separated)')
+    .option('-y, --yes', 'Auto-install any missing agent versions without prompting')
     .option('-H, --header <header>', 'HTTP header as name:value (repeatable)', (val, acc: string[]) => {
       acc.push(val);
       return acc;
@@ -285,6 +334,14 @@ Examples:
       const manifest = readManifest(localPath) || createDefaultManifest();
 
       manifest.mcp = manifest.mcp || {};
+
+      // Pre-flight: prompt-and-install any requested agent@version that isn't
+      // installed yet, before parseMcpAgentTargets validates the selector.
+      const okInstall = await ensureAgentVersionsInstalled(options.agents, MCP_CAPABLE_AGENTS, { yes: options.yes });
+      if (!okInstall) {
+        console.log(chalk.gray('Cancelled.'));
+        return;
+      }
 
       const targetConfig = parseMcpAgentTargets(options.agents);
 
@@ -571,6 +628,7 @@ Examples:
     .command('register [name]')
     .description('Apply MCP servers from manifest to agent config files')
     .option('-a, --agents <list>', 'Override manifest targets: claude, codex@0.116.0')
+    .option('-y, --yes', 'Auto-install any missing agent versions without prompting')
     .addHelpText('after', `
 Examples:
   # Register all servers from manifest
@@ -612,9 +670,17 @@ Examples:
         }
 
         console.log(`\n  ${chalk.cyan(mcpName)}:`);
-        const targets = options.agents
-          ? resolveInstalledAgentTargets(options.agents, MCP_CAPABLE_AGENTS)
-          : resolveConfiguredAgentTargets(config.agents, config.agentVersions, MCP_CAPABLE_AGENTS);
+        let targets;
+        if (options.agents) {
+          const resolved = await resolveInstalledAgentTargetsAutoInstalling(options.agents, MCP_CAPABLE_AGENTS, { yes: options.yes });
+          if (!resolved) {
+            console.log(chalk.gray('  Cancelled.'));
+            continue;
+          }
+          targets = resolved;
+        } else {
+          targets = resolveConfiguredAgentTargets(config.agents, config.agentVersions, MCP_CAPABLE_AGENTS);
+        }
         const results = await registerMcpToTargets(
           targets,
           mcpName,
@@ -639,7 +705,7 @@ Examples:
 
 async function installMcpsFromRepoSource(
   source: string,
-  options: { names?: string; agents?: string }
+  options: { names?: string; agents?: string; yes?: boolean }
 ): Promise<void> {
   const spinner = ora('Cloning repository...').start();
   let localPath: string;
@@ -693,12 +759,17 @@ async function installMcpsFromRepoSource(
   installSpinner.succeed(`Installed ${installed} MCP config(s) to ~/.agents/mcp/`);
 
   // Agent/version selection — same default as the non-repo form: every
-  // MCP-capable agent. resolveAgentVersionTargets is lenient with agents
-  // that have no installed versions.
+  // MCP-capable agent. Routes through resolveAgentTargetsAutoInstalling so
+  // a typo'd `claude@2.1.999` prompts to install (and --yes auto-installs).
   const agentsValue = options.agents ?? MCP_CAPABLE_AGENTS.join(',');
-  let targets: ReturnType<typeof resolveAgentVersionTargets>;
+  let targets;
   try {
-    targets = resolveAgentVersionTargets(agentsValue, MCP_CAPABLE_AGENTS);
+    const resolved = await resolveAgentTargetsAutoInstalling(agentsValue, MCP_CAPABLE_AGENTS, { yes: options.yes });
+    if (!resolved) {
+      console.log(chalk.gray('\nCancelled.'));
+      return;
+    }
+    targets = resolved;
   } catch (err) {
     console.log(chalk.red((err as Error).message));
     process.exit(1);

--- a/src/commands/packages.ts
+++ b/src/commands/packages.ts
@@ -69,6 +69,7 @@ import {
   parseCommaSeparatedList,
   requireDestructiveArg,
   requireInteractiveSelection,
+  resolveInstalledAgentTargetsAutoInstalling,
 } from './utils.js';
 import { itemPicker } from '../lib/picker.js';
 import {
@@ -431,6 +432,7 @@ When to use:
       '--names <list>',
       'When source is a repo: comma-separated resource names within the selected types'
     )
+    .option('-y, --yes', 'Auto-install any missing agent versions without prompting')
     .addHelpText('after', `
 Install resolves the package type (MCP server, skill, command, hook) and installs to the specified agents. Packages can come from registries (mcp:, skill:), GitHub (gh:user/repo), or direct URLs.
 
@@ -521,9 +523,17 @@ When to use:
           const installedAgents = MCP_CAPABLE_AGENTS.filter(
             (id) => cliStates[id]?.installed || listInstalledVersions(id).length > 0
           );
-          const targets = options.agents
-            ? resolveInstalledAgentTargets(options.agents, MCP_CAPABLE_AGENTS)
-            : resolveConfiguredAgentTargets(installedAgents, undefined, MCP_CAPABLE_AGENTS);
+          let targets;
+          if (options.agents) {
+            const resolved = await resolveInstalledAgentTargetsAutoInstalling(options.agents, MCP_CAPABLE_AGENTS, { yes: options.yes });
+            if (!resolved) {
+              console.log(chalk.gray('Cancelled.'));
+              return;
+            }
+            targets = resolved;
+          } else {
+            targets = resolveConfiguredAgentTargets(installedAgents, undefined, MCP_CAPABLE_AGENTS);
+          }
 
           if (targets.selectedAgents.length === 0) {
             console.log(chalk.yellow('\nNo MCP-capable agents installed.'));
@@ -625,9 +635,17 @@ When to use:
           const installedAgents = ALL_AGENT_IDS.filter(
             (id) => gitCliStates[id]?.installed || listInstalledVersions(id).length > 0
           );
-          const targets = options.agents
-            ? resolveInstalledAgentTargets(options.agents, ALL_AGENT_IDS)
-            : resolveConfiguredAgentTargets(installedAgents, undefined, ALL_AGENT_IDS);
+          let targets;
+          if (options.agents) {
+            const resolved = await resolveInstalledAgentTargetsAutoInstalling(options.agents, ALL_AGENT_IDS, { yes: options.yes });
+            if (!resolved) {
+              console.log(chalk.gray('Cancelled.'));
+              return;
+            }
+            targets = resolved;
+          } else {
+            targets = resolveConfiguredAgentTargets(installedAgents, undefined, ALL_AGENT_IDS);
+          }
 
           if (targets.selectedAgents.length === 0) {
             console.log(chalk.yellow('\nNo agents selected.'));

--- a/src/commands/permissions.ts
+++ b/src/commands/permissions.ts
@@ -52,6 +52,7 @@ import {
   parseCommaSeparatedList,
   printWithPager,
   requireInteractiveSelection,
+  resolveAgentTargetsAutoInstalling,
 } from './utils.js';
 
 export function shouldRefuseBroadPermissions(
@@ -356,9 +357,14 @@ Examples:
           let versionSelections: Map<AgentId, string[]>;
 
           if (options.agents) {
-            const result = resolveAgentVersionTargets(options.agents, PERMISSIONS_CAPABLE_AGENTS, {
+            const result = await resolveAgentTargetsAutoInstalling(options.agents, PERMISSIONS_CAPABLE_AGENTS, {
+              yes: options.yes,
               allVersions: options.all,
             });
+            if (!result) {
+              console.log(chalk.gray('Cancelled.'));
+              return;
+            }
             selectedAgents = result.selectedAgents;
             versionSelections = result.versionSelections;
           } else if (options.all) {
@@ -513,9 +519,14 @@ Examples:
           let versionSelections: Map<AgentId, string[]>;
 
           if (options.agents) {
-            const result = resolveAgentVersionTargets(options.agents, PERMISSIONS_CAPABLE_AGENTS, {
+            const result = await resolveAgentTargetsAutoInstalling(options.agents, PERMISSIONS_CAPABLE_AGENTS, {
+              yes: options.yes,
               allVersions: options.all,
             });
+            if (!result) {
+              console.log(chalk.gray('Cancelled.'));
+              return;
+            }
             selectedAgents = result.selectedAgents;
             versionSelections = result.versionSelections;
           } else if (options.all) {
@@ -645,9 +656,14 @@ Examples:
           let versionSelections: Map<AgentId, string[]>;
 
           if (options.agents) {
-            const result = resolveAgentVersionTargets(options.agents, PERMISSIONS_CAPABLE_AGENTS, {
+            const result = await resolveAgentTargetsAutoInstalling(options.agents, PERMISSIONS_CAPABLE_AGENTS, {
+              yes: options.yes,
               allVersions: options.all,
             });
+            if (!result) {
+              console.log(chalk.gray('Cancelled.'));
+              return;
+            }
             selectedAgents = result.selectedAgents;
             versionSelections = result.versionSelections;
           } else if (options.all) {

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -53,6 +53,7 @@ import {
   printWithPager,
   requireInteractiveSelection,
   requireDestructiveArg,
+  resolveAgentTargetsAutoInstalling,
 } from './utils.js';
 
 /** Register the `agents rules` command tree (list, add, view, remove). */
@@ -388,7 +389,11 @@ Examples:
         let versionSelections: Map<AgentId, string[]>;
 
         if (options.agents) {
-          const result = resolveAgentVersionTargets(options.agents, ALL_AGENT_IDS);
+          const result = await resolveAgentTargetsAutoInstalling(options.agents, ALL_AGENT_IDS, { yes: options.yes });
+          if (!result) {
+            console.log(chalk.gray('Cancelled.'));
+            return;
+          }
           selectedAgents = result.selectedAgents;
           versionSelections = result.versionSelections;
         } else {

--- a/src/commands/skills.ts
+++ b/src/commands/skills.ts
@@ -57,6 +57,7 @@ import {
   parseCommaSeparatedList,
   printWithPager,
   requireInteractiveSelection,
+  resolveAgentTargetsAutoInstalling,
   promptRemovalTargets,
   type RemovalTarget,
 } from './utils.js';
@@ -332,7 +333,11 @@ Examples:
         let versionSelections: Map<AgentId, string[]>;
 
         if (options.agents) {
-          const result = resolveAgentVersionTargets(options.agents, SKILLS_CAPABLE_AGENTS);
+          const result = await resolveAgentTargetsAutoInstalling(options.agents, SKILLS_CAPABLE_AGENTS, { yes: options.yes });
+          if (!result) {
+            console.log(chalk.gray('Cancelled.'));
+            return;
+          }
           selectedAgents = result.selectedAgents;
           versionSelections = result.versionSelections;
         } else {

--- a/src/commands/subagents.ts
+++ b/src/commands/subagents.ts
@@ -43,6 +43,7 @@ import {
   requireDestructiveArg,
   promptRemovalTargets,
   parseCommaSeparatedList,
+  resolveAgentTargetsAutoInstalling,
   type RemovalTarget,
 } from './utils.js';
 import {
@@ -231,7 +232,11 @@ Examples:
       let versionSelections: Map<AgentId, string[]>;
 
       if (agentsArg) {
-        const result = resolveAgentVersionTargets(agentsArg, SUBAGENT_CAPABLE_AGENTS);
+        const result = await resolveAgentTargetsAutoInstalling(agentsArg, SUBAGENT_CAPABLE_AGENTS, { yes: options.yes });
+        if (!result) {
+          console.log(chalk.gray('Cancelled.'));
+          return;
+        }
         selectedAgents = result.selectedAgents;
         versionSelections = result.versionSelections;
       } else {

--- a/src/commands/utils.ts
+++ b/src/commands/utils.ts
@@ -8,6 +8,19 @@
 import * as os from 'os';
 import { spawnSync } from 'child_process';
 import chalk from 'chalk';
+import ora from 'ora';
+import { confirm } from '@inquirer/prompts';
+import type { AgentId } from '../lib/types.js';
+import { AGENTS, agentLabel, resolveAgentName } from '../lib/agents.js';
+import {
+  installVersion,
+  listInstalledVersions,
+  resolveAgentVersionTargets,
+  resolveInstalledAgentTargets,
+  VersionNotInstalledError,
+  type InstalledAgentTargetResult,
+  type VersionSelectionResult,
+} from '../lib/versions.js';
 
 /**
  * Check if an error is from user cancelling a prompt (Ctrl+C)
@@ -167,3 +180,161 @@ export function formatPath(fullPath: string, cwd?: string): string {
   }
   return fullPath;
 }
+
+/**
+ * Parse a --agents selector and collect every (agentId, specificVersion) pair
+ * the user requested where the version is a concrete x.y.z (not `default`,
+ * not `all`, not `latest`) and is NOT currently installed.
+ *
+ * This is the lookahead the auto-install wrappers use to decide whether to
+ * prompt + install before delegating to resolveAgentVersionTargets.
+ */
+function collectMissingVersions(
+  value: string,
+  availableAgents: readonly AgentId[]
+): Array<{ agentId: AgentId; version: string }> {
+  const missing: Array<{ agentId: AgentId; version: string }> = [];
+  const seen = new Set<string>();
+
+  for (const raw of value.split(',').map((s) => s.trim()).filter(Boolean)) {
+    // Literal `all` / `all@all` expand to per-agent — never missing.
+    if (raw === 'all' || raw === 'all@all') continue;
+
+    const atIndex = raw.indexOf('@');
+    if (atIndex === -1) continue; // bare agent → resolves to default; never missing in this sense
+
+    const agentToken = raw.slice(0, atIndex).trim();
+    const versionToken = raw.slice(atIndex + 1).trim();
+
+    // Non-specific selectors handled by the underlying resolver.
+    if (!versionToken || versionToken === 'default' || versionToken === 'all') continue;
+
+    const agentId = resolveAgentName(agentToken);
+    if (!agentId || !availableAgents.includes(agentId)) continue;
+
+    const installed = listInstalledVersions(agentId);
+    if (installed.includes(versionToken)) continue;
+
+    const key = `${agentId}@${versionToken}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    missing.push({ agentId, version: versionToken });
+  }
+
+  return missing;
+}
+
+/**
+ * Sequentially install every requested missing version with a per-version
+ * spinner. Aborts via process.exit(1) on the first failure — the user
+ * already approved the install so a partial-install outcome is worse than
+ * a hard stop.
+ */
+async function installMissingVersions(
+  missing: ReadonlyArray<{ agentId: AgentId; version: string }>
+): Promise<void> {
+  for (const { agentId, version } of missing) {
+    const label = `${agentLabel(agentId)}@${version}`;
+    const spinner = ora(`Installing ${label}...`).start();
+    try {
+      const result = await installVersion(agentId, version, (msg) => {
+        spinner.text = msg;
+      });
+      if (!result.success) {
+        spinner.fail(`Failed to install ${label}: ${result.error ?? 'unknown error'}`);
+        process.exit(1);
+      }
+      spinner.succeed(`Installed ${label}`);
+    } catch (err) {
+      spinner.fail(`Failed to install ${label}: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  }
+}
+
+/**
+ * Make sure every specific `agent@x.y.z` the user typed is installed before
+ * the caller resolves targets. Returns true if the caller should continue,
+ * false if the user declined the prompt. Exported so non-standard caller
+ * shapes (e.g. mcp.ts's manifest-shaped parser) can run the pre-flight
+ * without going through resolveAgentVersionTargets first.
+ */
+export async function ensureAgentVersionsInstalled(
+  value: string,
+  availableAgents: readonly AgentId[],
+  options: { yes?: boolean } = {}
+): Promise<boolean> {
+  const missing = collectMissingVersions(value, availableAgents);
+  if (missing.length === 0) return true;
+
+  const summary = missing.map((m) => `${agentLabel(m.agentId)}@${m.version}`).join(', ');
+
+  if (!options.yes) {
+    if (!isInteractiveTerminal()) {
+      console.error(chalk.red(`Missing agent version(s): ${summary}`));
+      console.error(chalk.gray('In a scripted shell, opt in to auto-install:'));
+      console.error(chalk.cyan(`  rerun with --yes`));
+      console.error(chalk.gray('Or pre-install:'));
+      for (const m of missing) {
+        console.error(chalk.cyan(`  agents add ${m.agentId}@${m.version}`));
+      }
+      process.exit(1);
+    }
+
+    console.log(chalk.yellow(`\nThe following agent version(s) are not installed:`));
+    for (const m of missing) {
+      console.log(`  ${chalk.cyan(`${agentLabel(m.agentId)}@${m.version}`)}`);
+    }
+
+    let proceed: boolean;
+    try {
+      proceed = await confirm({
+        message: `Install ${missing.length} missing version${missing.length === 1 ? '' : 's'}?`,
+        default: true,
+      });
+    } catch (err) {
+      if (isPromptCancelled(err)) return false;
+      throw err;
+    }
+    if (!proceed) return false;
+  }
+
+  await installMissingVersions(missing);
+  return true;
+}
+
+/**
+ * Resolve a `--agents` selector and, if any requested `agent@version` isn't
+ * installed yet, prompt to install it (or auto-install with --yes) before
+ * delegating to resolveAgentVersionTargets. Returns null when the user
+ * declines the install prompt — callers should treat that as a clean cancel.
+ */
+export async function resolveAgentTargetsAutoInstalling(
+  value: string,
+  availableAgents: readonly AgentId[],
+  options: { yes?: boolean; allVersions?: boolean } = {}
+): Promise<VersionSelectionResult | null> {
+  const ok = await ensureAgentVersionsInstalled(value, availableAgents, options);
+  if (!ok) return null;
+  return resolveAgentVersionTargets(value, availableAgents, { allVersions: options.allVersions });
+}
+
+/**
+ * Same as resolveAgentTargetsAutoInstalling but returns the broader
+ * InstalledAgentTargetResult that includes `directAgents` (for paths like
+ * `agents install` and `mcp register` that fall through to unmanaged homes
+ * when no managed version is installed).
+ */
+export async function resolveInstalledAgentTargetsAutoInstalling(
+  value: string,
+  availableAgents: readonly AgentId[],
+  options: { yes?: boolean; allVersions?: boolean } = {}
+): Promise<InstalledAgentTargetResult | null> {
+  const ok = await ensureAgentVersionsInstalled(value, availableAgents, options);
+  if (!ok) return null;
+  return resolveInstalledAgentTargets(value, availableAgents, { allVersions: options.allVersions });
+}
+
+// Re-export so callers can `catch (err) { if (err instanceof VersionNotInstalledError) … }`
+// without reaching into ../lib/versions directly.
+export { VersionNotInstalledError } from '../lib/versions.js';

--- a/src/commands/workflows.ts
+++ b/src/commands/workflows.ts
@@ -44,6 +44,7 @@ import {
   printWithPager,
   promptRemovalTargets,
   parseCommaSeparatedList,
+  resolveAgentTargetsAutoInstalling,
   type RemovalTarget,
 } from './utils.js';
 import {
@@ -267,7 +268,11 @@ Examples:
         let versionSelections: Map<AgentId, string[]>;
 
         if (options.agents) {
-          const result = resolveAgentVersionTargets(options.agents, WORKFLOW_CAPABLE_AGENTS);
+          const result = await resolveAgentTargetsAutoInstalling(options.agents, WORKFLOW_CAPABLE_AGENTS, { yes: options.yes });
+          if (!result) {
+            console.log(chalk.gray('Cancelled.'));
+            return;
+          }
           selectedAgents = result.selectedAgents;
           versionSelections = result.versionSelections;
         } else {

--- a/src/lib/__tests__/version-not-installed-error.test.ts
+++ b/src/lib/__tests__/version-not-installed-error.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for VersionNotInstalledError + selector consistency between
+ * resolveAgentVersionTargets and resolveInstalledAgentTargets.
+ *
+ * Before this work, resolveInstalledAgentTargets was missing the `@all`
+ * branch and threw a bare Error (the auto-install wrapper could not catch
+ * it by type, only by string match). Both gaps are closed here.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+let TEST_ROOT: string;
+let VERSIONS_DIR: string;
+
+vi.mock('../state.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../state.js')>();
+  return {
+    ...actual,
+    getVersionsDir: () => VERSIONS_DIR,
+  };
+});
+
+async function loadLib() {
+  return await import('../versions.js');
+}
+
+const CLI_COMMAND: Record<string, string> = {
+  claude: 'claude',
+  codex: 'codex',
+  gemini: 'gemini',
+};
+
+function makeFakeInstall(agent: string, version: string): void {
+  const binDir = path.join(VERSIONS_DIR, agent, version, 'node_modules', '.bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  const cli = CLI_COMMAND[agent] ?? agent;
+  fs.writeFileSync(path.join(binDir, cli), '#!/bin/sh\n');
+  fs.chmodSync(path.join(binDir, cli), 0o755);
+}
+
+describe('VersionNotInstalledError + resolveInstalledAgentTargets @all parity', () => {
+  beforeEach(() => {
+    TEST_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'vne-'));
+    VERSIONS_DIR = path.join(TEST_ROOT, 'versions');
+    fs.mkdirSync(VERSIONS_DIR, { recursive: true });
+    vi.resetModules();
+  });
+
+  it('resolveAgentVersionTargets throws VersionNotInstalledError with agentId + version', async () => {
+    makeFakeInstall('claude', '2.1.141');
+    const { resolveAgentVersionTargets, VersionNotInstalledError } = await loadLib();
+
+    try {
+      resolveAgentVersionTargets('claude@2.1.999', ['claude']);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(VersionNotInstalledError);
+      const typed = err as InstanceType<typeof VersionNotInstalledError>;
+      expect(typed.agentId).toBe('claude');
+      expect(typed.version).toBe('2.1.999');
+      expect(typed.installedVersions).toContain('2.1.141');
+    }
+  });
+
+  it('resolveInstalledAgentTargets throws VersionNotInstalledError with agentId + version', async () => {
+    makeFakeInstall('claude', '2.1.141');
+    const { resolveInstalledAgentTargets, VersionNotInstalledError } = await loadLib();
+
+    try {
+      resolveInstalledAgentTargets('claude@2.1.999', ['claude']);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(VersionNotInstalledError);
+      const typed = err as InstanceType<typeof VersionNotInstalledError>;
+      expect(typed.agentId).toBe('claude');
+      expect(typed.version).toBe('2.1.999');
+    }
+  });
+
+  it('resolveInstalledAgentTargets expands `agent@all` to every installed version', async () => {
+    makeFakeInstall('claude', '2.1.141');
+    makeFakeInstall('claude', '2.1.158');
+    makeFakeInstall('claude', '2.1.200');
+
+    const { resolveInstalledAgentTargets } = await loadLib();
+    const result = resolveInstalledAgentTargets('claude@all', ['claude']);
+
+    expect(result.selectedAgents).toEqual(['claude']);
+    const versions = result.versionSelections.get('claude');
+    expect(versions).toBeDefined();
+    expect(new Set(versions)).toEqual(new Set(['2.1.141', '2.1.158', '2.1.200']));
+  });
+
+  it('resolveInstalledAgentTargets expands literal `all` across capable agents (skipping uninstalled)', async () => {
+    makeFakeInstall('claude', '2.1.141');
+    makeFakeInstall('codex', '0.116.0');
+    // gemini intentionally not installed
+
+    const { resolveInstalledAgentTargets } = await loadLib();
+    const result = resolveInstalledAgentTargets('all', ['claude', 'codex', 'gemini']);
+
+    expect(new Set(result.selectedAgents)).toEqual(new Set(['claude', 'codex']));
+    expect(result.versionSelections.get('claude')).toEqual(['2.1.141']);
+    expect(result.versionSelections.get('codex')).toEqual(['0.116.0']);
+    expect(result.versionSelections.has('gemini')).toBe(false);
+  });
+});

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -2317,6 +2317,23 @@ export interface InstalledAgentTargetResult {
 }
 
 /**
+ * Thrown when the user references an agent@version that is not installed.
+ * Carries the parsed (agentId, version) so callers can react — e.g. prompt
+ * to install it on demand — without having to parse the error message.
+ */
+export class VersionNotInstalledError extends Error {
+  constructor(
+    public readonly agentId: AgentId,
+    public readonly version: string,
+    public readonly installedVersions: readonly string[]
+  ) {
+    const installed = installedVersions.length > 0 ? installedVersions.join(', ') : '(none)';
+    super(`Version ${version} is not installed for ${AGENTS[agentId].name}. Installed versions: ${installed}`);
+    this.name = 'VersionNotInstalledError';
+  }
+}
+
+/**
  * Resolve a comma-separated --agents list into concrete version selections.
  * Bare agents target the default version, or the newest installed version when no default exists.
  * Explicit agent@version targets only that installed version.
@@ -2421,9 +2438,7 @@ export function resolveAgentVersionTargets(
     }
 
     if (!installedVersions.includes(versionToken)) {
-      throw new Error(
-        `Version ${versionToken} is not installed for ${AGENTS[agentId].name}. Installed versions: ${installedVersions.join(', ')}`
-      );
+      throw new VersionNotInstalledError(agentId, versionToken, installedVersions);
     }
 
     const explicitVersions = explicitSelections.has(agentId)
@@ -2454,10 +2469,28 @@ export function resolveInstalledAgentTargets(
   const selectedAgents: AgentId[] = [];
   const directAgents: AgentId[] = [];
   const versionSelections = new Map<AgentId, string[]>();
-  const targets = value
+  const rawTargets = value
     .split(',')
     .map((item) => item.trim())
     .filter(Boolean);
+
+  // Expand literal `all` (with optional @all) into every available agent's all
+  // installed versions. Skip agents with no installed versions so `all` is
+  // lenient — only explicit `claude@all` errors when claude isn't installed.
+  // Mirrors resolveAgentVersionTargets so every --agents flag site supports
+  // the same selector syntax.
+  const targets: string[] = [];
+  for (const t of rawTargets) {
+    if (t === 'all' || t === 'all@all') {
+      for (const a of availableAgents) {
+        if (listInstalledVersions(a).length > 0) {
+          targets.push(`${a}@all`);
+        }
+      }
+    } else {
+      targets.push(t);
+    }
+  }
 
   const addVersionTarget = (agentId: AgentId, version: string) => {
     const versions = versionSelections.get(agentId) || [];
@@ -2482,7 +2515,7 @@ export function resolveInstalledAgentTargets(
     }
 
     if (atIndex !== -1 && !versionToken) {
-      throw new Error(`Missing version in --agents entry '${target}'. Use agent@x.y.z or agent@default.`);
+      throw new Error(`Missing version in --agents entry '${target}'. Use agent@x.y.z, agent@default, or agent@all.`);
     }
 
     const agentId = resolveAgentName(agentToken);
@@ -2523,14 +2556,22 @@ export function resolveInstalledAgentTargets(
       continue;
     }
 
+    if (versionToken === 'all') {
+      if (installedVersions.length === 0) {
+        throw new Error(`No managed versions are installed for ${AGENTS[agentId].name}. Run: agents add ${agentId}@latest`);
+      }
+      for (const version of installedVersions) {
+        addVersionTarget(agentId, version);
+      }
+      continue;
+    }
+
     if (installedVersions.length === 0) {
       throw new Error(`No managed versions are installed for ${AGENTS[agentId].name}. Run: agents add ${agentId}@latest`);
     }
 
     if (!installedVersions.includes(versionToken)) {
-      throw new Error(
-        `Version ${versionToken} is not installed for ${AGENTS[agentId].name}. Installed versions: ${installedVersions.join(', ')}`
-      );
+      throw new VersionNotInstalledError(agentId, versionToken, installedVersions);
     }
 
     addVersionTarget(agentId, versionToken);


### PR DESCRIPTION
## Summary

Two related changes that together close the inconsistencies the audit surfaced in #118-128:

**1. Auto-install on missing version.** When `--agents claude@2.1.999` references a version that isn't installed, prompt to install it (or auto-install with `--yes`) then continue. Used to be a hard error.

\`\`\`
$ agents skills add gh:phnx-labs/.agents-system --names animator --agents claude@2.1.999

Found 1 skill(s):
  animator: ...

The following agent version(s) are not installed:
  Claude@2.1.999

? Install 1 missing version? (Y/n) y

- Installing Claude@2.1.999...
✔ Installed Claude@2.1.999

Synced skills to 1 managed version(s)
\`\`\`

Non-TTY without `--yes` errors clearly:
\`\`\`
Missing agent version(s): Claude@2.1.999
In a scripted shell, opt in to auto-install:
  rerun with --yes
Or pre-install:
  agents add claude@2.1.999
\`\`\`

**2. Selector consistency.** Every `--agents`-taking command now supports the same syntax: \`agent\`, \`agent@default\`, \`agent@x.y.z\`, \`agent@all\`, literal \`all\`. The audit found four gaps, all closed here:

| Command | Before | After |
|---|---|---|
| \`agents install gh:...\` (mcp: and gh: paths) | \`@all\` threw "Version all is not installed" | works |
| \`mcp add\` inline form | \`@all\` not recognised | works (parseMcpAgentTargets extended) |
| \`mcp register\`, \`mcp remove\` | no \`@all\` | works |
| \`commands remove\`, \`hooks remove\` | raw \`split(',')\` against bare AgentId; \`@version\` silently matched zero | routed through resolveInstalledAgentTargets |

## Implementation

- **VersionNotInstalledError** in \`src/lib/versions.ts\` carries \`agentId\` + \`version\` + \`installedVersions\`. Both resolver throw sites (\`resolveAgentVersionTargets\` / \`resolveInstalledAgentTargets\`) use it instead of bare \`Error\` so callers can catch by type.
- **\`resolveAgentTargetsAutoInstalling\` + \`resolveInstalledAgentTargetsAutoInstalling\`** wrappers in \`src/commands/utils.ts\` pre-flight the selector, bulk-prompt, call \`installVersion\` per missing version with spinners, then delegate to the underlying resolver.
- **\`--yes\` flag** added to commands that didn't already have one (\`mcp add\`, \`mcp register\`, \`agents install\`). Pre-existing \`--yes\` on \`<resource> add\` family keeps its existing "skip prompts" semantics, with the bonus of also covering the new install confirm.

## Out of scope

Deferred to follow-up PRs per the audit:
- **Browser profile agent-version pinning** — \`BrowserProfileConfig\` currently has no agent/version field.
- **Execution-time pinning** — \`agents routines add --agent\` is bare-only; \`agents run claude@default\` silently degrades; \`agents teams add ... claude@default\` stores null and tracks later default changes.

## Test plan

- [x] 9 new unit tests across two files:
  - \`src/lib/__tests__/version-not-installed-error.test.ts\` (4) — typed error at both resolver sites, \`@all\` + literal \`all\` expansion on \`resolveInstalledAgentTargets\`.
  - \`src/commands/__tests__/auto-install-resolver.test.ts\` (5) — happy path, \`--yes\` auto-install, non-TTY exit, install-failure abort, no-op short-circuit for non-specific selectors. \`installVersion\` mocked.
- [x] \`bun run build\` clean (tsc passes).
- [x] \`bunx vitest run src/lib/__tests__/ src/commands/__tests__/ tests/non-interactive.test.ts tests/registry.test.ts\` — 45/46 test files pass; the 4 \`models.test.ts\` failures pre-exist on \`origin/main\` (same set documented in #118 / #127 / #128) and are environment-dependent.
- [x] Live smoke: \`agents workflows add /tmp/fixture --agents claude@99.99.99\` (non-TTY) fires the new error message pointing at \`--yes\` and \`agents add claude@99.99.99\`.
- [x] CLI surface verified via \`agents mcp add --help\`, \`agents install --help\`, \`agents mcp register --help\` — \`--yes\` flag visible, \`@all\` advertised.

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/74c016e5978521a9175e05569420db47)