### PR TITLE
feat(modes): four-mode permission system (plan/edit/auto/skip) with capability gating

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -14,6 +14,8 @@ import {
   execAgent,
   runWithFallback,
   AGENT_COMMANDS,
+  normalizeMode,
+  resolveMode,
   type ExecOptions,
   type ExecMode,
   type ExecEffort,
@@ -78,7 +80,7 @@ export function registerRunCommand(program: Command): void {
   const runCmd = program
     .command('run <agent> [prompt]')
     .description('Execute an agent. Pass a prompt for headless runs; omit it to launch the agent interactively.')
-    .option('-m, --mode <mode>', 'How much the agent can do: plan (read-only), edit (can write files), full (writes + all permissions)', 'plan')
+    .option('-m, --mode <mode>', 'How much the agent can do: plan (read-only), edit (can write files), auto (smart classifier auto-approves safe ops, prompts for risky), skip (bypass all permission prompts). \'full\' accepted as alias for skip.', 'plan')
     .option('-e, --effort <effort>', 'Reasoning effort: low | medium | high | xhigh | max | auto (claude and codex only)', 'auto')
     .option('--model <model>', 'Override the model directly (e.g., claude-opus-4-6)')
     .option(
@@ -149,8 +151,12 @@ export function registerRunCommand(program: Command): void {
       agents run claude "deploy the worker" --secrets prod --mode edit
     `,
     notes: `
-      Modes:
-        plan  read-only       edit  can write files       full  writes + all permissions
+      Modes (not every agent supports every mode — check agents.yaml capabilities):
+        plan  read-only investigation; no writes, no shell side-effects
+        edit  may edit files; prompts for shell / risky operations
+        auto  smart classifier auto-approves safe ops, prompts for risky (claude, copilot)
+        skip  bypass every permission prompt (dangerously-skip-permissions)
+        Legacy 'full' is silently rewritten to 'skip'.
 
       Run strategy (set via --strategy or run.<agent>.strategy in agents.yaml):
         pinned     use the workspace/global pinned version (default)
@@ -324,9 +330,21 @@ export function registerRunCommand(program: Command): void {
         }
       }
 
+      // Accept the four canonical modes plus 'full' as a permanent silent
+      // alias for 'skip' (rewritten downstream by normalizeMode in exec.ts).
       const mode = options.mode as ExecMode;
-      if (!['plan', 'edit', 'full'].includes(mode)) {
-        console.error(chalk.red(`Invalid mode: ${mode}. Use 'plan', 'edit', or 'full'`));
+      if (!['plan', 'edit', 'auto', 'skip', 'full'].includes(mode)) {
+        console.error(chalk.red(`Invalid mode: ${mode}. Use plan, edit, auto, or skip ('full' accepted as alias for skip).`));
+        process.exit(1);
+      }
+
+      // Surface capability errors as a clean CLI message instead of a stack
+      // trace from buildExecCommand. resolveMode degrades 'auto' silently and
+      // throws on unsupported 'plan'/'skip' — we catch and pretty-print.
+      try {
+        resolveMode(agent, normalizeMode(mode));
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
         process.exit(1);
       }
 

--- a/src/commands/routines.ts
+++ b/src/commands/routines.ts
@@ -239,7 +239,7 @@ export function registerRoutinesCommands(program: Command): void {
     .option('-a, --agent <agent>', 'Which agent runs this routine: claude, codex, gemini, cursor, or opencode')
     .option('--workflow <name>', 'Run an installed workflow (~/.agents/workflows/<name>) via `agents run`. Mutually exclusive with --agent.')
     .option('-p, --prompt <prompt>', 'Task instruction for the agent')
-    .option('-m, --mode <mode>', 'Execution mode: plan (read-only) or edit (can write files)', 'plan')
+    .option('-m, --mode <mode>', "Execution mode: plan (read-only), edit (can write files), auto (smart classifier), or skip (bypass all permission prompts). 'full' accepted as alias for skip.", 'plan')
     .option('-e, --effort <effort>', 'Reasoning effort: low | medium | high | xhigh | max | auto', 'auto')
     .option('-t, --timeout <timeout>', 'Kill the agent if it runs longer than this (e.g., 10m, 2h, 3d, 1w; max 1w)', '10m')
     .option('--timezone <tz>', 'Interpret schedule in this timezone (e.g., America/Los_Angeles)')

--- a/src/commands/teams.ts
+++ b/src/commands/teams.ts
@@ -70,7 +70,8 @@ const AGENT_NAMES: Record<AgentType, string> = {
 };
 
 const VALID_AGENTS = Object.keys(AGENT_NAMES) as AgentType[];
-const VALID_MODES = ['plan', 'edit', 'full'] as const;
+// 'full' kept as historical alias for 'skip'; normalized to 'skip' downstream.
+const VALID_MODES = ['plan', 'edit', 'auto', 'skip', 'full'] as const;
 const VALID_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max', 'auto'] as const;
 const VALID_CLOUD_PROVIDERS = ['rush', 'codex', 'factory'] as const satisfies readonly CloudProviderId[];
 
@@ -812,7 +813,7 @@ export function registerTeamsCommands(program: Command): void {
     .alias('a')
     .description("Add a teammate to work on a task. Runs in background; returns immediately. Use 'status' to check in.")
     .option('-n, --name <name>', 'Friendly name for this teammate (e.g. alice). Required if using --after. Unique within team.')
-    .option('-m, --mode <mode>', `Permissions: plan (read-only) | edit (can write files) | full (write + skip permission prompts)`, 'edit')
+    .option('-m, --mode <mode>', `Permissions: plan (read-only) | edit (can write files) | auto (smart classifier auto-approves safe ops) | skip (bypass all permission prompts). 'full' accepted as alias for skip.`, 'edit')
     .option('-e, --effort <effort>', `Reasoning intensity: ${VALID_EFFORTS.join('|')}`, 'medium')
     .option('--model <model>', 'Override the effort tier and use this specific model (e.g. claude-opus-4-6)')
     .option(

--- a/src/lib/__tests__/exec.test.ts
+++ b/src/lib/__tests__/exec.test.ts
@@ -6,10 +6,12 @@ import {
   detectRateLimit,
   AGENT_COMMANDS,
   parseExecEnv,
+  normalizeMode,
+  resolveMode,
   type ExecOptions,
-  type ExecMode,
 } from '../exec.js';
-import type { AgentId } from '../types.js';
+import type { AgentId, Mode } from '../types.js';
+import { AGENTS } from '../agents.js';
 
 function opts(overrides: Partial<ExecOptions>): ExecOptions {
   return {
@@ -22,7 +24,6 @@ function opts(overrides: Partial<ExecOptions>): ExecOptions {
 }
 
 const ALL_AGENTS = Object.keys(AGENT_COMMANDS) as AgentId[];
-const ALL_MODES: ExecMode[] = ['plan', 'edit', 'full'];
 
 describe('buildExecCommand', () => {
   // --- Mode flags per agent ---
@@ -40,10 +41,21 @@ describe('buildExecCommand', () => {
       expect(cmd[cmd.indexOf('--permission-mode') + 1]).toBe('acceptEdits');
     });
 
-    it('claude full produces --dangerously-skip-permissions', () => {
-      const cmd = buildExecCommand(opts({ agent: 'claude', mode: 'full' }));
+    it('claude skip produces --dangerously-skip-permissions', () => {
+      const cmd = buildExecCommand(opts({ agent: 'claude', mode: 'skip' }));
       expect(cmd).toContain('--dangerously-skip-permissions');
       expect(cmd).not.toContain('--permission-mode');
+    });
+
+    it("claude 'full' (legacy alias) routes through skip and produces --dangerously-skip-permissions", () => {
+      const cmd = buildExecCommand(opts({ agent: 'claude', mode: 'skip' as Mode }));
+      expect(cmd).toContain('--dangerously-skip-permissions');
+    });
+
+    it('claude auto produces --permission-mode auto (smart classifier)', () => {
+      const cmd = buildExecCommand(opts({ agent: 'claude', mode: 'auto' }));
+      expect(cmd).toContain('--permission-mode');
+      expect(cmd[cmd.indexOf('--permission-mode') + 1]).toBe('auto');
     });
 
     it('codex plan produces --sandbox workspace-write', () => {
@@ -59,39 +71,41 @@ describe('buildExecCommand', () => {
       expect(cmd).toContain('--full-auto');
     });
 
-    it('codex full produces --full-auto without --sandbox', () => {
-      const cmd = buildExecCommand(opts({ agent: 'codex', mode: 'full' }));
+    it('codex skip produces --full-auto without --sandbox', () => {
+      const cmd = buildExecCommand(opts({ agent: 'codex', mode: 'skip' }));
       expect(cmd).toContain('--full-auto');
       expect(cmd).not.toContain('--sandbox');
     });
 
-    it('gemini plan has no mode flags', () => {
+    it('gemini plan produces --approval-mode plan', () => {
       const cmd = buildExecCommand(opts({ agent: 'gemini', mode: 'plan' }));
-      expect(cmd).not.toContain('--yolo');
+      expect(cmd).toContain('--approval-mode');
+      expect(cmd[cmd.indexOf('--approval-mode') + 1]).toBe('plan');
     });
 
-    it('gemini edit produces --yolo', () => {
+    it('gemini edit produces --approval-mode auto_edit', () => {
       const cmd = buildExecCommand(opts({ agent: 'gemini', mode: 'edit' }));
+      expect(cmd).toContain('--approval-mode');
+      expect(cmd[cmd.indexOf('--approval-mode') + 1]).toBe('auto_edit');
+    });
+
+    it('gemini skip produces --yolo', () => {
+      const cmd = buildExecCommand(opts({ agent: 'gemini', mode: 'skip' }));
       expect(cmd).toContain('--yolo');
     });
 
-    it('gemini full produces --yolo', () => {
-      const cmd = buildExecCommand(opts({ agent: 'gemini', mode: 'full' }));
-      expect(cmd).toContain('--yolo');
+    it('cursor plan throws (cursor has no read-only mode)', () => {
+      expect(() => buildExecCommand(opts({ agent: 'cursor', mode: 'plan' })))
+        .toThrow(/cursor does not support 'plan' mode/);
     });
 
-    it('cursor plan has no mode flags', () => {
-      const cmd = buildExecCommand(opts({ agent: 'cursor', mode: 'plan' }));
+    it('cursor edit produces no flags (edit is cursor default)', () => {
+      const cmd = buildExecCommand(opts({ agent: 'cursor', mode: 'edit' }));
       expect(cmd).not.toContain('-f');
     });
 
-    it('cursor edit produces -f', () => {
-      const cmd = buildExecCommand(opts({ agent: 'cursor', mode: 'edit' }));
-      expect(cmd).toContain('-f');
-    });
-
-    it('cursor full produces -f', () => {
-      const cmd = buildExecCommand(opts({ agent: 'cursor', mode: 'full' }));
+    it('cursor skip produces -f', () => {
+      const cmd = buildExecCommand(opts({ agent: 'cursor', mode: 'skip' }));
       expect(cmd).toContain('-f');
     });
 
@@ -106,9 +120,9 @@ describe('buildExecCommand', () => {
       expect(cmd[cmd.indexOf('--agent') + 1]).toBe('build');
     });
 
-    it('opencode full produces --agent build', () => {
-      const cmd = buildExecCommand(opts({ agent: 'opencode', mode: 'full' }));
-      expect(cmd[cmd.indexOf('--agent') + 1]).toBe('build');
+    it('opencode skip throws (opencode has no skip-permissions flag)', () => {
+      expect(() => buildExecCommand(opts({ agent: 'opencode', mode: 'skip' })))
+        .toThrow(/opencode does not support 'skip' mode/);
     });
 
     it('openclaw plan produces --mode plan', () => {
@@ -122,8 +136,8 @@ describe('buildExecCommand', () => {
       expect(cmd[cmd.indexOf('--mode') + 1]).toBe('edit');
     });
 
-    it('openclaw full produces --mode full', () => {
-      const cmd = buildExecCommand(opts({ agent: 'openclaw', mode: 'full' }));
+    it('openclaw skip produces --mode full (openclaw native flag is still "full")', () => {
+      const cmd = buildExecCommand(opts({ agent: 'openclaw', mode: 'skip' }));
       expect(cmd[cmd.indexOf('--mode') + 1]).toBe('full');
     });
 
@@ -142,10 +156,15 @@ describe('buildExecCommand', () => {
       expect(cmd).not.toContain('--mode');
     });
 
-    it('copilot full produces --allow-all (tools + paths + URLs)', () => {
-      const cmd = buildExecCommand(opts({ agent: 'copilot', mode: 'full' }));
+    it('copilot skip produces --allow-all (tools + paths + URLs)', () => {
+      const cmd = buildExecCommand(opts({ agent: 'copilot', mode: 'skip' }));
       expect(cmd).toContain('--allow-all');
       expect(cmd).not.toContain('--allow-all-tools');
+    });
+
+    it('copilot auto produces --autopilot (smart classifier)', () => {
+      const cmd = buildExecCommand(opts({ agent: 'copilot', mode: 'auto' }));
+      expect(cmd).toContain('--autopilot');
     });
 
     it('copilot uses -p (not positional) for the prompt', () => {
@@ -161,13 +180,17 @@ describe('buildExecCommand', () => {
       expect(cmd[cmd.indexOf('--output-format') + 1]).toBe('json');
     });
 
-    it('every agent has all three mode entries', () => {
+    it('every agent declares at least the edit mode (the universal default)', () => {
       for (const agent of ALL_AGENTS) {
-        const template = AGENT_COMMANDS[agent];
-        for (const mode of ALL_MODES) {
-          expect(template.modeFlags[mode]).toBeDefined();
-          expect(Array.isArray(template.modeFlags[mode])).toBe(true);
-        }
+        expect(AGENTS[agent].capabilities.modes).toContain('edit');
+      }
+    });
+
+    it("AGENT_COMMANDS.modeFlags keys agree with AGENTS.capabilities.modes (no drift)", () => {
+      for (const agent of ALL_AGENTS) {
+        const cap = [...AGENTS[agent].capabilities.modes].sort();
+        const decl = Object.keys(AGENT_COMMANDS[agent].modeFlags).sort();
+        expect(decl).toEqual(cap);
       }
     });
   });
@@ -473,17 +496,17 @@ describe('buildExecCommand', () => {
 
   describe('version pinning', () => {
     it('appends @version to base command when version is set', () => {
-      const cmd = buildExecCommand(opts({ agent: 'claude', version: '2.1.98', mode: 'full' }));
+      const cmd = buildExecCommand(opts({ agent: 'claude', version: '2.1.98', mode: 'skip' }));
       expect(cmd[0]).toBe('claude@2.1.98');
     });
 
     it('does not append @version when version is undefined', () => {
-      const cmd = buildExecCommand(opts({ agent: 'claude', mode: 'full' }));
+      const cmd = buildExecCommand(opts({ agent: 'claude', mode: 'skip' }));
       expect(cmd[0]).toBe('claude');
     });
 
     it('works for codex with version', () => {
-      const cmd = buildExecCommand(opts({ agent: 'codex', version: '0.98.0', mode: 'full' }));
+      const cmd = buildExecCommand(opts({ agent: 'codex', version: '0.98.0', mode: 'skip' }));
       expect(cmd[0]).toBe('codex@0.98.0');
       expect(cmd[1]).toBe('exec');
     });
@@ -495,7 +518,7 @@ describe('buildExecCommand', () => {
     it('produces claude command matching agent-runner pattern', () => {
       const cmd = buildExecCommand(opts({
         agent: 'claude',
-        mode: 'full',
+        mode: 'skip',
         headless: true,
         sessionId: 'sess-123',
         verbose: true,
@@ -514,7 +537,7 @@ describe('buildExecCommand', () => {
     it('produces codex command matching agent-runner pattern', () => {
       const cmd = buildExecCommand(opts({
         agent: 'codex',
-        mode: 'full',
+        mode: 'skip',
         prompt: 'fix the bug',
       }));
       expect(cmd).toEqual([
@@ -527,7 +550,7 @@ describe('buildExecCommand', () => {
     it('claude with effort=high emits --effort high', () => {
       const cmd = buildExecCommand(opts({
         agent: 'claude',
-        mode: 'full',
+        mode: 'skip',
         effort: 'high',
         prompt: 'fix the bug',
       }));
@@ -542,7 +565,7 @@ describe('buildExecCommand', () => {
     it('codex with effort=medium emits -c model_reasoning_effort=medium before exec', () => {
       const cmd = buildExecCommand(opts({
         agent: 'codex',
-        mode: 'full',
+        mode: 'skip',
         effort: 'medium',
         prompt: 'fix the bug',
       }));
@@ -611,5 +634,59 @@ describe('buildFallbackPrompt', () => {
     const prompt = buildFallbackPrompt('codex', undefined, 'claude', 'deploy');
     expect(prompt).not.toMatch(/^\/continue/);
     expect(prompt).toContain('Original request: deploy');
+  });
+});
+
+describe('normalizeMode', () => {
+  it.each<[string, Mode]>([
+    ['plan', 'plan'],
+    ['edit', 'edit'],
+    ['auto', 'auto'],
+    ['skip', 'skip'],
+    ['full', 'skip'],          // canonical alias
+    ['FULL', 'skip'],          // case insensitive
+    [' Skip ', 'skip'],        // whitespace tolerant
+  ])("maps '%s' → %s", (input, expected) => {
+    expect(normalizeMode(input)).toBe(expected);
+  });
+
+  it.each(['', null, undefined])("throws on empty/nullish input: %s", (input) => {
+    expect(() => normalizeMode(input)).toThrow(/Mode is required/);
+  });
+
+  it.each(['yolo', 'dangerous', 'ralph', 'foo', 'auto_edit'])("throws on unknown mode '%s'", (input) => {
+    expect(() => normalizeMode(input)).toThrow(/Invalid mode/);
+  });
+});
+
+describe('resolveMode', () => {
+  it("returns the requested mode when supported (claude/skip)", () => {
+    expect(resolveMode('claude', 'skip')).toBe('skip');
+  });
+
+  it("degrades 'auto' to 'edit' for agents without smart-classifier support", () => {
+    // codex has no auto in its capabilities.modes — should silently degrade.
+    expect(AGENTS.codex.capabilities.modes).not.toContain('auto');
+    expect(resolveMode('codex', 'auto')).toBe('edit');
+  });
+
+  it("keeps 'auto' for agents that natively support it (claude, copilot)", () => {
+    expect(resolveMode('claude', 'auto')).toBe('auto');
+    expect(resolveMode('copilot', 'auto')).toBe('auto');
+  });
+
+  it("throws on 'skip' for agents without skip support, naming supported modes", () => {
+    expect(() => resolveMode('opencode', 'skip'))
+      .toThrow(/opencode does not support 'skip' mode\. Supported modes: plan, edit\./);
+  });
+
+  it("throws on 'plan' for agents without plan support (cursor)", () => {
+    expect(() => resolveMode('cursor', 'plan'))
+      .toThrow(/cursor does not support 'plan' mode\. Supported modes: edit, skip\./);
+  });
+
+  it("throws on 'skip' for kiro (edit-only agent)", () => {
+    expect(() => resolveMode('kiro', 'skip'))
+      .toThrow(/kiro does not support 'skip' mode\. Supported modes: edit\./);
   });
 });

--- a/src/lib/acp/client.ts
+++ b/src/lib/acp/client.ts
@@ -134,7 +134,12 @@ function buildClient(opts: AcpRunOptions): Client {
     },
 
     async requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
-      const optionId = mode === 'full'
+      // `skip` (formerly `full`) and `auto` blanket-approve; in `auto` the
+      // upstream model has its own classifier so we just say "allow once" and
+      // let it decide. `edit` says allow_once. `plan` should never reach here
+      // (canWrite gates writes earlier), but if it does we cancel.
+      const skipAll = mode === 'skip';
+      const optionId = skipAll
         ? (params.options.find(o => o.kind === 'allow_always')?.optionId
             ?? params.options[0]?.optionId)
         : params.options.find(o => o.kind === 'allow_once')?.optionId;

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -215,7 +215,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: true,
-    capabilities: { hooks: true, mcp: true, allowlist: true, skills: true, commands: true, plugins: true, rulesImports: true },
+    capabilities: { hooks: true, mcp: true, allowlist: true, skills: true, commands: true, plugins: true, modes: ['plan', 'edit', 'auto', 'skip'], rulesImports: true },
   },
   // codex hooks: gated to >= 0.116.0 (introduced [features] codex_hooks flag).
   codex: {
@@ -234,7 +234,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: true,
-    capabilities: { hooks: { since: '0.116.0' }, mcp: true, allowlist: false, skills: true, commands: { until: '0.117.0' }, plugins: { since: '0.128.0' } },
+    capabilities: { hooks: { since: '0.116.0' }, mcp: true, allowlist: false, skills: true, commands: { until: '0.117.0' }, plugins: { since: '0.128.0' }, modes: ['plan', 'edit', 'skip'] },
   },
   gemini: {
     id: 'gemini',
@@ -253,7 +253,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     supportsHooks: true,
     nativeAgentsSkillsDir: true,
     // gemini hooks: shipped in v0.26.0 (Jan 2026); older binaries silently ignore the `hooks` key.
-    capabilities: { hooks: { since: '0.26.0' }, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, rulesImports: true },
+    capabilities: { hooks: { since: '0.26.0' }, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, modes: ['plan', 'edit', 'skip'], rulesImports: true },
   },
   cursor: {
     id: 'cursor',
@@ -271,7 +271,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: false,
-    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false },
+    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, modes: ['edit', 'skip'] },
   },
   opencode: {
     id: 'opencode',
@@ -288,7 +288,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: false,
-    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false },
+    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, modes: ['plan', 'edit'] },
   },
   openclaw: {
     id: 'openclaw',
@@ -305,7 +305,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '{{ARGUMENTS}}',
     supportsHooks: true,
-    capabilities: { hooks: true, mcp: true, allowlist: false, skills: true, commands: false, plugins: true },
+    capabilities: { hooks: true, mcp: true, allowlist: false, skills: true, commands: false, plugins: true, modes: ['plan', 'edit', 'skip'] },
   },
   copilot: {
     id: 'copilot',
@@ -322,7 +322,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: false,
-    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false },
+    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, modes: ['plan', 'edit', 'auto', 'skip'] },
   },
   amp: {
     id: 'amp',
@@ -339,7 +339,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: false,
-    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false },
+    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, modes: ['plan', 'edit'] },
   },
   kiro: {
     id: 'kiro',
@@ -357,7 +357,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: false,
-    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false },
+    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, modes: ['edit'] },
   },
   goose: {
     id: 'goose',
@@ -375,7 +375,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: false,
-    capabilities: { hooks: false, mcp: true, allowlist: false, skills: false, commands: false, plugins: false },
+    capabilities: { hooks: false, mcp: true, allowlist: false, skills: false, commands: false, plugins: false, modes: ['edit'] },
   },
   roo: {
     id: 'roo',
@@ -393,7 +393,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: false,
-    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false },
+    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, modes: ['plan', 'edit'] },
   },
   // Google Antigravity CLI (`agy`) — official replacement for Gemini CLI as of IO 2026.
   // configDir nests inside `~/.gemini/` since agy shares the parent dir with the Gemini
@@ -420,7 +420,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '{{args}}',
     supportsHooks: true,
-    capabilities: { hooks: true, mcp: true, allowlist: true, skills: true, commands: true, plugins: true, rulesImports: false },
+    capabilities: { hooks: true, mcp: true, allowlist: true, skills: true, commands: true, plugins: true, modes: ['edit', 'skip'], rulesImports: false },
   },
   // xAI Grok Build CLI (`grok`) — early beta, SuperGrok Heavy. Auth via OAuth on
   // first launch, or XAI_API_KEY env var for headless. MCP servers configured inline
@@ -451,6 +451,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
       skills: true,
       commands: false, // covered by skills
       plugins: true,
+      modes: ['plan', 'edit', 'skip'],
       rulesImports: true,
     },
   },

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -7,15 +7,62 @@
 import { spawn } from 'child_process';
 import { randomUUID } from 'crypto';
 import * as path from 'path';
-import type { AgentId } from './types.js';
+import type { AgentId, Mode } from './types.js';
+import { ALL_MODES } from './types.js';
+import { AGENTS } from './agents.js';
 import { parseTimeout } from './routines.js';
 import { getVersionHomePath, isVersionInstalled, resolveVersion } from './versions.js';
 import { resolveModel, buildReasoningFlags } from './models.js';
 import { emitStart, maybeRotate, createTimer, redactPrompt, redactArgs } from './events.js';
 import { sanitizeProcessEnv } from './secrets/bundles.js';
 
-/** Agent execution modes controlling tool access and autonomy level. */
-export type ExecMode = 'plan' | 'edit' | 'full' | 'auto';
+/**
+ * Agent execution modes. Canonical name `skip` (dangerously skip permissions);
+ * `full` is accepted as a permanent silent alias via normalizeMode().
+ */
+export type ExecMode = Mode;
+
+/**
+ * Map a raw mode string (CLI flag, YAML field, env var) to the canonical Mode.
+ *
+ * Accepts the historical `full` spelling and rewrites it to `skip`. Throws on
+ * anything outside the four canonical values so bad input fails loud at the
+ * boundary rather than silently picking a wrong code path.
+ */
+export function normalizeMode(input: string | null | undefined): Mode {
+  if (!input) {
+    throw new Error(`Mode is required. Use one of: ${ALL_MODES.join(', ')}.`);
+  }
+  const v = input.trim().toLowerCase();
+  if (v === 'full') return 'skip';
+  if ((ALL_MODES as readonly string[]).includes(v)) return v as Mode;
+  throw new Error(`Invalid mode '${input}'. Use one of: ${ALL_MODES.join(', ')} (or 'full' as a deprecated alias for 'skip').`);
+}
+
+/**
+ * Resolve a requested mode against an agent's capability table.
+ *
+ * - `auto` on an agent without auto support silently degrades to `edit`
+ *   (every agent supports edit-like behavior as its default).
+ * - `skip` on an agent without skip support throws with a clear message
+ *   naming the agent's supported modes. No silent fallback — the user
+ *   explicitly asked to bypass permissions; pretending we did is unsafe.
+ * - `plan` on an agent without plan support throws the same way.
+ */
+export function resolveMode(agent: AgentId, requested: Mode): Mode {
+  const supported = AGENTS[agent].capabilities.modes;
+  if (supported.includes(requested)) return requested;
+
+  if (requested === 'auto') {
+    // Fall back to edit — guaranteed to exist on every agent (every agent has
+    // at least 'edit' in its modes table, since that's the default behavior).
+    return 'edit';
+  }
+
+  throw new Error(
+    `${agent} does not support '${requested}' mode. Supported modes: ${supported.join(', ')}.`,
+  );
+}
 
 /** Reasoning effort levels passed to agents that support them. 'auto' defers to the agent's default. */
 export type ExecEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'auto';
@@ -134,23 +181,29 @@ export function buildExecEnv(options: ExecOptions): NodeJS.ProcessEnv {
 }
 
 
-/** Describes how to translate ExecOptions into CLI arguments for a specific agent. */
+/**
+ * Describes how to translate ExecOptions into CLI arguments for a specific agent.
+ *
+ * `modeFlags` only declares modes this agent natively supports. Keys must agree
+ * with AGENTS[agent].capabilities.modes — resolveMode() routes a request to a
+ * supported mode (or throws), then buildExecCommand looks up the flags here.
+ */
 export interface AgentCommandTemplate {
   base: string[];
   promptFlag: 'positional' | string;
-  modeFlags: {
-    plan: string[];
-    edit: string[];
-    full: string[];
-    auto?: string[];
-  };
+  modeFlags: Partial<Record<Mode, string[]>>;
   jsonFlags?: string[];
   modelFlag?: string;
   printFlags?: string[];
   verboseFlag?: string;
 }
 
-/** CLI command templates for every supported agent. */
+/**
+ * CLI command templates for every supported agent.
+ *
+ * Each agent's `modeFlags` keys MUST match the modes listed in
+ * AGENTS[agent].capabilities.modes. A test in exec.test.ts asserts this.
+ */
 export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
   claude: {
     base: ['claude'],
@@ -158,8 +211,8 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
     modeFlags: {
       plan: ['--permission-mode', 'plan'],
       edit: ['--permission-mode', 'acceptEdits'],
-      full: ['--dangerously-skip-permissions'],
       auto: ['--permission-mode', 'auto'],
+      skip: ['--dangerously-skip-permissions'],
     },
     jsonFlags: ['--output-format', 'stream-json', '--verbose'],
     modelFlag: '--model',
@@ -170,9 +223,13 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
     base: ['codex', 'exec'],
     promptFlag: 'positional',
     modeFlags: {
+      // NOTE: codex has no read-only mode in --sandbox; 'plan' here means
+      // "workspace-write but no auto-approval" — closer to plan-as-restraint.
+      // True read-only requires --sandbox read-only which we haven't wired.
       plan: ['--sandbox', 'workspace-write'],
       edit: ['--sandbox', 'workspace-write', '--full-auto'],
-      full: ['--full-auto'],
+      // skip drops the sandbox entirely; --full-auto then approves anything.
+      skip: ['--full-auto'],
     },
     jsonFlags: ['--json'],
     modelFlag: '--model',
@@ -181,9 +238,9 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
     base: ['gemini'],
     promptFlag: 'positional',
     modeFlags: {
-      plan: [],
-      edit: ['--yolo'],
-      full: ['--yolo'],
+      plan: ['--approval-mode', 'plan'],
+      edit: ['--approval-mode', 'auto_edit'],
+      skip: ['--yolo'],
     },
     jsonFlags: ['--output-format', 'stream-json'],
     modelFlag: '--model',
@@ -192,9 +249,9 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
     base: ['cursor-agent'],
     promptFlag: '-p',
     modeFlags: {
-      plan: [],
-      edit: ['-f'],
-      full: ['-f'],
+      // cursor-agent has no read-only flag; we only expose edit + skip.
+      edit: [],
+      skip: ['-f'],
     },
     jsonFlags: ['--output-format', 'stream-json'],
     modelFlag: '--model',
@@ -205,7 +262,6 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
     modeFlags: {
       plan: ['--agent', 'plan'],
       edit: ['--agent', 'build'],
-      full: ['--agent', 'build'],
     },
     jsonFlags: ['--format', 'json'],
     modelFlag: '--model',
@@ -216,7 +272,7 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
     modeFlags: {
       plan: ['--mode', 'plan'],
       edit: ['--mode', 'edit'],
-      full: ['--mode', 'full'],
+      skip: ['--mode', 'full'],
     },
     jsonFlags: ['--output-format', 'stream-json'],
     modelFlag: '--model',
@@ -225,19 +281,21 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
   // against `copilot --help` from v0.0.413+:
   //   -p, --prompt <text>          non-interactive one-shot
   //   --mode <interactive|plan|autopilot>
+  //   --autopilot                  start in autopilot (smart-classifier) mode
   //   --allow-all-tools            required for non-interactive tool exec
   //   --allow-all (alias --yolo)   tools + paths + URLs
   //   --output-format <text|json>  json => JSONL, one object per line
   //   --model <model>
-  // Plan mode is read-only so it does not need an allow-tools grant; edit/full
-  // need at minimum --allow-all-tools so headless runs don't stall on prompts.
+  // Plan mode is read-only so it does not need an allow-tools grant; edit
+  // needs --allow-all-tools so headless runs don't stall on prompts.
   copilot: {
     base: ['copilot'],
     promptFlag: '-p',
     modeFlags: {
       plan: ['--mode', 'plan'],
       edit: ['--allow-all-tools'],
-      full: ['--allow-all'],
+      auto: ['--autopilot'],
+      skip: ['--allow-all'],
     },
     jsonFlags: ['--output-format', 'json'],
     modelFlag: '--model',
@@ -248,7 +306,6 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
     modeFlags: {
       plan: ['--mode', 'plan'],
       edit: ['--mode', 'edit'],
-      full: ['--mode', 'edit'],
     },
     modelFlag: '--model',
   },
@@ -256,9 +313,8 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
     base: ['kiro-cli'],
     promptFlag: 'positional',
     modeFlags: {
-      plan: [],
+      // kiro-cli has no permission flags — edit is the default behavior.
       edit: [],
-      full: [],
     },
     modelFlag: '--model',
   },
@@ -266,9 +322,8 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
     base: ['goose', 'run'],
     promptFlag: 'positional',
     modeFlags: {
-      plan: [],
+      // goose has no permission flags — edit is the default behavior.
       edit: [],
-      full: [],
     },
   },
   roo: {
@@ -277,11 +332,9 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
     modeFlags: {
       plan: ['--mode', 'architect'],
       edit: ['--mode', 'code'],
-      full: ['--mode', 'code'],
     },
     modelFlag: '--model',
   },
-  // Antigravity full mode uses --dangerously-skip-permissions (YOLO).
   // TODO: --output-format json is documented but currently broken upstream
   // ("flags provided but not defined: -output-format"). Track resolution at
   // https://github.com/google-antigravity/antigravity-cli/issues/7 before
@@ -290,9 +343,10 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
     base: ['agy'],
     promptFlag: 'positional',
     modeFlags: {
-      plan: [],
+      // agy --help shows no plan/edit flags; default behavior is edit-like
+      // (prompts on tool use). Only skip has an explicit flag.
       edit: [],
-      full: ['--dangerously-skip-permissions'],
+      skip: ['--dangerously-skip-permissions'],
     },
     modelFlag: '--model',
   },
@@ -300,9 +354,12 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
     base: ['grok'],
     promptFlag: '-p',
     modeFlags: {
+      // grok defaults to plan mode; --permission-mode <MODE> exists in --help
+      // (modes not enumerated). Preserve historical --mode plan behavior until
+      // someone with a working grok install can verify the canonical spelling.
       plan: ['--mode', 'plan'],
       edit: [],
-      full: ['--always-approve'],
+      skip: ['--always-approve'],
     },
     jsonFlags: ['--output-format', 'streaming-json'],
     modelFlag: '--model',
@@ -341,8 +398,19 @@ export function buildExecCommand(options: ExecOptions): string[] {
     }
   }
 
-  // Add mode flags. 'auto' is only defined for claude; other agents fall back to edit flags.
-  const modeFlags = template.modeFlags[options.mode] ?? template.modeFlags.edit;
+  // Resolve the requested mode against the agent's capability table.
+  // - `auto` on an agent without auto support → silently degrades to `edit`
+  // - `skip`/`plan` on an unsupported agent → throws a clear error
+  // After resolveMode, the chosen mode is guaranteed to be in template.modeFlags.
+  const resolvedMode = resolveMode(options.agent, normalizeMode(options.mode));
+  const modeFlags = template.modeFlags[resolvedMode];
+  if (!modeFlags) {
+    // Defense in depth: would only fire if AGENTS.capabilities.modes and
+    // AGENT_COMMANDS.modeFlags drifted apart. Tests assert they agree.
+    throw new Error(
+      `Internal error: ${options.agent} declares '${resolvedMode}' in capabilities.modes but has no entry in AGENT_COMMANDS.modeFlags.${resolvedMode}.`,
+    );
+  }
   cmd.push(...modeFlags);
 
   // Add print/headless flags only when a prompt is provided. Without a prompt

--- a/src/lib/routines.ts
+++ b/src/lib/routines.ts
@@ -29,7 +29,8 @@ export interface JobConfig {
   schedule: string;
   agent: AgentId;  // required when workflow is absent
   workflow?: string;
-  mode: 'plan' | 'edit' | 'full';
+  // 'full' is accepted as a permanent silent alias for 'skip' (see normalizeMode).
+  mode: 'plan' | 'edit' | 'auto' | 'skip' | 'full';
   effort: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'auto';
   timeout: string;
   enabled: boolean;
@@ -178,8 +179,8 @@ export function validateJob(config: Partial<JobConfig>): string[] {
       errors.push('workflow must be a lowercase alphanumeric name (hyphens and underscores allowed, e.g. autodev)');
     }
   }
-  if (config.mode && !['plan', 'edit', 'full'].includes(config.mode)) {
-    errors.push('mode must be plan, edit, or full');
+  if (config.mode && !['plan', 'edit', 'auto', 'skip', 'full'].includes(config.mode)) {
+    errors.push("mode must be plan, edit, auto, or skip ('full' accepted as alias for skip)");
   }
   if (config.effort && !['low', 'medium', 'high', 'xhigh', 'max', 'auto'].includes(config.effort)) {
     errors.push('effort must be low, medium, high, xhigh, max, or auto');

--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -23,6 +23,7 @@ import type { AgentId } from './types.js';
 import { prepareJobHome, buildSpawnEnv } from './sandbox.js';
 import { resolveModel, buildReasoningFlags } from './models.js';
 import { createTimer, maybeRotate, redactPrompt } from './events.js';
+import { normalizeMode } from './exec.js';
 
 /** Result of a completed job execution, including metadata and optional report. */
 export interface RunResult {
@@ -55,11 +56,17 @@ export function buildJobCommand(config: JobConfig, resolvedPrompt: string): stri
 
   let cmd = template.map((part) => part.replace('{prompt}', resolvedPrompt));
 
+  // Canonicalize mode (accepts legacy `full` as alias for `skip`).
+  const mode = normalizeMode(config.mode);
+
   if (config.agent === 'claude') {
-    if (config.mode === 'edit') {
+    if (mode === 'edit') {
       const planIndex = cmd.indexOf('plan');
       if (planIndex !== -1) cmd[planIndex] = 'acceptEdits';
-    } else if (config.mode === 'full') {
+    } else if (mode === 'auto') {
+      const planIndex = cmd.indexOf('plan');
+      if (planIndex !== -1) cmd[planIndex] = 'auto';
+    } else if (mode === 'skip') {
       // Replace --permission-mode plan with --dangerously-skip-permissions
       const pmIndex = cmd.indexOf('--permission-mode');
       if (pmIndex !== -1) cmd.splice(pmIndex, 2, '--dangerously-skip-permissions');
@@ -82,9 +89,9 @@ export function buildJobCommand(config: JobConfig, resolvedPrompt: string): stri
   }
 
   if (config.agent === 'codex') {
-    if (config.mode === 'edit') {
+    if (mode === 'edit') {
       cmd.push('--full-auto');
-    } else if (config.mode === 'full') {
+    } else if (mode === 'skip') {
       // Remove sandbox restriction, just --full-auto
       const sbIndex = cmd.indexOf('--sandbox');
       if (sbIndex !== -1) cmd.splice(sbIndex, 2);
@@ -95,7 +102,9 @@ export function buildJobCommand(config: JobConfig, resolvedPrompt: string): stri
   }
 
   if (config.agent === 'gemini') {
-    if (config.mode === 'edit' || config.mode === 'full') {
+    if (mode === 'edit') {
+      cmd.push('--approval-mode', 'auto_edit');
+    } else if (mode === 'skip') {
       cmd.push('--yolo');
     }
 

--- a/src/lib/session/types.ts
+++ b/src/lib/session/types.ts
@@ -43,7 +43,7 @@ export interface SessionEvent {
 export interface TeamOrigin {
   /** Teammate name if set, otherwise first 8 chars of the agent UUID. */
   handle?: string;
-  /** Agent mode: 'plan', 'edit', or 'full'. */
+  /** Agent mode: 'plan', 'edit', 'auto', or 'skip' ('full' accepted as legacy alias for 'skip'). */
   mode?: string;
 }
 

--- a/src/lib/teams/agents.ts
+++ b/src/lib/teams/agents.ts
@@ -203,13 +203,17 @@ const CLAUDE_PLAN_MODE_PREFIX = `You are running in HEADLESS PLAN MODE. This mod
 
 `;
 
-const VALID_MODES = ['plan', 'edit', 'full', 'auto'] as const;
-type Mode = typeof VALID_MODES[number];
+// Canonical modes plus the historical `full` alias (rewritten to `skip` by
+// normalizeModeValue). Keep `full` listed so user-typed CLI flags and stored
+// metadata that pre-date the rename continue to parse.
+export const VALID_MODES = ['plan', 'edit', 'auto', 'skip', 'full'] as const;
+type Mode = 'plan' | 'edit' | 'auto' | 'skip';
 
 function normalizeModeValue(modeValue: string | null | undefined): Mode | null {
   if (!modeValue) return null;
   const normalized = modeValue.trim().toLowerCase();
-  if (VALID_MODES.includes(normalized as Mode)) {
+  if (normalized === 'full') return 'skip';
+  if ((['plan', 'edit', 'auto', 'skip'] as readonly string[]).includes(normalized)) {
     return normalized as Mode;
   }
   return null;
@@ -223,7 +227,7 @@ function defaultModeFromEnv(): Mode {
       return parsed;
     }
     if (rawValue) {
-      console.warn(`Invalid ${envVar}='${rawValue}'. Use 'plan' or 'edit'. Falling back to plan mode.`);
+      console.warn(`Invalid ${envVar}='${rawValue}'. Use plan, edit, auto, or skip. Falling back to plan mode.`);
     }
   }
   return 'plan';
@@ -282,13 +286,13 @@ export function resolveMode(
 ): Mode {
   const normalizedDefault = normalizeModeValue(defaultMode);
   if (!normalizedDefault) {
-    throw new Error(`Invalid default mode '${defaultMode}'. Use 'plan' or 'edit'.`);
+    throw new Error(`Invalid default mode '${defaultMode}'. Use plan, edit, auto, or skip.`);
   }
 
   if (requestedMode !== null && requestedMode !== undefined) {
     const normalizedMode = normalizeModeValue(requestedMode);
     if (!normalizedMode) {
-      throw new Error(`Invalid mode '${requestedMode}'. Valid modes: 'plan' (read-only) or 'edit' (can write).`);
+      throw new Error(`Invalid mode '${requestedMode}'. Valid modes: plan (read-only), edit (can write), auto (smart classifier), skip (bypass all permissions). 'full' is accepted as alias for skip.`);
     }
     return normalizedMode;
   }
@@ -475,7 +479,9 @@ export class AgentProcess {
   }
 
   get isEditMode(): boolean {
-    return this.mode === 'edit' || this.mode === 'full';
+    // Any mode that can mutate the workspace counts as "edit mode" for the
+    // purposes of guarding read-only flows (plan-mode teammates).
+    return this.mode === 'edit' || this.mode === 'auto' || this.mode === 'skip';
   }
 
   async getAgentDir(): Promise<string> {
@@ -714,12 +720,16 @@ export class AgentProcess {
       const metaContent = await fs.readFile(metaPath, 'utf-8');
       const meta = JSON.parse(metaContent);
 
-      // Legacy teammates may have mode='ralph' or 'cloud' from before modes
-      // were narrowed. Coerce to the closest current mode so they still load.
+      // Legacy teammates may have mode='ralph', 'cloud', or 'full' from before
+      // modes were narrowed/renamed. Coerce to the closest current mode so they
+      // still load.
       const modeMap: Record<string, Mode> = {
+        plan: 'plan',
         edit: 'edit',
-        full: 'full',
-        ralph: 'full',  // ralph used the same "no-permission" flags as full
+        auto: 'auto',
+        skip: 'skip',
+        full: 'skip',   // historical alias — `full` is the old name for `skip`
+        ralph: 'skip',  // ralph used the same "no-permission" flags as full
         cloud: 'edit',  // cloud teammates had edit-level write access
       };
       const resolvedMode: Mode = modeMap[meta.mode] || 'plan';
@@ -917,7 +927,7 @@ export class AgentManager {
     this.cleanupAgeDays = cleanupAgeDays;
     const resolvedDefaultMode = defaultMode ? normalizeModeValue(defaultMode) : defaultModeFromEnv();
     if (!resolvedDefaultMode) {
-      throw new Error(`Invalid default_mode '${defaultMode}'. Use 'plan' or 'edit'.`);
+      throw new Error(`Invalid default_mode '${defaultMode}'. Use plan, edit, auto, or skip.`);
     }
     this.defaultMode = resolvedDefaultMode;
 
@@ -1319,7 +1329,7 @@ export class AgentManager {
     // plan-mode restrictions) and a universal summary suffix. These are
     // team-specific prompt scaffolding — `agents run` does not apply them.
     let fullPrompt = prompt + PROMPT_SUFFIX;
-    if (agentType === 'claude' && mode !== 'edit') {
+    if (agentType === 'claude' && mode === 'plan') {
       fullPrompt = CLAUDE_PLAN_MODE_PREFIX + fullPrompt;
     }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -46,6 +46,12 @@ export interface AgentConfig {
     commands: Capability;
     plugins: Capability;
     /**
+     * Permission modes this agent natively supports. Modes outside this set
+     * are gated by buildExecCommand: `auto` silently degrades to `edit`,
+     * `skip` errors with a clear message naming the supported modes.
+     */
+    modes: Mode[];
+    /**
      * Whether the agent natively resolves `@path/to/file` imports inside its
      * rules file at session start. If false, agents-cli must pre-compile the
      * rules file (inline all @-imports) when syncing it into the version home.
@@ -64,6 +70,21 @@ export type Capability = boolean | { since?: string; until?: string };
 
 /** Names of every gateable capability on AgentConfig. */
 export type CapabilityName = 'hooks' | 'mcp' | 'allowlist' | 'skills' | 'commands' | 'plugins';
+
+/**
+ * Permission modes controlling agent autonomy.
+ *   plan  read-only investigation; no writes, no shell side-effects
+ *   edit  may edit files; prompts for shell/risky operations
+ *   auto  smart classifier auto-approves safe operations, prompts for risky ones
+ *   skip  bypasses every permission prompt (dangerously-skip-permissions)
+ *
+ * `full` is accepted as a permanent silent alias for `skip` via normalizeMode().
+ * Per-agent support is declared on AgentConfig.capabilities.modes.
+ */
+export type Mode = 'plan' | 'edit' | 'auto' | 'skip';
+
+/** Every canonical mode in declaration order. Useful for iteration / validation. */
+export const ALL_MODES: readonly Mode[] = ['plan', 'edit', 'auto', 'skip'] as const;
 
 /** Reason a capability check failed. */
 export type CapabilityFailReason = 'unsupported' | 'too_old' | 'too_new';

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -99,7 +99,14 @@ describe('validateJob', () => {
 
   it('rejects invalid mode', () => {
     const errors = validateJob({ ...makeConfig(), mode: 'yolo' as any });
-    expect(errors).toContain('mode must be plan, edit, or full');
+    expect(errors).toContain("mode must be plan, edit, auto, or skip ('full' accepted as alias for skip)");
+  });
+
+  it("accepts 'skip' (canonical) and 'full' (legacy alias) and 'auto'", () => {
+    for (const m of ['plan', 'edit', 'auto', 'skip', 'full'] as const) {
+      const errors = validateJob({ ...makeConfig(), mode: m });
+      expect(errors).not.toContain("mode must be plan, edit, auto, or skip ('full' accepted as alias for skip)");
+    }
   });
 
   it('rejects invalid effort', () => {

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -100,8 +100,19 @@ describe('buildJobCommand', () => {
       expect(cmd).toContain('hello');
     });
 
-    it('adds --yolo in edit mode', () => {
+    it('adds --approval-mode auto_edit in edit mode', () => {
       const cmd = buildJobCommand(makeConfig({ agent: 'gemini', mode: 'edit' }), 'hello');
+      expect(cmd).toContain('--approval-mode');
+      expect(cmd[cmd.indexOf('--approval-mode') + 1]).toBe('auto_edit');
+    });
+
+    it('adds --yolo in skip mode (formerly full)', () => {
+      const cmd = buildJobCommand(makeConfig({ agent: 'gemini', mode: 'skip' }), 'hello');
+      expect(cmd).toContain('--yolo');
+    });
+
+    it("legacy 'full' alias still produces --yolo for gemini", () => {
+      const cmd = buildJobCommand(makeConfig({ agent: 'gemini', mode: 'full' as any }), 'hello');
       expect(cmd).toContain('--yolo');
     });
 


### PR DESCRIPTION
## Summary

Rename `full` → `skip` as the canonical name for "dangerously skip permissions" and formalize `auto` as a first-class smart-classifier mode. Each of the 13 supported agents now declares which of `plan | edit | auto | skip` its CLI natively supports, and `buildExecCommand` enforces that gate.

## Behavior

- **`skip` on an unsupported agent throws a clear error**, no silent degrade:
  ```
  $ agents run opencode "x" --mode skip
  opencode does not support 'skip' mode. Supported modes: plan, edit.
  $ echo $?
  1
  ```
- **`auto` on an agent without a smart classifier silently degrades to `edit`** (so cross-agent scripts targeting codex/gemini/cursor stay portable).
- **`full` is accepted as a permanent silent alias for `skip`** everywhere modes are read — CLI flag, routines YAML, teams YAML, session metadata, team-runner stored meta. No deprecation warning.

## Per-agent capability table (locked from real `--help` probes + `src/lib/exec.ts` history)

| Agent | plan | edit | auto | skip | skip flag |
|---|---|---|---|---|---|
| claude | ✓ | ✓ | ✓ | ✓ | `--dangerously-skip-permissions` |
| codex | ✓ | ✓ | — | ✓ | `--full-auto` (no sandbox) |
| gemini | ✓ | ✓ | — | ✓ | `--yolo` |
| copilot | ✓ | ✓ | ✓ | ✓ | `--allow-all` (auto = `--autopilot`) |
| antigravity | — | ✓ | — | ✓ | `--dangerously-skip-permissions` |
| grok | ✓ | ✓ | — | ✓ | `--always-approve` |
| openclaw | ✓ | ✓ | — | ✓ | `--mode full` |
| cursor | — | ✓ | — | ✓ | `-f` |
| opencode | ✓ | ✓ | — | — | — |
| amp | ✓ | ✓ | — | — | — |
| roo | ✓ | ✓ | — | — | — |
| kiro | — | ✓ | — | — | — |
| goose | — | ✓ | — | — | — |

Also fixes a long-standing bug: `gemini` edit now emits `--approval-mode auto_edit` (the documented flag) instead of `--yolo` (which is actually skip).

## Files

- `src/lib/types.ts` — `Mode` type + `ALL_MODES` + `capabilities.modes`
- `src/lib/agents.ts` — populate `modes` for all 13 agents
- `src/lib/exec.ts` — rename `full`→`skip` in `modeFlags`, add `normalizeMode()` + `resolveMode()`, wire into `buildExecCommand`
- `src/lib/runner.ts` — routines runtime accepts canonical Mode + `full` alias
- `src/lib/routines.ts` — JobConfig.mode widened + validator updated
- `src/lib/teams/agents.ts` — VALID_MODES updated + legacy `full`/`ralph`/`cloud` mapped to canonical
- `src/lib/acp/client.ts` — `mode === 'full'` → `mode === 'skip'`
- `src/lib/session/types.ts` — TeamOrigin comment
- `src/commands/exec.ts` — CLI help + capability error wrapping (clean message, exit 1)
- `src/commands/routines.ts` — `--mode` help
- `src/commands/teams.ts` — VALID_MODES + `--mode` help

## Test plan

- [x] `bun run test src/lib/__tests__/exec.test.ts` — 116/116 pass (was 91; added 25 tests covering normalizeMode/resolveMode/capability rejection/full-alias)
- [x] `bun run test` (full suite) — 1946 pass / 8 fail; all 8 reproduce on `origin/main` (pre-existing: local codex install broken, project-sync tests depend on HOME state). Zero new failures from this change.
- [x] E2E: `agents run claude "..." --mode skip --headless` → banner shows `--dangerously-skip-permissions`, agent runs
- [x] E2E: `agents run claude "..." --mode full --headless` → resolves to skip, same banner
- [x] E2E: `agents run opencode "x" --mode skip --headless` → exits 1 with `opencode does not support 'skip' mode. Supported modes: plan, edit.`

## Session Context

[Session transcript](https://gist.github.com/muqsitnawaz/421797f67534f8291e0dd4bcb9ac795f)