### PR TITLE
release: 1.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 1.21.0
+## 1.20.1
+
+**Agents selector (auto-install missing versions + unified `@all` everywhere)**
+
+- `--agents claude@2.1.999` used to hard-error when 2.1.999 wasn't installed. Now the CLI prompts to install it inline and continues (auto-install with `--yes`). No more breaking flow to run `agents add` first.
+- `--agents claude@all` and the bare `all` literal now work across every callsite that takes `--agents` — previously `agents install gh:...`, `mcp register`, `mcp remove`, and inline `mcp add` had diverged from the canonical syntax and threw "Version all is not installed" despite the help text advertising it. Selector is unified end-to-end.
 
 **Prompt (fail loud on non-TTY + `@all` syntax in picker)**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phnx-labs/agents-cli",
-  "version": "1.21.0",
+  "version": "1.20.1",
   "description": "One CLI for all your AI coding agents - versions, config, cloud dispatch, sessions, and teams (now with first-class Grok Build CLI support)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Relabel 1.21.0 -> 1.20.1. Same content (prompt @all syntax, profiles wizard, install gh: sniffing, feedback command, 5 security fixes, routines exit-code fix, copilot MCP path fix) shipped under a patch version. Adds PR #132 (auto-install missing versions + unified --agents selector) to the changelog.