### PR TITLE
fix(secrets): close 3 audit findings — export gate, view literals, migrate-acl prefix, redactor, passphrase floor

### DIFF
--- a/src/commands/secrets-migrate.ts
+++ b/src/commands/secrets-migrate.ts
@@ -129,6 +129,11 @@ export function registerSecretsMigrateAclCommand(secrets: Command): void {
           throw new Error('migrate-acl is macOS-only. Linux items already use the keyring-native ACL model.');
         }
         const prefix = opts.prefix ?? ITEM_PREFIX;
+        if (!prefix.startsWith(ITEM_PREFIX)) {
+          throw new Error(
+            `--prefix must start with '${ITEM_PREFIX}' to avoid touching unrelated Keychain items (got '${prefix}').`,
+          );
+        }
         const items = listKeychainItems(prefix).map((item) => {
           const localExists = hasKeychainToken(item);
           return { item, sync: !localExists };

--- a/src/commands/secrets-migrate.ts
+++ b/src/commands/secrets-migrate.ts
@@ -33,7 +33,7 @@ import {
   setKeychainToken,
 } from '../lib/secrets/index.js';
 import { getBackupsDir } from '../lib/state.js';
-import { encryptBlob } from '../lib/secrets/sync.js';
+import { encryptBlob, MIN_PASSPHRASE_LEN } from '../lib/secrets/sync.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
 
 const ITEM_PREFIX = 'agents-cli.';
@@ -79,7 +79,7 @@ async function promptPassphrase(): Promise<string> {
   }
   const { password } = await import('@inquirer/prompts');
   const first = await password({ message: 'Backup passphrase (used to encrypt the pre-migration snapshot)', mask: true });
-  if (first.length < 8) throw new Error('Passphrase must be at least 8 characters.');
+  if (first.length < MIN_PASSPHRASE_LEN) throw new Error(`Passphrase must be at least ${MIN_PASSPHRASE_LEN} characters.`);
   const second = await password({ message: 'Confirm passphrase', mask: true });
   if (first !== second) throw new Error('Passphrases do not match.');
   return first;
@@ -169,7 +169,7 @@ export function registerSecretsMigrateAclCommand(secrets: Command): void {
           ? (() => {
               const v = process.env[opts.passphraseEnv!];
               if (!v) throw new Error(`Env var '${opts.passphraseEnv}' not set.`);
-              if (v.length < 8) throw new Error(`Env var '${opts.passphraseEnv}' must be at least 8 chars.`);
+              if (v.length < MIN_PASSPHRASE_LEN) throw new Error(`Passphrase must be at least ${MIN_PASSPHRASE_LEN} characters.`);
               return v;
             })()
           : await promptPassphrase();

--- a/src/commands/secrets-sync.ts
+++ b/src/commands/secrets-sync.ts
@@ -11,6 +11,7 @@ import type { Command } from 'commander';
 import chalk from 'chalk';
 import {
   listRemoteBundles,
+  MIN_PASSPHRASE_LEN,
   pullBundle,
   pushBundle,
 } from '../lib/secrets/sync.js';
@@ -23,7 +24,7 @@ async function promptPassphrase(message: string, confirm = false): Promise<strin
   }
   const { password } = await import('@inquirer/prompts');
   const first = await password({ message, mask: true });
-  if (first.length < 8) throw new Error('Passphrase must be at least 8 characters.');
+  if (first.length < MIN_PASSPHRASE_LEN) throw new Error(`Passphrase must be at least ${MIN_PASSPHRASE_LEN} characters.`);
   if (!confirm) return first;
   const second = await password({ message: 'Confirm passphrase', mask: true });
   if (first !== second) throw new Error('Passphrases do not match.');
@@ -33,8 +34,8 @@ async function promptPassphrase(message: string, confirm = false): Promise<strin
 function passphraseFromEnvOrPrompt(confirm: boolean): Promise<string> {
   const fromEnv = process.env.AGENTS_SECRETS_PASSPHRASE;
   if (fromEnv) {
-    if (fromEnv.length < 8) {
-      return Promise.reject(new Error('AGENTS_SECRETS_PASSPHRASE must be at least 8 characters.'));
+    if (fromEnv.length < MIN_PASSPHRASE_LEN) {
+      return Promise.reject(new Error(`Passphrase must be at least ${MIN_PASSPHRASE_LEN} characters.`));
     }
     return Promise.resolve(fromEnv);
   }

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -465,7 +465,7 @@ export function registerSecretsCommands(program: Command): void {
               typeof raw === 'string'
                 ? raw
                 : (raw && typeof raw === 'object' && 'value' in raw ? (raw as any).value : '');
-            console.log(`  ${chalk.cyan(e.key.padEnd(28))} ${kindLabel(e.kind).padEnd(18)} ${literalValue}`);
+            console.log(`  ${chalk.cyan(e.key.padEnd(28))} ${kindLabel(e.kind).padEnd(18)} ${redact(literalValue, reveal)}`);
           } else {
             console.log(`  ${chalk.cyan(e.key.padEnd(28))} ${kindLabel(e.kind).padEnd(18)} ${e.detail}`);
           }
@@ -948,8 +948,8 @@ Examples:
           return;
         }
 
-        if (isInteractiveTerminal() && !opts.plaintext) {
-          console.error(chalk.red('export to a TTY requires --plaintext (prevents shoulder-surfing).'));
+        if (!opts.plaintext) {
+          console.error(chalk.red('export prints secrets in the clear and requires --plaintext (works for TTY and pipes alike).'));
           process.exit(1);
         }
         const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `export to shell` });

--- a/src/lib/secrets/__tests__/sync.test.ts
+++ b/src/lib/secrets/__tests__/sync.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { encryptBlob, decryptBlob } from '../sync.js';
+import { encryptBlob, decryptBlob, MIN_PASSPHRASE_LEN } from '../sync.js';
 
 describe('sync encrypt/decrypt', () => {
   it('round-trips arbitrary JSON under a passphrase', () => {
@@ -22,7 +22,8 @@ describe('sync encrypt/decrypt', () => {
   });
 
   it('rejects short passphrases', () => {
-    expect(() => encryptBlob('payload', 'short')).toThrow(/at least 8 characters/);
+    const short = 'x'.repeat(MIN_PASSPHRASE_LEN - 1);
+    expect(() => encryptBlob('payload', short)).toThrow(/at least 12 characters/);
   });
 
   it('rejects tampered ciphertext (auth tag mismatch)', () => {

--- a/src/lib/secrets/sync.ts
+++ b/src/lib/secrets/sync.ts
@@ -34,6 +34,7 @@ const BUNDLE_ENDPOINT = '/api/v1/secrets/bundles';
 // PBKDF2 cost. 600k SHA-256 iters matches OWASP 2023+ guidance and keeps a
 // passphrase prompt under a second on the hardware the CLI targets.
 const PBKDF2_ITER = 600_000;
+export const MIN_PASSPHRASE_LEN = 12;
 const KEY_LEN = 32;
 const SALT_LEN = 16;
 const IV_LEN = 12;
@@ -97,8 +98,8 @@ function deriveKey(passphrase: string, salt: Buffer): Buffer {
 
 /** Encrypt a JSON-serializable payload with a passphrase. */
 export function encryptBlob(plaintext: string, passphrase: string): EncryptedEnvelope {
-  if (!passphrase || passphrase.length < 8) {
-    throw new Error('Passphrase must be at least 8 characters.');
+  if (!passphrase || passphrase.length < MIN_PASSPHRASE_LEN) {
+    throw new Error(`Passphrase must be at least ${MIN_PASSPHRASE_LEN} characters.`);
   }
   const salt = crypto.randomBytes(SALT_LEN);
   const iv = crypto.randomBytes(IV_LEN);

--- a/src/lib/session/__tests__/render.test.ts
+++ b/src/lib/session/__tests__/render.test.ts
@@ -193,6 +193,19 @@ describe('renderConversationMarkdown', () => {
     expect(out).not.toContain('TOKEN=abc123');
   });
 
+  it('redacts secrets echoed in user, assistant, thinking, and error blocks by default', () => {
+    const token = 'sk-' + 'a'.repeat(40);
+    const events: SessionEvent[] = [
+      { type: 'message', agent: 'claude', timestamp: 't0', role: 'user', content: `here is my key ${token}` },
+      { type: 'message', agent: 'claude', timestamp: 't1', role: 'assistant', content: `your key ${token} is noted` },
+      { type: 'thinking', agent: 'claude', timestamp: 't2', content: `mulling over ${token}` },
+      { type: 'error', agent: 'claude', timestamp: 't3', content: `failed with ${token}` },
+    ];
+    const out = renderConversationMarkdown(events);
+    expect(out).not.toContain(token);
+    expect(out).toContain('[REDACTED_API_KEY]');
+  });
+
   it('can render markdown without redaction when explicitly requested', () => {
     const events: SessionEvent[] = [
       { type: 'tool_use', agent: 'claude', timestamp: 't0', tool: 'Bash', args: {}, command: 'TOKEN=abc123 deploy' },

--- a/src/lib/session/render.ts
+++ b/src/lib/session/render.ts
@@ -920,12 +920,12 @@ export function renderConversationMarkdown(
   for (const event of events) {
     if (event.type === 'message') {
       if (event.role === 'user') {
-        parts.push(`## User\n\n${event.content ?? ''}`);
+        parts.push(`## User\n\n${sanitize(event.content ?? '')}`);
       } else if (event.role === 'assistant') {
-        parts.push(`## Assistant\n\n${event.content ?? ''}`);
+        parts.push(`## Assistant\n\n${sanitize(event.content ?? '')}`);
       }
     } else if (event.type === 'thinking') {
-      if (event.content) parts.push(`### Thinking\n\n${event.content}`);
+      if (event.content) parts.push(`### Thinking\n\n${sanitize(event.content)}`);
     } else if (event.type === 'tool_use') {
       const tool = event.tool || 'unknown';
       if (event.command) {
@@ -943,7 +943,7 @@ export function renderConversationMarkdown(
         parts.push(`### Tool Result\n\n\`\`\`\n${body}\n\`\`\``);
       }
     } else if (event.type === 'error') {
-      parts.push(`### Error\n\n${event.content || event.tool || 'Unknown error'}`);
+      parts.push(`### Error\n\n${event.content ? sanitize(event.content) : (event.tool || 'Unknown error')}`);
     }
   }
 


### PR DESCRIPTION
## Summary

A 5-codex-agent security audit of the `secrets` subcommand surfaced 18 findings; after independent verification, 5 were real-and-worth-fixing. This branch lands the 3 mechanical client-side fixes plus 2 follow-ons that came out of parallel teammate work.

## Fixes

### `e56e1bda` — export/view/migrate-acl tightenings (HIGH + 2 MED)
- **`secrets export`** previously only required `--plaintext` on a TTY. Non-TTY callers (CI, scripts, log-capturing parents) got raw `KEY=VALUE` lines silently. Now `--plaintext` is required unconditionally. The documented `eval "$(agents secrets export prod --plaintext)"` pattern is unaffected.
- **`secrets view`** masked keychain-backed values but printed literals raw, so anything imported with `--all-plaintext` leaked on display. Literals now go through the same `redact(value, reveal)` gate.
- **`secrets migrate-acl --commit --prefix ""`** (or any non-`agents-cli.` prefix) would enumerate and rewrite arbitrary Keychain items. Now rejects prefixes that don't start with `agents-cli.`.

### `e6755b78` — markdown redactor closes user/assistant/thinking/error gap (MED)
`renderConversationMarkdown` only `sanitize()`d `tool_use.command` and `tool_result.content`. If an agent echoed a secret in chat (assistant reply, thinking block, error), `agents sessions <id> --markdown` revealed it even with redact on. Now all four event types pass through `sanitize()`.

### `0b3de4ac` — passphrase floor 8 → 12 chars (MED)
PBKDF2-SHA256 at 600k iters matches OWASP 2026 but 8-char minimum let users pick `password1` and lose offline-decrypt resistance against leaked `api.prix.dev` ciphertext. Centralized `MIN_PASSPHRASE_LEN = 12` in `sync.ts`, imported at every check site.

## Deliberately deferred

- **ETag/If-Match on sync push/pull** — requires server-side support on `api.prix.dev`. Open issue.
- **Helper integrity verification per call** — verified not-a-boundary: macOS Keychain ACL is `[biometryCurrentSet, .or, .devicePasscode]`, which is user-presence, not code-identity. Replacing the helper doesn't grant new reads.
- **Bundle env becomes process-wide for spawned agents** — that's the documented feature of `secrets exec`. Doc/scope note, not a code fix.

## Test plan

- [x] Build: `bun run build` — clean
- [x] Tests: `bun run test src/lib/secrets/ src/lib/session/` — 16 files, 228 tests pass
- [x] End-to-end: `node dist/index.js secrets export __nonexistent__` now errors with `export prints secrets in the clear and requires --plaintext (works for TTY and pipes alike).`
- [x] End-to-end: `node dist/index.js secrets migrate-acl --commit --prefix "evil."` now errors with `--prefix must start with 'agents-cli.'`
- [x] New unit test in `src/lib/session/__tests__/render.test.ts` covers the redactor fix