### PR TITLE
feat(copilot): detect unmanaged ~/.copilot installs in agents setup

### DIFF
--- a/src/lib/__tests__/unmanaged-installs.test.ts
+++ b/src/lib/__tests__/unmanaged-installs.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { UNMANAGED_DETECTION_CANDIDATES } from '../agents.js';
+
+describe('UNMANAGED_DETECTION_CANDIDATES', () => {
+  it('includes copilot', () => {
+    expect(UNMANAGED_DETECTION_CANDIDATES).toContain('copilot');
+  });
+
+  it('keeps the other first-class agents (regression guard)', () => {
+    expect(UNMANAGED_DETECTION_CANDIDATES).toEqual(
+      expect.arrayContaining(['claude', 'codex', 'gemini', 'grok'])
+    );
+  });
+});

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -650,14 +650,27 @@ export interface UnmanagedInstall {
 }
 
 /**
+ * Agents that `agents setup` probes for pre-existing native installations
+ * (i.e., a config dir present before agents-cli took over). Add an agent here
+ * once its `cliCommand` reports a usable `--version` and its session dir is
+ * wired into `getSessionDir`.
+ */
+export const UNMANAGED_DETECTION_CANDIDATES: AgentId[] = [
+  'claude',
+  'codex',
+  'gemini',
+  'grok',
+  'copilot',
+];
+
+/**
  * Detect existing agent installations that are NOT yet managed by agents-cli.
  * Returns agents whose config dir exists as a real directory (not a symlink).
  */
 export async function getUnmanagedAgentInstalls(): Promise<UnmanagedInstall[]> {
   const unmanaged: UnmanagedInstall[] = [];
-  const candidates: AgentId[] = ['claude', 'codex', 'gemini', 'grok'];
 
-  for (const agentId of candidates) {
+  for (const agentId of UNMANAGED_DETECTION_CANDIDATES) {
     const agent = AGENTS[agentId];
     try {
       const stat = fs.lstatSync(agent.configDir);


### PR DESCRIPTION
## Summary

- `getUnmanagedAgentInstalls` (`src/lib/agents.ts:656`) walked a hardcoded `candidates: AgentId[] = ['claude', 'codex', 'gemini', 'grok']`. Copilot was missing, so users who had already run `npm i -g @github/copilot` before discovering agents-cli never got the migration prompt from `agents setup` and their `~/.copilot/` stayed unmanaged.
- Hoist `candidates` to an exported `UNMANAGED_DETECTION_CANDIDATES` constant (named seam for testing and future additions) and add `'copilot'`.

## Why it's safe to enable now

Copilot already has the two prerequisites the function depends on:
- Session dir wired: `getSessionDir` has `case 'copilot':` at `src/lib/agents.ts:909` (added in `1f796313 feat(copilot): wire copilot session dir and jsonl extension`), so `countSessionFiles('copilot')` works.
- `getCliVersion('copilot')` resolves via the generic `findInPath(agent.cliCommand)` path — verified locally: `copilot --version` returns `GitHub Copilot CLI 1.0.56`.

## Changes

- `src/lib/agents.ts` — extract `candidates` to module-level `UNMANAGED_DETECTION_CANDIDATES` with a docstring; add `'copilot'`.
- `src/lib/__tests__/unmanaged-installs.test.ts` — assert `'copilot'` is in the list and the other four first-class agents are still there (regression guard).

## Test plan

- [x] `bun test src/lib/__tests__/unmanaged-installs.test.ts` — 2 passing.
- [x] `bun run build` — tsc passes.
- [x] End-to-end via built `dist/`: `node -e "require('./dist/lib/agents.js').UNMANAGED_DETECTION_CANDIDATES"` returns `[ 'claude', 'codex', 'gemini', 'grok', 'copilot' ]`.

## Note on behavioral tests

I tried `vi.spyOn(fs, 'lstatSync')` to drive the function end-to-end against a fake `~/.copilot/` directory, but ESM module exports are read-only (`TypeError: Cannot redefine property: lstatSync`). The function reads `AGENTS[agentId].configDir` which is captured at module-load from `HOME`, so injecting a temp HOME would require `vi.resetModules()` + a full module re-init. The named-constant assertion catches the regression that matters here (someone removing copilot from the list) without the mocking overhead.