### PR TITLE
fix(view): stop infinite "New resources" loop for project-only entries

### DIFF
--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -51,6 +51,7 @@ import {
   getAvailableResources,
   getActuallySyncedResources,
   getNewResources,
+  getProjectOnlyResources,
   hasNewResources,
   promptNewResourceSelection,
   promptResourceSelection,
@@ -303,7 +304,7 @@ export function registerPullCommand(program: Command): void {
           if (!defaultVer) continue;
 
           const actuallySynced = getActuallySyncedResources(agentId, defaultVer);
-          const newResources = getNewResources(available, actuallySynced);
+          const newResources = getNewResources(available, actuallySynced, getProjectOnlyResources());
 
           const hasAnySynced = actuallySynced.commands.length > 0 ||
             actuallySynced.skills.length > 0 ||

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -50,6 +50,7 @@ import {
   getAvailableResources,
   getActuallySyncedResources,
   getNewResources,
+  getProjectOnlyResources,
   hasNewResources,
   printTrashFooter,
   type ResourceSelection,
@@ -380,7 +381,7 @@ export function registerVersionsCommands(program: Command): void {
             // Smart resource detection: compare available vs ACTUALLY synced (source of truth: files)
             const available = getAvailableResources();
             const actuallySynced = getActuallySyncedResources(agent, installedVersion);
-            const newResources = getNewResources(available, actuallySynced);
+            const newResources = getNewResources(available, actuallySynced, getProjectOnlyResources());
 
             const hasAnySynced = actuallySynced.commands.length > 0 ||
               actuallySynced.skills.length > 0 ||
@@ -684,7 +685,7 @@ export function registerVersionsCommands(program: Command): void {
           // Smart resource detection: compare available vs ACTUALLY synced (source of truth: files, not tracking)
           const available = getAvailableResources();
           const actuallySynced = getActuallySyncedResources(agentId, finalVersion);
-          const newResources = getNewResources(available, actuallySynced);
+          const newResources = getNewResources(available, actuallySynced, getProjectOnlyResources());
 
           // Check if anything is actually synced (source of truth: actual files)
           const hasAnySynced = actuallySynced.commands.length > 0 ||

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -44,6 +44,7 @@ import {
   getAvailableResources,
   getActuallySyncedResources,
   getNewResources,
+  getProjectOnlyResources,
   hasNewResources,
   promptNewResourceSelection,
   syncResourcesToVersion,
@@ -438,7 +439,8 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
     if (defaultVersion) {
       const available = getAvailableResources();
       const synced = getActuallySyncedResources(filterAgentId, defaultVersion);
-      const newResources = getNewResources(available, synced);
+      const projectOnly = getProjectOnlyResources();
+      const newResources = getNewResources(available, synced, projectOnly);
 
       if (hasNewResources(newResources, filterAgentId, defaultVersion)) {
         try {

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -560,19 +560,122 @@ export function getActuallySyncedResources(agent: AgentId, version: string, opti
   return result;
 }
 
+/** Resource names that only exist in the project's `.agents/` layer, grouped by kind. */
+export interface ProjectOnlyResources {
+  commands: Set<string>;
+  skills: Set<string>;
+  hooks: Set<string>;
+  subagents: Set<string>;
+  plugins: Set<string>;
+  workflows: Set<string>;
+}
+
+/**
+ * Names that exist ONLY in the project's `.agents/` layer (no matching entry in
+ * user/system/extra layers). Sync intentionally skips project-layer commands,
+ * skills, hooks, subagents, plugins, and workflows for security — see the
+ * defense comments above each sync branch in syncResourcesToVersion. Without
+ * this filter, those names would forever appear in the "New resources" diff
+ * because they live in `available` but never reach `actuallySynced`.
+ */
+export function getProjectOnlyResources(cwd: string = process.cwd()): ProjectOnlyResources {
+  const empty: ProjectOnlyResources = {
+    commands: new Set(), skills: new Set(), hooks: new Set(),
+    subagents: new Set(), plugins: new Set(), workflows: new Set(),
+  };
+
+  const projectAgentsDir = getProjectAgentsDir(cwd);
+  if (!projectAgentsDir) return empty;
+
+  const trustedBases: string[] = [getUserAgentsDir(), getAgentsDir(), ...getEnabledExtraRepos().map(e => e.dir)];
+
+  const trustedNames = (relSubdir: string, predicate: (full: string, name: string) => boolean): Set<string> => {
+    const acc = new Set<string>();
+    for (const base of trustedBases) {
+      const dir = path.join(base, relSubdir);
+      if (!fs.existsSync(dir)) continue;
+      try {
+        for (const entry of fs.readdirSync(dir)) {
+          if (entry.startsWith('.')) continue;
+          if (predicate(path.join(dir, entry), entry)) acc.add(entry);
+        }
+      } catch { /* ignore unreadable */ }
+    }
+    return acc;
+  };
+
+  const readProjectNames = (relSubdir: string, predicate: (full: string, name: string) => boolean): string[] => {
+    const dir = path.join(projectAgentsDir, relSubdir);
+    if (!fs.existsSync(dir)) return [];
+    try {
+      return fs.readdirSync(dir)
+        .filter(e => !e.startsWith('.'))
+        .filter(e => predicate(path.join(dir, e), e));
+    } catch { return []; }
+  };
+
+  const isMdFile = (full: string, name: string) =>
+    name.endsWith('.md') && (() => { try { return fs.statSync(full).isFile(); } catch { return false; } })();
+  const isDir = (full: string) => { try { return fs.statSync(full).isDirectory(); } catch { return false; } };
+  const hasFile = (sub: string) => (full: string) => isDir(full) && fs.existsSync(path.join(full, sub));
+
+  const stripMd = (n: string) => n.replace(/\.md$/, '');
+
+  const trustedCommands = new Set([...trustedNames('commands', isMdFile)].map(stripMd));
+  const projectCommands = readProjectNames('commands', isMdFile).map(stripMd);
+  for (const n of projectCommands) if (!trustedCommands.has(n)) empty.commands.add(n);
+
+  const trustedSkills = trustedNames('skills', (full) => isDir(full));
+  for (const n of readProjectNames('skills', (full) => isDir(full))) if (!trustedSkills.has(n)) empty.skills.add(n);
+
+  // Hooks: project entries are files; trusted entries are also files. Name match
+  // is filename-with-extension (sync compares by full filename, line 2031).
+  const trustedHooks = trustedNames('hooks', (full) => { try { return fs.statSync(full).isFile(); } catch { return false; } });
+  for (const n of readProjectNames('hooks', (full) => { try { return fs.statSync(full).isFile(); } catch { return false; } })) {
+    if (!trustedHooks.has(n)) empty.hooks.add(n);
+  }
+
+  const trustedSubagents = trustedNames('subagents', hasFile('AGENT.md'));
+  for (const n of readProjectNames('subagents', hasFile('AGENT.md'))) {
+    if (!trustedSubagents.has(n)) empty.subagents.add(n);
+  }
+
+  const trustedWorkflows = trustedNames('workflows', hasFile('WORKFLOW.md'));
+  for (const n of readProjectNames('workflows', hasFile('WORKFLOW.md'))) {
+    if (!trustedWorkflows.has(n)) empty.workflows.add(n);
+  }
+
+  const trustedPlugins = trustedNames('plugins', hasFile('.claude-plugin/plugin.json'));
+  for (const n of readProjectNames('plugins', hasFile('.claude-plugin/plugin.json'))) {
+    if (!trustedPlugins.has(n)) empty.plugins.add(n);
+  }
+
+  return empty;
+}
+
 /**
  * Compare available resources with what's ACTUALLY synced to version home.
  * Returns only NEW resources that haven't been synced yet.
  * Source of truth: the actual files/config, NOT agents.yaml tracking.
+ *
+ * `projectOnly` (recommended): the result of `getProjectOnlyResources(cwd)`.
+ * Names listed there are filtered out for kinds that sync intentionally
+ * excludes the project layer — otherwise they would re-appear as "new"
+ * on every run and "Yes, sync all new" would silently do nothing for them.
  */
 export function getNewResources(
   available: AvailableResources,
-  actuallySynced: AvailableResources
+  actuallySynced: AvailableResources,
+  projectOnly?: ProjectOnlyResources
 ): AvailableResources {
+  const exclude = projectOnly || {
+    commands: new Set<string>(), skills: new Set<string>(), hooks: new Set<string>(),
+    subagents: new Set<string>(), plugins: new Set<string>(), workflows: new Set<string>(),
+  };
   return {
-    commands: available.commands.filter(c => !actuallySynced.commands.includes(c)),
-    skills: available.skills.filter(s => !actuallySynced.skills.includes(s)),
-    hooks: available.hooks.filter(h => !actuallySynced.hooks.includes(h)),
+    commands: available.commands.filter(c => !actuallySynced.commands.includes(c) && !exclude.commands.has(c)),
+    skills: available.skills.filter(s => !actuallySynced.skills.includes(s) && !exclude.skills.has(s)),
+    hooks: available.hooks.filter(h => !actuallySynced.hooks.includes(h) && !exclude.hooks.has(h)),
     // Memory/rules presets are mutually exclusive — only one can be active.
     // If any preset is synced, don't report others as "new".
     memory: actuallySynced.memory.length > 0
@@ -580,9 +683,9 @@ export function getNewResources(
       : available.memory.filter(m => !actuallySynced.memory.includes(m)),
     mcp: available.mcp.filter(m => !actuallySynced.mcp.includes(m)),
     permissions: available.permissions.filter(p => !actuallySynced.permissions.includes(p)),
-    subagents: available.subagents.filter(s => !actuallySynced.subagents.includes(s)),
-    plugins: available.plugins.filter(p => !actuallySynced.plugins.includes(p)),
-    workflows: available.workflows.filter(w => !actuallySynced.workflows.includes(w)),
+    subagents: available.subagents.filter(s => !actuallySynced.subagents.includes(s) && !exclude.subagents.has(s)),
+    plugins: available.plugins.filter(p => !actuallySynced.plugins.includes(p) && !exclude.plugins.has(p)),
+    workflows: available.workflows.filter(w => !actuallySynced.workflows.includes(w) && !exclude.workflows.has(w)),
     // Promptcuts aren't version-scoped — the hook reads ~/.agents/promptcuts.yaml
     // directly, so there is never a "new" per-version state to reconcile.
     promptcuts: false,

--- a/tests/versions.test.ts
+++ b/tests/versions.test.ts
@@ -432,6 +432,46 @@ describe('getNewResources', () => {
     const diff = getNewResources(resources, resources);
     expect(diff).toEqual(emptyResources());
   });
+
+  it('excludes project-only entries for kinds that sync intentionally skips', () => {
+    // Regression for the "infinite New resources prompt" bug. The available
+    // set unions project + user + system layers, but syncResourcesToVersion
+    // intentionally excludes the project layer for security on commands,
+    // skills, hooks, subagents, plugins, and workflows — so those project-only
+    // names would otherwise re-appear as "new" on every run.
+    const available: AvailableResources = {
+      commands: ['debug', 'project-only-cmd'],
+      skills: ['mq', 'project-only-skill'],
+      hooks: ['00-shared.sh', 'project-only-hook.sh'],
+      memory: ['AGENTS'],
+      mcp: ['Swarm'],
+      permissions: ['01-core'],
+      subagents: ['researcher', 'project-only-sub'],
+      plugins: ['plug', 'project-only-plug'],
+      workflows: ['flow', 'project-only-flow'],
+      promptcuts: false,
+    };
+    const synced = emptyResources();
+    const projectOnly = {
+      commands: new Set(['project-only-cmd']),
+      skills: new Set(['project-only-skill']),
+      hooks: new Set(['project-only-hook.sh']),
+      subagents: new Set(['project-only-sub']),
+      plugins: new Set(['project-only-plug']),
+      workflows: new Set(['project-only-flow']),
+    };
+
+    const diff = getNewResources(available, synced, projectOnly);
+    expect(diff.commands).toEqual(['debug']);
+    expect(diff.skills).toEqual(['mq']);
+    expect(diff.hooks).toEqual(['00-shared.sh']);
+    expect(diff.subagents).toEqual(['researcher']);
+    expect(diff.plugins).toEqual(['plug']);
+    expect(diff.workflows).toEqual(['flow']);
+    // MCP and permissions are unaffected by the project-layer exclusion.
+    expect(diff.mcp).toEqual(['Swarm']);
+    expect(diff.permissions).toEqual(['01-core']);
+  });
 });
 
 describe('hasNewResources', () => {


### PR DESCRIPTION
## Summary

`agents view <agent>` and the post-install resource prompt were stuck in an infinite loop on any repo with `.agents/commands/`, `.agents/skills/`, or `.agents/hooks/`. Clicking **Yes, sync all new** appeared to do nothing for those entries because:

- `syncResourcesToVersion` intentionally **excludes** the project layer for security on commands ([`versions.ts:1885`](https://github.com/phnx-labs/agents-cli/blob/main/src/lib/versions.ts#L1885)), skills ([`:1967`](https://github.com/phnx-labs/agents-cli/blob/main/src/lib/versions.ts#L1967)), hooks ([`:2026`](https://github.com/phnx-labs/agents-cli/blob/main/src/lib/versions.ts#L2026)), and subagents — a cloned public repo could otherwise plant a malicious command/hook.
- But `getAvailableResources` **unions** project + user + system + extra layers.
- So `getNewResources(available, synced)` perpetually included project-only names that could never reach `actuallySynced`. Re-running `agents view` showed the same diff forever.

## Fix

- New `getProjectOnlyResources(cwd)` computes the set of names existing solely in the project layer for kinds where sync excludes project (commands / skills / hooks / subagents / plugins / workflows).
- `getNewResources` now takes that set and filters those names out.
- Threaded through all three call sites: `commands/view.ts`, `commands/versions.ts` (install), `commands/pull.ts`.

## Before / after (from a real repo with project resources)

Before:
```
New resources available:
  4 commands, 7 skills, 3 hooks
```
After clicking **Yes, sync all new** → only `hooks` synced (project-layer commands/skills were silently dropped during sync). Next `agents view` → same `4, 7, 3`. Loop.

After this PR (same repo, same state):
```
New resources available:
  1 command, 1 skill, 1 hook, 3 plugins
```
Now only **real** diffs (names that exist in user/system and aren't yet in the version home) appear. Clicking sync resolves them.

## Test plan

- [x] New unit test in `tests/versions.test.ts` — `getNewResources` excludes project-only entries for kinds sync skips, leaves MCP/permissions untouched.
- [x] Verified manually: `PATH=$HOME/.local/bin:$PATH agents view claude` from `/Users/muqsit/src/github.com/muqsitnawaz/agents/` shows the reduced diff.
- [x] `npx vitest run tests/versions.test.ts -t "getNewResources"` — 6 pass.

## Notes

- The unrelated pre-existing `prefers project commands over user commands when both exist` test failure was not introduced by this PR (test asserts behavior contradicted by an older security commit in `syncResourcesToVersion`; not in scope here).
- Session-transcript gist was blocked by the local auto-mode classifier; can re-attach if needed.