### PR TITLE
fix(view): align globally-installed rows + optional overageCredits + exhaustive badge switch

### DIFF
--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -388,6 +388,18 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
         return `${cliState?.version || 'installed'} (global)`.length;
       })
     );
+    // Pre-pass: max badge width so rows with `lastActive` line up whether or
+    // not THIS row carries a throttle badge. Without this, the row that DOES
+    // have "out of credits" shifts every other row's `lastActive` left by
+    // ~16 chars, exactly what the version-managed block at maxStatusWidth
+    // already solves above.
+    let gMaxStatusWidth = 0;
+    for (const agentId of globallyInstalled) {
+      const gInfoRaw = globalInfoMap.get(agentId);
+      const gInfo = gInfoRaw ? mergeCanonical(gInfoRaw) : undefined;
+      const w = visibleWidth(formatUsageStatusBadge(gInfo?.usageStatus));
+      if (w > gMaxStatusWidth) gMaxStatusWidth = w;
+    }
 
     for (const agentId of globallyInstalled) {
       const agent = AGENTS[agentId];
@@ -407,7 +419,10 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
       if (gInfo?.email || gUsageStr || gActiveStr) parts.push(gInfo?.email ? chalk.cyan(gInfo.email) : '');
       if (gUsageStr || gActiveStr) parts.push(gUsageStr);
       const gStatusStr = formatUsageStatusBadge(gInfo?.usageStatus);
-      if (gStatusStr) parts.push(gStatusStr);
+      if (gMaxStatusWidth > 0) {
+        const statusPad = ' '.repeat(Math.max(0, gMaxStatusWidth - visibleWidth(gStatusStr)));
+        parts.push(gStatusStr + statusPad);
+      }
       if (gActiveStr) parts.push(gActiveStr);
       console.log(parts.join('  '));
       if (showPaths && cliState?.path) {
@@ -815,7 +830,10 @@ export interface ViewJsonVersion {
   email: string | null;
   plan: string | null;
   usageStatus: 'available' | 'rate_limited' | 'out_of_credits' | null;
-  overageCredits: { amount: number; currency: string } | null;
+  // Optional so existing TypeScript consumers compiled against the prior
+  // interface don't error on the new field; null means we know there are no
+  // outstanding overage credits, undefined means we haven't fetched / can't say.
+  overageCredits?: { amount: number; currency: string } | null;
   windows: Array<{
     key: 'session' | 'week' | 'sonnet_week';
     usedPercent: number;

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -327,14 +327,25 @@ export function formatUsageSummary(
  * a glance at the row tells the user whether the version can do useful work.
  * The same signal is exposed as `usageStatus` in `agents view --json` for
  * programmatic consumers (e.g. the swarmify panel's "resume in healthy agent").
+ *
+ * The switch is exhaustive on purpose — adding a new `AccountInfo.usageStatus`
+ * value without updating the cases here is a build error at `_exhaustive`,
+ * which is exactly the bug class this PR is fixing.
  */
 export function formatUsageStatusBadge(
   usageStatus: 'available' | 'rate_limited' | 'out_of_credits' | null | undefined
 ): string {
-  if (!usageStatus || usageStatus === 'available') return '';
-  if (usageStatus === 'out_of_credits') return chalk.red('out of credits');
-  if (usageStatus === 'rate_limited') return chalk.yellow('rate-limited');
-  return '';
+  if (usageStatus === null || usageStatus === undefined) return '';
+  switch (usageStatus) {
+    case 'available':       return '';
+    case 'out_of_credits':  return chalk.red('out of credits');
+    case 'rate_limited':    return chalk.yellow('rate-limited');
+    default: {
+      const _exhaustive: never = usageStatus;
+      void _exhaustive;
+      return '';
+    }
+  }
 }
 
 /** Format a multi-line usage section for detailed agent views. */


### PR DESCRIPTION
## Summary

Follow-up to the now-merged throttle-badge work (landed via 1dae0283 + original PR #145 review). Addresses the three issues the reviewer flagged on #145.

### Changes

1. **Globally-installed rows now align consistently.** The Not-Managed (\`globallyInstalled\`) block was missing the \`maxStatusWidth\` pre-pass that the version-managed block already had. A row with \`out of credits\` was shifting every other row's \`lastActive\` left by ~16 chars. Mirrored the two-pass alignment so columns line up whether or not the row carries a badge.

2. **\`ViewJsonVersion.overageCredits\` is now optional.** The original landing committed it as a required field, which is a breaking change for TS consumers compiled against the prior shape. Now \`overageCredits?\` with a comment distinguishing \`null\` (definitively none) from \`undefined\` (not fetched).

3. **\`formatUsageStatusBadge\` is exhaustive.** Old if-chain silently returned \`''\` for any future status value — exactly the bug class this whole thread is fixing. Switched to a case + \`assertNever\` so adding a new \`AccountInfo.usageStatus\` member fails the build instead of going invisible.

## Test plan

- [x] \`npx vitest run src/lib/__tests__/usage.test.ts\` — 10 pass.
- [x] \`bun run build\` — TS clean.
- [x] Verified end-to-end with the dev install in the previous session — the throttle badge renders correctly for both managed and global agents.

## Why a new PR

The original PR #145 went merge-conflict with main once 1dae0283 landed (it added the exact same content with a different commit hash). Closed as superseded; this PR is a clean follow-up off current main carrying only the three reviewer asks.