### PR TITLE
fix(agents): support grok and antigravity cli flows

### DIFF
--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -336,7 +336,7 @@ export function registerVersionsCommands(program: Command): void {
         const { agent, version } = parsed;
         const agentConfig = AGENTS[agent];
 
-        if (!agentConfig.npmPackage) {
+        if (!agentConfig.npmPackage && !agentConfig.installScript) {
           console.log(chalk.yellow(`${agentLabel(agentConfig.id)} has no npm package. Install manually.`));
           continue;
         }

--- a/src/lib/__tests__/exec.test.ts
+++ b/src/lib/__tests__/exec.test.ts
@@ -167,6 +167,18 @@ describe('buildExecCommand', () => {
       expect(cmd).toContain('--autopilot');
     });
 
+    it('grok plan produces --permission-mode plan', () => {
+      const cmd = buildExecCommand(opts({ agent: 'grok', mode: 'plan' }));
+      expect(cmd).toContain('--permission-mode');
+      expect(cmd[cmd.indexOf('--permission-mode') + 1]).toBe('plan');
+      expect(cmd).not.toContain('--mode');
+    });
+
+    it('grok skip produces --always-approve', () => {
+      const cmd = buildExecCommand(opts({ agent: 'grok', mode: 'skip' }));
+      expect(cmd).toContain('--always-approve');
+    });
+
     it('copilot uses -p (not positional) for the prompt', () => {
       const cmd = buildExecCommand(opts({ agent: 'copilot', prompt: 'do the thing', mode: 'edit' }));
       const idx = cmd.indexOf('-p');
@@ -216,6 +228,11 @@ describe('buildExecCommand', () => {
     it('gemini headless adds nothing', () => {
       const cmd = buildExecCommand(opts({ agent: 'gemini', headless: true }));
       expect(cmd).not.toContain('--print');
+    });
+
+    it('antigravity headless prompts use --print before the prompt', () => {
+      const cmd = buildExecCommand(opts({ agent: 'antigravity', mode: 'edit', headless: true }));
+      expect(cmd).toEqual(['agy', '--print', 'do the thing']);
     });
   });
 

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -434,7 +434,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     color: 'cyanBright',
     cliCommand: 'grok',
     npmPackage: '',
-    installScript: 'curl -fsSL https://x.ai/cli/install.sh | bash -s VERSION',
+    installScript: 'curl -fsSL https://x.ai/cli/install.sh | bash',
     configDir: path.join(HOME, '.grok'),
     commandsDir: '', // Grok primarily uses skills + slash commands from skills
     commandsSubdir: '',

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -348,16 +348,15 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
       edit: [],
       skip: ['--dangerously-skip-permissions'],
     },
+    printFlags: ['--print'],
     modelFlag: '--model',
   },
   grok: {
     base: ['grok'],
     promptFlag: '-p',
     modeFlags: {
-      // grok defaults to plan mode; --permission-mode <MODE> exists in --help
-      // (modes not enumerated). Preserve historical --mode plan behavior until
-      // someone with a working grok install can verify the canonical spelling.
-      plan: ['--mode', 'plan'],
+      // grok --help lists `--permission-mode plan`; the TUI defaults to ask.
+      plan: ['--permission-mode', 'plan'],
       edit: [],
       skip: ['--always-approve'],
     },

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1127,40 +1127,49 @@ export async function installVersion(
 ): Promise<{ success: boolean; installedVersion: string; error?: string }> {
   const agentConfig = AGENTS[agent];
 
-  if (!agentConfig.npmPackage) {
-    // Support agents that provide an installScript (cursor, roo, goose, kiro, grok, etc.)
-    if (agentConfig.installScript) {
-      // For grok we give special love because the user asked for first-class support
-      if (agent === 'grok') {
-        onProgress?.(`Installing Grok ${version} via official installer...`);
-        try {
-          const script = agentConfig.installScript.replace('VERSION', version);
-          // The official installer supports -s <version>
-          const { exec } = await import('child_process');
-          const { promisify } = await import('util');
-          const execAsync = promisify(exec);
-          await execAsync(script, { timeout: 120000 });
-          onProgress?.('Grok binary installed. Setting up agents-cli version home for isolation...');
-        } catch (err: any) {
-          return { success: false, installedVersion: version, error: `Grok installer failed: ${err.message}` };
-        }
-      } else {
-        return {
-          success: false,
-          installedVersion: version,
-          error: `${agent} uses an external installer. Run: ${agentConfig.installScript}`,
-        };
-      }
-    } else {
-      return { success: false, installedVersion: version, error: 'Agent has no npm package' };
-    }
-  }
-
   // Validate before deriving filesystem paths or npm package specs. The CLI
   // parser already enforces this for user input; this guard protects direct
   // callers and tests the critical install path at the source.
   if (!VERSION_RE.test(version)) {
     throw new Error(`Invalid version: ${JSON.stringify(version)}`);
+  }
+
+  if (!agentConfig.npmPackage) {
+    if (!agentConfig.installScript) {
+      return { success: false, installedVersion: version, error: 'Agent has no npm package' };
+    }
+
+    if (version !== 'latest' && !agentConfig.installScript.includes('VERSION')) {
+      return {
+        success: false,
+        installedVersion: version,
+        error: `${agentConfig.name} installer does not support version-pinned installs. Use ${agent}@latest.`,
+      };
+    }
+
+    let installedVersion = version;
+    try {
+      const script = agentConfig.installScript.replaceAll('VERSION', version);
+      onProgress?.(`Installing ${agentConfig.name}@${version} via official installer...`);
+      await execAsync(script, { timeout: 120000 });
+
+      if (version === 'latest') {
+        installedVersion = await getCliVersionFromPath(agent) || version;
+      }
+
+      onProgress?.(`${agentConfig.name} installed. Setting up agents-cli version home for isolation...`);
+    } catch (err: any) {
+      emit('version.install', { agent, version, error: err.message });
+      return { success: false, installedVersion: version, error: `${agentConfig.name} installer failed: ${err.message}` };
+    }
+
+    ensureAgentsDir();
+    const versionDir = getVersionDir(agent, installedVersion);
+    fs.mkdirSync(versionDir, { recursive: true });
+    fs.mkdirSync(path.join(versionDir, 'home'), { recursive: true });
+    createVersionedAlias(agent, installedVersion);
+    emit('version.install', { agent, version: installedVersion });
+    return { success: true, installedVersion };
   }
 
   ensureAgentsDir();
@@ -1169,15 +1178,6 @@ export async function installVersion(
   // Create version directory and isolated home
   fs.mkdirSync(versionDir, { recursive: true });
   fs.mkdirSync(path.join(versionDir, 'home'), { recursive: true });
-
-  // For agents using external installers (especially grok), we don't do npm install.
-  // The binary is managed by the agent's own installer; we only manage the isolated home + resources.
-  if (agent === 'grok' || !agentConfig.npmPackage) {
-    // Grok (and similar) — binary already installed by the step above (or user ran external installer).
-    // We still want to record the version for config isolation.
-    createVersionedAlias(agent, version);
-    return { success: true, installedVersion: version };
-  }
 
   // Initialize package.json (only for real npm agents)
   const packageJson = {
@@ -1530,6 +1530,18 @@ export async function getInstalledVersion(agent: AgentId, version: string): Prom
     return match ? match[1] : version;
   } catch {
     return version;
+  }
+}
+
+async function getCliVersionFromPath(agent: AgentId): Promise<string | null> {
+  const agentConfig = AGENTS[agent];
+  try {
+    await execFileAsync('which', [agentConfig.cliCommand]);
+    const { stdout } = await execFileAsync(agentConfig.cliCommand, ['--version'], { timeout: 3000 });
+    const match = stdout.match(/(\d+\.\d+\.\d+)/);
+    return match ? match[1] : null;
+  } catch {
+    return null;
   }
 }
 

--- a/tests/versions.test.ts
+++ b/tests/versions.test.ts
@@ -140,6 +140,7 @@ import {
   type AvailableResources,
   type ResourceSelection,
 } from '../src/lib/versions.js';
+import { AGENTS } from '../src/lib/agents.js';
 
 function installManagedVersion(agent: 'claude' | 'codex', version: string): void {
   const binaryPath = getBinaryPath(agent, version);
@@ -1045,6 +1046,28 @@ describe('installVersion', () => {
     );
 
     expect(fs.existsSync(path.join(AGENTS_DIR, 'versions', 'claude'))).toBe(false);
+  });
+
+  it('runs configured external installers for non-npm agents and creates a version home', async () => {
+    const original = AGENTS.antigravity.installScript;
+    AGENTS.antigravity.installScript = 'true VERSION';
+
+    try {
+      const result = await installVersion('antigravity', '1.2.3');
+
+      expect(result).toEqual({ success: true, installedVersion: '1.2.3' });
+      expect(fs.existsSync(path.join(AGENTS_DIR, 'versions', 'antigravity', '1.2.3', 'home'))).toBe(true);
+    } finally {
+      AGENTS.antigravity.installScript = original;
+    }
+  });
+
+  it('rejects version-pinned external installs when the installer has no version placeholder', async () => {
+    const result = await installVersion('antigravity', '1.2.3');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('does not support version-pinned installs');
+    expect(fs.existsSync(path.join(AGENTS_DIR, 'versions', 'antigravity'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- route non-npm agents with configured install scripts through installVersion instead of stopping at the npm-package check
- update Grok run argv to use --permission-mode plan and keep --always-approve for skip
- add Antigravity --print for headless prompt runs
- use official latest installers for Grok/Antigravity and reject unsupported pinned installs clearly

## Verification
- bun test src/lib/__tests__/exec.test.ts
- bunx vitest run tests/versions.test.ts -t installVersion
- bun run build
- node --input-type=module -e "import { buildExecCommand } from './dist/lib/exec.js'; for (const [agent, mode] of [['grok','plan'], ['grok','skip'], ['antigravity','edit'], ['antigravity','skip']]) console.log(agent, mode, JSON.stringify(buildExecCommand({ agent, prompt: 'hello', mode, effort: 'auto', headless: true })));"
- node dist/index.js add antigravity@1.2.3 --yes

## Notes
- Full tests/versions.test.ts currently has an unrelated failure in syncResourcesToVersion > commands syncing > prefers project commands over user commands when both exist.
- The first bun run build attempt failed under sandbox EPERM creating dist/; rerun with filesystem approval passed.

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/c983344ba3eee51e42671924506c55cc)