### PR TITLE
fix(secrets): round 2 — remove confirm, control-char escape, env-var warn, security-model doc

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -240,6 +240,27 @@ eval "$(agents secrets export prod --plaintext)"
 
 `agents secrets create prod` then `agents secrets add prod STRIPE_API_KEY` — the key is stored in Keychain and injected automatically on `agents run --secrets prod`.
 
+## Security model
+
+The threat model `agents secrets` defends against is **on-disk plaintext exposure** — credentials in `.env` files, shell history, dotfiles, accidental git commits, backups. It does NOT defend a logged-in user from another binary running as that same user.
+
+What the macOS Keychain ACL actually protects:
+
+- Keychain items are written with `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` plus an access control of `biometryCurrentSet OR devicePasscode`. Source: `src/lib/secrets/keychain-helper.swift:32-44`.
+- That ACL is **user-presence**, not **code-identity**. The OS does not pin the item to the helper binary's code signature. Any same-user process that calls `SecItemCopyMatching` with the same service+account names and pops Touch ID (or the password sheet) gets the value.
+
+Practical implications:
+
+- A malicious binary running as your user, with you logged in at the keyboard, can read any bundle by popping Touch ID with a prompt that says "Unlock agents-cli secrets". Don't approve Touch ID prompts you didn't initiate.
+- `agents secrets list` returns service names without prompting — service names are enumerable metadata. Don't name a bundle after a secret value.
+- Bundle values injected via `agents secrets exec` or `agents run --secrets <bundle>` flow into the child process environment, which is inherited by every subprocess that child spawns (npm install scripts, shell commands, etc.). That's the documented feature — only put credentials in a bundle that you're OK letting the agent's full subprocess tree see.
+
+What we don't protect against:
+
+- Other same-user processes (you control your user account).
+- A user who approves a Touch ID prompt for an attacker-controlled binary.
+- Cross-user attacks where the attacker is `root` (the OS keychain is owned at user scope).
+
 ## See Also
 
 - `docs/00-concepts.md` — DotAgents repos and resource model

--- a/src/commands/secrets-sync.ts
+++ b/src/commands/secrets-sync.ts
@@ -31,15 +31,31 @@ async function promptPassphrase(message: string, confirm = false): Promise<strin
   return first;
 }
 
+// Print the env-var-source warning at most once per process so a `--all` push
+// over many bundles doesn't flood stderr with the same notice.
+let envPassphraseWarned = false;
+
 function passphraseFromEnvOrPrompt(confirm: boolean): Promise<string> {
   const fromEnv = process.env.AGENTS_SECRETS_PASSPHRASE;
   if (fromEnv) {
     if (fromEnv.length < MIN_PASSPHRASE_LEN) {
       return Promise.reject(new Error(`Passphrase must be at least ${MIN_PASSPHRASE_LEN} characters.`));
     }
+    if (!envPassphraseWarned) {
+      envPassphraseWarned = true;
+      process.stderr.write(chalk.yellow(
+        'warn: using AGENTS_SECRETS_PASSPHRASE. Env vars are readable by other same-user processes ' +
+        '(/proc, ps, crash dumps, CI logs) — rotate the passphrase after CI use.\n',
+      ));
+    }
     return Promise.resolve(fromEnv);
   }
   return promptPassphrase('Sync passphrase', confirm);
+}
+
+/** Strip C0/C1 control bytes from server-supplied strings before terminal print. */
+function safePrint(s: string): string {
+  return s.replace(/[\x00-\x08\x0B-\x1F\x7F-\x9F]/g, '');
 }
 
 /** Register `agents secrets push|pull|remote-list` on the parent secrets Command. */
@@ -135,7 +151,7 @@ export function registerSecretsSyncCommands(secrets: Command): void {
         }
         console.log(chalk.bold(`${'NAME'.padEnd(24)} UPDATED_AT`));
         for (const r of remote) {
-          console.log(`${chalk.cyan(r.name.padEnd(24))} ${chalk.gray(r.updated_at)}`);
+          console.log(`${chalk.cyan(safePrint(r.name).padEnd(24))} ${chalk.gray(safePrint(r.updated_at))}`);
         }
       } catch (err) {
         console.error(chalk.red((err as Error).message));

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -231,7 +231,7 @@ function renderBundleRow(b: SecretsBundle): string {
     `${padVisible(created, 9)} ` +
     `${padVisible(updated, 9)} ` +
     `${padVisible(used, 7)}`;
-  return b.description ? `${head} ${chalk.gray(b.description)}` : head.trimEnd();
+  return b.description ? `${head} ${chalk.gray(safePrint(b.description))}` : head.trimEnd();
 }
 
 /** Colorize a variable source kind (literal, keychain, env, file, exec). */
@@ -251,6 +251,18 @@ function redact(value: string, reveal: boolean): string {
   if (reveal) return value;
   if (!value) return '';
   return '*'.repeat(Math.min(value.length, 8));
+}
+
+/**
+ * Strip ASCII / C1 control bytes from a string before printing it to the
+ * terminal. Bundle descriptions, notes, and remote-supplied names can carry
+ * arbitrary text and a malicious value containing ANSI escape sequences (e.g.
+ * OSC 52 clipboard set, screen-clear, cursor moves) would otherwise be
+ * interpreted by the user's terminal. Allow tab and newline so multi-line
+ * notes still render; strip everything else in the C0/C1 ranges plus DEL.
+ */
+function safePrint(s: string): string {
+  return s.replace(/[\x00-\x08\x0B-\x1F\x7F-\x9F]/g, '');
 }
 
 /**
@@ -317,7 +329,7 @@ function renderMetaLine(meta: VarMeta | undefined, reveal: boolean): string {
     parts.push(colored);
   }
   if (meta.note) {
-    let note = meta.note;
+    let note = safePrint(meta.note);
     if (!reveal && note.length > 80) {
       note = note.slice(0, 79) + '\u2026';
     }
@@ -420,7 +432,7 @@ export function registerSecretsCommands(program: Command): void {
         const bundle = readBundle(resolvedName);
         const entries = describeBundle(bundle);
         console.log(chalk.bold(bundle.name));
-        if (bundle.description) console.log(chalk.gray(bundle.description));
+        if (bundle.description) console.log(chalk.gray(safePrint(bundle.description)));
         if (bundle.allow_exec) console.log(chalk.yellow('allow_exec: true'));
         if (bundle.created_at) console.log(chalk.gray(`created_at: ${bundle.created_at} (${humanAge(bundle.created_at)})`));
         if (bundle.updated_at) console.log(chalk.gray(`updated_at: ${bundle.updated_at} (${humanAge(bundle.updated_at)})`));
@@ -715,7 +727,8 @@ Examples:
     .command('remove [bundle] [key]')
     .description('Remove a key from the bundle. Purges the keychain item if the ref was keychain:. Use --keep-secret to retain it.')
     .option('--keep-secret', 'Leave the keychain item in place after removing the ref from the bundle')
-    .action(async (bundleName: string | undefined, key: string | undefined, opts: { keepSecret?: boolean }) => {
+    .option('-y, --yes', 'Skip the confirmation prompt when purging a keychain item')
+    .action(async (bundleName: string | undefined, key: string | undefined, opts: { keepSecret?: boolean; yes?: boolean }) => {
       try {
         const resolvedBundleName = bundleName ?? (await pickBundleName('remove from'));
         const bundle = readBundle(resolvedBundleName);
@@ -725,9 +738,28 @@ Examples:
           process.exit(1);
         }
         const raw = bundle.vars[resolvedKey];
+        const willPurge = !opts.keepSecret && typeof raw === 'string' && raw.startsWith('keychain:');
+        if (willPurge && !opts.yes) {
+          if (!isInteractiveTerminal()) {
+            console.error(chalk.red(
+              `Refusing to purge keychain item for ${resolvedBundleName}.${resolvedKey} non-interactively. ` +
+              `Pass --yes to confirm or --keep-secret to retain the keychain entry.`,
+            ));
+            process.exit(1);
+          }
+          const { confirm } = await import('@inquirer/prompts');
+          const ok = await confirm({
+            message: `Purge keychain item for ${resolvedBundleName}.${resolvedKey}? (use --keep-secret to retain)`,
+            default: false,
+          });
+          if (!ok) {
+            console.log(chalk.gray('Aborted. Bundle metadata unchanged.'));
+            return;
+          }
+        }
         delete bundle.vars[resolvedKey];
         writeBundle(bundle);
-        if (!opts.keepSecret && typeof raw === 'string' && raw.startsWith('keychain:')) {
+        if (willPurge) {
           const item = secretsKeychainItem(resolvedBundleName, raw.slice('keychain:'.length));
           const removed = deleteKeychainToken(item);
           if (removed) {

--- a/src/lib/secrets/__tests__/bundles.test.ts
+++ b/src/lib/secrets/__tests__/bundles.test.ts
@@ -127,8 +127,12 @@ describe('describeBundle + resolveBundleEnv', () => {
 
   it('resolveBundleEnv inlines literals and resolves env: refs', () => {
     process.env.__AGENTS_RESOLVE_TEST = 'resolved-value';
-    const bundle = b({ STATIC: 'x', DYN: 'env:__AGENTS_RESOLVE_TEST' });
-    expect(resolveBundleEnv(bundle)).toEqual({ STATIC: 'x', DYN: 'resolved-value' });
+    try {
+      const bundle = b({ STATIC: 'x', DYN: 'env:__AGENTS_RESOLVE_TEST' });
+      expect(resolveBundleEnv(bundle)).toEqual({ STATIC: 'x', DYN: 'resolved-value' });
+    } finally {
+      delete process.env.__AGENTS_RESOLVE_TEST;
+    }
   });
 
   it('keychainItemsForBundle enumerates keychain-backed keys only', () => {

--- a/src/lib/secrets/__tests__/secrets.test.ts
+++ b/src/lib/secrets/__tests__/secrets.test.ts
@@ -70,8 +70,12 @@ describe('keychain item namespacing', () => {
 describe('resolveRef providers', () => {
   it('resolves env: from process.env', () => {
     process.env.__AGENTS_TEST_ENV_VAR = 'hello-from-parent';
-    const value = resolveRef({ provider: 'env', value: '__AGENTS_TEST_ENV_VAR' });
-    expect(value).toBe('hello-from-parent');
+    try {
+      const value = resolveRef({ provider: 'env', value: '__AGENTS_TEST_ENV_VAR' });
+      expect(value).toBe('hello-from-parent');
+    } finally {
+      delete process.env.__AGENTS_TEST_ENV_VAR;
+    }
   });
 
   it('env: throws when the parent var is unset', () => {
@@ -83,9 +87,13 @@ describe('resolveRef providers', () => {
 
   it('env: enforces the allowlist when one is set', () => {
     process.env.__AGENTS_TEST_BLOCKED = 'leaky';
-    expect(() =>
-      resolveRef({ provider: 'env', value: '__AGENTS_TEST_BLOCKED' }, { envAllowlist: ['SOMETHING_ELSE'] })
-    ).toThrow(/not in allowlist/);
+    try {
+      expect(() =>
+        resolveRef({ provider: 'env', value: '__AGENTS_TEST_BLOCKED' }, { envAllowlist: ['SOMETHING_ELSE'] })
+      ).toThrow(/not in allowlist/);
+    } finally {
+      delete process.env.__AGENTS_TEST_BLOCKED;
+    }
   });
 
   it('file: reads and trims the target', () => {


### PR DESCRIPTION
## Summary

Follow-on to #135. Five small cleanups from the audit Low list + the reframed High #1 doc note.

## What's in this PR

| Audit # | Severity | Change |
|---|---|---|
| #12 | LOW | `secrets remove` now prompts (TTY) or refuses (non-TTY) before purging a keychain item. `-y / --yes` skips the prompt; `--keep-secret` retains the keychain entry. Metadata-only removals stay unprompted (reversible). |
| #13 | LOW | New `safePrint()` strips C0/C1 control bytes from bundle descriptions, notes, and server-supplied remote-list names before terminal output. Closes ANSI-injection by a malicious bundle author or compromised `api.prix.dev` response. |
| #16 | LOW | `AGENTS_SECRETS_PASSPHRASE` now triggers a once-per-process stderr warning about same-user env visibility (`/proc`, `ps`, crash dumps, CI logs) with a "rotate after CI use" nudge. |
| #17 | LOW | Three `__AGENTS_*` test env vars are now cleaned up in `finally` blocks instead of leaking into sibling tests. |
| #1 reframe | DOC | `docs/secrets.md` gets a **Security model** section explicitly stating the Keychain ACL is user-presence (Touch ID OR passcode), not code-identity. Same-user binaries can read any bundle by popping Touch ID with the right service name. |

## Test plan

- [x] `bun run test src/lib/secrets/ src/lib/session/` — 16 files, 228 tests pass
- [x] End-to-end:
  - `node dist/index.js secrets remove --help` shows `-y, --yes`
  - `AGENTS_SECRETS_PASSPHRASE=abcdefghijkl agents secrets pull` emits the stderr warning
  - `safePrint('hello\x1b[2J\x07world')` → `'hello[2Jworld'` (ESC + BEL stripped)

## Deliberately deferred

- `#8` (list returns service names without auth) — pending design call: require Touch ID on every `list` vs hash-the-names migration.
- `#10` (sync ETag/If-Match) — server-side, will be filed against `prix-api`.
- `#15` (pull restore non-atomic) — needs careful stage-then-commit refactor.