### PR TITLE
feat(view+teams): show profiles as first-class targets

### DIFF
--- a/src/commands/teams.ts
+++ b/src/commands/teams.ts
@@ -52,6 +52,7 @@ import { parseExecEnv } from '../lib/exec.js';
 import { teamPicker, printTeamTable, type TeamRow } from './teams-picker.js';
 import { itemPicker } from '../lib/picker.js';
 import type { AgentProcess } from '../lib/teams/agents.js';
+import { profileExists, readProfile } from '../lib/profiles.js';
 import {
   isPromptCancelled,
   isInteractiveTerminal,
@@ -139,16 +140,56 @@ function fullName(type: AgentType, version: string | null | undefined): string {
   return version ? `${name} ${version}` : name;
 }
 
-function parseTeammate(spec: string): { agent: AgentType; version: string | null } {
+/**
+ * Resolve a teammate spec to its execution target.
+ *
+ * Accepts:
+ *  - `claude`            — default version of an installed agent
+ *  - `claude@2.1.112`    — pinned version of an installed agent
+ *  - `<profile-name>`    — runs through `agents run <profile>`, with the
+ *                          profile's host agent used as the underlying
+ *                          AgentType for event parsing and CLI checks.
+ *
+ * `agent` is always the underlying harness so event parsers, CLI-availability
+ * checks, and version pins keep working. `profileName` is set only when the
+ * spec resolved through a profile.
+ */
+function parseTeammate(spec: string): {
+  agent: AgentType;
+  version: string | null;
+  profileName: string | null;
+} {
   const [name, version] = spec.split('@');
-  if (!VALID_AGENTS.includes(name as AgentType)) {
-    die(
-      `Unknown teammate '${name}'. Available: ${VALID_AGENTS.join(', ')}.\n` +
-        `  Use the form 'claude' or 'claude@2.1.112' (see 'agents view' for installed versions).`
-    );
+
+  if (VALID_AGENTS.includes(name as AgentType)) {
+    const agent = name as AgentType;
+    return {
+      agent,
+      version: resolveVersionAlias(agent as AgentId, version) ?? null,
+      profileName: null,
+    };
   }
-  const agent = name as AgentType;
-  return { agent, version: resolveVersionAlias(agent as AgentId, version) ?? null };
+
+  // Not a built-in agent id — try resolving as a profile name. A profile
+  // pinning a version is allowed; `profile@<override>` is not (would conflict
+  // with the profile's own host.version).
+  if (!version && profileExists(name)) {
+    try {
+      const profile = readProfile(name);
+      return {
+        agent: profile.host.agent as AgentType,
+        version: profile.host.version ?? null,
+        profileName: profile.name,
+      };
+    } catch (err) {
+      die(`Profile '${name}' is malformed: ${(err as Error).message}`);
+    }
+  }
+
+  die(
+    `Unknown teammate '${spec}'. Available agents: ${VALID_AGENTS.join(', ')}.\n` +
+      `  Use 'claude', 'claude@2.1.112', or the name of a profile from 'agents view'.`
+  );
 }
 
 function shortId(id: string): string {
@@ -638,6 +679,8 @@ export function registerTeamsCommands(program: Command): void {
       Teammate syntax:
         'claude'           the default Claude version on this machine
         'claude@2.1.112'   a specific installed version (see 'agents view')
+        '<profile>'        a profile from 'agents view' — runs through 'agents
+                           run <profile>' with the profile's host harness
 
       Short aliases:
         teams c  = create    teams a  = add       teams s  = status
@@ -861,7 +904,7 @@ export function registerTeamsCommands(program: Command): void {
         }
       }
 
-      const { agent, version } = parseTeammate(teammate);
+      const { agent, version, profileName } = parseTeammate(teammate);
       if (version && !isVersionInstalled(agent, version)) {
         die(
           `${AGENT_NAMES[agent]} ${version} isn't installed.\n` +
@@ -1015,14 +1058,15 @@ export function registerTeamsCommands(program: Command): void {
           opts.repo ?? null,
           opts.branch ?? null,
           worktreeName,
-          worktreePath
+          worktreePath,
+          profileName,
         );
 
         if (isJsonMode(opts)) {
           console.log(JSON.stringify(result, null, 2));
           return;
         }
-        const who = fullName(agent, version);
+        const who = profileName ? `${profileName} (via ${fullName(agent, version)})` : fullName(agent, version);
         const staged = result.status === 'pending';
         const verb = staged ? 'Staged' : 'Welcomed';
         const greeting = result.name

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -67,8 +67,32 @@ import { isGitRepo, getGitSyncStatus } from '../lib/git.js';
 import { getCentralRulesFileName } from '../lib/rules/rules.js';
 import { composeRulesFromState, type ComposedSubrule } from '../lib/rules/compose.js';
 import { getConfiguredRunStrategy } from '../lib/rotate.js';
+import { listProfiles, profileSummary, type ProfileSummary } from '../lib/profiles.js';
 import { confirm } from '@inquirer/prompts';
 import { formatPath, isInteractiveTerminal, isPromptCancelled } from './utils.js';
+
+/**
+ * Group profile summaries by their host harness, optionally filtered to a
+ * single agent. Profile YAMLs that fail validation are silently skipped by
+ * `listProfiles` so this never throws on a malformed file.
+ */
+function getProfilesByAgent(filterAgentId?: AgentId): Map<AgentId, ProfileSummary[]> {
+  const byAgent = new Map<AgentId, ProfileSummary[]>();
+  for (const profile of listProfiles()) {
+    if (filterAgentId && profile.host.agent !== filterAgentId) continue;
+    const summary = profileSummary(profile);
+    const existing = byAgent.get(profile.host.agent);
+    if (existing) existing.push(summary);
+    else byAgent.set(profile.host.agent, [summary]);
+  }
+  return byAgent;
+}
+
+/** Build the usage-column equivalent for a profile row: "profile  <model>". */
+function profileKindAndModel(model: string, planWidth: number): string {
+  const kind = 'profile'.padEnd(Math.max(planWidth, 'profile'.length));
+  return `${kind}  ${model}`;
+}
 
 function termLink(text: string, filePath: string): string {
   const url = `file://${filePath}`;
@@ -159,6 +183,8 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
 
   const agentsToShow = filterAgentId ? [filterAgentId] : ALL_AGENT_IDS;
   const showPaths = !!filterAgentId;
+  const profilesByAgent = getProfilesByAgent(filterAgentId);
+  const profileSummaries = [...profilesByAgent.values()].flat();
 
   // Auto-heal stale versioned aliases. Pre-v2 aliases (e.g. pre-CLAUDE_CONFIG_DIR
   // claude shims) silently route login through the default version's symlinked
@@ -256,15 +282,19 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
   // Separate version-managed from globally-installed agents
   const versionManaged: AgentId[] = [];
   const globallyInstalled: AgentId[] = [];
+  const profileOnly: AgentId[] = [];
 
   for (const agentId of agentsToShow) {
     const versions = listInstalledVersions(agentId);
     const cliState = cliStates[agentId];
+    const hasProfiles = (profilesByAgent.get(agentId)?.length ?? 0) > 0;
 
     if (versions.length > 0) {
       versionManaged.push(agentId);
     } else if (cliState?.installed) {
       globallyInstalled.push(agentId);
+    } else if (hasProfiles) {
+      profileOnly.push(agentId);
     }
   }
 
@@ -287,6 +317,12 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
         if (info?.email) maxEmail = Math.max(maxEmail, info.email.length);
         if (info?.plan) maxPlanWidth = Math.max(maxPlanWidth, info.plan.length);
       }
+      // Profile rows share these columns with version rows so they line up.
+      for (const profile of profilesByAgent.get(agentId) ?? []) {
+        maxVerLabel = Math.max(maxVerLabel, profile.name.length);
+        maxEmail = Math.max(maxEmail, profile.auth.length);
+        maxPlanWidth = Math.max(maxPlanWidth, 'profile'.length);
+      }
     }
     // Second pass: compute max visible usage + status widths (now that maxPlanWidth is settled)
     for (const agentId of versionManaged) {
@@ -300,6 +336,10 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
         maxUsageWidth = Math.max(maxUsageWidth, visibleWidth(usageStr));
         const statusStr = formatUsageStatusBadge(info?.usageStatus);
         maxStatusWidth = Math.max(maxStatusWidth, visibleWidth(statusStr));
+      }
+      for (const profile of profilesByAgent.get(agentId) ?? []) {
+        const usageEquivalent = profileKindAndModel(profile.model, maxPlanWidth);
+        maxUsageWidth = Math.max(maxUsageWidth, visibleWidth(usageEquivalent));
       }
     }
 
@@ -367,6 +407,19 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
         }
       }
 
+      // Profile rows share the same columns as versions: name | auth | "profile"+model.
+      // No status badge, no last-active — profiles don't accumulate usage state.
+      for (const profile of profilesByAgent.get(agentId) ?? []) {
+        const nameCol = chalk.cyan(profile.name.padEnd(maxVerLabel));
+        const authCol = chalk.gray(profile.auth.padEnd(maxEmail));
+        const usageEquivalent = profileKindAndModel(profile.model, maxPlanWidth);
+        const usagePad = ' '.repeat(Math.max(0, maxUsageWidth - visibleWidth(usageEquivalent)));
+        console.log(`    ${nameCol}  ${authCol}  ${chalk.gray(usageEquivalent + usagePad)}`);
+        if (showPaths) {
+          console.log(chalk.gray(`      ${profile.path}`));
+        }
+      }
+
       // Check for project override
       const projectVersion = getProjectVersionFromCwd(agentId);
       if (projectVersion && projectVersion !== globalDefault) {
@@ -428,6 +481,25 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
       if (showPaths && cliState?.path) {
         console.log(chalk.gray(`      ${cliState.path}`));
       }
+      // Profile rows under a globally-installed harness. Use a simpler
+      // alignment here since this section doesn't share column state with
+      // the version-managed block.
+      const profilesHere = profilesByAgent.get(agentId) ?? [];
+      if (profilesHere.length > 0) {
+        const nameWidth = Math.max(globalMaxVerLabel, ...profilesHere.map((p) => p.name.length));
+        const authWidth = Math.max(...profilesHere.map((p) => p.auth.length));
+        for (const profile of profilesHere) {
+          console.log(
+            `    ${chalk.cyan(profile.name.padEnd(nameWidth))}  ` +
+              `${chalk.gray(profile.auth.padEnd(authWidth))}  ` +
+              `${chalk.gray('profile')}  ` +
+              chalk.gray(profile.model),
+          );
+          if (showPaths) {
+            console.log(chalk.gray(`      ${profile.path}`));
+          }
+        }
+      }
       if (agent.npmPackage && cliState?.version) {
         console.log(chalk.gray(`    Manage: agents add ${agentId}@${cliState.version} -y`));
       }
@@ -435,14 +507,51 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
     }
   }
 
+  // Agents with no install but with profiles defined — render under the same
+  // harness header so users find them where they look.
+  if (profileOnly.length > 0) {
+    if (versionManaged.length === 0 && globallyInstalled.length === 0) {
+      console.log(chalk.bold('Profile-only Agents\n'));
+    }
+    for (const agentId of profileOnly) {
+      const profilesHere = profilesByAgent.get(agentId) ?? [];
+      console.log(`  ${chalk.bold(agentLabel(agentId))}${chalk.yellow(' (profile only)')}`);
+      const nameWidth = Math.max(...profilesHere.map((p) => p.name.length));
+      const authWidth = Math.max(...profilesHere.map((p) => p.auth.length));
+      for (const profile of profilesHere) {
+        console.log(
+          `    ${chalk.cyan(profile.name.padEnd(nameWidth))}  ` +
+            `${chalk.gray(profile.auth.padEnd(authWidth))}  ` +
+            `${chalk.gray('profile')}  ` +
+            chalk.gray(profile.model),
+        );
+        if (showPaths) {
+          console.log(chalk.gray(`      ${profile.path}`));
+        }
+      }
+      console.log();
+    }
+  }
+
   // If filtering to a specific agent and not found
-  if (filterAgentId && versionManaged.length === 0 && globallyInstalled.length === 0) {
+  if (
+    filterAgentId &&
+    versionManaged.length === 0 &&
+    globallyInstalled.length === 0 &&
+    profileOnly.length === 0
+  ) {
     console.log(`  ${chalk.bold(agentLabel(filterAgentId))}: ${chalk.gray('not installed')}`);
     console.log();
   }
 
   // No agents installed at all
-  if (versionManaged.length === 0 && globallyInstalled.length === 0 && !filterAgentId) {
+  if (
+    versionManaged.length === 0 &&
+    globallyInstalled.length === 0 &&
+    profileOnly.length === 0 &&
+    profileSummaries.length === 0 &&
+    !filterAgentId
+  ) {
     console.log(chalk.gray('  No agent CLIs installed.'));
     console.log(chalk.gray('  Run: agents add claude@latest'));
     console.log();
@@ -847,6 +956,7 @@ export interface ViewJsonVersion {
 export interface ViewJsonAgent {
   agent: AgentId;
   versions: ViewJsonVersion[];
+  profiles: ProfileSummary[];
 }
 
 /**
@@ -923,6 +1033,7 @@ async function collectAgentsJson(filterAgentId?: AgentId): Promise<ViewJsonAgent
     else byAgent.set(agentId, [entry]);
   }
 
+  const profilesByAgent = getProfilesByAgent(filterAgentId);
   const out: ViewJsonAgent[] = [];
   for (const agentId of agentsToShow) {
     const versions = byAgent.get(agentId) ?? [];
@@ -930,7 +1041,7 @@ async function collectAgentsJson(filterAgentId?: AgentId): Promise<ViewJsonAgent
       if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
       return compareVersions(b.version, a.version);
     });
-    out.push({ agent: agentId, versions });
+    out.push({ agent: agentId, versions, profiles: profilesByAgent.get(agentId) ?? [] });
   }
   return out;
 }
@@ -1223,7 +1334,7 @@ export async function viewAction(
     // --json ignores the @version suffix (detailed resource view is not yet
     // exposed as structured data). Emit the version list for the agent.
     const data = await collectAgentsJson(agentId);
-    console.log(JSON.stringify(data[0] ?? { agent: agentId, versions: [] }, null, 2));
+    console.log(JSON.stringify(data[0] ?? { agent: agentId, versions: [], profiles: [] }, null, 2));
     return;
   }
 

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -11,7 +11,7 @@ import * as path from 'path';
 import * as yaml from 'yaml';
 import type { AgentId } from './types.js';
 import { getUserAgentsDir } from './state.js';
-import { getKeychainToken, keychainItemName } from './secrets/profiles.js';
+import { getKeychainToken, hasKeychainToken, keychainItemName } from './secrets/profiles.js';
 import { getPreset, type Preset } from './profiles-presets.js';
 
 /** A named profile binding an agent host, env vars, and optional keychain auth. */
@@ -31,6 +31,21 @@ export interface Profile {
   provider?: string;
 }
 
+/**
+ * Stable, machine-readable summary used by `agents view` and `--json`.
+ * `agent` is the underlying harness (claude/codex/...) so consumers can
+ * group profiles under installed agents without reparsing host strings.
+ */
+export interface ProfileSummary {
+  name: string;
+  agent: AgentId;
+  host: string;
+  provider: string;
+  model: string;
+  auth: string;
+  path: string;
+}
+
 const PROFILE_NAME_PATTERN = /^[a-z0-9][a-z0-9-_]{0,48}$/i;
 
 /** Get the directory where profile YAML files are stored. */
@@ -40,6 +55,12 @@ export function getProfilesDir(): string {
 
 function profilePath(name: string): string {
   return path.join(getProfilesDir(), `${name}.yml`);
+}
+
+/** Return the on-disk YAML path for a profile name. */
+export function getProfilePath(name: string): string {
+  validateProfileName(name);
+  return profilePath(name);
 }
 
 /** Validate a profile name against the allowed pattern. Throws on invalid input. */
@@ -112,6 +133,116 @@ export function listProfiles(): Profile[] {
     }
   }
   return profiles.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Format the host harness and optional pinned version for display. */
+export function profileHostLabel(profile: Profile): string {
+  return profile.host.version ? `${profile.host.agent}@${profile.host.version}` : profile.host.agent;
+}
+
+/** Return the configured provider name, deriving it from the shared keychain item when needed. */
+export function profileProviderLabel(profile: Profile): string {
+  return profile.provider || profile.auth?.keychainItem?.split('.')[1] || '-';
+}
+
+const MODEL_ENV_KEYS = [
+  'ANTHROPIC_MODEL',
+  'ANTHROPIC_SMALL_FAST_MODEL',
+  'OPENAI_MODEL',
+  'GEMINI_MODEL',
+  'GROK_MODEL',
+] as const;
+
+/** Return the configured model env value for display. */
+export function profileModelLabel(profile: Profile): string {
+  for (const key of MODEL_ENV_KEYS) {
+    const value = profile.env[key];
+    if (value) return value;
+  }
+  for (const [key, value] of Object.entries(profile.env)) {
+    if ((key === 'MODEL' || key.endsWith('_MODEL')) && value) return value;
+  }
+  return '-';
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const parts = token.split('.');
+  if (parts.length < 2) return null;
+  try {
+    const normalized = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+    const decoded = Buffer.from(padded, 'base64').toString('utf-8');
+    const parsed = JSON.parse(decoded);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function maskToken(token: string): string {
+  if (token.length <= 12) return `${token.slice(0, 3)}...${token.slice(-2)}`;
+  return `${token.slice(0, 6)}...${token.slice(-4)}`;
+}
+
+const INLINE_AUTH_KEYS = [
+  'ANTHROPIC_AUTH_TOKEN',
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY',
+  'GOOGLE_API_KEY',
+  'XAI_API_KEY',
+] as const;
+
+function inlineAuthToken(profile: Profile): string | undefined {
+  if (profile.auth?.envVar && profile.env[profile.auth.envVar]) {
+    return profile.env[profile.auth.envVar];
+  }
+  for (const key of INLINE_AUTH_KEYS) {
+    const value = profile.env[key];
+    if (value) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Build a non-secret auth identity/status label for list surfaces.
+ *
+ * - Inline JWT in env: decode locally and show email / preferred_username / sub.
+ * - Inline opaque token in env: masked prefix/suffix (user explicitly stored it
+ *   in the YAML, so they accept the leak in their own output).
+ * - Keychain-backed auth: provider + "stored" or "missing" (non-prompting).
+ * - No auth at all: provider only.
+ */
+export function profileAuthLabel(profile: Profile): string {
+  const provider = profileProviderLabel(profile);
+  const token = inlineAuthToken(profile);
+  if (token) {
+    const payload = decodeJwtPayload(token);
+    const identity =
+      payload?.email ||
+      payload?.preferred_username ||
+      payload?.username ||
+      payload?.sub;
+    if (typeof identity === 'string') return `${provider} ${identity}`;
+    return `${provider} ${maskToken(token)}`;
+  }
+  if (profile.auth) {
+    return `${provider} ${hasKeychainToken(profile.auth.keychainItem) ? 'stored' : 'missing'}`;
+  }
+  return provider;
+}
+
+/** Build a stable, machine-readable summary for list and view surfaces. */
+export function profileSummary(profile: Profile): ProfileSummary {
+  return {
+    name: profile.name,
+    agent: profile.host.agent,
+    host: profileHostLabel(profile),
+    provider: profileProviderLabel(profile),
+    model: profileModelLabel(profile),
+    auth: profileAuthLabel(profile),
+    path: getProfilePath(profile.name),
+  };
 }
 
 /**

--- a/src/lib/teams/agents.ts
+++ b/src/lib/teams/agents.ts
@@ -402,6 +402,11 @@ export class AgentProcess {
   // Pinned model for this teammate. When null, the agent's CLI picks its
   // own default (no --model forwarded).
   model: string | null = null;
+  // Profile target name when the teammate was added via `agents teams add
+  // <team> <profile>`. The launcher targets the profile name so env/keychain
+  // injection happens; agentType stays the underlying harness so event
+  // parsers and CLI availability checks keep working.
+  profileName: string | null = null;
   // Extra env vars passed through to the child process (from --env KEY=VALUE).
   envOverrides: Record<string, string> | null = null;
   // Factory task-type label. Drives planner fan-out. Null for plain teammates — no behavioral change.
@@ -446,7 +451,8 @@ export class AgentProcess {
     cloudRepo: string | null = null,
     cloudBranch: string | null = null,
     worktreeName: string | null = null,
-    worktreePath: string | null = null
+    worktreePath: string | null = null,
+    profileName: string | null = null,
   ) {
     this.agentId = agentId;
     this.remoteSessionId = remoteSessionId;
@@ -454,6 +460,7 @@ export class AgentProcess {
     this.after = after;
     this.effort = effort;
     this.model = model;
+    this.profileName = profileName;
     this.envOverrides = envOverrides;
     this.taskType = taskType;
     this.cloudRepo = cloudRepo;
@@ -559,6 +566,7 @@ export class AgentProcess {
       after: this.after,
       effort: this.effort,
       model: this.model,
+      profile_name: this.profileName,
       env_overrides: this.envOverrides,
       task_type: this.taskType,
       cloud_repo: this.cloudRepo,
@@ -694,6 +702,7 @@ export class AgentProcess {
       after: this.after,
       effort: this.effort,
       model: this.model,
+      profile_name: this.profileName,
       env_overrides: this.envOverrides,
       task_type: this.taskType,
       cloud_repo: this.cloudRepo,
@@ -772,7 +781,8 @@ export class AgentProcess {
         meta.cloud_repo || null,
         meta.cloud_branch || null,
         meta.worktree_name || null,
-        meta.worktree_path || null
+        meta.worktree_path || null,
+        meta.profile_name || null,
       );
       agent.startTime = typeof meta.start_time === 'string' ? meta.start_time : null;
       return agent;
@@ -1071,7 +1081,8 @@ export class AgentManager {
     cloudRepo: string | null = null,
     cloudBranch: string | null = null,
     worktreeName: string | null = null,
-    worktreePath: string | null = null
+    worktreePath: string | null = null,
+    profileName: string | null = null,
   ): Promise<AgentProcess> {
     await this.initialize();
     const resolvedMode = resolveMode(mode, this.defaultMode);
@@ -1131,6 +1142,9 @@ export class AgentManager {
     // dispatched via the cloud provider and passed us the provider + session.
     const isCloudBacked = Boolean(cloudProvider);
     if (!isCloudBacked) {
+      // Profile-backed teammates still spawn through `agents run`, which
+      // resolves the profile to its host harness — so the CLI we need to be
+      // present is the underlying agentType, not the profile name.
       const [available, pathOrError] = checkCliAvailable(agentType);
       if (!available) {
         throw new Error(pathOrError || 'CLI tool not available');
@@ -1174,7 +1188,8 @@ export class AgentManager {
       cloudRepo,
       cloudBranch,
       worktreeName,
-      worktreePath
+      worktreePath,
+      profileName,
     );
 
     const agentDir = await agent.getAgentDir();
@@ -1223,6 +1238,7 @@ export class AgentManager {
       agent.agentId,
       effort,
       agent.version,
+      agent.profileName,
     );
 
     debug(`Launching ${agent.agentType} agent ${agent.agentId} [${agent.mode}]: ${cmd.slice(0, 3).join(' ')}...`);
@@ -1324,6 +1340,7 @@ export class AgentManager {
     sessionId: string | null = null,
     effort: EffortLevel = 'medium',
     version: string | null = null,
+    profileName: string | null = null,
   ): string[] {
     // Compose the prompt: a plan-mode prefix for Claude (clarifying headless
     // plan-mode restrictions) and a universal summary suffix. These are
@@ -1333,7 +1350,10 @@ export class AgentManager {
       fullPrompt = CLAUDE_PLAN_MODE_PREFIX + fullPrompt;
     }
 
-    const target = version ? `${agentType}@${version}` : agentType;
+    // Profile target takes precedence — `agents run <profile>` resolves the
+    // host harness, version pin, and env injection in one place. Plain
+    // version pins only apply when no profile is selected.
+    const target = profileName ?? (version ? `${agentType}@${version}` : agentType);
     const agentsCli = process.argv[1];
 
     const cmd: string[] = [

--- a/src/lib/teams/api.ts
+++ b/src/lib/teams/api.ts
@@ -76,6 +76,7 @@ export interface SpawnResult {
   status: string;
   started_at: string;
   version?: string | null;
+  profile_name?: string | null;
   remote_session_id?: string | null;
   name?: string | null;
   after?: string[];
@@ -172,14 +173,15 @@ export async function handleSpawn(
   cloudRepo: string | null = null,
   cloudBranch: string | null = null,
   worktreeName: string | null = null,
-  worktreePath: string | null = null
+  worktreePath: string | null = null,
+  profileName: string | null = null,
 ): Promise<SpawnResult> {
   const defaultMode = manager.getDefaultMode();
   const resolvedMode = resolveMode(mode, defaultMode);
   const resolvedEffort = effort ?? 'medium';
 
   debug(
-    `[spawn] Spawning ${agentType} agent for task "${taskName}" [${resolvedMode}] effort=${resolvedEffort}...`
+    `[spawn] Spawning ${agentType} agent for task "${taskName}" [${resolvedMode}] effort=${resolvedEffort}${profileName ? ` profile=${profileName}` : ''}...`
   );
 
   const agent = await manager.spawn(
@@ -202,7 +204,8 @@ export async function handleSpawn(
     cloudRepo,
     cloudBranch,
     worktreeName,
-    worktreePath
+    worktreePath,
+    profileName,
   );
 
   debug(`[spawn] Spawned ${agentType} agent ${agent.agentId} for task "${taskName}"`);
@@ -214,6 +217,7 @@ export async function handleSpawn(
     status: agent.status,
     started_at: agent.startedAt.toISOString(),
     version: agent.version,
+    profile_name: agent.profileName,
     remote_session_id: agent.remoteSessionId,
     name: agent.name,
     after: agent.after,

--- a/tests/non-interactive.test.ts
+++ b/tests/non-interactive.test.ts
@@ -159,6 +159,35 @@ function readSessionFilePath(home: string, id: string): string | null {
   return output.length > 0 ? output : null;
 }
 
+function writeProfileYaml(
+  home: string,
+  name: string,
+  body: {
+    agent: string;
+    version?: string;
+    env?: Record<string, string>;
+    provider?: string;
+    description?: string;
+  },
+): void {
+  const dir = path.join(home, '.agents', 'profiles');
+  fs.mkdirSync(dir, { recursive: true });
+  const env = body.env ?? {};
+  const lines: string[] = [
+    `name: ${name}`,
+    'host:',
+    `  agent: ${body.agent}`,
+  ];
+  if (body.version) lines.push(`  version: ${body.version}`);
+  if (body.provider) lines.push(`provider: ${body.provider}`);
+  if (body.description) lines.push(`description: "${body.description}"`);
+  lines.push('env:');
+  for (const [k, v] of Object.entries(env)) {
+    lines.push(`  ${k}: "${v}"`);
+  }
+  fs.writeFileSync(path.join(dir, `${name}.yml`), lines.join('\n') + '\n');
+}
+
 function seedNewerUpdateCache(home: string, futureVersion: string): void {
   const cacheDir = path.join(home, '.agents', '.cache');
   fs.mkdirSync(cacheDir, { recursive: true });
@@ -536,4 +565,87 @@ describe('non-interactive CLI usage', () => {
     expect(combined).toContain(`Update available: ${PACKAGE_VERSION.version} -> 99.0.0`);
     expect(combined).not.toContain('Upgrade now');
   });
+
+  it('renders profile rows inline under their host harness in `agents view`', () => {
+    const home = makeTempHome();
+    tempHomes.push(home);
+    writeFakeManagedVersion(home, 'claude', '2.1.143', 'claude');
+    writeFakeManagedVersion(home, 'codex', '0.134.0', 'codex');
+    writeProfileYaml(home, 'yosemite', {
+      agent: 'claude',
+      provider: 'truefoundry',
+      env: { ANTHROPIC_MODEL: 'truefoundry/qwen3-coder' },
+    });
+    writeProfileYaml(home, 'ollama', {
+      agent: 'codex',
+      provider: 'ollama',
+      env: { OPENAI_MODEL: 'qwen3-coder:30b' },
+    });
+
+    const result = runAgents(home, ['view'], { AGENTS_CLI_DISABLE_AUTO_UPDATE: '1' });
+    const combined = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.status, combined).toBe(0);
+    // No separate "Profiles" section header — rows live under the harness.
+    expect(combined).not.toMatch(/^Profiles\s*$/m);
+    // Each profile row carries its name, the `profile` kind marker, and model.
+    expect(combined).toContain('yosemite');
+    expect(combined).toContain('truefoundry/qwen3-coder');
+    expect(combined).toContain('ollama');
+    expect(combined).toContain('qwen3-coder:30b');
+    expect(combined).toContain('profile');
+  }, 30_000);
+
+  it('filters profiles to the requested harness in `agents view claude`', () => {
+    const home = makeTempHome();
+    tempHomes.push(home);
+    writeFakeManagedVersion(home, 'claude', '2.1.143', 'claude');
+    writeFakeManagedVersion(home, 'codex', '0.134.0', 'codex');
+    writeProfileYaml(home, 'yosemite', {
+      agent: 'claude',
+      env: { ANTHROPIC_MODEL: 'truefoundry/qwen3-coder' },
+    });
+    writeProfileYaml(home, 'ollama', {
+      agent: 'codex',
+      env: { OPENAI_MODEL: 'qwen3-coder:30b' },
+    });
+
+    const result = runAgents(home, ['view', 'claude'], { AGENTS_CLI_DISABLE_AUTO_UPDATE: '1' });
+    const combined = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.status, combined).toBe(0);
+    expect(combined).toContain('yosemite');
+    expect(combined).not.toContain('ollama');
+  }, 30_000);
+
+  it('includes profile summaries in `agents view <agent> --json`', () => {
+    const home = makeTempHome();
+    tempHomes.push(home);
+    writeFakeManagedVersion(home, 'claude', '2.1.143', 'claude');
+    writeProfileYaml(home, 'yosemite', {
+      agent: 'claude',
+      provider: 'truefoundry',
+      env: { ANTHROPIC_MODEL: 'truefoundry/qwen3-coder' },
+    });
+
+    const result = runAgents(home, ['view', 'claude', '--json'], {
+      AGENTS_CLI_DISABLE_AUTO_UPDATE: '1',
+    });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    // `view <agent> --json` emits a single object, not an array.
+    const claudeEntry = JSON.parse(result.stdout) as {
+      agent: string;
+      profiles: Array<{ name: string; agent: string; model: string; provider: string }>;
+    };
+    expect(claudeEntry.agent).toBe('claude');
+    expect(claudeEntry.profiles).toEqual([
+      expect.objectContaining({
+        name: 'yosemite',
+        agent: 'claude',
+        model: 'truefoundry/qwen3-coder',
+        provider: 'truefoundry',
+      }),
+    ]);
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary

- `agents view` renders profile rows inline under each harness, sharing column alignment with installed versions. The `profile` kind sits where the plan badge does; the model fills the usage slot. No more separate Profiles table.
- The auth column shows a non-secret identity: decoded JWT email/username when present, otherwise `<provider> stored|missing` for keychain-backed profiles, or a masked prefix/suffix for inline tokens.
- `agents teams add <team> <profile>` accepts profile names. The launcher targets `agents run <profile>` so env + keychain injection happens in one place; the underlying agent type stays the host harness so event parsers, CLI checks, and version pins keep working.
- `agents view --json` (and `agents view <agent> --json`) gains a `profiles` array on each agent entry — discoverable target list for the Stormify extension and other consumers.

## Before / after

Before — separate Profiles section, mismatched columns:
\`\`\`
Installed Agent CLIs

  Claude (balanced)
    2.1.143 (default)  muqsitnawaz@icloud.com  Pro  ...
    2.1.142            muqsit@getrush.ai       Pro  ...

Profiles

  NAME      HOST    PROVIDER  MODEL
  yosemite  claude  -         <provider-account>/qwen3-coder
\`\`\`

After — profile rows aligned with version rows under each harness:
\`\`\`
Installed Agent CLIs

  Claude (balanced)
    2.1.143 (default)  muqsitnawaz@icloud.com  Pro      S: ░░░░░ W: ██░░░  out of credits  1m ago
    2.1.142            muqsit@getrush.ai       Pro      S: █░░░░ W: █░░░░  rate-limited    just now
    yosemite           openrouter user@email   profile  truefoundry/qwen3-coder
\`\`\`

## Test plan

- [x] \`bun run test tests/non-interactive.test.ts\` — 18 passed, 0 failed
- [x] \`bun run build\` — clean TypeScript compile
- [x] Manual \`agents view\` and \`agents view claude\` against real profiles on host machine — columns line up, profile rows show under the right harness, auth labels don't leak keychain secrets
- [ ] Manual: \`agents teams add my-team yosemite \"task\"\` once a working profile is on hand

## Session Context

[Session transcript](https://gist.github.com/muqsitnawaz/8eada42f42cc5ddb813a47bd8661b17f)

🤖 Generated with [Claude Code](https://claude.com/claude-code)