### PR TITLE
perf(run): memoize readMeta + stale-while-revalidate Claude usage probe

### DIFF
--- a/src/lib/__tests__/state.test.ts
+++ b/src/lib/__tests__/state.test.ts
@@ -272,4 +272,95 @@ describe('readMeta merges agents.yaml from both repos', () => {
       codex: '2.0.0',
     });
   });
+
+  it('caches parsed agents.yaml across repeated reads (no re-parse when mtime unchanged)', () => {
+    const moduleUrl = pathToFileURL(modulePath).href;
+    fs.writeFileSync(
+      path.join(userDir, 'agents.yaml'),
+      'agents:\n  claude: "1.0.0"\n',
+      'utf-8',
+    );
+
+    // Spawn a single process that reads readMeta three times back-to-back AND counts how
+    // many readFileSync calls hit agents.yaml. If the cache works, only the FIRST call
+    // should read the file; subsequent calls should be served from memory.
+    const output = runStateScriptWithNode(testDir, `
+      import fs from 'fs';
+      import path from 'path';
+      import { syncBuiltinESMExports } from 'module';
+
+      const targetUser = path.join(process.env.HOME, '.agents', 'agents.yaml');
+      const targetSystem = path.join(process.env.HOME, '.agents-system', 'agents.yaml');
+      const originalRead = fs.readFileSync;
+      let reads = 0;
+      fs.readFileSync = (file, opts) => {
+        if (file === targetUser || file === targetSystem) reads++;
+        return originalRead(file, opts);
+      };
+      syncBuiltinESMExports();
+
+      const { readMeta } = await import(${JSON.stringify(moduleUrl)});
+      readMeta();
+      const readsAfterFirst = reads;
+      readMeta();
+      readMeta();
+      console.log(JSON.stringify({ readsAfterFirst, readsTotal: reads }));
+    `);
+    const counts = JSON.parse(output) as { readsAfterFirst: number; readsTotal: number };
+
+    // After the first read, the cache should be primed. The next two reads must add zero
+    // new yaml file reads against either source path.
+    expect(counts.readsTotal).toBe(counts.readsAfterFirst);
+    expect(counts.readsAfterFirst).toBeGreaterThan(0);
+  });
+
+  it('invalidates the cache when writeMeta runs', () => {
+    const moduleUrl = pathToFileURL(modulePath).href;
+    fs.writeFileSync(
+      path.join(userDir, 'agents.yaml'),
+      'agents:\n  claude: "1.0.0"\n',
+      'utf-8',
+    );
+
+    const output = runStateScriptWithNode(testDir, `
+      import { readMeta, writeMeta } from ${JSON.stringify(moduleUrl)};
+      const before = readMeta();
+      writeMeta({ ...before, agents: { ...before.agents, claude: '9.9.9' } });
+      const after = readMeta();
+      console.log(JSON.stringify({ before: before.agents?.claude, after: after.agents?.claude }));
+    `);
+    const result = JSON.parse(output) as { before: string; after: string };
+
+    expect(result.before).toBe('1.0.0');
+    expect(result.after).toBe('9.9.9');
+  });
+
+  it('refreshes the cache when agents.yaml is modified out-of-band', () => {
+    const moduleUrl = pathToFileURL(modulePath).href;
+    fs.writeFileSync(
+      path.join(userDir, 'agents.yaml'),
+      'agents:\n  claude: "1.0.0"\n',
+      'utf-8',
+    );
+
+    const output = runStateScriptWithNode(testDir, `
+      import fs from 'fs';
+      import path from 'path';
+      import { readMeta } from ${JSON.stringify(moduleUrl)};
+
+      const target = path.join(process.env.HOME, '.agents', 'agents.yaml');
+      const before = readMeta();
+
+      // Wait long enough for the mtime to definitely advance (HFS+ mtime is per-second).
+      await new Promise((r) => setTimeout(r, 1100));
+      fs.writeFileSync(target, 'agents:\\n  claude: "2.0.0"\\n', 'utf-8');
+
+      const after = readMeta();
+      console.log(JSON.stringify({ before: before.agents?.claude, after: after.agents?.claude }));
+    `);
+    const result = JSON.parse(output) as { before: string; after: string };
+
+    expect(result.before).toBe('1.0.0');
+    expect(result.after).toBe('2.0.0');
+  });
 });

--- a/src/lib/__tests__/usage.test.ts
+++ b/src/lib/__tests__/usage.test.ts
@@ -1,14 +1,16 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AccountInfo } from '../agents.js';
+import * as state from '../state.js';
 import {
   buildCanonicalUsageContext,
   formatUsageSummary,
   formatUsageStatusBadge,
   getClaudeKeychainService,
+  getUsageInfoForIdentity,
   readClaudeUsageCache,
   isClaudeUsageOrgMatch,
   writeClaudeUsageCache,
@@ -215,6 +217,79 @@ describe('Claude usage cache', () => {
       expect(cached?.windows.map((window) => window.shortLabel)).toEqual(['S', 'W']);
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('SWR: fresh cache (<2 min) is returned with no network call', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-usage-swr-'));
+    const realFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls++;
+      throw new Error('fetch must not be called on fresh cache');
+    }) as typeof globalThis.fetch;
+    vi.spyOn(state, 'getCacheDir').mockReturnValue(tmpDir);
+
+    try {
+      const snapshot: UsageSnapshot = {
+        source: 'live',
+        sourceLabel: 'live account data',
+        capturedAt: new Date(Date.now() - 30_000), // 30 s old — fresh.
+        windows: [
+          { key: 'session', label: 'S', shortLabel: 'S', usedPercent: 10, resetsAt: null, windowMinutes: 300 },
+        ],
+      };
+      writeClaudeUsageCache('claude:org=swr-fresh', snapshot);
+
+      const result = await getUsageInfoForIdentity({
+        agentId: 'claude',
+        info: makeAccountInfo({ usageKey: 'claude:org=swr-fresh' }),
+      });
+
+      expect(result.error).toBeNull();
+      expect(result.snapshot?.windows[0]?.usedPercent).toBe(10);
+      expect(fetchCalls).toBe(0);
+    } finally {
+      globalThis.fetch = realFetch;
+      vi.restoreAllMocks();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('SWR: stale cache (>2 min, <24 h) returns the cached snapshot instantly', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-usage-swr-'));
+    vi.spyOn(state, 'getCacheDir').mockReturnValue(tmpDir);
+
+    try {
+      const snapshot: UsageSnapshot = {
+        source: 'live',
+        sourceLabel: 'live account data',
+        capturedAt: new Date(Date.now() - 5 * 60 * 1000), // 5 min old — stale but within SWR.
+        windows: [
+          { key: 'session', label: 'S', shortLabel: 'S', usedPercent: 42, resetsAt: null, windowMinutes: 300 },
+        ],
+      };
+      writeClaudeUsageCache('claude:org=swr-stale', snapshot);
+
+      const t0 = Date.now();
+      const result = await getUsageInfoForIdentity({
+        agentId: 'claude',
+        info: makeAccountInfo({ usageKey: 'claude:org=swr-stale' }),
+      });
+      const elapsedMs = Date.now() - t0;
+
+      // The foreground must NOT block on any I/O — not network, not the
+      // synchronous `security` CLI call that loadClaudeOauth makes under
+      // the hood. The fix is that triggerBackgroundUsageRefresh defers its
+      // entire body to setImmediate, so the caller returns before any of
+      // that runs. 100 ms is a generous ceiling for the in-process cache
+      // read + serialization.
+      expect(elapsedMs).toBeLessThan(100);
+      expect(result.error).toBeNull();
+      expect(result.snapshot?.windows[0]?.usedPercent).toBe(42);
+    } finally {
+      vi.restoreAllMocks();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -480,6 +480,26 @@ export function createDefaultMeta(): Meta {
 let metaCache: { mtime: number; meta: Meta } | null = null;
 let metaLockDepth = 0;
 
+/** Return mtimeMs for a file path, or 0 if the file is absent or unreadable. */
+function safeMtimeMs(filePath: string): number {
+  try {
+    return fs.statSync(filePath).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+/** Compute the combined cache stamp for the user + system agents.yaml files. */
+function currentMetaStamp(): number {
+  return safeMtimeMs(META_FILE) + safeMtimeMs(SYSTEM_META_FILE) * 1e-3;
+}
+
+/** Memoize a parsed Meta against the current file mtimes. */
+function rememberMeta(meta: Meta): Meta {
+  metaCache = { mtime: currentMetaStamp(), meta };
+  return meta;
+}
+
 function withMetaLock<T>(fn: () => T): T {
   ensureAgentsDir();
   if (metaLockDepth > 0) {
@@ -548,9 +568,30 @@ function migrateSystemMetaToUser(): void {
   }
 }
 
-/** Read and cache ~/.agents/agents.yaml, migrating from legacy locations if needed. */
+/**
+ * Read and cache ~/.agents/agents.yaml, migrating from legacy locations if needed.
+ *
+ * Cache invariants:
+ * - Cache key is the mtime of the user agents.yaml.
+ * - `writeMetaUnlocked` clears the cache; in-process callers always see fresh state.
+ * - If the file is mutated by ANOTHER process while we hold a stale cache, the
+ *   mtime check below catches it on the next read (assuming the mtime advanced).
+ * - The cache stores the merged system+user meta; both files' mtimes contribute.
+ */
 export function readMeta(): Meta {
   ensureAgentsDir();
+
+  // Fast path: serve from cache when both source files are byte-identical to
+  // what we last parsed. Reduces N readMeta calls per CLI invocation to ~2 stat
+  // syscalls plus an in-memory object spread.
+  if (metaCache) {
+    const userMtime = safeMtimeMs(META_FILE);
+    const systemMtime = safeMtimeMs(SYSTEM_META_FILE);
+    const stamp = userMtime + systemMtime * 1e-3;
+    if (stamp === metaCache.mtime) {
+      return metaCache.meta;
+    }
+  }
 
   // NOTE: agents.yaml migration from ~/.agents-system/ to ~/.agents/ is handled
   // exclusively by runMigration() in migrate.ts, called from postinstall and
@@ -582,7 +623,7 @@ export function readMeta(): Meta {
 
       writeMeta(meta);
       try { fs.unlinkSync(oldMetaFile); } catch { /* non-critical */ }
-      return meta;
+      return rememberMeta(meta);
     } catch {
       /* meta.yaml migration failed */
     }
@@ -626,16 +667,16 @@ export function readMeta(): Meta {
 
     if (applyRegistrySeeds(meta)) {
       writeMeta(meta);
-      return meta;
+      return rememberMeta(meta);
     }
-    return meta;
+    return rememberMeta(meta);
   }
 
   const meta = createDefaultMeta();
   if (applyRegistrySeeds(meta)) {
     writeMeta(meta);
   }
-  return meta;
+  return rememberMeta(meta);
 }
 
 /** Serialize and write agents.yaml to the user repo, invalidating the in-memory cache. */

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -248,46 +248,102 @@ export async function getUsageInfoByIdentity(inputs: UsageIdentityInput[]): Prom
   };
 }
 
-const USAGE_CACHE_FRESH_MS = 2 * 60 * 1000; // 2 minutes
+const USAGE_CACHE_FRESH_MS = 2 * 60 * 1000; // 2 minutes — fresh window: don't refresh.
+const USAGE_CACHE_SWR_MS = 24 * 60 * 60 * 1000; // 24 hours — beyond this, block on live fetch.
+
+/** In-process dedup: don't fire concurrent background refreshes for the same identity. */
+const inFlightRefreshes = new Map<string, Promise<void>>();
 
 /**
- * Fetch usage for a single identity, with a 2-minute cache fast path.
- * Falls back to cached data when the live fetch fails.
+ * Fetch usage for a single identity using stale-while-revalidate.
+ *
+ * - Cache fresh (< 2 min): return cached snapshot, NO network.
+ * - Cache stale but < 24h: return cached snapshot instantly, fire background refresh.
+ * - Cache too stale or absent: block on live fetch, fall back to cache on error.
+ *
+ * This keeps `agents run` startup off the network on the hot path. The first
+ * invocation after a cold install or 24h gap still blocks once to seed the
+ * cache; every run after that returns instantly while the cache silently
+ * refreshes in the background.
  */
 export async function getUsageInfoForIdentity(input: UsageIdentityInput): Promise<UsageInfo> {
   const usageKey = getUsageLookupKey(input.info);
 
-  // Fast path: serve from cache if fresh. Skips the network call entirely.
-  if (input.agentId === 'claude' && usageKey) {
-    const cached = readClaudeUsageCache(usageKey);
-    if (cached?.capturedAt) {
-      const ageMs = Date.now() - cached.capturedAt.getTime();
-      if (ageMs < USAGE_CACHE_FRESH_MS) {
-        return { snapshot: cached, error: null };
-      }
-    }
+  // Non-Claude or no identity: legacy path, blocking fetch.
+  if (input.agentId !== 'claude' || !usageKey) {
+    return getUsageInfo(input.agentId, {
+      home: input.home,
+      cliVersion: input.cliVersion,
+      organizationId: input.info.organizationId,
+    });
   }
 
-  // Cache miss or stale -- make the network call.
+  const cached = readClaudeUsageCache(usageKey);
+  const ageMs = cached?.capturedAt ? Date.now() - cached.capturedAt.getTime() : Infinity;
+
+  // Fresh: cache is recent enough, skip network entirely.
+  if (cached && ageMs < USAGE_CACHE_FRESH_MS) {
+    return { snapshot: cached, error: null };
+  }
+
+  // Stale-while-revalidate: cache exists and isn't ancient, return it now and
+  // refresh in the background so the next invocation has fresh data.
+  if (cached && ageMs < USAGE_CACHE_SWR_MS) {
+    triggerBackgroundUsageRefresh(input, usageKey);
+    return { snapshot: cached, error: null };
+  }
+
+  // Cold cache or > 24h old: block on live fetch.
   const usage = await getUsageInfo(input.agentId, {
     home: input.home,
     cliVersion: input.cliVersion,
     organizationId: input.info.organizationId,
   });
-  if (input.agentId !== 'claude' || !usageKey) {
-    return usage;
-  }
 
   if (usage.snapshot?.source === 'live') {
     writeClaudeUsageCache(usageKey, usage.snapshot);
     return usage;
   }
 
-  const cached = readClaudeUsageCache(usageKey);
+  // Live fetch failed — last-resort fallback to whatever cache we had.
   if (cached) {
     return { snapshot: cached, error: usage.error };
   }
   return usage;
+}
+
+/**
+ * Kick off a background refresh of the usage cache. Errors are swallowed —
+ * a failed background refresh leaves the existing cache in place for the
+ * next invocation. The work is deferred to a future event-loop tick via
+ * `setImmediate` because some of the call chain (loadClaudeOauth →
+ * getKeychainToken → execFileSync) does synchronous I/O even though the
+ * functions are declared `async`. Without the defer, that sync I/O blocks
+ * the SWR caller and defeats the whole point of returning the cache instantly.
+ */
+function triggerBackgroundUsageRefresh(input: UsageIdentityInput, usageKey: string): void {
+  if (inFlightRefreshes.has(usageKey)) return;
+
+  const promise = new Promise<void>((resolve) => {
+    setImmediate(async () => {
+      try {
+        const usage = await getUsageInfo(input.agentId, {
+          home: input.home,
+          cliVersion: input.cliVersion,
+          organizationId: input.info.organizationId,
+        });
+        if (usage.snapshot?.source === 'live') {
+          writeClaudeUsageCache(usageKey, usage.snapshot);
+        }
+      } catch {
+        /* background refresh failed — leave existing cache in place */
+      } finally {
+        inFlightRefreshes.delete(usageKey);
+        resolve();
+      }
+    });
+  });
+  inFlightRefreshes.set(usageKey, promise);
 }
 
 /** Format a one-line usage summary with compact bars for inline display. */


### PR DESCRIPTION
## Summary

Two independent perf fixes for the \`agents run\` cold-start path. Each is its own commit.

### \`perf(usage): stale-while-revalidate the Claude usage probe\` (9fce62ec)

\`agents run\` resolves rotation by calling \`getUsageInfoForIdentity\`. On a 2-minute-stale cache it made a blocking fetch to \`api.anthropic.com/api/oauth/usage\` (5s timeout) before claude could spawn — every cold invocation past the 2-minute window paid 5-8s of network before the user saw anything.

- cache fresh (<2 min): return cached, no network (was: same)
- cache stale (<24 h): return cached **instantly**, refresh in background (was: block 5-8s)
- cache cold / >24 h: block on live fetch (was: same)

Background refresh runs inside \`setImmediate\` because \`loadClaudeOauth\` → \`getKeychainToken\` is synchronous I/O even though declared async — without the defer it still blocks the caller on the keychain syscall.

### \`perf(state): memoize readMeta against agents.yaml mtimes\` (b2a2d23d)

\`readMeta()\` had a \`metaCache\` module-global wired in years ago (with \`writeMetaUnlocked\` clearing it) but no read path ever consulted it. Every call did 2× \`fs.readFileSync\` + 2× \`yaml.parse\` on the system+user \`agents.yaml\`. Hot callers (\`getConfiguredRunStrategy\`, \`getGlobalDefault\`, \`getVersionResources\`, \`ensureVersionResourcePatterns\`) fire it multiple times per run.

Wires the existing cache to the read path; freshness check is the sum of user mtime + scaled system mtime. Writers already invalidate; out-of-band edits picked up on the next stat.

## Test plan

- [ ] \`bun run vitest run src/lib/__tests__/usage.test.ts src/lib/__tests__/state.test.ts\` — covers SWR foreground latency (<100ms even with stale cache), fresh-cache no-fetch, readMeta same-process cache hit, writeMeta invalidation, external-mutation invalidation.
- [ ] \`time agents run codex --headless --mode plan "noop"\` from \$HOME on a warmed cache — should drop ~5-8s vs. previous behavior.
- [ ] Verify \`agents view claude\` still surfaces fresh usage after the first run (SWR background refresh updates the cache).

## Note

Commits carry \`Co-Authored-By:\` trailers from the engine that authored them — not stripped because the git deny list (\`rebase\`, \`reset\`, \`filter-branch\`) blocks rewriting the parent commit cleanly. Squash-merge will drop them.