### PR TITLE
feat(permissions): add Antigravity + Grok serializers

### DIFF
--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -29,9 +29,10 @@ const HOME = os.homedir();
 
 /** Agents that support the permissions subsystem. */
 // antigravity: permissions in ~/.gemini/antigravity-cli/settings.json under
-// `permissions: { allow: [...], deny: [...] }`. Serializer is a follow-up.
-// grok: permissions via --allow/--deny CLI flags or [permission] block in
-// ~/.grok/config.toml. Serializer is a follow-up.
+// `permissions: { allow: [...], deny: [...] }` with action-namespaced entries:
+// command(...), read_file(...), write_file(...), read_url(...), mcp(...).
+// grok: permissions in ~/.grok/config.toml under [permission] as a `rules`
+// array of `{ action, tool, pattern }` tables.
 export const PERMISSIONS_CAPABLE_AGENTS: AgentId[] = ['claude', 'codex', 'opencode', 'antigravity', 'grok', 'gemini'];
 
 /** Filename used for Codex Starlark deny-rules generated from permission groups. */
@@ -496,6 +497,116 @@ export function convertToGeminiFormat(set: PermissionSet): { tools: { allowed: s
     }
   }
   return { tools: { allowed: Array.from(allowed) } };
+}
+
+/**
+ * Strip Claude's `:*` subcommand-wildcard suffix and return a space-glob form.
+ * "mq:*" -> "mq *", "git status" -> "git status", "*" -> "*".
+ * Used by serializers whose native pattern grammar uses ` *` instead of `:*`.
+ */
+function normalizeBashPattern(pattern: string): string {
+  if (pattern === '*' || pattern === '**') return '*';
+  if (pattern.endsWith(':*')) return pattern.slice(0, -2) + ' *';
+  return pattern;
+}
+
+/**
+ * Convert canonical permission set to Antigravity format.
+ * Antigravity reads ~/.gemini/antigravity-cli/settings.json with
+ *   { permissions: { allow: [...], deny: [...] } }
+ * where each entry is action-namespaced: command(...), read_file(...),
+ * write_file(...), read_url(...), mcp(...).
+ * Bash maps to `command`, Read to `read_file`, Write to `write_file`,
+ * WebFetch to `read_url`. Other canonical tools are skipped.
+ * Note: Antigravity matches `command(npm install)` as an exact string,
+ * not a prefix — `Bash(npm:*)` becomes `command(npm *)` which is a glob
+ * but Antigravity upstream has a known exact-match bug for some forms.
+ */
+export function convertToAntigravityFormat(set: PermissionSet): { permissions: { allow: string[]; deny?: string[] } } {
+  const allow = serializeAntigravityEntries(set.allow);
+  const deny = set.deny ? serializeAntigravityEntries(set.deny) : [];
+  return {
+    permissions: {
+      allow,
+      ...(deny.length ? { deny } : {}),
+    },
+  };
+}
+
+function serializeAntigravityEntries(perms: string[]): string[] {
+  const out = new Set<string>();
+  for (const perm of perms) {
+    if (BLANKET_BASH_FORMS.has(perm)) {
+      out.add('command(*)');
+      continue;
+    }
+    const parsed = parseCanonicalPattern(perm);
+    if (!parsed) continue;
+    const action = ANTIGRAVITY_ACTION_BY_TOOL[parsed.tool];
+    if (!action) continue;
+    if (parsed.tool === 'bash') {
+      out.add(`${action}(${normalizeBashPattern(parsed.pattern)})`);
+    } else {
+      const p = parsed.pattern === '**' ? '*' : parsed.pattern;
+      out.add(`${action}(${p})`);
+    }
+  }
+  return Array.from(out);
+}
+
+const ANTIGRAVITY_ACTION_BY_TOOL: Record<string, string | undefined> = {
+  bash: 'command',
+  read: 'read_file',
+  write: 'write_file',
+  webfetch: 'read_url',
+};
+
+/**
+ * Convert canonical permission set to Grok format.
+ * Grok reads ~/.grok/config.toml with
+ *   [permission]
+ *   rules = [ { action = "allow", tool = "bash", pattern = "git *" }, ... ]
+ * Tool names are lowercase: bash, read, edit, grep, mcptool, webfetch.
+ * Canonical Write maps to Grok's `edit` tool.
+ */
+export function convertToGrokFormat(set: PermissionSet): { permission: { rules: GrokRule[] } } {
+  const rules: GrokRule[] = [];
+  for (const perm of set.allow) {
+    const rule = canonicalToGrokRule(perm, 'allow');
+    if (rule) rules.push(rule);
+  }
+  if (set.deny) {
+    for (const perm of set.deny) {
+      const rule = canonicalToGrokRule(perm, 'deny');
+      if (rule) rules.push(rule);
+    }
+  }
+  return { permission: { rules } };
+}
+
+export type GrokRule = { action: 'allow' | 'deny'; tool: string; pattern?: string };
+
+const GROK_TOOL_BY_CANONICAL: Record<string, string | undefined> = {
+  bash: 'bash',
+  read: 'read',
+  write: 'edit',
+  grep: 'grep',
+  webfetch: 'webfetch',
+};
+
+function canonicalToGrokRule(perm: string, action: 'allow' | 'deny'): GrokRule | null {
+  if (BLANKET_BASH_FORMS.has(perm)) {
+    return { action, tool: 'bash', pattern: '*' };
+  }
+  const parsed = parseCanonicalPattern(perm);
+  if (!parsed) return null;
+  const tool = GROK_TOOL_BY_CANONICAL[parsed.tool];
+  if (!tool) return null;
+  const pattern = parsed.tool === 'bash' ? normalizeBashPattern(parsed.pattern) : parsed.pattern;
+  if (pattern === '' || pattern === undefined) {
+    return { action, tool };
+  }
+  return { action, tool, pattern };
 }
 
 /**
@@ -1081,6 +1192,60 @@ export function applyPermissionsToVersion(
         }
         settings.tools = tools;
       });
+      return { success: true };
+    }
+
+    if (agentId === 'antigravity') {
+      const antigravityPerms = convertToAntigravityFormat(set);
+      const settingsPath = path.join(versionHome, '.gemini', 'antigravity-cli', 'settings.json');
+      updateGeminiSettings(settingsPath, (settings) => {
+        const perms = (typeof settings.permissions === 'object' && settings.permissions !== null && !Array.isArray(settings.permissions))
+          ? settings.permissions as Record<string, unknown>
+          : {};
+        if (merge) {
+          const existingAllow = Array.isArray(perms.allow) ? (perms.allow as string[]) : [];
+          const existingDeny = Array.isArray(perms.deny) ? (perms.deny as string[]) : [];
+          perms.allow = Array.from(new Set([...existingAllow, ...antigravityPerms.permissions.allow]));
+          const mergedDeny = Array.from(new Set([...existingDeny, ...(antigravityPerms.permissions.deny ?? [])]));
+          if (mergedDeny.length) perms.deny = mergedDeny;
+          else delete perms.deny;
+        } else {
+          perms.allow = antigravityPerms.permissions.allow;
+          if (antigravityPerms.permissions.deny?.length) perms.deny = antigravityPerms.permissions.deny;
+          else delete perms.deny;
+        }
+        settings.permissions = perms;
+      });
+      return { success: true };
+    }
+
+    if (agentId === 'grok') {
+      const grokPerms = convertToGrokFormat(set);
+      const configPath = path.join(versionHome, '.grok', 'config.toml');
+      let config: Record<string, unknown> = {};
+      if (fs.existsSync(configPath)) {
+        config = TOML.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+      }
+      const existingPermission = (typeof config.permission === 'object' && config.permission !== null && !Array.isArray(config.permission))
+        ? config.permission as Record<string, unknown>
+        : {};
+      if (merge) {
+        const existingRules = Array.isArray(existingPermission.rules) ? (existingPermission.rules as GrokRule[]) : [];
+        const seen = new Set<string>();
+        const dedup: GrokRule[] = [];
+        for (const r of [...existingRules, ...grokPerms.permission.rules]) {
+          const key = `${r.action}|${r.tool}|${r.pattern ?? ''}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          dedup.push(r);
+        }
+        existingPermission.rules = dedup;
+      } else {
+        existingPermission.rules = grokPerms.permission.rules;
+      }
+      config.permission = existingPermission;
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(configPath, TOML.stringify(config as any), 'utf-8');
       return { success: true };
     }
 

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -10,6 +10,8 @@ import {
   convertToClaudeFormat,
   convertToOpenCodeFormat,
   convertToCodexFormat,
+  convertToAntigravityFormat,
+  convertToGrokFormat,
   claudeToCanonical,
   openCodeToCanonical,
   codexToCanonical,
@@ -744,9 +746,107 @@ describe('applyPermissionsToVersion', () => {
       allow: ['Bash(git *)'],
     };
 
-    const result = applyPermissionsToVersion('gemini' as any, set, versionHome, true);
+    const result = applyPermissionsToVersion('cursor' as any, set, versionHome, true);
     expect(result.success).toBe(false);
     expect(result.error).toContain('does not support permissions');
+  });
+
+  it('writes Antigravity permissions to .gemini/antigravity-cli/settings.json', () => {
+    const versionHome = join(testDir, 'antigravity-write');
+    mkdirSync(versionHome, { recursive: true });
+
+    const set: PermissionSet = {
+      name: 'test',
+      allow: ['Bash(git *)', 'Bash(mq:*)', 'Read(/Users/me)', 'Bash(*)'],
+      deny: ['Bash(rm -rf *)'],
+    };
+
+    const result = applyPermissionsToVersion('antigravity' as any, set, versionHome, false);
+    expect(result.success).toBe(true);
+
+    const settingsPath = join(versionHome, '.gemini', 'antigravity-cli', 'settings.json');
+    expect(existsSync(settingsPath)).toBe(true);
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    expect(settings.permissions.allow).toContain('command(git *)');
+    expect(settings.permissions.allow).toContain('command(mq *)');
+    expect(settings.permissions.allow).toContain('command(*)');
+    expect(settings.permissions.allow).toContain('read_file(/Users/me)');
+    expect(settings.permissions.deny).toEqual(['command(rm -rf *)']);
+  });
+
+  it('merge=true preserves existing Antigravity entries and dedupes', () => {
+    const versionHome = join(testDir, 'antigravity-merge');
+    const dir = join(versionHome, '.gemini', 'antigravity-cli');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'settings.json'), JSON.stringify({
+      colorScheme: 'tokyo night',
+      permissions: { allow: ['command(npm test)', 'command(git *)'] },
+    }), 'utf-8');
+
+    const set: PermissionSet = {
+      name: 'test',
+      allow: ['Bash(git *)', 'Bash(yarn:*)'],
+    };
+
+    const result = applyPermissionsToVersion('antigravity' as any, set, versionHome, true);
+    expect(result.success).toBe(true);
+
+    const settings = JSON.parse(readFileSync(join(dir, 'settings.json'), 'utf-8'));
+    expect(settings.colorScheme).toBe('tokyo night');
+    expect(settings.permissions.allow).toContain('command(npm test)');
+    expect(settings.permissions.allow).toContain('command(git *)');
+    expect(settings.permissions.allow).toContain('command(yarn *)');
+    // No duplicate of "command(git *)"
+    expect(settings.permissions.allow.filter((e: string) => e === 'command(git *)')).toHaveLength(1);
+  });
+
+  it('writes Grok permissions to .grok/config.toml under [permission].rules', () => {
+    const versionHome = join(testDir, 'grok-write');
+    mkdirSync(versionHome, { recursive: true });
+
+    const set: PermissionSet = {
+      name: 'test',
+      allow: ['Bash(git *)', 'Bash(*)', 'Read(/Users/me)', 'Write(src/)', 'WebFetch(example.com)'],
+      deny: ['Bash(rm -rf *)'],
+    };
+
+    const result = applyPermissionsToVersion('grok' as any, set, versionHome, false);
+    expect(result.success).toBe(true);
+
+    const configPath = join(versionHome, '.grok', 'config.toml');
+    expect(existsSync(configPath)).toBe(true);
+    const config = TOML.parse(readFileSync(configPath, 'utf-8')) as any;
+    const rules = config.permission.rules as Array<{ action: string; tool: string; pattern?: string }>;
+    expect(rules).toContainEqual({ action: 'allow', tool: 'bash', pattern: 'git *' });
+    expect(rules).toContainEqual({ action: 'allow', tool: 'bash', pattern: '*' });
+    expect(rules).toContainEqual({ action: 'allow', tool: 'read', pattern: '/Users/me' });
+    expect(rules).toContainEqual({ action: 'allow', tool: 'edit', pattern: 'src/' });
+    expect(rules).toContainEqual({ action: 'allow', tool: 'webfetch', pattern: 'example.com' });
+    expect(rules).toContainEqual({ action: 'deny', tool: 'bash', pattern: 'rm -rf *' });
+  });
+
+  it('merge=true preserves existing Grok rules and dedupes', () => {
+    const versionHome = join(testDir, 'grok-merge');
+    const dir = join(versionHome, '.grok');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.toml'), TOML.stringify({
+      ui: { permission_mode: 'ask' },
+      permission: { rules: [{ action: 'allow', tool: 'bash', pattern: 'git *' }] },
+    } as any), 'utf-8');
+
+    const set: PermissionSet = {
+      name: 'test',
+      allow: ['Bash(git *)', 'Bash(yarn:*)'],
+    };
+
+    const result = applyPermissionsToVersion('grok' as any, set, versionHome, true);
+    expect(result.success).toBe(true);
+
+    const config = TOML.parse(readFileSync(join(dir, 'config.toml'), 'utf-8')) as any;
+    expect(config.ui.permission_mode).toBe('ask');
+    const rules = config.permission.rules as Array<{ action: string; tool: string; pattern?: string }>;
+    expect(rules.filter(r => r.action === 'allow' && r.tool === 'bash' && r.pattern === 'git *')).toHaveLength(1);
+    expect(rules).toContainEqual({ action: 'allow', tool: 'bash', pattern: 'yarn *' });
   });
 
   it('merge=true keeps existing Claude rules not present in new set', () => {


### PR DESCRIPTION
## Summary

`PERMISSIONS_CAPABLE_AGENTS` listed `antigravity` and `grok` but `applyPermissionsToVersion` had no branches for them — both fell through to `Agent 'X' does not support permissions`. User-configured permission groups were silently ignored, so every session reprompted for every tool call.

This PR ships real serializers for both, matched against upstream docs (not guessed):

- **Antigravity** (`antigravity.google/docs/permissions`): JSON at `~/.gemini/antigravity-cli/settings.json` with `{ permissions: { allow: [...], deny: [...] } }`. Entries are action-namespaced — `command(...)`, `read_file(...)`, `write_file(...)`, `read_url(...)`.
- **Grok** (`docs.x.ai/build/enterprise`): TOML at `~/.grok/config.toml` with `[[permission.rules]]` array-of-tables where each rule is `{ action, tool, pattern }`. Lowercase tool names (`bash`, `read`, `edit`, `grep`, `webfetch`). Canonical `Write(...)` maps to grok's `edit` tool.

Adds a `normalizeBashPattern` helper that converts Claude's `cmd:*` form into the space-glob `cmd *` form both agents use natively.

## Verification

End-to-end against the user's real `local-tools` permission set on a synthetic versionHome:

**Grok TOML output**:
```toml
[[permission.rules]]
action = "allow"
tool = "bash"
pattern = "mq *"
```

**Antigravity JSON output**:
```json
{ "permissions": { "allow": ["command(mq *)", ...] } }
```

Both match the upstream-doc examples exactly.

## Test plan

- [x] 4 new `applyPermissionsToVersion` tests for write + merge on both agents
- [x] Fixed the broken "unsupported agent" test (was asserting against `'gemini'` which is now supported)
- [x] Full permissions.test.ts suite: 57/57 pass
- [x] Manual end-to-end against real user permission set

🤖 Generated with [Claude Code](https://claude.com/claude-code)