### PR TITLE
fix(pty): atomic pid claim prevents duplicate-spawn socket clobber

### DIFF
--- a/src/lib/__tests__/pty-server.test.ts
+++ b/src/lib/__tests__/pty-server.test.ts
@@ -84,6 +84,47 @@ describe('PTY socket permission', () => {
   }, 15_000);
 });
 
+describe('PTY duplicate-spawn race resolution', () => {
+  it('exits cleanly without touching the socket when a live PID file already exists', async () => {
+    // Pre-stage a PID file pointing to a live process (this test runner). The
+    // server boot must detect this via isPtyServerRunning() and exit cleanly
+    // — if it didn't, line ~223's unlinkSync would clobber the winner's socket
+    // inode, orphaning the prior server. We pin a sentinel byte sequence in
+    // the socket path and assert it survives.
+    const pidDir = path.join(TEST_HOME, '.agents', '.cache', 'helpers', 'pty');
+    await fsp.mkdir(pidDir, { recursive: true });
+    const pidPath = path.join(pidDir, 'pty.pid');
+    await fsp.writeFile(pidPath, String(process.pid), 'utf-8');
+
+    const socketPath = getSocketPath();
+    const sentinel = 'sentinel-from-winner';
+    await fsp.writeFile(socketPath, sentinel, 'utf-8');
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__test_exit_${code ?? 0}`);
+    }) as never);
+
+    let caught: Error | null = null;
+    try {
+      await runPtyServer();
+    } catch (err: any) {
+      caught = err;
+    }
+
+    expect(caught, 'runPtyServer should have exited via process.exit(0)').not.toBeNull();
+    expect(caught!.message).toBe('__test_exit_0');
+
+    // Sentinel survived — the duplicate did not clobber the winner's socket.
+    expect(await fsp.readFile(socketPath, 'utf-8')).toBe(sentinel);
+    // PID file untouched — the winner's PID is still there.
+    expect(await fsp.readFile(pidPath, 'utf-8')).toBe(String(process.pid));
+
+    exitSpy.mockRestore();
+    await fsp.rm(pidPath, { force: true });
+    await fsp.rm(socketPath, { force: true });
+  }, 15_000);
+});
+
 describe('captureProcessStartTime', () => {
   it('returns null or a non-empty string for the current process', () => {
     const value = captureProcessStartTime(process.pid);

--- a/src/lib/pty-server.ts
+++ b/src/lib/pty-server.ts
@@ -217,8 +217,31 @@ export async function runPtyServer(): Promise<void> {
 
   const sessions = new Map<string, Session>();
   const socketPath = getSocketPath();
+  const pidPath = getPtyPidPath();
 
-  // Remove stale socket
+  // Race resolution must happen BEFORE touching the socket file. Two clients
+  // racing ensureServer() in pty-client.ts can both observe
+  // isPtyServerRunning()=false and spawn parallel servers; without the
+  // O_EXCL claim below, the second spawn would unlink the first's socket
+  // inode and overwrite its PID file, orphaning the first server with its
+  // kernel socket binding intact but unreachable via the filesystem.
+  if (isPtyServerRunning()) {
+    log('INFO', 'PTY server already running; duplicate spawn exits cleanly');
+    process.exit(0);
+  }
+  try {
+    fs.writeFileSync(pidPath, String(process.pid), { flag: 'wx', encoding: 'utf-8' });
+  } catch (err: any) {
+    if (err && err.code === 'EEXIST') {
+      log('INFO', 'PID slot claimed by a concurrent server; exiting cleanly');
+      process.exit(0);
+    }
+    throw err;
+  }
+  // We own the PID slot; ensure it's released on any exit path, not just SIGTERM/SIGINT.
+  process.on('exit', () => { try { fs.unlinkSync(pidPath); } catch {} });
+
+  // Remove stale socket from a prior crashed server. Safe now that we hold the PID slot.
   if (fs.existsSync(socketPath)) {
     try { fs.unlinkSync(socketPath); } catch {}
   }
@@ -573,8 +596,6 @@ export async function runPtyServer(): Promise<void> {
   // start so the caller learns immediately.
   fs.chmodSync(socketPath, 0o600);
 
-  // Write PID
-  fs.writeFileSync(getPtyPidPath(), String(process.pid), 'utf-8');
   log('INFO', `PTY server started (PID: ${process.pid}, socket: ${socketPath})`);
 
   // Shutdown handler


### PR DESCRIPTION
## Summary

Resolves a race in \`runPtyServer()\` where two clients calling \`ensureServer()\` in \`pty-client.ts\` simultaneously can both observe \`isPtyServerRunning()=false\` and spawn parallel servers. The second server unlinks the first's socket inode at \`pty-server.ts:222\` and overwrites the PID file at the old line 577, orphaning the first server — it stays alive holding its kernel socket binding, but no filesystem path routes to it.

Observed in the wild: 24+ idle \`pty _server\` processes accumulating on a developer machine over a long session, consuming ~1.9 GB RSS.

## Fix

Move PID-slot acquisition BEFORE socket cleanup, and make it atomic with \`fs.writeFileSync(pidPath, ..., { flag: 'wx' })\`. The loser sees \`EEXIST\` and exits cleanly via \`process.exit(0)\` without touching the winner's socket file.

Also adds \`process.on('exit', ...)\` to unlink the PID file on any exit path, not just \`SIGTERM\`/\`SIGINT\` (the previous code at lines 590 only handled signals).

## Commits

1. \`fix(pty): atomic pid claim prevents duplicate-spawn socket clobber\` — the fix in \`src/lib/pty-server.ts\` (~24 LoC)
2. \`test(pty): pin duplicate-spawn race resolution\` — vitest test that pre-stages a PID file pointing to a live process, runs \`runPtyServer()\`, asserts it exits cleanly and the socket sentinel survives

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`src/lib/__tests__/pty-server.test.ts\` — 5/5 pass (4 pre-existing + 1 new race test)
- [x] Full suite delta: 18 pre-existing failures on origin/main (browser/permissions/MCP/models/registry — none touch \`pty-*\`); my commits don't change that count
- [ ] Soak: run \`agents pty start\` from N concurrent shells, verify only 1 process survives

## Context

Part of an audit of cold-path latency in agent terminal startup. Companion PR \`muqsitnawaz/swarmify#33\` (merged) fixed the extension-side \`promptReady\` gate. F2 (Claude usage stale-while-revalidate) shipped in #159 — already on \`main\`.