### PR TITLE
fix(run): degrade default mode when agent lacks plan support

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -148,7 +148,7 @@ export function registerRunCommand(program: Command): void {
 
   runCmd.action(async (agentSpec: string, prompt: string | undefined, options: ExecCommandActionOptions) => {
       const [
-        { buildExecCommand, parseExecEnv, execAgent, runWithFallback, normalizeMode, resolveMode },
+        { buildExecCommand, parseExecEnv, execAgent, runWithFallback, normalizeMode, resolveMode, defaultModeFor },
         { ALL_AGENT_IDS },
         { profileExists, resolveProfileForRun },
         { readAndResolveBundleEnv, describeBundle },
@@ -329,20 +329,33 @@ export function registerRunCommand(program: Command): void {
 
       // Accept the four canonical modes plus 'full' as a permanent silent
       // alias for 'skip' (rewritten downstream by normalizeMode in exec.ts).
-      const mode = options.mode as ExecMode;
+      let mode = options.mode as ExecMode;
       if (!['plan', 'edit', 'auto', 'skip', 'full'].includes(mode)) {
         console.error(chalk.red(`Invalid mode: ${mode}. Use plan, edit, auto, or skip ('full' accepted as alias for skip).`));
         process.exit(1);
       }
 
-      // Surface capability errors as a clean CLI message instead of a stack
-      // trace from buildExecCommand. resolveMode degrades 'auto' silently and
-      // throws on unsupported 'plan'/'skip' — we catch and pretty-print.
+      // When the user did not pass --mode explicitly, the default is the
+      // generic 'plan'. Some agents (antigravity: edit/skip only, grok in some
+      // configurations) do not support plan. For implicit defaults, degrade
+      // silently to the agent's first listed mode rather than throwing — the
+      // user did not ask for read-only, they asked for "just run it." An
+      // explicit --mode plan still throws (see resolveMode), because silently
+      // elevating an explicit read-only request to edit is unsafe.
+      const modeSource = runCmd.getOptionValueSource('mode');
+      const modeIsDefault = modeSource === 'default';
       try {
         resolveMode(agent, normalizeMode(mode));
       } catch (err) {
-        console.error(chalk.red((err as Error).message));
-        process.exit(1);
+        if (modeIsDefault) {
+          mode = defaultModeFor(agent) as ExecMode;
+          if (!options.quiet) {
+            process.stderr.write(chalk.gray(`[agents] ${agent} has no '${options.mode}' mode; using '${mode}'\n`));
+          }
+        } else {
+          console.error(chalk.red((err as Error).message));
+          process.exit(1);
+        }
       }
 
       const effort = options.effort as ExecEffort;

--- a/src/lib/__tests__/exec.test.ts
+++ b/src/lib/__tests__/exec.test.ts
@@ -8,6 +8,7 @@ import {
   parseExecEnv,
   normalizeMode,
   resolveMode,
+  defaultModeFor,
   type ExecOptions,
 } from '../exec.js';
 import type { AgentId, Mode } from '../types.js';
@@ -705,5 +706,24 @@ describe('resolveMode', () => {
   it("throws on 'skip' for kiro (edit-only agent)", () => {
     expect(() => resolveMode('kiro', 'skip'))
       .toThrow(/kiro does not support 'skip' mode\. Supported modes: edit\./);
+  });
+});
+
+describe('defaultModeFor', () => {
+  it('returns the first listed mode for each agent', () => {
+    // Antigravity: ['edit', 'skip'] — no plan, so default must be edit.
+    expect(defaultModeFor('antigravity')).toBe('edit');
+    // Cursor: ['edit', 'skip'] — same.
+    expect(defaultModeFor('cursor')).toBe('edit');
+    // Claude: ['plan', 'edit', 'auto', 'skip'] — plan is safest.
+    expect(defaultModeFor('claude')).toBe('plan');
+    // Kiro: edit-only.
+    expect(defaultModeFor('kiro')).toBe('edit');
+  });
+
+  it('agrees with capabilities.modes[0] for every agent (single source of truth)', () => {
+    for (const agent of ALL_AGENTS) {
+      expect(defaultModeFor(agent)).toBe(AGENTS[agent].capabilities.modes[0]);
+    }
   });
 });

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -64,6 +64,23 @@ export function resolveMode(agent: AgentId, requested: Mode): Mode {
   );
 }
 
+/**
+ * The mode an agent should run in when the caller has no preference.
+ *
+ * Returns the first entry in the agent's `capabilities.modes` table — the
+ * declaration order is the source of truth for "the safest mode this agent
+ * supports." Agents that include `plan` list it first; agents like
+ * antigravity that have no read-only mode list `edit` first.
+ *
+ * Use this when the user did not pass `--mode` explicitly. When the user
+ * *did* pass `--mode plan` and the agent doesn't support it, call
+ * `resolveMode` instead so the user sees a loud error rather than a silent
+ * elevation from read-only to writable.
+ */
+export function defaultModeFor(agent: AgentId): Mode {
+  return AGENTS[agent].capabilities.modes[0];
+}
+
 /** Reasoning effort levels passed to agents that support them. 'auto' defers to the agent's default. */
 export type ExecEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'auto';
 


### PR DESCRIPTION
## Summary

`agents run antigravity` (and any agent whose `capabilities.modes` table omits `plan`, e.g. `cursor`) exited 1 with:

```
antigravity does not support 'plan' mode. Supported modes: edit, skip.
```

This happened because `commands/exec.ts` set the `--mode` default to the literal string `'plan'` (`src/commands/exec.ts:59`) and then ran the result through `resolveMode`, which throws for unsupported modes. The user never asked for plan — that was a CLI default leaking through.

## Fix

- New `defaultModeFor(agent)` in `src/lib/exec.ts` — returns `capabilities.modes[0]`, the agent's first declared (safest) mode. Single source of truth.
- In the run command action, detect whether `--mode` came from the user (commander `getOptionValueSource('mode') !== 'default'`). If `resolveMode` rejects the value AND it was the implicit default, fall back to `defaultModeFor(agent)` with a single greyed-out notice.
- Explicit `--mode plan` on antigravity still errors loudly — silently elevating an asked-for read-only mode to `edit` is unsafe.

## Verification

- `agents run antigravity` → `[agents] antigravity has no 'plan' mode; using 'edit'` → spawns `agy@1.0.6` (verified).
- `agents run antigravity --mode plan` → still errors as before (safety preserved).
- `agents run claude` → unchanged (claude lists plan first, so default stays plan).
- 121 tests pass in `src/lib/__tests__/exec.test.ts` (added two for `defaultModeFor`).

## Session Context

[Session transcript](https://gist.github.com/muqsitnawaz/c1e00be507360f4b9984860dde050cdc)

## Test plan

- [x] `bun test src/lib/__tests__/exec.test.ts` passes
- [x] `agents run antigravity` launches (no `--mode` needed)
- [x] `agents run antigravity --mode plan` still errors (explicit safety branch)
- [x] `agents run claude` still defaults to plan mode