### PR TITLE
chore(release): 1.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.20.3
+
+**`agents run` startup latency (stale-while-revalidate the usage probe + memoize agents.yaml)**
+
+- The default `agents run` strategy is `available`, which calls `getUsageInfoForIdentity` to skip rate-limited accounts. With a 2-minute cache, every cold invocation past that window made a blocking `fetch` to `api.anthropic.com/api/oauth/usage` (5 s timeout, plus an optional 15 s OAuth token refresh) before `spawn(claude)` — so `agents run claude` regularly stalled 5–8 s with nothing on screen after the rotation banner.
+- The cache is now stale-while-revalidate: fresh (<2 min) returns instantly with no network, stale-but-recent (<24 h) returns the cached snapshot instantly and refreshes in the background, and only a fully cold / >24 h cache blocks on the live fetch. The background refresh defers its first await past `setImmediate` so the synchronous Keychain CLI call (`security find-generic-password`, invoked by `loadClaudeOauth`) cannot block the foreground caller — that's how an SWR returns "instantly" even while the refresh is technically still on its first sync step.
+- `readMeta()` had a `metaCache` module global plus `writeMetaUnlocked` cache-invalidation logic wired in years ago — but no read path ever consulted the cache. So every call did 2x `fs.readFileSync` + 2x `yaml.parse` on system + user `agents.yaml`, and hot callers (`getConfiguredRunStrategy`, `getGlobalDefault`, `getVersionResources`, `ensureVersionResourcePatterns`) fire it multiple times per `agents run`. The read path now consults the cache, keyed on the combined mtime of both source files — out-of-band edits still invalidate on the next stat, and in-process writers already clear it.
+
 ## 1.20.2
 
 **Grok and Antigravity Support & Documentation**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phnx-labs/agents-cli",
-  "version": "1.20.2",
+  "version": "1.20.3",
   "description": "One CLI for all your AI coding agents - versions, config, cloud dispatch, sessions, and teams (now with first-class Grok Build CLI support)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Release prep for 1.20.3. The code changes (`perf: stale-while-revalidate the usage probe + memoize readMeta`) were already merged via #159; this PR is just the version bump + CHANGELOG entry to cut the release.

## Changes

- `package.json`: 1.20.2 → 1.20.3
- `CHANGELOG.md`: new 1.20.3 entry describing the two perf fixes that landed in #159

## Test plan

- [x] `tsc --noEmit` clean
- [x] Focused usage + state tests pass (25/25)
- [x] Live verification — `agents run` startup visibly faster after dev install

## Notes

CI failures (`tests/permissions.test.ts:748`, `tests/project-resources-pipeline.test.ts:254`) exist on `main` HEAD already (`gh run list --branch main --workflow CI` shows both recent runs failing). Not introduced here.

## Session Context

[Session transcript](https://gist.github.com/muqsitnawaz/10d6ac8776fe8c3a72dfdfee3ff053f8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)