### PR TITLE
fix(import,view): adopt installScript-based agents (Grok, Antigravity, Cursor)

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -25,6 +25,7 @@ import type { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { confirm } from '@inquirer/prompts';
 
@@ -36,6 +37,7 @@ import {
   finalizeImport,
   importAgentBinary,
   importAgentConfig,
+  importInstallScriptBinary,
   isValidImportVersion,
   resolvePackageDirFromBinary,
 } from '../lib/import.js';
@@ -60,16 +62,14 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
   const agentId = agentArg;
   const agent = AGENTS[agentId];
 
-  // Reject agents that don't ship via npm before we spin up PATH lookups and
-  // prompts. cursor/kiro/goose/roo all have npmPackage='' and use custom
-  // install scripts — the symlink-farm import doesn't apply to them.
-  if (!agent.npmPackage) {
-    console.error(chalk.red(`${agentLabel(agentId)} doesn't install via npm — \`agents import\` only handles npm-style packages.`));
-    console.error(chalk.gray(`Use \`agents add ${agentId}\` to install via its native script.`));
-    process.exit(1);
-  }
+  // installScript-based agents (Grok, Antigravity, Cursor, Kiro, Goose, Roo)
+  // don't have an npm package; their binary lives wherever the curl/brew
+  // installer dropped it. We adopt by symlinking that PATH binary directly
+  // into the version's `node_modules/.bin/`. No package.json walk.
+  const isInstallScriptAgent = !agent.npmPackage;
 
   let globalPath: string | null = null;
+  let installScriptBinary: string | null = null;
 
   if (opts.fromPath) {
     globalPath = path.resolve(opts.fromPath);
@@ -77,38 +77,78 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
       console.error(chalk.red(`Path does not exist: ${globalPath}`));
       process.exit(1);
     }
+    if (isInstallScriptAgent) {
+      // With --from-path on an installScript agent, the path is the binary
+      // itself (or a directory containing it). Accept either.
+      if (fs.statSync(globalPath).isDirectory()) {
+        const candidate = path.join(globalPath, agent.cliCommand);
+        if (!fs.existsSync(candidate)) {
+          console.error(chalk.red(`No "${agent.cliCommand}" in ${globalPath}`));
+          process.exit(1);
+        }
+        installScriptBinary = candidate;
+      } else {
+        installScriptBinary = globalPath;
+      }
+    }
   } else {
     const binary = await getCliPath(agentId);
     if (!binary) {
-      // Use || (not ??) so empty-string npmPackage falls back to cliCommand.
-      // Defensive: agents with empty npmPackage are rejected above, but keep
-      // the operator correct in case that early check is ever relaxed.
-      const installName = agent.npmPackage || agent.cliCommand;
+      const installHint = isInstallScriptAgent
+        ? `Run \`agents add ${agentId}\` to install via the official script, or pass --from-path.`
+        : `Install it first (e.g. \`npm i -g ${agent.npmPackage || agent.cliCommand}\`) or pass --from-path.`;
       console.error(chalk.red(`No "${agent.cliCommand}" found on PATH.`));
-      console.error(chalk.gray(`Install it first (e.g. \`npm i -g ${installName}\`) or pass --from-path.`));
+      console.error(chalk.gray(installHint));
       process.exit(1);
     }
-    globalPath = resolvePackageDirFromBinary(binary);
-    if (!globalPath) {
-      console.error(chalk.red(`Could not resolve npm package for binary: ${binary}`));
-      console.error(chalk.gray('Pass --from-path <dir> with the package directory explicitly.'));
-      process.exit(1);
+    if (isInstallScriptAgent) {
+      installScriptBinary = binary;
+    } else {
+      globalPath = resolvePackageDirFromBinary(binary);
+      if (!globalPath) {
+        console.error(chalk.red(`Could not resolve npm package for binary: ${binary}`));
+        console.error(chalk.gray('Pass --from-path <dir> with the package directory explicitly.'));
+        process.exit(1);
+      }
+    }
+  }
+
+  // For Grok, the binary on PATH is typically `~/.grok/bin/grok` (a moving
+  // pointer to the latest install). Prefer the exact versioned file in
+  // `~/.grok/downloads/` so the v<x.y.z> alias is pinned to that file and
+  // doesn't drift when the user upgrades externally.
+  if (isInstallScriptAgent && agentId === 'grok' && !opts.fromPath) {
+    const detected = await getCliVersion(agentId);
+    if (detected) {
+      const downloads = path.join(os.homedir(), '.grok', 'downloads');
+      try {
+        const entries = fs.readdirSync(downloads);
+        const exact = entries.find((e) => e.startsWith('grok-') && e.includes(detected));
+        if (exact) {
+          installScriptBinary = path.join(downloads, exact);
+        }
+      } catch {
+        /* fall back to PATH binary already set above */
+      }
     }
   }
 
   let version = opts.version;
   if (!version) {
-    try {
-      const pkg = JSON.parse(fs.readFileSync(path.join(globalPath, 'package.json'), 'utf8'));
-      version = typeof pkg.version === 'string' ? pkg.version : undefined;
-    } catch {
-      /* fall through */
+    if (!isInstallScriptAgent && globalPath) {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(path.join(globalPath, 'package.json'), 'utf8'));
+        version = typeof pkg.version === 'string' ? pkg.version : undefined;
+      } catch {
+        /* fall through */
+      }
     }
     // Only fall back to running the PATH binary's --version when we're
-    // auto-detecting. With --from-path, the PATH binary may belong to a
-    // different install entirely; reporting its version here would silently
-    // mis-attribute the imported version.
-    if (!version && !opts.fromPath) {
+    // auto-detecting. With --from-path on an npm agent, the PATH binary may
+    // belong to a different install entirely; reporting its version here
+    // would silently mis-attribute the imported version. installScript agents
+    // always use `<bin> --version` since they have no package.json to read.
+    if (!version && (isInstallScriptAgent || !opts.fromPath)) {
       const detected = await getCliVersion(agentId);
       version = detected ?? undefined;
     }
@@ -126,9 +166,10 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
   }
 
   const versionDir = getVersionDir(agentId, version);
+  const fromLabel = isInstallScriptAgent ? (installScriptBinary as string) : (globalPath as string);
 
   console.log(chalk.bold(`\nImport ${agentLabel(agentId)} v${version}`));
-  console.log(`  from: ${chalk.gray(globalPath)}`);
+  console.log(`  from: ${chalk.gray(fromLabel)}`);
   console.log(`  into: ${chalk.gray(versionDir)}`);
 
   const configDirExists = fs.existsSync(agent.configDir);
@@ -169,7 +210,8 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
     const cfgSpinner = ora(`Importing config dir for ${agentLabel(agentId)} v${version}...`).start();
     const cfgResult = await importAgentConfig(agentId, version);
     if (cfgResult.success) {
-      cfgSpinner.succeed(`Config imported (${agent.configDir} -> ${versionDir}/home/.${agentId})`);
+      const relConfig = path.relative(os.homedir(), agent.configDir);
+      cfgSpinner.succeed(`Config imported (${agent.configDir} -> ${versionDir}/home/${relConfig})`);
     } else if (cfgResult.skipped) {
       cfgSpinner.warn(`Config: ${cfgResult.error}`);
     } else {
@@ -179,14 +221,21 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
   }
 
   const binSpinner = ora(`Registering ${agentLabel(agentId)} v${version} binary...`).start();
-  const binResult = importAgentBinary(
-    { agentId, npmPackage: agent.npmPackage, cliCommand: agent.cliCommand },
-    version,
-    globalPath,
-    versionDir
-  );
+  const binResult = isInstallScriptAgent
+    ? importInstallScriptBinary(
+        { agentId, npmPackage: agent.npmPackage, cliCommand: agent.cliCommand },
+        version,
+        installScriptBinary as string,
+        versionDir
+      )
+    : importAgentBinary(
+        { agentId, npmPackage: agent.npmPackage, cliCommand: agent.cliCommand },
+        version,
+        globalPath as string,
+        versionDir
+      );
   if (binResult.success) {
-    binSpinner.succeed(`Binary registered (${agent.cliCommand} -> ${globalPath})`);
+    binSpinner.succeed(`Binary registered (${agent.cliCommand} -> ${binResult.resolvedFromPath})`);
   } else if (binResult.skipped) {
     binSpinner.warn(`Binary: ${binResult.error}`);
   } else {
@@ -225,11 +274,19 @@ Examples:
   $ agents import openclaw --version 2026.3.8       Pin a version label
   $ agents import openclaw --from-path /opt/homebrew/lib/node_modules/openclaw
 
+  # installScript-based agents (curl/brew installers, no npm package):
+  $ agents import grok                              Adopt ~/.grok/downloads/grok-<ver>
+  $ agents import antigravity                       Adopt ~/.local/bin/agy
+  $ agents import cursor                            Adopt ~/.local/bin/cursor-agent
+  $ agents import antigravity --from-path ~/.local/bin/agy
+
 When to use:
-  When an agent CLI is already installed globally via npm or homebrew and you
-  want to bring it under agents-cli management without reinstalling. Creates a
-  symlink farm pointing at the existing install — nothing is copied or moved
-  (except the agent's config dir, which is moved into the version's home).
+  When an agent CLI is already installed globally and you want to bring it
+  under agents-cli management without reinstalling. Creates a symlink farm
+  pointing at the existing install — nothing is copied or moved (except the
+  agent's config dir, which is moved into the version's home). Works for both
+  npm-style packages (claude, codex, gemini, opencode, openclaw) and
+  installScript-based agents (grok, antigravity, cursor, kiro, goose, roo).
 `)
     .action(runImport);
 }

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -536,6 +536,10 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
       }
       if (agent.npmPackage && cliState?.version) {
         console.log(chalk.gray(`    Manage: agents add ${agentId}@${cliState.version} -y`));
+      } else if (!agent.npmPackage && cliState?.installed) {
+        // installScript-based agent already on PATH — direct users to adopt the
+        // existing install with `agents import` instead of re-running curl.
+        console.log(chalk.gray(`    Adopt:  agents import ${agentId}`));
       }
       console.log();
     }

--- a/src/lib/__tests__/import.test.ts
+++ b/src/lib/__tests__/import.test.ts
@@ -13,7 +13,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
-import { resolvePackageDirFromBinary, importAgentBinary } from '../import.js';
+import { resolvePackageDirFromBinary, importAgentBinary, importInstallScriptBinary } from '../import.js';
 
 const OPENCLAW_SPEC = { agentId: 'openclaw', npmPackage: 'openclaw', cliCommand: 'openclaw' };
 
@@ -187,5 +187,74 @@ describe('importAgentBinary', () => {
 
     const managedBinary = path.join(versionDir, 'node_modules', '.bin', 'openclaw');
     expect(fs.realpathSync(managedBinary)).toBe(fs.realpathSync(binarySource));
+  });
+});
+
+describe('importInstallScriptBinary', () => {
+  let tmp: string;
+  let versionDir: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-import-installscript-'));
+    versionDir = path.join(tmp, '.agents', '.history', 'versions', 'antigravity', '1.0.6');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const ANTIGRAVITY_SPEC = { agentId: 'antigravity', npmPackage: '', cliCommand: 'agy' };
+
+  function makeFakeInstallScriptBinary(): string {
+    // Mirror `curl ... install.sh` landing the binary at ~/.local/bin/agy.
+    const localBin = path.join(tmp, '.local', 'bin');
+    fs.mkdirSync(localBin, { recursive: true });
+    const binaryPath = path.join(localBin, 'agy');
+    fs.writeFileSync(binaryPath, '#!/usr/bin/env bash\necho "fake agy"\n');
+    fs.chmodSync(binaryPath, 0o755);
+    return binaryPath;
+  }
+
+  it('symlinks the PATH binary into node_modules/.bin and writes a marker', () => {
+    const binaryPath = makeFakeInstallScriptBinary();
+
+    const result = importInstallScriptBinary(ANTIGRAVITY_SPEC, '1.0.6', binaryPath, versionDir);
+    expect(result.success).toBe(true);
+    expect(result.resolvedFromPath).toBe(binaryPath);
+
+    const managedBinary = path.join(versionDir, 'node_modules', '.bin', 'agy');
+    expect(fs.lstatSync(managedBinary).isSymbolicLink()).toBe(true);
+    expect(fs.realpathSync(managedBinary)).toBe(fs.realpathSync(binaryPath));
+
+    // Marker package.json records provenance + installScript origin.
+    const marker = JSON.parse(fs.readFileSync(path.join(versionDir, 'package.json'), 'utf8'));
+    expect(marker.imported).toBe(true);
+    expect(marker.installScriptBased).toBe(true);
+    expect(marker.from).toBe(binaryPath);
+
+    // Isolated home is created.
+    expect(fs.existsSync(path.join(versionDir, 'home'))).toBe(true);
+  });
+
+  it('returns skipped=true on a second import of the same version', () => {
+    const binaryPath = makeFakeInstallScriptBinary();
+    const first = importInstallScriptBinary(ANTIGRAVITY_SPEC, '1.0.6', binaryPath, versionDir);
+    expect(first.success).toBe(true);
+
+    const second = importInstallScriptBinary(ANTIGRAVITY_SPEC, '1.0.6', binaryPath, versionDir);
+    expect(second.success).toBe(false);
+    expect(second.skipped).toBe(true);
+    expect(second.error).toMatch(/already installed/);
+  });
+
+  it('fails cleanly when the binary path does not exist', () => {
+    const result = importInstallScriptBinary(
+      ANTIGRAVITY_SPEC,
+      '1.0.6',
+      path.join(tmp, 'does-not-exist'),
+      versionDir
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Binary does not exist/);
   });
 });

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -73,12 +73,23 @@ function saveCliVersionCache(): void {
   }
 }
 
-/** Synchronous PATH search -- no subprocess. Returns first matching binary path. */
+/**
+ * Synchronous PATH search -- no subprocess. Returns first matching binary path.
+ *
+ * Skips our own shims dir (`~/.agents/.cache/shims/`) — those shims are
+ * dispatch helpers, not real installs. Counting them as installed produced a
+ * false positive where agents with NO real binary on the host (e.g. a
+ * never-installed Cursor whose only PATH entry was our `cursor-agent` shim
+ * dispatcher) showed up under `agents view`'s "Not Managed by Agents CLI"
+ * section, even though the user had nothing to import.
+ */
 function findInPath(command: string): string | null {
   const pathEnv = process.env.PATH || '';
   const pathExt = process.platform === 'win32' ? (process.env.PATHEXT || '').split(';') : [''];
+  const shimsDir = getShimsDir();
   for (const dir of pathEnv.split(path.delimiter)) {
     if (!dir) continue;
+    if (path.resolve(dir) === path.resolve(shimsDir)) continue;
     for (const ext of pathExt) {
       const full = path.join(dir, command + ext);
       try {

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -550,8 +550,16 @@ async function getCachedVersionForBinary(agentId: AgentId, binaryPath: string): 
     version = null;
   }
 
-  cache[agentId] = { binaryPath, mtime, version };
-  saveCliVersionCache();
+  // Skip persisting null results — the most common cause is a transient
+  // `--version` failure (slow startup, stdout race, etc.). A sticky-null
+  // entry kept users in a broken state where every subsequent
+  // `getCachedVersionForBinary` short-circuited to null forever, even
+  // after the binary started working. Re-probing on the next call costs
+  // one execFile; persisting null costs the whole feature.
+  if (version !== null) {
+    cache[agentId] = { binaryPath, mtime, version };
+    saveCliVersionCache();
+  }
   return version;
 }
 

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -18,6 +18,7 @@
  */
 
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import type { AgentId } from './types.js';
 import { AGENTS } from './agents.js';
@@ -64,14 +65,19 @@ export async function importAgentConfig(
   const configDir = agent.configDir;
   const versionsDir = getVersionsDir();
   const versionHome = path.join(versionsDir, agentId, version, 'home');
-  const versionConfigDir = path.join(versionHome, `.${agentId}`);
+  // Match the shim's derivation in generateShimScript: the per-version config
+  // path mirrors the original configDir's path relative to $HOME. Hardcoding
+  // `.${agentId}` broke for nested configDirs like Antigravity
+  // (`~/.gemini/antigravity-cli`) — the destination would be `.antigravity`,
+  // mismatching the shim's expectation of `.gemini/antigravity-cli`.
+  const versionConfigDir = path.join(versionHome, path.relative(os.homedir(), configDir));
 
   if (fs.existsSync(versionConfigDir)) {
     return { success: false, skipped: true, error: `${version} already installed` };
   }
 
   try {
-    fs.mkdirSync(versionHome, { recursive: true });
+    fs.mkdirSync(path.dirname(versionConfigDir), { recursive: true });
     fs.renameSync(configDir, versionConfigDir);
     fs.symlinkSync(versionConfigDir, configDir);
     setGlobalDefault(agentId, version);
@@ -206,6 +212,70 @@ export function importAgentBinary(
     fs.symlinkSync(binaryTarget, binaryLink);
 
     return { success: true, resolvedFromPath: globalPath };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}
+
+/**
+ * Register an existing installScript-based binary (Grok, Antigravity, Cursor,
+ * etc. — anything with `npmPackage: ''` and a curl/brew installer) under the
+ * managed version path. Unlike `importAgentBinary` this skips the npm
+ * package.json walk and just symlinks the resolved PATH binary directly into
+ * `{versionDir}/node_modules/.bin/{cliCommand}`. The symlink is what makes
+ * `listInstalledVersions` consider the version Managed.
+ *
+ * Layout produced:
+ *
+ *   {versionDir}/
+ *     package.json                              # marker (private, imported, from)
+ *     home/                                     # empty isolated $HOME
+ *     node_modules/.bin/{cliCommand} -> {binaryPath}
+ *
+ * For agents whose binary lookup is special-cased elsewhere (e.g. Grok's
+ * `~/.grok/downloads/`), the symlink is still created — `getBinaryPath` won't
+ * read it for those agents, but it documents provenance and lets a future
+ * refactor consolidate the binary-resolution registry.
+ */
+export function importInstallScriptBinary(
+  spec: AgentBinarySpec,
+  version: string,
+  binaryPath: string,
+  versionDir: string
+): ImportBinaryResult {
+  const binaryLink = path.join(versionDir, 'node_modules', '.bin', spec.cliCommand);
+
+  let alreadyExists = false;
+  try {
+    fs.lstatSync(binaryLink);
+    alreadyExists = true;
+  } catch {
+    /* not present */
+  }
+  if (alreadyExists) {
+    return { success: false, skipped: true, error: `${version} already installed`, resolvedFromPath: binaryPath };
+  }
+
+  if (!fs.existsSync(binaryPath)) {
+    return { success: false, error: `Binary does not exist: ${binaryPath}` };
+  }
+
+  try {
+    fs.mkdirSync(path.join(versionDir, 'home'), { recursive: true });
+    fs.mkdirSync(path.join(versionDir, 'node_modules', '.bin'), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(versionDir, 'package.json'),
+      JSON.stringify(
+        { name: `agents-${spec.agentId}-${version}`, version: '1.0.0', private: true, imported: true, from: binaryPath, installScriptBased: true },
+        null,
+        2
+      )
+    );
+
+    fs.symlinkSync(binaryPath, binaryLink);
+
+    return { success: true, resolvedFromPath: binaryPath };
   } catch (err) {
     return { success: false, error: (err as Error).message };
   }

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -32,6 +32,7 @@ import { getDefaultPermissionSet, applyPermissionsToVersion as applyPermsToVersi
 import { installMcpServers, parseMcpServerConfig } from './mcp.js';
 import { markdownToToml } from './convert.js';
 import { createVersionedAlias, removeVersionedAlias, switchConfigSymlink, getConfigSymlinkVersion, ensureClaudeInsideSymlink } from './shims.js';
+import { importInstallScriptBinary } from './import.js';
 import { listInstalledSubagents, transformSubagentForClaude, syncSubagentToOpenclaw, SUBAGENT_CAPABLE_AGENTS } from './subagents.js';
 import { WORKFLOW_CAPABLE_AGENTS, listInstalledWorkflows, syncWorkflowToVersion } from './workflows.js';
 import { parseHookManifest, registerHooksToSettings } from './hooks.js';
@@ -1270,6 +1271,32 @@ export async function installVersion(
     const versionDir = getVersionDir(agent, installedVersion);
     fs.mkdirSync(versionDir, { recursive: true });
     fs.mkdirSync(path.join(versionDir, 'home'), { recursive: true });
+
+    // Symlink the installed binary into the version's node_modules/.bin so
+    // listInstalledVersions (which checks getBinaryPath) sees this version as
+    // installed. Without this, `agents add antigravity@latest` succeeds
+    // but `agents view` shows the agent under "Not Managed" because
+    // listInstalledVersions returns [] — the installer drops the binary in
+    // ~/.local/bin (or similar) rather than the version's node_modules/.bin.
+    // Grok is special-cased in getBinaryPath itself (binary lives in
+    // ~/.grok/downloads), so we skip the symlink there.
+    if (agent !== 'grok') {
+      try {
+        const { stdout: whichOut } = await execFileAsync('which', [agentConfig.cliCommand]);
+        const installedBinary = whichOut.trim();
+        if (installedBinary && fs.existsSync(installedBinary)) {
+          importInstallScriptBinary(
+            { agentId: agent, npmPackage: agentConfig.npmPackage, cliCommand: agentConfig.cliCommand },
+            installedVersion,
+            installedBinary,
+            versionDir
+          );
+        }
+      } catch {
+        /* binary missing from PATH — install script failed silently; surface via the existing version.install error path below isn't possible here since the script returned 0. Leave the version dir empty so getBinaryPath check correctly reports it uninstalled. */
+      }
+    }
+
     createVersionedAlias(agent, installedVersion);
     emit('version.install', { agent, version: installedVersion });
     return { success: true, installedVersion };


### PR DESCRIPTION
## Summary

Brings Grok and Antigravity (and the install path for Cursor) into "Installed Agent CLIs" so `agents view` no longer reports them under "Not Managed by Agents CLI" once adopted. Closes three independent bugs that were blocking the seven-priority-agents experience.

### Bugs fixed

1. **`agents import` refused installScript-based agents.** A hard `!agent.npmPackage` gate in `src/commands/import.ts` rejected Grok, Antigravity, Cursor, Kiro, Goose, and Roo at the door. There was no adoption path for an existing global install — users had to re-run the curl script via `agents add`, which suffered from bug #3.
2. **`importAgentConfig` hardcoded the destination as `.${agentId}`.** Worked for `.openclaw` → `.openclaw`, broke for nested configDirs like Antigravity's `~/.gemini/antigravity-cli`. Now mirrors the shim's own derivation in `generateShimScript`: `path.relative(os.homedir(), agent.configDir)`.
3. **`installVersion`'s installScript branch never wired the binary into the version dir.** Created `versionDir/home/` and a versioned alias but skipped the symlink farm under `node_modules/.bin/`. `listInstalledVersions` filters by `fs.existsSync(getBinaryPath(...))`, so the version was invisible — pushing the agent permanently into "Not Managed" even after a successful `agents add`.

### Polish

- `getCachedVersionForBinary` no longer persists `null` version results. A transient `--version` failure was being cached forever, blocking every subsequent probe even after the binary started working. (This briefly broke `agents import antigravity` until the cache entry was hand-cleared during testing.)
- `agents view` surfaces an `Adopt: agents import <agent>` hint for installScript-based agents in the "Not Managed" section, matching the existing `Manage: agents add <agent>@<ver>` hint for npm agents.
- New `importInstallScriptBinary` helper in `src/lib/import.ts`, used by both the import command and `installVersion`. Writes a marker `package.json` with `installScriptBased: true` for provenance.

### Files

```
src/commands/import.ts           | 137 +++++++++++++++++++++++++++------------
src/commands/view.ts             |   4 ++
src/lib/__tests__/import.test.ts |  71 +++++++++++++++++++-
src/lib/agents.ts                |  12 +++-
src/lib/import.ts                |  74 ++++++++++++++++++++-
src/lib/versions.ts              |  27 ++++++++
6 files changed, 280 insertions(+), 45 deletions(-)
```

## Test plan

- [x] `bun run test src/lib/__tests__/import.test.ts src/lib/import.test.ts src/lib/__tests__/versions.test.ts` — 32/32 pass.
- [x] `agents import antigravity -y` end-to-end:
  - Config moved to `~/.agents/.history/versions/antigravity/1.0.6/home/.gemini/antigravity-cli` (correct nested path).
  - `~/.gemini/antigravity-cli` is a symlink to that path.
  - `~/.agents/.history/versions/antigravity/1.0.6/node_modules/.bin/agy → /Users/muqsit/.local/bin/agy`.
- [x] `agents view` — Antigravity and Grok both appear under "Installed Agent CLIs" at `1.0.6 (default)` / `0.2.32 (default)`. Cursor remains under "Not Managed" (no `cursor-agent` installed on this host) with the new `Adopt:` hint.
- [x] `agents view antigravity@default` / `agents view grok@default` — resources (commands, skills) render correctly.
- [x] `~/.agents/.cache/shims/agy --version` → `1.0.6`. `~/.agents/.cache/shims/agy@1.0.6 --version` → `1.0.6`. `~/.agents/.cache/shims/grok --version` → `grok 0.2.32 (5cb5dfeb89f) [stable]`.
- [x] `agents teams create + add grok + add antigravity + add claude` — all three teammates accepted and ran in plan mode.
- [x] `agents add antigravity@latest -y` on an already-imported install — idempotent, no breakage.
- [ ] Reviewer to retest on a clean Cursor install (where `cursor-agent` is actually on PATH) to confirm `agents import cursor` adopts it via the same code path.

Pre-existing failing tests on this base (`tests/browser/*`, `tests/permissions.test.ts`, `tests/project-resources-pipeline.test.ts`, `tests/registry.test.ts`, `tests/versions.test.ts > syncResourcesToVersion`, `src/lib/__tests__/models.test.ts`, `src/lib/resources/permissions.test.ts`) are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)