### PR TITLE
perf(shims): drop foreground sync from launch hot path (~13s → ~60ms)

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -8,37 +8,13 @@
 
 import type { Command } from 'commander';
 import chalk from 'chalk';
-import {
-  buildExecCommand,
-  parseExecEnv,
-  execAgent,
-  runWithFallback,
-  AGENT_COMMANDS,
-  normalizeMode,
-  resolveMode,
-  type ExecOptions,
-  type ExecMode,
-  type ExecEffort,
-  type FallbackEntry,
-} from '../lib/exec.js';
+import type { ExecOptions, ExecMode, ExecEffort, FallbackEntry } from '../lib/exec.js';
 import type { AgentId } from '../lib/types.js';
-import { profileExists, resolveProfileForRun } from '../lib/profiles.js';
 import { setHelpSections } from '../lib/help.js';
-import { readAndResolveBundleEnv, describeBundle } from '../lib/secrets/bundles.js';
-import {
-  getConfiguredRunStrategy,
-  normalizeRunStrategy,
-  resolveRunVersion,
-  RUN_STRATEGIES,
-  type RotateResult,
-} from '../lib/rotate.js';
-import { getGlobalDefault, getVersionHomePath, resolveVersion, resolveVersionAlias } from '../lib/versions.js';
-import { buildDiscoveredPlugin, loadPluginManifest, syncPluginToVersion } from '../lib/plugins.js';
-import { parseWorkflowFrontmatter, resolveWorkflowRef } from '../lib/workflows.js';
+import type { RotateResult } from '../lib/rotate.js';
+import { AGENTS } from '../lib/agents.js';
 import * as fs from 'fs';
 import * as path from 'path';
-
-const VALID_AGENTS = Object.keys(AGENT_COMMANDS);
 
 interface ExecCommandActionOptions {
   mode: ExecMode;
@@ -64,7 +40,7 @@ interface ExecCommandActionOptions {
 
 /** Type guard that narrows a string to a known AgentId. */
 function isValidAgent(agent: string): agent is AgentId {
-  return VALID_AGENTS.includes(agent);
+  return agent in AGENTS;
 }
 
 /** Build a one-line banner describing which version the strategy picked. */
@@ -171,6 +147,27 @@ export function registerRunCommand(program: Command): void {
   });
 
   runCmd.action(async (agentSpec: string, prompt: string | undefined, options: ExecCommandActionOptions) => {
+      const [
+        { buildExecCommand, parseExecEnv, execAgent, runWithFallback, normalizeMode, resolveMode },
+        { ALL_AGENT_IDS },
+        { profileExists, resolveProfileForRun },
+        { readAndResolveBundleEnv, describeBundle },
+        { getConfiguredRunStrategy, normalizeRunStrategy, resolveRunVersion, RUN_STRATEGIES },
+        { getGlobalDefault, getVersionHomePath, resolveVersionAlias },
+        { buildDiscoveredPlugin, loadPluginManifest, syncPluginToVersion },
+        { parseWorkflowFrontmatter, resolveWorkflowRef },
+      ] = await Promise.all([
+        import('../lib/exec.js'),
+        import('../lib/agents.js'),
+        import('../lib/profiles.js'),
+        import('../lib/secrets/bundles.js'),
+        import('../lib/rotate.js'),
+        import('../lib/versions.js'),
+        import('../lib/plugins.js'),
+        import('../lib/workflows.js'),
+      ]);
+      const isValidAgent = (agent: string): agent is AgentId => ALL_AGENT_IDS.includes(agent as AgentId);
+
       // Parse agent@version
       const [rawAgent, rawVersion] = agentSpec.split('@');
       let agent: AgentId;
@@ -282,7 +279,7 @@ export function registerRunCommand(program: Command): void {
         process.stderr.write(chalk.gray(`Workflow '${rawAgent}' → claude (${subagentCount} subagents)\n`));
       } else {
         console.error(chalk.red(`Unknown agent: ${rawAgent}`));
-        console.error(chalk.gray(`Available agents: ${VALID_AGENTS.join(', ')}`));
+        console.error(chalk.gray(`Available agents: ${ALL_AGENT_IDS.join(', ')}`));
         console.error(chalk.gray(`Or add a profile: agents profiles add <name>`));
         process.exit(1);
       }
@@ -431,7 +428,7 @@ export function registerRunCommand(program: Command): void {
           const [fbAgent, fbVersion] = entry.split('@');
           if (!isValidAgent(fbAgent)) {
             console.error(chalk.red(`Unknown fallback agent: ${fbAgent}`));
-            console.error(chalk.gray(`Available: ${VALID_AGENTS.join(', ')}`));
+            console.error(chalk.gray(`Available: ${ALL_AGENT_IDS.join(', ')}`));
             process.exit(1);
           }
           if (fbAgent === agent) {

--- a/src/lib/__tests__/shims.test.ts
+++ b/src/lib/__tests__/shims.test.ts
@@ -84,8 +84,8 @@ describe('addShimsToPath', () => {
 });
 
 describe('SHIM_SCHEMA_VERSION', () => {
-  it('is 14 (configDirName derived from agentConfig.configDir for nested layouts)', () => {
-    expect(SHIM_SCHEMA_VERSION).toBe(14);
+  it('is 15 (launch shims do not run foreground resource sync)', () => {
+    expect(SHIM_SCHEMA_VERSION).toBe(15);
   });
 });
 
@@ -204,10 +204,11 @@ describe('generateShimScript', () => {
     expect(script).not.toContain('required by .agents-version');
   });
 
-  it('find_project_agents_dir stops at agents.yaml or .git', () => {
+  it('does not run project resource sync on the launch hot path', () => {
     const script = generateShimScript('claude');
-    expect(script).toContain('[ -f "$dir/agents.yaml" ]');
-    expect(script).not.toContain('[ -f "$dir/.agents-version" ]');
+    expect(script).not.toContain('find_project_agents_dir');
+    expect(script).not.toContain('sync --agent "$AGENT"');
+    expect(script).not.toContain('refresh-rules --agent "$AGENT"');
   });
 
   it('includes find_latest_installed that handles semver and date-based versions', () => {
@@ -240,17 +241,17 @@ describe('generateShimScript', () => {
     expect(script).toContain('read -r _ans </dev/tty');
   });
 
-  it('uses an absolute agents-cli entrypoint for helper calls', () => {
+  it('uses an absolute agents-cli entrypoint for cold-path helper calls only', () => {
     const script = generateShimScript('codex');
     const match = script.match(/^AGENTS_BIN='([^']+)'$/m);
 
     expect(match).not.toBeNull();
     expect(path.isAbsolute(match![1])).toBe(true);
-    expect(script).toContain('"$AGENTS_BIN" refresh-rules --agent "$AGENT" --agent-version "$VERSION"');
     expect(script).toContain('"$AGENTS_BIN" use "$AGENT" "$LATEST"');
     expect(script).toContain('"$AGENTS_BIN" add "$AGENT@$VERSION" --yes');
-    expect(script).toContain('"$AGENTS_BIN" sync --agent "$AGENT" --agent-version "$VERSION" --project-dir "$PROJECT_AGENTS_DIR"');
     expect(script).not.toMatch(/^\s*agents (refresh-rules|use|add|sync)\b/m);
+    expect(script).not.toContain('"$AGENTS_BIN" refresh-rules');
+    expect(script).not.toContain('"$AGENTS_BIN" sync');
   });
 
   it('fails clearly when the embedded agents-cli entrypoint is not executable', () => {

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -212,8 +212,11 @@ async function promptConflictStrategy(
  *         instead of hardcoding `.${agent}`. Backwards-compatible for every
  *         existing agent (their configDir is `~/.{agent}`); enables nested
  *         layouts like Antigravity's `~/.gemini/antigravity-cli/`.
+ *   v15 — remove foreground resource sync / rules refresh from launch shims.
+ *         Version homes are reconciled by agents-cli management commands; the
+ *         shim hot path only resolves a version and execs the agent binary.
  */
-export const SHIM_SCHEMA_VERSION = 14;
+export const SHIM_SCHEMA_VERSION = 15;
 
 /** Internal marker string used to embed the schema version in shim scripts. */
 const SHIM_VERSION_MARKER = 'agents-shim-version:';
@@ -276,18 +279,6 @@ export GROK_HOME="$VERSION_DIR/home/.grok"
 `
           : '';
 
-  // Agents that don't natively resolve @-imports in their rules file need
-  // agents-cli to recompile when the user edits a rule/preset file. The
-  // check is fast (sha256 of ~8 small files) and skips the recompile when
-  // sources haven't changed.
-  const refreshRulesCall = !agentConfig.capabilities.rulesImports
-    ? `
-# Recompile rules if any rule/preset source has changed since last sync.
-# Fast-path check (~10-20ms) when nothing changed; full recompile only on
-# actual diff. Non-blocking failure — if the refresh errors, we still launch.
-"$AGENTS_BIN" refresh-rules --agent "$AGENT" --agent-version "$VERSION" --quiet 2>/dev/null || true
-`
-    : '';
   const launchArgs = agent === 'codex' ? ' -c check_for_update_on_startup=false' : '';
 
   return `#!/bin/bash
@@ -340,22 +331,6 @@ resolve_default_version() {
       in_agents && $0 ~ "^  " agent ":" { gsub(/.*:[[:space:]]*["'"'"']?|["'"'"']?[[:space:]]*$/, ""); print; exit }
     ' "$meta"
   fi
-}
-
-# Find project-scoped .agents directory (stop at agents.yaml or .git)
-find_project_agents_dir() {
-  local dir="$PWD"
-  while [ "$dir" != "/" ]; do
-    if [ -d "$dir/.agents" ]; then
-      echo "$dir/.agents"
-      return 0
-    fi
-    if [ -f "$dir/agents.yaml" ] || [ -d "$dir/.git" ] || [ -f "$dir/.git" ]; then
-      break
-    fi
-    dir=$(dirname "$dir")
-  done
-  return 1
 }
 
 # Find the latest installed version by numeric component comparison.
@@ -509,12 +484,7 @@ if [ ! -x "$BINARY" ]; then
   fi
 fi
 
-# Sync project-scoped resources into version home if a project .agents/ is present
-PROJECT_AGENTS_DIR=$(find_project_agents_dir)
-if [ -n "$PROJECT_AGENTS_DIR" ]; then
-  "$AGENTS_BIN" sync --agent "$AGENT" --agent-version "$VERSION" --project-dir "$PROJECT_AGENTS_DIR" --quiet >/dev/null 2>&1
-fi
-${refreshRulesCall}${managedEnv}
+${managedEnv}
 
 exec "$BINARY"${launchArgs} "$@"
 `;

--- a/src/lib/versions.test.ts
+++ b/src/lib/versions.test.ts
@@ -112,6 +112,27 @@ describe('version resource sync path handling', () => {
     expect(fs.existsSync(path.join(syncedSkillDir, 'secret-link'))).toBe(false);
   });
 
+  it('skips a clean full sync after expanding persisted resource patterns', async () => {
+    const home = makeTempHome();
+
+    const skillDir = path.join(home, '.agents-system', 'skills', 'tiny');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), 'skill body', 'utf-8');
+
+    const first = runVersionSync(
+      home,
+      "syncResourcesToVersion('codex', '0.1.0', undefined, { cwd: home })"
+    ) as { skills: boolean };
+
+    const second = runVersionSync(
+      home,
+      "syncResourcesToVersion('codex', '0.1.0', undefined, { cwd: home })"
+    ) as { skills: boolean };
+
+    expect(first.skills).toBe(true);
+    expect(second.skills).toBe(false);
+  });
+
   it('does not sync project MCP servers under the default user-only MCP policy', async () => {
     const home = makeTempHome();
     const project = path.join(home, 'repo');

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1923,12 +1923,11 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
     }
   }
 
-  // Fast guard: skip the entire sync when no selection is active and nothing
-  // has changed since the last full sync. Drops steady-state cost from ~16s
-  // (unconditional file copies) to ~8-15ms (`isStale` walks the manifest's
-  // fingerprints, short-circuiting at the first mismatch). Numbers from
-  // scripts/bench-staleness.ts against a real ~50-resource project.
-  if (!selection && !options.force) {
+  // Fast guard: skip the entire sync when the caller requested a full sync and
+  // nothing has changed since the last full sync. Pattern-derived selections
+  // still count as full syncs because they are the persisted intended scope,
+  // not a one-off caller override.
+  if (!userPassedSelection && !options.force) {
     const manifest = loadManifest(agent, version);
     if (manifest && !isStale(manifest, agent, version, cwd)) {
       return { commands: false, skills: false, hooks: false, memory: [], permissions: false, mcp: [], subagents: [], plugins: [], workflows: [] };

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -370,15 +370,15 @@ describe('shims - generateShimScript', () => {
     expect(script).not.toContain('meta.yaml');
   });
 
-  test('includes project sync hook in shim', () => {
+  test('does not include foreground project sync in shim', () => {
     const script = generateShimScript('claude');
-    expect(script).toContain('find_project_agents_dir');
-    expect(script).toContain('"$AGENTS_BIN" sync --agent "$AGENT" --agent-version "$VERSION" --project-dir "$PROJECT_AGENTS_DIR"');
+    expect(script).not.toContain('find_project_agents_dir');
+    expect(script).not.toContain('"$AGENTS_BIN" sync --agent "$AGENT"');
   });
 
-  test('non-@-capable agents get a refresh-rules shim hook', () => {
+  test('non-@-capable agents do not refresh rules on the launch hot path', () => {
     const script = generateShimScript('codex');
-    expect(script).toContain('"$AGENTS_BIN" refresh-rules --agent "$AGENT" --agent-version "$VERSION"');
+    expect(script).not.toContain('"$AGENTS_BIN" refresh-rules --agent "$AGENT"');
   });
 
   test('shim does not use --version flag, which collides with the top-level CLI version flag', () => {


### PR DESCRIPTION
## Summary

The shim at `~/.agents/.cache/shims/<agent>` was spawning a foreground `agents sync --agent <agent> --agent-version <v> --project-dir <p> --quiet` on every launch — a full Node + agents-cli cold start before the agent binary `exec`. On this machine, `claude --version` took **13.44s** through the shim vs **0.036s** running the binary directly.

This commit (already authored at 675815e1) removes the sync block from `generateShimScript` and bumps `SHIM_SCHEMA_VERSION` to 15. Project-scoped resource sync + rules recompile are now handled out-of-band by management commands, not on every launch.

Measured after regenerating shims:

\`\`\`
before: claude --version  → 13.44s
after:  claude --version  →  0.057s   (~235x faster)
\`\`\`

Also tightens `syncResourcesToVersion`'s fast-guard so pattern-derived selections still count as full syncs (they're the persisted intended scope, not a one-off caller override).

## Test plan

- [x] `bun test src/lib/shims.test.ts src/lib/versions.test.ts tests/shims.test.ts` — 42 pass
- [x] Regenerated shim on disk reports `agents-shim-version: 15` and contains no `agents sync` call (`grep -c "agents.*sync" ~/.agents/.cache/shims/claude` → 0)
- [x] `claude --version` measured at ~57ms (3 trials) vs 13.44s before
- [ ] CI matrix (Node 22 + 24)
- [ ] Verify project-scoped resource changes still land via the out-of-band management path (manual: edit a project skill, run `agents sync`, launch agent)

## Session Context

[Session transcript](https://gist.github.com/muqsitnawaz/6b08a98bd9d0a1ed771d1737bd4a8082)

🤖 Generated with [Claude Code](https://claude.com/claude-code)