### PR TITLE
fix(plugins): skip outside-pointing symlinks in marketplace copy (1.20.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.20.4
+
+**Plugin marketplace sync (skip outside-pointing symlinks)**
+
+- `copyPluginToMarketplace` used `fs.cpSync(plugin.root, dest, { recursive: true, dereference: false })`, which faithfully preserved every symlink — including the ones plugin authors put at the top of their plugin source for prompt-side references (the rush plugin's `app -> ../../../rush/app`, `web -> rush/web`, `widgets -> rush/widgets`). Those targets resolve to the rush monorepo (~8.7 GB of `app/` including node_modules + .next builds, 782 MB of `web/`, plus 463 MB brand-assets). Every claude version got a full set of those symlinks in `~/.claude/plugins/marketplaces/agents-cli/plugins/rush/`. When the consumer (Claude Code, OpenClaw) discovers plugins, it walks the marketplace tree and follows those symlinks — producing multi-minute startup hangs.
+- The copy now walks the source tree and drops symlinks whose `realpath` escapes the plugin root, leaving internal symlinks intact (cpSync rewrites internal targets to absolute paths into the source tree, which the consumer still resolves correctly). One informational line per plugin lists the skipped names so plugin authors notice.
+- Existing per-version marketplace directories still hold the bloat from prior syncs; clean up with `rm` against `~/.claude/plugins/marketplaces/agents-cli/plugins/*/{app,web,widgets,*-symlinks-that-escaped}` then re-run `agents pull` or any plugin sync to re-copy with the filter.
+
 ## 1.20.3
 
 **`agents run` startup latency (stale-while-revalidate the usage probe + memoize agents.yaml)**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phnx-labs/agents-cli",
-  "version": "1.20.3",
+  "version": "1.20.4",
   "description": "One CLI for all your AI coding agents - versions, config, cloud dispatch, sessions, and teams (now with first-class Grok Build CLI support)",
   "type": "module",
   "main": "dist/index.js",

--- a/src/lib/__tests__/plugin-marketplace.test.ts
+++ b/src/lib/__tests__/plugin-marketplace.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { copyPluginToMarketplace } from '../plugin-marketplace.js';
+import type { DiscoveredPlugin } from '../types.js';
+
+/**
+ * The rush plugin has symlinks like `app -> ../../../rush/app` that point at
+ * sibling codebases the prompt-side surface wants to reference but the
+ * marketplace consumer (Claude Code, OpenClaw) walks on plugin discovery —
+ * dragging multi-GB node_modules + .next + brand-asset trees into per-version
+ * scans and producing the multi-minute startup hang the user reported on
+ * 2026-06-07. copyPluginToMarketplace must drop outside-pointing symlinks.
+ */
+
+let tmpDir = '';
+let pluginSource = '';
+let outsideTarget = '';
+let versionHome = '';
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-marketplace-test-'));
+  pluginSource = path.join(tmpDir, 'plugins', 'sample');
+  outsideTarget = path.join(tmpDir, 'sibling-monorepo');
+  versionHome = path.join(tmpDir, 'versions', 'claude', '99.99.99');
+  fs.mkdirSync(pluginSource, { recursive: true });
+  fs.mkdirSync(outsideTarget, { recursive: true });
+  fs.mkdirSync(versionHome, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makePlugin(name: string): DiscoveredPlugin {
+  // DiscoveredPlugin's full shape includes capability metadata, but
+  // copyPluginToMarketplace only reads .name + .root. Cast through unknown
+  // to keep the fixture small.
+  return { name, root: pluginSource } as unknown as DiscoveredPlugin;
+}
+
+describe('copyPluginToMarketplace', () => {
+  it('skips symlinks whose target escapes the plugin root (the rush-app bug)', () => {
+    // Plugin shape mirroring rush/: a manifest, real content under skills/,
+    // and an outside-pointing symlink at the top level.
+    fs.mkdirSync(path.join(pluginSource, '.claude-plugin'));
+    fs.writeFileSync(
+      path.join(pluginSource, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name: 'sample', version: '1.0.0' }),
+    );
+    fs.mkdirSync(path.join(pluginSource, 'skills', 'helper'), { recursive: true });
+    fs.writeFileSync(path.join(pluginSource, 'skills', 'helper', 'SKILL.md'), 'helper');
+    // Bloat target that should NOT end up in the marketplace.
+    fs.writeFileSync(path.join(outsideTarget, 'huge.bin'), Buffer.alloc(1024));
+    fs.symlinkSync(outsideTarget, path.join(pluginSource, 'app'));
+
+    const dest = copyPluginToMarketplace(makePlugin('sample'), 'claude', versionHome);
+
+    expect(fs.existsSync(dest)).toBe(true);
+    expect(fs.existsSync(path.join(dest, 'app'))).toBe(false);
+    expect(fs.existsSync(path.join(dest, 'skills', 'helper', 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(dest, '.claude-plugin', 'plugin.json'))).toBe(true);
+  });
+
+  it('preserves symlinks whose target stays inside the plugin root', () => {
+    fs.mkdirSync(path.join(pluginSource, 'skills', 'real'), { recursive: true });
+    fs.writeFileSync(path.join(pluginSource, 'skills', 'real', 'SKILL.md'), 'real skill');
+    // Relative symlink staying inside the plugin tree (e.g. an alias to a sibling skill).
+    fs.symlinkSync('real', path.join(pluginSource, 'skills', 'alias'));
+
+    const dest = copyPluginToMarketplace(makePlugin('sample'), 'claude', versionHome);
+
+    const aliasPath = path.join(dest, 'skills', 'alias');
+    const aliasStat = fs.lstatSync(aliasPath);
+    expect(aliasStat.isSymbolicLink()).toBe(true);
+    // Node's cpSync rewrites relative symlink targets to absolute paths into
+    // the SOURCE tree when preserving them — that's fine for the consumer
+    // (the original file is still readable) and proves the filter let the
+    // symlink through. The contract we care about: the symlink exists and
+    // resolves to the original content.
+    expect(fs.readFileSync(aliasPath + '/SKILL.md', 'utf-8')).toBe('real skill');
+  });
+
+  it('copies regular files and directories untouched when no symlinks are present', () => {
+    fs.mkdirSync(path.join(pluginSource, '.claude-plugin'));
+    fs.writeFileSync(
+      path.join(pluginSource, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name: 'plain', version: '0.0.1' }),
+    );
+    fs.mkdirSync(path.join(pluginSource, 'commands'));
+    fs.writeFileSync(path.join(pluginSource, 'commands', 'hello.md'), 'hello');
+    fs.mkdirSync(path.join(pluginSource, 'hooks'));
+    fs.writeFileSync(path.join(pluginSource, 'hooks', 'hooks.json'), '[]');
+
+    const dest = copyPluginToMarketplace(makePlugin('plain'), 'claude', versionHome);
+
+    expect(fs.readFileSync(path.join(dest, 'commands', 'hello.md'), 'utf-8')).toBe('hello');
+    expect(fs.readFileSync(path.join(dest, 'hooks', 'hooks.json'), 'utf-8')).toBe('[]');
+  });
+
+  it('rush-shaped fixture (3 outside symlinks at top level) stays small', () => {
+    // Recreate rush layout: top-level outside symlinks (`app`, `web`, `widgets`)
+    // plus real plugin content. If the bug regresses, the dest would equal the
+    // outside target size (bytes pulled in via dereferencing) or contain those
+    // symlinks. Either is a fail.
+    for (const name of ['app', 'web', 'widgets']) {
+      const dir = path.join(outsideTarget, name);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'large.bin'), Buffer.alloc(8 * 1024));
+      fs.symlinkSync(dir, path.join(pluginSource, name));
+    }
+    fs.mkdirSync(path.join(pluginSource, '.claude-plugin'));
+    fs.writeFileSync(
+      path.join(pluginSource, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name: 'rush-like', version: '1.0.0' }),
+    );
+    fs.writeFileSync(path.join(pluginSource, 'README.md'), '# rush-like');
+
+    const dest = copyPluginToMarketplace(makePlugin('rush-like'), 'claude', versionHome);
+
+    for (const name of ['app', 'web', 'widgets']) {
+      expect(fs.existsSync(path.join(dest, name))).toBe(false);
+    }
+    expect(fs.existsSync(path.join(dest, '.claude-plugin', 'plugin.json'))).toBe(true);
+    expect(fs.readFileSync(path.join(dest, 'README.md'), 'utf-8')).toBe('# rush-like');
+  });
+});

--- a/src/lib/plugin-marketplace.ts
+++ b/src/lib/plugin-marketplace.ts
@@ -72,6 +72,16 @@ function settingsPath(agent: AgentId, versionHome: string): string {
 /**
  * Copy plugin source into marketplace install dir.
  * Source of truth remains ~/.agents/plugins/<name>/ — this is a per-version snapshot.
+ *
+ * Symlinks pointing OUTSIDE the plugin source root are dropped. They show up
+ * when plugin authors (legitimately) link prompt-side references to sibling
+ * codebases — e.g. the rush plugin's `app -> ../../../rush/app` for @app/...
+ * autocomplete in user prompts. Faithfully copying those symlinks pollutes
+ * the marketplace with gigabytes of node_modules / .next / brand-asset video
+ * that the consumer (Claude Code, OpenClaw) then walks during plugin
+ * discovery — which is the documented cause of multi-minute startup hangs.
+ *
+ * Internal symlinks (target stays inside the plugin root) are preserved.
  */
 export function copyPluginToMarketplace(
   plugin: DiscoveredPlugin,
@@ -83,7 +93,43 @@ export function copyPluginToMarketplace(
   if (fs.existsSync(dest)) {
     fs.rmSync(dest, { recursive: true, force: true });
   }
-  fs.cpSync(plugin.root, dest, { recursive: true, dereference: false });
+
+  const sourceRealRoot = (() => {
+    try { return fs.realpathSync(plugin.root); }
+    catch { return plugin.root; }
+  })();
+  const skipped: string[] = [];
+
+  fs.cpSync(plugin.root, dest, {
+    recursive: true,
+    dereference: false,
+    filter: (src) => {
+      try {
+        const stat = fs.lstatSync(src);
+        if (!stat.isSymbolicLink()) return true;
+        const target = fs.realpathSync(src);
+        if (target === sourceRealRoot || target.startsWith(sourceRealRoot + path.sep)) {
+          return true;
+        }
+        skipped.push(path.relative(plugin.root, src) || path.basename(src));
+        return false;
+      } catch {
+        // Dangling symlink or stat failure — drop it; it can't be useful in
+        // the marketplace and would error the consumer's walk anyway.
+        skipped.push(path.relative(plugin.root, src) || path.basename(src));
+        return false;
+      }
+    },
+  });
+
+  if (skipped.length > 0) {
+    process.stderr.write(
+      `agents-cli: plugin '${plugin.name}' has ${skipped.length} symlink(s) ` +
+      `pointing outside its source root; not copied to marketplace ` +
+      `(would bloat consumer startup): ${skipped.join(', ')}\n`
+    );
+  }
+
   return dest;
 }
 


### PR DESCRIPTION
## Summary

Closes the multi-minute claude startup hang on machines that have the rush plugin (or any plugin with prompt-side reference symlinks at the top level).

`copyPluginToMarketplace` used `fs.cpSync(plugin.root, dest, { recursive: true, dereference: false })`, which preserved every symlink including ones pointing **outside** the plugin source root. The rush plugin has `app -> ../../../rush/app` (8.7 GB monorepo), `web -> rush/web` (782 MB), `widgets -> rush/widgets` — those got faithfully copied into every per-version `~/.claude/plugins/marketplaces/agents-cli/plugins/rush/`. When the consumer walks the marketplace for plugin discovery, it follows the symlinks and reads gigabytes.

The copy now drops symlinks whose `realpath` escapes the plugin root and emits one informational line per plugin listing the dropped names. Internal symlinks (target stays inside the plugin tree) are preserved.

## Test plan

- [x] 4 new tests in `src/lib/__tests__/plugin-marketplace.test.ts` — all pass
  - outside-symlink dropped (rush-app shape)
  - inside-symlink preserved + readable
  - no-symlink baseline (regular files copied untouched)
  - rush-shaped fixture with 3 top-level outside symlinks stays small
- [x] `tsc --noEmit` clean

## Cleanup note

Existing marketplaces still contain the bloat from prior syncs. After this lands, users can clean up with:

```bash
for d in ~/.agents/.history/versions/claude/*/home/.claude/plugins/marketplaces/agents-cli/plugins/*/; do
  for link in "$d"/app "$d"/web "$d"/widgets; do
    [ -L "$link" ] && rm "$link"
  done
done
```

Then `agents pull` re-syncs with the filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)