### PR TITLE
fix(tests): align with project-resource security defense + gemini perm adoption

### DIFF
--- a/src/lib/resources/permissions.test.ts
+++ b/src/lib/resources/permissions.test.ts
@@ -265,12 +265,16 @@ describe('PermissionsHandler', () => {
         allow: ['Bash(*)'],
       });
 
-      // Gemini doesn't support permissions
-      runPermissionsExpression(home, `PermissionsHandler.sync('gemini', ${JSON.stringify(versionHome)})`);
+      // Cursor doesn't support permissions (not in PERMISSIONS_CAPABLE_AGENTS).
+      // Gemini was capable as of 236b4105 — pick an agent that's still on the
+      // excluded list, otherwise this test silently flips when capability is
+      // added.
+      runPermissionsExpression(home, `PermissionsHandler.sync('cursor', ${JSON.stringify(versionHome)})`);
 
-      // No config should be written
-      const configPath = path.join(versionHome, '.gemini', 'settings.json');
-      expect(fs.existsSync(configPath)).toBe(false);
+      // No config should be written for a non-capable agent. Probe both the
+      // canonical settings file paths a capable agent would have used.
+      expect(fs.existsSync(path.join(versionHome, '.cursor', 'settings.json'))).toBe(false);
+      expect(fs.existsSync(path.join(versionHome, '.claude', 'settings.json'))).toBe(false);
     });
   });
 

--- a/tests/project-resources-pipeline.test.ts
+++ b/tests/project-resources-pipeline.test.ts
@@ -235,43 +235,46 @@ describe('project-resources: resolveResource project precedence', () => {
   });
 });
 
-describe('project-resources: syncResourcesToVersion orphan-sweep', () => {
-  // When the agent shim runs in project A (which has
-  // .agents/commands/proj-a-only.md), then later in project B (which has no
-  // .agents/), the project-A command must NOT linger in the shared version
-  // home and fire silently inside project B. This test exercises the sweep
-  // added to syncResourcesToVersion alongside the existing hooks/plugins
-  // sweeps.
-  it('removes a project command from version home after cwd moves to a project without that command', async () => {
-    const { repoRoot, siblingRoot } = setupFixture();
+describe('project-resources: syncResourcesToVersion security defense', () => {
+  // Commit 1cc35b14 (fix(security): project-resource defense) closed a
+  // threat-class: a cloned public repo could ship .agents/commands/foo.md
+  // with a harmful body, and the next `agents run` would materialize that
+  // file under the agent's prompt surface. The fix unconditionally excludes
+  // the project layer from sync for commands/skills/MCP/subagents/permissions.
+  // resolveResource still surfaces project entries for listing/inspection;
+  // only the materializing pipeline is locked down.
+  //
+  // These tests pin the defense at the sync layer. If a future change re-adds
+  // project-layer materialization without a confirm step, these assertions
+  // flip and the threat returns.
+  it('does NOT materialize a project command into version home, regardless of cwd', async () => {
+    const { repoRoot } = setupFixture();
     const { syncResourcesToVersion } = await import('../src/lib/versions.js');
+    const { resolveResource } = await import('../src/lib/resources.js');
 
-    // First sync: cwd=repoRoot. The project command `myproj` resolves and
-    // lands in the version home.
+    // Sanity: the fixture's project command resolves, so the resolver still
+    // sees it. This is the "list / inspect" path that must keep working.
+    const resolved = resolveResource('commands', 'myproj', repoRoot);
+    expect(resolved?.source).toBe('project');
+
+    // But sync must NOT plant it under the agent's prompt surface.
     syncResourcesToVersion('claude', '99.99.99', undefined, { cwd: repoRoot, force: true });
 
     const versionCmd = path.join(VERSIONS_DIR, 'claude', '99.99.99', 'home', '.claude', 'commands', 'myproj.md');
-    expect(fs.existsSync(versionCmd)).toBe(true);
-
-    // Second sync: cwd=siblingRoot. No project .agents/ → no `myproj` in the
-    // resolved set. Pre-fix: the file lingers. Post-fix: orphan sweep removes
-    // it.
-    syncResourcesToVersion('claude', '99.99.99', undefined, { cwd: siblingRoot, force: true });
-
     expect(fs.existsSync(versionCmd)).toBe(false);
   });
 
-  it('removes a project skill from version home after cwd moves to a project without that skill', async () => {
-    const { repoRoot, siblingRoot } = setupFixture();
+  it('does NOT materialize a project skill into version home, regardless of cwd', async () => {
+    const { repoRoot } = setupFixture();
     const { syncResourcesToVersion } = await import('../src/lib/versions.js');
+    const { resolveResource } = await import('../src/lib/resources.js');
+
+    const resolved = resolveResource('skills', 'myskill', repoRoot);
+    expect(resolved?.source).toBe('project');
 
     syncResourcesToVersion('claude', '99.99.99', undefined, { cwd: repoRoot, force: true });
 
     const versionSkill = path.join(VERSIONS_DIR, 'claude', '99.99.99', 'home', '.claude', 'skills', 'myskill');
-    expect(fs.existsSync(versionSkill)).toBe(true);
-
-    syncResourcesToVersion('claude', '99.99.99', undefined, { cwd: siblingRoot, force: true });
-
     expect(fs.existsSync(versionSkill)).toBe(false);
   });
 });

--- a/tests/versions.test.ts
+++ b/tests/versions.test.ts
@@ -815,11 +815,21 @@ describe('syncResourcesToVersion', () => {
       expect(fs.existsSync(path.join(commandsDir, 'nonexistent.md'))).toBe(false);
     });
 
-    it('prefers project commands over user commands when both exist', () => {
+    it('ignores project commands and uses the user/system layer (security defense)', () => {
+      // The project `.agents/commands/` layer is intentionally excluded from
+      // sync — a cloned public repo could ship a malicious command body that
+      // fires when the user invokes the slash command. See commit 1cc35b14.
+      // The resolveResource API still surfaces project commands (so `agents
+      // commands list` and friends can show them) but the sync pipeline used
+      // by the shim only materializes user/system content. This test pins
+      // that contract.
       setupCentralResources();
       const projectAgents = path.join(TEST_ROOT, 'project', '.agents');
       fs.mkdirSync(path.join(projectAgents, 'commands'), { recursive: true });
-      fs.writeFileSync(path.join(projectAgents, 'commands', 'debug.md'), '# Project debug');
+      fs.writeFileSync(
+        path.join(projectAgents, 'commands', 'debug.md'),
+        '# Project debug — must NOT land in version home'
+      );
       PROJECT_AGENTS_DIR = projectAgents;
       hoistedState.PROJECT_AGENTS_DIR = PROJECT_AGENTS_DIR;
       const versionHome = path.join(AGENTS_DIR, 'versions', 'claude', '2.0.65', 'home');
@@ -827,9 +837,14 @@ describe('syncResourcesToVersion', () => {
 
       syncResourcesToVersion('claude', '2.0.65', undefined, { projectDir: projectAgents, cwd: path.dirname(projectAgents) });
 
+      // debug.md lands because setupCentralResources() planted it in the user
+      // layer (line 701, body 'Debug things' / 'Debug prompt with $ARGUMENTS').
+      // The synced body must be the user-layer one, not the project marker —
+      // that proves the project layer was skipped.
       const commandsDir = path.join(getVersionHomePath('claude', '2.0.65'), '.claude', 'commands');
       const content = fs.readFileSync(path.join(commandsDir, 'debug.md'), 'utf-8');
-      expect(content).toContain('Project debug');
+      expect(content).toContain('Debug things');
+      expect(content).not.toContain('Project debug — must NOT land in version home');
     });
 
     it('empty selection syncs nothing', () => {


### PR DESCRIPTION
## Summary

Four tests have been asserting yesterday's contract since the May 27 security fix (`1cc35b14`) and the June Gemini permissions adoption (`236b4105`). CI on `main` has been red for 40+ commits as a result; bisect confirms none of the assertions were catching real product regressions — they're catching deliberate behavior changes.

This PR rewrites the four to assert the *new* contracts. Net: **-4 failures on main**, all of the same "stale assertion" class.

## What changed and why

### `tests/versions.test.ts` — "prefers project commands over user commands when both exist"

**Old contract:** project layer > user > system at the sync layer.

**New contract** (`src/lib/versions.ts:1857-1869`, commit `1cc35b14`):

> Commands are content that gets injected into the agent's prompt surface (slash commands, skill bodies). We intentionally do NOT pull from the project's own `.agents/commands/` directory: a cloned public repo could ship a command whose body instructs the agent to do something harmful the next time the user invokes it.

Test now pins the inverse: a project `debug.md` must NOT clobber the user `debug.md` in version home.

### `tests/project-resources-pipeline.test.ts` — the orphan-sweep pair

These checked that a project command/skill was synced to version home, then swept on cwd change. The first half is no longer true by design — project commands/skills never sync. Renamed the suite from "orphan-sweep" to "security defense" and asserts:

1. `resolveResource` still surfaces the project entry — the inspect path (`agents commands list`, `agents skills list`) stays functional.
2. `syncResourcesToVersion` does NOT materialize it under the agent's prompt surface, regardless of cwd.

### `src/lib/resources/permissions.test.ts` — "skips non-permission-capable agents"

Used `'gemini'` as the negative case. Gemini joined `PERMISSIONS_CAPABLE_AGENTS` in `236b4105`, so the test silently flipped. Swapped to `'cursor'` (still not in the list) and probe both candidate paths so the assertion is robust to the choice of agent dir. Same fix #162 applied in the sibling `tests/permissions.test.ts:749`.

## Out of scope

Main currently has 13 total test failures; this PR fixes 4. The remaining 9 (1 in `tests/permissions.test.ts`, 7 in `src/lib/agents.test.ts` MCP CLI block, 1 in `src/lib/mcp.test.ts`) are separate concerns:
- The `tests/permissions.test.ts` failure is the one #162 fixes.
- The MCP block looks like a different regression class — worth its own PR.

## Test plan

- [x] `bun run test tests/versions.test.ts tests/project-resources-pipeline.test.ts src/lib/resources/permissions.test.ts` → 121/121 passing
- [x] Full suite: 9 pre-existing failures remain, no new failures introduced
- [x] Bisect confirmed the regressions were `1cc35b14` (3 of 4) and `236b4105` (the 4th), not introduced by this PR