### PR TITLE
feat(capabilities): declare subagents/rules/workflows in agent matrix

### DIFF
--- a/docs/00-concepts.md
+++ b/docs/00-concepts.md
@@ -85,3 +85,25 @@ Each installed agent CLI version gets an isolated **version home** — a directo
 When you run `claude` (via the shim), agents-cli reads `agents.yaml`, resolves the version, and sets `HOME` to the matching version home before exec-ing the binary. The agent sees only its version-specific config — no bleed between versions.
 
 See [01-version-management.md](01-version-management.md) for install and switching details, and [02-resource-sync.md](02-resource-sync.md) for how resources are synced into version homes.
+
+---
+
+## Capability matrix
+
+`src/lib/agents.ts` is the canonical capability matrix for resource sync. Every gateable resource kind is declared per agent so prompt, sync, and staleness code can share the same source of truth.
+
+| Agent | Hooks | MCP | Permissions | Skills | Commands | Plugins | Subagents | Rules | Workflows |
+|------|-------|-----|-------------|--------|----------|---------|-----------|-------|-----------|
+| Claude | yes | yes | yes | yes | yes | yes | yes | `CLAUDE.md` | yes |
+| Codex | >= 0.116.0 | yes | no | yes | < 0.117.0 | >= 0.128.0 | no | `AGENTS.md` | no |
+| Gemini | >= 0.26.0 | yes | no | yes | yes | no | no | `GEMINI.md` | no |
+| Cursor | no | yes | no | yes | yes | no | no | `.cursorrules` | no |
+| OpenCode | no | yes | no | yes | yes | no | no | `AGENTS.md` | no |
+| OpenClaw | yes | yes | no | yes | no | yes | yes | `workspace/AGENTS.md` | no |
+| Copilot | no | yes | no | yes | yes | no | no | `AGENTS.md` | no |
+| Amp | no | yes | no | yes | yes | no | no | `AGENTS.md` | no |
+| Kiro | no | yes | no | yes | yes | no | no | `AGENTS.md` | no |
+| Goose | no | yes | no | no | no | no | no | `AGENTS.md` | no |
+| Roo Code | no | yes | no | yes | yes | no | no | `AGENTS.md` | no |
+| Antigravity | yes | yes | yes | yes | yes | yes | no | `AGENTS.md` | no |
+| Grok | yes | yes | yes | yes | no | yes | no | `AGENTS.md` | no |

--- a/src/lib/__tests__/capabilities.test.ts
+++ b/src/lib/__tests__/capabilities.test.ts
@@ -19,6 +19,11 @@ describe('supports() capability gate', () => {
       expect(supports('codex', 'hooks')).toEqual({ ok: true });
       expect(supports('gemini', 'hooks')).toEqual({ ok: true });
     });
+
+    it('returns ok for rules file object-form caps', () => {
+      expect(supports('claude', 'rules')).toEqual({ ok: true });
+      expect(supports('claude', 'rules', '1.0.0')).toEqual({ ok: true });
+    });
   });
 
   describe('codex hooks since 0.116.0', () => {

--- a/src/lib/agents.test.ts
+++ b/src/lib/agents.test.ts
@@ -4,6 +4,8 @@ import * as path from 'path';
 import { pathToFileURL } from 'url';
 import { spawnSync } from 'child_process';
 import { afterEach, describe, expect, it } from 'vitest';
+import { AGENTS } from './agents.js';
+import type { CapabilityName } from './types.js';
 
 const tempDirs: string[] = [];
 
@@ -166,5 +168,27 @@ describe('MCP CLI execution', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('skipped: agent does not support HTTP MCP registration');
+  });
+});
+
+describe('AGENTS capability matrix', () => {
+  it('declares every gateable resource capability for every agent', () => {
+    const requiredCapabilities: CapabilityName[] = [
+      'hooks',
+      'mcp',
+      'allowlist',
+      'skills',
+      'commands',
+      'plugins',
+      'subagents',
+      'rules',
+      'workflows',
+    ];
+
+    for (const [agentId, config] of Object.entries(AGENTS)) {
+      for (const capability of requiredCapabilities) {
+        expect(config.capabilities, `${agentId} missing ${capability}`).toHaveProperty(capability);
+      }
+    }
   });
 });

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -226,7 +226,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: true,
-    capabilities: { hooks: true, mcp: true, allowlist: true, skills: true, commands: true, plugins: true, modes: ['plan', 'edit', 'auto', 'skip'], rulesImports: true },
+    capabilities: { hooks: true, mcp: true, allowlist: true, skills: true, commands: true, plugins: true, subagents: true, rules: { file: 'CLAUDE.md' }, workflows: true, modes: ['plan', 'edit', 'auto', 'skip'], rulesImports: true },
   },
   // codex hooks: gated to >= 0.116.0 (introduced [features] codex_hooks flag).
   codex: {
@@ -245,7 +245,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: true,
-    capabilities: { hooks: { since: '0.116.0' }, mcp: true, allowlist: false, skills: true, commands: { until: '0.117.0' }, plugins: { since: '0.128.0' }, modes: ['plan', 'edit', 'skip'] },
+    capabilities: { hooks: { since: '0.116.0' }, mcp: true, allowlist: false, skills: true, commands: { until: '0.117.0' }, plugins: { since: '0.128.0' }, subagents: false, rules: { file: 'AGENTS.md' }, workflows: false, modes: ['plan', 'edit', 'skip'] },
   },
   gemini: {
     id: 'gemini',
@@ -264,7 +264,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     supportsHooks: true,
     nativeAgentsSkillsDir: true,
     // gemini hooks: shipped in v0.26.0 (Jan 2026); older binaries silently ignore the `hooks` key.
-    capabilities: { hooks: { since: '0.26.0' }, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, modes: ['plan', 'edit', 'skip'], rulesImports: true },
+    capabilities: { hooks: { since: '0.26.0' }, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, subagents: false, rules: { file: 'GEMINI.md' }, workflows: false, modes: ['plan', 'edit', 'skip'], rulesImports: true },
   },
   cursor: {
     id: 'cursor',
@@ -282,7 +282,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: false,
-    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, modes: ['edit', 'skip'] },
+    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, subagents: false, rules: { file: '.cursorrules' }, workflows: false, modes: ['edit', 'skip'] },
   },
   opencode: {
     id: 'opencode',
@@ -299,7 +299,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: false,
-    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, modes: ['plan', 'edit'] },
+    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, subagents: false, rules: { file: 'AGENTS.md' }, workflows: false, modes: ['plan', 'edit'] },
   },
   openclaw: {
     id: 'openclaw',
@@ -316,7 +316,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '{{ARGUMENTS}}',
     supportsHooks: true,
-    capabilities: { hooks: true, mcp: true, allowlist: false, skills: true, commands: false, plugins: true, modes: ['plan', 'edit', 'skip'] },
+    capabilities: { hooks: true, mcp: true, allowlist: false, skills: true, commands: false, plugins: true, subagents: true, rules: { file: 'workspace/AGENTS.md' }, workflows: false, modes: ['plan', 'edit', 'skip'] },
   },
   copilot: {
     id: 'copilot',
@@ -333,7 +333,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: false,
-    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, modes: ['plan', 'edit', 'auto', 'skip'] },
+    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, subagents: false, rules: { file: 'AGENTS.md' }, workflows: false, modes: ['plan', 'edit', 'auto', 'skip'] },
   },
   amp: {
     id: 'amp',
@@ -350,7 +350,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: false,
-    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, modes: ['plan', 'edit'] },
+    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, subagents: false, rules: { file: 'AGENTS.md' }, workflows: false, modes: ['plan', 'edit'] },
   },
   kiro: {
     id: 'kiro',
@@ -368,7 +368,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: false,
-    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, modes: ['edit'] },
+    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, subagents: false, rules: { file: 'AGENTS.md' }, workflows: false, modes: ['edit'] },
   },
   goose: {
     id: 'goose',
@@ -386,7 +386,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: false,
-    capabilities: { hooks: false, mcp: true, allowlist: false, skills: false, commands: false, plugins: false, modes: ['edit'] },
+    capabilities: { hooks: false, mcp: true, allowlist: false, skills: false, commands: false, plugins: false, subagents: false, rules: { file: 'AGENTS.md' }, workflows: false, modes: ['edit'] },
   },
   roo: {
     id: 'roo',
@@ -404,7 +404,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: false,
-    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, modes: ['plan', 'edit'] },
+    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, subagents: false, rules: { file: 'AGENTS.md' }, workflows: false, modes: ['plan', 'edit'] },
   },
   // Google Antigravity CLI (`agy`) — official replacement for Gemini CLI as of IO 2026.
   // configDir nests inside `~/.gemini/` since agy shares the parent dir with the Gemini
@@ -431,7 +431,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '{{args}}',
     supportsHooks: true,
-    capabilities: { hooks: true, mcp: true, allowlist: true, skills: true, commands: true, plugins: true, modes: ['edit', 'skip'], rulesImports: false },
+    capabilities: { hooks: true, mcp: true, allowlist: true, skills: true, commands: true, plugins: true, subagents: false, rules: { file: 'AGENTS.md' }, workflows: false, modes: ['edit', 'skip'], rulesImports: false },
   },
   // xAI Grok Build CLI (`grok`) — early beta, SuperGrok Heavy. Auth via OAuth on
   // first launch, or XAI_API_KEY env var for headless. MCP servers configured inline
@@ -462,6 +462,9 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
       skills: true,
       commands: false, // covered by skills
       plugins: true,
+      subagents: false,
+      rules: { file: 'AGENTS.md' },
+      workflows: false,
       modes: ['plan', 'edit', 'skip'],
       rulesImports: true,
     },

--- a/src/lib/capabilities.ts
+++ b/src/lib/capabilities.ts
@@ -14,6 +14,7 @@ import type {
   Capability,
   CapabilityName,
   CapabilityResult,
+  RulesCapability,
 } from './types.js';
 
 /**
@@ -31,7 +32,7 @@ function compareVersions(a: string, b: string): number {
   return 0;
 }
 
-function getCapability(agent: AgentId, cap: CapabilityName): Capability {
+function getCapability(agent: AgentId, cap: CapabilityName): Capability | RulesCapability {
   return AGENTS[agent].capabilities[cap];
 }
 
@@ -58,6 +59,7 @@ export function supports(
   const c = getCapability(agent, cap);
   if (c === false) return { ok: false, reason: 'unsupported' };
   if (c === true) return { ok: true };
+  if ('file' in c) return { ok: true };
 
   if (!version) return { ok: true };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,6 +45,9 @@ export interface AgentConfig {
     skills: Capability;
     commands: Capability;
     plugins: Capability;
+    subagents: Capability;
+    rules: RulesCapability;
+    workflows: Capability;
     /**
      * Permission modes this agent natively supports. Modes outside this set
      * are gated by buildExecCommand: `auto` silently degrades to `edit`,
@@ -68,8 +71,11 @@ export interface AgentConfig {
  */
 export type Capability = boolean | { since?: string; until?: string };
 
+/** Rules sync writes one composed instructions file per supported agent. */
+export type RulesCapability = false | { file: string };
+
 /** Names of every gateable capability on AgentConfig. */
-export type CapabilityName = 'hooks' | 'mcp' | 'allowlist' | 'skills' | 'commands' | 'plugins';
+export type CapabilityName = 'hooks' | 'mcp' | 'allowlist' | 'skills' | 'commands' | 'plugins' | 'subagents' | 'rules' | 'workflows';
 
 /**
  * Permission modes controlling agent autonomy.


### PR DESCRIPTION
## Summary
- PR 1 of 3 from plan `playful-stirring-hedgehog.md`.
- Extends the static agent capability matrix with `subagents`, `rules`, and `workflows`.
- Adds `RulesCapability` typing, teaches `supports()` the `{ file }` rules capability shape, and documents the matrix.
- No behavior change intended; callers consume these fields in PR 2.

## Verification
- `bun run build` exited 0. The guarded macOS app copy printed `cp: bin/Agents CLI.app: No such file or directory`.
- `bun run test src/lib/__tests__/capabilities.test.ts src/lib/agents.test.ts` passed: 2 files, 28 tests.
- `bun run test` ran 2021 tests and failed 45 existing/environment-sensitive tests, including sandbox EPERM writes under `/Users/muqsit/.agents...`, current model catalog expectations, and existing Gemini permission expectations.
- `agents view grok` resource summary matched the installed baseline: `20 commands, 1 hook, 1 rule file, 22 permission groups`.

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/bf27f5b55d2dfb9f8674ba5ea5e8defb)