### PR TITLE
feat: auto-correct single-typo agent names in agents run

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -278,10 +278,19 @@ export function registerRunCommand(program: Command): void {
           : 0;
         process.stderr.write(chalk.gray(`Workflow '${rawAgent}' → claude (${subagentCount} subagents)\n`));
       } else {
-        console.error(chalk.red(`Unknown agent: ${rawAgent}`));
-        console.error(chalk.gray(`Available agents: ${ALL_AGENT_IDS.join(', ')}`));
-        console.error(chalk.gray(`Or add a profile: agents profiles add <name>`));
-        process.exit(1);
+        // Smart pick: auto-correct a single typo (insertion/deletion/substitution/transposition)
+        // against the known agent ids before giving up. Example: `cladue` -> `claude`, `grk` -> `grok`.
+        const { fuzzyMatch, FUZZY_PRESETS } = await import('../lib/fuzzy.js');
+        const suggested = fuzzyMatch(rawAgent, ALL_AGENT_IDS, FUZZY_PRESETS.agents);
+        if (suggested && isValidAgent(suggested)) {
+          process.stderr.write(chalk.gray(`Resolved '${rawAgent}' -> '${suggested}' (single-edit match)\n`));
+          agent = suggested;
+        } else {
+          console.error(chalk.red(`Unknown agent: ${rawAgent}`));
+          console.error(chalk.gray(`Available agents: ${ALL_AGENT_IDS.join(', ')}`));
+          console.error(chalk.gray(`Or add a profile: agents profiles add <name>`));
+          process.exit(1);
+        }
       }
 
       version = resolveVersionAlias(agent, version);
@@ -437,12 +446,22 @@ export function registerRunCommand(program: Command): void {
           process.exit(1);
         }
         const entries = options.fallback.split(',').map(s => s.trim()).filter(Boolean);
+        const { fuzzyMatch: fuzzyFb, FUZZY_PRESETS: PRESETS_FB } = await import('../lib/fuzzy.js');
         for (const entry of entries) {
-          const [fbAgent, fbVersion] = entry.split('@');
-          if (!isValidAgent(fbAgent)) {
-            console.error(chalk.red(`Unknown fallback agent: ${fbAgent}`));
-            console.error(chalk.gray(`Available: ${ALL_AGENT_IDS.join(', ')}`));
-            process.exit(1);
+          const [rawFbAgent, fbVersion] = entry.split('@');
+          let fbAgent: AgentId;
+          if (isValidAgent(rawFbAgent)) {
+            fbAgent = rawFbAgent;
+          } else {
+            const suggested = fuzzyFb(rawFbAgent, ALL_AGENT_IDS, PRESETS_FB.agents);
+            if (suggested && isValidAgent(suggested)) {
+              process.stderr.write(chalk.gray(`Resolved fallback '${rawFbAgent}' -> '${suggested}' (single-edit match)\n`));
+              fbAgent = suggested;
+            } else {
+              console.error(chalk.red(`Unknown fallback agent: ${rawFbAgent}`));
+              console.error(chalk.gray(`Available: ${ALL_AGENT_IDS.join(', ')}`));
+              process.exit(1);
+            }
           }
           if (fbAgent === agent) {
             console.error(chalk.red(`Fallback cannot include the primary agent (${agent}). Rate-limit fallback only helps when switching providers.`));

--- a/src/lib/fuzzy.test.ts
+++ b/src/lib/fuzzy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { levenshtein, fuzzyMatch, FUZZY_PRESETS } from './fuzzy.js';
+import { levenshtein, damerauLevenshtein, fuzzyMatch, FUZZY_PRESETS } from './fuzzy.js';
 
 describe('levenshtein', () => {
   it('returns 0 for identical strings', () => {
@@ -19,25 +19,45 @@ describe('levenshtein', () => {
   });
 });
 
+describe('damerauLevenshtein', () => {
+  it('counts an adjacent transposition as one edit', () => {
+    expect(damerauLevenshtein('cladue', 'claude')).toBe(1);
+    expect(damerauLevenshtein('gemnii', 'gemini')).toBe(1);
+  });
+
+  it('matches levenshtein for insertion/deletion/substitution', () => {
+    expect(damerauLevenshtein('grk', 'grok')).toBe(1);
+    expect(damerauLevenshtein('claud', 'claude')).toBe(1);
+    expect(damerauLevenshtein('codx', 'codex')).toBe(1);
+  });
+
+  it('returns 0/length for trivial cases', () => {
+    expect(damerauLevenshtein('claude', 'claude')).toBe(0);
+    expect(damerauLevenshtein('', 'abc')).toBe(3);
+    expect(damerauLevenshtein('abc', '')).toBe(3);
+  });
+});
+
 describe('fuzzyMatch', () => {
-  const agents = ['claude', 'codex', 'gemini', 'cursor', 'opencode', 'openclaw', 'copilot', 'amp', 'kiro', 'goose', 'roo'];
+  const agents = ['claude', 'codex', 'gemini', 'cursor', 'opencode', 'openclaw', 'copilot', 'amp', 'kiro', 'goose', 'roo', 'antigravity', 'grok'];
 
   it('returns null for exact matches (fuzzy is for non-exact)', () => {
     expect(fuzzyMatch('claude', agents, FUZZY_PRESETS.agents)).toBeNull();
   });
 
-  it('matches common typos', () => {
-    expect(fuzzyMatch('cladue', agents, FUZZY_PRESETS.agents)).toBe('claude');
-    expect(fuzzyMatch('claud', agents, FUZZY_PRESETS.agents)).toBe('claude');
-    expect(fuzzyMatch('codx', agents, FUZZY_PRESETS.agents)).toBe('codex');
+  it('matches single-edit typos (insertion, deletion, transposition)', () => {
+    expect(fuzzyMatch('cladue', agents, FUZZY_PRESETS.agents)).toBe('claude'); // transposition
+    expect(fuzzyMatch('claud', agents, FUZZY_PRESETS.agents)).toBe('claude');  // deletion
+    expect(fuzzyMatch('codx', agents, FUZZY_PRESETS.agents)).toBe('codex');    // deletion
+    expect(fuzzyMatch('grk', agents, FUZZY_PRESETS.agents)).toBe('grok');      // insertion
+    expect(fuzzyMatch('gemni', agents, FUZZY_PRESETS.agents)).toBe('gemini');  // deletion
   });
 
-  it('returns null for ambiguous inputs', () => {
+  it('returns null for ambiguous or too-distant inputs', () => {
     expect(fuzzyMatch('co', agents, FUZZY_PRESETS.agents)).toBeNull();
-  });
-
-  it('returns null for inputs too far from any candidate', () => {
     expect(fuzzyMatch('xyz', agents, FUZZY_PRESETS.agents)).toBeNull();
+    // Two substitutions away — outside the 1-edit tolerance for agent names.
+    expect(fuzzyMatch('cladxe', agents, FUZZY_PRESETS.agents)).toBeNull();
   });
 
   it('respects maxDistance for efforts (strict)', () => {

--- a/src/lib/fuzzy.ts
+++ b/src/lib/fuzzy.ts
@@ -21,11 +21,42 @@ export function levenshtein(a: string, b: string): number {
   return dp[m][n];
 }
 
+/**
+ * Damerau-Levenshtein (optimal string alignment) distance.
+ * Counts a transposition of two adjacent characters as a single edit,
+ * so `cladue` -> `claude` is distance 1, matching the user's notion of
+ * "one misspelling."
+ */
+export function damerauLevenshtein(a: string, b: string): number {
+  const m = a.length, n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+  const dp: number[][] = Array.from({ length: m + 1 }, (_, i) =>
+    Array.from({ length: n + 1 }, (_, j) => (i === 0 ? j : j === 0 ? i : 0))
+  );
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + cost,
+      );
+      if (i > 1 && j > 1 && a[i - 1] === b[j - 2] && a[i - 2] === b[j - 1]) {
+        dp[i][j] = Math.min(dp[i][j], dp[i - 2][j - 2] + 1);
+      }
+    }
+  }
+  return dp[m][n];
+}
+
 export interface FuzzyOptions {
   /** Absolute max edit distance allowed. */
   maxDistance?: number;
   /** Max ratio of distance to input length. If set, effective threshold = min(maxDistance, floor(len * maxRatio)). */
   maxRatio?: number;
+  /** Use Damerau-Levenshtein (transposition = 1 edit) instead of plain Levenshtein. */
+  damerau?: boolean;
 }
 
 /**
@@ -37,7 +68,7 @@ export function fuzzyMatch<T extends string>(
   candidates: readonly T[],
   options: FuzzyOptions = {}
 ): T | null {
-  const { maxDistance = 2, maxRatio } = options;
+  const { maxDistance = 2, maxRatio, damerau = false } = options;
   const lower = input.toLowerCase();
 
   // Reject inputs that are too short - they're too ambiguous
@@ -48,10 +79,12 @@ export function fuzzyMatch<T extends string>(
     ? Math.min(maxDistance, Math.floor(lower.length * maxRatio))
     : maxDistance;
 
+  const distance = damerau ? damerauLevenshtein : levenshtein;
+
   // Find all candidates within threshold (excluding exact matches)
   const matches: { candidate: T; dist: number }[] = [];
   for (const candidate of candidates) {
-    const dist = levenshtein(lower, candidate.toLowerCase());
+    const dist = distance(lower, candidate.toLowerCase());
     if (dist > 0 && dist <= threshold) {
       matches.push({ candidate, dist });
     }
@@ -73,8 +106,8 @@ export function fuzzyMatch<T extends string>(
  * Based on pairwise distance analysis of candidate pools.
  */
 export const FUZZY_PRESETS = {
-  /** Agents: min pairwise dist=3 (opencode/openclaw), safe tolerance=2 */
-  agents: { maxDistance: 2 },
+  /** Agents: 1 mistype (insertion/deletion/substitution/transposition). Damerau so `cladue`->`claude` is 1. */
+  agents: { maxDistance: 1, damerau: true },
   /** Modes: plan/edit/full all at dist=4, lenient */
   modes: { maxDistance: 2 },
   /** Efforts: high/xhigh at dist=1, must be strict */


### PR DESCRIPTION
## Summary
- `agents run cladue` now auto-resolves to `claude`, `grk` to `grok`, etc., before erroring.
- Adds `damerauLevenshtein` so a single adjacent transposition counts as one edit; `cladue` -> `claude` is distance 1.
- Tightens `FUZZY_PRESETS.agents` to `{ maxDistance: 1, damerau: true }` — accepts one mistype (insert/delete/sub/transposition) and rejects anything further.
- Same correction applied to `--fallback` agent ids.

## Behavior
- `agents run cladue` -> `Resolved 'cladue' -> 'claude' (single-edit match)` then claude runs.
- `agents run grk "hi"` -> `Resolved 'grk' -> 'grok' (single-edit match)`.
- `agents run xyz` -> still errors with the original "Unknown agent" message.
- Exact matches (`agents run claude`) -> no extra noise.

## Test plan
- [x] `bun run test src/lib/fuzzy.test.ts` — 11/11 pass (added Damerau coverage + agent preset cases).
- [x] Manual end-to-end via dev install: `cladue`, `grk`, `xyz`, `claude` all behave as above.
- [x] Full suite: 2020 pass; the 2 pre-existing failures on origin/main (`tests/permissions.test.ts`, `tests/registry.test.ts`) are unrelated.