### PR TITLE
chore(keychain): bump Agents CLI.app.sha256 to match 1.20.4 published binary

### DIFF
--- a/scripts/Agents CLI.app.sha256
+++ b/scripts/Agents CLI.app.sha256
@@ -1,1 +1,1 @@
-559f155ca6bf1cde094536cc1e3ea0af27e3d11ec6fd98cb76deab170ab5b1c5  bin/Agents CLI.app/Contents/MacOS/Agents CLI
+2328fe42acff2b8b0da9ae6dd146e956ced66c83496ec60d34b26e0260fab4b6  bin/Agents CLI.app/Contents/MacOS/Agents CLI


### PR DESCRIPTION
## Summary

The parallel release of 1.20.4 rebuilt and notarized the keychain helper
(SHA `2328fe42acff…`) but the `.sha256` lock on main still pointed at 1.20.0's
`559f155ca6bf…`. Sync the lock to the published binary so audits of what
1.20.4 actually shipped against main match.

One-line change, no functional impact (the `.app` binary isn't tracked in git
and isn't shipped via this file — the .sha256 is an audit lock, not a build
input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)