### PR TITLE
refactor(layout): fold ~/.agents-system/ into ~/.agents/.system/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,13 +33,13 @@ CLI for managing AI coding agent versions, config, sessions, and cloud dispatch 
 |---|---|---|
 | `.agents/` (project root) | **Project repo** — project-specific commands, skills, hooks, rules. Scoped to this repo only. | Project maintainers |
 | `~/.agents/` | **User repo** — your resources + ALL operational state (versions, shims, sessions, agents.yaml, browser runtime). | You / CLI |
-| `~/.agents-system/` | **System repo** — npm-shipped defaults ONLY. Nothing else. | Maintainers |
+| `~/.agents/.system/` | **System repo** — npm-shipped defaults ONLY. Nothing else. | Maintainers |
 
 Resources AND `agents.yaml` resolve **project > user > system** — project-level pins override user/system.
 
 ### What lives where
 
-**System repo (`~/.agents-system/`)** — npm-shipped defaults, fully tracked:
+**System repo (`~/.agents/.system/`)** — npm-shipped defaults, fully tracked:
 ```
 commands/  hooks/  hooks.yaml  mcp/  permissions/  profiles/  rules/  skills/
 ```
@@ -94,7 +94,7 @@ src/
 
 `hooks.yaml` is a central manifest, read from system + user (user wins). Each entry has `script`, `events`, optional `timeout`, optional `matches:` predicates, optional `enabled: false` to disable a system-shipped hook from the user side. The `agents:` field is deprecated — the registrar uses the capability table to decide which agents register the hook. Predicates (`prompt_contains`, `prompt_matches`, `tool_name`, `tool_args_match`, `cwd_includes`, `project_has`, `git_dirty`) AND together at fire time.
 
-Promptcuts are hook data, not a top-level resource — `~/.agents-system/hooks/promptcuts.yaml` (defaults) and `~/.agents/hooks/promptcuts.yaml` (user) are merged by the expand-promptcuts script with user precedence.
+Promptcuts are hook data, not a top-level resource — `~/.agents/.system/hooks/promptcuts.yaml` (defaults) and `~/.agents/hooks/promptcuts.yaml` (user) are merged by the expand-promptcuts script with user precedence.
 
 ## Agent config
 

--- a/docs/00-concepts.md
+++ b/docs/00-concepts.md
@@ -25,12 +25,12 @@ Every agents-cli installation maintains two repos:
 
 | Repo | Path | Owner | Purpose |
 |------|------|-------|---------|
-| **System repo** | `~/.agents-system/` | agents-cli maintainers | Core resources and defaults shipped with every install. Updated via `npm update -g agents-cli`. |
+| **System repo** | `~/.agents/.system/` | agents-cli maintainers | Core resources and defaults shipped with every install. Updated via `npm update -g agents-cli`. |
 | **User repo** | `~/.agents/` | You | Your personal additions and overrides. Synced with `agents repo push` / `agents repo pull`. |
 
 A project can also have a local repo — drop a `.agents/` directory at the project root. Its resources apply only while you're inside that project tree.
 
-Extra repos can be registered via `agents repo add <source>`. They clone into `~/.agents-system/.repos/<alias>/` and participate in resolution after the user repo.
+Extra repos can be registered via `agents repo add <source>`. They clone into `~/.agents-<alias>/` (peer of `~/.agents/`) and participate in resolution after the user repo.
 
 ---
 
@@ -62,8 +62,8 @@ When agents-cli resolves a resource it searches four layers in order and stops a
 ```
 project (.agents/ at project root)
   └─ user (~/.agents/)
-       └─ extra repos (~/.agents-system/.repos/<alias>/)
-            └─ system (~/.agents-system/)
+       └─ extra repos (~/.agents-<alias>/)
+            └─ system (~/.agents/.system/)
 ```
 
 **Same-named resource wins at the highest layer.** A `commands/deploy.md` in your user repo overrides the system default. Everything without a name collision unions in — you get all resources from all layers, with higher layers taking precedence on conflicts.
@@ -80,7 +80,7 @@ The resolution logic lives in `src/lib/resources.ts` — `resolveResource(kind, 
 
 ## Version homes
 
-Each installed agent CLI version gets an isolated **version home** — a directory under `~/.agents-system/versions/<agent>/<version>/home/` that contains a complete config environment for that version. Syncing copies (or symlinks) the resolved resource set into the version home in the format each agent expects.
+Each installed agent CLI version gets an isolated **version home** — a directory under `~/.agents/.history/versions/<agent>/<version>/home/` that contains a complete config environment for that version. Syncing copies (or symlinks) the resolved resource set into the version home in the format each agent expects.
 
 When you run `claude` (via the shim), agents-cli reads `agents.yaml`, resolves the version, and sets `HOME` to the matching version home before exec-ing the binary. The agent sees only its version-specific config — no bleed between versions.
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -11,9 +11,11 @@ import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 
 const HOME = os.homedir();
-const SHIMS_DIR = path.join(HOME, '.agents', '.cache', 'shims');
-const SYSTEM_DIR = path.join(HOME, '.agents-system');
 const USER_DIR = path.join(HOME, '.agents');
+const SHIMS_DIR = path.join(USER_DIR, '.cache', 'shims');
+// System repo lives inside the user repo (folded in v1.21). Legacy installs at
+// ~/.agents-system/ are migrated by src/lib/migrate.ts on first CLI invocation.
+const SYSTEM_DIR = path.join(USER_DIR, '.system');
 const AGENTS_BIN = fileURLToPath(new URL('../dist/index.js', import.meta.url));
 const INSTALL_HELPER_SCRIPT = fileURLToPath(new URL('./install-helper.js', import.meta.url));
 
@@ -43,72 +45,16 @@ To complete setup, run: npx agents setup
   process.exit(0);
 }
 
-// Create directories
+// Create directories. The full migration (legacy ~/.agents-system/ fold,
+// runtime-state bucket moves, etc.) runs from src/lib/migrate.ts on the first
+// CLI invocation — we don't duplicate it here.
+fs.mkdirSync(USER_DIR, { recursive: true, mode: 0o700 });
 fs.mkdirSync(SHIMS_DIR, { recursive: true });
 fs.mkdirSync(SYSTEM_DIR, { recursive: true });
-fs.mkdirSync(USER_DIR, { recursive: true, mode: 0o700 });
 
 // Copy the signed macOS Keychain helper to a stable user path so its trusted-app
 // ACLs survive future npm publishes (which re-sign the bundle).
 installKeychainHelper();
-
-// One-shot idempotent migrations
-function runMigrations() {
-  // 1. Move agents.yaml from system to user repo
-  const src = path.join(SYSTEM_DIR, 'agents.yaml');
-  const dest = path.join(USER_DIR, 'agents.yaml');
-  if (fs.existsSync(src) && !fs.existsSync(dest)) {
-    try { fs.renameSync(src, dest); } catch { /* best-effort */ }
-  }
-
-  // 2. Delete dead prompts.json
-  const promptsJson = path.join(SYSTEM_DIR, 'prompts.json');
-  if (fs.existsSync(promptsJson)) {
-    try { fs.unlinkSync(promptsJson); } catch { /* best-effort */ }
-  }
-
-  // 3. Move legacy config.json to ~/.agents/teams/config.json
-  const configSrc = path.join(SYSTEM_DIR, 'config.json');
-  const configDest = path.join(USER_DIR, 'teams', 'config.json');
-  if (fs.existsSync(configSrc) && !fs.existsSync(configDest)) {
-    try {
-      fs.mkdirSync(path.dirname(configDest), { recursive: true });
-      fs.copyFileSync(configSrc, configDest);
-      fs.unlinkSync(configSrc);
-    } catch { /* best-effort */ }
-  }
-
-  // 4. Move installed agent versions from ~/.agents/versions/ -> ~/.agents-system/versions/
-  // Pre-split layout put binaries under the user repo. Post-split, listInstalledVersions
-  // only scans the system root, so legacy installs become invisible without this move.
-  const userVersions = path.join(USER_DIR, 'versions');
-  const sysVersions = path.join(SYSTEM_DIR, 'versions');
-  if (fs.existsSync(userVersions)) {
-    try {
-      let moved = 0;
-      let skipped = 0;
-      for (const agent of fs.readdirSync(userVersions, { withFileTypes: true })) {
-        if (!agent.isDirectory()) continue;
-        const srcAgentDir = path.join(userVersions, agent.name);
-        const dstAgentDir = path.join(sysVersions, agent.name);
-        try { fs.mkdirSync(dstAgentDir, { recursive: true }); } catch {}
-        for (const ver of fs.readdirSync(srcAgentDir, { withFileTypes: true })) {
-          if (!ver.isDirectory()) continue;
-          const src = path.join(srcAgentDir, ver.name);
-          const dst = path.join(dstAgentDir, ver.name);
-          if (fs.existsSync(dst)) { skipped++; continue; }
-          try { fs.renameSync(src, dst); moved++; } catch {}
-        }
-        try { if (fs.readdirSync(srcAgentDir).length === 0) fs.rmdirSync(srcAgentDir); } catch {}
-      }
-      try { if (fs.readdirSync(userVersions).length === 0) fs.rmdirSync(userVersions); } catch {}
-      if (moved > 0) console.log(`  Migrated ${moved} agent version dir(s) to ~/.agents-system/versions/`);
-      if (skipped > 0) console.log(`  Kept ${skipped} legacy version dir(s) at ~/.agents/versions/ (already present in system root)`);
-    } catch { /* best-effort */ }
-  }
-}
-
-runMigrations();
 
 const shellName = path.basename(process.env.SHELL || '/bin/bash');
 

--- a/scripts/sandbox.sh
+++ b/scripts/sandbox.sh
@@ -221,8 +221,8 @@ if ! command -v agents &>/dev/null; then
   sudo npm install -g @phnx-labs/agents-cli 2>/dev/null || true
 fi
 if command -v agents &>/dev/null; then
-  # First-time setup: clones ~/.agents-system (public) and provisions ~/.agents
-  if [[ ! -d ~/.agents-system ]]; then
+  # First-time setup: clones ~/.agents/.system (public) and provisions ~/.agents
+  if [[ ! -d ~/.agents/.system ]]; then
     echo "Setting up agents-cli..."
     agents setup 2>&1 | tail -3 || true
   fi

--- a/src/commands/__tests__/beta.test.ts
+++ b/src/commands/__tests__/beta.test.ts
@@ -24,8 +24,8 @@ function writeUpdateCache(home: string): void {
     JSON.stringify({ lastCheck: Date.now(), latestVersion: packageJson.version }),
     'utf-8'
   );
-  // ensureInitialized() checks for ~/.agents-system/.git to confirm setup.
-  fs.mkdirSync(path.join(home, '.agents-system', '.git'), { recursive: true });
+  // ensureInitialized() checks for ~/.agents/.system/.git to confirm setup.
+  fs.mkdirSync(path.join(home, '.agents', '.system', '.git'), { recursive: true });
 }
 
 function runAgents(args: string[], home: string) {

--- a/src/commands/__tests__/sessions.test.ts
+++ b/src/commands/__tests__/sessions.test.ts
@@ -22,8 +22,8 @@ function writeUpdateCache(tempHome: string): void {
     JSON.stringify({ lastCheck: Date.now(), latestVersion: packageJson.version }),
     'utf-8'
   );
-  // ensureInitialized() checks for ~/.agents-system/.git to confirm setup.
-  fs.mkdirSync(path.join(tempHome, '.agents-system', '.git'), { recursive: true });
+  // ensureInitialized() checks for ~/.agents/.system/.git to confirm setup.
+  fs.mkdirSync(path.join(tempHome, '.agents', '.system', '.git'), { recursive: true });
 }
 
 function writeClaudeSession(

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -147,7 +147,7 @@ Examples:
   # Codex Cloud
   agents cloud run "add auth tests" --provider codex --env env_abc123
 
-  # Default provider (set in ~/.agents-system/agents.yaml)
+  # Default provider (set in ~/.agents/agents.yaml)
   agents cloud run "refactor auth module" --repo user/repo
 `)
     .action(async (positionalPrompt: string | undefined, options: Record<string, unknown>) => {

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -138,7 +138,7 @@ function printCatalog(agent: AgentId, version: string, isDefault: boolean, optio
   const src = locateModelSource(agent, version);
   if (!src) {
     console.log(chalk.yellow(`  Could not locate model source for ${agent}@${version}.`));
-        console.log(chalk.gray(`  Expected the agent's CLI bundle or native binary under ~/.agents-system/versions/${agent}/${version}/.`));
+        console.log(chalk.gray(`  Expected the agent's CLI bundle or native binary under ~/.agents/.history/versions/${agent}/${version}/.`));
     return;
   }
 

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -2,7 +2,7 @@
  * Config pull command.
  *
  * Registers the `agents pull` command which clones or updates the
- * system ~/.agents-system/ git repo and syncs CLI versions, MCP servers,
+ * system ~/.agents/.system/ git repo and syncs CLI versions, MCP servers,
  * resources, and hooks to installed agent versions.
  */
 
@@ -80,7 +80,7 @@ import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
 
 /**
  * Old repo layout stored promptcuts under claude/promptcuts.yaml (agent-scoped).
- * The new layout is ~/.agents-system/promptcuts.yaml at the repo root — the hook
+ * The new layout is ~/.agents/.system/promptcuts.yaml at the repo root — the hook
  * reads from a fixed path so it survives version upgrades. If the root file
  * doesn't exist yet but an agent-scoped one does, hoist the first one found.
  */
@@ -113,7 +113,7 @@ export function registerPullCommand(program: Command): void {
 
   setHelpSections(pullCmd, {
     examples: `
-      # First time: clone the system repo into ~/.agents-system/
+      # First time: clone the system repo into ~/.agents/.system/
       agents pull
 
       # Sync only one agent's config
@@ -215,7 +215,7 @@ export function registerPullCommand(program: Command): void {
 
         // One-time migration: promptcuts.yaml moved from agent-scoped
         // (e.g. claude/promptcuts.yaml) to repo root. We move it so the
-        // hook at ~/.agents-system/hooks/ can always find it at a fixed path.
+        // hook at ~/.agents/.system/hooks/ can always find it at a fixed path.
         migratePromptcutsToRoot(agentsDir);
 
         // Read manifest for CLI versions and MCP config

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -2,7 +2,7 @@
  * Extra DotAgent repo management.
  *
  * Registers `agents repo add|init|list|remove|enable|disable` which manage
- * additional DotAgent repos alongside the primary ~/.agents-system/ repo so
+ * additional DotAgent repos alongside the primary ~/.agents/.system/ repo so
  * private, work, or team skills can ship separately from public ones.
  *
  * Extras are user-level config: managed clones live at ~/.agents-<alias>/ as
@@ -314,7 +314,7 @@ export function registerRepoCommands(program: Command): void {
           ? chalk.yellow('not a git repo — run: agents setup')
           : chalk.green('cloned');
       const systemCommitLabel = systemCommit ? chalk.gray(`(${systemCommit})`) : '';
-      console.log(chalk.bold('System  (~/.agents-system/)'));
+      console.log(chalk.bold('System  (~/.agents/.system/)'));
       console.log(`  ${chalk.cyan('system'.padEnd(12))}  ${systemUrl}  ${systemStatus}  ${systemCommitLabel}`);
 
       // User repo
@@ -415,7 +415,7 @@ export function registerRepoCommands(program: Command): void {
 
   repoCmd
     .command('pull [alias]')
-    .description('Pull updates. Aliases: "system" (~/.agents-system/), "user" (~/.agents/), or any registered extra. No arg pulls all.')
+    .description('Pull updates. Aliases: "system" (~/.agents/.system/), "user" (~/.agents/), or any registered extra. No arg pulls all.')
     .action(async (alias: string | undefined) => {
       const targets = collectRepoTargets(alias);
       if (!targets) {

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -643,7 +643,7 @@ Examples:
         }
         const presets = Array.from(presetSet).sort();
         if (presets.length === 0) {
-          console.log(chalk.red('No presets found. Define presets in ~/.agents-system/rules/rules.yaml or ~/.agents/rules/rules.yaml.'));
+          console.log(chalk.red('No presets found. Define presets in ~/.agents/.system/rules/rules.yaml or ~/.agents/rules/rules.yaml.'));
           process.exit(1);
         }
 

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -2,7 +2,7 @@
  * First-run setup command.
  *
  * Registers the `agents setup` command which clones the system repo into
- * ~/.agents-system/ and installs agent CLIs with resource syncing.
+ * ~/.agents/.system/ and installs agent CLIs with resource syncing.
  */
 
 import type { Command } from 'commander';
@@ -65,13 +65,13 @@ async function importAgent(agentId: AgentId, version: string): Promise<{ success
   }
 }
 
-/** First-run setup. Clones ~/.agents-system/ from the system repo if needed. */
+/** First-run setup. Clones ~/.agents/.system/ from the system repo if needed. */
 export async function runSetup(program: Command, options: { force?: boolean; suppressFooter?: boolean; systemRepo?: boolean } = {}): Promise<void> {
   const agentsDir = getAgentsDir();
   const alreadyConfigured = isGitRepo(agentsDir);
 
   if (alreadyConfigured && !options.force) {
-    console.log(chalk.gray('~/.agents-system/ is already set up.'));
+    console.log(chalk.gray('~/.agents/.system/ is already set up.'));
     console.log(chalk.gray('\nTo sync updates:      agents repo pull system'));
     console.log(chalk.gray('To re-run setup:      agents setup --force'));
     return;
@@ -91,9 +91,9 @@ export async function runSetup(program: Command, options: { force?: boolean; sup
   if (options.systemRepo === false) {
     ensureAgentsDir();
     console.log(chalk.gray('Skipping system repo clone (--no-system-repo).'));
-    console.log(chalk.gray(`Populate ~/.agents-system/ yourself before running other commands that depend on it.\n`));
+    console.log(chalk.gray(`Populate ~/.agents/.system/ yourself before running other commands that depend on it.\n`));
   } else {
-    console.log(chalk.gray(`Cloning the system repo from ${systemRepoSlug(systemRepo)} into ~/.agents-system/.\n`));
+    console.log(chalk.gray(`Cloning the system repo from ${systemRepoSlug(systemRepo)} into ~/.agents/.system/.\n`));
 
     ensureAgentsDir();
 
@@ -200,7 +200,7 @@ export async function runSetup(program: Command, options: { force?: boolean; sup
 
 /**
  * Ensure the system repo exists before running a command that needs it.
- * If ~/.agents-system/ is not a git repo AND we're in an interactive TTY,
+ * If ~/.agents/.system/ is not a git repo AND we're in an interactive TTY,
  * prompt the user to run setup now. In non-interactive mode, print a clear
  * error and exit.
  */
@@ -232,20 +232,20 @@ export function registerSetupCommand(program: Command): void {
   const setupCmd = program
     .command('setup')
     .description('First-time setup. Clones a config repo and installs agent CLIs.')
-    .option('-f, --force', 'Re-run setup even if ~/.agents-system/ already exists (use with caution)')
-    .option('--no-system-repo', 'Skip cloning the system repo (you must populate ~/.agents-system/ yourself)');
+    .option('-f, --force', 'Re-run setup even if ~/.agents/.system/ already exists (use with caution)')
+    .option('--no-system-repo', 'Skip cloning the system repo (you must populate ~/.agents/.system/ yourself)');
 
   setHelpSections(setupCmd, {
     examples: `
-      # First-time setup (clones the system repo into ~/.agents-system/)
+      # First-time setup (clones the system repo into ~/.agents/.system/)
       agents setup
 
-      # Re-run after corruption or to repair ~/.agents-system/
+      # Re-run after corruption or to repair ~/.agents/.system/
       agents setup --force
     `,
     notes: `
       What it does:
-        1. Clones the system repo into ~/.agents-system/
+        1. Clones the system repo into ~/.agents/.system/
         2. Installs agent CLIs based on agents.yaml in that repo
         3. Syncs commands, skills, hooks, and MCP servers to each version
 

--- a/src/commands/trash.ts
+++ b/src/commands/trash.ts
@@ -1,10 +1,10 @@
 /**
  * `agents trash` — list and restore soft-deleted version directories.
  *
- * `removeVersion` moves a version dir to ~/.agents-system/trash/versions/<agent>/<version>/<timestamp>/
+ * `removeVersion` moves a version dir to ~/.agents/.history/trash/versions/<agent>/<version>/<timestamp>/
  * instead of hard-deleting. These commands let the user inspect what's there
  * and put a soft-deleted version back. The trash never auto-expires; only
- * `rm -rf ~/.agents-system/trash/` removes bytes from disk.
+ * `rm -rf ~/.agents/.history/trash/` removes bytes from disk.
  */
 import type { Command } from 'commander';
 import chalk from 'chalk';
@@ -150,7 +150,7 @@ export function registerTrashCommands(program: Command): void {
 
   trash
     .command('restore <target>')
-    .description('Restore a soft-deleted version (e.g. "claude@2.1.110") back to ~/.agents-system/versions/')
+    .description('Restore a soft-deleted version (e.g. "claude@2.1.110") back to ~/.agents/.history/versions/')
     .action((target: string) => {
       const parsed = parseAgentVersion(target);
       if (!parsed) {

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -550,11 +550,11 @@ export function registerVersionsCommands(program: Command): void {
   useCmd.action(async (agentArg: string, versionArg: string | undefined, options) => {
       try {
         const skipPrompts = options.yes || !isInteractiveTerminal();
-        // Auto-pull ~/.agents-system if it's a git repo with remote (silent on success)
+        // Auto-pull ~/.agents/.system if it's a git repo with remote (silent on success)
         const agentsDir = getAgentsDir();
         const pullResult = await tryAutoPull(agentsDir);
         if (pullResult.pulled) {
-          console.log(chalk.gray('Synced ~/.agents-system from remote'));
+          console.log(chalk.gray('Synced ~/.agents/.system from remote'));
         }
 
         // Support both "claude 2.0.65" and "claude@2.0.65" formats

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,7 +184,7 @@ Diagnostics:
 
 Config sync:
   drive                           Sync session history across machines via rsync
-  pull                            Clone or pull the system repo at ~/.agents-system/
+  pull                            Clone or pull the system repo at ~/.agents/.system/
   repo init --path <dir>          Scaffold your own editable repo from a template
   repo add <path|gh:user/repo>    Merge an extra repo after the system repo
 
@@ -202,7 +202,7 @@ Options:
   -V, --version                   Show version number
   -h, --help                      Show help
 
-System config lives in ~/.agents-system/. Run 'agents <command> --help' for details.
+System config lives in ~/.agents/.system/. Run 'agents <command> --help' for details.
 `;
   }
   return originalHelpInformation();

--- a/src/lib/__tests__/doctor-diff.test.ts
+++ b/src/lib/__tests__/doctor-diff.test.ts
@@ -11,11 +11,11 @@ let projectDir: string;
 
 beforeEach(() => {
   testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-diff-test-'));
-  systemDir = path.join(testHome, '.agents-system');
   userDir = path.join(testHome, '.agents');
+  systemDir = path.join(userDir, '.system');
   projectDir = path.join(testHome, 'work');
-  fs.mkdirSync(systemDir, { recursive: true });
   fs.mkdirSync(userDir, { recursive: true });
+  fs.mkdirSync(systemDir, { recursive: true });
   fs.mkdirSync(projectDir, { recursive: true });
 
   // Avoid the migrator running and failing on a missing legacy state.

--- a/src/lib/__tests__/promptcuts-paths.test.ts
+++ b/src/lib/__tests__/promptcuts-paths.test.ts
@@ -15,9 +15,9 @@ import {
 describe('promptcuts path resolution', () => {
   const home = os.homedir();
 
-  it('system promptcuts file lives in ~/.agents-system/hooks/', () => {
+  it('system promptcuts file lives in ~/.agents/.system/hooks/', () => {
     expect(getSystemPromptcutsPath()).toBe(
-      path.join(home, '.agents-system', 'hooks', 'promptcuts.yaml')
+      path.join(home, '.agents', '.system', 'hooks', 'promptcuts.yaml')
     );
   });
 
@@ -36,7 +36,7 @@ describe('promptcuts path resolution', () => {
 
   it('neither path is at the repo root anymore', () => {
     expect(getSystemPromptcutsPath()).not.toBe(
-      path.join(home, '.agents-system', 'promptcuts.yaml')
+      path.join(home, '.agents', '.system', 'promptcuts.yaml')
     );
     expect(getUserPromptcutsPath()).not.toBe(
       path.join(home, '.agents', 'promptcuts.yaml')

--- a/src/lib/__tests__/shims.test.ts
+++ b/src/lib/__tests__/shims.test.ts
@@ -191,10 +191,10 @@ describe('generateShimScript', () => {
     expect(script).toContain('agents.yaml');
   });
 
-  it('skips $HOME/.agents-system/agents.yaml when walking up', () => {
+  it('skips $HOME/.agents/agents.yaml when walking up', () => {
     const script = generateShimScript('claude');
     expect(script).toContain('user_agents_yaml');
-    expect(script).toContain('$HOME/.agents-system/agents.yaml');
+    expect(script).toContain('$HOME/.agents/agents.yaml');
     expect(script).toContain('"$candidate" != "$user_agents_yaml"');
   });
 

--- a/src/lib/__tests__/state.test.ts
+++ b/src/lib/__tests__/state.test.ts
@@ -22,8 +22,8 @@ import {
 } from '../state.js';
 
 describe('state paths', () => {
-  it('keeps system resource directories under ~/.agents-system', () => {
-    const systemRoot = path.join(os.homedir(), '.agents-system');
+  it('keeps system resource directories under ~/.agents/.system', () => {
+    const systemRoot = path.join(os.homedir(), '.agents', '.system');
 
     expect(getCommandsDir()).toBe(path.join(systemRoot, 'commands'));
     expect(getHooksDir()).toBe(path.join(systemRoot, 'hooks'));
@@ -128,7 +128,7 @@ describe('readMeta merges agents.yaml from both repos', () => {
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'state-test-'));
     userDir = path.join(testDir, '.agents');
-    systemDir = path.join(testDir, '.agents-system');
+    systemDir = path.join(userDir, '.system');
     fs.mkdirSync(userDir, { recursive: true });
     fs.mkdirSync(systemDir, { recursive: true });
   });
@@ -290,7 +290,7 @@ describe('readMeta merges agents.yaml from both repos', () => {
       import { syncBuiltinESMExports } from 'module';
 
       const targetUser = path.join(process.env.HOME, '.agents', 'agents.yaml');
-      const targetSystem = path.join(process.env.HOME, '.agents-system', 'agents.yaml');
+      const targetSystem = path.join(process.env.HOME, '.agents', '.system', 'agents.yaml');
       const originalRead = fs.readFileSync;
       let reads = 0;
       fs.readFileSync = (file, opts) => {

--- a/src/lib/auto-pull-worker.ts
+++ b/src/lib/auto-pull-worker.ts
@@ -5,7 +5,7 @@
  * For the user repo + enabled extras: `git fetch` + write a status marker the foreground
  * CLI surfaces on its next invocation.
  *
- * Per-repo lock files at ~/.agents-system/.fetch/<alias>.lock prevent concurrent fetches.
+ * Per-repo lock files at ~/.agents/.system/.fetch/<alias>.lock prevent concurrent fetches.
  * Lock mtime under 5 min => skip (another invocation already in flight).
  */
 
@@ -24,7 +24,7 @@ import { lockFilePath, statusFilePath, type FetchStatusMarker } from './auto-pul
 const LOCK_TTL_MS = 5 * 60 * 1000;
 
 /**
- * Background auto-pull of ~/.agents-system/ is off by default. When enabled it
+ * Background auto-pull of ~/.agents/.system/ is off by default. When enabled it
  * silently fast-forwards a tracked source tree that the CLI then reads as a
  * source of skills, hooks, install manifests, and commands — anyone with push
  * access to that upstream gets remote code execution on every user the next

--- a/src/lib/auto-pull.ts
+++ b/src/lib/auto-pull.ts
@@ -1,6 +1,6 @@
 /**
  * Background sync for tracked git repos:
- *   - System repo (~/.agents-system/) is read-only locally — fast-forward auto-pull is safe.
+ *   - System repo (~/.agents/.system/) is read-only locally — fast-forward auto-pull is safe.
  *   - User repo (~/.agents/) and enabled extras may have local commits, so we only
  *     `git fetch` and write a status marker. Next CLI invocation surfaces a one-line
  *     notice if upstream is ahead. Pulling is left to the user via `agents repo pull`.

--- a/src/lib/beta.ts
+++ b/src/lib/beta.ts
@@ -3,7 +3,7 @@
  *
  * Preview features live in the git-trackable user repo (~/.agents/agents.yaml)
  * when present, and otherwise fall back to the local system state file
- * (~/.agents-system/agents.yaml). This keeps opt-ins portable for users with a
+ * (~/.agents/.system/agents.yaml). This keeps opt-ins portable for users with a
  * personal agents repo without mixing them into unrelated version capability
  * checks.
  */

--- a/src/lib/commands.test.ts
+++ b/src/lib/commands.test.ts
@@ -64,7 +64,7 @@ function scaffoldInstalledVersion(home: string, agent: string, version: string):
 
 /** Place a command .md in the system commands dir so listCentralCommands() finds it. */
 function writeSystemCommand(home: string, name: string, content: string): void {
-  const dir = path.join(home, '.agents-system', 'commands');
+  const dir = path.join(home, '.agents', '.system', 'commands');
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, `${name}.md`), content, 'utf-8');
 }

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -654,7 +654,7 @@ export function installCommandCentrally(
 }
 
 /**
- * List commands from user (~/.agents/commands/) and system (~/.agents-system/commands/) dirs.
+ * List commands from user (~/.agents/commands/) and system (~/.agents/.system/commands/) dirs.
  * User dir takes priority; deduplication preserves first occurrence.
  */
 export function listCentralCommands(): string[] {

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -702,7 +702,7 @@ export async function installHooksCentrally(
 }
 
 /**
- * List hooks from user (~/.agents/hooks/) and system (~/.agents-system/hooks/) dirs.
+ * List hooks from user (~/.agents/hooks/) and system (~/.agents/.system/hooks/) dirs.
  * User dir takes priority; deduplication preserves first occurrence.
  */
 export function listCentralHooks(): HookEntry[] {
@@ -720,7 +720,7 @@ export function listCentralHooks(): HookEntry[] {
 }
 
 /**
- * Parse hook manifests. Reads system hooks from ~/.agents-system/hooks.yaml
+ * Parse hook manifests. Reads system hooks from ~/.agents/.system/hooks.yaml
  * (npm-shipped defaults) and user hooks from the `hooks:` section of
  * ~/.agents/agents.yaml. Merges with user-wins-on-key-collision precedence.
  * A user entry with `enabled: false` disables the system-shipped hook of
@@ -785,7 +785,7 @@ type CodexHooksFile = {
  * Register hooks as lifecycle events in an agent's config.
  * Reads hooks.yaml manifest, merges into the agent's config file(s).
  * Only manages hooks whose command paths are under ~/.agents/hooks/ or
- * ~/.agents-system/hooks/. Does not remove user-added hooks.
+ * ~/.agents/.system/hooks/. Does not remove user-added hooks.
  *
  * @param agentsDirOverride - When provided, treats this single dir as the
  *   only managed hook root. Used by tests to inject a temp path. In normal

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -11,10 +11,63 @@ import * as os from 'os';
 import * as yaml from 'yaml';
 
 const HOME = process.env.HOME ?? os.homedir();
-const SYSTEM_DIR = path.join(HOME, '.agents-system');
 const USER_DIR = path.join(HOME, '.agents');
+/** Canonical system-repo location (post-fold). */
+const SYSTEM_DIR = path.join(USER_DIR, '.system');
+/** Legacy system-repo location — folded into SYSTEM_DIR by foldLegacySystemRepo(). */
+const LEGACY_SYSTEM_DIR = path.join(HOME, '.agents-system');
 const HISTORY_DIR = path.join(USER_DIR, '.history');
 const CACHE_DIR = path.join(USER_DIR, '.cache');
+
+/**
+ * Fold ~/.agents-system/ into ~/.agents/.system/.
+ *
+ * MUST run first in runMigration() — every other migrator reads SYSTEM_DIR
+ * (the new path), so the contents have to be there before they execute.
+ *
+ * Strategy:
+ *   1. If legacy dir doesn't exist or is already a symlink, no-op.
+ *   2. If new path doesn't exist yet, rename in one shot (fast path).
+ *   3. If both exist (mid-migration / re-run on partially-migrated state),
+ *      merge legacy → new with new winning on collision, then drop legacy.
+ *
+ * After the contents move, the legacy path becomes a symlink → SYSTEM_DIR
+ * so external tooling that still references ~/.agents-system/ keeps
+ * resolving correctly. The symlink is harmless on its own and can be
+ * removed with `rm ~/.agents-system` once everything has updated.
+ *
+ * Idempotent: re-running converges to "contents at SYSTEM_DIR, symlink at
+ * LEGACY_SYSTEM_DIR" without duplicating data.
+ */
+function foldLegacySystemRepo(): void {
+  let legacyStat: fs.Stats | null = null;
+  try { legacyStat = fs.lstatSync(LEGACY_SYSTEM_DIR); } catch { /* missing */ }
+  if (!legacyStat) return;
+  if (legacyStat.isSymbolicLink()) return;
+  if (!legacyStat.isDirectory()) return;
+
+  try {
+    fs.mkdirSync(USER_DIR, { recursive: true, mode: 0o700 });
+  } catch { /* best-effort */ }
+
+  if (!fs.existsSync(SYSTEM_DIR)) {
+    try {
+      fs.renameSync(LEGACY_SYSTEM_DIR, SYSTEM_DIR);
+      try { fs.symlinkSync(SYSTEM_DIR, LEGACY_SYSTEM_DIR); } catch { /* best-effort */ }
+      console.error('Folded ~/.agents-system/ into ~/.agents/.system/ (left back-compat symlink)');
+      return;
+    } catch {
+      // Cross-device rename or perm issue — fall through to copy + remove.
+    }
+  }
+
+  try {
+    copyDirSkipExisting(LEGACY_SYSTEM_DIR, SYSTEM_DIR);
+    fs.rmSync(LEGACY_SYSTEM_DIR, { recursive: true, force: true });
+    try { fs.symlinkSync(SYSTEM_DIR, LEGACY_SYSTEM_DIR); } catch { /* best-effort */ }
+    console.error('Merged ~/.agents-system/ into ~/.agents/.system/ (left back-compat symlink)');
+  } catch { /* best-effort */ }
+}
 
 /**
  * Move ~/.agents-system/agents.yaml -> ~/.agents/agents.yaml.
@@ -1332,6 +1385,8 @@ function migrateVersionResourcesToPatterns(): void {
 
 /** Run all idempotent migrations. Safe to call multiple times. */
 export async function runMigration(): Promise<void> {
+  // MUST run first: every other migrator reads SYSTEM_DIR (the new path).
+  foldLegacySystemRepo();
   migrateAgentsYaml();
   deleteSystemPromptsJson();
   migrateSystemConfigJson();

--- a/src/lib/pty-client.ts
+++ b/src/lib/pty-client.ts
@@ -71,7 +71,7 @@ async function ensureServer(): Promise<void> {
     await new Promise(r => setTimeout(r, 100));
   }
 
-  throw new Error('PTY server failed to start within 5 seconds. Check ~/.agents-system/helpers/pty/logs.jsonl');
+  throw new Error('PTY server failed to start within 5 seconds. Check ~/.agents/.system/helpers/pty/logs.jsonl');
 }
 
 function getServerSpawnArgs(): { bin: string; args: string[] } {

--- a/src/lib/pty-server.ts
+++ b/src/lib/pty-server.ts
@@ -6,7 +6,7 @@
  * across multiple CLI invocations. Each session holds a real PTY (via node-pty)
  * and a headless terminal emulator (via @xterm/headless) for screen rendering.
  *
- * Protocol: newline-delimited JSON over ~/.agents-system/pty.sock
+ * Protocol: newline-delimited JSON over ~/.agents/.system/pty.sock
  */
 
 import * as net from 'net';

--- a/src/lib/resource-patterns.ts
+++ b/src/lib/resource-patterns.ts
@@ -2,7 +2,7 @@
  * Resource selection patterns for agents.yaml versions: entries.
  *
  * Pattern syntax: [!]source:name
- *   "system:*"     — all resources from ~/.agents-system/
+ *   "system:*"     — all resources from ~/.agents/.system/
  *   "user:*"       — all resources from ~/.agents/
  *   "rush:*"       — all resources from ~/.agents-rush/  (extra repo alias)
  *   "project:*"    — all resources from .agents/ in the project root

--- a/src/lib/resources/hooks.test.ts
+++ b/src/lib/resources/hooks.test.ts
@@ -27,11 +27,11 @@ import { HooksHandler } from './hooks.js';
 describe('HooksHandler', () => {
   beforeEach(() => {
     TEST_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-handler-'));
-    SYSTEM_DIR = path.join(TEST_ROOT, '.agents-system');
     USER_DIR = path.join(TEST_ROOT, '.agents');
+    SYSTEM_DIR = path.join(USER_DIR, '.system');
     PROJECT_DIR = path.join(TEST_ROOT, 'project', '.agents');
-    fs.mkdirSync(SYSTEM_DIR, { recursive: true });
     fs.mkdirSync(USER_DIR, { recursive: true });
+    fs.mkdirSync(SYSTEM_DIR, { recursive: true });
     fs.mkdirSync(PROJECT_DIR, { recursive: true });
   });
 

--- a/src/lib/resources/hooks.ts
+++ b/src/lib/resources/hooks.ts
@@ -2,7 +2,7 @@
  * HooksHandler - ResourceHandler implementation for hooks.
  *
  * Hook declarations live in:
- *   - System: ~/.agents-system/hooks.yaml (npm-shipped defaults)
+ *   - System: ~/.agents/.system/hooks.yaml (npm-shipped defaults)
  *   - User:   `hooks:` section of ~/.agents/agents.yaml
  *   - Project: <project>/.agents/hooks.yaml
  *

--- a/src/lib/resources/mcp.ts
+++ b/src/lib/resources/mcp.ts
@@ -2,7 +2,7 @@
  * MCP resource handler - lists, resolves, and syncs MCP server configs across layers.
  *
  * MCP servers are stored as YAML files in mcp/ directories:
- *   ~/.agents-system/mcp/   (system)
+ *   ~/.agents/.system/mcp/   (system)
  *   ~/.agents/mcp/          (user)
  *   .agents/mcp/            (project)
  *

--- a/src/lib/resources/permissions.test.ts
+++ b/src/lib/resources/permissions.test.ts
@@ -61,11 +61,11 @@ describe('PermissionsHandler', () => {
       const home = makeTempHome();
 
       // Create system and user directories
-      fs.mkdirSync(path.join(home, '.agents-system'), { recursive: true });
+      fs.mkdirSync(path.join(home, '.agents', '.system'), { recursive: true });
       fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
 
       // Create permissions in both layers
-      writePermissionYaml(home, '.agents-system', 'base', {
+      writePermissionYaml(home, path.join('.agents', '.system'), 'base', {
         name: 'base',
         description: 'Base permissions',
         allow: ['Bash(git *)'],
@@ -95,11 +95,11 @@ describe('PermissionsHandler', () => {
     it('user layer wins on name conflict', () => {
       const home = makeTempHome();
 
-      fs.mkdirSync(path.join(home, '.agents-system'), { recursive: true });
+      fs.mkdirSync(path.join(home, '.agents', '.system'), { recursive: true });
       fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
 
       // Same name in both layers - user should win
-      writePermissionYaml(home, '.agents-system', 'shared', {
+      writePermissionYaml(home, path.join('.agents', '.system'), 'shared', {
         name: 'shared',
         description: 'System version',
         allow: ['Bash(git *)'],
@@ -125,11 +125,11 @@ describe('PermissionsHandler', () => {
       const home = makeTempHome();
       const projectDir = makeTempHome();
 
-      fs.mkdirSync(path.join(home, '.agents-system'), { recursive: true });
+      fs.mkdirSync(path.join(home, '.agents', '.system'), { recursive: true });
       fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
       fs.mkdirSync(path.join(projectDir, '.agents'), { recursive: true });
 
-      writePermissionYaml(home, '.agents-system', 'perms', {
+      writePermissionYaml(home, path.join('.agents', '.system'), 'perms', {
         name: 'perms',
         description: 'System',
         allow: ['Read(**)'],
@@ -165,7 +165,7 @@ describe('PermissionsHandler', () => {
     it('returns null for non-existent permission', () => {
       const home = makeTempHome();
 
-      fs.mkdirSync(path.join(home, '.agents-system'), { recursive: true });
+      fs.mkdirSync(path.join(home, '.agents', '.system'), { recursive: true });
       fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
 
       const result = runPermissionsExpression(home, `PermissionsHandler.resolve('claude', 'nonexistent')`);
@@ -175,10 +175,10 @@ describe('PermissionsHandler', () => {
     it('resolves from user layer when name exists in both', () => {
       const home = makeTempHome();
 
-      fs.mkdirSync(path.join(home, '.agents-system'), { recursive: true });
+      fs.mkdirSync(path.join(home, '.agents', '.system'), { recursive: true });
       fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
 
-      writePermissionYaml(home, '.agents-system', 'dev', {
+      writePermissionYaml(home, path.join('.agents', '.system'), 'dev', {
         name: 'dev',
         description: 'System dev',
         allow: ['Bash(ls)'],
@@ -200,7 +200,7 @@ describe('PermissionsHandler', () => {
     it('supports both .yaml and .yml extensions', () => {
       const home = makeTempHome();
 
-      fs.mkdirSync(path.join(home, '.agents-system'), { recursive: true });
+      fs.mkdirSync(path.join(home, '.agents', '.system'), { recursive: true });
       fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
 
       // Write with .yml extension
@@ -224,10 +224,10 @@ describe('PermissionsHandler', () => {
       const home = makeTempHome();
       const versionHome = makeTempHome();
 
-      fs.mkdirSync(path.join(home, '.agents-system'), { recursive: true });
+      fs.mkdirSync(path.join(home, '.agents', '.system'), { recursive: true });
       fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
 
-      writePermissionYaml(home, '.agents-system', 'base', {
+      writePermissionYaml(home, path.join('.agents', '.system'), 'base', {
         name: 'base',
         allow: ['Read(**)', 'Bash(git *)'],
       });
@@ -257,7 +257,7 @@ describe('PermissionsHandler', () => {
       const home = makeTempHome();
       const versionHome = makeTempHome();
 
-      fs.mkdirSync(path.join(home, '.agents-system'), { recursive: true });
+      fs.mkdirSync(path.join(home, '.agents', '.system'), { recursive: true });
       fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
 
       writePermissionYaml(home, '.agents', 'test', {

--- a/src/lib/rotate.ts
+++ b/src/lib/rotate.ts
@@ -84,7 +84,7 @@ export function getProjectRunStrategy(agent: AgentId, startPath: string): RunStr
 /**
  * Resolve the configured strategy. Lookup order:
  *   1. project-local agents.yaml (nearest to `startPath`)
- *   2. ~/.agents-system/agents.yaml
+ *   2. ~/.agents/.system/agents.yaml
  *   3. default: `available` (use the pinned default version when healthy,
  *      otherwise fall through to a healthy account so a single rate-limited
  *      account doesn't block the run).

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -286,7 +286,6 @@ export GROK_HOME="$VERSION_DIR/home/.grok"
 # Shim for ${agentConfig.name}
 # ${SHIM_VERSION_MARKER} ${SHIM_SCHEMA_VERSION}
 
-AGENTS_SYSTEM_DIR="$HOME/.agents-system"
 AGENTS_USER_DIR="$HOME/.agents"
 AGENTS_BIN=${agentsBin}
 AGENT="${agent}"
@@ -297,10 +296,10 @@ if [ -z "$AGENTS_BIN" ] || [ ! -x "$AGENTS_BIN" ]; then
   exit 127
 fi
 
-# Find project agents.yaml walking up from cwd (skip $HOME/.agents-system/agents.yaml)
+# Find project agents.yaml walking up from cwd (skip $HOME/.agents/agents.yaml)
 find_project_version() {
   local dir="$PWD"
-  local user_agents_yaml="$AGENTS_SYSTEM_DIR/agents.yaml"
+  local user_agents_yaml="$AGENTS_USER_DIR/agents.yaml"
   while [ "$dir" != "/" ]; do
     local candidate="$dir/agents.yaml"
     if [ -f "$candidate" ] && [ "$candidate" != "$user_agents_yaml" ]; then

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -401,7 +401,7 @@ export function skillContentMatches(
 }
 
 /**
- * List skill names from user (~/.agents/skills/) and system (~/.agents-system/skills/) dirs.
+ * List skill names from user (~/.agents/skills/) and system (~/.agents/.system/skills/) dirs.
  * User dir takes priority; deduplication preserves first occurrence.
  */
 export function listCentralSkills(): string[] {

--- a/src/lib/staleness/__tests__/_fixtures.ts
+++ b/src/lib/staleness/__tests__/_fixtures.ts
@@ -2,7 +2,7 @@
  * End-to-end fixture helpers for the staleness library.
  *
  * Each test gets a temp directory acting as $HOME, with `.agents/` (user),
- * `.agents-system/` (system), and `project/.agents/` (project). The
+ * `.agents/.system/` (system), and `project/.agents/` (project). The
  * `harness()` function spawns a Bun subprocess with HOME=<tmpdir> so the
  * library resolves paths into that temp tree — no module mocking, no
  * `vi.resetModules`, just real filesystem isolation. Works under both
@@ -30,7 +30,7 @@ export interface Fixture {
 export function newFixture(prefix: string): Fixture {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), `stale-e2e-${prefix}-`));
   const userDir = path.join(home, '.agents');
-  const systemDir = path.join(home, '.agents-system');
+  const systemDir = path.join(userDir, '.system');
   const projectRoot = path.join(home, 'project');
   const projectAgents = path.join(projectRoot, '.agents');
   fs.mkdirSync(userDir, { recursive: true });

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -1,22 +1,26 @@
 /**
  * Filesystem layout and persistent state for agents-cli.
  *
- * Two roots:
- *  - ~/.agents-system/ — system repo (npm-shipped resources, read-only defaults)
- *  - ~/.agents/        — user repo (resources + agents.yaml + operational state)
+ * Single root at ~/.agents/ with three internal buckets:
  *
- * Inside ~/.agents/, top-level paths hold ONLY resources + agents.yaml.
- * Operational state lives in two sibling buckets:
- *
- *  - ~/.agents/.history/ — durable runtime data (sessions, versions, runs,
+ *   ~/.agents/           — user repo: user-authored resources + agents.yaml
+ *                          (git-tracked via `agents repo push`).
+ *   ~/.agents/.system/   — system repo: npm-shipped resources, regenerable.
+ *                          Don't hand-edit; maintained by npm install /
+ *                          `agents repo pull system`.
+ *   ~/.agents/.history/  — durable runtime data (sessions, versions, runs,
  *                          teams/agents, trash, backups). Backed up by
  *                          `agents repo push`.
- *  - ~/.agents/.cache/   — regenerable runtime data (shims, packages, helpers
+ *   ~/.agents/.cache/    — regenerable runtime data (shims, packages, helpers
  *                          for daemon/pty, terminals, cloud, drive, browser
  *                          chrome-data, logs, companion). Gitignored.
  *
  * Resolution precedence for resources: project > user > system.
  * Every module that needs a path or reads/writes agents.yaml goes through here.
+ *
+ * Legacy layout (pre-fold): system repo lived at ~/.agents-system/ as a peer
+ * of ~/.agents/. runMigration() folds it into ~/.agents/.system/ on first run
+ * and leaves a back-compat symlink at the old path.
  */
 
 import * as fs from 'fs';
@@ -31,11 +35,18 @@ const HOME = process.env.HOME ?? os.homedir();
 
 // ─── Root directories ─────────────────────────────────────────────────────────
 
-/** System repo — npm-shipped, read-only from user commands. */
-const SYSTEM_AGENTS_DIR = path.join(HOME, '.agents-system');
-
 /** User repo — user-authored resources and agents.yaml. Always-on. */
 const USER_AGENTS_DIR = path.join(HOME, '.agents');
+
+/** System repo — npm-shipped, read-only from user commands. Lives inside the user repo. */
+const SYSTEM_AGENTS_DIR = path.join(USER_AGENTS_DIR, '.system');
+
+/**
+ * Legacy system-repo location (pre-fold). Exported so the migrator can fold
+ * it into SYSTEM_AGENTS_DIR. No runtime code outside the migrator should
+ * reference this — use SYSTEM_AGENTS_DIR.
+ */
+const LEGACY_SYSTEM_AGENTS_DIR = path.join(HOME, '.agents-system');
 
 // ─── Meta file (agents.yaml lives in the user repo) ──────────────────────────
 
@@ -125,14 +136,19 @@ const META_HEADER = `# agents-cli metadata
 
 // ─── Root getters ─────────────────────────────────────────────────────────────
 
-/** Root of the system data directory (~/.agents-system/). */
+/** Root of the system data directory (~/.agents/.system/). */
 export function getAgentsDir(): string {
   return SYSTEM_AGENTS_DIR;
 }
 
-/** Root of the system data directory (~/.agents-system/). */
+/** Root of the system data directory (~/.agents/.system/). */
 export function getSystemAgentsDir(): string {
   return SYSTEM_AGENTS_DIR;
+}
+
+/** Legacy system-repo location (~/.agents-system/). Exported for migration only. */
+export function getLegacySystemAgentsDir(): string {
+  return LEGACY_SYSTEM_AGENTS_DIR;
 }
 
 /** Root of the user repo (~/.agents/). Always present after ensureAgentsDir(). */
@@ -220,7 +236,7 @@ export function getPermissionsDir(): string { return SYSTEM_PERMISSIONS_DIR; }
 /** Path to subagent definition directories — system repo. */
 export function getSubagentsDir(): string { return SYSTEM_SUBAGENTS_DIR; }
 
-/** Path to ~/.agents-system/hooks/promptcuts.yaml (system defaults). */
+/** Path to ~/.agents/.system/hooks/promptcuts.yaml (system defaults). */
 export function getPromptcutsPath(): string { return SYSTEM_PROMPTCUTS_FILE; }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -262,7 +262,7 @@ export interface InstalledSkill {
   agent: AgentId;
 }
 
-/** Git remote metadata for the ~/.agents-system/ config repository. */
+/** Git remote metadata for the ~/.agents/.system/ config repository. */
 export interface RepoInfo {
   source: string;
   branch: string;
@@ -270,7 +270,7 @@ export interface RepoInfo {
   lastSync: string;
 }
 
-/** Canonical system repo cloned into ~/.agents-system/. */
+/** Canonical system repo cloned into ~/.agents/.system/. */
 export const DEFAULT_SYSTEM_REPO = 'gh:phnx-labs/.agents-system';
 
 /** Strip the `gh:` prefix and `.git` suffix to get a GitHub `owner/repo` slug. */
@@ -409,7 +409,7 @@ export type ResourceType = 'commands' | 'skills' | 'hooks' | 'memory' | 'mcp' | 
 
 /**
  * A resource selection pattern stored in agents.yaml versions:
- *   "system:*"      — all resources from ~/.agents-system/
+ *   "system:*"      — all resources from ~/.agents/.system/
  *   "user:*"        — all resources from ~/.agents/
  *   "rush:*"        — all resources from ~/.agents-rush/  (extra repo alias)
  *   "project:*"     — all resources from .agents/ in the project root
@@ -517,7 +517,7 @@ export interface ExtraRepoConfig {
   enabled: boolean;
 }
 
-/** Top-level structure of ~/.agents-system/agents.yaml -- the CLI's persistent state. */
+/** Top-level structure of ~/.agents/.system/agents.yaml -- the CLI's persistent state. */
 export interface Meta {
   agents?: Partial<Record<AgentId, string>>;
   run?: Partial<Record<AgentId, { strategy?: RunStrategy }>>;
@@ -527,7 +527,7 @@ export interface Meta {
   registries?: Record<RegistryType, Record<string, RegistryConfig>>;
   // Per-version resource tracking
   versions?: Partial<Record<AgentId, Record<string, VersionResources>>>;
-  // Git remote source URL (when ~/.agents-system/ is a git repo)
+  // Git remote source URL (when ~/.agents/.system/ is a git repo)
   source?: string;
   /**
    * Extra DotAgent repos merged after ~/.agents/. Managed clones live as peer

--- a/src/lib/versions.test.ts
+++ b/src/lib/versions.test.ts
@@ -42,8 +42,8 @@ describe('version resource sync path handling', () => {
   it('intersects explicit resource selections with discovered resources before syncing', async () => {
     const home = makeTempHome();
 
-    fs.mkdirSync(path.join(home, '.agents-system', 'commands'), { recursive: true });
-    fs.writeFileSync(path.join(home, '.agents-system', 'commands', 'safe.md'), 'safe command', 'utf-8');
+    fs.mkdirSync(path.join(home, '.agents', '.system', 'commands'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.agents', '.system', 'commands', 'safe.md'), 'safe command', 'utf-8');
 
     const result = runVersionSync(
       home,
@@ -58,9 +58,9 @@ describe('version resource sync path handling', () => {
   it('keeps prompts for Codex 0.116.x and converts commands to generated skills for Codex 0.117.0+', async () => {
     const home = makeTempHome();
 
-    fs.mkdirSync(path.join(home, '.agents-system', 'commands'), { recursive: true });
+    fs.mkdirSync(path.join(home, '.agents', '.system', 'commands'), { recursive: true });
     fs.writeFileSync(
-      path.join(home, '.agents-system', 'commands', 'recap.md'),
+      path.join(home, '.agents', '.system', 'commands', 'recap.md'),
       ['---', 'description: Summarize the current session', '---', '', 'Recap the conversation so far.'].join('\n'),
       'utf-8'
     );
@@ -94,7 +94,7 @@ describe('version resource sync path handling', () => {
   it('does not follow symlinks inside copied skill resources', async () => {
     const home = makeTempHome();
 
-    const skillDir = path.join(home, '.agents-system', 'skills', 'leaky');
+    const skillDir = path.join(home, '.agents', '.system', 'skills', 'leaky');
     fs.mkdirSync(skillDir, { recursive: true });
     fs.writeFileSync(path.join(skillDir, 'SKILL.md'), 'skill body', 'utf-8');
     const secretPath = path.join(home, 'secret.txt');
@@ -115,7 +115,7 @@ describe('version resource sync path handling', () => {
   it('skips a clean full sync after expanding persisted resource patterns', async () => {
     const home = makeTempHome();
 
-    const skillDir = path.join(home, '.agents-system', 'skills', 'tiny');
+    const skillDir = path.join(home, '.agents', '.system', 'skills', 'tiny');
     fs.mkdirSync(skillDir, { recursive: true });
     fs.writeFileSync(path.join(skillDir, 'SKILL.md'), 'skill body', 'utf-8');
 

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -2,7 +2,7 @@
  * Version management module for agents-cli.
  *
  * Handles installing, removing, listing, and switching between agent CLI versions.
- * Each version is installed into an isolated directory under ~/.agents-system/versions/{agent}/{version}/
+ * Each version is installed into an isolated directory under ~/.agents/.system/versions/{agent}/{version}/
  * with its own HOME directory for config isolation. Resources (commands, skills, hooks, memory,
  * MCP servers, permissions, subagents, plugins) from ~/.agents/ are synced into version homes
  * via copies or conversions (not symlinks).
@@ -1410,10 +1410,10 @@ function removeInstallArtifacts(versionDir: string): void {
 }
 
 /**
- * Soft-delete a version directory by moving it to ~/.agents-system/trash/versions/.
+ * Soft-delete a version directory by moving it to ~/.agents/.system/trash/versions/.
  * Returns the trash path on success or null on failure / no source.
  *
- * Trash layout: ~/.agents-system/trash/versions/<agent>/<version>/<timestamp>/
+ * Trash layout: ~/.agents/.system/trash/versions/<agent>/<version>/<timestamp>/
  * The timestamp suffix lets a user soft-delete the same version twice (after
  * re-install) without collision and gives a chronological audit trail.
  *
@@ -1443,7 +1443,7 @@ export function softDeleteVersionDir(agent: AgentId, version: string): string | 
  * Remove a specific version of an agent.
  *
  * Soft-delete only: moves the entire version directory (including `home/`)
- * to ~/.agents-system/trash/versions/. Recoverable via `agents trash restore`.
+ * to ~/.agents/.system/trash/versions/. Recoverable via `agents trash restore`.
  * Nothing is hard-deleted.
  */
 export function removeVersion(agent: AgentId, version: string): boolean {
@@ -1594,7 +1594,7 @@ export function resolveVersionAliasLoose(agent: AgentId, raw: string | undefined
 }
 
 /**
- * Get version specified in a project-root agents.yaml (not the user ~/.agents-system/agents.yaml).
+ * Get version specified in a project-root agents.yaml (not the user ~/.agents/.system/agents.yaml).
  */
 export function getProjectVersion(agent: AgentId, startPath: string): string | null {
   const userAgentsYaml = path.join(getUserAgentsDir(), 'agents.yaml');

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -48,7 +48,7 @@ export interface DiscoveredWorkflow {
   subagentCount: number;
 }
 
-/** A workflow in central storage (~/.agents/workflows/ or ~/.agents-system/workflows/). */
+/** A workflow in central storage (~/.agents/workflows/ or ~/.agents/.system/workflows/). */
 export interface InstalledWorkflow {
   name: string;
   path: string;
@@ -193,7 +193,7 @@ export function discoverWorkflowsFromRepo(repoPath: string): DiscoveredWorkflow[
 
 /**
  * List all workflows in central storage.
- * User layer (~/.agents/workflows/) wins over system (~/.agents-system/workflows/).
+ * User layer (~/.agents/workflows/) wins over system (~/.agents/.system/workflows/).
  */
 export function listInstalledWorkflows(): Map<string, InstalledWorkflow> {
   const result = new Map<string, InstalledWorkflow>();

--- a/tests/non-interactive.test.ts
+++ b/tests/non-interactive.test.ts
@@ -12,18 +12,18 @@ const PACKAGE_VERSION = JSON.parse(
 
 function makeTempHome(): string {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-non-interactive-'));
+  // User dir: commands, agents.yaml live here
+  const userDir = path.join(home, '.agents');
+  fs.mkdirSync(userDir, { recursive: true });
   // System dir: update-check and versions live here.
   // Needs a .git dir so ensureInitialized() doesn't block commands.
-  const systemDir = path.join(home, '.agents-system');
+  const systemDir = path.join(userDir, '.system');
   fs.mkdirSync(systemDir, { recursive: true });
   fs.mkdirSync(path.join(systemDir, '.git'), { recursive: true });
   fs.writeFileSync(
     path.join(systemDir, '.update-check'),
     JSON.stringify({ lastCheck: Date.now(), latestVersion: PACKAGE_VERSION.version }),
   );
-  // User dir: commands, agents.yaml live here
-  const userDir = path.join(home, '.agents');
-  fs.mkdirSync(userDir, { recursive: true });
   return home;
 }
 


### PR DESCRIPTION
## Summary
- Single root: the system repo moves from peer dotdir `~/.agents-system/` to `~/.agents/.system/`, matching the existing `.history/` + `.cache/` discipline.
- Idempotent migration: `foldLegacySystemRepo()` runs first in `runMigration()` on next CLI invocation. Renames (fast path) or merges-then-removes, then drops a back-compat symlink at `~/.agents-system/` → `~/.agents/.system/` so external tooling that still hardcodes the legacy path keeps resolving.
- Postinstall cleanup: drops the duplicate inline `runMigrations()` block in `scripts/postinstall.js` — `src/lib/migrate.ts` already runs on every CLI command (`src/index.ts:845`), and step 4 of the inline duplicate was a stale inverted version-move that becomes destructive post-fold.

## Why
Users kept treating `~/.agents-system/` as something they should edit / git-track; the dotdir at `$HOME` invited it. Folding into the user repo as a `.system/` bucket (sibling to `.history/` and `.cache/`) makes the "don't hand-edit" signal clearer and removes a class of "which repo do I edit" confusion.

## Test plan
- [x] `bun run build` — clean
- [x] `bun run test` — 2045 passed, 0 failed (21 skipped)
- [ ] Smoke on a real machine post-merge: `~/.agents-system/` becomes a symlink → `~/.agents/.system/`, and existing shims keep resolving
- [ ] Verify pre-fold systems with extra repos at `~/.agents-<alias>/` are untouched (peer dirs, not affected)

## Touch points
- `src/lib/state.ts` — `SYSTEM_AGENTS_DIR` now `~/.agents/.system/`; added `LEGACY_SYSTEM_AGENTS_DIR` + `getLegacySystemAgentsDir()` for the migrator only
- `src/lib/migrate.ts` — `foldLegacySystemRepo()` (new), wired as first call in `runMigration()`
- `scripts/postinstall.js` — drops dead duplicate; `SYSTEM_DIR` const updated
- `src/lib/shims.ts` — fixes a pre-existing shim bug where `user_agents_yaml` was derived from `$AGENTS_SYSTEM_DIR` (wrong dir); now uses `$AGENTS_USER_DIR`
- Tests: `state.test.ts`, `promptcuts-paths.test.ts`, `non-interactive.test.ts`, `beta.test.ts`, `sessions.test.ts`, `versions.test.ts`, `doctor-diff.test.ts`, `hooks.test.ts`, `permissions.test.ts`, `shims.test.ts`, `_fixtures.ts` — fixture paths updated
- Docs: `AGENTS.md` (symlinked to CLAUDE.md), `docs/00-concepts.md` — layout description; drive-by fix on a stale extra-repos path