### PR TITLE
fix(layout): make the fold migrator actually run on upgrade installs

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -48,9 +48,16 @@ To complete setup, run: npx agents setup
 // Create directories. The full migration (legacy ~/.agents-system/ fold,
 // runtime-state bucket moves, etc.) runs from src/lib/migrate.ts on the first
 // CLI invocation — we don't duplicate it here.
+//
+// SYSTEM_DIR is intentionally NOT pre-created: if a legacy ~/.agents-system/
+// exists, the migrator's fast-path rename needs SYSTEM_DIR to be absent so it
+// can move the legacy tree in one shot (including .git). Pre-creating an empty
+// skeleton forces the slower merge path AND can leave the new dir without
+// `.git`, which makes ensureInitialized() exit "not set up" before the
+// migrator runs. The migrator + first `agents setup` create SYSTEM_DIR as
+// needed.
 fs.mkdirSync(USER_DIR, { recursive: true, mode: 0o700 });
 fs.mkdirSync(SHIMS_DIR, { recursive: true });
-fs.mkdirSync(SYSTEM_DIR, { recursive: true });
 
 // Copy the signed macOS Keychain helper to a stable user path so its trusted-app
 // ACLs survive future npm publishes (which re-sign the bundle).

--- a/src/index.ts
+++ b/src/index.ts
@@ -812,6 +812,20 @@ const helpOrVersionRequested = passedArgs.some(
   (arg) => arg === '--help' || arg === '-h' || arg === '--version' || arg === '-V',
 );
 
+// Fold legacy ~/.agents-system/ into ~/.agents/.system/ BEFORE ensureInitialized
+// runs. ensureInitialized checks for .git inside the new path; if the user is
+// upgrading from a layout where .git lives under the legacy path, the check
+// would fail and exit before the migrator ever runs. Also runs outside the
+// sentinel guard below because the sentinel was set by pre-fold releases and
+// would otherwise skip this step on every existing install. Idempotent —
+// no-ops when legacy is missing or already a symlink.
+if (process.env.AGENTS_SKIP_MIGRATION !== '1') {
+  try {
+    const { foldLegacySystemRepo } = await import('./lib/migrate.js');
+    foldLegacySystemRepo();
+  } catch { /* must never block CLI startup */ }
+}
+
 if (
   !firstRun &&
   requestedCommand &&

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -39,7 +39,7 @@ const CACHE_DIR = path.join(USER_DIR, '.cache');
  * Idempotent: re-running converges to "contents at SYSTEM_DIR, symlink at
  * LEGACY_SYSTEM_DIR" without duplicating data.
  */
-function foldLegacySystemRepo(): void {
+export function foldLegacySystemRepo(): void {
   let legacyStat: fs.Stats | null = null;
   try { legacyStat = fs.lstatSync(LEGACY_SYSTEM_DIR); } catch { /* missing */ }
   if (!legacyStat) return;


### PR DESCRIPTION
## Summary

PR #182 introduced the fold from `~/.agents-system/` → `~/.agents/.system/`, but the migrator was being **skipped on every real upgrade install** due to two compounding bugs found during post-merge verification on the author's machine.

## Bugs

1. **`ensureInitialized()` runs BEFORE the migration block in `src/index.ts`.** It checks for `.git` inside `~/.agents/.system/`. On a legacy install the `.git` still lives in `~/.agents-system/` (or postinstall pre-created an empty `.system/` skeleton with no `.git`) → `ensureInitialized` exits with `agents-cli is not set up. Run: agents setup` BEFORE the migration block runs. The fold never happens.

2. **The sentinel guard (`~/.agents/.cache/.migrated = v9`) is already set by pre-fold releases.** Even if (1) didn't fire, the fold call inside `runMigration()` is skipped because the sentinel matches the current value. Bumping the sentinel would re-run *every* migration (see issue #20), so that's not an option.

## Fix

- Call `foldLegacySystemRepo()` directly at the top of CLI startup, **before** `ensureInitialized`, and **outside** the sentinel-guarded block. The function is idempotent — early-returns when the legacy path is missing or already a symlink, so it's safe to run on every CLI invocation.
- Stop pre-creating `~/.agents/.system/` in `postinstall.js`. The empty skeleton was forcing the fold's slower merge path and creating a no-`.git` directory that broke `ensureInitialized`.

## Test plan

Verified end-to-end on the author's machine after dev-build install:

- [x] Pre-state: `~/.agents-system/` = 17M real directory; `~/.agents/.system/` = empty skeleton.
- [x] Trigger: `agents repo list` (sentinel already at `v9` from prior installs).
- [x] Output: `Merged ~/.agents-system/ into ~/.agents/.system/ (left back-compat symlink)`.
- [x] Post-state: `~/.agents-system → /Users/muqsit/.agents/.system` (symlink). `~/.agents/.system/` is 17M with `.git`.
- [x] `agents repo list` resolves through the new path: `System  (~/.agents/.system/)`.
- [x] `bun run test`: 2045 passed, 21 skipped.

Follows #182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)