### PR TITLE
test(settings): cover env/hooks/mcpServers survival through Claude writers

### DIFF
--- a/src/lib/__tests__/hooks.test.ts
+++ b/src/lib/__tests__/hooks.test.ts
@@ -533,3 +533,85 @@ describe('registerHooksToSettings - Antigravity', () => {
     expect(result.errors[0]).toContain('missing');
   });
 });
+
+describe('registerHooksToSettings - Claude', () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-test-'));
+    agentsDir = path.join(tmpDir, '.agents');
+    fs.mkdirSync(path.join(agentsDir, 'hooks'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeClaudeVersionHome(): string {
+    const home = path.join(tmpDir, 'claude-home');
+    fs.mkdirSync(path.join(home, '.claude'), { recursive: true });
+    return home;
+  }
+
+  function readClaudeSettings(home: string): Record<string, any> {
+    return JSON.parse(
+      fs.readFileSync(path.join(home, '.claude', 'settings.json'), 'utf-8')
+    );
+  }
+
+  it('preserves env, mcpServers, permissions, and custom top-level keys (regression #137)', () => {
+    const versionHome = makeClaudeVersionHome();
+    const settingsPath = path.join(versionHome, '.claude', 'settings.json');
+
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        env: { FOO: 'bar', DEBUG: 'true' },
+        mcpServers: {
+          fooServer: { command: '/bin/foo', args: ['--bar'] },
+        },
+        permissions: { allow: ['Bash(ls:*)'], deny: [] },
+        customKey: { nested: 'preserved' },
+      }, null, 2)
+    );
+
+    const scriptPath = makeScript('pre-tool.sh');
+    const manifest: Record<string, ManifestHook> = {
+      'pre-tool': { script: 'pre-tool.sh', events: ['PreToolUse'], matcher: 'Bash' },
+    };
+
+    const result = registerHooksToSettings('claude', versionHome, manifest, agentsDir);
+    expect(result.errors).toHaveLength(0);
+    expect(result.registered).toContain('pre-tool -> PreToolUse');
+
+    const settings = readClaudeSettings(versionHome);
+
+    expect(settings.env).toEqual({ FOO: 'bar', DEBUG: 'true' });
+    expect(settings.mcpServers).toEqual({
+      fooServer: { command: '/bin/foo', args: ['--bar'] },
+    });
+    expect(settings.permissions).toEqual({ allow: ['Bash(ls:*)'], deny: [] });
+    expect(settings.customKey).toEqual({ nested: 'preserved' });
+
+    expect(settings.hooks).toBeDefined();
+    expect(settings.hooks.PreToolUse).toHaveLength(1);
+    expect(settings.hooks.PreToolUse[0].matcher).toBe('Bash');
+    expect(settings.hooks.PreToolUse[0].hooks).toHaveLength(1);
+    expect(settings.hooks.PreToolUse[0].hooks[0].command).toBe(scriptPath);
+    expect(settings.hooks.PreToolUse[0].hooks[0].type).toBe('command');
+  });
+
+  it('writes hooks alongside an empty pre-existing settings.json', () => {
+    const versionHome = makeClaudeVersionHome();
+    const scriptPath = makeScript('on-prompt.sh');
+
+    const manifest: Record<string, ManifestHook> = {
+      'on-prompt': { script: 'on-prompt.sh', events: ['UserPromptSubmit'] },
+    };
+
+    const result = registerHooksToSettings('claude', versionHome, manifest, agentsDir);
+    expect(result.errors).toHaveLength(0);
+
+    const settings = readClaudeSettings(versionHome);
+    expect(settings.hooks.UserPromptSubmit).toHaveLength(1);
+    expect(settings.hooks.UserPromptSubmit[0].hooks[0].command).toBe(scriptPath);
+  });
+});

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -694,6 +694,59 @@ describe('applyPermissionsToVersion', () => {
     expect(settings.otherSetting).toBe('preserved');
   });
 
+  it('preserves env, hooks, mcpServers, and custom top-level keys (regression #137)', () => {
+    const versionHome = join(testDir, 'claude-version-survival');
+    const claudeDir = join(versionHome, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+
+    const existing = {
+      env: { FOO: 'bar', DEBUG: 'true' },
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: 'Bash',
+            hooks: [{ type: 'command', command: 'echo test' }],
+          },
+        ],
+      },
+      mcpServers: {
+        fooServer: { command: '/bin/foo', args: ['--bar'] },
+      },
+      customKey: { nested: 'preserved' },
+      permissions: { allow: ['Bash(npm *)'], deny: [] },
+    };
+    writeFileSync(join(claudeDir, 'settings.json'), JSON.stringify(existing, null, 2));
+
+    const set: PermissionSet = {
+      name: 'test',
+      allow: ['Bash(git *)'],
+      deny: ['Bash(rm *)'],
+    };
+
+    const result = applyPermissionsToVersion('claude', set, versionHome, true);
+    expect(result.success).toBe(true);
+
+    const settings = JSON.parse(readFileSync(join(claudeDir, 'settings.json'), 'utf-8'));
+
+    expect(settings.env).toEqual({ FOO: 'bar', DEBUG: 'true' });
+    expect(settings.hooks).toEqual({
+      PreToolUse: [
+        {
+          matcher: 'Bash',
+          hooks: [{ type: 'command', command: 'echo test' }],
+        },
+      ],
+    });
+    expect(settings.mcpServers).toEqual({
+      fooServer: { command: '/bin/foo', args: ['--bar'] },
+    });
+    expect(settings.customKey).toEqual({ nested: 'preserved' });
+
+    expect(settings.permissions.allow).toContain('Bash(npm *)');
+    expect(settings.permissions.allow).toContain('Bash(git *)');
+    expect(settings.permissions.deny).toContain('Bash(rm *)');
+  });
+
   it('applies OpenCode permissions to version home', () => {
     const versionHome = join(testDir, 'opencode-version-home');
     mkdirSync(versionHome, { recursive: true });


### PR DESCRIPTION
Regression coverage for #137.

The close on #137 verified the read-mutate-write pattern in writers is correct, but no test actually exercises the env-survival scenario with realistic dicts:

- `tests/permissions.test.ts:445-492` ("merges with existing permissions") reimplements the read/merge/write logic inline in the test body — it tests the test's own copy of the logic, not the production function.
- `tests/permissions.test.ts:666-694` calls the real `applyPermissionsToVersion('claude', ...)` but only asserts a placeholder `otherSetting: 'preserved'` survives — never realistic env/hooks/mcpServers dicts.
- `src/lib/__tests__/hooks.test.ts` has describe blocks for Codex (line 28) and Antigravity (line 326) but ZERO `registerHooksToSettings - Claude` coverage.

This PR adds tests that call the real exported functions with realistic env/hooks/mcpServers/customKey content and assert deep-equal survival:

- `tests/permissions.test.ts`: new test "preserves env, hooks, mcpServers, and custom top-level keys (regression #137)" — invokes `applyPermissionsToVersion('claude', ...)` against a pre-seeded settings.json and deep-equals all non-permissions keys.
- `src/lib/__tests__/hooks.test.ts`: new `describe('registerHooksToSettings - Claude', ...)` block mirroring the Codex/Antigravity structure, plus a survival test and an empty-settings test.

## Test plan
- [x] `bun run test -- tests/permissions.test.ts src/lib/__tests__/hooks.test.ts` -> 85 passed (85)

Tests-only change. No production code touched.