### PR TITLE
fix(shims): rewrite session file_paths after config-symlink backup rename

### DIFF
--- a/src/lib/session/__tests__/db.test.ts
+++ b/src/lib/session/__tests__/db.test.ts
@@ -12,7 +12,16 @@ process.env.HOME = TEST_HOME;
 
 const { getDB, getDBPath, querySessions, closeDB } = await import('../db.js');
 
+// JSONL files live under TEST_HOME so they're isolated and torn down with it.
+// querySessions filters out rows whose file_path no longer exists on disk
+// (defense against phantom rows after a config-symlink swap, see #136), so
+// every seeded row needs a real backing file.
+const SEED_FILES_DIR = path.join(TEST_HOME, 'seed-files');
+fs.mkdirSync(SEED_FILES_DIR, { recursive: true });
+
 function seed(id: string, version: string | null, timestamp: string): void {
+  const filePath = path.join(SEED_FILES_DIR, `${id}.jsonl`);
+  fs.writeFileSync(filePath, '');
   const db = getDB();
   db.prepare(`
     INSERT INTO sessions (
@@ -26,8 +35,8 @@ function seed(id: string, version: string | null, timestamp: string): void {
     version,
     timestamp,
     'agents-cli',
-    '/tmp/test',
-    `/tmp/test/${id}.jsonl`,
+    SEED_FILES_DIR,
+    filePath,
     0,
     0,
     0,

--- a/src/lib/session/db.ts
+++ b/src/lib/session/db.ts
@@ -711,10 +711,23 @@ function buildSessionWhere(options: QueryOptions): { clause: string; params: any
 export function querySessions(options: QueryOptions = {}): SessionMeta[] {
   const db = getDB();
   const { clause, params } = buildSessionWhere(options);
-  const limitClause = options.limit ? `LIMIT ${Math.max(1, Math.floor(options.limit))}` : '';
+  // When a LIMIT is in play, we still need to filter stale rows AFTER the query,
+  // so over-fetch a small buffer. Without this, a page of 50 rows where the first
+  // 5 are stale would return only 45 to the caller even when there are more.
+  const limitClause = options.limit
+    ? `LIMIT ${Math.max(1, Math.floor(options.limit)) + 16}`
+    : '';
   const sql = `SELECT * FROM sessions ${clause} ORDER BY timestamp DESC ${limitClause}`;
   const rows = db.prepare(sql).all(...params) as SessionRow[];
-  return rows.map(rowToMeta);
+  // Belt-and-suspenders: drop rows whose JSONL no longer exists on disk. The
+  // authoritative fix is to keep file_path in sync (see updateSessionFilePaths
+  // callers), but skipping vanished rows here prevents phantom sessions from
+  // surfacing in the Factory UI if any code path forgets to rewrite (#136).
+  // Synthetic rows (OpenClaw channels/cron — see scanOpenClawIncremental) carry
+  // an empty file_path and are exempt; they're keyed by CLI output, not files.
+  const live = rows.filter(r => !r.file_path || fs.existsSync(r.file_path));
+  const trimmed = options.limit ? live.slice(0, options.limit) : live;
+  return trimmed.map(rowToMeta);
 }
 
 /** Count sessions matching the given filter options. */

--- a/src/lib/shims.session-rewrite.test.ts
+++ b/src/lib/shims.session-rewrite.test.ts
@@ -1,0 +1,146 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let TEST_VERSIONS_DIR = '';
+let TEST_BACKUPS_DIR = '';
+
+vi.mock('./state.js', async () => {
+  const actual = await vi.importActual<typeof import('./state.js')>('./state.js');
+  return {
+    ...actual,
+    getVersionsDir: () => TEST_VERSIONS_DIR,
+    getBackupsDir: () => TEST_BACKUPS_DIR,
+    ensureAgentsDir: () => {},
+  };
+});
+
+import { switchConfigSymlink } from './shims.js';
+import { getDB, querySessions } from './session/db.js';
+
+const tempDirs: string[] = [];
+const insertedSessionIds: string[] = [];
+
+function makeTempHome(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'shims-session-rewrite-'));
+  tempDirs.push(root);
+  TEST_VERSIONS_DIR = path.join(root, '.agents', 'versions');
+  TEST_BACKUPS_DIR = path.join(root, '.agents', 'backups');
+  fs.mkdirSync(TEST_VERSIONS_DIR, { recursive: true });
+  process.env.AGENTS_REAL_HOME = root;
+  return root;
+}
+
+afterEach(() => {
+  // Clean up any DB rows we inserted (the DB is the user's real sessions DB).
+  if (insertedSessionIds.length > 0) {
+    try {
+      const db = getDB();
+      for (const id of insertedSessionIds.splice(0)) {
+        db.prepare(`DELETE FROM session_text WHERE session_id = ?`).run(id);
+        db.prepare(`DELETE FROM sessions WHERE id = ?`).run(id);
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  delete process.env.AGENTS_REAL_HOME;
+  for (const d of tempDirs.splice(0)) {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe('switchConfigSymlink — rewrites session file_paths after backup rename (#136)', () => {
+  let home: string;
+  let claudeConfigDir: string;
+  let versionHome: string;
+  let sessionId: string;
+  let oldSessionPath: string;
+
+  beforeEach(() => {
+    home = makeTempHome();
+    claudeConfigDir = path.join(home, '.claude');
+    versionHome = path.join(TEST_VERSIONS_DIR, 'claude', '2.0.65', 'home');
+    fs.mkdirSync(versionHome, { recursive: true });
+
+    // Seed a real-directory ~/.claude with a session JSONL the indexer would
+    // discover. This is the exact first-install state that triggers #136 —
+    // the dir is a real dir, not yet a symlink.
+    const projectsDir = path.join(claudeConfigDir, 'projects', '-Users-test-repo');
+    fs.mkdirSync(projectsDir, { recursive: true });
+    sessionId = `9c1f${Math.random().toString(16).slice(2, 10)}-test-${Date.now()}`;
+    oldSessionPath = path.join(projectsDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(
+      oldSessionPath,
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'hi' } }) + '\n',
+    );
+
+    // Insert a matching DB row pointing at the OLD path — this is the row
+    // that goes phantom after the rename if updateSessionFilePaths is skipped.
+    const db = getDB();
+    db.prepare(`
+      INSERT OR REPLACE INTO sessions
+        (id, short_id, agent, timestamp, file_path, is_team_origin)
+      VALUES (?, ?, ?, ?, ?, 0)
+    `).run(
+      sessionId,
+      sessionId.slice(0, 8),
+      'claude',
+      new Date().toISOString(),
+      oldSessionPath,
+    );
+    insertedSessionIds.push(sessionId);
+  });
+
+  it('moves JSONLs to backup and rewrites DB rows so querySessions returns no phantom paths', async () => {
+    const result = await switchConfigSymlink('claude', '2.0.65');
+    expect(result.success).toBe(true);
+    expect(result.backupPath).toBeDefined();
+
+    // ~/.claude is now a symlink pointing at the version home.
+    const stat = fs.lstatSync(claudeConfigDir);
+    expect(stat.isSymbolicLink()).toBe(true);
+
+    // The JSONL has moved to backupPath/projects/<encoded>/<id>.jsonl
+    const expectedNewPath = path.join(
+      result.backupPath!,
+      'projects',
+      '-Users-test-repo',
+      `${sessionId}.jsonl`,
+    );
+    expect(fs.existsSync(expectedNewPath)).toBe(true);
+
+    // DB row file_path must have been rewritten — not stale, not deleted.
+    const db = getDB();
+    const row = db
+      .prepare(`SELECT file_path FROM sessions WHERE id = ?`)
+      .get(sessionId) as { file_path: string } | undefined;
+    expect(row).toBeDefined();
+    expect(row!.file_path).toBe(expectedNewPath);
+    expect(fs.existsSync(row!.file_path)).toBe(true);
+
+    // querySessions must surface the row (existsSync filter keeps it).
+    // We can't filter the entire DB to just our row, so look it up explicitly
+    // among the returned set.
+    const sessions = querySessions({ limit: 5000 });
+    const hit = sessions.find(s => s.id === sessionId);
+    expect(hit).toBeDefined();
+    expect(hit!.filePath).toBe(expectedNewPath);
+  });
+
+  it('querySessions filters out rows whose JSONL has vanished (defensive)', () => {
+    // Point the seed row at a path we then delete — simulates any future
+    // migration path that forgets to call updateSessionFilePaths.
+    const db = getDB();
+    const ghostPath = path.join(home, 'ghost', `${sessionId}.jsonl`);
+    db.prepare(`UPDATE sessions SET file_path = ? WHERE id = ?`).run(ghostPath, sessionId);
+    // Ensure the file does not exist.
+    expect(fs.existsSync(ghostPath)).toBe(false);
+
+    const sessions = querySessions({ limit: 5000 });
+    const hit = sessions.find(s => s.id === sessionId);
+    expect(hit).toBeUndefined();
+  });
+});

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -832,6 +832,25 @@ export async function switchConfigSymlink(
       fs.mkdirSync(agentBackupDir, { recursive: true });
       fs.renameSync(configPath, finalBackupPath);
 
+      // Session JSONLs that lived under the old configPath have just moved to
+      // finalBackupPath on disk. Rewrite any DB rows pointing at the old prefix
+      // so querySessions stops returning phantom rows (issue #136). The
+      // discoverer at src/lib/session/discover.ts already scans backup dirs, so
+      // future indexer runs will find the new files — this just keeps the
+      // existing rows valid in the meantime.
+      //
+      // Dynamic import so loading shims.ts doesn't transitively open the
+      // sessions DB — many tests partially mock state.js and would break.
+      try {
+        const { updateSessionFilePaths } = await import('./session/db.js');
+        updateSessionFilePaths(configPath, finalBackupPath);
+      } catch (err) {
+        console.error(
+          `Warning: failed to update session file_paths after backing up ${configPath}: ` +
+            `${(err as Error).message}. Stale rows may appear in session listings until the next scan.`
+        );
+      }
+
       // Create symlink (parent already exists since the dir we just moved was here)
       fs.symlinkSync(versionConfigPath, configPath);
 


### PR DESCRIPTION
Fixes #136.

When `~/.claude` (or any agent config dir) is a real directory on first install or version switch, `switchConfigSymlink` renames it to `~/.agents/.history/backups/<agent>/<ts>/` and drops a symlink in its place. The JSONL files survive on disk, but the rows in `sessions.db` still point at the old `~/.claude/projects/...` path. Result: `querySessions` keeps returning rows whose `file_path` no longer exists, and Factory UI shows phantom sessions you can't open.

## Changes

- **`src/lib/shims.ts`** — after `fs.renameSync(configPath, finalBackupPath)`, call `updateSessionFilePaths(configPath, finalBackupPath)` to rewrite DB rows. Mirrors the post-`removeVersion` pattern already used in `src/commands/versions.ts`. Dynamic `import('./session/db.js')` so `shims.ts` doesn't transitively open the sessions DB at module load (many tests partially mock `state.js` and would otherwise break).
- **`src/lib/session/db.ts`** — defensive filter in `querySessions`: drop rows whose non-empty `file_path` no longer exists on disk. Belt-and-suspenders against any future code path that forgets to call `updateSessionFilePaths`. Synthetic rows (OpenClaw channels/cron, `file_path === ''`) are exempt.
- **`src/lib/shims.session-rewrite.test.ts`** — new regression test:
  - seeds a real session JSONL under `~/.claude/projects/.../sessionId.jsonl`
  - inserts a matching DB row
  - invokes `switchConfigSymlink('claude', '2.0.65')`
  - asserts the JSONL is at the new backup path
  - asserts `querySessions` returns the row with rewritten `file_path` (not a phantom)
  - second test asserts the defensive filter drops ghost rows
- **`src/lib/session/__tests__/db.test.ts`** — updated `seed()` to materialize JSONL files (the new filter requires real files; previously the test seeded fake `/tmp/test/*.jsonl` paths).

## Test plan

- [x] `bun run test src/lib/shims.session-rewrite.test.ts` — 2/2 pass
- [x] `bun run test src/lib/__tests__/versions.test.ts` — regression (removeVersion + updateSessionFilePaths) still passes
- [x] `bun run test src/lib/session/` — all DB + discover tests pass
- [x] `bun run test src/lib/shims.openclaw-migration.test.ts` — switchConfigSymlink openclaw path unchanged
- [x] `bun run test src/commands/__tests__/sessions.test.ts` — OpenClaw synthetic-row test passes (empty-file_path exemption)
- [x] `bunx tsc --noEmit` — clean