### PR TITLE
perf(view): sub-ms resource diff via isStale fast path

### DIFF
--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -67,6 +67,7 @@ import { getCentralRulesFileName } from '../lib/rules/rules.js';
 import { composeRulesFromState, type ComposedSubrule } from '../lib/rules/compose.js';
 import { getConfiguredRunStrategy } from '../lib/rotate.js';
 import { listProfiles, profileSummary, type ProfileSummary } from '../lib/profiles.js';
+import { loadManifest, isStale } from '../lib/staleness/index.js';
 import { confirm } from '@inquirer/prompts';
 import { formatPath, isInteractiveTerminal, isPromptCancelled } from './utils.js';
 
@@ -609,6 +610,12 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
   if (filterAgentId && versionManaged.length > 0) {
     const defaultVersion = getGlobalDefault(filterAgentId);
     if (defaultVersion) {
+      const manifest = loadManifest(filterAgentId, defaultVersion);
+      const cwd = process.cwd();
+      if (manifest && !isStale(manifest, filterAgentId, defaultVersion, cwd)) {
+        return;
+      }
+
       const available = getAvailableResources();
       const synced = getActuallySyncedResources(filterAgentId, defaultVersion);
       const projectOnly = getProjectOnlyResources();

--- a/src/lib/staleness/registry.test.ts
+++ b/src/lib/staleness/registry.test.ts
@@ -10,6 +10,11 @@
  * production CLI launch.
  */
 import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { fileURLToPath } from 'url';
 import { AGENTS } from '../agents.js';
 import { supports } from '../capabilities.js';
 import type { AgentId } from '../types.js';
@@ -26,6 +31,9 @@ function isExempt(agent: AgentId, kind: ResourceKind): boolean {
   if (kind === 'skills' && AGENTS[agent].nativeAgentsSkillsDir) return true;
   return false;
 }
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
 
 describe('staleness/registry', () => {
   it('boots without throwing', () => {
@@ -67,6 +75,104 @@ describe('staleness/registry', () => {
   it('antigravity has a permissions writer + detector', () => {
     expect(WRITERS.permissions.antigravity).toBeDefined();
     expect(DETECTORS.permissions.antigravity).toBeDefined();
+  });
+
+  it('writer registry full-sync roundtrip leaves manifests non-stale', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'staleness-registry-roundtrip-'));
+    try {
+      const script = String.raw`
+        import * as fs from 'fs';
+        import * as path from 'path';
+        import { AGENTS } from './src/lib/agents.ts';
+        import { supports } from './src/lib/capabilities.ts';
+        import { getVersionHomePath, syncResourcesToVersion } from './src/lib/versions.ts';
+        import { buildManifest, isStale } from './src/lib/staleness/index.ts';
+        import {
+          ALL_RESOURCE_KINDS,
+          WRITERS,
+          DETECTORS,
+          kindToCapability,
+        } from './src/lib/staleness/registry.ts';
+
+        const home = process.env.HOME;
+        if (!home) throw new Error('HOME missing');
+
+        const userDir = path.join(home, '.agents');
+        const systemDir = path.join(userDir, '.system');
+        const projectRoot = path.join(home, 'project');
+        const write = (rel, content, mode) => {
+          const p = path.join(userDir, rel);
+          fs.mkdirSync(path.dirname(p), { recursive: true });
+          fs.writeFileSync(p, content);
+          if (mode) fs.chmodSync(p, mode);
+        };
+        const writeSystem = (rel, content) => {
+          const p = path.join(systemDir, rel);
+          fs.mkdirSync(path.dirname(p), { recursive: true });
+          fs.writeFileSync(p, content);
+        };
+
+        fs.mkdirSync(projectRoot, { recursive: true });
+        write('commands/roundtrip-command.md', '# Roundtrip\n');
+        write('skills/roundtrip-skill/SKILL.md', '---\nname: roundtrip-skill\ndescription: fixture\n---\n');
+        write('hooks/roundtrip-hook', '#!/usr/bin/env sh\nexit 0\n', 0o755);
+        write('mcp/roundtrip-mcp.yaml', 'name: roundtrip-mcp\ntransport: stdio\ncommand: echo\nargs: ["ok"]\n');
+        write('permissions/groups/roundtrip-permission.yaml', 'name: roundtrip-permission\nallow:\n  - Bash(echo:*)\n');
+        write('subagents/roundtrip-subagent/AGENT.md', '---\nname: roundtrip-subagent\ndescription: fixture\n---\nBody\n');
+        write('plugins/roundtrip-plugin/.claude-plugin/plugin.json', JSON.stringify({
+          name: 'roundtrip-plugin',
+          version: '0.0.0',
+          description: 'fixture',
+        }, null, 2));
+        write('workflows/roundtrip-workflow/WORKFLOW.md', '---\nname: roundtrip-workflow\ndescription: fixture\n---\n');
+        writeSystem('rules/rules.yaml', 'presets:\n  default:\n    subrules:\n      - roundtrip-rule\n');
+        writeSystem('rules/subrules/roundtrip-rule.md', 'Roundtrip rule\n');
+
+        const version = '0.0.0-test';
+        const failures = [];
+        for (const agent of Object.keys(AGENTS)) {
+          const coveredKinds = ALL_RESOURCE_KINDS.filter((kind) => {
+            const cap = kindToCapability(kind);
+            if (!supports(agent, cap).ok) return false;
+            if (kind === 'skills' && AGENTS[agent].nativeAgentsSkillsDir) return false;
+            return Boolean(WRITERS[kind][agent] && DETECTORS[kind][agent]);
+          });
+          if (coveredKinds.length === 0) continue;
+
+          const versionHome = getVersionHomePath(agent, version);
+          const fakeBin = path.join(home, '.agents', '.history', 'versions', agent, version, 'node_modules', '.bin', AGENTS[agent].cliCommand);
+          fs.mkdirSync(path.dirname(fakeBin), { recursive: true });
+          fs.writeFileSync(fakeBin, '#!/usr/bin/env sh\nexit 0\n');
+          fs.chmodSync(fakeBin, 0o755);
+
+          syncResourcesToVersion(agent, version, undefined, { cwd: projectRoot, force: true });
+          const manifest = buildManifest(agent, version, projectRoot);
+          if (isStale(manifest, agent, version, projectRoot)) {
+            failures.push(agent + ': stale after full sync');
+          }
+          for (const kind of coveredKinds) {
+            try {
+              DETECTORS[kind][agent].list({ version, versionHome, cwd: projectRoot });
+            } catch (err) {
+              failures.push(agent + '/' + kind + ': detector threw ' + ((err && err.message) || err));
+            }
+          }
+        }
+
+        if (failures.length > 0) {
+          throw new Error(failures.join('\n'));
+        }
+      `;
+
+      execFileSync('bun', ['--eval', script], {
+        cwd: repoRoot,
+        env: { ...process.env, HOME: home },
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 
   // Gemini's allowlist capability is `false` in the matrix today even though


### PR DESCRIPTION
Plan: /Users/muqsit/.agents/.history/versions/claude/2.1.141/home/.claude/plans/playful-stirring-hedgehog.md

## What changed

- `src/commands/view.ts:70` imports `loadManifest` and `isStale`.
- `src/commands/view.ts:613-617` loads the default version manifest and returns before the slow resource diff when the manifest is fresh.
- `src/commands/view.ts:619-622` keeps the existing slow path intact for missing or stale manifests.
- `src/lib/staleness/registry.test.ts:80-176` adds a filesystem roundtrip test that full-syncs registered writer/detector pairs, builds a manifest, and fails if `isStale` reports drift.

## Verification

Build:

```text
$ bun run build
$ tsc && rm -rf 'dist/lib/secrets/AgentsKeychain.app' 'dist/lib/secrets/Agents CLI.app' && ([ "$(uname)" = "Darwin" ] && cp -R 'bin/Agents CLI.app' 'dist/lib/secrets/Agents CLI.app' || true)
cp: bin/Agents CLI.app: No such file or directory
```

Exit code: 0.

Targeted registry test:

```text
$ bun run test src/lib/staleness/registry.test.ts
Test Files  1 passed (1)
Tests  7 passed (7)
```

Full suite in sandbox with writable HOME:

```text
Test Files  2 failed | 161 passed | 2 skipped (165)
Tests  6 failed | 2060 passed | 21 skipped (2087)
```

Remaining failures were outside this PR path:

```text
src/lib/__tests__/bugfixes.test.ts:15 ENOENT: no such file or directory, mkdtemp '/private/tmp/agents-cli-vitest-home/.agents-system/agents-cli-sandbox-allowed-XXXXXX'
src/lib/browser/runtime-state.test.ts:66 expected null to deeply equal { pid: 97391, port: 9222, command: "node" }
src/lib/browser/runtime-state.test.ts:235 expected false to be true
```

After creating `/private/tmp/agents-cli-vitest-home/.agents-system`, the bugfix file passed and only the browser runtime process-command checks remained:

```text
Test Files  1 failed | 1 passed (2)
Tests  2 failed | 34 passed (36)
src/lib/browser/runtime-state.test.ts:66 expected null to deeply equal { pid: 80076, port: 9222, command: "node" }
src/lib/browser/runtime-state.test.ts:235 expected false to be true
```

## Behavior

Missing manifest keeps the slow prompt path:

```text
missing_rc=13
8:New resources available:
10:? Sync new resources?
Installed Agent CLIs

  Claude (available)
    1.0.0 (default)  (not signed in — run claude to log in)
      /private/tmp/agents-cli-view-home/.agents/.history/versions/claude/1.0.0


New resources available:
  1 command
? Sync new resources?
```

Fresh manifest skips the prompt:

```text
fresh_rc=0
Installed Agent CLIs

  Claude (available)
    1.0.0 (default)  (not signed in — run claude to log in)
      /private/tmp/agents-cli-view-home/.agents/.history/versions/claude/1.0.0
```

## Performance

Total built-CLI wall time in an isolated fresh-manifest fixture:

```text
claude fresh timing:
real 3.46
user 0.51
sys 0.39

grok fresh timing:
real 0.28
user 0.29
sys 0.15
```

The Claude total includes unrelated CLI/account-status work in the fake fixture. Direct diff-gate timing for the changed path:

```text
claude run=1 stale=false diff_ms=7.667
claude run=2 stale=false diff_ms=0.798
claude run=3 stale=false diff_ms=0.683
claude run=4 stale=false diff_ms=0.643
claude run=5 stale=false diff_ms=0.733
grok run=1 stale=false diff_ms=0.622
grok run=2 stale=false diff_ms=0.698
grok run=3 stale=false diff_ms=0.756
grok run=4 stale=false diff_ms=0.924
grok run=5 stale=false diff_ms=1.199
```

## Session Context

Session gist export could not be produced in this sandbox after three attempts:

```text
agents sessions --last 50 --markdown > /tmp/session-export.md
Failed to discover sessions: unable to open database file

agents sessions --last 50 --markdown > /tmp/session-export.md
Failed to discover sessions: attempt to write a readonly database

agents sessions . --limit 50 --markdown > /tmp/session-export.md
Failed to discover sessions: unable to open database file
```
