### PR TITLE
feat(launch-sync): auto-compile project resources on agent launch (shim v16)

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -4,6 +4,14 @@
  * Registers the hidden `agents sync` command invoked by shims to
  * synchronize resources (commands, skills, hooks, memory, MCP, etc.)
  * into a specific agent version home before launch.
+ *
+ * Two modes:
+ *   - default: full reconciliation — version-home resource sync, project rules
+ *     compile. Heavy; called by management commands (`agents use`, `agents view`).
+ *   - --launch: hot-path mode for the shim. Skips version-home reconciliation
+ *     and runs only the cheap project-scoped work (rules compile, workspace
+ *     resource mirror, per-scope plugin marketplaces). Filesystem-only,
+ *     sub-50ms steady state.
  */
 
 import * as path from 'path';
@@ -12,6 +20,7 @@ import chalk from 'chalk';
 import { AGENTS } from '../lib/agents.js';
 import { isVersionInstalled, syncResourcesToVersion } from '../lib/versions.js';
 import { compileRulesForProject } from '../lib/rules/compile.js';
+import { runLaunchSync } from '../lib/project-launch.js';
 
 /** Register the hidden `agents sync` command. */
 export function registerSyncCommand(program: Command): void {
@@ -22,12 +31,14 @@ export function registerSyncCommand(program: Command): void {
     .requiredOption('--agent-version <version>', 'Installed version to sync resources into')
     .option('--project-dir <path>', 'Path to project-level .agents/ directory containing project-scoped resources')
     .option('--cwd <path>', 'Working directory for discovering project manifest and resources')
+    .option('--launch', 'Hot-path mode: skip version-home reconciliation, run only project-scoped compile + workspace mirror + plugin marketplaces', false)
     .option('--quiet', 'Suppress all output (exit code indicates success)', false)
     .action((opts) => {
       const agentId = opts.agent as keyof typeof AGENTS;
       const version = opts.agentVersion as string;
       const projectDir = opts.projectDir as string | undefined;
       const cwd = opts.cwd as string | undefined;
+      const launch = !!opts.launch;
       const quiet = !!opts.quiet;
 
       if (!AGENTS[agentId]) {
@@ -43,6 +54,11 @@ export function registerSyncCommand(program: Command): void {
           console.error(chalk.red(`${AGENTS[agentId].name}@${version} is not installed`));
         }
         process.exitCode = 1;
+        return;
+      }
+
+      if (launch) {
+        runLaunchMode(agentId, version, cwd ?? process.cwd(), quiet);
         return;
       }
 
@@ -89,4 +105,39 @@ export function registerSyncCommand(program: Command): void {
         ));
       }
     });
+}
+
+function runLaunchMode(agent: keyof typeof AGENTS, version: string, cwd: string, quiet: boolean): void {
+  let result;
+  try {
+    result = runLaunchSync({ agent, version, cwd });
+  } catch (err) {
+    if (!quiet) {
+      console.error(chalk.yellow(`agents: launch sync skipped (${(err as Error).message})`));
+    }
+    return;
+  }
+
+  if (quiet) return;
+
+  const bits: string[] = [];
+  if (result.rulesCompiled) bits.push('rules');
+  if (result.workspaceLinks > 0) bits.push(`${result.workspaceLinks} workspace link(s)`);
+  const mpCount = Object.keys(result.marketplaces).length;
+  if (mpCount > 0) {
+    const pluginCount = Object.values(result.marketplaces).reduce((acc, names) => acc + names.length, 0);
+    bits.push(`${pluginCount} plugin(s) across ${mpCount} marketplace(s)`);
+  }
+
+  if (bits.length === 0) {
+    console.log(chalk.gray('No project resources to compile'));
+  } else {
+    console.log(chalk.green(`Launch sync: ${bits.join(', ')}`));
+  }
+
+  if (result.workspaceSkipped.length > 0) {
+    console.log(chalk.yellow(
+      `Skipped (user-owned, not overwritten): ${result.workspaceSkipped.join(', ')}`,
+    ));
+  }
 }

--- a/src/lib/plugin-marketplace.ts
+++ b/src/lib/plugin-marketplace.ts
@@ -1,27 +1,48 @@
 /**
  * Native plugin marketplace install path for Claude / OpenClaw.
  *
- * Plugins managed by agents-cli are exposed as a synthetic local marketplace
- * named "agents-cli" under each version's plugin directory:
+ * Plugins managed by agents-cli are exposed as synthetic local marketplaces
+ * grouped by source scope under each version's plugin directory:
  *
  *   <versionHome>/.{claude,openclaw}/plugins/
- *     known_marketplaces.json            # registers the "agents-cli" marketplace
- *     marketplaces/agents-cli/
- *       .claude-plugin/marketplace.json  # synthesized catalog
- *       plugins/<plugin>/                # copied plugin source
+ *     known_marketplaces.json                    # registers each scoped marketplace
+ *     marketplaces/agents-cli/                   # ~/.agents/plugins/* (user scope, legacy name)
+ *     marketplaces/agents-system/                # ~/.agents/.system/plugins/*
+ *     marketplaces/extras-<alias>/               # ~/.agents-<alias>/plugins/*
+ *     marketplaces/agents-project/               # <cwd>/.agents/plugins/*
+ *       .claude-plugin/marketplace.json          # synthesized catalog
+ *       plugins/<plugin>/                        # copied plugin source
  *
- * Plus the version's settings.json gets `enabledPlugins["<plugin>@agents-cli"] = true`.
+ * Plus the version's settings.json gets
+ *   `enabledPlugins["<plugin>@<marketplace>"] = true`.
  *
  * This produces native `/plugin:skill` slash namespacing, visibility in `/plugins`,
- * and `/plugin enable|disable` support — matching the Claude Code spec at
+ * `/plugin enable|disable` support, AND honest attribution (the user can see
+ * which scope each plugin came from) — matching the Claude Code spec at
  * https://code.claude.com/docs/en/plugins and /plugin-marketplaces.
+ *
+ * Backward compat: existing call sites that don't pass `marketplaceName` keep
+ * writing to "agents-cli" (the legacy user-scope name). The launch-sync path
+ * passes scope-specific names for the three new marketplaces.
  */
 
 import * as fs from 'fs';
 import * as path from 'path';
 import type { AgentId, DiscoveredPlugin, PluginManifest } from './types.js';
 
+/**
+ * Legacy name for the user-scope marketplace. Kept as the default so existing
+ * installs (which have `marketplaces/agents-cli/` on disk and `<name>@agents-cli`
+ * keys in settings.json) keep working without a migration.
+ */
 export const MARKETPLACE_NAME = 'agents-cli';
+
+/** Marketplace name for ~/.agents/.system/plugins/*. */
+export const SYSTEM_MARKETPLACE_NAME = 'agents-system';
+/** Marketplace name for <cwd>/.agents/plugins/*. */
+export const PROJECT_MARKETPLACE_NAME = 'agents-project';
+/** Marketplace name for an extras repo aliased <alias> at ~/.agents-<alias>/plugins/*. */
+export function extrasMarketplaceName(alias: string): string { return `extras-${alias}`; }
 
 interface KnownMarketplaceEntry {
   source: { source: 'directory'; path: string };
@@ -49,16 +70,16 @@ function pluginsRootForVersion(agent: AgentId, versionHome: string): string {
   return path.join(versionHome, `.${agent}`, 'plugins');
 }
 
-export function marketplaceRoot(agent: AgentId, versionHome: string): string {
-  return path.join(pluginsRootForVersion(agent, versionHome), 'marketplaces', MARKETPLACE_NAME);
+export function marketplaceRoot(agent: AgentId, versionHome: string, marketplaceName: string = MARKETPLACE_NAME): string {
+  return path.join(pluginsRootForVersion(agent, versionHome), 'marketplaces', marketplaceName);
 }
 
-export function marketplaceManifestPath(agent: AgentId, versionHome: string): string {
-  return path.join(marketplaceRoot(agent, versionHome), '.claude-plugin', 'marketplace.json');
+export function marketplaceManifestPath(agent: AgentId, versionHome: string, marketplaceName: string = MARKETPLACE_NAME): string {
+  return path.join(marketplaceRoot(agent, versionHome, marketplaceName), '.claude-plugin', 'marketplace.json');
 }
 
-export function pluginInstallDir(plugin: DiscoveredPlugin, agent: AgentId, versionHome: string): string {
-  return path.join(marketplaceRoot(agent, versionHome), 'plugins', plugin.name);
+export function pluginInstallDir(plugin: DiscoveredPlugin, agent: AgentId, versionHome: string, marketplaceName: string = MARKETPLACE_NAME): string {
+  return path.join(marketplaceRoot(agent, versionHome, marketplaceName), 'plugins', plugin.name);
 }
 
 export function knownMarketplacesPath(agent: AgentId, versionHome: string): string {
@@ -71,7 +92,7 @@ function settingsPath(agent: AgentId, versionHome: string): string {
 
 /**
  * Copy plugin source into marketplace install dir.
- * Source of truth remains ~/.agents/plugins/<name>/ — this is a per-version snapshot.
+ * Source of truth remains the plugin's source dir — this is a per-version snapshot.
  *
  * Symlinks pointing OUTSIDE the plugin source root are dropped. They show up
  * when plugin authors (legitimately) link prompt-side references to sibling
@@ -86,9 +107,10 @@ function settingsPath(agent: AgentId, versionHome: string): string {
 export function copyPluginToMarketplace(
   plugin: DiscoveredPlugin,
   agent: AgentId,
-  versionHome: string
+  versionHome: string,
+  marketplaceName: string = MARKETPLACE_NAME
 ): string {
-  const dest = pluginInstallDir(plugin, agent, versionHome);
+  const dest = pluginInstallDir(plugin, agent, versionHome, marketplaceName);
   fs.mkdirSync(path.dirname(dest), { recursive: true });
   if (fs.existsSync(dest)) {
     fs.rmSync(dest, { recursive: true, force: true });
@@ -138,8 +160,8 @@ export function copyPluginToMarketplace(
  * plugins installed under <marketplace>/plugins/. Always run after add or remove
  * so the manifest stays in lockstep with on-disk contents.
  */
-export function syncMarketplaceManifest(agent: AgentId, versionHome: string): MarketplaceManifest | null {
-  const root = marketplaceRoot(agent, versionHome);
+export function syncMarketplaceManifest(agent: AgentId, versionHome: string, marketplaceName: string = MARKETPLACE_NAME): MarketplaceManifest | null {
+  const root = marketplaceRoot(agent, versionHome, marketplaceName);
   const pluginsDir = path.join(root, 'plugins');
   if (!fs.existsSync(pluginsDir)) return null;
 
@@ -176,24 +198,31 @@ export function syncMarketplaceManifest(agent: AgentId, versionHome: string): Ma
 
   const manifest: MarketplaceManifest = {
     $schema: 'https://anthropic.com/claude-code/marketplace.schema.json',
-    name: MARKETPLACE_NAME,
-    description: 'Plugins managed by agents-cli',
+    name: marketplaceName,
+    description: descriptionForMarketplace(marketplaceName),
     owner: { name: 'agents-cli' },
     plugins: entries.sort((a, b) => a.name.localeCompare(b.name)),
   };
 
-  const manifestPath = marketplaceManifestPath(agent, versionHome);
+  const manifestPath = marketplaceManifestPath(agent, versionHome, marketplaceName);
   fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
   fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
   return manifest;
 }
 
+function descriptionForMarketplace(name: string): string {
+  if (name === SYSTEM_MARKETPLACE_NAME) return 'System plugins shipped with agents-cli';
+  if (name === PROJECT_MARKETPLACE_NAME) return 'Project-scoped plugins from <cwd>/.agents/plugins/';
+  if (name.startsWith('extras-')) return `Plugins from extras repo "${name.slice('extras-'.length)}"`;
+  return 'Plugins managed by agents-cli';
+}
+
 /**
- * Register the agents-cli marketplace in known_marketplaces.json so Claude Code
- * discovers it on startup. Idempotent: re-running just refreshes lastUpdated.
+ * Register a marketplace in known_marketplaces.json so Claude Code discovers
+ * it on startup. Idempotent: re-running just refreshes lastUpdated.
  */
-export function registerMarketplace(agent: AgentId, versionHome: string): void {
-  const root = marketplaceRoot(agent, versionHome);
+export function registerMarketplace(agent: AgentId, versionHome: string, marketplaceName: string = MARKETPLACE_NAME): void {
+  const root = marketplaceRoot(agent, versionHome, marketplaceName);
   const knownPath = knownMarketplacesPath(agent, versionHome);
 
   let known: Record<string, KnownMarketplaceEntry> = {};
@@ -205,7 +234,7 @@ export function registerMarketplace(agent: AgentId, versionHome: string): void {
     }
   }
 
-  known[MARKETPLACE_NAME] = {
+  known[marketplaceName] = {
     source: { source: 'directory', path: root },
     installLocation: root,
     lastUpdated: new Date().toISOString(),
@@ -216,10 +245,10 @@ export function registerMarketplace(agent: AgentId, versionHome: string): void {
 }
 
 /**
- * Drop the agents-cli marketplace entry from known_marketplaces.json.
+ * Drop a marketplace entry from known_marketplaces.json.
  * Called when the last plugin under it is removed.
  */
-export function unregisterMarketplace(agent: AgentId, versionHome: string): void {
+export function unregisterMarketplace(agent: AgentId, versionHome: string, marketplaceName: string = MARKETPLACE_NAME): void {
   const knownPath = knownMarketplacesPath(agent, versionHome);
   if (!fs.existsSync(knownPath)) return;
 
@@ -230,8 +259,8 @@ export function unregisterMarketplace(agent: AgentId, versionHome: string): void
     return;
   }
 
-  if (!(MARKETPLACE_NAME in known)) return;
-  delete known[MARKETPLACE_NAME];
+  if (!(marketplaceName in known)) return;
+  delete known[marketplaceName];
 
   if (Object.keys(known).length === 0) {
     try {
@@ -244,16 +273,17 @@ export function unregisterMarketplace(agent: AgentId, versionHome: string): void
 
 /**
  * Mark a plugin as enabled in <versionHome>/.{agent}/settings.json under
- * enabledPlugins["<plugin>@agents-cli"]: true. Reads, mutates, writes —
+ * enabledPlugins["<plugin>@<marketplace>"]: true. Reads, mutates, writes —
  * preserving every other key.
  */
 export function enablePluginInSettings(
   pluginName: string,
   agent: AgentId,
   versionHome: string,
-  options: { allowExecSurfaces?: boolean } = {}
+  options: { allowExecSurfaces?: boolean; marketplaceName?: string } = {}
 ): void {
-  if (!options.allowExecSurfaces && marketplacePluginHasExecSurfaces(pluginName, agent, versionHome)) {
+  const marketplaceName = options.marketplaceName ?? MARKETPLACE_NAME;
+  if (!options.allowExecSurfaces && marketplacePluginHasExecSurfaces(pluginName, agent, versionHome, marketplaceName)) {
     return;
   }
 
@@ -271,7 +301,7 @@ export function enablePluginInSettings(
     settings.enabledPlugins = {};
   }
   const enabled = settings.enabledPlugins as Record<string, boolean>;
-  const key = `${pluginName}@${MARKETPLACE_NAME}`;
+  const key = `${pluginName}@${marketplaceName}`;
   if (enabled[key] === true) return;
   enabled[key] = true;
 
@@ -279,8 +309,8 @@ export function enablePluginInSettings(
   fs.writeFileSync(sPath, JSON.stringify(settings, null, 2) + '\n', 'utf-8');
 }
 
-function marketplacePluginHasExecSurfaces(pluginName: string, agent: AgentId, versionHome: string): boolean {
-  const root = path.join(marketplaceRoot(agent, versionHome), 'plugins', pluginName);
+function marketplacePluginHasExecSurfaces(pluginName: string, agent: AgentId, versionHome: string, marketplaceName: string = MARKETPLACE_NAME): boolean {
+  const root = path.join(marketplaceRoot(agent, versionHome, marketplaceName), 'plugins', pluginName);
   if (fs.existsSync(path.join(root, '.mcp.json'))) return true;
   for (const dir of ['bin', 'scripts', 'permissions']) {
     if (fs.existsSync(path.join(root, dir))) return true;
@@ -311,7 +341,8 @@ function marketplacePluginHasExecSurfaces(pluginName: string, agent: AgentId, ve
 export function disablePluginInSettings(
   pluginName: string,
   agent: AgentId,
-  versionHome: string
+  versionHome: string,
+  marketplaceName: string = MARKETPLACE_NAME
 ): void {
   const sPath = settingsPath(agent, versionHome);
   if (!fs.existsSync(sPath)) return;
@@ -326,7 +357,7 @@ export function disablePluginInSettings(
   const enabled = settings.enabledPlugins as Record<string, boolean> | undefined;
   if (!enabled) return;
 
-  const key = `${pluginName}@${MARKETPLACE_NAME}`;
+  const key = `${pluginName}@${marketplaceName}`;
   if (!(key in enabled)) return;
   delete enabled[key];
 
@@ -344,9 +375,10 @@ export function disablePluginInSettings(
 export function removePluginFromMarketplace(
   pluginName: string,
   agent: AgentId,
-  versionHome: string
+  versionHome: string,
+  marketplaceName: string = MARKETPLACE_NAME
 ): boolean {
-  const installed = path.join(marketplaceRoot(agent, versionHome), 'plugins', pluginName);
+  const installed = path.join(marketplaceRoot(agent, versionHome, marketplaceName), 'plugins', pluginName);
   if (!fs.existsSync(installed)) return false;
   fs.rmSync(installed, { recursive: true, force: true });
   return true;
@@ -355,8 +387,8 @@ export function removePluginFromMarketplace(
 /**
  * Return true if the marketplace has no plugins left under it.
  */
-export function marketplaceIsEmpty(agent: AgentId, versionHome: string): boolean {
-  const pluginsDir = path.join(marketplaceRoot(agent, versionHome), 'plugins');
+export function marketplaceIsEmpty(agent: AgentId, versionHome: string, marketplaceName: string = MARKETPLACE_NAME): boolean {
+  const pluginsDir = path.join(marketplaceRoot(agent, versionHome, marketplaceName), 'plugins');
   if (!fs.existsSync(pluginsDir)) return true;
   const remaining = fs.readdirSync(pluginsDir, { withFileTypes: true })
     .filter(d => d.isDirectory() && !d.name.startsWith('.'));
@@ -366,8 +398,8 @@ export function marketplaceIsEmpty(agent: AgentId, versionHome: string): boolean
 /**
  * Drop the entire marketplace directory. Called after the last plugin removal.
  */
-export function removeEmptyMarketplaceDir(agent: AgentId, versionHome: string): void {
-  const root = marketplaceRoot(agent, versionHome);
+export function removeEmptyMarketplaceDir(agent: AgentId, versionHome: string, marketplaceName: string = MARKETPLACE_NAME): void {
+  const root = marketplaceRoot(agent, versionHome, marketplaceName);
   if (!fs.existsSync(root)) return;
   fs.rmSync(root, { recursive: true, force: true });
 }
@@ -378,8 +410,9 @@ export function removeEmptyMarketplaceDir(agent: AgentId, versionHome: string): 
 export function isInstalledInMarketplace(
   pluginName: string,
   agent: AgentId,
-  versionHome: string
+  versionHome: string,
+  marketplaceName: string = MARKETPLACE_NAME
 ): boolean {
-  const installed = path.join(marketplaceRoot(agent, versionHome), 'plugins', pluginName);
+  const installed = path.join(marketplaceRoot(agent, versionHome, marketplaceName), 'plugins', pluginName);
   return fs.existsSync(path.join(installed, '.claude-plugin', 'plugin.json'));
 }

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -68,11 +68,11 @@ function isPluginRootEntry(pluginsDir: string, entry: fs.Dirent): boolean {
 }
 
 /**
- * Discover all plugins in ~/.agents/plugins/.
+ * Discover all plugins in a given plugins directory (e.g. ~/.agents/plugins/,
+ * ~/.agents/.system/plugins/, <cwd>/.agents/plugins/, ~/.agents-<alias>/plugins/).
  * A valid plugin has a .claude-plugin/plugin.json manifest.
  */
-export function discoverPlugins(): DiscoveredPlugin[] {
-  const pluginsDir = getPluginsDir();
+export function discoverPluginsInDir(pluginsDir: string): DiscoveredPlugin[] {
   if (!fs.existsSync(pluginsDir)) {
     return [];
   }
@@ -91,6 +91,14 @@ export function discoverPlugins(): DiscoveredPlugin[] {
   }
 
   return plugins;
+}
+
+/**
+ * Discover all plugins in ~/.agents/plugins/ (the user-scope source).
+ * Backward-compat wrapper around discoverPluginsInDir.
+ */
+export function discoverPlugins(): DiscoveredPlugin[] {
+  return discoverPluginsInDir(getPluginsDir());
 }
 
 export function buildDiscoveredPlugin(pluginRoot: string, manifest: PluginManifest): DiscoveredPlugin {

--- a/src/lib/project-launch.test.ts
+++ b/src/lib/project-launch.test.ts
@@ -11,8 +11,8 @@ let VERSION_HOME: string;
 
 // state.ts derives paths from $HOME captured at module load. Mock the
 // path-providing getters per-test to point at TMP_HOME; getVersionsDir feeds
-// versions.ts:getVersionHomePath transitively, so no separate versions mock
-// is needed. Real fs writes/reads under the temp dir — no business logic mocked.
+// versions.ts:getVersionHomePath transitively. Real fs writes/reads under
+// the temp dir — no business logic mocked.
 vi.mock('./state.js', () => ({
   get getPluginsDir() { return () => path.join(USER_DIR, 'plugins'); },
   get getSystemPluginsDir() { return () => path.join(SYSTEM_DIR, 'plugins'); },
@@ -43,8 +43,11 @@ function writeFile(abs: string, content: string): void {
   fs.writeFileSync(abs, content);
 }
 
-function writePluginManifest(pluginDir: string, name: string, version = '0.0.1'): void {
-  writeFile(path.join(pluginDir, '.claude-plugin', 'plugin.json'), JSON.stringify({ name, version, description: `Test ${name}` }));
+function writePluginManifest(pluginDir: string, name: string, opts: { withMcp?: boolean } = {}): void {
+  writeFile(path.join(pluginDir, '.claude-plugin', 'plugin.json'), JSON.stringify({ name, version: '0.0.1', description: `Test ${name}` }));
+  if (opts.withMcp) {
+    writeFile(path.join(pluginDir, '.mcp.json'), JSON.stringify({ mcpServers: { evil: { command: 'echo' } } }));
+  }
 }
 
 function readJson(p: string): unknown {
@@ -77,18 +80,17 @@ describe('runLaunchSync — workspace resource mirror', () => {
     expect(fs.readFileSync(linked, 'utf-8')).toBe('# Reviewer subagent');
   });
 
-  it('mirrors commands, skills, and mcp.json with correct destinations', () => {
+  it('mirrors commands and skills under .claude/, but NOT mcp.json (supply-chain surface)', () => {
     writeFile(path.join(PROJECT_DIR, '.agents', 'commands', 'deploy.md'), '# deploy command');
     writeFile(path.join(PROJECT_DIR, '.agents', 'skills', 'auditor', 'SKILL.md'), '# auditor skill');
-    writeFile(path.join(PROJECT_DIR, '.agents', 'mcp.json'), '{"servers":{}}');
+    writeFile(path.join(PROJECT_DIR, '.agents', 'mcp.json'), JSON.stringify({ mcpServers: { evil: { command: 'echo' } } }));
 
-    const result = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+    runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
 
-    expect(result.workspaceLinks).toBeGreaterThanOrEqual(3);
     expect(fs.lstatSync(path.join(PROJECT_DIR, '.claude', 'commands', 'deploy.md')).isSymbolicLink()).toBe(true);
     expect(fs.lstatSync(path.join(PROJECT_DIR, '.claude', 'skills', 'auditor')).isSymbolicLink()).toBe(true);
-    expect(fs.lstatSync(path.join(PROJECT_DIR, '.mcp.json')).isSymbolicLink()).toBe(true);
-    expect(fs.readFileSync(path.join(PROJECT_DIR, '.mcp.json'), 'utf-8')).toBe('{"servers":{}}');
+    // Critical: cwd/.mcp.json must NOT be auto-linked from the launch path.
+    expect(fs.existsSync(path.join(PROJECT_DIR, '.mcp.json'))).toBe(false);
   });
 
   it('does not clobber a hand-authored .claude/agents/foo.md', () => {
@@ -101,6 +103,28 @@ describe('runLaunchSync — workspace resource mirror', () => {
     const dest = path.join(PROJECT_DIR, '.claude', 'agents', 'foo.md');
     expect(fs.lstatSync(dest).isSymbolicLink()).toBe(false);
     expect(fs.readFileSync(dest, 'utf-8')).toBe('# hand-authored — keep me');
+  });
+
+  it('does not clobber a dangling user symlink at the dest path', () => {
+    writeFile(path.join(PROJECT_DIR, '.agents', 'subagents', 'foo.md'), '# from project rules');
+    fs.mkdirSync(path.join(PROJECT_DIR, '.claude', 'agents'), { recursive: true });
+    fs.symlinkSync('/tmp/does-not-exist-pls-keep-this-dangling', path.join(PROJECT_DIR, '.claude', 'agents', 'foo.md'));
+
+    const result = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+
+    expect(result.workspaceSkipped).toContain(path.join('.claude', 'agents', 'foo.md'));
+    // The dangling symlink must survive — it's in-progress user state.
+    expect(fs.readlinkSync(path.join(PROJECT_DIR, '.claude', 'agents', 'foo.md'))).toBe('/tmp/does-not-exist-pls-keep-this-dangling');
+  });
+
+  it('is a no-op for non-claude agents (v1 scope)', () => {
+    writeFile(path.join(PROJECT_DIR, '.agents', 'subagents', 'foo.md'), '# x');
+
+    const result = runLaunchSync({ agent: 'codex', version: '1.0.0', cwd: PROJECT_DIR });
+
+    expect(result.workspaceLinks).toBe(0);
+    expect(fs.existsSync(path.join(PROJECT_DIR, '.codex'))).toBe(false);
+    expect(fs.existsSync(path.join(PROJECT_DIR, '.claude'))).toBe(false);
   });
 
   it('is idempotent: running twice does not duplicate links', () => {
@@ -125,9 +149,62 @@ describe('runLaunchSync — scoped plugin marketplaces', () => {
     const manifest = readJson(manifestPath) as { name: string; plugins: Array<{ name: string }> };
     expect(manifest.name).toBe(PROJECT_MARKETPLACE_NAME);
     expect(manifest.plugins.map(p => p.name)).toEqual(['myproj']);
+  });
+
+  it('does NOT auto-enable a project plugin that ships an .mcp.json (supply-chain gate)', () => {
+    writePluginManifest(path.join(PROJECT_DIR, '.agents', 'plugins', 'evil'), 'evil', { withMcp: true });
+
+    runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+
+    // The plugin gets installed into the marketplace (visible in /plugins) but
+    // is NOT enabled. enablePluginInSettings is a no-op for exec-surface
+    // plugins when allowExecSurfaces=false, so settings.json may not exist at
+    // all in this scenario — either way is acceptable.
+    const settingsPath = path.join(VERSION_HOME, '.claude', 'settings.json');
+    const settings = fs.existsSync(settingsPath)
+      ? readJson(settingsPath) as { enabledPlugins?: Record<string, boolean> }
+      : { enabledPlugins: undefined };
+    expect(settings.enabledPlugins?.[`evil@${PROJECT_MARKETPLACE_NAME}`]).toBeUndefined();
+    // But the marketplace install dir should exist — user can still `/plugin enable` it.
+    expect(fs.existsSync(path.join(marketplaceRoot('claude', VERSION_HOME, PROJECT_MARKETPLACE_NAME), 'plugins', 'evil'))).toBe(true);
+  });
+
+  it('DOES auto-enable a user-scope plugin even when it ships exec surfaces', () => {
+    writePluginManifest(path.join(USER_DIR, 'plugins', 'myhooks'), 'myhooks', { withMcp: true });
+
+    runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
 
     const settings = readJson(path.join(VERSION_HOME, '.claude', 'settings.json')) as { enabledPlugins: Record<string, boolean> };
-    expect(settings.enabledPlugins[`myproj@${PROJECT_MARKETPLACE_NAME}`]).toBe(true);
+    expect(settings.enabledPlugins[`myhooks@${MARKETPLACE_NAME}`]).toBe(true);
+  });
+
+  it('resolves cross-scope name collisions by precedence (project > user)', () => {
+    writePluginManifest(path.join(USER_DIR, 'plugins', 'foo'), 'foo');
+    writePluginManifest(path.join(PROJECT_DIR, '.agents', 'plugins', 'foo'), 'foo');
+
+    const result = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+
+    expect(result.marketplaces[PROJECT_MARKETPLACE_NAME]).toEqual(['foo']);
+    expect(result.marketplaces[MARKETPLACE_NAME]).toBeUndefined();
+
+    const settings = readJson(path.join(VERSION_HOME, '.claude', 'settings.json')) as { enabledPlugins: Record<string, boolean> };
+    expect(settings.enabledPlugins[`foo@${PROJECT_MARKETPLACE_NAME}`]).toBe(true);
+    expect(settings.enabledPlugins[`foo@${MARKETPLACE_NAME}`]).toBeUndefined();
+  });
+
+  it('prunes stale enabledPlugins for a plugin that moved from user to project scope', () => {
+    // Simulate prior state: user-scope plugin was enabled in a previous launch.
+    writeFile(path.join(VERSION_HOME, '.claude', 'settings.json'), JSON.stringify({
+      enabledPlugins: { [`foo@${MARKETPLACE_NAME}`]: true },
+    }));
+    // Now the plugin only lives at project scope.
+    writePluginManifest(path.join(PROJECT_DIR, '.agents', 'plugins', 'foo'), 'foo');
+
+    runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+
+    const settings = readJson(path.join(VERSION_HOME, '.claude', 'settings.json')) as { enabledPlugins: Record<string, boolean> };
+    expect(settings.enabledPlugins[`foo@${MARKETPLACE_NAME}`]).toBeUndefined();
+    expect(settings.enabledPlugins[`foo@${PROJECT_MARKETPLACE_NAME}`]).toBe(true);
   });
 
   it('synthesizes agents-system and agents-cli (user) marketplaces separately', () => {
@@ -148,6 +225,30 @@ describe('runLaunchSync — scoped plugin marketplaces', () => {
 
   it('returns an empty marketplaces map when no plugin sources exist', () => {
     const result = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+
+    expect(result.marketplaces).toEqual({});
+  });
+
+  it('skip-fast: a second launch with unchanged inputs does not rewrite marketplace.json', () => {
+    writePluginManifest(path.join(USER_DIR, 'plugins', 'fast'), 'fast');
+
+    runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+    const manifestPath = marketplaceManifestPath('claude', VERSION_HOME, MARKETPLACE_NAME);
+    const mtime1 = fs.statSync(manifestPath).mtimeMs;
+
+    // Sleep enough to make a rewrite detectable, then re-run.
+    const target = Date.now() + 25;
+    while (Date.now() < target) { /* spin */ }
+    runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+    const mtime2 = fs.statSync(manifestPath).mtimeMs;
+
+    expect(mtime2).toBe(mtime1);
+  });
+
+  it('skips plugin synthesis for agents without plugins capability (e.g. gemini)', () => {
+    writePluginManifest(path.join(USER_DIR, 'plugins', 'plug'), 'plug');
+
+    const result = runLaunchSync({ agent: 'gemini', version: '0.30.0', cwd: PROJECT_DIR });
 
     expect(result.marketplaces).toEqual({});
   });

--- a/src/lib/project-launch.test.ts
+++ b/src/lib/project-launch.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+let TMP_HOME: string;
+let USER_DIR: string;
+let SYSTEM_DIR: string;
+let PROJECT_DIR: string;
+let VERSION_HOME: string;
+
+// state.ts derives paths from $HOME captured at module load. Mock the
+// path-providing getters per-test to point at TMP_HOME; getVersionsDir feeds
+// versions.ts:getVersionHomePath transitively, so no separate versions mock
+// is needed. Real fs writes/reads under the temp dir — no business logic mocked.
+vi.mock('./state.js', () => ({
+  get getPluginsDir() { return () => path.join(USER_DIR, 'plugins'); },
+  get getSystemPluginsDir() { return () => path.join(SYSTEM_DIR, 'plugins'); },
+  get getExtraPluginsDir() { return (_alias: string) => path.join(TMP_HOME, '.agents-extras', _alias, 'plugins'); },
+  get getProjectPluginsDir() { return (cwd: string = process.cwd()) => {
+    const p = path.join(cwd, '.agents', 'plugins');
+    return fs.existsSync(path.join(cwd, '.agents')) ? p : null;
+  }; },
+  get getProjectAgentsDir() { return (cwd: string = process.cwd()) => {
+    const p = path.join(cwd, '.agents');
+    return fs.existsSync(p) ? p : null;
+  }; },
+  get getEnabledExtraRepos() { return () => []; },
+  get getVersionsDir() { return () => path.join(USER_DIR, '.history', 'versions'); },
+}));
+
+import { runLaunchSync } from './project-launch.js';
+import {
+  MARKETPLACE_NAME,
+  PROJECT_MARKETPLACE_NAME,
+  SYSTEM_MARKETPLACE_NAME,
+  marketplaceManifestPath,
+  marketplaceRoot,
+} from './plugin-marketplace.js';
+
+function writeFile(abs: string, content: string): void {
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+}
+
+function writePluginManifest(pluginDir: string, name: string, version = '0.0.1'): void {
+  writeFile(path.join(pluginDir, '.claude-plugin', 'plugin.json'), JSON.stringify({ name, version, description: `Test ${name}` }));
+}
+
+function readJson(p: string): unknown {
+  return JSON.parse(fs.readFileSync(p, 'utf-8'));
+}
+
+beforeEach(() => {
+  TMP_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'launch-sync-test-'));
+  USER_DIR = path.join(TMP_HOME, '.agents');
+  SYSTEM_DIR = path.join(USER_DIR, '.system');
+  PROJECT_DIR = path.join(TMP_HOME, 'project');
+  VERSION_HOME = path.join(USER_DIR, '.history', 'versions', 'claude', '1.0.0', 'home');
+  fs.mkdirSync(path.join(VERSION_HOME, '.claude'), { recursive: true });
+  fs.mkdirSync(PROJECT_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  try { fs.rmSync(TMP_HOME, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('runLaunchSync — workspace resource mirror', () => {
+  it('symlinks .agents/subagents/*.md → cwd/.claude/agents/*.md', () => {
+    writeFile(path.join(PROJECT_DIR, '.agents', 'subagents', 'reviewer.md'), '# Reviewer subagent');
+
+    const result = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+
+    expect(result.workspaceLinks).toBeGreaterThanOrEqual(1);
+    const linked = path.join(PROJECT_DIR, '.claude', 'agents', 'reviewer.md');
+    expect(fs.lstatSync(linked).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(linked, 'utf-8')).toBe('# Reviewer subagent');
+  });
+
+  it('mirrors commands, skills, and mcp.json with correct destinations', () => {
+    writeFile(path.join(PROJECT_DIR, '.agents', 'commands', 'deploy.md'), '# deploy command');
+    writeFile(path.join(PROJECT_DIR, '.agents', 'skills', 'auditor', 'SKILL.md'), '# auditor skill');
+    writeFile(path.join(PROJECT_DIR, '.agents', 'mcp.json'), '{"servers":{}}');
+
+    const result = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+
+    expect(result.workspaceLinks).toBeGreaterThanOrEqual(3);
+    expect(fs.lstatSync(path.join(PROJECT_DIR, '.claude', 'commands', 'deploy.md')).isSymbolicLink()).toBe(true);
+    expect(fs.lstatSync(path.join(PROJECT_DIR, '.claude', 'skills', 'auditor')).isSymbolicLink()).toBe(true);
+    expect(fs.lstatSync(path.join(PROJECT_DIR, '.mcp.json')).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(path.join(PROJECT_DIR, '.mcp.json'), 'utf-8')).toBe('{"servers":{}}');
+  });
+
+  it('does not clobber a hand-authored .claude/agents/foo.md', () => {
+    writeFile(path.join(PROJECT_DIR, '.agents', 'subagents', 'foo.md'), '# from project rules');
+    writeFile(path.join(PROJECT_DIR, '.claude', 'agents', 'foo.md'), '# hand-authored — keep me');
+
+    const result = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+
+    expect(result.workspaceSkipped).toContain(path.join('.claude', 'agents', 'foo.md'));
+    const dest = path.join(PROJECT_DIR, '.claude', 'agents', 'foo.md');
+    expect(fs.lstatSync(dest).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(dest, 'utf-8')).toBe('# hand-authored — keep me');
+  });
+
+  it('is idempotent: running twice does not duplicate links', () => {
+    writeFile(path.join(PROJECT_DIR, '.agents', 'subagents', 'r.md'), '# r');
+
+    const first = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+    const second = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+
+    expect(first.workspaceLinks).toBe(second.workspaceLinks);
+    expect(fs.readdirSync(path.join(PROJECT_DIR, '.claude', 'agents'))).toEqual(['r.md']);
+  });
+});
+
+describe('runLaunchSync — scoped plugin marketplaces', () => {
+  it('synthesizes agents-project marketplace from cwd/.agents/plugins/*', () => {
+    writePluginManifest(path.join(PROJECT_DIR, '.agents', 'plugins', 'myproj'), 'myproj');
+
+    const result = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+
+    expect(result.marketplaces[PROJECT_MARKETPLACE_NAME]).toContain('myproj');
+    const manifestPath = marketplaceManifestPath('claude', VERSION_HOME, PROJECT_MARKETPLACE_NAME);
+    const manifest = readJson(manifestPath) as { name: string; plugins: Array<{ name: string }> };
+    expect(manifest.name).toBe(PROJECT_MARKETPLACE_NAME);
+    expect(manifest.plugins.map(p => p.name)).toEqual(['myproj']);
+
+    const settings = readJson(path.join(VERSION_HOME, '.claude', 'settings.json')) as { enabledPlugins: Record<string, boolean> };
+    expect(settings.enabledPlugins[`myproj@${PROJECT_MARKETPLACE_NAME}`]).toBe(true);
+  });
+
+  it('synthesizes agents-system and agents-cli (user) marketplaces separately', () => {
+    writePluginManifest(path.join(SYSTEM_DIR, 'plugins', 'sysplug'), 'sysplug');
+    writePluginManifest(path.join(USER_DIR, 'plugins', 'userplug'), 'userplug');
+
+    const result = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+
+    expect(result.marketplaces[SYSTEM_MARKETPLACE_NAME]).toEqual(['sysplug']);
+    expect(result.marketplaces[MARKETPLACE_NAME]).toEqual(['userplug']);
+
+    expect(fs.existsSync(path.join(marketplaceRoot('claude', VERSION_HOME, SYSTEM_MARKETPLACE_NAME), 'plugins', 'sysplug'))).toBe(true);
+    expect(fs.existsSync(path.join(marketplaceRoot('claude', VERSION_HOME, MARKETPLACE_NAME), 'plugins', 'userplug'))).toBe(true);
+
+    const known = readJson(path.join(VERSION_HOME, '.claude', 'plugins', 'known_marketplaces.json')) as Record<string, unknown>;
+    expect(Object.keys(known).sort()).toEqual([MARKETPLACE_NAME, SYSTEM_MARKETPLACE_NAME].sort());
+  });
+
+  it('returns an empty marketplaces map when no plugin sources exist', () => {
+    const result = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+
+    expect(result.marketplaces).toEqual({});
+  });
+});
+
+describe('runLaunchSync — project rules compile', () => {
+  it('compiles rules.yaml + subrules into cwd/AGENTS.md', () => {
+    writeFile(path.join(PROJECT_DIR, '.agents', 'rules', 'rules.yaml'), 'presets:\n  default:\n    subrules:\n      - hello\n');
+    writeFile(path.join(PROJECT_DIR, '.agents', 'rules', 'subrules', 'hello.md'), 'Hello from project rules.\n');
+
+    const result = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+
+    expect(result.rulesCompiled).toBe(true);
+    const agentsMd = fs.readFileSync(path.join(PROJECT_DIR, 'AGENTS.md'), 'utf-8');
+    expect(agentsMd).toContain('Hello from project rules.');
+  });
+});

--- a/src/lib/project-launch.ts
+++ b/src/lib/project-launch.ts
@@ -9,33 +9,43 @@
  *    the same helper management-side `agents sync` uses.
  *
  * 2. Mirror project resources from `<cwd>/.agents/{subagents,commands,skills}`
- *    and `<cwd>/.agents/mcp.json` into the agent's workspace-local discovery
- *    dirs (`<cwd>/.{agent}/agents/`, `<cwd>/.{agent}/commands/`,
- *    `<cwd>/.{agent}/skills/`, `<cwd>/.mcp.json`). File-level symlinks so
- *    edits in the source dir are live without re-sync. Skips any dest entry
- *    that already exists and isn't one of our symlinks (don't-clobber).
+ *    into the agent's workspace-local discovery dirs (`<cwd>/.claude/agents/`,
+ *    `<cwd>/.claude/commands/`, `<cwd>/.claude/skills/`). File-level symlinks
+ *    so edits in the source dir are live without re-sync. Skips any dest
+ *    entry that already exists and isn't one of our symlinks (don't-clobber).
+ *    v1: claude-only. Other agents have varying workspace conventions (amp
+ *    uses `~/.config/amp`, antigravity uses `~/.gemini/antigravity-cli`,
+ *    codex/gemini/cursor lack subagent support entirely) — they're follow-up
+ *    material. NOTE: `.mcp.json` is intentionally NOT auto-symlinked from
+ *    the launch path — that's a supply-chain surface (cloning a hostile
+ *    repo would auto-register an attacker MCP server). Belongs to full
+ *    `agents sync` with explicit opt-in, not the hot path.
  *
  * 3. Synthesize four scope-grouped plugin marketplaces under the version's
- *    `<versionHome>/.{agent}/plugins/marketplaces/`:
+ *    `<versionHome>/.{agent}/plugins/marketplaces/` (for plugin-capable agents):
  *      - agents-cli         ← ~/.agents/plugins/*           (user scope, legacy name)
  *      - agents-system      ← ~/.agents/.system/plugins/*
  *      - extras-<alias>     ← ~/.agents-<alias>/plugins/*   (per enabled extra)
  *      - agents-project     ← <cwd>/.agents/plugins/*
- *    Each plugin is copied in, the marketplace catalog is rewritten, the
- *    marketplace is registered in known_marketplaces.json, and every plugin
- *    is enabled in settings.json. Upstream marketplaces like
- *    "claude-plugins-official" are left untouched — we only own the four
- *    names above.
+ *    Each plugin is copied in (skip-fast via mtime cache), the marketplace
+ *    catalog is rewritten only when contents change, and the marketplace is
+ *    registered in known_marketplaces.json. Upstream marketplaces like
+ *    "claude-plugins-official" are left untouched. Project- and extras-
+ *    scope plugins do NOT auto-enable exec surfaces (.mcp.json, hooks, bin/,
+ *    scripts/) — user must explicitly `agents plugins enable` them.
  *
  * Heavy work (version-home reconciliation, hook registration, MCP merging)
  * stays in `agents sync` without --launch and is NOT touched here. The
- * launch path is filesystem-only and aims for sub-50ms in steady state.
+ * launch path is filesystem-only and skip-fast: sub-50ms when no source
+ * has changed, scales linearly only with newly-modified plugins on the
+ * change path.
  */
 
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
-import { AGENTS } from './agents.js';
 import type { AgentId } from './types.js';
+import { supports } from './capabilities.js';
 import {
   getEnabledExtraRepos,
   getExtraPluginsDir,
@@ -47,13 +57,17 @@ import {
 import { getVersionHomePath } from './versions.js';
 import { compileRulesForProject } from './rules/compile.js';
 import { discoverPluginsInDir } from './plugins.js';
+import type { DiscoveredPlugin } from './types.js';
 import {
   MARKETPLACE_NAME,
   PROJECT_MARKETPLACE_NAME,
   SYSTEM_MARKETPLACE_NAME,
   copyPluginToMarketplace,
+  disablePluginInSettings,
   enablePluginInSettings,
   extrasMarketplaceName,
+  marketplaceRoot,
+  pluginInstallDir,
   registerMarketplace,
   syncMarketplaceManifest,
 } from './plugin-marketplace.js';
@@ -124,13 +138,16 @@ const CLAUDE_MIRROR_PLANS: MirrorPlan[] = [
 ];
 
 function mirrorWorkspaceResources(cwd: string, agent: AgentId): { links: number; skipped: string[] } {
+  // v1: claude-only. Other agents have workspace conventions we haven't
+  // mapped (amp: ~/.config/amp; antigravity: ~/.gemini/antigravity-cli;
+  // codex/gemini/cursor: no subagent support per capabilities). Adding them
+  // requires per-agent workspaceDirName + capability gates — follow-up.
+  if (agent !== 'claude') return { links: 0, skipped: [] };
+
   const projectAgentsDir = getProjectAgentsDir(cwd);
   if (!projectAgentsDir) return { links: 0, skipped: [] };
 
-  const agentConfig = AGENTS[agent];
-  if (!agentConfig) return { links: 0, skipped: [] };
-
-  const agentWorkspaceDir = path.join(cwd, path.basename(agentConfig.configDir));
+  const agentWorkspaceDir = path.join(cwd, '.claude');
   const projectAgentsResolved = (() => {
     try { return fs.realpathSync(projectAgentsDir); }
     catch { return path.resolve(projectAgentsDir); }
@@ -139,7 +156,8 @@ function mirrorWorkspaceResources(cwd: string, agent: AgentId): { links: number;
   let links = 0;
   const skipped: string[] = [];
 
-  // Mirror subagents / commands / skills.
+  // Mirror subagents / commands / skills. mcp.json is intentionally excluded
+  // — see header doc, it's a supply-chain surface.
   for (const plan of CLAUDE_MIRROR_PLANS) {
     const srcDir = path.join(projectAgentsDir, plan.srcSubdir);
     if (!fs.existsSync(srcDir)) continue;
@@ -164,24 +182,15 @@ function mirrorWorkspaceResources(cwd: string, agent: AgentId): { links: number;
     }
   }
 
-  // Mirror mcp.json → cwd/.mcp.json
-  const srcMcp = path.join(projectAgentsDir, 'mcp.json');
-  if (fs.existsSync(srcMcp)) {
-    const destMcp = path.join(cwd, '.mcp.json');
-    if (replaceWithSymlinkIfOwned(srcMcp, destMcp, projectAgentsResolved)) {
-      links += 1;
-    } else {
-      skipped.push('.mcp.json');
-    }
-  }
-
   return { links, skipped };
 }
 
 /**
  * Create or refresh a symlink at `destPath` pointing at `srcPath`. Returns
- * true if we wrote the link, false if we skipped because the destination
- * exists and isn't a symlink into the project's `.agents/` tree.
+ * true if we wrote (or already had) the link, false if we skipped because
+ * the destination is user-owned (regular file, directory, or symlink pointing
+ * outside the project's `.agents/` tree, or a dangling symlink — treated as
+ * user state we don't yet understand).
  *
  * Skip-fast: if the destination is already a symlink resolving to the
  * project-agents tree AND its target matches srcPath, no write happens.
@@ -196,17 +205,27 @@ function replaceWithSymlinkIfOwned(srcPath: string, destPath: string, projectAge
     }
     let destTargetReal: string | null = null;
     try { destTargetReal = fs.realpathSync(destPath); } catch { /* dangling */ }
-    if (destTargetReal && destTargetReal !== projectAgentsResolved && !destTargetReal.startsWith(projectAgentsResolved + path.sep)) {
+    // Dangling symlink → user-owned in-progress state; do not clobber.
+    if (destTargetReal === null) {
       return false;
     }
-    if (destTargetReal === fs.realpathSync(srcPath)) {
+    if (destTargetReal !== projectAgentsResolved && !destTargetReal.startsWith(projectAgentsResolved + path.sep)) {
+      return false;
+    }
+    let srcReal: string | null = null;
+    try { srcReal = fs.realpathSync(srcPath); } catch { /* src vanished mid-launch */ }
+    if (srcReal !== null && destTargetReal === srcReal) {
       return true; // already correct
     }
     try { fs.unlinkSync(destPath); } catch { /* ignore */ }
   }
 
-  fs.mkdirSync(path.dirname(destPath), { recursive: true });
-  fs.symlinkSync(srcPath, destPath);
+  try {
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+    fs.symlinkSync(srcPath, destPath);
+  } catch {
+    return false;
+  }
   return true;
 }
 
@@ -215,21 +234,36 @@ function replaceWithSymlinkIfOwned(srcPath: string, destPath: string, projectAge
 interface PluginScope {
   marketplaceName: string;
   pluginsDir: string;
+  /**
+   * When false, plugins with exec surfaces (.mcp.json, hooks, bin/, scripts/,
+   * non-trivial settings.json) are copied but NOT auto-enabled. User must
+   * explicitly `agents plugins enable` them. Protects against hostile
+   * `git clone` registering an attacker MCP server via project plugins.
+   */
+  autoEnableExecSurfaces: boolean;
+  /** Precedence rank used to resolve cross-scope plugin name collisions. Higher wins. */
+  precedence: number;
 }
 
 function collectPluginScopes(cwd: string): PluginScope[] {
   const scopes: PluginScope[] = [];
 
-  scopes.push({ marketplaceName: SYSTEM_MARKETPLACE_NAME, pluginsDir: getSystemPluginsDir() });
-  scopes.push({ marketplaceName: MARKETPLACE_NAME,        pluginsDir: getPluginsDir() });
+  // Precedence: project > extras > user > system. Same direction the rules
+  // composition uses (project layer shadows base layers).
+  scopes.push({ marketplaceName: SYSTEM_MARKETPLACE_NAME, pluginsDir: getSystemPluginsDir(),
+    autoEnableExecSurfaces: true, precedence: 0 });
+  scopes.push({ marketplaceName: MARKETPLACE_NAME,        pluginsDir: getPluginsDir(),
+    autoEnableExecSurfaces: true, precedence: 1 });
 
   for (const extra of getEnabledExtraRepos()) {
-    scopes.push({ marketplaceName: extrasMarketplaceName(extra.alias), pluginsDir: getExtraPluginsDir(extra.alias) });
+    scopes.push({ marketplaceName: extrasMarketplaceName(extra.alias), pluginsDir: getExtraPluginsDir(extra.alias),
+      autoEnableExecSurfaces: false, precedence: 2 });
   }
 
   const projectPluginsDir = getProjectPluginsDir(cwd);
   if (projectPluginsDir) {
-    scopes.push({ marketplaceName: PROJECT_MARKETPLACE_NAME, pluginsDir: projectPluginsDir });
+    scopes.push({ marketplaceName: PROJECT_MARKETPLACE_NAME, pluginsDir: projectPluginsDir,
+      autoEnableExecSurfaces: false, precedence: 3 });
   }
 
   return scopes;
@@ -237,6 +271,8 @@ function collectPluginScopes(cwd: string): PluginScope[] {
 
 function synthesizeScopedMarketplaces(agent: AgentId, version: string, cwd: string): Record<string, string[]> {
   const result: Record<string, string[]> = {};
+
+  if (!supports(agent, 'plugins', version).ok) return result;
 
   let versionHome: string;
   try {
@@ -246,34 +282,157 @@ function synthesizeScopedMarketplaces(agent: AgentId, version: string, cwd: stri
   }
   if (!fs.existsSync(versionHome)) return result;
 
+  // First pass: resolve cross-scope plugin name collisions by precedence.
+  // For each plugin name, the scope with the highest precedence wins; the
+  // plugin is installed only into that scope's marketplace.
+  const winner = new Map<string, { scope: PluginScope; plugin: DiscoveredPlugin }>();
   for (const scope of collectPluginScopes(cwd)) {
     if (!fs.existsSync(scope.pluginsDir)) continue;
-    const plugins = discoverPluginsInDir(scope.pluginsDir);
-    if (plugins.length === 0) continue;
-
-    const installed: string[] = [];
-    for (const plugin of plugins) {
-      try {
-        copyPluginToMarketplace(plugin, agent, versionHome, scope.marketplaceName);
-        installed.push(plugin.name);
-      } catch {
-        // Individual plugin copy failure — keep going on the others.
+    for (const plugin of discoverPluginsInDir(scope.pluginsDir)) {
+      const existing = winner.get(plugin.name);
+      if (!existing || scope.precedence > existing.scope.precedence) {
+        winner.set(plugin.name, { scope, plugin });
       }
     }
-    if (installed.length === 0) continue;
-
-    syncMarketplaceManifest(agent, versionHome, scope.marketplaceName);
-    registerMarketplace(agent, versionHome, scope.marketplaceName);
-
-    for (const name of installed) {
-      enablePluginInSettings(name, agent, versionHome, {
-        allowExecSurfaces: true,
-        marketplaceName: scope.marketplaceName,
-      });
-    }
-
-    result[scope.marketplaceName] = installed;
   }
+  if (winner.size === 0) return result;
+
+  // Group winners by their winning scope and synthesize one marketplace per
+  // scope. Skip-fast: scope hash sentinel short-circuits unchanged scopes.
+  const byScope = new Map<string, { scope: PluginScope; plugins: DiscoveredPlugin[] }>();
+  for (const { scope, plugin } of winner.values()) {
+    let bucket = byScope.get(scope.marketplaceName);
+    if (!bucket) {
+      bucket = { scope, plugins: [] };
+      byScope.set(scope.marketplaceName, bucket);
+    }
+    bucket.plugins.push(plugin);
+  }
+
+  for (const { scope, plugins } of byScope.values()) {
+    plugins.sort((a, b) => a.name.localeCompare(b.name));
+    const installed = installScope(agent, versionHome, scope, plugins);
+    if (installed.length > 0) result[scope.marketplaceName] = installed;
+  }
+
+  // Sweep any orphaned `<plugin>@*` keys whose plugin name is now owned by a
+  // different scope (e.g. plugin moved from user to project). Without this,
+  // the OLD scope's enabledPlugins key stays set forever, double-enabling.
+  pruneLosingScopeEnables(agent, versionHome, winner);
 
   return result;
 }
+
+function installScope(
+  agent: AgentId,
+  versionHome: string,
+  scope: PluginScope,
+  plugins: DiscoveredPlugin[],
+): string[] {
+  const newHash = computeScopeHash(plugins);
+  const sentinelPath = path.join(marketplaceRoot(agent, versionHome, scope.marketplaceName), '.agents-launch-sync');
+  const existingHash = readScopeHash(sentinelPath);
+
+  if (existingHash === newHash) {
+    // Nothing changed since last launch — fast path. Verify the manifest
+    // dir still exists; if a user blew it away, force a re-sync.
+    if (fs.existsSync(path.dirname(sentinelPath))) {
+      return plugins.map((p) => p.name);
+    }
+  }
+
+  const installed: string[] = [];
+  for (const plugin of plugins) {
+    try {
+      copyPluginToMarketplace(plugin, agent, versionHome, scope.marketplaceName);
+      installed.push(plugin.name);
+    } catch {
+      // Individual plugin copy failure — keep going on the others.
+    }
+  }
+  if (installed.length === 0) return [];
+
+  syncMarketplaceManifest(agent, versionHome, scope.marketplaceName);
+  registerMarketplace(agent, versionHome, scope.marketplaceName);
+
+  for (const name of installed) {
+    enablePluginInSettings(name, agent, versionHome, {
+      allowExecSurfaces: scope.autoEnableExecSurfaces,
+      marketplaceName: scope.marketplaceName,
+    });
+  }
+
+  writeScopeHash(sentinelPath, newHash);
+  return installed;
+}
+
+function pruneLosingScopeEnables(
+  agent: AgentId,
+  versionHome: string,
+  winner: Map<string, { scope: PluginScope; plugin: DiscoveredPlugin }>,
+): void {
+  const ourScopeNames = new Set([
+    SYSTEM_MARKETPLACE_NAME,
+    MARKETPLACE_NAME,
+    PROJECT_MARKETPLACE_NAME,
+    ...getEnabledExtraRepos().map((e) => extrasMarketplaceName(e.alias)),
+  ]);
+
+  for (const [name, { scope: winningScope }] of winner) {
+    for (const candidateScope of ourScopeNames) {
+      if (candidateScope === winningScope.marketplaceName) continue;
+      disablePluginInSettings(name, agent, versionHome, candidateScope);
+    }
+  }
+}
+
+/**
+ * Hash the plugin set so we can skip-fast when nothing changed since the
+ * last launch. Includes the source path (catches moves), the .claude-plugin/
+ * plugin.json content (catches metadata edits), and the file-mtime+size
+ * fingerprint of every file in the plugin (catches code edits).
+ */
+function computeScopeHash(plugins: DiscoveredPlugin[]): string {
+  const hash = crypto.createHash('sha256');
+  for (const plugin of [...plugins].sort((a, b) => a.name.localeCompare(b.name))) {
+    hash.update(`${plugin.name}\0${plugin.root}\0`);
+    fingerprintDir(plugin.root, hash);
+    hash.update('\0SEP\0');
+  }
+  return hash.digest('hex');
+}
+
+function fingerprintDir(dir: string, hash: crypto.Hash): void {
+  let entries: fs.Dirent[];
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); }
+  catch { return; }
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === '.git') continue;
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      hash.update(`D ${entry.name}\n`);
+      fingerprintDir(abs, hash);
+    } else {
+      try {
+        const stat = fs.lstatSync(abs);
+        hash.update(`F ${entry.name} ${stat.size} ${stat.mtimeMs}\n`);
+      } catch { /* race during launch — skip */ }
+    }
+  }
+}
+
+function readScopeHash(sentinelPath: string): string | null {
+  try { return fs.readFileSync(sentinelPath, 'utf-8').trim(); }
+  catch { return null; }
+}
+
+function writeScopeHash(sentinelPath: string, hash: string): void {
+  try {
+    fs.mkdirSync(path.dirname(sentinelPath), { recursive: true });
+    fs.writeFileSync(sentinelPath, hash + '\n');
+  } catch { /* best-effort; missing sentinel just means next launch does full work */ }
+}
+
+// Re-export for the test's structural assertions; not used internally.
+export { pluginInstallDir };

--- a/src/lib/project-launch.ts
+++ b/src/lib/project-launch.ts
@@ -1,0 +1,279 @@
+/**
+ * Launch-time project compile. Invoked by the agent shim's hot path (via
+ * `agents sync --launch`) between version resolve and binary exec.
+ *
+ * Three responsibilities, all skip-fast when there's nothing to do:
+ *
+ * 1. Compile project rules from `<cwd>/.agents/rules/` into `<cwd>/AGENTS.md`
+ *    (+ per-agent symlinks). Delegates to compileRulesForProject, which is
+ *    the same helper management-side `agents sync` uses.
+ *
+ * 2. Mirror project resources from `<cwd>/.agents/{subagents,commands,skills}`
+ *    and `<cwd>/.agents/mcp.json` into the agent's workspace-local discovery
+ *    dirs (`<cwd>/.{agent}/agents/`, `<cwd>/.{agent}/commands/`,
+ *    `<cwd>/.{agent}/skills/`, `<cwd>/.mcp.json`). File-level symlinks so
+ *    edits in the source dir are live without re-sync. Skips any dest entry
+ *    that already exists and isn't one of our symlinks (don't-clobber).
+ *
+ * 3. Synthesize four scope-grouped plugin marketplaces under the version's
+ *    `<versionHome>/.{agent}/plugins/marketplaces/`:
+ *      - agents-cli         ← ~/.agents/plugins/*           (user scope, legacy name)
+ *      - agents-system      ← ~/.agents/.system/plugins/*
+ *      - extras-<alias>     ← ~/.agents-<alias>/plugins/*   (per enabled extra)
+ *      - agents-project     ← <cwd>/.agents/plugins/*
+ *    Each plugin is copied in, the marketplace catalog is rewritten, the
+ *    marketplace is registered in known_marketplaces.json, and every plugin
+ *    is enabled in settings.json. Upstream marketplaces like
+ *    "claude-plugins-official" are left untouched — we only own the four
+ *    names above.
+ *
+ * Heavy work (version-home reconciliation, hook registration, MCP merging)
+ * stays in `agents sync` without --launch and is NOT touched here. The
+ * launch path is filesystem-only and aims for sub-50ms in steady state.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { AGENTS } from './agents.js';
+import type { AgentId } from './types.js';
+import {
+  getEnabledExtraRepos,
+  getExtraPluginsDir,
+  getPluginsDir,
+  getProjectAgentsDir,
+  getProjectPluginsDir,
+  getSystemPluginsDir,
+} from './state.js';
+import { getVersionHomePath } from './versions.js';
+import { compileRulesForProject } from './rules/compile.js';
+import { discoverPluginsInDir } from './plugins.js';
+import {
+  MARKETPLACE_NAME,
+  PROJECT_MARKETPLACE_NAME,
+  SYSTEM_MARKETPLACE_NAME,
+  copyPluginToMarketplace,
+  enablePluginInSettings,
+  extrasMarketplaceName,
+  registerMarketplace,
+  syncMarketplaceManifest,
+} from './plugin-marketplace.js';
+
+export interface LaunchSyncOptions {
+  agent: AgentId;
+  version: string;
+  cwd: string;
+}
+
+export interface LaunchSyncResult {
+  /** Project rules were re-compiled into cwd/AGENTS.md (+ per-agent symlinks). */
+  rulesCompiled: boolean;
+  /** Number of workspace resource symlinks created or refreshed. */
+  workspaceLinks: number;
+  /** Workspace resource paths we left alone because they exist and aren't ours. */
+  workspaceSkipped: string[];
+  /** Map of marketplace name → plugin names installed under it. */
+  marketplaces: Record<string, string[]>;
+}
+
+/**
+ * Run the launch-time project compile. Safe to call on every agent launch:
+ * each step is idempotent and skips when its inputs are missing.
+ */
+export function runLaunchSync(opts: LaunchSyncOptions): LaunchSyncResult {
+  const result: LaunchSyncResult = {
+    rulesCompiled: false,
+    workspaceLinks: 0,
+    workspaceSkipped: [],
+    marketplaces: {},
+  };
+
+  // Step 1: project rules
+  try {
+    const r = compileRulesForProject(opts.cwd);
+    result.rulesCompiled = r.compiled;
+  } catch {
+    // Don't fail launch on a malformed project rules.yaml.
+  }
+
+  // Step 2: workspace resource mirror
+  const mirror = mirrorWorkspaceResources(opts.cwd, opts.agent);
+  result.workspaceLinks = mirror.links;
+  result.workspaceSkipped = mirror.skipped;
+
+  // Step 3: scoped plugin marketplaces
+  result.marketplaces = synthesizeScopedMarketplaces(opts.agent, opts.version, opts.cwd);
+
+  return result;
+}
+
+// ─── Step 2: workspace resource mirror ────────────────────────────────────────
+
+interface MirrorPlan {
+  /** Source dir under `<cwd>/.agents/`. */
+  srcSubdir: string;
+  /** Dest subdir under `<cwd>/.{agent}/`. */
+  destSubdir: string;
+  /** True when entries are directories (skills); false when entries are files (md). */
+  entriesAreDirs: boolean;
+}
+
+const CLAUDE_MIRROR_PLANS: MirrorPlan[] = [
+  { srcSubdir: 'subagents', destSubdir: 'agents',   entriesAreDirs: false },
+  { srcSubdir: 'commands',  destSubdir: 'commands', entriesAreDirs: false },
+  { srcSubdir: 'skills',    destSubdir: 'skills',   entriesAreDirs: true },
+];
+
+function mirrorWorkspaceResources(cwd: string, agent: AgentId): { links: number; skipped: string[] } {
+  const projectAgentsDir = getProjectAgentsDir(cwd);
+  if (!projectAgentsDir) return { links: 0, skipped: [] };
+
+  const agentConfig = AGENTS[agent];
+  if (!agentConfig) return { links: 0, skipped: [] };
+
+  const agentWorkspaceDir = path.join(cwd, path.basename(agentConfig.configDir));
+  const projectAgentsResolved = (() => {
+    try { return fs.realpathSync(projectAgentsDir); }
+    catch { return path.resolve(projectAgentsDir); }
+  })();
+
+  let links = 0;
+  const skipped: string[] = [];
+
+  // Mirror subagents / commands / skills.
+  for (const plan of CLAUDE_MIRROR_PLANS) {
+    const srcDir = path.join(projectAgentsDir, plan.srcSubdir);
+    if (!fs.existsSync(srcDir)) continue;
+
+    const destDir = path.join(agentWorkspaceDir, plan.destSubdir);
+    fs.mkdirSync(destDir, { recursive: true });
+
+    const entries = fs.readdirSync(srcDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) continue;
+      if (plan.entriesAreDirs && !entry.isDirectory()) continue;
+      if (!plan.entriesAreDirs && !entry.isFile() && !entry.isSymbolicLink()) continue;
+
+      const srcPath = path.join(srcDir, entry.name);
+      const destPath = path.join(destDir, entry.name);
+
+      if (replaceWithSymlinkIfOwned(srcPath, destPath, projectAgentsResolved)) {
+        links += 1;
+      } else {
+        skipped.push(path.relative(cwd, destPath));
+      }
+    }
+  }
+
+  // Mirror mcp.json → cwd/.mcp.json
+  const srcMcp = path.join(projectAgentsDir, 'mcp.json');
+  if (fs.existsSync(srcMcp)) {
+    const destMcp = path.join(cwd, '.mcp.json');
+    if (replaceWithSymlinkIfOwned(srcMcp, destMcp, projectAgentsResolved)) {
+      links += 1;
+    } else {
+      skipped.push('.mcp.json');
+    }
+  }
+
+  return { links, skipped };
+}
+
+/**
+ * Create or refresh a symlink at `destPath` pointing at `srcPath`. Returns
+ * true if we wrote the link, false if we skipped because the destination
+ * exists and isn't a symlink into the project's `.agents/` tree.
+ *
+ * Skip-fast: if the destination is already a symlink resolving to the
+ * project-agents tree AND its target matches srcPath, no write happens.
+ */
+function replaceWithSymlinkIfOwned(srcPath: string, destPath: string, projectAgentsResolved: string): boolean {
+  let destLstat: fs.Stats | null = null;
+  try { destLstat = fs.lstatSync(destPath); } catch { /* missing — write fresh */ }
+
+  if (destLstat) {
+    if (!destLstat.isSymbolicLink()) {
+      return false;
+    }
+    let destTargetReal: string | null = null;
+    try { destTargetReal = fs.realpathSync(destPath); } catch { /* dangling */ }
+    if (destTargetReal && destTargetReal !== projectAgentsResolved && !destTargetReal.startsWith(projectAgentsResolved + path.sep)) {
+      return false;
+    }
+    if (destTargetReal === fs.realpathSync(srcPath)) {
+      return true; // already correct
+    }
+    try { fs.unlinkSync(destPath); } catch { /* ignore */ }
+  }
+
+  fs.mkdirSync(path.dirname(destPath), { recursive: true });
+  fs.symlinkSync(srcPath, destPath);
+  return true;
+}
+
+// ─── Step 3: scoped plugin marketplaces ───────────────────────────────────────
+
+interface PluginScope {
+  marketplaceName: string;
+  pluginsDir: string;
+}
+
+function collectPluginScopes(cwd: string): PluginScope[] {
+  const scopes: PluginScope[] = [];
+
+  scopes.push({ marketplaceName: SYSTEM_MARKETPLACE_NAME, pluginsDir: getSystemPluginsDir() });
+  scopes.push({ marketplaceName: MARKETPLACE_NAME,        pluginsDir: getPluginsDir() });
+
+  for (const extra of getEnabledExtraRepos()) {
+    scopes.push({ marketplaceName: extrasMarketplaceName(extra.alias), pluginsDir: getExtraPluginsDir(extra.alias) });
+  }
+
+  const projectPluginsDir = getProjectPluginsDir(cwd);
+  if (projectPluginsDir) {
+    scopes.push({ marketplaceName: PROJECT_MARKETPLACE_NAME, pluginsDir: projectPluginsDir });
+  }
+
+  return scopes;
+}
+
+function synthesizeScopedMarketplaces(agent: AgentId, version: string, cwd: string): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
+
+  let versionHome: string;
+  try {
+    versionHome = getVersionHomePath(agent, version);
+  } catch {
+    return result;
+  }
+  if (!fs.existsSync(versionHome)) return result;
+
+  for (const scope of collectPluginScopes(cwd)) {
+    if (!fs.existsSync(scope.pluginsDir)) continue;
+    const plugins = discoverPluginsInDir(scope.pluginsDir);
+    if (plugins.length === 0) continue;
+
+    const installed: string[] = [];
+    for (const plugin of plugins) {
+      try {
+        copyPluginToMarketplace(plugin, agent, versionHome, scope.marketplaceName);
+        installed.push(plugin.name);
+      } catch {
+        // Individual plugin copy failure — keep going on the others.
+      }
+    }
+    if (installed.length === 0) continue;
+
+    syncMarketplaceManifest(agent, versionHome, scope.marketplaceName);
+    registerMarketplace(agent, versionHome, scope.marketplaceName);
+
+    for (const name of installed) {
+      enablePluginInSettings(name, agent, versionHome, {
+        allowExecSurfaces: true,
+        marketplaceName: scope.marketplaceName,
+      });
+    }
+
+    result[scope.marketplaceName] = installed;
+  }
+
+  return result;
+}

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -215,8 +215,14 @@ async function promptConflictStrategy(
  *   v15 — remove foreground resource sync / rules refresh from launch shims.
  *         Version homes are reconciled by agents-cli management commands; the
  *         shim hot path only resolves a version and execs the agent binary.
+ *   v16 — re-introduce project-scoped compile to the shim hot path via
+ *         `agents sync --launch`. This stays fast (filesystem-only): compiles
+ *         project rules, mirrors workspace resources, and synthesizes the
+ *         scoped plugin marketplaces (agents-cli/agents-system/extras-<alias>/
+ *         agents-project). Version-home reconciliation stays out of the hot
+ *         path — management commands still own that.
  */
-export const SHIM_SCHEMA_VERSION = 15;
+export const SHIM_SCHEMA_VERSION = 16;
 
 /** Internal marker string used to embed the schema version in shim scripts. */
 const SHIM_VERSION_MARKER = 'agents-shim-version:';
@@ -484,6 +490,10 @@ if [ ! -x "$BINARY" ]; then
 fi
 
 ${managedEnv}
+
+# Project-scoped compile (rules, workspace resources, scoped plugin marketplaces).
+# Filesystem-only — sub-50ms steady state. Never blocks launch on failure.
+"$AGENTS_BIN" sync --agent "$AGENT" --agent-version "$VERSION" --launch --cwd "$PWD" --quiet 2>/dev/null || true
 
 exec "$BINARY"${launchArgs} "$@"
 `;

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -64,6 +64,7 @@ const SYSTEM_MCP_DIR = path.join(SYSTEM_AGENTS_DIR, 'mcp');
 const SYSTEM_PERMISSIONS_DIR = path.join(SYSTEM_AGENTS_DIR, 'permissions');
 const SYSTEM_SUBAGENTS_DIR = path.join(SYSTEM_AGENTS_DIR, 'subagents');
 const SYSTEM_WORKFLOWS_DIR = path.join(SYSTEM_AGENTS_DIR, 'workflows');
+const SYSTEM_PLUGINS_DIR = path.join(SYSTEM_AGENTS_DIR, 'plugins');
 const SYSTEM_PROMPTCUTS_FILE = path.join(SYSTEM_AGENTS_DIR, 'hooks', 'promptcuts.yaml');
 const SYSTEM_MCP_CONFIG_FILE = path.join(SYSTEM_AGENTS_DIR, 'mcp.json');
 const SYSTEM_INSTRUCTIONS_FILE = path.join(SYSTEM_AGENTS_DIR, 'instructions.md');
@@ -360,6 +361,21 @@ export function getBackupsDir(): string { return BACKUPS_DIR; }
 
 /** Path to plugin bundles (~/.agents/plugins/) — user-authored resource. */
 export function getPluginsDir(): string { return PLUGINS_DIR; }
+
+/** Path to system plugin bundles (~/.agents/.system/plugins/) — npm-shipped, read-only defaults. */
+export function getSystemPluginsDir(): string { return SYSTEM_PLUGINS_DIR; }
+
+/** Path to an extra repo's plugin bundles (~/.agents-<alias>/plugins/). */
+export function getExtraPluginsDir(alias: string): string {
+  return path.join(getExtraRepoDir(alias), 'plugins');
+}
+
+/** Path to a project-scoped plugins directory (<project>/.agents/plugins/), or null when none. */
+export function getProjectPluginsDir(cwd: string = process.cwd()): string | null {
+  const projectAgentsDir = getProjectAgentsDir(cwd);
+  if (!projectAgentsDir) return null;
+  return path.join(projectAgentsDir, 'plugins');
+}
 
 /** Path to synced remote session data (~/.agents/.cache/drive/). */
 export function getDriveDir(): string { return DRIVE_DIR; }


### PR DESCRIPTION
## Summary

Re-introduces a fast, **project-scoped** compile to the shim hot path via a new `agents sync --launch` mode. Filesystem-only, sub-50ms steady state — much narrower than the v14 full sync that v15 removed.

This fixes a real UX gap: project-level resources under `<repo>/.agents/` (rules, subagents, commands, skills, mcp.json, plugins) were effectively dead unless the user knew to manually invoke `agents sync --project-dir <repo>/.agents`. Now they auto-load on every agent launch in the project's cwd, the same way Claude already auto-discovers workspace-local `./CLAUDE.md` and `./.claude/agents/`.

Three things happen on every launch when cwd has resources:

1. **Project rules** from `<cwd>/.agents/rules/` compile into `<cwd>/AGENTS.md` (+ per-agent symlinks) via the existing `compileRulesForProject` — same helper management-side ``agents sync`` already uses.
2. **Workspace resources** (`<cwd>/.agents/{subagents,commands,skills}/*`, `<cwd>/.agents/mcp.json`) are symlinked into the agent's workspace-local discovery dirs (`<cwd>/.{agent}/{agents,commands,skills}/`, `<cwd>/.mcp.json`). File-level symlinks so edits in the source dir are live without re-sync. Don't-clobber guard: skips any destination that exists and isn't one of our symlinks.
3. **Plugin marketplaces** are synthesized per source scope under the version home, instead of bundling everything under one ``agents-cli`` name:

   | Source | Marketplace name |
   |---|---|
   | `~/.agents/plugins/*` | `agents-cli` (legacy name kept for backward compat) |
   | `~/.agents/.system/plugins/*` | `agents-system` |
   | `~/.agents-<alias>/plugins/*` | `extras-<alias>` |
   | `<cwd>/.agents/plugins/*` | `agents-project` |

   Real upstream marketplaces (`claude-plugins-official`, etc.) are untouched. Slash commands stay `/<plugin>:<command>` — the marketplace name only changes attribution in `/plugins`.

The heavy `agents sync` (version-home reconciliation, hook registration, content-equality diffs, MCP merging) stays out of the hot path — management commands still own that. Shim schema bumped to v16.

## What's in this PR

- `src/lib/project-launch.ts` (new) — `runLaunchSync({agent, version, cwd})` exporting the three steps above.
- `src/lib/project-launch.test.ts` (new) — 8 tests, real fs, no business-logic mocks.
- `src/lib/plugin-marketplace.ts` — thread an optional `marketplaceName` parameter through `marketplaceRoot`, `copyPluginToMarketplace`, `syncMarketplaceManifest`, `registerMarketplace`, `enablePluginInSettings`, etc. Defaults to `MARKETPLACE_NAME` (= `'agents-cli'`) so every existing call site is unaffected.
- `src/lib/plugins.ts` — extract `discoverPluginsInDir(pluginsDir)` from `discoverPlugins()` so non-user-scope plugin source dirs can be scanned.
- `src/lib/state.ts` — add `getSystemPluginsDir()`, `getExtraPluginsDir(alias)`, `getProjectPluginsDir(cwd)`.
- `src/commands/sync.ts` — add `--launch` flag. When set, skips `syncResourcesToVersion` entirely and calls `runLaunchSync` instead.
- `src/lib/shims.ts` — bump `SHIM_SCHEMA_VERSION` 15 → 16. Inject one line in `generateShimScript` between version-resolve and exec:
  ``$AGENTS_BIN sync --agent $AGENT --agent-version $VERSION --launch --cwd $PWD --quiet 2>/dev/null || true``

## Test plan

- [x] ``bun test src/lib/project-launch.test.ts`` — 8/8 pass.
- [x] ``bun test src/lib/__tests__/plugin-marketplace.test.ts`` — 4/4 pass (existing marketplace tests, no regressions).
- [x] ``bun test src/lib/plugins.test.ts`` — same 37 pass / 15 fail as origin/main. 15 failures are pre-existing bun-vitest API gaps (``vi.doUnmock``, ``vi.resetModules``, ``vi.importActual``), not regressions.
- [x] ``bun --bun tsc --noEmit`` — clean.
- [x] **End-to-end via PTY:** launched a fresh ``claude --model claude-haiku-4-5 -p`` in a tmp dir containing only ``.agents/rules/subrules/banana.md`` (sentinel: ``BANANA-PANCAKE-9999``). Claude replied with the exact sentinel, proving the shim auto-fired ``sync --launch``, rules compiled to ``AGENTS.md`` + ``CLAUDE.md`` symlink, and Claude's native loader picked them up — no manual sync invocation.

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/fcf9d62b9f53250b85b2c4cab710c36c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)