### PR TITLE
fix(shims): stop spurious repair prompts on --version, make repair honest

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,7 @@ import {
   ensureVersionedAliasCurrent,
   getPathShadowingExecutable,
   getPathSetupInstructions,
-  hasAliasShadowingShim,
+  getShimsDir,
   isShimsInPath,
   listAgentsWithInstalledVersions,
   removeLegacyUserShim,
@@ -445,8 +445,18 @@ async function checkForUpdates(): Promise<void> {
   }
 }
 
-async function maybeBootstrapShimIntegration(requestedCommand: string | undefined): Promise<void> {
+async function maybeBootstrapShimIntegration(
+  requestedCommand: string | undefined,
+  helpOrVersionRequested: boolean,
+): Promise<void> {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    return;
+  }
+  // Pure documentation paths must never trigger interactive repair — mirrors
+  // the helpOrVersionRequested gate around ensureInitialized below. Covers
+  // both bare `agents --version` (requestedCommand === undefined) and
+  // `agents <subcommand> --help` (requestedCommand === subcommand name).
+  if (helpOrVersionRequested) {
     return;
   }
   if (requestedCommand === 'sync' || requestedCommand === 'refresh-rules') {
@@ -488,12 +498,13 @@ async function maybeBootstrapShimIntegration(requestedCommand: string | undefine
     .map((agent) => ({ agent, shadowedBy: getPathShadowingExecutable(agent) }))
     .filter((item): item is { agent: keyof typeof AGENTS; shadowedBy: string } => Boolean(item.shadowedBy));
 
-  // Also check for shell aliases that shadow the shim
-  const aliased = defaultAgents.filter((agent) => hasAliasShadowingShim(agent));
-
-  // If shims are in PATH and nothing is binary-shadowing, we're done.
   // Shell aliases that call the same command with extra flags are intentional
-  // customization and don't break shim integration.
+  // customization and don't break shim integration — `addShimsToPath` cannot
+  // touch them, so they don't belong in the repair prompt. We previously
+  // computed an `aliased` list here and inserted it into `affected`, which
+  // contradicted the comment below and surfaced false positives (e.g. an
+  // earlier `alias codex=...` cancelled by a later `unalias codex` was
+  // reported because the detector did a static rc-file regex).
   if (shadowed.length === 0 && isShimsInPath()) {
     return;
   }
@@ -512,14 +523,11 @@ async function maybeBootstrapShimIntegration(requestedCommand: string | undefine
   for (const { agent, shadowedBy } of shadowed) {
     affected.push(`${AGENTS[agent].cliCommand} -> ${shadowedBy}`);
   }
-  for (const agent of aliased) {
-    if (!shadowed.some((s) => s.agent === agent)) {
-      affected.push(`${AGENTS[agent].cliCommand} (alias)`);
-    }
-  }
   if (affected.length === 0) {
-    // PATH issue - show all installed agents
-    affected.push(...installedAgents.map((agent) => AGENTS[agent].cliCommand));
+    // Pure PATH-not-loaded case: rc may already have the shim block, but the
+    // running shell hasn't sourced it. Don't list agents here — they aren't
+    // broken; only the PATH is stale. The prompt + post-message handle it.
+    affected.push('PATH entry missing');
   }
 
   const shouldRepair = await confirm({
@@ -538,15 +546,34 @@ async function maybeBootstrapShimIntegration(requestedCommand: string | undefine
   if (!pathResult.success) {
     console.log(chalk.yellow('Could not repair shim PATH setup automatically.'));
     console.log(chalk.gray(pathResult.error || getPathSetupInstructions()));
+    // Write the sentinel even on failure — otherwise an unwritable rc file
+    // re-prompts every invocation in the same shell. The user opens a new
+    // terminal (new PPID) to retry.
+    try { fs.writeFileSync(sentinelPath, '1'); } catch { /* best-effort */ }
     return;
   }
 
+  // When the rc file already has the canonical shim block, `addShimsToPath`
+  // is a no-op — re-emitting produced byte-identical content. In this branch
+  // the user clicked "Yes" but nothing changed on disk, AND the underlying
+  // cause (a real binary shadow, or a stale shell PATH) is unaffected by
+  // this command. Be honest about it and point at the actual action.
   if (pathResult.alreadyPresent) {
-    console.log(chalk.yellow('Shim PATH entry is already in your shell config, but this shell has not reloaded it yet.'));
+    if (shadowed.length > 0) {
+      const targets = shadowed
+        .map(({ agent, shadowedBy }) => `  ${AGENTS[agent].cliCommand}: ${shadowedBy}`)
+        .join('\n');
+      console.log(chalk.yellow('Repair could not change anything — the shim is shadowed by another binary on PATH:'));
+      console.log(chalk.gray(targets));
+      console.log(chalk.gray(`Fix it by removing or reordering that binary, or making sure ${getShimsDir()} appears earlier in PATH than its parent dir.`));
+    } else {
+      console.log(chalk.yellow(`Shim PATH entry is already in ~/${pathResult.rcFile} — this shell just needs to reload it.`));
+      console.log(chalk.gray(`Run: source ~/${pathResult.rcFile}   (or open a new terminal)`));
+    }
   } else {
     console.log(chalk.green(`Repaired shim PATH setup in ~/${pathResult.rcFile}`));
+    console.log(chalk.gray(getPathSetupInstructions()));
   }
-  console.log(chalk.gray(getPathSetupInstructions()));
   try { fs.writeFileSync(sentinelPath, '1'); } catch { /* best-effort */ }
 }
 
@@ -868,7 +895,7 @@ if (process.env.AGENTS_SKIP_MIGRATION !== '1') {
 }
 
 try {
-  await maybeBootstrapShimIntegration(requestedCommand);
+  await maybeBootstrapShimIntegration(requestedCommand, helpOrVersionRequested);
   await program.parseAsync();
 } catch (err) {
   if (err instanceof Error && err.name === 'ExitPromptError') {

--- a/src/lib/shims.test.ts
+++ b/src/lib/shims.test.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { spawnSync } from 'child_process';
 import { afterEach, describe, expect, it } from 'vitest';
-import { generateShimScript, SHIM_SCHEMA_VERSION } from './shims.js';
+import { generateShimScript, hasAliasShadowingShim, SHIM_SCHEMA_VERSION } from './shims.js';
 import { getProjectVersion } from './versions.js';
 
 const tempDirs: string[] = [];
@@ -221,5 +221,43 @@ describe('claude shim .oauth_token fallback', () => {
     expect(result.status, result.stderr).toBe(0);
     const log = fs.readFileSync(logPath, 'utf-8');
     expect(log).toContain('TOKEN:<unset>');
+  });
+});
+
+describe('hasAliasShadowingShim', () => {
+  function makeFakeHome(rc: string): string {
+    const home = makeTempDir();
+    fs.writeFileSync(path.join(home, '.zshrc'), rc);
+    return home;
+  }
+
+  it('returns true for a plain `alias codex=...`', () => {
+    const home = makeFakeHome(`alias codex='codex --foo'\n`);
+    expect(hasAliasShadowingShim('codex', { homeDir: home })).toBe(true);
+  });
+
+  it('returns false when a later `unalias codex` cancels an earlier alias', () => {
+    // Real-world: rc declares an alias near the top, then a cleanup block
+    // unalias's a list of names later. Static regex on whole-file content
+    // (the previous implementation) reported true here.
+    const home = makeFakeHome(
+      `alias codex="codex --sandbox workspace-write"\n# ... more rc ...\nunalias claude codex gemini 2>/dev/null || true\n`,
+    );
+    expect(hasAliasShadowingShim('codex', { homeDir: home })).toBe(false);
+  });
+
+  it('returns true when alias appears AFTER a prior unalias for the same name', () => {
+    const home = makeFakeHome(`unalias codex 2>/dev/null || true\nalias codex='codex --foo'\n`);
+    expect(hasAliasShadowingShim('codex', { homeDir: home })).toBe(true);
+  });
+
+  it('returns false when only an unalias is present', () => {
+    const home = makeFakeHome(`unalias codex 2>/dev/null || true\n`);
+    expect(hasAliasShadowingShim('codex', { homeDir: home })).toBe(false);
+  });
+
+  it('returns false when the rc file mentions a different command', () => {
+    const home = makeFakeHome(`alias claude='claude --foo'\n`);
+    expect(hasAliasShadowingShim('codex', { homeDir: home })).toBe(false);
   });
 });

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -1361,10 +1361,16 @@ export function removeLegacyUserShim(agent: AgentId, overrides?: { homeDir?: str
  * Shell aliases live in the user's session and aren't visible from a Node.js
  * child process. We do a best-effort scan of common RC files for `alias
  * <command>=` patterns. Returns false when detection is inconclusive.
+ *
+ * Tracks the LAST `alias` / `unalias` action for this command per rc file —
+ * a trailing `unalias codex` cancels an earlier `alias codex=...`, and
+ * `unalias` can name multiple commands on one line. Without this, an
+ * `alias` line elsewhere in the file would surface as a false positive
+ * (e.g. seen in zshrc setups that conditionally clear an alias later).
  */
-export function hasAliasShadowingShim(agent: AgentId): boolean {
+export function hasAliasShadowingShim(agent: AgentId, overrides?: { homeDir?: string }): boolean {
   const cliCommand = AGENTS[agent].cliCommand;
-  const HOME = os.homedir();
+  const HOME = overrides?.homeDir || os.homedir();
   const rcFiles = [
     path.join(HOME, '.zshrc'),
     path.join(HOME, '.bashrc'),
@@ -1372,13 +1378,24 @@ export function hasAliasShadowingShim(agent: AgentId): boolean {
     path.join(HOME, '.profile'),
   ];
 
-  const pattern = new RegExp(`^\\s*alias\\s+${cliCommand}\\s*=`, 'm');
+  const escaped = cliCommand.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // `alias <cmd>=...`
+  const aliasPattern = new RegExp(`^\\s*alias\\s+${escaped}\\s*=`);
+  // `unalias <name>...` where one name is <cmd>. Matches:
+  //   unalias codex
+  //   unalias claude codex gemini 2>/dev/null || true
+  const unaliasPattern = new RegExp(`^\\s*unalias\\b[^\\n]*\\b${escaped}\\b`);
 
   for (const rcFile of rcFiles) {
     try {
       if (!fs.existsSync(rcFile)) continue;
       const content = fs.readFileSync(rcFile, 'utf-8');
-      if (pattern.test(content)) return true;
+      let lastAction: 'alias' | 'unalias' | null = null;
+      for (const line of content.split('\n')) {
+        if (aliasPattern.test(line)) lastAction = 'alias';
+        else if (unaliasPattern.test(line)) lastAction = 'unalias';
+      }
+      if (lastAction === 'alias') return true;
     } catch {
       // unreadable rc file — skip
     }


### PR DESCRIPTION
## Summary

- `agents --version` and `agents --help` no longer trigger the interactive \"Repair shim integration now?\" prompt — they're pure documentation paths and now share the existing `helpOrVersionRequested` gate that already protects `ensureInitialized`.
- The repair flow stops claiming success when it didn't actually fix anything: when `addShimsToPath` returns `alreadyPresent: true` AND a real binary shadow exists, the output now names the shadowing path and tells the user how to fix it. When `alreadyPresent: true` and no shadow, it points at `source ~/.zshrc` instead of re-emitting the full setup instructions.
- `hasAliasShadowingShim` now respects a later `unalias <name>` (including the multi-name form `unalias claude codex gemini`) that cancels an earlier `alias` line in the same rc file. The previous static whole-file regex flagged cancelled aliases as active.
- Shell aliases are dropped from the prompt's `affected` list entirely — they were already documented as intentional customization in the surrounding comment, but the code added them to the prompt anyway. `addShimsToPath` cannot touch aliases, so they didn't belong there.
- Empty `affected` no longer enumerates every installed agent as if they were broken; it surfaces a single `PATH entry missing` line instead.
- The `!pathResult.success` branch now writes the per-shell sentinel so an unwritable rc file doesn't re-prompt every invocation.

## Why this came up

User ran `agents --version` and was prompted to \"Repair shim integration now? agy -> /Users/muqsit/.local/bin/agy, codex (alias)\". Three teams investigated in parallel and confirmed:

1. The `--version` invocation was hitting the shim bootstrap because the existing `helpOrVersionRequested` constant was only wired to setup, not bootstrap.
2. The `agy` shadow was real per the current contract — `/Users/muqsit/.local/bin/agy` is the upstream Antigravity CLI placed by `curl ... antigravity.google/cli/install.sh`, and the installer's `export PATH=\"$HOME/.local/bin:$PATH\"` runs after agents-cli's own shim PATH prepend so it wins. The detector correctly reports the bypass — what this PR fixes is making the prompt's offer match what \"Repair\" can actually do (which for that shadow is nothing — only re-ordering PATH or removing the binary helps).
3. The `codex (alias)` was a false positive: `~/.zshrc:133` has `alias codex=...` and `~/.zshrc:498` does `unalias codex` — the static regex only saw the alias.

## Test plan

- [x] Unit tests for `hasAliasShadowingShim` (alias-only, alias-then-unalias, unalias-then-alias, unalias-only, unrelated-command) — all pass.
- [x] `bun run test src/lib/shims.test.ts` — 16/16 pass.
- [x] `bunx tsc --noEmit` — clean.
- [x] `script -q /dev/null bash -c 'node ./dist/index.js --version'` no longer fires the prompt (was the original bug).
- [x] Same for `--help` and `teams --version`.
- [ ] Reviewer to verify the `alreadyPresent + shadow` branch's wording in their own environment if they have a competing global install.

The three failing tests in the suite (`tests/runner.test.ts` and `src/lib/__tests__/bugfixes.test.ts`) are pre-existing on `origin/main` and don't import anything changed in this PR.

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/6c40352db2eb607ae5e45cf9d6f261f7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)