### PR TITLE
fix(tests): unblock CI on main — sandbox HOME isolation + codex flag

### DIFF
--- a/src/lib/__tests__/bugfixes.test.ts
+++ b/src/lib/__tests__/bugfixes.test.ts
@@ -9,15 +9,26 @@ import { cleanOrphanedPluginSkills } from '../plugins.js';
 describe('Bug Fix: Path traversal in sandbox.ts', () => {
   let overlayHome: string;
   let allowedDir: string;
+  let fakeHome: string;
+  let originalHome: string | undefined;
 
   beforeEach(() => {
+    // Point HOME at an isolated tmpdir so the test never touches the real home.
+    // sandbox.ts resolves the user's home via os.homedir(), which consults $HOME.
+    originalHome = process.env.HOME;
+    fakeHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'sandbox-fakehome-')));
+    process.env.HOME = fakeHome;
+
     overlayHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sandbox-test-'));
-    allowedDir = fs.mkdtempSync(path.join(os.homedir(), '.agents-system', 'agents-cli-sandbox-allowed-'));
+    fs.mkdirSync(path.join(fakeHome, '.agents-system'), { recursive: true });
+    allowedDir = fs.mkdtempSync(path.join(fakeHome, '.agents-system', 'agents-cli-sandbox-allowed-'));
   });
 
   afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
     fs.rmSync(overlayHome, { recursive: true, force: true });
-    fs.rmSync(allowedDir, { recursive: true, force: true });
+    fs.rmSync(fakeHome, { recursive: true, force: true });
   });
 
   it('should block path traversal via .. components', () => {

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -74,14 +74,14 @@ describe('buildJobCommand', () => {
       expect(cmd).toContain('hello');
     });
 
-    it('adds --full-auto in edit mode', () => {
+    it('adds --dangerously-bypass-approvals-and-sandbox in edit mode', () => {
       const cmd = buildJobCommand(makeConfig({ agent: 'codex', mode: 'edit' }), 'hello');
-      expect(cmd).toContain('--full-auto');
+      expect(cmd).toContain('--dangerously-bypass-approvals-and-sandbox');
     });
 
-    it('does not add --full-auto in plan mode', () => {
+    it('does not add bypass flag in plan mode', () => {
       const cmd = buildJobCommand(makeConfig({ agent: 'codex', mode: 'plan' }), 'hello');
-      expect(cmd).not.toContain('--full-auto');
+      expect(cmd).not.toContain('--dangerously-bypass-approvals-and-sandbox');
     });
 
     it('adds --model flag when config.model is set', () => {


### PR DESCRIPTION
## Summary

CI has been red on `main` since #184 (and blocking every PR). Two test failures, both fixed here:

### 1. `bugfixes.test.ts` mkdtemp into `~/.agents-system/`
On GitHub runners `~/.agents-system/` doesn't exist, so `mkdtempSync` ENOENT'd in `beforeEach`. The test wasn't really about that directory — it tests path-traversal blocking in \`symlinkAllowedDirs\`. Now each test gets a fake HOME under \`os.tmpdir()\` and the path-traversal tests run identically on Mac and Linux.

### 2. `tests/runner.test.ts` asserts removed `--full-auto` codex flag
[#138](https://github.com/phnx-labs/agents-cli/pull/138) replaced \`--full-auto\` with \`--dangerously-bypass-approvals-and-sandbox\` in \`runner.ts\` months ago. The test was never updated. Asserts the current flag now.

Closes #194.

## Test plan
- [x] \`bun run vitest run src/lib/__tests__/bugfixes.test.ts tests/runner.test.ts\` — 38 passed
- [x] \`bun run test\` (full suite) — 2076 passed, 21 skipped, 0 failed
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)