### PR TITLE
fix(push): redirect bare 'agents push' to 'agents repo push'

### DIFF
--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -1,0 +1,37 @@
+/**
+ * Removed `agents push` command.
+ *
+ * `agents push` was previously the inverse of the god-command `agents pull` —
+ * it pushed local commits in `~/.agents/` upstream. It is replaced by the
+ * explicit `agents repo push <alias>` so the target repo is named, matching
+ * the post-split `agents repo pull` shape.
+ *
+ * Kept registered so muscle-memory invocations (including `agents push --help`)
+ * land on a clear redirect instead of cascading to the top-level help.
+ */
+
+import type { Command } from 'commander';
+import { setHelpSections } from '../lib/help.js';
+
+const REDIRECT =
+  'agents-cli: "agents push" was removed.\n' +
+  '            Git push a repo: agents repo push <alias>   (system | user | <extra>)\n\n';
+
+/** Register the deprecated `agents push` command as a hard-error redirect. */
+export function registerPushCommand(program: Command): void {
+  const pushCmd = program
+    .command('push [alias]')
+    .description('Removed. See `agents repo push`.');
+
+  setHelpSections(pushCmd, {
+    notes: `
+      Removed. Equivalent:
+        agents repo push <alias>     git push (system | user | extra)
+    `,
+  });
+
+  pushCmd.action(() => {
+    process.stderr.write(REDIRECT);
+    process.exit(2);
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ if (IS_DEV_BUILD) {
 
 // Import command registrations
 import { registerPullCommand } from './commands/pull.js';
+import { registerPushCommand } from './commands/push.js';
 import { registerRepoCommands } from './commands/repo.js';
 import { registerSetupCommand, runSetup } from './commands/setup.js';
 import { registerStatusCommand } from './commands/status.js';
@@ -714,6 +715,7 @@ program
     });
 
 registerPullCommand(program);
+registerPushCommand(program);
 registerRepoCommands(program);
 registerSetupCommand(program);
 


### PR DESCRIPTION
## Summary

\`agents push\` was previously the inverse of \`agents pull\`, then both got split into \`agents repo push|pull <alias>\`. \`pull\` kept a hard-error redirect for muscle memory; \`push\` didn't, so:

- bare \`agents push\` now errors with \"unknown command 'push' (Did you mean use?)\" which is wrong (it should redirect to \`agents repo push\`)
- \`agents push --help\` cascades to the global top-level help — silently swallowed

This PR mirrors the \`pull\` redirect pattern. New \`src/commands/push.ts\` registers \`push\` with a clear redirect:

\`\`\`
$ agents push
agents-cli: \"agents push\" was removed.
            Git push a repo: agents repo push <alias>   (system | user | <extra>)

$ agents push --help
Usage: agents push [options] [alias]

Removed. See \`agents repo push\`.

Notes:
  Removed. Equivalent:
    agents repo push <alias>     git push (system | user | extra)
\`\`\`

Closes #193.

## Test plan
- [x] \`node dist/index.js push\` → redirect msg + exit 2
- [x] \`node dist/index.js push --help\` → redirect msg in help format
- [x] \`bun run test\` (full suite) — 2076 passed, 21 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)