### PR TITLE
fix(run): resolve versioned shims to absolute path so spawn doesn't depend on PATH

### DIFF
--- a/src/lib/__tests__/exec.test.ts
+++ b/src/lib/__tests__/exec.test.ts
@@ -528,6 +528,26 @@ describe('buildExecCommand', () => {
       expect(cmd[0]).toBe('codex@0.98.0');
       expect(cmd[1]).toBe('exec');
     });
+
+    it('resolves to absolute shim path when the shim exists on disk (closes #196)', async () => {
+      // Linux installs without ~/.agents/.cache/shims on PATH would otherwise
+      // spawn the bare versioned name and fail with ENOENT.
+      const fs = await import('fs');
+      const path = await import('path');
+      const { getShimsDir } = await import('../state.js');
+      const shimsDir = getShimsDir();
+      fs.mkdirSync(shimsDir, { recursive: true });
+      const fakeShim = path.join(shimsDir, 'claude@9.9.9-test');
+      const preexisted = fs.existsSync(fakeShim);
+      if (!preexisted) fs.writeFileSync(fakeShim, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+      try {
+        const cmd = buildExecCommand(opts({ agent: 'claude', version: '9.9.9-test', mode: 'skip' }));
+        expect(cmd[0]).toBe(fakeShim);
+        expect(path.isAbsolute(cmd[0])).toBe(true);
+      } finally {
+        if (!preexisted) fs.rmSync(fakeShim, { force: true });
+      }
+    });
   });
 
   // --- Snapshot: agent-runner.sh patterns ---

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -6,6 +6,7 @@
  */
 import { spawn } from 'child_process';
 import { randomUUID } from 'crypto';
+import * as fs from 'fs';
 import * as path from 'path';
 import type { AgentId, Mode } from './types.js';
 import { ALL_MODES } from './types.js';
@@ -15,6 +16,7 @@ import { getVersionHomePath, isVersionInstalled, resolveVersion } from './versio
 import { resolveModel, buildReasoningFlags } from './models.js';
 import { emitStart, maybeRotate, createTimer, redactPrompt, redactArgs } from './events.js';
 import { sanitizeProcessEnv } from './secrets/bundles.js';
+import { getShimsDir } from './state.js';
 
 /**
  * Agent execution modes. Canonical name `skip` (dangerously skip permissions);
@@ -394,9 +396,14 @@ export function buildExecCommand(options: ExecOptions): string[] {
     cmd.splice(1, 1);
   }
 
-  // Use versioned alias if a specific version was requested (e.g., claude@2.1.98)
+  // Use versioned alias if a specific version was requested (e.g., claude@2.1.98).
+  // Resolve to the absolute path of the shim so spawn doesn't depend on PATH —
+  // on Linux installs where the shims dir isn't on PATH, spawning the bare
+  // versioned name fails with ENOENT even though `agents view` shows the agent.
   if (options.version && cmd.length > 0) {
-    cmd[0] = `${cmd[0]}@${options.version}`;
+    const versionedName = `${cmd[0]}@${options.version}`;
+    const absPath = path.join(getShimsDir(), versionedName);
+    cmd[0] = fs.existsSync(absPath) ? absPath : versionedName;
   }
 
   // Add reasoning effort flags (before mode flags for codex -c positioning)


### PR DESCRIPTION
## Summary

On Linux installs where \`~/.agents/.cache/shims/\` isn't on PATH, \`agents run claude\` spawned the bare versioned name (e.g. \`claude@2.1.138\`) and failed with ENOENT — even though \`agents view\` reported the agent as available. Confusing trap.

Repro (Ubuntu 24.04, fresh nvm install of 1.20.4):
\`\`\`
$ agents view
  Shims: /home/muqsit/.agents/.cache/shims (not in PATH)
$ agents run claude \"say hi\"
Running: claude@2.1.138 ...
Failed to execute claude: spawn claude@2.1.138 ENOENT
\`\`\`

\`buildExecCommand\` now checks for the shim file at \`getShimsDir()/<cmd>@<ver>\` and uses the absolute path when present. Falls back to the bare versioned name when the shim isn't there, so PATH-based installs still work.

Closes #196.

## Test plan
- [x] New regression test: materializes a fake shim and asserts \`cmd[0]\` is the absolute path
- [x] \`bun run test\` — 2077 passed, 21 skipped, 0 failed
- [ ] Manual repro on yosemite-s0 (Ubuntu) once published

🤖 Generated with [Claude Code](https://claude.com/claude-code)