### PR TITLE
fix(windows): fix setup and agent install on native Windows

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -112,7 +112,7 @@ export async function runSetup(program: Command, options: { force?: boolean; sup
       // Check git is available
       try {
         const { execSync } = await import('child_process');
-        execSync('which git', { stdio: 'ignore' });
+        execSync('git --version', { stdio: 'ignore' });
       } catch {
         spinner.fail('git is not installed');
         console.log(chalk.gray('Install git first: https://git-scm.com/downloads'));

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -35,7 +35,12 @@ function installGithooksSymlinks(repoDir: string): void {
     if (fs.lstatSync(dest, { throwIfNoEntry: false })) {
       fs.rmSync(dest);
     }
-    fs.symlinkSync(target, dest);
+    try {
+      fs.symlinkSync(target, dest);
+    } catch (err) {
+      // Windows requires Developer Mode or elevated privileges for symlinks; skip gracefully.
+      if ((err as NodeJS.ErrnoException).code !== 'EPERM') throw err;
+    }
   }
 }
 

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -819,7 +819,7 @@ export async function switchConfigSymlink(
       // Different target - update it
       fs.unlinkSync(configPath);
       fs.mkdirSync(path.dirname(configPath), { recursive: true });
-      fs.symlinkSync(versionConfigPath, configPath);
+      fs.symlinkSync(versionConfigPath, configPath, process.platform === 'win32' ? 'junction' : undefined);
       return { success: true };
     } else if (stat.isDirectory()) {
       // Real directory exists - backup and replace with symlink
@@ -852,7 +852,7 @@ export async function switchConfigSymlink(
       }
 
       // Create symlink (parent already exists since the dir we just moved was here)
-      fs.symlinkSync(versionConfigPath, configPath);
+      fs.symlinkSync(versionConfigPath, configPath, process.platform === 'win32' ? 'junction' : undefined);
 
       return { success: true, backupPath: finalBackupPath };
     } else {
@@ -864,7 +864,7 @@ export async function switchConfigSymlink(
       // For nested layouts (e.g., ~/.gemini/antigravity-cli) the parent dir
       // may also be missing if the parent agent (Gemini) is not installed.
       fs.mkdirSync(path.dirname(configPath), { recursive: true });
-      fs.symlinkSync(versionConfigPath, configPath);
+      fs.symlinkSync(versionConfigPath, configPath, process.platform === 'win32' ? 'junction' : undefined);
       return { success: true };
     }
     return { success: false, error: (err as Error).message };

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -925,7 +925,7 @@ export async function getLatestNpmVersion(agent: AgentId): Promise<string | null
   if (!agentConfig.npmPackage) return null;
 
   try {
-    const { stdout } = await execFileAsync('npm', ['view', agentConfig.npmPackage, 'version']);
+    const { stdout } = await execFileAsync('npm', ['view', agentConfig.npmPackage, 'version'], { shell: process.platform === 'win32' });
     return stdout.trim();
   } catch {
     return null;
@@ -1078,8 +1078,8 @@ export async function installVersion(
     // ~/.grok/downloads), so we skip the symlink there.
     if (agent !== 'grok') {
       try {
-        const { stdout: whichOut } = await execFileAsync('which', [agentConfig.cliCommand]);
-        const installedBinary = whichOut.trim();
+        const { stdout: whichOut } = await execFileAsync(process.platform === 'win32' ? 'where' : 'which', [agentConfig.cliCommand]);
+        const installedBinary = whichOut.trim().split('\n')[0];
         if (installedBinary && fs.existsSync(installedBinary)) {
           importInstallScriptBinary(
             { agentId: agent, npmPackage: agentConfig.npmPackage, cliCommand: agentConfig.cliCommand },
@@ -1120,8 +1120,9 @@ export async function installVersion(
 
   try {
     // Check npm is available
+    const winShell = process.platform === 'win32';
     try {
-      await execFileAsync('which', ['npm']);
+      await execFileAsync('npm', ['--version'], { shell: winShell });
     } catch {
       return {
         success: false,
@@ -1131,7 +1132,7 @@ export async function installVersion(
     }
 
     onProgress?.(`Installing ${packageSpec}...`);
-    const { stdout } = await execFileAsync('npm', ['install', packageSpec], { cwd: versionDir });
+    const { stdout } = await execFileAsync('npm', ['install', packageSpec], { cwd: versionDir, shell: winShell });
 
     // Determine the actual installed version
     let installedVersion = version;
@@ -1462,8 +1463,7 @@ export async function getInstalledVersion(agent: AgentId, version: string): Prom
 async function getCliVersionFromPath(agent: AgentId): Promise<string | null> {
   const agentConfig = AGENTS[agent];
   try {
-    await execFileAsync('which', [agentConfig.cliCommand]);
-    const { stdout } = await execFileAsync(agentConfig.cliCommand, ['--version'], { timeout: 3000 });
+    const { stdout } = await execFileAsync(agentConfig.cliCommand, ['--version'], { timeout: 3000, shell: process.platform === 'win32' });
     const match = stdout.match(/(\d+\.\d+\.\d+)/);
     return match ? match[1] : null;
   } catch {


### PR DESCRIPTION
## Problem

`agents setup` and `agents add <agent>` both fail on native Windows 11 with Node 24. Four separate bugs, all the same root cause: POSIX assumptions that break on Windows.

## Bugs fixed

### 1. `which git` in `setup.ts`
`execSync('which git')` throws on Windows even when git is installed — `which` is not available outside WSL/bash. Replaced with `git --version`, which is cross-platform.

### 2. Githooks symlinks EPERM in `git.ts`
`installGithooksSymlinks` calls `fs.symlinkSync` which throws `EPERM` on Windows unless Developer Mode is enabled. These hooks are only needed for developing agents-cli itself, not using it. Wrapped in a try/catch that skips on `EPERM` and rethrows anything else.

### 3. `which npm` + bare `npm` invocations in `versions.ts`
- `execFileAsync('which', ['npm'])` — same issue as above
- `execFileAsync('npm', ...)` — npm on Windows is `npm.cmd`, a batch file; `execFile` cannot run batch files without a shell

Fixed by replacing the `which npm` check with `npm --version` and adding `{ shell: process.platform === 'win32' }` to all three npm `execFileAsync` calls (`--version`, `view`, `install`).

Also replaced `execFileAsync('which', [agentConfig.cliCommand])` with `where` on win32 (trimming to first line since `where` can return multiple matches), and dropped the redundant `which` pre-check in `getCliVersionFromPath` — the `--version` call already throws if absent.

### 4. Config directory symlinks EPERM in `shims.ts`
`switchConfigSymlink` creates `~/.codex`, `~/.claude`, etc. as symlinks into the versioned home. On Windows, symbolic links require Developer Mode or elevation. Directory **junctions** (`fs.symlinkSync(target, path, 'junction')`) work for all users with no privilege requirement.

Added `process.platform === 'win32' ? 'junction' : undefined` to the three `symlinkSync` calls in `switchConfigSymlink`.

## Tested

Windows 11 Pro, Node 24.16.0, npm 11.13.0 — `agents setup` and `agents add codex` both complete successfully after these changes.

## Out of scope (noted for follow-up)
- `addShimsToPath` in `shims.ts` only handles bash/zsh/fish; Windows PATH management via PowerShell profile or system env vars is a separate issue
- File-level symlinks in `switchHomeFileSymlinks` (e.g. `~/.claude.json`) — junctions only work for directories; file symlinks still need Developer Mode on Windows
