### PR TITLE
test(shims): align stale invariants with launch-sync (PR #199)

### DIFF
--- a/src/lib/__tests__/shims.test.ts
+++ b/src/lib/__tests__/shims.test.ts
@@ -87,8 +87,8 @@ describe('addShimsToPath', () => {
 });
 
 describe('SHIM_SCHEMA_VERSION', () => {
-  it('is 15 (launch shims do not run foreground resource sync)', () => {
-    expect(SHIM_SCHEMA_VERSION).toBe(15);
+  it('is 16 (launch shims call sync --launch on hot path, never foreground)', () => {
+    expect(SHIM_SCHEMA_VERSION).toBe(16);
   });
 });
 
@@ -207,10 +207,12 @@ describe('generateShimScript', () => {
     expect(script).not.toContain('required by .agents-version');
   });
 
-  it('does not run project resource sync on the launch hot path', () => {
+  it('does not run foreground project resource sync on the launch hot path', () => {
     const script = generateShimScript('claude');
     expect(script).not.toContain('find_project_agents_dir');
-    expect(script).not.toContain('sync --agent "$AGENT"');
+    // sync IS allowed on the hot path, but only with --launch (filesystem-only,
+    // sub-50ms, non-blocking). A foreground sync without --launch is forbidden.
+    expect(script).not.toMatch(/\bsync --agent "\$AGENT"(?![^\n]*--launch)/);
     expect(script).not.toContain('refresh-rules --agent "$AGENT"');
   });
 
@@ -254,7 +256,9 @@ describe('generateShimScript', () => {
     expect(script).toContain('"$AGENTS_BIN" add "$AGENT@$VERSION" --yes');
     expect(script).not.toMatch(/^\s*agents (refresh-rules|use|add|sync)\b/m);
     expect(script).not.toContain('"$AGENTS_BIN" refresh-rules');
-    expect(script).not.toContain('"$AGENTS_BIN" sync');
+    // sync IS called on the hot path, but only with --launch (filesystem-only,
+    // sub-50ms, non-blocking). A foreground sync without --launch is forbidden.
+    expect(script).not.toMatch(/"\$AGENTS_BIN" sync\b(?![^\n]*--launch)/);
   });
 
   it('fails clearly when the embedded agents-cli entrypoint is not executable', () => {

--- a/src/lib/project-launch.test.ts
+++ b/src/lib/project-launch.test.ts
@@ -27,6 +27,10 @@ vi.mock('./state.js', () => ({
   }; },
   get getEnabledExtraRepos() { return () => []; },
   get getVersionsDir() { return () => path.join(USER_DIR, '.history', 'versions'); },
+  // agents.ts calls getCliVersionCachePath() at module-load (not lazily) to
+  // build a const. Return an os.tmpdir()-based path because USER_DIR isn't
+  // initialized until beforeEach; runLaunchSync doesn't touch this file.
+  get getCliVersionCachePath() { return () => path.join(os.tmpdir(), 'agents-cli-version.json'); },
 }));
 
 import { runLaunchSync } from './project-launch.js';

--- a/src/lib/project-launch.test.ts
+++ b/src/lib/project-launch.test.ts
@@ -31,6 +31,10 @@ vi.mock('./state.js', () => ({
   // build a const. Return an os.tmpdir()-based path because USER_DIR isn't
   // initialized until beforeEach; runLaunchSync doesn't touch this file.
   get getCliVersionCachePath() { return () => path.join(os.tmpdir(), 'agents-cli-version.json'); },
+  // rules/compose.ts calls these to discover user + system rule layers.
+  // Point at directories that won't exist so only the project layer is active.
+  get getUserRulesDir() { return () => path.join(USER_DIR, 'rules'); },
+  get getResolvedRulesDir() { return () => path.join(SYSTEM_DIR, 'rules'); },
 }));
 
 import { runLaunchSync } from './project-launch.js';

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -373,7 +373,9 @@ describe('shims - generateShimScript', () => {
   test('does not include foreground project sync in shim', () => {
     const script = generateShimScript('claude');
     expect(script).not.toContain('find_project_agents_dir');
-    expect(script).not.toContain('"$AGENTS_BIN" sync --agent "$AGENT"');
+    // sync IS called on the hot path, but only with --launch (filesystem-only,
+    // sub-50ms, non-blocking). A foreground sync without --launch is forbidden.
+    expect(script).not.toMatch(/"\$AGENTS_BIN" sync\b(?![^\n]*--launch)/);
   });
 
   test('non-@-capable agents do not refresh rules on the launch hot path', () => {


### PR DESCRIPTION
## Summary

Main has been red since PR #199 (`feat/launch-sync`, `fc540c5`) shipped. That PR introduced `sync --launch` on the shim hot path and bumped `SHIM_SCHEMA_VERSION` 15 → 16, but missed updating four test invariants. Every PR opened against main since (#207, #208, #209, #210) inherited the same red CI.

This patch realigns the tests with the new design. The invariant `runLaunchSync` enforces is:

- Foreground sync (without `--launch`) **is** forbidden — would block launch.
- `sync --launch` **is** allowed — filesystem-only, sub-50ms, non-blocking. Source comment lives at `src/lib/shims.ts:494-496`.

## Changes

- `src/lib/__tests__/shims.test.ts` — narrow three `not.toContain('… sync')` assertions to a regex that rejects sync without `--launch`. Update `SHIM_SCHEMA_VERSION` expectation 15 → 16 and rename the test to match the new design.
- `tests/shims.test.ts` — same narrowing on the integration copy of the assertion.
- `src/lib/project-launch.test.ts` — add `getCliVersionCachePath` to the `./state.js` mock. `src/lib/agents.ts:44` calls it at module-load time when `project-launch.js` is imported transitively; the missing mock entry crashed the entire file before any test could run.

## Verification

Ran `bun run test` locally. Confirmed:

- All four shim assertions previously failing on main now pass.
- `src/lib/project-launch.test.ts` now loads (15 / 16 pass — see below for the remaining one).

## Out of scope — pre-existing failures still on main

These three are unrelated to PR #199 / launch-sync. Calling them out for follow-up; not fixed here:

- `src/lib/project-launch.test.ts > runLaunchSync — project rules compile > compiles rules.yaml + subrules into cwd/AGENTS.md` — newly visible now that the file loads. Real bug in `runLaunchSync`'s rules-compile path returning `rulesCompiled: false` when rules exist.
- `tests/non-interactive.test.ts > does not switch an existing default during non-interactive add` — assertion failure on default-switch behavior.
- `tests/registry.test.ts > resolves skill: prefix to git fallback` — 30s timeout (likely network).

## Test plan

- [x] `bun run test` locally — 4 shim assertions pass, file-load failure resolved.
- [ ] CI green on this PR.
- [ ] After merge, confirm main's next CI run is green minus the three documented pre-existing failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)