### PR TITLE
ci(secret-scan): skip gitleaks on PRs from forks

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -23,7 +23,22 @@ jobs:
           # Full history so the scheduled run audits the whole tree.
           fetch-depth: 0
 
-      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+      # gitleaks-action requires GITLEAKS_LICENSE for org-owned repos and
+      # exits hard when it's missing. Forks cannot read org secrets, so PRs
+      # from forks always fail here. Skip on fork PRs; the post-merge scan
+      # on main still covers the same commits.
+      - name: Determine if PR is from a fork
+        id: fork
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] && \
+             [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.fork.outputs.is_fork != 'true'
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
           # Required by gitleaks-action v2 for PR scans (posts findings as PR comments).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

PR #207 from external contributor AndreMMartins fails the gitleaks job with:

> 🛑 missing gitleaks license. Go grab one at gitleaks.io and store it as a GitHub Secret named GITLEAKS_LICENSE. For more info about the recent breaking update, see [here](https://github.com/gitleaks/gitleaks-action#-announcement).
>
> `[phnx-labs] is an organization. License key is required.`

`gitleaks-action` v3 requires `GITLEAKS_LICENSE` for org-owned repos and exits hard when it's missing. Forks cannot read org secrets, so every PR from an external contributor breaks here.

## Fix

Skip the action when `github.event.pull_request.head.repo.full_name != github.repository`. The post-merge `push` event on main still runs the scan with the license available, and the weekly cron full-history audit is untouched. Coverage of fork commits is preserved (deferred from PR-time to merge-time).

## Why not `pull_request_target`?

It would let us read secrets on fork PRs, but it also gives fork-supplied code access to the org's secrets at PR time. Not worth the supply-chain risk for a SOC-2-gated scan that runs again on merge.

## Test plan

- [ ] CI on this PR runs gitleaks normally (same-repo).
- [ ] After merge, PR #207's next CI run skips gitleaks and unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)