### PR TITLE
feat(view): per-section filters + descriptions in detail view

### DIFF
--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -167,6 +167,42 @@ interface ResourceWithSync {
   ruleCount?: number;
   syncState?: SyncState;
   scope?: 'user' | 'project';
+  description?: string;
+}
+
+/** Per-section filter flags. When any are true, only those sections render. */
+export interface ViewSectionFilter {
+  commands?: boolean;
+  skills?: boolean;
+  mcp?: boolean;
+  workflows?: boolean;
+  plugins?: boolean;
+  rules?: boolean;
+  hooks?: boolean;
+  promptcuts?: boolean;
+}
+
+const SECTION_KEYS = ['commands', 'skills', 'mcp', 'workflows', 'plugins', 'rules', 'hooks', 'promptcuts'] as const;
+type SectionKey = (typeof SECTION_KEYS)[number];
+
+/**
+ * Decide whether a section should render given the filter. If no flags are set,
+ * everything renders (current behavior). If any flag is set, only those sections
+ * render — flags are additive.
+ */
+function shouldRenderSection(key: SectionKey, filter: ViewSectionFilter | undefined): boolean {
+  if (!filter) return true;
+  const anySet = SECTION_KEYS.some((k) => filter[k]);
+  if (!anySet) return true;
+  return filter[key] === true;
+}
+
+/** Trim a description to a column-friendly snippet. Strips newlines, collapses whitespace. */
+function summarizeDescription(desc: string | undefined, maxLen = 80): string {
+  if (!desc) return '';
+  const cleaned = desc.replace(/\s+/g, ' ').trim();
+  if (cleaned.length <= maxLen) return cleaned;
+  return cleaned.slice(0, maxLen - 1).trimEnd() + '…';
 }
 
 function getProfileSummaries(filterAgentId?: AgentId): ProfileSummary[] {
@@ -653,7 +689,11 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
  * Show detailed resources for a specific agent version.
  * Called when: `agents view claude@2.0.65` or `agents view claude@default`
  */
-async function showAgentResources(agentId: AgentId, requestedVersion: string): Promise<void> {
+async function showAgentResources(
+  agentId: AgentId,
+  requestedVersion: string,
+  filter?: ViewSectionFilter,
+): Promise<void> {
   const spinner = ora({ text: 'Loading...', isSilent: !process.stdout.isTTY }).start();
 
   const cwd = process.cwd();
@@ -773,6 +813,8 @@ async function showAgentResources(agentId: AgentId, requestedVersion: string): P
     })),
     skills: resources.skills.map(r => ({
       ...r,
+      // ruleCount of 0 is noise — every skill has 0 unless it ships subrules, which is rare.
+      ruleCount: r.ruleCount && r.ruleCount > 0 ? r.ruleCount : undefined,
       syncState: r.scope === 'project' ? undefined : getSyncState(r.name, 'skills', skillsSync),
     })),
     skillErrors: resources.skillErrors,
@@ -822,7 +864,9 @@ async function showAgentResources(agentId: AgentId, requestedVersion: string): P
         : chalk.gray('[system]');
       display += ` ${sourceTag}`;
       const syncStr = r.syncState ? chalk.gray(` [${r.syncState}]`) : '';
-      console.log(`    ${display}${syncStr}`);
+      const descSnippet = summarizeDescription(r.description);
+      const descStr = descSnippet ? chalk.gray(`  ${descSnippet}`) : '';
+      console.log(`    ${display}${syncStr}${descStr}`);
     }
   }
 
@@ -841,49 +885,60 @@ async function showAgentResources(agentId: AgentId, requestedVersion: string): P
     console.log(`  ${chalk.green(label).padEnd(24)} ${chalk.gray(formatPath(getEffectivePromptcutsPath(), cwd))}`);
   }
 
-  // 1. Agent CLI info
-  console.log(chalk.bold('Agent CLIs\n'));
-  const accountInfo = await getAccountInfo(agentId, home);
-  const usageInfo = await getUsageInfoForIdentity({
-    agentId,
-    home,
-    cliVersion: version,
-    info: accountInfo,
-  });
-  const emailStr = accountInfo.email ? chalk.cyan(`  ${accountInfo.email}`) : '';
-  const status = chalk.green(version);
-  const usageStr = formatUsageSummary(accountInfo.plan, null);
-  const usagePart = usageStr ? `  ${usageStr}` : '';
-  console.log(`  ${colorAgent(agentId)(AGENTS[agentId].name.padEnd(14))} ${status}${emailStr}${usagePart}`);
+  const anyFilterSet = filter && SECTION_KEYS.some((k) => filter[k]);
 
-  const usageLines = formatUsageSection(usageInfo);
-  if (usageLines.length > 0) {
-    console.log();
-    for (const line of usageLines) {
-      console.log(line);
+  // 1. Agent CLI info — skip the header entirely when the user asked for a
+  // specific section. They want "nothing more or less."
+  if (!anyFilterSet) {
+    console.log(chalk.bold('Agent CLIs\n'));
+    const accountInfo = await getAccountInfo(agentId, home);
+    const usageInfo = await getUsageInfoForIdentity({
+      agentId,
+      home,
+      cliVersion: version,
+      info: accountInfo,
+    });
+    const emailStr = accountInfo.email ? chalk.cyan(`  ${accountInfo.email}`) : '';
+    const status = chalk.green(version);
+    const usageStr = formatUsageSummary(accountInfo.plan, null);
+    const usagePart = usageStr ? `  ${usageStr}` : '';
+    console.log(`  ${colorAgent(agentId)(AGENTS[agentId].name.padEnd(14))} ${status}${emailStr}${usagePart}`);
+
+    const usageLines = formatUsageSection(usageInfo);
+    if (usageLines.length > 0) {
+      console.log();
+      for (const line of usageLines) {
+        console.log(line);
+      }
     }
   }
 
   // 2. Resources
-  renderSection('Commands', agentData.commands);
-  renderSection('Skills', agentData.skills);
+  if (shouldRenderSection('commands', filter)) {
+    renderSection('Commands', agentData.commands);
+  }
+  if (shouldRenderSection('skills', filter)) {
+    renderSection('Skills', agentData.skills);
 
-  // Show skill parse errors if any
-  if (agentData.skillErrors.length > 0) {
-    console.log(`\n  ${chalk.red('Skill Errors')}:`);
-    for (const err of agentData.skillErrors) {
-      console.log(`    ${chalk.red(err.name.padEnd(20))} ${chalk.gray(err.error)}`);
-      console.log(`      ${chalk.gray(formatPath(err.path, cwd))}`);
+    // Show skill parse errors only when skills section is visible
+    if (agentData.skillErrors.length > 0) {
+      console.log(`\n  ${chalk.red('Skill Errors')}:`);
+      for (const err of agentData.skillErrors) {
+        console.log(`    ${chalk.red(err.name.padEnd(20))} ${chalk.gray(err.error)}`);
+        console.log(`      ${chalk.gray(formatPath(err.path, cwd))}`);
+      }
     }
   }
 
-  renderSection('MCP Servers', agentData.mcp);
+  if (shouldRenderSection('mcp', filter)) {
+    renderSection('MCP Servers', agentData.mcp);
+  }
 
-  if (isCapable(agentId, 'workflows')) {
+  if (shouldRenderSection('workflows', filter) && isCapable(agentId, 'workflows')) {
     renderSection('Workflows', agentData.workflows);
   }
 
-  if (isCapable(agentId, 'plugins')) {
+  if (shouldRenderSection('plugins', filter) && isCapable(agentId, 'plugins')) {
     const plugins = discoverPlugins().filter(p => pluginSupportsAgent(p, agentId));
     console.log(chalk.bold('\nPlugins\n'));
     if (plugins.length === 0) {
@@ -963,13 +1018,20 @@ async function showAgentResources(agentId: AgentId, requestedVersion: string): P
       }
     }
   }
-  renderRulesSection();
+  if (shouldRenderSection('rules', filter)) {
+    renderRulesSection();
+  }
 
-  renderSection('Hooks', agentData.hooks);
-  renderPromptcuts();
+  if (shouldRenderSection('hooks', filter)) {
+    renderSection('Hooks', agentData.hooks);
+  }
+  if (shouldRenderSection('promptcuts', filter)) {
+    renderPromptcuts();
+  }
 
-  // Show legend at the end if git repo exists
-  if (hasGitRepo) {
+  // Show legend at the end if git repo exists and we showed all sections.
+  // Filtered single-section views skip it — noise for promptcuts or plugins.
+  if (hasGitRepo && !anyFilterSet) {
     console.log();
     console.log(chalk.gray('Legend:'), chalk.green('Tracked'), chalk.blue('Local-only'), chalk.yellow('Modified'), chalk.red('Deleted'));
   }
@@ -1322,12 +1384,28 @@ export async function pruneDuplicates(
  */
 export async function viewAction(
   agentArg?: string,
-  options?: { json?: boolean; prune?: boolean; yes?: boolean; dryRun?: boolean }
+  options?: {
+    json?: boolean;
+    prune?: boolean;
+    yes?: boolean;
+    dryRun?: boolean;
+  } & ViewSectionFilter,
 ): Promise<void> {
   const json = options?.json === true;
   const prune = options?.prune === true;
   const yes = options?.yes === true;
   const dryRun = options?.dryRun === true;
+  const filter: ViewSectionFilter = {
+    commands: options?.commands,
+    skills: options?.skills,
+    mcp: options?.mcp,
+    workflows: options?.workflows,
+    plugins: options?.plugins,
+    rules: options?.rules,
+    hooks: options?.hooks,
+    promptcuts: options?.promptcuts,
+  };
+  const filterIsSet = SECTION_KEYS.some((k) => filter[k]);
 
   if (!agentArg) {
     if (prune) {
@@ -1383,7 +1461,11 @@ export async function viewAction(
 
   if (requestedVersion) {
     // Specific version requested: show detailed resources
-    await showAgentResources(agentId, requestedVersion);
+    await showAgentResources(agentId, requestedVersion, filter);
+  } else if (filterIsSet) {
+    // `agents view claude --skills` → fall through to detail view on default.
+    // Section filters only make sense for the per-version detail view.
+    await showAgentResources(agentId, 'default', filter);
   } else {
     // Just agent name: show versions for that agent
     await showInstalledVersions(agentId);
@@ -1399,6 +1481,14 @@ export function registerViewCommand(program: Command): void {
     .option('--prune', 'Remove older installed versions that share an account with a newer installed version. Skips the global default.')
     .option('--dry-run', 'With --prune, show duplicate versions without deleting')
     .option('-y, --yes', 'Skip the prune confirmation prompt.')
+    .option('--commands', 'Show only commands in the detail view.')
+    .option('--skills', 'Show only skills in the detail view.')
+    .option('--mcp', 'Show only MCP servers in the detail view.')
+    .option('--workflows', 'Show only workflows in the detail view.')
+    .option('--plugins', 'Show only plugins in the detail view.')
+    .option('--rules', 'Show only rules in the detail view.')
+    .option('--hooks', 'Show only hooks in the detail view.')
+    .option('--promptcuts', 'Show only promptcuts in the detail view.')
     .addHelpText('after', `
 Examples:
   # Show all installed agents with versions, accounts, and usage
@@ -1419,6 +1509,11 @@ Examples:
   agents view claude --prune
   agents view claude --prune -y
 
+  # Filter the detail view to a single section (combinable)
+  agents view claude@default --skills
+  agents view claude@default --plugins --workflows
+  agents view claude --commands    # implicitly the default version
+
 When to use:
   - Checking which agents are installed and what their default versions are
   - Seeing which account each version is logged into (useful for multi-account setups)
@@ -1435,5 +1530,13 @@ Output:
   - With --prune: plan of which older versions will be removed, then confirm
   - With --prune --dry-run: preview only, no deletions
 `)
-    .action((agentArg: string | undefined, options: { json?: boolean; prune?: boolean; yes?: boolean; dryRun?: boolean }) => viewAction(agentArg, options));
+    .action((
+      agentArg: string | undefined,
+      options: {
+        json?: boolean;
+        prune?: boolean;
+        yes?: boolean;
+        dryRun?: boolean;
+      } & ViewSectionFilter,
+    ) => viewAction(agentArg, options));
 }

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -141,6 +141,8 @@ export interface ResourceEntry {
   name: string;
   path: string;
   scope: 'user' | 'project';
+  /** One-line description pulled from frontmatter; not all resource kinds have one. */
+  description?: string;
 }
 
 /** A skill resource entry with optional rule count. */
@@ -197,7 +199,7 @@ export function getAgentResources(
   const commands: ResourceEntry[] = [];
   for (const cmd of listInstalledCommandsWithScope(agentId, cwd, { home })) {
     if (shouldInclude(cmd.scope)) {
-      commands.push({ name: cmd.name, path: cmd.path, scope: cmd.scope });
+      commands.push({ name: cmd.name, path: cmd.path, scope: cmd.scope, description: cmd.description });
     }
   }
 
@@ -211,6 +213,7 @@ export function getAgentResources(
         path: skill.path,
         scope: skill.scope,
         ruleCount: skill.ruleCount,
+        description: skill.metadata.description || undefined,
       });
     }
   }


### PR DESCRIPTION
## Summary

- Adds eight combinable flags to `agents view <agent>@<version>` (and `agents view <agent> --<section>` which falls through to the default version): `--commands`, `--skills`, `--mcp`, `--workflows`, `--plugins`, `--rules`, `--hooks`, `--promptcuts`. When any are set, only those sections render and the "Agent CLIs" header is suppressed.
- Surfaces each resource's frontmatter description inline after the `[user]`/`[synced]` tags so users can learn what a skill or command is for without opening the file. Sourced from data already parsed by `listInstalledSkillsWithScope` / `listInstalledCommandsWithScope`.
- Drops the noisy `(0 rules)` annotation that every skill carried in the prior output — most skills ship no subrules so the count is always 0.

## Usage

```bash
agents view claude@default --skills              # only Skills section
agents view claude@default --plugins --workflows # combine
agents view claude --commands                    # implicit default version
agents view claude@default                       # unchanged — every section
```

Subagents and permissions are not yet rendered by `view` (they're not loaded by `getAgentResources()` in `src/lib/resources.ts:159`), so I didn't add stub flags for them.

## Test plan

- [x] `bun run build` — TS compiles clean.
- [x] `agents view claude@default --skills` — only Skills, with descriptions, no "Agent CLIs" header.
- [x] `agents view claude --plugins --workflows` — only those two sections, implicit default version.
- [x] `agents view claude@default` (no flags) — all 9 sections present, backward compatible.
- [ ] CI passes on the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)