### PR TITLE
ci: enable prix code-reviewer on PRs

### DIFF
--- a/.github/rush.yml
+++ b/.github/rush.yml
@@ -1,0 +1,7 @@
+version: 1
+agents:
+  - id: prix/code-reviewer
+    on:
+      pull_request:
+        types: [opened, reopened, synchronize]
+        branches: [main]


### PR DESCRIPTION
Adds .github/rush.yml so prix-cloud GitHub App dispatches the code-reviewer agent on PR events (opened, reopened, synchronize) against main.