### PR TITLE
fix(secrets): `agents secrets list` empty on Linux (libsecret attributes go to stderr)

### DIFF
--- a/src/lib/secrets/linux.test.ts
+++ b/src/lib/secrets/linux.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { parseSecretToolItems } from './linux.js';
+
+const PREFIX = 'agents-cli.bundles.';
+
+/**
+ * Real `secret-tool search --all service agents-cli` output on libsecret
+ * 0.21.4. The crux: the `attribute.*` lines (including `attribute.item`, the
+ * only machine-readable item name) are emitted on STDERR, while
+ * label/secret/schema land on STDOUT. listSecretToolItems concatenates both
+ * streams; these fixtures mirror each stream separately so the regression is
+ * pinned to the actual split, not a hand-merged blob.
+ */
+const STDOUT = [
+  '[/5]',
+  'label = agents-cli: agents-cli.bundles.demo',
+  'secret = {"description":"test","vars":{"API_KEY":{"value":"sk-test"}}}',
+  'created = 2026-06-08 23:31:56',
+  'modified = 2026-06-08 23:31:57',
+  'schema = org.freedesktop.Secret.Generic',
+].join('\n');
+
+const STDERR = [
+  'attribute.account = muqsit',
+  'attribute.service = agents-cli',
+  'attribute.item = agents-cli.bundles.demo',
+].join('\n');
+
+describe('parseSecretToolItems', () => {
+  it('finds items when attribute.item is on stderr (libsecret 0.21.4 split)', () => {
+    // stdout alone has no attribute.item line — this is the bug: parsing only
+    // stdout returned [] even though the bundle exists.
+    expect(parseSecretToolItems(STDOUT, PREFIX)).toEqual([]);
+    // The fix concatenates both streams before parsing.
+    const combined = `${STDOUT}\n${STDERR}`;
+    expect(parseSecretToolItems(combined, PREFIX)).toEqual(['agents-cli.bundles.demo']);
+  });
+
+  it('also works when attributes are on stdout (older libsecret)', () => {
+    const combined = `${STDOUT}\n${STDERR}\n`;
+    expect(parseSecretToolItems(combined, PREFIX)).toContain('agents-cli.bundles.demo');
+  });
+
+  it('enumerates multiple items and dedupes', () => {
+    const combined = [
+      'attribute.item = agents-cli.bundles.alpha',
+      'attribute.item = agents-cli.bundles.beta',
+      'attribute.item = agents-cli.bundles.alpha',
+    ].join('\n');
+    expect(parseSecretToolItems(combined, PREFIX)).toEqual([
+      'agents-cli.bundles.alpha',
+      'agents-cli.bundles.beta',
+    ]);
+  });
+
+  it('filters by prefix, excluding other services and secret keys', () => {
+    const combined = [
+      'attribute.item = agents-cli.bundles.demo',
+      'attribute.item = agents-cli.secrets.demo.API_KEY',
+      'attribute.item = some-other-app.token',
+    ].join('\n');
+    expect(parseSecretToolItems(combined, PREFIX)).toEqual(['agents-cli.bundles.demo']);
+  });
+
+  it('returns [] on empty output', () => {
+    expect(parseSecretToolItems('', PREFIX)).toEqual([]);
+  });
+});

--- a/src/lib/secrets/linux.ts
+++ b/src/lib/secrets/linux.ts
@@ -377,6 +377,35 @@ export function deleteSecretToolToken(item: string): boolean {
 }
 
 /**
+ * Parse the item names out of `secret-tool search --all` output, keeping only
+ * those starting with `prefix`. Exported for tests.
+ *
+ * `output` must be the combined stdout+stderr of the search: libsecret splits
+ * the dump across both streams — the value/label/schema lines go to stdout
+ * while the `attribute.*` lines (which carry `attribute.item`, the only place
+ * the item name is reliably machine-readable) go to stderr (observed on
+ * libsecret 0.21.4). Which stream each line lands on has varied across
+ * libsecret versions, so callers concatenate both rather than bet on one.
+ */
+export function parseSecretToolItems(output: string, prefix: string): string[] {
+  const items: string[] = [];
+  // Parse output format:
+  // [/org/freedesktop/secrets/collection/login/1]
+  // label = agents-cli: myitem
+  // ...
+  // attribute.item = myitem
+  const itemRegex = /attribute\.item\s*=\s*(.+)/g;
+  let match;
+  while ((match = itemRegex.exec(output)) !== null) {
+    const itemName = match[1].trim();
+    if (itemName.startsWith(prefix)) {
+      items.push(itemName);
+    }
+  }
+  return [...new Set(items)]; // dedupe
+}
+
+/**
  * List secrets by prefix. secret-tool doesn't have a list command,
  * so we use secret-tool search which outputs in a specific format.
  */
@@ -397,24 +426,8 @@ export function listSecretToolItems(prefix: string): string[] {
     return [];
   }
 
-  const output = result.stdout?.toString() || '';
-  const items: string[] = [];
-
-  // Parse output format:
-  // [/org/freedesktop/secrets/collection/login/1]
-  // label = agents-cli: myitem
-  // ...
-  // attribute.item = myitem
-  const itemRegex = /attribute\.item\s*=\s*(.+)/g;
-  let match;
-  while ((match = itemRegex.exec(output)) !== null) {
-    const itemName = match[1].trim();
-    if (itemName.startsWith(prefix)) {
-      items.push(itemName);
-    }
-  }
-
-  return [...new Set(items)]; // dedupe
+  const output = `${result.stdout?.toString() || ''}\n${result.stderr?.toString() || ''}`;
+  return parseSecretToolItems(output, prefix);
 }
 
 /** KeychainBackend implementation for Linux. Routes through secret-tool


### PR DESCRIPTION
## Problem

On Linux, `agents secrets list` always reports **"No secrets bundles configured"** even when bundles exist and are fully usable via `view`, `add`, `exec`, and `delete`. The bundles are correctly stored in the GNOME Keyring — only enumeration is broken.

Closes #222.

## Root cause

`listSecretToolItems()` parsed only `result.stdout` for `attribute.item = …` lines. But on **libsecret 0.21.4**, `secret-tool search --all` routes the `attribute.*` lines (the only machine-readable item names) to **stderr**, while `label`/`secret`/`schema` go to stdout. The regex matched nothing → `list` returned `[]`.

`view`/`get` were unaffected because they use `secret-tool lookup`, which returns the value on stdout.

Confirmed directly:

```js
const r = spawnSync('secret-tool', ['search','--all','service','agents-cli']);
// r.stdout: label / secret / created / modified / schema
// r.stderr: attribute.account / attribute.service / attribute.item   <-- needed line
```

## Fix

- Parse `stdout + stderr` concatenated — robust to which stream libsecret routes attributes to across versions.
- Extract the parsing into a pure, exported `parseSecretToolItems(output, prefix)`.
- Add `linux.test.ts` with a regression test pinned to the real 0.21.4 stream split. It runs on CI **without** a live keyring (asserts stdout-alone returns `[]`, combined returns the item), plus multi-item dedupe and prefix-filtering cases.

## Verification (end-to-end, real keyring on Ubuntu noble / libsecret 0.21.4)

| Command | Before | After |
|---|---|---|
| `list` (1 bundle) | empty | shows bundle, key count, dates |
| `list` (2 bundles) | empty | both enumerated |
| `exec … -- bash` | n/a | injects real values into subprocess |
| `delete` | n/a | removes bundle + purges keyring (0 items remain) |

```
 Test Files  8 passed (8)
      Tests  98 passed (98)
```
(includes the 5 new `parseSecretToolItems` cases)

## Notes

- No behavior change on macOS — this only touches the Linux `secret-tool` path.
- Pre-existing unrelated `tsc` error in `src/commands/teams.ts:71` (`kimi` key) is present on `main` and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)