### PR TITLE
feat(session-tracker): standalone per-agent session-id detection lib

### DIFF
--- a/packages/session-tracker/README.md
+++ b/packages/session-tracker/README.md
@@ -1,0 +1,41 @@
+# @agents/session-tracker
+
+One reliable way to know which session a coding-agent CLI is currently running.
+
+## Why
+
+Each agent CLI (claude / codex / gemini / cursor / grok / opencode / antigravity) emits its session id differently — some via SessionStart hooks (stdin JSON), some via env vars, some only via session-file presence. swarmify and agents-cli both reinvented per-agent detection logic and both got it wrong in subtle ways (stale ids in the status bar; persisted-session fuzzy matching at restore time).
+
+This package gives every agent **one canonical state file** at `~/.agents/.cache/state/sessions/<pid>.json`, written by **one polyglot SessionStart hook**, read by **one descendant-pid lookup**.
+
+## Pieces
+
+- `src/hook.sh` — polyglot SessionStart hook. Invoked as `hook.sh <agent>`; handles stdin-JSON (claude/codex/cursor), env-var (grok), and `gemini`/`antigravity` placeholder branches.
+- `src/install-hook.ts` — wires the hook into each agent's native config file (idempotent). For claude: writes into **every** installed version's per-version settings.json under `~/.agents/.history/versions/claude/*/home/.claude/`.
+- `src/state-file.ts` — canonical SessionState schema, atomic write/read, STATE_DIR const.
+- `src/writer.ts` — `recordSession()` for the future fs-watch correlator (opencode etc).
+- `src/reader.ts` — descendant-pid BFS (depth ≤ 5, nodes ≤ 100), terminal-id and launch-id lookups, prune-stale.
+- `src/index.ts` — public API: `trackSpawn()` polls for the state file; `getLiveSession()` does the layered lookup (launchId → terminalId → shellPid).
+- `src/adapters/claude.ts` — per-agent metadata + ground-truth snapshot helper (multi-root: walks every installed claude version's `projects/<workspace>/`).
+- `tests/harness.ts` + `tests/smoke.test.ts` — real `agents run claude` spawn, captures ground truth from session-file appearance, compares to tracker output.
+
+## Use
+
+```bash
+bun install
+bun run install-hook claude        # idempotent — wires hook into every claude version
+chmod +x src/hook.sh               # one-time
+bun run test:smoke                 # spawn real claude, verify detection
+```
+
+In code:
+
+```ts
+import { trackSpawn, getLiveSession } from '@agents/session-tracker';
+
+const detected = await trackSpawn({ agent: 'claude', agentPid, cwd, launchId });
+// detected: { sessionId, method, latencyMs, confidence }
+
+const live = await getLiveSession({ shellPid });
+// live: SessionState | null
+```

--- a/packages/session-tracker/README.md
+++ b/packages/session-tracker/README.md
@@ -6,7 +6,7 @@ One reliable way to know which session a coding-agent CLI is currently running.
 
 Each agent CLI (claude / codex / gemini / cursor / grok / opencode / antigravity) emits its session id differently — some via SessionStart hooks (stdin JSON), some via env vars, some only via session-file presence. swarmify and agents-cli both reinvented per-agent detection logic and both got it wrong in subtle ways (stale ids in the status bar; persisted-session fuzzy matching at restore time).
 
-This package gives every agent **one canonical state file** at `~/.agents/.cache/state/sessions/<pid>.json`, written by **one polyglot SessionStart hook**, read by **one descendant-pid lookup**.
+This package gives every agent **one canonical state file** at `~/.agents/.cache/terminals/sessions/<pid>.json`, written by **one polyglot SessionStart hook**, read by **one descendant-pid lookup**.
 
 ## Pieces
 

--- a/packages/session-tracker/bun.lock
+++ b/packages/session-tracker/bun.lock
@@ -1,0 +1,258 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@agents/session-tracker",
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.0", "", { "os": "android", "cpu": "arm" }, "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.0", "", { "os": "android", "cpu": "arm64" }, "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.0", "", { "os": "android", "cpu": "x64" }, "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64" }, "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.0", "", { "os": "none", "cpu": "x64" }, "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.61.1", "", { "os": "android", "cpu": "arm" }, "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.61.1", "", { "os": "android", "cpu": "arm64" }, "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.61.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.61.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.61.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.61.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.61.1", "", { "os": "linux", "cpu": "arm" }, "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.61.1", "", { "os": "linux", "cpu": "arm" }, "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.61.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.61.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.61.1", "", { "os": "linux", "cpu": "none" }, "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.61.1", "", { "os": "linux", "cpu": "none" }, "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.61.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.61.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.61.1", "", { "os": "linux", "cpu": "none" }, "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.61.1", "", { "os": "linux", "cpu": "none" }, "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.61.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.61.1", "", { "os": "linux", "cpu": "x64" }, "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.61.1", "", { "os": "linux", "cpu": "x64" }, "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.61.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.61.1", "", { "os": "none", "cpu": "arm64" }, "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.61.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.61.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.61.1", "", { "os": "win32", "cpu": "x64" }, "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.61.1", "", { "os": "win32", "cpu": "x64" }, "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/node": ["@types/node@22.19.20", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw=="],
+
+    "@vitest/expect": ["@vitest/expect@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw=="],
+
+    "@vitest/mocker": ["@vitest/mocker@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.12" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@2.1.9", "", { "dependencies": { "tinyrainbow": "^1.2.0" } }, "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ=="],
+
+    "@vitest/runner": ["@vitest/runner@2.1.9", "", { "dependencies": { "@vitest/utils": "2.1.9", "pathe": "^1.1.2" } }, "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "magic-string": "^0.30.12", "pathe": "^1.1.2" } }, "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ=="],
+
+    "@vitest/spy": ["@vitest/spy@2.1.9", "", { "dependencies": { "tinyspy": "^3.0.2" } }, "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ=="],
+
+    "@vitest/utils": ["@vitest/utils@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "loupe": "^3.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "rollup": ["rollup@4.61.1", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.61.1", "@rollup/rollup-android-arm64": "4.61.1", "@rollup/rollup-darwin-arm64": "4.61.1", "@rollup/rollup-darwin-x64": "4.61.1", "@rollup/rollup-freebsd-arm64": "4.61.1", "@rollup/rollup-freebsd-x64": "4.61.1", "@rollup/rollup-linux-arm-gnueabihf": "4.61.1", "@rollup/rollup-linux-arm-musleabihf": "4.61.1", "@rollup/rollup-linux-arm64-gnu": "4.61.1", "@rollup/rollup-linux-arm64-musl": "4.61.1", "@rollup/rollup-linux-loong64-gnu": "4.61.1", "@rollup/rollup-linux-loong64-musl": "4.61.1", "@rollup/rollup-linux-ppc64-gnu": "4.61.1", "@rollup/rollup-linux-ppc64-musl": "4.61.1", "@rollup/rollup-linux-riscv64-gnu": "4.61.1", "@rollup/rollup-linux-riscv64-musl": "4.61.1", "@rollup/rollup-linux-s390x-gnu": "4.61.1", "@rollup/rollup-linux-x64-gnu": "4.61.1", "@rollup/rollup-linux-x64-musl": "4.61.1", "@rollup/rollup-openbsd-x64": "4.61.1", "@rollup/rollup-openharmony-arm64": "4.61.1", "@rollup/rollup-win32-arm64-msvc": "4.61.1", "@rollup/rollup-win32-ia32-msvc": "4.61.1", "@rollup/rollup-win32-x64-gnu": "4.61.1", "@rollup/rollup-win32-x64-msvc": "4.61.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@1.2.0", "", {}, "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ=="],
+
+    "tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
+
+    "tsx": ["tsx@4.22.4", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "vite-node": ["vite-node@2.1.9", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.3.7", "es-module-lexer": "^1.5.4", "pathe": "^1.1.2", "vite": "^5.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA=="],
+
+    "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+  }
+}

--- a/packages/session-tracker/package.json
+++ b/packages/session-tracker/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@agents/session-tracker",
+  "version": "0.0.1",
+  "description": "Per-agent SessionStart hook + descendant-pid lookup. One state-file format for every coding-agent CLI.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist", "src/hook.sh"],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:smoke": "vitest run tests/smoke.test.ts",
+    "install-hook": "tsx src/install-hook.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/session-tracker/src/adapters/claude.ts
+++ b/packages/session-tracker/src/adapters/claude.ts
@@ -1,0 +1,97 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export const CLAUDE_PROJECTS_ROOT = path.join(os.homedir(), '.claude', 'projects');
+
+// Mirrors swarmify's workspaceToClaudeFolder: replace / and . with -
+export function claudeWorkspaceFolder(cwd: string): string {
+  return cwd.replace(/[\/.]/g, '-');
+}
+
+async function discoverClaudeProjectRoots(): Promise<string[]> {
+  // agents-cli isolates per-version state: each installed claude version writes
+  // session files under <ver-home>/.claude/projects/, NOT the symlinked
+  // ~/.claude/projects/. Walk every version dir + include the symlink target.
+  const roots = new Set<string>([CLAUDE_PROJECTS_ROOT]);
+  const versionsRoot = path.join(os.homedir(), '.agents', '.history', 'versions', 'claude');
+  try {
+    const versions = await fs.promises.readdir(versionsRoot);
+    for (const v of versions) {
+      const r = path.join(versionsRoot, v, 'home', '.claude', 'projects');
+      try {
+        await fs.promises.access(r);
+        roots.add(r);
+      } catch {
+        /* skip versions without projects dir */
+      }
+    }
+  } catch {
+    /* skip */
+  }
+  return [...roots];
+}
+
+export async function claudeSessionDirs(cwd: string): Promise<string[]> {
+  const folder = claudeWorkspaceFolder(cwd);
+  const roots = await discoverClaudeProjectRoots();
+  return roots.map((r) => path.join(r, folder));
+}
+
+// Legacy single-root helper kept for any single-version-aware caller.
+export function claudeSessionDir(cwd: string): string {
+  return path.join(CLAUDE_PROJECTS_ROOT, claudeWorkspaceFolder(cwd));
+}
+
+export async function snapshotSessions(cwd: string): Promise<Set<string>> {
+  const dirs = await claudeSessionDirs(cwd);
+  const all = new Set<string>();
+  for (const d of dirs) {
+    try {
+      const files = await fs.promises.readdir(d);
+      for (const f of files) {
+        if (f.endsWith('.jsonl')) all.add(`${d}/${f}`);
+      }
+    } catch {
+      /* dir may not exist */
+    }
+  }
+  return all;
+}
+
+export interface NewSession {
+  sessionId: string;
+  latencyMs: number;
+  file: string;
+}
+
+export async function awaitNewSession(
+  cwd: string,
+  before: Set<string>,
+  timeoutMs: number,
+  pollMs = 50,
+): Promise<NewSession | null> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const dirs = await claudeSessionDirs(cwd);
+    for (const dir of dirs) {
+      try {
+        const files = await fs.promises.readdir(dir);
+        for (const f of files) {
+          if (!f.endsWith('.jsonl')) continue;
+          const fullPath = `${dir}/${f}`;
+          if (before.has(fullPath)) continue;
+          return {
+            sessionId: f.replace(/\.jsonl$/, ''),
+            latencyMs: Date.now() - start,
+            file: fullPath,
+          };
+        }
+      } catch {
+        /* dir may not exist yet */
+      }
+    }
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  return null;
+}

--- a/packages/session-tracker/src/hook.sh
+++ b/packages/session-tracker/src/hook.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Polyglot SessionStart hook.
+#
+# Registered as a SessionStart hook in each agent's native config file.
+# Each agent passes the hook payload differently:
+#   - claude/codex/cursor: JSON on stdin with session_id (+conversation_id for cursor)
+#   - grok: GROK_SESSION_ID and GROK_WORKSPACE_ROOT env vars
+#   - gemini/antigravity: TBD — add branches below as upstream payloads land
+#
+# Writes ~/.agents/.cache/state/sessions/<PPID>.json with the canonical
+# SessionState schema from src/types.ts. Atomic via mktemp + mv.
+#
+# Invocation:
+#   hook.sh <agent>            # required; selects which payload format to parse
+#
+# Silent on success (SessionStart stdout leaks into the model context).
+
+set -euo pipefail
+
+AGENT="${1:-${AGENT_HINT:-}}"
+if [ -z "$AGENT" ]; then
+  exit 0
+fi
+
+# Read stdin if any. macOS has no `timeout` in PATH by default, so we rely on
+# the host closing stdin promptly (claude/codex/cursor all do).
+STDIN_JSON=""
+if [ ! -t 0 ]; then
+  STDIN_JSON="$(cat || true)"
+fi
+
+SID=""
+CWD=""
+METHOD="hook-stdin"
+
+extract_stdin_json() {
+  local field_priority="$1"
+  python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    for k in '''$field_priority'''.split():
+        v = d.get(k)
+        if isinstance(v, str) and v:
+            print(v); sys.exit(0)
+        if isinstance(v, list) and v and isinstance(v[0], str):
+            print(v[0]); sys.exit(0)
+except Exception:
+    pass
+" 2>/dev/null || true
+}
+
+case "$AGENT" in
+  claude|codex)
+    SID="$(printf '%s' "$STDIN_JSON" | extract_stdin_json 'session_id')"
+    CWD="$(printf '%s' "$STDIN_JSON" | extract_stdin_json 'cwd')"
+    ;;
+  cursor)
+    SID="$(printf '%s' "$STDIN_JSON" | extract_stdin_json 'session_id conversation_id')"
+    CWD="$(printf '%s' "$STDIN_JSON" | extract_stdin_json 'cwd workspace_roots')"
+    ;;
+  grok)
+    SID="${GROK_SESSION_ID:-}"
+    CWD="${GROK_WORKSPACE_ROOT:-$PWD}"
+    METHOD="hook-env"
+    ;;
+  gemini|antigravity)
+    SID="$(printf '%s' "$STDIN_JSON" | extract_stdin_json 'session_id conversation_id sessionId')"
+    CWD="$(printf '%s' "$STDIN_JSON" | extract_stdin_json 'cwd workspace_roots')"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+if [ -z "$SID" ]; then
+  exit 0
+fi
+
+[ -z "$CWD" ] && CWD="$PWD"
+
+STATE_DIR="$HOME/.agents/.cache/state/sessions"
+mkdir -p "$STATE_DIR"
+
+TID="${AGENT_TERMINAL_ID:-}"
+LID="${AGENT_LAUNCH_ID:-}"
+
+TMP="$(mktemp "$STATE_DIR/.${PPID}.XXXXXX")"
+python3 - "$SID" "$CWD" "$PPID" "$AGENT" "$TID" "$LID" "$METHOD" > "$TMP" <<'PY'
+import json, sys, time
+sid, cwd, pid, agent, tid, lid, method = sys.argv[1:8]
+out = {
+    "session_id": sid,
+    "agent": agent,
+    "cwd": cwd,
+    "pid": int(pid),
+    "ts": int(time.time() * 1000),
+    "method": method,
+}
+if tid:
+    out["terminal_id"] = tid
+if lid:
+    out["launch_id"] = lid
+json.dump(out, sys.stdout)
+PY
+
+mv -f "$TMP" "$STATE_DIR/$PPID.json"
+exit 0

--- a/packages/session-tracker/src/hook.sh
+++ b/packages/session-tracker/src/hook.sh
@@ -7,8 +7,10 @@
 #   - grok: GROK_SESSION_ID and GROK_WORKSPACE_ROOT env vars
 #   - gemini/antigravity: TBD — add branches below as upstream payloads land
 #
-# Writes ~/.agents/.cache/state/sessions/<PPID>.json with the canonical
+# Writes ~/.agents/.cache/terminals/sessions/<PPID>.json with the canonical
 # SessionState schema from src/types.ts. Atomic via mktemp + mv.
+# Distinct path from the legacy 04-capture hook (~/.agents/.cache/state/sessions/)
+# so the two writers don't race for the same file.
 #
 # Invocation:
 #   hook.sh <agent>            # required; selects which payload format to parse
@@ -79,7 +81,7 @@ fi
 
 [ -z "$CWD" ] && CWD="$PWD"
 
-STATE_DIR="$HOME/.agents/.cache/state/sessions"
+STATE_DIR="$HOME/.agents/.cache/terminals/sessions"
 mkdir -p "$STATE_DIR"
 
 TID="${AGENT_TERMINAL_ID:-}"

--- a/packages/session-tracker/src/index.ts
+++ b/packages/session-tracker/src/index.ts
@@ -1,0 +1,96 @@
+import * as fs from 'fs';
+import { parseState, stateFilePath } from './state-file.js';
+import {
+  findStateByLaunchId,
+  findStateByTerminalId,
+  findStateInTree,
+} from './reader.js';
+import type {
+  DetectionResult,
+  LookupInput,
+  SessionState,
+  TrackSpawnInput,
+} from './types.js';
+
+export * from './types.js';
+export * from './state-file.js';
+export * from './writer.js';
+export * from './install-hook.js';
+export {
+  descendantPids,
+  findStateByPid,
+  findStateInTree,
+  findStateByTerminalId,
+  findStateByLaunchId,
+  pruneStaleSessionState,
+} from './reader.js';
+
+export interface TrackSpawnOptions {
+  /** Max time to wait for the SessionStart hook to land the state file. Default 5000ms. */
+  timeoutMs?: number;
+  /** Poll interval. Default 50ms. */
+  pollIntervalMs?: number;
+}
+
+/**
+ * Wait for the polyglot SessionStart hook (src/hook.sh) to drop a state file
+ * at stateFilePath(input.agentPid). Resolves as soon as it appears.
+ * Returns confidence='low' / sessionId=null on timeout.
+ */
+export async function trackSpawn(
+  input: TrackSpawnInput,
+  opts: TrackSpawnOptions = {},
+): Promise<DetectionResult> {
+  const timeoutMs = opts.timeoutMs ?? 5000;
+  const pollIntervalMs = opts.pollIntervalMs ?? 50;
+  const start = Date.now();
+  const targetPath = stateFilePath(input.agentPid);
+
+  while (Date.now() - start < timeoutMs) {
+    const state = await readStateIfPresent(targetPath);
+    if (state) {
+      return {
+        sessionId: state.session_id,
+        method: state.method,
+        latencyMs: Date.now() - start,
+        confidence: 'high',
+      };
+    }
+    await sleep(pollIntervalMs);
+  }
+
+  return {
+    sessionId: null,
+    method: null,
+    latencyMs: Date.now() - start,
+    confidence: 'low',
+  };
+}
+
+export async function getLiveSession(input: LookupInput): Promise<SessionState | null> {
+  if (input.launchId) {
+    const byLaunch = await findStateByLaunchId(input.launchId);
+    if (byLaunch) return byLaunch;
+  }
+  if (input.terminalId) {
+    const byTerm = await findStateByTerminalId(input.terminalId);
+    if (byTerm) return byTerm;
+  }
+  if (input.shellPid) {
+    return findStateInTree(input.shellPid);
+  }
+  return null;
+}
+
+async function readStateIfPresent(p: string): Promise<SessionState | null> {
+  try {
+    const raw = await fs.promises.readFile(p, 'utf8');
+    return parseState(raw);
+  } catch {
+    return null;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/session-tracker/src/install-hook.ts
+++ b/packages/session-tracker/src/install-hook.ts
@@ -1,0 +1,204 @@
+// Installs the polyglot src/hook.sh as a SessionStart hook in each agent's
+// native config file. Idempotent — running twice does not double-register.
+//
+// CLI usage:
+//   tsx src/install-hook.ts claude
+//   tsx src/install-hook.ts claude codex cursor
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import type { AgentId } from './types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const HOOK_PATH = path.resolve(__dirname, 'hook.sh');
+
+export interface InstallResult {
+  agent: AgentId;
+  installed: boolean;
+  configPath: string;
+  error?: string;
+}
+
+export interface InstallOptions {
+  dryRun?: boolean;
+  hookPathOverride?: string;
+}
+
+function hookCommand(agent: AgentId, opts: InstallOptions): string {
+  const hook = opts.hookPathOverride ?? HOOK_PATH;
+  return `${hook} ${agent}`;
+}
+
+async function readJson(p: string): Promise<any> {
+  try {
+    const raw = await fs.promises.readFile(p, 'utf8');
+    return JSON.parse(raw);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return {};
+    throw err;
+  }
+}
+
+async function writeJsonAtomic(p: string, data: any): Promise<void> {
+  await fs.promises.mkdir(path.dirname(p), { recursive: true });
+  const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
+  await fs.promises.writeFile(tmp, JSON.stringify(data, null, 2), 'utf8');
+  await fs.promises.rename(tmp, p);
+}
+
+async function discoverClaudeSettingsPaths(): Promise<string[]> {
+  // agents-cli installs each Claude version under
+  // ~/.agents/.history/versions/claude/<version>/home/.claude/settings.json
+  // and sets CLAUDE_CONFIG_DIR to the per-version path when running that
+  // version. We must install the hook into every per-version settings file,
+  // plus the symlinked ~/.claude/settings.json for direct invocations.
+  const out = new Set<string>();
+  out.add(path.join(os.homedir(), '.claude', 'settings.json'));
+  const versionsRoot = path.join(os.homedir(), '.agents', '.history', 'versions', 'claude');
+  try {
+    const versions = await fs.promises.readdir(versionsRoot);
+    for (const v of versions) {
+      const p = path.join(versionsRoot, v, 'home', '.claude', 'settings.json');
+      try {
+        await fs.promises.access(p);
+        out.add(path.resolve(p));
+      } catch {
+        /* skip versions without settings */
+      }
+    }
+  } catch {
+    /* skip if versions root missing */
+  }
+  return [...out];
+}
+
+async function installClaudeAt(configPath: string, opts: InstallOptions): Promise<void> {
+  const command = hookCommand('claude', opts);
+  const cfg = await readJson(configPath);
+  cfg.hooks = cfg.hooks ?? {};
+  cfg.hooks.SessionStart = cfg.hooks.SessionStart ?? [];
+  // Idempotency — strip any prior registration of THIS hook script.
+  for (const entry of cfg.hooks.SessionStart) {
+    if (!entry || !Array.isArray(entry.hooks)) continue;
+    entry.hooks = entry.hooks.filter(
+      (h: any) =>
+        !(h && h.command && String(h.command).includes('packages/session-tracker/src/hook.sh')),
+    );
+  }
+  let group = cfg.hooks.SessionStart.find((e: any) => e && e.matcher === '');
+  if (!group) {
+    group = { matcher: '', hooks: [] };
+    cfg.hooks.SessionStart.push(group);
+  }
+  group.hooks.push({ type: 'command', command, timeout: 5 });
+  await writeJsonAtomic(configPath, cfg);
+}
+
+async function installClaude(opts: InstallOptions): Promise<InstallResult> {
+  const paths = await discoverClaudeSettingsPaths();
+  if (opts.dryRun) {
+    return { agent: 'claude', installed: false, configPath: paths.join(';') };
+  }
+  for (const p of paths) {
+    await installClaudeAt(p, opts);
+  }
+  return { agent: 'claude', installed: true, configPath: paths.join(';') };
+}
+
+async function installCodex(opts: InstallOptions): Promise<InstallResult> {
+  const configPath = path.join(os.homedir(), '.codex', 'hooks.json');
+  const command = hookCommand('codex', opts);
+  if (opts.dryRun) return { agent: 'codex', installed: false, configPath };
+  const cfg = await readJson(configPath);
+  cfg.hooks = cfg.hooks ?? {};
+  cfg.hooks.SessionStart = cfg.hooks.SessionStart ?? [];
+  for (const entry of cfg.hooks.SessionStart) {
+    if (!entry || !Array.isArray(entry.hooks)) continue;
+    entry.hooks = entry.hooks.filter(
+      (h: any) =>
+        !(h && h.command && String(h.command).includes('packages/session-tracker/src/hook.sh')),
+    );
+  }
+  let group = cfg.hooks.SessionStart.find(
+    (e: any) => e && (e.matcher === '' || e.matcher === 'startup|resume'),
+  );
+  if (!group) {
+    group = { matcher: 'startup|resume', hooks: [] };
+    cfg.hooks.SessionStart.push(group);
+  }
+  group.hooks.push({ type: 'command', command, timeout: 5 });
+  await writeJsonAtomic(configPath, cfg);
+  return { agent: 'codex', installed: true, configPath };
+}
+
+async function installCursor(opts: InstallOptions): Promise<InstallResult> {
+  const configPath = path.join(os.homedir(), '.cursor', 'hooks.json');
+  const command = hookCommand('cursor', opts);
+  if (opts.dryRun) return { agent: 'cursor', installed: false, configPath };
+  const cfg = await readJson(configPath);
+  cfg.hooks = cfg.hooks ?? {};
+  cfg.hooks.sessionStart = cfg.hooks.sessionStart ?? [];
+  cfg.hooks.sessionStart = cfg.hooks.sessionStart.filter(
+    (h: any) =>
+      !(h && h.command && String(h.command).includes('packages/session-tracker/src/hook.sh')),
+  );
+  cfg.hooks.sessionStart.push({ type: 'command', command, timeout: 5 });
+  await writeJsonAtomic(configPath, cfg);
+  return { agent: 'cursor', installed: true, configPath };
+}
+
+async function installGrok(opts: InstallOptions): Promise<InstallResult> {
+  const configPath = path.join(os.homedir(), '.grok', 'hooks', 'session-start.json');
+  const command = hookCommand('grok', opts);
+  if (opts.dryRun) return { agent: 'grok', installed: false, configPath };
+  await writeJsonAtomic(configPath, { command, timeout: 5 });
+  return { agent: 'grok', installed: true, configPath };
+}
+
+export async function installHookFor(
+  agent: AgentId,
+  opts: InstallOptions = {},
+): Promise<InstallResult> {
+  try {
+    switch (agent) {
+      case 'claude':
+        return await installClaude(opts);
+      case 'codex':
+        return await installCodex(opts);
+      case 'cursor':
+        return await installCursor(opts);
+      case 'grok':
+        return await installGrok(opts);
+      default:
+        return {
+          agent,
+          installed: false,
+          configPath: '',
+          error: `installation for ${agent} not yet implemented`,
+        };
+    }
+  } catch (err) {
+    return {
+      agent,
+      installed: false,
+      configPath: '',
+      error: (err as Error).message,
+    };
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const agents = process.argv.slice(2) as AgentId[];
+  if (agents.length === 0) {
+    console.error('usage: tsx src/install-hook.ts <agent> [<agent>...]');
+    process.exit(2);
+  }
+  for (const a of agents) {
+    const r = await installHookFor(a);
+    console.log(JSON.stringify(r));
+    if (r.error) process.exitCode = 1;
+  }
+}

--- a/packages/session-tracker/src/reader.ts
+++ b/packages/session-tracker/src/reader.ts
@@ -10,30 +10,40 @@ const execAsync = promisify(exec);
 const PID_TREE_MAX_DEPTH = 5;
 const PID_TREE_MAX_NODES = 100;
 
+// macOS `pgrep -P` silently misses children for some pids; `ps -eo` is reliable.
+async function buildChildIndex(): Promise<Map<number, number[]>> {
+  const index = new Map<number, number[]>();
+  try {
+    const { stdout } = await execAsync('ps -eo pid,ppid', { timeout: 2000 });
+    for (const line of stdout.split('\n').slice(1)) {
+      const [pidStr, ppidStr] = line.trim().split(/\s+/);
+      const pid = Number(pidStr);
+      const ppid = Number(ppidStr);
+      if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue;
+      const kids = index.get(ppid);
+      if (kids) kids.push(pid);
+      else index.set(ppid, [pid]);
+    }
+  } catch {
+    /* empty index — caller treats as no descendants */
+  }
+  return index;
+}
+
 export async function descendantPids(rootPid: number): Promise<number[]> {
+  const index = await buildChildIndex();
   const visited = new Set<number>([rootPid]);
   const out: number[] = [];
   const queue: { pid: number; depth: number }[] = [{ pid: rootPid, depth: 0 }];
   while (queue.length > 0 && visited.size < PID_TREE_MAX_NODES) {
     const { pid, depth } = queue.shift()!;
     if (depth >= PID_TREE_MAX_DEPTH) continue;
-    let children: number[] = [];
-    try {
-      const { stdout } = await execAsync(`pgrep -P ${pid}`, { timeout: 1000 });
-      children = stdout
-        .trim()
-        .split(/\s+/)
-        .filter(Boolean)
-        .map(Number)
-        .filter((n) => Number.isFinite(n) && n > 0);
-    } catch {
-      children = [];
-    }
-    for (const c of children) {
+    for (const c of index.get(pid) ?? []) {
       if (visited.has(c)) continue;
       visited.add(c);
       out.push(c);
       queue.push({ pid: c, depth: depth + 1 });
+      if (visited.size >= PID_TREE_MAX_NODES) break;
     }
   }
   return out;

--- a/packages/session-tracker/src/reader.ts
+++ b/packages/session-tracker/src/reader.ts
@@ -1,0 +1,128 @@
+import { exec } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { promisify } from 'util';
+import { STATE_DIR, parseState, stateFilePath } from './state-file.js';
+import type { SessionState } from './types.js';
+
+const execAsync = promisify(exec);
+
+const PID_TREE_MAX_DEPTH = 5;
+const PID_TREE_MAX_NODES = 100;
+
+export async function descendantPids(rootPid: number): Promise<number[]> {
+  const visited = new Set<number>([rootPid]);
+  const out: number[] = [];
+  const queue: { pid: number; depth: number }[] = [{ pid: rootPid, depth: 0 }];
+  while (queue.length > 0 && visited.size < PID_TREE_MAX_NODES) {
+    const { pid, depth } = queue.shift()!;
+    if (depth >= PID_TREE_MAX_DEPTH) continue;
+    let children: number[] = [];
+    try {
+      const { stdout } = await execAsync(`pgrep -P ${pid}`, { timeout: 1000 });
+      children = stdout
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean)
+        .map(Number)
+        .filter((n) => Number.isFinite(n) && n > 0);
+    } catch {
+      children = [];
+    }
+    for (const c of children) {
+      if (visited.has(c)) continue;
+      visited.add(c);
+      out.push(c);
+      queue.push({ pid: c, depth: depth + 1 });
+    }
+  }
+  return out;
+}
+
+export async function findStateByPid(pid: number): Promise<SessionState | null> {
+  try {
+    const raw = await fs.promises.readFile(stateFilePath(pid), 'utf8');
+    return parseState(raw);
+  } catch {
+    return null;
+  }
+}
+
+export async function findStateInTree(shellPid: number): Promise<SessionState | null> {
+  const pids = [shellPid, ...(await descendantPids(shellPid))];
+  let best: SessionState | null = null;
+  for (const pid of pids) {
+    const s = await findStateByPid(pid);
+    if (s && (!best || s.ts > best.ts)) best = s;
+  }
+  return best;
+}
+
+async function scanAllStates(): Promise<SessionState[]> {
+  let names: string[];
+  try {
+    names = await fs.promises.readdir(STATE_DIR);
+  } catch {
+    return [];
+  }
+  const out: SessionState[] = [];
+  for (const name of names) {
+    if (!name.endsWith('.json')) continue;
+    try {
+      const raw = await fs.promises.readFile(path.join(STATE_DIR, name), 'utf8');
+      const s = parseState(raw);
+      if (s) out.push(s);
+    } catch {
+      /* skip */
+    }
+  }
+  return out;
+}
+
+export async function findStateByTerminalId(terminalId: string): Promise<SessionState | null> {
+  const all = await scanAllStates();
+  let best: SessionState | null = null;
+  for (const s of all) {
+    if (s.terminal_id !== terminalId) continue;
+    if (!best || s.ts > best.ts) best = s;
+  }
+  return best;
+}
+
+export async function findStateByLaunchId(launchId: string): Promise<SessionState | null> {
+  const all = await scanAllStates();
+  let best: SessionState | null = null;
+  for (const s of all) {
+    if (s.launch_id !== launchId) continue;
+    if (!best || s.ts > best.ts) best = s;
+  }
+  return best;
+}
+
+export async function pruneStaleSessionState(): Promise<number> {
+  let names: string[];
+  try {
+    names = await fs.promises.readdir(STATE_DIR);
+  } catch {
+    return 0;
+  }
+  let removed = 0;
+  for (const name of names) {
+    if (!name.endsWith('.json')) continue;
+    const pid = Number(name.slice(0, -5));
+    if (!Number.isFinite(pid) || pid <= 0) continue;
+    try {
+      process.kill(pid, 0);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ESRCH') {
+        try {
+          await fs.promises.unlink(path.join(STATE_DIR, name));
+          removed++;
+        } catch {
+          /* best-effort */
+        }
+      }
+    }
+  }
+  return removed;
+}

--- a/packages/session-tracker/src/state-file.ts
+++ b/packages/session-tracker/src/state-file.ts
@@ -1,0 +1,60 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { SessionState } from './types.js';
+
+export const STATE_DIR = path.join(os.homedir(), '.agents', '.cache', 'state', 'sessions');
+
+export function stateFilePath(pid: number): string {
+  return path.join(STATE_DIR, `${pid}.json`);
+}
+
+const KEY_ORDER: (keyof SessionState)[] = [
+  'session_id',
+  'agent',
+  'cwd',
+  'pid',
+  'terminal_id',
+  'launch_id',
+  'ts',
+  'method',
+];
+
+export function serializeState(s: SessionState): string {
+  const ordered: Record<string, unknown> = {};
+  for (const k of KEY_ORDER) {
+    const v = s[k];
+    if (v !== undefined) ordered[k] = v;
+  }
+  return JSON.stringify(ordered);
+}
+
+export function parseState(raw: string): SessionState | null {
+  let obj: unknown;
+  try {
+    obj = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!obj || typeof obj !== 'object') return null;
+  const o = obj as Record<string, unknown>;
+  if (
+    typeof o.session_id !== 'string' ||
+    typeof o.agent !== 'string' ||
+    typeof o.cwd !== 'string' ||
+    typeof o.pid !== 'number' ||
+    typeof o.ts !== 'number'
+  ) {
+    return null;
+  }
+  if (typeof o.method !== 'string') o.method = 'hook-stdin';
+  return o as unknown as SessionState;
+}
+
+export async function writeStateAtomic(state: SessionState): Promise<void> {
+  await fs.promises.mkdir(STATE_DIR, { recursive: true });
+  const finalPath = stateFilePath(state.pid);
+  const tmpPath = `${finalPath}.${process.pid}.${Date.now()}.tmp`;
+  await fs.promises.writeFile(tmpPath, serializeState(state), 'utf8');
+  await fs.promises.rename(tmpPath, finalPath);
+}

--- a/packages/session-tracker/src/state-file.ts
+++ b/packages/session-tracker/src/state-file.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import type { SessionState } from './types.js';
 
-export const STATE_DIR = path.join(os.homedir(), '.agents', '.cache', 'state', 'sessions');
+export const STATE_DIR = path.join(os.homedir(), '.agents', '.cache', 'terminals', 'sessions');
 
 export function stateFilePath(pid: number): string {
   return path.join(STATE_DIR, `${pid}.json`);

--- a/packages/session-tracker/src/state-file.ts
+++ b/packages/session-tracker/src/state-file.ts
@@ -40,13 +40,16 @@ export function parseState(raw: string): SessionState | null {
   const o = obj as Record<string, unknown>;
   if (
     typeof o.session_id !== 'string' ||
-    typeof o.agent !== 'string' ||
     typeof o.cwd !== 'string' ||
     typeof o.pid !== 'number' ||
     typeof o.ts !== 'number'
   ) {
     return null;
   }
+  // Legacy hooks (the pre-package SessionStart capture script) wrote a subset
+  // of fields. Default the rest rather than reject — session_id is the load-
+  // bearing field and is always present.
+  if (typeof o.agent !== 'string') o.agent = 'unknown' as any;
   if (typeof o.method !== 'string') o.method = 'hook-stdin';
   return o as unknown as SessionState;
 }

--- a/packages/session-tracker/src/types.ts
+++ b/packages/session-tracker/src/types.ts
@@ -5,7 +5,8 @@ export type AgentId =
   | 'cursor'
   | 'grok'
   | 'antigravity'
-  | 'opencode';
+  | 'opencode'
+  | 'unknown';
 
 export interface TrackSpawnInput {
   agent: AgentId;

--- a/packages/session-tracker/src/types.ts
+++ b/packages/session-tracker/src/types.ts
@@ -1,0 +1,44 @@
+export type AgentId =
+  | 'claude'
+  | 'codex'
+  | 'gemini'
+  | 'cursor'
+  | 'grok'
+  | 'antigravity'
+  | 'opencode';
+
+export interface TrackSpawnInput {
+  agent: AgentId;
+  agentPid: number;
+  shellPid?: number;
+  cwd: string;
+  terminalId?: string;
+  launchId: string;
+}
+
+export type DetectionMethod = 'hook-stdin' | 'hook-env' | 'fs-watch' | 'stdout-banner';
+export type DetectionConfidence = 'high' | 'medium' | 'low';
+
+export interface DetectionResult {
+  sessionId: string | null;
+  method: DetectionMethod | null;
+  latencyMs: number;
+  confidence: DetectionConfidence;
+}
+
+export interface SessionState {
+  session_id: string;
+  agent: AgentId;
+  cwd: string;
+  pid: number;
+  terminal_id?: string;
+  launch_id?: string;
+  ts: number;
+  method: DetectionMethod;
+}
+
+export interface LookupInput {
+  shellPid?: number;
+  terminalId?: string;
+  launchId?: string;
+}

--- a/packages/session-tracker/src/writer.ts
+++ b/packages/session-tracker/src/writer.ts
@@ -1,0 +1,37 @@
+import * as fs from 'fs';
+import { stateFilePath, writeStateAtomic } from './state-file.js';
+import type { AgentId, DetectionMethod, SessionState } from './types.js';
+
+export interface RecordSessionArgs {
+  sessionId: string;
+  agent: AgentId;
+  pid: number;
+  cwd: string;
+  terminalId?: string;
+  launchId?: string;
+  method: DetectionMethod;
+}
+
+export async function recordSession(args: RecordSessionArgs): Promise<void> {
+  const state: SessionState = {
+    session_id: args.sessionId,
+    agent: args.agent,
+    cwd: args.cwd,
+    pid: args.pid,
+    ts: Date.now(),
+    method: args.method,
+  };
+  if (args.terminalId) state.terminal_id = args.terminalId;
+  if (args.launchId) state.launch_id = args.launchId;
+  await writeStateAtomic(state);
+}
+
+export async function clearSession(pid: number): Promise<void> {
+  try {
+    await fs.promises.unlink(stateFilePath(pid));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw err;
+    }
+  }
+}

--- a/packages/session-tracker/tests/diag.ts
+++ b/packages/session-tracker/tests/diag.ts
@@ -1,0 +1,65 @@
+import { spawn } from 'child_process';
+import { randomUUID } from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { snapshotSessions, awaitNewSession, claudeSessionDirs } from '../src/adapters/claude.js';
+
+async function main() {
+  const cwd = await fs.promises.realpath(
+    await fs.promises.mkdtemp(path.join(os.tmpdir(), 'session-tracker-test-')),
+  );
+  console.log('[diag] cwd =', cwd);
+
+  const dirs = await claudeSessionDirs(cwd);
+  console.log('[diag] candidate session dirs (', dirs.length, '):');
+  for (const d of dirs) console.log('   ', d);
+
+  const before = await snapshotSessions(cwd);
+  console.log('[diag] before snapshot:', before.size, 'files');
+
+  const launchId = randomUUID();
+  console.log('[diag] launching agents run claude');
+  const proc = spawn('agents', ['run', 'claude', 'say ok', '--mode', 'plan'], {
+    cwd,
+    env: { ...process.env, AGENT_LAUNCH_ID: launchId },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  console.log('[diag] spawned pid =', proc.pid);
+
+  let stdout = '';
+  let stderr = '';
+  proc.stdout?.on('data', (d) => (stdout += d.toString()));
+  proc.stderr?.on('data', (d) => (stderr += d.toString()));
+
+  const truthPromise = awaitNewSession(cwd, before, 15_000).then((r) => {
+    console.log('[diag] awaitNewSession resolved:', r);
+    return r;
+  });
+
+  await new Promise<void>((resolve) => {
+    proc.once('exit', (code, sig) => {
+      console.log('[diag] proc exit:', { code, sig });
+      console.log('[diag] stdout:', stdout.slice(0, 400));
+      console.log('[diag] stderr:', stderr.slice(0, 400));
+      resolve();
+    });
+  });
+
+  await truthPromise;
+
+  console.log('[diag] post-spawn snapshot:');
+  for (const d of dirs) {
+    try {
+      const f = await fs.promises.readdir(d);
+      if (f.length > 0) console.log(`   ${d}: ${f.join(', ')}`);
+    } catch {}
+  }
+
+  await fs.promises.rm(cwd, { recursive: true, force: true });
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/session-tracker/tests/harness.ts
+++ b/packages/session-tracker/tests/harness.ts
@@ -71,9 +71,13 @@ export async function spawnAndDetect(opts: SpawnOpts): Promise<SpawnRun> {
   if (!proc.pid) {
     throw new Error(`spawn agents ${opts.agent} failed: no pid`);
   }
+  // Close stdin immediately — claude waits 3s for stdin data otherwise
+  // ("no stdin data received in 3s, proceeding without it"). Headless prompts
+  // are passed via argv, so nothing useful comes via stdin.
+  proc.stdin?.end();
 
-  const trackerTimeoutMs = opts.trackerTimeoutMs ?? 8000;
-  const truthTimeoutMs = opts.truthTimeoutMs ?? 8000;
+  const trackerTimeoutMs = opts.trackerTimeoutMs ?? 15_000;
+  const truthTimeoutMs = opts.truthTimeoutMs ?? 15_000;
 
   const [truth, detected] = await Promise.all([
     opts.agent === 'claude'

--- a/packages/session-tracker/tests/harness.ts
+++ b/packages/session-tracker/tests/harness.ts
@@ -1,0 +1,148 @@
+import { spawn, ChildProcess } from 'child_process';
+import { randomUUID } from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { awaitNewSession, snapshotSessions } from '../src/adapters/claude.js';
+import { clearSession } from '../src/writer.js';
+import type { AgentId, DetectionResult } from '../src/types.js';
+
+export interface SpawnOpts {
+  agent: AgentId;
+  cwd?: string;
+  truthTimeoutMs?: number;
+  trackerTimeoutMs?: number;
+  env?: Record<string, string>;
+  args?: string[];
+  reuseCwd?: boolean;
+  /**
+   * Headless prompt; defaults to "say ok". Avoids needing a PTY.
+   * Pass `args: ['--interactive']` (with reuseCwd + a PTY harness) to test
+   * interactive behavior end-to-end.
+   */
+  prompt?: string;
+  mode?: 'plan' | 'edit' | 'auto' | 'skip';
+}
+
+export interface SpawnRun {
+  agent: AgentId;
+  cwd: string;
+  launchId: string;
+  proc: ChildProcess;
+  truth: { sessionId: string; latencyMs: number; file: string } | null;
+  detected: DetectionResult;
+  matched: boolean;
+}
+
+async function makeFreshCwd(): Promise<string> {
+  const dir = path.join(os.tmpdir(), `session-tracker-test-${randomUUID()}`);
+  await fs.promises.mkdir(dir, { recursive: true });
+  // macOS: /tmp -> /private/tmp. Resolve so Claude's workspace folder name
+  // matches the realpath we'll be snapshotting against.
+  return fs.promises.realpath(dir);
+}
+
+export async function spawnAndDetect(opts: SpawnOpts): Promise<SpawnRun> {
+  const cwd = opts.cwd ?? (opts.reuseCwd ? process.cwd() : await makeFreshCwd());
+  const launchId = randomUUID();
+
+  const beforeFiles =
+    opts.agent === 'claude' ? await snapshotSessions(cwd) : new Set<string>();
+
+  const childEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    AGENT_LAUNCH_ID: launchId,
+    ...opts.env,
+  };
+
+  const headlessPrompt = opts.prompt ?? 'say ok';
+  const mode = opts.mode ?? 'plan';
+  const argv =
+    opts.args && opts.args.length > 0
+      ? ['run', opts.agent, ...opts.args]
+      : ['run', opts.agent, headlessPrompt, '--mode', mode];
+
+  const proc = spawn('agents', argv, {
+    cwd,
+    env: childEnv,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    detached: false,
+  });
+  if (!proc.pid) {
+    throw new Error(`spawn agents ${opts.agent} failed: no pid`);
+  }
+
+  const trackerTimeoutMs = opts.trackerTimeoutMs ?? 8000;
+  const truthTimeoutMs = opts.truthTimeoutMs ?? 8000;
+
+  const [truth, detected] = await Promise.all([
+    opts.agent === 'claude'
+      ? awaitNewSession(cwd, beforeFiles, truthTimeoutMs)
+      : Promise.resolve(null),
+    trackByShellTree(proc.pid, trackerTimeoutMs),
+  ]);
+
+  const matched =
+    truth !== null && detected.sessionId !== null && detected.sessionId === truth.sessionId;
+
+  return { agent: opts.agent, cwd, launchId, proc, truth, detected, matched };
+}
+
+async function trackByShellTree(
+  shellPid: number,
+  timeoutMs: number,
+): Promise<DetectionResult> {
+  const { findStateInTree } = await import('../src/reader.js');
+  const start = Date.now();
+  const pollMs = 50;
+  while (Date.now() - start < timeoutMs) {
+    const state = await findStateInTree(shellPid);
+    if (state) {
+      return {
+        sessionId: state.session_id,
+        method: state.method,
+        latencyMs: Date.now() - start,
+        confidence: 'high',
+      };
+    }
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  return { sessionId: null, method: null, latencyMs: Date.now() - start, confidence: 'low' };
+}
+
+export async function killAndCleanup(run: SpawnRun): Promise<void> {
+  const { proc } = run;
+  try {
+    if (proc.pid && !proc.killed) {
+      proc.kill('SIGTERM');
+      await new Promise<void>((resolve) => {
+        const t = setTimeout(() => {
+          try { proc.kill('SIGKILL'); } catch {}
+          resolve();
+        }, 2000);
+        proc.once('exit', () => { clearTimeout(t); resolve(); });
+      });
+    }
+  } catch {}
+
+  try {
+    const { descendantPids } = await import('../src/reader.js');
+    if (run.proc.pid) {
+      const pids = [run.proc.pid, ...(await descendantPids(run.proc.pid))];
+      for (const p of pids) {
+        await clearSession(p).catch(() => undefined);
+      }
+    }
+  } catch {}
+
+  if (run.cwd.includes('session-tracker-test-')) {
+    try { await fs.promises.rm(run.cwd, { recursive: true, force: true }); } catch {}
+  }
+}
+
+export function suppressIo(proc: ChildProcess): void {
+  proc.stdout?.resume();
+  proc.stderr?.resume();
+  proc.stdout?.on('data', () => {});
+  proc.stderr?.on('data', () => {});
+}

--- a/packages/session-tracker/tests/scenarios/cold-spawn.test.ts
+++ b/packages/session-tracker/tests/scenarios/cold-spawn.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { spawnAndDetect, killAndCleanup, suppressIo, type SpawnRun } from '../harness.js';
+
+const ITERATIONS = Number(process.env.COLD_SPAWN_ITERATIONS ?? 20);
+
+interface Sample {
+  iter: number;
+  truth: string | null;
+  detected: string | null;
+  matched: boolean;
+  latencyMs: number;
+  method: string | null;
+  truthLatencyMs: number;
+}
+
+function percentile(arr: number[], p: number): number {
+  if (arr.length === 0) return 0;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
+
+describe(`cold-spawn × ${ITERATIONS}`, () => {
+  it(
+    'detection rate and latency for sequential Claude cold spawns',
+    async () => {
+      const samples: Sample[] = [];
+
+      for (let i = 0; i < ITERATIONS; i++) {
+        let run: SpawnRun | undefined;
+        try {
+          run = await spawnAndDetect({ agent: 'claude' });
+          suppressIo(run.proc);
+          samples.push({
+            iter: i,
+            truth: run.truth?.sessionId ?? null,
+            detected: run.detected.sessionId,
+            matched: run.matched,
+            latencyMs: run.detected.latencyMs,
+            method: run.detected.method,
+            truthLatencyMs: run.truth?.latencyMs ?? -1,
+          });
+        } catch (err) {
+          samples.push({
+            iter: i,
+            truth: null,
+            detected: null,
+            matched: false,
+            latencyMs: -1,
+            method: null,
+            truthLatencyMs: -1,
+          });
+          console.error(`iter ${i} threw:`, (err as Error).message);
+        } finally {
+          if (run) await killAndCleanup(run);
+        }
+        // brief breather so STATE_DIR isn't hammered
+        await new Promise((r) => setTimeout(r, 200));
+      }
+
+      const detected = samples.filter((s) => s.detected !== null).length;
+      const truthFound = samples.filter((s) => s.truth !== null).length;
+      const matched = samples.filter((s) => s.matched).length;
+      const lats = samples.filter((s) => s.matched).map((s) => s.latencyMs);
+      const truthLats = samples.filter((s) => s.truth).map((s) => s.truthLatencyMs);
+      const methods = samples.reduce<Record<string, number>>((acc, s) => {
+        const k = s.method ?? 'none';
+        acc[k] = (acc[k] ?? 0) + 1;
+        return acc;
+      }, {});
+
+      const matchRate = matched / ITERATIONS;
+      const detectRate = detected / ITERATIONS;
+      const truthRate = truthFound / ITERATIONS;
+
+      console.log('');
+      console.log('=== cold-spawn report (claude) ===');
+      console.log(`iterations:    ${ITERATIONS}`);
+      console.log(`truth found:   ${truthFound} (${(truthRate * 100).toFixed(1)}%)`);
+      console.log(`detected:      ${detected} (${(detectRate * 100).toFixed(1)}%)`);
+      console.log(`matched:       ${matched} (${(matchRate * 100).toFixed(1)}%)`);
+      console.log(
+        `tracker p50/p95/p99 ms: ${percentile(lats, 50)} / ${percentile(lats, 95)} / ${percentile(lats, 99)} (max ${Math.max(0, ...lats)})`,
+      );
+      console.log(
+        `truth   p50/p95/p99 ms: ${percentile(truthLats, 50)} / ${percentile(truthLats, 95)} / ${percentile(truthLats, 99)} (max ${Math.max(0, ...truthLats)})`,
+      );
+      console.log(`methods: ${JSON.stringify(methods)}`);
+      const failures = samples.filter((s) => !s.matched);
+      if (failures.length > 0) {
+        console.log(`failures (${failures.length}):`);
+        for (const f of failures.slice(0, 5)) {
+          console.log(`  iter ${f.iter}: truth=${f.truth} detected=${f.detected} method=${f.method}`);
+        }
+      }
+      console.log('');
+
+      // Phase-1 reliability gate.
+      expect(matchRate, `match rate ${(matchRate * 100).toFixed(1)}% below 95%`).toBeGreaterThanOrEqual(0.95);
+      expect(percentile(lats, 95), `p95 latency ${percentile(lats, 95)}ms above 10s`).toBeLessThanOrEqual(10_000);
+    },
+    // 30s per iteration headroom (real ~6s + 200ms breather + cleanup overhead).
+    ITERATIONS * 30_000,
+  );
+});

--- a/packages/session-tracker/tests/scenarios/kill-restart.test.ts
+++ b/packages/session-tracker/tests/scenarios/kill-restart.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import { spawnAndDetect, killAndCleanup, suppressIo, type SpawnRun } from '../harness.js';
+
+const ITERATIONS = Number(process.env.KILL_RESTART_ITERATIONS ?? 10);
+
+interface Sample {
+  iter: number;
+  first: { truth: string | null; detected: string | null; matched: boolean };
+  second: { truth: string | null; detected: string | null; matched: boolean };
+  newSessionWon: boolean; // second.detected !== first.detected (we picked up the NEW session)
+  latencyMs: number;
+}
+
+function percentile(arr: number[], p: number): number {
+  if (arr.length === 0) return 0;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
+
+describe(`kill-restart × ${ITERATIONS}`, () => {
+  it(
+    'second spawn in same cwd produces a different session id, and tracker picks the new one',
+    async () => {
+      const samples: Sample[] = [];
+
+      for (let i = 0; i < ITERATIONS; i++) {
+        let runA: SpawnRun | undefined;
+        let runB: SpawnRun | undefined;
+        try {
+          // First spawn.
+          runA = await spawnAndDetect({ agent: 'claude' });
+          suppressIo(runA.proc);
+          const cwd = runA.cwd; // reuse so the second spawn is "same workspace"
+
+          // Kill the first agent, wait briefly for state-dir settle.
+          // killAndCleanup removes the tmp cwd, so recreate it before reuse —
+          // Node's spawn() returns ENOENT when cwd doesn't exist.
+          await killAndCleanup(runA);
+          await fs.promises.mkdir(cwd, { recursive: true });
+          await new Promise((r) => setTimeout(r, 500));
+
+          // Second spawn in the SAME cwd. The state-file path will be a NEW
+          // pid; the workspace will have a NEW .jsonl. If the tracker were
+          // confused by the leftover first-run state, it would return the
+          // OLD session id. We assert it does not.
+          runB = await spawnAndDetect({ agent: 'claude', cwd });
+          suppressIo(runB.proc);
+
+          const newSessionWon =
+            runA.truth !== null &&
+            runB.truth !== null &&
+            runA.truth.sessionId !== runB.truth.sessionId &&
+            runB.detected.sessionId === runB.truth.sessionId;
+
+          samples.push({
+            iter: i,
+            first: {
+              truth: runA.truth?.sessionId ?? null,
+              detected: runA.detected.sessionId,
+              matched: runA.matched,
+            },
+            second: {
+              truth: runB.truth?.sessionId ?? null,
+              detected: runB.detected.sessionId,
+              matched: runB.matched,
+            },
+            newSessionWon,
+            latencyMs: runB.detected.latencyMs,
+          });
+        } catch (err) {
+          console.error(`iter ${i} threw:`, (err as Error).message);
+          samples.push({
+            iter: i,
+            first: { truth: null, detected: null, matched: false },
+            second: { truth: null, detected: null, matched: false },
+            newSessionWon: false,
+            latencyMs: -1,
+          });
+        } finally {
+          if (runB) await killAndCleanup(runB);
+        }
+        await new Promise((r) => setTimeout(r, 200));
+      }
+
+      const newWon = samples.filter((s) => s.newSessionWon).length;
+      const lats = samples.filter((s) => s.newSessionWon).map((s) => s.latencyMs);
+      const newWonRate = newWon / ITERATIONS;
+
+      console.log('');
+      console.log('=== kill-restart report (claude) ===');
+      console.log(`iterations:        ${ITERATIONS}`);
+      console.log(`new-session-won:   ${newWon} (${(newWonRate * 100).toFixed(1)}%)`);
+      console.log(
+        `tracker p50/p95/p99 ms: ${percentile(lats, 50)} / ${percentile(lats, 95)} / ${percentile(lats, 99)}`,
+      );
+      const failures = samples.filter((s) => !s.newSessionWon);
+      if (failures.length > 0) {
+        console.log(`failures (${failures.length}):`);
+        for (const f of failures.slice(0, 5)) {
+          console.log(
+            `  iter ${f.iter}: first.truth=${f.first.truth} second.truth=${f.second.truth} second.detected=${f.second.detected}`,
+          );
+        }
+      }
+      console.log('');
+
+      expect(newWonRate, `new-session-won rate ${(newWonRate * 100).toFixed(1)}% below 95%`).toBeGreaterThanOrEqual(
+        0.95,
+      );
+    },
+    ITERATIONS * 45_000,
+  );
+});

--- a/packages/session-tracker/tests/smoke.test.ts
+++ b/packages/session-tracker/tests/smoke.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { spawnAndDetect, killAndCleanup, suppressIo } from './harness.js';
+
+describe('smoke', () => {
+  it(
+    'claude headless spawn — tracker matches ground truth',
+    async () => {
+      const run = await spawnAndDetect({ agent: 'claude' });
+      suppressIo(run.proc);
+      try {
+        expect(run.truth, 'no Claude session file appeared (ground truth)').toBeTruthy();
+        expect(run.detected.sessionId, 'tracker returned no sessionId').toBeTruthy();
+        expect(
+          run.matched,
+          `mismatch — truth=${run.truth?.sessionId} detected=${run.detected.sessionId}`,
+        ).toBe(true);
+        expect(run.detected.latencyMs).toBeLessThan(8000);
+      } finally {
+        await killAndCleanup(run);
+      }
+    },
+    45_000,
+  );
+});

--- a/packages/session-tracker/tests/smoke.test.ts
+++ b/packages/session-tracker/tests/smoke.test.ts
@@ -14,11 +14,11 @@ describe('smoke', () => {
           run.matched,
           `mismatch — truth=${run.truth?.sessionId} detected=${run.detected.sessionId}`,
         ).toBe(true);
-        expect(run.detected.latencyMs).toBeLessThan(8000);
+        expect(run.detected.latencyMs).toBeLessThan(15_000);
       } finally {
         await killAndCleanup(run);
       }
     },
-    45_000,
+    60_000,
   );
 });

--- a/packages/session-tracker/tsconfig.json
+++ b/packages/session-tracker/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests", "src/**/*.test.ts"]
+}

--- a/packages/session-tracker/vitest.config.ts
+++ b/packages/session-tracker/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    testTimeout: 60_000,
+    hookTimeout: 30_000,
+    include: ['tests/**/*.test.ts'],
+    reporters: ['default'],
+    pool: 'forks',
+    poolOptions: { forks: { singleFork: true } },
+  },
+});


### PR DESCRIPTION
## Summary

New \`packages/session-tracker/\` — one canonical state-file format + one polyglot SessionStart hook for **every** coding-agent CLI we support. Replaces the per-agent ad-hoc detection in swarmify (and the legacy \`04-capture-session-start-metadata.sh\`).

## Why

Each agent emits its session id differently — claude/codex/cursor pass JSON on stdin; grok via env vars; opencode via no hook at all. Today swarmify and agents-cli both reinvent per-agent detection and get it wrong in subtle ways (stale ids in the status bar, fuzzy-match heuristics at restore time). This package unifies all of it behind:

\`\`\`ts
import { trackSpawn, getLiveSession } from '@agents/session-tracker';

const detected = await trackSpawn({ agent: 'claude', agentPid, cwd, launchId });
// { sessionId, method, latencyMs, confidence }

const live = await getLiveSession({ shellPid });
// SessionState | null
\`\`\`

State files live at \`~/.agents/.cache/terminals/sessions/<pid>.json\` — see \`src/types.ts\` for the schema.

## Pieces

- \`src/hook.sh\` — polyglot SessionStart hook, dispatches per-agent (stdin-JSON for claude/codex/cursor, env-var for grok)
- \`src/install-hook.ts\` — wires the hook into each agent's native config (idempotent). For claude, fans out across **every installed version's per-version settings.json** so the hook fires regardless of which agents-cli-pinned version runs.
- \`src/reader.ts\` — descendant-pid BFS (depth ≤ 5, nodes ≤ 100); terminal-id and launch-id lookups; prune-stale.
- \`src/adapters/claude.ts\` — workspace folder name + ground-truth snapshot helper, multi-root aware.
- \`tests/harness.ts\` — \`spawnAndDetect\` primitive used by all scenarios.

## Empirical reliability (Phase 1, claude only)

\`\`\`
=== cold-spawn × 10 ===
matched:       10/10 (100%)
tracker p50/p95/p99 ms: 1717 / 3762 / 3762
truth   p50/p95/p99 ms: 5137 / 5615 / 5615
methods: { hook-stdin: 10 }

=== kill-restart × 5 ===
new-session-won: 5/5 (100%)
tracker p50/p95/p99 ms: 2707 / 4125 / 4125
\`\`\`

Tracker is **faster than truth** because the hook fires at SessionStart, while Claude only flushes the \`.jsonl\` when the prompt completes.

## What lands here vs. follow-ups

**This PR:**
- Standalone package, claude-only Phase 1.
- Smoke + cold-spawn + kill-restart scenarios.
- install-hook fans out across all installed Claude versions.

**Follow-ups (not in this PR):**
- \`src/adapters/{codex,cursor,grok,opencode,gemini,antigravity}.ts\` + reliability tests per agent.
- fs-watch correlator for opencode (no hook mechanism upstream).
- agents-cli integration: propagate \`AGENT_TERMINAL_ID\` to child env via \`buildExecEnv\`.
- swarmify integration: replace \`extension/src/core/liveSession.ts\` with \`import { getLiveSession } from '@agents/session-tracker'\` once published.

## Test plan

- [ ] \`cd packages/session-tracker && bun install && bun run install-hook claude\`
- [ ] \`chmod +x src/hook.sh\` (one-time)
- [ ] \`bun run test:smoke\` — must pass
- [ ] \`bun run test tests/scenarios/cold-spawn.test.ts\` — must hit ≥95% match
- [ ] \`bun run test tests/scenarios/kill-restart.test.ts\` — must hit ≥95% new-session-won