### PR TITLE
release: restore entitlement-fixed keychain helper SHA for 1.20.5

### DIFF
--- a/scripts/Agents CLI.app.sha256
+++ b/scripts/Agents CLI.app.sha256
@@ -1,1 +1,1 @@
-2328fe42acff2b8b0da9ae6dd146e956ced66c83496ec60d34b26e0260fab4b6  bin/Agents CLI.app/Contents/MacOS/Agents CLI
+4d46fe0cc7afd6deb3ba0ad2ffcb12e2f4074a79e7618b4f0eafff55d458d507  bin/Agents CLI.app/Contents/MacOS/Agents CLI


### PR DESCRIPTION
## Summary

Restores \`scripts/Agents CLI.app.sha256\` to the rebuilt + notarized helper SHA (\`4d46fe0cc...\`) from PR #210, undoing commit e772a19a which reverted it back to the broken 1.20.4 SHA.

## Why

Shipping 1.20.5 with the old SHA would publish the 1.20.4 helper that fails \`SecItemAdd\` with \`OSStatus -34018\` (errSecMissingEntitlement) on macOS 26 fresh installs — i.e., the regression PR #210 was supposed to fix.

This commit aligns the SHA with the binary I rebuilt + notarized earlier today (submission \`4b71adb4-8773-42fa-b572-74a74ee683eb\`, Accepted, stapled, Gatekeeper-accepted).

## Test plan

- [x] \`bash scripts/verify-keychain-helper.sh\` → \`VERIFY OK\` locally
- [ ] After merge, run \`scripts/release.sh 1.20.5 --apply\` with \`NPM_TOKEN\` env from a clean worktree