### PR TITLE
perf(shim v17): bash skip-fast — exec without spawning node when nothing changed

### DIFF
--- a/src/lib/__tests__/shims.test.ts
+++ b/src/lib/__tests__/shims.test.ts
@@ -87,8 +87,8 @@ describe('addShimsToPath', () => {
 });
 
 describe('SHIM_SCHEMA_VERSION', () => {
-  it('is 16 (launch shims call sync --launch on hot path, never foreground)', () => {
-    expect(SHIM_SCHEMA_VERSION).toBe(16);
+  it('is 17 (launch sync wrapped in a bash skip-fast sentinel gate)', () => {
+    expect(SHIM_SCHEMA_VERSION).toBe(17);
   });
 });
 

--- a/src/lib/project-launch.test.ts
+++ b/src/lib/project-launch.test.ts
@@ -274,3 +274,40 @@ describe('runLaunchSync — project rules compile', () => {
     expect(agentsMd).toContain('Hello from project rules.');
   });
 });
+
+describe('runLaunchSync — shim skip-fast sentinel', () => {
+  // Local-scope $HOME override: touchLaunchSentinel reads process.env.HOME
+  // directly (matches the bash shim's $HOME expansion). Scoping the override
+  // to this describe block keeps the other tests' mocked state.js paths
+  // intact — globally overriding HOME breaks their settings.json fixtures.
+  let originalHome: string | undefined;
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    process.env.HOME = TMP_HOME;
+  });
+  afterEach(() => {
+    if (originalHome !== undefined) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+  });
+
+  it('writes the bash skip-fast sentinel at the shim-expected path', () => {
+    runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+
+    // Slug derivation must match shims.ts: `/` and ` ` → `_`.
+    const slug = PROJECT_DIR.replace(/\//g, '_').replace(/ /g, '_');
+    const sentinel = path.join(USER_DIR, '.cache', 'launch-sync', `claude@1.0.0@${slug}`);
+    expect(fs.existsSync(sentinel)).toBe(true);
+  });
+
+  it('sentinel mtime advances on a second run after the first', () => {
+    runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+    const slug = PROJECT_DIR.replace(/\//g, '_').replace(/ /g, '_');
+    const sentinel = path.join(USER_DIR, '.cache', 'launch-sync', `claude@1.0.0@${slug}`);
+    const t1 = fs.statSync(sentinel).mtimeMs;
+    const target = Date.now() + 25;
+    while (Date.now() < target) { /* spin */ }
+    runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+    const t2 = fs.statSync(sentinel).mtimeMs;
+    expect(t2).toBeGreaterThan(t1);
+  });
+});

--- a/src/lib/project-launch.ts
+++ b/src/lib/project-launch.ts
@@ -43,6 +43,7 @@
 
 import * as crypto from 'crypto';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import type { AgentId, MarketplaceSpec } from './types.js';
 import { supports } from './capabilities.js';
@@ -92,6 +93,11 @@ export interface LaunchSyncResult {
 /**
  * Run the launch-time project compile. Safe to call on every agent launch:
  * each step is idempotent and skips when its inputs are missing.
+ *
+ * After a successful run, touches the shim-side skip-fast sentinel at
+ * `~/.agents/.cache/launch-sync/<agent>@<version>@<projectslug>` so the next
+ * shim invocation can skip the node spawn entirely when no source dir is
+ * newer than the sentinel (shim schema v17+).
  */
 export function runLaunchSync(opts: LaunchSyncOptions): LaunchSyncResult {
   const result: LaunchSyncResult = {
@@ -117,7 +123,40 @@ export function runLaunchSync(opts: LaunchSyncOptions): LaunchSyncResult {
   // Step 3: scoped plugin marketplaces
   result.marketplaces = synthesizeScopedMarketplaces(opts.agent, opts.version, opts.cwd);
 
+  // Touch the shim's skip-fast sentinel. Best-effort — if this fails the
+  // shim just won't skip on the next launch, which is correct fallback.
+  touchLaunchSentinel(opts.agent, opts.version, opts.cwd);
+
   return result;
+}
+
+/**
+ * Path of the shim's skip-fast sentinel for this (agent, version, cwd) tuple.
+ * Must match the SHIM-SIDE format in src/lib/shims.ts (PROJECT_SLUG derivation):
+ *   slug = PWD with `/` → `_` and ` ` → `_`
+ *
+ * Cache leak note: this dir accumulates one zero-byte file per
+ * (agent, version, project) tuple ever launched. Disk impact is negligible
+ * (inodes only). A periodic GC belongs in `agents prune` — follow-up.
+ */
+function launchSentinelPath(agent: AgentId, version: string, cwd: string): string {
+  const slug = cwd.replace(/\//g, '_').replace(/ /g, '_');
+  // Prefer $HOME (respects test overrides + matches bash's $HOME expansion in
+  // the shim), fall back to os.homedir() so the lookup never resolves to '/'
+  // if HOME is somehow unset.
+  const home = process.env.HOME || os.homedir();
+  return path.join(home, '.agents', '.cache', 'launch-sync', `${agent}@${version}@${slug}`);
+}
+
+function touchLaunchSentinel(agent: AgentId, version: string, cwd: string): void {
+  try {
+    const sentinel = launchSentinelPath(agent, version, cwd);
+    fs.mkdirSync(path.dirname(sentinel), { recursive: true });
+    // Empty content — purely an mtime carrier for the shim's `[ -nt ]` compare.
+    fs.writeFileSync(sentinel, '');
+  } catch {
+    // best-effort
+  }
 }
 
 // ─── Step 2: workspace resource mirror ────────────────────────────────────────

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -221,8 +221,16 @@ async function promptConflictStrategy(
  *         scoped plugin marketplaces (agents-cli/agents-system/extras-<alias>/
  *         agents-project). Version-home reconciliation stays out of the hot
  *         path — management commands still own that.
+ *   v17 — bash-side skip-fast sentinel under ~/.agents/.cache/launch-sync/.
+ *         When the sentinel mtime is newer than every source dir, exec the
+ *         agent binary directly without spawning node. Cuts steady-state
+ *         hot-path latency from ~680ms (node startup + module init) to ~11ms
+ *         (a few stat calls). Node writes the sentinel after each successful
+ *         sync. Documented limitation: POSIX dir mtime only updates on
+ *         top-level entry add/remove — deep edits to plugin contents won't
+ *         trigger auto-resync, run `agents sync` for that.
  */
-export const SHIM_SCHEMA_VERSION = 16;
+export const SHIM_SCHEMA_VERSION = 17;
 
 /** Internal marker string used to embed the schema version in shim scripts. */
 const SHIM_VERSION_MARKER = 'agents-shim-version:';
@@ -508,8 +516,32 @@ fi
 ${managedEnv}
 
 # Project-scoped compile (rules, workspace resources, scoped plugin marketplaces).
-# Filesystem-only — sub-50ms steady state. Never blocks launch on failure.
-"$AGENTS_BIN" sync --agent "$AGENT" --agent-version "$VERSION" --launch --cwd "$PWD" --quiet 2>/dev/null || true
+# Skip-fast: if a sentinel from the last sync exists and is newer than all
+# source dirs (project .agents/, user plugins, system plugins), exec the
+# agent binary directly without spawning node. Cuts steady-state hot-path
+# latency from ~680ms (node startup + agents-cli module init) to ~11ms (a
+# handful of stat calls). Never blocks launch on failure of the sync itself.
+#
+# Known limitation: POSIX dir mtime updates only on entry add/remove at that
+# level. Deep edits to existing plugin contents (e.g. editing a SKILL.md
+# inside a plugin) won't bump the parent dir's mtime — the marketplace copy
+# stays stale until \`agents sync\` runs explicitly or a top-level entry
+# changes. Advanced users hot-iterating on plugins know to run sync.
+PROJECT_SLUG=\$(printf '%s' "\$PWD" | tr / _ | tr ' ' _)
+LAUNCH_SENTINEL="\$AGENTS_USER_DIR/.cache/launch-sync/\${AGENT}@\${VERSION}@\${PROJECT_SLUG}"
+LAUNCH_SKIP=0
+if [ -f "\$LAUNCH_SENTINEL" ]; then
+  LAUNCH_SKIP=1
+  for LAUNCH_SRC in "\$PWD/.agents" "\$AGENTS_USER_DIR/plugins" "\$AGENTS_USER_DIR/.system/plugins"; do
+    if [ -e "\$LAUNCH_SRC" ] && [ "\$LAUNCH_SRC" -nt "\$LAUNCH_SENTINEL" ]; then
+      LAUNCH_SKIP=0
+      break
+    fi
+  done
+fi
+if [ "\$LAUNCH_SKIP" = "0" ]; then
+  "\$AGENTS_BIN" sync --agent "\$AGENT" --agent-version "\$VERSION" --launch --cwd "\$PWD" --quiet 2>/dev/null || true
+fi
 
 exec "$BINARY"${launchArgs} "$@"
 `;


### PR DESCRIPTION
## Summary

Cuts the launch-sync hot path from **~680ms → ~11ms** (~60x speedup) by gating the node spawn behind a bash mtime check. Supersedes #209 (which got stale during #225's marketplace refactor).

v16's launch sync runs `agents sync --launch` on every shim invocation. The actual work is filesystem-only, but node startup + agents-cli module init costs ~680ms. For 60+ concurrent agent terminals on cold IDE start, that's ~40s of cumulative latency to compile resources that probably haven't changed.

This PR adds a shim-side skip gate. Before spawning node:

```bash
PROJECT_SLUG=$(printf '%s' "$PWD" | tr / _ | tr ' ' _)
LAUNCH_SENTINEL="$AGENTS_USER_DIR/.cache/launch-sync/${AGENT}@${VERSION}@${PROJECT_SLUG}"
LAUNCH_SKIP=0
if [ -f "$LAUNCH_SENTINEL" ]; then
  LAUNCH_SKIP=1
  for LAUNCH_SRC in "$PWD/.agents" "$AGENTS_USER_DIR/plugins" "$AGENTS_USER_DIR/.system/plugins"; do
    if [ -e "$LAUNCH_SRC" ] && [ "$LAUNCH_SRC" -nt "$LAUNCH_SENTINEL" ]; then
      LAUNCH_SKIP=0; break
    fi
  done
fi
if [ "$LAUNCH_SKIP" = "0" ]; then
  "$AGENTS_BIN" sync --agent "$AGENT" --agent-version "$VERSION" --launch --cwd "$PWD" --quiet 2>/dev/null || true
fi
```

After every successful `runLaunchSync`, the node side touches the sentinel via `fs.writeFileSync(path, '')` — empty content, the mtime is the cache key.

## Measured impact

| Path | Before (v16) | After (v17) | Speedup |
|---|---|---|---|
| Cold (sentinel missing or stale) | ~680ms | ~680ms | 1x (unchanged) |
| Warm (sentinel fresh) | ~680ms | **~11ms** | **~60x** |

## What's in this PR

- `src/lib/shims.ts` — bump `SHIM_SCHEMA_VERSION` 16 → 17. Inject the bash skip-fast block between `${managedEnv}` and `exec "$BINARY"`. Inline comment documents the POSIX dir-mtime limitation.
- `src/lib/project-launch.ts` — `runLaunchSync` now calls `touchLaunchSentinel` at the end. Slug derivation matches the shim's `PROJECT_SLUG` exactly (`/` and space → `_`).
- `src/lib/project-launch.test.ts` — 2 new tests covering sentinel write + mtime advancement. `$HOME` override is scoped to the sentinel describe block so it doesn't break the marketplace tests (those rely on the mocked `getPluginsDir`/`getVersionsDir` returning TMP_HOME-derived paths captured at module load).
- `src/lib/__tests__/shims.test.ts` — bump the `SHIM_SCHEMA_VERSION === 16` assertion to 17.

## Known limitation (documented in the shim)

POSIX dir mtime updates only when entries are **added or removed** at that level. Deep edits to existing plugin contents (e.g. editing a `SKILL.md` inside a plugin without changing the plugin's top-level file list) won't bump the source dir's mtime → marketplace copy stays stale until `agents sync` runs explicitly or a top-level entry changes.

Expected trade-off for the bash-fast path. Advanced users hot-iterating on plugins know to run sync. The 99% case (new install, new plugin, new project) is caught correctly.

## Test plan

- [x] `bun --bun tsc --noEmit` — clean.
- [x] `node ./node_modules/vitest/vitest.mjs run src/lib/project-launch.test.ts` — 18/18 pass.
- [x] `node ./node_modules/vitest/vitest.mjs run src/lib/__tests__/shims.test.ts tests/shims.test.ts` — 75/75 pass.
- [x] Standalone launch sync bench: 678ms cold → 11ms warm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)