### PR TITLE
fix(session-tracker): align state path with swarmify, tolerate legacy schema, replace flaky pgrep

### DIFF
--- a/packages/session-tracker/src/hook.sh
+++ b/packages/session-tracker/src/hook.sh
@@ -7,7 +7,7 @@
 #   - grok: GROK_SESSION_ID and GROK_WORKSPACE_ROOT env vars
 #   - gemini/antigravity: TBD — add branches below as upstream payloads land
 #
-# Writes ~/.agents/.cache/state/sessions/<PPID>.json with the canonical
+# Writes ~/.agents/.cache/terminals/sessions/<PPID>.json with the canonical
 # SessionState schema from src/types.ts. Atomic via mktemp + mv.
 #
 # Invocation:
@@ -82,7 +82,7 @@ fi
 
 [ -z "$CWD" ] && CWD="$PWD"
 
-STATE_DIR="$HOME/.agents/.cache/state/sessions"
+STATE_DIR="$HOME/.agents/.cache/terminals/sessions"
 mkdir -p "$STATE_DIR"
 
 TID="${AGENT_TERMINAL_ID:-}"

--- a/packages/session-tracker/src/reader.ts
+++ b/packages/session-tracker/src/reader.ts
@@ -10,30 +10,40 @@ const execAsync = promisify(exec);
 const PID_TREE_MAX_DEPTH = 5;
 const PID_TREE_MAX_NODES = 100;
 
+// macOS `pgrep -P` silently misses children for some pids; `ps -eo` is reliable.
+async function buildChildIndex(): Promise<Map<number, number[]>> {
+  const index = new Map<number, number[]>();
+  try {
+    const { stdout } = await execAsync('ps -eo pid,ppid', { timeout: 2000 });
+    for (const line of stdout.split('\n').slice(1)) {
+      const [pidStr, ppidStr] = line.trim().split(/\s+/);
+      const pid = Number(pidStr);
+      const ppid = Number(ppidStr);
+      if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue;
+      const kids = index.get(ppid);
+      if (kids) kids.push(pid);
+      else index.set(ppid, [pid]);
+    }
+  } catch {
+    /* empty index — caller treats as no descendants */
+  }
+  return index;
+}
+
 export async function descendantPids(rootPid: number): Promise<number[]> {
+  const index = await buildChildIndex();
   const visited = new Set<number>([rootPid]);
   const out: number[] = [];
   const queue: { pid: number; depth: number }[] = [{ pid: rootPid, depth: 0 }];
   while (queue.length > 0 && visited.size < PID_TREE_MAX_NODES) {
     const { pid, depth } = queue.shift()!;
     if (depth >= PID_TREE_MAX_DEPTH) continue;
-    let children: number[] = [];
-    try {
-      const { stdout } = await execAsync(`pgrep -P ${pid}`, { timeout: 1000 });
-      children = stdout
-        .trim()
-        .split(/\s+/)
-        .filter(Boolean)
-        .map(Number)
-        .filter((n) => Number.isFinite(n) && n > 0);
-    } catch {
-      children = [];
-    }
-    for (const c of children) {
+    for (const c of index.get(pid) ?? []) {
       if (visited.has(c)) continue;
       visited.add(c);
       out.push(c);
       queue.push({ pid: c, depth: depth + 1 });
+      if (visited.size >= PID_TREE_MAX_NODES) break;
     }
   }
   return out;

--- a/packages/session-tracker/src/state-file.ts
+++ b/packages/session-tracker/src/state-file.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import type { SessionState } from './types.js';
 
-export const STATE_DIR = path.join(os.homedir(), '.agents', '.cache', 'state', 'sessions');
+export const STATE_DIR = path.join(os.homedir(), '.agents', '.cache', 'terminals', 'sessions');
 
 export function stateFilePath(pid: number): string {
   return path.join(STATE_DIR, `${pid}.json`);
@@ -40,14 +40,14 @@ export function parseState(raw: string): SessionState | null {
   const o = obj as Record<string, unknown>;
   if (
     typeof o.session_id !== 'string' ||
-    typeof o.agent !== 'string' ||
     typeof o.cwd !== 'string' ||
     typeof o.pid !== 'number' ||
     typeof o.ts !== 'number'
   ) {
     return null;
   }
-  // method is informational — older legacy hooks didn't write it. Default rather than reject.
+  // Legacy 04-capture hook omits agent + method. Default rather than reject.
+  if (typeof o.agent !== 'string') o.agent = 'unknown';
   if (typeof o.method !== 'string') o.method = 'hook-stdin';
   return o as unknown as SessionState;
 }

--- a/packages/session-tracker/tests/state-file.test.ts
+++ b/packages/session-tracker/tests/state-file.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { parseState } from '../src/state-file.js';
+
+describe('parseState', () => {
+  it('parses the canonical schema written by hook.sh', () => {
+    const raw = JSON.stringify({
+      session_id: 'aaaa-bbbb',
+      agent: 'claude',
+      cwd: '/x',
+      pid: 123,
+      ts: 1780000000000,
+      method: 'hook-stdin',
+      terminal_id: 'cl-1',
+    });
+    const s = parseState(raw);
+    expect(s).not.toBeNull();
+    expect(s!.session_id).toBe('aaaa-bbbb');
+    expect(s!.agent).toBe('claude');
+    expect(s!.terminal_id).toBe('cl-1');
+  });
+
+  it('parses the legacy 04-capture hook schema (no agent, no method)', () => {
+    // This is the literal shape ~/.agents/.system/hooks/04-capture-session-start-metadata.sh
+    // writes — kept around for backward compat with already-installed agent versions.
+    const raw = '{"session_id": "df106759-aaaa", "cwd": "/x", "pid": 35013, "ts": 1780964717}';
+    const s = parseState(raw);
+    expect(s).not.toBeNull();
+    expect(s!.session_id).toBe('df106759-aaaa');
+    expect(s!.agent).toBe('unknown');
+    expect(s!.method).toBe('hook-stdin');
+  });
+
+  it('rejects missing session_id', () => {
+    const raw = '{"cwd": "/x", "pid": 1, "ts": 1}';
+    expect(parseState(raw)).toBeNull();
+  });
+
+  it('rejects malformed JSON', () => {
+    expect(parseState('{not json')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Three independent bugs in `packages/session-tracker/` (landed via #221) together prevented the live session id from flowing through to swarmify on macOS. Fixing all three plus aligning the canonical state-file path with what swarmify just shipped against (#45).

## What's fixed

### 1. STATE_DIR rename `state/sessions/` → `terminals/sessions/`

swarmify's `liveSession.ts` (released today via [muqsitnawaz/swarmify#45](https://github.com/muqsitnawaz/swarmify/pull/45)) reads from `~/.agents/.cache/terminals/sessions/`. Main's hook was writing to `~/.agents/.cache/state/sessions/`, so once the orphan `feat-session-tracker` worktree hook is gone the read path goes dry. Moving both `hook.sh` and `state-file.ts` together keeps writer and reader aligned.

### 2. `parseState` tolerates the legacy hook schema

The legacy `~/.agents/.system/hooks/04-capture-session-start-metadata.sh` writes `{session_id, cwd, pid, ts}` — no `agent`, no `method`. Main's parser required both, so `findStateByPid` silently returned `null` for state files like:

```
{"session_id":"df106759-...","cwd":"/x","pid":35013,"ts":1780964717}
```

Now defaults to `agent: "unknown"` + `method: "hook-stdin"` rather than rejecting. Four unit tests cover canonical, legacy, missing-session, and malformed inputs.

### 3. `descendantPids` replaces flaky `pgrep -P` with `ps -eo pid,ppid`

Verified locally: `pgrep -P 34812` and `pgrep -P 34966` returned empty even though `ps -eo` correctly listed both pids' direct children. When this hits, `findStateInTree` returns `null` even when a state file exists for a descendant. Switched to a one-shot `ps -eo pid,ppid` index + BFS. Preserves `PID_TREE_MAX_DEPTH=5` and `PID_TREE_MAX_NODES=100`.

## Verification

Ran the patched `findStateInTree` against four levels of the running claude pid tree (pid 35013, session `df106759-aa7b-4e4b-b8ec-67cec460af56`):

```
own-shell-via-agents-run       pid=34812 PASS
agents-run-wrapper-direct      pid=34966 PASS
claude-pid-direct              pid=35013 PASS
no-match                       pid=99999 PASS
```

`tests/state-file.test.ts` — 4/4 pass:

```
✓ parses the canonical schema written by hook.sh
✓ parses the legacy 04-capture hook schema (no agent, no method)
✓ rejects missing session_id
✓ rejects malformed JSON
```

## After merge

```bash
bun -C packages/session-tracker run install-hook claude
```

Re-installs the hook at the new `terminals/sessions/` path. Swarmify's just-merged live-session reader picks up state files from the new hook automatically.

## Closes

- Closes the loop on #45 (swarmify) which would otherwise regress once the orphan PR #227 worktree is removed.
- Supersedes the path-rename portion of the closed #227.