### PR TITLE
fix(browser): resolve Linux distro browser wrapper scripts to the real ELF (#229)

### DIFF
--- a/src/commands/browser.ts
+++ b/src/commands/browser.ts
@@ -13,7 +13,7 @@ import {
   getEndpointPresets,
   type BrowserProfile,
 } from '../lib/browser/profiles.js';
-import { findBrowserPath, getPortOccupant } from '../lib/browser/chrome.js';
+import { findBrowserPath, getPortOccupant, isLauncherScript } from '../lib/browser/chrome.js';
 import {
   listProfileCacheDirs,
   removeProfileCache,
@@ -352,10 +352,28 @@ function registerProfilesCommands(browser: Command): void {
 
       const checks: Array<{ label: string; ok: boolean; detail: string }> = [];
 
-      // 1. Binary exists for declared browser type
+      // 1. Binary exists for declared browser type, and is a real executable we
+      //    can drive — not a distro launcher script. findBrowserPath already
+      //    unwraps the known Chromium wrappers to their ELF; if it still hands
+      //    back a shebang script we couldn't resolve, `start` would fail with
+      //    `CDP connection closed` (the wrapper re-execs the browser as a child,
+      //    breaking the --remote-debugging-pipe transport — issue #229). Flag it
+      //    here instead of letting launch fail opaquely.
       try {
         const binPath = findBrowserPath(profile.browser, profile.binary);
-        checks.push({ label: 'binary', ok: true, detail: binPath });
+        if (isLauncherScript(binPath)) {
+          checks.push({
+            label: 'binary',
+            ok: false,
+            detail:
+              `${binPath} is a launcher script, not the browser executable — ` +
+              `agents browser drives the browser over --remote-debugging-pipe and ` +
+              `can't attach to a wrapper that re-execs it. Point the profile at the ` +
+              `real binary (\`--binary /path/to/browser\`) or reinstall the standard package.`,
+          });
+        } else {
+          checks.push({ label: 'binary', ok: true, detail: binPath });
+        }
       } catch (err) {
         checks.push({
           label: 'binary',
@@ -390,7 +408,16 @@ function registerProfilesCommands(browser: Command): void {
       } else {
         const occupant = getPortOccupant(port);
         if (!occupant) {
-          checks.push({ label: 'port', ok: true, detail: `${port} is free` });
+          // A free port doesn't mean "ready to launch here": for a local
+          // profile we self-launch over an internal --remote-debugging-pipe and
+          // never bind this port. The port is consulted only to attach to a
+          // browser someone already started on it. Say so, so a green doctor
+          // can't be read as "the port is what launch depends on" (#229).
+          checks.push({
+            label: 'port',
+            ok: true,
+            detail: `${port} free — will self-launch over an internal pipe (port used only to attach to an already-running browser)`,
+          });
         } else {
           try {
             const { browser } = await discoverBrowserWsUrl(port, 'localhost', profile.name);

--- a/src/lib/browser/chrome.test.ts
+++ b/src/lib/browser/chrome.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 
 const presentPaths = new Set<string>();
 
@@ -11,7 +14,7 @@ vi.mock('fs', async () => {
   };
 });
 
-import { findFirstInstalledBrowser } from './chrome.js';
+import { findFirstInstalledBrowser, resolveBrowserBinary } from './chrome.js';
 
 describe('findFirstInstalledBrowser', () => {
   beforeEach(() => {
@@ -69,5 +72,82 @@ describe('findFirstInstalledBrowser', () => {
   it('returns null on unsupported platforms', () => {
     expect(findFirstInstalledBrowser('aix')).toBeNull();
     expect(findFirstInstalledBrowser('freebsd')).toBeNull();
+  });
+});
+
+// resolveBrowserBinary only does work on Linux, where distro launchers are
+// shell wrappers around the real ELF. The `head -c2` read, realpath, and
+// readFileSync below all hit the actual filesystem (existsSync is the only
+// mocked fs call), so these are gated to Linux hosts.
+describe.skipIf(os.platform() !== 'linux')('resolveBrowserBinary', () => {
+  // The upstream Chromium wrapper, verbatim down to the launch line — this is
+  // exactly what Debian/Ubuntu ship at /usr/bin/{brave-browser,google-chrome}.
+  const WRAPPER = [
+    '#!/bin/bash',
+    'export CHROME_WRAPPER="`readlink -f "$0"`"',
+    'HERE="`dirname "$CHROME_WRAPPER"`"',
+    'exec < /dev/null',
+    'exec > >(exec cat)',
+    'exec 2> >(exec cat >&2)',
+    '"$HERE/brave" "$@" || true',
+    '',
+  ].join('\n');
+  // ELF magic so the byte-sniff classifies it as a real binary, not a script.
+  const ELF = Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01, 0x01, 0x00]);
+
+  let dir: string;
+
+  beforeEach(() => {
+    presentPaths.clear();
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-resolve-'));
+  });
+
+  function realFsPaths(...names: string[]) {
+    // existsSync is mocked to consult presentPaths, so register the real ELF
+    // for the resolver's final fs.existsSync(realBinary) guard.
+    for (const n of names) presentPaths.add(path.join(dir, n));
+  }
+
+  it('follows a Chromium wrapper script to the real ELF next to it', () => {
+    fs.writeFileSync(path.join(dir, 'brave-browser'), WRAPPER);
+    fs.writeFileSync(path.join(dir, 'brave'), ELF);
+    realFsPaths('brave');
+
+    expect(resolveBrowserBinary(path.join(dir, 'brave-browser'))).toBe(
+      path.join(dir, 'brave')
+    );
+  });
+
+  it('also handles the `exec -a "$0" "$HERE/chrome"` wrapper variant', () => {
+    const variant = WRAPPER.replace('"$HERE/brave" "$@" || true', 'exec -a "$0" "$HERE/chrome" "$@"');
+    fs.writeFileSync(path.join(dir, 'google-chrome'), variant);
+    fs.writeFileSync(path.join(dir, 'chrome'), ELF);
+    realFsPaths('chrome');
+
+    expect(resolveBrowserBinary(path.join(dir, 'google-chrome'))).toBe(
+      path.join(dir, 'chrome')
+    );
+  });
+
+  it('leaves a real ELF binary untouched', () => {
+    const elfPath = path.join(dir, 'brave');
+    fs.writeFileSync(elfPath, ELF);
+
+    expect(resolveBrowserBinary(elfPath)).toBe(elfPath);
+  });
+
+  it('returns the original path when the wrapped binary is missing', () => {
+    const wrapperPath = path.join(dir, 'brave-browser');
+    fs.writeFileSync(wrapperPath, WRAPPER);
+    // Note: no `brave` ELF written and none registered in presentPaths.
+
+    expect(resolveBrowserBinary(wrapperPath)).toBe(wrapperPath);
+  });
+
+  it('returns the original path for a script with no recognizable launch line', () => {
+    const scriptPath = path.join(dir, 'weird-launcher');
+    fs.writeFileSync(scriptPath, '#!/bin/sh\necho hello\n');
+
+    expect(resolveBrowserBinary(scriptPath)).toBe(scriptPath);
   });
 });

--- a/src/lib/browser/chrome.test.ts
+++ b/src/lib/browser/chrome.test.ts
@@ -14,7 +14,7 @@ vi.mock('fs', async () => {
   };
 });
 
-import { findFirstInstalledBrowser, resolveBrowserBinary } from './chrome.js';
+import { findFirstInstalledBrowser, resolveBrowserBinary, isLauncherScript } from './chrome.js';
 
 describe('findFirstInstalledBrowser', () => {
   beforeEach(() => {
@@ -149,5 +149,30 @@ describe.skipIf(os.platform() !== 'linux')('resolveBrowserBinary', () => {
     fs.writeFileSync(scriptPath, '#!/bin/sh\necho hello\n');
 
     expect(resolveBrowserBinary(scriptPath)).toBe(scriptPath);
+  });
+});
+
+describe.skipIf(os.platform() === 'win32')('isLauncherScript', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    presentPaths.clear();
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-launcher-'));
+  });
+
+  it('reports true for a shebang wrapper script', () => {
+    const p = path.join(dir, 'brave-browser');
+    fs.writeFileSync(p, '#!/bin/bash\n"$HERE/brave" "$@"\n');
+    expect(isLauncherScript(p)).toBe(true);
+  });
+
+  it('reports false for a real ELF binary', () => {
+    const p = path.join(dir, 'brave');
+    fs.writeFileSync(p, Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01, 0x01, 0x00]));
+    expect(isLauncherScript(p)).toBe(false);
+  });
+
+  it('reports false for a missing path', () => {
+    expect(isLauncherScript(path.join(dir, 'nope'))).toBe(false);
   });
 });

--- a/src/lib/browser/chrome.ts
+++ b/src/lib/browser/chrome.ts
@@ -49,12 +49,71 @@ const BROWSER_PATHS: Record<string, Record<BrowserType, string[]>> = {
 };
 
 
+/**
+ * On Debian/Ubuntu the canonical launchers under `/usr/bin`
+ * (`brave-browser`, `google-chrome`, `chromium`) are not the browser ELF —
+ * they're `#!/bin/bash` wrapper scripts (the upstream Chromium wrapper) that,
+ * as their final step, run the real binary as a NON-exec child:
+ *
+ *     exec < /dev/null
+ *     exec > >(exec cat)
+ *     exec 2> >(exec cat >&2)
+ *     "$HERE/brave" "$@" || true
+ *
+ * That breaks `launchBrowser`'s `--remote-debugging-pipe` transport two ways:
+ * the std-fd sanitization (and the extra `cat` process-substitution children)
+ * disturbs the inherited CDP pipe on fd 3/4, and the pid we record is the
+ * wrapper's, not the browser's. The symptom is `read ECONNRESET` /
+ * `CDP connection closed` right after spawn (issue #229).
+ *
+ * Follow the wrapper to the ELF it execs. The wrapper sets
+ * `HERE="dirname(readlink -f "$0")"` and invokes `"$HERE/<name>"`, so we
+ * resolve the script path, scan for that invocation line, and join the two.
+ * Returns the original path untouched when it's already an ELF, when it's not
+ * a resolvable wrapper, or on any non-Linux platform.
+ */
+export function resolveBrowserBinary(binaryPath: string): string {
+  if (os.platform() !== 'linux') return binaryPath;
+  let fd: number;
+  try {
+    fd = fs.openSync(binaryPath, 'r');
+  } catch {
+    return binaryPath;
+  }
+  let head: Buffer;
+  try {
+    head = Buffer.alloc(2);
+    fs.readSync(fd, head, 0, 2, 0);
+  } finally {
+    fs.closeSync(fd);
+  }
+  // ELF binaries start with 0x7f 'E'; shebang scripts with '#!'. Only scripts
+  // need unwrapping.
+  if (!(head[0] === 0x23 && head[1] === 0x21)) return binaryPath;
+
+  let script: string;
+  let realScriptPath: string;
+  try {
+    realScriptPath = fs.realpathSync(binaryPath);
+    script = fs.readFileSync(realScriptPath, 'utf8');
+  } catch {
+    return binaryPath;
+  }
+  // Match the Chromium wrapper's launch line: `"$HERE/<name>" "$@"`, optionally
+  // prefixed with `exec -a "$0"`. The captured name is the real ELF, sitting in
+  // the same directory as the resolved wrapper.
+  const match = script.match(/"\$HERE\/([A-Za-z0-9._-]+)"\s+"\$@"/);
+  if (!match) return binaryPath;
+  const realBinary = path.join(path.dirname(realScriptPath), match[1]);
+  return fs.existsSync(realBinary) ? realBinary : binaryPath;
+}
+
 export function findBrowserPath(browserType: BrowserType, customBinary?: string): string {
   if (customBinary) {
     if (!fs.existsSync(customBinary)) {
       throw new Error(`Custom binary not found: ${customBinary}`);
     }
-    return customBinary;
+    return resolveBrowserBinary(customBinary);
   }
 
   if (browserType === 'custom') {
@@ -70,7 +129,7 @@ export function findBrowserPath(browserType: BrowserType, customBinary?: string)
   const candidates = platformPaths[browserType] || [];
   for (const p of candidates) {
     if (fs.existsSync(p)) {
-      return p;
+      return resolveBrowserBinary(p);
     }
   }
 
@@ -111,7 +170,7 @@ export function findFirstInstalledBrowser(
     const candidates = platformPaths[browserType] || [];
     for (const p of candidates) {
       if (fs.existsSync(p)) {
-        return { browserType, binary: p };
+        return { browserType, binary: resolveBrowserBinary(p) };
       }
     }
   }

--- a/src/lib/browser/chrome.ts
+++ b/src/lib/browser/chrome.ts
@@ -72,24 +72,40 @@ const BROWSER_PATHS: Record<string, Record<BrowserType, string[]>> = {
  * Returns the original path untouched when it's already an ELF, when it's not
  * a resolvable wrapper, or on any non-Linux platform.
  */
-export function resolveBrowserBinary(binaryPath: string): string {
-  if (os.platform() !== 'linux') return binaryPath;
+function readsAsShebangScript(binaryPath: string): boolean {
   let fd: number;
   try {
     fd = fs.openSync(binaryPath, 'r');
   } catch {
-    return binaryPath;
+    return false;
   }
-  let head: Buffer;
   try {
-    head = Buffer.alloc(2);
+    const head = Buffer.alloc(2);
     fs.readSync(fd, head, 0, 2, 0);
+    // ELF binaries start with 0x7f 'E'; shebang scripts with '#!'.
+    return head[0] === 0x23 && head[1] === 0x21;
   } finally {
     fs.closeSync(fd);
   }
-  // ELF binaries start with 0x7f 'E'; shebang scripts with '#!'. Only scripts
-  // need unwrapping.
-  if (!(head[0] === 0x23 && head[1] === 0x21)) return binaryPath;
+}
+
+/**
+ * True when `binaryPath` is a shebang script rather than a native browser
+ * executable. The Linux distro launchers (`/usr/bin/brave-browser`, …) are such
+ * scripts; `launchBrowser` can't drive one over `--remote-debugging-pipe` (see
+ * resolveBrowserBinary). `profiles doctor` uses this to flag a profile whose
+ * binary resolves to a wrapper we couldn't unwrap. Shebang scripts are a
+ * Linux/Unix concept — returns false on Windows/macOS app bundles.
+ */
+export function isLauncherScript(binaryPath: string): boolean {
+  if (os.platform() === 'win32') return false;
+  return readsAsShebangScript(binaryPath);
+}
+
+export function resolveBrowserBinary(binaryPath: string): string {
+  if (os.platform() !== 'linux') return binaryPath;
+  // Only shebang scripts need unwrapping; a real ELF passes straight through.
+  if (!readsAsShebangScript(binaryPath)) return binaryPath;
 
   let script: string;
   let realScriptPath: string;


### PR DESCRIPTION
## Problem

`agents browser start --profile brave` (and chrome/chromium) fails on Debian/Ubuntu with `read ECONNRESET` → `CDP connection closed` immediately after launch (#229).

Root cause: the canonical launchers under `/usr/bin` (`brave-browser`, `google-chrome`, `chromium`) are **not** the browser ELF — they're the upstream Chromium `#!/bin/bash` wrapper, whose final step runs the real binary as a **non-exec child** after sanitizing std FDs:

```bash
exec < /dev/null
exec > >(exec cat)
exec 2> >(exec cat >&2)
"$HERE/brave" "$@" || true
```

`launchBrowser()` drives CDP over `--remote-debugging-pipe` (fd 3/4). Spawning the wrapper breaks that transport — the fd sanitization plus the extra `cat` process-substitution children disturb the inherited pipe, and the pid we record is the wrapper's, not the browser's.

## Fix

`resolveBrowserBinary()` (`src/lib/browser/chrome.ts`):
- byte-sniffs the candidate; ELF binaries pass straight through
- for a shebang script, follows it to the ELF it execs (`"$HERE/<name>"`, joined against the resolved wrapper dir)
- returns the original path untouched for unrecognized scripts and on every non-Linux platform

Wired into `findBrowserPath()` (both the candidate-list and custom-binary paths) and `findFirstInstalledBrowser()`.

## Verification

End-to-end on Ubuntu 24.04 (aarch64), against the **built** code over the real pipe transport:

```
findBrowserPath(brave) => /opt/brave.com/brave/brave   # was /usr/bin/brave-browser
launching brave over pipe transport...
launched: pid=41903 port=0 wsUrl=pipe://41896/1
Browser.getVersion => {"product":"Chrome/149.0.7827.54", ...}
PASS: wrapper resolved + CDP pipe handshake succeeded end-to-end
```

- `src/lib/browser/chrome.test.ts`: 5 new `resolveBrowserBinary` cases (wrapper→ELF, the `exec -a "$0"` variant, ELF passthrough, missing-target passthrough, unrecognized-script passthrough). Gated to Linux hosts since the resolver no-ops elsewhere.
- Full `src/lib/browser` suite: **173/173 pass**.

Fixes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)