### PR TITLE
Add selector-based run defaults

### DIFF
--- a/src/commands/defaults.test.ts
+++ b/src/commands/defaults.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const repoRoot = process.cwd();
+const entrypoint = path.join(repoRoot, 'src/index.ts');
+
+function runAgents(home: string, args: string[]): string {
+  return execFileSync('bun', [entrypoint, ...args], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: home,
+      AGENTS_NO_AUTOPULL: '1',
+      AGENTS_SKIP_MIGRATION: '1',
+      AGENTS_CLI_DISABLE_AUTO_UPDATE: '1',
+    },
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+describe('defaults command', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-defaults-test-'));
+    fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
+    fs.mkdirSync(path.join(home, '.agents', '.system', '.git'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('sets, lists, and unsets run defaults', () => {
+    const setOut = runAgents(home, ['defaults', 'run', 'set', 'claude@2.1.45', '--mode', 'full', '--model', 'opus']);
+    expect(setOut).toContain('claude:2.1.45');
+    expect(setOut).toContain('mode skip');
+    expect(setOut).toContain('model opus');
+
+    const yaml = fs.readFileSync(path.join(home, '.agents', 'agents.yaml'), 'utf-8');
+    expect(yaml).toContain('claude:2.1.45');
+    expect(yaml).toContain('mode: skip');
+    expect(yaml).toContain('model: opus');
+
+    const listOut = runAgents(home, ['defaults', 'run', 'list']);
+    expect(listOut).toContain('claude:2.1.45');
+    expect(listOut).toContain('mode skip');
+    expect(listOut).toContain('model opus');
+
+    const unsetOut = runAgents(home, ['defaults', 'run', 'unset', 'claude:2.1.45']);
+    expect(unsetOut).toContain('Removed run default claude:2.1.45');
+
+    const emptyListOut = runAgents(home, ['defaults', 'run', 'list']);
+    expect(emptyListOut).toContain('No run defaults configured');
+  });
+});

--- a/src/commands/defaults.ts
+++ b/src/commands/defaults.ts
@@ -1,0 +1,104 @@
+/**
+ * Defaults command tree.
+ *
+ * `agents defaults run ...` manages selector-based defaults for `agents run`.
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { setHelpSections } from '../lib/help.js';
+import {
+  listRunDefaults,
+  setRunDefault,
+  unsetRunDefault,
+  type RunDefaultEntry,
+} from '../lib/run-defaults.js';
+
+interface RunDefaultsSetOptions {
+  mode?: string;
+  model?: string;
+}
+
+function formatRunDefault(entry: RunDefaultEntry): string {
+  const parts: string[] = [];
+  if (entry.defaults.mode) parts.push(`mode ${chalk.white(entry.defaults.mode)}`);
+  if (entry.defaults.model) parts.push(`model ${chalk.white(entry.defaults.model)}`);
+  return `${chalk.cyan(entry.selector.padEnd(22))} ${parts.join('  ')}`;
+}
+
+export function registerDefaultsCommands(program: Command): void {
+  const defaults = program
+    .command('defaults')
+    .description('Manage default options for agents-cli commands');
+
+  const run = defaults
+    .command('run')
+    .description('Manage selector-based defaults for `agents run`');
+
+  setHelpSections(run, {
+    examples: `
+      agents defaults run list
+      agents defaults run set 'claude:*' --mode auto --model opus
+      agents defaults run set claude@2.1.45 --mode plan --model sonnet
+      agents defaults run unset 'claude:*'
+    `,
+    notes: `
+      Selectors use <agent>:<version>. Use * for all versions of an agent.
+      Exact selectors override wildcard selectors field by field.
+      Explicit flags on agents run always win over configured defaults.
+    `,
+  });
+
+  run
+    .command('list')
+    .description('List configured run defaults')
+    .action(() => {
+      const entries = listRunDefaults();
+      if (entries.length === 0) {
+        console.log(chalk.gray('No run defaults configured.'));
+        console.log(chalk.gray("Set one with: agents defaults run set 'claude:*' --mode auto --model opus"));
+        return;
+      }
+
+      console.log(chalk.bold('Run Defaults\n'));
+      for (const entry of entries) {
+        console.log(`  ${formatRunDefault(entry)}`);
+      }
+    });
+
+  run
+    .command('set <selector>')
+    .description('Set defaults for an agent/version selector')
+    .option('--mode <mode>', "Default mode: plan, edit, auto, skip. 'full' accepted as alias for skip.")
+    .option('--model <model>', 'Default model or model alias, forwarded via --model')
+    .action((selector: string, options: RunDefaultsSetOptions) => {
+      try {
+        const entry = setRunDefault(selector, {
+          ...(options.mode !== undefined ? { mode: options.mode } : {}),
+          ...(options.model !== undefined ? { model: options.model } : {}),
+        });
+        console.log(chalk.green('Set run default:'));
+        console.log(`  ${formatRunDefault(entry)}`);
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+
+  run
+    .command('unset <selector>')
+    .description('Remove defaults for an agent/version selector')
+    .action((selector: string) => {
+      try {
+        const removed = unsetRunDefault(selector);
+        if (removed) {
+          console.log(chalk.green(`Removed run default ${selector}`));
+        } else {
+          console.log(chalk.gray(`No run default matched ${selector}`));
+        }
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+}

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -10,6 +10,7 @@ import type { Command } from 'commander';
 import chalk from 'chalk';
 import type { ExecOptions, ExecMode, ExecEffort, FallbackEntry } from '../lib/exec.js';
 import type { AgentId } from '../lib/types.js';
+import type { ResolvedRunDefaults } from '../lib/run-defaults.js';
 import { setHelpSections } from '../lib/help.js';
 import type { RotateResult } from '../lib/rotate.js';
 import { AGENTS } from '../lib/agents.js';
@@ -153,9 +154,10 @@ export function registerRunCommand(program: Command): void {
         { profileExists, resolveProfileForRun },
         { readAndResolveBundleEnv, describeBundle },
         { getConfiguredRunStrategy, normalizeRunStrategy, resolveRunVersion, RUN_STRATEGIES },
-        { getGlobalDefault, getVersionHomePath, resolveVersionAlias },
+        { getGlobalDefault, getVersionHomePath, resolveVersion, resolveVersionAlias },
         { buildDiscoveredPlugin, loadPluginManifest, syncPluginToVersion },
         { parseWorkflowFrontmatter, resolveWorkflowRef },
+        { resolveRunDefaults },
       ] = await Promise.all([
         import('../lib/exec.js'),
         import('../lib/agents.js'),
@@ -165,6 +167,7 @@ export function registerRunCommand(program: Command): void {
         import('../lib/versions.js'),
         import('../lib/plugins.js'),
         import('../lib/workflows.js'),
+        import('../lib/run-defaults.js'),
       ]);
       const isValidAgent = (agent: string): agent is AgentId => ALL_AGENT_IDS.includes(agent as AgentId);
 
@@ -174,6 +177,7 @@ export function registerRunCommand(program: Command): void {
       let version: string | undefined = rawVersion || undefined;
       let profileEnv: Record<string, string> | undefined;
       let fromProfile = false;
+      let workflowModel: string | undefined;
       const cwd = options.cwd ?? process.cwd();
 
       if (isValidAgent(rawAgent)) {
@@ -202,6 +206,10 @@ export function registerRunCommand(program: Command): void {
         //   subagents/*.md     ← flat .md files copied to ~/.claude/agents/ for Agent tool discovery
         const workflowDir = resolveWorkflowRef(rawAgent, cwd)!;
         agent = 'claude';
+        const workflowFrontmatter = parseWorkflowFrontmatter(workflowDir);
+        if (typeof workflowFrontmatter?.model === 'string' && workflowFrontmatter.model.trim() !== '') {
+          workflowModel = workflowFrontmatter.model.trim();
+        }
 
         const resolvedVersion = resolveVersionAlias('claude', version);
         const versionHome = getVersionHomePath('claude', resolvedVersion ?? getGlobalDefault('claude') ?? '');
@@ -255,8 +263,7 @@ export function registerRunCommand(program: Command): void {
         // Auto-inject secrets bundles declared in the workflow's frontmatter `secrets:` field.
         // Union with any --secrets flags the user passed; dedupe. Skip when --no-auto-secrets is set.
         if (!options.noAutoSecrets) {
-          const fm = parseWorkflowFrontmatter(workflowDir);
-          const declared = fm?.secrets ?? [];
+          const declared = workflowFrontmatter?.secrets ?? [];
           if (declared.length > 0) {
             const existing = new Set(options.secrets);
             const added: string[] = [];
@@ -336,9 +343,19 @@ export function registerRunCommand(program: Command): void {
         }
       }
 
+      const defaultVersion = version ?? resolveVersion(agent, cwd);
+      const runDefaults: ResolvedRunDefaults = fromProfile
+        ? { sources: {} }
+        : resolveRunDefaults(agent, defaultVersion, cwd);
+
       // Accept the four canonical modes plus 'full' as a permanent silent
       // alias for 'skip' (rewritten downstream by normalizeMode in exec.ts).
       let mode = options.mode as ExecMode;
+      const modeSource = runCmd.getOptionValueSource('mode');
+      const modeFromRunDefault = modeSource === 'default' && !!runDefaults.mode;
+      if (modeFromRunDefault) {
+        mode = runDefaults.mode as ExecMode;
+      }
       if (!['plan', 'edit', 'auto', 'skip', 'full'].includes(mode)) {
         console.error(chalk.red(`Invalid mode: ${mode}. Use plan, edit, auto, or skip ('full' accepted as alias for skip).`));
         process.exit(1);
@@ -351,12 +368,11 @@ export function registerRunCommand(program: Command): void {
       // user did not ask for read-only, they asked for "just run it." An
       // explicit --mode plan still throws (see resolveMode), because silently
       // elevating an explicit read-only request to edit is unsafe.
-      const modeSource = runCmd.getOptionValueSource('mode');
       const modeIsDefault = modeSource === 'default';
       try {
         resolveMode(agent, normalizeMode(mode));
       } catch (err) {
-        if (modeIsDefault) {
+        if (modeIsDefault && !modeFromRunDefault) {
           mode = defaultModeFor(agent) as ExecMode;
           if (!options.quiet) {
             process.stderr.write(chalk.gray(`[agents] ${agent} has no '${options.mode}' mode; using '${mode}'\n`));
@@ -410,6 +426,12 @@ export function registerRunCommand(program: Command): void {
         ? { ...(profileEnv ?? {}), ...secretsEnv, ...(userEnv ?? {}) }
         : undefined;
 
+      const modelSource = runCmd.getOptionValueSource('model');
+      const model = options.model
+        ?? (!fromProfile && modelSource === undefined
+          ? (workflowModel ?? (options.fallback ? undefined : runDefaults.model))
+          : undefined);
+
       const execOptions: ExecOptions = {
         agent,
         version,
@@ -418,7 +440,7 @@ export function registerRunCommand(program: Command): void {
         mode,
         effort,
         cwd: options.cwd,
-        model: options.model,
+        model,
         addDirs: options.addDir,
         json: options.json,
         headless: options.headless ?? true,

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -66,6 +66,7 @@ import { isGitRepo, getGitSyncStatus } from '../lib/git.js';
 import { getCentralRulesFileName } from '../lib/rules/rules.js';
 import { composeRulesFromState, type ComposedSubrule } from '../lib/rules/compose.js';
 import { getConfiguredRunStrategy } from '../lib/rotate.js';
+import { resolveRunDefaults } from '../lib/run-defaults.js';
 import { listProfiles, profileSummary, type ProfileSummary } from '../lib/profiles.js';
 import { loadManifest, isStale } from '../lib/staleness/index.js';
 import { confirm } from '@inquirer/prompts';
@@ -413,6 +414,10 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
         // Otherwise it reflects install time (misleading "just now" for fresh installs).
         const activeStr = vInfo && hasEmail ? formatLastActive(vInfo.lastActive) : '';
         const hasActive = activeStr.length > 0;
+        const runDefaults = resolveRunDefaults(agentId, version);
+        const runDefaultBits: string[] = [];
+        if (runDefaults.mode) runDefaultBits.push(`mode:${runDefaults.mode}`);
+        if (runDefaults.model) runDefaultBits.push(`model:${runDefaults.model}`);
 
         if (!hasEmail && !hasUsage) {
           // Installed but never signed in
@@ -432,6 +437,9 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
             parts.push(statusStr + statusPad);
           }
           if (hasActive) parts.push(activeStr);
+        }
+        if (runDefaultBits.length > 0) {
+          parts.push(chalk.gray(`run ${runDefaultBits.join(' ')}`));
         }
 
         console.log(parts.join('  '));

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ import { registerDaemonCommands } from './commands/daemon.js';
 import { registerRoutinesCommands } from './commands/routines.js';
 import { registerRunCommand } from './commands/exec.js';
 import { registerModelsCommand } from './commands/models.js';
+import { registerDefaultsCommands } from './commands/defaults.js';
 import { registerPruneCommand } from './commands/prune.js';
 import { registerTrashCommands } from './commands/trash.js';
 import { registerDoctorCommand } from './commands/doctor.js';
@@ -168,6 +169,7 @@ Packages:
 
 Run and dispatch:
   run <agent|profile> [prompt]    Run an agent. Omit prompt for interactive mode.
+  defaults                        Configure run defaults by agent/version selector
   teams                           Coordinate multiple agents on shared work
   routines                        Run agents on a cron schedule (scheduler auto-starts)
   sessions                        Browse, search, and replay past runs (live-search in TTY; grouped by workspace)
@@ -597,6 +599,7 @@ registerPackagesCommands(program);
 registerDaemonCommands(program);
 registerRoutinesCommands(program);
 registerRunCommand(program);
+registerDefaultsCommands(program);
 registerModelsCommand(program);
 registerPruneCommand(program);
 registerTrashCommands(program);

--- a/src/lib/rotate.ts
+++ b/src/lib/rotate.ts
@@ -6,13 +6,12 @@
  */
 
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
-import * as yaml from 'yaml';
 import type { AgentId, RunStrategy } from './types.js';
 import { getAccountInfo, type AccountInfo } from './agents.js';
-import { readMeta, writeMeta, getHelpersDir, getUserAgentsDir } from './state.js';
+import { readMeta, writeMeta, getHelpersDir } from './state.js';
 import { listInstalledVersions, getVersionHomePath, resolveVersion } from './versions.js';
+import { getProjectRunConfigs } from './run-config.js';
 import {
   getUsageInfoByIdentity,
   getUsageLookupKey,
@@ -61,21 +60,9 @@ export function normalizeRunStrategy(value: unknown): RunStrategy | null {
 
 /** Read project-local run strategy from the nearest agents.yaml, if present. */
 export function getProjectRunStrategy(agent: AgentId, startPath: string): RunStrategy | null {
-  let dir = path.resolve(startPath);
-  const userAgentsYaml = path.join(getUserAgentsDir(), 'agents.yaml');
-
-  while (dir !== path.dirname(dir)) {
-    const manifestPath = path.join(dir, 'agents.yaml');
-    if (manifestPath !== userAgentsYaml && fs.existsSync(manifestPath)) {
-      try {
-        const parsed = yaml.parse(fs.readFileSync(manifestPath, 'utf-8'));
-        const strategy = normalizeRunStrategy(parsed?.run?.[agent]?.strategy);
-        if (strategy) return strategy;
-      } catch {
-        // Ignore malformed project config and keep walking, matching version resolution.
-      }
-    }
-    dir = path.dirname(dir);
+  for (const runConfig of getProjectRunConfigs(startPath)) {
+    const strategy = normalizeRunStrategy(runConfig[agent]?.strategy);
+    if (strategy) return strategy;
   }
 
   return null;

--- a/src/lib/run-config.test.ts
+++ b/src/lib/run-config.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { getProjectRunConfigs } from './run-config.js';
+
+describe('getProjectRunConfigs', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-run-config-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('returns project run configs from nearest directory upward', () => {
+    const nested = path.join(root, 'app', 'pkg');
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'agents.yaml'),
+      [
+        'run:',
+        '  defaults:',
+        '    "claude:*":',
+        '      model: opus',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    fs.writeFileSync(
+      path.join(root, 'app', 'agents.yaml'),
+      [
+        'run:',
+        '  defaults:',
+        '    "claude:*":',
+        '      mode: auto',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    expect(getProjectRunConfigs(nested)).toEqual([
+      {
+        defaults: {
+          'claude:*': {
+            mode: 'auto',
+          },
+        },
+      },
+      {
+        defaults: {
+          'claude:*': {
+            model: 'opus',
+          },
+        },
+      },
+    ]);
+  });
+});

--- a/src/lib/run-config.ts
+++ b/src/lib/run-config.ts
@@ -1,0 +1,40 @@
+/**
+ * Project-local `run:` config discovery.
+ *
+ * The user/system `agents.yaml` is read through state.ts. Project-local
+ * agents.yaml files are discovered from the current working directory upward.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'yaml';
+import type { RunConfig } from './types.js';
+import { getUserAgentsDir } from './state.js';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Return project-local run configs from nearest directory upward. */
+export function getProjectRunConfigs(startPath: string = process.cwd()): RunConfig[] {
+  const configs: RunConfig[] = [];
+  let dir = path.resolve(startPath);
+  const userAgentsYaml = path.join(getUserAgentsDir(), 'agents.yaml');
+
+  while (dir !== path.dirname(dir)) {
+    const manifestPath = path.join(dir, 'agents.yaml');
+    if (manifestPath !== userAgentsYaml && fs.existsSync(manifestPath)) {
+      try {
+        const parsed = yaml.parse(fs.readFileSync(manifestPath, 'utf-8'));
+        if (isRecord(parsed?.run)) {
+          configs.push(parsed.run as RunConfig);
+        }
+      } catch {
+        // Ignore malformed project config and keep walking.
+      }
+    }
+    dir = path.dirname(dir);
+  }
+
+  return configs;
+}

--- a/src/lib/run-defaults.test.ts
+++ b/src/lib/run-defaults.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeRunDefaultMode,
+  parseRunDefaultSelector,
+  resolveRunDefaultsFromConfig,
+  resolveRunDefaultsFromConfigs,
+} from './run-defaults.js';
+import type { RunConfig } from './types.js';
+
+describe('run defaults', () => {
+  it('canonicalizes selector forms', () => {
+    expect(parseRunDefaultSelector('claude:*')).toEqual({
+      agent: 'claude',
+      version: '*',
+      selector: 'claude:*',
+    });
+    expect(parseRunDefaultSelector('claude@2.1.45')).toEqual({
+      agent: 'claude',
+      version: '2.1.45',
+      selector: 'claude:2.1.45',
+    });
+    expect(parseRunDefaultSelector('codex')).toEqual({
+      agent: 'codex',
+      version: '*',
+      selector: 'codex:*',
+    });
+  });
+
+  it('rejects invalid selectors', () => {
+    expect(() => parseRunDefaultSelector('unknown:*')).toThrow(/Invalid agent/);
+    expect(() => parseRunDefaultSelector('claude:../../bad')).toThrow(/Invalid selector version/);
+    expect(() => parseRunDefaultSelector('claude@1@2')).toThrow(/Invalid selector/);
+  });
+
+  it("normalizes legacy 'full' mode to skip", () => {
+    expect(normalizeRunDefaultMode('full')).toBe('skip');
+    expect(normalizeRunDefaultMode('AUTO')).toBe('auto');
+    expect(() => normalizeRunDefaultMode('write')).toThrow(/Invalid mode/);
+  });
+
+  it('merges wildcard and exact selector defaults field by field', () => {
+    const config: RunConfig = {
+      defaults: {
+        'claude:*': {
+          mode: 'auto',
+          model: 'opus',
+        },
+        'claude:2.1.45': {
+          mode: 'plan',
+        },
+      },
+    };
+
+    expect(resolveRunDefaultsFromConfig(config, 'claude', '2.1.45')).toEqual({
+      mode: 'plan',
+      model: 'opus',
+      sources: {
+        mode: 'claude:2.1.45',
+        model: 'claude:*',
+      },
+    });
+  });
+
+  it('uses wildcard defaults when no exact selector matches', () => {
+    const config: RunConfig = {
+      defaults: {
+        'codex:*': {
+          mode: 'plan',
+          model: 'gpt-5.2-codex',
+        },
+      },
+    };
+
+    expect(resolveRunDefaultsFromConfig(config, 'codex', '0.134.0')).toEqual({
+      mode: 'plan',
+      model: 'gpt-5.2-codex',
+      sources: {
+        mode: 'codex:*',
+        model: 'codex:*',
+      },
+    });
+  });
+
+  it('layers multiple configs field by field with later configs taking precedence', () => {
+    const userConfig: RunConfig = {
+      defaults: {
+        'claude:*': {
+          mode: 'auto',
+          model: 'opus',
+        },
+      },
+    };
+    const projectConfig: RunConfig = {
+      defaults: {
+        'claude:2.1.45': {
+          mode: 'plan',
+        },
+      },
+    };
+
+    expect(resolveRunDefaultsFromConfigs([userConfig, projectConfig], 'claude', '2.1.45')).toEqual({
+      mode: 'plan',
+      model: 'opus',
+      sources: {
+        mode: 'claude:2.1.45',
+        model: 'claude:*',
+      },
+    });
+  });
+});

--- a/src/lib/run-defaults.ts
+++ b/src/lib/run-defaults.ts
@@ -1,0 +1,241 @@
+/**
+ * Selector-based defaults for `agents run`.
+ *
+ * Stored under agents.yaml:
+ *
+ *   run:
+ *     defaults:
+ *       "claude:*":
+ *         mode: auto
+ *         model: opus
+ *       "claude:2.1.45":
+ *         mode: plan
+ */
+
+import type { AgentId, Mode, RunConfig, RunDefaults } from './types.js';
+import { ALL_MODES } from './types.js';
+import { AGENTS } from './agents.js';
+import { readMeta, updateMeta } from './state.js';
+import { getProjectRunConfigs } from './run-config.js';
+
+const VERSION_RE = /^(?:\*|latest|(?!.*\.\.)[A-Za-z0-9._+-]{1,64})$/;
+
+export interface ParsedRunDefaultSelector {
+  agent: AgentId;
+  version: string;
+  selector: string;
+}
+
+export interface ResolvedRunDefaults extends RunDefaults {
+  sources: {
+    mode?: string;
+    model?: string;
+  };
+}
+
+export interface RunDefaultEntry {
+  selector: string;
+  defaults: RunDefaults;
+}
+
+type RunDefaultsInput = {
+  mode?: unknown;
+  model?: unknown;
+};
+
+function isAgentId(value: string): value is AgentId {
+  return value in AGENTS;
+}
+
+export function normalizeRunDefaultMode(input: string): Mode {
+  const mode = input.trim().toLowerCase();
+  if (mode === 'full') return 'skip';
+  if ((ALL_MODES as readonly string[]).includes(mode)) return mode as Mode;
+  throw new Error(`Invalid mode '${input}'. Use one of: ${ALL_MODES.join(', ')} (or 'full' as an alias for 'skip').`);
+}
+
+function normalizeRunDefaults(defaults: RunDefaultsInput, selector: string): RunDefaults {
+  const out: RunDefaults = {};
+
+  if (defaults.mode !== undefined) {
+    if (typeof defaults.mode !== 'string') {
+      throw new Error(`Invalid mode in run.defaults.${selector}: expected a string.`);
+    }
+    out.mode = normalizeRunDefaultMode(defaults.mode);
+  }
+
+  if (defaults.model !== undefined) {
+    if (typeof defaults.model !== 'string' || defaults.model.trim() === '') {
+      throw new Error(`Invalid model in run.defaults.${selector}: expected a non-empty string.`);
+    }
+    out.model = defaults.model.trim();
+  }
+
+  return out;
+}
+
+export function parseRunDefaultSelector(input: string): ParsedRunDefaultSelector {
+  const raw = input.trim();
+  if (!raw) throw new Error('Selector is required. Use <agent>:<version>, <agent>@<version>, or <agent>:*.');
+
+  let agentPart: string;
+  let versionPart: string;
+
+  if (raw.includes('@')) {
+    const parts = raw.split('@');
+    if (parts.length !== 2) throw new Error(`Invalid selector '${input}'. Use <agent>@<version>.`);
+    [agentPart, versionPart] = parts;
+  } else if (raw.includes(':')) {
+    const idx = raw.indexOf(':');
+    agentPart = raw.slice(0, idx);
+    versionPart = raw.slice(idx + 1);
+  } else {
+    agentPart = raw;
+    versionPart = '*';
+  }
+
+  const agent = agentPart.toLowerCase();
+  if (!isAgentId(agent)) {
+    throw new Error(`Invalid agent '${agentPart}'. Available agents: ${Object.keys(AGENTS).join(', ')}.`);
+  }
+
+  if (!VERSION_RE.test(versionPart)) {
+    throw new Error(`Invalid selector version '${versionPart}'. Use *, latest, or [A-Za-z0-9._+-]{1,64}.`);
+  }
+
+  return {
+    agent,
+    version: versionPart,
+    selector: `${agent}:${versionPart}`,
+  };
+}
+
+function sortedDefaults(defaults: Record<string, RunDefaults>): Record<string, RunDefaults> {
+  return Object.fromEntries(
+    Object.entries(defaults).sort(([a], [b]) => a.localeCompare(b)),
+  );
+}
+
+export function resolveRunDefaultsFromConfig(
+  runConfig: RunConfig | undefined,
+  agent: AgentId,
+  version?: string | null,
+): ResolvedRunDefaults {
+  const defaults = runConfig?.defaults ?? {};
+  const wildcardSelector = `${agent}:*`;
+  const exactSelector = version ? `${agent}:${version}` : null;
+  const resolved: ResolvedRunDefaults = { sources: {} };
+
+  const wildcard = defaults[wildcardSelector]
+    ? normalizeRunDefaults(defaults[wildcardSelector], wildcardSelector)
+    : null;
+  if (wildcard?.mode) {
+    resolved.mode = wildcard.mode;
+    resolved.sources.mode = wildcardSelector;
+  }
+  if (wildcard?.model) {
+    resolved.model = wildcard.model;
+    resolved.sources.model = wildcardSelector;
+  }
+
+  if (exactSelector && defaults[exactSelector]) {
+    const exact = normalizeRunDefaults(defaults[exactSelector], exactSelector);
+    if (exact.mode) {
+      resolved.mode = exact.mode;
+      resolved.sources.mode = exactSelector;
+    }
+    if (exact.model) {
+      resolved.model = exact.model;
+      resolved.sources.model = exactSelector;
+    }
+  }
+
+  return resolved;
+}
+
+export function resolveRunDefaultsFromConfigs(
+  runConfigs: Array<RunConfig | undefined>,
+  agent: AgentId,
+  version?: string | null,
+): ResolvedRunDefaults {
+  const resolved: ResolvedRunDefaults = { sources: {} };
+
+  for (const runConfig of runConfigs) {
+    const next = resolveRunDefaultsFromConfig(runConfig, agent, version);
+    if (next.mode) {
+      resolved.mode = next.mode;
+      resolved.sources.mode = next.sources.mode;
+    }
+    if (next.model) {
+      resolved.model = next.model;
+      resolved.sources.model = next.sources.model;
+    }
+  }
+
+  return resolved;
+}
+
+export function resolveRunDefaults(
+  agent: AgentId,
+  version?: string | null,
+  startPath: string = process.cwd(),
+): ResolvedRunDefaults {
+  const projectRunConfigs = getProjectRunConfigs(startPath).reverse();
+  return resolveRunDefaultsFromConfigs([readMeta().run, ...projectRunConfigs], agent, version);
+}
+
+export function listRunDefaults(): RunDefaultEntry[] {
+  const defaults = readMeta().run?.defaults ?? {};
+  return Object.entries(defaults)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([selector, value]) => ({
+      selector,
+      defaults: normalizeRunDefaults(value, selector),
+    }));
+}
+
+export function setRunDefault(selectorInput: string, defaultsInput: RunDefaultsInput): RunDefaultEntry {
+  const parsed = parseRunDefaultSelector(selectorInput);
+  const defaults = normalizeRunDefaults(defaultsInput, parsed.selector);
+  if (!defaults.mode && !defaults.model) {
+    throw new Error('Set at least one default: --mode <mode> or --model <model>.');
+  }
+
+  updateMeta((meta) => {
+    const run = { ...(meta.run ?? {}) } as RunConfig;
+    const currentDefaults = { ...(run.defaults ?? {}) };
+    currentDefaults[parsed.selector] = {
+      ...(currentDefaults[parsed.selector] ?? {}),
+      ...defaults,
+    };
+    run.defaults = sortedDefaults(currentDefaults);
+    return { ...meta, run };
+  });
+
+  return {
+    selector: parsed.selector,
+    defaults: {
+      ...(readMeta().run?.defaults?.[parsed.selector] ?? {}),
+    },
+  };
+}
+
+export function unsetRunDefault(selectorInput: string): boolean {
+  const parsed = parseRunDefaultSelector(selectorInput);
+  let removed = false;
+
+  updateMeta((meta) => {
+    const run = { ...(meta.run ?? {}) } as RunConfig;
+    const currentDefaults = { ...(run.defaults ?? {}) };
+    removed = Object.prototype.hasOwnProperty.call(currentDefaults, parsed.selector);
+    delete currentDefaults[parsed.selector];
+    if (Object.keys(currentDefaults).length > 0) {
+      run.defaults = sortedDefaults(currentDefaults);
+    } else {
+      delete run.defaults;
+    }
+    return { ...meta, run };
+  });
+
+  return removed;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,6 +12,22 @@ export type AgentId = 'claude' | 'codex' | 'gemini' | 'cursor' | 'opencode' | 'o
 /** How `agents run <agent>` chooses an installed version when none is pinned. */
 export type RunStrategy = 'pinned' | 'available' | 'balanced';
 
+/** Per-agent run strategy config. */
+export interface AgentRunConfig {
+  strategy?: RunStrategy;
+}
+
+/** Default launch options applied by `agents run` when flags are omitted. */
+export interface RunDefaults {
+  mode?: Mode;
+  model?: string;
+}
+
+/** `run:` section in agents.yaml. Agent keys keep strategy; `defaults` stores selector rules. */
+export type RunConfig = Partial<Record<AgentId, AgentRunConfig>> & {
+  defaults?: Record<string, RunDefaults>;
+};
+
 /** Preview features that users can opt into via `agents beta`. */
 export type BetaFeatureName = 'drive' | 'factory';
 
@@ -210,7 +226,7 @@ export interface InstalledHook {
 /** Package manifest (agents.yaml) found inside a cloned config repo or package. */
 export interface Manifest {
   agents?: Partial<Record<AgentId, string>>;
-  run?: Partial<Record<AgentId, { strategy?: RunStrategy }>>;
+  run?: RunConfig;
   beta?: {
     enabled?: BetaFeatureName[];
   };
@@ -520,7 +536,7 @@ export interface ExtraRepoConfig {
 /** Top-level structure of ~/.agents/.system/agents.yaml -- the CLI's persistent state. */
 export interface Meta {
   agents?: Partial<Record<AgentId, string>>;
-  run?: Partial<Record<AgentId, { strategy?: RunStrategy }>>;
+  run?: RunConfig;
   beta?: {
     enabled?: BetaFeatureName[];
   };

--- a/tests/run-defaults-command.test.ts
+++ b/tests/run-defaults-command.test.ts
@@ -35,6 +35,7 @@ describe('agents run defaults', () => {
       `fs.writeFileSync(${JSON.stringify(argvPath)}, JSON.stringify(process.argv.slice(2)));`,
     ].join('\n');
     writeExecutable(path.join(managedBinDir, 'claude'), captureArgvScript);
+    writeExecutable(path.join(binDir, 'claude'), captureArgvScript);
     fs.writeFileSync(
       path.join(home, '.agents', 'agents.yaml'),
       [

--- a/tests/run-defaults-command.test.ts
+++ b/tests/run-defaults-command.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const repoRoot = process.cwd();
+const entrypoint = path.join(repoRoot, 'src/index.ts');
+
+function writeExecutable(filePath: string, body: string): void {
+  fs.writeFileSync(filePath, body, 'utf-8');
+  fs.chmodSync(filePath, 0o755);
+}
+
+describe('agents run defaults', () => {
+  let home: string;
+  let binDir: string;
+  let projectDir: string;
+  let argvPath: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-run-defaults-test-'));
+    binDir = path.join(home, 'bin');
+    projectDir = path.join(home, 'project');
+    argvPath = path.join(home, 'argv.json');
+    fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
+    fs.mkdirSync(path.join(home, '.agents', '.system', '.git'), { recursive: true });
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(projectDir, { recursive: true });
+    const managedBinDir = path.join(home, '.agents', '.history', 'versions', 'claude', '2.1.45', 'node_modules', '.bin');
+    fs.mkdirSync(managedBinDir, { recursive: true });
+    const captureArgvScript = [
+      '#!/usr/bin/env node',
+      'const fs = require("fs");',
+      `fs.writeFileSync(${JSON.stringify(argvPath)}, JSON.stringify(process.argv.slice(2)));`,
+    ].join('\n');
+    writeExecutable(path.join(managedBinDir, 'claude'), captureArgvScript);
+    fs.writeFileSync(
+      path.join(home, '.agents', 'agents.yaml'),
+      [
+        'agents:',
+        '  claude: "2.1.45"',
+        'run:',
+        '  claude:',
+        '    strategy: pinned',
+        '  defaults:',
+        '    "claude:*":',
+        '      mode: auto',
+        '      model: opus',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    writeExecutable(path.join(binDir, 'claude@2.1.45'), captureArgvScript);
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('applies configured mode and model when flags are omitted', () => {
+    execFileSync('bun', [entrypoint, 'run', 'claude', 'hello', '--quiet', '--headless'], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        HOME: home,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+        AGENTS_NO_AUTOPULL: '1',
+        AGENTS_SKIP_MIGRATION: '1',
+        AGENTS_CLI_DISABLE_AUTO_UPDATE: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const argv = JSON.parse(fs.readFileSync(argvPath, 'utf-8')) as string[];
+    expect(argv).toContain('--permission-mode');
+    expect(argv[argv.indexOf('--permission-mode') + 1]).toBe('auto');
+    expect(argv).toContain('--model');
+    expect(argv[argv.indexOf('--model') + 1]).toBe('opus');
+    expect(argv).toContain('--print');
+    expect(argv).toContain('hello');
+  });
+
+  it('lets project-local defaults override user defaults field by field', () => {
+    fs.writeFileSync(
+      path.join(projectDir, 'agents.yaml'),
+      [
+        'run:',
+        '  defaults:',
+        '    "claude:2.1.45":',
+        '      mode: plan',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    execFileSync('bun', [entrypoint, 'run', 'claude', 'hello', '--quiet', '--headless'], {
+      cwd: projectDir,
+      env: {
+        ...process.env,
+        HOME: home,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+        AGENTS_NO_AUTOPULL: '1',
+        AGENTS_SKIP_MIGRATION: '1',
+        AGENTS_CLI_DISABLE_AUTO_UPDATE: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const argv = JSON.parse(fs.readFileSync(argvPath, 'utf-8')) as string[];
+    expect(argv).toContain('--permission-mode');
+    expect(argv[argv.indexOf('--permission-mode') + 1]).toBe('plan');
+    expect(argv).toContain('--model');
+    expect(argv[argv.indexOf('--model') + 1]).toBe('opus');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `agents defaults run list|set|unset` for selector-based defaults stored under `run.defaults`.
- Resolve defaults by agent/version selector, including wildcard and exact rules, with project-local `agents.yaml` overriding user/system fields.
- Apply default `mode` and `model` in `agents run` only when explicit flags are omitted, and surface resolved defaults in `agents view`.

## Validation
- `bun test src/lib/run-config.test.ts src/lib/run-defaults.test.ts src/commands/defaults.test.ts tests/run-defaults-command.test.ts src/lib/__tests__/rotate.test.ts src/lib/__tests__/exec.test.ts` -> 154 pass, 0 fail.
- `bun run build` -> exit 0. The optional Darwin copy step logged `cp: bin/Agents CLI.app: No such file or directory`, but the build command succeeded.
- `bun src/index.ts defaults run --help` rendered the new command tree and examples.
- `bun test` -> process exited 0, but output still contains unrelated existing failures around missing `node_modules/tsx/dist/cli.mjs`, capability/MCP/PTY assertions, and a version duplicate notice assertion.

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/d658148c0040e642236f645edccc404e)
