### PR TITLE
fix(permissions): translate canonical patterns to Kimi's syntax

### DIFF
--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -2,7 +2,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { buildPermissionsFromGroups, containsBroadGrants, convertDenyToCodexRules } from './permissions.js';
+import * as TOML from 'smol-toml';
+import { applyPermissionsToVersion, buildPermissionsFromGroups, containsBroadGrants, convertDenyToCodexRules, convertToKimiFormat } from './permissions.js';
 
 const tempDirs: string[] = [];
 
@@ -54,5 +55,69 @@ describe('containsBroadGrants', () => {
     });
 
     expect(result).toBeNull();
+  });
+});
+
+describe('convertToKimiFormat', () => {
+  it('translates Claude `:*` bash patterns into Kimi trailing-`*` globs', () => {
+    // The core bug: copying `Bash(git status:*)` verbatim never matches in
+    // Kimi's engine (it globs the raw command string), so every call prompts.
+    const { permission } = convertToKimiFormat({
+      name: 'core',
+      allow: ['Bash(git status:*)', 'Bash(mq:*)', 'Bash(env)'],
+      deny: [],
+    });
+
+    expect(permission.rules).toEqual([
+      { decision: 'allow', pattern: 'Bash(git status*)' },
+      { decision: 'allow', pattern: 'Bash(mq*)' },
+      { decision: 'allow', pattern: 'Bash(env)' },
+    ]);
+  });
+
+  it('collapses blanket and glob grants to name-only rules with original casing', () => {
+    const { permission } = convertToKimiFormat({
+      name: 'broad',
+      allow: ['Bash(*)', 'Read(**)', 'Grep'],
+      deny: [],
+    });
+
+    expect(permission.rules).toEqual([
+      { decision: 'allow', pattern: 'Bash' },
+      { decision: 'allow', pattern: 'Read' },
+      { decision: 'allow', pattern: 'Grep' },
+    ]);
+  });
+
+  it('carries deny rules through the same translation', () => {
+    const { permission } = convertToKimiFormat({
+      name: 'deny',
+      allow: [],
+      deny: ['Bash(rm -rf:*)'],
+    });
+
+    expect(permission.rules).toEqual([
+      { decision: 'deny', pattern: 'Bash(rm -rf*)' },
+    ]);
+  });
+
+  it('writes a re-parseable TOML config with translated patterns (no raw `:*`)', () => {
+    const home = makeTempHome();
+    const res = applyPermissionsToVersion(
+      'kimi',
+      { name: 'set', allow: ['Bash(ls:*)'], deny: ['Bash(rm -rf:*)'] },
+      home,
+      false,
+    );
+    expect(res.success).toBe(true);
+
+    const raw = fs.readFileSync(path.join(home, '.kimi-code', 'config.toml'), 'utf-8');
+    const parsed = TOML.parse(raw) as { permission: { rules: Array<{ decision: string; pattern: string }> } };
+    expect(parsed.permission.rules).toEqual([
+      { decision: 'allow', pattern: 'Bash(ls*)' },
+      { decision: 'deny', pattern: 'Bash(rm -rf*)' },
+    ]);
+    // The pre-fix bug would have left the un-matchable Claude `:*` form on disk.
+    expect(raw).not.toContain(':*');
   });
 });

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -608,6 +608,83 @@ function canonicalToGrokRule(perm: string, action: 'allow' | 'deny'): GrokRule |
   return { action, tool, pattern };
 }
 
+export type KimiRule = { decision: 'allow' | 'deny'; pattern: string };
+
+/**
+ * Parse a canonical permission string preserving the tool's original casing.
+ * `parseCanonicalPattern` lowercases the tool name, which is fine for Grok
+ * (lowercase tool vocabulary) but wrong for Kimi, whose tool names are
+ * capitalized (`Bash`, `Read`, `Grep`). Bare tool names (no parens, e.g.
+ * `Read` or an MCP id like `mcp__server__tool`) return `pattern: null`.
+ */
+function parseCanonicalPreserveCase(perm: string): { tool: string; pattern: string | null } {
+  const m = perm.match(/^([\w-]+)\((.*)\)$/);
+  if (m) return { tool: m[1], pattern: m[2] };
+  return { tool: perm, pattern: null };
+}
+
+/**
+ * Strip Claude's `:*` subcommand-wildcard suffix into Kimi's bare-`*` glob.
+ * Kimi matches the trailing `*` against the raw command string with zero-or-more
+ * semantics, so `git status*` covers both `git status` and `git status -s` in a
+ * single rule (its own docs use `Bash(rm -rf*)`). This is why Kimi uses no space
+ * before `*`, unlike Grok/Antigravity's ` *` form (`normalizeBashPattern`).
+ * "git status:*" -> "git status*", "mq:*" -> "mq*", "*"/"**" -> "*".
+ */
+function kimiBashPattern(pattern: string): string {
+  if (pattern === '*' || pattern === '**') return '*';
+  if (pattern.endsWith(':*')) return pattern.slice(0, -2) + '*';
+  return pattern;
+}
+
+function canonicalToKimiRule(perm: string, decision: 'allow' | 'deny'): KimiRule | null {
+  if (BLANKET_BASH_FORMS.has(perm)) {
+    return { decision, pattern: 'Bash' };
+  }
+  const { tool, pattern } = parseCanonicalPreserveCase(perm);
+  // Bare tool name (no parens) — name-only match. Covers `Read`, `Grep`, and
+  // MCP tool ids, which Kimi can only match by name anyway.
+  if (pattern === null) {
+    return { decision, pattern: tool };
+  }
+  if (tool.toLowerCase() === 'bash') {
+    const p = kimiBashPattern(pattern);
+    return { decision, pattern: p === '*' ? 'Bash' : `Bash(${p})` };
+  }
+  // Non-Bash built-ins (Read/Write/Edit/Grep/Glob/WebFetch...) share Kimi's
+  // capitalized tool vocabulary, so pass the tool+pattern through. A `**`/`*`
+  // glob means "any" — collapse to a name-only rule.
+  if (pattern === '*' || pattern === '**') {
+    return { decision, pattern: tool };
+  }
+  return { decision, pattern: `${tool}(${pattern})` };
+}
+
+/**
+ * Convert a canonical permission set to Kimi Code's `[permission].rules` format.
+ * Kimi (`~/.kimi-code/config.toml`) reads rules of the form
+ *   [[permission.rules]]
+ *   decision = "allow"
+ *   pattern  = "Bash(git status*)"
+ * Tool names are capitalized and the Bash arg-glob uses a trailing `*` (no
+ * Claude `:*` separator). Without this conversion the canonical strings match
+ * nothing in Kimi's engine and every tool call falls through to a prompt.
+ */
+export function convertToKimiFormat(set: PermissionSet): { permission: { rules: KimiRule[] } } {
+  const rules: KimiRule[] = [];
+  for (const perm of set.allow) {
+    const rule = canonicalToKimiRule(perm, 'allow');
+    if (rule) rules.push(rule);
+  }
+  if (set.deny) {
+    for (const perm of set.deny) {
+      const rule = canonicalToKimiRule(perm, 'deny');
+      if (rule) rules.push(rule);
+    }
+  }
+  return { permission: { rules } };
+}
+
 /**
  * Convert canonical permission set to OpenCode format.
  * OpenCode uses: { permission: { bash: { "git *": "allow", "rm *": "deny" } } }
@@ -1255,13 +1332,7 @@ export function applyPermissionsToVersion(
         config = TOML.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
       }
 
-      const newRules: Array<{ decision: string; pattern: string }> = [];
-      for (const allow of set.allow) {
-        newRules.push({ decision: 'allow', pattern: allow });
-      }
-      for (const deny of set.deny || []) {
-        newRules.push({ decision: 'deny', pattern: deny });
-      }
+      const newRules: Array<{ decision: string; pattern: string }> = convertToKimiFormat(set).permission.rules;
 
       if (merge) {
         const existingPermission = (typeof config.permission === 'object' && config.permission !== null && !Array.isArray(config.permission))


### PR DESCRIPTION
## Problem

`agents-cli` advertises first-class Kimi permission support (`allowlist: true`), but the allowlist was **dead on arrival**. The Kimi branch of `applyPermissionsToVersion` (`src/lib/permissions.ts`) copied canonical permission strings into `[permission].rules` **verbatim**:

```ts
for (const allow of set.allow) newRules.push({ decision: 'allow', pattern: allow });
```

So `Bash(git status:*)` landed in `~/.kimi-code/config.toml` unchanged. But Kimi globs the **raw command string** and its pattern grammar has no Claude-style `:*` separator (its own docs use `Bash(rm -rf*)`). The result: `Bash(git status:*)` matches nothing, so **every** tool call falls through to an interactive approval prompt. The user experience is "Kimi prompts for everything, even with a synced allowlist."

Every other rules-based agent already converts: `convertToGrokFormat`, `convertToAntigravityFormat`, `convertToGeminiFormat`. Kimi was the one that skipped it.

## Fix

Add `convertToKimiFormat` (mirrors `convertToGrokFormat`) and use it in the writer:

- Parses the canonical pattern, **preserving Kimi's capitalized tool names** (`Bash`, `Read`, `Grep`) — `parseCanonicalPattern` lowercases, which is correct for Grok but wrong for Kimi, so a case-preserving parse is used.
- Rewrites the Bash arg-glob from Claude's `:*` to Kimi's trailing-`*`: `git status:*` -> `git status*`. The trailing `*` has zero-or-more semantics so a single rule covers both `git status` and `git status -s`.
- Blanket (`Bash(*)`) and `**` grants collapse to name-only rules.
- Deny rules run through the same translation.

## Verification

- `bunx vitest run src/lib/permissions.test.ts` -> 8 passed (4 new), `tsc --noEmit` clean.
- New tests assert the `:* -> *` translation, name-only collapse, deny passthrough, and a writer round-trip that re-parses the TOML and asserts no raw `:*` survives to disk.
- **End-to-end against kimi 0.11.0** (interactive TUI, default manual mode): synced the real groups, then drove a live session via PTY. An allow-listed command (`echo`) auto-approved with **no prompt and no `permission.record_approval_result` event**; a non-allowed command (`touch`) still surfaced the approval dialog. The allowlist now discriminates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)