### PR TITLE
fix(secrets): helper has/list miss DP-keychain items; installer skips stale-helper reinstall

### DIFF
--- a/scripts/Agents CLI.app.sha256
+++ b/scripts/Agents CLI.app.sha256
@@ -1,1 +1,1 @@
-4d46fe0cc7afd6deb3ba0ad2ffcb12e2f4074a79e7618b4f0eafff55d458d507  bin/Agents CLI.app/Contents/MacOS/Agents CLI
+9f6c67c71952827c6982ea3eefcd8e4a738f46f27a059e84ed77324bb0d99b51  bin/Agents CLI.app/Contents/MacOS/Agents CLI

--- a/src/lib/secrets/__tests__/install-helper.test.ts
+++ b/src/lib/secrets/__tests__/install-helper.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Behavioral tests for the keychain helper installer.
+ *
+ * These run against the real signed bundle at <repo>/bin/Agents CLI.app and
+ * the real `codesign` binary, redirecting the install destination via $HOME
+ * (os.homedir() reads it per call). They are skipped on non-darwin and on
+ * checkouts without the locally built helper bundle (bin/ is gitignored), so
+ * they execute on dev and release machines, not on Linux CI.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { ensureKeychainHelperInstalled, getKeychainHelperPath, setInstallRootForTest } from '../install-helper.js';
+
+const SOURCE_APP = path.join(process.cwd(), 'bin', 'Agents CLI.app');
+const SOURCE_EXEC = path.join(SOURCE_APP, 'Contents', 'MacOS', 'Agents CLI');
+const skip = process.platform !== 'darwin' || !fs.existsSync(SOURCE_EXEC);
+
+const sha256 = (p: string) => createHash('sha256').update(fs.readFileSync(p)).digest('hex');
+
+describe.skipIf(skip)('keychain helper staleness reinstall', () => {
+  let tmpHome: string;
+  let installedExec: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-helper-test-'));
+    setInstallRootForTest(tmpHome);
+    installedExec = path.join(
+      tmpHome, 'Library', 'Application Support', 'agents-cli', 'Agents CLI.app', 'Contents', 'MacOS', 'Agents CLI'
+    );
+  });
+
+  afterEach(() => {
+    setInstallRootForTest(null);
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('installs the bundled helper on first use', () => {
+    ensureKeychainHelperInstalled();
+    expect(fs.existsSync(installedExec)).toBe(true);
+    expect(sha256(installedExec)).toBe(sha256(SOURCE_EXEC));
+  });
+
+  it('replaces a stale helper even when its signature still verifies', () => {
+    // Reproduce the 1.20.4 incident shape: the installed helper differs from
+    // the bundled one but passes `codesign --verify`. Re-signing ad-hoc
+    // rewrites the executable's embedded signature blob, so the binary's
+    // bytes diverge from the bundled source while the bundle still verifies
+    // — exactly like an old validly-signed helper left behind by a previous
+    // CLI version. Before the staleness check, the installer's "exists and
+    // verifies" early-return kept such a helper forever.
+    ensureKeychainHelperInstalled();
+    const installedApp = path.dirname(path.dirname(path.dirname(installedExec)));
+    const resign = spawnSync('codesign', ['--sign', '-', '--force', '--deep', installedApp], {
+      stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8',
+    });
+    expect(resign.status).toBe(0);
+    const verify = spawnSync('codesign', ['--verify', '--deep', '--strict', installedApp], {
+      stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8',
+    });
+    expect(verify.status).toBe(0);
+    expect(sha256(installedExec)).not.toBe(sha256(SOURCE_EXEC));
+
+    const helperPath = getKeychainHelperPath();
+
+    expect(helperPath).toBe(installedExec);
+    expect(sha256(installedExec)).toBe(sha256(SOURCE_EXEC));
+  });
+
+  it('leaves a healthy install untouched', () => {
+    ensureKeychainHelperInstalled();
+    const before = fs.statSync(installedExec).mtimeMs;
+    ensureKeychainHelperInstalled();
+    getKeychainHelperPath();
+    expect(fs.statSync(installedExec).mtimeMs).toBe(before);
+  });
+});

--- a/src/lib/secrets/__tests__/keychain-helper.test.ts
+++ b/src/lib/secrets/__tests__/keychain-helper.test.ts
@@ -25,3 +25,35 @@ describe('keychain-helper Touch ID policy', () => {
     expect(source).toContain('case "get-batch":');
   });
 });
+
+describe('keychain-helper data-protection keychain coverage', () => {
+  // Items written by `set` carry a biometry ACL, which forces them into the
+  // data-protection keychain. A query with kSecUseAuthenticationUIFail and
+  // no kSecUseDataProtectionKeychain key never sees those items, so has/list
+  // reported every stored secret as missing (RUSH-1083). Each command needs
+  // a DP pass alongside the file-based one.
+  it('has probes both the file-based and data-protection keychains', () => {
+    const source = helperSource();
+    const hasBlock = source.slice(source.indexOf('case "has":'), source.indexOf('case "get":'));
+
+    expect(hasBlock).toContain('for dp in [false, true]');
+    expect(hasBlock).toContain('kSecUseDataProtectionKeychain');
+    // UIFail is the no-prompt guarantee; a present DP item then surfaces as
+    // errSecInteractionNotAllowed, which must count as "exists".
+    expect(hasBlock).toContain('kSecUseAuthenticationUIFail');
+    expect(hasBlock).toContain('errSecInteractionNotAllowed');
+  });
+
+  it('list enumerates both keychains and tolerates a locked DP keybag', () => {
+    const source = helperSource();
+    const listBlock = source.slice(source.indexOf('case "list":'), source.indexOf('case "has":'));
+
+    expect(listBlock).toContain('kSecUseDataProtectionKeychain');
+    expect(listBlock).toContain('for query in [fileQuery, dpQuery]');
+    // The DP keybag locks with the screen; enumeration must skip, not die.
+    expect(listBlock).toContain('if status == errSecInteractionNotAllowed { continue }');
+    // The DP pass must keep an explicit kSecReturn* key: with none at all,
+    // SecItemCopyMatching evaluates the biometry ACL and blocks on Touch ID.
+    expect(listBlock).toContain('kSecReturnAttributes');
+  });
+});

--- a/src/lib/secrets/install-helper.ts
+++ b/src/lib/secrets/install-helper.ts
@@ -15,6 +15,7 @@
 
 import { fileURLToPath } from 'url';
 import { spawnSync } from 'child_process';
+import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -22,9 +23,19 @@ import * as path from 'path';
 const APP_BUNDLE_NAME = 'Agents CLI.app';
 const INSTALL_DIR_NAME = 'agents-cli';
 
+let installRootOverride: string | null = null;
+
+/** Redirect the install root (test only). Returns the previous override so callers can restore. */
+export function setInstallRootForTest(dir: string | null): string | null {
+  const prev = installRootOverride;
+  installRootOverride = dir;
+  return prev;
+}
+
 /** Absolute path to the installed `.app` bundle directory (not the executable). */
 function installedAppPath(): string {
-  return path.join(os.homedir(), 'Library', 'Application Support', INSTALL_DIR_NAME, APP_BUNDLE_NAME);
+  const root = installRootOverride ?? os.homedir();
+  return path.join(root, 'Library', 'Application Support', INSTALL_DIR_NAME, APP_BUNDLE_NAME);
 }
 
 /** Absolute path to the executable inside the installed `.app` bundle. */
@@ -64,6 +75,33 @@ function assertDarwin(): void {
   }
 }
 
+function sha256File(filePath: string): string {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+/**
+ * True when the installed helper executable differs byte-for-byte from the
+ * bundled source helper. A stale-but-validly-signed helper is exactly how the
+ * broken 1.20.4 build (signed, but missing the keychain-access-groups
+ * entitlement) survived upgrades: codesign --verify passes on it, so the
+ * "exists and verifies" early-return kept it installed forever. Returns false
+ * when there is no bundled source to compare against (dev installs) or no
+ * installed copy yet — both cases are decided by the existence checks in the
+ * callers, not by staleness.
+ */
+function installedHelperIsStale(): boolean {
+  let srcApp: string;
+  try {
+    srcApp = sourceAppPath();
+  } catch {
+    return false;
+  }
+  const srcExec = path.join(srcApp, 'Contents', 'MacOS', 'Agents CLI');
+  const destExec = installedExecutablePath();
+  if (!fs.existsSync(srcExec) || !fs.existsSync(destExec)) return false;
+  return sha256File(srcExec) !== sha256File(destExec);
+}
+
 function codesignVerify(appPath: string): { ok: boolean; output: string } {
   const r = spawnSync('codesign', ['--verify', '--deep', '--strict', appPath], {
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -95,8 +133,10 @@ function copyAppBundle(src: string, dest: string): void {
 
 /**
  * Idempotent install. Copies the bundled `.app` to the stable user path. Skips
- * if the destination already exists and `codesign --verify` passes, unless
- * `forceReinstall=true`.
+ * if the destination already exists, `codesign --verify` passes, AND the
+ * installed executable matches the bundled one byte-for-byte — a valid
+ * signature alone is not enough, because an outdated helper signs clean too.
+ * `forceReinstall=true` skips all checks and always copies.
  *
  * Notarization is checked via `spctl --assess` after install — a failure is
  * logged as a warning but does NOT throw. Notarization checks require network
@@ -108,7 +148,7 @@ export function ensureKeychainHelperInstalled(opts: { forceReinstall?: boolean }
   const dest = installedAppPath();
   if (!opts.forceReinstall && fs.existsSync(dest)) {
     const { ok } = codesignVerify(dest);
-    if (ok) return;
+    if (ok && !installedHelperIsStale()) return;
   }
   const src = sourceAppPath();
   copyAppBundle(src, dest);
@@ -132,14 +172,18 @@ export function ensureKeychainHelperInstalled(opts: { forceReinstall?: boolean }
 
 /**
  * Return the absolute path to the helper executable. If the installed bundle
- * is missing, performs a lazy install first.
+ * is missing, or is stale relative to the bundled source helper, performs a
+ * lazy (re)install first. The staleness check is what lets an upgraded CLI
+ * replace a helper a previous version installed — `agents helper install`
+ * never runs on `npm i -g`, so this call site is the only one every machine
+ * is guaranteed to pass through.
  *
  * Throws on non-darwin.
  */
 export function getKeychainHelperPath(): string {
   assertDarwin();
   const exec = installedExecutablePath();
-  if (!fs.existsSync(exec)) {
+  if (!fs.existsSync(exec) || installedHelperIsStale()) {
     ensureKeychainHelperInstalled();
   }
   return exec;

--- a/src/lib/secrets/keychain-helper.swift
+++ b/src/lib/secrets/keychain-helper.swift
@@ -138,21 +138,44 @@ case "list":
     // list <prefix> — enumerate generic-password items whose service starts
     // with <prefix> for the current user. Returns attributes only (never
     // data), so it never decrypts and never prompts.
+    //
+    // Two passes, because no single query covers both keychains: items written
+    // by `set` carry a biometry ACL, which forces them into the data-protection
+    // keychain, and a query with kSecUseAuthenticationUIFail skips the DP
+    // keychain entirely (it errors with errSecInteractionNotAllowed before
+    // returning anything). The DP pass therefore omits the UI key — safe only
+    // because kSecReturnAttributes without kSecReturnData never evaluates the
+    // ACL. Do NOT drop the explicit return key: with no kSecReturn* at all,
+    // SecItemCopyMatching evaluates the ACL anyway and blocks on Touch ID.
     guard args.count == 3 else { die(2, "Usage: agents-keychain list <prefix>") }
     let prefix = args[2]
     guard !prefix.isEmpty else { die(2, "list requires non-empty prefix") }
     let user = ProcessInfo.processInfo.environment["USER"] ?? NSUserName()
-    let query: [CFString: Any] = [
+    let fileQuery: [CFString: Any] = [
         kSecClass: kSecClassGenericPassword,
         kSecMatchLimit: kSecMatchLimitAll,
         kSecReturnAttributes: kCFBooleanTrue!,
         kSecUseAuthenticationUI: kSecUseAuthenticationUIFail,
     ]
-    var result: AnyObject?
-    let status = SecItemCopyMatching(query as CFDictionary, &result)
-    if status == errSecItemNotFound { exit(0) }
-    if status != errSecSuccess { die(2, "Failed to enumerate keychain (OSStatus \(status))") }
-    guard let items = result as? [[String: Any]] else { exit(0) }
+    let dpQuery: [CFString: Any] = [
+        kSecClass: kSecClassGenericPassword,
+        kSecMatchLimit: kSecMatchLimitAll,
+        kSecReturnAttributes: kCFBooleanTrue!,
+        kSecUseDataProtectionKeychain: kCFBooleanTrue!,
+    ]
+    var items: [[String: Any]] = []
+    for query in [fileQuery, dpQuery] {
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound { continue }
+        // The DP keybag locks with the screen; enumeration then reports
+        // errSecInteractionNotAllowed wholesale. Skip the pass instead of
+        // failing — the file-based results are still valid, and DP items
+        // are unreadable until unlock anyway.
+        if status == errSecInteractionNotAllowed { continue }
+        if status != errSecSuccess { die(2, "Failed to enumerate keychain (OSStatus \(status))") }
+        items.append(contentsOf: (result as? [[String: Any]]) ?? [])
+    }
     var seen = Set<String>()
     for item in items {
         guard let svce = item[kSecAttrService as String] as? String, svce.hasPrefix(prefix) else { continue }
@@ -166,18 +189,30 @@ case "has":
     // has <service> <account> — existence check, exit 0 if present else 1.
     // Reads no data, so it never decrypts and never prompts. If the OS
     // reports that interaction would be required, the item still exists.
+    //
+    // Two passes, because no single prompt-free query covers both keychains:
+    // items written by `set` carry a biometry ACL, which forces them into the
+    // data-protection keychain, and a UIFail query without the DP key skips
+    // the DP keychain entirely — it reports errSecItemNotFound for items that
+    // exist. The DP pass keeps UIFail (guaranteed no prompt); a present
+    // DP item then surfaces as errSecInteractionNotAllowed, which already
+    // counts as "exists".
     guard args.count == 4 else { die(2, "Usage: agents-keychain has <service> <account>") }
     let (service, account) = (args[2], args[3])
-    let query: [CFString: Any] = [
-        kSecClass: kSecClassGenericPassword,
-        kSecAttrService: service as CFString,
-        kSecAttrAccount: account as CFString,
-        kSecMatchLimit: kSecMatchLimitOne,
-        kSecUseAuthenticationUI: kSecUseAuthenticationUIFail,
-    ]
-    var ignored: AnyObject?
-    let status = SecItemCopyMatching(query as CFDictionary, &ignored)
-    exit((status == errSecSuccess || status == errSecInteractionNotAllowed) ? 0 : 1)
+    for dp in [false, true] {
+        var query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service as CFString,
+            kSecAttrAccount: account as CFString,
+            kSecMatchLimit: kSecMatchLimitOne,
+            kSecUseAuthenticationUI: kSecUseAuthenticationUIFail,
+        ]
+        if dp { query[kSecUseDataProtectionKeychain] = kCFBooleanTrue! }
+        var ignored: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &ignored)
+        if status == errSecSuccess || status == errSecInteractionNotAllowed { exit(0) }
+    }
+    exit(1)
 
 case "get":
     // get <service> <account> — single protected read. Pops Touch ID (or


### PR DESCRIPTION
Fixes the two bugs behind the `OSStatus -34018` aftermath on zion (RUSH-1083).

## Bug 1: `has`/`list` blind to the data-protection keychain

`set` writes secrets with a biometry ACL, which forces items into the DP keychain. The `has`/`list` queries passed `kSecUseAuthenticationUIFail` without `kSecUseDataProtectionKeychain` — and that combination skips the DP keychain entirely. Result: every freshly stored secret showed as red **missing** in `agents secrets view`, and `sync push` refused complete bundles with "keychain item missing".

Empirically probed on macOS 26.4 with a signed+entitled test binary (all variants in the session transcript):

| Query | DP item | legacy item |
|---|---|---|
| plain + UIFail (old code) | **errSecItemNotFound** | found |
| + `kSecUseDataProtectionKeychain` + UIFail | errSecInteractionNotAllowed (= exists) | not found |
| no UI key, no `kSecReturn*` | **blocks on Touch ID** (ACL evaluates) | found |
| ReturnAttributes, no UI key | found, no prompt | found |

So: `has` now runs a file-based pass and a DP pass, both with UIFail (guaranteed promptless); `list` enumerates both keychains, keeps an explicit `kSecReturnAttributes` (dropping every `kSecReturn*` key makes SecItemCopyMatching evaluate the ACL and hang on Touch ID), and skips the DP pass with `errSecInteractionNotAllowed` when the keybag is locked (screen lock locks it).

## Bug 2: installer keeps stale helpers forever

`ensureKeychainHelperInstalled` early-returned whenever the installed bundle passed `codesign --verify`. The broken 1.20.4 helper (validly signed, missing the `keychain-access-groups` entitlement) therefore survived every upgrade — exactly how zion stayed broken. The installer now also compares installed vs bundled executable by SHA-256 and reinstalls on mismatch, wired into `getKeychainHelperPath()` since that's the only path every machine passes through (`agents helper install` never runs on `npm i -g`).

## Verification

- `bun run test` (vitest): **2156 passed, 0 failed** (3 new install-helper behavioral tests run against real `codesign`; ad-hoc re-sign reproduces the valid-signature-different-bytes incident shape)
- End-to-end on zion: fresh bundle + `add --value-stdin` → `agents secrets view` shows **stored**; helper `has` exit 0; `list` enumerates the DP item; locked-screen behavior verified separately
- Helper rebuilt universal + signed, pinned SHA updated (`9f6c67c7…`). **Notarization pending** — `notarytool submit` + `staple` on the existing bundle; neither alters the pinned executable bytes.

Closes RUSH-1083.

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/044b79149ca9698b7f33e92e245917c4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)