### PR TITLE
fix(permissions): match Kimi Bash rules with path arguments

### DIFF
--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -59,18 +59,23 @@ describe('containsBroadGrants', () => {
 });
 
 describe('convertToKimiFormat', () => {
-  it('translates Claude `:*` bash patterns into Kimi trailing-`*` globs', () => {
+  it('translates Claude `:*` bash patterns into Kimi globs, with a slash-crossing variant', () => {
     // The core bug: copying `Bash(git status:*)` verbatim never matches in
     // Kimi's engine (it globs the raw command string), so every call prompts.
+    // The second `*​/**` form is required because Kimi's `*` does not cross `/`,
+    // so a bare `cmd*` misses any path argument (`git push origin feat/x`).
     const { permission } = convertToKimiFormat({
       name: 'core',
-      allow: ['Bash(git status:*)', 'Bash(mq:*)', 'Bash(env)'],
+      allow: ['Bash(git push:*)', 'Bash(mq:*)', 'Bash(env)'],
       deny: [],
     });
 
     expect(permission.rules).toEqual([
-      { decision: 'allow', pattern: 'Bash(git status*)' },
+      { decision: 'allow', pattern: 'Bash(git push*)' },
+      { decision: 'allow', pattern: 'Bash(git push*/**)' },
       { decision: 'allow', pattern: 'Bash(mq*)' },
+      { decision: 'allow', pattern: 'Bash(mq*/**)' },
+      // Exact command (no `:*`) takes no path args — single rule, no slash variant.
       { decision: 'allow', pattern: 'Bash(env)' },
     ]);
   });
@@ -98,6 +103,7 @@ describe('convertToKimiFormat', () => {
 
     expect(permission.rules).toEqual([
       { decision: 'deny', pattern: 'Bash(rm -rf*)' },
+      { decision: 'deny', pattern: 'Bash(rm -rf*/**)' },
     ]);
   });
 
@@ -115,7 +121,9 @@ describe('convertToKimiFormat', () => {
     const parsed = TOML.parse(raw) as { permission: { rules: Array<{ decision: string; pattern: string }> } };
     expect(parsed.permission.rules).toEqual([
       { decision: 'allow', pattern: 'Bash(ls*)' },
+      { decision: 'allow', pattern: 'Bash(ls*/**)' },
       { decision: 'deny', pattern: 'Bash(rm -rf*)' },
+      { decision: 'deny', pattern: 'Bash(rm -rf*/**)' },
     ]);
     // The pre-fix bug would have left the un-matchable Claude `:*` form on disk.
     expect(raw).not.toContain(':*');

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -624,40 +624,53 @@ function parseCanonicalPreserveCase(perm: string): { tool: string; pattern: stri
 }
 
 /**
- * Strip Claude's `:*` subcommand-wildcard suffix into Kimi's bare-`*` glob.
- * Kimi matches the trailing `*` against the raw command string with zero-or-more
- * semantics, so `git status*` covers both `git status` and `git status -s` in a
- * single rule (its own docs use `Bash(rm -rf*)`). This is why Kimi uses no space
- * before `*`, unlike Grok/Antigravity's ` *` form (`normalizeBashPattern`).
- * "git status:*" -> "git status*", "mq:*" -> "mq*", "*"/"**" -> "*".
+ * Translate a canonical Bash arg-glob (`cmd:*`) into the Kimi pattern(s) that
+ * actually match that command's invocations.
+ *
+ * Kimi matches Bash arg-globs with picomatch, where `*` does NOT cross `/` and a
+ * `**` only globstars when it is its own path segment (`*​/**`, `**​/`). A plain
+ * `cmd*` therefore matches `git status -s` but NOT `git push origin feat/x` or
+ * `cat dir/file` — any argument containing a slash falls through to a prompt
+ * (verified interactively against kimi 0.12.1). We emit TWO patterns so the
+ * command auto-approves whether its args contain a slash or not:
+ *   - `cmd*`     — no-slash args (and the bare command; `*` is zero-or-more).
+ *   - `cmd*​/**` — args with a path: `*` consumes up to the first `/`, then the
+ *                 bounded globstar crosses the remaining slashes.
+ * "git push:*" -> ["git push*", "git push*​/**"].
  */
-function kimiBashPattern(pattern: string): string {
-  if (pattern === '*' || pattern === '**') return '*';
-  if (pattern.endsWith(':*')) return pattern.slice(0, -2) + '*';
-  return pattern;
+function kimiBashPatterns(pattern: string): string[] {
+  if (pattern === '*' || pattern === '**') return ['*'];
+  if (pattern.endsWith(':*')) {
+    const prefix = pattern.slice(0, -2);
+    return [`${prefix}*`, `${prefix}*/**`];
+  }
+  // Exact command (no `:*`, e.g. `env`, `pwd`, `true`) — no path args expected.
+  return [pattern];
 }
 
-function canonicalToKimiRule(perm: string, decision: 'allow' | 'deny'): KimiRule | null {
+function canonicalToKimiRules(perm: string, decision: 'allow' | 'deny'): KimiRule[] {
   if (BLANKET_BASH_FORMS.has(perm)) {
-    return { decision, pattern: 'Bash' };
+    return [{ decision, pattern: 'Bash' }];
   }
   const { tool, pattern } = parseCanonicalPreserveCase(perm);
   // Bare tool name (no parens) — name-only match. Covers `Read`, `Grep`, and
   // MCP tool ids, which Kimi can only match by name anyway.
   if (pattern === null) {
-    return { decision, pattern: tool };
+    return [{ decision, pattern: tool }];
   }
   if (tool.toLowerCase() === 'bash') {
-    const p = kimiBashPattern(pattern);
-    return { decision, pattern: p === '*' ? 'Bash' : `Bash(${p})` };
+    return kimiBashPatterns(pattern).map((p) => ({
+      decision,
+      pattern: p === '*' ? 'Bash' : `Bash(${p})`,
+    }));
   }
   // Non-Bash built-ins (Read/Write/Edit/Grep/Glob/WebFetch...) share Kimi's
   // capitalized tool vocabulary, so pass the tool+pattern through. A `**`/`*`
   // glob means "any" — collapse to a name-only rule.
   if (pattern === '*' || pattern === '**') {
-    return { decision, pattern: tool };
+    return [{ decision, pattern: tool }];
   }
-  return { decision, pattern: `${tool}(${pattern})` };
+  return [{ decision, pattern: `${tool}(${pattern})` }];
 }
 
 /**
@@ -669,17 +682,19 @@ function canonicalToKimiRule(perm: string, decision: 'allow' | 'deny'): KimiRule
  * Tool names are capitalized and the Bash arg-glob uses a trailing `*` (no
  * Claude `:*` separator). Without this conversion the canonical strings match
  * nothing in Kimi's engine and every tool call falls through to a prompt.
+ *
+ * Each `:*` Bash rule expands to TWO patterns (`cmd*` and `cmd*​/**`) so the
+ * command auto-approves whether or not its arguments contain a slash — see
+ * `kimiBashPatterns` for why Kimi's picomatch matcher needs both.
  */
 export function convertToKimiFormat(set: PermissionSet): { permission: { rules: KimiRule[] } } {
   const rules: KimiRule[] = [];
   for (const perm of set.allow) {
-    const rule = canonicalToKimiRule(perm, 'allow');
-    if (rule) rules.push(rule);
+    rules.push(...canonicalToKimiRules(perm, 'allow'));
   }
   if (set.deny) {
     for (const perm of set.deny) {
-      const rule = canonicalToKimiRule(perm, 'deny');
-      if (rule) rules.push(rule);
+      rules.push(...canonicalToKimiRules(perm, 'deny'));
     }
   }
   return { permission: { rules } };


### PR DESCRIPTION
## Problem

Follow-up to #242. The Kimi converter translated `Bash(cmd:*)` to a single `Bash(cmd*)`. Kimi matches Bash arg-globs with **picomatch**, where `*` does **not** cross `/` and a `**` only globstars when it is its own path segment. So `Bash(cmd*)` matched `git status -s` but **not any argument containing a slash**:

- `cat dir/file`
- `ls /tmp/x`
- `cd /abs/path`
- `git push origin feature/branch` ← slash in the branch name

All of these fell through to an interactive approval prompt **despite a matching allow rule** — the exact "Kimi keeps prompting me for `git push`" symptom.

I verified the matcher behavior interactively (kimi 0.12.1, driven via `agents pty`, decisions read from `wire.jsonl`):

| Command | Rule present | Pre-fix |
|---|---|---|
| `git status && ls` (no slashes) | both allowed | auto-approved |
| `cat sub/probe.txt` | `Bash(cat*)` | **prompted** |
| `cd /tmp/x/sub && git status` | `Bash(cd*)` | **prompted** |
| `cat sub/probe.txt` | name-only `Bash` | auto-approved |

Name-only matched (no arg pattern → no picomatch), confirming it's the arg-glob, not a path policy.

## Fix

Expand each `:*` Bash rule to **two** patterns:
- `cmd*` — no-slash args (and the bare command; `*` is zero-or-more).
- `cmd*​/**` — `*` consumes up to the first `/`, then the bounded globstar crosses the remaining slashes.

Exact commands (`Bash(env)`) and non-Bash tools are unchanged. Deny rules get the same expansion (so `rm -rf` denials also cover path forms).

## Verification

- `bunx vitest run src/lib/permissions.test.ts` → 8 passed; `tsc --noEmit` clean.
- Updated tests assert the dual emission and the writer round-trip.
- **End-to-end against kimi 0.12.1** with the real synced groups: post-fix, `cd /tmp/.../sub && git status` and `git push --dry-run origin feature/test` (slashed branch) both auto-approve with **zero approval events** — the same commands that prompted before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)