### PR TITLE
Cross-platform clipboard + macOS-only guards + upgrade [version]

### DIFF
--- a/docs/computer.md
+++ b/docs/computer.md
@@ -4,7 +4,7 @@ Drive native macOS apps from AI agents via the Accessibility API.
 
 ## Overview
 
-`agents computer` controls macOS applications through the Accessibility
+`agents computers` controls macOS applications through the Accessibility
 (`AXUIElement`) and Screen Recording frameworks. It requires a separate helper
 app (`Computer Helper.app`) installed in `/Applications/` with two macOS TCC
 grants: Accessibility and Screen Recording.
@@ -25,7 +25,7 @@ macOS APIs (`launchctl`, `AXUIElement`, `CoreGraphics`).
 ```
 agent process
      │
-     │  agents computer <subcommand>
+     │  agents computers <subcommand>
      ▼
   CLI (computer.ts)
      │
@@ -62,7 +62,7 @@ different process.
 ### 1. Install the helper
 
 ```bash
-agents computer install-helper
+agents computers install-helper
 ```
 
 This copies `Computer Helper.app` to `/Applications/Computer Helper.app`,
@@ -106,7 +106,7 @@ defaults read /Applications/SomeApp.app/Contents/Info CFBundleIdentifier
 ### 4. Start the daemon when you need it
 
 ```bash
-agents computer start
+agents computers start
 ```
 
 The daemon is not always-on. Start it when you need it, stop it when done.
@@ -115,19 +115,19 @@ an always-on background listener that can drive any app is a large attack
 surface.
 
 ```bash
-agents computer stop   # when finished
+agents computers stop   # when finished
 ```
 
 ## Command Reference
 
 | Command | Description |
 |---------|-------------|
-| `agents computer install-helper` | Copy helper to /Applications/, write LaunchAgent plist |
-| `agents computer start` | Load the LaunchAgent and start the daemon |
-| `agents computer stop` | Unload the LaunchAgent, remove the socket |
-| `agents computer reload` | Reload the allow-list policy from ~/.agents/permissions/groups/ (SIGHUP the daemon) |
-| `agents computer status` | Report install state, daemon state, TCC trust, policy, and peer list |
-| `agents computer screenshot` | Capture a JPEG of the frontmost window of an allowed app |
+| `agents computers install-helper` | Copy helper to /Applications/, write LaunchAgent plist |
+| `agents computers start` | Load the LaunchAgent and start the daemon |
+| `agents computers stop` | Unload the LaunchAgent, remove the socket |
+| `agents computers reload` | Reload the allow-list policy from ~/.agents/permissions/groups/ (SIGHUP the daemon) |
+| `agents computers status` | Report install state, daemon state, TCC trust, policy, and peer list |
+| `agents computers screenshot` | Capture a JPEG of the frontmost window of an allowed app |
 
 `screenshot` flags:
 
@@ -154,27 +154,27 @@ agents computer stop   # when finished
 
 ```bash
 # Install
-agents computer install-helper
+agents computers install-helper
 
 # Grant permissions in System Settings (manual step)
 # Then:
-agents computer start
-agents computer status
+agents computers start
+agents computers status
 # trust: granted means you are ready
 ```
 
 ### 2. Screenshot the active app
 
 ```bash
-agents computer start
+agents computers start
 
 # Bring the app you want to the foreground, then:
-agents computer screenshot --out /tmp/app-snapshot.jpg
+agents computers screenshot --out /tmp/app-snapshot.jpg
 
 # Or target a specific app by bundle ID:
-agents computer screenshot --bundle com.apple.mail --out /tmp/mail.jpg
+agents computers screenshot --bundle com.apple.mail --out /tmp/mail.jpg
 
-agents computer stop
+agents computers stop
 ```
 
 ### 3. Add a new app to the allow list, then reload
@@ -186,31 +186,31 @@ cat >> ~/.agents/permissions/groups/computer.yaml << 'EOF'
 EOF
 
 # Reload without restarting the daemon
-agents computer reload
+agents computers reload
 # Output: policy: 4 apps allowed (com.apple.mail, com.apple.notes, ...)
 
 # Now screenshot Calendar
-agents computer screenshot --bundle com.apple.calendar --out /tmp/calendar.jpg
+agents computers screenshot --bundle com.apple.calendar --out /tmp/calendar.jpg
 ```
 
 ### 4. Automate a native macOS app from an agent
 
 The computer helper exposes JSON-RPC methods (`list_apps`, `screenshot`,
 `trust_status`) over the socket. Agents calling these directly should use
-`agents computer start` to bring the daemon up, then target the socket at
+`agents computers start` to bring the daemon up, then target the socket at
 `~/.agents/.cache/helpers/computer.sock`. The CLI is the intended interface;
 see `src/lib/computer-rpc.ts` for the raw wire format if you need to call the
 socket from another process.
 
 ```bash
-agents computer start
-agents computer status          # confirm trust: granted
+agents computers start
+agents computers status          # confirm trust: granted
 
 # Screenshot Finder and feed the image to your agent
-agents computer screenshot --bundle com.apple.finder --out /tmp/finder.jpg
+agents computers screenshot --bundle com.apple.finder --out /tmp/finder.jpg
 
 # When automation is complete:
-agents computer stop
+agents computers stop
 ```
 
 ## Demo

--- a/src/commands/computer.ts
+++ b/src/commands/computer.ts
@@ -28,8 +28,16 @@ const COMPUTER_HELP_GROUPS = [
 
 export function registerComputerCommand(program: Command): void {
   const computer = program
-    .command('computer')
-    .description('Drive macOS apps via Accessibility — list, screenshot, click, type');
+    .command('computers')
+    .description('Drive macOS apps via Accessibility — list, screenshot, click, type (macOS only)')
+    // The whole subsystem is macOS Accessibility / TCC. Fail fast with a clear
+    // message on other platforms instead of a downstream ENOENT / launchctl error.
+    .hook('preAction', () => {
+      if (process.platform !== 'darwin') {
+        console.error('agents computers: macOS only — it drives apps via the macOS Accessibility API.');
+        process.exit(1);
+      }
+    });
 
   registerComputerSubcommands(computer);
   registerCommandGroups(computer, COMPUTER_HELP_GROUPS);

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -1099,15 +1099,14 @@ Examples:
       }
 
       if (opts.copy) {
-        const { spawn } = await import('child_process');
-        const proc = spawn('pbcopy', [], { stdio: ['pipe', 'inherit', 'inherit'] });
-        proc.stdin.write(password);
-        proc.stdin.end();
-        await new Promise<void>((resolve, reject) => {
-          proc.on('close', (code) => code === 0 ? resolve() : reject(new Error('pbcopy failed')));
-          proc.on('error', reject);
-        });
-        console.log(chalk.green(`Password copied to clipboard (${length} chars)`));
+        try {
+          await copyToClipboard(password);
+          console.log(chalk.green(`Password copied to clipboard (${length} chars)`));
+        } catch (err) {
+          console.error(chalk.red(`Clipboard copy failed: ${(err as Error).message}`));
+          console.error(chalk.gray('Re-run without --copy to print the password instead.'));
+          process.exitCode = 1;
+        }
       } else {
         console.log(password);
       }
@@ -1115,4 +1114,44 @@ Examples:
 
   registerSecretsSyncCommands(cmd);
   registerSecretsMigrateAclCommand(cmd);
+}
+
+/**
+ * Copy text to the system clipboard, cross-platform.
+ * macOS: `pbcopy`. Windows: `clip`. Linux: tries `wl-copy` (Wayland), then
+ * `xclip`, then `xsel` (X11). Throws with an install hint if none are present.
+ */
+async function copyToClipboard(text: string): Promise<void> {
+  const { spawn } = await import('child_process');
+  const candidates: Array<[string, string[]]> =
+    process.platform === 'darwin'
+      ? [['pbcopy', []]]
+      : process.platform === 'win32'
+        ? [['clip', []]]
+        : [
+            ['wl-copy', []],
+            ['xclip', ['-selection', 'clipboard']],
+            ['xsel', ['--clipboard', '--input']],
+          ];
+
+  let lastErr: Error | null = null;
+  for (const [cmd, args] of candidates) {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const proc = spawn(cmd, args, { stdio: ['pipe', 'ignore', 'ignore'] });
+        proc.on('error', reject);
+        proc.on('close', (code) => (code === 0 ? resolve() : reject(new Error(`${cmd} exited ${code}`))));
+        proc.stdin.write(text);
+        proc.stdin.end();
+      });
+      return;
+    } catch (err) {
+      lastErr = err as Error;
+    }
+  }
+  const hint =
+    process.platform === 'linux'
+      ? ' Install one: wl-clipboard (Wayland) or xclip / xsel (X11).'
+      : '';
+  throw new Error(`no clipboard tool available (${lastErr?.message ?? 'none found'}).${hint}`);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,9 +240,13 @@ async function showWhatsNew(fromVersion: string, toVersion: string): Promise<voi
       const versionMatch = line.match(/^## (\d+\.\d+\.\d+)/);
       if (versionMatch) {
         currentVersion = versionMatch[1];
-        const isNewer = currentVersion !== fromVersion &&
-          compareVersions(currentVersion, fromVersion) > 0;
-        inRelevantSection = isNewer;
+        // Only the range the user actually moved through: (fromVersion, toVersion].
+        // Bounding the top end matters when upgrading to a specific older
+        // version, and guards against a changelog that lists unreleased entries.
+        const inRange =
+          compareVersions(currentVersion, fromVersion) > 0 &&
+          compareVersions(currentVersion, toVersion) <= 0;
+        inRelevantSection = inRange;
         if (inRelevantSection) {
           relevantChanges.push('');
           relevantChanges.push(chalk.bold(`v${currentVersion}`));
@@ -303,11 +307,14 @@ function saveUpdateCheck(latestVersion: string): void {
 }
 
 /** Fetch the exact latest npm version plus its registry integrity hash. */
-async function fetchLatestNpmPackageMetadata(timeoutMs = 5000): Promise<NpmPackageMetadata> {
-  const response = await fetch(`https://registry.npmjs.org/${NPM_PACKAGE_NAME}/latest`, {
+async function fetchNpmPackageMetadata(versionOrTag = 'latest', timeoutMs = 5000): Promise<NpmPackageMetadata> {
+  const response = await fetch(`https://registry.npmjs.org/${NPM_PACKAGE_NAME}/${versionOrTag}`, {
     signal: AbortSignal.timeout(timeoutMs),
   });
   if (!response.ok) {
+    if (response.status === 404) {
+      throw new Error(`${NPM_PACKAGE_NAME}@${versionOrTag} not found on npm`);
+    }
     throw new Error('Could not reach npm registry');
   }
 
@@ -371,7 +378,7 @@ async function promptUpgrade(latestVersion: string): Promise<void> {
     const { spawnSync } = await import('child_process');
     let spinner = ora('Resolving package metadata...').start();
     try {
-      const metadata = await fetchLatestNpmPackageMetadata();
+      const metadata = await fetchNpmPackageMetadata();
       spinner.succeed(`Resolved ${NPM_PACKAGE_NAME}@${metadata.version}`);
       printResolvedPackage(metadata);
 
@@ -677,29 +684,34 @@ for (const alias of ['jobs', 'cron']) {
 
 program
     .command('upgrade')
-    .description('Upgrade agents-cli to the latest version')
+    .description('Upgrade agents-cli to the latest version (or a specific [version])')
+    .argument('[version]', 'Target version or dist-tag to install (default: latest)')
     .option('-y, --yes', 'Install without an interactive confirmation prompt')
-    .action(async (options: { yes?: boolean }) => {
-      let spinner = ora('Checking for updates...').start();
+    .action(async (version: string | undefined, options: { yes?: boolean }) => {
+      const target = version ?? 'latest';
+      let spinner = ora(version ? `Resolving ${NPM_PACKAGE_NAME}@${target}...` : 'Checking for updates...').start();
       try {
-        const metadata = await fetchLatestNpmPackageMetadata();
-        const latestVersion = metadata.version;
+        const metadata = await fetchNpmPackageMetadata(target);
+        const resolvedVersion = metadata.version;
 
-        if (latestVersion === VERSION) {
-          spinner.succeed(`Already on latest version (${VERSION})`);
+        if (resolvedVersion === VERSION) {
+          spinner.succeed(`Already on ${VERSION}`);
           return;
         }
 
-        if (compareVersions(latestVersion, VERSION) <= 0) {
-          spinner.succeed(`Already ahead of latest (${VERSION} >= ${latestVersion})`);
+        // For `latest` (no explicit version) skip when already ahead. When a
+        // version is named explicitly, honor it even if it's a downgrade.
+        if (!version && compareVersions(resolvedVersion, VERSION) <= 0) {
+          spinner.succeed(`Already ahead of latest (${VERSION} >= ${resolvedVersion})`);
           return;
         }
 
-        spinner.succeed(`Resolved ${NPM_PACKAGE_NAME}@${latestVersion}`);
+        const direction = compareVersions(resolvedVersion, VERSION) < 0 ? 'Downgrade' : 'Upgrade';
+        spinner.succeed(`Resolved ${NPM_PACKAGE_NAME}@${resolvedVersion}`);
         printResolvedPackage(metadata);
         if (isInteractiveTerminal() && !options.yes) {
           const approved = await confirm({
-            message: `Install ${NPM_PACKAGE_NAME}@${latestVersion}?`,
+            message: `Install ${NPM_PACKAGE_NAME}@${resolvedVersion}?`,
             default: false,
           });
           if (!approved) {
@@ -708,13 +720,16 @@ program
           }
         }
 
-        spinner = ora(`Upgrading ${VERSION} -> ${latestVersion}...`).start();
+        spinner = ora(`${direction === 'Downgrade' ? 'Downgrading' : 'Upgrading'} ${VERSION} -> ${resolvedVersion}...`).start();
         await installResolvedPackage(metadata);
-        spinner.succeed(`Upgraded to ${latestVersion}`);
-        await showWhatsNew(VERSION, latestVersion);
+        spinner.succeed(`${direction}d to ${resolvedVersion}`);
+        // Only show the changelog for a genuine upgrade range.
+        if (compareVersions(resolvedVersion, VERSION) > 0) {
+          await showWhatsNew(VERSION, resolvedVersion);
+        }
       } catch (err) {
         spinner.fail('Upgrade failed');
-        console.log(chalk.gray('Run manually: agents upgrade --yes'));
+        console.log(chalk.gray(`Run manually: agents upgrade ${version ? version + ' ' : ''}--yes`));
       }
     });
 

--- a/src/lib/browser/chrome.ts
+++ b/src/lib/browser/chrome.ts
@@ -149,6 +149,9 @@ export function findBrowserPath(browserType: BrowserType, customBinary?: string)
     }
   }
 
+  if (browserType === 'comet' && platform !== 'darwin') {
+    throw new Error('Browser "comet" is macOS-only (Comet is a macOS Chromium fork). Use chrome, chromium, brave, or edge on this platform.');
+  }
   throw new Error(`Browser "${browserType}" not found. Install it first.`);
 }
 


### PR DESCRIPTION
Follow-ups from the Linux feature-support audit, plus the requested `upgrade`/`computers` changes.

## Changes

**1. `secrets generate --copy` works off macOS** (`secrets.ts`)
It hardcoded `pbcopy` and threw `pbcopy failed` on Linux/Windows. New `copyToClipboard` tries the right tool per platform — `pbcopy` (macOS), `clip` (Windows), `wl-copy` → `xclip` → `xsel` (Linux). On failure it reports cleanly and tells you to re-run without `--copy` (it does **not** print the password — `--copy` means "don't print").

**2. `agents computer` → `agents computers`, with a macOS-only guard** (`computer.ts`)
- Renamed to `computers`. Commander prefix-matches the old `computer`, so existing usage and muscle memory keep working.
- A `preAction` guard makes non-macOS exit with `agents computers: macOS only` instead of a downstream `ENOENT`/`launchctl` error. (`docs/computer.md` updated.)
- Bonus: `--browser comet` on non-macOS now explains Comet is a macOS-only Chromium fork instead of a generic "not found" (`browser/chrome.ts`).

**3. `agents upgrade [version]` + scoped changelog** (`index.ts`)
- `agents upgrade` now takes an optional `[version]` (specific version or dist-tag; default `latest`). An explicit version is honored even if it's a downgrade. Generalized the npm metadata fetch to any version with a clean 404 message.
- `showWhatsNew` now bounds the "What's new" output to **`(fromVersion, toVersion]`** — the range you actually moved through — instead of everything newer than your old version.

## Verification
- `tsc --noEmit` clean; `versions` tests pass.
- `agents upgrade --help` shows `[version]`; `agents computers --help` shows the renamed command with "(macOS only)"; `agents computer` still resolves via prefix match.

No new unit tests: these surfaces are spawn/network-bound (clipboard tools, npm registry, the macOS Accessibility helper) and aren't cleanly testable without mocking, which this repo bans. Behavior verified by running the built CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)