### PR TITLE
feat(pty): native Windows support — named-pipe transport + shell-aware runtime (#233)

### DIFF
--- a/src/lib/__tests__/pty-server.test.ts
+++ b/src/lib/__tests__/pty-server.test.ts
@@ -27,7 +27,7 @@ const tmpBase = process.platform === 'darwin' ? '/tmp' : os.tmpdir();
 const TEST_HOME = fs.mkdtempSync(path.join(tmpBase, 'agents-pty-test-'));
 process.env.HOME = TEST_HOME;
 
-const { runPtyServer, captureProcessStartTime, getSocketPath } = await import('../pty-server.js');
+const { runPtyServer, captureProcessStartTime, getSocketPath, derivePtyEndpoint, buildSentinelCommand } = await import('../pty-server.js');
 
 // The multiarch fork BAKES Linux prebuilds (glibc + musl, all Node ABIs incl.
 // 22/24) into its npm tarball, so the native binary is present on Linux even
@@ -133,6 +133,54 @@ describe.skipIf(!nodePtyLoadable)('PTY duplicate-spawn race resolution', () => {
     await fsp.rm(pidPath, { force: true });
     await fsp.rm(socketPath, { force: true });
   }, 15_000);
+});
+
+describe('derivePtyEndpoint (cross-platform transport)', () => {
+  const ptyDir = '/home/u/.agents/.cache/helpers/pty';
+
+  it('returns a pty.sock file path on unix platforms', () => {
+    expect(derivePtyEndpoint('linux', ptyDir)).toBe(path.join(ptyDir, 'pty.sock'));
+    expect(derivePtyEndpoint('darwin', ptyDir)).toBe(path.join(ptyDir, 'pty.sock'));
+  });
+
+  it('returns a \\\\.\\pipe\\ named pipe on win32 — never a filesystem path', () => {
+    const winDir = 'C:\\Users\\u\\.agents\\.cache\\helpers\\pty';
+    const endpoint = derivePtyEndpoint('win32', winDir);
+    // Named pipes must use the \\.\pipe\ prefix or net.createServer rejects them.
+    expect(endpoint).toMatch(/^\\\\\.\\pipe\\agents-pty-[0-9a-f]{16}$/);
+    // It must NOT be a real path under the scratch dir — fs.existsSync would
+    // always report false for a pipe, breaking the readiness probe if it were.
+    expect(endpoint.startsWith(winDir)).toBe(false);
+  });
+
+  it('is stable for a given dir and unique per dir (per-user pipe isolation)', () => {
+    const a1 = derivePtyEndpoint('win32', 'C:\\Users\\alice\\pty');
+    const a2 = derivePtyEndpoint('win32', 'C:\\Users\\alice\\pty');
+    const b = derivePtyEndpoint('win32', 'C:\\Users\\bob\\pty');
+    expect(a1).toBe(a2);        // same dir -> same pipe (client/server agree)
+    expect(a1).not.toBe(b);     // different user -> different pipe
+  });
+});
+
+describe('buildSentinelCommand (shell-aware exec wrapper)', () => {
+  it('uses POSIX `;` + `$?` for sh/zsh/bash', () => {
+    expect(buildSentinelCommand('/bin/zsh', 'ls')).toBe('ls; echo "__AGENTS_PTY_DONE__:$?"');
+    expect(buildSentinelCommand('/bin/bash', 'ls')).toBe('ls; echo "__AGENTS_PTY_DONE__:$?"');
+  });
+
+  it('uses cmd.exe `&` + %errorlevel% so the marker always prints', () => {
+    // `&&` would skip the echo on failure; `&` must be used so completion is
+    // always detected regardless of the command's exit status.
+    expect(buildSentinelCommand('C:\\Windows\\System32\\cmd.exe', 'dir'))
+      .toBe('dir & echo __AGENTS_PTY_DONE__:%errorlevel%');
+  });
+
+  it('uses PowerShell `;` + $LASTEXITCODE', () => {
+    expect(buildSentinelCommand('powershell.exe', 'Get-ChildItem'))
+      .toBe('Get-ChildItem; echo "__AGENTS_PTY_DONE__:$LASTEXITCODE"');
+    expect(buildSentinelCommand('pwsh', 'Get-ChildItem'))
+      .toBe('Get-ChildItem; echo "__AGENTS_PTY_DONE__:$LASTEXITCODE"');
+  });
 });
 
 describe('captureProcessStartTime', () => {

--- a/src/lib/pty-client.ts
+++ b/src/lib/pty-client.ts
@@ -14,6 +14,7 @@ import { getSocketPath, getPtyPidPath, getPtyLogPath, isPtyServerRunning } from 
 
 const CONNECT_TIMEOUT_MS = 5000;
 const RESPONSE_TIMEOUT_MS = 30000;
+const IS_WINDOWS = process.platform === 'win32';
 
 /** JSON response envelope from the PTY server. */
 export interface PtyResponse {
@@ -55,11 +56,13 @@ async function ensureServer(): Promise<void> {
   child.unref();
   fs.closeSync(logFd);
 
-  // Wait for socket to appear
+  // Wait for the server to become reachable. On Unix the socket file appearing is
+  // a cheap readiness signal; on Windows the named pipe is not a filesystem object
+  // (fs.existsSync always returns false), so we just attempt the ping directly.
   const socketPath = getSocketPath();
   const deadline = Date.now() + 5000;
   while (Date.now() < deadline) {
-    if (fs.existsSync(socketPath)) {
+    if (IS_WINDOWS || fs.existsSync(socketPath)) {
       // Verify we can connect
       try {
         await sendRequest({ action: 'ping' });
@@ -85,9 +88,11 @@ function getServerSpawnArgs(): { bin: string; args: string[] } {
     }
   } catch {}
 
-  // Fallback: use the globally installed agents command
+  // Fallback: use the globally installed agents command. `which` is Unix-only;
+  // Windows uses `where`, which can return multiple lines — take the first.
   try {
-    const agentsBin = execSync('which agents', { encoding: 'utf-8' }).trim();
+    const lookup = IS_WINDOWS ? 'where agents' : 'which agents';
+    const agentsBin = execSync(lookup, { encoding: 'utf-8' }).split(/\r?\n/)[0].trim();
     if (agentsBin) {
       return { bin: agentsBin, args: ['pty', '_server'] };
     }
@@ -103,7 +108,10 @@ function sendRequest(req: any): Promise<PtyResponse> {
   return new Promise((resolve, reject) => {
     const socketPath = getSocketPath();
 
-    if (!fs.existsSync(socketPath)) {
+    // On Unix a missing socket file means the server isn't up — fail fast with a
+    // clear message. On Windows the named pipe isn't a filesystem object, so we
+    // skip the probe and let createConnection surface ENOENT/connection errors.
+    if (!IS_WINDOWS && !fs.existsSync(socketPath)) {
       reject(new Error('PTY server socket not found. Is the server running?'));
       return;
     }

--- a/src/lib/pty-server.ts
+++ b/src/lib/pty-server.ts
@@ -53,6 +53,7 @@ export function captureProcessStartTime(pid: number): string | null {
 
 // --- Constants ---
 
+const IS_WINDOWS = process.platform === 'win32';
 const SENTINEL = '__AGENTS_PTY_DONE__';
 const SOCKET_NAME = 'pty.sock';
 const PID_FILE = 'pty.pid';
@@ -97,13 +98,54 @@ const PTY_ENV_ALLOWLIST = [
   'NO_COLOR', 'FORCE_COLOR',
 ];
 
+/**
+ * Windows allowlist. cmd.exe / PowerShell refuse to start (or misbehave) without
+ * SystemRoot, ComSpec, PATHEXT and the USERPROFILE/APPDATA family, so a Unix-style
+ * allowlist would spawn a broken shell. PATH/TERM/color/NODE vars are shared with
+ * the Unix list; the rest are Windows-specific.
+ */
+const PTY_ENV_ALLOWLIST_WIN = [
+  'SystemRoot', 'SystemDrive', 'windir', 'ComSpec', 'PATH', 'PATHEXT',
+  'TEMP', 'TMP', 'USERPROFILE', 'HOMEDRIVE', 'HOMEPATH', 'HOME',
+  'APPDATA', 'LOCALAPPDATA', 'PROGRAMFILES', 'PROGRAMDATA',
+  'USERNAME', 'USERDOMAIN', 'COMPUTERNAME', 'OS',
+  'PROCESSOR_ARCHITECTURE', 'NUMBER_OF_PROCESSORS',
+  'TERM', 'COLORTERM', 'NO_COLOR', 'FORCE_COLOR',
+  'NODE_PATH', 'BUN_INSTALL',
+];
+
 function buildPtyEnv(): Record<string, string> {
   const env: Record<string, string> = {};
-  for (const key of PTY_ENV_ALLOWLIST) {
+  const allowlist = IS_WINDOWS ? PTY_ENV_ALLOWLIST_WIN : PTY_ENV_ALLOWLIST;
+  for (const key of allowlist) {
     const v = process.env[key];
     if (v !== undefined) env[key] = v;
   }
   return env;
+}
+
+/**
+ * Wrap a user command so a `__SENTINEL__:<exit>` line is printed after it
+ * finishes — that line drives completion detection in the exec/read flow.
+ * The separator and exit-code variable are shell-family specific:
+ *   POSIX sh/zsh/bash : `cmd; echo "S:$?"`
+ *   PowerShell        : `cmd; echo "S:$LASTEXITCODE"`
+ *   cmd.exe           : `cmd & echo S:%errorlevel%`  (`&` always runs the echo)
+ * Only the completion marker matters; the numeric exit code is informational
+ * (the authoritative code comes from node-pty's onExit).
+ */
+export function buildSentinelCommand(shell: string, command: string): string {
+  // Split on both separators: a Windows shell path (`C:\…\cmd.exe`) must be
+  // recognized even when this code runs under POSIX path.basename, which does
+  // not treat `\` as a separator.
+  const name = (shell.split(/[\\/]/).pop() || shell).toLowerCase();
+  if (name === 'cmd.exe' || name === 'cmd') {
+    return `${command} & echo ${SENTINEL}:%errorlevel%`;
+  }
+  if (name === 'powershell.exe' || name === 'powershell' || name === 'pwsh.exe' || name === 'pwsh') {
+    return `${command}; echo "${SENTINEL}:$LASTEXITCODE"`;
+  }
+  return `${command}; echo "${SENTINEL}:$?"`;
 }
 
 /** Get the PTY helper directory, creating it if needed. */
@@ -113,9 +155,28 @@ function getPtyDir(): string {
   return dir;
 }
 
-/** Get the unix socket path for the PTY server. */
+/**
+ * Resolve the IPC endpoint for a given platform + PTY scratch dir. Pure so both
+ * branches are testable without stubbing process.platform.
+ *
+ * Unix: an AF_UNIX socket file inside the scratch dir.
+ * Windows: a named pipe (`\\.\pipe\…`). Named pipes are NOT filesystem objects,
+ * so the name is derived from a hash of the (per-user) scratch dir to keep it
+ * stable across invocations and isolated per user — and callers must never probe
+ * it with fs.existsSync (it always reports false). Both forms are accepted by
+ * net.createServer/createConnection.
+ */
+export function derivePtyEndpoint(platform: NodeJS.Platform, ptyDir: string): string {
+  if (platform === 'win32') {
+    const hash = crypto.createHash('sha1').update(ptyDir).digest('hex').slice(0, 16);
+    return `\\\\.\\pipe\\agents-pty-${hash}`;
+  }
+  return path.join(ptyDir, SOCKET_NAME);
+}
+
+/** Get the IPC endpoint the PTY server listens on / clients connect to. */
 export function getSocketPath(): string {
-  return path.join(getPtyDir(), SOCKET_NAME);
+  return derivePtyEndpoint(process.platform, getPtyDir());
 }
 
 /** Get the path to the PTY server PID file. */
@@ -244,8 +305,10 @@ export async function runPtyServer(): Promise<void> {
   // We own the PID slot; ensure it's released on any exit path, not just SIGTERM/SIGINT.
   process.on('exit', () => { try { fs.unlinkSync(pidPath); } catch {} });
 
-  // Remove stale socket from a prior crashed server. Safe now that we hold the PID slot.
-  if (fs.existsSync(socketPath)) {
+  // Remove stale socket from a prior crashed server. Safe now that we hold the PID
+  // slot. Windows named pipes are not filesystem inodes — they vanish with their
+  // owning process, so there's nothing to unlink (and existsSync always reports false).
+  if (!IS_WINDOWS && fs.existsSync(socketPath)) {
     try { fs.unlinkSync(socketPath); } catch {}
   }
 
@@ -309,8 +372,10 @@ export async function runPtyServer(): Promise<void> {
       case 'start': {
         const rows = req.params?.rows || 24;
         const cols = req.params?.cols || 120;
-        const shell = req.params?.shell || process.env.SHELL || 'zsh';
-        const cwd = req.params?.cwd || process.env.HOME || '/';
+        const shell = req.params?.shell
+          || (IS_WINDOWS ? (process.env.ComSpec || 'powershell.exe') : (process.env.SHELL || 'zsh'));
+        const cwd = req.params?.cwd
+          || (IS_WINDOWS ? (process.env.USERPROFILE || process.env.HOME || process.cwd()) : (process.env.HOME || '/'));
         const id = generateId();
 
         let ptyProcess: any;
@@ -390,7 +455,9 @@ export async function runPtyServer(): Promise<void> {
         session.activeCommand = command;
         session.pendingOutput = '';
 
-        session.pty.write(`${command}; echo "${SENTINEL}:$?"\n`);
+        // Windows conpty submits on CR; POSIX line discipline expects LF.
+        const submit = IS_WINDOWS ? '\r' : '\n';
+        session.pty.write(`${buildSentinelCommand(session.shell, command)}${submit}`);
         session.lastActivity = Date.now();
 
         return { ok: true, submitted: true };
@@ -581,14 +648,20 @@ export async function runPtyServer(): Promise<void> {
   // any local user with execute on the parent dir could connect to the socket
   // during the listen()-to-chmod() window. macOS BSD AF_UNIX semantics make
   // socket mode advisory only, so the parent dir is the real boundary.
+  //
+  // On Windows the transport is a named pipe, not a filesystem inode: chmod/umask
+  // are no-ops (and umask throws in some Node builds), and pipe ACLs default to
+  // the creating user. So we skip the Unix hardening entirely there.
   const agentsDir = getPtyDirRoot();
   fs.mkdirSync(agentsDir, { recursive: true });
-  fs.chmodSync(agentsDir, 0o700);
+  if (!IS_WINDOWS) {
+    fs.chmodSync(agentsDir, 0o700);
 
-  // umask covers any inherited group/other bits while listen() is creating
-  // the socket inode — it only matters for the unobservable instant before
-  // we can chmod the inode itself.
-  process.umask(0o077);
+    // umask covers any inherited group/other bits while listen() is creating
+    // the socket inode — it only matters for the unobservable instant before
+    // we can chmod the inode itself.
+    process.umask(0o077);
+  }
 
   await new Promise<void>((resolve) => {
     server.listen(socketPath, () => resolve());
@@ -596,8 +669,10 @@ export async function runPtyServer(): Promise<void> {
 
   // Surface chmod failures: a 0o600 socket is a load-bearing security
   // assumption, not a nice-to-have. If we can't lock it down, refuse to
-  // start so the caller learns immediately.
-  fs.chmodSync(socketPath, 0o600);
+  // start so the caller learns immediately. (No-op on Windows named pipes.)
+  if (!IS_WINDOWS) {
+    fs.chmodSync(socketPath, 0o600);
+  }
 
   log('INFO', `PTY server started (PID: ${process.pid}, socket: ${socketPath})`);
 
@@ -610,7 +685,8 @@ export async function runPtyServer(): Promise<void> {
     sessions.clear();
     clearInterval(cleanupInterval);
     server.close();
-    try { fs.unlinkSync(socketPath); } catch {}
+    // Named pipes are reclaimed by the OS on close; only Unix sockets leave a file.
+    if (!IS_WINDOWS) { try { fs.unlinkSync(socketPath); } catch {} }
     try { fs.unlinkSync(getPtyPidPath()); } catch {}
     process.exit(0);
   }


### PR DESCRIPTION
Closes #233.

`agents pty` was architected around Unix sockets and POSIX shells, so on native Windows it was broken-to-unusable. This makes the transport and runtime platform-aware **without changing any Unix behavior**.

## What was broken on Windows (verified against `origin/main`)
- `getSocketPath()` returns a filesystem `pty.sock` path; `server.listen(socketPath)` + `fs.chmodSync(socketPath, 0o600)` are Unix-socket-only (`pty-server.ts:117,600`).
- Client gates every request on `fs.existsSync(socketPath)` (`pty-client.ts:62,106`) — a named pipe is **not** a filesystem object, so that always returns false and rejects.
- Shell default falls back to `zsh` (`pty-server.ts:312`); `cwd` to `$HOME`.
- `exec` sentinel uses POSIX `; echo "S:$?"` (`pty-server.ts:434`).
- Spawn-arg fallback shells out to `which` (`pty-client.ts:90`).

## Changes

**Transport**
- `derivePtyEndpoint(platform, dir)`: Unix → AF_UNIX socket file; Windows → `\\.\pipe\agents-pty-<hash>` named pipe (hash of the per-user scratch dir → client/server agree, isolated per user). `getSocketPath()` delegates to it. Pure + exported → both branches unit-tested.
- On Windows, skip every filesystem assumption about the endpoint: stale-socket cleanup, the readiness `existsSync` probe (ping directly), the `sendRequest` `existsSync` guard, and the Unix hardening (`chmod` dir/socket, `umask`, shutdown `unlink`). Pipe ACLs default to the creating user; `umask` throws in some Node builds.

**Runtime**
- Shell default `ComSpec || powershell.exe`; `cwd` default `USERPROFILE`.
- Windows env allowlist (`SystemRoot`, `ComSpec`, `PATHEXT`, `USERPROFILE`/`APPDATA` family, …) — cmd/PowerShell won't start without these.
- `buildSentinelCommand(shell, command)`: shell-aware exec wrapper — cmd.exe `& echo S:%errorlevel%`, PowerShell `; echo "S:$LASTEXITCODE"`, POSIX `; echo "S:$?"`. Submit with CR on conpty, LF on POSIX.
- `getServerSpawnArgs` falls back to `where` instead of `which`.

## Tests
- `derivePtyEndpoint`: both branches — pipe format `^\\.\pipe\agents-pty-[0-9a-f]{16}$`, never a filesystem path, stable per dir, unique per user.
- `buildSentinelCommand`: all three shell families (the cmd.exe `&`-not-`&&` detail is pinned — `&&` would skip the marker on failure).
- Existing server-boot (socket 0o600 / dir 0o700) + duplicate-spawn race tests unchanged; they run on Linux CI (the multiarch fork bakes Linux prebuilds).

## Verification
- **Unix path, end-to-end on macOS:** real `zsh` session, `exec` round-trips `HELLO_FROM_PTY_42` through node-pty + the sentinel/read loop, then `stop`. No regression.
- **Native Windows: pending your test on Parallels.** Caveat: the `@homebridge/node-pty-prebuilt-multiarch` fork ships **win32-x64 / win32-ia32 only — no win32-arm64**. On Windows-on-ARM (Parallels) install an **x64 Node** build; the win32-x64 binary loads under Windows-on-ARM x64 emulation. (Confirmed against the fork's v0.13.1 release assets: Node ABIs v127/v137 = Node 22/24 present for win32-x64.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)