### PR TITLE
fix(computer-helper): make synthesized input land on UXP/Chromium/canvas surfaces

### DIFF
--- a/packages/computer-helper/Sources/ComputerHelper/AX.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/AX.swift
@@ -80,17 +80,14 @@ enum AX {
         // a click at those screen coords. Used for canvas apps, games, and any
         // element the AX tree doesn't expose — the accessibility equivalent of
         // browser_click's coordinate mode.
+        let clickCount = Params.intOpt(params, "count") ?? 1
+        let background = Params.bool(params, "background")
         if Params.stringOpt(params, "element_id") == nil {
             if let x = Params.intOpt(params, "x"), let y = Params.intOpt(params, "y") {
                 let pt = CGPoint(x: x, y: y)
                 CursorSprite.shared.flash(at: pt)
-                guard let down = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: pt, mouseButton: .left),
-                      let up = CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: pt, mouseButton: .left) else {
-                    throw RPCError(code: "action_failed", message: "could not create click event")
-                }
-                down.postToPid(pid_t(pid))
-                up.postToPid(pid_t(pid))
-                return ["ok": true, "action": "CGEvent", "at": [x, y]]
+                let method = try EventSynth.click(at: pt, pid: pid, button: "left", clickCount: clickCount, background: background)
+                return ["ok": true, "action": method, "at": [x, y]]
             }
             throw RPCError.invalid("pass either element_id or x,y")
         }
@@ -154,13 +151,8 @@ enum AX {
             throw RPCError(code: "action_failed", message: "element has no frame and no AXPress action")
         }
         CursorSprite.shared.flash(at: center)
-        guard let down = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: center, mouseButton: .left),
-              let up = CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: center, mouseButton: .left) else {
-            throw RPCError(code: "action_failed", message: "could not create click event")
-        }
-        down.postToPid(pid_t(pid))
-        up.postToPid(pid_t(pid))
-        return ["ok": true, "action": "CGEvent", "at": [Int(center.x), Int(center.y)]]
+        let method = try EventSynth.click(at: center, pid: pid, button: "left", clickCount: clickCount, background: background)
+        return ["ok": true, "action": method, "at": [Int(center.x), Int(center.y)]]
     }
 
     // MARK: - type / setValue
@@ -206,6 +198,84 @@ enum AX {
         if err != .success {
             throw RPCError(code: "action_failed", message: "AXSetAttributeValue=\(err.rawValue)")
         }
+        // Many fields (Photoshop's transform W/H, form inputs) only push the
+        // written value into the document model on Return/blur — AXValue alone
+        // updates the display but is never committed. Opt-in commit closes that
+        // gap: prefer the AX-native AXConfirm action, else synthesize Return.
+        var committed = false
+        if Params.bool(params, "commit") {
+            committed = commitField(el: el, pid: pid)
+        }
+        return ["ok": true, "committed": committed]
+    }
+
+    // Push a just-written field value into the app's model. AXConfirm is the
+    // documented AX commit; when unsupported, a Return keystroke to the pid is
+    // the universal fallback (the field is focused after setValue).
+    private static func commitField(el: AXUIElement, pid: Int) -> Bool {
+        let actions = copyActionNames(el)
+        if actions.contains("AXConfirm") {
+            if AXUIElementPerformAction(el, "AXConfirm" as CFString) == .success {
+                return true
+            }
+        }
+        if let down = CGEvent(keyboardEventSource: EventSynth.source, virtualKey: 0x24, keyDown: true),
+           let up = CGEvent(keyboardEventSource: EventSynth.source, virtualKey: 0x24, keyDown: false) {
+            down.postToPid(pid_t(pid))
+            up.postToPid(pid_t(pid))
+            return true
+        }
+        return false
+    }
+
+    // MARK: - arbitrary AX action
+
+    // Perform any AX action the element advertises (AXPress, AXConfirm,
+    // AXCancel, AXRaise, AXIncrement, AXShowMenu, ...). The previous surface
+    // hardcoded a fixed set; this lets callers drive actions the tree exposes
+    // without us enumerating every one.
+    static func axAction(params: [String: Any], cache: ElementCache) throws -> [String: Any] {
+        try ensureTrusted()
+        let pid = try Params.int(params, "pid")
+        try ensurePidAllowed(pid)
+        let elementId = try Params.string(params, "element_id")
+        let action = try Params.string(params, "action")
+
+        guard let el = cache.get(pid: pid, id: elementId) else {
+            throw RPCError.stale()
+        }
+        let available = copyActionNames(el)
+        guard available.contains(action) else {
+            throw RPCError.unsupported("element does not support \(action); available: \(available.joined(separator: ", "))")
+        }
+        let err = AXUIElementPerformAction(el, action as CFString)
+        if err != .success {
+            throw RPCError(code: "action_failed", message: "AXPerformAction(\(action))=\(err.rawValue)")
+        }
+        return ["ok": true, "action": action]
+    }
+
+    // MARK: - focus
+
+    // Set keyboard focus to an element (kAXFocusedAttribute = true) so a
+    // subsequent key/type lands in the right field without a synthesized click.
+    static func setFocus(params: [String: Any], cache: ElementCache) throws -> [String: Any] {
+        try ensureTrusted()
+        let pid = try Params.int(params, "pid")
+        try ensurePidAllowed(pid)
+        let elementId = try Params.string(params, "element_id")
+        guard let el = cache.get(pid: pid, id: elementId) else {
+            throw RPCError.stale()
+        }
+        var settable = DarwinBoolean(false)
+        AXUIElementIsAttributeSettable(el, kAXFocusedAttribute as CFString, &settable)
+        if !settable.boolValue {
+            throw RPCError.unsupported("AXFocused not settable on element \(elementId)")
+        }
+        let err = AXUIElementSetAttributeValue(el, kAXFocusedAttribute as CFString, kCFBooleanTrue)
+        if err != .success {
+            throw RPCError(code: "action_failed", message: "AXSetFocused=\(err.rawValue)")
+        }
         return ["ok": true]
     }
 
@@ -215,12 +285,7 @@ enum AX {
         // Focus the input by clicking at (x,y) first.
         let pt = CGPoint(x: x, y: y)
         CursorSprite.shared.flash(at: pt)
-        guard let down = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: pt, mouseButton: .left),
-              let up = CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: pt, mouseButton: .left) else {
-            throw RPCError(code: "action_failed", message: "could not create focus click")
-        }
-        down.postToPid(pid_t(pid))
-        up.postToPid(pid_t(pid))
+        _ = try EventSynth.click(at: pt, pid: pid, button: "left", clickCount: 1, background: false)
         Thread.sleep(forTimeInterval: 0.05)
 
         // Put text on the pasteboard and paste. NSPasteboard.general is
@@ -360,10 +425,17 @@ enum AX {
             warpedTo = [x, y]
         }
 
-        guard let ev = CGEvent(scrollWheelEvent2Source: nil, units: .pixel, wheelCount: 2, wheel1: Int32(dy), wheel2: Int32(dx), wheel3: 0) else {
+        guard let ev = CGEvent(scrollWheelEvent2Source: EventSynth.source, units: .pixel, wheelCount: 2, wheel1: Int32(dy), wheel2: Int32(dx), wheel3: 0) else {
             throw RPCError(code: "action_failed", message: "could not create scroll event")
         }
-        ev.postToPid(pid_t(pid))
+        // When the caller warped the cursor to a target, deliver through the HID
+        // tap so the event lands on the view under that point (matching click
+        // semantics); otherwise keep the focus-safe pid route.
+        if warpedTo != nil {
+            ev.post(tap: .cghidEventTap)
+        } else {
+            ev.postToPid(pid_t(pid))
+        }
         var result: [String: Any] = ["ok": true, "method": "CGEvent"]
         if let at = warpedTo { result["at"] = at }
         return result

--- a/packages/computer-helper/Sources/ComputerHelper/EventSynth.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/EventSynth.swift
@@ -1,0 +1,154 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+// Centralized mouse-event synthesis. This is the single source of truth for
+// turning a (point, button, clickCount) into CGEvents that real apps accept.
+//
+// Why this exists: the previous implementation built events with
+// `CGEvent(mouseEventSource: nil, ...)` and delivered them with
+// `postToPid`, setting no auxiliary fields. That works for plain AppKit
+// controls but is *silently dropped* by Chromium/CEF/UXP renderers
+// (Photoshop's contextual taskbar, Electron apps, embedded web views) and by
+// OpenGL canvas surfaces. Those surfaces validate that an event looks like it
+// came from the real HID pipeline:
+//
+//   - a non-nil event source tied to HID state (.hidSystemState)
+//   - kCGMouseEventClickState (the click counter) set to >= 1
+//   - kCGMouseEventSubtype = NSEventSubtypeMouseEvent (3)
+//   - kCGMouseEventButtonNumber set explicitly
+//   - a preceding .mouseMoved so the surface has cursor-hover state
+//   - a measurable down -> up dwell (a 0ms click is filtered as noise)
+//   - delivery through the HID event tap with the cursor actually warped to
+//     the target, so the app's internal cursor cache agrees with the event
+//     location
+//
+// Trade-off: routing through .cghidEventTap warps the real cursor and the
+// target must be frontmost. That is the correct trade-off for the helper's
+// job (drive the app the caller pointed at). Callers that specifically want
+// the old focus-safe behaviour for plain AppKit targets can pass
+// background=true to fall back to postToPid.
+enum EventSynth {
+
+    // One HID-tied source reused for every synthesized event. nil sources are
+    // what the renderer filters reject; a process-wide .hidSystemState source
+    // carries the implicit-trust state those surfaces look for.
+    static let source: CGEventSource? = CGEventSource(stateID: .hidSystemState)
+
+    // NSEventSubtypeMouseEvent. Part of the telemetry Chromium's synthetic-
+    // event filter checks; absent it, clicks into web/UXP content drop.
+    private static let subtypeMouseEvent: Int64 = 3
+
+    // Timing. mouseMoved must land a frame before the press so the surface's
+    // cursor-tracking cache updates; the down->up dwell must be non-zero so
+    // the click isn't coalesced away. Values are conservative but still well
+    // under human perception.
+    private static let postMoveDwell: TimeInterval = 0.012
+    private static let pressDwell: TimeInterval = 0.020
+
+    struct Buttons {
+        let down: CGEventType
+        let up: CGEventType
+        let dragged: CGEventType
+        let mouseButton: CGMouseButton
+    }
+
+    static func buttons(for name: String) -> Buttons {
+        if name == "right" {
+            return Buttons(down: .rightMouseDown, up: .rightMouseUp, dragged: .rightMouseDragged, mouseButton: .right)
+        }
+        return Buttons(down: .leftMouseDown, up: .leftMouseUp, dragged: .leftMouseDragged, mouseButton: .left)
+    }
+
+    // Stamp the auxiliary fields every synthesized mouse event needs. Applied
+    // to move/down/up/dragged alike.
+    private static func stamp(_ ev: CGEvent, button: CGMouseButton, clickState: Int) {
+        ev.setIntegerValueField(.mouseEventClickState, value: Int64(max(clickState, 1)))
+        ev.setIntegerValueField(.mouseEventButtonNumber, value: Int64(button.rawValue))
+        ev.setIntegerValueField(.mouseEventSubtype, value: subtypeMouseEvent)
+    }
+
+    private static func make(_ type: CGEventType, at pt: CGPoint, button: CGMouseButton, clickState: Int) -> CGEvent? {
+        guard let ev = CGEvent(mouseEventSource: source, mouseType: type, mouseCursorPosition: pt, mouseButton: button) else {
+            return nil
+        }
+        stamp(ev, button: button, clickState: clickState)
+        return ev
+    }
+
+    // Deliver one event. Primary path is the HID tap (real pipeline, accepted
+    // by every surface). background=true keeps the legacy focus-safe postToPid
+    // route for plain AppKit targets that don't need HID-level trust.
+    private static func post(_ ev: CGEvent, pid: Int, background: Bool) {
+        if background {
+            ev.postToPid(pid_t(pid))
+        } else {
+            ev.post(tap: .cghidEventTap)
+        }
+    }
+
+    // A full click: warp -> move -> dwell -> down -> dwell -> up. Returns the
+    // delivery method used for the RPC result.
+    @discardableResult
+    static func click(at pt: CGPoint, pid: Int, button name: String = "left", clickCount: Int = 1, background: Bool = false) throws -> String {
+        let b = buttons(for: name)
+
+        if !background {
+            // Align the OS cursor with the event location so the surface's
+            // internal cursor cache agrees with where the press lands.
+            CGWarpMouseCursorPosition(pt)
+        }
+
+        guard let move = make(.mouseMoved, at: pt, button: b.mouseButton, clickState: 0),
+              let down = make(b.down, at: pt, button: b.mouseButton, clickState: clickCount),
+              let up = make(b.up, at: pt, button: b.mouseButton, clickState: clickCount) else {
+            throw RPCError(code: "action_failed", message: "could not create mouse events")
+        }
+
+        post(move, pid: pid, background: background)
+        Thread.sleep(forTimeInterval: postMoveDwell)
+        post(down, pid: pid, background: background)
+        Thread.sleep(forTimeInterval: pressDwell)
+        post(up, pid: pid, background: background)
+
+        return background ? "postToPid" : "hidTap"
+    }
+
+    // A drag: warp -> move -> down -> dwell -> N dragged steps -> up.
+    @discardableResult
+    static func drag(from: CGPoint, to: CGPoint, pid: Int, button name: String = "left", steps: Int = 16, background: Bool = false) throws -> String {
+        let b = buttons(for: name)
+
+        if !background {
+            CGWarpMouseCursorPosition(from)
+        }
+
+        guard let move = make(.mouseMoved, at: from, button: b.mouseButton, clickState: 0),
+              let down = make(b.down, at: from, button: b.mouseButton, clickState: 1) else {
+            throw RPCError(code: "action_failed", message: "could not create drag start events")
+        }
+        post(move, pid: pid, background: background)
+        Thread.sleep(forTimeInterval: postMoveDwell)
+        post(down, pid: pid, background: background)
+        // Drop-target recognizers need a hold after press before the first move.
+        Thread.sleep(forTimeInterval: 0.05)
+
+        let n = max(steps, 1)
+        for i in 1...n {
+            let t = Double(i) / Double(n)
+            let pt = CGPoint(x: from.x + (to.x - from.x) * CGFloat(t),
+                             y: from.y + (to.y - from.y) * CGFloat(t))
+            if !background { CGWarpMouseCursorPosition(pt) }
+            if let dragEv = make(b.dragged, at: pt, button: b.mouseButton, clickState: 1) {
+                post(dragEv, pid: pid, background: background)
+            }
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+
+        guard let up = make(b.up, at: to, button: b.mouseButton, clickState: 1) else {
+            throw RPCError(code: "action_failed", message: "could not create drag end event")
+        }
+        post(up, pid: pid, background: background)
+        return background ? "postToPid" : "hidTap"
+    }
+}

--- a/packages/computer-helper/Sources/ComputerHelper/Events.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/Events.swift
@@ -33,6 +33,42 @@ enum Events {
         return ["ok": true]
     }
 
+    // Type an arbitrary unicode string into the focused field. Unlike sendKey
+    // (one chord, US-ANSI keycodes only), this emits the literal characters via
+    // CGEventKeyboardSetUnicodeString — punctuation, digits, mixed case, and
+    // non-ASCII all work without a keycode table. Posts to the pid; the caller
+    // is responsible for focusing the target first (click / set_focus).
+    static func typeText(params: [String: Any]) throws -> [String: Any] {
+        let pid = try Params.int(params, "pid")
+        let text = try Params.string(params, "text")
+        guard NSRunningApplication(processIdentifier: pid_t(pid)) != nil else {
+            throw RPCError.appMissing(pid)
+        }
+        try ensurePidAllowed(pid)
+
+        for scalar in text.unicodeScalars {
+            var utf16 = Array(String(scalar).utf16)
+            guard let down = CGEvent(keyboardEventSource: EventSynth.source, virtualKey: 0, keyDown: true),
+                  let up = CGEvent(keyboardEventSource: EventSynth.source, virtualKey: 0, keyDown: false) else {
+                throw RPCError(code: "action_failed", message: "could not create key event")
+            }
+            down.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: &utf16)
+            up.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: &utf16)
+            down.postToPid(pid_t(pid))
+            up.postToPid(pid_t(pid))
+            Thread.sleep(forTimeInterval: 0.004)
+        }
+
+        if Params.bool(params, "commit") {
+            if let down = CGEvent(keyboardEventSource: EventSynth.source, virtualKey: 0x24, keyDown: true),
+               let up = CGEvent(keyboardEventSource: EventSynth.source, virtualKey: 0x24, keyDown: false) {
+                down.postToPid(pid_t(pid))
+                up.postToPid(pid_t(pid))
+            }
+        }
+        return ["ok": true, "chars": text.count]
+    }
+
     private struct Chord {
         let keyCode: CGKeyCode
         let flags: CGEventFlags

--- a/packages/computer-helper/Sources/ComputerHelper/Mouse.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/Mouse.swift
@@ -39,48 +39,16 @@ enum Mouse {
             }
         }
 
-        // Fallback: synthesize mouse down at source, a series of dragged events,
-        // and an up at the destination. Posted to pid so the user's focus is
-        // minimally disrupted.
-        let downType: CGEventType = button == "right" ? .rightMouseDown : .leftMouseDown
-        let dragType: CGEventType = button == "right" ? .rightMouseDragged : .leftMouseDragged
-        let upType: CGEventType = button == "right" ? .rightMouseUp : .leftMouseUp
-        let mouseButton: CGMouseButton = button == "right" ? .right : .left
-
-        guard let down = CGEvent(mouseEventSource: nil, mouseType: downType, mouseCursorPosition: fromPt, mouseButton: mouseButton) else {
-            throw RPCError(code: "action_failed", message: "could not create mouseDown event")
-        }
+        // Fallback: synthesize the full move->down->drag->up sequence through
+        // the centralized synthesizer (HID tap, fully-stamped events) so it
+        // lands on Chromium/UXP/canvas surfaces, not just plain AppKit views.
+        let background = Params.bool(params, "background")
         CursorSprite.shared.showFor(drag: fromPt)
-        down.postToPid(pid_t(pid))
-
-        // Many drag-and-drop implementations (NSView, drop targets, sortable
-        // lists) need a minimum hold after mouseDown before recognising the
-        // gesture as a drag rather than a click. Without this dwell the
-        // sequence is sometimes interpreted as a single click.
-        Thread.sleep(forTimeInterval: 0.05)
-
-        // Intermediate drag events help apps that watch the event stream.
-        let steps = 10
-        for i in 1...steps {
-            let t = Double(i) / Double(steps)
-            let x = fromPt.x + (toPt.x - fromPt.x) * CGFloat(t)
-            let y = fromPt.y + (toPt.y - fromPt.y) * CGFloat(t)
-            let pt = CGPoint(x: x, y: y)
-            CursorSprite.shared.move(to: pt)
-            if let drag = CGEvent(mouseEventSource: nil, mouseType: dragType, mouseCursorPosition: pt, mouseButton: mouseButton) {
-                drag.postToPid(pid_t(pid))
-            }
-            Thread.sleep(forTimeInterval: 0.01)
-        }
-
-        guard let up = CGEvent(mouseEventSource: nil, mouseType: upType, mouseCursorPosition: toPt, mouseButton: mouseButton) else {
-            throw RPCError(code: "action_failed", message: "could not create mouseUp event")
-        }
-        up.postToPid(pid_t(pid))
+        let method = try EventSynth.drag(from: fromPt, to: toPt, pid: pid, button: button, background: background)
         // Brief lingering flash at destination, then hide.
         CursorSprite.shared.flash(at: toPt)
 
-        return ["ok": true, "method": "CGEvent"]
+        return ["ok": true, "method": method]
     }
 
     // MARK: - right click
@@ -97,13 +65,8 @@ enum Mouse {
             if let x = Params.intOpt(params, "x"), let y = Params.intOpt(params, "y") {
                 let pt = CGPoint(x: x, y: y)
                 CursorSprite.shared.flash(at: pt)
-                guard let down = CGEvent(mouseEventSource: nil, mouseType: .rightMouseDown, mouseCursorPosition: pt, mouseButton: .right),
-                      let up = CGEvent(mouseEventSource: nil, mouseType: .rightMouseUp, mouseCursorPosition: pt, mouseButton: .right) else {
-                    throw RPCError(code: "action_failed", message: "could not create right click event")
-                }
-                down.postToPid(pid_t(pid))
-                up.postToPid(pid_t(pid))
-                return ["ok": true, "method": "CGEvent", "at": [x, y]]
+                let method = try EventSynth.click(at: pt, pid: pid, button: "right", clickCount: 1, background: Params.bool(params, "background"))
+                return ["ok": true, "method": method, "at": [x, y]]
             }
             throw RPCError.invalid("pass either element_id or x,y")
         }
@@ -131,14 +94,8 @@ enum Mouse {
             throw RPCError(code: "action_failed", message: "element has no frame")
         }
         CursorSprite.shared.flash(at: center)
-
-        guard let down = CGEvent(mouseEventSource: nil, mouseType: .rightMouseDown, mouseCursorPosition: center, mouseButton: .right),
-              let up = CGEvent(mouseEventSource: nil, mouseType: .rightMouseUp, mouseCursorPosition: center, mouseButton: .right) else {
-            throw RPCError(code: "action_failed", message: "could not create right click event")
-        }
-        down.postToPid(pid_t(pid))
-        up.postToPid(pid_t(pid))
-        return ["ok": true, "method": "CGEvent"]
+        let method = try EventSynth.click(at: center, pid: pid, button: "right", clickCount: 1, background: Params.bool(params, "background"))
+        return ["ok": true, "method": method]
     }
 
     // MARK: - focus window

--- a/packages/computer-helper/Sources/ComputerHelper/RPC.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/RPC.swift
@@ -97,6 +97,12 @@ final class Dispatcher {
             return try AX.setValue(params: params, cache: cache)
         case "key":
             return try Events.sendKey(params: params)
+        case "type_text":
+            return try Events.typeText(params: params)
+        case "ax_action":
+            return try AX.axAction(params: params, cache: cache)
+        case "set_focus":
+            return try AX.setFocus(params: params, cache: cache)
         case "scroll":
             return try AX.scroll(params: params, cache: cache)
         case "screenshot":

--- a/packages/computer-helper/Sources/ComputerHelper/Screenshot.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/Screenshot.swift
@@ -10,10 +10,22 @@ import UniformTypeIdentifiers
 // SCK is the supported replacement, captures across Spaces, and accepts an
 // SCWindow target by windowID without raising the window (focus-safe).
 //
-// Window picking: an app's first CGWindowList entry is non-deterministic and
-// for canvas/video apps (CapCut, OBS, broadcast tools) is often a tiny
-// transparent overlay rather than the editor surface. We pick the largest
-// onscreen layer-0 alpha>0 window owned by the pid instead.
+// Modes (params):
+//   - list=true            → enumerate the app's windows (id/title/frame/layer/
+//                            active), no image. Lets a caller see modal dialogs,
+//                            popovers, and floating panels that the default
+//                            largest-window capture hides.
+//   - window_id=<n>        → capture exactly that window (use a window id from
+//                            list=true). The way to screenshot a modal sheet or
+//                            the contextual taskbar.
+//   - display=true         → capture the whole display the app's main window is
+//                            on, compositing every overlapping window. The way
+//                            to see stacked modals + the editor together.
+//   - (default)            → largest on-screen layer-0 window owned by pid.
+//
+// Every image response now also reports the captured region's global origin
+// and the backing scale factor, so a caller can map screenshot pixels to
+// global screen coordinates for click()/scroll(): global = origin + pixel/scale.
 enum Screenshot {
     static func capture(params: [String: Any]) throws -> [String: Any] {
         let pid = try Params.int(params, "pid")
@@ -22,15 +34,24 @@ enum Screenshot {
         // Hard floor + user allow list. Throws before SCK initializes.
         try ensurePidAllowed(pid)
 
-        // SCK is async; bridge to the sync RPC dispatcher with a semaphore.
-        // 5s is well above the 100-300ms typical SCK frame grab; if we hit
-        // it something is wrong (permission, hung daemon, denied window).
+        let listOnly = Params.bool(params, "list")
+        let display = Params.bool(params, "display")
+        let windowId = Params.intOpt(params, "window_id")
+
         let semaphore = DispatchSemaphore(value: 0)
         var captured: Result<[String: Any], Error>!
 
         Task {
             do {
-                captured = .success(try await captureAsync(pid: pid, quality: quality))
+                if listOnly {
+                    captured = .success(try await listWindows(pid: pid))
+                } else if display {
+                    captured = .success(try await captureDisplay(pid: pid, quality: quality))
+                } else if let wid = windowId {
+                    captured = .success(try await captureWindowId(pid: pid, windowId: wid, quality: quality))
+                } else {
+                    captured = .success(try await captureLargest(pid: pid, quality: quality))
+                }
             } catch {
                 captured = .failure(error)
             }
@@ -44,71 +65,147 @@ enum Screenshot {
         return try captured.get()
     }
 
-    private static func captureAsync(pid: Int, quality: Int) async throws -> [String: Any] {
-        // SCShareableContent.current enumerates everything the helper is
-        // allowed to capture. Filters by pid and picks the dominant editor
-        // window (largest area, layer 0, on-screen). Returns app_not_found
-        // when no candidate exists — same contract as the old CGWindowList
-        // implementation.
-        let content: SCShareableContent
+    // MARK: - enumeration
+
+    private static func shareable() async throws -> SCShareableContent {
         do {
-            // onScreenWindowsOnly=false matches CapCut and other apps whose
-            // editor window is on a different Space (or otherwise filtered
-            // out by the on-screen check). We then prefer the largest
-            // layer-0 window, which is empirically the editor.
-            content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+            // onScreenWindowsOnly=false matches apps whose editor window is on a
+            // different Space (or otherwise filtered by the on-screen check).
+            return try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
         } catch {
             throw RPCError(code: "action_failed", message: "SCShareableContent failed: \(error.localizedDescription) (grant Screen Recording to ComputerHelper)")
         }
+    }
 
+    private static func listWindows(pid: Int) async throws -> [String: Any] {
+        let content = try await shareable()
+        let mine = content.windows.filter { $0.owningApplication?.processID == pid_t(pid) }
+        // Largest layer-0 window first, then by descending area — the editor
+        // surface leads, dialogs/panels follow.
+        let sorted = mine.sorted { lhs, rhs in
+            if lhs.windowLayer != rhs.windowLayer { return lhs.windowLayer < rhs.windowLayer }
+            return area(lhs.frame) > area(rhs.frame)
+        }
+        let windows: [[String: Any]] = sorted.map { w in
+            [
+                "window_id": Int(w.windowID),
+                "title": w.title ?? "",
+                "layer": w.windowLayer,
+                "active": w.isActive,
+                "on_screen": w.isOnScreen,
+                "bounds": [Int(w.frame.origin.x), Int(w.frame.origin.y), Int(w.frame.width), Int(w.frame.height)],
+            ]
+        }
+        return ["pid": pid, "windows": windows, "window_count": windows.count]
+    }
+
+    // MARK: - capture variants
+
+    private static func captureLargest(pid: Int, quality: Int) async throws -> [String: Any] {
+        let content = try await shareable()
         let candidates = content.windows.filter {
             $0.owningApplication?.processID == pid_t(pid) && $0.windowLayer == 0
         }
-        guard !candidates.isEmpty else {
-            // Fall back to any-layer windows if no layer-0 candidate exists.
-            // Some apps put real UI on non-zero layers (rare but seen on
-            // older Qt builds). Better to capture something than fail blind.
-            let anyLayer = content.windows.filter { $0.owningApplication?.processID == pid_t(pid) }
-            guard let largest = anyLayer.max(by: { area($0.frame) < area($1.frame) }) else {
-                throw RPCError(code: "action_failed", message: "no visible windows for pid \(pid)")
-            }
+        if let largest = candidates.max(by: { area($0.frame) < area($1.frame) }) {
             return try await snap(window: largest, quality: quality)
         }
-        let largest = candidates.max(by: { area($0.frame) < area($1.frame) })!
+        // Fall back to any-layer windows if no layer-0 candidate exists.
+        let anyLayer = content.windows.filter { $0.owningApplication?.processID == pid_t(pid) }
+        guard let largest = anyLayer.max(by: { area($0.frame) < area($1.frame) }) else {
+            throw RPCError(code: "action_failed", message: "no visible windows for pid \(pid)")
+        }
         return try await snap(window: largest, quality: quality)
+    }
+
+    private static func captureWindowId(pid: Int, windowId: Int, quality: Int) async throws -> [String: Any] {
+        let content = try await shareable()
+        guard let window = content.windows.first(where: {
+            $0.owningApplication?.processID == pid_t(pid) && Int($0.windowID) == windowId
+        }) else {
+            throw RPCError(code: "element_not_found", message: "window_id \(windowId) not found for pid \(pid) — call screenshot with list=true to enumerate")
+        }
+        return try await snap(window: window, quality: quality)
+    }
+
+    // Capture the entire display the app's main window sits on, compositing all
+    // windows (including modal sheets and the editor together).
+    private static func captureDisplay(pid: Int, quality: Int) async throws -> [String: Any] {
+        let content = try await shareable()
+        let mine = content.windows.filter { $0.owningApplication?.processID == pid_t(pid) }
+        guard let anchor = mine.max(by: { area($0.frame) < area($1.frame) }) else {
+            throw RPCError(code: "action_failed", message: "no visible windows for pid \(pid)")
+        }
+        let anchorCenter = CGPoint(x: anchor.frame.midX, y: anchor.frame.midY)
+        // SCDisplay.frame is in global points; pick the display containing the
+        // app's main window center.
+        guard let scDisplay = content.displays.first(where: { $0.frame.contains(anchorCenter) }) ?? content.displays.first else {
+            throw RPCError(code: "action_failed", message: "no displays available")
+        }
+
+        let filter = SCContentFilter(display: scDisplay, excludingWindows: [])
+        let config = SCStreamConfiguration()
+        config.width = max(Int(scDisplay.frame.width), 1)
+        config.height = max(Int(scDisplay.frame.height), 1)
+        config.pixelFormat = kCVPixelFormatType_32BGRA
+        config.showsCursor = false
+        config.capturesAudio = false
+
+        let cgImage = try await captureImage(filter: filter, config: config)
+        let scale = scDisplay.frame.width > 0 ? Double(cgImage.width) / Double(scDisplay.frame.width) : 1.0
+        return try encode(cgImage: cgImage, quality: quality, regionOrigin: scDisplay.frame.origin, scale: scale, extra: [
+            "mode": "display",
+            "display_id": Int(scDisplay.displayID),
+        ])
     }
 
     private static func area(_ r: CGRect) -> CGFloat { r.width * r.height }
 
     private static func snap(window: SCWindow, quality: Int) async throws -> [String: Any] {
         let filter = SCContentFilter(desktopIndependentWindow: window)
-
         let config = SCStreamConfiguration()
         // sourceRect=CGRect.null tells SCK to use the window's natural bounds.
-        // pixelFormat=BGRA is the only format we can reliably ferry through
-        // CGImage->NSBitmapImageRep->JPEG without an extra Metal hop.
         config.width = max(Int(window.frame.width), 1)
         config.height = max(Int(window.frame.height), 1)
         config.pixelFormat = kCVPixelFormatType_32BGRA
         config.showsCursor = false
         config.capturesAudio = false
 
-        let cgImage: CGImage
+        let cgImage = try await captureImage(filter: filter, config: config)
+        // SCK returns a backing-store image: on Retina it is ~2x the requested
+        // point size. Report the scale so callers can map pixels -> points.
+        let scale = window.frame.width > 0 ? Double(cgImage.width) / Double(window.frame.width) : 1.0
+        return try encode(cgImage: cgImage, quality: quality, regionOrigin: window.frame.origin, scale: scale, extra: [
+            "mode": "window",
+            "window_id": Int(window.windowID),
+            "title": window.title ?? "",
+        ])
+    }
+
+    private static func captureImage(filter: SCContentFilter, config: SCStreamConfiguration) async throws -> CGImage {
         do {
-            cgImage = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
+            return try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
         } catch {
             throw RPCError(code: "action_failed", message: "SCK captureImage failed: \(error.localizedDescription)")
         }
+    }
 
+    private static func encode(cgImage: CGImage, quality: Int, regionOrigin: CGPoint, scale: Double, extra: [String: Any]) throws -> [String: Any] {
         let rep = NSBitmapImageRep(cgImage: cgImage)
         guard let data = rep.representation(using: .jpeg, properties: [.compressionFactor: Double(quality) / 100.0]) else {
             throw RPCError(code: "action_failed", message: "JPEG encode failed")
         }
-        return [
+        var out: [String: Any] = [
             "image_data": data.base64EncodedString(),
             "mime_type": "image/jpeg",
             "width": cgImage.width,
             "height": cgImage.height,
+            // Global point origin of the captured region + backing scale.
+            // To click a feature at screenshot pixel (px,py):
+            //   global_x = origin_x + px/scale ; global_y = origin_y + py/scale
+            "origin": [Int(regionOrigin.x), Int(regionOrigin.y)],
+            "scale": scale,
         ]
+        for (k, v) in extra { out[k] = v }
+        return out
     }
 }


### PR DESCRIPTION
## What

The computer-use helper's synthesized **mouse** events were silently dropped by Photoshop's UXP contextual taskbar, Electron/CEF web views, and OpenGL canvases — while keyboard events to the same process worked. This made the helper unable to click anything rendered in an embedded web/canvas surface.

**Root cause** (confirmed against `cua`/`osaurus`/`cliclick` references and the CGEvent docs): events were built with a `nil` `CGEventSource` and delivered via `postToPid` with **no** `kCGMouseEventClickState`, no `mouseEventSubtype`, no preceding `mouseMoved`, and a **0ms** down→up interval. Chromium/UXP renderers hit-test against exactly that telemetry and discard events that lack it.

## Changes

- **`EventSynth.swift` (new)** — single source of truth for mouse synthesis: `hidSystemState` source, stamped `clickState`/`buttonNumber`/`subtype`, a cursor-warped preceding `mouseMoved`, a real press dwell, and HID-tap delivery. `background=true` preserves the old focus-safe `postToPid` route for plain AppKit targets. `click`/`right_click`/`drag`/`scroll`/`setValueByCoords` all route through it.
- **`Screenshot.swift`** — `list=true` (enumerate windows incl. modals/popups), `window_id=<n>` (capture a specific window/dialog), `display=true` (full-display composite), and every image response now returns `origin` + `scale` so callers can map screenshot pixels → global click coordinates (`global = origin + pixel/scale`). Fixes the old largest-window-only capture that was blind to dialogs.
- **`AX.swift`** — `type`/`setValue` gains opt-in `commit` (AXConfirm, else Return) so written field values reach the document model, not just the display; new `ax_action` (perform any advertised AX action) and `set_focus` (set `AXFocused`).
- **`Events.swift`** — new `type_text` types an arbitrary unicode string (the old `key` only sent single US-ANSI chords).
- **`RPC.swift`** — dispatches `type_text`, `ax_action`, `set_focus`.

## Verification (end-to-end, live Photoshop 2026)

| Check | Before | After |
|---|---|---|
| Click Move tool at toolbar coords | byte-identical screenshot (dead) | commits pending crop, canvas 2048² → 3804×1581, Generative Layer created |
| Click Hand/Type tool | no change | options bar switches, toolbar highlight moves |
| `screenshot list=true` | n/a | surfaces a `Progress` dialog the old capture hid |
| `screenshot window_id=<progress>` | impossible | renders the dialog directly |
| screenshot metadata | none | `origin:[0,33] scale:1` (matches externally-measured window position) |

No Swift test target exists and these are synthesized-OS-event / ScreenCaptureKit paths (repo bans mocking); the live-app verification above is the integration test.

## Scope / follow-ups

Per the agreed scope (P0 mouse + P1 observation/AX in one helper rebuild). Deliberately **not** in this PR:
- Exposing the 13 dark daemon methods as `agents computer` CLI subcommands (audit finding — the CLI still only surfaces `screenshot`).
- `docs/computer.md` update for the new params/methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
