### PR TITLE
feat(computer): expose daemon interaction methods as CLI verbs

### DIFF
--- a/src/commands/computer-actions.test.ts
+++ b/src/commands/computer-actions.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { pickTarget, parseXY, buildElementOrCoords, type AppInfo } from './computer-actions.js';
+
+const apps: AppInfo[] = [
+  { pid: 100, name: 'Finder', bundle_id: 'com.apple.finder', active: false },
+  { pid: 200, name: 'Photoshop', bundle_id: 'com.adobe.Photoshop', active: true },
+  { pid: 300, name: 'Notes', bundle_id: 'com.apple.notes', active: false },
+];
+
+describe('pickTarget', () => {
+  it('prefers an explicit pid, returning the matching app', () => {
+    const r = pickTarget(apps, { pid: 300 });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.app.bundle_id).toBe('com.apple.notes');
+  });
+
+  it('passes through a pid the daemon does not list (daemon is the authority)', () => {
+    const r = pickTarget(apps, { pid: 999 });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.app.pid).toBe(999);
+      expect(r.app.bundle_id).toBe('');
+    }
+  });
+
+  it('pid wins over bundle when both are given', () => {
+    const r = pickTarget(apps, { pid: 100, bundle: 'com.adobe.Photoshop' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.app.pid).toBe(100);
+  });
+
+  it('resolves a bundle id to its running pid', () => {
+    const r = pickTarget(apps, { bundle: 'com.adobe.Photoshop' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.app.pid).toBe(200);
+  });
+
+  it('errors when the bundle is not running / not allow-listed', () => {
+    const r = pickTarget(apps, { bundle: 'com.unknown.app' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('com.unknown.app');
+  });
+
+  it('falls back to the frontmost active app when neither pid nor bundle is given', () => {
+    const r = pickTarget(apps, {});
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.app.pid).toBe(200);
+  });
+
+  it('errors when nothing is active and no target is specified', () => {
+    const noneActive = apps.map((a) => ({ ...a, active: false }));
+    const r = pickTarget(noneActive, {});
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('parseXY', () => {
+  it('parses a valid coordinate pair', () => {
+    expect(parseXY('18,136', '--from')).toEqual({ x: 18, y: 136 });
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseXY(' 18 , 136 ', '--to')).toEqual({ x: 18, y: 136 });
+  });
+
+  it('parses negative coordinates', () => {
+    expect(parseXY('-5,-10', '--from')).toEqual({ x: -5, y: -10 });
+  });
+
+  it('throws on the wrong number of parts', () => {
+    expect(() => parseXY('18', '--from')).toThrow('--from');
+    expect(() => parseXY('1,2,3', '--from')).toThrow('--from');
+  });
+
+  it('throws on non-numeric parts', () => {
+    expect(() => parseXY('a,b', '--to')).toThrow('--to');
+  });
+});
+
+describe('buildElementOrCoords', () => {
+  it('builds an element_id spec from --id', () => {
+    const r = buildElementOrCoords({ id: '@e7' });
+    expect(r).toEqual({ ok: true, params: { element_id: '@e7' } });
+  });
+
+  it('builds an x/y spec from coordinates', () => {
+    const r = buildElementOrCoords({ x: 18, y: 136 });
+    expect(r).toEqual({ ok: true, params: { x: 18, y: 136 } });
+  });
+
+  it('prefers --id over coordinates when both are present', () => {
+    const r = buildElementOrCoords({ id: '@e7', x: 1, y: 2 });
+    expect(r).toEqual({ ok: true, params: { element_id: '@e7' } });
+  });
+
+  it('errors when neither target is provided', () => {
+    const r = buildElementOrCoords({});
+    expect(r.ok).toBe(false);
+  });
+
+  it('errors when only one coordinate is provided', () => {
+    const r = buildElementOrCoords({ x: 18 });
+    expect(r.ok).toBe(false);
+  });
+});

--- a/src/commands/computer-actions.ts
+++ b/src/commands/computer-actions.ts
@@ -1,0 +1,386 @@
+// Action verbs for `agents computer` — the interaction surface over the
+// computer-helper daemon's RPC methods (click, type, key, drag, scroll,
+// describe, ax-action, focus, ...). These mirror `agents browser`'s verb
+// layout: flat verbs under the noun, bundle-id targeting, --json on reads.
+//
+// The daemon already implements every method; this file is the thin, typed
+// CLI skin over it plus a shared target resolver so callers stay in bundle-id
+// space and never hand-manage pids.
+
+import { Command } from 'commander';
+import {
+  openComputerClient,
+  describeTransport,
+  type ComputerClient,
+  type RPCResponse,
+} from '../lib/computer-rpc.js';
+
+export interface AppInfo {
+  pid: number;
+  name: string;
+  bundle_id: string;
+  active: boolean;
+}
+
+// Pure target picker — exercised by unit tests. Precedence: explicit --pid,
+// then --bundle, then the frontmost active allow-listed app (the same default
+// `screenshot` uses). Kept side-effect-free so the resolution rules are
+// testable without a live daemon.
+export function pickTarget(
+  list: AppInfo[],
+  opts: { pid?: number; bundle?: string },
+): { ok: true; app: AppInfo } | { ok: false; error: string } {
+  if (opts.pid != null) {
+    const app = list.find((a) => a.pid === opts.pid);
+    // A --pid the daemon doesn't list (not allow-listed / not running) is
+    // still passed through: the daemon is the authority and will return a
+    // precise permission_denied / app_not_found. We don't second-guess it.
+    return { ok: true, app: app ?? { pid: opts.pid, name: '', bundle_id: '', active: false } };
+  }
+  if (opts.bundle) {
+    const app = list.find((a) => a.bundle_id === opts.bundle);
+    if (!app) {
+      return {
+        ok: false,
+        error: `bundle not in allow list (or not running): ${opts.bundle}\nadd Computer(${opts.bundle}) to a permissions group, then \`agents computer reload\``,
+      };
+    }
+    return { ok: true, app };
+  }
+  const active = list.find((a) => a.active);
+  if (!active) {
+    return {
+      ok: false,
+      error: 'no active app found in allow list\nadd Computer(<bundle-id>) to a permissions group, then `agents computer reload`',
+    };
+  }
+  return { ok: true, app: active };
+}
+
+// Parse an "x,y" coordinate pair. Pure + tested.
+export function parseXY(s: string, flag: string): { x: number; y: number } {
+  const parts = s.split(',').map((v) => v.trim());
+  if (parts.length !== 2) {
+    throw new Error(`${flag} must be "x,y" (got: ${s})`);
+  }
+  const x = Number(parts[0]);
+  const y = Number(parts[1]);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) {
+    throw new Error(`${flag} must be two numbers "x,y" (got: ${s})`);
+  }
+  return { x, y };
+}
+
+// Build the element-or-coords target spec shared by click/type/scroll/etc.
+// Pure + tested: returns the params fragment or an error string.
+export function buildElementOrCoords(opts: {
+  id?: string;
+  x?: number;
+  y?: number;
+}): { ok: true; params: Record<string, unknown> } | { ok: false; error: string } {
+  if (opts.id) return { ok: true, params: { element_id: opts.id } };
+  if (opts.x != null && opts.y != null) return { ok: true, params: { x: opts.x, y: opts.y } };
+  return { ok: false, error: 'pass --id <@eN> (from `describe`) or --x <n> --y <n>' };
+}
+
+function reportMissingHelper(): never {
+  console.error('helper not built. Run: ./packages/computer-helper/scripts/build.sh debug');
+  process.exit(1);
+}
+
+// Open a client, run fn, always close. Fails fast if no helper is present.
+export async function withClient<T>(fn: (client: ComputerClient) => Promise<T>): Promise<T> {
+  if (describeTransport().kind === 'none') reportMissingHelper();
+  const client = openComputerClient();
+  try {
+    return await fn(client);
+  } finally {
+    await client.close();
+  }
+}
+
+// Unwrap an RPC response: print + exit on error, else return result.
+export function unwrap(r: RPCResponse): Record<string, unknown> {
+  if (r.error) {
+    console.error(`error: ${r.error.code}: ${r.error.message}`);
+    process.exit(1);
+  }
+  return r.result ?? {};
+}
+
+// Resolve the target pid via list_apps + pickTarget, printing a precise error
+// and exiting when no target matches.
+async function resolveTargetPid(client: ComputerClient, opts: { pid?: number; bundle?: string }): Promise<number> {
+  // A directly-supplied pid skips the list_apps roundtrip — the daemon gates.
+  if (opts.pid != null) return opts.pid;
+  const apps = unwrap(await client.call('list_apps'));
+  const list = (apps.apps as AppInfo[]) || [];
+  const picked = pickTarget(list, opts);
+  if (!picked.ok) {
+    console.error(picked.error);
+    process.exit(1);
+  }
+  return picked.app.pid;
+}
+
+function emit(result: Record<string, unknown>, json: boolean, human: () => string): void {
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(human());
+  }
+}
+
+// Add the shared --pid/--bundle target options to a verb.
+function addTargetOpts(cmd: Command): Command {
+  return cmd
+    .option('--bundle <id>', 'Bundle id of the target app (default: frontmost allow-listed app)')
+    .option('--pid <n>', 'Target pid directly (overrides --bundle)', (v) => parseInt(v, 10));
+}
+
+// Add the shared --id/--x/--y element-or-coords options to a verb.
+function addElementOrCoordOpts(cmd: Command): Command {
+  return cmd
+    .option('--id <@eN>', 'Element id from `describe`')
+    .option('--x <n>', 'X coordinate (global, points)', (v) => parseInt(v, 10))
+    .option('--y <n>', 'Y coordinate (global, points)', (v) => parseInt(v, 10));
+}
+
+type TargetOpts = { pid?: number; bundle?: string; json?: boolean };
+type ElemOpts = TargetOpts & { id?: string; x?: number; y?: number };
+
+export function registerActionCommands(program: Command): void {
+  // apps — list_apps
+  addTargetOpts(
+    program
+      .command('apps')
+      .description('List apps the daemon may drive (allow-listed + running)')
+      .option('--json', 'Emit JSON'),
+  ).action(async (opts: TargetOpts) => {
+    await withClient(async (client) => {
+      const res = unwrap(await client.call('list_apps'));
+      const list = (res.apps as AppInfo[]) || [];
+      emit(res, Boolean(opts.json), () =>
+        list.length === 0
+          ? '(no allow-listed apps running)'
+          : list
+              .map((a) => `${a.active ? '*' : ' '} ${String(a.pid).padStart(6)}  ${a.bundle_id}  ${a.name}`)
+              .join('\n'),
+      );
+    });
+  });
+
+  // describe — AX tree
+  addTargetOpts(
+    program
+      .command('describe')
+      .description('Dump the accessibility tree (element ids feed click/type --id)')
+      .option('--depth <n>', 'Max tree depth', (v) => parseInt(v, 10))
+      .option('--json', 'Emit compact JSON (default: pretty)'),
+  ).action(async (opts: TargetOpts & { depth?: number }) => {
+    await withClient(async (client) => {
+      const pid = await resolveTargetPid(client, opts);
+      const params: Record<string, unknown> = { pid };
+      if (opts.depth != null) params.max_depth = opts.depth;
+      const res = unwrap(await client.call('describe', params));
+      // The tree is inherently structured — always JSON, pretty unless --json.
+      console.log(JSON.stringify(opts.json ? res : res.tree ?? res, null, 2));
+    });
+  });
+
+  // click
+  addElementOrCoordOpts(
+    addTargetOpts(
+      program
+        .command('click')
+        .description('Click an element (--id) or screen coordinate (--x --y)')
+        .option('--count <n>', 'Click count (2 = double-click)', (v) => parseInt(v, 10))
+        .option('--background', 'Focus-safe postToPid delivery (plain AppKit only; skips HID tap)')
+        .option('--json', 'Emit JSON'),
+    ),
+  ).action(async (opts: ElemOpts & { count?: number; background?: boolean }) => {
+    await withClient(async (client) => {
+      const pid = await resolveTargetPid(client, opts);
+      const spec = buildElementOrCoords(opts);
+      if (!spec.ok) {
+        console.error(spec.error);
+        process.exit(1);
+      }
+      const params: Record<string, unknown> = { pid, ...spec.params };
+      if (opts.count != null) params.count = opts.count;
+      if (opts.background) params.background = true;
+      const res = unwrap(await client.call('click', params));
+      emit(res, Boolean(opts.json), () => `clicked (${res.action ?? 'ok'})`);
+    });
+  });
+
+  // right-click
+  addElementOrCoordOpts(
+    addTargetOpts(
+      program
+        .command('right-click')
+        .description('Right-click (context menu) an element or coordinate')
+        .option('--json', 'Emit JSON'),
+    ),
+  ).action(async (opts: ElemOpts) => {
+    await withClient(async (client) => {
+      const pid = await resolveTargetPid(client, opts);
+      const spec = buildElementOrCoords(opts);
+      if (!spec.ok) {
+        console.error(spec.error);
+        process.exit(1);
+      }
+      const res = unwrap(await client.call('right_click', { pid, ...spec.params }));
+      emit(res, Boolean(opts.json), () => `right-clicked (${res.method ?? 'ok'})`);
+    });
+  });
+
+  // type — set value on a field (--id) or paste at coords, optional commit
+  addElementOrCoordOpts(
+    addTargetOpts(
+      program
+        .command('type')
+        .description('Set a field value (--id) or paste at a coordinate (--x --y)')
+        .requiredOption('--text <s>', 'Text to enter')
+        .option('--commit', 'Commit after typing (AXConfirm / Return) so the value reaches the model')
+        .option('--allow-secure-field', 'Permit typing into a password field')
+        .option('--json', 'Emit JSON'),
+    ),
+  ).action(async (opts: ElemOpts & { text: string; commit?: boolean; allowSecureField?: boolean }) => {
+    await withClient(async (client) => {
+      const pid = await resolveTargetPid(client, opts);
+      const spec = buildElementOrCoords(opts);
+      if (!spec.ok) {
+        console.error(spec.error);
+        process.exit(1);
+      }
+      const params: Record<string, unknown> = { pid, ...spec.params, text: opts.text };
+      if (opts.commit) params.commit = true;
+      if (opts.allowSecureField) params.allow_secure_field = true;
+      const res = unwrap(await client.call('type', params));
+      emit(res, Boolean(opts.json), () => `typed ${opts.text.length} char(s)${res.committed ? ' (committed)' : ''}`);
+    });
+  });
+
+  // type-text — stream an arbitrary unicode string into the focused field
+  addTargetOpts(
+    program
+      .command('type-text')
+      .description('Type an arbitrary unicode string into the focused field (focus first via click/focus)')
+      .requiredOption('--text <s>', 'Text to type')
+      .option('--commit', 'Press Return after typing')
+      .option('--json', 'Emit JSON'),
+  ).action(async (opts: TargetOpts & { text: string; commit?: boolean }) => {
+    await withClient(async (client) => {
+      const pid = await resolveTargetPid(client, opts);
+      const params: Record<string, unknown> = { pid, text: opts.text };
+      if (opts.commit) params.commit = true;
+      const res = unwrap(await client.call('type_text', params));
+      emit(res, Boolean(opts.json), () => `typed ${res.chars ?? opts.text.length} char(s)`);
+    });
+  });
+
+  // key — single chord
+  addTargetOpts(
+    program
+      .command('key')
+      .description('Send a key chord, e.g. "cmd+shift+s", "enter", "esc"')
+      .requiredOption('--keys <chord>', 'Key chord')
+      .option('--json', 'Emit JSON'),
+  ).action(async (opts: TargetOpts & { keys: string }) => {
+    await withClient(async (client) => {
+      const pid = await resolveTargetPid(client, opts);
+      const res = unwrap(await client.call('key', { pid, keys: opts.keys }));
+      emit(res, Boolean(opts.json), () => `sent ${opts.keys}`);
+    });
+  });
+
+  // drag — from one point to another
+  addTargetOpts(
+    program
+      .command('drag')
+      .description('Drag from one coordinate to another')
+      .requiredOption('--from <x,y>', 'Start coordinate "x,y"')
+      .requiredOption('--to <x,y>', 'End coordinate "x,y"')
+      .option('--button <left|right>', 'Mouse button', 'left')
+      .option('--background', 'Focus-safe postToPid delivery (plain AppKit only)')
+      .option('--json', 'Emit JSON'),
+  ).action(async (opts: TargetOpts & { from: string; to: string; button: string; background?: boolean }) => {
+    let from: { x: number; y: number };
+    let to: { x: number; y: number };
+    try {
+      from = parseXY(opts.from, '--from');
+      to = parseXY(opts.to, '--to');
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+    await withClient(async (client) => {
+      const pid = await resolveTargetPid(client, opts);
+      const params: Record<string, unknown> = {
+        pid,
+        from: [from.x, from.y],
+        to: [to.x, to.y],
+        button: opts.button,
+      };
+      if (opts.background) params.background = true;
+      const res = unwrap(await client.call('drag', params));
+      emit(res, Boolean(opts.json), () => `dragged ${opts.from} -> ${opts.to} (${res.method ?? 'ok'})`);
+    });
+  });
+
+  // scroll — by delta at an element or coordinate
+  addElementOrCoordOpts(
+    addTargetOpts(
+      program
+        .command('scroll')
+        .description('Scroll by a pixel delta at an element or coordinate')
+        .option('--dy <n>', 'Vertical delta (negative = down)', (v) => parseInt(v, 10))
+        .option('--dx <n>', 'Horizontal delta', (v) => parseInt(v, 10))
+        .option('--json', 'Emit JSON'),
+    ),
+  ).action(async (opts: ElemOpts & { dy?: number; dx?: number }) => {
+    await withClient(async (client) => {
+      const pid = await resolveTargetPid(client, opts);
+      const params: Record<string, unknown> = { pid };
+      if (opts.id) params.element_id = opts.id;
+      if (opts.x != null) params.x = opts.x;
+      if (opts.y != null) params.y = opts.y;
+      if (opts.dy != null) params.dy = opts.dy;
+      if (opts.dx != null) params.dx = opts.dx;
+      const res = unwrap(await client.call('scroll', params));
+      emit(res, Boolean(opts.json), () => `scrolled (${res.method ?? 'ok'})`);
+    });
+  });
+
+  // ax-action — perform any advertised AX action on an element
+  addTargetOpts(
+    program
+      .command('ax-action')
+      .description('Perform an arbitrary AX action (AXConfirm, AXCancel, AXRaise, ...) on an element')
+      .requiredOption('--id <@eN>', 'Element id from `describe`')
+      .requiredOption('--action <name>', 'AX action name')
+      .option('--json', 'Emit JSON'),
+  ).action(async (opts: TargetOpts & { id: string; action: string }) => {
+    await withClient(async (client) => {
+      const pid = await resolveTargetPid(client, opts);
+      const res = unwrap(await client.call('ax_action', { pid, element_id: opts.id, action: opts.action }));
+      emit(res, Boolean(opts.json), () => `performed ${opts.action}`);
+    });
+  });
+
+  // focus — set keyboard focus to an element
+  addTargetOpts(
+    program
+      .command('focus')
+      .description('Set keyboard focus to an element (so type-text/key land there)')
+      .requiredOption('--id <@eN>', 'Element id from `describe`')
+      .option('--json', 'Emit JSON'),
+  ).action(async (opts: TargetOpts & { id: string }) => {
+    await withClient(async (client) => {
+      const pid = await resolveTargetPid(client, opts);
+      const res = unwrap(await client.call('set_focus', { pid, element_id: opts.id }));
+      emit(res, Boolean(opts.json), () => `focused ${opts.id}`);
+    });
+  });
+}

--- a/src/commands/computer.ts
+++ b/src/commands/computer.ts
@@ -18,23 +18,25 @@ import {
   writeComputerPolicy,
   writeComputerPeers,
 } from '../lib/computer-rpc.js';
+import { registerActionCommands, withClient, unwrap, pickTarget, type AppInfo } from './computer-actions.js';
 
 // Help groups — mirror `agents browser` so the mental model carries over.
 const COMPUTER_HELP_GROUPS = [
-  { title: 'Installation', names: ['install-helper'] },
+  { title: 'Installation', names: ['setup'] },
   { title: 'Daemon lifecycle', names: ['start', 'stop', 'reload', 'status'] },
-  { title: 'Capture evidence', names: ['screenshot'] },
+  { title: 'Observe', names: ['apps', 'describe', 'screenshot'] },
+  { title: 'Interact', names: ['click', 'right-click', 'type', 'type-text', 'key', 'drag', 'scroll', 'ax-action', 'focus'] },
 ] as const;
 
 export function registerComputerCommand(program: Command): void {
   const computer = program
-    .command('computers')
+    .command('computer')
     .description('Drive macOS apps via Accessibility — list, screenshot, click, type (macOS only)')
     // The whole subsystem is macOS Accessibility / TCC. Fail fast with a clear
     // message on other platforms instead of a downstream ENOENT / launchctl error.
     .hook('preAction', () => {
       if (process.platform !== 'darwin') {
-        console.error('agents computers: macOS only — it drives apps via the macOS Accessibility API.');
+        console.error('agents computer: macOS only — it drives apps via the macOS Accessibility API.');
         process.exit(1);
       }
     });
@@ -44,18 +46,14 @@ export function registerComputerCommand(program: Command): void {
 }
 
 export function registerComputerSubcommands(program: Command): void {
-  registerInstallHelperCommand(program);
+  registerSetupCommand(program);
   registerStartCommand(program);
   registerStopCommand(program);
   registerReloadCommand(program);
   registerStatusCommand(program);
   registerScreenshotCommand(program);
+  registerActionCommands(program);
   registerCommandGroups(program, COMPUTER_HELP_GROUPS);
-}
-
-function reportMissingHelper(): never {
-  console.error('helper not built. Run: ./packages/computer-helper/scripts/build.sh debug');
-  process.exit(1);
 }
 
 function registerStatusCommand(program: Command): void {
@@ -82,7 +80,7 @@ function registerStatusCommand(program: Command): void {
 
       if (!installed) {
         console.log('');
-        console.log('Run:  agents computer install-helper');
+        console.log('Run:  agents computer setup');
         return;
       }
       if (!socketUp) {
@@ -116,58 +114,64 @@ function registerStatusCommand(program: Command): void {
 function registerScreenshotCommand(program: Command): void {
   program
     .command('screenshot')
-    .description('Capture a JPEG of the frontmost window of a bundle id (default: frontmost app)')
-    .option('--bundle <id>', 'Bundle id to capture (default: bundle id of frontmost app)')
+    .description('Capture a window (default: largest), enumerate windows (--list), or the whole display (--display)')
+    .option('--bundle <id>', 'Bundle id to capture (default: frontmost allow-listed app)')
+    .option('--pid <n>', 'Target pid directly (overrides --bundle)', (v) => parseInt(v, 10))
+    .option('--list', 'List the app\'s windows (id/title/layer/bounds) instead of capturing — reveals modals/popups')
+    .option('--window-id <n>', 'Capture a specific window by id (from --list)', (v) => parseInt(v, 10))
+    .option('--display', 'Capture the whole display the app is on (composites stacked modals)')
     .option('--out <path>', 'Output JPEG path', './computer-screenshot.jpg')
     .option('--quality <n>', 'JPEG quality 1-100', (v) => parseInt(v, 10), 85)
-    .action(async (opts: { bundle?: string; out: string; quality: number }) => {
-      const transport = describeTransport();
-      if (transport.kind === 'none') reportMissingHelper();
-
+    .option('--json', 'Emit JSON (metadata for captures; window list for --list)')
+    .action(async (opts: {
+      bundle?: string;
+      pid?: number;
+      list?: boolean;
+      windowId?: number;
+      display?: boolean;
+      out: string;
+      quality: number;
+      json?: boolean;
+    }) => {
       const quality = Math.max(1, Math.min(100, opts.quality || 85));
 
-      const client = openComputerClient();
-      try {
-        // Step 1: list_apps to get the candidate set.
-        const apps = await client.call('list_apps');
-        if (apps.error) {
-          console.error(`error: ${apps.error.code}: ${apps.error.message}`);
-          process.exit(1);
-        }
-        const list = (apps.result?.apps as Array<{
-          pid: number;
-          name: string;
-          bundle_id: string;
-          active: boolean;
-          excluded: boolean;
-        }>) || [];
-
-        let target: typeof list[number] | undefined;
-        if (opts.bundle) {
-          target = list.find((a) => a.bundle_id === opts.bundle);
-          if (!target) {
-            console.error(`bundle not in allow list (or not running): ${opts.bundle}`);
-            console.error(`add Computer(${opts.bundle}) to a permissions group, then \`agents computer reload\``);
+      await withClient(async (client) => {
+        // Resolve the target pid (explicit --pid, else --bundle, else frontmost).
+        let pid = opts.pid;
+        if (pid == null) {
+          const list = (unwrap(await client.call('list_apps')).apps as AppInfo[]) || [];
+          const picked = pickTarget(list, { bundle: opts.bundle });
+          if (!picked.ok) {
+            console.error(picked.error);
             process.exit(1);
           }
-        } else {
-          target = list.find((a) => a.active);
-          if (!target) {
-            console.error('no active app found in allow list');
-            console.error('add Computer(<bundle-id>) to a permissions group, then `agents computer reload`');
-            process.exit(1);
-          }
+          pid = picked.app.pid;
         }
 
-        // Step 2: screenshot.
-        const shot = await client.call('screenshot', { pid: target.pid, quality });
-        if (shot.error) {
-          console.error(`error: ${shot.error.code}: ${shot.error.message}`);
-          process.exit(1);
+        // --list: enumerate windows, no image.
+        if (opts.list) {
+          const res = unwrap(await client.call('screenshot', { pid, list: true }));
+          const windows = (res.windows as Array<Record<string, unknown>>) || [];
+          if (opts.json) {
+            console.log(JSON.stringify(res, null, 2));
+          } else if (windows.length === 0) {
+            console.log('(no windows)');
+          } else {
+            for (const w of windows) {
+              const b = (w.bounds as number[]) || [];
+              console.log(`${String(w.window_id).padStart(8)}  layer ${w.layer}  [${b.join(',')}]  ${w.title || '(untitled)'}`);
+            }
+          }
+          return;
         }
-        const b64 = shot.result?.image_data as string | undefined;
-        const width = shot.result?.width as number | undefined;
-        const height = shot.result?.height as number | undefined;
+
+        // Capture: window (default / --window-id) or full display.
+        const params: Record<string, unknown> = { pid, quality };
+        if (opts.display) params.display = true;
+        else if (opts.windowId != null) params.window_id = opts.windowId;
+
+        const res = unwrap(await client.call('screenshot', params));
+        const b64 = res.image_data as string | undefined;
         if (!b64) {
           console.error('helper returned no image_data');
           process.exit(1);
@@ -175,14 +179,21 @@ function registerScreenshotCommand(program: Command): void {
         const buf = Buffer.from(b64, 'base64');
         const outPath = path.resolve(opts.out);
         fs.writeFileSync(outPath, buf);
-        console.log(`saved: ${outPath} (${width ?? '?'}x${height ?? '?'}, ${buf.byteLength} bytes)`);
-      } finally {
-        await client.close();
-      }
+
+        if (opts.json) {
+          // Drop the heavy base64 from the metadata echo; report where it went.
+          const meta = { ...res, image_data: `<saved to ${outPath}>` };
+          console.log(JSON.stringify(meta, null, 2));
+        } else {
+          const origin = (res.origin as number[]) || [];
+          const originStr = origin.length === 2 ? `, origin [${origin.join(',')}], scale ${res.scale ?? '?'}` : '';
+          console.log(`saved: ${outPath} (${res.width ?? '?'}x${res.height ?? '?'}, ${buf.byteLength} bytes${originStr})`);
+        }
+      });
     });
 }
 
-// install-helper:
+// setup (alias: install-helper):
 //   1. resolve dist .app
 //   2. copy to /Applications/Computer Helper.app
 //   3. codesign --verify the destination
@@ -200,9 +211,10 @@ const HELPER_APP_NAME = 'Computer Helper.app';
 const HELPER_APP_DEST = `/Applications/${HELPER_APP_NAME}`;
 const HELPER_LABEL = HELPER_BUNDLE_ID;
 
-function registerInstallHelperCommand(program: Command): void {
+function registerSetupCommand(program: Command): void {
   program
-    .command('install-helper')
+    .command('setup')
+    .alias('install-helper')
     .description('Install ComputerHelper.app to /Applications/ (does NOT activate the daemon — run `start` to enable)')
     .action(async () => {
       const srcApp = resolveHelperApp();
@@ -302,12 +314,12 @@ function registerStartCommand(program: Command): void {
 
       if (!fs.existsSync(plistPath)) {
         console.error(`plist not found at ${plistPath}`);
-        console.error('run: agents computer install-helper');
+        console.error('run: agents computer setup');
         process.exit(1);
       }
       if (!fs.existsSync(HELPER_APP_DEST)) {
         console.error(`helper app not found at ${HELPER_APP_DEST}`);
-        console.error('run: agents computer install-helper');
+        console.error('run: agents computer setup');
         process.exit(1);
       }
 


### PR DESCRIPTION
## What

`agents computer` exposed only `screenshot` + daemon lifecycle, yet the helper daemon implements 13 interaction methods (click, type, key, drag, scroll, describe, ax_action, set_focus, type_text, right_click, list_apps). They had **no CLI surface** — driving anything meant hand-writing raw socket scripts. This adds flat action verbs under `computer`, mirroring `agents browser`'s layout so the mental model carries over.

## Changes

**New verbs** (thin, typed skins over daemon methods):

| Group | Verbs |
|---|---|
| Observe | `apps`, `describe`, `screenshot` |
| Interact | `click`, `right-click`, `type`, `type-text`, `key`, `drag`, `scroll`, `ax-action`, `focus` |

- Each verb takes `--bundle <id>` (resolved to pid via `list_apps`) **or** `--pid <n>`; default is the frontmost allow-listed app. Element-targeting verbs take `--id <@eN>` (from `describe`) **or** `--x/--y`. Read verbs take `--json`.
- **`screenshot`** gains `--list` (enumerate windows incl. modals/popups), `--window-id <n>` (capture a specific window/dialog), `--display` (full-display composite), `--pid`, and `--json`; it now prints the `origin`/`scale` metadata so callers can map screenshot pixels → global coordinates.
- **Shared, unit-tested target resolver** (`pickTarget`) keeps callers in bundle-id space; pure helpers `parseXY` / `buildElementOrCoords`.
- **`install-helper` → `setup`** (more intuitive), with `install-helper` kept as an `.alias()` so shipped usage and docs keep working.
- **Fix `computers` → `computer`** (singular) — the command was registered plural while every help string, the standalone `src/computer.ts` entrypoint, and `agents browser` are singular.

## Verification

End-to-end against the live daemon (the helper input-fix build):

```
$ agents computer apps
   37162  com.adobe.Photoshop  Adobe Photoshop 2026
$ agents computer click --bundle com.adobe.Photoshop --x 18 --y 656
clicked (hidTap)
$ agents computer screenshot --list --bundle com.adobe.Photoshop
  123514  layer 0  [520,398,472,128]  Progress      ← modal the old capture hid
$ agents computer screenshot --window-id 123514 --bundle com.adobe.Photoshop --out p.jpg
saved: p.jpg (472x128, ..., origin [520,398], scale 1)
```

- **17 new unit tests** (`computer-actions.test.ts`) for the resolver precedence + arg parsing.
- **Full suite: 2247 passed, 51 skipped, 0 failed.** `tsc` clean.
- Socket round-trips are integration (repo bans mocking), verified live as above.

**Windows/cross-platform:** `computer` is macOS-only by design — a `preAction` hook hard-exits with a clear message on non-darwin. Verb registration and the TS build/unit tests are platform-agnostic, so CI on non-mac is unaffected.

## Stacking / scope

- `type-text`, `ax-action`, and `focus` call daemon methods introduced in the **helper input-fix PR** — this CLI PR stacks on it. The other verbs work against today's shipped daemon.
- **Deliberately out of scope (next):** a `computer` *skill* wrapping these verbs the way the browser skill does (`browser.ts` literally tells agents to prefer the skill), and a `docs/computer.md` refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
