### PR TITLE
feat(platform): platform abstraction foundation + Windows session path filters (#234)

### DIFF
--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -18,6 +18,7 @@ import type { AgentId } from '../lib/types.js';
 import type { SessionAgentId, SessionMeta, ViewMode } from '../lib/session/types.js';
 import { SESSION_AGENTS } from '../lib/session/types.js';
 import { discoverArtifacts, readArtifact, resolveArtifact } from '../lib/session/artifacts.js';
+import { looksLikePath, toComparablePath, homeDir } from '../lib/platform/index.js';
 import { getActiveSessions, type ActiveSession } from '../lib/session/active.js';
 import { discoverSessions, countSessionsInScope, resolveSessionById, searchContentIndex, parseTimeFilter, type DiscoverOptions, type ScanProgress } from '../lib/session/discover.js';
 import { filterTeamSessions } from '../lib/session/team-filter.js';
@@ -127,16 +128,6 @@ const PICKER_RECENT_COUNT = 15;
 const PICKER_POOL_LIMIT = 200;
 
 /**
- * Detect whether a positional argument looks like a filesystem path.
- * Naked paths (., ./, ../, /, ~) filter sessions by project directory.
- * Everything else is treated as a search query string.
- */
-function isPathLike(query: string): boolean {
-  return query === '.' || query.startsWith('./') || query.startsWith('../')
-    || query.startsWith('/') || query.startsWith('~');
-}
-
-/**
  * Resolve a path-like query to an absolute directory path.
  */
 function resolvePathFilter(query: string): string {
@@ -224,8 +215,13 @@ function contextColor(context: ActiveSession['context']): (s: string) => string 
 
 function shortCwd(cwd?: string): string {
   if (!cwd) return '-';
-  const home = os.homedir();
-  return cwd.startsWith(home) ? '~' + cwd.slice(home.length) : cwd;
+  const home = homeDir();
+  // Compare in normalized form so the `~` shorthand also lands on Windows
+  // (case-insensitive, backslash paths); on POSIX this is byte-identical to the
+  // previous `cwd.startsWith(home)`. The displayed tail keeps original casing.
+  return toComparablePath(cwd).startsWith(toComparablePath(home))
+    ? '~' + cwd.slice(home.length)
+    : cwd;
 }
 
 function formatStartedAt(startedAtMs?: number): string {
@@ -426,7 +422,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
   // Path-like queries filter by project directory instead of text search.
   let pathFilter: string | undefined;
   let searchQuery: string | undefined;
-  if (query && isPathLike(query)) {
+  if (query && looksLikePath(query)) {
     const resolved = resolvePathFilter(query);
     if (!fs.existsSync(resolved)) {
       console.log(chalk.yellow(`Path not found: ${resolved}`));

--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -12,6 +12,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { getDaemonDir as getDaemonDirRoot } from './state.js';
+import { isAlive } from './platform/index.js';
 import { listJobs as listAllJobs } from './routines.js';
 import { JobScheduler } from './scheduler.js';
 import { executeJobDetached, monitorRunningJobs } from './runner.js';
@@ -118,13 +119,9 @@ export function removeDaemonPid(): void {
 export function isDaemonRunning(): boolean {
   const pid = readDaemonPid();
   if (!pid) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    removeDaemonPid();
-    return false;
-  }
+  if (isAlive(pid)) return true;
+  removeDaemonPid();
+  return false;
 }
 
 /** Redact values that look like tokens or credentials in a log message. */

--- a/src/lib/platform/exec.test.ts
+++ b/src/lib/platform/exec.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { whichCommand, findExecutable } from './exec.js';
+
+describe('whichCommand', () => {
+  it('is `where` on win32, `which` elsewhere', () => {
+    expect(whichCommand('win32')).toBe('where');
+    expect(whichCommand('darwin')).toBe('which');
+    expect(whichCommand('linux')).toBe('which');
+  });
+});
+
+describe('findExecutable', () => {
+  it('resolves a real executable to an absolute path on the current platform', () => {
+    // `node` is guaranteed present in CI and dev.
+    const p = findExecutable('node');
+    expect(p).toBeTruthy();
+    expect(p!.length).toBeGreaterThan(0);
+    expect(p).toMatch(/node/i);
+  });
+
+  it('returns null for a name that does not exist', () => {
+    expect(findExecutable('definitely-not-a-real-binary-xyz123')).toBeNull();
+  });
+});

--- a/src/lib/platform/exec.ts
+++ b/src/lib/platform/exec.ts
@@ -1,0 +1,25 @@
+/**
+ * Executable resolution, platform-aware.
+ */
+import { execFileSync } from 'child_process';
+
+/** PATH-search command for the platform: `where` on Windows, else `which`. */
+export function whichCommand(platform: NodeJS.Platform = process.platform): string {
+  return platform === 'win32' ? 'where' : 'which';
+}
+
+/**
+ * Resolve an executable name to its absolute path via the OS PATH search, or
+ * `null` if not found. On Windows `where` can return several lines (one per
+ * PATHEXT match, e.g. `agents.cmd` and `agents.ps1`) — the first is the one the
+ * shell would actually run, matching `which` semantics on POSIX.
+ */
+export function findExecutable(name: string, platform: NodeJS.Platform = process.platform): string | null {
+  try {
+    const out = execFileSync(whichCommand(platform), [name], { encoding: 'utf-8' });
+    const first = out.trim().split(/\r?\n/)[0]?.trim();
+    return first || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/platform/index.ts
+++ b/src/lib/platform/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Platform abstraction — the ONE place OS-divergent behavior is decided.
+ *
+ * Consumers express intent (`looksLikePath`, `findExecutable`, `isAlive`) instead
+ * of scattering `process.platform === 'win32'` checks. Each helper that has an
+ * observable branch accepts an explicit `platform` argument (defaulting to
+ * `process.platform`), so all three OSes are unit-testable on any host.
+ *
+ * Modules grow per concern as features land:
+ *   paths   — path classification + normalization
+ *   exec    — executable resolution
+ *   process — process liveness / control
+ * (ipc + shell follow when their consumers migrate off inline branches.)
+ */
+export const IS_WINDOWS = process.platform === 'win32';
+export const IS_MACOS = process.platform === 'darwin';
+export const IS_LINUX = process.platform === 'linux';
+
+export * from './paths.js';
+export * from './exec.js';
+export * from './process.js';

--- a/src/lib/platform/paths.test.ts
+++ b/src/lib/platform/paths.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import * as os from 'os';
+import { looksLikePath, toComparablePath, homeDir } from './paths.js';
+
+describe('looksLikePath', () => {
+  // POSIX markers must classify identically on every platform — this is the
+  // pre-existing behavior the migration must not regress.
+  for (const platform of ['darwin', 'linux', 'win32'] as const) {
+    it(`recognizes POSIX path markers on ${platform}`, () => {
+      for (const q of ['.', './x', '../x', '/abs/path', '~', '~/x']) {
+        expect(looksLikePath(q, platform)).toBe(true);
+      }
+    });
+    it(`treats plain words as search terms on ${platform}`, () => {
+      for (const q of ['claude', 'fix auth', 'RUSH-123', '']) {
+        expect(looksLikePath(q, platform)).toBe(false);
+      }
+    });
+  }
+
+  it('recognizes Windows drive-letter and UNC paths ONLY on win32', () => {
+    for (const q of ['C:\\repo', 'c:/repo', 'D:\\a\\b', '\\\\server\\share', '.\\rel', '..\\rel']) {
+      expect(looksLikePath(q, 'win32')).toBe(true);
+      // The crux of #234's no-regression guarantee: the same string is a search
+      // term on macOS/Linux, never silently reinterpreted as a path filter.
+      expect(looksLikePath(q, 'darwin')).toBe(false);
+      expect(looksLikePath(q, 'linux')).toBe(false);
+    }
+  });
+});
+
+describe('toComparablePath', () => {
+  it('is identity on POSIX (no behavior change)', () => {
+    expect(toComparablePath('/Users/Me/Repo', 'darwin')).toBe('/Users/Me/Repo');
+    expect(toComparablePath('src/Foo.ts', 'linux')).toBe('src/Foo.ts');
+  });
+  it('folds separators and lowercases on win32 (case-insensitive FS)', () => {
+    expect(toComparablePath('C:\\Users\\Me\\Repo', 'win32')).toBe('c:/users/me/repo');
+    expect(toComparablePath('src\\Foo.ts', 'win32')).toBe('src/foo.ts');
+  });
+});
+
+describe('homeDir', () => {
+  it('matches os.homedir()', () => {
+    expect(homeDir()).toBe(os.homedir());
+  });
+});

--- a/src/lib/platform/paths.ts
+++ b/src/lib/platform/paths.ts
@@ -1,0 +1,56 @@
+/**
+ * Path classification + normalization, platform-aware.
+ */
+import * as os from 'os';
+
+/** Windows drive-letter absolute path: `C:\` or `C:/`. */
+const WIN_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
+
+/**
+ * Does this positional argument look like a filesystem path (vs a search term)?
+ *
+ * POSIX markers (`.`, `./`, `../`, `/`, `~`) are recognized on every platform —
+ * identical to the long-standing behavior. Windows-only shapes (drive-letter
+ * `C:\…`, UNC `\\…`, backslash-relative `.\` / `..\`) are recognized ONLY on
+ * win32, so a literal `C:\repo` typed on macOS/Linux still resolves as a search
+ * term — i.e. no behavior change off Windows.
+ */
+export function looksLikePath(query: string, platform: NodeJS.Platform = process.platform): boolean {
+  if (
+    query === '.' ||
+    query.startsWith('./') ||
+    query.startsWith('../') ||
+    query.startsWith('/') ||
+    query.startsWith('~')
+  ) {
+    return true;
+  }
+  if (platform === 'win32') {
+    return (
+      WIN_DRIVE_RE.test(query) ||
+      query.startsWith('\\\\') ||
+      query.startsWith('.\\') ||
+      query.startsWith('..\\')
+    );
+  }
+  return false;
+}
+
+/**
+ * Normalize a path for comparison/prefix-matching: backslashes folded to forward
+ * slashes and lowercased on Windows (its filesystem is case-insensitive). On
+ * POSIX the input is returned unchanged, so callers behave exactly as before.
+ */
+export function toComparablePath(p: string, platform: NodeJS.Platform = process.platform): string {
+  if (platform === 'win32') return p.replace(/\\/g, '/').toLowerCase();
+  return p;
+}
+
+/**
+ * Canonical home directory. Use this instead of `process.env.HOME`, which is
+ * unset on Windows (where the home is `USERPROFILE`); `os.homedir()` resolves
+ * correctly on all three platforms.
+ */
+export function homeDir(): string {
+  return os.homedir();
+}

--- a/src/lib/platform/process.test.ts
+++ b/src/lib/platform/process.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { isAlive } from './process.js';
+
+describe('isAlive', () => {
+  it('is true for the current process', () => {
+    expect(isAlive(process.pid)).toBe(true);
+  });
+
+  it('is false for invalid pids', () => {
+    expect(isAlive(0)).toBe(false);
+    expect(isAlive(-1)).toBe(false);
+  });
+
+  it('is false for a pid that is almost certainly not running', () => {
+    // 2^30 is well above any realistic live PID on Linux/macOS/Windows.
+    expect(isAlive(1 << 30)).toBe(false);
+  });
+});

--- a/src/lib/platform/process.ts
+++ b/src/lib/platform/process.ts
@@ -1,0 +1,21 @@
+/**
+ * Process liveness / control, platform-aware.
+ */
+
+/**
+ * Is a process with this PID currently alive?
+ *
+ * Uses the signal-0 probe, which is cross-platform in Node (Windows included —
+ * it maps to OpenProcess). Returns false on any error (no such process, or no
+ * permission to signal it), matching the long-standing call sites that treat a
+ * throw from `process.kill(pid, 0)` as "not running".
+ */
+export function isAlive(pid: number): boolean {
+  if (!pid || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/pty-server.ts
+++ b/src/lib/pty-server.ts
@@ -16,6 +16,7 @@ import * as crypto from 'crypto';
 import { execFileSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { getPtyDir as getPtyDirRoot } from './state.js';
+import { isAlive } from './platform/index.js';
 
 /**
  * Capture a stable identifier for a process at the moment it was started.
@@ -197,12 +198,12 @@ export function isPtyServerRunning(): boolean {
   try {
     const pid = parseInt(fs.readFileSync(pidPath, 'utf-8').trim(), 10);
     if (isNaN(pid)) return false;
-    process.kill(pid, 0);
-    return true;
+    if (isAlive(pid)) return true;
   } catch {
-    try { fs.unlinkSync(pidPath); } catch {}
-    return false;
+    // read failed — fall through and treat the pid file as stale
   }
+  try { fs.unlinkSync(pidPath); } catch {}
+  return false;
 }
 
 // --- Logging ---

--- a/src/lib/session/artifacts.ts
+++ b/src/lib/session/artifacts.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { SessionMeta, SessionArtifact } from './types.js';
 import { parseSession } from './parse.js';
+import { toComparablePath } from '../platform/index.js';
 
 /** Tool names that produce file artifacts (writes, edits, patches). */
 const WRITE_TOOLS = new Set([
@@ -97,8 +98,13 @@ export function resolveArtifact(
   if (byBase.length === 1) return byBase[0];
   if (byBase.length > 1) return byBase[0];
 
-  // Path suffix match (e.g. "src/foo.ts")
-  const bySuffix = artifacts.filter(a => a.path.endsWith('/' + name) || a.path === name);
+  // Path suffix match (e.g. "src/foo.ts"). Normalize so Windows `\` paths match
+  // a forward-slash query too; on POSIX this is identical to the old comparison.
+  const target = toComparablePath(name);
+  const bySuffix = artifacts.filter(a => {
+    const ap = toComparablePath(a.path);
+    return ap.endsWith('/' + target) || ap === target;
+  });
   if (bySuffix.length >= 1) return bySuffix[0];
 
   return null;

--- a/src/lib/teams/agents.ts
+++ b/src/lib/teams/agents.ts
@@ -14,6 +14,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { randomUUID } from 'crypto';
 import { resolveAgentsDir } from './persistence.js';
+import { findExecutable } from '../platform/index.js';
 import { normalizeEvents, AgentType } from './parsers.js';
 import { debug } from './debug.js';
 import { setGeminiAutoUpdateDisabled, updateGeminiSettings } from '../gemini-settings.js';
@@ -331,13 +332,10 @@ export function checkCliAvailable(agentType: AgentType): [boolean, string | null
     return [false, `Unknown agent type: ${agentType}`];
   }
 
-  try {
-    const whichCmd = process.platform === 'win32' ? 'where' : 'which';
-    const whichPath = execFileSync(whichCmd, [executable], { encoding: 'utf-8' }).trim().split(/\r?\n/)[0].trim();
-    return [true, whichPath];
-  } catch {
-    return [false, `CLI tool '${executable}' not found in PATH. Install it first.`];
-  }
+  const resolved = findExecutable(executable);
+  return resolved
+    ? [true, resolved]
+    : [false, `CLI tool '${executable}' not found in PATH. Install it first.`];
 }
 
 /** Check availability of all known agent CLIs. Returns a map of agent type to install status. */


### PR DESCRIPTION
Establishes the scalable cross-platform pattern (Linux/macOS/Windows) and lands the first real consumer on it. Part of the Windows-support track (#231-#236 / RUSH-1070-1076).

## The pattern: branch once per concern, consumers express intent

Today there are **41 `process.platform` branches across ~20 files** plus OS-divergent primitives (`which`/`lsof`/`ps`/`pbcopy`/signals) spread across ~28 more — the whack-a-mole the audit flagged. This introduces `src/lib/platform/` as the single source of truth:

```
src/lib/platform/
  index.ts    IS_WINDOWS/IS_MACOS/IS_LINUX + barrel
  paths.ts    looksLikePath · toComparablePath · homeDir
  exec.ts     whichCommand · findExecutable (where/PATHEXT-aware)
  process.ts  isAlive (cross-platform signal-0 probe)
```

No consumer writes `process.platform === 'win32'` — they call `looksLikePath(arg)` / `findExecutable('agents')` / `isAlive(pid)`. The branch lives once, inside the concern module. No class hierarchy, no DI — just intent-revealing functions. Each helper with an observable branch takes an explicit `platform` arg (default `process.platform`), so all three OSes are unit-tested on any host (same approach as the existing `derivePtyEndpoint(platform, …)`).

Modules are **seeded with exactly the functions consumed here** — they grow per concern as #231 (binary/shim resolution), #235 (process inspection), #236 (kill-tree, path portability) land. No speculative dead code.

## The one behavior change — #234 (sessions Windows paths)

`agents sessions C:\repo` / `\\server\share` now classify as **path filters** on Windows instead of being mis-read as search terms (`looksLikePath`); artifact suffix-matching and the `~` cwd shorthand handle backslash + case-insensitive paths (`toComparablePath`). Drive-letter/UNC shapes are recognized **only on win32** — macOS/Linux behavior is byte-identical.

## No-DX-change consolidations onto the foundation

Behavior-preserving swaps (covered by existing tests):
- `teams/agents.ts` `checkCliAvailable` → `findExecutable` (was inline `where`/`which`)
- `daemon.ts` `isDaemonRunning`, `pty-server.ts` `isPtyServerRunning` → `isAlive`

## Verification
- 16 new platform unit tests (all three OSes via explicit `platform` arg).
- **Full suite: 2252 passed / 0 failed** — the regression gate for the migrations.
- **Real Windows-ARM** (Parallels, win32/arm64, Node 24): `looksLikePath` classifies every drive-letter/UNC/backslash case correctly; `toComparablePath('C:\Users\Me\Repo')` → `c:/users/me/repo`.
- **No command surface, flags, or output changed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)