### PR TITLE
feat(windows): shorthand .cmd shims + honest PATH guidance on install (#231)

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -95,6 +95,11 @@ function writeAliasShims() {
     const target = path.join(SHIMS_DIR, name);
     const script = `#!/bin/sh\nAGENTS_BIN=${shellQuote(AGENTS_BIN)}\nif [ -z "$AGENTS_BIN" ] || [ ! -x "$AGENTS_BIN" ]; then\n  echo "agents: agents-cli entrypoint missing or not executable: $AGENTS_BIN" >&2\n  exit 127\nfi\nexec "$AGENTS_BIN" ${name} "$@"\n`;
     fs.writeFileSync(target, script, { mode: 0o755 });
+    // Windows can't run the POSIX shim; drop a `.cmd` companion that invokes the
+    // entrypoint via node so the bare shorthand works in a Windows shell.
+    if (process.platform === 'win32') {
+      fs.writeFileSync(target + '.cmd', `@echo off\r\nnode "${AGENTS_BIN}" ${name} %*\r\n`);
+    }
     written.push(name);
   }
   return written;
@@ -139,8 +144,20 @@ function isAlreadyConfigured(rcFile) {
 }
 
 async function main() {
+  // Windows has no shell rc files to edit. Write the `.cmd` shorthands and point
+  // the user at the PATH entry they can add (the primary `agents` command is
+  // already on PATH via npm's global bin, so this only affects bare shorthands
+  // and versioned aliases).
+  if (process.platform === 'win32') {
+    console.log(`\nagents-cli installed.`);
+    const written = writeAliasShims();
+    console.log(`  Installed shorthands: ${written.join(', ')}`);
+    console.log(`\nTo use bare shorthands (${ALIASES.join(', ')}) and versioned aliases, add this to your PATH:`);
+    console.log(`  ${SHIMS_DIR}`);
+    console.log(`  PowerShell: setx PATH "$env:PATH;${SHIMS_DIR}"  (then open a new terminal)`);
+  }
   // Opt-in: AGENTS_INIT_SHELL=1 npm install -g @phnx-labs/agents-cli
-  if (process.env.AGENTS_INIT_SHELL === '1') {
+  else if (process.env.AGENTS_INIT_SHELL === '1') {
     const rcFile = getShellRc();
     if (!isAlreadyConfigured(rcFile)) {
       const addition = `\n# agents-cli: version switching for AI coding agents\n${exportLine}\n`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,7 @@ import {
   removeLegacyUserShim,
 } from './lib/shims.js';
 import type { AgentId } from './lib/types.js';
+import { IS_WINDOWS } from './lib/platform/index.js';
 
 // Transparent shim delegate: the generated Windows `.cmd` shims invoke
 // `agents __shim <agent>[@version] <raw args>`. Intercept here, before commander
@@ -518,6 +519,14 @@ async function maybeBootstrapShimIntegration(
   // "yes" to never deletes the file; next invocation finds it again).
   for (const agent of installedAgents) {
     removeLegacyUserShim(agent);
+  }
+
+  // The remaining flow is rc-file PATH repair, which is POSIX-only. On Windows
+  // the shims were just regenerated (incl. `.cmd` companions) above; PATH setup
+  // is covered by the install-time guidance, so stop here rather than printing
+  // shell-rc instructions that don't apply.
+  if (IS_WINDOWS) {
+    return;
   }
 
   const defaultAgents = installedAgents.filter((agent) => getGlobalDefault(agent));

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -1638,6 +1638,15 @@ Then restart your shell or run:
 export function addShimsToPath(
   overrides?: { homeDir?: string; shell?: string; shimsDir?: string },
 ): { success: boolean; alreadyPresent?: boolean; rcFile?: string; error?: string } {
+  // Windows has no shell rc file to edit: the primary `agents` command is already
+  // on PATH via npm's global bin, and bare shorthands / versioned aliases are
+  // handled by the `.cmd` shims plus the PATH guidance printed at install time.
+  // Report "already present" so callers don't emit a misleading "added to
+  // ~/.bashrc / source ~/.bashrc" message. (The `shell` override is the test hook
+  // for exercising the POSIX path, so it bypasses this short-circuit.)
+  if (IS_WINDOWS && !overrides?.shell) {
+    return { success: true, alreadyPresent: true };
+  }
   const shimsDir = overrides?.shimsDir || getShimsDir();
   const { rcFile, rcPath, shell } = getShellRcFile(overrides);
 


### PR DESCRIPTION
Finishes the Windows setup surface of #231, on top of #253 (agent `.cmd` shims) and the #252 platform foundation.

## Two bugs, both confirmed on a live Windows VM
1. `agents add` printed **"Added shims to ~/.bashrc" / "source ~/.bashrc"** on Windows — there's no rc file and no `source`.
2. Shorthand shims (`sessions`/`secrets`/`browser`/`pty`/`teams`) were POSIX `#!/bin/sh` only — couldn't run standalone in a Windows shell.

## Changes (all `IS_WINDOWS`-gated; POSIX byte-unchanged)
- **postinstall.js**: write a `<name>.cmd` companion per shorthand (`node "<entrypoint>" <name> %*`), and on Windows replace the shell-rc PATH logic with honest guidance — the shims dir + a `setx` one-liner. (The primary `agents` command is already on PATH via npm's global bin, so this only affects bare shorthands + versioned aliases.)
- **shims.ts `addShimsToPath`**: short-circuit on Windows (no rc file to edit) so `add`/`setup`/`refresh` stop emitting the misleading message. The `shell` test override bypasses the short-circuit, so the existing POSIX tests still exercise the real path.
- **index.ts `maybeBootstrapShimIntegration`**: regenerate shims as before, then stop before the POSIX rc-file PATH-repair prompt on Windows.

## Verified end-to-end on real Windows
Parallels (win32 x64, Node 24), installing this build via `npm pack` + `npm i -g`:
```
postinstall wrote: browser.cmd codex.cmd pty.cmd secrets.cmd sessions.cmd teams.cmd
> sessions --help        # runs standalone via the .cmd shorthand
  -n, --limit <n>  Maximum number of sessions ...
> agents add codex -y    # NO "~/.bashrc" / "source" message anymore
  Codex@0.139.0 already installed
```
Full suite green (2253 passed; the occasional 1-fail is the pre-existing `non-interactive.test.ts` real-npm flake).

With this + #253, the Windows **setup → add → run → standalone shims** path works. Remaining #231 niceties (auto-mutating Windows PATH via the registry rather than printing a `setx` hint) can follow if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)