### PR TITLE
docs(secrets): multi-account-per-website bundle convention

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -234,6 +234,32 @@ agents secrets exec prod -- ./scripts/deploy.sh
 eval "$(agents secrets export prod --plaintext)"
 ```
 
+### 7. Website logins with multiple accounts
+
+Name the bundle after the domain and group keys by account handle — one bundle per site, any number of accounts inside. Per-key `--note` records when to use each account; `view` prints notes in the clear while values stay masked, so an agent can pick the right account without revealing anything:
+
+```bash
+agents secrets create x.com --description "X/Twitter accounts. Read key notes to pick the right one."
+
+agents secrets add x.com ZEFFMUKS_USERNAME --value zeffmuks \
+  --note "Personal account. Casual engagement, memes."
+agents secrets add x.com ZEFFMUKS_PASSWORD --type password \
+  --note "Password for @zeffmuks"
+agents secrets add x.com SOCIAL_GETRUSH_USERNAME --value social@getrush.ai \
+  --note "Official Rush brand account. Marketing, announcements."
+agents secrets add x.com SOCIAL_GETRUSH_PASSWORD --type password \
+  --note "Password for social@getrush.ai"
+
+# Pick an account by reading notes, then reveal just that account's pair
+agents secrets view x.com
+agents secrets export x.com --plaintext | grep '^SOCIAL_GETRUSH_'
+
+# Or bind the bundle to a browser profile so it injects at browser start
+agents browser profiles create x --browser chrome --secrets x.com
+```
+
+Key naming: uppercase the handle, replace non-alphanumerics with `_`, suffix `_USERNAME` / `_PASSWORD` (plus `_TOTP_SECRET` for 2FA accounts).
+
 ## Demo
 
 <video autoplay loop muted playsinline width="100%" src="../assets/videos/secrets.mp4"></video>

--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -90,6 +90,33 @@ agents secrets add prod STRIPE_KEY --type api-key --expires 2027-12-31 --note "L
 
 The `list` command shows secrets expiring in the next 30 days. Expired secrets show in red.
 
+## "I have multiple accounts on one website"
+
+For browser logins, name the bundle after the domain — `x.com`, `linkedin.com`, `reddit.com` — and group keys by account handle. One bundle per site, any number of accounts inside. Every account carries a `--note` saying when to use it:
+
+```bash
+agents secrets create x.com --description "X/Twitter accounts. Read key notes to pick the right one."
+
+agents secrets add x.com ZEFFMUKS_USERNAME --value zeffmuks \
+  --note "Personal account. Casual engagement, memes."
+agents secrets add x.com ZEFFMUKS_PASSWORD --type password \
+  --note "Password for @zeffmuks"
+
+agents secrets add x.com SOCIAL_GETRUSH_USERNAME --value social@getrush.ai \
+  --note "Official Rush brand account. Product marketing, announcements, replies as Rush."
+agents secrets add x.com SOCIAL_GETRUSH_PASSWORD --type password \
+  --note "Password for social@getrush.ai"
+```
+
+Key naming: uppercase the handle, replace non-alphanumerics with `_`, suffix with `_USERNAME` / `_PASSWORD` (plus `_TOTP_SECRET` if the account has 2FA).
+
+To pick an account, run `agents secrets view x.com` — notes print in the clear while values stay masked. Reveal only the pair you need:
+
+```bash
+agents secrets view x.com                  # read notes, choose the account
+agents secrets export x.com --plaintext | grep '^SOCIAL_GETRUSH_'
+```
+
 ## "I have a .env file I want to import"
 
 ```bash


### PR DESCRIPTION
## What

Documents the convention for storing multiple website accounts in one domain-named bundle (`x.com`, `linkedin.com`):

- Keys grouped by account handle: `ZEFFMUKS_USERNAME` / `ZEFFMUKS_PASSWORD` (+ `_TOTP_SECRET` for 2FA)
- Per-key `--note` records when an agent should use each account
- `agents secrets view <domain>` prints notes in the clear with values masked, so an agent can pick the right account without revealing anything
- Reveal only the chosen pair via `export --plaintext | grep '^HANDLE_'`, or bind the bundle to a browser profile (`agents browser profiles create -s <bundle>`)

Added to both `skills/secrets/SKILL.md` (what agents read) and `docs/secrets.md` (recipe 7).

## Why

Use case: agents driving `agents browser` for research/marketing need to choose between several X/Twitter accounts (personal, brand, etc.). The CLI primitives all exist; the convention was undocumented so agents had no consistent pattern.

Verified end-to-end against the live CLI: created a scratch `example.com` bundle with two account groups and notes, confirmed `view` renders notes under masked keys, deleted it. `export --plaintext` and `browser profiles create --secrets` flags confirmed against `--help` and `src/commands/browser.ts:172`.

## Session Context

Transcript gist omitted: this session's output includes `agents secrets` bundle contents, so the export was blocked from upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)