### PR TITLE
feat(computer): window raising, keyboard focus guards, actionable errors, RPC timeout

### DIFF
--- a/packages/computer-helper/Sources/ComputerHelper/Events.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/Events.swift
@@ -17,6 +17,7 @@ enum Events {
             throw RPCError.appMissing(pid)
         }
         try ensurePidAllowed(pid)
+        let front = try checkFrontmost(pid: pid, params: params)
 
         let chord = try parseChord(keys)
 
@@ -30,7 +31,7 @@ enum Events {
 
         down.postToPid(pid_t(pid))
         up.postToPid(pid_t(pid))
-        return ["ok": true]
+        return ["ok": true, "frontmost": front]
     }
 
     // Type an arbitrary unicode string into the focused field. Unlike sendKey
@@ -45,6 +46,7 @@ enum Events {
             throw RPCError.appMissing(pid)
         }
         try ensurePidAllowed(pid)
+        let front = try checkFrontmost(pid: pid, params: params)
 
         for scalar in text.unicodeScalars {
             var utf16 = Array(String(scalar).utf16)
@@ -66,7 +68,20 @@ enum Events {
                 up.postToPid(pid_t(pid))
             }
         }
-        return ["ok": true, "chars": text.count]
+        return ["ok": true, "chars": text.count, "frontmost": front]
+    }
+
+    // postToPid keyboard events are silently dropped by apps that gate input
+    // on key-window status (Parallels guest VMs, some Catalyst apps) — the
+    // caller would see ok:true while nothing landed. Always report whether
+    // the target was frontmost at post time; with require_frontmost the
+    // mismatch becomes a hard error instead of a warning.
+    private static func checkFrontmost(pid: Int, params: [String: Any]) throws -> Bool {
+        let front = NSWorkspace.shared.frontmostApplication?.processIdentifier == pid_t(pid)
+        if !front && Params.bool(params, "require_frontmost") {
+            throw RPCError(code: "not_frontmost", message: "pid \(pid) is not the frontmost app — keystrokes would be dropped by key-window-gated targets. Run `agents computer raise` first, then retry")
+        }
+        return front
     }
 
     private struct Chord {

--- a/packages/computer-helper/Sources/ComputerHelper/Mouse.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/Mouse.swift
@@ -3,6 +3,13 @@ import AppKit
 import CoreGraphics
 import Foundation
 
+// Private SPI: the only bridge from an AXUIElement window to its CGWindowID
+// (the id `screenshot --list` reports). Stable across macOS releases for
+// years but unsupported — callers must treat a non-.success return as "no id"
+// and fall back to title matching, never as a hard error.
+@_silgen_name("_AXUIElementGetWindow")
+func _AXUIElementGetWindow(_ element: AXUIElement, _ windowID: inout CGWindowID) -> AXError
+
 // Mouse-based interactions: drag and right-click. Prefers native AX actions
 // when the element supports them; falls back to synthesized CGEvents posted
 // to the target pid.
@@ -103,9 +110,11 @@ enum Mouse {
     // After NSRunningApplication.activate returns true the window-raise is
     // still propagating through WindowServer. Callers that immediately
     // screenshot or describe will race the raise and read the previous
-    // foreground app. Poll frontmostApplication for up to 200 ms so the
-    // helper only reports ok once the app is actually frontmost.
-    private static let focusPollTotalMs: Int = 200
+    // foreground app. Poll frontmostApplication so the helper only reports ok
+    // once the app is actually frontmost. 600 ms total: fullscreen-Space
+    // switches (Parallels VMs, fullscreen editors) animate longer than the
+    // same-Space raise the original 200 ms budget assumed.
+    private static let focusPollTotalMs: Int = 600
     private static let focusPollIntervalMs: Int = 20
 
     static func focusWindow(params: [String: Any]) throws -> [String: Any] {
@@ -125,16 +134,156 @@ enum Mouse {
             throw RPCError(code: "action_failed", message: "activate returned false")
         }
 
+        // Optional window-level raise. App-level activate only brings forward
+        // the app's most-recently-used window/Space; when one app has windows
+        // across several Spaces (e.g. two fullscreen VMs) the caller selects
+        // one by window_id (from `screenshot --list`) or title substring.
+        // Two strategies, in order:
+        //   1. kAXWindowsAttribute match -> AXRaise. Works for same-Space and
+        //      minimized windows.
+        //   2. The app's "Window" menu -> AXPress the item whose title
+        //      matches. Fullscreen-Space windows on inactive Spaces are
+        //      absent from kAXWindowsAttribute entirely, but document-based
+        //      apps list every window in the Window menu, and pressing the
+        //      item switches Spaces (this is what works for Parallels VMs).
+        var raisedWindow = false
+        var windowInfo: [String: Any] = [:]
+        let windowId = Params.intOpt(params, "window_id")
+        let title = Params.stringOpt(params, "title")
+        if windowId != nil || title != nil {
+            try AX.ensureTrusted()
+            // A bare window_id still needs a title for the menu fallback —
+            // resolve it from the window server (needs Screen Recording,
+            // which the helper already holds for screenshots).
+            let titleQuery = title ?? windowId.flatMap { windowTitleForId($0, pid: pid) }
+            if let (win, info) = matchWindow(pid: pid, windowId: windowId, title: titleQuery) {
+                // Mark main first so the raise targets this window, then
+                // AXRaise pulls it (and its Space) forward.
+                AXUIElementSetAttributeValue(win, kAXMainAttribute as CFString, kCFBooleanTrue)
+                let raiseErr = AXUIElementPerformAction(win, kAXRaiseAction as CFString)
+                if raiseErr != .success {
+                    throw RPCError(code: "action_failed", message: "AXRaise failed (AXError \(raiseErr.rawValue)) for window_id=\(windowId.map(String.init) ?? "-") title=\(titleQuery ?? "-")")
+                }
+                raisedWindow = true
+                windowInfo = info
+                windowInfo["method"] = "ax_raise"
+            } else if let q = titleQuery, let pressed = pressWindowMenuItem(pid: pid, titleQuery: q) {
+                raisedWindow = true
+                windowInfo = ["title": pressed, "method": "window_menu"]
+            } else {
+                throw RPCError(code: "element_not_found", message: "no window matching window_id=\(windowId.map(String.init) ?? "-") title=\(titleQuery ?? title ?? "-") for pid \(pid) — run `agents computer screenshot --list` to enumerate windows")
+            }
+        }
+
         let ticks = focusPollTotalMs / focusPollIntervalMs
         var elapsedMs = 0
         for _ in 0..<ticks {
             if NSWorkspace.shared.frontmostApplication?.processIdentifier == pid_t(pid) {
-                return ["ok": true, "was_minimized": wasHidden, "focus_elapsed_ms": elapsedMs]
+                var result: [String: Any] = [
+                    "ok": true,
+                    "was_minimized": wasHidden,
+                    "focus_elapsed_ms": elapsedMs,
+                    "raised_window": raisedWindow,
+                ]
+                for (k, v) in windowInfo { result[k] = v }
+                return result
             }
             Thread.sleep(forTimeInterval: Double(focusPollIntervalMs) / 1000.0)
             elapsedMs += focusPollIntervalMs
         }
         throw RPCError(code: "focus_timeout", message: "app pid=\(pid) did not become frontmost within \(focusPollTotalMs)ms (modal-blocked or invisible?)")
+    }
+
+    // Match an AXWindow by CGWindowID (via the _AXUIElementGetWindow SPI) or
+    // title substring. Polls up to 300 ms: right after activate, a window can
+    // take a beat to appear in kAXWindowsAttribute. Returns nil (instead of
+    // throwing) so focusWindow can fall through to the Window-menu strategy.
+    private static func matchWindow(pid: Int, windowId: Int?, title: String?) -> (AXUIElement, [String: Any])? {
+        let deadline = Date().addingTimeInterval(0.3)
+        repeat {
+            let wins = axWindows(pid: pid)
+            if let target = windowId {
+                for w in wins {
+                    var wid: CGWindowID = 0
+                    if _AXUIElementGetWindow(w, &wid) == .success, Int(wid) == target {
+                        return (w, ["window_id": target, "title": axTitle(w)])
+                    }
+                }
+            }
+            if let q = title?.lowercased(), !q.isEmpty {
+                for w in wins where axTitle(w).lowercased().contains(q) {
+                    var info: [String: Any] = ["title": axTitle(w)]
+                    var wid: CGWindowID = 0
+                    if _AXUIElementGetWindow(w, &wid) == .success {
+                        info["window_id"] = Int(wid)
+                    }
+                    return (w, info)
+                }
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        } while Date() < deadline
+        return nil
+    }
+
+    // Resolve a CGWindowID to its title via the window server. Window names
+    // require Screen Recording permission, which the helper already holds.
+    private static func windowTitleForId(_ windowId: Int, pid: Int) -> String? {
+        guard let list = CGWindowListCopyWindowInfo(.optionAll, kCGNullWindowID) as? [[String: Any]] else { return nil }
+        for info in list {
+            guard let num = info[kCGWindowNumber as String] as? Int, num == windowId,
+                  let owner = info[kCGWindowOwnerPID as String] as? Int, owner == pid else { continue }
+            if let name = info[kCGWindowName as String] as? String, !name.isEmpty {
+                return name
+            }
+        }
+        return nil
+    }
+
+    // Press the item in the app's "Window" menu whose title contains the
+    // query. Menu items are enumerable regardless of which Space their window
+    // lives on — unlike kAXWindowsAttribute — and pressing one performs the
+    // app's own raise + Space switch. Matches the English "Window" menu only;
+    // localized menu bars fall through to nil (caller reports
+    // element_not_found with the --list hint).
+    private static func pressWindowMenuItem(pid: Int, titleQuery: String) -> String? {
+        let axApp = AXUIElementCreateApplication(pid_t(pid))
+        var mbRaw: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(axApp, kAXMenuBarAttribute as CFString, &mbRaw) == .success,
+              let mb = mbRaw, CFGetTypeID(mb) == AXUIElementGetTypeID() else { return nil }
+        let menuBar = mb as! AXUIElement
+        let q = titleQuery.lowercased()
+        for barItem in axChildren(menuBar) where axTitle(barItem) == "Window" {
+            for menu in axChildren(barItem) {
+                for item in axChildren(menu) {
+                    let t = axTitle(item)
+                    if !t.isEmpty, t.lowercased().contains(q),
+                       AXUIElementPerformAction(item, kAXPressAction as CFString) == .success {
+                        return t
+                    }
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func axWindows(pid: Int) -> [AXUIElement] {
+        let axApp = AXUIElementCreateApplication(pid_t(pid))
+        var raw: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute as CFString, &raw) == .success else { return [] }
+        return raw as? [AXUIElement] ?? []
+    }
+
+    private static func axChildren(_ el: AXUIElement) -> [AXUIElement] {
+        var raw: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(el, kAXChildrenAttribute as CFString, &raw) == .success else { return [] }
+        return raw as? [AXUIElement] ?? []
+    }
+
+    private static func axTitle(_ win: AXUIElement) -> String {
+        var raw: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(win, kAXTitleAttribute as CFString, &raw) == .success,
+              let s = raw as? String else { return "" }
+        return s
     }
 
     // MARK: - helpers

--- a/packages/computer-helper/Sources/ComputerHelper/Screenshot.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/Screenshot.swift
@@ -170,7 +170,20 @@ enum Screenshot {
         config.showsCursor = false
         config.capturesAudio = false
 
-        let cgImage = try await captureImage(filter: filter, config: config)
+        // Off-Space capture works for plain windows (that's why shareable()
+        // passes onScreenWindowsOnly=false) but SCK refuses windows on
+        // inactive *fullscreen* Spaces with an opaque stream error. Don't
+        // pre-block the attempt — convert the failure into an actionable
+        // error instead.
+        let cgImage: CGImage
+        do {
+            cgImage = try await captureImage(filter: filter, config: config)
+        } catch {
+            if !window.isOnScreen {
+                throw RPCError(code: "window_offscreen", message: "window_id \(Int(window.windowID)) (\(window.title ?? "")) is not on the active Space and SCK could not capture it — run `agents computer raise --window-id \(Int(window.windowID))` first, then retry")
+            }
+            throw error
+        }
         // SCK returns a backing-store image: on Retina it is ~2x the requested
         // point size. Report the scale so callers can map pixels -> points.
         let scale = window.frame.width > 0 ? Double(cgImage.width) / Double(window.frame.width) : 1.0

--- a/src/commands/computer-actions.test.ts
+++ b/src/commands/computer-actions.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { pickTarget, parseXY, buildElementOrCoords, type AppInfo } from './computer-actions.js';
+import {
+  pickTarget,
+  parseXY,
+  buildElementOrCoords,
+  buildRaiseParams,
+  buildWaitParams,
+  type AppInfo,
+} from './computer-actions.js';
+import { resolveRpcTimeoutMs, RPC_TIMEOUT_MS } from '../lib/computer-rpc.js';
 
 const apps: AppInfo[] = [
   { pid: 100, name: 'Finder', bundle_id: 'com.apple.finder', active: false },
@@ -101,5 +109,71 @@ describe('buildElementOrCoords', () => {
   it('errors when only one coordinate is provided', () => {
     const r = buildElementOrCoords({ x: 18 });
     expect(r.ok).toBe(false);
+  });
+});
+
+describe('buildRaiseParams', () => {
+  it('returns empty params for an app-level raise', () => {
+    expect(buildRaiseParams({})).toEqual({});
+  });
+
+  it('builds a window_id param', () => {
+    expect(buildRaiseParams({ windowId: 127403 })).toEqual({ window_id: 127403 });
+  });
+
+  it('builds a title param', () => {
+    expect(buildRaiseParams({ title: 'Windows 11' })).toEqual({ title: 'Windows 11' });
+  });
+
+  it('passes both refinements through when given', () => {
+    expect(buildRaiseParams({ windowId: 5, title: 'VM' })).toEqual({ window_id: 5, title: 'VM' });
+  });
+});
+
+describe('buildWaitParams', () => {
+  it('duration wins over every other mode', () => {
+    const r = buildWaitParams({ duration: 500, id: '@e1', role: 'AXButton' });
+    expect(r).toEqual({ ok: true, params: { duration_ms: 500 } });
+  });
+
+  it('builds an element poll from --id', () => {
+    const r = buildWaitParams({ id: '@e3', until: 'enabled', timeout: 2000 });
+    expect(r).toEqual({ ok: true, params: { until: 'enabled', timeout_ms: 2000, element_id: '@e3' } });
+  });
+
+  it('element id wins over a locator', () => {
+    const r = buildWaitParams({ id: '@e3', role: 'AXButton' });
+    expect(r).toEqual({ ok: true, params: { element_id: '@e3' } });
+  });
+
+  it('builds a locator from role/label/identifier', () => {
+    const r = buildWaitParams({ role: 'AXButton', label: 'Save' });
+    expect(r).toEqual({ ok: true, params: { locator: { role: 'AXButton', label: 'Save' } } });
+  });
+
+  it('errors when no mode is selected', () => {
+    const r = buildWaitParams({});
+    expect(r.ok).toBe(false);
+  });
+
+  it('errors when only --until/--timeout are given (no target)', () => {
+    const r = buildWaitParams({ until: 'exists', timeout: 1000 });
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('resolveRpcTimeoutMs', () => {
+  it('defaults to RPC_TIMEOUT_MS when the env var is unset', () => {
+    expect(resolveRpcTimeoutMs(undefined)).toBe(RPC_TIMEOUT_MS);
+  });
+
+  it('parses a positive override', () => {
+    expect(resolveRpcTimeoutMs('5000')).toBe(5000);
+  });
+
+  it('rejects garbage and non-positive values', () => {
+    expect(resolveRpcTimeoutMs('abc')).toBe(RPC_TIMEOUT_MS);
+    expect(resolveRpcTimeoutMs('0')).toBe(RPC_TIMEOUT_MS);
+    expect(resolveRpcTimeoutMs('-1')).toBe(RPC_TIMEOUT_MS);
   });
 });

--- a/src/commands/computer-actions.ts
+++ b/src/commands/computer-actions.ts
@@ -83,6 +83,58 @@ export function buildElementOrCoords(opts: {
   return { ok: false, error: 'pass --id <@eN> (from `describe`) or --x <n> --y <n>' };
 }
 
+// Build the focus_window params for `raise`. Pure + tested: window_id and
+// title are both optional refinements over the app-level activate.
+export function buildRaiseParams(opts: {
+  windowId?: number;
+  title?: string;
+}): Record<string, unknown> {
+  const params: Record<string, unknown> = {};
+  if (opts.windowId != null) params.window_id = opts.windowId;
+  if (opts.title) params.title = opts.title;
+  return params;
+}
+
+// Build the wait RPC params. Pure + tested. Three modes, mirroring the
+// daemon's Wait.run: --duration (unconditional sleep), --id + --until
+// (cached-element poll), or --role/--label/--identifier (live locator poll).
+export function buildWaitParams(opts: {
+  duration?: number;
+  id?: string;
+  until?: string;
+  role?: string;
+  label?: string;
+  identifier?: string;
+  timeout?: number;
+}): { ok: true; params: Record<string, unknown> } | { ok: false; error: string } {
+  if (opts.duration != null) {
+    return { ok: true, params: { duration_ms: opts.duration } };
+  }
+  const params: Record<string, unknown> = {};
+  if (opts.until) params.until = opts.until;
+  if (opts.timeout != null) params.timeout_ms = opts.timeout;
+  if (opts.id) {
+    return { ok: true, params: { ...params, element_id: opts.id } };
+  }
+  const locator: Record<string, string> = {};
+  if (opts.role) locator.role = opts.role;
+  if (opts.label) locator.label = opts.label;
+  if (opts.identifier) locator.identifier = opts.identifier;
+  if (Object.keys(locator).length === 0) {
+    return { ok: false, error: 'pass --duration <ms>, --id <@eN>, or a locator (--role/--label/--identifier)' };
+  }
+  return { ok: true, params: { ...params, locator } };
+}
+
+// postToPid keyboard delivery is dropped by key-window-gated apps (Parallels
+// VMs and friends) — when the daemon reports the target was not frontmost,
+// the keystrokes may have landed nowhere. Surface that loudly on stderr.
+function warnIfNotFrontmost(res: Record<string, unknown>): void {
+  if (res.frontmost === false) {
+    console.error('warning: target was not the frontmost app — keystrokes may have been dropped. Run `agents computer raise` first.');
+  }
+}
+
 function reportMissingHelper(): never {
   console.error('helper not built. Run: ./packages/computer-helper/scripts/build.sh debug');
   process.exit(1);
@@ -121,6 +173,12 @@ async function resolveTargetPid(client: ComputerClient, opts: { pid?: number; bu
     process.exit(1);
   }
   return picked.app.pid;
+}
+
+// --raise flag: app-level focus_window before the main action so coordinate
+// clicks and keystrokes land on a visible, key window.
+async function raiseIfRequested(client: ComputerClient, pid: number, raise?: boolean): Promise<void> {
+  if (raise) unwrap(await client.call('focus_window', { pid }));
 }
 
 function emit(result: Record<string, unknown>, json: boolean, human: () => string): void {
@@ -196,9 +254,10 @@ export function registerActionCommands(program: Command): void {
         .description('Click an element (--id) or screen coordinate (--x --y)')
         .option('--count <n>', 'Click count (2 = double-click)', (v) => parseInt(v, 10))
         .option('--background', 'Focus-safe postToPid delivery (plain AppKit only; skips HID tap)')
+        .option('--raise', 'Bring the target app to the front first')
         .option('--json', 'Emit JSON'),
     ),
-  ).action(async (opts: ElemOpts & { count?: number; background?: boolean }) => {
+  ).action(async (opts: ElemOpts & { count?: number; background?: boolean; raise?: boolean }) => {
     await withClient(async (client) => {
       const pid = await resolveTargetPid(client, opts);
       const spec = buildElementOrCoords(opts);
@@ -206,6 +265,7 @@ export function registerActionCommands(program: Command): void {
         console.error(spec.error);
         process.exit(1);
       }
+      await raiseIfRequested(client, pid, opts.raise);
       const params: Record<string, unknown> = { pid, ...spec.params };
       if (opts.count != null) params.count = opts.count;
       if (opts.background) params.background = true;
@@ -269,13 +329,18 @@ export function registerActionCommands(program: Command): void {
       .description('Type an arbitrary unicode string into the focused field (focus first via click/focus)')
       .requiredOption('--text <s>', 'Text to type')
       .option('--commit', 'Press Return after typing')
+      .option('--raise', 'Bring the target app to the front first')
+      .option('--require-frontmost', 'Fail (not warn) if the target is not the frontmost app')
       .option('--json', 'Emit JSON'),
-  ).action(async (opts: TargetOpts & { text: string; commit?: boolean }) => {
+  ).action(async (opts: TargetOpts & { text: string; commit?: boolean; raise?: boolean; requireFrontmost?: boolean }) => {
     await withClient(async (client) => {
       const pid = await resolveTargetPid(client, opts);
+      await raiseIfRequested(client, pid, opts.raise);
       const params: Record<string, unknown> = { pid, text: opts.text };
       if (opts.commit) params.commit = true;
+      if (opts.requireFrontmost) params.require_frontmost = true;
       const res = unwrap(await client.call('type_text', params));
+      warnIfNotFrontmost(res);
       emit(res, Boolean(opts.json), () => `typed ${res.chars ?? opts.text.length} char(s)`);
     });
   });
@@ -286,11 +351,17 @@ export function registerActionCommands(program: Command): void {
       .command('key')
       .description('Send a key chord, e.g. "cmd+shift+s", "enter", "esc"')
       .requiredOption('--keys <chord>', 'Key chord')
+      .option('--raise', 'Bring the target app to the front first')
+      .option('--require-frontmost', 'Fail (not warn) if the target is not the frontmost app')
       .option('--json', 'Emit JSON'),
-  ).action(async (opts: TargetOpts & { keys: string }) => {
+  ).action(async (opts: TargetOpts & { keys: string; raise?: boolean; requireFrontmost?: boolean }) => {
     await withClient(async (client) => {
       const pid = await resolveTargetPid(client, opts);
-      const res = unwrap(await client.call('key', { pid, keys: opts.keys }));
+      await raiseIfRequested(client, pid, opts.raise);
+      const params: Record<string, unknown> = { pid, keys: opts.keys };
+      if (opts.requireFrontmost) params.require_frontmost = true;
+      const res = unwrap(await client.call('key', params));
+      warnIfNotFrontmost(res);
       emit(res, Boolean(opts.json), () => `sent ${opts.keys}`);
     });
   });
@@ -304,8 +375,9 @@ export function registerActionCommands(program: Command): void {
       .requiredOption('--to <x,y>', 'End coordinate "x,y"')
       .option('--button <left|right>', 'Mouse button', 'left')
       .option('--background', 'Focus-safe postToPid delivery (plain AppKit only)')
+      .option('--raise', 'Bring the target app to the front first')
       .option('--json', 'Emit JSON'),
-  ).action(async (opts: TargetOpts & { from: string; to: string; button: string; background?: boolean }) => {
+  ).action(async (opts: TargetOpts & { from: string; to: string; button: string; background?: boolean; raise?: boolean }) => {
     let from: { x: number; y: number };
     let to: { x: number; y: number };
     try {
@@ -317,6 +389,7 @@ export function registerActionCommands(program: Command): void {
     }
     await withClient(async (client) => {
       const pid = await resolveTargetPid(client, opts);
+      await raiseIfRequested(client, pid, opts.raise);
       const params: Record<string, unknown> = {
         pid,
         from: [from.x, from.y],
@@ -337,11 +410,13 @@ export function registerActionCommands(program: Command): void {
         .description('Scroll by a pixel delta at an element or coordinate')
         .option('--dy <n>', 'Vertical delta (negative = down)', (v) => parseInt(v, 10))
         .option('--dx <n>', 'Horizontal delta', (v) => parseInt(v, 10))
+        .option('--raise', 'Bring the target app to the front first')
         .option('--json', 'Emit JSON'),
     ),
-  ).action(async (opts: ElemOpts & { dy?: number; dx?: number }) => {
+  ).action(async (opts: ElemOpts & { dy?: number; dx?: number; raise?: boolean }) => {
     await withClient(async (client) => {
       const pid = await resolveTargetPid(client, opts);
+      await raiseIfRequested(client, pid, opts.raise);
       const params: Record<string, unknown> = { pid };
       if (opts.id) params.element_id = opts.id;
       if (opts.x != null) params.x = opts.x;
@@ -383,4 +458,98 @@ export function registerActionCommands(program: Command): void {
       emit(res, Boolean(opts.json), () => `focused ${opts.id}`);
     });
   });
+
+  // raise — bring an app (or one of its windows) to the front. The window
+  // forms (--window-id/--title) also switch macOS Spaces, which is the only
+  // way to reach a fullscreen-Space window (VM, fullscreen editor) for
+  // capture and HID-tap input.
+  addTargetOpts(
+    program
+      .command('raise')
+      .description('Bring an app (or a specific window) to the front — switches Spaces for fullscreen windows')
+      .option('--window-id <n>', 'Raise a specific window by id (from `screenshot --list`)', (v) => parseInt(v, 10))
+      .option('--title <s>', 'Raise the window whose title contains this string')
+      .option('--json', 'Emit JSON'),
+  ).action(async (opts: TargetOpts & { windowId?: number; title?: string }) => {
+    await withClient(async (client) => {
+      const pid = await resolveTargetPid(client, opts);
+      const res = unwrap(await client.call('focus_window', { pid, ...buildRaiseParams(opts) }));
+      emit(res, Boolean(opts.json), () => {
+        const scope = res.raised_window ? `window ${res.title ?? res.window_id ?? ''}`.trim() : 'app';
+        return `raised ${scope} (${res.focus_elapsed_ms ?? 0}ms)`;
+      });
+    });
+  });
+
+  // wait — settle the UI before the next action
+  addTargetOpts(
+    program
+      .command('wait')
+      .description('Wait for a duration (--duration) or for an element (--id / --role/--label) to satisfy --until')
+      .option('--duration <ms>', 'Unconditional sleep in ms (50-30000)', (v) => parseInt(v, 10))
+      .option('--id <@eN>', 'Element id from `describe` to poll')
+      .option('--until <cond>', 'Condition: exists | enabled | disappears (default: exists)')
+      .option('--role <s>', 'Locator: AX role (e.g. AXButton)')
+      .option('--label <s>', 'Locator: element label')
+      .option('--identifier <s>', 'Locator: AX identifier')
+      .option('--timeout <ms>', 'Poll timeout in ms (default 5000)', (v) => parseInt(v, 10))
+      .option('--json', 'Emit JSON'),
+  ).action(async (opts: TargetOpts & { duration?: number; id?: string; until?: string; role?: string; label?: string; identifier?: string; timeout?: number }) => {
+    const spec = buildWaitParams(opts);
+    if (!spec.ok) {
+      console.error(spec.error);
+      process.exit(1);
+    }
+    await withClient(async (client) => {
+      const params: Record<string, unknown> = { ...spec.params };
+      // duration-only waits don't need a target pid
+      if (params.duration_ms == null) params.pid = await resolveTargetPid(client, opts);
+      const res = unwrap(await client.call('wait', params));
+      emit(res, Boolean(opts.json), () =>
+        res.satisfied ? `satisfied (${res.waited_ms}ms)` : `timed out (${res.waited_ms}ms)`,
+      );
+    });
+  });
+
+  // get-text — read text without OCR
+  addTargetOpts(
+    program
+      .command('get-text')
+      .description('Extract visible text from the app (or a subtree via --id)')
+      .option('--id <@eN>', 'Element id from `describe` to scope the extraction')
+      .option('--max-chars <n>', 'Cap the extracted text length', (v) => parseInt(v, 10))
+      .option('--json', 'Emit JSON'),
+  ).action(async (opts: TargetOpts & { id?: string; maxChars?: number }) => {
+    await withClient(async (client) => {
+      const pid = await resolveTargetPid(client, opts);
+      const params: Record<string, unknown> = { pid };
+      if (opts.id) params.element_id = opts.id;
+      if (opts.maxChars != null) params.max_chars = opts.maxChars;
+      const res = unwrap(await client.call('get_text', params));
+      emit(res, Boolean(opts.json), () => String(res.text ?? ''));
+    });
+  });
+
+  // launch — start an app (no target resolution: it isn't running yet)
+  program
+    .command('launch')
+    .description('Launch an app by bundle id, path, or name')
+    .option('--bundle <id>', 'Bundle id (e.g. com.apple.TextEdit)')
+    .option('--path <p>', 'Path to the .app bundle')
+    .option('--name <s>', 'App name (resolved via /Applications and LaunchServices)')
+    .option('--json', 'Emit JSON')
+    .action(async (opts: { bundle?: string; path?: string; name?: string; json?: boolean }) => {
+      if (!opts.bundle && !opts.path && !opts.name) {
+        console.error('pass one of --bundle, --path, --name');
+        process.exit(1);
+      }
+      await withClient(async (client) => {
+        const params: Record<string, unknown> = {};
+        if (opts.bundle) params.bundle_id = opts.bundle;
+        if (opts.path) params.path = opts.path;
+        if (opts.name) params.name = opts.name;
+        const res = unwrap(await client.call('launch_app', params));
+        emit(res, Boolean(opts.json), () => `launched ${res.name} (pid ${res.pid})`);
+      });
+    });
 }

--- a/src/commands/computer.ts
+++ b/src/commands/computer.ts
@@ -24,8 +24,8 @@ import { registerActionCommands, withClient, unwrap, pickTarget, type AppInfo } 
 const COMPUTER_HELP_GROUPS = [
   { title: 'Installation', names: ['setup'] },
   { title: 'Daemon lifecycle', names: ['start', 'stop', 'reload', 'status'] },
-  { title: 'Observe', names: ['apps', 'describe', 'screenshot'] },
-  { title: 'Interact', names: ['click', 'right-click', 'type', 'type-text', 'key', 'drag', 'scroll', 'ax-action', 'focus'] },
+  { title: 'Observe', names: ['apps', 'describe', 'screenshot', 'get-text'] },
+  { title: 'Interact', names: ['launch', 'raise', 'click', 'right-click', 'type', 'type-text', 'key', 'drag', 'scroll', 'ax-action', 'focus', 'wait'] },
 ] as const;
 
 export function registerComputerCommand(program: Command): void {

--- a/src/lib/computer-rpc.ts
+++ b/src/lib/computer-rpc.ts
@@ -220,6 +220,17 @@ export function openComputerClient(): ComputerClient {
   return new StdioClient(helperExec);
 }
 
+// Per-call RPC timeout. Without it a hung daemon (deadlocked connection
+// queue, stopped process) hangs the CLI forever — the waiter map never
+// settles. 30s clears every daemon-side ceiling (wait caps at 30s,
+// launch_app at 10s, screenshot at 5s). Overridable for slower flows.
+export const RPC_TIMEOUT_MS = 30_000;
+
+export function resolveRpcTimeoutMs(env: string | undefined): number {
+  const n = Number(env);
+  return Number.isFinite(n) && n > 0 ? n : RPC_TIMEOUT_MS;
+}
+
 // Shared waiter map + line parser. Both transports plug their reader into
 // `handleChunk` and their writer into `send`.
 abstract class BaseClient implements ComputerClient {
@@ -262,8 +273,19 @@ abstract class BaseClient implements ComputerClient {
     }
     const id = this.nextId++;
     const payload = JSON.stringify({ id, method, params: params ?? {} }) + '\n';
+    const timeoutMs = resolveRpcTimeoutMs(process.env.COMPUTER_HELPER_RPC_TIMEOUT_MS);
     return new Promise((resolve) => {
-      this.waiters.set(id, resolve);
+      const timer = setTimeout(() => {
+        if (this.waiters.delete(id)) {
+          resolve({ id, error: { code: 'rpc_timeout', message: `helper did not respond within ${timeoutMs}ms` } });
+        }
+      }, timeoutMs);
+      // Resolve as an error (never reject) so callers flow through unwrap()
+      // uniformly, matching failPending's contract.
+      this.waiters.set(id, (r) => {
+        clearTimeout(timer);
+        resolve(r);
+      });
       this.send(payload);
     });
   }


### PR DESCRIPTION
## Why

Driving a **Parallels Windows 11 VM** (fullscreen Space) with `agents computer` exposed four reliability gaps the Photoshop benchmark (#250/#251) never hit:

1. **No way to raise a window.** The daemon's `focus_window` RPC existed but had no CLI verb and was app-level only — useless when one app owns windows on several fullscreen Spaces (two VMs). The eval had to shell out to osascript.
2. **Silent false success on keyboard.** `type-text`/`key` returned `ok:true` while delivering nothing — Parallels drops postToPid keystrokes when its window isn't key.
3. **Opaque SCK error** capturing a window on an inactive fullscreen Space (`Failed to start stream due to audio/video capture failure`).
4. **No RPC timeout** — a hung daemon hung the CLI forever.

## What

**Daemon (`packages/computer-helper`):**
- `focus_window` gains `window_id`/`title`: AXRaise via `kAXWindowsAttribute` match (`_AXUIElementGetWindow` SPI, title fallback). Fullscreen-Space windows are absent from `kAXWindowsAttribute` entirely (verified live), so the second strategy AXPresses the matching item in the app's **Window menu** — that performs the app's own raise + Space switch. Bare `window_id` resolves to a title via `CGWindowListCopyWindowInfo`.
- `key`/`type_text` report `"frontmost"` in every result; `require_frontmost` param upgrades a mismatch to a `not_frontmost` error pointing at `raise`. Default stays warn-only — focus-free postToPid typing into AppKit targets is a feature.
- Screenshot failures for off-Space windows now return `window_offscreen` with the exact `raise` command to run. Off-Space captures that work (plain windows) are unchanged — no precheck, only error conversion.

**CLI:**
- New verbs: `raise` (focus_window), `wait`, `get-text`, `launch` — daemon RPCs that previously had no CLI surface.
- `--raise` convenience flag on `click`/`type-text`/`key`/`drag`/`scroll`; `--require-frontmost` on `type-text`/`key`; stderr warning whenever the daemon reports `frontmost:false`.
- `computer-rpc.ts`: per-call timeout (default 30s, `COMPUTER_HELPER_RPC_TIMEOUT_MS` override) resolving to an `rpc_timeout` error response.

## Testing proof

Unit: `bunx tsc --noEmit` clean; vitest **30/30** (13 new: `buildRaiseParams`, `buildWaitParams`, `resolveRpcTimeoutMs`).

Acceptance (live Parallels Windows 11 VM, fresh boot, **zero osascript**):

| Test | Result |
|---|---|
| `type-text --require-frontmost` while VM off-Space | `error: not_frontmost: pid 27446 is not the frontmost app — … Run \`agents computer raise\` first` (exit 1) |
| plain `type-text` while off-Space | `ok` + `"frontmost": false` + stderr warning (was: silent false success) |
| `screenshot --window-id` off-Space | `error: window_offscreen: window_id 141242 (Windows 11) is not on the active Space … run \`agents computer raise --window-id 141242\` first` (was: raw SCK stream error) |
| `raise --title "Windows 11"` | `{"raised_window": true, "method": "window_menu"}` — Space switched |
| screenshot after raise | `origin [0,33]` (active-Space coords; off-Space reported `[1584,33]` in the original eval) |
| click Search → `type-text "powershell" --raise --require-frontmost` → `key enter` | Search pane opened, 10 chars landed, PowerShell launched — all `frontmost: true` |
| `type-text "echo accept-pass-raise-focus" --commit` | command executed in guest PowerShell, output `accept-pass-raise-focus` visible on screen |
| SIGSTOP daemon → any verb | `error: rpc_timeout: helper did not respond within 3000ms` in 3s (was: hang); daemon resumed clean after SIGCONT |

Mid-test fix worth noting: the first `raise` implementation (AX windows only) failed against the live VM with `element_not_found` — that's what motivated the Window-menu fallback, which then passed.

## Install note

Daemon and CLI ship together but install differently: the helper needs a rebuild + `agents computer setup` + `start` (same-cert rebuild at the same path preserves TCC grants — verified again this round); the TS side is live on npm release. `computer` remains macOS-only by design (darwin guard unchanged); the Windows coverage here is *driving* a Windows VM from macOS.

Known flake observed once: a long `type-text` stream into the VM dropped characters mid-stream after a focus blip; `--require-frontmost` + retry recovered. Tracked as a possible follow-up (per-char delay param).

## Session Context
[Session transcript](https://gist.github.com/muqsitnawaz/c44e1cf2a591d424c6d6f0db0fc485da)

🤖 Generated with [Claude Code](https://claude.com/claude-code)