### PR TITLE
feat(windows): register shims dir on User PATH via registry API, not a setx hint (#231)

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -144,17 +144,17 @@ function isAlreadyConfigured(rcFile) {
 }
 
 async function main() {
-  // Windows has no shell rc files to edit. Write the `.cmd` shorthands and point
-  // the user at the PATH entry they can add (the primary `agents` command is
-  // already on PATH via npm's global bin, so this only affects bare shorthands
-  // and versioned aliases).
+  // Windows has no shell rc files to edit. Write the `.cmd` shorthands here; the
+  // shims dir gets registered on the User PATH by `agents setup` (via the native
+  // registry API), so we point the user there instead of mutating PATH from an
+  // npm lifecycle script. The primary `agents` command is already on PATH via
+  // npm's global bin and works immediately.
   if (process.platform === 'win32') {
     console.log(`\nagents-cli installed.`);
     const written = writeAliasShims();
     console.log(`  Installed shorthands: ${written.join(', ')}`);
-    console.log(`\nTo use bare shorthands (${ALIASES.join(', ')}) and versioned aliases, add this to your PATH:`);
-    console.log(`  ${SHIMS_DIR}`);
-    console.log(`  PowerShell: setx PATH "$env:PATH;${SHIMS_DIR}"  (then open a new terminal)`);
+    console.log(`\nNext: run  agents setup  — it finishes setup and adds the shims dir to your PATH`);
+    console.log(`(so the bare shorthands ${ALIASES.join(', ')} and versioned aliases work in a new terminal).`);
   }
   // Opt-in: AGENTS_INIT_SHELL=1 npm install -g @phnx-labs/agents-cli
   else if (process.env.AGENTS_INIT_SHELL === '1') {

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -168,8 +168,8 @@ export async function runSetup(program: Command, options: { force?: boolean; sup
       if (!isShimsInPath()) {
         const pathResult = addShimsToPath();
         if (pathResult.success && !pathResult.alreadyPresent) {
-          console.log(chalk.green(`\nAdded shims to ~/${pathResult.rcFile}`));
-          console.log(chalk.gray('Restart your shell or run: source ~/' + pathResult.rcFile));
+          console.log(chalk.green(`\nAdded shims to ${pathResult.location}`));
+          console.log(chalk.gray(pathResult.reloadHint));
         } else if (!pathResult.success) {
           console.log(chalk.yellow('\nTo enable version switching, add shims to PATH:'));
           console.log(chalk.gray(getPathSetupInstructions()));

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -484,8 +484,8 @@ export function registerVersionsCommands(program: Command): void {
             if (!isShimsInPath()) {
               const pathResult = addShimsToPath();
               if (pathResult.success && !pathResult.alreadyPresent) {
-                console.log(chalk.green(`  Added shims to ~/${pathResult.rcFile}`));
-                console.log(chalk.gray('  Restart your shell or run: source ~/' + pathResult.rcFile));
+                console.log(chalk.green(`  Added shims to ${pathResult.location}`));
+                console.log(chalk.gray('  ' + pathResult.reloadHint));
               } else if (!pathResult.success) {
                 console.log(chalk.yellow('\nCould not auto-add shims to PATH:'));
                 console.log(chalk.gray(getPathSetupInstructions()));

--- a/src/lib/__tests__/shims.test.ts
+++ b/src/lib/__tests__/shims.test.ts
@@ -77,6 +77,8 @@ describe('addShimsToPath', () => {
         success: true,
         ...(fixture.meta.alreadyPresent ? { alreadyPresent: true } : {}),
         rcFile,
+        location: `~/${rcFile}`,
+        reloadHint: `Restart your shell or run: source ~/${rcFile}`,
       });
 
       const content = fs.readFileSync(rcPath, 'utf8');

--- a/src/lib/refresh.ts
+++ b/src/lib/refresh.ts
@@ -273,8 +273,8 @@ export async function refresh(options: RefreshOptions = {}): Promise<void> {
   if (!isShimsInPath()) {
     const pathResult = addShimsToPath();
     if (pathResult.success && !pathResult.alreadyPresent) {
-      console.log(chalk.green(`\nAdded shims to ~/${pathResult.rcFile}`));
-      console.log(chalk.gray('Restart your shell or run: source ~/' + pathResult.rcFile));
+      console.log(chalk.green(`\nAdded shims to ${pathResult.location}`));
+      console.log(chalk.gray(pathResult.reloadHint));
     } else if (!pathResult.success) {
       console.log(chalk.yellow('\nCould not auto-add shims to PATH:'));
       console.log(chalk.gray(getPathSetupInstructions()));

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -11,6 +11,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { execFileSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { confirm, select } from '@inquirer/prompts';
 import type { AgentId } from './types.js';
@@ -1631,21 +1632,29 @@ Then restart your shell or run:
   source ~/${rcFile}`;
 }
 
+interface ShimPathResult {
+  success: boolean;
+  alreadyPresent?: boolean;
+  rcFile?: string;
+  /** Human label of where the entry landed, e.g. `~/.zshrc` or `your user PATH`. */
+  location?: string;
+  /** Per-platform "how to pick it up" hint, e.g. `source ~/.zshrc` / open a new terminal. */
+  reloadHint?: string;
+  error?: string;
+}
+
 /**
- * Add shims directory to shell PATH configuration.
- * Returns true if added, false if already present or failed.
+ * Add the shims directory to PATH: edits the shell rc file on POSIX, or registers
+ * it on the Windows User PATH (registry + WM_SETTINGCHANGE). Idempotent.
  */
 export function addShimsToPath(
   overrides?: { homeDir?: string; shell?: string; shimsDir?: string },
-): { success: boolean; alreadyPresent?: boolean; rcFile?: string; error?: string } {
-  // Windows has no shell rc file to edit: the primary `agents` command is already
-  // on PATH via npm's global bin, and bare shorthands / versioned aliases are
-  // handled by the `.cmd` shims plus the PATH guidance printed at install time.
-  // Report "already present" so callers don't emit a misleading "added to
-  // ~/.bashrc / source ~/.bashrc" message. (The `shell` override is the test hook
-  // for exercising the POSIX path, so it bypasses this short-circuit.)
+): ShimPathResult {
+  // Windows has no shell rc file to edit. Register the shims dir on the User PATH
+  // via the platform-native mechanism instead. (The `shell` override is the test
+  // hook for exercising the POSIX path, so it bypasses this branch.)
   if (IS_WINDOWS && !overrides?.shell) {
-    return { success: true, alreadyPresent: true };
+    return addShimsToWindowsUserPath(overrides?.shimsDir || getShimsDir());
   }
   const shimsDir = overrides?.shimsDir || getShimsDir();
   const { rcFile, rcPath, shell } = getShellRcFile(overrides);
@@ -1683,14 +1692,51 @@ export function addShimsToPath(
     let newContent = contentWithoutShimLines + separator + exportBlock;
     newContent = newContent.replace(/\n{2,}$/g, '\n');
 
+    const location = `~/${rcFile}`;
+    const reloadHint = `Restart your shell or run: source ~/${rcFile}`;
     if (newContent === content) {
-      return { success: true, alreadyPresent: true, rcFile };
+      return { success: true, alreadyPresent: true, rcFile, location, reloadHint };
     }
 
     fs.writeFileSync(rcPath, newContent, 'utf-8');
-    return { success: true, rcFile };
+    return { success: true, rcFile, location, reloadHint };
   } catch (err) {
     return { success: false, error: `Could not write ${rcFile}: ${(err as Error).message}` };
+  }
+}
+
+/**
+ * Register the shims dir on the Windows User PATH via the .NET environment API,
+ * which writes the registry AND broadcasts WM_SETTINGCHANGE — the correct analog
+ * of editing a shell rc file (no `setx` truncation, no manual step). Idempotent:
+ * a no-op when the dir is already present. The shims dir is passed via an env var
+ * so it is never interpolated into the PowerShell script text.
+ */
+function addShimsToWindowsUserPath(shimsDir: string): ShimPathResult {
+  const script = [
+    '$d = $env:AGENTS_SHIMS_DIR',
+    "$u = [Environment]::GetEnvironmentVariable('Path','User')",
+    "if ($null -eq $u) { $u = '' }",
+    "$parts = @($u -split ';' | Where-Object { $_ -ne '' })",
+    "if ($parts -contains $d) { 'present' } else {",
+    "  [Environment]::SetEnvironmentVariable('Path', (($parts + $d) -join ';'), 'User')",
+    "  'added'",
+    '}',
+  ].join('\n');
+  try {
+    const out = execFileSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', script], {
+      encoding: 'utf-8',
+      env: { ...process.env, AGENTS_SHIMS_DIR: shimsDir },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+    return {
+      success: true,
+      alreadyPresent: out.includes('present'),
+      location: 'your user PATH',
+      reloadHint: 'Open a new terminal for the change to take effect.',
+    };
+  } catch (err) {
+    return { success: false, error: `Could not update the Windows user PATH: ${(err as Error).message}` };
   }
 }
 


### PR DESCRIPTION
The correct fix for the Windows PATH gap — replacing the ad-hoc `setx` hint from #254 with proper native User-PATH registration. Built on the `platform/` foundation (#252).

## Why
#254 punted: on Windows, `addShimsToPath` no-op'd and postinstall *printed* a `setx` one-liner. So the version-aware shims (`codex`, `codex@x`, `sessions`, …) were unreachable unless the user hand-edited PATH. This does it the real way.

## What
- **`addShimsToWindowsUserPath()`** — on Windows, `addShimsToPath` registers the shims dir on the **User PATH** via the .NET environment API: `[Environment]::SetEnvironmentVariable('Path', …, 'User')`. Writes the registry **and broadcasts `WM_SETTINGCHANGE`** — the correct analog of editing a shell rc file. No `setx` truncation, no manual step, **idempotent**. The shims dir is passed via an **env var**, never interpolated into the script text.
- **Centralized messaging** — `addShimsToPath` returns `location` + `reloadHint`; `setup`/`versions`/`refresh` print those instead of hardcoding `~/<rcFile>` / `source ~/<rcFile>`. **POSIX output byte-identical**; Windows reads "Added shims to your user PATH / Open a new terminal."
- **postinstall.js** — drop the `setx` hint; point Windows users at `agents setup` (which registers). Shorthand `.cmd` generation unchanged.

## Verified on real Windows (Parallels, win32, Node 24)
```
call 1 → {"success":true,"alreadyPresent":false,"location":"your user PATH",...}
User PATH now → …\WindowsApps;…\.agents\.cache\shims   (appended via registry)
call 2 → {"success":true,"alreadyPresent":true,...}      (idempotent, no dup)
```
POSIX path byte-unchanged — existing rc-file rewrite tests (zsh/bash/fish) pass with `location`/`reloadHint` asserted. (Lone unrelated full-suite failure is the pre-existing `models.test.ts` network flake.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)