### PR TITLE
test(e2e): fresh-image settings-survival regression for install/import/sync (#112, #137)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ scripts/scrub-history.sh
 
 # Local scratch / abandoned scaffold (lives in agent-cli-web, not here)
 /website/
+.e2e-pack-*

--- a/tests/e2e/container-fresh-install.sh
+++ b/tests/e2e/container-fresh-install.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Runs INSIDE a fresh Linux container (node:24). Replays the issue #112/#137
+# scenario end-to-end: a user with existing Claude Code + Codex installs and
+# populated user config installs agents-cli, adopts both agents, and triggers
+# the launch-time factory sync. Asserts no user setting is lost at any step.
+set -euo pipefail
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+step() { echo; echo "==> $1"; }
+
+# ---------------------------------------------------------------------------
+# 1. Seed pre-existing user config (what Emanuele had before installing us)
+# ---------------------------------------------------------------------------
+step "Seed unmanaged ~/.claude and ~/.codex"
+
+mkdir -p ~/.claude
+cat > ~/.claude/settings.json <<'JSON'
+{
+  "env": { "FOO": "bar", "DEBUG": "true" },
+  "permissions": { "allow": ["Bash(npm *)"], "deny": ["Bash(rm -rf *)"] },
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [{ "type": "command", "command": "echo guard" }] }
+    ]
+  },
+  "mcpServers": { "fooServer": { "command": "/bin/foo", "args": ["--bar"] } },
+  "customKey": { "nested": "preserved" }
+}
+JSON
+echo "# my global rules" > ~/.claude/CLAUDE.md
+cat > ~/.claude.json <<'JSON'
+{ "theme": "dark", "mcpServers": { "userServer": { "command": "/bin/user-mcp" } } }
+JSON
+
+mkdir -p ~/.codex
+cat > ~/.codex/config.toml <<'TOML'
+model = "gpt-5.5"
+approval_policy = "on-request"
+
+[mcp_servers.tomlServer]
+command = "/bin/toml-mcp"
+
+[projects."/root/work"]
+trust_level = "trusted"
+TOML
+echo '{"OPENAI_API_KEY":"sk-test-not-real"}' > ~/.codex/auth.json
+
+cp ~/.claude/settings.json /tmp/claude-settings.before.json
+cp ~/.codex/config.toml /tmp/codex-config.before.toml
+
+# ---------------------------------------------------------------------------
+# 2. Install the real agent CLIs (the unmanaged installs agents-cli will adopt)
+# ---------------------------------------------------------------------------
+step "npm install -g claude-code + codex"
+npm install -g --silent @anthropic-ai/claude-code @openai/codex
+
+# ---------------------------------------------------------------------------
+# 3. Install agents-cli from the local tarball (postinstall runs here)
+# ---------------------------------------------------------------------------
+step "npm install -g agents-cli tarball"
+npm install -g /e2e/agents-cli.tgz 2>&1 | tail -40
+
+assert_claude_settings() {
+  local phase="$1"
+  node -e '
+    const fs = require("fs");
+    const before = JSON.parse(fs.readFileSync("/tmp/claude-settings.before.json", "utf8"));
+    const after = JSON.parse(fs.readFileSync(process.env.HOME + "/.claude/settings.json", "utf8"));
+    const eq = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+    const errs = [];
+    for (const key of ["env", "hooks", "mcpServers", "customKey"]) {
+      if (!eq(before[key], after[key])) errs.push(`${key} changed: ${JSON.stringify(after[key])}`);
+    }
+    for (const list of ["allow", "deny"]) {
+      for (const rule of before.permissions[list]) {
+        if (!(after.permissions?.[list] || []).includes(rule)) errs.push(`permissions.${list} lost: ${rule}`);
+      }
+    }
+    if (errs.length) { console.error(errs.join("\n")); process.exit(1); }
+  ' || fail "claude settings.json lost user config ($phase)"
+  echo "ok: claude settings survived ($phase)"
+}
+
+assert_codex_config() {
+  local phase="$1"
+  for needle in 'model = "gpt-5.5"' 'tomlServer' 'trust_level = "trusted"'; do
+    grep -qF "$needle" ~/.codex/config.toml || fail "codex config.toml lost: $needle ($phase)"
+  done
+  grep -qF 'sk-test-not-real' ~/.codex/auth.json || fail "codex auth.json lost ($phase)"
+  echo "ok: codex config survived ($phase)"
+}
+
+assert_claude_settings "after npm install"
+assert_codex_config "after npm install"
+
+# ---------------------------------------------------------------------------
+# 4. First-run setup (clones the public system repo), then adopt both agents
+#    via the same importAgentConfig path the interactive setup flow uses.
+# ---------------------------------------------------------------------------
+step "agents setup"
+agents setup </dev/null || fail "agents setup exited non-zero"
+
+step "agents import claude + codex"
+agents import claude --yes </dev/null || fail "agents import claude failed"
+agents import codex --yes </dev/null || fail "agents import codex failed"
+
+[ -L ~/.claude ] || fail "~/.claude is not a symlink after import"
+[ -L ~/.codex ] || fail "~/.codex is not a symlink after import"
+echo "ok: config dirs adopted ($(readlink ~/.claude))"
+
+assert_claude_settings "after import"
+assert_codex_config "after import"
+
+# ---------------------------------------------------------------------------
+# 5. Trigger the launch-time factory sync — the exact call the claude shim
+#    makes on every launch, and the path that wiped settings in #112/#137.
+# ---------------------------------------------------------------------------
+step "launch sync (factory settings writers)"
+CLAUDE_VERSION=$(ls ~/.agents/.history/versions/claude/ | head -1)
+agents sync --agent claude --agent-version "$CLAUDE_VERSION" --launch --cwd "$HOME" --quiet </dev/null \
+  || echo "warn: launch sync exited non-zero (continuing to assertions)"
+CODEX_VERSION=$(ls ~/.agents/.history/versions/codex/ | head -1)
+agents sync --agent codex --agent-version "$CODEX_VERSION" --launch --cwd "$HOME" --quiet </dev/null \
+  || echo "warn: codex launch sync exited non-zero (continuing to assertions)"
+
+assert_claude_settings "after launch sync"
+assert_codex_config "after launch sync"
+
+echo
+echo "PASS: all user settings survived install, import, and factory sync"

--- a/tests/e2e/fresh-install-settings.sh
+++ b/tests/e2e/fresh-install-settings.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# E2E regression test for issues #112/#137: installing agents-cli on a machine
+# with existing Claude Code / Codex user config must not lose any settings.
+#
+# Builds the CLI from the current checkout, packs it, and replays the full
+# fresh-machine flow (npm install -> setup -> import -> launch sync) inside a
+# clean node:24 Linux container. Requires a running docker daemon (colima ok).
+#
+# Usage: bash tests/e2e/fresh-install-settings.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+REPO_DIR=$(pwd)
+# Keep the pack dir inside the repo: colima/Docker Desktop only share /Users
+# by default, so a /var/folders mktemp dir would mount as an empty directory.
+WORK_DIR=$(mktemp -d "$REPO_DIR/.e2e-pack-XXXXXX")
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+docker info >/dev/null 2>&1 || { echo "SKIP: docker daemon not available"; exit 0; }
+
+echo "==> build + pack"
+bun run build >/dev/null
+# --ignore-scripts: skip the prepack keychain-helper verification; the signed
+# macOS app only exists in release builds and is unused on Linux. The packed
+# tarball still contains scripts/postinstall.js, which runs in the container.
+npm pack --silent --ignore-scripts --pack-destination "$WORK_DIR" >/dev/null
+TGZ=$(ls "$WORK_DIR"/*.tgz)
+echo "    $(basename "$TGZ")"
+
+echo "==> docker run (node:24-bookworm)"
+docker run --rm \
+  -v "$TGZ:/e2e/agents-cli.tgz:ro" \
+  -v "$REPO_DIR/tests/e2e/container-fresh-install.sh:/e2e/run.sh:ro" \
+  node:24-bookworm \
+  bash /e2e/run.sh


### PR DESCRIPTION
## Why

#112 and #137 (settings.json overwritten on install / factory sync) were fixed at the writer level and covered by unit tests (`tests/permissions.test.ts`, regression #137), but the unit tests exercise the writer functions directly — not the real `npm install -g` → setup → import → launch-sync flow that bit the reporter on a fresh Linux box. This closes that gap.

## What

`tests/e2e/fresh-install-settings.sh` packs the CLI from the current checkout and replays the full fresh-machine scenario inside a clean `node:24-bookworm` container:

1. Seed a populated unmanaged `~/.claude` (env, permissions, hooks, mcpServers, custom keys, `~/.claude.json`) and `~/.codex` (config.toml with mcp_servers + project trust, auth.json)
2. `npm install -g @anthropic-ai/claude-code @openai/codex` (real packages)
3. `npm install -g` the local agents-cli tarball (postinstall runs for real)
4. `agents setup` (clones the public system repo) + `agents import claude/codex --yes`
5. Fire the exact launch sync the shim runs (`agents sync --agent ... --launch`)

After every phase, assert byte-equality of `env`/`hooks`/`mcpServers`/custom keys, superset of `permissions.allow/deny`, and survival of the Codex config + auth.

## Verified

Run locally via colima (docker runtime):

```
ok: claude settings survived (after npm install)
ok: codex config survived (after npm install)
ok: config dirs adopted (/root/.agents/.history/versions/claude/2.1.174/home/.claude)
ok: claude settings survived (after import)
ok: codex config survived (after import)
ok: claude settings survived (after launch sync)
ok: codex config survived (after launch sync)
PASS: all user settings survived install, import, and factory sync
```

Skips cleanly (`exit 0`) when no docker daemon is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)