### PR TITLE
fix(upgrade): pin self-update install to the running copy's prefix and verify it

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -32,6 +32,35 @@ function shellQuote(value) {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+// Shorthands that delegate to the installed agents-cli entrypoint.
+const ALIASES = ['sessions', 'secrets', 'browser', 'pty', 'teams'];
+
+function writeAliasShims() {
+  const written = [];
+  for (const name of ALIASES) {
+    const target = path.join(SHIMS_DIR, name);
+    const script = `#!/bin/sh\nAGENTS_BIN=${shellQuote(AGENTS_BIN)}\nif [ -z "$AGENTS_BIN" ] || [ ! -x "$AGENTS_BIN" ]; then\n  echo "agents: agents-cli entrypoint missing or not executable: $AGENTS_BIN" >&2\n  exit 127\nfi\nexec "$AGENTS_BIN" ${name} "$@"\n`;
+    fs.writeFileSync(target, script, { mode: 0o755 });
+    // Windows can't run the POSIX shim; drop a `.cmd` companion that invokes the
+    // entrypoint via node so the bare shorthand works in a Windows shell.
+    if (process.platform === 'win32') {
+      fs.writeFileSync(target + '.cmd', `@echo off\r\nnode "${AGENTS_BIN}" ${name} %*\r\n`);
+    }
+    written.push(name);
+  }
+  return written;
+}
+
+// Self-updater entry: the upgrade installs with --ignore-scripts (skipping
+// this script as an npm lifecycle hook), then re-invokes it with this env var
+// so the alias shims are refreshed from the newly installed copy. Shims only —
+// no prompts, no rc-file edits, no output.
+if (process.env.AGENTS_POSTINSTALL_SHIMS_ONLY === '1') {
+  fs.mkdirSync(SHIMS_DIR, { recursive: true });
+  writeAliasShims();
+  process.exit(0);
+}
+
 // For local installs, create directories and show a message
 const isGlobalInstall = process.env.npm_config_global || process.argv.includes('-g');
 if (!isGlobalInstall) {
@@ -85,25 +114,6 @@ function getShellRc() {
 const exportLine = shellName === 'fish'
   ? `fish_add_path ${SHIMS_DIR}`
   : `export PATH="${SHIMS_DIR}:$PATH"`;
-
-// Shorthands that delegate to the installed agents-cli entrypoint.
-const ALIASES = ['sessions', 'secrets', 'browser', 'pty', 'teams'];
-
-function writeAliasShims() {
-  const written = [];
-  for (const name of ALIASES) {
-    const target = path.join(SHIMS_DIR, name);
-    const script = `#!/bin/sh\nAGENTS_BIN=${shellQuote(AGENTS_BIN)}\nif [ -z "$AGENTS_BIN" ] || [ ! -x "$AGENTS_BIN" ]; then\n  echo "agents: agents-cli entrypoint missing or not executable: $AGENTS_BIN" >&2\n  exit 127\nfi\nexec "$AGENTS_BIN" ${name} "$@"\n`;
-    fs.writeFileSync(target, script, { mode: 0o755 });
-    // Windows can't run the POSIX shim; drop a `.cmd` companion that invokes the
-    // entrypoint via node so the bare shorthand works in a Windows shell.
-    if (process.platform === 'win32') {
-      fs.writeFileSync(target + '.cmd', `@echo off\r\nnode "${AGENTS_BIN}" ${name} %*\r\n`);
-    }
-    written.push(name);
-  }
-  return written;
-}
 
 function getVersion() {
   const pkgPath = new URL('../package.json', import.meta.url).pathname;

--- a/scripts/postinstall.test.ts
+++ b/scripts/postinstall.test.ts
@@ -47,4 +47,29 @@ describe('postinstall alias shims', () => {
     expect(script).toContain('exec "$AGENTS_BIN" sessions "$@"');
     expect(script).not.toContain('exec agents sessions "$@"');
   });
+
+  it('shims-only mode writes aliases silently without the install flow', () => {
+    // The self-updater installs with --ignore-scripts and then re-invokes
+    // postinstall with this env var to refresh the alias shims. It must not
+    // prompt, print, or take the local/global install branches.
+    const home = makeTempHome();
+    const result = spawnSync(process.execPath, [path.join(REPO_ROOT, 'scripts', 'postinstall.js')], {
+      env: {
+        ...process.env,
+        HOME: home,
+        AGENTS_POSTINSTALL_SHIMS_ONLY: '1',
+        SHELL: '/bin/sh',
+      },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe('');
+
+    for (const name of ['sessions', 'secrets', 'browser', 'pty', 'teams']) {
+      const script = fs.readFileSync(path.join(home, '.agents', '.cache', 'shims', name), 'utf-8');
+      expect(script).toContain(`exec "$AGENTS_BIN" ${name} "$@"`);
+      expect(script).toContain(path.join(REPO_ROOT, 'dist', 'index.js'));
+    }
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageJsonPath = path.join(__dirname, '..', 'package.json');
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
 const VERSION = packageJson.version;
-const NPM_PACKAGE_NAME = '@phnx-labs/agents-cli';
+import {
+  NPM_PACKAGE_NAME,
+  deriveGlobalPrefix,
+  installPackageIntoPrefix,
+  verifyInstalledVersion,
+  refreshAliasShims,
+} from './lib/self-update.js';
 
 interface NpmPackageMetadata {
   version: string;
@@ -352,12 +358,11 @@ function printResolvedPackage(metadata: NpmPackageMetadata): void {
 }
 
 async function installResolvedPackage(metadata: NpmPackageMetadata): Promise<void> {
-  const { execFile } = await import('child_process');
-  const { promisify } = await import('util');
-  const execFileAsync = promisify(execFile);
-  const installArgs = ['install', '-g', '@phnx-labs/agents-cli', '--ignore-scripts'];
-  installArgs[2] = `${NPM_PACKAGE_NAME}@${metadata.version}`;
-  await execFileAsync('npm', installArgs);
+  const packageRoot = path.resolve(__dirname, '..');
+  const prefix = deriveGlobalPrefix(packageRoot);
+  await installPackageIntoPrefix(`${NPM_PACKAGE_NAME}@${metadata.version}`, prefix);
+  verifyInstalledVersion(packageRoot, metadata.version);
+  refreshAliasShims(packageRoot);
 }
 
 /** Present an interactive upgrade prompt (TTY) or a one-line hint (non-TTY). */
@@ -413,14 +418,18 @@ async function promptUpgrade(latestVersion: string): Promise<void> {
       spinner.succeed(`Upgraded to ${metadata.version}`);
       await showWhatsNew(VERSION, metadata.version);
       console.log();
-      // Re-exec with new version and exit
-      const result = spawnSync('agents', process.argv.slice(2), {
+      // Re-exec the verified install's entrypoint and exit. PATH lookup of
+      // `agents` could resolve a different copy (dev build, another prefix)
+      // than the one that was just upgraded.
+      const entrypoint = path.resolve(__dirname, '..', 'dist', 'index.js');
+      const result = spawnSync(process.execPath, [entrypoint, ...process.argv.slice(2)], {
         stdio: 'inherit',
         shell: false,
       });
       process.exit(result.status ?? 0);
-    } catch {
-      spinner.fail('Upgrade failed');
+    } catch (err) {
+      if (isPromptCancelled(err)) return;
+      spinner.fail(`Upgrade failed: ${err instanceof Error ? err.message : String(err)}`);
       console.log(chalk.gray('Run manually: agents upgrade --yes'));
     }
     console.log();
@@ -753,7 +762,8 @@ program
           await showWhatsNew(VERSION, resolvedVersion);
         }
       } catch (err) {
-        spinner.fail('Upgrade failed');
+        if (isPromptCancelled(err)) return;
+        spinner.fail(`Upgrade failed: ${err instanceof Error ? err.message : String(err)}`);
         console.log(chalk.gray(`Run manually: agents upgrade ${version ? version + ' ' : ''}--yes`));
       }
     });

--- a/src/lib/self-update.test.ts
+++ b/src/lib/self-update.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  deriveGlobalPrefix,
+  installPackageIntoPrefix,
+  readInstalledVersion,
+  verifyInstalledVersion,
+} from './self-update.js';
+
+const tempDirs: string[] = [];
+
+function makeTempDir(label: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `agents-self-update-${label}-`));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('deriveGlobalPrefix', () => {
+  it('resolves the POSIX npm global layout (<prefix>/lib/node_modules/<scoped pkg>)', () => {
+    const root = path.join('/Users/x/.nvm/versions/node/v24.15.0', 'lib', 'node_modules', '@phnx-labs', 'agents-cli');
+    expect(deriveGlobalPrefix(root)).toBe('/Users/x/.nvm/versions/node/v24.15.0');
+  });
+
+  it('resolves the Windows npm global layout (<prefix>/node_modules/<scoped pkg>)', () => {
+    const root = path.join('/x/npm-prefix', 'node_modules', '@phnx-labs', 'agents-cli');
+    expect(deriveGlobalPrefix(root)).toBe('/x/npm-prefix');
+  });
+
+  it('resolves the dev-install prefix used by scripts/install.sh', () => {
+    const root = path.join('/Users/x/.local/agents-cli-dev', 'lib', 'node_modules', '@phnx-labs', 'agents-cli');
+    expect(deriveGlobalPrefix(root)).toBe('/Users/x/.local/agents-cli-dev');
+  });
+
+  it('throws for a source checkout that is not under node_modules', () => {
+    expect(() => deriveGlobalPrefix('/Users/x/src/github.com/muqsitnawaz/agents-cli')).toThrow(
+      /not an npm-managed install/,
+    );
+  });
+});
+
+describe('verifyInstalledVersion', () => {
+  function writePackage(dir: string, version: string): string {
+    const root = path.join(dir, 'lib', 'node_modules', '@phnx-labs', 'agents-cli');
+    fs.mkdirSync(root, { recursive: true });
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: '@phnx-labs/agents-cli', version }));
+    return root;
+  }
+
+  it('passes when the package root carries the expected version', () => {
+    const root = writePackage(makeTempDir('verify-ok'), '1.20.7');
+    expect(() => verifyInstalledVersion(root, '1.20.7')).not.toThrow();
+  });
+
+  it('throws with both versions when the running root was not updated', () => {
+    // The original incident: npm exits 0 after installing into a different
+    // prefix, while the running copy's root still carries the old version.
+    const root = writePackage(makeTempDir('verify-stale'), '1.20.4');
+    expect(() => verifyInstalledVersion(root, '1.20.7')).toThrow(/still 1\.20\.4 \(expected 1\.20\.7\)/);
+  });
+});
+
+describe('installPackageIntoPrefix', () => {
+  function packDummyPackage(version: string): string {
+    const src = makeTempDir('dummy-src');
+    fs.writeFileSync(
+      path.join(src, 'package.json'),
+      JSON.stringify({ name: '@agents-cli-test/dummy', version, license: 'MIT' }),
+    );
+    const tarball = execFileSync('npm', ['pack', '--silent'], { cwd: src, encoding: 'utf-8' }).trim();
+    return path.join(src, tarball);
+  }
+
+  it('installs into the given prefix and the result verifies in place', { timeout: 120_000 }, async () => {
+    const prefix = makeTempDir('prefix');
+    const tarball = packDummyPackage('2.0.0');
+
+    await installPackageIntoPrefix(tarball, prefix);
+
+    const installedRoot = path.join(prefix, 'lib', 'node_modules', '@agents-cli-test', 'dummy');
+    expect(readInstalledVersion(installedRoot)).toBe('2.0.0');
+    expect(() => verifyInstalledVersion(installedRoot, '2.0.0')).not.toThrow();
+    // The exact upgrade-flow composition: the prefix derived from the
+    // installed root must round-trip back to the prefix we installed into.
+    expect(deriveGlobalPrefix(installedRoot)).toBe(prefix);
+  });
+
+  it('verification catches an install that landed in a different prefix', { timeout: 120_000 }, async () => {
+    // Reproduces the divergent-prefix incident end-to-end: the "running"
+    // copy lives in prefix A at 1.0.0, the install writes 2.0.0 into prefix
+    // B, and verification against A's root must fail rather than report a
+    // successful upgrade.
+    const prefixA = makeTempDir('prefix-a');
+    const prefixB = makeTempDir('prefix-b');
+    const runningRoot = path.join(prefixA, 'lib', 'node_modules', '@agents-cli-test', 'dummy');
+    fs.mkdirSync(runningRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(runningRoot, 'package.json'),
+      JSON.stringify({ name: '@agents-cli-test/dummy', version: '1.0.0' }),
+    );
+
+    await installPackageIntoPrefix(packDummyPackage('2.0.0'), prefixB);
+
+    expect(() => verifyInstalledVersion(runningRoot, '2.0.0')).toThrow(/still 1\.0\.0 \(expected 2\.0\.0\)/);
+  });
+});

--- a/src/lib/self-update.ts
+++ b/src/lib/self-update.ts
@@ -1,0 +1,89 @@
+/**
+ * Self-update install plumbing.
+ *
+ * The hard requirement: an upgrade must replace the copy that is currently
+ * running. A bare `npm install -g` writes into the global prefix of whatever
+ * `npm` PATH happens to resolve — on machines with more than one node
+ * installation (nvm + Homebrew + vendored runtimes) that prefix can belong to
+ * a different node than the one this copy lives under. The install then
+ * "succeeds" while the running copy stays stale and re-prompts forever.
+ *
+ * So every step here is anchored to the running package root on disk, never
+ * to PATH resolution.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+
+export const NPM_PACKAGE_NAME = '@phnx-labs/agents-cli';
+
+/**
+ * Derive the npm global prefix that owns the install at `packageRoot`.
+ *
+ * npm's global layout for a scoped package:
+ *   POSIX:   <prefix>/lib/node_modules/@phnx-labs/agents-cli
+ *   Windows: <prefix>/node_modules/@phnx-labs/agents-cli
+ *
+ * Throws when `packageRoot` is not inside a node_modules tree (e.g. running
+ * from a source checkout) — there is no prefix to install into, and guessing
+ * one is exactly the bug this module exists to prevent.
+ */
+export function deriveGlobalPrefix(packageRoot: string): string {
+  const resolved = path.resolve(packageRoot);
+  // Two levels up from the package root: the scope dir, then node_modules.
+  const nodeModulesDir = path.dirname(path.dirname(resolved));
+  if (path.basename(nodeModulesDir) !== 'node_modules') {
+    throw new Error(
+      `${resolved} is not an npm-managed install; reinstall with: npm install -g ${NPM_PACKAGE_NAME}`,
+    );
+  }
+  const parent = path.dirname(nodeModulesDir);
+  return path.basename(parent) === 'lib' ? path.dirname(parent) : parent;
+}
+
+/**
+ * Install `spec` into an explicit global prefix. `--prefix` pins the
+ * destination no matter which npm binary PATH resolves. `--ignore-scripts`
+ * skips lifecycle scripts; the caller refreshes alias shims afterwards via
+ * refreshAliasShims().
+ */
+export async function installPackageIntoPrefix(spec: string, prefix: string): Promise<void> {
+  const { execFile } = await import('child_process');
+  const { promisify } = await import('util');
+  const execFileAsync = promisify(execFile);
+  await execFileAsync('npm', ['install', '-g', '--prefix', prefix, spec, '--ignore-scripts']);
+}
+
+/** Read the version field of the package.json at `packageRoot`, fresh from disk. */
+export function readInstalledVersion(packageRoot: string): string {
+  return JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf-8')).version;
+}
+
+/**
+ * Assert that the install at `packageRoot` now carries `expectedVersion`.
+ * npm exiting 0 only proves it wrote *somewhere*; this proves it wrote *here*.
+ */
+export function verifyInstalledVersion(packageRoot: string, expectedVersion: string): void {
+  const actual = readInstalledVersion(packageRoot);
+  if (actual !== expectedVersion) {
+    throw new Error(
+      `npm reported success but ${packageRoot} is still ${actual} (expected ${expectedVersion}). ` +
+        `Run manually: npm install -g --prefix ${deriveGlobalPrefix(packageRoot)} ${NPM_PACKAGE_NAME}@${expectedVersion}`,
+    );
+  }
+}
+
+/**
+ * Re-run the freshly installed copy's postinstall in shims-only mode so the
+ * bare-command aliases (secrets, sessions, ...) pick up the new entrypoint
+ * and any aliases added in the new version. Best-effort: a failure here
+ * leaves the previous shims in place, which still point at the (now
+ * upgraded) package root.
+ */
+export function refreshAliasShims(packageRoot: string): void {
+  spawnSync(process.execPath, [path.join(packageRoot, 'scripts', 'postinstall.js')], {
+    env: { ...process.env, AGENTS_POSTINSTALL_SHIMS_ONLY: '1' },
+    stdio: 'ignore',
+  });
+}

--- a/tests/package-name-consistency.test.ts
+++ b/tests/package-name-consistency.test.ts
@@ -41,13 +41,15 @@ describe('package-name consistency (@phnx-labs canonical)', () => {
     expect(src).not.toContain('@companion/agents-cli');
   });
 
-  it('src/index.ts upgrade commands install the canonical package', () => {
+  it('upgrade installs are built from the canonical package constant', () => {
+    // The npm install itself lives in src/lib/self-update.ts; index.ts builds
+    // the install spec from the shared NPM_PACKAGE_NAME constant.
+    const selfUpdate = read('src/lib/self-update.ts');
+    expect(selfUpdate).toContain(`export const NPM_PACKAGE_NAME = '${NPM_PACKAGE}';`);
+    expect(selfUpdate).not.toContain('@companion');
     const src = read('src/index.ts');
-    const matches = src.match(/'install',\s*'-g',\s*'([^']+)'/g) ?? [];
-    expect(matches.length).toBeGreaterThan(0);
-    for (const m of matches) {
-      expect(m).toContain(NPM_PACKAGE);
-    }
+    const specs = src.match(/installPackageIntoPrefix\(`\$\{NPM_PACKAGE_NAME\}@/g) ?? [];
+    expect(specs.length).toBeGreaterThan(0);
   });
 
   it('src/index.ts version-check URLs target the canonical package', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     pool: 'forks',
-    include: ['tests/**/*.test.ts', 'src/**/__tests__/**/*.test.ts', 'src/**/*.test.ts'],
+    include: ['tests/**/*.test.ts', 'src/**/__tests__/**/*.test.ts', 'src/**/*.test.ts', 'scripts/**/*.test.ts'],
     testTimeout: 30000,
   },
 });


### PR DESCRIPTION
## Bug

The self-updater ran PATH-resolved `npm install -g @phnx-labs/agents-cli@X`. On machines with multiple node installations (nvm + Homebrew + vendored runtimes), the `npm` a subprocess resolves can belong to a different node than the one the running copy lives under. The install exits 0 into the wrong global prefix, the updater prints "Upgraded to X", but the executing install never changes — and every subsequent run re-prompts "Update available: old -> X" forever.

Observed in the wild: shim-launched copy at `~/.nvm/versions/node/v24.15.0/...` stayed at 1.20.4 while "Upgrade now" installed 1.20.7 into `~/.hermes/node/...` (a prefix not even on PATH), confirmed via npm debug logs.

## Fix

- **`src/lib/self-update.ts`** (new): derive the npm global prefix from the running package root (`<prefix>/lib/node_modules/@phnx-labs/agents-cli`) and pass it as `--prefix`, so the install lands where the running copy lives no matter which npm PATH resolves. After install, re-read the running root's `package.json` and **fail loudly** if the version did not change — npm exiting 0 only proves it wrote *somewhere*.
- **Re-exec the verified entrypoint** via `process.execPath` + absolute path instead of PATH-resolved `agents` (which can be a different copy, e.g. a dev build).
- **`scripts/postinstall.js`**: new `AGENTS_POSTINSTALL_SHIMS_ONLY=1` entry so the updater (which installs with `--ignore-scripts`) can refresh the alias shims (`secrets`, `sessions`, ...) from the newly installed copy — no prompts, no output.
- Upgrade failures now print the underlying error instead of a bare "Upgrade failed".
- **`vitest.config.ts`**: include `scripts/**/*.test.ts` — the existing `postinstall.test.ts` was never picked up by the runner.

## Tests

- `src/lib/self-update.test.ts`: prefix derivation (POSIX / Windows / dev-install layouts, source-checkout rejection); verification pass/fail; **real `npm install -g --prefix`** of a packed dummy tarball into a temp prefix, including the exact divergent-prefix incident (install lands in prefix B, verification against prefix A's root must throw).
- `scripts/postinstall.test.ts`: shims-only mode writes all five alias shims silently.

## End-to-end verification

Packed this branch, installed it into a throwaway prefix as the "running copy", ran the real `upgrade` command against the live registry:

- **Happy path**: `upgrade 1.20.6 --yes` resolved from the registry, installed into the running copy's own prefix, verification passed, on-disk version changed.
- **Control (old code)**: with a no-op fake `npm` on PATH, the pre-fix updater printed the changelog as if upgraded while installing nothing — the original bug reproduced.
- **Fixed code, same fake npm**: `Upgrade failed: npm reported success but <root> is still 1.20.7 (expected 1.20.6). Run manually: npm install -g --prefix <prefix> @phnx-labs/agents-cli@1.20.6`

Full suite: green except `src/lib/__tests__/models.test.ts` (fails identically on `main` — pre-existing) and a few load-induced flakes that pass in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)