### PR TITLE
perf(run): cache the session last-active walk that slowed every launch

### DIFF
--- a/src/lib/agents.test.ts
+++ b/src/lib/agents.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { pathToFileURL } from 'url';
 import { spawnSync } from 'child_process';
 import { afterEach, describe, expect, it } from 'vitest';
-import { AGENTS } from './agents.js';
+import { AGENTS, resolveLastActive } from './agents.js';
 import type { CapabilityName } from './types.js';
 
 const tempDirs: string[] = [];
@@ -190,5 +190,100 @@ describe('AGENTS capability matrix', () => {
         expect(config.capabilities, `${agentId} missing ${capability}`).toHaveProperty(capability);
       }
     }
+  });
+});
+
+describe('resolveLastActive', () => {
+  function makeClaudeHome(sessionMtimeSec?: number): string {
+    const home = makeTempDir();
+    const projects = path.join(home, '.claude', 'projects', 'some-project');
+    fs.mkdirSync(projects, { recursive: true });
+    if (sessionMtimeSec !== undefined) {
+      const session = path.join(projects, 'session.jsonl');
+      fs.writeFileSync(session, '{}', 'utf-8');
+      fs.utimesSync(session, sessionMtimeSec, sessionMtimeSec);
+    }
+    return home;
+  }
+
+  function cacheFile(): string {
+    return path.join(makeTempDir(), 'last-active.json');
+  }
+
+  it('returns the newest session mtime and persists it to the cache', () => {
+    const home = makeClaudeHome(5_000);
+    const cachePath = cacheFile();
+
+    const result = resolveLastActive('claude', home, undefined, cachePath);
+    expect(result?.getTime()).toBe(5_000_000);
+
+    const cache = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+    expect(cache[`claude:${home}`]).toEqual({ mtimeMs: 5_000_000, computedAt: expect.any(Number) });
+  });
+
+  it('serves from cache within the fresh window instead of re-walking', () => {
+    const home = makeClaudeHome(5_000);
+    const cachePath = cacheFile();
+    const t0 = new Date('2026-06-11T00:00:00Z');
+
+    expect(resolveLastActive('claude', home, undefined, cachePath, t0)?.getTime()).toBe(5_000_000);
+
+    // A newer session appears, but the cache is still fresh — the cached
+    // value must win, proving the walk was skipped.
+    const newer = path.join(home, '.claude', 'projects', 'some-project', 'newer.jsonl');
+    fs.writeFileSync(newer, '{}', 'utf-8');
+    fs.utimesSync(newer, 9_000, 9_000);
+
+    const within = new Date(t0.getTime() + 60_000);
+    expect(resolveLastActive('claude', home, undefined, cachePath, within)?.getTime()).toBe(5_000_000);
+
+    // Past the fresh window the walk runs again and picks up the newer file.
+    const beyond = new Date(t0.getTime() + 3 * 60_000);
+    expect(resolveLastActive('claude', home, undefined, cachePath, beyond)?.getTime()).toBe(9_000_000);
+  });
+
+  it('falls back to config mtime when the home has no sessions, including via a fresh null entry', () => {
+    const home = makeClaudeHome();
+    const cachePath = cacheFile();
+    const config = path.join(home, '.claude.json');
+    fs.writeFileSync(config, '{}', 'utf-8');
+    fs.utimesSync(config, 7_000, 7_000);
+    const t0 = new Date('2026-06-11T00:00:00Z');
+
+    expect(resolveLastActive('claude', home, config, cachePath, t0)?.getTime()).toBe(7_000_000);
+    // Second call hits the fresh null entry and must still fall through to config mtime.
+    const within = new Date(t0.getTime() + 60_000);
+    expect(resolveLastActive('claude', home, config, cachePath, within)?.getTime()).toBe(7_000_000);
+  });
+
+  it('treats a corrupt cache file as empty and recomputes', () => {
+    const home = makeClaudeHome(5_000);
+    const cachePath = cacheFile();
+    fs.writeFileSync(cachePath, 'not json', 'utf-8');
+
+    expect(resolveLastActive('claude', home, undefined, cachePath)?.getTime()).toBe(5_000_000);
+  });
+});
+
+describe('resolveLastActive cache pruning', () => {
+  it('drops stale entries for other homes on write', () => {
+    const home = path.join(makeTempDir(), 'live-home');
+    const projects = path.join(home, '.claude', 'projects', 'p');
+    fs.mkdirSync(projects, { recursive: true });
+    const session = path.join(projects, 's.jsonl');
+    fs.writeFileSync(session, '{}', 'utf-8');
+    fs.utimesSync(session, 5_000, 5_000);
+
+    const cachePath = path.join(makeTempDir(), 'last-active.json');
+    const t0 = new Date('2026-06-11T00:00:00Z');
+    fs.writeFileSync(cachePath, JSON.stringify({
+      'claude:/gone/stale-home': { mtimeMs: 1_000, computedAt: t0.getTime() - 10 * 60_000 },
+      'claude:/gone/fresh-home': { mtimeMs: 2_000, computedAt: t0.getTime() - 30_000 },
+    }), 'utf-8');
+
+    resolveLastActive('claude', home, undefined, cachePath, t0);
+
+    const cache = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+    expect(Object.keys(cache).sort()).toEqual([`claude:${home}`, 'claude:/gone/fresh-home'].sort());
   });
 });

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -16,8 +16,8 @@ import * as os from 'os';
 import * as TOML from 'smol-toml';
 import chalk from 'chalk';
 import type { AgentConfig, AgentId } from './types.js';
-import { walkForFiles } from './fs-walk.js';
-import { getVersionsDir, getShimsDir, getCliVersionCachePath } from './state.js';
+import { latestFileMtimeMs } from './fs-walk.js';
+import { getCacheDir, getVersionsDir, getShimsDir, getCliVersionCachePath } from './state.js';
 import { resolveVersion, getVersionHomePath, getBinaryPath } from './versions.js';
 
 /** Represents the installation state of an agent's CLI binary. */
@@ -942,18 +942,64 @@ export async function getAccountInfo(
   }
 }
 
-/** Determine when the agent was last used by checking session file mtimes, falling back to config mtime. */
-function resolveLastActive(
+// Fresh window for the cached session walk. Matches USAGE_CACHE_FRESH_MS in
+// usage.ts so a launch storm reuses both probes for the same period.
+const LAST_ACTIVE_CACHE_FRESH_MS = 2 * 60 * 1000;
+
+const getLastActiveCachePath = () => path.join(getCacheDir(), 'last-active.json');
+
+interface LastActiveCacheEntry {
+  /** Newest session-file mtime (ms), or null when the home had no sessions. */
+  mtimeMs: number | null;
+  /** When the walk that produced this entry ran (ms since epoch). */
+  computedAt: number;
+}
+
+/**
+ * Determine when the agent was last used by checking session file mtimes,
+ * falling back to config mtime.
+ *
+ * The session walk stats every transcript under the home's session dir —
+ * thousands of files on long-lived installs — and `agents run` rotation calls
+ * this once per installed version on every launch. The walk result is cached
+ * on disk for a short window so back-to-back launches skip it entirely.
+ * Cache read/write is best-effort: any failure falls back to walking.
+ */
+export function resolveLastActive(
   agentId: AgentId,
   base: string,
-  configPath?: string
+  configPath?: string,
+  cachePath = getLastActiveCachePath(),
+  now = new Date()
 ): Date | null {
   const sessionDir = getSessionDir(agentId, base);
   const sessionExt = getSessionExtension(agentId);
   if (sessionDir && sessionExt) {
-    const latestSession = getLatestFileMtime(sessionDir, sessionExt);
-    if (latestSession) {
-      return latestSession;
+    const key = `${agentId}:${base}`;
+    const cache = readLastActiveCacheFile(cachePath);
+    const entry = cache[key];
+    const fresh =
+      entry &&
+      typeof entry.computedAt === 'number' &&
+      now.getTime() - entry.computedAt >= 0 &&
+      now.getTime() - entry.computedAt < LAST_ACTIVE_CACHE_FRESH_MS;
+
+    if (fresh) {
+      if (entry.mtimeMs !== null) return new Date(entry.mtimeMs);
+      // Fresh entry with no sessions: fall through to the config mtime below.
+    } else {
+      const mtimeMs = latestFileMtimeMs(sessionDir, sessionExt);
+      cache[key] = { mtimeMs, computedAt: now.getTime() };
+      // Stale entries are never served, so drop them on write — keeps homes
+      // that no longer exist (removed versions, test temp dirs) from
+      // accumulating in the file.
+      for (const [k, v] of Object.entries(cache)) {
+        if (k !== key && !(typeof v?.computedAt === 'number' && now.getTime() - v.computedAt < LAST_ACTIVE_CACHE_FRESH_MS)) {
+          delete cache[k];
+        }
+      }
+      writeLastActiveCacheFile(cache, cachePath);
+      if (mtimeMs !== null) return new Date(mtimeMs);
     }
   }
 
@@ -962,6 +1008,27 @@ function resolveLastActive(
     return fs.statSync(configPath).mtime;
   } catch {
     return null;
+  }
+}
+
+/** Read the entire last-active cache file. Missing or corrupt file reads as empty. */
+function readLastActiveCacheFile(cachePath: string): Record<string, LastActiveCacheEntry> {
+  if (!fs.existsSync(cachePath)) return {};
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cachePath, 'utf-8')) as Record<string, LastActiveCacheEntry>;
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Write the entire last-active cache. Best-effort; a failed write just means the next call walks again. */
+function writeLastActiveCacheFile(cache: Record<string, LastActiveCacheEntry>, cachePath: string): void {
+  try {
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    fs.writeFileSync(cachePath, JSON.stringify(cache), 'utf-8');
+  } catch {
+    /* best-effort */
   }
 }
 
@@ -1027,18 +1094,6 @@ export function countSessionFiles(agentId: AgentId): number {
   };
   walk(sessionDir);
   return count;
-}
-
-/** Walk a directory for files matching the extension and return the mtime of the most recent one. */
-function getLatestFileMtime(dir: string, ext: string): Date | null {
-  if (!fs.existsSync(dir)) return null;
-  const [latest] = walkForFiles(dir, ext, 1);
-  if (!latest) return null;
-  try {
-    return fs.statSync(latest).mtime;
-  } catch {
-    return null;
-  }
 }
 
 /** Decode the payload section of a JWT token without verifying its signature. */

--- a/src/lib/fs-walk.test.ts
+++ b/src/lib/fs-walk.test.ts
@@ -1,0 +1,95 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { walkForFiles, latestFileMtimeMs } from './fs-walk.js';
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-fs-walk-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/** Create a file with a deterministic mtime (seconds since epoch). */
+function writeFileAt(filePath: string, mtimeSec: number): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, 'x', 'utf-8');
+  fs.utimesSync(filePath, mtimeSec, mtimeSec);
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('walkForFiles', () => {
+  it('returns matching files newest first, honoring the limit', () => {
+    const dir = makeTempDir();
+    writeFileAt(path.join(dir, 'a', 'old.jsonl'), 1_000);
+    writeFileAt(path.join(dir, 'b', 'newest.jsonl'), 3_000);
+    writeFileAt(path.join(dir, 'mid.jsonl'), 2_000);
+    writeFileAt(path.join(dir, 'ignored.txt'), 4_000);
+
+    const all = walkForFiles(dir, '.jsonl', 10);
+    expect(all.map((p) => path.basename(p))).toEqual(['newest.jsonl', 'mid.jsonl', 'old.jsonl']);
+
+    const limited = walkForFiles(dir, '.jsonl', 1);
+    expect(limited.map((p) => path.basename(p))).toEqual(['newest.jsonl']);
+  });
+
+  it('follows symlinked directories and matches symlinked files', () => {
+    const dir = makeTempDir();
+    const outside = makeTempDir();
+    writeFileAt(path.join(outside, 'linked-dir', 'inside.jsonl'), 2_000);
+    writeFileAt(path.join(outside, 'target.jsonl'), 1_000);
+
+    fs.symlinkSync(path.join(outside, 'linked-dir'), path.join(dir, 'linked-dir'));
+    fs.symlinkSync(path.join(outside, 'target.jsonl'), path.join(dir, 'link.jsonl'));
+    // Dangling symlink must be skipped, not crash the walk.
+    fs.symlinkSync(path.join(outside, 'missing.jsonl'), path.join(dir, 'dangling.jsonl'));
+
+    const found = walkForFiles(dir, '.jsonl', 10).map((p) => path.basename(p));
+    expect(found).toEqual(['inside.jsonl', 'link.jsonl']);
+  });
+
+  it('stops descending beyond depth 5', () => {
+    const dir = makeTempDir();
+    const deep = path.join(dir, '1', '2', '3', '4', '5', '6');
+    writeFileAt(path.join(deep, 'too-deep.jsonl'), 1_000);
+    writeFileAt(path.join(dir, '1', '2', '3', '4', '5', 'reachable.jsonl'), 2_000);
+
+    const found = walkForFiles(dir, '.jsonl', 10).map((p) => path.basename(p));
+    expect(found).toEqual(['reachable.jsonl']);
+  });
+});
+
+describe('latestFileMtimeMs', () => {
+  it('returns the newest matching mtime across nested dirs', () => {
+    const dir = makeTempDir();
+    writeFileAt(path.join(dir, 'a', 'old.jsonl'), 1_000);
+    writeFileAt(path.join(dir, 'b', 'c', 'newest.jsonl'), 3_000);
+    writeFileAt(path.join(dir, 'newer-but-wrong-ext.txt'), 9_000);
+
+    expect(latestFileMtimeMs(dir, '.jsonl')).toBe(3_000_000);
+  });
+
+  it('returns null when nothing matches or the dir is missing', () => {
+    const dir = makeTempDir();
+    writeFileAt(path.join(dir, 'other.txt'), 1_000);
+
+    expect(latestFileMtimeMs(dir, '.jsonl')).toBeNull();
+    expect(latestFileMtimeMs(path.join(dir, 'does-not-exist'), '.jsonl')).toBeNull();
+  });
+
+  it('agrees with walkForFiles on the same tree', () => {
+    const dir = makeTempDir();
+    writeFileAt(path.join(dir, 'p1', 's1.jsonl'), 1_500);
+    writeFileAt(path.join(dir, 'p2', 's2.jsonl'), 2_500);
+
+    const [newest] = walkForFiles(dir, '.jsonl', 1);
+    expect(latestFileMtimeMs(dir, '.jsonl')).toBe(fs.statSync(newest).mtimeMs);
+  });
+});

--- a/src/lib/fs-walk.ts
+++ b/src/lib/fs-walk.ts
@@ -1,36 +1,70 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-/** Walk a directory recursively for files with a given extension. */
-export function walkForFiles(dir: string, ext: string, limit: number): string[] {
-  const results: { path: string; mtime: number }[] = [];
-
+/**
+ * Recursively visit files with a given extension, calling onFile with each
+ * match's path and mtime. Uses dirent types from readdir so only matching
+ * files (and symlinks, to preserve follow semantics) pay a stat call —
+ * directories are classified for free. On large session trees this roughly
+ * halves the syscall count versus stat-per-entry.
+ */
+function walkEntries(dir: string, ext: string, onFile: (filePath: string, mtimeMs: number) => void): void {
   function walk(d: string, depth: number) {
     if (depth > 5) return;
-    let entries: string[];
+    let entries: fs.Dirent[];
     try {
-      entries = fs.readdirSync(d);
+      entries = fs.readdirSync(d, { withFileTypes: true });
     } catch {
       return;
     }
 
     for (const entry of entries) {
-      const full = path.join(d, entry);
-      const stat = safeStatSync(full);
-      if (!stat) continue;
+      const full = path.join(d, entry.name);
+      let isDirectory = entry.isDirectory();
 
-      if (stat.isDirectory()) {
+      // Symlinks: dirent reports the link itself, but the previous stat-based
+      // walk followed links into directories and matched linked files. Stat
+      // (which follows) only for symlinks to keep that behavior.
+      if (entry.isSymbolicLink()) {
+        const stat = safeStatSync(full);
+        if (!stat) continue;
+        isDirectory = stat.isDirectory();
+      }
+
+      if (isDirectory) {
         walk(full, depth + 1);
-      } else if (entry.endsWith(ext)) {
-        results.push({ path: full, mtime: stat.mtimeMs });
+      } else if (entry.name.endsWith(ext)) {
+        const stat = safeStatSync(full);
+        if (stat) onFile(full, stat.mtimeMs);
       }
     }
   }
 
   walk(dir, 0);
+}
+
+/** Walk a directory recursively for files with a given extension, newest first. */
+export function walkForFiles(dir: string, ext: string, limit: number): string[] {
+  const results: { path: string; mtime: number }[] = [];
+  walkEntries(dir, ext, (filePath, mtimeMs) => {
+    results.push({ path: filePath, mtime: mtimeMs });
+  });
 
   results.sort((a, b) => b.mtime - a.mtime);
   return results.slice(0, limit).map(r => r.path);
+}
+
+/**
+ * Return the newest mtime (ms) among files with the given extension, or null
+ * when none match. Single pass tracking the max — no collection or sort.
+ * Hot-path helper for the `agents run` account-recency probe.
+ */
+export function latestFileMtimeMs(dir: string, ext: string): number | null {
+  let latest: number | null = null;
+  walkEntries(dir, ext, (_filePath, mtimeMs) => {
+    if (latest === null || mtimeMs > latest) latest = mtimeMs;
+  });
+  return latest;
 }
 
 function safeStatSync(p: string): fs.Stats | null {


### PR DESCRIPTION
## Problem

`agents run <agent>` with the `balanced`/`available` strategy got slower every day. Rotation calls `getAccountInfo` once per installed version on every launch, and each call resolved "last active" by recursively **statting every entry** under the version home's session tree, sorting all files by mtime, then re-statting the winner — just to learn the single newest session mtime.

Measured on a real install (3 Claude versions, ~2,400 accumulated transcripts):

- 2,577 `stat` + 774 `readdir` calls per version per launch
- ~550ms cold-cache per version
- `resolveRunVersion('claude', 'balanced')`: **1,592ms** before the TUI can even start spawning

Since session transcripts only accumulate, launch latency silently grows without bound. (The usage probe itself was already fine — the SWR cache from #159 serves it in ~1ms when warm; the walk was the remaining hot-path cost.)

## Fix

1. **`fs-walk.ts`**: classify entries via `readdirSync(..., { withFileTypes: true })` instead of a `statSync` per entry. Only ext-matching files (and symlinks, to preserve the old follow-into-dirs semantics) pay a stat. Roughly halves syscalls for all callers (session discovery, codex usage probe).
2. **`fs-walk.ts`**: new `latestFileMtimeMs()` — single-pass max scan, no collection/sort/re-stat — replaces `walkForFiles(dir, ext, 1)` for the recency probe.
3. **`agents.ts`**: `resolveLastActive` persists the walk result in `~/.agents/.cache/last-active.json` with a 2-minute fresh window (mirrors `USAGE_CACHE_FRESH_MS`, same best-effort read/write pattern as `claude-usage.json`). Back-to-back launches skip the walk entirely; stale entries are pruned on write so removed versions and test temp homes don't accumulate.

## Measured result

| Path | Before | After |
|---|---|---|
| `resolveRunVersion('claude', 'balanced')`, cold | 1,592ms | 834ms (walk paid once per 2 min) |
| Same, warm — new process each time | 1,592ms | **34–55ms** |

## Tests

- New `src/lib/fs-walk.test.ts` (1:1): ordering/limit, symlink follow + dangling-link skip, depth cap, max-mtime agreement with `walkForFiles` — all on real temp FS trees.
- `agents.test.ts`: `resolveLastActive` returns newest session mtime and persists it; serves from cache inside the fresh window (proven by writing a newer session that must NOT be picked up until the window lapses); fresh-null entry falls through to config mtime; corrupt cache file recomputes; stale-entry pruning.
- Full suite: same single pre-existing failure as `main` (`models.test.ts` per-cloud routing), no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)