### PR TITLE
feat(windows): killTree primitive + Windows-safe daemon stop/reload (#236, #232)

### DIFF
--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -12,7 +12,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { getDaemonDir as getDaemonDirRoot } from './state.js';
-import { isAlive } from './platform/index.js';
+import { isAlive, killTree } from './platform/index.js';
 import { listJobs as listAllJobs } from './routines.js';
 import { JobScheduler } from './scheduler.js';
 import { executeJobDetached, monitorRunningJobs } from './runner.js';
@@ -453,16 +453,21 @@ export function stopDaemon(): boolean {
 
   const pid = readDaemonPid();
   if (pid) {
-    try {
-      process.kill(pid, 'SIGTERM');
-    } catch { /* process already exited */ }
-
-    setTimeout(() => {
+    if (process.platform === 'win32') {
+      // Windows has no graceful termination signal — terminate the daemon and
+      // its job/browser child tree in one shot (taskkill /T), so stop doesn't
+      // report success while children keep running.
+      killTree(pid);
+    } else {
       try {
-        process.kill(pid, 0);
-        process.kill(pid, 'SIGKILL');
+        process.kill(pid, 'SIGTERM');
       } catch { /* process already exited */ }
-    }, 5000);
+
+      // Escalate to a hard tree-kill if it ignored SIGTERM after the grace period.
+      setTimeout(() => {
+        if (isAlive(pid)) killTree(pid);
+      }, 5000);
+    }
   }
 
   removeDaemonPid();
@@ -503,6 +508,12 @@ export function readDaemonLog(lines?: number): string {
 export function signalDaemonReload(): boolean {
   const pid = readDaemonPid();
   if (!pid) return false;
+  if (process.platform === 'win32') {
+    // Windows has no SIGHUP, so signal-based live reload isn't available. Sending
+    // it would throw; instead report "not reloaded" so callers tell the user to
+    // restart the daemon to pick up job changes.
+    return false;
+  }
   try {
     process.kill(pid, 'SIGHUP');
     return true;

--- a/src/lib/platform/process.test.ts
+++ b/src/lib/platform/process.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { isAlive } from './process.js';
+import { spawn } from 'child_process';
+import { isAlive, killTree } from './process.js';
 
 describe('isAlive', () => {
   it('is true for the current process', () => {
@@ -14,5 +15,26 @@ describe('isAlive', () => {
   it('is false for a pid that is almost certainly not running', () => {
     // 2^30 is well above any realistic live PID on Linux/macOS/Windows.
     expect(isAlive(1 << 30)).toBe(false);
+  });
+});
+
+describe('killTree', () => {
+  it('terminates a running process', async () => {
+    // A child that would otherwise live forever — killTree must actually end it.
+    const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });
+    const pid = child.pid!;
+    expect(isAlive(pid)).toBe(true);
+
+    killTree(pid);
+
+    for (let i = 0; i < 100 && isAlive(pid); i++) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    expect(isAlive(pid)).toBe(false);
+  });
+
+  it('is a no-op for invalid pids (never throws)', () => {
+    expect(() => killTree(0)).not.toThrow();
+    expect(() => killTree(-1)).not.toThrow();
   });
 });

--- a/src/lib/platform/process.ts
+++ b/src/lib/platform/process.ts
@@ -1,6 +1,30 @@
 /**
  * Process liveness / control, platform-aware.
  */
+import { execFileSync } from 'child_process';
+
+/**
+ * Forcefully terminate a process AND its descendant tree.
+ *
+ * Windows: `taskkill /F /T /PID` — the only reliable way to take down the whole
+ * tree (a bare TerminateProcess leaves children orphaned, which is exactly the
+ * "stop reported success but the tree is still alive" bug). POSIX: SIGKILL to the
+ * pid (matching the existing hard-kill behavior; callers that own a process group
+ * can pass the negative pid). Best-effort — never throws; an already-exited
+ * process counts as success.
+ */
+export function killTree(pid: number): void {
+  if (!pid || pid <= 0) return;
+  if (process.platform === 'win32') {
+    try {
+      execFileSync('taskkill', ['/F', '/T', '/PID', String(pid)], { stdio: 'ignore' });
+    } catch { /* already gone, or no such pid */ }
+  } else {
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch { /* already gone */ }
+  }
+}
 
 /**
  * Is a process with this PID currently alive?


### PR DESCRIPTION
First slice of the Windows portability work (#236), on the `platform/` foundation. Also closes the **stop/kill half of #232**.

## Problem
The routines scheduler daemon used POSIX signals that misbehave on Windows:
- `stopDaemon`'s `SIGTERM → SIGKILL` killed only the daemon, **orphaning its job/browser child tree** — "stop" reported success while children kept running (exactly the #232 "reports success but the tree is alive" bug).
- `signalDaemonReload` uses `SIGHUP`, which **throws on Windows** (no such signal).

## Fix
- **`platform/process.ts` → `killTree(pid)`** — the process concern grows: `taskkill /F /T /PID` on Windows (the only reliable whole-tree kill), `SIGKILL` on POSIX. Best-effort, never throws.
- **`daemon.ts stopDaemon`** — on Windows, `killTree` the daemon + child tree in one shot; on POSIX keep graceful `SIGTERM` then escalate to `killTree` if still alive. **POSIX byte-identical** to the old `kill(pid,0)` + `SIGKILL`.
- **`daemon.ts signalDaemonReload`** — gate `SIGHUP` off on Windows (return `false` so callers tell the user to restart the daemon to reload). Behavior-identical on Windows (the old code already caught the throw → `false`) and POSIX; just clearer and no-throw.

## Tests
- `killTree` unit-tested: spawns a real long-lived child, `killTree`s it, asserts it dies; no-op on invalid pids (never throws). Runs on Linux/macOS CI (POSIX path).
- tsc clean; platform tests pass (18). The inconsistent **8-vs-12** full-run failures are the known spawn/filesystem integration tests flaking under parallel load on my Mac — **all pass in isolation** (verified 37 tests across 4 of them), none touch daemon/process. CI runs the suite properly.

## Scope
First of the #236 cluster (the process concern). Follow-ups on the same foundation: path/exec portability (`process.env.HOME` → `homeDir`, `tail -f`/`vi` guards in routines, `git.ts` Windows abs-path detection), and the remaining kill sites (teams stop, browser/computer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)