### PR TITLE
fix(upgrade): preserve 'Skip this version' across cache refreshes; sync cache with resolved version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -300,33 +300,19 @@ async function showWhatsNew(fromVersion: string, toVersion: string): Promise<voi
 
 const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 import { getUpdateCheckPath, getMigratedSentinelPath, getUserAgentsDir } from './lib/state.js';
+import {
+  readUpdateCache,
+  saveUpdateCheck,
+  dismissUpdateVersion,
+  shouldPromptUpgrade,
+  type UpdateCheckCache,
+} from './lib/self-update.js';
 const UPDATE_CHECK_FILE = getUpdateCheckPath();
 
-/** Read the cached update-check state from disk. Returns null if the file is missing or corrupt. */
-function readUpdateCache(): { lastCheck: number; latestVersion: string; dismissed?: string } | null {
-  try {
-    return JSON.parse(fs.readFileSync(UPDATE_CHECK_FILE, 'utf-8'));
-  } catch {
-    /* cache file missing or corrupt */
-    return null;
-  }
-}
-
 /** Determine whether enough time has elapsed since the last registry fetch. */
-function shouldFetchLatest(cache: { lastCheck: number } | null): boolean {
+function shouldFetchLatest(cache: UpdateCheckCache | null): boolean {
   if (!cache) return true;
   return Date.now() - cache.lastCheck > UPDATE_CHECK_INTERVAL_MS;
-}
-
-/** Persist the latest known version and current timestamp to the update-check cache. */
-function saveUpdateCheck(latestVersion: string): void {
-  try {
-    const dir = path.dirname(UPDATE_CHECK_FILE);
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(UPDATE_CHECK_FILE, JSON.stringify({ lastCheck: Date.now(), latestVersion }));
-  } catch {
-    /* best-effort cache update */
-  }
 }
 
 /** Fetch the exact latest npm version plus its registry integrity hash. */
@@ -382,17 +368,7 @@ async function promptUpgrade(latestVersion: string): Promise<void> {
   });
 
   if (answer === 'dismiss') {
-    try {
-      const dir = path.dirname(UPDATE_CHECK_FILE);
-      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-      const existing = readUpdateCache();
-      fs.writeFileSync(UPDATE_CHECK_FILE, JSON.stringify({
-        ...existing,
-        lastCheck: existing?.lastCheck ?? Date.now(),
-        latestVersion,
-        dismissed: latestVersion,
-      }));
-    } catch { /* best-effort */ }
+    dismissUpdateVersion(UPDATE_CHECK_FILE, latestVersion);
     return;
   }
 
@@ -401,6 +377,10 @@ async function promptUpgrade(latestVersion: string): Promise<void> {
     let spinner = ora('Resolving package metadata...').start();
     try {
       const metadata = await fetchNpmPackageMetadata();
+      // The prompt showed the cached latest, which can lag the registry (the
+      // 24h window) — sync the cache to what was actually resolved so later
+      // prompts and the install agree on the same version.
+      saveUpdateCheck(UPDATE_CHECK_FILE, metadata.version);
       spinner.succeed(`Resolved ${NPM_PACKAGE_NAME}@${metadata.version}`);
       printResolvedPackage(metadata);
 
@@ -450,7 +430,7 @@ function refreshUpdateCacheInBackground(): void {
     .then((response) => (response.ok ? response.json() : null))
     .then((data) => {
       if (data && typeof (data as any).version === 'string') {
-        saveUpdateCheck((data as any).version);
+        saveUpdateCheck(UPDATE_CHECK_FILE, (data as any).version);
       }
     })
     .catch(() => {
@@ -462,7 +442,7 @@ function refreshUpdateCacheInBackground(): void {
 async function checkForUpdates(): Promise<void> {
   if (process.env.AGENTS_CLI_DISABLE_AUTO_UPDATE) return;
 
-  const cache = readUpdateCache();
+  const cache = readUpdateCache(UPDATE_CHECK_FILE);
 
   // Kick off network refresh in background if stale. Does not block.
   if (shouldFetchLatest(cache)) {
@@ -472,9 +452,9 @@ async function checkForUpdates(): Promise<void> {
   // Prompt based on current cache (may be from a previous run's background refresh).
   // Skip if the user dismissed this exact version — they'll be prompted again when
   // a newer version appears.
-  if (cache?.latestVersion && cache.latestVersion !== VERSION && compareVersions(cache.latestVersion, VERSION) > 0 && cache.latestVersion !== cache.dismissed) {
+  if (shouldPromptUpgrade(cache, VERSION)) {
     try {
-      await promptUpgrade(cache.latestVersion);
+      await promptUpgrade(cache!.latestVersion);
     } catch (err) {
       if (isPromptCancelled(err)) return;
       /* prompt error, ignore */

--- a/src/lib/self-update.test.ts
+++ b/src/lib/self-update.test.ts
@@ -5,8 +5,12 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   deriveGlobalPrefix,
+  dismissUpdateVersion,
   installPackageIntoPrefix,
   readInstalledVersion,
+  readUpdateCache,
+  saveUpdateCheck,
+  shouldPromptUpgrade,
   verifyInstalledVersion,
 } from './self-update.js';
 
@@ -110,5 +114,59 @@ describe('installPackageIntoPrefix', () => {
     await installPackageIntoPrefix(packDummyPackage('2.0.0'), prefixB);
 
     expect(() => verifyInstalledVersion(runningRoot, '2.0.0')).toThrow(/still 1\.0\.0 \(expected 2\.0\.0\)/);
+  });
+});
+
+describe('update-check cache', () => {
+  function cacheFile(): string {
+    return path.join(makeTempDir('cache'), 'nested', '.update-check');
+  }
+
+  it('readUpdateCache returns null for a missing or corrupt file', () => {
+    const file = cacheFile();
+    expect(readUpdateCache(file)).toBeNull();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, 'not json');
+    expect(readUpdateCache(file)).toBeNull();
+  });
+
+  it('saveUpdateCheck creates the parent directory and records the version', () => {
+    const file = cacheFile();
+    saveUpdateCheck(file, '1.20.7');
+    const cache = readUpdateCache(file);
+    expect(cache?.latestVersion).toBe('1.20.7');
+    expect(cache?.lastCheck).toBeTypeOf('number');
+  });
+
+  it('a background refresh does not erase a dismissed version', () => {
+    // The original bug: the user picked "Skip 1.20.7", then the next 24h
+    // background refresh rewrote the cache without the dismissed marker and
+    // re-prompted for the exact version they skipped.
+    const file = cacheFile();
+    dismissUpdateVersion(file, '1.20.7');
+    expect(shouldPromptUpgrade(readUpdateCache(file), '1.20.4')).toBe(false);
+
+    saveUpdateCheck(file, '1.20.7');
+
+    expect(readUpdateCache(file)?.dismissed).toBe('1.20.7');
+    expect(shouldPromptUpgrade(readUpdateCache(file), '1.20.4')).toBe(false);
+  });
+
+  it('a newer latest than the dismissed one resumes prompting', () => {
+    const file = cacheFile();
+    dismissUpdateVersion(file, '1.20.7');
+    saveUpdateCheck(file, '1.20.8');
+
+    const cache = readUpdateCache(file);
+    expect(cache?.dismissed).toBe('1.20.7');
+    expect(shouldPromptUpgrade(cache, '1.20.4')).toBe(true);
+  });
+
+  it('shouldPromptUpgrade is false when current is equal to or ahead of latest', () => {
+    const cache = { lastCheck: 1, latestVersion: '1.20.7' };
+    expect(shouldPromptUpgrade(cache, '1.20.7')).toBe(false);
+    expect(shouldPromptUpgrade(cache, '1.21.0')).toBe(false);
+    expect(shouldPromptUpgrade(null, '1.20.4')).toBe(false);
+    expect(shouldPromptUpgrade(cache, '1.20.4')).toBe(true);
   });
 });

--- a/src/lib/self-update.ts
+++ b/src/lib/self-update.ts
@@ -15,8 +15,74 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { spawnSync } from 'child_process';
+import { compareVersions } from './versions.js';
 
 export const NPM_PACKAGE_NAME = '@phnx-labs/agents-cli';
+
+export interface UpdateCheckCache {
+  lastCheck: number;
+  latestVersion: string;
+  dismissed?: string;
+}
+
+/** Read the cached update-check state from disk. Returns null if the file is missing or corrupt. */
+export function readUpdateCache(file: string): UpdateCheckCache | null {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf-8'));
+  } catch {
+    /* cache file missing or corrupt */
+    return null;
+  }
+}
+
+/**
+ * Persist the latest known version and current timestamp. Preserves an
+ * existing `dismissed` marker — the background refresh must not erase a
+ * user's "Skip this version" choice, or they get re-prompted for the exact
+ * version they dismissed.
+ */
+export function saveUpdateCheck(file: string, latestVersion: string): void {
+  try {
+    const dir = path.dirname(file);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const dismissed = readUpdateCache(file)?.dismissed;
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ lastCheck: Date.now(), latestVersion, ...(dismissed ? { dismissed } : {}) }),
+    );
+  } catch {
+    /* best-effort cache update */
+  }
+}
+
+/** Record that the user chose to skip `version`; suppresses prompts until a newer version appears. */
+export function dismissUpdateVersion(file: string, version: string): void {
+  try {
+    const dir = path.dirname(file);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const existing = readUpdateCache(file);
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        lastCheck: existing?.lastCheck ?? Date.now(),
+        latestVersion: version,
+        dismissed: version,
+      }),
+    );
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Whether the cached state warrants an upgrade prompt for a copy running `currentVersion`. */
+export function shouldPromptUpgrade(cache: UpdateCheckCache | null, currentVersion: string): boolean {
+  if (!cache?.latestVersion) return false;
+  return (
+    cache.latestVersion !== currentVersion &&
+    compareVersions(cache.latestVersion, currentVersion) > 0 &&
+    cache.latestVersion !== cache.dismissed
+  );
+}
 
 /**
  * Derive the npm global prefix that owns the install at `packageRoot`.


### PR DESCRIPTION
Follow-up to #263 — the remaining update-check cache bugs.

## Bugs

1. **"Skip 1.20.7" didn't stick.** `saveUpdateCheck()` rewrote the cache as `{lastCheck, latestVersion}` without spreading the existing `dismissed` field, so the next 24h background refresh erased the user's skip and re-prompted for the exact version they dismissed.
2. **Prompt/install version mismatch persisted.** The prompt reads the cached latest ("Update available: 1.20.4 -> 1.20.5") while "Upgrade now" resolves the registry live (installs 1.20.7), and the cache stayed stale afterwards.

## Fix

- Cache read/write/dismiss and the prompt predicate move into `src/lib/self-update.ts` (the module from #263): `readUpdateCache` / `saveUpdateCheck` / `dismissUpdateVersion` / `shouldPromptUpgrade`, all taking the cache path explicitly.
- `saveUpdateCheck` now preserves an existing `dismissed` marker.
- The live-resolved version is written back to the cache at resolve time in the "Upgrade now" flow, so subsequent prompts and the install agree.

## Tests

- 5 new cases in `src/lib/self-update.test.ts` against real files: the background-refresh-erases-dismiss regression, dismissed survives `saveUpdateCheck`, a newer latest resumes prompting, corrupt/missing cache, prompt-predicate bounds.
- Real-CLI smoke test: built `dist/index.js` with a seeded cache in a temp `$HOME` — non-TTY hint prints without `dismissed` (`Update available: 1.20.8 -> 9.9.9`) and is silent with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)