### PR TITLE
feat: tolerate single-typo agent names everywhere an agent arg is parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+**Single-typo agent names auto-correct everywhere, not just `agents run`**
+
+- `agents view cladue` used to print `Unknown agent 'cladue'` even though `agents run cladue` auto-corrected. `resolveAgentName` — the canonical resolver behind `view`, `usage`, `inspect`, `doctor`, `sync`, `models`, `skills`, `hooks`, `import`, `sessions --agent`, and every `agent@version` spec (`agents add claud@latest`, `agents use codx@2.1.170`) — now falls back to Damerau-Levenshtein distance-1 matching against canonical ids and multi-letter aliases: `cladue` -> `claude` (transposition), `kim` -> `kimi`, `codx` -> `codex`, `gemni` -> `gemini`.
+- Corrections apply only when unambiguous: every distance-1 candidate must agree on one agent. `kiri` (one edit from both `kiro` and `kimi`) and inputs under 3 characters still error. `agents run` keeps its existing exact -> profile -> workflow -> fuzzy precedence, so a profile named `claud` still beats the typo correction.
+- Fixes `kimi` being listed as a valid agent but missing from the alias map — `agents view kimi` previously errored. Added `kimi` / `kimi-code` entries.
+
 ## 1.20.7
 
 **`agents inspect` — DotAgents repo targets (#256)**

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ agents run codex "Fix the issues Claude found"
 agents run gemini "Write tests for the fixed code"
 ```
 
-Each resolves to the project-pinned version with skills, MCP servers, and permissions already synced.
+Each resolves to the project-pinned version with skills, MCP servers, and permissions already synced. Single-typo names auto-correct across every command — `agents view cladue` resolves to `claude`, `agents add codx@latest` to `codex`.
 
 ### Rate-limited? Keep working.
 

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -29,9 +29,8 @@ import * as os from 'os';
 import * as path from 'path';
 import { confirm } from '@inquirer/prompts';
 
-import type { AgentId } from '../lib/types.js';
 import { ALL_AGENT_IDS } from '../lib/agents.js';
-import { AGENTS, getCliPath, getCliVersion, agentLabel } from '../lib/agents.js';
+import { AGENTS, getCliPath, getCliVersion, agentLabel, resolveAgentName } from '../lib/agents.js';
 import { getVersionDir } from '../lib/versions.js';
 import {
   finalizeImport,
@@ -49,17 +48,13 @@ interface ImportOptions {
   yes?: boolean;
 }
 
-function isValidAgentId(value: string): value is AgentId {
-  return (ALL_AGENT_IDS as string[]).includes(value);
-}
-
 async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
-  if (!isValidAgentId(agentArg)) {
+  const agentId = resolveAgentName(agentArg);
+  if (!agentId) {
     console.error(chalk.red(`Unknown agent: ${agentArg}`));
     console.error(chalk.gray(`Known agents: ${ALL_AGENT_IDS.join(', ')}`));
     process.exit(1);
   }
-  const agentId = agentArg;
   const agent = AGENTS[agentId];
 
   // installScript-based agents (Grok, Antigravity, Cursor, Kiro, Goose, Roo)

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -20,7 +20,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import * as yaml from 'yaml';
 import type { AgentId, CapabilityName } from '../lib/types.js';
-import { AGENTS, getCliState } from '../lib/agents.js';
+import { AGENTS, getCliState, resolveAgentName } from '../lib/agents.js';
 import { supports } from '../lib/capabilities.js';
 import {
   readMeta,
@@ -113,12 +113,16 @@ export async function inspectAction(target: string, options: InspectOptions): Pr
       await inspectRepo(repo, options);
       return;
     }
-    const extras = getEnabledExtraRepos();
-    console.error(chalk.red(`Unknown target: ${target}`));
-    console.error(chalk.gray(`Agents: ${Object.keys(AGENTS).join(', ')}`));
-    const aliases = extras.length > 0 ? `, ${extras.map(e => e.alias).join(', ')}` : '';
-    console.error(chalk.gray(`Repos:  user, system, project${aliases} — or a path to a repo with a .agents/ dir`));
-    process.exit(1);
+    // Repo targets take precedence over typo correction; only fall through to
+    // parseTarget when the key resolves to an agent (alias or single-edit fix).
+    if (!resolveAgentName(agentKey)) {
+      const extras = getEnabledExtraRepos();
+      console.error(chalk.red(`Unknown target: ${target}`));
+      console.error(chalk.gray(`Agents: ${Object.keys(AGENTS).join(', ')}`));
+      const aliases = extras.length > 0 ? `, ${extras.map(e => e.alias).join(', ')}` : '';
+      console.error(chalk.gray(`Repos:  user, system, project${aliases} — or a path to a repo with a .agents/ dir`));
+      process.exit(1);
+    }
   }
 
   const { agent, version } = parseTarget(target);
@@ -148,7 +152,12 @@ export async function inspectAction(target: string, options: InspectOptions): Pr
 
 function parseTarget(target: string): { agent: AgentId; version: string } {
   const [rawAgent, rawVersion] = target.split('@');
-  const agent = (rawAgent || '').toLowerCase() as AgentId;
+  const agent = resolveAgentName(rawAgent || '');
+  if (!agent) {
+    console.error(chalk.red(`Unknown agent: ${rawAgent}`));
+    console.error(chalk.gray(`Known agents: ${Object.keys(AGENTS).join(', ')}`));
+    process.exit(1);
+  }
 
   let version = rawVersion;
   if (!version || version === 'default') {

--- a/src/commands/refresh-rules.ts
+++ b/src/commands/refresh-rules.ts
@@ -8,7 +8,7 @@
 
 import { Command } from 'commander';
 import chalk from 'chalk';
-import { AGENTS } from '../lib/agents.js';
+import { AGENTS, resolveAgentName } from '../lib/agents.js';
 import { isVersionInstalled } from '../lib/versions.js';
 import { ensureRulesFresh, supportsRulesImports } from '../lib/rules/compile.js';
 
@@ -26,12 +26,12 @@ export function registerRefreshRulesCommand(program: Command): void {
     .requiredOption('--agent-version <version>', 'Installed version whose rules file should be refreshed')
     .option('--quiet', 'Suppress all output (exit code indicates success)', false)
     .action((opts) => {
-      const agentId = opts.agent as keyof typeof AGENTS;
+      const agentId = resolveAgentName(opts.agent as string);
       const version = opts.agentVersion as string;
       const quiet = !!opts.quiet;
 
-      if (!AGENTS[agentId]) {
-        if (!quiet) console.error(chalk.red(`Unknown agent '${agentId}'`));
+      if (!agentId) {
+        if (!quiet) console.error(chalk.red(`Unknown agent '${opts.agent}'`));
         process.exitCode = 1;
         return;
       }

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -26,6 +26,7 @@ import { parseSession } from '../lib/session/parse.js';
 import { renderConversationMarkdown, renderSummary, renderSummaryHeader, computeSummaryStats, renderJson, filterEvents, parseRoleList, type FilterOptions } from '../lib/session/render.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { colorAgent, resolveAgentName } from '../lib/agents.js';
+import { fuzzyMatch, FUZZY_PRESETS } from '../lib/fuzzy.js';
 import { resolveVersionAliasLoose } from '../lib/versions.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
 import { sessionPicker, type PickedSession } from './sessions-picker.js';
@@ -973,8 +974,21 @@ interface AgentFilter {
 function parseAgentFilter(agentName?: string): AgentFilter {
   if (!agentName) return {};
   const [name, version] = agentName.split('@', 2);
-  const agent = name as SessionAgentId;
-  if (!SESSION_AGENTS.includes(agent)) {
+  let agent: SessionAgentId | null = SESSION_AGENTS.includes(name as SessionAgentId)
+    ? (name as SessionAgentId)
+    : null;
+  if (!agent) {
+    // Aliases and single-typo corrections (cladue -> claude). SESSION_AGENTS
+    // includes ids (rush, hermes) that resolveAgentName doesn't know, so fall
+    // back to fuzzy-matching the session list directly.
+    const resolved = resolveAgentName(name);
+    if (resolved && SESSION_AGENTS.includes(resolved as SessionAgentId)) {
+      agent = resolved as SessionAgentId;
+    } else {
+      agent = fuzzyMatch(name, SESSION_AGENTS, FUZZY_PRESETS.agents);
+    }
+  }
+  if (!agent) {
     console.error(chalk.red(`Unknown agent: ${name}. Use: ${SESSION_AGENTS.join(', ')}`));
     process.exit(1);
   }

--- a/src/commands/usage.ts
+++ b/src/commands/usage.ts
@@ -15,6 +15,8 @@ import {
   AGENTS,
   getAccountInfo,
   agentLabel,
+  resolveAgentName,
+  formatAgentError,
 } from '../lib/agents.js';
 import type { AgentId } from '../lib/types.js';
 import { listInstalledVersions, getGlobalDefault, getVersionHomePath } from '../lib/versions.js';
@@ -34,9 +36,17 @@ Examples:
   agents usage codex        Show usage for Codex only
 `)
     .action(async (agentFilter?: string) => {
-      const filter = agentFilter as AgentId | undefined;
+      let filter: AgentId | undefined;
+      if (agentFilter) {
+        const resolved = resolveAgentName(agentFilter);
+        if (!resolved) {
+          console.error(chalk.red(formatAgentError(agentFilter)));
+          process.exit(1);
+        }
+        filter = resolved;
+      }
       const targets = filter
-        ? [filter].filter((id) => ALL_AGENT_IDS.includes(id))
+        ? [filter]
         : ALL_AGENT_IDS.filter((id) => listInstalledVersions(id).length > 0);
 
       if (targets.length === 0) {

--- a/src/lib/agents.test.ts
+++ b/src/lib/agents.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { pathToFileURL } from 'url';
 import { spawnSync } from 'child_process';
 import { afterEach, describe, expect, it } from 'vitest';
-import { AGENTS, resolveLastActive } from './agents.js';
+import { AGENTS, ALL_AGENT_IDS, resolveAgentName, resolveLastActive } from './agents.js';
 import type { CapabilityName } from './types.js';
 
 const tempDirs: string[] = [];
@@ -285,5 +285,47 @@ describe('resolveLastActive cache pruning', () => {
 
     const cache = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
     expect(Object.keys(cache).sort()).toEqual([`claude:${home}`, 'claude:/gone/fresh-home'].sort());
+  });
+});
+
+describe('resolveAgentName', () => {
+  it('resolves every canonical id, including ones missing from the alias map', () => {
+    for (const id of ALL_AGENT_IDS) {
+      expect(resolveAgentName(id), `canonical id ${id}`).toBe(id);
+    }
+  });
+
+  it('resolves aliases and shorthands case-insensitively', () => {
+    expect(resolveAgentName('claude-code')).toBe('claude');
+    expect(resolveAgentName('cc')).toBe('claude');
+    expect(resolveAgentName('CLAUDE')).toBe('claude');
+    expect(resolveAgentName('kimi-code')).toBe('kimi');
+  });
+
+  it('corrects a single typo against canonical ids', () => {
+    expect(resolveAgentName('cladue')).toBe('claude'); // transposition
+    expect(resolveAgentName('claud')).toBe('claude'); // deletion
+    expect(resolveAgentName('clude')).toBe('claude'); // deletion
+    expect(resolveAgentName('codx')).toBe('codex');
+    expect(resolveAgentName('kim')).toBe('kimi');
+    expect(resolveAgentName('gemni')).toBe('gemini');
+    expect(resolveAgentName('grook')).toBe('grok');
+  });
+
+  it('corrects a single typo against multi-letter aliases', () => {
+    expect(resolveAgentName('clw')).toBe('openclaw'); // claw minus a letter
+    expect(resolveAgentName('roocod')).toBe('roo'); // roocode minus a letter
+  });
+
+  it('returns null when the correction is ambiguous', () => {
+    // 'kiri' is one edit from both kiro and kimi
+    expect(resolveAgentName('kiri')).toBeNull();
+  });
+
+  it('returns null for short or unrecognizable input', () => {
+    expect(resolveAgentName('cl')).toBeNull();
+    expect(resolveAgentName('gpt')).toBeNull();
+    expect(resolveAgentName('')).toBeNull();
+    expect(resolveAgentName('definitely-not-an-agent')).toBeNull();
   });
 });

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -17,6 +17,7 @@ import * as TOML from 'smol-toml';
 import chalk from 'chalk';
 import type { AgentConfig, AgentId } from './types.js';
 import { latestFileMtimeMs } from './fs-walk.js';
+import { damerauLevenshtein } from './fuzzy.js';
 import { getCacheDir, getVersionsDir, getShimsDir, getCliVersionCachePath } from './state.js';
 import { resolveVersion, getVersionHomePath, getBinaryPath } from './versions.js';
 
@@ -1744,11 +1745,30 @@ export const AGENT_NAME_ALIASES: Record<string, AgentId> = {
   'grok-build': 'grok',
   'xai-grok': 'grok',
   gk: 'grok',
+  kimi: 'kimi',
+  'kimi-code': 'kimi',
 };
 
-/** Resolve a user-provided agent name (alias, shorthand, or canonical) to its AgentId. */
+/**
+ * Resolve a user-provided agent name (alias, shorthand, or canonical) to its AgentId.
+ * Tolerates a single typo (insertion/deletion/substitution/transposition) against
+ * canonical ids and aliases — `cladue` -> claude, `kim` -> kimi, `codx` -> codex —
+ * but only when the correction is unambiguous (all distance-1 candidates agree on
+ * one agent). Two-letter shorthands are excluded as fuzzy candidates.
+ */
 export function resolveAgentName(input: string): AgentId | null {
-  return AGENT_NAME_ALIASES[input.toLowerCase()] || null;
+  const lower = input.toLowerCase();
+  const exact = AGENT_NAME_ALIASES[lower] ?? (AGENTS[lower as AgentId] ? (lower as AgentId) : null);
+  if (exact || lower.length < 3) return exact;
+
+  const hits = new Set<AgentId>();
+  for (const id of ALL_AGENT_IDS) {
+    if (damerauLevenshtein(lower, id) === 1) hits.add(id);
+  }
+  for (const [key, id] of Object.entries(AGENT_NAME_ALIASES)) {
+    if (key.length >= 3 && damerauLevenshtein(lower, key) === 1) hits.add(id);
+  }
+  return hits.size === 1 ? hits.values().next().value! : null;
 }
 
 /** Check whether the input string matches any known agent name or alias. */

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -851,10 +851,10 @@ export function parseAgentSpec(spec: string): AgentSpec | null {
   if (parts.length > 2) {
     return null;
   }
-  const agentName = parts[0].toLowerCase();
   const version = parts[1] || 'latest';
 
-  if (!AGENTS[agentName as AgentId]) {
+  const agent = resolveAgentName(parts[0]);
+  if (!agent) {
     return null;
   }
 
@@ -865,7 +865,7 @@ export function parseAgentSpec(spec: string): AgentSpec | null {
   }
 
   return {
-    agent: agentName as AgentId,
+    agent,
     version,
   };
 }


### PR DESCRIPTION
## Problem

`ag view cladue` errored with `Unknown agent 'cladue'` even though `agents run cladue` has auto-corrected since #176. Every other command (`view`, `usage`, `inspect`, `doctor`, `import`, `sessions --agent`, and all `agent@version` specs like `agents add claud@latest`) rejected single-typo names.

## Change

- **`resolveAgentName` (src/lib/agents.ts)** — the canonical resolver now falls back to Damerau-Levenshtein distance-1 matching (transpositions count as one edit, so `cladue` -> `claude`) against canonical ids and multi-letter aliases. Corrections apply only when every distance-1 candidate agrees on one agent: `kiri` (one edit from both `kiro` and `kimi`) and inputs under 3 chars still error.
- **`parseAgentSpec` (src/lib/versions.ts)** routes through the resolver, so `claud@latest` / `codx@2.1.170` / alias`@version` work in `add`, `use`, `doctor`, `sync`, `versions`.
- **Bypass sites rerouted**: `import`, `inspect` (repo targets keep precedence; typo correction is the last resort), `refresh-rules`, `usage`, `sessions --agent` (also fuzzy-matches session-only ids `rush`/`hermes`).
- **`exec`/`run` untouched** — already fuzzy; keeps its exact -> profile -> workflow -> fuzzy precedence so a profile named `claud` beats correction.

## Bonus fixes

- `kimi` was listed in the Valid agents error but missing from `AGENT_NAME_ALIASES` — `agents view kimi` errored. Added `kimi`/`kimi-code`.
- `inspect`'s `parseTarget` blind-cast unknown names, surfacing a misleading `No default version set for <garbage>` — restored validation.

## Testing

- New `resolveAgentName` suite in `src/lib/agents.test.ts`: every canonical id, aliases, all four edit kinds, ambiguity, short/garbage inputs.
- `vitest run` on agents/fuzzy/versions/inspect test files: 126 + 6 passed.
- E2E against the built CLI: `view cladue` -> claude listing, `inspect cladue` -> claude detail, `inspect user` -> repo target unaffected, `doctor claud@2.1.170` -> resolves, `sessions --agent cladue` -> claude sessions, `view kiri`/`inspect zzz` -> proper errors.

Supersedes the unmerged `docs/fuzzy-agent-match-note` branch (its run-only CHANGELOG note is folded into the broader entry here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)