### PR TITLE
feat(windows): path/exec portability — homeDir, Windows local-source paths, notepad editor (#236)

### DIFF
--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -9,6 +9,7 @@
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import * as fs from 'fs';
+import { homeDir } from '../lib/platform/index.js';
 import {
   AGENTS,
   ALL_AGENT_IDS,
@@ -193,5 +194,5 @@ function printCatalog(agent: AgentId, version: string, isDefault: boolean, optio
 
 /** Abbreviate a path by replacing the home directory with ~. */
 function shortPath(p: string): string {
-  return p.replace(process.env.HOME || '~', '~');
+  return p.replace(homeDir(), '~');
 }

--- a/src/commands/plugins.ts
+++ b/src/commands/plugins.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { Command } from 'commander';
 import chalk from 'chalk';
+import { homeDir } from '../lib/platform/index.js';
 import { input } from '@inquirer/prompts';
 
 import { agentLabel } from '../lib/agents.js';
@@ -60,7 +61,7 @@ import { discoverMarketplaces } from '../lib/plugin-marketplace.js';
 
 /** Replace the home directory prefix with ~ for display. */
 function formatPath(p: string): string {
-  const home = process.env.HOME || '';
+  const home = homeDir();
   if (home && p.startsWith(home)) {
     return '~' + p.slice(home.length);
   }
@@ -429,7 +430,7 @@ Examples:
         });
       }
       const name = nameArg;
-      const pluginsDir = path.join(process.env.HOME || '', '.agents', 'plugins');
+      const pluginsDir = path.join(homeDir(), '.agents', 'plugins');
       const pluginRoot = safeJoin(pluginsDir, name);
 
       // Use discovered plugin when present; fall back to name+root if source is already gone

--- a/src/commands/routines.ts
+++ b/src/commands/routines.ts
@@ -37,6 +37,7 @@ import {
 } from '../lib/routines.js';
 import type { JobConfig } from '../lib/routines.js';
 import { getRoutinesDir } from '../lib/state.js';
+import { IS_WINDOWS } from '../lib/platform/index.js';
 import { safeJoin } from '../lib/paths.js';
 import { executeJob, executeJobDetached } from '../lib/runner.js';
 import { JobScheduler } from '../lib/scheduler.js';
@@ -462,7 +463,7 @@ export function registerRoutinesCommands(program: Command): void {
       }
 
       const targetPath = jobPath || path.join(getRoutinesDir(), `${name}.yml`);
-      const editor = process.env.EDITOR || process.env.VISUAL || 'vi';
+      const editor = process.env.EDITOR || process.env.VISUAL || (IS_WINDOWS ? 'notepad' : 'vi');
       const editorParts = editor.split(/\s+/).filter(Boolean);
       const editorBin = editorParts[0];
       const editorArgs = [...editorParts.slice(1), targetPath];

--- a/src/commands/subagents.ts
+++ b/src/commands/subagents.ts
@@ -14,6 +14,7 @@ import * as path from 'path';
 import { checkbox } from '@inquirer/prompts';
 
 import { AGENTS, agentLabel } from '../lib/agents.js';
+import { homeDir } from '../lib/platform/index.js';
 import { capableAgents } from '../lib/capabilities.js';
 import type { AgentId } from '../lib/types.js';
 import { cloneRepo } from '../lib/git.js';
@@ -55,7 +56,7 @@ import {
 
 /** Replace the home directory prefix with ~ for display. */
 function formatPath(p: string): string {
-  const home = process.env.HOME || '';
+  const home = homeDir();
   if (home && p.startsWith(home)) {
     return '~' + p.slice(home.length);
   }

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -8,6 +8,7 @@
 import simpleGit, { SimpleGit } from 'simple-git';
 import * as fs from 'fs';
 import * as path from 'path';
+import { IS_WINDOWS, isWindowsAbsolutePath } from './platform/index.js';
 import { getPackageLocalPath } from './state.js';
 import { DEFAULT_SYSTEM_REPO, systemRepoSlug } from './types.js';
 
@@ -144,8 +145,12 @@ export function parseSource(source: string): GitSource {
     };
   }
 
-  // Local path (absolute or relative)
-  if (cleanSource.startsWith('/') || cleanSource.startsWith('./') || cleanSource.startsWith('../')) {
+  // Local path (absolute or relative). On Windows also recognize drive-letter
+  // (C:\…) and UNC (\\…) roots, which the POSIX prefixes miss.
+  if (
+    cleanSource.startsWith('/') || cleanSource.startsWith('./') || cleanSource.startsWith('../')
+    || (IS_WINDOWS && isWindowsAbsolutePath(cleanSource))
+  ) {
     if (fs.existsSync(cleanSource)) {
       return {
         type: 'local',

--- a/src/lib/platform/paths.test.ts
+++ b/src/lib/platform/paths.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import * as os from 'os';
-import { looksLikePath, toComparablePath, homeDir } from './paths.js';
+import { looksLikePath, toComparablePath, homeDir, isWindowsAbsolutePath } from './paths.js';
 
 describe('looksLikePath', () => {
   // POSIX markers must classify identically on every platform — this is the
@@ -43,5 +43,18 @@ describe('toComparablePath', () => {
 describe('homeDir', () => {
   it('matches os.homedir()', () => {
     expect(homeDir()).toBe(os.homedir());
+  });
+});
+
+describe('isWindowsAbsolutePath', () => {
+  it('recognizes drive-letter and UNC roots', () => {
+    for (const p of ['C:\\repo', 'c:/repo', 'D:\\a\\b', '\\\\server\\share']) {
+      expect(isWindowsAbsolutePath(p)).toBe(true);
+    }
+  });
+  it('rejects POSIX paths and bare names', () => {
+    for (const p of ['/abs/path', './rel', '~/x', 'owner/repo', 'plugin-name', '']) {
+      expect(isWindowsAbsolutePath(p)).toBe(false);
+    }
   });
 });

--- a/src/lib/platform/paths.ts
+++ b/src/lib/platform/paths.ts
@@ -54,3 +54,13 @@ export function toComparablePath(p: string, platform: NodeJS.Platform = process.
 export function homeDir(): string {
   return os.homedir();
 }
+
+/**
+ * Is this a Windows absolute path — a drive-letter root (`C:\`, `C:/`) or a UNC
+ * share (`\\server\share`)? Used by local-source parsing to recognize a native
+ * Windows path that the POSIX `/`, `./`, `../` prefixes miss. Caller decides
+ * whether to apply it (typically gated on win32).
+ */
+export function isWindowsAbsolutePath(p: string): boolean {
+  return WIN_DRIVE_RE.test(p) || p.startsWith('\\\\');
+}

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -14,6 +14,7 @@ import * as path from 'path';
 import { execFileSync } from 'child_process';
 import type { AgentId, DiscoveredPlugin, PluginManifest, MarketplaceSpec } from './types.js';
 import { getPluginsDir, getTrashPluginsDir, getExtraPluginsDir, getProjectPluginsDir } from './state.js';
+import { IS_WINDOWS, isWindowsAbsolutePath, homeDir } from './platform/index.js';
 import { listInstalledVersions, getVersionHomePath } from './versions.js';
 import { AGENTS, agentConfigDirName } from './agents.js';
 import { capableAgents, isCapable } from './capabilities.js';
@@ -1125,9 +1126,10 @@ export async function installPlugin(spec: string): Promise<{ name: string; root:
   const { name: specName, source } = parseInstallSpec(spec);
 
   // Resolve local path (handle ~)
-  const isLocalPath = source.startsWith('/') || source.startsWith('./') || source.startsWith('../') || source.startsWith('~');
+  const isLocalPath = source.startsWith('/') || source.startsWith('./') || source.startsWith('../') || source.startsWith('~')
+    || (IS_WINDOWS && isWindowsAbsolutePath(source));
   const resolvedSource = isLocalPath
-    ? source.replace(/^~/, process.env.HOME || '~')
+    ? source.replace(/^~/, homeDir())
     : source;
 
   const pluginsDir = getPluginsDir();
@@ -1209,7 +1211,7 @@ export async function updatePlugin(name: string): Promise<{ success: boolean; er
     if (sourceInfo.isGit) {
       execFileSync('git', ['-C', plugin.root, 'pull', '--ff-only'], { stdio: 'pipe' });
     } else {
-      const resolvedSource = sourceInfo.source.replace(/^~/, process.env.HOME || '~');
+      const resolvedSource = sourceInfo.source.replace(/^~/, homeDir());
       if (!fs.existsSync(resolvedSource)) {
         return { success: false, error: `Source path no longer exists: ${resolvedSource}` };
       }


### PR DESCRIPTION
Second slice of #236 (the path/exec concern), on the `platform/` foundation. **POSIX behavior byte-identical; Windows additions gated.**

## Fixes
- **`HOME` → `homeDir()`** — the no-fallback `process.env.HOME || ''` / `|| '~'` reads (HOME is unset on Windows) now resolve via `os.homedir()` through the platform helper: `commands/plugins.ts`, `commands/subagents.ts`, `commands/models.ts`, `lib/plugins.ts`. On POSIX `os.homedir() === process.env.HOME` → identical.
- **Local-source parsing** — new `platform.isWindowsAbsolutePath()` (drive-letter `C:\` / UNC `\\`), used (win32-gated) in `lib/git.ts` `parseSource` and `lib/plugins.ts` local-source detection, so a native Windows path (`agents repo add C:\work\repo`, `agents plugins install C:\…`) isn't misread as a non-local source. POSIX `/`,`./`,`../`,`~` prefixes unchanged.
- **Editor fallback** — `agents routines edit` falls back to `notepad` on Windows instead of `vi` (absent there), still honoring `$EDITOR`/`$VISUAL` first.

## Tests
- `isWindowsAbsolutePath` unit-tested (drive/UNC accepted; POSIX paths + bare names rejected).
- tsc clean; platform + git + plugin tests pass (147 across 12 files). POSIX unchanged.

## Scope / remaining #236
Done: process concern (#266, killTree + daemon) and this path/exec concern. Remaining: `tail -f` log-follow has no Windows equivalent (`daemon.ts`/`routines.ts` `--follow`) — needs a cross-platform follow implementation, deferred to its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)