### PR TITLE
feat(upgrade): warn once when PATH resolves agents-cli to divergent installs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -299,15 +299,58 @@ async function showWhatsNew(fromVersion: string, toVersion: string): Promise<voi
 }
 
 const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
-import { getUpdateCheckPath, getMigratedSentinelPath, getUserAgentsDir } from './lib/state.js';
+import { getUpdateCheckPath, getMigratedSentinelPath, getUserAgentsDir, getRuntimeStateDir } from './lib/state.js';
 import {
   readUpdateCache,
   saveUpdateCheck,
   dismissUpdateVersion,
   shouldPromptUpgrade,
+  findAgentsCliInstalls,
   type UpdateCheckCache,
 } from './lib/self-update.js';
 const UPDATE_CHECK_FILE = getUpdateCheckPath();
+
+/**
+ * Warn once when PATH resolves `agents` to a different agents-cli install
+ * than the copy that is currently running (or to several). Divergent installs
+ * are how self-updates "succeed" without changing the command the user types.
+ * The warning re-fires only when the set of install roots changes; dev builds
+ * (0.0.0-dev) are ignored because side-by-side dev installs are a supported
+ * workflow.
+ */
+function maybeWarnMultiInstall(): void {
+  const sentinel = path.join(getRuntimeStateDir(), 'multi-install-warned');
+  const runningRoot = path.resolve(__dirname, '..');
+  const byRoot = new Map<string, { version: string; note: string }>();
+  byRoot.set(runningRoot, { version: VERSION, note: 'running' });
+  for (const install of findAgentsCliInstalls(process.env.PATH || '')) {
+    if (install.version.startsWith('0.0.0-dev')) continue;
+    if (!byRoot.has(install.packageRoot)) {
+      byRoot.set(install.packageRoot, { version: install.version, note: `agents on PATH: ${install.binPath}` });
+    }
+  }
+
+  if (byRoot.size < 2) {
+    try { fs.unlinkSync(sentinel); } catch { /* nothing recorded */ }
+    return;
+  }
+
+  const key = [...byRoot.keys()].sort().join('\n');
+  try {
+    if (fs.readFileSync(sentinel, 'utf-8') === key) return;
+  } catch { /* not warned for this set yet */ }
+
+  console.error(chalk.yellow('Multiple agents-cli installs detected:'));
+  for (const [root, info] of byRoot) {
+    console.error(chalk.gray(`  ${root}  ${info.version}  (${info.note})`));
+  }
+  console.error(chalk.gray('Upgrades apply to the running copy. Remove a stale copy with: npm uninstall -g --prefix <prefix> @phnx-labs/agents-cli'));
+
+  try {
+    fs.mkdirSync(path.dirname(sentinel), { recursive: true });
+    fs.writeFileSync(sentinel, key);
+  } catch { /* best-effort; worst case the warning repeats */ }
+}
 
 /** Determine whether enough time has elapsed since the last registry fetch. */
 function shouldFetchLatest(cache: UpdateCheckCache | null): boolean {
@@ -441,6 +484,8 @@ function refreshUpdateCacheInBackground(): void {
 /** Check for available updates using the local cache. Triggers a background refresh if stale. */
 async function checkForUpdates(): Promise<void> {
   if (process.env.AGENTS_CLI_DISABLE_AUTO_UPDATE) return;
+
+  maybeWarnMultiInstall();
 
   const cache = readUpdateCache(UPDATE_CHECK_FILE);
 

--- a/src/lib/self-update.test.ts
+++ b/src/lib/self-update.test.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import {
   deriveGlobalPrefix,
   dismissUpdateVersion,
+  findAgentsCliInstalls,
   installPackageIntoPrefix,
   readInstalledVersion,
   readUpdateCache,
@@ -168,5 +169,68 @@ describe('update-check cache', () => {
     expect(shouldPromptUpgrade(cache, '1.21.0')).toBe(false);
     expect(shouldPromptUpgrade(null, '1.20.4')).toBe(false);
     expect(shouldPromptUpgrade(cache, '1.20.4')).toBe(true);
+  });
+});
+
+describe('findAgentsCliInstalls', () => {
+  /** Lay out an npm-global-shaped install and a bin dir whose `agents` symlinks into it. */
+  function makeInstall(base: string, name: string, version: string, pkgName = '@phnx-labs/agents-cli') {
+    const packageRoot = path.join(base, name, 'lib', 'node_modules', ...pkgName.split('/'));
+    fs.mkdirSync(path.join(packageRoot, 'dist'), { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, 'package.json'), JSON.stringify({ name: pkgName, version }));
+    fs.writeFileSync(path.join(packageRoot, 'dist', 'index.js'), '// entrypoint\n');
+    const binDir = path.join(base, name, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.symlinkSync(path.join(packageRoot, 'dist', 'index.js'), path.join(binDir, 'agents'));
+    // realpath the root: on macOS the tmpdir lives under /var -> /private/var,
+    // and the scanner reports canonicalized paths.
+    return { packageRoot: fs.realpathSync(packageRoot), binDir };
+  }
+
+  it('resolves each PATH entry to its package root, deduplicating repeats', () => {
+    const base = makeTempDir('installs');
+    const a = makeInstall(base, 'prefix-a', '1.20.4');
+    const b = makeInstall(base, 'prefix-b', '1.20.7');
+    const pathEnv = [a.binDir, b.binDir, a.binDir].join(path.delimiter);
+
+    const installs = findAgentsCliInstalls(pathEnv);
+
+    expect(installs).toHaveLength(2);
+    expect(installs.map((i) => i.packageRoot).sort()).toEqual([a.packageRoot, b.packageRoot].sort());
+    expect(installs.find((i) => i.packageRoot === a.packageRoot)?.version).toBe('1.20.4');
+    expect(installs.find((i) => i.packageRoot === b.packageRoot)?.version).toBe('1.20.7');
+  });
+
+  it('follows symlink chains like the dev install (~/.local/bin/agents -> prefix bin -> dist)', () => {
+    const base = makeTempDir('chain');
+    const real = makeInstall(base, 'dev-prefix', '0.0.0-dev.abc123');
+    const localBin = path.join(base, 'local-bin');
+    fs.mkdirSync(localBin, { recursive: true });
+    fs.symlinkSync(path.join(real.binDir, 'agents'), path.join(localBin, 'agents'));
+
+    const installs = findAgentsCliInstalls(localBin);
+
+    expect(installs).toHaveLength(1);
+    expect(installs[0].packageRoot).toBe(real.packageRoot);
+    expect(installs[0].version).toBe('0.0.0-dev.abc123');
+  });
+
+  it('skips unrelated binaries, foreign packages, and missing entries', () => {
+    const base = makeTempDir('noise');
+    // A plain executable named `agents` that is some other tool entirely.
+    const plainBin = path.join(base, 'plain-bin');
+    fs.mkdirSync(plainBin, { recursive: true });
+    fs.writeFileSync(path.join(plainBin, 'agents'), '#!/bin/sh\necho other tool\n', { mode: 0o755 });
+    // A dist/index.js layout that belongs to a different npm package.
+    const foreign = makeInstall(base, 'foreign', '3.0.0', '@other/agents-tool');
+    // A dangling symlink and a dir with no `agents` at all.
+    const dangling = path.join(base, 'dangling-bin');
+    fs.mkdirSync(dangling, { recursive: true });
+    fs.symlinkSync(path.join(base, 'nowhere', 'dist', 'index.js'), path.join(dangling, 'agents'));
+    const empty = path.join(base, 'empty-bin');
+    fs.mkdirSync(empty, { recursive: true });
+
+    const pathEnv = [plainBin, foreign.binDir, dangling, empty].join(path.delimiter);
+    expect(findAgentsCliInstalls(pathEnv)).toEqual([]);
   });
 });

--- a/src/lib/self-update.ts
+++ b/src/lib/self-update.ts
@@ -153,3 +153,53 @@ export function refreshAliasShims(packageRoot: string): void {
     stdio: 'ignore',
   });
 }
+
+export interface AgentsCliInstall {
+  /** The PATH entry (`<dir>/agents`) that resolves to this install. */
+  binPath: string;
+  /** Package root containing package.json and dist/. */
+  packageRoot: string;
+  version: string;
+}
+
+/**
+ * Scan PATH for `agents` entrypoints and resolve each to the agents-cli
+ * package root it executes. More than one distinct root means upgrades,
+ * shims, and the command the user types can act on different copies — the
+ * divergence behind silently-failing self-updates.
+ *
+ * npm bin entries are symlinks that resolve to `<packageRoot>/dist/index.js`
+ * (the dev install's `~/.local/bin/agents` chains through the dev prefix to
+ * the same shape). Anything that doesn't resolve to a dist/index.js inside a
+ * package named @phnx-labs/agents-cli is some other tool and is skipped.
+ * POSIX-only: Windows npm bins are .cmd wrappers, not symlinks.
+ */
+export function findAgentsCliInstalls(pathEnv: string): AgentsCliInstall[] {
+  if (process.platform === 'win32') return [];
+  const installs: AgentsCliInstall[] = [];
+  const seenRoots = new Set<string>();
+  for (const dir of pathEnv.split(path.delimiter).filter(Boolean)) {
+    const candidate = path.join(dir, 'agents');
+    let real: string;
+    try {
+      real = fs.realpathSync(candidate);
+    } catch {
+      continue; // missing or dangling symlink
+    }
+    if (path.basename(real) !== 'index.js' || path.basename(path.dirname(real)) !== 'dist') {
+      continue;
+    }
+    const packageRoot = path.dirname(path.dirname(real));
+    if (seenRoots.has(packageRoot)) continue;
+    let pkg: { name?: unknown; version?: unknown };
+    try {
+      pkg = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf-8'));
+    } catch {
+      continue;
+    }
+    if (pkg.name !== NPM_PACKAGE_NAME || typeof pkg.version !== 'string') continue;
+    seenRoots.add(packageRoot);
+    installs.push({ binPath: candidate, packageRoot, version: pkg.version });
+  }
+  return installs;
+}


### PR DESCRIPTION
Third piece of the divergent-install work (#263 pinned upgrades to the running prefix, #267 fixed the update-check cache). This one makes the divergence *visible*.

## Problem

Machines with several node installations accumulate multiple agents-cli copies whose prefixes diverge: the command the user types, the alias shims, and npm upgrades can each act on a different copy — and nothing ever said so. The incident machine had three (nvm shim target at 1.20.4, an orphaned 1.20.7 in a vendored node's prefix, a dev build).

## Change

- `findAgentsCliInstalls(pathEnv)` in `src/lib/self-update.ts`: scans PATH for `agents` entrypoints, resolves symlink chains to `<root>/dist/index.js`, confirms the package is `@phnx-labs/agents-cli`, dedupes by package root. POSIX-only (Windows npm bins are .cmd wrappers).
- `maybeWarnMultiInstall()` at startup (same gate as the update check): when more than one distinct root exists, print a one-time stderr warning listing each root, its version, and how it's reached, plus the removal command. Dev builds (`0.0.0-dev`) are excluded — side-by-side dev installs are a supported workflow per CLAUDE.md.
- Warn-once semantics via a sentinel at `~/.agents/.cache/state/multi-install-warned` holding the sorted root set: re-fires only when the set changes, clears when divergence resolves.

## Tests

- 3 new cases in `src/lib/self-update.test.ts` with real symlink fixtures: npm-global layouts dedupe correctly; dev-install-style symlink chains resolve; plain binaries named `agents`, foreign packages, dangling symlinks, and empty dirs are all skipped.

## End-to-end verification

Built CLI run against two fake installs in a temp PATH and temp $HOME, five runs:
1. Both fakes on PATH → warning lists all three roots (running + 2) with versions.
2. Same PATH → silent (sentinel).
3. One fake removed → set changed, warning re-fires with the new set.
4. No fakes → silent, sentinel cleared.
5. Both fakes back → warning re-fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)