### PR TITLE
feat(windows): cross-platform log --follow, replacing spawned tail -f (#236)

### DIFF
--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -7,7 +7,6 @@
  */
 
 import type { Command } from 'commander';
-import { spawn } from 'child_process';
 import chalk from 'chalk';
 import * as path from 'path';
 
@@ -112,12 +111,12 @@ you never need to start it manually.
       warnDeprecated('logs', 'agents routines scheduler-logs');
       if (options.follow) {
         const { getDaemonDir } = await import('../lib/state.js');
+        const { followFile } = await import('../lib/log-follow.js');
         const logPath = path.join(getDaemonDir(), 'logs.jsonl');
-        const child = spawn('tail', ['-f', logPath], { stdio: ['ignore', 'pipe', 'pipe'] });
-        child.stdout.pipe(process.stdout);
-        child.stderr.pipe(process.stderr);
-        child.on('exit', () => process.exit(0));
-        process.on('SIGINT', () => { child.kill(); process.exit(0); });
+        const recent = readDaemonLog(parseInt(options.lines, 10));
+        if (recent) console.log(recent);
+        const stop = followFile(logPath, (text) => process.stdout.write(text), { fromEnd: true });
+        process.on('SIGINT', () => { stop(); process.exit(0); });
         return;
       }
 

--- a/src/commands/routines.ts
+++ b/src/commands/routines.ts
@@ -789,14 +789,13 @@ export function registerRoutinesCommands(program: Command): void {
     .option('-f, --follow', 'Stream log output in real time (like tail -f)')
     .action(async (options) => {
       if (options.follow) {
-        const { spawn } = await import('child_process');
         const { getDaemonDir } = await import('../lib/state.js');
+        const { followFile } = await import('../lib/log-follow.js');
         const logPath = path.join(getDaemonDir(), 'logs.jsonl');
-        const child = spawn('tail', ['-f', logPath]);
-        child.stdout?.pipe(process.stdout);
-        child.stderr?.pipe(process.stderr);
-        child.on('exit', () => process.exit(0));
-        process.on('SIGINT', () => { child.kill(); process.exit(0); });
+        const recent = readDaemonLog(parseInt(options.lines, 10));
+        if (recent) console.log(recent);
+        const stop = followFile(logPath, (text) => process.stdout.write(text), { fromEnd: true });
+        process.on('SIGINT', () => { stop(); process.exit(0); });
         return;
       }
 

--- a/src/lib/log-follow.test.ts
+++ b/src/lib/log-follow.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { followFile } from './log-follow.js';
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('followFile', () => {
+  it('emits existing content then streams appends', async () => {
+    const f = path.join(os.tmpdir(), `follow-test-${process.pid}-${Date.now()}`);
+    fs.writeFileSync(f, 'line1\n');
+    const chunks: string[] = [];
+    const stop = followFile(f, (t) => chunks.push(t), { intervalMs: 15 });
+    try {
+      await sleep(40);
+      fs.appendFileSync(f, 'line2\n');
+      for (let i = 0; i < 50 && !chunks.join('').includes('line2'); i++) await sleep(15);
+    } finally {
+      stop();
+      fs.rmSync(f, { force: true });
+    }
+    const all = chunks.join('');
+    expect(all).toContain('line1'); // pre-existing content
+    expect(all).toContain('line2'); // appended after follow started
+  });
+
+  it('with fromEnd, skips existing content and only emits new appends', async () => {
+    const f = path.join(os.tmpdir(), `follow-end-${process.pid}-${Date.now()}`);
+    fs.writeFileSync(f, 'OLD\n');
+    const chunks: string[] = [];
+    const stop = followFile(f, (t) => chunks.push(t), { intervalMs: 15, fromEnd: true });
+    try {
+      await sleep(40);
+      fs.appendFileSync(f, 'NEW\n');
+      for (let i = 0; i < 50 && !chunks.join('').includes('NEW'); i++) await sleep(15);
+    } finally {
+      stop();
+      fs.rmSync(f, { force: true });
+    }
+    const all = chunks.join('');
+    expect(all).not.toContain('OLD');
+    expect(all).toContain('NEW');
+  });
+});

--- a/src/lib/log-follow.ts
+++ b/src/lib/log-follow.ts
@@ -1,0 +1,58 @@
+/**
+ * Cross-platform `tail -f`.
+ *
+ * Replaces spawning the POSIX `tail` binary (absent on Windows) with a poll-based
+ * follower that behaves identically on every platform and needs no external
+ * dependency. Reads bytes appended since the last position every `intervalMs`;
+ * resets to 0 if the file shrinks (truncation / log rotation). The active timer
+ * keeps the event loop alive, so callers just register a SIGINT handler that
+ * calls the returned stop().
+ */
+import * as fs from 'fs';
+
+export interface FollowOptions {
+  /** Poll interval in milliseconds (default 500). */
+  intervalMs?: number;
+  /** Start at the current end of file (skip existing content). Default false. */
+  fromEnd?: boolean;
+}
+
+export function followFile(
+  filePath: string,
+  onChunk: (text: string) => void,
+  opts: FollowOptions = {},
+): () => void {
+  const intervalMs = opts.intervalMs ?? 500;
+  let pos = 0;
+
+  if (opts.fromEnd) {
+    try { pos = fs.statSync(filePath).size; } catch { pos = 0; }
+  } else {
+    try {
+      const initial = fs.readFileSync(filePath);
+      if (initial.length > 0) onChunk(initial.toString('utf-8'));
+      pos = initial.length;
+    } catch { /* file may not exist yet — start at 0 and wait for it to appear */ }
+  }
+
+  const poll = () => {
+    let size: number;
+    try { size = fs.statSync(filePath).size; } catch { return; /* gone / not yet created */ }
+    if (size < pos) pos = 0; // truncated or rotated — re-read from the top
+    if (size <= pos) return;
+
+    let fd: number | undefined;
+    try {
+      fd = fs.openSync(filePath, 'r');
+      const buf = Buffer.alloc(size - pos);
+      const bytes = fs.readSync(fd, buf, 0, buf.length, pos);
+      pos += bytes;
+      if (bytes > 0) onChunk(buf.subarray(0, bytes).toString('utf-8'));
+    } catch { /* transient read error — retry next tick */ } finally {
+      if (fd !== undefined) { try { fs.closeSync(fd); } catch { /* noop */ } }
+    }
+  };
+
+  const timer = setInterval(poll, intervalMs);
+  return () => clearInterval(timer);
+}


### PR DESCRIPTION
Final slice of #236. `agents routines scheduler-logs --follow` (and the deprecated `daemon logs -f`) spawned the POSIX **`tail`** binary, which doesn't exist on Windows — so live log-follow was broken there.

## Fix
- **`lib/log-follow.ts` → `followFile(path, onChunk, { fromEnd })`** — a dependency-free, poll-based `tail -f`. Emits existing content (or starts at EOF with `fromEnd`), then streams bytes appended since the last position; resets on shrink (truncation / rotation). The active timer keeps the process alive; callers `stop()` it on SIGINT.
- **`daemon.ts` / `routines.ts`** — print the last N lines via `readDaemonLog`, then stream new appends via `followFile({ fromEnd: true })` instead of `spawn('tail', ['-f', …])`. Dropped the now-unused `child_process` import.

It's **pure Node `fs`** — no platform branch — so the POSIX and Windows paths are literally the same code (no spawned external binary anywhere now, even on POSIX).

## Tests
- `followFile` unit-tested against a real file: emits existing content then a genuinely-appended line; `fromEnd` skips existing content and streams only new appends. Runs on Linux/macOS CI; identical behavior on Windows.
- tsc clean.

## Closes the #236 cluster
- process concern — #266 (`killTree` + Windows-safe daemon stop/reload, also closed #232's stop/kill half)
- path/exec concern — #269 (`homeDir`, Windows local-source paths, `notepad`)
- log-follow — this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)