### PR TITLE
feat(windows): complete browser discovery — %LOCALAPPDATA%, 64-bit Edge, env roots (#235)

### DIFF
--- a/src/lib/browser/chrome.ts
+++ b/src/lib/browser/chrome.ts
@@ -11,6 +11,14 @@ import type { Readable, Writable } from 'stream';
 
 import type { BrowserType } from './types.js';
 
+// Windows install roots. Resolve from the environment (fall back to the usual
+// defaults) so per-user installs under %LOCALAPPDATA% and 64-bit Program Files
+// are found, not just the hardcoded x86 path. Only the `win32` entries below use
+// these; on other platforms they compute unused placeholder strings.
+const WIN_PROGRAMFILES = process.env.ProgramFiles || 'C:\\Program Files';
+const WIN_PROGRAMFILES_X86 = process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)';
+const WIN_LOCALAPPDATA = process.env.LOCALAPPDATA || `${os.homedir()}\\AppData\\Local`;
+
 const BROWSER_PATHS: Record<string, Record<BrowserType, string[]>> = {
   darwin: {
     chrome: [
@@ -33,16 +41,22 @@ const BROWSER_PATHS: Record<string, Record<BrowserType, string[]>> = {
   },
   win32: {
     chrome: [
-      'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
-      'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+      `${WIN_PROGRAMFILES}\\Google\\Chrome\\Application\\chrome.exe`,
+      `${WIN_PROGRAMFILES_X86}\\Google\\Chrome\\Application\\chrome.exe`,
+      `${WIN_LOCALAPPDATA}\\Google\\Chrome\\Application\\chrome.exe`,
     ],
     comet: [],
-    chromium: [],
+    chromium: [
+      `${WIN_LOCALAPPDATA}\\Chromium\\Application\\chrome.exe`,
+    ],
     brave: [
-      'C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe',
+      `${WIN_PROGRAMFILES}\\BraveSoftware\\Brave-Browser\\Application\\brave.exe`,
+      `${WIN_PROGRAMFILES_X86}\\BraveSoftware\\Brave-Browser\\Application\\brave.exe`,
+      `${WIN_LOCALAPPDATA}\\BraveSoftware\\Brave-Browser\\Application\\brave.exe`,
     ],
     edge: [
-      'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
+      `${WIN_PROGRAMFILES}\\Microsoft\\Edge\\Application\\msedge.exe`,
+      `${WIN_PROGRAMFILES_X86}\\Microsoft\\Edge\\Application\\msedge.exe`,
     ],
     custom: [],
   },


### PR DESCRIPTION
First slice of #235 — the safe, additive discovery piece. Windows browser discovery only listed hardcoded `C:\Program Files`/`(x86)` paths, so `agents browser` couldn't find a browser that was actually installed.

## Fix
- **Per-user installs** under `%LOCALAPPDATA%` (Chrome, Brave, Chromium) are now searched.
- **64-bit Edge** path added (was x86-only).
- **Chromium** got Windows paths (had none).
- Program Files roots **read from the environment** (`%ProgramFiles%` / `%ProgramFiles(x86)%` / `%LOCALAPPDATA%`, with fallbacks) instead of hardcoded strings.

Purely additive — existing paths preserved, only more candidates searched; darwin/linux entries untouched. Zero regression risk.

## Verified on real Windows (Parallels)
Edge resolves to `C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe` — which is in the new list — and the env roots (`ProgramFiles`, `LOCALAPPDATA`) expand correctly. tsc clean; browser tests pass (171).

## Remaining #235 (load-bearing, follow-ups)
Flagged deliberately as separate PRs because they touch the browser **daemon** and warrant a real Windows browser in the loop:
- **Named-pipe IPC** — `ipc.ts` uses `process.umask` + a Unix-socket `createServer(socketPath)` (fails on Windows). This is the same fix already proven for pty (#249): `\\.\pipe\` named pipe + guard umask/chmod, plus a Windows-safe daemon-running check in the client (its `fs.existsSync(socket)` gate can't see a named pipe).
- **Port inspection** — `chrome.ts` `allocatePort`/`getPortOccupant` shell out to `lsof`; needs `netstat -ano` / `Get-NetTCPConnection` on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)