### PR TITLE
feat(windows): named-pipe IPC for the browser daemon (#235)

### DIFF
--- a/src/lib/browser/ipc.ts
+++ b/src/lib/browser/ipc.ts
@@ -1,6 +1,7 @@
 import * as net from 'net';
 import * as fs from 'fs';
 import * as path from 'path';
+import { IS_WINDOWS, ipcEndpoint } from '../platform/index.js';
 import { getHelpersDir } from '../state.js';
 import { BrowserService } from './service.js';
 import { startDaemon } from '../daemon.js';
@@ -33,10 +34,39 @@ export function getSocketPath(): string {
   return path.join(getHelpersDir(), 'browser', SOCKET_NAME);
 }
 
+/**
+ * The address the daemon actually listens on / clients connect to: the unix
+ * socket file on POSIX, a `\\.\pipe\` named pipe on Windows. `getSocketPath`
+ * stays the canonical key (and the POSIX socket path); on Windows it's only used
+ * to derive a stable pipe name, never touched on disk.
+ */
+function getIpcEndpoint(): string {
+  return ipcEndpoint(getSocketPath());
+}
+
+/** Can we open a connection to the daemon right now? Used on Windows where a
+ * named pipe can't be probed with fs.existsSync. Resolves false on any error. */
+function probeDaemon(endpoint: string, timeoutMs = 500): Promise<boolean> {
+  return new Promise((resolve) => {
+    const sock = net.createConnection(endpoint);
+    let done = false;
+    const finish = (ok: boolean) => { if (done) return; done = true; sock.destroy(); resolve(ok); };
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    sock.on('connect', () => { clearTimeout(timer); finish(true); });
+    sock.on('error', () => { clearTimeout(timer); finish(false); });
+  });
+}
+
+/** Is the daemon reachable? existsSync probe on POSIX, connect probe on Windows. */
+async function isDaemonReachable(): Promise<boolean> {
+  if (IS_WINDOWS) return probeDaemon(getIpcEndpoint());
+  return fs.existsSync(getSocketPath());
+}
+
 async function waitForSocket(socketPath: string, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (fs.existsSync(socketPath)) return;
+    if (IS_WINDOWS ? await probeDaemon(getIpcEndpoint()) : fs.existsSync(socketPath)) return;
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
   throw new Error('Timeout waiting for browser daemon socket');
@@ -52,12 +82,17 @@ export class BrowserIPCServer {
 
   async start(): Promise<void> {
     const socketPath = getSocketPath();
+    const endpoint = getIpcEndpoint();
     const socketDir = path.dirname(socketPath);
     fs.mkdirSync(socketDir, { recursive: true, mode: 0o700 });
-    fs.chmodSync(socketDir, 0o700);
 
-    if (fs.existsSync(socketPath)) {
-      fs.unlinkSync(socketPath);
+    if (!IS_WINDOWS) {
+      fs.chmodSync(socketDir, 0o700);
+      // Remove a stale unix socket from a prior crash. (Named pipes are not
+      // filesystem objects and vanish with their owning process.)
+      if (fs.existsSync(socketPath)) {
+        fs.unlinkSync(socketPath);
+      }
     }
 
     this.server = net.createServer((socket) => {
@@ -88,6 +123,13 @@ export class BrowserIPCServer {
     });
 
     return new Promise((resolve, reject) => {
+      if (IS_WINDOWS) {
+        // Windows named pipe: no umask/chmod — filesystem perms don't apply and
+        // pipe ACLs default to the creating user.
+        this.server!.listen(endpoint, () => resolve());
+        this.server!.on('error', (err) => reject(err));
+        return;
+      }
       // Lock down the browser socket dir before opening the socket; on macOS
       // the parent dir is the real local-user boundary for AF_UNIX sockets.
       const prevUmask = process.umask(0o077);
@@ -120,9 +162,11 @@ export class BrowserIPCServer {
       this.server = null;
     }
 
-    const socketPath = getSocketPath();
-    if (fs.existsSync(socketPath)) {
-      fs.unlinkSync(socketPath);
+    if (!IS_WINDOWS) {
+      const socketPath = getSocketPath();
+      if (fs.existsSync(socketPath)) {
+        fs.unlinkSync(socketPath);
+      }
     }
 
     await this.service.shutdown();
@@ -524,26 +568,29 @@ async function sendRawIPCRequest(
   opts: IPCRequestOptions = {}
 ): Promise<IPCResponse> {
   const socketPath = getSocketPath();
+  const endpoint = getIpcEndpoint();
   const autoStartDaemon = opts.autoStartDaemon ?? true;
 
-  if (!fs.existsSync(socketPath)) {
+  if (!(await isDaemonReachable())) {
     if (!autoStartDaemon) {
       throw new BrowserDaemonNotRunningError();
     }
-    await fs.promises.mkdir(path.dirname(socketPath), { recursive: true, mode: 0o700 });
-    await fs.promises.chmod(path.dirname(socketPath), 0o700);
+    if (!IS_WINDOWS) {
+      await fs.promises.mkdir(path.dirname(socketPath), { recursive: true, mode: 0o700 });
+      await fs.promises.chmod(path.dirname(socketPath), 0o700);
+    }
     startDaemon();
-    if (!fs.existsSync(socketPath)) {
+    if (!(await isDaemonReachable())) {
       await waitForSocket(socketPath, 6000);
     }
-    if (!fs.existsSync(socketPath)) {
+    if (!(await isDaemonReachable())) {
       throw new Error('Failed to start browser daemon');
     }
     await new Promise((r) => setTimeout(r, 300));
   }
 
   return new Promise((resolve, reject) => {
-    const socket = net.createConnection(socketPath);
+    const socket = net.createConnection(endpoint);
     let buffer = '';
 
     socket.on('connect', () => {

--- a/src/lib/platform/index.ts
+++ b/src/lib/platform/index.ts
@@ -19,3 +19,4 @@ export const IS_LINUX = process.platform === 'linux';
 export * from './paths.js';
 export * from './exec.js';
 export * from './process.js';
+export * from './ipc.js';

--- a/src/lib/platform/ipc.test.ts
+++ b/src/lib/platform/ipc.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { ipcEndpoint } from './ipc.js';
+
+describe('ipcEndpoint', () => {
+  it('returns the socket path unchanged on POSIX', () => {
+    expect(ipcEndpoint('/home/u/.agents/.cache/helpers/browser/browser.sock', 'linux'))
+      .toBe('/home/u/.agents/.cache/helpers/browser/browser.sock');
+    expect(ipcEndpoint('/x/y.sock', 'darwin')).toBe('/x/y.sock');
+  });
+
+  it('returns a \\\\.\\pipe\\ named pipe on win32 — never a filesystem path', () => {
+    const ep = ipcEndpoint('C:\\Users\\u\\.agents\\.cache\\helpers\\browser\\browser.sock', 'win32');
+    expect(ep).toMatch(/^\\\\\.\\pipe\\agents-[0-9a-f]{16}$/);
+    expect(ep.includes('browser.sock')).toBe(false);
+  });
+
+  it('is stable per socket path and unique across paths', () => {
+    const a1 = ipcEndpoint('C:\\a\\browser.sock', 'win32');
+    const a2 = ipcEndpoint('C:\\a\\browser.sock', 'win32');
+    const b = ipcEndpoint('C:\\b\\browser.sock', 'win32');
+    expect(a1).toBe(a2);
+    expect(a1).not.toBe(b);
+  });
+});

--- a/src/lib/platform/ipc.ts
+++ b/src/lib/platform/ipc.ts
@@ -1,0 +1,22 @@
+/**
+ * Local-daemon IPC endpoint, platform-aware.
+ */
+import * as crypto from 'crypto';
+
+/**
+ * Resolve the address a local daemon listens on / clients connect to.
+ *
+ * POSIX: the AF_UNIX socket file path itself.
+ * Windows: a named pipe (`\\.\pipe\agents-<hash>`). Filesystem socket files
+ * aren't supported there, and named pipes are NOT filesystem objects — derive a
+ * stable name from a hash of the socket path so client and server agree without
+ * touching disk, and never probe the result with fs.existsSync (it always reports
+ * false). Both forms are accepted by net.createServer / net.createConnection.
+ */
+export function ipcEndpoint(socketPath: string, platform: NodeJS.Platform = process.platform): string {
+  if (platform === 'win32') {
+    const hash = crypto.createHash('sha1').update(socketPath).digest('hex').slice(0, 16);
+    return `\\\\.\\pipe\\agents-${hash}`;
+  }
+  return socketPath;
+}


### PR DESCRIPTION
The load-bearing #235 piece — the browser daemon's IPC transport. It was Unix-socket only (`process.umask` + `net.createServer(socketPath)` on a filesystem path), so `agents browser` couldn't start on Windows at all. Same fix already proven for pty (#249), generalized into the platform layer.

## Changes
- **`platform/ipc.ts` → `ipcEndpoint(socketPath)`** — the unix socket path on POSIX, a `\\.\pipe\agents-<hash>` named pipe on Windows (hash of the socket path so client + server agree without touching disk). Exported via the barrel.
- **Server (`ipc.ts`)** — on Windows, listen on the named-pipe endpoint and skip the Unix-only hardening (`umask`, `chmod`, stale-socket `unlink`). **POSIX path byte-unchanged.**
- **Client (`ipc.ts`)** — a named pipe isn't a filesystem object, so the `fs.existsSync(socket)` daemon-running gate can't see it. Added `probeDaemon()` (connect probe) + `isDaemonReachable()` — `existsSync` on POSIX (identical), connect-probe on Windows. `waitForSocket`/`stop()` guarded likewise; connect to the endpoint.

## Verified END-TO-END on real Windows (Parallels, win32)
A harness with my **compiled** `ipcEndpoint` →
```
endpoint=\\.\pipe\agents-21c4d8d1c7c791f8
PASS ipcEndpoint is a named pipe
PASS probe before server start -> not reachable
PASS named-pipe server.listen succeeded
PASS probe after start -> reachable
PASS client roundtrip echo
IPC_RESULT: ALL_PASS
```
So the transport **and** the new probe-connect daemon detection work on real Windows. `ipcEndpoint` unit-tested; POSIX browser tests pass (194); tsc clean.

## Remaining #235
`lsof` → `netstat`/`Get-NetTCPConnection` port inspection (`chrome.ts` `allocatePort` / `getPortOccupant`) — a separate, smaller follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)