### PR TITLE
feat(windows): netstat/tasklist port inspection, replacing lsof (#235)

### DIFF
--- a/src/lib/browser/chrome.ts
+++ b/src/lib/browser/chrome.ts
@@ -360,14 +360,41 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Is a TCP port currently bound? `lsof` on POSIX, `netstat -ano` on Windows
+ * (lsof doesn't exist there). Returns false on any tooling error so port
+ * allocation degrades to "assume free" rather than throwing.
+ */
+function isPortInUse(port: number): boolean {
+  if (process.platform === 'win32') {
+    try {
+      const out = execFileSync('netstat', ['-ano', '-p', 'TCP'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      // Lines look like: "  TCP    0.0.0.0:9200    0.0.0.0:0    LISTENING    1234"
+      return out.split('\n').some((line) => {
+        const f = line.trim().split(/\s+/);
+        return f[0] === 'TCP' && f[3] === 'LISTENING' && !!f[1]?.endsWith(`:${port}`);
+      });
+    } catch {
+      return false;
+    }
+  }
+  try {
+    execFileSync('lsof', ['-i', `:${port}`], { stdio: 'ignore' });
+    return true; // lsof found a binding
+  } catch {
+    return false; // nothing on the port
+  }
+}
+
 export function allocatePort(): number {
   const base = 9200;
   const max = 9300;
 
   for (let port = base; port < max; port++) {
-    try {
-      execFileSync('lsof', ['-i', `:${port}`], { stdio: 'ignore' });
-    } catch {
+    if (!isPortInUse(port)) {
       return port;
     }
   }
@@ -381,11 +408,42 @@ export interface PortOccupant {
 }
 
 /**
- * Identify the process listening on a TCP port via lsof. Returns null when nothing is bound.
- * Used for clearer error messages when a profile's configured port is taken by a non-debug
- * process (e.g. Comet running without --remote-debugging-port).
+ * Identify the process listening on a TCP port. Returns null when nothing is bound.
+ * Used for clearer error messages when a profile's configured port is taken by a
+ * non-debug process (e.g. Comet running without --remote-debugging-port).
+ * `lsof` on POSIX; `netstat -ano` + `tasklist` on Windows.
  */
 export function getPortOccupant(port: number): PortOccupant | null {
+  if (process.platform === 'win32') {
+    try {
+      const out = execFileSync('netstat', ['-ano', '-p', 'TCP'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      let pid = 0;
+      for (const line of out.split('\n')) {
+        const f = line.trim().split(/\s+/);
+        if (f[0] === 'TCP' && f[3] === 'LISTENING' && f[1]?.endsWith(`:${port}`)) {
+          pid = parseInt(f[4], 10) || 0;
+          break;
+        }
+      }
+      if (!pid) return null;
+      let command = 'unknown';
+      try {
+        // tasklist CSV row: "image.exe","1234","Console","1","12,345 K"
+        const tl = execFileSync('tasklist', ['/FI', `PID eq ${pid}`, '/FO', 'CSV', '/NH'], {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        });
+        const m = tl.match(/^"([^"]+)"/);
+        if (m) command = m[1];
+      } catch { /* keep 'unknown' */ }
+      return { pid, command };
+    } catch {
+      return null;
+    }
+  }
   try {
     const out = execFileSync('lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-Fpcn'], {
       encoding: 'utf8',

--- a/src/lib/browser/port.test.ts
+++ b/src/lib/browser/port.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import * as net from 'net';
+import { allocatePort, getPortOccupant } from './chrome.js';
+
+describe('port inspection', () => {
+  it('getPortOccupant detects a real listener', async () => {
+    const server = net.createServer();
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', () => r()));
+    const port = (server.address() as net.AddressInfo).port;
+    try {
+      const occ = getPortOccupant(port);
+      expect(occ).not.toBeNull();
+      expect(occ!.pid).toBeGreaterThan(0);
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
+  it('allocatePort returns a free port in [9200, 9300)', () => {
+    const p = allocatePort();
+    expect(p).toBeGreaterThanOrEqual(9200);
+    expect(p).toBeLessThan(9300);
+  });
+});


### PR DESCRIPTION
The **final** #235 piece — Windows port inspection. The browser port helpers shelled out to `lsof`, absent on Windows, so `allocatePort` treated every port as free (always returned 9200) and `getPortOccupant` always returned null (no port-conflict detection).

## Fix
- **`isPortInUse(port)`** — new helper: `lsof -i :port` on POSIX, `netstat -ano` on Windows (parse for a `LISTENING` row on the port). `allocatePort` uses it instead of inlining lsof. POSIX behavior identical (`lsof` throw = free).
- **`getPortOccupant(port)`** — on Windows: `netstat -ano` → listening pid, then `tasklist` → process name. POSIX `lsof -Fpcn` path unchanged.

## Tested
- `getPortOccupant` detects a real bound listener; `allocatePort` returns a free in-range port — Linux/macOS CI (lsof path).
- **Verified end-to-end on real Windows (Parallels):**
  ```
  PASS detects listener via netstat :: {"pid":10864,"command":"node.exe"}
  PASS pid matches this process
  PASS command resolved via tasklist :: node.exe
  PASS unbound port -> null
  ```
- tsc clean.

## Completes the Windows audit
With browser discovery (#272) and named-pipe IPC (#273), the browser subsystem is Windows-portable. All of #231–#237 are now addressed across this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)