### PR TITLE
fix(inspect): resolve project .agents/ for `inspect .` and enrich plugin drill-down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+**`agents inspect .` reads the project `.agents/`, and plugin drill-down shows bundled skills**
+
+- `agents inspect .` (and any path to a repo root) now resolves to the project's nested `.agents/` tree when that tree is a populated DotAgents root, instead of the project root itself. Previously a top-level `agents.yaml` version-pin or an unrelated source `skills/` dir at the repo root was mistaken for a DotAgents root, so `inspect .` reported the wrong directory's resources (e.g. `plugins 0` while the real `.agents/plugins/` held a plugin). A bare `.agents`-named dir still resolves to itself, and standalone clones / extra repos that keep resources at the top level (using `.agents/` only for worktrees) are unaffected — their nested `.agents/` is not a DotAgents root, so the top level still wins.
+- `agents inspect <repo> --plugins` now reads plugin bundles through the plugin discoverer: the list shows each plugin's manifest description, and drilling into one (`--plugins <name>`) reports its bundled skills, commands, subagents, hooks, MCP servers, and version. Previously plugins were treated as opaque directories with no description and no view into what they ship.
+
 **Single-typo agent names auto-correct everywhere, not just `agents run`**
 
 - `agents view cladue` used to print `Unknown agent 'cladue'` even though `agents run cladue` auto-corrected. `resolveAgentName` — the canonical resolver behind `view`, `usage`, `inspect`, `doctor`, `sync`, `models`, `skills`, `hooks`, `import`, `sessions --agent`, and every `agent@version` spec (`agents add claud@latest`, `agents use codx@2.1.170`) — now falls back to Damerau-Levenshtein distance-1 matching against canonical ids and multi-letter aliases: `cladue` -> `claude` (transposition), `kim` -> `kimi`, `codx` -> `codex`, `gemni` -> `gemini`.

--- a/src/commands/__tests__/inspect.test.ts
+++ b/src/commands/__tests__/inspect.test.ts
@@ -72,9 +72,9 @@ function makeFixture(): string {
   return home;
 }
 
-function run(home: string, args: string[]) {
+function run(home: string, args: string[], cwd: string = home) {
   return spawnSync(tsxBin, [cliEntry, ...args], {
-    cwd: home,
+    cwd,
     env: {
       ...process.env,
       HOME: home,
@@ -84,6 +84,43 @@ function run(home: string, args: string[]) {
     },
     encoding: 'utf-8',
   });
+}
+
+/**
+ * Build a project dir (separate from HOME's ~/.agents) whose resources live
+ * under `.agents/`, plus decoy top-level `agents.yaml` + `skills/` that must NOT
+ * be mistaken for the DotAgents tree. The `.agents/` holds a skill, a command,
+ * and a plugin bundling its own skill.
+ */
+function makeProjectRepo(): string {
+  const proj = fs.mkdtempSync(path.join(os.tmpdir(), 'inspect-proj-' + crypto.randomBytes(4).toString('hex') + '-'));
+
+  // Decoys at the project root — a version pin and an unrelated source skills/ dir.
+  writeFile(path.join(proj, 'agents.yaml'), 'agents:\n  claude: 9.9.9\n');
+  writeFile(
+    path.join(proj, 'skills', 'decoy-skill', 'SKILL.md'),
+    '---\nname: decoy-skill\ndescription: Top-level source skill, not a DotAgents resource.\n---\n\nBody.\n'
+  );
+
+  // The real DotAgents tree under .agents/.
+  const dot = path.join(proj, '.agents');
+  writeFile(
+    path.join(dot, 'skills', 'proj-skill', 'SKILL.md'),
+    '---\nname: proj-skill\ndescription: A project-scoped skill.\n---\n\nBody.\n'
+  );
+  writeFile(path.join(dot, 'commands', 'proj-cmd.md'), '---\ndescription: Project command.\n---\n\nDo it.\n');
+
+  const plugin = path.join(dot, 'plugins', 'myplugin');
+  writeFile(
+    path.join(plugin, '.claude-plugin', 'plugin.json'),
+    JSON.stringify({ name: 'myplugin', description: 'A bundled plugin.', version: '0.0.1' })
+  );
+  writeFile(
+    path.join(plugin, 'skills', 'bundled', 'SKILL.md'),
+    '---\nname: bundled\ndescription: Skill shipped inside the plugin.\n---\n\nBody.\n'
+  );
+
+  return proj;
 }
 
 let fixtureHome: string;
@@ -168,5 +205,61 @@ describe('agents inspect', () => {
     const r = run(fixtureHome, ['inspect', 'claude', '--skills', '--commands']);
     expect(r.status).toBe(1);
     expect(r.stderr + r.stdout).toMatch(/at most one drill-down flag/i);
+  });
+});
+
+describe('agents inspect <repo>', () => {
+  let projectRepo: string;
+
+  beforeEach(() => {
+    projectRepo = makeProjectRepo();
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(projectRepo, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('inspect . from a project root reads .agents/, not the top-level source dirs', () => {
+    // cwd is the project root, which has a decoy top-level skills/ + agents.yaml.
+    const r = run(fixtureHome, ['inspect', '.', '--json'], projectRepo);
+    expect(r.status).toBe(0);
+    const data = JSON.parse(r.stdout);
+    // Root must be the nested .agents/, not the project root.
+    expect(data.root).toMatch(/\.agents$/);
+    // .agents/ has exactly one skill (proj-skill) — the decoy top-level skill is excluded.
+    expect(data.resources.skills).toBe(1);
+    expect(data.resources.commands).toBe(1);
+    expect(data.resources.plugins).toBe(1);
+  });
+
+  it('--skills lists the .agents/ skill, not the decoy top-level one', () => {
+    const r = run(fixtureHome, ['inspect', '.', '--skills', '--json'], projectRepo);
+    expect(r.status).toBe(0);
+    const names = (JSON.parse(r.stdout).items as Array<{ name: string }>).map(i => i.name);
+    expect(names).toContain('proj-skill');
+    expect(names).not.toContain('decoy-skill');
+  });
+
+  it('--plugins surfaces the manifest description and bundled skills', () => {
+    const list = run(fixtureHome, ['inspect', '.', '--plugins', '--json'], projectRepo);
+    expect(list.status).toBe(0);
+    const item = (JSON.parse(list.stdout).items as Array<{ name: string; description: string }>)
+      .find(i => i.name === 'myplugin');
+    expect(item?.description).toBe('A bundled plugin.');
+
+    // Drilling into the plugin reports its nested skill.
+    const detail = run(fixtureHome, ['inspect', '.', '--plugins', 'myplugin', '--json'], projectRepo);
+    expect(detail.status).toBe(0);
+    const match = JSON.parse(detail.stdout).match as { name: string; skills?: string };
+    expect(match.name).toBe('myplugin');
+    expect(match.skills).toContain('bundled');
+  });
+
+  it('resolves built-in repo layers (system) and reports resource counts', () => {
+    const r = run(fixtureHome, ['inspect', 'system', '--json']);
+    expect(r.status).toBe(0);
+    const data = JSON.parse(r.stdout);
+    expect(data.repo).toBe('system');
+    expect(data.root).toMatch(/\.system$/);
   });
 });

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -19,7 +19,7 @@ import * as path from 'path';
 import { Command } from 'commander';
 import chalk from 'chalk';
 import * as yaml from 'yaml';
-import type { AgentId, CapabilityName } from '../lib/types.js';
+import type { AgentId, CapabilityName, DiscoveredPlugin } from '../lib/types.js';
 import { AGENTS, getCliState, resolveAgentName } from '../lib/agents.js';
 import { supports } from '../lib/capabilities.js';
 import {
@@ -37,7 +37,7 @@ import {
   type ResourceEntry,
   type SkillResourceEntry,
 } from '../lib/resources.js';
-import { discoverPlugins } from '../lib/plugins.js';
+import { discoverPlugins, discoverPluginsInDir } from '../lib/plugins.js';
 import { countSessionsInScope } from '../lib/session/discover.js';
 import type { SessionAgentId } from '../lib/session/types.js';
 import { damerauLevenshtein } from '../lib/fuzzy.js';
@@ -68,6 +68,8 @@ interface ResourceItem {
   linkTarget: string;
   /** One-line description (frontmatter `description:` or first non-frontmatter line). */
   description: string;
+  /** Extra detail rows surfaced in detail mode (e.g. a plugin's bundled skills/commands). */
+  extra?: Array<[string, string]>;
 }
 
 interface InspectOptions {
@@ -226,18 +228,23 @@ export function resolveRepoTarget(target: string, cwd?: string): RepoTarget | nu
   const stat = safeStat(abs);
   if (!stat || !stat.isDirectory()) return null;
 
-  // A dir that is itself a DotAgents root wins over its nested .agents/ —
-  // extra repos like ~/.agents-extras keep resources at the top level and use
-  // .agents/ only for worktrees.
-  if (isDotAgentsRoot(abs)) {
-    const label = path.basename(abs) === '.agents' ? path.basename(path.dirname(abs)) : path.basename(abs);
-    return { label, root: abs };
+  // A dir literally named `.agents` is the root itself.
+  if (path.basename(abs) === '.agents') {
+    return { label: path.basename(path.dirname(abs)), root: abs };
   }
-  if (path.basename(abs) !== '.agents') {
-    const nested = path.join(abs, '.agents');
-    if (safeStat(nested)?.isDirectory()) {
-      return { label: path.basename(abs), root: nested };
-    }
+  // A nested `.agents/` that is a populated DotAgents root wins over `abs` — the
+  // project case (`agents inspect .` from a repo root whose resources live under
+  // `.agents/`, while the repo's own top-level `skills/`, `agents.yaml` pin, etc.
+  // are unrelated source, not a DotAgents tree).
+  const nested = path.join(abs, '.agents');
+  if (isDotAgentsRoot(nested)) {
+    return { label: path.basename(abs), root: nested };
+  }
+  // Otherwise treat `abs` itself as the root: standalone clones and extra repos
+  // like ~/.agents-extras keep resources at the top level and use `.agents/`
+  // only for worktrees (so their nested `.agents/` is not a DotAgents root).
+  if (isDotAgentsRoot(abs)) {
+    return { label: path.basename(abs), root: abs };
   }
   return null;
 }
@@ -271,6 +278,15 @@ async function inspectRepo(repo: RepoTarget, options: InspectOptions): Promise<v
 
 /** List one resource kind from a single repo root — no layering, no overrides. */
 export function collectRepoKind(repo: RepoTarget, kind: DrillableKind): ResourceItem[] {
+  // Plugins are bundles with a manifest + nested skills/commands/hooks — read
+  // them through the plugin discoverer so the manifest description and bundled
+  // resources surface, rather than treating each as an opaque directory.
+  if (kind === 'plugins') {
+    return discoverPluginsInDir(path.join(repo.root, 'plugins'))
+      .map(p => pluginToItem(p, repo.label))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
   const dir = path.join(repo.root, kind);
   let entries: fs.Dirent[];
   try {
@@ -582,14 +598,31 @@ function collectKind(agent: AgentId, versionHome: string, kind: DrillableKind): 
 }
 
 function pluginItems(): ResourceItem[] {
-  const plugins = discoverPlugins();
-  return plugins.map(p => ({
-    name: p.name,
-    source: 'user',
-    path: p.root,
-    linkTarget: linkTarget(p.root),
-    description: p.manifest.description ?? '',
-  }));
+  return discoverPlugins().map(p => pluginToItem(p, 'user'));
+}
+
+/**
+ * Map a discovered plugin to a resource item, surfacing the manifest description
+ * and the bundle's nested resources (skills, commands, hooks, ...) as detail rows.
+ */
+function pluginToItem(plugin: DiscoveredPlugin, source: string): ResourceItem {
+  const extra: Array<[string, string]> = [];
+  const list = (names: string[]): string =>
+    names.length <= 8 ? names.join(', ') : `${names.slice(0, 8).join(', ')}, +${names.length - 8} more`;
+  if (plugin.skills.length) extra.push(['skills', `${plugin.skills.length}  (${list(plugin.skills)})`]);
+  if (plugin.commands.length) extra.push(['commands', `${plugin.commands.length}  (${list(plugin.commands)})`]);
+  if (plugin.agentDefs.length) extra.push(['subagents', `${plugin.agentDefs.length}  (${list(plugin.agentDefs)})`]);
+  if (plugin.hooks.length) extra.push(['hooks', String(plugin.hooks.length)]);
+  if (plugin.mcpServers.length) extra.push(['mcp', list(plugin.mcpServers)]);
+  if (plugin.manifest.version) extra.push(['version', plugin.manifest.version]);
+  return {
+    name: plugin.name,
+    source,
+    path: plugin.root,
+    linkTarget: linkTarget(plugin.root),
+    description: plugin.manifest.description ?? '',
+    extra,
+  };
 }
 
 function entriesFromAgentResources(agent: AgentId, versionHome: string, kind: 'commands' | 'hooks' | 'workflows'): ResourceItem[] {
@@ -658,6 +691,10 @@ function buildDetailRows(item: ResourceItem, kind: DrillableKind): Array<[string
       if (typeof fm.model === 'string') rows.push(['model', fm.model]);
       if (Array.isArray(fm.tools)) rows.push(['tools', fm.tools.join(', ')]);
     }
+  }
+  // Plugin bundles carry their nested resources as pre-built rows.
+  if (kind === 'plugins' && item.extra) {
+    rows.push(...item.extra);
   }
   return rows;
 }


### PR DESCRIPTION
## What

Two fixes to `agents inspect` repo-target support (the DotAgents-repo feature shipped in 1.20.7, #256):

### 1. `agents inspect .` now reads the project's `.agents/` tree

Previously, `resolveRepoTarget` treated a directory as a DotAgents root if it had a top-level `agents.yaml` (which is also a plain version-pin file) **or** any kind-named dir like `skills/` (common source dir). So running `inspect .` from a project root inspected the project root itself, not its `.agents/`:

```
# before — wrong dir
$ agents inspect .
  skills 7   plugins 0      # read the repo's source skills/, missed .agents/plugins/

# after — correct
$ agents inspect .
  skills 6   plugins 1      # reads <project>/.agents/
```

Resolution now prefers a **populated nested `.agents/`** (the project case). A dir literally named `.agents` still resolves to itself, and standalone clones / extra repos that keep resources at the top level (using `.agents/` only for worktrees) are unaffected — their nested `.agents/` isn't a DotAgents root, so the top level still wins.

### 2. Plugin drill-down shows the bundle's contents

Repo `--plugins` treated each plugin as an opaque directory (no description, no contents). It now reads through the plugin discoverer:

```
$ agents inspect . --plugins agc
  ✓  agc   agents-cli project plugin: skills + commands specific to this repo...
     skills     1  (artist)
     version    0.1.0
```

A shared `pluginToItem` helper backs both the repo and agent inspect paths, so the agent view gains the same enrichment (skills / commands / subagents / hooks / MCP / version).

## Testing

- `src/commands/__tests__/inspect.test.ts`: new `agents inspect <repo>` suite — precedence fix (decoy top-level `skills/` + `agents.yaml` ignored in favor of nested `.agents/`), `--skills` lists the `.agents/` skill not the decoy, `--plugins` surfaces manifest description + bundled skills, and built-in `system` layer resolves.
- Full suite: `inspect.test.ts` 10/10 pass, `plugins.test.ts` 4/4 pass, `tsc --noEmit` clean.
- Real-flow verified against `~/.agents` (by path → self), `~/.agents/.system` (standalone root → self), and a project root (`.` → nested `.agents/`, plugins enriched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)