### PR TITLE
feat(inspect): enrich bare repo summary with names, manifest, git detail, sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+**`agents inspect <repo>` summary now shows what's actually inside, not just counts**
+
+- The bare repo summary gained four enrichments so it reads as an inventory instead of a tally: (1) **resource name previews** — each kind lists its first few names with a `…(+N)` tail; (2) **manifest summary** — `agents.yaml` is parsed for its `run.<agent>.strategy` and any `agents.<agent>` version pins, shown under `manifests` instead of just the filename; (3) **git detail** — last commit (sha, subject, relative time), ahead/behind upstream when non-zero, and the names of dirty files; (4) **size + file counts** — total repo size and a per-kind byte size. `--json` carries all of it (`git.lastCommit`, `git.ahead/behind`, `manifest`, `size`, and per-kind `{count, bytes, files, names}`); `--brief` still skips resources and size.
+- Fixed a path-parse bug surfaced by the dirty-files list: the shared git helper trimmed leading whitespace, which clipped the first character off the first `git status --porcelain` path; status is now read untrimmed.
+
 **`agents inspect .` reads the project `.agents/`, and plugin drill-down shows bundled skills**
 
 - `agents inspect .` (and any path to a repo root) now resolves to the project's nested `.agents/` tree when that tree is a populated DotAgents root, instead of the project root itself. Previously a top-level `agents.yaml` version-pin or an unrelated source `skills/` dir at the repo root was mistaken for a DotAgents root, so `inspect .` reported the wrong directory's resources (e.g. `plugins 0` while the real `.agents/plugins/` held a plugin). A bare `.agents`-named dir still resolves to itself, and standalone clones / extra repos that keep resources at the top level (using `.agents/` only for worktrees) are unaffected — their nested `.agents/` is not a DotAgents root, so the top level still wins.

--- a/src/commands/__tests__/inspect.test.ts
+++ b/src/commands/__tests__/inspect.test.ts
@@ -227,9 +227,9 @@ describe('agents inspect <repo>', () => {
     // Root must be the nested .agents/, not the project root.
     expect(data.root).toMatch(/\.agents$/);
     // .agents/ has exactly one skill (proj-skill) — the decoy top-level skill is excluded.
-    expect(data.resources.skills).toBe(1);
-    expect(data.resources.commands).toBe(1);
-    expect(data.resources.plugins).toBe(1);
+    expect(data.resources.skills.count).toBe(1);
+    expect(data.resources.commands.count).toBe(1);
+    expect(data.resources.plugins.count).toBe(1);
   });
 
   it('--skills lists the .agents/ skill, not the decoy top-level one', () => {

--- a/src/commands/inspect.test.ts
+++ b/src/commands/inspect.test.ts
@@ -1,8 +1,16 @@
+import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { resolveRepoTarget, collectRepoKind } from './inspect.js';
+import {
+  resolveRepoTarget,
+  collectRepoKind,
+  repoManifestSummary,
+  repoGitInfo,
+  pathSize,
+  formatBytes,
+} from './inspect.js';
 import { getUserAgentsDir, getSystemAgentsDir } from '../lib/state.js';
 
 const tempDirs: string[] = [];
@@ -97,5 +105,87 @@ describe('collectRepoKind', () => {
     const root = makeProjectRepo();
     const repo = resolveRepoTarget(root)!;
     expect(collectRepoKind(repo, 'workflows')).toEqual([]);
+  });
+});
+
+describe('repoManifestSummary', () => {
+  it('extracts run strategies and version pins from agents.yaml', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-manifest-'));
+    tempDirs.push(dir);
+    fs.writeFileSync(path.join(dir, 'agents.yaml'),
+      'run:\n  claude:\n    strategy: balanced\n  codex:\n    strategy: pinned\nagents:\n  claude: 2.1.170\n');
+
+    const summary = repoManifestSummary(dir)!;
+    expect(summary.strategies).toEqual([
+      { agent: 'claude', strategy: 'balanced' },
+      { agent: 'codex', strategy: 'pinned' },
+    ]);
+    expect(summary.versions).toEqual([{ agent: 'claude', version: '2.1.170' }]);
+  });
+
+  it('returns null when agents.yaml is absent or has nothing to summarize', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-manifest-empty-'));
+    tempDirs.push(dir);
+    expect(repoManifestSummary(dir)).toBeNull();
+    fs.writeFileSync(path.join(dir, 'agents.yaml'), 'hooks:\n  some-hook:\n    script: x.sh\n');
+    expect(repoManifestSummary(dir)).toBeNull();
+  });
+});
+
+describe('pathSize', () => {
+  it('sums file bytes and counts, recursing dirs and ignoring symlinks', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-size-'));
+    tempDirs.push(dir);
+    fs.writeFileSync(path.join(dir, 'a.txt'), 'hello');          // 5 bytes
+    fs.mkdirSync(path.join(dir, 'sub'));
+    fs.writeFileSync(path.join(dir, 'sub', 'b.txt'), 'world!!');  // 7 bytes
+    // A symlink to a real file must not be followed/counted.
+    fs.symlinkSync(path.join(dir, 'a.txt'), path.join(dir, 'link.txt'));
+
+    const size = pathSize(dir);
+    expect(size.bytes).toBe(12);
+    expect(size.files).toBe(2);
+  });
+
+  it('returns zero for a missing path', () => {
+    expect(pathSize(path.join(os.tmpdir(), 'definitely-missing-xyz'))).toEqual({ bytes: 0, files: 0 });
+  });
+});
+
+describe('formatBytes', () => {
+  it('renders human-readable sizes', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(86 * 1024)).toBe('86 KB');
+    expect(formatBytes(3.1 * 1024 * 1024)).toBe('3.1 MB');
+  });
+});
+
+describe('repoGitInfo', () => {
+  it('reports branch, last commit, and dirty files on a real repo', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-git-'));
+    tempDirs.push(dir);
+    const g = (args: string) => execSync(`git -C ${JSON.stringify(dir)} ${args}`, { stdio: ['ignore', 'pipe', 'ignore'] });
+    g('init -q -b main');
+    g('config user.email t@t.t');
+    g('config user.name t');
+    fs.writeFileSync(path.join(dir, 'a.txt'), 'one');
+    g('add a.txt');
+    g('commit -q -m "first commit"');
+    fs.writeFileSync(path.join(dir, 'a.txt'), 'two');   // make the tree dirty
+
+    const info = repoGitInfo(dir)!;
+    expect(info.branch).toBe('main');
+    expect(info.lastCommit?.subject).toBe('first commit');
+    expect(info.lastCommit?.sha).toMatch(/^[0-9a-f]{7,}$/);
+    expect(info.dirtyFiles).toContain('a.txt');
+    expect(info.dirty).toBe(1);
+  });
+
+  it('returns null for a non-git directory', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-nogit-'));
+    tempDirs.push(dir);
+    expect(repoGitInfo(dir)).toBeNull();
   });
 });

--- a/src/commands/inspect.test.ts
+++ b/src/commands/inspect.test.ts
@@ -106,6 +106,14 @@ describe('collectRepoKind', () => {
     const repo = resolveRepoTarget(root)!;
     expect(collectRepoKind(repo, 'workflows')).toEqual([]);
   });
+
+  it('skips build/tooling caches (__pycache__, node_modules)', () => {
+    const root = makeProjectRepo();
+    fs.mkdirSync(path.join(root, '.agents', 'commands', '__pycache__'));
+    fs.mkdirSync(path.join(root, '.agents', 'commands', 'node_modules'));
+    const repo = resolveRepoTarget(root)!;
+    expect(collectRepoKind(repo, 'commands').map(c => c.name)).toEqual(['plain', 'ship']);
+  });
 });
 
 describe('repoManifestSummary', () => {

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -308,15 +308,88 @@ export function collectRepoKind(repo: RepoTarget, kind: DrillableKind): Resource
   return items.sort((a, b) => a.name.localeCompare(b.name));
 }
 
+/** A few resource names for the at-a-glance preview, with a `…(+N)` tail. */
+function previewNames(items: ResourceItem[], n: number): string {
+  if (items.length === 0) return '';
+  const shown = items.slice(0, n).map(i => i.name);
+  const extra = items.length - shown.length;
+  return shown.join(', ') + (extra > 0 ? ` …(+${extra})` : '');
+}
+
+/** Recursive size + file count of a path; symlinks are not followed. */
+export function pathSize(p: string): { bytes: number; files: number } {
+  let stat: fs.Stats;
+  try { stat = fs.lstatSync(p); } catch { return { bytes: 0, files: 0 }; }
+  if (stat.isSymbolicLink()) return { bytes: 0, files: 0 };
+  if (stat.isFile()) return { bytes: stat.size, files: 1 };
+  if (!stat.isDirectory()) return { bytes: 0, files: 0 };
+  let entries: fs.Dirent[];
+  try { entries = fs.readdirSync(p, { withFileTypes: true }); } catch { return { bytes: 0, files: 0 }; }
+  let bytes = 0, files = 0;
+  for (const e of entries) {
+    const sub = pathSize(path.join(p, e.name));
+    bytes += sub.bytes; files += sub.files;
+  }
+  return { bytes, files };
+}
+
+/** Human byte size: "84 KB", "3.1 MB". */
+export function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let v = n / 1024, i = 0;
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+  return `${v >= 10 ? Math.round(v) : v.toFixed(1)} ${units[i]}`;
+}
+
+export interface ManifestSummary {
+  /** `run.<agent>.strategy` pairs from agents.yaml. */
+  strategies: Array<{ agent: string; strategy: string }>;
+  /** `agents.<agent>` version pins from agents.yaml, when present. */
+  versions: Array<{ agent: string; version: string }>;
+}
+
+/** Parse the repo's own agents.yaml into the version pins + run strategies it declares. */
+export function repoManifestSummary(root: string): ManifestSummary | null {
+  let parsed: unknown;
+  try {
+    parsed = yaml.parse(fs.readFileSync(path.join(root, 'agents.yaml'), 'utf-8'));
+  } catch { return null; }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const obj = parsed as Record<string, unknown>;
+
+  const strategies: ManifestSummary['strategies'] = [];
+  if (obj.run && typeof obj.run === 'object') {
+    for (const [agent, cfg] of Object.entries(obj.run as Record<string, unknown>)) {
+      const strategy = cfg && typeof cfg === 'object' ? (cfg as Record<string, unknown>).strategy : undefined;
+      if (typeof strategy === 'string') strategies.push({ agent, strategy });
+    }
+  }
+
+  const versions: ManifestSummary['versions'] = [];
+  if (obj.agents && typeof obj.agents === 'object') {
+    for (const [agent, ver] of Object.entries(obj.agents as Record<string, unknown>)) {
+      if (typeof ver === 'string') versions.push({ agent, version: ver });
+    }
+  }
+
+  if (strategies.length === 0 && versions.length === 0) return null;
+  return { strategies, versions };
+}
+
 function renderRepoSummary(repo: RepoTarget, options: InspectOptions): void {
   const git = repoGitInfo(repo.root);
   const manifests = REPO_MARKER_FILES.filter(m => fs.existsSync(path.join(repo.root, m)));
+  const manifest = repoManifestSummary(repo.root);
 
-  const counts = {} as Record<DrillableKind, { total: number; bySource: Record<string, number> }>;
+  const kindData = {} as Record<DrillableKind, { items: ResourceItem[]; size: { bytes: number; files: number } }>;
+  let totalBytes = 0, totalFiles = 0;
   if (!options.brief) {
     for (const kind of DRILLABLE_KINDS) {
       const items = collectRepoKind(repo, kind);
-      counts[kind] = { total: items.length, bySource: { [repo.label]: items.length } };
+      const size = pathSize(path.join(repo.root, kind));
+      kindData[kind] = { items, size };
+      totalBytes += size.bytes; totalFiles += size.files;
     }
   }
 
@@ -326,8 +399,15 @@ function renderRepoSummary(repo: RepoTarget, options: InspectOptions): void {
       root: repo.root,
       git,
       manifests,
+      manifest,
+      size: options.brief ? null : { bytes: totalBytes, files: totalFiles },
       resources: options.brief ? null : Object.fromEntries(
-        DRILLABLE_KINDS.map(kind => [kind, counts[kind].total]),
+        DRILLABLE_KINDS.map(kind => [kind, {
+          count: kindData[kind].items.length,
+          bytes: kindData[kind].size.bytes,
+          files: kindData[kind].size.files,
+          names: kindData[kind].items.map(i => i.name),
+        }]),
       ),
     }, null, 2));
     return;
@@ -335,19 +415,51 @@ function renderRepoSummary(repo: RepoTarget, options: InspectOptions): void {
 
   console.log('\n' + chalk.bold(repo.label) + '  ' + chalk.gray('[dotagents repo]') + '\n');
 
-  const rows: Array<[string, string]> = [['root', termLink(repo.root, repo.root)]];
+  // Indent for continuation sub-rows: 2 leading + 10 key column + 1 space.
+  const sub = (label: string, value: string) => console.log(`  ${''.padEnd(10)} ${chalk.gray(label.padEnd(8))} ${value}`);
+
+  console.log(`  ${'root'.padEnd(10)} ${termLink(repo.root, repo.root)}`);
+
   if (git) {
     const dirty = git.dirty > 0 ? ` ${chalk.gray('·')} ${chalk.yellow(`${git.dirty} dirty`)}` : '';
     const url = git.url ? ` ${chalk.gray('·')} ${chalk.gray(git.url)}` : '';
-    rows.push(['git', `${git.branch}${dirty}${url}`]);
+    console.log(`  ${'git'.padEnd(10)} ${git.branch}${dirty}${url}`);
+    if (git.lastCommit) {
+      const rel = git.lastCommit.relative ? `  ${chalk.gray(`(${git.lastCommit.relative})`)}` : '';
+      sub('last', `${chalk.cyan(git.lastCommit.sha)}  ${truncate(git.lastCommit.subject, 60)}${rel}`);
+    }
+    if (git.ahead !== null && git.behind !== null && (git.ahead > 0 || git.behind > 0)) {
+      sub('sync', `ahead ${git.ahead} ${chalk.gray('·')} behind ${git.behind}`);
+    }
+    if (git.dirtyFiles.length > 0) {
+      const shown = git.dirtyFiles.slice(0, 4).join(', ');
+      const extra = git.dirtyFiles.length - Math.min(4, git.dirtyFiles.length);
+      sub('dirty', chalk.yellow(shown + (extra > 0 ? ` …(+${extra})` : '')));
+    }
   }
-  if (manifests.length > 0) rows.push(['manifests', manifests.join(', ')]);
-  for (const [k, v] of rows) console.log(`  ${k.padEnd(10)} ${v}`);
+
+  if (manifests.length > 0) {
+    console.log(`  ${'manifests'.padEnd(10)} ${manifests.join(', ')}`);
+    if (manifest) {
+      if (manifest.versions.length > 0) {
+        sub('versions', manifest.versions.map(v => `${v.agent} ${chalk.cyan(v.version)}`).join(chalk.gray(' · ')));
+      }
+      if (manifest.strategies.length > 0) {
+        sub('run', manifest.strategies.map(s => `${s.agent}:${s.strategy}`).join(chalk.gray(' · ')));
+      }
+    }
+  }
 
   if (!options.brief) {
+    console.log(`  ${'size'.padEnd(10)} ${formatBytes(totalBytes)} ${chalk.gray('·')} ${totalFiles} files`);
+
     console.log('\n' + chalk.bold('Resources'));
     for (const kind of DRILLABLE_KINDS) {
-      console.log(`  ${kind.padEnd(10)} ${String(counts[kind].total).padStart(4)}`);
+      const { items, size } = kindData[kind];
+      const count = String(items.length).padStart(4);
+      const sz = items.length > 0 ? formatBytes(size.bytes).padStart(8) : ''.padEnd(8);
+      const preview = items.length > 0 ? chalk.gray(truncate(previewNames(items, 4), 60)) : '';
+      console.log(`  ${kind.padEnd(10)} ${count}  ${sz}  ${preview}`.trimEnd());
     }
   }
 
@@ -356,7 +468,17 @@ function renderRepoSummary(repo: RepoTarget, options: InspectOptions): void {
   console.log('');
 }
 
-function repoGitInfo(root: string): { branch: string; dirty: number; url: string | null } | null {
+export interface RepoGitInfo {
+  branch: string;
+  dirty: number;
+  dirtyFiles: string[];
+  url: string | null;
+  lastCommit: { sha: string; subject: string; relative: string } | null;
+  ahead: number | null;
+  behind: number | null;
+}
+
+export function repoGitInfo(root: string): RepoGitInfo | null {
   const git = (args: string): string | null => {
     try {
       return execSync(`git -C ${JSON.stringify(root)} ${args}`, { stdio: ['ignore', 'pipe', 'ignore'] })
@@ -365,9 +487,30 @@ function repoGitInfo(root: string): { branch: string; dirty: number; url: string
   };
   const branch = git('rev-parse --abbrev-ref HEAD');
   if (branch === null) return null;
-  const status = git('status --porcelain');
-  const dirty = status ? status.split('\n').filter(Boolean).length : 0;
-  return { branch, dirty, url: git('remote get-url origin') };
+
+  // Read status WITHOUT trimming — git()'s .trim() would strip the leading
+  // space of the first porcelain line (`XY path`), corrupting the path slice.
+  let statusRaw: string | null;
+  try {
+    statusRaw = execSync(`git -C ${JSON.stringify(root)} status --porcelain`, { stdio: ['ignore', 'pipe', 'ignore'] }).toString();
+  } catch { statusRaw = null; }
+  const dirtyFiles = statusRaw ? statusRaw.split('\n').filter(Boolean).map(l => l.slice(3)) : [];
+
+  let lastCommit: RepoGitInfo['lastCommit'] = null;
+  const log = git('log -1 --format=%h%x1f%s%x1f%cr');
+  if (log) {
+    const [sha, subject, relative] = log.split('\x1f');
+    if (sha) lastCommit = { sha, subject: subject ?? '', relative: relative ?? '' };
+  }
+
+  let ahead: number | null = null, behind: number | null = null;
+  const counts = git("rev-list --left-right --count '@{upstream}...HEAD'");
+  if (counts) {
+    const [b, a] = counts.split(/\s+/).map(n => parseInt(n, 10));
+    if (Number.isFinite(b) && Number.isFinite(a)) { behind = b; ahead = a; }
+  }
+
+  return { branch, dirty: dirtyFiles.length, dirtyFiles, url: git('remote get-url origin'), lastCommit, ahead, behind };
 }
 
 // ─── Summary mode ────────────────────────────────────────────────────────────

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -296,6 +296,8 @@ export function collectRepoKind(repo: RepoTarget, kind: DrillableKind): Resource
   const items: ResourceItem[] = [];
   for (const entry of entries) {
     if (entry.name.startsWith('.')) continue;
+    // Build/tooling caches are never resources — they only inflate counts.
+    if (entry.name === '__pycache__' || entry.name === 'node_modules') continue;
     const p = path.join(dir, entry.name);
     items.push({
       name: entry.name.replace(/\.(md|yaml|yml|toml|json)$/, ''),


### PR DESCRIPTION
## What

`agents inspect <repo>` (e.g. `inspect .`, `inspect system`) showed only per-kind **counts** — you could see `skills 14` but not which skills, what the manifest pins, git state beyond branch+dirty, or sizes. This enriches the bare summary so it reads as an inventory.

Four additions (all four requested):

1. **Resource name previews** — each kind lists its first few names with a `…(+N)` tail.
2. **`agents.yaml` manifest summary** — `run.<agent>.strategy` + any `agents.<agent>` version pins, shown under `manifests`.
3. **Git detail** — last commit (sha / subject / relative time), ahead/behind upstream (when non-zero), and dirty file names.
4. **Size + file counts** — total repo size and a per-kind byte size.

`--json` carries everything (`git.lastCommit`, `git.ahead/behind`, `manifest`, `size`, per-kind `{count, bytes, files, names}`); `--brief` still skips resources/size.

## Bug fixed along the way

The shared git helper does `.toString().trim()`, which stripped the leading space off the first `git status --porcelain` line (`XY path`), clipping the first character off the first dirty path. Status is now read untrimmed. The old code only counted lines, so it never surfaced.

## Real output (`inspect system`)

```
system  [dotagents repo]

  root       /Users/muqsit/.agents/.system
  git        main · 1 dirty · git@github.com:phnx-labs/.agents-system.git
             last     360ac22  feat: rename /issues to /tickets; port docs…  (20 hours ago)
             dirty    .gitignore
  manifests  agents.yaml
             run      claude:balanced
  size       262 KB · 61 files

Resources
  commands     13     66 KB  clean, commit, continue, debug …(+9)
  skills       14     77 KB  agents-cli, browser, composer, computer …(+10)
  ...
```

## Tests

`src/commands/inspect.test.ts` — 16 pass. New coverage: `repoManifestSummary` (strategies + version pins, null cases), `pathSize` (recursion, symlink-skip, missing path), `formatBytes`, `repoGitInfo` (branch/lastCommit/dirtyFiles on a real git repo incl. the trim-parse regression, null on non-git).

Scope: repo summary only — agent inspect view untouched.