### PR TITLE
fix(upgrade): refresh the macOS Keychain helper after upgrading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**`agents upgrade` now refreshes the macOS Keychain helper**
+
+- Upgrading runs `npm install -g … --ignore-scripts`, so the postinstall that installs the signed Keychain helper never fired — a user upgrading away from a broken build (e.g. the entitlement-less 1.20.4 helper that failed `SecItemAdd` with `errSecMissingEntitlement -34018`) kept the broken helper until the lazy staleness check in `getKeychainHelperPath()` happened to repair it on their next secret operation. `installResolvedPackage` now force-refreshes the helper (`ensureKeychainHelperInstalled({ forceReinstall: true })`) on darwin after the install, so both the explicit `agents upgrade` and the auto-update prompt land the fixed helper immediately. Best-effort and non-fatal: an upgrade never fails because the helper could not be reinstalled, and `agents helper install --force` remains the manual path.
+
 **`agents inspect <repo>` summary now shows what's actually inside, not just counts**
 
 - The bare repo summary gained four enrichments so it reads as an inventory instead of a tally: (1) **resource name previews** — each kind lists its first few names with a `…(+N)` tail; (2) **manifest summary** — `agents.yaml` is parsed for its `run.<agent>.strategy` and any `agents.<agent>` version pins, shown under `manifests` instead of just the filename; (3) **git detail** — last commit (sha, subject, relative time), ahead/behind upstream when non-zero, and the names of dirty files; (4) **size + file counts** — total repo size and a per-kind byte size. `--json` carries all of it (`git.lastCommit`, `git.ahead/behind`, `manifest`, `size`, and per-kind `{count, bytes, files, names}`); `--brief` still skips resources and size.

--- a/src/index.ts
+++ b/src/index.ts
@@ -392,6 +392,23 @@ async function installResolvedPackage(metadata: NpmPackageMetadata): Promise<voi
   await installPackageIntoPrefix(`${NPM_PACKAGE_NAME}@${metadata.version}`, prefix);
   verifyInstalledVersion(packageRoot, metadata.version);
   refreshAliasShims(packageRoot);
+  // The npm install above runs with --ignore-scripts, so the postinstall that
+  // installs the macOS Keychain helper never fires on upgrade. Force-refresh the
+  // helper here so a user upgrading FROM a broken build (e.g. the entitlement-less
+  // 1.20.4 helper that fails SecItemAdd with -34018) gets the fixed, signed bundle
+  // immediately — instead of waiting for the lazy staleness check in
+  // getKeychainHelperPath() to repair it on their next secret operation. The new
+  // package is already on disk, so the dynamic import resolves the freshly-installed
+  // helper module + bundle. Best-effort: an upgrade must never fail because the
+  // helper could not be reinstalled (`agents helper install --force` stays available).
+  if (process.platform === 'darwin') {
+    try {
+      const { ensureKeychainHelperInstalled } = await import('./lib/secrets/install-helper.js');
+      ensureKeychainHelperInstalled({ forceReinstall: true });
+    } catch {
+      // Non-fatal.
+    }
+  }
 }
 
 /** Present an interactive upgrade prompt (TTY) or a one-line hint (non-TTY). */


### PR DESCRIPTION
## Problem

`agents upgrade` runs `npm install -g … --ignore-scripts`, so the postinstall that installs the signed macOS Keychain helper **never fires on upgrade**. A user upgrading away from a broken build — e.g. the entitlement-less **1.20.4** helper that fails `SecItemAdd` with `errSecMissingEntitlement -34018` ("can't store secrets") — keeps the broken helper. It's only repaired lazily, when `getKeychainHelperPath()`'s staleness check runs on their *next* secret operation. So "I upgraded but secrets still fail until I do something else" is a real, confusing gap.

## Fix

`installResolvedPackage` (the shared chokepoint for both the explicit `agents upgrade` and the auto-update prompt) now force-refreshes the helper after the install, on darwin:

```ts
if (process.platform === 'darwin') {
  try {
    const { ensureKeychainHelperInstalled } = await import('./lib/secrets/install-helper.js');
    ensureKeychainHelperInstalled({ forceReinstall: true });
  } catch { /* non-fatal */ }
}
```

The freshly-installed package is already on disk, so the dynamic import resolves the new helper module + signed bundle. **Best-effort and non-fatal** — an upgrade never fails because the helper couldn't be reinstalled, and `agents helper install --force` stays as the manual path.

## Verification
- `tsc --noEmit` clean, `bun run build` clean, change present in `dist/index.js`
- `keychain-helper.test.ts` passes (4/4) — the called function is already covered
- E2E (`agents upgrade` against npm) can't run pre-publish; the logic calls the existing, tested helper from one new guarded site

## Note for the currently-affected user
This ships in the **next** release, so it fixes *future* upgrades. The user on the old build still needs the one-time manual refresh today: `agents upgrade --yes && agents helper install --force`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)