### PR TITLE
fix(routines): pass AGENTS_USER_DIR to sandboxed shim so jobs resolve the configured version (#257)

### DIFF
--- a/src/lib/__tests__/shims.test.ts
+++ b/src/lib/__tests__/shims.test.ts
@@ -89,8 +89,8 @@ describe('addShimsToPath', () => {
 });
 
 describe('SHIM_SCHEMA_VERSION', () => {
-  it('is 17 (launch sync wrapped in a bash skip-fast sentinel gate)', () => {
-    expect(SHIM_SCHEMA_VERSION).toBe(17);
+  it('is 18 (overridable AGENTS_USER_DIR for routines sandbox)', () => {
+    expect(SHIM_SCHEMA_VERSION).toBe(18);
   });
 });
 

--- a/src/lib/sandbox.test.ts
+++ b/src/lib/sandbox.test.ts
@@ -1,0 +1,29 @@
+
+import { describe, it, expect } from 'vitest';
+import { buildSpawnEnv } from './sandbox.js';
+import { getUserAgentsDir } from './state.js';
+import * as os from 'os';
+import * as path from 'path';
+
+describe('buildSpawnEnv', () => {
+  it('sets HOME to the overlay and AGENTS_USER_DIR to the real user agents dir', () => {
+    const overlayHome = path.join(os.tmpdir(), 'test-overlay-home');
+    const env = buildSpawnEnv(overlayHome);
+    
+    expect(env.HOME).toBe(overlayHome);
+    expect(env.AGENTS_USER_DIR).toBe(getUserAgentsDir());
+  });
+
+  it('preserves other allowlisted env vars', () => {
+    // PATH is usually allowlisted
+    if (process.env.PATH) {
+      const env = buildSpawnEnv('/tmp/overlay');
+      expect(env.PATH).toBe(process.env.PATH);
+    }
+  });
+
+  it('allows extra env overrides', () => {
+    const env = buildSpawnEnv('/tmp/overlay', { FOO: 'bar' });
+    expect(env.FOO).toBe('bar');
+  });
+});

--- a/src/lib/sandbox.ts
+++ b/src/lib/sandbox.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import * as os from 'os';
 import type { JobConfig } from './routines.js';
 import { setGeminiAutoUpdateDisabled, updateGeminiSettings } from './gemini-settings.js';
-import { getRoutinesDir } from './state.js';
+import { getRoutinesDir, getUserAgentsDir } from './state.js';
 
 function resolveRealHome(): string {
   const home = os.homedir();
@@ -65,7 +65,10 @@ function tomlString(value: string): string {
 
 /** Build a restricted environment for a sandboxed process, setting HOME to the overlay. */
 export function buildSpawnEnv(overlayHome: string, extraEnv?: Record<string, string>): Record<string, string> {
-  const env: Record<string, string> = { HOME: overlayHome };
+  const env: Record<string, string> = {
+    HOME: overlayHome,
+    AGENTS_USER_DIR: getUserAgentsDir(),
+  };
 
   for (const key of ENV_ALLOWLIST) {
     if (process.env[key]) {

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -232,7 +232,7 @@ async function promptConflictStrategy(
  *         top-level entry add/remove — deep edits to plugin contents won't
  *         trigger auto-resync, run `agents sync` for that.
  */
-export const SHIM_SCHEMA_VERSION = 17;
+export const SHIM_SCHEMA_VERSION = 18;
 
 /** Internal marker string used to embed the schema version in shim scripts. */
 const SHIM_VERSION_MARKER = 'agents-shim-version:';
@@ -308,7 +308,7 @@ export KIMI_CODE_HOME="$VERSION_DIR/home/${configDirName}"
 # Shim for ${agentConfig.name}
 # ${SHIM_VERSION_MARKER} ${SHIM_SCHEMA_VERSION}
 
-AGENTS_USER_DIR="$HOME/.agents"
+AGENTS_USER_DIR="\${AGENTS_USER_DIR:-$HOME/.agents}"
 AGENTS_BIN=${agentsBin}
 AGENT="${agent}"
 CLI_COMMAND="${cliCommand}"


### PR DESCRIPTION
Closes #257.

## Root Cause
The routines sandbox spawns agent shims with a redirected `HOME` directory (overlay). Since the shims were hardcoded to derive `AGENTS_USER_DIR` from `$HOME/.agents`, they looked for configuration in the empty overlay directory, failing with "no version of <agent> configured".

## Fix
1.  **Shim Template**: Modified `src/lib/shims.ts` to make `AGENTS_USER_DIR` overridable via an environment variable, defaulting to `$HOME/.agents`.
2.  **Schema Bump**: Bumped `SHIM_SCHEMA_VERSION` to `18` to ensure existing shims are regenerated on upgrade.
3.  **Sandbox Environment**: Updated `src/lib/sandbox.ts` (`buildSpawnEnv`) to explicitly set `AGENTS_USER_DIR` to the real user agents directory (`~/.agents`).

## Verification
- Added `src/lib/sandbox.test.ts` to verify that `buildSpawnEnv` correctly sets both `HOME` (to the overlay) and `AGENTS_USER_DIR` (to the real config root).
- Verified that `SHIM_SCHEMA_VERSION` is correctly embedded in generated shims.
- Full build and test suite pass.