### PR TITLE
ci(dependabot): track bun.lock + skip gitleaks on dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,12 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
-  - package-ecosystem: "npm"
+  # bun, not npm: CI installs with bun and enforces bun.lock (bun auto-enables
+  # --frozen-lockfile under CI). The npm ecosystem updated package.json +
+  # package-lock.json but left bun.lock stale, so every dependabot PR failed
+  # `bun install` with "lockfile had changes, but lockfile is frozen". The bun
+  # ecosystem updates bun.lock in lockstep. (Dependabot bun support GA 2025-02.)
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -24,14 +24,18 @@ jobs:
           fetch-depth: 0
 
       # gitleaks-action requires GITLEAKS_LICENSE for org-owned repos and
-      # exits hard when it's missing. Forks cannot read org secrets, so PRs
-      # from forks always fail here. Skip on fork PRs; the post-merge scan
-      # on main still covers the same commits.
-      - name: Determine if PR is from a fork
+      # exits hard when it's missing. Two PR classes can't read that secret and
+      # so always fail here: (1) fork PRs (forks can't read org secrets), and
+      # (2) Dependabot PRs (runs use the restricted Dependabot secret store, not
+      # the repo/org store, so secrets.GITLEAKS_LICENSE is empty). Skip both;
+      # the post-merge scan on main re-scans the same commits with the license.
+      - name: Determine if scan should be skipped
         id: fork
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ] && \
              [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.actor }}" = "dependabot[bot]" ]; then
             echo "is_fork=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_fork=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why

Every dependabot PR (#276, #277) fails CI for two structural reasons unrelated to the bump itself:

1. **Stale `bun.lock`.** CI installs with `bun`, which auto-enables `--frozen-lockfile` under `CI=true`. The `npm` ecosystem updated `package.json` + `package-lock.json` but left `bun.lock` stale → `error: lockfile had changes, but lockfile is frozen`.
2. **Missing gitleaks license.** Dependabot runs use the restricted Dependabot secret store (`Secret source: Dependabot`), so `secrets.GITLEAKS_LICENSE` is empty and `gitleaks-action` exits hard: `🛑 missing gitleaks license`.

## What

- **`.github/dependabot.yml`**: `package-ecosystem: npm` → `bun`. Dependabot bun support is GA (2025-02) and updates `bun.lock` — the lockfile CI actually enforces.
- **`.github/workflows/secret-scan.yml`**: extend the existing fork-skip to also skip `dependabot[bot]` PRs. The post-merge scan on `main` re-scans the same commits with the license, so coverage is unchanged.

Closes the CI half of #276/#277. (marked v18 in #277 is separately a no-go: `marked-terminal@7.3.0` peer-caps `marked` at `<16`.)