### PR TITLE
fix(project): deliver project-layer subagents to .claude/agents on launch (#281)

### DIFF
--- a/src/lib/project-launch.test.ts
+++ b/src/lib/project-launch.test.ts
@@ -77,15 +77,63 @@ afterEach(() => {
 });
 
 describe('runLaunchSync — workspace resource mirror', () => {
-  it('symlinks .agents/subagents/*.md → cwd/.claude/agents/*.md', () => {
-    writeFile(path.join(PROJECT_DIR, '.agents', 'subagents', 'reviewer.md'), '# Reviewer subagent');
+  // #281: the real subagent source shape is a DIRECTORY containing AGENT.md
+  // (NOT a flat .md file). It must be flattened and WRITTEN to
+  // cwd/.claude/agents/<name>.md as a regular file — symlinking can't work
+  // because a subagent is N source files collapsed into one.
+  it('writes .agents/subagents/<name>/AGENT.md → cwd/.claude/agents/<name>.md (flattened, regular file)', () => {
+    writeFile(
+      path.join(PROJECT_DIR, '.agents', 'subagents', 'probe-agent', 'AGENT.md'),
+      '---\nname: probe-agent\ndescription: Probes things\nmodel: sonnet\n---\n\nProbe the codebase carefully.',
+    );
 
     const result = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
 
     expect(result.workspaceLinks).toBeGreaterThanOrEqual(1);
-    const linked = path.join(PROJECT_DIR, '.claude', 'agents', 'reviewer.md');
-    expect(fs.lstatSync(linked).isSymbolicLink()).toBe(true);
-    expect(fs.readFileSync(linked, 'utf-8')).toBe('# Reviewer subagent');
+    const dest = path.join(PROJECT_DIR, '.claude', 'agents', 'probe-agent.md');
+    // Regular file, NOT a symlink — the bug was a silent zero-delivery drop.
+    expect(fs.lstatSync(dest).isFile()).toBe(true);
+    expect(fs.lstatSync(dest).isSymbolicLink()).toBe(false);
+    const written = fs.readFileSync(dest, 'utf-8');
+    // Clean flattened frontmatter + body.
+    expect(written).toMatch(/^---\nname: probe-agent\ndescription: Probes things\nmodel: sonnet\n---/);
+    expect(written).toContain('Probe the codebase carefully.');
+  });
+
+  it('flattens a multi-file subagent (AGENT.md + SOUL.md) into ## sections', () => {
+    writeFile(
+      path.join(PROJECT_DIR, '.agents', 'subagents', 'probe-agent', 'AGENT.md'),
+      '---\nname: probe-agent\ndescription: Probes things\n---\n\nMain body.',
+    );
+    writeFile(
+      path.join(PROJECT_DIR, '.agents', 'subagents', 'probe-agent', 'SOUL.md'),
+      'The soul of the agent.',
+    );
+
+    runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+
+    const written = fs.readFileSync(path.join(PROJECT_DIR, '.claude', 'agents', 'probe-agent.md'), 'utf-8');
+    expect(written).toContain('Main body.');
+    expect(written).toContain('## Soul');
+    expect(written).toContain('The soul of the agent.');
+  });
+
+  it('refreshes a previously-generated subagent file on a later launch', () => {
+    const agentMd = path.join(PROJECT_DIR, '.agents', 'subagents', 'probe-agent', 'AGENT.md');
+    writeFile(agentMd, '---\nname: probe-agent\ndescription: v1\n---\n\nVersion one.');
+    runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+
+    const dest = path.join(PROJECT_DIR, '.claude', 'agents', 'probe-agent.md');
+    expect(fs.readFileSync(dest, 'utf-8')).toContain('Version one.');
+
+    // Edit the source; the generated file (carries our marker) must refresh.
+    writeFile(agentMd, '---\nname: probe-agent\ndescription: v2\n---\n\nVersion two.');
+    const result = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
+
+    expect(result.workspaceLinks).toBeGreaterThanOrEqual(1);
+    const refreshed = fs.readFileSync(dest, 'utf-8');
+    expect(refreshed).toContain('Version two.');
+    expect(refreshed).not.toContain('Version one.');
   });
 
   it('mirrors commands and skills under .claude/, but NOT mcp.json (supply-chain surface)', () => {
@@ -102,7 +150,7 @@ describe('runLaunchSync — workspace resource mirror', () => {
   });
 
   it('does not clobber a hand-authored .claude/agents/foo.md', () => {
-    writeFile(path.join(PROJECT_DIR, '.agents', 'subagents', 'foo.md'), '# from project rules');
+    writeFile(path.join(PROJECT_DIR, '.agents', 'subagents', 'foo', 'AGENT.md'), '---\nname: foo\ndescription: from project\n---\n\nGenerated body.');
     writeFile(path.join(PROJECT_DIR, '.claude', 'agents', 'foo.md'), '# hand-authored — keep me');
 
     const result = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
@@ -110,11 +158,12 @@ describe('runLaunchSync — workspace resource mirror', () => {
     expect(result.workspaceSkipped).toContain(path.join('.claude', 'agents', 'foo.md'));
     const dest = path.join(PROJECT_DIR, '.claude', 'agents', 'foo.md');
     expect(fs.lstatSync(dest).isSymbolicLink()).toBe(false);
+    // Hand-authored file (no generated marker) survives untouched.
     expect(fs.readFileSync(dest, 'utf-8')).toBe('# hand-authored — keep me');
   });
 
   it('does not clobber a dangling user symlink at the dest path', () => {
-    writeFile(path.join(PROJECT_DIR, '.agents', 'subagents', 'foo.md'), '# from project rules');
+    writeFile(path.join(PROJECT_DIR, '.agents', 'subagents', 'foo', 'AGENT.md'), '---\nname: foo\ndescription: from project\n---\n\nGenerated body.');
     fs.mkdirSync(path.join(PROJECT_DIR, '.claude', 'agents'), { recursive: true });
     fs.symlinkSync('/tmp/does-not-exist-pls-keep-this-dangling', path.join(PROJECT_DIR, '.claude', 'agents', 'foo.md'));
 
@@ -136,7 +185,7 @@ describe('runLaunchSync — workspace resource mirror', () => {
   });
 
   it('is idempotent: running twice does not duplicate links', () => {
-    writeFile(path.join(PROJECT_DIR, '.agents', 'subagents', 'r.md'), '# r');
+    writeFile(path.join(PROJECT_DIR, '.agents', 'subagents', 'r', 'AGENT.md'), '---\nname: r\ndescription: r\n---\n\nBody.');
 
     const first = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
     const second = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });

--- a/src/lib/project-launch.ts
+++ b/src/lib/project-launch.ts
@@ -56,6 +56,7 @@ import {
   getSystemPluginsDir,
 } from './state.js';
 import { getVersionHomePath } from './versions.js';
+import { transformSubagentForClaude } from './subagents.js';
 import { compileRulesForProject } from './rules/compile.js';
 import { discoverPluginsInDir, hasPluginExecSurfaces, inspectPluginCapabilities } from './plugins.js';
 import type { DiscoveredPlugin } from './types.js';
@@ -166,15 +167,36 @@ interface MirrorPlan {
   srcSubdir: string;
   /** Dest subdir under `<cwd>/.{agent}/`. */
   destSubdir: string;
-  /** True when entries are directories (skills); false when entries are files (md). */
-  entriesAreDirs: boolean;
+  /**
+   * How each source entry becomes a dest entry:
+   *  - 'file-symlink':   each *.md FILE is symlinked 1:1 (commands).
+   *  - 'dir-symlink':    each DIRECTORY is symlinked 1:1 (skills — a skill IS a dir).
+   *  - 'subagent-write': each subagent DIRECTORY (containing AGENT.md plus
+   *    optional sibling .md files) is FLATTENED into a single written .md file.
+   *    A subagent has no single file to point a symlink at, so we write the
+   *    transform output instead — see writeProjectSubagents.
+   */
+  mode: 'file-symlink' | 'dir-symlink' | 'subagent-write';
 }
 
 const CLAUDE_MIRROR_PLANS: MirrorPlan[] = [
-  { srcSubdir: 'subagents', destSubdir: 'agents',   entriesAreDirs: false },
-  { srcSubdir: 'commands',  destSubdir: 'commands', entriesAreDirs: false },
-  { srcSubdir: 'skills',    destSubdir: 'skills',   entriesAreDirs: true },
+  { srcSubdir: 'subagents', destSubdir: 'agents',   mode: 'subagent-write' },
+  { srcSubdir: 'commands',  destSubdir: 'commands', mode: 'file-symlink' },
+  { srcSubdir: 'skills',    destSubdir: 'skills',   mode: 'dir-symlink' },
 ];
+
+/**
+ * Marker prepended-as-trailing-comment to every subagent file WE generate.
+ * It's an HTML comment — invisible to the markdown the agent reads — placed on
+ * the last line so it never disturbs the leading `---` frontmatter block.
+ *
+ * Ownership rule (the one don't-clobber decision for written, non-symlink
+ * files): we only overwrite a `.claude/agents/<name>.md` whose content carries
+ * this marker. A user-authored file (no marker) or a symlink at the dest is
+ * left untouched. A marker beats an mtime/sidecar sentinel because it travels
+ * with the file across copies and git, and needs no out-of-band state.
+ */
+const GENERATED_SUBAGENT_MARKER = '<!-- agents-cli:generated-subagent';
 
 function mirrorWorkspaceResources(cwd: string, agent: AgentId): { links: number; skipped: string[] } {
   // v1: claude-only. Other agents have workspace conventions we haven't
@@ -204,11 +226,19 @@ function mirrorWorkspaceResources(cwd: string, agent: AgentId): { links: number;
     const destDir = path.join(agentWorkspaceDir, plan.destSubdir);
     fs.mkdirSync(destDir, { recursive: true });
 
+    // Subagents flatten N source files into one written .md — not a symlink.
+    if (plan.mode === 'subagent-write') {
+      const r = writeProjectSubagents(srcDir, destDir, cwd);
+      links += r.links;
+      skipped.push(...r.skipped);
+      continue;
+    }
+
     const entries = fs.readdirSync(srcDir, { withFileTypes: true });
     for (const entry of entries) {
       if (entry.name.startsWith('.')) continue;
-      if (plan.entriesAreDirs && !entry.isDirectory()) continue;
-      if (!plan.entriesAreDirs && !entry.isFile() && !entry.isSymbolicLink()) continue;
+      if (plan.mode === 'dir-symlink' && !entry.isDirectory()) continue;
+      if (plan.mode === 'file-symlink' && !entry.isFile() && !entry.isSymbolicLink()) continue;
 
       const srcPath = path.join(srcDir, entry.name);
       const destPath = path.join(destDir, entry.name);
@@ -222,6 +252,84 @@ function mirrorWorkspaceResources(cwd: string, agent: AgentId): { links: number;
   }
 
   return { links, skipped };
+}
+
+/**
+ * Mirror project subagents into `<cwd>/.claude/agents/`. The canonical source
+ * shape is a DIRECTORY containing AGENT.md (e.g. `.agents/subagents/probe/AGENT.md`)
+ * — confirmed by the detector (versions.ts) and lister (subagents.ts). Each
+ * such directory is flattened via transformSubagentForClaude (the exact writer
+ * the version-home sync uses) into a single `<name>.md`, then written under an
+ * ownership marker so a re-launch refreshes our file but never clobbers a
+ * user-authored one.
+ *
+ * Returns the same {links, skipped} shape the symlink path reports, so the
+ * caller's accounting is uniform across resource kinds.
+ */
+function writeProjectSubagents(srcDir: string, destDir: string, cwd: string): { links: number; skipped: string[] } {
+  let links = 0;
+  const skipped: string[] = [];
+
+  for (const entry of fs.readdirSync(srcDir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue;
+    if (!entry.isDirectory()) continue;
+
+    const subagentDir = path.join(srcDir, entry.name);
+    if (!fs.existsSync(path.join(subagentDir, 'AGENT.md'))) continue;
+
+    const destPath = path.join(destDir, `${entry.name}.md`);
+    if (writeSubagentIfOwned(subagentDir, destPath)) {
+      links += 1;
+    } else {
+      skipped.push(path.relative(cwd, destPath));
+    }
+  }
+
+  return { links, skipped };
+}
+
+/**
+ * Write a flattened subagent file at `destPath`, refusing to clobber user state.
+ *
+ *   - dest missing            → write fresh.
+ *   - dest is our generation  → overwrite (refresh; carries GENERATED_SUBAGENT_MARKER).
+ *   - dest is a symlink / any
+ *     non-regular file         → SKIP (user state we don't own).
+ *   - dest is a regular file
+ *     without our marker        → SKIP (hand-authored .claude/agents/<name>.md).
+ *
+ * Returns true when our file is present (written now or already current),
+ * false when we left a user-owned dest alone.
+ */
+function writeSubagentIfOwned(subagentDir: string, destPath: string): boolean {
+  let existing: string | null = null;
+  let destLstat: fs.Stats | null = null;
+  try { destLstat = fs.lstatSync(destPath); } catch { /* missing — write fresh */ }
+
+  if (destLstat) {
+    if (!destLstat.isFile()) return false; // symlink/dir/etc. — user state
+    try { existing = fs.readFileSync(destPath, 'utf-8'); } catch { return false; }
+    if (!existing.includes(GENERATED_SUBAGENT_MARKER)) return false; // hand-authored
+  }
+
+  let body: string;
+  try {
+    body = transformSubagentForClaude(subagentDir);
+  } catch {
+    return false; // malformed AGENT.md — don't write a broken file
+  }
+  const content = `${body}\n\n${GENERATED_SUBAGENT_MARKER} — edit .agents/subagents/${path.basename(subagentDir)}/ instead -->\n`;
+
+  // Skip-fast: identical content already on disk → no write (keeps mtime stable).
+  if (existing === content) return true;
+
+  try {
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+    fs.writeFileSync(destPath, content);
+  } catch {
+    return false;
+  }
+  return true;
 }
 
 /**


### PR DESCRIPTION
Closes #281.

## Root cause

Project-layer subagents in `<project>/.agents/subagents/<name>/AGENT.md` are detected by `agents inspect project` but were **never delivered** to the agent. Project skills *are* delivered (symlinked into `.claude/skills/`); subagents were not.

The launch-time mirror is the **only** delivery path for project subagents — the version-home writer deliberately excludes the project layer (`src/lib/staleness/writers/subagents.ts:5-8`, via `listInstalledSubagents` which reads user+system only, `src/lib/subagents.ts:127`).

That mirror declared the subagents plan as a flat-file plan:

```ts
// before — src/lib/project-launch.ts
{ srcSubdir: 'subagents', destSubdir: 'agents', entriesAreDirs: false },
```

`entriesAreDirs: false` made the mirror loop accept **file** entries only:

```ts
if (!plan.entriesAreDirs && !entry.isFile() && !entry.isSymbolicLink()) continue;
```

But the canonical subagent shape is a **directory** containing `AGENT.md` — confirmed by the detector (`src/lib/versions.ts:255-257`, `d.isDirectory() && exists(.../AGENT.md)`) and the lister (`src/lib/subagents.ts:130-135`). So every dir entry hit the `continue` and was silently dropped — zero links, no warning. Exactly the reported symptom.

### The misleading test

`src/lib/project-launch.test.ts` used a **fake flat-file** shape (`.agents/subagents/reviewer.md`) that never occurs in practice, so the test passed while the real shape failed. Rewritten to the real `dir + AGENT.md` shape.

## The fix

Special-case the subagents plan: each subagent **directory** is flattened into a single written `<name>.md` via `transformSubagentForClaude` (`src/lib/subagents.ts:229`) — the exact transform the version-home writer uses (`src/lib/staleness/writers/subagents.ts:35`). It reads the AGENT.md frontmatter into a clean `---` header and appends sibling `*.md` files as `## Section` blocks.

### Write vs. symlink + ownership marker (the one design decision)

Subagents are **written**, not symlinked: a subagent is N source files collapsed into one file, so there's no single source file to point a symlink at (skills symlink because a skill *is* a directory).

Because a written file isn't a symlink, the existing `replaceWithSymlinkIfOwned` guard doesn't apply. I use a **content ownership marker**: every generated file ends with an HTML comment (`<!-- agents-cli:generated-subagent ... -->`) — invisible to the markdown the agent reads, placed last so it never disturbs the leading `---` frontmatter. The clobber rule:

- dest missing → write fresh
- dest carries our marker → overwrite (refresh a prior generation)
- dest is a symlink / non-regular file → skip (user state)
- dest is a regular file without the marker → skip (hand-authored)

A content marker beats an mtime/sidecar sentinel because it travels with the file across copies and git, and needs no out-of-band state.

Scope: claude-only mirror, consistent with current v1 scope (`src/lib/project-launch.ts:184`).

## Test evidence

`bunx vitest run src/lib/project-launch.test.ts` → **20 passed**. New/updated cases:
- writes `.agents/subagents/<name>/AGENT.md` → `.claude/agents/<name>.md` as a **regular file** (not symlink), flattened frontmatter + body
- multi-file subagent (`AGENT.md` + `SOUL.md`) flattens into a `## Soul` section
- a later launch refreshes a previously-generated file after a source edit
- hand-authored `.claude/agents/foo.md` survives untouched
- dangling user symlink at the dest survives
- idempotent across runs

E2E sanity (scratch dir + real `runLaunchSync`) produced `.claude/agents/probe-agent.md` as a regular file with clean frontmatter, body, `## Soul`, and the ownership marker.

> Note: the repo's subprocess-spawning test files fail in this sandbox due to a local shell wrapper that blocks child `node` spawns (`status null`); they are unrelated to this change and do not touch `project-launch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)