### PR TITLE
chore(deps-dev): bump @types/node to 25.9.3 (with bun.lock)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
       "devDependencies": {
         "@types/diff": "8.0.0",
         "@types/marked-terminal": "6.1.1",
-        "@types/node": "25.9.2",
+        "@types/node": "25.9.3",
         "tsx": "4.22.4",
         "typescript": "6.0.3",
         "vitest": "4.1.8",
@@ -194,7 +194,7 @@
 
     "@types/marked-terminal": ["@types/marked-terminal@6.1.1", "", { "dependencies": { "@types/cardinal": "^2.1", "@types/node": "*", "chalk": "^5.3.0", "marked": ">=6.0.0 <12" } }, "sha512-DfoUqkmFDCED7eBY9vFUhJ9fW8oZcMAK5EwRDQ9drjTbpQa+DnBTQQCwWhTFVf4WsZ6yYcJTI8D91wxTWXRZZQ=="],
 
-    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+    "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
 
     "@types/proper-lockfile": ["@types/proper-lockfile@4.1.4", "", { "dependencies": { "@types/retry": "*" } }, "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ=="],
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   "devDependencies": {
     "@types/diff": "8.0.0",
     "@types/marked-terminal": "6.1.1",
-    "@types/node": "25.9.2",
+    "@types/node": "25.9.3",
     "tsx": "4.22.4",
     "typescript": "6.0.3",
     "vitest": "4.1.8"


### PR DESCRIPTION
Supersedes #276. Same `@types/node` 25.9.2 → 25.9.3 bump dependabot proposed, but with `bun.lock` regenerated so CI's frozen-lockfile install passes (dependabot's npm-ecosystem PR only touched `package.json` + `package-lock.json`). Future dependabot PRs avoid this via the bun-ecosystem switch in #283.

CI-frozen install verified locally: `CI=true bun install --frozen-lockfile` → exit 0, no changes.