### PR TITLE
feat(computer): add --char-delay for lossy keyboard relays (#262)

### DIFF
--- a/packages/computer-helper/Sources/ComputerHelper/Events.swift
+++ b/packages/computer-helper/Sources/ComputerHelper/Events.swift
@@ -48,6 +48,12 @@ enum Events {
         try ensurePidAllowed(pid)
         let front = try checkFrontmost(pid: pid, params: params)
 
+        // Inter-character delay. Default 4ms (backward compatible); lossy
+        // keyboard relays (Parallels/VM guests) can drop chars mid-stream at
+        // that rate, so callers may raise it. Clamp to [1, 250]ms.
+        let charDelayMs = min(250, max(1, Params.intOpt(params, "char_delay_ms") ?? 4))
+        let charDelay = Double(charDelayMs) / 1000.0
+
         for scalar in text.unicodeScalars {
             var utf16 = Array(String(scalar).utf16)
             guard let down = CGEvent(keyboardEventSource: EventSynth.source, virtualKey: 0, keyDown: true),
@@ -58,7 +64,7 @@ enum Events {
             up.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: &utf16)
             down.postToPid(pid_t(pid))
             up.postToPid(pid_t(pid))
-            Thread.sleep(forTimeInterval: 0.004)
+            Thread.sleep(forTimeInterval: charDelay)
         }
 
         if Params.bool(params, "commit") {

--- a/src/commands/computer-actions.test.ts
+++ b/src/commands/computer-actions.test.ts
@@ -5,6 +5,9 @@ import {
   buildElementOrCoords,
   buildRaiseParams,
   buildWaitParams,
+  clampCharDelay,
+  CHAR_DELAY_MIN_MS,
+  CHAR_DELAY_MAX_MS,
   type AppInfo,
 } from './computer-actions.js';
 import { resolveRpcTimeoutMs, RPC_TIMEOUT_MS } from '../lib/computer-rpc.js';
@@ -159,6 +162,35 @@ describe('buildWaitParams', () => {
   it('errors when only --until/--timeout are given (no target)', () => {
     const r = buildWaitParams({ until: 'exists', timeout: 1000 });
     expect(r.ok).toBe(false);
+  });
+});
+
+describe('clampCharDelay', () => {
+  it('returns undefined when unset so the daemon applies its 4ms default', () => {
+    expect(clampCharDelay(undefined)).toBeUndefined();
+  });
+
+  it('passes a typical VM-guest value through unchanged', () => {
+    expect(clampCharDelay(25)).toBe(25);
+  });
+
+  it('clamps below the floor up to the minimum', () => {
+    expect(clampCharDelay(0)).toBe(CHAR_DELAY_MIN_MS);
+    expect(clampCharDelay(-100)).toBe(CHAR_DELAY_MIN_MS);
+  });
+
+  it('clamps above the ceiling down to the maximum', () => {
+    expect(clampCharDelay(1000)).toBe(CHAR_DELAY_MAX_MS);
+  });
+
+  it('keeps the boundary values', () => {
+    expect(clampCharDelay(CHAR_DELAY_MIN_MS)).toBe(1);
+    expect(clampCharDelay(CHAR_DELAY_MAX_MS)).toBe(250);
+  });
+
+  it('truncates fractional input and rejects NaN', () => {
+    expect(clampCharDelay(25.9)).toBe(25);
+    expect(clampCharDelay(NaN)).toBeUndefined();
   });
 });
 

--- a/src/commands/computer-actions.ts
+++ b/src/commands/computer-actions.ts
@@ -95,6 +95,18 @@ export function buildRaiseParams(opts: {
   return params;
 }
 
+// Inter-character typing delay for type-text. Default 4ms matches the daemon's
+// historical fixed rate; lossy keyboard relays (Parallels/VM guests) drop chars
+// at that rate, so callers can raise it. Clamp to [1, 250]ms CLI-side (the
+// daemon clamps too — defense in depth). Returns undefined when unset so the
+// daemon applies its own default. Pure + tested.
+export const CHAR_DELAY_MIN_MS = 1;
+export const CHAR_DELAY_MAX_MS = 250;
+export function clampCharDelay(ms: number | undefined): number | undefined {
+  if (ms === undefined || !Number.isFinite(ms)) return undefined;
+  return Math.min(CHAR_DELAY_MAX_MS, Math.max(CHAR_DELAY_MIN_MS, Math.trunc(ms)));
+}
+
 // Build the wait RPC params. Pure + tested. Three modes, mirroring the
 // daemon's Wait.run: --duration (unconditional sleep), --id + --until
 // (cached-element poll), or --role/--label/--identifier (live locator poll).
@@ -331,14 +343,17 @@ export function registerActionCommands(program: Command): void {
       .option('--commit', 'Press Return after typing')
       .option('--raise', 'Bring the target app to the front first')
       .option('--require-frontmost', 'Fail (not warn) if the target is not the frontmost app')
+      .option('--char-delay <ms>', 'Inter-character delay in ms (default 4; raise for lossy keyboard relays like VM guests, e.g. 25). Clamped to [1, 250].', (v) => parseInt(v, 10))
       .option('--json', 'Emit JSON'),
-  ).action(async (opts: TargetOpts & { text: string; commit?: boolean; raise?: boolean; requireFrontmost?: boolean }) => {
+  ).action(async (opts: TargetOpts & { text: string; commit?: boolean; raise?: boolean; requireFrontmost?: boolean; charDelay?: number }) => {
     await withClient(async (client) => {
       const pid = await resolveTargetPid(client, opts);
       await raiseIfRequested(client, pid, opts.raise);
       const params: Record<string, unknown> = { pid, text: opts.text };
       if (opts.commit) params.commit = true;
       if (opts.requireFrontmost) params.require_frontmost = true;
+      const charDelay = clampCharDelay(opts.charDelay);
+      if (charDelay !== undefined) params.char_delay_ms = charDelay;
       const res = unwrap(await client.call('type_text', params));
       warnIfNotFrontmost(res);
       emit(res, Boolean(opts.json), () => `typed ${res.chars ?? opts.text.length} char(s)`);


### PR DESCRIPTION
Closes #262.

## Problem

`Events.typeText` hardcoded the inter-character sleep at `Thread.sleep(forTimeInterval: 0.004)`. During the #258 acceptance run against a Parallels Windows 11 guest, a 28-char `type-text` stream dropped everything after char 11 mid-stream (daemon reported `frontmost: true`, `ok: true` — the drop happened inside the guest's keyboard relay). A slower inter-char rate recovers it.

## Change (3 surfaces)

1. **Daemon (Swift)** — `packages/computer-helper/Sources/ComputerHelper/Events.swift`: parse optional `char_delay_ms` from the `type_text` RPC params (via the existing `Params.intOpt` helper), **clamp to `[1, 250]`ms**, **default stays 4ms** (backward compatible). Replaced `Thread.sleep(forTimeInterval: 0.004)` with `Thread.sleep(forTimeInterval: Double(charDelayMs)/1000.0)`.
2. **CLI (TypeScript)** — `src/commands/computer-actions.ts`: added `--char-delay <ms>` to `agents computer type-text`, parsed to int, clamped CLI-side via the new pure `clampCharDelay` helper (defense in depth) and forwarded as `char_delay_ms` in the RPC payload. Returns `undefined` when unset so the daemon applies its own 4ms default.
3. **Clamp enforced on both sides** — daemon `min(250, max(1, … ?? 4))`; CLI `clampCharDelay` mirrors `[1, 250]` and truncates fractional input.

## Tests

`src/commands/computer-actions.test.ts` — 6 new `clampCharDelay` cases (default/unset, typical 25, floor, ceiling, boundaries, fractional+NaN). Full file: 36 tests pass. No Swift XCTest target exists in `Package.swift`, so the clamp is covered CLI-side plus the real-flow timing run below.

## Verified

- `swift build` (daemon) — compiles clean (one pre-existing unrelated deprecation warning).
- `bun run build` (TS) — `tsc` passes.
- `bunx vitest run src/commands/computer-actions.test.ts` — 36/36 pass.
- `agents computer type-text --help` renders `--char-delay <ms>`.
- **Real-flow timing** driving the freshly-built daemon (`trust_status: trusted:true`) into a focused TextEdit, 18-char string:
  - `char_delay_ms=1` → 34ms
  - `char_delay_ms=250` → 4530ms (≈ 18 × 250)
  - `char_delay_ms=5000` → 4533ms — **clamped to 250** (would be ~90s unclamped)
  - All three: daemon returned `{"ok":true,"chars":18,"frontmost":true}`.

This proves parse + clamp + delay-applied through the new daemon code.

## Needs the reporter's VM

The issue's acceptance criterion — ~10 consecutive 28+-char `type-text` runs into a Parallels guest with `--char-delay 25` delivering without drops — requires the reporter's Parallels Windows 11 guest. That is not reproducible on this host; the drop is inside the guest's keyboard relay. The mechanism (slower inter-char rate via `--char-delay`) is implemented and verified locally.

## Follow-up (separate repo)

The skill-doc note — recommending `--char-delay 25` (or higher) for lossy relays / VM guests in `skills/computer/SKILL.md` — lives in the **`.agents-system`** repo (`gh:phnx-labs/.agents-system`), not this one. Tracked as a follow-up there; intentionally not touched here.