### PR TITLE
fix(plugins): make `plugins sync` version-aware; stop crashing on agent@version

### DIFF
--- a/src/commands/plugins.ts
+++ b/src/commands/plugins.ts
@@ -347,14 +347,17 @@ Examples:
   // agents plugins sync <name> [agent]
   pluginsCmd
     .command('sync <name> [agent]')
-    .description('Apply a plugin to the default version of an agent (or all supported agents if none specified)')
+    .description('Apply a plugin to an agent. Syncs every installed version (pass agent@version to target one).')
     .option('--allow-exec-surfaces', 'Enable the plugin even when it ships hooks/, .mcp.json, bin/, scripts/, settings.json, or permissions/')
     .addHelpText('after', `
 Examples:
-  # Sync a plugin to a specific agent (default version)
+  # Sync a plugin to every installed version of an agent
   agents plugins sync rush-toolkit claude
 
-  # Sync to all supported agents
+  # Sync to one specific version (parity with 'agents sync')
+  agents plugins sync rush-toolkit claude@2.1.142
+
+  # Sync to all supported agents (every installed version of each)
   agents plugins sync rush-toolkit
 
   # Re-affirm consent for a hooks-bearing plugin
@@ -367,12 +370,23 @@ Examples:
         process.exit(1);
       }
 
+      // Accept the same "agent@version" form as `agents sync`. Splitting here
+      // also means an unknown spec is reported cleanly rather than crashing
+      // isCapable() with a bare "claude@2.1.168".
+      let versionArg: string | undefined;
+      let agentName: string | undefined = agentArg;
+      if (agentArg && agentArg.includes('@')) {
+        const at = agentArg.lastIndexOf('@');
+        agentName = agentArg.slice(0, at);
+        versionArg = agentArg.slice(at + 1);
+      }
+
       // Determine target agents
       let targetAgents: AgentId[];
-      if (agentArg) {
-        const agentId = agentArg as AgentId;
+      if (agentName) {
+        const agentId = agentName as AgentId;
         if (!isCapable(agentId, 'plugins')) {
-          console.log(chalk.red(`Agent '${agentArg}' does not support plugins`));
+          console.log(chalk.red(`Agent '${agentName}' does not support plugins`));
           process.exit(1);
         }
         if (!pluginSupportsAgent(plugin, agentId)) {
@@ -381,6 +395,10 @@ Examples:
         }
         targetAgents = [agentId];
       } else {
+        if (versionArg) {
+          console.log(chalk.red(`A version (@${versionArg}) requires naming the agent, e.g. claude@${versionArg}`));
+          process.exit(1);
+        }
         targetAgents = capableAgents('plugins').filter(a => pluginSupportsAgent(plugin, a));
       }
 
@@ -390,8 +408,20 @@ Examples:
         const versions = listInstalledVersions(agentId);
         if (versions.length === 0) continue;
 
-        const defaultVer = getGlobalDefault(agentId);
-        const targetVersions = defaultVer ? [defaultVer] : [versions[versions.length - 1]];
+        // Default to EVERY installed version. The previous behaviour synced only
+        // the global default, which silently skipped non-default versions used
+        // by balanced rotation -- so a rotated version would lack the plugin's
+        // slash commands. An explicit agent@version narrows back to one.
+        let targetVersions: string[];
+        if (versionArg) {
+          if (!versions.includes(versionArg)) {
+            console.log(chalk.red(`${agentLabel(agentId)} has no installed version ${versionArg} (installed: ${versions.join(', ')})`));
+            process.exit(1);
+          }
+          targetVersions = [versionArg];
+        } else {
+          targetVersions = versions;
+        }
 
         for (const version of targetVersions) {
           const didSync = allowExec

--- a/src/lib/__tests__/capabilities.test.ts
+++ b/src/lib/__tests__/capabilities.test.ts
@@ -92,6 +92,15 @@ describe('isCapable()', () => {
     expect(isCapable('cursor', 'hooks')).toBe(false);
     expect(isCapable('opencode', 'plugins')).toBe(false);
   });
+
+  it('reports false for an unknown agent id instead of throwing (RUSH-1153)', () => {
+    // A caller passing "claude@2.1.168" (the agent@version form) instead of a
+    // bare "claude" must not crash with "Cannot read properties of undefined
+    // (reading 'capabilities')". getCapability() guards the unknown id.
+    expect(() => isCapable('claude@2.1.168' as never, 'plugins')).not.toThrow();
+    expect(isCapable('claude@2.1.168' as never, 'plugins')).toBe(false);
+    expect(supports('not-an-agent' as never, 'plugins')).toEqual({ ok: false, reason: 'unsupported' });
+  });
 });
 
 describe('capableAgents()', () => {

--- a/src/lib/capabilities.ts
+++ b/src/lib/capabilities.ts
@@ -33,7 +33,12 @@ function compareVersions(a: string, b: string): number {
 }
 
 function getCapability(agent: AgentId, cap: CapabilityName): Capability | RulesCapability {
-  return AGENTS[agent].capabilities[cap];
+  // Guard against unknown agent ids (e.g. a caller passing "claude@2.1.168"
+  // instead of "claude"). Without this, AGENTS[agent] is undefined and the
+  // property access throws an opaque TypeError instead of reporting false.
+  const def = AGENTS[agent];
+  if (!def) return false;
+  return def.capabilities[cap];
 }
 
 /**


### PR DESCRIPTION
## Problem

`agents plugins sync <plugin> <agent>` only ever synced the **global default** version:

```ts
const defaultVer = getGlobalDefault(agentId);
const targetVersions = defaultVer ? [defaultVer] : [versions[versions.length - 1]];
```

With balanced rotation across multiple installed versions, any plugin synced this way landed only on the default. Non-default versions drifted and silently lost the plugin's slash commands — e.g. `/code:loop` was missing when `agents run claude` rotated to `claude@2.1.168`, while it worked on the default `2.1.170`.

Worse, trying to target a specific version crashed:

```
$ agents plugins sync code claude@2.1.168
TypeError: Cannot read properties of undefined (reading 'capabilities')
    at getCapability (lib/capabilities.ts) → isCapable → commands/plugins.ts
```

The `[agent]` positional was passed straight to `isCapable()`; `AGENTS['claude@2.1.168']` is `undefined`. The sibling `agents sync` command already accepts `agent@version` (`"claude" or "claude@2.1.142"`), so this was both a crash and an inconsistency.

## Fix

- **`commands/plugins.ts`** — parse the `agent@version` form (parity with `agents sync`). Default (no version) now syncs **every installed version** instead of only the global default, so rotated versions stay consistent. An explicit `@version` narrows to one and validates it's actually installed.
- **`lib/capabilities.ts`** — `getCapability()` guards unknown agent ids (returns `false` instead of dereferencing `undefined`).
- **test** — regression covering the unknown-agent-id guard (the assertion that catches the crash).

## Verification

- `tsc --noEmit` clean
- `vitest run` — capabilities 21/21 (incl. new regression), plugins suites 72/72
- End-to-end against the built `dist/`:
  - `plugins sync agents claude@2.1.168` → `Synced agents to Claude@2.1.168` (was the crash)
  - `plugins sync agents claude@9.9.9` → `Claude has no installed version 9.9.9 (installed: ...)` (clean error, no stack trace)

## Notes / follow-ups (not in this PR)

- The shim runs launch-sync as `... --launch --quiet 2>/dev/null || true` (`lib/shims.js`), which swallows every error — so a failed per-version sync is invisible. Worth surfacing separately.
- When a plugin's winning scope changes, stale `<plugin>@<scope>` entries linger in `installed_plugins.json` (`pruneLosingScopeEnables` only cleans `settings.json`).

Tracked internally as RUSH-1153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
