### PR TITLE
feat(versions): add @oldest version alias wherever @latest is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Think `requirements.txt` for CLI coding agents, on steroids. A shim reads `agent
 ```bash
 agents add claude@2.0.65     # Install a specific version
 agents add codex@latest       # Install latest
+agents add codex@oldest       # Install the oldest published version
 agents view                   # See everything installed
 ```
 

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -157,8 +157,9 @@ function parseMcpAgentTargets(value: string): {
       continue;
     }
 
-    const resolvedVersion = versionToken === 'latest'
-      ? installedVersions[installedVersions.length - 1]
+    const resolvedVersion =
+      versionToken === 'latest' ? installedVersions[installedVersions.length - 1]
+      : versionToken === 'oldest' ? installedVersions[0]
       : versionToken;
 
     if (!installedVersions.includes(resolvedVersion)) {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -93,7 +93,7 @@ async function runSync(agentSpec: string | undefined, opts: SyncOpts): Promise<v
       return;
     }
     agentId = parsed.agent;
-    if (parsed.version !== 'latest') version = parsed.version;
+    if (parsed.version !== 'latest' && parsed.version !== 'oldest') version = parsed.version;
   }
 
   if (opts.agent) {

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -38,6 +38,7 @@ import {
   listInstalledVersions,
   isVersionInstalled,
   isLatestInstalled,
+  isOldestInstalled,
   getGlobalDefault,
   setGlobalDefault,
   getVersionHomePath,
@@ -87,18 +88,6 @@ function fixSessionFilePaths(agent: AgentId, version: string, oldVersionDir: str
   if (stamps.length === 0) return;
   const trashPath = path.join(trashAgentDir, stamps[0]);
   updateSessionFilePaths(oldVersionDir, trashPath);
-}
-
-/**
- * Helper to get actual installed version for an agent.
- * Returns the latest installed version, or throws if none installed.
- */
-async function getInstalledVersionForAgent(agent: AgentId): Promise<string> {
-  const versions = listInstalledVersions(agent);
-  if (versions.length > 0) {
-    return versions[versions.length - 1];
-  }
-  throw new Error(`No versions of ${agent} installed`);
 }
 
 function formatAccountHint(info: AccountInfo, usage: UsageSnapshot | null): string {
@@ -173,7 +162,7 @@ async function versionPruneAction(
     const { agent, version } = parsed;
     const agentConfig = AGENTS[agent];
 
-    if (version === 'latest' || !spec.includes('@')) {
+    if (version === 'latest' || version === 'oldest' || !spec.includes('@')) {
       const versions = listInstalledVersions(agent);
       if (versions.length === 0) {
         console.log(chalk.gray(`No versions of ${agentLabel(agentConfig.id)} installed`));
@@ -307,6 +296,9 @@ export function registerVersionsCommands(program: Command): void {
       # Install the latest version of an agent
       agents add claude@latest
 
+      # Install the oldest published version of an agent
+      agents add claude@oldest
+
       # Install a specific version (reproducibility)
       agents add claude@2.1.112
 
@@ -343,7 +335,7 @@ export function registerVersionsCommands(program: Command): void {
           continue;
         }
 
-        // Check if already installed (handle 'latest' specially)
+        // Check if already installed (resolve 'latest'/'oldest' against npm first)
         let alreadyInstalled = false;
         let installedAsVersion = version;
         if (version === 'latest') {
@@ -351,6 +343,12 @@ export function registerVersionsCommands(program: Command): void {
           if (latestCheck.installed && latestCheck.version) {
             alreadyInstalled = true;
             installedAsVersion = latestCheck.version;
+          }
+        } else if (version === 'oldest') {
+          const oldestCheck = await isOldestInstalled(agent);
+          if (oldestCheck.installed && oldestCheck.version) {
+            alreadyInstalled = true;
+            installedAsVersion = oldestCheck.version;
           }
         } else {
           alreadyInstalled = isVersionInstalled(agent, version);
@@ -378,6 +376,9 @@ export function registerVersionsCommands(program: Command): void {
             }
 
             const installedVersion = result.installedVersion || version;
+            // Track the concrete version so a `--project` pin records it instead
+            // of the `latest`/`oldest` alias.
+            installedAsVersion = installedVersion;
 
             // Seed the fresh version home with user settings from the current
             // default version (settings.json, keybindings, codex config/auth).
@@ -528,7 +529,9 @@ export function registerVersionsCommands(program: Command): void {
             : createDefaultManifest();
 
           manifest.agents = manifest.agents || {};
-          manifest.agents[agent] = version === 'latest' ? (await getInstalledVersionForAgent(agent)) : version;
+          manifest.agents[agent] = (version === 'latest' || version === 'oldest')
+            ? installedAsVersion
+            : version;
 
           writeManifest(process.cwd(), manifest);
           console.log(chalk.green(`  Pinned ${agentLabel(agentConfig.id)}@${version} in .agents/agents.yaml`));
@@ -585,7 +588,7 @@ export function registerVersionsCommands(program: Command): void {
             return;
           }
           agent = parsed.agent;
-          version = parsed.version === 'latest' ? undefined : parsed.version;
+          version = (parsed.version === 'latest' || parsed.version === 'oldest') ? undefined : parsed.version;
         } else {
           const agentLower = agentArg.toLowerCase();
           if (!AGENTS[agentLower as AgentId]) {

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -930,6 +930,26 @@ export async function getLatestNpmVersion(agent: AgentId): Promise<string | null
 }
 
 /**
+ * Get the oldest published version from npm for an agent.
+ */
+export async function getOldestNpmVersion(agent: AgentId): Promise<string | null> {
+  const agentConfig = AGENTS[agent];
+  if (!agentConfig.npmPackage) return null;
+
+  try {
+    const { stdout } = await execFileAsync('npm', ['view', agentConfig.npmPackage, 'versions', '--json'], { shell: process.platform === 'win32' });
+    const parsed = JSON.parse(stdout.trim());
+    // `npm view ... versions --json` returns an array (multiple versions) or a
+    // bare string (single published version). Normalize to an array.
+    const versions: string[] = Array.isArray(parsed) ? parsed : [parsed];
+    const sorted = versions.filter((v) => VERSION_RE.test(v)).sort(compareVersions);
+    return sorted[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Check if 'latest' version is already installed (by resolving to actual version).
  */
 export async function isLatestInstalled(agent: AgentId): Promise<{ installed: boolean; version: string | null }> {
@@ -938,6 +958,17 @@ export async function isLatestInstalled(agent: AgentId): Promise<{ installed: bo
     return { installed: false, version: null };
   }
   return { installed: isVersionInstalled(agent, latestVersion), version: latestVersion };
+}
+
+/**
+ * Check if 'oldest' published version is already installed (by resolving to actual version).
+ */
+export async function isOldestInstalled(agent: AgentId): Promise<{ installed: boolean; version: string | null }> {
+  const oldestVersion = await getOldestNpmVersion(agent);
+  if (!oldestVersion) {
+    return { installed: false, version: null };
+  }
+  return { installed: isVersionInstalled(agent, oldestVersion), version: oldestVersion };
 }
 
 /**
@@ -1093,6 +1124,21 @@ export async function installVersion(
     createVersionedAlias(agent, installedVersion);
     emit('version.install', { agent, version: installedVersion });
     return { success: true, installedVersion };
+  }
+
+  // Resolve the `oldest` alias to a concrete npm version up front so the rest
+  // of the install path treats it as an ordinary pinned install. (`latest`
+  // keeps its bare-package-name + post-install-rename handling below.)
+  if (version === 'oldest') {
+    const oldest = await getOldestNpmVersion(agent);
+    if (!oldest) {
+      return {
+        success: false,
+        installedVersion: version,
+        error: `Could not resolve the oldest published version for ${agentConfig.name} from npm.`,
+      };
+    }
+    version = oldest;
   }
 
   ensureAgentsDir();
@@ -1339,6 +1385,7 @@ export function resolveVersion(agent: AgentId, projectPath?: string): string | n
  *
  *   undefined / "" / "default"  -> undefined  (caller falls back to project pin or global default)
  *   "latest"                    -> highest installed version (process.exit if none installed)
+ *   "oldest"                    -> lowest installed version (process.exit if none installed)
  *   "x.y.z" (installed)         -> "x.y.z"
  *   "x.y.z" (not installed)     -> process.exit with installed-list hint
  *
@@ -1350,14 +1397,14 @@ export function resolveVersion(agent: AgentId, projectPath?: string): string | n
 export function resolveVersionAlias(agent: AgentId, raw: string | undefined | null): string | undefined {
   if (!raw || raw === 'default') return undefined;
 
-  if (raw === 'latest') {
+  if (raw === 'latest' || raw === 'oldest') {
     const installed = listInstalledVersions(agent);
     if (installed.length === 0) {
       console.error(chalk.red(`No ${agent} versions installed.`));
       console.error(chalk.gray(`Install one: agents versions install ${agent}`));
       process.exit(1);
     }
-    return installed[installed.length - 1];
+    return raw === 'oldest' ? installed[0] : installed[installed.length - 1];
   }
 
   if (!isVersionInstalled(agent, raw)) {
@@ -1374,15 +1421,16 @@ export function resolveVersionAlias(agent: AgentId, raw: string | undefined | nu
 
 /**
  * Loose variant of resolveVersionAlias for record-filter contexts (sessions,
- * team history). Same `default`/`latest` semantics, but explicit versions
- * pass through unchanged so historical records of uninstalled versions remain
- * queryable.
+ * team history). Same `default`/`latest`/`oldest` semantics, but explicit
+ * versions pass through unchanged so historical records of uninstalled versions
+ * remain queryable.
  */
 export function resolveVersionAliasLoose(agent: AgentId, raw: string | undefined | null): string | undefined {
   if (!raw || raw === 'default') return undefined;
-  if (raw === 'latest') {
+  if (raw === 'latest' || raw === 'oldest') {
     const installed = listInstalledVersions(agent);
-    return installed.length > 0 ? installed[installed.length - 1] : undefined;
+    if (installed.length === 0) return undefined;
+    return raw === 'oldest' ? installed[0] : installed[installed.length - 1];
   }
   return raw;
 }

--- a/tests/versions.test.ts
+++ b/tests/versions.test.ts
@@ -153,6 +153,8 @@ import {
   resolveAgentVersionTargets,
   resolveInstalledAgentTargets,
   resolveConfiguredAgentTargets,
+  resolveVersionAlias,
+  resolveVersionAliasLoose,
   compareVersions,
   getNewResources,
   hasNewResources,
@@ -228,6 +230,11 @@ describe('parseAgentSpec', () => {
     expect(result).toEqual({ agent: 'gemini', version: 'latest' });
   });
 
+  it('handles explicit oldest', () => {
+    const result = parseAgentSpec('gemini@oldest');
+    expect(result).toEqual({ agent: 'gemini', version: 'oldest' });
+  });
+
   it('normalizes agent name to lowercase', () => {
     const result = parseAgentSpec('CLAUDE@1.0.0');
     expect(result).toEqual({ agent: 'claude', version: '1.0.0' });
@@ -252,6 +259,62 @@ describe('parseAgentSpec', () => {
       expect(result).not.toBeNull();
       expect(result!.agent).toBe(agent);
     }
+  });
+});
+
+describe('resolveVersionAlias', () => {
+  it('resolves "latest" to the highest installed version', () => {
+    installManagedVersion('claude', '2.0.0');
+    installManagedVersion('claude', '2.1.0');
+    installManagedVersion('claude', '2.0.5');
+
+    expect(resolveVersionAlias('claude', 'latest')).toBe('2.1.0');
+  });
+
+  it('resolves "oldest" to the lowest installed version', () => {
+    installManagedVersion('claude', '2.0.0');
+    installManagedVersion('claude', '2.1.0');
+    installManagedVersion('claude', '2.0.5');
+
+    expect(resolveVersionAlias('claude', 'oldest')).toBe('2.0.0');
+  });
+
+  it('returns undefined for default/empty', () => {
+    expect(resolveVersionAlias('claude', 'default')).toBeUndefined();
+    expect(resolveVersionAlias('claude', '')).toBeUndefined();
+    expect(resolveVersionAlias('claude', undefined)).toBeUndefined();
+  });
+
+  it('passes an installed explicit version through unchanged', () => {
+    installManagedVersion('codex', '0.1.0');
+    installManagedVersion('codex', '0.2.0');
+
+    expect(resolveVersionAlias('codex', '0.1.0')).toBe('0.1.0');
+  });
+});
+
+describe('resolveVersionAliasLoose', () => {
+  it('resolves "oldest" to the lowest installed version', () => {
+    installManagedVersion('codex', '0.1.0');
+    installManagedVersion('codex', '0.2.0');
+
+    expect(resolveVersionAliasLoose('codex', 'oldest')).toBe('0.1.0');
+  });
+
+  it('resolves "latest" to the highest installed version', () => {
+    installManagedVersion('codex', '0.1.0');
+    installManagedVersion('codex', '0.2.0');
+
+    expect(resolveVersionAliasLoose('codex', 'latest')).toBe('0.2.0');
+  });
+
+  it('returns undefined for "oldest"/"latest" when nothing is installed', () => {
+    expect(resolveVersionAliasLoose('codex', 'oldest')).toBeUndefined();
+    expect(resolveVersionAliasLoose('codex', 'latest')).toBeUndefined();
+  });
+
+  it('passes uninstalled explicit versions through unchanged', () => {
+    expect(resolveVersionAliasLoose('codex', '9.9.9')).toBe('9.9.9');
   });
 });
 


### PR DESCRIPTION
## What

Adds a parallel `@oldest` version specifier alongside the existing `@latest`, supported everywhere `@latest` is.

```bash
agents add claude@oldest        # install the oldest published version
agents view claude@oldest       # resolve to the lowest installed version
agents run/exec/mcp/sync ... @oldest
```

## How

- **`resolveVersionAlias` / `resolveVersionAliasLoose`** — `"oldest"` resolves to `installed[0]` (lowest), mirroring `"latest"` → `installed[last]`. Both rely on the existing `compareVersions` ascending sort.
- **`getOldestNpmVersion` / `isOldestInstalled`** — npm-side resolution for the install path: `npm view <pkg> versions --json`, filter via `VERSION_RE`, sort with `compareVersions`, take the lowest.
- **`installVersion`** — resolves the `oldest` alias to a concrete npm version up front so the rest of the install path treats it as an ordinary pinned install.
- **`add` / `remove` / `use` / `prune`, `sync`, `mcp` targets** — treat `oldest` symmetrically with `latest`.
- A `--project` pin records the concrete resolved version, not the alias.

## Tests

- `parseAgentSpec('gemini@oldest')`, `resolveVersionAlias`/`resolveVersionAliasLoose` for both `oldest` and `latest`, plus empty/uninstalled passthrough cases.
- Full `tests/versions.test.ts`: **99/99 pass** on this branch (off current `main`).

## End-to-end verification

Built `dist/` and ran against real installed versions (`2.1.142, 2.1.168, 2.1.170, 2.1.181`):

| command | resolved |
|---|---|
| `view claude@oldest` | `2.1.142` (lowest) |
| `view claude@latest` | `2.1.181` (highest) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)