### PR TITLE
[codex] fix picker preview overflow

### DIFF
--- a/src/lib/picker.test.ts
+++ b/src/lib/picker.test.ts
@@ -1,0 +1,35 @@
+import { stripVTControlCharacters } from 'node:util';
+import { describe, expect, it } from 'vitest';
+import { limitPreviewHeight } from './picker.js';
+
+function renderedRows(text: string, width: number): number {
+  return text.split('\n').reduce((rows, line) => {
+    const visible = stripVTControlCharacters(line).length;
+    return rows + Math.max(1, Math.ceil(visible / width));
+  }, 0);
+}
+
+describe('limitPreviewHeight', () => {
+  it('leaves previews unchanged when they fit', () => {
+    const preview = ['title', 'body', 'footer'].join('\n');
+
+    expect(limitPreviewHeight(preview, 3, 80)).toBe(preview);
+  });
+
+  it('clips multi-line previews to the row budget', () => {
+    const preview = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join('\n');
+    const clipped = limitPreviewHeight(preview, 4, 80);
+
+    expect(renderedRows(clipped, 80)).toBeLessThanOrEqual(4);
+    expect(stripVTControlCharacters(clipped)).toContain('preview truncated');
+    expect(stripVTControlCharacters(clipped)).not.toContain('line 10');
+  });
+
+  it('accounts for wrapped long lines before adding the truncation marker', () => {
+    const preview = 'x'.repeat(200);
+    const clipped = limitPreviewHeight(preview, 3, 20);
+
+    expect(renderedRows(clipped, 20)).toBeLessThanOrEqual(3);
+    expect(stripVTControlCharacters(clipped)).toContain('truncated');
+  });
+});

--- a/src/lib/picker.ts
+++ b/src/lib/picker.ts
@@ -30,6 +30,7 @@ import {
   Separator,
 } from '@inquirer/core';
 import chalk from 'chalk';
+import { stripVTControlCharacters } from 'node:util';
 
 /** Configuration for the interactive picker prompt. */
 export interface PickerConfig<T> {
@@ -53,6 +54,95 @@ export interface PickedItem<T> {
 interface Choice<T> {
   value: T;
   label: string;
+}
+
+const DEFAULT_TERMINAL_ROWS = 24;
+const DEFAULT_TERMINAL_WIDTH = 80;
+
+function terminalWidth(): number {
+  return Math.max(1, process.stdout.columns || DEFAULT_TERMINAL_WIDTH);
+}
+
+function terminalRows(): number {
+  return Math.max(1, process.stdout.rows || DEFAULT_TERMINAL_ROWS);
+}
+
+function renderedRows(text: string, width: number): number {
+  const normalizedWidth = Math.max(1, width);
+  return text.split('\n').reduce((rows, line) => {
+    const visible = stripVTControlCharacters(line).length;
+    return rows + Math.max(1, Math.ceil(visible / normalizedWidth));
+  }, 0);
+}
+
+function truncateAnsiLine(line: string, maxVisibleWidth: number): string {
+  if (maxVisibleWidth <= 0) return '';
+
+  const targetWidth = Math.max(0, maxVisibleWidth - 1);
+  const ansiPattern = /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))/y;
+  let out = '';
+  let visible = 0;
+
+  for (let i = 0; i < line.length;) {
+    ansiPattern.lastIndex = i;
+    const ansi = ansiPattern.exec(line);
+    if (ansi) {
+      out += ansi[0];
+      i = ansiPattern.lastIndex;
+      continue;
+    }
+
+    const char = line[i];
+    if (visible >= targetWidth) break;
+    out += char;
+    visible += 1;
+    i += char.length;
+  }
+
+  return out + '\x1b[0m' + chalk.gray('…');
+}
+
+function takePreviewRows(preview: string, rowBudget: number, width: number): string[] {
+  const lines = preview.split('\n');
+  const out: string[] = [];
+  let used = 0;
+
+  for (const line of lines) {
+    const lineRows = renderedRows(line, width);
+    if (used + lineRows <= rowBudget) {
+      out.push(line);
+      used += lineRows;
+      continue;
+    }
+
+    const remainingRows = rowBudget - used;
+    if (remainingRows > 0) {
+      out.push(truncateAnsiLine(line, remainingRows * width));
+    }
+    break;
+  }
+
+  return out;
+}
+
+function previewTruncatedMarker(width: number): string {
+  const full = '... preview truncated to fit terminal';
+  const short = '... truncated';
+  const text = full.length <= width ? full : short;
+  if (text.length <= width) return chalk.gray(text);
+  return chalk.gray(text.slice(0, Math.max(0, width - 1)) + '…');
+}
+
+/** Clip a picker preview so the full prompt can fit in the terminal viewport. */
+export function limitPreviewHeight(preview: string, maxRows: number, width: number): string {
+  const normalizedRows = Math.max(0, maxRows);
+  if (normalizedRows === 0) return '';
+  if (renderedRows(preview, width) <= normalizedRows) return preview;
+  if (normalizedRows === 1) return previewTruncatedMarker(width);
+
+  const lines = takePreviewRows(preview, normalizedRows - 1, width);
+  lines.push(previewTruncatedMarker(width));
+  return lines.join('\n');
 }
 
 /** Show an interactive fuzzy-filter picker and return the selected item, or null on cancel. */
@@ -142,22 +232,34 @@ export function itemPicker<T>(config: PickerConfig<T>): Promise<PickedItem<T> | 
       loop: false,
     });
 
-    const parts: string[] = [header, page];
-    if (results.length === 0) {
-      parts.push(chalk.gray(`  ${cfg.emptyMessage ?? 'No matches.'}`));
-    }
-
-    if (previewOpen && selected && cfg.buildPreview) {
-      parts.push(chalk.gray('─'.repeat(Math.min(process.stdout.columns || 80, 80))));
-      parts.push(cfg.buildPreview(selected.value));
-    }
-
     const enter = cfg.enterHint ?? 'select';
     const help = previewOpen
       ? chalk.gray(`↑↓ navigate · space: close preview · ⏎ ${enter} · esc: cancel`)
       : chalk.gray(
           `↑↓ navigate${hasPreview ? ' · space: preview' : ''} · ⏎ ${enter} · esc: cancel`
         );
+
+    const parts: string[] = [header, page];
+    if (results.length === 0) {
+      parts.push(chalk.gray(`  ${cfg.emptyMessage ?? 'No matches.'}`));
+    }
+
+    if (previewOpen && selected && cfg.buildPreview) {
+      const width = terminalWidth();
+      const separator = chalk.gray('─'.repeat(Math.min(width, 80)));
+      const fixedRows =
+        renderedRows(header, width) +
+        renderedRows(parts.slice(1).join('\n'), width) +
+        renderedRows(separator, width) +
+        renderedRows(help, width);
+      const availablePreviewRows = terminalRows() - fixedRows;
+      const preview = limitPreviewHeight(cfg.buildPreview(selected.value), availablePreviewRows, width);
+      if (preview) {
+        parts.push(separator);
+        parts.push(preview);
+      }
+    }
+
     parts.push(help);
 
     return [header, parts.slice(1).join('\n')];


### PR DESCRIPTION
## What Changed

Clips long interactive picker previews to the available terminal viewport instead of rendering the entire preview pane.

The shared picker now:
- counts rendered terminal rows after ANSI stripping
- accounts for line wrapping at the current terminal width
- reserves space for the header, page rows, separator, and footer help text
- adds a truncation marker when a preview is clipped

## Root Cause

`agents plugins` passes rich plugin detail text into the shared picker. For plugins with long descriptions or many synced resources, the picker rendered the full preview. Inquirer then had to redraw a frame taller than the terminal viewport, so the top of the prompt/list was pushed into scrollback.

## Before / After Evidence

Before this change, the real PTY reproduction of `bun run dev plugins` with a long plugin preview ended with `ESC[44A`, meaning the prompt frame was 44 rows tall. On a normal terminal that hides the top rows, matching the reported screenshot.

After this change, the same real flow on this branch, selecting the `code` plugin row, ended with `ESC[23A`. The header/list stayed visible and the preview showed:

```text
code v0.6.1
code - coding-workflow plugin. Sub-skills for the manager/router engineering loop...
... preview truncated to fit terminal
up/down navigate - space: close preview - enter view - esc: cancel
```

## Validation

- `bun test src/commands/plugins.test.ts src/lib/picker.test.ts src/commands/resource-view.test.ts`
  - Worktree result: 7 passing tests across the files present on `origin/main` plus the new picker test.
- `bun run build`
  - Exit code 0.
  - The isolated worktree printed a non-fatal `cp: bin/Agents CLI.app: No such file or directory` after `tsc`; the script guards that copy with `|| true`.
- Real PTY check:
  - `bun run dev plugins`
  - declined the unrelated shim repair prompt
  - selected the `code` row
  - confirmed the picker frame fits at 23 rows with the truncation marker visible
