### PR TITLE
fix(run): make --headless / --interactive flags definitive for mode resolution

### DIFF
--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -12,8 +12,14 @@ Dispatch a single agent for a one-off task. `agents run` is the fundamental comm
 
 ## Headless vs interactive
 
-- **Prompt provided** → headless. Pipes stdout, no TTY, exits when the agent finishes.
-- **Prompt omitted** → interactive. Launches the agent's TUI with full stdio inheritance.
+Explicit flags are definitive; otherwise the mode is inferred from prompt presence:
+
+- `--interactive` (`-i`) → always interactive, even with a prompt (the prompt is forwarded as the first message).
+- `--headless` → always headless, even with no prompt (the prompt is read from stdin).
+- Neither flag, **prompt provided** → headless. Pipes stdout, no TTY, exits when the agent finishes.
+- Neither flag, **prompt omitted** → interactive. Launches the agent's TUI with full stdio inheritance.
+
+`--interactive` and `--headless` are mutually exclusive — passing both errors out.
 
 ```bash
 # Interactive (TUI)

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -85,8 +85,8 @@ export function registerRunCommand(program: Command): void {
     )
     .option('--json', 'Stream events as JSON lines (for parsing by other tools)')
     .option('--quiet', 'Suppress preamble (rotation banner, "Running:" line). Useful when piping JSON events to a parser.', false)
-    .option('--headless', 'Non-interactive mode (auto-enabled when prompt provided)', false)
-    .option('-i, --interactive', 'Force interactive mode even when a prompt is provided')
+    .option('--headless', 'Force headless mode. Auto-enabled when a prompt is provided; pass explicitly to stay headless with no prompt (reads the prompt from stdin).', false)
+    .option('-i, --interactive', 'Force interactive mode even when a prompt is provided. Mutually exclusive with --headless.')
     .option('--session-id <id>', 'Resume a previous conversation (Claude only)')
     .option('--verbose', 'Show detailed execution logs')
     .option('--timeout <duration>', 'Kill the agent after this duration (e.g., 30m, 1h, 2h30m)')
@@ -443,12 +443,17 @@ export function registerRunCommand(program: Command): void {
         model,
         addDirs: options.addDir,
         json: options.json,
-        headless: options.headless ?? true,
+        headless: options.headless,
         sessionId: options.sessionId,
         verbose: options.verbose,
         timeout: options.timeout,
         env,
       };
+
+      if (options.interactive && options.headless) {
+        console.error(chalk.red('--interactive and --headless are mutually exclusive. Pass one, or neither (mode is inferred from prompt presence).'));
+        process.exit(1);
+      }
 
       if (options.interactive) {
         if (options.fallback) {

--- a/src/lib/__tests__/exec.test.ts
+++ b/src/lib/__tests__/exec.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildExecCommand,
+  resolveInteractive,
   buildExecEnv,
   buildFallbackPrompt,
   detectRateLimit,
@@ -278,14 +279,62 @@ describe('buildExecCommand', () => {
       expect(cmd).toContain('fix auth');
     });
 
-    it('no prompt behaves as interactive by default (no --print)', () => {
-      const cmd = buildExecCommand(opts({ agent: 'claude', prompt: undefined, headless: true }));
+    it('no prompt and no flag behaves as interactive by default (no --print)', () => {
+      const cmd = buildExecCommand(opts({ agent: 'claude', prompt: undefined }));
       expect(cmd).not.toContain('--print');
     });
 
     it('prompt without interactive behaves as headless (adds --print)', () => {
       const cmd = buildExecCommand(opts({ agent: 'claude', prompt: 'fix auth', headless: true }));
       expect(cmd).toContain('--print');
+    });
+
+    it('--headless with no prompt forces headless (adds --print, reads stdin)', () => {
+      const cmd = buildExecCommand(opts({ agent: 'claude', prompt: undefined, headless: true }));
+      expect(cmd).toContain('--print');
+    });
+
+    it('--headless with no prompt keeps codex in headless exec subcommand', () => {
+      const cmd = buildExecCommand(opts({ agent: 'codex', mode: 'edit', prompt: undefined, headless: true }));
+      expect(cmd.slice(0, 2)).toEqual(['codex', 'exec']);
+    });
+
+    it('no flag and no prompt drops the codex exec subcommand (interactive TUI)', () => {
+      const cmd = buildExecCommand(opts({ agent: 'codex', mode: 'edit', prompt: undefined }));
+      expect(cmd[0]).toBe('codex');
+      expect(cmd).not.toContain('exec');
+    });
+  });
+
+  // --- resolveInteractive precedence ---
+
+  describe('resolveInteractive precedence', () => {
+    it('no flags + no prompt -> interactive', () => {
+      expect(resolveInteractive({ prompt: undefined })).toBe(true);
+    });
+
+    it('no flags + prompt -> headless', () => {
+      expect(resolveInteractive({ prompt: 'do x' })).toBe(false);
+    });
+
+    it('--headless + no prompt -> headless (definitive)', () => {
+      expect(resolveInteractive({ prompt: undefined, headless: true })).toBe(false);
+    });
+
+    it('--headless + prompt -> headless', () => {
+      expect(resolveInteractive({ prompt: 'do x', headless: true })).toBe(false);
+    });
+
+    it('--interactive + no prompt -> interactive', () => {
+      expect(resolveInteractive({ prompt: undefined, interactive: true })).toBe(true);
+    });
+
+    it('--interactive + prompt -> interactive (definitive)', () => {
+      expect(resolveInteractive({ prompt: 'do x', interactive: true })).toBe(true);
+    });
+
+    it('--interactive wins over --headless at the resolver level', () => {
+      expect(resolveInteractive({ prompt: 'do x', interactive: true, headless: true })).toBe(true);
     });
   });
 

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -92,11 +92,12 @@ export interface ExecOptions {
   version?: string;
   /** Omit to launch the CLI interactively -- no prompt, no --print, stdio fully inherited. */
   prompt?: string;
-  /** Force interactive mode even when a prompt is provided. */
+  /** Force interactive mode even when a prompt is provided. Wins over `headless`. */
   interactive?: boolean;
   mode: ExecMode;
   effort: ExecEffort;
   cwd?: string;
+  /** Force headless mode even when no prompt is provided (e.g. piping via stdin). */
   headless?: boolean;
   json?: boolean;
   model?: string;
@@ -105,6 +106,20 @@ export interface ExecOptions {
   sessionId?: string;
   verbose?: boolean;
   env?: Record<string, string>;
+}
+
+/**
+ * Resolve interactive vs headless. Explicit flags are definitive and win over
+ * inference: `--interactive` forces interactive, `--headless` forces headless.
+ * With neither flag, prompt presence decides (prompt -> headless, none -> interactive).
+ * `--interactive` takes precedence over `--headless`; the CLI layer rejects passing both.
+ */
+export function resolveInteractive(
+  options: Pick<ExecOptions, 'interactive' | 'headless' | 'prompt'>,
+): boolean {
+  if (options.interactive === true) return true;
+  if (options.headless === true) return false;
+  return options.prompt === undefined;
 }
 
 /** Pattern for valid environment variable names (C identifier rules). */
@@ -435,7 +450,7 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
 export function buildExecCommand(options: ExecOptions): string[] {
   const template = AGENT_COMMANDS[options.agent];
   const cmd: string[] = [...template.base];
-  const interactive = options.interactive === true || options.prompt === undefined;
+  const interactive = resolveInteractive(options);
 
   // For Codex and Droid, 'exec' is the headless subcommand -- drop it for
   // interactive mode so we run the TUI ('codex' / 'droid') instead of the
@@ -631,7 +646,7 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
 
   const timeoutMs = options.timeout ? parseTimeout(options.timeout) : undefined;
   const piped = !process.stdout.isTTY;
-  const interactive = options.interactive === true || options.prompt === undefined;
+  const interactive = resolveInteractive(options);
 
   maybeRotate();
   const timer = createTimer('agent.run', {


### PR DESCRIPTION
## Problem

`agents run <agent> [prompt]` decided interactive-vs-headless from a single expression, duplicated in `buildExecCommand` and `spawnAgent`:

```ts
const interactive = options.interactive === true || options.prompt === undefined;
```

This honored `--interactive` but **ignored `--headless`**. So `agents run claude --headless` (no prompt) hit `prompt === undefined` and silently launched the interactive TUI — the flag was a no-op for mode resolution (it only weakly gated `printFlags`).

## Fix

- Centralize the decision in one exported `resolveInteractive()` helper with explicit precedence: `--interactive` wins → `--headless` wins → otherwise prompt presence decides (prompt → headless, none → interactive). Both former call sites now use it, so they can't drift.
- This is **harness-agnostic**: every supported agent keys off the single `interactive` boolean (codex/droid `exec`-subcommand drop, stdio inherit-vs-pipe, `printFlags`), so the central fix covers claude, codex, gemini, cursor, opencode, openclaw, copilot, amp, kiro, goose, roo, antigravity, grok, kimi, droid.
- Reject `--interactive --headless` together with a clear error.
- Drop the dead `options.headless ?? true` — commander defaults the flag to `false`, so it was never `undefined`.
- Document the precedence in `skills/run/SKILL.md` and the flag help.

## Verification

- `npm run build` clean.
- `npm test` — **2403 passed, 46 skipped, 0 failed** (added a `resolveInteractive precedence` suite + builder cases; corrected one existing test that had baked in the old buggy behavior).
- Real-flow probe against the built `dist`:
  - `claude --headless` (no prompt) → `["claude","--permission-mode","acceptEdits","--print"]` (was: interactive TUI)
  - `claude` (no flag, no prompt) → interactive TUI, no `--print`
  - `claude "x"` → headless `-p x` (unchanged)
  - `claude "x" -i` → interactive, prompt forwarded
  - `codex --headless` (no prompt) → keeps `exec`; `codex` (no flag) → drops `exec` (TUI)
  - `agents run claude "x" -i --headless` → errors out, exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)