### PR TITLE
feat: card wallet, picker viewport clipping, standalone-binary import, run-mode ergonomics

### DIFF
--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run
-description: "Execute a single agent headlessly or interactively. Supports plan/edit/full modes, secrets bundle injection, version pinning, fallback chains, balanced rotation, profile dispatch (Kimi/DeepSeek/etc.), and workflow dispatch by name. Triggers on: 'run claude', 'run codex', 'agents run', 'dispatch an agent', 'headless agent', 'one-off agent task'."
+description: "Execute a single agent headlessly or interactively. Supports plan/edit/auto/skip modes, secrets bundle injection, version pinning, fallback chains, balanced rotation, profile dispatch (Kimi/DeepSeek/etc.), and workflow dispatch by name. Triggers on: 'run claude', 'run codex', 'agents run', 'dispatch an agent', 'headless agent', 'one-off agent task'."
 argument-hint: "<agent|profile|workflow> [prompt]"
 allowed-tools: Bash(agents run*)
 user-invocable: true
@@ -31,18 +31,31 @@ agents run claude "summarize recent git commits"
 
 ## Modes
 
-Permission mode controls what the agent can do. Headless runs MUST set an explicit mode or hang at `ExitPlanMode`.
+Permission mode controls what the agent can do.
 
 | Mode | What it allows |
 |------|----------------|
-| `plan` (default) | Read-only — research, audit, analysis |
-| `edit` | Read + write files |
-| `full` | Writes + all permissions (autonomous) |
+| `plan` (default) | Read-only — research, audit, analysis. No writes, no shell side-effects. |
+| `edit` | Read + write files; prompts for shell / risky operations |
+| `auto` | Smart classifier auto-approves safe ops (incl. commit + push to the current branch) and blocks risky ones (force-push, push to `main`, `git reset --hard`). Claude/copilot only. |
+| `skip` | Bypass every permission prompt (`--dangerously-skip-permissions`). `full` is accepted as a permanent alias. |
 
 ```bash
 agents run claude "fix lint errors in src/" --mode edit
-agents run deploy-bot --mode full "deploy api to staging"
+agents run claude "/code:commit" --mode auto          # run a command unattended, safely
+agents run deploy-bot --mode skip "deploy api to staging"
 ```
+
+**Headless runs need a non-`plan` mode to act.** The default `plan` is read-only, so an
+action command (e.g. `/code:commit`) run headless would otherwise stall forever at
+`ExitPlanMode` with no TTY to approve the plan. Running a slash command headless without
+an explicit `--mode` is rejected up front with a fix; pick `--mode auto` (recommended),
+`edit`, or `skip`. Pass `--mode plan` explicitly only when you genuinely want a read-only run.
+
+Note: `auto` and `skip` cannot be scoped to a directory — they are per-run modes, not
+per-repo. To restrict no-prompt behavior to one repository, use that repo's
+`.claude/settings.json` `permissions.allow`/`deny` rules (file rules are path-anchored;
+deny always wins) rather than a blanket mode.
 
 ## Reasoning effort and model
 
@@ -184,7 +197,7 @@ Emits a unified event stream; ndjson when combined with `--json`.
 
 | Flag | Purpose |
 |------|---------|
-| `--mode plan\|edit\|full` | Permission level (default `plan`) |
+| `--mode plan\|edit\|auto\|skip` | Permission level (default `plan`; `full` = alias for `skip`) |
 | `--effort low\|...\|max\|auto` | Reasoning effort |
 | `--model <id>` | Override model |
 | `--secrets <bundle>` | Inject keychain bundle (repeatable) |

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -149,7 +149,7 @@ export function registerRunCommand(program: Command): void {
 
   runCmd.action(async (agentSpec: string, prompt: string | undefined, options: ExecCommandActionOptions) => {
       const [
-        { buildExecCommand, parseExecEnv, execAgent, runWithFallback, normalizeMode, resolveMode, defaultModeFor },
+        { buildExecCommand, parseExecEnv, execAgent, runWithFallback, normalizeMode, resolveMode, defaultModeFor, headlessPlanStallCommand },
         { ALL_AGENT_IDS },
         { profileExists, resolveProfileForRun },
         { readAndResolveBundleEnv, describeBundle },
@@ -381,6 +381,30 @@ export function registerRunCommand(program: Command): void {
           console.error(chalk.red((err as Error).message));
           process.exit(1);
         }
+      }
+
+      // Fail fast on the headless-plan stall footgun: a slash command run
+      // headless under the implicit default 'plan' mode hangs forever at
+      // ExitPlanMode (no TTY to approve the plan). Tell the user how to fix it
+      // instead of leaving them staring at a frozen process. Explicit
+      // `--mode plan` is respected for genuine read-only command runs.
+      const stallCmd = headlessPlanStallCommand({
+        prompt,
+        interactive: options.interactive,
+        mode,
+        modeIsDefault,
+      });
+      if (stallCmd) {
+        console.error(
+          chalk.red(`Refusing to run ${stallCmd} headless in read-only 'plan' mode — it would hang at ExitPlanMode (no TTY to approve the plan).`)
+        );
+        console.error(
+          chalk.yellow(`Re-run with an explicit mode: --mode auto (recommended — auto-approves safe ops, blocks risky ones), --mode edit, or --mode full.`)
+        );
+        console.error(
+          chalk.gray(`Pass --mode plan explicitly if you really want a read-only run.`)
+        );
+        process.exit(1);
       }
 
       const effort = options.effort as ExecEffort;

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -63,6 +63,12 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
   // into the version's `node_modules/.bin/`. No package.json walk.
   const isInstallScriptAgent = !agent.npmPackage;
 
+  // Whether to adopt the binary by a direct symlink (installScript style) vs.
+  // the npm package.json walk. Starts equal to isInstallScriptAgent, but an
+  // npm-capable agent that turns out to be installed as a standalone binary
+  // (see the resolvePackageDirFromBinary fallback below) flips this to true.
+  let useDirectBinaryImport = isInstallScriptAgent;
+
   let globalPath: string | null = null;
   let installScriptBinary: string | null = null;
 
@@ -101,9 +107,15 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
     } else {
       globalPath = resolvePackageDirFromBinary(binary);
       if (!globalPath) {
-        console.error(chalk.red(`Could not resolve npm package for binary: ${binary}`));
-        console.error(chalk.gray('Pass --from-path <dir> with the package directory explicitly.'));
-        process.exit(1);
+        // npmPackage is declared, but the binary on PATH doesn't live inside an
+        // npm package layout — e.g. Kimi installed via its curl install.sh,
+        // which drops a standalone bundled binary at ~/.kimi-code/bin/kimi
+        // rather than into node_modules/<pkg>/. The binary is valid and
+        // self-contained, so adopt it the same way as an installScript agent:
+        // a direct symlink. Key the decision on the on-disk layout, not on
+        // whether an npmPackage label happens to exist.
+        installScriptBinary = binary;
+        useDirectBinaryImport = true;
       }
     }
   }
@@ -130,7 +142,7 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
 
   let version = opts.version;
   if (!version) {
-    if (!isInstallScriptAgent && globalPath) {
+    if (!useDirectBinaryImport && globalPath) {
       try {
         const pkg = JSON.parse(fs.readFileSync(path.join(globalPath, 'package.json'), 'utf8'));
         version = typeof pkg.version === 'string' ? pkg.version : undefined;
@@ -161,7 +173,7 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
   }
 
   const versionDir = getVersionDir(agentId, version);
-  const fromLabel = isInstallScriptAgent ? (installScriptBinary as string) : (globalPath as string);
+  const fromLabel = useDirectBinaryImport ? (installScriptBinary as string) : (globalPath as string);
 
   console.log(chalk.bold(`\nImport ${agentLabel(agentId)} v${version}`));
   console.log(`  from: ${chalk.gray(fromLabel)}`);
@@ -216,7 +228,7 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
   }
 
   const binSpinner = ora(`Registering ${agentLabel(agentId)} v${version} binary...`).start();
-  const binResult = isInstallScriptAgent
+  const binResult = useDirectBinaryImport
     ? importInstallScriptBinary(
         { agentId, npmPackage: agent.npmPackage, cliCommand: agent.cliCommand },
         version,

--- a/src/commands/wallet.ts
+++ b/src/commands/wallet.ts
@@ -1,0 +1,219 @@
+/**
+ * `agents wallet` — a device-local credit-card vault backed by macOS Keychain.
+ *
+ * UX intent matches Apple Wallet: list cards freely (no biometric), reveal
+ * a card with Touch ID. Card numbers never leave the device. This is NOT
+ * Apple Pay — we store the real PAN, not a network DPAN, and do not generate
+ * per-transaction cryptograms. The help text reflects this.
+ *
+ * Bundle layout:
+ *   ~/.agents/wallet/cards.json                   metadata (id, last4, brand, exp)
+ *   agents-cli.secrets.wallet.<id>                JSON {pan, cvc, cardholder}
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import {
+  addCard,
+  detectBrand,
+  isValidLuhn,
+  listCards,
+  readIndex,
+  removeCard,
+  renameCard,
+  showCard,
+  type CardBrand,
+  type CardMetadata,
+} from '../lib/wallet/index.js';
+import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
+import { setHelpSections } from '../lib/help.js';
+
+function brandLabel(b: CardBrand): string {
+  switch (b) {
+    case 'visa': return 'Visa';
+    case 'mastercard': return 'Mastercard';
+    case 'amex': return 'American Express';
+    case 'discover': return 'Discover';
+    case 'diners': return 'Diners Club';
+    case 'jcb': return 'JCB';
+    case 'unionpay': return 'UnionPay';
+    default: return 'Card';
+  }
+}
+
+function formatExp(month: string, year: string): string {
+  return `${month}/${year.slice(-2)}`;
+}
+
+function renderRow(c: CardMetadata): string {
+  const nick = c.nickname.padEnd(24);
+  const brand = brandLabel(c.brand).padEnd(18);
+  const last4 = `•••• ${c.last4}`.padEnd(10);
+  const exp = formatExp(c.exp_month, c.exp_year);
+  return `  ${chalk.cyan(nick)} ${brand} ${last4} ${chalk.gray('exp ' + exp)}  ${chalk.gray(c.id)}`;
+}
+
+async function promptString(message: string, validate?: (v: string) => true | string): Promise<string> {
+  const { input } = await import('@inquirer/prompts');
+  return await input({ message, validate });
+}
+
+async function promptSecret(message: string): Promise<string> {
+  const { password } = await import('@inquirer/prompts');
+  return await password({ message, mask: true });
+}
+
+function requireTTY(action: string): void {
+  if (!isInteractiveTerminal()) {
+    throw new Error(`'agents wallet ${action}' requires an interactive terminal.`);
+  }
+}
+
+export function registerWalletCommands(program: Command): void {
+  const cmd = program
+    .command('wallet')
+    .description(
+      'Device-local credit-card vault backed by macOS Keychain (Touch ID required to reveal). ' +
+      'Encrypted at rest, never leaves your device. Not Apple Pay — stores real PANs, no tokenization.'
+    );
+
+  setHelpSections(cmd, {
+    examples: `
+      $ agents wallet add                              # interactive: PAN, CVC, expiry, nickname
+      $ agents wallet list                             # last 4 only, no Touch ID prompt
+      $ agents wallet show personal-amex               # Touch ID required, reveals full card
+      $ agents wallet rename personal-amex "Travel"
+      $ agents wallet remove personal-amex
+    `,
+  });
+
+  cmd
+    .command('add')
+    .description('Add a card to the vault. Interactive prompt for PAN, CVC, expiry, cardholder, nickname.')
+    .option('--nickname <name>', 'Set the nickname non-interactively (still prompts for PAN/CVC)')
+    .option('--stdin-json', 'Read all fields as a JSON object on stdin (for IPC callers). Emits the new card metadata as JSON to stdout.')
+    .action(async (opts: { nickname?: string; stdinJson?: boolean }) => {
+      try {
+        if (opts.stdinJson) {
+          const raw = await new Promise<string>((resolve, reject) => {
+            const chunks: Buffer[] = [];
+            process.stdin.on('data', (c: Buffer | string) => {
+              chunks.push(typeof c === 'string' ? Buffer.from(c) : c);
+            });
+            process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+            process.stdin.on('error', reject);
+          });
+          const input = JSON.parse(raw);
+          const meta = addCard(input);
+          process.stdout.write(JSON.stringify({ card: meta }) + '\n');
+          return;
+        }
+        requireTTY('add');
+        const pan = (await promptSecret('Card number')).replace(/\s+/g, '');
+        if (!/^\d+$/.test(pan)) throw new Error('PAN must contain only digits.');
+        if (!isValidLuhn(pan)) throw new Error('PAN failed Luhn checksum — typo?');
+        const brand = detectBrand(pan);
+        console.log(chalk.gray(`Detected: ${brandLabel(brand)} •••• ${pan.slice(-4)}`));
+
+        const exp_month = await promptString('Expiration month (MM)', (v) => {
+          const n = Number(v);
+          return Number.isInteger(n) && n >= 1 && n <= 12 ? true : 'Month must be 1-12';
+        });
+        const exp_year = await promptString('Expiration year (YY or YYYY)', (v) => {
+          const d = v.replace(/\D/g, '');
+          return d.length === 2 || d.length === 4 ? true : 'Year must be 2 or 4 digits';
+        });
+        const cvc = (await promptSecret('CVC')).replace(/\s+/g, '');
+        if (!/^\d{3,4}$/.test(cvc)) throw new Error('CVC must be 3 or 4 digits.');
+        const cardholder = await promptString('Cardholder name (as printed)');
+        const nickname = opts.nickname?.trim() || await promptString('Nickname (e.g. Personal Amex)', (v) => v.trim() ? true : 'Required');
+
+        const meta = addCard({ nickname, pan, cvc, cardholder, exp_month, exp_year });
+        console.log(chalk.green(`Added ${brandLabel(meta.brand)} •••• ${meta.last4} as '${meta.nickname}' (id: ${meta.id})`));
+      } catch (err) {
+        if (isPromptCancelled(err)) return;
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+
+  cmd
+    .command('list')
+    .alias('ls')
+    .description('List stored cards (metadata only — last 4, brand, expiry). No biometric prompt.')
+    .option('--json', 'Emit JSON to stdout')
+    .action((opts: { json?: boolean }) => {
+      try {
+        const cards = listCards();
+        if (opts.json) {
+          process.stdout.write(JSON.stringify({ cards }, null, 2) + '\n');
+          return;
+        }
+        if (cards.length === 0) {
+          console.log(chalk.gray('No cards in wallet. Try: agents wallet add'));
+          return;
+        }
+        console.log(chalk.bold(`  ${'NICKNAME'.padEnd(24)} ${'BRAND'.padEnd(18)} ${'LAST4'.padEnd(10)} EXP        ID`));
+        for (const c of cards) console.log(renderRow(c));
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+
+  cmd
+    .command('show <id>')
+    .description('Reveal a card. Touch ID required. Argument is a card id or nickname.')
+    .option('--json', 'Emit JSON to stdout (still triggers Touch ID)')
+    .action((id: string, opts: { json?: boolean }) => {
+      try {
+        const full = showCard(id);
+        if (opts.json) {
+          process.stdout.write(JSON.stringify(full, null, 2) + '\n');
+          return;
+        }
+        console.log();
+        console.log(chalk.bold(`  ${full.nickname}`));
+        console.log(`  ${chalk.gray('Brand     ')} ${brandLabel(full.brand)}`);
+        console.log(`  ${chalk.gray('Number    ')} ${full.pan.match(/.{1,4}/g)?.join(' ') ?? full.pan}`);
+        console.log(`  ${chalk.gray('CVC       ')} ${full.cvc}`);
+        console.log(`  ${chalk.gray('Expires   ')} ${formatExp(full.exp_month, full.exp_year)}`);
+        console.log(`  ${chalk.gray('Holder    ')} ${full.cardholder}`);
+        console.log();
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+
+  cmd
+    .command('remove <id>')
+    .alias('rm')
+    .description('Remove a card from the vault. Argument is a card id or nickname.')
+    .action((id: string) => {
+      try {
+        const meta = removeCard(id);
+        if (!meta) {
+          console.error(chalk.red(`No card found matching '${id}'.`));
+          process.exit(1);
+        }
+        console.log(chalk.green(`Removed '${meta.nickname}' (${brandLabel(meta.brand)} •••• ${meta.last4}).`));
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+
+  cmd
+    .command('rename <id> <new-nickname>')
+    .description('Rename a card. Argument is the current id or nickname.')
+    .action((id: string, newNickname: string) => {
+      try {
+        const meta = renameCard(id, newNickname);
+        console.log(chalk.green(`Renamed to '${meta.nickname}'.`));
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,7 @@ import { registerBrowserCommand } from './commands/browser.js';
 import { registerComputerCommand } from './commands/computer.js';
 import { registerProfilesCommands } from './commands/profiles.js';
 import { registerSecretsCommands } from './commands/secrets.js';
+import { registerWalletCommands } from './commands/wallet.js';
 import { registerHelperCommand } from './commands/helper.js';
 import { registerFactoryCommands } from './commands/factory.js';
 import { registerUsageCommand } from './commands/usage.js';
@@ -731,6 +732,7 @@ program
 
 registerProfilesCommands(program);
 registerSecretsCommands(program);
+registerWalletCommands(program);
 registerHelperCommand(program);
 registerBetaCommands(program);
 registerSyncCommand(program);

--- a/src/lib/__tests__/exec.test.ts
+++ b/src/lib/__tests__/exec.test.ts
@@ -10,6 +10,7 @@ import {
   normalizeMode,
   resolveMode,
   defaultModeFor,
+  headlessPlanStallCommand,
   type ExecOptions,
 } from '../exec.js';
 import type { AgentId, Mode } from '../types.js';
@@ -839,5 +840,57 @@ describe('defaultModeFor', () => {
     for (const agent of ALL_AGENTS) {
       expect(defaultModeFor(agent)).toBe(AGENTS[agent].capabilities.modes[0]);
     }
+  });
+});
+
+describe('headlessPlanStallCommand', () => {
+  // The footgun: `ag run claude "/code:commit"` with no --mode defaults to
+  // read-only plan, then hangs forever at ExitPlanMode in a headless run.
+  it('blocks a slash command run headless under implicit-default plan', () => {
+    expect(
+      headlessPlanStallCommand({ prompt: '/code:commit', interactive: undefined, mode: 'plan', modeIsDefault: true })
+    ).toBe('/code:commit');
+  });
+
+  it('returns the bare command token, dropping arguments', () => {
+    expect(
+      headlessPlanStallCommand({ prompt: '/code:loop RUSH-1 RUSH-2', interactive: undefined, mode: 'plan', modeIsDefault: true })
+    ).toBe('/code:loop');
+  });
+
+  it('does not block an EXPLICIT --mode plan (modeIsDefault false) — read-only command runs are valid', () => {
+    expect(
+      headlessPlanStallCommand({ prompt: '/code-review', interactive: undefined, mode: 'plan', modeIsDefault: false })
+    ).toBeNull();
+  });
+
+  it('does not block a natural-language prompt under default plan (valid research run)', () => {
+    expect(
+      headlessPlanStallCommand({ prompt: 'summarize recent git commits', interactive: undefined, mode: 'plan', modeIsDefault: true })
+    ).toBeNull();
+  });
+
+  it('does not block interactive runs', () => {
+    expect(
+      headlessPlanStallCommand({ prompt: '/code:commit', interactive: true, mode: 'plan', modeIsDefault: true })
+    ).toBeNull();
+  });
+
+  it('does not block when no prompt (interactive TUI)', () => {
+    expect(
+      headlessPlanStallCommand({ prompt: undefined, interactive: undefined, mode: 'plan', modeIsDefault: true })
+    ).toBeNull();
+  });
+
+  it.each(['edit', 'auto', 'skip', 'full'])('does not block under non-plan mode %s', (mode) => {
+    expect(
+      headlessPlanStallCommand({ prompt: '/code:commit', interactive: undefined, mode, modeIsDefault: true })
+    ).toBeNull();
+  });
+
+  it('tolerates leading whitespace before the slash command', () => {
+    expect(
+      headlessPlanStallCommand({ prompt: '  /deploy staging', interactive: undefined, mode: 'plan', modeIsDefault: true })
+    ).toBe('/deploy');
   });
 });

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -42,6 +42,38 @@ export function normalizeMode(input: string | null | undefined): Mode {
 }
 
 /**
+ * Detect the headless-plan stall footgun.
+ *
+ * A slash command (e.g. `/code:commit`) run headless under the IMPLICIT default
+ * `plan` mode hangs forever: plan is read-only, so the agent calls ExitPlanMode
+ * to start working, and in a headless run there is no TTY to approve it. The
+ * process just sits there. Callers use this to fail fast with a fix instead.
+ *
+ * Returns the offending command token (e.g. `/code:commit`) when the run should
+ * be blocked, else null. Guards are deliberately narrow:
+ *   - interactive runs / no prompt        -> not headless, never blocks
+ *   - explicit --mode (modeIsDefault false) -> respected; `--mode plan` is a
+ *     legitimate read-only command run and must not be blocked
+ *   - resolved mode is not `plan`          -> only plan stalls at ExitPlanMode
+ *   - prompt is not a slash command        -> natural-language read-only prompts
+ *     ("summarize commits") are a valid default-plan use and must not be blocked
+ */
+export function headlessPlanStallCommand(args: {
+  prompt: string | undefined;
+  interactive: boolean | undefined;
+  mode: string;
+  modeIsDefault: boolean;
+}): string | null {
+  const { prompt, interactive, mode, modeIsDefault } = args;
+  if (interactive === true || prompt === undefined) return null;
+  if (!modeIsDefault) return null;
+  if (normalizeMode(mode) !== 'plan') return null;
+  const trimmed = prompt.trimStart();
+  if (!trimmed.startsWith('/')) return null;
+  return trimmed.split(/\s+/)[0];
+}
+
+/**
  * Resolve a requested mode against an agent's capability table.
  *
  * - `auto` on an agent without auto support silently degrades to `edit`

--- a/src/lib/picker.test.ts
+++ b/src/lib/picker.test.ts
@@ -1,0 +1,35 @@
+import { stripVTControlCharacters } from 'node:util';
+import { describe, expect, it } from 'vitest';
+import { limitPreviewHeight } from './picker.js';
+
+function renderedRows(text: string, width: number): number {
+  return text.split('\n').reduce((rows, line) => {
+    const visible = stripVTControlCharacters(line).length;
+    return rows + Math.max(1, Math.ceil(visible / width));
+  }, 0);
+}
+
+describe('limitPreviewHeight', () => {
+  it('leaves previews unchanged when they fit', () => {
+    const preview = ['title', 'body', 'footer'].join('\n');
+
+    expect(limitPreviewHeight(preview, 3, 80)).toBe(preview);
+  });
+
+  it('clips multi-line previews to the row budget', () => {
+    const preview = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join('\n');
+    const clipped = limitPreviewHeight(preview, 4, 80);
+
+    expect(renderedRows(clipped, 80)).toBeLessThanOrEqual(4);
+    expect(stripVTControlCharacters(clipped)).toContain('preview truncated');
+    expect(stripVTControlCharacters(clipped)).not.toContain('line 10');
+  });
+
+  it('accounts for wrapped long lines before adding the truncation marker', () => {
+    const preview = 'x'.repeat(200);
+    const clipped = limitPreviewHeight(preview, 3, 20);
+
+    expect(renderedRows(clipped, 20)).toBeLessThanOrEqual(3);
+    expect(stripVTControlCharacters(clipped)).toContain('truncated');
+  });
+});

--- a/src/lib/picker.ts
+++ b/src/lib/picker.ts
@@ -30,6 +30,7 @@ import {
   Separator,
 } from '@inquirer/core';
 import chalk from 'chalk';
+import { stripVTControlCharacters } from 'node:util';
 
 /** Configuration for the interactive picker prompt. */
 export interface PickerConfig<T> {
@@ -53,6 +54,95 @@ export interface PickedItem<T> {
 interface Choice<T> {
   value: T;
   label: string;
+}
+
+const DEFAULT_TERMINAL_ROWS = 24;
+const DEFAULT_TERMINAL_WIDTH = 80;
+
+function terminalWidth(): number {
+  return Math.max(1, process.stdout.columns || DEFAULT_TERMINAL_WIDTH);
+}
+
+function terminalRows(): number {
+  return Math.max(1, process.stdout.rows || DEFAULT_TERMINAL_ROWS);
+}
+
+function renderedRows(text: string, width: number): number {
+  const normalizedWidth = Math.max(1, width);
+  return text.split('\n').reduce((rows, line) => {
+    const visible = stripVTControlCharacters(line).length;
+    return rows + Math.max(1, Math.ceil(visible / normalizedWidth));
+  }, 0);
+}
+
+function truncateAnsiLine(line: string, maxVisibleWidth: number): string {
+  if (maxVisibleWidth <= 0) return '';
+
+  const targetWidth = Math.max(0, maxVisibleWidth - 1);
+  const ansiPattern = /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))/y;
+  let out = '';
+  let visible = 0;
+
+  for (let i = 0; i < line.length;) {
+    ansiPattern.lastIndex = i;
+    const ansi = ansiPattern.exec(line);
+    if (ansi) {
+      out += ansi[0];
+      i = ansiPattern.lastIndex;
+      continue;
+    }
+
+    const char = line[i];
+    if (visible >= targetWidth) break;
+    out += char;
+    visible += 1;
+    i += char.length;
+  }
+
+  return out + '\x1b[0m' + chalk.gray('…');
+}
+
+function takePreviewRows(preview: string, rowBudget: number, width: number): string[] {
+  const lines = preview.split('\n');
+  const out: string[] = [];
+  let used = 0;
+
+  for (const line of lines) {
+    const lineRows = renderedRows(line, width);
+    if (used + lineRows <= rowBudget) {
+      out.push(line);
+      used += lineRows;
+      continue;
+    }
+
+    const remainingRows = rowBudget - used;
+    if (remainingRows > 0) {
+      out.push(truncateAnsiLine(line, remainingRows * width));
+    }
+    break;
+  }
+
+  return out;
+}
+
+function previewTruncatedMarker(width: number): string {
+  const full = '... preview truncated to fit terminal';
+  const short = '... truncated';
+  const text = full.length <= width ? full : short;
+  if (text.length <= width) return chalk.gray(text);
+  return chalk.gray(text.slice(0, Math.max(0, width - 1)) + '…');
+}
+
+/** Clip a picker preview so the full prompt can fit in the terminal viewport. */
+export function limitPreviewHeight(preview: string, maxRows: number, width: number): string {
+  const normalizedRows = Math.max(0, maxRows);
+  if (normalizedRows === 0) return '';
+  if (renderedRows(preview, width) <= normalizedRows) return preview;
+  if (normalizedRows === 1) return previewTruncatedMarker(width);
+
+  const lines = takePreviewRows(preview, normalizedRows - 1, width);
+  lines.push(previewTruncatedMarker(width));
+  return lines.join('\n');
 }
 
 /** Show an interactive fuzzy-filter picker and return the selected item, or null on cancel. */
@@ -142,22 +232,34 @@ export function itemPicker<T>(config: PickerConfig<T>): Promise<PickedItem<T> | 
       loop: false,
     });
 
-    const parts: string[] = [header, page];
-    if (results.length === 0) {
-      parts.push(chalk.gray(`  ${cfg.emptyMessage ?? 'No matches.'}`));
-    }
-
-    if (previewOpen && selected && cfg.buildPreview) {
-      parts.push(chalk.gray('─'.repeat(Math.min(process.stdout.columns || 80, 80))));
-      parts.push(cfg.buildPreview(selected.value));
-    }
-
     const enter = cfg.enterHint ?? 'select';
     const help = previewOpen
       ? chalk.gray(`↑↓ navigate · space: close preview · ⏎ ${enter} · esc: cancel`)
       : chalk.gray(
           `↑↓ navigate${hasPreview ? ' · space: preview' : ''} · ⏎ ${enter} · esc: cancel`
         );
+
+    const parts: string[] = [header, page];
+    if (results.length === 0) {
+      parts.push(chalk.gray(`  ${cfg.emptyMessage ?? 'No matches.'}`));
+    }
+
+    if (previewOpen && selected && cfg.buildPreview) {
+      const width = terminalWidth();
+      const separator = chalk.gray('─'.repeat(Math.min(width, 80)));
+      const fixedRows =
+        renderedRows(header, width) +
+        renderedRows(parts.slice(1).join('\n'), width) +
+        renderedRows(separator, width) +
+        renderedRows(help, width);
+      const availablePreviewRows = terminalRows() - fixedRows;
+      const preview = limitPreviewHeight(cfg.buildPreview(selected.value), availablePreviewRows, width);
+      if (preview) {
+        parts.push(separator);
+        parts.push(preview);
+      }
+    }
+
     parts.push(help);
 
     return [header, parts.slice(1).join('\n')];

--- a/src/lib/wallet/__tests__/wallet.test.ts
+++ b/src/lib/wallet/__tests__/wallet.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Wallet storage tests.
+ *
+ * The Keychain backend is swapped for an in-memory map via
+ * setKeychainBackendForTest so tests don't touch the real Keychain (which
+ * would surface biometric prompts). The wallet's file index is redirected
+ * to a per-test tmp dir via _setIndexPathForTest. End-to-end Keychain +
+ * Touch ID is verified manually on a real Mac per the plan's verify section.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  setKeychainBackendForTest,
+  type KeychainBackend,
+} from '../../secrets/index.js';
+import {
+  _setIndexPathForTest,
+  addCard,
+  detectBrand,
+  findCard,
+  isValidLuhn,
+  listCards,
+  removeCard,
+  renameCard,
+  showCard,
+} from '../index.js';
+
+// In-memory backend mirrors the shape the secrets module expects.
+function makeMemoryBackend(): KeychainBackend {
+  const store = new Map<string, string>();
+  return {
+    has: (k) => store.has(k),
+    get: (k) => {
+      if (!store.has(k)) throw new Error(`not found: ${k}`);
+      return store.get(k)!;
+    },
+    set: (k, v) => { store.set(k, v); },
+    delete: (k) => store.delete(k),
+    list: (prefix) => [...store.keys()].filter((k) => k.startsWith(prefix)),
+  };
+}
+
+// Stripe test PANs — these pass Luhn and don't correspond to real cards.
+const VISA_PAN = '4242424242424242';
+const MC_PAN = '5555555555554444';
+const AMEX_PAN = '378282246310005';
+const INVALID_PAN = '4242424242424241'; // Luhn fails
+
+let tmpDir = '';
+let prevBackend: KeychainBackend | null = null;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wallet-test-'));
+  _setIndexPathForTest(path.join(tmpDir, 'cards.json'));
+  prevBackend = setKeychainBackendForTest(makeMemoryBackend());
+});
+
+afterEach(() => {
+  setKeychainBackendForTest(prevBackend);
+  _setIndexPathForTest(null);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('Luhn', () => {
+  it('accepts well-known test PANs', () => {
+    expect(isValidLuhn(VISA_PAN)).toBe(true);
+    expect(isValidLuhn(MC_PAN)).toBe(true);
+    expect(isValidLuhn(AMEX_PAN)).toBe(true);
+  });
+  it('rejects a single-digit-flipped PAN', () => {
+    expect(isValidLuhn(INVALID_PAN)).toBe(false);
+  });
+  it('rejects too-short and too-long inputs', () => {
+    expect(isValidLuhn('1234')).toBe(false);
+    expect(isValidLuhn('1'.repeat(20))).toBe(false);
+  });
+});
+
+describe('detectBrand', () => {
+  it('classifies known BINs', () => {
+    expect(detectBrand(VISA_PAN)).toBe('visa');
+    expect(detectBrand(MC_PAN)).toBe('mastercard');
+    expect(detectBrand(AMEX_PAN)).toBe('amex');
+    expect(detectBrand('6011000990139424')).toBe('discover');
+    expect(detectBrand('3056930009020004')).toBe('diners');
+    expect(detectBrand('3530111333300000')).toBe('jcb');
+    expect(detectBrand('6200000000000005')).toBe('unionpay');
+  });
+  it('falls back to unknown on unrecognized BIN', () => {
+    expect(detectBrand('9999999999999999')).toBe('unknown');
+  });
+});
+
+describe('add → list → show → remove round-trip', () => {
+  it('stores and retrieves a card', () => {
+    const meta = addCard({
+      nickname: 'Personal Visa',
+      pan: VISA_PAN,
+      cvc: '123',
+      cardholder: 'MUQSIT NAWAZ',
+      exp_month: '9',
+      exp_year: '27',
+    });
+    expect(meta.brand).toBe('visa');
+    expect(meta.last4).toBe('4242');
+    expect(meta.exp_month).toBe('09');
+    expect(meta.exp_year).toBe('2027');
+    expect(meta.kind).toBe('pan_encrypted');
+    expect(meta.id).toMatch(/^[0-9a-f]{12}$/);
+
+    const cards = listCards();
+    expect(cards).toHaveLength(1);
+    expect(cards[0].nickname).toBe('Personal Visa');
+
+    const full = showCard(meta.id);
+    expect(full.pan).toBe(VISA_PAN);
+    expect(full.cvc).toBe('123');
+    expect(full.cardholder).toBe('MUQSIT NAWAZ');
+
+    const removed = removeCard(meta.id);
+    expect(removed?.id).toBe(meta.id);
+    expect(listCards()).toHaveLength(0);
+    expect(() => showCard(meta.id)).toThrow(/No card found/);
+  });
+
+  it('looks up cards by nickname (case-insensitive)', () => {
+    addCard({
+      nickname: 'Business MC',
+      pan: MC_PAN,
+      cvc: '321',
+      cardholder: 'MUQSIT NAWAZ',
+      exp_month: '02',
+      exp_year: '2029',
+    });
+    expect(findCard('business mc')?.last4).toBe('4444');
+    expect(findCard('BUSINESS MC')?.last4).toBe('4444');
+  });
+});
+
+describe('validation', () => {
+  it('rejects a PAN with bad Luhn', () => {
+    expect(() => addCard({
+      nickname: 'Bad',
+      pan: INVALID_PAN,
+      cvc: '123',
+      cardholder: 'X',
+      exp_month: '1',
+      exp_year: '2027',
+    })).toThrow(/Luhn/);
+  });
+  it('rejects CVC that is not 3-4 digits', () => {
+    expect(() => addCard({
+      nickname: 'Bad CVC',
+      pan: VISA_PAN,
+      cvc: '12',
+      cardholder: 'X',
+      exp_month: '1',
+      exp_year: '2027',
+    })).toThrow(/CVC/);
+  });
+  it('rejects duplicate nicknames (case-insensitive)', () => {
+    addCard({
+      nickname: 'My Card',
+      pan: VISA_PAN, cvc: '123', cardholder: 'X', exp_month: '1', exp_year: '2027',
+    });
+    expect(() => addCard({
+      nickname: 'my card',
+      pan: MC_PAN, cvc: '321', cardholder: 'X', exp_month: '1', exp_year: '2027',
+    })).toThrow(/already exists/);
+  });
+  it('rejects bad expiration month', () => {
+    expect(() => addCard({
+      nickname: 'X', pan: VISA_PAN, cvc: '123', cardholder: 'X',
+      exp_month: '13', exp_year: '2027',
+    })).toThrow(/month/);
+  });
+});
+
+describe('rename', () => {
+  it('renames a card and rejects collisions', () => {
+    const a = addCard({
+      nickname: 'A', pan: VISA_PAN, cvc: '123', cardholder: 'X', exp_month: '1', exp_year: '2027',
+    });
+    const b = addCard({
+      nickname: 'B', pan: MC_PAN, cvc: '321', cardholder: 'X', exp_month: '1', exp_year: '2027',
+    });
+    const renamed = renameCard(a.id, 'A New Name');
+    expect(renamed.nickname).toBe('A New Name');
+    expect(findCard('A New Name')?.id).toBe(a.id);
+
+    expect(() => renameCard(b.id, 'a new name')).toThrow(/already exists/);
+  });
+});
+
+describe('index file safety', () => {
+  it('keeps Keychain and index in sync on rollback', () => {
+    // Force the index to fail by pointing it at an unwritable path
+    // mid-test. Simulates a disk-full / permission failure between the
+    // Keychain write and the index write.
+    const card = addCard({
+      nickname: 'OK', pan: VISA_PAN, cvc: '123', cardholder: 'X', exp_month: '1', exp_year: '2027',
+    });
+    // Confirm Keychain has the secret (would throw if missing)
+    expect(showCard(card.id).pan).toBe(VISA_PAN);
+
+    // Now simulate index write failure: point at a directory we cannot write
+    _setIndexPathForTest('/this/path/does/not/exist/cards.json');
+    expect(() => addCard({
+      nickname: 'Will Fail', pan: MC_PAN, cvc: '321', cardholder: 'X', exp_month: '1', exp_year: '2027',
+    })).toThrow();
+    // Restore real tmp index
+    _setIndexPathForTest(path.join(tmpDir, 'cards.json'));
+    const remaining = listCards();
+    // Only the first card should still be present; the rollback should
+    // have removed the partial Keychain entry for "Will Fail".
+    expect(remaining.map((c) => c.nickname)).toEqual(['OK']);
+  });
+});

--- a/src/lib/wallet/index.ts
+++ b/src/lib/wallet/index.ts
@@ -1,0 +1,301 @@
+/**
+ * Wallet: device-local credit-card vault.
+ *
+ * Two-tier storage so listing the wallet doesn't pop Touch ID, but reading
+ * a card always does:
+ *
+ *   Card metadata (id, nickname, brand, last4, expiry, created_at, kind)
+ *     -> ~/.agents/wallet/cards.json, mode 0600
+ *     -> Display-only data, equivalent of Apple Wallet's "card art" tier.
+ *
+ *   Card secret (PAN, CVC, cardholder)
+ *     -> Keychain item `agents-cli.secrets.wallet.<id>` (JSON-encoded)
+ *     -> Routed through the signed helper, so the OS gates decryption with
+ *        Touch ID + biometryCurrentSet. Re-enrolling Touch ID invalidates
+ *        the item, matching Apple Pay's AR-value rotation behavior.
+ *
+ * Not Apple Pay: we store a real PAN, not a network DPAN, and we do not
+ * generate per-transaction cryptograms. Callers must surface this clearly.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import {
+  deleteKeychainToken,
+  getKeychainToken,
+  secretsKeychainItem,
+  setKeychainToken,
+} from '../secrets/index.js';
+
+const WALLET_BUNDLE = 'wallet';
+const DEFAULT_INDEX_DIR = path.join(os.homedir(), '.agents', 'wallet');
+const DEFAULT_INDEX_PATH = path.join(DEFAULT_INDEX_DIR, 'cards.json');
+
+let indexPathOverride: string | null = null;
+
+function indexPath(): string {
+  return indexPathOverride ?? DEFAULT_INDEX_PATH;
+}
+
+function indexDir(): string {
+  return path.dirname(indexPath());
+}
+
+/** Test seam: override the index path. Returns the previous override (or null). */
+export function _setIndexPathForTest(p: string | null): string | null {
+  const prev = indexPathOverride;
+  indexPathOverride = p;
+  return prev;
+}
+
+export type CardBrand =
+  | 'visa'
+  | 'mastercard'
+  | 'amex'
+  | 'discover'
+  | 'diners'
+  | 'jcb'
+  | 'unionpay'
+  | 'unknown';
+
+/** Storage kind discriminator. Reserved for future kind: 'stripe_token'. */
+export type CardKind = 'pan_encrypted';
+
+/** Non-sensitive card metadata. Safe to display without biometric auth. */
+export interface CardMetadata {
+  id: string;
+  nickname: string;
+  brand: CardBrand;
+  last4: string;
+  exp_month: string;
+  exp_year: string;
+  created_at: string;
+  kind: CardKind;
+}
+
+/** Sensitive card fields. Keychain-stored, Touch ID required to read. */
+export interface CardSecret {
+  pan: string;
+  cvc: string;
+  cardholder: string;
+}
+
+/** Card metadata plus its secret payload. Returned by show() only. */
+export interface CardFull extends CardMetadata, CardSecret {}
+
+/** Input shape for add(). */
+export interface AddCardInput {
+  nickname: string;
+  pan: string;
+  cvc: string;
+  cardholder: string;
+  exp_month: string;
+  exp_year: string;
+}
+
+/** Compute the Luhn checksum and verify a candidate PAN. */
+export function isValidLuhn(pan: string): boolean {
+  const digits = pan.replace(/\D/g, '');
+  if (digits.length < 12 || digits.length > 19) return false;
+  let sum = 0;
+  let alt = false;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let n = digits.charCodeAt(i) - 48;
+    if (alt) {
+      n *= 2;
+      if (n > 9) n -= 9;
+    }
+    sum += n;
+    alt = !alt;
+  }
+  return sum % 10 === 0;
+}
+
+/** Detect card brand from the BIN (first 6 digits). */
+export function detectBrand(pan: string): CardBrand {
+  const d = pan.replace(/\D/g, '');
+  if (/^4/.test(d)) return 'visa';
+  if (/^(5[1-5]|2[2-7])/.test(d)) return 'mastercard';
+  if (/^3[47]/.test(d)) return 'amex';
+  if (/^6(011|5|4[4-9])/.test(d)) return 'discover';
+  if (/^3(0[0-5]|[689])/.test(d)) return 'diners';
+  if (/^35(2[89]|[3-8])/.test(d)) return 'jcb';
+  if (/^(62|81)/.test(d)) return 'unionpay';
+  return 'unknown';
+}
+
+function normalizeMonth(mm: string): string {
+  const n = Number(mm);
+  if (!Number.isInteger(n) || n < 1 || n > 12) {
+    throw new Error(`Invalid expiration month: ${mm}`);
+  }
+  return n.toString().padStart(2, '0');
+}
+
+function normalizeYear(yy: string): string {
+  const d = yy.replace(/\D/g, '');
+  if (d.length === 2) return '20' + d;
+  if (d.length === 4) {
+    const n = Number(d);
+    if (n < 2000 || n > 2100) throw new Error(`Invalid expiration year: ${yy}`);
+    return d;
+  }
+  throw new Error(`Invalid expiration year: ${yy}`);
+}
+
+function ensureIndexDir(): void {
+  fs.mkdirSync(indexDir(), { recursive: true, mode: 0o700 });
+}
+
+/** Atomically read the index file. Returns [] when missing. */
+export function readIndex(): CardMetadata[] {
+  const p = indexPath();
+  if (!fs.existsSync(p)) return [];
+  const raw = fs.readFileSync(p, 'utf-8');
+  if (!raw.trim()) return [];
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Wallet index at ${p} is not an array.`);
+  }
+  return parsed as CardMetadata[];
+}
+
+/** Atomically write the index file via tmp + rename. */
+function writeIndex(cards: CardMetadata[]): void {
+  ensureIndexDir();
+  const p = indexPath();
+  const tmp = p + '.tmp.' + process.pid;
+  fs.writeFileSync(tmp, JSON.stringify(cards, null, 2), { mode: 0o600 });
+  fs.renameSync(tmp, indexPath());
+}
+
+function walletKeychainItem(id: string): string {
+  return secretsKeychainItem(WALLET_BUNDLE, id);
+}
+
+function generateId(): string {
+  // 12 hex chars (6 bytes). Unique enough for a per-user wallet; short
+  // enough to type if needed.
+  return crypto.randomBytes(6).toString('hex');
+}
+
+/** List all stored cards. Does NOT trigger biometric auth. */
+export function listCards(): CardMetadata[] {
+  return readIndex();
+}
+
+/** Look up a card by id (or by case-insensitive nickname). Returns undefined when missing. */
+export function findCard(idOrNickname: string): CardMetadata | undefined {
+  const cards = readIndex();
+  const exact = cards.find((c) => c.id === idOrNickname);
+  if (exact) return exact;
+  const lc = idOrNickname.toLowerCase();
+  return cards.find((c) => c.nickname.toLowerCase() === lc);
+}
+
+/**
+ * Add a new card. Validates Luhn + expiry. Returns the metadata for the
+ * stored card. The PAN/CVC/cardholder are written to Keychain in a single
+ * JSON blob; only metadata is mirrored to the index file.
+ */
+export function addCard(input: AddCardInput): CardMetadata {
+  const pan = input.pan.replace(/\s+/g, '');
+  if (!/^\d+$/.test(pan)) throw new Error('PAN must contain only digits.');
+  if (!isValidLuhn(pan)) throw new Error('PAN failed Luhn checksum.');
+  const cvc = input.cvc.replace(/\s+/g, '');
+  if (!/^\d{3,4}$/.test(cvc)) throw new Error('CVC must be 3 or 4 digits.');
+  const nickname = input.nickname.trim();
+  if (!nickname) throw new Error('Nickname is required.');
+  const cardholder = input.cardholder.trim();
+  if (!cardholder) throw new Error('Cardholder name is required.');
+  if (/[\r\n]/.test(cardholder)) throw new Error('Cardholder name contains newlines.');
+
+  const exp_month = normalizeMonth(input.exp_month);
+  const exp_year = normalizeYear(input.exp_year);
+  const last4 = pan.slice(-4);
+  const brand = detectBrand(pan);
+
+  const cards = readIndex();
+  if (cards.some((c) => c.nickname.toLowerCase() === nickname.toLowerCase())) {
+    throw new Error(`A card named '${nickname}' already exists. Pick a different nickname.`);
+  }
+
+  const id = generateId();
+  const meta: CardMetadata = {
+    id,
+    nickname,
+    brand,
+    last4,
+    exp_month,
+    exp_year,
+    created_at: new Date().toISOString(),
+    kind: 'pan_encrypted',
+  };
+
+  const secret: CardSecret = { pan, cvc, cardholder };
+  // Keychain item first; if it succeeds, mirror to index. If the index
+  // write fails afterward, attempt to roll back the keychain insertion
+  // so callers don't see ghost secrets.
+  setKeychainToken(walletKeychainItem(id), JSON.stringify(secret));
+  try {
+    writeIndex([...cards, meta]);
+  } catch (err) {
+    try { deleteKeychainToken(walletKeychainItem(id)); } catch { /* best-effort rollback */ }
+    throw err;
+  }
+  return meta;
+}
+
+/**
+ * Reveal a card by id. **Triggers Touch ID on macOS.** Throws if the card
+ * isn't in the index or if the keychain entry is missing/cancelled.
+ */
+export function showCard(idOrNickname: string): CardFull {
+  const meta = findCard(idOrNickname);
+  if (!meta) throw new Error(`No card found matching '${idOrNickname}'.`);
+  const raw = getKeychainToken(walletKeychainItem(meta.id));
+  let secret: CardSecret;
+  try {
+    secret = JSON.parse(raw) as CardSecret;
+  } catch (err) {
+    throw new Error(`Card secret for '${meta.nickname}' is corrupted (not valid JSON).`);
+  }
+  if (!secret.pan || !secret.cvc || !secret.cardholder) {
+    throw new Error(`Card secret for '${meta.nickname}' is missing required fields.`);
+  }
+  return { ...meta, ...secret };
+}
+
+/** Delete a card from both the index and Keychain. Returns the removed metadata or undefined. */
+export function removeCard(idOrNickname: string): CardMetadata | undefined {
+  const cards = readIndex();
+  const meta = findCard(idOrNickname);
+  if (!meta) return undefined;
+  const remaining = cards.filter((c) => c.id !== meta.id);
+  writeIndex(remaining);
+  try { deleteKeychainToken(walletKeychainItem(meta.id)); } catch { /* keychain may already be gone */ }
+  return meta;
+}
+
+/** Rename a card. Throws if the new nickname collides with an existing card. */
+export function renameCard(idOrNickname: string, newNickname: string): CardMetadata {
+  const nickname = newNickname.trim();
+  if (!nickname) throw new Error('Nickname is required.');
+  const cards = readIndex();
+  const meta = findCard(idOrNickname);
+  if (!meta) throw new Error(`No card found matching '${idOrNickname}'.`);
+  if (
+    cards.some(
+      (c) => c.id !== meta.id && c.nickname.toLowerCase() === nickname.toLowerCase(),
+    )
+  ) {
+    throw new Error(`A card named '${nickname}' already exists.`);
+  }
+  const updated: CardMetadata = { ...meta, nickname };
+  const next = cards.map((c) => (c.id === meta.id ? updated : c));
+  writeIndex(next);
+  return updated;
+}
+


### PR DESCRIPTION
Clean rebase of the unmerged work that had accumulated on the stale `fix/kimi-env-injection` branch (whose original PR #247 already merged). Replayed onto current `main` — fast-forwardable, no conflicts. Already-merged work (kimi fixes #247, typo-tolerance #268, `@oldest` #298, the install.sh build-args guard) was dropped since it's already in `main`.

## What's here (8 commits)

**`agents wallet` — device-local card vault**
- Keychain-backed card vault library (PAN in Keychain, metadata index on disk).
- `agents wallet` command: add / list / show / rename / remove, brand detection, Luhn validation.
- Tests use an in-memory Keychain backend (no real Keychain / biometric prompts in CI).

**Picker**
- Clip picker preview to the terminal viewport height so long previews don't overflow the screen. + tests.

**Import**
- `agents import`: adopt a standalone bundled binary (direct symlink) for npm-declared agents that are actually installed via a curl `install.sh` (e.g. Kimi at `~/.kimi-code/bin/kimi`), keyed on the on-disk layout rather than the `npmPackage` label.

**`agents run` ergonomics**
- Fail fast (with a `--mode auto` hint) instead of hanging at `ExitPlanMode` when a slash command is run headless under the implicit default read-only `plan` mode. Narrow guard: explicit `--mode plan`, interactive runs, non-plan modes, and natural-language prompts are never blocked.
- Correct the `run` skill docs to the real four modes (`plan`/`edit`/`auto`/`skip`; `full` = alias for `skip`) and note that `auto`/`skip` are per-run, not dir-scopable (per-repo no-prompt = `.claude/settings.json` allow/deny rules).

## Verification
- `bun run build`: green.
- Affected suites green: `exec.test.ts`, `picker.test.ts`, `wallet.test.ts` (13).
- Fast-forwardable into `main`.

Note: one older commit from the stale branch — `a100c200` "make resource tables responsive" (~300 lines in `resource-view.ts`) — was held back to keep this PR focused; can follow up separately if still wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)