### PR TITLE
fix(windows): portable hook paths, PATH prepend, prune error handling, and view cleanup

### DIFF
--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -138,7 +138,18 @@ function warnIfShimShadowed(agent: AgentId): void {
 
   console.log(chalk.yellow(`  Warning: ${AGENTS[agent].cliCommand} currently resolves to ${shadowedBy}`));
   console.log(chalk.gray(`  Managed shim: ${getShimPath(agent)}`));
-  console.log(chalk.gray(`  ${getPathSetupInstructions().split('\n').join('\n  ')}`));
+
+  const result = addShimsToPath();
+  if (!result.success) {
+    console.log(chalk.gray(`  ${getPathSetupInstructions().split('\n').join('\n  ')}`));
+    return;
+  }
+  if (result.alreadyPresent) {
+    console.log(chalk.gray(`  Shim PATH entry already set — ${AGENTS[agent].cliCommand} is shadowed by another binary. Remove or reorder it so ${getShimPath(agent)} takes priority.`));
+    return;
+  }
+  console.log(chalk.green(`  Added shim directory to ${result.location}.`));
+  console.log(chalk.gray(`  ${result.reloadHint}`));
 }
 
 type VersionPruneVerb = 'prune' | 'remove';
@@ -200,7 +211,11 @@ async function versionPruneAction(
 
         for (const v of toRemove) {
           const versionDir = getVersionDir(agent, v);
-          removeVersion(agent, v);
+          const removed = removeVersion(agent, v);
+          if (!removed) {
+            console.log(chalk.red(`Failed to move ${agentLabel(agentConfig.id)}@${v} to trash — a file may be locked by a running process. Close any active sessions and try again.`));
+            continue;
+          }
           fixSessionFilePaths(agent, v, versionDir);
           console.log(chalk.green(`Moved ${agentLabel(agentConfig.id)}@${v} to trash`));
           moved.push({ agent, version: v });
@@ -226,7 +241,11 @@ async function versionPruneAction(
       console.log(chalk.gray(`${agentLabel(agentConfig.id)}@${version} not installed`));
     } else {
       const versionDir = getVersionDir(agent, version);
-      removeVersion(agent, version);
+      const removed = removeVersion(agent, version);
+      if (!removed) {
+        console.log(chalk.red(`Failed to move ${agentLabel(agentConfig.id)}@${version} to trash — a file may be locked by a running process. Close any active sessions and try again.`));
+        continue;
+      }
       fixSessionFilePaths(agent, version, versionDir);
       console.log(chalk.green(`Moved ${agentLabel(agentConfig.id)}@${version} to trash`));
       moved.push({ agent, version });

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -639,16 +639,7 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
     console.log();
   }
 
-  // Show shims path status at the end (only for full list with managed versions)
-  if (versionManaged.length > 0 && !filterAgentId) {
-    const shimsDir = getShimsDir();
-    if (isShimsInPath()) {
-      console.log(chalk.gray(`Shims: ${shimsDir} (in PATH)`));
-    } else {
-      console.log(chalk.yellow(`Shims: ${shimsDir} (not in PATH)`));
-      console.log(chalk.gray('Add to PATH for automatic version switching'));
-    }
-  }
+
 
   // Check for new resources when viewing a specific agent
   if (filterAgentId && versionManaged.length > 0) {

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -9,6 +9,7 @@
  */
 
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import * as yaml from 'yaml';
 import * as TOML from 'smol-toml';
@@ -56,9 +57,40 @@ function getManagedHookPrefixes(): string[] {
   ];
 }
 
+/**
+ * Convert an absolute path under HOME to a portable ~/... form with forward
+ * slashes. Hook commands stored this way work on both macOS and Windows:
+ * absolute Windows paths break in bash because backslashes are stripped as
+ * escape characters, whereas ~/... paths expand correctly via the ~/.claude
+ * symlink/junction on both platforms.
+ */
+function toPortableCommand(absPath: string): string {
+  const home = os.homedir();
+  const normalized = absPath.split(path.sep).join('/');
+  const homeNorm = home.split(path.sep).join('/');
+  if (normalized.startsWith(homeNorm + '/')) {
+    return '~/' + normalized.slice(homeNorm.length + 1);
+  }
+  return normalized;
+}
+
 function isManagedHookCommand(command: string, prefixes: string[]): boolean {
+  // Expand ~/... so tilde-form portable commands can be matched against
+  // absolute managed prefixes.
+  let expanded = command;
+  if (command.startsWith('~/')) {
+    expanded = path.join(os.homedir(), command.slice(2));
+  }
+  // Resolve the directory through symlinks/junctions (e.g. ~/.claude on
+  // Windows is a junction to the versioned home dir where prefixes live).
+  // Resolve the dir, not the full path — the file may not exist after removal.
+  const dir = path.dirname(expanded);
+  let resolvedDir = dir;
+  try { resolvedDir = fs.realpathSync(dir); } catch { /* absent or broken link */ }
+  const resolved = path.join(resolvedDir, path.basename(expanded));
+
   for (const prefix of prefixes) {
-    if (command.startsWith(prefix)) return true;
+    if (resolved.startsWith(prefix)) return true;
   }
   return false;
 }
@@ -89,9 +121,9 @@ function resolveHookCommand(
     // No caching opted in — make sure a previously generated shim from an
     // earlier `cache:` config is gone so the JSONL doesn't keep claiming hits.
     removeHookShim(name);
-    return scriptPath;
+    return toPortableCommand(scriptPath);
   }
-  return generateHookShim({ name, scriptPath, cache });
+  return toPortableCommand(generateHookShim({ name, scriptPath, cache }));
 }
 
 /**
@@ -1478,8 +1510,7 @@ function registerHooksForKimi(
   const filteredHooks = hooksArray.filter((h) => {
     const cmd = typeof h.command === 'string' ? h.command : '';
     if (!cmd) return true;
-    const isManaged = managedPrefixes.some((p) => cmd.startsWith(p));
-    if (!isManaged) return true;
+    if (!isManagedHookCommand(cmd, managedPrefixes)) return true;
     return currentManifestPaths.has(cmd);
   });
 

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -1709,8 +1709,10 @@ export function addShimsToPath(
  * Register the shims dir on the Windows User PATH via the .NET environment API,
  * which writes the registry AND broadcasts WM_SETTINGCHANGE — the correct analog
  * of editing a shell rc file (no `setx` truncation, no manual step). Idempotent:
- * a no-op when the dir is already present. The shims dir is passed via an env var
- * so it is never interpolated into the PowerShell script text.
+ * a no-op when the shims dir is already first in the User PATH. Moves it to the
+ * front when it exists but is in the wrong position (e.g. appended by an old
+ * install) so it overrides any npm/global installs that appear later. The shims
+ * dir is passed via an env var so it is never interpolated into the script text.
  */
 function addShimsToWindowsUserPath(shimsDir: string): ShimPathResult {
   const script = [
@@ -1718,8 +1720,11 @@ function addShimsToWindowsUserPath(shimsDir: string): ShimPathResult {
     "$u = [Environment]::GetEnvironmentVariable('Path','User')",
     "if ($null -eq $u) { $u = '' }",
     "$parts = @($u -split ';' | Where-Object { $_ -ne '' })",
-    "if ($parts -contains $d) { 'present' } else {",
-    "  [Environment]::SetEnvironmentVariable('Path', (($parts + $d) -join ';'), 'User')",
+    // Already first — nothing to do
+    "if ($parts.Count -gt 0 -and $parts[0] -eq $d) { 'present' } else {",
+    // Remove any existing occurrence then prepend, matching POSIX `export PATH="${shimsDir}:$PATH"`
+    "  $newParts = @($d) + @($parts | Where-Object { $_ -ne $d })",
+    "  [Environment]::SetEnvironmentVariable('Path', ($newParts -join ';'), 'User')",
     "  'added'",
     '}',
   ].join('\n');

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1272,7 +1272,15 @@ export function softDeleteVersionDir(agent: AgentId, version: string): string | 
 
   try {
     fs.mkdirSync(trashAgentDir, { recursive: true, mode: 0o700 });
-    fs.renameSync(versionDir, trashDest);
+    try {
+      fs.renameSync(versionDir, trashDest);
+    } catch (renameErr) {
+      // On Windows, rename fails with EPERM/EACCES when any file in the tree
+      // is locked by a running process. Fall back to recursive copy + delete.
+      if ((renameErr as NodeJS.ErrnoException).code !== 'EPERM' && (renameErr as NodeJS.ErrnoException).code !== 'EACCES') throw renameErr;
+      fs.cpSync(versionDir, trashDest, { recursive: true });
+      fs.rmSync(versionDir, { recursive: true, force: true });
+    }
     return trashDest;
   } catch {
     return null;


### PR DESCRIPTION
## Summary

- **Portable hook paths** (`src/lib/hooks.ts`): added `toPortableCommand()` to store hook commands as `~/...` with forward slashes so they work on both macOS and Windows. Updated `isManagedHookCommand()` to handle tilde-form paths and resolve Windows junctions/symlinks before matching against managed prefixes.
- **Windows PATH prepend** (`src/lib/shims.ts`): changed `addShimsToWindowsUserPath()` to prepend the shims directory instead of appending, matching POSIX behavior and ensuring agents-cli overrides conflicting npm/global installs. Also repositions it to the front if previously appended by an older install.
- **Prune error handling** (`src/commands/versions.ts`, `src/lib/versions.ts`): `softDeleteVersionDir()` falls back to recursive copy + delete on Windows when rename fails with EPERM/EACCES (locked files). `versionPruneAction()` checks the return value and surfaces a user-friendly message. `warnIfShimShadowed()` auto-invokes `addShimsToPath()` when shims are shadowed.
- **View cleanup** (`src/commands/view.ts`): removed the Shims status line from `showInstalledVersions()` -- the shadowing warning now handles that prompt automatically.

## Test plan

- [ ] Install on Windows; confirm hook commands are stored as `~/...` paths and fire correctly
- [ ] Install on Windows; confirm shims directory appears at the front of PATH (both fresh install and upgrade from old version)
- [ ] Run `agents versions prune` on Windows with a running agent holding a file lock; confirm user-friendly error instead of crash
- [ ] Run `agents view` and confirm no Shims status line appears

Generated with [Claude Code](https://claude.com/claude-code)