### PR TITLE
fix(registry): bound registry fetches with an 8s timeout

### DIFF
--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -85,6 +85,14 @@ export function removeRegistry(type: RegistryType, name: string): boolean {
   return false;
 }
 
+/**
+ * Cap every registry network call. Without this a slow or unreachable registry
+ * hangs the calling command indefinitely (`agents add`, `agents mcp`, package
+ * resolution) — and makes CI flake when the registry is unreachable. On timeout
+ * the fetch aborts, callers fall back to their git/no-match path.
+ */
+const REGISTRY_FETCH_TIMEOUT_MS = 8000;
+
 async function fetchMcpRegistry(
   url: string,
   query?: string,
@@ -103,7 +111,10 @@ async function fetchMcpRegistry(
     headers['Authorization'] = `Bearer ${apiKey}`;
   }
 
-  const response = await fetch(fullUrl, { headers });
+  const response = await fetch(fullUrl, {
+    headers,
+    signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
+  });
   if (!response.ok) {
     throw new Error(`Registry request failed: ${response.status} ${response.statusText}`);
   }
@@ -273,7 +284,10 @@ async function fetchSkillIndex(url: string, apiKey?: string): Promise<SkillIndex
   const headers: Record<string, string> = { Accept: 'application/json' };
   if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
 
-  const response = await fetch(url, { headers });
+  const response = await fetch(url, {
+    headers,
+    signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
+  });
   if (!response.ok) {
     throw new Error(`Registry request failed: ${response.status} ${response.statusText}`);
   }


### PR DESCRIPTION
## Problem

The MCP/skill registry fetches in `src/lib/registry.ts` had **no timeout**. When a registry is slow or unreachable:

- `agents add`, `agents mcp`, and package resolution (`resolvePackage`) hang indefinitely.
- CI flakes: `tests/registry.test.ts:172` ("resolves unknown user/repo to git fallback") drives `resolvePackage → getMcpServerInfo → fetch` and was timing out at the 30s vitest limit.

That single flaky test was turning **every open dependabot PR red** (#293, #294, #295, #296) for a reason unrelated to the dependency bumps.

## Fix

Cap both `fetch` sites in `registry.ts` with `AbortSignal.timeout(8s)`. On timeout the fetch aborts; the existing per-registry `try/catch` swallows it and callers fall back to their git/no-match path — **same outcome, now bounded**. This is also the correct production behavior: resolution should never hang on a dead registry.

## Verification

- `bun run build` (tsc): clean, exit 0.
- `bun x vitest run tests/registry.test.ts`: **17 passed | 7 skipped**, including the previously-flaky line 172.