### PR TITLE
fix(browser): auto-restart stale browser daemon on version skew (#291)

### DIFF
--- a/src/lib/browser/ipc.test.ts
+++ b/src/lib/browser/ipc.test.ts
@@ -6,6 +6,7 @@ import {
   formatBrowserDaemonNotRunningError,
   getSocketPath,
   sendIPCRequest,
+  shouldRestartStaleDaemon,
 } from './ipc.js';
 import { getHelpersDir } from '../state.js';
 import { startDaemon } from '../daemon.js';
@@ -22,6 +23,7 @@ vi.mock('../state.js', () => ({
 
 vi.mock('../daemon.js', () => ({
   startDaemon: vi.fn(),
+  stopDaemon: vi.fn(),
 }));
 
 afterEach(() => {
@@ -44,5 +46,22 @@ describe('sendIPCRequest', () => {
       sendIPCRequest({ action: 'status' }, { autoStartDaemon: false })
     ).rejects.toThrow(formatBrowserDaemonNotRunningError());
     expect(startDaemon).not.toHaveBeenCalled();
+  });
+});
+
+describe('shouldRestartStaleDaemon', () => {
+  it('restarts when the daemon reports a different concrete version', () => {
+    expect(shouldRestartStaleDaemon('1.2.0', '1.3.0')).toBe(true);
+    expect(shouldRestartStaleDaemon('0.0.0-dev.abc', '0.0.0-dev.def')).toBe(true);
+  });
+
+  it('does not restart when versions match', () => {
+    expect(shouldRestartStaleDaemon('1.3.0', '1.3.0')).toBe(false);
+  });
+
+  it('does not restart on an ambiguous daemon version', () => {
+    expect(shouldRestartStaleDaemon(undefined, '1.3.0')).toBe(false);
+    expect(shouldRestartStaleDaemon('', '1.3.0')).toBe(false);
+    expect(shouldRestartStaleDaemon('unknown', '1.3.0')).toBe(false);
   });
 });

--- a/src/lib/browser/ipc.ts
+++ b/src/lib/browser/ipc.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { IS_WINDOWS, ipcEndpoint } from '../platform/index.js';
 import { getHelpersDir } from '../state.js';
 import { BrowserService } from './service.js';
-import { startDaemon } from '../daemon.js';
+import { startDaemon, stopDaemon } from '../daemon.js';
 import { getCliVersion } from '../version.js';
 import type { IPCRequest, IPCResponse, RefNodeJson } from './types.js';
 
@@ -522,45 +522,61 @@ export class BrowserIPCServer {
   }
 }
 
-let versionCheckedThisProcess = false;
+let versionReconciledThisProcess = false;
 
 /**
- * Check the daemon's version against ours and warn loudly when they
- * differ. Fires at most once per CLI process — successive calls in the
- * same `agents browser ...` invocation are cheap. The whole reason this
- * code exists: a launchd-managed registry daemon kept serving stale code
- * to a dev-build CLI for an entire session and nothing surfaced it.
+ * Decide whether a running daemon is stale and must be restarted. A daemon
+ * is stale when it reports a concrete version that differs from this CLI's.
+ * `undefined`/`'unknown'` means the daemon is too old to answer the `version`
+ * action reliably — don't churn it on that ambiguous signal.
  */
-async function maybeWarnVersionMismatch(): Promise<void> {
-  if (versionCheckedThisProcess) return;
-  versionCheckedThisProcess = true;
+export function shouldRestartStaleDaemon(
+  daemonVersion: string | undefined,
+  clientVersion: string
+): boolean {
+  if (!daemonVersion || daemonVersion === 'unknown') return false;
+  return daemonVersion !== clientVersion;
+}
+
+/**
+ * Reconcile the running daemon's version with ours. If the daemon is serving
+ * stale code, stop and restart it so this request — and the rest of the
+ * session — runs the current build. Runs at most once per CLI process. The
+ * whole reason this exists: a launchd-managed daemon kept serving stale code
+ * to a dev-build CLI for an entire session and nothing surfaced it (#291).
+ */
+async function reconcileDaemonVersion(socketPath: string): Promise<void> {
+  if (versionReconciledThisProcess) return;
+  versionReconciledThisProcess = true;
+
+  let daemon: string | undefined;
   try {
-    const resp = await sendRawIPCRequest({ action: 'version' });
-    const daemon = resp.version;
-    const client = getCliVersion();
-    if (!daemon || daemon === 'unknown' || daemon === client) return;
-    process.stderr.write(
-      `\nwarning: browser daemon is on ${daemon} but this CLI is on ${client}.\n` +
-        `         Run \`agents daemon restart\` to load the current code.\n\n`
-    );
+    const resp = await sendRawIPCRequest({ action: 'version' }, { autoStartDaemon: false });
+    daemon = resp.version;
   } catch {
-    // daemon might be an older build that doesn't speak 'version' — that's
-    // itself a hint, but a noisy one. Stay silent on this path.
+    // Daemon unreachable or too old to speak 'version' — leave it alone.
+    return;
   }
+
+  const client = getCliVersion();
+  if (!shouldRestartStaleDaemon(daemon, client)) return;
+
+  process.stderr.write(
+    `\nbrowser daemon was on ${daemon}, this CLI is on ${client} — restarting it to load current code.\n\n`
+  );
+  stopDaemon();
+  startDaemon();
+  if (!(await isDaemonReachable())) {
+    await waitForSocket(socketPath, 6000);
+  }
+  await new Promise((r) => setTimeout(r, 300));
 }
 
 export async function sendIPCRequest(
   request: IPCRequest,
   opts: IPCRequestOptions = {}
 ): Promise<IPCResponse> {
-  const result = await sendRawIPCRequest(request, opts);
-  // Run the version check after the user's request returns — keeps the
-  // critical path zero-overhead and ensures `start` doesn't get blocked
-  // on a daemon-restart warning that the user hasn't read yet.
-  if (request.action !== 'version') {
-    maybeWarnVersionMismatch().catch(() => {});
-  }
-  return result;
+  return sendRawIPCRequest(request, opts);
 }
 
 async function sendRawIPCRequest(
@@ -587,6 +603,13 @@ async function sendRawIPCRequest(
       throw new Error('Failed to start browser daemon');
     }
     await new Promise((r) => setTimeout(r, 300));
+  }
+
+  // Before serving a real request, make sure the daemon isn't running stale
+  // code. Skips the internal `version` probe (avoids recursion) and callers
+  // that opt out of auto-start. No-ops once reconciled or when versions match.
+  if (request.action !== 'version' && autoStartDaemon) {
+    await reconcileDaemonVersion(socketPath);
   }
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Closes #291.

## Problem

The browser daemon is hosted inside the scheduler daemon and auto-starts on the first IPC request. But `startDaemon()` early-returns when a daemon is already alive **with no version check** (`src/lib/daemon.ts:323-326`) — so a daemon launched from a stale build keeps serving old code for the whole session.

The only signal was a warning that told the user to run `agents daemon restart` — **a subcommand that does not exist** (`src/commands/daemon.ts` exposes `start`/`stop`/`status`/`logs`/`_run`, no `restart`; `agents daemon` is itself deprecated).

## Fix

Replace the warn-only path in `src/lib/browser/ipc.ts` with `reconcileDaemonVersion()`: when the daemon reports a concrete version different from this CLI's, **stop and restart it** so the current request and the rest of the session run current code.

- Fires at most once per CLI process.
- Skips the internal `version` probe (no recursion) and callers that opt out of auto-start.
- The decision is factored into a pure, exported `shouldRestartStaleDaemon(daemonVersion, clientVersion)` — returns `false` on `undefined`/`''`/`'unknown'` so an older daemon that can't answer reliably isn't churned.

## Verification

- `tsc --noEmit`: clean, exit 0.
- `bun x vitest run src/lib/browser/ipc.test.ts`: **5 passed** (added `shouldRestartStaleDaemon` coverage: match → no restart, concrete-diff → restart, ambiguous → no restart).