### PR TITLE
fix(windows): make `agents` discoverable right after npm i -g

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+**Windows: `agents` is discoverable right after `npm i -g`**
+
+- On a global Windows install, postinstall now prepends npm's global-bin dir (where `agents.cmd`/`agents.ps1` live) to the **User PATH** via the .NET environment API. Node's installer normally adds it, but winget / portable / nvm-windows setups often don't — and then `npm i -g @phnx-labs/agents-cli` succeeds yet `agents` is "not recognized". The shims dir (claude/codex/…) is still left to `agents setup`, which the user can now run because `agents` resolves.
+- Postinstall also detects a `Restricted`/`AllSigned` PowerShell execution policy (which blocks the generated `.ps1` launchers, so even an on-PATH `agents` fails in PowerShell) and prints the one-line fix (`Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`). The policy is a security setting, so it is never changed silently — only surfaced.
+- Refactor: the Windows User-PATH prepend logic moved from `shims.ts` into a new `src/lib/platform/winpath.ts` leaf module (`prependToWindowsUserPath`, `getEffectiveExecutionPolicy`, `blocksLocalScripts`, `npmGlobalBinFromEntry`); `addShimsToWindowsUserPath` now delegates to it. Pure helpers are unit-tested.
+
 **Factory AI Droid (first-class support)**
 
 - Add `droid` as a first-class supported agent (AgentId + full registry entry for Factory AI's `droid` CLI, config in `~/.factory/`). Installs via the official script (`curl -fsSL https://app.factory.ai/cli | sh`); the binary is resolved through the standard install-script path and isolated per version via the `~/.factory` config symlink (Droid has no `*_HOME` override).

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -154,17 +154,45 @@ function isAlreadyConfigured(rcFile) {
 }
 
 async function main() {
-  // Windows has no shell rc files to edit. Write the `.cmd` shorthands here; the
-  // shims dir gets registered on the User PATH by `agents setup` (via the native
-  // registry API), so we point the user there instead of mutating PATH from an
-  // npm lifecycle script. The primary `agents` command is already on PATH via
-  // npm's global bin and works immediately.
+  // Windows has no shell rc files to edit. Write the `.cmd` shorthands here, then
+  // make sure npm's global-bin dir is on the User PATH so the `agents` command
+  // itself resolves: Node's installer normally adds it, but winget / portable /
+  // nvm-windows setups often don't — and then `npm i -g` succeeds yet `agents`
+  // is "not recognized". The shims dir (claude/codex/...) is still left to
+  // `agents setup`, which the user can now run because `agents` is discoverable.
   if (process.platform === 'win32') {
     console.log(`\nagents-cli installed.`);
     const written = writeAliasShims();
     console.log(`  Installed shorthands: ${written.join(', ')}`);
-    console.log(`\nNext: run  agents setup  — it finishes setup and adds the shims dir to your PATH`);
-    console.log(`(so the bare shorthands ${ALIASES.join(', ')} and versioned aliases work in a new terminal).`);
+
+    // Best-effort: import the platform leaf module from the just-installed dist.
+    // If it's missing or PowerShell is unavailable we degrade to plain guidance.
+    try {
+      const { prependToWindowsUserPath, getEffectiveExecutionPolicy, blocksLocalScripts, npmGlobalBinFromEntry } =
+        await import('../dist/lib/platform/winpath.js');
+
+      const npmBinDir = npmGlobalBinFromEntry(AGENTS_BIN);
+      const pathResult = prependToWindowsUserPath(npmBinDir);
+      if (pathResult.success && !pathResult.alreadyPresent) {
+        console.log(`  Added npm's global bin to your user PATH so 'agents' resolves:\n    ${npmBinDir}`);
+      } else if (!pathResult.success) {
+        console.log(`  Could not update PATH automatically. Add this to your user PATH manually:\n    ${npmBinDir}`);
+      }
+
+      // .ps1 launchers (npm.ps1, agents.ps1) are blocked under Restricted/AllSigned;
+      // we can't safely weaken a security setting from an installer, so guide instead.
+      const policy = getEffectiveExecutionPolicy();
+      if (blocksLocalScripts(policy)) {
+        console.log(`\n  PowerShell execution policy is '${policy}', which blocks the 'agents' launcher (a .ps1).`);
+        console.log(`  Allow local scripts for your user:`);
+        console.log(`    Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`);
+      }
+    } catch {
+      /* dist or PowerShell unavailable — skip; `agents setup` still wires shims */
+    }
+
+    console.log(`\nNext: open a new terminal, then run  agents setup`);
+    console.log(`(adds the shims dir so bare ${ALIASES.join(', ')} and versioned aliases work).`);
   }
   // Opt-in: AGENTS_INIT_SHELL=1 npm install -g @phnx-labs/agents-cli
   else if (process.env.AGENTS_INIT_SHELL === '1') {

--- a/src/lib/platform/index.ts
+++ b/src/lib/platform/index.ts
@@ -20,3 +20,4 @@ export * from './paths.js';
 export * from './exec.js';
 export * from './process.js';
 export * from './ipc.js';
+export * from './winpath.js';

--- a/src/lib/platform/winpath.test.ts
+++ b/src/lib/platform/winpath.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import * as path from 'path';
+import { blocksLocalScripts, npmGlobalBinFromEntry } from './winpath.js';
+
+describe('blocksLocalScripts', () => {
+  // Restricted/AllSigned block the unsigned .ps1 launchers npm and agents-cli
+  // generate, so the bare commands fail in PowerShell even when on PATH.
+  it('flags policies that block unsigned local scripts', () => {
+    for (const p of ['Restricted', 'AllSigned', 'restricted', 'allsigned', '  Restricted  ']) {
+      expect(blocksLocalScripts(p)).toBe(true);
+    }
+  });
+
+  it('allows policies that permit local scripts', () => {
+    for (const p of ['RemoteSigned', 'Bypass', 'Unrestricted', 'Undefined']) {
+      expect(blocksLocalScripts(p)).toBe(false);
+    }
+  });
+
+  it('treats unknown / null policy as non-blocking (no false alarm)', () => {
+    expect(blocksLocalScripts(null)).toBe(false);
+    expect(blocksLocalScripts('')).toBe(false);
+  });
+});
+
+describe('npmGlobalBinFromEntry', () => {
+  // entry = <prefix>/node_modules/@phnx-labs/agents-cli/dist/index.js -> <prefix>
+  // (on Windows the npm bin launchers live in the prefix root, where agents.cmd
+  // is — exactly the dir that must be on PATH for `agents` to resolve).
+  it('resolves the prefix four levels up from dist/index.js', () => {
+    const prefix = path.join('opt', 'tools', 'npmglobal');
+    const entry = path.join(prefix, 'node_modules', '@phnx-labs', 'agents-cli', 'dist', 'index.js');
+    expect(npmGlobalBinFromEntry(entry)).toBe(path.resolve(prefix));
+  });
+});

--- a/src/lib/platform/winpath.ts
+++ b/src/lib/platform/winpath.ts
@@ -1,0 +1,94 @@
+/**
+ * Windows User PATH + execution-policy primitives.
+ *
+ * The single place that mutates the Windows User PATH via the .NET environment
+ * API (which writes the registry AND broadcasts WM_SETTINGCHANGE — the correct
+ * analog of editing a shell rc file: no `setx` truncation, no manual step).
+ * Consumers: `shims.ts` (shims dir) and `scripts/postinstall.js` (npm global-bin
+ * dir, so the `agents` command itself resolves).
+ *
+ * Leaf module — imports only `child_process` and `path` so it is cheap to load
+ * from the npm lifecycle script without pulling the rest of the CLI.
+ */
+import { execFileSync } from 'child_process';
+import * as path from 'path';
+
+export interface WinPathResult {
+  success: boolean;
+  /** True when `dir` was already the first PATH entry (no write performed). */
+  alreadyPresent?: boolean;
+  error?: string;
+}
+
+/**
+ * Prepend `dir` to the Windows User PATH. Idempotent: a no-op when `dir` is
+ * already first; moves it to the front when it exists but is positioned later
+ * (e.g. appended by an older install) so it overrides conflicting entries.
+ * `dir` is passed via an env var so it is never interpolated into the script
+ * text.
+ */
+export function prependToWindowsUserPath(dir: string): WinPathResult {
+  const script = [
+    '$d = $env:AGENTS_WINPATH_DIR',
+    "$u = [Environment]::GetEnvironmentVariable('Path','User')",
+    "if ($null -eq $u) { $u = '' }",
+    "$parts = @($u -split ';' | Where-Object { $_ -ne '' })",
+    // Already first — nothing to do
+    "if ($parts.Count -gt 0 -and $parts[0] -eq $d) { 'present' } else {",
+    // Remove any existing occurrence then prepend, matching POSIX `export PATH="${dir}:$PATH"`
+    "  $newParts = @($d) + @($parts | Where-Object { $_ -ne $d })",
+    "  [Environment]::SetEnvironmentVariable('Path', ($newParts -join ';'), 'User')",
+    "  'added'",
+    '}',
+  ].join('\n');
+  try {
+    const out = execFileSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', script], {
+      encoding: 'utf-8',
+      env: { ...process.env, AGENTS_WINPATH_DIR: dir },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+    return { success: true, alreadyPresent: out.includes('present') };
+  } catch (err) {
+    return { success: false, error: `Could not update the Windows user PATH: ${(err as Error).message}` };
+  }
+}
+
+/**
+ * The effective PowerShell execution policy (e.g. `Restricted`, `RemoteSigned`),
+ * or null if it can't be determined (PowerShell missing / errored).
+ */
+export function getEffectiveExecutionPolicy(): string | null {
+  try {
+    const out = execFileSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', 'Get-ExecutionPolicy'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether a policy blocks running unsigned local `.ps1` scripts — which is what
+ * npm and agents-cli generate (`npm.ps1`, `agents.ps1`). Under these the bare
+ * `agents` / `npm` commands fail in PowerShell with a security error even when
+ * on PATH. Pure — testable on any host.
+ */
+export function blocksLocalScripts(policy: string | null): boolean {
+  if (!policy) return false;
+  const p = policy.trim().toLowerCase();
+  return p === 'restricted' || p === 'allsigned';
+}
+
+/**
+ * Resolve the npm global-bin directory (where the generated `agents` /
+ * `agents.cmd` launchers live, and where npm expects PATH to point) from the
+ * package entrypoint. On Windows npm places bin launchers directly in the
+ * prefix root, so the bin dir is the prefix itself.
+ *
+ * entry = `<prefix>/node_modules/@phnx-labs/agents-cli/dist/index.js` → `<prefix>`
+ */
+export function npmGlobalBinFromEntry(entryJsPath: string): string {
+  return path.resolve(path.dirname(entryJsPath), '..', '..', '..', '..');
+}

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -11,11 +11,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { execFileSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { confirm, select } from '@inquirer/prompts';
 import type { AgentId } from './types.js';
-import { IS_WINDOWS } from './platform/index.js';
+import { IS_WINDOWS, prependToWindowsUserPath } from './platform/index.js';
 import { getShimsDir, getVersionsDir, getBackupsDir, ensureAgentsDir } from './state.js';
 export { getShimsDir };
 import { AGENTS } from './agents.js';
@@ -1715,34 +1714,16 @@ export function addShimsToPath(
  * dir is passed via an env var so it is never interpolated into the script text.
  */
 function addShimsToWindowsUserPath(shimsDir: string): ShimPathResult {
-  const script = [
-    '$d = $env:AGENTS_SHIMS_DIR',
-    "$u = [Environment]::GetEnvironmentVariable('Path','User')",
-    "if ($null -eq $u) { $u = '' }",
-    "$parts = @($u -split ';' | Where-Object { $_ -ne '' })",
-    // Already first — nothing to do
-    "if ($parts.Count -gt 0 -and $parts[0] -eq $d) { 'present' } else {",
-    // Remove any existing occurrence then prepend, matching POSIX `export PATH="${shimsDir}:$PATH"`
-    "  $newParts = @($d) + @($parts | Where-Object { $_ -ne $d })",
-    "  [Environment]::SetEnvironmentVariable('Path', ($newParts -join ';'), 'User')",
-    "  'added'",
-    '}',
-  ].join('\n');
-  try {
-    const out = execFileSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', script], {
-      encoding: 'utf-8',
-      env: { ...process.env, AGENTS_SHIMS_DIR: shimsDir },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    }).trim();
-    return {
-      success: true,
-      alreadyPresent: out.includes('present'),
-      location: 'your user PATH',
-      reloadHint: 'Open a new terminal for the change to take effect.',
-    };
-  } catch (err) {
-    return { success: false, error: `Could not update the Windows user PATH: ${(err as Error).message}` };
+  const r = prependToWindowsUserPath(shimsDir);
+  if (!r.success) {
+    return { success: false, error: r.error };
   }
+  return {
+    success: true,
+    alreadyPresent: r.alreadyPresent,
+    location: 'your user PATH',
+    reloadHint: 'Open a new terminal for the change to take effect.',
+  };
 }
 
 export function listAgentsWithInstalledVersions(): AgentId[] {


### PR DESCRIPTION
## Summary

Follow-up to #303. On a global **Windows** install, `npm i -g @phnx-labs/agents-cli` can succeed yet `agents` is "not recognized" — two stock-setup gaps that #303 (shims-dir PATH) doesn't cover:

1. **npm's global-bin dir isn't on PATH.** Node's installer normally adds `%APPDATA%\npm`, but winget / portable / nvm-windows setups often don't. Postinstall now **prepends it to the User PATH** via the same .NET environment API used for the shims dir, so the `agents` command itself resolves. The shims dir (claude/codex/…) is still left to `agents setup`, which is now runnable.
2. **Restricted execution policy blocks the `.ps1` launcher.** Even on PATH, `agents` fails in PowerShell under `Restricted`/`AllSigned`. Postinstall detects this and prints the one-line fix (`Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`). The policy is a security setting — never changed silently, only surfaced.

## Refactor

Windows User-PATH logic moved from `shims.ts` into a new `src/lib/platform/winpath.ts` leaf module (`prependToWindowsUserPath`, `getEffectiveExecutionPolicy`, `blocksLocalScripts`, `npmGlobalBinFromEntry`). `addShimsToWindowsUserPath` delegates to it — behavior unchanged.

## Tests

- Unit: `winpath.test.ts` covers the pure helpers (policy classifier + npm-bin path math); existing shims/exec/platform/postinstall suites green.
- End-to-end on a **Windows 11 VM** as a real user, from the broken stock state (npm-bin off PATH + `Restricted` policy):
  - postinstall printed `Added npm's global bin to your user PATH` + the execution-policy hint
  - User PATH gained `C:\Users\…\AppData\Roaming\npm` (prepended)
  - `agents --version` → `1.20.12` in a fresh process (cmd; and PowerShell after applying the hint)