### PR TITLE
fix(rotate): dedup balanced candidates by org, not email (#309)

### DIFF
--- a/src/lib/__tests__/rotate.test.ts
+++ b/src/lib/__tests__/rotate.test.ts
@@ -64,6 +64,7 @@ function cand(overrides: Partial<RotateCandidate>): RotateCandidate {
     agent: 'claude',
     version: '0.0.0',
     email: 'a@b.com',
+    usageKey: null,
     usageStatus: 'available',
     usageSnapshot: null,
     authValid: true,
@@ -285,6 +286,55 @@ describe('pickBalancedCandidate', () => {
     // Among the user-a@example.com versions, the older lastActive wins.
     const survivor = result!.healthy.find((x) => x.email === 'user-a@example.com');
     expect(survivor!.version).toBe('2.1.118');
+  });
+
+  it('keeps two orgs under one email as distinct candidates (dedup by org, not email)', () => {
+    // Same Google identity signed into a Personal org on one version and an
+    // Enterprise org on another. Quota is per-org, so these are separate
+    // rate-limit buckets and must both stay healthy — the email collision is
+    // not an account collision. Regression for #309.
+    const personal = cand({
+      version: '2.1.170',
+      email: 'taylor@example.com',
+      usageKey: 'claude:org=e93db6f2',
+      usageSnapshot: claudeUsage(0, 0),
+    });
+    const enterprise = cand({
+      version: '2.1.183',
+      email: 'taylor@example.com',
+      usageKey: 'claude:org=8763a87b',
+      usageSnapshot: claudeUsage(0, 64),
+    });
+
+    const result = pickBalancedCandidate([personal, enterprise]);
+    expect(result!.healthy).toHaveLength(2);
+    expect(result!.excluded).toHaveLength(0);
+    expect(result!.healthy.map((c) => c.version).sort()).toEqual(['2.1.170', '2.1.183']);
+  });
+
+  it('still collapses two versions sharing one org (same usage key)', () => {
+    // Two installed versions, same org → same quota bucket → must dedup to one
+    // even though they are distinct versions. The lower-used / older-active one
+    // survives per compareCandidates.
+    const a = cand({
+      version: '2.1.170',
+      email: 'taylor@example.com',
+      usageKey: 'claude:org=e93db6f2',
+      lastActive: new Date('2026-04-20T10:00:00Z'),
+    });
+    const b = cand({
+      version: '2.1.183',
+      email: 'taylor@example.com',
+      usageKey: 'claude:org=e93db6f2',
+      lastActive: new Date('2026-04-20T05:00:00Z'),
+    });
+
+    const result = pickBalancedCandidate([a, b]);
+    expect(result!.healthy).toHaveLength(1);
+    expect(result!.excluded).toHaveLength(1);
+    // Older lastActive wins (compareCandidates tiebreak), newer is excluded.
+    expect(result!.healthy[0].version).toBe('2.1.183');
+    expect(result!.excluded[0].version).toBe('2.1.170');
   });
 
   it('parallel selection fans out across unique accounts even when versions share emails', () => {

--- a/src/lib/rotate.ts
+++ b/src/lib/rotate.ts
@@ -28,6 +28,13 @@ export interface RotateCandidate {
   agent: AgentId;
   version: string;
   email: string | null;
+  /**
+   * Per-org usage/quota key (e.g. `claude:org=<orgUuid>`) — the unit rate
+   * limits are actually measured in. Distinct orgs signed in under the same
+   * email have distinct keys, so this is the correct dedup boundary; null when
+   * no usage identity is available (then we fall back to email).
+   */
+  usageKey: string | null;
   usageStatus: AccountInfo['usageStatus'];
   usageSnapshot: UsageSnapshot | null;
   authValid: boolean;
@@ -138,19 +145,30 @@ function compareCandidates(a: RotateCandidate, b: RotateCandidate): number {
   return Math.random() - 0.5;
 }
 
+/**
+ * Identity a candidate dedups on. Quota is tracked per-org, so two versions
+ * that share an org are the same rate-limit bucket and must collapse — but two
+ * orgs under the same email (e.g. Enterprise + Personal on one Google identity)
+ * are genuinely separate buckets and must stay distinct. Prefer the org usage
+ * key; fall back to email only when no usage identity is available.
+ */
+function candidateIdentity(c: RotateCandidate): string {
+  return c.usageKey ?? c.email!;
+}
+
 function dedupeAndSortCandidates(candidates: RotateCandidate[]): RotateCandidate[] {
-  const byEmail = new Map<string, RotateCandidate>();
+  const byIdentity = new Map<string, RotateCandidate>();
   for (const c of candidates) {
-    const email = c.email!;
-    const existing = byEmail.get(email);
+    const id = candidateIdentity(c);
+    const existing = byIdentity.get(id);
     if (!existing) {
-      byEmail.set(email, c);
+      byIdentity.set(id, c);
       continue;
     }
-    if (compareCandidates(c, existing) < 0) byEmail.set(email, c);
+    if (compareCandidates(c, existing) < 0) byIdentity.set(id, c);
   }
 
-  return [...byEmail.values()].sort(compareCandidates);
+  return [...byIdentity.values()].sort(compareCandidates);
 }
 
 /**
@@ -297,7 +315,7 @@ async function collectRunCandidates(agent: AgentId): Promise<RotateCandidate[]> 
     const usageSnapshot = usageKey
       ? usageByKey.get(usageKey)?.snapshot ?? null
       : null;
-    return { ...candidate, usageSnapshot };
+    return { ...candidate, usageKey, usageSnapshot };
   });
 }
 


### PR DESCRIPTION
Closes #309.

## Problem

The `balanced` run strategy deduplicated routing candidates by **email**, but quota/rate limits are tracked per **org** (`usageKey = claude:org=<orgUuid>`). When one email is signed into two different Anthropic orgs — e.g. an Enterprise org and a Personal org under the same Google identity — these are genuinely separate rate-limit buckets, but the balancer collapsed them into one candidate and pushed the other to `excluded`.

Result: the rotation banner permanently read `1 of N healthy`, and `weightedRandomByCapacity` never fanned out — parallel runs stampeded the single surviving org instead of distributing by headroom.

## Root cause

`dedupeAndSortCandidates` (`src/lib/rotate.ts`) keyed its dedup map on `c.email`. Meanwhile `collectRunCandidates` already computed the per-org `usageKey` via `getUsageLookupKey(info)` but **discarded** it after looking up the usage snapshot — so the org identity never reached the dedup layer.

## Fix

- Carry `usageKey: string | null` on `RotateCandidate`, populated in `collectRunCandidates`.
- Dedup on a `candidateIdentity()` = `usageKey ?? email`. Distinct orgs stay distinct; same-org/multi-version still collapses to one bucket; email remains the fallback when no usage identity is available (preserving prior behavior for accounts with no live usage data).

## Tests

Added to `src/lib/__tests__/rotate.test.ts`:
- two orgs under one email stay as two healthy candidates (the #309 case) → reports `2 of 2 healthy`;
- two versions sharing one org still collapse to a single candidate.

`vitest run src/lib/__tests__/rotate.test.ts` → 25 passed. `tsc` clean.

Note: two unrelated suites (`models.test.ts` Gemini catalog, `hooks.test.ts` GC invariant) fail on `main` independent of this change — this diff touches only `rotate.ts` + `rotate.test.ts`, and neither failing module imports rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)