### PR TITLE
feat(cli): add rm/purge aliases for remove and a top-level restore command

### DIFF
--- a/src/commands/trash.ts
+++ b/src/commands/trash.ts
@@ -113,6 +113,59 @@ function humanSize(bytes: number): string {
   return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
 }
 
+/**
+ * Restore a soft-deleted version back into ~/.agents/.history/versions/.
+ * Shared by `agents trash restore` and the top-level `agents restore` alias.
+ * Exits the process with a non-zero code on any failure.
+ */
+export function restoreVersion(target: string): void {
+  const parsed = parseAgentVersion(target);
+  if (!parsed) {
+    console.error(chalk.red(`Expected <agent>@<version>, got: ${target}`));
+    process.exit(1);
+  }
+  const { agent, version } = parsed;
+  const entries = listTrashEntries(agent);
+  const entry = pickLatest(entries, agent, version);
+  if (!entry) {
+    console.error(chalk.red(`No trashed copy found for ${agent}@${version}`));
+    console.error(chalk.gray('Run `agents trash list` to see what exists.'));
+    process.exit(1);
+  }
+  const dest = getVersionDir(agent, version);
+  if (fs.existsSync(dest)) {
+    console.error(chalk.red(`Cannot restore: ${dest} already exists.`));
+    console.error(chalk.gray('Move or remove the existing dir first, then re-run restore.'));
+    process.exit(1);
+  }
+  try {
+    fs.mkdirSync(path.dirname(dest), { recursive: true, mode: 0o700 });
+    fs.renameSync(entry.trashPath, dest);
+  } catch (err) {
+    console.error(chalk.red(`Restore failed: ${(err as Error).message}`));
+    process.exit(1);
+  }
+  // Best-effort cleanup of empty stamp/version parents in trash.
+  try {
+    const verDir = path.dirname(entry.trashPath);
+    if (fs.readdirSync(verDir).length === 0) fs.rmdirSync(verDir);
+    const agentDir = path.dirname(verDir);
+    if (fs.readdirSync(agentDir).length === 0) fs.rmdirSync(agentDir);
+  } catch { /* best-effort */ }
+  console.log(chalk.green(`Restored ${agentLabel(agent)}@${version} to ${dest}`));
+}
+
+/**
+ * Register the top-level `agents restore` command — a shorthand for
+ * `agents trash restore` so users can undo a `remove`/`prune` directly.
+ */
+export function registerRestoreCommand(program: Command): void {
+  program
+    .command('restore <target>')
+    .description('Restore a soft-deleted agent version (e.g. "codex@0.141.0") removed via prune/remove')
+    .action((target: string) => restoreVersion(target));
+}
+
 export function registerTrashCommands(program: Command): void {
   const trash = program
     .command('trash')
@@ -145,46 +198,11 @@ export function registerTrashCommands(program: Command): void {
         );
       }
       console.log();
-      console.log(chalk.gray('Restore with: agents trash restore <agent>@<version>'));
+      console.log(chalk.gray('Restore with: agents restore <agent>@<version>'));
     });
 
   trash
     .command('restore <target>')
     .description('Restore a soft-deleted version (e.g. "claude@2.1.110") back to ~/.agents/.history/versions/')
-    .action((target: string) => {
-      const parsed = parseAgentVersion(target);
-      if (!parsed) {
-        console.error(chalk.red(`Expected <agent>@<version>, got: ${target}`));
-        process.exit(1);
-      }
-      const { agent, version } = parsed;
-      const entries = listTrashEntries(agent);
-      const entry = pickLatest(entries, agent, version);
-      if (!entry) {
-        console.error(chalk.red(`No trashed copy found for ${agent}@${version}`));
-        console.error(chalk.gray('Run `agents trash list` to see what exists.'));
-        process.exit(1);
-      }
-      const dest = getVersionDir(agent, version);
-      if (fs.existsSync(dest)) {
-        console.error(chalk.red(`Cannot restore: ${dest} already exists.`));
-        console.error(chalk.gray('Move or remove the existing dir first, then re-run restore.'));
-        process.exit(1);
-      }
-      try {
-        fs.mkdirSync(path.dirname(dest), { recursive: true, mode: 0o700 });
-        fs.renameSync(entry.trashPath, dest);
-      } catch (err) {
-        console.error(chalk.red(`Restore failed: ${(err as Error).message}`));
-        process.exit(1);
-      }
-      // Best-effort cleanup of empty stamp/version parents in trash.
-      try {
-        const verDir = path.dirname(entry.trashPath);
-        if (fs.readdirSync(verDir).length === 0) fs.rmdirSync(verDir);
-        const agentDir = path.dirname(verDir);
-        if (fs.readdirSync(agentDir).length === 0) fs.rmdirSync(agentDir);
-      } catch { /* best-effort */ }
-      console.log(chalk.green(`Restored ${agentLabel(agent)}@${version} to ${dest}`));
-    });
+    .action((target: string) => restoreVersion(target));
 }

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -559,7 +559,13 @@ export function registerVersionsCommands(program: Command): void {
     });
 
   configureVersionPruneCommand(program.command('prune <specs...>'), 'prune');
-  configureVersionPruneCommand(program.command('remove <specs...>', { hidden: true }), 'remove');
+  // `rm` and `purge` are commander aliases for `remove` (which is itself an
+  // alias for `prune`). Native `.aliases()` keeps them in lockstep — same
+  // action, same options, no duplicate registration.
+  configureVersionPruneCommand(
+    program.command('remove <specs...>', { hidden: true }).aliases(['rm', 'purge']),
+    'remove',
+  );
 
   const useCmd = program
     .command('use <agent> [version]')

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ import { registerRunCommand } from './commands/exec.js';
 import { registerModelsCommand } from './commands/models.js';
 import { registerDefaultsCommands } from './commands/defaults.js';
 import { registerPruneCommand } from './commands/prune.js';
-import { registerTrashCommands } from './commands/trash.js';
+import { registerTrashCommands, registerRestoreCommand } from './commands/trash.js';
 import { registerDoctorCommand } from './commands/doctor.js';
 import { registerSubagentsCommands } from './commands/subagents.js';
 import { registerPluginsCommands } from './commands/plugins.js';
@@ -716,6 +716,7 @@ registerDefaultsCommands(program);
 registerModelsCommand(program);
 registerPruneCommand(program);
 registerTrashCommands(program);
+registerRestoreCommand(program);
 registerDoctorCommand(program);
 
 // Deprecated 'exec' alias for 'run'

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1347,9 +1347,9 @@ export function printTrashFooter(moved: Array<{ agent: AgentId; version: string 
   console.log(chalk.gray('Sessions remain accessible via `agents sessions`.'));
   if (moved.length === 1) {
     const { agent, version } = moved[0];
-    console.log(chalk.gray(`Restore with: agents trash restore ${agent}@${version}`));
+    console.log(chalk.gray(`Restore with: agents restore ${agent}@${version}`));
   } else {
-    console.log(chalk.gray('Restore with: agents trash restore <agent>@<version>  (run `agents trash list` to see)'));
+    console.log(chalk.gray('Restore with: agents restore <agent>@<version>  (run `agents trash list` to see)'));
   }
 }
 

--- a/tests/non-interactive.test.ts
+++ b/tests/non-interactive.test.ts
@@ -253,7 +253,7 @@ describe('non-interactive CLI usage', () => {
     expect(result.status).toBe(0);
     expect(combined).toContain(`Moved Claude@${version} to trash`);
     expect(combined).toContain('Sessions remain accessible via `agents sessions`.');
-    expect(combined).toContain(`Restore with: agents trash restore claude@${version}`);
+    expect(combined).toContain(`Restore with: agents restore claude@${version}`);
     expect(fs.existsSync(versionDir)).toBe(false);
 
     const trashAgentDir = path.join(home, '.agents', '.history', 'trash', 'versions', 'claude', version);
@@ -285,6 +285,56 @@ describe('non-interactive CLI usage', () => {
     expect(combined).toContain(`Moved Codex@${version} to trash`);
     expect(fs.existsSync(versionDir)).toBe(false);
     expect(fs.existsSync(path.join(home, '.agents', '.history', 'trash', 'versions', 'codex', version))).toBe(true);
+  });
+
+  it.each(['rm', 'purge'])('treats %s as an alias for version prune', (verb) => {
+    const home = makeTempHome();
+    tempHomes.push(home);
+    const version = '0.131.0';
+    writeFakeManagedVersion(home, 'codex', version, 'codex');
+
+    const versionDir = path.join(home, '.agents', '.history', 'versions', 'codex', version);
+    const result = runAgents(home, [verb, `codex@${version}`]);
+    const combined = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.status).toBe(0);
+    expect(combined).toContain(`Moved Codex@${version} to trash`);
+    expect(fs.existsSync(versionDir)).toBe(false);
+    expect(fs.existsSync(path.join(home, '.agents', '.history', 'trash', 'versions', 'codex', version))).toBe(true);
+  });
+
+  it('restores a soft-deleted version via the top-level restore command', () => {
+    const home = makeTempHome();
+    tempHomes.push(home);
+    const version = '0.132.0';
+    writeFakeManagedVersion(home, 'codex', version, 'codex');
+
+    const versionDir = path.join(home, '.agents', '.history', 'versions', 'codex', version);
+    expect(runAgents(home, ['remove', `codex@${version}`]).status).toBe(0);
+    expect(fs.existsSync(versionDir)).toBe(false);
+
+    const result = runAgents(home, ['restore', `codex@${version}`]);
+    const combined = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.status).toBe(0);
+    expect(combined).toContain(`Restored Codex@${version}`);
+    // Version directory is back where it was, binary intact.
+    expect(fs.existsSync(versionDir)).toBe(true);
+    expect(fs.existsSync(path.join(versionDir, 'node_modules', '.bin', 'codex'))).toBe(true);
+    // Trash entry for this version is emptied out after the move.
+    const trashVersionDir = path.join(home, '.agents', '.history', 'trash', 'versions', 'codex', version);
+    expect(fs.existsSync(trashVersionDir)).toBe(false);
+  });
+
+  it('exits non-zero when restoring a version that is not in trash', () => {
+    const home = makeTempHome();
+    tempHomes.push(home);
+
+    const result = runAgents(home, ['restore', 'codex@9.9.9']);
+    const combined = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.status).toBe(1);
+    expect(combined).toContain('No trashed copy found for codex@9.9.9');
   });
 
   it('does not hard-delete trash entries through cleanup', () => {


### PR DESCRIPTION
## What

- Add `rm` and `purge` as aliases for `agents remove` (which is itself an alias for `agents prune`), via commander's native `.aliases()` — all three share one action/options registration.
- Add a top-level `agents restore <agent>@<version>` command as a shorthand for `agents trash restore`, so a removed/pruned version can be recovered without the `trash` subcommand. The restore logic is extracted into a shared `restoreVersion()` used by both entry points.
- Removal footers (`prune`/`remove` output and `trash list`) now point at the shorter `agents restore <agent>@<version>`.

## Why

`agents remove codex@0.141.0` moves a version to trash, but the only way back was the longer `agents trash restore …` (and `agents restore` returned "unknown command"). `rm`/`purge` are the muscle-memory verbs for removal; `restore` is the natural inverse.

## Testing

- `tsc --noEmit` clean; `npm run build` clean.
- Verified end-to-end against the real CLI: restored a trashed version back into `~/.agents/.history/versions/`, then re-removed to leave trash state intact.
- New tests in `tests/non-interactive.test.ts`: `rm`/`purge` alias coverage, a `restore` round-trip (remove → restore → binary intact, trash emptied), and the not-in-trash failure path. Updated the existing footer assertion. 30/30 pass across affected files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
