### PR TITLE
fix(run): launch the OpenCode TUI for interactive `agents run opencode`

### DIFF
--- a/src/lib/__tests__/exec.test.ts
+++ b/src/lib/__tests__/exec.test.ts
@@ -305,6 +305,33 @@ describe('buildExecCommand', () => {
       expect(cmd[0]).toBe('codex');
       expect(cmd).not.toContain('exec');
     });
+
+    it('no flag and no prompt drops the opencode run subcommand (interactive TUI)', () => {
+      const cmd = buildExecCommand(opts({ agent: 'opencode', prompt: undefined }));
+      expect(cmd[0]).toBe('opencode');
+      expect(cmd).not.toContain('run');
+    });
+
+    it('--headless with no prompt keeps opencode in headless run subcommand', () => {
+      const cmd = buildExecCommand(opts({ agent: 'opencode', prompt: undefined, headless: true }));
+      expect(cmd.slice(0, 2)).toEqual(['opencode', 'run']);
+    });
+
+    it('prompt without flags keeps opencode headless with the prompt as a positional', () => {
+      const cmd = buildExecCommand(opts({ agent: 'opencode', prompt: 'fix auth' }));
+      expect(cmd.slice(0, 2)).toEqual(['opencode', 'run']);
+      expect(cmd[cmd.length - 1]).toBe('fix auth');
+      expect(cmd).not.toContain('--prompt');
+    });
+
+    it('--interactive with a prompt launches the opencode TUI and forwards via --prompt', () => {
+      const cmd = buildExecCommand(opts({ agent: 'opencode', prompt: 'fix auth', interactive: true }));
+      expect(cmd[0]).toBe('opencode');
+      expect(cmd).not.toContain('run');
+      const flagIdx = cmd.indexOf('--prompt');
+      expect(flagIdx).toBeGreaterThan(-1);
+      expect(cmd[flagIdx + 1]).toBe('fix auth');
+    });
   });
 
   // --- resolveInteractive precedence ---

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -484,11 +484,16 @@ export function buildExecCommand(options: ExecOptions): string[] {
   const cmd: string[] = [...template.base];
   const interactive = resolveInteractive(options);
 
-  // For Codex and Droid, 'exec' is the headless subcommand -- drop it for
-  // interactive mode so we run the TUI ('codex' / 'droid') instead of the
-  // one-shot 'codex exec' / 'droid exec'.
-  if ((options.agent === 'codex' || options.agent === 'droid') && interactive && cmd[1] === 'exec') {
-    cmd.splice(1, 1);
+  // For Codex and Droid, 'exec' is the headless subcommand; for OpenCode, 'run'
+  // is. Drop it for interactive mode so we launch the TUI (`codex` / `droid` /
+  // `opencode`, each agent's default command) instead of the one-shot headless
+  // subcommand ('codex exec' / 'droid exec' / 'opencode run').
+  if (interactive) {
+    if ((options.agent === 'codex' || options.agent === 'droid') && cmd[1] === 'exec') {
+      cmd.splice(1, 1);
+    } else if (options.agent === 'opencode' && cmd[1] === 'run') {
+      cmd.splice(1, 1);
+    }
   }
 
   // Use versioned alias if a specific version was requested (e.g., claude@2.1.98).
@@ -589,7 +594,11 @@ export function buildExecCommand(options: ExecOptions): string[] {
   // so the CLI launches its TUI. When --interactive is passed alongside a prompt
   // we still forward the prompt so the agent receives it as the first message.
   if (options.prompt !== undefined) {
-    if (template.promptFlag === 'positional') {
+    if (interactive && options.agent === 'opencode') {
+      // The OpenCode TUI takes an initial prompt via --prompt; a bare positional
+      // on the default command is parsed as a project path, not a message.
+      cmd.push('--prompt', options.prompt);
+    } else if (template.promptFlag === 'positional') {
       cmd.push(options.prompt);
     } else {
       cmd.push(template.promptFlag, options.prompt);


### PR DESCRIPTION
## Problem

`agents run opencode` with no prompt is meant to launch OpenCode's interactive TUI, but it didn't. `opencode run [message]` is OpenCode's **headless** one-shot subcommand — the interactive TUI is the **default** command, `opencode [project]` (confirmed via `opencode --help`).

The subcommand-drop logic in `buildExecCommand` (`src/lib/exec.ts`) only stripped the headless subcommand for `codex`/`droid` (`exec`). For opencode the `run` token was never dropped, so an interactive `agents run opencode` built `opencode run --agent plan`, which never renders the TUI.

The general headless/interactive resolution (no prompt → interactive, prompt → headless, `--headless`/`--interactive` force the mode) already works (PR #300); this only fixes the opencode-specific command construction.

## Changes

- **Drop `run` for opencode in interactive mode**, mirroring the existing codex/droid `exec` handling.
- **Forward an interactive prompt via `--prompt`** instead of a bare positional — the TUI parses a bare positional as a *project path*, not a message (`--prompt` is the TUI's initial-prompt flag).

## Resulting commands

| Invocation | Built command |
| --- | --- |
| `agents run opencode` | `opencode --agent plan` (TUI) |
| `agents run opencode "list files"` | `opencode run --agent plan "list files"` (headless) |
| `agents run opencode -i "summarize"` | `opencode --agent plan --prompt "summarize"` (TUI, seeded) |
| `agents run opencode --headless` | `opencode run --agent plan` (stays headless) |

codex/claude/droid commands are unchanged.

## Tests

`src/lib/__tests__/exec.test.ts` — 4 new cases mirroring the codex interactive cases (TUI drop, headless retention, positional prompt headless, `--prompt` forwarding). `exec.test.ts` passes 154/154. Also verified against the compiled `dist/lib/exec.js` artifact for all four scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
