### PR TITLE
test(security): RCE-regression coverage for execFile migration sites (RUSH-554)

### DIFF
--- a/src/lib/drive-sync.test.ts
+++ b/src/lib/drive-sync.test.ts
@@ -1,0 +1,179 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { pathToFileURL } from 'url';
+import { spawnSync } from 'child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+
+// `config.remote` flows from disk (~/.agents/.cache/drive/config.json) into the
+// argv of rsync/ssh. A tampered config could carry shell metacharacters or a
+// leading-dash argv flag. These tests exercise the REAL compiled drive-sync
+// module against fake `rsync`/`ssh` binaries on PATH and assert two things:
+//   1. A tainted remote is rejected by assertValidRemote on EVERY read, before
+//      any exec — so the fake binary's `pwned` marker is never created.
+//   2. A well-formed remote is handed to rsync/ssh as a single literal argv
+//      element, never shell-evaluated.
+
+const tempDirs: string[] = [];
+
+function makeTempHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-drive-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+const moduleUrl = pathToFileURL(path.resolve('dist/lib/drive-sync.js')).href;
+
+/** Drive config dir for a given fake HOME (mirrors getDriveDir's layout). */
+function driveDir(home: string): string {
+  return path.join(home, '.agents', '.cache', 'drive');
+}
+
+/** Plant a config.json on disk with the given remote value. */
+function writeRemoteConfig(home: string, remote: string | null): void {
+  const dir = driveDir(home);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'config.json'),
+    JSON.stringify({ remote, attached: false, previousTargets: null, lastPull: null, lastPush: null }, null, 2),
+    'utf-8'
+  );
+}
+
+/**
+ * Write fake `rsync` and `ssh` binaries that log their argv (one ARG per line)
+ * and create a `pwned` file iff a shell ever interpolates the remote. Returns
+ * the bin dir to prepend to PATH and the marker path that must never appear.
+ */
+function writeFakeTools(home: string): { binDir: string; logPath: string; pwnedPath: string } {
+  const binDir = path.join(home, 'fakebin');
+  fs.mkdirSync(binDir, { recursive: true });
+  const logPath = path.join(home, 'argv.log');
+  const pwnedPath = path.join(home, 'pwned');
+  const body = [
+    '#!/bin/sh',
+    `LOG_FILE='${logPath}'`,
+    `printf "CMD:%s\\n" "$0" >> "$LOG_FILE"`,
+    'for arg do',
+    '  printf "ARG:%s\\n" "$arg" >> "$LOG_FILE"',
+    'done',
+    'exit 0',
+    '',
+  ].join('\n');
+  for (const name of ['rsync', 'ssh']) {
+    const p = path.join(binDir, name);
+    fs.writeFileSync(p, body, 'utf-8');
+    fs.chmodSync(p, 0o755);
+  }
+  return { binDir, logPath, pwnedPath };
+}
+
+function runDrive(home: string, binDir: string, expression: string): { ok: boolean; error?: string } {
+  const child = spawnSync(process.execPath, ['--input-type=module', '-e', `
+    import * as drive from ${JSON.stringify(moduleUrl)};
+    try {
+      const r = await (${expression});
+      console.log(JSON.stringify({ ok: true, result: r }));
+    } catch (err) {
+      console.log(JSON.stringify({ ok: false, error: err.message }));
+    }
+  `], {
+    env: { ...process.env, HOME: home, PATH: `${binDir}:${process.env.PATH ?? ''}` },
+    encoding: 'utf-8',
+  });
+  expect(child.status, child.stderr).toBe(0);
+  return JSON.parse(child.stdout.trim());
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('drive sync remote validation', () => {
+  const malicious = [
+    'evil; touch pwned@host',
+    'a@host`touch pwned`',
+    'a@host$(touch pwned)',
+    'a@host|touch pwned',
+    'a@host && touch pwned',
+    '-e/bin/sh@host',          // leading-dash argv-flag injection
+    '$(touch pwned)@host',
+  ];
+
+  for (const remote of malicious) {
+    it(`rejects a tainted remote on pull, never reaching rsync: ${JSON.stringify(remote)}`, () => {
+      const home = makeTempHome();
+      const { binDir, pwnedPath } = writeFakeTools(home);
+      writeRemoteConfig(home, remote);
+
+      const outcome = runDrive(home, binDir, "drive.pull()");
+
+      expect(outcome.ok).toBe(false);
+      expect(outcome.error).toContain('Invalid drive remote');
+      // The fake rsync was never invoked, and no shell expanded the metachars.
+      expect(fs.existsSync(pwnedPath)).toBe(false);
+      expect(fs.existsSync(path.join(home, 'argv.log'))).toBe(false);
+    });
+
+    it(`rejects a tainted remote on push, never reaching ssh/rsync: ${JSON.stringify(remote)}`, () => {
+      const home = makeTempHome();
+      const { binDir, pwnedPath } = writeFakeTools(home);
+      writeRemoteConfig(home, remote);
+
+      const outcome = runDrive(home, binDir, "drive.push()");
+
+      expect(outcome.ok).toBe(false);
+      expect(outcome.error).toContain('Invalid drive remote');
+      expect(fs.existsSync(pwnedPath)).toBe(false);
+      expect(fs.existsSync(path.join(home, 'argv.log'))).toBe(false);
+    });
+
+    it(`rejects a tainted remote at setRemote write-time: ${JSON.stringify(remote)}`, () => {
+      const home = makeTempHome();
+      const { binDir } = writeFakeTools(home);
+
+      const outcome = runDrive(home, binDir, `(async () => drive.setRemote(${JSON.stringify(remote)}))()`);
+
+      expect(outcome.ok).toBe(false);
+      expect(outcome.error).toContain('Invalid drive remote');
+      // Nothing was persisted.
+      expect(fs.existsSync(path.join(driveDir(home), 'config.json'))).toBe(false);
+    });
+  }
+
+  it('passes a well-formed remote to rsync as one literal argv element', () => {
+    const home = makeTempHome();
+    const { binDir, logPath, pwnedPath } = writeFakeTools(home);
+    writeRemoteConfig(home, 'user@host');
+
+    const outcome = runDrive(home, binDir, "drive.pull()");
+
+    expect(outcome.ok, outcome.error).toBe(true);
+    const log = fs.readFileSync(logPath, 'utf-8');
+    // The remote spec is exactly one argv element — `:` is not a shell op, and
+    // no metacharacters were present to expand. No pwned marker possible.
+    expect(log).toContain('ARG:-az');
+    expect(log).toContain('ARG:--exclude=config.json');
+    expect(log).toContain('ARG:user@host:~/.agents/drive/');
+    expect(fs.existsSync(pwnedPath)).toBe(false);
+  });
+
+  it('passes a well-formed remote to ssh + rsync as literal argv on push', () => {
+    const home = makeTempHome();
+    const { binDir, logPath, pwnedPath } = writeFakeTools(home);
+    writeRemoteConfig(home, 'user@host');
+
+    const outcome = runDrive(home, binDir, "drive.push()");
+
+    expect(outcome.ok, outcome.error).toBe(true);
+    const log = fs.readFileSync(logPath, 'utf-8');
+    // ssh gets the remote as a bare argv element and the mkdir command as a
+    // single positional string — no local shell sees either.
+    expect(log).toContain('ARG:user@host');
+    expect(log).toContain('ARG:mkdir -p ~/.agents/drive');
+    expect(log).toContain('ARG:user@host:~/.agents/drive/');
+    expect(fs.existsSync(pwnedPath)).toBe(false);
+  });
+});

--- a/src/lib/versions.test.ts
+++ b/src/lib/versions.test.ts
@@ -239,3 +239,66 @@ describe('version resource sync path handling', () => {
     expect(result).toEqual(['0.2.33']);
   });
 });
+
+// `installVersion` derives an `npm install <pkg>@<version>` spec from `version`,
+// which originates from the `agents add pkg@<version>` CLI arg or a
+// `.agents-version` pin. The argv-form execFile call cannot be reached for a
+// tainted version because VERSION_RE rejects it at the source (versions.ts).
+// These tests assert the rejection happens before any npm exec, so a malicious
+// version can never escape into a shell.
+function runInstallVersion(home: string, agent: string, version: string): { ok: boolean; error?: string } {
+  const moduleUrl = pathToFileURL(path.resolve('src/lib/versions.ts')).href;
+  const tsxBin = path.resolve('node_modules/.bin/tsx');
+  const child = spawnSync(tsxBin, ['-e', `
+    import { installVersion } from ${JSON.stringify(moduleUrl)};
+    (async () => {
+      try {
+        const r = await installVersion(${JSON.stringify(agent)}, ${JSON.stringify(version)});
+        console.log(JSON.stringify({ ok: true, result: r }));
+      } catch (err) {
+        console.log(JSON.stringify({ ok: false, error: err.message }));
+      }
+    })();
+  `], {
+    env: { ...process.env, HOME: home },
+    encoding: 'utf-8',
+  });
+  expect(child.status, child.stderr).toBe(0);
+  return JSON.parse(child.stdout.trim());
+}
+
+describe('installVersion version validation', () => {
+  const malicious = [
+    'latest; touch /tmp/pwned',
+    '1.0.0 && rm -rf ~',
+    '$(touch /tmp/pwned)',
+    '`touch /tmp/pwned`',
+    '1.0.0|cat /etc/passwd',
+    '--registry=http://evil.example.com',
+  ];
+
+  for (const version of malicious) {
+    it(`rejects malicious version before any npm exec: ${JSON.stringify(version)}`, () => {
+      const home = makeTempHome();
+      const outcome = runInstallVersion(home, 'codex', version);
+      expect(outcome.ok).toBe(false);
+      expect(outcome.error).toContain('Invalid version');
+      // No version dir was created — rejection happened at the source, before
+      // ensureAgentsDir / npm install could run.
+      expect(fs.existsSync(path.join(home, '.agents', '.history', 'versions', 'codex'))).toBe(false);
+    });
+  }
+
+  it('accepts a well-formed semver version through the validation guard', () => {
+    const home = makeTempHome();
+    // A valid version passes VERSION_RE. `kiro` has no npmPackage and a
+    // non-VERSION installScript, so installVersion returns a benign,
+    // network-free error AFTER the guard — proving valid input is not rejected.
+    const outcome = runInstallVersion(home, 'kiro', '0.0.0-rc.1');
+    expect(outcome.ok).toBe(true);
+    const result = (outcome as { result?: { success: boolean; error?: string } }).result;
+    expect(result?.success).toBe(false);
+    expect(result?.error ?? '').not.toContain('Invalid version');
+    expect(result?.error ?? '').toContain('does not support version-pinned installs');
+  });
+});

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1160,6 +1160,8 @@ export async function installVersion(
   const packageSpec = version === 'latest'
     ? agentConfig.npmPackage
     : `${agentConfig.npmPackage}@${version}`;
+  // The `${agentConfig.npmPackage}@` prefix is load-bearing: it ensures `version`
+  // (which VERSION_RE permits to start with `-`) is never passed as a standalone npm CLI flag.
 
   try {
     // Check npm is available


### PR DESCRIPTION
## Summary

RUSH-554 flagged four exec-with-template-interpolation sites that reached a shell with attacker-influenced input → RCE. **All four were already migrated to `execFile`/`execFileSync` array-form (no shell) and validated on `main`** before this branch was cut — the working tree had zero source diff vs `origin/main`. This PR closes the **test gap**: two of the four sites had no regression coverage, so a future refactor could silently reintroduce the shell.

No source changes — coverage only. The migrations themselves live in already-merged commits (e.g. `d608df49` "validate remote target with dedicated function").

## The 4 sites (current state on main, verified file:line)

1. **MCP register (CRITICAL)** — `src/lib/agents.ts:1228-1236`: `splitCommandLine(command)` → `execFileAsync(bin, ['mcp','add','--transport',transport,'--scope',scope,name,'--',...commandArgs])`. Already covered by `src/lib/agents.test.ts:64` (injects `demo; touch …` / `/bin/echo; touch …`, asserts no `pwned` file).
2. **Drive sync (CRITICAL)** — `src/lib/drive-sync.ts:105,122,123`: `execFileAsync('rsync', ['-az','--exclude=config.json', remoteSpec, localDir])`, `execFileAsync('ssh', [config.remote, 'mkdir -p ~/.agents/drive'])`, with `assertValidRemote` re-validating `config.remote` against `REMOTE_RE` on **every read** (`readDriveConfig` line 59-61) and at `setRemote` write-time (line 88). **Had no test → added `src/lib/drive-sync.test.ts`.**
3. **npm install (HIGH)** — `src/lib/versions.ts:1178`: `execFileAsync('npm', ['install', packageSpec])`, guarded by `VERSION_RE` at the source in `installVersion` (line 1061) and `parseVersionSpec` (line 863). **VERSION_RE guard had no security test → added cases to `src/lib/versions.test.ts`.**
4. **Manifest MCP install (HIGH)** — `src/lib/mcp.ts:240,247,269,320`: `execFileSync(binaryPath, args)` array form for manifest-controlled `server.name`/`server.config.url`/`args[]`. Already covered by `src/lib/mcp.test.ts:60`.

## Test plan

```
npm run build                                  # tsc → BUILD_OK
node ./node_modules/vitest/vitest.mjs run \
  src/lib/drive-sync.test.ts src/lib/versions.test.ts \
  src/lib/agents.test.ts src/lib/mcp.test.ts   # affected files
npm test                                        # full suite
```

Results:
- Affected files: drive-sync + versions = **38 passed**; agents + mcp = pass.
- **Mutation check:** temporarily replacing `if (!REMOTE_RE.test(remote))` with `if (false)` and rebuilding makes **21/23 drive-sync tests fail** (tainted remotes reach the fake rsync/ssh, `pwned`/argv.log markers appear). Restored + rebuilt → green. Proves the tests catch the real RCE regression, not ceremony.
- Full suite: **`Test Files 194 passed | 3 skipped (197)` / `Tests 2479 passed | 46 skipped (2525)`** — 0 failures.

## Security note

Every previously-tainted input is now provably either **rejected at a single canonical validation point** or **passed as a literal argv element** that no shell ever parses:

- **drive remote** — `assertValidRemote` (`REMOTE_RE = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+$/`) runs on every disk read, on write, and again in `pull`/`push`; metacharacters (`;`, `|`, `$()`, backticks, `&&`) and leading-dash argv-flag injection are thrown out before any exec. A well-formed `user@host` is handed to rsync/ssh as one argv element.
- **install version** — `VERSION_RE` rejects any non-semver/dist-tag version before `ensureAgentsDir` or `npm install` can run; `packageSpec` can never carry shell syntax or an injected npm flag.
- **MCP name/command/manifest args** — split via `splitCommandLine` and passed as discrete argv elements to `execFile(Sync)` with no shell, so `;`/`"`/`$()` are inert literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)