### PR TITLE
chore(release): 1.20.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phnx-labs/agents-cli",
-  "version": "1.20.12",
+  "version": "1.20.13",
   "description": "One CLI for all your AI coding agents - versions, config, cloud dispatch, sessions, and teams (now with first-class Grok Build CLI support)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release **1.20.13** — bumps `package.json` (single-line), shipping the accumulated backlog since `v1.20.12`.

## Features
- feat(cli): rm/purge aliases for `remove` + top-level `restore` command (#311)
- feat: `agents wallet` command + keychain-backed card vault
- feat: Factory AI Droid as a first-class managed agent (#297)
- feat(versions): `@oldest` alias wherever `@latest` is supported (#298)
- feat(settings): carry user settings forward on version add/use (#264)
- feat(computer): `--char-delay` for lossy keyboard relays (#289)
- feat: plugin resource breakdown in `inspect` + singular `--plugin/--skill` flags
- feat: clip picker preview to terminal viewport height

## Fixes
- fix(run): launch the OpenCode TUI for interactive `agents run opencode` (#312)
- fix(windows): discoverability after `npm i -g` (#307); portable hook paths / PATH prepend (#303)
- fix(browser): auto-restart stale browser daemon on version skew (#291)
- fix(plugins): version-aware `plugins sync` (#292)
- fix(project): deliver project-layer subagents to `.claude/agents` on launch (#284)
- fix(routines): resolve configured version in sandboxed shim (#282)
- fix(run): definitive headless/interactive mode resolution (#300); fail fast on headless plan-mode slash commands
- fix(registry): bound registry fetches with an 8s timeout
- plus additional view/plugin/import fixes

## Publish
After merge, tag the merged commit `v1.20.13` and push the tag (CI `publish` job runs `npm publish --provenance`). If the CI `NPM_TOKEN` isn't configured, publish manually from a machine with npm auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
