### PR TITLE
feat(cli): surface host CLIs in doctor and view

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -42,6 +42,7 @@ import {
   type VersionResourceReport,
 } from '../lib/doctor-diff.js';
 import { unifiedDiff, colorizeUnifiedDiff } from '../lib/diff-text.js';
+import { listCliStatus } from '../lib/cli-resources.js';
 import { setHelpSections } from '../lib/help.js';
 import * as fs from 'fs';
 
@@ -124,6 +125,7 @@ function renderOverviewText(
   clis: ReturnType<typeof checkAllClis>,
   syncRows: SyncStatusRow[],
   orphanRows: OrphanRow[],
+  hostClis: ReturnType<typeof listCliStatus>,
 ): void {
   console.log(chalk.bold('Agent CLIs'));
   if (Object.keys(clis).length === 0) {
@@ -170,6 +172,30 @@ function renderOverviewText(
       console.log(`  ${chalk.yellow('warn ')}  ${label}  ${chalk.gray(parts.join(', '))}`);
     }
     console.log(chalk.gray('  Run `agents prune cleanup` to remove.'));
+  }
+  console.log();
+
+  // Host CLIs are host-global (declared in any DotAgents repo's cli/, installed
+  // to PATH — not synced into version homes), so they live in the overview, not
+  // the per-version resource diff. Source tag shows which repo layer declared
+  // each, including user-level and extra repos.
+  console.log(chalk.bold('Host CLIs'));
+  if (hostClis.statuses.length === 0) {
+    console.log(chalk.gray('  (none declared — add one with `agents cli add <name>`)'));
+  } else {
+    const nameWidth = Math.max(...hostClis.statuses.map((s) => s.manifest.name.length));
+    for (const { manifest, installed } of hostClis.statuses) {
+      const label = manifest.name.padEnd(nameWidth);
+      const src = chalk.gray(`[${manifest.source}]`);
+      if (installed) {
+        console.log(`  ${chalk.green('ready')}  ${label}  ${src}  ${chalk.gray(manifest.description || '')}`);
+      } else {
+        console.log(`  ${chalk.red('miss ')}  ${label}  ${src}  ${chalk.gray(`not installed — run \`agents cli install ${manifest.name}\``)}`);
+      }
+    }
+  }
+  for (const err of hostClis.errors) {
+    console.log(`  ${chalk.red('err  ')}  ${chalk.gray(err.file)}: ${chalk.gray(err.reason)}`);
   }
 }
 
@@ -408,11 +434,25 @@ export function registerDoctorCommand(program: Command): void {
         const clis = checkAllClis();
         const syncRows = checkSyncStatus(cwd);
         const orphanRows = countOrphans();
+        const hostClis = listCliStatus(cwd);
         if (opts.json) {
-          console.log(JSON.stringify({ clis, sync: syncRows, orphans: orphanRows }, null, 2));
+          console.log(JSON.stringify({
+            clis,
+            sync: syncRows,
+            orphans: orphanRows,
+            hostClis: {
+              statuses: hostClis.statuses.map((s) => ({
+                name: s.manifest.name,
+                source: s.manifest.source,
+                description: s.manifest.description ?? null,
+                installed: s.installed,
+              })),
+              errors: hostClis.errors,
+            },
+          }, null, 2));
           return;
         }
-        renderOverviewText(clis, syncRows, orphanRows);
+        renderOverviewText(clis, syncRows, orphanRows, hostClis);
         return;
       }
 

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -59,6 +59,7 @@ import {
   removeShim,
 } from '../lib/shims.js';
 import { getAgentResources, listResources } from '../lib/resources.js';
+import { listCliStatus } from '../lib/cli-resources.js';
 import { isCapable } from '../lib/capabilities.js';
 import { discoverPlugins, pluginSupportsAgent } from '../lib/plugins.js';
 import { getAgentsDir, getUserAgentsDir, getEffectivePromptcutsPath, readMergedPromptcuts } from '../lib/state.js';
@@ -181,9 +182,10 @@ export interface ViewSectionFilter {
   rules?: boolean;
   hooks?: boolean;
   promptcuts?: boolean;
+  cli?: boolean;
 }
 
-const SECTION_KEYS = ['commands', 'skills', 'mcp', 'workflows', 'plugins', 'rules', 'hooks', 'promptcuts'] as const;
+const SECTION_KEYS = ['commands', 'skills', 'mcp', 'workflows', 'plugins', 'rules', 'hooks', 'promptcuts', 'cli'] as const;
 type SectionKey = (typeof SECTION_KEYS)[number];
 
 /**
@@ -244,6 +246,48 @@ function renderProfilesSection(profiles: ProfileSummary[]): void {
  * Show installed versions for one or all agents.
  * Called when: `agents view` or `agents view claude`
  */
+/** Color the source-layer tag for a host CLI, matching the rules-section convention. */
+function hostCliSourceTag(source: string): string {
+  if (source === 'project') return chalk.blue('[project]');
+  if (source === 'user') return chalk.cyan('[user]');
+  if (source === 'system') return chalk.gray('[system]');
+  // Anything else is an extra repo, tagged by its alias.
+  return chalk.magenta(`[${source}]`);
+}
+
+/**
+ * Render the host-CLI section. Host CLIs are host-global: declared in any
+ * DotAgents repo's `cli/` (project > user > system > extras), installed to PATH
+ * rather than copied into a version home. They render identically in the overview
+ * and in a per-agent detail view because every agent on the host shares them.
+ * The source tag shows which repo layer declared each — so user-level and
+ * extra-repo manifests are visibly supported.
+ */
+function renderHostClisSection(cwd: string): void {
+  const { statuses, errors } = listCliStatus(cwd);
+  console.log(chalk.bold('\nHost CLIs\n'));
+  if (statuses.length === 0) {
+    console.log(`  ${chalk.gray('none declared')} ${chalk.gray('— add one with `agents cli add <name>`')}`);
+  } else {
+    const nameWidth = Math.max(...statuses.map((s) => s.manifest.name.length));
+    let anyMissing = false;
+    for (const { manifest, installed } of statuses) {
+      if (!installed) anyMissing = true;
+      const status = installed ? chalk.green('installed') : chalk.red('missing  ');
+      const linkedName = termLink(manifest.name.padEnd(nameWidth), linkTarget(manifest.path));
+      const tag = hostCliSourceTag(manifest.source);
+      const desc = manifest.description ? chalk.gray(`  ${summarizeDescription(manifest.description, 60)}`) : '';
+      console.log(`  ${status}  ${chalk.cyan(linkedName)} ${tag}${desc}`);
+    }
+    if (anyMissing) {
+      console.log(chalk.gray('  Install missing with `agents cli install`'));
+    }
+  }
+  for (const err of errors) {
+    console.log(`  ${chalk.red('error')}      ${chalk.gray(err.file)}: ${chalk.gray(err.reason)}`);
+  }
+}
+
 async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
   const spinnerText = filterAgentId
     ? `Checking ${agentLabel(filterAgentId)} agents...`
@@ -639,7 +683,10 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
     console.log();
   }
 
-
+  // Host CLIs are host-global, not per-agent — show them once in the overview.
+  if (!filterAgentId) {
+    renderHostClisSection(process.cwd());
+  }
 
   // Check for new resources when viewing a specific agent
   if (filterAgentId && versionManaged.length > 0) {
@@ -1027,6 +1074,9 @@ async function showAgentResources(
   if (shouldRenderSection('promptcuts', filter)) {
     renderPromptcuts();
   }
+  if (shouldRenderSection('cli', filter)) {
+    renderHostClisSection(cwd);
+  }
 
   // Show legend at the end if git repo exists and we showed all sections.
   // Filtered single-section views skip it — noise for promptcuts or plugins.
@@ -1403,6 +1453,7 @@ export async function viewAction(
     rules: options?.rules,
     hooks: options?.hooks,
     promptcuts: options?.promptcuts,
+    cli: options?.cli,
   };
   const filterIsSet = SECTION_KEYS.some((k) => filter[k]);
 
@@ -1488,6 +1539,7 @@ export function registerViewCommand(program: Command): void {
     .option('--rules', 'Show only rules in the detail view.')
     .option('--hooks', 'Show only hooks in the detail view.')
     .option('--promptcuts', 'Show only promptcuts in the detail view.')
+    .option('--cli', 'Show only host CLIs (declared in cli/, installed to PATH).')
     .addHelpText('after', `
 Examples:
   # Show all installed agents with versions, accounts, and usage


### PR DESCRIPTION
## What

Host CLIs (declared in `cli/<name>.yaml`, installed to host PATH) are managed by `agents cli` but were invisible in the two places operators actually look — `agents doctor` and `agents view`. This wires them into both, source-layer aware.

## Changes

**`agents doctor`** (`src/commands/doctor.ts`)
- New **Host CLIs** section in the overview: `ready`/`miss` status, source-repo tag, description.
- `--json` gains an additive `hostClis` key (`{name, source, description, installed}` + `errors`). doctor's JSON is an object, so this is non-breaking.
- Host CLIs are host-global, so they live in the overview — not the per-version resource diff (`DoctorKind` is for resources synced into version homes; CLIs install to PATH).

**`agents view`** (`src/commands/view.ts`)
- **Host CLIs** section in the overview (`agents view`) and in the per-agent detail view (`agents view <agent>@<version>`), with clickable manifest links and source-layer tags.
- New `--cli` filter, wired into `ViewSectionFilter` / `SECTION_KEYS`.
- `view --json` keeps its array shape — left untouched to avoid breaking programmatic consumers.

**Source-layer aware** — `[project]` / `[user]` / `[system]` / `[<extra-alias>]` tags come from the existing `listResources('cli', cwd)` resolution (project > user > system > extra repos), so user-repo and extra-repo manifests are visibly supported.

## Why

`agents cli` could install/check host CLIs, but `agents doctor` was blind to them and `agents view` never listed them — so a missing required host tool (e.g. `gh`, `linear`) never surfaced where users diagnose their install.

## Test

- `tsc --noEmit` clean against `origin/main`.
- **133/133 vitest tests pass** (`bun run test`).
- Verified end-to-end against a dev build: `agents doctor`, `agents doctor --json`, `agents view`, `agents view <agent>@default`, and `agents view <agent>@default --cli` all render the section correctly.

> Note: session transcript gist intentionally omitted — the session contains private global agent config, unsuitable for an external link on a public repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
