### PR TITLE
ci(publish): grant id-token: write for npm provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write # required for `npm publish --provenance`
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## What
Adds `id-token: write` to the `publish` job in `ci.yml`.

## Why
The publish job runs `npm publish --provenance`, which needs a Sigstore OIDC token. The job only declared `permissions: contents: read`, so provenance would fail even with a valid `NPM_TOKEN`. This (plus a missing token secret) is why CI-based publishing hasn't worked and releases were effectively manual.

Provenance prerequisites already satisfied: `package.json` has a matching `repository` field, and the repo is public.

## To fully enable CI publishing
1. This PR (adds `id-token: write`).
2. Add repo Actions secret **`NPM_TOKEN`** (npm automation token with publish access).

Then a release is just: push a `vX.Y.Z` tag → `publish` job builds, tests, and `npm publish --provenance --access=public`.

## Testing
- YAML validated (`yaml.safe_load`); `publish.permissions = {contents: read, id-token: write}`.
- No app code touched; build/test jobs unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)