### PR TITLE
ci: add manual verify-publish-auth workflow

### DIFF
--- a/.github/workflows/verify-publish-auth.yml
+++ b/.github/workflows/verify-publish-auth.yml
@@ -1,0 +1,34 @@
+name: Verify npm publish auth
+
+# Manual, non-destructive check that the NPM_TOKEN secret is present and valid.
+# Runs `npm whoami` against the public registry with the publish token — it does
+# NOT publish anything. Use it to confirm the release pipeline can authenticate
+# before (or independently of) cutting a release.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Use Node.js 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Check npm authentication
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN}" ]; then
+            echo "::error::NPM_TOKEN secret is empty or unset."
+            exit 1
+          fi
+          echo "Authenticated to npm as: $(npm whoami)"
+          echo "Packages this token can access under @phnx-labs:"
+          npm access list packages @phnx-labs 2>/dev/null || echo "(could not list packages; whoami above is the decisive auth check)"


### PR DESCRIPTION
Adds a `workflow_dispatch` workflow that runs `npm whoami` against the npm registry using the `NPM_TOKEN` secret — a non-destructive check that the release pipeline can authenticate. It does **not** publish.

Use: Actions → "Verify npm publish auth" → Run workflow (or `gh workflow run verify-publish-auth.yml`).

Merging this so the workflow is dispatchable from the default branch; first run verifies the freshly-added `NPM_TOKEN` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)