### PR TITLE
feat(inspect,doctor): expand inspect summary, fix plugin hooks, precise orphan-hook detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+**`agents inspect` summary: expanded detail for hooks, plugins, and MCP**
+
+- The bare `agents inspect <agent>` / `agents inspect <repo>` summary no longer collapses everything to a count table. Simple kinds (commands, skills, rules, subagents, workflows) keep a count line but now preview a few names; the rich kinds get their own expanded sections: **hooks** show their events + `matches:` predicates + cache (`PreToolUse(Bash) · git_dirty · prompt~"deploy" (5m cache)`), **plugins** show version + bundle contents (`v2.1.0  skills:6 commands:5 hooks:2 mcp:1`), and **MCP** show transport + url/command. Drill-down flags (`--hooks`, `--plugins`, `--mcp`) and `--brief` are unchanged; `--json` gains the structured detail additively (existing keys retained).
+- Hook detail joins installed hooks to the manifest by **script basename** (installed hooks are named after their script file while the manifest keys on the logical name), and the repo Hooks section uses the grouped hook reader so a script + its data file collapse to one clean entry.
+
+**Plugin hooks were misreported — fixed**
+
+- `discoverPluginHooks` read the **top-level** keys of a plugin's `hooks/hooks.json`, so the official `{ description, hooks: { SessionStart: [...] } }` format surfaced as `description, hooks` instead of the real events. It now reads the `hooks` wrapper when present (falling back to top-level keys for the flat format), so `agents inspect --plugin <name>` and the plugin row show the actual lifecycle events (e.g. `SessionStart, PreToolUse, …`).
+
+**`agents doctor` / `agents prune`: precise orphan-hooks detection**
+
+- Orphan-hook detection now flags hook scripts present in a version home that **no `agents.yaml`/`hooks.yaml` entry registers** — i.e. scripts that sync to disk but are never wired to a lifecycle event, so they never fire. This replaces the source-diff heuristic, which compared only against the user hooks dir and so **false-flagged valid system-sourced, registered hooks** (e.g. `03-linear-inject`, `04-capture`) as orphans — meaning `agents prune cleanup` could have deleted live hooks. Doctor's Orphans section and `prune cleanup hooks` now share this single manifest-based definition. `parseHookManifest` gained a silent (`{ warn: false }`) option so the diagnostic doesn't emit shadow/override warnings.
+
 **Regression coverage: resource sync from extras repos**
 
 - Added end-to-end regression tests (`src/lib/__tests__/extras-sync.test.ts`) locking in two behaviors for repos registered via `agents repo add` (`~/.agents-<alias>/`): a top-level `commands/<name>.md` is written into the agent's version home on `agents sync`, and plugins under `plugins/<name>/` are synthesized into a registered `agents-<alias>` marketplace on launch. Both already work in `main`; the tests exercise the real sync path (no mocking, isolated `$HOME`) so the extras-repo behavior can't silently regress (#313, #314).

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+../../../node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-../../../node_modules

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -33,7 +33,7 @@ import {
 import { loadManifest, isStale } from '../lib/staleness/index.js';
 import { diffVersionCommands, iterCommandsCapableVersions } from '../lib/commands.js';
 import { diffVersionSkills, iterSkillsCapableVersions } from '../lib/skills.js';
-import { diffVersionHooks, iterHooksCapableVersions } from '../lib/hooks.js';
+import { iterHooksCapableVersions, listUnmanagedHooksInVersionHome } from '../lib/hooks.js';
 import {
   diffVersionResources,
   DOCTOR_ALL_KINDS,
@@ -112,10 +112,14 @@ function countOrphans(): OrphanRow[] {
     const diff = diffVersionSkills(agent, version);
     if (diff.orphans.length > 0) ensure(agent, version).skills = diff.orphans.length;
   }
+  // Orphan hooks are scripts in the version home that no agents.yaml/hooks.yaml
+  // entry registers — so the registrar never wires them to an event and they
+  // never fire. (Distinct from the source-diff `diffVersionHooks().orphans`,
+  // which false-flags valid system-sourced registered hooks.)
   for (const { agent, version } of iterHooksCapableVersions()) {
     if (version !== getGlobalDefault(agent)) continue;
-    const diff = diffVersionHooks(agent, version);
-    if (diff.orphans.length > 0) ensure(agent, version).hooks = diff.orphans.length;
+    const dead = listUnmanagedHooksInVersionHome(agent, version);
+    if (dead.length > 0) ensure(agent, version).hooks = dead.length;
   }
 
   return Array.from(byKey.values()).filter((r) => r.commands + r.skills + r.hooks > 0);

--- a/src/commands/inspect.test.ts
+++ b/src/commands/inspect.test.ts
@@ -10,7 +10,11 @@ import {
   repoGitInfo,
   pathSize,
   formatBytes,
+  summarizeHook,
+  summarizeMcp,
+  hookManifestByScript,
 } from './inspect.js';
+import type { ManifestHook } from '../lib/types.js';
 import { getUserAgentsDir, getSystemAgentsDir } from '../lib/state.js';
 
 const tempDirs: string[] = [];
@@ -167,6 +171,71 @@ describe('formatBytes', () => {
     expect(formatBytes(1024)).toBe('1.0 KB');
     expect(formatBytes(86 * 1024)).toBe('86 KB');
     expect(formatBytes(3.1 * 1024 * 1024)).toBe('3.1 MB');
+  });
+});
+
+describe('summarizeHook', () => {
+  it('shows events only when there is no matcher or predicate', () => {
+    expect(summarizeHook({ script: 'x.sh', events: ['SessionStart'] })).toBe('SessionStart');
+  });
+
+  it('joins multiple events with a slash', () => {
+    expect(summarizeHook({ script: 'x.sh', events: ['PreToolUse', 'PostToolUse'] }))
+      .toBe('PreToolUse/PostToolUse');
+  });
+
+  it('puts the matcher in parens after the events', () => {
+    expect(summarizeHook({ script: 'x.sh', events: ['PreToolUse'], matcher: 'Bash' }))
+      .toBe('PreToolUse(Bash)');
+  });
+
+  it('uses matches.tool_name as the matcher when no explicit matcher is set', () => {
+    expect(summarizeHook({ script: 'x.sh', events: ['PreToolUse'], matches: { tool_name: ['Bash', 'Edit'] } }))
+      .toBe('PreToolUse(Bash|Edit)');
+  });
+
+  it('appends a `·`-separated predicate summary from matches', () => {
+    const hook: ManifestHook = {
+      script: 'x.sh',
+      events: ['PreToolUse'],
+      matcher: 'Bash',
+      matches: { git_dirty: true, prompt_contains: 'deploy' },
+    };
+    expect(summarizeHook(hook)).toBe('PreToolUse(Bash) · git_dirty · prompt~"deploy"');
+  });
+
+  it('adds a cache tail, stripping the -bg background suffix', () => {
+    expect(summarizeHook({ script: 'x.sh', events: ['SessionStart'], cache: '5m-bg' }))
+      .toBe('SessionStart (5m cache)');
+    expect(summarizeHook({ script: 'x.sh', events: ['SessionStart'], cache: { ttl: '1h', key: 'per-cwd' } }))
+      .toBe('SessionStart (1h cache)');
+  });
+});
+
+describe('summarizeMcp', () => {
+  it('renders an http server as transport + url', () => {
+    expect(summarizeMcp({ name: 'posthog', transport: 'http', url: 'https://mcp.posthog.com' }))
+      .toBe('http   https://mcp.posthog.com');
+  });
+
+  it('renders a stdio server as transport + command line', () => {
+    expect(summarizeMcp({ name: 'linear', transport: 'stdio', command: 'npx', args: ['linear-mcp-server'] }))
+      .toBe('stdio  npx linear-mcp-server');
+  });
+});
+
+describe('hookManifestByScript', () => {
+  it('keys hooks by their script basename without extension, not the manifest key', () => {
+    const manifest: Record<string, ManifestHook> = {
+      'capture-session-start-metadata': { script: '04-capture-session-start-metadata.sh', events: ['SessionStart'] },
+      'git-guard': { script: 'git-guard.sh', events: ['PreToolUse'], matcher: 'Bash' },
+    };
+    const byScript = hookManifestByScript(manifest);
+    // Installed hook names equal the script basename, so that is the join key.
+    expect(byScript.get('04-capture-session-start-metadata')?.events).toEqual(['SessionStart']);
+    expect(byScript.get('git-guard')?.matcher).toBe('Bash');
+    // The manifest key itself is NOT a lookup key.
+    expect(byScript.get('capture-session-start-metadata')).toBeUndefined();
   });
 });
 

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -19,7 +19,7 @@ import * as path from 'path';
 import { Command } from 'commander';
 import chalk from 'chalk';
 import * as yaml from 'yaml';
-import type { AgentId, CapabilityName, DiscoveredPlugin } from '../lib/types.js';
+import type { AgentId, CapabilityName, DiscoveredPlugin, ManifestHook, HookMatches, HookCache } from '../lib/types.js';
 import { AGENTS, getCliState, resolveAgentName } from '../lib/agents.js';
 import { supports } from '../lib/capabilities.js';
 import {
@@ -37,6 +37,8 @@ import {
   type ResourceEntry,
   type SkillResourceEntry,
 } from '../lib/resources.js';
+import { listHookEntriesFromDir } from '../lib/hooks.js';
+import { listMcpServerConfigs, discoverMcpConfigsFromRepo, type McpYamlConfig } from '../lib/mcp.js';
 import { discoverPlugins, discoverPluginsInDir, pluginResourceGroups, type PluginResourceGroup } from '../lib/plugins.js';
 import { PLUGIN_GROUP_COLORS } from './plugins.js';
 import { countSessionsInScope } from '../lib/session/discover.js';
@@ -55,6 +57,15 @@ const DRILLABLE_KINDS = [
   'subagents',
 ] as const;
 type DrillableKind = typeof DRILLABLE_KINDS[number];
+
+/**
+ * Summary-view partition. SIMPLE kinds render as a one-line count + name preview;
+ * RICH kinds (hooks/plugins/mcp) get their own expanded section showing each
+ * item's key detail (events/predicates, bundle contents, transport/url). Together
+ * they cover every DrillableKind.
+ */
+const SIMPLE_KINDS = ['commands', 'skills', 'rules', 'subagents', 'workflows'] as const;
+const RICH_KINDS = ['hooks', 'plugins', 'mcp'] as const;
 
 /**
  * Singular aliases for the plural drill-down flags. `--plugin code` reads as
@@ -421,6 +432,9 @@ function renderRepoSummary(repo: RepoTarget, options: InspectOptions): void {
 
   const kindData = {} as Record<DrillableKind, { items: ResourceItem[]; size: { bytes: number; files: number } }>;
   let totalBytes = 0, totalFiles = 0;
+  let repoHookByScript: Map<string, ManifestHook> = new Map();
+  let repoHookItemList: ResourceItem[] = [];
+  let repoMcpConfigs: Map<string, McpYamlConfig> = new Map();
   if (!options.brief) {
     for (const kind of DRILLABLE_KINDS) {
       const items = collectRepoKind(repo, kind);
@@ -428,6 +442,9 @@ function renderRepoSummary(repo: RepoTarget, options: InspectOptions): void {
       kindData[kind] = { items, size };
       totalBytes += size.bytes; totalFiles += size.files;
     }
+    repoHookByScript = hookManifestByScript(hookManifestFromFile(path.join(repo.root, 'agents.yaml')));
+    repoHookItemList = repoHookItems(repo);
+    repoMcpConfigs = new Map(discoverMcpConfigsFromRepo(repo.root).map(s => [s.name, s.config]));
   }
 
   if (options.json) {
@@ -439,12 +456,31 @@ function renderRepoSummary(repo: RepoTarget, options: InspectOptions): void {
       manifest,
       size: options.brief ? null : { bytes: totalBytes, files: totalFiles },
       resources: options.brief ? null : Object.fromEntries(
-        DRILLABLE_KINDS.map(kind => [kind, {
-          count: kindData[kind].items.length,
-          bytes: kindData[kind].size.bytes,
-          files: kindData[kind].size.files,
-          names: kindData[kind].items.map(i => i.name),
-        }]),
+        DRILLABLE_KINDS.map(kind => {
+          const size = kindData[kind].size;
+          // Hooks use the grouped reader (clean names) instead of the raw readdir.
+          const items = kind === 'hooks' ? repoHookItemList : kindData[kind].items;
+          const base = {
+            count: items.length,
+            bytes: size.bytes,
+            files: size.files,
+            names: items.map(i => i.name),
+          };
+          if (kind === 'hooks') return [kind, { ...base, items: items.map(i => {
+            const h = repoHookByScript.get(i.name);
+            return { name: i.name, events: h?.events ?? [], matcher: h?.matcher, matches: h?.matches, cache: h?.cache };
+          }) }];
+          if (kind === 'mcp') return [kind, { ...base, items: items.map(i => {
+            const c = repoMcpConfigs.get(i.name);
+            return { name: i.name, transport: c?.transport, url: c?.url, command: c?.command, args: c?.args };
+          }) }];
+          if (kind === 'plugins') return [kind, { ...base, items: items.map(i => ({
+            name: i.name,
+            version: i.extra?.find(([k]) => k === 'version')?.[1],
+            groups: Object.fromEntries((i.groups ?? []).map(g => [g.label, g.items.length])),
+          })) }];
+          return [kind, base];
+        }),
       ),
     }, null, 2));
     return;
@@ -491,13 +527,17 @@ function renderRepoSummary(repo: RepoTarget, options: InspectOptions): void {
     console.log(`  ${'size'.padEnd(10)} ${formatBytes(totalBytes)} ${chalk.gray('·')} ${totalFiles} files`);
 
     console.log('\n' + chalk.bold('Resources'));
-    for (const kind of DRILLABLE_KINDS) {
+    for (const kind of SIMPLE_KINDS) {
       const { items, size } = kindData[kind];
       const count = String(items.length).padStart(4);
       const sz = items.length > 0 ? formatBytes(size.bytes).padStart(8) : ''.padEnd(8);
       const preview = items.length > 0 ? chalk.gray(truncate(previewNames(items, 4), 60)) : '';
       console.log(`  ${kind.padEnd(10)} ${count}  ${sz}  ${preview}`.trimEnd());
     }
+
+    printExpandedSection('Hooks', hookRows(repoHookItemList, repoHookByScript));
+    printExpandedSection('Plugins', pluginRows(kindData.plugins.items));
+    printExpandedSection('MCP', mcpRows(kindData.mcp.items, repoMcpConfigs));
   }
 
   console.log('');
@@ -566,7 +606,9 @@ async function renderSummary(agent: AgentId, version: string, versionHome: strin
 
   const capabilities = collectCapabilities(agent, version);
 
-  const counts = options.brief ? null : collectCounts(agent, versionHome);
+  const itemsByKind = options.brief ? null : collectItemsByKind(agent, versionHome);
+  const hookByScript = options.brief ? null : hookManifestByScript(loadCentralHookManifest());
+  const mcpConfigs = options.brief ? null : new Map(listMcpServerConfigs().map(s => [s.name, s.config]));
 
   const sessions = options.brief ? null : {
     total: safeCountSessions(agent),
@@ -584,7 +626,7 @@ async function renderSummary(agent: AgentId, version: string, versionHome: strin
       strategy,
       installedShim: cliState?.installed === true ? cliState.path : null,
       capabilities,
-      resources: counts,
+      resources: itemsByKind ? summaryResourcesJson(itemsByKind, hookByScript!, mcpConfigs!) : null,
       sessions,
     };
     console.log(JSON.stringify(json, null, 2));
@@ -612,14 +654,14 @@ async function renderSummary(agent: AgentId, version: string, versionHome: strin
     console.log(`  ${cap.padEnd(10)} ${mark} ${reason}`);
   }
 
-  if (counts) {
+  if (itemsByKind) {
     console.log('\n' + chalk.bold('Resources'));
-    for (const kind of DRILLABLE_KINDS) {
-      const c = counts[kind];
-      if (!c) continue;
-      const breakdown = formatScopeBreakdown(c.bySource);
-      console.log(`  ${kind.padEnd(10)} ${String(c.total).padStart(4)}   ${chalk.gray(breakdown)}`);
+    for (const kind of SIMPLE_KINDS) {
+      printSimpleResourceRow(kind, itemsByKind[kind]);
     }
+    printExpandedSection('Hooks', hookRows(itemsByKind.hooks, hookByScript!));
+    printExpandedSection('Plugins', pluginRows(itemsByKind.plugins));
+    printExpandedSection('MCP', mcpRows(itemsByKind.mcp, mcpConfigs!));
   }
 
   if (sessions) {
@@ -755,13 +797,54 @@ function collectCapabilities(agent: AgentId, version: string): Record<Capability
   return out;
 }
 
-function collectCounts(agent: AgentId, versionHome: string): Record<DrillableKind, { total: number; bySource: Record<string, number> }> {
-  const out = {} as Record<DrillableKind, { total: number; bySource: Record<string, number> }>;
+function collectItemsByKind(agent: AgentId, versionHome: string): Record<DrillableKind, ResourceItem[]> {
+  const out = {} as Record<DrillableKind, ResourceItem[]>;
+  for (const kind of DRILLABLE_KINDS) out[kind] = collectKind(agent, versionHome, kind);
+  return out;
+}
+
+/** A simple-kind count row: `kind  N   user:30 system:12   name, name …(+K)`. */
+function printSimpleResourceRow(kind: string, items: ResourceItem[]): void {
+  const count = String(items.length).padStart(4);
+  const breakdown = chalk.gray(scopeBreakdownPlain(countBySource(items.map(i => i.source))).padEnd(18));
+  const preview = items.length > 0 ? chalk.gray(truncate(previewNames(items, 3), 48)) : '';
+  console.log(`  ${kind.padEnd(10)} ${count}   ${breakdown}  ${preview}`.trimEnd());
+}
+
+/**
+ * Build the `resources` JSON: every kind keeps `total` + `bySource` (back-compat),
+ * simple kinds add `names`, and the rich kinds add structured `items` (hook
+ * events/predicates, mcp transport/url/command, plugin version + group counts).
+ */
+function summaryResourcesJson(
+  itemsByKind: Record<DrillableKind, ResourceItem[]>,
+  hookByScript: Map<string, ManifestHook>,
+  mcpConfigs: Map<string, McpYamlConfig>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
   for (const kind of DRILLABLE_KINDS) {
-    const items = collectKind(agent, versionHome, kind);
-    const bySource: Record<string, number> = {};
-    for (const item of items) bySource[item.source] = (bySource[item.source] || 0) + 1;
-    out[kind] = { total: items.length, bySource };
+    const items = itemsByKind[kind];
+    const base = { total: items.length, bySource: countBySource(items.map(i => i.source)) };
+    if (kind === 'hooks') {
+      out[kind] = { ...base, items: items.map(i => {
+        const h = hookByScript.get(i.name);
+        return { name: i.name, source: i.source, events: h?.events ?? [], matcher: h?.matcher, matches: h?.matches, cache: h?.cache };
+      }) };
+    } else if (kind === 'mcp') {
+      out[kind] = { ...base, items: items.map(i => {
+        const c = mcpConfigs.get(i.name);
+        return { name: i.name, source: i.source, transport: c?.transport, url: c?.url, command: c?.command, args: c?.args };
+      }) };
+    } else if (kind === 'plugins') {
+      out[kind] = { ...base, items: items.map(i => ({
+        name: i.name,
+        source: i.source,
+        version: i.extra?.find(([k]) => k === 'version')?.[1],
+        groups: Object.fromEntries((i.groups ?? []).map(g => [g.label, g.items.length])),
+      })) };
+    } else {
+      out[kind] = { ...base, names: items.map(i => i.name) };
+    }
   }
   return out;
 }
@@ -886,6 +969,193 @@ function buildDetailRows(item: ResourceItem, kind: DrillableKind): Array<[string
     if (item.extra) rows.push(...item.extra);
   }
   return rows;
+}
+
+// ─── Rich expanded sections (summary view) ───────────────────────────────────
+
+/** One row in an expanded section: a source tag, a clickable name, and a detail string. */
+interface RichRow {
+  source: string;
+  name: string;
+  detail: string;
+  linkTarget?: string;
+}
+
+/** `system` → `sys`; everything else unchanged. Keeps the tag column narrow. */
+function abbrevSource(s: string): string {
+  return s === 'system' ? 'sys' : s;
+}
+
+/**
+ * Compact one-liner for a hook from its manifest entry: the firing events (with
+ * the matcher/tool-name in parens), then a `·`-separated predicate summary, then
+ * an optional cache tail. Plain text — the caller applies color.
+ */
+export function summarizeHook(hook: ManifestHook): string {
+  const events = (hook.events ?? []).join('/') || '(no event)';
+  let matcher = hook.matcher;
+  if (!matcher && hook.matches?.tool_name) {
+    const tn = hook.matches.tool_name;
+    matcher = Array.isArray(tn) ? tn.join('|') : tn;
+  }
+  const head = matcher ? `${events}(${matcher})` : events;
+
+  const parts = [head];
+  const preds = summarizeMatches(hook.matches);
+  if (preds) parts.push(preds);
+  let line = parts.join(' · ');
+
+  const ttl = hookCacheTtl(hook.cache);
+  if (ttl) line += ` (${ttl} cache)`;
+  return line;
+}
+
+/** `·`-separated predicate summary from a hook's `matches:` block (tool_name omitted — shown in the matcher parens). */
+function summarizeMatches(m?: HookMatches): string {
+  if (!m) return '';
+  const bits: string[] = [];
+  if (m.git_dirty) bits.push('git_dirty');
+  if (m.prompt_contains) bits.push(`prompt~"${truncate(m.prompt_contains, 24)}"`);
+  if (m.prompt_matches) bits.push(`prompt=/${truncate(m.prompt_matches, 24)}/`);
+  if (m.tool_args_match) bits.push(`args=/${truncate(m.tool_args_match, 20)}/`);
+  if (m.cwd_includes) {
+    const c = Array.isArray(m.cwd_includes) ? m.cwd_includes.join('|') : m.cwd_includes;
+    bits.push(`cwd~${truncate(c, 24)}`);
+  }
+  if (m.project_has) bits.push(`has ${m.project_has}`);
+  return bits.join(' · ');
+}
+
+/** Normalize a hook cache shorthand/object to a display ttl ("5m", "1h"); null when uncached. */
+function hookCacheTtl(cache?: HookCache): string | null {
+  if (cache === undefined || cache === null) return null;
+  if (typeof cache === 'string') return cache.replace(/-bg$/, '');
+  return String(cache.ttl);
+}
+
+/** Compact one-liner for an MCP server: padded transport + the url (http) or command line (stdio). */
+export function summarizeMcp(cfg: McpYamlConfig): string {
+  const target = cfg.transport === 'http'
+    ? (cfg.url ?? '')
+    : [cfg.command, ...(cfg.args ?? [])].filter(Boolean).join(' ');
+  return `${cfg.transport.padEnd(5)}  ${truncate(target, 60)}`.trimEnd();
+}
+
+/** Print `Title (N)` then up to `max` aligned `[source] name  detail` rows with a `…(+K)` tail. */
+function printExpandedSection(title: string, rows: RichRow[], max = 6): void {
+  console.log('\n' + chalk.bold(title) + chalk.gray(` (${rows.length})`));
+  if (rows.length === 0) {
+    console.log(chalk.gray('  (none)'));
+    return;
+  }
+  const shown = rows.slice(0, max);
+  const nameW = Math.max(...shown.map(r => r.name.length));
+  for (const r of shown) {
+    const tag = chalk.gray(`[${abbrevSource(r.source)}]`.padEnd(8));
+    const padded = r.name.padEnd(nameW);
+    const name = r.linkTarget ? termLink(chalk.cyan(padded), r.linkTarget) : chalk.cyan(padded);
+    const detail = r.detail ? '  ' + chalk.gray(r.detail) : '';
+    console.log(`  ${tag} ${name}${detail}`);
+  }
+  if (rows.length > max) console.log(chalk.gray(`  …(+${rows.length - max})`));
+}
+
+/** Tally a source list into `{user: n, system: m}`. */
+function countBySource(sources: string[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const s of sources) out[s] = (out[s] || 0) + 1;
+  return out;
+}
+
+/** Unbracketed scope breakdown for the simple count rows: `user:30 system:12`. */
+function scopeBreakdownPlain(bySource: Record<string, number>): string {
+  return Object.entries(bySource).map(([k, v]) => `${k}:${v}`).join(' ');
+}
+
+/**
+ * Index a hook manifest by script basename (no extension). Installed hooks are
+ * named after their script file (`04-capture-…`), while the manifest is keyed by
+ * logical name (`capture-…`) with the filename in `script:` — so we join on the
+ * script basename, not the manifest key.
+ */
+export function hookManifestByScript(manifest: Record<string, ManifestHook>): Map<string, ManifestHook> {
+  const out = new Map<string, ManifestHook>();
+  for (const hook of Object.values(manifest)) {
+    if (hook && typeof hook.script === 'string') {
+      out.set(path.basename(hook.script).replace(/\.[^.]+$/, ''), hook);
+    }
+  }
+  return out;
+}
+
+/** Build hook rows by enriching the installed hook items with manifest events/predicates. */
+function hookRows(items: ResourceItem[], byScript: Map<string, ManifestHook>): RichRow[] {
+  return items.map(item => {
+    const hook = byScript.get(item.name);
+    return {
+      source: item.source,
+      name: item.name,
+      linkTarget: item.linkTarget,
+      // Hooks are shell scripts with no human description — show events/predicates
+      // from the manifest, or nothing rather than a meaningless shebang line.
+      detail: hook ? summarizeHook(hook) : '',
+    };
+  });
+}
+
+/** Build plugin rows: `vVERSION  skills:6 commands:5 …` from the bundle's groups. */
+function pluginRows(items: ResourceItem[]): RichRow[] {
+  return items.map(item => {
+    const version = item.extra?.find(([k]) => k === 'version')?.[1];
+    const counts = (item.groups ?? []).map(g => `${g.label}:${g.items.length}`).join(' ');
+    const detail = [version ? `v${version}` : '', counts].filter(Boolean).join('  ');
+    return { source: item.source, name: item.name, detail, linkTarget: item.linkTarget };
+  });
+}
+
+/** Build MCP rows by joining the installed mcp items with their full configs (transport/url/command). */
+function mcpRows(items: ResourceItem[], configs: Map<string, McpYamlConfig>): RichRow[] {
+  return items.map(item => {
+    const cfg = configs.get(item.name);
+    return { source: item.source, name: item.name, detail: cfg ? summarizeMcp(cfg) : item.description };
+  });
+}
+
+/** Read a repo/agents.yaml `hooks:` section into a name→ManifestHook map (best-effort). */
+function hookManifestFromFile(agentsYamlPath: string): Record<string, ManifestHook> {
+  try {
+    const meta = yaml.parse(fs.readFileSync(agentsYamlPath, 'utf-8')) as { hooks?: Record<string, ManifestHook> } | null;
+    return meta?.hooks ?? {};
+  } catch { return {}; }
+}
+
+/**
+ * Merge the system + user `agents.yaml` hook manifests (user wins on key
+ * collision). Built directly from the two layer files rather than via
+ * `parseHookManifest()` so inspecting never emits the shadow/override warnings
+ * that the registrar path prints.
+ */
+function loadCentralHookManifest(): Record<string, ManifestHook> {
+  return {
+    ...hookManifestFromFile(path.join(getSystemAgentsDir(), 'agents.yaml')),
+    ...hookManifestFromFile(path.join(getUserAgentsDir(), 'agents.yaml')),
+  };
+}
+
+/**
+ * Hook items for a repo's Hooks section. Uses the grouped hook reader (script +
+ * data file collapsed into one entry, non-hook files like promptcuts.yaml or
+ * README.md filtered out) rather than a naive readdir, so names are clean and
+ * join cleanly against the manifest by script basename.
+ */
+function repoHookItems(repo: RepoTarget): ResourceItem[] {
+  return listHookEntriesFromDir(path.join(repo.root, 'hooks')).map(h => ({
+    name: h.name,
+    source: repo.label,
+    path: h.scriptPath,
+    linkTarget: h.scriptPath,
+    description: '',
+  }));
 }
 
 // ─── Fuzzy matching ──────────────────────────────────────────────────────────
@@ -1056,10 +1326,4 @@ function safeCountSessions(agent: AgentId): number {
 function truncate(s: string, n: number): string {
   if (s.length <= n) return s;
   return s.slice(0, n - 1) + '…';
-}
-
-function formatScopeBreakdown(bySource: Record<string, number>): string {
-  const entries = Object.entries(bySource);
-  if (entries.length === 0) return '';
-  return '[' + entries.map(([k, v]) => `${k}:${v}`).join(' ') + ']';
 }

--- a/src/commands/prune.ts
+++ b/src/commands/prune.ts
@@ -37,7 +37,7 @@ import {
   removeSkillFromVersion,
 } from '../lib/skills.js';
 import {
-  diffVersionHooks,
+  listUnmanagedHooksInVersionHome,
   iterHooksCapableVersions,
   removeHookFromVersion,
 } from '../lib/hooks.js';
@@ -113,9 +113,12 @@ function collectOrphans(types: ResourceType[], all: boolean): OrphanGroup[] {
 
   if (types.includes('hooks')) {
     for (const { agent, version } of scopePairs(iterHooksCapableVersions(), all)) {
-      const diff = diffVersionHooks(agent, version);
-      if (diff.orphans.length > 0) {
-        groups.push({ type: 'hooks', agent, version, orphans: diff.orphans });
+      // Orphan hooks = scripts present in the version home that no
+      // agents.yaml/hooks.yaml entry registers, so they never fire. Same
+      // definition the doctor overview reports.
+      const orphans = listUnmanagedHooksInVersionHome(agent, version);
+      if (orphans.length > 0) {
+        groups.push({ type: 'hooks', agent, version, orphans });
       }
     }
   }
@@ -283,7 +286,7 @@ async function runOrphanPrune(
 
   const total = groups.reduce((n, g) => n + g.orphans.length, 0);
 
-  console.log(chalk.bold('Orphans (in version home, not in any source)\n'));
+  console.log(chalk.bold('Orphans (in version home, unmanaged by any source)\n'));
   for (const g of groups) {
     const label = `${g.type} · ${g.agent}@${g.version}`;
     console.log(`  ${chalk.cyan(label)}  ${g.orphans.join(', ')}`);

--- a/src/lib/__tests__/hooks.test.ts
+++ b/src/lib/__tests__/hooks.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
-import { registerHooksToSettings } from '../hooks.js';
+import { registerHooksToSettings, unmanagedHookNames } from '../hooks.js';
 import { CODEX_HOOKS_MIN_VERSION } from '../agents.js';
 import { compareVersions } from '../versions.js';
 import type { ManifestHook } from '../types.js';
@@ -24,6 +24,36 @@ function makeVersionHome(): string {
   fs.mkdirSync(path.join(home, '.codex'), { recursive: true });
   return home;
 }
+
+describe('unmanagedHookNames', () => {
+  it('flags installed hooks whose name matches no manifest script basename', () => {
+    const installed = [
+      '00-agent-verify-work-complete', // system script, no manifest entry → dead
+      '02-expand-prompt-bang-commands', // dead
+      '03-linear-inject-tasks-context', // manifest-declared → registered
+      'git-guard', // manifest-declared → registered
+    ];
+    const manifestScripts = ['03-linear-inject-tasks-context.sh', 'git-guard.sh', 'rm-guard.sh'];
+    expect(unmanagedHookNames(installed, manifestScripts)).toEqual([
+      '00-agent-verify-work-complete',
+      '02-expand-prompt-bang-commands',
+    ]);
+  });
+
+  it('matches on script basename regardless of extension (.sh, .py)', () => {
+    // Manifest scripts can carry any extension; the installed name is ext-stripped.
+    expect(unmanagedHookNames(['guard'], ['guard.py'])).toEqual([]);
+    expect(unmanagedHookNames(['guard'], ['guard.sh'])).toEqual([]);
+  });
+
+  it('returns nothing when every installed hook is declared', () => {
+    expect(unmanagedHookNames(['a', 'b'], ['a.sh', 'b.sh'])).toEqual([]);
+  });
+
+  it('returns all installed hooks when the manifest is empty', () => {
+    expect(unmanagedHookNames(['a', 'b'], [])).toEqual(['a', 'b']);
+  });
+});
 
 describe('registerHooksToSettings - Codex', () => {
   beforeEach(() => {

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -760,7 +760,8 @@ export function listCentralHooks(): HookEntry[] {
  *
  * Hooks marked `enabled: false` are dropped from the returned map.
  */
-export function parseHookManifest(): Record<string, ManifestHook> {
+export function parseHookManifest(opts: { warn?: boolean } = {}): Record<string, ManifestHook> {
+  const warn = opts.warn !== false;
   const merged: Record<string, ManifestHook> = {};
   const systemHooks: Record<string, ManifestHook> = {};
 
@@ -782,7 +783,7 @@ export function parseHookManifest(): Record<string, ManifestHook> {
     try {
       const meta = yaml.parse(fs.readFileSync(userMetaPath, 'utf-8')) as { hooks?: Record<string, ManifestHook> } | null;
       if (meta?.hooks) for (const [name, def] of Object.entries(meta.hooks)) {
-        if (systemHooks[name] && def.override !== true) {
+        if (warn && systemHooks[name] && def.override !== true) {
           const action = def.enabled === false ? 'disables' : 'shadows';
           console.warn(
             `[agents hooks] User-layer hook '${name}' ${action} system-shipped hook. Set 'override: true' to silence this warning.`,
@@ -798,6 +799,36 @@ export function parseHookManifest(): Record<string, ManifestHook> {
     if (def.enabled === false) delete merged[name];
   }
   return merged;
+}
+
+/**
+ * Hook script files present on disk that no manifest entry declares — "dead"
+ * hooks. The registrar only wires manifest-declared hooks into an agent's
+ * native config (settings.json / config.toml), matching the installed file to a
+ * manifest entry by script basename. So a file whose basename matches no
+ * manifest `script:` is never registered: it occupies the hooks dir and shows
+ * up in listings, but no lifecycle event ever fires it.
+ *
+ * Pure on purpose (no disk reads) so it is trivially testable; callers pass the
+ * installed hook names and the manifest's script paths.
+ */
+export function unmanagedHookNames(installedHookNames: string[], manifestScripts: string[]): string[] {
+  const managed = new Set(manifestScripts.map((s) => path.basename(s).replace(/\.[^.]+$/, '')));
+  return installedHookNames.filter((name) => !managed.has(name)).sort();
+}
+
+/**
+ * The dead hooks (see {@link unmanagedHookNames}) sitting in one version home.
+ * Reads the merged hook manifest silently — a diagnostic must not emit the
+ * shadow/override warnings the registrar path prints.
+ */
+export function listUnmanagedHooksInVersionHome(agent: AgentId, version: string): string[] {
+  if (!AGENTS[agent].supportsHooks) return [];
+  const scripts = Object.values(parseHookManifest({ warn: false }))
+    .map((h) => h.script)
+    .filter((s): s is string => typeof s === 'string');
+  const installed = listHooksInVersionHome(agent, version).map((e) => e.name);
+  return unmanagedHookNames(installed, scripts);
 }
 
 // Codex events that support a matcher field (matches tool name or session type).

--- a/src/lib/plugins.test.ts
+++ b/src/lib/plugins.test.ts
@@ -12,6 +12,7 @@ import {
   discoverPluginCommands,
   discoverPluginAgentDefs,
   discoverPluginBin,
+  discoverPluginHooks,
   expandPluginVars,
   loadUserConfig,
   saveUserConfig,
@@ -341,6 +342,47 @@ describe('discoverPluginAgentDefs', () => {
 
     const defs = discoverPluginAgentDefs(tmpDir);
     expect(defs).toEqual(['reviewer']);
+  });
+});
+
+// ─── discoverPluginHooks ──────────────────────────────────────────────────────
+
+describe('discoverPluginHooks', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns empty array when hooks/hooks.json does not exist', () => {
+    expect(discoverPluginHooks(tmpDir)).toEqual([]);
+  });
+
+  it('reads the event names from the official `hooks`-wrapped format', () => {
+    const hooksDir = path.join(tmpDir, 'hooks');
+    fs.mkdirSync(hooksDir);
+    fs.writeFileSync(path.join(hooksDir, 'hooks.json'), JSON.stringify({
+      description: 'Memory plugin',
+      hooks: {
+        SessionStart: [{ hooks: [{ type: 'command', command: 'node x.js' }] }],
+        PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'node y.js' }] }],
+      },
+    }));
+    // The events are surfaced — NOT the top-level `description` / `hooks` keys.
+    expect(discoverPluginHooks(tmpDir)).toEqual(['SessionStart', 'PreToolUse']);
+  });
+
+  it('reads top-level keys for the flat (unwrapped) format', () => {
+    const hooksDir = path.join(tmpDir, 'hooks');
+    fs.mkdirSync(hooksDir);
+    fs.writeFileSync(path.join(hooksDir, 'hooks.json'), JSON.stringify({
+      PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'guard.sh' }] }],
+    }));
+    expect(discoverPluginHooks(tmpDir)).toEqual(['PreToolUse']);
   });
 });
 

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -269,13 +269,25 @@ function discoverPluginSkills(pluginRoot: string): string[] {
     .map(d => d.name);
 }
 
-function discoverPluginHooks(pluginRoot: string): string[] {
+/**
+ * The lifecycle events a plugin hooks into, read from hooks/hooks.json.
+ *
+ * The official plugin format wraps the event map under a `hooks` key
+ * (`{ description, hooks: { SessionStart: [...], PreToolUse: [...] } }`), so the
+ * meaningful keys are the events — NOT the top-level keys (`description`,
+ * `hooks`). Older/flat files put the event names at the top level directly; we
+ * read whichever object actually holds the event map.
+ */
+export function discoverPluginHooks(pluginRoot: string): string[] {
   const hooksFile = path.join(pluginRoot, 'hooks', 'hooks.json');
   if (!fs.existsSync(hooksFile)) return [];
 
   try {
     const content = JSON.parse(fs.readFileSync(hooksFile, 'utf-8')) as Record<string, unknown>;
-    return Object.keys(content);
+    const eventMap = content.hooks && typeof content.hooks === 'object' && !Array.isArray(content.hooks)
+      ? content.hooks as Record<string, unknown>
+      : content;
+    return Object.keys(eventMap);
   } catch {
     return [];
   }


### PR DESCRIPTION
## What & why

Three related improvements to how agents-cli surfaces hooks and plugins.

### 1. `agents inspect` summary — expanded detail
The bare `agents inspect <agent>` / `agents inspect <repo>` summary collapsed everything to a count table (`hooks 6 [user:4 system:2]`) — you couldn't see *what* the hooks/plugins/mcp servers were without drilling in.

- Simple kinds (commands, skills, rules, subagents, workflows) keep a count line but now **preview a few names**.
- Rich kinds get **expanded sections**: hooks show events + `matches:` predicates + cache (`PreToolUse(Bash) · git_dirty · prompt~"deploy" (5m cache)`); plugins show version + bundle contents (`v2.1.0  skills:6 commands:5 hooks:2 mcp:1`); MCP shows transport + url/command.
- Drill-down flags (`--hooks`/`--plugins`/`--mcp`) and `--brief` unchanged; `--json` gains structured detail **additively** (existing keys retained).
- Hooks join the manifest by **script basename** (installed hooks are named after their script file; the manifest keys on the logical name); the repo Hooks section uses the grouped reader so a script + its data file collapse to one clean entry.

### 2. Plugin hooks were misreported — fixed
`discoverPluginHooks` read the **top-level** keys of a plugin's `hooks/hooks.json`, so the official `{ description, hooks: { SessionStart: [...] } }` format surfaced as `description, hooks` instead of the real events. It now reads the `hooks` wrapper when present (falling back to top-level for the flat format), so plugin hooks show the actual lifecycle events.

### 3. `agents doctor` / `agents prune` — precise orphan-hook detection
Orphan-hook detection now flags hook scripts in a version home that **no `agents.yaml`/`hooks.yaml` entry registers** (synced to disk but never wired to an event → never fire). This replaces the source-diff heuristic, which compared only against the user hooks dir and so **false-flagged valid system-sourced, registered hooks** (e.g. `03-linear-inject`, `04-capture`) — meaning `prune cleanup` could have **deleted live hooks**. Doctor's Orphans section and `prune cleanup hooks` now share one manifest-based definition. `parseHookManifest` gained a silent `{ warn: false }` option so the diagnostic doesn't emit shadow/override warnings.

## Tests
- New unit tests: `summarizeHook` / `summarizeMcp` / `hookManifestByScript` (inspect), `discoverPluginHooks` nested+flat (plugins), `unmanagedHookNames` (hooks).
- Full suite: **2499 passed, 0 failed**. Verified end-to-end against a real install (`agents inspect`, `agents doctor`, `agents prune cleanup hooks --` dry-run) and a synthetic plugin/repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)