### PR TITLE
chore(release): 1.20.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phnx-labs/agents-cli",
-  "version": "1.20.13",
+  "version": "1.20.14",
   "description": "One CLI for all your AI coding agents - versions, config, cloud dispatch, sessions, and teams (now with first-class Grok Build CLI support)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release 1.20.14.

Ships the inspect/doctor/plugin-hooks work from #350 (already in Unreleased changelog):
- `agents inspect` summary expands hooks/plugins/MCP detail
- plugin hooks now report real lifecycle events (hooks.json wrapper fix)
- `doctor`/`prune` share one precise, manifest-based orphan-hook definition

Tagging `v1.20.14` after merge triggers the CI publish job to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)