### PR TITLE
fix(repo): backfill <alias>:* into existing versions when an extra repo is added

### DIFF
--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -39,6 +39,7 @@ function resolveRepoPath(target?: string): string {
 }
 
 import {
+  applyExtraAliasToVersions,
   ensureAgentsDir,
   getExtraRepoDir,
   getSystemAgentsDir,
@@ -299,6 +300,7 @@ export function registerRepoCommands(program: Command): void {
         const commit = log.latest?.hash.slice(0, 8) || 'unknown';
         extras[alias] = { url: targetDir, path: targetDir, enabled: true };
         updateMeta({ extraRepos: extras });
+        syncExtraAliasAcrossVersions(alias, true);
         spinner.succeed(`Created ${targetDir} (${commit})`);
         console.log(chalk.gray(`\nRegistered as "${alias}". Edit files there, then add your own git remote when ready.`));
       } catch (err) {
@@ -347,6 +349,7 @@ export function registerRepoCommands(program: Command): void {
       if (parsed.type === 'local') {
         extras[alias] = { url: parsed.url, path: parsed.url, enabled: true };
         updateMeta({ extraRepos: extras });
+        syncExtraAliasAcrossVersions(alias, true);
         syncMarketplacesForDefaults();
         console.log(chalk.green(`Registered local repo "${alias}" -> ${parsed.url}`));
         return;
@@ -384,6 +387,7 @@ export function registerRepoCommands(program: Command): void {
 
       extras[alias] = { url: parsed.url, path: targetDir, enabled: true };
       updateMeta({ extraRepos: extras });
+      syncExtraAliasAcrossVersions(alias, true);
       syncMarketplacesForDefaults();
 
       console.log(chalk.gray(`\nRegistered as "${alias}". Skills and commands from this repo will be`));
@@ -425,6 +429,7 @@ export function registerRepoCommands(program: Command): void {
 
       delete extras[alias];
       updateMeta({ extraRepos: extras });
+      syncExtraAliasAcrossVersions(alias, false);
       syncMarketplacesForDefaults();
       console.log(chalk.green(`Removed "${alias}"`));
     });
@@ -637,6 +642,20 @@ function collectRepoTargets(alias: string | undefined): RepoTarget[] | null {
   return [found];
 }
 
+/**
+ * Keep already-installed versions' selectors in sync with an extra-repo change:
+ * add `<alias>:*` when the repo is registered/enabled, strip it when removed.
+ * Newly-installed versions inherit it from `defaultPatterns()` at scaffold time,
+ * so without this a repo added after install is invisible to existing versions.
+ */
+function syncExtraAliasAcrossVersions(alias: string, add: boolean): void {
+  const n = applyExtraAliasToVersions(alias, add);
+  if (n > 0) {
+    const verb = add ? 'Added to' : 'Removed from';
+    console.log(chalk.gray(`${verb} ${n} existing version selector${n === 1 ? '' : 's'}.`));
+  }
+}
+
 async function toggle(alias: string, enabled: boolean): Promise<void> {
   const meta = readMeta();
   const extras: Record<string, ExtraRepoConfig> = { ...(meta.extraRepos || {}) };
@@ -651,6 +670,9 @@ async function toggle(alias: string, enabled: boolean): Promise<void> {
   }
   extras[alias] = { ...extras[alias], enabled };
   updateMeta({ extraRepos: extras });
+  // Re-enabling backfills the alias into existing versions; disabling leaves the
+  // selectors (resolution skips disabled extras) so a later enable is a no-op.
+  if (enabled) syncExtraAliasAcrossVersions(alias, true);
   syncMarketplacesForDefaults();
   console.log(chalk.green(`${enabled ? 'Enabled' : 'Disabled'} "${alias}"`));
 }

--- a/src/lib/__tests__/extra-alias-selectors.test.ts
+++ b/src/lib/__tests__/extra-alias-selectors.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { withAlias, withoutAlias } from '../state.js';
+
+// These guard the selector-amend logic behind `applyExtraAliasToVersions`, which
+// backfills an extra-repo alias into already-installed versions' selectors when a
+// repo is registered (and strips it on remove). The position and idempotency are
+// the load-bearing parts — a wrong position changes resolution precedence, and a
+// non-idempotent add corrupts the list on repeated `repo add`/launch.
+
+describe('withAlias', () => {
+  it('inserts <alias>:* immediately before project:* (after system/user)', () => {
+    expect(withAlias(['system:*', 'user:*', 'project:*'], 'extras')).toEqual([
+      'system:*',
+      'user:*',
+      'extras:*',
+      'project:*',
+    ]);
+  });
+
+  it('appends when there is no project layer (e.g. hooks)', () => {
+    expect(withAlias(['system:*', 'user:*'], 'extras')).toEqual([
+      'system:*',
+      'user:*',
+      'extras:*',
+    ]);
+  });
+
+  it('keeps multiple extras in registration order, all before project', () => {
+    const once = withAlias(['system:*', 'user:*', 'project:*'], 'rush');
+    expect(withAlias(once, 'extras')).toEqual([
+      'system:*',
+      'user:*',
+      'rush:*',
+      'extras:*',
+      'project:*',
+    ]);
+  });
+
+  it('is idempotent — re-adding the same alias is a no-op and returns the same ref', () => {
+    const input = ['system:*', 'user:*', 'extras:*', 'project:*'];
+    const out = withAlias(input, 'extras');
+    expect(out).toBe(input);
+  });
+
+  it('does not double-add when the alias is referenced by a specific include', () => {
+    const input = ['system:*', 'user:*', 'extras:my-skill', 'project:*'];
+    expect(withAlias(input, 'extras')).toBe(input);
+  });
+
+  it('does not re-add an alias the user explicitly excluded', () => {
+    const input = ['system:*', 'user:*', '!extras:noisy', 'project:*'];
+    expect(withAlias(input, 'extras')).toBe(input);
+  });
+
+  it('does not confuse a prefix-sharing alias (extras2 vs extras)', () => {
+    expect(withAlias(['system:*', 'user:*', 'extras2:*', 'project:*'], 'extras')).toEqual([
+      'system:*',
+      'user:*',
+      'extras2:*',
+      'extras:*',
+      'project:*',
+    ]);
+  });
+});
+
+describe('withoutAlias', () => {
+  it('removes the alias include and leaves everything else', () => {
+    expect(withoutAlias(['system:*', 'user:*', 'extras:*', 'project:*'], 'extras')).toEqual([
+      'system:*',
+      'user:*',
+      'project:*',
+    ]);
+  });
+
+  it('removes specific includes and excludes for the alias', () => {
+    expect(withoutAlias(['user:*', 'extras:a', '!extras:b', 'project:*'], 'extras')).toEqual([
+      'user:*',
+      'project:*',
+    ]);
+  });
+
+  it('returns the same ref when the alias is absent (no-op)', () => {
+    const input = ['system:*', 'user:*', 'project:*'];
+    expect(withoutAlias(input, 'extras')).toBe(input);
+  });
+
+  it('does not strip a prefix-sharing alias', () => {
+    expect(withoutAlias(['user:*', 'extras2:*', 'extras:*'], 'extras')).toEqual([
+      'user:*',
+      'extras2:*',
+    ]);
+  });
+});

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -807,6 +807,75 @@ export function ensureVersionResourcePatterns(
   if (changed) writeMeta(meta);
 }
 
+/**
+ * Resource types that resolve across the extra-repo layer. Mirrors
+ * `defaultPatterns()`: extras feed commands/skills/hooks/subagents/plugins/
+ * workflows, but never permissions (`system:*`) or mcp (`user:*`).
+ */
+const EXTRA_ELIGIBLE_TYPES: readonly (keyof VersionResources)[] = [
+  'commands', 'skills', 'hooks', 'subagents', 'plugins', 'workflows',
+];
+
+/**
+ * Insert `<alias>:*` at the canonical position (after the system/user/other-extra
+ * includes, before `project:*`), unless the alias is already referenced — as an
+ * include (`alias:...`) or an exclude (`!alias:...`). Returns a new array when it
+ * changes, otherwise the same reference (so callers can detect no-ops cheaply).
+ */
+export function withAlias(list: ResourcePattern[], alias: string): ResourcePattern[] {
+  const prefix = `${alias}:`;
+  if (list.some(p => p === `${alias}:*` || p.startsWith(prefix) || p.startsWith(`!${prefix}`))) {
+    return list;
+  }
+  const next = [...list];
+  const projIdx = next.findIndex(p => p === 'project:*' || p.startsWith('project:'));
+  if (projIdx >= 0) next.splice(projIdx, 0, `${alias}:*`);
+  else next.push(`${alias}:*`);
+  return next;
+}
+
+/** Strip every reference to `<alias>:...` / `!<alias>:...` from a selector list. */
+export function withoutAlias(list: ResourcePattern[], alias: string): ResourcePattern[] {
+  const prefix = `${alias}:`;
+  const next = list.filter(p => !(p.startsWith(prefix) || p.startsWith(`!${prefix}`)));
+  return next.length === list.length ? list : next;
+}
+
+/**
+ * Backfill (add=true) or strip (add=false) an extra-repo alias across every
+ * already-installed version's selectors. New versions get the alias via
+ * `defaultPatterns()` at scaffold time; this keeps existing versions in sync
+ * when an extra repo is registered/enabled or removed. Only touches selector
+ * lists that are already set — an unset list is left for `defaultPatterns()`.
+ * Returns the number of (agent, version) pairs changed.
+ */
+export function applyExtraAliasToVersions(alias: string, add: boolean): number {
+  const meta = readMeta();
+  if (!meta.versions) return 0;
+  let changed = false;
+  let count = 0;
+  for (const versions of Object.values(meta.versions)) {
+    if (!versions) continue;
+    for (const vr of Object.values(versions)) {
+      if (!vr) continue;
+      let touched = false;
+      for (const type of EXTRA_ELIGIBLE_TYPES) {
+        const cur = (vr as Record<string, ResourcePattern[] | undefined>)[type];
+        if (!Array.isArray(cur) || cur.length === 0) continue;
+        const next = add ? withAlias(cur, alias) : withoutAlias(cur, alias);
+        if (next !== cur) {
+          (vr as Record<string, ResourcePattern[]>)[type] = next;
+          touched = true;
+          changed = true;
+        }
+      }
+      if (touched) count++;
+    }
+  }
+  if (changed) writeMeta(meta);
+  return count;
+}
+
 export function getVersionResources(
   agent: AgentId,
   version: string


### PR DESCRIPTION
## What

`agents repo add` / `repo init` / `repo enable` registered an extra repo in `meta.extraRepos` but never updated **already-installed** versions' selectors. So a repo added *after* a version was installed was invisible to it — its `skills`/`commands`/`hooks` resolution still read `[system:*, user:*, project:*]` with no `<alias>:*`. `defaultPatterns()` only seeds the alias for versions scaffolded *after* the repo was registered.

Fixes #351.

## Change

- **`state.ts`** — new `applyExtraAliasToVersions(alias, add)`: amends every existing version's extras-eligible selectors (`commands`, `skills`, `hooks`, `subagents`, `plugins`, `workflows` — not `permissions`/`mcp`, matching `defaultPatterns`), inserting `<alias>:*` just before `project:*`, idempotently; strips it when `add=false`. Only touches selector lists that are already set (unset lists get `defaultPatterns()` at scaffold time). Exposes `withAlias`/`withoutAlias` pure helpers for testing.
- **`repo.ts`** — call it after `updateMeta` in `add` (local + remote), `init`, and `enable` (backfill); and in `remove` (strip). `disable` leaves selectors in place since resolution already skips disabled extras, so a later `enable` is a no-op.

## Test

- **11 unit tests** (`extra-alias-selectors.test.ts`) covering position (before `project:*`), append-when-no-project (hooks), multi-extra ordering, idempotency, not-double-adding on specific includes/excludes, and prefix-sharing aliases (`extras` vs `extras2`).
- **Integration run** over a real `agents.yaml` (3 versions): `add` inserted `<alias>:*` before `project:*` in skills/commands/hooks across all versions and **not** in permissions/mcp; re-`add` → 0 changes (idempotent); `remove` → exact inverse.
- `tsc --noEmit` clean.

## Note

This fixes the mechanism for **new** `repo add`s. Existing installs that already missed an extra (e.g. a codex default whose `skills` lacked `extras:*`) are corrected by re-running `agents repo enable <alias>` (or `repo add` for a fresh one), which now backfills them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
