### PR TITLE
feat(secrets): raw cross-platform `secrets get/set <item>` for hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+**`agents secrets get/set <item>`: raw, cross-platform keychain access for hooks**
+
+- New `agents secrets get <item>` / `agents secrets set <item>` read and write a single keychain item **by bare name** (outside the bundle namespace), so shell hooks and automation have one platform-agnostic credential primitive to call instead of hardcoding `/usr/bin/security` (macOS-only) or `secret-tool` (Linux-only). `get` prints the value to stdout (newline-terminated for clean `$(…)` capture), sends diagnostics to stderr, and exits 1 with empty stdout when the item is missing — exactly what a `SessionStart` hook needs to probe-and-fallback quietly. Routing goes through the existing cross-platform keychain layer: macOS via `/usr/bin/security`, Linux via `secret-tool` with the encrypted-file fallback.
+- `setKeychainToken` now writes bare (non-`agents-cli.`) items on macOS **without** the biometry ACL, mirroring the existing no-prompt read path for such items. This is what lets a hook read e.g. `linear-api-key` silently on every launch — routing it through the Touch ID helper would attach an ACL the `/usr/bin/security` read can't satisfy without popping the legacy password sheet. The change is purely additive: every existing caller passes an `agents-cli.`-namespaced item and is unaffected (still biometry-gated via the signed helper).
+
 **`agents inspect` summary: expanded detail for hooks, plugins, and MCP**
 
 - The bare `agents inspect <agent>` / `agents inspect <repo>` summary no longer collapses everything to a count table. Simple kinds (commands, skills, rules, subagents, workflows) keep a count line but now preview a few names; the rich kinds get their own expanded sections: **hooks** show their events + `matches:` predicates + cache (`PreToolUse(Bash) · git_dirty · prompt~"deploy" (5m cache)`), **plugins** show version + bundle contents (`v2.1.0  skills:6 commands:5 hooks:2 mcp:1`), and **MCP** show transport + url/command. Drill-down flags (`--hooks`, `--plugins`, `--mcp`) and `--brief` are unchanged; `--json` gains the structured detail additively (existing keys retained).

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -31,6 +31,7 @@ import {
 } from '../lib/secrets/bundles.js';
 import {
   deleteKeychainToken,
+  getKeychainToken,
   getKeychainTokens,
   hasKeychainToken,
   secretsKeychainItem,
@@ -397,6 +398,7 @@ export function registerSecretsCommands(program: Command): void {
   registerCommandGroups(cmd, [
     { title: 'Bundle commands', names: ['list', 'view', 'create', 'rename', 'describe', 'delete'] },
     { title: 'Secret commands', names: ['add', 'rotate', 'remove', 'import', 'export'] },
+    { title: 'Raw item commands', names: ['get', 'set'] },
     { title: 'Sync commands', names: ['push', 'pull', 'remote-list'] },
     { title: 'Utilities', names: ['exec', 'generate', 'migrate-acl'] },
   ]);
@@ -484,6 +486,53 @@ export function registerSecretsCommands(program: Command): void {
           const metaLine = renderMetaLine(bundle.meta?.[e.key], reveal);
           if (metaLine) console.log(metaLine);
         }
+      } catch (err) {
+        if (isPromptCancelled(err)) return;
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+
+  cmd
+    .command('get <item>')
+    .description('Print a raw keychain item by name (for shell hooks/automation). Cross-platform; no bundle required.')
+    .action((item: string) => {
+      try {
+        // Routes through the platform keychain layer: macOS reads bare items
+        // via /usr/bin/security (no Touch ID), Linux via secret-tool with the
+        // encrypted-file fallback. The value goes to stdout (newline-terminated
+        // so `$(agents secrets get NAME)` captures it cleanly); diagnostics go
+        // to stderr so they never pollute the captured value.
+        const value = getKeychainToken(item);
+        process.stdout.write(value.endsWith('\n') ? value : `${value}\n`);
+      } catch {
+        // Missing item is a normal, quiet outcome for a hook probe: exit 1,
+        // print nothing to stdout. Callers test the exit code / empty capture.
+        process.exit(1);
+      }
+    });
+
+  cmd
+    .command('set <item>')
+    .description('Store a raw keychain item by name (for shell hooks/automation). Cross-platform; no bundle required.')
+    .option('--value <v>', 'Value to store (omit to read from stdin or be prompted)')
+    .option('--value-stdin', 'Read the value from stdin')
+    .action(async (item: string, opts: { value?: string; valueStdin?: boolean }) => {
+      try {
+        let value: string;
+        if (opts.value !== undefined) {
+          value = opts.value;
+        } else if (opts.valueStdin) {
+          value = readStdinSync();
+          if (!value) throw new Error('No value received on stdin.');
+        } else {
+          value = await promptForSecret(`Enter value for ${item}`);
+        }
+        // setKeychainToken stores bare items WITHOUT the biometry ACL on macOS
+        // so `agents secrets get` can read them back without a password sheet;
+        // on Linux it goes through secret-tool / encrypted-file fallback.
+        setKeychainToken(item, value);
+        console.error(chalk.green(`Stored keychain item '${item}'.`));
       } catch (err) {
         if (isPromptCancelled(err)) return;
         console.error(chalk.red((err as Error).message));

--- a/src/lib/secrets/__tests__/raw-item.test.ts
+++ b/src/lib/secrets/__tests__/raw-item.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  getKeychainToken,
+  setKeychainToken,
+  hasKeychainToken,
+  deleteKeychainToken,
+  setKeychainBackendForTest,
+  type KeychainBackend,
+} from '../index.js';
+import { _resetForTest } from '../linux.js';
+
+/**
+ * The `agents secrets get/set <item>` raw-item path — the cross-platform
+ * primitive the Linear SessionStart hook calls instead of hardcoding
+ * `/usr/bin/security`. These items use BARE names (e.g. `linear-api-key`),
+ * not the `agents-cli.` namespace, which is exactly what distinguishes the
+ * no-biometry hook path from biometry-gated bundle items.
+ */
+
+// ---------------------------------------------------------------------------
+// Platform-independent contract: bare item names round-trip through the
+// public index.ts API. Uses the in-memory test backend so it runs on any OS
+// (incl. macOS dev machines) without touching a real keychain/keyring.
+// ---------------------------------------------------------------------------
+describe('raw keychain item API contract', () => {
+  let store: Map<string, string>;
+  let prev: KeychainBackend | null;
+
+  beforeEach(() => {
+    store = new Map();
+    const mem: KeychainBackend = {
+      has: (i) => store.has(i),
+      get: (i) => {
+        if (!store.has(i)) throw new Error(`Keychain item '${i}' not found.`);
+        return store.get(i)!;
+      },
+      set: (i, v) => { store.set(i, v); },
+      delete: (i) => store.delete(i),
+      list: (p) => [...store.keys()].filter((k) => k.startsWith(p)),
+    };
+    prev = setKeychainBackendForTest(mem);
+  });
+
+  afterEach(() => {
+    setKeychainBackendForTest(prev);
+  });
+
+  it('round-trips a bare item name (the hook stores linear-api-key)', () => {
+    expect(hasKeychainToken('linear-api-key')).toBe(false);
+    setKeychainToken('linear-api-key', 'lin_api_xxx');
+    expect(hasKeychainToken('linear-api-key')).toBe(true);
+    expect(getKeychainToken('linear-api-key')).toBe('lin_api_xxx');
+  });
+
+  it('overwrites in place on repeated set (upsert)', () => {
+    setKeychainToken('linear-team-id', 'team-old');
+    setKeychainToken('linear-team-id', 'team-new');
+    expect(getKeychainToken('linear-team-id')).toBe('team-new');
+  });
+
+  it('throws on a missing item so the hook can fall back quietly', () => {
+    expect(() => getKeychainToken('never-stored')).toThrow(/not found/);
+  });
+
+  it('delete removes the item', () => {
+    setKeychainToken('linear-api-key', 'v');
+    expect(deleteKeychainToken('linear-api-key')).toBe(true);
+    expect(hasKeychainToken('linear-api-key')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Linux real backend: force the encrypted-file fallback (so CI doesn't need an
+// unlocked GNOME Keyring) and exercise the ACTUAL critical path index.ts takes
+// on Linux — value gets encrypted to disk and decrypted back. This is the path
+// the hook hits on this user's Linux box.
+// ---------------------------------------------------------------------------
+describe.skipIf(process.platform !== 'linux')('raw item via real Linux file fallback', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-rawitem-'));
+    _resetForTest({ fileDir: dir, forceFileFallback: true, passphrase: 'test-pass' });
+  });
+
+  afterEach(() => {
+    _resetForTest();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('set then get a bare item round-trips through libsecret file fallback', () => {
+    setKeychainToken('linear-api-key', 'lin_api_secret');
+    expect(getKeychainToken('linear-api-key')).toBe('lin_api_secret');
+    expect(hasKeychainToken('linear-api-key')).toBe(true);
+    // Encrypted on disk under <item>.enc — never the plaintext value.
+    const onDisk = fs.readFileSync(path.join(dir, 'linear-api-key.enc'), 'utf8');
+    expect(onDisk).not.toContain('lin_api_secret');
+    expect(JSON.parse(onDisk)).toHaveProperty('ciphertext');
+  });
+
+  it('missing item throws', () => {
+    expect(() => getKeychainToken('absent-item')).toThrow();
+    expect(hasKeychainToken('absent-item')).toBe(false);
+  });
+});

--- a/src/lib/secrets/index.ts
+++ b/src/lib/secrets/index.ts
@@ -258,6 +258,27 @@ export function setKeychainToken(item: string, value: string): void {
 
   if (isLinux()) { linuxBackend.set(item, value); return; }
 
+  // Bare (non-`agents-cli.`) items are written WITHOUT the biometry ACL so
+  // they round-trip with the no-prompt read path in getKeychainToken (which
+  // also uses /usr/bin/security for non-our items). This is what lets a
+  // SessionStart hook read e.g. `linear-api-key` silently on every launch.
+  // Routing these through the helper would attach a Touch ID ACL that the
+  // /usr/bin/security read can't satisfy without popping the legacy password
+  // sheet. -U upserts so repeated sets overwrite in place.
+  if (!isOurItem(item)) {
+    const sec = spawnSync('/usr/bin/security', [
+      'add-generic-password', '-U',
+      '-a', os.userInfo().username,
+      '-s', item,
+      '-w', value,
+    ], { stdio: ['ignore', 'pipe', 'pipe'] });
+    if (sec.status !== 0) {
+      const msg = sec.stderr?.toString().trim();
+      throw new Error(msg || `Failed to write keychain item '${item}'.`);
+    }
+    return;
+  }
+
   const bin = getKeychainHelperPath();
   const result = spawnSync(bin, ['set', item, os.userInfo().username], {
     input: value,


### PR DESCRIPTION
## Why

Shell hooks that need a credential had to hardcode the platform keychain CLI — `/usr/bin/security` on macOS, `secret-tool` on Linux. The Linear `SessionStart` hook (`03-linear-inject-tasks-context.sh` in `.agents-system`) did exactly this and printed `Linear credentials not found in Keychain` on **every** session start on Linux, because `security` doesn't exist there at all.

The CLI already owns a complete cross-platform keychain layer (`getKeychainToken`/`setKeychainToken` in `src/lib/secrets/index.ts` → macOS helper / `/usr/bin/security` / Linux `secret-tool` + encrypted-file fallback). It just wasn't reachable from a shell hook — `agents secrets` only exposed **bundle** subcommands.

## What

- **`agents secrets get <item>`** — read one keychain item by **bare name** (outside the bundle namespace). Prints the value to stdout (newline-terminated for clean `$(…)` capture), diagnostics to stderr, and exits `1` with empty stdout when missing. This is the probe-and-fallback shape a `SessionStart` hook needs.
- **`agents secrets set <item>`** — write one by bare name (`--value`, `--value-stdin`, or interactive prompt).
- Both route through the existing keychain layer, so **no per-hook platform branching** ever lives in bash again.

## macOS correctness (does not break macOS)

`getKeychainToken` already reads bare (non-`agents-cli.`) items via `/usr/bin/security` with **no Touch ID**. But `setKeychainToken` had no matching bare-item branch — it always routed to the biometry-ACL helper, so a `set`→`get` of `linear-api-key` would pop the legacy password sheet on every read.

This PR adds a bare-item write branch on macOS that mirrors the proven read path (`/usr/bin/security add-generic-password -U`). It is **purely additive**: all 13 existing `setKeychainToken` callers pass `agents-cli.`-namespaced items, so they keep the biometry-gated helper path unchanged. No existing macOS flow is touched.

## Tests

- Platform-independent API contract (in-memory backend): bare-name round-trip, upsert, missing-throws, delete.
- Linux-only round-trip through the **real** libsecret encrypted-file fallback: value encrypted on disk under `<item>.enc`, decrypted back; missing-throws.
- End-to-end verified on Linux against the built CLI: `set --value` → `get` returns the value on clean stdout (exit 0); `get` of a missing item → empty stdout, exit 1.
- Full suite: **2505 pass, 0 fail, 46 skipped**.

## Follow-up

Companion PR to `phnx-labs/.agents-system` rewrites the Linear hook to call `agents secrets get linear-api-key` instead of `security find-generic-password`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)