### PR TITLE
fix(browser): don't inject detectable webdriver shim on self-launched browsers

### DIFF
--- a/src/lib/browser/service.ts
+++ b/src/lib/browser/service.ts
@@ -2116,23 +2116,34 @@ export class BrowserService {
       flatten: true,
     })) as { sessionId: string };
 
-    // Inject a one-shot stealth shim before any page script runs. Chromium
-    // unconditionally exposes navigator.webdriver = true when a remote-debug
-    // transport is attached; Cloudflare Turnstile, hCaptcha, and similar bot
-    // checks read that property first. For browsers agents-cli spawns the
-    // --disable-blink-features=AutomationControlled launch flag already
-    // covers this, but for attach-to-running profiles (the Comet / Arc /
-    // Brave case where the user launched the browser themselves) the flag
-    // is unavailable — Page.addScriptToEvaluateOnNewDocument is the only
-    // lever. Non-page targets (workers, service workers) will reject these
-    // calls; we swallow the error and keep going.
-    try {
-      await conn.cdp.send('Page.enable', {}, sessionId);
-      await conn.cdp.send('Page.addScriptToEvaluateOnNewDocument', {
-        source: "Object.defineProperty(navigator,'webdriver',{get:()=>undefined});",
-      }, sessionId);
-    } catch {
-      // Target doesn't support Page domain — nothing to inject.
+    // Inject a stealth shim before any page script runs. Chromium exposes
+    // navigator.webdriver = true whenever a remote-debug transport is attached;
+    // Cloudflare Turnstile, hCaptcha, and similar bot checks read it first.
+    //
+    // Only attach-to-running profiles (conn.pid === 0 — Comet / Arc / Brave the
+    // user launched themselves) need this. Browsers agents-cli spawns already
+    // carry the --disable-blink-features=AutomationControlled launch flag, which
+    // makes navigator.webdriver a native Navigator.prototype getter returning
+    // false — indistinguishable from an untouched browser. Injecting on top of
+    // that is actively harmful: it defines an OWN getter on the instance, and an
+    // own `webdriver` descriptor (native lives on the prototype) returning
+    // `undefined` (native returns `false`) is itself a tampering signal that
+    // bot.sannysoft.com and similar tests flag as "WebDriver present".
+    //
+    // When we do inject (attach mode), mirror native semantics exactly: define
+    // on Navigator.prototype and return false, so no own descriptor leaks and
+    // the value matches a real browser. Non-page targets (workers, service
+    // workers) reject these calls; swallow the error and keep going.
+    if (conn.pid === 0) {
+      try {
+        await conn.cdp.send('Page.enable', {}, sessionId);
+        await conn.cdp.send('Page.addScriptToEvaluateOnNewDocument', {
+          source:
+            "Object.defineProperty(Navigator.prototype,'webdriver',{get:()=>false,configurable:true});",
+        }, sessionId);
+      } catch {
+        // Target doesn't support Page domain — nothing to inject.
+      }
     }
 
     conn.sessionCache.set(tabId, sessionId);


### PR DESCRIPTION
## What

The `navigator.webdriver` stealth shim in `BrowserService.getSessionId` (`src/lib/browser/service.ts`) was injected **unconditionally on every tab** — including for browsers agents-cli **self-launches**, which already carry the `--disable-blink-features=AutomationControlled` flag (`src/lib/browser/chrome.ts:268`). The extra injection makes self-launched profiles **more** bot-detectable, not less.

Fixes #349.

## Why it's a bug

For a self-launched browser the launch flag makes `navigator.webdriver` a **native `Navigator.prototype` getter returning `false`** — indistinguishable from an untouched browser. The shim then runs `Object.defineProperty(navigator, 'webdriver', { get: () => undefined })`, which:

- creates an **own** property on the `navigator` instance (native lives on the prototype → an own descriptor is a tampering tell), and
- returns **`undefined`** (a real Chrome returns **`false`**).

`bot.sannysoft.com`'s `WebDriver (New)` test flags exactly this → red **"present (failed)"**, where an untouched browser passes.

(Subtle: the very first page load — before the shim warms up — shows green, so a single startup screenshot is misleading. The regression only shows on steady-state reloads.)

## Fix

1. **Guard the injection with `conn.pid === 0`** — the existing attach-mode sentinel (`pid` is the spawned browser's PID for self-launched profiles, `0` for attach-to-running ones; already used this way at `service.ts:1857`). Self-launched browsers are left to the launch flag.
2. **Make the attach-mode shim native-faithful** — define on `Navigator.prototype` returning `false` (no own descriptor, native value) instead of an own instance getter returning `undefined`.

```diff
-    try {
-      await conn.cdp.send('Page.enable', {}, sessionId);
-      await conn.cdp.send('Page.addScriptToEvaluateOnNewDocument', {
-        source: "Object.defineProperty(navigator,'webdriver',{get:()=>undefined});",
-      }, sessionId);
-    } catch { /* ... */ }
+    if (conn.pid === 0) {
+      try {
+        await conn.cdp.send('Page.enable', {}, sessionId);
+        await conn.cdp.send('Page.addScriptToEvaluateOnNewDocument', {
+          source:
+            "Object.defineProperty(Navigator.prototype,'webdriver',{get:()=>false,configurable:true});",
+        }, sessionId);
+      } catch { /* non-page target */ }
+    }
```

## Verification (end-to-end)

Built this branch and ran a **self-launched** Brave profile against `bot.sannysoft.com`:

| | before (main) | after (this PR) |
|---|---|---|
| `navigator.webdriver` | `undefined` | `false` (native) |
| own `webdriver` descriptor | present (getter) | none |
| sannysoft `WebDriver (New)` | **present (failed)** 🔴 | **missing (passed)** 🟢 |

Live eval on the fixed build:
```json
{"value":"false","ownGetter":false,"sannysoftRow":"missing (passed)"}
```

The whole sannysoft table (including WebGL) is green on the fixed build. Attach-mode profiles still get a shim, now indistinguishable from native.

## Tests

`bun test` was run on this branch **and** on clean `origin/main` in the same sandbox:

| branch | pass | fail | skip |
|---|---|---|---|
| `origin/main` (baseline) | 1888 | 578 | 46 |
| this PR | 1923 | 547 | 46 |

The large failure count is **pre-existing and environment-dependent** — the `session-tracker` integration harness spawns the `agents` binary, which isn't on `PATH` in this sandbox (`ENOENT spawn 'agents'`), and those restart/timing tests are flaky run-to-run. This PR is **no worse than baseline** (in fact marginally greener, within the noise), and it touches only `src/lib/browser/service.ts` — there are no failures in browser code on either branch. CI (Node 22/24) runs the suite in a proper environment.

## Notes

- No dedicated unit test added: the repo forbids mocking (real-services-only), and there's no existing browser-launch integration harness to extend; the behavior is covered by the E2E check above. Happy to add an integration test if you point me at the right harness.
