### PR TITLE
chore(release): 1.20.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phnx-labs/agents-cli",
-  "version": "1.20.14",
+  "version": "1.20.15",
   "description": "One CLI for all your AI coding agents - versions, config, cloud dispatch, sessions, and teams (now with first-class Grok Build CLI support)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release 1.20.15. Publishes the commits that landed after the 1.20.14 release commit (incl. #358 repo backfill, #362 browser fix). npm publish happens from the tagged commit after merge.