### PR TITLE
fix(shims): upgrade-only shim regen to stop multi-install ping-pong

### DIFF
--- a/src/lib/__tests__/shims.test.ts
+++ b/src/lib/__tests__/shims.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -315,5 +315,69 @@ describe('hasAliasShadowingShim', () => {
       'utf8',
     );
     expect(hasAliasShadowingShim('codex', { homeDir: home })).toBe(false);
+  });
+});
+
+// Regression: two agents-cli installs with different SHIM_SCHEMA_VERSION sharing
+// ~/.agents/.cache/shims/ used to ping-pong — each regenerated every shim whose
+// embedded marker !== its own constant, so they took turns rewriting all shims
+// on every launch. ensureShimCurrent is now upgrade-only: it never downgrades a
+// shim stamped by a newer install. (SHIMS_DIR is derived from HOME at module
+// load, so re-import under a temp HOME to keep the real shims dir untouched.)
+describe('ensureShimCurrent — upgrade-only / newest-wins', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-shim-current-'));
+    process.env.HOME = home;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    vi.resetModules();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  function writeShim(shimPath: string, marker: string): void {
+    fs.mkdirSync(path.dirname(shimPath), { recursive: true });
+    fs.writeFileSync(shimPath, `#!/bin/bash\n# ${marker}\nexec true\n`, { mode: 0o755 });
+  }
+
+  it('does NOT downgrade a shim stamped by a newer install', async () => {
+    const mod = await import('../shims.js');
+    const shimPath = mod.getShimPath('claude');
+    const newer = mod.SHIM_SCHEMA_VERSION + 1;
+    writeShim(shimPath, `agents-shim-version: ${newer}`);
+    const before = fs.readFileSync(shimPath, 'utf8');
+
+    expect(mod.ensureShimCurrent('claude')).toBe('current');
+    expect(fs.readFileSync(shimPath, 'utf8')).toBe(before); // left untouched
+  });
+
+  it('regenerates a shim from an older install (upgrade)', async () => {
+    const mod = await import('../shims.js');
+    const shimPath = mod.getShimPath('claude');
+    writeShim(shimPath, 'agents-shim-version: 1');
+
+    expect(mod.ensureShimCurrent('claude')).toBe('updated');
+    expect(fs.readFileSync(shimPath, 'utf8')).toContain(
+      `agents-shim-version: ${mod.SHIM_SCHEMA_VERSION}`,
+    );
+  });
+
+  it('regenerates an unversioned (pre-marker) shim', async () => {
+    const mod = await import('../shims.js');
+    const shimPath = mod.getShimPath('claude');
+    writeShim(shimPath, 'no marker here');
+
+    expect(mod.ensureShimCurrent('claude')).toBe('updated');
+  });
+
+  it('leaves a current shim untouched', async () => {
+    const mod = await import('../shims.js');
+    mod.createShim('claude');
+    expect(mod.ensureShimCurrent('claude')).toBe('current');
   });
 });

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -730,7 +730,10 @@ export function ensureVersionedAliasCurrent(agent: AgentId, version: string): 'c
     createVersionedAlias(agent, version);
     return 'created';
   }
-  if (!isVersionedAliasCurrent(agent, version)) {
+  // Upgrade-only (newest-wins), same rationale as ensureShimCurrent: never
+  // downgrade an alias stamped by a newer install sharing the shims dir.
+  const onDisk = readVersionedAliasSchemaVersion(agent, version);
+  if (onDisk === null || onDisk < VERSIONED_ALIAS_SCHEMA_VERSION) {
     createVersionedAlias(agent, version);
     return 'updated';
   }
@@ -1366,7 +1369,14 @@ export function ensureShimCurrent(agent: AgentId): 'created' | 'updated' | 'curr
     createShim(agent);
     return 'created';
   }
-  if (!isShimCurrent(agent)) {
+  // Upgrade-only (newest-wins): regenerate only when the on-disk shim is
+  // unversioned/unreadable (null) or OLDER than this binary. Never downgrade a
+  // shim stamped by a NEWER agents-cli install. Two installs at different
+  // SHIM_SCHEMA_VERSION sharing ~/.agents/.cache/shims/ (e.g. a dev build on
+  // PATH alongside a Hermes-bundled published copy) otherwise ping-pong —
+  // rewriting every shim on each alternating launch and adding boot latency.
+  const onDisk = readShimSchemaVersion(agent);
+  if (onDisk === null || onDisk < SHIM_SCHEMA_VERSION) {
     createShim(agent);
     return 'updated';
   }


### PR DESCRIPTION
## Problem

Every interactive `agents`/`ag` invocation regenerated all installed shims, printing `Updated <agent> shim` for each and adding boot latency:

```
Updated agy shim
Updated claude shim
... (9 agents)
```

## Root cause

`ensureShimCurrent` / `ensureVersionedAliasCurrent` regenerated on any schema **mismatch** (`isShimCurrent` uses strict `===`), so they would **downgrade** a shim stamped by a different install.

Two agents-cli installs share `~/.agents/.cache/shims/`:
- a dev/newer build on PATH (`SHIM_SCHEMA_VERSION = 18`)
- a Hermes-bundled published copy (`@phnx-labs/agents-cli@1.20.7`, `SHIM_SCHEMA_VERSION = 17`)

Each rewrote every shim whose embedded marker `!==` its own constant, so the two **took turns** flipping all shared shims `18↔17` on every alternating launch.

Proven by direct execution against the real shim:
```
hermes v17 ensureShimCurrent('claude') -> updated   18→17  (DOWNGRADE)
dev    v18 ensureShimCurrent('claude') -> updated   17→18  (upgrade)
hermes v17 again                       -> updated   18→17  (DOWNGRADE)
```

Smoking gun: the only installed agent **not** rewritten was `droid` — v17's registry doesn't include `droid`, so it never touched it while the 9 shared agents ping-ponged.

## Fix

Make regeneration **upgrade-only (newest-wins)**: regenerate only when the on-disk shim is unversioned/unreadable or strictly **older** than this binary. Never downgrade a shim written by a newer install. The newest schema wins and older installs defer, so the ping-pong cannot occur regardless of which install launches.

After the fix, the same sequence is stable:
```
hermes(fixed) -> current   18
dev(fixed)    -> current   18
hermes(fixed) -> current   18
```

## Tests

4 regression tests in `shims.test.ts` (re-import under a temp HOME to keep the real shims dir untouched): does-not-downgrade-newer, upgrades-older, regenerates-unversioned, leaves-current. All shim suites green; full build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)