### PR TITLE
feat(teams): add Kimi stream-json event parser

### DIFF
--- a/src/lib/session/__tests__/parse-kimi.test.ts
+++ b/src/lib/session/__tests__/parse-kimi.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Verifies parseKimi normalizes Kimi's internal wire.jsonl session log into the
+ * shared SessionEvent shape, and detectAgent routes Kimi session paths correctly.
+ */
+
+import { describe, expect, test } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { parseKimi, detectAgent, parseSession } from '../parse.js';
+
+function makeKimiSession(wireContent: string): string {
+  const base = path.join(os.tmpdir(), `.kimi-code`, 'sessions', `kimi-parse-${Date.now()}-${Math.random()}`);
+  const sessionDir = path.join(base, 'session_test-123e4567-e89b-12d3-a456-426614174000');
+  const agentsDir = path.join(sessionDir, 'agents', 'main');
+  fs.mkdirSync(agentsDir, { recursive: true });
+  fs.writeFileSync(path.join(sessionDir, 'state.json'), JSON.stringify({
+    title: 'Test session',
+    createdAt: '2026-06-24T00:00:00.000Z',
+  }));
+  fs.writeFileSync(path.join(agentsDir, 'wire.jsonl'), wireContent);
+  return path.join(sessionDir, 'state.json');
+}
+
+describe('parseKimi', () => {
+  test('maps user append_message to message event', () => {
+    const statePath = makeKimiSession(JSON.stringify({
+      type: 'context.append_message',
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello Kimi' }],
+      },
+      time: 1750723200000,
+    }));
+
+    const events = parseKimi(statePath);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'message',
+      agent: 'kimi',
+      role: 'user',
+      content: 'Hello Kimi',
+    });
+  });
+
+  test('maps assistant append_message to message event', () => {
+    const statePath = makeKimiSession(JSON.stringify({
+      type: 'context.append_message',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hi there' }],
+      },
+      time: 1750723200000,
+    }));
+
+    const events = parseKimi(statePath);
+    expect(events[0]).toMatchObject({
+      type: 'message',
+      agent: 'kimi',
+      role: 'assistant',
+      content: 'Hi there',
+    });
+  });
+
+  test('maps content.part text to assistant message', () => {
+    const statePath = makeKimiSession(JSON.stringify({
+      type: 'context.append_loop_event',
+      event: {
+        type: 'content.part',
+        part: { type: 'text', text: 'Done.' },
+      },
+      time: 1750723200000,
+    }));
+
+    const events = parseKimi(statePath);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'message',
+      agent: 'kimi',
+      role: 'assistant',
+      content: 'Done.',
+    });
+  });
+
+  test('maps content.part think to thinking event', () => {
+    const statePath = makeKimiSession(JSON.stringify({
+      type: 'context.append_loop_event',
+      event: {
+        type: 'content.part',
+        part: { type: 'think', think: 'Let me check...' },
+      },
+      time: 1750723200000,
+    }));
+
+    const events = parseKimi(statePath);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'thinking',
+      agent: 'kimi',
+      content: 'Let me check...',
+    });
+  });
+
+  test('maps Bash tool.call to tool_use with command', () => {
+    const statePath = makeKimiSession(JSON.stringify({
+      type: 'context.append_loop_event',
+      event: {
+        type: 'tool.call',
+        toolCallId: 'tool_1',
+        name: 'Bash',
+        function: {
+          name: 'Bash',
+          arguments: JSON.stringify({ command: 'ls -la' }),
+        },
+      },
+      time: 1750723200000,
+    }));
+
+    const events = parseKimi(statePath);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'tool_use',
+      agent: 'kimi',
+      tool: 'Bash',
+      command: 'ls -la',
+      args: { command: 'ls -la' },
+    });
+  });
+
+  test('maps Read tool.call to tool_use with path', () => {
+    const statePath = makeKimiSession(JSON.stringify({
+      type: 'context.append_loop_event',
+      event: {
+        type: 'tool.call',
+        toolCallId: 'tool_2',
+        name: 'Read',
+        function: {
+          name: 'Read',
+          arguments: JSON.stringify({ path: '/tmp/file.txt' }),
+        },
+      },
+      time: 1750723200000,
+    }));
+
+    const events = parseKimi(statePath);
+    expect(events[0]).toMatchObject({
+      type: 'tool_use',
+      agent: 'kimi',
+      tool: 'Read',
+      path: '/tmp/file.txt',
+    });
+  });
+
+  test('maps tool.result to tool_result and correlates tool name', () => {
+    const jsonl = [
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.call',
+          toolCallId: 'tool_3',
+          name: 'Bash',
+          function: {
+            name: 'Bash',
+            arguments: JSON.stringify({ command: 'echo hi' }),
+          },
+        },
+        time: 1750723200000,
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.result',
+          toolCallId: 'tool_3',
+          result: { output: 'hi' },
+        },
+        time: 1750723200001,
+      },
+    ].map(o => JSON.stringify(o)).join('\n');
+
+    const statePath = makeKimiSession(jsonl);
+    const events = parseKimi(statePath);
+    expect(events).toHaveLength(2);
+    expect(events[1]).toMatchObject({
+      type: 'tool_result',
+      agent: 'kimi',
+      tool: 'Bash',
+      success: true,
+      output: 'hi',
+    });
+  });
+
+  test('maps failed tool.result to error event', () => {
+    const jsonl = [
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.call',
+          toolCallId: 'tool_4',
+          name: 'Bash',
+          function: {
+            name: 'Bash',
+            arguments: JSON.stringify({ command: 'false' }),
+          },
+        },
+        time: 1750723200000,
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.result',
+          toolCallId: 'tool_4',
+          result: { output: 'Error: command failed', isError: true },
+        },
+        time: 1750723200001,
+      },
+    ].map(o => JSON.stringify(o)).join('\n');
+
+    const statePath = makeKimiSession(jsonl);
+    const events = parseKimi(statePath);
+    expect(events[1]).toMatchObject({
+      type: 'error',
+      agent: 'kimi',
+      tool: 'Bash',
+      success: false,
+    });
+  });
+
+  test('maps usage.record to usage event', () => {
+    const statePath = makeKimiSession(JSON.stringify({
+      type: 'usage.record',
+      usage: {
+        inputOther: 100,
+        output: 50,
+      },
+      model: 'kimi-code/kimi-for-coding',
+      time: 1750723200000,
+    }));
+
+    const events = parseKimi(statePath);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'usage',
+      agent: 'kimi',
+      model: 'kimi-code/kimi-for-coding',
+      inputTokens: 100,
+      outputTokens: 50,
+    });
+  });
+
+  test('returns empty array when wire.jsonl is missing', () => {
+    const base = path.join(os.tmpdir(), `kimi-parse-missing-${Date.now()}`);
+    const sessionDir = path.join(base, 'session_test-123e4567-e89b-12d3-a456-426614174000');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(path.join(sessionDir, 'state.json'), JSON.stringify({}));
+
+    const events = parseKimi(path.join(sessionDir, 'state.json'));
+    expect(events).toEqual([]);
+  });
+});
+
+describe('detectAgent routes kimi paths', () => {
+  test('local ~/.kimi-code/ state.json path', () => {
+    expect(detectAgent('/home/me/.kimi-code/sessions/wd_foo/session_abc/state.json')).toBe('kimi');
+  });
+
+  test('parseSession dispatches through detectAgent for kimi', () => {
+    const statePath = makeKimiSession(JSON.stringify({
+      type: 'context.append_message',
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'hi from kimi' }],
+      },
+      time: 1750723200000,
+    }));
+
+    const events = parseSession(statePath);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      agent: 'kimi',
+      type: 'message',
+      role: 'user',
+      content: 'hi from kimi',
+    });
+  });
+});

--- a/src/lib/session/parse.ts
+++ b/src/lib/session/parse.ts
@@ -90,7 +90,7 @@ export function parseSession(filePath: string, agent?: SessionAgentId): SessionE
     case 'rush': events = parseRush(filePath); break;
     case 'openclaw': events = []; break; // OpenClaw sessions don't have parseable files yet
     case 'hermes': events = parseHermes(filePath); break;
-    case 'kimi': events = []; break; // Kimi event parsing not implemented yet — discover.ts builds metadata only
+    case 'kimi': events = parseKimi(filePath); break;
   }
 
   // Chokepoint: every string field that originated in an untrusted session
@@ -108,6 +108,7 @@ export function detectAgent(filePath: string): SessionAgentId | null {
   if (filePath.includes('/.grok/') || filePath.includes('\\.grok\\')) return 'grok';
   if (filePath.includes('/.rush/') || filePath.includes('\\.rush\\')) return 'rush';
   if (filePath.includes('/.hermes/') || filePath.includes('\\.hermes\\')) return 'hermes';
+  if (filePath.includes('/.kimi-code/') || filePath.includes('\\.kimi-code\\')) return 'kimi';
   // Cloud convention: cloud-sessions/<id>/session.<format>.jsonl
   const cloudMatch = filePath.match(/session\.(claude|codex|rush)\.jsonl(?:$|[?#])/);
   if (cloudMatch) return cloudMatch[1] as SessionAgentId;
@@ -960,4 +961,176 @@ function hermesContentToText(content: any): string {
     })
     .join('\n')
     .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Kimi parser
+//
+// Kimi stores session metadata in state.json and the conversation transcript
+// in agents/main/wire.jsonl under ~/.kimi-code/sessions/<workdir>/session_<uuid>/.
+// wire.jsonl uses a role-based schema:
+//   - "context.append_message" with role=user/assistant -> messages
+//   - "context.append_loop_event" with content.part type=text/think -> message/thinking
+//   - "context.append_loop_event" with event.type=tool.call -> tool_use
+//   - "context.append_loop_event" with event.type=tool.result -> tool_result
+//   - "usage.record" -> usage
+// ---------------------------------------------------------------------------
+
+/** Parse a Kimi session state.json file by reading its agents/main/wire.jsonl. */
+export function parseKimi(filePath: string): SessionEvent[] {
+  const sessionDir = path.dirname(filePath);
+  const wirePath = path.join(sessionDir, 'agents', 'main', 'wire.jsonl');
+  if (!fs.existsSync(wirePath)) {
+    return [];
+  }
+
+  const content = safeReadSessionFile(wirePath);
+  const lines = content.split('\n').filter(l => l.trim());
+  const events: SessionEvent[] = [];
+
+  // Map tool.call uuid -> tool name so tool.result can carry the tool name.
+  const toolCallMap = new Map<string, string>();
+
+  function extractMessageText(rawContent: any): string {
+    if (typeof rawContent === 'string') return rawContent.trim();
+    if (Array.isArray(rawContent)) {
+      return rawContent
+        .map((part: any) => (typeof part?.text === 'string' ? part.text : ''))
+        .join('')
+        .trim();
+    }
+    return '';
+  }
+
+  function timestampFrom(raw: any): string {
+    const t = raw?.time;
+    if (typeof t === 'number' && t > 0) {
+      return new Date(t).toISOString();
+    }
+    return new Date().toISOString();
+  }
+
+  for (const line of lines) {
+    let raw: any;
+    try {
+      raw = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    const type = raw?.type;
+    const timestamp = timestampFrom(raw);
+
+    if (type === 'context.append_message') {
+      const message = raw.message || {};
+      const role = message.role === 'user' ? 'user' : 'assistant';
+      const text = extractMessageText(message.content);
+      if (!text) continue;
+
+      events.push({
+        type: 'message',
+        agent: 'kimi',
+        timestamp,
+        role,
+        content: text,
+      });
+    } else if (type === 'context.append_loop_event') {
+      const event = raw.event || {};
+      const eventType = event.type;
+
+      if (eventType === 'content.part') {
+        const part = event.part || {};
+        const partType = part.type;
+
+        if (partType === 'text') {
+          const text = typeof part.text === 'string' ? part.text.trim() : '';
+          if (text) {
+            events.push({
+              type: 'message',
+              agent: 'kimi',
+              timestamp,
+              role: 'assistant',
+              content: text,
+            });
+          }
+        } else if (partType === 'think') {
+          const think = typeof part.think === 'string' ? part.think.trim() : '';
+          if (think) {
+            events.push({
+              type: 'thinking',
+              agent: 'kimi',
+              timestamp,
+              content: think,
+            });
+          }
+        }
+      } else if (eventType === 'tool.call') {
+        const fn = event.function || {};
+        const toolName = typeof event.name === 'string' ? event.name : (fn.name || 'unknown');
+        let args: Record<string, any> = {};
+        if (typeof fn.arguments === 'string') {
+          try {
+            args = JSON.parse(fn.arguments);
+          } catch {
+            args = { _raw: fn.arguments };
+          }
+        } else if (fn.arguments && typeof fn.arguments === 'object') {
+          args = fn.arguments;
+        }
+
+        const callId = event.toolCallId || event.uuid;
+        if (callId) {
+          toolCallMap.set(callId, toolName);
+        }
+
+        events.push({
+          type: 'tool_use',
+          agent: 'kimi',
+          timestamp,
+          tool: toolName,
+          args,
+          path: args.path || args.file_path || undefined,
+          command: toolName === 'Bash' ? args.command : undefined,
+        });
+      } else if (eventType === 'tool.result') {
+        const callId = event.toolCallId || event.parentUuid;
+        const toolName = (callId && toolCallMap.get(callId)) || 'unknown';
+        const result = event.result || {};
+        const output = typeof result.output === 'string' ? result.output : '';
+        const isError = result.isError === true || (output && output.startsWith('Error:'));
+
+        events.push({
+          type: isError ? 'error' : 'tool_result',
+          agent: 'kimi',
+          timestamp,
+          tool: toolName,
+          success: !isError,
+          output: output.length > 500 ? output.slice(0, 497) + '...' : output,
+        });
+
+        if (callId) {
+          toolCallMap.delete(callId);
+        }
+      }
+    } else if (type === 'usage.record') {
+      const usage = raw.usage || {};
+      const inputTokens = usage.inputOther ?? usage.input_tokens;
+      const outputTokens = usage.output ?? usage.output_tokens;
+      if (
+        (typeof inputTokens === 'number' && inputTokens >= 0) ||
+        (typeof outputTokens === 'number' && outputTokens >= 0)
+      ) {
+        events.push({
+          type: 'usage',
+          agent: 'kimi',
+          timestamp,
+          model: raw.model || usage.model,
+          inputTokens: typeof inputTokens === 'number' ? inputTokens : undefined,
+          outputTokens: typeof outputTokens === 'number' ? outputTokens : undefined,
+        });
+      }
+    }
+  }
+
+  return events;
 }

--- a/src/lib/teams/__tests__/parsers-kimi.test.ts
+++ b/src/lib/teams/__tests__/parsers-kimi.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Kimi (`kimi --output-format stream-json`) parser tests.
+ *
+ * Kimi's stream-json mode emits a simple role-based JSONL schema:
+ *   - assistant messages and tool_calls
+ *   - tool results
+ *   - meta events (e.g. session.resume_hint)
+ * These tests pin the normalization contract so the team runner can produce
+ * structured summaries for Kimi teammates.
+ */
+import { describe, expect, it } from 'vitest';
+import { normalizeEvents } from '../parsers.js';
+
+describe('normalizeEvents(kimi)', () => {
+  it('maps assistant content to a complete message', () => {
+    const events = normalizeEvents('kimi', { role: 'assistant', content: 'Hi.' });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'message',
+      agent: 'kimi',
+      content: 'Hi.',
+      complete: true,
+    });
+  });
+
+  it('drops empty assistant content', () => {
+    expect(normalizeEvents('kimi', { role: 'assistant', content: '' })).toEqual([]);
+  });
+
+  it('maps Bash tool_calls to bash events with file-op sidecars', () => {
+    const events = normalizeEvents('kimi', {
+      role: 'assistant',
+      tool_calls: [{
+        type: 'function',
+        id: 'tool_1',
+        function: {
+          name: 'Bash',
+          arguments: JSON.stringify({ command: 'cat file.txt && rm old.txt' }),
+        },
+      }],
+    });
+
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'bash',
+        agent: 'kimi',
+        tool: 'Bash',
+        command: 'cat file.txt && rm old.txt',
+      }),
+      expect.objectContaining({
+        type: 'file_read',
+        agent: 'kimi',
+        tool: 'bash',
+        path: 'file.txt',
+      }),
+      expect.objectContaining({
+        type: 'file_delete',
+        agent: 'kimi',
+        tool: 'bash',
+        path: 'old.txt',
+      }),
+    ]));
+  });
+
+  it('maps Read tool_calls to file_read events', () => {
+    const events = normalizeEvents('kimi', {
+      role: 'assistant',
+      tool_calls: [{
+        type: 'function',
+        id: 'tool_2',
+        function: {
+          name: 'Read',
+          arguments: JSON.stringify({ path: '/tmp/readme.md' }),
+        },
+      }],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'file_read',
+      agent: 'kimi',
+      tool: 'Read',
+      path: '/tmp/readme.md',
+    });
+  });
+
+  it('maps Edit tool_calls to file_write events', () => {
+    const events = normalizeEvents('kimi', {
+      role: 'assistant',
+      tool_calls: [{
+        type: 'function',
+        id: 'tool_3',
+        function: {
+          name: 'Edit',
+          arguments: JSON.stringify({ path: '/tmp/file.txt', old_string: 'a', new_string: 'b' }),
+        },
+      }],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'file_write',
+      agent: 'kimi',
+      tool: 'Edit',
+      path: '/tmp/file.txt',
+    });
+  });
+
+  it('maps Write tool_calls to file_create events', () => {
+    const events = normalizeEvents('kimi', {
+      role: 'assistant',
+      tool_calls: [{
+        type: 'function',
+        id: 'tool_4',
+        function: {
+          name: 'Write',
+          arguments: JSON.stringify({ path: '/tmp/new.txt', content: 'hello' }),
+        },
+      }],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'file_create',
+      agent: 'kimi',
+      tool: 'Write',
+      path: '/tmp/new.txt',
+    });
+  });
+
+  it('maps unknown tools to tool_use events', () => {
+    const events = normalizeEvents('kimi', {
+      role: 'assistant',
+      tool_calls: [{
+        type: 'function',
+        id: 'tool_5',
+        function: {
+          name: 'FetchURL',
+          arguments: JSON.stringify({ url: 'https://example.com' }),
+        },
+      }],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'tool_use',
+      agent: 'kimi',
+      tool: 'FetchURL',
+      args: { url: 'https://example.com' },
+    });
+  });
+
+  it('handles multiple tool_calls in one assistant event', () => {
+    const events = normalizeEvents('kimi', {
+      role: 'assistant',
+      tool_calls: [
+        {
+          type: 'function',
+          id: 'tool_6',
+          function: {
+            name: 'Read',
+            arguments: JSON.stringify({ path: '/a' }),
+          },
+        },
+        {
+          type: 'function',
+          id: 'tool_7',
+          function: {
+            name: 'Read',
+            arguments: JSON.stringify({ path: '/b' }),
+          },
+        },
+      ],
+    });
+
+    expect(events).toHaveLength(2);
+    expect(events[0].path).toBe('/a');
+    expect(events[1].path).toBe('/b');
+  });
+
+  it('maps tool results to tool_result events', () => {
+    const events = normalizeEvents('kimi', {
+      role: 'tool',
+      tool_call_id: 'tool_1',
+      content: 'output here',
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'tool_result',
+      agent: 'kimi',
+      tool_call_id: 'tool_1',
+      success: true,
+      content: 'output here',
+    });
+  });
+
+  it('marks tool results with Error: prefix as failures', () => {
+    const events = normalizeEvents('kimi', {
+      role: 'tool',
+      tool_call_id: 'tool_1',
+      content: 'Error: command failed',
+    });
+
+    expect(events[0].success).toBe(false);
+  });
+
+  it('marks tool results with isError as failures', () => {
+    const events = normalizeEvents('kimi', {
+      role: 'tool',
+      tool_call_id: 'tool_1',
+      content: 'something',
+      isError: true,
+    });
+
+    expect(events[0].success).toBe(false);
+  });
+
+  it('maps session.resume_hint meta events to init with session_id', () => {
+    const events = normalizeEvents('kimi', {
+      role: 'meta',
+      type: 'session.resume_hint',
+      session_id: 'sess-123',
+      command: 'kimi -r sess-123',
+      content: 'To resume...',
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'init',
+      agent: 'kimi',
+      session_id: 'sess-123',
+    });
+  });
+
+  it('passes through unknown meta types as meta events', () => {
+    const events = normalizeEvents('kimi', {
+      role: 'meta',
+      type: 'custom',
+      payload: 'x',
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'meta',
+      agent: 'kimi',
+      meta_type: 'custom',
+    });
+  });
+
+  it('falls back to unknown for malformed input', () => {
+    const events = normalizeEvents('kimi', null);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'unknown',
+      agent: 'kimi',
+    });
+  });
+
+  it('falls back to unknown for unrecognized roles', () => {
+    const events = normalizeEvents('kimi', { role: 'system', type: 'ping' });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'ping',
+      agent: 'kimi',
+    });
+  });
+
+  it('survives unparseable tool arguments', () => {
+    const events = normalizeEvents('kimi', {
+      role: 'assistant',
+      tool_calls: [{
+        type: 'function',
+        id: 'tool_bad',
+        function: {
+          name: 'Bash',
+          arguments: 'not-json',
+        },
+      }],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'tool_use',
+      agent: 'kimi',
+      tool: 'Bash',
+    });
+    expect(events[0].args).toMatchObject({ _raw: 'not-json' });
+  });
+});

--- a/src/lib/teams/parsers.ts
+++ b/src/lib/teams/parsers.ts
@@ -2,7 +2,7 @@
  * Agent event stream parsers.
  *
  * Normalizes the heterogeneous JSON event formats emitted by each agent CLI
- * (Claude, Codex, Gemini, Cursor, OpenCode, Grok, Antigravity) into a unified
+ * (Claude, Codex, Gemini, Cursor, OpenCode, Grok, Antigravity, Kimi) into a unified
  * event schema with consistent types: init, message, tool_use, bash,
  * file_read, file_write, file_create, file_delete, result, error, and others.
  */
@@ -29,6 +29,8 @@ export function normalizeEvents(agentType: AgentType, raw: any): any[] {
     return normalizeGrok(raw);
   } else if (agentType === 'antigravity') {
     return normalizeAntigravity(raw);
+  } else if (agentType === 'kimi') {
+    return normalizeKimi(raw);
   }
 
   // droid (Factory AI) intentionally falls through to the generic normalizer
@@ -933,6 +935,168 @@ function normalizeGrok(raw: any): any[] {
   return [{
     type: eventType,
     agent: 'grok',
+    raw: raw,
+    timestamp: timestamp,
+  }];
+}
+
+// --- Kimi parsing ---
+// Kimi's `--output-format stream-json` emits one JSON object per line with a
+// simple `role`-based schema:
+//   - {"role":"assistant","content":"..."}                          → final message
+//   - {"role":"assistant","tool_calls":[{"function":{"name":"Bash","arguments":"<json>"}}]} → tool use
+//   - {"role":"tool","tool_call_id":"...","content":"..."}            → tool result
+//   - {"role":"meta","type":"session.resume_hint","session_id":"..."} → init / session id
+// Tool arguments are JSON-stringified inside `function.arguments` and must be
+// parsed before extracting paths/commands. Verified against live `kimi` runs.
+function normalizeKimi(raw: any): any[] {
+  const timestamp = new Date().toISOString();
+
+  if (!raw || typeof raw !== 'object') {
+    return [{
+      type: 'unknown',
+      agent: 'kimi',
+      raw: raw,
+      timestamp: timestamp,
+    }];
+  }
+
+  const role = typeof raw.role === 'string' ? raw.role : '';
+
+  // Assistant message (final answer or tool-call request).
+  if (role === 'assistant') {
+    const events: any[] = [];
+
+    if (typeof raw.content === 'string' && raw.content) {
+      events.push({
+        type: 'message',
+        agent: 'kimi',
+        content: raw.content,
+        complete: true,
+        timestamp: timestamp,
+      });
+    }
+
+    const toolCalls = Array.isArray(raw.tool_calls) ? raw.tool_calls : [];
+    for (const toolCall of toolCalls) {
+      const fn = toolCall?.function || {};
+      const toolName = typeof fn.name === 'string' ? fn.name : 'unknown';
+      let toolArgs: any = {};
+      if (typeof fn.arguments === 'string') {
+        try {
+          toolArgs = JSON.parse(fn.arguments);
+        } catch {
+          toolArgs = { _raw: fn.arguments };
+        }
+      } else if (fn.arguments && typeof fn.arguments === 'object') {
+        toolArgs = fn.arguments;
+      }
+
+      const filePath = toolArgs?.path || toolArgs?.file_path || '';
+      const command = toolArgs?.command || '';
+
+      // Map known tools to structured events. If a known tool is missing the
+      // fields we need (e.g. unparseable arguments), fall back to tool_use so
+      // the event is still visible in summaries rather than dropped.
+      let normalized: any[] | null = null;
+      if (toolName === 'Bash' && command) {
+        const bashEvents: any[] = [{
+          type: 'bash',
+          agent: 'kimi',
+          tool: toolName,
+          command: command,
+          timestamp: timestamp,
+        }];
+        const [filesRead, filesWritten, filesDeleted] = extractFileOpsFromBash(command);
+        for (const p of filesRead) {
+          bashEvents.push({ type: 'file_read', agent: 'kimi', tool: 'bash', path: p, command, timestamp });
+        }
+        for (const p of filesWritten) {
+          bashEvents.push({ type: 'file_write', agent: 'kimi', tool: 'bash', path: p, command, timestamp });
+        }
+        for (const p of filesDeleted) {
+          bashEvents.push({ type: 'file_delete', agent: 'kimi', tool: 'bash', path: p, command, timestamp });
+        }
+        normalized = bashEvents;
+      } else if (toolName === 'Read' && filePath) {
+        normalized = [{
+          type: 'file_read',
+          agent: 'kimi',
+          tool: toolName,
+          path: filePath,
+          timestamp: timestamp,
+        }];
+      } else if (toolName === 'Edit' && filePath) {
+        normalized = [{
+          type: 'file_write',
+          agent: 'kimi',
+          tool: toolName,
+          path: filePath,
+          timestamp: timestamp,
+        }];
+      } else if (toolName === 'Write' && filePath) {
+        normalized = [{
+          type: 'file_create',
+          agent: 'kimi',
+          tool: toolName,
+          path: filePath,
+          timestamp: timestamp,
+        }];
+      }
+
+      if (normalized) {
+        events.push(...normalized);
+      } else {
+        events.push({
+          type: 'tool_use',
+          agent: 'kimi',
+          tool: toolName,
+          args: toolArgs,
+          timestamp: timestamp,
+        });
+      }
+    }
+
+    return events.length > 0 ? events : [];
+  }
+
+  // Tool result (response to an assistant tool_call).
+  if (role === 'tool') {
+    const content = typeof raw.content === 'string' ? raw.content : '';
+    const success = raw.isError !== true && !(content && content.startsWith('Error:'));
+    return [{
+      type: 'tool_result',
+      agent: 'kimi',
+      tool_call_id: typeof raw.tool_call_id === 'string' ? raw.tool_call_id : null,
+      success: success,
+      content: content,
+      timestamp: timestamp,
+    }];
+  }
+
+  // Meta events (session lifecycle).
+  if (role === 'meta') {
+    const metaType = typeof raw.type === 'string' ? raw.type : '';
+    if (metaType === 'session.resume_hint') {
+      return [{
+        type: 'init',
+        agent: 'kimi',
+        session_id: typeof raw.session_id === 'string' ? raw.session_id : null,
+        timestamp: timestamp,
+      }];
+    }
+    return [{
+      type: 'meta',
+      agent: 'kimi',
+      meta_type: metaType,
+      raw: raw,
+      timestamp: timestamp,
+    }];
+  }
+
+  return [{
+    type: raw.type || 'unknown',
+    agent: 'kimi',
     raw: raw,
     timestamp: timestamp,
   }];


### PR DESCRIPTION
Implements `normalizeKimi` for the Kimi Code CLI's `--output-format stream-json` output so teammates added via `agents teams add ... kimi ...` produce structured `message`, `bash`, `file_read`, `file_write`, `file_create`, `tool_use`, `tool_result`, and `init` events instead of raw unknown events.

Also adds `parseKimi()` for `agents sessions <id>`: it reads Kimi's internal `agents/main/wire.jsonl` and normalizes `context.append_message`, `content.part`, `tool.call`, `tool.result`, and `usage.record` events into the shared `SessionEvent` shape. Wired into `parseSession` and `detectAgent`.

Verified against live `kimi` runs. Includes 16 unit tests covering assistant messages, Bash/Read/Edit/Write tool calls, tool results, meta session hints, and malformed input fallbacks, plus 12 session parser tests for user/assistant messages, thinking, Bash/Read tool calls, tool results, usage, missing-wire fallback, and path-based agent detection.
