### PR TITLE
fix(plugins): validate Claude plugin manifests at sync, warn loudly

### DIFF
--- a/src/lib/plugin-marketplace.test.ts
+++ b/src/lib/plugin-marketplace.test.ts
@@ -27,6 +27,7 @@ import {
   unregisterMarketplace,
   addPluginToSettings,
   removePluginFromSettings,
+  validateClaudePluginManifest,
 } from './plugin-marketplace.js';
 import type { DiscoveredPlugin, MarketplaceSpec } from './types.js';
 
@@ -240,6 +241,31 @@ describe('syncMarketplaceManifest', () => {
     const manifest = syncMarketplaceManifest(SPECS.user, 'claude', versionHome);
     expect(manifest!.plugins.map(p => p.name)).toEqual(['beta', 'zeta']);
   });
+
+  it('WIRING: warns to stderr when a synced plugin ships a Claude-invalid manifest', () => {
+    // The real bug: a plugin.json with bare-name skills syncs "successfully" but
+    // Claude rejects the whole plugin. The sync path must surface it loudly.
+    installInto(SPECS.user, discoveredPlugin(writePluginSource(srcDir, 'badplug', { skills: ['loop'] }), 'badplug'), versionHome);
+    // A valid neighbour must NOT warn.
+    installInto(SPECS.user, discoveredPlugin(writePluginSource(srcDir, 'goodplug'), 'goodplug'), versionHome);
+
+    const origWrite = process.stderr.write.bind(process.stderr);
+    const captured: string[] = [];
+    process.stderr.write = ((chunk: unknown) => { captured.push(String(chunk)); return true; }) as typeof process.stderr.write;
+    try {
+      const manifest = syncMarketplaceManifest(SPECS.user, 'claude', versionHome);
+      // Sync still completes and catalogues both plugins — the warning is advisory, not fatal.
+      expect(manifest!.plugins.map(p => p.name)).toEqual(['badplug', 'goodplug']);
+    } finally {
+      process.stderr.write = origWrite;
+    }
+
+    const out = captured.join('');
+    expect(out).toContain("plugin 'badplug'");
+    expect(out).toContain('"skills"');
+    expect(out).toContain('"./');
+    expect(out).not.toContain('goodplug');
+  });
 });
 
 // ─── registerMarketplace / unregisterMarketplace ─────────────────────────────
@@ -421,5 +447,54 @@ describe('add/removePluginFromSettings', () => {
     removePluginFromSettings('alpha', 'agents-cli', 'claude', versionHome);
     const s = JSON.parse(fs.readFileSync(settingsFile(), 'utf-8'));
     expect(s.enabledPlugins).toBeUndefined();
+  });
+});
+
+describe('validateClaudePluginManifest', () => {
+  it('passes a manifest with no resource fields (the common case — skills auto-discover)', () => {
+    expect(validateClaudePluginManifest({ name: 'code', version: '1.0.0', description: 'x' })).toEqual([]);
+  });
+
+  it('flags skills declared as bare names — the real bug that breaks Claude plugin loading', () => {
+    const warnings = validateClaudePluginManifest({
+      name: 'code',
+      skills: ['dispatch', 'loop', 'review'],
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('"skills"');
+    expect(warnings[0]).toContain('"dispatch"');
+    expect(warnings[0]).toContain('"./');
+  });
+
+  it('passes skills given as proper relative "./" paths', () => {
+    expect(
+      validateClaudePluginManifest({ name: 'code', skills: ['./skills/loop', './skills/review'] })
+    ).toEqual([]);
+  });
+
+  it('passes a single-string resource field that starts with "./"', () => {
+    expect(validateClaudePluginManifest({ name: 'c', commands: './commands/commit' })).toEqual([]);
+  });
+
+  it('flags commands and agents with the same "./" rule', () => {
+    expect(validateClaudePluginManifest({ name: 'c', commands: ['commit'] })[0]).toContain('"commands"');
+    expect(validateClaudePluginManifest({ name: 'c', agents: ['reviewer'] })[0]).toContain('"agents"');
+  });
+
+  it('flags non-string entries', () => {
+    const warnings = validateClaudePluginManifest({ name: 'c', skills: [{ path: './skills/loop' }] });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('non-string');
+  });
+
+  it('does NOT touch hooks/mcpServers (they legitimately accept inline objects)', () => {
+    expect(
+      validateClaudePluginManifest({ name: 'c', hooks: { PreToolUse: [] }, mcpServers: { x: {} } })
+    ).toEqual([]);
+  });
+
+  it('is null/garbage safe', () => {
+    expect(validateClaudePluginManifest(null)).toEqual([]);
+    expect(validateClaudePluginManifest('nope')).toEqual([]);
   });
 });

--- a/src/lib/plugin-marketplace.ts
+++ b/src/lib/plugin-marketplace.ts
@@ -242,6 +242,54 @@ export function copyPluginToMarketplace(
   return dest;
 }
 
+// ─── Manifest validation ─────────────────────────────────────────────────────
+
+/**
+ * Claude Code's plugin-manifest schema requires the resource path fields to be
+ * relative paths starting with "./" — `skills`/`commands`/`agents` are
+ * `union([startsWith("./"), array(startsWith("./"))])` (verified against the
+ * Claude Code binary). Bare names like "loop" fail validation and Claude rejects
+ * the ENTIRE plugin at load time, surfacing only in its `/plugin` > Errors tab.
+ *
+ * agents-cli copies plugin.json verbatim into the marketplace, so a malformed
+ * manifest ships looking fully installed while loading nothing. This catches the
+ * unambiguous type violation (non-"./" string entries) and returns one warning
+ * per offending field so the caller can surface it loudly. `hooks`/`mcpServers`
+ * are intentionally skipped — they legitimately accept inline objects, so a path
+ * check would false-positive.
+ */
+export function validateClaudePluginManifest(manifest: unknown): string[] {
+  const warnings: string[] = [];
+  if (!manifest || typeof manifest !== 'object') return warnings;
+  const m = manifest as Record<string, unknown>;
+
+  for (const field of ['skills', 'commands', 'agents'] as const) {
+    const value = m[field];
+    if (value === undefined || value === null) continue;
+
+    const entries = Array.isArray(value) ? value : [value];
+    for (const entry of entries) {
+      if (typeof entry !== 'string') {
+        warnings.push(
+          `plugin.json field "${field}" must contain relative paths starting with "./" ` +
+          `(e.g. "./${field}/<name>"); found a non-string value. Claude Code will reject the whole plugin.`
+        );
+        break;
+      }
+      if (!entry.startsWith('./')) {
+        warnings.push(
+          `plugin.json field "${field}" entry "${entry}" must be a relative path starting with "./" ` +
+          `(e.g. "./${field}/${entry}"). Claude Code rejects the entire plugin otherwise — ` +
+          `remove the field to auto-discover from ${field}/, or use relative paths.`
+        );
+        break;
+      }
+    }
+  }
+
+  return warnings;
+}
+
 // ─── Catalog synthesis ──────────────────────────────────────────────────────
 
 /**
@@ -276,6 +324,10 @@ export function syncMarketplaceManifest(spec: MarketplaceSpec, agent: AgentId, v
       manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf-8'));
     } catch {
       continue;
+    }
+
+    for (const warning of validateClaudePluginManifest(manifest)) {
+      process.stderr.write(`agents-cli: plugin '${manifest.name ?? entry.name}': ${warning}\n`);
     }
 
     entries.push({


### PR DESCRIPTION
## Problem

`agents plugins install`/`sync` copy a plugin's `.claude-plugin/plugin.json` **verbatim** into the per-version marketplace and never validate it against Claude Code's manifest schema. A manifest whose `skills`/`commands`/`agents` fields use **bare names** instead of `"./"`-relative paths is rejected wholesale by Claude at load time — but agents-cli prints `Synced ✓` and `plugins list` shows it `everywhere`, so the plugin silently loads **nothing**. The only diagnostic is Claude's hidden `/plugin` → **Errors** tab.

This was a real, hard-to-diagnose failure: the `code` plugin shipped `"skills": ["dispatch","loop",...]`, installed "successfully," and `/code:loop` never appeared.

## Root cause

Claude Code's schema (verified against the `claude.exe` binary) requires these fields to be relative paths starting with `"./"`:

```js
x9 = Re(() => v.string().startsWith("./"))   // path to a skill/command/agent dir, relative to plugin root
skills: v.union([ x9, v.array(x9) ])
```

Bare names fail `.startsWith("./")` → `skills: Invalid input` → whole plugin discarded.

## Fix

- Add `validateClaudePluginManifest()` and call it from `syncMarketplaceManifest` — the chokepoint hit by install, sync, and `repo refresh`.
- For `skills`/`commands`/`agents` given as a string or string[], every entry must start with `"./"`; otherwise emit a **stderr warning** naming the plugin + field (matching the existing outside-root-symlink warning style).
- `hooks`/`mcpServers` are intentionally untouched — they legitimately accept inline objects, so a path check would false-positive.
- **Advisory, not fatal** — sync still completes and catalogues the plugin.

## Verification

- `bun run build` clean; **full suite 2526 passed / 46 skipped / 0 failures**.
- New unit tests for `validateClaudePluginManifest` (bare names, proper `./` paths, single-string, commands/agents, non-string, hooks/mcpServers untouched, null-safe).
- New **wiring** test: `syncMarketplaceManifest` on a real tmp filesystem warns for a bad plugin and stays silent for a good neighbour.
- **Real CLI E2E**: `node dist/index.js plugins install <bad-plugin>` now prints:
  ```
  agents-cli: plugin 'badpluge2e': plugin.json field "skills" entry "loop" must be a relative path starting with "./" (e.g. "./skills/loop"). Claude Code rejects the entire plugin otherwise — remove the field to auto-discover from skills/, or use relative paths.
  ```

## Note for review

The warning prints once per synced version (e.g. twice for Claude + Codex). Left as-is — loud is the point — but happy to dedupe to one line if preferred.

Closes #379
