### PR TITLE
fix(daemon): inject long-lived Claude OAuth token into scheduler env

### DIFF
--- a/src/lib/daemon.test.ts
+++ b/src/lib/daemon.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Daemon service-manifest generation.
+ *
+ * The load-bearing behavior under test: a long-lived Claude OAuth token stored
+ * in the `claude` secrets bundle is baked into the launchd plist / systemd unit
+ * environment, so headless routine runs stop depending on the short-lived
+ * interactive Keychain OAuth session. The Keychain itself is swapped for an
+ * in-memory backend via setKeychainBackendForTest — the contract here is the
+ * generator, not the Keychain wiring (that rides the e2e smoke run).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  generateLaunchdPlist,
+  generateSystemdUnit,
+  readDaemonClaudeOAuthToken,
+} from './daemon.js';
+import {
+  secretsKeychainItem,
+  setKeychainBackendForTest,
+  type KeychainBackend,
+} from './secrets/index.js';
+
+const OAUTH_ITEM = secretsKeychainItem('claude', 'CLAUDE_CODE_OAUTH_TOKEN');
+
+function makeMemoryBackend(): { backend: KeychainBackend; store: Map<string, string> } {
+  const store = new Map<string, string>();
+  const backend: KeychainBackend = {
+    has: (item) => store.has(item),
+    get: (item) => {
+      const v = store.get(item);
+      if (v === undefined) throw new Error(`Keychain item '${item}' not found.`);
+      return v;
+    },
+    set: (item, value) => { store.set(item, value); },
+    delete: (item) => store.delete(item),
+    list: (prefix) => Array.from(store.keys()).filter((k) => k.startsWith(prefix)),
+  };
+  return { backend, store };
+}
+
+let restore: KeychainBackend | null = null;
+let store: Map<string, string>;
+
+beforeEach(() => {
+  const m = makeMemoryBackend();
+  store = m.store;
+  restore = setKeychainBackendForTest(m.backend);
+});
+
+afterEach(() => {
+  setKeychainBackendForTest(restore);
+});
+
+describe('readDaemonClaudeOAuthToken', () => {
+  it('returns null when no token is configured', () => {
+    expect(readDaemonClaudeOAuthToken()).toBeNull();
+  });
+
+  it('returns the stored token', () => {
+    store.set(OAUTH_ITEM, 'sk-ant-oat01-abc123');
+    expect(readDaemonClaudeOAuthToken()).toBe('sk-ant-oat01-abc123');
+  });
+
+  it('trims surrounding whitespace from the stored token', () => {
+    store.set(OAUTH_ITEM, '  sk-ant-oat01-abc123\n');
+    expect(readDaemonClaudeOAuthToken()).toBe('sk-ant-oat01-abc123');
+  });
+
+  it('treats an empty/whitespace-only token as absent', () => {
+    store.set(OAUTH_ITEM, '   ');
+    expect(readDaemonClaudeOAuthToken()).toBeNull();
+  });
+});
+
+describe('generateLaunchdPlist', () => {
+  it('omits CLAUDE_CODE_OAUTH_TOKEN when none is configured', () => {
+    const plist = generateLaunchdPlist();
+    expect(plist).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
+    // The PATH entry is always present so EnvironmentVariables is never empty.
+    expect(plist).toContain('<key>PATH</key>');
+  });
+
+  it('injects the token into EnvironmentVariables when configured', () => {
+    store.set(OAUTH_ITEM, 'sk-ant-oat01-abc123');
+    const plist = generateLaunchdPlist();
+    expect(plist).toContain('<key>CLAUDE_CODE_OAUTH_TOKEN</key>');
+    expect(plist).toContain('<string>sk-ant-oat01-abc123</string>');
+    // Must sit inside the EnvironmentVariables dict, after PATH.
+    const envIdx = plist.indexOf('<key>EnvironmentVariables</key>');
+    const tokenIdx = plist.indexOf('<key>CLAUDE_CODE_OAUTH_TOKEN</key>');
+    expect(envIdx).toBeGreaterThan(-1);
+    expect(tokenIdx).toBeGreaterThan(envIdx);
+  });
+
+  it('XML-escapes special characters in the token value', () => {
+    store.set(OAUTH_ITEM, 'tok&en<x>');
+    const plist = generateLaunchdPlist();
+    expect(plist).toContain('<string>tok&amp;en&lt;x&gt;</string>');
+    expect(plist).not.toContain('<string>tok&en<x></string>');
+  });
+});
+
+describe('generateSystemdUnit', () => {
+  it('omits the token Environment line when none is configured', () => {
+    expect(generateSystemdUnit()).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
+  });
+
+  it('adds an Environment line for the token when configured', () => {
+    store.set(OAUTH_ITEM, 'sk-ant-oat01-abc123');
+    expect(generateSystemdUnit()).toContain(
+      'Environment=CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-abc123',
+    );
+  });
+});

--- a/src/lib/daemon.test.ts
+++ b/src/lib/daemon.test.ts
@@ -17,11 +17,11 @@ import {
 } from './daemon.js';
 import {
   secretsKeychainItem,
+  setKeychainToken,
   setKeychainBackendForTest,
   type KeychainBackend,
 } from './secrets/index.js';
-
-const OAUTH_ITEM = secretsKeychainItem('claude', 'CLAUDE_CODE_OAUTH_TOKEN');
+import { writeBundle, deleteBundle } from './secrets/bundles.js';
 
 function makeMemoryBackend(): { backend: KeychainBackend; store: Map<string, string> } {
   const store = new Map<string, string>();
@@ -39,36 +39,51 @@ function makeMemoryBackend(): { backend: KeychainBackend; store: Map<string, str
   return { backend, store };
 }
 
+/** Seed the `claude` bundle with a keychain-backed CLAUDE_CODE_OAUTH_TOKEN. */
+function seedKeychainBacked(value: string): void {
+  writeBundle({ name: 'claude', vars: { CLAUDE_CODE_OAUTH_TOKEN: 'keychain:CLAUDE_CODE_OAUTH_TOKEN' } });
+  setKeychainToken(secretsKeychainItem('claude', 'CLAUDE_CODE_OAUTH_TOKEN'), value);
+}
+
+/** Seed the `claude` bundle with a literal CLAUDE_CODE_OAUTH_TOKEN. */
+function seedLiteral(value: string): void {
+  writeBundle({ name: 'claude', vars: { CLAUDE_CODE_OAUTH_TOKEN: value } });
+}
+
 let restore: KeychainBackend | null = null;
-let store: Map<string, string>;
 
 beforeEach(() => {
   const m = makeMemoryBackend();
-  store = m.store;
   restore = setKeychainBackendForTest(m.backend);
 });
 
 afterEach(() => {
+  try { deleteBundle('claude'); } catch { /* not created */ }
   setKeychainBackendForTest(restore);
 });
 
 describe('readDaemonClaudeOAuthToken', () => {
-  it('returns null when no token is configured', () => {
+  it('returns null when the bundle does not exist', () => {
     expect(readDaemonClaudeOAuthToken()).toBeNull();
   });
 
-  it('returns the stored token', () => {
-    store.set(OAUTH_ITEM, 'sk-ant-oat01-abc123');
+  it('returns a keychain-backed token', () => {
+    seedKeychainBacked('sk-ant-oat01-abc123');
     expect(readDaemonClaudeOAuthToken()).toBe('sk-ant-oat01-abc123');
   });
 
+  it('returns a token stored as a literal (the no-op footgun fix)', () => {
+    seedLiteral('sk-ant-oat01-literal');
+    expect(readDaemonClaudeOAuthToken()).toBe('sk-ant-oat01-literal');
+  });
+
   it('trims surrounding whitespace from the stored token', () => {
-    store.set(OAUTH_ITEM, '  sk-ant-oat01-abc123\n');
+    seedKeychainBacked('  sk-ant-oat01-abc123\n');
     expect(readDaemonClaudeOAuthToken()).toBe('sk-ant-oat01-abc123');
   });
 
   it('treats an empty/whitespace-only token as absent', () => {
-    store.set(OAUTH_ITEM, '   ');
+    seedKeychainBacked('   ');
     expect(readDaemonClaudeOAuthToken()).toBeNull();
   });
 });
@@ -82,7 +97,7 @@ describe('generateLaunchdPlist', () => {
   });
 
   it('injects the token into EnvironmentVariables when configured', () => {
-    store.set(OAUTH_ITEM, 'sk-ant-oat01-abc123');
+    seedKeychainBacked('sk-ant-oat01-abc123');
     const plist = generateLaunchdPlist();
     expect(plist).toContain('<key>CLAUDE_CODE_OAUTH_TOKEN</key>');
     expect(plist).toContain('<string>sk-ant-oat01-abc123</string>');
@@ -94,7 +109,7 @@ describe('generateLaunchdPlist', () => {
   });
 
   it('XML-escapes special characters in the token value', () => {
-    store.set(OAUTH_ITEM, 'tok&en<x>');
+    seedKeychainBacked('tok&en<x>');
     const plist = generateLaunchdPlist();
     expect(plist).toContain('<string>tok&amp;en&lt;x&gt;</string>');
     expect(plist).not.toContain('<string>tok&en<x></string>');
@@ -107,7 +122,7 @@ describe('generateSystemdUnit', () => {
   });
 
   it('adds an Environment line for the token when configured', () => {
-    store.set(OAUTH_ITEM, 'sk-ant-oat01-abc123');
+    seedKeychainBacked('sk-ant-oat01-abc123');
     expect(generateSystemdUnit()).toContain(
       'Environment=CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-abc123',
     );

--- a/src/lib/daemon.test.ts
+++ b/src/lib/daemon.test.ts
@@ -14,6 +14,7 @@ import {
   generateLaunchdPlist,
   generateSystemdUnit,
   readDaemonClaudeOAuthToken,
+  buildDetachedDaemonEnv,
 } from './daemon.js';
 import {
   secretsKeychainItem,
@@ -126,5 +127,25 @@ describe('generateSystemdUnit', () => {
     expect(generateSystemdUnit()).toContain(
       'Environment=CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-abc123',
     );
+  });
+});
+
+describe('buildDetachedDaemonEnv', () => {
+  it('injects the token when configured and absent from the base env', () => {
+    seedKeychainBacked('sk-ant-oat01-detached');
+    const env = buildDetachedDaemonEnv({ PATH: '/usr/bin' });
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('sk-ant-oat01-detached');
+    expect(env.PATH).toBe('/usr/bin');
+  });
+
+  it('leaves an already-set token untouched (launchd-provided wins)', () => {
+    seedKeychainBacked('sk-ant-oat01-fromKeychain');
+    const env = buildDetachedDaemonEnv({ CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-fromEnv' });
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('sk-ant-oat01-fromEnv');
+  });
+
+  it('adds no token key when none is configured', () => {
+    const env = buildDetachedDaemonEnv({ PATH: '/usr/bin' });
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
   });
 });

--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -19,6 +19,7 @@ import { executeJobDetached, monitorRunningJobs } from './runner.js';
 import { detectOverdueJobs, notifyOverdue } from './overdue.js';
 import { BrowserService } from './browser/service.js';
 import { BrowserIPCServer } from './browser/ipc.js';
+import { secretsKeychainItem, hasKeychainToken, getKeychainToken } from './secrets/index.js';
 
 const PID_FILE = 'daemon.pid';
 const LOCK_FILE = 'daemon.lock';
@@ -27,6 +28,13 @@ const LOG_MAX_SIZE = 5 * 1024 * 1024; // 5 MB
 const LOG_ROTATE_COUNT = 3;
 const PLIST_NAME = 'com.phnx-labs.agents-daemon';
 const SYSTEMD_UNIT = 'agents-daemon.service';
+
+// A long-lived `claude setup-token` value stored in this secrets bundle/key is
+// baked into the daemon's service-manager environment so headless routine runs
+// authenticate without depending on the short-lived interactive Keychain OAuth
+// session (which expires between runs and produces intermittent 401s).
+const DAEMON_OAUTH_BUNDLE = 'claude';
+const DAEMON_OAUTH_KEY = 'CLAUDE_CODE_OAUTH_TOKEN';
 
 function getDaemonDir(): string {
   const dir = getDaemonDirRoot();
@@ -250,10 +258,42 @@ export async function runDaemon(): Promise<void> {
   await new Promise(() => {});
 }
 
+/**
+ * Read the long-lived Claude OAuth token (from `claude setup-token`) that the
+ * user stored under the `claude` secrets bundle. Returns null when it isn't
+ * configured, the Keychain read is cancelled, or the platform has no keychain —
+ * the daemon then behaves exactly as before (relying on the interactive OAuth
+ * session). Never throws: a misconfigured token must not block daemon startup.
+ */
+export function readDaemonClaudeOAuthToken(): string | null {
+  const item = secretsKeychainItem(DAEMON_OAUTH_BUNDLE, DAEMON_OAUTH_KEY);
+  try {
+    if (!hasKeychainToken(item)) return null;
+    const token = getKeychainToken(item).trim();
+    return token.length > 0 ? token : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Escape a string for safe inclusion in an XML <string> node. */
+function xmlEscape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 /** Generate a macOS launchd plist for auto-starting the daemon. */
 export function generateLaunchdPlist(): string {
   const agentsBin = getAgentsBinPath();
   const logPath = getLogPath();
+  const oauthToken = readDaemonClaudeOAuthToken();
+  const oauthEntry = oauthToken
+    ? `
+    <key>${DAEMON_OAUTH_KEY}</key>
+    <string>${xmlEscape(oauthToken)}</string>`
+    : '';
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -278,7 +318,7 @@ export function generateLaunchdPlist(): string {
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
-    <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:${os.homedir()}/.bun/bin:${os.homedir()}/.nvm/versions/node/v24.0.0/bin</string>
+    <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:${os.homedir()}/.bun/bin:${os.homedir()}/.nvm/versions/node/v24.0.0/bin</string>${oauthEntry}
   </dict>
 </dict>
 </plist>`;
@@ -287,6 +327,10 @@ export function generateLaunchdPlist(): string {
 /** Generate a Linux systemd user unit for auto-starting the daemon. */
 export function generateSystemdUnit(): string {
   const agentsBin = getAgentsBinPath();
+  const oauthToken = readDaemonClaudeOAuthToken();
+  const oauthLine = oauthToken
+    ? `\nEnvironment=${DAEMON_OAUTH_KEY}=${oauthToken}`
+    : '';
 
   return `[Unit]
 Description=Agents Daemon - Scheduled Job Runner
@@ -297,7 +341,7 @@ Type=simple
 ExecStart=${agentsBin} daemon _run
 Restart=always
 RestartSec=10
-Environment=PATH=/usr/local/bin:/usr/bin:/bin:${os.homedir()}/.nvm/versions/node/v24.0.0/bin
+Environment=PATH=/usr/local/bin:/usr/bin:/bin:${os.homedir()}/.nvm/versions/node/v24.0.0/bin${oauthLine}
 
 [Install]
 WantedBy=default.target`;
@@ -350,6 +394,9 @@ function startDaemonLocked(): { pid: number | null; method: string } {
         fs.mkdirSync(plistDir, { recursive: true });
       }
       fs.writeFileSync(plistPath, generateLaunchdPlist(), 'utf-8');
+      // The plist may embed a long-lived OAuth token in EnvironmentVariables;
+      // keep it owner-only so it isn't world/group readable on disk.
+      fs.chmodSync(plistPath, 0o600);
 
       try {
         execFileSync('launchctl', ['unload', plistPath], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
@@ -376,6 +423,8 @@ function startDaemonLocked(): { pid: number | null; method: string } {
         fs.mkdirSync(unitDir, { recursive: true });
       }
       fs.writeFileSync(unitPath, generateSystemdUnit(), 'utf-8');
+      // May embed a long-lived OAuth token in an Environment= line; owner-only.
+      fs.chmodSync(unitPath, 0o600);
 
       execFileSync('systemctl', ['--user', 'daemon-reload'], { encoding: 'utf-8' });
       execFileSync('systemctl', ['--user', 'enable', SYSTEMD_UNIT], { encoding: 'utf-8' });

--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -19,7 +19,7 @@ import { executeJobDetached, monitorRunningJobs } from './runner.js';
 import { detectOverdueJobs, notifyOverdue } from './overdue.js';
 import { BrowserService } from './browser/service.js';
 import { BrowserIPCServer } from './browser/ipc.js';
-import { secretsKeychainItem, hasKeychainToken, getKeychainToken } from './secrets/index.js';
+import { readAndResolveBundleEnv } from './secrets/bundles.js';
 
 const PID_FILE = 'daemon.pid';
 const LOCK_FILE = 'daemon.lock';
@@ -260,16 +260,17 @@ export async function runDaemon(): Promise<void> {
 
 /**
  * Read the long-lived Claude OAuth token (from `claude setup-token`) that the
- * user stored under the `claude` secrets bundle. Returns null when it isn't
+ * user stored under the `claude` secrets bundle. Resolves the bundle the same
+ * way `agents run --secrets` does, so the token is found whether it was stored
+ * keychain-backed or as a literal. Returns null when the bundle/key isn't
  * configured, the Keychain read is cancelled, or the platform has no keychain —
  * the daemon then behaves exactly as before (relying on the interactive OAuth
  * session). Never throws: a misconfigured token must not block daemon startup.
  */
 export function readDaemonClaudeOAuthToken(): string | null {
-  const item = secretsKeychainItem(DAEMON_OAUTH_BUNDLE, DAEMON_OAUTH_KEY);
   try {
-    if (!hasKeychainToken(item)) return null;
-    const token = getKeychainToken(item).trim();
+    const { env } = readAndResolveBundleEnv(DAEMON_OAUTH_BUNDLE, { caller: 'daemon' });
+    const token = (env[DAEMON_OAUTH_KEY] ?? '').trim();
     return token.length > 0 ? token : null;
   } catch {
     return null;

--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -441,6 +441,23 @@ function startDaemonLocked(): { pid: number | null; method: string } {
   return startDetached();
 }
 
+/**
+ * Environment for the detached daemon fallback. The launchd/systemd paths
+ * deliver the long-lived OAuth token via the service manifest's environment;
+ * the detached path has no manifest, so inject it here. Read happens during an
+ * interactive `routines start`, so a Keychain Touch ID prompt can be satisfied;
+ * the daemon then passes it to every routine run it spawns. An already-set
+ * value (e.g. inherited from launchd) is left untouched.
+ */
+export function buildDetachedDaemonEnv(baseEnv: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env = { ...baseEnv };
+  if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
+    const token = readDaemonClaudeOAuthToken();
+    if (token) env.CLAUDE_CODE_OAUTH_TOKEN = token;
+  }
+  return env;
+}
+
 function startDetached(): { pid: number; method: string } {
   const agentsBin = getAgentsBinPath();
   const logPath = getLogPath();
@@ -449,6 +466,7 @@ function startDetached(): { pid: number; method: string } {
   const child = spawn(agentsBin, ['daemon', '_run'], {
     stdio: ['ignore', logFd, logFd],
     detached: true,
+    env: buildDetachedDaemonEnv(),
   });
 
   child.unref();


### PR DESCRIPTION
## Problem

Every enabled scheduled routine has been failing. Evidence from the latest `security-sweep` run (`~/.agents/.history/runs/security-sweep/2026-06-23T17-32-51-114Z/`):

- `meta.json` → `"status":"failed","exitCode":1`
- `stdout.log` → `error_status:401,"error":"authentication_failed"`
- `report.md` → `Not logged in · Please run /login`

It's **intermittent** — `branch-cleanup` succeeded at 7PM PT while the runs before/after it 401'd. The signature of a short-lived OAuth access token that only refreshes on interactive use.

## Root cause

Routine runs spawn with the daemon's inherited `{ ...process.env }` (`runner.ts:201`). The launchd plist / systemd unit set **only `PATH`** — no token. On macOS the shim's `.oauth_token` file fallback is **Linux-only** (`shims.ts:268`), so `claude` falls back to the **Keychain OAuth session** from interactive login. That access token is short-lived and headless runs can't self-refresh → 401. No long-lived token existed anywhere (`~/.claude/.oauth_token` absent, none in `agents secrets`).

## Fix

Bake a long-lived `claude setup-token` value into the daemon's environment so headless runs stop depending on the interactive session. Three parts:

1. **`readDaemonClaudeOAuthToken()`** resolves the `claude` bundle via `readAndResolveBundleEnv` (same path as `agents run --secrets`) and reads `CLAUDE_CODE_OAUTH_TOKEN`. Works whether stored keychain-backed or literal; never throws.
2. **Service manifests** — `generateLaunchdPlist()` injects it into `EnvironmentVariables` (XML-escaped); `generateSystemdUnit()` adds an `Environment=` line. Manifests are `chmod 0600` since they may embed a secret.
3. **Detached fallback** — when launchd `load` fails (observed live: `Unload failed: 5: I/O error`), the daemon falls through to a plain detached spawn that would otherwise drop the token. `buildDetachedDaemonEnv()` injects it there too (read once during interactive `routines start`; an already-set value from launchd wins).

## Verified end-to-end (live)

- Real `claude` bundle → `readDaemonClaudeOAuthToken()` resolves the token → injected into the generated plist's `EnvironmentVariables`, XML-escaped.
- After `routines stop && start`: running daemon carries `CLAUDE_CODE_OAUTH_TOKEN` (confirmed via `ps eww <pid>`).
- Headless `claude` with that token env var returns `AUTH_OK` — no 401.
- Live plist on disk: mode `-rw-------`, contains the token.

## Operator steps

```
claude setup-token                                   # long-lived sk-ant-oat01-… (browser OAuth)
printf '%s' '<paste-token>' | agents secrets add claude CLAUDE_CODE_OAUTH_TOKEN --value-stdin --type token
agents routines stop && agents routines start        # regenerates the plist + injects into the detached env
```

## Tests

- `src/lib/daemon.test.ts` (13 tests) against the **real** generators (Keychain swapped via `setKeychainBackendForTest`; bundles seeded through the real `writeBundle`/`setKeychainToken` API): token omission/injection, keychain-backed **and** literal resolution, XML-escaping, whitespace-trim, systemd line, and `buildDetachedDaemonEnv` (inject / don't-clobber / absent).
- `tsc --noEmit` clean. Full secrets + daemon suite: no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
