### PR TITLE
fix(view): derive usage badge from live windows, not the overage flag

### DIFF
--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -26,6 +26,7 @@ import {
 import type { AccountInfo } from '../lib/agents.js';
 import type { AgentId } from '../lib/types.js';
 import {
+  deriveUsageStatusFromSnapshot,
   formatUsageSection,
   formatUsageSummary,
   formatUsageStatusBadge,
@@ -389,7 +390,11 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
     return {
       ...info,
       plan: canon.plan,
-      usageStatus: canon.usageStatus,
+      // Throttle state comes from the live usage windows, not the pay-as-you-go
+      // overage flag that AccountInfo.usageStatus used to carry. A maxed window
+      // means rate-limited; no snapshot means no badge. See
+      // deriveUsageStatusFromSnapshot.
+      usageStatus: deriveUsageStatusFromSnapshot(usageByKey.get(key)?.snapshot),
       overageCredits: canon.overageCredits,
     };
   };
@@ -1150,7 +1155,11 @@ async function collectAgentsJson(filterAgentId?: AgentId): Promise<ViewJsonAgent
     return {
       ...info,
       plan: canon.plan,
-      usageStatus: canon.usageStatus,
+      // Throttle state comes from the live usage windows, not the pay-as-you-go
+      // overage flag that AccountInfo.usageStatus used to carry. A maxed window
+      // means rate-limited; no snapshot means no badge. See
+      // deriveUsageStatusFromSnapshot.
+      usageStatus: deriveUsageStatusFromSnapshot(usageByKey.get(key)?.snapshot),
       overageCredits: canon.overageCredits,
     };
   };

--- a/src/lib/__tests__/usage.test.ts
+++ b/src/lib/__tests__/usage.test.ts
@@ -7,6 +7,7 @@ import type { AccountInfo } from '../agents.js';
 import * as state from '../state.js';
 import {
   buildCanonicalUsageContext,
+  deriveUsageStatusFromSnapshot,
   formatUsageSummary,
   formatUsageStatusBadge,
   getClaudeKeychainService,
@@ -15,6 +16,7 @@ import {
   isClaudeUsageOrgMatch,
   writeClaudeUsageCache,
   type UsageSnapshot,
+  type UsageWindow,
 } from '../usage.js';
 
 function makeAccountInfo(overrides: Partial<AccountInfo> = {}): AccountInfo {
@@ -83,6 +85,49 @@ describe('usage formatting', () => {
     expect(formatUsageStatusBadge('available')).toBe('');
     expect(stripAnsi(formatUsageStatusBadge('rate_limited'))).toBe('rate-limited');
     expect(stripAnsi(formatUsageStatusBadge('out_of_credits'))).toBe('out of credits');
+  });
+});
+
+describe('deriveUsageStatusFromSnapshot', () => {
+  function win(key: UsageWindow['key'], usedPercent: number): UsageWindow {
+    return {
+      key,
+      label: key,
+      shortLabel: key === 'week' ? 'W' : key === 'session' ? 'S' : 'So',
+      usedPercent,
+      resetsAt: null,
+      windowMinutes: null,
+    };
+  }
+  function snap(windows: UsageWindow[]): UsageSnapshot {
+    return { source: 'live', sourceLabel: 'live account data', capturedAt: new Date('2026-04-17T12:00:00Z'), windows };
+  }
+
+  it('returns null when there is no snapshot or no windows', () => {
+    expect(deriveUsageStatusFromSnapshot(null)).toBeNull();
+    expect(deriveUsageStatusFromSnapshot(undefined)).toBeNull();
+    expect(deriveUsageStatusFromSnapshot(snap([]))).toBeNull();
+  });
+
+  it('is available when every blocking window is below 100%', () => {
+    expect(deriveUsageStatusFromSnapshot(snap([win('session', 5), win('week', 5)]))).toBe('available');
+  });
+
+  it('is rate_limited when any blocking window is maxed', () => {
+    expect(deriveUsageStatusFromSnapshot(snap([win('session', 100), win('week', 40)]))).toBe('rate_limited');
+    expect(deriveUsageStatusFromSnapshot(snap([win('session', 10), win('week', 100)]))).toBe('rate_limited');
+  });
+
+  it('ignores a maxed sonnet_week sub-limit when other windows are fine', () => {
+    expect(
+      deriveUsageStatusFromSnapshot(snap([win('session', 10), win('week', 20), win('sonnet_week', 100)]))
+    ).toBe('available');
+  });
+
+  it('does not regress to "out of credits" for a usable account with overage disabled', () => {
+    // The real-world bug: a Pro account at 5% weekly usage whose pay-as-you-go
+    // overage is disabled must read as available, never out_of_credits.
+    expect(deriveUsageStatusFromSnapshot(snap([win('session', 2), win('week', 5)]))).toBe('available');
   });
 });
 

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -887,11 +887,16 @@ export async function getAccountInfo(
           plan = oa.billingType;
         }
 
-        let usageStatus: AccountInfo['usageStatus'] = null;
-        const reason = data.cachedExtraUsageDisabledReason;
-        if (reason === 'out_of_credits') usageStatus = 'out_of_credits';
-        else if (reason) usageStatus = 'rate_limited';
-        else usageStatus = 'available';
+        // usageStatus is NOT derived from cachedExtraUsageDisabledReason. That
+        // field reports why pay-as-you-go overage is off (out_of_credits = no
+        // overage credits purchased; org_level_disabled = admin turned overage
+        // off), which says nothing about whether the account is throttled — a
+        // Pro account at 5% weekly usage with overage disabled is fully usable.
+        // Real throttle state comes from the live usage windows; callers derive
+        // it via deriveUsageStatusFromSnapshot(). Here we only report whether
+        // the account is signed in at all. Overage state stays visible through
+        // overageCredits below.
+        const usageStatus: AccountInfo['usageStatus'] = email ? 'available' : null;
 
         let overageCredits: AccountInfo['overageCredits'] = null;
         const orgId = oa?.organizationUuid;

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -373,6 +373,33 @@ export function formatUsageSummary(
 }
 
 /**
+ * Derive an account's real throttle state from its live usage windows — the
+ * same signal `agents usage` shows and balanced rotation trusts
+ * (`getRoutingUsedPercent` in rotate.ts). A window at 100% utilization means
+ * the account is throttled until that window resets.
+ *
+ * Returns `null` when there is no snapshot, so callers render no badge rather
+ * than a misleading one. This deliberately never consults
+ * `cachedExtraUsageDisabledReason`: that field describes why pay-as-you-go
+ * overage is disabled (`out_of_credits` = no overage credits purchased,
+ * `org_level_disabled` = an admin turned overage off), NOT whether the account
+ * can do work right now. A Pro account at 5% weekly usage with overage disabled
+ * is fully usable, yet that flag would mislabel it "out of credits".
+ *
+ * The model-specific `sonnet_week` sub-limit is excluded: hitting it throttles
+ * one model, not the account, so it shouldn't flip the whole row to throttled.
+ */
+export function deriveUsageStatusFromSnapshot(
+  snapshot: UsageSnapshot | null | undefined
+): 'available' | 'rate_limited' | null {
+  if (!snapshot || snapshot.windows.length === 0) return null;
+  const blocking = snapshot.windows.filter((window) => window.key !== 'sonnet_week');
+  const windows = blocking.length > 0 ? blocking : snapshot.windows;
+  const maxUsed = Math.max(...windows.map((window) => window.usedPercent));
+  return maxUsed >= 100 ? 'rate_limited' : 'available';
+}
+
+/**
  * Compact colored badge for the account's overall usage status. Renders only
  * when the account is throttled — `available` and `null` return ''.
  *


### PR DESCRIPTION
## Problem

`agents view` showed incorrect status badges:

| version | account | badge shown | reality (`agents usage`) |
|---|---|---|---|
| 2.1.181 | icloud | **out of credits** | 2% session / 5% week — wide open |
| 2.1.187 | getrush | **rate-limited** | admin disabled overage, not throttled |

## Root cause

The badge was derived from `cachedExtraUsageDisabledReason` in `getAccountInfo` (`src/lib/agents.ts`). That field reports why **pay-as-you-go overage** is disabled — not whether the account is throttled:

- `out_of_credits` (no overage credits purchased) → red "out of credits"
- `org_level_disabled` (admin disabled overage) → caught by the `else` branch → yellow "rate-limited"

The real throttle signal is the live usage windows, already the source of truth for `agents usage` and for balanced rotation (`getRoutingUsedPercent` in `rotate.ts` decides on `usedPercent < 100` and only falls back to `usageStatus` when there's no snapshot). Only `view`'s badge still trusted the wrong field.

## Fix (at the source)

- **`agents.ts`** — stop fabricating `usageStatus` from the overage flag; report only whether the account is signed in. Also corrects rotation's fallback, which could otherwise exclude a usable account whose overage is merely off.
- **`usage.ts`** — add `deriveUsageStatusFromSnapshot()`: `rate_limited` only when a blocking window (session/week; the model-specific `sonnet_week` sub-limit is excluded) hits 100%, else `available`, `null` when there's no snapshot (so no badge).
- **`view.ts`** — both `mergeCanonical` paths (overview + `--json`) derive the badge from the live snapshot.

Overage/credit balance stays visible through the existing `overageCredits` column.

## Verification

- Built and ran `agents view` against three real accounts — the false "out of credits" / "rate-limited" badges no longer appear.
- New unit tests for `deriveUsageStatusFromSnapshot` (boundary at 100%, `sonnet_week` exclusion, the overage-disabled regression case). `usage`/`agents`/`rotate`/`capabilities`/`exec` suites pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)