### PR TITLE
chore(release): 1.20.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phnx-labs/agents-cli",
-  "version": "1.20.15",
+  "version": "1.20.16",
   "description": "One CLI for all your AI coding agents - versions, config, cloud dispatch, sessions, and teams (now with first-class Grok Build CLI support)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release 1.20.16.

Includes #382 — `fix(view): derive usage badge from live windows, not the overage flag` (corrects the false "out of credits" / "rate-limited" badges in `agents view`).

Tag `v1.20.16` will be pushed after merge to trigger the npm publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)