### PR TITLE
fix(secrets): auto-provision file-store passphrase on headless Linux (#371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Headless Linux: `agents secrets` works out of the box when the keyring is locked**
+
+- On a headless server the libsecret/GNOME-keyring collection is locked, so the encrypted-file fallback is the only option — but it previously hard-failed unless `AGENTS_SECRETS_PASSPHRASE` was set, leaving `agents secrets` silently unusable. Now, on a headless run with no passphrase set, a random machine-local passphrase is auto-provisioned once at `~/.agents/.cache/secrets/.passphrase` (mode 0600) so the encrypted-file store just works. `AGENTS_SECRETS_PASSPHRASE` still takes precedence (off-disk key), an existing `.passphrase` is reused for stable interactive/headless behavior, and interactive TTY sessions are still prompted. Security model + resolution order documented in `docs/secrets.md`. (#371)
+
 **`agents secrets get/set <item>`: raw, cross-platform keychain access for hooks**
 
 - New `agents secrets get <item>` / `agents secrets set <item>` read and write a single keychain item **by bare name** (outside the bundle namespace), so shell hooks and automation have one platform-agnostic credential primitive to call instead of hardcoding `/usr/bin/security` (macOS-only) or `secret-tool` (Linux-only). `get` prints the value to stdout (newline-terminated for clean `$(…)` capture), sends diagnostics to stderr, and exits 1 with empty stdout when the item is missing — exactly what a `SessionStart` hook needs to probe-and-fallback quietly. Routing goes through the existing cross-platform keychain layer: macOS via `/usr/bin/security`, Linux via `secret-tool` with the encrypted-file fallback.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -287,6 +287,39 @@ What we don't protect against:
 - A user who approves a Touch ID prompt for an attacker-controlled binary.
 - Cross-user attacks where the attacker is `root` (the OS keychain is owned at user scope).
 
+## Linux: headless servers and the encrypted-file fallback
+
+On Linux, secrets are stored via `libsecret` / `secret-tool` (the GNOME Keyring
+Secret Service). On a **headless server** there is no graphical login, so the
+default keyring collection is **locked** and `secret-tool` can't write to it.
+When that happens (or when `secret-tool` isn't installed), `agents secrets`
+transparently falls back to an **AES-256-GCM encrypted-file store** under
+`~/.agents/.cache/secrets/` (one `<item>.enc` file per secret, mode 0600).
+
+The encryption key (passphrase) is resolved in this order:
+
+1. **`AGENTS_SECRETS_PASSPHRASE`** — if set, always used. This is the way to
+   keep the key **off disk** (e.g. exported from a password manager, or sourced
+   into the shell per session). Recommended for shared/CI machines.
+2. **An existing machine-local passphrase** — `~/.agents/.cache/secrets/.passphrase`
+   (mode 0600), if one was provisioned earlier. Used for both interactive and
+   headless runs so they always agree.
+3. **A TTY prompt** — interactive sessions are asked for the passphrase.
+4. **Auto-provisioned** — on a headless run (no TTY) with none of the above, a
+   random passphrase is generated once and written to
+   `~/.agents/.cache/secrets/.passphrase` (mode 0600). This is what makes
+   `agents secrets` work out of the box on a server.
+
+**Security model of the file store.** The auto-provisioned passphrase is
+encryption-at-rest with the key held in a 0600 file — the same posture as an SSH
+private key, and identical to the common `export AGENTS_SECRETS_PASSPHRASE=… ` in
+`~/.zshenv` (chmod 600) workaround. It protects against on-disk plaintext
+exposure (backups, accidental commits, `.env` leaks), not against another
+process running as the same user. For a key held **off disk**, set
+`AGENTS_SECRETS_PASSPHRASE` (it always takes precedence) or unlock the keyring
+(e.g. configure `pam_gnome_keyring` for SSH login). To rotate, set a new
+`AGENTS_SECRETS_PASSPHRASE`, re-add the secrets, and delete `.passphrase`.
+
 ## See Also
 
 - `docs/00-concepts.md` — DotAgents repos and resource model

--- a/src/lib/secrets/__tests__/linux.test.ts
+++ b/src/lib/secrets/__tests__/linux.test.ts
@@ -208,3 +208,75 @@ describe('linuxBackend (via forced file fallback)', () => {
     expect(linuxBackend.list('agents-cli.secrets.persisted-probe.')).toEqual(['agents-cli.secrets.persisted-probe.API_KEY']);
   });
 });
+
+/**
+ * The reported bug (#371): on a headless box the keyring is locked AND no
+ * AGENTS_SECRETS_PASSPHRASE is set, so the file fallback's getPassphrase() used
+ * to hard-throw — `agents secrets` was unusable out of the box. The fix
+ * auto-provisions a machine-local passphrase (0600 file) instead.
+ *
+ * isTTY is stubbed false so these are deterministic regardless of how the test
+ * runner is launched (a real TTY would otherwise hit the interactive prompt).
+ */
+describe('headless auto-provisioned passphrase (no env, locked keyring)', () => {
+  let tmpDir: string;
+  let prevTty: boolean | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-autopass-'));
+    delete process.env.AGENTS_SECRETS_PASSPHRASE;
+    prevTty = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    // No `passphrase` passed → cachedPassphrase stays null, forcing the real
+    // getPassphrase() resolution path. Force the file fallback so we don't need
+    // a real secret-tool (the closest proxy for "headless, locked collection").
+    _resetForTest({ fileDir: tmpDir, forceFileFallback: true });
+  });
+
+  afterEach(() => {
+    delete process.env.AGENTS_SECRETS_PASSPHRASE;
+    Object.defineProperty(process.stdin, 'isTTY', { value: prevTty, configurable: true });
+    _resetForTest();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('set/get works without env or keyring, and writes a 0600 .passphrase', () => {
+    // Previously this threw "no AGENTS_SECRETS_PASSPHRASE is set".
+    linuxBackend.set('agents-cli.secrets.work.API_KEY', 'sk-headless-123');
+    expect(linuxBackend.get('agents-cli.secrets.work.API_KEY')).toBe('sk-headless-123');
+
+    const passFp = path.join(tmpDir, '.passphrase');
+    expect(fs.existsSync(passFp)).toBe(true);
+    expect(fs.statSync(passFp).mode & 0o777).toBe(0o600);
+    // The on-disk item is ciphertext, not the plaintext value.
+    const enc = fs.readFileSync(path.join(tmpDir, 'agents-cli.secrets.work.API_KEY.enc'), 'utf8');
+    expect(enc).not.toContain('sk-headless-123');
+  });
+
+  it('the .passphrase file is stable across processes (decrypts later)', () => {
+    linuxBackend.set('agents-cli.secrets.work.API_KEY', 'persisted');
+    const provisioned = fs.readFileSync(path.join(tmpDir, '.passphrase'), 'utf8');
+
+    // Fresh process: clear in-memory cache, keep the same store dir.
+    _resetForTest({ fileDir: tmpDir, forceFileFallback: true });
+    expect(linuxBackend.get('agents-cli.secrets.work.API_KEY')).toBe('persisted');
+    // Same passphrase reused, not regenerated.
+    expect(fs.readFileSync(path.join(tmpDir, '.passphrase'), 'utf8')).toBe(provisioned);
+  });
+
+  it('.passphrase is not surfaced as a secret item', () => {
+    linuxBackend.set('agents-cli.secrets.work.A', 'a');
+    expect(linuxBackend.list('').filter((n) => n.includes('passphrase'))).toEqual([]);
+    expect(linuxBackend.has('.passphrase')).toBe(false);
+  });
+
+  it('AGENTS_SECRETS_PASSPHRASE still takes precedence over a provisioned file', () => {
+    // Provision a machine-local passphrase by writing under no env.
+    linuxBackend.set('agents-cli.secrets.work.A', 'under-machine-pass');
+    // Now a process with an explicit env passphrase must use THAT, so it cannot
+    // decrypt the item written under the machine passphrase.
+    process.env.AGENTS_SECRETS_PASSPHRASE = 'explicit-different-pass';
+    _resetForTest({ fileDir: tmpDir, forceFileFallback: true });
+    expect(() => linuxBackend.get('agents-cli.secrets.work.A')).toThrow(/decrypt|passphrase/i);
+  });
+});

--- a/src/lib/secrets/linux.ts
+++ b/src/lib/secrets/linux.ts
@@ -46,6 +46,7 @@ let isAvailable = false;
 
 let useFileFallback = false;
 let warnedFallback = false;
+let warnedAutoPassphrase = false;
 let fileDirOverride: string | null = null;
 let cachedPassphrase: string | null = null;
 
@@ -99,7 +100,13 @@ function preflight(): 'file' | 'secret-tool' {
     checkedAvailability = true;
   }
   if (!isAvailable) {
-    if (process.env.AGENTS_SECRETS_PASSPHRASE) {
+    // No secret-tool. Route to the encrypted-file fallback whenever a passphrase
+    // source exists or can be auto-provisioned: an explicit
+    // AGENTS_SECRETS_PASSPHRASE, an already-provisioned machine-local passphrase,
+    // or a headless context (no TTY) where getPassphrase() auto-provisions one.
+    // Only an INTERACTIVE session with none of these gets the install hint —
+    // installing libsecret is the better fix when someone is at the keyboard.
+    if (process.env.AGENTS_SECRETS_PASSPHRASE || machinePassphraseExists() || !process.stdin.isTTY) {
       activateFileFallback();
       return 'file';
     }
@@ -148,6 +155,69 @@ function readPassphraseFromTty(): string {
   }
 }
 
+/** Path of the auto-provisioned machine-local passphrase. Lives alongside the
+ *  encrypted items but is never itself an item (no `.enc` suffix, so it's
+ *  excluded from list/has/get and from fileFallbackPreviouslyActivated). */
+function passphraseFilePath(): string {
+  return path.join(fileDir(), '.passphrase');
+}
+
+/** True if a machine-local passphrase has already been provisioned. */
+function machinePassphraseExists(): boolean {
+  try {
+    return fs.readFileSync(passphraseFilePath(), 'utf8').trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function readMachinePassphrase(): string | null {
+  try {
+    const p = fs.readFileSync(passphraseFilePath(), 'utf8').trim();
+    return p.length > 0 ? p : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Provision (or read back) a stable machine-local passphrase for the encrypted
+ * file store, so `agents secrets` works out of the box on a headless box where
+ * the keyring is locked and no AGENTS_SECRETS_PASSPHRASE is set.
+ *
+ * Security model: this is encryption-at-rest with the key held in a 0600 file —
+ * the same posture as an SSH private key, and identical to the common
+ * "export AGENTS_SECRETS_PASSPHRASE=… in ~/.zshenv (chmod 600)" workaround. The
+ * keyring (key in a daemon's locked memory) is stronger but is unavailable
+ * without a graphical/unlocked session. For an off-disk key, set
+ * AGENTS_SECRETS_PASSPHRASE (it always takes precedence) or unlock the keyring.
+ */
+function provisionMachinePassphrase(): string {
+  const existing = readMachinePassphrase();
+  if (existing) return existing;
+
+  ensureFileDir();
+  const generated = randomBytes(32).toString('base64');
+  const fp = passphraseFilePath();
+  try {
+    // wx: fail if a concurrent process created it first (then we read theirs).
+    fs.writeFileSync(fp, generated, { mode: 0o600, flag: 'wx' });
+  } catch {
+    const raced = readMachinePassphrase();
+    if (raced) return raced;
+    throw new Error(`Failed to provision machine-local passphrase at ${fp}.`);
+  }
+  if (!warnedAutoPassphrase) {
+    warnedAutoPassphrase = true;
+    process.stderr.write(
+      `[agents] keyring locked and no AGENTS_SECRETS_PASSPHRASE set; provisioned a ` +
+      `machine-local passphrase at ${fp} (mode 0600). Set AGENTS_SECRETS_PASSPHRASE ` +
+      `for a key held off disk.\n`
+    );
+  }
+  return generated;
+}
+
 function getPassphrase(): string {
   if (cachedPassphrase !== null) return cachedPassphrase;
   const env = process.env.AGENTS_SECRETS_PASSPHRASE;
@@ -155,17 +225,24 @@ function getPassphrase(): string {
     cachedPassphrase = env;
     return env;
   }
-  if (!process.stdin.isTTY) {
-    throw new Error(
-      'Secret-service collection is locked and no AGENTS_SECRETS_PASSPHRASE is set.\n' +
-      'Set AGENTS_SECRETS_PASSPHRASE in your environment to use the encrypted-file fallback,\n' +
-      'or unlock the keyring (e.g. configure pam_gnome_keyring for SSH login).'
-    );
+  // A previously-provisioned machine-local passphrase is this machine's stable
+  // file-store key — prefer it for both interactive and headless runs so they
+  // always agree (a TTY run won't re-prompt once the file exists).
+  const onDisk = readMachinePassphrase();
+  if (onDisk) {
+    cachedPassphrase = onDisk;
+    return onDisk;
   }
-  const p = readPassphraseFromTty();
-  if (!p) throw new Error('No passphrase entered.');
-  cachedPassphrase = p;
-  return p;
+  // First run, no env, no provisioned key: prompt when interactive, otherwise
+  // (headless — the reported bug) auto-provision instead of hard-failing.
+  if (process.stdin.isTTY) {
+    const p = readPassphraseFromTty();
+    if (!p) throw new Error('No passphrase entered.');
+    cachedPassphrase = p;
+    return p;
+  }
+  cachedPassphrase = provisionMachinePassphrase();
+  return cachedPassphrase;
 }
 
 // ---------- AES-256-GCM ----------
@@ -462,6 +539,7 @@ export function _resetForTest(opts: {
   fileDirOverride = opts.fileDir ?? null;
   useFileFallback = opts.forceFileFallback ?? false;
   warnedFallback = false;
+  warnedAutoPassphrase = false;
   cachedPassphrase = opts.passphrase ?? null;
   checkedAvailability = false;
   isAvailable = false;


### PR DESCRIPTION
Closes #371. Part of the cross-machine sync epic #363.

## Problem
On a headless server the libsecret/GNOME-keyring collection is **locked**, so the AES-256-GCM encrypted-file store is the only viable backend — but `getPassphrase()` hard-threw unless `AGENTS_SECRETS_PASSPHRASE` was set. Net effect: `agents secrets` was **silently unusable** on servers out of the box (repro in the issue).

## Fix
When the keyring is locked, no `AGENTS_SECRETS_PASSPHRASE` is set, and there's no TTY to prompt, auto-provision a random machine-local passphrase once at `~/.agents/.cache/secrets/.passphrase` (mode 0600) and reuse it.

Passphrase resolution order (in `getPassphrase`):
1. `AGENTS_SECRETS_PASSPHRASE` — always wins (the off-disk option)
2. existing `~/.agents/.cache/secrets/.passphrase` — reused so interactive + headless runs agree
3. TTY prompt — interactive sessions unchanged
4. auto-provision — headless first run (the bug)

`preflight()` also routes a *missing* `secret-tool` to the file fallback on headless instead of erroring; an interactive session with no tool still gets the libsecret install hint.

## Security model
The auto-provisioned passphrase is encryption-at-rest with the key in a 0600 file — the same posture as an SSH private key, and identical to the documented `AGENTS_SECRETS_PASSPHRASE`-in-`~/.zshenv` workaround. For an off-disk key, set `AGENTS_SECRETS_PASSPHRASE` (always takes precedence) or unlock the keyring. Documented in `docs/secrets.md`.

> Design note: the issue offered "guide the user **or** offer to provision the file-store passphrase" — this takes the provision path because it serves the epic's "just works on every machine" goal with zero per-server setup. Happy to switch to a guided-error variant if preferred.

## Tests / verification
- 4 new headless-auto-provision cases driving the **real** file backend (real fs + real AES-256-GCM, no mocks): set/get with no env, `.passphrase` is 0600, item is ciphertext on disk, passphrase stable across processes, `.passphrase` never surfaced as a secret item, `AGENTS_SECRETS_PASSPHRASE` precedence. **24/24 pass, `tsc --noEmit` clean.**
- The new tests exercise the exact bug path (`linuxBackend.set/get` → `preflight` → file fallback → `getPassphrase` → `provisionMachinePassphrase` → encrypt/decrypt). The `agents secrets <cmd>` CLI is a thin wrapper over this `linuxBackend`.
- Full `agents secrets ...` CLI E2E on a fresh headless box is the one remaining check (couldn't reach it from a source run in-sandbox due to the `agents setup` gate) — the library-level path it calls is fully covered above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)