### PR TITLE
feat(secrets): SyncBackend transport seam, decouple sync.ts from Rush (#364)

### DIFF
--- a/src/lib/secrets/__tests__/sync-backend.test.ts
+++ b/src/lib/secrets/__tests__/sync-backend.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Contract test for the `SyncBackend` transport seam (#364).
+ *
+ * Proves the secrets push/pull path is decoupled from any specific backend:
+ * an in-memory `SyncBackend` (a Map, no network, no Rush) is installed via
+ * `setSyncBackend`, and a real bundle (literal var + keychain-backed secret)
+ * round-trips through encrypt -> putEnvelope -> getEnvelope -> decrypt ->
+ * restore. The backend only ever sees ciphertext.
+ *
+ * Mocking note (same rationale as bundles-storage.test.ts): `os.homedir` is
+ * redirected to a temp dir so writes don't touch the real ~/.agents, and the
+ * keychain goes through an in-memory `KeychainBackend`. The contract under
+ * test is the transport seam, not Keychain or the filesystem.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+interface OsMockState { homedir: string }
+const osMockState: OsMockState = ((globalThis as Record<string, unknown>)
+  .__agents_cli_os_mock__ as OsMockState | undefined)
+  ?? (((globalThis as Record<string, unknown>).__agents_cli_os_mock__ = { homedir: '' }) as OsMockState);
+
+vi.mock('os', () => {
+  const actual = require('node:os') as typeof import('os');
+  return {
+    ...actual,
+    default: actual,
+    homedir: () => {
+      const state = (globalThis as Record<string, unknown>)
+        .__agents_cli_os_mock__ as OsMockState | undefined;
+      return state?.homedir || actual.homedir();
+    },
+  };
+});
+
+import {
+  pushBundle,
+  pullBundle,
+  deleteRemoteBundle,
+  listRemoteBundles,
+  setSyncBackend,
+} from '../sync.js';
+import type { SyncBackend, SyncEnvelope } from '../sync-backend.js';
+import { writeBundle, bundleExists, deleteBundle } from '../bundles.js';
+import {
+  setKeychainBackendForTest,
+  getKeychainToken,
+  setKeychainToken,
+  secretsKeychainItem,
+  type KeychainBackend,
+} from '../index.js';
+
+const PASS = 'correct-horse-battery-staple';
+
+function makeMemoryKeychain(): { backend: KeychainBackend; store: Map<string, string> } {
+  const store = new Map<string, string>();
+  const backend: KeychainBackend = {
+    has: (i) => store.has(i),
+    get: (i) => {
+      if (!store.has(i)) throw new Error(`Keychain item '${i}' not found.`);
+      return store.get(i)!;
+    },
+    set: (i, v) => { store.set(i, v); },
+    delete: (i) => store.delete(i),
+    list: (p) => [...store.keys()].filter((k) => k.startsWith(p)),
+  };
+  return { backend, store };
+}
+
+/** In-memory SyncBackend — the test double the contract is asserted against. */
+function makeMemorySyncBackend(): { backend: SyncBackend; store: Map<string, SyncEnvelope> } {
+  const store = new Map<string, SyncEnvelope>();
+  const backend: SyncBackend = {
+    async putEnvelope(name, payload) { store.set(name, payload); },
+    async getEnvelope(name) { return store.get(name) ?? null; },
+    async deleteEnvelope(name) { return store.delete(name); },
+    async listEnvelopes() {
+      return [...store.entries()].map(([name, p]) => ({ name, updated_at: p.updated_at }));
+    },
+  };
+  return { backend, store };
+}
+
+let tmpDir: string;
+let restoreKeychain: KeychainBackend | null = null;
+let restoreBackend: SyncBackend;
+let remote: Map<string, SyncEnvelope>;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-syncbackend-'));
+  osMockState.homedir = tmpDir;
+  restoreKeychain = setKeychainBackendForTest(makeMemoryKeychain().backend);
+  const mem = makeMemorySyncBackend();
+  remote = mem.store;
+  restoreBackend = setSyncBackend(mem.backend);
+});
+
+afterEach(() => {
+  setKeychainBackendForTest(restoreKeychain);
+  setSyncBackend(restoreBackend);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('SyncBackend seam: push/pull round-trip through an in-memory driver', () => {
+  it('round-trips a bundle (literal var + keychain secret) and stores only ciphertext', async () => {
+    // Arrange: a bundle with a literal var and a keychain-backed secret value.
+    writeBundle({
+      name: 'work',
+      description: 'contract test bundle',
+      vars: { REGION: 'us-east', API_KEY: 'keychain:apikey' },
+    });
+    setKeychainToken(secretsKeychainItem('work', 'apikey'), 'sk-live-SECRET-123');
+
+    // Act: push -> the in-memory backend receives one envelope.
+    const { updated_at } = await pushBundle('work', { passphrase: PASS });
+    expect(remote.has('work')).toBe(true);
+    const stored = remote.get('work')!;
+    expect(stored.updated_at).toBe(updated_at);
+
+    // The stored blob is ciphertext — neither the secret value nor metadata leaks.
+    const serialized = JSON.stringify(stored);
+    expect(serialized).not.toContain('sk-live-SECRET-123');
+    expect(serialized).not.toContain('us-east');
+    expect(stored.envelope.kdf).toBe('pbkdf2-sha256');
+
+    // Wipe local state to simulate a different machine.
+    deleteBundle('work');
+    setKeychainBackendForTest(makeMemoryKeychain().backend); // empty keychain
+    expect(bundleExists('work')).toBe(false);
+
+    // Act: pull -> decrypts and restores bundle + secret.
+    const restored = await pullBundle('work', { passphrase: PASS, force: true });
+    expect(restored.name).toBe('work');
+    expect(restored.vars.REGION).toBe('us-east');
+    expect(bundleExists('work')).toBe(true);
+    expect(getKeychainToken(secretsKeychainItem('work', 'apikey'))).toBe('sk-live-SECRET-123');
+  });
+
+  it('pull throws a backend-agnostic error when the remote has no such bundle', async () => {
+    await expect(pullBundle('absent', { passphrase: PASS })).rejects.toThrow(/not found/i);
+  });
+
+  it('wrong passphrase fails to decrypt on pull', async () => {
+    writeBundle({ name: 'secure', vars: { A: 'plain' } });
+    await pushBundle('secure', { passphrase: PASS });
+    deleteBundle('secure');
+    await expect(
+      pullBundle('secure', { passphrase: 'a-different-passphrase', force: true }),
+    ).rejects.toThrow(/wrong passphrase|decrypt/i);
+  });
+
+  it('list and delete go through the backend', async () => {
+    writeBundle({ name: 'one', vars: { A: '1' } });
+    writeBundle({ name: 'two', vars: { B: '2' } });
+    await pushBundle('one', { passphrase: PASS });
+    await pushBundle('two', { passphrase: PASS });
+
+    const listed = (await listRemoteBundles()).map((b) => b.name).sort();
+    expect(listed).toEqual(['one', 'two']);
+
+    expect(await deleteRemoteBundle('one')).toBe(true);
+    expect(await deleteRemoteBundle('one')).toBe(false); // already gone
+    expect((await listRemoteBundles()).map((b) => b.name)).toEqual(['two']);
+  });
+});

--- a/src/lib/secrets/drivers/rush.ts
+++ b/src/lib/secrets/drivers/rush.ts
@@ -1,0 +1,98 @@
+/**
+ * Rush `SyncBackend` driver — the original (and currently default) transport
+ * for `agents secrets push/pull`. Talks to api.prix.dev and authenticates with
+ * the session token written by `rush login` (`~/.rush/user.yaml`).
+ *
+ * This is the ONE place in the secrets module allowed to reference Rush
+ * (api.prix.dev / ~/.rush). It is an opt-in driver kept for backwards
+ * compatibility with bundles already pushed to Rush; `sync.ts` selects it as
+ * the default but the transport seam (`SyncBackend`) lets other backends drop
+ * in without touching the crypto or push/pull logic.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as yaml from 'yaml';
+import type { SyncBackend, SyncEnvelope, RemoteBundleSummary } from '../sync-backend.js';
+
+const PROXY_BASE = 'https://api.prix.dev';
+const USER_YAML = path.join(os.homedir(), '.rush', 'user.yaml');
+const BUNDLE_ENDPOINT = '/api/v1/secrets/bundles';
+
+interface RushUserYaml {
+  session?: {
+    access_token?: string;
+  };
+}
+
+function readRushToken(): string {
+  if (!fs.existsSync(USER_YAML)) {
+    throw new Error('Not logged in to Rush. Run `rush login` first.');
+  }
+  const raw = fs.readFileSync(USER_YAML, 'utf-8');
+  const data = yaml.parse(raw) as RushUserYaml;
+  const token = data?.session?.access_token;
+  if (!token) {
+    throw new Error('No session token in ~/.rush/user.yaml. Run `rush login` first.');
+  }
+  return token;
+}
+
+async function api(method: string, endpoint: string, body?: unknown): Promise<Response> {
+  const token = readRushToken();
+  const url = endpoint.startsWith('http') ? endpoint : `${PROXY_BASE}${endpoint}`;
+  return fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function bundlePath(name: string): string {
+  return `${BUNDLE_ENDPOINT}/${encodeURIComponent(name)}`;
+}
+
+/** The Rush transport. Plaintext never reaches here — only ciphertext envelopes. */
+export const rushSyncBackend: SyncBackend = {
+  async putEnvelope(name: string, payload: SyncEnvelope): Promise<void> {
+    const res = await api('PUT', bundlePath(name), payload);
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new Error(`Push failed (${res.status} ${res.statusText}): ${body}`);
+    }
+  },
+
+  async getEnvelope(name: string): Promise<SyncEnvelope | null> {
+    const res = await api('GET', bundlePath(name));
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new Error(`Pull failed (${res.status} ${res.statusText}): ${body}`);
+    }
+    return await res.json() as SyncEnvelope;
+  },
+
+  async deleteEnvelope(name: string): Promise<boolean> {
+    const res = await api('DELETE', bundlePath(name));
+    if (res.status === 404) return false;
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new Error(`Delete failed (${res.status} ${res.statusText}): ${body}`);
+    }
+    return true;
+  },
+
+  async listEnvelopes(): Promise<RemoteBundleSummary[]> {
+    const res = await api('GET', BUNDLE_ENDPOINT);
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new Error(`List failed (${res.status} ${res.statusText}): ${body}`);
+    }
+    const data = await res.json() as { bundles?: RemoteBundleSummary[] };
+    return data.bundles ?? [];
+  },
+};

--- a/src/lib/secrets/sync-backend.ts
+++ b/src/lib/secrets/sync-backend.ts
@@ -1,0 +1,52 @@
+/**
+ * Transport seam for encrypted secrets-bundle sync.
+ *
+ * A `SyncBackend` moves opaque ciphertext envelopes to and from some remote.
+ * It NEVER sees plaintext: encryption (`encryptBlob`) happens in `sync.ts`
+ * before `putEnvelope`, and decryption (`decryptBlob`) happens after
+ * `getEnvelope`. This mirrors the `KeychainBackend` storage seam
+ * (`src/lib/secrets/index.ts`) but abstracts *transport* rather than at-rest
+ * storage — so the high-level push/pull logic in `sync.ts` is decoupled from
+ * any specific backend (Rush's api.prix.dev, a future Supabase driver, an
+ * in-memory test double, …).
+ */
+
+/** Encrypted bundle envelope (AES-256-GCM, key via PBKDF2-SHA256). All byte
+ *  fields are base64. The server only ever stores/returns this — never plaintext. */
+export interface EncryptedEnvelope {
+  v: 1;
+  kdf: 'pbkdf2-sha256';
+  iter: number;
+  salt: string;
+  iv: string;
+  ct: string;
+  tag: string;
+}
+
+/** A stored bundle object: the ciphertext envelope plus a last-updated stamp. */
+export interface SyncEnvelope {
+  envelope: EncryptedEnvelope;
+  updated_at: string;
+}
+
+/** Lightweight listing entry returned by `listEnvelopes`. */
+export interface RemoteBundleSummary {
+  name: string;
+  updated_at: string;
+}
+
+/**
+ * Pluggable transport for encrypted bundles. Implementations handle only the
+ * wire/storage; the crypto and bundle snapshot/restore stay backend-agnostic
+ * in `sync.ts`.
+ */
+export interface SyncBackend {
+  /** Store (create or overwrite) the envelope for `name`. */
+  putEnvelope(name: string, payload: SyncEnvelope): Promise<void>;
+  /** Fetch the envelope for `name`, or `null` if the remote has none. */
+  getEnvelope(name: string): Promise<SyncEnvelope | null>;
+  /** Delete `name` on the remote. Returns false if it didn't exist. */
+  deleteEnvelope(name: string): Promise<boolean>;
+  /** List every bundle the authenticated user has on the remote. */
+  listEnvelopes(): Promise<RemoteBundleSummary[]>;
+}

--- a/src/lib/secrets/sync.ts
+++ b/src/lib/secrets/sync.ts
@@ -1,18 +1,17 @@
 /**
- * Remote sync client for secrets bundles.
+ * Remote sync for secrets bundles — backend-agnostic.
  *
  * Replaces the previous "leave it to iCloud Keychain" model with explicit
- * push/pull against api.prix.dev. Bundle contents (vars + secret values) are
- * encrypted client-side with AES-256-GCM under a key derived from a
- * user-supplied passphrase via PBKDF2-SHA256. Plaintext never leaves the
- * machine — api.prix.dev only ever sees the ciphertext + KDF parameters.
+ * push/pull. Bundle contents (vars + secret values) are encrypted client-side
+ * with AES-256-GCM under a key derived from a user-supplied passphrase via
+ * PBKDF2-SHA256; only the resulting ciphertext envelope is handed to the
+ * transport. The transport itself is a pluggable `SyncBackend` (see
+ * `sync-backend.ts`) — the Rush driver (`drivers/rush.ts`, api.prix.dev) is the
+ * default for backwards compatibility, swappable via `setSyncBackend`. Plaintext
+ * never leaves this module; the backend only ever sees ciphertext + KDF params.
  */
 
 import * as crypto from 'crypto';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import * as yaml from 'yaml';
 import {
   getKeychainToken,
   hasKeychainToken,
@@ -26,10 +25,12 @@ import {
   validateBundleName,
   type SecretsBundle,
 } from './bundles.js';
+import { rushSyncBackend } from './drivers/rush.js';
+import type { SyncBackend, SyncEnvelope, RemoteBundleSummary, EncryptedEnvelope } from './sync-backend.js';
 
-const PROXY_BASE = 'https://api.prix.dev';
-const USER_YAML = path.join(os.homedir(), '.rush', 'user.yaml');
-const BUNDLE_ENDPOINT = '/api/v1/secrets/bundles';
+// Re-export the envelope + summary types so existing importers of this module
+// keep resolving them from here.
+export type { EncryptedEnvelope, RemoteBundleSummary } from './sync-backend.js';
 
 // PBKDF2 cost. 600k SHA-256 iters matches OWASP 2023+ guidance and keeps a
 // passphrase prompt under a second on the hardware the CLI targets.
@@ -39,57 +40,20 @@ const KEY_LEN = 32;
 const SALT_LEN = 16;
 const IV_LEN = 12;
 
-/** Envelope for an encrypted bundle. All byte fields are base64. */
-export interface EncryptedEnvelope {
-  v: 1;
-  kdf: 'pbkdf2-sha256';
-  iter: number;
-  salt: string;
-  iv: string;
-  ct: string;
-  tag: string;
-}
+/**
+ * Active transport backend. Defaults to the Rush driver for backwards
+ * compatibility with bundles already pushed to api.prix.dev; `setSyncBackend`
+ * swaps it (a future Supabase driver, or an in-memory double in tests). The
+ * crypto + snapshot/restore below stay backend-agnostic — the backend only
+ * ever moves ciphertext envelopes, never plaintext.
+ */
+let backend: SyncBackend = rushSyncBackend;
 
-interface PushPayload {
-  envelope: EncryptedEnvelope;
-  updated_at: string;
-}
-
-interface RemoteBundleSummary {
-  name: string;
-  updated_at: string;
-}
-
-interface RushUserYaml {
-  session?: {
-    access_token?: string;
-  };
-}
-
-function readRushToken(): string {
-  if (!fs.existsSync(USER_YAML)) {
-    throw new Error('Not logged in to Rush. Run `rush login` first.');
-  }
-  const raw = fs.readFileSync(USER_YAML, 'utf-8');
-  const data = yaml.parse(raw) as RushUserYaml;
-  const token = data?.session?.access_token;
-  if (!token) {
-    throw new Error('No session token in ~/.rush/user.yaml. Run `rush login` first.');
-  }
-  return token;
-}
-
-async function api(method: string, endpoint: string, body?: unknown): Promise<Response> {
-  const token = readRushToken();
-  const url = endpoint.startsWith('http') ? endpoint : `${PROXY_BASE}${endpoint}`;
-  return fetch(url, {
-    method,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body: body === undefined ? undefined : JSON.stringify(body),
-  });
+/** Override the sync transport. Returns the previous backend (restore in tests). */
+export function setSyncBackend(next: SyncBackend): SyncBackend {
+  const prev = backend;
+  backend = next;
+  return prev;
 }
 
 function deriveKey(passphrase: string, salt: Buffer): Buffer {
@@ -174,18 +138,14 @@ export interface PushOptions {
   passphrase: string;
 }
 
-/** Push a local bundle to api.prix.dev. Encrypts client-side; server only sees ciphertext. */
+/** Push a local bundle to the remote. Encrypts client-side; the backend only sees ciphertext. */
 export async function pushBundle(name: string, opts: PushOptions): Promise<{ updated_at: string }> {
   validateBundleName(name);
   const snap = snapshotBundle(name);
   const envelope = encryptBlob(JSON.stringify(snap), opts.passphrase);
   const updated_at = new Date().toISOString();
-  const payload: PushPayload = { envelope, updated_at };
-  const res = await api('PUT', `${BUNDLE_ENDPOINT}/${encodeURIComponent(name)}`, payload);
-  if (!res.ok) {
-    const body = await res.text().catch(() => '');
-    throw new Error(`Push failed (${res.status} ${res.statusText}): ${body}`);
-  }
+  const payload: SyncEnvelope = { envelope, updated_at };
+  await backend.putEnvelope(name, payload);
   return { updated_at };
 }
 
@@ -196,18 +156,13 @@ export interface PullOptions {
   force?: boolean;
 }
 
-/** Pull a bundle by name from api.prix.dev and materialize it locally. */
+/** Pull a bundle by name from the remote and materialize it locally. */
 export async function pullBundle(name: string, opts: PullOptions): Promise<SecretsBundle> {
   validateBundleName(name);
-  const res = await api('GET', `${BUNDLE_ENDPOINT}/${encodeURIComponent(name)}`);
-  if (res.status === 404) {
-    throw new Error(`Remote bundle '${name}' not found on api.prix.dev.`);
+  const data = await backend.getEnvelope(name);
+  if (!data) {
+    throw new Error(`Remote bundle '${name}' not found.`);
   }
-  if (!res.ok) {
-    const body = await res.text().catch(() => '');
-    throw new Error(`Pull failed (${res.status} ${res.statusText}): ${body}`);
-  }
-  const data = await res.json() as PushPayload;
   const plaintext = decryptBlob(data.envelope, opts.passphrase);
   const snap = JSON.parse(plaintext) as BundleSnapshot;
   if (!snap || !snap.bundle || snap.bundle.name !== name) {
@@ -227,22 +182,10 @@ export async function pullBundle(name: string, opts: PullOptions): Promise<Secre
 /** Delete a bundle on the remote. */
 export async function deleteRemoteBundle(name: string): Promise<boolean> {
   validateBundleName(name);
-  const res = await api('DELETE', `${BUNDLE_ENDPOINT}/${encodeURIComponent(name)}`);
-  if (res.status === 404) return false;
-  if (!res.ok) {
-    const body = await res.text().catch(() => '');
-    throw new Error(`Delete failed (${res.status} ${res.statusText}): ${body}`);
-  }
-  return true;
+  return backend.deleteEnvelope(name);
 }
 
-/** List bundles currently stored on api.prix.dev for this user. */
+/** List bundles currently stored on the remote for this user. */
 export async function listRemoteBundles(): Promise<RemoteBundleSummary[]> {
-  const res = await api('GET', BUNDLE_ENDPOINT);
-  if (!res.ok) {
-    const body = await res.text().catch(() => '');
-    throw new Error(`List failed (${res.status} ${res.statusText}): ${body}`);
-  }
-  const data = await res.json() as { bundles?: RemoteBundleSummary[] };
-  return data.bundles ?? [];
+  return backend.listEnvelopes();
 }


### PR DESCRIPTION
Closes #364. Part of the cross-machine sync epic #363.

## What
Introduce a pluggable `SyncBackend` transport interface and route the secrets push/pull path through it, removing the hard Rush coupling from `sync.ts`. This is the foundation that lets agents-cli own a billable hosted sync backend (a future Supabase driver, #367) instead of being wired to Rush's `api.prix.dev`.

## Changes
- **New `src/lib/secrets/sync-backend.ts`** — `SyncBackend` (`putEnvelope`/`getEnvelope`/`deleteEnvelope`/`listEnvelopes`) + wire types (`EncryptedEnvelope`, `SyncEnvelope`, `RemoteBundleSummary`). Mirrors the `KeychainBackend` storage seam but abstracts *transport*.
- **New `src/lib/secrets/drivers/rush.ts`** — the `api.prix.dev` + `~/.rush/user.yaml` logic moved verbatim into an opt-in `rushSyncBackend`. Kept for backwards compat with bundles already on Rush; **the only place in the secrets module that references prix.dev/~/.rush**.
- **`sync.ts`** — `encryptBlob`/`decryptBlob`/snapshot/restore stay backend-agnostic; transport routes through a swappable `backend` (default `rushSyncBackend`), exposed via `setSyncBackend`. Envelope/summary types re-exported so importers are unaffected.

## Acceptance (from the issue)
- ✅ `agents secrets push/pull/remote-list` register and run unchanged (the rush driver is a 1:1 code move — verified the command tree loads).
- ✅ No `prix.dev`/`~/.rush` reference in `src/lib/secrets/` outside `drivers/rush.ts` (only doc comments name it as the default backend).
- ✅ In-memory-driver contract test.

## Tests
New `__tests__/sync-backend.test.ts`: installs an in-memory `SyncBackend` via `setSyncBackend` and round-trips a real bundle (literal var + keychain-backed secret) through encrypt → `putEnvelope` → `getEnvelope` → decrypt → restore, asserting **ciphertext-only** storage (no plaintext value or metadata leaks); plus not-found, wrong-passphrase, and list/delete via the backend. Full secrets suite **110 pass / 3 skip**, `tsc --noEmit` clean.

> The Rush transport itself can't be E2E'd here (needs `rush login` + network to api.prix.dev), but its code is unchanged — only relocated. The contract test proves the seam is correctly wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)