### PR TITLE
chore(release): 1.20.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phnx-labs/agents-cli",
-  "version": "1.20.16",
+  "version": "1.20.17",
   "description": "One CLI for all your AI coding agents - versions, config, cloud dispatch, sessions, and teams (now with first-class Grok Build CLI support)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release 1.20.17.

Ships the two commits that landed on `main` after the 1.20.16 tag without their own version bump:
- #384 — `fix(secrets): auto-provision file-store passphrase on headless Linux`
- #385 — `feat(secrets): SyncBackend transport seam, decouple sync.ts from Rush`

Also already on `main` from 1.20.16: #381 daemon OAuth-token fix.

Tag `v1.20.17` will be pushed after merge; npm publish is completed from a macOS machine (the CI publish job can't pack the macOS-only Keychain helper `bin/Agents CLI.app`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
