### PR TITLE
fix(plugins): make Claude-invalid manifest warning actionable (Fix: hint for agents)

### DIFF
--- a/src/lib/plugin-marketplace.test.ts
+++ b/src/lib/plugin-marketplace.test.ts
@@ -264,6 +264,10 @@ describe('syncMarketplaceManifest', () => {
     expect(out).toContain("plugin 'badplug'");
     expect(out).toContain('"skills"');
     expect(out).toContain('"./');
+    // Carries actionable fix text, not just a complaint.
+    expect(out).toContain('Fix:');
+    expect(out).toContain('delete the "skills" field');
+    // The valid neighbour never warns.
     expect(out).not.toContain('goodplug');
   });
 });
@@ -464,6 +468,9 @@ describe('validateClaudePluginManifest', () => {
     expect(warnings[0]).toContain('"skills"');
     expect(warnings[0]).toContain('"dispatch"');
     expect(warnings[0]).toContain('"./');
+    // Must tell the reader (human or agent) exactly how to fix it.
+    expect(warnings[0]).toContain('Fix:');
+    expect(warnings[0]).toContain('delete the "skills" field');
   });
 
   it('passes skills given as proper relative "./" paths', () => {

--- a/src/lib/plugin-marketplace.ts
+++ b/src/lib/plugin-marketplace.ts
@@ -267,20 +267,29 @@ export function validateClaudePluginManifest(manifest: unknown): string[] {
     const value = m[field];
     if (value === undefined || value === null) continue;
 
+    // How-to-fix written so a human OR a coding agent reading stderr can act
+    // without further investigation. Deleting the field is the recommended fix:
+    // Claude auto-discovers skills/commands/agents from their directories, which
+    // is why every well-formed plugin omits these fields entirely.
+    const fix =
+      `Fix: delete the "${field}" field from plugin.json (recommended — Claude ` +
+      `auto-discovers from the ${field}/ directory), or rewrite every entry as a ` +
+      `"./"-relative path (e.g. "./${field}/<name>").`;
+
     const entries = Array.isArray(value) ? value : [value];
     for (const entry of entries) {
       if (typeof entry !== 'string') {
         warnings.push(
-          `plugin.json field "${field}" must contain relative paths starting with "./" ` +
-          `(e.g. "./${field}/<name>"); found a non-string value. Claude Code will reject the whole plugin.`
+          `field "${field}" must be a "./"-relative path string or an array of them; ` +
+          `found a non-string entry. Claude Code silently rejects the ENTIRE plugin. ${fix}`
         );
         break;
       }
       if (!entry.startsWith('./')) {
         warnings.push(
-          `plugin.json field "${field}" entry "${entry}" must be a relative path starting with "./" ` +
-          `(e.g. "./${field}/${entry}"). Claude Code rejects the entire plugin otherwise — ` +
-          `remove the field to auto-discover from ${field}/, or use relative paths.`
+          `field "${field}" entry "${entry}" must be a relative path starting with "./" ` +
+          `(e.g. "./${field}/${entry}"), not a bare name. Claude Code silently rejects the ` +
+          `ENTIRE plugin — no commands or skills load. ${fix}`
         );
         break;
       }
@@ -327,7 +336,12 @@ export function syncMarketplaceManifest(spec: MarketplaceSpec, agent: AgentId, v
     }
 
     for (const warning of validateClaudePluginManifest(manifest)) {
-      process.stderr.write(`agents-cli: plugin '${manifest.name ?? entry.name}': ${warning}\n`);
+      // Reference the plugin by name, not the marketplace-copy path: that copy is
+      // regenerated from source on every sync, so editing it gets stomped. The fix
+      // belongs in the plugin's SOURCE .claude-plugin/plugin.json.
+      process.stderr.write(
+        `agents-cli: plugin '${manifest.name ?? entry.name}' has a Claude-invalid manifest — ${warning}\n`
+      );
     }
 
     entries.push({


### PR DESCRIPTION
## What

Makes the Claude-invalid-manifest warning (added in #380) **actionable** — so a human or a coding agent that sees it on stderr can fix it without any investigation.

Before:
```
agents-cli: plugin 'code': plugin.json field "skills" entry "loop" must be a relative path starting with "./" ...
```

After:
```
agents-cli: plugin 'code' has a Claude-invalid manifest — field "skills" entry "loop" must be a relative path starting with "./" (e.g. "./skills/loop"), not a bare name. Claude Code silently rejects the ENTIRE plugin — no commands or skills load. Fix: delete the "skills" field from plugin.json (recommended — Claude auto-discovers from the skills/ directory), or rewrite every entry as a "./"-relative path (e.g. "./skills/<name>").
```

The message now states the **consequence** and a **`Fix:`** line with two concrete options.

## Why reference the plugin by name, not a path

An earlier draft printed the manifest's file path — but that was the **marketplace copy** (`.../marketplaces/<mkt>/plugins/<name>/...`), which is regenerated from source on every sync. Pointing an editor or agent at it would send the fix to a file that gets stomped on the next sync. The fix belongs in the plugin's **source** manifest, so the warning names the plugin and lets the reader locate its source.

## Verification

- `bun run build` clean; **full suite 2610 passed / 46 skipped / 0 failures** (after merging latest `main`).
- Updated unit + wiring tests assert the `Fix:` guidance is present.
- **Real CLI E2E**: `node dist/index.js plugins install <bad-plugin>` prints the full actionable message above; throwaway plugin removed afterward.

Builds on #380 / #379.
