### PR TITLE
feat(sync): expand `agents sync` into the umbrella verb (#369)

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -2,10 +2,17 @@
  * `agents sync` — synchronize central resources into an installed agent version.
  *
  * Forms:
- *   agents sync claude                                  # uses default/sole installed version
- *   agents sync claude@2.1.142                          # explicit version
- *   agents sync claude@latest                           # newest installed
+ *   agents sync                                         # umbrella: fetch remote (repos+secrets+sessions) -> reconcile all
+ *   agents sync --repos|--secrets|--sessions            # umbrella: fetch only those, then reconcile
+ *   agents sync --cloud                                 # umbrella: fetch all, skip reconcile
+ *   agents sync --local                                 # umbrella: reconcile all, no fetch
+ *   agents sync claude                                  # one agent: uses default/sole installed version
+ *   agents sync claude@2.1.142                          # one agent: explicit version
+ *   agents sync claude@latest                           # one agent: newest installed
  *   agents sync --agent claude --agent-version 2.1.142  # legacy form, still supported
+ *
+ * The umbrella stages live in lib/sync-umbrella.ts; this file dispatches to them
+ * when no agent is given.
  *
  * In a TTY the command previews available/new resources and lets the user
  * select what to sync (same prompts shown after `agents add`). Pass
@@ -44,6 +51,7 @@ import {
 import { compileRulesForProject } from '../lib/rules/compile.js';
 import { runLaunchSync } from '../lib/project-launch.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
+import { runUmbrellaSync, type UmbrellaFlags } from '../lib/sync-umbrella.js';
 
 interface SyncOpts {
   agent?: string;
@@ -54,14 +62,20 @@ interface SyncOpts {
   yes?: boolean;
   force?: boolean;
   quiet?: boolean;
+  // Umbrella-verb flags (only meaningful when no agent is given).
+  repos?: boolean;
+  secrets?: boolean;
+  sessions?: boolean;
+  cloud?: boolean;
+  local?: boolean;
 }
 
 /** Register the `agents sync` command. */
 export function registerSyncCommand(program: Command): void {
   program
     .command('sync [agentSpec]')
-    .summary('Sync resources into an installed agent version')
-    .description('Sync resources (commands, skills, hooks, rules, MCPs, plugins, etc.) into an installed agent version. Previews what will change and lets you pick.\n\n[agentSpec] is the agent name with an optional @version, e.g. "claude" or "claude@2.1.142". Omit the version to sync into the active (or sole installed) one.')
+    .summary('Make this machine current, or sync resources into one agent')
+    .description('With an [agentSpec], syncs resources (commands, skills, hooks, rules, MCPs, plugins, etc.) into that installed agent version — previews changes and lets you pick. e.g. "claude" or "claude@2.1.142".\n\nWith NO agent, runs the umbrella verb: fetch remote state (config repos + secrets + sessions) then reconcile it into every installed agent. Scope it with --repos / --secrets / --sessions, --cloud (fetch only), or --local (reconcile only).')
     .option('--agent <agent>', 'Agent identifier (legacy form; prefer the positional spec)')
     .option('--agent-version <version>', 'Version to sync into (legacy form; prefer "agent@version")')
     .option('--project-dir <path>', 'Path to project-level .agents/ directory containing project-scoped resources')
@@ -70,9 +84,69 @@ export function registerSyncCommand(program: Command): void {
     .option('-y, --yes', 'Skip the interactive preview and auto-sync all detected resources', false)
     .option('--force', 'Re-sync even if no changes are detected since the last sync', false)
     .option('--quiet', 'Suppress all output (exit code indicates success)', false)
+    // Umbrella verb (no agent given): make this machine current.
+    .option('--repos', 'Umbrella: git-pull ~/.agents + enabled ~/.agents-* extras', false)
+    .option('--secrets', 'Umbrella: pull encrypted secret bundles from the remote', false)
+    .option('--sessions', 'Umbrella: sync session transcripts across machines', false)
+    .option('--cloud', 'Umbrella: fetch all remote state but skip the local reconcile', false)
+    .option('--local', "Umbrella: reconcile resources into installed agents only (no fetch)", false)
     .action(async (agentSpec: string | undefined, opts: SyncOpts) => {
       await runSync(agentSpec, opts);
     });
+}
+
+/**
+ * The umbrella verb: bare `agents sync` (no agent) makes this machine current.
+ * Resolves the flags + a secrets passphrase (env-only for now; tokenized auth
+ * arrives with `agents login`) and runs the fetch+reconcile stages, then prints
+ * a one-line summary. Stage failures are non-fatal and surfaced as warnings.
+ */
+async function runUmbrella(
+  opts: SyncOpts,
+  quiet: boolean,
+  outLog: (msg: string) => void,
+  errLog: (msg: string) => void,
+): Promise<void> {
+  const flags: UmbrellaFlags = {
+    repos: opts.repos,
+    secrets: opts.secrets,
+    sessions: opts.sessions,
+    cloud: opts.cloud,
+    local: opts.local,
+  };
+  const passphrase = process.env.AGENTS_SECRETS_PASSPHRASE || undefined;
+
+  if (!quiet) outLog(chalk.bold('Syncing this machine…'));
+  try {
+    const result = await runUmbrellaSync({
+      flags,
+      yes: !!opts.yes,
+      passphrase,
+      log: (msg) => { if (!quiet) outLog(chalk.gray(`  ${msg}`)); },
+    });
+
+    if (!quiet) {
+      const parts: string[] = [];
+      if (result.repos) {
+        parts.push(`repos ${result.repos.pulled} pulled` +
+          (result.repos.errors.length ? `, ${result.repos.errors.length} failed` : ''));
+      }
+      if (result.secrets) {
+        parts.push(result.secrets.skipped ? 'secrets skipped' : `secrets ${result.secrets.pulled} pulled`);
+      }
+      if (result.sessions) {
+        parts.push(result.sessions.ran ? `sessions ${result.sessions.merged} merged` : 'sessions off');
+      }
+      if (result.reconciled) parts.push('reconciled');
+      outLog(chalk.green(`✓ sync: ${parts.join(' · ') || 'nothing to do'}`));
+
+      const errs = [...(result.repos?.errors ?? []), ...(result.secrets?.errors ?? [])];
+      for (const e of errs) errLog(chalk.yellow(`  ! ${e}`));
+    }
+  } catch (err) {
+    errLog(chalk.red(`sync failed: ${(err as Error).message}`));
+    process.exitCode = 1;
+  }
 }
 
 async function runSync(agentSpec: string | undefined, opts: SyncOpts): Promise<void> {
@@ -110,10 +184,9 @@ async function runSync(agentSpec: string | undefined, opts: SyncOpts): Promise<v
   }
 
   if (!agentId) {
-    errLog(chalk.red('Usage: agents sync <agent>[@version]'));
-    errLog(chalk.gray('       agents sync claude'));
-    errLog(chalk.gray('       agents sync claude@2.1.142'));
-    process.exitCode = 1;
+    // No agent specified → the umbrella verb: make this machine current
+    // (fetch repos + secrets + sessions, then reconcile all installed agents).
+    await runUmbrella(opts, quiet, outLog, errLog);
     return;
   }
 

--- a/src/lib/sync-umbrella.test.ts
+++ b/src/lib/sync-umbrella.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { planUmbrellaStages } from './sync-umbrella.js';
+
+/**
+ * The flag matrix for the umbrella `agents sync` verb. This is the bug-prone
+ * part (which stages run for which flags); the I/O executor wraps existing
+ * tested library functions.
+ */
+describe('planUmbrellaStages', () => {
+  it('bare: fetch all three, then reconcile', () => {
+    expect(planUmbrellaStages({})).toEqual({
+      fetchRepos: true, fetchSecrets: true, fetchSessions: true, reconcile: true,
+    });
+  });
+
+  it('--local: reconcile only, no fetch', () => {
+    expect(planUmbrellaStages({ local: true })).toEqual({
+      fetchRepos: false, fetchSecrets: false, fetchSessions: false, reconcile: true,
+    });
+  });
+
+  it('--local wins even if other flags are set', () => {
+    expect(planUmbrellaStages({ local: true, repos: true, cloud: true })).toEqual({
+      fetchRepos: false, fetchSecrets: false, fetchSessions: false, reconcile: true,
+    });
+  });
+
+  it('--cloud: fetch all three, skip reconcile', () => {
+    expect(planUmbrellaStages({ cloud: true })).toEqual({
+      fetchRepos: true, fetchSecrets: true, fetchSessions: true, reconcile: false,
+    });
+  });
+
+  it('single selector (--sessions): fetch only that, then reconcile', () => {
+    expect(planUmbrellaStages({ sessions: true })).toEqual({
+      fetchRepos: false, fetchSecrets: false, fetchSessions: true, reconcile: true,
+    });
+  });
+
+  it('multiple selectors: fetch exactly those, then reconcile', () => {
+    expect(planUmbrellaStages({ repos: true, secrets: true })).toEqual({
+      fetchRepos: true, fetchSecrets: true, fetchSessions: false, reconcile: true,
+    });
+  });
+
+  it('selector + --cloud: fetch only the selected, skip reconcile', () => {
+    expect(planUmbrellaStages({ repos: true, cloud: true })).toEqual({
+      fetchRepos: true, fetchSecrets: false, fetchSessions: false, reconcile: false,
+    });
+  });
+});

--- a/src/lib/sync-umbrella.ts
+++ b/src/lib/sync-umbrella.ts
@@ -1,0 +1,163 @@
+/**
+ * Umbrella `agents sync` orchestration — "make this machine current".
+ *
+ * Bare `agents sync` fetches remote state (config repos + secrets + sessions)
+ * then reconciles it into every installed agent's version home. Each stage is
+ * an existing exported library function; this module only sequences them and
+ * decides — from the flags — which stages run (`planUmbrellaStages`). The
+ * planner is pure so the flag matrix is unit-tested without any I/O.
+ *
+ * Stage backends:
+ *   repos    -> git pull of ~/.agents + enabled ~/.agents-* extras (pullRepo)
+ *   secrets  -> listRemoteBundles + pullBundle (needs a passphrase; skipped
+ *               cleanly when none is available — tokenized non-interactive auth
+ *               arrives with `agents login`, #366/#367)
+ *   sessions -> syncSessions(), gated by isSyncConfigured() exactly like the daemon
+ *   reconcile-> refresh({ skipPrompts }) — re-materialize resources into homes
+ */
+
+import { pullRepo } from './git.js';
+import { getUserAgentsDir, getEnabledExtraRepos } from './state.js';
+import { listRemoteBundles, pullBundle } from './secrets/sync.js';
+
+/** The five umbrella flags off `agents sync`. */
+export interface UmbrellaFlags {
+  repos?: boolean;
+  secrets?: boolean;
+  sessions?: boolean;
+  cloud?: boolean;
+  local?: boolean;
+}
+
+/** Which stages a given flag combination runs. */
+export interface UmbrellaPlan {
+  fetchRepos: boolean;
+  fetchSecrets: boolean;
+  fetchSessions: boolean;
+  reconcile: boolean;
+}
+
+/**
+ * Decide which stages run. Pure — no I/O. Semantics:
+ *   bare (no flags)        fetch all three, then reconcile
+ *   --local                reconcile only, no fetch
+ *   --cloud                fetch (all, or the selected subset), skip reconcile
+ *   --repos/--secrets/...  fetch only the selected types, then reconcile
+ * `--local` wins over everything; `--cloud` suppresses reconcile.
+ */
+export function planUmbrellaStages(f: UmbrellaFlags): UmbrellaPlan {
+  if (f.local) {
+    return { fetchRepos: false, fetchSecrets: false, fetchSessions: false, reconcile: true };
+  }
+  const anySelector = !!(f.repos || f.secrets || f.sessions);
+  if (anySelector) {
+    return {
+      fetchRepos: !!f.repos,
+      fetchSecrets: !!f.secrets,
+      fetchSessions: !!f.sessions,
+      reconcile: !f.cloud,
+    };
+  }
+  // No per-type selector: bare = all + reconcile; --cloud = all, no reconcile.
+  return { fetchRepos: true, fetchSecrets: true, fetchSessions: true, reconcile: !f.cloud };
+}
+
+export interface UmbrellaResult {
+  plan: UmbrellaPlan;
+  repos?: { pulled: number; errors: string[] };
+  secrets?: { pulled: number; skipped: boolean; reason?: string; errors: string[] };
+  sessions?: { ran: boolean; pushed: number; pulled: number; merged: number };
+  reconciled: boolean;
+}
+
+export interface RunUmbrellaArgs {
+  flags: UmbrellaFlags;
+  /** Progress sink (already quiet-aware in the caller). */
+  log: (msg: string) => void;
+  /** Pass `skipPrompts` through to reconcile / non-interactive behavior. */
+  yes: boolean;
+  /** Secrets passphrase, if available (env var or prompt). Undefined => skip secrets. */
+  passphrase?: string;
+}
+
+/**
+ * Execute the planned stages in order: repos -> secrets -> sessions -> reconcile.
+ * A failure in one fetch stage is recorded and does not abort the others or the
+ * reconcile — `agents sync` should make as much current as it can in one pass.
+ */
+export async function runUmbrellaSync(args: RunUmbrellaArgs): Promise<UmbrellaResult> {
+  const { flags, log, yes, passphrase } = args;
+  const plan = planUmbrellaStages(flags);
+  const result: UmbrellaResult = { plan, reconciled: false };
+
+  if (plan.fetchRepos) {
+    const dirs = [
+      { alias: 'user', dir: getUserAgentsDir() },
+      ...getEnabledExtraRepos().map((e) => ({ alias: e.alias, dir: e.dir })),
+    ];
+    let pulled = 0;
+    const errors: string[] = [];
+    for (const { alias, dir } of dirs) {
+      const r = await pullRepo(dir);
+      if (r.success) {
+        pulled++;
+        log(`repos: ${alias} → ${r.commit}`);
+      } else {
+        errors.push(`${alias}: ${r.error ?? 'unknown error'}`);
+      }
+    }
+    result.repos = { pulled, errors };
+  }
+
+  if (plan.fetchSecrets) {
+    if (!passphrase) {
+      result.secrets = {
+        pulled: 0,
+        skipped: true,
+        reason: 'no passphrase — set AGENTS_SECRETS_PASSPHRASE or run `agents login` (#366)',
+        errors: [],
+      };
+      log('secrets: skipped (no passphrase available)');
+    } else {
+      let pulled = 0;
+      const errors: string[] = [];
+      try {
+        const remote = await listRemoteBundles();
+        for (const b of remote) {
+          try {
+            await pullBundle(b.name, { passphrase, force: true });
+            pulled++;
+            log(`secrets: ${b.name}`);
+          } catch (err) {
+            errors.push(`${b.name}: ${(err as Error).message}`);
+          }
+        }
+      } catch (err) {
+        errors.push((err as Error).message);
+      }
+      result.secrets = { pulled, skipped: false, errors };
+    }
+  }
+
+  if (plan.fetchSessions) {
+    // Gate exactly like the daemon: a missing r2.backups bundle is a clean no-op,
+    // not an error that fails the whole sync.
+    const { isSyncConfigured } = await import('./session/sync/config.js');
+    if (isSyncConfigured()) {
+      const { syncSessions } = await import('./session/sync/sync.js');
+      const r = await syncSessions();
+      result.sessions = { ran: true, pushed: r.pushed, pulled: r.pulled, merged: r.merged };
+      log(`sessions: pushed ${r.pushed}, pulled ${r.pulled}, merged ${r.merged}`);
+    } else {
+      result.sessions = { ran: false, pushed: 0, pulled: 0, merged: 0 };
+    }
+  }
+
+  if (plan.reconcile) {
+    const { refresh } = await import('./refresh.js');
+    await refresh({ skipPrompts: yes });
+    result.reconciled = true;
+  }
+
+  return result;
+}


### PR DESCRIPTION
Closes #369. Part of epic #363.

## What
Bare `agents sync` previously printed a usage error. It now runs the **umbrella verb** — "make this machine current": fetch remote state (config repos + secrets + sessions) then reconcile it into every installed agent's version home.

**Backwards-compatible:** `agents sync claude[@version]` and every existing flag (`--yes/--force/--quiet/--launch/--agent/--agent-version`) are untouched; the new behavior triggers only when no agent is given.

## Surface
```
agents sync              # fetch all three -> reconcile all installed agents
agents sync --repos      # git-pull ~/.agents + enabled ~/.agents-* extras
agents sync --secrets    # pull encrypted secret bundles
agents sync --sessions   # cross-machine session transcript sync
agents sync --cloud      # fetch all, skip reconcile
agents sync --local      # reconcile only, no fetch
```

## Implementation
Reuses existing exported library functions (no subprocess spawning — matches the daemon's import-and-call pattern):
- **repos** → `pullRepo(dir)` over `getUserAgentsDir()` + `getEnabledExtraRepos()` (system repo excluded, like `agents repo pull`)
- **secrets** → `listRemoteBundles()` + `pullBundle()`, gated on a passphrase; **skipped cleanly when none** is available (tokenized non-interactive auth lands with #366/#367)
- **sessions** → `syncSessions()`, gated by `isSyncConfigured()` exactly like the daemon (absent `r2.backups` = silent no-op)
- **reconcile** → `refresh({ skipPrompts })`

Stage-selection logic is a **pure `planUmbrellaStages`** (`lib/sync-umbrella.ts`); stage failures are non-fatal (sync makes as much current as it can in one pass).

## Tests / verification
- **7 unit tests** over the full flag matrix (bare / --local / --cloud / single + multi selectors / selector+cloud). `tsc --noEmit` clean.
- `agents sync --help` shows the 5 new flags; the `agents sync claude` path is structurally unchanged (only the no-agent branch was modified).
- **Parked:** the full umbrella E2E (real `git pull` + `refresh` against the live `~/.agents`) — running unreleased sync code against the production machine is the destructive path; verify post-release with `agents sync --local` then a bare `agents sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)