### PR TITLE
fix(hooks): realpath-normalize managed prefixes so antigravity GC works through symlinks

### DIFF
--- a/src/lib/__tests__/hooks.test.ts
+++ b/src/lib/__tests__/hooks.test.ts
@@ -511,6 +511,41 @@ describe('registerHooksToSettings - Antigravity', () => {
     expect(settings.hooks.before_tool_call[0].command).toContain('a.sh');
   });
 
+  it('prunes managed entries when the hooks root is reached through a symlink (GC realpath invariant)', () => {
+    // Deterministic, cross-platform repro of the macOS bug where the managed
+    // prefix points through a symlink: isManagedHookCommand realpath-resolves
+    // the command dir, so the raw prefix must be realpath-resolved too or GC
+    // silently no-ops. Build an explicit symlinked hooks root so this fails on
+    // Linux CI too (not just where TMPDIR is /var -> /private/var).
+    const realRoot = path.join(tmpDir, 'real-agents');
+    fs.mkdirSync(path.join(realRoot, 'hooks'), { recursive: true });
+    for (const n of ['a.sh', 'b.sh']) {
+      const p = path.join(realRoot, 'hooks', n);
+      fs.writeFileSync(p, '#!/bin/sh\necho hi\n', 'utf-8');
+      fs.chmodSync(p, 0o755);
+    }
+    const linkRoot = path.join(tmpDir, 'link-agents');
+    fs.symlinkSync(realRoot, linkRoot);
+
+    const versionHome = makeAgyVersionHome();
+    const firstManifest: Record<string, ManifestHook> = {
+      a: { script: 'a.sh', events: ['PreToolUse'] },
+      b: { script: 'b.sh', events: ['PreToolUse'] },
+    };
+    registerHooksToSettings('antigravity', versionHome, firstManifest, linkRoot);
+    let settings = readAgySettings(versionHome);
+    expect(settings.hooks.before_tool_call).toHaveLength(2);
+
+    // 'b' removed upstream — must be pruned despite the symlinked managed root.
+    const secondManifest: Record<string, ManifestHook> = {
+      a: { script: 'a.sh', events: ['PreToolUse'] },
+    };
+    registerHooksToSettings('antigravity', versionHome, secondManifest, linkRoot);
+    settings = readAgySettings(versionHome);
+    expect(settings.hooks.before_tool_call).toHaveLength(1);
+    expect(settings.hooks.before_tool_call[0].command).toContain('a.sh');
+  });
+
   it('never touches user-authored entries outside managedPrefixes', () => {
     const versionHome = makeAgyVersionHome();
     const settingsPath = path.join(versionHome, '.gemini', 'antigravity-cli', 'settings.json');

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -91,6 +91,14 @@ function isManagedHookCommand(command: string, prefixes: string[]): boolean {
 
   for (const prefix of prefixes) {
     if (resolved.startsWith(prefix)) return true;
+    // The command dir above is realpath-resolved, but a raw prefix may still
+    // point through a symlink (macOS TMPDIR /var -> /private/var, or a
+    // symlinked ~/.agents). Compare against a realpath-normalized prefix too
+    // so the two sides match. Strip the trailing sep, resolve the dir, re-add.
+    const rawPrefixDir = prefix.endsWith(path.sep) ? prefix.slice(0, -path.sep.length) : prefix;
+    let resolvedPrefix = prefix;
+    try { resolvedPrefix = fs.realpathSync(rawPrefixDir) + path.sep; } catch { /* absent or broken link */ }
+    if (resolvedPrefix !== prefix && resolved.startsWith(resolvedPrefix)) return true;
   }
   return false;
 }


### PR DESCRIPTION
## Problem

`isManagedHookCommand` (`src/lib/hooks.ts`) realpath-resolves the stored command's directory but compared it against **raw, unresolved** managed prefixes. When the hooks root is reached through a symlink, the two sides never match:

- macOS TMPDIR (`/var` -> `/private/var`)
- a symlinked `~/.agents` — the agents-cli convention (`~/.agents/.history/versions/...`)

Result: every managed hook command looks user-authored, so antigravity hook GC **silently no-ops** and stale `before_tool_call` entries are never pruned when a hook is removed upstream.

## Why it shipped

Introduced by #303 (2026-05-09), which added `realpathSync(dir)` to the command side only. The existing GC test (`prunes removed managed entries on subsequent sync`) **did** catch it — but only on macOS, because it relies on the symlinked TMPDIR. Linux CI (where `/tmp` isn't a symlink) passed, so it slipped through every release since 1.20.15. It surfaced now because a strict macOS `release.sh` run (no `--skip-tests`) hit it.

## Fix

Resolve each prefix through `realpath` too before the `startsWith` check (8 lines, additive — the raw `startsWith` still runs first, so non-symlink paths and absent prefixes are unaffected).

## Test

Adds a deterministic, **cross-platform** regression test that builds an explicit symlinked hooks root, so it fails on Linux CI too — closing the gap that let this ship. Proven both ways locally (macOS):

- With fix: `hooks.test.ts` 32/32 pass
- Fix reverted: the new test fails with the exact signature (`expected length 1 but got 2`)
- Full suite (built): 2602 passed, 0 related failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)