### PR TITLE
ci: drop unbuildable Linux publish job; document local macOS release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,37 +37,18 @@ jobs:
       - name: Test
         run: bun run test
 
-  publish:
-    needs: build
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write # required for `npm publish --provenance`
-
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-
-      - name: Use Node.js 24
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Build
-        run: bun run build
-
-      - name: Test
-        run: bun run test
-
-      - name: Publish to npm
-        run: |
-          npm run prepack
-          npm publish --provenance --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  # No CI publish job — publishing happens locally on macOS via
+  # `scripts/release.sh <version> --apply`.
+  #
+  # The npm package bundles `dist/lib/secrets/Agents CLI.app` (package.json
+  # `files`), a native macOS keychain helper that must be compiled with swiftc,
+  # codesigned with the "Developer ID Application" identity, and notarized via
+  # `xcrun notarytool` (see scripts/build-keychain-helper.sh). `prepack`
+  # (scripts/verify-keychain-helper.sh) refuses to pack unless that signed
+  # binary matches the pinned sha in scripts/Agents CLI.app.sha256.
+  #
+  # GitHub-hosted and the phnx-labs self-hosted runners are Linux — they have no
+  # swiftc/codesign/notarytool and cannot produce the helper, so a CI publish
+  # would either fail at prepack or ship a macOS-broken tarball. Releasing stays
+  # on a macOS machine that holds the signed helper and the npm token. The build
+  # job above still runs on tag pushes as a sanity check.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,19 @@ scripts/install.sh --skip-tests
 
 **Bin entrypoints need `chmod 755`.** [`scripts/build.sh`](scripts/build.sh) chmods every `package.json#bin` entry after `tsc` emits. Newer npm preserves tarball file mode and does NOT auto-chmod — 644 surfaces as `zsh: permission denied: agents`. Do not skip this step.
 
+## Releasing
+
+**Releases are cut locally on macOS — there is no CI publish.** Run from a clean, in-sync `main`:
+
+```bash
+scripts/release.sh <version>          # dry-run: validates bump, type-checks, builds, tests, previews tarball
+scripts/release.sh <version> --apply  # commits chore(release), tags v<version>, npm publish, pushes
+```
+
+`release.sh` reads the npm token from the `npmjs.com` secrets bundle (`agents secrets`), so no 2FA prompt and no token on disk.
+
+**Why not CI?** The package bundles `dist/lib/secrets/Agents CLI.app` — a native keychain helper that must be compiled with `swiftc`, codesigned with the Developer ID identity, and notarized (`xcrun notarytool`); see [`scripts/build-keychain-helper.sh`](scripts/build-keychain-helper.sh). `prepack` ([`scripts/verify-keychain-helper.sh`](scripts/verify-keychain-helper.sh)) refuses to pack unless that signed binary matches the sha pinned in `scripts/Agents CLI.app.sha256`. CI runners are Linux and cannot produce it, so publishing stays on a macOS machine that holds the signed helper. The keychain helper itself is rebuilt only when [`src/lib/secrets/keychain-helper.swift`](src/lib/secrets/keychain-helper.swift) changes — rerun `scripts/build-keychain-helper.sh` (needs `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` / `APPLE_TEAM_ID`) and update the pinned sha.
+
 ## Conventions
 
 - `AGENTS.md` is canonical; `CLAUDE.md` / `GEMINI.md` are symlinks. **Edit `AGENTS.md` only.**


### PR DESCRIPTION
## Problem

The `publish` CI job (triggered on `v*` tag pushes) has **failed on every release** — `v1.20.15` (run 28079269198) and `v1.20.16` (run 28093320621) both failed identically at `npm run prepack`:

```
shasum: bin/Agents CLI.app/Contents/MacOS/Agents CLI: No such file or directory
```

It is structurally impossible to fix on the current runners. The package bundles `dist/lib/secrets/Agents CLI.app` (declared in `package.json` `files`) — a native macOS keychain helper that `scripts/build-keychain-helper.sh` compiles with `swiftc`, codesigns with the Developer ID identity, and notarizes via `xcrun notarytool`. `prepack` (`scripts/verify-keychain-helper.sh`) refuses to pack unless that signed binary matches the sha pinned in `scripts/Agents CLI.app.sha256`.

CI runners are Linux (GitHub-hosted `ubuntu-latest`; the phnx-labs self-hosted pool is `[self-hosted, linux, x64]`) — no `swiftc`/`codesign`/`notarytool`. So the job either fails at prepack (current behavior) or would ship a macOS-broken tarball.

Real releases already happen locally on macOS via `scripts/release.sh`, which builds, verifies the helper sha, and `npm publish`es. Every shipped version (incl. 1.20.16/1.20.17) went out that way.

## Change

- Remove the `publish` job from `ci.yml`. The `build`+`test` job still runs on tag pushes as a sanity check.
- Replace it with a comment documenting why there is no CI publish.
- Add a **Releasing** section to `AGENTS.md` documenting `scripts/release.sh <version> --apply` as the canonical path and the why-not-CI rationale.

Net effect: no more recurring false-alarm red "publish" runs on every tag; the release process is documented where maintainers will find it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)