### PR TITLE
fix(git): block unsafe clone transports and gate untrusted git hooks

### DIFF
--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for git source parsing and transport validation.
+ *
+ * Focus: assertSafeGitTransport must reject the transports that lead to
+ * clone-time RCE (ext::/fd:: remote helpers, option injection) or plaintext
+ * MITM (http://, git://, file://), while still allowing https/ssh/SCP and
+ * local paths. These checks are pure string logic, identical on every OS.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { assertSafeGitTransport, parseSource } from './git.js';
+
+describe('assertSafeGitTransport', () => {
+  const allowed = [
+    'https://github.com/owner/repo.git',
+    'https://gitlab.com/owner/repo',
+    'ssh://git@github.com/owner/repo.git',
+    'git@github.com:owner/repo.git', // SCP-style SSH
+    'example.com:owner/repo.git', // SCP-style without user
+    '/abs/local/path',
+    './relative/path',
+    'C:\\Users\\me\\repo', // Windows absolute path (no scheme)
+  ];
+
+  for (const src of allowed) {
+    it(`allows ${src}`, () => {
+      expect(() => assertSafeGitTransport(src)).not.toThrow();
+    });
+  }
+
+  const rejected: Array<[string, RegExp]> = [
+    ['ext::sh -c "id"', /remote-helper/],
+    ['ext::sh -c touch\\ /tmp/pwned', /remote-helper/],
+    ['fd::17/18', /remote-helper/],
+    ['-oProxyCommand=evil', /interpreted as a git option/],
+    ['--upload-pack=evil', /interpreted as a git option/],
+    ['http://example.com/repo.git', /not an allowed transport/],
+    ['git://example.com/repo.git', /not an allowed transport/],
+    ['file:///etc/passwd', /not an allowed transport/],
+  ];
+
+  for (const [src, pattern] of rejected) {
+    it(`rejects ${src}`, () => {
+      expect(() => assertSafeGitTransport(src)).toThrow(pattern);
+    });
+  }
+
+  it('ignores surrounding whitespace when classifying', () => {
+    expect(() => assertSafeGitTransport('  ext::sh -c id  ')).toThrow(/remote-helper/);
+  });
+});
+
+describe('parseSource transport safety', () => {
+  it('rejects a generic http:// URL', () => {
+    expect(() => parseSource('http://example.com/owner/repo')).toThrow(/not an allowed transport/);
+  });
+
+  it('accepts a generic https:// URL as type url', () => {
+    const parsed = parseSource('https://example.com/owner/repo');
+    expect(parsed.type).toBe('url');
+    expect(parsed.url).toBe('https://example.com/owner/repo.git');
+  });
+
+  it('upgrades an http://github.com URL to https (does not reject)', () => {
+    const parsed = parseSource('http://github.com/owner/repo');
+    expect(parsed.type).toBe('github');
+    expect(parsed.url).toBe('https://github.com/owner/repo.git');
+  });
+
+  it('keeps gh: shorthand on https', () => {
+    const parsed = parseSource('gh:owner/repo');
+    expect(parsed.type).toBe('github');
+    expect(parsed.url).toBe('https://github.com/owner/repo.git');
+  });
+});

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -13,15 +13,88 @@ import { getPackageLocalPath } from './state.js';
 import { DEFAULT_SYSTEM_REPO, systemRepoSlug } from './types.js';
 
 /**
+ * Validate that a clone/pull source uses a safe git transport before it is
+ * handed to `git`.
+ *
+ * Git's remote-helper transports (`ext::`, `fd::`, …) execute arbitrary
+ * commands at clone time, `file://`/`git://` are unauthenticated, and a source
+ * beginning with `-` is parsed by `git` as a command-line flag (option
+ * injection). We therefore allow only:
+ *   - `https://`                         (encrypted + authenticated)
+ *   - `ssh://` and SCP-style `git@host:path` / `host:path`
+ *   - local filesystem paths (callers handle these before reaching `git clone`)
+ *
+ * Pure string inspection — no filesystem or platform calls — so it behaves
+ * identically on Linux, macOS, and Windows.
+ *
+ * @throws Error if the source uses a disallowed transport.
+ */
+export function assertSafeGitTransport(source: string): void {
+  const s = source.trim();
+
+  // A leading dash is interpreted by git as an option, not a source.
+  if (s.startsWith('-')) {
+    throw new Error(
+      `Refusing to use git source "${source}": a source starting with "-" is interpreted as a git option.`,
+    );
+  }
+
+  // Remote-helper transports look like "<name>::…" (ext::, fd::, …). SCP-style
+  // "git@host:path" uses a single ":" and is intentionally not matched here.
+  const helper = s.match(/^[a-zA-Z][a-zA-Z0-9+.-]*::/);
+  if (helper) {
+    throw new Error(
+      `Refusing to use git source "${source}": git remote-helper transports (ext::, fd::, …) are not allowed.`,
+    );
+  }
+
+  // Explicit "<scheme>://" URLs: permit only https and ssh.
+  const scheme = s.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
+  if (scheme) {
+    const name = scheme[1].toLowerCase();
+    if (name !== 'https' && name !== 'ssh') {
+      throw new Error(
+        `Refusing to use git source "${source}": "${name}://" is not an allowed transport (use https:// or ssh://).`,
+      );
+    }
+  }
+  // No scheme -> SCP-style SSH ("git@host:path") or a local path; both safe.
+}
+
+/**
+ * Whether installing a cloned/pulled repo's `.githooks/` is enabled.
+ *
+ * Installing hooks wires those scripts into `.git/hooks/`, so `git` EXECUTES
+ * them on the next commit/checkout/merge. A repo added via `agents repo add
+ * <source>` is untrusted, so auto-installing its hooks is remote code
+ * execution. We require explicit opt-in via `AGENTS_ENABLE_GITHOOKS=1`.
+ */
+function githooksEnabled(): boolean {
+  const v = process.env.AGENTS_ENABLE_GITHOOKS;
+  return v === '1' || v === 'true';
+}
+
+/**
  * Install hooks from `.githooks/` by symlinking each entry into `.git/hooks/`.
  *
- * Why: `git config core.hooksPath` is a known sandbox-escape vector and is
- * blocked by some sandboxed environments (e.g. Claude Code). Symlinks inside
- * `.git/hooks/` sidestep that restriction entirely -- Git runs them the same way.
+ * Gated behind `AGENTS_ENABLE_GITHOOKS=1` (see {@link githooksEnabled}) because
+ * the hooks run code on git operations and the source repo may be untrusted.
+ *
+ * Why symlinks rather than `git config core.hooksPath`: `core.hooksPath` is a
+ * known sandbox-escape vector and is blocked by some sandboxed environments
+ * (e.g. Claude Code). Symlinks inside `.git/hooks/` run the same way.
  */
 function installGithooksSymlinks(repoDir: string): void {
   const githooksDir = path.join(repoDir, '.githooks');
   if (!fs.existsSync(githooksDir)) return;
+
+  if (!githooksEnabled()) {
+    console.error(
+      `Skipped installing git hooks from ${githooksDir} (they run code on git operations).\n` +
+        `  Set AGENTS_ENABLE_GITHOOKS=1 to enable hooks for repos you trust.`,
+    );
+    return;
+  }
 
   const hooksDir = path.join(repoDir, '.git', 'hooks');
   fs.mkdirSync(hooksDir, { recursive: true });
@@ -137,7 +210,9 @@ export function parseSource(source: string): GitSource {
       };
     }
 
-    // Generic URL
+    // Generic URL -- must be an encrypted, authenticated transport
+    // (rejects http://, file://, git://, ext::, and leading "-").
+    assertSafeGitTransport(cleanSource);
     return {
       type: 'url',
       url: cleanSource.endsWith('.git') ? cleanSource : `${cleanSource}.git`,
@@ -214,6 +289,7 @@ export async function cloneOrPull(
     return { isNew: false, commit: log.latest?.hash.slice(0, 8) || 'unknown' };
   }
 
+  assertSafeGitTransport(source.url);
   fs.mkdirSync(targetDir, { recursive: true });
   await git.clone(source.url, targetDir);
 
@@ -426,6 +502,7 @@ export async function cloneIntoExisting(
   const tempDir = path.join(targetDir, '.git-clone-temp');
 
   try {
+    assertSafeGitTransport(parsed.url);
     // Clone to temp directory
     fs.mkdirSync(tempDir, { recursive: true });
     await git.clone(parsed.url, tempDir);

--- a/src/lib/plugins.test.ts
+++ b/src/lib/plugins.test.ts
@@ -640,7 +640,7 @@ describe('installPlugin validation', () => {
     'evil; rm -rf /tmp/SHOULD_NOT_DELETE',
     '$(touch /tmp/SHOULD_NOT_EXIST)',
     '`touch /tmp/SHOULD_NOT_EXIST`',
-  ])('passes git clone input through execFileSync argv form: %s', async (source) => {
+  ])('passes git clone input through execFileSync argv form after "--": %s', async (source) => {
     const { installPlugin } = await import('./plugins.js');
 
     await expect(installPlugin(`safe@${source}`)).rejects.toThrow('Installed source has no valid .claude-plugin/plugin.json');
@@ -648,9 +648,23 @@ describe('installPlugin validation', () => {
     expect(execFileSyncMock).toHaveBeenCalledOnce();
     const [bin, args, opts] = execFileSyncMock.mock.calls[0];
     expect(bin).toBe('git');
-    expect(args.slice(0, 4)).toEqual(['clone', '--depth', '1', source]);
-    expect(args[4]).toMatch(/\/safe$/);
+    // "--" separates options from operands so the source can never be parsed
+    // as a git flag; the metacharacters above are inert in argv form.
+    expect(args.slice(0, 4)).toEqual(['clone', '--depth', '1', '--']);
+    expect(args[4]).toBe(source);
+    expect(args[5]).toMatch(/\/safe$/);
     expect(opts).toEqual({ stdio: 'pipe' });
+  });
+
+  it.each([
+    'ext::sh -c id',
+    '-oProxyCommand=evil',
+    'http://example.com/repo.git',
+  ])('rejects unsafe git transport before cloning: %s', async (source) => {
+    const { installPlugin } = await import('./plugins.js');
+
+    await expect(installPlugin(`safe@${source}`)).rejects.toThrow(/Refusing to use git source/);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
   });
 
   it('rejects path-traversal plugin names before copying a local source', async () => {

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -15,6 +15,7 @@ import { execFileSync } from 'child_process';
 import type { AgentId, DiscoveredPlugin, PluginManifest, MarketplaceSpec } from './types.js';
 import { getPluginsDir, getTrashPluginsDir, getExtraPluginsDir, getProjectPluginsDir } from './state.js';
 import { IS_WINDOWS, isWindowsAbsolutePath, homeDir } from './platform/index.js';
+import { assertSafeGitTransport } from './git.js';
 import { listInstalledVersions, getVersionHomePath } from './versions.js';
 import { AGENTS, agentConfigDirName } from './agents.js';
 import { capableAgents, isCapable } from './capabilities.js';
@@ -1205,11 +1206,13 @@ export async function installPlugin(spec: string): Promise<{ name: string; root:
     }
     fs.cpSync(resolvedSource, targetRoot, { recursive: true });
   } else {
-    // Git clone
+    // Git clone. Validate the transport (blocks ext::/file:///http:///leading-"-")
+    // and pass "--" so the source can never be parsed as a git option.
+    assertSafeGitTransport(resolvedSource);
     if (fs.existsSync(targetRoot)) {
       fs.rmSync(targetRoot, { recursive: true, force: true });
     }
-    execFileSync('git', ['clone', '--depth', '1', resolvedSource, targetRoot], {
+    execFileSync('git', ['clone', '--depth', '1', '--', resolvedSource, targetRoot], {
       stdio: 'pipe',
     });
   }


### PR DESCRIPTION
## Summary

Three related supply-chain hardening fixes for git clone/pull paths. All are cross-platform (Linux/macOS/Windows) — the new logic is pure string inspection + an env-var check, with no platform-specific calls.

These came out of a security review of the clone/pull surface. Sandboxing was explicitly out of scope; these are the RCE/MITM-class issues that stand on their own.

### 1. Plugin clone — arbitrary transport + option injection → RCE
`installPlugin` passed its raw source straight to `git clone`. A spec like `agents plugins install name@ext::sh -c "id"` executed arbitrary commands at clone time (git remote-helper transport), and a source starting with `-` was option-injected — both *before* the manifest trust gate.
**Fix:** new shared `assertSafeGitTransport()` + a `--` separator before the source.

### 2. `parseSource` accepted plaintext `http://` → MITM
Generic (non-GitHub) `http://` URLs were cloned and their skills/hooks/MCP executed.
**Fix:** route generic URLs through `assertSafeGitTransport` (rejects `http://`, `file://`, `git://`, `ext::`/`fd::`, leading `-`; allows `https`/`ssh`/SCP-style + local). Re-validated at both `git.clone` call sites (`cloneOrPull`, `cloneIntoExisting`) as defense in depth.

### 3. Auto-installed git hooks from cloned repos → RCE
Cloning/pulling any repo auto-symlinked its `.githooks/` into `.git/hooks/` (the code comment notes this deliberately bypasses `core.hooksPath` sandboxing). So `agents repo add gh:attacker/repo` ran attacker code on the next commit/checkout/merge.
**Fix:** gate hook installation behind explicit opt-in `AGENTS_ENABLE_GITHOOKS=1`; otherwise skip with a clear notice.

## Behavior changes
- Generic `http://` and other non-https/ssh transports are now rejected for `add`/`repo add`/plugin install. GitHub `http://` URLs are still auto-upgraded to `https://` as before.
- Repo `.githooks/` are no longer installed unless `AGENTS_ENABLE_GITHOOKS=1` is set.

## Testing
- New `src/lib/git.test.ts`: transport allow/deny matrix + `parseSource` safety.
- Extended `src/lib/plugins.test.ts`: clone argv now expects `--`; added unsafe-transport rejection cases.
- Full suite: **2679 passed, 46 skipped, 0 failed**.
- Verified end-to-end with a **real git repo** (no mocks): gate off skips hooks (emits notice), gate on installs them; transport guard blocks `ext::`/leading-dash/`http://`, allows https + SCP-SSH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)