### PR TITLE
feat(run): autonomous loop driver + checkpoint/resume (#332)

### DIFF
--- a/docs/07-entrypoints-and-loops.md
+++ b/docs/07-entrypoints-and-loops.md
@@ -2,7 +2,7 @@
 
 The unifying model behind plugins, workflows, routines, and loops: two axes — one for packaging, one for invocation.
 
-> **Status: design direction.** The resources-vs-entrypoints split (see [00-concepts.md](00-concepts.md)) is current. The unification below — plugins packaging workflows, per-routine plugin scoping, unified `run` dispatch, and the `loop` block — is proposed and only partly implemented. The [Today vs. proposed](#today-vs-proposed) table marks each item.
+> **Status: design direction.** The resources-vs-entrypoints split (see [00-concepts.md](00-concepts.md)) is current. The unification below — plugins packaging workflows, per-routine plugin scoping, unified `run` dispatch — is proposed and only partly implemented. **The `loop` block ships** (`agents run --loop` + `--resume-checkpoint`, issue #332): the driver, the four guard fields, and harness-level checkpoint/resume are live. The [Today vs. proposed](#today-vs-proposed) table marks each item.
 
 ---
 
@@ -109,6 +109,42 @@ Rule of thumb: omit qualifiers until there is a collision; qualify `type` when t
 
 Without `loop:`, a routine fires its entrypoint once per cadence — the current behavior. With `loop:`, each fire runs the entrypoint until the condition is met or a guard trips. Exit reasons mirror the teams supervisor (`condition-met | budget | stalled | max | signal`).
 
+### Running a loop today (`agents run --loop`)
+
+The loop driver ships as additive flags on `agents run` (issue #332). The CLI verb is **`agents run --loop`** — not a separate `agents loop` command.
+
+```bash
+# Re-inject a prompt back-to-back, up to 5 turns, stopping early on the signal,
+# with a 100k-token hard cap enforced OUTSIDE the agent.
+agents run claude "drive the migration to green" \
+  --loop --until signal --max-iterations 5 --budget 100000 --interval 0 --mode skip
+```
+
+| Flag | Maps to | Meaning |
+|------|---------|---------|
+| `--loop` | activate | Re-inject the prompt/entrypoint each iteration until a stop condition. |
+| `--max-iterations <n>` | `max_iterations` | Hard cap on iterations (`stoppedBy: max`). |
+| `--budget <tokens>` | `budget` | Cumulative-token hard cap (`stoppedBy: budget`), enforced outside the agent. |
+| `--until signal` | `until` | Read `<runDir>/loop-signal.json` each turn; absent or `continue:false` stops (`stoppedBy: condition-met`, fail-closed). |
+| `--interval <dur>` | `interval` | Delay between iterations (`0` back-to-back, `30m` paces). |
+| `--resume-checkpoint <file>` | resume | Continue a killed run from its `checkpoint.json`. |
+
+**Each iteration** spawns one headless turn (`--json` stream). Iteration 2+ pins the same `--session-id` so the agent resumes its conversation; the prompt is re-injected every turn. The driver exposes the signal path to the entrypoint via the `AGENTS_LOOP_SIGNAL` env var (plus `AGENTS_RUN_DIR` and `AGENTS_LOOP_ITERATION`) — the agent writes its `{continue, reason}` vote there; the driver, OUTSIDE the agent, decides whether to continue.
+
+A workflow may declare a `loop:` block in its WORKFLOW.md frontmatter; `agents run <workflow>` then honors it **without** a `--loop` flag. CLI flags override the workflow's declared fields one-by-one.
+
+### Checkpoint / resume
+
+The driver writes `<runsDir>/<runId>/checkpoint.json` **after every iteration** (atomic temp+rename) and inside the SIGINT/SIGTERM handler. The checkpoint records `{ id, agent, version, prompt, sessionId, iteration, loop, loopSignal, cumulativeTokens }` — the harness state a kill would otherwise destroy. This is distinct from `--session-id`, which resumes only the provider-side *conversation*; the checkpoint resumes the *harness* (iteration count, prompt chain, token tally).
+
+```bash
+# A SIGTERM/timeout/machine-sleep killed the run mid-loop. Continue from the
+# last completed iteration — same runId, same session, carried token count.
+agents run claude --resume-checkpoint ~/.agents/.history/runs/<runId>/checkpoint.json --max-iterations 10
+```
+
+Resume reuses the checkpoint's loop config but lets the resume command **raise** the bounds field-by-field (e.g. a higher `--max-iterations`) so "continue, run more" is one gesture.
+
 ---
 
 ## Today vs. proposed
@@ -124,7 +160,8 @@ Without `loop:`, a routine fires its entrypoint once per cadence — the current
 | Workflow frontmatter `model` / `tools` / `mcpServers` / `allowedAgents` enforced | yes (Claude) — `model` → `--model`, `tools` → `--tools` (restricts available tools), `mcpServers` → ephemeral `--mcp-config` + `--strict-mcp-config` (only named servers), `allowedAgents` → only listed subagent definitions copied into the run; unenforceable declarations warn, never silently drop | yes |
 | `run` target qualifiers | n/a — auto-detect (agent > profile > workflow) | `[<type>:]<name>[@<source>]` |
 | Loop a workflow on a *cadence* | yes — routine with `workflow:` | — |
-| Loop an entrypoint *until a condition* | no | `loop:` block / `agents loop <entrypoint>` |
+| Loop an entrypoint *until a condition* | **shipped** — `agents run --loop` + workflow `loop:` frontmatter (issue #332) | — |
+| Harness checkpoint / resume a killed loop | **shipped** — `checkpoint.json` after every iteration; `agents run --resume-checkpoint <file>` | — |
 
 ---
 

--- a/docs/07-entrypoints-and-loops.md
+++ b/docs/07-entrypoints-and-loops.md
@@ -126,20 +126,21 @@ agents run claude "drive the migration to green" \
 | `--max-iterations <n>` | `max_iterations` | Hard cap on iterations (`stoppedBy: max`). |
 | `--budget <tokens>` | `budget` | Cumulative-token hard cap (`stoppedBy: budget`), enforced outside the agent. |
 | `--until signal` | `until` | Read `<runDir>/loop-signal.json` each turn; absent or `continue:false` stops (`stoppedBy: condition-met`, fail-closed). |
-| `--interval <dur>` | `interval` | Delay between iterations (`0` back-to-back, `30m` paces). |
+| `--interval <dur>` | `interval` | Delay between iterations (`0` back-to-back, `30m` paces). Units `w/d/h/m` — `30s` and bare numbers are rejected at config build, never silently run full-speed. |
 | `--resume-checkpoint <file>` | resume | Continue a killed run from its `checkpoint.json`. |
 
-**Each iteration** spawns one headless turn (`--json` stream). Iteration 2+ pins the same `--session-id` so the agent resumes its conversation; the prompt is re-injected every turn. The driver exposes the signal path to the entrypoint via the `AGENTS_LOOP_SIGNAL` env var (plus `AGENTS_RUN_DIR` and `AGENTS_LOOP_ITERATION`) — the agent writes its `{continue, reason}` vote there; the driver, OUTSIDE the agent, decides whether to continue.
+**Each iteration** spawns one headless turn (`--json` stream) and **pins its own fresh `--session-id`** — `--session-id` *creates* a session, so re-passing one errors `Session ID already in use`. To carry conversation memory forward, iteration 2+ injects the established `/continue <prior session id>` directive (the same mechanism the rate-limit fallback chain uses) ahead of the re-injected entrypoint, so the agent recalls the prior turn before doing this iteration's work. Cross-iteration continuity applies to **claude only**; other agents run each iteration as an independent fresh conversation (the driver warns when `--loop` is paired with a non-claude agent). The driver exposes the signal path to the entrypoint via the `AGENTS_LOOP_SIGNAL` env var (plus `AGENTS_RUN_DIR` and `AGENTS_LOOP_ITERATION`) — the agent writes its `{continue, reason}` vote there; the driver, OUTSIDE the agent, decides whether to continue.
 
 A workflow may declare a `loop:` block in its WORKFLOW.md frontmatter; `agents run <workflow>` then honors it **without** a `--loop` flag. CLI flags override the workflow's declared fields one-by-one.
 
 ### Checkpoint / resume
 
-The driver writes `<runsDir>/<runId>/checkpoint.json` **after every iteration** (atomic temp+rename) and inside the SIGINT/SIGTERM handler. The checkpoint records `{ id, agent, version, prompt, sessionId, iteration, loop, loopSignal, cumulativeTokens }` — the harness state a kill would otherwise destroy. This is distinct from `--session-id`, which resumes only the provider-side *conversation*; the checkpoint resumes the *harness* (iteration count, prompt chain, token tally).
+The driver writes `<runsDir>/<runId>/checkpoint.json` **after every iteration** (atomic temp+rename) and inside the SIGINT/SIGTERM handler. The checkpoint records `{ id, agent, version, prompt, sessionId, iteration, loop, loopSignal, cumulativeTokens }` — the harness state a kill would otherwise destroy. `sessionId` is the **last completed iteration's** session id; resume threads the *conversation* forward by `/continue`-ing from it, while the rest of the checkpoint resumes the *harness* (iteration count, prompt chain, token tally).
 
 ```bash
 # A SIGTERM/timeout/machine-sleep killed the run mid-loop. Continue from the
-# last completed iteration — same runId, same session, carried token count.
+# last completed iteration — same runId, /continue from the last session,
+# carried token count.
 agents run claude --resume-checkpoint ~/.agents/.history/runs/<runId>/checkpoint.json --max-iterations 10
 ```
 

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -172,6 +172,33 @@ agents run claude "generate sales report" --timeout 30m
 agents run claude "..." --timeout 2h30m
 ```
 
+## Autonomous loop (`--loop`) + checkpoint/resume
+
+`--loop` re-injects the prompt each iteration until a stop condition. The driver is deterministic; the agent inside stays free to spawn subagents. Every guard runs OUTSIDE the agent — the agent cannot vote past a kill-switch.
+
+```bash
+# Re-inject up to 5 turns, stop early on the agent's signal, 100k-token hard cap.
+agents run claude "drive the migration to green" \
+  --loop --until signal --max-iterations 5 --budget 100000 --interval 0 --mode skip
+```
+
+| Loop flag | Stop reason | Meaning |
+|-----------|-------------|---------|
+| `--max-iterations <n>` | `max` | Hard cap on iterations. |
+| `--budget <tokens>` | `budget` | Cumulative-token cap, enforced outside the agent (exit 7). |
+| `--until signal` | `condition-met` | Reads `<runDir>/loop-signal.json` `{continue,reason}` each turn; absent or `continue:false` stops (fail-closed). |
+| `--interval <dur>` | — | Delay between turns (`0` back-to-back, `30m` paces). |
+
+Iteration 2+ pins the same `--session-id` so the conversation resumes; the prompt is re-injected every turn. The driver hands the entrypoint `AGENTS_LOOP_SIGNAL` (path to write its `{continue, reason}` vote), `AGENTS_RUN_DIR`, and `AGENTS_LOOP_ITERATION`.
+
+**Checkpoint/resume.** A `checkpoint.json` is written under `~/.agents/.history/runs/<runId>/` after every iteration (and on SIGINT/SIGTERM). Resume a killed run:
+
+```bash
+agents run claude --resume-checkpoint ~/.agents/.history/runs/<runId>/checkpoint.json --max-iterations 10
+```
+
+Resume continues from the last completed iteration with the same runId, session id, prompt, and carried token count. CLI loop flags on a resume RAISE the checkpoint's bounds (e.g. a higher `--max-iterations`), so "continue, run more" is one command. This is harness state — distinct from `--session-id`, which only resumes the provider-side conversation.
+
 ## Budget guardrails (pre-flight estimate + hard kill)
 
 When a `budget:` block is configured in `agents.yaml` (project > user), every
@@ -244,6 +271,12 @@ Emits a unified event stream; ndjson when combined with `--json`.
 | `--verbose` | Detailed logs |
 | `--timeout 30m` | Kill after duration |
 | `--session-id <id>` | Resume conversation (Claude) |
+| `--loop` | Re-inject the prompt until a stop condition |
+| `--max-iterations <n>` | Loop iteration hard cap (`stoppedBy: max`) |
+| `--budget <tokens>` | Loop cumulative-token cap (`stoppedBy: budget`) |
+| `--until signal` | Loop stops on `loop-signal.json` `{continue:false}` / absent (fail-closed) |
+| `--interval <dur>` | Loop delay between iterations (`0` back-to-back) |
+| `--resume-checkpoint <file>` | Resume a killed loop from its `checkpoint.json` |
 | `--fallback codex,gemini` | Rate-limit fallback chain |
 | `-b, --balanced` | Shortcut for `--strategy balanced` |
 | `--strategy pinned\|available\|balanced` | Version selection |

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -187,9 +187,9 @@ agents run claude "drive the migration to green" \
 | `--max-iterations <n>` | `max` | Hard cap on iterations. |
 | `--budget <tokens>` | `budget` | Cumulative-token cap, enforced outside the agent (exit 7). |
 | `--until signal` | `condition-met` | Reads `<runDir>/loop-signal.json` `{continue,reason}` each turn; absent or `continue:false` stops (fail-closed). |
-| `--interval <dur>` | — | Delay between turns (`0` back-to-back, `30m` paces). |
+| `--interval <dur>` | — | Delay between turns (`0` back-to-back, `30m` paces; units `w/d/h/m`, `30s`/bare numbers rejected). |
 
-Iteration 2+ pins the same `--session-id` so the conversation resumes; the prompt is re-injected every turn. The driver hands the entrypoint `AGENTS_LOOP_SIGNAL` (path to write its `{continue, reason}` vote), `AGENTS_RUN_DIR`, and `AGENTS_LOOP_ITERATION`.
+Each iteration pins its **own fresh `--session-id`** (`--session-id` *creates* a session — re-passing one errors `Session ID already in use`). To carry memory forward, iteration 2+ prepends `/continue <prior session id>` to the re-injected prompt so the agent recalls the prior turn first. Continuity is **claude-only**; other agents loop as independent fresh conversations (the driver warns). The driver hands the entrypoint `AGENTS_LOOP_SIGNAL` (path to write its `{continue, reason}` vote), `AGENTS_RUN_DIR`, and `AGENTS_LOOP_ITERATION`.
 
 **Checkpoint/resume.** A `checkpoint.json` is written under `~/.agents/.history/runs/<runId>/` after every iteration (and on SIGINT/SIGTERM). Resume a killed run:
 
@@ -197,7 +197,7 @@ Iteration 2+ pins the same `--session-id` so the conversation resumes; the promp
 agents run claude --resume-checkpoint ~/.agents/.history/runs/<runId>/checkpoint.json --max-iterations 10
 ```
 
-Resume continues from the last completed iteration with the same runId, session id, prompt, and carried token count. CLI loop flags on a resume RAISE the checkpoint's bounds (e.g. a higher `--max-iterations`), so "continue, run more" is one command. This is harness state — distinct from `--session-id`, which only resumes the provider-side conversation.
+Resume continues from the last completed iteration with the same runId, prompt, and carried token count; the first resumed iteration `/continue`s from the checkpoint's recorded session id (the last completed iteration's). CLI loop flags on a resume RAISE the checkpoint's bounds (e.g. a higher `--max-iterations`), so "continue, run more" is one command.
 
 ## Budget guardrails (pre-flight estimate + hard kill)
 

--- a/skills/workflows/SKILL.md
+++ b/skills/workflows/SKILL.md
@@ -177,9 +177,27 @@ mcpServers:                 # MCP servers to enable — ENFORCED (Claude, --stri
 allowedAgents:              # subagents the orchestrator may dispatch to — ENFORCED (Claude, file filter)
   - security
   - correctness
+loop:                       # optional autonomous loop (issue #332)
+  until: signal             #   stop when loop-signal.json says continue:false (absent = fail-closed)
+  max_iterations: 3         #   hard cap on iterations
+  budget: 500000            #   cumulative-token hard cap, enforced outside the agent
+  interval: "0"             #   delay between iterations ("0" back-to-back, "30m" paces)
 ```
 
 All fields are optional. A workflow with no frontmatter beyond `---` fences still works — the Markdown body alone is enough.
+
+### Looping a workflow (`loop:` block)
+
+A `loop:` block wraps the workflow in a bounded until-condition loop. `agents run <workflow>` then re-injects the orchestrator each iteration **without a `--loop` flag** — the declared block is honored automatically. CLI loop flags (`--max-iterations`, `--budget`, `--until`, `--interval`) override the declared fields one-by-one.
+
+| Field | Stop reason | Meaning |
+|---|---|---|
+| `until: signal` | `condition-met` | Reads `<runDir>/loop-signal.json` `{continue,reason}` each turn; absent or `continue:false` stops (fail-closed). The orchestrator writes its vote to the path in `AGENTS_LOOP_SIGNAL`. |
+| `max_iterations: <n>` | `max` | Hard cap on iterations. |
+| `budget: <tokens>` | `budget` | Cumulative-token cap, enforced OUTSIDE the agent (the agent cannot vote past it). |
+| `interval: "<dur>"` | — | Delay between iterations. |
+
+A malformed `loop:` field (bad `until`, non-positive `max_iterations`/`budget`, non-string `interval`) is dropped defensively rather than passed to the driver — same discipline as the `tools:`/`mcpServers:` coercion. A `checkpoint.json` is written after every iteration; resume a killed run with `agents run <workflow> --resume-checkpoint <file>`. See [docs/07-entrypoints-and-loops.md](../../docs/07-entrypoints-and-loops.md) for the full loop model.
 
 ### Scoping & security (enforced at run time, Claude)
 

--- a/src/commands/exec-loop.test.ts
+++ b/src/commands/exec-loop.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { buildLoopConfig, loopExitCode } from './exec.js';
+
+describe('buildLoopConfig — flag/frontmatter merge (issue #332)', () => {
+  it('returns undefined for a plain run (no --loop, no workflow loop)', () => {
+    expect(buildLoopConfig({})).toBeUndefined();
+  });
+
+  it('activates a bare loop on --loop alone (driver applies its own cap)', () => {
+    expect(buildLoopConfig({ loop: true })).toEqual({});
+  });
+
+  it('activates from a workflow loop block even without --loop', () => {
+    expect(buildLoopConfig({}, { max_iterations: 3 })).toEqual({ maxIterations: 3 });
+  });
+
+  it('translates snake_case workflow fields to the camelCase driver config', () => {
+    expect(buildLoopConfig({}, { until: 'signal', max_iterations: 5, budget: 100, interval: '30m' }))
+      .toEqual({ until: 'signal', maxIterations: 5, budget: 100, interval: '30m' });
+  });
+
+  it('CLI flags override workflow values field-by-field', () => {
+    const cfg = buildLoopConfig(
+      { loop: true, maxIterations: '7', budget: '999' },
+      { max_iterations: 3, budget: 100, interval: '10m' },
+    );
+    // CLI wins for max_iterations and budget; interval falls through from workflow.
+    expect(cfg).toEqual({ maxIterations: 7, budget: 999, interval: '10m' });
+  });
+
+  it('rejects an invalid --until', () => {
+    expect(() => buildLoopConfig({ loop: true, until: 'forever' })).toThrow(/Only 'signal'/);
+  });
+
+  it('rejects a non-positive --max-iterations', () => {
+    expect(() => buildLoopConfig({ loop: true, maxIterations: '0' })).toThrow(/positive integer/);
+    expect(() => buildLoopConfig({ loop: true, maxIterations: 'abc' })).toThrow(/positive integer/);
+  });
+
+  it('rejects a non-positive --budget', () => {
+    expect(() => buildLoopConfig({ loop: true, budget: '-5' })).toThrow(/positive token/);
+  });
+});
+
+describe('loopExitCode', () => {
+  it('maps clean stops to 0', () => {
+    expect(loopExitCode('condition-met')).toBe(0);
+    expect(loopExitCode('max')).toBe(0);
+  });
+
+  it('maps budget to 7 (matches BUDGET_KILL_EXIT_CODE)', () => {
+    expect(loopExitCode('budget')).toBe(7);
+  });
+
+  it('maps signal to 130 and error/stalled to 1', () => {
+    expect(loopExitCode('signal')).toBe(130);
+    expect(loopExitCode('error')).toBe(1);
+    expect(loopExitCode('stalled')).toBe(1);
+  });
+});

--- a/src/commands/exec-loop.test.ts
+++ b/src/commands/exec-loop.test.ts
@@ -40,6 +40,20 @@ describe('buildLoopConfig — flag/frontmatter merge (issue #332)', () => {
   it('rejects a non-positive --budget', () => {
     expect(() => buildLoopConfig({ loop: true, budget: '-5' })).toThrow(/positive token/);
   });
+
+  it('accepts "0" and valid durations for --interval', () => {
+    expect(buildLoopConfig({ loop: true, interval: '0' })).toEqual({ interval: '0' });
+    expect(buildLoopConfig({ loop: true, interval: '30m' })).toEqual({ interval: '30m' });
+    expect(buildLoopConfig({ loop: true, interval: '2h30m' })).toEqual({ interval: '2h30m' });
+  });
+
+  it('rejects an unparseable --interval instead of silently running back-to-back (FIX 3)', () => {
+    // Before: parseTimeout returned null for these and the driver coalesced to
+    // 0ms, so a typo ran the loop full-speed. Now they're rejected at config build.
+    expect(() => buildLoopConfig({ loop: true, interval: '30s' })).toThrow(/Invalid --interval/);
+    expect(() => buildLoopConfig({ loop: true, interval: '5' })).toThrow(/Invalid --interval/);
+    expect(() => buildLoopConfig({ loop: true, interval: 'abc' })).toThrow(/Invalid --interval/);
+  });
 });
 
 describe('loopExitCode', () => {

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -39,6 +39,12 @@ interface ExecCommandActionOptions {
   strategy?: string;
   acp?: boolean;
   yes?: boolean;
+  loop?: boolean;
+  resumeCheckpoint?: string;
+  maxIterations?: string;
+  budget?: string;
+  until?: string;
+  interval?: string;
 }
 
 /** Type guard that narrows a string to a known AgentId. */
@@ -52,6 +58,81 @@ function formatRotationBanner(result: RotateResult, verb: string = 'balanced'): 
   const label = picked.email ? `${picked.email} · ${picked.agent}@${picked.version}` : `${picked.agent}@${picked.version}`;
   const ratio = `${healthy.length} of ${healthy.length + excluded.length} healthy`;
   return `[agents] ${verb} picked ${label} (${ratio})`;
+}
+
+/**
+ * Build the LoopConfig the driver consumes from CLI flags and/or a workflow's
+ * `loop:` frontmatter block (issue #332). Returns undefined when neither source
+ * activates a loop (the common single-shot run). CLI flags take precedence over
+ * the workflow's declared values field-by-field, so `--max-iterations 5`
+ * overrides a workflow's `max_iterations: 3`.
+ *
+ * `--loop` with no sub-options is a valid bare loop (driver applies its own
+ * maxIterations safety cap). A workflow `loop:` block activates a loop even
+ * without `--loop` so `agents run <workflow>` honors a declared loop.
+ */
+export function buildLoopConfig(
+  flags: { loop?: boolean; maxIterations?: string; budget?: string; until?: string; interval?: string },
+  workflowLoop?: import('../lib/workflows.js').LoopConfigRaw,
+): import('../lib/loop.js').LoopConfig | undefined {
+  const active = flags.loop === true || workflowLoop !== undefined;
+  if (!active) return undefined;
+
+  const cfg: import('../lib/loop.js').LoopConfig = {};
+
+  // until: CLI > workflow. Only `signal` is supported.
+  const until = flags.until ?? workflowLoop?.until;
+  if (until !== undefined) {
+    if (until !== 'signal') {
+      throw new Error(`Invalid --until '${until}'. Only 'signal' is supported.`);
+    }
+    cfg.until = 'signal';
+  }
+
+  // max_iterations: CLI > workflow.
+  if (flags.maxIterations !== undefined) {
+    const n = Number(flags.maxIterations);
+    if (!Number.isInteger(n) || n <= 0) {
+      throw new Error(`Invalid --max-iterations '${flags.maxIterations}'. Use a positive integer.`);
+    }
+    cfg.maxIterations = n;
+  } else if (workflowLoop?.max_iterations !== undefined) {
+    cfg.maxIterations = workflowLoop.max_iterations;
+  }
+
+  // budget (tokens): CLI > workflow.
+  if (flags.budget !== undefined) {
+    const b = Number(flags.budget);
+    if (!Number.isFinite(b) || b <= 0) {
+      throw new Error(`Invalid --budget '${flags.budget}'. Use a positive token count.`);
+    }
+    cfg.budget = b;
+  } else if (workflowLoop?.budget !== undefined) {
+    cfg.budget = workflowLoop.budget;
+  }
+
+  // interval: CLI > workflow.
+  const interval = flags.interval ?? workflowLoop?.interval;
+  if (interval !== undefined) cfg.interval = interval;
+
+  return cfg;
+}
+
+/** Map a loop stop reason to a process exit code. condition-met/max are clean exits. */
+export function loopExitCode(stoppedBy: import('../lib/loop.js').LoopStoppedBy): number {
+  switch (stoppedBy) {
+    case 'condition-met':
+    case 'max':
+      return 0;
+    case 'budget':
+      return 7; // mirrors BUDGET_KILL_EXIT_CODE so CI can tell a budget stop apart
+    case 'signal':
+      return 130; // 128 + SIGINT(2)
+    case 'stalled':
+    case 'error':
+    default:
+      return 1;
+  }
 }
 
 /** Register the `agents run <agent> [prompt]` command. */
@@ -112,6 +193,30 @@ export function registerRunCommand(program: Command): void {
       '-y, --yes',
       'Skip the interactive budget-confirm prompt (require_confirm_over). Never skips a hard budget block.',
       false,
+    )
+    .option(
+      '--loop',
+      'Re-inject the prompt/entrypoint each iteration until a stop condition (issue #332). Guards (--max-iterations, --budget, --until) are enforced outside the agent. Writes a checkpoint after every iteration for --resume-checkpoint.',
+    )
+    .option(
+      '--resume-checkpoint <file>',
+      'Resume a killed loop run from its checkpoint.json. Continues from the last completed iteration, reusing the same runId, session id, prompt, and loop config.',
+    )
+    .option(
+      '--max-iterations <n>',
+      'Loop hard cap: stop after N iterations (stoppedBy: max). Loop only.',
+    )
+    .option(
+      '--budget <tokens>',
+      'Loop token hard-cap: stop once cumulative tokens reach this (stoppedBy: budget), enforced outside the agent. Loop only.',
+    )
+    .option(
+      '--until <signal>',
+      'Loop stop condition. `signal` reads <runDir>/loop-signal.json {continue,reason} each iteration; absent or continue:false stops (fail-closed). Loop only.',
+    )
+    .option(
+      '--interval <dur>',
+      'Loop delay between iterations ("0" back-to-back, "30m" paces). Loop only.',
     );
 
   setHelpSections(runCmd, {
@@ -155,6 +260,76 @@ export function registerRunCommand(program: Command): void {
   });
 
   runCmd.action(async (agentSpec: string, prompt: string | undefined, options: ExecCommandActionOptions) => {
+      // --resume-checkpoint short-circuits normal dispatch entirely: the
+      // checkpoint already carries the agent, version, prompt, session id,
+      // iteration, and loop config of the killed run. Reconstruct ExecOptions
+      // straight from it and continue the loop from the last completed
+      // iteration, reusing the SAME runId/runDir (issue #332).
+      if (options.resumeCheckpoint) {
+        const { readCheckpoint } = await import('../lib/checkpoint.js');
+        const { runLoop } = await import('../lib/loop.js');
+        const { getRunsDir } = await import('../lib/state.js');
+        const cp = readCheckpoint(options.resumeCheckpoint);
+        if (!cp) {
+          console.error(chalk.red(`Checkpoint not found or unreadable: ${options.resumeCheckpoint}`));
+          process.exit(1);
+        }
+        const runDir = path.join(getRunsDir(), cp.id);
+        fs.mkdirSync(runDir, { recursive: true });
+        const resumeExec: ExecOptions = {
+          agent: cp.agent,
+          version: cp.version,
+          prompt: cp.prompt,
+          mode: options.mode,
+          effort: options.effort,
+          cwd: options.cwd,
+          sessionId: cp.sessionId,
+          json: true,
+          headless: true,
+        };
+        // Resume honors the checkpoint's loop config, but lets the resume
+        // command RAISE the bounds field-by-field — `--max-iterations 4` on a
+        // checkpoint capped at 2 is the natural "continue, run more" gesture.
+        // Flags override; unspecified fields fall through from the checkpoint.
+        const resumeLoop = { ...cp.loop };
+        if (options.maxIterations !== undefined) {
+          const n = Number(options.maxIterations);
+          if (!Number.isInteger(n) || n <= 0) {
+            console.error(chalk.red(`Invalid --max-iterations '${options.maxIterations}'. Use a positive integer.`));
+            process.exit(1);
+          }
+          resumeLoop.maxIterations = n;
+        }
+        if (options.budget !== undefined) {
+          const b = Number(options.budget);
+          if (!Number.isFinite(b) || b <= 0) {
+            console.error(chalk.red(`Invalid --budget '${options.budget}'. Use a positive token count.`));
+            process.exit(1);
+          }
+          resumeLoop.budget = b;
+        }
+        if (options.interval !== undefined) resumeLoop.interval = options.interval;
+        if (options.until !== undefined) {
+          if (options.until !== 'signal') {
+            console.error(chalk.red(`Invalid --until '${options.until}'. Only 'signal' is supported.`));
+            process.exit(1);
+          }
+          resumeLoop.until = 'signal';
+        }
+        process.stderr.write(chalk.gray(`[loop] resuming ${cp.agent} run ${cp.id} from iteration ${cp.iteration + 1} (session ${(cp.sessionId ?? '').slice(0, 8)})\n`));
+        const result = await runLoop(resumeExec, resumeLoop, {
+          runId: cp.id,
+          runDir,
+          agent: cp.agent,
+          version: cp.version,
+          startIteration: cp.iteration + 1,
+          startTokens: cp.cumulativeTokens ?? 0,
+          sessionId: cp.sessionId,
+        });
+        process.stderr.write(chalk.gray(`[loop] stopped: ${result.stoppedBy} after ${result.iterations} iteration(s), ${result.tokens} tokens\n`));
+        process.exit(loopExitCode(result.stoppedBy));
+      }
+
       const [
         { buildExecCommand, parseExecEnv, execAgent, runWithFallback, normalizeMode, resolveMode, defaultModeFor, headlessPlanStallCommand },
         { ALL_AGENT_IDS },
@@ -192,6 +367,9 @@ export function registerRunCommand(program: Command): void {
       // WORKFLOW.md capability scoping, translated to Claude headless flags below.
       let workflowToolsRestrict: string[] | undefined;
       let workflowMcpConfigPath: string | undefined;
+      // WORKFLOW.md `loop:` block (issue #332). When a workflow declares it,
+      // `agents run <workflow>` honors the loop without a --loop flag.
+      let workflowLoop: import('../lib/workflows.js').LoopConfigRaw | undefined;
       const cwd = options.cwd ?? process.cwd();
 
       if (isValidAgent(rawAgent)) {
@@ -224,6 +402,7 @@ export function registerRunCommand(program: Command): void {
         if (typeof workflowFrontmatter?.model === 'string' && workflowFrontmatter.model.trim() !== '') {
           workflowModel = workflowFrontmatter.model.trim();
         }
+        workflowLoop = workflowFrontmatter?.loop;
 
         const resolvedVersion = resolveVersionAlias('claude', version);
         const versionHome = getVersionHomePath('claude', resolvedVersion ?? getGlobalDefault('claude') ?? '');
@@ -728,6 +907,53 @@ export function registerRunCommand(program: Command): void {
           // best-effort: nothing actionable if the temp dir is already gone.
         }
       };
+
+      // Loop dispatch (issue #332). Active when --loop is passed OR a workflow
+      // declares a `loop:` block. The loop path runs AFTER the #346 pre-flight
+      // gate above (which fired once) — the loop's token budget is an ADDITIONAL
+      // guard, not a replacement. Composable, not bypassing.
+      let loopConfig: import('../lib/loop.js').LoopConfig | undefined;
+      try {
+        loopConfig = buildLoopConfig(options, workflowLoop);
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+      if (loopConfig) {
+        if (prompt === undefined) {
+          console.error(chalk.red('--loop requires a prompt (or a workflow whose loop is paired with a prompt). The loop re-injects the prompt each iteration.'));
+          process.exit(1);
+        }
+        if (options.interactive) {
+          console.error(chalk.red('--loop is headless-only. The loop re-injects programmatically; an interactive TUI cannot be re-driven.'));
+          process.exit(1);
+        }
+        if (fallback.length > 0) {
+          console.error(chalk.red('--loop is not compatible with --fallback yet. Drop one.'));
+          process.exit(1);
+        }
+        const { runLoop } = await import('../lib/loop.js');
+        const { getRunsDir } = await import('../lib/state.js');
+        const runId = `loop-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const runDir = path.join(getRunsDir(), runId);
+        fs.mkdirSync(runDir, { recursive: true });
+        process.stderr.write(chalk.gray(`[loop] run ${runId} — max ${loopConfig.maxIterations ?? '∞'}${loopConfig.budget ? `, budget ${loopConfig.budget} tokens` : ''}${loopConfig.until ? `, until ${loopConfig.until}` : ''}${loopConfig.interval ? `, interval ${loopConfig.interval}` : ''}\n`));
+        try {
+          const result = await runLoop({ ...execOptions, json: true, headless: true }, loopConfig, {
+            runId,
+            runDir,
+            agent,
+            version,
+          });
+          cleanupWorkflowMcpConfig();
+          process.stderr.write(chalk.gray(`[loop] stopped: ${result.stoppedBy} after ${result.iterations} iteration(s), ${result.tokens} tokens (checkpoint: ${path.join(runDir, 'checkpoint.json')})\n`));
+          process.exit(loopExitCode(result.stoppedBy));
+        } catch (err) {
+          cleanupWorkflowMcpConfig();
+          console.error(chalk.red(`Loop failed for ${agent}: ${(err as Error).message}`));
+          process.exit(1);
+        }
+      }
 
       try {
         let exitCode: number;

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -12,6 +12,7 @@ import type { ExecOptions, ExecMode, ExecEffort, FallbackEntry } from '../lib/ex
 import type { AgentId } from '../lib/types.js';
 import type { ResolvedRunDefaults } from '../lib/run-defaults.js';
 import { setHelpSections } from '../lib/help.js';
+import { parseLoopInterval } from '../lib/loop.js';
 import type { RotateResult } from '../lib/rotate.js';
 import { AGENTS } from '../lib/agents.js';
 import * as fs from 'fs';
@@ -111,9 +112,20 @@ export function buildLoopConfig(
     cfg.budget = workflowLoop.budget;
   }
 
-  // interval: CLI > workflow.
+  // interval: CLI > workflow. Validate eagerly — an unparseable interval
+  // (e.g. "30s", "5", "abc") must be rejected here, not silently coalesced to
+  // 0ms (back-to-back) at run time. "0" is the one accepted non-duration value.
   const interval = flags.interval ?? workflowLoop?.interval;
-  if (interval !== undefined) cfg.interval = interval;
+  if (interval !== undefined) {
+    try {
+      parseLoopInterval(interval);
+    } catch {
+      throw new Error(
+        `Invalid --interval '${interval}'. Use "0" for back-to-back or a duration like "30m", "1h", "2h30m" (units: w/d/h/m).`,
+      );
+    }
+    cfg.interval = interval;
+  }
 
   return cfg;
 }
@@ -308,7 +320,15 @@ export function registerRunCommand(program: Command): void {
           }
           resumeLoop.budget = b;
         }
-        if (options.interval !== undefined) resumeLoop.interval = options.interval;
+        if (options.interval !== undefined) {
+          try {
+            parseLoopInterval(options.interval);
+          } catch {
+            console.error(chalk.red(`Invalid --interval '${options.interval}'. Use "0" for back-to-back or a duration like "30m", "1h", "2h30m" (units: w/d/h/m).`));
+            process.exit(1);
+          }
+          resumeLoop.interval = options.interval;
+        }
         if (options.until !== undefined) {
           if (options.until !== 'signal') {
             console.error(chalk.red(`Invalid --until '${options.until}'. Only 'signal' is supported.`));

--- a/src/lib/checkpoint.test.ts
+++ b/src/lib/checkpoint.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { writeCheckpoint, readCheckpoint, type Checkpoint } from './checkpoint.js';
+
+function tmpFile(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-checkpoint-test-'));
+  return path.join(dir, 'checkpoint.json');
+}
+
+function sample(overrides: Partial<Checkpoint> = {}): Checkpoint {
+  return {
+    id: 'loop-123-abc',
+    agent: 'claude',
+    version: '2.1.170',
+    prompt: 'do the thing',
+    sessionId: '11111111-2222-3333-4444-555555555555',
+    iteration: 2,
+    loop: { until: 'signal', maxIterations: 5, budget: 100000, interval: '0' },
+    loopSignal: { continue: true, reason: 'more work' },
+    cumulativeTokens: 4242,
+    createdAt: '2026-06-24T00:00:00.000Z',
+    updatedAt: '2026-06-24T00:01:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('checkpoint round-trip', () => {
+  it('writes and reads back every field intact', () => {
+    const file = tmpFile();
+    const cp = sample();
+    writeCheckpoint(cp, file);
+    const back = readCheckpoint(file);
+    expect(back).toEqual(cp);
+  });
+
+  it('preserves the loop config (the resume-critical state)', () => {
+    const file = tmpFile();
+    const cp = sample({ iteration: 7, cumulativeTokens: 999 });
+    writeCheckpoint(cp, file);
+    const back = readCheckpoint(file)!;
+    expect(back.iteration).toBe(7);
+    expect(back.cumulativeTokens).toBe(999);
+    expect(back.loop.maxIterations).toBe(5);
+    expect(back.loop.budget).toBe(100000);
+    expect(back.sessionId).toBe(cp.sessionId);
+  });
+});
+
+describe('atomic write', () => {
+  it('leaves no .tmp file behind after a successful write', () => {
+    const file = tmpFile();
+    writeCheckpoint(sample(), file);
+    const dir = path.dirname(file);
+    const leftover = fs.readdirSync(dir).filter((f) => f.endsWith('.tmp'));
+    expect(leftover).toEqual([]);
+    expect(fs.existsSync(file)).toBe(true);
+  });
+
+  it('overwrites an existing checkpoint in place (rename, not append)', () => {
+    const file = tmpFile();
+    writeCheckpoint(sample({ iteration: 1 }), file);
+    writeCheckpoint(sample({ iteration: 2 }), file);
+    const back = readCheckpoint(file)!;
+    expect(back.iteration).toBe(2);
+    // A single valid JSON object — not two concatenated writes.
+    expect(() => JSON.parse(fs.readFileSync(file, 'utf-8'))).not.toThrow();
+  });
+});
+
+describe('readCheckpoint corruption handling', () => {
+  it('returns null for a missing file', () => {
+    const file = tmpFile();
+    expect(readCheckpoint(file)).toBeNull();
+  });
+
+  it('returns null for invalid JSON', () => {
+    const file = tmpFile();
+    fs.writeFileSync(file, '{ not valid json', 'utf-8');
+    expect(readCheckpoint(file)).toBeNull();
+  });
+
+  it('returns null when required fields are missing (shape guard)', () => {
+    const file = tmpFile();
+    fs.writeFileSync(file, JSON.stringify({ agent: 'claude' }), 'utf-8');
+    expect(readCheckpoint(file)).toBeNull();
+  });
+});

--- a/src/lib/checkpoint.ts
+++ b/src/lib/checkpoint.ts
@@ -1,0 +1,80 @@
+/**
+ * Harness-level loop checkpoint (issue #332).
+ *
+ * A checkpoint is the durable harness state for a `--loop` run: it records the
+ * iteration count, the pinned session id, the prompt being re-injected, and the
+ * loop config — everything `--resume-checkpoint` needs to continue a run that a
+ * SIGTERM, timeout, or machine sleep killed mid-flight.
+ *
+ * This is NOT provider-side state. `--session-id` resumes Claude's *conversation*
+ * (server-side); a checkpoint resumes the *harness* (iteration count, loop
+ * variables, prompt chain) — the part Claude's own resume cannot recover.
+ *
+ * Atomic write (temp + rename) mirrors `writeRunMeta` in routines.ts so a crash
+ * mid-write never leaves a half-written checkpoint that `readCheckpoint` would
+ * choke on. `readCheckpoint` returns null on a missing or corrupt file (mirrors
+ * `readRunMeta`) — a corrupt checkpoint is a "start fresh", never a throw.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { AgentId } from './types.js';
+import { getRunsDir } from './state.js';
+import type { LoopConfig, LoopSignal } from './loop.js';
+
+/** Durable harness state for a looped run, serialized to checkpoint.json. */
+export interface Checkpoint {
+  /** runId == the run directory name under getRunsDir(). */
+  id: string;
+  agent: AgentId;
+  version?: string;
+  /** The prompt re-injected each iteration. */
+  prompt?: string;
+  /** Pinned Claude session id so a resume continues the same conversation. */
+  sessionId?: string;
+  /** Iterations COMPLETED so far. A resume starts at iteration + 1. */
+  iteration: number;
+  /** The loop config governing termination. */
+  loop: LoopConfig;
+  /** Last loop-signal read, if any (for audit / resume context). */
+  loopSignal?: LoopSignal;
+  /** Cumulative tokens consumed across all iterations so far. */
+  cumulativeTokens?: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Path to a run's checkpoint file: <runsDir>/<runId>/checkpoint.json. */
+export function checkpointPath(runId: string): string {
+  return path.join(getRunsDir(), runId, 'checkpoint.json');
+}
+
+/**
+ * Write a checkpoint atomically (temp file + rename). The rename is atomic on a
+ * single filesystem, so a reader never observes a partially written file.
+ * Mirrors the durable-write contract of `writeRunMeta`.
+ */
+export function writeCheckpoint(c: Checkpoint, file?: string): void {
+  const target = file ?? checkpointPath(c.id);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  const tmp = `${target}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(c, null, 2), 'utf-8');
+  fs.renameSync(tmp, target);
+}
+
+/**
+ * Read a checkpoint from disk. Returns null if the file is missing or its
+ * contents are not valid JSON — corruption means "no resumable state", which
+ * the caller treats as a fresh start. Mirrors `readRunMeta`.
+ */
+export function readCheckpoint(file: string): Checkpoint | null {
+  if (!fs.existsSync(file)) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    if (!parsed || typeof parsed !== 'object') return null;
+    if (typeof parsed.id !== 'string' || typeof parsed.iteration !== 'number') return null;
+    return parsed as Checkpoint;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/loop-integration.test.ts
+++ b/src/lib/loop-integration.test.ts
@@ -141,6 +141,11 @@ describe('loop driver — checkpoint write + resume continuity', () => {
     const finalCp = readCheckpoint(cpFile)!;
     expect(finalCp.iteration).toBe(4);
     expect(finalCp.cumulativeTokens).toBe(640);
-    expect(finalCp.sessionId).toBe(cp!.sessionId); // conversation continuity
+    // Each iteration pins a DISTINCT session id (`--session-id` CREATES a
+    // session; re-passing one errors "already in use"). Continuity is threaded
+    // via /continue, not a shared id — so the final checkpoint records the LAST
+    // iteration's fresh id, which differs from the resumed-from id.
+    expect(typeof finalCp.sessionId).toBe('string');
+    expect(finalCp.sessionId).not.toBe(cp!.sessionId);
   });
 });

--- a/src/lib/loop-integration.test.ts
+++ b/src/lib/loop-integration.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Integration test for the loop driver (issue #332).
+ *
+ * Unlike loop.test.ts (which injects a fake run-fn), this exercises the REAL
+ * defaultRunIteration — actual child_process.spawn, actual stdout stream-json
+ * parsing, actual token accumulation — against a fake `claude` binary on PATH
+ * that emits real Claude-shaped stream-json and writes loop-signal.json. This
+ * proves the spawn + parse + signal + checkpoint + resume wiring end-to-end
+ * without paying for a real model.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { runLoop, defaultRunIteration, loopSignalPath } from './loop.js';
+import { readCheckpoint, checkpointPath } from './checkpoint.js';
+import type { ExecOptions } from './exec.js';
+
+let binDir: string;
+let runDir: string;
+let origPath: string | undefined;
+let origHome: string | undefined;
+
+/**
+ * A fake `claude` that:
+ *  - emits one Claude stream-json assistant turn carrying message.usage tokens
+ *  - reads a control file (FAKE_CLAUDE_SIGNAL) to decide what loop-signal to
+ *    write into the run dir (so the test can script continue/stop per iteration)
+ */
+const FAKE_CLAUDE = `#!/usr/bin/env bash
+echo '{"type":"assistant","message":{"model":"claude-sonnet-4-5","usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":10}}}'
+echo '{"type":"result","usage":{"input_tokens":100,"output_tokens":50}}'
+if [ -n "$FAKE_CLAUDE_SIGNAL_DIR" ]; then
+  # Decrement a counter file; while >0 write continue:true, then continue:false.
+  COUNTER="$FAKE_CLAUDE_SIGNAL_DIR/counter"
+  N=$(cat "$COUNTER" 2>/dev/null || echo 0)
+  if [ "$N" -gt 1 ]; then
+    echo '{"continue":true,"reason":"more"}' > "$FAKE_CLAUDE_SIGNAL_DIR/loop-signal.json"
+    echo $((N - 1)) > "$COUNTER"
+  else
+    echo '{"continue":false,"reason":"done"}' > "$FAKE_CLAUDE_SIGNAL_DIR/loop-signal.json"
+  fi
+fi
+exit 0
+`;
+
+beforeAll(() => {
+  binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-loop-int-bin-'));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-loop-int-home-'));
+  runDir = path.join(home, 'rundir');
+  fs.mkdirSync(runDir, { recursive: true });
+  const fakeClaude = path.join(binDir, 'claude');
+  fs.writeFileSync(fakeClaude, FAKE_CLAUDE, { mode: 0o755 });
+  origPath = process.env.PATH;
+  origHome = process.env.HOME;
+  process.env.PATH = `${binDir}:${origPath}`;
+  // HOME pinned so checkpointPath() (via getRunsDir) resolves into a temp tree.
+  process.env.HOME = home;
+});
+
+afterAll(() => {
+  if (origPath !== undefined) process.env.PATH = origPath;
+  if (origHome !== undefined) process.env.HOME = origHome;
+});
+
+const exec: ExecOptions = {
+  agent: 'claude',
+  prompt: 'loop please',
+  mode: 'skip',
+  effort: 'auto',
+};
+
+describe('loop driver — real spawn + token parse', () => {
+  it('defaultRunIteration spawns the agent and sums tokens off the real stream-json', async () => {
+    const res = await defaultRunIteration(exec);
+    expect(res.exitCode).toBe(0);
+    // 100 input + 50 output + 10 cache-read = 160 from the single assistant turn
+    // (the result line is intentionally skipped by extractUsageEvents).
+    expect(res.tokens).toBe(160);
+  });
+
+  it('runs 3 real iterations then stops with max (interval 0, real spawns)', async () => {
+    const res = await runLoop(exec, { maxIterations: 3, interval: '0' }, {
+      runId: 'int-max',
+      runDir,
+      agent: 'claude',
+    });
+    expect(res.iterations).toBe(3);
+    expect(res.stoppedBy).toBe('max');
+    expect(res.tokens).toBe(480); // 3 * 160
+  });
+
+  it('until=signal stops with condition-met when the fake agent writes continue:false', async () => {
+    const signalRunDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-loop-int-sig-'));
+    // counter=2 → iter1 writes continue:true, iter2 writes continue:false.
+    fs.writeFileSync(path.join(signalRunDir, 'counter'), '2', 'utf-8');
+    const res = await runLoop(
+      { ...exec, env: { FAKE_CLAUDE_SIGNAL_DIR: signalRunDir } },
+      { until: 'signal', maxIterations: 10, interval: '0' },
+      { runId: 'int-sig', runDir: signalRunDir, agent: 'claude' },
+    );
+    expect(res.stoppedBy).toBe('condition-met');
+    expect(res.iterations).toBe(2);
+    expect(res.lastSignal?.continue).toBe(false);
+    expect(res.lastSignal?.reason).toBe('done');
+  });
+});
+
+describe('loop driver — checkpoint write + resume continuity', () => {
+  it('writes a checkpoint at the real run path and resume continues from it', async () => {
+    // Phase 1: run 2 iterations of a 4-iteration loop, then simulate a kill by
+    // only running to maxIterations:2 — the checkpoint captures iteration 2.
+    const phase1 = await runLoop(exec, { maxIterations: 2, interval: '0' }, {
+      runId: 'int-resume',
+      runDir,
+      agent: 'claude',
+      version: undefined,
+    });
+    expect(phase1.iterations).toBe(2);
+    const cpFile = checkpointPath('int-resume');
+    const cp = readCheckpoint(cpFile);
+    expect(cp).not.toBeNull();
+    expect(cp!.iteration).toBe(2);
+    expect(cp!.cumulativeTokens).toBe(320); // 2 * 160
+    expect(typeof cp!.sessionId).toBe('string');
+
+    // Phase 2: resume from the checkpoint — continue from iteration 3 with the
+    // same session id and carried token count, running up to maxIterations 4.
+    const phase2 = await runLoop(exec, { maxIterations: 4, interval: '0' }, {
+      runId: cp!.id,
+      runDir,
+      agent: 'claude',
+      startIteration: cp!.iteration + 1,
+      startTokens: cp!.cumulativeTokens ?? 0,
+      sessionId: cp!.sessionId,
+    });
+    expect(phase2.iterations).toBe(2); // iterations 3 and 4
+    expect(phase2.stoppedBy).toBe('max');
+    expect(phase2.tokens).toBe(640); // 320 carried + 2*160
+
+    const finalCp = readCheckpoint(cpFile)!;
+    expect(finalCp.iteration).toBe(4);
+    expect(finalCp.cumulativeTokens).toBe(640);
+    expect(finalCp.sessionId).toBe(cp!.sessionId); // conversation continuity
+  });
+});

--- a/src/lib/loop.test.ts
+++ b/src/lib/loop.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  runLoop,
+  loopSignalPath,
+  readLoopSignal,
+  clearLoopSignal,
+  type LoopContext,
+  type IterationResult,
+} from './loop.js';
+import type { ExecOptions } from './exec.js';
+import type { Checkpoint } from './checkpoint.js';
+
+function tmpRunDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'agents-loop-test-'));
+}
+
+const baseExec: ExecOptions = {
+  agent: 'claude',
+  prompt: 'iterate',
+  mode: 'skip',
+  effort: 'auto',
+};
+
+function baseCtx(runDir: string, overrides: Partial<LoopContext> = {}): LoopContext {
+  return { runId: 'loop-test', runDir, agent: 'claude', ...overrides };
+}
+
+/** A run-fn that records each call and returns a fixed token count + exit 0. */
+function recordingRun(tokensPerIter = 0): {
+  fn: (o: ExecOptions) => Promise<IterationResult>;
+  calls: ExecOptions[];
+} {
+  const calls: ExecOptions[] = [];
+  return {
+    calls,
+    fn: async (o: ExecOptions) => {
+      calls.push(o);
+      return { exitCode: 0, tokens: tokensPerIter };
+    },
+  };
+}
+
+const noSleep = async () => {};
+
+describe('runLoop — termination by max_iterations', () => {
+  it('runs exactly maxIterations turns then stops with stoppedBy max', async () => {
+    const runDir = tmpRunDir();
+    const rec = recordingRun();
+    const checkpoints: Checkpoint[] = [];
+    const result = await runLoop(baseExec, { maxIterations: 3, interval: '0' }, baseCtx(runDir), {
+      runIteration: rec.fn,
+      sleep: noSleep,
+      writeCheckpoint: (c) => checkpoints.push({ ...c }),
+    });
+    expect(result.iterations).toBe(3);
+    expect(result.stoppedBy).toBe('max');
+    expect(rec.calls.length).toBe(3);
+    // A checkpoint after every iteration.
+    expect(checkpoints.length).toBe(3);
+    expect(checkpoints[checkpoints.length - 1].iteration).toBe(3);
+  });
+
+  it('pins --session-id from iteration 2 onward so the conversation resumes', async () => {
+    const runDir = tmpRunDir();
+    const rec = recordingRun();
+    await runLoop(baseExec, { maxIterations: 3, interval: '0' }, baseCtx(runDir), {
+      runIteration: rec.fn,
+      sleep: noSleep,
+      writeCheckpoint: () => {},
+    });
+    // Every iteration carries a session id; iterations 2+ carry the SAME pinned id.
+    const ids = rec.calls.map((c) => c.sessionId);
+    expect(ids.every((id) => typeof id === 'string' && id.length > 0)).toBe(true);
+    expect(ids[1]).toBe(ids[2]);
+    expect(ids[0]).toBe(ids[1]); // fresh run mints one id reused throughout
+  });
+});
+
+describe('runLoop — until=signal', () => {
+  it('stops with condition-met when the entrypoint writes continue:false', async () => {
+    const runDir = tmpRunDir();
+    let iter = 0;
+    const result = await runLoop(baseExec, { until: 'signal', maxIterations: 10, interval: '0' }, baseCtx(runDir), {
+      runIteration: async () => {
+        iter++;
+        // The "agent" writes the signal AFTER iteration 1 saying "stop".
+        if (iter === 1) {
+          fs.writeFileSync(loopSignalPath(runDir), JSON.stringify({ continue: false, reason: 'goal reached' }), 'utf-8');
+        }
+        return { exitCode: 0, tokens: 0 };
+      },
+      sleep: noSleep,
+      writeCheckpoint: () => {},
+    });
+    expect(result.iterations).toBe(1);
+    expect(result.stoppedBy).toBe('condition-met');
+    expect(result.lastSignal?.reason).toBe('goal reached');
+  });
+
+  it('continues while the signal says continue:true, then stops on false', async () => {
+    const runDir = tmpRunDir();
+    let iter = 0;
+    const result = await runLoop(baseExec, { until: 'signal', maxIterations: 10, interval: '0' }, baseCtx(runDir), {
+      runIteration: async () => {
+        iter++;
+        const cont = iter < 3; // stop on the 3rd
+        fs.writeFileSync(loopSignalPath(runDir), JSON.stringify({ continue: cont }), 'utf-8');
+        return { exitCode: 0, tokens: 0 };
+      },
+      sleep: noSleep,
+      writeCheckpoint: () => {},
+    });
+    expect(result.iterations).toBe(3);
+    expect(result.stoppedBy).toBe('condition-met');
+  });
+
+  it('fail-closed: an absent signal file stops with condition-met', async () => {
+    const runDir = tmpRunDir();
+    // run-fn never writes loop-signal.json — absence must be treated as stop.
+    const result = await runLoop(baseExec, { until: 'signal', maxIterations: 10, interval: '0' }, baseCtx(runDir), {
+      runIteration: async () => ({ exitCode: 0, tokens: 0 }),
+      sleep: noSleep,
+      writeCheckpoint: () => {},
+    });
+    expect(result.iterations).toBe(1);
+    expect(result.stoppedBy).toBe('condition-met');
+    expect(result.lastSignal?.continue).toBe(false);
+  });
+
+  it('deletes the signal file between iterations so a stale signal cannot carry over', async () => {
+    const runDir = tmpRunDir();
+    let iter = 0;
+    const seenSignalBeforeRun: boolean[] = [];
+    await runLoop(baseExec, { until: 'signal', maxIterations: 3, interval: '0' }, baseCtx(runDir), {
+      runIteration: async () => {
+        iter++;
+        // Record whether a stale signal survived into this iteration's start.
+        seenSignalBeforeRun.push(fs.existsSync(loopSignalPath(runDir)));
+        fs.writeFileSync(loopSignalPath(runDir), JSON.stringify({ continue: iter < 3 }), 'utf-8');
+        return { exitCode: 0, tokens: 0 };
+      },
+      sleep: noSleep,
+      writeCheckpoint: () => {},
+    });
+    // The driver clears the signal after reading it, so no iteration ever begins
+    // with a leftover signal file present.
+    expect(seenSignalBeforeRun).toEqual([false, false, false]);
+  });
+});
+
+describe('runLoop — budget (token cap)', () => {
+  it('stops with budget once cumulative tokens reach the cap', async () => {
+    const runDir = tmpRunDir();
+    // 400 tokens/iter, cap 1000 → stops after iter 3 (1200 >= 1000).
+    const result = await runLoop(baseExec, { budget: 1000, maxIterations: 100, interval: '0' }, baseCtx(runDir), {
+      runIteration: async () => ({ exitCode: 0, tokens: 400 }),
+      sleep: noSleep,
+      writeCheckpoint: () => {},
+    });
+    expect(result.stoppedBy).toBe('budget');
+    expect(result.iterations).toBe(3);
+    expect(result.tokens).toBe(1200);
+  });
+
+  it('does not stop on budget when tokens stay under the cap (max wins)', async () => {
+    const runDir = tmpRunDir();
+    const result = await runLoop(baseExec, { budget: 100000, maxIterations: 2, interval: '0' }, baseCtx(runDir), {
+      runIteration: async () => ({ exitCode: 0, tokens: 10 }),
+      sleep: noSleep,
+      writeCheckpoint: () => {},
+    });
+    expect(result.stoppedBy).toBe('max');
+    expect(result.tokens).toBe(20);
+  });
+});
+
+describe('runLoop — error handling', () => {
+  it('stops with error and checkpoints when an iteration exits non-zero', async () => {
+    const runDir = tmpRunDir();
+    let last: Checkpoint | undefined;
+    const result = await runLoop(baseExec, { maxIterations: 5, interval: '0' }, baseCtx(runDir), {
+      runIteration: async () => ({ exitCode: 2, tokens: 5 }),
+      sleep: noSleep,
+      writeCheckpoint: (c) => { last = { ...c }; },
+    });
+    expect(result.stoppedBy).toBe('error');
+    expect(result.iterations).toBe(1);
+    expect(last?.iteration).toBe(1);
+  });
+
+  it('stops with error when an iteration throws', async () => {
+    const runDir = tmpRunDir();
+    const result = await runLoop(baseExec, { maxIterations: 5, interval: '0' }, baseCtx(runDir), {
+      runIteration: async () => { throw new Error('spawn blew up'); },
+      sleep: noSleep,
+      writeCheckpoint: () => {},
+    });
+    expect(result.stoppedBy).toBe('error');
+    expect(result.iterations).toBe(0);
+  });
+});
+
+describe('runLoop — resume from checkpoint', () => {
+  it('starts at checkpoint.iteration+1 and carries token count forward', async () => {
+    const runDir = tmpRunDir();
+    const rec = recordingRun(100);
+    const checkpoints: Checkpoint[] = [];
+    // Simulate a run that already completed 2 iterations (300 tokens), resuming
+    // at iteration 3 with maxIterations 4 → runs iterations 3 and 4 only.
+    const result = await runLoop(baseExec, { maxIterations: 4, interval: '0' }, baseCtx(runDir, {
+      startIteration: 3,
+      startTokens: 300,
+      sessionId: 'resumed-session-id',
+    }), {
+      runIteration: rec.fn,
+      sleep: noSleep,
+      writeCheckpoint: (c) => checkpoints.push({ ...c }),
+    });
+    // Only 2 NEW iterations executed (3 and 4).
+    expect(rec.calls.length).toBe(2);
+    expect(result.iterations).toBe(2);
+    expect(result.stoppedBy).toBe('max');
+    // Token count continued from 300: 300 + 2*100 = 500.
+    expect(result.tokens).toBe(500);
+    // Resumed runs reuse the carried session id (conversation continuity).
+    expect(rec.calls.every((c) => c.sessionId === 'resumed-session-id')).toBe(true);
+    // The final checkpoint records the real iteration number, not a fresh count.
+    expect(checkpoints[checkpoints.length - 1].iteration).toBe(4);
+    expect(checkpoints[checkpoints.length - 1].cumulativeTokens).toBe(500);
+  });
+});
+
+describe('loop-signal helpers', () => {
+  it('readLoopSignal returns null for a missing file and coerces continue defensively', () => {
+    const runDir = tmpRunDir();
+    expect(readLoopSignal(runDir)).toBeNull();
+    fs.writeFileSync(loopSignalPath(runDir), JSON.stringify({ continue: 'yes', reason: 5 }), 'utf-8');
+    const sig = readLoopSignal(runDir)!;
+    expect(sig.continue).toBe(false); // non-boolean true coerced to false (fail-closed)
+    expect(sig.reason).toBeUndefined(); // non-string reason dropped
+  });
+
+  it('clearLoopSignal removes the file and is a no-op when already absent', () => {
+    const runDir = tmpRunDir();
+    fs.writeFileSync(loopSignalPath(runDir), '{"continue":true}', 'utf-8');
+    clearLoopSignal(runDir);
+    expect(fs.existsSync(loopSignalPath(runDir))).toBe(false);
+    expect(() => clearLoopSignal(runDir)).not.toThrow();
+  });
+});

--- a/src/lib/loop.test.ts
+++ b/src/lib/loop.test.ts
@@ -7,6 +7,8 @@ import {
   loopSignalPath,
   readLoopSignal,
   clearLoopSignal,
+  parseLoopInterval,
+  buildLoopContinuePrompt,
   type LoopContext,
   type IterationResult,
 } from './loop.js';
@@ -63,7 +65,7 @@ describe('runLoop — termination by max_iterations', () => {
     expect(checkpoints[checkpoints.length - 1].iteration).toBe(3);
   });
 
-  it('pins --session-id from iteration 2 onward so the conversation resumes', async () => {
+  it('pins a DISTINCT session id per iteration and threads continuity via /continue', async () => {
     const runDir = tmpRunDir();
     const rec = recordingRun();
     await runLoop(baseExec, { maxIterations: 3, interval: '0' }, baseCtx(runDir), {
@@ -71,11 +73,31 @@ describe('runLoop — termination by max_iterations', () => {
       sleep: noSleep,
       writeCheckpoint: () => {},
     });
-    // Every iteration carries a session id; iterations 2+ carry the SAME pinned id.
     const ids = rec.calls.map((c) => c.sessionId);
+    const prompts = rec.calls.map((c) => c.prompt);
+    // `--session-id` CREATES a session — re-passing one errors "already in use".
+    // So every iteration must pin a UNIQUE id.
     expect(ids.every((id) => typeof id === 'string' && id.length > 0)).toBe(true);
-    expect(ids[1]).toBe(ids[2]);
-    expect(ids[0]).toBe(ids[1]); // fresh run mints one id reused throughout
+    expect(new Set(ids).size).toBe(3);
+    // Iteration 1 gets the bare entrypoint.
+    expect(prompts[0]).toBe('iterate');
+    // Iterations 2+ thread the PRIOR iteration's session via /continue, then
+    // re-append the entrypoint. The id referenced must be the previous turn's.
+    expect(prompts[1]).toBe(`/continue ${ids[0]}\n\niterate`);
+    expect(prompts[2]).toBe(`/continue ${ids[1]}\n\niterate`);
+  });
+
+  it('non-claude loops run independent conversations (no /continue injection)', async () => {
+    const runDir = tmpRunDir();
+    const rec = recordingRun();
+    await runLoop(
+      { ...baseExec, agent: 'codex' },
+      { maxIterations: 3, interval: '0' },
+      baseCtx(runDir, { agent: 'codex' }),
+      { runIteration: rec.fn, sleep: noSleep, writeCheckpoint: () => {} },
+    );
+    // Every iteration re-injects the bare entrypoint — no /continue handoff.
+    expect(rec.calls.every((c) => c.prompt === 'iterate')).toBe(true);
   });
 });
 
@@ -203,6 +225,82 @@ describe('runLoop — error handling', () => {
   });
 });
 
+describe('runLoop — signal classification (FIX 2)', () => {
+  it('classifies a non-zero exit AFTER SIGINT as signal, not error', async () => {
+    const runDir = tmpRunDir();
+    // Ctrl-C kills the child mid-iteration: the iteration returns a non-zero
+    // exit, but a SIGINT arrived first. That must be 'signal' (exit 130), not
+    // 'error'. Emit SIGINT during the iteration, then return exit 130.
+    const result = await runLoop(baseExec, { maxIterations: 5, interval: '0' }, baseCtx(runDir), {
+      runIteration: async () => {
+        process.emit('SIGINT' as any);
+        return { exitCode: 130, tokens: 0 };
+      },
+      sleep: noSleep,
+      writeCheckpoint: () => {},
+    });
+    expect(result.stoppedBy).toBe('signal');
+  });
+
+  it('classifies a throw AFTER SIGINT as signal, not error', async () => {
+    const runDir = tmpRunDir();
+    // A SIGINT that kills the child can surface as a spawn rejection rather than
+    // a clean non-zero exit. With the stop flag set, that is still a signal.
+    const result = await runLoop(baseExec, { maxIterations: 5, interval: '0' }, baseCtx(runDir), {
+      runIteration: async () => {
+        process.emit('SIGINT' as any);
+        throw new Error('killed by signal');
+      },
+      sleep: noSleep,
+      writeCheckpoint: () => {},
+    });
+    expect(result.stoppedBy).toBe('signal');
+  });
+
+  it('a genuine non-zero exit with NO signal is still error', async () => {
+    const runDir = tmpRunDir();
+    const result = await runLoop(baseExec, { maxIterations: 5, interval: '0' }, baseCtx(runDir), {
+      runIteration: async () => ({ exitCode: 2, tokens: 0 }),
+      sleep: noSleep,
+      writeCheckpoint: () => {},
+    });
+    expect(result.stoppedBy).toBe('error');
+  });
+});
+
+describe('buildLoopContinuePrompt (FIX 1)', () => {
+  it('prepends the /continue skill directive then re-appends the entrypoint', () => {
+    expect(buildLoopContinuePrompt('abc-123', 'do the work')).toBe(
+      '/continue abc-123\n\ndo the work',
+    );
+  });
+});
+
+describe('parseLoopInterval (FIX 3)', () => {
+  it('accepts "0" as explicit back-to-back (0ms)', () => {
+    expect(parseLoopInterval('0')).toBe(0);
+    expect(parseLoopInterval(' 0 ')).toBe(0);
+  });
+
+  it('accepts valid durations', () => {
+    expect(parseLoopInterval('30m')).toBe(30 * 60 * 1000);
+    expect(parseLoopInterval('1h')).toBe(60 * 60 * 1000);
+    expect(parseLoopInterval('2h30m')).toBe((2 * 60 + 30) * 60 * 1000);
+  });
+
+  it('returns 0 for undefined (no interval configured)', () => {
+    expect(parseLoopInterval(undefined)).toBe(0);
+  });
+
+  it('THROWS on unparseable input instead of silently coalescing to 0', () => {
+    // The bug: "30s" / "5" / "abc" parsed to null then coalesced to 0ms, so a
+    // typo ran the loop full-speed. Each must now throw.
+    expect(() => parseLoopInterval('30s')).toThrow(/Invalid loop interval/);
+    expect(() => parseLoopInterval('5')).toThrow(/Invalid loop interval/);
+    expect(() => parseLoopInterval('abc')).toThrow(/Invalid loop interval/);
+  });
+});
+
 describe('runLoop — resume from checkpoint', () => {
   it('starts at checkpoint.iteration+1 and carries token count forward', async () => {
     const runDir = tmpRunDir();
@@ -225,11 +323,19 @@ describe('runLoop — resume from checkpoint', () => {
     expect(result.stoppedBy).toBe('max');
     // Token count continued from 300: 300 + 2*100 = 500.
     expect(result.tokens).toBe(500);
-    // Resumed runs reuse the carried session id (conversation continuity).
-    expect(rec.calls.every((c) => c.sessionId === 'resumed-session-id')).toBe(true);
-    // The final checkpoint records the real iteration number, not a fresh count.
+    // The FIRST resumed iteration continues the killed run's conversation via
+    // /continue <carried id>; it pins its own fresh session id (not the carried
+    // one — re-passing would error "already in use").
+    expect(rec.calls[0].prompt).toBe('/continue resumed-session-id\n\niterate');
+    expect(rec.calls[0].sessionId).not.toBe('resumed-session-id');
+    // The second resumed iteration continues from the first resumed iteration.
+    expect(rec.calls[1].prompt).toBe(`/continue ${rec.calls[0].sessionId}\n\niterate`);
+    expect(rec.calls[1].sessionId).not.toBe(rec.calls[0].sessionId);
+    // The final checkpoint records the real iteration number and the LAST
+    // iteration's session id (what a future resume continues from).
     expect(checkpoints[checkpoints.length - 1].iteration).toBe(4);
     expect(checkpoints[checkpoints.length - 1].cumulativeTokens).toBe(500);
+    expect(checkpoints[checkpoints.length - 1].sessionId).toBe(rec.calls[1].sessionId);
   });
 });
 

--- a/src/lib/loop.ts
+++ b/src/lib/loop.ts
@@ -1,0 +1,339 @@
+/**
+ * Autonomous loop driver (issue #332).
+ *
+ * Re-injects an entrypoint each iteration until a stop condition is met. The
+ * driver is the deterministic skeleton; the entrypoint inside stays dynamic (it
+ * can spawn subagents freely). Every guard — `max_iterations`, `budget`, the
+ * `until: signal` condition, SIGINT/SIGTERM — lives OUTSIDE the agent, so the
+ * agent cannot vote past a kill-switch (the standard answer to runaway-loop and
+ * runaway-cost failure modes; see docs/07-entrypoints-and-loops.md).
+ *
+ * Structure mirrors the teams supervisor (`runSupervisor` in teams/supervisor.ts):
+ * a bounded for-loop with a hard cap, a SIGINT/SIGTERM trap that flips a stop
+ * flag, a per-iteration guard check, an interval sleep, and a typed `stoppedBy`
+ * union for the exit reason.
+ *
+ * Token accounting: the budget cap is a TOKEN hard-cap, enforced after each
+ * turn from the usage events parsed off the agent's stream-json output. Token
+ * extraction reuses `extractUsageEvents` from budget/enforce.ts (read-only
+ * import) rather than re-implementing the per-provider parsing.
+ */
+
+import { spawn } from 'child_process';
+import { randomUUID } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { AgentId } from './types.js';
+import type { ExecOptions } from './exec.js';
+import { buildExecCommand, buildExecEnv } from './exec.js';
+import { extractUsageEvents } from './budget/enforce.js';
+import { parseTimeout } from './routines.js';
+import { writeCheckpoint, type Checkpoint } from './checkpoint.js';
+
+/** Loop block config (docs/07-entrypoints-and-loops.md → "The loop block"). */
+export interface LoopConfig {
+  /** Stop condition. `signal` reads loop-signal.json; absence is fail-closed. */
+  until?: 'signal';
+  /** Hard cap on iterations. */
+  maxIterations?: number;
+  /** Token hard-cap, enforced outside the agent. */
+  budget?: number;
+  /** Delay between iterations: "0" back-to-back, "30m" paces. */
+  interval?: string;
+}
+
+/** The loop-signal.json contract the entrypoint writes each iteration. */
+export interface LoopSignal {
+  continue: boolean;
+  reason?: string;
+}
+
+/** Why the loop stopped. Mirrors the teams supervisor exit reasons. */
+export type LoopStoppedBy =
+  | 'condition-met'
+  | 'budget'
+  | 'stalled'
+  | 'max'
+  | 'signal'
+  | 'error';
+
+/** Result of a loop run. */
+export interface LoopResult {
+  /** Iterations actually executed. */
+  iterations: number;
+  stoppedBy: LoopStoppedBy;
+  elapsedMs: number;
+  /** Cumulative tokens consumed across all iterations. */
+  tokens: number;
+  /** Last loop-signal read, if any. */
+  lastSignal?: LoopSignal;
+}
+
+/** What a single iteration's run function returns. */
+export interface IterationResult {
+  exitCode: number;
+  /** Tokens consumed this iteration (input + output + cache). */
+  tokens: number;
+}
+
+/** Per-iteration run function — the injectable seam that makes the driver testable. */
+export type RunIteration = (options: ExecOptions) => Promise<IterationResult>;
+
+/** Context the driver needs that isn't part of ExecOptions. */
+export interface LoopContext {
+  runId: string;
+  runDir: string;
+  agent: AgentId;
+  version?: string;
+  /** Iteration to start at (1 for a fresh run, checkpoint.iteration+1 for a resume). */
+  startIteration?: number;
+  /** Tokens already consumed before this driver started (carried across a resume). */
+  startTokens?: number;
+  /** Session id to pin so the agent resumes its conversation across iterations. */
+  sessionId?: string;
+}
+
+/** Dependency seams for testing. */
+export interface LoopDeps {
+  /** Per-iteration runner. Defaults to a token-capturing spawn (defaultRunIteration). */
+  runIteration?: RunIteration;
+  /** Sleep function (ms). Defaults to setTimeout-backed. Injectable so tests don't wait. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Checkpoint writer. Defaults to writeCheckpoint. */
+  writeCheckpoint?: (c: Checkpoint) => void;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+/** Path to a run's loop-signal.json. */
+export function loopSignalPath(runDir: string): string {
+  return path.join(runDir, 'loop-signal.json');
+}
+
+/**
+ * Read and parse loop-signal.json. Returns null when the file is absent or
+ * unparseable — the caller treats null as fail-closed (continue:false).
+ */
+export function readLoopSignal(runDir: string): LoopSignal | null {
+  const file = loopSignalPath(runDir);
+  if (!fs.existsSync(file)) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    if (!parsed || typeof parsed !== 'object') return null;
+    return { continue: parsed.continue === true, reason: typeof parsed.reason === 'string' ? parsed.reason : undefined };
+  } catch {
+    return null;
+  }
+}
+
+/** Delete loop-signal.json so a stale signal never carries into the next iteration. */
+export function clearLoopSignal(runDir: string): void {
+  const file = loopSignalPath(runDir);
+  try {
+    if (fs.existsSync(file)) fs.unlinkSync(file);
+  } catch {
+    /* best-effort: a missing file is the desired state anyway. */
+  }
+}
+
+/**
+ * Default per-iteration runner: spawn the agent, tee stdout, and sum token usage
+ * off the stream. This is a purpose-built token-capturing spawn for the loop's
+ * budget guard, not a re-implementation of exec's fallback/budget machinery —
+ * it reuses `buildExecCommand` / `buildExecEnv` (the canonical command/env
+ * builders) and `extractUsageEvents` (the canonical stream parser). The agent
+ * is forced to JSON/headless so the usage stream is parseable.
+ */
+export function defaultRunIteration(options: ExecOptions): Promise<IterationResult> {
+  // Force the stream-json output the usage parser needs; a loop iteration is
+  // always headless (re-injected programmatically, never an interactive TUI).
+  const execOptions: ExecOptions = { ...options, json: true, headless: true, interactive: false };
+  const cmd = buildExecCommand(execOptions);
+  const [executable, ...args] = cmd;
+  const env = buildExecEnv(execOptions);
+  const cwd = execOptions.cwd || process.cwd();
+  const model = execOptions.model ?? `${execOptions.agent}-default`;
+
+  return new Promise((resolve, reject) => {
+    const useShell = process.platform === 'win32' && (
+      !path.isAbsolute(executable) || executable.endsWith('.cmd')
+    );
+    const child = spawn(executable, args, {
+      cwd,
+      stdio: ['inherit', 'pipe', 'pipe'],
+      env,
+      shell: useShell,
+    });
+
+    let tokens = 0;
+    let pending = '';
+    if (child.stdout) {
+      child.stdout.pipe(process.stdout);
+      child.stdout.on('data', (chunk: Buffer) => {
+        const { events, rest } = extractUsageEvents(chunk.toString('utf-8'), pending, model, execOptions.agent);
+        pending = rest;
+        for (const ev of events) {
+          tokens += (ev.inputTokens ?? 0) + (ev.outputTokens ?? 0)
+            + (ev.cacheReadTokens ?? 0) + (ev.cacheCreationTokens ?? 0);
+        }
+      });
+    }
+    if (child.stderr) child.stderr.pipe(process.stderr);
+
+    child.on('error', (err) => reject(err));
+    child.on('close', (code, signal) => {
+      resolve({ exitCode: code ?? (signal ? 1 : 0), tokens });
+    });
+  });
+}
+
+/**
+ * Run the autonomous loop. Returns when a guard trips, the until-condition is
+ * met, the iteration cap is reached, or a signal arrives.
+ *
+ * stoppedBy semantics:
+ *   - `condition-met` — until=signal and the signal said stop (continue:false
+ *     OR the file was absent/corrupt → fail-closed).
+ *   - `budget`        — cumulative tokens crossed the budget cap (checked after
+ *     each turn, outside the agent).
+ *   - `max`           — ran maxIterations iterations without any earlier stop.
+ *   - `signal`        — SIGINT/SIGTERM arrived; checkpoint is written before exit.
+ *   - `error`         — an iteration threw or exited non-zero.
+ */
+export async function runLoop(
+  execOptions: ExecOptions,
+  loop: LoopConfig,
+  ctx: LoopContext,
+  deps?: LoopDeps,
+): Promise<LoopResult> {
+  const runIteration = deps?.runIteration ?? defaultRunIteration;
+  const sleep = deps?.sleep ?? defaultSleep;
+  const persist = deps?.writeCheckpoint ?? writeCheckpoint;
+
+  const startedAt = Date.now();
+  const maxIterations = loop.maxIterations ?? 1000;
+  const intervalMs = loop.interval !== undefined ? (parseTimeout(loop.interval) ?? 0) : 0;
+  // "0" interval is intentional back-to-back; parseTimeout returns null for "0"
+  // (it rejects zero/negative), so coalesce null → 0 above.
+
+  // Pin a session id so iteration >= 2 resumes the same conversation. A resume
+  // carries the prior session id in via ctx.sessionId; a fresh run mints one.
+  const sessionId = ctx.sessionId ?? randomUUID();
+  const startIteration = ctx.startIteration ?? 1;
+
+  let tokens = ctx.startTokens ?? 0;
+  let lastSignal: LoopSignal | undefined;
+
+  let stopSignal = false;
+  const onSig = () => { stopSignal = true; };
+  process.once('SIGINT', onSig);
+  process.once('SIGTERM', onSig);
+
+  const checkpoint = (iteration: number): void => {
+    const now = new Date().toISOString();
+    persist({
+      id: ctx.runId,
+      agent: ctx.agent,
+      version: ctx.version,
+      prompt: execOptions.prompt,
+      sessionId,
+      iteration,
+      loop,
+      loopSignal: lastSignal,
+      cumulativeTokens: tokens,
+      createdAt: now,
+      updatedAt: now,
+    });
+  };
+
+  const done = (iterations: number, stoppedBy: LoopStoppedBy): LoopResult => ({
+    iterations,
+    stoppedBy,
+    elapsedMs: Date.now() - startedAt,
+    tokens,
+    lastSignal,
+  });
+
+  try {
+    let iteration = startIteration;
+    for (; iteration <= maxIterations; iteration++) {
+      if (stopSignal) {
+        checkpoint(iteration - 1);
+        return done(iteration - startIteration, 'signal');
+      }
+
+      // Iteration >= 2 (counting from the very first run, not the resume offset)
+      // pins --session-id so Claude resumes its conversation. Re-inject the
+      // prompt every iteration.
+      //
+      // AGENTS_LOOP_SIGNAL / AGENTS_RUN_DIR: tell the entrypoint where to write
+      // loop-signal.json so the guard (read OUTSIDE the agent) can see it. The
+      // agent never decides whether to continue — it only writes its vote.
+      const iterOptions: ExecOptions = {
+        ...execOptions,
+        sessionId: iteration >= 2 ? sessionId : (execOptions.sessionId ?? sessionId),
+        env: {
+          ...execOptions.env,
+          AGENTS_RUN_DIR: ctx.runDir,
+          AGENTS_LOOP_SIGNAL: loopSignalPath(ctx.runDir),
+          AGENTS_LOOP_ITERATION: String(iteration),
+        },
+      };
+
+      let result: IterationResult;
+      try {
+        result = await runIteration(iterOptions);
+      } catch (err) {
+        checkpoint(iteration - 1);
+        process.stderr.write(`[loop] iteration ${iteration} failed: ${(err as Error).message}\n`);
+        return done(iteration - startIteration, 'error');
+      }
+
+      tokens += result.tokens;
+      const completed = iteration - startIteration + 1;
+
+      // until=signal: read the signal the entrypoint wrote this iteration.
+      // Absent/corrupt OR continue:false => stop (fail-closed).
+      if (loop.until === 'signal') {
+        lastSignal = readLoopSignal(ctx.runDir) ?? { continue: false, reason: 'loop-signal.json absent (fail-closed)' };
+        clearLoopSignal(ctx.runDir);
+        if (!lastSignal.continue) {
+          checkpoint(iteration);
+          return done(completed, 'condition-met');
+        }
+      }
+
+      // Budget (token hard-cap), enforced after the turn — outside the agent.
+      if (loop.budget !== undefined && tokens >= loop.budget) {
+        checkpoint(iteration);
+        return done(completed, 'budget');
+      }
+
+      // A non-zero exit is a hard error — don't keep re-injecting into a broken run.
+      if (result.exitCode !== 0) {
+        checkpoint(iteration);
+        process.stderr.write(`[loop] iteration ${iteration} exited ${result.exitCode}\n`);
+        return done(completed, 'error');
+      }
+
+      checkpoint(iteration);
+
+      if (stopSignal) {
+        return done(completed, 'signal');
+      }
+
+      // Pace between iterations. Skip the sleep after the final iteration.
+      if (iteration < maxIterations && intervalMs > 0) {
+        await sleep(intervalMs);
+        if (stopSignal) {
+          return done(completed, 'signal');
+        }
+      }
+    }
+    return done(maxIterations - startIteration + 1, 'max');
+  } finally {
+    process.off('SIGINT', onSig);
+    process.off('SIGTERM', onSig);
+  }
+}

--- a/src/lib/loop.ts
+++ b/src/lib/loop.ts
@@ -89,7 +89,11 @@ export interface LoopContext {
   startIteration?: number;
   /** Tokens already consumed before this driver started (carried across a resume). */
   startTokens?: number;
-  /** Session id to pin so the agent resumes its conversation across iterations. */
+  /**
+   * On a resume, the killed run's LAST iteration session id. The first resumed
+   * iteration `/continue`s from it to thread conversation memory forward.
+   * Undefined on a fresh run (iteration 1 mints its own id, no prior to continue).
+   */
   sessionId?: string;
 }
 
@@ -109,6 +113,47 @@ const defaultSleep = (ms: number): Promise<void> =>
 /** Path to a run's loop-signal.json. */
 export function loopSignalPath(runDir: string): string {
   return path.join(runDir, 'loop-signal.json');
+}
+
+/**
+ * Build the prompt for iteration >= 2 so the agent CONTINUES the prior
+ * iteration's conversation instead of starting fresh.
+ *
+ * This reuses the repo's established cross-process Claude-continuity mechanism —
+ * the `/continue <id>` skill (see `buildFallbackPrompt` in exec.ts, which hands
+ * a rate-limit successor `/continue ${prevSessionId}`). The skill loads the
+ * prior transcript via `agents sessions <id>`, so continuity does NOT depend on
+ * the provider's native session being "active"; it reads the transcript off
+ * disk. That is why each loop iteration can safely pin a FRESH session id (the
+ * `--session-id` flag CREATES a session — re-passing one errors "Session ID
+ * already in use") while still threading the conversation forward via the
+ * prior id.
+ *
+ * The original entrypoint is re-appended after the continue directive so the
+ * agent both recalls the prior turn AND knows what to do this iteration.
+ */
+export function buildLoopContinuePrompt(prevSessionId: string, entrypoint: string): string {
+  return `/continue ${prevSessionId}\n\n${entrypoint}`;
+}
+
+/**
+ * Resolve a loop interval string to milliseconds. `"0"` is an explicit
+ * back-to-back run (0ms). Any other string must parse via parseTimeout
+ * (e.g. "30m", "1h"); an unparseable value (e.g. "30s", "5", "abc") is a
+ * configuration error and must NOT silently coalesce to 0 (which would run the
+ * loop full-speed on a typo). Throws on bad input; validate at config build
+ * time (validateLoopInterval) so the error surfaces before the loop starts.
+ */
+export function parseLoopInterval(interval: string | undefined): number {
+  if (interval === undefined) return 0;
+  if (interval.trim() === '0') return 0;
+  const ms = parseTimeout(interval);
+  if (ms === null) {
+    throw new Error(
+      `Invalid loop interval '${interval}'. Use "0" for back-to-back or a duration like "30m", "1h", "2h30m" (units: w/d/h/m).`,
+    );
+  }
+  return ms;
 }
 
 /**
@@ -213,14 +258,40 @@ export async function runLoop(
 
   const startedAt = Date.now();
   const maxIterations = loop.maxIterations ?? 1000;
-  const intervalMs = loop.interval !== undefined ? (parseTimeout(loop.interval) ?? 0) : 0;
-  // "0" interval is intentional back-to-back; parseTimeout returns null for "0"
-  // (it rejects zero/negative), so coalesce null → 0 above.
+  const intervalMs = parseLoopInterval(loop.interval);
 
-  // Pin a session id so iteration >= 2 resumes the same conversation. A resume
-  // carries the prior session id in via ctx.sessionId; a fresh run mints one.
-  const sessionId = ctx.sessionId ?? randomUUID();
+  // Per-iteration session pinning (issue #332). `--session-id` CREATES a
+  // session, so each iteration must pin a DISTINCT id — re-passing one errors
+  // "Session ID already in use". Iteration 1 pins `firstSessionId`; iteration
+  // >= 2 mints a fresh id AND injects `/continue <prior id>` so the agent
+  // threads the prior conversation forward (see buildLoopContinuePrompt).
+  //
+  // `prevSessionId` is the id whose transcript the NEXT iteration continues
+  // from. On a resume it is ctx.sessionId (the killed run's last session);
+  // on a fresh run it starts undefined and is set after iteration 1.
+  const firstSessionId = randomUUID();
+  let prevSessionId = ctx.sessionId;
+  // The session id recorded in the checkpoint is the most recent iteration's id
+  // (what a resume must continue from). Seeded to the resume id or iter-1 id.
+  let lastIterationSessionId = ctx.sessionId ?? firstSessionId;
   const startIteration = ctx.startIteration ?? 1;
+  // The loop re-injects the entrypoint every iteration, so a prompt is required.
+  // The command layer enforces this before dispatch; assert it here so the
+  // continuity prompt-builder has a defined entrypoint to thread.
+  if (execOptions.prompt === undefined) {
+    throw new Error('runLoop requires execOptions.prompt — the loop re-injects the entrypoint each iteration.');
+  }
+  const entrypointPrompt = execOptions.prompt;
+  // `/continue` continuity only applies to claude (the skill + native resume
+  // surface). Other agents run each iteration as an independent fresh
+  // conversation — warn so the lost continuity is never silent.
+  const continuitySupported = ctx.agent === 'claude';
+  if (!continuitySupported && maxIterations !== 1) {
+    process.stderr.write(
+      `[loop] WARNING: cross-iteration conversation continuity applies to claude only. ` +
+      `Each ${ctx.agent} iteration runs as an independent fresh conversation (no /continue handoff).\n`,
+    );
+  }
 
   let tokens = ctx.startTokens ?? 0;
   let lastSignal: LoopSignal | undefined;
@@ -236,8 +307,11 @@ export async function runLoop(
       id: ctx.runId,
       agent: ctx.agent,
       version: ctx.version,
-      prompt: execOptions.prompt,
-      sessionId,
+      prompt: entrypointPrompt,
+      // Resume must continue from the LAST iteration's conversation, so the
+      // checkpoint records that iteration's session id (the one a future
+      // `/continue` should thread from), not a single pinned id.
+      sessionId: lastIterationSessionId,
       iteration,
       loop,
       loopSignal: lastSignal,
@@ -263,16 +337,30 @@ export async function runLoop(
         return done(iteration - startIteration, 'signal');
       }
 
-      // Iteration >= 2 (counting from the very first run, not the resume offset)
-      // pins --session-id so Claude resumes its conversation. Re-inject the
-      // prompt every iteration.
-      //
+      // Pin a DISTINCT session id every iteration (`--session-id` CREATES a
+      // session; re-passing one errors "Session ID already in use"). The first
+      // executed iteration of a fresh run reuses firstSessionId; every later
+      // iteration mints a new id.
+      const iterationSessionId =
+        prevSessionId === undefined ? firstSessionId : randomUUID();
+
+      // Continuity: when a prior iteration exists (prevSessionId set) and the
+      // agent supports it, thread the conversation forward via the established
+      // `/continue <prior id>` prompt-injection. Otherwise re-inject the bare
+      // entrypoint. prevSessionId is set after iteration 1 of a fresh run, or
+      // carried in from ctx.sessionId on a resume.
+      const iterationPrompt =
+        prevSessionId !== undefined && continuitySupported
+          ? buildLoopContinuePrompt(prevSessionId, entrypointPrompt)
+          : entrypointPrompt;
+
       // AGENTS_LOOP_SIGNAL / AGENTS_RUN_DIR: tell the entrypoint where to write
       // loop-signal.json so the guard (read OUTSIDE the agent) can see it. The
       // agent never decides whether to continue — it only writes its vote.
       const iterOptions: ExecOptions = {
         ...execOptions,
-        sessionId: iteration >= 2 ? sessionId : (execOptions.sessionId ?? sessionId),
+        prompt: iterationPrompt,
+        sessionId: iterationSessionId,
         env: {
           ...execOptions.env,
           AGENTS_RUN_DIR: ctx.runDir,
@@ -285,10 +373,21 @@ export async function runLoop(
       try {
         result = await runIteration(iterOptions);
       } catch (err) {
+        // A SIGINT/SIGTERM mid-iteration kills the child; the resulting throw
+        // is a signal stop, not an error. Check the stop flag first.
+        if (stopSignal) {
+          checkpoint(iteration - 1);
+          return done(iteration - startIteration, 'signal');
+        }
         checkpoint(iteration - 1);
         process.stderr.write(`[loop] iteration ${iteration} failed: ${(err as Error).message}\n`);
         return done(iteration - startIteration, 'error');
       }
+
+      // This iteration's conversation is now on disk under iterationSessionId.
+      // The next iteration continues from it; a checkpoint records it for resume.
+      prevSessionId = iterationSessionId;
+      lastIterationSessionId = iterationSessionId;
 
       tokens += result.tokens;
       const completed = iteration - startIteration + 1;
@@ -310,8 +409,14 @@ export async function runLoop(
         return done(completed, 'budget');
       }
 
-      // A non-zero exit is a hard error — don't keep re-injecting into a broken run.
+      // A non-zero exit is a hard error — UNLESS a signal arrived mid-iteration.
+      // Ctrl-C kills the child (non-zero exit / SIGINT exit code); that is a
+      // 'signal' stop (exit 130), not an 'error'. Check the stop flag first.
       if (result.exitCode !== 0) {
+        if (stopSignal) {
+          checkpoint(iteration);
+          return done(completed, 'signal');
+        }
         checkpoint(iteration);
         process.stderr.write(`[loop] iteration ${iteration} exited ${result.exitCode}\n`);
         return done(completed, 'error');

--- a/src/lib/workflows.test.ts
+++ b/src/lib/workflows.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { parseLoopBlock, parseWorkflowFrontmatter } from './workflows.js';
+
+describe('parseLoopBlock — defensive coercion (issue #332)', () => {
+  it('parses a well-formed loop block', () => {
+    expect(parseLoopBlock({ until: 'signal', max_iterations: 3, budget: 500000, interval: '30m' }))
+      .toEqual({ until: 'signal', max_iterations: 3, budget: 500000, interval: '30m' });
+  });
+
+  it('returns undefined when the block is absent or not an object', () => {
+    expect(parseLoopBlock(undefined)).toBeUndefined();
+    expect(parseLoopBlock(null)).toBeUndefined();
+    expect(parseLoopBlock('signal')).toBeUndefined();
+    expect(parseLoopBlock([1, 2])).toBeUndefined();
+  });
+
+  it('drops an unknown until value (only `signal` is valid)', () => {
+    expect(parseLoopBlock({ until: 'whenever', max_iterations: 2 }))
+      .toEqual({ max_iterations: 2 });
+  });
+
+  it('drops a non-integer / non-positive max_iterations', () => {
+    expect(parseLoopBlock({ max_iterations: 2.5 })).toBeUndefined();
+    expect(parseLoopBlock({ max_iterations: 0 })).toBeUndefined();
+    expect(parseLoopBlock({ max_iterations: -3 })).toBeUndefined();
+    expect(parseLoopBlock({ max_iterations: '5' })).toBeUndefined(); // string, not number
+  });
+
+  it('drops a non-positive or non-numeric budget', () => {
+    expect(parseLoopBlock({ budget: 0 })).toBeUndefined();
+    expect(parseLoopBlock({ budget: -1 })).toBeUndefined();
+    expect(parseLoopBlock({ budget: 'lots' })).toBeUndefined();
+  });
+
+  it('drops a non-string interval', () => {
+    expect(parseLoopBlock({ interval: 30 })).toBeUndefined();
+    expect(parseLoopBlock({ interval: '0' })).toEqual({ interval: '0' });
+  });
+
+  it('returns undefined when an all-garbage block leaves no recognized field', () => {
+    expect(parseLoopBlock({ until: 'nope', max_iterations: -1, budget: 'x', interval: 5 }))
+      .toBeUndefined();
+  });
+});
+
+describe('parseWorkflowFrontmatter — loop block', () => {
+  function writeWorkflow(frontmatter: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-wf-loop-test-'));
+    fs.writeFileSync(path.join(dir, 'WORKFLOW.md'), `---\n${frontmatter}\n---\nbody\n`, 'utf-8');
+    return dir;
+  }
+
+  it('parses a declared loop block from real WORKFLOW.md frontmatter', () => {
+    const dir = writeWorkflow([
+      'name: cluster-feedback',
+      'description: cluster mentions',
+      'loop:',
+      '  until: signal',
+      '  max_iterations: 3',
+      '  budget: 500000',
+      '  interval: "0"',
+    ].join('\n'));
+    const fm = parseWorkflowFrontmatter(dir)!;
+    expect(fm.loop).toEqual({ until: 'signal', max_iterations: 3, budget: 500000, interval: '0' });
+  });
+
+  it('leaves loop undefined when no loop block is present', () => {
+    const dir = writeWorkflow('name: plain\ndescription: no loop');
+    const fm = parseWorkflowFrontmatter(dir)!;
+    expect(fm.loop).toBeUndefined();
+  });
+
+  it('drops a malformed loop block rather than passing a bad shape to the driver', () => {
+    const dir = writeWorkflow([
+      'name: bad',
+      'description: bad loop',
+      'loop:',
+      '  until: forever',
+      '  max_iterations: -1',
+    ].join('\n'));
+    const fm = parseWorkflowFrontmatter(dir)!;
+    expect(fm.loop).toBeUndefined();
+  });
+});

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -24,6 +24,22 @@ import { listInstalledVersions, getVersionHomePath } from './versions.js';
 // lib/capabilities.ts. The capability matrix on AgentConfig is the single
 // source of truth.
 
+/**
+ * The `loop:` block as it appears in WORKFLOW.md frontmatter (YAML, snake_case).
+ * Parsed defensively and translated to the camelCase LoopConfig the driver
+ * consumes (src/lib/loop.ts). See docs/07-entrypoints-and-loops.md.
+ */
+export interface LoopConfigRaw {
+  /** Stop condition. Only `signal` is supported today. */
+  until?: 'signal';
+  /** Hard cap on iterations. */
+  max_iterations?: number;
+  /** Token hard-cap, enforced outside the agent. */
+  budget?: number;
+  /** Delay between iterations ("0" back-to-back, "30m" paces). */
+  interval?: string;
+}
+
 /** Parsed WORKFLOW.md frontmatter. */
 export interface WorkflowFrontmatter {
   name: string;
@@ -40,6 +56,12 @@ export interface WorkflowFrontmatter {
    * Pass `--no-auto-secrets` to skip this injection.
    */
   secrets?: string[];
+  /**
+   * Optional loop block: wraps the workflow in a bounded until-condition loop
+   * (issue #332). When present, `agents run <workflow>` honors it without a
+   * `--loop` flag. Validated/coerced in parseWorkflowFrontmatter.
+   */
+  loop?: LoopConfigRaw;
 }
 
 /** A workflow found during repo discovery. */
@@ -89,10 +111,49 @@ export function parseWorkflowFrontmatter(workflowDir: string): WorkflowFrontmatt
       mcpServers: asStringArray(parsed.mcpServers),
       allowedAgents: asStringArray(parsed.allowedAgents),
       secrets: asStringArray(parsed.secrets),
+      loop: parseLoopBlock(parsed.loop),
     };
   } catch {
     return null;
   }
+}
+
+/**
+ * Defensively coerce a frontmatter `loop:` value into a LoopConfigRaw.
+ *
+ * Mirrors the asStringArray discipline above: a malformed field is dropped to
+ * undefined rather than passed through, so the loop driver never sees a bad
+ * shape. Returns undefined when `loop:` is absent or not an object, or when no
+ * recognized field survives coercion (an all-garbage block is treated as
+ * "no loop", not "empty loop").
+ *
+ * Field rules:
+ *   - until:          only the literal `signal` is accepted; anything else dropped.
+ *   - max_iterations: a finite positive integer; non-numbers/<=0 dropped.
+ *   - budget:         a finite positive number (tokens); non-numbers/<=0 dropped.
+ *   - interval:       a string (e.g. "0", "30m"); non-strings dropped.
+ */
+export function parseLoopBlock(v: unknown): LoopConfigRaw | undefined {
+  if (!v || typeof v !== 'object' || Array.isArray(v)) return undefined;
+  const raw = v as Record<string, unknown>;
+  const out: LoopConfigRaw = {};
+
+  if (raw.until === 'signal') out.until = 'signal';
+
+  if (typeof raw.max_iterations === 'number'
+    && Number.isFinite(raw.max_iterations)
+    && Number.isInteger(raw.max_iterations)
+    && raw.max_iterations > 0) {
+    out.max_iterations = raw.max_iterations;
+  }
+
+  if (typeof raw.budget === 'number' && Number.isFinite(raw.budget) && raw.budget > 0) {
+    out.budget = raw.budget;
+  }
+
+  if (typeof raw.interval === 'string') out.interval = raw.interval;
+
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 /**


### PR DESCRIPTION
Closes #332.

## What
Implements the specced-but-unbuilt `loop:` capability: `agents run --loop` (+ `--max-iterations`/`--budget`/`--until`/`--interval`) and `--resume-checkpoint`, plus workflow-frontmatter `loop:` support. Re-injects an entrypoint until a condition, with harness-level checkpoint/resume that survives a kill.

## Design
- `src/lib/loop.ts` `runLoop()` — modeled on the teams supervisor: bounded `max_iterations`, `until: signal` (reads `loop-signal.json`, **fail-closed** when absent/corrupt), token `budget` cap (reuses `extractUsageEvents` from `budget/enforce.ts`, no double-count), `interval` pacing. Typed `stoppedBy: condition-met|budget|stalled|max|signal|error`. Guards live outside the agent.
- `src/lib/checkpoint.ts` — atomic (temp+rename) checkpoint after every iteration and on SIGINT/SIGTERM, under `getRunsDir()`. `--resume-checkpoint` continues the same runId from `iteration+1`.
- **Conversation continuity** uses the repo's existing cross-process pattern (`/continue <id>` prompt injection + fresh session id per iteration) — verified against real Claude (iteration 2 recalls a fact from iteration 1; no "session ID already in use"). Continuity is claude-only; a warning fires for other agents.
- Signal mechanism: driver injects `AGENTS_LOOP_SIGNAL`/`AGENTS_RUN_DIR`/`AGENTS_LOOP_ITERATION`; the agent writes its vote, the driver decides outside the agent.
- Loop path runs **after** #346's pre-flight budget gate (no bypass); non-loop runs are unchanged. SIGINT mid-iteration classified as `signal` (exit 130). Malformed `--interval` rejected loudly.

## Scope
`agents run --loop` + workflow `loop:` frontmatter. Routines (`JobConfig`) loop integration is a documented follow-up.

## Verification
- `bun run build` clean; full suite **2783 passed | 46 skipped**, 0 failures (+ loop/checkpoint/workflow/integration tests).
- Real-flow: 3-iteration loop stops with `max`; `until=signal` stops with `condition-met`; kill + `--resume-checkpoint` continues from the last iteration with the same session; real-claude 2-iteration continuity transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)