### PR TITLE
fix(teams): record real teammate exit code so non-streaming agents aren't falsely failed

### DIFF
--- a/src/lib/teams/agents.exit-code.test.ts
+++ b/src/lib/teams/agents.exit-code.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Exit-code sentinel: a teammate whose process exits cleanly but whose stream
+ * emits no parsed terminal event (kimi, antigravity, droid) must resolve to
+ * COMPLETED — not the false FAILED the old hardcoded `reapProcess` produced.
+ *
+ * These spawn real processes through the production wrapper (buildSentinelCommand)
+ * and drive the real updateStatusFromProcess(), so they exercise the actual
+ * critical path with no mocking.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  AgentProcess,
+  AgentStatus,
+  buildSentinelCommand,
+  captureProcessStartTime,
+} from './agents.js';
+
+function tmpBase(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'agents-exitcode-test-'));
+}
+
+function makeAgent(base: string, id: string): AgentProcess {
+  fs.mkdirSync(path.join(base, id), { recursive: true });
+  return new AgentProcess(
+    id,
+    'test-team',
+    'kimi', // an agent whose parser emits NO `type:'result'` event
+    'do a thing',
+    null,
+    'plan',
+    null,
+    AgentStatus.RUNNING,
+    new Date(),
+    null,
+    base, // baseDir -> getAgentDir() = base/id
+  );
+}
+
+/**
+ * Spawn a teammate exactly the way launchProcess does: a detached shell that
+ * runs `cmd`, streams stdout to the agent log, and (when `sentinel`) records
+ * the real exit code to the sentinel file. Resolves once the process has exited
+ * so the caller can assert the resolved status. `sentinel: false` simulates a
+ * process killed before it could record $? (SIGKILL on timeout/stop).
+ */
+function spawnTeammate(
+  agent: AgentProcess,
+  agentDir: string,
+  cmd: string[],
+  sentinel = true,
+): Promise<void> {
+  const stdoutFd = fs.openSync(path.join(agentDir, 'stdout.log'), 'w');
+  const exitCodePath = path.join(agentDir, 'exit_code');
+  const shellCmd = sentinel
+    ? buildSentinelCommand(cmd, exitCodePath)
+    : cmd.map((c) => `'${c.replace(/'/g, `'\\''`)}'`).join(' ');
+  const child = spawn('/bin/sh', ['-c', shellCmd], {
+    stdio: ['ignore', stdoutFd, stdoutFd],
+    detached: true,
+  });
+  agent.pid = child.pid ?? null;
+  agent.startTime = agent.pid ? captureProcessStartTime(agent.pid) : null;
+  agent.status = AgentStatus.RUNNING;
+  return new Promise((resolve) => {
+    child.on('exit', () => {
+      try { fs.closeSync(stdoutFd); } catch { /* already closed */ }
+      resolve();
+    });
+  });
+}
+
+describe('teams exit-code sentinel', () => {
+  it('marks a clean exit COMPLETED even when the stream has no terminal event', async () => {
+    const base = tmpBase();
+    const agentDir = path.join(base, 'a1');
+    const agent = makeAgent(base, 'a1');
+
+    // Plain, non-JSON stdout: readNewEvents() parses no `result`/`turn.completed`
+    // event, so the verdict comes entirely from the exit code. This is the kimi/
+    // antigravity case that used to be falsely FAILED.
+    await spawnTeammate(agent, agentDir, ['echo', 'plain-text-not-json']);
+    await agent.updateStatusFromProcess();
+
+    expect(fs.readFileSync(path.join(agentDir, 'exit_code'), 'utf-8').trim()).toBe('0');
+    expect(agent.status).toBe(AgentStatus.COMPLETED);
+  });
+
+  it('marks a non-zero exit FAILED', async () => {
+    const base = tmpBase();
+    const agentDir = path.join(base, 'a2');
+    const agent = makeAgent(base, 'a2');
+
+    await spawnTeammate(agent, agentDir, ['sh', '-c', 'exit 3']);
+    await agent.updateStatusFromProcess();
+
+    expect(fs.readFileSync(path.join(agentDir, 'exit_code'), 'utf-8').trim()).toBe('3');
+    expect(agent.status).toBe(AgentStatus.FAILED);
+  });
+
+  it('marks a process killed before writing the sentinel FAILED', async () => {
+    const base = tmpBase();
+    const agentDir = path.join(base, 'a3');
+    const agent = makeAgent(base, 'a3');
+
+    // No sentinel written -> mimics SIGKILL mid-run. Absence must read as failure.
+    await spawnTeammate(agent, agentDir, ['true'], false);
+    expect(fs.existsSync(path.join(agentDir, 'exit_code'))).toBe(false);
+    await agent.updateStatusFromProcess();
+
+    expect(agent.status).toBe(AgentStatus.FAILED);
+  });
+});
+
+describe('buildSentinelCommand', () => {
+  it('appends the exit-code redirect after the command', () => {
+    const wrapped = buildSentinelCommand(['echo', 'hi'], '/tmp/x/exit_code');
+    expect(wrapped).toBe(`'echo' 'hi'; echo $? > '/tmp/x/exit_code'`);
+  });
+
+  it('single-quotes args so shell metacharacters cannot inject', () => {
+    const wrapped = buildSentinelCommand(['echo', '$(rm -rf /); `boom`'], '/tmp/exit_code');
+    // The dangerous arg is fully single-quoted; no unquoted $() or backticks.
+    expect(wrapped).toContain(`'$(rm -rf /); \`boom\`'`);
+    expect(wrapped.startsWith(`'echo' '`)).toBe(true);
+  });
+
+  it('escapes embedded single quotes via the close-escape-reopen idiom', () => {
+    const wrapped = buildSentinelCommand(["it's"], '/tmp/exit_code');
+    expect(wrapped).toBe(`'it'\\''s'; echo $? > '/tmp/exit_code'`);
+  });
+});

--- a/src/lib/teams/agents.ts
+++ b/src/lib/teams/agents.ts
@@ -147,6 +147,27 @@ function hasTransitiveDep(
 export type { AgentType } from './parsers.js';
 
 /**
+ * Single-quote a string for safe interpolation into a POSIX `sh -c` command.
+ * Wraps in single quotes and escapes embedded single quotes via the standard
+ * `'\''` close-escape-reopen idiom, so arbitrary prompts/paths can't break out
+ * of quoting or inject shell syntax.
+ */
+function shSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Wrap a teammate argv in a POSIX shell command that runs it and then records
+ * the real exit code to `exitCodePath`. `echo $?` captures the status of the
+ * preceding command, so the sentinel reflects the underlying CLI's exit code,
+ * not the shell's. Single source of truth shared by launchProcess() and its
+ * test. See reapProcess() for how the sentinel is consumed.
+ */
+export function buildSentinelCommand(cmd: string[], exitCodePath: string): string {
+  return `${cmd.map(shSingleQuote).join(' ')}; echo $? > ${shSingleQuote(exitCodePath)}`;
+}
+
+/**
  * Capture a stable identifier for a process at the moment it was started.
  * Used to defeat PID reuse: a kill(pid, ...) is only safe when the process
  * still occupies the PID we observed at spawn time. A bare kill(pid, 0)
@@ -543,6 +564,16 @@ export class AgentProcess {
     return path.join(await this.getAgentDir(), 'meta.json');
   }
 
+  /**
+   * Path to the exit-code sentinel. The launcher wraps the teammate command in
+   * a shell that writes the underlying CLI's `$?` here once it exits. Detached
+   * teammates can't be wait()ed on by the parent, so this file is the only
+   * durable record of the real exit status — see reapProcess().
+   */
+  async getExitCodePath(): Promise<string> {
+    return path.join(await this.getAgentDir(), 'exit_code');
+  }
+
   toDict(): any {
     return {
       agent_id: this.agentId,
@@ -886,12 +917,35 @@ export class AgentProcess {
     await this.saveMeta();
   }
 
+  /**
+   * Recover the teammate's exit status after its process is gone.
+   *
+   * The teammate is spawned detached + unref()'d (see launchProcess), so the
+   * parent never gets the child's exit code from the OS. Instead the launcher
+   * wraps the command in a shell that records `$?` to the exit-code sentinel.
+   * This reads that file:
+   *   - still alive            -> null (no verdict yet)
+   *   - sentinel present       -> the real exit code (0 = success)
+   *   - sentinel absent        -> 1 (the shell was killed before it could write
+   *                                  it, e.g. SIGKILL on timeout/stop — a real
+   *                                  failure)
+   *
+   * Returning a real code (not a hardcoded 1) is what lets agents whose stream
+   * never emits a parsed terminal event — kimi, antigravity, droid — be marked
+   * completed on success instead of falsely failed.
+   */
   private async reapProcess(): Promise<number | null> {
     if (!this.pid) return null;
+    // isProcessAlive() applies the start-time guard, so a recycled PID now
+    // owned by an unrelated process doesn't read as still-alive.
+    if (this.isProcessAlive()) return null;
+
     try {
-      process.kill(this.pid, 0);
-      return null;
+      const raw = (await fs.readFile(await this.getExitCodePath(), 'utf-8')).trim();
+      const code = Number.parseInt(raw, 10);
+      return Number.isNaN(code) ? 1 : code;
     } catch {
+      // No sentinel: the shell died before recording $? (killed mid-run).
       return 1;
     }
   }
@@ -1247,7 +1301,20 @@ export class AgentManager {
       const stdoutFile = await fs.open(stdoutPath, 'w');
       const stdoutFd = stdoutFile.fd;
 
-      const childProcess = spawn(cmd[0], cmd.slice(1), {
+      // Wrap the teammate command in a shell that records the underlying CLI's
+      // exit code to a sentinel file. Detached + unref()'d children can't be
+      // wait()ed on by this parent, so the sentinel is the only durable record
+      // of the real exit status — reapProcess() reads it to decide
+      // completed-vs-failed for agents whose stream emits no parsed terminal
+      // event (kimi, antigravity, droid). Remove any stale sentinel from a
+      // prior run of the same agent id first so a restart can't read it.
+      const exitCodePath = await agent.getExitCodePath();
+      await fs.rm(exitCodePath, { force: true }).catch(() => {});
+      const wrappedCmd = buildSentinelCommand(cmd, exitCodePath);
+
+      // detached:true makes the shell the process-group leader, so stop()'s
+      // `kill(-pid)` still reaches the underlying CLI through the group.
+      const childProcess = spawn('/bin/sh', ['-c', wrappedCmd], {
         stdio: ['ignore', stdoutFd, stdoutFd],
         cwd: agent.cwd || undefined,
         detached: true,


### PR DESCRIPTION
## Problem

Teammates whose stream emits no parsed terminal event are **always reported `failed`, even on a clean success**. Observed live with a 4-agent mixed team (claude, codex, kimi, antigravity): kimi and antigravity both did the work correctly (wrote their files) but the tracker marked them `failed`; meanwhile the on-disk result was correct.

Affected today:
- **kimi** — `normalizeKimi` (`src/lib/teams/parsers.ts`) handles `assistant`/`tool`/`meta` roles but never emits a `type:'result'` event.
- **antigravity** — `agy` has no working headless JSON (`--output-format json` is broken upstream, no `jsonFlags` in `src/lib/exec.ts`), so every stdout line fails `JSON.parse` and becomes a `raw` event — no terminal event ever.
- **droid** — falls through the generic normalizer (`parsers.ts`), which also never emits `result`.

## Root cause

Two bugs combine in `src/lib/teams/agents.ts`:

1. The stream path (`readNewEvents`) never sets a terminal status for these agents, so status stays `RUNNING`.
2. The fallback `reapProcess()` returned a **hardcoded `1`** whenever the process was gone. It only did `kill(pid, 0)` — a liveness probe — and could never recover a real exit code, because teammates are spawned `detached` + `unref()`'d with nothing capturing their status. So the fallback path forced `FAILED` on every successful run.

This is a textbook fallback-that-hides-a-bug: the fake `1` masquerades as an exit code.

## Fix

Wrap the spawned command in `/bin/sh -c '<cmd>; echo $? > exit_code'` so the underlying CLI's true exit code is durably recorded to a sentinel file. `reapProcess()` now reads it:

- sentinel present + `0` → `completed`
- sentinel present + non-zero → `failed`
- sentinel absent (process killed before writing it, e.g. SIGKILL on timeout/stop) → `failed`

Agent-agnostic — fixes kimi, antigravity, droid, and any future CLI regardless of whether it emits a parseable terminal event. The richer stream path still wins when an agent *does* emit a terminal event (claude/codex/gemini/cursor/grok/opencode), so timing/usage data is unaffected.

Also hardened:
- `reapProcess()` now uses `isProcessAlive()` (start-time guarded) instead of a bare `kill(pid, 0)`, so a recycled PID can't read as still-running.
- The shell wrapper becomes the process-group leader, so `stop()`'s `kill(-pid)` still reaches the underlying CLI through the group.
- A stale sentinel from a prior run of the same agent id is removed before launch.

## Tests

`src/lib/teams/agents.exit-code.test.ts` — spawns **real** processes through the shared `buildSentinelCommand` wrapper and drives the **real** `updateStatusFromProcess()` (no mocking):

- clean exit with non-JSON stdout (the kimi/antigravity case) → `completed`
- non-zero exit → `failed`
- missing sentinel (killed mid-run) → `failed`
- shell-quoting injection-safety of `buildSentinelCommand`

Without the fix, case 1 resolves to `failed` (the bug).

```
src/lib/teams/  -> 10 files, 62 tests passed (incl. 6 new)
tsc --noEmit    -> clean
```

Note: 3 unrelated test files (`agents.test.ts`, `drive-sync.test.ts`, `mcp.test.ts`) fail in this local Linux env — they spawn real claude/codex/gemini/ssh/rsync binaries. They are **byte-identical to `origin/main`** on this branch (`git diff origin/main` touches only `src/lib/teams/agents.ts`), so the failures are pre-existing/environmental, not from this change.

## Remaining manual verification

The status-resolution path is fully covered by real-process tests. A live `agents teams` run with kimi/antigravity confirming `completed` end-to-end is the one step not automated here (the live kimi run was unavailable in this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)