### PR TITLE
fix(teams): recognize kimi session.resume_hint as the terminal event

### DIFF
--- a/src/lib/teams/__tests__/parsers-kimi.test.ts
+++ b/src/lib/teams/__tests__/parsers-kimi.test.ts
@@ -9,7 +9,14 @@
  * structured summaries for Kimi teammates.
  */
 import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import { fileURLToPath } from 'url';
 import { normalizeEvents } from '../parsers.js';
+
+function fixtureLines(name: string): any[] {
+  const p = fileURLToPath(new URL(`./testdata/${name}`, import.meta.url));
+  return fs.readFileSync(p, 'utf-8').split('\n').map((l) => l.trim()).filter(Boolean).map((l) => JSON.parse(l));
+}
 
 describe('normalizeEvents(kimi)', () => {
   it('maps assistant content to a complete message', () => {
@@ -216,7 +223,7 @@ describe('normalizeEvents(kimi)', () => {
     expect(events[0].success).toBe(false);
   });
 
-  it('maps session.resume_hint meta events to init with session_id', () => {
+  it('maps session.resume_hint (kimi terminal marker) to a success result with session_id', () => {
     const events = normalizeEvents('kimi', {
       role: 'meta',
       type: 'session.resume_hint',
@@ -227,8 +234,9 @@ describe('normalizeEvents(kimi)', () => {
 
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
-      type: 'init',
+      type: 'result',
       agent: 'kimi',
+      status: 'success',
       session_id: 'sess-123',
     });
   });
@@ -287,4 +295,25 @@ describe('normalizeEvents(kimi)', () => {
     });
     expect(events[0].args).toMatchObject({ _raw: 'not-json' });
   });
+});
+
+// Captured from live `kimi` runs via `agents teams` (no-tool and tool-using).
+// Confirms session.resume_hint is the LAST event and the only terminal event —
+// so a real kimi stream resolves to exactly one success result.
+describe('normalizeEvents(kimi) — real captured streams', () => {
+  for (const fixture of ['kimi-stream-notool.jsonl', 'kimi-stream-tool.jsonl']) {
+    it(`${fixture}: emits exactly one terminal result (success), and it is last`, () => {
+      const raws = fixtureLines(fixture);
+      const events = raws.flatMap((r) => normalizeEvents('kimi', r));
+
+      const results = events.filter((e) => e.type === 'result');
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({ agent: 'kimi', status: 'success' });
+
+      // The terminal result must be the final normalized event of the stream.
+      expect(events[events.length - 1].type).toBe('result');
+      // And there is no `init` event — kimi emits none.
+      expect(events.some((e) => e.type === 'init')).toBe(false);
+    });
+  }
 });

--- a/src/lib/teams/__tests__/testdata/kimi-stream-notool.jsonl
+++ b/src/lib/teams/__tests__/testdata/kimi-stream-notool.jsonl
@@ -1,0 +1,2 @@
+{"role":"assistant","content":"pong\n\n**Summary:**\n1. I replied with the single word you requested and did not use any tools."}
+{"role":"meta","type":"session.resume_hint","session_id":"session_57dd54b1-678b-4a15-b586-3bd5d7e7623b","command":"kimi -r session_57dd54b1-678b-4a15-b586-3bd5d7e7623b","content":"To resume this session: kimi -r session_57dd54b1-678b-4a15-b586-3bd5d7e7623b"}

--- a/src/lib/teams/__tests__/testdata/kimi-stream-tool.jsonl
+++ b/src/lib/teams/__tests__/testdata/kimi-stream-tool.jsonl
@@ -1,0 +1,4 @@
+{"role":"assistant","tool_calls":[{"id":"tool_dRTWFaX7fzTHm4FhkbzOyOG3","function":{"name":"Bash","arguments":"{\"command\":\"echo hello\"}"}}]}
+{"role":"tool","tool_call_id":"tool_dRTWFaX7fzTHm4FhkbzOyOG3","content":"hello\n"}
+{"role":"assistant","content":"done\n\n**Summary:**\n1. I ran `echo hello` via the Bash tool."}
+{"role":"meta","type":"session.resume_hint","session_id":"session_9f2c","command":"kimi -r session_9f2c","content":"To resume this session: kimi -r session_9f2c"}

--- a/src/lib/teams/agents.kimi-status.test.ts
+++ b/src/lib/teams/agents.kimi-status.test.ts
@@ -1,0 +1,41 @@
+/**
+ * End-to-end wiring: a real kimi stream (terminating in session.resume_hint)
+ * must resolve a teammate to COMPLETED via the stream path, and capture the
+ * session id. Against the old parser (resume_hint -> init) the stream produced
+ * no terminal event, so status stayed RUNNING and only the exit code could
+ * resolve it — this test would fail there.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { AgentProcess, AgentStatus } from './agents.js';
+
+function fixture(name: string): string {
+  return fs.readFileSync(
+    fileURLToPath(new URL(`./__tests__/testdata/${name}`, import.meta.url)),
+    'utf-8',
+  );
+}
+
+describe('kimi teammate status from a real stream', () => {
+  it('resolves COMPLETED and captures session_id from session.resume_hint', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-kimi-status-'));
+    const id = 'k1';
+    fs.mkdirSync(path.join(base, id), { recursive: true });
+
+    const agent = new AgentProcess(
+      id, 'test-team', 'kimi', 'do a thing', null, 'plan',
+      null, AgentStatus.RUNNING, new Date(), null, base,
+    );
+
+    // Write the captured kimi stream exactly as it lands in the teammate log.
+    fs.writeFileSync(path.join(base, id, 'stdout.log'), fixture('kimi-stream-tool.jsonl'));
+
+    await agent.readNewEvents();
+
+    expect(agent.status).toBe(AgentStatus.COMPLETED);
+    expect(agent.remoteSessionId).toBe('session_9f2c');
+  });
+});

--- a/src/lib/teams/parsers.ts
+++ b/src/lib/teams/parsers.ts
@@ -946,9 +946,16 @@ function normalizeGrok(raw: any): any[] {
 //   - {"role":"assistant","content":"..."}                          → final message
 //   - {"role":"assistant","tool_calls":[{"function":{"name":"Bash","arguments":"<json>"}}]} → tool use
 //   - {"role":"tool","tool_call_id":"...","content":"..."}            → tool result
-//   - {"role":"meta","type":"session.resume_hint","session_id":"..."} → init / session id
-// Tool arguments are JSON-stringified inside `function.arguments` and must be
-// parsed before extracting paths/commands. Verified against live `kimi` runs.
+//   - {"role":"meta","type":"session.resume_hint","session_id":"..."} → terminal/result
+// Kimi emits NO dedicated result/turn-complete event and NO init event. The
+// `session.resume_hint` meta is its terminal marker: emitted exactly once, as
+// the LAST line, on clean completion (it carries the `kimi -r <id>` resume
+// command). We map it to a success `result` so the team runner resolves status
+// from the stream; the run's exit code remains the safety net for crashes that
+// never reach the hint. Tool arguments are JSON-stringified inside
+// `function.arguments` and must be parsed before extracting paths/commands.
+// Verified against live `kimi` runs (no-tool and tool-using) — see
+// __tests__/testdata/kimi-stream-*.jsonl.
 function normalizeKimi(raw: any): any[] {
   const timestamp = new Date().toISOString();
 
@@ -1078,9 +1085,14 @@ function normalizeKimi(raw: any): any[] {
   if (role === 'meta') {
     const metaType = typeof raw.type === 'string' ? raw.type : '';
     if (metaType === 'session.resume_hint') {
+      // Kimi's terminal marker (see header). Emit a success `result` so the
+      // team runner's terminal-event detection resolves the teammate to
+      // COMPLETED from the stream. session_id is preserved for cross-
+      // referencing — readNewEvents() captures it off any event.
       return [{
-        type: 'init',
+        type: 'result',
         agent: 'kimi',
+        status: 'success',
         session_id: typeof raw.session_id === 'string' ? raw.session_id : null,
         timestamp: timestamp,
       }];


### PR DESCRIPTION
Follow-up to #402 (exit-code sentinel). That PR made kimi/antigravity report the correct *status*; this one restores kimi's **stream-driven** terminal event so its status resolves from the stream (with an accurate completion time) instead of relying solely on the process exit code.

## Root cause

Kimi's `--output-format stream-json` emits **no** dedicated result/turn-complete event and **no** init event. Its only lifecycle marker is `session.resume_hint`, emitted exactly once as the **last** line on clean completion (it carries the `kimi -r <id>` resume command). `normalizeKimi` mapped it to `init` (`parsers.ts`), so the team runner's terminal-event detection (`agents.ts:686`) never fired for kimi — status stayed `RUNNING`.

Verified against live `kimi` runs via `agents teams`:

```
no-tool:   assistant(content)                    -> meta:session.resume_hint   (last)
tool-using: assistant(tool_calls) -> tool -> assistant(content) -> meta:session.resume_hint  (last)
```

`session.resume_hint` is always last, never at the start, and there is no `init`. Captured shapes checked in as `__tests__/testdata/kimi-stream-*.jsonl`.

## Fix

Map `session.resume_hint` to a success `result` (preserving `session_id`) so kimi teammates resolve to `COMPLETED` from the stream. The exit-code sentinel from #402 remains the safety net for crashes that never reach the hint (the common failure mode), so failures are still caught.

## Tests

- `parsers-kimi.test.ts`: updated the unit test (was asserting the wrong `init` mapping) to `result`/`success`; added fixture tests asserting `resume_hint` is the **sole** terminal event, occurs **last**, and no `init` is emitted — run against the real captured streams.
- `agents.kimi-status.test.ts`: writes a real kimi stream to a teammate log and drives `AgentProcess.readNewEvents()`, asserting status `COMPLETED` and `session_id` captured. Fails against the old `init` mapping.

```
src/lib/teams/  -> 11 files, 65 tests passed
tsc --noEmit    -> clean
```

## Out of scope (documented, not fixable here)
- **antigravity** — `agy` emits no headless JSON (upstream, no `jsonFlags`); nothing to parse. Relies on the exit-code sentinel.
- **droid** — not installed locally; the existing code comment forbids guessing its schema. Relies on the exit-code sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)