### PR TITLE
feat(secrets): file-backed bundles for headless/remote reads (no Touch ID)

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -43,6 +43,35 @@ Source: `src/lib/secrets/index.ts:43` (`REF_PATTERN`), `src/lib/secrets/bundles.
 
 The batch-read design means `agents secrets list` pops Touch ID once for all bundles, not once per bundle. Source: `src/lib/secrets/bundles.ts:269-271`.
 
+## File-backed bundles (headless / remote)
+
+The keychain backend is biometry-gated, so it can't be read on a headless Mac
+over SSH — there's no GUI session to satisfy Touch ID / the device passcode.
+A **file-backed** bundle stores the same items in an AES-256-GCM encrypted-file
+store (`~/.agents/.cache/secrets/<item>.enc`, scrypt-derived key) keyed by
+`AGENTS_SECRETS_PASSPHRASE` instead — no biometry, fully headless. Source:
+`src/lib/secrets/filestore.ts`, routed per-bundle in `src/lib/secrets/bundles.ts`
+(`bundleBackend`, `bundleItemStore`).
+
+```
+~/.agents/.cache/secrets/
+  agents-cli.bundles.rush.releases.enc          <- metadata (encrypted)
+  agents-cli.secrets.rush.releases.TOKEN.enc    <- value (encrypted)
+```
+
+- **Opt-in.** Create with `--backend file` (or `import --backend file`). Keychain
+  stays the default; existing bundles are untouched.
+- **macOS requires an explicit passphrase.** On a Mac the file store never
+  auto-provisions a machine-local key — reads/writes need `AGENTS_SECRETS_PASSPHRASE`
+  in the environment (or an interactive prompt). This keeps the box holding only
+  ciphertext: the passphrase is supplied per run, not stored next to the data.
+  (Linux keeps the existing locked-keyring auto-provision fallback.)
+- **The passphrase is the one key.** Hold it in a biometry-gated keychain bundle
+  on a trusted machine and forward it per run; never commit it.
+
+Recommended custody for a remote release (laptop keeps the key, the remote Mac
+holds only ciphertext): see [Recipe 8](#8-headless-release-on-a-remote-mac).
+
 ## Command Reference
 
 ### Bundle commands
@@ -56,6 +85,7 @@ The batch-read design means `agents secrets list` pops Touch ID once for all bun
 | `secrets create [name]` | Create an empty bundle | `agents secrets create prod` |
 | `secrets create [name] --description <text>` | Create with a description | `agents secrets create prod --description "Live API keys"` |
 | `secrets create [name] --allow-exec` | Enable exec: refs in this bundle | `agents secrets create tools --allow-exec` |
+| `secrets create [name] --backend <keychain\|file>` | Storage backend; `file` is passphrase-encrypted and headless-readable (see [File-backed bundles](#file-backed-bundles-headless--remote)) | `agents secrets create rush.releases --backend file` |
 | `secrets create [name] --force` | Overwrite an existing bundle | `agents secrets create prod --force` |
 | `secrets rename <old> <new>` / `mv` | Rename bundle and move all keychain items | `agents secrets rename staging prod` |
 | `secrets rename <old> <new> --force` | Overwrite destination if it exists | `agents secrets rename old new --force` |
@@ -273,6 +303,40 @@ agents browser profiles create x --browser chrome --secrets x.com
 ```
 
 Key naming: uppercase the handle, replace non-alphanumerics with `_`, suffix `_USERNAME` / `_PASSWORD` (plus `_TOTP_SECRET` for 2FA accounts).
+
+### 8. Headless release on a remote Mac
+
+Run a release on a headless Mac (e.g. a build host reached over SSH) that needs
+signing/release secrets, without any Touch ID on the remote. The laptop holds
+the one passphrase (biometry-gated) and hands it over per run; the remote holds
+only ciphertext. See [File-backed bundles](#file-backed-bundles-headless--remote).
+
+```bash
+# --- One-time setup, on the laptop ---
+# 1. Keep a strong passphrase in a biometry-gated keychain bundle (the one key).
+agents secrets generate 32 | agents secrets add release.key PASSPHRASE --value-stdin
+
+# 2. Ship the release secrets to the remote as a file-backed bundle. The laptop
+#    resolves them (one Touch ID) and forwards AGENTS_SECRETS_PASSPHRASE over
+#    stdin (never argv) so the remote can encrypt them at rest.
+export AGENTS_SECRETS_PASSPHRASE="$(agents secrets exec release.key -- printenv PASSPHRASE)"
+agents secrets export apple.com    --to-ssh --host mac-mini --remote-backend file
+agents secrets export rush.releases --to-ssh --host mac-mini --remote-backend file
+unset AGENTS_SECRETS_PASSPHRASE
+
+# --- Each release, from the laptop ---
+# Read the passphrase (one Touch ID) and run the release on the remote. The
+# passphrase reaches the remote process env, never its disk or argv.
+P="$(agents secrets exec release.key -- printenv PASSPHRASE)"   # one Touch ID
+ssh mac-mini 'AGENTS_SECRETS_PASSPHRASE=$(cat) \
+  agents secrets exec rush.releases -- ./rush/app/scripts/release.sh 0.10.0 alpha.1 --yes' <<<"$P"
+```
+
+`$(cat)` reads the passphrase from ssh stdin so it never appears in the remote
+process's argv / `ps`. The remote `agents secrets exec` decrypts the file-backed
+bundle with it — no Touch ID, no GUI. (`codesign` itself still needs the Developer
+ID identity in an unlocked keychain on the build host — a one-time `security
+import` of the `.p12`, unrelated to `agents secrets`.)
 
 ## Demo
 

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -11,7 +11,9 @@ import chalk from 'chalk';
 import * as fs from 'fs';
 import { spawnSync } from 'child_process';
 import {
+  bundleBackend,
   bundleExists,
+  bundleItemStore,
   bundleTier,
   deleteBundle,
   describeBundle,
@@ -29,12 +31,12 @@ import {
   validateExpiresFutureDated,
   validateSecretType,
   writeBundle,
+  type SecretsBackend,
   type SecretsBundle,
   type SecretsTier,
   type VarMeta,
 } from '../lib/secrets/bundles.js';
 import {
-  deleteKeychainToken,
   getKeychainToken,
   getKeychainTokens,
   hasKeychainToken,
@@ -284,7 +286,11 @@ function renderBundleRow(b: SecretsBundle): string {
     `${padVisible(created, 9)} ` +
     `${padVisible(updated, 9)} ` +
     `${padVisible(used, 7)}`;
-  return b.description ? `${head} ${chalk.gray(safePrint(b.description))}` : head.trimEnd();
+  // Mark file-backed bundles so `list` distinguishes them from keychain ones.
+  const tag = b.backend === 'file' ? chalk.magenta('[file] ') : '';
+  const desc = b.description ? chalk.gray(safePrint(b.description)) : '';
+  const trailer = `${tag}${desc}`.trimEnd();
+  return trailer ? `${head} ${trailer}` : head.trimEnd();
 }
 
 /** Colorize a variable source kind (literal, keychain, env, file, exec). */
@@ -500,6 +506,7 @@ export function registerSecretsCommands(program: Command): void {
         console.log(chalk.bold(bundle.name));
         if (bundle.description) console.log(chalk.gray(safePrint(bundle.description)));
         if (bundle.allow_exec) console.log(chalk.yellow('allow_exec: true'));
+        if (bundle.backend === 'file') console.log(chalk.gray('backend: file (passphrase-encrypted; reads need AGENTS_SECRETS_PASSPHRASE, no Touch ID)'));
         if (bundleTier(bundle) === 'session') console.log(chalk.gray('tier: session (secrets-agent eligible)'));
         if (bundle.created_at) console.log(chalk.gray(`created_at: ${bundle.created_at} (${humanAge(bundle.created_at)})`));
         if (bundle.updated_at) console.log(chalk.gray(`updated_at: ${bundle.updated_at} (${humanAge(bundle.updated_at)})`));
@@ -611,12 +618,14 @@ export function registerSecretsCommands(program: Command): void {
     .option('--description <text>', 'Free-form description')
     .option('--allow-exec', 'Allow exec: refs in this bundle (off by default)')
     .option('--tier <tier>', 'secrets-agent tier: biometry (default) or session', 'biometry')
+    .option('--backend <backend>', 'storage backend: keychain (default) or file (passphrase-encrypted, headless-readable)', 'keychain')
     .option('--force', 'Overwrite an existing bundle')
-    .action(async (name: string | undefined, opts: { description?: string; allowExec?: boolean; tier?: string; force?: boolean }) => {
+    .action(async (name: string | undefined, opts: { description?: string; allowExec?: boolean; tier?: string; backend?: string; force?: boolean }) => {
       try {
         const resolvedName = name ?? (await promptBundleName());
         validateBundleName(resolvedName);
         const tier = parseTierOpt(opts.tier);
+        const backend = parseBackendOpt(opts.backend);
         if (bundleExists(resolvedName) && !opts.force) {
           console.error(chalk.red(`Bundle '${resolvedName}' already exists. Use --force to overwrite.`));
           process.exit(1);
@@ -625,11 +634,16 @@ export function registerSecretsCommands(program: Command): void {
           name: resolvedName,
           description: opts.description,
           allow_exec: opts.allowExec,
+          backend: backend === 'file' ? 'file' : undefined,
           tier,
           vars: {},
         };
         writeBundle(bundle);
-        console.log(chalk.green(`Bundle '${resolvedName}' created${tier === 'session' ? ' (tier: session)' : ''}.`));
+        const tags = [tier === 'session' ? 'tier: session' : null, backend === 'file' ? 'backend: file' : null].filter(Boolean);
+        console.log(chalk.green(`Bundle '${resolvedName}' created${tags.length ? ` (${tags.join(', ')})` : ''}.`));
+        if (backend === 'file') {
+          console.log(chalk.gray('File-backed: items are AES-256-GCM encrypted under AGENTS_SECRETS_PASSPHRASE (no Touch ID).'));
+        }
         console.log(chalk.gray(`Try: agents secrets add ${resolvedName} MY_KEY`));
       } catch (err) {
         if (isPromptCancelled(err)) return;
@@ -756,7 +770,7 @@ export function registerSecretsCommands(program: Command): void {
           console.log(chalk.green(`${resolvedBundleName}.${resolvedKey} = <literal>`));
           return;
         }
-        // Default path: keychain-backed.
+        // Default path: stored in the bundle's backend (keychain or file).
         let secretValue: string;
         if (opts.valueStdin) {
           secretValue = readStdinSync();
@@ -765,11 +779,12 @@ export function registerSecretsCommands(program: Command): void {
           secretValue = await promptForSecret(`Enter value for ${resolvedBundleName}.${resolvedKey}`);
         }
         const item = secretsKeychainItem(resolvedBundleName, resolvedKey);
-        setKeychainToken(item, secretValue);
+        bundleItemStore(bundle.backend).set(item, secretValue);
         bundle.vars[resolvedKey] = keychainRef(resolvedKey);
         applyMeta();
         writeBundle(bundle);
-        console.log(chalk.green(`${resolvedBundleName}.${resolvedKey} stored in keychain (${item}).`));
+        const where = bundle.backend === 'file' ? 'encrypted file store' : 'keychain';
+        console.log(chalk.green(`${resolvedBundleName}.${resolvedKey} stored in ${where} (${item}).`));
       } catch (err) {
         if (isPromptCancelled(err)) return;
         console.error(chalk.red((err as Error).message));
@@ -878,9 +893,10 @@ Examples:
         writeBundle(bundle);
         if (willPurge) {
           const item = secretsKeychainItem(resolvedBundleName, raw.slice('keychain:'.length));
-          const removed = deleteKeychainToken(item);
+          const removed = bundleItemStore(bundle.backend).delete(item);
           if (removed) {
-            console.log(chalk.green(`Removed ${resolvedBundleName}.${resolvedKey} and purged keychain item.`));
+            const where = bundle.backend === 'file' ? 'encrypted file item' : 'keychain item';
+            console.log(chalk.green(`Removed ${resolvedBundleName}.${resolvedKey} and purged ${where}.`));
             return;
           }
         }
@@ -921,8 +937,9 @@ Examples:
           }
         }
         if (!opts.keepSecrets) {
+          const store = bundleItemStore(bundle.backend);
           for (const { item } of keychainItemsForBundle(bundle)) {
-            deleteKeychainToken(item);
+            store.delete(item);
           }
         }
         const existed = deleteBundle(resolvedName);
@@ -973,17 +990,19 @@ Examples:
 
   cmd
     .command('import [bundle]')
-    .description('Import keys from a .env file or a 1Password vault into a bundle. By default every key is stored in keychain.')
+    .description('Import keys from a .env file or a 1Password vault into a bundle. The bundle is created if it does not exist. Values are stored in the bundle\'s backend (keychain by default).')
     .option('--from <path>', 'Path to a .env file')
     .option('--from-1password', 'Import secrets from a 1Password vault (requires the op CLI)')
     .option('--vault <name>', '1Password vault name (used with --from-1password)')
     .option('--all-plaintext', 'Store every imported value as a literal in the bundle metadata (skip keychain item creation)')
+    .option('--backend <backend>', 'When creating the bundle: keychain (default) or file (passphrase-encrypted, headless-readable)', 'keychain')
     .option('--force', 'Overwrite an existing key in the bundle')
     .action(async (bundleName: string | undefined, opts: {
       from?: string;
       from1password?: boolean;
       vault?: string;
       allPlaintext?: boolean;
+      backend?: string;
       force?: boolean;
     }) => {
       try {
@@ -995,7 +1014,28 @@ Examples:
         }
 
         const resolvedBundleName = bundleName ?? (await pickBundleName('import into'));
-        const bundle = readBundle(resolvedBundleName);
+        const requestedBackend = parseBackendOpt(opts.backend);
+        // Read the bundle if it exists (inheriting its backend); otherwise
+        // create it with the requested backend so a single `import --backend
+        // file` works (this is what `export --to-ssh --remote-backend file`
+        // drives on the remote).
+        let bundle: SecretsBundle;
+        if (bundleExists(resolvedBundleName)) {
+          bundle = readBundle(resolvedBundleName);
+          if (requestedBackend === 'file' && bundle.backend !== 'file') {
+            throw new Error(
+              `Bundle '${resolvedBundleName}' already exists with a keychain backend; ` +
+              `--backend file cannot change it. Delete it first to recreate as file-backed.`
+            );
+          }
+        } else {
+          bundle = {
+            name: resolvedBundleName,
+            backend: requestedBackend === 'file' ? 'file' : undefined,
+            vars: {},
+          };
+        }
+        const store = bundleItemStore(bundle.backend);
         let added = 0;
         let skipped = 0;
 
@@ -1013,7 +1053,7 @@ Examples:
               bundle.vars[envKey] = { value };
             } else {
               const item = secretsKeychainItem(resolvedBundleName, envKey);
-              setKeychainToken(item, value);
+              store.set(item, value);
               bundle.vars[envKey] = keychainRef(envKey);
             }
             added++;
@@ -1035,7 +1075,7 @@ Examples:
               bundle.vars[key] = { value };
             } else {
               const item = secretsKeychainItem(resolvedBundleName, key);
-              setKeychainToken(item, value);
+              store.set(item, value);
               bundle.vars[key] = keychainRef(key);
             }
             added++;
@@ -1058,6 +1098,7 @@ Examples:
     .option('--vault <name>', '1Password vault name (used with --to-1password)')
     .option('--to-ssh', 'Push the bundle to remote machine(s) over SSH via their native agents-cli import')
     .option('--host <target...>', 'SSH target(s) for --to-ssh: host alias or user@host (repeatable)')
+    .option('--remote-backend <backend>', 'Backend for the bundle on the remote: keychain (default) or file (passphrase-encrypted, headless-readable). file forwards AGENTS_SECRETS_PASSPHRASE over stdin.', 'keychain')
     .option('--force', 'Overwrite existing keys/items on the target (used with --to-1password and --to-ssh)')
     .action(async (bundleName: string | undefined, opts: {
       plaintext?: boolean;
@@ -1065,6 +1106,7 @@ Examples:
       vault?: string;
       toSsh?: boolean;
       host?: string[];
+      remoteBackend?: string;
       force?: boolean;
     }) => {
       try {
@@ -1077,23 +1119,52 @@ Examples:
             throw new Error('--to-ssh requires at least one --host <target>.');
           }
           for (const h of hosts) assertValidSshTarget(h);
+          const remoteBackend = parseBackendOpt(opts.remoteBackend);
+          // For a file-backed remote bundle the remote must encrypt at rest with
+          // a passphrase. We forward the LOCAL AGENTS_SECRETS_PASSPHRASE — the
+          // operator unlocks it once on this (trusted, biometry-gated) machine —
+          // and ship it as the FIRST stdin line so it never lands in argv / `ps`
+          // / the remote shell history. The remote `read -r` consumes that line;
+          // `agents secrets import --from /dev/stdin` reads the .env remainder.
+          let remotePassphrase = '';
+          if (remoteBackend === 'file') {
+            remotePassphrase = process.env.AGENTS_SECRETS_PASSPHRASE ?? '';
+            if (!remotePassphrase) {
+              throw new Error(
+                '--remote-backend file needs AGENTS_SECRETS_PASSPHRASE set locally to encrypt the ' +
+                'bundle at rest on the remote. Set it for this command, then unlock it the same way per run.'
+              );
+            }
+          }
           const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `ssh export` });
           const dotenv = bundleEnvToDotenv(env);
           const keyCount = Object.keys(env).length;
-          // Drive the remote's own `agents secrets` CLI so values land in its native
-          // backend (Keychain on macOS, libsecret / encrypted-file on Linux). Create
-          // the bundle if missing, then import the piped .env. `bash -lc` so the login
-          // PATH resolves `agents`; the .env flows over ssh stdin and is never parsed
-          // by a remote shell.
+          // Drive the remote's own `agents secrets` CLI so values land in its
+          // chosen backend. `bash -lc` so the login PATH resolves `agents`; the
+          // .env (and, for file, the passphrase) flow over ssh stdin and are
+          // never parsed by a remote shell.
           const force = opts.force ? ' --force' : '';
-          const remoteAgents =
-            `agents secrets create ${shellQuote(resolvedBundleName)} >/dev/null 2>&1 || true; ` +
-            `agents secrets import ${shellQuote(resolvedBundleName)} --from /dev/stdin${force}`;
+          const backendFlag = remoteBackend === 'file' ? ' --backend file' : '';
+          let remoteAgents: string;
+          let input: string;
+          if (remoteBackend === 'file') {
+            // import --backend file auto-creates the file-backed bundle; no
+            // separate `create` needed.
+            remoteAgents =
+              `IFS= read -r AGENTS_SECRETS_PASSPHRASE; export AGENTS_SECRETS_PASSPHRASE; ` +
+              `agents secrets import ${shellQuote(resolvedBundleName)} --from /dev/stdin${backendFlag}${force}`;
+            input = `${remotePassphrase}\n${dotenv}`;
+          } else {
+            remoteAgents =
+              `agents secrets create ${shellQuote(resolvedBundleName)} >/dev/null 2>&1 || true; ` +
+              `agents secrets import ${shellQuote(resolvedBundleName)} --from /dev/stdin${force}`;
+            input = dotenv;
+          }
           const remoteCmd = `bash -lc ${shellQuote(remoteAgents)}`;
           let failures = 0;
           for (const host of hosts) {
             const res = spawnSync('ssh', ['-o', 'BatchMode=yes', host, remoteCmd], {
-              input: dotenv,
+              input,
               stdio: ['pipe', 'pipe', 'pipe'],
               encoding: 'utf-8',
             });
@@ -1409,6 +1480,14 @@ function parseTierOpt(raw: string | undefined): SecretsTier {
     process.exit(1);
   }
   console.error(chalk.red(`Invalid --tier '${raw}'. Use 'biometry' or 'session'.`));
+  process.exit(1);
+}
+
+/** Validate a --backend value, exiting with a clear message on a bad one. */
+function parseBackendOpt(raw: string | undefined): SecretsBackend {
+  const v = (raw ?? 'keychain').toLowerCase();
+  if (v === 'keychain' || v === 'file') return v;
+  console.error(chalk.red(`Invalid --backend '${raw}'. Use 'keychain' or 'file'.`));
   process.exit(1);
 }
 

--- a/src/lib/secrets/__tests__/bundles-file-backend.test.ts
+++ b/src/lib/secrets/__tests__/bundles-file-backend.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for file-backed bundles: the opt-in, non-biometry backend used for
+ * headless / remote release runs. Items live in the AES-256-GCM encrypted-file
+ * store (filestore.ts) keyed by AGENTS_SECRETS_PASSPHRASE — never the keychain.
+ *
+ * Setup: a real temp-dir file store (real crypto, per project "no mocking" of
+ * the path under test) plus an in-memory keychain backend so the keychain
+ * branch never touches the user's real Keychain. The assertions prove the
+ * routing: file-backed values land in the file store and NOT in the keychain,
+ * backend is discovered by location, and listBundles merges both stores.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  bundleBackend,
+  bundleItemStore,
+  keychainRef,
+  listBundles,
+  readAndResolveBundleEnv,
+  readBundle,
+  writeBundle,
+  type SecretsBundle,
+} from '../bundles.js';
+import { _resetFileStoreForTest } from '../filestore.js';
+import {
+  secretsKeychainItem,
+  setKeychainBackendForTest,
+  type KeychainBackend,
+} from '../index.js';
+
+interface StoredItem { value: string }
+function makeMemoryBackend(): { backend: KeychainBackend; store: Map<string, StoredItem> } {
+  const store = new Map<string, StoredItem>();
+  const backend: KeychainBackend = {
+    has: (item) => store.has(item),
+    get: (item) => {
+      const v = store.get(item);
+      if (!v) throw new Error(`Keychain item '${item}' not found.`);
+      return v.value;
+    },
+    set: (item, value) => { store.set(item, { value }); },
+    delete: (item) => store.delete(item),
+    list: (prefix) => Array.from(store.keys()).filter((k) => k.startsWith(prefix)),
+  };
+  return { backend, store };
+}
+
+const PASS = 'per-run-passphrase';
+let restore: KeychainBackend | null = null;
+let kcStore: Map<string, StoredItem>;
+let tmpDir: string;
+
+beforeEach(() => {
+  const m = makeMemoryBackend();
+  kcStore = m.store;
+  restore = setKeychainBackendForTest(m.backend);
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-bundles-file-'));
+  process.env.AGENTS_SECRETS_PASSPHRASE = PASS;
+  _resetFileStoreForTest({ fileDir: tmpDir, passphrase: PASS });
+});
+
+afterEach(() => {
+  setKeychainBackendForTest(restore);
+  delete process.env.AGENTS_SECRETS_PASSPHRASE;
+  _resetFileStoreForTest();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Helper: create a file-backed bundle with one keychain-style secret value. */
+function createFileBundle(name: string, key: string, value: string): void {
+  const bundle: SecretsBundle = { name, backend: 'file', vars: {} };
+  bundleItemStore('file').set(secretsKeychainItem(name, key), value);
+  bundle.vars[key] = keychainRef(key);
+  writeBundle(bundle);
+}
+
+describe('file-backed bundle routing', () => {
+  it('stores items in the file store, not the keychain, and resolves them headlessly', () => {
+    createFileBundle('rel', 'TOKEN', 'sealed-value');
+
+    // Backend discovered by location (metadata .enc present in the file store).
+    expect(bundleBackend('rel')).toBe('file');
+    expect(readBundle('rel').backend).toBe('file');
+
+    // Resolves from the file store with no keychain involvement.
+    const { env } = readAndResolveBundleEnv('rel', { caller: 'test' });
+    expect(env.TOKEN).toBe('sealed-value');
+
+    // Nothing about this bundle leaked into the keychain backend.
+    const keychainKeys = Array.from(kcStore.keys());
+    expect(keychainKeys.some((k) => k.includes('rel'))).toBe(false);
+
+    // Ciphertext is on disk; plaintext is not.
+    const enc = fs.readFileSync(path.join(tmpDir, 'agents-cli.secrets.rel.TOKEN.enc'), 'utf8');
+    expect(enc).not.toContain('sealed-value');
+  });
+
+  it('resolution fails clearly when the passphrase is wrong', () => {
+    createFileBundle('rel', 'TOKEN', 'sealed-value');
+    process.env.AGENTS_SECRETS_PASSPHRASE = 'wrong';
+    _resetFileStoreForTest({ fileDir: tmpDir, passphrase: 'wrong' });
+    expect(() => readAndResolveBundleEnv('rel', { caller: 'test' })).toThrow(/decrypt|passphrase/i);
+  });
+
+  it('listBundles merges keychain and file bundles with the right backend tag', () => {
+    // A keychain bundle (lands in the in-memory keychain backend).
+    writeBundle({ name: 'kc-bundle', vars: { A: 'x' } });
+    // A file bundle (lands in the temp file store).
+    createFileBundle('file-bundle', 'TOKEN', 'v');
+
+    const bundles = listBundles();
+    const byName = Object.fromEntries(bundles.map((b) => [b.name, b]));
+    expect(byName['kc-bundle']?.backend).toBeUndefined(); // keychain ⇒ absent
+    expect(byName['file-bundle']?.backend).toBe('file');
+  });
+});

--- a/src/lib/secrets/bundles.ts
+++ b/src/lib/secrets/bundles.ts
@@ -1,12 +1,18 @@
 /**
- * Secret bundles — named sets of keychain-backed environment variables.
+ * Secret bundles — named sets of environment variables backed by a secret store.
  *
- * Bundle metadata (name, description, vars map) is stored in the macOS
- * Keychain as a JSON blob under `agents-cli.bundles.<name>`. Secret values
- * live one per keychain item under `agents-cli.secrets.<bundle>.<key>`.
- * Every item is device-local and gated by Touch ID / device passcode — see
- * src/lib/secrets/index.ts for the access-control story. Nothing about
- * secrets ever lives in plaintext on disk.
+ * Bundle metadata (name, description, vars map) is stored as a JSON blob under
+ * `agents-cli.bundles.<name>`; secret values live one per item under
+ * `agents-cli.secrets.<bundle>.<key>`. Two backends carry those items:
+ *
+ *  - `keychain` (default): the macOS Keychain (device-local, Touch ID / device
+ *    passcode gated) or Linux libsecret — see src/lib/secrets/index.ts.
+ *  - `file`: an AES-256-GCM encrypted-file store keyed by a passphrase
+ *    (src/lib/secrets/filestore.ts). Opt-in, for headless / remote runs where
+ *    no biometry prompt can be satisfied (e.g. a release on a remote Mac over
+ *    SSH). The item-name scheme is identical, so the only difference is where
+ *    bytes land. A file-backed bundle is discovered by the presence of its
+ *    metadata item in the file store.
  *
  * Cross-machine sync is handled by src/lib/secrets/sync.ts via an explicit
  * encrypted export/import flow; the bundle layer is sync-agnostic.
@@ -29,8 +35,93 @@ import {
   type BundleValue,
   type SecretRef,
 } from './index.js';
+import { fileStore } from './filestore.js';
 import { emit } from '../events.js';
 import { agentGetSync, agentAutoLoadSync, secretsAgentAutoEnabled, DEFAULT_TTL_MS } from './agent.js';
+
+/** Which store carries a bundle's items. */
+export type SecretsBackend = 'keychain' | 'file';
+
+/**
+ * Uniform read/write surface over a secret store, so the bundle functions
+ * don't branch on backend at every call site.
+ */
+interface ItemStore {
+  has(item: string): boolean;
+  get(item: string): string;
+  getBatch(items: string[]): Map<string, string>;
+  set(item: string, value: string): void;
+  delete(item: string): boolean;
+  list(prefix: string): string[];
+}
+
+const keychainStore: ItemStore = {
+  has: hasKeychainToken,
+  get: getKeychainToken,
+  getBatch: getKeychainTokens,
+  set: setKeychainToken,
+  delete: deleteKeychainToken,
+  list: listKeychainItems,
+};
+
+// The file store auto-provisions a machine-local passphrase on Linux (the
+// existing headless-libsecret fallback) but NEVER on macOS: a file-backed
+// bundle on a Mac must be unlocked with an explicit AGENTS_SECRETS_PASSPHRASE
+// supplied per run, so the box holds ciphertext only. assertFileBackendUsable()
+// enforces that the passphrase is present before we touch the store.
+const FILE_ALLOW_AUTO_PROVISION = process.platform !== 'darwin';
+
+const fileItemStore: ItemStore = {
+  has: (item) => fileStore.has(item),
+  get: (item) => fileStore.get(item, { allowAutoProvision: FILE_ALLOW_AUTO_PROVISION }),
+  getBatch: (items) => {
+    const out = new Map<string, string>();
+    for (const item of items) {
+      try {
+        out.set(item, fileStore.get(item, { allowAutoProvision: FILE_ALLOW_AUTO_PROVISION }));
+      } catch {
+        // Missing/undecryptable item — absent from the map, mirroring
+        // getKeychainTokens (caller decides whether that's an error).
+      }
+    }
+    return out;
+  },
+  set: (item, value) => fileStore.set(item, value, { allowAutoProvision: FILE_ALLOW_AUTO_PROVISION }),
+  delete: (item) => fileStore.delete(item),
+  list: (prefix) => fileStore.list(prefix),
+};
+
+function itemStore(backend: SecretsBackend): ItemStore {
+  return backend === 'file' ? fileItemStore : keychainStore;
+}
+
+/**
+ * Discover a bundle's backend by location: a file-backed bundle's metadata
+ * item exists in the encrypted-file store. This is a plain file-existence
+ * check — no passphrase, no Touch ID — so it sidesteps the chicken-and-egg of
+ * "read metadata to learn where metadata lives." Absent ⇒ keychain.
+ */
+export function bundleBackend(name: string): SecretsBackend {
+  return fileStore.has(BUNDLE_META_PREFIX + name) ? 'file' : 'keychain';
+}
+
+/**
+ * Guard a file-backed bundle operation. On macOS the file store must be
+ * unlocked with an explicit passphrase (env or interactive prompt) — we refuse
+ * to silently auto-provision a machine-local key there, so a remote/headless
+ * Mac cannot decrypt on its own. Linux keeps the existing auto-provision
+ * behavior, so this is a no-op there.
+ */
+function assertFileBackendUsable(name: string): void {
+  if (process.platform !== 'darwin') return;
+  if (process.env.AGENTS_SECRETS_PASSPHRASE && process.env.AGENTS_SECRETS_PASSPHRASE.length > 0) return;
+  if (process.stdin.isTTY) return;
+  throw new Error(
+    `File-backed bundle '${name}' needs AGENTS_SECRETS_PASSPHRASE to be set on macOS ` +
+    `(no biometry prompt is available headlessly). Set it for this run, e.g.\n` +
+    `  AGENTS_SECRETS_PASSPHRASE=… agents secrets exec ${name} -- <command>`
+  );
+}
 
 /** Allowed values for a secret's `type` metadata field. */
 export const SECRET_TYPES = [
@@ -71,6 +162,8 @@ export interface SecretsBundle {
   name: string;
   description?: string;
   allow_exec?: boolean;
+  /** Which store carries this bundle's items. Absent ⇒ `keychain` (the default). */
+  backend?: SecretsBackend;
   /** Secrets-agent interaction tier. Absent ⇒ `biometry` (the safe default). */
   tier?: SecretsTier;
   /** ISO 8601 UTC timestamp. Set once on the first writeBundle() for a bundle. */
@@ -185,15 +278,24 @@ function bundleMetaItem(name: string): string {
 
 export function bundleExists(name: string): boolean {
   validateBundleName(name);
-  return hasKeychainToken(bundleMetaItem(name));
+  return itemStore(bundleBackend(name)).has(bundleMetaItem(name));
 }
 
 export function readBundle(name: string): SecretsBundle {
   validateBundleName(name);
+  const backend = bundleBackend(name);
+  if (backend === 'file') assertFileBackendUsable(name);
   let json: string;
   try {
-    json = getKeychainToken(bundleMetaItem(name));
-  } catch {
+    json = itemStore(backend).get(bundleMetaItem(name));
+  } catch (err) {
+    // A file-backed bundle whose metadata is on disk but fails to decrypt is a
+    // wrong-passphrase error, not a missing bundle — surface that clearly.
+    if (backend === 'file' && fileStore.has(bundleMetaItem(name))) {
+      throw new Error(
+        `Bundle '${name}': failed to decrypt — wrong AGENTS_SECRETS_PASSPHRASE or tampered file store. (${(err as Error).message})`,
+      );
+    }
     throw new Error(`Secrets bundle '${name}' not found.`);
   }
   let parsed: Partial<SecretsBundle>;
@@ -206,11 +308,15 @@ export function readBundle(name: string): SecretsBundle {
     throw new Error(`Bundle '${name}' is malformed.`);
   }
   // Unknown fields on the JSON (e.g. legacy sync flags) are silently dropped
-  // here; the SecretsBundle shape is the only source of truth.
+  // here; the SecretsBundle shape is the only source of truth. `backend` is
+  // authoritative from location discovery, not the persisted field.
   const bundle: SecretsBundle = {
     name,
     description: parsed.description,
     allow_exec: Boolean(parsed.allow_exec),
+    // Absent ⇒ keychain (mirrors `tier`); only set when file-backed so a
+    // keychain bundle round-trips byte-for-byte.
+    backend: backend === 'file' ? 'file' : undefined,
     tier: parseTier(parsed.tier),
     vars: parsed.vars && typeof parsed.vars === 'object' ? parsed.vars : {},
   };
@@ -238,6 +344,8 @@ export function bundleTier(bundle: SecretsBundle): SecretsTier {
 
 export function writeBundle(bundle: SecretsBundle): void {
   validateBundleName(bundle.name);
+  const backend: SecretsBackend = bundle.backend ?? 'keychain';
+  if (backend === 'file') assertFileBackendUsable(bundle.name);
   for (const key of Object.keys(bundle.vars)) {
     validateEnvKey(key);
   }
@@ -264,6 +372,7 @@ export function writeBundle(bundle: SecretsBundle): void {
   const payload = {
     description: bundle.description,
     allow_exec: bundle.allow_exec ? true : undefined,
+    backend: backend === 'file' ? 'file' : undefined,
     tier: bundle.tier === 'session' ? 'session' : undefined,
     created_at: bundle.created_at,
     updated_at: bundle.updated_at,
@@ -272,72 +381,103 @@ export function writeBundle(bundle: SecretsBundle): void {
     meta,
   };
   const json = JSON.stringify(payload);
-  setKeychainToken(bundleMetaItem(bundle.name), json);
+  itemStore(backend).set(bundleMetaItem(bundle.name), json);
   emit('secrets.set', { bundle: bundle.name });
 }
 
 export function deleteBundle(name: string): boolean {
   validateBundleName(name);
-  const deleted = deleteKeychainToken(bundleMetaItem(name));
+  const deleted = itemStore(bundleBackend(name)).delete(bundleMetaItem(name));
   if (deleted) {
     emit('secrets.delete', { bundle: name });
   }
   return deleted;
 }
 
-export function listBundles(): SecretsBundle[] {
-  let services: string[];
+/**
+ * Parse a stored metadata JSON blob into a SecretsBundle, applying the lenient
+ * posture listBundles wants (skip malformed / invalid-key bundles rather than
+ * throw). `backend` is authoritative from where the item was found. Returns
+ * null to skip.
+ */
+function parseBundleMeta(name: string, json: string, backend: SecretsBackend): SecretsBundle | null {
+  let parsed: Partial<SecretsBundle>;
   try {
-    services = listKeychainItems(BUNDLE_META_PREFIX);
+    parsed = JSON.parse(json) as Partial<SecretsBundle>;
   } catch {
-    return [];
+    return null;
   }
-  const names = services
+  if (!parsed || typeof parsed !== 'object') return null;
+  const bundle: SecretsBundle = {
+    name,
+    description: parsed.description,
+    allow_exec: Boolean(parsed.allow_exec),
+    backend: backend === 'file' ? 'file' : undefined,
+    tier: parseTier(parsed.tier),
+    vars: parsed.vars && typeof parsed.vars === 'object' ? parsed.vars : {},
+  };
+  if (typeof parsed.created_at === 'string') bundle.created_at = parsed.created_at;
+  if (typeof parsed.updated_at === 'string') bundle.updated_at = parsed.updated_at;
+  if (typeof parsed.last_used === 'string') bundle.last_used = parsed.last_used;
+  if (parsed.meta && typeof parsed.meta === 'object') bundle.meta = parsed.meta;
+  for (const key of Object.keys(bundle.vars)) {
+    if (!ENV_KEY_PATTERN.test(key)) return null;
+  }
+  return bundle;
+}
+
+export function listBundles(): SecretsBundle[] {
+  const out: SecretsBundle[] = [];
+
+  // Keychain-backed bundles: batch all metadata reads behind ONE Touch ID
+  // prompt instead of N. Bundle metadata items carry user-presence ACLs (same
+  // as secret values), so a naive loop over readBundle() spawns a fresh
+  // LAContext per item — meaning N biometric prompts for `secrets list`.
+  let keychainServices: string[] = [];
+  try {
+    keychainServices = listKeychainItems(BUNDLE_META_PREFIX);
+  } catch {
+    keychainServices = [];
+  }
+  const keychainNames = keychainServices
     .map((s) => s.slice(BUNDLE_META_PREFIX.length))
     .filter((n) => BUNDLE_NAME_PATTERN.test(n));
-  if (names.length === 0) return [];
+  if (keychainNames.length > 0) {
+    const fetched = getKeychainTokens(keychainNames.map(bundleMetaItem));
+    for (const name of keychainNames) {
+      const json = fetched.get(bundleMetaItem(name));
+      if (json === undefined) continue;
+      const bundle = parseBundleMeta(name, json, 'keychain');
+      if (bundle) out.push(bundle);
+    }
+  }
 
-  // Batch all metadata reads behind ONE Touch ID prompt instead of N. Bundle
-  // metadata items carry user-presence ACLs (same as secret values), so a naive
-  // loop over readBundle() spawns a fresh LAContext per item — meaning N
-  // biometric prompts for `secrets list`. Sharing a single context across all
-  // SecItemCopyMatching calls collapses the prompt to one. Mirrors the pattern
-  // already used by resolveBundleEnv for runtime secret injection.
-  const itemsToFetch = names.map(bundleMetaItem);
-  const fetched = getKeychainTokens(itemsToFetch);
-
-  const out: SecretsBundle[] = [];
-  for (const name of names) {
-    const json = fetched.get(bundleMetaItem(name));
-    if (json === undefined) continue;
-    let parsed: Partial<SecretsBundle>;
+  // File-backed bundles live in the encrypted-file store. Enumeration is a
+  // silent directory listing; only decryption needs the passphrase, so a
+  // `secrets list` without one still shows the names (values stay sealed).
+  let fileServices: string[] = [];
+  try {
+    fileServices = fileStore.list(BUNDLE_META_PREFIX);
+  } catch {
+    fileServices = [];
+  }
+  const fileNames = fileServices
+    .map((s) => s.slice(BUNDLE_META_PREFIX.length))
+    .filter((n) => BUNDLE_NAME_PATTERN.test(n));
+  for (const name of fileNames) {
+    let json: string;
     try {
-      parsed = JSON.parse(json) as Partial<SecretsBundle>;
+      json = fileItemStore.get(bundleMetaItem(name));
     } catch {
-      // Skip malformed bundles; surfaced via `agents secrets view <name>`.
+      // No passphrase (or wrong one): surface the bundle by name so it isn't
+      // invisible, with empty vars. `agents secrets view` reports the error.
+      out.push({ name, backend: 'file', vars: {} });
       continue;
     }
-    if (!parsed || typeof parsed !== 'object') continue;
-    const bundle: SecretsBundle = {
-      name,
-      description: parsed.description,
-      allow_exec: Boolean(parsed.allow_exec),
-      tier: parseTier(parsed.tier),
-      vars: parsed.vars && typeof parsed.vars === 'object' ? parsed.vars : {},
-    };
-    if (typeof parsed.created_at === 'string') bundle.created_at = parsed.created_at;
-    if (typeof parsed.updated_at === 'string') bundle.updated_at = parsed.updated_at;
-    if (typeof parsed.last_used === 'string') bundle.last_used = parsed.last_used;
-    if (parsed.meta && typeof parsed.meta === 'object') bundle.meta = parsed.meta;
-    // Skip bundles with invalid env keys rather than throwing — same lenient
-    // posture readBundle had via the outer catch.
-    let valid = true;
-    for (const key of Object.keys(bundle.vars)) {
-      if (!ENV_KEY_PATTERN.test(key)) { valid = false; break; }
-    }
-    if (!valid) continue;
-    out.push(bundle);
+    const bundle = parseBundleMeta(name, json, 'file');
+    if (bundle) out.push(bundle);
   }
+
   return out.sort((a, b) => a.name.localeCompare(b.name));
 }
 
@@ -420,8 +560,9 @@ export function resolveBundleEnv(bundle: SecretsBundle, _opts: ResolveBundleOpti
     }
   }
 
+  const store = itemStore(bundle.backend ?? 'keychain');
   const fetched = keychainItemsToFetch.length > 0
-    ? getKeychainTokens(keychainItemsToFetch)
+    ? store.getBatch(keychainItemsToFetch)
     : new Map<string, string>();
 
   const env: Record<string, string> = {};
@@ -436,7 +577,7 @@ export function resolveBundleEnv(bundle: SecretsBundle, _opts: ResolveBundleOpti
       const value = fetched.get(item);
       if (value === undefined) {
         throw new Error(
-          `Bundle '${bundle.name}' key '${key}': keychain item '${item}' not found. ` +
+          `Bundle '${bundle.name}' key '${key}': stored item '${item}' not found. ` +
           `Run: agents secrets add ${bundle.name} ${key}`
         );
       }
@@ -476,12 +617,15 @@ export function readAndResolveBundleEnv(
 ): { bundle: SecretsBundle; env: Record<string, string> } {
   validateBundleName(name);
 
+  const backend = bundleBackend(name);
+
   // Fast-path: if the secrets-agent holds this bundle (user ran
   // `agents secrets unlock <name>`), return the cached snapshot with no Touch
   // ID. Soft — any failure falls through to the real keychain read below. macOS
-  // only; the never-unlocked path is a single stat (agentSocketExists) so it
-  // costs nothing when the agent isn't running.
-  if (!opts.noAgent && process.env.AGENTS_SECRETS_NO_AGENT !== '1') {
+  // / keychain only — the agent exists to dedup Touch ID prompts, and a
+  // file-backed bundle has none to dedup. The never-unlocked path is a single
+  // stat (agentSocketExists) so it costs nothing when the agent isn't running.
+  if (backend === 'keychain' && !opts.noAgent && process.env.AGENTS_SECRETS_NO_AGENT !== '1') {
     const hit = agentGetSync(name);
     if (hit) {
       stampLastUsed(hit.bundle);
@@ -496,11 +640,14 @@ export function readAndResolveBundleEnv(
     }
   }
 
+  if (backend === 'file') assertFileBackendUsable(name);
+  const store = itemStore(backend);
+
   const metaItem = bundleMetaItem(name);
   const bundleSecretPrefix = `${SECRETS_ITEM_PREFIX}${name}.`;
   let secretItems: string[];
   try {
-    secretItems = listKeychainItems(bundleSecretPrefix);
+    secretItems = store.list(bundleSecretPrefix);
   } catch {
     secretItems = [];
   }
@@ -510,10 +657,19 @@ export function readAndResolveBundleEnv(
     : `read ${name} secrets`;
 
   void reason;
-  const fetched = getKeychainTokens([metaItem, ...secretItems]);
+  const fetched = store.getBatch([metaItem, ...secretItems]);
 
   const json = fetched.get(metaItem);
   if (json === undefined) {
+    // For a file-backed bundle the metadata item is on disk (that's how
+    // bundleBackend resolved to 'file'); a missing decrypt means the wrong
+    // passphrase, not a missing bundle. getBatch swallowed the decrypt error,
+    // so distinguish here rather than report a misleading "not found".
+    if (backend === 'file' && fileStore.has(metaItem)) {
+      throw new Error(
+        `Bundle '${name}': failed to decrypt — wrong AGENTS_SECRETS_PASSPHRASE or tampered file store.`,
+      );
+    }
     throw new Error(`Secrets bundle '${name}' not found.`);
   }
   let parsed: Partial<SecretsBundle>;
@@ -529,6 +685,7 @@ export function readAndResolveBundleEnv(
     name,
     description: parsed.description,
     allow_exec: Boolean(parsed.allow_exec),
+    backend: backend === 'file' ? 'file' : undefined,
     tier: parseTier(parsed.tier),
     vars: parsed.vars && typeof parsed.vars === 'object' ? parsed.vars : {},
   };
@@ -584,7 +741,7 @@ export function readAndResolveBundleEnv(
         const value = fetched.get(item);
         if (value === undefined) {
           throw new Error(
-            `Bundle '${bundle.name}' key '${key}': keychain item '${item}' not found. ` +
+            `Bundle '${bundle.name}' key '${key}': stored item '${item}' not found. ` +
             `Run: agents secrets add ${bundle.name} ${key}`,
           );
         }
@@ -607,6 +764,7 @@ export function readAndResolveBundleEnv(
     // next concurrent run reads silently. Skipped when noAgent (e.g. `unlock`,
     // which loads the agent itself). Fire-and-forget — never blocks this read.
     if (
+      backend === 'keychain' &&
       !opts.noAgent &&
       process.env.AGENTS_SECRETS_NO_AGENT !== '1' &&
       bundleTier(bundle) === 'session' &&
@@ -655,7 +813,7 @@ export function rotateBundleSecret(bundle: SecretsBundle, key: string, opts: Rot
   }
   const shortId = raw.slice('keychain:'.length);
   const item = secretsKeychainItem(bundle.name, shortId);
-  setKeychainToken(item, opts.newValue);
+  itemStore(bundle.backend ?? 'keychain').set(item, opts.newValue);
 
   if (opts.clearMeta) {
     if (bundle.meta) delete bundle.meta[key];
@@ -701,14 +859,18 @@ export function renameBundle(oldName: string, newName: string, opts: RenameOptio
     throw new Error(`Bundle '${oldName}' not found.`);
   }
   const source = readBundle(oldName);
+  // Rename stays within the source's backend. The store carries both the
+  // per-key secret items and (via writeBundle/deleteBundle) the metadata.
+  const store = itemStore(source.backend ?? 'keychain');
 
   if (bundleExists(newName)) {
     if (!opts.force) {
       throw new Error(`Bundle '${newName}' already exists. Use --force to overwrite.`);
     }
     const dest = readBundle(newName);
+    const destStore = itemStore(dest.backend ?? 'keychain');
     for (const { item } of keychainItemsForBundle(dest)) {
-      deleteKeychainToken(item);
+      destStore.delete(item);
     }
     deleteBundle(newName);
   }
@@ -721,21 +883,38 @@ export function renameBundle(oldName: string, newName: string, opts: RenameOptio
     if (typeof raw !== 'string' || !raw.startsWith('keychain:')) continue;
     const shortId = raw.slice('keychain:'.length);
     const newItem = secretsKeychainItem(newName, shortId);
-    const value = getKeychainToken(oldItem);
-    setKeychainToken(newItem, value);
+    const value = store.get(oldItem);
+    store.set(newItem, value);
   }
 
-  // writeBundle preserves source.created_at and refreshes updated_at.
+  // writeBundle preserves source.created_at, refreshes updated_at, and keeps
+  // the source backend (spread carries source.backend).
   const renamed: SecretsBundle = { ...source, name: newName };
   writeBundle(renamed);
 
-  // Cleanup: delete the old per-key keychain items, then the old metadata.
+  // Cleanup: delete the old per-key items, then the old metadata.
   for (const { item: oldItem } of sourceItems) {
-    deleteKeychainToken(oldItem);
+    store.delete(oldItem);
   }
   deleteBundle(oldName);
 
   emit('secrets.rename', { from: oldName, to: newName });
+}
+
+/**
+ * The store (keychain or encrypted file) that carries a bundle's items. The
+ * CLI uses this to read/write/delete per-key items (built with
+ * secretsKeychainItem) in the same store as the bundle's metadata, for `add` /
+ * `import` / `remove` / `delete`. Pass the bundle's resolved backend
+ * (`bundle.backend ?? 'keychain'`).
+ */
+export function bundleItemStore(backend: SecretsBackend | undefined): {
+  set(item: string, value: string): void;
+  delete(item: string): boolean;
+  get(item: string): string;
+  has(item: string): boolean;
+} {
+  return itemStore(backend ?? 'keychain');
 }
 
 // Iterate all keychain-backed keys in a bundle for cleanup on rm/unset.

--- a/src/lib/secrets/filestore.test.ts
+++ b/src/lib/secrets/filestore.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for the passphrase policy of the shared encrypted-file store.
+ *
+ * The crypto round-trip and basic file-store ops are covered by
+ * __tests__/linux.test.ts (which exercises the same module via the Linux
+ * backend re-exports). This file pins the NEW `allowAutoProvision` seam that
+ * the macOS file-backed bundle path relies on: with auto-provision OFF, a
+ * missing passphrase is a hard error and NO machine-local key is written to
+ * disk — so a remote/headless Mac can only decrypt with a passphrase handed in
+ * per run, never one sitting next to the ciphertext.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileStore, getPassphrase, _resetFileStoreForTest } from './filestore.js';
+
+describe('filestore passphrase policy (allowAutoProvision)', () => {
+  let tmpDir: string;
+  let prevTty: boolean | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-filestore-'));
+    delete process.env.AGENTS_SECRETS_PASSPHRASE;
+    // Force the headless branch deterministically regardless of how the runner
+    // was launched (a real TTY would otherwise hit the interactive prompt).
+    prevTty = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    _resetFileStoreForTest({ fileDir: tmpDir });
+  });
+
+  afterEach(() => {
+    delete process.env.AGENTS_SECRETS_PASSPHRASE;
+    Object.defineProperty(process.stdin, 'isTTY', { value: prevTty, configurable: true });
+    _resetFileStoreForTest();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('with allowAutoProvision:false and no passphrase, getPassphrase throws (no .passphrase written)', () => {
+    expect(() => getPassphrase({ allowAutoProvision: false })).toThrow(/AGENTS_SECRETS_PASSPHRASE/);
+    expect(fs.existsSync(path.join(tmpDir, '.passphrase'))).toBe(false);
+  });
+
+  it('with allowAutoProvision:false, fileStore.set refuses and writes nothing to disk', () => {
+    expect(() => fileStore.set('agents-cli.secrets.b.K', 'v', { allowAutoProvision: false }))
+      .toThrow(/AGENTS_SECRETS_PASSPHRASE/);
+    // No ciphertext, no provisioned key — the box holds nothing decryptable.
+    expect(fs.readdirSync(tmpDir)).toEqual([]);
+  });
+
+  it('with an explicit AGENTS_SECRETS_PASSPHRASE, set/get round-trips with auto-provision OFF', () => {
+    process.env.AGENTS_SECRETS_PASSPHRASE = 'per-run-key';
+    _resetFileStoreForTest({ fileDir: tmpDir });
+    const opts = { allowAutoProvision: false } as const;
+    fileStore.set('agents-cli.secrets.b.K', 'sealed', opts);
+    expect(fileStore.get('agents-cli.secrets.b.K', opts)).toBe('sealed');
+    // Encrypted on disk; the machine key was never provisioned.
+    expect(fs.existsSync(path.join(tmpDir, '.passphrase'))).toBe(false);
+    const enc = fs.readFileSync(path.join(tmpDir, 'agents-cli.secrets.b.K.enc'), 'utf8');
+    expect(enc).not.toContain('sealed');
+  });
+
+  it('with the wrong passphrase, get fails the auth tag with a clear message (auto-provision OFF)', () => {
+    process.env.AGENTS_SECRETS_PASSPHRASE = 'right';
+    _resetFileStoreForTest({ fileDir: tmpDir });
+    fileStore.set('agents-cli.secrets.b.K', 'sealed', { allowAutoProvision: false });
+    process.env.AGENTS_SECRETS_PASSPHRASE = 'wrong';
+    _resetFileStoreForTest({ fileDir: tmpDir });
+    expect(() => fileStore.get('agents-cli.secrets.b.K', { allowAutoProvision: false }))
+      .toThrow(/decrypt|passphrase/i);
+  });
+});

--- a/src/lib/secrets/filestore.ts
+++ b/src/lib/secrets/filestore.ts
@@ -1,0 +1,320 @@
+/**
+ * Passphrase-encrypted file store for secrets — platform-neutral.
+ *
+ * An AES-256-GCM encrypted-file store under `~/.agents/.cache/secrets/`. The
+ * encryption key is scrypt-derived from a passphrase read from
+ * `AGENTS_SECRETS_PASSPHRASE` (preferred), a machine-local provisioned key, or
+ * a TTY prompt. One `<item>.enc` JSON file per item, mode 0600.
+ *
+ * Two callers:
+ *  - Linux (src/lib/secrets/linux.ts): the headless fallback when the default
+ *    Secret Service collection is locked. Auto-provisions a machine-local
+ *    passphrase so `agents secrets` works out of the box on a server.
+ *  - macOS file-backed bundles (src/lib/secrets/bundles.ts): an explicit,
+ *    opt-in non-biometry backend for headless/remote release runs. The bundle
+ *    layer guards this path so it only activates with an explicit
+ *    AGENTS_SECRETS_PASSPHRASE (or TTY) — never the silent machine-local
+ *    auto-provision — so a remote box holds ciphertext only.
+ *
+ * The item-name scheme is shared with the keychain backend so a file-backed
+ * item and its keychain twin carry identical names:
+ *   `agents-cli.bundles.<name>` and `agents-cli.secrets.<bundle>.<key>`.
+ */
+
+import { execSync } from 'child_process';
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { KeychainBackend } from './index.js';
+
+// ---------- file store location ----------
+
+let fileDirOverride: string | null = null;
+let cachedPassphrase: string | null = null;
+let warnedAutoPassphrase = false;
+
+export function fileDir(): string {
+  return fileDirOverride ?? path.join(os.homedir(), '.agents', '.cache', 'secrets');
+}
+
+function ensureFileDir(): void {
+  fs.mkdirSync(fileDir(), { recursive: true, mode: 0o700 });
+}
+
+// ---------- passphrase ----------
+
+function readPassphraseFromTty(): string {
+  const fd = fs.openSync('/dev/tty', 'r+');
+  let echoDisabled = false;
+  try {
+    fs.writeSync(fd, 'Enter AGENTS_SECRETS_PASSPHRASE: ');
+    try {
+      execSync('stty -echo < /dev/tty', { stdio: 'ignore' });
+      echoDisabled = true;
+    } catch {
+      // stty not available — fall through; passphrase will echo. Better
+      // than refusing to function.
+    }
+    let pass = '';
+    const buf = Buffer.alloc(1);
+    while (true) {
+      const n = fs.readSync(fd, buf, 0, 1, null);
+      if (n === 0) break;
+      const ch = buf.toString('utf8', 0, n);
+      if (ch === '\n' || ch === '\r') break;
+      pass += ch;
+    }
+    return pass;
+  } finally {
+    if (echoDisabled) {
+      try { execSync('stty echo < /dev/tty', { stdio: 'ignore' }); } catch { /* best effort */ }
+    }
+    try { fs.writeSync(fd, '\n'); } catch { /* best effort */ }
+    fs.closeSync(fd);
+  }
+}
+
+/** Path of the auto-provisioned machine-local passphrase. Lives alongside the
+ *  encrypted items but is never itself an item (no `.enc` suffix, so it's
+ *  excluded from list/has/get and from fileFallbackPreviouslyActivated). */
+function passphraseFilePath(): string {
+  return path.join(fileDir(), '.passphrase');
+}
+
+/** True if a machine-local passphrase has already been provisioned. */
+export function machinePassphraseExists(): boolean {
+  try {
+    return fs.readFileSync(passphraseFilePath(), 'utf8').trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function readMachinePassphrase(): string | null {
+  try {
+    const p = fs.readFileSync(passphraseFilePath(), 'utf8').trim();
+    return p.length > 0 ? p : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Provision (or read back) a stable machine-local passphrase for the encrypted
+ * file store, so `agents secrets` works out of the box on a headless box where
+ * the keyring is locked and no AGENTS_SECRETS_PASSPHRASE is set.
+ *
+ * Security model: this is encryption-at-rest with the key held in a 0600 file —
+ * the same posture as an SSH private key, and identical to the common
+ * "export AGENTS_SECRETS_PASSPHRASE=… in ~/.zshenv (chmod 600)" workaround. The
+ * keyring (key in a daemon's locked memory) is stronger but is unavailable
+ * without a graphical/unlocked session. For an off-disk key, set
+ * AGENTS_SECRETS_PASSPHRASE (it always takes precedence) or unlock the keyring.
+ */
+function provisionMachinePassphrase(): string {
+  const existing = readMachinePassphrase();
+  if (existing) return existing;
+
+  ensureFileDir();
+  const generated = randomBytes(32).toString('base64');
+  const fp = passphraseFilePath();
+  try {
+    // wx: fail if a concurrent process created it first (then we read theirs).
+    fs.writeFileSync(fp, generated, { mode: 0o600, flag: 'wx' });
+  } catch {
+    const raced = readMachinePassphrase();
+    if (raced) return raced;
+    throw new Error(`Failed to provision machine-local passphrase at ${fp}.`);
+  }
+  if (!warnedAutoPassphrase) {
+    warnedAutoPassphrase = true;
+    process.stderr.write(
+      `[agents] keyring locked and no AGENTS_SECRETS_PASSPHRASE set; provisioned a ` +
+      `machine-local passphrase at ${fp} (mode 0600). Set AGENTS_SECRETS_PASSPHRASE ` +
+      `for a key held off disk.\n`
+    );
+  }
+  return generated;
+}
+
+/**
+ * Resolve the passphrase for the encrypted file store.
+ *
+ * Order: AGENTS_SECRETS_PASSPHRASE > previously-provisioned machine-local key >
+ * (interactive) TTY prompt > (headless) auto-provisioned machine-local key.
+ *
+ * `allowAutoProvision` (default true, used by the Linux fallback) controls the
+ * last two steps. macOS file-backed bundles pass `false` so a missing
+ * passphrase is a hard, explicit error instead of a silently provisioned
+ * on-disk key — the caller (bundles.ts) guards this before we get here.
+ */
+export function getPassphrase(opts: { allowAutoProvision?: boolean } = {}): string {
+  const allowAutoProvision = opts.allowAutoProvision ?? true;
+  if (cachedPassphrase !== null) return cachedPassphrase;
+  const env = process.env.AGENTS_SECRETS_PASSPHRASE;
+  if (env && env.length > 0) {
+    cachedPassphrase = env;
+    return env;
+  }
+  // A previously-provisioned machine-local passphrase is this machine's stable
+  // file-store key — prefer it for both interactive and headless runs so they
+  // always agree (a TTY run won't re-prompt once the file exists).
+  const onDisk = readMachinePassphrase();
+  if (onDisk) {
+    cachedPassphrase = onDisk;
+    return onDisk;
+  }
+  if (!allowAutoProvision) {
+    throw new Error(
+      'AGENTS_SECRETS_PASSPHRASE is not set. A passphrase is required to decrypt ' +
+      'this file-backed secret store.'
+    );
+  }
+  // First run, no env, no provisioned key: prompt when interactive, otherwise
+  // (headless — the reported bug) auto-provision instead of hard-failing.
+  if (process.stdin.isTTY) {
+    const p = readPassphraseFromTty();
+    if (!p) throw new Error('No passphrase entered.');
+    cachedPassphrase = p;
+    return p;
+  }
+  cachedPassphrase = provisionMachinePassphrase();
+  return cachedPassphrase;
+}
+
+// ---------- AES-256-GCM ----------
+
+/** Encrypted-file on-disk shape. Exported for tests. */
+export interface EncFile {
+  salt: string;
+  iv: string;
+  authTag: string;
+  ciphertext: string;
+}
+
+function deriveKey(passphrase: string, salt: Buffer): Buffer {
+  return scryptSync(passphrase, salt, 32);
+}
+
+/** Encrypt plaintext under a passphrase using AES-256-GCM with a random
+ *  scrypt salt and a random 96-bit IV. Exported for tests. */
+export function encryptForFallback(plaintext: string, passphrase: string): EncFile {
+  const salt = randomBytes(16);
+  const iv = randomBytes(12);
+  const key = deriveKey(passphrase, salt);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  return {
+    salt: salt.toString('hex'),
+    iv: iv.toString('hex'),
+    authTag: cipher.getAuthTag().toString('hex'),
+    ciphertext: ciphertext.toString('hex'),
+  };
+}
+
+/** Decrypt an EncFile under a passphrase. Throws on wrong key or tampered
+ *  ciphertext (auth-tag mismatch). Exported for tests. */
+export function decryptForFallback(enc: EncFile, passphrase: string): string {
+  const salt = Buffer.from(enc.salt, 'hex');
+  const iv = Buffer.from(enc.iv, 'hex');
+  const authTag = Buffer.from(enc.authTag, 'hex');
+  const ciphertext = Buffer.from(enc.ciphertext, 'hex');
+  const key = deriveKey(passphrase, salt);
+  const decipher = createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(authTag);
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return plaintext.toString('utf8');
+}
+
+// ---------- file backend ----------
+
+function fileFor(item: string): string {
+  return path.join(fileDir(), `${item}.enc`);
+}
+
+function fileHas(item: string): boolean {
+  return fs.existsSync(fileFor(item));
+}
+
+function fileGet(item: string, opts: { allowAutoProvision?: boolean } = {}): string {
+  const fp = fileFor(item);
+  if (!fs.existsSync(fp)) {
+    throw new Error(`Secret '${item}' not found in encrypted store.`);
+  }
+  const raw = fs.readFileSync(fp, 'utf8');
+  let parsed: EncFile;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`Encrypted secret file ${fp} is corrupt (not valid JSON).`);
+  }
+  try {
+    return decryptForFallback(parsed, getPassphrase(opts));
+  } catch {
+    throw new Error(
+      `Failed to decrypt '${item}'. Wrong AGENTS_SECRETS_PASSPHRASE or tampered file.`
+    );
+  }
+}
+
+function fileSet(item: string, value: string, opts: { allowAutoProvision?: boolean } = {}): void {
+  ensureFileDir();
+  const enc = encryptForFallback(value, getPassphrase(opts));
+  fs.writeFileSync(fileFor(item), JSON.stringify(enc), { mode: 0o600 });
+}
+
+function fileDelete(item: string): boolean {
+  const fp = fileFor(item);
+  if (!fs.existsSync(fp)) return true; // idempotent, matches secret-tool clear
+  fs.unlinkSync(fp);
+  return true;
+}
+
+function fileList(prefix: string): string[] {
+  const dir = fileDir();
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir)
+    .filter((f) => f.endsWith('.enc'))
+    .map((f) => f.slice(0, -'.enc'.length))
+    .filter((name) => name.startsWith(prefix));
+}
+
+/** True if the fallback dir has any committed encrypted items. */
+export function fileStoreHasItems(): boolean {
+  try {
+    return fs.readdirSync(fileDir()).some((e) => e.endsWith('.enc'));
+  } catch {
+    return false;
+  }
+}
+
+/** Low-level file-store ops, exported so callers (linux fallback, macOS
+ *  file-backed bundles) can opt into or out of passphrase auto-provision. */
+export const fileStore = {
+  has: fileHas,
+  get: fileGet,
+  set: fileSet,
+  delete: fileDelete,
+  list: fileList,
+};
+
+/** File-only KeychainBackend (exported for tests; the Linux backend uses these
+ *  ops with auto-provision allowed). */
+export const fileBackend: KeychainBackend = {
+  has: fileHas,
+  get: (item: string) => fileGet(item),
+  set: (item: string, value: string) => fileSet(item, value),
+  delete: fileDelete,
+  list: fileList,
+};
+
+/** Test-only: reset module state (file dir + cached passphrase). */
+export function _resetFileStoreForTest(opts: {
+  fileDir?: string | null;
+  passphrase?: string | null;
+} = {}): void {
+  fileDirOverride = opts.fileDir ?? null;
+  cachedPassphrase = opts.passphrase ?? null;
+  warnedAutoPassphrase = false;
+}

--- a/src/lib/secrets/linux.ts
+++ b/src/lib/secrets/linux.ts
@@ -7,26 +7,35 @@
  * (common on server-class Linux — no graphical login means the keyring
  * passphrase never enters the daemon, so `secret-tool store` fails with
  * "Cannot create an item in a locked collection"), we transparently switch
- * to a file-based AES-256-GCM encrypted store under
- * `~/.agents/.cache/secrets/`. The encryption key is scrypt-derived from a
- * passphrase read from `AGENTS_SECRETS_PASSPHRASE` (preferred) or a TTY
- * prompt. The decision is cached per process; one stderr line is emitted
- * the first time the fallback activates.
+ * to the AES-256-GCM encrypted-file store in ./filestore.ts. The decision is
+ * cached per process; one stderr line is emitted the first time the fallback
+ * activates.
  *
  * Secrets stored via secret-tool use:
  *   service = "agents-cli"
  *   account = username
  *   item    = the secret identifier
- *
- * File-fallback layout: one `<item>.enc` JSON file per item, mode 0600.
  */
 
-import { spawnSync, execSync } from 'child_process';
-import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'crypto';
-import * as fs from 'fs';
+import { spawnSync } from 'child_process';
 import * as os from 'os';
-import * as path from 'path';
 import type { KeychainBackend } from './index.js';
+import {
+  fileStore,
+  fileDir,
+  fileStoreHasItems,
+  machinePassphraseExists,
+  _resetFileStoreForTest,
+} from './filestore.js';
+
+// Re-exported so existing importers (and tests) can keep reaching these via
+// './linux.js'. The implementations live in ./filestore.ts.
+export {
+  encryptForFallback,
+  decryptForFallback,
+  fileBackend,
+  type EncFile,
+} from './filestore.js';
 
 const SERVICE = 'agents-cli';
 
@@ -46,13 +55,6 @@ let isAvailable = false;
 
 let useFileFallback = false;
 let warnedFallback = false;
-let warnedAutoPassphrase = false;
-let fileDirOverride: string | null = null;
-let cachedPassphrase: string | null = null;
-
-function fileDir(): string {
-  return fileDirOverride ?? path.join(os.homedir(), '.agents', '.cache', 'secrets');
-}
 
 function activateFileFallback(): void {
   if (useFileFallback) return;
@@ -70,18 +72,6 @@ function isLockedCollectionError(stderr: string): boolean {
          /Prompt was dismissed/i.test(stderr);
 }
 
-/** True if the fallback dir has any committed encrypted items. Means an
- *  earlier process (this one or another) already routed writes to the file
- *  store, so this process must keep reading/writing from the same store —
- *  otherwise `list` / `get` / `has` would silently miss them. */
-function fileFallbackPreviouslyActivated(): boolean {
-  try {
-    return fs.readdirSync(fileDir()).some((e) => e.endsWith('.enc'));
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Decide which backend a given op should use. Activates file fallback if
  * `secret-tool` is missing and `AGENTS_SECRETS_PASSPHRASE` is set, OR if a
@@ -91,7 +81,7 @@ function fileFallbackPreviouslyActivated(): boolean {
  */
 function preflight(): 'file' | 'secret-tool' {
   if (useFileFallback) return 'file';
-  if (fileFallbackPreviouslyActivated()) {
+  if (fileStoreHasItems()) {
     activateFileFallback();
     return 'file';
   }
@@ -122,246 +112,12 @@ function preflight(): 'file' | 'secret-tool' {
   return 'secret-tool';
 }
 
-// ---------- passphrase ----------
-
-function readPassphraseFromTty(): string {
-  const fd = fs.openSync('/dev/tty', 'r+');
-  let echoDisabled = false;
-  try {
-    fs.writeSync(fd, 'Enter AGENTS_SECRETS_PASSPHRASE: ');
-    try {
-      execSync('stty -echo < /dev/tty', { stdio: 'ignore' });
-      echoDisabled = true;
-    } catch {
-      // stty not available — fall through; passphrase will echo. Better
-      // than refusing to function.
-    }
-    let pass = '';
-    const buf = Buffer.alloc(1);
-    while (true) {
-      const n = fs.readSync(fd, buf, 0, 1, null);
-      if (n === 0) break;
-      const ch = buf.toString('utf8', 0, n);
-      if (ch === '\n' || ch === '\r') break;
-      pass += ch;
-    }
-    return pass;
-  } finally {
-    if (echoDisabled) {
-      try { execSync('stty echo < /dev/tty', { stdio: 'ignore' }); } catch { /* best effort */ }
-    }
-    try { fs.writeSync(fd, '\n'); } catch { /* best effort */ }
-    fs.closeSync(fd);
-  }
-}
-
-/** Path of the auto-provisioned machine-local passphrase. Lives alongside the
- *  encrypted items but is never itself an item (no `.enc` suffix, so it's
- *  excluded from list/has/get and from fileFallbackPreviouslyActivated). */
-function passphraseFilePath(): string {
-  return path.join(fileDir(), '.passphrase');
-}
-
-/** True if a machine-local passphrase has already been provisioned. */
-function machinePassphraseExists(): boolean {
-  try {
-    return fs.readFileSync(passphraseFilePath(), 'utf8').trim().length > 0;
-  } catch {
-    return false;
-  }
-}
-
-function readMachinePassphrase(): string | null {
-  try {
-    const p = fs.readFileSync(passphraseFilePath(), 'utf8').trim();
-    return p.length > 0 ? p : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Provision (or read back) a stable machine-local passphrase for the encrypted
- * file store, so `agents secrets` works out of the box on a headless box where
- * the keyring is locked and no AGENTS_SECRETS_PASSPHRASE is set.
- *
- * Security model: this is encryption-at-rest with the key held in a 0600 file —
- * the same posture as an SSH private key, and identical to the common
- * "export AGENTS_SECRETS_PASSPHRASE=… in ~/.zshenv (chmod 600)" workaround. The
- * keyring (key in a daemon's locked memory) is stronger but is unavailable
- * without a graphical/unlocked session. For an off-disk key, set
- * AGENTS_SECRETS_PASSPHRASE (it always takes precedence) or unlock the keyring.
- */
-function provisionMachinePassphrase(): string {
-  const existing = readMachinePassphrase();
-  if (existing) return existing;
-
-  ensureFileDir();
-  const generated = randomBytes(32).toString('base64');
-  const fp = passphraseFilePath();
-  try {
-    // wx: fail if a concurrent process created it first (then we read theirs).
-    fs.writeFileSync(fp, generated, { mode: 0o600, flag: 'wx' });
-  } catch {
-    const raced = readMachinePassphrase();
-    if (raced) return raced;
-    throw new Error(`Failed to provision machine-local passphrase at ${fp}.`);
-  }
-  if (!warnedAutoPassphrase) {
-    warnedAutoPassphrase = true;
-    process.stderr.write(
-      `[agents] keyring locked and no AGENTS_SECRETS_PASSPHRASE set; provisioned a ` +
-      `machine-local passphrase at ${fp} (mode 0600). Set AGENTS_SECRETS_PASSPHRASE ` +
-      `for a key held off disk.\n`
-    );
-  }
-  return generated;
-}
-
-function getPassphrase(): string {
-  if (cachedPassphrase !== null) return cachedPassphrase;
-  const env = process.env.AGENTS_SECRETS_PASSPHRASE;
-  if (env && env.length > 0) {
-    cachedPassphrase = env;
-    return env;
-  }
-  // A previously-provisioned machine-local passphrase is this machine's stable
-  // file-store key — prefer it for both interactive and headless runs so they
-  // always agree (a TTY run won't re-prompt once the file exists).
-  const onDisk = readMachinePassphrase();
-  if (onDisk) {
-    cachedPassphrase = onDisk;
-    return onDisk;
-  }
-  // First run, no env, no provisioned key: prompt when interactive, otherwise
-  // (headless — the reported bug) auto-provision instead of hard-failing.
-  if (process.stdin.isTTY) {
-    const p = readPassphraseFromTty();
-    if (!p) throw new Error('No passphrase entered.');
-    cachedPassphrase = p;
-    return p;
-  }
-  cachedPassphrase = provisionMachinePassphrase();
-  return cachedPassphrase;
-}
-
-// ---------- AES-256-GCM ----------
-
-/** Encrypted-file on-disk shape. Exported for tests. */
-export interface EncFile {
-  salt: string;
-  iv: string;
-  authTag: string;
-  ciphertext: string;
-}
-
-function deriveKey(passphrase: string, salt: Buffer): Buffer {
-  return scryptSync(passphrase, salt, 32);
-}
-
-/** Encrypt plaintext under a passphrase using AES-256-GCM with a random
- *  scrypt salt and a random 96-bit IV. Exported for tests. */
-export function encryptForFallback(plaintext: string, passphrase: string): EncFile {
-  const salt = randomBytes(16);
-  const iv = randomBytes(12);
-  const key = deriveKey(passphrase, salt);
-  const cipher = createCipheriv('aes-256-gcm', key, iv);
-  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
-  return {
-    salt: salt.toString('hex'),
-    iv: iv.toString('hex'),
-    authTag: cipher.getAuthTag().toString('hex'),
-    ciphertext: ciphertext.toString('hex'),
-  };
-}
-
-/** Decrypt an EncFile under a passphrase. Throws on wrong key or tampered
- *  ciphertext (auth-tag mismatch). Exported for tests. */
-export function decryptForFallback(enc: EncFile, passphrase: string): string {
-  const salt = Buffer.from(enc.salt, 'hex');
-  const iv = Buffer.from(enc.iv, 'hex');
-  const authTag = Buffer.from(enc.authTag, 'hex');
-  const ciphertext = Buffer.from(enc.ciphertext, 'hex');
-  const key = deriveKey(passphrase, salt);
-  const decipher = createDecipheriv('aes-256-gcm', key, iv);
-  decipher.setAuthTag(authTag);
-  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
-  return plaintext.toString('utf8');
-}
-
-// ---------- file backend ----------
-
-function fileFor(item: string): string {
-  return path.join(fileDir(), `${item}.enc`);
-}
-
-function ensureFileDir(): void {
-  fs.mkdirSync(fileDir(), { recursive: true, mode: 0o700 });
-}
-
-function fileHas(item: string): boolean {
-  return fs.existsSync(fileFor(item));
-}
-
-function fileGet(item: string): string {
-  const fp = fileFor(item);
-  if (!fs.existsSync(fp)) {
-    throw new Error(`Secret '${item}' not found in encrypted store.`);
-  }
-  const raw = fs.readFileSync(fp, 'utf8');
-  let parsed: EncFile;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    throw new Error(`Encrypted secret file ${fp} is corrupt (not valid JSON).`);
-  }
-  try {
-    return decryptForFallback(parsed, getPassphrase());
-  } catch {
-    throw new Error(
-      `Failed to decrypt '${item}'. Wrong AGENTS_SECRETS_PASSPHRASE or tampered file.`
-    );
-  }
-}
-
-function fileSet(item: string, value: string): void {
-  ensureFileDir();
-  const enc = encryptForFallback(value, getPassphrase());
-  fs.writeFileSync(fileFor(item), JSON.stringify(enc), { mode: 0o600 });
-}
-
-function fileDelete(item: string): boolean {
-  const fp = fileFor(item);
-  if (!fs.existsSync(fp)) return true; // idempotent, matches secret-tool clear
-  fs.unlinkSync(fp);
-  return true;
-}
-
-function fileList(prefix: string): string[] {
-  const dir = fileDir();
-  if (!fs.existsSync(dir)) return [];
-  return fs.readdirSync(dir)
-    .filter((f) => f.endsWith('.enc'))
-    .map((f) => f.slice(0, -'.enc'.length))
-    .filter((name) => name.startsWith(prefix));
-}
-
-/** File-only KeychainBackend (exported for tests; the public surface uses
- *  the secret-tool-with-fallback `linuxBackend` below). */
-export const fileBackend: KeychainBackend = {
-  has: fileHas,
-  get: fileGet,
-  set: fileSet,
-  delete: fileDelete,
-  list: fileList,
-};
-
 // ---------- secret-tool ops with fallback ----------
 
 /** secret-tool lookup attributes:
  *   service=agents-cli account=<user> item=<itemName> */
 export function hasSecretToolToken(item: string): boolean {
-  if (preflight() === 'file') return fileHas(item);
+  if (preflight() === 'file') return fileStore.has(item);
   const user = os.userInfo().username;
   const result = spawnSync('secret-tool', [
     'lookup',
@@ -375,13 +131,13 @@ export function hasSecretToolToken(item: string): boolean {
   const stderr = result.stderr?.toString() ?? '';
   if (isLockedCollectionError(stderr)) {
     activateFileFallback();
-    return fileHas(item);
+    return fileStore.has(item);
   }
   return false;
 }
 
 export function getSecretToolToken(item: string): string {
-  if (preflight() === 'file') return fileGet(item);
+  if (preflight() === 'file') return fileStore.get(item);
   const user = os.userInfo().username;
   const result = spawnSync('secret-tool', [
     'lookup',
@@ -397,14 +153,14 @@ export function getSecretToolToken(item: string): string {
   const stderr = result.stderr?.toString() ?? '';
   if (isLockedCollectionError(stderr)) {
     activateFileFallback();
-    return fileGet(item);
+    return fileStore.get(item);
   }
   throw new Error(`Secret '${item}' not found in keyring.`);
 }
 
 export function setSecretToolToken(item: string, value: string): void {
   if (!value || !value.trim()) throw new Error('Secret value is empty.');
-  if (preflight() === 'file') return fileSet(item, value);
+  if (preflight() === 'file') return fileStore.set(item, value);
 
   const user = os.userInfo().username;
   const label = `agents-cli: ${item}`;
@@ -422,7 +178,7 @@ export function setSecretToolToken(item: string, value: string): void {
   const stderr = result.stderr?.toString().trim() ?? '';
   if (isLockedCollectionError(stderr)) {
     activateFileFallback();
-    fileSet(item, value);
+    fileStore.set(item, value);
     return;
   }
   throw new Error(
@@ -433,7 +189,7 @@ export function setSecretToolToken(item: string, value: string): void {
 }
 
 export function deleteSecretToolToken(item: string): boolean {
-  if (preflight() === 'file') return fileDelete(item);
+  if (preflight() === 'file') return fileStore.delete(item);
   const user = os.userInfo().username;
   const result = spawnSync('secret-tool', [
     'clear',
@@ -445,7 +201,7 @@ export function deleteSecretToolToken(item: string): boolean {
   const stderr = result.stderr?.toString() ?? '';
   if (isLockedCollectionError(stderr)) {
     activateFileFallback();
-    return fileDelete(item);
+    return fileStore.delete(item);
   }
   // secret-tool clear returns 0 whether the item existed or not.
   // A non-zero exit that isn't a locked-collection error is a real failure;
@@ -487,7 +243,7 @@ export function parseSecretToolItems(output: string, prefix: string): string[] {
  * so we use secret-tool search which outputs in a specific format.
  */
 export function listSecretToolItems(prefix: string): string[] {
-  if (preflight() === 'file') return fileList(prefix);
+  if (preflight() === 'file') return fileStore.list(prefix);
   const result = spawnSync('secret-tool', [
     'search',
     '--all',
@@ -498,7 +254,7 @@ export function listSecretToolItems(prefix: string): string[] {
     const stderr = result.stderr?.toString() ?? '';
     if (isLockedCollectionError(stderr)) {
       activateFileFallback();
-      return fileList(prefix);
+      return fileStore.list(prefix);
     }
     return [];
   }
@@ -530,17 +286,16 @@ export const linuxBackend: KeychainBackend = {
 };
 
 /** Test-only: reset module state so independent test cases don't bleed
- *  passphrase / fallback decisions across each other. */
+ *  passphrase / fallback decisions across each other. File-store state (file
+ *  dir + cached passphrase) lives in ./filestore.ts and is reset there. */
 export function _resetForTest(opts: {
   fileDir?: string | null;
   forceFileFallback?: boolean;
   passphrase?: string | null;
 } = {}): void {
-  fileDirOverride = opts.fileDir ?? null;
+  _resetFileStoreForTest({ fileDir: opts.fileDir ?? null, passphrase: opts.passphrase ?? null });
   useFileFallback = opts.forceFileFallback ?? false;
   warnedFallback = false;
-  warnedAutoPassphrase = false;
-  cachedPassphrase = opts.passphrase ?? null;
   checkedAvailability = false;
   isAvailable = false;
 }


### PR DESCRIPTION
## Problem

The keychain backend is **biometry-gated**, so an `agents secrets` bundle cannot be read on a **headless Mac over SSH** — there is no GUI/Aqua session to satisfy the Touch ID / device-passcode prompt (ACL `[.biometryCurrentSet, .or, .devicePasscode]`, `keychain-helper.swift:27-44`; `index.ts:9-10` deliberately forbids a `/usr/bin/security` fast-path for our items).

That blocks an agent on a remote Mac (e.g. `mac-mini`) from running a release that pulls signing/release secrets via `agents secrets exec apple.com` / `rush.releases`. PR #405 (secrets-agent) reduced *repeat* prompts but still needs one Touch ID and a local GUI — it does nothing headless.

## Approach

Add an **opt-in, per-bundle `file` backend**: items live in an AES-256-GCM + scrypt encrypted-file store keyed by `AGENTS_SECRETS_PASSPHRASE` (no biometry), reusing the crypto that already powers the Linux locked-keyring fallback. Custody model: the laptop keeps the one passphrase (biometry-gated) and forwards it per run; the remote holds **ciphertext only**.

## Changes

- **`filestore.ts` (new)** — extracted the encrypted-file store + passphrase resolution out of `linux.ts` into a shared, platform-neutral module with an `allowAutoProvision` seam. `linux.ts` imports + re-exports it; Linux behavior is byte-for-byte unchanged.
- **`bundles.ts`** — `backend: 'keychain' | 'file'`; location-discovered routing (`bundleBackend`); an `ItemStore` abstraction; `listBundles` merges both stores; file-backed resolution skips the Touch ID secrets-agent; clearer wrong-passphrase errors. **On macOS the file backend requires an explicit passphrase and never auto-provisions a machine-local key** (Linux keeps its auto-provision fallback).
- **`secrets.ts`** — `--backend file` on `create`/`import` (import auto-creates), `--remote-backend file` on `export --to-ssh` with the passphrase forwarded over **stdin (never argv/`ps`)**, backend shown in `view`/`list`.
- **Docs** — `docs/secrets.md`: File-backed bundles section + headless-release recipe.

## Tests / verification

- New: `filestore.test.ts` (passphrase policy), `__tests__/bundles-file-backend.test.ts` (routing) — real crypto, no mocking of the path under test.
- `tsc --noEmit` clean; secrets suite **133 passed**; affected modules (daemon/wallet/secrets command) **30 passed**. (Unrelated pre-existing failure in `mcp.test.ts` — Codex argv; `mcp.ts` untouched.)
- **Real CLI flow**: created a file-backed bundle, added a key, resolved via `agents secrets exec` in a fresh process with **zero Touch ID** — value returned, ciphertext-only on disk, no plaintext; no-passphrase path errors cleanly (no hang).

## Note

A companion change (separate repo, not in this PR) adds `--yes`/`CI` to `rush/cli/scripts/release.sh` so the headless release doesn't hang on its `read -p` confirmations. `codesign` still needs the Developer ID identity in an unlocked keychain on the build host (one-time `security import`, unrelated to `agents secrets`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)