### PR TITLE
fix(secrets): harden secrets-agent auto-cache against slow broker cold-start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Fix: secrets-agent auto-cache now survives a slow broker cold-start under load**
+
+- `secrets.agent.auto` (auto-cache on first read of a `session`-tier bundle) used a fire-and-forget inline loader that gave up connecting to the broker after 3s. But the broker it spawns is itself a full CLI cold-starting; under heavy load (many concurrent agents) that can exceed 3s, so the loader quit before the broker bound and the cache silently never populated — every read kept prompting. The auto-load now runs through a detached `secrets _agent-load` worker that reuses the robust `ensureAgentRunning` path (spawn-then-ping, 20s budget) and loads synchronously, so it reliably populates even when the broker is slow to start. Manual `agents secrets unlock` was always reliable and is unchanged. (secret values still travel over stdin, never argv.)
+
 **`agents secrets unlock`: a secrets-agent that ends Touch ID prompt spam (macOS)**
 
 - macOS pops a Touch ID prompt **per bundle, per process** — the biometry assertion is process-local and macOS refuses to cache `kSecAccessControl`+biometry items, so running several agents at once (`agents teams`, parallel `agents run --secrets`) re-prompts once per process. New `agents secrets unlock <bundle>` reads the bundle once (one prompt) and holds the resolved env in a local broker; every later resolution — `agents run`, teammates, browser profiles, the routines daemon — is served from memory over a user-only Unix socket (`~/.agents/.cache/helpers/secrets-agent/`, `0700`) with no prompt. `agents secrets lock` wipes it; `agents secrets status` shows what's held and when it locks. The hold also ends on TTL expiry (default 24h, `--ttl`) and on screen-lock / sleep.

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -59,6 +59,7 @@ import {
   agentLock,
   agentStatus,
   ensureAgentRunning,
+  runAgentLoadFromStdin,
   runSecretsAgent,
 } from '../lib/secrets/agent.js';
 import { parseDuration } from '../lib/hooks/cache.js';
@@ -1463,6 +1464,13 @@ Examples:
     .description('Run the secrets-agent broker in the foreground (internal)')
     .action(async () => {
       await runSecretsAgent();
+    });
+
+  cmd
+    .command('_agent-load', { hidden: true })
+    .description('Detached auto-cache worker: load a bundle from stdin into the broker (internal)')
+    .action(async () => {
+      await runAgentLoadFromStdin();
     });
 
   registerSecretsSyncCommands(cmd);

--- a/src/lib/secrets/agent.ts
+++ b/src/lib/secrets/agent.ts
@@ -84,20 +84,24 @@ function pidPath(): string {
 }
 
 /**
- * Argv for re-invoking THIS cli to run the broker, so a side-by-side dev build
- * spawns its own broker rather than the registry-installed one. We always go
- * through `process.execPath` (the node binary) with the JS entrypoint as the
- * first arg — the entrypoint isn't reliably executable in dev builds (invoked
- * as `node dist/index.js`, no +x), so spawning it directly EACCES'd.
+ * Argv for re-invoking THIS cli with a hidden subcommand, so a side-by-side dev
+ * build spawns its own helpers rather than the registry-installed one. We always
+ * go through `process.execPath` (the node binary) with the JS entrypoint as the
+ * first arg — the entrypoint isn't reliably executable in dev builds (invoked as
+ * `node dist/index.js`, no +x), so spawning it directly EACCES'd.
  */
-function brokerSpawn(): { cmd: string; args: string[] } {
+function cliSpawn(sub: string[]): { cmd: string; args: string[] } {
   const argv1 = process.argv[1];
   const entry = argv1 && fs.existsSync(argv1) ? argv1 : null;
-  if (entry) return { cmd: process.execPath, args: [entry, 'secrets', '_agent-run'] };
+  if (entry) return { cmd: process.execPath, args: [entry, ...sub] };
   // No resolvable entrypoint (unusual) — fall back to the PATH shim.
   let bin = 'agents';
   try { bin = execFileSync('which', ['agents'], { encoding: 'utf-8' }).trim(); } catch { /* default */ }
-  return { cmd: bin, args: ['secrets', '_agent-run'] };
+  return { cmd: bin, args: sub };
+}
+
+function brokerSpawn(): { cmd: string; args: string[] } {
+  return cliSpawn(['secrets', '_agent-run']);
 }
 
 // ─── Wire protocol ───────────────────────────────────────────────────────────
@@ -382,43 +386,17 @@ export function secretsAgentAutoEnabled(): boolean {
 }
 
 /**
- * Inline node program that loads one bundle into the broker, started detached
- * from the hot path. Reads the JSON payload from stdin (so secret values never
- * appear in argv / `ps`), retries the socket for a few seconds to absorb a
- * cold-started agent, sends the load, and exits. argv after -e: [execPath, <socket>].
- */
-const DETACHED_LOAD_PROGRAM = `
-const net = require('net');
-const sock = process.argv[1];
-let input = '';
-process.stdin.setEncoding('utf-8');
-process.stdin.on('data', (d) => { input += d; });
-process.stdin.on('end', () => {
-  let payload; try { payload = JSON.parse(input); } catch (e) { process.exit(1); }
-  let attempts = 0;
-  const tryConnect = () => {
-    const c = net.createConnection(sock);
-    c.on('connect', () => {
-      c.write(JSON.stringify({ cmd: 'load', name: payload.name, bundle: payload.bundle, env: payload.env, ttlMs: payload.ttlMs }) + '\\n');
-    });
-    c.setEncoding('utf-8');
-    c.on('data', () => { try { c.destroy(); } catch (e) {} process.exit(0); });
-    c.on('error', () => {
-      try { c.destroy(); } catch (e) {}
-      if (++attempts >= 30) process.exit(1);
-      setTimeout(tryConnect, 100);
-    });
-  };
-  tryConnect();
-});
-`;
-
-/**
  * Fire-and-forget: populate the broker with a freshly-resolved bundle so the
  * NEXT process reads it without a prompt. Used by the auto-cache path after a
  * real keychain read of a `session`-tier bundle. Adds no latency to the caller
- * — it spawns the agent (if needed) and a detached loader, both unref'd, then
- * returns immediately. Entirely best-effort; never throws. macOS only.
+ * — it spawns a detached `secrets _agent-load` worker (passing the resolved env
+ * over stdin, never argv) and returns immediately.
+ *
+ * The worker reuses the robust `ensureAgentRunning` path (spawn-then-ping with a
+ * generous budget) rather than a tight inline retry loop: under heavy load the
+ * broker is itself a cold-starting full CLI and can take several seconds to bind
+ * the socket, so a short fixed budget would give up before it's ready and the
+ * cache would silently never populate. Best-effort; never throws. macOS only.
  */
 export function agentAutoLoadSync(
   name: string,
@@ -428,20 +406,37 @@ export function agentAutoLoadSync(
 ): void {
   if (!onDarwin()) return;
   try {
-    if (!agentSocketExists()) {
-      const { cmd, args } = brokerSpawn();
-      spawn(cmd, args, { stdio: 'ignore', detached: true }).unref();
-    }
-    const loader = spawn(process.execPath, ['-e', DETACHED_LOAD_PROGRAM, socketPath()], {
-      stdio: ['pipe', 'ignore', 'ignore'],
-      detached: true,
-    });
-    loader.stdin?.write(JSON.stringify({ name, bundle, env, ttlMs }));
-    loader.stdin?.end();
-    loader.unref();
+    const { cmd, args } = cliSpawn(['secrets', '_agent-load']);
+    const worker = spawn(cmd, args, { stdio: ['pipe', 'ignore', 'ignore'], detached: true });
+    worker.stdin?.write(JSON.stringify({ name, bundle, env, ttlMs }));
+    worker.stdin?.end();
+    worker.unref();
   } catch {
     // best-effort: the next read just pops Touch ID as it would today
   }
+}
+
+/**
+ * Body of the hidden `secrets _agent-load` worker. Reads one `{name, bundle,
+ * env, ttlMs}` payload from stdin, ensures the broker is up (robust, generous
+ * budget), and loads the bundle into it. Detached from the originating read, so
+ * its latency is invisible — which is why it can afford a long ensure budget.
+ */
+export async function runAgentLoadFromStdin(): Promise<void> {
+  if (!onDarwin()) return;
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  let payload: { name?: string; bundle?: SecretsBundle; env?: Record<string, string>; ttlMs?: number };
+  try {
+    payload = JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+  } catch {
+    return; // malformed payload — nothing to load
+  }
+  if (!payload || !payload.name || !payload.bundle || !payload.env) return;
+  // Generous budget: the broker is a cold-starting full CLI; under load it can
+  // take several seconds to bind. We're detached, so waiting costs nothing.
+  if (!(await ensureAgentRunning(20000))) return;
+  await agentLoad(payload.name, payload.bundle, payload.env, payload.ttlMs ?? DEFAULT_TTL_MS);
 }
 
 /** Store a resolved bundle in the broker. Returns false on transport failure. */


### PR DESCRIPTION
## Problem

`secrets.agent.auto` (auto-cache on the first read of a `session`-tier bundle) silently failed to populate the broker under load. Repro (verified live on a heavily-loaded machine): a `session`-tier bundle read with `auto: true` resolved fine, but `agents secrets status` showed no broker, and subsequent reads kept prompting Touch ID.

## Root cause

The auto path was fire-and-forget with a tight budget: it spawned the broker **and** an inline `node -e` loader that gave up connecting after `30 × 100ms = 3s` (`agent.js`). But the broker it spawns is itself a *full CLI cold-starting* — under heavy load (many concurrent agents) that easily exceeds 3s, so the loader quit before the broker bound the socket. Nothing got cached. Manual `agents secrets unlock` was never affected (it `await`s `ensureAgentRunning` and loads synchronously).

## Fix

Replace the inline loader with a hidden **`secrets _agent-load`** worker spawned detached. It reads the `{name, bundle, env, ttlMs}` payload from **stdin** (secrets never touch argv) and reuses the robust `ensureAgentRunning` path (spawn-then-ping, **20s** budget) before loading. Detached, so the long budget adds zero latency to the originating read.

## Verification

- `_agent-load` worker (stdin payload, no keychain): brings up the broker and loads ✓
- Full `agentAutoLoadSync` → `_agent-load` chain with **immediate parent exit** (mimics `secrets exec`): broker populated within ~1s ✓ (the exact scenario that failed before)
- Secrets suite: 137 passed / 5 skipped; typecheck clean.

Manual `unlock` unchanged. Ships as a patch on top of the 1.20.18 secrets-agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
