### PR TITLE
fix(self-update): upgrade bun-managed installs with bun, not npm --prefix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,9 @@ const VERSION = packageJson.version;
 import {
   NPM_PACKAGE_NAME,
   deriveGlobalPrefix,
+  detectPackageManager,
   installPackageIntoPrefix,
+  installPackageWithBun,
   verifyInstalledVersion,
   refreshAliasShims,
 } from './lib/self-update.js';
@@ -391,8 +393,16 @@ function printResolvedPackage(metadata: NpmPackageMetadata): void {
 
 async function installResolvedPackage(metadata: NpmPackageMetadata): Promise<void> {
   const packageRoot = path.resolve(__dirname, '..');
-  const prefix = deriveGlobalPrefix(packageRoot);
-  await installPackageIntoPrefix(`${NPM_PACKAGE_NAME}@${metadata.version}`, prefix);
+  const spec = `${NPM_PACKAGE_NAME}@${metadata.version}`;
+  // Upgrade with the package manager that owns this install. A bun global
+  // install lives at <bunGlobalDir>/node_modules/... (no `lib` segment), so an
+  // `npm install --prefix` would write to <bunGlobalDir>/lib/node_modules and
+  // never touch the running copy — npm exits 0, the verify below fails.
+  if (detectPackageManager(packageRoot) === 'bun') {
+    await installPackageWithBun(spec);
+  } else {
+    await installPackageIntoPrefix(spec, deriveGlobalPrefix(packageRoot));
+  }
   verifyInstalledVersion(packageRoot, metadata.version);
   refreshAliasShims(packageRoot);
   // The npm install above runs with --ignore-scripts, so the postinstall that

--- a/src/lib/self-update.test.ts
+++ b/src/lib/self-update.test.ts
@@ -4,7 +4,9 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
+  bunGlobalDir,
   deriveGlobalPrefix,
+  detectPackageManager,
   dismissUpdateVersion,
   findAgentsCliInstalls,
   installPackageIntoPrefix,
@@ -52,6 +54,40 @@ describe('deriveGlobalPrefix', () => {
   });
 });
 
+describe('detectPackageManager', () => {
+  const savedBunInstall = process.env.BUN_INSTALL;
+  afterEach(() => {
+    if (savedBunInstall === undefined) delete process.env.BUN_INSTALL;
+    else process.env.BUN_INSTALL = savedBunInstall;
+  });
+
+  it('detects bun from the BUN_INSTALL global layout (no lib segment)', () => {
+    process.env.BUN_INSTALL = '/Users/x/.bun';
+    const root = path.join(bunGlobalDir(), 'node_modules', '@phnx-labs', 'agents-cli');
+    expect(root).toBe('/Users/x/.bun/install/global/node_modules/@phnx-labs/agents-cli');
+    expect(detectPackageManager(root)).toBe('bun');
+  });
+
+  it('detects bun structurally when BUN_INSTALL is not exported (default ~/.bun)', () => {
+    delete process.env.BUN_INSTALL;
+    // A bun install rooted at a `.bun` dir other than the current $HOME's.
+    const root = path.join('/opt/someuser/.bun/install/global', 'node_modules', '@phnx-labs', 'agents-cli');
+    expect(detectPackageManager(root)).toBe('bun');
+  });
+
+  it('treats the npm POSIX layout (<prefix>/lib/node_modules) as npm', () => {
+    delete process.env.BUN_INSTALL;
+    const root = path.join('/Users/x/.nvm/versions/node/v24.15.0', 'lib', 'node_modules', '@phnx-labs', 'agents-cli');
+    expect(detectPackageManager(root)).toBe('npm');
+  });
+
+  it('does not mistake a non-bun "global" dir for a bun install', () => {
+    process.env.BUN_INSTALL = '/Users/x/.bun';
+    const root = path.join('/srv/global', 'node_modules', '@phnx-labs', 'agents-cli');
+    expect(detectPackageManager(root)).toBe('npm');
+  });
+});
+
 describe('verifyInstalledVersion', () => {
   function writePackage(dir: string, version: string): string {
     const root = path.join(dir, 'lib', 'node_modules', '@phnx-labs', 'agents-cli');
@@ -70,6 +106,28 @@ describe('verifyInstalledVersion', () => {
     // prefix, while the running copy's root still carries the old version.
     const root = writePackage(makeTempDir('verify-stale'), '1.20.4');
     expect(() => verifyInstalledVersion(root, '1.20.7')).toThrow(/still 1\.20\.4 \(expected 1\.20\.7\)/);
+  });
+
+  it('suggests `bun add -g` (not npm --prefix) when the stale install is bun-managed', () => {
+    // The bun incident: the npm --prefix command in the hint is exactly what
+    // could not update a bun install, so the manual hint must use bun instead.
+    const saved = process.env.BUN_INSTALL;
+    const base = makeTempDir('verify-bun');
+    process.env.BUN_INSTALL = base;
+    try {
+      const root = path.join(base, 'install', 'global', 'node_modules', '@phnx-labs', 'agents-cli');
+      fs.mkdirSync(root, { recursive: true });
+      fs.writeFileSync(
+        path.join(root, 'package.json'),
+        JSON.stringify({ name: '@phnx-labs/agents-cli', version: '1.20.17' }),
+      );
+      expect(() => verifyInstalledVersion(root, '1.20.19')).toThrow(
+        /Run manually: bun add -g @phnx-labs\/agents-cli@1\.20\.19/,
+      );
+    } finally {
+      if (saved === undefined) delete process.env.BUN_INSTALL;
+      else process.env.BUN_INSTALL = saved;
+    }
   });
 });
 

--- a/src/lib/self-update.ts
+++ b/src/lib/self-update.ts
@@ -13,11 +13,59 @@
  */
 
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { spawnSync } from 'child_process';
 import { compareVersions } from './versions.js';
 
 export const NPM_PACKAGE_NAME = '@phnx-labs/agents-cli';
+
+export type PackageManager = 'npm' | 'bun';
+
+/**
+ * The directory bun installs global packages into:
+ *   <BUN_INSTALL>/install/global   (BUN_INSTALL defaults to ~/.bun)
+ *
+ * A globally-installed scoped package then lives at
+ * `<bunGlobalDir>/node_modules/@phnx-labs/agents-cli` — note there is NO `lib`
+ * segment, unlike npm's POSIX layout. That single difference is why an
+ * npm-based upgrade silently misses a bun install (see deriveGlobalPrefix).
+ */
+export function bunGlobalDir(): string {
+  const bunInstall = process.env.BUN_INSTALL || path.join(os.homedir(), '.bun');
+  return path.join(bunInstall, 'install', 'global');
+}
+
+/**
+ * Identify which package manager owns the install at `packageRoot`, so the
+ * upgrade can shell out to the one that actually replaces this copy.
+ *
+ * bun lays a global package out as `<bunGlobalDir>/node_modules/<scoped pkg>`,
+ * so the prefix (the parent of `node_modules`) is the bun global dir itself.
+ * Everything else — npm's `<prefix>/lib/node_modules` and the Windows
+ * `<prefix>/node_modules` — is treated as npm.
+ *
+ * Detection is path-based (no subprocess): it matches the resolved bun global
+ * dir from BUN_INSTALL/$HOME, and falls back to the structural `.bun/install/
+ * global` tail for a relocated BUN_INSTALL not exported into this process.
+ */
+export function detectPackageManager(packageRoot: string): PackageManager {
+  const resolved = path.resolve(packageRoot);
+  const prefix = path.dirname(path.dirname(path.dirname(resolved))); // strip <scope>/<pkg>/node_modules
+  if (prefix === path.resolve(bunGlobalDir())) return 'bun';
+  const parts = prefix.split(path.sep);
+  const n = parts.length;
+  if (n >= 3 && parts[n - 1] === 'global' && parts[n - 2] === 'install' && parts[n - 3] === '.bun') {
+    return 'bun';
+  }
+  return 'npm';
+}
+
+/** The shell command a user can run by hand to reproduce the upgrade for `manager`. */
+function manualInstallHint(manager: PackageManager, packageRoot: string, spec: string): string {
+  if (manager === 'bun') return `bun add -g ${spec}`;
+  return `npm install -g --prefix ${deriveGlobalPrefix(packageRoot)} ${spec}`;
+}
 
 export interface UpdateCheckCache {
   lastCheck: number;
@@ -121,6 +169,21 @@ export async function installPackageIntoPrefix(spec: string, prefix: string): Pr
   await execFileAsync('npm', ['install', '-g', '--prefix', prefix, spec, '--ignore-scripts']);
 }
 
+/**
+ * Install `spec` into bun's global store with `bun add -g`. bun writes to
+ * `<bunGlobalDir>/node_modules/<pkg>`, which is exactly the running package
+ * root for a bun install — so verifyInstalledVersion() sees the new version
+ * in place. bun skips untrusted lifecycle scripts, so the caller refreshes
+ * alias shims afterwards via refreshAliasShims() rather than relying on the
+ * package's postinstall hook.
+ */
+export async function installPackageWithBun(spec: string): Promise<void> {
+  const { execFile } = await import('child_process');
+  const { promisify } = await import('util');
+  const execFileAsync = promisify(execFile);
+  await execFileAsync('bun', ['add', '-g', spec]);
+}
+
 /** Read the version field of the package.json at `packageRoot`, fresh from disk. */
 export function readInstalledVersion(packageRoot: string): string {
   return JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf-8')).version;
@@ -133,9 +196,11 @@ export function readInstalledVersion(packageRoot: string): string {
 export function verifyInstalledVersion(packageRoot: string, expectedVersion: string): void {
   const actual = readInstalledVersion(packageRoot);
   if (actual !== expectedVersion) {
+    const manager = detectPackageManager(packageRoot);
+    const hint = manualInstallHint(manager, packageRoot, `${NPM_PACKAGE_NAME}@${expectedVersion}`);
     throw new Error(
-      `npm reported success but ${packageRoot} is still ${actual} (expected ${expectedVersion}). ` +
-        `Run manually: npm install -g --prefix ${deriveGlobalPrefix(packageRoot)} ${NPM_PACKAGE_NAME}@${expectedVersion}`,
+      `the package manager reported success but ${packageRoot} is still ${actual} (expected ${expectedVersion}). ` +
+        `Run manually: ${hint}`,
     );
   }
 }

--- a/tests/package-name-consistency.test.ts
+++ b/tests/package-name-consistency.test.ts
@@ -48,7 +48,9 @@ describe('package-name consistency (@phnx-labs canonical)', () => {
     expect(selfUpdate).toContain(`export const NPM_PACKAGE_NAME = '${NPM_PACKAGE}';`);
     expect(selfUpdate).not.toContain('@companion');
     const src = read('src/index.ts');
-    const specs = src.match(/installPackageIntoPrefix\(`\$\{NPM_PACKAGE_NAME\}@/g) ?? [];
+    // The install spec is built once from the shared constant, then handed to
+    // the package-manager-specific installer (npm --prefix or `bun add -g`).
+    const specs = src.match(/const spec = `\$\{NPM_PACKAGE_NAME\}@/g) ?? [];
     expect(specs.length).toBeGreaterThan(0);
   });
 


### PR DESCRIPTION
Fixes #408.

## Problem

`agents upgrade` always runs `npm install -g --prefix <prefix>`. On a **bun**-managed global install the package lives at `<bunGlobalDir>/node_modules/@phnx-labs/agents-cli` (no `lib` segment), so `deriveGlobalPrefix` returns the bun global dir and npm writes the new version to `<bunGlobalDir>/lib/node_modules/...` — a path nothing resolves. npm exits 0, the running copy stays stale, and `verifyInstalledVersion()` correctly throws. Worse, the manual hint it prints (`npm install -g --prefix ...`) lands in the same dead directory, so the user can't recover by following it.

Observed upgrading `1.20.17 -> 1.20.19` on macOS with bun `1.3.11`:

```
✖ Upgrade failed: npm reported success but ~/.bun/install/global/node_modules/@phnx-labs/agents-cli
  is still 1.20.17 (expected 1.20.19).
```

## Fix

Detect the package manager that owns the install from its on-disk layout, and dispatch accordingly:

- **bun** install → `bun add -g <spec>` (writes to `<bunGlobalDir>/node_modules/...`, which *is* the running package root, so `verifyInstalledVersion` passes in place)
- everything else → existing `npm install -g --prefix` path

The post-upgrade "Run manually:" hint now matches the detected manager (`bun add -g …` instead of the npm command that can't fix a bun install).

Detection is path-based — no subprocess. It matches the resolved bun global dir (`$BUN_INSTALL || ~/.bun` + `/install/global`) and falls back to the structural `.bun/install/global` tail when `BUN_INSTALL` isn't exported into the process.

## Tests

`src/lib/self-update.test.ts` — added coverage for:
- `detectPackageManager`: bun via `BUN_INSTALL`, bun structurally (default `~/.bun`), npm POSIX `lib/node_modules`, and a non-bun `/global` lookalike that must stay `npm`.
- `verifyInstalledVersion`: a stale **bun** install's manual hint uses `bun add -g`, not `npm --prefix`.

```
Test Files  1 passed (1)
     Tests  21 passed (21)
```

`tsc --noEmit` clean. Verified `detectPackageManager` against the real reproducing path (`~/.bun/install/global/node_modules/...` → `bun`; `~/.nvm/.../lib/node_modules/...` → `npm`), and confirmed manually that `bun add -g @phnx-labs/agents-cli@<v>` updates the running copy in place.

## Follow-up (not in this PR)

The alias-shim writer in `scripts/postinstall.js` bakes an absolute `AGENTS_BIN` from the postinstall's own location. A stray `npm install -g` on a bun box runs the postinstall from npm's `lib/` copy and writes shims pointing at that dead path, breaking bare `secrets`/`browser`/`pty`/`sessions`/`teams`. Worth anchoring `AGENTS_BIN` to the resolved `agents` bin symlink target rather than the script location — happy to do that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
