### PR TITLE
fix(versions): reconcile stale literal `latest` dir for script-installed agents

### DIFF
--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -173,7 +173,15 @@ async function versionPruneAction(
     const { agent, version } = parsed;
     const agentConfig = AGENTS[agent];
 
-    if (version === 'latest' || version === 'oldest' || !spec.includes('@')) {
+    // Script-installed agents (droid, grok) can have a *literal* `latest`
+    // version dir on disk when the post-install version probe failed. An
+    // explicit `<agent>@latest` should remove that dir directly rather than
+    // routing to the interactive picker (which can't run non-interactively),
+    // so treat an installed literal `latest` as a concrete pinned version.
+    const isLiteralLatestInstalled =
+      version === 'latest' && spec.includes('@') && isVersionInstalled(agent, 'latest');
+
+    if (!isLiteralLatestInstalled && (version === 'latest' || version === 'oldest' || !spec.includes('@'))) {
       const versions = listInstalledVersions(agent);
       if (versions.length === 0) {
         console.log(chalk.gray(`No versions of ${agentLabel(agentConfig.id)} installed`));

--- a/src/lib/versions.test.ts
+++ b/src/lib/versions.test.ts
@@ -38,6 +38,79 @@ function runVersionSync(home: string, expression: string): unknown {
   return JSON.parse(child.stdout.trim());
 }
 
+function runReconcile(home: string, agent: string, installedVersion: string): string {
+  // tsx (Node) subprocess with an isolated HOME — exercises the real fs +
+  // session-db path that reconcileStaleLatestDir touches, no mocking.
+  const moduleUrl = pathToFileURL(path.resolve('src/lib/versions.ts')).href;
+  const tsxBin = path.resolve('node_modules/.bin/tsx');
+  const child = spawnSync(tsxBin, ['-e', `
+    import { reconcileStaleLatestDir } from ${JSON.stringify(moduleUrl)};
+    (async () => {
+      const result = await reconcileStaleLatestDir(${JSON.stringify(agent)}, ${JSON.stringify(installedVersion)});
+      console.log(JSON.stringify(result));
+    })();
+  `], {
+    env: { ...process.env, HOME: home },
+    encoding: 'utf-8',
+  });
+  expect(child.status, child.stderr).toBe(0);
+  return JSON.parse(child.stdout.trim());
+}
+
+function droidVersionDir(home: string, version: string): string {
+  return path.join(home, '.agents', '.history', 'versions', 'droid', version);
+}
+
+describe('reconcileStaleLatestDir', () => {
+  it('renames a stale literal `latest` dir onto the resolved version, preserving home/', () => {
+    const home = makeTempHome();
+    const latestHome = path.join(droidVersionDir(home, 'latest'), 'home');
+    fs.mkdirSync(latestHome, { recursive: true });
+    fs.writeFileSync(path.join(latestHome, 'marker.txt'), 'keep me', 'utf-8');
+
+    const action = runReconcile(home, 'droid', '0.158.0');
+
+    expect(action).toBe('renamed');
+    expect(fs.existsSync(droidVersionDir(home, 'latest'))).toBe(false);
+    expect(fs.readFileSync(path.join(droidVersionDir(home, '0.158.0'), 'home', 'marker.txt'), 'utf-8')).toBe('keep me');
+  });
+
+  it('trashes the stale `latest` dir when the resolved version dir already exists', () => {
+    const home = makeTempHome();
+    fs.mkdirSync(path.join(droidVersionDir(home, 'latest'), 'home'), { recursive: true });
+    fs.mkdirSync(path.join(droidVersionDir(home, '0.158.0'), 'home'), { recursive: true });
+
+    const action = runReconcile(home, 'droid', '0.158.0');
+
+    expect(action).toBe('trashed');
+    expect(fs.existsSync(droidVersionDir(home, 'latest'))).toBe(false);
+    expect(fs.existsSync(droidVersionDir(home, '0.158.0'))).toBe(true);
+    // Soft-deleted, not hard-deleted — recoverable from trash.
+    const trashDir = path.join(home, '.agents', '.history', 'trash', 'versions', 'droid', 'latest');
+    expect(fs.existsSync(trashDir)).toBe(true);
+  });
+
+  it('is a no-op when no stale `latest` dir exists', () => {
+    const home = makeTempHome();
+    fs.mkdirSync(path.join(droidVersionDir(home, '0.158.0'), 'home'), { recursive: true });
+
+    const action = runReconcile(home, 'droid', '0.158.0');
+
+    expect(action).toBe('none');
+    expect(fs.existsSync(droidVersionDir(home, '0.158.0'))).toBe(true);
+  });
+
+  it('is a no-op when the resolved version is itself `latest` (probe failed)', () => {
+    const home = makeTempHome();
+    fs.mkdirSync(path.join(droidVersionDir(home, 'latest'), 'home'), { recursive: true });
+
+    const action = runReconcile(home, 'droid', 'latest');
+
+    expect(action).toBe('none');
+    expect(fs.existsSync(droidVersionDir(home, 'latest'))).toBe(true);
+  });
+});
+
 describe('version resource sync path handling', () => {
   it('intersects explicit resource selections with discovered resources before syncing', async () => {
     const home = makeTempHome();

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1091,6 +1091,9 @@ export async function installVersion(
 
       if (version === 'latest') {
         installedVersion = await getCliVersionFromPath(agent) || version;
+        // Fold any stale literal `latest` dir from an earlier probe-failed
+        // install into the real version so it stops shadowing `agents view`.
+        await reconcileStaleLatestDir(agent, installedVersion);
       }
 
       onProgress?.(`${agentConfig.name} installed. Setting up agents-cli version home for isolation...`);
@@ -1267,6 +1270,57 @@ function removeInstallArtifacts(versionDir: string): void {
     if (entry === 'home') continue;
     fs.rmSync(path.join(versionDir, entry), { recursive: true, force: true });
   }
+}
+
+/**
+ * Fold a stale literal `latest` version dir into the real resolved version.
+ *
+ * Script-installed agents (droid, grok) have no npm package to read a version
+ * from, so the installer resolves the version by probing `<cli> --version`
+ * after the install script runs. When that probe failed (3s timeout, or the
+ * freshly-dropped binary not yet resolvable on PATH) the installer fell back to
+ * the literal string `latest`, creating a `versions/<agent>/latest/` dir. A
+ * later install where the probe succeeded then created a SECOND dir at the real
+ * semver, orphaning `latest` — and because these agents' getBinaryPath points
+ * at a single global binary regardless of version dir, `latest` keeps showing
+ * up in `agents view` next to the real version forever.
+ *
+ * Call this once the install path has resolved a real version: if a stale
+ * `latest` dir exists, rename it onto the real version (preserving `home/`), or
+ * if the real dir already exists, soft-delete the `latest` dir to trash. No-op
+ * when nothing was resolved or no stale dir is present, so it is safe to call
+ * on every script-based install. Returns the action taken (for tests/logging).
+ */
+export async function reconcileStaleLatestDir(
+  agent: AgentId,
+  installedVersion: string,
+): Promise<'none' | 'renamed' | 'trashed'> {
+  if (installedVersion === 'latest') return 'none';
+
+  const staleLatestDir = getVersionDir(agent, 'latest');
+  const realVersionDir = getVersionDir(agent, installedVersion);
+  if (staleLatestDir === realVersionDir || !fs.existsSync(staleLatestDir)) {
+    return 'none';
+  }
+
+  if (!fs.existsSync(realVersionDir)) {
+    fs.renameSync(staleLatestDir, realVersionDir);
+    return 'renamed';
+  }
+
+  // Both dirs exist. Stripping install artifacts would not hide `latest` for
+  // global-binary agents (getBinaryPath ignores dir contents), so the whole
+  // dir must go. Soft-delete to trash so any `home/` data stays recoverable
+  // via `agents restore <agent>@latest`, then rewrite session file paths to
+  // point at the trashed location so history stays readable. The session-db
+  // module is imported lazily — it carries a top-level await that the CJS test
+  // harness can't statically transform, so it must stay out of the eager graph.
+  const trashPath = softDeleteVersionDir(agent, 'latest');
+  if (trashPath) {
+    const { updateSessionFilePaths } = await import('./session/db.js');
+    updateSessionFilePaths(staleLatestDir, trashPath);
+  }
+  return 'trashed';
 }
 
 /**


### PR DESCRIPTION
## Problem

`agents view` showed Droid under two versions — a literal `latest` **and** a real semver (`0.158.0`) — for the same single install:

```
Droid (available)
  latest (default)   (not signed in)
  0.158.0            (not signed in)
```

Script-installed agents (droid, grok) have no npm package to read a version from, so `installVersion` probes `<cli> --version` after the install script runs. When that probe fails (3s timeout, or the freshly-dropped binary not yet resolvable on PATH) it falls back to the literal string `latest` and creates `versions/<agent>/latest/`. A later install where the probe succeeds then creates a **second** dir at the real semver. Because `getBinaryPath` for these agents points at a single global binary (`~/.local/bin/droid`) regardless of version dir, `listInstalledVersions` reports *every* subdir as installed — so the orphaned `latest` lingers in `agents view` forever.

On top of that, `agents remove <agent>@latest` routed `@latest` to the interactive picker (treating it purely as an alias), so the stale dir couldn't be removed non-interactively at all.

## Fix

- **`reconcileStaleLatestDir`** (called from `installVersion` once a real version resolves): folds a stale `latest` dir into the resolved version — rename when the real dir is absent, else soft-delete `latest` to trash with session file paths rewritten so history stays readable. `session/db` is imported lazily so its top-level await stays out of the CJS test-eval graph.
- **`agents remove <agent>@latest`** now removes an installed *literal* `latest` dir directly instead of routing to the picker, when such a dir actually exists. npm `@latest`/`@oldest` alias behavior is unchanged.

## Tests

Four real-filesystem tests (no mocking) covering rename, trash-when-real-dir-exists, and both no-op paths. `src/lib/versions.test.ts` + `src/lib/skills.test.ts` pass isolated (35/35); full-suite deltas vs `main` are pre-existing timeout flakiness, none in the touched area.

## Verified end-to-end

Built the dev CLI from this branch and ran the real flow:

```
$ agents remove droid@latest
Default version removed. ...
Moved Droid@latest to trash
$ agents view | grep -A2 Droid
  Droid (available)
    0.158.0 (default)  (not signed in — run droid to log in)
```