### PR TITLE
feat(secrets): persistent launchd service for the secrets-agent broker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+**`agents secrets start`: persistent secrets-agent service (fixes the broker under heavy load)**
+
+- On a heavily-loaded machine (many concurrent agents, high load average) the on-demand broker — a full CLI cold-start — couldn't get scheduled enough CPU to finish booting and bind its socket, so `unlock`/auto-cache silently failed and reads kept prompting. New `agents secrets start` installs the broker as a **launchd user service** (`RunAtLoad` + `KeepAlive`, `ProcessType: Interactive` for foreground scheduling priority): it starts once and stays up for the whole login session, so every read just connects — the cold start happens once (and launchd retries until it wins), never per read. `agents secrets stop` removes it; `agents secrets status` shows whether it's installed.
+- `unlock` and the auto-cache worker now install/kickstart this service automatically via `ensureAgentRunning`, falling back to the old one-off detached spawn only if the service path is unavailable. So the persistent broker is set up on first use with no extra step.
+- macOS only. Security model unchanged: in-memory only, per-bundle TTL, wiped on screen-lock/sleep.
+
 **Fix: secrets-agent auto-cache now survives a slow broker cold-start under load**
 
 - `secrets.agent.auto` (auto-cache on first read of a `session`-tier bundle) used a fire-and-forget inline loader that gave up connecting to the broker after 3s. But the broker it spawns is itself a full CLI cold-starting; under heavy load (many concurrent agents) that can exceed 3s, so the loader quit before the broker bound and the cache silently never populated — every read kept prompting. The auto-load now runs through a detached `secrets _agent-load` worker that reuses the robust `ensureAgentRunning` path (spawn-then-ping, 20s budget) and loads synchronously, so it reliably populates even when the broker is slow to start. Manual `agents secrets unlock` was always reliable and is unchanged. (secret values still travel over stdin, never argv.)

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -59,8 +59,11 @@ import {
   agentLock,
   agentStatus,
   ensureAgentRunning,
+  installSecretsAgentService,
   runAgentLoadFromStdin,
   runSecretsAgent,
+  secretsAgentServiceInstalled,
+  uninstallSecretsAgentService,
 } from '../lib/secrets/agent.js';
 import { parseDuration } from '../lib/hooks/cache.js';
 import { registerCommandGroups, setHelpSections } from '../lib/help.js';
@@ -468,7 +471,7 @@ export function registerSecretsCommands(program: Command): void {
   registerCommandGroups(cmd, [
     { title: 'Bundle commands', names: ['list', 'view', 'create', 'rename', 'describe', 'delete'] },
     { title: 'Secret commands', names: ['add', 'rotate', 'remove', 'import', 'export'] },
-    { title: 'Agent commands', names: ['unlock', 'lock', 'status', 'tier'] },
+    { title: 'Agent commands', names: ['start', 'stop', 'unlock', 'lock', 'status', 'tier'] },
     { title: 'Raw item commands', names: ['get', 'set'] },
     { title: 'Sync commands', names: ['push', 'pull', 'remote-list'] },
     { title: 'Utilities', names: ['exec', 'generate', 'migrate-acl'] },
@@ -1424,6 +1427,12 @@ Examples:
         console.log(chalk.gray('secrets-agent is macOS-only.'));
         return;
       }
+      console.log(
+        chalk.gray('service: ') +
+        (secretsAgentServiceInstalled()
+          ? chalk.green('installed (persistent)')
+          : chalk.yellow('not installed — run `agents secrets start` for a persistent broker')),
+      );
       const entries = await agentStatus();
       if (entries.length === 0) {
         console.log(chalk.gray('No bundles unlocked. The secrets-agent is idle or not running.'));
@@ -1460,10 +1469,37 @@ Examples:
     });
 
   cmd
+    .command('start')
+    .description('Install + start the secrets-agent as a persistent background service (macOS). Survives heavy load; reads connect instantly.')
+    .action(async () => {
+      if (process.platform !== 'darwin') {
+        console.error(chalk.red('secrets-agent service is macOS-only.'));
+        process.exit(1);
+      }
+      process.stdout.write(chalk.gray('Installing launchd service…\n'));
+      if (await installSecretsAgentService()) {
+        console.log(chalk.green('secrets-agent service running.') + chalk.gray(' It stays up across the session; unlock/auto-cache now connect instantly.'));
+      } else {
+        console.error(chalk.red('Service installed but did not become reachable in time (machine may be heavily loaded — launchd will keep retrying).'));
+        process.exit(1);
+      }
+    });
+
+  cmd
+    .command('stop')
+    .description('Stop + remove the persistent secrets-agent service and wipe what it held.')
+    .action(async () => {
+      if (process.platform !== 'darwin') return;
+      await uninstallSecretsAgentService();
+      console.log(chalk.green('secrets-agent service stopped and removed.'));
+    });
+
+  cmd
     .command('_agent-run', { hidden: true })
     .description('Run the secrets-agent broker in the foreground (internal)')
-    .action(async () => {
-      await runSecretsAgent();
+    .option('--service', 'run as a persistent launchd service (never idle-exit)')
+    .action(async (opts: { service?: boolean }) => {
+      await runSecretsAgent({ service: Boolean(opts.service) });
     });
 
   cmd

--- a/src/lib/secrets/agent.ts
+++ b/src/lib/secrets/agent.ts
@@ -104,6 +104,100 @@ function brokerSpawn(): { cmd: string; args: string[] } {
   return cliSpawn(['secrets', '_agent-run']);
 }
 
+// ─── Persistent launchd service ──────────────────────────────────────────────
+// On a heavily-loaded machine a freshly-spawned broker (a full CLI cold start)
+// can't get scheduled enough CPU to finish booting and bind its socket — so the
+// on-demand model fails exactly when there are many agents (the case we care
+// about). The fix is to run the broker as a launchd user service: started once
+// with RunAtLoad + KeepAlive, it stays up, and every read just connects. The
+// cold start happens once (and launchd retries until it wins), never per-read.
+
+const SERVICE_LABEL = 'com.phnx-labs.agents-secrets-agent';
+
+function servicePlistPath(): string {
+  return path.join(os.homedir(), 'Library', 'LaunchAgents', `${SERVICE_LABEL}.plist`);
+}
+
+/** True if the launchd plist for the persistent broker is installed. */
+export function secretsAgentServiceInstalled(): boolean {
+  return onDarwin() && fs.existsSync(servicePlistPath());
+}
+
+function generateServicePlist(): string {
+  const { cmd, args } = cliSpawn(['secrets', '_agent-run', '--service']);
+  const progArgs = [cmd, ...args]
+    .map((a) => `    <string>${a.replace(/&/g, '&amp;').replace(/</g, '&lt;')}</string>`)
+    .join('\n');
+  const logPath = path.join(agentDir(), 'service.log');
+  const home = os.homedir();
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${SERVICE_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+${progArgs}
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Interactive</string>
+  <key>StandardOutPath</key>
+  <string>${logPath}</string>
+  <key>StandardErrorPath</key>
+  <string>${logPath}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:${home}/.bun/bin</string>
+  </dict>
+</dict>
+</plist>`;
+}
+
+/**
+ * Install + start the persistent broker as a launchd user service (idempotent).
+ * Writes the plist, bootstraps it into the GUI domain, and waits for the socket.
+ * `ProcessType: Interactive` asks launchd to schedule it at foreground priority
+ * so it can boot even when the machine is loaded. Returns true once reachable.
+ */
+export async function installSecretsAgentService(timeoutMs = 30000): Promise<boolean> {
+  if (!onDarwin()) return false;
+  const plist = servicePlistPath();
+  fs.mkdirSync(path.dirname(plist), { recursive: true });
+  fs.writeFileSync(plist, generateServicePlist());
+  const uid = process.getuid?.() ?? 0;
+  // bootstrap is the modern API; fall back to legacy load. Both idempotent-ish.
+  try {
+    execFileSync('launchctl', ['bootstrap', `gui/${uid}`, plist], { stdio: ['ignore', 'ignore', 'ignore'] });
+  } catch {
+    try { execFileSync('launchctl', ['load', '-w', plist], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* may already be loaded */ }
+  }
+  // kickstart to force an immediate start even if already bootstrapped.
+  try { execFileSync('launchctl', ['kickstart', '-k', `gui/${uid}/${SERVICE_LABEL}`], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* best effort */ }
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await agentPing()) return true;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return false;
+}
+
+/** Stop + remove the persistent broker service, and wipe whatever it held. */
+export async function uninstallSecretsAgentService(): Promise<void> {
+  if (!onDarwin()) return;
+  await agentLock(); // wipe the in-memory store before tearing down
+  const plist = servicePlistPath();
+  const uid = process.getuid?.() ?? 0;
+  try { execFileSync('launchctl', ['bootout', `gui/${uid}/${SERVICE_LABEL}`], { stdio: ['ignore', 'ignore', 'ignore'] }); }
+  catch { try { execFileSync('launchctl', ['unload', '-w', plist], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* not loaded */ } }
+  try { fs.unlinkSync(plist); } catch { /* already gone */ }
+}
+
 // ─── Wire protocol ───────────────────────────────────────────────────────────
 // Newline-delimited JSON: one request object per line, one response line back.
 
@@ -174,8 +268,12 @@ export function handleAgentRequest(
  * `agents secrets _agent-run`. Holds the store in memory, serves the socket,
  * sweeps expired entries, wipes on screen-lock/sleep, and self-exits when idle.
  */
-export async function runSecretsAgent(): Promise<void> {
+export async function runSecretsAgent(opts: { service?: boolean } = {}): Promise<void> {
   if (!onDarwin()) return; // nothing to broker without biometry prompts
+  // When launchd keeps us alive as a persistent service, never idle-exit:
+  // exiting would just make launchd cold-start us again, reintroducing the
+  // startup-under-load fragility the service exists to avoid.
+  const persistent = opts.service === true;
 
   // Single-instance guard: O_EXCL pid file. If a live broker already holds it,
   // exit quietly — the existing one keeps serving.
@@ -207,7 +305,7 @@ export async function runSecretsAgent(): Promise<void> {
     const now = Date.now();
     for (const [name, e] of store) if (now >= e.expiresAt) store.delete(name);
     if (store.size === 0) {
-      if (now - emptySince >= IDLE_EXIT_MS) shutdown(0);
+      if (!persistent && now - emptySince >= IDLE_EXIT_MS) shutdown(0);
     } else {
       emptySince = now;
     }
@@ -471,15 +569,33 @@ async function agentPing(): Promise<boolean> {
 }
 
 /**
- * Ensure a broker is running and reachable, spawning one detached if not.
- * Returns true once the socket answers a ping. On protocol-version skew, kills
- * the stale broker and respawns. macOS only.
+ * Ensure a broker is running and reachable. Returns true once the socket answers
+ * a ping. macOS only.
+ *
+ * Prefers the persistent launchd service: if it isn't installed we install it
+ * (which makes the broker survive for the whole login session, so subsequent
+ * reads never cold-start); if it's installed but unreachable we kickstart it.
+ * Only when the service path can't be used do we fall back to a one-off detached
+ * broker — that's the model that gets starved under heavy load, so it's last.
  */
 export async function ensureAgentRunning(timeoutMs = 5000): Promise<boolean> {
   if (!onDarwin()) return false;
   if (await agentPing()) return true;
 
-  // Socket exists but ping failed → stale/old broker. Kill it before respawn.
+  // Path 1: the persistent service. installSecretsAgentService is idempotent and
+  // waits for the socket; for an already-installed service we kickstart and wait.
+  try {
+    if (!secretsAgentServiceInstalled()) {
+      if (await installSecretsAgentService(Math.max(timeoutMs, 20000))) return true;
+    } else {
+      const uid = process.getuid?.() ?? 0;
+      try { execFileSync('launchctl', ['kickstart', '-k', `gui/${uid}/${SERVICE_LABEL}`], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* may already be running */ }
+      const d = Date.now() + timeoutMs;
+      while (Date.now() < d) { if (await agentPing()) return true; await new Promise((r) => setTimeout(r, 150)); }
+    }
+  } catch { /* fall through to the one-off spawn */ }
+
+  // Path 2 (fallback): one-off detached broker. Clear a stale socket/pid first.
   const stalePid = (() => {
     try { return parseInt(fs.readFileSync(pidPath(), 'utf-8').trim(), 10); }
     catch { return NaN; }
@@ -491,11 +607,7 @@ export async function ensureAgentRunning(timeoutMs = 5000): Promise<boolean> {
   try { fs.unlinkSync(pidPath()); } catch { /* gone */ }
 
   const { cmd, args } = brokerSpawn();
-  const child = spawn(cmd, args, {
-    stdio: 'ignore',
-    detached: true,
-  });
-  child.unref();
+  spawn(cmd, args, { stdio: 'ignore', detached: true }).unref();
 
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {


### PR DESCRIPTION
## Problem

On a heavily-loaded machine (high load average, many concurrent agents) the on-demand secrets-agent broker — a full CLI cold-start — can't get scheduled enough CPU to finish booting and bind its socket. So `unlock`/auto-cache silently fail to populate, and reads keep prompting Touch ID. (Observed live at load ~310: the broker process stuck in node bootstrap, never binding.)

## Fix: persistent launchd service

`agents secrets start` installs the broker as a **launchd user service** — `RunAtLoad` + `KeepAlive`, `ProcessType: Interactive` (foreground scheduling priority so it can boot even under load). It starts **once** and stays up for the whole login session, so every read just connects to the already-running socket; the cold start happens once (and launchd retries until it wins), never per read.

- `ensureAgentRunning` now installs/kickstarts the service automatically (used by `unlock` and the auto-cache worker), falling back to the old one-off detached spawn only if the service path is unavailable. So it's set up on first use, no extra step.
- `agents secrets stop` removes it; `agents secrets status` shows whether it's installed.
- `--service` flag makes the broker skip idle-exit so launchd doesn't churn-restart it.
- macOS only. Security model unchanged: in-memory only, per-bundle TTL, wiped on screen-lock/sleep.

Mirrors the existing routines-daemon launchd pattern (`src/lib/daemon.ts`).

## Verification

Typecheck clean locally; CI runs the full suite. (Live end-to-end verification on the author's machine is constrained by the same load that motivated this change — the persistent service is precisely what makes it robust there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
