### PR TITLE
fix(sync): stop Touch ID storm from daemon session-sync re-reading keychain

### DIFF
--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -265,6 +265,9 @@ export async function runDaemon(): Promise<void> {
     scheduler.reloadAll();
     const reloaded = scheduler.listScheduled();
     log('INFO', `Reloaded ${reloaded.length} jobs`);
+    // Drop the memoized R2 config so rotated/added sync credentials are re-read
+    // on the next cycle instead of waiting for a restart.
+    void import('./session/sync/config.js').then(m => m.clearR2ConfigCache());
   };
 
   const handleShutdown = async () => {

--- a/src/lib/session/sync/config.test.ts
+++ b/src/lib/session/sync/config.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { setKeychainBackendForTest, type KeychainBackend } from '../../secrets/index.js';
+import { writeBundle, type SecretsBundle } from '../../secrets/bundles.js';
+import {
+  loadR2Config,
+  isSyncConfigured,
+  clearR2ConfigCache,
+  RESOLVE_RETRY_COOLDOWN_MS,
+  SYNC_BUNDLE,
+} from './config.js';
+
+/**
+ * Guards the resolution cache that stops the daemon's ~90s session-sync from
+ * re-reading the biometry-gated `r2.backups` keychain bundle every cycle (the
+ * Touch ID storm). Uses the in-memory keychain backend seam (same as
+ * tier.test.ts) so the real readAndResolveBundleEnv path runs without a real
+ * keychain — `gets` counts how often the backend is actually read, which is the
+ * proxy for "would this prompt for Touch ID again?".
+ */
+class CountingBackend implements KeychainBackend {
+  store = new Map<string, string>();
+  gets = 0;
+  has(item: string) { return this.store.has(item); }
+  get(item: string) {
+    this.gets++;
+    const v = this.store.get(item);
+    if (v === undefined) throw new Error(`missing ${item}`);
+    return v;
+  }
+  set(item: string, value: string) { this.store.set(item, value); }
+  delete(item: string) { return this.store.delete(item); }
+  list(prefix: string) { return [...this.store.keys()].filter(k => k.startsWith(prefix)); }
+}
+
+let be: CountingBackend;
+let prev: KeychainBackend | null = null;
+
+beforeEach(() => {
+  be = new CountingBackend();
+  prev = setKeychainBackendForTest(be);
+  process.env.AGENTS_SECRETS_NO_AGENT = '1'; // force keychain path, skip secrets-agent
+  clearR2ConfigCache();
+});
+afterEach(() => {
+  setKeychainBackendForTest(prev);
+  delete process.env.AGENTS_SECRETS_NO_AGENT;
+  clearR2ConfigCache();
+});
+
+function writeValidBundle(): void {
+  const b: SecretsBundle = {
+    name: SYNC_BUNDLE,
+    vars: {
+      R2_ACCOUNT_ID: 'acct123',
+      R2_BUCKET_NAME: 'agents-sessions',
+      R2_ACCESS_KEY_ID: 'ak-test',
+      R2_SECRET_ACCESS_KEY: 'sk-test',
+    },
+  };
+  writeBundle(b);
+}
+
+describe('R2 config resolution cache', () => {
+  it('reads the keychain once across many loadR2Config calls', () => {
+    writeValidBundle();
+    const a = loadR2Config();
+    const b1 = loadR2Config();
+    const c = loadR2Config();
+    expect(a.bucket).toBe('agents-sessions');
+    expect(a.endpoint).toBe('https://acct123.r2.cloudflarestorage.com');
+    expect(b1).toBe(a); // memoized: same object
+    expect(c).toBe(a);
+    expect(be.gets).toBe(1); // only the first call touched the backend
+  });
+
+  it('lets isSyncConfigured short-circuit once resolved (no re-read)', () => {
+    writeValidBundle();
+    expect(isSyncConfigured()).toBe(true);
+    const after = be.gets;
+    expect(isSyncConfigured()).toBe(true);
+    expect(isSyncConfigured()).toBe(true);
+    expect(be.gets).toBe(after); // cached — never re-read
+  });
+
+  it('clearR2ConfigCache forces a fresh read (credential rotation / SIGHUP)', () => {
+    writeValidBundle();
+    loadR2Config();
+    expect(be.gets).toBe(1);
+    clearR2ConfigCache();
+    loadR2Config();
+    expect(be.gets).toBe(2);
+  });
+
+  it('re-checks an ABSENT bundle every cycle (never prompts, fast pickup)', () => {
+    // No bundle written → "not found" → must keep polling so a later
+    // `agents secrets add` is picked up promptly. A missing item never prompts.
+    expect(isSyncConfigured(1_000)).toBe(false);
+    expect(isSyncConfigured(2_000)).toBe(false);
+    expect(be.gets).toBe(2); // re-read each call, no backoff
+  });
+
+  it('backs off after a prompt-bearing failure so it does not re-storm', () => {
+    // A present-but-incomplete bundle resolves the meta (a real keychain read
+    // that would prompt) then fails validation — exactly the case we must not
+    // retry every 90s.
+    writeBundle({ name: SYNC_BUNDLE, vars: { R2_ACCOUNT_ID: 'acct123' } });
+
+    const t0 = 1_000_000;
+    expect(isSyncConfigured(t0)).toBe(false);
+    expect(be.gets).toBe(1); // read once (the failing attempt)
+
+    // Within the cooldown: do NOT re-read (would re-prompt).
+    expect(isSyncConfigured(t0 + RESOLVE_RETRY_COOLDOWN_MS - 1)).toBe(false);
+    expect(be.gets).toBe(1);
+
+    // After the cooldown: allowed to try again.
+    expect(isSyncConfigured(t0 + RESOLVE_RETRY_COOLDOWN_MS + 1)).toBe(false);
+    expect(be.gets).toBe(2);
+  });
+
+  it('recovers immediately once the bundle becomes valid after a cooldown', () => {
+    const t0 = 5_000_000;
+    expect(isSyncConfigured(t0)).toBe(false); // absent
+    writeValidBundle();
+    // absent path does not back off, so the very next check resolves
+    expect(isSyncConfigured(t0 + 1)).toBe(true);
+    expect(loadR2Config().bucket).toBe('agents-sessions');
+  });
+});

--- a/src/lib/session/sync/config.ts
+++ b/src/lib/session/sync/config.ts
@@ -24,7 +24,7 @@ export interface R2Config {
  * actionable error if the bundle or any key is missing — sync cannot proceed
  * without real credentials (no silent fallback).
  */
-export function loadR2Config(): R2Config {
+function resolveR2Config(): R2Config {
   const { env } = readAndResolveBundleEnv(SYNC_BUNDLE, { caller: 'sessions-sync' });
   const accountId = env.R2_ACCOUNT_ID?.trim();
   const bucket = env.R2_BUCKET_NAME?.trim();
@@ -53,12 +53,58 @@ export function loadR2Config(): R2Config {
   };
 }
 
-/** True when the sync bundle exists and looks resolvable, without throwing. */
-export function isSyncConfigured(): boolean {
+// ── Resolution cache ────────────────────────────────────────────────────────
+// The daemon calls isSyncConfigured() + syncSessions() every ~90s, and each used
+// to trigger a fresh read of the biometry-gated `r2.backups` keychain items —
+// one Touch ID prompt per gated item, every cycle, forever. We instead resolve
+// at most once per process: a success is memoized for the process lifetime
+// (cleared on daemon SIGHUP via clearR2ConfigCache), so subsequent cycles never
+// touch the keychain again. A *prompt-bearing* failure (cancelled Touch ID, etc.)
+// starts a cooldown so a dismissed prompt is not re-issued every cycle. A simply
+// absent bundle never prompts, so it is re-checked each cycle (fast pickup when
+// the user later adds credentials).
+let cachedConfig: R2Config | null = null;
+let lastPromptFailureAt = 0;
+/** Window after a prompt-bearing resolution failure during which we skip
+ *  re-attempting (and thus re-prompting). SIGHUP / restart bypasses it. */
+export const RESOLVE_RETRY_COOLDOWN_MS = 30 * 60 * 1000; // 30 minutes
+
+/** Drop the cached resolution so the next call reads the bundle fresh. Called on
+ *  daemon SIGHUP (to pick up rotated credentials) and between tests. */
+export function clearR2ConfigCache(): void {
+  cachedConfig = null;
+  lastPromptFailureAt = 0;
+}
+
+/**
+ * Resolve R2 credentials, reading the keychain at most once per process. The
+ * first call reads (and may prompt for Touch ID); every later call returns the
+ * memoized result. Throws if the bundle/keys are missing — failures are not
+ * memoized, but see isSyncConfigured for the re-prompt cooldown.
+ */
+export function loadR2Config(): R2Config {
+  if (cachedConfig) return cachedConfig;
+  cachedConfig = resolveR2Config();
+  return cachedConfig;
+}
+
+/**
+ * True when the sync bundle exists and resolves, without throwing. After a
+ * prompt-bearing failure (e.g. a cancelled Touch ID) it returns false without
+ * re-reading the keychain for RESOLVE_RETRY_COOLDOWN_MS, so a dismissed prompt
+ * does not re-storm every cycle. `now` is injectable for tests.
+ */
+export function isSyncConfigured(now: number = Date.now()): boolean {
+  if (cachedConfig) return true;
+  if (lastPromptFailureAt && now - lastPromptFailureAt < RESOLVE_RETRY_COOLDOWN_MS) return false;
   try {
     loadR2Config();
     return true;
-  } catch {
+  } catch (err) {
+    // A missing bundle never prompts, so keep re-checking it each cycle (so a
+    // later `agents secrets add` is picked up quickly). Any other failure may
+    // have cost a prompt (cancelled Touch ID, keychain error) — back off.
+    if (!/not found/i.test((err as Error).message)) lastPromptFailureAt = now;
     return false;
   }
 }


### PR DESCRIPTION
## Problem

The background `agents daemon` runs cross-machine session sync on a ~90s timer. Every cycle called `isSyncConfigured()` **and** `syncSessions()`, and each ran `loadR2Config()` — a fresh, biometry-gated read of the `r2.backups` keychain bundle. With the two gated items (`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`) read twice per cycle, macOS surfaced **a Touch ID prompt per gated item, every few minutes, forever** — and entirely independent of whether the R2 credentials were valid (in the wild they were read-only, so the sync 403'd anyway while still prompting).

## Fix

`src/lib/session/sync/config.ts`:
- **Memoize resolution** — read the keychain at most once per process; reuse for the daemon's lifetime. No more per-cycle reads.
- **Cooldown on prompt-bearing failure** — a cancelled Touch ID / keychain error / present-but-incomplete bundle starts a 30-min backoff so a dismissed prompt doesn't re-storm every cycle.
- **Absent bundle still re-checks each cycle** — a missing bundle never prompts, so polling continues for fast pickup after `agents secrets add`.
- `clearR2ConfigCache()` exported and wired to the daemon **SIGHUP** so rotated/added creds are picked up without a restart.

## Tests

New `config.test.ts` (6 cases) via the in-memory keychain seam (no mocking, same approach as `tier.test.ts`): memoization, `isSyncConfigured` short-circuit, cache clear, absent-bundle re-checking, prompt-failure cooldown window, and recovery once a bundle becomes valid.

- `bunx vitest run src/lib/session/sync/ src/lib/secrets/` → **163 passed, 5 skipped**
- `tsc` clean

## Note

This reduces the prompt to at most once per daemon lifetime (login/restart) rather than every cycle. Fully eliminating even that would require routing the daemon read through the secrets-agent — left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)