### PR TITLE
feat(secrets): self-heal stale daemon/broker onto new code after upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+**Self-healing: long-running processes reload onto new code after an upgrade**
+
+- Root cause behind a class of "stale behavior" bugs: a routines daemon or secrets-agent broker keeps running **pre-upgrade code** for days. An in-place `npm i -g` swaps the files but not the running processes, so fixes (keychain read-memoization, the broker fast-path, etc.) silently never take effect — the daemon kept popping Touch ID from the keychain because it predated the fix.
+- **Heal-on-upgrade:** `postinstall` now bounces the routines daemon and kickstarts the persistent secrets-agent broker onto the just-installed code — the one moment we know the code changed. Best-effort, non-fatal, skipped in CI / with `AGENTS_NO_HEAL=1`.
+- **Broker version-skew self-heal:** the broker's `ping` reports the version of the code it's running; `ensureAgentRunning` (the unlock / auto-cache path, never per-read) restarts a broker found running stale code, and a persistent broker self-exits on detecting an in-place upgrade so launchd relaunches it fresh. New `getCliVersionFresh()` re-reads `package.json` to detect the swap.
+- No hot-path cost: all checks live on existing control-plane paths (postinstall, the broker sweep, `ensureAgentRunning`), never on a per-secret-read. macOS only. Complements #412 (daemon session-sync memoization) by ensuring the daemon actually *runs* that code.
+
 **`agents secrets start`: persistent secrets-agent service (fixes the broker under heavy load)**
 
 - On a heavily-loaded machine (many concurrent agents, high load average) the on-demand broker — a full CLI cold-start — couldn't get scheduled enough CPU to finish booting and bind its socket, so `unlock`/auto-cache silently failed and reads kept prompting. New `agents secrets start` installs the broker as a **launchd user service** (`RunAtLoad` + `KeepAlive`, `ProcessType: Interactive` for foreground scheduling priority): it starts once and stays up for the whole login session, so every read just connects — the cold start happens once (and launchd retries until it wins), never per read. `agents secrets stop` removes it; `agents secrets status` shows whether it's installed.

--- a/docs/08-secrets-agent-process-model.md
+++ b/docs/08-secrets-agent-process-model.md
@@ -1,0 +1,103 @@
+# Secrets-agent process model (design decision)
+
+> Status: **proposed** · Supersedes nothing · Related: [secrets.md](secrets.md), [03-routines.md](03-routines.md)
+
+A design record for *where the secrets-agent broker should live as a process* —
+its own service, or folded into the routines daemon. Written after a stretch of
+production incidents (stale daemon reading the keychain, broker cold-start
+starvation, duplicate daemons) made the process model worth pinning down.
+
+## Context
+
+The **secrets-agent broker** (`src/lib/secrets/agent.ts`) is a persistent
+process that holds unlocked bundles in memory behind a `0700` Unix socket, so
+concurrent agents stop re-prompting Touch ID per process. It currently runs as
+its own launchd user service, `com.phnx-labs.agents-secrets-agent`.
+
+The **routines daemon** (`src/lib/daemon.ts`, `com.phnx-labs.agents-daemon`)
+already hosts a socket IPC service of the same shape — `BrowserIPCServer` — which
+prompted the question: *isn't the broker a second daemon we don't need? Fold it
+into the routines daemon.*
+
+## What the routines daemon actually is today
+
+`runDaemon()` runs, **in-process**:
+
+- the cron **scheduler** (`JobScheduler`),
+- `BrowserService` + `BrowserIPCServer` (a socket server),
+- **session-sync** to R2 every 90s,
+- overdue-job detection + native notification on startup,
+- orphan-process reaping,
+- a 60s monitor interval.
+
+It persists via launchd **or** a detached fallback, and **only auto-starts when
+a routine exists** ("the scheduler auto-starts on first `routines add`").
+
+Observed failure modes this cycle: heavy/slow startup, stale pid file
+(`launchctl … PID: null`), duplicate daemon processes, and cold-start
+starvation under high load (a fresh node process couldn't finish booting at load
+~310).
+
+## Why the broker has different requirements than the scheduler
+
+| | Secrets broker | Routines scheduler |
+|---|---|---|
+| Blast radius of being down | **Loud** — every secret read pops Touch ID | Quiet — a cron job just runs late |
+| Footprint | Tiny (socket + `Map`) | Heavy (browser, sync, scheduler) |
+| Who needs it | Anyone using `agents secrets` | Only users with routines |
+| Cold-start budget | Must be ~instant | Tolerant of slow start |
+
+A reliability/security primitive that *everything* depends on should have the
+**fewest dependencies and the lightest footprint**, and must not inherit the
+failure modes of unrelated subsystems.
+
+## Options
+
+1. **Fold into the routines daemon.** Host the broker next to `BrowserIPCServer`.
+   - Fewer processes; reuses one lifecycle; matches an existing pattern.
+   - **But** couples secrets availability to a heavy, only-runs-with-routines,
+     empirically-flaky host; and forces secrets-only users to run the whole
+     scheduler/browser/sync stack they don't need. It makes the *more* critical
+     thing depend on the *less* reliable thing.
+2. **Keep the broker as its own minimal service.**
+   - Fault-isolated, lightweight, independently available, fast cold-start.
+   - **But** two persistent services with (currently) two different lifecycle
+     mechanisms — untidy unless both are auto-managed + self-healing.
+3. **Unify into a light supervisor.** One always-on, lightweight background
+   process that hosts only fast services in-process (broker; scheduler
+   *triggers*) and spawns heavy work (job *runs*, browser automation, session
+   sync) as separate on-demand children.
+   - One background presence + a light, reliable core + isolation of heavy work.
+   - **But** the largest refactor: today the daemon runs browser+sync in-process.
+
+## Decision
+
+**Do not fold the broker into today's daemon (reject Option 1).**
+
+- **Short term — Option 2, made invisible.** Keep the broker its own minimal,
+  auto-started, self-healing service. The "two processes" cost is only a problem
+  if a human has to *manage* them; with auto-start + heal-on-upgrade +
+  version-skew self-heal (see [secrets.md](secrets.md#self-healing-across-upgrades)),
+  neither service needs hand-holding. Reliability isolation outweighs tidiness
+  for a security primitive.
+- **Long term — Option 3.** Evolve toward a light supervisor: move
+  `BrowserService`/IPC and session-sync out of the daemon core into spawned
+  children, leaving a light core that can host the broker too. *That* is the
+  legitimate "one daemon," and it's the right time to consolidate — not by
+  pushing the broker into the heavy daemon as it stands.
+
+The guiding principle: **consolidate processes by making the host light, not by
+making the critical service heavy.**
+
+## Consequences
+
+- The broker keeps its own `com.phnx-labs.agents-secrets-agent` service; the
+  redundancy is paid down by self-healing, not by merging.
+- The daemon's own fragility (PID-null, duplicates, cold-start) is fixed on its
+  own merits (single-instance enforcement, self-heal) rather than inherited by
+  secrets.
+- The two services should converge on **one** lifecycle convention (launchd
+  primary, detached fallback, version-skew self-heal) so they look and heal the
+  same way — a prerequisite for the eventual Option-3 merge.
+- Revisit this record when the supervisor refactor is scoped; at that point the
+  broker folds into the *light* core and this status moves to "superseded."

--- a/docs/08-secrets-agent-process-model.md
+++ b/docs/08-secrets-agent-process-model.md
@@ -1,6 +1,6 @@
 # Secrets-agent process model (design decision)
 
-> Status: **proposed** · Supersedes nothing · Related: [secrets.md](secrets.md), [03-routines.md](03-routines.md)
+> Status: **accepted** · Supersedes nothing · Related: [secrets.md](secrets.md), [03-routines.md](03-routines.md)
 
 A design record for *where the secrets-agent broker should live as a process* —
 its own service, or folded into the routines daemon. Written after a stretch of
@@ -51,53 +51,64 @@ A reliability/security primitive that *everything* depends on should have the
 **fewest dependencies and the lightest footprint**, and must not inherit the
 failure modes of unrelated subsystems.
 
+A note on an argument we explicitly **reject**: "the daemon is flaky, so keep the
+broker out of it." A daemon is *defined* by being the supervised, always-on,
+bounce-back backbone — robustness is its job. The PID-null / duplicate /
+cold-start incidents are **bugs to fix in the daemon**, not properties to design
+around. Routing a critical service *around* the daemon to dodge its bugs is
+backwards; the fix is to make the daemon worthy of hosting critical services.
+And the reliability isolation a separate broker seems to buy is largely illusory:
+both a standalone broker and the daemon recover the same way — launchd
+`KeepAlive` — so splitting them adds a second thing to supervise without adding
+real resilience.
+
 ## Options
 
-1. **Fold into the routines daemon.** Host the broker next to `BrowserIPCServer`.
-   - Fewer processes; reuses one lifecycle; matches an existing pattern.
-   - **But** couples secrets availability to a heavy, only-runs-with-routines,
-     empirically-flaky host; and forces secrets-only users to run the whole
-     scheduler/browser/sync stack they don't need. It makes the *more* critical
-     thing depend on the *less* reliable thing.
-2. **Keep the broker as its own minimal service.**
-   - Fault-isolated, lightweight, independently available, fast cold-start.
-   - **But** two persistent services with (currently) two different lifecycle
-     mechanisms — untidy unless both are auto-managed + self-healing.
-3. **Unify into a light supervisor.** One always-on, lightweight background
-   process that hosts only fast services in-process (broker; scheduler
-   *triggers*) and spawns heavy work (job *runs*, browser automation, session
-   sync) as separate on-demand children.
-   - One background presence + a light, reliable core + isolation of heavy work.
-   - **But** the largest refactor: today the daemon runs browser+sync in-process.
+1. **Fold into the daemon, and harden the daemon.** Host the broker in the
+   daemon next to `BrowserIPCServer`; make the daemon the always-on,
+   single-instance, self-healing backbone it is meant to be.
+   - One supervised backbone for all background services; one lifecycle; one
+     self-heal path; the broker inherits the daemon's robustness.
+   - Requires real work: the daemon must (a) be **always-on**, not gated on
+     having routines; (b) enforce **single-instance** (no duplicates); (c) start
+     the **broker socket first/fast** so secrets availability never waits on
+     browser/sync init; (d) keep heavy/risky work (browser automation, job runs)
+     in **spawned children** so a crash there can't take the backbone down.
+2. **Keep the broker as its own minimal service.** Fault-isolated, but two
+   services on two lifecycle mechanisms, and the "isolation" is mostly illusory
+   (both rely on `KeepAlive`). Rejected — it treats daemon bugs as permanent.
 
 ## Decision
 
-**Do not fold the broker into today's daemon (reject Option 1).**
+**Fold the broker into the daemon — and harden the daemon into the robust,
+always-on, self-healing backbone (Option 1).** A daemon is the right home for a
+persistent, critical background service precisely *because* it is supposed to be
+the most reliable, supervised component. The broker's reliability should come
+*from* a reliable daemon, not from avoiding it.
 
-- **Short term — Option 2, made invisible.** Keep the broker its own minimal,
-  auto-started, self-healing service. The "two processes" cost is only a problem
-  if a human has to *manage* them; with auto-start + heal-on-upgrade +
-  version-skew self-heal (see [secrets.md](secrets.md#self-healing-across-upgrades)),
-  neither service needs hand-holding. Reliability isolation outweighs tidiness
-  for a security primitive.
-- **Long term — Option 3.** Evolve toward a light supervisor: move
-  `BrowserService`/IPC and session-sync out of the daemon core into spawned
-  children, leaving a light core that can host the broker too. *That* is the
-  legitimate "one daemon," and it's the right time to consolidate — not by
-  pushing the broker into the heavy daemon as it stands.
+The guiding principle (corrected): **make the host (the daemon) reliable enough
+to carry the critical service — don't route the critical service around the
+host.**
 
-The guiding principle: **consolidate processes by making the host light, not by
-making the critical service heavy.**
+This makes the daemon the single backbone that hosts the scheduler, browser IPC,
+and the secrets broker, with heavy/optional work spawned as children to bound
+blast radius.
 
 ## Consequences
 
-- The broker keeps its own `com.phnx-labs.agents-secrets-agent` service; the
-  redundancy is paid down by self-healing, not by merging.
-- The daemon's own fragility (PID-null, duplicates, cold-start) is fixed on its
-  own merits (single-instance enforcement, self-heal) rather than inherited by
-  secrets.
-- The two services should converge on **one** lifecycle convention (launchd
-  primary, detached fallback, version-skew self-heal) so they look and heal the
-  same way — a prerequisite for the eventual Option-3 merge.
-- Revisit this record when the supervisor refactor is scoped; at that point the
-  broker folds into the *light* core and this status moves to "superseded."
+- The standalone `com.phnx-labs.agents-secrets-agent` launchd service is retired;
+  the broker becomes a service hosted inside `com.phnx-labs.agents-daemon`. The
+  `secrets start/stop` surface either goes away or becomes thin aliases for
+  daemon lifecycle.
+- The daemon must become **always-on** (start for any background need, not only
+  `routines add`) and **single-instance** (the PID-null/duplicate bugs are
+  fixed, not tolerated).
+- In `runDaemon()`, **bind the broker socket before** the browser/session-sync
+  setup, so secrets resolution is available within milliseconds of daemon start
+  even while the heavier services initialize.
+- Heavy/crash-prone work stays in child processes so a failure there can't take
+  down the broker; the daemon core stays light enough to be trustworthy.
+- Self-heal (heal-on-upgrade + version-skew restart, PR #413) applies to the one
+  daemon, covering the broker for free.
+- Migration: on upgrade, `bootout` the old secrets-agent service and let the
+  daemon take over the socket.

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ How agents-cli is laid out on disk and how it decides what to load.
 |---|---|
 | [Profiles](profiles.md) | Named (host CLI, endpoint, model, keychain auth) bundles — run Kimi / MiniMax / GLM / DeepSeek / Qwen through Claude Code with no proxy. |
 | [Secrets](secrets.md) | Keychain-backed env-var bundles. Inject into runs via `agents run --secrets <name>`. 1Password import/export, encrypted push/pull. |
+| [Secrets-agent process model](08-secrets-agent-process-model.md) | Design decision: why the secrets broker is its own service, not folded into the routines daemon (and the path to a light supervisor). |
 
 ## Orchestration
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ How agents-cli is laid out on disk and how it decides what to load.
 |---|---|
 | [Profiles](profiles.md) | Named (host CLI, endpoint, model, keychain auth) bundles — run Kimi / MiniMax / GLM / DeepSeek / Qwen through Claude Code with no proxy. |
 | [Secrets](secrets.md) | Keychain-backed env-var bundles. Inject into runs via `agents run --secrets <name>`. 1Password import/export, encrypted push/pull. |
-| [Secrets-agent process model](08-secrets-agent-process-model.md) | Design decision: why the secrets broker is its own service, not folded into the routines daemon (and the path to a light supervisor). |
+| [Secrets-agent process model](08-secrets-agent-process-model.md) | Design decision: fold the secrets broker into a hardened, always-on daemon — make the host reliable enough to carry the critical service rather than routing around it. |
 
 ## Orchestration
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -126,6 +126,8 @@ holds only ciphertext): see [Recipe 8](#8-headless-release-on-a-remote-mac).
 
 | Command | Description | Example |
 |---------|-------------|---------|
+| `secrets start` | Install + run the secrets-agent as a persistent background service (survives heavy load; reads connect instantly) | `agents secrets start` |
+| `secrets stop` | Stop + remove the persistent service and wipe what it held | `agents secrets stop` |
 | `secrets unlock [names...]` | Read a bundle once (one Touch ID) and hold it in the secrets-agent so later runs read it silently | `agents secrets unlock prod` |
 | `secrets unlock --all` | Unlock every configured bundle | `agents secrets unlock --all` |
 | `secrets unlock <name> --ttl <dur>` | Hold for a custom lifetime (default 24h) | `agents secrets unlock prod --ttl 30m` |
@@ -376,6 +378,17 @@ The secrets-agent is the ssh-agent answer:
 - The hold ends when its TTL expires (default 24h, `--ttl` to change), you run `agents secrets lock`, or the screen locks / the machine sleeps. Nothing is ever written to disk.
 
 It is **opt-in by construction**: if you never run `unlock`, resolution is byte-for-byte today's keychain path. Audit events tag broker-served reads with `"source":"agent"` so you can tell them apart from real keychain reads.
+
+### Persistent service
+
+`agents secrets start` installs the broker as a **launchd user service** (`RunAtLoad` + `KeepAlive`, `ProcessType: Interactive`). Without it, the broker is cold-started on demand — and on a heavily loaded machine a freshly spawned process can't get scheduled to finish booting and bind its socket, so reads silently fall back to the keychain and prompt. The service starts **once** and stays up for the whole login session, so every read just connects. `agents secrets stop` removes it; `agents secrets status` shows whether it's installed. `unlock` and auto-cache install/kickstart it automatically, so first use sets it up.
+
+### Self-healing across upgrades
+
+A long-running daemon or broker keeps running the code it started with; an in-place `npm i -g` swaps the files but not the running process, so a fix can silently fail to take effect (e.g. a pre-fix daemon keeps reading the keychain). The agent self-heals onto new code with no per-read cost:
+
+- **Heal-on-upgrade:** `postinstall` bounces the routines daemon and kickstarts the broker onto the just-installed code (best-effort; skip with `AGENTS_NO_HEAL=1`).
+- **Version-skew detection:** the broker's `ping` reports the version of the code it's running; `ensureAgentRunning` restarts a stale broker, and a persistent broker self-exits on detecting an in-place upgrade so launchd relaunches it fresh.
 
 ### Tiers and auto-cache
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -239,6 +239,8 @@ To enable version-aware shims, add this to your shell config:
     console.log(`  Installed shorthands: ${written.join(', ')}`);
   }
 
+  await healLongRunningProcesses();
+
   const version = getVersion();
   if (version) {
     const section = getChangelogSection(version);
@@ -248,6 +250,39 @@ To enable version-aware shims, add this to your shell config:
       console.log('');
     }
   }
+}
+
+/**
+ * Self-heal long-running processes onto the just-installed code (macOS).
+ *
+ * The root cause behind stale-behavior bugs is a daemon/broker that keeps
+ * running pre-upgrade code for days. An in-place `npm i -g` swaps the files but
+ * not the running processes — so we bounce them here, the one moment we know the
+ * code just changed. Best-effort and non-fatal: a failure must never break the
+ * install. Skipped in CI and when AGENTS_NO_HEAL=1.
+ */
+async function healLongRunningProcesses() {
+  if (process.platform !== 'darwin') return;
+  if (process.env.CI || process.env.AGENTS_NO_HEAL === '1') return;
+  // Routines daemon: restart so it reloads new code (e.g. picks up keychain
+  // read-memoization / broker fast-path that a stale daemon wouldn't have).
+  try {
+    const d = await import('../dist/lib/daemon.js');
+    if (d.isDaemonRunning?.()) {
+      d.stopDaemon?.();
+      d.startDaemon?.();
+      console.log('  Restarted the routines daemon onto this version.');
+    }
+  } catch { /* best effort */ }
+  // Persistent secrets-agent broker: kickstart so launchd relaunches it on the
+  // new code. No-op if the service isn't installed; never blocks.
+  try {
+    const a = await import('../dist/lib/secrets/agent.js');
+    if (a.secretsAgentServiceInstalled?.()) {
+      a.kickstartSecretsAgentService?.();
+      console.log('  Reloaded the secrets-agent service onto this version.');
+    }
+  } catch { /* best effort */ }
 }
 
 main().catch((err) => {

--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -150,6 +150,8 @@ agents secrets lock               # wipe it; next read re-prompts
 
 `unlock` reads the bundle once and keeps the resolved values in a local broker behind a user-only socket; later runs read from memory with no prompt. The hold ends on its TTL (default 24h, `--ttl 30m`), when you `lock`, or when the screen locks / the machine sleeps. Nothing is written to disk.
 
+For a machine running lots of agents, run `agents secrets start` once — it installs the broker as a persistent background service (launchd) that stays up across the session, so a cold-started broker can't get starved under load. It self-heals onto new code after `npm i -g` upgrades. `agents secrets status` shows whether it's installed.
+
 **Skip `unlock` entirely** — mark a bundle `session` tier and turn on auto-cache, then the first prompt of a run populates the broker for you:
 
 ```bash

--- a/src/lib/secrets/agent.test.ts
+++ b/src/lib/secrets/agent.test.ts
@@ -94,9 +94,14 @@ describe('handleAgentRequest', () => {
     expect(r).toMatchObject({ hit: true, env: { K: 'new' } });
   });
 
-  it('ping reports the protocol version', () => {
+  it('ping reports the protocol version and the running CLI version', () => {
     const r = handleAgentRequest(freshStore(), { cmd: 'ping' }, 0);
     expect(r).toMatchObject({ ok: true, cmd: 'ping' });
-    if (r.ok && r.cmd === 'ping') expect(typeof r.version).toBe('number');
+    if (r.ok && r.cmd === 'ping') {
+      expect(typeof r.version).toBe('number');
+      // cliVersion drives staleness detection — a client compares it to its own
+      // fresh on-disk read and restarts the broker on mismatch.
+      expect(typeof r.cliVersion).toBe('string');
+    }
   });
 });

--- a/src/lib/secrets/agent.ts
+++ b/src/lib/secrets/agent.ts
@@ -31,6 +31,7 @@ import { spawn, spawnSync, execFileSync, type ChildProcess } from 'child_process
 import { getHelpersDir, readMeta } from '../state.js';
 import { isAlive } from '../platform/process.js';
 import { getKeychainHelperPath } from './install-helper.js';
+import { getCliVersion, getCliVersionFresh } from '../version.js';
 import type { SecretsBundle } from './bundles.js';
 
 /** Bumped when the wire protocol changes; a client that pings a mismatched
@@ -181,10 +182,24 @@ export async function installSecretsAgentService(timeoutMs = 30000): Promise<boo
   try { execFileSync('launchctl', ['kickstart', '-k', `gui/${uid}/${SERVICE_LABEL}`], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* best effort */ }
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (await agentPing()) return true;
+    if ((await agentPing()).reachable) return true;
     await new Promise((r) => setTimeout(r, 200));
   }
   return false;
+}
+
+/**
+ * Kickstart the already-installed persistent broker so launchd relaunches it
+ * onto the current on-disk code. Used by postinstall heal-on-upgrade. No-op if
+ * the service isn't installed; never rewrites the plist or waits, so it's safe
+ * and fast to call from an installer.
+ */
+export function kickstartSecretsAgentService(): void {
+  if (!onDarwin() || !secretsAgentServiceInstalled()) return;
+  const uid = process.getuid?.() ?? 0;
+  try {
+    execFileSync('launchctl', ['kickstart', '-k', `gui/${uid}/${SERVICE_LABEL}`], { stdio: ['ignore', 'ignore', 'ignore'] });
+  } catch { /* best effort */ }
 }
 
 /** Stop + remove the persistent broker service, and wipe whatever it held. */
@@ -209,7 +224,7 @@ export type Request =
   | { cmd: 'status' };
 
 export type Response =
-  | { ok: true; cmd: 'ping'; version: number }
+  | { ok: true; cmd: 'ping'; version: number; cliVersion: string }
   | { ok: true; cmd: 'get'; hit: false }
   | { ok: true; cmd: 'get'; hit: true; bundle: SecretsBundle; env: Record<string, string> }
   | { ok: true; cmd: 'load' }
@@ -232,7 +247,11 @@ export function handleAgentRequest(
 ): Response {
   switch (req.cmd) {
     case 'ping':
-      return { ok: true, cmd: 'ping', version: PROTOCOL_VERSION };
+      // Report the version of the code this broker is RUNNING (getCliVersion
+      // caches the value from the broker's startup), not the on-disk version.
+      // A client compares this to its own fresh on-disk read; a mismatch means
+      // the broker is running pre-upgrade code and should be restarted.
+      return { ok: true, cmd: 'ping', version: PROTOCOL_VERSION, cliVersion: getCliVersion() };
     case 'get': {
       const e = store.get(req.name);
       if (!e || now >= e.expiresAt) {
@@ -301,9 +320,24 @@ export async function runSecretsAgent(opts: { service?: boolean } = {}): Promise
   const sock = socketPath();
   try { fs.unlinkSync(sock); } catch { /* no stale socket */ }
 
+  // Capture the version of the code we're running so the sweep can detect when
+  // an in-place upgrade has landed and self-heal onto it. getCliVersion caches
+  // this value for the process lifetime; getCliVersionFresh re-reads on disk.
+  const runningVersion = getCliVersion();
+
   const sweep = () => {
     const now = Date.now();
     for (const [name, e] of store) if (now >= e.expiresAt) store.delete(name);
+    // Self-heal: a newer version was installed in place — exit so launchd
+    // relaunches us on the new code. Only meaningful when launchd will restart
+    // us (persistent); a one-off broker just keeps serving until idle.
+    if (persistent) {
+      const onDisk = getCliVersionFresh();
+      if (onDisk !== 'unknown' && runningVersion !== 'unknown' && onDisk !== runningVersion) {
+        shutdown(0); // KeepAlive relaunches on the new code
+        return;
+      }
+    }
     if (store.size === 0) {
       if (!persistent && now - emptySince >= IDLE_EXIT_MS) shutdown(0);
     } else {
@@ -561,11 +595,15 @@ export async function agentStatus(): Promise<AgentStatusEntry[]> {
   return r?.ok === true && r.cmd === 'status' ? r.entries : [];
 }
 
-/** Is a broker live and speaking our protocol version? */
-async function agentPing(): Promise<boolean> {
-  if (!agentSocketExists()) return false;
+/** Ping result: whether a broker is reachable + speaking our protocol, and the
+ * version of the code it's running (for staleness detection). */
+async function agentPing(): Promise<{ reachable: boolean; cliVersion?: string }> {
+  if (!agentSocketExists()) return { reachable: false };
   const r = await request({ cmd: 'ping' });
-  return r?.ok === true && r.cmd === 'ping' && r.version === PROTOCOL_VERSION;
+  if (r?.ok === true && r.cmd === 'ping' && r.version === PROTOCOL_VERSION) {
+    return { reachable: true, cliVersion: r.cliVersion };
+  }
+  return { reachable: false };
 }
 
 /**
@@ -580,7 +618,16 @@ async function agentPing(): Promise<boolean> {
  */
 export async function ensureAgentRunning(timeoutMs = 5000): Promise<boolean> {
   if (!onDarwin()) return false;
-  if (await agentPing()) return true;
+
+  // Self-heal: if a broker is reachable but running pre-upgrade code (its
+  // reported version != the version on disk now), tear it down so the paths
+  // below bring up a fresh one on current code. A current, reachable broker is
+  // accepted immediately.
+  const ping = await agentPing();
+  if (ping.reachable) {
+    if (ping.cliVersion === undefined || ping.cliVersion === getCliVersionFresh()) return true;
+    await teardownStaleBroker();
+  }
 
   // Path 1: the persistent service. installSecretsAgentService is idempotent and
   // waits for the socket; for an already-installed service we kickstart and wait.
@@ -591,7 +638,7 @@ export async function ensureAgentRunning(timeoutMs = 5000): Promise<boolean> {
       const uid = process.getuid?.() ?? 0;
       try { execFileSync('launchctl', ['kickstart', '-k', `gui/${uid}/${SERVICE_LABEL}`], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* may already be running */ }
       const d = Date.now() + timeoutMs;
-      while (Date.now() < d) { if (await agentPing()) return true; await new Promise((r) => setTimeout(r, 150)); }
+      while (Date.now() < d) { if ((await agentPing()).reachable) return true; await new Promise((r) => setTimeout(r, 150)); }
     }
   } catch { /* fall through to the one-off spawn */ }
 
@@ -611,8 +658,25 @@ export async function ensureAgentRunning(timeoutMs = 5000): Promise<boolean> {
 
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (await agentPing()) return true;
+    if ((await agentPing()).reachable) return true;
     await new Promise((r) => setTimeout(r, 100));
   }
   return false;
+}
+
+/**
+ * Tear down a stale broker (running pre-upgrade code) so a fresh one can take
+ * over. If the persistent service is installed, bootout makes launchd relaunch
+ * it on the new code; otherwise kill the process and clear its socket/pid.
+ */
+async function teardownStaleBroker(): Promise<void> {
+  if (secretsAgentServiceInstalled()) {
+    const uid = process.getuid?.() ?? 0;
+    try { execFileSync('launchctl', ['kickstart', '-k', `gui/${uid}/${SERVICE_LABEL}`], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* best effort */ }
+    return; // kickstart -k restarts the service onto current code; socket/pid managed by it
+  }
+  const pid = (() => { try { return parseInt(fs.readFileSync(pidPath(), 'utf-8').trim(), 10); } catch { return NaN; } })();
+  if (!isNaN(pid) && isAlive(pid)) { try { process.kill(pid, 'SIGTERM'); } catch { /* gone */ } }
+  try { fs.unlinkSync(socketPath()); } catch { /* gone */ }
+  try { fs.unlinkSync(pidPath()); } catch { /* gone */ }
 }

--- a/src/lib/version.test.ts
+++ b/src/lib/version.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { getCliVersion, getCliVersionFresh } from './version.js';
+
+describe('version', () => {
+  it('getCliVersion returns a non-empty version string', () => {
+    const v = getCliVersion();
+    expect(typeof v).toBe('string');
+    expect(v.length).toBeGreaterThan(0);
+  });
+
+  it('getCliVersionFresh re-reads package.json and matches getCliVersion when unchanged', () => {
+    // Both read the same on-disk package.json; with no in-place swap mid-test
+    // they must agree. (In production they diverge only after `npm i -g` swaps
+    // the file under a running process — the signal the broker/daemon heal on.)
+    expect(getCliVersionFresh()).toBe(getCliVersion());
+  });
+
+  it('getCliVersionFresh is not the memoized cache (callable repeatedly, stable)', () => {
+    const a = getCliVersionFresh();
+    const b = getCliVersionFresh();
+    expect(a).toBe(b);
+    expect(a).not.toBe('');
+  });
+});

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -24,3 +24,23 @@ export function getCliVersion(): string {
   }
   return cached;
 }
+
+/**
+ * Read the version from package.json on disk every call, bypassing the cache.
+ *
+ * `getCliVersion()` memoizes the version a long-running process *started* with.
+ * After `npm i -g` overwrites the install in place, the on-disk package.json
+ * changes but the running process keeps its old in-memory code. Comparing this
+ * fresh read against the cached startup value is how a daemon/broker detects it
+ * is now stale and should reload onto the new code (self-healing). Returns
+ * 'unknown' on any error.
+ */
+export function getCliVersionFresh(): string {
+  try {
+    const pkgPath = path.join(__dirname, '..', '..', 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    return String(pkg.version || 'unknown');
+  } catch {
+    return 'unknown';
+  }
+}


### PR DESCRIPTION
## The pattern behind this whole class of bugs

Every "still getting prompted / stale behavior" issue this week traced to the same thing: **a long-running process running pre-upgrade code.** An in-place `npm i -g` swaps the files on disk but the *running* routines daemon / secrets-agent broker keeps its old in-memory code — sometimes for days. So fixes (keychain read-memoization in #412, the broker fast-path, etc.) silently never take effect. A user has no way to know they need to manually restart a daemon.

This makes the long-running processes **self-heal onto new code**, with **zero hot-path cost** (every check is on a control-plane path, never a per-secret-read).

## What it does

1. **Heal-on-upgrade (`scripts/postinstall.js`)** — the one moment we know the code changed: bounce the routines daemon (`stopDaemon`+`startDaemon`) and kickstart the persistent secrets-agent broker so both reload the just-installed code. Best-effort, non-fatal, skipped in CI / with `AGENTS_NO_HEAL=1`. macOS only.
2. **Broker version-skew self-heal (`src/lib/secrets/agent.ts`)** — `ping` now reports the version of the code the broker is *running*; `ensureAgentRunning` (only the unlock / auto-cache path) restarts a broker found running stale code; and a persistent broker self-exits on detecting an in-place upgrade so launchd relaunches it fresh.
3. **`getCliVersionFresh()` (`src/lib/version.ts`)** — re-reads `package.json` each call (vs the memoized `getCliVersion`) to detect that a swap happened under a running process.

Complements #412: that memoizes the daemon's session-sync reads; this ensures the daemon actually *runs* that code after an upgrade.

## Deliberately conservative

I did **not** add runtime polling that auto-restarts the daemon — on a production routines machine a restart-loop bug is worse than the disease. Heal-on-upgrade fires once per install (no loop), and the broker self-exit is guarded to a clear version mismatch + only when launchd will relaunch it.

## Verification / caveat

Typecheck clean; 12 unit tests pass (version skew + broker ping reporting `cliVersion`). The heal-on-upgrade daemon restart **was not verifiable on the author's machine under the current extreme load** (broker cold-starts are starved and process manipulation is gated), which is exactly why this is opened for review rather than auto-released. CI validates the logic on clean runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
