### PR TITLE
feat(cloud): run each agent in its own native cloud

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ src/
     hooks/match.ts     # `matches:` predicate evaluator
     migrate.ts         # One-shot idempotent migrations
     session/           # Discovery, parsing, rendering (Claude / Codex / Gemini / OpenCode)
-    cloud/             # Provider registry (Rush / Codex / Factory)
+    cloud/             # Provider registry (Rush / Codex / Factory / Antigravity)
     teams/             # `agents teams` orchestration
     profiles.ts        # Host CLI + endpoint + model bundles
 ```

--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -5,13 +5,30 @@ Run agent tasks on remote infrastructure across multiple cloud backends, with un
 ## Overview
 
 `agents cloud` dispatches tasks to remote agent environments without requiring
-a local CLI session. Three providers ship today: Rush Cloud (GitHub-repo-backed
-pods), Codex Cloud (pre-built Codex environments), and Factory (Droid +
-computer-use targets). Every dispatched task is tracked in a local SQLite store
+a local CLI session. **Each agent runs in its own cloud** — four providers ship
+today: Rush Cloud (Claude against a GitHub repo → PR), Codex Cloud (pre-built
+Codex environments), Factory (Droid on a cloud Droid Computer), and Antigravity
+(Gemini Managed Agents). Pass `--agent` and the provider is auto-selected;
+`--provider` overrides. Every dispatched task is tracked in a local SQLite store
 so `agents cloud list` shows the full history across all providers, and transient
 states (`queued`, `allocating`, `running`, `input_required`) are refreshed
 from the live provider API on each `list` call. Tasks continue running after
 you disconnect — reconnect any time with `agents cloud logs <id>`.
+
+### Agent auto-routing
+
+`agents cloud run --agent <id>` routes to that agent's native cloud unless you
+pass `--provider`. Resolution precedence (`resolveProvider` in
+`src/lib/cloud/registry.ts`): explicit `--provider` > the agent's `cloudProvider`
+(declared in the agent registry, `src/lib/agents.ts`) > `cloud.default_provider`
+in `~/.agents/agents.yaml` > `rush`.
+
+| Agent | Native cloud | Why |
+|---|---|---|
+| `claude` | `rush` | Claude Code has no headless Anthropic-hosted dispatch CLI (only `--remote-control`, which bridges a *local* session). Rush runs Claude against a repo → PR. |
+| `codex` | `codex` | `codex cloud exec` — first-class native CLI. |
+| `droid` | `factory` | Factory Droid Computer (cloud VM) via `droid computer ssh` + remote `droid exec`. |
+| `antigravity` | `antigravity` | Gemini Managed Agents Interactions API (remote sandbox). |
 
 ## Architecture
 
@@ -98,16 +115,32 @@ agents cloud providers
 
 ## Providers
 
-Three providers are registered at startup (`src/lib/cloud/registry.ts:49-51`):
+Four providers are registered at startup (`src/lib/cloud/registry.ts`):
 
 | ID | Name | Dispatch target | Multi-repo |
 |---|---|---|---|
 | `rush` | Rush Cloud | GitHub repo + branch | Yes — clones each repo into `/workspace/<owner>/<name>/` |
-| `codex` | Codex Cloud | Pre-built Codex environment | No — bundle the repos into the env |
-| `factory` | Factory | Droid + computer-use pod | No |
+| `codex` | Codex Cloud | Pre-built Codex environment (`--env`) | No — bundle the repos into the env |
+| `factory` | Factory (Droid) | Droid Computer (`--computer`) via relay SSH + `droid exec` | No |
+| `antigravity` | Antigravity (Gemini) | Gemini Managed Agents remote sandbox | No — raw sandbox, no repo → PR |
 
 The default provider is read from `cloud.default_provider` in
-`~/.agents/agents.yaml`. If unset, it falls back to `rush`.
+`~/.agents/agents.yaml`. If unset, it falls back to `rush`. Note that an
+agent's native cloud (via `--agent`) takes precedence over `default_provider`.
+
+**Factory (Droid).** `droid exec` is synchronous, so a Factory dispatch runs the
+remote exec to completion (no live SSE — output appears when the run finishes)
+and the task id is droid's own `session_id`. Requires the `droid` CLI, a Factory
+login, and a pre-provisioned Droid Computer (`--computer <name>`, or
+`cloud.providers.factory.computer`). Create one in Factory (Settings → Droid
+Computers) or register a machine with `droid computer register`.
+
+**Antigravity (Gemini).** Talks to the Interactions API
+(`POST /v1beta/interactions`, agent `antigravity-preview-05-2026`). The Gemini
+API key comes from an `agents secrets` bundle named in
+`cloud.providers.antigravity.secretsBundle` (or `GEMINI_API_KEY` /
+`GOOGLE_API_KEY` in the env). It is a raw sandbox — no GitHub repo → PR; pass a
+repo and it routes you to `--provider rush` instead.
 
 ### Provider configuration (`~/.agents/agents.yaml`)
 
@@ -119,7 +152,11 @@ cloud:
     codex:
       env: env_a1b2c3        # default Codex Cloud environment ID
     factory:
-      computer: linux-vm-1   # default computer target
+      computer: linux-vm-1   # default Droid Computer name
+      autonomy: high         # droid exec --auto level (low|medium|high; default high)
+    antigravity:
+      secretsBundle: gemini.com   # agents secrets bundle holding GEMINI_API_KEY
+      # model: antigravity-preview-05-2026   # optional managed-agent override
 ```
 
 Rush Cloud uses the session token injected by `agents` — no separate config
@@ -231,6 +268,28 @@ agents cloud status tsk_4f2a91
 
 # Unblock it
 agents cloud message tsk_4f2a91 "Looks good — also update the OpenAPI spec"
+```
+
+### 7. Dispatch to a droid's own cloud (Factory Droid Computer)
+
+`--agent droid` auto-routes to Factory; the run executes `droid exec` on the
+named Droid Computer.
+
+```bash
+agents cloud run "add a vitest for src/util/slug.ts" \
+  --agent droid \
+  --computer cloud-vm-1 \
+  --autonomy high
+```
+
+### 8. Dispatch to Antigravity (Gemini Managed Agents)
+
+`--agent antigravity` auto-routes to the Gemini Interactions API. No repo — it's
+a remote sandbox.
+
+```bash
+# key resolved from cloud.providers.antigravity.secretsBundle, or GEMINI_API_KEY
+agents cloud run "benchmark three JSON parsers and report the fastest" --agent antigravity
 ```
 
 ## Budget Guardrails

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -57,12 +57,16 @@ function isJsonMode(opts: { json?: boolean }): boolean {
 export function registerCloudCommands(program: Command): void {
   const cloud = program
     .command('cloud', { hidden: true })
-    .description('Dispatch and manage cloud agent tasks across providers (Rush Cloud, Codex Cloud, Factory).')
+    .description('Dispatch and manage cloud agent tasks across providers (Rush, Codex, Factory, Antigravity).')
     .addHelpText('after', `
+Each agent runs in its own cloud. Pass --agent and the provider is auto-selected
+(claude→rush, codex→codex, droid→factory, antigravity→antigravity); --provider overrides.
+
 Providers:
-  rush      Rush Cloud — dispatches against a GitHub repo + branch
-  codex     Codex Cloud — runs in a pre-built Codex environment
-  factory   Factory pods — Droid + computer-use targets
+  rush         Rush Cloud — Claude against a GitHub repo + branch → PR
+  codex        Codex Cloud — runs in a pre-built Codex environment (--env)
+  factory      Factory Droid Computer — droid exec on a cloud VM (--computer)
+  antigravity  Gemini Managed Agents — Antigravity harness in a remote sandbox
 
 Examples:
   # Dispatch a quick fix to Rush Cloud and stream the output
@@ -103,8 +107,8 @@ Examples:
   cloud
     .command('run [prompt]')
     .description('Dispatch a task to a cloud agent.')
-    .option('--provider <id>', 'Cloud backend: rush, codex, factory')
-    .option('--agent <name>', 'Agent to run: claude, codex, droid')
+    .option('--provider <id>', 'Cloud backend: rush, codex, factory, antigravity (overrides agent auto-routing)')
+    .option('--agent <name>', 'Agent to run: claude, codex, droid, antigravity (auto-routes to its native cloud)')
     .option(
       '--repo <owner/repo>',
       'GitHub repository. Repeatable for multi-repo dispatch (Rush Cloud only).',
@@ -120,6 +124,7 @@ Examples:
     .option('--model <model>', 'Model override')
     .option('--env <id>', 'Codex Cloud environment ID')
     .option('--computer <name>', 'Factory/Droid computer target')
+    .option('--autonomy <level>', 'Factory/Droid autonomy: low, medium, high (default high)')
     .option('--mode <mode>', 'Execution mode (e.g., plan, edit, full)')
     .option(
       '-b, --balanced',
@@ -168,7 +173,9 @@ Examples:
         }
       }
 
-      const provider = resolveProvider(options.provider as string | undefined);
+      // Agent-aware: with no --provider, the agent routes to its native cloud
+      // (claude→rush, codex→codex, droid→factory, antigravity→antigravity).
+      const provider = resolveProvider(options.provider as string | undefined, options.agent as string | undefined);
 
       // --repo is repeatable: commander gives us an array via our collector.
       // A single --repo value arrives as a one-element array; keep the legacy
@@ -193,6 +200,7 @@ Examples:
 
       if (options.env) dispatchOptions.providerOptions!.env = options.env as string;
       if (options.computer) dispatchOptions.providerOptions!.computer = options.computer as string;
+      if (options.autonomy) dispatchOptions.providerOptions!.autonomy = options.autonomy as string;
       if (options.mode) dispatchOptions.providerOptions!.mode = options.mode as string;
       if (options.balanced || (options.strategy as string) === 'balanced') {
         dispatchOptions.providerOptions!.strategy = 'balanced';

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -229,6 +229,9 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: true,
+    // Claude Code has no headless Anthropic-hosted dispatch CLI (only
+    // --remote-control, which bridges a *local* session). Its cloud is Rush.
+    cloudProvider: 'rush',
     capabilities: { hooks: true, mcp: true, allowlist: true, skills: true, commands: true, plugins: true, subagents: true, rules: { file: 'CLAUDE.md' }, workflows: true, modes: ['plan', 'edit', 'auto', 'skip'], rulesImports: true },
   },
   // codex hooks: gated to >= 0.116.0 (introduced [features] codex_hooks flag).
@@ -248,6 +251,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: true,
+    cloudProvider: 'codex',
     capabilities: { hooks: { since: '0.116.0' }, mcp: true, allowlist: false, skills: true, commands: { until: '0.117.0' }, plugins: { since: '0.128.0' }, subagents: false, rules: { file: 'AGENTS.md' }, workflows: false, modes: ['plan', 'edit', 'skip'] },
   },
   gemini: {
@@ -434,6 +438,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '{{args}}',
     supportsHooks: true,
+    cloudProvider: 'antigravity',
     capabilities: { hooks: true, mcp: true, allowlist: true, skills: true, commands: true, plugins: true, subagents: false, rules: { file: 'AGENTS.md' }, workflows: false, modes: ['edit', 'skip'], rulesImports: false },
   },
   // xAI Grok Build CLI (`grok`) — early beta, SuperGrok Heavy. Auth via OAuth on
@@ -531,6 +536,9 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: false,
+    // Factory Droid Computers (cloud VMs) reached via `droid computer ssh` +
+    // remote headless `droid exec`.
+    cloudProvider: 'factory',
     capabilities: {
       hooks: false,
       mcp: true,

--- a/src/lib/cloud/agent-routing.test.ts
+++ b/src/lib/cloud/agent-routing.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { resolveProvider, nativeProviderForAgent } from './registry.js';
+
+describe('nativeProviderForAgent', () => {
+  it('maps the four agents to their own cloud', () => {
+    expect(nativeProviderForAgent('claude')).toBe('rush');
+    expect(nativeProviderForAgent('codex')).toBe('codex');
+    expect(nativeProviderForAgent('droid')).toBe('factory');
+    expect(nativeProviderForAgent('antigravity')).toBe('antigravity');
+  });
+
+  it('returns undefined for agents with no native cloud', () => {
+    expect(nativeProviderForAgent('gemini')).toBeUndefined();
+    expect(nativeProviderForAgent('cursor')).toBeUndefined();
+    expect(nativeProviderForAgent('not-an-agent')).toBeUndefined();
+  });
+});
+
+describe('resolveProvider precedence', () => {
+  it('routes an agent to its native cloud when no provider is given', () => {
+    expect(resolveProvider(undefined, 'codex').id).toBe('codex');
+    expect(resolveProvider(undefined, 'droid').id).toBe('factory');
+    expect(resolveProvider(undefined, 'antigravity').id).toBe('antigravity');
+    expect(resolveProvider(undefined, 'claude').id).toBe('rush');
+  });
+
+  it('lets an explicit --provider override the agent', () => {
+    expect(resolveProvider('codex', 'droid').id).toBe('codex');
+    expect(resolveProvider('rush', 'codex').id).toBe('rush');
+  });
+
+  it('falls back to the default (rush) for an agent with no native cloud', () => {
+    expect(resolveProvider(undefined, 'gemini').id).toBe('rush');
+  });
+
+  it('falls back to the default (rush) when neither provider nor agent is given', () => {
+    expect(resolveProvider().id).toBe('rush');
+  });
+});

--- a/src/lib/cloud/antigravity.test.ts
+++ b/src/lib/cloud/antigravity.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mapStatus,
+  buildInteractionBody,
+  parseInteraction,
+} from './antigravity.js';
+import { AntigravityCloudProvider } from './antigravity.js';
+
+describe('mapStatus', () => {
+  it('maps Interactions API statuses to the canonical enum', () => {
+    expect(mapStatus('queued')).toBe('queued');
+    expect(mapStatus('in_progress')).toBe('running');
+    expect(mapStatus('completed')).toBe('completed');
+    expect(mapStatus('failed')).toBe('failed');
+    expect(mapStatus('cancelled')).toBe('cancelled');
+  });
+  it('defaults unknown/empty to completed (synchronous response is terminal)', () => {
+    expect(mapStatus(undefined)).toBe('completed');
+    expect(mapStatus('weird')).toBe('completed');
+  });
+});
+
+describe('buildInteractionBody', () => {
+  it('targets the managed agent with a remote sandbox', () => {
+    expect(buildInteractionBody('summarize the repo', 'antigravity-preview-05-2026')).toEqual({
+      agent: 'antigravity-preview-05-2026',
+      input: 'summarize the repo',
+      environment: 'remote',
+    });
+  });
+});
+
+describe('parseInteraction', () => {
+  it('parses id, status, summary, and environment id', () => {
+    const out = parseInteraction({
+      id: 'int_1',
+      environment_id: 'env_9',
+      status: 'completed',
+      output_text: 'done',
+    });
+    expect(out).toEqual({ id: 'int_1', status: 'completed', summary: 'done', environmentId: 'env_9' });
+  });
+
+  it('falls back to interaction_id then a synthetic id', () => {
+    expect(parseInteraction({ interaction_id: 'x', status: 'completed' }).id).toBe('x');
+    expect(parseInteraction({ status: 'completed' }).id).toMatch(/^antigravity-/);
+  });
+});
+
+describe('AntigravityCloudProvider capabilities', () => {
+  const ENV_KEYS = ['GEMINI_API_KEY', 'GOOGLE_API_KEY'];
+
+  it('is unavailable with no key source', () => {
+    const saved = ENV_KEYS.map((k) => [k, process.env[k]] as const);
+    for (const k of ENV_KEYS) delete process.env[k];
+    try {
+      const p = new AntigravityCloudProvider();
+      expect(p.capabilities().available).toBe(false);
+    } finally {
+      for (const [k, v] of saved) if (v !== undefined) process.env[k] = v;
+    }
+  });
+
+  it('is available when a Gemini key is in the environment', () => {
+    const prev = process.env.GEMINI_API_KEY;
+    process.env.GEMINI_API_KEY = 'test-key';
+    try {
+      const p = new AntigravityCloudProvider();
+      const caps = p.capabilities();
+      expect(caps.available).toBe(true);
+      expect(caps.dispatch).toBe(true);
+      // Raw sandbox: no repo→PR, no follow-up messaging in v1.
+      expect(caps.multiRepo).toBe(false);
+      expect(caps.message).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.GEMINI_API_KEY;
+      else process.env.GEMINI_API_KEY = prev;
+    }
+  });
+
+  it('is available when a secrets bundle is configured (resolved lazily)', () => {
+    const p = new AntigravityCloudProvider({ secretsBundle: 'gemini.com' });
+    expect(p.capabilities().available).toBe(true);
+  });
+});
+
+describe('AntigravityCloudProvider dispatch guards', () => {
+  it('rejects repo-backed dispatch with a pointer to Rush', async () => {
+    const p = new AntigravityCloudProvider({ secretsBundle: 'gemini.com' });
+    await expect(
+      p.dispatch({ prompt: 'do', repos: ['owner/repo'] }),
+    ).rejects.toThrow(/raw sandbox|rush/i);
+  });
+});

--- a/src/lib/cloud/antigravity.ts
+++ b/src/lib/cloud/antigravity.ts
@@ -1,0 +1,236 @@
+/**
+ * Antigravity cloud provider — Google's Antigravity agent via the Gemini
+ * **Managed Agents Interactions API**.
+ *
+ * The `agy` CLI is local-only (`--print` / `--sandbox`); Antigravity's cloud
+ * surface is an HTTP endpoint that runs the Antigravity harness in a remote
+ * ephemeral Linux sandbox:
+ *
+ *   POST https://generativelanguage.googleapis.com/v1beta/interactions
+ *   x-goog-api-key: <GEMINI_API_KEY>
+ *   { "agent": "antigravity-preview-05-2026", "input": "<prompt>", "environment": "remote" }
+ *
+ * The call is synchronous by default (the response carries `status` +
+ * `output_text`), so `dispatch()` awaits it, returns a terminal CloudTask, and
+ * `stream()` replays the buffered text + done events — same shape as the Factory
+ * provider. It is a raw sandbox: no GitHub repo → PR (that's Rush's job).
+ *
+ * Auth: the Gemini API key comes from an `agents secrets` bundle named in
+ * `cloud.providers.antigravity.secretsBundle` (never from agents.yaml), falling
+ * back to GEMINI_API_KEY / GOOGLE_API_KEY in the environment.
+ */
+
+import type {
+  CloudProvider,
+  CloudTask,
+  CloudTaskStatus,
+  CloudEvent,
+  DispatchOptions,
+  ProviderCapabilities,
+} from './types.js';
+import { resolveDispatchRepos } from './types.js';
+import { readAndResolveBundleEnv } from '../secrets/bundles.js';
+
+const INTERACTIONS_URL = 'https://generativelanguage.googleapis.com/v1beta/interactions';
+const DEFAULT_MODEL = 'antigravity-preview-05-2026';
+const KEY_NAMES = ['GEMINI_API_KEY', 'GOOGLE_API_KEY'] as const;
+
+/** Shape of the Interactions API response we consume (defensive: all optional). */
+interface InteractionResponse {
+  id?: string;
+  interaction_id?: string;
+  environment_id?: string;
+  status?: string;
+  output_text?: string;
+  error?: { message?: string } | string;
+}
+
+/** Map an Interactions API status string to the canonical CloudTaskStatus. */
+export function mapStatus(s: string | undefined): CloudTaskStatus {
+  const lower = (s ?? '').toLowerCase();
+  if (lower.includes('queue') || lower.includes('pending')) return 'queued';
+  if (lower.includes('run') || lower.includes('progress')) return 'running';
+  if (lower.includes('complete') || lower.includes('success')) return 'completed';
+  if (lower.includes('fail') || lower.includes('error')) return 'failed';
+  if (lower.includes('cancel')) return 'cancelled';
+  return 'completed';
+}
+
+/** Build the Interactions API request body for a fresh dispatch. */
+export function buildInteractionBody(prompt: string, model: string): Record<string, unknown> {
+  return {
+    agent: model,
+    input: prompt,
+    environment: 'remote',
+  };
+}
+
+/** Parse an Interactions API response into a CloudTask (minus prompt/timestamps). */
+export function parseInteraction(resp: InteractionResponse): { id: string; status: CloudTaskStatus; summary?: string; environmentId?: string } {
+  const id = resp.id ?? resp.interaction_id ?? `antigravity-${Date.now()}`;
+  return {
+    id,
+    status: mapStatus(resp.status),
+    summary: resp.output_text,
+    environmentId: resp.environment_id,
+  };
+}
+
+/** A completed interaction, buffered in-process for `stream()` to replay. */
+interface BufferedRun {
+  events: CloudEvent[];
+  task: CloudTask;
+}
+
+export class AntigravityCloudProvider implements CloudProvider {
+  id = 'antigravity' as const;
+  name = 'Antigravity (Gemini)';
+
+  private secretsBundle?: string;
+  private model: string;
+  private runs = new Map<string, BufferedRun>();
+
+  constructor(config?: { secretsBundle?: string; model?: string }) {
+    this.secretsBundle = config?.secretsBundle;
+    this.model = config?.model ?? DEFAULT_MODEL;
+  }
+
+  /**
+   * True when a key *source* is configured. Cheap: never resolves the bundle
+   * (which could prompt for biometry) — that happens lazily at dispatch.
+   */
+  private hasKeySource(): boolean {
+    if (this.secretsBundle) return true;
+    return KEY_NAMES.some((k) => Boolean(process.env[k]));
+  }
+
+  /** Resolve the Gemini API key from the configured bundle or the environment. */
+  private resolveApiKey(): string {
+    if (this.secretsBundle) {
+      try {
+        const { env } = readAndResolveBundleEnv(this.secretsBundle, { caller: 'cloud:antigravity' });
+        for (const k of KEY_NAMES) {
+          if (env[k]) return env[k];
+        }
+        throw new Error(
+          `Secrets bundle '${this.secretsBundle}' has no ${KEY_NAMES.join(' or ')}. Add one: agents secrets add ${this.secretsBundle} GEMINI_API_KEY`,
+        );
+      } catch (err) {
+        throw new Error(`Could not read Gemini API key from bundle '${this.secretsBundle}': ${(err as Error).message}`);
+      }
+    }
+    for (const k of KEY_NAMES) {
+      const v = process.env[k];
+      if (v) return v;
+    }
+    throw new Error(
+      `Antigravity cloud needs a Gemini API key. Set cloud.providers.antigravity.secretsBundle in ~/.agents/agents.yaml, or export ${KEY_NAMES.join(' / ')}.`,
+    );
+  }
+
+  capabilities(): ProviderCapabilities {
+    const available = this.hasKeySource();
+    return {
+      available,
+      dispatch: available,
+      status: available,
+      list: available,
+      stream: available,
+      cancel: false,
+      message: false,
+      multiRepo: false,
+      skills: false,
+      images: false,
+    };
+  }
+
+  async dispatch(options: DispatchOptions): Promise<CloudTask> {
+    // The Interactions sandbox has no GitHub repo → PR flow. Reject repos
+    // loudly rather than silently ignoring them (point the user at Rush).
+    const repos = resolveDispatchRepos(options);
+    if (repos.length > 0) {
+      throw new Error(
+        `Antigravity cloud is a raw sandbox with no GitHub repo → PR flow. Got repo(s): ${repos.join(', ')}. ` +
+          `Use --provider rush for repo-backed dispatch.`,
+      );
+    }
+
+    const apiKey = this.resolveApiKey();
+    const model = (options.model as string | undefined) ?? this.model;
+    const body = buildInteractionBody(options.prompt, model);
+
+    let resp: Response;
+    try {
+      resp = await fetch(INTERACTIONS_URL, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-goog-api-key': apiKey },
+        body: JSON.stringify(body),
+      });
+    } catch (err) {
+      throw new Error(`Antigravity dispatch failed (network): ${(err as Error).message}`);
+    }
+
+    const text = await resp.text();
+    if (!resp.ok) {
+      throw new Error(`Antigravity dispatch failed (${resp.status}): ${text.slice(0, 500)}`);
+    }
+
+    let parsed: InteractionResponse;
+    try {
+      parsed = JSON.parse(text) as InteractionResponse;
+    } catch {
+      throw new Error(`Antigravity returned non-JSON response: ${text.slice(0, 300)}`);
+    }
+
+    const { id, status, summary } = parseInteraction(parsed);
+    const now = new Date().toISOString();
+    const task: CloudTask = {
+      id,
+      provider: 'antigravity',
+      status,
+      agent: 'antigravity',
+      prompt: options.prompt,
+      summary,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const events: CloudEvent[] = [];
+    if (summary) events.push({ type: 'text', content: summary, timestamp: now });
+    events.push({ type: 'done', status, summary, timestamp: now });
+    this.runs.set(id, { events, task });
+
+    return task;
+  }
+
+  async status(taskId: string): Promise<CloudTask> {
+    const run = this.runs.get(taskId);
+    if (run) return run.task;
+    throw new Error(`No live status for Antigravity task ${taskId} (synchronous interaction; see local cache).`);
+  }
+
+  async list(): Promise<CloudTask[]> {
+    return [...this.runs.values()].map((r) => r.task);
+  }
+
+  async *stream(taskId: string): AsyncIterable<CloudEvent> {
+    const run = this.runs.get(taskId);
+    if (!run) {
+      yield {
+        type: 'error',
+        message: `Antigravity interaction ${taskId} is not buffered in this process. The interaction is synchronous — see 'agents cloud status ${taskId}' for the result.`,
+        timestamp: new Date().toISOString(),
+      };
+      return;
+    }
+    for (const event of run.events) yield event;
+  }
+
+  async cancel(_taskId: string): Promise<void> {
+    throw new Error('Cancel is not supported for Antigravity — interactions run synchronously to completion.');
+  }
+
+  async message(_taskId: string, _content: string): Promise<void> {
+    throw new Error('Follow-up messages are not yet supported for Antigravity cloud tasks.');
+  }
+}

--- a/src/lib/cloud/factory.test.ts
+++ b/src/lib/cloud/factory.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveAutonomy,
+  buildExecArgs,
+  buildSshArgs,
+  mapResultStatus,
+  mapDroidEvent,
+} from './factory.js';
+
+describe('resolveAutonomy', () => {
+  it('passes through valid levels', () => {
+    expect(resolveAutonomy('low')).toBe('low');
+    expect(resolveAutonomy('medium')).toBe('medium');
+    expect(resolveAutonomy('high')).toBe('high');
+  });
+
+  it('falls back to high for invalid/missing values', () => {
+    expect(resolveAutonomy(undefined)).toBe('high');
+    expect(resolveAutonomy('full')).toBe('high');
+    expect(resolveAutonomy(42)).toBe('high');
+  });
+
+  it('honors a custom fallback', () => {
+    expect(resolveAutonomy(undefined, 'low')).toBe('low');
+  });
+});
+
+describe('buildExecArgs', () => {
+  it('builds a headless stream-json exec with autonomy', () => {
+    expect(buildExecArgs('fix the bug', { autonomy: 'high' })).toEqual([
+      'exec', '--auto', 'high', '--output-format', 'stream-json', 'fix the bug',
+    ]);
+  });
+
+  it('inserts -s when resuming a session', () => {
+    expect(buildExecArgs('keep going', { autonomy: 'medium', sessionId: 'sess-123' })).toEqual([
+      'exec', '--auto', 'medium', '--output-format', 'stream-json', '-s', 'sess-123', 'keep going',
+    ]);
+  });
+});
+
+describe('buildSshArgs', () => {
+  it('wires the droid relay as an OpenSSH ProxyCommand and quotes the remote cmd', () => {
+    const args = buildSshArgs(
+      'cloud-vm-1',
+      'droid',
+      ['exec', '--auto', 'high', '--output-format', 'stream-json', 'do a thing'],
+      { droidBin: '/usr/bin/droid', user: 'droid' },
+    );
+    // ProxyCommand routes through the relay for the named computer.
+    expect(args).toContain('-o');
+    expect(args.some((a) => a.startsWith('ProxyCommand=/usr/bin/droid computer ssh cloud-vm-1 --proxy'))).toBe(true);
+    // Connects as user@computer.
+    expect(args).toContain('droid@cloud-vm-1');
+    // The remote command is a single shell-quoted string ending the argv.
+    expect(args[args.length - 1]).toBe(
+      `'droid' 'exec' '--auto' 'high' '--output-format' 'stream-json' 'do a thing'`,
+    );
+  });
+
+  it('escapes single quotes in the prompt safely', () => {
+    const args = buildSshArgs('vm', 'droid', ['exec', `it's fine`], { droidBin: 'droid', user: 'droid' });
+    expect(args[args.length - 1]).toContain(`'it'\\''s fine'`);
+  });
+});
+
+describe('mapResultStatus', () => {
+  it('maps is_error to failed', () => {
+    expect(mapResultStatus({ is_error: true, subtype: 'error' })).toBe('failed');
+  });
+  it('maps success to completed', () => {
+    expect(mapResultStatus({ is_error: false, subtype: 'success' })).toBe('completed');
+  });
+  it('detects cancellation in subtype', () => {
+    expect(mapResultStatus({ is_error: false, subtype: 'cancelled' })).toBe('cancelled');
+  });
+});
+
+describe('mapDroidEvent', () => {
+  it('maps a result event to done with status + summary', () => {
+    const ev = mapDroidEvent({ type: 'result', subtype: 'success', is_error: false, result: 'all green', session_id: 'abc' });
+    expect(ev.type).toBe('done');
+    if (ev.type === 'done') {
+      expect(ev.status).toBe('completed');
+      expect(ev.summary).toBe('all green');
+    }
+  });
+
+  it('maps an errored result to a failed done', () => {
+    const ev = mapDroidEvent({ type: 'result', is_error: true, result: 'boom' });
+    expect(ev.type).toBe('done');
+    if (ev.type === 'done') expect(ev.status).toBe('failed');
+  });
+
+  it('maps assistant text', () => {
+    const ev = mapDroidEvent({ type: 'assistant', text: 'thinking out loud' });
+    expect(ev).toMatchObject({ type: 'text', content: 'thinking out loud' });
+  });
+
+  it('extracts text from a content array', () => {
+    const ev = mapDroidEvent({ type: 'message', content: [{ text: 'a' }, { text: 'b' }] });
+    expect(ev).toMatchObject({ type: 'text', content: 'ab' });
+  });
+
+  it('maps tool calls and results', () => {
+    expect(mapDroidEvent({ type: 'tool_call', name: 'Bash', input: { cmd: 'ls' } }))
+      .toMatchObject({ type: 'tool_use', tool: 'Bash' });
+    expect(mapDroidEvent({ type: 'tool_result', name: 'Bash', output: 'files' }))
+      .toMatchObject({ type: 'tool_result', tool: 'Bash' });
+  });
+
+  it('surfaces unknown event types rather than dropping them', () => {
+    const ev = mapDroidEvent({ type: 'mystery', foo: 1 });
+    expect(ev.type).toBe('unknown');
+    if (ev.type === 'unknown') expect(ev.name).toBe('mystery');
+  });
+});

--- a/src/lib/cloud/factory.ts
+++ b/src/lib/cloud/factory.ts
@@ -1,10 +1,28 @@
 /**
- * Factory/Droid cloud provider -- stub for Phase 2.
+ * Factory (Droid) cloud provider.
  *
- * Will dispatch tasks to a `droid daemon` running on a remote machine.
- * All methods throw until the droid daemon API is documented and stable.
+ * Dispatches to a Factory **Droid Computer** — a persistent cloud VM (managed
+ * by Factory, or bring-your-own via `droid computer register`). There is no
+ * `droid cloud run`; remote execution = reach the computer over the Droid relay
+ * (`droid computer ssh <name>`) and run a headless `droid exec` there.
+ *
+ * `droid exec` is synchronous (it runs to completion and exits, unlike Codex
+ * Cloud which is async server-side). So `dispatch()` runs the remote exec to
+ * completion with `--output-format stream-json`, buffers the NDJSON events, and
+ * `stream()` replays them. The task id is droid's own `session_id` (captured
+ * from the run output), so it lines up with `droid exec -s <id>` for future
+ * resume support.
+ *
+ * Transport note: the exact relay SSH composition (user + ProxyCommand) is
+ * built in `buildSshArgs()` and must be confirmed against a live provisioned
+ * Droid Computer (Factory auth required). `capabilities().available` gates on
+ * the droid binary + a configured computer so the provider fails with a clear
+ * message rather than misfiring when unconfigured.
  */
 
+import { spawn, execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
 import type {
   CloudProvider,
   CloudTask,
@@ -12,30 +30,176 @@ import type {
   CloudEvent,
   DispatchOptions,
   ProviderCapabilities,
+  DroidAutonomy,
 } from './types.js';
+import { getShimsDir } from '../state.js';
+
+const SHIMS_DIR = getShimsDir();
+
+const DEFAULT_AUTONOMY: DroidAutonomy = 'high';
+const VALID_AUTONOMY = new Set<DroidAutonomy>(['low', 'medium', 'high']);
+
+/** Locate the droid binary, checking agents-cli shims first then PATH. */
+export function findDroidBinary(): string | null {
+  const shim = path.join(SHIMS_DIR, 'droid');
+  if (fs.existsSync(shim)) return shim;
+  try {
+    return execFileSync('which', ['droid'], { stdio: 'pipe' }).toString().trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Normalize an autonomy value, falling back to the safe cloud default (`high`). */
+export function resolveAutonomy(value: unknown, fallback: DroidAutonomy = DEFAULT_AUTONOMY): DroidAutonomy {
+  return typeof value === 'string' && VALID_AUTONOMY.has(value as DroidAutonomy)
+    ? (value as DroidAutonomy)
+    : fallback;
+}
 
 /**
- * Factory/Droid cloud provider — stub for Phase 2.
- *
- * Integration path: `droid daemon` running on a remote machine (workstation, cloud VM, k8s pod).
- * Dispatch via HTTP to the daemon, stream output, cancel via HTTP DELETE.
- *
- * Not yet implemented because:
- * 1. Droid v0.104 has no cloud dispatch command (droid exec is local only)
- * 2. droid daemon API isn't documented yet
- * 3. droid computer register/ssh is the remote execution primitive but needs exploration
+ * Build the remote `droid exec` argv. Headless, stream-json output, given
+ * autonomy. `sessionId` (when resuming) maps to `-s`.
  */
+export function buildExecArgs(
+  prompt: string,
+  opts: { autonomy: DroidAutonomy; sessionId?: string },
+): string[] {
+  const args = ['exec', '--auto', opts.autonomy, '--output-format', 'stream-json'];
+  if (opts.sessionId) args.push('-s', opts.sessionId);
+  args.push(prompt);
+  return args;
+}
+
+/**
+ * Build the `ssh` argv that runs a remote command on a Droid Computer through
+ * the Droid relay. The relay is used as an OpenSSH ProxyCommand
+ * (`droid computer ssh <name> --proxy`), so the connection rides Factory's
+ * brokered tunnel rather than a directly reachable host.
+ *
+ * `remoteArgv` is the already-built remote command (e.g. droid exec argv); it is
+ * shell-quoted into a single remote command string.
+ */
+export function buildSshArgs(
+  computer: string,
+  remoteBin: string,
+  remoteArgv: string[],
+  opts: { droidBin: string; user: string; port?: string },
+): string[] {
+  const remoteCmd = [remoteBin, ...remoteArgv].map(shellQuote).join(' ');
+  const proxy = `ProxyCommand=${opts.droidBin} computer ssh ${computer} --proxy --port %p`;
+  return [
+    '-o', proxy,
+    '-o', 'StrictHostKeyChecking=accept-new',
+    '-p', opts.port ?? '22',
+    `${opts.user}@${computer}`,
+    remoteCmd,
+  ];
+}
+
+/** POSIX single-quote a shell argument. */
+function shellQuote(arg: string): string {
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Map a droid stream-json `result.subtype` / `is_error` to a CloudTaskStatus. */
+export function mapResultStatus(line: { is_error?: boolean; subtype?: string }): CloudTaskStatus {
+  if (line.is_error) return 'failed';
+  if (line.subtype && /cancel/i.test(line.subtype)) return 'cancelled';
+  return 'completed';
+}
+
+/**
+ * Map one parsed droid stream-json event to a CloudEvent. The stream-json
+ * schema is only partially documented, so this is defensive: known shapes map
+ * to typed events, everything else surfaces as `unknown` rather than being
+ * dropped (mirrors the rest of the cloud event pipeline).
+ */
+export function mapDroidEvent(obj: Record<string, unknown>): CloudEvent {
+  const ts = new Date().toISOString();
+  const type = String(obj.type ?? '');
+
+  switch (type) {
+    case 'result': {
+      return {
+        type: 'done',
+        status: mapResultStatus(obj as { is_error?: boolean; subtype?: string }),
+        summary: typeof obj.result === 'string' ? obj.result : undefined,
+        timestamp: ts,
+      };
+    }
+    case 'assistant':
+    case 'message':
+    case 'text': {
+      const content = extractText(obj);
+      if (content) return { type: 'text', content, timestamp: ts };
+      break;
+    }
+    case 'thinking':
+    case 'reasoning': {
+      const content = extractText(obj);
+      if (content) return { type: 'thinking', content, timestamp: ts };
+      break;
+    }
+    case 'tool_call':
+    case 'tool_use': {
+      return { type: 'tool_use', tool: String(obj.name ?? obj.tool ?? 'tool'), input: obj.input ?? obj.arguments ?? {}, timestamp: ts };
+    }
+    case 'tool_result': {
+      return { type: 'tool_result', tool: String(obj.name ?? obj.tool ?? 'tool'), output: obj.output ?? obj.result ?? '', timestamp: ts };
+    }
+    case 'error': {
+      return { type: 'error', message: String(obj.message ?? obj.error ?? 'unknown error'), timestamp: ts };
+    }
+  }
+  return { type: 'unknown', name: type || 'unknown', data: JSON.stringify(obj), timestamp: ts };
+}
+
+/** Pull a text string out of the varied droid message shapes. */
+function extractText(obj: Record<string, unknown>): string {
+  if (typeof obj.text === 'string') return obj.text;
+  if (typeof obj.content === 'string') return obj.content;
+  if (Array.isArray(obj.content)) {
+    return obj.content
+      .map((c) => (c && typeof c === 'object' && typeof (c as Record<string, unknown>).text === 'string' ? (c as Record<string, unknown>).text as string : ''))
+      .join('');
+  }
+  const msg = obj.message;
+  if (msg && typeof msg === 'object') return extractText(msg as Record<string, unknown>);
+  return '';
+}
+
+/** A completed droid run, buffered in-process for `stream()` to replay. */
+interface BufferedRun {
+  events: CloudEvent[];
+  task: CloudTask;
+}
+
 export class FactoryCloudProvider implements CloudProvider {
   id = 'factory' as const;
   name = 'Factory (Droid)';
 
+  private defaultComputer?: string;
+  private defaultAutonomy: DroidAutonomy;
+  /** session_id → buffered run, populated by dispatch, drained by stream. */
+  private runs = new Map<string, BufferedRun>();
+
+  constructor(config?: { computer?: string; autonomy?: DroidAutonomy }) {
+    this.defaultComputer = config?.computer;
+    this.defaultAutonomy = resolveAutonomy(config?.autonomy);
+  }
+
   capabilities(): ProviderCapabilities {
+    const droid = findDroidBinary() !== null;
+    const computer = Boolean(this.defaultComputer);
     return {
-      available: false,
-      dispatch: false,
-      status: false,
-      list: false,
-      stream: false,
+      // Reachable only when the droid binary exists AND a computer is set.
+      // (A per-dispatch --computer can still override the missing default.)
+      available: droid && computer,
+      dispatch: droid,
+      status: droid,
+      list: droid,
+      stream: droid,
       cancel: false,
       message: false,
       multiRepo: false,
@@ -44,27 +208,128 @@ export class FactoryCloudProvider implements CloudProvider {
     };
   }
 
-  async dispatch(_options: DispatchOptions): Promise<CloudTask> {
-    throw new Error('Factory cloud provider is not yet available. Coming in a future release.');
+  async dispatch(options: DispatchOptions): Promise<CloudTask> {
+    const droidBin = findDroidBinary();
+    if (!droidBin) {
+      throw new Error('droid CLI not found. Install it: curl -fsSL https://app.factory.ai/cli | sh');
+    }
+
+    const computer = (options.providerOptions?.computer as string | undefined) ?? this.defaultComputer;
+    if (!computer) {
+      throw new Error(
+        'Factory cloud requires a Droid Computer. Pass --computer <name>, or set ' +
+          'cloud.providers.factory.computer in ~/.agents/agents.yaml. Create one in ' +
+          'Factory (Settings → Droid Computers), or register a machine with `droid computer register`.',
+      );
+    }
+
+    const autonomy = resolveAutonomy(options.providerOptions?.autonomy ?? options.providerOptions?.mode, this.defaultAutonomy);
+    const user = (options.providerOptions?.user as string | undefined) ?? 'droid';
+
+    const execArgs = buildExecArgs(options.prompt, { autonomy });
+    const sshArgs = buildSshArgs(computer, 'droid', execArgs, { droidBin, user });
+
+    const { events, status, summary, sessionId } = await this.runRemote(sshArgs);
+
+    const now = new Date().toISOString();
+    const id = sessionId ?? `droid-${Date.now()}`;
+    const task: CloudTask = {
+      id,
+      provider: 'factory',
+      status,
+      agent: 'droid',
+      prompt: options.prompt,
+      summary,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.runs.set(id, { events, task });
+    return task;
   }
 
-  async status(_taskId: string): Promise<CloudTask> {
-    throw new Error('Factory cloud provider is not yet available.');
+  /** Run the remote droid exec to completion, collecting events + final result. */
+  private runRemote(sshArgs: string[]): Promise<{ events: CloudEvent[]; status: CloudTaskStatus; summary?: string; sessionId?: string }> {
+    return new Promise((resolve, reject) => {
+      const proc = spawn('ssh', sshArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
+      const events: CloudEvent[] = [];
+      let status: CloudTaskStatus = 'failed';
+      let summary: string | undefined;
+      let sessionId: string | undefined;
+      let stdoutBuf = '';
+      let stderr = '';
+
+      const handleLine = (line: string) => {
+        const trimmed = line.trim();
+        if (!trimmed) return;
+        let obj: Record<string, unknown>;
+        try {
+          obj = JSON.parse(trimmed);
+        } catch {
+          // Non-JSON line (banner, ssh notice) — surface it, don't drop it.
+          events.push({ type: 'unknown', name: 'stdout', data: trimmed, timestamp: new Date().toISOString() });
+          return;
+        }
+        if (typeof obj.session_id === 'string') sessionId = obj.session_id;
+        const event = mapDroidEvent(obj);
+        if (event.type === 'done') {
+          status = event.status ?? 'completed';
+          summary = event.summary ?? summary;
+        }
+        events.push(event);
+      };
+
+      proc.stdout.on('data', (d: Buffer) => {
+        stdoutBuf += d.toString();
+        const lines = stdoutBuf.split('\n');
+        stdoutBuf = lines.pop() ?? '';
+        for (const line of lines) handleLine(line);
+      });
+      proc.stderr.on('data', (d: Buffer) => { stderr += d.toString(); });
+
+      proc.on('error', (err) => reject(err));
+      proc.on('close', (code) => {
+        if (stdoutBuf) handleLine(stdoutBuf);
+        if (code !== 0 && events.every((e) => e.type !== 'done')) {
+          // Surface the auth error verbatim — it's the common first-run failure.
+          const detail = stderr.trim() || `ssh exited ${code}`;
+          reject(new Error(`Factory dispatch failed: ${detail}`));
+          return;
+        }
+        resolve({ events, status, summary, sessionId });
+      });
+    });
   }
 
-  async list(_filter?: { status?: CloudTaskStatus }): Promise<CloudTask[]> {
-    return [];
+  async status(taskId: string): Promise<CloudTask> {
+    const run = this.runs.get(taskId);
+    if (run) return run.task;
+    // No remote task registry — the command layer falls back to the local store.
+    throw new Error(`No live status for Factory task ${taskId} (synchronous run; see local cache).`);
   }
 
-  async *stream(_taskId: string): AsyncIterable<CloudEvent> {
-    throw new Error('Factory cloud provider is not yet available.');
+  async list(): Promise<CloudTask[]> {
+    // Factory has no remote task list; `agents cloud list` reads the local store.
+    return [...this.runs.values()].map((r) => r.task);
+  }
+
+  async *stream(taskId: string): AsyncIterable<CloudEvent> {
+    const run = this.runs.get(taskId);
+    if (!run) {
+      yield {
+        type: 'error',
+        message: `Factory run ${taskId} is not buffered in this process. droid exec is synchronous — its output is not retained after the run completes. See 'agents cloud status ${taskId}' for the summary.`,
+        timestamp: new Date().toISOString(),
+      };
+      return;
+    }
+    for (const event of run.events) yield event;
   }
 
   async cancel(_taskId: string): Promise<void> {
-    throw new Error('Factory cloud provider is not yet available.');
+    throw new Error('Cancel is not supported for Factory (Droid) — droid exec runs synchronously to completion.');
   }
 
   async message(_taskId: string, _content: string): Promise<void> {
-    throw new Error('Factory cloud provider is not yet available.');
+    throw new Error('Follow-up messages are not yet supported for Factory (Droid) cloud tasks.');
   }
 }

--- a/src/lib/cloud/registry.ts
+++ b/src/lib/cloud/registry.ts
@@ -13,7 +13,10 @@ import type { CloudProvider, CloudProviderId, CloudConfig } from './types.js';
 import { RushCloudProvider } from './rush.js';
 import { CodexCloudProvider } from './codex.js';
 import { FactoryCloudProvider } from './factory.js';
+import { AntigravityCloudProvider } from './antigravity.js';
 import { getUserAgentsDir } from '../state.js';
+import { AGENTS } from '../agents.js';
+import type { AgentId } from '../types.js';
 
 const META_FILE = path.join(getUserAgentsDir(), 'agents.yaml');
 
@@ -48,7 +51,18 @@ function initProviders(): void {
 
   providers.set('rush', new RushCloudProvider());
   providers.set('codex', new CodexCloudProvider(config.providers?.codex));
-  providers.set('factory', new FactoryCloudProvider());
+  providers.set('factory', new FactoryCloudProvider(config.providers?.factory));
+  providers.set('antigravity', new AntigravityCloudProvider(config.providers?.antigravity));
+}
+
+/**
+ * The cloud provider an agent dispatches to by default. Reads the canonical
+ * `cloudProvider` field on the agent registry entry — one source of truth, no
+ * side map. Returns undefined for agents with no native cloud.
+ */
+export function nativeProviderForAgent(agentId: string): CloudProviderId | undefined {
+  const agent = AGENTS[agentId as AgentId];
+  return agent?.cloudProvider;
 }
 
 /** Look up a provider by ID, throwing if the ID is unknown. */
@@ -73,8 +87,20 @@ export function getAllProviders(): CloudProvider[] {
   return [...providers.values()];
 }
 
-/** Resolve the active provider from an explicit flag or the configured default. */
-export function resolveProvider(explicit?: string): CloudProvider {
-  const id = (explicit ?? getDefaultProviderId()) as CloudProviderId;
+/**
+ * Resolve the active provider for a dispatch.
+ *
+ * Precedence: explicit `--provider` > the agent's native cloud
+ * (`cloudProvider`) > configured `cloud.default_provider` > `rush`. This is
+ * what makes `agents cloud run --agent droid` land on Factory and
+ * `--agent codex` land on Codex Cloud without the user naming a provider.
+ *
+ * Callers that already hold a concrete provider id (e.g. resolving a stored
+ * task's provider) pass it as `explicit` and the agent arg is ignored.
+ */
+export function resolveProvider(explicit?: string, agentId?: string): CloudProvider {
+  const id = (explicit
+    ?? (agentId ? nativeProviderForAgent(agentId) : undefined)
+    ?? getDefaultProviderId()) as CloudProviderId;
   return getProvider(id);
 }

--- a/src/lib/cloud/types.ts
+++ b/src/lib/cloud/types.ts
@@ -6,8 +6,19 @@
  * the dispatch pipeline.
  */
 
-/** Identifier for a supported cloud dispatch backend. */
-export type CloudProviderId = 'rush' | 'codex' | 'factory';
+/**
+ * Identifier for a supported cloud dispatch backend.
+ *
+ * Each id is one agent's *own* cloud:
+ *   - `rush`        — Rush Cloud (runs Claude against a GitHub repo → PR)
+ *   - `codex`       — OpenAI Codex Cloud (`codex cloud exec`)
+ *   - `factory`     — Factory Droid Computers (`droid computer ssh` + remote `droid exec`)
+ *   - `antigravity` — Google Gemini Managed Agents (Interactions API)
+ *
+ * Agents route to their native cloud automatically (see `cloudProvider` in the
+ * agent registry); `--provider` overrides.
+ */
+export type CloudProviderId = 'rush' | 'codex' | 'factory' | 'antigravity';
 
 /**
  * Lifecycle state of a cloud-dispatched task.
@@ -192,11 +203,27 @@ export interface CloudProvider {
   message(taskId: string, content: string): Promise<void>;
 }
 
+/** Autonomy level passed to `droid exec --auto` for Factory cloud dispatches. */
+export type DroidAutonomy = 'low' | 'medium' | 'high';
+
 /** Per-provider configuration stored in the `cloud.providers` section of agents.yaml. */
 export interface CloudProviderConfig {
   rush?: Record<string, string>;
   codex?: { env?: string };
-  factory?: { computer?: string };
+  /**
+   * Factory (Droid) cloud. `computer` is the pre-provisioned Droid Computer
+   * name (managed in Factory's UI, or BYOM via `droid computer register`) —
+   * the Factory analogue of Codex's pre-built `env`. `autonomy` is the default
+   * `droid exec --auto` level for cloud runs (defaults to `high`).
+   */
+  factory?: { computer?: string; autonomy?: DroidAutonomy };
+  /**
+   * Antigravity (Gemini Managed Agents) cloud. The Gemini API key is read from
+   * an `agents secrets` bundle named here (never stored in agents.yaml); if
+   * unset, the provider falls back to GEMINI_API_KEY / GOOGLE_API_KEY in the
+   * environment. `model` overrides the default managed-agent id.
+   */
+  antigravity?: { secretsBundle?: string; model?: string };
 }
 
 /** Top-level `cloud` section of agents.yaml. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,8 @@
  * formats for each supported agent.
  */
 
+import type { CloudProviderId } from './cloud/types.js';
+
 /** Unique identifier for a supported AI coding agent. */
 export type AgentId = 'claude' | 'codex' | 'gemini' | 'cursor' | 'opencode' | 'openclaw' | 'copilot' | 'amp' | 'kiro' | 'goose' | 'roo' | 'antigravity' | 'grok' | 'kimi' | 'droid';
 
@@ -93,6 +95,13 @@ export interface AgentConfig {
   variableSyntax: string;
   supportsHooks: boolean;
   nativeAgentsSkillsDir?: boolean;
+  /**
+   * This agent's *own* cloud backend. `agents cloud run --agent <id>` routes
+   * here when no `--provider` is given (precedence: --provider > this >
+   * cloud.default_provider > rush). Undefined means the agent has no native
+   * cloud and falls back to the configured default.
+   */
+  cloudProvider?: CloudProviderId;
   capabilities: {
     hooks: Capability;
     mcp: Capability;


### PR DESCRIPTION
## What

Make **each agent run in its own cloud** via `agents cloud`. `agents cloud run --agent <id>` now auto-routes to that agent's native cloud; `--provider` overrides.

| Agent | Native cloud | Status |
|---|---|---|
| `codex` | Codex Cloud (`codex cloud exec`) | already shipped |
| `claude` | Rush Cloud | routed (Claude Code has no headless Anthropic-hosted dispatch CLI — only `--remote-control`, a *local* phone-bridged session) |
| `droid` | **Factory Droid Computer** (cloud VM) | **implemented** (was a stub) |
| `antigravity` | **Gemini Managed Agents** (Interactions API) | **new provider** |

## How

- **Routing source of truth**: a `cloudProvider` field on the agent registry (`src/lib/agents.ts`). `resolveProvider(provider?, agent?)` applies precedence: `--provider` > agent-native > `cloud.default_provider` > `rush`.
- **Factory (Droid)**: reaches a pre-provisioned Droid Computer over the relay (`droid computer ssh <name>` as an OpenSSH ProxyCommand) and runs headless `droid exec --output-format stream-json`. `droid exec` is synchronous, so dispatch runs to completion, the task id is droid's own `session_id`, and stream-json events map into the shared `CloudEvent` pipeline. Needs the `droid` CLI + Factory login + a `--computer` (or `cloud.providers.factory.computer`).
- **Antigravity (Gemini)**: `POST /v1beta/interactions`, agent `antigravity-preview-05-2026`. Gemini key resolved from an `agents secrets` bundle (`cloud.providers.antigravity.secretsBundle`) or `GEMINI_API_KEY`/`GOOGLE_API_KEY`. It's a raw sandbox — rejects repo-backed dispatch and points at `--provider rush`.
- CLI: agent-aware dispatch + `--autonomy <low|medium|high>` for Droid; help/`providers` updated. Docs in `docs/cloud.md`.

## Verification

- **Full suite green on crabbox** (CI-exact `bun install --ignore-scripts && bun run build && bun run test`): **231 files / 2885 tests passed, 0 failures**, including 31 new tests (routing precedence + all 4 agent mappings, factory arg/ssh/event builders, antigravity request/response/capabilities/guards).
- **Live `agents cloud providers`** (built CLI) lists all four and reports availability correctly: `rush` (ready, default), `codex` (ready), `factory` (not configured — no computer), `antigravity` (not configured — no key).

## Not yet verified end-to-end (needs credentials I don't hold)

- **Droid relay E2E**: requires a Factory login + a provisioned Droid Computer. The exact relay SSH user/ProxyCommand form (`buildSshArgs`) is built to the documented relay mechanics but should be confirmed against a live computer; `capabilities().available` gates on droid + a configured computer so it fails with a clear message until then.
- **Antigravity E2E**: requires a Gemini API key in a secrets bundle.

Follow-ups (intentionally out of scope): durable cross-process resume / `message()` for Factory + Antigravity (needs persisting provider state; the local store currently ignores `provider_data`).
