### PR TITLE
feat(versions): centralized fast agent-spec resolver + cached listInstalledVersions

### DIFF
--- a/bench/resolve-perf.ts
+++ b/bench/resolve-perf.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env tsx
+// Benchmark harness for centralized agent-spec resolution.
+//
+// Measures, against the host's real installed versions:
+//   A. listInstalledVersions — cold (cache busted each call) vs warm (cached)
+//   B. resolveAgentTargets fast paths (exact / @pinned / bare) — meta-only,
+//      no enumeration once warm
+//   C. resolveAgentTargets enumerate paths (@latest / @all)
+//   D. 1000x repeated resolution of the hot-path spec (simulates per-subcommand
+//      resolution across a session) — total + per-call
+//
+// The "fast paths perform zero readdir" invariant is asserted in the unit test
+// (agent-spec.test.ts, via vi.spyOn) — bun makes fs.readdirSync read-only so it
+// can't be instrumented here; this harness measures wall-clock instead.
+//
+// Output: JSON on stdout. Run before/after to diff: `bun bench/resolve-perf.ts`.
+
+import { performance } from 'perf_hooks';
+import { listInstalledVersions, invalidateInstalledVersionsCache, getGlobalDefault } from '../src/lib/versions.js';
+import { resolveAgentTargets } from '../src/lib/agent-spec.js';
+import { ALL_AGENT_IDS } from '../src/lib/agents.js';
+import type { AgentId } from '../src/lib/types.js';
+
+const agent: AgentId | undefined = ALL_AGENT_IDS.find((a) => listInstalledVersions(a).length > 0);
+if (!agent) {
+  console.log(JSON.stringify({ error: 'no agent has installed versions on this host' }, null, 2));
+  process.exit(0);
+}
+const installed = listInstalledVersions(agent);
+const exactVer = installed[installed.length - 1];
+const pinned = getGlobalDefault(agent);
+
+function time(fn: () => void, iters: number): { totalMs: number; perCallUs: number } {
+  for (let i = 0; i < Math.min(50, iters); i++) fn(); // warmup
+  const t0 = performance.now();
+  for (let i = 0; i < iters; i++) fn();
+  const totalMs = performance.now() - t0;
+  return { totalMs: +totalMs.toFixed(3), perCallUs: +((totalMs * 1000) / iters).toFixed(3) };
+}
+
+const results: Record<string, unknown> = {
+  host: { agent, installedCount: installed.length, exactVer, pinned },
+};
+
+// A. cold (cache busted each call) vs warm (cached)
+{
+  const cold = time(() => {
+    invalidateInstalledVersionsCache(agent);
+    listInstalledVersions(agent);
+  }, 2000);
+  const warm = time(() => listInstalledVersions(agent), 200000);
+  results.listInstalledVersions = {
+    cold,
+    warm,
+    speedup: +(cold.perCallUs / warm.perCallUs).toFixed(1),
+  };
+}
+
+// B. fast paths (meta-only; no enumeration warm)
+{
+  listInstalledVersions(agent); // warm
+  results.fastPaths = {
+    exact: time(() => resolveAgentTargets(`${agent}@${exactVer}`), 100000),
+    pinned: pinned ? time(() => resolveAgentTargets(`${agent}@pinned`), 100000) : 'no-default-set',
+    bare: time(() => resolveAgentTargets(`${agent}`), 100000),
+  };
+}
+
+// C. enumerate paths
+{
+  results.enumeratePaths = {
+    latest: time(() => resolveAgentTargets(`${agent}@latest`), 100000),
+    all: time(() => resolveAgentTargets(`${agent}@all`), 100000),
+  };
+}
+
+// D. 1000x hot-path spec
+results.hotPath1000x = time(() => resolveAgentTargets(`${agent}@${exactVer}`), 1000);
+
+console.log(JSON.stringify(results, null, 2));

--- a/src/lib/agent-spec.ts
+++ b/src/lib/agent-spec.ts
@@ -1,0 +1,199 @@
+// Centralized agent-spec resolution — one vocabulary, one resolver, reused by
+// every subcommand that accepts `<agent>[@<qualifier>]`.
+//
+// The qualifier vocabulary used to be split across three functions in
+// versions.ts (parseAgentSpec, resolveVersionAlias, resolveInstalledAgentTargets)
+// with diverging support — `@latest`/`@oldest` in one, `@all`/`@default` in
+// another, `@pinned` nowhere. This module is the single source of truth.
+//
+// Built for the hot path (`--launch`, ~100ms budget): the common specs resolve
+// with NO directory enumeration —
+//   exact `claude@2.1.181`   → one isVersionInstalled() (existsSync)
+//   `claude@pinned|@default` → memoized getGlobalDefault() + existsSync
+//   bare `claude`            → resolveVersion() (memoized meta), no readdir
+// Only the relative qualifiers `@latest`/`@oldest`/`@all` enumerate, and even
+// then via the mtime-cached listInstalledVersions().
+
+import type { AgentId } from './types.js';
+import { AGENTS, ALL_AGENT_IDS, resolveAgentName, formatAgentError } from './agents.js';
+import {
+  listInstalledVersions,
+  getGlobalDefault,
+  isVersionInstalled,
+  resolveVersion,
+} from './versions.js';
+
+export interface AgentTarget {
+  agent: AgentId;
+  /** Resolved exact version, or null when the agent has no installed versions yet. */
+  version: string | null;
+}
+
+/** Canonical qualifier set, in help/display order. `pinned` ≡ `default`. */
+export const AGENT_QUALIFIERS = ['latest', 'oldest', 'pinned', 'default', 'all'] as const;
+export type AgentQualifier = (typeof AGENT_QUALIFIERS)[number];
+
+/** Shared `--help` epilog so every agent-spec command documents the same grammar. */
+export const AGENT_SPEC_HELP =
+  'Agent spec: <agent>[@<qualifier>]. Qualifiers: ' +
+  '@latest (highest installed), @oldest (lowest installed), ' +
+  '@pinned / @default (your configured default — synonyms), ' +
+  '@all (every installed version), or an exact @x.y.z. ' +
+  'Bare <agent> uses the resolved default (project pin → global default). ' +
+  'Comma-separate to combine: claude@all,codex@latest.';
+
+export class AgentSpecError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AgentSpecError';
+  }
+}
+
+export interface ResolveAgentTargetsOptions {
+  /** Project dir for resolving a bare spec's project pin. Defaults to process.cwd(). */
+  cwd?: string;
+  /** Restrict the agents a spec may name (e.g. only mcp-capable). Defaults to all. */
+  availableAgents?: readonly AgentId[];
+}
+
+/**
+ * Resolve an agent spec (single or comma-list) into concrete installed targets.
+ * Domain = installed: `@latest`/`@oldest`/`@all` range over installed versions
+ * (`add`/`install` use a separate available-version path). Throws AgentSpecError
+ * on bad input — never calls process.exit, so it is safe on the hot path and in
+ * library contexts.
+ */
+export function resolveAgentTargets(
+  spec: string,
+  opts: ResolveAgentTargetsOptions = {},
+): AgentTarget[] {
+  const cwd = opts.cwd ?? process.cwd();
+  const available = opts.availableAgents ?? ALL_AGENT_IDS;
+
+  const rawEntries = spec
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (rawEntries.length === 0) {
+    throw new AgentSpecError('Empty agent spec.');
+  }
+
+  // Expand the bare literal `all` (or `all@all`) into every available agent that
+  // has at least one installed version. Lenient: agents with nothing installed
+  // are skipped rather than erroring.
+  const entries: string[] = [];
+  for (const e of rawEntries) {
+    if (e === 'all' || e === 'all@all') {
+      for (const a of available) {
+        if (listInstalledVersions(a).length > 0) entries.push(`${a}@all`);
+      }
+    } else {
+      entries.push(e);
+    }
+  }
+
+  const out: AgentTarget[] = [];
+  const seen = new Set<string>();
+  const push = (agent: AgentId, version: string | null) => {
+    const key = `${agent}@${version ?? ''}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push({ agent, version });
+    }
+  };
+
+  for (const entry of entries) {
+    const at = entry.indexOf('@');
+    const agentToken = (at === -1 ? entry : entry.slice(0, at)).trim();
+    const qualifier = at === -1 ? null : entry.slice(at + 1).trim();
+
+    if (!agentToken) continue;
+    if (at !== -1 && !qualifier) {
+      throw new AgentSpecError(
+        `Missing version in '${entry}'. Use ${agentToken}@x.y.z, @latest, @oldest, @pinned, @default, or @all.`,
+      );
+    }
+
+    const agent = resolveAgentName(agentToken);
+    if (!agent || !available.includes(agent)) {
+      throw new AgentSpecError(formatAgentError(agentToken, [...available]));
+    }
+    const name = AGENTS[agent].name;
+
+    // ----- bare: resolved default, NO enumeration in the common case -----
+    if (qualifier === null) {
+      const resolved = resolveVersion(agent, cwd); // project pin → global default (meta-only)
+      if (resolved) {
+        push(agent, resolved);
+      } else {
+        const installed = listInstalledVersions(agent);
+        if (installed.length === 0) push(agent, null);
+        else if (installed.length === 1) push(agent, installed[0]);
+        else
+          throw new AgentSpecError(
+            `No default version set for ${name}. Specify one (${agent}@<version>) or set it: agents use ${agent}@<version>.`,
+          );
+      }
+      continue;
+    }
+
+    // ----- @pinned / @default: synonyms, meta-only fast path -----
+    if (qualifier === 'pinned' || qualifier === 'default') {
+      const def = getGlobalDefault(agent);
+      if (!def) {
+        throw new AgentSpecError(`No default version set for ${name}. Run: agents use ${agent}@<version>`);
+      }
+      push(agent, def);
+      continue;
+    }
+
+    // ----- @all: every installed version -----
+    if (qualifier === 'all') {
+      const installed = listInstalledVersions(agent);
+      if (installed.length === 0) {
+        throw new AgentSpecError(`No managed versions are installed for ${name}. Run: agents add ${agent}@latest`);
+      }
+      for (const v of installed) push(agent, v);
+      continue;
+    }
+
+    // ----- @latest / @oldest: enumerate (mtime-cached), pick an end -----
+    if (qualifier === 'latest' || qualifier === 'oldest') {
+      const installed = listInstalledVersions(agent); // already sorted ascending
+      if (installed.length === 0) {
+        throw new AgentSpecError(`No managed versions are installed for ${name}. Run: agents add ${agent}@latest`);
+      }
+      push(agent, qualifier === 'oldest' ? installed[0] : installed[installed.length - 1]);
+      continue;
+    }
+
+    // ----- exact version: one existsSync, NO enumeration -----
+    if (!isVersionInstalled(agent, qualifier)) {
+      const installed = listInstalledVersions(agent);
+      const hint = installed.length ? ` Installed: ${installed.join(', ')}.` : '';
+      throw new AgentSpecError(`${name}@${qualifier} is not installed.${hint} Install it: agents add ${agent}@${qualifier}`);
+    }
+    push(agent, qualifier);
+  }
+
+  return out;
+}
+
+/**
+ * Convenience for single-target commands (`use`, `run`): resolve a spec that
+ * must name exactly one installed version. Rejects `@all` / multi-target specs.
+ */
+export function resolveSingleAgentTarget(
+  spec: string,
+  opts: ResolveAgentTargetsOptions = {},
+): { agent: AgentId; version: string } {
+  const targets = resolveAgentTargets(spec, opts);
+  if (targets.length !== 1) {
+    throw new AgentSpecError(`'${spec}' resolves to ${targets.length} targets; this command needs exactly one.`);
+  }
+  const t = targets[0];
+  if (t.version === null) {
+    throw new AgentSpecError(`No installed version for ${AGENTS[t.agent].name}. Run: agents add ${t.agent}@latest`);
+  }
+  return { agent: t.agent, version: t.version };
+}

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -979,13 +979,35 @@ export async function isOldestInstalled(agent: AgentId): Promise<{ installed: bo
   return { installed: isVersionInstalled(agent, oldestVersion), version: oldestVersion };
 }
 
+// Per-process cache for listInstalledVersions. The agent's versions dir mtime
+// changes whenever a version dir is added or removed (install/remove), so a
+// stamp match means the installed set is unchanged and we skip the readdir +
+// N binary stats. Mirrors the readMeta() cache in state.ts. Hot path:
+// resolveAgentTargets and every enumerate-style consumer hit this.
+const installedVersionsCache = new Map<AgentId, { stamp: number; versions: string[] }>();
+
+/** Drop the installed-versions cache (call after install/remove mutations). */
+export function invalidateInstalledVersionsCache(agent?: AgentId): void {
+  if (agent) installedVersionsCache.delete(agent);
+  else installedVersionsCache.clear();
+}
+
 /**
- * List all installed versions for an agent.
+ * List all installed versions for an agent (cached by versions-dir mtime).
  */
 export function listInstalledVersions(agent: AgentId): string[] {
   const agentVersionsDir = path.join(getVersionsDir(), agent);
-  if (!fs.existsSync(agentVersionsDir)) {
+  let stamp: number;
+  try {
+    stamp = fs.statSync(agentVersionsDir).mtimeMs;
+  } catch {
+    installedVersionsCache.set(agent, { stamp: 0, versions: [] });
     return [];
+  }
+
+  const cached = installedVersionsCache.get(agent);
+  if (cached && cached.stamp === stamp) {
+    return cached.versions;
   }
 
   const entries = fs.readdirSync(agentVersionsDir, { withFileTypes: true });
@@ -1000,7 +1022,9 @@ export function listInstalledVersions(agent: AgentId): string[] {
     }
   }
 
-  return versions.sort(compareVersions);
+  versions.sort(compareVersions);
+  installedVersionsCache.set(agent, { stamp, versions });
+  return versions;
 }
 
 /**


### PR DESCRIPTION
**Draft / WIP.** Foundation PR for unifying agent-spec resolution. Type-checks clean (`tsc`); runtime verification (bench run + vitest) is pending — see status below.

## Why
The `<agent>[@<qualifier>]` grammar was split across three functions with **diverging** support — `@latest`/`@oldest` in `resolveVersionAlias`, `@all`/`@default` in `resolveInstalledAgentTargets`, `@pinned` nowhere — so the same spec works in some subcommands and errors in others. And `listInstalledVersions` (~30 call sites) does an uncached `readdir` + N binary-stats on every call. This centralizes the grammar and makes resolution hot-path-fast, so every subcommand inherits both.

## What
- **`src/lib/agent-spec.ts`** — `resolveAgentTargets(spec, {cwd, availableAgents}) → AgentTarget[]`. Full canonical vocabulary: bare (project pin → global default), exact `@x.y.z`, `@latest`, `@oldest`, `@pinned ≡ @default` (synonyms), `@all`, comma-lists. Throws `AgentSpecError` — never `process.exit` (unlike `resolveVersionAlias`). Exports `AGENT_SPEC_HELP` (shared `--help` epilog) + `resolveSingleAgentTarget`. **Fast by construction:** exact / `@pinned` / bare resolve with **no directory enumeration** (one `existsSync` / meta-only); only `@latest`/`@oldest`/`@all` enumerate.
- **`src/lib/versions.ts`** — `listInstalledVersions` now cached per-process by the versions-dir mtime (auto-invalidates on install/remove; explicit `invalidateInstalledVersionsCache()` exported). Speeds up **every** enumerate-path consumer.
- **`bench/resolve-perf.ts`** — cold-vs-warm + fast-path-vs-enumerate timing harness.

## Status
- [x] Type-checks (`tsc` clean)
- [ ] **Bench run / numbers** — the standalone harness (`bun`/`tsx bench/resolve-perf.ts`) hangs on a lib-graph import side-effect when run outside the CLI bootstrap (pre-existing; the real CLI and vitest both import these modules fine). Needs to run via the test harness or a narrower import.
- [ ] **vitest test** — `agent-spec.test.ts`: full grammar in both domains, single-target rejection of `@all`, and a `vi.spyOn(fs,'readdirSync')` assertion that exact/`@pinned`/bare do **zero** readdirs.
- [ ] **Wire consumers** — route `sync` (+ `use`/`add`/`remove`/`run`) through `resolveAgentTargets`; make the old three functions thin wrappers so all ~30 call sites inherit the grammar + speed. (`add`/`install` pass the `available` domain.)
- [ ] Docs: grammar table in `docs/01-version-management.md` + `AGENT_SPEC_HELP` in each command epilog.

Part of the larger `agents sync` unification (one verb, interactive default, system-plugin fix). This is the resolver foundation that lands first.