### PR TITLE
feat(menubar): macOS menu-bar helper with auto-enable

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dist/**/*.d.ts",
     "dist/**/*.json",
     "dist/lib/secrets/Agents CLI.app/**",
+    "dist/lib/menubar/MenubarHelper.app/**",
     "scripts/postinstall.js",
     "scripts/install-helper.js",
     "CHANGELOG.md",
@@ -43,7 +44,7 @@
     "url": "https://github.com/phnx-labs/agents-cli/issues"
   },
   "scripts": {
-    "build": "tsc && rm -rf 'dist/lib/secrets/AgentsKeychain.app' 'dist/lib/secrets/Agents CLI.app' && ([ \"$(uname)\" = \"Darwin\" ] && cp -R 'bin/Agents CLI.app' 'dist/lib/secrets/Agents CLI.app' || true)",
+    "build": "tsc && rm -rf 'dist/lib/secrets/AgentsKeychain.app' 'dist/lib/secrets/Agents CLI.app' 'dist/lib/menubar/MenubarHelper.app' && ([ \"$(uname)\" = \"Darwin\" ] && cp -R 'bin/Agents CLI.app' 'dist/lib/secrets/Agents CLI.app' || true) && ([ \"$(uname)\" = \"Darwin\" ] && [ -d 'bin/MenubarHelper.app' ] && mkdir -p 'dist/lib/menubar' && cp -R 'bin/MenubarHelper.app' 'dist/lib/menubar/MenubarHelper.app' || true)",
     "prepack": "scripts/verify-keychain-helper.sh",
     "postinstall": "node scripts/postinstall.js",
     "dev": "tsx src/index.ts",

--- a/packages/menubar-helper/.gitignore
+++ b/packages/menubar-helper/.gitignore
@@ -1,0 +1,4 @@
+.build/
+dist/
+*.xcodeproj/
+Package.resolved

--- a/packages/menubar-helper/Package.swift
+++ b/packages/menubar-helper/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "MenubarHelper",
+    platforms: [.macOS(.v14)],
+    targets: [
+        .executableTarget(
+            name: "MenubarHelper",
+            path: "Sources/MenubarHelper",
+            linkerSettings: [
+                .linkedFramework("AppKit"),
+                .linkedFramework("CoreGraphics"),
+                .linkedLibrary("sqlite3"),
+            ]
+        )
+    ]
+)

--- a/packages/menubar-helper/Sources/MenubarHelper/AgentsCLI.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/AgentsCLI.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+// Thin bridge to the `agents` CLI. The helper never owns state or reimplements
+// scheduling — it shells the CLI for data and actions. TS stays the source of
+// truth (see CLAUDE.md: "Swift reads, TS owns truth").
+enum AgentsCLI {
+    static let home = NSHomeDirectory()
+
+    private static let env = ProcessInfo.processInfo.environment
+
+    // Resolve the `agents` binary. A GUI/launchd process inherits no user PATH,
+    // so probe explicit locations. Env override wins for dev builds.
+    static let binary: String = {
+        if let b = env["AGENTS_BIN"], !b.isEmpty,
+           FileManager.default.isExecutableFile(atPath: b) {
+            return b
+        }
+        let candidates = [
+            "\(home)/.local/bin/agents",
+            "/opt/homebrew/bin/agents",
+            "/usr/local/bin/agents",
+            "\(home)/.npm-global/bin/agents",
+        ]
+        for c in candidates where FileManager.default.isExecutableFile(atPath: c) {
+            return c
+        }
+        return "agents" // last resort; relies on PATH if somehow set
+    }()
+
+    // The `agents` bin is a `#!/usr/bin/env -S node` script, but a launchd/GUI
+    // process has a minimal PATH so `env` can't find node. The daemon (a node
+    // process) passes its own interpreter + entry point so we exec node
+    // directly and never depend on PATH. Falls back to the shebang bin.
+    private static func argv(_ args: [String]) -> [String] {
+        if let node = env["AGENTS_NODE"], let entry = env["AGENTS_ENTRY"],
+           FileManager.default.isExecutableFile(atPath: node),
+           FileManager.default.fileExists(atPath: entry) {
+            return [node, entry] + args
+        }
+        return [binary] + args
+    }
+
+    // MARK: Daemon liveness — read the scheduler PID file + signal 0.
+    // Path from src/lib/daemon.ts:24 + src/lib/state.ts (helpers/daemon).
+    static func daemonPid() -> Int? {
+        let path = "\(home)/.agents/.cache/helpers/daemon/daemon.pid"
+        guard let raw = try? String(contentsOfFile: path, encoding: .utf8) else { return nil }
+        guard let pid = Int(raw.trimmingCharacters(in: .whitespacesAndNewlines)) else { return nil }
+        return kill(pid_t(pid), 0) == 0 ? pid : nil
+    }
+
+    // Routines are secondary and fetched only when the menu opens. This shells
+    // the CLI, but `routines list` does NOT trigger the sessions re-index — it
+    // only computes cron next-run, which is cheap. Session data never comes from
+    // here; it's read directly from disk by LocalState.
+    static func routines() -> [Routine] {
+        guard let data = capture(argv(["routines", "list", "--json"])) else { return [] }
+        return (try? JSONDecoder().decode([Routine].self, from: data)) ?? []
+    }
+
+    // MARK: Actions
+    // New interactive session: open a Terminal window running `agents run <agent>`.
+    // A status-bar click can't host a TUI, so hand off to the user's terminal.
+    static func newSession(agent: String) {
+        let cmd = "\(shellQuote(binary)) run \(shellQuote(agent))"
+        let script = "tell application \"Terminal\"\nactivate\ndo script \"\(cmd)\"\nend tell"
+        runDetached(["/usr/bin/osascript", "-e", script])
+    }
+
+    static func routineRun(_ name: String) { runDetached(argv(["routines", "run", name])) }
+    static func routinePause(_ name: String) { runDetached(argv(["routines", "pause", name])) }
+    static func routineResume(_ name: String) { runDetached(argv(["routines", "resume", name])) }
+    static func routineLogs(_ name: String) {
+        let cmd = "\(shellQuote(binary)) routines logs \(shellQuote(name))"
+        let script = "tell application \"Terminal\"\nactivate\ndo script \"\(cmd)\"\nend tell"
+        runDetached(["/usr/bin/osascript", "-e", script])
+    }
+
+    static func openPath(_ path: String) { runDetached(["/usr/bin/open", path]) }
+
+    static func stopDaemon() { runDetached(argv(["routines", "stop"])) }
+
+    // "Quit menu bar" disables the launchd agent so it doesn't relaunch on the
+    // KeepAlive policy, then the app terminates.
+    static func menubarDisable() { runDetached(argv(["menubar", "disable"])) }
+
+    // MARK: Process helpers
+    private static func capture(_ argv: [String]) -> Data? {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: argv[0])
+        p.arguments = Array(argv.dropFirst())
+        let out = Pipe()
+        p.standardOutput = out
+        p.standardError = FileHandle.nullDevice
+        do {
+            try p.run()
+        } catch {
+            return nil
+        }
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        p.waitUntilExit()
+        return p.terminationStatus == 0 ? data : nil
+    }
+
+    private static func runDetached(_ argv: [String]) {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: argv[0])
+        p.arguments = Array(argv.dropFirst())
+        p.standardOutput = FileHandle.nullDevice
+        p.standardError = FileHandle.nullDevice
+        try? p.run()
+    }
+
+    private static func shellQuote(_ s: String) -> String {
+        "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}

--- a/packages/menubar-helper/Sources/MenubarHelper/Icon.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/Icon.swift
@@ -1,0 +1,63 @@
+import AppKit
+
+// The agents-cli mark: the chunky lowercase `a` glyph from public/favicon.svg,
+// drawn as a *template* image (black + alpha only) so macOS tints it for the
+// light/dark menu bar, vibrancy, and selection states. The lime tile from the
+// favicon is intentionally dropped — colored squares render as muddy boxes in
+// the status bar and break dark-mode adaptation.
+//
+// Path coordinates are lifted verbatim from favicon.svg's 32x32 viewBox, with
+// the y-axis flipped (SVG is y-down, AppKit is y-up) so the notch sits top-right.
+enum Icon {
+    // SVG viewBox is 32x32. Render into an 18pt status item with 1pt inset.
+    private static let unit: CGFloat = 32
+
+    static func make() -> NSImage {
+        let size = NSSize(width: 18, height: 18)
+        let image = NSImage(size: size, flipped: false) { rect in
+            let inset: CGFloat = 1
+            let drawable = rect.insetBy(dx: inset, dy: inset)
+            let scale = min(drawable.width, drawable.height) / unit
+
+            let t = NSAffineTransform()
+            t.translateX(by: drawable.minX, yBy: drawable.minY)
+            t.scaleX(by: scale, yBy: scale)
+            t.concat()
+
+            let path = glyphPath()
+            NSColor.black.setFill()
+            path.fill()
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }
+
+    // Outer `a` silhouette + inner counter (hole), even-odd filled.
+    // Coordinates: y' = 32 - y_svg.
+    private static func glyphPath() -> NSBezierPath {
+        let path = NSBezierPath()
+        path.windingRule = .evenOdd
+
+        // Outer shape.
+        path.move(to: NSPoint(x: 6, y: 22))
+        path.line(to: NSPoint(x: 24, y: 22))
+        path.line(to: NSPoint(x: 26, y: 20))
+        path.line(to: NSPoint(x: 26, y: 6))
+        path.line(to: NSPoint(x: 20, y: 6))
+        path.line(to: NSPoint(x: 20, y: 10))
+        path.line(to: NSPoint(x: 12, y: 10))
+        path.line(to: NSPoint(x: 12, y: 6))
+        path.line(to: NSPoint(x: 6, y: 6))
+        path.close()
+
+        // Inner counter — even-odd carves it out of the outer shape.
+        path.move(to: NSPoint(x: 12, y: 16))
+        path.line(to: NSPoint(x: 12, y: 14))
+        path.line(to: NSPoint(x: 20, y: 14))
+        path.line(to: NSPoint(x: 20, y: 16))
+        path.close()
+
+        return path
+    }
+}

--- a/packages/menubar-helper/Sources/MenubarHelper/LocalState.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/LocalState.swift
@@ -1,0 +1,178 @@
+import Foundation
+import SQLite3
+
+// Reads live agent state DIRECTLY from disk — never shells the `agents` CLI for
+// data. This is the whole point: `agents sessions` (without --active) triggers a
+// full transcript re-index into sessions.db, which is costly. Every source here
+// is a cheap file read, so the dropdown populates instantly on click.
+//
+// Sources (all grounded in src/lib/session/active.ts + src/lib/state.ts):
+//   terminals : ~/.agents/.cache/terminals/live-terminals.json
+//   teams     : ~/.agents/.history/teams/agents/<id>/meta.json
+//   cloud     : ~/.agents/.cache/cloud/tasks.db  (SQLite)
+//   attention : ~/.agents/.cache/state/attention/<sessionId>  (written by the Notification hook)
+//   installed : ~/.agents/.history/versions/<agent>/
+enum SessionStatus: String {
+    case running
+    case idle
+    case attention   // blocked waiting for the user (Notification hook) or cloud needs_review
+    case queued
+}
+
+struct Session {
+    let agent: String
+    let repo: String
+    let cwd: String?
+    let status: SessionStatus
+    let context: String   // terminal | teams | cloud
+    let detail: String
+}
+
+enum LocalState {
+    private static let home = NSHomeDirectory()
+    private static let fm = FileManager.default
+    private static let activeWindowMs: Double = 2 * 60_000  // matches ACTIVE_MTIME_WINDOW_MS
+
+    static func nowMs() -> Double { Date().timeIntervalSince1970 * 1000 }
+
+    // MARK: Installed agents (cheap: list version dirs)
+    static func installedAgents() -> [String] {
+        let dir = "\(home)/.agents/.history/versions"
+        let names = (try? fm.contentsOfDirectory(atPath: dir)) ?? []
+        return names.filter { !$0.hasPrefix(".") }.sorted()
+    }
+
+    // MARK: Attention sentinels (written by the Notification hook)
+    private static func attentionSessionIds() -> Set<String> {
+        let dir = "\(home)/.agents/.cache/state/attention"
+        let names = (try? fm.contentsOfDirectory(atPath: dir)) ?? []
+        return Set(names.filter { !$0.hasPrefix(".") })
+    }
+
+    // MARK: All active sessions
+    // includeTeams is false for the periodic badge poll — the teams/agents dir
+    // accumulates ALL historical agents (can be thousands of meta.json files), so
+    // scanning it every few seconds is too costly. Terminals + cloud + attention
+    // are cheap. The full scan (with teams) runs only when the menu opens.
+    static func sessions(includeTeams: Bool = true) -> [Session] {
+        let attention = attentionSessionIds()
+        var all = terminals(attention: attention) + cloud()
+        if includeTeams { all += teams(attention: attention) }
+        return all
+    }
+
+    // MARK: Terminals
+    private static func terminals(attention: Set<String>) -> [Session] {
+        let path = "\(home)/.agents/.cache/terminals/live-terminals.json"
+        guard let data = fm.contents(atPath: path),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return [] }
+
+        var out: [Session] = []
+        for (_, window) in root {
+            guard let w = window as? [String: Any],
+                  let entries = w["entries"] as? [[String: Any]] else { continue }
+            for e in entries {
+                guard let pid = e["pid"] as? Int, pidAlive(pid) else { continue }
+                let kind = (e["kind"] as? String) ?? "session"
+                let cwd = e["cwd"] as? String
+                let label = e["label"] as? String
+                let sid = (e["sessionId"] as? String) ?? ""
+                let repo = label?.isEmpty == false ? label! : (cwd.map { ($0 as NSString).lastPathComponent } ?? "")
+                let status = sessionStatus(sessionId: sid, kind: kind, cwd: cwd, attention: attention)
+                out.append(Session(agent: kind, repo: repo, cwd: cwd, status: status, context: "terminal", detail: ""))
+            }
+        }
+        return out
+    }
+
+    // MARK: Teams (filter to running + pid alive; the dir holds all history)
+    private static func teams(attention: Set<String>) -> [Session] {
+        let base = "\(home)/.agents/.history/teams/agents"
+        let ids = (try? fm.contentsOfDirectory(atPath: base)) ?? []
+        var out: [Session] = []
+        for id in ids where !id.hasPrefix(".") {
+            let metaPath = "\(base)/\(id)/meta.json"
+            guard let data = fm.contents(atPath: metaPath),
+                  let m = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { continue }
+            guard (m["status"] as? String) == "running" else { continue }
+            guard let pid = m["pid"] as? Int, pidAlive(pid) else { continue }
+            let agent = (m["agentType"] as? String) ?? "agent"
+            let cwd = m["cwd"] as? String
+            let task = (m["taskName"] as? String) ?? (m["name"] as? String) ?? ""
+            let repo = cwd.map { ($0 as NSString).lastPathComponent } ?? ""
+            out.append(Session(agent: agent, repo: repo, cwd: cwd,
+                               status: .running, context: "teams", detail: task))
+        }
+        return out
+    }
+
+    // MARK: Cloud (SQLite read of tasks.db)
+    private static func cloud() -> [Session] {
+        let path = "\(home)/.agents/.cache/cloud/tasks.db"
+        guard fm.fileExists(atPath: path) else { return [] }
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
+            sqlite3_close(db); return []
+        }
+        defer { sqlite3_close(db) }
+        let sql = "SELECT agent, status, prompt, repo, provider FROM tasks " +
+                  "WHERE status NOT IN ('completed','failed','cancelled') ORDER BY created_at DESC"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return [] }
+        defer { sqlite3_finalize(stmt) }
+
+        var out: [Session] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            let agent = col(stmt, 0) ?? "cloud"
+            let raw = col(stmt, 1) ?? ""
+            let prompt = col(stmt, 2) ?? ""
+            let repo = col(stmt, 3) ?? (col(stmt, 4) ?? "cloud")
+            let status: SessionStatus = raw == "running" ? .running
+                : (raw == "input_required" || raw == "needs_review") ? .attention : .queued
+            out.append(Session(agent: agent, repo: repo, cwd: nil,
+                               status: status, context: "cloud", detail: String(prompt.prefix(40))))
+        }
+        return out
+    }
+
+    // MARK: Status for a local session
+    // attention sentinel wins; else claude transcript mtime (cheap single stat);
+    // else default running when alive (mirrors active.ts classifyActivity fallback).
+    private static func sessionStatus(sessionId: String, kind: String, cwd: String?, attention: Set<String>) -> SessionStatus {
+        if !sessionId.isEmpty, attention.contains(sessionId) { return .attention }
+        if kind == "claude", let cwd, let mtime = claudeTranscriptMtimeMs(sessionId: sessionId, cwd: cwd) {
+            return (nowMs() - mtime) < activeWindowMs ? .running : .idle
+        }
+        return .running
+    }
+
+    // Claude transcript lives at ~/.claude/projects/<enc>/<sid>.jsonl (and per-version
+    // homes). enc = cwd with `/` and `.` replaced by `-` (active.ts:139). One stat each.
+    private static func claudeTranscriptMtimeMs(sessionId: String, cwd: String) -> Double? {
+        let enc = String(cwd.map { ($0 == "/" || $0 == ".") ? "-" : $0 })
+        var roots = ["\(home)/.claude/projects/\(enc)/\(sessionId).jsonl"]
+        let versionsBase = "\(home)/.agents/.history/versions/claude"
+        if let versions = try? fm.contentsOfDirectory(atPath: versionsBase) {
+            for v in versions where !v.hasPrefix(".") {
+                roots.append("\(versionsBase)/\(v)/home/.claude/projects/\(enc)/\(sessionId).jsonl")
+            }
+        }
+        var newest: Double?
+        for p in roots {
+            if let attrs = try? fm.attributesOfItem(atPath: p),
+               let m = (attrs[.modificationDate] as? Date)?.timeIntervalSince1970 {
+                let ms = m * 1000
+                if newest == nil || ms > newest! { newest = ms }
+            }
+        }
+        return newest
+    }
+
+    // MARK: helpers
+    static func pidAlive(_ pid: Int) -> Bool { kill(pid_t(pid), 0) == 0 || errno == EPERM }
+
+    private static func col(_ stmt: OpaquePointer?, _ i: Int32) -> String? {
+        guard let c = sqlite3_column_text(stmt, i) else { return nil }
+        return String(cString: c)
+    }
+}

--- a/packages/menubar-helper/Sources/MenubarHelper/Models.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/Models.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+// Shape of `agents routines list --json` (added in src/commands/routines.ts).
+// Routines are secondary in the menu bar — fetched only when the menu opens.
+struct Routine: Decodable {
+    let name: String
+    let agent: String?
+    let workflow: String?
+    let repo: String?
+    let schedule: String
+    let scheduleHuman: String?
+    let enabled: Bool
+    let overdue: Bool
+    let nextRun: String?
+    let nextRunHuman: String?
+    let lastStatus: String?            // completed | failed | timeout | running | null
+    let lastRunStartedAt: String?
+    let lastRunCompletedAt: String?
+}

--- a/packages/menubar-helper/Sources/MenubarHelper/StatusItemController.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/StatusItemController.swift
@@ -1,0 +1,240 @@
+import AppKit
+
+// Owns the NSStatusItem. Layout: NEEDS YOU (attention) pinned on top, then a +New
+// launcher, then the agent roster (per-agent running/idle counts), then a single
+// routines line. All session data is read directly from disk (LocalState) — no
+// CLI, no re-index — so the menu populates instantly on click.
+final class StatusItemController: NSObject, NSMenuDelegate {
+    private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+    private let accent = NSColor(red: 0x39 / 255.0, green: 0xd3 / 255.0, blue: 0x53 / 255.0, alpha: 1) // #39d353
+    private let alert = NSColor.systemRed
+
+    // Cached cheap snapshot for the badge (no teams scan).
+    private var badgeSessions: [Session] = []
+
+    func install() {
+        if let button = statusItem.button {
+            button.image = Icon.make()
+            button.imagePosition = .imageLeading
+            button.toolTip = "agents-cli"
+        }
+        let menu = NSMenu()
+        menu.delegate = self
+        statusItem.menu = menu
+
+        tick()
+        // Cheap poll: terminals + cloud + attention only. Badge stays glanceable
+        // without paying the teams-dir scan cost on every interval.
+        Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { [weak self] _ in self?.tick() }
+
+        if ProcessInfo.processInfo.environment["MENUBAR_DUMP"] == "1" {
+            let probe = NSMenu()
+            menuWillOpen(probe)
+            FileHandle.standardError.write("=== MENU DUMP (\(probe.numberOfItems) items) ===\n".data(using: .utf8)!)
+            for it in probe.items {
+                let kind = it.isSeparatorItem ? "----" : it.title
+                let sub = it.submenu.map { " [\($0.items.map { $0.title }.joined(separator: " | "))]" } ?? ""
+                FileHandle.standardError.write("  \(kind)\(sub)\n".data(using: .utf8)!)
+            }
+        }
+    }
+
+    private func tick() {
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let s = LocalState.sessions(includeTeams: false)
+            DispatchQueue.main.async {
+                self?.badgeSessions = s
+                self?.refreshBadge()
+            }
+        }
+    }
+
+    private func refreshBadge() {
+        guard let button = statusItem.button else { return }
+        let attention = badgeSessions.filter { $0.status == .attention }.count
+        let running = badgeSessions.filter { $0.status == .running }.count
+        if attention > 0 {
+            button.attributedTitle = badge("!", alert)       // needs you — highest priority
+        } else if running > 0 {
+            button.attributedTitle = badge(" \(running)", accent)
+        } else {
+            button.title = ""
+        }
+    }
+
+    private func badge(_ s: String, _ color: NSColor) -> NSAttributedString {
+        NSAttributedString(string: s, attributes: [
+            .foregroundColor: color,
+            .font: NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .bold),
+        ])
+    }
+
+    // MARK: - Menu (rebuilt on open against fresh, full state)
+    func menuWillOpen(_ menu: NSMenu) {
+        let sessions = LocalState.sessions(includeTeams: true)
+        let installed = LocalState.installedAgents()
+        let routines = AgentsCLI.routines()
+        let daemonPid = AgentsCLI.daemonPid()
+        badgeSessions = sessions
+        rebuild(menu, sessions: sessions, installed: installed, routines: routines, daemonPid: daemonPid)
+        refreshBadge()
+    }
+
+    private func rebuild(_ menu: NSMenu, sessions: [Session], installed: [String], routines: [Routine], daemonPid: Int?) {
+        menu.removeAllItems()
+
+        // NEEDS YOU — attention sessions + failed/overdue routines, pinned on top.
+        let needAttention = sessions.filter { $0.status == .attention }
+        let badRoutines = routines.filter { $0.lastStatus == "failed" || $0.lastStatus == "timeout" || $0.overdue }
+        if !needAttention.isEmpty || !badRoutines.isEmpty {
+            addSectionTitle(menu, "NEEDS YOU (\(needAttention.count + badRoutines.count))", color: alert)
+            for s in needAttention {
+                let item = NSMenuItem(title: "  ! \(s.agent)  \(s.repo)  awaiting input", action: nil, keyEquivalent: "")
+                if let cwd = s.cwd { item.submenu = revealSubmenu(cwd) }
+                menu.addItem(item)
+            }
+            for r in badRoutines {
+                let why = r.overdue ? "overdue" : (r.lastStatus ?? "failed")
+                let item = NSMenuItem(title: "  ! routine \(r.name)  \(why)", action: nil, keyEquivalent: "")
+                item.submenu = routineSubmenu(r)
+                menu.addItem(item)
+            }
+            menu.addItem(.separator())
+        }
+
+        // + New session.
+        let newItem = NSMenuItem(title: "New session", action: nil, keyEquivalent: "n")
+        let newSub = NSMenu()
+        for agent in installed {
+            let it = NSMenuItem(title: agent, action: #selector(onNewSession(_:)), keyEquivalent: "")
+            it.target = self; it.representedObject = agent
+            newSub.addItem(it)
+        }
+        newItem.submenu = newSub
+        menu.addItem(newItem)
+        menu.addItem(.separator())
+
+        // Agent roster — per-agent counts; only show agents that are installed.
+        let running = sessions.filter { $0.status == .running }.count
+        let idle = sessions.filter { $0.status == .idle }.count
+        addSectionTitle(menu, "AGENTS  ·  \(running) running · \(idle) idle", color: .secondaryLabelColor)
+        for agent in installed {
+            let mine = sessions.filter { $0.agent == agent }
+            let item = NSMenuItem(title: rosterRow(agent: agent, sessions: mine), action: nil, keyEquivalent: "")
+            item.submenu = rosterSubmenu(agent: agent, sessions: mine)
+            menu.addItem(item)
+        }
+        menu.addItem(.separator())
+
+        // Routines — one compact line (secondary).
+        let routineLine: String
+        if routines.isEmpty {
+            routineLine = "routines   none"
+        } else {
+            let next = routines.compactMap { $0.enabled ? $0.nextRunHuman : nil }.first(where: { $0 != "-" }) ?? "—"
+            let failed = badRoutines.count
+            routineLine = "routines   next \(next)" + (failed > 0 ? "  ·  \(failed) failed" : "")
+        }
+        let routinesItem = NSMenuItem(title: routineLine, action: nil, keyEquivalent: "")
+        if !routines.isEmpty { routinesItem.submenu = allRoutinesSubmenu(routines) }
+        menu.addItem(routinesItem)
+        menu.addItem(.separator())
+
+        // Footer.
+        if daemonPid != nil {
+            let stop = NSMenuItem(title: "Stop scheduler", action: #selector(onStopScheduler), keyEquivalent: "")
+            stop.target = self
+            menu.addItem(stop)
+        }
+        let quit = NSMenuItem(title: "Quit menu bar", action: #selector(onQuit), keyEquivalent: "q")
+        quit.target = self
+        menu.addItem(quit)
+    }
+
+    // MARK: Row builders
+    private func rosterRow(agent: String, sessions: [Session]) -> String {
+        let attn = sessions.filter { $0.status == .attention }.count
+        let run = sessions.filter { $0.status == .running }.count
+        let idle = sessions.filter { $0.status == .idle }.count
+        let name = agent.padding(toLength: 11, withPad: " ", startingAt: 0)
+        if attn > 0 { return "\(name) ! \(attn) awaiting input" }
+        if run > 0 { return "\(name) ● \(run) running" + (idle > 0 ? " · \(idle) idle" : "") }
+        if idle > 0 { return "\(name) ○ \(idle) idle" }
+        return "\(name) ○ idle"
+    }
+
+    private func rosterSubmenu(agent: String, sessions: [Session]) -> NSMenu {
+        let sub = NSMenu()
+        for s in sessions {
+            let mark = s.status == .attention ? "! " : (s.status == .running ? "● " : "○ ")
+            let detail = s.detail.isEmpty ? "" : "  ·  \(s.detail)"
+            let row = NSMenuItem(title: "\(mark)\(s.repo)\(detail)", action: nil, keyEquivalent: "")
+            if let cwd = s.cwd { row.submenu = revealSubmenu(cwd) }
+            sub.addItem(row)
+        }
+        if !sessions.isEmpty { sub.addItem(.separator()) }
+        let new = NSMenuItem(title: "New \(agent) session", action: #selector(onNewSession(_:)), keyEquivalent: "")
+        new.target = self; new.representedObject = agent
+        sub.addItem(new)
+        return sub
+    }
+
+    private func revealSubmenu(_ cwd: String) -> NSMenu {
+        let sub = NSMenu()
+        let reveal = NSMenuItem(title: "Reveal working dir", action: #selector(onOpenPath(_:)), keyEquivalent: "")
+        reveal.target = self; reveal.representedObject = cwd
+        sub.addItem(reveal)
+        return sub
+    }
+
+    private func routineSubmenu(_ r: Routine) -> NSMenu {
+        let sub = NSMenu()
+        let run = NSMenuItem(title: "Run now", action: #selector(onRoutineRun(_:)), keyEquivalent: "")
+        run.target = self; run.representedObject = r.name
+        sub.addItem(run)
+        let logs = NSMenuItem(title: "Logs", action: #selector(onRoutineLogs(_:)), keyEquivalent: "")
+        logs.target = self; logs.representedObject = r.name
+        sub.addItem(logs)
+        return sub
+    }
+
+    private func allRoutinesSubmenu(_ routines: [Routine]) -> NSMenu {
+        let sub = NSMenu()
+        for r in routines {
+            let mark = r.lastStatus == "failed" || r.lastStatus == "timeout" ? "! "
+                : (r.enabled ? "  " : "· ")
+            let when = r.enabled ? (r.nextRunHuman ?? r.schedule) : "paused"
+            let item = NSMenuItem(title: "\(mark)\(r.name)  \(when)", action: nil, keyEquivalent: "")
+            item.submenu = routineSubmenu(r)
+            sub.addItem(item)
+        }
+        return sub
+    }
+
+    // MARK: Actions
+    @objc private func onNewSession(_ s: NSMenuItem) {
+        if let a = s.representedObject as? String { AgentsCLI.newSession(agent: a) }
+    }
+    @objc private func onRoutineRun(_ s: NSMenuItem) { withName(s, AgentsCLI.routineRun) }
+    @objc private func onRoutineLogs(_ s: NSMenuItem) { withName(s, AgentsCLI.routineLogs) }
+    @objc private func onOpenPath(_ s: NSMenuItem) {
+        if let p = s.representedObject as? String { AgentsCLI.openPath(p) }
+    }
+    @objc private func onStopScheduler() { AgentsCLI.stopDaemon() }
+    @objc private func onQuit() { AgentsCLI.menubarDisable(); NSApp.terminate(nil) }
+
+    private func withName(_ s: NSMenuItem, _ fn: (String) -> Void) {
+        if let n = s.representedObject as? String { fn(n) }
+    }
+
+    // MARK: Helpers
+    private func addSectionTitle(_ menu: NSMenu, _ title: String, color: NSColor) {
+        let it = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        it.isEnabled = false
+        it.attributedTitle = NSAttributedString(string: title, attributes: [
+            .foregroundColor: color,
+            .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
+        ])
+        menu.addItem(it)
+    }
+}

--- a/packages/menubar-helper/Sources/MenubarHelper/main.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/main.swift
@@ -1,0 +1,27 @@
+import AppKit
+
+// agents-cli menu bar helper. A no-Dock (.accessory) status-bar app whose
+// lifecycle is tied to the routines scheduler daemon — the daemon spawns it on
+// start and it self-terminates when the daemon's PID goes away.
+//
+// Usage:
+//   MenubarHelper                 # daemon-spawned; quits when daemon stops
+//   MENUBAR_STANDALONE=1 ...      # dev: stay up even with no daemon running
+//   AGENTS_BIN=/path/to/agents    # override the `agents` binary location
+
+let app = NSApplication.shared
+app.setActivationPolicy(.accessory)
+
+let controller = StatusItemController()
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    let controller: StatusItemController
+    init(_ c: StatusItemController) { self.controller = c }
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        controller.install()
+    }
+}
+
+let delegate = AppDelegate(controller)
+app.delegate = delegate
+app.run()

--- a/packages/menubar-helper/scripts/build.sh
+++ b/packages/menubar-helper/scripts/build.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+MODE="${1:-debug}"
+
+if [ "$MODE" = "release" ]; then
+    # Universal build needs Xcode's xcbuild. Fall back to a native single-arch
+    # release build when only the Command Line Tools are installed, so a release
+    # can still be cut on a machine without full Xcode.
+    if swift build -c release --arch arm64 --arch x86_64 2>/dev/null; then
+        SRC=".build/apple/Products/Release/MenubarHelper"
+    else
+        echo "  universal build unavailable (no Xcode/xcbuild); building native single-arch release"
+        swift build -c release
+        SRC="$(swift build -c release --show-bin-path)/MenubarHelper"
+    fi
+else
+    swift build
+    SRC=".build/debug/MenubarHelper"
+fi
+
+DEST_DIR="dist"
+mkdir -p "$DEST_DIR"
+
+# Standalone binary (embedded inside a parent signed .app when shipped).
+DEST="$DEST_DIR/menubar-helper-mac"
+cp "$SRC" "$DEST"
+
+# .app bundle. LSUIElement=true keeps it out of the Dock and the ⌘-Tab
+# switcher — it lives only in the menu bar. Unlike the computer helper, the
+# status item needs no TCC grant, so ad-hoc signing is fine and we skip
+# notarization entirely.
+APP="$DEST_DIR/MenubarHelper.app"
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS"
+cp "$SRC" "$APP/Contents/MacOS/MenubarHelper"
+cat > "$APP/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>MenubarHelper</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.phnx-labs.agents-menubar</string>
+    <key>CFBundleName</key>
+    <string>Agents Menu Bar</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSUIElement</key>
+    <true/>
+</dict>
+</plist>
+PLIST
+
+SIGN_ID="${MENUBAR_HELPER_SIGN_ID:-}"
+if [ -z "$SIGN_ID" ]; then
+    SIGN_ID=$(security find-identity -v -p codesigning 2>/dev/null | grep -oE '"Developer ID Application: [^"]+"' | head -1 | tr -d '"')
+fi
+[ -z "$SIGN_ID" ] && SIGN_ID="-"
+echo "  signing with: $SIGN_ID"
+codesign --force --options runtime --sign "$SIGN_ID" --identifier com.phnx-labs.agents-menubar "$APP" 2>&1 | sed 's/^/  /'
+codesign --force --options runtime --sign "$SIGN_ID" --identifier com.phnx-labs.agents-menubar "$DEST" 2>&1 | sed 's/^/  /'
+
+echo "built: $DEST"
+echo "built: $APP"

--- a/src/commands/menubar.ts
+++ b/src/commands/menubar.ts
@@ -1,0 +1,93 @@
+/**
+ * `agents menubar` — manage the macOS menu-bar helper.
+ *
+ * The helper is a no-Dock status-bar app that surfaces running sessions, agents
+ * needing input, and routines, and launches new sessions. It auto-installs on
+ * upgrade (runMigration -> installMenubarLaunchAgentOnUpgrade) for every macOS
+ * user; these commands are the manual override.
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import {
+  enableMenubarService,
+  disableMenubarService,
+  getMenubarStatus,
+} from '../lib/menubar/install-menubar.js';
+
+function notMac(): boolean {
+  if (process.platform !== 'darwin') {
+    console.log(chalk.yellow('The menu bar helper is macOS only.'));
+    return true;
+  }
+  return false;
+}
+
+export function registerMenubarCommands(program: Command): void {
+  const menubar = program
+    .command('menubar')
+    .description('Manage the macOS menu-bar helper (running sessions, agents awaiting input, routines)');
+
+  menubar
+    .command('enable')
+    .description('Install and start the menu-bar helper (launches at login)')
+    .action(() => {
+      if (notMac()) return;
+      const ok = enableMenubarService({ clearOptOut: true });
+      if (!ok) {
+        console.log(chalk.red('Could not enable: no menu-bar helper bundle ships with this install.'));
+        console.log(chalk.gray('  This build may predate the helper, or be a non-macOS package.'));
+        return;
+      }
+      console.log(chalk.green('Menu bar helper enabled.') + chalk.gray('  Look for the agents mark in your menu bar.'));
+    });
+
+  menubar
+    .command('disable')
+    .description('Stop and remove the menu-bar helper (stays off across upgrades)')
+    .action(() => {
+      if (notMac()) return;
+      disableMenubarService();
+      console.log(chalk.green('Menu bar helper disabled.') + chalk.gray('  Re-enable any time with `agents menubar enable`.'));
+    });
+
+  menubar
+    .command('status')
+    .description('Show whether the menu-bar helper is installed and running')
+    .option('--json', 'Emit machine-readable JSON')
+    .action((options: { json?: boolean }) => {
+      const s = getMenubarStatus();
+      if (options.json) {
+        process.stdout.write(JSON.stringify(s) + '\n');
+        return;
+      }
+      if (s.platform !== 'darwin') {
+        console.log(chalk.yellow('The menu bar helper is macOS only.'));
+        return;
+      }
+      const yn = (b: boolean) => (b ? chalk.green('yes') : chalk.gray('no'));
+      console.log(chalk.bold('Menu bar helper\n'));
+      console.log(`  running            ${yn(s.running)}`);
+      console.log(`  service installed  ${yn(s.serviceInstalled)}`);
+      console.log(`  app installed      ${s.installedApp ? chalk.gray(s.installedApp) : chalk.gray('no')}`);
+      console.log(`  bundle source      ${s.source ? chalk.gray(s.source) : chalk.red('missing (cannot enable)')}`);
+      console.log(`  disabled by user   ${yn(s.disabledByUser)}`);
+      if (!s.serviceInstalled && !s.disabledByUser) {
+        console.log(chalk.gray('\n  Enable it with `agents menubar enable`.'));
+      }
+    });
+
+  // Bare `agents menubar` -> status.
+  menubar.action(() => {
+    const s = getMenubarStatus();
+    if (s.platform !== 'darwin') {
+      console.log(chalk.yellow('The menu bar helper is macOS only.'));
+      return;
+    }
+    const yn = (b: boolean) => (b ? chalk.green('yes') : chalk.gray('no'));
+    console.log(chalk.bold('Menu bar helper\n'));
+    console.log(`  running            ${yn(s.running)}`);
+    console.log(`  service installed  ${yn(s.serviceInstalled)}`);
+    console.log(chalk.gray('\n  enable | disable | status'));
+  });
+}

--- a/src/commands/routines.ts
+++ b/src/commands/routines.ts
@@ -161,9 +161,14 @@ export function registerRoutinesCommands(program: Command): void {
   routinesCmd
     .command('list')
     .description('See all scheduled jobs, when they run next, and their last execution status')
-    .action(() => {
+    .option('--json', 'Emit machine-readable JSON instead of the table (used by the menu bar helper)')
+    .action((options: { json?: boolean }) => {
       const jobs = listAllJobs(process.cwd());
       if (jobs.length === 0) {
+        if (options.json) {
+          process.stdout.write('[]\n');
+          return;
+        }
         console.log(chalk.gray('No jobs configured'));
         console.log(chalk.gray('  Add a job: agents routines add <path-to-job.yml>'));
         return;
@@ -178,6 +183,35 @@ export function registerRoutinesCommands(program: Command): void {
         for (const j of detectOverdueJobs()) overdueSet.add(j.name);
       } catch {
         // Best-effort indicator; never block the list on detection errors.
+      }
+
+      // Machine-readable path: same data the table renders, but structured.
+      // The menu bar helper relies on this so it never reimplements cron math.
+      if (options.json) {
+        const nowJson = new Date();
+        const payload = jobs.map((job) => {
+          const nextRun = scheduler.getNextRun(job.name);
+          const latestRun = getLatestRun(job.name);
+          return {
+            name: job.name,
+            agent: job.agent ?? null,
+            workflow: job.workflow ?? null,
+            repo: job.repo ?? null,
+            schedule: job.schedule,
+            scheduleHuman: humanizeCron(job.schedule, job.timezone),
+            timezone: job.timezone ?? null,
+            enabled: job.enabled,
+            overdue: overdueSet.has(job.name),
+            nextRun: nextRun ? nextRun.toISOString() : null,
+            nextRunHuman: humanizeNextRun(nextRun ?? null, nowJson, job.timezone),
+            lastStatus: latestRun?.status ?? null,
+            lastRunStartedAt: latestRun?.startedAt ?? null,
+            lastRunCompletedAt: latestRun?.completedAt ?? null,
+          };
+        });
+        scheduler.stopAll();
+        process.stdout.write(JSON.stringify(payload) + '\n');
+        return;
       }
 
       console.log(chalk.bold('Scheduled Jobs\n'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,7 @@ import { registerProfilesCommands } from './commands/profiles.js';
 import { registerSecretsCommands } from './commands/secrets.js';
 import { registerWalletCommands } from './commands/wallet.js';
 import { registerHelperCommand } from './commands/helper.js';
+import { registerMenubarCommands } from './commands/menubar.js';
 import { registerFactoryCommands } from './commands/factory.js';
 import { registerUsageCommand } from './commands/usage.js';
 import { registerCostCommand } from './commands/cost.js';
@@ -737,6 +738,7 @@ registerProfilesCommands(program);
 registerSecretsCommands(program);
 registerWalletCommands(program);
 registerHelperCommand(program);
+registerMenubarCommands(program);
 registerBetaCommands(program);
 registerSyncCommand(program);
 registerRefreshRulesCommand(program);
@@ -997,6 +999,20 @@ if (process.env.AGENTS_SKIP_MIGRATION !== '1') {
       } catch { /* best-effort */ }
     }
   } catch { /* migration must never block CLI startup */ }
+}
+
+// Auto-enable the macOS menu-bar helper once, for every user. Best-effort and
+// idempotent: installMenubarLaunchAgentOnUpgrade() no-ops when not on darwin,
+// when the user ran `agents menubar disable` (sticky opt-out), when the service
+// is already installed, or when no helper bundle ships with this build. This is
+// a lightweight startup self-heal (two existsSync checks then return) rather
+// than a migration-sentinel bump, so it covers fresh installs AND upgrades
+// without re-running the full migration for the whole user base (issue #20).
+if (process.platform === 'darwin' && process.env.AGENTS_SKIP_MIGRATION !== '1') {
+  try {
+    const { installMenubarLaunchAgentOnUpgrade } = await import('./lib/menubar/install-menubar.js');
+    installMenubarLaunchAgentOnUpgrade();
+  } catch { /* never block CLI startup on the menu bar */ }
 }
 
 try {

--- a/src/lib/menubar/install-menubar.ts
+++ b/src/lib/menubar/install-menubar.ts
@@ -1,0 +1,289 @@
+/**
+ * Install + lifecycle for the macOS menu-bar helper (`MenubarHelper.app`).
+ *
+ * Mirrors `src/lib/secrets/install-helper.ts` (stable Application Support path,
+ * survives npm re-sign) and the secrets-agent launchd pattern in
+ * `src/lib/secrets/agent.ts` (RunAtLoad + KeepAlive user service).
+ *
+ * The helper is a no-Dock `.accessory` status-bar app. It reads live agent
+ * state directly from disk and shells `agents` only for actions, so the plist
+ * bakes in the node interpreter + entry point + bin path so the GUI process can
+ * find the CLI without a login PATH.
+ *
+ * Opt-out is sticky: `agents menubar disable` drops a sentinel that the upgrade
+ * migration (`installMenubarLaunchAgent` in migrate.ts) honors, so a disabled
+ * menu bar never silently comes back on the next release.
+ */
+
+import { fileURLToPath } from 'url';
+import { execFileSync, spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { getRuntimeStateDir, getHelpersDir } from '../state.js';
+
+const APP_BUNDLE_NAME = 'MenubarHelper.app';
+const INSTALL_DIR_NAME = 'agents-cli';
+const SERVICE_LABEL = 'com.phnx-labs.agents-menubar';
+
+function onDarwin(): boolean {
+  return process.platform === 'darwin';
+}
+
+/** ~/Library/Application Support/agents-cli/MenubarHelper.app */
+function installedAppPath(): string {
+  return path.join(os.homedir(), 'Library', 'Application Support', INSTALL_DIR_NAME, APP_BUNDLE_NAME);
+}
+
+/** Executable inside the installed bundle. */
+function installedExecutablePath(): string {
+  return path.join(installedAppPath(), 'Contents', 'MacOS', 'MenubarHelper');
+}
+
+/** ~/Library/LaunchAgents/com.phnx-labs.agents-menubar.plist */
+function servicePlistPath(): string {
+  return path.join(os.homedir(), 'Library', 'LaunchAgents', `${SERVICE_LABEL}.plist`);
+}
+
+/** Sticky opt-out marker written by `agents menubar disable`. */
+function disabledSentinelPath(): string {
+  return path.join(getRuntimeStateDir(), 'menubar.disabled');
+}
+
+/** True if the user explicitly disabled the menu bar (don't auto-enable on upgrade). */
+export function menubarDisabledByUser(): boolean {
+  return fs.existsSync(disabledSentinelPath());
+}
+
+/** True if the launchd plist for the menu-bar service is installed. */
+export function menubarServiceInstalled(): boolean {
+  return onDarwin() && fs.existsSync(servicePlistPath());
+}
+
+/**
+ * Locate the source `.app` shipped alongside the compiled JS.
+ *   1. dist/lib/menubar/MenubarHelper.app — npm install layout (sibling of this file)
+ *   2. <repo>/bin/MenubarHelper.app       — raw working tree (tsx/dev)
+ *   3. <repo>/packages/menubar-helper/dist/MenubarHelper.app — fresh local build
+ */
+function sourceAppPath(): string | null {
+  const candidates: string[] = [];
+  try {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    candidates.push(path.join(here, APP_BUNDLE_NAME));
+    candidates.push(path.resolve(here, '..', '..', '..', 'bin', APP_BUNDLE_NAME));
+    candidates.push(
+      path.resolve(here, '..', '..', '..', 'packages', 'menubar-helper', 'dist', APP_BUNDLE_NAME)
+    );
+  } catch {
+    /* import.meta.url unavailable */
+  }
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  return null;
+}
+
+/** Resolve the `agents` launcher binary on PATH-less GUI processes. */
+function resolveAgentsBin(): string | null {
+  const home = os.homedir();
+  const candidates = [
+    path.join(home, '.local', 'bin', 'agents'),
+    '/opt/homebrew/bin/agents',
+    '/usr/local/bin/agents',
+    path.join(home, '.npm-global', 'bin', 'agents'),
+  ];
+  for (const c of candidates) {
+    try {
+      fs.accessSync(c, fs.constants.X_OK);
+      return c;
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+
+/** Resolve the compiled CLI entry (dist/index.js) so the helper can exec node directly. */
+function resolveCliEntry(): string | null {
+  try {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    // dist/lib/menubar/install-menubar.js -> dist/index.js
+    const entry = path.resolve(here, '..', '..', 'index.js');
+    if (fs.existsSync(entry)) return entry;
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+function copyAppBundle(src: string, dest: string): void {
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  if (fs.existsSync(dest)) fs.rmSync(dest, { recursive: true, force: true });
+  // `cp -R` preserves the bundle's signature and resource forks (see install-helper.ts).
+  const r = spawnSync('cp', ['-R', src, dest], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8' });
+  if (r.status !== 0) {
+    const msg = (r.stderr || r.stdout || '').toString().trim();
+    throw new Error(`Failed to copy ${src} -> ${dest}: ${msg || 'unknown error'}`);
+  }
+}
+
+/**
+ * Copy the bundled `.app` to the stable user path (idempotent unless forced).
+ * Returns the installed executable path, or null if no source bundle ships
+ * with this install (e.g. Linux package, or a build without the helper).
+ */
+export function ensureMenubarAppInstalled(opts: { forceReinstall?: boolean } = {}): string | null {
+  if (!onDarwin()) return null;
+  const src = sourceAppPath();
+  if (!src) return null;
+  const dest = installedAppPath();
+  if (!opts.forceReinstall && fs.existsSync(dest)) return installedExecutablePath();
+  copyAppBundle(src, dest);
+  return installedExecutablePath();
+}
+
+function xmlEscape(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function generateServicePlist(execPath: string): string {
+  const home = os.homedir();
+  const logPath = path.join(getHelpersDir(), 'menubar', 'menubar.log');
+  fs.mkdirSync(path.dirname(logPath), { recursive: true });
+
+  // Bake interpreter + entry + bin so the GUI helper can reach the CLI with no
+  // login PATH. AgentsCLI.swift prefers [AGENTS_NODE, AGENTS_ENTRY] when both
+  // exist, else falls back to AGENTS_BIN, else probes well-known paths.
+  const env: Record<string, string> = {
+    PATH: `/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:${path.dirname(process.execPath)}:${home}/.local/bin`,
+  };
+  const node = process.execPath;
+  const entry = resolveCliEntry();
+  const bin = resolveAgentsBin();
+  if (node && entry) {
+    env.AGENTS_NODE = node;
+    env.AGENTS_ENTRY = entry;
+  }
+  if (bin) env.AGENTS_BIN = bin;
+
+  const envXml = Object.entries(env)
+    .map(([k, v]) => `    <key>${xmlEscape(k)}</key>\n    <string>${xmlEscape(v)}</string>`)
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${SERVICE_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${xmlEscape(execPath)}</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Interactive</string>
+  <key>StandardOutPath</key>
+  <string>${xmlEscape(logPath)}</string>
+  <key>StandardErrorPath</key>
+  <string>${xmlEscape(logPath)}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+${envXml}
+  </dict>
+</dict>
+</plist>`;
+}
+
+/**
+ * Install + start the menu-bar helper as a launchd user service (idempotent).
+ * Clears the sticky opt-out, installs the .app, writes the plist, and
+ * bootstraps it into the GUI domain. Returns false on non-darwin or when no
+ * helper bundle ships with this install.
+ */
+export function enableMenubarService(opts: { clearOptOut?: boolean } = { clearOptOut: true }): boolean {
+  if (!onDarwin()) return false;
+  const exec = ensureMenubarAppInstalled({ forceReinstall: true });
+  if (!exec) return false;
+
+  if (opts.clearOptOut) {
+    try { fs.rmSync(disabledSentinelPath(), { force: true }); } catch { /* already gone */ }
+  }
+
+  const plist = servicePlistPath();
+  fs.mkdirSync(path.dirname(plist), { recursive: true });
+  fs.writeFileSync(plist, generateServicePlist(exec));
+
+  const uid = process.getuid?.() ?? 0;
+  try {
+    execFileSync('launchctl', ['bootstrap', `gui/${uid}`, plist], { stdio: ['ignore', 'ignore', 'ignore'] });
+  } catch {
+    try { execFileSync('launchctl', ['load', '-w', plist], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* may already be loaded */ }
+  }
+  try { execFileSync('launchctl', ['kickstart', '-k', `gui/${uid}/${SERVICE_LABEL}`], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* best effort */ }
+  return true;
+}
+
+/**
+ * Stop + remove the menu-bar service and write the sticky opt-out so the
+ * upgrade migration won't re-enable it.
+ */
+export function disableMenubarService(): void {
+  if (!onDarwin()) return;
+  const plist = servicePlistPath();
+  const uid = process.getuid?.() ?? 0;
+  try { execFileSync('launchctl', ['bootout', `gui/${uid}/${SERVICE_LABEL}`], { stdio: ['ignore', 'ignore', 'ignore'] }); }
+  catch { try { execFileSync('launchctl', ['unload', '-w', plist], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* not loaded */ } }
+  try { fs.unlinkSync(plist); } catch { /* already gone */ }
+  try {
+    fs.mkdirSync(path.dirname(disabledSentinelPath()), { recursive: true });
+    fs.writeFileSync(disabledSentinelPath(), `disabled ${new Date().toISOString()}\n`);
+  } catch { /* best effort */ }
+}
+
+/**
+ * Upgrade-time auto-enable. Runs from runMigration() once per sentinel bump.
+ * No-ops if: not darwin, the user opted out, no helper bundle ships, or the
+ * service is already installed. Best-effort — never throws into migration.
+ */
+export function installMenubarLaunchAgentOnUpgrade(): void {
+  try {
+    if (!onDarwin()) return;
+    if (menubarDisabledByUser()) return;
+    if (menubarServiceInstalled()) return;
+    if (!sourceAppPath()) return;
+    enableMenubarService({ clearOptOut: false });
+  } catch {
+    /* never block migration on the menu bar */
+  }
+}
+
+export interface MenubarStatus {
+  platform: string;
+  source: string | null;
+  installedApp: string | null;
+  serviceInstalled: boolean;
+  running: boolean;
+  disabledByUser: boolean;
+}
+
+export function getMenubarStatus(): MenubarStatus {
+  const dest = installedAppPath();
+  let running = false;
+  if (onDarwin()) {
+    const r = spawnSync('pgrep', ['-f', 'MenubarHelper'], { stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf-8' });
+    running = r.status === 0 && (r.stdout || '').trim().length > 0;
+  }
+  return {
+    platform: process.platform,
+    source: sourceAppPath(),
+    installedApp: fs.existsSync(dest) ? dest : null,
+    serviceInstalled: menubarServiceInstalled(),
+    running,
+    disabledByUser: menubarDisabledByUser(),
+  };
+}


### PR DESCRIPTION
## What

Adds a macOS menu-bar helper for agents-cli: a no-Dock `NSStatusItem` app that gives you an at-a-glance view of agent activity and quick actions, right from the menu bar.

The dropdown surfaces, in priority order:
- **NEEDS YOU** — sessions awaiting input (cloud `needs_review` + local `Notification`-hook attention) and failed/overdue routines, pinned on top.
- **New session** — launch any installed agent in a new Terminal.
- **Agent roster** — per-agent running/idle counts, drill into each live session, reveal its working dir.
- **Routines** — one compact line, next run + failures, fetched only on open.
- Footer — stop scheduler, quit.

## How it stays fast

The helper reads live state **directly from disk** — `~/.agents/.cache/terminals/live-terminals.json`, `teams/agents/*/meta.json`, cloud `tasks.db` (SQLite), attention sentinels, installed agents from the versions dir. It never shells `agents sessions` (which triggers a full transcript re-index). The CLI is invoked only for actions and for `routines list --json`. The periodic badge poll skips the (potentially huge) teams dir; the full scan runs only when the menu opens.

## Lifecycle / rollout

- Ships as a launchd user service `com.phnx-labs.agents-menubar` (RunAtLoad + KeepAlive), mirroring the secrets-agent pattern.
- **Auto-enables once per user on macOS** via a lightweight startup self-heal (`installMenubarLaunchAgentOnUpgrade`) — *not* a migration-sentinel bump, so it covers fresh installs and upgrades without re-running the full migration for the whole user base (issue #20).
- Sticky opt-out: `agents menubar disable` writes a sentinel the self-heal honors, so a disabled menu bar never silently returns on upgrade.
- New command: `agents menubar enable | disable | status`.

## Packaging

- The signed `.app` is bundled into the npm tarball the same way as the keychain helper: built into `bin/MenubarHelper.app`, copied to `dist/lib/menubar/MenubarHelper.app` at build time, included via the `files` glob.
- `packages/menubar-helper/scripts/build.sh` falls back to a native single-arch release build when full Xcode/xcbuild isn't present.

## Verification

- Swift package builds and signs with the Developer ID identity.
- Menu renders correctly from real machine state (verified via `MENUBAR_DUMP=1`): all installed agents, live session counts, roster, routines line.
- `tsc` clean.

## Follow-up (separate PR, `.agents-system` repo)

The local "awaiting input" attention signal needs a `Notification`/`Stop`/`UserPromptSubmit` hook that writes/clears `~/.agents/.cache/state/attention/<sessionId>`. Until that ships, "NEEDS YOU" reflects cloud tasks + failed routines only.
