### PR TITLE
bench: TUI vs headless local-overhead benchmark

### DIFF
--- a/bench/offload-smoke.sh
+++ b/bench/offload-smoke.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Headless offload smoke test.
+#
+# Proves `agents run` dispatches a headless agent end-to-end and prints how long
+# it took. Run it ON the offload device (e.g. the GB10 / yosemite-s0), or from a
+# laptop over ssh:  ssh muqsit@yosemite-s0 'bash -s' < bench/offload-smoke.sh
+#
+# Headless leaves no TUI / Ink render loop and no terminal-emulator repaint on
+# the host — that is the whole point of pushing fan-out work off the laptop.
+set -euo pipefail
+
+AGENT="${AGENT:-claude}"
+MODEL="${MODEL:-haiku}"
+PROMPT="${PROMPT:-Reply with exactly: OK}"
+
+echo "# headless offload smoke | host=$(hostname) agent=${AGENT} model=${MODEL}"
+start=$(date +%s.%N)
+
+out="$(agents run "${AGENT}" "${PROMPT}" --model "${MODEL}" --mode plan --quiet 2>/dev/null | tail -1)"
+
+end=$(date +%s.%N)
+elapsed=$(awk "BEGIN{printf \"%.2f\", ${end}-${start}}")
+
+echo "reply : ${out}"
+echo "wall  : ${elapsed}s"
+[ -n "${out}" ] && echo "PASS — headless dispatch works on $(hostname)" || { echo "FAIL — empty reply"; exit 1; }

--- a/bench/tty-vs-headless.py
+++ b/bench/tty-vs-headless.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Local-overhead benchmark: interactive TUI vs headless Claude Code.
+
+Answers "is there a resource benefit to running agents headless?" by isolating
+the LOCAL cost of the agent harness (model round-trips are identical and
+network-bound, so they are not the signal). Per claude process, via os.wait4
+rusage, we capture:
+
+  - wall clock (s)
+  - user CPU (s) + system CPU (s)   -> local compute: Ink render loop, parsing
+  - peak RSS (MB)                    -> per-instance memory footprint
+
+Experiments:
+  A. headless active task   claude -p <task> --output-format json
+  B. TUI active task        claude (interactive) driven over a real pty
+  C. TUI idle pane          open a pane, sit at the prompt, do nothing
+  D. TUI marginal idle/sec  (long-hold CPU - startup CPU) / elapsed
+  E. parallel headless      N concurrent headless runs; wall + memory scaling
+
+CAVEAT: the pty "terminal" here is a Python reader, NOT a GPU terminal emulator.
+Real interactive use adds iTerm/VS Code/Terminal repaint cost on every streamed
+token, which this harness does NOT capture -> the TUI numbers below are a LOWER
+BOUND on real-world interactive overhead.
+
+Usage:
+  python3 bench/tty-vs-headless.py            # full run, 4 iters, haiku
+  ITERS=6 MODEL=haiku python3 bench/tty-vs-headless.py
+  PARALLEL=1,4,8,16 python3 bench/tty-vs-headless.py
+
+Each iteration makes one real model call (~$0.05 on haiku with the injected
+system prompt), so a default full run is roughly $0.5-1.0 of API spend.
+Results are also written to bench/tty-vs-headless.results.json.
+"""
+import os
+import pty
+import time
+import select
+import json
+import tempfile
+import statistics
+
+MODEL = os.environ.get("MODEL", "haiku")
+ITERS = int(os.environ.get("ITERS", "4"))
+PARALLEL = [int(x) for x in os.environ.get("PARALLEL", "1,4,8").split(",")]
+TASK = "Print the integers from 1 to 60, one per line, with no other commentary."
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _rusage(ru, wall, extra=None):
+    d = dict(
+        wall_s=round(wall, 3),
+        user_cpu_s=round(ru.ru_utime, 3),
+        sys_cpu_s=round(ru.ru_stime, 3),
+        cpu_s=round(ru.ru_utime + ru.ru_stime, 3),
+        max_rss_mb=round(ru.ru_maxrss / 1024.0, 1),  # Linux reports KB
+    )
+    if extra:
+        d.update(extra)
+    return d
+
+
+def run_headless():
+    tf = tempfile.NamedTemporaryFile(delete=False, suffix=".json")
+    tf.close()
+    t0 = time.time()
+    pid = os.fork()
+    if pid == 0:
+        os.dup2(os.open("/dev/null", os.O_RDONLY), 0)
+        fout = os.open(tf.name, os.O_WRONLY | os.O_TRUNC)
+        os.dup2(fout, 1)
+        os.dup2(fout, 2)
+        os.execvp("claude", ["claude", "-p", TASK, "--model", MODEL, "--output-format", "json"])
+        os._exit(127)
+    _, _, ru = os.wait4(pid, 0)
+    wall = time.time() - t0
+    api = dur = None
+    try:
+        with open(tf.name) as f:
+            j = json.load(f)
+        api, dur = j.get("duration_api_ms"), j.get("duration_ms")
+    except Exception:
+        pass
+    os.unlink(tf.name)
+    return _rusage(ru, wall, {"api_ms": api, "self_dur_ms": dur})
+
+
+def drive_pty(send_prompt, hold_s):
+    """Fork claude under a pty. If send_prompt: submit TASK after a warmup and
+    wait for the response to settle. Else: sit idle for hold_s."""
+    t0 = time.time()
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.execvp("claude", ["claude", "--model", MODEL])
+        os._exit(127)
+    WARMUP, IDLE_GAP, HARD_CAP = 3.0, 4.0, 45.0
+    sent = False
+    bytes_after_send = 0
+    last_data = t0
+    while True:
+        el = time.time() - t0
+        if send_prompt and not sent and el > WARMUP:
+            os.write(fd, (TASK + "\r").encode())
+            sent = True
+            last_data = time.time()
+        r, _, _ = select.select([fd], [], [], 0.3)
+        if r:
+            try:
+                data = os.read(fd, 65536)
+            except OSError:
+                break
+            if not data:
+                break
+            last_data = time.time()
+            if sent:
+                bytes_after_send += len(data)
+        now = time.time()
+        if send_prompt:
+            if sent and bytes_after_send > 200 and (now - last_data) > IDLE_GAP:
+                break
+            if el > HARD_CAP:
+                break
+        elif el > hold_s:
+            break
+    try:
+        os.write(fd, b"/exit\r")
+        time.sleep(0.5)
+        os.kill(pid, 9)
+    except (OSError, ProcessLookupError):
+        pass
+    _, _, ru = os.wait4(pid, 0)
+    return _rusage(ru, time.time() - t0, {"bytes_streamed": bytes_after_send})
+
+
+def parallel_headless(n):
+    t0 = time.time()
+    kids = []
+    for _ in range(n):
+        tf = tempfile.NamedTemporaryFile(delete=False, suffix=".json")
+        tf.close()
+        pid = os.fork()
+        if pid == 0:
+            os.dup2(os.open("/dev/null", os.O_RDONLY), 0)
+            fout = os.open(tf.name, os.O_WRONLY | os.O_TRUNC)
+            os.dup2(fout, 1)
+            os.dup2(fout, 2)
+            os.execvp("claude", ["claude", "-p", TASK, "--model", MODEL, "--output-format", "json"])
+            os._exit(127)
+        kids.append((pid, tf.name))
+    per = []
+    for pid, fname in kids:
+        _, _, ru = os.wait4(pid, 0)
+        api = None
+        try:
+            with open(fname) as f:
+                api = json.load(f).get("duration_api_ms")
+        except Exception:
+            pass
+        os.unlink(fname)
+        per.append(dict(cpu=round(ru.ru_utime + ru.ru_stime, 2),
+                        rss_mb=round(ru.ru_maxrss / 1024.0, 1), api_ms=api))
+    return time.time() - t0, per
+
+
+def _med(rows, key):
+    vals = [r[key] for r in rows if isinstance(r.get(key), (int, float))]
+    return statistics.median(vals) if vals else 0.0
+
+
+def main():
+    u = os.uname()
+    ncpu = os.cpu_count()
+    print(f"# Claude Code: TUI(PTY) vs headless | model={MODEL} iters={ITERS}")
+    print(f"# host={u.nodename} {u.machine} cores={ncpu}")
+    results = {"host": u.nodename, "machine": u.machine, "cores": ncpu, "model": MODEL}
+
+    print("\n[A] headless active task ...", flush=True)
+    head = []
+    for i in range(ITERS):
+        r = run_headless()
+        head.append(r)
+        print(f"  {i+1}: wall={r['wall_s']}s cpu={r['cpu_s']}s rss={r['max_rss_mb']}MB api={r['api_ms']}ms", flush=True)
+
+    print("\n[B] TUI active task ...", flush=True)
+    tui = []
+    for i in range(ITERS):
+        r = drive_pty(True, 0)
+        tui.append(r)
+        print(f"  {i+1}: wall={r['wall_s']}s cpu={r['cpu_s']}s rss={r['max_rss_mb']}MB", flush=True)
+
+    print("\n[C/D] TUI idle + marginal idle CPU/sec ...", flush=True)
+    short = [drive_pty(False, 4.0) for _ in range(2)]
+    long = [drive_pty(False, 34.0) for _ in range(2)]
+    s_cpu, l_cpu = _med(short, "cpu_s"), _med(long, "cpu_s")
+    s_w, l_w = _med(short, "wall_s"), _med(long, "wall_s")
+    marginal = (l_cpu - s_cpu) / (l_w - s_w) if l_w > s_w else 0.0
+    print(f"  startup(~{s_w:.0f}s) cpu={s_cpu:.2f}s  long(~{l_w:.0f}s) cpu={l_cpu:.2f}s")
+    print(f"  => marginal idle = {marginal*100:.1f}% of one core per open pane")
+
+    print("\n[E] parallel headless scaling ...", flush=True)
+    par = {}
+    for n in PARALLEL:
+        wall, rows = parallel_headless(n)
+        apis = [p["api_ms"] for p in rows if p["api_ms"]]
+        rss = [p["rss_mb"] for p in rows]
+        par[str(n)] = dict(wall=round(wall, 2), per=rows)
+        print(f"  N={n:2}: wall={wall:5.2f}s median_api={statistics.median(apis) if apis else 0:.0f}ms "
+              f"total_rss~={sum(rss):.0f}MB", flush=True)
+
+    head_cpu, tui_cpu = _med(head, "cpu_s"), _med(tui, "cpu_s")
+    head_rss, tui_rss = _med(head, "max_rss_mb"), _med(tui, "max_rss_mb")
+    print("\n=== summary (medians) ===")
+    print(f"  CPU/task : headless {head_cpu:.2f}s  vs  TUI {tui_cpu:.2f}s   (TUI {tui_cpu/head_cpu:.1f}x)")
+    print(f"  RSS/inst : headless {head_rss:.0f}MB vs  TUI {tui_rss:.0f}MB  (TUI +{tui_rss-head_rss:.0f}MB)")
+    print(f"  TUI idle : {marginal*100:.1f}% core/pane steady-state")
+
+    results.update(headless_active=head, tui_active=tui,
+                   tui_idle_short=short, tui_idle_long=long,
+                   marginal_idle_core_frac=marginal, parallel=par)
+    out = os.path.join(HERE, "tty-vs-headless.results.json")
+    with open(out, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"\nraw -> {out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a reproducible benchmark quantifying the **local** resource cost of running Claude Code interactively (TUI / Ink render loop) vs **headless** (`claude -p`). Motivation: deciding whether to offload fan-out agent work off a laptop onto a dedicated device.

## Files

- `bench/tty-vs-headless.py` — per-process CPU + peak RSS via `os.wait4` rusage across four experiments: headless active task, TUI active task (driven over a real pty so the Ink loop runs), idle-pane marginal CPU/sec, and parallel headless scaling. Env-tunable `ITERS` / `MODEL` / `PARALLEL`.
- `bench/offload-smoke.sh` — times a real `agents run` headless dispatch (PASS/FAIL); runnable on the device or over ssh from a laptop.

## Results (GB10, yosemite-s0, 20 cores / 125 GB)

| Metric (median) | Headless | TUI | Δ |
|---|---|---|---|
| Local CPU / task | 1.9 s | 4.4 s | TUI ~2.3× |
| Peak RSS / instance | 319 MB | 398 MB | +79 MB |
| Idle open pane | n/a | ~1.5% core | steady-state |

8 concurrent headless runs finish in ~the same wall as 1 (~2.5 GB RAM total) — the ceiling is the Anthropic API, not the box.

> Note: the pty harness reads bytes into Python, not a GPU terminal emulator, so TUI numbers are a **lower bound** on real interactive cost (emulator repaint on every streamed token is unmeasured).

## Verification

Both scripts run end-to-end on `yosemite-s0`: harness reproduces the numbers above; `offload-smoke.sh` returns `OK` / PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)