### PR TITLE
feat(cloud): discover pre-provisioned targets + interactive picker

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -30,6 +30,36 @@ in `~/.agents/agents.yaml` > `rush`.
 | `droid` | `factory` | Factory Droid Computer (cloud VM) via `droid computer ssh` + remote `droid exec`. |
 | `antigravity` | `antigravity` | Gemini Managed Agents Interactions API (remote sandbox). |
 
+### Pre-provisioned targets (env / computer)
+
+Two of the clouds don't clone a repo per dispatch — they run *inside* something
+you provision once:
+
+- **Codex** runs in an **environment** (`env_…`) created in the Codex web UI,
+  which bundles a repo + base image + setup scripts. `codex cloud exec` requires
+  `--env`.
+- **Factory** runs on a **Droid Computer** (a persistent cloud VM). Dispatch
+  requires `--computer`.
+
+(Rush is per-repo via `--repo`; Antigravity spins up an on-demand sandbox — no
+pre-provisioned target.)
+
+So you supply the target one of three ways: per-run (`--env` / `--computer`), a
+default in `agents.yaml` (`cloud.providers.codex.env` /
+`cloud.providers.factory.computer`), or — interactively — let the CLI pick it.
+
+**Discover targets:** `agents cloud envs [--provider <id>]` lists what you can
+dispatch into. Factory enumerates Droid Computers via `droid computer list`
+(surfacing the sign-in error verbatim if you're not authenticated). Codex has no
+list-environments CLI, so it prints guidance to browse them with the interactive
+`codex cloud` instead.
+
+**Interactive picker:** if a dispatch is missing its target and you're in a TTY,
+`agents cloud run` offers a picker rather than erroring — a `select` of your
+Droid Computers (Factory), or, where the backend can't enumerate (Codex), the
+actionable guidance. The picker falls back to a free-text prompt if the listing
+is empty, so a dispatch is never hard-blocked.
+
 ## Architecture
 
 ```
@@ -70,6 +100,7 @@ agents cloud providers
 | `agents cloud cancel <id>` | Cancel a running task |
 | `agents cloud message <id> <text>` | Send a follow-up to a finished or needs-review task |
 | `agents cloud providers` | List available providers and their status |
+| `agents cloud envs` | List the pre-provisioned targets (Codex environments / Droid Computers) you can dispatch into |
 
 ### `cloud run` options
 

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -12,7 +12,8 @@ import ora from 'ora';
 import { resolveProvider, getAllProviders, getDefaultProviderId } from '../lib/cloud/registry.js';
 import { insertTask, updateTaskStatus, getTaskById, listTasks as listStoredTasks, listActiveTasks } from '../lib/cloud/store.js';
 import { renderStream } from '../lib/cloud/stream.js';
-import type { CloudProviderId, CloudTaskStatus, DispatchOptions } from '../lib/cloud/types.js';
+import type { CloudProvider, CloudProviderId, CloudTarget, CloudTaskStatus, DispatchOptions } from '../lib/cloud/types.js';
+import { MissingTargetError } from '../lib/cloud/types.js';
 
 /** Print an error message to stderr and exit. */
 function die(msg: string, code = 1): never {
@@ -51,6 +52,51 @@ function statusColor(status: string): (s: string) => string {
 
 function isJsonMode(opts: { json?: boolean }): boolean {
   return Boolean(opts.json) || !process.stdout.isTTY;
+}
+
+/**
+ * After a `MissingTargetError`, try to resolve the target interactively.
+ * Returns the chosen id, or undefined when no interactive resolution is
+ * possible (non-TTY/JSON, provider can't enumerate, or user cancels) — the
+ * caller then prints the error's guidance.
+ *
+ * Codex has no `listTargets` (no list-environments CLI), so it always returns
+ * undefined here and the user sees the `codex cloud` guidance. Factory lists
+ * Droid Computers; if listing fails (not signed in) or parses to nothing, we
+ * fall back to a free-text prompt so a dispatch is never hard-blocked.
+ */
+async function pickMissingTarget(
+  provider: CloudProvider,
+  err: MissingTargetError,
+  json: boolean,
+): Promise<string | undefined> {
+  if (json || !process.stdout.isTTY) return undefined;
+  if (!provider.listTargets) return undefined;
+
+  const { select, input } = await import('@inquirer/prompts');
+  const promptName = err.kind === 'env' ? 'environment' : 'computer';
+
+  let targets: CloudTarget[];
+  try {
+    targets = await provider.listTargets();
+  } catch (listErr) {
+    process.stderr.write(chalk.dim(`Could not list ${promptName}s: ${(listErr as Error).message}\n`));
+    targets = [];
+  }
+
+  try {
+    if (targets.length > 0) {
+      return await select({
+        message: `Select a ${promptName}`,
+        choices: targets.map((t) => ({ value: t.id, name: t.label ? `${t.id}  ${chalk.dim(t.label)}` : t.id })),
+      });
+    }
+    const typed = (await input({ message: `No ${promptName}s found. Enter a ${promptName} name (blank to cancel):` })).trim();
+    return typed || undefined;
+  } catch {
+    // User hit Ctrl-C / Esc on the prompt.
+    return undefined;
+  }
 }
 
 /** Register the `agents cloud` command tree (run, list, status, logs, cancel, message, providers). */
@@ -207,15 +253,38 @@ Examples:
       }
       if (options.uploadAccountTokens) dispatchOptions.providerOptions!.uploadAccountTokens = true;
 
-      // Dispatch
-      const spinner = ora({ text: `Dispatching to ${provider.name}...`, stream: process.stderr }).start();
+      // Dispatch. On a missing pre-provisioned target (Codex env / Factory
+      // computer), offer an interactive picker instead of a raw error.
+      const dispatchOnce = async () => {
+        const spinner = ora({ text: `Dispatching to ${provider.name}...`, stream: process.stderr }).start();
+        try {
+          const t = await provider.dispatch(dispatchOptions);
+          spinner.succeed(`Task ${t.id} dispatched to ${provider.name}`);
+          return t;
+        } catch (err) {
+          spinner.fail('Dispatch failed');
+          throw err;
+        }
+      };
+
       let task;
       try {
-        task = await provider.dispatch(dispatchOptions);
-        spinner.succeed(`Task ${task.id} dispatched to ${provider.name}`);
+        task = await dispatchOnce();
       } catch (err) {
-        spinner.fail('Dispatch failed');
-        die((err as Error).message);
+        if (err instanceof MissingTargetError) {
+          const picked = await pickMissingTarget(provider, err, json);
+          if (!picked) {
+            die(err.guidance ? `${err.message}\n\n${err.guidance}` : err.message);
+          }
+          dispatchOptions.providerOptions![err.kind] = picked;
+          try {
+            task = await dispatchOnce();
+          } catch (err2) {
+            die((err2 as Error).message);
+          }
+        } else {
+          die((err as Error).message);
+        }
       }
 
       // Persist locally
@@ -459,6 +528,62 @@ Examples:
         const status = available ? chalk.green('ready') : chalk.dim('not configured');
         const defaultTag = isDefault ? chalk.cyan(' (default)') : '';
         console.log(`  ${p.id.padEnd(12)} ${p.name.padEnd(20)} ${status}${defaultTag}`);
+      }
+    });
+
+  // ── agents cloud envs ─────────────────────────────────────────────────
+  // Discover the pre-provisioned targets a provider runs inside — Codex
+  // environments, Factory Droid Computers — so users don't copy opaque IDs
+  // out of a web UI.
+  cloud
+    .command('envs')
+    .alias('targets')
+    .description('List the pre-provisioned targets (Codex environments / Droid Computers) you can dispatch into.')
+    .option('--provider <id>', 'Only this provider (codex, factory, ...)')
+    .option('--json', 'JSON output')
+    .action(async (options: Record<string, unknown>) => {
+      const json = isJsonMode(options as { json?: boolean });
+      const only = options.provider as CloudProviderId | undefined;
+
+      // Providers that run inside a pre-provisioned target declare targetKind.
+      const providers = getAllProviders().filter((p) => p.targetKind && (!only || p.id === only));
+      if (only && providers.length === 0) {
+        die(`Provider '${only}' has no pre-provisioned targets (or is unknown). Targets apply to: codex, factory.`);
+      }
+
+      const results: Array<{ provider: CloudProviderId; kind: string; targets: { id: string; label?: string }[]; note?: string }> = [];
+      for (const p of providers) {
+        const kind = p.targetKind!;
+        if (!p.listTargets) {
+          // Not enumerable (Codex). Surface guidance instead of a list.
+          const guidance = kind === 'env'
+            ? 'Codex environments are not listable from the CLI. Browse/create them with `codex cloud` (interactive), then use --env <id>.'
+            : 'Not enumerable from the CLI.';
+          results.push({ provider: p.id, kind, targets: [], note: guidance });
+          continue;
+        }
+        try {
+          const targets = await p.listTargets();
+          results.push({ provider: p.id, kind, targets: targets.map((t) => ({ id: t.id, label: t.label })) });
+        } catch (err) {
+          results.push({ provider: p.id, kind, targets: [], note: (err as Error).message });
+        }
+      }
+
+      if (json) {
+        process.stdout.write(JSON.stringify(results, null, 2) + '\n');
+        return;
+      }
+
+      for (const r of results) {
+        console.log(chalk.bold(`\n${r.provider}`) + chalk.dim(` (${r.kind})`));
+        if (r.targets.length > 0) {
+          for (const t of r.targets) {
+            console.log(`  ${t.id}${t.label ? '  ' + chalk.dim(t.label) : ''}`);
+          }
+        } else {
+          console.log(chalk.dim(`  ${r.note ?? 'none'}`));
+        }
       }
     });
 }

--- a/src/lib/cloud/codex.ts
+++ b/src/lib/cloud/codex.ts
@@ -18,7 +18,7 @@ import type {
   DispatchOptions,
   ProviderCapabilities,
 } from './types.js';
-import { resolveDispatchRepos } from './types.js';
+import { resolveDispatchRepos, MissingTargetError } from './types.js';
 import { getShimsDir } from '../state.js';
 
 const SHIMS_DIR = getShimsDir();
@@ -95,6 +95,10 @@ function parseTaskFromText(text: string): Partial<CloudTask> {
 export class CodexCloudProvider implements CloudProvider {
   id = 'codex' as const;
   name = 'Codex Cloud';
+  targetKind = 'env' as const;
+  // No listTargets: OpenAI ships no non-interactive "list environments"
+  // command. `codex cloud exec` requires --env and the help points at the
+  // interactive `codex cloud` TUI to browse. So discovery is guidance-only.
 
   private defaultEnv?: string;
 
@@ -121,7 +125,13 @@ export class CodexCloudProvider implements CloudProvider {
   async dispatch(options: DispatchOptions): Promise<CloudTask> {
     const env = (options.providerOptions?.env as string | undefined) ?? this.defaultEnv;
     if (!env) {
-      throw new Error('Codex Cloud requires --env <id>. Set a default in ~/.agents/agents.yaml under cloud.providers.codex.env.');
+      throw new MissingTargetError(
+        'env',
+        'Codex Cloud requires --env <id>.',
+        'Codex environments are created in the Codex web UI and bundle a repo + setup. ' +
+          'Browse yours with `codex cloud` (interactive), then re-run with --env <id> ' +
+          'or set a default in ~/.agents/agents.yaml under cloud.providers.codex.env.',
+      );
     }
 
     // Codex envs bundle their own repo list — the repos a task can touch are

--- a/src/lib/cloud/factory.test.ts
+++ b/src/lib/cloud/factory.test.ts
@@ -5,6 +5,8 @@ import {
   buildSshArgs,
   mapResultStatus,
   mapDroidEvent,
+  parseComputerList,
+  FactoryCloudProvider,
 } from './factory.js';
 
 describe('resolveAutonomy', () => {
@@ -113,5 +115,40 @@ describe('mapDroidEvent', () => {
     const ev = mapDroidEvent({ type: 'mystery', foo: 1 });
     expect(ev.type).toBe('unknown');
     if (ev.type === 'unknown') expect(ev.name).toBe('mystery');
+  });
+});
+
+describe('parseComputerList', () => {
+  it('parses computer names from a tabular listing, skipping the header', () => {
+    const out = parseComputerList(
+      [
+        'NAME            STATUS    TYPE',
+        'cloud-vm-1      active    managed',
+        'my-laptop       paused    byom',
+      ].join('\n'),
+    );
+    expect(out).toEqual([
+      { id: 'cloud-vm-1', label: 'active    managed', kind: 'computer' },
+      { id: 'my-laptop', label: 'paused    byom', kind: 'computer' },
+    ]);
+  });
+
+  it('handles a bare name-per-line listing', () => {
+    expect(parseComputerList('alpha\nbeta\n')).toEqual([
+      { id: 'alpha', label: undefined, kind: 'computer' },
+      { id: 'beta', label: undefined, kind: 'computer' },
+    ]);
+  });
+
+  it('skips separators and status messages, yielding [] on empty/error output', () => {
+    expect(parseComputerList('')).toEqual([]);
+    expect(parseComputerList('No authenticated user with organization available')).toEqual([]);
+    expect(parseComputerList('-------\n=======')).toEqual([]);
+  });
+});
+
+describe('FactoryCloudProvider target discovery', () => {
+  it('declares computer as its target kind', () => {
+    expect(new FactoryCloudProvider().targetKind).toBe('computer');
   });
 });

--- a/src/lib/cloud/factory.ts
+++ b/src/lib/cloud/factory.ts
@@ -28,10 +28,12 @@ import type {
   CloudTask,
   CloudTaskStatus,
   CloudEvent,
+  CloudTarget,
   DispatchOptions,
   ProviderCapabilities,
   DroidAutonomy,
 } from './types.js';
+import { MissingTargetError } from './types.js';
 import { getShimsDir } from '../state.js';
 
 const SHIMS_DIR = getShimsDir();
@@ -55,6 +57,42 @@ export function resolveAutonomy(value: unknown, fallback: DroidAutonomy = DEFAUL
   return typeof value === 'string' && VALID_AUTONOMY.has(value as DroidAutonomy)
     ? (value as DroidAutonomy)
     : fallback;
+}
+
+/** Run the droid CLI and capture output (used for `computer list`). */
+function runDroid(bin: string, args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolve) => {
+    const proc = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (d: Buffer) => { stdout += d.toString(); });
+    proc.stderr.on('data', (d: Buffer) => { stderr += d.toString(); });
+    proc.on('error', (e) => resolve({ stdout, stderr: stderr + String(e), code: 127 }));
+    proc.on('close', (code) => resolve({ stdout, stderr, code: code ?? 1 }));
+  });
+}
+
+/**
+ * Parse `droid computer list` text into targets. Defensive: the exact column
+ * layout isn't documented, so we take the first whitespace token of each data
+ * row as the computer name and keep the remainder as a label, skipping headers,
+ * separators, and status messages. The interactive picker degrades to free-text
+ * entry if this yields nothing, so an unexpected layout never blocks a dispatch.
+ */
+export function parseComputerList(text: string): CloudTarget[] {
+  const out: CloudTarget[] = [];
+  for (const raw of text.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (/^(name|computer|status|id)\b/i.test(line)) continue;   // header row
+    if (/^[-=_\s|]+$/.test(line)) continue;                      // separator rule
+    if (/^(no |failed|error|warning)\b/i.test(line)) continue;   // status message
+    const name = line.split(/\s+/)[0];
+    if (!name) continue;
+    const label = line.slice(name.length).trim() || undefined;
+    out.push({ id: name, label, kind: 'computer' });
+  }
+  return out;
 }
 
 /**
@@ -178,6 +216,7 @@ interface BufferedRun {
 export class FactoryCloudProvider implements CloudProvider {
   id = 'factory' as const;
   name = 'Factory (Droid)';
+  targetKind = 'computer' as const;
 
   private defaultComputer?: string;
   private defaultAutonomy: DroidAutonomy;
@@ -208,6 +247,21 @@ export class FactoryCloudProvider implements CloudProvider {
     };
   }
 
+  /** Enumerate Droid Computers via `droid computer list`. Throws if not signed in. */
+  async listTargets(): Promise<CloudTarget[]> {
+    const droidBin = findDroidBinary();
+    if (!droidBin) {
+      throw new Error('droid CLI not found. Install it: curl -fsSL https://app.factory.ai/cli | sh');
+    }
+    const { stdout, stderr, code } = await runDroid(droidBin, ['computer', 'list']);
+    if (code !== 0) {
+      // Surface droid's own message verbatim — e.g. "No authenticated user with
+      // organization available" when the user hasn't logged in.
+      throw new Error((stderr.trim() || stdout.trim() || `droid computer list exited ${code}`));
+    }
+    return parseComputerList(stdout);
+  }
+
   async dispatch(options: DispatchOptions): Promise<CloudTask> {
     const droidBin = findDroidBinary();
     if (!droidBin) {
@@ -216,10 +270,12 @@ export class FactoryCloudProvider implements CloudProvider {
 
     const computer = (options.providerOptions?.computer as string | undefined) ?? this.defaultComputer;
     if (!computer) {
-      throw new Error(
-        'Factory cloud requires a Droid Computer. Pass --computer <name>, or set ' +
-          'cloud.providers.factory.computer in ~/.agents/agents.yaml. Create one in ' +
-          'Factory (Settings → Droid Computers), or register a machine with `droid computer register`.',
+      throw new MissingTargetError(
+        'computer',
+        'Factory cloud requires a Droid Computer.',
+        'Pass --computer <name>, or set cloud.providers.factory.computer in ~/.agents/agents.yaml. ' +
+          'Create one in Factory (Settings → Droid Computers), or register a machine with `droid computer register`. ' +
+          'List yours with `agents cloud envs --provider factory`.',
       );
     }
 

--- a/src/lib/cloud/target-discovery.test.ts
+++ b/src/lib/cloud/target-discovery.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { MissingTargetError } from './types.js';
+import { CodexCloudProvider } from './codex.js';
+import { FactoryCloudProvider } from './factory.js';
+import { RushCloudProvider } from './rush.js';
+import { AntigravityCloudProvider } from './antigravity.js';
+
+describe('MissingTargetError', () => {
+  it('is an Error carrying the missing kind and guidance', () => {
+    const e = new MissingTargetError('env', 'need env', 'do this');
+    expect(e).toBeInstanceOf(Error);
+    expect(e.name).toBe('MissingTargetError');
+    expect(e.kind).toBe('env');
+    expect(e.guidance).toBe('do this');
+  });
+});
+
+describe('targetKind matrix', () => {
+  it('only Codex (env) and Factory (computer) run inside a pre-provisioned target', () => {
+    expect(new CodexCloudProvider().targetKind).toBe('env');
+    expect(new FactoryCloudProvider().targetKind).toBe('computer');
+    // Rush is per-repo, Antigravity is an on-demand sandbox — no fixed target.
+    expect(new RushCloudProvider().targetKind).toBeUndefined();
+    expect(new AntigravityCloudProvider().targetKind).toBeUndefined();
+  });
+
+  it('Codex exposes no listTargets (no list-environments CLI); Factory does', () => {
+    expect(new CodexCloudProvider().listTargets).toBeUndefined();
+    expect(typeof new FactoryCloudProvider().listTargets).toBe('function');
+  });
+});
+
+describe('Codex dispatch without an env', () => {
+  it('throws a MissingTargetError(env) with codex-cloud guidance', async () => {
+    const p = new CodexCloudProvider();
+    await expect(p.dispatch({ prompt: 'do a thing' })).rejects.toMatchObject({
+      name: 'MissingTargetError',
+      kind: 'env',
+    });
+    // guidance points at the interactive browser, since there's no list CLI
+    await p.dispatch({ prompt: 'x' }).catch((e: MissingTargetError) => {
+      expect(e.guidance).toMatch(/codex cloud/i);
+    });
+  });
+});

--- a/src/lib/cloud/types.ts
+++ b/src/lib/cloud/types.ts
@@ -176,6 +176,37 @@ export interface ProviderCapabilities {
 }
 
 /**
+ * A pre-provisioned dispatch target a provider runs *inside* — a Codex
+ * environment (`env_…`) or a Factory Droid Computer (a name). Surfaced by
+ * `agents cloud envs` and the missing-target picker so users don't have to
+ * copy opaque IDs out of a web UI.
+ */
+export interface CloudTarget {
+  /** The value passed to dispatch (env id / computer name). */
+  id: string;
+  /** Human label — repo, description, or status. */
+  label?: string;
+  kind: TargetKind;
+}
+
+/** Which dispatch option a provider's pre-provisioned target maps to. */
+export type TargetKind = 'env' | 'computer';
+
+/**
+ * Thrown by a provider's `dispatch()` when it needs a pre-provisioned target
+ * (Codex env / Factory computer) and none was supplied. The CLI catches this
+ * to offer a picker (`listTargets`) or actionable guidance, instead of a raw
+ * error. `kind` names the missing flag; `guidance` is shown when the target
+ * can't be enumerated.
+ */
+export class MissingTargetError extends Error {
+  constructor(public kind: TargetKind, message: string, public guidance?: string) {
+    super(message);
+    this.name = 'MissingTargetError';
+  }
+}
+
+/**
  * Contract that every cloud backend must implement.
  *
  * Each provider translates between the unified dispatch interface and its
@@ -201,6 +232,22 @@ export interface CloudProvider {
 
   /** Send a follow-up message to a finished/idle/needs_review task. */
   message(taskId: string, content: string): Promise<void>;
+
+  /**
+   * The pre-provisioned target this provider runs inside, if any. Set for
+   * Codex (`env`) and Factory (`computer`); undefined for Rush (per-repo) and
+   * Antigravity (on-demand sandbox).
+   */
+  targetKind?: TargetKind;
+
+  /**
+   * Enumerate selectable targets for `agents cloud envs` and the picker.
+   * Present only when the backend can list non-interactively (Factory via
+   * `droid computer list`). Codex has no such CLI — it omits this, and callers
+   * fall back to `MissingTargetError.guidance`. May throw (e.g. not signed in);
+   * callers surface that verbatim.
+   */
+  listTargets?(): Promise<CloudTarget[]>;
 }
 
 /** Autonomy level passed to `droid exec --auto` for Factory cloud dispatches. */


### PR DESCRIPTION
## What

Follow-up to the cloud-routing PR: make the **pre-provisioned target** that Codex and Factory require (a Codex environment / a Droid Computer) **discoverable**, instead of an opaque ID you copy out of a web UI.

This is the answer to "you can't run a lot of codex agents without supplying an environment ID."

## Why the friction exists

The four clouds split two ways:
- **Stateless / per-dispatch** — Rush clones `--repo` fresh each run; Antigravity spins up an on-demand sandbox. No setup.
- **Stateful / pre-provisioned** — Codex runs in an **environment** (`env_…`, repo + image + setup baked in, required by `codex cloud exec`); Factory runs on a **Droid Computer**. You provision once, then reference it.

So `--env` / `--computer` isn't busywork we added — it's *where the run happens*.

## What this adds

- **`agents cloud envs [--provider <id>]`** — lists the targets you can dispatch into.
  - Factory: enumerates Droid Computers via `droid computer list` (surfaces the sign-in error verbatim when not authenticated).
  - Codex: **no list-environments CLI exists** (`codex cloud exec` requires `--env`; the help points at the interactive `codex cloud` TUI), so it prints actionable guidance instead.
- **Interactive picker** — dispatch now throws a typed `MissingTargetError(kind, guidance)` when the target is absent. In a TTY, `cloud run` catches it and offers a `select` of your Droid Computers (free-text fallback if the listing is empty, so a dispatch is never hard-blocked). Non-TTY / Codex → the guidance.
- **Provider contract**: optional `targetKind` (`env` | `computer`) + `listTargets()`. Codex = `env`, no `listTargets`; Factory = `computer` + parses `droid computer list`; Rush/Antigravity = neither.

## Verification

- **Full suite on crabbox** (CI-exact): **232 files / 2900 tests passed, 0 failures** (factory 20, target-discovery 4 new).
- **Live built CLI** (piped/JSON):
  - `agents cloud envs` → codex: *"environments are not listable from the CLI; browse with `codex cloud`"*; factory: actually ran `droid computer list` and surfaced *"No authenticated user with organization available"* (proves the real call path); rush/antigravity excluded (no target).
  - `agents cloud run --agent codex` (no env, non-TTY) → routes to Codex, fails with the clear `MissingTargetError` + `codex cloud` guidance.

## Not verified end-to-end (needs creds)

- The Factory **picker `select`** and the parsed `droid computer list` table need a Factory login to confirm against real output. `parseComputerList` is defensive + unit-tested against a plausible layout, and the picker degrades to free-text, so an unexpected column layout never blocks a dispatch. The non-TTY guidance path and the real `droid computer list` invocation (auth error) are proven live.
