### PR TITLE
feat(rules): subrule directories that bundle a rule with its enforcement hooks

### DIFF
--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -16,7 +16,8 @@ import * as TOML from 'smol-toml';
 import { AGENTS, ALL_AGENT_IDS, agentConfigDirName } from './agents.js';
 import { supports, explainSkip, capableAgents } from './capabilities.js';
 import { setGeminiAutoUpdateDisabled, updateGeminiSettings } from './gemini-settings.js';
-import { getAgentsDir, getHooksDir as getSystemHooksDir, getUserHooksDir, getUserAgentsDir, getSystemAgentsDir, getProjectAgentsDir, getTrashHooksDir, getEnabledExtraRepos } from './state.js';
+import { getAgentsDir, getHooksDir as getSystemHooksDir, getUserHooksDir, getUserAgentsDir, getSystemAgentsDir, getProjectAgentsDir, getTrashHooksDir, getEnabledExtraRepos, getResolvedRulesDir, getUserRulesDir } from './state.js';
+import { collectSubruleHooksFromState } from './rules/compose.js';
 
 function getCentralHooksDir(): string { return getUserHooksDir(); }
 
@@ -54,6 +55,12 @@ function getManagedHookPrefixes(): string[] {
     path.join(getUserAgentsDir(), 'hooks') + path.sep,
     ...extraDirs.map(d => path.join(d, 'hooks') + path.sep),
     path.join(getSystemAgentsDir(), 'hooks') + path.sep,
+    // Subrule-dir hook scripts register by their absolute source path under a
+    // rules `subrules/` tree. Cover those trees so a removed subrule/hook's
+    // stale settings entry gets garbage-collected like any other managed hook.
+    path.join(getUserRulesDir(), 'subrules') + path.sep,
+    ...extraDirs.map(d => path.join(d, 'rules', 'subrules') + path.sep),
+    path.join(getResolvedRulesDir(), 'subrules') + path.sep,
   ];
 }
 
@@ -165,6 +172,18 @@ const SCRIPT_EXTENSIONS = new Set([
 
 function isExecutable(mode: number): boolean {
   return (mode & 0o111) !== 0;
+}
+
+/**
+ * Ensure a script file carries an exec bit. Subrule-dir hook scripts are
+ * registered by their source path (not copied), so they must be executable in
+ * place. Best-effort: a chmod failure (read-only fs, foreign owner) is ignored.
+ */
+function ensureExecutable(scriptPath: string): void {
+  try {
+    const mode = fs.statSync(scriptPath).mode;
+    if (!isExecutable(mode)) fs.chmodSync(scriptPath, mode | 0o755);
+  } catch { /* best effort */ }
 }
 
 function getHooksDir(agentId: AgentId): string {
@@ -773,6 +792,14 @@ export function parseHookManifest(opts: { warn?: boolean } = {}): Record<string,
   const merged: Record<string, ManifestHook> = {};
   const systemHooks: Record<string, ManifestHook> = {};
 
+  // Lowest-precedence layer: hooks declared inside active subrule directories.
+  // Seeded first so any same-key entry from system/user agents.yaml wins.
+  // Gated so a malformed hooks.yaml never breaks rule sync.
+  try {
+    const subruleHooks = collectSubruleHooksFromState();
+    for (const [name, def] of Object.entries(subruleHooks)) merged[name] = def;
+  } catch { /* subrule hook collection is best-effort */ }
+
   // System layer: hooks: section of agents.yaml (npm-shipped, separate repo).
   const systemPath = path.join(getSystemAgentsDir(), 'agents.yaml');
   if (fs.existsSync(systemPath)) {
@@ -899,6 +926,12 @@ export function registerHooksToSettings(
     ? path.join(versionHome, agentConfigDirName(agentId), AGENTS[agentId].hooksDir)
     : null;
   const resolveScript = (script: string): string | null => {
+    // Subrule-dir hooks declare an already-absolute script path. Use it
+    // directly (made executable) — these are not copied into the version home.
+    if (path.isAbsolute(script) && fs.existsSync(script)) {
+      ensureExecutable(script);
+      return script;
+    }
     if (overrideRoots) {
       return resolveContainedHookPath(path.join(overrideRoots[0], 'hooks'), script);
     }

--- a/src/lib/resources/rules.test.ts
+++ b/src/lib/resources/rules.test.ts
@@ -203,6 +203,52 @@ describe('listSubrulesInDir', () => {
 
     expect(names).toEqual(['rule']);
   });
+
+  it('lists dir-form subrules (foo/rule.md) alongside flat ones', () => {
+    const dir = path.join(tmpDir, 'subrules');
+    writeFile('subrules/flat.md', 'FLAT');
+    writeFile('subrules/dir/rule.md', 'DIR');
+    // A directory without rule.md is not a subrule.
+    writeFile('subrules/notarule/hooks.yaml', 'x: {}');
+
+    const names = listSubrulesInDir(dir);
+
+    expect(names).toEqual(['dir', 'flat']);
+  });
+});
+
+describe('rules — dir-form subrules', () => {
+  it('resolveRule reads dir-form rule.md', () => {
+    const system = makeLayer('system', 'system');
+    writeFile('system/subrules/foo/rule.md', 'DIR FOO');
+
+    const result = resolveRule('foo', [system]);
+    expect(result).not.toBeNull();
+    expect(result!.item.content).toBe('DIR FOO');
+    expect(result!.path).toBe(path.join(system.dir, 'subrules', 'foo', 'rule.md'));
+  });
+
+  it('dir-form in a higher layer shadows a flat one in a lower layer', () => {
+    const system = makeLayer('system', 'system');
+    const user = makeLayer('user', 'user');
+    writeFile('system/subrules/foo.md', 'SYS FLAT');
+    writeFile('user/subrules/foo/rule.md', 'USER DIR');
+
+    const result = resolveRule('foo', [user, system]);
+    expect(result!.layer).toBe('user');
+    expect(result!.item.content).toBe('USER DIR');
+  });
+
+  it('listAllRules includes dir-form subrules', () => {
+    const system = makeLayer('system', 'system');
+    writeFile('system/subrules/flat.md', 'FLAT');
+    writeFile('system/subrules/dir/rule.md', 'DIR');
+
+    const results = listAllRules([system]);
+    const byName = Object.fromEntries(results.map((r) => [r.name, r.item.content]));
+    expect(Object.keys(byName).sort()).toEqual(['dir', 'flat']);
+    expect(byName.dir).toBe('DIR');
+  });
 });
 
 describe('RulesHandler.format', () => {

--- a/src/lib/resources/rules.ts
+++ b/src/lib/resources/rules.ts
@@ -23,6 +23,22 @@ import {
 
 const SUBRULES_DIR = 'subrules';
 const SUBRULES_README = 'README.md';
+/** Inside a dir-form subrule, the prose file. */
+const SUBRULE_RULE_FILE = 'rule.md';
+
+/**
+ * Resolve the prose file path for a subrule named `name` under `subrulesDir`.
+ *
+ * Dir form `<name>/rule.md` wins when present; otherwise the flat `<name>.md`.
+ * Returns null when neither exists.
+ */
+function resolveSubruleFile(subrulesDir: string, name: string): string | null {
+  const dirForm = path.join(subrulesDir, name, SUBRULE_RULE_FILE);
+  if (fs.existsSync(dirForm)) return dirForm;
+  const flatForm = path.join(subrulesDir, `${name}.md`);
+  if (fs.existsSync(flatForm)) return flatForm;
+  return null;
+}
 
 /** A rule item is a subrule markdown fragment. */
 export interface RuleItem {
@@ -39,17 +55,26 @@ export interface RulesLayerDir {
 }
 
 /**
- * List subrule markdown files in a directory.
- * Returns names without the .md extension.
+ * List subrule names in a directory.
+ *
+ * A name comes from either the flat form `<name>.md` OR the dir form
+ * `<name>/rule.md`; a directory without `rule.md` is not a subrule. Returns
+ * names without the .md extension.
  */
 export function listSubrulesInDir(subrulesDir: string): string[] {
   if (!fs.existsSync(subrulesDir)) return [];
   try {
-    return fs
-      .readdirSync(subrulesDir)
-      .filter((f) => f.endsWith('.md') && f !== SUBRULES_README)
-      .map((f) => f.slice(0, -3))
-      .sort();
+    const names = new Set<string>();
+    for (const entry of fs.readdirSync(subrulesDir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (fs.existsSync(path.join(subrulesDir, entry.name, SUBRULE_RULE_FILE))) {
+          names.add(entry.name);
+        }
+      } else if (entry.name.endsWith('.md') && entry.name !== SUBRULES_README) {
+        names.add(entry.name.slice(0, -3));
+      }
+    }
+    return [...names].sort();
   } catch {
     return [];
   }
@@ -107,7 +132,8 @@ export function listAllRules(layers: RulesLayerDir[]): ResolvedItem<RuleItem>[] 
       if (seen.has(name)) continue;
       seen.add(name);
 
-      const filePath = path.join(subrulesDir, `${name}.md`);
+      const filePath = resolveSubruleFile(subrulesDir, name);
+      if (!filePath) continue;
       let content = '';
       try {
         content = fs.readFileSync(filePath, 'utf-8');
@@ -133,8 +159,8 @@ export function listAllRules(layers: RulesLayerDir[]): ResolvedItem<RuleItem>[] 
  */
 export function resolveRule(name: string, layers: RulesLayerDir[]): ResolvedItem<RuleItem> | null {
   for (const { layer, dir } of layers) {
-    const filePath = path.join(dir, SUBRULES_DIR, `${name}.md`);
-    if (fs.existsSync(filePath)) {
+    const filePath = resolveSubruleFile(path.join(dir, SUBRULES_DIR), name);
+    if (filePath) {
       let content = '';
       try {
         content = fs.readFileSync(filePath, 'utf-8');

--- a/src/lib/rules/compose.test.ts
+++ b/src/lib/rules/compose.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
-import { composeRules, type RulesLayer } from './compose.js';
+import { composeRules, collectSubruleHooks, type RulesLayer } from './compose.js';
 
 let tmpDir: string;
 
@@ -220,5 +220,132 @@ describe('composeRules — output sanity', () => {
 
     const result = composeRules({ layers: [user, sys] });
     expect(result.subrules.map((s) => s.name)).toEqual(['real']);
+  });
+});
+
+describe('composeRules — dir-form subrules', () => {
+  it('composes a dir-form subrule (subrules/foo/rule.md) like a flat one', () => {
+    const sys = makeLayer('system', 'system');
+    writeFile('system/subrules/foo/rule.md', 'FOO body');
+    writeFile('system/rules.yaml', 'presets:\n  default:\n    subrules: [foo]\n');
+
+    const result = composeRules({ layers: [sys] });
+    expect(result.subrules.map((s) => s.name)).toEqual(['foo']);
+    expect(result.content).toBe('FOO body\n');
+    expect(result.subrules[0].subruleDir).toBe(
+      path.join(sys.rulesDir, 'subrules', 'foo')
+    );
+    expect(result.subrules[0].sourcePath).toBe(
+      path.join(sys.rulesDir, 'subrules', 'foo', 'rule.md')
+    );
+  });
+
+  it('flat and dir forms coexist; a dir-form shadows a lower-layer flat one', () => {
+    const sys = makeLayer('system', 'system');
+    const user = makeLayer('user', 'user');
+    // Lower layer (system) has flat foo; higher layer (user) has dir-form foo.
+    writeFile('system/subrules/foo.md', 'SYS FLAT FOO');
+    writeFile('user/subrules/foo/rule.md', 'USER DIR FOO');
+    // A coexisting flat subrule in the same higher layer.
+    writeFile('user/subrules/bar.md', 'USER BAR');
+    writeFile('system/rules.yaml', 'presets:\n  default:\n    subrules: [foo, bar]\n');
+
+    const result = composeRules({ layers: [user, sys] });
+    expect(result.content).toContain('USER DIR FOO');
+    expect(result.content).not.toContain('SYS FLAT FOO');
+    expect(result.content).toContain('USER BAR');
+    const foo = result.subrules.find((s) => s.name === 'foo')!;
+    expect(foo.layerScope).toBe('user');
+    expect(foo.subruleDir).toBe(path.join(user.rulesDir, 'subrules', 'foo'));
+    const bar = result.subrules.find((s) => s.name === 'bar')!;
+    expect(bar.subruleDir).toBeUndefined();
+  });
+
+  it('auto-appends a dir-form subrule not named by the preset', () => {
+    const sys = makeLayer('system', 'system');
+    const user = makeLayer('user', 'user');
+    writeFile('system/rules.yaml', 'presets:\n  default:\n    subrules: []\n');
+    writeFile('user/subrules/extra/rule.md', 'EXTRA DIR');
+
+    const result = composeRules({ layers: [user, sys] });
+    expect(result.subrules.map((s) => s.name)).toEqual(['extra']);
+    expect(result.content).toBe('EXTRA DIR\n');
+    expect(result.subrules[0].subruleDir).toBe(
+      path.join(user.rulesDir, 'subrules', 'extra')
+    );
+  });
+
+  it('ignores a subrule directory that has no rule.md', () => {
+    const sys = makeLayer('system', 'system');
+    const user = makeLayer('user', 'user');
+    writeFile('system/rules.yaml', 'presets:\n  default:\n    subrules: []\n');
+    writeFile('user/subrules/notarule/hooks.yaml', 'x: {}\n');
+    writeFile('user/subrules/real.md', 'REAL');
+
+    const result = composeRules({ layers: [user, sys] });
+    expect(result.subrules.map((s) => s.name)).toEqual(['real']);
+  });
+});
+
+describe('collectSubruleHooks', () => {
+  it('returns an absolute-script entry for a dir subrule with hooks.yaml', () => {
+    const sys = makeLayer('system', 'system');
+    writeFile('system/subrules/foo/rule.md', 'FOO');
+    writeFile('system/subrules/foo/enforce.sh', '#!/bin/sh\necho hi\n');
+    writeFile(
+      'system/subrules/foo/hooks.yaml',
+      'enforce:\n  script: enforce.sh\n  events: [PreToolUse]\n  matcher: "Edit|Write"\n'
+    );
+    writeFile('system/rules.yaml', 'presets:\n  default:\n    subrules: [foo]\n');
+
+    const hooks = collectSubruleHooks([sys]);
+    expect(Object.keys(hooks)).toEqual(['foo__enforce']);
+    const entry = hooks['foo__enforce'];
+    expect(entry.script).toBe(
+      path.join(sys.rulesDir, 'subrules', 'foo', 'enforce.sh')
+    );
+    expect(path.isAbsolute(entry.script)).toBe(true);
+    expect(entry.events).toEqual(['PreToolUse']);
+    expect(entry.matcher).toBe('Edit|Write');
+  });
+
+  it('accepts the wrapped { hooks: { ... } } shape too', () => {
+    const sys = makeLayer('system', 'system');
+    writeFile('system/subrules/foo/rule.md', 'FOO');
+    writeFile('system/subrules/foo/enforce.sh', '#!/bin/sh\n');
+    writeFile(
+      'system/subrules/foo/hooks.yaml',
+      'hooks:\n  enforce:\n    script: enforce.sh\n    events: [Stop]\n'
+    );
+    writeFile('system/rules.yaml', 'presets:\n  default:\n    subrules: [foo]\n');
+
+    const hooks = collectSubruleHooks([sys]);
+    expect(Object.keys(hooks)).toEqual(['foo__enforce']);
+    expect(hooks['foo__enforce'].events).toEqual(['Stop']);
+  });
+
+  it('returns nothing for flat subrules', () => {
+    const sys = makeLayer('system', 'system');
+    writeFile('system/subrules/foo.md', 'FOO');
+    writeFile('system/rules.yaml', 'presets:\n  default:\n    subrules: [foo]\n');
+
+    expect(collectSubruleHooks([sys])).toEqual({});
+  });
+
+  it('returns nothing for a dir subrule without hooks.yaml', () => {
+    const sys = makeLayer('system', 'system');
+    writeFile('system/subrules/foo/rule.md', 'FOO');
+    writeFile('system/rules.yaml', 'presets:\n  default:\n    subrules: [foo]\n');
+
+    expect(collectSubruleHooks([sys])).toEqual({});
+  });
+
+  it('does not throw on a malformed hooks.yaml — skips that subrule', () => {
+    const sys = makeLayer('system', 'system');
+    writeFile('system/subrules/foo/rule.md', 'FOO');
+    writeFile('system/subrules/foo/hooks.yaml', ': : not : valid : yaml :');
+    writeFile('system/rules.yaml', 'presets:\n  default:\n    subrules: [foo]\n');
+
+    expect(() => collectSubruleHooks([sys])).not.toThrow();
   });
 });

--- a/src/lib/rules/compose.ts
+++ b/src/lib/rules/compose.ts
@@ -29,6 +29,7 @@ import {
   getProjectAgentsDir,
   getEnabledExtraRepos,
 } from '../state.js';
+import type { ManifestHook } from '../types.js';
 
 export type LayerScope = 'project' | 'user' | 'extra' | 'system';
 
@@ -60,6 +61,8 @@ export interface ComposedSubrule {
   sourcePath: string;
   layerScope: LayerScope;
   layerAlias?: string;
+  /** Set when the subrule is dir-form (`subrules/<name>/`); the dir itself. */
+  subruleDir?: string;
 }
 
 export interface ComposeResult {
@@ -77,6 +80,31 @@ const SUBRULES_DIR_NAME = 'subrules';
 const RULES_YAML_NAME = 'rules.yaml';
 const DEFAULT_PRESET = 'default';
 const SUBRULES_README = 'README.md';
+/** Inside a dir-form subrule, the prose file. */
+const SUBRULE_RULE_FILE = 'rule.md';
+/** Inside a dir-form subrule, the optional hook manifest. */
+const SUBRULE_HOOKS_FILE = 'hooks.yaml';
+
+/**
+ * Resolve the prose file for a subrule named `name` under `<rulesDir>/subrules/`.
+ *
+ * A subrule resolves to the DIRECTORY form `subrules/<name>/rule.md` when that
+ * file exists, otherwise the flat form `subrules/<name>.md`. Returns the
+ * markdown path plus the dir-form subrule directory when applicable (callers
+ * that fold hooks need the dir to resolve `hooks.yaml` and relative scripts).
+ */
+function resolveSubrulePath(
+  rulesDir: string,
+  name: string
+): { sourcePath: string; subruleDir?: string } | null {
+  const dirForm = path.join(rulesDir, SUBRULES_DIR_NAME, name, SUBRULE_RULE_FILE);
+  if (fs.existsSync(dirForm)) {
+    return { sourcePath: dirForm, subruleDir: path.join(rulesDir, SUBRULES_DIR_NAME, name) };
+  }
+  const flatForm = path.join(rulesDir, SUBRULES_DIR_NAME, `${name}.md`);
+  if (fs.existsSync(flatForm)) return { sourcePath: flatForm };
+  return null;
+}
 
 function readRulesYaml(rulesDir: string): RulesYaml | null {
   const p = path.join(rulesDir, RULES_YAML_NAME);
@@ -105,23 +133,32 @@ function resolvePreset(
 function findSubrule(
   layers: RulesLayer[],
   name: string
-): { sourcePath: string; layer: RulesLayer } | null {
+): { sourcePath: string; subruleDir?: string; layer: RulesLayer } | null {
   for (const layer of layers) {
-    const p = path.join(layer.rulesDir, SUBRULES_DIR_NAME, `${name}.md`);
-    if (fs.existsSync(p)) return { sourcePath: p, layer };
+    const found = resolveSubrulePath(layer.rulesDir, name);
+    if (found) return { ...found, layer };
   }
   return null;
 }
 
+/**
+ * List subrule names in a layer. A name is contributed by either the flat
+ * form `subrules/<name>.md` OR the dir form `subrules/<name>/rule.md`; a
+ * directory without `rule.md` is not a subrule and is skipped.
+ */
 function listLayerSubruleNames(layer: RulesLayer): string[] {
   const dir = path.join(layer.rulesDir, SUBRULES_DIR_NAME);
   if (!fs.existsSync(dir)) return [];
   try {
-    return fs
-      .readdirSync(dir)
-      .filter((f) => f.endsWith('.md') && f !== SUBRULES_README)
-      .map((f) => f.slice(0, -3))
-      .sort();
+    const names = new Set<string>();
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (fs.existsSync(path.join(dir, entry.name, SUBRULE_RULE_FILE))) names.add(entry.name);
+      } else if (entry.name.endsWith('.md') && entry.name !== SUBRULES_README) {
+        names.add(entry.name.slice(0, -3));
+      }
+    }
+    return [...names].sort();
   } catch {
     return [];
   }
@@ -156,6 +193,7 @@ export function composeRules(opts: ComposeOptions): ComposeResult {
       sourcePath: found.sourcePath,
       layerScope: found.layer.scope,
       layerAlias: found.layer.alias,
+      subruleDir: found.subruleDir,
     });
     seen.add(name);
   }
@@ -166,11 +204,14 @@ export function composeRules(opts: ComposeOptions): ComposeResult {
     if (layer.scope === 'system') continue;
     for (const name of listLayerSubruleNames(layer)) {
       if (seen.has(name)) continue;
+      const resolved = resolveSubrulePath(layer.rulesDir, name);
+      if (!resolved) continue;
       composed.push({
         name,
-        sourcePath: path.join(layer.rulesDir, SUBRULES_DIR_NAME, `${name}.md`),
+        sourcePath: resolved.sourcePath,
         layerScope: layer.scope,
         layerAlias: layer.alias,
+        subruleDir: resolved.subruleDir,
       });
       seen.add(name);
     }
@@ -233,4 +274,78 @@ export function discoverRulesLayers(opts: { cwd?: string } = {}): RulesLayer[] {
 export function composeRulesFromState(opts: { preset?: string; cwd?: string } = {}): ComposeResult {
   const layers = discoverRulesLayers({ cwd: opts.cwd });
   return composeRules({ preset: opts.preset, layers });
+}
+
+/**
+ * hooks.yaml shape (the bare-map form, chosen for brevity):
+ *
+ *   <hookName>:
+ *     script: enforce.sh        # relative to the subrule dir
+ *     events: [PreToolUse]
+ *     matcher: "Edit|Write"     # optional
+ *     timeout: 30               # optional
+ *
+ * A wrapped `{ hooks: { <hookName>: {...} } }` form is also accepted so a
+ * hooks.yaml can carry sibling keys without confusing the parser.
+ */
+function parseSubruleHooksFile(file: string): Record<string, ManifestHook> {
+  const parsed = yaml.parse(fs.readFileSync(file, 'utf-8')) as
+    | Record<string, ManifestHook>
+    | { hooks?: Record<string, ManifestHook> }
+    | null;
+  if (!parsed || typeof parsed !== 'object') return {};
+  const map = (parsed as { hooks?: Record<string, ManifestHook> }).hooks ?? parsed;
+  return (map as Record<string, ManifestHook>) || {};
+}
+
+/**
+ * Collect hooks declared inside the active subrule directories.
+ *
+ * Resolves the same composed subrule set as {@link composeRules} (preset-named
+ * plus auto-append, highest-layer-wins per name). For each dir-form subrule
+ * that ships a `hooks.yaml`, parses it, rewrites each hook's `script` to an
+ * ABSOLUTE path under the subrule dir, and namespaces the key as
+ * `<subruleName>__<hookName>` to avoid collisions across subrules.
+ *
+ * Returns an empty map for flat subrules and dir-form subrules without a
+ * `hooks.yaml`. A malformed hooks.yaml is skipped (try/catch) so a bad file
+ * never breaks rule composition or hook registration.
+ */
+export function collectSubruleHooks(
+  layers: RulesLayer[],
+  presetName?: string
+): Record<string, ManifestHook> {
+  const result: Record<string, ManifestHook> = {};
+  let composed: ComposeResult;
+  try {
+    composed = composeRules({ preset: presetName, layers });
+  } catch {
+    return result;
+  }
+
+  for (const sub of composed.subrules) {
+    if (!sub.subruleDir) continue; // flat subrule — no hooks
+    const hooksFile = path.join(sub.subruleDir, SUBRULE_HOOKS_FILE);
+    if (!fs.existsSync(hooksFile)) continue;
+    try {
+      const hooks = parseSubruleHooksFile(hooksFile);
+      for (const [hookName, def] of Object.entries(hooks)) {
+        if (!def || typeof def !== 'object' || typeof def.script !== 'string') continue;
+        const absScript = path.resolve(sub.subruleDir, def.script);
+        result[`${sub.name}__${hookName}`] = { ...def, script: absScript };
+      }
+    } catch {
+      // Malformed hooks.yaml — skip this subrule's hooks, keep the rest.
+    }
+  }
+
+  return result;
+}
+
+/** Convenience wrapper — discovers layers from state, then collects hooks. */
+export function collectSubruleHooksFromState(
+  opts: { preset?: string; cwd?: string } = {}
+): Record<string, ManifestHook> {
+  const layers = discoverRulesLayers({ cwd: opts.cwd });
+  return collectSubruleHooks(layers, opts.preset);
 }

--- a/src/lib/staleness/checkers/rules.ts
+++ b/src/lib/staleness/checkers/rules.ts
@@ -63,7 +63,17 @@ function activeSources(agent: AgentId, version: string, cwd: string): Record<str
     if (fs.existsSync(yamlPath)) result['rules.yaml'] = yamlPath;
   }
   for (const sub of compose.subrules) {
-    result[`subrules/${sub.name}.md`] = sub.sourcePath;
+    // Key off the actual source path so dir-form subrules (subrules/<name>/rule.md)
+    // and flat ones (subrules/<name>.md) both fingerprint the file that really
+    // contributes to the output, not a hard-coded `.md` that may not exist.
+    if (sub.subruleDir) {
+      result[`subrules/${sub.name}/rule.md`] = sub.sourcePath;
+      // Fingerprint hooks.yaml too so editing a hook re-syncs the rules section.
+      const hooksFile = path.join(sub.subruleDir, 'hooks.yaml');
+      if (fs.existsSync(hooksFile)) result[`subrules/${sub.name}/hooks.yaml`] = hooksFile;
+    } else {
+      result[`subrules/${sub.name}.md`] = sub.sourcePath;
+    }
   }
   return result;
 }


### PR DESCRIPTION
## What

Lets a subrule be a **directory** `rules/subrules/<name>/` bundling its prose with its enforcement hooks:

```
subrules/<name>/
  rule.md       # the rule text (was subrules/<name>.md)
  hooks.yaml    # optional: 1..N hooks (the existing ManifestHook shape)
  *.sh          # guard scripts, resolved relative to this dir
```

Flat `subrules/<name>.md` keeps working unchanged — the dir form wins only when `<name>/rule.md` exists. This is the foundation for shipping a rule together with the hook that mechanically enforces it (the `git-guard.sh`+`git-guard.md` pattern, unified).

## How

- `compose.ts`: `resolveSubrulePath` (dir-or-flat) rewires `findSubrule` / `listLayerSubruleNames` / both append sites; new `collectSubruleHooks(layers, preset)` returns `Record<"<subrule>__<hook>", ManifestHook>` with `script` rewritten to an absolute path.
- `parseHookManifest` folds subrule hooks in as the **lowest-precedence** layer (user/system `agents.yaml` still win), try/catch-gated so a malformed `hooks.yaml` can't break rule sync.
- `registerHooksToSettings` registers already-absolute scripts by portable path; the `subrules/` tree joins the managed-hook prefixes for GC.
- `resources/rules.ts` duplicate resolver mirrors the dir-or-flat logic; staleness fingerprints the real `rule.md` + `hooks.yaml`.

## Verified

- `tsc --noEmit`: 0 errors. Affected tests: 43 rules + 54 hooks pass.
- End-to-end: a dir subrule with `hooks.yaml` composes its `rule.md` into output **and** registers its `PreToolUse` hook into a real `settings.json` (`REGISTERED: [...-> PreToolUse] ERRORS: []`); the guard script blocks a footer body (exit 2) and allows a clean one (exit 0).

## Context

Came out of a retro across 119 Claude/Codex sessions: the most-violated rules already exist in prose — they just aren't *enforced*. This unlocks co-locating the enforcing hook with each rule. Content (footer-strip, gh-merge-guard, etc.) ships separately in `.agents-system`.