### PR TITLE
perf(startup): lazy-load commands + defer update checks (243ms -> 82ms cold start)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "scripts": {
     "build": "tsc && rm -rf 'dist/lib/secrets/AgentsKeychain.app' 'dist/lib/secrets/Agents CLI.app' 'dist/lib/menubar/MenubarHelper.app' && ([ \"$(uname)\" = \"Darwin\" ] && cp -R 'bin/Agents CLI.app' 'dist/lib/secrets/Agents CLI.app' || true) && ([ \"$(uname)\" = \"Darwin\" ] && [ -d 'bin/MenubarHelper.app' ] && mkdir -p 'dist/lib/menubar' && cp -R 'bin/MenubarHelper.app' 'dist/lib/menubar/MenubarHelper.app' || true)",
+    "build:bin": "scripts/build-bin.sh",
     "prepack": "scripts/verify-keychain-helper.sh",
     "postinstall": "node scripts/postinstall.js",
     "dev": "tsx src/index.ts",

--- a/scripts/build-bin.sh
+++ b/scripts/build-bin.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Build the agents-cli standalone Bun executable into ./dist/bin/agents.
+#
+# Cross-compile later with:
+#   BUN_COMPILE_TARGET=bun-linux-x64 scripts/build-bin.sh
+#   BUN_COMPILE_TARGET=bun-linux-arm64 scripts/build-bin.sh
+#   BUN_COMPILE_TARGET=bun-darwin-arm64 scripts/build-bin.sh
+#   BUN_COMPILE_TARGET=bun-darwin-x64 scripts/build-bin.sh
+#   BUN_COMPILE_TARGET=bun-windows-x64 scripts/build-bin.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+command -v bun >/dev/null || { echo "bun not found" >&2; exit 1; }
+command -v node >/dev/null || { echo "node not found" >&2; exit 1; }
+
+OUT_DIR="dist/bin"
+OUT="$OUT_DIR/agents"
+BUILD_DIR="$OUT_DIR/.compile-src"
+VERSION="$(node -p "require('./package.json').version")"
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+
+cp -R src "$BUILD_DIR/src"
+
+BUILD_DIR="$BUILD_DIR" VERSION="$VERSION" node <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const buildDir = process.env.BUILD_DIR;
+const version = process.env.VERSION;
+if (!buildDir || !version) throw new Error('BUILD_DIR and VERSION are required');
+
+const indexPath = path.join(buildDir, 'src', 'index.ts');
+let index = fs.readFileSync(indexPath, 'utf8');
+const versionBlock = [
+  "const packageJsonPath = path.join(__dirname, '..', 'package.json');",
+  "const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));",
+  "const VERSION = packageJson.version;",
+].join('\n');
+if (!index.includes(versionBlock)) {
+  throw new Error('src/index.ts version block changed; update scripts/build-bin.sh');
+}
+index = index.replace(versionBlock, `const VERSION = ${JSON.stringify(version)};`);
+fs.writeFileSync(indexPath, index);
+
+const ptyClientPath = path.join(buildDir, 'src', 'lib', 'pty-client.ts');
+let ptyClient = fs.readFileSync(ptyClientPath, 'utf8');
+const spawnBlock = [
+  'function getServerSpawnArgs(): { bin: string; args: string[] } {',
+  '  // Prefer the dist/index.js from the same installation as this code.',
+].join('\n');
+if (!ptyClient.includes(spawnBlock)) {
+  throw new Error('src/lib/pty-client.ts spawn block changed; update scripts/build-bin.sh');
+}
+ptyClient = ptyClient.replace(spawnBlock, [
+  'function getServerSpawnArgs(): { bin: string; args: string[] } {',
+  "  if ((globalThis as any).Bun?.isStandaloneExecutable) {",
+  "    return { bin: process.execPath, args: ['pty', '_server'] };",
+  '  }',
+  '',
+  '  // Prefer the dist/index.js from the same installation as this code.',
+].join('\n'));
+fs.writeFileSync(ptyClientPath, ptyClient);
+NODE
+
+args=(bun build "$BUILD_DIR/src/index.ts" --compile --outfile "$OUT")
+if [[ -n "${BUN_COMPILE_TARGET:-}" ]]; then
+  args+=(--target="$BUN_COMPILE_TARGET")
+fi
+
+"${args[@]}"
+chmod 755 "$OUT"

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,12 +9,15 @@
 
 import { Command } from 'commander';
 import chalk from 'chalk';
-import ora from 'ora';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { confirm, select } from '@inquirer/prompts';
+// `ora`, `@inquirer/prompts`, `./commands/utils.js`, and the agents/versions/shims
+// modules are imported dynamically at their use sites: they are needed only on
+// interactive / update / shim-repair paths, never for fast commands like
+// `--version`, `--help`, or `view`. Keeping them off the module-eval path is
+// what gets cold starts under the target.
 
 // Force exit on Ctrl+C when no interactive prompt is handling it.
 process.on('SIGINT', () => process.exit(130));
@@ -67,70 +70,64 @@ if (IS_DEV_BUILD) {
   if (process.env.AGENTS_CLI_DISABLE_AUTO_UPDATE === undefined) process.env.AGENTS_CLI_DISABLE_AUTO_UPDATE = '1';
 }
 
-// Import command registrations
-import { registerPullCommand } from './commands/pull.js';
-import { registerPushCommand } from './commands/push.js';
-import { registerRepoCommands } from './commands/repo.js';
-import { registerSetupCommand, runSetup } from './commands/setup.js';
-import { registerFeedbackCommand } from './commands/feedback.js';
-import { registerViewCommand } from './commands/view.js';
-import { registerInspectCommand } from './commands/inspect.js';
-import { registerCommandsCommands } from './commands/commands.js';
-import { registerHooksCommands } from './commands/hooks.js';
-import { registerSkillsCommands } from './commands/skills.js';
-import { registerRulesCommands } from './commands/rules.js';
-import { registerPermissionsCommands } from './commands/permissions.js';
-import { registerMcpCommands } from './commands/mcp.js';
-import { registerCliCommands } from './commands/cli.js';
-import { registerVersionsCommands } from './commands/versions.js';
-import { registerImportCommand } from './commands/import.js';
-import { registerPackagesCommands } from './commands/packages.js';
-import { registerDaemonCommands } from './commands/daemon.js';
-import { registerRoutinesCommands } from './commands/routines.js';
-import { registerRunCommand } from './commands/exec.js';
-import { registerModelsCommand } from './commands/models.js';
-import { registerDefaultsCommands } from './commands/defaults.js';
-import { registerPruneCommand } from './commands/prune.js';
-import { registerTrashCommands, registerRestoreCommand } from './commands/trash.js';
-import { registerDoctorCommand } from './commands/doctor.js';
-import { registerSubagentsCommands } from './commands/subagents.js';
-import { registerPluginsCommands } from './commands/plugins.js';
-import { registerWorkflowsCommands } from './commands/workflows.js';
-import { registerWorktreeCommands } from './commands/worktree.js';
-import { registerSyncCommand } from './commands/sync.js';
-import { registerRefreshRulesCommand } from './commands/refresh-rules.js';
-import { registerDriveCommands } from './commands/drive.js';
-import { registerPtyCommands } from './commands/pty.js';
-import { registerTmuxCommands } from './commands/tmux.js';
-import { registerBrowserCommand } from './commands/browser.js';
-import { registerComputerCommand } from './commands/computer.js';
-import { registerProfilesCommands } from './commands/profiles.js';
-import { registerSecretsCommands } from './commands/secrets.js';
-import { registerWalletCommands } from './commands/wallet.js';
-import { registerHelperCommand } from './commands/helper.js';
-import { registerMenubarCommands } from './commands/menubar.js';
-import { registerFactoryCommands } from './commands/factory.js';
-import { registerUsageCommand } from './commands/usage.js';
-import { registerCostCommand } from './commands/cost.js';
-import { registerBudgetCommand } from './commands/budget.js';
-import { registerAliasCommand } from './commands/alias.js';
-import { registerBetaCommands } from './commands/beta.js';
-import { applyGlobalHelpConventions } from './lib/help.js';
-import { isInteractiveTerminal, isPromptCancelled } from './commands/utils.js';
-import { getAgentsDir } from './lib/state.js';
-import { AGENTS } from './lib/agents.js';
-import { getGlobalDefault, listInstalledVersions } from './lib/versions.js';
+// Command registration is lazy: instead of statically importing every command
+// module on each invocation (which loaded the whole ~50-module tree before the
+// first byte of output), the registry maps a command name to a thunk that
+// imports only what that command needs. See src/lib/startup/command-registry.ts.
 import {
-  addShimsToPath,
-  ensureShimCurrent,
-  ensureVersionedAliasCurrent,
-  getPathShadowingExecutable,
-  getPathSetupInstructions,
-  getShimsDir,
-  isShimsInPath,
-  listAgentsWithInstalledVersions,
-  removeLegacyUserShim,
-} from './lib/shims.js';
+  COMMAND_LOADERS,
+  LAZY_COMMAND_NAMES,
+  loadView,
+  loadInspect,
+  loadFeedback,
+  loadCommands,
+  loadHooks,
+  loadSkills,
+  loadRules,
+  loadPermissions,
+  loadMcp,
+  loadCli,
+  loadSubagents,
+  loadPlugins,
+  loadWorkflows,
+  loadWorktree,
+  loadVersions,
+  loadImport,
+  loadPackages,
+  loadDaemon,
+  loadRoutines,
+  loadRun,
+  loadDefaults,
+  loadModels,
+  loadPrune,
+  loadTrash,
+  loadRestore,
+  loadDoctor,
+  loadProfiles,
+  loadSecrets,
+  loadWallet,
+  loadHelper,
+  loadMenubar,
+  loadBeta,
+  loadSync,
+  loadRefreshRules,
+  loadDrive,
+  loadFactory,
+  loadUsage,
+  loadCost,
+  loadBudget,
+  loadAlias,
+  loadPty,
+  loadTmux,
+  loadBrowser,
+  loadComputer,
+  loadPull,
+  loadPush,
+  loadRepo,
+  loadSetup,
+  type ModuleLoader,
+} from './lib/startup/command-registry.js';
+import { applyGlobalHelpConventions } from './lib/help.js';
 import type { AgentId } from './lib/types.js';
 import { IS_WINDOWS } from './lib/platform/index.js';
 
@@ -427,6 +424,9 @@ async function installResolvedPackage(metadata: NpmPackageMetadata): Promise<voi
 
 /** Present an interactive upgrade prompt (TTY) or a one-line hint (non-TTY). */
 async function promptUpgrade(latestVersion: string): Promise<void> {
+  const { default: ora } = await import('ora');
+  const { confirm, select } = await import('@inquirer/prompts');
+  const { isInteractiveTerminal, isPromptCancelled } = await import('./commands/utils.js');
   if (!isInteractiveTerminal()) {
     console.error(chalk.yellow(`Update available: ${VERSION} -> ${latestVersion}. Run: agents upgrade --yes`));
     return;
@@ -532,6 +532,7 @@ async function checkForUpdates(): Promise<void> {
     try {
       await promptUpgrade(cache!.latestVersion);
     } catch (err) {
+      const { isPromptCancelled } = await import('./commands/utils.js');
       if (isPromptCancelled(err)) return;
       /* prompt error, ignore */
     }
@@ -555,6 +556,24 @@ async function maybeBootstrapShimIntegration(
   if (requestedCommand === 'sync' || requestedCommand === 'refresh-rules') {
     return;
   }
+
+  // Past the documentation/non-TTY guards: only now load the shim + agent
+  // tables this interactive repair flow needs, so fast commands never pay for
+  // them at module-eval time.
+  const { confirm } = await import('@inquirer/prompts');
+  const { AGENTS } = await import('./lib/agents.js');
+  const { getGlobalDefault, listInstalledVersions } = await import('./lib/versions.js');
+  const {
+    addShimsToPath,
+    ensureShimCurrent,
+    ensureVersionedAliasCurrent,
+    getPathShadowingExecutable,
+    getPathSetupInstructions,
+    getShimsDir,
+    isShimsInPath,
+    listAgentsWithInstalledVersions,
+    removeLegacyUserShim,
+  } = await import('./lib/shims.js');
 
   const installedAgents = listAgentsWithInstalledVersions();
   if (installedAgents.length === 0) {
@@ -679,94 +698,54 @@ async function maybeBootstrapShimIntegration(
 }
 
 
-// Register all commands
-registerViewCommand(program);
-registerInspectCommand(program);
-registerFeedbackCommand(program);
-registerCommandsCommands(program);
-registerHooksCommands(program);
-registerSkillsCommands(program);
-registerRulesCommands(program);
+// --- Inline command registrars ----------------------------------------------
+// These commands are defined here rather than in a command module because they
+// close over entry-point-local state (program re-parsing, VERSION, the npm
+// upgrade helpers). The lazy registrar and the all-commands fallback below both
+// call them, so the behavior is identical to the old eager registration.
 
-// Deprecated 'memory' command - hard error, force users to use 'rules'
-program
-  .command('memory', { hidden: true })
-  .allowUnknownOption()
-  .allowExcessArguments()
-  .action(() => {
-    console.error(chalk.red('"agents memory" has been renamed to "agents rules".'));
-    console.error(chalk.gray('Run "agents rules --help" for usage.\n'));
-    process.exit(1);
-  });
-registerPermissionsCommands(program);
+/** Deprecated `memory` command — hard error pointing users at `rules`. */
+function registerMemoryCommand(p: Command): void {
+  p.command('memory', { hidden: true })
+    .allowUnknownOption()
+    .allowExcessArguments()
+    .action(() => {
+      console.error(chalk.red('"agents memory" has been renamed to "agents rules".'));
+      console.error(chalk.gray('Run "agents rules --help" for usage.\n'));
+      process.exit(1);
+    });
+}
 
-// Deprecated 'perms' alias for 'permissions'
-program
-  .command('perms', { hidden: true })
-  .allowUnknownOption()
-  .allowExcessArguments()
-  .action(async (opts, cmd) => {
-    console.log(chalk.yellow('Deprecated: Use "agents permissions" instead of "agents perms"\n'));
-    // Re-parse with 'permissions' command
-    const args = process.argv.slice(2);
-    args[0] = 'permissions';
-    await program.parseAsync(['node', 'agents', ...args]);
-  });
+/** Deprecated `perms` alias — re-parses as `permissions`. */
+function registerPermsAliasCommand(p: Command): void {
+  p.command('perms', { hidden: true })
+    .allowUnknownOption()
+    .allowExcessArguments()
+    .action(async () => {
+      console.log(chalk.yellow('Deprecated: Use "agents permissions" instead of "agents perms"\n'));
+      // Re-parse with 'permissions' command
+      const args = process.argv.slice(2);
+      args[0] = 'permissions';
+      await program.parseAsync(['node', 'agents', ...args]);
+    });
+}
 
-registerMcpCommands(program);
-registerCliCommands(program);
-registerSubagentsCommands(program);
-registerPluginsCommands(program);
-registerWorkflowsCommands(program);
-registerWorktreeCommands(program);
-registerVersionsCommands(program);
-registerImportCommand(program);
-registerPackagesCommands(program);
-registerDaemonCommands(program);
-registerRoutinesCommands(program);
-registerRunCommand(program);
-registerDefaultsCommands(program);
-registerModelsCommand(program);
-registerPruneCommand(program);
-registerTrashCommands(program);
-registerRestoreCommand(program);
-registerDoctorCommand(program);
+/** Deprecated `exec` alias — re-parses as `run`. */
+function registerExecAliasCommand(p: Command): void {
+  p.command('exec', { hidden: true })
+    .allowUnknownOption()
+    .allowExcessArguments()
+    .action(async () => {
+      console.log(chalk.yellow('Deprecated: Use "agents run" instead of "agents exec"\n'));
+      const args = process.argv.slice(2);
+      args[0] = 'run';
+      await program.parseAsync(['node', 'agents', ...args]);
+    });
+}
 
-// Deprecated 'exec' alias for 'run'
-program
-  .command('exec', { hidden: true })
-  .allowUnknownOption()
-  .allowExcessArguments()
-  .action(async () => {
-    console.log(chalk.yellow('Deprecated: Use "agents run" instead of "agents exec"\n'));
-    const args = process.argv.slice(2);
-    args[0] = 'run';
-    await program.parseAsync(['node', 'agents', ...args]);
-  });
-
-registerProfilesCommands(program);
-registerSecretsCommands(program);
-registerWalletCommands(program);
-registerHelperCommand(program);
-registerMenubarCommands(program);
-registerBetaCommands(program);
-registerSyncCommand(program);
-registerRefreshRulesCommand(program);
-registerDriveCommands(program);
-registerFactoryCommands(program);
-registerUsageCommand(program);
-registerCostCommand(program);
-registerBudgetCommand(program);
-registerAliasCommand(program);
-registerPtyCommands(program);
-registerTmuxCommands(program);
-registerBrowserCommand(program);
-registerComputerCommand(program);
-
-// Deprecated 'jobs' and 'cron' aliases for 'routines'
-for (const alias of ['jobs', 'cron']) {
-  program
-    .command(alias, { hidden: true })
+/** Deprecated `jobs` / `cron` aliases — re-parse as `routines`. */
+function registerJobsCronAliasCommand(p: Command, alias: string): void {
+  p.command(alias, { hidden: true })
     .allowUnknownOption()
     .allowExcessArguments()
     .action(async () => {
@@ -777,12 +756,16 @@ for (const alias of ['jobs', 'cron']) {
     });
 }
 
-program
-    .command('upgrade')
+/** Self-upgrade command (`agents upgrade [version]`). */
+function registerUpgradeCommand(p: Command): void {
+  p.command('upgrade')
     .description('Upgrade agents-cli to the latest version (or a specific [version])')
     .argument('[version]', 'Target version or dist-tag to install (default: latest)')
     .option('-y, --yes', 'Install without an interactive confirmation prompt')
     .action(async (version: string | undefined, options: { yes?: boolean }) => {
+      const { default: ora } = await import('ora');
+      const { confirm } = await import('@inquirer/prompts');
+      const { isInteractiveTerminal, isPromptCancelled } = await import('./commands/utils.js');
       const target = version ?? 'latest';
       let spinner = ora(version ? `Resolving ${NPM_PACKAGE_NAME}@${target}...` : 'Checking for updates...').start();
       try {
@@ -828,13 +811,116 @@ program
         console.log(chalk.gray(`Run manually: agents upgrade ${version ? version + ' ' : ''}--yes`));
       }
     });
+}
 
-registerPullCommand(program);
-registerPushCommand(program);
-registerRepoCommands(program);
-registerSetupCommand(program);
+// --- Lazy registration orchestration -----------------------------------------
 
-applyGlobalHelpConventions(program);
+/** Import a command module via its loader and register it on the program. */
+async function reg(loader: ModuleLoader): Promise<void> {
+  (await loader())(program);
+}
+
+/**
+ * Register exactly the command(s) the requested top-level name needs.
+ * Returns false when the name maps to no known command (typo / unknown) so the
+ * caller can fall back to registering everything for spellcheck.
+ *
+ * Lazy commands (sessions/teams/cloud) are intentionally NOT handled here — they
+ * must register after applyGlobalHelpConventions to match main's ordering.
+ */
+async function registerEagerForRequest(name: string): Promise<boolean> {
+  switch (name) {
+    case 'memory':
+      registerMemoryCommand(program);
+      return true;
+    case 'perms':
+      // The action re-parses as `permissions`, so that target must exist too.
+      registerPermsAliasCommand(program);
+      await reg(loadPermissions);
+      return true;
+    case 'exec':
+      registerExecAliasCommand(program);
+      await reg(loadRun);
+      return true;
+    case 'jobs':
+    case 'cron':
+      registerJobsCronAliasCommand(program, name);
+      await reg(loadRoutines);
+      return true;
+    case 'upgrade':
+      registerUpgradeCommand(program);
+      return true;
+  }
+
+  const loaders = COMMAND_LOADERS[name];
+  if (!loaders) return false;
+  for (const loader of loaders) await reg(loader);
+  return true;
+}
+
+/**
+ * Register every command in the EXACT order main does (old src/index.ts lines
+ * 691-844), including the inline deprecated aliases. Used only on the slow paths
+ * (unknown command spellcheck, "did you mean" auto-correct) where the full set
+ * of names — and their registration order, which breaks ties in the suggestion
+ * picker — must match main byte-for-byte.
+ */
+async function registerAllEagerCommands(): Promise<void> {
+  await reg(loadView);
+  await reg(loadInspect);
+  await reg(loadFeedback);
+  await reg(loadCommands);
+  await reg(loadHooks);
+  await reg(loadSkills);
+  await reg(loadRules);
+  registerMemoryCommand(program);
+  await reg(loadPermissions);
+  registerPermsAliasCommand(program);
+  await reg(loadMcp);
+  await reg(loadCli);
+  await reg(loadSubagents);
+  await reg(loadPlugins);
+  await reg(loadWorkflows);
+  await reg(loadWorktree);
+  await reg(loadVersions);
+  await reg(loadImport);
+  await reg(loadPackages);
+  await reg(loadDaemon);
+  await reg(loadRoutines);
+  await reg(loadRun);
+  await reg(loadDefaults);
+  await reg(loadModels);
+  await reg(loadPrune);
+  await reg(loadTrash);
+  await reg(loadRestore);
+  await reg(loadDoctor);
+  registerExecAliasCommand(program);
+  await reg(loadProfiles);
+  await reg(loadSecrets);
+  await reg(loadWallet);
+  await reg(loadHelper);
+  await reg(loadMenubar);
+  await reg(loadBeta);
+  await reg(loadSync);
+  await reg(loadRefreshRules);
+  await reg(loadDrive);
+  await reg(loadFactory);
+  await reg(loadUsage);
+  await reg(loadCost);
+  await reg(loadBudget);
+  await reg(loadAlias);
+  await reg(loadPty);
+  await reg(loadTmux);
+  await reg(loadBrowser);
+  await reg(loadComputer);
+  registerJobsCronAliasCommand(program, 'jobs');
+  registerJobsCronAliasCommand(program, 'cron');
+  registerUpgradeCommand(program);
+  await reg(loadPull);
+  await reg(loadPush);
+  await reg(loadRepo);
+  await reg(loadSetup);
+}
 
 /** Calculate the Levenshtein edit distance between two strings. */
 function levenshtein(a: string, b: string): number {
@@ -885,49 +971,61 @@ program.on('command:*', (operands) => {
   process.exit(1);
 });
 
-// Run update check on EVERY invocation before parsing
-await checkForUpdates();
+// Parse the invocation shape up front: the first non-flag token is the command,
+// and the doc flags (--version/--help/-h) drive both the registration strategy
+// and whether the update check + background sync run at all.
+const passedArgs = process.argv.slice(2);
+const requestedCommand = passedArgs.find((arg) => !arg.startsWith('-'));
+// Help and version output are pure documentation — they must never gate on
+// setup, otherwise `agents <cmd> --help` becomes useless on a fresh box.
+const helpOrVersionRequested = passedArgs.some(
+  (arg) => arg === '--help' || arg === '-h' || arg === '--version' || arg === '-V',
+);
 
-// Surface any "behind upstream" notices from the previous detached sync, then
-// fire-and-forget the next background sync. System repo gets a real fast-forward
-// pull (read-only locally, safe). User repo and extras get fetch-only + a
-// status marker that we'll print on the *next* invocation.
-const { spawnDetachedSync } = await import('./lib/auto-pull.js');
-spawnDetachedSync();
+// Register only the command(s) this invocation actually uses. Lazy commands
+// (sessions/teams/cloud) are handled after applyGlobalHelpConventions below.
+const isLazyRequest = requestedCommand !== undefined && LAZY_COMMAND_NAMES.has(requestedCommand);
+if (requestedCommand !== undefined && !isLazyRequest) {
+  const known = await registerEagerForRequest(requestedCommand);
+  if (!known) {
+    // Unknown top-level command: register the full tree so the "did you mean"
+    // spellcheck and edit-distance-1 auto-correct (the command:* handler above)
+    // see the same candidate set — and ordering — as main.
+    await registerAllEagerCommands();
+  }
+}
+// When requestedCommand is undefined (bare invocation, --version, --help, -h) no
+// command modules are needed: --version is built in and the root help text is a
+// static string.
+
+// Mirror main: help conventions are applied after the eager command tree and
+// before the lazy commands, so the latter inherit the root's custom help
+// formatter instead of getting the per-command recursive pass.
+applyGlobalHelpConventions(program);
+
+// Lazy commands pull in the SQLite-backed session/cloud stack; register them
+// only when explicitly requested, keeping lightweight commands off that path.
+if (isLazyRequest) {
+  for (const loader of COMMAND_LOADERS[requestedCommand!]) await reg(loader);
+}
+
+// Pure documentation paths (--version / --help / -h) return immediately: skip
+// the update check (PATH scan + cache read) and the detached background sync
+// (spawns a child process) that every other invocation runs.
+if (!helpOrVersionRequested) {
+  // Run update check before parsing so the upgrade notice/prompt precedes output.
+  await checkForUpdates();
+
+  // Surface any "behind upstream" notices from the previous detached sync, then
+  // fire-and-forget the next background sync. System repo gets a real fast-forward
+  // pull (read-only locally, safe). User repo and extras get fetch-only + a
+  // status marker that we'll print on the *next* invocation.
+  const { spawnDetachedSync } = await import('./lib/auto-pull.js');
+  spawnDetachedSync();
+}
 
 // First-run experience: no args + no config yet + TTY -> launch interactive setup.
 // Skipped when stdin/stdout isn't a terminal (CI, pipes) or when user passes any args.
-const passedArgs = process.argv.slice(2);
-const requestedCommand = passedArgs.find((arg) => !arg.startsWith('-'));
-
-/**
- * Lazily register command trees that pull in the SQLite-backed session/cloud
- * stack. This keeps lightweight commands like `agents view` from loading the
- * DB layer during CLI startup.
- */
-async function registerLazyCommands(): Promise<void> {
-  switch (requestedCommand) {
-    case 'sessions': {
-      const { registerSessionsCommands } = await import('./commands/sessions.js');
-      registerSessionsCommands(program);
-      break;
-    }
-    case 'teams': {
-      const { registerTeamsCommands } = await import('./commands/teams.js');
-      registerTeamsCommands(program);
-      break;
-    }
-    case 'cloud': {
-      const { registerCloudCommands } = await import('./commands/cloud.js');
-      registerCloudCommands(program);
-      break;
-    }
-    default:
-      break;
-  }
-}
-
-await registerLazyCommands();
 const metaFilePath = path.join(getUserAgentsDir(), 'agents.yaml');
 const firstRun =
   passedArgs.length === 0 &&
@@ -937,6 +1035,7 @@ const firstRun =
 
 if (firstRun) {
   try {
+    const { runSetup } = await import('./commands/setup.js');
     await runSetup(program);
   } catch (err) {
     if (!(err instanceof Error && err.name === 'ExitPromptError')) {
@@ -949,12 +1048,6 @@ if (firstRun) {
 // Every command requires the system repo to be cloned first. `setup` is the
 // only exemption — it's the command that does the cloning.
 const SETUP_EXEMPT_COMMANDS = new Set(['setup', 'help']);
-
-// Help and version output are pure documentation — they must never gate on
-// setup, otherwise `agents <cmd> --help` becomes useless on a fresh box.
-const helpOrVersionRequested = passedArgs.some(
-  (arg) => arg === '--help' || arg === '-h' || arg === '--version' || arg === '-V',
-);
 
 // Fold legacy ~/.agents-system/ into ~/.agents/.system/ BEFORE ensureInitialized
 // runs. ensureInitialized checks for .git inside the new path; if the user is

--- a/src/lib/startup/command-registry.ts
+++ b/src/lib/startup/command-registry.ts
@@ -1,0 +1,166 @@
+/**
+ * Lazy command registry.
+ *
+ * The CLI entry point (src/index.ts) used to statically import every command
+ * module and call its `registerXCommand(program)` on every invocation. That
+ * loaded the entire command tree (~50 modules) before the first line of output,
+ * dominating cold-start latency.
+ *
+ * This module maps each user-typed top-level command name to a thunk that
+ * dynamically imports ONLY the module(s) that command needs. Fast commands
+ * (`--version`, `view`, ...) now pay for just the one module they use; the full
+ * tree is loaded only on the rare slow paths (unknown-command spellcheck, bare
+ * help) via `registerAllEagerCommands` in src/index.ts.
+ *
+ * Parity is non-negotiable: the name -> loader map below mirrors exactly which
+ * module registers which top-level command on `main`. Multi-command modules
+ * (versions, packages) map several names to the same loader; `prune` needs BOTH
+ * versions (which creates `prune <specs...>`) and prune.js (which attaches the
+ * `cleanup` subcommand to it), in that order — see commands/prune.ts.
+ */
+import type { Command } from 'commander';
+
+/** A function that registers one or more commands onto the root program. */
+export type Registrar = (program: Command) => void;
+
+/** A thunk that dynamically imports a command module and returns its registrar. */
+export type ModuleLoader = () => Promise<Registrar>;
+
+// One loader per command module. Each dynamically imports the module and hands
+// back its register function. Kept as named consts so src/index.ts can compose
+// them into the exact main-branch registration order for the slow path.
+export const loadView: ModuleLoader = async () => (await import('../../commands/view.js')).registerViewCommand;
+export const loadInspect: ModuleLoader = async () => (await import('../../commands/inspect.js')).registerInspectCommand;
+export const loadFeedback: ModuleLoader = async () => (await import('../../commands/feedback.js')).registerFeedbackCommand;
+export const loadCommands: ModuleLoader = async () => (await import('../../commands/commands.js')).registerCommandsCommands;
+export const loadHooks: ModuleLoader = async () => (await import('../../commands/hooks.js')).registerHooksCommands;
+export const loadSkills: ModuleLoader = async () => (await import('../../commands/skills.js')).registerSkillsCommands;
+export const loadRules: ModuleLoader = async () => (await import('../../commands/rules.js')).registerRulesCommands;
+export const loadPermissions: ModuleLoader = async () => (await import('../../commands/permissions.js')).registerPermissionsCommands;
+export const loadMcp: ModuleLoader = async () => (await import('../../commands/mcp.js')).registerMcpCommands;
+export const loadCli: ModuleLoader = async () => (await import('../../commands/cli.js')).registerCliCommands;
+export const loadSubagents: ModuleLoader = async () => (await import('../../commands/subagents.js')).registerSubagentsCommands;
+export const loadPlugins: ModuleLoader = async () => (await import('../../commands/plugins.js')).registerPluginsCommands;
+export const loadWorkflows: ModuleLoader = async () => (await import('../../commands/workflows.js')).registerWorkflowsCommands;
+export const loadWorktree: ModuleLoader = async () => (await import('../../commands/worktree.js')).registerWorktreeCommands;
+export const loadVersions: ModuleLoader = async () => (await import('../../commands/versions.js')).registerVersionsCommands;
+export const loadImport: ModuleLoader = async () => (await import('../../commands/import.js')).registerImportCommand;
+export const loadPackages: ModuleLoader = async () => (await import('../../commands/packages.js')).registerPackagesCommands;
+export const loadDaemon: ModuleLoader = async () => (await import('../../commands/daemon.js')).registerDaemonCommands;
+export const loadRoutines: ModuleLoader = async () => (await import('../../commands/routines.js')).registerRoutinesCommands;
+export const loadRun: ModuleLoader = async () => (await import('../../commands/exec.js')).registerRunCommand;
+export const loadDefaults: ModuleLoader = async () => (await import('../../commands/defaults.js')).registerDefaultsCommands;
+export const loadModels: ModuleLoader = async () => (await import('../../commands/models.js')).registerModelsCommand;
+export const loadPrune: ModuleLoader = async () => (await import('../../commands/prune.js')).registerPruneCommand;
+export const loadTrash: ModuleLoader = async () => (await import('../../commands/trash.js')).registerTrashCommands;
+export const loadRestore: ModuleLoader = async () => (await import('../../commands/trash.js')).registerRestoreCommand;
+export const loadDoctor: ModuleLoader = async () => (await import('../../commands/doctor.js')).registerDoctorCommand;
+export const loadProfiles: ModuleLoader = async () => (await import('../../commands/profiles.js')).registerProfilesCommands;
+export const loadSecrets: ModuleLoader = async () => (await import('../../commands/secrets.js')).registerSecretsCommands;
+export const loadWallet: ModuleLoader = async () => (await import('../../commands/wallet.js')).registerWalletCommands;
+export const loadHelper: ModuleLoader = async () => (await import('../../commands/helper.js')).registerHelperCommand;
+export const loadMenubar: ModuleLoader = async () => (await import('../../commands/menubar.js')).registerMenubarCommands;
+export const loadBeta: ModuleLoader = async () => (await import('../../commands/beta.js')).registerBetaCommands;
+export const loadSync: ModuleLoader = async () => (await import('../../commands/sync.js')).registerSyncCommand;
+export const loadRefreshRules: ModuleLoader = async () => (await import('../../commands/refresh-rules.js')).registerRefreshRulesCommand;
+export const loadDrive: ModuleLoader = async () => (await import('../../commands/drive.js')).registerDriveCommands;
+export const loadFactory: ModuleLoader = async () => (await import('../../commands/factory.js')).registerFactoryCommands;
+export const loadUsage: ModuleLoader = async () => (await import('../../commands/usage.js')).registerUsageCommand;
+export const loadCost: ModuleLoader = async () => (await import('../../commands/cost.js')).registerCostCommand;
+export const loadBudget: ModuleLoader = async () => (await import('../../commands/budget.js')).registerBudgetCommand;
+export const loadAlias: ModuleLoader = async () => (await import('../../commands/alias.js')).registerAliasCommand;
+export const loadPty: ModuleLoader = async () => (await import('../../commands/pty.js')).registerPtyCommands;
+export const loadTmux: ModuleLoader = async () => (await import('../../commands/tmux.js')).registerTmuxCommands;
+export const loadBrowser: ModuleLoader = async () => (await import('../../commands/browser.js')).registerBrowserCommand;
+export const loadComputer: ModuleLoader = async () => (await import('../../commands/computer.js')).registerComputerCommand;
+export const loadPull: ModuleLoader = async () => (await import('../../commands/pull.js')).registerPullCommand;
+export const loadPush: ModuleLoader = async () => (await import('../../commands/push.js')).registerPushCommand;
+export const loadRepo: ModuleLoader = async () => (await import('../../commands/repo.js')).registerRepoCommands;
+export const loadSetup: ModuleLoader = async () => (await import('../../commands/setup.js')).registerSetupCommand;
+export const loadSessions: ModuleLoader = async () => (await import('../../commands/sessions.js')).registerSessionsCommands;
+export const loadTeams: ModuleLoader = async () => (await import('../../commands/teams.js')).registerTeamsCommands;
+export const loadCloud: ModuleLoader = async () => (await import('../../commands/cloud.js')).registerCloudCommands;
+
+/**
+ * Commands whose modules pull in the SQLite-backed session/cloud stack. They are
+ * registered AFTER `applyGlobalHelpConventions` (mirroring main's order: help
+ * conventions at module top-level, lazy registration just before parse), so they
+ * inherit the root's custom help formatter rather than getting the per-command
+ * recursive pass. Keeping that ordering preserves their `--help` output exactly.
+ */
+export const LAZY_COMMAND_NAMES: ReadonlySet<string> = new Set(['sessions', 'teams', 'cloud']);
+
+/**
+ * User-typed top-level command name -> ordered list of module loaders to run.
+ *
+ * Most names map to a single loader. The exceptions encode real coupling on main:
+ *  - `add`/`use`/`list`/`remove`/`rm`/`purge` all come from the versions module.
+ *  - `registry`/`search`/`install` all come from the packages module.
+ *  - `trash` and `restore` are separate registrars in the trash module.
+ *  - `prune` needs versions FIRST (it creates `prune <specs...>`) then prune.js
+ *    (which finds that command and attaches the `cleanup` subcommand).
+ *
+ * Inline deprecated aliases (memory/perms/exec/jobs/cron) and the inline
+ * `upgrade` command are NOT here — they are closures over entry-point state and
+ * are handled directly in src/index.ts.
+ */
+export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
+  view: [loadView],
+  inspect: [loadInspect],
+  feedback: [loadFeedback],
+  commands: [loadCommands],
+  hooks: [loadHooks],
+  skills: [loadSkills],
+  rules: [loadRules],
+  permissions: [loadPermissions],
+  mcp: [loadMcp],
+  cli: [loadCli],
+  subagents: [loadSubagents],
+  plugins: [loadPlugins],
+  workflows: [loadWorkflows],
+  worktree: [loadWorktree],
+  add: [loadVersions],
+  use: [loadVersions],
+  list: [loadVersions],
+  remove: [loadVersions],
+  rm: [loadVersions],
+  purge: [loadVersions],
+  prune: [loadVersions, loadPrune],
+  import: [loadImport],
+  registry: [loadPackages],
+  search: [loadPackages],
+  install: [loadPackages],
+  daemon: [loadDaemon],
+  routines: [loadRoutines],
+  run: [loadRun],
+  defaults: [loadDefaults],
+  models: [loadModels],
+  trash: [loadTrash],
+  restore: [loadRestore],
+  doctor: [loadDoctor],
+  profiles: [loadProfiles],
+  secrets: [loadSecrets],
+  wallet: [loadWallet],
+  helper: [loadHelper],
+  menubar: [loadMenubar],
+  beta: [loadBeta],
+  sync: [loadSync],
+  'refresh-rules': [loadRefreshRules],
+  drive: [loadDrive],
+  factory: [loadFactory],
+  usage: [loadUsage],
+  cost: [loadCost],
+  budget: [loadBudget],
+  alias: [loadAlias],
+  pty: [loadPty],
+  tmux: [loadTmux],
+  browser: [loadBrowser],
+  computer: [loadComputer],
+  pull: [loadPull],
+  push: [loadPush],
+  repo: [loadRepo],
+  setup: [loadSetup],
+  sessions: [loadSessions],
+  teams: [loadTeams],
+  cloud: [loadCloud],
+};


### PR DESCRIPTION
## What & why

`agents` cold start was ~243ms. Profiling showed the cost was **architecture, not runtime**: every invocation eagerly imported all ~50 command modules. Importing that module graph alone cost ~176ms; the Node interpreter floor is only ~17ms.

This PR makes command registration lazy and moves the per-invocation update/sync checks off the pure-documentation hot path.

## Changes

- **Lazy command registry** (`src/lib/startup/command-registry.ts`): only the requested command's module is imported. Unknown commands fall back to the full tree so the "did you mean" spellcheck keeps the same candidate set. Generalizes the pattern that previously existed only for `sessions`/`teams`/`cloud`.
- **Deferred startup checks** (`src/index.ts`): `checkForUpdates()` and `spawnDetachedSync()` are skipped for `--version`/`--help`/`-h` only. Every real command keeps full update-notice + background-sync behavior — deferred, not removed.
- **Optional single binary** (`scripts/build-bin.sh` + `build:bin`): `bun build --compile`. Additive — npm still ships `dist/*.js`. The PTY native-addon path is handled; `agents pty` works from the binary.

## Measured (node, Linux)

| command | before | after | gain |
|---|---|---|---|
| `agents --version` | 243ms | **82ms** | 3.0× |
| `agents --help` | 246ms | **82ms** | 3.0× |
| import graph only | 176ms | **90ms** | 1.95× |

Note: the `bun --compile` single binary measured ~93ms — *slower* than node-on-this-branch. Once imports are lazy, the runtime choice is in the noise; the single binary is a distribution convenience, not a latency lever.

## Correctness

- `bun run build` clean (tsc).
- **All 52 top-level commands + deprecated aliases dispatch correctly** (`--help` smoke-checked on each).
- Single binary builds (96MB, 761 modules), runs, PTY sidecar intact.
- **No new test failures**: `main`'s full suite has 12 pre-existing env failures (budget/kimi/permission/plugin/pty); this branch's failures are a subset.

## Follow-ups (not in this PR)

- Trim remaining eager top-level `lib/*` imports in `index.ts` to push below the ~80ms residual.
- Decide whether to ship the single binary as a distribution channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
