### PR TITLE
build(release): prepack gate so a release can't ship without the menubar .app

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "scripts": {
     "build": "tsc && rm -rf 'dist/lib/secrets/AgentsKeychain.app' 'dist/lib/secrets/Agents CLI.app' 'dist/lib/menubar/MenubarHelper.app' && ([ \"$(uname)\" = \"Darwin\" ] && cp -R 'bin/Agents CLI.app' 'dist/lib/secrets/Agents CLI.app' || true) && ([ \"$(uname)\" = \"Darwin\" ] && [ -d 'bin/MenubarHelper.app' ] && mkdir -p 'dist/lib/menubar' && cp -R 'bin/MenubarHelper.app' 'dist/lib/menubar/MenubarHelper.app' || true)",
-    "prepack": "scripts/verify-keychain-helper.sh",
+    "prepack": "scripts/verify-keychain-helper.sh && scripts/verify-menubar-helper.sh",
     "postinstall": "node scripts/postinstall.js",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",

--- a/scripts/verify-menubar-helper.sh
+++ b/scripts/verify-menubar-helper.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# prepack gate for the macOS menu-bar helper.
+#
+# The npm `build` script copies bin/MenubarHelper.app into dist only when the
+# bundle is present:  [ -d 'bin/MenubarHelper.app' ] && cp -R ... || true
+# That `|| true` means a release run WITHOUT the staged app silently ships the
+# menubar CODE but no .app — and on every user machine `agents menubar enable`
+# then reports "no bundle ships" and the auto-enable no-ops. 1.20.22 shipped
+# exactly this way. This gate fails the pack so it can't happen again.
+#
+# Unlike the keychain helper we don't pin a sha: the status-bar app is ad-hoc
+# signed and rebuilt freely, so a pinned sha would false-positive on every
+# rebuild. Presence + a valid signature catches the real failure mode (missing
+# or corrupt bundle) without blocking routine rebuilds.
+#
+# prepack only runs at `npm pack` / `npm publish` time, which is macOS-only
+# (releases are cut locally on macOS — see CLAUDE.md), so requiring the bundle
+# here does not affect Linux CI, which never packs.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+APP="bin/MenubarHelper.app"
+
+if [ ! -d "$APP" ]; then
+  echo "menubar helper missing: $APP not found" >&2
+  echo "Build and stage it before releasing:" >&2
+  echo "  packages/menubar-helper/scripts/build.sh release" >&2
+  echo "  cp -R packages/menubar-helper/dist/MenubarHelper.app bin/MenubarHelper.app" >&2
+  exit 1
+fi
+
+if command -v codesign >/dev/null 2>&1; then
+  if ! codesign --verify --deep --strict "$APP" 2>/dev/null; then
+    echo "menubar helper failed codesign --verify --deep --strict: $APP" >&2
+    echo "Rebuild it: packages/menubar-helper/scripts/build.sh release" >&2
+    exit 1
+  fi
+fi
+
+echo "menubar helper present and signed: $APP"


### PR DESCRIPTION
## Why

`1.20.22` shipped the menubar **code** but no `MenubarHelper.app`: the npm `build` copy step is best-effort (`[ -d 'bin/MenubarHelper.app' ] && cp -R … || true`), so a release run without the staged app silently produces a code-only tarball. On every user machine `agents menubar enable` then reports *"no bundle ships"* and the startup auto-enable no-ops — the menu bar is dead on arrival.

## What

- Add `scripts/verify-menubar-helper.sh`: presence + `codesign --verify --deep --strict` of `bin/MenubarHelper.app`.
- Chain it into `prepack` after the keychain check, so `npm pack`/`publish` refuses to build a tarball without the signed app.

No sha-pin (unlike the keychain helper): the status-bar app is ad-hoc signed and rebuilt freely, so a pinned sha would false-positive on every rebuild. Presence + valid signature catches the real failure mode. prepack only runs at publish time (macOS), so Linux CI is unaffected.