### PR TITLE
feat: support passthrough args after -- in agents run

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -250,6 +250,10 @@ export function registerRunCommand(program: Command): void {
 
       # Inject a keychain-backed secrets bundle
       agents run claude "deploy the worker" --secrets prod --mode edit
+
+      # Pass arbitrary native flags to the underlying CLI via -- separator
+      agents run kimi -- --plan --some-kimi-option value
+      agents run claude "fix the bug" -- --custom-flag
     `,
     notes: `
       Modes (not every agent supports every mode — check agents.yaml capabilities):
@@ -268,10 +272,18 @@ export function registerRunCommand(program: Command): void {
       Fallback: --fallback codex,gemini retries on rate-limit failure via /continue handoff. Each entry accepts @version.
 
       Resume: --session-id <id> continues a prior Claude conversation.
+
+      Passthrough: everything after -- is forwarded verbatim to the underlying agent CLI.
+        agents run kimi -- --plan --some-native-flag value
     `,
   });
 
-  runCmd.action(async (agentSpec: string, prompt: string | undefined, options: ExecCommandActionOptions) => {
+  runCmd.action(async (agentSpec: string, prompt: string | undefined, options: ExecCommandActionOptions, command: Command) => {
+      // Capture everything after -- as passthrough args forwarded verbatim to the underlying CLI.
+      // Use command.args (all positional strings) and strip the declared positional args from the front.
+      const declaredArgCount = prompt !== undefined ? 2 : 1;
+      const passthroughArgs = command.args.slice(declaredArgCount);
+
       // --resume-checkpoint short-circuits normal dispatch entirely: the
       // checkpoint already carries the agent, version, prompt, session id,
       // iteration, and loop config of the killed run. Reconstruct ExecOptions
@@ -774,6 +786,7 @@ export function registerRunCommand(program: Command): void {
         env,
         toolsRestrict: workflowToolsRestrict,
         mcpConfigPath: workflowMcpConfigPath,
+        passthroughArgs,
       };
 
       if (options.interactive && options.headless) {

--- a/src/lib/__tests__/exec.test.ts
+++ b/src/lib/__tests__/exec.test.ts
@@ -338,6 +338,45 @@ describe('buildExecCommand', () => {
     });
   });
 
+  // --- Passthrough args (everything after --) ---
+
+  describe('passthrough args', () => {
+    it('forwards arbitrary flags after -- for kimi', () => {
+      const cmd = buildExecCommand(opts({ agent: 'kimi', prompt: undefined, passthroughArgs: ['--plan', '--some-flag', 'value'] }));
+      expect(cmd.slice(-3)).toEqual(['--plan', '--some-flag', 'value']);
+    });
+
+    it('forwards flags after -- without breaking the prompt', () => {
+      const cmd = buildExecCommand(opts({ agent: 'kimi', prompt: 'fix auth', passthroughArgs: ['--custom-flag'] }));
+      const promptIdx = cmd.indexOf('fix auth');
+      const flagIdx = cmd.indexOf('--custom-flag');
+      expect(promptIdx).toBeGreaterThan(-1);
+      expect(flagIdx).toBeGreaterThan(promptIdx);
+    });
+
+    it('forwards flags in interactive mode', () => {
+      const cmd = buildExecCommand(opts({ agent: 'claude', prompt: undefined, interactive: true, passthroughArgs: ['--custom-flag'] }));
+      expect(cmd).toContain('--custom-flag');
+      expect(cmd[cmd.length - 1]).toBe('--custom-flag');
+    });
+
+    it('does not include passthrough args when empty', () => {
+      const cmd = buildExecCommand(opts({ agent: 'kimi' }));
+      expect(cmd).not.toContain('--custom-flag');
+    });
+
+    it('forwards passthrough args for codex after all generated flags', () => {
+      const cmd = buildExecCommand(opts({ agent: 'codex', mode: 'edit', prompt: undefined, passthroughArgs: ['--verbose', '--timeout', '10m'] }));
+      expect(cmd.slice(-3)).toEqual(['--verbose', '--timeout', '10m']);
+    });
+
+    it('combines --mode mapping and passthrough args for kimi', () => {
+      const cmd = buildExecCommand(opts({ agent: 'kimi', mode: 'skip', passthroughArgs: ['--extra'] }));
+      expect(cmd).toContain('--yolo');
+      expect(cmd[cmd.length - 1]).toBe('--extra');
+    });
+  });
+
   // --- resolveInteractive precedence ---
 
   describe('resolveInteractive precedence', () => {

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -155,6 +155,8 @@ export interface ExecOptions {
    * flag alone merely ADDS to the existing server set).
    */
   mcpConfigPath?: string;
+  /** Raw args captured after `--` on the command line, forwarded verbatim to the underlying agent CLI. */
+  passthroughArgs?: string[];
 }
 
 /**
@@ -684,6 +686,12 @@ export function buildExecCommand(options: ExecOptions): string[] {
       cmd.push('--mcp-config', options.mcpConfigPath);
       cmd.push('--strict-mcp-config');
     }
+  }
+
+  // Forward arbitrary native flags supplied after `--` verbatim. Appended last
+  // so they cannot be misinterpreted as values for earlier flags or as the prompt.
+  if (options.passthroughArgs && options.passthroughArgs.length > 0) {
+    cmd.push(...options.passthroughArgs);
   }
 
   return cmd;


### PR DESCRIPTION
Forward everything after `--` verbatim to the underlying agent CLI.

Example:
```bash
agents run kimi -- --plan --some-native-flag value
agents run claude "fix the bug" -- --custom-flag
```

Changes:
- `src/commands/exec.ts`: capture positional args after declared positionals and add them to `ExecOptions`
- `src/lib/exec.ts`: append `passthroughArgs` last in `buildExecCommand`
- `src/lib/__tests__/exec.test.ts`: add passthrough tests for kimi, codex, claude, mode+passthrough combo, and empty default