### PR TITLE
fix(secrets-agent): defer broker self-heal until cache is empty (#435)

### DIFF
--- a/src/lib/secrets/agent.test.ts
+++ b/src/lib/secrets/agent.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { SecretsBundle } from './bundles.js';
-import { handleAgentRequest, type StoredBundle, type Request } from './agent.js';
+import { handleAgentRequest, shouldSelfHealForUpgrade, type StoredBundle, type Request } from './agent.js';
 
 /**
  * These tests target the broker's store semantics — the part with real bug
@@ -103,5 +103,31 @@ describe('handleAgentRequest', () => {
       // fresh on-disk read and restarts the broker on mismatch.
       expect(typeof r.cliVersion).toBe('string');
     }
+  });
+});
+
+describe('shouldSelfHealForUpgrade (#435: never wipe a hot cache on upgrade)', () => {
+  it('defers the restart while bundles are unlocked, even on a version change', () => {
+    // The bug: an in-place `npm i -g` bumped the version, the broker self-healed
+    // immediately, wiped the in-memory unlocks, and the next read re-prompted.
+    expect(shouldSelfHealForUpgrade(true, 1, '1.20.21', '1.20.22')).toBe(false);
+    expect(shouldSelfHealForUpgrade(true, 5, '1.20.21', '1.20.22')).toBe(false);
+  });
+
+  it('self-heals once the store is empty and the version changed', () => {
+    expect(shouldSelfHealForUpgrade(true, 0, '1.20.21', '1.20.22')).toBe(true);
+  });
+
+  it('does not restart when the version is unchanged', () => {
+    expect(shouldSelfHealForUpgrade(true, 0, '1.20.22', '1.20.22')).toBe(false);
+  });
+
+  it('never self-heals a non-persistent (one-off) broker', () => {
+    expect(shouldSelfHealForUpgrade(false, 0, '1.20.21', '1.20.22')).toBe(false);
+  });
+
+  it('does not restart on an unknown version on either side (no spurious flap)', () => {
+    expect(shouldSelfHealForUpgrade(true, 0, 'unknown', '1.20.22')).toBe(false);
+    expect(shouldSelfHealForUpgrade(true, 0, '1.20.22', 'unknown')).toBe(false);
   });
 });

--- a/src/lib/secrets/agent.ts
+++ b/src/lib/secrets/agent.ts
@@ -48,6 +48,28 @@ const IDLE_EXIT_MS = 5 * 60 * 1000; // 5m
 /** How often the broker sweeps expired entries. */
 const SWEEP_INTERVAL_MS = 30 * 1000;
 
+/**
+ * Decide whether a persistent broker should self-heal onto freshly-installed
+ * code (exit so launchd relaunches it). Only when the store is EMPTY: exiting
+ * with bundles still unlocked wipes them from memory, so the next reader falls
+ * back to a direct keychain read and re-prompts for Touch ID. Deferring the
+ * restart until the cache is idle (TTL-expired / screen-locked) means an
+ * in-place `npm i -g` never wipes a hot cache — the new code is adopted at the
+ * next quiet moment instead. See #435: rapid repeated upgrades wiped a hot
+ * cache on every bump and produced a recurring Touch ID storm.
+ */
+export function shouldSelfHealForUpgrade(
+  persistent: boolean,
+  storeSize: number,
+  runningVersion: string,
+  onDiskVersion: string,
+): boolean {
+  if (!persistent) return false;
+  if (storeSize > 0) return false; // hot cache — defer rather than wipe unlocks
+  if (runningVersion === 'unknown' || onDiskVersion === 'unknown') return false;
+  return onDiskVersion !== runningVersion;
+}
+
 export interface StoredBundle {
   bundle: SecretsBundle;
   env: Record<string, string>;
@@ -328,15 +350,15 @@ export async function runSecretsAgent(opts: { service?: boolean } = {}): Promise
   const sweep = () => {
     const now = Date.now();
     for (const [name, e] of store) if (now >= e.expiresAt) store.delete(name);
-    // Self-heal: a newer version was installed in place — exit so launchd
-    // relaunches us on the new code. Only meaningful when launchd will restart
-    // us (persistent); a one-off broker just keeps serving until idle.
-    if (persistent) {
-      const onDisk = getCliVersionFresh();
-      if (onDisk !== 'unknown' && runningVersion !== 'unknown' && onDisk !== runningVersion) {
-        shutdown(0); // KeepAlive relaunches on the new code
-        return;
-      }
+    // Self-heal onto a newer in-place install — but ONLY while the store is
+    // empty, so we never wipe live unlocks and force a re-prompt (#435). The
+    // `store.size === 0` short-circuit also keeps getCliVersionFresh (a disk
+    // read) off the hot path. A pending upgrade is adopted at the next idle
+    // sweep instead of immediately.
+    if (store.size === 0 &&
+        shouldSelfHealForUpgrade(persistent, store.size, runningVersion, getCliVersionFresh())) {
+      shutdown(0); // KeepAlive relaunches on the new code
+      return;
     }
     if (store.size === 0) {
       if (!persistent && now - emptySince >= IDLE_EXIT_MS) shutdown(0);


### PR DESCRIPTION
Fixes #435.

## Problem
The persistent secrets-agent broker self-heals onto freshly-installed code by exiting on any version change (`sweep()` → `shutdown(0)` → launchd relaunch). Exiting **wipes the in-memory unlock cache**, so the next secret read falls back to a direct keychain read and **re-prompts for Touch ID**.

Rapid repeated in-place upgrades (`npm i -g` bouncing 1.20.20→.21→.22 across concurrent sessions/auto-update) wiped a hot cache on every bump → a recurring Touch ID storm, easily mistaken for a sync bug.

## Fix
Gate the self-heal on an **empty store**: while bundles are unlocked, defer the restart rather than wipe them; adopt the pending upgrade at the next idle sweep (after TTL expiry / screen-lock empties the cache). The `store.size === 0` short-circuit also keeps `getCliVersionFresh()` (a disk read) off the hot path. No change to the RAM-only security model.

Extracted `shouldSelfHealForUpgrade(persistent, storeSize, runningVersion, onDiskVersion)` as a pure, unit-tested helper.

## Tests
`src/lib/secrets/agent.test.ts` — 5 new cases (defer while hot / self-heal when empty / unchanged version / non-persistent / unknown version). `bunx vitest run src/lib/secrets/agent.test.ts` → **14 passed**; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)