### PR TITLE
feat(repo): add `repos view [name]` to inspect one repo without opening it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**`agents repos view [name]`: inspect one repo's contents without opening it**
+
+- New `agents repo view <name>` (also reachable as `agents repos view`, now a first-class alias of the `repo` command) prints a single repo's git state and per-kind resource counts — `system`, `user`, `project`, or an extra-repo alias. Omit the name for an interactive picker over the registered repos. It reuses the `inspect` repo renderer, so output matches `agents inspect <repo>`; supports `--brief` and `--json`. Source: `src/commands/repo.ts`, `src/commands/inspect.ts`.
+
 **Secrets prompt policy: human-readable `always` / `daily`, and `secrets list` now shows it**
 
 - Renamed the secrets-agent `tier` to a **prompt policy** with plain-language names: `biometry` → **`always`** (ask every time), `session` → **`daily`** (ask once, then held ~24h until screen-lock / sleep / logout). The old name `session` was misleading — it never meant "once per login session" — and collided with the half-dozen other "session" concepts in the CLI (`agents sessions`, sessions-sync, pty/browser sessions). Set it with `agents secrets policy <bundle> [always|daily]`.

--- a/docs/00-concepts.md
+++ b/docs/00-concepts.md
@@ -53,6 +53,8 @@ Resources are installed once in `~/.agents/` and synced to every supported agent
 
 To inspect what's installed, use the per-kind listers — `agents commands list`, `agents skills list`, `agents hooks list`, `agents mcp list`, `agents permissions list`, `agents subagents list`, `agents profiles list`. There is no single `agents resources` viewer that prints a merged cross-kind table today; if you want one, file an issue.
 
+To inspect a single repo on its own — its git state plus per-kind resource counts — use `agents repos view <repo>` (`system`, `user`, `project`, or an extra-repo alias). Omit the name for an interactive picker. It renders without opening anything; add `--brief` for the header only or `--json` for machine-readable output.
+
 ---
 
 ## Layered resolution

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -102,7 +102,7 @@ interface ResourceItem {
   groups?: PluginResourceGroup[];
 }
 
-interface InspectOptions {
+export interface InspectOptions {
   brief?: boolean;
   json?: boolean;
   // Drill-down flags. commander treats `--skills [query]` so the value is
@@ -305,7 +305,7 @@ function isDotAgentsRoot(dir: string): boolean {
   return false;
 }
 
-async function inspectRepo(repo: RepoTarget, options: InspectOptions): Promise<void> {
+export async function inspectRepo(repo: RepoTarget, options: InspectOptions): Promise<void> {
   const drill = pickDrillKind(options);
   const jsonHead = { repo: repo.label, root: repo.root };
 

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -20,6 +20,13 @@ import simpleGit from 'simple-git';
 import { confirm, input } from '@inquirer/prompts';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
 import { setHelpSections } from '../lib/help.js';
+import { itemPicker } from '../lib/picker.js';
+import {
+  inspectRepo,
+  resolveRepoTarget,
+  type RepoTarget as InspectRepoTarget,
+  type InspectOptions,
+} from './inspect.js';
 
 const HOME = os.homedir();
 
@@ -201,6 +208,7 @@ async function listRepos(alias: string | undefined): Promise<void> {
 export function registerRepoCommands(program: Command): void {
   const repoCmd = program
     .command('repo')
+    .alias('repos')
     .description('Manage extra DotAgent repos alongside ~/.agents/ (for private or team skills).');
 
   setHelpSections(repoCmd, {
@@ -219,6 +227,9 @@ export function registerRepoCommands(program: Command): void {
 
       # See what's registered
       agents repo list
+
+      # View one repo's contents (git state + resource counts); omit the name for a picker
+      agents repos view system
 
       # Temporarily disable without deleting
       agents repo disable acme
@@ -400,6 +411,43 @@ export function registerRepoCommands(program: Command): void {
     .description('Show all repos: branch, ahead/behind, dirty counts, URL, commit.')
     .action(async (alias: string | undefined) => {
       await listRepos(alias);
+    });
+
+  repoCmd
+    .command('view [name]')
+    .description("Show one repo's contents: git state and per-kind resource counts. Omit the name for an interactive picker.")
+    .option('--brief', 'header + git only; skip resource counts')
+    .option('--json', 'machine-readable JSON output')
+    .action(async (name: string | undefined, options: InspectOptions) => {
+      if (name) {
+        const repo = resolveRepoTarget(name);
+        if (!repo) {
+          console.log(chalk.red(`Unknown repo "${name}". Use "system", "user", "project", or a registered extra alias.`));
+          process.exitCode = 1;
+          return;
+        }
+        await inspectRepo(repo, options);
+        return;
+      }
+
+      const targets = collectRepoTargets(undefined) || [];
+      if (!isInteractiveTerminal()) {
+        console.log(chalk.red('No repo name given and not an interactive terminal.'));
+        console.log(chalk.gray('Pass a name (e.g. `agents repos view system`) or run in a TTY for the picker.'));
+        process.exitCode = 1;
+        return;
+      }
+
+      const picked = await itemPicker<RepoTarget>({
+        message: 'Select a repo to view',
+        items: targets,
+        filter: (q) => targets.filter((t) => t.alias.toLowerCase().includes(q.toLowerCase())),
+        labelFor: (t) => `${chalk.cyan(t.alias.padEnd(10))} ${chalk.gray(t.dir)}`,
+      });
+      if (!picked) return;
+
+      const repo: InspectRepoTarget = { label: picked.item.alias, root: picked.item.dir };
+      await inspectRepo(repo, options);
     });
 
   repoCmd

--- a/tests/repo-view.test.ts
+++ b/tests/repo-view.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PACKAGE_VERSION = JSON.parse(
+  fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf-8'),
+) as { version: string };
+
+const tempHomes: string[] = [];
+
+/** Scaffold a fake $HOME with a system + user DotAgents repo, each holding a skill. */
+function makeTempHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-repo-view-'));
+  tempHomes.push(home);
+
+  const userDir = path.join(home, '.agents');
+  const systemDir = path.join(userDir, '.system');
+  fs.mkdirSync(path.join(systemDir, '.git'), { recursive: true });
+  fs.writeFileSync(
+    path.join(systemDir, '.update-check'),
+    JSON.stringify({ lastCheck: Date.now(), latestVersion: PACKAGE_VERSION.version }),
+  );
+
+  // System repo: marker manifest + one skill so the summary has content to render.
+  fs.writeFileSync(path.join(systemDir, 'agents.yaml'), 'agents: {}\n');
+  fs.mkdirSync(path.join(systemDir, 'skills', 'demo-skill'), { recursive: true });
+  fs.writeFileSync(
+    path.join(systemDir, 'skills', 'demo-skill', 'SKILL.md'),
+    '---\ndescription: A demo skill\n---\n\n# demo-skill\n',
+  );
+
+  // User repo: its own manifest + skill.
+  fs.writeFileSync(path.join(userDir, 'agents.yaml'), 'agents: {}\n');
+  fs.mkdirSync(path.join(userDir, 'skills', 'user-skill'), { recursive: true });
+  fs.writeFileSync(
+    path.join(userDir, 'skills', 'user-skill', 'SKILL.md'),
+    '---\ndescription: A user skill\n---\n\n# user-skill\n',
+  );
+
+  return home;
+}
+
+function runAgents(home: string, args: string[], extraEnv: Record<string, string> = {}) {
+  return spawnSync('node', ['--import', 'tsx', 'src/index.ts', ...args], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, HOME: home, SHELL: '/bin/zsh', ...extraEnv },
+    encoding: 'utf-8',
+  });
+}
+
+/** Drop ANSI colors + OSC-8 hyperlink escapes so we can assert on plain text. */
+function strip(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '').replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+afterEach(() => {
+  while (tempHomes.length > 0) {
+    const home = tempHomes.pop()!;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+describe('agents repo view', () => {
+  it('renders a named repo summary with its resource section', () => {
+    const home = makeTempHome();
+    const result = runAgents(home, ['repo', 'view', 'system']);
+    expect(result.status).toBe(0);
+    const out = strip(result.stdout);
+    expect(out).toContain('system');
+    expect(out).toContain('[dotagents repo]');
+    expect(out).toContain('Resources');
+    expect(out).toContain('demo-skill');
+  });
+
+  it('exposes the same output under the `repos` alias', () => {
+    const home = makeTempHome();
+    const viaRepo = strip(runAgents(home, ['repo', 'view', 'system']).stdout);
+    const viaRepos = strip(runAgents(home, ['repos', 'view', 'system']).stdout);
+    expect(viaRepos).toBe(viaRepo);
+  });
+
+  it('errors on an unknown repo name', () => {
+    const home = makeTempHome();
+    const result = runAgents(home, ['repo', 'view', 'nope']);
+    expect(result.status).not.toBe(0);
+    expect(strip(result.stdout) + strip(result.stderr)).toContain('Unknown repo "nope"');
+  });
+
+  it('errors with a hint when no name is given in a non-interactive terminal', () => {
+    const home = makeTempHome();
+    // spawnSync gives the child a piped (non-TTY) stdin → picker is unavailable.
+    const result = runAgents(home, ['repo', 'view']);
+    expect(result.status).not.toBe(0);
+    expect(strip(result.stdout)).toContain('not an interactive terminal');
+  });
+});


### PR DESCRIPTION
## What

Adds `agents repo view <name>` (also reachable as `agents repos view` — `repos` is now a first-class alias of the `repo` command) to display a single repo's contents — git state + per-kind resource counts — **without opening anything**.

- **Name given** (`agents repos view system`) → renders that repo (`system`, `user`, `project`, or an extra-repo alias).
- **No name** → interactive picker over the registered repos (`system`, `user`, enabled extras).
- **No name + non-TTY** → error with a hint, exit 1.
- Supports `--brief` and `--json`.

## How

Thin, repo-scoped wrapper that **reuses** the existing `inspect` repo renderer instead of duplicating it:

- `src/commands/inspect.ts` — export `inspectRepo` + `InspectOptions` (were private). Calling `inspectRepo` directly (not `inspectAction`) keeps the command strictly repo-scoped so it never falls through to agent inspection.
- `src/commands/repo.ts` — `.alias('repos')` on the command; new `view [name]` subcommand using `itemPicker` (`src/lib/picker.ts`) for the no-name case and `collectRepoTargets` (the same source `list`/`pull`/`push` use) for the picker list.
- `docs/00-concepts.md` + `CHANGELOG.md`.

## Tests

`tests/repo-view.test.ts` (integration, real CLI via tsx against a scaffolded `$HOME`): named render, `repos` alias parity, unknown-repo error, non-interactive guard. **4/4 pass**; existing `extra-repos` + `non-interactive` suites unaffected (**27/27**).

## Verified end-to-end

```
agents repos view system          # renders summary, no editor/pager
agents repo view system           # alias of command name
agents repos view system --brief  # header/git only
agents repos view system --json   # machine-readable
agents repos view nonexistent     # error + exit 1
agents repos view < /dev/null     # non-TTY guard + exit 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)