### PR TITLE
fix: refresh menu bar helper on upgrade

### DIFF
--- a/src/commands/menubar.ts
+++ b/src/commands/menubar.ts
@@ -70,9 +70,13 @@ export function registerMenubarCommands(program: Command): void {
       console.log(`  running            ${yn(s.running)}`);
       console.log(`  service installed  ${yn(s.serviceInstalled)}`);
       console.log(`  app installed      ${s.installedApp ? chalk.gray(s.installedApp) : chalk.gray('no')}`);
+      console.log(`  installed version  ${s.installedVersion ? chalk.gray(s.installedVersion) : chalk.gray('unknown')}`);
+      console.log(`  current version    ${chalk.gray(s.currentVersion)}`);
       console.log(`  bundle source      ${s.source ? chalk.gray(s.source) : chalk.red('missing (cannot enable)')}`);
       console.log(`  disabled by user   ${yn(s.disabledByUser)}`);
-      if (!s.serviceInstalled && !s.disabledByUser) {
+      if (s.stale) {
+        console.log(chalk.yellow('\n  Installed helper is stale — runs on next `agents` startup, or `agents menubar enable` now.'));
+      } else if (!s.serviceInstalled && !s.disabledByUser) {
         console.log(chalk.gray('\n  Enable it with `agents menubar enable`.'));
       }
     });

--- a/src/lib/menubar/install-menubar.test.ts
+++ b/src/lib/menubar/install-menubar.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { isMenubarStale } from './install-menubar.js';
+
+// Regression guard for the upgrade self-heal: before this, the helper was only
+// (re)installed when no service existed, so `npm update` left the menu bar
+// running the previous release's binary. isMenubarStale is the decision that
+// must flag an upgraded/missing install for reinstall.
+describe('isMenubarStale', () => {
+  it('is stale when the helper binary is gone (App Support cleared)', () => {
+    expect(isMenubarStale({ installedVersion: '1.20.24', currentVersion: '1.20.24', execExists: false })).toBe(true);
+  });
+
+  it('is stale after an upgrade (installed version != current)', () => {
+    expect(isMenubarStale({ installedVersion: '1.20.24', currentVersion: '1.20.25', execExists: true })).toBe(true);
+  });
+
+  it('is stale on a pre-stamp install (no version marker yet)', () => {
+    expect(isMenubarStale({ installedVersion: null, currentVersion: '1.20.25', execExists: true })).toBe(true);
+  });
+
+  it('is NOT stale when version matches and the binary is present', () => {
+    expect(isMenubarStale({ installedVersion: '1.20.25', currentVersion: '1.20.25', execExists: true })).toBe(false);
+  });
+});

--- a/src/lib/menubar/install-menubar.ts
+++ b/src/lib/menubar/install-menubar.ts
@@ -21,6 +21,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { getRuntimeStateDir, getHelpersDir } from '../state.js';
+import { getCliVersion } from '../version.js';
 
 const APP_BUNDLE_NAME = 'MenubarHelper.app';
 const INSTALL_DIR_NAME = 'agents-cli';
@@ -30,9 +31,33 @@ function onDarwin(): boolean {
   return process.platform === 'darwin';
 }
 
+/** ~/Library/Application Support/agents-cli */
+function installDir(): string {
+  return path.join(os.homedir(), 'Library', 'Application Support', INSTALL_DIR_NAME);
+}
+
 /** ~/Library/Application Support/agents-cli/MenubarHelper.app */
 function installedAppPath(): string {
-  return path.join(os.homedir(), 'Library', 'Application Support', INSTALL_DIR_NAME, APP_BUNDLE_NAME);
+  return path.join(installDir(), APP_BUNDLE_NAME);
+}
+
+/**
+ * Version stamp written next to the installed bundle. The upgrade self-heal
+ * compares this against the running CLI's version to decide whether the App
+ * Support copy + plist need to be rebuilt — without it, a `npm update` refreshes
+ * dist/index.js but leaves the menu bar running the OLD helper binary and a
+ * plist whose baked paths may have drifted.
+ */
+function installedVersionMarkerPath(): string {
+  return path.join(installDir(), '.menubar-version');
+}
+
+function readInstalledMenubarVersion(): string | null {
+  try {
+    return fs.readFileSync(installedVersionMarkerPath(), 'utf-8').trim() || null;
+  } catch {
+    return null;
+  }
 }
 
 /** Executable inside the installed bundle. */
@@ -225,7 +250,36 @@ export function enableMenubarService(opts: { clearOptOut?: boolean } = { clearOp
     try { execFileSync('launchctl', ['load', '-w', plist], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* may already be loaded */ }
   }
   try { execFileSync('launchctl', ['kickstart', '-k', `gui/${uid}/${SERVICE_LABEL}`], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* best effort */ }
+
+  // Stamp the version we just installed so the upgrade self-heal can tell when
+  // a later release ships a newer helper that needs reinstalling.
+  try { fs.writeFileSync(installedVersionMarkerPath(), getCliVersion()); } catch { /* best effort */ }
   return true;
+}
+
+/**
+ * Pure staleness decision (no I/O) so the truth table is unit-testable. The
+ * installed service is stale when the helper binary is gone, or when it was
+ * installed by a different CLI version than the one now running — a version
+ * change is the signal that the plist's baked interpreter/entry/bundle paths
+ * and the helper binary itself may have drifted. A null installedVersion
+ * (pre-stamp install) counts as stale so old installs get re-stamped once.
+ */
+export function isMenubarStale(opts: {
+  installedVersion: string | null;
+  currentVersion: string;
+  execExists: boolean;
+}): boolean {
+  if (!opts.execExists) return true;
+  return opts.installedVersion !== opts.currentVersion;
+}
+
+function menubarSetupStale(): boolean {
+  return isMenubarStale({
+    installedVersion: readInstalledMenubarVersion(),
+    currentVersion: getCliVersion(),
+    execExists: fs.existsSync(installedExecutablePath()),
+  });
 }
 
 /**
@@ -246,19 +300,32 @@ export function disableMenubarService(): void {
 }
 
 /**
- * Upgrade-time auto-enable. Runs from runMigration() once per sentinel bump.
- * No-ops if: not darwin, the user opted out, no helper bundle ships, or the
- * service is already installed. Best-effort — never throws into migration.
+ * Startup self-heal, run on every darwin CLI invocation (see src/index.ts).
+ * No-ops cheaply (a couple of existsSync + a tiny file read) unless work is
+ * needed:
+ *   - fresh install (no service yet)      -> enable
+ *   - upgrade (version stamp changed) or  -> re-enable: recopy the new helper
+ *     the App Support helper went missing     binary + rewrite the plist + kick
+ *
+ * Without the staleness re-enable, `npm update` refreshed the CLI but left the
+ * menu bar running the previous release's helper binary on a possibly-stale
+ * plist. No-ops if: not darwin, the user opted out, or no helper bundle ships.
+ * Best-effort — never throws into startup.
  */
 export function installMenubarLaunchAgentOnUpgrade(): void {
   try {
     if (!onDarwin()) return;
     if (menubarDisabledByUser()) return;
-    if (menubarServiceInstalled()) return;
     if (!sourceAppPath()) return;
-    enableMenubarService({ clearOptOut: false });
+    if (!menubarServiceInstalled()) {
+      enableMenubarService({ clearOptOut: false });
+      return;
+    }
+    if (menubarSetupStale()) {
+      enableMenubarService({ clearOptOut: false });
+    }
   } catch {
-    /* never block migration on the menu bar */
+    /* never block startup on the menu bar */
   }
 }
 
@@ -266,6 +333,9 @@ export interface MenubarStatus {
   platform: string;
   source: string | null;
   installedApp: string | null;
+  installedVersion: string | null;
+  currentVersion: string;
+  stale: boolean;
   serviceInstalled: boolean;
   running: boolean;
   disabledByUser: boolean;
@@ -278,11 +348,15 @@ export function getMenubarStatus(): MenubarStatus {
     const r = spawnSync('pgrep', ['-f', 'MenubarHelper'], { stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf-8' });
     running = r.status === 0 && (r.stdout || '').trim().length > 0;
   }
+  const serviceInstalled = menubarServiceInstalled();
   return {
     platform: process.platform,
     source: sourceAppPath(),
     installedApp: fs.existsSync(dest) ? dest : null,
-    serviceInstalled: menubarServiceInstalled(),
+    installedVersion: readInstalledMenubarVersion(),
+    currentVersion: getCliVersion(),
+    stale: onDarwin() && serviceInstalled && menubarSetupStale(),
+    serviceInstalled,
     running,
     disabledByUser: menubarDisabledByUser(),
   };


### PR DESCRIPTION
## Problem

`installMenubarLaunchAgentOnUpgrade()` returned early whenever a service was already installed (`if (menubarServiceInstalled()) return;`). So on `npm update`, the CLI (`dist/index.js`) updated but the menu bar kept running the **previous release's** `MenubarHelper.app` in `~/Library/Application Support`, on a plist whose baked interpreter/entry/bundle paths could have drifted. Helper fixes never reached existing users — they had to manually `agents menubar disable && enable`.

Verified live: the shipped v1.20.24 install on this machine reports `installedVersion: null`, `stale: true` — it would never self-refresh under the old code.

## Fix

- Stamp the installed bundle with the CLI version (`.menubar-version` next to the app) on every `enableMenubarService`.
- New pure decision `isMenubarStale({ installedVersion, currentVersion, execExists })`: stale when the helper binary is missing or the stamped version != running version.
- `installMenubarLaunchAgentOnUpgrade` now: fresh install → enable; existing install → re-enable **only when stale** (re-copies the new helper + rewrites the plist + kickstarts). Still a cheap no-op on the steady state (one existsSync + a tiny file read), still honors the sticky opt-out, still never throws into startup.
- `menubar status` now shows installed vs current version and a stale flag.

## Tests

`src/lib/menubar/install-menubar.test.ts` — 4 cases pinning the staleness truth table (missing binary, upgraded version, pre-stamp null, up-to-date). `tsc` clean; `vitest` 4/4 pass.

To actually reach users this needs a merge + release (the release pipeline already stages `bin/MenubarHelper.app` via the prepack gate).