### PR TITLE
feat(secrets): default policy to daily (one Touch ID/day), configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+**Secrets default policy is now `daily` (one Touch ID per ~24h), not `always`**
+
+- The default prompt policy for bundles without an explicit one flipped from `always` (Touch ID on *every* read) to **`daily`** (one prompt, then held ~24h until screen-lock / sleep / logout). This is the fix for the prompt storm: a background reader like sessions-sync hammering a bundle now costs one Touch ID per ~24h instead of one per read.
+- **Auto-cache is on by default.** The secrets-agent is the mechanism that delivers the daily policy, so it self-caches a `daily` bundle on first read with no `secrets.agent.auto: true` needed. Opt out with `secrets.agent.auto: false`.
+- **Configurable, still flexible.** Set the global default in `agents.yaml` (`secrets.policy: always` to restore prompt-every-time), or override per bundle with `agents secrets policy <bundle> always` for high-value keys (signing, SSH) you want to confirm on every read.
+- **Explicit `always` now persists** under the legacy `tier: biometry` token (older CLIs read it as their own always default). Bundles with no stored policy inherit the configured default — so an existing always-by-default bundle quietly becomes `daily` on first read by the new CLI, which is the intended migration.
+
 **Secrets prompt policy: human-readable `always` / `daily`, and `secrets list` now shows it**
 
 - Renamed the secrets-agent `tier` to a **prompt policy** with plain-language names: `biometry` → **`always`** (ask every time), `session` → **`daily`** (ask once, then held ~24h until screen-lock / sleep / logout). The old name `session` was misleading — it never meant "once per login session" — and collided with the half-dozen other "session" concepts in the CLI (`agents sessions`, sessions-sync, pty/browser sessions). Set it with `agents secrets policy <bundle> [always|daily]`.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -133,8 +133,8 @@ holds only ciphertext): see [Recipe 8](#8-headless-release-on-a-remote-mac).
 | `secrets unlock <name> --ttl <dur>` | Hold for a custom lifetime (default 24h) | `agents secrets unlock prod --ttl 30m` |
 | `secrets lock [names...]` | Wipe held bundles from the agent (default: all) — next read re-prompts | `agents secrets lock` |
 | `secrets status` | Show which bundles the agent holds and when they lock | `agents secrets status` |
-| `secrets policy <bundle> [policy]` | Show or set a bundle's prompt policy: `always` (default) or `daily` | `agents secrets policy dev daily` |
-| `secrets create <name> --policy daily` | Create a bundle that's held after one prompt | `agents secrets create dev --policy daily` |
+| `secrets policy <bundle> [policy]` | Show or set a bundle's prompt policy: `daily` (default) or `always` | `agents secrets policy signing always` |
+| `secrets create <name> --policy always` | Create a bundle that prompts on every read | `agents secrets create signing --policy always` |
 
 See [The secrets-agent](#the-secrets-agent-macos) below for the model and the security trade-off.
 
@@ -392,21 +392,24 @@ A long-running daemon or broker keeps running the code it started with; an in-pl
 
 ### Prompt policy and auto-cache
 
-Each bundle has a **prompt policy** that controls how often macOS asks for Touch ID, shown in the `POLICY` column of `agents secrets list` and set with `agents secrets policy <bundle> [always|daily]` (also `--policy` on `create`):
+Each bundle has a **prompt policy** that controls how often macOS asks for Touch ID, shown in the `POLICY` column of `agents secrets list` and set with `agents secrets policy <bundle> [daily|always]` (also `--policy` on `create`):
 
-- **`always`** (default): ask every time. Only an explicit `unlock` ever puts it in the agent; every other read pops Touch ID. Use for high-value bundles you want to confirm every time.
-- **`daily`**: ask once, then hold it silently. You can `unlock` it, and — if you set `secrets.agent.auto: true` in `agents.yaml` — the **first real keychain read auto-loads it** into the broker (in the background, no added latency), so the next concurrent run reads it silently without you running `unlock` at all. Held up to ~24h from that unlock (not refreshed on use) — re-asks sooner after screen-lock, sleep, logout, or `lock`. Despite the name, it is **not** tied to one calendar day or one login session; it's the rolling ~24h hold.
+- **`daily`** (default): ask once, then hold it silently. The **first real keychain read auto-loads it** into the broker (in the background, no added latency), so the next concurrent run reads it silently without you running `unlock` at all — one Touch ID per ~24h. Held from that unlock (not refreshed on use) — re-asks sooner after screen-lock, sleep, logout, or `lock`. Despite the name, it is **not** tied to one calendar day or one login session; it's the rolling ~24h hold.
+- **`always`**: ask every time. Only an explicit `unlock` ever puts it in the agent; every other read pops Touch ID. Opt high-value bundles (signing keys, etc.) into this when you want to confirm every single read.
 
-> Wire-format note: the policy persists under the legacy `tier` key (`session` == `daily`; absent == `always`) so bundles stay readable across mixed CLI versions on synced machines. `--tier`/`agents secrets tier` and the old `biometry`/`session` values still work as aliases.
+Change the **default** for all bundles globally in `agents.yaml` (`secrets.policy: always` to flip it back), or override per bundle with `agents secrets policy <bundle> always`.
+
+> Wire-format note: the policy persists under the legacy `tier` key (`session` == `daily`, `biometry` == explicit `always`, absent == inherit the default) so bundles stay readable across mixed CLI versions on synced machines. `--tier`/`agents secrets tier` and the old `biometry`/`session` values still work as aliases.
 
 ```yaml
 # ~/.agents/agents.yaml
 secrets:
+  policy: daily   # default prompt policy for bundles without an explicit one (this IS the default)
   agent:
-    auto: true   # daily-policy bundles self-cache on first prompt
+    auto: false   # opt OUT of daily-policy self-caching (on by default)
 ```
 
-Auto-cache is **off by default** and only ever applies to `daily`-policy bundles — an `always` bundle is never auto-held. (A third `never` policy — items stored without the biometry ACL for fully silent reads with no agent — is intentionally not offered yet; it needs a separate signed-helper change and is the global downgrade the agent is designed to avoid. Tracked in [issue #421](https://github.com/phnx-labs/agents-cli/issues/421).)
+Auto-cache is **on by default** and only ever applies to `daily`-policy bundles — an `always` bundle is never auto-held. (A third `never` policy — items stored without the biometry ACL for fully silent reads with no agent — is intentionally not offered yet; it needs a separate signed-helper change and is the global downgrade the agent is designed to avoid. Tracked in [issue #421](https://github.com/phnx-labs/agents-cli/issues/421).)
 
 **The trade-off (read this):** while a bundle is unlocked, a same-user process that can reach the socket reads it **silently** — today it would at least have to pop a visible "Unlock agents-cli secrets" prompt you might notice. That is the same trust boundary the keychain already concedes above ("any same-user process can pop the prompt and read"), minus the prompt. Bound it by unlocking only the bundles you need, keeping a short TTL, locking when you step away, and never unlocking high-value bundles you'd rather always confirm.
 

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -475,14 +475,15 @@ export function registerSecretsCommands(program: Command): void {
       never touch disk in plaintext. Every item is device-local and gated by Touch ID
       or device passcode; cross-machine sync is handled by 'agents secrets push/pull'.
 
-      Touch ID noise: macOS pops a prompt per bundle per process, so concurrent
-      agents each re-prompt. Each bundle has a prompt policy, shown in the POLICY
-      column of 'agents secrets list':
-        always (default)  ask for Touch ID every time — never auto-held.
-        daily             ask once, then hold it silently in the local agent up
+      Touch ID noise: macOS pops a prompt per bundle per process. Each bundle has
+      a prompt policy, shown in the POLICY column of 'agents secrets list':
+        daily (default)   ask once, then hold it silently in the local agent up
                           to ~24h, until screen-lock / sleep / logout or 'lock'.
-      Set it with 'agents secrets policy <bundle> daily'. 'agents secrets unlock
-      <bundle>' holds any bundle after one prompt regardless of policy. Nothing on disk.
+        always            ask for Touch ID every time — never auto-held.
+      The default is 'daily' (one Touch ID per ~24h); change it globally with
+      'secrets.policy' in agents.yaml, or per bundle with 'agents secrets policy
+      <bundle> always'. 'agents secrets unlock <bundle>' holds any bundle after one
+      prompt regardless of policy. Nothing on disk.
 
       See also:
         agents secrets policy <bundle> daily           ask once a day, not every run
@@ -664,7 +665,7 @@ export function registerSecretsCommands(program: Command): void {
     .description('Create an empty bundle')
     .option('--description <text>', 'Free-form description')
     .option('--allow-exec', 'Allow exec: refs in this bundle (off by default)')
-    .option('--policy <policy>', 'prompt policy: always (default, ask every time) or daily (ask once a day)')
+    .option('--policy <policy>', 'prompt policy: daily (default, ask once a day) or always (ask every time)')
     .addOption(new Option('--tier <policy>', 'deprecated alias for --policy').hideHelp())
     .option('--backend <backend>', 'storage backend: keychain (default) or file (passphrase-encrypted, headless-readable)', 'keychain')
     .option('--force', 'Overwrite an existing bundle')
@@ -672,7 +673,10 @@ export function registerSecretsCommands(program: Command): void {
       try {
         const resolvedName = name ?? (await promptBundleName());
         validateBundleName(resolvedName);
-        const policy = parsePolicyOpt(opts.policy ?? opts.tier);
+        // Leave policy unset unless the user explicitly chose one, so the bundle
+        // inherits the configured default (`daily`) instead of being pinned.
+        const policyOpt = opts.policy ?? opts.tier;
+        const policy = policyOpt ? parsePolicyOpt(policyOpt) : undefined;
         const backend = parseBackendOpt(opts.backend);
         if (bundleExists(resolvedName) && !opts.force) {
           console.error(chalk.red(`Bundle '${resolvedName}' already exists. Use --force to overwrite.`));
@@ -688,7 +692,7 @@ export function registerSecretsCommands(program: Command): void {
         };
         writeBundle(bundle);
         const tags = [
-          policy === 'daily' ? 'policy: daily' : 'policy: always ask',
+          bundlePolicy(bundle) === 'daily' ? 'policy: daily' : 'policy: always ask',
           backend === 'file' ? 'backend: file' : null,
         ].filter(Boolean);
         console.log(chalk.green(`Bundle '${resolvedName}' created (${tags.join(', ')}).`));
@@ -1495,7 +1499,7 @@ Examples:
   cmd
     .command('policy <bundle> [policy]')
     .alias('tier')
-    .description("Show or set a bundle's prompt policy: always (default, ask every time) or daily (ask once a day).")
+    .description("Show or set a bundle's prompt policy: daily (default, ask once a day) or always (ask every time).")
     .action((bundleName: string, policyArg: string | undefined) => {
       try {
         const bundle = readBundle(bundleName);
@@ -1508,7 +1512,7 @@ Examples:
         writeBundle(bundle);
         console.log(chalk.green(`${bundle.name} policy set to ${next}.`));
         if (next === 'daily') {
-          console.log(chalk.gray('Held by the secrets-agent after one unlock: run `agents secrets unlock`, or enable auto-cache with `secrets.agent.auto: true` in agents.yaml.'));
+          console.log(chalk.gray('Held by the secrets-agent for ~24h after one unlock (auto-cache is on by default; disable with `secrets.agent.auto: false` in agents.yaml).'));
         } else {
           console.log(chalk.gray('Asks for Touch ID every time — never auto-held.'));
         }

--- a/src/lib/secrets/agent.ts
+++ b/src/lib/secrets/agent.ts
@@ -529,13 +529,15 @@ export function agentGetSync(name: string): { bundle: SecretsBundle; env: Record
   }
 }
 
-/** True when `secrets.agent.auto` is enabled in agents.yaml. Best-effort; a
- * missing/unreadable meta reads as off. */
+/** True unless `secrets.agent.auto` is explicitly disabled in agents.yaml. The
+ * broker is the mechanism that delivers the `daily` default policy (one Touch ID
+ * per ~24h), so auto-caching is ON by default; opt out with
+ * `secrets.agent.auto: false`. Best-effort; an unreadable meta reads as on. */
 export function secretsAgentAutoEnabled(): boolean {
   try {
-    return readMeta().secrets?.agent?.auto === true;
+    return readMeta().secrets?.agent?.auto !== false;
   } catch {
-    return false;
+    return true;
   }
 }
 

--- a/src/lib/secrets/bundles.ts
+++ b/src/lib/secrets/bundles.ts
@@ -37,6 +37,7 @@ import {
 } from './index.js';
 import { fileStore } from './filestore.js';
 import { emit } from '../events.js';
+import { readMeta } from '../state.js';
 import { agentGetSync, agentAutoLoadSync, secretsAgentAutoEnabled, DEFAULT_TTL_MS } from './agent.js';
 
 /** Which store carries a bundle's items. */
@@ -148,18 +149,19 @@ export interface VarMeta {
 
 /**
  * A bundle's prompt policy — how often macOS asks for Touch ID to read it:
- * - `always` (default): asks every time. Only an explicit `agents secrets
- *   unlock` ever holds it in the secrets-agent; every other read pops Touch ID.
- *   Use for high-value bundles you want to confirm every time.
- * - `daily`: ask once, then hold it silently. Eligible for the secrets-agent —
- *   `unlock` it, or (when `secrets.agent.auto` is enabled) the first real
- *   keychain read auto-loads it so concurrent runs read it silently. Held up to
- *   ~24h from that unlock (not refreshed on use); re-asks sooner after
- *   screen-lock, sleep, logout, or `agents secrets lock`.
+ * - `daily` (default): ask once, then hold it silently for up to ~24h. Eligible
+ *   for the secrets-agent — the first real keychain read auto-loads it (auto-cache
+ *   is on by default) so concurrent runs read it silently, or `unlock` it
+ *   explicitly. Held from that unlock (not refreshed on use); re-asks sooner
+ *   after screen-lock, sleep, logout, or `agents secrets lock`.
+ * - `always`: asks every time. Never auto-held — only an explicit `agents
+ *   secrets unlock` ever holds it; every other read pops Touch ID. Opt a
+ *   high-value bundle into this when you want to confirm every single read.
  *
- * Stored on disk under the legacy `tier` key (`session` == `daily`; absent ==
- * `always`) so bundles stay readable across mixed CLI versions on synced
- * machines. The in-memory and user-facing vocabulary is `policy`/`always`/`daily`.
+ * The default is configurable via `secrets.policy` in agents.yaml. Stored on disk
+ * under the legacy `tier` key (`session` == `daily`, `biometry` == explicit
+ * `always`, absent == inherit the default) so bundles stay readable across mixed
+ * CLI versions on synced machines. The user-facing vocabulary is `policy`/`always`/`daily`.
  */
 export type SecretsPolicy = 'always' | 'daily';
 
@@ -170,8 +172,8 @@ export interface SecretsBundle {
   allow_exec?: boolean;
   /** Which store carries this bundle's items. Absent ⇒ `keychain` (the default). */
   backend?: SecretsBackend;
-  /** Prompt policy. Absent ⇒ `always` (the safe default). Serialized under the
-   * legacy `tier` key — see SecretsPolicy. */
+  /** Prompt policy. Absent ⇒ the configured default (`daily`). Serialized under
+   * the legacy `tier` key — see SecretsPolicy. */
   policy?: SecretsPolicy;
   /** ISO 8601 UTC timestamp. Set once on the first writeBundle() for a bundle. */
   created_at?: string;
@@ -340,17 +342,33 @@ export function readBundle(name: string): SecretsBundle {
   return bundle;
 }
 
-/** Normalize the persisted prompt policy. The on-disk `tier` key uses the
- * legacy `session` token for `daily` (and `biometry`/absent for the default),
- * so accept both the legacy and current tokens. Anything but `daily`/`session`
- * ⇒ undefined (resolves to the `always` default). */
+/** Normalize the persisted prompt policy. The on-disk `tier` key uses legacy
+ * tokens for cross-version compatibility: `session` ⇒ `daily`, `biometry` ⇒ an
+ * explicit `always`. An absent token ⇒ undefined, which resolves to the
+ * configured default policy (`daily`). Persisting an explicit `always` as the
+ * legacy `biometry` token keeps older CLIs correct — they don't know `daily`,
+ * read `biometry` as undefined, and fall back to their own always default. */
 function parsePolicy(raw: unknown): SecretsPolicy | undefined {
-  return raw === 'daily' || raw === 'session' ? 'daily' : undefined;
+  if (raw === 'daily' || raw === 'session') return 'daily';
+  if (raw === 'always' || raw === 'biometry') return 'always';
+  return undefined;
 }
 
-/** The effective prompt policy of a bundle (absent ⇒ `always`). */
+/** The default prompt policy applied to bundles without an explicit per-bundle
+ * policy. Configurable via `secrets.policy` in agents.yaml; `daily` (one Touch
+ * ID per ~24h) unless the user explicitly opts back into prompt-every-time with
+ * `always`. Best-effort: an unreadable config falls back to the `daily` default. */
+export function secretsDefaultPolicy(): SecretsPolicy {
+  try {
+    return readMeta().secrets?.policy === 'always' ? 'always' : 'daily';
+  } catch {
+    return 'daily';
+  }
+}
+
+/** The effective prompt policy of a bundle (absent ⇒ the configured default). */
 export function bundlePolicy(bundle: SecretsBundle): SecretsPolicy {
-  return bundle.policy ?? 'always';
+  return bundle.policy ?? secretsDefaultPolicy();
 }
 
 export function writeBundle(bundle: SecretsBundle): void {
@@ -384,9 +402,11 @@ export function writeBundle(bundle: SecretsBundle): void {
     description: bundle.description,
     allow_exec: bundle.allow_exec ? true : undefined,
     backend: backend === 'file' ? 'file' : undefined,
-    // Wire format: persist `daily` under the legacy `tier`/`session` token so
-    // older CLI versions on other synced machines keep reading the policy.
-    tier: bundle.policy === 'daily' ? 'session' : undefined,
+    // Wire format: persist the policy under the legacy `tier` token so older CLI
+    // versions on other synced machines keep reading it — `daily`⇒`session`,
+    // explicit `always`⇒`biometry`. An absent policy omits the token entirely
+    // and resolves to the configured default (`daily`) on read.
+    tier: bundle.policy === 'daily' ? 'session' : bundle.policy === 'always' ? 'biometry' : undefined,
     created_at: bundle.created_at,
     updated_at: bundle.updated_at,
     last_used: bundle.last_used,

--- a/src/lib/secrets/policy.test.ts
+++ b/src/lib/secrets/policy.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { setKeychainBackendForTest, type KeychainBackend } from './index.js';
-import { writeBundle, readBundle, listBundles, bundlePolicy, type SecretsBundle } from './bundles.js';
+import { writeBundle, readBundle, listBundles, bundlePolicy, secretsDefaultPolicy, type SecretsBundle } from './bundles.js';
 
 /**
  * Covers the bundle prompt-policy field across the three parse sites (readBundle,
@@ -58,27 +58,42 @@ describe('secrets prompt-policy persistence', () => {
     expect(bundlePolicy(readBundle('legacy'))).toBe('daily');
   });
 
-  it('defaults to always when no policy is stored', () => {
+  it('stores no policy when unset and resolves it to the configured default', () => {
     writeBundle(bundle('b'));
     const read = readBundle('b');
-    expect(read.policy).toBeUndefined();
-    expect(bundlePolicy(read)).toBe('always');
+    expect(read.policy).toBeUndefined(); // absent on disk → inherits the default
+    // On a clean machine/CI (no `secrets.policy` in agents.yaml) the default is daily.
+    expect(secretsDefaultPolicy()).toBe('daily');
+    expect(bundlePolicy(read)).toBe(secretsDefaultPolicy());
   });
 
-  it('persists an explicit always policy as the absent default (not a literal)', () => {
+  it('persists an explicit always override (survives the daily default flip)', () => {
     writeBundle(bundle('b2', 'always'));
-    // always is the default, so it is not written into the JSON — it reads back
-    // as undefined, which bundlePolicy() resolves to always.
-    expect(readBundle('b2').policy).toBeUndefined();
+    // always is no longer the default, so it MUST be persisted — under the legacy
+    // `biometry` token, which older CLIs read as their own always default.
+    const raw = JSON.parse(mem.get('agents-cli.bundles.b2'));
+    expect(raw.tier).toBe('biometry');
+    expect(readBundle('b2').policy).toBe('always');
     expect(bundlePolicy(readBundle('b2'))).toBe('always');
   });
 
-  it('reflects the policy in listBundles', () => {
+  it('reads a legacy `tier: biometry` bundle back as an explicit always', () => {
+    writeBundle(bundle('old')); // create the metadata item
+    const item = 'agents-cli.bundles.old';
+    const raw = JSON.parse(mem.get(item));
+    raw.tier = 'biometry'; // simulate metadata written by an older CLI version
+    mem.set(item, JSON.stringify(raw));
+    expect(bundlePolicy(readBundle('old'))).toBe('always');
+  });
+
+  it('reflects the policy in listBundles (unset inherits the default)', () => {
     writeBundle(bundle('alpha', 'daily'));
-    writeBundle(bundle('beta'));
+    writeBundle(bundle('beta')); // unset → default
+    writeBundle(bundle('gamma', 'always')); // explicit override
     const byName = Object.fromEntries(listBundles().map((b) => [b.name, bundlePolicy(b)]));
     expect(byName.alpha).toBe('daily');
-    expect(byName.beta).toBe('always');
+    expect(byName.beta).toBe(secretsDefaultPolicy());
+    expect(byName.gamma).toBe('always');
   });
 
   it('treats an unknown/forward-incompatible persisted policy as the default', () => {
@@ -89,6 +104,6 @@ describe('secrets prompt-policy persistence', () => {
     raw.tier = 'galaxy-brain';
     mem.set(item, JSON.stringify(raw));
     expect(readBundle('weird').policy).toBeUndefined();
-    expect(bundlePolicy(readBundle('weird'))).toBe('always');
+    expect(bundlePolicy(readBundle('weird'))).toBe(secretsDefaultPolicy());
   });
 });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -625,9 +625,13 @@ export interface ExtraRepoConfig {
 export interface Meta {
   agents?: Partial<Record<AgentId, string>>;
   run?: RunConfig;
-  /** macOS secrets-agent config. `auto` makes the first real keychain read of a
-   * `session`-tier bundle populate the broker so concurrent runs read silently. */
+  /** macOS secrets-agent config. `policy` is the default prompt policy for
+   * bundles without an explicit per-bundle policy: `daily` (the default) asks
+   * once per ~24h, `always` asks every time. `auto` (default on) lets the first
+   * real keychain read of a `daily` bundle populate the broker so concurrent
+   * runs read silently — set it `false` to force a prompt on every read. */
   secrets?: {
+    policy?: 'always' | 'daily';
     agent?: {
       auto?: boolean;
     };


### PR DESCRIPTION
## Why

The secrets prompt storm has a simple root cause: **the default prompt policy is `always`** (Touch ID on *every* read). A background reader like `sessions-sync` hammering a bundle pops a prompt on every read. Per-bundle `daily` exists but you'd have to set it on every bundle by hand, and the setting wasn't durable.

This makes the **default `daily`** — one Touch ID per ~24h, held until screen-lock / sleep / logout — while keeping the policy system for flexibility.

## What

- **Default policy → `daily`.** Bundles without an explicit policy inherit it (`bundlePolicy()` → `secretsDefaultPolicy()`).
- **Configurable** via `secrets.policy` in `agents.yaml` (`always` to restore prompt-every-time). Per-bundle override (`agents secrets policy <bundle> always`) retained for high-value keys (signing, SSH).
- **Auto-cache on by default** (`secrets.agent.auto` defaults true) — it's the mechanism that delivers `daily`; opt out with `secrets.agent.auto: false`.
- **Explicit `always` now persists** under the legacy `tier: biometry` token. Previously `always` was the default and written as *absent*, so after this flip an explicit `always` would silently read back as `daily` — fixed. Older CLIs read `biometry` as their own always default (cross-version safe).
- `secrets create` no longer pins new bundles to `always`.

### Migration / failure mode
A bundle with no stored policy quietly becomes `daily` on first read by the new CLI — the intended migration. If a per-bundle override is ever lost, it now falls back to the *safe-quiet* `daily`, not the noisy `always`.

## Tests / verification

- `policy.test.ts`: updated; new regression guards for explicit-`always` persistence (`tier: biometry`) and default resolution. Full secrets suite: **141 passed / 5 skipped**; command tests **4 passed**; `tsc --noEmit` clean.
- **End-to-end against the built binary** via file-backed bundles (no Touch ID): unset → `policy: daily`, `--policy always` → `always`, round-trips through a fresh process reading the encrypted store.

## Scope note
This silences the **value-read** storm (sessions-sync etc.). `secrets list` / `view` still read metadata directly and prompt once per run — making those silent too (broker-served metadata cache) is a planned fast-follow, not in this PR. No keychain-helper change here, so this ships via the normal release (no re-notarization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)