### PR TITLE
fix(state): wait out lock contention instead of dropping a write (#306)

### DIFF
--- a/src/lib/__tests__/state.test.ts
+++ b/src/lib/__tests__/state.test.ts
@@ -185,11 +185,16 @@ describe('readMeta merges agents.yaml from both repos', () => {
   });
 
   it('does not lose concurrent updateMeta callback writes', async () => {
+    // Hold the meta lock through the callback longer than the old count-bounded
+    // retry budget (~750ms). The loser of the race must wait this out and still
+    // land its write; on the pre-fix lock it would exhaust its retries, throw,
+    // and silently drop a write — so this deterministically guards #306.
+    const HOLD_MS = 1_000;
     const makeUpdate = (agent: string, version: string) => `
       const { updateMeta } = await import(${JSON.stringify(modulePath)});
       updateMeta((meta) => {
         const block = new Int32Array(new SharedArrayBuffer(4));
-        Atomics.wait(block, 0, 0, 250);
+        Atomics.wait(block, 0, 0, ${HOLD_MS});
         return {
           ...meta,
           agents: {

--- a/src/lib/fs-atomic.ts
+++ b/src/lib/fs-atomic.ts
@@ -4,7 +4,18 @@ import { randomBytes } from 'crypto';
 import lockfile from 'proper-lockfile';
 
 const LOCK_STALE_MS = 5_000;
-const LOCK_RETRIES = 5;
+// Wall-clock budget to acquire the lock before giving up. A count-bounded retry
+// (the old 5 attempts / ~750ms ceiling) could expire while a peer legitimately
+// held the lock — under CI/parallel load two `agents` invocations mutating
+// agents.yaml would have one throw and silently drop its write. The budget must
+// comfortably exceed both a normal critical-section hold and the stale-break
+// window (LOCK_STALE_MS): a dead holder's lock turns stale at 5s and is then
+// broken on the next attempt, so this only ever waits out a live, in-progress
+// holder. Bounded (not unbounded) so a truly wedged holder still surfaces an
+// error instead of hanging the CLI forever.
+const LOCK_ACQUIRE_TIMEOUT_MS = 30_000;
+const LOCK_RETRY_MIN_MS = 50;
+const LOCK_RETRY_MAX_MS = 250;
 
 // Reused across all sleepSync calls — avoids allocating a new SAB each time.
 const _sleepBuf = new Int32Array(new SharedArrayBuffer(4));
@@ -45,24 +56,30 @@ export function atomicWriteFileSync(filePath: string, content: string): void {
 
 /**
  * Acquires an exclusive proper-lockfile lock on filePath, runs fn, then
- * releases the lock. Retries up to LOCK_RETRIES times with linear back-off.
- * Breaks stale locks older than LOCK_STALE_MS.
+ * releases the lock. Retries with capped linear back-off until either the lock
+ * is acquired or LOCK_ACQUIRE_TIMEOUT_MS elapses. Breaks stale locks older than
+ * LOCK_STALE_MS, so a crashed holder never blocks past the stale window.
  */
 export function withFileLock<T>(filePath: string, fn: () => T): T {
   let release: (() => void) | null = null;
   let lastError: unknown;
-  for (let attempt = 0; attempt <= LOCK_RETRIES; attempt++) {
+  const deadline = Date.now() + LOCK_ACQUIRE_TIMEOUT_MS;
+  for (let attempt = 0; ; attempt++) {
     try {
       release = lockfile.lockSync(filePath, { stale: LOCK_STALE_MS });
       break;
     } catch (err) {
       lastError = err;
-      if (attempt < LOCK_RETRIES) sleepSync(50 * (attempt + 1));
+      if (Date.now() >= deadline) break;
+      const backoff = Math.min(LOCK_RETRY_MIN_MS * (attempt + 1), LOCK_RETRY_MAX_MS);
+      sleepSync(Math.min(backoff, Math.max(0, deadline - Date.now())));
     }
   }
   if (!release) {
     const message = lastError instanceof Error ? lastError.message : String(lastError);
-    throw new Error(`Could not acquire lock for ${filePath}: ${message}`);
+    throw new Error(
+      `Could not acquire lock for ${filePath} after ${LOCK_ACQUIRE_TIMEOUT_MS}ms: ${message}`,
+    );
   }
   try {
     return fn();


### PR DESCRIPTION
## Summary

Fixes #306. `withFileLock` (`src/lib/fs-atomic.ts`) retried only 5 times with linear backoff (~750ms ceiling) and then **threw** — so under CI/parallel load two `agents` invocations mutating `agents.yaml` could have the loser exhaust its budget and **silently lose its `updateMeta` write**. This is both a real data-loss risk (parallel installs / `agents teams`) and the recurring red `build (22)` flake that has failed unrelated PRs.

## Fix

- Replace the count-bounded retry with a **30s wall-clock deadline** + capped linear backoff (50ms→250ms).
- `proper-lockfile` still breaks locks stale past `LOCK_STALE_MS` (5s), so a **crashed** holder never blocks past the stale window — the budget only ever waits out a *live, in-progress* holder.
- Stays **bounded** (not unbounded) so a truly wedged holder surfaces an error instead of hanging the CLI forever.
- Fix is at the source (`withFileLock`), so both callers — `state.ts` (agents.yaml) and `manifest.ts` — benefit.

## Test

Strengthened the existing `does not lose concurrent updateMeta callback writes` test to hold the lock **1s** (past the old ~750ms budget), converting a load-dependent flaky test into a **deterministic regression**.

Verified locally:
- With the real 30s budget: `state.test.ts` 13/13 pass; `state` + `manifest` 15/15 pass; `tsc --noEmit` clean.
- Temporarily shrinking the budget to **700ms** (emulating the old ceiling) makes the concurrent test **fail** — the loser exits non-zero and drops its write — proving the test catches #306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)