### PR TITLE
docs: menu bar page + changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@
 - **Configurable, still flexible.** Set the global default in `agents.yaml` (`secrets.policy: always` to restore prompt-every-time), or override per bundle with `agents secrets policy <bundle> always` for high-value keys (signing, SSH) you want to confirm on every read.
 - **Explicit `always` now persists** under the legacy `tier: biometry` token (older CLIs read it as their own always default). Bundles with no stored policy inherit the configured default — so an existing always-by-default bundle quietly becomes `daily` on first read by the new CLI, which is the intended migration.
 
+**Menu bar: a macOS status item for agent activity (`agents menubar`)**
+
+- New no-Dock menu bar app showing live agent activity on the machine: a **NEEDS YOU** section (sessions awaiting input + failed/overdue routines), a per-agent **roster** (running / idle counts across installed agents), a **+ New session** launcher, and a one-line routines summary. The icon badges red `!` when something needs you, green with a count when sessions are running.
+- Reads state **directly from disk** — `live-terminals.json`, teams `meta.json`, and the cloud `tasks.db` — so opening the menu never triggers the costly sessions transcript re-index. The CLI is shelled only for actions (start a session, run a routine).
+- **Auto-enabled on macOS** for every user as a launchd login service (`com.phnx-labs.agents-menubar`); a fresh install brings the icon up with no manual step. Manage with `agents menubar enable | disable | status`. Opt out with `agents menubar disable` — sticky across upgrades.
+- **Upgrade self-heal:** the installed bundle is version-stamped, and the startup self-heal now re-installs the helper when a newer release ships a newer build (or the installed copy goes missing), instead of skipping whenever a service already existed. So `npm update` actually moves users onto the new helper binary + plist rather than leaving the old one running (#442). `agents menubar status` shows installed vs current version and staleness.
+- Docs: [Menu bar](docs/menubar.md). macOS only.
+
 **`agents repos view [name]`: inspect one repo's contents without opening it**
 
 - New `agents repo view <name>` (also reachable as `agents repos view`, now a first-class alias of the `repo` command) prints a single repo's git state and per-kind resource counts — `system`, `user`, `project`, or an extra-repo alias. Omit the name for an interactive picker over the registered repos. It reuses the `inspect` repo renderer, so output matches `agents inspect <repo>`; supports `--brief` and `--json`. Source: `src/commands/repo.ts`, `src/commands/inspect.ts`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ How agents-cli is laid out on disk and how it decides what to load.
 | [Browser](browser.md) | Drive Chrome / Brave / Edge / Electron via CDP. Profiles, screenshots, click/type/evaluate, remote endpoints. |
 | [PTY](pty.md) | Persistent pseudo-terminals for REPLs and TUIs — start, exec, screen-snapshot, signal. |
 | [Computer](computer.md) | macOS Accessibility automation — screenshot the active app, click by label. |
+| [Menu bar](menubar.md) | macOS status item — live sessions, agents awaiting input, routines, + new session. Auto-enabled; `agents menubar enable/disable/status`. |
 
 ---
 

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -40,7 +40,8 @@ out with `agents menubar disable`.
 ```
 
 - **NEEDS YOU** — pinned on top. Sessions blocked waiting for you, plus routines
-  whose last run failed or that are overdue. Empty when nothing needs attention.
+  whose last run failed, timed out, or that are overdue. Empty when nothing needs
+  attention.
 - **New session** — launches `agents run <agent>` in a new Terminal window.
 - **AGENTS** — every installed agent with running / idle counts. A session is
   *running* if its transcript was written in the last 2 minutes, else *idle*.
@@ -70,7 +71,8 @@ The helper assembles the menu by reading these directly — no CLI, no re-index:
 |---|---|---|
 | Terminals | `~/.agents/.cache/terminals/live-terminals.json` | terminal / IDE sessions (agent, cwd, pid) |
 | Teams | `~/.agents/.history/teams/agents/<id>/meta.json` | running teammate agents |
-| Cloud | `~/.agents/.cache/cloud/tasks.db` (SQLite) | cloud tasks, incl. `needs_review` → "awaiting input" |
+| Cloud | `~/.agents/.cache/cloud/tasks.db` (SQLite) | cloud tasks, incl. `input_required` or `needs_review` → "awaiting input" |
+| Attention sentinels | `~/.agents/.cache/state/attention/<sessionId>` | terminal sessions awaiting input (written by the Notification hook) |
 | Installed agents | `~/.agents/.history/versions/<agent>/` | the agent roster |
 
 Liveness is a `kill(pid, 0)` check; running-vs-idle is the transcript file's

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -1,0 +1,107 @@
+# Menu bar
+
+A macOS status-bar item that surfaces live agent activity on the machine.
+
+## Overview
+
+The menu bar helper (`MenubarHelper.app`) is a no-Dock, `.accessory` status-bar
+app. Its icon — the agents-cli `a` mark — sits in the menu bar and answers, at a
+glance, "what are my agents doing right now, and does anything need me?"
+
+It reads state **directly from disk** and never invokes the `agents` CLI to
+populate the menu, so opening it costs a few file reads and never triggers the
+sessions transcript re-index. It shells the CLI only for *actions* (starting a
+session, running a routine).
+
+macOS only. It is auto-enabled for every user (see [Lifecycle](#lifecycle)); opt
+out with `agents menubar disable`.
+
+## The dropdown
+
+```
+ a !                      icon + badge (red ! = needs you, green N = N running)
+ ┌─ agents ─────────────────────────────┐
+ │ NEEDS YOU (2)                         │   sessions awaiting input +
+ │   ! claude  api  awaiting input    ›  │   failed / overdue routines
+ │   ! routine nightly-sync  failed   ›  │
+ ├────────────────────────────────────────┤
+ │ New session                       ⌘N  │   submenu: one entry per installed agent
+ ├────────────────────────────────────────┤
+ │ AGENTS · 2 running · 3 idle           │
+ │   claude    ● 2 running            ›  │   per-agent counts; submenu lists the
+ │   codex     ○ idle                ›  │   sessions and a "New <agent>" launcher
+ │   …                                   │
+ ├────────────────────────────────────────┤
+ │ routines  next 9:00am · 1 failed   ›  │   one compact line (secondary)
+ ├────────────────────────────────────────┤
+ │ Stop scheduler                        │   shown when the routines daemon is up
+ │ Quit menu bar                     ⌘Q  │   disables the launchd service
+ └────────────────────────────────────────┘
+```
+
+- **NEEDS YOU** — pinned on top. Sessions blocked waiting for you, plus routines
+  whose last run failed or that are overdue. Empty when nothing needs attention.
+- **New session** — launches `agents run <agent>` in a new Terminal window.
+- **AGENTS** — every installed agent with running / idle counts. A session is
+  *running* if its transcript was written in the last 2 minutes, else *idle*.
+- **routines** — next run and failed count; the submenu lists all routines with
+  Run now / Logs.
+
+The icon badges **red `!`** when anything needs you and **green with a count**
+when sessions are running; otherwise it is the bare mark.
+
+## Commands
+
+```
+agents menubar            # status (also: agents menubar status)
+agents menubar enable     # install + start the launchd login service
+agents menubar disable    # stop + remove it (sticky opt-out)
+agents menubar status     # installed / running, versions, staleness; --json
+```
+
+`status` reports the installed bundle version vs. the current CLI version and
+whether the install is stale (see [Lifecycle](#lifecycle)).
+
+## Data sources
+
+The helper assembles the menu by reading these directly — no CLI, no re-index:
+
+| Source | Path | Gives |
+|---|---|---|
+| Terminals | `~/.agents/.cache/terminals/live-terminals.json` | terminal / IDE sessions (agent, cwd, pid) |
+| Teams | `~/.agents/.history/teams/agents/<id>/meta.json` | running teammate agents |
+| Cloud | `~/.agents/.cache/cloud/tasks.db` (SQLite) | cloud tasks, incl. `needs_review` → "awaiting input" |
+| Installed agents | `~/.agents/.history/versions/<agent>/` | the agent roster |
+
+Liveness is a `kill(pid, 0)` check; running-vs-idle is the transcript file's
+mtime. The teams directory accumulates history, so the periodic badge refresh
+skips it — the full teams scan runs only when the menu opens.
+
+## Lifecycle
+
+The helper is a launchd user service (`com.phnx-labs.agents-menubar`,
+`RunAtLoad` + `KeepAlive`), installed to
+`~/Library/Application Support/agents-cli/MenubarHelper.app`.
+
+- **Auto-enable.** On every macOS CLI invocation a cheap self-heal installs the
+  service if it is missing — so a fresh install brings the icon up without a
+  manual step.
+- **Upgrade refresh.** The installed bundle is stamped with the CLI version. When
+  a newer release ships a newer helper (or the installed copy goes missing), the
+  self-heal re-copies the bundle, rewrites the plist, and restarts it — so
+  `npm update` actually moves users onto the new helper instead of leaving the
+  old one running.
+- **Opt-out is sticky.** `agents menubar disable` writes
+  `~/.agents/.cache/state/menubar.disabled`; the auto-enable honors it, so a
+  disabled menu bar never silently returns on the next upgrade. Re-enable with
+  `agents menubar enable`.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `~/Library/LaunchAgents/com.phnx-labs.agents-menubar.plist` | launchd service |
+| `~/Library/Application Support/agents-cli/MenubarHelper.app` | installed helper bundle |
+| `~/Library/Application Support/agents-cli/.menubar-version` | installed-version stamp |
+| `~/.agents/.cache/state/menubar.disabled` | sticky opt-out marker |
+| `~/.agents/.cache/helpers/menubar/menubar.log` | helper stdout / stderr |


### PR DESCRIPTION
Backfills the missing docs for the menu bar feature (shipped in 1.20.25 with no changelog/docs) and the upgrade self-heal fix (#442).

- `docs/menubar.md` — new page (dropdown layout, commands, data sources, lifecycle/auto-enable, file locations), grounded in the shipped Swift + `install-menubar.ts`.
- `docs/README.md` — Menu bar row added to the Automation table.
- `CHANGELOG.md` — Unreleased entry covering the feature + the #442 upgrade refresh.

Docs-only; no code change.