### PR TITLE
feat(sessions): query a remote machine's sessions live over SSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**`agents sessions --host <machine>`: query a remote machine's sessions live over SSH**
+
+- `agents sessions "<query>" --host <alias|user@host>` runs the same session query on a remote machine's own index over SSH and streams the result back — repeat `--host` (or pass several) to fan out across machines. SSH access is the only auth; there's no daemon or shared store. Targets are validated against a strict allowlist (`SSH_TARGET_RE`) to block flag-smuggling, and the forwarded invocation is double-quoted (`shellQuote`) so a query like `$(whoami)` survives as a literal string on both shell layers. Source: `src/lib/session/remote.ts`, `src/commands/sessions.ts`, `docs/05-sessions.md`.
+
 **Fix: migrations + menu-bar self-heal were silently disabled on Homebrew-node installs**
 
 - The "is this a dev build?" check walked `dirname(dirname(argv[1]))` looking for a `.git`, without resolving the bin symlink. On a Homebrew-node setup `agents` is `/opt/homebrew/bin/agents`, so it walked up to `/opt/homebrew` — **which is itself a git repo** — and false-positived as a dev build. Dev builds auto-set `AGENTS_SKIP_MIGRATION=1`, which gates **both** one-shot migrations **and** the menu-bar upgrade self-heal. Net effect: every Homebrew-node user ran with migrations and the menu-bar refresh permanently off.

--- a/docs/05-sessions.md
+++ b/docs/05-sessions.md
@@ -169,6 +169,33 @@ content 1.0   # everything else
 - ISO date: `2026-04-22T00:00:00Z`
 - Natural: `yesterday`, `today`
 
+## Remote Sessions over SSH
+
+Discovery is local-only — every path is rooted at `os.homedir()`, so a machine
+sees only its own transcripts. `--host` runs the query on another machine instead:
+
+```
+# Search another machine's sessions live (no sync, always current)
+agents sessions "auth bug" --last 3 --host yosemite-s1
+
+# Fan the same query across several machines
+agents sessions --all "deploy script" --host box-a --host box-b
+```
+
+It works by invoking the **remote's own** `agents sessions` against its already-built
+index over SSH and streaming stdout back — `ssh -o BatchMode=yes <host> bash -lc
+'agents sessions …'` (`src/lib/session/remote.ts`). Every other flag (`--since`,
+`--json`, `--markdown`, query, even `tail` and `--active`) forwards verbatim, since
+the far end runs the same binary. `--host` is stripped before forwarding so there is
+no recursion; the target must be a host alias or `user@host` (validated against
+`SSH_TARGET_RE` to block argv-flag smuggling). SSH access is the only auth — if you
+can `ssh <host>`, you own the box; there is no identity layer.
+
+This is the **live** counterpart to `agents sessions sync` (R2 + CRDT union, eventual
+~90s): no upfront copy and always current, but the peer must be reachable. Use sync
+to make every machine's sessions show up in plain `agents sessions`; use `--host` to
+peek at a specific machine on demand.
+
 ## Schema Version
 
 Schema version is currently `6`. Migrations run on connection open; old DBs

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -23,6 +23,7 @@ import { getActiveSessions, type ActiveSession } from '../lib/session/active.js'
 import { discoverSessions, countSessionsInScope, resolveSessionById, searchContentIndex, parseTimeFilter, type DiscoverOptions, type ScanProgress } from '../lib/session/discover.js';
 import { filterTeamSessions } from '../lib/session/team-filter.js';
 import { parseSession } from '../lib/session/parse.js';
+import { runRemoteSessions } from '../lib/session/remote.js';
 import { renderConversationMarkdown, renderSummary, renderSummaryHeader, computeSummaryStats, renderJson, filterEvents, parseRoleList, type FilterOptions } from '../lib/session/render.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { colorAgent, resolveAgentName } from '../lib/agents.js';
@@ -59,6 +60,7 @@ interface SessionsOptions extends SessionFilterOptions {
   artifact?: string;
   active?: boolean;
   cloud?: boolean;
+  host?: string[];
 }
 
 interface ClaudeHistoryEntry {
@@ -402,6 +404,16 @@ async function renderActiveSessions(asJson: boolean): Promise<void> {
 
 /** Main action handler for `agents sessions`. Routes to picker, table, or single-session render. */
 async function sessionsAction(query: string | undefined, options: SessionsOptions): Promise<void> {
+  if (options.host && options.host.length > 0) {
+    try {
+      runRemoteSessions(options.host);
+    } catch (err: any) {
+      console.error(chalk.red(err.message));
+      process.exit(1);
+    }
+    return;
+  }
+
   if (options.active) {
     await renderActiveSessions(options.json === true);
     return;
@@ -1288,7 +1300,8 @@ export function registerSessionsCommands(program: Command): void {
     .option('--artifacts', 'List all files written or edited during a session')
     .option('--artifact <name>', 'Read a specific artifact by filename or path (outputs to stdout)')
     .option('--active', 'Show only sessions running right now across terminals, teams, cloud, and headless agents')
-    .option('--cloud', 'Source sessions from Rush Cloud (captured runs) instead of local disk');
+    .option('--cloud', 'Source sessions from Rush Cloud (captured runs) instead of local disk')
+    .option('-H, --host <target...>', 'Run this query on remote machine(s) over SSH (host alias or user@host; repeatable)');
 
   setHelpSections(sessionsCmd, {
     examples: `
@@ -1309,8 +1322,15 @@ export function registerSessionsCommands(program: Command): void {
 
       # Export for analysis
       agents sessions --since 30d --limit 200 --json > sessions.json
+
+      # Search another machine's sessions live over SSH (no sync needed)
+      agents sessions "auth bug" --last 3 --host yosemite-s1
+
+      # Fan the same query out across several machines
+      agents sessions --all "deploy script" --host box-a --host box-b
     `,
     notes: `
+      - --host runs the query on the remote's own index over SSH (host alias or user@host); repeat or pass several to fan out. SSH access is the only auth.
       - --include and --exclude are mutually exclusive.
       - --first and --last are mutually exclusive.
       - A filter flag (--include/--exclude/--first/--last) without --markdown/--json defaults to --markdown output.

--- a/src/lib/session/remote.test.ts
+++ b/src/lib/session/remote.test.ts
@@ -55,6 +55,38 @@ describe('buildForwardedArgs', () => {
     expect(buildForwardedArgs(argv('sessions', 'tail', '--latest', '--host', 'box')))
       .toEqual(['sessions', 'tail', '--latest']);
   });
+
+  it('strips every host in the variadic --host a b form (not just the first)', () => {
+    // Commander's `<target...>` lets `--host box1 box2` set host=['box1','box2'].
+    // Without the known-host set the scan would only drop box1 and leak box2
+    // into the remote query. Passing the set strips both.
+    expect(
+      buildForwardedArgs(
+        argv('sessions', 'auth bug', '--host', 'box1', 'box2', '--json'),
+        new Set(['box1', 'box2']),
+      ),
+    ).toEqual(['sessions', 'auth bug', '--json']);
+  });
+
+  it('strips repeated --host flags when given the host set', () => {
+    expect(
+      buildForwardedArgs(
+        argv('sessions', 'auth bug', '--host', 'box1', '--host', 'box2'),
+        new Set(['box1', 'box2']),
+      ),
+    ).toEqual(['sessions', 'auth bug']);
+  });
+
+  it('stops consuming at the first token that is not a known host', () => {
+    // The scan only swallows consecutive tokens present in the host set; a
+    // trailing non-host token ('auth') is preserved rather than over-consumed.
+    expect(
+      buildForwardedArgs(
+        argv('sessions', '--host', 'box1', 'box2', 'auth'),
+        new Set(['box1', 'box2']),
+      ),
+    ).toEqual(['sessions', 'auth']);
+  });
 });
 
 describe('shellQuote', () => {

--- a/src/lib/session/remote.test.ts
+++ b/src/lib/session/remote.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
+import {
+  buildForwardedArgs,
+  buildRemoteCommand,
+  shellQuote,
+  assertValidSshTarget,
+} from './remote.js';
+
+/**
+ * Decode the argv the *remote* would actually receive. `buildRemoteCommand` emits
+ * `bash -lc '<...>'`; ssh hands that to the remote login shell, which runs it. We
+ * reproduce that exactly: an outer bash defines+exports an `agents` shim (exported
+ * functions survive the nested `bash -lc` via the environment), then runs the
+ * command. The shim prints each arg on its own line, so stdout == the remote argv.
+ * This is the true end-to-end check of the two-layer quoting (injection-safety).
+ */
+function decodeRemoteArgv(forwarded: string[]): string[] {
+  const shim = `agents() { for a in "$@"; do printf '%s\\n' "$a"; done; }; export -f agents; `;
+  const res = spawnSync('bash', ['-c', shim + buildRemoteCommand(forwarded)], { encoding: 'utf-8' });
+  expect(res.status).toBe(0);
+  return res.stdout.split('\n').slice(0, -1); // drop trailing empty from final newline
+}
+
+// argv as the runtime hands it to us: [runtime, script, 'sessions', ...userArgs]
+const argv = (...userArgs: string[]) => ['/usr/bin/bun', '/path/agents', ...userArgs];
+
+describe('buildForwardedArgs', () => {
+  it('drops --host with a separate value but keeps everything else in order', () => {
+    expect(buildForwardedArgs(argv('sessions', 'auth bug', '--last', '3', '--host', 'yosemite-s1')))
+      .toEqual(['sessions', 'auth bug', '--last', '3']);
+  });
+
+  it('drops the --host=value form', () => {
+    expect(buildForwardedArgs(argv('sessions', '--host=yosemite-s1', '--json', 'query')))
+      .toEqual(['sessions', '--json', 'query']);
+  });
+
+  it('drops the -H short flag and its value', () => {
+    expect(buildForwardedArgs(argv('sessions', '-H', 'box', '--since', '2h')))
+      .toEqual(['sessions', '--since', '2h']);
+  });
+
+  it('drops the glued -Hvalue short form', () => {
+    expect(buildForwardedArgs(argv('sessions', '-Hyosemite-s1', 'query')))
+      .toEqual(['sessions', 'query']);
+  });
+
+  it('keeps a query that legitimately contains the word host', () => {
+    expect(buildForwardedArgs(argv('sessions', 'fix the host header bug', '--host', 'box')))
+      .toEqual(['sessions', 'fix the host header bug']);
+  });
+
+  it('forwards subcommands like tail verbatim', () => {
+    expect(buildForwardedArgs(argv('sessions', 'tail', '--latest', '--host', 'box')))
+      .toEqual(['sessions', 'tail', '--latest']);
+  });
+});
+
+describe('shellQuote', () => {
+  it('wraps a plain word in single quotes', () => {
+    expect(shellQuote('agents')).toBe("'agents'");
+  });
+
+  it('escapes embedded single quotes (the injection-prone case)', () => {
+    // A query carrying a single quote must not break out of the quoting.
+    expect(shellQuote("o'brien")).toBe("'o'\\''brien'");
+  });
+});
+
+describe('buildRemoteCommand', () => {
+  it('wraps the invocation in bash -lc so the remote login PATH resolves agents', () => {
+    expect(buildRemoteCommand(['sessions', 'q']).startsWith('bash -lc ')).toBe(true);
+  });
+
+  it('reconstructs the exact argv on the remote through both shell layers', () => {
+    expect(decodeRemoteArgv(['sessions', 'auth bug', '--last', '3']))
+      .toEqual(['sessions', 'auth bug', '--last', '3']);
+  });
+
+  it('keeps a query with a single quote injection-safe (no early quote-break)', () => {
+    // A naive escaper lets the apostrophe close the outer quote and split the arg.
+    expect(decodeRemoteArgv(['sessions', "it's broken"]))
+      .toEqual(['sessions', "it's broken"]);
+  });
+
+  it('neutralizes shell metacharacters in a query (no command substitution)', () => {
+    expect(decodeRemoteArgv(['sessions', '$(whoami); rm -rf /', '--json']))
+      .toEqual(['sessions', '$(whoami); rm -rf /', '--json']);
+  });
+});
+
+describe('assertValidSshTarget', () => {
+  it('accepts a bare host alias and user@host', () => {
+    expect(() => assertValidSshTarget('yosemite-s1')).not.toThrow();
+    expect(() => assertValidSshTarget('deploy@staging.example.com')).not.toThrow();
+  });
+
+  it('rejects a leading dash (argv flag smuggling) and shell metacharacters', () => {
+    expect(() => assertValidSshTarget('-oProxyCommand=evil')).toThrow(/Invalid SSH target/);
+    expect(() => assertValidSshTarget('box; rm -rf /')).toThrow(/Invalid SSH target/);
+    expect(() => assertValidSshTarget('box$(whoami)')).toThrow(/Invalid SSH target/);
+  });
+});

--- a/src/lib/session/remote.ts
+++ b/src/lib/session/remote.ts
@@ -1,0 +1,112 @@
+/**
+ * `agents sessions --host <target>` — run the session query on a remote machine
+ * over SSH and stream its output back. Session transcripts and the index DB live
+ * on the machine that produced them (see `discover.ts`, all `os.homedir()`-rooted),
+ * so instead of syncing the bytes here we invoke the *remote's own* `agents
+ * sessions` against its already-built index and forward stdout verbatim.
+ *
+ * This is the live counterpart to `agents sessions sync` (R2/CRDT, eventual): no
+ * upfront copy, always current, but the peer must be reachable. SSH access is the
+ * only auth — if you can `ssh <host>`, you own the box (no identity layer by design).
+ *
+ * Mirrors the transport already used by `agents secrets export --to-ssh`
+ * (`src/commands/secrets.ts`): `ssh -o BatchMode=yes <host> bash -lc '<cmd>'`,
+ * with `bash -lc` so the remote login PATH resolves `agents`.
+ */
+import { spawnSync } from 'child_process';
+import chalk from 'chalk';
+
+/**
+ * SSH target: a bare ssh-config host alias (e.g. `yosemite-s1`) or `user@host`.
+ * The strict allowlist blocks shell metacharacters and a leading `-`, so a target
+ * can never be smuggled in as an ssh argv flag.
+ */
+export const SSH_TARGET_RE = /^[a-zA-Z0-9._-]+(@[a-zA-Z0-9._-]+)?$/;
+
+export function assertValidSshTarget(host: string): void {
+  if (!SSH_TARGET_RE.test(host)) {
+    throw new Error(
+      `Invalid SSH target ${JSON.stringify(host)}. Expected a host alias or user@host ` +
+        `(letters, digits, '.', '_', '-').`,
+    );
+  }
+}
+
+/** POSIX single-quote a string for safe interpolation into a remote shell command. */
+export function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Strip the `--host`/`-H` flag (and its value) from a raw `agents sessions` argv,
+ * leaving the args to forward to the remote unchanged. The remote runs the same
+ * binary, so every other flag (`--since`, `--last`, `--json`, query, …) carries
+ * over for free. Handles every form commander accepts: `--host h`, `--host=h`,
+ * `-H h`, `-H=h`, and the glued short form `-Hh`.
+ *
+ * @param argv full process argv; the sessions args begin at index 2
+ *             (`[runtime, script, 'sessions', ...]`).
+ */
+export function buildForwardedArgs(argv: string[]): string[] {
+  const args = argv.slice(2);
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--host' || a === '-H') {
+      i++; // also consume the separate value token
+      continue;
+    }
+    if (a.startsWith('--host=') || a.startsWith('-H=')) continue;
+    if (/^-H.+/.test(a)) continue; // glued short form: -Hyosemite-s1
+    out.push(a);
+  }
+  return out;
+}
+
+/**
+ * Build the single remote command string for `ssh <host> <cmd>`. Forwarded args
+ * are quoted for the inner login shell, then the whole `agents …` invocation is
+ * quoted again so it survives `bash -lc <...>`.
+ */
+export function buildRemoteCommand(forwardedArgs: string[]): string {
+  const inner = ['agents', ...forwardedArgs].map(shellQuote).join(' ');
+  return `bash -lc ${shellQuote(inner)}`;
+}
+
+const SSH_OPTS = [
+  '-o', 'BatchMode=yes',
+  '-o', 'StrictHostKeyChecking=accept-new',
+  '-o', 'ConnectTimeout=10',
+];
+
+/**
+ * Run the current `agents sessions` invocation on one or more remote machines over
+ * SSH, streaming each remote's output to the terminal. Sets `process.exitCode = 1`
+ * if any host fails. Reads the invocation from `process.argv` (override via
+ * `argv` for testing).
+ */
+export function runRemoteSessions(hosts: string[], argv: string[] = process.argv): void {
+  for (const host of hosts) assertValidSshTarget(host); // fail fast on any bad target
+
+  const remoteCmd = buildRemoteCommand(buildForwardedArgs(argv));
+  const multi = hosts.length > 1;
+  let failures = 0;
+
+  for (const host of hosts) {
+    if (multi) process.stdout.write(chalk.cyan(`\n── ${host} ──\n`));
+    const res = spawnSync('ssh', [...SSH_OPTS, host, remoteCmd], { stdio: 'inherit' });
+    if (res.error) {
+      failures++;
+      console.error(chalk.red(`${host}: ${res.error.message}`));
+      continue;
+    }
+    if (res.status !== 0) {
+      failures++;
+      console.error(
+        chalk.red(`${host}: remote query failed (exit ${res.status ?? 'signal'}).`),
+      );
+    }
+  }
+
+  if (failures > 0) process.exitCode = 1;
+}

--- a/src/lib/session/remote.ts
+++ b/src/lib/session/remote.ts
@@ -47,13 +47,22 @@ export function shellQuote(s: string): string {
  * @param argv full process argv; the sessions args begin at index 2
  *             (`[runtime, script, 'sessions', ...]`).
  */
-export function buildForwardedArgs(argv: string[]): string[] {
+export function buildForwardedArgs(argv: string[], hosts: Set<string> = new Set()): string[] {
   const args = argv.slice(2);
   const out: string[] = [];
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === '--host' || a === '-H') {
-      i++; // also consume the separate value token
+      // Commander's `<target...>` variadic accepts both `--host a --host b` and
+      // `--host a b` — consume every consecutive token that is a known host so
+      // the variadic form doesn't leak the extra hosts into the remote argv.
+      // Fall back to consuming the single next token when we have no host set
+      // (e.g. malformed input) so the flag value never leaks either way.
+      if (hosts.size > 0) {
+        while (i + 1 < args.length && hosts.has(args[i + 1])) i++;
+      } else {
+        i++; // also consume the separate value token
+      }
       continue;
     }
     if (a.startsWith('--host=') || a.startsWith('-H=')) continue;
@@ -88,7 +97,7 @@ const SSH_OPTS = [
 export function runRemoteSessions(hosts: string[], argv: string[] = process.argv): void {
   for (const host of hosts) assertValidSshTarget(host); // fail fast on any bad target
 
-  const remoteCmd = buildRemoteCommand(buildForwardedArgs(argv));
+  const remoteCmd = buildRemoteCommand(buildForwardedArgs(argv, new Set(hosts)));
   const multi = hosts.length > 1;
   let failures = 0;
 


### PR DESCRIPTION
## What

Adds `agents sessions --host <target>` — search/read **another machine's** sessions live over SSH, without syncing anything.

```bash
# Search a peer's sessions against its own index (always current, no copy)
agents sessions "auth bug" --last 3 --host yosemite-s1

# Fan the same query across machines
agents sessions --all "deploy script" --host box-a --host box-b
```

## Why

Session discovery is local-only — every path in `discover.ts` is `os.homedir()`-rooted, so a machine only ever sees its own transcripts. `agents sessions sync` (R2 + CRDT) already covers cross-machine, but it's **eventual** (~90s daemon cadence) and pays an upfront copy of every transcript. This is the **live** counterpart: invoke the remote's own `agents sessions` against its already-built index and stream stdout back.

| | `sessions sync` (existing) | `--host` (this PR) |
|---|---|---|
| Transport | R2 bucket (CRDT union) | SSH, peer-to-peer |
| Freshness | eventual (~90s) | live |
| Upfront cost | copies all transcripts | none |
| Offline peer | works | fails (peer must be up) |

## How

Mirrors the transport already used by `agents secrets export --to-ssh`:
`ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 <host> bash -lc 'agents sessions …'`. `bash -lc` so the remote login PATH resolves `agents`.

- Every other flag (`--since`, `--json`, `--markdown`, query, `tail`, `--active`) forwards **verbatim** — the far end runs the same binary, so no per-flag plumbing.
- `--host` is stripped from the argv before forwarding (no recursion). Repeatable / variadic for fan-out.
- Targets validated against `SSH_TARGET_RE` (host alias or `user@host`) to block argv-flag smuggling (`-oProxyCommand=…`).
- SSH access is the only auth — if you can `ssh <host>`, you own the box. No identity layer, by design.

New module `src/lib/session/remote.ts`; one branch added at the top of `sessionsAction`.

## Tests

`src/lib/session/remote.test.ts` (14 cases) covers the two bug-prone parts:
- **argv stripping** — every `--host`/`-H` form (`--host h`, `--host=h`, `-H h`, `-Hh`), and that a query containing the word "host" survives.
- **double-quoting** — a **real-bash round-trip** that defines an exported `agents` shim and runs the produced `bash -lc '…'`, decoding the argv the remote would actually receive. Proves injection-safety through both shell layers (apostrophes, `$(whoami); rm -rf /`).

Full session suite green (217 passing), typecheck clean.

## Verification

End-to-end wiring verified with a stub `ssh` on PATH — correct 8-arg invocation and double-quoted remote command. **Not** verified: the live SSH hop to a real peer (the dev sandbox blocks outbound `ssh`); reviewer/author should smoke-test `agents sessions --host <a-real-host>` once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)