### PR TITLE
fix: dev-build false-positive disables migrations + menu bar on Homebrew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+**Fix: migrations + menu-bar self-heal were silently disabled on Homebrew-node installs**
+
+- The "is this a dev build?" check walked `dirname(dirname(argv[1]))` looking for a `.git`, without resolving the bin symlink. On a Homebrew-node setup `agents` is `/opt/homebrew/bin/agents`, so it walked up to `/opt/homebrew` — **which is itself a git repo** — and false-positived as a dev build. Dev builds auto-set `AGENTS_SKIP_MIGRATION=1`, which gates **both** one-shot migrations **and** the menu-bar upgrade self-heal. Net effect: every Homebrew-node user ran with migrations and the menu-bar refresh permanently off.
+- Detection now `realpath`s the entrypoint (so a symlinked bin resolves into the real package dir) and requires the `.git`'s repo root to actually be the `@phnx-labs/agents-cli` package — an unrelated ancestor repo no longer counts. Extracted to `src/lib/startup/dev-build.ts` with tests covering the Homebrew symlink layout, a real checkout, and unrelated-ancestor cases.
+
 **Secrets default policy is now `daily` (one Touch ID per ~24h), not `always`**
 
 - The default prompt policy for bundles without an explicit one flipped from `always` (Touch ID on *every* read) to **`daily`** (one prompt, then held ~24h until screen-lock / sleep / logout). This is the fix for the prompt storm: a background reader like sessions-sync hammering a bundle now costs one Touch ID per ~24h instead of one per read.

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
+import { detectDevBuild } from './lib/startup/dev-build.js';
 // `ora`, `@inquirer/prompts`, `./commands/utils.js`, and the agents/versions/shims
 // modules are imported dynamically at their use sites: they are needed only on
 // interactive / update / shim-repair paths, never for fast commands like
@@ -56,14 +57,7 @@ interface NpmPackageMetadata {
 // must not scribble on the user's real ~/.agents/), and skip the update prompt
 // (the "0.0.0-dev -> 1.x.y" message is misleading). Each individual env var
 // can still be set explicitly to override (set to '0' to re-enable).
-const IS_DEV_BUILD: boolean = (() => {
-  if (VERSION.startsWith('0.0.0-dev')) return true;
-  try {
-    const cliPath = process.argv[1] || '';
-    const repoRoot = path.dirname(path.dirname(cliPath));
-    return fs.existsSync(path.join(repoRoot, '.git'));
-  } catch { return false; }
-})();
+const IS_DEV_BUILD: boolean = detectDevBuild(process.argv[1] || '', VERSION);
 if (IS_DEV_BUILD) {
   if (process.env.AGENTS_NO_AUTOPULL === undefined) process.env.AGENTS_NO_AUTOPULL = '1';
   if (process.env.AGENTS_SKIP_MIGRATION === undefined) process.env.AGENTS_SKIP_MIGRATION = '1';

--- a/src/lib/startup/dev-build.test.ts
+++ b/src/lib/startup/dev-build.test.ts
@@ -1,0 +1,72 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { detectDevBuild } from './dev-build.js';
+
+const tmpDirs: string[] = [];
+function mkTmp(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'devbuild-'));
+  tmpDirs.push(d);
+  return d;
+}
+function writeFile(p: string, body = ''): void {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, body);
+}
+
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+describe('detectDevBuild', () => {
+  it('a 0.0.0-dev version is always a dev build', () => {
+    expect(detectDevBuild('/anything', '0.0.0-dev.abc123')).toBe(true);
+  });
+
+  it('Homebrew-node npm-global install is NOT a dev build (the bug)', () => {
+    // Reproduce the real layout: a brew prefix that is itself a git repo, with
+    // `agents` symlinked from <prefix>/bin into the installed package under
+    // <prefix>/lib/node_modules. The naive dirname(dirname(symlink)) walked to
+    // <prefix>, saw <prefix>/.git, and false-positived as a dev build.
+    const prefix = mkTmp();
+    fs.mkdirSync(path.join(prefix, '.git')); // Homebrew's own repo
+    const pkgDir = path.join(prefix, 'lib', 'node_modules', '@phnx-labs', 'agents-cli');
+    writeFile(path.join(pkgDir, 'package.json'), JSON.stringify({ name: '@phnx-labs/agents-cli' }));
+    const entry = path.join(pkgDir, 'dist', 'index.js');
+    writeFile(entry, '// cli');
+    const binLink = path.join(prefix, 'bin', 'agents');
+    fs.mkdirSync(path.dirname(binLink), { recursive: true });
+    fs.symlinkSync(entry, binLink);
+
+    expect(detectDevBuild(binLink, '1.20.27')).toBe(false);
+  });
+
+  it('a real agents-cli source checkout IS a dev build', () => {
+    const repo = mkTmp();
+    fs.mkdirSync(path.join(repo, '.git'));
+    writeFile(path.join(repo, 'package.json'), JSON.stringify({ name: '@phnx-labs/agents-cli' }));
+    const entry = path.join(repo, 'dist', 'index.js');
+    writeFile(entry, '// cli');
+
+    expect(detectDevBuild(entry, '1.20.27')).toBe(true);
+  });
+
+  it('an unrelated ancestor git repo does not count as a dev build', () => {
+    // A git repo whose root is NOT the agents-cli package (no/foreign package.json).
+    const root = mkTmp();
+    fs.mkdirSync(path.join(root, '.git'));
+    writeFile(path.join(root, 'package.json'), JSON.stringify({ name: 'some-other-thing' }));
+    const entry = path.join(root, 'dist', 'index.js');
+    writeFile(entry, '// cli');
+
+    expect(detectDevBuild(entry, '1.20.27')).toBe(false);
+  });
+
+  it('a plain install with no ancestor git repo is not a dev build', () => {
+    const dir = mkTmp();
+    const entry = path.join(dir, 'pkg', 'dist', 'index.js');
+    writeFile(entry, '// cli');
+    expect(detectDevBuild(entry, '1.20.27')).toBe(false);
+  });
+});

--- a/src/lib/startup/dev-build.ts
+++ b/src/lib/startup/dev-build.ts
@@ -1,0 +1,38 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Decide whether the CLI is running from a source checkout (a "dev build") vs an
+ * installed package. Dev builds suppress autopull / migrations / auto-update so
+ * iterating on the repo never mutates the user's real setup.
+ *
+ * Two signals:
+ *   1. A `0.0.0-dev*` version stamp (scripts/install.sh dev installs).
+ *   2. Running out of an actual agents-cli git checkout.
+ *
+ * Signal 2 must be precise. The naive check —
+ * `existsSync(dirname(dirname(argv[1])) + '/.git')` — false-positives badly:
+ *   - npm-global bins are symlinks. `/opt/homebrew/bin/agents` →
+ *     `…/node_modules/@phnx-labs/agents-cli/dist/index.js`. Without resolving the
+ *     symlink, `dirname(dirname())` walks to `/opt/homebrew`, which is **itself a
+ *     git repo** (Homebrew). So every Homebrew-node user looked like a dev build
+ *     and had migrations + the menu-bar self-heal silently disabled.
+ *
+ * Fix: resolve the symlink with realpath, then require the `.git`'s repo root to
+ * actually be the agents-cli package (its package.json `name`), not some
+ * unrelated ancestor that happens to be version-controlled.
+ */
+export function detectDevBuild(argv1: string, version: string): boolean {
+  if (version.startsWith('0.0.0-dev')) return true;
+  try {
+    const cliPath = fs.realpathSync(argv1 || '');
+    const repoRoot = path.dirname(path.dirname(cliPath));
+    if (!fs.existsSync(path.join(repoRoot, '.git'))) return false;
+    const pkgPath = path.join(repoRoot, 'package.json');
+    if (!fs.existsSync(pkgPath)) return false;
+    const name = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))?.name;
+    return name === '@phnx-labs/agents-cli';
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Root cause

`IS_DEV_BUILD` in `src/index.ts` decided "dev build" via `existsSync(dirname(dirname(argv[1])) + '/.git')` **without resolving the bin symlink**. On a Homebrew-node install, `agents` is `/opt/homebrew/bin/agents`, so that walks up to `/opt/homebrew` — which is itself a git repo (Homebrew). False-positive → dev build → it auto-sets `AGENTS_SKIP_MIGRATION=1` (`index.ts:67-70`).

That flag gates **both** one-shot migrations (`index.ts:1082`) **and** the menu-bar upgrade self-heal (`index.ts:1114`). So for every Homebrew-node user, migrations and the menu-bar auto-refresh (the #442 fix) were **silently disabled**.

Reproduced:

```
/opt/homebrew/.git                      exists (Homebrew is a git repo)
argv[1] = /opt/homebrew/bin/<bin>       bin invoked via brew symlink
dirname(dirname(argv[1])) = /opt/homebrew
.git at that root? true                 -> IS_DEV_BUILD wrongly true
```

## Fix

Extracted detection to `src/lib/startup/dev-build.ts`:
- `realpath` the entrypoint first, so a symlinked bin resolves into the real package dir (`…/node_modules/@phnx-labs/agents-cli/dist/index.js`) whose parent has no `.git`.
- Require the `.git` repo root to actually be the `@phnx-labs/agents-cli` package (package.json `name`), so an unrelated ancestor repo can't qualify.

## Tests

`src/lib/startup/dev-build.test.ts` — 5 cases with real temp dirs + symlinks: `0.0.0-dev` stamp, the **Homebrew symlink layout** (the bug → now false), a real checkout (true), an unrelated-ancestor repo (false), and a plain install (false). `tsc` clean; vitest 5/5.

Needs a release to reach users; once shipped, Homebrew-node users get migrations + the menu-bar self-heal back.
