### PR TITLE
fix(sync): convert commands to skills for skills-only agents (kimi et al.)

### DIFF
--- a/src/lib/__tests__/versions.test.ts
+++ b/src/lib/__tests__/versions.test.ts
@@ -3,11 +3,15 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as crypto from 'crypto';
+import { execFileSync } from 'child_process';
+import { fileURLToPath } from 'url';
 
 import { getProjectVersion, removeVersion } from '../versions.js';
 import { getVersionsDir, getTrashVersionsDir } from '../state.js';
 import { getDB, updateSessionFilePaths } from '../session/db.js';
 import type { AgentId } from '../types.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 
 let tmpDir: string;
 
@@ -140,6 +144,69 @@ describe('removeVersion soft-deletes the entire version dir to trash', () => {
       }
     });
   }
+});
+
+// Regression: for a commands-as-skills agent (kimi: commands:false, skills:true,
+// no native command runtime), the commands writer materializes each command as a
+// skill dir under skills/. The skills orphan-sweep that runs afterward in a full
+// (no-selection) sync must NOT delete those converted command-skills — that bug
+// silently dropped every command (e.g. /recap) from kimi/grok.
+describe('syncResourcesToVersion preserves command-skills through the skills orphan-sweep', () => {
+  it('[kimi] keeps converted command-skills AND real skills after a full sync', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cmdskill-sweep-'));
+    try {
+      const script = String.raw`
+        import * as fs from 'fs';
+        import * as path from 'path';
+        import { getVersionHomePath, syncResourcesToVersion } from './src/lib/versions.ts';
+
+        const home = process.env.HOME;
+        if (!home) throw new Error('HOME missing');
+        const userDir = path.join(home, '.agents');
+        const projectRoot = path.join(home, 'project');
+        fs.mkdirSync(projectRoot, { recursive: true });
+        const write = (rel, content) => {
+          const p = path.join(userDir, rel);
+          fs.mkdirSync(path.dirname(p), { recursive: true });
+          fs.writeFileSync(p, content);
+        };
+        // A top-level command (converts to a command-skill) and a real skill.
+        write('commands/recap.md', ['---','description: Recap','---','','recap body'].join('\n'));
+        write('skills/realskill/SKILL.md', ['---','name: realskill','description: a real skill','---','','body'].join('\n'));
+
+        const agent = 'kimi';
+        const version = '0.0.0-test';
+        const fakeBin = path.join(userDir, '.history', 'versions', agent, version, 'node_modules', '.bin', 'kimi');
+        fs.mkdirSync(path.dirname(fakeBin), { recursive: true });
+        fs.writeFileSync(fakeBin, '#!/usr/bin/env sh\nexit 0\n');
+        fs.chmodSync(fakeBin, 0o755);
+
+        // Full sync: no selection -> orphan sweep runs.
+        syncResourcesToVersion(agent, version, undefined, { cwd: projectRoot, force: true });
+
+        const skillsDir = path.join(getVersionHomePath(agent, version), '.kimi-code', 'skills');
+        const recapMd = path.join(skillsDir, 'recap', 'SKILL.md');
+        console.log(JSON.stringify({
+          recapExists: fs.existsSync(recapMd),
+          recapIsCommandSkill: fs.existsSync(recapMd) && fs.readFileSync(recapMd, 'utf-8').includes('agents_command: "recap"'),
+          realSkillExists: fs.existsSync(path.join(skillsDir, 'realskill', 'SKILL.md')),
+        }));
+      `;
+      const out = execFileSync('bun', ['--eval', script], {
+        cwd: repoRoot,
+        env: { ...process.env, HOME: home },
+        encoding: 'utf-8',
+      });
+      const result = JSON.parse(out.trim()) as {
+        recapExists: boolean; recapIsCommandSkill: boolean; realSkillExists: boolean;
+      };
+      expect(result.recapExists).toBe(true);
+      expect(result.recapIsCommandSkill).toBe(true);
+      expect(result.realSkillExists).toBe(true);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
 });
 
 // When a version is removed, the command handler calls removeVersion then

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -318,6 +318,8 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     commandsDir: '', // OpenClaw uses Gateway-based slash commands, not file-based
     commandsSubdir: '',
     skillsDir: path.join(HOME, '.openclaw', 'skills'),
+    nativeCommandRuntime: true, // Gateway resolves slash commands — don't convert commands to skills
+
     hooksDir: 'hooks',
     instructionsFile: 'workspace/AGENTS.md', // Primary memory file (also has SOUL.md, IDENTITY.md, etc.)
     format: 'markdown',

--- a/src/lib/staleness/detectors/commands.ts
+++ b/src/lib/staleness/detectors/commands.ts
@@ -1,8 +1,8 @@
 /**
  * Commands detector — mirrors versions.ts:343-357. Inspects the version home,
- * returns command names. Honors the commands-as-skills marker for grok and
- * Codex >= 0.117.0; falls back to scanning `{agentDir}/<commandsSubdir>/` for
- * the native path.
+ * returns command names. Honors the commands-as-skills marker for skills-only
+ * agents (grok, kimi, Codex >= 0.117.0, …); falls back to scanning
+ * `{agentDir}/<commandsSubdir>/` for the native path.
  */
 import * as fs from 'fs';
 import * as path from 'path';
@@ -33,13 +33,14 @@ function buildCommandsDetector(agent: AgentId): ResourceDetector {
   };
 }
 
-// Detector registration mirrors writers/commands.ts — see that file for the
-// openclaw vs grok asymmetry.
+// Detector registration mirrors writers/commands.ts — skills-capable agents
+// with no native command-file dir convert commands to skills by default; only
+// agents with their own slash-command runtime (nativeCommandRuntime) opt out.
 export const commandsDetectors = lazyAgentMap<ResourceDetector>(() => {
   const m: Partial<Record<AgentId, ResourceDetector>> = {};
   for (const id of Object.keys(AGENTS) as AgentId[]) {
     const cfg = AGENTS[id];
-    if (cfg.capabilities.commands === false && (!cfg.commandsSubdir || cfg.commandsSubdir === '') && id !== 'grok') continue;
+    if (cfg.capabilities.commands === false && (!cfg.commandsSubdir || cfg.commandsSubdir === '') && cfg.nativeCommandRuntime) continue;
     const hasCommands = cfg.capabilities.commands !== false;
     const hasSkills = cfg.capabilities.skills !== false;
     if (hasCommands || hasSkills) m[id] = buildCommandsDetector(id);

--- a/src/lib/staleness/registry.test.ts
+++ b/src/lib/staleness/registry.test.ts
@@ -67,6 +67,25 @@ describe('staleness/registry', () => {
     expect(DETECTORS.commands.grok).toBeDefined();
   });
 
+  it('kimi has a commands writer + detector for commands-as-skills', () => {
+    // kimi.capabilities.commands === false with an empty commandsSubdir, like
+    // grok — but it has no native command runtime, so commands must convert to
+    // skills. Registration is driven by nativeCommandRuntime, not an agent-id
+    // allowlist; this is the assertion that would have caught the kimi
+    // silent-skip (the "every supported (agent, kind)" check skips kimi because
+    // supports('kimi','commands') is false).
+    expect(WRITERS.commands.kimi).toBeDefined();
+    expect(DETECTORS.commands.kimi).toBeDefined();
+  });
+
+  it('openclaw opts OUT of commands-as-skills (native command runtime)', () => {
+    // openclaw resolves slash commands through its Gateway runtime, so it
+    // declares nativeCommandRuntime and must NOT be registered for commands.
+    expect(AGENTS.openclaw.nativeCommandRuntime).toBe(true);
+    expect(WRITERS.commands.openclaw).toBeUndefined();
+    expect(DETECTORS.commands.openclaw).toBeUndefined();
+  });
+
   it('grok has a permissions writer + detector', () => {
     expect(WRITERS.permissions.grok).toBeDefined();
     expect(DETECTORS.permissions.grok).toBeDefined();

--- a/src/lib/staleness/writers/commands.test.ts
+++ b/src/lib/staleness/writers/commands.test.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
 
-function runCommandsWriterFixture(scriptBody: string): unknown {
+function runCommandsWriterFixture(scriptBody: string, agent = 'grok', configDirName = '.grok'): unknown {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'commands-writer-'));
   try {
     const script = `
@@ -17,11 +17,13 @@ function runCommandsWriterFixture(scriptBody: string): unknown {
 
       const home = process.env.HOME;
       if (!home) throw new Error('HOME missing');
+      const agent = ${JSON.stringify(agent)};
+      const configDirName = ${JSON.stringify(configDirName)};
       const userDir = path.join(home, '.agents');
       const projectRoot = path.join(home, 'project');
       const version = '0.2.33';
-      const versionHome = path.join(home, '.agents', '.history', 'versions', 'grok', version, 'home');
-      const agentDir = path.join(versionHome, '.grok');
+      const versionHome = path.join(home, '.agents', '.history', 'versions', agent, version, 'home');
+      const agentDir = path.join(versionHome, configDirName);
       fs.mkdirSync(projectRoot, { recursive: true });
       fs.mkdirSync(agentDir, { recursive: true });
       const writeUser = (rel, content) => {
@@ -30,8 +32,8 @@ function runCommandsWriterFixture(scriptBody: string): unknown {
         fs.writeFileSync(p, content, 'utf-8');
         return p;
       };
-      const writer = getWriter('commands', 'grok');
-      if (!writer) throw new Error('grok commands writer missing');
+      const writer = getWriter('commands', agent);
+      if (!writer) throw new Error(agent + ' commands writer missing');
       ${scriptBody}
     `;
     const out = execFileSync('bun', ['--eval', script], {
@@ -82,5 +84,24 @@ describe('commands writer', () => {
 
     expect(result.synced).toEqual(['plan']);
     expect(result.exists).toBe(false);
+  });
+
+  it('converts a command to a skill for kimi (commands:false, no native runtime)', () => {
+    const result = runCommandsWriterFixture(`
+      writeUser('commands/recap.md', ['---', 'description: Summarize the situation', '---', '', 'recap body'].join('\\n'));
+
+      const writeResult = writer.write({ version, versionHome, selection: ['recap'], cwd: projectRoot });
+      const skillPath = path.join(agentDir, 'skills', 'recap', 'SKILL.md');
+      console.log(JSON.stringify({
+        synced: writeResult.synced,
+        exists: fs.existsSync(skillPath),
+        content: fs.existsSync(skillPath) ? fs.readFileSync(skillPath, 'utf-8') : '',
+      }));
+    `, 'kimi', '.kimi-code') as { synced: string[]; exists: boolean; content: string };
+
+    expect(result.synced).toEqual(['recap']);
+    expect(result.exists).toBe(true);
+    expect(result.content).toContain('agents_command: "recap"');
+    expect(result.content).toContain('recap body');
   });
 });

--- a/src/lib/staleness/writers/commands.ts
+++ b/src/lib/staleness/writers/commands.ts
@@ -84,24 +84,19 @@ function buildCommandsWriter(agent: AgentId): ResourceWriter<string[]> {
 //   - commands-as-skills (grok, codex >= 0.117.0)
 //
 // Agents that have skills but use a NATIVE non-file slash-command system
-// (openclaw → Gateway-based commands) are NOT registered. The signal is an
-// empty `commandsSubdir`: there's no directory to write to AND the agent
-// doesn't want commands-as-skills either (it has its own runtime command
-// resolver).
+// (openclaw → Gateway-based commands) are NOT registered. They declare
+// `nativeCommandRuntime: true` to opt out — their own runtime resolves slash
+// commands, so there's nothing to write and nothing to convert.
 export const commandsWriters = lazyAgentMap<ResourceWriter<string[]>>(() => {
   const m: Partial<Record<AgentId, ResourceWriter<string[]>>> = {};
   for (const id of Object.keys(AGENTS) as AgentId[]) {
     const cfg = AGENTS[id];
     if (cfg.capabilities.commands === false && (!cfg.skillsDir || cfg.skillsDir === '')) continue;
-    // Native non-file slash-command runtime — no version-home write.
+    // Skills-capable agent with no native command-file dir: convert commands to
+    // skills by default (grok, kimi, …). Opt out only agents with their own
+    // slash-command runtime (openclaw).
     if (cfg.capabilities.commands === false && (!cfg.commandsSubdir || cfg.commandsSubdir === '')) {
-      // Grok has empty commandsSubdir AND wants commands-as-skills.
-      // Distinguish: grok has skillsDir set; openclaw also has skillsDir, so we
-      // can't use that. The cleanest signal is the agent's `cliCommand` set —
-      // openclaw flags `commands: false` AND has its Gateway runtime, while
-      // grok flags `commands: false` because grok's slash commands are skills.
-      // We opt in explicitly: only grok takes commands-as-skills today.
-      if (id !== 'grok') continue;
+      if (cfg.nativeCommandRuntime) continue;
     }
     const hasCommands = cfg.capabilities.commands !== false;
     const hasSkills = cfg.capabilities.skills !== false;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -88,6 +88,13 @@ export interface AgentConfig {
   commandsDir: string;
   commandsSubdir: string;
   skillsDir: string;
+  /**
+   * Agent resolves slash-commands through its own runtime (e.g. openclaw's
+   * Gateway), so agents-cli commands must NOT be converted into skills for it.
+   * Skills-capable agents WITHOUT a native command-file dir convert commands to
+   * skills by default; set this to opt such an agent out of that conversion.
+   */
+  nativeCommandRuntime?: boolean;
   hooksDir: string;
   pluginManifestDir?: string;
   instructionsFile: string;

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -2000,7 +2000,13 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
     // dot-dirs to keep plugin-managed subtrees (.plugins/, .promptcuts) intact.
     const skillsTargetSweep = path.join(agentDir, 'skills');
     if (!userPassedSelection && fs.existsSync(skillsTargetSweep) && !fs.lstatSync(skillsTargetSweep).isSymbolicLink()) {
+      // Trust real skills AND command-skills: when commandsAsSkills, the
+      // commands writer (above) materialized each command as a skill dir under
+      // skills/. Those names are not in skillsToSync, so without this they'd be
+      // swept as orphans — silently deleting every converted command (e.g.
+      // /recap on kimi/grok).
       const trustedSkills = new Set(skillsToSync);
+      if (commandsAsSkills) for (const cmd of commandsToSync) trustedSkills.add(cmd);
       for (const entry of fs.readdirSync(skillsTargetSweep, { withFileTypes: true })) {
         if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
         if (!trustedSkills.has(entry.name)) {


### PR DESCRIPTION
## Problem

Slash commands like `/recap` never appeared in **Kimi CLI** (and were silently dropped for other skills-only harnesses). Kimi only ingests *skills*; agents-cli commands are supposed to auto-convert into skills for such agents (the same mechanism used for Codex ≥0.117.0). Two bugs broke that.

## Root causes

1. **Hardcoded agent-id allowlist.** The commands→skills path in the staleness **writer** (`staleness/writers/commands.ts`) and **detector** (`staleness/detectors/commands.ts`) gated on `id !== 'grok'`, so Kimi — `commands: false`, empty `commandsSubdir`, `skills: true` — was dropped from the registry entirely and its commands were silently skipped.

2. **Orphan-sweep deleting fresh command-skills.** In `syncResourcesToVersion`, the commands writer materializes each command as `skills/<name>/SKILL.md`, but the subsequent skills orphan-sweep (`versions.ts`) deleted any dir not in the *real-skill* trusted set — wiping the just-written command-skills. Plugin commands survived only because they sync in a later phase. This silently affected **grok** and **Codex ≥0.117.0** as well.

## Fix

- Replace the `id !== 'grok'` allowlist with a declarative `nativeCommandRuntime` opt-out flag (`AgentConfig`), set only on **openclaw** (resolves slash commands via its own Gateway runtime). Every skills-capable agent with no native command-file dir now converts commands→skills by default — Kimi works today, future skills-only harnesses work for free.
- Add command-skill names to the skills orphan-sweep trusted set so converted commands survive a full sync.

## Verification

- Full suite (vitest, CI-equivalent): **2838 passed, 0 failed**.
- New regression tests: registry membership (kimi in / openclaw out), writer converts a command for kimi, and orphan-sweep preserves command-skills.
- End-to-end: `agents sync kimi` now syncs 24 commands (was 8); `~/.kimi-code/skills/recap/SKILL.md` exists with `agents_command: "recap"`. Confirmed `recap` survives the sweep for `grok@0.2.32` and `codex@0.134.0` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)