### PR TITLE
Redesign menubar dropdown layout

### DIFF
--- a/packages/menubar-helper/Sources/MenubarHelper/AgentsCLI.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/AgentsCLI.swift
@@ -58,6 +58,16 @@ enum AgentsCLI {
         return (try? JSONDecoder().decode([Routine].self, from: data)) ?? []
     }
 
+    static func recentSessions(limit: Int = 3) -> [RecentSession] {
+        guard let data = capture(argv(["sessions", "--all", "--limit", "\(limit)", "--json"])) else { return [] }
+        return (try? JSONDecoder().decode([RecentSession].self, from: data)) ?? []
+    }
+
+    static func doctorOverview() -> DoctorOverview? {
+        guard let data = capture(argv(["doctor", "--json"])) else { return nil }
+        return try? JSONDecoder().decode(DoctorOverview.self, from: data)
+    }
+
     // MARK: Actions
     // New interactive session: open a Terminal window running `agents run <agent>`.
     // A status-bar click can't host a TUI, so hand off to the user's terminal.

--- a/packages/menubar-helper/Sources/MenubarHelper/LocalState.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/LocalState.swift
@@ -10,8 +10,9 @@ import SQLite3
 //   terminals : ~/.agents/.cache/terminals/live-terminals.json
 //   teams     : ~/.agents/.history/teams/agents/<id>/meta.json
 //   cloud     : ~/.agents/.cache/cloud/tasks.db  (SQLite)
+//   browser   : ~/.agents/.cache/browser/<profile>/tasks.json
 //   attention : ~/.agents/.cache/state/attention/<sessionId>  (written by the Notification hook)
-//   installed : ~/.agents/.history/versions/<agent>/
+//   roster    : fixed product-supported order
 enum SessionStatus: String {
     case running
     case idle
@@ -32,14 +33,59 @@ enum LocalState {
     private static let home = NSHomeDirectory()
     private static let fm = FileManager.default
     private static let activeWindowMs: Double = 2 * 60_000  // matches ACTIVE_MTIME_WINDOW_MS
+    static let desiredAgents: [MenuAgent] = [
+        MenuAgent(id: "claude", label: "Claude"),
+        MenuAgent(id: "codex", label: "Codex"),
+        MenuAgent(id: "grok", label: "Grok-Cli"),
+        MenuAgent(id: "kimi", label: "Kimi-Cli"),
+        MenuAgent(id: "antigravity", label: "Antigravity"),
+        MenuAgent(id: "droid", label: "Droid"),
+        MenuAgent(id: "opencode", label: "OpenCode"),
+    ]
 
     static func nowMs() -> Double { Date().timeIntervalSince1970 * 1000 }
 
-    // MARK: Installed agents (cheap: list version dirs)
+    // MARK: Product-supported roster
     static func installedAgents() -> [String] {
-        let dir = "\(home)/.agents/.history/versions"
-        let names = (try? fm.contentsOfDirectory(atPath: dir)) ?? []
-        return names.filter { !$0.hasPrefix(".") }.sorted()
+        desiredAgents.map(\.id)
+    }
+
+    static func agentLabel(_ id: String) -> String {
+        desiredAgents.first { $0.id == normalizeAgent(id) }?.label ?? id
+    }
+
+    static func normalizeAgent(_ raw: String) -> String {
+        let v = raw.lowercased().replacingOccurrences(of: "_", with: "-")
+        switch v {
+        case "grok-cli": return "grok"
+        case "kimi-cli": return "kimi"
+        case "open-code": return "opencode"
+        default: return v
+        }
+    }
+
+    // MARK: Browser sessions
+    static func browserTasks(limit: Int = 3) -> [BrowserTask] {
+        let base = "\(home)/.agents/.cache/browser"
+        let profiles = (try? fm.contentsOfDirectory(atPath: base)) ?? []
+        var out: [BrowserTask] = []
+
+        for profile in profiles where !profile.hasPrefix(".") {
+            let path = "\(base)/\(profile)/tasks.json"
+            guard let data = fm.contents(atPath: path),
+                  let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { continue }
+            for (key, raw) in root {
+                guard let task = raw as? [String: Any] else { continue }
+                guard let pid = int(task["pid"]), pid > 0, pidAlive(pid) else { continue }
+                let tabs = task["tabs"] as? [String: Any]
+                let name = string(task["name"]) ?? key
+                let createdAt = double(task["createdAt"]) ?? 0
+                out.append(BrowserTask(name: name, profile: profile, tabCount: tabs?.count ?? 0,
+                                       createdAt: createdAt, pid: pid))
+            }
+        }
+
+        return Array(out.sorted { $0.createdAt > $1.createdAt }.prefix(limit))
     }
 
     // MARK: Attention sentinels (written by the Notification hook)
@@ -174,5 +220,23 @@ enum LocalState {
     private static func col(_ stmt: OpaquePointer?, _ i: Int32) -> String? {
         guard let c = sqlite3_column_text(stmt, i) else { return nil }
         return String(cString: c)
+    }
+
+    private static func int(_ value: Any?) -> Int? {
+        if let i = value as? Int { return i }
+        if let n = value as? NSNumber { return n.intValue }
+        if let s = value as? String { return Int(s) }
+        return nil
+    }
+
+    private static func double(_ value: Any?) -> Double? {
+        if let d = value as? Double { return d }
+        if let n = value as? NSNumber { return n.doubleValue }
+        if let s = value as? String { return Double(s) }
+        return nil
+    }
+
+    private static func string(_ value: Any?) -> String? {
+        value as? String
     }
 }

--- a/packages/menubar-helper/Sources/MenubarHelper/Models.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/Models.swift
@@ -17,3 +17,55 @@ struct Routine: Decodable {
     let lastRunStartedAt: String?
     let lastRunCompletedAt: String?
 }
+
+struct MenuAgent {
+    let id: String
+    let label: String
+}
+
+struct RecentSession: Decodable {
+    let id: String?
+    let shortId: String?
+    let agent: String
+    let timestamp: String?
+    let project: String?
+    let cwd: String?
+    let filePath: String?
+    let gitBranch: String?
+    let topic: String?
+    let version: String?
+}
+
+struct BrowserTask {
+    let name: String
+    let profile: String
+    let tabCount: Int
+    let createdAt: Double
+    let pid: Int
+}
+
+struct DoctorOverview: Decodable {
+    let clis: [String: DoctorCli]?
+    let sync: [DoctorSync]?
+    let orphans: [DoctorOrphan]?
+}
+
+struct DoctorCli: Decodable {
+    let installed: Bool
+    let path: String?
+    let error: String?
+}
+
+struct DoctorSync: Decodable {
+    let agent: String
+    let version: String?
+    let status: String
+}
+
+struct DoctorOrphan: Decodable {
+    let agent: String
+    let version: String?
+    let commands: Int?
+    let skills: Int?
+    let hooks: Int?
+}

--- a/packages/menubar-helper/Sources/MenubarHelper/StatusItemController.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/StatusItemController.swift
@@ -1,27 +1,33 @@
 import AppKit
 
-// Owns the NSStatusItem. Layout: NEEDS YOU (attention) pinned on top, then a +New
-// launcher, then the agent roster (per-agent running/idle counts), then a single
-// routines line. All session data is read directly from disk (LocalState) — no
-// CLI, no re-index — so the menu populates instantly on click.
+// Owns the NSStatusItem. The dropdown is intentionally data-dense: a fixed
+// product roster, activity from local sessions/browser work, routines,
+// resource sync state, and compact warnings near the footer.
 final class StatusItemController: NSObject, NSMenuDelegate {
     private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     private let accent = NSColor(red: 0x39 / 255.0, green: 0xd3 / 255.0, blue: 0x53 / 255.0, alpha: 1) // #39d353
     private let alert = NSColor.systemRed
+    private let warning = NSColor.systemOrange
 
     // Cached cheap snapshot for the badge (no teams scan).
     private var badgeSessions: [Session] = []
 
-    // Routines are the ONLY menu input that isn't a cheap disk read: `agents
-    // routines list --json` shells the CLI (~300ms Node cold-start). Calling it
-    // synchronously in menuWillOpen blocked the dropdown ~300ms on every click —
-    // 200x the cost of the whole disk-read layer. Instead we cache it: warm it on
-    // the background poll and refresh after each open, so the menu always renders
-    // from the cheap layer (~1.4ms) and the routines line shows the last state.
+    // These three reads shell the CLI or touch the sessions DB. They are kept
+    // off the click path and rendered from warm caches when the menu opens.
     private var cachedRoutines: [Routine] = []
     private var routinesLoaded = false
     private var routinesInFlight = false
     private var routinesFetchedAt: Date?
+
+    private var cachedRecentSessions: [RecentSession] = []
+    private var recentSessionsLoaded = false
+    private var recentSessionsInFlight = false
+    private var recentSessionsFetchedAt: Date?
+
+    private var cachedDoctorOverview: DoctorOverview?
+    private var doctorLoaded = false
+    private var doctorInFlight = false
+    private var doctorFetchedAt: Date?
 
     func install() {
         if let button = statusItem.button {
@@ -39,14 +45,10 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { [weak self] _ in self?.tick() }
 
         if ProcessInfo.processInfo.environment["MENUBAR_DUMP"] == "1" {
+            loadDumpCaches()
             let probe = NSMenu()
             menuWillOpen(probe)
-            FileHandle.standardError.write("=== MENU DUMP (\(probe.numberOfItems) items) ===\n".data(using: .utf8)!)
-            for it in probe.items {
-                let kind = it.isSeparatorItem ? "----" : it.title
-                let sub = it.submenu.map { " [\($0.items.map { $0.title }.joined(separator: " | "))]" } ?? ""
-                FileHandle.standardError.write("  \(kind)\(sub)\n".data(using: .utf8)!)
-            }
+            dumpMenu(probe)
             // Dump mode is a probe for tests and diagnostics; do not leave a
             // second status item alive after emitting the menu contents.
             DispatchQueue.main.async { NSApp.terminate(nil) }
@@ -61,12 +63,26 @@ final class StatusItemController: NSObject, NSMenuDelegate {
                 self?.refreshBadge()
             }
         }
-        refreshRoutines() // keep the routines cache warm off the click path
+        refreshRoutines()
+        refreshRecentSessions()
+        refreshDoctorOverview()
     }
 
-    // Fetch routines on a background queue and cache them. Throttled to ~20s
-    // (routines change rarely) and coalesced so an open + a poll don't pile up.
-    // Must be called on the main thread (Timer + menuWillOpen both are).
+    private func loadDumpCaches() {
+        cachedRoutines = AgentsCLI.routines()
+        routinesLoaded = true
+        routinesFetchedAt = Date()
+
+        cachedRecentSessions = AgentsCLI.recentSessions(limit: 6)
+        recentSessionsLoaded = true
+        recentSessionsFetchedAt = Date()
+
+        cachedDoctorOverview = AgentsCLI.doctorOverview()
+        doctorLoaded = true
+        doctorFetchedAt = Date()
+    }
+
+    // MARK: Cached CLI refreshes
     private func refreshRoutines() {
         if routinesInFlight { return }
         if let t = routinesFetchedAt, Date().timeIntervalSince(t) < 20 { return }
@@ -83,12 +99,44 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         }
     }
 
+    private func refreshRecentSessions() {
+        if recentSessionsInFlight { return }
+        if let t = recentSessionsFetchedAt, Date().timeIntervalSince(t) < 45 { return }
+        recentSessionsInFlight = true
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let s = AgentsCLI.recentSessions(limit: 6)
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.cachedRecentSessions = s
+                self.recentSessionsLoaded = true
+                self.recentSessionsFetchedAt = Date()
+                self.recentSessionsInFlight = false
+            }
+        }
+    }
+
+    private func refreshDoctorOverview() {
+        if doctorInFlight { return }
+        if let t = doctorFetchedAt, Date().timeIntervalSince(t) < 60 { return }
+        doctorInFlight = true
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let d = AgentsCLI.doctorOverview()
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.cachedDoctorOverview = d
+                self.doctorLoaded = true
+                self.doctorFetchedAt = Date()
+                self.doctorInFlight = false
+            }
+        }
+    }
+
     private func refreshBadge() {
         guard let button = statusItem.button else { return }
         let attention = badgeSessions.filter { $0.status == .attention }.count
         let running = badgeSessions.filter { $0.status == .running }.count
         if attention > 0 {
-            button.attributedTitle = badge("!", alert)       // needs you — highest priority
+            button.attributedTitle = badge("!", alert)
         } else if running > 0 {
             button.attributedTitle = badge(" \(running)", accent)
         } else {
@@ -103,125 +151,252 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         ])
     }
 
-    // MARK: - Menu (rebuilt on open against fresh, full state)
+    // MARK: - Menu
     func menuWillOpen(_ menu: NSMenu) {
-        // Critical path is all cheap disk reads — no CLI shell. Routines come
-        // from the warm cache; we kick a (throttled) refresh for next time.
+        // Critical path is all cheap disk reads. CLI-backed sections come from
+        // warm caches; opening the menu only schedules refreshes for next time.
         let sessions = LocalState.sessions(includeTeams: true)
-        let installed = LocalState.installedAgents()
+        let browserTasks = LocalState.browserTasks(limit: 3)
         let daemonPid = AgentsCLI.daemonPid()
         badgeSessions = sessions
-        rebuild(menu, sessions: sessions, installed: installed, routines: cachedRoutines, daemonPid: daemonPid)
+        rebuild(menu, sessions: sessions, browserTasks: browserTasks,
+                recentSessions: cachedRecentSessions, routines: cachedRoutines,
+                doctor: cachedDoctorOverview, daemonPid: daemonPid)
         refreshBadge()
         refreshRoutines()
+        refreshRecentSessions()
+        refreshDoctorOverview()
     }
 
-    private func rebuild(_ menu: NSMenu, sessions: [Session], installed: [String], routines: [Routine], daemonPid: Int?) {
+    private func rebuild(_ menu: NSMenu, sessions: [Session], browserTasks: [BrowserTask],
+                         recentSessions: [RecentSession], routines: [Routine],
+                         doctor: DoctorOverview?, daemonPid: Int?) {
         menu.removeAllItems()
 
-        // NEEDS YOU — attention sessions + failed/overdue routines, pinned on top.
-        let needAttention = sessions.filter { $0.status == .attention }
-        let badRoutines = routines.filter { $0.lastStatus == "failed" || $0.lastStatus == "timeout" || $0.overdue }
-        if !needAttention.isEmpty || !badRoutines.isEmpty {
-            addSectionTitle(menu, "NEEDS YOU (\(needAttention.count + badRoutines.count))", color: alert)
-            for s in needAttention {
-                let item = NSMenuItem(title: "  ! \(s.agent)  \(s.repo)  awaiting input", action: nil, keyEquivalent: "")
-                if let cwd = s.cwd { item.submenu = revealSubmenu(cwd) }
-                menu.addItem(item)
-            }
-            for r in badRoutines {
-                let why = r.overdue ? "overdue" : (r.lastStatus ?? "failed")
-                let item = NSMenuItem(title: "  ! routine \(r.name)  \(why)", action: nil, keyEquivalent: "")
-                item.submenu = routineSubmenu(r)
-                menu.addItem(item)
-            }
+        addHeader(menu, daemonPid: daemonPid)
+        addNewSession(menu)
+        menu.addItem(.separator())
+
+        addAgents(menu, sessions: sessions, doctor: doctor)
+        menu.addItem(.separator())
+
+        addActivity(menu, browserTasks: browserTasks, recentSessions: recentSessions)
+        menu.addItem(.separator())
+
+        addRoutines(menu, routines: routines)
+        menu.addItem(.separator())
+
+        addResources(menu, doctor: doctor)
+
+        let warnings = warningRows(routines: routines, doctor: doctor)
+        if !warnings.isEmpty {
             menu.addItem(.separator())
+            addSectionTitle(menu, "WARNINGS", color: warning)
+            for row in warnings.prefix(4) {
+                let it = NSMenuItem(title: "  ! \(row)", action: nil, keyEquivalent: "")
+                menu.addItem(it)
+            }
+            if warnings.count > 4 {
+                menu.addItem(disabled("  \(warnings.count - 4) more warnings"))
+            }
         }
 
-        // + New session.
-        let newItem = NSMenuItem(title: "New session", action: nil, keyEquivalent: "n")
+        menu.addItem(.separator())
+        addFooter(menu, daemonPid: daemonPid)
+    }
+
+    private func addHeader(_ menu: NSMenu, daemonPid: Int?) {
+        let status = daemonPid == nil ? "STOPPED" : "RUNNING"
+        let title = "agents-cli                                      \(status)"
+        let item = disabled(title)
+        let attr = NSMutableAttributedString(string: title, attributes: [
+            .foregroundColor: NSColor.labelColor,
+            .font: NSFont.monospacedSystemFont(ofSize: 13, weight: .semibold),
+        ])
+        let range = (title as NSString).range(of: status)
+        attr.addAttributes([
+            .foregroundColor: daemonPid == nil ? alert : accent,
+            .font: NSFont.monospacedSystemFont(ofSize: 12, weight: .bold),
+        ], range: range)
+        item.attributedTitle = attr
+        menu.addItem(item)
+    }
+
+    private func addNewSession(_ menu: NSMenu) {
+        let newItem = NSMenuItem(title: "New Session", action: nil, keyEquivalent: "n")
         let newSub = NSMenu()
-        for agent in installed {
-            let it = NSMenuItem(title: agent, action: #selector(onNewSession(_:)), keyEquivalent: "")
-            it.target = self; it.representedObject = agent
+        for agent in LocalState.desiredAgents {
+            let it = NSMenuItem(title: agent.label, action: #selector(onNewSession(_:)), keyEquivalent: "")
+            it.target = self
+            it.representedObject = agent.id
             newSub.addItem(it)
         }
         newItem.submenu = newSub
         menu.addItem(newItem)
-        menu.addItem(.separator())
+    }
 
-        // Agent roster — per-agent counts; only show agents that are installed.
+    private func addAgents(_ menu: NSMenu, sessions: [Session], doctor: DoctorOverview?) {
         let running = sessions.filter { $0.status == .running }.count
         let idle = sessions.filter { $0.status == .idle }.count
         addSectionTitle(menu, "AGENTS  ·  \(running) running · \(idle) idle", color: .secondaryLabelColor)
-        for agent in installed {
-            let mine = sessions.filter { $0.agent == agent }
-            let item = NSMenuItem(title: rosterRow(agent: agent, sessions: mine), action: nil, keyEquivalent: "")
-            item.submenu = rosterSubmenu(agent: agent, sessions: mine)
+        for agent in LocalState.desiredAgents {
+            let mine = sessions.filter { LocalState.normalizeAgent($0.agent) == agent.id }
+            let item = NSMenuItem(title: rosterRow(agent: agent, sessions: mine, doctor: doctor),
+                                  action: nil, keyEquivalent: "")
+            item.submenu = rosterSubmenu(agent: agent, sessions: mine, doctor: doctor)
             menu.addItem(item)
         }
-        menu.addItem(.separator())
+    }
 
-        // Routines — one compact line (secondary). Cached off the click path;
-        // shows "checking…" only until the first background fetch lands.
-        let routineLine: String
-        if routines.isEmpty && !routinesLoaded {
-            routineLine = "routines   checking…"
-        } else if routines.isEmpty {
-            routineLine = "routines   none"
-        } else {
-            let next = routines.compactMap { $0.enabled ? $0.nextRunHuman : nil }.first(where: { $0 != "-" }) ?? "—"
-            let failed = badRoutines.count
-            routineLine = "routines   next \(next)" + (failed > 0 ? "  ·  \(failed) failed" : "")
+    private func addActivity(_ menu: NSMenu, browserTasks: [BrowserTask], recentSessions: [RecentSession]) {
+        addSectionTitle(menu, "ACTIVITY", color: .secondaryLabelColor)
+        let visibleRecentSessions = Array(recentSessions.filter {
+            let id = LocalState.normalizeAgent($0.agent)
+            return LocalState.desiredAgents.contains { $0.id == id }
+        }.prefix(3))
+
+        for task in browserTasks {
+            let tabs = task.tabCount == 1 ? "1 tab" : "\(task.tabCount) tabs"
+            let title = "  Browser      \(trim(task.name, 28)) · \(shortProfile(task.profile)) · \(tabs)"
+            let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+            item.submenu = browserTaskSubmenu(task)
+            menu.addItem(item)
         }
-        let routinesItem = NSMenuItem(title: routineLine, action: nil, keyEquivalent: "")
-        if !routines.isEmpty { routinesItem.submenu = allRoutinesSubmenu(routines) }
-        menu.addItem(routinesItem)
-        menu.addItem(.separator())
 
-        // Footer.
+        if visibleRecentSessions.isEmpty {
+            menu.addItem(disabled(recentSessionsLoaded ? "  No recent sessions" : "  Recent sessions checking…"))
+            return
+        }
+
+        for session in visibleRecentSessions {
+            let title = recentSessionTitle(session)
+            let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+            item.submenu = recentSessionSubmenu(session)
+            menu.addItem(item)
+        }
+    }
+
+    private func addRoutines(_ menu: NSMenu, routines: [Routine]) {
+        addSectionTitle(menu, "ROUTINES", color: .secondaryLabelColor)
+        let item = NSMenuItem(title: routinesSummary(routines), action: nil, keyEquivalent: "")
+        if !routines.isEmpty { item.submenu = allRoutinesSubmenu(routines) }
+        menu.addItem(item)
+    }
+
+    private func addResources(_ menu: NSMenu, doctor: DoctorOverview?) {
+        addSectionTitle(menu, "RESOURCES", color: .secondaryLabelColor)
+        let item = NSMenuItem(title: resourcesSummary(doctor), action: nil, keyEquivalent: "")
+        item.submenu = resourcesSubmenu(doctor)
+        menu.addItem(item)
+    }
+
+    private func addFooter(_ menu: NSMenu, daemonPid: Int?) {
         if daemonPid != nil {
             let stop = NSMenuItem(title: "Stop scheduler", action: #selector(onStopScheduler), keyEquivalent: "")
             stop.target = self
             menu.addItem(stop)
         }
+        let settings = NSMenuItem(title: "Settings", action: #selector(onOpenAgentsHome), keyEquivalent: ",")
+        settings.target = self
+        menu.addItem(settings)
+
         let quit = NSMenuItem(title: "Quit menu bar", action: #selector(onQuit), keyEquivalent: "q")
         quit.target = self
         menu.addItem(quit)
     }
 
     // MARK: Row builders
-    private func rosterRow(agent: String, sessions: [Session]) -> String {
+    private func rosterRow(agent: MenuAgent, sessions: [Session], doctor: DoctorOverview?) -> String {
         let attn = sessions.filter { $0.status == .attention }.count
         let run = sessions.filter { $0.status == .running }.count
         let idle = sessions.filter { $0.status == .idle }.count
-        let name = agent.padding(toLength: 11, withPad: " ", startingAt: 0)
-        if attn > 0 { return "\(name) ! \(attn) awaiting input" }
-        if run > 0 { return "\(name) ● \(run) running" + (idle > 0 ? " · \(idle) idle" : "") }
-        if idle > 0 { return "\(name) ○ \(idle) idle" }
-        return "\(name) ○ idle"
+        let name = agent.label.padding(toLength: 13, withPad: " ", startingAt: 0)
+        let resource = resourceHint(agent.id, doctor: doctor)
+        if cliInstalled(agent.id, doctor: doctor) == false { return "\(name) ! missing CLI" }
+        if attn > 0 { return "\(name) ! \(attn) awaiting input\(resource)" }
+        if run > 0 { return "\(name) ● \(run) running" + (idle > 0 ? " · \(idle) idle" : "") + resource }
+        if idle > 0 { return "\(name) ○ \(idle) idle\(resource)" }
+        return "\(name) ○ ready\(resource)"
     }
 
-    private func rosterSubmenu(agent: String, sessions: [Session]) -> NSMenu {
+    private func rosterSubmenu(agent: MenuAgent, sessions: [Session], doctor: DoctorOverview?) -> NSMenu {
         let sub = NSMenu()
-        for s in sessions {
-            let mark = s.status == .attention ? "! " : (s.status == .running ? "● " : "○ ")
-            let detail = s.detail.isEmpty ? "" : "  ·  \(s.detail)"
-            let row = NSMenuItem(title: "\(mark)\(s.repo)\(detail)", action: nil, keyEquivalent: "")
-            if let cwd = s.cwd { row.submenu = revealSubmenu(cwd) }
-            sub.addItem(row)
+        if sessions.isEmpty {
+            sub.addItem(disabled("No live sessions"))
+        } else {
+            for s in sessions {
+                let mark = s.status == .attention ? "! " : (s.status == .running ? "● " : "○ ")
+                let detail = s.detail.isEmpty ? "" : "  ·  \(trim(s.detail, 40))"
+                let row = NSMenuItem(title: "\(mark)\(s.repo)\(detail)", action: nil, keyEquivalent: "")
+                if let cwd = s.cwd { row.submenu = revealSubmenu(cwd) }
+                sub.addItem(row)
+            }
         }
-        if !sessions.isEmpty { sub.addItem(.separator()) }
-        let new = NSMenuItem(title: "New \(agent) session", action: #selector(onNewSession(_:)), keyEquivalent: "")
-        new.target = self; new.representedObject = agent
+
+        sub.addItem(.separator())
+        if let sync = syncState(agent.id, doctor: doctor) {
+            sub.addItem(disabled("Resources: \(sync.status)\(sync.version.map { " · \($0)" } ?? "")"))
+        } else {
+            sub.addItem(disabled(doctorLoaded ? "Resources: unknown" : "Resources: checking…"))
+        }
+        if let cli = doctor?.clis?[agent.id] {
+            sub.addItem(disabled(cli.installed ? "CLI installed" : "CLI missing"))
+        }
+
+        sub.addItem(.separator())
+        let new = NSMenuItem(title: "New \(agent.label) session", action: #selector(onNewSession(_:)), keyEquivalent: "")
+        new.target = self
+        new.representedObject = agent.id
         sub.addItem(new)
+        return sub
+    }
+
+    private func browserTaskSubmenu(_ task: BrowserTask) -> NSMenu {
+        let sub = NSMenu()
+        sub.addItem(disabled("Profile: \(task.profile)"))
+        sub.addItem(disabled("PID: \(task.pid)"))
+        let open = NSMenuItem(title: "Open browser cache", action: #selector(onOpenPath(_:)), keyEquivalent: "")
+        open.target = self
+        open.representedObject = "\(AgentsCLI.home)/.agents/.cache/browser/\(task.profile)"
+        sub.addItem(open)
+        return sub
+    }
+
+    private func recentSessionSubmenu(_ session: RecentSession) -> NSMenu {
+        let sub = NSMenu()
+        if let topic = session.topic, !topic.isEmpty {
+            sub.addItem(disabled(trim(topic, 60)))
+            sub.addItem(.separator())
+        }
+        if let version = session.version {
+            sub.addItem(disabled("Version: \(version)"))
+        }
+        if let branch = session.gitBranch {
+            sub.addItem(disabled("Branch: \(branch)"))
+        }
+        if session.version != nil || session.gitBranch != nil {
+            sub.addItem(.separator())
+        }
+        if let filePath = session.filePath {
+            let open = NSMenuItem(title: "Open transcript", action: #selector(onOpenPath(_:)), keyEquivalent: "")
+            open.target = self
+            open.representedObject = filePath
+            sub.addItem(open)
+        }
+        if let cwd = session.cwd {
+            let reveal = NSMenuItem(title: "Reveal project", action: #selector(onOpenPath(_:)), keyEquivalent: "")
+            reveal.target = self
+            reveal.representedObject = cwd
+            sub.addItem(reveal)
+        }
         return sub
     }
 
     private func revealSubmenu(_ cwd: String) -> NSMenu {
         let sub = NSMenu()
         let reveal = NSMenuItem(title: "Reveal working dir", action: #selector(onOpenPath(_:)), keyEquivalent: "")
-        reveal.target = self; reveal.representedObject = cwd
+        reveal.target = self
+        reveal.representedObject = cwd
         sub.addItem(reveal)
         return sub
     }
@@ -229,10 +404,20 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     private func routineSubmenu(_ r: Routine) -> NSMenu {
         let sub = NSMenu()
         let run = NSMenuItem(title: "Run now", action: #selector(onRoutineRun(_:)), keyEquivalent: "")
-        run.target = self; run.representedObject = r.name
+        run.target = self
+        run.representedObject = r.name
         sub.addItem(run)
+
+        let pauseResume = NSMenuItem(title: r.enabled ? "Pause" : "Resume",
+                                     action: r.enabled ? #selector(onRoutinePause(_:)) : #selector(onRoutineResume(_:)),
+                                     keyEquivalent: "")
+        pauseResume.target = self
+        pauseResume.representedObject = r.name
+        sub.addItem(pauseResume)
+
         let logs = NSMenuItem(title: "Logs", action: #selector(onRoutineLogs(_:)), keyEquivalent: "")
-        logs.target = self; logs.representedObject = r.name
+        logs.target = self
+        logs.representedObject = r.name
         sub.addItem(logs)
         return sub
     }
@@ -240,7 +425,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     private func allRoutinesSubmenu(_ routines: [Routine]) -> NSMenu {
         let sub = NSMenu()
         for r in routines {
-            let mark = r.lastStatus == "failed" || r.lastStatus == "timeout" ? "! "
+            let mark = r.lastStatus == "failed" || r.lastStatus == "timeout" || r.overdue ? "! "
                 : (r.enabled ? "  " : "· ")
             let when = r.enabled ? (r.nextRunHuman ?? r.schedule) : "paused"
             let item = NSMenuItem(title: "\(mark)\(r.name)  \(when)", action: nil, keyEquivalent: "")
@@ -250,15 +435,135 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         return sub
     }
 
+    private func resourcesSubmenu(_ doctor: DoctorOverview?) -> NSMenu {
+        let sub = NSMenu()
+        guard let doctor else {
+            sub.addItem(disabled(doctorLoaded ? "Doctor unavailable" : "Checking resources…"))
+            return sub
+        }
+
+        for agent in LocalState.desiredAgents {
+            let sync = syncState(agent.id, doctor: doctor)
+            let cli = doctor.clis?[agent.id]
+            var title = "\(agent.label)  "
+            if cli?.installed == false {
+                title += "missing CLI"
+            } else if let sync {
+                title += "\(sync.status)" + (sync.version.map { " · \($0)" } ?? "")
+            } else {
+                title += "unknown"
+            }
+            sub.addItem(disabled(title))
+        }
+
+        sub.addItem(.separator())
+        let open = NSMenuItem(title: "Open ~/.agents", action: #selector(onOpenAgentsHome), keyEquivalent: "")
+        open.target = self
+        sub.addItem(open)
+        return sub
+    }
+
+    // MARK: Summaries
+    private func routinesSummary(_ routines: [Routine]) -> String {
+        if routines.isEmpty && !routinesLoaded { return "  checking…" }
+        if routines.isEmpty { return "  none" }
+
+        let next = routines.compactMap { $0.enabled ? $0.nextRunHuman : nil }.first(where: { $0 != "-" }) ?? "—"
+        let bad = routines.filter { $0.lastStatus == "failed" || $0.lastStatus == "timeout" || $0.overdue }.count
+        let paused = routines.filter { !$0.enabled }.count
+        var parts = ["  \(routines.count) routines", "next \(next)"]
+        if paused > 0 { parts.append("\(paused) paused") }
+        if bad > 0 { parts.append("\(bad) warning\(bad == 1 ? "" : "s")") }
+        return parts.joined(separator: " · ")
+    }
+
+    private func resourcesSummary(_ doctor: DoctorOverview?) -> String {
+        guard let doctor else { return doctorLoaded ? "  unavailable" : "  checking…" }
+        let sync = desiredSyncStates(doctor)
+        let stale = sync.filter { $0.status == "stale" }.count
+        let never = sync.filter { $0.status == "never-synced" }.count
+        let missing = LocalState.desiredAgents.filter { doctor.clis?[$0.id]?.installed == false }.count
+        var parts: [String] = []
+        if stale > 0 { parts.append("\(stale) stale") }
+        if never > 0 { parts.append("\(never) never synced") }
+        if missing > 0 { parts.append("\(missing) missing CLI") }
+        if parts.isEmpty { parts.append("all synced") }
+        return "  sync \(parts.joined(separator: " · "))"
+    }
+
+    private func warningRows(routines: [Routine], doctor: DoctorOverview?) -> [String] {
+        var rows: [String] = []
+
+        let badRoutines = routines.filter { $0.lastStatus == "failed" || $0.lastStatus == "timeout" || $0.overdue }
+        if badRoutines.count == 1, let r = badRoutines.first {
+            let why = r.overdue ? "overdue" : (r.lastStatus ?? "failed")
+            rows.append("Routine \(r.name) \(why)")
+        } else if badRoutines.count > 1 {
+            rows.append("\(badRoutines.count) routines need attention")
+        }
+
+        if let doctor {
+            let missing = LocalState.desiredAgents.filter { doctor.clis?[$0.id]?.installed == false }.map(\.label)
+            if !missing.isEmpty { rows.append("Missing CLI: \(list(missing))") }
+
+            let never = desiredSyncStates(doctor).filter { $0.status == "never-synced" }.map { LocalState.agentLabel($0.agent) }
+            if !never.isEmpty { rows.append("Never synced: \(list(never))") }
+
+            let stale = desiredSyncStates(doctor).filter { $0.status == "stale" }.map { LocalState.agentLabel($0.agent) }
+            if !stale.isEmpty { rows.append("Stale resources: \(list(stale))") }
+
+            let drift = doctor.orphans?.filter { LocalState.desiredAgents.map(\.id).contains($0.agent) } ?? []
+            if !drift.isEmpty { rows.append("Local-only resources in \(drift.count) agents") }
+        }
+
+        return rows
+    }
+
+    private func recentSessionTitle(_ session: RecentSession) -> String {
+        let agent = LocalState.agentLabel(session.agent).padding(toLength: 11, withPad: " ", startingAt: 0)
+        let project = session.project ?? session.cwd.map { ($0 as NSString).lastPathComponent } ?? "session"
+        let sid = session.shortId ?? session.id.map { String($0.prefix(8)) } ?? "recent"
+        return "  \(agent) \(trim(project, 18)) · \(sid) · \(shortWhen(session.timestamp))"
+    }
+
+    private func resourceHint(_ agent: String, doctor: DoctorOverview?) -> String {
+        guard let doctor else { return "" }
+        if doctor.clis?[agent]?.installed == false { return " · missing CLI" }
+        guard let sync = syncState(agent, doctor: doctor) else { return "" }
+        switch sync.status {
+        case "stale": return " · stale"
+        case "never-synced": return " · never synced"
+        case "missing": return " · missing resources"
+        default: return ""
+        }
+    }
+
+    private func cliInstalled(_ agent: String, doctor: DoctorOverview?) -> Bool? {
+        doctor?.clis?[agent]?.installed
+    }
+
+    private func syncState(_ agent: String, doctor: DoctorOverview?) -> DoctorSync? {
+        doctor?.sync?.first { $0.agent == agent }
+    }
+
+    private func desiredSyncStates(_ doctor: DoctorOverview) -> [DoctorSync] {
+        LocalState.desiredAgents.compactMap { agent in
+            (doctor.sync ?? []).first { $0.agent == agent.id }
+        }
+    }
+
     // MARK: Actions
     @objc private func onNewSession(_ s: NSMenuItem) {
         if let a = s.representedObject as? String { AgentsCLI.newSession(agent: a) }
     }
     @objc private func onRoutineRun(_ s: NSMenuItem) { withName(s, AgentsCLI.routineRun) }
+    @objc private func onRoutinePause(_ s: NSMenuItem) { withName(s, AgentsCLI.routinePause) }
+    @objc private func onRoutineResume(_ s: NSMenuItem) { withName(s, AgentsCLI.routineResume) }
     @objc private func onRoutineLogs(_ s: NSMenuItem) { withName(s, AgentsCLI.routineLogs) }
     @objc private func onOpenPath(_ s: NSMenuItem) {
         if let p = s.representedObject as? String { AgentsCLI.openPath(p) }
     }
+    @objc private func onOpenAgentsHome() { AgentsCLI.openPath("\(AgentsCLI.home)/.agents") }
     @objc private func onStopScheduler() { AgentsCLI.stopDaemon() }
     @objc private func onQuit() { AgentsCLI.menubarDisable(); NSApp.terminate(nil) }
 
@@ -268,12 +573,63 @@ final class StatusItemController: NSObject, NSMenuDelegate {
 
     // MARK: Helpers
     private func addSectionTitle(_ menu: NSMenu, _ title: String, color: NSColor) {
-        let it = NSMenuItem(title: title, action: nil, keyEquivalent: "")
-        it.isEnabled = false
+        let it = disabled(title)
         it.attributedTitle = NSAttributedString(string: title, attributes: [
             .foregroundColor: color,
             .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
         ])
         menu.addItem(it)
+    }
+
+    private func disabled(_ title: String) -> NSMenuItem {
+        let it = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        it.isEnabled = false
+        return it
+    }
+
+    private func trim(_ value: String, _ max: Int) -> String {
+        if value.count <= max { return value }
+        return String(value.prefix(max - 1)) + "…"
+    }
+
+    private func shortProfile(_ profile: String) -> String {
+        profile.replacingOccurrences(of: "@endpoint-0", with: "")
+    }
+
+    private func shortWhen(_ raw: String?) -> String {
+        guard let raw, let date = parseIso(raw) else { return "recent" }
+        let cal = Calendar.current
+        if cal.isDateInToday(date) {
+            let f = DateFormatter()
+            f.dateStyle = .none
+            f.timeStyle = .short
+            return "today \(f.string(from: date))"
+        }
+        if cal.isDateInYesterday(date) { return "yesterday" }
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        return f.string(from: date)
+    }
+
+    private func parseIso(_ raw: String) -> Date? {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let d = f.date(from: raw) { return d }
+        f.formatOptions = [.withInternetDateTime]
+        return f.date(from: raw)
+    }
+
+    private func list(_ values: [String], limit: Int = 3) -> String {
+        if values.count <= limit { return values.joined(separator: ", ") }
+        return values.prefix(limit).joined(separator: ", ") + " +\(values.count - limit)"
+    }
+
+    private func dumpMenu(_ menu: NSMenu) {
+        FileHandle.standardError.write("=== MENU DUMP (\(menu.numberOfItems) items) ===\n".data(using: .utf8)!)
+        for it in menu.items {
+            let kind = it.isSeparatorItem ? "----" : it.title
+            let sub = it.submenu.map { " [\($0.items.map { $0.title }.joined(separator: " | "))]" } ?? ""
+            FileHandle.standardError.write("  \(kind)\(sub)\n".data(using: .utf8)!)
+        }
     }
 }

--- a/packages/menubar-helper/Sources/MenubarHelper/main.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/main.swift
@@ -31,4 +31,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 let delegate = AppDelegate(controller)
 app.delegate = delegate
+if ProcessInfo.processInfo.environment["MENUBAR_DUMP"] == "1" {
+    controller.install()
+    exit(0)
+}
 app.run()


### PR DESCRIPTION
## Summary
- redesign the macOS menu bar dropdown around Agents, Activity, Routines, Resources, and Warnings
- use the fixed supported agent roster/order: Claude, Codex, Grok-Cli, Kimi-Cli, Antigravity, Droid, OpenCode
- show browser tasks, supported recent sessions, routine state, resource sync status, and compact warnings
- make MENUBAR_DUMP reliable from the raw helper binary

## Verification
- swift build -c release
- packages/menubar-helper/scripts/build.sh release
- MENUBAR_DUMP=1 bin/MenubarHelper.app/Contents/MacOS/MenubarHelper
- git diff --check