### PR TITLE
fix(plugins): discover the system repo marketplace so sync stops deleting code/git/social

### DIFF
--- a/src/lib/plugin-marketplace.test.ts
+++ b/src/lib/plugin-marketplace.test.ts
@@ -104,6 +104,7 @@ describe('discoverMarketplaces', () => {
       pluginsDir?: string;
       extras?: Array<{ alias: string; dir: string; url: string }>;
       projectPlugins?: string | null;
+      systemPlugins?: string | null;
     },
     fn: (mod: typeof import('./plugin-marketplace.js')) => void | Promise<void>
   ): Promise<void> {
@@ -116,6 +117,10 @@ describe('discoverMarketplaces', () => {
         getPluginsDir: () => overrides.pluginsDir ?? userPlugins,
         getEnabledExtraRepos: () => overrides.extras ?? [],
         getProjectPluginsDir: () => overrides.projectPlugins ?? null,
+        // Default to a non-existent path so tests that don't opt into a system
+        // repo see no agents-system marketplace (deterministic across machines
+        // that may have a real ~/.agents/.system/plugins on disk).
+        getSystemPluginsDir: () => overrides.systemPlugins ?? path.join(tmpDir, 'no-system', 'plugins'),
       };
     });
     try {
@@ -171,6 +176,46 @@ describe('discoverMarketplaces', () => {
       expect(found.map(m => m.name)).toEqual(['agents-cli', 'agents-project']);
       expect(found[1].spec).toMatchObject({ kind: 'project', root: projectPlugins });
     });
+  });
+
+  it('includes the system marketplace FIRST when ~/.agents/.system/plugins/ exists', async () => {
+    const systemPlugins = path.join(tmpDir, 'system', 'plugins');
+    fs.mkdirSync(systemPlugins, { recursive: true });
+    await withState({ systemPlugins }, ({ discoverMarketplaces }) => {
+      const found = discoverMarketplaces();
+      // System listed first (lowest precedence), then the user repo.
+      expect(found.map(m => m.name)).toEqual(['agents-system', 'agents-cli']);
+      expect(found[0].spec).toMatchObject({ kind: 'system', root: systemPlugins });
+      expect(found[0].pluginsRoot).toBe(systemPlugins);
+    });
+  });
+
+  it('skips the system marketplace when its plugins/ dir does not exist', async () => {
+    await withState({ systemPlugins: path.join(tmpDir, 'absent', 'plugins') }, ({ discoverMarketplaces }) => {
+      expect(discoverMarketplaces().map(m => m.name)).toEqual(['agents-cli']);
+    });
+  });
+
+  it('orders marketplaces low→high precedence so name-dedupe keeps the highest scope', async () => {
+    const systemPlugins = path.join(tmpDir, 'system', 'plugins');
+    const extraDir = path.join(tmpDir, 'extra-extras');
+    const projectPlugins = path.join(tmpDir, 'proj', '.agents', 'plugins');
+    fs.mkdirSync(systemPlugins, { recursive: true });
+    fs.mkdirSync(path.join(extraDir, 'plugins'), { recursive: true });
+    fs.mkdirSync(projectPlugins, { recursive: true });
+    await withState(
+      { systemPlugins, extras: [{ alias: 'extras', dir: extraDir, url: 'gh:x/y' }], projectPlugins },
+      ({ discoverMarketplaces }) => {
+        // Order is the dedupe order consumers rely on (Map/last-wins): a plugin
+        // present in multiple repos resolves to project > extra > user > system.
+        expect(discoverMarketplaces({ cwd: '/whatever' }).map(m => m.name)).toEqual([
+          'agents-system',
+          'agents-cli',
+          'agents-extras',
+          'agents-project',
+        ]);
+      }
+    );
   });
 });
 

--- a/src/lib/plugin-marketplace.ts
+++ b/src/lib/plugin-marketplace.ts
@@ -30,7 +30,7 @@ import * as fs from 'fs';
 import { agentConfigDirName } from './agents.js';
 import * as path from 'path';
 import type { AgentId, DiscoveredPlugin, PluginManifest, MarketplaceSpec, DiscoveredMarketplace } from './types.js';
-import { getPluginsDir, getEnabledExtraRepos, getProjectPluginsDir } from './state.js';
+import { getPluginsDir, getEnabledExtraRepos, getProjectPluginsDir, getSystemPluginsDir } from './state.js';
 
 /**
  * Canonical name for the user-repo marketplace (~/.agents/plugins/). Kept as an
@@ -115,6 +115,20 @@ function descriptionFor(spec: MarketplaceSpec): string {
  */
 export function discoverMarketplaces(opts: { cwd?: string } = {}): DiscoveredMarketplace[] {
   const out: DiscoveredMarketplace[] = [];
+
+  // System repo — npm-shipped defaults (~/.agents/.system/plugins/) → the
+  // "agents-system" marketplace. Listed FIRST so it has the lowest precedence:
+  // consumers that dedupe by plugin name keep the LAST occurrence, letting
+  // user / extra / project plugins of the same name override a system one (same
+  // direction collectPluginScopes() in project-launch.ts uses). Without this,
+  // `agents sync` never discovers system plugins, so cleanOrphanedPluginSkills
+  // trashes whatever a project launch installed under agents-system and the
+  // marketplace gets unregistered on the next sync.
+  const systemRoot = getSystemPluginsDir();
+  if (dirExists(systemRoot)) {
+    const spec: MarketplaceSpec = { kind: 'system', root: systemRoot };
+    out.push({ spec, name: marketplaceNameFor(spec), pluginsRoot: systemRoot, description: descriptionFor(spec) });
+  }
 
   // User repo — always the canonical "agents-cli" marketplace.
   const userRoot = getPluginsDir();

--- a/src/lib/plugins.test.ts
+++ b/src/lib/plugins.test.ts
@@ -265,6 +265,65 @@ describe('discoverPlugins across marketplaces', () => {
     );
   });
 
+  it('getPlugin resolves a name collision to the highest-precedence scope (project > extra > user > system)', async () => {
+    const systemDir = path.join(tmpDir, 'system', 'plugins');
+    fs.mkdirSync(systemDir, { recursive: true });
+    // Same name in all four scopes — the user must NOT get the system copy.
+    writePlugin(systemDir, 'code');
+    writePlugin(userDir, 'code');
+    writePlugin(path.join(extraRepo, 'plugins'), 'code');
+    writePlugin(projectDir, 'code');
+
+    await withState(
+      {
+        getSystemPluginsDir: () => systemDir,
+        getPluginsDir: () => userDir,
+        getEnabledExtraRepos: () => [{ alias: 'extras', dir: extraRepo, url: '' }],
+        getProjectPluginsDir: () => projectDir,
+      },
+      ({ getPlugin }) => {
+        expect(getPlugin('code')?.marketplace).toBe('agents-project');
+      }
+    );
+  });
+
+  it('getPlugin prefers the user copy over a same-named system plugin', async () => {
+    const systemDir = path.join(tmpDir, 'system', 'plugins');
+    fs.mkdirSync(systemDir, { recursive: true });
+    writePlugin(systemDir, 'code');
+    writePlugin(userDir, 'code');
+
+    await withState(
+      {
+        getSystemPluginsDir: () => systemDir,
+        getPluginsDir: () => userDir,
+        getEnabledExtraRepos: () => [],
+        getProjectPluginsDir: () => null,
+      },
+      ({ getPlugin }) => {
+        expect(getPlugin('code')?.marketplace).toBe('agents-cli');
+      }
+    );
+  });
+
+  it('getPlugin still resolves a system-only plugin', async () => {
+    const systemDir = path.join(tmpDir, 'system', 'plugins');
+    fs.mkdirSync(systemDir, { recursive: true });
+    writePlugin(systemDir, 'sysonly');
+
+    await withState(
+      {
+        getSystemPluginsDir: () => systemDir,
+        getPluginsDir: () => userDir,
+        getEnabledExtraRepos: () => [],
+        getProjectPluginsDir: () => null,
+      },
+      ({ getPlugin }) => {
+        expect(getPlugin('sysonly')?.marketplace).toBe('agents-system');
+      }
+    );
+  });
+
   it('does NOT discover plugins from a disabled (filtered-out) extra repo', async () => {
     writePlugin(userDir, 'alpha');
     // The disabled repo's plugin exists on disk, but getEnabledExtraRepos (which

--- a/src/lib/plugins.test.ts
+++ b/src/lib/plugins.test.ts
@@ -137,7 +137,7 @@ describe('discoverPlugins', () => {
     vi.resetModules();
     vi.doMock('./state.js', async (importOriginal) => {
       const actual = await importOriginal<typeof import('./state.js')>();
-      return { ...actual, getPluginsDir: () => pluginsDir, getEnabledExtraRepos: () => [], getProjectPluginsDir: () => null };
+      return { ...actual, getPluginsDir: () => pluginsDir, getEnabledExtraRepos: () => [], getProjectPluginsDir: () => null, getSystemPluginsDir: () => path.join(tmpDir, 'no-system') };
     });
 
     try {
@@ -159,7 +159,7 @@ describe('discoverPlugins', () => {
     vi.resetModules();
     vi.doMock('./state.js', async (importOriginal) => {
       const actual = await importOriginal<typeof import('./state.js')>();
-      return { ...actual, getPluginsDir: () => pluginsDir, getEnabledExtraRepos: () => [], getProjectPluginsDir: () => null };
+      return { ...actual, getPluginsDir: () => pluginsDir, getEnabledExtraRepos: () => [], getProjectPluginsDir: () => null, getSystemPluginsDir: () => path.join(tmpDir, 'no-system') };
     });
 
     try {
@@ -213,7 +213,9 @@ describe('discoverPlugins across marketplaces', () => {
     vi.resetModules();
     vi.doMock('./state.js', async (importOriginal) => {
       const actual = await importOriginal<typeof import('./state.js')>();
-      return { ...actual, ...overrides };
+      // Isolate from a real ~/.agents/.system/plugins on the dev machine; a test
+      // can still opt into a system repo by passing getSystemPluginsDir in overrides.
+      return { ...actual, getSystemPluginsDir: () => path.join(tmpDir, 'no-system'), ...overrides };
     });
     try {
       const mod = await import('./plugins.js');

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -13,7 +13,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
 import type { AgentId, DiscoveredPlugin, PluginManifest, MarketplaceSpec } from './types.js';
-import { getPluginsDir, getTrashPluginsDir, getExtraPluginsDir, getProjectPluginsDir } from './state.js';
+import { getPluginsDir, getTrashPluginsDir, getExtraPluginsDir, getProjectPluginsDir, getSystemPluginsDir } from './state.js';
 import { IS_WINDOWS, isWindowsAbsolutePath, homeDir } from './platform/index.js';
 import { assertSafeGitTransport } from './git.js';
 import { listInstalledVersions, getVersionHomePath } from './versions.js';
@@ -36,6 +36,7 @@ import {
   marketplaceNameFor,
   MARKETPLACE_NAME,
   PROJECT_MARKETPLACE_NAME,
+  SYSTEM_MARKETPLACE_NAME,
 } from './plugin-marketplace.js';
 
 const PLUGIN_MANIFEST_DIR = '.claude-plugin';
@@ -239,11 +240,19 @@ export function assertPluginTargetContained(targetRoot: string, pluginsDir: stri
 }
 
 /**
- * Get a specific plugin by name.
+ * Get a specific plugin by name. On a cross-marketplace name collision the
+ * highest-precedence scope wins (project > extra > user > system) — the same
+ * resolution the sync writer's Map(last-wins) dedupe and collectPluginScopes()
+ * use. discoverPlugins() yields low→high precedence order, so the LAST match is
+ * the winner; returning the first match would resolve to the lowest scope (e.g.
+ * a system plugin over the user's same-named one), which is exactly backwards.
  */
 export function getPlugin(name: string): DiscoveredPlugin | null {
   const plugins = discoverPlugins();
-  return plugins.find(p => p.name === name) || null;
+  for (let i = plugins.length - 1; i >= 0; i--) {
+    if (plugins[i].name === name) return plugins[i];
+  }
+  return null;
 }
 
 /**
@@ -451,12 +460,17 @@ export function checkPluginDependencies(manifest: PluginManifest): string[] {
 /**
  * Reconstruct a MarketplaceSpec from a marketplace name. The inverse of
  * marketplaceNameFor(): "agents-cli" → user, "agents-project" → project,
- * "agents-<alias>" → extra. The per-version marketplace operations only key off
- * the name (never spec.root), but we resolve the real source root anyway so the
- * spec is honest for any caller that inspects it.
+ * "agents-system" → system, "agents-<alias>" → extra. The per-version
+ * marketplace operations only key off the name (never spec.root), but we
+ * resolve the real source root anyway so the spec is honest for any caller that
+ * inspects it (e.g. descriptionFor, which would otherwise label the system
+ * marketplace as an extra repo named "system").
  */
 function marketplaceSpecForName(name: string | undefined, cwd: string = process.cwd()): MarketplaceSpec {
   if (!name || name === MARKETPLACE_NAME) return { kind: 'user' };
+  if (name === SYSTEM_MARKETPLACE_NAME) {
+    return { kind: 'system', root: getSystemPluginsDir() };
+  }
   if (name === PROJECT_MARKETPLACE_NAME) {
     return { kind: 'project', root: getProjectPluginsDir(cwd) ?? '' };
   }


### PR DESCRIPTION
## Problem

System-repo plugins (`code`, `git`, `social` from `~/.agents/.system/plugins/`) never persist into an agent. They get installed at launch, then **deleted on the next `agents sync`** — leaving only orphaned `installed_plugins.json` records. `ag view --plugins` never shows them, even though `agents.yaml` requests `plugins: [system:*, user:*]`.

## Root cause

Two discovery paths disagreed about whether the system repo contributes a marketplace:

- **Launch** — `collectPluginScopes()` (`project-launch.ts`) **includes** `{ kind: 'system' }`, installs the plugins, registers `agents-system`, and enables them.
- **Sync** — `discoverMarketplaces()` (`plugin-marketplace.ts`) enumerated only user / extra / project. It **never** emitted a system marketplace.

Since `discoverMarketplaces()` is the single source feeding the staleness **detector**, the sync **writer**, the **orphan cleanup**, and `ag view`:

- the detector never offered code/git/social during sync;
- `cleanOrphanedPluginSkills()` built its "active" set from `discoverPlugins()`, so on every sync it treated whatever a launch had installed under the `agents-system` marketplace as **orphaned** — trashing the dirs, stripping the `enabledPlugins` keys, and `unregisterMarketplace('agents-system')`.

Launch installs → next sync trashes. They fought; sync won last.

## Fix

Emit `{ kind: 'system' }` from `discoverMarketplaces()` when `~/.agents/.system/plugins/` exists, **listed first** so name-dedupe (Map/last-wins in the writer) resolves collisions `project > extra > user > system` — the same precedence `collectPluginScopes()` uses. One source-level change; the detector, writer, orphan-cleanup, and `ag view` now agree.

Tests mock `getSystemPluginsDir` to an absent path so they're deterministic on machines with a real `~/.agents/.system/plugins`.

## Verification (end-to-end, claude@2.1.187)

Before: `enabledPlugins` = {agents, hivemind, create}; `known_marketplaces` = {agents-cli, agents-extras}; no `agents-system`.

After `agents sync -y`:
- `enabledPlugins` gains `code@agents-system`, `git@agents-system`, `social@agents-system`
- `known_marketplaces` gains `agents-system`; `marketplaces/agents-system/plugins/` = code, git, social
- `ag view claude@default --plugins` lists code, git, social
- No duplicate `git` (extras no longer ships git; resolves cleanly to agents-system)

## Tests

- `src/lib/plugin-marketplace.test.ts`: +3 cases (system listed first; skipped when dir absent; full low→high precedence order). All pass.
- `src/lib/plugins.test.ts`: 69/69 pass (mocks isolated from the real system repo).
- Full suite: only pre-existing, environment-driven failures remain in `src/lib/secrets/__tests__/bundles-storage.test.ts` (locked secret-service → file store reads real bundles; untouched by this diff, identical to `origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)