### PR TITLE
feat(sync): accept @latest/@oldest/@pinned/@default version selectors

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -9,6 +9,8 @@
  *   agents sync claude                                  # one agent: uses default/sole installed version
  *   agents sync claude@2.1.142                          # one agent: explicit version
  *   agents sync claude@latest                           # one agent: newest installed
+ *   agents sync claude@oldest                           # one agent: oldest installed
+ *   agents sync claude@pinned   (= claude@default)      # one agent: the pinned default version
  *   agents sync --agent claude --agent-version 2.1.142  # legacy form, still supported
  *
  * The umbrella stages live in lib/sync-umbrella.ts; this file dispatches to them
@@ -36,6 +38,7 @@ import {
   syncResourcesToVersion,
   parseAgentSpec,
   resolveVersion,
+  resolveVersionAlias,
   listInstalledVersions,
   getAvailableResources,
   getActuallySyncedResources,
@@ -75,7 +78,7 @@ export function registerSyncCommand(program: Command): void {
   program
     .command('sync [agentSpec]')
     .summary('Make this machine current, or sync resources into one agent')
-    .description('With an [agentSpec], syncs resources (commands, skills, hooks, rules, MCPs, plugins, etc.) into that installed agent version — previews changes and lets you pick. e.g. "claude" or "claude@2.1.142".\n\nWith NO agent, runs the umbrella verb: fetch remote state (config repos + secrets + sessions) then reconcile it into every installed agent. Scope it with --repos / --secrets / --sessions, --cloud (fetch only), or --local (reconcile only).')
+    .description('With an [agentSpec], syncs resources (commands, skills, hooks, rules, MCPs, plugins, etc.) into that installed agent version — previews changes and lets you pick. e.g. "claude", "claude@2.1.142", or a selector: @latest / @oldest / @pinned (= @default).\n\nWith NO agent, runs the umbrella verb: fetch remote state (config repos + secrets + sessions) then reconcile it into every installed agent. Scope it with --repos / --secrets / --sessions, --cloud (fetch only), or --local (reconcile only).')
     .option('--agent <agent>', 'Agent identifier (legacy form; prefer the positional spec)')
     .option('--agent-version <version>', 'Version to sync into (legacy form; prefer "agent@version")')
     .option('--project-dir <path>', 'Path to project-level .agents/ directory containing project-scoped resources')
@@ -158,16 +161,23 @@ async function runSync(agentSpec: string | undefined, opts: SyncOpts): Promise<v
   let agentId: AgentId | undefined;
   let version: string | undefined;
 
+  // A positional @selector typed by the user (latest/oldest/pinned/default/
+  // explicit). parseAgentSpec defaults a missing version to 'latest', so a bare
+  // `agents sync claude` and `agents sync claude@latest` are indistinguishable
+  // after parsing — we only treat the version as a selector when an '@' was
+  // actually typed, keeping bare `claude` on the default-version path.
+  let selector: string | undefined;
+
   if (agentSpec) {
     const parsed = parseAgentSpec(agentSpec);
     if (!parsed) {
       errLog(chalk.red(`Invalid agent spec '${agentSpec}'.`));
-      errLog(chalk.gray('Examples: claude, claude@2.1.142, codex@latest'));
+      errLog(chalk.gray('Examples: claude, claude@2.1.142, claude@latest, claude@oldest, claude@pinned'));
       process.exitCode = 1;
       return;
     }
     agentId = parsed.agent;
-    if (parsed.version !== 'latest' && parsed.version !== 'oldest') version = parsed.version;
+    if (agentSpec.includes('@')) selector = parsed.version;
   }
 
   if (opts.agent) {
@@ -180,6 +190,8 @@ async function runSync(agentSpec: string | undefined, opts: SyncOpts): Promise<v
     agentId = resolved;
   }
   if (opts.agentVersion) {
+    // Legacy flag and the launch-shim hot path (`--agent-version <concrete>`):
+    // pass through verbatim. Selector aliases are a positional-spec feature.
     version = opts.agentVersion;
   }
 
@@ -191,6 +203,14 @@ async function runSync(agentSpec: string | undefined, opts: SyncOpts): Promise<v
   }
 
   // ---------- 2. Resolve version (project pin → global default → sole installed) ----------
+  // A positional @selector wins over the default-resolution below.
+  //   @latest / @oldest        → newest / oldest installed (process.exit if none)
+  //   @pinned / @default       → undefined → fall through to the default path
+  //   @x.y.z                   → that version (process.exit if not installed)
+  if (selector !== undefined && !version) {
+    version = resolveVersionAlias(agentId, selector);
+  }
+
   if (!version) {
     version = resolveVersion(agentId, process.cwd()) || undefined;
     if (!version) {

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -1494,9 +1494,10 @@ export async function viewAction(
     console.log(chalk.red(formatAgentError(agentName)));
     process.exit(1);
   }
-  // Keep 'default' as-is since showAgentResources handles it; resolveVersionAlias
-  // returns undefined for 'default' which would skip the detailed view.
-  const requestedVersion = parts[1] === 'default'
+  // Keep 'default'/'pinned' as-is since showAgentResources handles 'default';
+  // resolveVersionAlias returns undefined for both (they're synonyms), which
+  // would otherwise skip the detailed view.
+  const requestedVersion = (parts[1] === 'default' || parts[1] === 'pinned')
     ? 'default'
     : (resolveVersionAlias(agentId, parts[1]) ?? null);
 

--- a/src/lib/versions.test.ts
+++ b/src/lib/versions.test.ts
@@ -375,3 +375,70 @@ describe('installVersion version validation', () => {
     expect(result?.error ?? '').toContain('does not support version-pinned installs');
   });
 });
+
+// `resolveVersionAlias` is the shared @selector vocabulary (latest / oldest /
+// default / pinned / explicit) every `agents <cmd> agent@<token>` reads. droid
+// installs a single global binary (~/.local/bin/droid) shared across version
+// dirs, so a fixture is just N dirs + one binary — every dir reads as installed.
+function runResolveAlias(home: string, agent: string, raw: string | undefined): string | null {
+  const moduleUrl = pathToFileURL(path.resolve('src/lib/versions.ts')).href;
+  const tsxBin = path.resolve('node_modules/.bin/tsx');
+  const child = spawnSync(tsxBin, ['-e', `
+    import { resolveVersionAlias } from ${JSON.stringify(moduleUrl)};
+    const r = resolveVersionAlias(${JSON.stringify(agent)}, ${JSON.stringify(raw ?? null)});
+    console.log(JSON.stringify({ v: r === undefined ? null : r }));
+  `], {
+    env: { ...process.env, HOME: home },
+    encoding: 'utf-8',
+  });
+  expect(child.status, child.stderr).toBe(0);
+  return (JSON.parse(child.stdout.trim()) as { v: string | null }).v;
+}
+
+function installDroidVersions(home: string, versions: string[]): void {
+  for (const v of versions) {
+    fs.mkdirSync(path.join(droidVersionDir(home, v), 'home'), { recursive: true });
+  }
+  // droid's binary is global and per-host, not per-version (getBinaryPath).
+  const bin = path.join(home, '.local', 'bin', 'droid');
+  fs.mkdirSync(path.dirname(bin), { recursive: true });
+  fs.writeFileSync(bin, '#!/bin/sh\nexit 0\n', 'utf-8');
+  fs.chmodSync(bin, 0o755);
+}
+
+describe('resolveVersionAlias @selectors', () => {
+  // Versions chosen so numeric ordering disagrees with lexical ordering:
+  // numeric oldest=0.9.0, newest=0.158.0; lexical would put "0.10.0" first.
+  const VERSIONS = ['0.9.0', '0.10.0', '0.158.0'];
+
+  it("resolves 'latest' to the highest installed version (numeric, not lexical)", () => {
+    const home = makeTempHome();
+    installDroidVersions(home, VERSIONS);
+    expect(runResolveAlias(home, 'droid', 'latest')).toBe('0.158.0');
+  });
+
+  it("resolves 'oldest' to the lowest installed version (numeric, not lexical)", () => {
+    const home = makeTempHome();
+    installDroidVersions(home, VERSIONS);
+    expect(runResolveAlias(home, 'droid', 'oldest')).toBe('0.9.0');
+  });
+
+  it("treats 'pinned' as a synonym for 'default' — both defer to the caller (undefined)", () => {
+    const home = makeTempHome();
+    installDroidVersions(home, VERSIONS);
+    expect(runResolveAlias(home, 'droid', 'pinned')).toBeNull();
+    expect(runResolveAlias(home, 'droid', 'default')).toBeNull();
+  });
+
+  it('passes an explicit installed version through unchanged', () => {
+    const home = makeTempHome();
+    installDroidVersions(home, VERSIONS);
+    expect(runResolveAlias(home, 'droid', '0.10.0')).toBe('0.10.0');
+  });
+
+  it("defers an absent/empty token to the caller (undefined)", () => {
+    const home = makeTempHome();
+    installDroidVersions(home, VERSIONS);
+    expect(runResolveAlias(home, 'droid', undefined)).toBeNull();
+  });
+});

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1489,11 +1489,14 @@ export function resolveVersion(agent: AgentId, projectPath?: string): string | n
 /**
  * Normalize a user-supplied @version token across CLI subcommands.
  *
- *   undefined / "" / "default"  -> undefined  (caller falls back to project pin or global default)
+ *   undefined / "" / "default" / "pinned" -> undefined  (caller falls back to project pin or global default)
  *   "latest"                    -> highest installed version (process.exit if none installed)
  *   "oldest"                    -> lowest installed version (process.exit if none installed)
  *   "x.y.z" (installed)         -> "x.y.z"
  *   "x.y.z" (not installed)     -> process.exit with installed-list hint
+ *
+ * `pinned` is a synonym for `default`: both name the project pin / global
+ * default, which the caller resolves.
  *
  * Use this anywhere the user can type `agents <cmd> claude@<token>` to keep the
  * vocabulary consistent. Subcommands with different semantics for `latest`
@@ -1501,7 +1504,7 @@ export function resolveVersion(agent: AgentId, projectPath?: string): string | n
  * parsing.
  */
 export function resolveVersionAlias(agent: AgentId, raw: string | undefined | null): string | undefined {
-  if (!raw || raw === 'default') return undefined;
+  if (!raw || raw === 'default' || raw === 'pinned') return undefined;
 
   if (raw === 'latest' || raw === 'oldest') {
     const installed = listInstalledVersions(agent);
@@ -1527,12 +1530,12 @@ export function resolveVersionAlias(agent: AgentId, raw: string | undefined | nu
 
 /**
  * Loose variant of resolveVersionAlias for record-filter contexts (sessions,
- * team history). Same `default`/`latest`/`oldest` semantics, but explicit
+ * team history). Same `default`/`pinned`/`latest`/`oldest` semantics, but explicit
  * versions pass through unchanged so historical records of uninstalled versions
  * remain queryable.
  */
 export function resolveVersionAliasLoose(agent: AgentId, raw: string | undefined | null): string | undefined {
-  if (!raw || raw === 'default') return undefined;
+  if (!raw || raw === 'default' || raw === 'pinned') return undefined;
   if (raw === 'latest' || raw === 'oldest') {
     const installed = listInstalledVersions(agent);
     if (installed.length === 0) return undefined;


### PR DESCRIPTION
## What

`agents sync <agent>@<selector>` now understands the same version selectors as `view` / `skills` / `mcp` / `hooks`:

| selector | resolves to |
|---|---|
| `@latest` | newest installed version |
| `@oldest` | oldest installed version |
| `@pinned` | the pinned default (synonym for `@default`) |
| `@default` | the pinned/global default |
| `@x.y.z` | that version (errors with installed-list if absent) |
| bare `claude` | default version (unchanged) |

## Why

Before this, sync only special-cased `latest`/`oldest` by **clearing** them so they fell through to the default-resolution path. Net effect:
- `agents sync claude@latest` silently resolved to the **default**, not the newest installed.
- `agents sync claude@pinned` / `@default` errored as `not installed` (treated as literal version names).

That's the gap. The fix routes the positional `@selector` through the shared `resolveVersionAlias`, and adds `pinned` there as a synonym for `default` — so `@pinned` resolves everywhere that helper is used, not only in sync.

## Scope / safety

- Bare `agents sync claude` still uses the default version — distinguished from `@latest` by the literal presence of `@` (parseAgentSpec collapses both to `latest`, so the `@` check is load-bearing).
- The legacy `--agent-version` flag (used by the launch-shim hot path) passes through **verbatim** — untouched.

## Verified end-to-end (real installed claude versions 2.1.170 / 2.1.187)

```
claude@latest  -> Synced to Claude@2.1.187   (newest)
claude@oldest  -> Synced to Claude@2.1.170   (oldest)
claude@pinned  -> No default pinned (default path)   } identical
claude@default -> No default pinned (default path)   }
claude         -> No default pinned (default path)   (NOT auto-newest)
claude@9.9.9   -> not installed. Installed: 2.1.170, 2.1.187
```

## Tests

5 new cases in `versions.test.ts` covering `resolveVersionAlias` (real-filesystem fixture, no mocks): latest/oldest pick by numeric (not lexical) order, `pinned`≡`default`≡undefined, explicit passthrough, absent token. Full suite green except 4 pre-existing `bundles-storage.test.ts` failures (Linux secret-store env issue; this diff touches nothing under `secrets/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)