### PR TITLE
feat(sessions): surface real session titles for Claude and Codex

### DIFF
--- a/src/lib/session/__tests__/db.test.ts
+++ b/src/lib/session/__tests__/db.test.ts
@@ -18,6 +18,8 @@ const {
   upsertSession,
   queryUsageRollup,
   topSessionsByCost,
+  syncTopics,
+  ftsSearch,
 } = await import('../db.js');
 const { costOfUsage } = await import('../../pricing/index.js');
 type SessionMeta = import('../types.js').SessionMeta;
@@ -215,5 +217,66 @@ describe('multi-model session cost equals sum of per-model usage', () => {
     const projMm = rows.find(r => r.key === 'proj-mm')!;
     expect(projMm.costUsd).toBeCloseTo(opus + haiku, 10);
     expect(projMm.costUsd).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// syncTopics — apply externally-sourced titles (Codex thread_name) by id.
+// ---------------------------------------------------------------------------
+
+const TOPIC_FILES_DIR = path.join(TEST_HOME, 'topic-files');
+fs.mkdirSync(TOPIC_FILES_DIR, { recursive: true });
+
+function seedTopic(id: string, topic: string): void {
+  const filePath = path.join(TOPIC_FILES_DIR, `${id}.jsonl`);
+  fs.writeFileSync(filePath, '');
+  const meta: SessionMeta = {
+    id,
+    shortId: id.slice(0, 8),
+    agent: 'codex',
+    timestamp: '2026-06-28T00:00:00.000Z',
+    project: 'agents-cli',
+    cwd: TOPIC_FILES_DIR,
+    filePath,
+    topic,
+  };
+  // Upsert through the public API so session_text (FTS) is populated too.
+  upsertSession(meta, 'searchable body text');
+}
+
+describe('syncTopics', () => {
+  beforeAll(() => {
+    seedTopic('codex-rename', 'first prompt fallback');
+    seedTopic('codex-keep', 'Already correct');
+  });
+
+  it('updates topic in sessions + FTS only for ids whose title differs', () => {
+    const updated = syncTopics(
+      new Map([
+        ['codex-rename', 'Review skill placement'],
+        ['codex-keep', 'Already correct'], // identical -> no update
+        ['codex-missing', 'No such session'], // not in DB -> no update
+      ]),
+    );
+    expect(updated).toBe(1);
+
+    const rows = querySessions({ agent: 'codex' });
+    expect(rows.find(r => r.id === 'codex-rename')?.topic).toBe('Review skill placement');
+    expect(rows.find(r => r.id === 'codex-keep')?.topic).toBe('Already correct');
+
+    // The new title is searchable via FTS (topic column was updated, not just sessions).
+    const hits = ftsSearch('Review skill placement');
+    expect(hits.some(h => h.sessionId === 'codex-rename')).toBe(true);
+  });
+
+  it('never clears an existing topic with an empty value', () => {
+    const updated = syncTopics(new Map([['codex-keep', '']]));
+    expect(updated).toBe(0);
+    const rows = querySessions({ agent: 'codex' });
+    expect(rows.find(r => r.id === 'codex-keep')?.topic).toBe('Already correct');
+  });
+
+  it('returns 0 for an empty map', () => {
+    expect(syncTopics(new Map())).toBe(0);
   });
 });

--- a/src/lib/session/__tests__/discover.test.ts
+++ b/src/lib/session/__tests__/discover.test.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import Database from '../../sqlite.js';
 import { buildFtsQuery } from '../db.js';
+import { scanClaudeSession, parseCodexThreadNameIndex } from '../discover.js';
 
 describe('buildFtsQuery', () => {
   it('returns empty expression for whitespace-only input', () => {
@@ -70,5 +71,101 @@ describe('FTS5 session_text schema (smoke test)', () => {
 
     expect(rows.map(r => r.session_id)).toContain('x');
     expect(rows.map(r => r.session_id)).not.toContain('y');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Claude session titles: `/rename` (custom-title) > Claude auto (ai-title) >
+// first-prompt topic. Both title events can repeat; the last one wins.
+// ---------------------------------------------------------------------------
+
+describe('scanClaudeSession title resolution', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-claude-title-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function write(lines: object[]): string {
+    const fp = path.join(dir, 'session.jsonl');
+    fs.writeFileSync(fp, lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+    return fp;
+  }
+
+  const userMsg = (text: string) => ({
+    type: 'user',
+    timestamp: '2026-06-28T00:00:00.000Z',
+    cwd: '/x',
+    message: { role: 'user', content: text },
+  });
+
+  it('prefers a user custom-title over the auto ai-title and first prompt', async () => {
+    const fp = write([
+      userMsg('fix the auth refresh bug please'),
+      { type: 'ai-title', aiTitle: 'Auth refresh fix', sessionId: 's' },
+      { type: 'custom-title', customTitle: 'close-li-outreach-gap', sessionId: 's' },
+    ]);
+    expect((await scanClaudeSession(fp)).topic).toBe('close-li-outreach-gap');
+  });
+
+  it('falls back to ai-title when there is no custom-title', async () => {
+    const fp = write([
+      userMsg('do the thing'),
+      { type: 'ai-title', aiTitle: 'Release new version of agents-cli', sessionId: 's' },
+    ]);
+    expect((await scanClaudeSession(fp)).topic).toBe('Release new version of agents-cli');
+  });
+
+  it('falls back to the first-prompt topic when no title events exist', async () => {
+    const fp = write([userMsg('investigate the flaky test')]);
+    expect((await scanClaudeSession(fp)).topic).toBe('investigate the flaky test');
+  });
+
+  it('takes the last custom-title when renamed more than once', async () => {
+    const fp = write([
+      userMsg('start'),
+      { type: 'custom-title', customTitle: 'first name', sessionId: 's' },
+      { type: 'custom-title', customTitle: 'second name', sessionId: 's' },
+    ]);
+    expect((await scanClaudeSession(fp)).topic).toBe('second name');
+  });
+
+  it('ignores whitespace-only title values', async () => {
+    const fp = write([
+      userMsg('real prompt here'),
+      { type: 'ai-title', aiTitle: '   ', sessionId: 's' },
+    ]);
+    expect((await scanClaudeSession(fp)).topic).toBe('real prompt here');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Codex titles live in session_index.jsonl (thread_name), updated out of band.
+// ---------------------------------------------------------------------------
+
+describe('parseCodexThreadNameIndex', () => {
+  it('maps id -> thread_name, trims, and skips malformed/empty/id-less lines', () => {
+    const raw = [
+      JSON.stringify({ id: 'a', thread_name: 'Review skill placement', updated_at: 'x' }),
+      '',
+      'not json at all',
+      JSON.stringify({ id: 'b', thread_name: '   ' }),
+      JSON.stringify({ id: '', thread_name: 'no id' }),
+      JSON.stringify({ id: 'c', thread_name: '  Find top resource hogs  ' }),
+    ].join('\n');
+
+    const map = parseCodexThreadNameIndex(raw);
+    expect(map.get('a')).toBe('Review skill placement');
+    expect(map.has('b')).toBe(false);
+    expect(map.has('')).toBe(false);
+    expect(map.get('c')).toBe('Find top resource hogs');
+    expect(map.size).toBe(2);
+  });
+
+  it('returns an empty map for empty input', () => {
+    expect(parseCodexThreadNameIndex('').size).toBe(0);
   });
 });

--- a/src/lib/session/db.ts
+++ b/src/lib/session/db.ts
@@ -662,6 +662,50 @@ export function syncLabels(labelMap: Map<string, string | null>): number {
   return updates.length;
 }
 
+/**
+ * Sync topics (session titles) for a set of sessions, keyed by id. For agents
+ * whose human-readable title lives in a side index that updates independently
+ * of the transcript (Codex `session_index.jsonl`), the per-file scan can't see
+ * a title that lands later. This applies those titles by id, updating both
+ * `sessions.topic` and the FTS5 topic column. Only ever sets a non-empty title
+ * and only when it differs from the stored value — cheap to call every run.
+ * Returns the number of rows updated.
+ */
+export function syncTopics(topicMap: Map<string, string>): number {
+  if (topicMap.size === 0) return 0;
+  const db = getDB();
+  const ids = [...topicMap.keys()];
+  const CHUNK = 500;
+  const updates: Array<{ id: string; topic: string }> = [];
+
+  for (let i = 0; i < ids.length; i += CHUNK) {
+    const chunk = ids.slice(i, i + CHUNK);
+    const placeholders = chunk.map(() => '?').join(',');
+    const rows = db
+      .prepare(`SELECT id, topic FROM sessions WHERE id IN (${placeholders})`)
+      .all(...chunk) as Array<{ id: string; topic: string | null }>;
+    for (const row of rows) {
+      const live = topicMap.get(row.id) ?? '';
+      if (live && live !== (row.topic ?? '')) {
+        updates.push({ id: row.id, topic: live });
+      }
+    }
+  }
+  if (updates.length === 0) return 0;
+
+  const updSessions = db.prepare(`UPDATE sessions SET topic = ? WHERE id = ?`);
+  const updFts = db.prepare(`UPDATE session_text SET topic = ? WHERE session_id = ?`);
+
+  const txn = db.transaction((items: typeof updates) => {
+    for (const { id, topic } of items) {
+      updSessions.run(topic, id);
+      updFts.run(topic, id);
+    }
+  });
+  txn(updates);
+  return updates.length;
+}
+
 /** Convert a raw database row into a SessionMeta object. */
 function rowToMeta(row: SessionRow): SessionMeta {
   return {

--- a/src/lib/session/discover.ts
+++ b/src/lib/session/discover.ts
@@ -31,6 +31,7 @@ import {
   getScanStampsForPaths,
   recordScans,
   syncLabels,
+  syncTopics,
   upsertSessionsBatch,
   querySessions,
   countSessions,
@@ -626,7 +627,16 @@ async function scanCodexIncremental(onProgress?: (p: ScanProgress) => void): Pro
   }
 
   const changed = filterChangedFiles(filePaths);
-  if (changed.length === 0) return;
+
+  // Codex keeps human-readable titles (`thread_name`) in `session_index.jsonl`,
+  // which updates independently of the rollout files — apply them by id on every
+  // scan so a title that lands after a session was first indexed still surfaces.
+  const titles = readCodexThreadNames();
+
+  if (changed.length === 0) {
+    syncTopics(titles);
+    return;
+  }
 
   onProgress?.({ agent: 'codex', parsed: 0, total: changed.length });
 
@@ -639,6 +649,9 @@ async function scanCodexIncremental(onProgress?: (p: ScanProgress) => void): Pro
       const result = await readCodexMeta(filePath, account, currentVersion);
       if (result && !seen.has(result.meta.id)) {
         seen.add(result.meta.id);
+        // Prefer the Codex-generated title over the first-prompt fallback.
+        const title = titles.get(result.meta.id);
+        if (title) result.meta.topic = title;
         entries.push({ meta: result.meta, content: result.content, scan });
       } else {
         touched.push({ filePath, scan });
@@ -652,6 +665,45 @@ async function scanCodexIncremental(onProgress?: (p: ScanProgress) => void): Pro
 
   upsertSessionsBatch(entries);
   recordScans(touched);
+  // Catch sessions whose rollout file was unchanged but gained a title since the
+  // last scan (the index changed, the transcript did not).
+  syncTopics(titles);
+}
+
+/** Parse the lines of a Codex `session_index.jsonl` into a session id -> title map. */
+export function parseCodexThreadNameIndex(raw: string): Map<string, string> {
+  const titles = new Map<string, string>();
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      const id = typeof entry.id === 'string' ? entry.id : '';
+      const name = typeof entry.thread_name === 'string' ? entry.thread_name.trim() : '';
+      if (id && name) titles.set(id, name);
+    } catch {
+      // skip malformed line
+    }
+  }
+  return titles;
+}
+
+/**
+ * Read Codex session titles across every Codex home (live + versioned). The
+ * `session_index.jsonl` file sits beside each `sessions/` rollout tree.
+ */
+function readCodexThreadNames(): Map<string, string> {
+  const titles = new Map<string, string>();
+  for (const sessionsDir of getAgentSessionDirs('codex', 'sessions')) {
+    const indexPath = path.join(path.dirname(sessionsDir), 'session_index.jsonl');
+    let raw: string;
+    try {
+      raw = fs.readFileSync(indexPath, 'utf-8');
+    } catch {
+      continue; // no index in this home
+    }
+    for (const [id, name] of parseCodexThreadNameIndex(raw)) titles.set(id, name);
+  }
+  return titles;
 }
 
 /** Stream-parse a single Codex JSONL file to extract session metadata. */
@@ -1447,7 +1499,7 @@ function extractHermesMessageText(content: any): string {
 }
 
 /** Stream a Claude JSONL file and extract scan-level metadata (timestamp, cwd, topic, tokens). */
-async function scanClaudeSession(filePath: string): Promise<ClaudeSessionScan> {
+export async function scanClaudeSession(filePath: string): Promise<ClaudeSessionScan> {
   const stream = fs.createReadStream(filePath, { encoding: 'utf-8' });
   const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
 
@@ -1456,6 +1508,10 @@ async function scanClaudeSession(filePath: string): Promise<ClaudeSessionScan> {
   let gitBranch: string | undefined;
   let version: string | undefined;
   let topic: string | undefined;
+  // Explicit session titles: `/rename` writes a `custom-title` event; Claude
+  // auto-generates an `ai-title`. Both can repeat across the file — last wins.
+  let customTitle: string | undefined;
+  let aiTitle: string | undefined;
   let entrypoint: string | undefined;
   let messageCount = 0;
   let tokenCount = 0;
@@ -1499,6 +1555,17 @@ async function scanClaudeSession(filePath: string): Promise<ClaudeSessionScan> {
         cwd = parsed.cwd || '';
         gitBranch = parsed.gitBranch || undefined;
         version = parsed.version || undefined;
+      }
+
+      if (parsed.type === 'custom-title') {
+        const t = typeof parsed.customTitle === 'string' ? parsed.customTitle.trim() : '';
+        if (t) customTitle = t;
+        continue;
+      }
+      if (parsed.type === 'ai-title') {
+        const t = typeof parsed.aiTitle === 'string' ? parsed.aiTitle.trim() : '';
+        if (t) aiTitle = t;
+        continue;
       }
 
       if (parsed.type === 'user') {
@@ -1557,12 +1624,16 @@ async function scanClaudeSession(filePath: string): Promise<ClaudeSessionScan> {
       ? lastTsMs - firstTsMs
       : undefined;
 
+  // Prefer an explicit session title (user `/rename` > Claude auto-title) over
+  // the first-prompt topic.
+  const resolvedTopic = customTitle || aiTitle || topic;
+
   return {
     timestamp,
     cwd,
     gitBranch,
     version,
-    topic,
+    topic: resolvedTopic,
     entrypoint,
     messageCount,
     tokenCount: sawTokenCount ? tokenCount : undefined,


### PR DESCRIPTION
## Problem

`agents sessions` derived its title column from the **first user prompt** only. But the agents already record real, human-friendly titles that the scanner ignored:

- **Claude** writes them into the transcript JSONL: `custom-title` (from `/rename`) and `ai-title` (auto-generated after the first exchange).
- **Codex** stores a `thread_name` in `~/.codex/session_index.jsonl` (e.g. `"Review skill placement"`), a side index that updates **independently** of the rollout files.

So a session the user explicitly renamed still listed as its opening prompt snippet.

## Change

- **Claude** (`scanClaudeSession`): resolve `topic` as `custom-title` > `ai-title` > first-prompt. Both title events can repeat; last write wins. Whitespace-only titles are ignored.
- **Codex** (`scanCodexIncremental`): read `thread_name` from `session_index.jsonl` across every Codex home and apply it by session id — both at upsert time and via a new `syncTopics()` pass that catches a title landing **after** the rollout file was last scanned (the index changes without the transcript changing).
- **`syncTopics()`** in `db.ts` mirrors `syncLabels()`: updates `sessions.topic` and the FTS `topic` column, only on non-empty diffs. Never clears an existing topic.

Kimi already used its stored title. Gemini / Grok / Antigravity have no title to derive (Grok's title table is empty and it isn't scanned at all yet) — left as-is.

## Tests

- Claude title precedence + all fallbacks + last-wins + whitespace guard (`discover.test.ts`).
- Codex index parsing: id→thread_name, trimming, skips malformed/empty/id-less lines (`discover.test.ts`).
- `syncTopics` diff behavior, no-clear-on-empty, FTS column update (`db.test.ts`).

30/30 in the two touched files pass; `tsc --noEmit` clean.

## End-to-end verification

Ran the real `discoverSessions` → scan → DB → query path against a temp HOME populated with **real** transcripts:

| agent | id | resolved topic | source |
|---|---|---|---|
| claude | 407a06ea | `close-li-outreach-gap` | custom-title (`/rename`) |
| claude | 57bada79 | `Release new version of agents-cli` | ai-title (auto) |
| codex | 019f07f6 | `Find top resource hogs` | thread_name (index) |
| codex | 019e973f | `Review skill placement` | thread_name (index) |

Second incremental run keeps titles stable (exercises the `changed===0` → `syncTopics` branch); a title-less session correctly falls back to its first prompt (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)