### PR TITLE
feat(repo): resource-level sync/changes in `repo list`

### DIFF
--- a/src/commands/repo.test.ts
+++ b/src/commands/repo.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { resourceUnit, formatResourceDelta, type ChangeAction } from './repo.js';
+
+/** Strip ANSI color codes so assertions are stable regardless of TTY/color env. */
+function plain(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\[[0-9;]*m/g, '');
+}
+
+const e = (action: ChangeAction, file: string) => ({ action, file });
+
+describe('resourceUnit', () => {
+  it('collapses every file under a directory-based resource to one unit', () => {
+    expect(resourceUnit('skills/git-workflow/SKILL.md')).toEqual({ kind: 'skill', unit: 'skills/git-workflow' });
+    expect(resourceUnit('skills/git-workflow/extra.md')).toEqual({ kind: 'skill', unit: 'skills/git-workflow' });
+    expect(resourceUnit('plugins/rush/.claude-plugin/plugin.json')).toEqual({ kind: 'plugin', unit: 'plugins/rush' });
+  });
+
+  it('maps prompts/ to command (Codex) and treats flat config files individually', () => {
+    expect(resourceUnit('prompts/foo.md').kind).toBe('command');
+    expect(resourceUnit('agents.yaml')).toEqual({ kind: 'config', unit: 'agents.yaml' });
+    expect(resourceUnit('hooks.yaml')).toEqual({ kind: 'config', unit: 'hooks.yaml' });
+  });
+
+  it('buckets unknown top-level paths as other', () => {
+    expect(resourceUnit('README.md').kind).toBe('other');
+  });
+});
+
+describe('formatResourceDelta', () => {
+  it('counts distinct resource units, not files (3 changed files in one skill = 1 skill)', () => {
+    const out = plain(formatResourceDelta([
+      e('changed', 'skills/foo/SKILL.md'),
+      e('changed', 'skills/foo/a.md'),
+      e('changed', 'skills/foo/b.md'),
+    ]));
+    expect(out).toBe('1 changed skill');
+  });
+
+  it('pluralizes and groups by action then kind', () => {
+    const out = plain(formatResourceDelta([
+      e('new', 'skills/a/SKILL.md'),
+      e('new', 'skills/b/SKILL.md'),
+      e('changed', 'hooks/h.md'),
+    ]));
+    expect(out).toBe('2 new skills, 1 changed hook');
+  });
+
+  it('treats a unit with mixed add+modify as a single change, not new', () => {
+    const out = plain(formatResourceDelta([
+      e('new', 'skills/foo/new-file.md'),
+      e('changed', 'skills/foo/SKILL.md'),
+    ]));
+    expect(out).toBe('1 changed skill');
+  });
+
+  it('caps at maxParts with a "+N more" overflow', () => {
+    const entries = [
+      e('new', 'skills/a/SKILL.md'),
+      e('new', 'commands/b.md'),
+      e('new', 'plugins/c/plugin.json'),
+      e('new', 'hooks/d.md'),
+      e('new', 'mcp/e.json'),
+      e('new', 'rules/f.md'),
+      e('new', 'workflows/g.ts'),
+    ];
+    const out = plain(formatResourceDelta(entries, 5));
+    expect(out.split(', ').length).toBe(6); // 5 phrases + "+N more"
+    expect(out.endsWith('+2 more')).toBe(true);
+  });
+
+  it('returns empty string for no changes', () => {
+    expect(formatResourceDelta([])).toBe('');
+  });
+});

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -104,13 +104,13 @@ function deriveAlias(source: string): string {
  * unit a user reasons about: one skill, one command, one plugin — even if it
  * spans several files on disk.
  */
-type ResourceKind =
+type RepoResourceKind =
   | 'skill' | 'command' | 'plugin' | 'hook' | 'mcp' | 'subagent'
   | 'rule' | 'workflow' | 'routine' | 'profile' | 'permission'
   | 'cli' | 'config' | 'other';
 
 /** Top-level dir -> resource kind. Directory-based resources collapse to one unit. */
-const RESOURCE_DIRS: Record<string, ResourceKind> = {
+const RESOURCE_DIRS: Record<string, RepoResourceKind> = {
   skills: 'skill', commands: 'command', prompts: 'command', plugins: 'plugin',
   hooks: 'hook', mcp: 'mcp', subagents: 'subagent', rules: 'rule',
   workflows: 'workflow', routines: 'routine', profiles: 'profile',
@@ -118,7 +118,7 @@ const RESOURCE_DIRS: Record<string, ResourceKind> = {
 };
 
 /** [singular, plural] display labels per kind. */
-const RESOURCE_LABELS: Record<ResourceKind, [string, string]> = {
+const RESOURCE_LABELS: Record<RepoResourceKind, [string, string]> = {
   skill: ['skill', 'skills'], command: ['command', 'commands'],
   plugin: ['plugin', 'plugins'], hook: ['hook', 'hooks'], mcp: ['MCP', 'MCPs'],
   subagent: ['subagent', 'subagents'], rule: ['rule', 'rules'],
@@ -129,7 +129,7 @@ const RESOURCE_LABELS: Record<ResourceKind, [string, string]> = {
 };
 
 /** Display order — the resources a user cares about most come first. */
-const RESOURCE_ORDER: ResourceKind[] = [
+const RESOURCE_ORDER: RepoResourceKind[] = [
   'skill', 'command', 'plugin', 'hook', 'mcp', 'subagent', 'rule',
   'workflow', 'routine', 'profile', 'permission', 'cli', 'config', 'other',
 ];
@@ -141,7 +141,7 @@ export type ChangeAction = 'new' | 'changed' | 'removed';
  * resources (skills/foo/SKILL.md) collapse to `skills/foo` so all their files
  * count as one unit; flat config files (agents.yaml, hooks.yaml) count alone.
  */
-export function resourceUnit(file: string): { kind: ResourceKind; unit: string } {
+export function resourceUnit(file: string): { kind: RepoResourceKind; unit: string } {
   const parts = file.split('/');
   const top = parts[0];
   if (top === 'agents.yaml' || top === 'hooks.yaml') return { kind: 'config', unit: top };
@@ -162,7 +162,7 @@ export function formatResourceDelta(
   maxParts = 5,
 ): string {
   // Gather every action seen across a unit's files, then collapse to one action.
-  const units = new Map<string, { kind: ResourceKind; actions: Set<ChangeAction> }>();
+  const units = new Map<string, { kind: RepoResourceKind; actions: Set<ChangeAction> }>();
   for (const { action, file } of entries) {
     const { kind, unit } = resourceUnit(file);
     const key = `${kind} ${unit}`;
@@ -278,11 +278,13 @@ async function renderRepoRow(t: RepoTarget): Promise<RepoRow> {
     } else {
       const pieces: string[] = [];
       if (behind > 0) {
-        const incoming = formatResourceDelta(await diffResourceEntries(git, 'HEAD..@{upstream}'));
+        // Three-dot isolates upstream's side via the merge-base, so a diverged
+        // branch reports exactly what a pull adds (not the inverse of local commits).
+        const incoming = formatResourceDelta(await diffResourceEntries(git, 'HEAD...@{upstream}'));
         pieces.push(`${incoming || chalk.yellow(`${behind} commit${behind > 1 ? 's' : ''}`)} ${chalk.gray('to pull')}`);
       }
       if (ahead > 0) {
-        const outgoing = formatResourceDelta(await diffResourceEntries(git, '@{upstream}..HEAD'));
+        const outgoing = formatResourceDelta(await diffResourceEntries(git, '@{upstream}...HEAD'));
         pieces.push(`${outgoing || chalk.yellow(`${ahead} commit${ahead > 1 ? 's' : ''}`)} ${chalk.gray('to push')}`);
       }
       sync = pieces.join(chalk.gray('  ·  '));

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -99,26 +99,132 @@ function deriveAlias(source: string): string {
 }
 
 /**
- * Categorized working-tree summary: `M:2 A:1 D:1 ?:3` — letters match the git
- * porcelain shorthand (Modified / Added / Deleted / Renamed / Unmerged /
- * Untracked). Zero counts are omitted so the column stays compact.
+ * These are DotAgent *resource* repos, so changes are reported at the resource
+ * level ("2 skills, 1 hook") rather than the raw-file level. A resource is the
+ * unit a user reasons about: one skill, one command, one plugin — even if it
+ * spans several files on disk.
  */
-function formatDirtyCounts(status: {
-  modified: string[];
-  created: string[];
-  deleted: string[];
-  renamed: unknown[];
-  conflicted: string[];
-  not_added: string[];
-}): string {
+type ResourceKind =
+  | 'skill' | 'command' | 'plugin' | 'hook' | 'mcp' | 'subagent'
+  | 'rule' | 'workflow' | 'routine' | 'profile' | 'permission'
+  | 'cli' | 'config' | 'other';
+
+/** Top-level dir -> resource kind. Directory-based resources collapse to one unit. */
+const RESOURCE_DIRS: Record<string, ResourceKind> = {
+  skills: 'skill', commands: 'command', prompts: 'command', plugins: 'plugin',
+  hooks: 'hook', mcp: 'mcp', subagents: 'subagent', rules: 'rule',
+  workflows: 'workflow', routines: 'routine', profiles: 'profile',
+  permissions: 'permission', cli: 'cli',
+};
+
+/** [singular, plural] display labels per kind. */
+const RESOURCE_LABELS: Record<ResourceKind, [string, string]> = {
+  skill: ['skill', 'skills'], command: ['command', 'commands'],
+  plugin: ['plugin', 'plugins'], hook: ['hook', 'hooks'], mcp: ['MCP', 'MCPs'],
+  subagent: ['subagent', 'subagents'], rule: ['rule', 'rules'],
+  workflow: ['workflow', 'workflows'], routine: ['routine', 'routines'],
+  profile: ['profile', 'profiles'], permission: ['permission', 'permissions'],
+  cli: ['CLI', 'CLIs'], config: ['config file', 'config files'],
+  other: ['other file', 'other files'],
+};
+
+/** Display order — the resources a user cares about most come first. */
+const RESOURCE_ORDER: ResourceKind[] = [
+  'skill', 'command', 'plugin', 'hook', 'mcp', 'subagent', 'rule',
+  'workflow', 'routine', 'profile', 'permission', 'cli', 'config', 'other',
+];
+
+export type ChangeAction = 'new' | 'changed' | 'removed';
+
+/**
+ * Map a repo-relative path to the resource unit it belongs to. Directory-based
+ * resources (skills/foo/SKILL.md) collapse to `skills/foo` so all their files
+ * count as one unit; flat config files (agents.yaml, hooks.yaml) count alone.
+ */
+export function resourceUnit(file: string): { kind: ResourceKind; unit: string } {
+  const parts = file.split('/');
+  const top = parts[0];
+  if (top === 'agents.yaml' || top === 'hooks.yaml') return { kind: 'config', unit: top };
+  const kind = RESOURCE_DIRS[top];
+  if (kind) return { kind, unit: parts.length > 1 ? `${top}/${parts[1]}` : file };
+  return { kind: 'other', unit: file };
+}
+
+/**
+ * Render a set of changed files as a resource-level summary, e.g.
+ * `2 new skills, 1 changed hook`. Counts distinct resource units (a skill whose
+ * three files all changed is "1 changed skill"), grouped by action then kind,
+ * and colors each phrase green/yellow/red for new/changed/removed. Caps at
+ * `maxParts` phrases, appending `+N more` so a big diff stays scannable.
+ */
+export function formatResourceDelta(
+  entries: { action: ChangeAction; file: string }[],
+  maxParts = 5,
+): string {
+  // Gather every action seen across a unit's files, then collapse to one action.
+  const units = new Map<string, { kind: ResourceKind; actions: Set<ChangeAction> }>();
+  for (const { action, file } of entries) {
+    const { kind, unit } = resourceUnit(file);
+    const key = `${kind} ${unit}`;
+    const cur = units.get(key) ?? { kind, actions: new Set<ChangeAction>() };
+    cur.actions.add(action);
+    units.set(key, cur);
+  }
+
+  const counts = new Map<string, number>(); // `${action} ${kind}` -> count
+  for (const { kind, actions } of units.values()) {
+    let action: ChangeAction;
+    if (actions.size === 1) action = [...actions][0]!;
+    else if ([...actions].every((a) => a === 'new')) action = 'new';
+    else if ([...actions].every((a) => a === 'removed')) action = 'removed';
+    else action = 'changed'; // mixed add+modify within one unit reads as a change
+    const key = `${action} ${kind}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  const COLOR: Record<ChangeAction, (s: string) => string> = {
+    new: chalk.green, changed: chalk.yellow, removed: chalk.red,
+  };
   const parts: string[] = [];
-  if (status.modified.length) parts.push(chalk.yellow(`M:${status.modified.length}`));
-  if (status.created.length) parts.push(chalk.green(`A:${status.created.length}`));
-  if (status.deleted.length) parts.push(chalk.red(`D:${status.deleted.length}`));
-  if (status.renamed.length) parts.push(chalk.cyan(`R:${status.renamed.length}`));
-  if (status.conflicted.length) parts.push(chalk.magenta(`U:${status.conflicted.length}`));
-  if (status.not_added.length) parts.push(chalk.gray(`?:${status.not_added.length}`));
-  return parts.join(' ');
+  for (const action of ['new', 'changed', 'removed'] as ChangeAction[]) {
+    for (const kind of RESOURCE_ORDER) {
+      const n = counts.get(`${action} ${kind}`);
+      if (!n) continue;
+      const [singular, plural] = RESOURCE_LABELS[kind];
+      parts.push(COLOR[action](`${n} ${action} ${n === 1 ? singular : plural}`));
+    }
+  }
+  if (parts.length > maxParts) {
+    const shown = parts.slice(0, maxParts);
+    shown.push(chalk.gray(`+${parts.length - maxParts} more`));
+    return shown.join(', ');
+  }
+  return parts.join(', ');
+}
+
+/** Parse `git diff --name-status <range>` into resource-delta entries. */
+async function diffResourceEntries(
+  git: ReturnType<typeof simpleGit>,
+  range: string,
+): Promise<{ action: ChangeAction; file: string }[]> {
+  let raw: string;
+  try {
+    raw = await git.diff(['--name-status', range]);
+  } catch {
+    return []; // no upstream resolvable / range invalid — caller falls back to counts
+  }
+  const out: { action: ChangeAction; file: string }[] = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    const cols = line.split('\t');
+    const code = cols[0] ?? '';
+    const file = cols[cols.length - 1] ?? ''; // renames put the new path last
+    if (!file) continue;
+    const c = code[0];
+    const action: ChangeAction = c === 'A' ? 'new' : c === 'D' ? 'removed' : 'changed';
+    out.push({ action, file });
+  }
+  return out;
 }
 
 /** Visible character width of a string with embedded ANSI color codes. */
@@ -132,52 +238,87 @@ function padVisible(s: string, width: number): string {
 }
 
 /**
- * Render one row of the unified repo table: alias / branch / ahead-behind /
- * dirty counts / url+commit. Used by `agents repo list` and the hidden
- * `agents repo status` alias.
+ * One rendered row. `cells` (branch / sync / changes / remote) feeds the aligned
+ * table; `raw` is a single free-form trailer for special cases (missing repo,
+ * no git remote, error) that don't fit the columns.
  */
-async function renderRepoRow(t: RepoTarget): Promise<string> {
-  const aliasCol = chalk.cyan(t.alias.padEnd(12));
+interface RepoRow {
+  alias: string;
+  cells?: [string, string, string, string];
+  raw?: string;
+}
 
+/**
+ * Render one repo's row data: branch, resource-level sync (what a pull/push would
+ * move), resource-level local edits, and the remote URL + commit. Used by
+ * `agents repo list` and the hidden `agents repo status` alias.
+ */
+async function renderRepoRow(t: RepoTarget): Promise<RepoRow> {
   if (!fs.existsSync(t.dir)) {
-    return `  ${aliasCol} ${chalk.red('missing')} ${chalk.gray(t.dir)}`;
+    return { alias: t.alias, raw: `${chalk.red('missing')} ${chalk.gray(t.dir)}` };
   }
   if (!isGitRepo(t.dir)) {
-    return `  ${aliasCol} ${chalk.gray('local (no git remote)')} ${chalk.gray(t.dir)}`;
+    return { alias: t.alias, raw: `${chalk.gray('local (no git remote)')} ${chalk.gray(t.dir)}` };
   }
 
   try {
     const git = simpleGit(t.dir);
     const status = await git.status();
-    const branch = status.tracking || status.current || '(detached)';
+    // Show the local branch name; the upstream remote is already implied by URL.
+    const branch = status.current || (status.tracking ? status.tracking.replace(/^origin\//, '') : '(detached)');
 
-    const inSync = (status.ahead ?? 0) === 0 && (status.behind ?? 0) === 0;
-    const remoteRaw = inSync ? 'in sync' : `+${status.ahead ?? 0} -${status.behind ?? 0}`;
-    const remoteColored = inSync ? chalk.green(remoteRaw) : chalk.yellow(remoteRaw);
-    const remotePad = ' '.repeat(Math.max(0, 12 - remoteRaw.length));
+    // SYNC: what a pull brings in / a push sends out, described by resource.
+    const ahead = status.ahead ?? 0;
+    const behind = status.behind ?? 0;
+    let sync: string;
+    if (!status.tracking) {
+      sync = chalk.gray('no upstream');
+    } else if (ahead === 0 && behind === 0) {
+      sync = chalk.green('up to date');
+    } else {
+      const pieces: string[] = [];
+      if (behind > 0) {
+        const incoming = formatResourceDelta(await diffResourceEntries(git, 'HEAD..@{upstream}'));
+        pieces.push(`${incoming || chalk.yellow(`${behind} commit${behind > 1 ? 's' : ''}`)} ${chalk.gray('to pull')}`);
+      }
+      if (ahead > 0) {
+        const outgoing = formatResourceDelta(await diffResourceEntries(git, '@{upstream}..HEAD'));
+        pieces.push(`${outgoing || chalk.yellow(`${ahead} commit${ahead > 1 ? 's' : ''}`)} ${chalk.gray('to push')}`);
+      }
+      sync = pieces.join(chalk.gray('  ·  '));
+    }
 
-    const tree = status.isClean() ? chalk.green('clean') : formatDirtyCounts(status);
+    // CHANGES: uncommitted working-tree edits, described by resource.
+    const localEntries: { action: ChangeAction; file: string }[] = [
+      ...status.created.map((f) => ({ action: 'new' as const, file: f })),
+      ...status.not_added.map((f) => ({ action: 'new' as const, file: f })),
+      ...status.modified.map((f) => ({ action: 'changed' as const, file: f })),
+      ...status.conflicted.map((f) => ({ action: 'changed' as const, file: f })),
+      ...status.renamed.map((r) => ({ action: 'changed' as const, file: (r as { to: string }).to })),
+      ...status.deleted.map((f) => ({ action: 'removed' as const, file: f })),
+    ];
+    const changes = status.isClean() ? chalk.green('clean') : formatResourceDelta(localEntries);
 
     const remotes = await git.getRemotes(true);
     const origin = remotes.find((r) => r.name === 'origin');
     const url = origin?.refs?.fetch || '';
     const commit = (await git.log({ maxCount: 1 })).latest?.hash.slice(0, 8) || '';
-    const tail = url
+    const remote = url
       ? chalk.gray(`${url}${commit ? ` (${commit})` : ''}`)
       : commit
         ? chalk.gray(`(${commit})`)
         : '';
 
-    return `  ${aliasCol} ${branch.padEnd(28)}  ${remoteColored}${remotePad}  ${padVisible(tree, 14)}  ${tail}`;
+    return { alias: t.alias, cells: [branch, sync, changes, remote] };
   } catch (err) {
-    return `  ${aliasCol} ${chalk.red('error')} ${(err as Error).message}`;
+    return { alias: t.alias, raw: `${chalk.red('error')} ${(err as Error).message}` };
   }
 }
 
 /**
  * Shared action body for `agents repo list` and the hidden `agents repo status`
- * alias. Prints a unified table: alias, branch, ahead/behind, dirty counts,
- * remote URL and short commit hash.
+ * alias. Prints an aligned table: repo, branch, resource-level sync (to pull /
+ * to push), resource-level local changes, and remote URL + short commit.
  */
 async function listRepos(alias: string | undefined): Promise<void> {
   const targets = collectRepoTargets(alias);
@@ -189,12 +330,32 @@ async function listRepos(alias: string | undefined): Promise<void> {
     console.log(chalk.gray('No repos to show.'));
     return;
   }
+
+  const rows = await Promise.all(targets.map(renderRepoRow));
+  const tableRows = rows.filter((r) => r.cells);
+
+  // Column widths grow to fit the widest visible content (resource summaries vary
+  // a lot in length), so the table stays aligned without truncating detail.
+  const headers = ['REPO', 'BRANCH', 'SYNC', 'CHANGES'];
+  const aliasW = Math.max(headers[0].length, ...rows.map((r) => r.alias.length));
+  const branchW = Math.max(headers[1].length, 0, ...tableRows.map((r) => visibleWidth(r.cells![0])));
+  const syncW = Math.max(headers[2].length, 0, ...tableRows.map((r) => visibleWidth(r.cells![1])));
+  const changesW = Math.max(headers[3].length, 0, ...tableRows.map((r) => visibleWidth(r.cells![2])));
+
   console.log('');
   console.log(
-    `  ${chalk.gray('REPO'.padEnd(12))} ${chalk.gray('BRANCH'.padEnd(28))}  ${chalk.gray('REMOTE'.padEnd(12))}  ${chalk.gray('LOCAL'.padEnd(14))}  ${chalk.gray('URL')}`,
+    `  ${chalk.gray(headers[0].padEnd(aliasW))}  ${chalk.gray(headers[1].padEnd(branchW))}  ${chalk.gray(headers[2].padEnd(syncW))}  ${chalk.gray(headers[3].padEnd(changesW))}  ${chalk.gray('REMOTE')}`,
   );
-  for (const t of targets) {
-    console.log(await renderRepoRow(t));
+  for (const r of rows) {
+    const aliasCol = chalk.cyan(r.alias.padEnd(aliasW));
+    if (r.cells) {
+      const [branch, sync, changes, remote] = r.cells;
+      console.log(
+        `  ${aliasCol}  ${padVisible(branch, branchW)}  ${padVisible(sync, syncW)}  ${padVisible(changes, changesW)}  ${remote}`,
+      );
+    } else {
+      console.log(`  ${aliasCol}  ${r.raw}`);
+    }
   }
 
   const userDir = getUserAgentsDir();
@@ -408,7 +569,7 @@ export function registerRepoCommands(program: Command): void {
   repoCmd
     .command('list [alias]')
     .alias('ls')
-    .description('Show all repos: branch, ahead/behind, dirty counts, URL, commit.')
+    .description('Show all repos with resource-level sync (skills/commands/plugins to pull or push) and local changes.')
     .action(async (alias: string | undefined) => {
       await listRepos(alias);
     });


### PR DESCRIPTION
## Why

`agents repo list` reported **git plumbing** when these are DotAgents **resource** repos:

```
  REPO     BRANCH       REMOTE    LOCAL    URL
  system   origin/main  +0 -9     M:3      git@github.com:phnx-labs/.agents-system.git (c6bdfb14)
```

`+0 -9` = 9 commits behind, `M:3` = 3 files modified. Neither tells you *which* skills/commands/plugins changed.

## After

```
  REPO    BRANCH  SYNC                                                                       CHANGES                           REMOTE
  system  main    1 new skill, 2 new plugins, 1 new hook, 2 changed skills, +4 more to pull  1 changed skill, 2 changed rules  git@github.com:phnx-labs/.agents-system.git (c6bdfb14)
  user    main    1 removed plugin to pull                                                   1 changed hook                    git@github.com:muqsitnawaz/.agents.git (ff441a20)
  extras  main    up to date                                                                 clean                             git@github.com:phnx-labs/.agents-extras.git (3783c49b)
```

## What

- **SYNC** (was `REMOTE`/`+0 -9`): diffs against upstream, maps each path to its resource unit, reports `… to pull` / `… to push`.
- **CHANGES** (was `LOCAL`/`M:3`): same mapping over the working tree, labeled new/changed/removed, colored green/yellow/red.
- Counts **distinct resource units** — a skill whose 3 files changed is "1 changed skill", not 3 files — via `resourceUnit()`.
- Capped at 5 phrases with `+N more`; columns auto-size so detail isn't truncated.
- `BRANCH` drops the redundant `origin/` prefix (the remote is already in the URL column).
- Leaves the upstream `repos` alias and `repo view` command untouched.

## Test

- New `src/commands/repo.test.ts`: unit-collapsing, action grouping/pluralization, mixed add+modify → "changed", and the `+N more` overflow cap. 8/8 pass.
- `src/commands` suite: 154/154 pass. `tsc` clean.
- Verified end-to-end: `repos list`, `repo list <alias>`, `repo status`, and `repo view system` all render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)