### PR TITLE
feat(hosts): agents hosts + run --host — offload agent runs onto your machines

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -53,6 +53,7 @@ interface ExecCommandActionOptions {
   computer?: string;
   remoteCwd?: string;
   follow?: boolean; // --no-follow sets this false
+  any?: boolean;
 }
 
 /** Type guard that narrows a string to a known AgentId. */
@@ -242,7 +243,8 @@ export function registerRunCommand(program: Command): void {
       'Offload this run onto a registered agent host over SSH instead of running locally. See `agents hosts`.',
     )
     .option('--remote-cwd <dir>', 'Working directory on the host for --host runs.')
-    .option('--no-follow', 'With --host, dispatch detached and return immediately (track via `agents hosts ps/logs`).');
+    .option('--no-follow', 'With --host, dispatch detached and return immediately (track via `agents hosts ps/logs`).')
+    .option('--any', 'With --host <cap> (a capability tag), pick any matching host instead of erroring when several match.');
 
   // `--on` and `--computer` are hidden aliases of `--host` — same behavior.
   runCmd.addOption(new Option('--on <name>', 'Alias of --host.').hideHelp());
@@ -318,7 +320,18 @@ export function registerRunCommand(program: Command): void {
         const { dispatchToHost } = await import('../lib/hosts/dispatch.js');
         let host = await resolveHost(hostName);
         if (!host) {
-          try { host = await resolveHostByCap(hostName); } catch { /* not a cap either */ }
+          // Not a host name — try capability routing (e.g. --host gpu). A
+          // "Multiple hosts tagged…" error is actionable and must surface;
+          // only "no host tagged" falls through to the generic unknown-host msg.
+          try {
+            host = await resolveHostByCap(hostName, options.any);
+          } catch (e) {
+            const msg = (e as Error).message ?? '';
+            if (msg.startsWith('Multiple hosts')) {
+              console.error(chalk.red(msg));
+              process.exit(1);
+            }
+          }
         }
         if (!host) {
           console.error(chalk.red(`Unknown host "${hostName}". List hosts: agents hosts list`));

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -6,7 +6,7 @@
  * injection, and multi-agent fallback chains for rate-limit resilience.
  */
 
-import type { Command } from 'commander';
+import { Option, type Command } from 'commander';
 import chalk from 'chalk';
 import type { ExecOptions, ExecMode, ExecEffort, FallbackEntry } from '../lib/exec.js';
 import type { AgentId } from '../lib/types.js';
@@ -46,6 +46,13 @@ interface ExecCommandActionOptions {
   budget?: string;
   until?: string;
   interval?: string;
+  // Host dispatch: run on a registered agent host instead of locally.
+  // `--host` is canonical; `--on`/`--computer` are hidden aliases.
+  host?: string;
+  on?: string;
+  computer?: string;
+  remoteCwd?: string;
+  follow?: boolean; // --no-follow sets this false
 }
 
 /** Type guard that narrows a string to a known AgentId. */
@@ -229,7 +236,17 @@ export function registerRunCommand(program: Command): void {
     .option(
       '--interval <dur>',
       'Loop delay between iterations ("0" back-to-back, "30m" paces). Loop only.',
-    );
+    )
+    .option(
+      '--host <name>',
+      'Offload this run onto a registered agent host over SSH instead of running locally. See `agents hosts`.',
+    )
+    .option('--remote-cwd <dir>', 'Working directory on the host for --host runs.')
+    .option('--no-follow', 'With --host, dispatch detached and return immediately (track via `agents hosts ps/logs`).');
+
+  // `--on` and `--computer` are hidden aliases of `--host` — same behavior.
+  runCmd.addOption(new Option('--on <name>', 'Alias of --host.').hideHelp());
+  runCmd.addOption(new Option('--computer <name>', 'Alias of --host.').hideHelp());
 
   setHelpSections(runCmd, {
     examples: `
@@ -283,6 +300,49 @@ export function registerRunCommand(program: Command): void {
       // Use command.args (all positional strings) and strip the declared positional args from the front.
       const declaredArgCount = prompt !== undefined ? 2 : 1;
       const passthroughArgs = command.args.slice(declaredArgCount);
+
+      // --host/--on/--computer: offload this run onto a registered agent host
+      // over SSH instead of running locally. The three flags are aliases.
+      const hostGiven = [options.host, options.on, options.computer].filter((v): v is string => !!v);
+      if (hostGiven.length > 0) {
+        if (new Set(hostGiven).size > 1) {
+          console.error(chalk.red('Conflicting --host/--on/--computer values — pass just one.'));
+          process.exit(1);
+        }
+        const hostName = hostGiven[0];
+        if (prompt === undefined) {
+          console.error(chalk.red('A prompt is required for host runs: agents run <agent> "<task>" --host <name>'));
+          process.exit(1);
+        }
+        const { resolveHost, resolveHostByCap } = await import('../lib/hosts/registry.js');
+        const { dispatchToHost } = await import('../lib/hosts/dispatch.js');
+        let host = await resolveHost(hostName);
+        if (!host) {
+          try { host = await resolveHostByCap(hostName); } catch { /* not a cap either */ }
+        }
+        if (!host) {
+          console.error(chalk.red(`Unknown host "${hostName}". List hosts: agents hosts list`));
+          process.exit(1);
+        }
+        try {
+          const { exitCode } = await dispatchToHost(host, {
+            agent: agentSpec.split('@')[0],
+            prompt,
+            mode: options.mode,
+            model: options.model,
+            remoteCwd: options.remoteCwd,
+            follow: options.follow !== false,
+          });
+          if (options.follow === false) {
+            console.log(chalk.green(`Dispatched to ${host.name}.`) + chalk.gray(' Track: agents hosts ps · Follow: agents hosts logs <id> -f'));
+            process.exit(0);
+          }
+          process.exit(exitCode === undefined || exitCode === -1 ? 1 : exitCode);
+        } catch (err) {
+          console.error(chalk.red((err as Error).message));
+          process.exit(1);
+        }
+      }
 
       // --resume-checkpoint short-circuits normal dispatch entirely: the
       // checkpoint already carries the agent, version, prompt, session id,

--- a/src/commands/hosts.ts
+++ b/src/commands/hosts.ts
@@ -81,11 +81,13 @@ async function doAdd(name: string | undefined, target: string | undefined, opts:
       choices: candidates.map((c) => ({ value: c, name: c })),
     });
     for (const c of picked) {
+      // The ssh target is the candidate name itself either way: ssh resolves it
+      // for ssh-config hosts, and it's a reachable hostname for known_hosts ones.
       const source = isSshConfigHost(c) ? 'ssh-config' : 'inline';
-      const probe = probeHost(source === 'ssh-config' ? c : c);
+      const probe = probeHost(c);
       await registerHost({ name: c, provider: 'local', source, ...(source === 'inline' ? { address: c } : {}), os: probe.os, caps: opts.cap });
       console.log(chalk.green(`Enrolled ${c}`) + chalk.gray(` (${source}${probe.os ? `, ${probe.os}` : ''})`));
-      if (opts.enroll !== false) await maybeBootstrap(source === 'ssh-config' ? c : c, c);
+      if (opts.enroll !== false) await maybeBootstrap(c, c);
     }
     return;
   }

--- a/src/commands/hosts.ts
+++ b/src/commands/hosts.ts
@@ -17,7 +17,6 @@ import { listSshConfigHosts, listKnownHosts, isSshConfigHost } from '../lib/host
 import {
   probeHost,
   remoteAgentsVersion,
-  remoteAgentInstalled,
   bootstrapAgentsCli,
   localCliVersion,
 } from '../lib/hosts/ready.js';

--- a/src/commands/hosts.ts
+++ b/src/commands/hosts.ts
@@ -1,0 +1,249 @@
+/**
+ * `agents hosts` — register and inspect agent hosts (machines you offload runs to).
+ *
+ * The registry is a thin overlay: ssh-config hosts are dispatchable with zero
+ * registration (connection details stay in ~/.ssh/config); enrollment only adds
+ * capability metadata or bootstraps agents-cli, plus inline (non-ssh-config)
+ * hosts. Dispatch itself is `agents run --host <name>` (see commands/exec.ts).
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { checkbox, confirm } from '@inquirer/prompts';
+import { assertValidSshTarget } from '../lib/ssh-exec.js';
+import { getProvider, listAllHosts, resolveHost } from '../lib/hosts/registry.js';
+import { sshTargetFor, type Host } from '../lib/hosts/types.js';
+import { listSshConfigHosts, listKnownHosts, isSshConfigHost } from '../lib/hosts/ssh-config.js';
+import {
+  probeHost,
+  remoteAgentsVersion,
+  remoteAgentInstalled,
+  bootstrapAgentsCli,
+  localCliVersion,
+} from '../lib/hosts/ready.js';
+import { listTasks, loadTask, localLogPath } from '../lib/hosts/tasks.js';
+import { followHostTask } from '../lib/hosts/progress.js';
+import * as fs from 'fs';
+
+interface AddOptions { cap?: string[]; os?: string; enroll?: boolean; }
+
+/** Parse `user@host` or `host` into its pieces. */
+function parseTarget(target: string): { address: string; user?: string } {
+  const at = target.indexOf('@');
+  if (at === -1) return { address: target };
+  return { user: target.slice(0, at), address: target.slice(at + 1) };
+}
+
+/** Bootstrap/verify agents-cli on a freshly-enrolled host (best-effort, prompts). */
+async function maybeBootstrap(target: string, hostName: string): Promise<void> {
+  const probe = probeHost(target);
+  if (!probe.reachable) {
+    console.log(chalk.yellow(`  Not reachable over SSH yet — skipping bootstrap. Fix key auth, then: agents hosts check ${hostName}`));
+    return;
+  }
+  const remoteVer = remoteAgentsVersion(target);
+  const localVer = localCliVersion();
+  if (!remoteVer) {
+    const ok = await confirm({ message: `  agents-cli not found on ${hostName}. Install ${localVer ? `v${localVer}` : 'latest'} now?`, default: true });
+    if (ok) {
+      console.log(chalk.gray('  Installing agents-cli on the host…'));
+      const r = bootstrapAgentsCli(target, localVer);
+      console.log(r.ok ? chalk.green('  Installed.') : chalk.red(`  Install failed:\n${r.output}`));
+    }
+    return;
+  }
+  const remoteClean = remoteVer.replace(/^v/, '');
+  if (localVer && remoteClean !== localVer) {
+    const ok = await confirm({ message: `  ${hostName} has agents-cli ${remoteClean}, you have ${localVer}. Upgrade to match?`, default: false });
+    if (ok) {
+      const r = bootstrapAgentsCli(target, localVer);
+      console.log(r.ok ? chalk.green('  Upgraded.') : chalk.red(`  Upgrade failed:\n${r.output}`));
+    }
+  }
+}
+
+async function registerHost(spec: Host): Promise<void> {
+  const provider = getProvider('local');
+  await provider.register!(spec);
+}
+
+async function doAdd(name: string | undefined, target: string | undefined, opts: AddOptions): Promise<void> {
+  // No name + no target → interactive scan of ssh sources.
+  if (!name && !target) {
+    const existing = new Set((await listAllHosts()).filter((h) => h.enrolled).map((h) => h.name));
+    const candidates = [...new Set([...listSshConfigHosts(), ...listKnownHosts()])].filter((c) => !existing.has(c));
+    if (candidates.length === 0) {
+      console.log(chalk.yellow('No SSH hosts found in ~/.ssh/config or ~/.ssh/known_hosts. Add one explicitly: agents hosts add <name> <user@host>'));
+      return;
+    }
+    const picked = await checkbox({
+      message: 'Select hosts to enroll (connection details come from ~/.ssh/config)',
+      choices: candidates.map((c) => ({ value: c, name: c })),
+    });
+    for (const c of picked) {
+      const source = isSshConfigHost(c) ? 'ssh-config' : 'inline';
+      const probe = probeHost(source === 'ssh-config' ? c : c);
+      await registerHost({ name: c, provider: 'local', source, ...(source === 'inline' ? { address: c } : {}), os: probe.os, caps: opts.cap });
+      console.log(chalk.green(`Enrolled ${c}`) + chalk.gray(` (${source}${probe.os ? `, ${probe.os}` : ''})`));
+      if (opts.enroll !== false) await maybeBootstrap(source === 'ssh-config' ? c : c, c);
+    }
+    return;
+  }
+
+  if (!name) {
+    console.log(chalk.red('Usage: agents hosts add <name> [user@host]'));
+    process.exitCode = 1;
+    return;
+  }
+
+  let spec: Host;
+  let sshTarget: string;
+  if (target) {
+    assertValidSshTarget(target);
+    const { address, user } = parseTarget(target);
+    spec = { name, provider: 'local', source: 'inline', address, user, caps: opts.cap, os: opts.os };
+    sshTarget = target;
+  } else if (isSshConfigHost(name)) {
+    spec = { name, provider: 'local', source: 'ssh-config', caps: opts.cap, os: opts.os };
+    sshTarget = name;
+  } else {
+    console.log(chalk.red(`"${name}" is not in ~/.ssh/config. Pass a target: agents hosts add ${name} <user@host>`));
+    process.exitCode = 1;
+    return;
+  }
+
+  const probe = probeHost(sshTarget);
+  if (!spec.os && probe.os) spec.os = probe.os;
+  await registerHost(spec);
+  console.log(chalk.green(`Enrolled ${name}`) + chalk.gray(` (${spec.source}${spec.os ? `, ${spec.os}` : ''}${spec.caps?.length ? `, caps: ${spec.caps.join(',')}` : ''})`));
+  if (opts.enroll !== false) await maybeBootstrap(sshTarget, name);
+}
+
+async function doList(json: boolean): Promise<void> {
+  const hosts = await listAllHosts();
+  if (json) {
+    console.log(JSON.stringify(hosts, null, 2));
+    return;
+  }
+  if (hosts.length === 0) {
+    console.log(chalk.gray('No hosts. Enroll one: agents hosts add <name> <user@host>  (or just: agents hosts add)'));
+    return;
+  }
+  console.log(chalk.bold('NAME').padEnd(20) + chalk.bold('SOURCE').padEnd(13) + chalk.bold('TARGET').padEnd(28) + chalk.bold('CAPS'));
+  for (const h of hosts) {
+    const tgt = h.source === 'ssh-config' ? chalk.gray('(ssh-config)') : `${h.user ? h.user + '@' : ''}${h.address ?? ''}`;
+    const mark = h.enrolled ? '' : chalk.gray(' ·available');
+    console.log(h.name.padEnd(20) + h.source.padEnd(13) + tgt.padEnd(28) + (h.caps?.join(',') ?? '') + mark);
+  }
+}
+
+async function doCheck(name: string): Promise<void> {
+  const host = await resolveHost(name);
+  if (!host) {
+    console.log(chalk.red(`Unknown host "${name}". Known: ${(await listAllHosts()).map((h) => h.name).join(', ') || '(none)'}`));
+    process.exitCode = 1;
+    return;
+  }
+  const target = sshTargetFor(host);
+  process.stdout.write(`Probing ${chalk.cyan(name)} (${target})… `);
+  const probe = probeHost(target);
+  if (!probe.reachable) {
+    console.log(chalk.red('unreachable'));
+    process.exitCode = 1;
+    return;
+  }
+  console.log(chalk.green('reachable') + chalk.gray(probe.os ? ` · ${probe.os}` : ''));
+  const ver = remoteAgentsVersion(target);
+  console.log(`  agents-cli: ${ver ? chalk.green(ver) : chalk.yellow('not installed')}`);
+}
+
+async function doRemove(name: string): Promise<void> {
+  const host = await resolveHost(name);
+  if (!host || !host.enrolled) {
+    console.log(chalk.yellow(`"${name}" is not enrolled (nothing to remove).`));
+    return;
+  }
+  await getProvider('local').remove!(name);
+  console.log(chalk.green(`Removed ${name}`));
+}
+
+async function doPs(json: boolean): Promise<void> {
+  const tasks = listTasks();
+  if (json) {
+    console.log(JSON.stringify(tasks, null, 2));
+    return;
+  }
+  if (tasks.length === 0) {
+    console.log(chalk.gray('No host tasks yet. Dispatch one: agents run <agent> "<task>" --host <name>'));
+    return;
+  }
+  console.log(chalk.bold('ID').padEnd(11) + chalk.bold('HOST').padEnd(16) + chalk.bold('AGENT').padEnd(10) + chalk.bold('STATUS').padEnd(11) + chalk.bold('PROMPT'));
+  for (const t of tasks) {
+    const status = t.status === 'completed' ? chalk.green(t.status) : t.status === 'failed' ? chalk.red(t.status) : chalk.yellow(t.status);
+    console.log(t.id.padEnd(11) + t.host.padEnd(16) + t.agent.padEnd(10) + status.padEnd(11) + t.prompt.slice(0, 50));
+  }
+}
+
+async function doLogs(id: string, follow: boolean): Promise<void> {
+  const task = loadTask(id);
+  if (!task) {
+    console.log(chalk.red(`Unknown task "${id}".`));
+    process.exitCode = 1;
+    return;
+  }
+  if (follow && task.status === 'running') {
+    const code = await followHostTask(task.target, { remoteLog: task.remoteLog, remoteExit: task.remoteExit, taskId: id, echo: true });
+    process.exitCode = code === -1 ? 1 : code;
+    return;
+  }
+  try {
+    process.stdout.write(fs.readFileSync(localLogPath(id), 'utf-8'));
+  } catch {
+    console.log(chalk.gray('(no local log captured for this task)'));
+  }
+}
+
+/** Register the `agents hosts` command tree. */
+export function registerHostsCommand(program: Command): void {
+  const hosts = program
+    .command('hosts')
+    .description('Register and inspect agent hosts (machines you offload runs to with `agents run --host <name>`).');
+
+  hosts
+    .command('add [name] [target]')
+    .description('Enroll a host. With no args, pick from ~/.ssh/config + known_hosts. `target` is user@host for hosts not in ssh config.')
+    .option('--cap <cap...>', 'Capability tag(s) for routing (e.g. --cap gpu)')
+    .option('--os <os>', 'Override detected OS label')
+    .option('--no-enroll', 'Register only — skip the remote agents-cli bootstrap/version check')
+    .action((name: string | undefined, target: string | undefined, opts: AddOptions) => doAdd(name, target, opts));
+
+  hosts
+    .command('list')
+    .alias('ls')
+    .description('List enrolled + ssh-config hosts (metadata only, no probing).')
+    .option('--json', 'Output JSON')
+    .action((opts: { json?: boolean }) => doList(!!opts.json));
+
+  hosts
+    .command('check <name>')
+    .description('Probe one host: reachable? agents-cli version?')
+    .action((name: string) => doCheck(name));
+
+  hosts
+    .command('remove <name>')
+    .alias('rm')
+    .description('Remove a host from the registry (does not touch ~/.ssh/config).')
+    .action((name: string) => doRemove(name));
+
+  hosts
+    .command('ps')
+    .description('List dispatched host tasks.')
+    .option('--json', 'Output JSON')
+    .action((opts: { json?: boolean }) => doPs(!!opts.json));
+
+  hosts
+    .command('logs <id>')
+    .description('Show a host task log; -f to follow a running one.')
+    .option('-f, --follow', 'Follow live output')
+    .action((id: string, opts: { follow?: boolean }) => doLogs(id, !!opts.follow));
+}

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -10,6 +10,7 @@ import { Option, type Command } from 'commander';
 import chalk from 'chalk';
 import * as fs from 'fs';
 import { spawnSync } from 'child_process';
+import { SSH_TARGET_RE, assertValidSshTarget } from '../lib/ssh-exec.js';
 import {
   bundleBackend,
   bundleExists,
@@ -187,18 +188,9 @@ function readStdinSync(): string {
   return Buffer.concat(chunks).toString('utf-8').trim();
 }
 
-/**
- * SSH target for `export --to-ssh`: a bare ssh-config host alias (e.g. `yosemite-s0`)
- * or `user@host`. The strict allowlist blocks shell metacharacters and a leading `-`
- * so a target can't be smuggled in as an ssh argv flag.
- */
-export const SSH_TARGET_RE = /^[a-zA-Z0-9._-]+(@[a-zA-Z0-9._-]+)?$/;
-
-export function assertValidSshTarget(host: string): void {
-  if (!SSH_TARGET_RE.test(host)) {
-    throw new Error(`Invalid SSH target ${JSON.stringify(host)}. Expected a host alias or user@host (letters, digits, '.', '_', '-').`);
-  }
-}
+// SSH target validation is defined canonically in src/lib/ssh-exec.ts and
+// re-exported here for back-compat with existing importers of these symbols.
+export { SSH_TARGET_RE, assertValidSshTarget };
 
 /** POSIX single-quote a string for safe interpolation into a remote shell command. */
 function shellQuote(s: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,7 @@ import {
   loadTmux,
   loadBrowser,
   loadComputer,
+  loadHosts,
   loadPull,
   loadPush,
   loadRepo,
@@ -907,6 +908,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadTmux);
   await reg(loadBrowser);
   await reg(loadComputer);
+  await reg(loadHosts);
   registerJobsCronAliasCommand(program, 'jobs');
   registerJobsCronAliasCommand(program, 'cron');
   registerUpgradeCommand(program);

--- a/src/lib/browser/drivers/ssh.ts
+++ b/src/lib/browser/drivers/ssh.ts
@@ -5,17 +5,16 @@ import { getPortOccupant } from '../chrome.js';
 import { parseEndpointUrl } from '../profiles.js';
 import { writeProfileRuntime, clearProfileRuntime } from '../runtime-state.js';
 import type { BrowserProfile } from '../types.js';
+// shellQuote lives in the shared ssh-exec helper (single choke point); re-export
+// so existing importers of `shellQuote` from this module keep working.
+import { shellQuote } from '../../ssh-exec.js';
+export { shellQuote };
 
 export interface SSHConnection {
   cdp: CDPClient;
   port: number;
   pid: number;
   cleanup: () => void;
-}
-
-export function shellQuote(s: string): string {
-  if (/^[A-Za-z0-9_./:=@%+-]+$/.test(s)) return s;
-  return "'" + s.replace(/'/g, "'\\''") + "'";
 }
 
 export async function connectSSH(

--- a/src/lib/hosts/dispatch.ts
+++ b/src/lib/hosts/dispatch.ts
@@ -1,0 +1,95 @@
+/**
+ * Dispatch a headless agent run onto a host over SSH.
+ *
+ * The run is launched detached (`nohup … &`) writing combined output to a remote
+ * log and its exit code to a sibling `.exit` file, so progress survives a dropped
+ * connection (followed via offset-tail in progress.ts). This is the offload win:
+ * the agent's process/thread/file fan-out happens on the host, not the laptop.
+ */
+
+import { randomUUID } from 'crypto';
+import { sshExec, shellQuote } from '../ssh-exec.js';
+import type { Host } from './types.js';
+import { sshTargetFor } from './types.js';
+import { ensureHostReady } from './ready.js';
+import { saveTask, updateTask, type HostTask } from './tasks.js';
+import { followHostTask } from './progress.js';
+
+// Use $HOME (not ~) so the path is correct whether or not it's quoted and
+// regardless of the run's cwd. Task ids are 8 hex chars, so these paths are
+// injection-safe to interpolate unquoted into remote commands.
+const REMOTE_DIR = '$HOME/.agents/.cache/hosts';
+
+export interface DispatchOptions {
+  agent: string;
+  prompt: string;
+  mode?: string;
+  model?: string;
+  remoteCwd?: string;
+  /** Stream progress and block until completion (default true). */
+  follow?: boolean;
+  timeoutMs?: number;
+}
+
+export interface DispatchResult {
+  task: HostTask;
+  /** Exit code when followed; undefined when detached (--no-follow). */
+  exitCode?: number;
+}
+
+export async function dispatchToHost(host: Host, opts: DispatchOptions): Promise<DispatchResult> {
+  const target = sshTargetFor(host);
+  const { warnings } = ensureHostReady(host, { agent: opts.agent });
+  for (const w of warnings) process.stderr.write(`[hosts] warning: ${w}\n`);
+
+  const id = randomUUID().slice(0, 8);
+  const remoteLog = `${REMOTE_DIR}/${id}.log`;
+  const remoteExit = `${REMOTE_DIR}/${id}.exit`;
+
+  // Inner command run under a login shell so PATH resolves `agents`.
+  const runParts = ['agents', 'run', shellQuote(opts.agent), shellQuote(opts.prompt), '--quiet'];
+  if (opts.mode) runParts.push('--mode', shellQuote(opts.mode));
+  if (opts.model) runParts.push('--model', shellQuote(opts.model));
+  const cwd = opts.remoteCwd ? `cd ${shellQuote(opts.remoteCwd)} && ` : '';
+  const inner = `${cwd}${runParts.join(' ')} > ${remoteLog} 2>&1; echo $? > ${remoteExit}`;
+
+  // Outer: ensure dir, launch detached under bash -lc, print the PID.
+  const launch = `mkdir -p ${REMOTE_DIR}; nohup bash -lc ${shellQuote(inner)} >/dev/null 2>&1 & echo $!`;
+  const res = sshExec(target, launch, { timeoutMs: 30000 });
+  if (res.code !== 0) {
+    throw new Error(`Failed to launch on "${host.name}": ${(res.stderr || res.stdout).trim() || 'ssh error'}`);
+  }
+  const pid = parseInt(res.stdout.trim().split('\n').pop() ?? '', 10);
+
+  const task: HostTask = {
+    id,
+    host: host.name,
+    target,
+    agent: opts.agent,
+    prompt: opts.prompt,
+    pid: Number.isFinite(pid) ? pid : undefined,
+    remoteLog,
+    remoteExit,
+    status: 'running',
+    createdAt: new Date().toISOString(),
+  };
+  saveTask(task);
+
+  if (opts.follow === false) {
+    return { task };
+  }
+
+  const exitCode = await followHostTask(target, {
+    remoteLog,
+    remoteExit,
+    taskId: id,
+    echo: true,
+    timeoutMs: opts.timeoutMs,
+  });
+  const finished = updateTask(id, {
+    status: exitCode === 0 ? 'completed' : exitCode === -1 ? 'unknown' : 'failed',
+    exitCode: exitCode === -1 ? undefined : exitCode,
+    finishedAt: new Date().toISOString(),
+  });
+  return { task: finished ?? task, exitCode };
+}

--- a/src/lib/hosts/progress.ts
+++ b/src/lib/hosts/progress.ts
@@ -1,0 +1,62 @@
+/**
+ * Follow a dispatched host run by offset-tailing its remote log.
+ *
+ * The run writes combined output to a log file on the host and its exit code to
+ * a sibling `.exit` file. We poll `tail -c +<offset>` (durable, offset-tracked —
+ * a dropped connection resumes from the saved offset) and finish when `.exit`
+ * appears. Rich transcript-parser rendering is a fast-follow.
+ */
+
+import * as fs from 'fs';
+import { sshExec } from '../ssh-exec.js';
+import { localLogPath } from './tasks.js';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export interface FollowOptions {
+  remoteLog: string;
+  remoteExit: string;
+  /** Mirror remote output into this task's local log too. */
+  taskId: string;
+  /** Print streamed output to stdout. */
+  echo?: boolean;
+  /** Overall wall-clock cap; returns -1 on timeout. */
+  timeoutMs?: number;
+  pollMs?: number;
+}
+
+/** Tail the remote log to stdout until the run finishes; return its exit code. */
+export async function followHostTask(target: string, opts: FollowOptions): Promise<number> {
+  const pollMs = opts.pollMs ?? 1500;
+  const deadline = Date.now() + (opts.timeoutMs ?? 3600_000);
+  const local = localLogPath(opts.taskId);
+  let offset = 0;
+
+  const drain = (): void => {
+    // remoteLog is a $HOME-prefixed path with a safe (hex) basename — intentionally
+    // unquoted so the remote shell expands $HOME.
+    const chunk = sshExec(target, `tail -c +${offset + 1} ${opts.remoteLog} 2>/dev/null`, { timeoutMs: 20000 });
+    if (chunk.stdout) {
+      if (opts.echo) process.stdout.write(chunk.stdout);
+      try { fs.appendFileSync(local, chunk.stdout); } catch { /* best-effort */ }
+      offset += Buffer.byteLength(chunk.stdout, 'utf8');
+    }
+  };
+
+  for (;;) {
+    drain();
+    const exit = sshExec(target, `cat ${opts.remoteExit} 2>/dev/null`, { timeoutMs: 12000 });
+    if (exit.code === 0 && exit.stdout.trim() !== '') {
+      drain(); // final flush
+      const code = parseInt(exit.stdout.trim(), 10);
+      return Number.isFinite(code) ? code : 0;
+    }
+    if (Date.now() > deadline) {
+      process.stderr.write('\n[hosts] follow timed out; the run continues on the host. Reattach with: agents hosts logs ' + opts.taskId + ' -f\n');
+      return -1;
+    }
+    await sleep(pollMs);
+  }
+}

--- a/src/lib/hosts/providers/local.test.ts
+++ b/src/lib/hosts/providers/local.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { LocalHostProvider as LHP } from './local.js';
+
+// state.ts captures HOME at module-load, so isolate by setting HOME to a temp
+// dir and re-importing the module graph fresh for each test (vi.resetModules).
+let home: string;
+let provider: LHP;
+
+async function freshProvider(): Promise<LHP> {
+  vi.resetModules();
+  const { LocalHostProvider } = await import('./local.js');
+  return new LocalHostProvider();
+}
+
+beforeEach(async () => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-hosts-test-'));
+  process.env.HOME = home;
+  fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
+  provider = await freshProvider();
+});
+
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+describe('LocalHostProvider CRUD', () => {
+  it('registers, lists, resolves, and removes an inline host', async () => {
+    await provider.register!({ name: 's1', provider: 'local', source: 'inline', address: 'yosemite-s1', user: 'muqsit', caps: ['gpu'] });
+
+    const listed = await provider.list();
+    const s1 = listed.find((h) => h.name === 's1');
+    expect(s1).toBeDefined();
+    expect(s1!.source).toBe('inline');
+    expect(s1!.address).toBe('yosemite-s1');
+    expect(s1!.user).toBe('muqsit');
+    expect(s1!.caps).toEqual(['gpu']);
+    expect(s1!.enrolled).toBe(true);
+
+    const resolved = await provider.resolve('s1');
+    expect(resolved?.address).toBe('yosemite-s1');
+
+    await provider.remove!('s1');
+    expect(await provider.resolve('s1')).toBeNull();
+    expect((await provider.list()).find((h) => h.name === 's1')).toBeUndefined();
+  });
+
+  it('persists across provider instances (written to agents.yaml)', async () => {
+    await provider.register!({ name: 'box', provider: 'local', source: 'inline', address: '10.0.0.5' });
+    const reloaded = await freshProvider();
+    expect((await reloaded.resolve('box'))?.address).toBe('10.0.0.5');
+  });
+});
+
+describe('LocalHostProvider ssh-config union + resolution order', () => {
+  it('lists ssh-config hosts as available (not enrolled) and unions with inline', async () => {
+    fs.mkdirSync(path.join(home, '.ssh'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.ssh', 'config'), 'Host cfg-box\n  HostName 1.2.3.4\n  User me\n', 'utf-8');
+    provider = await freshProvider();
+
+    await provider.register!({ name: 'inline-box', provider: 'local', source: 'inline', address: '9.9.9.9' });
+
+    const list = await provider.list();
+    const cfg = list.find((h) => h.name === 'cfg-box');
+    const inline = list.find((h) => h.name === 'inline-box');
+    expect(cfg).toBeDefined();
+    expect(cfg!.source).toBe('ssh-config');
+    expect(cfg!.enrolled).toBe(false); // dispatchable but not enrolled
+    expect(cfg!.address).toBeUndefined(); // connection details stay in ssh config
+    expect(inline!.enrolled).toBe(true);
+
+    // ssh-config host resolves without registration
+    expect((await provider.resolve('cfg-box'))?.source).toBe('ssh-config');
+  });
+
+  it('an inline overlay wins over an ssh-config host of the same name', async () => {
+    fs.mkdirSync(path.join(home, '.ssh'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.ssh', 'config'), 'Host dup\n  HostName 1.1.1.1\n', 'utf-8');
+    provider = await freshProvider();
+    await provider.register!({ name: 'dup', provider: 'local', source: 'inline', address: '2.2.2.2', caps: ['gpu'] });
+
+    const resolved = await provider.resolve('dup');
+    expect(resolved?.source).toBe('inline');
+    expect(resolved?.address).toBe('2.2.2.2');
+    expect(resolved?.caps).toEqual(['gpu']);
+    // not duplicated in the list
+    expect((await provider.list()).filter((h) => h.name === 'dup')).toHaveLength(1);
+  });
+});

--- a/src/lib/hosts/providers/local.ts
+++ b/src/lib/hosts/providers/local.ts
@@ -79,6 +79,11 @@ export class LocalHostProvider implements HostProvider {
     updateMeta((meta) => {
       const hosts = { ...(meta.hosts ?? {}) };
       delete hosts[name];
+      // Drop the key entirely when empty so we don't leave `hosts: {}` behind.
+      if (Object.keys(hosts).length === 0) {
+        const { hosts: _omit, ...rest } = meta;
+        return rest;
+      }
       return { ...meta, hosts };
     });
   }

--- a/src/lib/hosts/providers/local.ts
+++ b/src/lib/hosts/providers/local.ts
@@ -1,0 +1,85 @@
+/**
+ * Local host provider: the v1 directory.
+ *
+ * `list()` is the union of ssh-config `Host` stanzas (read-only, connection
+ * details owned by ssh) and inline entries the user registered in agents.yaml.
+ * The `Meta.hosts` overlay (caps/os, keyed by name) is merged onto both. We
+ * never copy or rewrite ssh config.
+ */
+
+import { readMeta, updateMeta } from '../../state.js';
+import type { HostEntry } from '../../types.js';
+import type { Host, HostProvider, HostProviderCapabilities } from '../types.js';
+import { listSshConfigHosts, isSshConfigHost } from '../ssh-config.js';
+
+function entries(): Record<string, HostEntry> {
+  return readMeta().hosts ?? {};
+}
+
+function toHost(name: string, entry: HostEntry, enrolled: boolean): Host {
+  return {
+    name,
+    provider: 'local',
+    enrolled,
+    source: entry.source,
+    address: entry.address,
+    user: entry.user,
+    os: entry.os,
+    caps: entry.caps,
+    addedAt: entry.addedAt,
+  };
+}
+
+export class LocalHostProvider implements HostProvider {
+  readonly id = 'local' as const;
+
+  capabilities(): HostProviderCapabilities {
+    return { directory: true, mutate: true, presence: false, relay: false, lease: false };
+  }
+
+  async list(): Promise<Host[]> {
+    const overlay = entries();
+    const out: Host[] = [];
+    const seen = new Set<string>();
+
+    // Inline + overlaid hosts from the registry.
+    for (const [name, entry] of Object.entries(overlay)) {
+      out.push(toHost(name, entry, true));
+      seen.add(name);
+    }
+    // ssh-config hosts not already carrying an overlay → available, not enrolled.
+    for (const name of listSshConfigHosts()) {
+      if (seen.has(name)) continue;
+      out.push(toHost(name, { source: 'ssh-config' }, false));
+      seen.add(name);
+    }
+    return out.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  async resolve(name: string): Promise<Host | null> {
+    const entry = entries()[name];
+    if (entry) return toHost(name, entry, true);
+    if (isSshConfigHost(name)) return toHost(name, { source: 'ssh-config' }, false);
+    return null;
+  }
+
+  async register(spec: Host): Promise<Host> {
+    const entry: HostEntry = {
+      source: spec.source,
+      ...(spec.source === 'inline' ? { address: spec.address, user: spec.user } : {}),
+      ...(spec.os ? { os: spec.os } : {}),
+      ...(spec.caps && spec.caps.length ? { caps: spec.caps } : {}),
+      addedAt: spec.addedAt ?? new Date().toISOString(),
+    };
+    updateMeta((meta) => ({ ...meta, hosts: { ...(meta.hosts ?? {}), [spec.name]: entry } }));
+    return toHost(spec.name, entry, true);
+  }
+
+  async remove(name: string): Promise<void> {
+    updateMeta((meta) => {
+      const hosts = { ...(meta.hosts ?? {}) };
+      delete hosts[name];
+      return { ...meta, hosts };
+    });
+  }
+}

--- a/src/lib/hosts/ready.ts
+++ b/src/lib/hosts/ready.ts
@@ -1,0 +1,98 @@
+/**
+ * Host readiness + bootstrap.
+ *
+ * Before a dispatch we ensure the box is reachable and has agents-cli. Enrollment
+ * can additionally install/upgrade agents-cli to match the local version (version
+ * parity) using the same shape as scripts/sandbox.sh. We never copy `.history`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { sshExec, sshReachable, shellQuote } from '../ssh-exec.js';
+import type { Host } from './types.js';
+import { sshTargetFor } from './types.js';
+
+/** Resolve this CLI's own version by walking up to the nearest package.json. */
+export function localCliVersion(): string | null {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 8; i++) {
+    const pkg = path.join(dir, 'package.json');
+    try {
+      const data = JSON.parse(fs.readFileSync(pkg, 'utf-8')) as { name?: string; version?: string };
+      if (data.name && data.version) return data.version;
+    } catch {
+      /* keep walking */
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/** uname over ssh → reachable + OS string. */
+export function probeHost(target: string): { reachable: boolean; os?: string } {
+  const r = sshExec(target, 'uname -s 2>/dev/null || echo unknown', { timeoutMs: 12000 });
+  if (r.code !== 0) return { reachable: false };
+  const os = r.stdout.trim();
+  return { reachable: true, os: os && os !== 'unknown' ? os : undefined };
+}
+
+/** Remote agents-cli version (login shell for PATH), or null if not installed. */
+export function remoteAgentsVersion(target: string): string | null {
+  const r = sshExec(target, 'bash -lc "agents --version 2>/dev/null"', { timeoutMs: 20000 });
+  if (r.code !== 0) return null;
+  const v = r.stdout.trim();
+  return v || null;
+}
+
+/** True if the named agent CLI is installed on the remote (best-effort). */
+export function remoteAgentInstalled(target: string, agent: string): boolean {
+  // `agents view` (formerly `agents list`) prints capitalized display names
+  // (e.g. "Claude"), so match case-insensitively.
+  const r = sshExec(target, `bash -lc "agents view 2>/dev/null || agents list 2>/dev/null"`, { timeoutMs: 20000 });
+  if (r.code !== 0) return false;
+  return new RegExp(`\\b${agent}\\b`, 'i').test(r.stdout);
+}
+
+/** Install (or upgrade to) a specific agents-cli version on the remote, then `agents setup`. */
+export function bootstrapAgentsCli(target: string, version: string | null): { ok: boolean; output: string } {
+  const spec = version ? `@phnx-labs/agents-cli@${version}` : '@phnx-labs/agents-cli';
+  const script =
+    `npm install -g ${shellQuote(spec)} 2>&1 | tail -3; ` +
+    `if [ ! -d ~/.agents/.system ]; then agents setup 2>&1 | tail -3 || true; fi; ` +
+    `agents --version`;
+  const r = sshExec(target, `bash -lc ${shellQuote(script)}`, { timeoutMs: 300000 });
+  return { ok: r.code === 0, output: (r.stdout + r.stderr).trim() };
+}
+
+export interface EnsureReadyOptions {
+  agent: string;
+  /** Throw instead of warn when the agent isn't installed remotely. */
+  requireAgent?: boolean;
+}
+
+/**
+ * Verify a host can run the agent: reachable + agents-cli present. Throws with an
+ * actionable message otherwise. Agent-not-installed is a warning by default (the
+ * remote `agents run` will surface it); pass requireAgent to make it fatal.
+ */
+export function ensureHostReady(host: Host, opts: EnsureReadyOptions): { warnings: string[] } {
+  const target = sshTargetFor(host);
+  if (!sshReachable(target)) {
+    throw new Error(`Host "${host.name}" (${target}) is not reachable over SSH. Check it's online and key auth works.`);
+  }
+  if (!remoteAgentsVersion(target)) {
+    throw new Error(
+      `agents-cli is not installed on "${host.name}". Enroll it first: agents hosts add ${host.name} (bootstraps agents-cli).`,
+    );
+  }
+  const warnings: string[] = [];
+  if (!remoteAgentInstalled(target, opts.agent)) {
+    const msg = `Agent "${opts.agent}" may not be installed on "${host.name}" (remote \`agents add ${opts.agent}\` to install).`;
+    if (opts.requireAgent) throw new Error(msg);
+    warnings.push(msg);
+  }
+  return { warnings };
+}

--- a/src/lib/hosts/registry.ts
+++ b/src/lib/hosts/registry.ts
@@ -1,0 +1,70 @@
+/**
+ * Host provider registry.
+ *
+ * Mirrors the cloud provider registry: a Map of provider id → implementation,
+ * instantiated once. v1 registers only `local`; adding `rush`/`tailscale`/
+ * `crabbox` later is a one-line `providers.set(...)` with no caller changes.
+ */
+
+import type { Host, HostProvider, HostProviderId } from './types.js';
+import { LocalHostProvider } from './providers/local.js';
+
+const providers: Map<HostProviderId, HostProvider> = new Map();
+
+function initProviders(): void {
+  if (providers.size > 0) return;
+  providers.set('local', new LocalHostProvider());
+}
+
+export function getProvider(id: HostProviderId): HostProvider {
+  initProviders();
+  const provider = providers.get(id);
+  if (!provider) {
+    throw new Error(`Unknown host provider: ${id}. Available: ${[...providers.keys()].join(', ')}`);
+  }
+  return provider;
+}
+
+export function getAllProviders(): HostProvider[] {
+  initProviders();
+  return [...providers.values()];
+}
+
+/** Every host across all registered providers, deduped by name (first wins). */
+export async function listAllHosts(): Promise<Host[]> {
+  const seen = new Set<string>();
+  const out: Host[] = [];
+  for (const provider of getAllProviders()) {
+    for (const host of await provider.list()) {
+      if (seen.has(host.name)) continue;
+      seen.add(host.name);
+      out.push(host);
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve a host name to a single host across providers, or null if unknown.
+ * First provider that owns the name wins (only `local` in v1).
+ */
+export async function resolveHost(name: string): Promise<Host | null> {
+  for (const provider of getAllProviders()) {
+    const host = await provider.resolve(name);
+    if (host) return host;
+  }
+  return null;
+}
+
+/**
+ * Resolve a host by capability tag (e.g. `--host gpu`). Returns the single
+ * matching host, or throws on 0 or >1 matches unless `any` is set (then first).
+ */
+export async function resolveHostByCap(cap: string, any = false): Promise<Host> {
+  const matches = (await listAllHosts()).filter((h) => h.caps?.includes(cap));
+  if (matches.length === 0) throw new Error(`No host tagged "${cap}". Tag one with: agents hosts add <name> --cap ${cap}`);
+  if (matches.length > 1 && !any) {
+    throw new Error(`Multiple hosts tagged "${cap}": ${matches.map((h) => h.name).join(', ')}. Name one, or pass --any.`);
+  }
+  return matches[0];
+}

--- a/src/lib/hosts/ssh-config.test.ts
+++ b/src/lib/hosts/ssh-config.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { parseSshConfigHosts, parseKnownHosts } from './ssh-config.js';
+
+describe('parseSshConfigHosts', () => {
+  it('extracts concrete Host names and skips wildcard/negated patterns', () => {
+    const cfg = [
+      '# my ssh config',
+      'Host yosemite-s0 yosemite-s1',
+      '  HostName 100.84.0.1',
+      '  User muqsit',
+      '',
+      'Host mac-mini',
+      '  HostName mac-mini.local',
+      '',
+      'Host *',
+      '  ServerAliveInterval 60',
+      '',
+      'Host *.internal !secret',
+      '  User root',
+    ].join('\n');
+    expect(parseSshConfigHosts(cfg)).toEqual(['yosemite-s0', 'yosemite-s1', 'mac-mini']);
+  });
+
+  it('dedupes repeated names and ignores comments/blank lines', () => {
+    const cfg = 'Host a\nHost a\n\n#Host b\nHost c';
+    expect(parseSshConfigHosts(cfg)).toEqual(['a', 'c']);
+  });
+});
+
+describe('parseKnownHosts', () => {
+  it('extracts hostnames, skips hashed entries, strips [host]:port and comma lists', () => {
+    const kh = [
+      '|1|abc123hashed=|def= ssh-ed25519 AAAA', // hashed → skipped
+      'yosemite-s1 ssh-ed25519 AAAA',
+      '[mac-mini.local]:2222 ssh-rsa BBBB',
+      'gh.example.com,140.82.1.2 ssh-ed25519 CCCC',
+      '',
+      '# comment',
+    ].join('\n');
+    expect(parseKnownHosts(kh)).toEqual(['yosemite-s1', 'mac-mini.local', 'gh.example.com', '140.82.1.2']);
+  });
+});

--- a/src/lib/hosts/ssh-config.test.ts
+++ b/src/lib/hosts/ssh-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseSshConfigHosts, parseKnownHosts } from './ssh-config.js';
+import { parseSshConfigHosts, parseKnownHosts, sshResolve } from './ssh-config.js';
 
 describe('parseSshConfigHosts', () => {
   it('extracts concrete Host names and skips wildcard/negated patterns', () => {
@@ -38,5 +38,13 @@ describe('parseKnownHosts', () => {
       '# comment',
     ].join('\n');
     expect(parseKnownHosts(kh)).toEqual(['yosemite-s1', 'mac-mini.local', 'gh.example.com', '140.82.1.2']);
+  });
+});
+
+describe('sshResolve target-injection guard', () => {
+  it('refuses a dash-led name instead of passing it to `ssh -G` as a flag', () => {
+    // Must never spawn `ssh -G -oProxyCommand=…` — the guard short-circuits to undefined.
+    expect(sshResolve('-oProxyCommand=evil')).toBeUndefined();
+    expect(sshResolve('a;rm -rf /')).toBeUndefined();
   });
 });

--- a/src/lib/hosts/ssh-config.ts
+++ b/src/lib/hosts/ssh-config.ts
@@ -1,0 +1,144 @@
+/**
+ * Read the user's SSH config as a host directory — we never copy or rewrite it.
+ *
+ * `~/.ssh/config` is the source of truth for connection details; we only parse
+ * `Host` stanzas to list candidate names and `ssh -G <name>` to resolve them for
+ * display. `known_hosts` is a secondary candidate source for enrollment.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+
+const SSH_DIR = path.join(os.homedir(), '.ssh');
+const SSH_CONFIG = path.join(SSH_DIR, 'config');
+const KNOWN_HOSTS = path.join(SSH_DIR, 'known_hosts');
+
+/**
+ * Parse `Host` stanza names from ssh config text. Wildcard/negated patterns
+ * (`*`, `?`, `!`) are skipped — they're match rules, not concrete hosts.
+ * Pure (text in, names out) so it's unit-testable.
+ */
+export function parseSshConfigHosts(content: string): string[] {
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const m = /^Host\s+(.+)$/i.exec(line);
+    if (!m) continue;
+    for (const tok of m[1].split(/\s+/)) {
+      if (!tok || /[*?!]/.test(tok)) continue;
+      if (seen.has(tok)) continue;
+      seen.add(tok);
+      names.push(tok);
+    }
+  }
+  return names;
+}
+
+/**
+ * Parse hostnames from known_hosts text. Hashed entries (`|1|…`) carry no
+ * recoverable hostname and are skipped; `[host]:port` and comma lists are split.
+ * Pure for testability.
+ */
+export function parseKnownHosts(content: string): string[] {
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const first = line.split(/\s+/)[0];
+    if (!first || first.startsWith('|')) continue; // hashed
+    for (const entry of first.split(',')) {
+      // strip [host]:port → host
+      const host = entry.replace(/^\[/, '').replace(/\](:\d+)?$/, '');
+      if (!host || /[*?]/.test(host) || seen.has(host)) continue;
+      seen.add(host);
+      names.push(host);
+    }
+  }
+  return names;
+}
+
+/** `Host` names from ~/.ssh/config, following `Include` globs (best-effort). */
+export function listSshConfigHosts(): string[] {
+  const names = new Set<string>();
+  const visit = (file: string, depth: number): void => {
+    if (depth > 8) return;
+    let content: string;
+    try {
+      content = fs.readFileSync(file, 'utf-8');
+    } catch {
+      return;
+    }
+    for (const name of parseSshConfigHosts(content)) names.add(name);
+    // Follow Include directives (best-effort, relative to ~/.ssh).
+    for (const rawLine of content.split('\n')) {
+      const m = /^\s*Include\s+(.+)$/i.exec(rawLine);
+      if (!m) continue;
+      for (const pat of m[1].trim().split(/\s+/)) {
+        const abs = path.isAbsolute(pat) ? pat : path.join(SSH_DIR, pat.replace(/^~\//, ''));
+        for (const f of globMaybe(abs)) visit(f, depth + 1);
+      }
+    }
+  };
+  visit(SSH_CONFIG, 0);
+  return [...names];
+}
+
+/** Minimal glob: expand a single trailing `*` in the basename, else literal. */
+function globMaybe(pattern: string): string[] {
+  if (!pattern.includes('*')) {
+    return fs.existsSync(pattern) ? [pattern] : [];
+  }
+  const dir = path.dirname(pattern);
+  const base = path.basename(pattern);
+  const re = new RegExp('^' + base.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$');
+  try {
+    return fs.readdirSync(dir).filter((f) => re.test(f)).map((f) => path.join(dir, f));
+  } catch {
+    return [];
+  }
+}
+
+/** Hostnames recorded in ~/.ssh/known_hosts (hashed entries skipped). */
+export function listKnownHosts(): string[] {
+  try {
+    return parseKnownHosts(fs.readFileSync(KNOWN_HOSTS, 'utf-8'));
+  } catch {
+    return [];
+  }
+}
+
+/** True if `name` is a concrete `Host` stanza in ssh config. */
+export function isSshConfigHost(name: string): boolean {
+  return listSshConfigHosts().includes(name);
+}
+
+export interface SshGResult {
+  hostname?: string;
+  user?: string;
+  port?: string;
+}
+
+/**
+ * Authoritative resolution of a host's effective ssh config via `ssh -G <name>`
+ * (honors Match/Include). Returns undefined if `ssh` is unavailable. Note:
+ * `ssh -G` returns defaults even for unknown names — pair with `isSshConfigHost`
+ * to decide whether a name is actually configured.
+ */
+export function sshResolve(name: string): SshGResult | undefined {
+  const res = spawnSync('ssh', ['-G', name], { encoding: 'utf-8', timeout: 5000 });
+  if (res.status !== 0 || !res.stdout) return undefined;
+  const out: SshGResult = {};
+  for (const line of res.stdout.split('\n')) {
+    const [key, ...rest] = line.trim().split(/\s+/);
+    const val = rest.join(' ');
+    if (key === 'hostname') out.hostname = val;
+    else if (key === 'user') out.user = val;
+    else if (key === 'port') out.port = val;
+  }
+  return out;
+}

--- a/src/lib/hosts/ssh-config.ts
+++ b/src/lib/hosts/ssh-config.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { spawnSync } from 'child_process';
+import { assertValidSshTarget } from '../ssh-exec.js';
 
 const SSH_DIR = path.join(os.homedir(), '.ssh');
 const SSH_CONFIG = path.join(SSH_DIR, 'config');
@@ -130,6 +131,14 @@ export interface SshGResult {
  * to decide whether a name is actually configured.
  */
 export function sshResolve(name: string): SshGResult | undefined {
+  // Same target-injection guard as sshExec: a name starting with `-` (or
+  // carrying shell metacharacters) must never reach `ssh` as a bare argv where
+  // it could be parsed as a flag (e.g. `-oProxyCommand=…`).
+  try {
+    assertValidSshTarget(name);
+  } catch {
+    return undefined;
+  }
   const res = spawnSync('ssh', ['-G', name], { encoding: 'utf-8', timeout: 5000 });
   if (res.status !== 0 || !res.stdout) return undefined;
   const out: SshGResult = {};

--- a/src/lib/hosts/tasks.ts
+++ b/src/lib/hosts/tasks.ts
@@ -1,0 +1,80 @@
+/**
+ * Local record of dispatched host tasks.
+ *
+ * Each dispatch writes a `<id>.json` sidecar next to its `<id>.log` (and the
+ * remote's `<id>.exit`) under ~/.agents/.cache/hosts/, so `agents hosts ps/logs`
+ * can list runs and follow output across CLI invocations. (Folding these into
+ * the cloud SQLite store so `agents cloud ps` sees them is a fast-follow — it
+ * needs care around the cloud status-refresh path.)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { getCacheDir } from '../state.js';
+
+export type HostTaskStatus = 'running' | 'completed' | 'failed' | 'unknown';
+
+export interface HostTask {
+  id: string;
+  host: string;
+  target: string;
+  agent: string;
+  prompt: string;
+  pid?: number;
+  /** Remote paths (under the host's ~/.agents/.cache/hosts/). */
+  remoteLog: string;
+  remoteExit: string;
+  status: HostTaskStatus;
+  exitCode?: number;
+  createdAt: string;
+  finishedAt?: string;
+}
+
+export function hostsCacheDir(): string {
+  return path.join(getCacheDir(), 'hosts');
+}
+
+function taskFile(id: string): string {
+  return path.join(hostsCacheDir(), `${id}.json`);
+}
+
+/** Local path we mirror a task's remote log into while following. */
+export function localLogPath(id: string): string {
+  return path.join(hostsCacheDir(), `${id}.log`);
+}
+
+export function saveTask(task: HostTask): void {
+  fs.mkdirSync(hostsCacheDir(), { recursive: true });
+  fs.writeFileSync(taskFile(task.id), JSON.stringify(task, null, 2));
+}
+
+export function loadTask(id: string): HostTask | null {
+  try {
+    return JSON.parse(fs.readFileSync(taskFile(id), 'utf-8')) as HostTask;
+  } catch {
+    return null;
+  }
+}
+
+export function updateTask(id: string, patch: Partial<HostTask>): HostTask | null {
+  const task = loadTask(id);
+  if (!task) return null;
+  const next = { ...task, ...patch };
+  saveTask(next);
+  return next;
+}
+
+export function listTasks(): HostTask[] {
+  let files: string[];
+  try {
+    files = fs.readdirSync(hostsCacheDir()).filter((f) => f.endsWith('.json'));
+  } catch {
+    return [];
+  }
+  const tasks: HostTask[] = [];
+  for (const f of files) {
+    const task = loadTask(f.replace(/\.json$/, ''));
+    if (task) tasks.push(task);
+  }
+  return tasks.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}

--- a/src/lib/hosts/types.ts
+++ b/src/lib/hosts/types.ts
@@ -1,0 +1,64 @@
+/**
+ * Agent-host provider contract.
+ *
+ * A `HostProvider` answers "what are my hosts, and how do I reach them?" — the
+ * pluggable directory/metadata/reachability layer. v1 ships only the `local`
+ * provider (ssh-config ∪ inline registry); `rush`/`tailscale`/`crabbox` are
+ * additive fast-follows behind this same contract. Capability-gated so partial
+ * providers are first-class (mirrors the cloud provider registry).
+ */
+
+import type { HostEntry } from '../types.js';
+
+export type HostProviderId = 'local';
+
+export type HostStatus = 'online' | 'offline' | 'unknown';
+
+/** A host as seen at runtime: its persisted entry plus name/provider/status. */
+export interface Host extends HostEntry {
+  name: string;
+  provider: HostProviderId;
+  /** True when the host has an explicit overlay/inline entry in the registry. */
+  enrolled?: boolean;
+  status?: HostStatus;
+}
+
+export interface HostProviderCapabilities {
+  /** Can list/track hosts. */
+  directory: boolean;
+  /** Can add/remove hosts. */
+  mutate: boolean;
+  /** Reports online/offline without an explicit probe. */
+  presence: boolean;
+  /** Can dispatch a command without an SSH address (its own relay). */
+  relay: boolean;
+  /** Can provision new hosts. */
+  lease: boolean;
+}
+
+export interface HostProvider {
+  id: HostProviderId;
+  capabilities(): HostProviderCapabilities;
+  /** Every host this provider knows about. */
+  list(): Promise<Host[]>;
+  /** Resolve one host by name, or null if unknown to this provider. */
+  resolve(name: string): Promise<Host | null>;
+  /** Persist a host (mutate-capable providers only). */
+  register?(spec: Host): Promise<Host>;
+  /** Remove a host (mutate-capable providers only). */
+  remove?(name: string): Promise<void>;
+  /** Presence without an explicit probe (presence-capable providers only). */
+  presence?(name: string): Promise<HostStatus>;
+}
+
+/**
+ * The ssh target string for a host: the bare name for ssh-config hosts (ssh
+ * resolves HostName/User/Port/Identity), else `user@address` (or `address`).
+ */
+export function sshTargetFor(host: Host): string {
+  if (host.source === 'ssh-config') return host.name;
+  if (!host.address) {
+    throw new Error(`Host "${host.name}" is inline but has no address.`);
+  }
+  return host.user ? `${host.user}@${host.address}` : host.address;
+}

--- a/src/lib/ssh-exec.test.ts
+++ b/src/lib/ssh-exec.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { assertValidSshTarget, SSH_TARGET_RE, shellQuote } from './ssh-exec.js';
+
+describe('assertValidSshTarget', () => {
+  it('accepts bare host aliases and user@host', () => {
+    expect(() => assertValidSshTarget('yosemite-s0')).not.toThrow();
+    expect(() => assertValidSshTarget('muqsit@yosemite-s1')).not.toThrow();
+    expect(() => assertValidSshTarget('box.local')).not.toThrow();
+    expect(() => assertValidSshTarget('100.84.1.2')).not.toThrow();
+  });
+
+  it('rejects shell metacharacters and command injection', () => {
+    expect(() => assertValidSshTarget('a;rm -rf /')).toThrow();
+    expect(() => assertValidSshTarget('a$(whoami)')).toThrow();
+    expect(() => assertValidSshTarget('a host')).toThrow();
+    expect(() => assertValidSshTarget('a|b')).toThrow();
+    expect(() => assertValidSshTarget('')).toThrow();
+  });
+
+  it('rejects a leading dash so a target cannot be smuggled as an ssh flag', () => {
+    // This is the bug the bare regex misses — guarded explicitly in ssh-exec.
+    expect(() => assertValidSshTarget('-oProxyCommand=evil')).toThrow();
+    expect(() => assertValidSshTarget('-l')).toThrow();
+    expect(SSH_TARGET_RE.test('-l')).toBe(true); // the bare regex matches '-l' — the leading-dash guard is what blocks it
+  });
+});
+
+describe('shellQuote', () => {
+  it('passes safe tokens through unquoted', () => {
+    expect(shellQuote('claude')).toBe('claude');
+    expect(shellQuote('/usr/bin/agents')).toBe('/usr/bin/agents');
+  });
+
+  it('single-quotes strings with spaces or shell metacharacters', () => {
+    expect(shellQuote('fix the bug')).toBe("'fix the bug'");
+    expect(shellQuote('a;b')).toBe("'a;b'");
+  });
+
+  it('escapes embedded single quotes correctly', () => {
+    // it's -> 'it'\''s'  (close, escaped quote, reopen)
+    expect(shellQuote("it's")).toBe("'it'\\''s'");
+  });
+});

--- a/src/lib/ssh-exec.ts
+++ b/src/lib/ssh-exec.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared SSH exec primitive — the single hardened choke point for running a
+ * command on a remote host over the system `ssh`.
+ *
+ * `agents hosts` dispatch and the browser driver both go through here so the
+ * connection hardening (`BatchMode`, `accept-new`, `ConnectTimeout`) and the
+ * target-injection guard live in exactly one place. Target validation is the
+ * canonical definition; `commands/secrets.ts` re-exports it.
+ */
+
+import { spawnSync } from 'child_process';
+
+/**
+ * SSH target: a bare ssh-config host alias (e.g. `yosemite-s0`) or `user@host`.
+ * The strict allowlist blocks shell metacharacters so a target can't be
+ * smuggled in as part of a remote command, and `sshExec` additionally rejects a
+ * leading `-` so it can never be parsed as an ssh argv flag.
+ */
+export const SSH_TARGET_RE = /^[a-zA-Z0-9._-]+(@[a-zA-Z0-9._-]+)?$/;
+
+export function assertValidSshTarget(host: string): void {
+  if (host.startsWith('-') || !SSH_TARGET_RE.test(host)) {
+    throw new Error(
+      `Invalid SSH target ${JSON.stringify(host)}. Expected a host alias or user@host (letters, digits, '.', '_', '-').`,
+    );
+  }
+}
+
+/** POSIX single-quote a string for safe interpolation into a remote shell command. */
+export function shellQuote(s: string): string {
+  if (/^[A-Za-z0-9_./:=@%+-]+$/.test(s)) return s;
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+/** Hardened ssh options applied to every connection. */
+export const SSH_OPTS: readonly string[] = [
+  '-o', 'StrictHostKeyChecking=accept-new',
+  '-o', 'BatchMode=yes',
+  '-o', 'ConnectTimeout=10',
+];
+
+export interface SshExecOptions {
+  /** Piped to the remote command's stdin (never interpolated into the shell). */
+  input?: string;
+  /** Kill the ssh process after this many ms. */
+  timeoutMs?: number;
+  /** Extra ssh flags inserted before the target (e.g. `-tt`). */
+  extraSshArgs?: string[];
+}
+
+export interface SshExecResult {
+  /** Remote exit status, or null if ssh itself failed / timed out. */
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+/**
+ * Run `remoteCmd` on `target` over ssh and capture stdout/stderr/exit.
+ *
+ * `remoteCmd` is passed as a single argv to ssh (the remote login shell parses
+ * it); callers that build it from user input must `shellQuote` the pieces.
+ */
+export function sshExec(target: string, remoteCmd: string, opts: SshExecOptions = {}): SshExecResult {
+  assertValidSshTarget(target);
+  const args = [...SSH_OPTS, ...(opts.extraSshArgs ?? []), target, remoteCmd];
+  const res = spawnSync('ssh', args, {
+    input: opts.input,
+    encoding: 'utf-8',
+    timeout: opts.timeoutMs,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const timedOut = !!(res.error && (res.error as NodeJS.ErrnoException).code === 'ETIMEDOUT');
+  return {
+    code: typeof res.status === 'number' ? res.status : null,
+    stdout: res.stdout ?? '',
+    stderr: res.stderr ?? '',
+    timedOut,
+  };
+}
+
+/** True if `target` is reachable over ssh (a passwordless `true` succeeds quickly). */
+export function sshReachable(target: string, timeoutMs = 10000): boolean {
+  return sshExec(target, 'true', { timeoutMs }).code === 0;
+}

--- a/src/lib/startup/command-registry.ts
+++ b/src/lib/startup/command-registry.ts
@@ -73,6 +73,7 @@ export const loadPty: ModuleLoader = async () => (await import('../../commands/p
 export const loadTmux: ModuleLoader = async () => (await import('../../commands/tmux.js')).registerTmuxCommands;
 export const loadBrowser: ModuleLoader = async () => (await import('../../commands/browser.js')).registerBrowserCommand;
 export const loadComputer: ModuleLoader = async () => (await import('../../commands/computer.js')).registerComputerCommand;
+export const loadHosts: ModuleLoader = async () => (await import('../../commands/hosts.js')).registerHostsCommand;
 export const loadPull: ModuleLoader = async () => (await import('../../commands/pull.js')).registerPullCommand;
 export const loadPush: ModuleLoader = async () => (await import('../../commands/push.js')).registerPushCommand;
 export const loadRepo: ModuleLoader = async () => (await import('../../commands/repo.js')).registerRepoCommands;
@@ -156,6 +157,7 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   tmux: [loadTmux],
   browser: [loadBrowser],
   computer: [loadComputer],
+  hosts: [loadHosts],
   pull: [loadPull],
   push: [loadPush],
   repo: [loadRepo],

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -676,6 +676,28 @@ export interface Meta {
    * lives separately in ~/.agents/.cache/browser/<profile>/.
    */
   browser?: Record<string, BrowserProfileConfig>;
+  /**
+   * Agent-host registry keyed by host name (`agents hosts`). Portable user
+   * config synced with `agents repo push/pull`. For `ssh-config` hosts this is
+   * just an overlay (caps/os) — the connection details stay in ~/.ssh/config and
+   * are never copied. `inline` hosts carry their own address/user.
+   */
+  hosts?: Record<string, HostEntry>;
+}
+
+/** Persisted agent-host entry in agents.yaml (overlay or inline). */
+export interface HostEntry {
+  /** `ssh-config`: reach via the bare name (ssh resolves). `inline`: use address/user below. */
+  source: 'ssh-config' | 'inline';
+  /** SSH-reachable target — inline hosts only (ssh-config hosts omit it). */
+  address?: string;
+  /** SSH user — inline hosts only. */
+  user?: string;
+  /** Captured at enroll probe. */
+  os?: string;
+  /** Free-form capability tags for routing (e.g. ['gpu']). */
+  caps?: string[];
+  addedAt?: string;
 }
 
 /** Browser profile definition stored in agents.yaml. */


### PR DESCRIPTION
## What

Phase 1 of the agent-hosts design (`docs/hosts.md`, RFC #438): register your own machines and **offload headless agent runs onto them over SSH**, so a thrashing laptop stays responsive. v1 has **no Rush dependency, no daemon, no account**.

```
agents hosts add s1 muqsit@yosemite-s1
agents run claude "fix the auth bug" --host s1     # runs on s1, live progress, real exit code
```

## Design

- **Pluggable `HostProvider` seam** (mirrors `cloud/registry.ts`), capability-gated. v1 ships only the `local` provider; `rush`/`tailscale`/`crabbox` are additive fast-follows behind the same contract — no rewrite.
- **`~/.ssh/config` is the source of truth, never copied.** Hosts in ssh config are dispatchable with **zero registration** (`ssh <name>` resolves HostName/User/Port/Identity); `Meta.hosts` is a thin overlay (caps/os) plus truly inline (non-ssh-config) hosts. Hosts ride whatever already syncs your ssh config across devices.
- **Dispatch** launches a detached remote `agents run` and follows progress by **offset-tailing the remote log** (durable, reconnect-safe), returning the real exit code. Tasks tracked under `~/.agents/.cache/hosts` (`agents hosts ps/logs`).
- **Shared hardened `ssh-exec` primitive** (`src/lib/ssh-exec.ts`) is now the single SSH choke point + canonical target validation (blocks metachars **and** a leading `-`); `secrets.ts` and the browser ssh driver consume it (dedup).

## Surface

- `agents hosts add [name] [user@host]` — no-arg form scans `~/.ssh/config` + `known_hosts` → `checkbox` multi-select; bootstraps/upgrades agents-cli to match the local version on enroll.
- `agents hosts list [--json] | check <name> | remove <name> | ps [--json] | logs <id> [-f]`
- `agents run --host <name>` (hidden aliases `--on`, `--computer`) + `--remote-cwd`, `--no-follow`.

## Tests

Unit (real, no mocks): `ssh-exec` (injection guard + shellQuote), `ssh-config` parsing (`Include`/wildcard, known_hosts hashed/`[host]:port`), `local` provider CRUD + ssh-config union + resolution order. **13 pass.**

**Real E2E, `yosemite-s0` → `yosemite-s1`:**
```
$ agents hosts add s1 yosemite-s1 --no-enroll   → Enrolled s1 (inline, Linux)
$ agents hosts check s1                          → reachable · Linux · agents-cli 1.20.27
$ agents run claude "...hostname..." --host s1 --mode skip
  yosemite-s1            ← agent executed OFF-BOX on the peer
$ echo $?  → 0
$ agents hosts ps --json → {status: completed, exitCode: 0}
```

Full suite: clean typecheck; the only failures (`secrets/__tests__/bundles-storage.test.ts`, 4) are **pre-existing and unrelated** — they fail identically on unmodified `main` (environmental, not from this change).

## Out of scope (fast-follows)

`rush`/`tailscale`/`crabbox` providers, transcript-parser rich rendering, cloud-store unification (`agents cloud ps` visibility), working-tree handoff (Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
