### PR TITLE
ci: cross-platform test matrix (Linux + macOS + Windows)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,20 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     permissions: {}
     strategy:
+      # Run every OS x node combo to completion so a single platform failure
+      # doesn't mask the others — we want the full cross-platform picture.
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [22, 24]
+    # Cross-platform gating is being brought up incrementally (Linux + macOS +
+    # Windows is the target). Native Windows still has known gaps (#TODO: link),
+    # so Windows legs may fail without blocking the branch until those land.
+    # Promote Windows to a required check once it's green.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -28,8 +37,15 @@ jobs:
       - name: Install dependencies
         run: bun install --ignore-scripts
 
-      - name: Install Playwright browsers
+      # --with-deps installs OS-level libs for headless Chromium and only works
+      # on Linux (apt). macOS and Windows ship the needed libs already.
+      - name: Install Playwright browsers (Linux)
+        if: runner.os == 'Linux'
         run: bunx playwright install --with-deps chromium
+
+      - name: Install Playwright browsers (macOS/Windows)
+        if: runner.os != 'Linux'
+        run: bunx playwright install chromium
 
       - name: Build
         run: bun run build


### PR DESCRIPTION
## What

Phase 1 of cross-platform release gating. Adds an `os` axis to the CI matrix so tests run on **ubuntu-latest + macos-latest + windows-latest** × node 22/24, with `fail-fast: false`.

## Why

A release is cut on macOS via `scripts/release.sh`, whose test step runs `npm test` **on that Mac only**. The suite is platform-conditional, so Linux-only tests (`raw-item.test.ts`, `chrome.test.ts`) silently skip at release time, and Windows is never exercised at all. CI itself was `ubuntu-latest`-only. Net: a release validates one platform, not the platforms it ships to.

This PR is the empirical foundation — it makes each platform's results **exist** so a later phase can gate the release on all-green-at-the-release-SHA.

## Phasing

- **This PR (Phase 1):** expand the matrix. macOS expected green; Windows expected red — `continue-on-error` keeps it non-blocking so we can read the real failure set from the logs instead of guessing.
- **Phase 2:** fix the Windows gaps CI reveals (`.cmd` shim companions, `rules.ts` junction-symlink fallback, ensure `secrets` tests `skipIf(win32)` rather than throw), then promote Windows → required.
- **Phase 3:** add a `release.sh` pre-flight that asserts every required platform check-run is green for `HEAD`, plus the macOS-only signing/notarization gate locally.

## Notes

- Playwright `--with-deps` is gated to Linux (apt-only); macOS/Windows use plain `playwright install chromium`.
- Promoting macOS/Windows to **required** status checks is a branch-protection change (the matrix rename means the required-check names change from `build (22)` to `build (ubuntu-latest, 22)`); that happens when each platform goes green, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)