### PR TITLE
feat: drive remote windows edge/chrome over ssh

### DIFF
--- a/src/lib/browser/drivers/ssh.test.ts
+++ b/src/lib/browser/drivers/ssh.test.ts
@@ -2,9 +2,23 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import {
+  buildLaunchCmd,
+  buildKillCmd,
+  buildWindowsLaunchScript,
+  buildWindowsKillScript,
+  encodePowerShell,
+} from './ssh.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const sshSrc = readFileSync(join(here, 'ssh.ts'), 'utf8');
+
+/** Decode a `powershell -NoProfile -EncodedCommand <b64>` back to its script. */
+function decodeEncoded(cmd: string): string {
+  const m = cmd.match(/^powershell -NoProfile -EncodedCommand (\S+)$/);
+  if (!m) throw new Error(`not an EncodedCommand invocation: ${cmd}`);
+  return Buffer.from(m[1], 'base64').toString('utf16le');
+}
 
 describe('ssh driver CDP launch args', () => {
   it('never sets --remote-allow-origins=* (DNS-rebind / cross-origin CDP risk)', () => {
@@ -13,5 +27,94 @@ describe('ssh driver CDP launch args', () => {
 
   it('scopes --remote-allow-origins to a 127.0.0.1 URL with the forwarded port', () => {
     expect(sshSrc).toMatch(/--remote-allow-origins=http:\/\/127\.0\.0\.1:\$\{port\}/);
+  });
+});
+
+describe('buildWindowsLaunchScript', () => {
+  it('spawns via WMI so the browser survives the ssh session (no start /B)', () => {
+    const s = buildWindowsLaunchScript('edge', 9222);
+    expect(s).toContain('Win32_Process');
+    expect(s).toContain('Invoke-CimMethod');
+    expect(s).not.toContain('start /B');
+    expect(s).not.toContain('Start-Process');
+  });
+
+  it('resolves the real .exe from App Paths for a known browser', () => {
+    expect(buildWindowsLaunchScript('edge', 9222)).toContain('App Paths\\msedge.exe');
+    expect(buildWindowsLaunchScript('chrome', 9222)).toContain('App Paths\\chrome.exe');
+  });
+
+  it('uses a custom binary path verbatim (no App Paths lookup)', () => {
+    const s = buildWindowsLaunchScript('custom', 9222, 'C:\\Tools\\msedge.exe');
+    expect(s).toContain("$exe = 'C:\\Tools\\msedge.exe'");
+    expect(s).not.toContain('App Paths');
+  });
+
+  it('sets the CDP port, scoped allow-origins, and a TEMP user-data-dir', () => {
+    const s = buildWindowsLaunchScript('edge', 9333);
+    expect(s).toContain('--remote-debugging-port=9333');
+    expect(s).toContain('--remote-allow-origins=http://127.0.0.1:9333');
+    expect(s).toContain('$env:TEMP');
+    expect(s).toContain('agents-browser-9333');
+  });
+
+  it('rejects browser=custom without a binary', () => {
+    expect(() => buildWindowsLaunchScript('custom', 9222)).toThrow(/requires a binary/);
+  });
+});
+
+describe('encodePowerShell', () => {
+  it('round-trips a script through UTF-16LE base64', () => {
+    const script = buildWindowsLaunchScript('edge', 9222);
+    const cmd = encodePowerShell(script);
+    expect(cmd.startsWith('powershell -NoProfile -EncodedCommand ')).toBe(true);
+    expect(decodeEncoded(cmd)).toBe(script);
+  });
+
+  it('produces a single quote-free token (safe over ssh → cmd.exe)', () => {
+    const cmd = encodePowerShell(buildWindowsLaunchScript('edge', 9222));
+    const b64 = cmd.replace('powershell -NoProfile -EncodedCommand ', '');
+    expect(b64).toMatch(/^[A-Za-z0-9+/=]+$/);
+  });
+});
+
+describe('buildLaunchCmd (windows)', () => {
+  it('returns an EncodedCommand wrapping the WMI launch script', () => {
+    const cmd = buildLaunchCmd('windows', 'edge', 9222);
+    expect(decodeEncoded(cmd)).toBe(buildWindowsLaunchScript('edge', 9222));
+  });
+});
+
+describe('buildLaunchCmd (posix)', () => {
+  it('backgrounds the .app binary with & and a /tmp user-data-dir', () => {
+    const cmd = buildLaunchCmd('posix', 'edge', 9222);
+    expect(cmd).toContain('Microsoft Edge.app');
+    expect(cmd).toContain('--remote-debugging-port=9222');
+    expect(cmd).toContain('--user-data-dir=/tmp/agents-browser-9222');
+    expect(cmd.trimEnd()).toMatch(/&$/);
+    expect(cmd).not.toContain('powershell');
+  });
+
+  it('uses a custom binary path verbatim', () => {
+    const cmd = buildLaunchCmd('posix', 'custom', 9222, '/opt/edge/edge');
+    expect(cmd).toContain('/opt/edge/edge');
+  });
+});
+
+describe('buildKillCmd', () => {
+  it('windows tears down via encoded Get-NetTCPConnection → Stop-Process', () => {
+    const cmd = buildKillCmd('windows', 9222);
+    const script = decodeEncoded(cmd);
+    expect(script).toBe(buildWindowsKillScript(9222));
+    expect(script).toContain('Get-NetTCPConnection -LocalPort 9222');
+    expect(script).toContain('Stop-Process');
+    expect(script).not.toContain('lsof');
+  });
+
+  it('posix tears down via lsof + kill on the port', () => {
+    const cmd = buildKillCmd('posix', 9222);
+    expect(cmd).toContain('lsof -ti');
+    expect(cmd).toContain(':9222');
+    expect(cmd).not.toContain('Stop-Process');
   });
 });

--- a/src/lib/browser/drivers/ssh.ts
+++ b/src/lib/browser/drivers/ssh.ts
@@ -13,6 +13,15 @@ export interface SSHConnection {
   cleanup: () => void;
 }
 
+/**
+ * Which shell dialect the *remote* host speaks. Selected per-endpoint via the
+ * `&os=windows` query param on an `ssh://` target. POSIX is the default — the
+ * historical behavior for macOS/Linux remotes. Windows remotes run OpenSSH
+ * Server with cmd.exe as the default shell, so the launch/teardown command
+ * strings differ (no `&` backgrounding, no `lsof`, `.exe` instead of `.app`).
+ */
+export type RemoteOs = 'windows' | 'posix';
+
 export function shellQuote(s: string): string {
   if (/^[A-Za-z0-9_./:=@%+-]+$/.test(s)) return s;
   return "'" + s.replace(/'/g, "'\\''") + "'";
@@ -39,6 +48,13 @@ export async function connectSSH(
   const host = parsed.host;
   const remotePort = parsed.port;
 
+  // `&os=windows` switches the remote-command dialect (cmd.exe launch via
+  // `start`, taskkill teardown). Anything else — including absent — is posix.
+  // The query param is the single source of truth so the driver never has to
+  // be threaded a separate per-profile field.
+  const remoteOs: RemoteOs =
+    (url.searchParams.get('os') || '').toLowerCase() === 'windows' ? 'windows' : 'posix';
+
   // Bind the tunnel to the SAME local port the user configured. Using an
   // allocated port instead made `status` print confusing rows like
   // `port 9200 (configured 10005)` and made it impossible to predict which
@@ -59,7 +75,7 @@ export async function connectSSH(
   }
 
   try {
-    await ensureRemoteBrowser(user, host, profile.browser, remotePort, profile.binary);
+    await ensureRemoteBrowser(user, host, profile.browser, remotePort, remoteOs, profile.binary);
   } catch {
     // Browser may already be running, continue
   }
@@ -186,34 +202,114 @@ function tryConnect(port: number): Promise<void> {
   });
 }
 
-async function ensureRemoteBrowser(
-  user: string,
-  host: string,
+// macOS .app launchers — the historical POSIX table.
+const POSIX_BROWSER_PATHS: Record<string, string> = {
+  chrome: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  comet: '/Applications/Comet.app/Contents/MacOS/Comet',
+  chromium: '/Applications/Chromium.app/Contents/MacOS/Chromium',
+  brave: '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+  edge: '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+};
+
+// Windows App Paths registry keys per browser. CreateProcess (used by WMI
+// Win32_Process.Create) does not honor App Paths the way ShellExecute/`start`
+// does, so the launch script resolves the real `.exe` path from this registry
+// key at runtime — covering both Program Files and Program Files (x86)
+// installs without hardcoding (or guessing) the location.
+const WIN_BROWSER_APPPATH: Record<string, string> = {
+  chrome: 'chrome.exe',
+  chromium: 'chrome.exe',
+  brave: 'brave.exe',
+  edge: 'msedge.exe',
+};
+
+/** Single-quote a string for embedding inside a PowerShell literal. */
+function psSingleQuote(s: string): string {
+  return "'" + s.replace(/'/g, "''") + "'";
+}
+
+/**
+ * Wrap a PowerShell script as a `-EncodedCommand` invocation. Base64 of the
+ * UTF-16LE bytes is a single quote-free token, so it rides through Node spawn
+ * → Windows sshd → cmd.exe with zero escaping hazards (hand-quoted
+ * `powershell -Command "…"` is fragile the moment a path or URL is involved).
+ */
+export function encodePowerShell(script: string): string {
+  const b64 = Buffer.from(script, 'utf16le').toString('base64');
+  return `powershell -NoProfile -EncodedCommand ${b64}`;
+}
+
+/**
+ * The PowerShell that launches the browser on a Windows remote. Two hard
+ * requirements shaped this:
+ *   1. The browser must OUTLIVE the ssh session. Windows OpenSSH terminates
+ *      the session's job tree on disconnect, which reaps both `start /B` and
+ *      `Start-Process` children (verified against a real box). WMI
+ *      `Win32_Process.Create` spawns under the WMI provider service instead,
+ *      so the process survives after we drop the ssh connection and reconnect
+ *      over the CDP tunnel.
+ *   2. A distinct `--user-data-dir` so a fresh instance bound to the debugging
+ *      port comes up even when the user already has Edge open.
+ * CreateProcess ignores App Paths, so we resolve the real `.exe` from the
+ * registry at runtime rather than relying on a bare `msedge` name.
+ */
+export function buildWindowsLaunchScript(
   browserType: string,
   port: number,
   customBinary?: string
-): Promise<void> {
-  const browserPaths: Record<string, string> = {
-    chrome: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-    comet: '/Applications/Comet.app/Contents/MacOS/Comet',
-    chromium: '/Applications/Chromium.app/Contents/MacOS/Chromium',
-    brave: '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
-    edge: '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
-  };
-
-  let browserPath: string;
+): string {
+  let exeExpr: string;
   if (customBinary) {
-    browserPath = customBinary;
+    exeExpr = psSingleQuote(customBinary);
   } else if (browserType === 'custom') {
     throw new Error('browser: custom requires a binary path in the profile');
   } else {
-    browserPath = browserPaths[browserType];
-    if (!browserPath) {
-      throw new Error(`Unknown browser type: ${browserType}`);
-    }
+    const exeKey = WIN_BROWSER_APPPATH[browserType];
+    if (!exeKey) throw new Error(`Unknown browser type for windows remote: ${browserType}`);
+    exeExpr =
+      `(Get-ItemProperty 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\${exeKey}').'(default)'`;
   }
+  // Keep the `--remote-allow-origins=http://127.0.0.1:${port}` literal in
+  // source — a test asserts CDP is never opened to `*`.
+  return [
+    `$exe = ${exeExpr}`,
+    `$cl = '"' + $exe + '" --remote-debugging-port=${port}` +
+      ` --remote-allow-origins=http://127.0.0.1:${port}` +
+      ` --disable-background-timer-throttling --user-data-dir="' + $env:TEMP + '\\agents-browser-${port}"'`,
+    `Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{ CommandLine = $cl } | Out-Null`,
+  ].join('; ');
+}
 
-  const remoteCmd = [
+/** The PowerShell that kills whatever holds the CDP port on a Windows remote. */
+export function buildWindowsKillScript(port: number): string {
+  return (
+    `Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue ` +
+    `| ForEach-Object { Stop-Process -Id $_.OwningProcess -Force -ErrorAction SilentlyContinue }`
+  );
+}
+
+/**
+ * Build the remote command that launches the browser detached with a CDP port.
+ * POSIX backgrounds the `.app` binary with `… &`; Windows resolves the exe and
+ * spawns it via WMI (encoded PowerShell) so it survives the ssh session.
+ */
+export function buildLaunchCmd(
+  remoteOs: RemoteOs,
+  browserType: string,
+  port: number,
+  customBinary?: string
+): string {
+  if (remoteOs === 'windows') {
+    return encodePowerShell(buildWindowsLaunchScript(browserType, port, customBinary));
+  }
+  const browserPath = customBinary ?? POSIX_BROWSER_PATHS[browserType];
+  if (!browserPath) {
+    if (browserType === 'custom') {
+      throw new Error('browser: custom requires a binary path in the profile');
+    }
+    throw new Error(`Unknown browser type for posix remote: ${browserType}`);
+  }
+  return [
     shellQuote(browserPath),
     `--remote-debugging-port=${port}`,
     shellQuote(`--remote-allow-origins=http://127.0.0.1:${port}`),
@@ -221,6 +317,29 @@ async function ensureRemoteBrowser(
     `--user-data-dir=/tmp/agents-browser-${port}`,
     '</dev/null >/dev/null 2>&1 &',
   ].join(' ');
+}
+
+/**
+ * Build the remote command that kills whatever holds the CDP port.
+ * POSIX uses `lsof`+`kill`; Windows uses encoded PowerShell
+ * (Get-NetTCPConnection → Stop-Process).
+ */
+export function buildKillCmd(remoteOs: RemoteOs, port: number): string {
+  if (remoteOs === 'windows') {
+    return encodePowerShell(buildWindowsKillScript(port));
+  }
+  return `pids=$(lsof -ti ${shellQuote(`:${port}`)} 2>/dev/null); [ -z "$pids" ] || kill -9 $pids 2>/dev/null || true`;
+}
+
+async function ensureRemoteBrowser(
+  user: string,
+  host: string,
+  browserType: string,
+  port: number,
+  remoteOs: RemoteOs,
+  customBinary?: string
+): Promise<void> {
+  const remoteCmd = buildLaunchCmd(remoteOs, browserType, port, customBinary);
 
   return new Promise((resolve, reject) => {
     const child = spawn(
@@ -249,13 +368,13 @@ export async function restartRemoteBrowser(
   host: string,
   browserType: string,
   port: number,
+  remoteOs: RemoteOs,
   customBinary?: string
 ): Promise<void> {
   // Kill any process using the remote debugging port
-  const killCmd = `pids=$(lsof -ti ${shellQuote(`:${port}`)} 2>/dev/null); [ -z "$pids" ] || kill -9 $pids 2>/dev/null || true`;
-  await runSSHCommand(user, host, killCmd);
+  await runSSHCommand(user, host, buildKillCmd(remoteOs, port));
   await sleep(500);
-  await ensureRemoteBrowser(user, host, browserType, port, customBinary);
+  await ensureRemoteBrowser(user, host, browserType, port, remoteOs, customBinary);
   await sleep(1500);
 }
 

--- a/src/lib/browser/profiles.ts
+++ b/src/lib/browser/profiles.ts
@@ -203,6 +203,29 @@ function hasSshEndpoint(endpoints: BrowserProfileConfig['endpoints']): boolean {
   });
 }
 
+/**
+ * True when any endpoint is an `ssh://…?os=windows` target — i.e. the browser
+ * lives on a remote Windows host. Such a profile's binary (`msedge.exe`) will
+ * never exist on this Mac, so create-time local-binary validation must be
+ * skipped; the binary is resolved on the remote at connect time instead.
+ */
+function hasRemoteWindowsEndpoint(endpoints: BrowserProfileConfig['endpoints']): boolean {
+  const targets = Array.isArray(endpoints)
+    ? endpoints
+    : Object.values(endpoints).map((preset) => preset.target);
+  return targets.some((target) => {
+    try {
+      const url = new URL(target);
+      return (
+        url.protocol === 'ssh:' &&
+        (url.searchParams.get('os') || '').toLowerCase() === 'windows'
+      );
+    } catch {
+      return false;
+    }
+  });
+}
+
 export async function createProfile(profile: BrowserProfile): Promise<void> {
   const meta = readMeta();
   if (meta.browser?.[profile.name]) {
@@ -233,7 +256,13 @@ export async function createProfile(profile: BrowserProfile): Promise<void> {
   // error ("Comet not installed at /Applications/Comet.app") rather than
   // deferring the failure to the first task. `findBrowserPath` short-circuits
   // for browser=custom without a binary by throwing — same outcome.
-  findBrowserPath(profile.browser, profile.binary);
+  //
+  // Skip for remote-Windows profiles: the browser is `msedge.exe` on the
+  // remote box, never on this Mac, so a local lookup would always (wrongly)
+  // fail. The remote launcher resolves it at connect time via App Paths.
+  if (!hasRemoteWindowsEndpoint(profile.endpoints)) {
+    findBrowserPath(profile.browser, profile.binary);
+  }
 
   meta.browser = meta.browser ?? {};
   meta.browser[profile.name] = profileToConfig(profile);

--- a/src/lib/browser/types.ts
+++ b/src/lib/browser/types.ts
@@ -8,7 +8,15 @@ export type BrowserType = 'chrome' | 'comet' | 'chromium' | 'brave' | 'edge' | '
  * Per-endpoint overrides take precedence over profile-level fields.
  */
 export interface EndpointPreset {
-  /** CDP URL — `cdp://host:port` or `ssh://host?port=N` */
+  /**
+   * CDP URL — `cdp://host:port` or `ssh://host?port=N`.
+   *
+   * For an SSH target whose remote is Windows, append `&os=windows` (e.g.
+   * `ssh://user@host?port=9222&os=windows`). The driver then speaks the
+   * cmd.exe dialect (launch via `start /B msedge`, teardown via PowerShell)
+   * instead of the POSIX default. The query param is the single source of
+   * truth for remote-OS selection.
+   */
   target: string;
   /** Override the profile-level binary (e.g. a remote host has no local binary). */
   binary?: string;

--- a/src/lib/browser/types.ts
+++ b/src/lib/browser/types.ts
@@ -13,7 +13,8 @@ export interface EndpointPreset {
    *
    * For an SSH target whose remote is Windows, append `&os=windows` (e.g.
    * `ssh://user@host?port=9222&os=windows`). The driver then speaks the
-   * cmd.exe dialect (launch via `start /B msedge`, teardown via PowerShell)
+   * Windows dialect (launch via WMI Win32_Process.Create so the browser
+   * survives the ssh session, teardown via Get-NetTCPConnection/Stop-Process)
    * instead of the POSIX default. The query param is the single source of
    * truth for remote-OS selection.
    */


### PR DESCRIPTION
## What

Teach the `agents browser` SSH driver to drive **Edge/Chrome on a remote Windows host** over the existing CDP tunnel. Opt in per-endpoint with `&os=windows`:

```
agents browser profiles create win --browser edge \
  --endpoint 'ssh://muqsit@win-mini?port=9222&os=windows'
agents browser --profile win open https://www.google.com
```

The SSH transport was already OS-agnostic; only the remote *command strings* assumed POSIX. This branches launch/teardown on the remote OS, with `os=windows` on the endpoint URL as the single source of truth.

## Why WMI instead of `start /B`

My first cut used `start /B msedge` — it failed end-to-end: **Windows OpenSSH terminates the session's entire job tree on disconnect**, so the browser was reaped the instant the launch SSH call returned (verified on a real box — `start /B` *and* `Start-Process` children both die). The fix is **WMI `Win32_Process.Create`**, which spawns the process under the WMI provider service so it survives after we drop the connection and reconnect over the CDP tunnel. It's delivered as PowerShell `-EncodedCommand` (base64 UTF-16LE) so the command rides Node spawn -> sshd -> cmd.exe with zero quoting hazards.

`CreateProcess` ignores App Paths, so the launch script resolves the real `.exe` from the registry at runtime (handles Program Files vs Program Files (x86) without guessing).

## Changes

- `drivers/ssh.ts` — `os=windows` parsing; `buildLaunchCmd`/`buildKillCmd` branch on remote OS; Windows path via WMI + encoded PowerShell
- `profiles.ts` — skip create-time **local** binary validation for remote-Windows profiles (the `.exe` only exists on the remote)
- `types.ts` — document the `&os=windows` endpoint param
- `ssh.test.ts` — 14 unit tests on the generated command strings / encoding

## Verification (real box, `win-mini`)

Ran the **exact** `buildLaunchCmd('windows','edge',9230)` output over SSH:

- Edge came up: `Browser: Edg/149.0.4022.98`, `Windows NT 10.0; Win64`
- Survived the SSH session, bound CDP, tunneled, navigated -> `LOADED: https://www.google.com/ | Google`
- `tsc --noEmit` clean; 57/57 browser unit tests pass

## Notes

- Prereq (doc, not code): remote must run OpenSSH Server with **key auth** (the tunnel uses `BatchMode=yes`).
- Mode is background automation — the remote browser renders in the SSH (session-0) window station, not on the user's monitor. On-screen control is the job of the planned Windows computer-use daemon (Direction 2).