### PR TITLE
feat: signed-in state for agents with emailless oauth credentials

### DIFF
--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -74,6 +74,10 @@ import { loadManifest, isStale } from '../lib/staleness/index.js';
 import { confirm } from '@inquirer/prompts';
 import { formatPath, isInteractiveTerminal, isPromptCancelled } from './utils.js';
 
+// Shown in the email column for agents that are signed in but expose no email
+// address locally (Antigravity, Kimi store an opaque OAuth/JWT credential).
+const SIGNED_IN_LABEL = 'signed in';
+
 /**
  * Group profile summaries by their host harness, optionally filtered to a
  * single agent. Profile YAMLs that fail validation are silently skipped by
@@ -435,6 +439,7 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
         const rawInfo = infoMap.get(`${agentId}:${v}`);
         const info = rawInfo ? mergeCanonical(rawInfo) : undefined;
         if (info?.email) maxEmail = Math.max(maxEmail, info.email.length);
+        else if (info?.signedIn) maxEmail = Math.max(maxEmail, SIGNED_IN_LABEL.length);
         if (info?.plan) maxPlanWidth = Math.max(maxPlanWidth, info.plan.length);
       }
       // Profile rows share these columns with version rows so they line up.
@@ -493,6 +498,7 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
         // Build columns, trimming trailing whitespace when columns are empty
         const parts = [`    ${label}`];
         const hasEmail = !!vInfo?.email;
+        const signedIn = !!vInfo?.signedIn;
         const usageStr = formatUsageSummary(vInfo?.plan || null, usageInfo?.snapshot || null, maxPlanWidth);
         const hasUsage = usageStr.length > 0;
         // Only show lastActive for versions with an actual logged-in account.
@@ -504,13 +510,16 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
         if (runDefaults.mode) runDefaultBits.push(`mode:${runDefaults.mode}`);
         if (runDefaults.model) runDefaultBits.push(`model:${runDefaults.model}`);
 
-        if (!hasEmail && !hasUsage) {
+        if (!hasEmail && !hasUsage && !signedIn) {
           // Installed but never signed in
           parts.push(chalk.gray('(not signed in — run ' + agent.cliCommand + ' to log in)'));
         } else {
-          if (hasEmail || hasUsage || hasActive) {
-            const emailCol = (vInfo?.email || '').padEnd(maxEmail);
-            parts.push(hasEmail ? chalk.cyan(emailCol) : ' '.repeat(maxEmail));
+          if (hasEmail || hasUsage || hasActive || signedIn) {
+            // Signed-in agents without a local email (Antigravity, Kimi) show a
+            // "signed in" placeholder so they read as logged in, not blank.
+            const display = vInfo?.email || (signedIn ? SIGNED_IN_LABEL : '');
+            const emailCol = display.padEnd(maxEmail);
+            parts.push(display ? chalk.cyan(emailCol) : ' '.repeat(maxEmail));
           }
           if (hasUsage || hasActive) {
             const usagePad = ' '.repeat(Math.max(0, maxUsageWidth - visibleWidth(usageStr)));
@@ -596,7 +605,10 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
       const gUsage = gUsageKey ? usageByKey.get(gUsageKey) : undefined;
       const gUsageStr = formatUsageSummary(gInfo?.plan || null, gUsage?.snapshot || null);
       const gActiveStr = gInfo ? formatLastActive(gInfo.lastActive) : '';
-      if (gInfo?.email || gUsageStr || gActiveStr) parts.push(gInfo?.email ? chalk.cyan(gInfo.email) : '');
+      if (gInfo?.email || gUsageStr || gActiveStr || gInfo?.signedIn) {
+        const gDisplay = gInfo?.email || (gInfo?.signedIn ? SIGNED_IN_LABEL : '');
+        parts.push(gDisplay ? chalk.cyan(gDisplay) : '');
+      }
       if (gUsageStr || gActiveStr) parts.push(gUsageStr);
       const gStatusStr = formatUsageStatusBadge(gInfo?.usageStatus);
       if (gMaxStatusWidth > 0) {
@@ -949,7 +961,11 @@ async function showAgentResources(
       cliVersion: version,
       info: accountInfo,
     });
-    const emailStr = accountInfo.email ? chalk.cyan(`  ${accountInfo.email}`) : '';
+    const emailStr = accountInfo.email
+      ? chalk.cyan(`  ${accountInfo.email}`)
+      : accountInfo.signedIn
+        ? chalk.cyan(`  ${SIGNED_IN_LABEL}`)
+        : '';
     const status = chalk.green(version);
     const usageStr = formatUsageSummary(accountInfo.plan, null);
     const usagePart = usageStr ? `  ${usageStr}` : '';
@@ -1175,7 +1191,7 @@ async function collectAgentsJson(filterAgentId?: AgentId): Promise<ViewJsonAgent
     const entry: ViewJsonVersion = {
       version,
       isDefault: version === globalDefault,
-      signedIn: !!info.email,
+      signedIn: info.signedIn,
       email: info.email,
       plan: info.plan,
       usageStatus: info.usageStatus,

--- a/src/lib/__tests__/usage.test.ts
+++ b/src/lib/__tests__/usage.test.ts
@@ -31,6 +31,7 @@ function makeAccountInfo(overrides: Partial<AccountInfo> = {}): AccountInfo {
     usageStatus: null,
     overageCredits: null,
     lastActive: null,
+    signedIn: false,
     ...overrides,
   };
 }

--- a/src/lib/__tests__/version-duplicates.test.ts
+++ b/src/lib/__tests__/version-duplicates.test.ts
@@ -18,6 +18,7 @@ function account(overrides: Partial<AccountInfo>): AccountInfo {
     usageStatus: null,
     overageCredits: null,
     lastActive: null,
+    signedIn: false,
     ...overrides,
   };
 }

--- a/src/lib/agents.test.ts
+++ b/src/lib/agents.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { pathToFileURL } from 'url';
 import { spawnSync } from 'child_process';
 import { afterEach, describe, expect, it } from 'vitest';
-import { AGENTS, ALL_AGENT_IDS, resolveAgentName, resolveLastActive } from './agents.js';
+import { AGENTS, ALL_AGENT_IDS, getAccountInfo, resolveAgentName, resolveLastActive } from './agents.js';
 import type { CapabilityName } from './types.js';
 
 const tempDirs: string[] = [];
@@ -327,5 +327,77 @@ describe('resolveAgentName', () => {
     expect(resolveAgentName('gpt')).toBeNull();
     expect(resolveAgentName('')).toBeNull();
     expect(resolveAgentName('definitely-not-an-agent')).toBeNull();
+  });
+});
+
+/** Encode a minimal JWT (only the payload segment is ever decoded). */
+function makeJwt(payload: Record<string, unknown>): string {
+  const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString('base64url');
+  return `${b64({ alg: 'ES256', typ: 'JWT' })}.${b64(payload)}.sig`;
+}
+
+describe('getAccountInfo — token-only agents (no local email)', () => {
+  it('marks Antigravity signed in when a refresh token is present', async () => {
+    const home = makeTempDir();
+    const dir = path.join(home, '.gemini', 'antigravity-cli');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'antigravity-oauth-token'),
+      JSON.stringify({
+        token: { access_token: 'ya29.expired', refresh_token: '1//refresh', token_type: 'Bearer' },
+        auth_method: 'consumer',
+      }),
+      'utf-8'
+    );
+
+    const info = await getAccountInfo('antigravity', home);
+    expect(info.signedIn).toBe(true);
+    // Consumer Google OAuth exposes no email/identity claim locally.
+    expect(info.email).toBeNull();
+  });
+
+  it('treats Antigravity as signed out when the token file is missing', async () => {
+    const info = await getAccountInfo('antigravity', makeTempDir());
+    expect(info.signedIn).toBe(false);
+    expect(info.email).toBeNull();
+  });
+
+  it('treats Antigravity as signed out when the token carries no refresh token', async () => {
+    const home = makeTempDir();
+    const dir = path.join(home, '.gemini', 'antigravity-cli');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'antigravity-oauth-token'),
+      JSON.stringify({ token: { access_token: 'ya29.x' } }),
+      'utf-8'
+    );
+    const info = await getAccountInfo('antigravity', home);
+    expect(info.signedIn).toBe(false);
+  });
+
+  it('marks Kimi signed in and derives a stable account key from the JWT user_id', async () => {
+    const home = makeTempDir();
+    const dir = path.join(home, '.kimi-code', 'credentials');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'kimi-code.json'),
+      JSON.stringify({
+        access_token: makeJwt({ user_id: 'd483kfq783mkn8of1gtg', sub: 'd483kfq783mkn8of1gtg', scope: 'kimi-code' }),
+        refresh_token: makeJwt({ type: 'refresh' }),
+        token_type: 'Bearer',
+      }),
+      'utf-8'
+    );
+
+    const info = await getAccountInfo('kimi', home);
+    expect(info.signedIn).toBe(true);
+    expect(info.email).toBeNull();
+    expect(info.accountId).toBe('d483kfq783mkn8of1gtg');
+    expect(info.accountKey).toBe('kimi:user=d483kfq783mkn8of1gtg');
+  });
+
+  it('treats Kimi as signed out when the credentials file is missing', async () => {
+    const info = await getAccountInfo('kimi', makeTempDir());
+    expect(info.signedIn).toBe(false);
   });
 });

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -822,6 +822,12 @@ export interface AccountInfo {
   usageStatus: 'available' | 'rate_limited' | 'out_of_credits' | null;
   overageCredits: { amount: number; currency: string } | null;
   lastActive: Date | null;
+  // Whether the agent has a usable local credential. For most agents this
+  // tracks `email != null`, but some CLIs (Antigravity, Kimi) store an opaque
+  // OAuth/JWT credential with no email claim — they are signed in even though
+  // we can't surface an address. Callers that only want to know "logged in or
+  // not" should read this, not `email`.
+  signedIn: boolean;
 }
 
 /** Return the email address associated with the agent's auth config, or null. */
@@ -853,6 +859,7 @@ export async function getAccountInfo(
     usageStatus: null,
     overageCredits: null,
     lastActive: null,
+    signedIn: false,
   };
 
   const configFiles: Partial<Record<AgentId, string>> = {
@@ -929,6 +936,7 @@ export async function getAccountInfo(
           usageStatus,
           overageCredits,
           lastActive,
+          signedIn: !!email,
         };
       }
       case 'codex': {
@@ -971,11 +979,13 @@ export async function getAccountInfo(
           usageStatus,
           overageCredits: null,
           lastActive,
+          signedIn: !!email,
         };
       }
       case 'gemini': {
         const data = JSON.parse(await fs.promises.readFile(path.join(base, '.gemini', 'google_accounts.json'), 'utf-8'));
-        return { ...empty, email: data.active || null, lastActive };
+        const email = data.active || null;
+        return { ...empty, email, signedIn: !!email, lastActive };
       }
       case 'grok': {
         // Grok stores auth in ~/.grok/auth.json
@@ -984,10 +994,39 @@ export async function getAccountInfo(
           if (fs.existsSync(authPath)) {
             const data = JSON.parse(await fs.promises.readFile(authPath, 'utf-8'));
             const email = data.email || data.user?.email || data.account?.email || null;
-            return { ...empty, email, lastActive };
+            return { ...empty, email, signedIn: !!email, lastActive };
           }
         } catch {}
         return { ...empty, lastActive };
+      }
+      case 'antigravity': {
+        // Antigravity (`agy`) stores a Google OAuth token at
+        // ~/.gemini/antigravity-cli/antigravity-oauth-token. It's a consumer
+        // OAuth grant (access + refresh token, no id_token), so there's no email
+        // claim to read locally — presence of a refresh token is the only
+        // signed-in signal we can derive without a network call.
+        const tokenPath = path.join(base, '.gemini', 'antigravity-cli', 'antigravity-oauth-token');
+        if (!fs.existsSync(tokenPath)) return { ...empty, lastActive };
+        const data = JSON.parse(await fs.promises.readFile(tokenPath, 'utf-8'));
+        const hasToken =
+          typeof data?.token?.refresh_token === 'string' && !!data.token.refresh_token;
+        if (!hasToken) return { ...empty, lastActive };
+        return { ...empty, signedIn: true, lastActive };
+      }
+      case 'kimi': {
+        // Kimi Code stores OAuth credentials at
+        // ~/.kimi-code/credentials/kimi-code.json. The access token is a JWT
+        // whose payload carries an opaque user_id (no email), so we report
+        // signed-in state plus a stable account key for usage dedup.
+        const credPath = path.join(base, '.kimi-code', 'credentials', 'kimi-code.json');
+        if (!fs.existsSync(credPath)) return { ...empty, lastActive };
+        const data = JSON.parse(await fs.promises.readFile(credPath, 'utf-8'));
+        const accessToken = data?.access_token;
+        if (typeof accessToken !== 'string' || !accessToken) return { ...empty, lastActive };
+        const decoded = decodeJwtPayload(accessToken);
+        const userId = normalizeIdentityPart(decoded?.user_id ?? decoded?.sub);
+        const accountKey = buildIdentityKey(agentId, [['user', userId]]);
+        return { ...empty, signedIn: true, accountId: userId, accountKey, lastActive };
       }
       default:
         return { ...empty, lastActive };


### PR DESCRIPTION
Supersedes #450 (which accidentally reverted `cloudProvider` due to a stale local base — fixed here via a 3-way merge onto current `main`).

## What

Some agent CLIs (Antigravity, Kimi) store an opaque OAuth/JWT credential with no email claim, so they read as logged-out even when signed in. Adds a `signedIn` boolean to the agent login state and surfaces it in `agents view`.

## Commits

- `feat: add signedIn flag for agents with emailless oauth credentials` — `signedIn: boolean` on the login state (tracks `email != null` for most agents); Antigravity OAuth-token detection at `~/.gemini/antigravity-cli/antigravity-oauth-token`. Required-field fixture updates so existing tests compile. **`cloudProvider` from current `main` preserved.**
- `feat: show "signed in" placeholder for emailless agents in view`
- `test: cover signedIn detection across agent credential sources`

Callers that only need "logged in or not" should read `signedIn`, not `email`.