### PR TITLE
secrets export --host (drop --to-ssh) + make agents resolvable under nvm

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -322,8 +322,8 @@ agents secrets generate 32 | agents secrets add release.key PASSPHRASE --value-s
 #    resolves them (one Touch ID) and forwards AGENTS_SECRETS_PASSPHRASE over
 #    stdin (never argv) so the remote can encrypt them at rest.
 export AGENTS_SECRETS_PASSPHRASE="$(agents secrets exec release.key -- printenv PASSPHRASE)"
-agents secrets export apple.com    --to-ssh --host mac-mini --remote-backend file
-agents secrets export rush.releases --to-ssh --host mac-mini --remote-backend file
+agents secrets export apple.com    --host mac-mini --remote-backend file
+agents secrets export rush.releases --host mac-mini --remote-backend file
 unset AGENTS_SECRETS_PASSPHRASE
 
 # --- Each release, from the laptop ---

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -239,6 +239,10 @@ To enable version-aware shims, add this to your shell config:
     console.log(`  Installed shorthands: ${written.join(', ')}`);
   }
 
+  if (process.platform !== 'win32') {
+    await ensureAgentsResolvablePosix();
+  }
+
   await healLongRunningProcesses();
 
   const version = getVersion();
@@ -249,6 +253,64 @@ To enable version-aware shims, add this to your shell config:
       console.log(section);
       console.log('');
     }
+  }
+}
+
+/**
+ * Make the `agents` command resolvable in a *login* shell on POSIX.
+ *
+ * `agents`/`ag` reach PATH only through npm's bin symlink in the npm global-bin
+ * dir. Under nvm (and other per-user node prefixes) that dir is missing from a
+ * non-interactive login shell's PATH, so `bash -lc 'agents …'` fails with
+ * command-not-found — which breaks `agents secrets export --host` (it runs
+ * `bash -lc 'agents secrets import …'` on the remote) and the routines daemon
+ * (src/lib/daemon.ts falls back to bare `agents`). This is the POSIX symmetric
+ * counterpart of the Windows branch in main() that registers npm's global-bin
+ * dir on the user PATH.
+ *
+ * Self-heal, not a prompt: it fires ONLY when `agents` is otherwise
+ * unresolvable — the genuinely-broken state — so it acts decisively, exactly
+ * like the Windows PATH registration. The symlink never clobbers a dev build
+ * (scripts/install.sh) or any real file. Skipped in CI (ephemeral homes) and
+ * when AGENTS_NO_HEAL=1.
+ */
+async function ensureAgentsResolvablePosix() {
+  if (process.env.CI || process.env.AGENTS_NO_HEAL === '1') return;
+  try {
+    const { localBinDir, ensureLocalBinSymlink, loginShellResolves, dirOnLoginPath } =
+      await import('../dist/lib/platform/posixpath.js');
+
+    // macOS/homebrew, system-node Linux, and dev-build users already resolve it.
+    if (loginShellResolves('agents')) return;
+
+    const binDir = localBinDir();
+    const results = ['agents', 'ag'].map((name) => ensureLocalBinSymlink(name, AGENTS_BIN, binDir));
+    if (!results.some((r) => r.created)) return; // nothing we could safely link
+
+    if (dirOnLoginPath(binDir)) {
+      console.log(`\n  Linked 'agents' into ${binDir} (already on the login PATH) so 'bash -lc agents' resolves.`);
+      return;
+    }
+
+    // ~/.local/bin isn't on the *bash* login PATH yet. The consumers run
+    // `bash -lc`, so add it to the file a bash login shell reads (~/.bash_profile
+    // when present, else ~/.profile) — not the interactive $SHELL rc, which for a
+    // zsh user (.zshrc) bash would never source.
+    const bashRc = fs.existsSync(path.join(HOME, '.bash_profile'))
+      ? path.join(HOME, '.bash_profile')
+      : path.join(HOME, '.profile');
+    const marker = '# agents-cli: ensure ~/.local/bin on PATH (so the agents command resolves)';
+    let already = false;
+    try {
+      already = fs.existsSync(bashRc) && fs.readFileSync(bashRc, 'utf-8').includes(marker);
+    } catch { /* unreadable rc — fall through and append */ }
+    if (!already) {
+      fs.appendFileSync(bashRc, `\n${marker}\nexport PATH="${binDir}:$PATH"\n`);
+    }
+    console.log(`\n  Linked 'agents' into ${binDir} and added it to PATH in ${path.basename(bashRc)}.`);
+    console.log(`  Restart your shell (or run: source ~/${path.basename(bashRc)}) to pick it up.`);
+  } catch {
+    /* best-effort: a failure here must never break the install */
   }
 }
 

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -188,7 +188,7 @@ function readStdinSync(): string {
 }
 
 /**
- * SSH target for `export --to-ssh`: a bare ssh-config host alias (e.g. `yosemite-s0`)
+ * SSH target for `export --host`: a bare ssh-config host alias (e.g. `yosemite-s0`)
  * or `user@host`. The strict allowlist blocks shell metacharacters and a leading `-`
  * so a target can't be smuggled in as an ssh argv flag.
  */
@@ -465,7 +465,7 @@ export function registerSecretsCommands(program: Command): void {
       eval "$(agents secrets export prod --plaintext)"
 
       # Push the bundle to remote machine(s) over SSH (lands as a native bundle there)
-      agents secrets export prod --to-ssh --host yosemite-s0 --host yosemite-s1 --force
+      agents secrets export prod --host yosemite-s0 --host yosemite-s1 --force
 
       # Run a one-off command with secrets injected
       agents secrets exec prod -- ./deploy.sh
@@ -1072,7 +1072,7 @@ Examples:
         const requestedBackend = parseBackendOpt(opts.backend);
         // Read the bundle if it exists (inheriting its backend); otherwise
         // create it with the requested backend so a single `import --backend
-        // file` works (this is what `export --to-ssh --remote-backend file`
+        // file` works (this is what `export --host ... --remote-backend file`
         // drives on the remote).
         let bundle: SecretsBundle;
         if (bundleExists(resolvedBundleName)) {
@@ -1147,19 +1147,17 @@ Examples:
 
   cmd
     .command('export [bundle]')
-    .description('Resolve a bundle and print KEY=VALUE lines, push it to a 1Password vault with --to-1password, or push it to remote machine(s) over SSH with --to-ssh.')
+    .description('Resolve a bundle and print KEY=VALUE lines, push it to a 1Password vault with --to-1password, or push it to remote machine(s) over SSH with --host.')
     .option('--plaintext', 'Acknowledge that the resolved values will be printed in the clear (shell export mode)')
     .option('--to-1password', 'Push every key in the bundle as a PASSWORD item in a 1Password vault')
     .option('--vault <name>', '1Password vault name (used with --to-1password)')
-    .option('--to-ssh', 'Push the bundle to remote machine(s) over SSH via their native agents-cli import')
-    .option('--host <target...>', 'SSH target(s) for --to-ssh: host alias or user@host (repeatable)')
-    .option('--remote-backend <backend>', 'Backend for the bundle on the remote: keychain (default) or file (passphrase-encrypted, headless-readable). file forwards AGENTS_SECRETS_PASSPHRASE over stdin.', 'keychain')
-    .option('--force', 'Overwrite existing keys/items on the target (used with --to-1password and --to-ssh)')
+    .option('--host <target...>', 'Push the bundle over SSH to this target (host alias or user@host); repeatable for multiple machines')
+    .option('--remote-backend <backend>', 'Backend for the bundle on the remote (with --host): keychain (default) or file (passphrase-encrypted, headless-readable). file forwards AGENTS_SECRETS_PASSPHRASE over stdin.', 'keychain')
+    .option('--force', 'Overwrite existing keys/items on the target (used with --to-1password and --host)')
     .action(async (bundleName: string | undefined, opts: {
       plaintext?: boolean;
       to1password?: boolean;
       vault?: string;
-      toSsh?: boolean;
       host?: string[];
       remoteBackend?: string;
       force?: boolean;
@@ -1168,11 +1166,11 @@ Examples:
         const { readAndResolveBundleEnv, bundleToEnvPrefix, isReservedEnvName } = await import('../lib/secrets/bundles.js');
         const resolvedBundleName = bundleName ?? (await pickBundleName('export'));
 
-        if (opts.toSsh) {
-          const hosts = opts.host ?? [];
-          if (hosts.length === 0) {
-            throw new Error('--to-ssh requires at least one --host <target>.');
-          }
+        // The presence of --host selects SSH push: --host is the destination
+        // and carries the mode (no separate --to-ssh needed — it would be
+        // strictly redundant since SSH always requires at least one host).
+        const hosts = opts.host ?? [];
+        if (hosts.length > 0) {
           for (const h of hosts) assertValidSshTarget(h);
           const remoteBackend = parseBackendOpt(opts.remoteBackend);
           // For a file-backed remote bundle the remote must encrypt at rest with

--- a/src/lib/platform/posixpath.test.ts
+++ b/src/lib/platform/posixpath.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ensureLocalBinSymlink, localBinDir } from './posixpath.js';
+
+describe('localBinDir', () => {
+  it('is <home>/.local/bin', () => {
+    expect(localBinDir('/home/x')).toBe(path.join('/home/x', '.local', 'bin'));
+  });
+});
+
+describe('ensureLocalBinSymlink', () => {
+  let dir: string;
+  let target: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-posixpath-'));
+    target = path.join(dir, 'real-entry.js');
+    fs.writeFileSync(target, '#!/usr/bin/env node\n');
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('creates the symlink when nothing is there (and mkdirs the bin dir)', () => {
+    const binDir = path.join(dir, '.local', 'bin');
+    const res = ensureLocalBinSymlink('agents', target, binDir);
+    expect(res).toMatchObject({ ok: true, created: true });
+    expect(fs.realpathSync(path.join(binDir, 'agents'))).toBe(fs.realpathSync(target));
+  });
+
+  it('is idempotent — a second call does not recreate an already-correct link', () => {
+    const first = ensureLocalBinSymlink('agents', target, dir);
+    expect(first.created).toBe(true);
+    const second = ensureLocalBinSymlink('agents', target, dir);
+    expect(second).toMatchObject({ ok: true, created: false });
+  });
+
+  it('NEVER clobbers a dev-build symlink that points elsewhere', () => {
+    // Reproduces scripts/install.sh: ~/.local/bin/agents -> the dev build.
+    const devBuild = path.join(dir, 'agents-cli-dev', 'dist', 'index.js');
+    fs.mkdirSync(path.dirname(devBuild), { recursive: true });
+    fs.writeFileSync(devBuild, '#!/usr/bin/env node\n');
+    const linkPath = path.join(dir, 'agents');
+    fs.symlinkSync(devBuild, linkPath);
+
+    const res = ensureLocalBinSymlink('agents', target, dir);
+    expect(res.ok).toBe(false);
+    expect(res.created).toBe(false);
+    expect(res.skippedReason).toMatch(/points to/);
+    // The dev symlink is untouched.
+    expect(fs.realpathSync(linkPath)).toBe(fs.realpathSync(devBuild));
+  });
+
+  it('NEVER clobbers a real (non-symlink) file at the path', () => {
+    const linkPath = path.join(dir, 'agents');
+    fs.writeFileSync(linkPath, 'a real binary, not ours');
+    const res = ensureLocalBinSymlink('agents', target, dir);
+    expect(res).toMatchObject({ ok: false, created: false });
+    expect(res.skippedReason).toMatch(/non-symlink/);
+    expect(fs.readFileSync(linkPath, 'utf-8')).toBe('a real binary, not ours');
+    expect(fs.lstatSync(linkPath).isSymbolicLink()).toBe(false);
+  });
+});

--- a/src/lib/platform/posixpath.ts
+++ b/src/lib/platform/posixpath.ts
@@ -1,0 +1,159 @@
+/**
+ * POSIX login-PATH primitives for making the `agents` command resolvable.
+ *
+ * The Unix analog of winpath.ts. `agents`/`ag` land on PATH only via npm's
+ * bin symlink into the npm global-bin dir; under nvm (and other per-user node
+ * prefixes) that dir is absent from a *non-interactive login* shell's PATH, so
+ * `bash -lc 'agents …'` fails with command-not-found. That breaks every
+ * consumer that drives a login shell on the box: `agents secrets export --host`
+ * (which runs `bash -lc 'agents secrets import …'` on the remote) and the
+ * routines daemon (`src/lib/daemon.ts`, which falls back to bare `agents`).
+ *
+ * The fix mirrors the Windows postinstall branch (which registers npm's
+ * global-bin dir on the user PATH): symlink the entrypoint into ~/.local/bin —
+ * the XDG user-bin dir that mainstream distros auto-add to the login PATH when
+ * it exists (Debian/Ubuntu via ~/.profile, Fedora via /etc/profile.d) — and,
+ * where it is not yet on PATH, the caller adds it.
+ *
+ * Leaf module — imports only child_process / fs / os / path so it is cheap to
+ * load from the npm lifecycle script without pulling the rest of the CLI.
+ */
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/** The XDG user-bin dir, `~/.local/bin`. */
+export function localBinDir(home: string = os.homedir()): string {
+  return path.join(home, '.local', 'bin');
+}
+
+export interface SymlinkResult {
+  /** A usable symlink to `target` exists at the path after this call. */
+  ok: boolean;
+  /** True only when this call created the symlink (false = already correct, or left untouched). */
+  created: boolean;
+  /** Why an existing entry was left untouched (set only when ok is false). */
+  skippedReason?: string;
+  path: string;
+}
+
+/**
+ * Ensure `<dir>/<name>` is a symlink to `target`, NEVER clobbering a
+ * pre-existing real file or a symlink that already points elsewhere — most
+ * importantly a developer's `scripts/install.sh` dev build at
+ * `~/.local/bin/agents`. Only an absent path, or a symlink already pointing at
+ * `target`, is created/treated as ok. Idempotent.
+ */
+export function ensureLocalBinSymlink(
+  name: string,
+  target: string,
+  dir: string = localBinDir(),
+): SymlinkResult {
+  const linkPath = path.join(dir, name);
+  const want = path.resolve(target);
+  let current: string | null = null;
+  try {
+    current = fs.readlinkSync(linkPath);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EINVAL') {
+      // The path exists but is not a symlink — a real file/dir. Never clobber.
+      return { ok: false, created: false, skippedReason: 'a non-symlink file already exists here', path: linkPath };
+    }
+    if (code !== 'ENOENT') {
+      return { ok: false, created: false, skippedReason: (err as Error).message, path: linkPath };
+    }
+    // ENOENT — nothing there; fall through to create.
+  }
+  if (current !== null) {
+    const resolved = path.isAbsolute(current) ? current : path.resolve(dir, current);
+    if (resolved === want) return { ok: true, created: false, path: linkPath };
+    // Points somewhere else (e.g. a dev build) — the existing link wins.
+    return { ok: false, created: false, skippedReason: `symlink already points to ${current}`, path: linkPath };
+  }
+  fs.mkdirSync(dir, { recursive: true });
+  fs.symlinkSync(target, linkPath);
+  return { ok: true, created: true, path: linkPath };
+}
+
+/**
+ * Absolute path to `bash`. We probe bash specifically — NOT the user's $SHELL —
+ * because the consumers we are healing run `bash -lc` regardless of login shell:
+ * `secrets export --host` builds `bash -lc 'agents secrets import …'` for the
+ * remote, and the routines daemon resolves `agents` the same way. On a box whose
+ * login shell is zsh, zsh's login PATH may lack ~/.local/bin while bash's
+ * includes it (Debian/Ubuntu ~/.profile) — so probing $SHELL would give the
+ * wrong answer for what the consumer actually sees. Resolve from the *current*
+ * PATH (the install process has one) and fall back to /bin/bash.
+ */
+function bashPath(): string {
+  const found = (process.env.PATH || '')
+    .split(path.delimiter)
+    .map((d) => (d ? path.join(d, 'bash') : ''))
+    .find((p) => {
+      if (!p) return false;
+      try { fs.accessSync(p, fs.constants.X_OK); return true; } catch { return false; }
+    });
+  return found || '/bin/bash';
+}
+
+/**
+ * Environment for the probe shell that reproduces a *fresh* `bash -lc` — the
+ * PATH that `ssh host 'bash -lc …'` and the routines daemon actually get — and
+ * NOT the nvm/npm-augmented PATH of the install process.
+ *
+ * This is the crux: `npm i -g` (and a dev `bun run`) execute under nvm, so the
+ * caller's PATH already contains nvm's bin. A spawned shell inherits that PATH,
+ * so it would resolve `agents` and the heal would skip — during the very nvm
+ * install it exists to fix. We strip PATH (and nvm's hint vars) so the login
+ * profile rebuilds PATH from scratch, exactly as an incoming SSH command shell
+ * does. Login bash still sources /etc/profile + ~/.profile (which adds
+ * ~/.local/bin) but bails out of ~/.bashrc's nvm block early because it is
+ * non-interactive — which is precisely why bare `agents` is missing there.
+ */
+function loginProbeEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.PATH;
+  delete env.NVM_BIN;
+  delete env.NVM_INC;
+  for (const k of Object.keys(env)) if (k.startsWith('npm_')) delete env[k];
+  return env;
+}
+
+/**
+ * Does a fresh `bash -lc` resolve `cmd` on its PATH? This is the real question
+ * for the consumers we heal. Best-effort: any probe failure returns false so
+ * the caller heals rather than wrongly assuming success. `command -v` is a
+ * POSIX builtin.
+ */
+export function loginShellResolves(cmd: string): boolean {
+  try {
+    const res = spawnSync(bashPath(), ['-lc', `command -v ${cmd}`], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf-8',
+      timeout: 5000,
+      env: loginProbeEnv(),
+    });
+    return res.status === 0 && !!res.stdout && res.stdout.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** Is `dir` on a fresh `bash -lc` PATH? Best-effort; a probe failure returns false. */
+export function dirOnLoginPath(dir: string): boolean {
+  try {
+    const res = spawnSync(bashPath(), ['-lc', 'printf %s "$PATH"'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf-8',
+      timeout: 5000,
+      env: loginProbeEnv(),
+    });
+    if (res.status !== 0 || !res.stdout) return false;
+    const want = path.resolve(dir);
+    return res.stdout.split(':').some((p) => p && path.resolve(p) === want);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Two related fixes around `agents secrets export --host`, both verified end-to-end against a headless nvm box (yosemite-s0).

## 1. `secrets export`: infer SSH from `--host`, drop `--to-ssh`

`--to-ssh` was redundant — `--host` is mandatory for an SSH push, so the flag carried no information. And `--host` *without* `--to-ssh` was silently ignored (fell through to shell-print), so `agents secrets export bundle --host yosemite-s0` either errored `requires --plaintext` or printed secrets to the terminal. Now the presence of `--host` selects the SSH push (standard "flag names the destination" pattern), and `--to-ssh` is removed.

- `agents secrets export <bundle> --host <target>` — was `--to-ssh --host <target>`
- `--to-ssh` is now rejected as an unknown option
- Help text + `docs/secrets.md` updated

## 2. postinstall: make `agents` resolvable in a login shell under nvm

`agents`/`ag` reach PATH only via npm's bin symlink in the npm global-bin dir. Under nvm that dir is absent from a non-interactive login shell's PATH, so `bash -lc 'agents …'` fails with command-not-found — which silently broke the SSH push above (it runs `bash -lc 'agents secrets import …'` on the remote) and the routines daemon.

This adds the POSIX symmetric counterpart of the existing **Windows** postinstall branch (which already registers npm's global-bin dir on the user PATH for nvm-windows/winget). When a fresh `bash -lc` can't resolve `agents`, it symlinks the entrypoint into `~/.local/bin` (the XDG user-bin dir mainstream distros add to the login PATH) and, only if needed, adds that dir to the bash-login rc.

Design notes:
- Detection probes **`bash -lc`** (the actual consumer, not `$SHELL` — on a zsh box, zsh's login PATH may lack `~/.local/bin` while bash's includes it).
- The probe **strips PATH** so the login profile rebuilds it — otherwise the nvm-augmented PATH of the `npm i -g` process would hide the very gap being checked and the heal would no-op during the install it exists to fix.
- The symlink **never clobbers** a `scripts/install.sh` dev build or any real file.
- Skipped in CI and under `AGENTS_NO_HEAL=1`. No-op on macOS/homebrew and system-node Linux (already resolvable).
- New `src/lib/platform/posixpath.ts` leaf module (mirrors `winpath.ts`) + `posixpath.test.ts`.

## Verification (real flow, yosemite-s0 over tailnet)

- `secrets export <bundle> --host <s0>` (no `--to-ssh`) → `Imported 2 key(s)`; values round-trip exactly (incl. a `p@ss w0rd "x"` value); `--to-ssh` → `error: unknown option`.
- Removed `~/.local/bin/agents` to reproduce `bash -lc agents` → not found; ran the compiled `posixpath.js` on s0: detection `false` → symlinks created → `~/.local/bin` confirmed on the bash login PATH → resolves `true`; independent `ssh s0 'bash -lc "agents --version"'` → `1.20.27`.
- `tsc --noEmit` clean; `posixpath.test.ts` (clobber-guard) + `secrets.test.ts` + `help-output.test.ts` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)