### PR TITLE
feat(sessions): offline cache + clear unreachable message for --host

### DIFF
--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -24,6 +24,7 @@ import { discoverSessions, countSessionsInScope, resolveSessionById, searchConte
 import { filterTeamSessions } from '../lib/session/team-filter.js';
 import { parseSession } from '../lib/session/parse.js';
 import { runRemoteSessions } from '../lib/session/remote.js';
+import { formatRelativeTime } from '../lib/session/relative-time.js';
 import { renderConversationMarkdown, renderSummary, renderSummaryHeader, computeSummaryStats, renderJson, filterEvents, parseRoleList, type FilterOptions } from '../lib/session/render.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { colorAgent, resolveAgentName } from '../lib/agents.js';
@@ -1581,23 +1582,3 @@ function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max - 1) + '.' : s;
 }
 
-function formatRelativeTime(isoTimestamp: string): string {
-  const now = Date.now();
-  const then = new Date(isoTimestamp).getTime();
-  if (isNaN(then)) return isoTimestamp;
-
-  const diffMs = now - then;
-  const diffMin = Math.floor(diffMs / 60_000);
-  const diffHrs = Math.floor(diffMs / 3_600_000);
-  const diffDays = Math.floor(diffMs / 86_400_000);
-
-  if (diffMin < 1) return 'just now';
-  if (diffMin < 60) return `${diffMin} min ago`;
-  if (diffHrs < 24) return `${diffHrs} hour${diffHrs === 1 ? '' : 's'} ago`;
-  if (diffDays < 7) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
-
-  // Older: show date
-  const d = new Date(then);
-  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-  return `${months[d.getMonth()]} ${d.getDate()}`;
-}

--- a/src/lib/session/relative-time.ts
+++ b/src/lib/session/relative-time.ts
@@ -1,0 +1,26 @@
+/**
+ * Human-readable "time since" formatting for session timestamps. Lives here (not
+ * inline in `sessions.ts`) so both the session list renderer and the remote
+ * offline-cache banner (`remote.ts`) share one formatter — `sessions.ts` imports
+ * `remote.ts`, so a back-import would cycle.
+ */
+export function formatRelativeTime(isoTimestamp: string): string {
+  const now = Date.now();
+  const then = new Date(isoTimestamp).getTime();
+  if (isNaN(then)) return isoTimestamp;
+
+  const diffMs = now - then;
+  const diffMin = Math.floor(diffMs / 60_000);
+  const diffHrs = Math.floor(diffMs / 3_600_000);
+  const diffDays = Math.floor(diffMs / 86_400_000);
+
+  if (diffMin < 1) return 'just now';
+  if (diffMin < 60) return `${diffMin} min ago`;
+  if (diffHrs < 24) return `${diffHrs} hour${diffHrs === 1 ? '' : 's'} ago`;
+  if (diffDays < 7) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+
+  // Older: show date
+  const d = new Date(then);
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  return `${months[d.getMonth()]} ${d.getDate()}`;
+}

--- a/src/lib/session/remote.test.ts
+++ b/src/lib/session/remote.test.ts
@@ -5,6 +5,10 @@ import {
   buildRemoteCommand,
   shellQuote,
   assertValidSshTarget,
+  classifySshFailure,
+  remoteCachePath,
+  formatStaleBanner,
+  formatUnreachable,
 } from './remote.js';
 
 /**
@@ -132,5 +136,71 @@ describe('assertValidSshTarget', () => {
     expect(() => assertValidSshTarget('-oProxyCommand=evil')).toThrow(/Invalid SSH target/);
     expect(() => assertValidSshTarget('box; rm -rf /')).toThrow(/Invalid SSH target/);
     expect(() => assertValidSshTarget('box$(whoami)')).toThrow(/Invalid SSH target/);
+  });
+});
+
+describe('classifySshFailure', () => {
+  it('maps a clean exit to ok', () => {
+    expect(classifySshFailure({ status: 0 })).toBe('ok');
+  });
+
+  it('maps ssh exit 255 to unreachable (connection layer, not the remote query)', () => {
+    // 255 is ssh's own code for "could not establish the session" — the cache
+    // fallback hinges on telling this apart from a forwarded non-zero.
+    expect(classifySshFailure({ status: 255 })).toBe('unreachable');
+  });
+
+  it('maps any other non-zero to query-failed (remote agents ran and failed)', () => {
+    expect(classifySshFailure({ status: 1 })).toBe('query-failed');
+    expect(classifySshFailure({ status: 2 })).toBe('query-failed');
+    expect(classifySshFailure({ status: null })).toBe('query-failed'); // killed by signal
+  });
+
+  it('maps a spawn error (ssh binary missing, etc.) to spawn-error', () => {
+    expect(classifySshFailure({ error: new Error('ENOENT'), status: null })).toBe('spawn-error');
+  });
+});
+
+describe('remoteCachePath', () => {
+  it('is deterministic for the same host and args', () => {
+    const a = remoteCachePath('mac-mini', ['sessions', '--last', '3']);
+    const b = remoteCachePath('mac-mini', ['sessions', '--last', '3']);
+    expect(a).toBe(b);
+  });
+
+  it('separates distinct queries into distinct files', () => {
+    const a = remoteCachePath('mac-mini', ['sessions', '--last', '3']);
+    const b = remoteCachePath('mac-mini', ['sessions', '--last', '5']);
+    expect(a).not.toBe(b);
+  });
+
+  it('separates distinct hosts even for the same query', () => {
+    const a = remoteCachePath('box-a', ['sessions', 'auth']);
+    const b = remoteCachePath('box-b', ['sessions', 'auth']);
+    expect(a).not.toBe(b);
+  });
+
+  it('keeps the host readable but filesystem-safe in the filename', () => {
+    // user@host is a valid ssh target; the path segment must not contain a
+    // separator or other unsafe char that would escape the cache dir.
+    const p = remoteCachePath('deploy@staging.example.com', ['sessions']);
+    const file = p.split('/').pop()!;
+    expect(file.startsWith('deploy@staging.example.com__')).toBe(true);
+    expect(file.endsWith('.txt')).toBe(true);
+  });
+});
+
+describe('offline banners', () => {
+  it('stale banner names the host and how old the cache is', () => {
+    const twoHoursAgo = new Date('2026-06-29T00:00:00Z').getTime() - 2 * 3_600_000;
+    const msg = formatStaleBanner('mac-mini', twoHoursAgo);
+    expect(msg).toContain('mac-mini');
+    expect(msg.toLowerCase()).toContain('cached');
+  });
+
+  it('unreachable message names the host and the cause', () => {
+    const msg = formatUnreachable('mac-mini');
+    expect(msg).toContain('mac-mini');
+    expect(msg.toLowerCase()).toContain('unreachable');
   });
 });

--- a/src/lib/session/remote.ts
+++ b/src/lib/session/remote.ts
@@ -9,12 +9,25 @@
  * upfront copy, always current, but the peer must be reachable. SSH access is the
  * only auth — if you can `ssh <host>`, you own the box (no identity layer by design).
  *
+ * Offline degradation (no sync, still fetch-first): every *successful* fetch is
+ * cached to `~/.agents/.cache/remote-sessions/`, keyed by host + the exact query.
+ * When a later run finds the host unreachable, the cache is replayed with a clearly
+ * labelled "showing cached results" banner instead of returning nothing. The cache
+ * is a byproduct of fetches you already made — never a background job, freely
+ * deletable — so the fetch-don't-replicate model holds; this is just graceful
+ * degradation when the peer is asleep.
+ *
  * Mirrors the transport already used by `agents secrets export --to-ssh`
  * (`src/commands/secrets.ts`): `ssh -o BatchMode=yes <host> bash -lc '<cmd>'`,
  * with `bash -lc` so the remote login PATH resolves `agents`.
  */
 import { spawnSync } from 'child_process';
+import { mkdirSync, writeFileSync, readFileSync, existsSync, statSync } from 'fs';
+import { join } from 'path';
+import { createHash } from 'crypto';
 import chalk from 'chalk';
+import { getCacheDir } from '../state.js';
+import { formatRelativeTime } from './relative-time.js';
 
 /**
  * SSH target: a bare ssh-config host alias (e.g. `yosemite-s1`) or `user@host`.
@@ -88,32 +101,131 @@ const SSH_OPTS = [
   '-o', 'ConnectTimeout=10',
 ];
 
+/** The four outcomes of one `ssh <host> agents sessions …` invocation. */
+export type SshOutcome = 'ok' | 'unreachable' | 'query-failed' | 'spawn-error';
+
+/**
+ * Classify an ssh `spawnSync` result. ssh(1) reserves exit 255 for its own
+ * connection-layer failures (host down, timeout, refused, auth, changed host
+ * key) — distinct from any other non-zero, which is the remote `agents sessions`
+ * exit code forwarded back (the query ran but failed). The two must be handled
+ * differently: 255 may fall back to cache, a forwarded failure must surface.
+ */
+export function classifySshFailure(res: { error?: Error | null; status: number | null }): SshOutcome {
+  if (res.error) return 'spawn-error';
+  if (res.status === 0) return 'ok';
+  if (res.status === 255) return 'unreachable';
+  return 'query-failed';
+}
+
+/** Root of the offline-replay cache (`~/.agents/.cache/remote-sessions/`). */
+const REMOTE_CACHE_DIR = join(getCacheDir(), 'remote-sessions');
+
+/**
+ * Deterministic cache path for a (host, forwarded-args) pair. The forwarded args
+ * are hashed so distinct queries cache independently; the host stays readable in
+ * the filename (sanitised so `user@host` and aliases are filesystem-safe).
+ */
+export function remoteCachePath(host: string, forwardedArgs: string[]): string {
+  const hash = createHash('sha256').update(forwardedArgs.join('\u0000')).digest('hex').slice(0, 16);
+  const safeHost = host.replace(/[^a-zA-Z0-9._@-]/g, '_');
+  return join(REMOTE_CACHE_DIR, `${safeHost}__${hash}.txt`);
+}
+
+/** Banner shown above replayed cache rows when the peer is offline. */
+export function formatStaleBanner(host: string, mtimeMs: number): string {
+  const ago = formatRelativeTime(new Date(mtimeMs).toISOString());
+  return chalk.yellow(`${host}: offline — showing cached results from ${ago}`);
+}
+
+/** Message shown when a host is unreachable and there is no cache to fall back to. */
+export function formatUnreachable(host: string): string {
+  return chalk.red(
+    `${host}: unreachable over SSH (asleep, offline, or host key changed?) — ConnectTimeout 10s`,
+  );
+}
+
+/** Persist a successful fetch for later offline replay. Best-effort: a cache
+ * write must never break the live query. */
+function writeRemoteCache(host: string, forwardedArgs: string[], output: string): void {
+  try {
+    mkdirSync(REMOTE_CACHE_DIR, { recursive: true });
+    writeFileSync(remoteCachePath(host, forwardedArgs), output);
+  } catch {
+    // ignore — caching is an optimisation, not a guarantee
+  }
+}
+
+/** Replay a cached fetch for an unreachable host. Banner goes to stderr (so a
+ * piped stdout stays exactly the cached rows); returns false when nothing is
+ * cached for this exact (host, query). */
+function replayRemoteCache(host: string, forwardedArgs: string[]): boolean {
+  try {
+    const p = remoteCachePath(host, forwardedArgs);
+    if (!existsSync(p)) return false;
+    process.stderr.write(formatStaleBanner(host, statSync(p).mtimeMs) + '\n');
+    process.stdout.write(readFileSync(p, 'utf8'));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Run the current `agents sessions` invocation on one or more remote machines over
- * SSH, streaming each remote's output to the terminal. Sets `process.exitCode = 1`
- * if any host fails. Reads the invocation from `process.argv` (override via
- * `argv` for testing).
+ * SSH, writing each remote's output to the terminal. A successful fetch is cached;
+ * an unreachable host falls back to that cache (with a stale banner) when present.
+ * Sets `process.exitCode = 1` if any host could not be answered (live or cached).
+ * Reads the invocation from `process.argv` (override via `argv` for testing).
+ *
+ * Output is captured rather than `stdio: 'inherit'`-streamed so it can be cached.
+ * Session output is small and the remote returns quickly, so buffering is
+ * imperceptible; `maxBuffer` is generous for the rare large `--markdown <id>` dump.
  */
 export function runRemoteSessions(hosts: string[], argv: string[] = process.argv): void {
   for (const host of hosts) assertValidSshTarget(host); // fail fast on any bad target
 
-  const remoteCmd = buildRemoteCommand(buildForwardedArgs(argv, new Set(hosts)));
+  const forwarded = buildForwardedArgs(argv, new Set(hosts));
+  const remoteCmd = buildRemoteCommand(forwarded);
   const multi = hosts.length > 1;
   let failures = 0;
 
   for (const host of hosts) {
     if (multi) process.stdout.write(chalk.cyan(`\n── ${host} ──\n`));
-    const res = spawnSync('ssh', [...SSH_OPTS, host, remoteCmd], { stdio: 'inherit' });
-    if (res.error) {
-      failures++;
-      console.error(chalk.red(`${host}: ${res.error.message}`));
-      continue;
-    }
-    if (res.status !== 0) {
-      failures++;
-      console.error(
-        chalk.red(`${host}: remote query failed (exit ${res.status ?? 'signal'}).`),
-      );
+    const res = spawnSync('ssh', [...SSH_OPTS, host, remoteCmd], {
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+
+    switch (classifySshFailure(res)) {
+      case 'ok':
+        process.stdout.write(res.stdout ?? '');
+        if (res.stderr) process.stderr.write(res.stderr);
+        writeRemoteCache(host, forwarded, res.stdout ?? '');
+        break;
+
+      case 'unreachable':
+        // Served-from-cache counts as answered (degraded, but with data + a clear
+        // banner), so it does not increment failures. No cache → a real failure.
+        if (!replayRemoteCache(host, forwarded)) {
+          failures++;
+          console.error(formatUnreachable(host));
+        }
+        break;
+
+      case 'spawn-error':
+        failures++;
+        console.error(chalk.red(`${host}: ${res.error?.message ?? 'failed to launch ssh'}`));
+        break;
+
+      case 'query-failed':
+        // The remote ran but its query exited non-zero — surface its own output
+        // and exit code; never mask a genuine error with stale cache.
+        failures++;
+        if (res.stdout) process.stdout.write(res.stdout);
+        if (res.stderr) process.stderr.write(res.stderr);
+        console.error(chalk.red(`${host}: remote query failed (exit ${res.status ?? 'signal'}).`));
+        break;
     }
   }
 


### PR DESCRIPTION
## What

Two enhancements to `agents sessions --host` (live remote-session query over SSH, shipped in 1.20.27), both keeping the **fetch-don't-replicate** model — no sync, the cache is just a byproduct of fetches already made.

### 1. Distinguish "unreachable" from "remote query failed"
ssh(1) exit **255** = connection layer (host asleep/offline/refused/auth/host-key). Any other non-zero = the remote `agents sessions` ran and failed. Previously both collapsed into a generic `remote query failed (exit N)`.

- Unreachable now prints: `<host>: unreachable over SSH (asleep, offline, or host key changed?) — ConnectTimeout 10s`
- A genuine remote query failure still surfaces the remote's own stdout/stderr + exit code (never masked).

### 2. Disposable read-through offline cache
- Every **successful** `--host` fetch is cached to `~/.agents/.cache/remote-sessions/`, keyed by host + the exact query.
- When a later run finds the host **unreachable**, the cache is replayed with a stale banner instead of returning nothing:
  - banner → **stderr** (so a piped stdout stays exactly the rows): `<host>: offline — showing cached results from 2 hours ago`
  - served-from-cache exits 0 (degraded but answered); no cache → message + exit 1.
- Cache writes are best-effort; never a background job; freely deletable.

### Refactor
Extracts `formatRelativeTime` into `src/lib/session/relative-time.ts` so the banner and the session-list renderer share one formatter (`sessions.ts` imports `remote.ts`, so a back-import would cycle).

## Tests
- `classifySshFailure` (255 → unreachable, forwarded non-zero → query-failed, spawn error, clean exit)
- `remoteCachePath` determinism, per-query/per-host separation, `user@host` filesystem-safety
- banner / unreachable message formatting
- 27 passing in `remote.test.ts` (was 17); full session-lib suite green (228).

## End-to-end verification (compiled production build)
- Live `--host mac-mini` → rows + cache file written ✓
- Unreachable host, **no** cache → clear message + exit 1 ✓
- Unreachable host, **with** cache → stale banner (stderr) + rows (stdout) + exit 0 ✓
- Local `sessions` list unaffected by the `formatRelativeTime` extraction ✓

Implementation note: capture replaced `stdio: 'inherit'` (needed to cache output); generous `maxBuffer` covers large `--markdown` dumps. Session output is small and the remote returns quickly, so buffering is imperceptible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)