### PR TITLE
feat(run): add --resume [id] to continue a prior conversation

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -32,6 +32,8 @@ interface ExecCommandActionOptions {
   quiet?: boolean;
   headless?: boolean;
   interactive?: boolean;
+  /** --resume [id]: string id/prefix, or `true` for the bare flag (interactive picker). */
+  resume?: string | boolean;
   sessionId?: string;
   verbose?: boolean;
   timeout?: string;
@@ -182,7 +184,8 @@ export function registerRunCommand(program: Command): void {
     .option('--quiet', 'Suppress preamble (rotation banner, "Running:" line). Useful when piping JSON events to a parser.', false)
     .option('--headless', 'Force headless mode. Auto-enabled when a prompt is provided; pass explicitly to stay headless with no prompt (reads the prompt from stdin).', false)
     .option('-i, --interactive', 'Force interactive mode even when a prompt is provided. Mutually exclusive with --headless.')
-    .option('--session-id <id>', 'Resume a previous conversation (Claude only)')
+    .option('--resume [id]', 'Resume a previous conversation. Accepts a full or partial session id (prefix-matched against the index); omit the id to pick from recent sessions interactively. Resumes under the version that started the session. claude/codex resume natively; other agents replay via a /continue first message. Pair with a prompt to continue headlessly.')
+    .option('--session-id <id>', 'Force a NEW conversation to use this exact session UUID (Claude only). This CREATES a session — to resume an existing one, use --resume.')
     .option('--verbose', 'Show detailed execution logs')
     .option('--timeout <duration>', 'Kill the agent after this duration (e.g., 30m, 1h, 2h30m)')
     .option(
@@ -271,7 +274,7 @@ export function registerRunCommand(program: Command): void {
 
       Fallback: --fallback codex,gemini retries on rate-limit failure via /continue handoff. Each entry accepts @version.
 
-      Resume: --session-id <id> continues a prior Claude conversation.
+      Resume: --resume <id> continues a prior conversation (full or partial id; omit to pick interactively). claude/codex resume natively; others replay via a /continue first message. Add a prompt to continue headlessly.
 
       Passthrough: everything after -- is forwarded verbatim to the underlying agent CLI.
         agents run kimi -- --plan --some-native-flag value
@@ -363,7 +366,7 @@ export function registerRunCommand(program: Command): void {
       }
 
       const [
-        { buildExecCommand, parseExecEnv, execAgent, runWithFallback, normalizeMode, resolveMode, defaultModeFor, headlessPlanStallCommand },
+        { buildExecCommand, parseExecEnv, execAgent, runWithFallback, normalizeMode, resolveMode, defaultModeFor, headlessPlanStallCommand, nativeResume, resolveInteractive },
         { ALL_AGENT_IDS },
         { profileExists, resolveProfileForRun },
         { readAndResolveBundleEnv, describeBundle },
@@ -614,6 +617,102 @@ export function registerRunCommand(program: Command): void {
 
       version = resolveVersionAlias(agent, version);
 
+      // --resume: resolve a prior conversation and rewrite the run target to
+      // continue it. `version` here is already the alias-resolved candidate-version
+      // FILTER (undefined for default/any, concrete for @latest/@oldest/@x.y.z);
+      // it is replaced below by the chosen session's OWN version (isolation).
+      let resumeNative = false;
+      let resumeSessionId: string | undefined;
+      let forceInteractive = false;
+      if (options.resume !== undefined) {
+        if (options.sessionId) {
+          console.error(chalk.red('--resume and --session-id are mutually exclusive. --session-id CREATES a session with a fixed id; --resume continues an existing one.'));
+          process.exit(1);
+        }
+        if (options.loop || options.fallback || options.resumeCheckpoint) {
+          console.error(chalk.red('--resume cannot be combined with --loop, --fallback, or --resume-checkpoint (those are separate continuation mechanisms).'));
+          process.exit(1);
+        }
+
+        const { findSessionsById } = await import('../lib/session/db.js');
+        const { discoverSessions } = await import('../lib/session/discover.js');
+        const { pickSessionInteractive } = await import('./sessions.js');
+        const { buildContinuePrompt } = await import('../lib/loop.js');
+
+        // Freshen the index for this agent before any lookup (incremental, cached).
+        // AgentId is wider than SessionAgentId (cursor/amp/… keep no transcripts);
+        // those simply yield no matches and fall through to the not-found error.
+        const sessionAgent = agent as import('../lib/session/types.js').SessionAgentId;
+        await discoverSessions({ agent: sessionAgent, version });
+
+        // Resume is interactive unless a follow-on prompt makes it headless.
+        const wantsInteractive = resolveInteractive({ interactive: options.interactive, headless: options.headless, prompt });
+        const idArg = typeof options.resume === 'string' ? options.resume.trim() : '';
+        let scopeCwd: string | undefined;
+        try { scopeCwd = fs.realpathSync(cwd); } catch { scopeCwd = cwd; }
+
+        let session: import('../lib/session/types.js').SessionMeta | undefined;
+        if (idArg) {
+          let matches = findSessionsById(idArg, { agent: sessionAgent, version, cwd: scopeCwd });
+          if (matches.length === 0) {
+            const wide = findSessionsById(idArg, { agent: sessionAgent, version });
+            if (wide.length > 0) {
+              if (!options.quiet) process.stderr.write(chalk.gray(`No match for "${idArg}" in this project; widened to all projects.\n`));
+              matches = wide;
+            }
+          }
+          if (matches.length === 0) {
+            console.error(chalk.red(`No ${agent} session matching "${idArg}".`));
+            console.error(chalk.gray(`Browse sessions: agents sessions ${idArg}`));
+            process.exit(1);
+          } else if (matches.length === 1) {
+            session = matches[0];
+          } else if (wantsInteractive) {
+            const picked = await pickSessionInteractive(matches, `Multiple sessions match "${idArg}":`);
+            if (!picked) process.exit(0);
+            session = picked.session;
+          } else {
+            console.error(chalk.red(`"${idArg}" is ambiguous — ${matches.length} sessions match:`));
+            for (const m of matches.slice(0, 10)) {
+              console.error(chalk.gray(`  ${m.shortId}  ${m.timestamp.slice(0, 16).replace('T', ' ')}  ${m.topic ?? m.label ?? ''}`));
+            }
+            console.error(chalk.gray('Pass more of the id, or resume interactively (drop the prompt).'));
+            process.exit(1);
+          }
+        } else {
+          // Bare --resume: pick from recent sessions in scope. Needs a TTY.
+          if (!wantsInteractive) {
+            console.error(chalk.red('--resume with no id needs an interactive terminal. Pass a session id (full or prefix), or run without --headless.'));
+            process.exit(1);
+          }
+          const recent = await discoverSessions({ agent: sessionAgent, version, limit: 200 });
+          if (recent.length === 0) {
+            console.error(chalk.red(`No ${agent} sessions found to resume in this project.`));
+            console.error(chalk.gray('Browse all: agents sessions'));
+            process.exit(1);
+          }
+          const picked = await pickSessionInteractive(recent, `Resume which ${agent} session?`);
+          if (!picked) process.exit(0);
+          session = picked.session;
+          forceInteractive = true; // bare resume always lands in the agent's TUI
+        }
+
+        // Pin to the chosen session's own version (the isolated HOME the transcript
+        // lives in) and route by tier.
+        version = session.version;
+        if (nativeResume(agent)) {
+          resumeNative = true;
+          resumeSessionId = session.id;
+          if (!options.quiet) process.stderr.write(chalk.gray(`Resuming ${agent} ${session.shortId} (native)${version ? ` @${version}` : ''}\n`));
+        } else {
+          // Tier-2: launch fresh with a /continue <id> first message; the agent
+          // loads the transcript via `agents sessions <id>` and picks up.
+          prompt = buildContinuePrompt(session.id, prompt);
+          if (prompt.trim() === `/continue ${session.id}`) forceInteractive = true;
+          if (!options.quiet) process.stderr.write(chalk.gray(`Resuming ${agent} ${session.shortId} (/continue replay)${version ? ` @${version}` : ''}\n`));
+        }
+      }
+
       const configuredStrategy = getConfiguredRunStrategy(agent, cwd);
       const explicitStrategy = options.strategy ? normalizeRunStrategy(options.strategy) : null;
       if (options.strategy && !explicitStrategy) {
@@ -772,7 +871,7 @@ export function registerRunCommand(program: Command): void {
         agent,
         version,
         prompt,
-        interactive: options.interactive,
+        interactive: options.interactive || forceInteractive,
         mode,
         effort,
         cwd: options.cwd,
@@ -780,7 +879,8 @@ export function registerRunCommand(program: Command): void {
         addDirs: options.addDir,
         json: options.json,
         headless: options.headless,
-        sessionId: options.sessionId,
+        sessionId: resumeSessionId ?? options.sessionId,
+        resume: resumeNative,
         verbose: options.verbose,
         timeout: options.timeout,
         env,

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -786,7 +786,7 @@ function formatPickerLabel(s: SessionMeta, query: string): string {
   );
 }
 
-async function pickSessionInteractive(
+export async function pickSessionInteractive(
   sessions: SessionMeta[],
   message = 'Search sessions:',
   initialSearch?: string,

--- a/src/lib/exec.test.ts
+++ b/src/lib/exec.test.ts
@@ -1,5 +1,81 @@
 import { describe, it, expect } from 'vitest';
-import { shouldTapStdout, resolveInteractive } from './exec.js';
+import { shouldTapStdout, resolveInteractive, buildExecCommand, nativeResume } from './exec.js';
+import type { ExecOptions } from './exec.js';
+
+/** Minimal ExecOptions with required fields, overridable per test. */
+function execOpts(over: Partial<ExecOptions> & { agent: ExecOptions['agent'] }): ExecOptions {
+  return { mode: 'plan', effort: 'auto', ...over } as ExecOptions;
+}
+
+/** Find the index of the first occurrence of `tok` in argv (-1 if absent). */
+function idx(cmd: string[], tok: string): number {
+  return cmd.indexOf(tok);
+}
+
+describe('nativeResume (Tier-1 capability derives from the command template)', () => {
+  it('claude and codex resume natively', () => {
+    expect(nativeResume('claude')).toBe(true);
+    expect(nativeResume('codex')).toBe(true);
+  });
+  it('opencode and gemini do not (they fall back to /continue replay)', () => {
+    expect(nativeResume('opencode')).toBe(false);
+    expect(nativeResume('gemini')).toBe(false);
+  });
+});
+
+describe('buildExecCommand — native resume wiring', () => {
+  it('claude headless: emits --resume <id> alongside the prompt, not --session-id', () => {
+    const cmd = buildExecCommand(execOpts({
+      agent: 'claude', resume: true, sessionId: 'abc-123', headless: true, prompt: 'keep going',
+    }));
+    expect(cmd).toContain('--resume');
+    expect(cmd[idx(cmd, '--resume') + 1]).toBe('abc-123');
+    expect(cmd).not.toContain('--session-id');
+    expect(cmd[idx(cmd, '-p') + 1]).toBe('keep going');
+    expect(cmd).toContain('--print');
+  });
+
+  it('claude interactive (no prompt): bare --resume <id>, no --print', () => {
+    const cmd = buildExecCommand(execOpts({ agent: 'claude', resume: true, sessionId: 'abc-123', interactive: true }));
+    expect(cmd[idx(cmd, '--resume') + 1]).toBe('abc-123');
+    expect(cmd).not.toContain('--print');
+  });
+
+  it('legacy --session-id (no resume) still CREATES with the fixed id', () => {
+    const cmd = buildExecCommand(execOpts({ agent: 'claude', sessionId: 'abc-123', headless: true, prompt: 'hi' }));
+    expect(cmd).toContain('--session-id');
+    expect(cmd[idx(cmd, '--session-id') + 1]).toBe('abc-123');
+    expect(cmd).not.toContain('--resume');
+  });
+
+  it('codex headless: `codex exec resume <id> <prompt>` with the bypass flag, id before prompt', () => {
+    const cmd = buildExecCommand(execOpts({
+      agent: 'codex', mode: 'edit', resume: true, sessionId: 'xyz-9', headless: true, prompt: 'go',
+    }));
+    expect(cmd.slice(0, 3)).toEqual(['codex', 'exec', 'resume']);
+    expect(cmd).toContain('--dangerously-bypass-approvals-and-sandbox');
+    expect(idx(cmd, 'xyz-9')).toBeGreaterThan(idx(cmd, 'resume'));
+    expect(idx(cmd, 'go')).toBeGreaterThan(idx(cmd, 'xyz-9'));
+    // codex's `exec resume` does NOT accept --sandbox; it must not leak through.
+    expect(cmd).not.toContain('--sandbox');
+  });
+
+  it('codex interactive resume drops `exec`: `codex resume <id>`, no sandbox flags', () => {
+    const cmd = buildExecCommand(execOpts({ agent: 'codex', mode: 'plan', resume: true, sessionId: 'xyz-9', interactive: true }));
+    expect(cmd).toEqual(['codex', 'resume', 'xyz-9']);
+  });
+
+  it('codex plan-mode headless resume passes no bypass (read-only intent inherits sandbox)', () => {
+    const cmd = buildExecCommand(execOpts({ agent: 'codex', mode: 'plan', resume: true, sessionId: 'xyz-9', headless: true, prompt: 'go' }));
+    expect(cmd).not.toContain('--dangerously-bypass-approvals-and-sandbox');
+  });
+
+  it('non-native agent ignores resume in the arg builder (Tier-2 handles it via the prompt)', () => {
+    const cmd = buildExecCommand(execOpts({ agent: 'gemini', resume: true, sessionId: 'qqq', headless: true, prompt: 'go' }));
+    expect(cmd).not.toContain('--resume');
+    expect(cmd).not.toContain('qqq');
+  });
+});
 
 describe('shouldTapStdout (budget live-watcher attach gating, #346 FIX 3)', () => {
   // The regression FIX 3 fixes: a headless run AT A TERMINAL (piped=false) with

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -136,6 +136,14 @@ export interface ExecOptions {
   addDirs?: string[];
   timeout?: string;
   sessionId?: string;
+  /**
+   * Resume the conversation named by `sessionId` using the agent's NATIVE resume
+   * form (claude `--resume`, codex `resume`, opencode `--session`) instead of the
+   * default `--session-id` create. Only set for agents where `nativeResume` is
+   * true; other agents resume via a `/continue <id>` first message (Tier 2),
+   * which needs no flag and leaves this unset.
+   */
+  resume?: boolean;
   verbose?: boolean;
   env?: Record<string, string>;
   /**
@@ -322,6 +330,15 @@ export interface AgentCommandTemplate {
   modelFlag?: string;
   printFlags?: string[];
   verboseFlag?: string;
+  /**
+   * How this agent natively resumes a prior conversation. Presence here is the
+   * single source of truth for `nativeResume(agent)` — agents without it fall
+   * back to the universal `/continue <id>` replay (Tier 2). Two shapes:
+   *   { flag }       — append `<flag> <id>` (claude `--resume`, opencode `--session`)
+   *   { subcommand } — replace the headless base subcommand with `<subcommand> <id>`
+   *                    (codex: `codex exec` -> `codex resume <id>`)
+   */
+  resume?: { flag: string } | { subcommand: string };
 }
 
 /**
@@ -344,10 +361,12 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
     modelFlag: '--model',
     printFlags: ['--print'],
     verboseFlag: '--verbose',
+    resume: { flag: '--resume' },
   },
   codex: {
     base: ['codex', 'exec'],
     promptFlag: 'positional',
+    resume: { subcommand: 'resume' },
     modeFlags: {
       // NOTE: codex has no read-only mode in --sandbox; 'plan' here means
       // "workspace-write but no auto-approval" — closer to plan-as-restraint.
@@ -385,6 +404,9 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
   opencode: {
     base: ['opencode', 'run'],
     promptFlag: 'positional',
+    // opencode's native resume is `opencode --session <id>` (NOT under `run`), so
+    // it does not compose with this headless `run` base. Until that's verified on
+    // a box with opencode installed, opencode resumes via Tier-2 `/continue`.
     modeFlags: {
       plan: ['--agent', 'plan'],
       edit: ['--agent', 'build'],
@@ -520,6 +542,15 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
   },
 };
 
+/**
+ * Whether `agent` has a native resume form (Tier 1). Derived solely from the
+ * command template's `resume` field — the single source of truth. Agents that
+ * return false resume via the universal Tier-2 `/continue` replay instead.
+ */
+export function nativeResume(agent: AgentId): boolean {
+  return AGENT_COMMANDS[agent]?.resume !== undefined;
+}
+
 /** Assemble the full CLI argument array for an agent invocation. */
 export function buildExecCommand(options: ExecOptions): string[] {
   const template = AGENT_COMMANDS[options.agent];
@@ -536,6 +567,16 @@ export function buildExecCommand(options: ExecOptions): string[] {
     } else if (options.agent === 'opencode' && cmd[1] === 'run') {
       cmd.splice(1, 1);
     }
+  }
+
+  // Native resume with a `{ subcommand }` shape (codex) appends the resume verb
+  // to the base: `codex exec` -> `codex exec resume` (headless) and, after the
+  // interactive drop above, `codex` -> `codex resume` (TUI). The session id is
+  // pushed later as the first positional (before any prompt). `{ flag }` agents
+  // (claude) need no base change — the flag is appended with the id below.
+  const resumeSpec = options.resume ? template.resume : undefined;
+  if (resumeSpec && 'subcommand' in resumeSpec) {
+    cmd.push(resumeSpec.subcommand);
   }
 
   // Use versioned alias if a specific version was requested (e.g., claude@2.1.98).
@@ -591,7 +632,18 @@ export function buildExecCommand(options: ExecOptions): string[] {
       `Internal error: ${options.agent} declares '${resolvedMode}' in capabilities.modes but has no entry in AGENT_COMMANDS.modeFlags.${resolvedMode}.`,
     );
   }
-  cmd.push(...modeFlags);
+  if (resumeSpec && 'subcommand' in resumeSpec) {
+    // codex `exec resume` / `resume` does NOT accept `--sandbox <mode>` (only the
+    // bypass flag, verified against `codex exec resume --help`). So the standard
+    // codex modeFlags can't be reused on resume. A non-plan HEADLESS resume needs
+    // the bypass or it stalls on approval prompts; plan and interactive resume
+    // inherit codex's default sandbox and pass no flag.
+    if (!interactive && resolvedMode !== 'plan') {
+      cmd.push('--dangerously-bypass-approvals-and-sandbox');
+    }
+  } else {
+    cmd.push(...modeFlags);
+  }
 
   // Add print/headless flags only when a prompt is provided. Without a prompt
   // the caller wants an interactive REPL -- passing --print would immediately
@@ -600,8 +652,18 @@ export function buildExecCommand(options: ExecOptions): string[] {
     cmd.push(...template.printFlags);
   }
 
-  // Add session ID (Claude only)
-  if (options.sessionId && options.agent === 'claude') {
+  // Resume vs. create. With `resume`, emit the agent's NATIVE resume reference:
+  // `{ flag }` agents append `<flag> <id>` (claude `--resume <id>`); `{ subcommand }`
+  // agents (codex) already pushed the verb above, so the id is the first
+  // positional here — placed before the prompt positional appended later. Without
+  // `resume`, the legacy claude-only `--session-id` CREATES a session with that id.
+  if (options.resume && options.sessionId && resumeSpec) {
+    if ('flag' in resumeSpec) {
+      cmd.push(resumeSpec.flag, options.sessionId);
+    } else {
+      cmd.push(options.sessionId);
+    }
+  } else if (options.sessionId && options.agent === 'claude') {
     cmd.push('--session-id', options.sessionId);
   }
 

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -138,10 +138,10 @@ export interface ExecOptions {
   sessionId?: string;
   /**
    * Resume the conversation named by `sessionId` using the agent's NATIVE resume
-   * form (claude `--resume`, codex `resume`, opencode `--session`) instead of the
-   * default `--session-id` create. Only set for agents where `nativeResume` is
-   * true; other agents resume via a `/continue <id>` first message (Tier 2),
-   * which needs no flag and leaves this unset.
+   * form (claude `--resume`, codex `resume`) instead of the default `--session-id`
+   * create. Only set for agents where `nativeResume` returns true; other agents
+   * resume via a `/continue <id>` first message (Tier 2), which needs no flag and
+   * leaves this unset.
    */
   resume?: boolean;
   verbose?: boolean;
@@ -334,9 +334,9 @@ export interface AgentCommandTemplate {
    * How this agent natively resumes a prior conversation. Presence here is the
    * single source of truth for `nativeResume(agent)` — agents without it fall
    * back to the universal `/continue <id>` replay (Tier 2). Two shapes:
-   *   { flag }       — append `<flag> <id>` (claude `--resume`, opencode `--session`)
+   *   { flag }       — append `<flag> <id>` (e.g. claude `--resume <id>`)
    *   { subcommand } — replace the headless base subcommand with `<subcommand> <id>`
-   *                    (codex: `codex exec` -> `codex resume <id>`)
+   *                    (codex: `codex exec` -> `codex exec resume <id>`)
    */
   resume?: { flag: string } | { subcommand: string };
 }

--- a/src/lib/loop.test.ts
+++ b/src/lib/loop.test.ts
@@ -9,6 +9,7 @@ import {
   clearLoopSignal,
   parseLoopInterval,
   buildLoopContinuePrompt,
+  buildContinuePrompt,
   type LoopContext,
   type IterationResult,
 } from './loop.js';
@@ -272,6 +273,20 @@ describe('buildLoopContinuePrompt (FIX 1)', () => {
   it('prepends the /continue skill directive then re-appends the entrypoint', () => {
     expect(buildLoopContinuePrompt('abc-123', 'do the work')).toBe(
       '/continue abc-123\n\ndo the work',
+    );
+  });
+});
+
+describe('buildContinuePrompt (Tier-2 universal resume directive)', () => {
+  it('directive only when no follow-on prompt', () => {
+    expect(buildContinuePrompt('abc-123')).toBe('/continue abc-123');
+  });
+  it('treats a whitespace-only prompt as none', () => {
+    expect(buildContinuePrompt('abc-123', '   ')).toBe('/continue abc-123');
+  });
+  it('appends a real follow-on prompt after a blank line', () => {
+    expect(buildContinuePrompt('abc-123', 'what did we decide?')).toBe(
+      '/continue abc-123\n\nwhat did we decide?',
     );
   });
 });

--- a/src/lib/loop.ts
+++ b/src/lib/loop.ts
@@ -133,7 +133,20 @@ export function loopSignalPath(runDir: string): string {
  * agent both recalls the prior turn AND knows what to do this iteration.
  */
 export function buildLoopContinuePrompt(prevSessionId: string, entrypoint: string): string {
-  return `/continue ${prevSessionId}\n\n${entrypoint}`;
+  return buildContinuePrompt(prevSessionId, entrypoint);
+}
+
+/**
+ * The universal (Tier-2) resume directive: a `/continue <id>` first message that
+ * tells the agent to load the prior transcript via `agents sessions <id>` and
+ * pick up. Works for ANY agent that ships the `/continue` command — the resume
+ * path for agents without a native `--resume` (gemini, grok, opencode, …). An
+ * optional follow-on prompt is appended after a blank line; omitted when empty so
+ * a bare resume sends just the directive.
+ */
+export function buildContinuePrompt(sessionId: string, prompt?: string): string {
+  const directive = `/continue ${sessionId}`;
+  return prompt && prompt.trim() ? `${directive}\n\n${prompt}` : directive;
 }
 
 /**

--- a/src/lib/session/__tests__/db.test.ts
+++ b/src/lib/session/__tests__/db.test.ts
@@ -14,6 +14,7 @@ const {
   getDB,
   getDBPath,
   querySessions,
+  findSessionsById,
   closeDB,
   upsertSession,
   queryUsageRollup,
@@ -278,5 +279,94 @@ describe('syncTopics', () => {
 
   it('returns 0 for an empty map', () => {
     expect(syncTopics(new Map())).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findSessionsById — exact-then-prefix id resolution over the index (the
+// DB-backed equivalent of resolveSessionById, used by `agents run --resume`).
+// ---------------------------------------------------------------------------
+
+const ID_FILES_DIR = path.join(TEST_HOME, 'id-files');
+fs.mkdirSync(ID_FILES_DIR, { recursive: true });
+
+/** Seed a session with explicit id / short_id / agent / version / cwd. */
+function seedId(
+  id: string,
+  shortId: string,
+  agent: string,
+  version: string | null,
+  cwd: string,
+  timestamp: string,
+): void {
+  const filePath = path.join(ID_FILES_DIR, `${id}.jsonl`);
+  fs.writeFileSync(filePath, '');
+  getDB().prepare(`
+    INSERT INTO sessions (
+      id, short_id, agent, version, timestamp, project, cwd,
+      file_path, file_mtime_ms, file_size, scanned_at, is_team_origin
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+  `).run(id, shortId, agent, version, timestamp, 'proj-id', cwd, filePath, 0, 0, 0);
+}
+
+describe('findSessionsById', () => {
+  const HERE = path.join(ID_FILES_DIR, 'here');
+  const ELSEWHERE = path.join(ID_FILES_DIR, 'elsewhere');
+
+  beforeAll(() => {
+    // Two sessions sharing the prefix "80af" in THIS project's cwd.
+    seedId('80af76ca-b734-4f45-8833-ef1142219568', '80af76ca', 'claude', '2.1.180', HERE, '2026-06-01T10:00:00.000Z');
+    seedId('80af0000-0000-4000-8000-000000000001', '80af0000', 'claude', '2.1.181', HERE, '2026-06-02T10:00:00.000Z');
+    // A non-overlapping id in a DIFFERENT project's cwd (for widen test).
+    seedId('cccccccc-0000-4000-8000-000000000002', 'cccccccc', 'claude', '2.1.181', ELSEWHERE, '2026-06-03T10:00:00.000Z');
+    // A codex session whose id collides on prefix with the claude ones.
+    seedId('80af9999-0000-4000-8000-000000000003', '80af9999', 'codex', '0.50.0', HERE, '2026-06-04T10:00:00.000Z');
+  });
+
+  it('resolves a full id exactly (no prefix siblings dragged in)', () => {
+    const r = findSessionsById('80af76ca-b734-4f45-8833-ef1142219568', { agent: 'claude' });
+    expect(r.map(s => s.id)).toEqual(['80af76ca-b734-4f45-8833-ef1142219568']);
+  });
+
+  it('resolves a short id exactly', () => {
+    const r = findSessionsById('80af0000', { agent: 'claude' });
+    expect(r.map(s => s.id)).toEqual(['80af0000-0000-4000-8000-000000000001']);
+  });
+
+  it('is case-insensitive', () => {
+    const r = findSessionsById('80AF76CA', { agent: 'claude' });
+    expect(r.map(s => s.id)).toEqual(['80af76ca-b734-4f45-8833-ef1142219568']);
+  });
+
+  it('returns all prefix matches when ambiguous, newest first', () => {
+    const r = findSessionsById('80af', { agent: 'claude' });
+    expect(r.map(s => s.id)).toEqual([
+      '80af0000-0000-4000-8000-000000000001',
+      '80af76ca-b734-4f45-8833-ef1142219568',
+    ]);
+  });
+
+  it('scopes by agent — codex prefix sibling does not leak into a claude lookup', () => {
+    const claude = findSessionsById('80af', { agent: 'claude' });
+    expect(claude.some(s => s.agent === 'codex')).toBe(false);
+    const codex = findSessionsById('80af', { agent: 'codex' });
+    expect(codex.map(s => s.id)).toEqual(['80af9999-0000-4000-8000-000000000003']);
+  });
+
+  it('scopes by version', () => {
+    const r = findSessionsById('80af', { agent: 'claude', version: '2.1.180' });
+    expect(r.map(s => s.id)).toEqual(['80af76ca-b734-4f45-8833-ef1142219568']);
+  });
+
+  it('cwd scope finds in-project, and dropping cwd widens to other projects', () => {
+    const scoped = findSessionsById('cccccccc', { agent: 'claude', cwd: HERE });
+    expect(scoped).toEqual([]); // lives in ELSEWHERE, not HERE
+    const widened = findSessionsById('cccccccc', { agent: 'claude' });
+    expect(widened.map(s => s.id)).toEqual(['cccccccc-0000-4000-8000-000000000002']);
+  });
+
+  it('returns empty for an unknown id and a blank query', () => {
+    expect(findSessionsById('deadbeef', { agent: 'claude' })).toEqual([]);
+    expect(findSessionsById('   ', { agent: 'claude' })).toEqual([]);
   });
 });

--- a/src/lib/session/db.ts
+++ b/src/lib/session/db.ts
@@ -70,6 +70,7 @@ CREATE INDEX IF NOT EXISTS idx_sessions_timestamp ON sessions(timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_cwd ON sessions(cwd);
 CREATE INDEX IF NOT EXISTS idx_sessions_agent ON sessions(agent);
 CREATE INDEX IF NOT EXISTS idx_sessions_file_path ON sessions(file_path);
+CREATE INDEX IF NOT EXISTS idx_sessions_short_id ON sessions(short_id);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS session_text USING fts5(
   session_id UNINDEXED,
@@ -136,6 +137,10 @@ export interface QueryOptions {
   /** Match any session whose cwd equals this or is a descendant of it. */
   cwdPrefix?: string;
   project?: string;
+  /** Match the full session id or short id, case-insensitively (exact). */
+  idExact?: string;
+  /** Match sessions whose id or short id begins with this (case-insensitive prefix). */
+  idPrefix?: string;
   sinceMs?: number;
   untilMs?: number;
   limit?: number;
@@ -762,6 +767,19 @@ function buildSessionWhere(options: QueryOptions): { clause: string; params: any
     params.push(`%${options.project.toLowerCase()}%`);
   }
 
+  // id lookup. SQLite's LIKE is case-insensitive for ASCII, so a lowercased
+  // pattern matches mixed-case ids; the `=` exact compare adds COLLATE NOCASE
+  // for the same reason. short_id carries its own index (idx_sessions_short_id);
+  // id is the PRIMARY KEY.
+  if (options.idExact) {
+    where.push('(id = ? COLLATE NOCASE OR short_id = ? COLLATE NOCASE)');
+    params.push(options.idExact, options.idExact);
+  }
+  if (options.idPrefix) {
+    where.push('(id LIKE ? OR short_id LIKE ?)');
+    params.push(`${options.idPrefix}%`, `${options.idPrefix}%`);
+  }
+
   if (typeof options.sinceMs === 'number') {
     // Compare as strings; ISO 8601 timestamps sort lexicographically.
     where.push('timestamp >= ?');
@@ -928,6 +946,25 @@ export function getSessionById(id: string): SessionMeta | null {
   const db = getDB();
   const row = db.prepare(`SELECT * FROM sessions WHERE id = ?`).get(id) as SessionRow | undefined;
   return row ? rowToMeta(row) : null;
+}
+
+/**
+ * Resolve a full-or-partial session id against the index, exact-first then
+ * prefix — the DB-backed equivalent of resolveSessionById() that runs over the
+ * SQLite table instead of a pre-loaded array. Matches both the full id and the
+ * short id. An exact hit short-circuits so a complete id never also drags in its
+ * prefix siblings. `scope` narrows by agent / version / project (cwd) so an
+ * ambiguous prefix disambiguates against the caller's context.
+ */
+export function findSessionsById(
+  idQuery: string,
+  scope: Pick<QueryOptions, 'agent' | 'version' | 'cwd' | 'project'> = {},
+): SessionMeta[] {
+  const q = idQuery.trim();
+  if (!q) return [];
+  const exact = querySessions({ ...scope, idExact: q });
+  if (exact.length > 0) return exact;
+  return querySessions({ ...scope, idPrefix: q });
 }
 
 /** A single full-text search result with ranking score. */

--- a/src/lib/versions.test.ts
+++ b/src/lib/versions.test.ts
@@ -441,4 +441,28 @@ describe('resolveVersionAlias @selectors', () => {
     installDroidVersions(home, VERSIONS);
     expect(runResolveAlias(home, 'droid', undefined)).toBeNull();
   });
+
+  it("treats 'any' like default/pinned — no version constraint (undefined)", () => {
+    const home = makeTempHome();
+    installDroidVersions(home, VERSIONS);
+    expect(runResolveAlias(home, 'droid', 'any')).toBeNull();
+  });
+});
+
+describe('resolveVersionAliasLoose — @any', () => {
+  it('treats "any" like "default": no version constraint (undefined)', () => {
+    const home = makeTempHome();
+    const moduleUrl = pathToFileURL(path.resolve('src/lib/versions.ts')).href;
+    const tsxBin = path.resolve('node_modules/.bin/tsx');
+    const child = spawnSync(tsxBin, ['-e', `
+      import { resolveVersionAlias, resolveVersionAliasLoose } from ${JSON.stringify(moduleUrl)};
+      console.log(JSON.stringify({
+        strictAny: resolveVersionAlias('claude', 'any') ?? null,
+        looseAny: resolveVersionAliasLoose('claude', 'any') ?? null,
+        strictDefault: resolveVersionAlias('claude', 'default') ?? null,
+      }));
+    `], { env: { ...process.env, HOME: home }, encoding: 'utf-8' });
+    expect(child.status, child.stderr).toBe(0);
+    expect(JSON.parse(child.stdout.trim())).toEqual({ strictAny: null, looseAny: null, strictDefault: null });
+  });
 });

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1490,6 +1490,7 @@ export function resolveVersion(agent: AgentId, projectPath?: string): string | n
  * Normalize a user-supplied @version token across CLI subcommands.
  *
  *   undefined / "" / "default" / "pinned" -> undefined  (caller falls back to project pin or global default)
+ *   "any"                       -> undefined  (caller imposes no version constraint — e.g. resume across any version)
  *   "latest"                    -> highest installed version (process.exit if none installed)
  *   "oldest"                    -> lowest installed version (process.exit if none installed)
  *   "x.y.z" (installed)         -> "x.y.z"
@@ -1504,7 +1505,7 @@ export function resolveVersion(agent: AgentId, projectPath?: string): string | n
  * parsing.
  */
 export function resolveVersionAlias(agent: AgentId, raw: string | undefined | null): string | undefined {
-  if (!raw || raw === 'default' || raw === 'pinned') return undefined;
+  if (!raw || raw === 'default' || raw === 'pinned' || raw === 'any') return undefined;
 
   if (raw === 'latest' || raw === 'oldest') {
     const installed = listInstalledVersions(agent);
@@ -1535,7 +1536,7 @@ export function resolveVersionAlias(agent: AgentId, raw: string | undefined | nu
  * remain queryable.
  */
 export function resolveVersionAliasLoose(agent: AgentId, raw: string | undefined | null): string | undefined {
-  if (!raw || raw === 'default' || raw === 'pinned') return undefined;
+  if (!raw || raw === 'default' || raw === 'pinned' || raw === 'any') return undefined;
   if (raw === 'latest' || raw === 'oldest') {
     const installed = listInstalledVersions(agent);
     if (installed.length === 0) return undefined;


### PR DESCRIPTION
## What

`ag run claude --resume 80af76ca` now works. Adds `agents run <agent> --resume [id]` to continue a previous session — the gap behind `error: unknown option '--resume'`.

```
ag run claude --resume 80af76ca              # partial id -> resolved -> native resume (TUI)
ag run claude --resume 80af76ca "keep going" # + prompt -> headless continue
ag run claude --resume                       # bare -> interactive picker of recent sessions
ag run claude@latest --resume                # @latest/@oldest/@default/@any filter candidates by version
ag run gemini --resume <id> "..."            # Tier-2: /continue replay
```

## How

- **Smart id resolution over the existing index** (not a new search): new `findSessionsById` does exact-then-prefix matching in SQL on the `sessions` table (+ a `short_id` index). Full UUID or any prefix works; case-insensitive. Project-scoped first, widens to all projects if nothing matches.
- **Two-tier resume — no agent dead-ends:**
  - *Native* (claude, codex): emits the agent's real resume form (`claude --resume <id>`, `codex exec resume` / `codex resume`), driven by a new `resume` field on the command template (`nativeResume()` is the single source of truth).
  - *Universal `/continue` replay* (every other agent, or when a native binary is gone): launches fresh with a `/continue <id>` first message so the agent reloads the transcript via `agents sessions <id>`. Shared `buildContinuePrompt()` (also used by the loop driver).
- **Version isolation:** always resumes under the session's *own* version (the isolated HOME its transcript lives in). The `@version` part filters candidate sessions; adds the `@any` alias.
- **Picker reuse:** bare `--resume` and ambiguous-interactive reuse the existing `@inquirer` session picker; ambiguous-headless lists candidates and exits non-zero.
- **Clarifies `--session-id`:** it *creates* a session with a fixed UUID (it never resumed). `--resume` is rejected alongside `--session-id` / `--loop` / `--fallback` / `--resume-checkpoint`.

## Verification

- **Full suite green**; 13 new tests cover exact/short/prefix/ambiguous/version-scope/widen lookup, the per-agent resume argv (claude/codex native, non-native ignored), `buildContinuePrompt`, and the `@any` alias.
- **Live, real claude process** (via `agents pty`): partial `13e338a8` resolved to the full id, ran `claude@2.1.181 ... --resume 13e338a8-a8ad-... -p ...`, and claude resumed and replied — version-pinned to the session's own version, real `--resume` flag (not `--session-id`).
- Error paths exercised against the real index: unknown prefix -> hint (exit 1); ambiguous prefix -> widen message + candidate list (exit 1); mutual-exclusion (exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)