### PR TITLE
feat(platform): shared Windows-compat helpers (Phase A of native-Windows port)

### DIFF
--- a/src/lib/platform/exec.test.ts
+++ b/src/lib/platform/exec.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { whichCommand, findExecutable } from './exec.js';
+import { whichCommand, findExecutable, needsWindowsShell } from './exec.js';
 
 describe('whichCommand', () => {
   it('is `where` on win32, `which` elsewhere', () => {
@@ -20,5 +20,28 @@ describe('findExecutable', () => {
 
   it('returns null for a name that does not exist', () => {
     expect(findExecutable('definitely-not-a-real-binary-xyz123')).toBeNull();
+  });
+});
+
+describe('needsWindowsShell', () => {
+  it('is always false off Windows, even for .cmd or bare names', () => {
+    expect(needsWindowsShell('npm', 'linux')).toBe(false);
+    expect(needsWindowsShell('npm.cmd', 'linux')).toBe(false);
+    expect(needsWindowsShell('/usr/bin/node', 'darwin')).toBe(false);
+  });
+
+  it('on win32, needs the shell for .cmd/.bat wrappers (case-insensitive)', () => {
+    expect(needsWindowsShell('C:\\Program Files\\nodejs\\npm.cmd', 'win32')).toBe(true);
+    expect(needsWindowsShell('C:\\tools\\bun.CMD', 'win32')).toBe(true);
+    expect(needsWindowsShell('C:\\x\\run.bat', 'win32')).toBe(true);
+  });
+
+  it('on win32, needs the shell for a bare (PATHEXT-resolved) command name', () => {
+    expect(needsWindowsShell('npm', 'win32')).toBe(true);
+    expect(needsWindowsShell('bun', 'win32')).toBe(true);
+  });
+
+  it('on win32, a direct absolute .exe does NOT need the shell', () => {
+    expect(needsWindowsShell('C:\\Program Files\\nodejs\\node.exe', 'win32')).toBe(false);
   });
 });

--- a/src/lib/platform/exec.ts
+++ b/src/lib/platform/exec.ts
@@ -2,10 +2,27 @@
  * Executable resolution, platform-aware.
  */
 import { execFileSync } from 'child_process';
+import * as path from 'path';
 
 /** PATH-search command for the platform: `where` on Windows, else `which`. */
 export function whichCommand(platform: NodeJS.Platform = process.platform): string {
   return platform === 'win32' ? 'where' : 'which';
+}
+
+/**
+ * Does spawning `binary` require `shell: true` on this platform?
+ *
+ * On Windows a `.cmd`/`.bat` wrapper (npm.cmd, bun.cmd, the agent shims) cannot
+ * be exec'd directly — `spawn`/`execFile` look for a literal executable and miss
+ * the PATHEXT/cmd-interpreter step, surfacing as `ENOENT`/`EINVAL`. A bare
+ * command name (not an absolute path) needs the same PATHEXT resolution. Both
+ * cases require the shell. Always false off Windows, where direct exec is right.
+ */
+export function needsWindowsShell(binary: string, platform: NodeJS.Platform = process.platform): boolean {
+  if (platform !== 'win32') return false;
+  // path.win32.isAbsolute, not path.isAbsolute: the latter uses the HOST's rules,
+  // so a Windows path would read as relative when this runs on a Linux CI host.
+  return !path.win32.isAbsolute(binary) || /\.(cmd|bat)$/i.test(binary);
 }
 
 /**

--- a/src/lib/platform/index.ts
+++ b/src/lib/platform/index.ts
@@ -18,6 +18,7 @@ export const IS_LINUX = process.platform === 'linux';
 
 export * from './paths.js';
 export * from './exec.js';
+export * from './links.js';
 export * from './process.js';
 export * from './ipc.js';
 export * from './winpath.js';

--- a/src/lib/platform/links.test.ts
+++ b/src/lib/platform/links.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createLink } from './links.js';
+
+describe('createLink', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-links-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('links a directory so its contents are reachable through the link', () => {
+    const src = path.join(dir, 'srcdir');
+    fs.mkdirSync(src);
+    fs.writeFileSync(path.join(src, 'inner.txt'), 'hello');
+    const dst = path.join(dir, 'linkdir');
+
+    createLink(src, dst);
+
+    // Junction (Windows) or symlink (POSIX) — either way the content reads through.
+    expect(fs.readFileSync(path.join(dst, 'inner.txt'), 'utf8')).toBe('hello');
+  });
+
+  it('links a file so its content is reachable through the link', () => {
+    const src = path.join(dir, 'src.txt');
+    fs.writeFileSync(src, 'payload');
+    const dst = path.join(dir, 'link.txt');
+
+    createLink(src, dst);
+
+    expect(fs.readFileSync(dst, 'utf8')).toBe('payload');
+  });
+
+  it('throws when the source does not exist (no silent no-op)', () => {
+    expect(() => createLink(path.join(dir, 'nope'), path.join(dir, 'x'))).toThrow();
+  });
+});

--- a/src/lib/platform/links.ts
+++ b/src/lib/platform/links.ts
@@ -1,0 +1,42 @@
+/**
+ * Filesystem linking, platform-aware.
+ *
+ * POSIX symlinks have no portable equivalent on Windows: directory symlinks and
+ * file symlinks both require either Administrator or Developer Mode, while
+ * *junctions* (directories only) need no elevation. `createLink` picks the form
+ * that works without privilege — junction for directories — and falls back to a
+ * copy for file links when the OS refuses the symlink.
+ */
+import * as fs from 'fs';
+
+/**
+ * Create a link at `dst` pointing to `src`, portable across platforms.
+ *
+ * - **Directory** target: junction on Windows (no Developer Mode needed), plain
+ *   symlink on POSIX.
+ * - **File** target: symlink, falling back to `copyFileSync` when Windows
+ *   refuses the symlink (`EPERM`/`ENOSYS` — no Developer Mode). The copy is a
+ *   point-in-time snapshot, not a live link; acceptable for the immutable
+ *   targets we link (binaries, config files).
+ *
+ * `dst` must not already exist. Callers that replace atomically should link to a
+ * temp name and `rename` over the destination, exactly as before — the copy
+ * fallback is non-atomic, so the temp+rename stays the caller's responsibility.
+ */
+export function createLink(src: string, dst: string): void {
+  const win = process.platform === 'win32';
+  const isDir = fs.statSync(src).isDirectory();
+  // Type is ignored on POSIX; on Windows, junction (dir) avoids the elevation a
+  // dir symlink would need, and 'file' is the explicit file-symlink form.
+  const type: fs.symlink.Type | undefined = win ? (isDir ? 'junction' : 'file') : undefined;
+  try {
+    fs.symlinkSync(src, dst, type);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (win && !isDir && (code === 'EPERM' || code === 'ENOSYS')) {
+      fs.copyFileSync(src, dst);
+      return;
+    }
+    throw err;
+  }
+}

--- a/src/lib/platform/paths.test.ts
+++ b/src/lib/platform/paths.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import * as os from 'os';
-import { looksLikePath, toComparablePath, homeDir, isWindowsAbsolutePath } from './paths.js';
+import { looksLikePath, toComparablePath, homeDir, isWindowsAbsolutePath, toPosix, toPortableKey } from './paths.js';
 
 describe('looksLikePath', () => {
   // POSIX markers must classify identically on every platform — this is the
@@ -56,5 +56,29 @@ describe('isWindowsAbsolutePath', () => {
     for (const p of ['/abs/path', './rel', '~/x', 'owner/repo', 'plugin-name', '']) {
       expect(isWindowsAbsolutePath(p)).toBe(false);
     }
+  });
+});
+
+describe('toPosix', () => {
+  it('folds backslashes to forward slashes', () => {
+    expect(toPosix('C:\\Users\\Me\\repo')).toBe('C:/Users/Me/repo');
+    expect(toPosix('a\\b\\c')).toBe('a/b/c');
+  });
+  it('leaves POSIX paths unchanged', () => {
+    expect(toPosix('/Users/Me/repo')).toBe('/Users/Me/repo');
+    expect(toPosix('a/b/c')).toBe('a/b/c');
+  });
+});
+
+describe('toPortableKey', () => {
+  it('produces the historical POSIX slug unchanged (no regression of on-disk keys)', () => {
+    // Old logic: cwd.replace(/\//g,'_').replace(/ /g,'_')
+    expect(toPortableKey('/home/user/repo')).toBe('_home_user_repo');
+    expect(toPortableKey('/home/user/my repo')).toBe('_home_user_my_repo');
+  });
+  it('drops the Windows drive colon and folds separators (NTFS-safe)', () => {
+    // Without the drop, ':' is illegal in a filename (ADS separator) -> ENOENT.
+    expect(toPortableKey('C:\\Users\\me\\repo')).toBe('C_Users_me_repo');
+    expect(toPortableKey('D:\\a\\b c')).toBe('D_a_b_c');
   });
 });

--- a/src/lib/platform/paths.ts
+++ b/src/lib/platform/paths.ts
@@ -64,3 +64,27 @@ export function homeDir(): string {
 export function isWindowsAbsolutePath(p: string): boolean {
   return WIN_DRIVE_RE.test(p) || p.startsWith('\\\\');
 }
+
+/**
+ * Fold backslashes to forward slashes. Use when a path is going into a string
+ * that must read the same on every OS — a doc-comparable display path, a regex
+ * subject, a forward-slash-keyed lookup. Pure string transform; on POSIX input
+ * (no backslashes) it returns the value unchanged.
+ */
+export function toPosix(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
+/**
+ * Derive a filesystem-safe key/slug from an absolute path. Drops the Windows
+ * drive colon (`:` is illegal in NTFS filenames / is the ADS separator) and
+ * folds path separators and spaces to `_`. For a POSIX path this produces the
+ * exact historical slug (`/a/b c` -> `_a_b_c`), so existing on-disk keys are
+ * unchanged; on Windows `C:\a\b` -> `C_a_b` instead of an unusable name.
+ *
+ * Shell mirror (keep byte-identical in any bash shim that recomputes this key):
+ *   printf '%s' "$P" | tr -d ':' | tr '\\/ ' '_'
+ */
+export function toPortableKey(p: string): string {
+  return p.replace(/^([a-zA-Z]):/, '$1').replace(/[\\/ ]/g, '_');
+}


### PR DESCRIPTION
## What

**Phase A** of the native-Windows port (closing the 82 source-side Win32 bugs surfaced by the new Windows CI leg). This PR lands ONLY the shared, land-first infrastructure that the per-subsystem fan-out PRs will import — purely additive, no existing call-site touched.

| File | Adds |
|---|---|
| `platform/links.ts` *(new)* | `createLink(src,dst)` — junction for dirs (no Developer Mode needed), symlink with `copyFileSync` fallback for files when Windows refuses (`EPERM`/`ENOSYS`) |
| `platform/paths.ts` | `toPosix()`, `toPortableKey()` — the key drops the Windows drive `:` (illegal in NTFS filenames) and folds separators; **byte-identical to the historical POSIX slug**, so existing on-disk cache keys don't move |
| `platform/exec.ts` | `needsWindowsShell(binary)` — whether a spawn needs `shell:true` for a `.cmd`/`.bat` wrapper (`npm.cmd`, agent shims) or a bare PATHEXT-resolved name |
| `platform/index.ts` | re-export `links` |

## Why land-first

These three are consumed across multiple subsystems (linking: skills/migrate/rules/drive-sync; slug: shims/project-launch/sessions; spawn: self-update/cli-resources). Landing them once, alone, lets the fan-out streams import a stable API instead of each re-deriving the OS branch — and keeps boundary contracts clean.

## Verification

- `tsc --noEmit`: 0 errors
- `vitest run src/lib/platform/`: **38 passed**
- The `needsWindowsShell` test caught a real host-semantics bug — `path.isAbsolute` uses the *host's* rules, so a Windows path reads as relative on a Linux CI host; fixed to `path.win32.isAbsolute`. This is exactly the class of bug the platform-parameterized helpers exist to prevent.

Follow-ups: 6 fan-out PRs (WS-A..F) route their owned files through these helpers; `platform/*` stays edit-forbidden in those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)