### PR TITLE
fix(win): leaf modules (mode / IPC / process-listing / paths)

### DIFF
--- a/src/lib/__tests__/pty-server.test.ts
+++ b/src/lib/__tests__/pty-server.test.ts
@@ -49,7 +49,10 @@ afterEach(async () => {
   await fsp.rm(sock, { force: true });
 });
 
-describe.skipIf(!nodePtyLoadable)('PTY socket permission', () => {
+// Windows uses a named pipe, not a filesystem socket inode — getSocketPath()
+// returns a \\.\pipe\ path that can't be stat()ed or chmod()ed. These boot
+// tests assert unix-socket file semantics, so they are POSIX-only.
+describe.skipIf(!nodePtyLoadable || process.platform === 'win32')('PTY socket permission', () => {
   it('chmods the socket to 0o600 immediately after listen', async () => {
     // runPtyServer awaits forever; kick it off without awaiting and poll
     // for the socket inode to appear.
@@ -94,7 +97,9 @@ describe.skipIf(!nodePtyLoadable)('PTY socket permission', () => {
   }, 15_000);
 });
 
-describe.skipIf(!nodePtyLoadable)('PTY duplicate-spawn race resolution', () => {
+// POSIX-only for the same reason: it pre-stages a regular file at the socket
+// path and asserts it survives — a \\.\pipe\ path on Windows can't be written.
+describe.skipIf(!nodePtyLoadable || process.platform === 'win32')('PTY duplicate-spawn race resolution', () => {
   it('exits cleanly without touching the socket when a live PID file already exists', async () => {
     // Pre-stage a PID file pointing to a live process (this test runner). The
     // server boot must detect this via isPtyServerRunning() and exit cleanly

--- a/src/lib/__tests__/settings-manifest.test.ts
+++ b/src/lib/__tests__/settings-manifest.test.ts
@@ -148,8 +148,11 @@ describe('carryForwardSettings (codex)', () => {
     expect(merged.projects['/root/work'].trust_level).toBe('trusted');
     expect(merged.notice).toBeUndefined();
 
-    const mode = fs.statSync(path.join(toHome, '.codex/auth.json')).mode & 0o777;
-    expect(mode).toBe(0o600);
+    // NTFS has no POSIX mode bits — the 0o600 restrictMode is a no-op on Windows.
+    if (process.platform !== 'win32') {
+      const mode = fs.statSync(path.join(toHome, '.codex/auth.json')).mode & 0o777;
+      expect(mode).toBe(0o600);
+    }
   });
 
   it('copies prompt dir entries without clobbering existing ones', () => {

--- a/src/lib/browser/runtime-state.ts
+++ b/src/lib/browser/runtime-state.ts
@@ -292,18 +292,39 @@ export function reapOrphanedProcesses(): { reaped: number; details: string[] } {
 }
 
 function matchesCommand(pid: number, expectedCommand: string): boolean {
+  const out = liveProcessCommand(pid);
+  if (!out) return false;
+  // Match on the basename only — `/Applications/Comet.app/Contents/MacOS/Comet`
+  // vs the recorded `Comet`, vs `Google\ Chrome`, vs Windows `chrome.exe`.
+  // Case-insensitive.
+  const live = path.basename(out).toLowerCase();
+  const want = path.basename(expectedCommand).toLowerCase();
+  return live === want || live.startsWith(want) || want.startsWith(live);
+}
+
+/**
+ * The executable/image name the live `pid` is running, or null if it can't be
+ * determined. The process-listing API differs per OS: Windows has no `ps`, so
+ * we query `tasklist` (CSV image name in column 1); POSIX uses `ps -o comm=`.
+ */
+function liveProcessCommand(pid: number): string | null {
   try {
+    if (process.platform === 'win32') {
+      const out = execFileSync('tasklist', ['/FI', `PID eq ${pid}`, '/NH', '/FO', 'CSV'], {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+      // Rows look like: "node.exe","1234","Console","1","12,345 K"
+      // A no-match prints an "INFO: No tasks..." line that won't match the regex.
+      const m = out.match(/^"([^"]+)"/);
+      return m ? m[1] : null;
+    }
     const out = execFileSync('ps', ['-p', String(pid), '-o', 'comm='], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
-    if (!out) return false;
-    // Match on the basename only — `/Applications/Comet.app/Contents/MacOS/Comet`
-    // vs the recorded `Comet`, vs `Google\ Chrome`. Case-insensitive.
-    const live = path.basename(out).toLowerCase();
-    const want = path.basename(expectedCommand).toLowerCase();
-    return live === want || live.startsWith(want) || want.startsWith(live);
+    return out || null;
   } catch {
-    return false;
+    return null;
   }
 }

--- a/src/lib/cloud/paths.test.ts
+++ b/src/lib/cloud/paths.test.ts
@@ -1,22 +1,28 @@
 import { describe, it, expect } from 'vitest';
 import * as path from 'path';
+import * as os from 'os';
 import { getUserAgentsDir, getCloudDir } from '../state.js';
+
+// state.ts resolves its root as `process.env.HOME ?? os.homedir()`. On Windows
+// HOME is unset, so mirror that exact resolution rather than asserting against a
+// bare `process.env.HOME!` (which is `undefined` → `path.join` throws there).
+const HOME = process.env.HOME ?? os.homedir();
 
 describe('cloud path roots', () => {
   it('reads cloud config from ~/.agents/agents.yaml', async () => {
     const { getDefaultProviderId } = await import('./registry.js');
     expect(getDefaultProviderId()).toBeDefined();
     expect(path.join(getUserAgentsDir(), 'agents.yaml')).toBe(
-      path.join(process.env.HOME!, '.agents', 'agents.yaml'),
+      path.join(HOME, '.agents', 'agents.yaml'),
     );
   });
 
   it('stores cloud task state and consent under ~/.agents/.cache/cloud', () => {
     expect(path.join(getCloudDir(), 'tasks.db')).toBe(
-      path.join(process.env.HOME!, '.agents', '.cache', 'cloud', 'tasks.db'),
+      path.join(HOME, '.agents', '.cache', 'cloud', 'tasks.db'),
     );
     expect(path.join(getCloudDir(), 'rush-consent.json')).toBe(
-      path.join(process.env.HOME!, '.agents', '.cache', 'cloud', 'rush-consent.json'),
+      path.join(HOME, '.agents', '.cache', 'cloud', 'rush-consent.json'),
     );
   });
 });

--- a/src/lib/drive-sync.test.ts
+++ b/src/lib/drive-sync.test.ts
@@ -91,7 +91,9 @@ afterEach(() => {
   }
 });
 
-describe('drive sync remote validation', () => {
+// POSIX-only: these tests stand up `#!/bin/sh` fake `rsync`/`ssh` binaries on
+// PATH, which Windows can't execute (and rsync/ssh are absent → ENOENT).
+describe.skipIf(process.platform === 'win32')('drive sync remote validation', () => {
   const malicious = [
     'evil; touch pwned@host',
     'a@host`touch pwned`',

--- a/src/lib/project-launch.test.ts
+++ b/src/lib/project-launch.test.ts
@@ -38,6 +38,7 @@ vi.mock('./state.js', () => ({
 }));
 
 import { runLaunchSync } from './project-launch.js';
+import { toPortableKey } from './platform/index.js';
 import {
   MARKETPLACE_NAME,
   PROJECT_MARKETPLACE_NAME,
@@ -342,15 +343,16 @@ describe('runLaunchSync — shim skip-fast sentinel', () => {
   it('writes the bash skip-fast sentinel at the shim-expected path', () => {
     runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
 
-    // Slug derivation must match shims.ts: `/` and ` ` → `_`.
-    const slug = PROJECT_DIR.replace(/\//g, '_').replace(/ /g, '_');
+    // Slug derivation must match shims.ts / launchSentinelPath: the canonical
+    // toPortableKey mapping (drop drive colon, fold `\` `/` ` ` → `_`).
+    const slug = toPortableKey(PROJECT_DIR);
     const sentinel = path.join(USER_DIR, '.cache', 'launch-sync', `claude@1.0.0@${slug}`);
     expect(fs.existsSync(sentinel)).toBe(true);
   });
 
   it('sentinel mtime advances on a second run after the first', () => {
     runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
-    const slug = PROJECT_DIR.replace(/\//g, '_').replace(/ /g, '_');
+    const slug = toPortableKey(PROJECT_DIR);
     const sentinel = path.join(USER_DIR, '.cache', 'launch-sync', `claude@1.0.0@${slug}`);
     const t1 = fs.statSync(sentinel).mtimeMs;
     const target = Date.now() + 25;

--- a/src/lib/project-launch.ts
+++ b/src/lib/project-launch.ts
@@ -56,6 +56,7 @@ import {
   getSystemPluginsDir,
 } from './state.js';
 import { getVersionHomePath } from './versions.js';
+import { toPortableKey } from './platform/index.js';
 import { transformSubagentForClaude } from './subagents.js';
 import { compileRulesForProject } from './rules/compile.js';
 import { discoverPluginsInDir, hasPluginExecSurfaces, inspectPluginCapabilities } from './plugins.js';
@@ -133,15 +134,17 @@ export function runLaunchSync(opts: LaunchSyncOptions): LaunchSyncResult {
 
 /**
  * Path of the shim's skip-fast sentinel for this (agent, version, cwd) tuple.
- * Must match the SHIM-SIDE format in src/lib/shims.ts (PROJECT_SLUG derivation):
- *   slug = PWD with `/` → `_` and ` ` → `_`
+ * Must match the SHIM-SIDE format in src/lib/shims.ts (PROJECT_SLUG derivation),
+ * which is the canonical `toPortableKey` mapping: drop the Windows drive colon
+ * and fold `\`, `/`, and ` ` → `_`. On POSIX this is byte-identical to the old
+ * `/` and ` ` → `_` slug; on Windows it yields a legal filename (no `C:\`).
  *
  * Cache leak note: this dir accumulates one zero-byte file per
  * (agent, version, project) tuple ever launched. Disk impact is negligible
  * (inodes only). A periodic GC belongs in `agents prune` — follow-up.
  */
 function launchSentinelPath(agent: AgentId, version: string, cwd: string): string {
-  const slug = cwd.replace(/\//g, '_').replace(/ /g, '_');
+  const slug = toPortableKey(cwd);
   // Prefer $HOME (respects test overrides + matches bash's $HOME expansion in
   // the shim), fall back to os.homedir() so the lookup never resolves to '/'
   // if HOME is somehow unset.

--- a/src/lib/secrets/__tests__/linux.test.ts
+++ b/src/lib/secrets/__tests__/linux.test.ts
@@ -91,7 +91,8 @@ describe('fileBackend (encrypted-file store)', () => {
     const fp = path.join(tmpDir, 'agents-cli.bundles.work.enc');
     expect(fs.existsSync(fp)).toBe(true);
     const stat = fs.statSync(fp);
-    expect(stat.mode & 0o777).toBe(0o600);
+    // NTFS has no POSIX mode bits — the 0o600 lockdown is a no-op on Windows.
+    if (process.platform !== 'win32') expect(stat.mode & 0o777).toBe(0o600);
     const raw = fs.readFileSync(fp, 'utf8');
     expect(raw).not.toContain('FOO');
   });
@@ -247,7 +248,8 @@ describe('headless auto-provisioned passphrase (no env, locked keyring)', () => 
 
     const passFp = path.join(tmpDir, '.passphrase');
     expect(fs.existsSync(passFp)).toBe(true);
-    expect(fs.statSync(passFp).mode & 0o777).toBe(0o600);
+    // NTFS has no POSIX mode bits — the 0o600 lockdown is a no-op on Windows.
+    if (process.platform !== 'win32') expect(fs.statSync(passFp).mode & 0o777).toBe(0o600);
     // The on-disk item is ciphertext, not the plaintext value.
     const enc = fs.readFileSync(path.join(tmpDir, 'agents-cli.secrets.work.API_KEY.enc'), 'utf8');
     expect(enc).not.toContain('sk-headless-123');

--- a/src/lib/skills.test.ts
+++ b/src/lib/skills.test.ts
@@ -154,7 +154,7 @@ describe('removeSkillFromVersion — soft-delete', () => {
     expect(fs.existsSync(trashRoot)).toBe(false);
   });
 
-  it('creates trash directory with mode 0o700', () => {
+  it.skipIf(process.platform === 'win32')('creates trash directory with mode 0o700', () => {
     const home = makeTempHome();
     const agent = 'claude';
     const version = '2.0.0';
@@ -165,7 +165,7 @@ describe('removeSkillFromVersion — soft-delete', () => {
 
     const trashRoot = path.join(home, '.agents', '.history', 'trash', 'skills', agent, version, skillName);
     const stat = fs.statSync(trashRoot);
-    // 0o700 = owner rwx only
+    // 0o700 = owner rwx only. NTFS has no POSIX mode bits — POSIX-only assertion.
     expect(stat.mode & 0o777).toBe(0o700);
   });
 

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir, homedir } from 'os';
 import { buildJobCommand, extractReport } from '../src/lib/runner.js';
+import { toPosix } from '../src/lib/platform/index.js';
 import type { JobConfig } from '../src/lib/jobs.js';
 
 const TEST_DIR = join(tmpdir(), 'agents-cli-runner-test');
@@ -48,8 +49,10 @@ describe('buildJobCommand', () => {
         return acc;
       }, []);
       expect(addDirIndices.length).toBe(2);
-      expect(cmd[addDirIndices[0] + 1]).toBe(join(homedir(), 'projects/foo'));
-      expect(cmd[addDirIndices[1] + 1]).toBe(join(homedir(), 'reports'));
+      // The `~` expansion (os.homedir() + the rest of the entry) yields mixed
+      // separators on Windows; compare separator-agnostically.
+      expect(toPosix(cmd[addDirIndices[0] + 1])).toBe(toPosix(join(homedir(), 'projects/foo')));
+      expect(toPosix(cmd[addDirIndices[1] + 1])).toBe(toPosix(join(homedir(), 'reports')));
     });
 
     it('adds --model flag when config.model is set', () => {


### PR DESCRIPTION
## Workstream F — leaf modules

Turns the remaining WS-F leaf-module test failures green on the new `windows-latest` CI leg, with no regression on Linux/macOS.

### Source fixes (real Win32 bugs)
- **`project-launch.ts`** — the launch-sync sentinel slug embedded `C:\` (illegal `:` in an NTFS filename). Now derived via the canonical `toPortableKey` helper; byte-identical to the old `/`+` `→`_` slug on POSIX, legal on Windows.
- **`browser/runtime-state.ts`** — the pid-reuse defense shelled out to `ps`, which Windows lacks. Process-command lookup is now platform-aware: `tasklist /FO CSV` on Windows, `ps -o comm=` on POSIX.

### Test fixes (separator/mode-agnostic + POSIX-only guards)
- **secrets/linux, settings-manifest, skills** — guard exact `0o600`/`0o700` mode assertions behind a `win32` check (NTFS has no POSIX mode bits; the source `chmod`s are already no-ops there).
- **pty-server** — skip the unix-socket boot tests on `win32` (transport is a `\\.\pipe\` named pipe, not a stat-able inode).
- **drive-sync** — skip the `#!/bin/sh` fake-`rsync`/`ssh` tests on `win32` (tooling absent → ENOENT).
- **cloud/paths** — mirror `state.ts`'s `process.env.HOME ?? os.homedir()` instead of a bare `process.env.HOME!` (undefined on Windows → `path.join` throws).
- **runner** — compare `--add-dir` expansions separator-agnostically via `toPosix`.
- **project-launch** — compute the expected slug via `toPortableKey`.

### Verification
- `tsc` clean.
- All 156 tests across the 10 owned files pass on Linux (`vitest run`).
- The `windows-latest` CI leg on this PR is the cross-platform verifier.

Shared helpers (`toPortableKey`, `toPosix`) imported from `platform/index.js` — no edits to `platform/*`, `paths.ts`, or `state.ts`.