### PR TITLE
fix(win): versions/self-update/plugins

### DIFF
--- a/src/commands/__tests__/inspect.test.ts
+++ b/src/commands/__tests__/inspect.test.ts
@@ -7,7 +7,9 @@ import { spawnSync } from 'child_process';
 
 const repoRoot = process.cwd();
 const cliEntry = path.join(repoRoot, 'src', 'index.ts');
-const tsxBin = path.join(repoRoot, 'node_modules', '.bin', 'tsx');
+// Run tsx via `node node_modules/tsx/dist/cli.mjs`, not the .bin/tsx shim: on
+// Windows the shim is tsx.cmd, which spawnSync cannot exec without a shell.
+const tsxBin = path.join(repoRoot, 'node_modules', 'tsx', 'dist', 'cli.mjs');
 
 function mkdir(p: string): void {
   fs.mkdirSync(p, { recursive: true });
@@ -73,7 +75,7 @@ function makeFixture(): string {
 }
 
 function run(home: string, args: string[], cwd: string = home) {
-  return spawnSync(tsxBin, [cliEntry, ...args], {
+  return spawnSync(process.execPath, [tsxBin, cliEntry, ...args], {
     cwd,
     env: {
       ...process.env,
@@ -148,7 +150,7 @@ describe('agents inspect', () => {
     expect(data.version).toBe('9.9.9');
     expect(data.default).toBe(true);
     expect(data.home).toContain(path.join('versions', 'claude', '9.9.9', 'home'));
-    expect(data.shim).toContain('shims/claude');
+    expect(data.shim).toContain(path.join('shims', 'claude'));
     expect(data.alias).toContain('claude@9.9.9');
     expect(data.strategy).toBe('balanced');
     expect(data.capabilities.skills.ok).toBe(true);
@@ -176,7 +178,7 @@ describe('agents inspect', () => {
     expect(names).toContain('release');
     const demo = (data.items as Array<{ name: string; path: string }>).find(i => i.name === 'demo-skill');
     // For bundled skills, path is the skill directory.
-    expect(demo?.path).toMatch(/skills\/demo-skill$/);
+    expect(demo?.path).toMatch(/skills[\\/]demo-skill$/);
   });
 
   it('--skills <typo> resolves via fuzzy match; bogus query exits 1 with suggestions', () => {

--- a/src/lib/plugins.test.ts
+++ b/src/lib/plugins.test.ts
@@ -6,6 +6,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { toPosix } from './platform/index.js';
 
 import {
   loadPluginManifest,
@@ -713,7 +714,7 @@ describe('installPlugin validation', () => {
     // as a git flag; the metacharacters above are inert in argv form.
     expect(args.slice(0, 4)).toEqual(['clone', '--depth', '1', '--']);
     expect(args[4]).toBe(source);
-    expect(args[5]).toMatch(/\/safe$/);
+    expect(toPosix(args[5])).toMatch(/\/safe$/);
     expect(opts).toEqual({ stdio: 'pipe' });
   });
 

--- a/src/lib/sandbox.ts
+++ b/src/lib/sandbox.ts
@@ -13,6 +13,7 @@ import * as os from 'os';
 import type { JobConfig } from './routines.js';
 import { setGeminiAutoUpdateDisabled, updateGeminiSettings } from './gemini-settings.js';
 import { getRoutinesDir, getUserAgentsDir } from './state.js';
+import { createLink } from './platform/index.js';
 
 function resolveRealHome(): string {
   const home = os.homedir();
@@ -146,8 +147,10 @@ export function symlinkAllowedDirs(overlayHome: string, dirs: string[]): void {
 
     if (!fs.existsSync(symlinkTarget)) {
       try {
-        fs.symlinkSync(realPath, symlinkTarget);
-      } catch { /* symlink already exists */ }
+        // createLink uses a junction for directories on Windows (no elevation),
+        // a plain symlink on POSIX — allowed dirs are directories.
+        createLink(realPath, symlinkTarget);
+      } catch { /* link already exists or refused */ }
     }
   }
 }

--- a/src/lib/self-update.test.ts
+++ b/src/lib/self-update.test.ts
@@ -3,6 +3,7 @@ import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { needsWindowsShell, toPosix } from './platform/index.js';
 import {
   bunGlobalDir,
   deriveGlobalPrefix,
@@ -34,17 +35,19 @@ afterEach(() => {
 describe('deriveGlobalPrefix', () => {
   it('resolves the POSIX npm global layout (<prefix>/lib/node_modules/<scoped pkg>)', () => {
     const root = path.join('/Users/x/.nvm/versions/node/v24.15.0', 'lib', 'node_modules', '@phnx-labs', 'agents-cli');
-    expect(deriveGlobalPrefix(root)).toBe('/Users/x/.nvm/versions/node/v24.15.0');
+    // path.resolve so the expected carries a drive on Windows, matching the
+    // function's own path.resolve of the input.
+    expect(deriveGlobalPrefix(root)).toBe(path.resolve('/Users/x/.nvm/versions/node/v24.15.0'));
   });
 
   it('resolves the Windows npm global layout (<prefix>/node_modules/<scoped pkg>)', () => {
     const root = path.join('/x/npm-prefix', 'node_modules', '@phnx-labs', 'agents-cli');
-    expect(deriveGlobalPrefix(root)).toBe('/x/npm-prefix');
+    expect(deriveGlobalPrefix(root)).toBe(path.resolve('/x/npm-prefix'));
   });
 
   it('resolves the dev-install prefix used by scripts/install.sh', () => {
     const root = path.join('/Users/x/.local/agents-cli-dev', 'lib', 'node_modules', '@phnx-labs', 'agents-cli');
-    expect(deriveGlobalPrefix(root)).toBe('/Users/x/.local/agents-cli-dev');
+    expect(deriveGlobalPrefix(root)).toBe(path.resolve('/Users/x/.local/agents-cli-dev'));
   });
 
   it('throws for a source checkout that is not under node_modules', () => {
@@ -64,7 +67,7 @@ describe('detectPackageManager', () => {
   it('detects bun from the BUN_INSTALL global layout (no lib segment)', () => {
     process.env.BUN_INSTALL = '/Users/x/.bun';
     const root = path.join(bunGlobalDir(), 'node_modules', '@phnx-labs', 'agents-cli');
-    expect(root).toBe('/Users/x/.bun/install/global/node_modules/@phnx-labs/agents-cli');
+    expect(toPosix(root)).toBe('/Users/x/.bun/install/global/node_modules/@phnx-labs/agents-cli');
     expect(detectPackageManager(root)).toBe('bun');
   });
 
@@ -138,7 +141,11 @@ describe('installPackageIntoPrefix', () => {
       path.join(src, 'package.json'),
       JSON.stringify({ name: '@agents-cli-test/dummy', version, license: 'MIT' }),
     );
-    const tarball = execFileSync('npm', ['pack', '--silent'], { cwd: src, encoding: 'utf-8' }).trim();
+    const tarball = execFileSync('npm', ['pack', '--silent'], {
+      cwd: src,
+      encoding: 'utf-8',
+      shell: needsWindowsShell('npm'),
+    }).trim();
     return path.join(src, tarball);
   }
 
@@ -230,7 +237,10 @@ describe('update-check cache', () => {
   });
 });
 
-describe('findAgentsCliInstalls', () => {
+// findAgentsCliInstalls is POSIX-only (Windows npm bins are .cmd wrappers, not
+// symlinks — the function returns [] on win32), and the fixtures here create
+// symlinks that need Developer Mode on Windows. Skip the whole block there.
+describe.skipIf(process.platform === 'win32')('findAgentsCliInstalls', () => {
   /** Lay out an npm-global-shaped install and a bin dir whose `agents` symlinks into it. */
   function makeInstall(base: string, name: string, version: string, pkgName = '@phnx-labs/agents-cli') {
     const packageRoot = path.join(base, name, 'lib', 'node_modules', ...pkgName.split('/'));

--- a/src/lib/self-update.ts
+++ b/src/lib/self-update.ts
@@ -17,6 +17,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { spawnSync } from 'child_process';
 import { compareVersions } from './versions.js';
+import { needsWindowsShell } from './platform/index.js';
 
 export const NPM_PACKAGE_NAME = '@phnx-labs/agents-cli';
 
@@ -166,7 +167,10 @@ export async function installPackageIntoPrefix(spec: string, prefix: string): Pr
   const { execFile } = await import('child_process');
   const { promisify } = await import('util');
   const execFileAsync = promisify(execFile);
-  await execFileAsync('npm', ['install', '-g', '--prefix', prefix, spec, '--ignore-scripts']);
+  // On Windows `npm` is `npm.cmd`; execFile cannot run it without a shell (ENOENT).
+  await execFileAsync('npm', ['install', '-g', '--prefix', prefix, spec, '--ignore-scripts'], {
+    shell: needsWindowsShell('npm'),
+  });
 }
 
 /**
@@ -181,7 +185,8 @@ export async function installPackageWithBun(spec: string): Promise<void> {
   const { execFile } = await import('child_process');
   const { promisify } = await import('util');
   const execFileAsync = promisify(execFile);
-  await execFileAsync('bun', ['add', '-g', spec]);
+  // On Windows `bun` resolves to `bun.exe`/`bun.cmd`; force shell for the .cmd case.
+  await execFileAsync('bun', ['add', '-g', spec], { shell: needsWindowsShell('bun') });
 }
 
 /** Read the version field of the package.json at `packageRoot`, fresh from disk. */

--- a/src/lib/versions.test.ts
+++ b/src/lib/versions.test.ts
@@ -23,8 +23,12 @@ function runVersionSync(home: string, expression: string): unknown {
   // tsx (Node) — not bun. The CLI ships against Node, and `versions.ts`
   // transitively imports the SQLite layer that this test exercises.
   const moduleUrl = pathToFileURL(path.resolve('src/lib/versions.ts')).href;
-  const tsxBin = path.resolve('node_modules/.bin/tsx');
-  const child = spawnSync(tsxBin, ['-e', `
+  // Run tsx via `node node_modules/tsx/dist/cli.mjs` (not the .bin/tsx shim): on
+  // Windows the shim is tsx.cmd, which spawnSync cannot exec without a shell, and
+  // routing the multi-line `-e` script through cmd.exe would mangle it. node is an
+  // .exe everywhere, so this is shell-free and cross-platform.
+  const tsxBin = path.resolve('node_modules/tsx/dist/cli.mjs');
+  const child = spawnSync(process.execPath, [tsxBin, '-e', `
     import { listInstalledVersions, syncResourcesToVersion } from ${JSON.stringify(moduleUrl)};
     const home = ${JSON.stringify(home)};
     const result = ${expression};
@@ -42,8 +46,12 @@ function runReconcile(home: string, agent: string, installedVersion: string): st
   // tsx (Node) subprocess with an isolated HOME — exercises the real fs +
   // session-db path that reconcileStaleLatestDir touches, no mocking.
   const moduleUrl = pathToFileURL(path.resolve('src/lib/versions.ts')).href;
-  const tsxBin = path.resolve('node_modules/.bin/tsx');
-  const child = spawnSync(tsxBin, ['-e', `
+  // Run tsx via `node node_modules/tsx/dist/cli.mjs` (not the .bin/tsx shim): on
+  // Windows the shim is tsx.cmd, which spawnSync cannot exec without a shell, and
+  // routing the multi-line `-e` script through cmd.exe would mangle it. node is an
+  // .exe everywhere, so this is shell-free and cross-platform.
+  const tsxBin = path.resolve('node_modules/tsx/dist/cli.mjs');
+  const child = spawnSync(process.execPath, [tsxBin, '-e', `
     import { reconcileStaleLatestDir } from ${JSON.stringify(moduleUrl)};
     (async () => {
       const result = await reconcileStaleLatestDir(${JSON.stringify(agent)}, ${JSON.stringify(installedVersion)});
@@ -321,8 +329,12 @@ describe('version resource sync path handling', () => {
 // version can never escape into a shell.
 function runInstallVersion(home: string, agent: string, version: string): { ok: boolean; error?: string } {
   const moduleUrl = pathToFileURL(path.resolve('src/lib/versions.ts')).href;
-  const tsxBin = path.resolve('node_modules/.bin/tsx');
-  const child = spawnSync(tsxBin, ['-e', `
+  // Run tsx via `node node_modules/tsx/dist/cli.mjs` (not the .bin/tsx shim): on
+  // Windows the shim is tsx.cmd, which spawnSync cannot exec without a shell, and
+  // routing the multi-line `-e` script through cmd.exe would mangle it. node is an
+  // .exe everywhere, so this is shell-free and cross-platform.
+  const tsxBin = path.resolve('node_modules/tsx/dist/cli.mjs');
+  const child = spawnSync(process.execPath, [tsxBin, '-e', `
     import { installVersion } from ${JSON.stringify(moduleUrl)};
     (async () => {
       try {
@@ -382,8 +394,12 @@ describe('installVersion version validation', () => {
 // dirs, so a fixture is just N dirs + one binary — every dir reads as installed.
 function runResolveAlias(home: string, agent: string, raw: string | undefined): string | null {
   const moduleUrl = pathToFileURL(path.resolve('src/lib/versions.ts')).href;
-  const tsxBin = path.resolve('node_modules/.bin/tsx');
-  const child = spawnSync(tsxBin, ['-e', `
+  // Run tsx via `node node_modules/tsx/dist/cli.mjs` (not the .bin/tsx shim): on
+  // Windows the shim is tsx.cmd, which spawnSync cannot exec without a shell, and
+  // routing the multi-line `-e` script through cmd.exe would mangle it. node is an
+  // .exe everywhere, so this is shell-free and cross-platform.
+  const tsxBin = path.resolve('node_modules/tsx/dist/cli.mjs');
+  const child = spawnSync(process.execPath, [tsxBin, '-e', `
     import { resolveVersionAlias } from ${JSON.stringify(moduleUrl)};
     const r = resolveVersionAlias(${JSON.stringify(agent)}, ${JSON.stringify(raw ?? null)});
     console.log(JSON.stringify({ v: r === undefined ? null : r }));

--- a/tests/cli-command-sync-spec.test.ts
+++ b/tests/cli-command-sync-spec.test.ts
@@ -33,6 +33,7 @@ import {
   shouldInstallCommandAsSkill,
   installCommandSkillToVersion,
 } from '../src/lib/command-skills.js';
+import { toPosix } from '../src/lib/platform/index.js';
 
 type FormatKind =
   | 'markdown-flat'
@@ -153,10 +154,12 @@ describe('CLI command sync: registry-vs-docs conformance', () => {
           if (fmt.kind === 'skill-dir') {
             const skillsDir = reg.skillsDir ?? '';
             const docDirPrefix = expectedPath.replace(/\/[^/]+\/SKILL\.md$/, '');
+            // Registry paths use path.join (backslash on Windows); doc templates
+            // use forward slashes. Compare separator-agnostically.
             expect(
-              skillsDir,
+              toPosix(skillsDir),
               `Docs say ${id}${tag} skills live at ${docDirPrefix}/<name>/SKILL.md; registry has skillsDir=${skillsDir}.${banner}`,
-            ).toBe(docDirPrefix);
+            ).toBe(toPosix(docDirPrefix));
           } else if (fmt.kind === 'markdown-flat' || fmt.kind === 'toml-flat') {
             // Use the registry's real configDir as the write base — NOT a
             // hardcoded `.${id}`, which is wrong for agents whose config dir is
@@ -166,9 +169,9 @@ describe('CLI command sync: registry-vs-docs conformance', () => {
             const regPath = path.join(agentDir, reg.commandsSubdir ?? '', `name.${fmt.kind === 'toml-flat' ? 'toml' : 'md'}`);
             const docPathPattern = expectedPath.replace('{name}', 'name');
             expect(
-              regPath,
+              toPosix(regPath),
               `Docs say ${id}${tag} writes to ${docPathPattern}; registry would write to ${regPath}.${banner}`,
-            ).toBe(docPathPattern);
+            ).toBe(toPosix(docPathPattern));
           }
         });
       }

--- a/tests/versions.test.ts
+++ b/tests/versions.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { IS_WINDOWS, toPosix } from '../src/lib/platform/index.js';
 
 // Mock state.ts to redirect all paths to temp directory. Stash mutable
 // override state on globalThis instead of a top-level const — vitest 4
@@ -648,12 +649,12 @@ describe('version path helpers', () => {
 
   it('getBinaryPath returns correct binary location', () => {
     const bin = getBinaryPath('claude', '2.0.65');
-    expect(bin).toContain('node_modules/.bin/claude');
+    expect(toPosix(bin)).toContain('node_modules/.bin/claude');
   });
 
   it('getVersionHomePath returns home subdir', () => {
     const home = getVersionHomePath('claude', '2.0.65');
-    expect(home.endsWith('/home')).toBe(true);
+    expect(toPosix(home).endsWith('/home')).toBe(true);
   });
 });
 
@@ -1021,9 +1022,13 @@ describe('syncResourcesToVersion', () => {
       const hookFile = path.join(versionHome, '.claude', 'hooks', 'pre-commit.sh');
       expect(result.hooks).toBe(true);
       expect(fs.existsSync(hookFile)).toBe(true);
-      // Check executable permission
-      const stat = fs.statSync(hookFile);
-      expect(stat.mode & 0o111).toBeGreaterThan(0); // has execute bits
+      // Check executable permission — Windows has no POSIX exec bit (statSync
+      // mode does not carry 0o111), so the copy preserving it is only
+      // observable on POSIX.
+      if (!IS_WINDOWS) {
+        const stat = fs.statSync(hookFile);
+        expect(stat.mode & 0o111).toBeGreaterThan(0); // has execute bits
+      }
     });
 
     it('skips hooks for codex versions below minimum floor', () => {


### PR DESCRIPTION
Windows-port workstream E: turn Windows CI failures green for version management, self-update, plugins, sandbox, and inspect.

## Source fixes (real Win32 bugs)
- **self-update.ts** — `installPackageIntoPrefix` / `installPackageWithBun` route through `needsWindowsShell()` so the npm/bun install can run (`npm` is `npm.cmd` on Windows; bare `execFile` ENOENTs).
- **sandbox.ts** — `symlinkAllowedDirs` links via `createLink()` (junction for directories on Windows, no elevation) instead of a bare `fs.symlinkSync` of a directory, which requires Developer Mode. Fixes the dangling/dir-symlink case asserted in `bugfixes.test.ts`.

## Test fixes (separator / mode / spawn agnostic)
- **versions.test.ts, inspect.test.ts** — run tsx via `node node_modules/tsx/dist/cli.mjs` instead of the `.bin/tsx` shim. On Windows that shim is `tsx.cmd`, which `spawnSync` cannot exec without a shell, and routing the multi-line `-e` script through `cmd.exe` would mangle it. `node` is an `.exe` everywhere, so this is shell-free. This was the root cause behind "the version-dir scanner cannot find installed versions" — the subprocess never ran.
- **path assertions** — compare via `toPosix()` (or build the expected with `path.join`) so backslash paths match forward-slash docs (`tests/versions.test.ts`, `inspect.test.ts`, `cli-command-sync-spec.test.ts`, `plugins.test.ts`, `self-update.test.ts`).
- **exec-bit check** — guard the `stat.mode & 0o111` assertion with `IS_WINDOWS` (Windows has no POSIX exec bit).
- **findAgentsCliInstalls** — `describe.skipIf(win32)` (POSIX-only: Windows npm bins are `.cmd` wrappers, not symlinks; the function returns `[]` there).

## Verification
- All 7 owned test files green on Linux: 283 passed, 22 skipped.
- Sandbox tests (another workstream's) still green after the source change: 34 passed.
- `tsc --noEmit` clean.
- The windows-latest CI leg is the verifier.

No changes to `platform/*`, `paths.ts`, `state.ts`, `mcp.ts`, or `agents.ts`.