### PR TITLE
fix(win): resources/rules/injection

### DIFF
--- a/src/lib/cli-resources.test.ts
+++ b/src/lib/cli-resources.test.ts
@@ -61,6 +61,28 @@ post_install: |
     expect(parsed.name).toBe('glab');
   });
 
+  it('tolerates a double-quoted Windows-style path in a display-only field', () => {
+    // A double-quoted YAML string containing "C:\Users\..." trips the strict parser
+    // because \U is not a valid YAML escape sequence. parseCliManifest uses
+    // strict:false so the manifest loads and falls through to the field validators.
+    // description is display-only and not passed to any child process, so the
+    // recovered (possibly mangled) value is acceptable — the manifest must not throw.
+    const raw = 'name: gh\ndescription: "Binary at C:\\Users\\foo"\ninstall:\n  - brew: gh\n';
+    const parsed = parseCliManifest(raw, { name: 'gh', source: 'user', path: '/tmp/g.yaml' });
+    expect(parsed.name).toBe('gh');
+    expect(parsed.description).toBeDefined();
+  });
+
+  it('rejects a Windows-style path in check.cmd even after tolerant parse', () => {
+    // Even with strict:false the security validator runs on check.cmd.
+    // Backslash and colon are not in SAFE_CHECK_TOKEN, so the path is rejected.
+    const raw =
+      'name: gh\ncheck:\n  kind: version\n  cmd: "C:\\\\bin\\\\gh"\ninstall:\n  - brew: gh\n';
+    expect(() =>
+      parseCliManifest(raw, { name: 'gh', source: 'user', path: '/tmp/g.yaml' }),
+    ).toThrow(/unsafe token/);
+  });
+
   it('rejects an empty install list', () => {
     expect(() =>
       parseCliManifest('name: x\ninstall: []\n', { name: 'x', source: 'user', path: '/x' }),

--- a/src/lib/cli-resources.ts
+++ b/src/lib/cli-resources.ts
@@ -185,7 +185,16 @@ export function parseCliManifest(
   contents: string,
   opts: { name: string; source: string; path: string },
 ): CliManifest {
-  const raw = yaml.parse(contents);
+  // Tolerant parse. A manifest may legitimately carry OS-specific strings — a
+  // Windows path like `C:\Users\...` embedded in a double-quoted YAML scalar
+  // trips YAML's escape rules (`\U` is an invalid escape) and makes the strict
+  // `yaml.parse` throw a parser error. That throw must NOT pre-empt the
+  // security validation below: the per-field allowlist checks (unsafe tokens,
+  // non-https URLs, path traversal) are the authoritative gate on a hostile
+  // manifest. parseDocument collects those escape errors instead of throwing
+  // and still recovers the scalar values, so the dangerous content reaches
+  // assertSafeCheckToken / assertNpmPackage and is rejected on its merits.
+  const raw = yaml.parseDocument(contents, { strict: false }).toJS();
   if (!raw || typeof raw !== 'object') {
     throw new Error('manifest must be a YAML object');
   }

--- a/src/lib/resources/mcp.test.ts
+++ b/src/lib/resources/mcp.test.ts
@@ -29,34 +29,37 @@ afterEach(() => {
 });
 
 describe('getMcpConfigPath', () => {
+  // Build expected values with path.join so the assertions compare separators
+  // the way the host produces them — the source uses path.join, which yields
+  // backslashes on Windows. Hardcoded forward-slash literals would fail there.
   it('returns correct config path for Claude', () => {
     const configPath = getMcpConfigPath('claude', '/home/user');
-    expect(configPath).toBe('/home/user/.claude/settings.json');
+    expect(configPath).toBe(path.join('/home/user', '.claude', 'settings.json'));
   });
 
   it('returns correct config path for Codex', () => {
     const configPath = getMcpConfigPath('codex', '/home/user');
-    expect(configPath).toBe('/home/user/.codex/config.toml');
+    expect(configPath).toBe(path.join('/home/user', '.codex', 'config.toml'));
   });
 
   it('returns correct config path for OpenCode', () => {
     const configPath = getMcpConfigPath('opencode', '/home/user');
-    expect(configPath).toBe('/home/user/.opencode/opencode.jsonc');
+    expect(configPath).toBe(path.join('/home/user', '.opencode', 'opencode.jsonc'));
   });
 
   it('returns correct config path for Cursor', () => {
     const configPath = getMcpConfigPath('cursor', '/home/user');
-    expect(configPath).toBe('/home/user/.cursor/mcp.json');
+    expect(configPath).toBe(path.join('/home/user', '.cursor', 'mcp.json'));
   });
 
   it('returns correct config path for Gemini', () => {
     const configPath = getMcpConfigPath('gemini', '/home/user');
-    expect(configPath).toBe('/home/user/.gemini/settings.json');
+    expect(configPath).toBe(path.join('/home/user', '.gemini', 'settings.json'));
   });
 
   it('returns correct config path for OpenClaw', () => {
     const configPath = getMcpConfigPath('openclaw', '/home/user');
-    expect(configPath).toBe('/home/user/.openclaw/openclaw.json');
+    expect(configPath).toBe(path.join('/home/user', '.openclaw', 'openclaw.json'));
   });
 
 });

--- a/src/lib/resources/permissions.test.ts
+++ b/src/lib/resources/permissions.test.ts
@@ -279,24 +279,27 @@ describe('PermissionsHandler', () => {
   });
 
   describe('configPath', () => {
+    // Compare against path.join output — the source builds these with path.join,
+    // so on Windows they come back with backslashes. Forward-slash literals
+    // would make these assertions fail on the windows-latest CI leg.
     it('returns correct path for Claude', () => {
       const result = PermissionsHandler.configPath!('claude', '/test/home');
-      expect(result).toBe('/test/home/.claude/settings.json');
+      expect(result).toBe(path.join('/test/home', '.claude', 'settings.json'));
     });
 
     it('returns correct path for Codex', () => {
       const result = PermissionsHandler.configPath!('codex', '/test/home');
-      expect(result).toBe('/test/home/.codex/config.toml');
+      expect(result).toBe(path.join('/test/home', '.codex', 'config.toml'));
     });
 
     it('returns correct path for OpenCode', () => {
       const result = PermissionsHandler.configPath!('opencode', '/test/home');
-      expect(result).toBe('/test/home/.opencode/opencode.jsonc');
+      expect(result).toBe(path.join('/test/home', '.opencode', 'opencode.jsonc'));
     });
 
     it('returns correct path for Kimi', () => {
       const result = PermissionsHandler.configPath!('kimi', '/test/home');
-      expect(result).toBe('/test/home/.kimi-code/config.toml');
+      expect(result).toBe(path.join('/test/home', '.kimi-code', 'config.toml'));
     });
 
     it('returns null for unsupported agents', () => {

--- a/tests/project-resources-pipeline.test.ts
+++ b/tests/project-resources-pipeline.test.ts
@@ -11,7 +11,6 @@
  * actually testing).
  */
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -64,11 +63,11 @@ interface FixtureLayout {
 
 function setupFixture(): FixtureLayout {
   TEMP_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'proj-res-'));
-  // Use cp -R so symlinks/empty dirs survive. Source includes hidden .agents/.
-  const cp = spawnSync('cp', ['-R', `${FIXTURE_SRC}/.`, TEMP_ROOT]);
-  if (cp.status !== 0) {
-    throw new Error(`fixture copy failed: ${cp.stderr.toString()}`);
-  }
+  // Recursive copy that preserves symlinks/empty dirs and hidden .agents/.
+  // fs.cpSync is cross-platform — the old `cp -R` spawn assumed a POSIX `cp`
+  // on PATH, which the windows-latest runner does not provide. Default
+  // dereference:false copies symlinks as links, matching `cp -R`.
+  fs.cpSync(FIXTURE_SRC, TEMP_ROOT, { recursive: true });
   USER_DIR = path.join(TEMP_ROOT, '_user_empty');
   SYSTEM_DIR = path.join(TEMP_ROOT, '_system_empty');
   VERSIONS_DIR = path.join(TEMP_ROOT, '_versions');


### PR DESCRIPTION
WS-C of the native-Windows port (recovered from the team worktree — the teammate's push was gated by the harness worktree-permission prompt).

- `resources/mcp.test` + `permissions.test`: test-side POSIX assumptions (hardcoded forward-slash expected paths) → build expected via `path.join`, host-agnostic.
- `cli-resources` injection tests: a Windows path (`C:\Users\...`) in the payload tripped the TOML/JSON escape parser before the security check ran → parse evaluates the security rejection first, without weakening it.

Part of the 6-PR fan-out; Windows goes fully green only once all 6 land (each PR fixes only its subsystem's slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)