### PR TITLE
fix(release): allow cutting from a worktree (keep SHA-parity invariant)

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -75,7 +75,6 @@ fi
 
 # Must be on main, up to date with origin
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-[[ "$BRANCH" == "main" ]] || die "must be on main (currently on $BRANCH)"
 git fetch --quiet origin main
 LOCAL="$(git rev-parse HEAD)"
 REMOTE="$(git rev-parse origin/main)"


### PR DESCRIPTION
release.sh required the current branch be literally 'main', which no worktree can satisfy. Drop the branch-NAME check; keep working-tree-clean + LOCAL==REMOTE SHA parity (the real invariant: releasing exactly origin/main from any checkout).