### PR TITLE
fix(hooks): codex hooks never fired — wrong feature key + missing trust hash

### DIFF
--- a/src/lib/__tests__/hooks.test.ts
+++ b/src/lib/__tests__/hooks.test.ts
@@ -3,7 +3,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
-import { registerHooksToSettings, unmanagedHookNames } from '../hooks.js';
+import { registerHooksToSettings, unmanagedHookNames, computeCodexHookTrustHash } from '../hooks.js';
+import * as TOML from 'smol-toml';
 import { CODEX_HOOKS_MIN_VERSION } from '../agents.js';
 import { compareVersions } from '../versions.js';
 import type { ManifestHook } from '../types.js';
@@ -130,7 +131,7 @@ describe('registerHooksToSettings - Codex', () => {
     expect(groups[0].hooks[0].command).toBe(scriptPath);
   });
 
-  it('writes [features] codex_hooks = true to config.toml', () => {
+  it('writes [features] hooks = true to config.toml', () => {
     const versionHome = makeVersionHome();
     makeScript('on-prompt.sh');
 
@@ -144,7 +145,10 @@ describe('registerHooksToSettings - Codex', () => {
     expect(fs.existsSync(configPath)).toBe(true);
 
     const content = fs.readFileSync(configPath, 'utf-8');
-    expect(content).toContain('codex_hooks = true');
+    // Codex 0.116+ feature flag is `hooks`; the legacy `codex_hooks` name is
+    // an unrecognized key that Codex ignores with a deprecation error.
+    expect(content).toContain('hooks = true');
+    expect(content).not.toContain('codex_hooks');
   });
 
   it('preserves existing config.toml entries when enabling feature flag', () => {
@@ -161,8 +165,27 @@ describe('registerHooksToSettings - Codex', () => {
     registerHooksToSettings('codex', versionHome, manifest, agentsDir);
 
     const content = fs.readFileSync(configPath, 'utf-8');
-    expect(content).toContain('codex_hooks = true');
+    expect(content).toContain('hooks = true');
     expect(content).toContain('approval_policy');
+  });
+
+  it('migrates a stale [features] codex_hooks flag to hooks', () => {
+    const versionHome = makeVersionHome();
+    makeScript('on-prompt.sh');
+
+    // Simulate a config written by an older agents-cli build.
+    const configPath = path.join(versionHome, '.codex', 'config.toml');
+    fs.writeFileSync(configPath, '[features]\ncodex_hooks = true\n', 'utf-8');
+
+    const manifest: Record<string, ManifestHook> = {
+      'on-prompt': { script: 'on-prompt.sh', events: ['UserPromptSubmit'] },
+    };
+
+    registerHooksToSettings('codex', versionHome, manifest, agentsDir);
+
+    const content = fs.readFileSync(configPath, 'utf-8');
+    expect(content).toContain('hooks = true');
+    expect(content).not.toContain('codex_hooks');
   });
 
   it('does not duplicate managed hook entries on repeated calls', () => {
@@ -296,6 +319,129 @@ describe('registerHooksToSettings - Codex', () => {
       fs.readFileSync(path.join(versionHome, '.codex', 'hooks.json'), 'utf-8')
     );
     expect(hooksJson.hooks.UserPromptSubmit[0].hooks[0].command).toBe(scriptPath);
+  });
+
+  // Codex only runs a non-managed hook when it is enabled AND its trusted_hash
+  // in [hooks.state] matches the hash Codex recomputes. In `codex exec` mode
+  // there is no TUI prompt, so an untrusted hook is silently dropped — which is
+  // why agents-cli must pre-compute and persist the hash.
+  it('writes a [hooks.state] trusted_hash for each registered hook', () => {
+    const versionHome = makeVersionHome();
+    const scriptPath = makeScript('bash-tool-hook.sh');
+
+    const manifest: Record<string, ManifestHook> = {
+      'bash-hook': {
+        script: 'bash-tool-hook.sh',
+        events: ['PreToolUse'],
+        matcher: 'Bash',
+        timeout: 5,
+      },
+    };
+
+    registerHooksToSettings('codex', versionHome, manifest, agentsDir);
+
+    const hooksJsonPath = path.join(versionHome, '.codex', 'hooks.json');
+    const configPath = path.join(versionHome, '.codex', 'config.toml');
+    const config = TOML.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+    const state = (config.hooks as Record<string, unknown>).state as Record<
+      string,
+      { trusted_hash?: string; enabled?: boolean }
+    >;
+
+    const key = `${hooksJsonPath}:pre_tool_use:0:0`;
+    expect(state[key]).toBeDefined();
+    // The persisted hash must equal what Codex recomputes for this exact hook.
+    expect(state[key].trusted_hash).toBe(
+      computeCodexHookTrustHash('pre_tool_use', scriptPath, 5, 'Bash')
+    );
+    // Default-enabled: we must NOT write enabled = true (absence == enabled).
+    expect(state[key].enabled).toBeUndefined();
+  });
+
+  it('preserves a user-set enabled = false when rewriting the trust hash', () => {
+    const versionHome = makeVersionHome();
+    const scriptPath = makeScript('on-prompt.sh');
+
+    const manifest: Record<string, ManifestHook> = {
+      'on-prompt': { script: 'on-prompt.sh', events: ['UserPromptSubmit'] },
+    };
+
+    // First pass writes the trust hash.
+    registerHooksToSettings('codex', versionHome, manifest, agentsDir);
+    const configPath = path.join(versionHome, '.codex', 'config.toml');
+    const hooksJsonPath = path.join(versionHome, '.codex', 'hooks.json');
+    const key = `${hooksJsonPath}:user_prompt_submit:0:0`;
+
+    // User disables the hook from their side.
+    const config = TOML.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+    const state = (config.hooks as Record<string, unknown>).state as Record<
+      string,
+      { trusted_hash?: string; enabled?: boolean }
+    >;
+    state[key].enabled = false;
+    fs.writeFileSync(configPath, TOML.stringify(config as Parameters<typeof TOML.stringify>[0]), 'utf-8');
+
+    // Re-register; enabled = false must survive.
+    registerHooksToSettings('codex', versionHome, manifest, agentsDir);
+    const after = TOML.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+    const afterState = (after.hooks as Record<string, unknown>).state as Record<
+      string,
+      { trusted_hash?: string; enabled?: boolean }
+    >;
+    expect(afterState[key].enabled).toBe(false);
+    expect(afterState[key].trusted_hash).toBe(
+      computeCodexHookTrustHash('user_prompt_submit', scriptPath, 600, undefined)
+    );
+  });
+
+  // Ground-truth fixtures: these hashes were written into a real config.toml by
+  // the Codex 0.134.0 binary's own trust flow for these exact hook definitions.
+  // If canonicalization (key ordering, field omission, always-present
+  // `async:false`, TOML null-drop of an absent matcher) regresses, they break.
+  describe('computeCodexHookTrustHash — Codex 0.134.0 ground truth', () => {
+    const HOOK_DIR = '~/.agents/.history/versions/codex/0.134.0/home/.codex/hooks';
+
+    it('SessionStart metadata hook, no matcher', () => {
+      expect(
+        computeCodexHookTrustHash('session_start', `${HOOK_DIR}/04-capture-session-start-metadata.sh`, 5, undefined)
+      ).toBe('sha256:03b77fe0c51d19ec5438fd556ea783c70843f7ae24c1c640a190d3bfce70ea56');
+    });
+
+    it('PreToolUse git-guard, matcher "Bash"', () => {
+      expect(computeCodexHookTrustHash('pre_tool_use', `${HOOK_DIR}/git-guard.sh`, 5, 'Bash')).toBe(
+        'sha256:a5996ca377f7bd87d23d062ab6b7a8aef4745b9400c8da6a475009ec8096c6f1'
+      );
+    });
+
+    it('PreToolUse rm-guard, matcher "Bash"', () => {
+      expect(computeCodexHookTrustHash('pre_tool_use', `${HOOK_DIR}/rm-guard.sh`, 5, 'Bash')).toBe(
+        'sha256:f840a97db8c64eb46d0eef3d37ebc98a409c12e6bdbf73f19442d02543223d34'
+      );
+    });
+
+    it('PreToolUse large-file-add-guard, matcher "Bash"', () => {
+      expect(
+        computeCodexHookTrustHash('pre_tool_use', `${HOOK_DIR}/large-file-add-guard.sh`, 5, 'Bash')
+      ).toBe('sha256:a5c51bb0d1ad496a102de8ea2b88a9a4f5fed80ddab8f388691e9f45529d38d0');
+    });
+
+    it('treats an empty-string matcher the same as no matcher (TOML null-drop)', () => {
+      expect(computeCodexHookTrustHash('session_start', `${HOOK_DIR}/x.sh`, 5, '')).toBe(
+        computeCodexHookTrustHash('session_start', `${HOOK_DIR}/x.sh`, 5, undefined)
+      );
+    });
+
+    it('is matcher-sensitive', () => {
+      expect(computeCodexHookTrustHash('pre_tool_use', `${HOOK_DIR}/git-guard.sh`, 5, 'Bash')).not.toBe(
+        computeCodexHookTrustHash('pre_tool_use', `${HOOK_DIR}/git-guard.sh`, 5, 'Read')
+      );
+    });
+
+    it('normalizes a sub-1 timeout to 1 (Codex: unwrap_or(600).max(1))', () => {
+      expect(computeCodexHookTrustHash('session_start', `${HOOK_DIR}/x.sh`, 0, undefined)).toBe(
+        computeCodexHookTrustHash('session_start', `${HOOK_DIR}/x.sh`, 1, undefined)
+      );
+    });
   });
 });
 

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -8,6 +8,7 @@
  * and syncing them across version switches.
  */
 
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -886,6 +887,79 @@ type CodexHooksFile = {
   hooks: Record<string, CodexMatcherGroup[]>;
 };
 
+// Maps PascalCase hook event names (as written in hooks.json) to the
+// snake_case labels Codex uses in its persisted [hooks.state] keys.
+// Mirrors hook_event_key_label() in codex-rs/hooks/src/lib.rs.
+const CODEX_EVENT_KEY_LABELS: Record<string, string> = {
+  PreToolUse: 'pre_tool_use',
+  PermissionRequest: 'permission_request',
+  PostToolUse: 'post_tool_use',
+  PreCompact: 'pre_compact',
+  PostCompact: 'post_compact',
+  SessionStart: 'session_start',
+  UserPromptSubmit: 'user_prompt_submit',
+  SubagentStart: 'subagent_start',
+  SubagentStop: 'subagent_stop',
+  Stop: 'stop',
+};
+
+// Recursively sort object keys alphabetically at every level, mirroring
+// canonical_json() in codex-rs/config/src/fingerprint.rs. Codex hashes the
+// canonical JSON form so trust survives key-order differences.
+function canonicalizeForHash(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalizeForHash);
+  }
+  if (value && typeof value === 'object') {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      sorted[key] = canonicalizeForHash((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+/**
+ * Compute the trust hash Codex expects for a single command hook handler, so
+ * agents-cli can pre-trust the hooks it registers. Without a matching
+ * trusted_hash in [hooks.state], Codex classifies the hook Untrusted and
+ * silently drops it in non-interactive (`codex exec`) mode where there is no
+ * TUI prompt to approve it.
+ *
+ * Mirrors command_hook_hash() in codex-rs/hooks/src/engine/discovery.rs +
+ * version_for_toml() in codex-rs/config/src/fingerprint.rs:
+ *   sha256( canonicalJson( NormalizedHookIdentity ) ) prefixed with "sha256:".
+ *
+ * The identity passes through TOML on the Codex side, which drops None fields
+ * (commandWindows, statusMessage, and matcher when absent). `async` is always
+ * false (async hooks are not yet supported) and is always present. `timeout`
+ * is normalized to >= 1 (Codex: unwrap_or(600).max(1)).
+ */
+export function computeCodexHookTrustHash(
+  eventKeyLabel: string,
+  command: string,
+  timeout: number,
+  matcher: string | undefined
+): string {
+  const handler: Record<string, unknown> = {
+    type: 'command',
+    command,
+    timeout: Math.max(timeout, 1),
+    async: false,
+  };
+  const identity: Record<string, unknown> = {
+    event_name: eventKeyLabel,
+    hooks: [handler],
+  };
+  if (matcher !== undefined && matcher !== '') {
+    identity.matcher = matcher;
+  }
+  const canonical = canonicalizeForHash(identity);
+  const hex = crypto.createHash('sha256').update(JSON.stringify(canonical), 'utf-8').digest('hex');
+  return `sha256:${hex}`;
+}
+
 /**
  * Register hooks as lifecycle events in an agent's config.
  * Reads hooks.yaml manifest, merges into the agent's config file(s).
@@ -1246,7 +1320,11 @@ function registerHooksForCodex(
     return { registered, errors };
   }
 
-  // Ensure [features] codex_hooks = true in config.toml
+  // Ensure [features] hooks = true and pre-trust every registered hook in
+  // config.toml. Codex only runs hooks that are enabled AND trusted; in
+  // non-interactive (`codex exec`) mode there is no TUI prompt to approve
+  // them, so an untrusted hook is silently dropped. We compute the same
+  // trust hash Codex would and persist it under [hooks.state].
   try {
     let tomlConfig: Record<string, unknown> = {};
     if (fs.existsSync(configPath)) {
@@ -1258,7 +1336,62 @@ function registerHooksForCodex(
     if (!tomlConfig.features || typeof tomlConfig.features !== 'object') {
       tomlConfig.features = {};
     }
-    (tomlConfig.features as Record<string, unknown>).codex_hooks = true;
+    // Codex 0.116+ feature flag is `hooks` (the legacy `codex_hooks` name is
+    // an unrecognized key that triggers a deprecation error and is ignored).
+    const features = tomlConfig.features as Record<string, unknown>;
+    delete features.codex_hooks;
+    features.hooks = true;
+
+    // Pre-trust hooks. The [hooks.state] key is keyed by the hooks.json path
+    // exactly as Codex resolves it (the absolute CODEX_HOME path), the
+    // snake_case event label, and the per-event group/handler indices — which
+    // must match Codex's parse order, so we iterate the just-written
+    // hooksFile structure in array order.
+    if (!tomlConfig.hooks || typeof tomlConfig.hooks !== 'object') {
+      tomlConfig.hooks = {};
+    }
+    const hooksTable = tomlConfig.hooks as Record<string, unknown>;
+    const existingState =
+      hooksTable.state && typeof hooksTable.state === 'object'
+        ? (hooksTable.state as Record<string, { enabled?: boolean; trusted_hash?: string }>)
+        : {};
+    const hookState: Record<string, { enabled?: boolean; trusted_hash?: string }> = {};
+
+    for (const [event, eventGroups] of Object.entries(hooksFile.hooks)) {
+      const eventKeyLabel = CODEX_EVENT_KEY_LABELS[event];
+      if (!eventKeyLabel) continue;
+      eventGroups.forEach((group, groupIdx) => {
+        if (!group.hooks) return;
+        group.hooks.forEach((handler, handlerIdx) => {
+          if (handler.type !== 'command') return;
+          const key = `${hooksPath}:${eventKeyLabel}:${groupIdx}:${handlerIdx}`;
+          const trustedHash = computeCodexHookTrustHash(
+            eventKeyLabel,
+            handler.command,
+            handler.timeout,
+            group.matcher
+          );
+          // Preserve a user's explicit `enabled = false` for this exact hook;
+          // only (re)write the trust hash.
+          const prior = existingState[key];
+          const entry: { enabled?: boolean; trusted_hash?: string } = { trusted_hash: trustedHash };
+          if (prior && prior.enabled === false) {
+            entry.enabled = false;
+          }
+          hookState[key] = entry;
+        });
+      });
+    }
+
+    // Carry forward trust state for any hooks we did not (re)register this
+    // pass — e.g. user-added hooks under a different command path.
+    for (const [key, entry] of Object.entries(existingState)) {
+      if (!(key in hookState)) {
+        hookState[key] = entry;
+      }
+    }
+
+    hooksTable.state = hookState;
 
     fs.writeFileSync(configPath, TOML.stringify(tomlConfig as Parameters<typeof TOML.stringify>[0]), 'utf-8');
   } catch (err) {


### PR DESCRIPTION
## Root cause

`registerHooksForCodex` ([`src/lib/hooks.ts`](https://github.com/phnx-labs/agents-cli/blob/main/src/lib/hooks.ts)) wrote hooks.json correctly but config.toml was wrong in two ways, so **no Codex hook ever fired in `codex exec` mode**:

1. **Wrong feature flag.** It wrote `[features] codex_hooks = true`. Codex 0.116+ renamed the flag to `hooks`; `codex_hooks` is an unrecognized key that Codex ignores and reports as deprecated. The only TOML key alias Codex ships (`codex-rs/config/src/key_aliases.rs`) is unrelated, so the flag never took effect by that name.

2. **No trust hash.** It never wrote a `[hooks.state]` entry, so every hook was classified `Untrusted`. Codex's discovery engine (`codex-rs/hooks/src/engine/discovery.rs`) only runs a hook when it is enabled **and** `bypass_hook_trust || Trusted || Managed`. In non-interactive `codex exec` mode there is no TUI prompt to approve hooks, so untrusted hooks were silently dropped.

## The fix (two edits in `registerHooksForCodex`)

1. Write `[features] hooks = true`, and delete any stale `codex_hooks` key (migrates configs written by older builds).
2. Compute and persist a `trusted_hash` for every registered hook under `[hooks.state]`, keyed exactly as Codex expects: `"{hooksJsonPath}:{event_snake_case}:{groupIdx}:{handlerIdx}"`. We do **not** write `enabled = true` (absence already means enabled) and we preserve a user's explicit `enabled = false`.

### Hash algorithm (reverse-engineered + verified)

Mirrors `command_hook_hash()` (`discovery.rs`) + `version_for_toml()` (`fingerprint.rs`):

```
sha256( canonicalJSON( NormalizedHookIdentity ) )  →  "sha256:<hex>"
```

where the identity is `{ event_name, hooks: [{ async:false, command, timeout, type:"command" }], matcher? }`, keys are alpha-sorted at every level, and absent/None fields (matcher when empty, commandWindows, statusMessage) are dropped — the identity passes through TOML on Codex's side, and TOML has no null. `timeout` is normalized to `max(timeout, 1)`.

## Tests

`src/lib/__tests__/hooks.test.ts`:
- Updated the two stale assertions (`codex_hooks = true` → `hooks = true`) and added a migration test.
- New regression tests assert `computeCodexHookTrustHash` reproduces **three hashes the real Codex 0.134.0 binary wrote** for its own hooks (`git-guard` `a5996ca3…`, `rm-guard` `f840a97d…`, `large-file-add-guard` `a5c51bb0…`). These are the canary for any canonicalization regression.
- New tests for the `[hooks.state]` write path and `enabled = false` preservation.

Full suite green (242 files; the one flaky failure was a network `npm 404` in an install test, unrelated).

## End-to-end proof

Registered a SessionStart hook through the **patched compiled code path** (`registerHooksToSettings('codex', …)`), then ran the intact Codex **0.134.0** binary with `codex exec` and **no `--dangerously-bypass-hook-trust` flag** — trust came purely from the agents-cli-written hash:

```
$ codex exec -m gpt-5.5 --skip-git-repo-check --json "echo e2e_patched_codepath"
{"type":"thread.started", ...}
{"type":"turn.completed", ...}

Sentinel created: YES
Hook log: Mon Jun 29 04:07:25 PDT 2026
```

config.toml written by the patched code:
```toml
[features]
hooks = true

[hooks.state."…/vhome/.codex/hooks.json:session_start:0:0"]
trusted_hash = "sha256:f85773de9ba91f2702460f714ada8038915825ea139ef79530158041a79c817b"
```

No `codex_hooks` deprecation error appeared (vs. prior runs), confirming the feature-key fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)