### PR TITLE
fix(win): exec env-injection tests resolve HOME like the source

### DIFF
--- a/src/lib/__tests__/exec.test.ts
+++ b/src/lib/__tests__/exec.test.ts
@@ -32,6 +32,12 @@ function opts(overrides: Partial<ExecOptions>): ExecOptions {
 
 const ALL_AGENTS = Object.keys(AGENT_COMMANDS) as AgentId[];
 
+// Mirror the source's home resolution (src/lib/state.ts: `process.env.HOME ?? os.homedir()`).
+// On Windows process.env.HOME is unset, so a bare `process.env.HOME!` is undefined and
+// `path.join(undefined, …)` throws — these assertions must resolve home the same way the
+// version-home builder does so the expected path matches on every OS.
+const HOME = process.env.HOME ?? os.homedir();
+
 describe('buildExecCommand', () => {
   // --- Mode flags per agent ---
 
@@ -729,7 +735,7 @@ describe('buildExecCommand', () => {
       // path.join (not a forward-slash template) so the separator matches the
       // source on every OS — buildExecEnv builds this with path.join too.
       expect(env.CLAUDE_CONFIG_DIR).toBe(
-        path.join(process.env.HOME!, '.agents', '.history', 'versions', 'claude', '2.1.98', 'home', '.claude')
+        path.join(HOME, '.agents', '.history', 'versions', 'claude', '2.1.98', 'home', '.claude')
       );
     });
 
@@ -750,7 +756,7 @@ describe('buildExecCommand', () => {
     it('injects COPILOT_HOME for pinned Copilot versions', () => {
       const env = buildExecEnv(opts({ agent: 'copilot', version: '1.0.56', mode: 'edit' }));
       expect(env.COPILOT_HOME).toBe(
-        path.join(process.env.HOME!, '.agents', '.history', 'versions', 'copilot', '1.0.56', 'home', '.copilot')
+        path.join(HOME, '.agents', '.history', 'versions', 'copilot', '1.0.56', 'home', '.copilot')
       );
     });
 
@@ -767,7 +773,7 @@ describe('buildExecCommand', () => {
     it('injects KIMI_CODE_HOME for pinned Kimi versions', () => {
       const env = buildExecEnv(opts({ agent: 'kimi', version: '0.11.0' }));
       expect(env.KIMI_CODE_HOME).toBe(
-        path.join(process.env.HOME!, '.agents', '.history', 'versions', 'kimi', '0.11.0', 'home', '.kimi-code')
+        path.join(HOME, '.agents', '.history', 'versions', 'kimi', '0.11.0', 'home', '.kimi-code')
       );
     });
 


### PR DESCRIPTION
## Root cause

The Windows CI legs (`build (windows-latest, 22)` / `(…, 24)`) fail at the **Test** step (Build passes). One concrete, fully self-contained cluster: 3 failures in `src/lib/__tests__/exec.test.ts`, the `buildExecCommand > exec env` group:

- `injects Claude config dir for pinned Claude versions`
- `injects COPILOT_HOME for pinned Copilot versions`
- `injects KIMI_CODE_HOME for pinned Kimi versions`

CI error (windows-latest):

```
TypeError: The "path" argument must be of type string. Received undefined
 ❯ src/lib/__tests__/exec.test.ts:732:14   (also 753, 770)
```

Each assertion built the *expected* path from a bare `process.env.HOME!`:

```ts
path.join(process.env.HOME!, '.agents', '.history', 'versions', 'claude', '2.1.98', 'home', '.claude')
```

On Windows `process.env.HOME` is **unset** (Windows uses `USERPROFILE`), so the value is `undefined` and `path.join(undefined, …)` throws. On Linux/macOS `HOME` is set, so the bug was invisible.

The **source is correct** — `buildExecEnv` builds these via `getVersionHomePath` → `getVersionDir` → `getVersionsDir`, all rooted at `state.ts`'s `HOME = process.env.HOME ?? os.homedir()` (`src/lib/state.ts:34`), which resolves to `os.homedir()` on Windows. The test simply did not mirror that fallback. This is a **test bug, not a product bug**.

## Fix

`src/lib/__tests__/exec.test.ts` — resolve home in the test the same way the source does:

```ts
const HOME = process.env.HOME ?? os.homedir();
```

and use it in the three `exec env` assertions. `os` was already imported. No source/runtime change.

## Verification (local, Linux)

Reproduced the exact CI `TypeError` by simulating the Windows condition (`HOME` unset → `path.join(undefined, …)` throws), then confirmed the fix:

```
# Windows condition (HOME unset) — full file
$ env -u HOME node ./node_modules/vitest/vitest.mjs run src/lib/__tests__/exec.test.ts
 Test Files  1 passed (1)
      Tests  168 passed (168)

# Normal (HOME set)
 Tests  11 passed | 157 skipped (168)   # the "exec env" group
```

`bun run build` (tsc) is clean. (Pre-existing, unrelated secrets/keychain test failures on the Linux dev host are not touched by this diff.)

## Scope note

The original triage hypothesis (PR #461's `scripts/postinstall.js` / `posixpath.ts` POSIX-path change) is **disproven**: those files are not in the failure path — the **Build** step passes and postinstall does not run during `bun run test`. Windows CI is a non-blocking, incremental bring-up (`continue-on-error: ${{ matrix.os == 'windows-latest' }}` in `.github/workflows/ci.yml`) with several independent platform-specific test failures across other files (`project-launch`, `migrate`, `remote`, `bugfixes`, `self-update`, `versions`, …). This PR fixes the `exec.test.ts` cluster — a clean, verifiable test bug — matching the existing `fix(win): <subsystem>` PR series (#468/#469/#470). The remaining clusters are separate fixes.
