### PR TITLE
feat(secrets): read & use bundles from other hosts over SSH

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -72,6 +72,40 @@ store (`~/.agents/.cache/secrets/<item>.enc`, scrypt-derived key) keyed by
 Recommended custody for a remote release (laptop keeps the key, the remote Mac
 holds only ciphertext): see [Recipe 8](#8-headless-release-on-a-remote-mac).
 
+## Remote secrets (read & use from other hosts)
+
+Browse and *use* the bundles that live on another machine, over the same hardened
+SSH path that `secrets export --host` (the write direction) already uses. Hosts
+resolve through the `agents hosts` registry, an ssh-config alias, or `user@host`.
+
+```bash
+# Browse one host, or several at once (grouped by host)
+agents secrets list --host yosemite-s1
+agents secrets list --hosts yosemite-s0,yosemite-s1
+agents secrets view --host yosemite-s1 r2.backups --reveal --plaintext
+
+# Use a remote bundle ephemerally — values are injected, never stored locally
+agents secrets exec --host yosemite-s1 r2.backups -- ./deploy.sh
+agents run claude "ship it" --secrets r2.backups@yosemite-s1   # bundle@host suffix
+```
+
+- **`--host <target>`** (single) and **`--hosts <a,b,c>`** (comma list) compose on
+  `list` / `view`; **`bundle@host`** is the reference form for `run --secrets` and
+  the target for `exec --host`.
+- **Ephemeral.** Remote values cross over ssh stdout (encrypted in transit), are
+  parsed in memory, and injected into the run/command env — never written to this
+  machine's keychain or disk.
+- **The remote unlocks with its own credentials.** A file-backed remote bundle
+  reads headlessly via the remote's own `AGENTS_SECRETS_PASSPHRASE`; a keychain
+  bundle on a macOS remote will block on Touch ID under non-interactive SSH — use
+  a remote `file` bundle, an already-unlocked remote secrets-agent, or run
+  `view --reveal` from an interactive terminal (it forces an SSH TTY so the prompt
+  can surface). This machine's passphrase is never forwarded.
+
+Source: `src/lib/secrets/remote.ts` (transport + resolve), wired into `list` /
+`view` / `exec` in `src/commands/secrets.ts` and the `--secrets` loop in
+`src/commands/exec.ts`. The lossless wire format is `secrets export --format json`.
+
 ## Command Reference
 
 ### Bundle commands

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -443,6 +443,7 @@ export function registerRunCommand(program: Command): void {
         { ALL_AGENT_IDS },
         { profileExists, resolveProfileForRun },
         { readAndResolveBundleEnv, describeBundle },
+        { splitBundleRef, resolveSshTarget, remoteResolveEnv },
         { getConfiguredRunStrategy, normalizeRunStrategy, resolveRunVersion, RUN_STRATEGIES },
         { getGlobalDefault, getVersionHomePath, resolveVersion, resolveVersionAlias },
         { buildDiscoveredPlugin, loadPluginManifest, syncPluginToVersion },
@@ -455,6 +456,7 @@ export function registerRunCommand(program: Command): void {
         import('../lib/agents.js'),
         import('../lib/profiles.js'),
         import('../lib/secrets/bundles.js'),
+        import('../lib/secrets/remote.js'),
         import('../lib/rotate.js'),
         import('../lib/versions.js'),
         import('../lib/plugins.js'),
@@ -909,17 +911,27 @@ export function registerRunCommand(program: Command): void {
       // ones. Any resolution failure (missing keychain item, blocked exec ref)
       // aborts before spawn so the agent never sees a partial env.
       let secretsEnv: Record<string, string> = {};
-      for (const bundleName of options.secrets) {
+      for (const bundleRef of options.secrets) {
         try {
-          const { bundle, env: bundleEnv } = readAndResolveBundleEnv(bundleName, { caller: `agent ${agent}` });
-          const entries = describeBundle(bundle);
-          const counts: Record<string, number> = {};
-          for (const e of entries) {
-            counts[e.kind] = (counts[e.kind] || 0) + 1;
+          const { bundle: bundleName, host } = splitBundleRef(bundleRef);
+          if (host) {
+            // Remote bundle (`bundle@host`): resolve over SSH and inject
+            // ephemerally — values never touch this machine's keychain or disk.
+            const target = await resolveSshTarget(host);
+            const bundleEnv = await remoteResolveEnv(target, bundleName);
+            console.log(chalk.gray(`[secrets] Resolved ${bundleName}@${host}: ${Object.keys(bundleEnv).length} keys (remote, ephemeral)`));
+            secretsEnv = { ...secretsEnv, ...bundleEnv };
+          } else {
+            const { bundle, env: bundleEnv } = readAndResolveBundleEnv(bundleName, { caller: `agent ${agent}` });
+            const entries = describeBundle(bundle);
+            const counts: Record<string, number> = {};
+            for (const e of entries) {
+              counts[e.kind] = (counts[e.kind] || 0) + 1;
+            }
+            const breakdown = Object.entries(counts).map(([k, v]) => `${v} ${k}`).join(', ');
+            console.log(chalk.gray(`[secrets] Resolved ${bundleName}: ${entries.length} keys (${breakdown})`));
+            secretsEnv = { ...secretsEnv, ...bundleEnv };
           }
-          const breakdown = Object.entries(counts).map(([k, v]) => `${v} ${k}`).join(', ');
-          console.log(chalk.gray(`[secrets] Resolved ${bundleName}: ${entries.length} keys (${breakdown})`));
-          secretsEnv = { ...secretsEnv, ...bundleEnv };
         } catch (err) {
           console.error(chalk.red((err as Error).message));
           process.exit(1);

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -10,7 +10,13 @@ import { Option, type Command } from 'commander';
 import chalk from 'chalk';
 import * as fs from 'fs';
 import { spawnSync } from 'child_process';
-import { SSH_TARGET_RE, assertValidSshTarget } from '../lib/ssh-exec.js';
+import { SSH_TARGET_RE, assertValidSshTarget, type SshExecResult } from '../lib/ssh-exec.js';
+import {
+  parseHostsOption,
+  remoteResolveEnv,
+  remoteSecretsRaw,
+  resolveSshTarget,
+} from '../lib/secrets/remote.js';
 import {
   bundleBackend,
   bundleExists,
@@ -216,6 +222,42 @@ export function bundleEnvToDotenv(env: Record<string, string>): string {
     lines.push(`${k}="${v}"`);
   }
   return lines.join('\n') + '\n';
+}
+
+/**
+ * Browse `agents secrets <args>` on one or more remote hosts over SSH and print
+ * each host's stdout verbatim (lossless — no parsing). With >1 host the output
+ * is grouped under a `── <host> ──` header. `tty` forces an interactive ssh
+ * session (run sequentially) so a remote Touch-ID / passphrase prompt can
+ * surface (e.g. `view --reveal`); otherwise hosts are queried in parallel.
+ * Exits non-zero if any host fails.
+ */
+async function browseRemote(targets: string[], args: string[], tty: boolean): Promise<void> {
+  const multi = targets.length > 1;
+  let failures = 0;
+  const render = (name: string, res: SshExecResult) => {
+    if (multi) console.log(chalk.bold.cyan(`\n── ${name} ──`));
+    if (res.code === 0) {
+      if (res.stdout) process.stdout.write(res.stdout.endsWith('\n') ? res.stdout : `${res.stdout}\n`);
+      if (res.stderr.trim()) process.stderr.write(chalk.gray(res.stderr));
+    } else {
+      failures++;
+      const msg = (res.stderr || res.stdout || '').trim();
+      const why = res.timedOut ? 'timed out' : res.code === null ? 'ssh failed' : `exit ${res.code}`;
+      console.error(chalk.red(`${name}: ${why}${msg ? `: ${msg}` : ''}`));
+    }
+  };
+  if (tty) {
+    for (const t of targets) {
+      const target = await resolveSshTarget(t);
+      render(t, remoteSecretsRaw(target, args, { tty: true }));
+    }
+  } else {
+    const resolved = await Promise.all(targets.map((t) => resolveSshTarget(t)));
+    const results = resolved.map((target) => remoteSecretsRaw(target, args));
+    targets.forEach((t, i) => render(t, results[i]));
+  }
+  if (failures > 0) process.exit(1);
 }
 
 /** Strip ANSI escape sequences so padding can be computed on visible width. */
@@ -502,8 +544,15 @@ export function registerSecretsCommands(program: Command): void {
   cmd
     .command('list')
     .alias('ls')
-    .description('List configured secrets bundles')
-    .action(async () => {
+    .description('List configured secrets bundles (use --host/--hosts to list bundles on other machines over SSH)')
+    .option('--host <target>', 'List bundles on a remote host over SSH (enrolled `agents hosts` name, ssh-config alias, or user@host)')
+    .option('--hosts <list>', 'Comma-separated hosts to list in one shot, e.g. yosemite-s0,yosemite-s1')
+    .action(async (opts: { host?: string; hosts?: string }) => {
+      const targets = parseHostsOption(opts);
+      if (targets.length > 0) {
+        await browseRemote(targets, ['list'], false);
+        return;
+      }
       const bundles = listBundles();
       if (bundles.length === 0) {
         console.log(chalk.gray('No secrets bundles configured.'));
@@ -534,8 +583,26 @@ export function registerSecretsCommands(program: Command): void {
     .description('Show a bundle. Keychain values are masked by default — pass --reveal to see them.')
     .option('--reveal', 'Print keychain-backed values in the clear (TTY only unless --plaintext)')
     .option('--plaintext', 'Allow --reveal in non-interactive shells (use with care)')
-    .action(async (name: string | undefined, opts: { reveal?: boolean; plaintext?: boolean }) => {
+    .option('--host <target>', 'Show a bundle on a remote host over SSH (enrolled `agents hosts` name, ssh-config alias, or user@host)')
+    .option('--hosts <list>', 'Comma-separated hosts to show in one shot, e.g. yosemite-s0,yosemite-s1')
+    .action(async (name: string | undefined, opts: { reveal?: boolean; plaintext?: boolean; host?: string; hosts?: string }) => {
       try {
+        const targets = parseHostsOption(opts);
+        if (targets.length > 0) {
+          if (!name) {
+            console.error(chalk.red('A bundle name is required when viewing a remote host (interactive pick needs a local terminal).'));
+            process.exit(1);
+          }
+          const args = ['view', name];
+          if (opts.reveal) args.push('--reveal');
+          if (opts.plaintext) args.push('--plaintext');
+          // With --reveal, force a TTY so the remote keychain prompt can surface
+          // (and the remote's "--reveal in a non-TTY needs --plaintext" gate is
+          // satisfied) — only when this side is itself interactive.
+          const tty = Boolean(opts.reveal) && Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY);
+          await browseRemote(targets, args, tty);
+          return;
+        }
         const resolvedName = name ?? (await pickBundleName('view'));
         const bundle = readBundle(resolvedName);
         const entries = describeBundle(bundle);
@@ -1146,6 +1213,7 @@ Examples:
     .option('--host <target...>', 'Push the bundle over SSH to this target (host alias or user@host); repeatable for multiple machines')
     .option('--remote-backend <backend>', 'Backend for the bundle on the remote (with --host): keychain (default) or file (passphrase-encrypted, headless-readable). file forwards AGENTS_SECRETS_PASSPHRASE over stdin.', 'keychain')
     .option('--force', 'Overwrite existing keys/items on the target (used with --to-1password and --host)')
+    .option('--format <shell|json>', 'Output for --plaintext export: shell (default) or json (lossless, machine-readable; used by remote resolve)', 'shell')
     .action(async (bundleName: string | undefined, opts: {
       plaintext?: boolean;
       to1password?: boolean;
@@ -1153,6 +1221,7 @@ Examples:
       host?: string[];
       remoteBackend?: string;
       force?: boolean;
+      format?: string;
     }) => {
       try {
         const { readAndResolveBundleEnv, bundleToEnvPrefix, isReservedEnvName } = await import('../lib/secrets/bundles.js');
@@ -1261,11 +1330,21 @@ Examples:
           return;
         }
 
+        if (opts.format && opts.format !== 'shell' && opts.format !== 'json') {
+          console.error(chalk.red(`Invalid --format ${JSON.stringify(opts.format)}. Expected 'shell' or 'json'.`));
+          process.exit(1);
+        }
         if (!opts.plaintext) {
           console.error(chalk.red('export prints secrets in the clear and requires --plaintext (works for TTY and pipes alike).'));
           process.exit(1);
         }
         const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `export to shell` });
+        if (opts.format === 'json') {
+          // Lossless, machine-readable form consumed by `remoteResolveEnv` over
+          // SSH. Single object of KEY -> value; values verbatim (newlines, quotes).
+          process.stdout.write(JSON.stringify(env));
+          return;
+        }
         const prefix = bundleToEnvPrefix(resolvedBundleName);
         for (const [k, v] of Object.entries(env)) {
           const exportKey = isReservedEnvName(k) ? `${prefix}_${k}` : k;
@@ -1282,17 +1361,23 @@ Examples:
 
   cmd
     .command('exec <bundle> [command...]')
-    .description('Run a command with the bundle\'s secrets injected into the environment')
+    .description('Run a command with the bundle\'s secrets injected into the environment (use --host to resolve the bundle from a remote machine, ephemerally)')
+    .option('--host <target>', 'Resolve <bundle> on a remote host over SSH and inject it (ephemeral — never stored on this machine)')
     .allowUnknownOption()
-    .action(async (bundleName: string, commandParts: string[]) => {
+    .action(async (bundleName: string, commandParts: string[], execOpts: { host?: string }) => {
       try {
         if (commandParts.length === 0) {
           console.error(chalk.red('Usage: agents secrets exec <bundle> -- <command...>'));
           process.exit(1);
         }
-        const { readAndResolveBundleEnv } = await import('../lib/secrets/bundles.js');
         const [cmd, ...args] = commandParts;
-        const { env: secretEnv } = readAndResolveBundleEnv(bundleName, { caller: `command ${cmd}` });
+        let secretEnv: Record<string, string>;
+        if (execOpts.host) {
+          secretEnv = await remoteResolveEnv(await resolveSshTarget(execOpts.host), bundleName);
+        } else {
+          const { readAndResolveBundleEnv } = await import('../lib/secrets/bundles.js');
+          secretEnv = readAndResolveBundleEnv(bundleName, { caller: `command ${cmd}` }).env;
+        }
         const { spawn } = await import('child_process');
         const proc = spawn(cmd, args, {
           stdio: 'inherit',

--- a/src/lib/secrets/remote.test.ts
+++ b/src/lib/secrets/remote.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { SshExecResult } from '../ssh-exec.js';
+
+const { sshExecMock, resolveHostMock } = vi.hoisted(() => ({
+  sshExecMock: vi.fn(),
+  resolveHostMock: vi.fn(),
+}));
+
+// Keep the real assertValidSshTarget / shellQuote (so injection guarding and
+// quoting are exercised for real); only the network call is stubbed.
+vi.mock('../ssh-exec.js', async () => {
+  const actual = await vi.importActual<typeof import('../ssh-exec.js')>('../ssh-exec.js');
+  return { ...actual, sshExec: sshExecMock };
+});
+
+vi.mock('../hosts/registry.js', () => ({
+  resolveHost: resolveHostMock,
+}));
+
+import {
+  parseHostsOption,
+  splitBundleRef,
+  resolveSshTarget,
+  remoteSecretsRaw,
+  remoteResolveEnv,
+} from './remote.js';
+
+const ok = (stdout: string): SshExecResult => ({ code: 0, stdout, stderr: '', timedOut: false });
+
+beforeEach(() => {
+  sshExecMock.mockReset();
+  resolveHostMock.mockReset();
+  delete process.env.AGENTS_SECRETS_PASSPHRASE;
+});
+
+describe('parseHostsOption', () => {
+  it('returns empty when neither flag is set', () => {
+    expect(parseHostsOption({})).toEqual([]);
+  });
+
+  it('takes a single --host', () => {
+    expect(parseHostsOption({ host: 'yosemite-s1' })).toEqual(['yosemite-s1']);
+  });
+
+  it('splits a comma-separated --hosts list', () => {
+    expect(parseHostsOption({ hosts: 'yosemite-s0,yosemite-s1' })).toEqual(['yosemite-s0', 'yosemite-s1']);
+  });
+
+  it('merges --host and --hosts, trims, drops empties, dedupes in order', () => {
+    expect(parseHostsOption({ host: 'a', hosts: 'b, a ,,c' })).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('splitBundleRef', () => {
+  it('treats a plain name as a local bundle', () => {
+    expect(splitBundleRef('r2.backups')).toEqual({ bundle: 'r2.backups' });
+  });
+
+  it('splits bundle@host', () => {
+    expect(splitBundleRef('r2.backups@yosemite-s1')).toEqual({ bundle: 'r2.backups', host: 'yosemite-s1' });
+  });
+
+  it('splits on the FIRST @ so a user@host target survives', () => {
+    expect(splitBundleRef('r2.backups@muqsit@box')).toEqual({ bundle: 'r2.backups', host: 'muqsit@box' });
+  });
+
+  it('rejects a malformed reference with an empty side', () => {
+    expect(() => splitBundleRef('@box')).toThrow(/Expected 'bundle@host'/);
+    expect(() => splitBundleRef('bundle@')).toThrow(/Expected 'bundle@host'/);
+  });
+});
+
+describe('resolveSshTarget', () => {
+  it('resolves an enrolled host through the registry', async () => {
+    resolveHostMock.mockResolvedValue({ source: 'ssh-config', name: 'yosemite-s1' });
+    expect(await resolveSshTarget('Y1')).toBe('yosemite-s1');
+  });
+
+  it('falls back to a raw ssh target when the registry misses', async () => {
+    resolveHostMock.mockResolvedValue(null);
+    expect(await resolveSshTarget('muqsit@box')).toBe('muqsit@box');
+  });
+
+  it('rejects an injection-shaped raw target', async () => {
+    resolveHostMock.mockResolvedValue(null);
+    await expect(resolveSshTarget('a;rm -rf /')).rejects.toThrow();
+  });
+});
+
+describe('remoteSecretsRaw', () => {
+  it('drives the remote agents secrets CLI under bash -lc', () => {
+    sshExecMock.mockReturnValue(ok('listed'));
+    const res = remoteSecretsRaw('yosemite-s1', ['list']);
+    expect(res.stdout).toBe('listed');
+    const [target, remoteCmd, opts] = sshExecMock.mock.calls[0];
+    expect(target).toBe('yosemite-s1');
+    expect(remoteCmd).toBe(`bash -lc 'agents secrets list'`);
+    expect(opts.extraSshArgs).toBeUndefined();
+  });
+
+  it('shell-quotes each argument against injection', () => {
+    sshExecMock.mockReturnValue(ok(''));
+    remoteSecretsRaw('host', ['view', 'a; rm -rf /']);
+    const remoteCmd = sshExecMock.mock.calls[0][1] as string;
+    // The malicious arg is single-quoted inside, so the remote shell can't run it.
+    expect(remoteCmd).toContain(`'a; rm -rf /'`);
+    expect(remoteCmd.startsWith('bash -lc ')).toBe(true);
+  });
+
+  it('passes -tt when tty is requested', () => {
+    sshExecMock.mockReturnValue(ok(''));
+    remoteSecretsRaw('host', ['view', 'b', '--reveal'], { tty: true });
+    expect(sshExecMock.mock.calls[0][2].extraSshArgs).toEqual(['-tt']);
+  });
+});
+
+describe('remoteResolveEnv', () => {
+  it('resolves a bundle to an env map via export --format json (no passphrase)', async () => {
+    sshExecMock.mockReturnValue(ok('{"FOO":"bar","BAZ":"qux"}'));
+    const env = await remoteResolveEnv('yosemite-s1', 'r2.backups');
+    expect(env).toEqual({ FOO: 'bar', BAZ: 'qux' });
+    const [, remoteCmd, opts] = sshExecMock.mock.calls[0];
+    expect(remoteCmd).toBe(`bash -lc 'agents secrets export r2.backups --plaintext --format json'`);
+    expect(opts.input).toBeUndefined();
+  });
+
+  it('does NOT forward the local passphrase — the remote unlocks with its own', async () => {
+    process.env.AGENTS_SECRETS_PASSPHRASE = 'hunter2hunter2';
+    sshExecMock.mockReturnValue(ok('{"FOO":"bar"}'));
+    await remoteResolveEnv('host', 'b');
+    const [, remoteCmd, opts] = sshExecMock.mock.calls[0];
+    expect(opts.input).toBeUndefined();
+    expect(remoteCmd).not.toContain('hunter2hunter2');
+    expect(remoteCmd).not.toContain('AGENTS_SECRETS_PASSPHRASE');
+  });
+
+  it('tolerates login-shell banner noise around the JSON', async () => {
+    sshExecMock.mockReturnValue(ok('Welcome to box\n{"A":"1"}\nlogout'));
+    expect(await remoteResolveEnv('host', 'b')).toEqual({ A: '1' });
+  });
+
+  it('throws with the remote stderr on a non-zero exit', async () => {
+    sshExecMock.mockReturnValue({ code: 1, stdout: '', stderr: 'no such bundle', timedOut: false });
+    await expect(remoteResolveEnv('host', 'b')).rejects.toThrow(/no such bundle/);
+  });
+
+  it('throws a clear hint when the remote payload is not JSON', async () => {
+    sshExecMock.mockReturnValue(ok('command not found: agents'));
+    await expect(remoteResolveEnv('host', 'b')).rejects.toThrow(/--format json/);
+  });
+});

--- a/src/lib/secrets/remote.ts
+++ b/src/lib/secrets/remote.ts
@@ -1,0 +1,142 @@
+/**
+ * Remote secrets — read and use `agents secrets` bundles that live on another
+ * host, over the same hardened SSH path that `agents secrets export --host`
+ * (the write inverse) already uses.
+ *
+ * This is the READ / USE direction:
+ *   - browse:  drive the remote `agents secrets list|view` and stream its
+ *              stdout back verbatim (lossless, no parsing).
+ *   - use:     resolve a remote bundle to an env map (JSON over ssh stdout) and
+ *              inject it ephemerally — never written to this machine's keychain.
+ *
+ * Trust model: relies on the operator's existing SSH access to the host (same
+ * boundary as `export --host` / `run --host`). Bundle names are shell-quoted
+ * into the remote command; resolved VALUES return over ssh stdout; a forwarded
+ * file-backend passphrase travels over ssh stdin (first line) so it never lands
+ * in argv / `ps` / remote shell history. Nothing is persisted locally.
+ */
+
+import { sshExec, assertValidSshTarget, shellQuote, type SshExecResult } from '../ssh-exec.js';
+import { resolveHost } from '../hosts/registry.js';
+import { sshTargetFor } from '../hosts/types.js';
+
+const REMOTE_TIMEOUT_MS = 30_000;
+
+/**
+ * Resolve a `--host` value to an ssh target string. Tries the `agents hosts`
+ * registry first (enrolled name → ssh-config alias / `user@host`); on a miss,
+ * treats the value as a raw ssh target and validates it against injection.
+ */
+export async function resolveSshTarget(nameOrAlias: string): Promise<string> {
+  const host = await resolveHost(nameOrAlias);
+  if (host) return sshTargetFor(host);
+  assertValidSshTarget(nameOrAlias);
+  return nameOrAlias;
+}
+
+/**
+ * Merge `--host <single>` and `--hosts <a,b,c>` into an ordered, de-duplicated
+ * list. Both flags compose; either alone works. Empty when neither is set.
+ */
+export function parseHostsOption(opts: { host?: string; hosts?: string }): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const push = (h: string) => {
+    const t = h.trim();
+    if (t && !seen.has(t)) {
+      seen.add(t);
+      out.push(t);
+    }
+  };
+  if (opts.host) push(opts.host);
+  if (opts.hosts) for (const h of opts.hosts.split(',')) push(h);
+  return out;
+}
+
+/**
+ * Split a `bundle@host` reference. No `@` → a local bundle (host undefined).
+ * Bundle names can't contain `@` (BUNDLE_NAME_PATTERN), so the FIRST `@`
+ * separates the bundle from the ssh target — and the target itself may be a
+ * `user@host` (e.g. `r2.backups@muqsit@box` → bundle `r2.backups`, host
+ * `muqsit@box`).
+ */
+export function splitBundleRef(ref: string): { bundle: string; host?: string } {
+  const at = ref.indexOf('@');
+  if (at === -1) return { bundle: ref };
+  const bundle = ref.slice(0, at);
+  const host = ref.slice(at + 1);
+  if (!bundle || !host) {
+    throw new Error(`Invalid remote bundle reference ${JSON.stringify(ref)}. Expected 'bundle@host'.`);
+  }
+  return { bundle, host };
+}
+
+/**
+ * Run `agents secrets <args>` on a remote host over ssh and return the raw
+ * result. Used by the browse commands — the remote's human-readable stdout is
+ * streamed back unchanged. `tty` forces an interactive ssh session (`-tt`) so a
+ * remote Touch-ID / passphrase prompt can surface (e.g. `view --reveal`).
+ */
+export function remoteSecretsRaw(
+  target: string,
+  args: string[],
+  opts: { tty?: boolean; input?: string } = {},
+): SshExecResult {
+  const inner = ['agents', 'secrets', ...args].map(shellQuote).join(' ');
+  const remoteCmd = `bash -lc ${shellQuote(inner)}`;
+  return sshExec(target, remoteCmd, {
+    timeoutMs: REMOTE_TIMEOUT_MS,
+    input: opts.input,
+    extraSshArgs: opts.tty ? ['-tt'] : undefined,
+  });
+}
+
+/**
+ * Resolve a remote bundle to a plaintext env map by driving the remote's
+ * `agents secrets export <bundle> --plaintext --format json`. Values cross over
+ * ssh stdout (encrypted in transit), parsed in memory, never persisted.
+ *
+ * The remote unlocks the bundle with ITS OWN credentials — the owner host's
+ * keychain/secrets-agent, or its own `AGENTS_SECRETS_PASSPHRASE` (in the login
+ * env) for a file-backed bundle. We deliberately do NOT forward this machine's
+ * passphrase: the remote bundle is encrypted with the remote's passphrase, so
+ * overriding it would break the read. (A macOS remote under non-interactive
+ * SSH will block on Touch-ID — use `view`/`exec` with a remote `file` bundle,
+ * an already-unlocked remote secrets-agent, or an interactive `-tt` session.)
+ */
+export async function remoteResolveEnv(target: string, bundle: string): Promise<Record<string, string>> {
+  assertValidSshTarget(target);
+  const exportCmd = `agents secrets export ${shellQuote(bundle)} --plaintext --format json`;
+  const res: SshExecResult = sshExec(target, `bash -lc ${shellQuote(exportCmd)}`, {
+    timeoutMs: REMOTE_TIMEOUT_MS,
+  });
+
+  if (res.code !== 0) {
+    const msg = (res.stderr || res.stdout || '').trim();
+    const why = res.timedOut ? 'timed out' : res.code === null ? 'ssh failed' : `exit ${res.code}`;
+    throw new Error(`Failed to resolve '${bundle}' on ${target} (${why})${msg ? `: ${msg}` : ''}`);
+  }
+
+  // Tolerate login-shell banner noise on stdout: take the outer { … } object.
+  const raw = res.stdout;
+  const start = raw.indexOf('{');
+  const end = raw.lastIndexOf('}');
+  const jsonText = start >= 0 && end >= start ? raw.slice(start, end + 1) : raw.trim();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch {
+    throw new Error(
+      `Could not parse secrets JSON from '${bundle}' on ${target}. ` +
+        `Is the remote agents-cli new enough for 'secrets export --format json'?`,
+    );
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Unexpected payload resolving '${bundle}' on ${target}.`);
+  }
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+    env[k] = typeof v === 'string' ? v : String(v);
+  }
+  return env;
+}


### PR DESCRIPTION
## What

Adds the **read/use inverse** of the already-shipped `agents secrets export --host` (the write direction). From one machine you can now browse and *use* the secret bundles that live on another host, over the same hardened SSH choke point and host registry.

```bash
# Browse one host, or several at once (grouped by host)
agents secrets list --host yosemite-s1
agents secrets list --hosts yosemite-s0,yosemite-s1
agents secrets view --host yosemite-s1 r2.backups --reveal --plaintext

# Use a remote bundle ephemerally
agents secrets exec --host yosemite-s1 r2.backups -- ./deploy.sh
agents run claude "ship it" --secrets r2.backups@yosemite-s1   # bundle@host suffix
```

- **`--host <target>` (single) + `--hosts <a,b,c>` (comma list)** compose on `list`/`view`.
- **`bundle@host`** is the reference form for `run --secrets`; **`exec --host`** for one-off commands. Local and remote bundles mix freely in one run.

## Design

New `src/lib/secrets/remote.ts` is the single transport: host resolution (`agents hosts` registry / ssh-config alias / `user@host`), `--host`/`--hosts` parsing, `bundle@host` splitting (on the first `@`, so `user@host` targets survive), and remote resolve via a new lossless `secrets export --format json`. Wired into `list` / `view` / `exec` in `src/commands/secrets.ts` and the `--secrets` loop in `src/commands/exec.ts`.

## Security

- Every remote call routes through the existing `sshExec` guard (`BatchMode`, `accept-new`, `ConnectTimeout`, target-injection guard, `shellQuote`).
- Trust boundary is the operator's existing SSH access — same as `export --host` / `run --host`. No new tokens, nothing stored.
- **Ephemeral:** remote values cross over ssh stdout (encrypted in transit), are parsed in memory, and injected into the run/command env — never written to this machine's keychain or disk.
- **The remote unlocks with its own credentials** (its keychain / secrets-agent / own `AGENTS_SECRETS_PASSPHRASE` for file bundles). This machine's passphrase is **not** forwarded — forwarding would override and break a remote file bundle encrypted with a different passphrase. A macOS keychain remote under non-interactive SSH blocks on Touch ID; mitigations: remote `file` bundle, unlocked remote secrets-agent, or `view --reveal` from an interactive terminal (forces an SSH TTY).

## Tests / verification

- `src/lib/secrets/remote.test.ts` — 19 tests: host-list parse, `bundle@host` split (incl. `user@host`), target resolution (registry hit / raw fallback / injection reject), `remoteSecretsRaw` arg-quoting + `-tt`, `remoteResolveEnv` JSON parse / banner tolerance / non-zero exit / no-passphrase-forwarding.
- End-to-end on the yosemite-s0 ↔ s1 pair:
  - `secrets list --host yosemite-s1` and `--hosts yosemite-s0,yosemite-s1` — real cross-host hop, grouped output.
  - `secrets view --host ... --reveal --plaintext` — value revealed over SSH.
  - `secrets exec --host ... <bundle> -- printenv FOO` — resolved a value with an embedded quote (`bar baz"q`) losslessly and injected it.
  - `export --format json` verified locally (lossless vs the shell form).
- `tsc --noEmit` clean; full suite passes except 4 pre-existing failures in `src/lib/secrets/__tests__/bundles-storage.test.ts` that also fail on `main` (test-isolation: the `os` mock doesn't isolate the Linux secret-service/file store, so a dev box with real bundles inflates the count). Untouched by this diff.