### PR TITLE
fix(win): green the windows-latest CI matrix + make it a required gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [22, 24]
-    # Cross-platform gating is being brought up incrementally (Linux + macOS +
-    # Windows is the target). Native Windows still has known gaps (#TODO: link),
-    # so Windows legs may fail without blocking the branch until those land.
-    # Promote Windows to a required check once it's green.
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
+    # All three OSes gate merges. Windows is now green and required alongside
+    # Linux and macOS — no leg is allowed to fail (was: continue-on-error on
+    # windows-latest while the native-Windows gaps were brought up).
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/src/lib/__tests__/bugfixes.test.ts
+++ b/src/lib/__tests__/bugfixes.test.ts
@@ -11,13 +11,18 @@ describe('Bug Fix: Path traversal in sandbox.ts', () => {
   let allowedDir: string;
   let fakeHome: string;
   let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
 
   beforeEach(() => {
     // Point HOME at an isolated tmpdir so the test never touches the real home.
-    // sandbox.ts resolves the user's home via os.homedir(), which consults $HOME.
+    // sandbox.ts resolves the user's home via os.homedir(), which consults $HOME
+    // on POSIX but USERPROFILE on Windows — set both so the temp home takes
+    // effect cross-platform.
     originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
     fakeHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'sandbox-fakehome-')));
     process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
 
     overlayHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sandbox-test-'));
     fs.mkdirSync(path.join(fakeHome, '.agents-system'), { recursive: true });
@@ -27,6 +32,8 @@ describe('Bug Fix: Path traversal in sandbox.ts', () => {
   afterEach(() => {
     if (originalHome === undefined) delete process.env.HOME;
     else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
     fs.rmSync(overlayHome, { recursive: true, force: true });
     fs.rmSync(fakeHome, { recursive: true, force: true });
   });

--- a/src/lib/__tests__/hooks.test.ts
+++ b/src/lib/__tests__/hooks.test.ts
@@ -362,8 +362,13 @@ describe('registerHooksToSettings - Codex', () => {
     const key = `${hooksJsonPath}:pre_tool_use:0:0`;
     expect(state[key]).toBeDefined();
     // The persisted hash must equal what Codex recomputes for this exact hook.
+    // The registrar hashes the portable command it wrote into hooks.json, so
+    // re-hash that exact string (not the raw native scriptPath, which diverges
+    // on Windows where tmpdir lives under home and folds to a ~/-relative path).
+    const hooksJson = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf-8'));
+    const registeredCommand = hooksJson.hooks.PreToolUse[0].hooks[0].command;
     expect(state[key].trusted_hash).toBe(
-      computeCodexHookTrustHash('pre_tool_use', scriptPath, 5, 'Bash')
+      computeCodexHookTrustHash('pre_tool_use', registeredCommand, 5, 'Bash')
     );
     // Default-enabled: we must NOT write enabled = true (absence == enabled).
     expect(state[key].enabled).toBeUndefined();
@@ -400,8 +405,12 @@ describe('registerHooksToSettings - Codex', () => {
       { trusted_hash?: string; enabled?: boolean }
     >;
     expect(afterState[key].enabled).toBe(false);
+    // Hash the portable command the registrar wrote, not the native scriptPath
+    // (separator/tilde divergence on Windows — see the PreToolUse test above).
+    const hooksJson = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf-8'));
+    const registeredCommand = hooksJson.hooks.UserPromptSubmit[0].hooks[0].command;
     expect(afterState[key].trusted_hash).toBe(
-      computeCodexHookTrustHash('user_prompt_submit', scriptPath, 600, undefined)
+      computeCodexHookTrustHash('user_prompt_submit', registeredCommand, 600, undefined)
     );
   });
 

--- a/src/lib/__tests__/migrate.test.ts
+++ b/src/lib/__tests__/migrate.test.ts
@@ -82,7 +82,7 @@ describe('runMigration', () => {
     const sysOverlap = path.join(systemDir, 'versions', 'claude', '2.0.50', 'home', '.claude');
     fs.mkdirSync(sysOverlap, { recursive: true });
     fs.writeFileSync(path.join(sysOverlap, 'history.jsonl'), 'legacy-history');
-    fs.writeFileSync(path.join(sysOverlap, 'skills', 'mq', 'SKILL.md').replace('skills/mq/SKILL.md', 'skills-stale.md'), 'stale');
+    fs.writeFileSync(path.join(sysOverlap, 'skills-stale.md'), 'stale');
 
     // Pre-create the symlink that the migrator should re-point. Use the legacy system target.
     fs.writeFileSync(path.join(userDir, 'agents.yaml'), 'agents:\n  claude: 2.0.50\n');

--- a/src/lib/hosts/providers/local.test.ts
+++ b/src/lib/hosts/providers/local.test.ts
@@ -8,6 +8,8 @@ import type { LocalHostProvider as LHP } from './local.js';
 // dir and re-importing the module graph fresh for each test (vi.resetModules).
 let home: string;
 let provider: LHP;
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
 
 async function freshProvider(): Promise<LHP> {
   vi.resetModules();
@@ -18,12 +20,19 @@ async function freshProvider(): Promise<LHP> {
 beforeEach(async () => {
   home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-hosts-test-'));
   process.env.HOME = home;
+  // ssh-config reader resolves via os.homedir(), which reads USERPROFILE (not
+  // HOME) on Windows — set both so the temp home takes effect cross-platform.
+  process.env.USERPROFILE = home;
   fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
   provider = await freshProvider();
 });
 
 afterEach(() => {
   fs.rmSync(home, { recursive: true, force: true });
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
 });
 
 describe('LocalHostProvider CRUD', () => {

--- a/src/lib/migrate.test.ts
+++ b/src/lib/migrate.test.ts
@@ -238,8 +238,13 @@ describe('repairSelfReferentialBinShims', () => {
 
     withPath([realBinDir], () => repairSelfReferentialBinShims(versionsRoot, shimsDir));
 
-    // After repair it resolves to the real binary, not the shim.
-    expect(fs.realpathSync(binLink)).toBe(fs.realpathSync(realBin));
+    // After repair the loop is broken and the .bin entry yields the real binary.
+    // On Windows without the symlink privilege createLink copies (a copy's
+    // realpath is itself, not the target), so assert the functional contract —
+    // same bytes as the real binary, and no longer resolving back into the
+    // shims dir — rather than symlink-target identity.
+    expect(fs.readFileSync(binLink)).toEqual(fs.readFileSync(realBin));
+    expect(fs.realpathSync(binLink).startsWith(fs.realpathSync(shimsDir) + path.sep)).toBe(false);
   });
 
   it('removes the self-referential symlink when no real binary is on PATH', () => {

--- a/src/lib/migrate.test.ts
+++ b/src/lib/migrate.test.ts
@@ -228,8 +228,9 @@ describe('repairSelfReferentialBinShims', () => {
 
     // A genuine binary on PATH, in a dir that is NOT the shims dir.
     const realBinDir = makeTempRoot();
-    const realBin = path.join(realBinDir, 'droid');
-    fs.writeFileSync(realBin, '#!/bin/sh\n# real droid\n');
+    const exeExt = process.platform === 'win32' ? '.cmd' : '';
+    const realBin = path.join(realBinDir, 'droid' + exeExt);
+    fs.writeFileSync(realBin, process.platform === 'win32' ? '@echo off\r\n' : '#!/bin/sh\n# real droid\n');
     fs.chmodSync(realBin, 0o755);
 
     // Sanity: before repair the link resolves into the shims dir (the loop).
@@ -263,8 +264,9 @@ describe('repairSelfReferentialBinShims', () => {
     fs.mkdirSync(shimsDir, { recursive: true });
 
     const realBinDir = makeTempRoot();
-    const realBin = path.join(realBinDir, 'droid');
-    fs.writeFileSync(realBin, '#!/bin/sh\n');
+    const exeExt = process.platform === 'win32' ? '.cmd' : '';
+    const realBin = path.join(realBinDir, 'droid' + exeExt);
+    fs.writeFileSync(realBin, process.platform === 'win32' ? '@echo off\r\n' : '#!/bin/sh\n');
     fs.chmodSync(realBin, 0o755);
 
     const binDir = path.join(versionsRoot, 'droid', 'latest', 'node_modules', '.bin');

--- a/src/lib/project-launch.test.ts
+++ b/src/lib/project-launch.test.ts
@@ -166,13 +166,16 @@ describe('runLaunchSync — workspace resource mirror', () => {
   it('does not clobber a dangling user symlink at the dest path', () => {
     writeFile(path.join(PROJECT_DIR, '.agents', 'subagents', 'foo', 'AGENT.md'), '---\nname: foo\ndescription: from project\n---\n\nGenerated body.');
     fs.mkdirSync(path.join(PROJECT_DIR, '.claude', 'agents'), { recursive: true });
-    fs.symlinkSync('/tmp/does-not-exist-pls-keep-this-dangling', path.join(PROJECT_DIR, '.claude', 'agents', 'foo.md'));
+    const danglingTarget = path.join(os.tmpdir(), 'does-not-exist-pls-keep-this-dangling');
+    fs.symlinkSync(danglingTarget, path.join(PROJECT_DIR, '.claude', 'agents', 'foo.md'));
 
     const result = runLaunchSync({ agent: 'claude', version: '1.0.0', cwd: PROJECT_DIR });
 
     expect(result.workspaceSkipped).toContain(path.join('.claude', 'agents', 'foo.md'));
     // The dangling symlink must survive — it's in-progress user state.
-    expect(fs.readlinkSync(path.join(PROJECT_DIR, '.claude', 'agents', 'foo.md'))).toBe('/tmp/does-not-exist-pls-keep-this-dangling');
+    const dest = path.join(PROJECT_DIR, '.claude', 'agents', 'foo.md');
+    expect(fs.lstatSync(dest).isSymbolicLink()).toBe(true);  // still a symlink, not clobbered
+    expect(fs.existsSync(dest)).toBe(false);                 // still dangling (target absent)
   });
 
   it('is a no-op for non-claude agents (v1 scope)', () => {

--- a/src/lib/self-update.test.ts
+++ b/src/lib/self-update.test.ts
@@ -155,7 +155,11 @@ describe('installPackageIntoPrefix', () => {
 
     await installPackageIntoPrefix(tarball, prefix);
 
-    const installedRoot = path.join(prefix, 'lib', 'node_modules', '@agents-cli-test', 'dummy');
+    // npm prefix layout is platform-divergent: POSIX nests under lib/, Windows
+    // installs node_modules directly under the prefix. Source handles both.
+    const installedRoot = process.platform === 'win32'
+      ? path.join(prefix, 'node_modules', '@agents-cli-test', 'dummy')
+      : path.join(prefix, 'lib', 'node_modules', '@agents-cli-test', 'dummy');
     expect(readInstalledVersion(installedRoot)).toBe('2.0.0');
     expect(() => verifyInstalledVersion(installedRoot, '2.0.0')).not.toThrow();
     // The exact upgrade-flow composition: the prefix derived from the

--- a/src/lib/session/remote.test.ts
+++ b/src/lib/session/remote.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'child_process';
+import * as path from 'path';
 import {
   buildForwardedArgs,
   buildRemoteCommand,
@@ -184,7 +185,7 @@ describe('remoteCachePath', () => {
     // user@host is a valid ssh target; the path segment must not contain a
     // separator or other unsafe char that would escape the cache dir.
     const p = remoteCachePath('deploy@staging.example.com', ['sessions']);
-    const file = p.split('/').pop()!;
+    const file = path.basename(p);
     expect(file.startsWith('deploy@staging.example.com__')).toBe(true);
     expect(file.endsWith('.txt')).toBe(true);
   });

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -33,6 +33,21 @@ import { SEEDED_REGISTRIES } from './types.js';
 
 const HOME = process.env.HOME ?? os.homedir();
 
+/**
+ * Compare two filesystem paths for identity, resolving symlinks and (on
+ * Windows) 8.3 short-name vs long-name divergence via the OS realpath.
+ * Falls back to a case-folded normalize when a path doesn't exist on disk.
+ */
+function isSamePath(a: string, b: string): boolean {
+  try {
+    return fs.realpathSync.native(a) === fs.realpathSync.native(b);
+  } catch {
+    const norm = (p: string) =>
+      process.platform === 'win32' ? path.resolve(p).toLowerCase() : path.resolve(p);
+    return norm(a) === norm(b);
+  }
+}
+
 // ─── Root directories ─────────────────────────────────────────────────────────
 
 /** User repo — user-authored resources and agents.yaml. Always-on. */
@@ -184,7 +199,7 @@ export function getProjectAgentsDir(startPath: string = process.cwd()): string |
   while (true) {
     const agentsPath = path.join(dir, '.agents');
     if (fs.existsSync(agentsPath) && fs.statSync(agentsPath).isDirectory()) {
-      if (agentsPath !== SYSTEM_AGENTS_DIR && agentsPath !== USER_AGENTS_DIR) {
+      if (!isSamePath(agentsPath, SYSTEM_AGENTS_DIR) && !isSamePath(agentsPath, USER_AGENTS_DIR)) {
         return agentsPath;
       }
     }
@@ -311,6 +326,9 @@ export function getUserPromptcutsPath(): string { return USER_PROMPTCUTS_FILE; }
 //
 // Top-level dirs hold definitions/configs only; runtime data lives under
 // .history/ (durable) or .cache/ (regenerable). See file header.
+
+/** Canonical home anchor (HOME env override or os.homedir()). */
+export function getHomeDir(): string { return HOME; }
 
 /** Bucket root for durable runtime data (~/.agents/.history/). */
 export function getHistoryDir(): string { return HISTORY_DIR; }

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -24,7 +24,7 @@ import chalk from 'chalk';
 import * as TOML from 'smol-toml';
 import { checkbox, select, confirm } from '@inquirer/prompts';
 import type { AgentId, VersionResources } from './types.js';
-import { getVersionsDir, getShimsDir, ensureAgentsDir, readMeta, writeMeta, getCommandsDir, getSkillsDir, getHooksDir, getResolvedRulesDir, getUserRulesDir, getPermissionsDir, getSubagentsDir, getVersionResources, recordVersionResources, ensureVersionResourcePatterns, getMcpDir, getProjectAgentsDir, getPromptcutsPath, getUserPromptcutsPath, getEnabledExtraRepos, getAgentsDir, getOptionalUserAgentsDir, getUserAgentsDir, getTrashVersionsDir, getActiveRulesPreset } from './state.js';
+import { getVersionsDir, getShimsDir, ensureAgentsDir, readMeta, writeMeta, getCommandsDir, getSkillsDir, getHooksDir, getResolvedRulesDir, getUserRulesDir, getPermissionsDir, getSubagentsDir, getVersionResources, recordVersionResources, ensureVersionResourcePatterns, getMcpDir, getProjectAgentsDir, getPromptcutsPath, getUserPromptcutsPath, getEnabledExtraRepos, getAgentsDir, getOptionalUserAgentsDir, getUserAgentsDir, getTrashVersionsDir, getActiveRulesPreset, getHomeDir } from './state.js';
 import { defaultPatterns, expandPatterns } from './resource-patterns.js';
 import { resolveResource, listResources } from './resources.js';
 import { AGENTS, agentConfigDirName, getAccountEmail, getMcpConfigPathForHome, parseMcpConfig, resolveAgentName, formatAgentError, findInPath } from './agents.js';
@@ -900,7 +900,7 @@ export function getBinaryPath(agent: AgentId, version: string): string {
     // per-version — config isolation rides the ~/.factory symlink switch, not a
     // separate binary per version. Mirror the shim's `droid` branch so
     // isVersionInstalled/`agents view` agree with what actually executes.
-    return path.join(os.homedir(), '.local', 'bin', 'droid');
+    return path.join(getHomeDir(), '.local', 'bin', 'droid');
   }
   const versionDir = getVersionDir(agent, version);
   return path.join(versionDir, 'node_modules', '.bin', agentConfig.cliCommand);
@@ -1423,7 +1423,7 @@ export function removeVersion(agent: AgentId, version: string): boolean {
   // Clean up dangling config symlink if it pointed to the removed version
   const symlinkVersion = getConfigSymlinkVersion(agent);
   if (symlinkVersion === version) {
-    const configPath = path.join(os.homedir(), agentConfigDirName(agent));
+    const configPath = path.join(getHomeDir(), agentConfigDirName(agent));
     try {
       fs.unlinkSync(configPath);
     } catch {
@@ -2250,7 +2250,7 @@ export function getEffectiveHome(agentId: AgentId): string {
   if (resolved && isVersionInstalled(agentId, resolved)) {
     return getVersionHomePath(agentId, resolved);
   }
-  return os.homedir();
+  return getHomeDir();
 }
 
 /** Result of resolving agent/version targets from CLI input or interactive selection. */

--- a/src/lib/wallet/__tests__/wallet.test.ts
+++ b/src/lib/wallet/__tests__/wallet.test.ts
@@ -206,8 +206,12 @@ describe('index file safety', () => {
     // Confirm Keychain has the secret (would throw if missing)
     expect(showCard(card.id).pan).toBe(VISA_PAN);
 
-    // Now simulate index write failure: point at a directory we cannot write
-    _setIndexPathForTest('/this/path/does/not/exist/cards.json');
+    // Now simulate index write failure: put a regular file where the index
+    // dir needs to be, so mkdir(recursive) throws ENOTDIR/EEXIST on every OS.
+    // (A leading-`/` path is drive-relative on Windows and mkdir succeeds there.)
+    const blocker = path.join(tmpDir, 'blocker-file');
+    fs.writeFileSync(blocker, 'not a directory');
+    _setIndexPathForTest(path.join(blocker, 'cards.json'));
     expect(() => addCard({
       nickname: 'Will Fail', pan: MC_PAN, cvc: '321', cardholder: 'X', exp_month: '1', exp_year: '2027',
     })).toThrow();

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -1,12 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { existsSync, mkdirSync, rmSync, readFileSync, lstatSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { join, relative } from 'path';
 import { tmpdir, homedir } from 'os';
 
 const { TEST_REAL_HOME } = vi.hoisted(() => {
   const { tmpdir } = require('node:os');
   const { join } = require('node:path');
-  return { TEST_REAL_HOME: join(tmpdir(), 'agents-cli-sandbox-real-home') };
+  const { realpathSync } = require('node:fs');
+  // Canonicalize the tmp base so the mocked homedir() matches what
+  // realpathSync() returns inside symlinkAllowedDirs. On Windows tmpdir() is an
+  // 8.3 short name (RUNNER~1 vs runneradmin); on macOS /var symlinks to
+  // /private/var. Without this the source's HOME-containment guard sees the two
+  // forms as different and skips the link.
+  return { TEST_REAL_HOME: join(realpathSync(tmpdir()), 'agents-cli-sandbox-real-home') };
 });
 
 // vi.importActual / importOriginal are vitest-only; pull the real `os` via
@@ -323,10 +329,12 @@ describe('symlinkAllowedDirs', () => {
   it('creates symlink for HOME-relative dirs', () => {
     symlinkAllowedDirs(overlayHome, [realDir]);
 
-    const relative = realDir.replace(homedir() + '/', '');
-    const expectedLink = join(overlayHome, relative);
+    const expectedLink = join(overlayHome, relative(homedir(), realDir));
     expect(existsSync(expectedLink)).toBe(true);
-    expect(lstatSync(expectedLink).isSymbolicLink()).toBe(true);
+    // Windows links directories as junctions (no elevation needed); junctions
+    // report as directories, not symlinks. POSIX uses a real symlink.
+    const st = lstatSync(expectedLink);
+    expect(process.platform === 'win32' ? st.isDirectory() : st.isSymbolicLink()).toBe(true);
   });
 
   it('skips dirs outside HOME', () => {
@@ -342,8 +350,7 @@ describe('symlinkAllowedDirs', () => {
 
     symlinkAllowedDirs(overlayHome, [nestedDir]);
 
-    const relative = nestedDir.replace(homedir() + '/', '');
-    const expectedLink = join(overlayHome, relative);
+    const expectedLink = join(overlayHome, relative(homedir(), nestedDir));
     expect(existsSync(expectedLink)).toBe(true);
   });
 });

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -331,10 +331,10 @@ describe('symlinkAllowedDirs', () => {
 
     const expectedLink = join(overlayHome, relative(homedir(), realDir));
     expect(existsSync(expectedLink)).toBe(true);
-    // Windows links directories as junctions (no elevation needed); junctions
-    // report as directories, not symlinks. POSIX uses a real symlink.
-    const st = lstatSync(expectedLink);
-    expect(process.platform === 'win32' ? st.isDirectory() : st.isSymbolicLink()).toBe(true);
+    // Node reports a Windows junction as a symbolic link (a reparse point maps to
+    // S_IFLNK), so isSymbolicLink() holds on both POSIX (symlink) and Windows
+    // (junction).
+    expect(lstatSync(expectedLink).isSymbolicLink()).toBe(true);
   });
 
   it('skips dirs outside HOME', () => {

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -3,7 +3,11 @@ import { existsSync, mkdirSync, rmSync, readFileSync, lstatSync, writeFileSync }
 import { join } from 'path';
 import { tmpdir, homedir } from 'os';
 
-const TEST_REAL_HOME = join(tmpdir(), 'agents-cli-sandbox-real-home');
+const { TEST_REAL_HOME } = vi.hoisted(() => {
+  const { tmpdir } = require('node:os');
+  const { join } = require('node:path');
+  return { TEST_REAL_HOME: join(tmpdir(), 'agents-cli-sandbox-real-home') };
+});
 
 // vi.importActual / importOriginal are vitest-only; pull the real `os` via
 // `node:os` so this mock works under Bun's native test runner too.


### PR DESCRIPTION
## What

Greens the `windows-latest` CI matrix and **removes `continue-on-error`** so Windows becomes a required, merge-blocking check alongside Linux and macOS.

Before this PR, `windows-latest` was non-blocking (`ci.yml` `continue-on-error: ${{ matrix.os == 'windows-latest' }}`), so the matrix reported green while **14 tests + 1 suite** failed on Windows underneath (most recent main run: `12 test files failed | 234 passed`).

## Two genuine cross-platform source bugs

1. **`versions.ts` home anchor** — the droid binary path, config-symlink cleanup, and `getEffectiveHome` resolved home via raw `os.homedir()` (which reads `%USERPROFILE%` on Windows), while the module's canonical anchor is `state.ts` `HOME = process.env.HOME ?? os.homedir()`. Under tests that redirect home via `HOME`, the two diverged on Windows and the installed-version list came back empty (`resolveVersionAlias` x3 failures). Routed all three sites through a new exported `state.getHomeDir()`.
2. **`getProjectAgentsDir` walk-up guard** — the `~/.agents` skip-check compared paths by raw string, so an 8.3 short-name temp path (`C:\Users\RUNNER~1\.agents`) never matched the long-name `USER_AGENTS_DIR` (`runneradmin`), and the walk-up wrongly returned the real `~/.agents` instead of `null`. Now compares canonical realpaths via `isSamePath()`.

## The rest: POSIX-only test-fixture assumptions (no source change, no skips)

| Test | Fix |
|---|---|
| `local.test.ts`, `bugfixes.test.ts` | set `USERPROFILE` alongside `HOME` so `os.homedir()` honors the redirect on Windows (mirrors existing `cloud.test.ts`) |
| `remote.test.ts` | `path.basename` instead of `split('/')` |
| `self-update.test.ts` | branch npm prefix layout (Windows `node_modules` vs POSIX `lib/node_modules`) |
| `hooks.test.ts` | hash the portable command persisted to `hooks.json`, not the raw native path |
| `migrate.test.ts` / `__tests__/migrate.test.ts` | PATHEXT extension on the fake PATH binary; build the stale path directly instead of a `/`-replace |
| `project-launch.test.ts` | assert the dangling-symlink invariant, not a verbatim POSIX readlink target |
| `wallet.test.ts` | trigger index-write failure with a file-blocked parent dir (a leading-`/` mkdir *succeeds* on Windows) |
| `tests/sandbox.test.ts` | `vi.hoisted()` for `TEST_REAL_HOME` so the hoisted `vi.mock('os')` factory can't read it in the TDZ |

## Verification

- All 12 changed test files pass on Linux (**250/250**).
- Zero regression: the 5 pre-existing env-dependent failures (drive-sync, network installs, keychain) fail **identically** on `origin/main` baseline (35) and on this branch (35).
- The authoritative check is this PR's own `windows-latest` legs — now required, so the PR cannot merge until Windows is actually green.

No test skips; every behavior is exercised on all platforms.