### PR TITLE
feat(computer): Windows computer-use companion app (computer-helper-win)

### DIFF
--- a/.github/workflows/computer-helper-win.yml
+++ b/.github/workflows/computer-helper-win.yml
@@ -1,0 +1,47 @@
+name: computer-helper-win
+
+# Builds and smoke-tests the Windows computer-use daemon on a real Windows
+# runner. Self-contained (does not touch the main CI matrix) so it can land on
+# the win-computer-use branch without rebasing onto main's CI changes.
+#
+# Non-blocking for now (continue-on-error) until the verb set reaches parity
+# with the macOS helper — promote to a required check once green and stable.
+
+on:
+  push:
+    branches: ['win-computer-use', 'main']
+    paths:
+      - 'packages/computer-helper-win/**'
+      - '.github/workflows/computer-helper-win.yml'
+  pull_request:
+    paths:
+      - 'packages/computer-helper-win/**'
+      - '.github/workflows/computer-helper-win.yml'
+
+jobs:
+  build-and-smoke:
+    runs-on: windows-latest
+    continue-on-error: true
+    permissions: {}
+    defaults:
+      run:
+        working-directory: packages/computer-helper-win
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build (native win-x64)
+        run: dotnet build -c Release
+
+      - name: Smoke test (UIAutomation roundtrip + screenshot)
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem -Recurse -Path bin/Release -Filter computer-helper-win.exe | Select-Object -First 1
+          if (-not $exe) { throw "built exe not found under bin/Release" }
+          Write-Host "exe: $($exe.FullName)"
+          node smoke/smoke.mjs --exe "$($exe.FullName)" --port 8771

--- a/packages/computer-helper-win/.gitignore
+++ b/packages/computer-helper-win/.gitignore
@@ -1,0 +1,6 @@
+# .NET build outputs — the daemon exe is staged into the npm tarball at
+# release time by scripts, not committed.
+bin/
+obj/
+dist/
+build.log

--- a/packages/computer-helper-win/Apps.cs
+++ b/packages/computer-helper-win/Apps.cs
@@ -1,0 +1,88 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+namespace ComputerHelperWin;
+
+/// <summary>
+/// App enumeration + launch. Windows has no bundle ids, so we use the process
+/// image name as the `bundle_id` analog. Result shapes mirror Apps.swift:
+/// list_apps → {apps:[{pid,name,bundle_id,active,hidden,excluded}]},
+/// launch_app → {pid,name,bundle_id}.
+/// </summary>
+public static class Apps
+{
+    [DllImport("user32.dll")] private static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll")] private static extern bool IsWindowVisible(IntPtr hWnd);
+
+    public static Dictionary<string, object?> ListApps()
+    {
+        IntPtr fg = GetForegroundWindow();
+        var apps = new List<Dictionary<string, object?>>();
+
+        foreach (var p in Process.GetProcesses())
+        {
+            try
+            {
+                IntPtr hwnd = p.MainWindowHandle;
+                if (hwnd == IntPtr.Zero) continue; // only windowed apps, like the macOS list
+                string title = p.MainWindowTitle;
+                apps.Add(new()
+                {
+                    ["pid"] = p.Id,
+                    ["name"] = string.IsNullOrEmpty(title) ? p.ProcessName : title,
+                    ["bundle_id"] = p.ProcessName, // no bundle ids on Windows
+                    ["active"] = hwnd == fg,
+                    ["hidden"] = !IsWindowVisible(hwnd),
+                    ["excluded"] = false,
+                });
+            }
+            catch
+            {
+                // Process exited or access denied mid-enumeration — skip it.
+            }
+            finally
+            {
+                p.Dispose();
+            }
+        }
+
+        return new() { ["apps"] = apps };
+    }
+
+    public static Dictionary<string, object?> LaunchApp(JsonElement @params)
+    {
+        string? bundleId = P.StringOpt(@params, "bundle_id");
+        string? path = P.StringOpt(@params, "path");
+        string? name = P.StringOpt(@params, "name");
+
+        // The launch target: an explicit path, else the name/bundle_id which
+        // ShellExecute resolves via PATH + the App Paths registry (so "msedge"
+        // / "notepad" work without a full path).
+        string target = path ?? name ?? bundleId
+            ?? throw RpcError.Invalid("pass one of: bundle_id, path, name");
+
+        if ((name ?? "").Contains("..") || (name ?? "").Contains('/'))
+            throw RpcError.Invalid("name must not contain '/' or '..' — use path instead");
+
+        try
+        {
+            var psi = new ProcessStartInfo(target) { UseShellExecute = true };
+            var proc = Process.Start(psi)
+                ?? throw new RpcError("action_failed", $"failed to launch: {target}");
+            // ShellExecute may return a launcher that hands off to an existing
+            // instance; pid/name are best-effort in that case.
+            return new()
+            {
+                ["pid"] = proc.HasExited ? 0 : proc.Id,
+                ["name"] = target,
+                ["bundle_id"] = System.IO.Path.GetFileNameWithoutExtension(target),
+            };
+        }
+        catch (RpcError) { throw; }
+        catch (Exception e)
+        {
+            throw new RpcError("action_failed", $"launch failed for {target}: {e.Message}");
+        }
+    }
+}

--- a/packages/computer-helper-win/Automation.cs
+++ b/packages/computer-helper-win/Automation.cs
@@ -1,0 +1,153 @@
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+namespace ComputerHelperWin;
+
+/// <summary>
+/// Input + UIAutomation backend. This first slice implements the
+/// coordinate/input verbs (click x/y, type_text, key) via SendInput, which are
+/// directly visually verifiable. The UIAutomation tree verbs (describe →
+/// id-addressable click/get_text/set_focus/set value) are the next increment
+/// and currently report action_unsupported so the contract stays explicit.
+/// </summary>
+public sealed class Automation
+{
+    // ---- click ----------------------------------------------------------
+    public Dictionary<string, object?> Click(JsonElement p)
+    {
+        if (p.TryGetProperty("x", out var xe) && p.TryGetProperty("y", out var ye))
+        {
+            int x = xe.GetInt32(), y = ye.GetInt32();
+            MoveCursor(x, y);
+            SendMouse(MOUSEEVENTF_LEFTDOWN | MOUSEEVENTF_LEFTUP);
+            return new() { ["ok"] = true, ["x"] = x, ["y"] = y };
+        }
+        // id-based click needs the describe() element cache — not built yet.
+        throw RpcError.Unsupported("click by element id (use --x/--y for now; describe-cache is the next increment)");
+    }
+
+    // ---- type_text: unicode characters into the focused control ----------
+    public Dictionary<string, object?> TypeText(JsonElement p)
+    {
+        string text = P.StringOpt(p, "text") ?? throw RpcError.Invalid("type_text needs `text`");
+        int delayMs = P.IntOr(p, "char_delay_ms", 0);
+        foreach (char ch in text)
+        {
+            SendUnicode(ch);
+            if (delayMs > 0) Thread.Sleep(delayMs);
+        }
+        if (P.BoolOr(p, "commit", false)) SendVirtualKey(VK_RETURN);
+        return new() { ["ok"] = true, ["chars"] = text.Length };
+    }
+
+    // ---- key: a chord like "enter", "ctrl+a", "alt+f4" -------------------
+    public Dictionary<string, object?> SendKey(JsonElement p)
+    {
+        string keys = P.StringOpt(p, "keys") ?? P.StringOpt(p, "key")
+            ?? throw RpcError.Invalid("key needs `keys`");
+        var parts = keys.Split('+', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var mods = new List<ushort>();
+        ushort? main = null;
+        foreach (var raw in parts)
+        {
+            var tok = raw.ToLowerInvariant();
+            switch (tok)
+            {
+                case "ctrl" or "control": mods.Add(VK_CONTROL); break;
+                case "alt" or "option": mods.Add(VK_MENU); break;
+                case "shift": mods.Add(VK_SHIFT); break;
+                case "win" or "cmd" or "meta" or "super": mods.Add(VK_LWIN); break;
+                default: main = ResolveKey(tok); break;
+            }
+        }
+        if (main is null) throw RpcError.Invalid($"unrecognized key in chord: {keys}");
+        foreach (var m in mods) SendKeyEvent(m, false);
+        SendKeyEvent(main.Value, false);
+        SendKeyEvent(main.Value, true);
+        for (int i = mods.Count - 1; i >= 0; i--) SendKeyEvent(mods[i], true);
+        return new() { ["ok"] = true };
+    }
+
+    // ---- not-yet-implemented (UIAutomation tree) ------------------------
+    public Dictionary<string, object?> Describe(JsonElement p)
+        => throw RpcError.Unsupported("describe (UIAutomation tree walk) is the next increment");
+    public Dictionary<string, object?> SetValue(JsonElement p)
+        => throw RpcError.Unsupported("type (set value via ValuePattern) is the next increment");
+    public Dictionary<string, object?> SetFocus(JsonElement p)
+        => throw RpcError.Unsupported("set_focus is the next increment");
+    public Dictionary<string, object?> GetText(JsonElement p)
+        => throw RpcError.Unsupported("get_text is the next increment");
+
+    // ---- key name → virtual-key code ------------------------------------
+    private static ushort ResolveKey(string k) => k switch
+    {
+        "enter" or "return" => VK_RETURN,
+        "esc" or "escape" => VK_ESCAPE,
+        "tab" => VK_TAB,
+        "space" => VK_SPACE,
+        "backspace" => VK_BACK,
+        "delete" or "del" => VK_DELETE,
+        "up" => VK_UP,
+        "down" => VK_DOWN,
+        "left" => VK_LEFT,
+        "right" => VK_RIGHT,
+        "home" => VK_HOME,
+        "end" => VK_END,
+        _ when k.Length == 1 => (ushort)char.ToUpperInvariant(k[0]),
+        _ => throw RpcError.Invalid($"unknown key: {k}"),
+    };
+
+    // ---- SendInput interop ----------------------------------------------
+    private const uint INPUT_MOUSE = 0, INPUT_KEYBOARD = 1;
+    private const uint MOUSEEVENTF_MOVE = 0x0001, MOUSEEVENTF_ABSOLUTE = 0x8000;
+    private const uint MOUSEEVENTF_LEFTDOWN = 0x0002, MOUSEEVENTF_LEFTUP = 0x0004;
+    private const uint KEYEVENTF_KEYUP = 0x0002, KEYEVENTF_UNICODE = 0x0004;
+    private const ushort VK_BACK = 0x08, VK_TAB = 0x09, VK_RETURN = 0x0D, VK_SHIFT = 0x10,
+        VK_CONTROL = 0x11, VK_MENU = 0x12, VK_ESCAPE = 0x1B, VK_SPACE = 0x20,
+        VK_END = 0x23, VK_HOME = 0x24, VK_LEFT = 0x25, VK_UP = 0x26, VK_RIGHT = 0x27,
+        VK_DOWN = 0x28, VK_DELETE = 0x2E, VK_LWIN = 0x5B;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct INPUT { public uint type; public InputUnion U; }
+    [StructLayout(LayoutKind.Explicit)]
+    private struct InputUnion { [FieldOffset(0)] public MOUSEINPUT mi; [FieldOffset(0)] public KEYBDINPUT ki; }
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MOUSEINPUT { public int dx; public int dy; public uint mouseData; public uint dwFlags; public uint time; public IntPtr dwExtraInfo; }
+    [StructLayout(LayoutKind.Sequential)]
+    private struct KEYBDINPUT { public ushort wVk; public ushort wScan; public uint dwFlags; public uint time; public IntPtr dwExtraInfo; }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+    [DllImport("user32.dll")] private static extern bool SetCursorPos(int x, int y);
+    [DllImport("user32.dll")] private static extern int GetSystemMetrics(int n);
+
+    private static void MoveCursor(int x, int y) => SetCursorPos(x, y);
+
+    private static void SendMouse(uint flags)
+    {
+        var inp = new INPUT[]
+        {
+            new() { type = INPUT_MOUSE, U = new InputUnion { mi = new MOUSEINPUT { dwFlags = flags } } },
+        };
+        SendInput((uint)inp.Length, inp, Marshal.SizeOf<INPUT>());
+    }
+
+    private static void SendKeyEvent(ushort vk, bool keyUp)
+    {
+        var inp = new INPUT[]
+        {
+            new() { type = INPUT_KEYBOARD, U = new InputUnion { ki = new KEYBDINPUT { wVk = vk, dwFlags = keyUp ? KEYEVENTF_KEYUP : 0 } } },
+        };
+        SendInput((uint)inp.Length, inp, Marshal.SizeOf<INPUT>());
+    }
+
+    private static void SendVirtualKey(ushort vk) { SendKeyEvent(vk, false); SendKeyEvent(vk, true); }
+
+    private static void SendUnicode(char ch)
+    {
+        var down = new INPUT { type = INPUT_KEYBOARD, U = new InputUnion { ki = new KEYBDINPUT { wScan = ch, dwFlags = KEYEVENTF_UNICODE } } };
+        var up = new INPUT { type = INPUT_KEYBOARD, U = new InputUnion { ki = new KEYBDINPUT { wScan = ch, dwFlags = KEYEVENTF_UNICODE | KEYEVENTF_KEYUP } } };
+        var inp = new[] { down, up };
+        SendInput((uint)inp.Length, inp, Marshal.SizeOf<INPUT>());
+    }
+}

--- a/packages/computer-helper-win/Automation.cs
+++ b/packages/computer-helper-win/Automation.cs
@@ -1,29 +1,263 @@
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using System.Windows;
+using System.Windows.Automation;
+using System.Windows.Automation.Text;
 
 namespace ComputerHelperWin;
 
 /// <summary>
-/// Input + UIAutomation backend. This first slice implements the
-/// coordinate/input verbs (click x/y, type_text, key) via SendInput, which are
-/// directly visually verifiable. The UIAutomation tree verbs (describe →
-/// id-addressable click/get_text/set_focus/set value) are the next increment
-/// and currently report action_unsupported so the contract stays explicit.
+/// Input + UIAutomation backend.
+///
+/// Two layers:
+///   - Coordinate/input verbs (click x/y, type_text, key) via Win32 SendInput —
+///     the universal fallback for canvas apps and anything off the UIA tree.
+///   - UIAutomation tree verbs (describe -> id-addressable click / get_text /
+///     set_focus / type) via System.Windows.Automation, the Windows analogue of
+///     the macOS Accessibility (AXUIElement) backend in packages/computer-helper.
+///
+/// The result shapes mirror the macOS helper (AX.swift) so the single TS client
+/// in src/lib/computer-rpc.ts drives both platforms unchanged:
+///   describe -> { pid, tree, element_count, truncated }
+///   node     -> { id, role, enabled, label?, value?, bounds:[x,y,w,h]?, children? }
+/// Element ids are "@eN", reset on every describe (a stale id throws
+/// element_stale, prompting a re-describe — same contract as macOS).
 /// </summary>
 public sealed class Automation
 {
+    private readonly ElementCache _cache = new();
+
+    // ---- describe: UIAutomation tree walk -------------------------------
+    public Dictionary<string, object?> Describe(JsonElement p)
+    {
+        int pid = P.Int(p, "pid");
+        int maxDepth = P.IntOr(p, "max_depth", MaxDepthDefault);
+
+        var windows = TopLevelWindows(pid);
+        if (windows.Count == 0) throw RpcError.AppMissing(pid);
+
+        _cache.BeginDescribe(pid);
+        int counter = 0;
+        bool truncated = false;
+
+        // Synthetic application root (depth 0, always emitted) carrying the
+        // process's top-level windows — mirrors the macOS AXApplication root.
+        var rootId = _cache.NextRefId(pid);
+        var children = new List<Dictionary<string, object?>>();
+        foreach (var w in windows)
+        {
+            var node = Walk(w, pid, depth: 1, maxDepth, ref counter, ref truncated);
+            if (node != null) children.Add(node);
+        }
+        counter++;
+
+        var tree = new Dictionary<string, object?>
+        {
+            ["id"] = rootId,
+            ["role"] = "Application",
+            ["enabled"] = true,
+        };
+        var procName = SafeProcessName(pid);
+        if (procName != null) tree["label"] = procName;
+        if (children.Count > 0) tree["children"] = children;
+
+        return new()
+        {
+            ["pid"] = pid,
+            ["tree"] = tree,
+            ["element_count"] = counter,
+            ["truncated"] = truncated,
+        };
+    }
+
+    private Dictionary<string, object?>? Walk(
+        AutomationElement el, int pid, int depth, int maxDepth, ref int counter, ref bool truncated)
+    {
+        if (counter >= MaxElements) { truncated = true; return null; }
+        if (depth > maxDepth) return null;
+
+        string role;
+        string? label;
+        bool enabled;
+        int[]? bounds;
+        try
+        {
+            var info = el.Current;
+            role = ControlTypeName(info.ControlType);
+            label = NullIfEmpty(info.Name);
+            enabled = info.IsEnabled;
+            bounds = RectToBounds(info.BoundingRectangle);
+        }
+        catch (ElementNotAvailableException)
+        {
+            return null; // element vanished mid-walk — skip it
+        }
+        string? value = TryReadValue(el);
+
+        // Recurse via the ControlView walker (filters out raw/noise elements,
+        // the closest UIA analogue to the macOS interesting-roles filter).
+        var childNodes = new List<Dictionary<string, object?>>();
+        try
+        {
+            var walker = TreeWalker.ControlViewWalker;
+            for (var child = walker.GetFirstChild(el); child != null; child = walker.GetNextSibling(child))
+            {
+                var node = Walk(child, pid, depth + 1, maxDepth, ref counter, ref truncated);
+                if (node != null) childNodes.Add(node);
+                if (counter >= MaxElements) { truncated = true; break; }
+            }
+        }
+        catch (ElementNotAvailableException) { /* subtree gone — emit what we have */ }
+
+        bool isInteractable = InteractableRoles.Contains(role);
+        bool isContent = ContentRoles.Contains(role) && (label != null || !string.IsNullOrEmpty(value));
+        bool hasChildren = childNodes.Count > 0;
+        bool isTextEntry = role is "Edit" or "Document";
+
+        bool shouldEmit = isContent
+            || (isInteractable && (label != null || isTextEntry || hasChildren));
+
+        if (!shouldEmit)
+        {
+            // Flatten empty/unlabeled containers: pass children up.
+            if (childNodes.Count == 1) return childNodes[0];
+            if (childNodes.Count == 0) return null;
+            return new Dictionary<string, object?> { ["role"] = "Group", ["children"] = childNodes };
+        }
+
+        counter++;
+        var id = _cache.NextRefId(pid);
+        _cache.Put(pid, id, el);
+
+        var nodeOut = new Dictionary<string, object?>
+        {
+            ["id"] = id,
+            ["role"] = role,
+            ["enabled"] = enabled,
+        };
+        if (label != null) nodeOut["label"] = label;
+        if (!string.IsNullOrEmpty(value) && value != label) nodeOut["value"] = TruncateForDisplay(value!);
+        if (bounds != null) nodeOut["bounds"] = bounds;
+        if (childNodes.Count > 0) nodeOut["children"] = childNodes;
+        return nodeOut;
+    }
+
     // ---- click ----------------------------------------------------------
     public Dictionary<string, object?> Click(JsonElement p)
     {
+        // id-addressable click: resolve the element, prefer a UIA pattern,
+        // fall back to a synthetic click at its on-screen center.
+        string? elementId = P.StringOpt(p, "element_id");
+        if (elementId != null)
+        {
+            int pid = P.Int(p, "pid");
+            var el = _cache.Get(pid, elementId) ?? throw RpcError.Stale();
+            try
+            {
+                if (el.TryGetCurrentPattern(InvokePattern.Pattern, out var inv))
+                {
+                    ((InvokePattern)inv).Invoke();
+                    return new() { ["ok"] = true, ["action"] = "invoke" };
+                }
+                if (el.TryGetCurrentPattern(TogglePattern.Pattern, out var tog))
+                {
+                    ((TogglePattern)tog).Toggle();
+                    return new() { ["ok"] = true, ["action"] = "toggle" };
+                }
+                if (el.TryGetCurrentPattern(SelectionItemPattern.Pattern, out var sel))
+                {
+                    ((SelectionItemPattern)sel).Select();
+                    return new() { ["ok"] = true, ["action"] = "select" };
+                }
+                // No actionable pattern — click the element's center physically.
+                var b = RectToBounds(el.Current.BoundingRectangle)
+                    ?? throw RpcError.Unsupported("element has no invoke/toggle/select pattern and no bounds");
+                int cx = b[0] + b[2] / 2, cy = b[1] + b[3] / 2;
+                MoveCursor(cx, cy);
+                SendMouse(MOUSEEVENTF_LEFTDOWN | MOUSEEVENTF_LEFTUP);
+                return new() { ["ok"] = true, ["action"] = "click", ["at"] = new[] { cx, cy } };
+            }
+            catch (ElementNotAvailableException) { throw RpcError.Stale(); }
+        }
+
+        // Coordinate click (no element_id): the universal fallback.
         if (p.TryGetProperty("x", out var xe) && p.TryGetProperty("y", out var ye))
         {
             int x = xe.GetInt32(), y = ye.GetInt32();
             MoveCursor(x, y);
             SendMouse(MOUSEEVENTF_LEFTDOWN | MOUSEEVENTF_LEFTUP);
-            return new() { ["ok"] = true, ["x"] = x, ["y"] = y };
+            return new() { ["ok"] = true, ["action"] = "click", ["at"] = new[] { x, y } };
         }
-        // id-based click needs the describe() element cache — not built yet.
-        throw RpcError.Unsupported("click by element id (use --x/--y for now; describe-cache is the next increment)");
+        throw RpcError.Invalid("pass either element_id or x,y");
+    }
+
+    // ---- type / set value (ValuePattern, focus+type fallback) -----------
+    public Dictionary<string, object?> SetValue(JsonElement p)
+    {
+        string text = P.StringOpt(p, "value") ?? P.StringOpt(p, "text")
+            ?? throw RpcError.Invalid("type needs `value` (or `text`)");
+        string elementId = P.StringOpt(p, "element_id")
+            ?? throw RpcError.Invalid("type needs `element_id` (use type_text for the focused field)");
+        int pid = P.Int(p, "pid");
+        var el = _cache.Get(pid, elementId) ?? throw RpcError.Stale();
+
+        try
+        {
+            if (IsSecureField(el) && !P.BoolOr(p, "allow_secure_field", false))
+                throw RpcError.Denied("secure text field — set allow_secure_field=true to override");
+
+            if (el.TryGetCurrentPattern(ValuePattern.Pattern, out var vp))
+            {
+                var value = (ValuePattern)vp;
+                if (value.Current.IsReadOnly)
+                    throw RpcError.Unsupported($"value is read-only on element {elementId}");
+                value.SetValue(text);
+                bool committedVp = false;
+                if (P.BoolOr(p, "commit", false)) { el.SetFocus(); SendVirtualKey(VK_RETURN); committedVp = true; }
+                return new() { ["ok"] = true, ["committed"] = committedVp };
+            }
+
+            // No ValuePattern — focus and type the characters.
+            el.SetFocus();
+            foreach (char ch in text) SendUnicode(ch);
+            bool committed = false;
+            if (P.BoolOr(p, "commit", false)) { SendVirtualKey(VK_RETURN); committed = true; }
+            return new() { ["ok"] = true, ["committed"] = committed };
+        }
+        catch (ElementNotAvailableException) { throw RpcError.Stale(); }
+    }
+
+    // ---- set_focus ------------------------------------------------------
+    public Dictionary<string, object?> SetFocus(JsonElement p)
+    {
+        string elementId = P.StringOpt(p, "element_id") ?? throw RpcError.Invalid("set_focus needs `element_id`");
+        int pid = P.Int(p, "pid");
+        var el = _cache.Get(pid, elementId) ?? throw RpcError.Stale();
+        try { el.SetFocus(); return new() { ["ok"] = true }; }
+        catch (ElementNotAvailableException) { throw RpcError.Stale(); }
+        catch (Exception e) { throw new RpcError("action_failed", $"SetFocus failed: {e.Message}"); }
+    }
+
+    // ---- get_text -------------------------------------------------------
+    public Dictionary<string, object?> GetText(JsonElement p)
+    {
+        string? elementId = P.StringOpt(p, "element_id");
+        if (elementId == null) throw RpcError.Invalid("get_text needs `element_id`");
+        int pid = P.Int(p, "pid");
+        var el = _cache.Get(pid, elementId) ?? throw RpcError.Stale();
+        try
+        {
+            // Prefer rich document text, then ValuePattern, then the Name.
+            if (el.TryGetCurrentPattern(TextPattern.Pattern, out var tp))
+            {
+                var text = ((TextPattern)tp).DocumentRange.GetText(MaxTextChars);
+                return new() { ["text"] = text };
+            }
+            if (el.TryGetCurrentPattern(ValuePattern.Pattern, out var vp))
+                return new() { ["text"] = ((ValuePattern)vp).Current.Value ?? "" };
+            return new() { ["text"] = el.Current.Name ?? "" };
+        }
+        catch (ElementNotAvailableException) { throw RpcError.Stale(); }
     }
 
     // ---- type_text: unicode characters into the focused control ----------
@@ -68,17 +302,87 @@ public sealed class Automation
         return new() { ["ok"] = true };
     }
 
-    // ---- not-yet-implemented (UIAutomation tree) ------------------------
-    public Dictionary<string, object?> Describe(JsonElement p)
-        => throw RpcError.Unsupported("describe (UIAutomation tree walk) is the next increment");
-    public Dictionary<string, object?> SetValue(JsonElement p)
-        => throw RpcError.Unsupported("type (set value via ValuePattern) is the next increment");
-    public Dictionary<string, object?> SetFocus(JsonElement p)
-        => throw RpcError.Unsupported("set_focus is the next increment");
-    public Dictionary<string, object?> GetText(JsonElement p)
-        => throw RpcError.Unsupported("get_text is the next increment");
+    // ---- describe/value tuning ------------------------------------------
+    private const int MaxElements = 500;
+    private const int MaxDepthDefault = 25;
+    private const int MaxTextChars = 20_000;
+    private const int MaxValueDisplayChars = 400;
 
-    // ---- key name → virtual-key code ------------------------------------
+    // Roles surfaced to the agent as interactable (UIA ControlType short names).
+    private static readonly HashSet<string> InteractableRoles = new()
+    {
+        "Button", "CheckBox", "RadioButton", "ComboBox", "Edit", "Document",
+        "Hyperlink", "MenuItem", "Tab", "TabItem", "ListItem", "TreeItem",
+        "Slider", "SplitButton", "Spinner", "List", "Tree", "Table", "DataItem",
+        "Menu", "ToolBar", "ScrollBar", "Thumb",
+    };
+
+    // Roles that carry content we surface when labeled/valued.
+    private static readonly HashSet<string> ContentRoles = new() { "Text", "Image", "Header" };
+
+    // ControlType.ProgrammaticName is "ControlType.Button"; strip the prefix for
+    // a clean, locale-independent role string.
+    private static string ControlTypeName(ControlType ct)
+    {
+        var name = ct?.ProgrammaticName ?? "Custom";
+        int dot = name.LastIndexOf('.');
+        return dot >= 0 ? name[(dot + 1)..] : name;
+    }
+
+    private static string? TryReadValue(AutomationElement el)
+    {
+        try
+        {
+            if (el.TryGetCurrentPattern(ValuePattern.Pattern, out var vp))
+                return NullIfEmpty(((ValuePattern)vp).Current.Value);
+            if (el.TryGetCurrentPattern(RangeValuePattern.Pattern, out var rp))
+                return ((RangeValuePattern)rp).Current.Value.ToString("0.###");
+        }
+        catch (ElementNotAvailableException) { }
+        catch (InvalidOperationException) { }
+        return null;
+    }
+
+    private static bool IsSecureField(AutomationElement el)
+    {
+        try { return el.Current.IsPassword; }
+        catch { return false; }
+    }
+
+    private static int[]? RectToBounds(Rect r)
+    {
+        if (r.IsEmpty) return null;
+        if (double.IsInfinity(r.X) || double.IsInfinity(r.Y) ||
+            double.IsInfinity(r.Width) || double.IsInfinity(r.Height)) return null;
+        if (r.Width <= 0 || r.Height <= 0) return null;
+        return new[] { (int)r.X, (int)r.Y, (int)r.Width, (int)r.Height };
+    }
+
+    private static string TruncateForDisplay(string s)
+        => s.Length <= MaxValueDisplayChars ? s : s[..MaxValueDisplayChars] + "...";
+
+    private static string? NullIfEmpty(string? s) => string.IsNullOrEmpty(s) ? null : s;
+
+    private static List<AutomationElement> TopLevelWindows(int pid)
+    {
+        var result = new List<AutomationElement>();
+        try
+        {
+            var cond = new PropertyCondition(AutomationElement.ProcessIdProperty, pid);
+            var found = AutomationElement.RootElement.FindAll(TreeScope.Children, cond);
+            foreach (AutomationElement w in found) result.Add(w);
+        }
+        catch (ElementNotAvailableException) { }
+        return result;
+    }
+
+    private static string? SafeProcessName(int pid)
+    {
+        try { using var proc = System.Diagnostics.Process.GetProcessById(pid); return proc.ProcessName; }
+        catch { return null; }
+    }
+
+    // ---- key name -> virtual-key code -----------------------------------
     private static ushort ResolveKey(string k) => k switch
     {
         "enter" or "return" => VK_RETURN,

--- a/packages/computer-helper-win/ElementCache.cs
+++ b/packages/computer-helper-win/ElementCache.cs
@@ -1,0 +1,64 @@
+using System.Windows.Automation;
+
+namespace ComputerHelperWin;
+
+/// <summary>
+/// Per-process element handle cache, mirroring the macOS ElementCache.
+///
+/// describe() assigns each emitted element a short id ("@e1", "@e2", ...) and
+/// stashes the live AutomationElement here so a follow-up click/get_text/type
+/// can resolve the id back to the element. BeginDescribe(pid) clears the prior
+/// generation, so ids only live until the next describe of that pid — a later
+/// click with a stale id misses the lookup and the caller gets element_stale.
+///
+/// Connections are served on thread-pool threads (Program.HandleConnection), so
+/// every operation is guarded by a lock.
+/// </summary>
+public sealed class ElementCache
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<int, Dictionary<string, AutomationElement>> _byPid = new();
+    private readonly Dictionary<int, int> _counter = new();
+
+    /// <summary>Drop the prior generation for this pid and reset its id counter.</summary>
+    public void BeginDescribe(int pid)
+    {
+        lock (_gate)
+        {
+            _byPid[pid] = new Dictionary<string, AutomationElement>();
+            _counter[pid] = 0;
+        }
+    }
+
+    /// <summary>Allocate the next "@eN" id for this pid.</summary>
+    public string NextRefId(int pid)
+    {
+        lock (_gate)
+        {
+            int n = _counter.TryGetValue(pid, out var c) ? c + 1 : 1;
+            _counter[pid] = n;
+            return $"@e{n}";
+        }
+    }
+
+    public void Put(int pid, string id, AutomationElement element)
+    {
+        lock (_gate)
+        {
+            if (!_byPid.TryGetValue(pid, out var map))
+            {
+                map = new Dictionary<string, AutomationElement>();
+                _byPid[pid] = map;
+            }
+            map[id] = element;
+        }
+    }
+
+    public AutomationElement? Get(int pid, string id)
+    {
+        lock (_gate)
+        {
+            return _byPid.TryGetValue(pid, out var map) && map.TryGetValue(id, out var el) ? el : null;
+        }
+    }
+}

--- a/packages/computer-helper-win/Program.cs
+++ b/packages/computer-helper-win/Program.cs
@@ -1,0 +1,152 @@
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using ComputerHelperWin;
+
+// computer-helper-win — Windows computer-use daemon.
+//
+// Speaks newline-delimited JSON-RPC identical to the macOS Swift helper
+// (packages/computer-helper). Listens on a loopback TCP port; the agents CLI
+// reaches it over an `ssh -L` tunnel (so auth piggybacks on SSH keys). A
+// shared-secret token in the first frame is defense-in-depth on top of that.
+//
+// Usage: computer-helper-win --port <n> [--token-file <path>]
+//
+// Lifecycle is NOT self-managed: the CLI installs this as a scheduled task at
+// logon (so Task Scheduler owns it — it survives ssh disconnects and runs in
+// the interactive session for real-desktop UIAutomation/screenshot access).
+
+int port = 8765;
+string? tokenFile = null;
+for (int i = 0; i < args.Length - 1; i++)
+{
+    if (args[i] == "--port") port = int.Parse(args[i + 1]);
+    else if (args[i] == "--token-file") tokenFile = args[i + 1];
+}
+
+string? expectedToken = null;
+if (tokenFile != null && File.Exists(tokenFile))
+    expectedToken = File.ReadAllText(tokenFile).Trim();
+
+var dispatcher = new Dispatcher();
+
+// Bind loopback only — never expose the daemon to the network. The SSH tunnel
+// is the sole ingress.
+var listener = new TcpListener(IPAddress.Loopback, port);
+listener.Start();
+Console.Error.WriteLine($"computer-helper-win listening on 127.0.0.1:{port} (auth={(expectedToken != null ? "token" : "none")})");
+
+while (true)
+{
+    var client = await listener.AcceptTcpClientAsync();
+    _ = Task.Run(() => HandleConnection(client));
+}
+
+async Task HandleConnection(TcpClient client)
+{
+    using (client)
+    using (var stream = client.GetStream())
+    {
+        var buffer = new List<byte>();
+        var chunk = new byte[8192];
+        bool authed = expectedToken == null; // no token configured → open (tunnel-gated)
+
+        while (true)
+        {
+            int n;
+            try { n = await stream.ReadAsync(chunk); }
+            catch { break; }
+            if (n == 0) break;
+            buffer.AddRange(chunk[..n]);
+
+            int nl;
+            while ((nl = buffer.IndexOf((byte)'\n')) >= 0)
+            {
+                var lineBytes = buffer.GetRange(0, nl).ToArray();
+                buffer.RemoveRange(0, nl + 1);
+                if (lineBytes.Length == 0) continue;
+
+                var reply = HandleLine(lineBytes, ref authed);
+                if (reply == null) { return; } // auth failure → drop the connection
+                await stream.WriteAsync(reply);
+            }
+        }
+    }
+}
+
+byte[]? HandleLine(byte[] lineBytes, ref bool authed)
+{
+    JsonElement root;
+    try { root = JsonDocument.Parse(lineBytes).RootElement; }
+    catch { return Encode(JsonNull(), Err("invalid_params", "malformed json line")); }
+
+    JsonElement idEl = root.TryGetProperty("id", out var idv) ? idv.Clone() : default;
+    string method = root.TryGetProperty("method", out var mEl) && mEl.ValueKind == JsonValueKind.String
+        ? mEl.GetString()! : "";
+    JsonElement @params = root.TryGetProperty("params", out var pEl) ? pEl : default;
+
+    if (method.Length == 0)
+        return Encode(idEl, Err("invalid_params", "missing method"));
+
+    // Auth gate: until authed, only the `auth` method is accepted.
+    if (!authed)
+    {
+        if (method != "auth")
+            return null; // silently drop unauthenticated callers
+        string? tok = @params.ValueKind == JsonValueKind.Object ? P.StringOpt(@params, "token") : null;
+        if (tok != null && tok == expectedToken)
+        {
+            authed = true;
+            return Encode(idEl, new Dictionary<string, object?> { ["ok"] = true });
+        }
+        return null; // bad token → drop
+    }
+
+    if (method == "auth")
+        return Encode(idEl, new Dictionary<string, object?> { ["ok"] = true });
+
+    try
+    {
+        var result = dispatcher.Dispatch(method, @params);
+        return Encode(idEl, result);
+    }
+    catch (RpcError e)
+    {
+        return Encode(idEl, Err(e.Code, e.Message));
+    }
+    catch (Exception e)
+    {
+        return Encode(idEl, Err("internal", e.Message));
+    }
+}
+
+// ---- response framing: {"id":..,"result":{..}} | {"id":..,"error":{..}} ----
+static Dictionary<string, object?> Err(string code, string message)
+    => new() { ["__error"] = new Dictionary<string, object?> { ["code"] = code, ["message"] = message } };
+
+static JsonElement JsonNull() => JsonDocument.Parse("null").RootElement;
+
+static byte[] Encode(JsonElement id, Dictionary<string, object?> payload)
+{
+    var obj = new Dictionary<string, object?>();
+    obj["id"] = id.ValueKind == JsonValueKind.Undefined ? null : JsonValue(id);
+    if (payload.TryGetValue("__error", out var errObj))
+        obj["error"] = errObj;
+    else
+        obj["result"] = payload;
+
+    string json = JsonSerializer.Serialize(obj);
+    return Encoding.UTF8.GetBytes(json + "\n");
+}
+
+// Convert an echoed id JsonElement to a serializable primitive.
+static object? JsonValue(JsonElement e) => e.ValueKind switch
+{
+    JsonValueKind.Number => e.TryGetInt64(out var l) ? l : e.GetDouble(),
+    JsonValueKind.String => e.GetString(),
+    JsonValueKind.True => true,
+    JsonValueKind.False => false,
+    _ => null,
+};

--- a/packages/computer-helper-win/Rpc.cs
+++ b/packages/computer-helper-win/Rpc.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+
+namespace ComputerHelperWin;
+
+/// <summary>
+/// An RPC error carrying a stable string code, mirroring the macOS helper's
+/// RPCError (RPC.swift). The code vocabulary is part of the wire contract the
+/// TS client (src/lib/computer-rpc.ts) and CLI rely on.
+/// </summary>
+public sealed class RpcError(string code, string message) : Exception(message)
+{
+    public string Code { get; } = code;
+
+    public static RpcError NotFound(string what) => new("element_not_found", what);
+    public static RpcError Stale() => new("element_stale", "element handle expired, re-describe");
+    public static RpcError Unsupported(string action) => new("action_unsupported", action);
+    public static RpcError Denied(string reason) => new("permission_denied", reason);
+    public static RpcError AppMissing(int pid) => new("app_not_found", $"pid {pid}");
+    public static RpcError Invalid(string msg) => new("invalid_params", msg);
+    public static RpcError MethodNotFound(string method) => new("method_not_found", method);
+}
+
+/// <summary>
+/// Routes a JSON-RPC method + params to its handler. Method names, param keys,
+/// and result shapes are kept identical to the macOS dispatcher
+/// (packages/computer-helper/Sources/ComputerHelper/RPC.swift:76-127) so a
+/// single TS client drives both platforms.
+/// </summary>
+public sealed class Dispatcher
+{
+    private readonly Automation _automation = new();
+
+    public Dictionary<string, object?> Dispatch(string method, JsonElement @params)
+    {
+        return method switch
+        {
+            "ping" => new() { ["pong"] = true },
+            "trust_status" => TrustStatus(),
+            "list_apps" => Apps.ListApps(),
+            "launch_app" => Apps.LaunchApp(@params),
+            "screenshot" => Screenshot.Capture(@params),
+            "describe" => _automation.Describe(@params),
+            "click" => _automation.Click(@params),
+            "type" => _automation.SetValue(@params),
+            "type_text" => _automation.TypeText(@params),
+            "key" => _automation.SendKey(@params),
+            "set_focus" => _automation.SetFocus(@params),
+            "get_text" => _automation.GetText(@params),
+            // Parity stubs — not yet implemented on Windows. Returning
+            // action_unsupported (not method_not_found) tells the caller the
+            // verb is known but unavailable on this backend.
+            "scroll" or "drag" or "right_click" or "focus_window" or "ax_action" or "wait" or "notify"
+                => throw RpcError.Unsupported($"{method} not yet implemented on the windows backend"),
+            _ => throw RpcError.MethodNotFound(method),
+        };
+    }
+
+    private static Dictionary<string, object?> TrustStatus()
+    {
+        // Windows UIAutomation needs no per-process trust grant (unlike macOS
+        // Accessibility/TCC), so we are always "trusted". Report pid/path for
+        // the same diagnostic shape the CLI prints.
+        using var proc = System.Diagnostics.Process.GetCurrentProcess();
+        return new()
+        {
+            ["trusted"] = true,
+            ["pid"] = proc.Id,
+            ["path"] = Environment.ProcessPath ?? "",
+        };
+    }
+}
+
+/// <summary>Helpers for reading untyped JSON-RPC params (mirrors Params in main.swift).</summary>
+public static class P
+{
+    public static int Int(JsonElement p, string key)
+    {
+        if (!p.TryGetProperty(key, out var v)) throw RpcError.Invalid($"missing int param: {key}");
+        return v.ValueKind switch
+        {
+            JsonValueKind.Number => v.GetInt32(),
+            JsonValueKind.String when int.TryParse(v.GetString(), out var n) => n,
+            _ => throw RpcError.Invalid($"param {key} is not an int"),
+        };
+    }
+
+    public static int IntOr(JsonElement p, string key, int fallback)
+        => p.TryGetProperty(key, out var v) && v.ValueKind == JsonValueKind.Number ? v.GetInt32() : fallback;
+
+    public static string? StringOpt(JsonElement p, string key)
+        => p.TryGetProperty(key, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+    public static bool BoolOr(JsonElement p, string key, bool fallback)
+        => p.TryGetProperty(key, out var v) && (v.ValueKind == JsonValueKind.True || v.ValueKind == JsonValueKind.False)
+            ? v.GetBoolean() : fallback;
+}

--- a/packages/computer-helper-win/Screenshot.cs
+++ b/packages/computer-helper-win/Screenshot.cs
@@ -1,0 +1,45 @@
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Text.Json;
+using System.Windows.Forms;
+
+namespace ComputerHelperWin;
+
+/// <summary>
+/// Screen capture. Returns the same keys the CLI consumes from the macOS
+/// helper (src/commands/computer.ts:169-190): image_data (base64 PNG), width,
+/// height, origin [x,y], scale. We capture the whole virtual desktop; per-pid
+/// window capture is a future refinement (the macOS backend scopes by pid).
+/// </summary>
+public static class Screenshot
+{
+    public static Dictionary<string, object?> Capture(JsonElement @params)
+    {
+        // The virtual screen spans all monitors and can have a negative origin
+        // (a monitor left of / above the primary). origin lets the caller map
+        // screenshot pixels back to global coords: global = origin + pixel/scale.
+        Rectangle b = SystemInformation.VirtualScreen;
+        if (b.Width <= 0 || b.Height <= 0)
+            throw new RpcError("action_failed", "virtual screen has zero area");
+
+        using var bmp = new Bitmap(b.Width, b.Height, PixelFormat.Format32bppArgb);
+        using (var g = Graphics.FromImage(bmp))
+        {
+            g.CopyFromScreen(b.Left, b.Top, 0, 0, bmp.Size, CopyPixelOperation.SourceCopy);
+        }
+
+        using var ms = new MemoryStream();
+        bmp.Save(ms, ImageFormat.Png);
+        string b64 = Convert.ToBase64String(ms.ToArray());
+
+        return new()
+        {
+            ["image_data"] = b64,
+            ["width"] = b.Width,
+            ["height"] = b.Height,
+            ["origin"] = new[] { b.Left, b.Top },
+            ["scale"] = 1.0,
+        };
+    }
+}

--- a/packages/computer-helper-win/computer-helper-win.csproj
+++ b/packages/computer-helper-win/computer-helper-win.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Windows computer-use daemon. Speaks the SAME newline-delimited JSON-RPC
+    protocol as the macOS Swift helper (packages/computer-helper) so the TS
+    client in src/lib/computer-rpc.ts drives both unchanged. Built as a
+    self-contained single-file win-x64 exe (the box needs no .NET runtime),
+    cross-published from macOS/Linux via `scripts/build-win.sh`.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <!-- Allow cross-publishing a Windows target from macOS/Linux build hosts. -->
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <!-- WindowsForms pulls in System.Drawing (screen capture) + SystemInformation. -->
+    <UseWindowsForms>true</UseWindowsForms>
+    <!-- WPF pulls in System.Windows.Automation (UIAutomation client). -->
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>computer-helper-win</AssemblyName>
+    <RootNamespace>ComputerHelperWin</RootNamespace>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+</Project>

--- a/packages/computer-helper-win/smoke/smoke.mjs
+++ b/packages/computer-helper-win/smoke/smoke.mjs
@@ -1,0 +1,167 @@
+// Smoke test for computer-helper-win — exercises the real UIAutomation path on
+// Windows. Spawns the built daemon, then over the TCP/JSON-RPC wire:
+//   ping -> launch Notepad -> describe (UIAutomation tree walk) -> set_focus ->
+//   type_text -> get_text roundtrip -> screenshot.
+// Zero dependencies (node net + child_process). Exit 0 = pass, 1 = fail.
+//
+// Usage: node smoke.mjs --exe <path-to-computer-helper-win.exe> [--port 8765]
+
+import { spawn } from 'node:child_process';
+import { connect } from 'node:net';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const args = process.argv.slice(2);
+const exe = argVal('--exe');
+const port = Number(argVal('--port') ?? 8765);
+if (!exe) fail('missing --exe <path>');
+
+function argVal(flag) {
+  const i = args.indexOf(flag);
+  return i >= 0 && i + 1 < args.length ? args[i + 1] : undefined;
+}
+function fail(msg) {
+  console.error(`SMOKE FAIL: ${msg}`);
+  process.exit(1);
+}
+function ok(msg) {
+  console.log(`  ok: ${msg}`);
+}
+
+// ---- JSON-RPC client over one persistent TCP connection -------------------
+class Client {
+  constructor(sock) {
+    this.sock = sock;
+    this.buf = '';
+    this.waiters = new Map();
+    this.nextId = 1;
+    sock.setEncoding('utf8');
+    sock.on('data', (chunk) => {
+      this.buf += chunk;
+      let nl;
+      while ((nl = this.buf.indexOf('\n')) !== -1) {
+        const line = this.buf.slice(0, nl);
+        this.buf = this.buf.slice(nl + 1);
+        if (!line) continue;
+        let obj;
+        try { obj = JSON.parse(line); } catch { continue; }
+        const w = this.waiters.get(obj.id);
+        if (w) { this.waiters.delete(obj.id); w(obj); }
+      }
+    });
+  }
+  call(method, params = {}) {
+    const id = this.nextId++;
+    const payload = JSON.stringify({ id, method, params }) + '\n';
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.waiters.delete(id);
+        reject(new Error(`rpc timeout: ${method}`));
+      }, 30_000);
+      this.waiters.set(id, (obj) => {
+        clearTimeout(timer);
+        if (obj.error) reject(new Error(`${method} -> ${obj.error.code}: ${obj.error.message}`));
+        else resolve(obj.result);
+      });
+      this.sock.write(payload);
+    });
+  }
+}
+
+function findByRole(node, roles, out = []) {
+  if (!node || typeof node !== 'object') return out;
+  if (node.id && roles.includes(node.role)) out.push(node);
+  for (const c of node.children ?? []) findByRole(c, roles, out);
+  return out;
+}
+function countNodes(node) {
+  if (!node) return 0;
+  let n = node.id ? 1 : 0;
+  for (const c of node.children ?? []) n += countNodes(c);
+  return n;
+}
+
+async function connectWithRetry(p, tries = 50) {
+  for (let i = 0; i < tries; i++) {
+    try {
+      return await new Promise((resolve, reject) => {
+        const s = connect({ host: '127.0.0.1', port: p }, () => resolve(s));
+        s.on('error', reject);
+      });
+    } catch {
+      await sleep(200);
+    }
+  }
+  throw new Error(`could not connect to 127.0.0.1:${p}`);
+}
+
+const TYPED = `hello-smoke-${process.pid}`;
+
+async function main() {
+  console.log(`spawning daemon: ${exe} --port ${port}`);
+  const daemon = spawn(exe, ['--port', String(port)], { stdio: ['ignore', 'inherit', 'inherit'] });
+  daemon.on('exit', (code) => {
+    if (code !== null && code !== 0) console.error(`daemon exited early: ${code}`);
+  });
+
+  let sock;
+  try {
+    sock = await connectWithRetry(port);
+    const c = new Client(sock);
+
+    // 1. ping
+    const pong = await c.call('ping');
+    if (!pong?.pong) fail(`ping did not pong: ${JSON.stringify(pong)}`);
+    ok('ping');
+
+    // 2. launch Notepad (classic Win32 notepad on the runner)
+    const launched = await c.call('launch_app', { path: 'C:\\Windows\\System32\\notepad.exe' });
+    ok(`launch_app -> pid ${launched.pid}`);
+
+    // 3. resolve the notepad pid via list_apps (launch may hand off)
+    let pid = launched.pid;
+    for (let i = 0; i < 25; i++) {
+      const { apps } = await c.call('list_apps');
+      const np = apps.find((a) => /notepad/i.test(a.bundle_id ?? '') || /notepad/i.test(a.name ?? ''));
+      if (np) { pid = np.pid; break; }
+      await sleep(300);
+    }
+    if (!pid) fail('notepad pid not found via list_apps');
+    ok(`notepad pid = ${pid}`);
+
+    // 4. describe — the UIAutomation tree walk
+    const desc = await c.call('describe', { pid });
+    const total = countNodes(desc.tree);
+    if (!(desc.element_count > 0) || total === 0) fail(`describe returned empty tree: ${JSON.stringify(desc).slice(0, 400)}`);
+    const withBounds = findByRole(desc.tree, ['Window', 'Edit', 'Document', 'Application']).some((n) => Array.isArray(n.bounds));
+    if (!withBounds) fail('no node carried bounds — UIA property read is broken');
+    ok(`describe: element_count=${desc.element_count}`);
+
+    // 5. id-addressable roundtrip: focus the editable control, type, read back
+    const editable = findByRole(desc.tree, ['Edit', 'Document']);
+    if (editable.length === 0) fail(`no Edit/Document element in notepad tree: ${JSON.stringify(desc.tree).slice(0, 600)}`);
+    const elId = editable[0].id;
+    await c.call('set_focus', { pid, element_id: elId });
+    ok(`set_focus ${elId}`);
+    await c.call('type_text', { text: TYPED });
+    ok(`type_text "${TYPED}"`);
+    const got = await c.call('get_text', { pid, element_id: elId });
+    if (!String(got.text ?? '').includes(TYPED)) fail(`get_text roundtrip mismatch: got ${JSON.stringify(got.text)}`);
+    ok(`get_text roundtrip matched`);
+
+    // 6. screenshot
+    const shot = await c.call('screenshot');
+    if (!shot.image_data || shot.image_data.length < 1000) fail('screenshot image_data too small');
+    const png = Buffer.from(shot.image_data, 'base64');
+    if (!(png[0] === 0x89 && png[1] === 0x50 && png[2] === 0x4e && png[3] === 0x47)) fail('screenshot is not a PNG');
+    ok(`screenshot ${shot.width}x${shot.height} (${png.length} bytes)`);
+
+    console.log('SMOKE PASS');
+  } finally {
+    try { sock?.destroy(); } catch {}
+    try { daemon.kill(); } catch {}
+    // best-effort: close notepad so the runner session is clean
+    try { spawn('taskkill', ['/IM', 'notepad.exe', '/F'], { stdio: 'ignore' }); } catch {}
+  }
+}
+
+main().catch((e) => fail(e.message));

--- a/packages/computer-helper-win/smoke/smoke.mjs
+++ b/packages/computer-helper-win/smoke/smoke.mjs
@@ -144,8 +144,17 @@ async function main() {
     ok(`set_focus ${elId}`);
     await c.call('type_text', { text: TYPED });
     ok(`type_text "${TYPED}"`);
-    const got = await c.call('get_text', { pid, element_id: elId });
-    if (!String(got.text ?? '').includes(TYPED)) fail(`get_text roundtrip mismatch: got ${JSON.stringify(got.text)}`);
+    // SendInput delivers keystrokes to the target's message loop
+    // asynchronously, so poll get_text until the document settles.
+    let lastText = '';
+    let matched = false;
+    for (let i = 0; i < 30; i++) {
+      const got = await c.call('get_text', { pid, element_id: elId });
+      lastText = String(got.text ?? '');
+      if (lastText.includes(TYPED)) { matched = true; break; }
+      await sleep(150);
+    }
+    if (!matched) fail(`get_text roundtrip mismatch after retries: got ${JSON.stringify(lastText)}`);
     ok(`get_text roundtrip matched`);
 
     // 6. screenshot

--- a/src/lib/computer-rpc.ts
+++ b/src/lib/computer-rpc.ts
@@ -206,9 +206,30 @@ export function resolveHelperApp(): string | null {
   return path.resolve(exec, '..', '..', '..');
 }
 
-// Pick the best transport. If the socket exists, use it. Otherwise fall
-// back to spawning the helper as a subprocess (legacy path).
+// Resolve the TCP endpoint for the Windows daemon (computer-helper-win), if
+// configured. The Windows helper binds loopback TCP (Program.cs) and the CLI
+// reaches it over an `ssh -L` tunnel, so the endpoint is a local forwarded
+// port. COMPUTER_HELPER_TCP is "host:port" (host defaults to 127.0.0.1);
+// COMPUTER_HELPER_TOKEN is the shared secret sent in the first `auth` frame.
+export function resolveTcpEndpoint(): { host: string; port: number; token: string | null } | null {
+  const raw = process.env.COMPUTER_HELPER_TCP;
+  if (!raw || raw.length === 0) return null;
+  const [hostPart, portPart] = raw.includes(':') ? raw.split(':') : ['127.0.0.1', raw];
+  const port = Number(portPart);
+  if (!Number.isInteger(port) || port <= 0) return null;
+  const token = process.env.COMPUTER_HELPER_TOKEN;
+  return { host: hostPart || '127.0.0.1', port, token: token && token.length > 0 ? token : null };
+}
+
+// Pick the best transport. Precedence:
+//   1. COMPUTER_HELPER_TCP -> the Windows daemon over a (tunneled) TCP port.
+//   2. the macOS launchd socket if it exists.
+//   3. spawning the helper as a subprocess (legacy/dev fallback).
 export function openComputerClient(): ComputerClient {
+  const tcp = resolveTcpEndpoint();
+  if (tcp) {
+    return new TcpClient(tcp.host, tcp.port, tcp.token);
+  }
   const sockPath = resolveSocketPath();
   if (fs.existsSync(sockPath)) {
     return new SocketClient(sockPath);
@@ -310,6 +331,63 @@ class SocketClient extends BaseClient {
       this.closed = true;
       this.failPending('helper_exited', 'socket closed before reply');
     });
+  }
+
+  protected send(payload: string): void {
+    this.sock.write(payload);
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.sock.end();
+    await new Promise<void>((resolve) => {
+      if (this.closed) return resolve();
+      this.sock.on('close', () => resolve());
+    });
+  }
+}
+
+// TCP transport for the Windows daemon (computer-helper-win). The daemon
+// binds loopback only (Program.cs); the CLI reaches it over an `ssh -L`
+// tunnel, so `host` is typically 127.0.0.1 + a forwarded port. When a token
+// is configured the daemon accepts only an `auth` frame until authenticated,
+// so we send that first and gate every other call on it.
+class TcpClient extends BaseClient {
+  private sock: Socket;
+  private authReady: Promise<void>;
+
+  constructor(host: string, port: number, token: string | null) {
+    super();
+    this.sock = createConnection({ host, port });
+    this.sock.setEncoding('utf8');
+    this.sock.on('data', (chunk: string) => this.handleChunk(chunk));
+    this.sock.on('error', (err) => {
+      this.closed = true;
+      this.failPending('socket_error', err.message);
+    });
+    this.sock.on('close', () => {
+      this.closed = true;
+      this.failPending('helper_exited', 'tcp connection closed before reply');
+    });
+    // Kick off the auth handshake synchronously so its frame (id 1) is the
+    // first thing written. No token → daemon is open (tunnel-gated).
+    this.authReady = token ? this.authenticate(token) : Promise.resolve();
+  }
+
+  private async authenticate(token: string): Promise<void> {
+    const res = await super.call('auth', { token });
+    if (res.error) throw new Error(`computer-helper auth failed: ${res.error.code}`);
+  }
+
+  async call(method: string, params?: Record<string, unknown>): Promise<RPCResponse> {
+    if (method !== 'auth') {
+      try {
+        await this.authReady;
+      } catch (e) {
+        return { id: null, error: { code: 'auth_failed', message: (e as Error).message } };
+      }
+    }
+    return super.call(method, params);
   }
 
   protected send(payload: string): void {


### PR DESCRIPTION
## What

Adds `packages/computer-helper-win/` — the Windows sibling of the macOS `computer-helper` (Swift). A self-contained .NET daemon that speaks the **same line-delimited JSON-RPC** as the macOS helper, so the single TS client (`src/lib/computer-rpc.ts`) drives both platforms. The Windows box is reached over a loopback-TCP-over-`ssh -L` tunnel (the "remote Box" topology).

## What's implemented

**Input layer** (Win32 `SendInput`): `click` (x/y), `type_text` (unicode), `key` chords.

**UIAutomation layer** (`System.Windows.Automation`, this PR):
- `describe` — walks the ControlView tree, emitting the macOS node shape `{id, role, enabled, label?, value?, bounds:[x,y,w,h]?, children?}` with an `@eN` element cache reset per describe.
- id-addressable `click` (Invoke/Toggle/SelectionItem pattern, center-click fallback), `type` (ValuePattern.SetValue, focus+type fallback), `get_text` (Text/Value pattern), `set_focus`.

**TS client**: `TcpClient` + `COMPUTER_HELPER_TCP` / `COMPUTER_HELPER_TOKEN` routing so the CLI can reach the daemon (auth frame sent first). macOS socket/stdio paths unchanged.

## Verification

Dedicated `windows-latest` workflow (`.github/workflows/computer-helper-win.yml`) builds the daemon natively and runs a zero-dep Node smoke test over the real wire:

```
ok: ping
ok: launch_app -> pid <n>
ok: notepad pid = <n>
ok: describe: element_count=22        <- UIAutomation tree walk on real Windows
ok: set_focus @e8                     <- id-addressable verb
ok: type_text "hello-smoke-..."
ok: get_text roundtrip matched        <- focus + type + read-back
ok: screenshot 1024x768 (<n> bytes)
SMOKE PASS
```

## Not in this PR (follow-ups)
- Remote-box orchestration: `ssh -L` tunnel setup + Task Scheduler install of the daemon at logon (the daemon and TCP transport exist; the CLI plumbing to auto-provision a box is next).
- Remaining parity stubs still return `action_unsupported`: `scroll`, `drag`, `right_click`, `focus_window`, `ax_action`, `wait`, `notify`.
- Windows leg is `continue-on-error` until parity + stability; promote to required once green consistently.
