### PR TITLE
feat(sessions): discover and render Droid (Factory) sessions

### DIFF
--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -893,6 +893,7 @@ export function buildResumeCommand(session: SessionMeta): string[] | null {
     case 'hermes':
     case 'grok':
     case 'kimi':
+    case 'droid':
       // Grok (and some others) sessions are captured artifacts, not resumable the same way.
       return null;
   }

--- a/src/lib/session/__tests__/parse-droid.test.ts
+++ b/src/lib/session/__tests__/parse-droid.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Verifies parseDroid normalizes Droid's (Factory) message-envelope JSONL to
+ * the shared SessionEvent shape, drops injected <system-reminder> context, and
+ * detectAgent routes ~/.factory/ paths to the droid parser.
+ */
+
+import { describe, expect, test } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { parseDroid, detectAgent, parseSession } from '../parse.js';
+
+function writeTmp(content: string): string {
+  const dir = path.join(os.tmpdir(), `droid-parse-${Date.now()}-${Math.random()}`, '.factory', 'sessions', 'proj');
+  fs.mkdirSync(dir, { recursive: true });
+  const p = path.join(dir, 'sess.jsonl');
+  fs.writeFileSync(p, content);
+  return p;
+}
+
+describe('parseDroid', () => {
+  test('maps session_start + message envelope to normalized events', () => {
+    const jsonl = [
+      { type: 'session_start', id: 's1', title: 'Hi there', sessionTitle: 'Greeting', cwd: '/work' },
+      {
+        type: 'message',
+        timestamp: '2026-06-30T10:00:00Z',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'text', text: '<system-reminder>injected context</system-reminder>' },
+            { type: 'text', text: 'How do I run the tests?' },
+          ],
+        },
+      },
+      {
+        type: 'message',
+        timestamp: '2026-06-30T10:00:01Z',
+        message: {
+          role: 'assistant',
+          modelId: 'claude-opus-4-8',
+          content: [
+            { type: 'thinking', thinking: 'consider the options' },
+            { type: 'text', text: 'Run bun test.' },
+            { type: 'tool_use', id: 'tu1', name: 'Bash', input: { command: 'bun test' } },
+          ],
+        },
+      },
+      {
+        type: 'message',
+        timestamp: '2026-06-30T10:00:02Z',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'tool_result', tool_use_id: 'tu1', content: 'all green' },
+          ],
+        },
+      },
+    ]
+      .map((o) => JSON.stringify(o))
+      .join('\n');
+
+    const p = writeTmp(jsonl);
+    try {
+      const events = parseDroid(p);
+      // session_start skipped; system-reminder block dropped.
+      expect(events).toHaveLength(5);
+      expect(events[0]).toMatchObject({ type: 'message', agent: 'droid', role: 'user', content: 'How do I run the tests?' });
+      expect(events[1]).toMatchObject({ type: 'thinking', content: 'consider the options' });
+      expect(events[2]).toMatchObject({ type: 'message', role: 'assistant', content: 'Run bun test.' });
+      expect(events[3]).toMatchObject({ type: 'tool_use', tool: 'Bash', command: 'bun test' });
+      expect(events[4]).toMatchObject({ type: 'tool_result', tool: 'Bash', success: true, output: 'all green' });
+    } finally {
+      fs.rmSync(path.dirname(p), { recursive: true, force: true });
+    }
+  });
+
+  test('marks is_error tool_result as an error event', () => {
+    const jsonl = [
+      { type: 'message', timestamp: '2026-06-30T10:00:00Z', message: { role: 'assistant', content: [{ type: 'tool_use', id: 'x', name: 'Bash', input: { command: 'false' } }] } },
+      { type: 'message', timestamp: '2026-06-30T10:00:01Z', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'x', is_error: true, content: 'boom' }] } },
+    ]
+      .map((o) => JSON.stringify(o))
+      .join('\n');
+
+    const p = writeTmp(jsonl);
+    try {
+      const events = parseDroid(p);
+      expect(events.find((e) => e.type === 'error')).toMatchObject({ type: 'error', tool: 'Bash', content: 'boom' });
+    } finally {
+      fs.rmSync(path.dirname(p), { recursive: true, force: true });
+    }
+  });
+});
+
+describe('detectAgent routes droid paths', () => {
+  test('local ~/.factory/ path', () => {
+    expect(detectAgent('/home/me/.factory/sessions/proj/abc.jsonl')).toBe('droid');
+  });
+
+  test('parseSession dispatches through detectAgent for droid', () => {
+    const jsonl =
+      JSON.stringify({
+        type: 'message',
+        timestamp: '2026-06-30T10:00:00Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'hello droid' }] },
+      }) + '\n';
+
+    const p = writeTmp(jsonl);
+    try {
+      const events = parseSession(p);
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({ agent: 'droid', role: 'user', content: 'hello droid' });
+    } finally {
+      fs.rmSync(path.dirname(p), { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/session/discover.ts
+++ b/src/lib/session/discover.ts
@@ -166,6 +166,7 @@ export async function discoverSessions(options?: DiscoverOptions): Promise<Sessi
             case 'rush': return scanRushIncremental(onProgress);
             case 'hermes': return scanHermesIncremental(onProgress);
             case 'kimi': return scanKimiIncremental(onProgress);
+            case 'droid': return scanDroidIncremental(onProgress);
           }
         }),
       );
@@ -1516,6 +1517,242 @@ function extractHermesMessageText(content: any): string {
       if (typeof part?.text === 'string') return part.text;
       return '';
     })
+    .join('\n')
+    .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Droid (Factory)
+// ---------------------------------------------------------------------------
+
+/** Lightweight metadata extracted from a Droid JSONL file during incremental scan. */
+interface DroidSessionScan {
+  sessionId?: string;
+  timestamp?: string;
+  cwd?: string;
+  topic?: string;
+  model?: string;
+  messageCount: number;
+  durationMs?: number;
+  contentText?: string;
+}
+
+/**
+ * Incrementally re-scan changed Droid (Factory) session files and upsert into
+ * the DB. Droid writes one `<uuid>.jsonl` transcript plus a sibling
+ * `<uuid>.settings.json` (model + token usage) under
+ * `~/.factory/sessions/<encoded-cwd>/`.
+ */
+async function scanDroidIncremental(onProgress?: (p: ScanProgress) => void): Promise<void> {
+  const currentVersion = await getCurrentAgentVersion('droid');
+
+  const filePaths: string[] = [];
+  for (const sessionsDir of getAgentSessionDirs('droid', 'sessions')) {
+    // High limit: we only stat files here, parsing is gated by ledger match.
+    for (const fp of walkForFiles(sessionsDir, '.jsonl', 100_000)) {
+      filePaths.push(fp);
+    }
+  }
+
+  const changed = filterChangedFiles(filePaths);
+  if (changed.length === 0) return;
+
+  onProgress?.({ agent: 'droid', parsed: 0, total: changed.length });
+
+  const entries: ScanEntry[] = [];
+  const touched: Array<{ filePath: string; scan: ScanStamp }> = [];
+  const seen = new Set<string>();
+  let parsed = 0;
+  for (const { filePath, scan } of changed) {
+    try {
+      const result = await readDroidMeta(filePath, currentVersion);
+      if (result && !seen.has(result.meta.id)) {
+        seen.add(result.meta.id);
+        entries.push({ meta: result.meta, content: result.content, scan });
+      } else {
+        touched.push({ filePath, scan });
+      }
+    } catch {
+      touched.push({ filePath, scan });
+    }
+    parsed++;
+    onProgress?.({ agent: 'droid', parsed, total: changed.length });
+  }
+
+  upsertSessionsBatch(entries);
+  recordScans(touched);
+}
+
+/** Stream-parse a single Droid JSONL file (+ sibling settings) into session metadata. */
+async function readDroidMeta(
+  filePath: string,
+  currentVersion?: string,
+): Promise<{ meta: SessionMeta; content: string } | null> {
+  const scan = await scanDroidSession(filePath);
+  // The filename is the canonical session id; fall back to the session_start id.
+  const sessionId = path.basename(filePath).replace(/\.jsonl$/, '') || scan.sessionId || '';
+  if (!sessionId) return null;
+
+  // Token usage and cost live only in the sibling `<uuid>.settings.json`.
+  const settings = readDroidSettings(filePath.replace(/\.jsonl$/, '.settings.json'));
+  const model = settings.model || scan.model;
+  const tokenCount = settings.tokenCount;
+  const costUsd = model && settings.usage
+    ? costOfUsage({
+        model,
+        inputTokens: settings.usage.inputTokens,
+        outputTokens: settings.usage.outputTokens,
+        cacheReadTokens: settings.usage.cacheReadTokens,
+        cacheCreationTokens: settings.usage.cacheCreationTokens,
+      })
+    : 0;
+
+  const stat = safeStatSync(filePath);
+  const cwd = normalizeCwd(scan.cwd || '');
+  const meta: SessionMeta = {
+    id: sessionId,
+    shortId: sessionId.slice(0, 8),
+    agent: 'droid',
+    timestamp: scan.timestamp || (stat ? stat.mtime.toISOString() : new Date().toISOString()),
+    project: cwd ? path.basename(cwd) : undefined,
+    cwd,
+    filePath,
+    version: resolveSessionVersion('droid', filePath, undefined, currentVersion),
+    topic: scan.topic,
+    messageCount: scan.messageCount,
+    tokenCount,
+    costUsd: costUsd > 0 ? costUsd : undefined,
+    durationMs: scan.durationMs,
+  };
+  return { meta, content: scan.contentText || '' };
+}
+
+/** Read model + token usage from a Droid `<uuid>.settings.json` sidecar. */
+function readDroidSettings(settingsPath: string): {
+  model?: string;
+  tokenCount?: number;
+  usage?: { inputTokens?: number; outputTokens?: number; cacheReadTokens?: number; cacheCreationTokens?: number };
+} {
+  try {
+    const data = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    const model = typeof data.model === 'string' ? data.model : undefined;
+    const u = data.tokenUsage;
+    if (!u || typeof u !== 'object') return { model };
+    const usage = {
+      inputTokens: u.inputTokens,
+      outputTokens: u.outputTokens,
+      cacheReadTokens: u.cacheReadTokens,
+      cacheCreationTokens: u.cacheCreationTokens,
+    };
+    const tokenCount = sumKnownNumbers([
+      u.inputTokens,
+      u.outputTokens,
+      u.cacheCreationTokens,
+      u.cacheReadTokens,
+    ]) ?? undefined;
+    return { model, tokenCount, usage };
+  } catch {
+    return {};
+  }
+}
+
+/** Stream a Droid JSONL file and extract scan-level metadata (id, cwd, topic, model, duration). */
+async function scanDroidSession(filePath: string): Promise<DroidSessionScan> {
+  const stream = fs.createReadStream(filePath, { encoding: 'utf-8' });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+  let sessionId: string | undefined;
+  let timestamp: string | undefined;
+  let cwd: string | undefined;
+  let title: string | undefined;
+  let sessionTitle: string | undefined;
+  let firstUserTopic: string | undefined;
+  let model: string | undefined;
+  let messageCount = 0;
+  let firstTsMs: number | undefined;
+  let lastTsMs: number | undefined;
+  const userTexts: string[] = [];
+
+  try {
+    for await (const line of rl) {
+      if (!line.trim()) continue;
+
+      let parsed: any;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
+
+      if (parsed.type === 'session_start') {
+        sessionId = typeof parsed.id === 'string' ? parsed.id : sessionId;
+        cwd = typeof parsed.cwd === 'string' ? parsed.cwd : cwd;
+        // Droid auto-generates `sessionTitle`; `title` is the raw first prompt.
+        if (typeof parsed.sessionTitle === 'string' && parsed.sessionTitle.trim()) {
+          sessionTitle = parsed.sessionTitle.trim();
+        }
+        if (typeof parsed.title === 'string' && parsed.title.trim()) {
+          title = parsed.title.trim();
+        }
+        continue;
+      }
+
+      if (parsed.type !== 'message') continue;
+
+      // Track duration across every timestamped message.
+      if (typeof parsed.timestamp === 'string') {
+        const ms = new Date(parsed.timestamp).getTime();
+        if (!Number.isNaN(ms)) {
+          if (firstTsMs === undefined || ms < firstTsMs) firstTsMs = ms;
+          if (lastTsMs === undefined || ms > lastTsMs) lastTsMs = ms;
+        }
+      }
+      if (!timestamp && typeof parsed.timestamp === 'string') timestamp = parsed.timestamp;
+
+      const msg = parsed.message || {};
+      if (typeof msg.modelId === 'string') model = msg.modelId;
+
+      const text = extractDroidMessageText(msg.content);
+      if (!text) continue;
+      messageCount++;
+      if (msg.role === 'user') {
+        userTexts.push(text);
+        if (!firstUserTopic) firstUserTopic = extractSessionTopic(text);
+      }
+    }
+  } finally {
+    rl.close();
+    stream.destroy();
+  }
+
+  const durationMs =
+    firstTsMs !== undefined && lastTsMs !== undefined && lastTsMs > firstTsMs
+      ? lastTsMs - firstTsMs
+      : undefined;
+
+  return {
+    sessionId,
+    timestamp,
+    cwd,
+    // Prefer Droid's auto-title, then the raw first-prompt title, then the
+    // derived first-user-message topic.
+    topic: sessionTitle || title || firstUserTopic,
+    model,
+    messageCount,
+    durationMs,
+    contentText: userTexts.length > 0 ? userTexts.join('\n') : undefined,
+  };
+}
+
+/** Extract plain text from a Droid message content field (Anthropic-shaped blocks). */
+function extractDroidMessageText(content: any): string {
+  if (typeof content === 'string') return content.trim();
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((part: any) => (typeof part?.text === 'string' && part.type === 'text' ? part.text : ''))
+    // Droid front-loads injected context (date, skills list) as <system-reminder>
+    // text blocks on the first user turn — drop them so topic/content stay clean.
+    .filter((text: string) => text.trim() && !text.trim().startsWith('<system-reminder>'))
     .join('\n')
     .trim();
 }

--- a/src/lib/session/parse.ts
+++ b/src/lib/session/parse.ts
@@ -91,6 +91,7 @@ export function parseSession(filePath: string, agent?: SessionAgentId): SessionE
     case 'openclaw': events = []; break; // OpenClaw sessions don't have parseable files yet
     case 'hermes': events = parseHermes(filePath); break;
     case 'kimi': events = parseKimi(filePath); break;
+    case 'droid': events = parseDroid(filePath); break;
   }
 
   // Chokepoint: every string field that originated in an untrusted session
@@ -109,6 +110,7 @@ export function detectAgent(filePath: string): SessionAgentId | null {
   if (filePath.includes('/.rush/') || filePath.includes('\\.rush\\')) return 'rush';
   if (filePath.includes('/.hermes/') || filePath.includes('\\.hermes\\')) return 'hermes';
   if (filePath.includes('/.kimi-code/') || filePath.includes('\\.kimi-code\\')) return 'kimi';
+  if (filePath.includes('/.factory/') || filePath.includes('\\.factory\\')) return 'droid';
   // Cloud convention: cloud-sessions/<id>/session.<format>.jsonl
   const cloudMatch = filePath.match(/session\.(claude|codex|rush)\.jsonl(?:$|[?#])/);
   if (cloudMatch) return cloudMatch[1] as SessionAgentId;
@@ -1128,6 +1130,109 @@ export function parseKimi(filePath: string): SessionEvent[] {
           inputTokens: typeof inputTokens === 'number' ? inputTokens : undefined,
           outputTokens: typeof outputTokens === 'number' ? outputTokens : undefined,
         });
+      }
+    }
+  }
+
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+// Droid (Factory) parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a Droid (Factory) JSONL session file into normalized events. Droid
+ * wraps each turn in a `{type:'message', message:{role, content, modelId}}`
+ * envelope; the content blocks are Anthropic-shaped (text/thinking/tool_use/
+ * tool_result), so block handling mirrors the Claude parser.
+ */
+export function parseDroid(filePath: string): SessionEvent[] {
+  const content = safeReadSessionFile(filePath);
+  const lines = content.split('\n').filter(l => l.trim());
+  const events: SessionEvent[] = [];
+
+  // Map tool_use id -> {tool, args} for correlating with tool_result.
+  const toolUseMap = new Map<string, { tool: string; args: Record<string, any> }>();
+
+  for (const line of lines) {
+    let raw: any;
+    try {
+      raw = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    if (raw.type !== 'message') continue;
+
+    const message = raw.message || {};
+    const role = message.role === 'user' ? 'user' : 'assistant';
+    const timestamp = raw.timestamp || new Date().toISOString();
+    const blocks = message.content;
+
+    // Plain-string content (rare) renders as a single message.
+    if (typeof blocks === 'string') {
+      const text = blocks.trim();
+      if (text) events.push({ type: 'message', agent: 'droid', timestamp, role, content: text });
+      continue;
+    }
+    if (!Array.isArray(blocks)) continue;
+
+    for (const block of blocks) {
+      if (block.type === 'text') {
+        const text = (block.text || '').trim();
+        // Skip injected context blocks (date, skills list) on the first user turn.
+        if (text && !(role === 'user' && text.startsWith('<system-reminder>'))) {
+          events.push({ type: 'message', agent: 'droid', timestamp, role, content: text });
+        }
+      } else if (block.type === 'thinking') {
+        const thinkingText = (block.thinking || '').trim();
+        if (thinkingText) events.push({ type: 'thinking', agent: 'droid', timestamp, content: thinkingText });
+      } else if (block.type === 'tool_use') {
+        const toolName = block.name || 'unknown';
+        const toolInput = block.input || {};
+        if (block.id) toolUseMap.set(block.id, { tool: toolName, args: toolInput });
+        events.push({
+          type: 'tool_use',
+          agent: 'droid',
+          timestamp,
+          tool: toolName,
+          args: toolInput,
+          path: toolInput.file_path || toolInput.path || undefined,
+          command: toolName === 'Bash' ? toolInput.command : undefined,
+        });
+      } else if (block.type === 'tool_result') {
+        const toolId = block.tool_use_id;
+        const toolInfo = toolId ? toolUseMap.get(toolId) : undefined;
+        const isError = block.is_error === true;
+
+        let output = '';
+        if (typeof block.content === 'string') {
+          output = block.content;
+        } else if (Array.isArray(block.content)) {
+          output = block.content
+            .filter((c: any) => c.type === 'text')
+            .map((c: any) => c.text || '')
+            .join('\n');
+        }
+
+        if (isError) {
+          events.push({ type: 'error', agent: 'droid', timestamp, tool: toolInfo?.tool, content: output || 'Tool execution failed' });
+        } else {
+          events.push({
+            type: 'tool_result',
+            agent: 'droid',
+            timestamp,
+            tool: toolInfo?.tool,
+            success: true,
+            output: output.length > 500 ? output.slice(0, 497) + '...' : output,
+          });
+        }
+        if (toolId) toolUseMap.delete(toolId);
+      } else if (block.type === 'image') {
+        const source = block.source || {};
+        const sizeBytes = source.type === 'base64' ? Math.ceil(((source.data as string)?.length || 0) * 0.75) : 0;
+        events.push({ type: 'attachment', agent: 'droid', timestamp, mediaType: source.media_type || 'image/png', sizeBytes });
       }
     }
   }

--- a/src/lib/session/types.ts
+++ b/src/lib/session/types.ts
@@ -8,10 +8,10 @@
  */
 
 /** Agents that store session data on disk and can be discovered by `agents sessions`. */
-export type SessionAgentId = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'rush' | 'hermes' | 'grok' | 'kimi';
+export type SessionAgentId = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'rush' | 'hermes' | 'grok' | 'kimi' | 'droid';
 
 /** All agents with session discovery support, in display order. */
-export const SESSION_AGENTS: SessionAgentId[] = ['claude', 'codex', 'gemini', 'opencode', 'openclaw', 'rush', 'hermes', 'grok', 'kimi'];
+export const SESSION_AGENTS: SessionAgentId[] = ['claude', 'codex', 'gemini', 'opencode', 'openclaw', 'rush', 'hermes', 'grok', 'kimi', 'droid'];
 
 /** A single normalized event within a session (message, tool call, thinking, etc.). */
 export interface SessionEvent {


### PR DESCRIPTION
## Problem

Droid (Factory) is a supported harness for config/MCP, but it was **not** registered as a *session* agent — no entry in `SESSION_AGENTS`, no scanner, no parser. Its transcripts at `~/.factory/sessions/<encoded-cwd>/<uuid>.jsonl` were never discovered, so droid sessions never showed up in `agents sessions`.

## Fix

- **Register** `droid` in `SessionAgentId` / `SESSION_AGENTS` (`types.ts`) and wire the discovery switch (`discover.ts`).
- **Discovery** (`scanDroidIncremental` + `scanDroidSession`): stream the JSONL transcript for id/cwd/topic/duration/messageCount. Token usage + model live only in the sibling `<uuid>.settings.json`, so cost is computed from there via `costOfUsage`.
- **View** (`parseDroid` + `detectAgent`): render droid's `{type:'message', message:{role, content, modelId}}` envelope. Content blocks are Anthropic-shaped (text / thinking / tool_use / tool_result / image), so block handling mirrors the Claude parser.
- **Clean prompt/topic**: droid front-loads injected context (date, skills list) as `<system-reminder>` text blocks on the first user turn — these are dropped in both scan and parse so topic/prompt stay clean. Prefer droid's auto-generated `sessionTitle` as the topic.
- `buildResumeCommand`: group `droid` with the non-resumable agents for now (resume CLI semantics TBD).

## Verification

End-to-end against a real `~/.factory` session:

- `agents sessions --agent droid` and the default all-agents listing now show the droid session (`Casual greeting session`, correct project/timestamp/version).
- `agents sessions <id>` parses and renders the transcript; the displayed prompt is the real user message (`Hi, how are you//`), not the injected reminder.
- New `parse-droid.test.ts` (4 tests) + full session suite (253 tests) pass; `tsc --noEmit` clean.