### PR TITLE
feat(menubar): actionable-first dropdown, aligned to Factory Floor

### DIFF
--- a/packages/menubar-helper/Sources/MenubarHelper/AgentsCLI.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/AgentsCLI.swift
@@ -88,7 +88,15 @@ enum AgentsCLI {
 
     static func openPath(_ path: String) { runDetached(["/usr/bin/open", path]) }
 
+    static func startScheduler() { runDetached(argv(["routines", "start"])) }
     static func stopDaemon() { runDetached(argv(["routines", "stop"])) }
+
+    // Surface CLI health in a terminal — `agents doctor` is interactive output.
+    static func runDoctor() {
+        let cmd = "\(shellQuote(binary)) doctor"
+        let script = "tell application \"Terminal\"\nactivate\ndo script \"\(cmd)\"\nend tell"
+        runDetached(["/usr/bin/osascript", "-e", script])
+    }
 
     // "Quit menu bar" disables the launchd agent so it doesn't relaunch on the
     // KeepAlive policy, then the app terminates.

--- a/packages/menubar-helper/Sources/MenubarHelper/StatusItemController.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/StatusItemController.swift
@@ -6,9 +6,14 @@ import AppKit
 // has exactly one home — no section restates another.
 final class StatusItemController: NSObject, NSMenuDelegate {
     private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-    private let accent = NSColor(red: 0x39 / 255.0, green: 0xd3 / 255.0, blue: 0x53 / 255.0, alpha: 1) // #39d353
-    private let alert = NSColor.systemRed
-    private let warning = NSColor.systemOrange
+    // Factory Floor status palette (design-system.css). Brand green is accent /
+    // selection only — never a status. running/idle/waiting/failed are the four
+    // status colors, shared with the full dashboard so this reads as its quick view.
+    private let brand = NSColor(srgbRed: 0xa3 / 255.0, green: 0xe6 / 255.0, blue: 0x35 / 255.0, alpha: 1) // #a3e635
+    private let run   = NSColor(srgbRed: 0x22 / 255.0, green: 0xc5 / 255.0, blue: 0x5e / 255.0, alpha: 1) // #22C55E
+    private let idleC = NSColor(srgbRed: 0x6b / 255.0, green: 0x72 / 255.0, blue: 0x80 / 255.0, alpha: 1) // #6B7280
+    private let wait  = NSColor(srgbRed: 0xd4 / 255.0, green: 0xa7 / 255.0, blue: 0x2c / 255.0, alpha: 1) // #D4A72C
+    private let fail  = NSColor(srgbRed: 0xef / 255.0, green: 0x44 / 255.0, blue: 0x44 / 255.0, alpha: 1) // #EF4444
 
     // Cached cheap snapshot for the badge (no teams scan).
     private var badgeSessions: [Session] = []
@@ -137,9 +142,9 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         let attention = badgeSessions.filter { $0.status == .attention }.count
         let running = badgeSessions.filter { $0.status == .running }.count
         if attention > 0 {
-            button.attributedTitle = badge("!", alert)
+            button.attributedTitle = badge("⚠", wait)
         } else if running > 0 {
-            button.attributedTitle = badge(" \(running)", accent)
+            button.attributedTitle = badge(" \(running)", run)
         } else {
             button.title = ""
         }
@@ -209,14 +214,14 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         let status: String
         let color: NSColor
         if attn > 0 {
-            status = "! \(attn) awaiting input"
-            color = alert
+            status = "⚠ \(attn) needs you"
+            color = wait
         } else if running > 0 {
             status = "\u{25CF} \(running) running"
-            color = accent
+            color = run
         } else {
             status = "idle"
-            color = .secondaryLabelColor
+            color = idleC
         }
 
         let left = "agents-cli"
@@ -239,13 +244,14 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     }
 
     // Returns true if anything was rendered (caller adds the trailing separator).
+    // Order mirrors the Factory Floor phase rank: waiting first, then failed.
     private func addNeedsAttention(_ menu: NSMenu, sessions: [Session],
                                    routines: [Routine], daemonPid: Int?) -> Bool {
-        var rows: [(String, NSMenu?)] = []
+        var rows: [(String, NSColor, String, NSMenu?)] = []   // glyph, color, text, submenu
 
         for s in sessions where s.status == .attention {
             let detail = s.detail.isEmpty ? "awaiting input" : trim(s.detail, 34)
-            rows.append(("  ! \(LocalState.agentLabel(s.agent)) · \(s.repo) — \(detail)",
+            rows.append(("⚠", wait, "\(LocalState.agentLabel(s.agent)) · \(s.repo) — \(detail)",
                          s.cwd.map { revealSubmenu($0) }))
         }
 
@@ -257,21 +263,21 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             sub.addItem(.separator())
             let next = routines.compactMap { $0.enabled ? $0.nextRunHuman : nil }.first(where: { $0 != "-" }) ?? "—"
             sub.addItem(disabled("\(routines.count) routines waiting · next \(next)"))
-            rows.append(("  ! Scheduler stopped — routines won’t run", sub))
+            rows.append(("⚠", wait, "Scheduler stopped — routines won’t run", sub))
         }
 
         let bad = routines.filter { $0.lastStatus == "failed" || $0.lastStatus == "timeout" || $0.overdue }
         if bad.count == 1, let r = bad.first {
             let why = r.overdue ? "overdue" : (r.lastStatus ?? "failed")
-            rows.append(("  ! Routine \(r.name) \(why)", allRoutinesSubmenu(bad)))
+            rows.append(("✕", fail, "Routine \(r.name) \(why)", allRoutinesSubmenu(bad)))
         } else if bad.count > 1 {
-            rows.append(("  ! \(bad.count) routines failing", allRoutinesSubmenu(bad)))
+            rows.append(("✕", fail, "\(bad.count) routines failing", allRoutinesSubmenu(bad)))
         }
 
         if rows.isEmpty { return false }
-        addSectionTitle(menu, "NEEDS ATTENTION", color: warning)
-        for (title, sub) in rows {
-            let it = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        addSectionTitle(menu, "⚠ NEEDS YOU", color: wait)
+        for (glyph, color, text, sub) in rows {
+            let it = statusRow(glyph, color, text)
             it.submenu = sub
             menu.addItem(it)
         }
@@ -299,17 +305,16 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         addSectionTitle(menu, title, color: .secondaryLabelColor)
 
         for s in live {
-            let mark = s.status == .attention ? "! " : (s.status == .running ? "● " : "○ ")
+            let glyph = s.status == .attention ? "⚠" : (s.status == .running ? "●" : "◐")
+            let color = s.status == .attention ? wait : (s.status == .running ? run : idleC)
             let detail = s.detail.isEmpty ? "" : " — \(trim(s.detail, 32))"
-            let row = NSMenuItem(title: "  \(mark)\(LocalState.agentLabel(s.agent))   \(s.repo)\(detail)",
-                                 action: nil, keyEquivalent: "")
+            let row = statusRow(glyph, color, "\(LocalState.agentLabel(s.agent))   \(s.repo)\(detail)")
             if let cwd = s.cwd { row.submenu = revealSubmenu(cwd) }
             menu.addItem(row)
         }
         for task in browserTasks {
             let tabs = task.tabCount == 1 ? "1 tab" : "\(task.tabCount) tabs"
-            let row = NSMenuItem(title: "  ◦ Browser   \(trim(task.name, 24)) · \(shortProfile(task.profile)) · \(tabs)",
-                                 action: nil, keyEquivalent: "")
+            let row = statusRow("◦", idleC, "Browser   \(trim(task.name, 24)) · \(shortProfile(task.profile)) · \(tabs)")
             row.submenu = browserTaskSubmenu(task)
             menu.addItem(row)
         }
@@ -558,6 +563,23 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     private func disabled(_ title: String) -> NSMenuItem {
         let it = NSMenuItem(title: title, action: nil, keyEquivalent: "")
         it.isEnabled = false
+        return it
+    }
+
+    // A row whose leading status glyph is tinted with the Factory palette while
+    // the label stays default — mirrors the dashboard's color-coded status dots.
+    private func statusRow(_ glyph: String, _ glyphColor: NSColor, _ rest: String) -> NSMenuItem {
+        let title = "  \(glyph) \(rest)"
+        let it = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        let attr = NSMutableAttributedString(string: title, attributes: [
+            .font: NSFont.menuFont(ofSize: 0),
+            .foregroundColor: NSColor.labelColor,
+        ])
+        let r = (title as NSString).range(of: glyph)
+        if r.location != NSNotFound {
+            attr.addAttribute(.foregroundColor, value: glyphColor, range: r)
+        }
+        it.attributedTitle = attr
         return it
     }
 

--- a/packages/menubar-helper/Sources/MenubarHelper/StatusItemController.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/StatusItemController.swift
@@ -1,8 +1,9 @@
 import AppKit
 
-// Owns the NSStatusItem. The dropdown is intentionally data-dense: a fixed
-// product roster, activity from local sessions/browser work, routines,
-// resource sync state, and compact warnings near the footer.
+// Owns the NSStatusItem. The dropdown is actionable-first: what needs the user
+// now (attention sessions, a stopped scheduler, failing routines) leads; live
+// work follows; setup/health noise collapses into one row. Every health fact
+// has exactly one home — no section restates another.
 final class StatusItemController: NSObject, NSMenuDelegate {
     private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     private let accent = NSColor(red: 0x39 / 255.0, green: 0xd3 / 255.0, blue: 0x53 / 255.0, alpha: 1) // #39d353
@@ -173,53 +174,108 @@ final class StatusItemController: NSObject, NSMenuDelegate {
                          doctor: DoctorOverview?, daemonPid: Int?) {
         menu.removeAllItems()
 
-        addHeader(menu, daemonPid: daemonPid)
+        addHeader(menu, sessions: sessions)
+        menu.addItem(.separator())
+
+        // What needs me now — rendered only when there's something actionable.
+        if addNeedsAttention(menu, sessions: sessions, routines: routines, daemonPid: daemonPid) {
+            menu.addItem(.separator())
+        }
+
         addNewSession(menu)
         menu.addItem(.separator())
 
-        addAgents(menu, sessions: sessions, doctor: doctor)
-        menu.addItem(.separator())
-
-        addActivity(menu, browserTasks: browserTasks, recentSessions: recentSessions)
-        menu.addItem(.separator())
-
-        addRoutines(menu, routines: routines)
-        menu.addItem(.separator())
-
-        addResources(menu, doctor: doctor)
-
-        let warnings = warningRows(routines: routines, doctor: doctor)
-        if !warnings.isEmpty {
+        // Live work — skipped entirely on a calm, idle machine.
+        let live = sessions.filter { $0.status == .running || $0.status == .idle || $0.status == .attention }
+        if !live.isEmpty || !browserTasks.isEmpty {
+            addActive(menu, live: live, browserTasks: browserTasks)
             menu.addItem(.separator())
-            addSectionTitle(menu, "WARNINGS", color: warning)
-            for row in warnings.prefix(4) {
-                let it = NSMenuItem(title: "  ! \(row)", action: nil, keyEquivalent: "")
-                menu.addItem(it)
-            }
-            if warnings.count > 4 {
-                menu.addItem(disabled("  \(warnings.count - 4) more warnings"))
-            }
         }
+
+        addRecent(menu, recentSessions: recentSessions)
+        menu.addItem(.separator())
+
+        addRoutinesRow(menu, routines: routines)
+        addSetup(menu, doctor: doctor)
 
         menu.addItem(.separator())
         addFooter(menu, daemonPid: daemonPid)
     }
 
-    private func addHeader(_ menu: NSMenu, daemonPid: Int?) {
-        let status = daemonPid == nil ? "STOPPED" : "RUNNING"
-        let title = "agents-cli                                      \(status)"
+    // MARK: Sections
+    private func addHeader(_ menu: NSMenu, sessions: [Session]) {
+        let attn = sessions.filter { $0.status == .attention }.count
+        let running = sessions.filter { $0.status == .running }.count
+        let status: String
+        let color: NSColor
+        if attn > 0 {
+            status = "! \(attn) awaiting input"
+            color = alert
+        } else if running > 0 {
+            status = "\u{25CF} \(running) running"
+            color = accent
+        } else {
+            status = "idle"
+            color = .secondaryLabelColor
+        }
+
+        let left = "agents-cli"
+        let width = max(left.count + 3, 44 - status.count)
+        let title = left.padding(toLength: width, withPad: " ", startingAt: 0) + status
         let item = disabled(title)
         let attr = NSMutableAttributedString(string: title, attributes: [
             .foregroundColor: NSColor.labelColor,
             .font: NSFont.monospacedSystemFont(ofSize: 13, weight: .semibold),
         ])
-        let range = (title as NSString).range(of: status)
-        attr.addAttributes([
-            .foregroundColor: daemonPid == nil ? alert : accent,
-            .font: NSFont.monospacedSystemFont(ofSize: 12, weight: .bold),
-        ], range: range)
+        let range = (title as NSString).range(of: status, options: .backwards)
+        if range.location != NSNotFound {
+            attr.addAttributes([
+                .foregroundColor: color,
+                .font: NSFont.monospacedSystemFont(ofSize: 12, weight: .bold),
+            ], range: range)
+        }
         item.attributedTitle = attr
         menu.addItem(item)
+    }
+
+    // Returns true if anything was rendered (caller adds the trailing separator).
+    private func addNeedsAttention(_ menu: NSMenu, sessions: [Session],
+                                   routines: [Routine], daemonPid: Int?) -> Bool {
+        var rows: [(String, NSMenu?)] = []
+
+        for s in sessions where s.status == .attention {
+            let detail = s.detail.isEmpty ? "awaiting input" : trim(s.detail, 34)
+            rows.append(("  ! \(LocalState.agentLabel(s.agent)) · \(s.repo) — \(detail)",
+                         s.cwd.map { revealSubmenu($0) }))
+        }
+
+        if daemonPid == nil && !routines.isEmpty {
+            let sub = NSMenu()
+            let start = NSMenuItem(title: "Start scheduler", action: #selector(onStartScheduler), keyEquivalent: "")
+            start.target = self
+            sub.addItem(start)
+            sub.addItem(.separator())
+            let next = routines.compactMap { $0.enabled ? $0.nextRunHuman : nil }.first(where: { $0 != "-" }) ?? "—"
+            sub.addItem(disabled("\(routines.count) routines waiting · next \(next)"))
+            rows.append(("  ! Scheduler stopped — routines won’t run", sub))
+        }
+
+        let bad = routines.filter { $0.lastStatus == "failed" || $0.lastStatus == "timeout" || $0.overdue }
+        if bad.count == 1, let r = bad.first {
+            let why = r.overdue ? "overdue" : (r.lastStatus ?? "failed")
+            rows.append(("  ! Routine \(r.name) \(why)", allRoutinesSubmenu(bad)))
+        } else if bad.count > 1 {
+            rows.append(("  ! \(bad.count) routines failing", allRoutinesSubmenu(bad)))
+        }
+
+        if rows.isEmpty { return false }
+        addSectionTitle(menu, "NEEDS ATTENTION", color: warning)
+        for (title, sub) in rows {
+            let it = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+            it.submenu = sub
+            menu.addItem(it)
+        }
+        return true
     }
 
     private func addNewSession(_ menu: NSMenu) {
@@ -235,58 +291,66 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         menu.addItem(newItem)
     }
 
-    private func addAgents(_ menu: NSMenu, sessions: [Session], doctor: DoctorOverview?) {
-        let running = sessions.filter { $0.status == .running }.count
-        let idle = sessions.filter { $0.status == .idle }.count
-        addSectionTitle(menu, "AGENTS  ·  \(running) running · \(idle) idle", color: .secondaryLabelColor)
-        for agent in LocalState.desiredAgents {
-            let mine = sessions.filter { LocalState.normalizeAgent($0.agent) == agent.id }
-            let item = NSMenuItem(title: rosterRow(agent: agent, sessions: mine, doctor: doctor),
-                                  action: nil, keyEquivalent: "")
-            item.submenu = rosterSubmenu(agent: agent, sessions: mine, doctor: doctor)
-            menu.addItem(item)
+    private func addActive(_ menu: NSMenu, live: [Session], browserTasks: [BrowserTask]) {
+        let running = live.filter { $0.status == .running }.count
+        let idle = live.filter { $0.status == .idle }.count
+        var title = "ACTIVE"
+        if running > 0 || idle > 0 { title += "  ·  \(running) running · \(idle) idle" }
+        addSectionTitle(menu, title, color: .secondaryLabelColor)
+
+        for s in live {
+            let mark = s.status == .attention ? "! " : (s.status == .running ? "● " : "○ ")
+            let detail = s.detail.isEmpty ? "" : " — \(trim(s.detail, 32))"
+            let row = NSMenuItem(title: "  \(mark)\(LocalState.agentLabel(s.agent))   \(s.repo)\(detail)",
+                                 action: nil, keyEquivalent: "")
+            if let cwd = s.cwd { row.submenu = revealSubmenu(cwd) }
+            menu.addItem(row)
+        }
+        for task in browserTasks {
+            let tabs = task.tabCount == 1 ? "1 tab" : "\(task.tabCount) tabs"
+            let row = NSMenuItem(title: "  ◦ Browser   \(trim(task.name, 24)) · \(shortProfile(task.profile)) · \(tabs)",
+                                 action: nil, keyEquivalent: "")
+            row.submenu = browserTaskSubmenu(task)
+            menu.addItem(row)
         }
     }
 
-    private func addActivity(_ menu: NSMenu, browserTasks: [BrowserTask], recentSessions: [RecentSession]) {
-        addSectionTitle(menu, "ACTIVITY", color: .secondaryLabelColor)
-        let visibleRecentSessions = Array(recentSessions.filter {
+    private func addRecent(_ menu: NSMenu, recentSessions: [RecentSession]) {
+        addSectionTitle(menu, "RECENT", color: .secondaryLabelColor)
+        let visible = Array(recentSessions.filter {
             let id = LocalState.normalizeAgent($0.agent)
             return LocalState.desiredAgents.contains { $0.id == id }
         }.prefix(3))
-
-        for task in browserTasks {
-            let tabs = task.tabCount == 1 ? "1 tab" : "\(task.tabCount) tabs"
-            let title = "  Browser      \(trim(task.name, 28)) · \(shortProfile(task.profile)) · \(tabs)"
-            let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
-            item.submenu = browserTaskSubmenu(task)
-            menu.addItem(item)
-        }
-
-        if visibleRecentSessions.isEmpty {
+        if visible.isEmpty {
             menu.addItem(disabled(recentSessionsLoaded ? "  No recent sessions" : "  Recent sessions checking…"))
             return
         }
-
-        for session in visibleRecentSessions {
-            let title = recentSessionTitle(session)
-            let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        for session in visible {
+            let item = NSMenuItem(title: recentSessionTitle(session), action: nil, keyEquivalent: "")
             item.submenu = recentSessionSubmenu(session)
             menu.addItem(item)
         }
     }
 
-    private func addRoutines(_ menu: NSMenu, routines: [Routine]) {
-        addSectionTitle(menu, "ROUTINES", color: .secondaryLabelColor)
-        let item = NSMenuItem(title: routinesSummary(routines), action: nil, keyEquivalent: "")
+    private func addRoutinesRow(_ menu: NSMenu, routines: [Routine]) {
+        let detail: String
+        if routines.isEmpty {
+            detail = routinesLoaded ? "none" : "checking…"
+        } else {
+            let next = routines.compactMap { $0.enabled ? $0.nextRunHuman : nil }.first(where: { $0 != "-" }) ?? "—"
+            let paused = routines.filter { !$0.enabled }.count
+            var parts = ["\(routines.count)", "next \(next)"]
+            if paused > 0 { parts.append("\(paused) paused") }
+            detail = parts.joined(separator: " · ")
+        }
+        let item = NSMenuItem(title: "\(pad("Routines"))\(detail)", action: nil, keyEquivalent: "")
         if !routines.isEmpty { item.submenu = allRoutinesSubmenu(routines) }
         menu.addItem(item)
     }
 
-    private func addResources(_ menu: NSMenu, doctor: DoctorOverview?) {
-        addSectionTitle(menu, "RESOURCES", color: .secondaryLabelColor)
-        let item = NSMenuItem(title: resourcesSummary(doctor), action: nil, keyEquivalent: "")
-        item.submenu = resourcesSubmenu(doctor)
+    private func addSetup(_ menu: NSMenu, doctor: DoctorOverview?) {
+        let item = NSMenuItem(title: "\(pad("Setup"))\(setupSummary(doctor))", action: nil, keyEquivalent: "")
+        item.submenu = setupSubmenu(doctor)
         menu.addItem(item)
     }
 
@@ -305,52 +369,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         menu.addItem(quit)
     }
 
-    // MARK: Row builders
-    private func rosterRow(agent: MenuAgent, sessions: [Session], doctor: DoctorOverview?) -> String {
-        let attn = sessions.filter { $0.status == .attention }.count
-        let run = sessions.filter { $0.status == .running }.count
-        let idle = sessions.filter { $0.status == .idle }.count
-        let name = agent.label.padding(toLength: 13, withPad: " ", startingAt: 0)
-        let resource = resourceHint(agent.id, doctor: doctor)
-        if cliInstalled(agent.id, doctor: doctor) == false { return "\(name) ! missing CLI" }
-        if attn > 0 { return "\(name) ! \(attn) awaiting input\(resource)" }
-        if run > 0 { return "\(name) ● \(run) running" + (idle > 0 ? " · \(idle) idle" : "") + resource }
-        if idle > 0 { return "\(name) ○ \(idle) idle\(resource)" }
-        return "\(name) ○ ready\(resource)"
-    }
-
-    private func rosterSubmenu(agent: MenuAgent, sessions: [Session], doctor: DoctorOverview?) -> NSMenu {
-        let sub = NSMenu()
-        if sessions.isEmpty {
-            sub.addItem(disabled("No live sessions"))
-        } else {
-            for s in sessions {
-                let mark = s.status == .attention ? "! " : (s.status == .running ? "● " : "○ ")
-                let detail = s.detail.isEmpty ? "" : "  ·  \(trim(s.detail, 40))"
-                let row = NSMenuItem(title: "\(mark)\(s.repo)\(detail)", action: nil, keyEquivalent: "")
-                if let cwd = s.cwd { row.submenu = revealSubmenu(cwd) }
-                sub.addItem(row)
-            }
-        }
-
-        sub.addItem(.separator())
-        if let sync = syncState(agent.id, doctor: doctor) {
-            sub.addItem(disabled("Resources: \(sync.status)\(sync.version.map { " · \($0)" } ?? "")"))
-        } else {
-            sub.addItem(disabled(doctorLoaded ? "Resources: unknown" : "Resources: checking…"))
-        }
-        if let cli = doctor?.clis?[agent.id] {
-            sub.addItem(disabled(cli.installed ? "CLI installed" : "CLI missing"))
-        }
-
-        sub.addItem(.separator())
-        let new = NSMenuItem(title: "New \(agent.label) session", action: #selector(onNewSession(_:)), keyEquivalent: "")
-        new.target = self
-        new.representedObject = agent.id
-        sub.addItem(new)
-        return sub
-    }
-
+    // MARK: Submenus
     private func browserTaskSubmenu(_ task: BrowserTask) -> NSMenu {
         let sub = NSMenu()
         sub.addItem(disabled("Profile: \(task.profile)"))
@@ -435,111 +454,64 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         return sub
     }
 
-    private func resourcesSubmenu(_ doctor: DoctorOverview?) -> NSMenu {
+    private func setupSummary(_ doctor: DoctorOverview?) -> String {
+        guard let doctor else { return doctorLoaded ? "unavailable" : "checking…" }
+        let sync = desiredSyncStates(doctor)
+        let stale = sync.filter { $0.status == "stale" }.count
+        let never = sync.filter { $0.status == "never-synced" }.count
+        let missing = LocalState.desiredAgents.filter { doctor.clis?[$0.id]?.installed == false }.count
+        var parts: [String] = []
+        if missing > 0 { parts.append("\(missing) not installed") }
+        if stale > 0 { parts.append("\(stale) stale") }
+        if never > 0 { parts.append("\(never) unsynced") }
+        return parts.isEmpty ? "all set" : parts.joined(separator: " · ")
+    }
+
+    private func setupSubmenu(_ doctor: DoctorOverview?) -> NSMenu {
         let sub = NSMenu()
         guard let doctor else {
             sub.addItem(disabled(doctorLoaded ? "Doctor unavailable" : "Checking resources…"))
             return sub
         }
-
-        for agent in LocalState.desiredAgents {
-            let sync = syncState(agent.id, doctor: doctor)
-            let cli = doctor.clis?[agent.id]
-            var title = "\(agent.label)  "
-            if cli?.installed == false {
-                title += "missing CLI"
-            } else if let sync {
-                title += "\(sync.status)" + (sync.version.map { " · \($0)" } ?? "")
-            } else {
-                title += "unknown"
-            }
-            sub.addItem(disabled(title))
+        let notInstalled = LocalState.desiredAgents.filter { doctor.clis?[$0.id]?.installed == false }
+        if !notInstalled.isEmpty {
+            sub.addItem(disabled("Not installed"))
+            for a in notInstalled { sub.addItem(disabled("  \(a.label)")) }
         }
-
+        let needsSync = LocalState.desiredAgents.compactMap { a -> (MenuAgent, DoctorSync)? in
+            guard let s = syncState(a.id, doctor: doctor),
+                  s.status == "stale" || s.status == "never-synced" else { return nil }
+            return (a, s)
+        }
+        if !needsSync.isEmpty {
+            sub.addItem(disabled("Resources"))
+            for (a, s) in needsSync {
+                sub.addItem(disabled("  \(a.label)  \(s.status)\(s.version.map { " · \($0)" } ?? "")"))
+            }
+        }
+        if notInstalled.isEmpty && needsSync.isEmpty {
+            sub.addItem(disabled("All agents installed & synced"))
+        }
         sub.addItem(.separator())
+        let doctorItem = NSMenuItem(title: "Run agents doctor", action: #selector(onRunDoctor), keyEquivalent: "")
+        doctorItem.target = self
+        sub.addItem(doctorItem)
         let open = NSMenuItem(title: "Open ~/.agents", action: #selector(onOpenAgentsHome), keyEquivalent: "")
         open.target = self
         sub.addItem(open)
         return sub
     }
 
-    // MARK: Summaries
-    private func routinesSummary(_ routines: [Routine]) -> String {
-        if routines.isEmpty && !routinesLoaded { return "  checking…" }
-        if routines.isEmpty { return "  none" }
-
-        let next = routines.compactMap { $0.enabled ? $0.nextRunHuman : nil }.first(where: { $0 != "-" }) ?? "—"
-        let bad = routines.filter { $0.lastStatus == "failed" || $0.lastStatus == "timeout" || $0.overdue }.count
-        let paused = routines.filter { !$0.enabled }.count
-        var parts = ["  \(routines.count) routines", "next \(next)"]
-        if paused > 0 { parts.append("\(paused) paused") }
-        if bad > 0 { parts.append("\(bad) warning\(bad == 1 ? "" : "s")") }
-        return parts.joined(separator: " · ")
-    }
-
-    private func resourcesSummary(_ doctor: DoctorOverview?) -> String {
-        guard let doctor else { return doctorLoaded ? "  unavailable" : "  checking…" }
-        let sync = desiredSyncStates(doctor)
-        let stale = sync.filter { $0.status == "stale" }.count
-        let never = sync.filter { $0.status == "never-synced" }.count
-        let missing = LocalState.desiredAgents.filter { doctor.clis?[$0.id]?.installed == false }.count
-        var parts: [String] = []
-        if stale > 0 { parts.append("\(stale) stale") }
-        if never > 0 { parts.append("\(never) never synced") }
-        if missing > 0 { parts.append("\(missing) missing CLI") }
-        if parts.isEmpty { parts.append("all synced") }
-        return "  sync \(parts.joined(separator: " · "))"
-    }
-
-    private func warningRows(routines: [Routine], doctor: DoctorOverview?) -> [String] {
-        var rows: [String] = []
-
-        let badRoutines = routines.filter { $0.lastStatus == "failed" || $0.lastStatus == "timeout" || $0.overdue }
-        if badRoutines.count == 1, let r = badRoutines.first {
-            let why = r.overdue ? "overdue" : (r.lastStatus ?? "failed")
-            rows.append("Routine \(r.name) \(why)")
-        } else if badRoutines.count > 1 {
-            rows.append("\(badRoutines.count) routines need attention")
-        }
-
-        if let doctor {
-            let missing = LocalState.desiredAgents.filter { doctor.clis?[$0.id]?.installed == false }.map(\.label)
-            if !missing.isEmpty { rows.append("Missing CLI: \(list(missing))") }
-
-            let never = desiredSyncStates(doctor).filter { $0.status == "never-synced" }.map { LocalState.agentLabel($0.agent) }
-            if !never.isEmpty { rows.append("Never synced: \(list(never))") }
-
-            let stale = desiredSyncStates(doctor).filter { $0.status == "stale" }.map { LocalState.agentLabel($0.agent) }
-            if !stale.isEmpty { rows.append("Stale resources: \(list(stale))") }
-
-            let drift = doctor.orphans?.filter { LocalState.desiredAgents.map(\.id).contains($0.agent) } ?? []
-            if !drift.isEmpty { rows.append("Local-only resources in \(drift.count) agents") }
-        }
-
-        return rows
-    }
-
     private func recentSessionTitle(_ session: RecentSession) -> String {
-        let agent = LocalState.agentLabel(session.agent).padding(toLength: 11, withPad: " ", startingAt: 0)
+        let agent = LocalState.agentLabel(session.agent).padding(toLength: 9, withPad: " ", startingAt: 0)
         let project = session.project ?? session.cwd.map { ($0 as NSString).lastPathComponent } ?? "session"
-        let sid = session.shortId ?? session.id.map { String($0.prefix(8)) } ?? "recent"
-        return "  \(agent) \(trim(project, 18)) · \(sid) · \(shortWhen(session.timestamp))"
-    }
-
-    private func resourceHint(_ agent: String, doctor: DoctorOverview?) -> String {
-        guard let doctor else { return "" }
-        if doctor.clis?[agent]?.installed == false { return " · missing CLI" }
-        guard let sync = syncState(agent, doctor: doctor) else { return "" }
-        switch sync.status {
-        case "stale": return " · stale"
-        case "never-synced": return " · never synced"
-        case "missing": return " · missing resources"
-        default: return ""
+        let label: String
+        if let topic = session.topic, !topic.isEmpty {
+            label = "“\(trim(topic, 22))”"
+        } else {
+            label = session.shortId ?? session.id.map { String($0.prefix(8)) } ?? "recent"
         }
-    }
-
-    private func cliInstalled(_ agent: String, doctor: DoctorOverview?) -> Bool? {
-        doctor?.clis?[agent]?.installed
+        return "  \(agent) \(trim(project, 14)) · \(label) · \(shortWhen(session.timestamp))"
     }
 
     private func syncState(_ agent: String, doctor: DoctorOverview?) -> DoctorSync? {
@@ -564,6 +536,8 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         if let p = s.representedObject as? String { AgentsCLI.openPath(p) }
     }
     @objc private func onOpenAgentsHome() { AgentsCLI.openPath("\(AgentsCLI.home)/.agents") }
+    @objc private func onStartScheduler() { AgentsCLI.startScheduler() }
+    @objc private func onRunDoctor() { AgentsCLI.runDoctor() }
     @objc private func onStopScheduler() { AgentsCLI.stopDaemon() }
     @objc private func onQuit() { AgentsCLI.menubarDisable(); NSApp.terminate(nil) }
 
@@ -587,6 +561,11 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         return it
     }
 
+    // Left-pad a single-row label so its value column lines up (Routines / Setup).
+    private func pad(_ label: String) -> String {
+        label.padding(toLength: max(label.count + 1, 10), withPad: " ", startingAt: 0)
+    }
+
     private func trim(_ value: String, _ max: Int) -> String {
         if value.count <= max { return value }
         return String(value.prefix(max - 1)) + "…"
@@ -603,7 +582,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             let f = DateFormatter()
             f.dateStyle = .none
             f.timeStyle = .short
-            return "today \(f.string(from: date))"
+            return f.string(from: date)
         }
         if cal.isDateInYesterday(date) { return "yesterday" }
         let f = DateFormatter()
@@ -617,11 +596,6 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         if let d = f.date(from: raw) { return d }
         f.formatOptions = [.withInternetDateTime]
         return f.date(from: raw)
-    }
-
-    private func list(_ values: [String], limit: Int = 3) -> String {
-        if values.count <= limit { return values.joined(separator: ", ") }
-        return values.prefix(limit).joined(separator: ", ") + " +\(values.count - limit)"
     }
 
     private func dumpMenu(_ menu: NSMenu) {


### PR DESCRIPTION
## Why

The menu-bar dropdown repeated the same health fact up to **3×** (roster row + RESOURCES summary + WARNINGS) and gave 7 top-level rows to a fixed roster the user mostly doesn't use — in the common case 5 of 7 read `! missing CLI`. The genuinely actionable signals (an agent waiting on you, a stopped scheduler, a failing routine) were buried in grey text at the bottom. This makes the menu the glanceable **quick version of the Factory Floor** dashboard: what needs you, first.

## What

**Layout (commit 1):**
- Header shows live activity (`idle` / `● N running` / `⚠ N needs you`) instead of the scheduler-only `STOPPED/RUNNING`.
- New **NEEDS YOU** section leads, rendered only when non-empty: attention sessions, scheduler-stopped (with a **Start scheduler** action), failing/overdue routines.
- Fixed AGENTS roster replaced by **ACTIVE** (live sessions + browser only); skipped entirely on a calm idle machine.
- `ACTIVITY` → **RECENT**, showing the session **topic** instead of the hex id.
- `RESOURCES` + per-agent roster health + the duplicate `WARNINGS` section collapse into one **SETUP** row + grouped submenu. Every fact now has exactly one home.

**Factory Floor alignment (commit 2):**
- Locked palette: running `#22C55E`, idle `#6B7280`, waiting `#D4A72C`, failed `#EF4444`; brand `#a3e635` stays accent-only.
- Vocabulary + colored status glyphs: `⚠ NEEDS YOU`, `● Running`, `◐ Idle`, `✕ Failed`.
- Native SF menu font retained (Geist is for the in-app webview only).

Same data sources, no backend change. Net **-18 lines**.

## Verification

`MENUBAR_DUMP=1` on live data -> **18 items** (vs ~30 before): `⚠ NEEDS YOU` first, `✕ 7 routines failing`, no roster, no WARNINGS section, SETUP present, RECENT shows topics. Swift build clean.

Prototype (macOS-menu chrome, before/after + idle/busy toggle): `~/Downloads/menubar-redesign-prototype/index.html`.

## Follow-up (separate PR)

Terminal-launch rework: `New Session` currently hardcodes Terminal.app. Ghostty can't open a tab in an existing window from an external process (verified + upstream ghostty#12136), so the launcher will offer a terminal-host preference — default tmux-in-Ghostty (true tabs) or iTerm native tabs.