### PR TITLE
fix(doctor): detect agent CLIs via shims dir, not just PATH

### DIFF
--- a/src/lib/teams/agents.cli-detection.test.ts
+++ b/src/lib/teams/agents.cli-detection.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// Regression guard for the menu-bar "not installed" bug: a launchd/cron process
+// runs with a minimal PATH that omits ~/.agents/.cache/shims, so a bare PATH
+// lookup false-flags every shim-based CLI as missing. Detection must resolve the
+// canonical shims dir directly, independent of PATH.
+describe('checkCliAvailable — shims-dir detection', () => {
+  let tmpHome: string;
+  let origHome: string | undefined;
+  let origPath: string | undefined;
+
+  beforeEach(() => {
+    origHome = process.env.HOME;
+    origPath = process.env.PATH;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'checkcli-'));
+  });
+
+  afterEach(() => {
+    if (origHome === undefined) delete process.env.HOME; else process.env.HOME = origHome;
+    if (origPath === undefined) delete process.env.PATH; else process.env.PATH = origPath;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  it('reports installed from the shim even when PATH is empty', async () => {
+    process.env.HOME = tmpHome;
+    process.env.PATH = '';
+    const shimsDir = path.join(tmpHome, '.agents', '.cache', 'shims');
+    fs.mkdirSync(shimsDir, { recursive: true });
+    fs.writeFileSync(path.join(shimsDir, 'claude'), '#!/bin/sh\n', { mode: 0o755 });
+
+    vi.resetModules();
+    const { checkCliAvailable } = await import('./agents.js');
+    const [installed, resolved] = checkCliAvailable('claude' as never);
+
+    expect(installed).toBe(true);
+    expect(resolved).toBe(path.join(shimsDir, 'claude'));
+  });
+
+  it('reports not-installed when neither the shims dir nor PATH has the CLI', async () => {
+    process.env.HOME = tmpHome;
+    process.env.PATH = '';
+    fs.mkdirSync(path.join(tmpHome, '.agents', '.cache', 'shims'), { recursive: true });
+
+    vi.resetModules();
+    const { checkCliAvailable } = await import('./agents.js');
+    const [installed, err] = checkCliAvailable('claude' as never);
+
+    expect(installed).toBe(false);
+    expect(err).toMatch(/not found in PATH/);
+  });
+});

--- a/src/lib/teams/agents.ts
+++ b/src/lib/teams/agents.ts
@@ -19,7 +19,7 @@ import { normalizeEvents, AgentType } from './parsers.js';
 import { debug } from './debug.js';
 import { setGeminiAutoUpdateDisabled, updateGeminiSettings } from '../gemini-settings.js';
 import type { AgentId } from '../types.js';
-import { getAgentsDir as getSystemAgentsDir } from '../state.js';
+import { getAgentsDir as getSystemAgentsDir, getShimsDir } from '../state.js';
 import { AGENTS } from '../agents.js';
 import { sanitizeProcessEnv } from '../secrets/bundles.js';
 
@@ -346,11 +346,26 @@ export async function ensureGeminiPlanMode(): Promise<void> {
   }
 }
 
-/** Check whether the CLI binary for a given agent type exists in PATH. Returns [available, pathOrError]. */
+/**
+ * Check whether the CLI binary for a given agent type is installed.
+ * Returns [available, pathOrError].
+ *
+ * The agents-managed shims dir (`~/.agents/.cache/shims`) is the canonical
+ * install location, so a shim there means installed regardless of the caller's
+ * PATH. Non-interactive callers — the menu-bar helper, cron, CI — run with a
+ * minimal launchd PATH that omits the shims dir; a bare PATH lookup false-flags
+ * every shim-based CLI as "not installed". Check the shim first, PATH second
+ * (for CLIs the user installed outside agents-cli).
+ */
 export function checkCliAvailable(agentType: AgentType): [boolean, string | null] {
   const executable = AGENTS[agentType as AgentId]?.cliCommand;
   if (!executable) {
     return [false, `Unknown agent type: ${agentType}`];
+  }
+
+  const shimPath = path.join(getShimsDir(), executable);
+  if (fsSync.existsSync(shimPath)) {
+    return [true, shimPath];
   }
 
   const resolved = findExecutable(executable);


### PR DESCRIPTION
## Bug

The menu-bar Setup submenu listed **Claude, Codex, Grok-Cli, Kimi-Cli, OpenCode as "Not installed"** — while simultaneously showing them under Resources with synced versions, and they're the agents actively running sessions. Contradiction reported with a screenshot.

## Root cause

`checkCliAvailable()` (`src/lib/teams/agents.ts`) did a **PATH-only** lookup (`findExecutable` → `which`/`where`). Agent CLIs install as shims in `~/.agents/.cache/shims`, which is on an interactive shell's PATH but **not** on the minimal PATH a launchd process inherits. The menu-bar helper is a LaunchAgent (`com.phnx-labs.agents-menubar`) whose PATH is:

```
/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:~/.hermes/node/bin:~/.local/bin
```

— no shims dir. So when it shelled `agents doctor`, the shim-based CLIs resolved to nothing → `installed=false`, while `antigravity`/`droid` (resolved via a dir that *is* on the PATH) stayed correct. That's the exact 5-vs-2 split in the screenshot.

Reproduced: `env -i HOME=$HOME PATH="<launchd PATH>" agents doctor --json` → claude/codex/grok/kimi/opencode all `installed=false`.

## Fix

Resolve the canonical shims dir (`getShimsDir()`) first, PATH second (for CLIs installed outside agents-cli). Detection is now PATH-independent for every non-interactive caller (menu bar, cron, CI).

## Verification

- `agents doctor --json` under the launchd PATH now reports the shim-based CLIs `installed=true`; `gemini` (no shim, not on PATH) correctly stays `false`.
- New test `agents.cli-detection.test.ts` (real temp HOME + real shim on disk, empty PATH): installed-from-shim and not-installed cases. Would fail on the old PATH-only code.