### PR TITLE
fix(droid): close Factory harness support gaps (sessions/shims/inspect)

### DIFF
--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -1315,7 +1315,7 @@ function safeStat(p: string): fs.Stats | null {
 }
 
 const SESSION_AGENTS: ReadonlySet<string> = new Set([
-  'claude', 'codex', 'gemini', 'opencode', 'openclaw', 'rush', 'hermes', 'grok', 'kimi',
+  'claude', 'codex', 'gemini', 'opencode', 'openclaw', 'rush', 'hermes', 'grok', 'kimi', 'droid',
 ]);
 
 function safeCountSessions(agent: AgentId): number {

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -517,7 +517,8 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
   },
   // Factory AI Droid CLI (`droid`) — agentic coding CLI from factory.ai.
   // Install: `curl -fsSL https://app.factory.ai/cli | sh` (no npm package).
-  // Binary is NOT in node_modules/.bin — resolved via resolveDroidBinary().
+  // Binary is NOT in node_modules/.bin — the shim resolves the fixed install
+  // path ~/.local/bin/droid directly (see the droid branch in shims.ts).
   // Config: `~/.factory/` (settings.json, mcp.json, droids/, commands/).
   // Memory: native AGENTS.md. Subagents = custom droids (top-level .md files
   // in ~/.factory/droids/). Config isolation rides the ~/.factory symlink
@@ -751,6 +752,7 @@ export const UNMANAGED_DETECTION_CANDIDATES: AgentId[] = [
   'gemini',
   'grok',
   'copilot',
+  'droid',
 ];
 
 /**
@@ -1143,6 +1145,8 @@ function getSessionDir(agentId: AgentId, base: string): string | null {
       // Copilot persists sessions at ~/.copilot/session-state/<id>/events.jsonl.
       // The events.jsonl is the canonical NDJSON event stream per session.
       return path.join(base, '.copilot', 'session-state');
+    case 'droid':
+      return path.join(base, '.factory', 'sessions');
     default:
       return null;
   }
@@ -1154,6 +1158,7 @@ function getSessionExtension(agentId: AgentId): string | null {
     case 'claude':
     case 'codex':
     case 'copilot':
+    case 'droid':
       return '.jsonl';
     case 'gemini':
       return '.json';
@@ -1852,6 +1857,8 @@ export const AGENT_NAME_ALIASES: Record<string, AgentId> = {
   gk: 'grok',
   kimi: 'kimi',
   'kimi-code': 'kimi',
+  factory: 'droid',
+  'factory-ai': 'droid',
 };
 
 /**

--- a/src/lib/session/active.ts
+++ b/src/lib/session/active.ts
@@ -85,6 +85,7 @@ const AGENT_CLI_NAMES: Record<string, string> = {
   gemini: 'gemini',
   'cursor-agent': 'cursor',
   opencode: 'opencode',
+  droid: 'droid',
 };
 
 function isPidAlive(pid: number): boolean {

--- a/src/lib/session/cloud.ts
+++ b/src/lib/session/cloud.ts
@@ -67,6 +67,7 @@ function agentToFormat(agent: string): SessionAgentId | null {
   if (agent === 'claude') return 'claude';
   if (agent === 'codex') return 'codex';
   if (agent === 'rush') return 'rush';
+  if (agent === 'droid') return 'droid';
   return null;
 }
 

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -698,7 +698,11 @@ export KIMI_CODE_HOME="$HOME/.agents/.history/versions/${agent}/${version}/home/
 # ${VERSIONED_ALIAS_VERSION_MARKER} ${VERSIONED_ALIAS_SCHEMA_VERSION}
 # Direct alias for ${agentConfig.name}@${version}
 
-BINARY="$HOME/.agents/.history/versions/${agent}/${version}/node_modules/.bin/${agentConfig.cliCommand}"
+BINARY="${
+    agent === 'droid'
+      ? '$HOME/.local/bin/droid'
+      : `$HOME/.agents/.history/versions/${agent}/${version}/node_modules/.bin/${agentConfig.cliCommand}`
+  }"
 
 if [ ! -x "$BINARY" ]; then
   echo "agents: ${agent}@${version} not installed" >&2


### PR DESCRIPTION
Follow-up to #486 (droid session discovery). I audited the codebase for other places the **droid** (Factory) harness was under-supported and fixed the confident enumeration/switch gaps. Each was found by parallel review with file:line evidence and re-verified against the real `droid` CLI (v0.161.0) installed locally.

## Fixed

| Severity | File | Gap | Fix |
|---|---|---|---|
| breaks-feature | `session/active.ts` | `AGENT_CLI_NAMES` omitted droid → a running `droid`/`droid exec` process was invisible to `agents sessions --active` | add `droid: 'droid'` |
| breaks-feature | `session/cloud.ts` | `agentToFormat` returned `null` for droid → Factory cloud runs silently dropped from cloud session discovery | map `'droid' → 'droid'` |
| breaks-feature | `shims.ts` | versioned alias `droid@<version>` pointed at a nonexistent `node_modules/.bin/droid` and errored "not installed" | resolve `~/.local/bin/droid` (mirrors the main shim's droid branch) |
| degraded | `agents.ts` | `getSessionDir`/`getSessionExtension` omitted droid → `resolveLastActive` always null | wire `~/.factory/sessions` + `.jsonl` |
| degraded | `agents.ts` | `UNMANAGED_DETECTION_CANDIDATES` omitted droid → `agents setup` wouldn't adopt an existing `~/.factory` install | add `droid` |
| degraded | `inspect.ts` | local `SESSION_AGENTS` set drifted from canonical `session/types.ts` (missing droid) | add `droid` |
| cosmetic | `agents.ts` | no `factory`/`factory-ai` alias → `agents inspect factory` failed | add aliases |
| cosmetic | `agents.ts` | stale comment referenced nonexistent `resolveDroidBinary()` | correct it |

## Verified
- `agents inspect factory` now resolves to droid.
- Synthetic `~/.factory/sessions/.../<uuid>.jsonl` is discovered and listed; the droid guard in `inspect` no longer short-circuits (the residual `0` count is a pre-existing, agent-agnostic inspect behavior — `inspect claude` shows 0 too — out of scope here).
- `tsc --noEmit` clean; full session + agents/shims suites pass (907 + 45).

## False positives ruled out (real-CLI check)
- **`droid mcp add` exists** (`droid mcp --help` lists `add/remove/list/permissions`) — the exec `registerMcp` path is fine, no fix needed.

## Deferred (need Factory runtime detail — not guessed, per the codebase's "don't guess the schema" rule)
- `getAccountInfo` droid case — droid's auth is **not** a readable `~/.factory` file (no `auth.v2.file`, nothing in keychain under "factory"); needs Factory-specific auth research. This is why `agents list` shows droid "not signed in".
- teams `-o stream-json` event normalizer — schema must be sampled from a real run before mapping (comment in `teams/parsers.ts` explicitly warns against guessing).
- `agents models` catalog extraction for droid — needs a droid model-list extractor, not just an enum add.