### PR TITLE
feat(sync): @all version selector + repo-scoped sync

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -47,6 +47,8 @@ import {
   hasNewResources,
   promptResourceSelection,
   promptNewResourceSelection,
+  buildRepoScopedSelection,
+  listRepoNames,
   type ResourceSelection,
   type SyncResult,
   type AvailableResources,
@@ -59,6 +61,7 @@ import { runUmbrellaSync, type UmbrellaFlags } from '../lib/sync-umbrella.js';
 interface SyncOpts {
   agent?: string;
   agentVersion?: string;
+  repo?: string;
   projectDir?: string;
   cwd?: string;
   launch?: boolean;
@@ -76,11 +79,12 @@ interface SyncOpts {
 /** Register the `agents sync` command. */
 export function registerSyncCommand(program: Command): void {
   program
-    .command('sync [agentSpec]')
+    .command('sync [agentSpec] [repo]')
     .summary('Make this machine current, or sync resources into one agent')
-    .description('With an [agentSpec], syncs resources (commands, skills, hooks, rules, MCPs, plugins, etc.) into that installed agent version — previews changes and lets you pick. e.g. "claude", "claude@2.1.142", or a selector: @latest / @oldest / @pinned (= @default).\n\nWith NO agent, runs the umbrella verb: fetch remote state (config repos + secrets + sessions) then reconcile it into every installed agent. Scope it with --repos / --secrets / --sessions, --cloud (fetch only), or --local (reconcile only).')
+    .description('With an [agentSpec], syncs resources (commands, skills, hooks, rules, MCPs, plugins, etc.) into that installed agent version — previews changes and lets you pick. e.g. "claude", "claude@2.1.142", a selector: @latest / @oldest / @pinned (= @default), or @all for every installed version.\n\nAppend a [repo] (or pass --repo) to scope the sync to a single DotAgent repo — system / user / project / <alias>. e.g. "agents sync claude@all system" reconciles only the system repo\'s resources into every installed Claude.\n\nWith NO agent, runs the umbrella verb: fetch remote state (config repos + secrets + sessions) then reconcile it into every installed agent. Scope it with --repos / --secrets / --sessions, --cloud (fetch only), or --local (reconcile only).')
     .option('--agent <agent>', 'Agent identifier (legacy form; prefer the positional spec)')
     .option('--agent-version <version>', 'Version to sync into (legacy form; prefer "agent@version")')
+    .option('--repo <name>', 'Scope the sync to a single DotAgent repo: system / user / project / <alias> (also accepted as a positional)')
     .option('--project-dir <path>', 'Path to project-level .agents/ directory containing project-scoped resources')
     .option('--cwd <path>', 'Working directory for discovering project manifest and resources')
     .option('--launch', 'Hot-path mode (shim only): skip version-home reconciliation, run project-scoped compile + workspace mirror + plugin marketplaces', false)
@@ -93,8 +97,8 @@ export function registerSyncCommand(program: Command): void {
     .option('--sessions', 'Umbrella: sync session transcripts across machines', false)
     .option('--cloud', 'Umbrella: fetch all remote state but skip the local reconcile', false)
     .option('--local', "Umbrella: reconcile resources into installed agents only (no fetch)", false)
-    .action(async (agentSpec: string | undefined, opts: SyncOpts) => {
-      await runSync(agentSpec, opts);
+    .action(async (agentSpec: string | undefined, repo: string | undefined, opts: SyncOpts) => {
+      await runSync(agentSpec, repo, opts);
     });
 }
 
@@ -152,7 +156,7 @@ async function runUmbrella(
   }
 }
 
-async function runSync(agentSpec: string | undefined, opts: SyncOpts): Promise<void> {
+async function runSync(agentSpec: string | undefined, repoArg: string | undefined, opts: SyncOpts): Promise<void> {
   const quiet = !!opts.quiet;
   const errLog = (msg: string) => { if (!quiet) console.error(msg); };
   const outLog = (msg: string) => { if (!quiet) console.log(msg); };
@@ -162,22 +166,36 @@ async function runSync(agentSpec: string | undefined, opts: SyncOpts): Promise<v
   let version: string | undefined;
 
   // A positional @selector typed by the user (latest/oldest/pinned/default/
-  // explicit). parseAgentSpec defaults a missing version to 'latest', so a bare
-  // `agents sync claude` and `agents sync claude@latest` are indistinguishable
-  // after parsing — we only treat the version as a selector when an '@' was
-  // actually typed, keeping bare `claude` on the default-version path.
+  // all/explicit). parseAgentSpec defaults a missing version to 'latest', so a
+  // bare `agents sync claude` and `agents sync claude@latest` are
+  // indistinguishable after parsing — we only treat the version as a selector
+  // when an '@' was actually typed, keeping bare `claude` on the
+  // default-version path.
   let selector: string | undefined;
 
   if (agentSpec) {
     const parsed = parseAgentSpec(agentSpec);
     if (!parsed) {
       errLog(chalk.red(`Invalid agent spec '${agentSpec}'.`));
-      errLog(chalk.gray('Examples: claude, claude@2.1.142, claude@latest, claude@oldest, claude@pinned'));
+      errLog(chalk.gray('Examples: claude, claude@2.1.142, claude@latest, claude@oldest, claude@pinned, claude@all'));
       process.exitCode = 1;
       return;
     }
     agentId = parsed.agent;
     if (agentSpec.includes('@')) selector = parsed.version;
+  }
+
+  // Repo scope: --repo flag wins over the positional. Validate against the
+  // known DotAgent repos so a typo fails loudly instead of syncing nothing.
+  const repoScope = opts.repo || repoArg;
+  if (repoScope !== undefined) {
+    const known = listRepoNames();
+    if (!known.includes(repoScope)) {
+      errLog(chalk.red(`Unknown repo '${repoScope}'.`));
+      errLog(chalk.gray(`Known repos: ${known.join(', ')}`));
+      process.exitCode = 1;
+      return;
+    }
   }
 
   if (opts.agent) {
@@ -199,6 +217,38 @@ async function runSync(agentSpec: string | undefined, opts: SyncOpts): Promise<v
     // No agent specified → the umbrella verb: make this machine current
     // (fetch repos + secrets + sessions, then reconcile all installed agents).
     await runUmbrella(opts, quiet, outLog, errLog);
+    return;
+  }
+
+  const projectDir = opts.projectDir;
+  const cwd = opts.cwd || process.cwd();
+  const force = !!opts.force;
+
+  // ---------- 2a. @all: reconcile every installed version of this agent ----------
+  // Non-interactive by design — fanning an interactive preview across N
+  // versions is unusable. Honors an optional repo scope.
+  if (selector === 'all') {
+    const installed = listInstalledVersions(agentId);
+    if (installed.length === 0) {
+      errLog(chalk.red(`No ${agentLabel(agentId)} versions installed.`));
+      errLog(chalk.gray(`Install one: agents add ${agentId}@latest`));
+      process.exitCode = 1;
+      return;
+    }
+    let selection: ResourceSelection | undefined;
+    if (repoScope) {
+      selection = buildRepoScopedSelection(repoScope, cwd);
+      if (Object.keys(selection).length === 0) {
+        outLog(chalk.gray(`Nothing from repo '${repoScope}' to sync.`));
+        return;
+      }
+    }
+    const scopeLabel = repoScope ? chalk.gray(` (repo: ${repoScope})`) : '';
+    outLog(chalk.cyan(`Syncing ${installed.length} ${agentLabel(agentId)} version(s)${scopeLabel}.`));
+    for (const v of installed) {
+      const result = syncResourcesToVersion(agentId, v, selection, { projectDir, cwd, force });
+      if (!quiet) printSyncDetail(result, agentId, v, cwd);
+    }
     return;
   }
 
@@ -244,17 +294,27 @@ async function runSync(agentSpec: string | undefined, opts: SyncOpts): Promise<v
     return;
   }
 
-  const projectDir = opts.projectDir;
-  const cwd = opts.cwd || process.cwd();
-
   // ---------- 3. --launch mode bypasses everything below ----------
   if (opts.launch) {
     runLaunchMode(agentId, version, cwd, quiet);
     return;
   }
 
+  // ---------- 3b. Repo-scoped single-version sync ----------
+  // An explicit --repo / positional repo is a targeted request, so skip the
+  // interactive preview and reconcile just that repo's resources.
+  if (repoScope) {
+    const scoped = buildRepoScopedSelection(repoScope, cwd);
+    if (Object.keys(scoped).length === 0) {
+      outLog(chalk.gray(`Nothing from repo '${repoScope}' to sync into ${agentLabel(agentId)}@${version}.`));
+      return;
+    }
+    const result = syncResourcesToVersion(agentId, version, scoped, { projectDir, cwd, force });
+    if (!quiet) printSyncDetail(result, agentId, version, cwd);
+    return;
+  }
+
   // ---------- 4. Decide selection (interactive preview vs auto) ----------
-  const force = !!opts.force;
   const yes = !!opts.yes;
   const interactive = !quiet && !yes && isInteractiveTerminal();
 

--- a/src/lib/versions.test.ts
+++ b/src/lib/versions.test.ts
@@ -482,3 +482,51 @@ describe('resolveVersionAliasLoose — @any', () => {
     expect(JSON.parse(child.stdout.trim())).toEqual({ strictAny: null, looseAny: null, strictDefault: null });
   });
 });
+
+describe('buildRepoScopedSelection — agents sync <agent> --repo <name>', () => {
+  // Scaffold a user skill and a system skill in an isolated HOME, then confirm
+  // scoping to one repo returns only that layer's resources. Guards against
+  // layer-misattribution — the bug where `--repo system` would sweep in (or
+  // drop) the wrong repo's skills.
+  function runBuildScoped(home: string, repo: string): { skills?: string[] } {
+    const moduleUrl = pathToFileURL(path.resolve('src/lib/versions.ts')).href;
+    const tsxBin = path.resolve('node_modules/tsx/dist/cli.mjs');
+    const child = spawnSync(process.execPath, [tsxBin, '-e', `
+      import { buildRepoScopedSelection } from ${JSON.stringify(moduleUrl)};
+      const home = ${JSON.stringify(home)};
+      console.log(JSON.stringify(buildRepoScopedSelection(${JSON.stringify(repo)}, home)));
+    `], { env: { ...process.env, HOME: home }, encoding: 'utf-8' });
+    expect(child.status, child.stderr).toBe(0);
+    return JSON.parse(child.stdout.trim());
+  }
+
+  function scaffoldSkills(home: string): void {
+    const userSkill = path.join(home, '.agents', 'skills', 'user-only', 'SKILL.md');
+    const systemSkill = path.join(home, '.agents', '.system', 'skills', 'system-only', 'SKILL.md');
+    fs.mkdirSync(path.dirname(userSkill), { recursive: true });
+    fs.mkdirSync(path.dirname(systemSkill), { recursive: true });
+    fs.writeFileSync(userSkill, 'user skill body', 'utf-8');
+    fs.writeFileSync(systemSkill, 'system skill body', 'utf-8');
+  }
+
+  it('scopes to the system repo — only system-layer skills, not user', () => {
+    const home = makeTempHome();
+    scaffoldSkills(home);
+    const sel = runBuildScoped(home, 'system');
+    expect(sel.skills).toEqual(['system-only']);
+  });
+
+  it('scopes to the user repo — only user-layer skills, not system', () => {
+    const home = makeTempHome();
+    scaffoldSkills(home);
+    const sel = runBuildScoped(home, 'user');
+    expect(sel.skills).toEqual(['user-only']);
+  });
+
+  it('omits the memory file — a repo-scoped sync leaves merged rules untouched', () => {
+    const home = makeTempHome();
+    scaffoldSkills(home);
+    const sel = runBuildScoped(home, 'system') as Record<string, unknown>;
+    expect(sel.memory).toBeUndefined();
+  });
+});

--- a/src/lib/versions.test.ts
+++ b/src/lib/versions.test.ts
@@ -29,7 +29,7 @@ function runVersionSync(home: string, expression: string): unknown {
   // .exe everywhere, so this is shell-free and cross-platform.
   const tsxBin = path.resolve('node_modules/tsx/dist/cli.mjs');
   const child = spawnSync(process.execPath, [tsxBin, '-e', `
-    import { listInstalledVersions, syncResourcesToVersion } from ${JSON.stringify(moduleUrl)};
+    import { listInstalledVersions, syncResourcesToVersion, buildRepoScopedSelection } from ${JSON.stringify(moduleUrl)};
     const home = ${JSON.stringify(home)};
     const result = ${expression};
     console.log(JSON.stringify(result));
@@ -488,7 +488,7 @@ describe('buildRepoScopedSelection — agents sync <agent> --repo <name>', () =>
   // scoping to one repo returns only that layer's resources. Guards against
   // layer-misattribution — the bug where `--repo system` would sweep in (or
   // drop) the wrong repo's skills.
-  function runBuildScoped(home: string, repo: string): { skills?: string[] } {
+  function runBuildScoped(home: string, repo: string): { skills?: string[]; memory?: string[] } {
     const moduleUrl = pathToFileURL(path.resolve('src/lib/versions.ts')).href;
     const tsxBin = path.resolve('node_modules/tsx/dist/cli.mjs');
     const child = spawnSync(process.execPath, [tsxBin, '-e', `
@@ -523,10 +523,31 @@ describe('buildRepoScopedSelection — agents sync <agent> --repo <name>', () =>
     expect(sel.skills).toEqual(['user-only']);
   });
 
-  it('omits the memory file — a repo-scoped sync leaves merged rules untouched', () => {
+  it('skips the memory file through a real sync — leaves merged rules untouched', () => {
     const home = makeTempHome();
-    scaffoldSkills(home);
-    const sel = runBuildScoped(home, 'system') as Record<string, unknown>;
-    expect(sel.memory).toBeUndefined();
+    // Same fixture the "writes missing grok AGENTS.md" test uses to PROVE the
+    // memory file IS written for a partial selection. Under a repo scope the
+    // memory:[] sentinel must make syncResourcesToVersion skip it entirely —
+    // so this is a real negative control, not a check of the returned object.
+    const rulesDir = path.join(home, '.agents', '.system', 'rules');
+    fs.mkdirSync(path.join(rulesDir, 'subrules'), { recursive: true });
+    fs.writeFileSync(
+      path.join(rulesDir, 'rules.yaml'),
+      'presets:\n  default:\n    subrules:\n      - core\n',
+      'utf-8'
+    );
+    fs.writeFileSync(path.join(rulesDir, 'subrules', 'core.md'), 'scoped memory body\n', 'utf-8');
+
+    // The empty-array sentinel is what the skipMemory gate keys on.
+    expect(runBuildScoped(home, 'system').memory).toEqual([]);
+
+    const result = runVersionSync(
+      home,
+      "syncResourcesToVersion('grok', '0.2.33', buildRepoScopedSelection('system', home), { cwd: home })"
+    ) as { memory: string[] };
+
+    const agentsPath = path.join(home, '.agents', '.history', 'versions', 'grok', '0.2.33', 'home', '.grok', 'AGENTS.md');
+    expect(result.memory).toEqual([]);
+    expect(fs.existsSync(agentsPath)).toBe(false);
   });
 });

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1797,6 +1797,60 @@ export function getResourceDiff(agent: AgentId, version: string): ResourceDiff {
 }
 
 /**
+ * Enumerate the DotAgent repo names that resources can be scoped to:
+ * the fixed `project` / `user` / `system` layers plus every enabled extra
+ * repo alias. Used to validate `agents sync <agent> --repo <name>`.
+ */
+export function listRepoNames(): string[] {
+  return ['project', 'user', 'system', ...getEnabledExtraRepos().map(e => e.alias)];
+}
+
+/**
+ * Build a ResourceSelection scoped to a single DotAgent repo (`system`,
+ * `user`, `project`, or an extra-repo alias). Every resource kind is filtered
+ * to the entries whose source layer matches `repo`, reusing the same
+ * name→source maps and `source:*` pattern expansion the persisted-pattern
+ * sync path uses. Passing the result as an explicit `selection` means the sync
+ * touches only that repo's resources — no orphan-sweep of the other layers.
+ *
+ * `memory` is intentionally omitted: the memory file is a merge of all layers,
+ * not a per-repo artifact, so a repo-scoped sync leaves it untouched.
+ */
+export function buildRepoScopedSelection(repo: string, cwd: string = process.cwd()): ResourceSelection {
+  const patterns = [`${repo}:*`];
+  const selection: ResourceSelection = {};
+  const available = getAvailableResources(cwd);
+
+  const listableKinds = ['commands', 'skills', 'hooks', 'subagents'] as const;
+  for (const kind of listableKinds) {
+    const sourceMap = new Map(listResources(kind, cwd).map(r => [r.name, r.source]));
+    const names = expandPatterns(patterns, sourceMap);
+    if (names.length > 0) selection[kind] = names;
+  }
+
+  // permissions: all groups originate from the system repo.
+  const permMap = new Map(available.permissions.map(n => [n, 'system' as const]));
+  const perms = expandPatterns(patterns, permMap);
+  if (perms.length > 0) selection.permissions = perms;
+
+  // mcp: preserve project vs user scope (system/alias MCPs won't match those).
+  const mcpMap = new Map(getScopedMcpResources(cwd).map(r => [r.name, r.scope]));
+  const mcp = expandPatterns(patterns, mcpMap);
+  if (mcp.length > 0) selection.mcp = mcp;
+
+  // plugins / workflows: treated as user-source (mirrors the default patterns).
+  const pluginMap = new Map(available.plugins.map(n => [n, 'user' as const]));
+  const plugins = expandPatterns(patterns, pluginMap);
+  if (plugins.length > 0) selection.plugins = plugins;
+
+  const workflowMap = new Map(available.workflows.map(n => [n, 'user' as const]));
+  const workflows = expandPatterns(patterns, workflowMap);
+  if (workflows.length > 0) selection.workflows = workflows;
+
+  return selection;
+}
+
+/**
  * Sync central resources (~/.agents/) into a specific version's config directory.
  * Copies selected resources from central storage into {versionHome}/.{agent}/.
  *

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1805,6 +1805,39 @@ export function listRepoNames(): string[] {
   return ['project', 'user', 'system', ...getEnabledExtraRepos().map(e => e.alias)];
 }
 
+/** Pattern-selectable resource kinds — every kind whose selection is
+ * driven by `source:name` patterns (memory is preset-driven, handled apart). */
+type SelectableKind = 'commands' | 'skills' | 'hooks' | 'subagents' | 'permissions' | 'mcp' | 'plugins' | 'workflows';
+
+/**
+ * Build the name→source-layer map for one resource kind, the input
+ * `expandPatterns` matches `source:*` patterns against. This is the single
+ * source of truth for how each kind attributes its source layer:
+ *   - commands/skills/hooks/subagents → real layer from `listResources`
+ *   - permissions                     → always the system repo
+ *   - mcp                             → project vs user scope preserved
+ *   - plugins/workflows               → user repo
+ * Both the persisted-pattern sync path and `buildRepoScopedSelection` use it
+ * so the attribution can't drift between the two.
+ */
+function resourceSourceMap(kind: SelectableKind, cwd: string, available: AvailableResources): Map<string, string> {
+  switch (kind) {
+    case 'commands':
+    case 'skills':
+    case 'hooks':
+    case 'subagents':
+      return new Map(listResources(kind, cwd).map(r => [r.name, r.source]));
+    case 'permissions':
+      return new Map(available.permissions.map(n => [n, 'system']));
+    case 'mcp':
+      return new Map(getScopedMcpResources(cwd).map(r => [r.name, r.scope]));
+    case 'plugins':
+      return new Map(available.plugins.map(n => [n, 'user']));
+    case 'workflows':
+      return new Map(available.workflows.map(n => [n, 'user']));
+  }
+}
+
 /**
  * Build a ResourceSelection scoped to a single DotAgent repo (`system`,
  * `user`, `project`, or an extra-repo alias). Every resource kind is filtered
@@ -1813,40 +1846,23 @@ export function listRepoNames(): string[] {
  * sync path uses. Passing the result as an explicit `selection` means the sync
  * touches only that repo's resources — no orphan-sweep of the other layers.
  *
- * `memory` is intentionally omitted: the memory file is a merge of all layers,
- * not a per-repo artifact, so a repo-scoped sync leaves it untouched.
+ * `memory` is set to `[]` (not omitted): that empty-array sentinel is what
+ * `syncResourcesToVersion`'s `skipMemory` gate keys on to leave the memory
+ * file untouched — it's a merge of all layers, not a per-repo artifact.
  */
 export function buildRepoScopedSelection(repo: string, cwd: string = process.cwd()): ResourceSelection {
   const patterns = [`${repo}:*`];
-  const selection: ResourceSelection = {};
   const available = getAvailableResources(cwd);
+  const selection: ResourceSelection = {};
 
-  const listableKinds = ['commands', 'skills', 'hooks', 'subagents'] as const;
-  for (const kind of listableKinds) {
-    const sourceMap = new Map(listResources(kind, cwd).map(r => [r.name, r.source]));
-    const names = expandPatterns(patterns, sourceMap);
+  const kinds: SelectableKind[] = ['commands', 'skills', 'hooks', 'subagents', 'permissions', 'mcp', 'plugins', 'workflows'];
+  for (const kind of kinds) {
+    const names = expandPatterns(patterns, resourceSourceMap(kind, cwd, available));
     if (names.length > 0) selection[kind] = names;
   }
 
-  // permissions: all groups originate from the system repo.
-  const permMap = new Map(available.permissions.map(n => [n, 'system' as const]));
-  const perms = expandPatterns(patterns, permMap);
-  if (perms.length > 0) selection.permissions = perms;
-
-  // mcp: preserve project vs user scope (system/alias MCPs won't match those).
-  const mcpMap = new Map(getScopedMcpResources(cwd).map(r => [r.name, r.scope]));
-  const mcp = expandPatterns(patterns, mcpMap);
-  if (mcp.length > 0) selection.mcp = mcp;
-
-  // plugins / workflows: treated as user-source (mirrors the default patterns).
-  const pluginMap = new Map(available.plugins.map(n => [n, 'user' as const]));
-  const plugins = expandPatterns(patterns, pluginMap);
-  if (plugins.length > 0) selection.plugins = plugins;
-
-  const workflowMap = new Map(available.workflows.map(n => [n, 'user' as const]));
-  const workflows = expandPatterns(patterns, workflowMap);
-  if (workflows.length > 0) selection.workflows = workflows;
-
+  // Empty-array sentinel → skip the memory writer (see skipMemory below).
+  selection.memory = [];
   return selection;
 }
 
@@ -1918,32 +1934,22 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
       for (const [type, kind] of listableTypes) {
         const patterns = vr[type];
         if (!Array.isArray(patterns) || patterns.length === 0) continue;
-        const sourceMap = new Map(listResources(kind, cwd).map(r => [r.name, r.source]));
-        patternSelection[type] = expandPatterns(patterns, sourceMap);
+        patternSelection[type] = expandPatterns(patterns, resourceSourceMap(kind, cwd, available));
       }
 
-      // permissions: all groups are 'system' source.
+      // permissions / mcp / plugins / workflows: source attribution lives in
+      // resourceSourceMap so it can't drift from buildRepoScopedSelection.
       if (Array.isArray(vr.permissions) && vr.permissions.length > 0) {
-        const permMap = new Map(available.permissions.map(n => [n, 'system' as const]));
-        patternSelection.permissions = expandPatterns(vr.permissions, permMap);
+        patternSelection.permissions = expandPatterns(vr.permissions, resourceSourceMap('permissions', cwd, available));
       }
-
-      // mcp: pattern matching must preserve project vs user scope.
       if (Array.isArray(vr.mcp) && vr.mcp.length > 0) {
-        const mcpMap = new Map(getScopedMcpResources(cwd).map(resource => [resource.name, resource.scope]));
-        patternSelection.mcp = expandPatterns(vr.mcp, mcpMap);
+        patternSelection.mcp = expandPatterns(vr.mcp, resourceSourceMap('mcp', cwd, available));
       }
-
-      // plugins: treat all as 'user' source for now.
       if (Array.isArray(vr.plugins) && vr.plugins.length > 0) {
-        const pluginMap = new Map(available.plugins.map(n => [n, 'user' as const]));
-        patternSelection.plugins = expandPatterns(vr.plugins, pluginMap);
+        patternSelection.plugins = expandPatterns(vr.plugins, resourceSourceMap('plugins', cwd, available));
       }
-
-      // workflows: treat all as 'user' source.
       if (Array.isArray(vr.workflows) && vr.workflows.length > 0) {
-        const workflowMap = new Map(available.workflows.map(n => [n, 'user' as const]));
-        patternSelection.workflows = expandPatterns(vr.workflows, workflowMap);
+        patternSelection.workflows = expandPatterns(vr.workflows, resourceSourceMap('workflows', cwd, available));
       }
 
       // memory is not pattern-controlled (rulesPreset handles it) — always sync.


### PR DESCRIPTION
## What

Makes `agents sync` invocation robust and flag-free for the common cases, extending the positional agent-spec surface added in #453.

- **`@all` version selector** — `agents sync claude@all` reconciles into *every* installed version of an agent (previously errored `claude@all is not installed`). Non-interactive by design — fanning an interactive preview across N versions is unusable.
- **Repo scoping** — a positional `[repo]` or `--repo <name>` restricts the sync to a single DotAgent repo (`system` / `user` / `project` / `<alias>`). `--repo` (singular) now exists alongside the `--repos` umbrella boolean; the flag wins over the positional; unknown names fail loudly with the known list.

Both combine, so all of these now work:

```
agents sync claude@all --repo system   # the reported failing command
agents sync claude@all system          # positional repo, no flags
agents sync claude@2.1.187 --repo user # single version, scoped
agents sync claude@all                 # every version, full sync
```

## How

`buildRepoScopedSelection()` filters each resource kind to one source layer via the existing `source:*` pattern expansion (`resource-patterns.ts`), returned as an explicit `ResourceSelection`. Passing it as a caller selection means a scoped sync touches only that layer — no orphan-sweep of the others. The memory file is intentionally omitted: it's a cross-layer merge, not a per-repo artifact, so a repo-scoped sync leaves it untouched.

## Test

- 3 new hermetic tests in `versions.test.ts` prove layer separation (system scope -> only system-layer skills; user scope -> only user-layer skills; memory omitted). 29/29 pass.
- `tsc --noEmit` clean.
- Verified end-to-end against a real dev build: `--repo system` syncs permissions (system-source) but not plugins/workflows; `--repo user` does the inverse — exact layer separation. Unknown repo -> `Unknown repo 'bogus'. Known repos: project, user, system`. `--repos` umbrella and `--local` unaffected.