### PR TITLE
feat(models): add Antigravity + Kimi to `agents models`; fix silent agent dropout

### DIFF
--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -21,7 +21,7 @@ import type { AgentId } from '../lib/types.js';
 import { listInstalledVersions, getGlobalDefault, resolveVersion, resolveVersionAlias } from '../lib/versions.js';
 import { getModelCatalog, locateModelSource } from '../lib/models.js';
 
-const MODEL_CAPABLE_AGENTS: AgentId[] = ['claude', 'codex', 'gemini', 'opencode', 'cursor', 'openclaw'];
+const MODEL_CAPABLE_AGENTS: AgentId[] = ['claude', 'codex', 'gemini', 'opencode', 'cursor', 'openclaw', 'antigravity', 'kimi'];
 
 /**
  * Agents that don't necessarily install under ~/.agents/versions (cursor ships

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -90,7 +90,13 @@ async function resolveTargets(agentSpec: string | undefined): Promise<Target[]> 
       if (!version && PATH_ONLY_AGENTS.has(agent)) {
         version = fallbackPathVersion(agent);
       }
-      if (version) targets.push({ agent, version, isDefault: true });
+      if (version) {
+        targets.push({ agent, version, isDefault: true });
+      } else {
+        // Surface the gap instead of silently dropping the agent -- an
+        // uninstalled model-capable agent should tell the user how to add it.
+        console.error(chalk.gray(`${agentLabel(agent)}: not installed (run 'agents add ${agent}@latest')`));
+      }
     }
     if (targets.length === 0) {
       console.error(chalk.yellow('No installed agent versions found. Run `agents add claude@latest` to install one.'));

--- a/src/lib/__tests__/models.test.ts
+++ b/src/lib/__tests__/models.test.ts
@@ -27,13 +27,15 @@ const claudeBinaryVer = listInstalledVersions('claude').find((v) =>
 // Prefer a version whose model source actually resolves on this host — partial
 // installs (e.g. ones missing the vendored binary) would otherwise short-circuit
 // the catalog tests with null catalogs.
-const firstLocatable = (agent: 'codex' | 'gemini' | 'opencode' | 'openclaw'): string | null =>
+const firstLocatable = (agent: 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'antigravity' | 'kimi'): string | null =>
   listInstalledVersions(agent).find((v) => locateModelSource(agent, v) !== null) ?? null;
 
 const codexVer = firstLocatable('codex');
 const geminiVer = firstLocatable('gemini');
 const opencodeVer = firstLocatable('opencode');
 const openclawVer = firstLocatable('openclaw');
+const antigravityVer = firstLocatable('antigravity');
+const kimiVer = firstLocatable('kimi');
 
 describe('locateModelSource', () => {
   it('finds the JS bundle for Claude versions that ship one', () => {
@@ -245,6 +247,48 @@ describe('getModelCatalog (openclaw)', () => {
     for (const m of catalog.models) {
       expect(m.id).toContain('/');
     }
+  });
+});
+
+describe('getModelCatalog (antigravity)', () => {
+  it('parses `agy models` display-name-only rows and flags the first as default', () => {
+    if (!antigravityVer) return;
+    const src = locateModelSource('antigravity', antigravityVer);
+    expect(src).not.toBeNull();
+    expect(src!.kind).toBe('cli');
+
+    const catalog = getModelCatalog('antigravity', antigravityVer);
+    // `agy` may be unavailable/timing out in restricted environments; skip
+    // rather than fail when the CLI produces nothing.
+    if (!catalog || catalog.models.length === 0) return;
+    // Antigravity prints display names only; those strings ARE the accepted
+    // --model values, so id === displayName and each has a parenthesized level.
+    for (const m of catalog.models) {
+      expect(m.id).toBe(m.displayName);
+      expect(m.id).toMatch(/\([^)]+\)\s*$/);
+    }
+    // Exactly one default, and it is the first row.
+    const defaults = catalog.models.filter((m) => m.isDefault);
+    expect(defaults.length).toBe(1);
+    expect(catalog.models[0].isDefault).toBe(true);
+  });
+});
+
+describe('getModelCatalog (kimi)', () => {
+  it('parses `kimi provider list --json` model keys and marks the default', () => {
+    if (!kimiVer) return;
+    const src = locateModelSource('kimi', kimiVer);
+    expect(src).not.toBeNull();
+    expect(src!.kind).toBe('cli');
+
+    const catalog = getModelCatalog('kimi', kimiVer);
+    if (!catalog || catalog.models.length === 0) return;
+    // Kimi ids are `provider/model` keys from the config JSON.
+    for (const m of catalog.models) {
+      expect(m.id).toContain('/');
+    }
+    // At most one default may be flagged (the "Default model:" line).
+    expect(catalog.models.filter((m) => m.isDefault).length).toBeLessThanOrEqual(1);
   });
 });
 

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -863,11 +863,12 @@ export function getModelCatalog(agent: AgentId, version: string): ModelCatalog |
     aliases,
   };
 
-  // Don't cache empty CLI extractions: the CLI may have been mid-install,
-  // network-dependent, or transiently failing. Caching 0 models would mask
-  // the real catalog forever (mtime won't change). Bundle/binary/js sources
-  // are deterministic, so cache those even when empty.
-  if (src.kind !== 'cli' || models.length > 0) {
+  // Never cache an empty extraction, regardless of source kind. A 0-model
+  // result is always suspect: the CLI may have been mid-install, network-
+  // dependent, or transiently failing, and a js/bundle/binary extractor that
+  // regex-misses would otherwise pin an empty catalog forever (mtime won't
+  // change until the source file does). Only persist a non-empty catalog.
+  if (models.length > 0) {
     cache.entries[key] = { sourcePath: src.path, mtime, catalog };
     saveCache();
   }

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -237,6 +237,24 @@ export function locateModelSource(
     return null;
   }
 
+  if (agent === 'antigravity') {
+    // The `agy` shim under node_modules/.bin exposes `agy models`. We don't parse
+    // any bundle; the CLI produces its own (display-name-only) catalog.
+    const cli = path.join(versionDir, 'node_modules', '.bin', 'agy');
+    if (fs.existsSync(cli)) return { path: cli, kind: 'cli' };
+    const pathBin = findOnPath('agy');
+    if (pathBin) return { path: pathBin, kind: 'cli' };
+    return null;
+  }
+
+  if (agent === 'kimi') {
+    const cli = path.join(versionDir, 'node_modules', '.bin', 'kimi');
+    if (fs.existsSync(cli)) return { path: cli, kind: 'cli' };
+    const pathBin = findOnPath('kimi');
+    if (pathBin) return { path: pathBin, kind: 'cli' };
+    return null;
+  }
+
   if (agent === 'cursor') {
     // cursor-agent is installed via curl script, not agents-cli. Version argument
     // is accepted for API symmetry but ignored -- cursor lives on PATH.
@@ -682,6 +700,114 @@ function extractOpenClawCatalog(binaryPath: string): { models: ModelInfo[]; alia
 }
 
 /**
+ * Extract Antigravity's catalog via `agy models`. Antigravity is unusual: it
+ * prints DISPLAY NAMES ONLY, one per line, with no machine ids and no --json:
+ *   Gemini 3.5 Flash (Medium)
+ *   Claude Sonnet 4.6 (Thinking)
+ * Verified (agy 1.0.11) that those display strings ARE the accepted `--model`
+ * values -- `agy --model "Claude Opus 4.6 (Thinking)"` routes to that model,
+ * and an unknown value silently falls back to the first row. So we use each
+ * display string as both id and displayName, and mark the first row default.
+ */
+function extractAntigravityCatalog(binaryPath: string): { models: ModelInfo[]; aliases: Record<string, string> } {
+  let stdout: string;
+  try {
+    stdout = execFileSync(binaryPath, ['models'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 15_000,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+  } catch {
+    return { models: [], aliases: {} };
+  }
+
+  // Strip ANSI in case a spinner or color codes slip through.
+  // eslint-disable-next-line no-control-regex
+  const plain = stdout.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+  const models: ModelInfo[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of plain.split('\n')) {
+    const name = raw.trim();
+    if (!name) continue;
+    // Guard against any stray banner/usage lines: real rows look like
+    // "<Vendor> <Model> (<Level>)". Require an alphanumeric start and a
+    // parenthesized suffix, which every observed model row has.
+    if (!/^[A-Za-z0-9].*\([^)]+\)\s*$/.test(name)) continue;
+    if (seen.has(name)) continue;
+    seen.add(name);
+    models.push({
+      id: name,
+      displayName: name,
+      // Antigravity's first listed model is its default (unknown --model values
+      // fall back to it), so flag the first row we accept.
+      isDefault: models.length === 0,
+    });
+  }
+
+  return { models, aliases: {} };
+}
+
+/**
+ * Extract Kimi's catalog via `kimi provider list --json`, which emits the raw
+ * providers/models config. Model ids are the `models` object keys (e.g.
+ * `kimi-code/kimi-for-coding`). The default is reported on a separate plain
+ * `Default model: <id>` line by `kimi provider list` (no flags), so we run that
+ * too to flag the default row.
+ */
+function extractKimiCatalog(binaryPath: string): { models: ModelInfo[]; aliases: Record<string, string> } {
+  let jsonOut: string;
+  try {
+    jsonOut = execFileSync(binaryPath, ['provider', 'list', '--json'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 15_000,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+  } catch {
+    return { models: [], aliases: {} };
+  }
+
+  const firstBrace = jsonOut.indexOf('{');
+  if (firstBrace === -1) return { models: [], aliases: {} };
+  let parsed: any;
+  try {
+    parsed = JSON.parse(jsonOut.slice(firstBrace));
+  } catch {
+    return { models: [], aliases: {} };
+  }
+
+  // Resolve the default model id from the plain listing's "Default model:" line.
+  let defaultId: string | null = null;
+  try {
+    const plain = execFileSync(binaryPath, ['provider', 'list'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 10_000,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+    const m = plain.match(/Default model:\s*(\S+)/);
+    if (m) defaultId = m[1];
+  } catch {
+    /* default flag is best-effort */
+  }
+
+  const modelsObj = parsed?.models && typeof parsed.models === 'object' ? parsed.models : {};
+  const models: ModelInfo[] = [];
+  for (const id of Object.keys(modelsObj)) {
+    const info = modelsObj[id] ?? {};
+    models.push({
+      id,
+      displayName: typeof info.displayName === 'string' ? info.displayName : undefined,
+      isDefault: defaultId != null && id === defaultId,
+    });
+  }
+
+  return { models, aliases: {} };
+}
+
+/**
  * Build (or load from cache) the model catalog for a specific (agent, version).
  * Cache is keyed on source-file mtime (binary or js module), so re-extracts
  * automatically when the user upgrades or reinstalls a version.
@@ -724,6 +850,8 @@ export function getModelCatalog(agent: AgentId, version: string): ModelCatalog |
     if (agent === 'opencode') ({ models, aliases } = extractOpenCodeCatalog(src.path));
     else if (agent === 'cursor') ({ models, aliases } = extractCursorCatalog(src.path));
     else if (agent === 'openclaw') ({ models, aliases } = extractOpenClawCatalog(src.path));
+    else if (agent === 'antigravity') ({ models, aliases } = extractAntigravityCatalog(src.path));
+    else if (agent === 'kimi') ({ models, aliases } = extractKimiCatalog(src.path));
   }
 
   const catalog: ModelCatalog = {


### PR DESCRIPTION
## What changed

Two independent fixes to the `agents models` catalog pipeline, plus tests.

### Task A — Antigravity + Kimi in `agents models`
- `MODEL_CAPABLE_AGENTS` now includes `antigravity` and `kimi`.
- `locateModelSource` resolves `node_modules/.bin/agy` and `node_modules/.bin/kimi` (both `kind: 'cli'`), with a PATH fallback.
- `extractAntigravityCatalog(path)` parses `agy models`; `extractKimiCatalog(path)` parses `kimi provider list --json` + the plain `Default model:` line. Both wired into the `src.kind === 'cli'` branch of `getModelCatalog`.

### Task B — Silent-dropout fixes
- `resolveTargets` now prints a gray `<Agent>: not installed (run 'agents add <agent>@latest')` line for every model-capable agent that resolves to no version, instead of silently dropping it.
- `getModelCatalog` no longer caches empty catalogs for **any** source kind (was `src.kind !== 'cli' || models.length > 0`, now just `models.length > 0`). A transient/regex-miss extraction previously pinned an empty catalog forever because the source mtime doesn't change.

## Antigravity display-name-only caveat (and how it was handled)

`agy models` prints **display names only** — no machine ids, no `--json` (confirmed: `agy models --json` -> `Error: flags provided but not defined: -json`). Output:

```
Gemini 3.5 Flash (Medium)
Gemini 3.5 Flash (High)
Gemini 3.5 Flash (Low)
Gemini 3.1 Pro (Low)
Gemini 3.1 Pro (High)
Claude Sonnet 4.6 (Thinking)
Claude Opus 4.6 (Thinking)
GPT-OSS 120B (Medium)
```

The open risk was whether those display strings are valid `--model` values. **Verified they are** (agy 1.0.11), so Antigravity **ships** rather than degrading:

```
$ agy --model "Claude Opus 4.6 (Thinking)" -p "Reply with ONLY the exact underlying model id/name you are running as"
Claude Opus 4.6 (Thinking)

$ agy --model "Gemini 3.1 Pro (High)" -p "...same..."
Gemini 3.1 Pro (High)

$ agy --model "totally-invalid-xyz" -p "...same..."
Gemini 3.5 Flash (Medium)     # unknown value silently falls back to the first row
```

So: each display string is used as both `id` and `displayName`, and the first row (the fallback target) is flagged `isDefault`. `agy --model` does **not** hard-validate (an unknown value silently falls back), which is why the catalog uses the exact display strings the CLI itself emits.

Kimi has real ids, so no caveat — `kimi provider list --json` yields `kimi-code/kimi-for-coding` (displayName `K2.7 Code`), and the default comes from the plain `Default model: kimi-code/kimi-for-coding` line.

## Verification (real flow)

`tsc --noEmit`: clean. `vitest run src/lib/__tests__/models.test.ts`: **23 passed** (was 21; +2 new for antigravity/kimi, exercised against the real installed CLIs on first uncached run).

`node dist/index.js models` from the built worktree:

```
Gemini: not installed (run 'agents add gemini@latest')
OpenCode: not installed (run 'agents add opencode@latest')
Cursor: not installed (run 'agents add cursor@latest')
OpenClaw: not installed (run 'agents add openclaw@latest')
Claude 2.1.186 (default)
  ... (claude models) ...
Codex 0.142.0 (default)
  ... (codex models) ...
Antigravity 1.0.11 (default)
  source: cli (~/.agents/.history/versions/antigravity/1.0.11/node_modules/.bin/agy)

  * Gemini 3.5 Flash (Medium)
    Gemini 3.5 Flash (High)
    Gemini 3.5 Flash (Low)
    Gemini 3.1 Pro (Low)
    Gemini 3.1 Pro (High)
    Claude Sonnet 4.6 (Thinking)
    Claude Opus 4.6 (Thinking)
    GPT-OSS 120B (Medium)

Kimi 0.19.2 (default)
  source: cli (~/.agents/.history/versions/kimi/0.19.2/node_modules/.bin/kimi)

  * kimi-code/kimi-for-coding (K2.7 Code)
```

Before this PR, Antigravity + Kimi did not appear at all, and Gemini/OpenCode/Cursor/OpenClaw were silently dropped (no "not installed" lines). The `*` marks the default model.

## Notes for the reviewer

- The full `vitest run` suite shows 9 pre-existing failures in `src/lib/secrets/__tests__/bundles-storage.test.ts` and `src/lib/session/sync/config.test.ts` — these are macOS-Keychain-backed tests that cannot pass on the Linux host used here; they are **unrelated to this diff** (this PR touches only `src/commands/models.ts`, `src/lib/models.ts`, `src/lib/__tests__/models.test.ts`). Confirm whether those two suites are expected to pass in your CI matrix.
- Antigravity ids are human display strings with spaces/parens. If any downstream consumer of `ModelInfo.id` assumes a slug-shaped id (no spaces), it should be checked — but `agy --model` is the only consumer and it accepts these strings verbatim.
