### PR TITLE
feat(sessions): live state engine — waiting/PR/worktree/ticket + reliable preview

### DIFF
--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -20,6 +20,8 @@ import { SESSION_AGENTS } from '../lib/session/types.js';
 import { discoverArtifacts, readArtifact, resolveArtifact } from '../lib/session/artifacts.js';
 import { looksLikePath, toComparablePath, homeDir } from '../lib/platform/index.js';
 import { getActiveSessions, type ActiveSession } from '../lib/session/active.js';
+import { stringWidth, truncateToWidth, padToWidth, terminalWidth } from '../lib/session/width.js';
+import type { SessionActivity, AwaitingReason } from '../lib/session/state.js';
 import { discoverSessions, countSessionsInScope, resolveSessionById, searchContentIndex, parseTimeFilter, type DiscoverOptions, type ScanProgress } from '../lib/session/discover.js';
 import { filterTeamSessions } from '../lib/session/team-filter.js';
 import { parseSession } from '../lib/session/parse.js';
@@ -62,6 +64,10 @@ interface SessionsOptions extends SessionFilterOptions {
   active?: boolean;
   cloud?: boolean;
   host?: string[];
+  /** Group the listing by directory and drop the id/version columns. */
+  tree?: boolean;
+  /** With --active: show only sessions waiting on user input; exit 1 if any. */
+  waiting?: boolean;
 }
 
 interface ClaudeHistoryEntry {
@@ -235,42 +241,68 @@ function formatStartedAt(startedAtMs?: number): string {
   return formatRelativeTime(new Date(startedAtMs).toISOString());
 }
 
-/** Build a display-friendly description for an active session (label or topic). */
+/**
+ * Build the live description for an active session: prefer the state engine's
+ * preview (the latest turn), then a user label, then the first-prompt topic.
+ */
 function buildSessionDescription(s: ActiveSession): string {
   if (s.context === 'cloud') {
-    return `${s.cloudProvider ?? ''}${s.cloudTaskId ? ` · ${s.cloudTaskId.slice(0, 12)}` : ''}`;
+    return s.preview || `${s.cloudProvider ?? ''}${s.cloudTaskId ? ` · ${s.cloudTaskId.slice(0, 12)}` : ''}`;
   }
   if (s.context === 'teams') {
     const parts = [s.teamName];
-    if (s.label) parts.push(s.label);
+    if (s.preview) parts.push(s.preview);
+    else if (s.label) parts.push(s.label);
     else if (s.topic) parts.push(s.topic);
     return parts.filter(Boolean).join(' · ');
   }
-  // Terminal or headless: prefer label, then topic
-  if (s.label) return s.label;
-  if (s.topic) return s.topic;
-  return '';
+  // Terminal or headless: prefer the live preview, then label, then topic.
+  return s.preview || s.label || s.topic || '';
+}
+
+/** Short human word for a session's activity (falls back to the coarse status). */
+function activityLabel(s: ActiveSession): string {
+  if (s.activity === 'waiting_input') return 'waiting';
+  if (s.activity === 'working') return 'working';
+  if (s.activity === 'idle') return 'idle';
+  return s.status === 'input_required' ? 'waiting' : s.status;
+}
+
+/**
+ * Compact, colour-coded badges for the durable/awaiting signals. Text-only (no
+ * emoji, per repo convention): `plan` / `ask` / `perm` for why it's waiting,
+ * `PR#N`, `wt:slug`, `TICKET-123`.
+ */
+function signalBadges(s: Pick<ActiveSession, 'awaitingReason' | 'pr' | 'worktree' | 'ticket'>): string {
+  const parts: string[] = [];
+  if (s.awaitingReason === 'plan_review') parts.push(chalk.yellow('plan'));
+  else if (s.awaitingReason === 'question') parts.push(chalk.yellow('ask'));
+  else if (s.awaitingReason === 'permission') parts.push(chalk.yellow('perm'));
+  if (s.ticket) parts.push(chalk.cyan(s.ticket.id));
+  if (s.pr) parts.push(chalk.blue(`PR#${s.pr.number ?? '?'}`));
+  if (s.worktree) parts.push(chalk.magenta(`wt:${s.worktree.slug}`));
+  return parts.join(' ');
 }
 
 /**
  * Render a single agent-session row inside an already-printed group header.
  * Indent is the leading whitespace (2 spaces for flat groups, 4 inside a
- * window sub-group).
+ * window sub-group). Leads with the 8-char session id (the address to read or
+ * resume it); status, badges, and the live preview fill the rest, sized to the
+ * terminal width so the row never wraps.
  */
 function printActiveRow(s: ActiveSession, indent: string): void {
-  const kindCol = colorAgent(s.kind as any)(padRight(truncate(s.kind, 8), 9));
-  const hostCol = chalk.gray(padRight(truncate(s.host ?? '-', 8), 9));
-  const statusCol = statusColor(s.status)(padRight(truncate(s.status, 7), 8));
-  const pidCol = chalk.yellow(padRight(s.pid ? String(s.pid) : '-', 7));
-  const desc = buildSessionDescription(s);
-  console.log(
-    indent +
-    pidCol +
-    kindCol +
-    hostCol +
-    statusCol +
-    chalk.white(truncate(desc || '-', 50))
-  );
+  const idCol = chalk.dim(padToWidth((s.sessionId?.slice(0, 8)) ?? '-', 9));
+  const kindCol = colorAgent(s.kind as any)(padToWidth(truncateToWidth(s.kind, 8), 9));
+  const hostCol = chalk.gray(padToWidth(truncateToWidth(s.host ?? '-', 8), 9));
+  const statusCol = statusColor(s.status)(padToWidth(truncateToWidth(activityLabel(s), 8), 9));
+  const badges = signalBadges(s);
+  const desc = buildSessionDescription(s) || '-';
+  // Fill the remaining width with the preview so nothing wraps under tmux/SSH.
+  const fixed = stringWidth(indent) + 9 + 9 + 9 + 9 + (badges ? stringWidth(badges) + 1 : 0);
+  const room = Math.max(12, terminalWidth() - fixed - 1);
+  const descCol = chalk.white(truncateToWidth(desc, room));
+  console.log(indent + idCol + kindCol + hostCol + statusCol + (badges ? badges + ' ' : '') + descCol);
 }
 
 /**
@@ -352,16 +384,22 @@ export function groupActiveSessions(sessions: ActiveSession[]): ActiveSessionsLa
 }
 
 /** Render the unified active-session view. */
-async function renderActiveSessions(asJson: boolean): Promise<void> {
-  const sessions = await getActiveSessions();
+async function renderActiveSessions(asJson: boolean, waitingOnly = false): Promise<void> {
+  const all = await getActiveSessions();
+  // --waiting: only sessions blocked on the user. Exits non-zero when any are
+  // present so a supervising agent or hook can poll it as a gate.
+  const sessions = waitingOnly
+    ? all.filter(s => s.status === 'input_required')
+    : all;
 
   if (asJson) {
     process.stdout.write(JSON.stringify(sessions, null, 2) + '\n');
+    if (waitingOnly && sessions.length > 0) process.exitCode = 1;
     return;
   }
 
   if (sessions.length === 0) {
-    console.log(chalk.gray('No active agent sessions.'));
+    console.log(chalk.gray(waitingOnly ? 'No sessions waiting on input.' : 'No active agent sessions.'));
     return;
   }
 
@@ -401,6 +439,9 @@ async function renderActiveSessions(asJson: boolean): Promise<void> {
   if (idleCount > 0) parts.push(`${idleCount} idle`);
   if (queuedCount > 0) parts.push(`${queuedCount} queued`);
   console.log(chalk.gray(`\n${sessions.length} active (${parts.join(', ')}).`));
+
+  // Scriptable gate: a non-zero exit when anything is waiting on the user.
+  if (waitingOnly && sessions.length > 0) process.exitCode = 1;
 }
 
 /** Main action handler for `agents sessions`. Routes to picker, table, or single-session render. */
@@ -416,7 +457,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
   }
 
   if (options.active) {
-    await renderActiveSessions(options.json === true);
+    await renderActiveSessions(options.json === true, options.waiting === true);
     return;
   }
 
@@ -562,7 +603,9 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
       return;
     }
 
-    if (isInteractiveTerminal()) {
+    // --tree is a printed grouped listing, not an interactive pick — render it
+    // directly even in a TTY.
+    if (isInteractiveTerminal() && !options.tree) {
       const message = pathFilter
         ? `Search sessions (${path.basename(pathFilter)}):`
         : formatSearchMessage(options);
@@ -576,7 +619,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
 
     // Non-interactive fallback (piped output)
     const filtered = searchQuery ? filterSessionsByQuery(sessions, searchQuery) : sessions;
-    printSessionTable(filtered, hiddenCount);
+    printSessionTable(filtered, hiddenCount, options.tree === true);
   } catch (err: any) {
     tracker.stop();
     spinner?.stop();
@@ -596,25 +639,89 @@ function teamTag(session: SessionMeta): string {
   return parts ? `[${parts}] ` : '[team] ';
 }
 
-function printSessionTable(sessions: SessionMeta[], hiddenCount = 0): void {
-  for (const session of sessions) {
-    const agentColor = colorAgent(session.agent);
-    const when = formatRelativeTime(session.timestamp);
-    const project = session.project || '-';
-    const tag = teamTag(session);
-    const label = (session as any).label;
-    const topic = tag ? `${tag}${session.topic ?? ''}` : session.topic;
-    const versionStr = session.version || '-';
+/** Adapt a SessionMeta's persisted signals to the badge renderer's shape. */
+function metaSignals(s: SessionMeta): Parameters<typeof signalBadges>[0] {
+  return {
+    pr: s.prUrl ? { url: s.prUrl, number: s.prNumber } : undefined,
+    worktree: s.worktreeSlug ? { path: s.cwd ?? '', slug: s.worktreeSlug } : undefined,
+    ticket: s.ticketId ? { id: s.ticketId } : undefined,
+  };
+}
 
-    console.log(
-      chalk.white(padRight(session.shortId, 10)) +
-      agentColor(padRight(truncate(session.agent, 8), 9)) +
-      chalk.yellow(padRight(truncate(versionStr, 7), 8)) +
-      chalk.cyan(padRight(truncate(project, 14), 16)) +
-      renderTopicCell(label, topic, '', 48, 50) +
-      chalk.gray(when)
-    );
+/** One flat table row: shortId · agent · version · project · topic(+badges) · time. */
+function flatSessionRow(session: SessionMeta): string {
+  const agentColor = colorAgent(session.agent);
+  const when = formatRelativeTime(session.timestamp);
+  const project = session.project || '-';
+  const tag = teamTag(session);
+  const label = (session as any).label;
+  const topic = tag ? `${tag}${session.topic ?? ''}` : session.topic;
+  const versionStr = session.version || '-';
+  const badges = signalBadges(metaSignals(session));
+  const badgeW = badges ? stringWidth(badges) + 1 : 0;
+  const topicW = Math.max(16, terminalWidth() - (10 + 9 + 8 + 16) - badgeW - stringWidth(when) - 1);
+
+  return (
+    chalk.white(padToWidth(truncateToWidth(session.shortId, 9), 10)) +
+    agentColor(padToWidth(truncateToWidth(session.agent, 8), 9)) +
+    chalk.yellow(padToWidth(truncateToWidth(versionStr, 7), 8)) +
+    chalk.cyan(padToWidth(truncateToWidth(project, 14), 16)) +
+    renderTopicCell(label, topic, '', topicW, topicW) +
+    (badges ? badges + ' ' : '') +
+    chalk.gray(when)
+  );
+}
+
+/** One tree-mode row (grouped under a dir header): id · agent · badges · topic · time. No version/project column. */
+function treeSessionRow(session: SessionMeta): string {
+  const agentColor = colorAgent(session.agent);
+  const when = formatRelativeTime(session.timestamp);
+  const tag = teamTag(session);
+  const label = (session as any).label;
+  const topic = (tag ? `${tag}${session.topic ?? ''}` : session.topic) || '-';
+  const badges = signalBadges(metaSignals(session));
+  const badgeW = badges ? stringWidth(badges) + 1 : 0;
+  const head = label ? `${label} · ${topic}` : topic;
+  const topicW = Math.max(12, terminalWidth() - (2 + 9 + 8) - badgeW - stringWidth(when) - 1);
+
+  return (
+    '  ' +
+    chalk.dim(padToWidth(session.shortId, 9)) +
+    agentColor(padToWidth(truncateToWidth(session.agent, 7), 8)) +
+    (badges ? badges + ' ' : '') +
+    padToWidth(chalk.white(truncateToWidth(head, topicW)), topicW) +
+    ' ' + chalk.gray(when)
+  );
+}
+
+function printSessionTable(sessions: SessionMeta[], hiddenCount = 0, tree = false): void {
+  if (tree) {
+    // Group by directory; drop the id/version columns from view. The short id
+    // stays as each row's leading handle (the address to read/resume it).
+    const byDir = new Map<string, SessionMeta[]>();
+    for (const s of sessions) {
+      const key = s.cwd || s.project || 'unknown';
+      (byDir.get(key) ?? byDir.set(key, []).get(key)!).push(s);
+    }
+    const keys = [...byDir.keys()].sort((a, b) => {
+      const d = byDir.get(b)!.length - byDir.get(a)!.length;
+      return d !== 0 ? d : a.localeCompare(b);
+    });
+    let first = true;
+    for (const key of keys) {
+      if (!first) console.log();
+      first = false;
+      const group = byDir.get(key)!;
+      console.log(`${chalk.cyan.bold(shortCwd(key))} ${chalk.gray(`(${group.length})`)}`);
+      for (const s of group) console.log(treeSessionRow(s));
+    }
+    const dirWord = keys.length === 1 ? 'directory' : 'directories';
+    console.log(chalk.gray(`\n${sessions.length} session${sessions.length === 1 ? '' : 's'} across ${keys.length} ${dirWord}.`));
+    if (hiddenCount > 0) console.log(chalk.gray(formatTeamHiddenFooter(hiddenCount)));
+    return;
   }
+
+  for (const session of sessions) console.log(flatSessionRow(session));
 
   const countLine = `${sessions.length} session${sessions.length === 1 ? '' : 's'}.`;
   console.log(chalk.gray(`\n${countLine}`));
@@ -738,8 +845,10 @@ function renderTopicCell(
   const tpc = (topic ?? '').trim();
   const sep = ' · ';
   const raw = lbl && tpc ? `${lbl}${sep}${tpc}` : (lbl || tpc);
-  const visible = truncate(raw, visibleWidth);
-  const padding = ' '.repeat(Math.max(0, paddedWidth - visible.length));
+  // Width-aware: measure/truncate/pad by display cells, not String.length, so
+  // ANSI escapes and wide (CJK/emoji) glyphs don't drift the column.
+  const visible = truncateToWidth(raw, visibleWidth);
+  const padding = ' '.repeat(Math.max(0, paddedWidth - stringWidth(visible)));
   const labelEnd = lbl ? Math.min(lbl.length, visible.length) : 0;
 
   let matchStart = -1, matchEnd = -1;
@@ -1302,6 +1411,8 @@ export function registerSessionsCommands(program: Command): void {
     .option('--artifacts', 'List all files written or edited during a session')
     .option('--artifact <name>', 'Read a specific artifact by filename or path (outputs to stdout)')
     .option('--active', 'Show only sessions running right now across terminals, teams, cloud, and headless agents')
+    .option('--waiting', 'With --active: show only sessions waiting on your input (exits non-zero if any)')
+    .option('--tree', 'Group the listing by directory; drops the id/version columns for readability')
     .option('--cloud', 'Source sessions from Rush Cloud (captured runs) instead of local disk')
     .option('-H, --host <target...>', 'Run this query on remote machine(s) over SSH (host alias or user@host; repeatable)');
 

--- a/src/lib/session/__tests__/db.test.ts
+++ b/src/lib/session/__tests__/db.test.ts
@@ -137,10 +137,19 @@ describe('migration v5 -> v6 adds cost/duration columns', () => {
     expect(cols).toContain('duration_ms');
   });
 
-  it('schema_version is recorded as 6', () => {
+  it('schema_version is recorded as the current version', () => {
     const db = getDB();
     const row = db.prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string };
-    expect(row.value).toBe('6');
+    expect(row.value).toBe('7');
+  });
+
+  it('v7 adds the session-state columns (pr_url, worktree_slug, ticket_id)', () => {
+    const db = getDB();
+    const cols = (db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>).map(c => c.name);
+    expect(cols).toContain('pr_url');
+    expect(cols).toContain('pr_number');
+    expect(cols).toContain('worktree_slug');
+    expect(cols).toContain('ticket_id');
   });
 });
 

--- a/src/lib/session/active.ts
+++ b/src/lib/session/active.ts
@@ -25,7 +25,10 @@ import { listActiveTasks } from '../cloud/store.js';
 import { AgentManager } from '../teams/agents.js';
 import { getTerminalsDir } from '../state.js';
 import { buildClaudeLabelMap } from './discover.js';
+import { latestSessionFileForCwd } from './db.js';
 import { extractSessionTopic } from './prompt.js';
+import { readSessionTail } from './tail.js';
+import { inferSessionState, type SessionState, type SessionActivity, type AwaitingReason, type DetectedPr, type DetectedWorktree, type DetectedTicket } from './state.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -45,6 +48,18 @@ export interface ActiveSession {
   label?: string;
   /** First meaningful line of the initial prompt (extracted topic). */
   topic?: string;
+  /** Live preview: the latest turn (agent message or tool action), from the state engine. */
+  preview?: string;
+  /** Inferred activity: working / waiting_input / idle (from the transcript tail). */
+  activity?: SessionActivity;
+  /** Why the agent is waiting, when activity is waiting_input. */
+  awaitingReason?: AwaitingReason;
+  /** PR opened during the session. */
+  pr?: DetectedPr;
+  /** Worktree the session runs in. */
+  worktree?: DetectedWorktree;
+  /** Tracker ticket the session is tied to. */
+  ticket?: DetectedTicket;
   sessionFile?: string;
   startedAtMs?: number;
   status: ActiveStatus;
@@ -182,6 +197,61 @@ function classifyActivity(sessionFile: string | undefined): 'running' | 'idle' {
 }
 
 /**
+ * Locate the live transcript for an agent process. Claude files are keyed by
+ * cwd (+ optional session uuid); Codex files are date-partitioned, so we resolve
+ * the newest indexed Codex session for the cwd instead.
+ */
+function findSessionFileForKind(kind: string, cwd?: string, sessionId?: string): string | undefined {
+  if (!cwd) return undefined;
+  if (kind === 'claude') return findClaudeSessionFile(cwd, sessionId);
+  if (kind === 'codex') return latestSessionFileForCwd('codex', cwd);
+  return undefined;
+}
+
+/** Recover the session UUID from a transcript filename (Claude `<uuid>.jsonl`, Codex `rollout-…-<uuid>.jsonl`). */
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+function sessionIdFromFile(file?: string): string | undefined {
+  if (!file) return undefined;
+  return path.basename(file).match(UUID_RE)?.[0];
+}
+
+/** Infer live state from a session file's tail (Claude/Codex). Undefined when unreadable. */
+function computeLiveState(kind: string, sessionFile: string | undefined, cwd: string | undefined, pidAlive: boolean): SessionState | undefined {
+  if (!sessionFile) return undefined;
+  const agent = kind === 'codex' ? 'codex' : 'claude';
+  const events = readSessionTail(sessionFile, agent);
+  if (events.length === 0) return undefined;
+  let mtimeMs: number | undefined;
+  try { mtimeMs = fs.statSync(sessionFile).mtimeMs; } catch { /* vanished between calls */ }
+  return inferSessionState(events, { cwd, pidAlive, mtimeMs, activeWindowMs: ACTIVE_MTIME_WINDOW_MS });
+}
+
+/** Map inferred activity onto the coarse ActiveStatus used by the renderer and counts. */
+function statusFromActivity(activity: SessionActivity): ActiveStatus {
+  return activity === 'working' ? 'running' : activity === 'waiting_input' ? 'input_required' : 'idle';
+}
+
+/**
+ * Fold a computed SessionState onto an active-session row: rich status +
+ * preview + PR/worktree/ticket badges. With no state (unreadable/non-Claude/
+ * Codex file) it degrades to the mtime-only classification.
+ */
+function applyState(base: Omit<ActiveSession, 'status'>, state: SessionState | undefined, fallbackFile: string | undefined): ActiveSession {
+  if (!state) return { ...base, status: classifyActivity(fallbackFile) };
+  return {
+    ...base,
+    status: statusFromActivity(state.activity),
+    activity: state.activity,
+    awaitingReason: state.awaitingReason,
+    // Prefer the live preview (latest turn); keep the first-prompt topic as a fallback.
+    preview: state.preview ?? base.preview,
+    pr: state.pr,
+    worktree: state.worktree,
+    ticket: state.ticket,
+  };
+}
+
+/**
  * Extract the first user message's content from a Claude JSONL file.
  * Reads only the first ~50 lines for speed, since the user message is
  * typically near the top (after system/queue events).
@@ -260,25 +330,22 @@ export async function listTeamsActive(): Promise<ActiveSession[]> {
   const running = await mgr.listRunning();
   return running.map((a): ActiveSession => {
     const sessionId = a.parentSessionId ?? a.remoteSessionId ?? undefined;
-    const sessionFile =
-      a.agentType === 'claude' && a.cwd
-        ? findClaudeSessionFile(a.cwd, sessionId ?? undefined)
-        : undefined;
+    const sessionFile = findSessionFileForKind(a.agentType, a.cwd ?? undefined, sessionId ?? undefined);
     const topic = sessionFile ? quickExtractTopic(sessionFile) : undefined;
-    return {
+    const state = computeLiveState(a.agentType, sessionFile, a.cwd ?? undefined, a.pid ? isPidAlive(a.pid) : true);
+    return applyState({
       context: 'teams',
       kind: a.agentType,
       pid: a.pid ?? undefined,
-      sessionId,
+      sessionId: sessionId ?? sessionIdFromFile(sessionFile),
       cwd: a.cwd ?? undefined,
       label: a.name ?? undefined,
       topic,
       sessionFile,
       startedAtMs: a.startedAt.getTime(),
-      status: classifyActivity(sessionFile),
       teamName: a.taskName,
       agentId: a.agentId,
-    };
+    }, state, sessionFile);
   });
 }
 
@@ -296,28 +363,25 @@ export async function listTerminalsActive(): Promise<ActiveSession[]> {
   const labelMap = buildClaudeLabelMap();
 
   return entries.map((t): ActiveSession => {
-    const sessionFile =
-      t.kind === 'claude' && t.cwd
-        ? findClaudeSessionFile(t.cwd, t.sessionId)
-        : undefined;
+    const sessionFile = findSessionFileForKind(t.kind, t.cwd ?? undefined, t.sessionId);
     // Prefer label from live terminal, fall back to Claude's session label
     const label = t.label ?? (t.sessionId ? labelMap.get(t.sessionId) : undefined) ?? undefined;
     // Extract topic from session file (first meaningful user message)
     const topic = sessionFile ? quickExtractTopic(sessionFile) : undefined;
-    return {
+    const state = computeLiveState(t.kind, sessionFile, t.cwd ?? undefined, isPidAlive(t.pid));
+    return applyState({
       context: 'terminal',
       kind: t.kind,
       host: detectHost(t.pid, procByPid),
       pid: t.pid,
-      sessionId: t.sessionId,
+      sessionId: t.sessionId ?? sessionIdFromFile(sessionFile),
       cwd: t.cwd ?? undefined,
       label,
       topic,
       sessionFile,
       startedAtMs: t.startedAtMs,
-      status: classifyActivity(sessionFile),
       windowId: t.windowId,
-    };
+    }, state, sessionFile);
   });
 }
 
@@ -498,20 +562,21 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
   for (let i = 0; i < candidates.length; i++) {
     const { pid, kind } = candidates[i];
     const cwd = cwds[i];
-    const sessionFile = kind === 'claude' && cwd ? findClaudeSessionFile(cwd) : undefined;
+    const sessionFile = findSessionFileForKind(kind, cwd);
     const topic = sessionFile ? quickExtractTopic(sessionFile) : undefined;
     const host = detectHost(pid, procByPid);
     const context: ActiveContext = host && UI_HOSTS.has(host) ? 'terminal' : 'headless';
-    out.push({
+    const state = computeLiveState(kind, sessionFile, cwd, true);
+    out.push(applyState({
       context,
       kind,
       host,
       pid,
       cwd,
+      sessionId: sessionIdFromFile(sessionFile),
       topic,
       sessionFile,
-      status: classifyActivity(sessionFile),
-    });
+    }, state, sessionFile));
   }
   return out;
 }

--- a/src/lib/session/db.ts
+++ b/src/lib/session/db.ts
@@ -17,7 +17,7 @@ const SESSIONS_DIR = getSessionsDir();
 const DB_PATH = getSessionsDbPath();
 
 /** Current schema version; bumped when migrations are added. */
-const SCHEMA_VERSION = 6;
+const SCHEMA_VERSION = 7;
 
 /**
  * Canonicalize a file path for use as a scan_ledger key. The same physical
@@ -64,7 +64,11 @@ CREATE TABLE IF NOT EXISTS sessions (
   file_mtime_ms INTEGER,
   file_size INTEGER,
   scanned_at INTEGER,
-  is_team_origin INTEGER DEFAULT 0
+  is_team_origin INTEGER DEFAULT 0,
+  pr_url TEXT,
+  pr_number INTEGER,
+  worktree_slug TEXT,
+  ticket_id TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_timestamp ON sessions(timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_cwd ON sessions(cwd);
@@ -120,6 +124,10 @@ export interface SessionRow {
   file_size: number | null;
   scanned_at: number | null;
   is_team_origin: number;
+  pr_url: string | null;
+  pr_number: number | null;
+  worktree_slug: string | null;
+  ticket_id: string | null;
 }
 
 /** File stat snapshot used to detect changes between scan runs. */
@@ -221,6 +229,17 @@ function migrateSchema(db: Database.Database, fromVersion: number): void {
     if (!cols.some(c => c.name === 'duration_ms')) {
       db.exec(`ALTER TABLE sessions ADD COLUMN duration_ms INTEGER`);
     }
+    db.exec(`DELETE FROM scan_ledger;`);
+  }
+  if (fromVersion < 7) {
+    // v6 → v7: the session-state engine now persists durable signals (PR opened,
+    // worktree, tracker ticket) at scan time. Add the columns and force a full
+    // rescan so every existing session gets them populated.
+    const cols = db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>;
+    if (!cols.some(c => c.name === 'pr_url')) db.exec(`ALTER TABLE sessions ADD COLUMN pr_url TEXT`);
+    if (!cols.some(c => c.name === 'pr_number')) db.exec(`ALTER TABLE sessions ADD COLUMN pr_number INTEGER`);
+    if (!cols.some(c => c.name === 'worktree_slug')) db.exec(`ALTER TABLE sessions ADD COLUMN worktree_slug TEXT`);
+    if (!cols.some(c => c.name === 'ticket_id')) db.exec(`ALTER TABLE sessions ADD COLUMN ticket_id TEXT`);
     db.exec(`DELETE FROM scan_ledger;`);
   }
 }
@@ -444,12 +463,14 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     id, short_id, agent, version, account, timestamp,
     project, cwd, git_branch, topic, label, message_count, token_count,
     cost_usd, duration_ms,
-    file_path, file_mtime_ms, file_size, scanned_at, is_team_origin
+    file_path, file_mtime_ms, file_size, scanned_at, is_team_origin,
+    pr_url, pr_number, worktree_slug, ticket_id
   ) VALUES (
     @id, @short_id, @agent, @version, @account, @timestamp,
     @project, @cwd, @git_branch, @topic, @label, @message_count, @token_count,
     @cost_usd, @duration_ms,
-    @file_path, @file_mtime_ms, @file_size, @scanned_at, @is_team_origin
+    @file_path, @file_mtime_ms, @file_size, @scanned_at, @is_team_origin,
+    @pr_url, @pr_number, @worktree_slug, @ticket_id
   )
   ON CONFLICT(id) DO UPDATE SET
     short_id = excluded.short_id,
@@ -470,7 +491,11 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     file_mtime_ms = excluded.file_mtime_ms,
     file_size = excluded.file_size,
     scanned_at = excluded.scanned_at,
-    is_team_origin = excluded.is_team_origin
+    is_team_origin = excluded.is_team_origin,
+    pr_url = excluded.pr_url,
+    pr_number = excluded.pr_number,
+    worktree_slug = excluded.worktree_slug,
+    ticket_id = excluded.ticket_id
 `);
 
 const deleteTextStmt = (db: Database.Database) =>
@@ -523,6 +548,10 @@ export function upsertSession(meta: SessionMeta, content: string, scan?: ScanSta
     file_size: scan?.fileSize ?? null,
     scanned_at: Date.now(),
     is_team_origin: meta.isTeamOrigin ? 1 : 0,
+    pr_url: meta.prUrl ?? null,
+    pr_number: meta.prNumber ?? null,
+    worktree_slug: meta.worktreeSlug ?? null,
+    ticket_id: meta.ticketId ?? null,
   };
 
   const txn = db.transaction(() => {
@@ -611,6 +640,10 @@ export function upsertSessionsBatch(
         file_size: scan?.fileSize ?? null,
         scanned_at: now,
         is_team_origin: meta.isTeamOrigin ? 1 : 0,
+        pr_url: meta.prUrl ?? null,
+        pr_number: meta.prNumber ?? null,
+        worktree_slug: meta.worktreeSlug ?? null,
+        ticket_id: meta.ticketId ?? null,
       });
       delText.run(meta.id);
       insText.run(
@@ -732,7 +765,28 @@ function rowToMeta(row: SessionRow): SessionMeta {
     topic: row.topic ?? undefined,
     label: row.label ?? undefined,
     isTeamOrigin: row.is_team_origin === 1,
+    prUrl: row.pr_url ?? undefined,
+    prNumber: row.pr_number ?? undefined,
+    worktreeSlug: row.worktree_slug ?? undefined,
+    ticketId: row.ticket_id ?? undefined,
   };
+}
+
+/**
+ * Newest indexed session file for an agent working in `cwd`. Lets the live
+ * `--active` scanner locate a Codex transcript (whose files are date-partitioned,
+ * not cwd-keyed like Claude's) by reusing the index. Returns undefined if the
+ * session hasn't been scanned yet — the caller degrades to no live state.
+ */
+export function latestSessionFileForCwd(agent: SessionAgentId, cwd: string): string | undefined {
+  if (!cwd) return undefined;
+  let normalized = cwd;
+  try { normalized = fs.realpathSync(cwd); } catch { /* use as-is */ }
+  const db = getDB();
+  const row = db
+    .prepare(`SELECT file_path FROM sessions WHERE agent = ? AND cwd = ? ORDER BY timestamp DESC LIMIT 1`)
+    .get(agent, normalized) as { file_path: string } | undefined;
+  return row?.file_path;
 }
 
 /** Build a parameterized WHERE clause from query options. */

--- a/src/lib/session/discover.ts
+++ b/src/lib/session/discover.ts
@@ -24,6 +24,7 @@ import { walkForFiles } from '../fs-walk.js';
 import { getConfigSymlinkVersion } from '../shims.js';
 import { SESSION_AGENTS } from './types.js';
 import { extractSessionTopic } from './prompt.js';
+import { extractPrUrl, detectWorktree, detectTicket, isPrCreateCommand } from './state.js';
 import { costOfUsage } from '../pricing/index.js';
 import {
   getDB,
@@ -110,6 +111,11 @@ interface ClaudeSessionScan {
   entrypoint?: string;
   /** Concatenated user message text, ready to hand to FTS5. */
   contentText?: string;
+  /** Durable state signals persisted to the index by the session-state engine. */
+  prUrl?: string;
+  prNumber?: number;
+  worktreeSlug?: string;
+  ticketId?: string;
 }
 
 /** Lightweight metadata extracted from a Codex JSONL file during incremental scan. */
@@ -125,6 +131,10 @@ interface CodexSessionScan {
   costUsd?: number;
   durationMs?: number;
   contentText?: string;
+  prUrl?: string;
+  prNumber?: number;
+  worktreeSlug?: string;
+  ticketId?: string;
 }
 
 const cachedAgentVersions = new Map<SessionAgentId, Promise<string | undefined>>();
@@ -565,6 +575,10 @@ async function readClaudeMeta(
       costUsd: scan.costUsd,
       durationMs: scan.durationMs,
       isTeamOrigin,
+      prUrl: scan.prUrl,
+      prNumber: scan.prNumber,
+      worktreeSlug: scan.worktreeSlug,
+      ticketId: scan.ticketId,
     };
   } else {
     const stat = safeStatSync(filePath);
@@ -582,6 +596,10 @@ async function readClaudeMeta(
       durationMs: scan.durationMs,
       topic: scan.topic,
       isTeamOrigin,
+      prUrl: scan.prUrl,
+      prNumber: scan.prNumber,
+      worktreeSlug: scan.worktreeSlug,
+      ticketId: scan.ticketId,
     };
   }
 
@@ -758,6 +776,10 @@ async function readCodexMeta(
     costUsd: scan.costUsd,
     durationMs: scan.durationMs,
     account,
+    prUrl: scan.prUrl,
+    prNumber: scan.prNumber,
+    worktreeSlug: scan.worktreeSlug,
+    ticketId: scan.ticketId,
   };
   return { meta, content: scan.contentText || '' };
 }
@@ -1782,6 +1804,12 @@ export async function scanClaudeSession(filePath: string): Promise<ClaudeSession
   let lastTsMs: number | undefined;
   const seenAssistantIds = new Set<string>();
   const userTexts: string[] = [];
+  // Durable PR signal: set only when an actual `gh pr create` Bash *command*
+  // runs (structural — the command field, not any prose mentioning it), then
+  // capture the pull URL from a later tool_result's output.
+  let sawPrCreate = false;
+  let prUrl: string | undefined;
+  let prNumber: number | undefined;
 
   try {
     for await (const line of rl) {
@@ -1798,6 +1826,28 @@ export async function scanClaudeSession(filePath: string): Promise<ClaudeSession
       // and is the clean structural signal for "was this a team spawn?"
       if (!entrypoint && typeof parsed.entrypoint === 'string') {
         entrypoint = parsed.entrypoint;
+      }
+
+      // PR signal, structurally: a Bash tool_use whose command is `gh pr create`
+      // marks intent; the pull URL is then read from a tool_result's output.
+      if (!prUrl) {
+        if (!sawPrCreate && parsed.type === 'assistant' && Array.isArray(parsed.message?.content)) {
+          for (const b of parsed.message.content) {
+            if (b?.type === 'tool_use' && typeof b?.input?.command === 'string' && isPrCreateCommand(b.input.command)) {
+              sawPrCreate = true;
+            }
+          }
+        }
+        if (sawPrCreate && parsed.type === 'user' && Array.isArray(parsed.message?.content)) {
+          for (const b of parsed.message.content) {
+            if (b?.type !== 'tool_result') continue;
+            const text = typeof b.content === 'string'
+              ? b.content
+              : Array.isArray(b.content) ? b.content.map((c: any) => c?.text || '').join('\n') : '';
+            const pr = extractPrUrl(text);
+            if (pr) { prUrl = pr.url; prNumber = pr.number; }
+          }
+        }
       }
 
       // Track duration across every timestamped event, not just the first.
@@ -1886,6 +1936,8 @@ export async function scanClaudeSession(filePath: string): Promise<ClaudeSession
   // Prefer an explicit session title (user `/rename` > Claude auto-title) over
   // the first-prompt topic.
   const resolvedTopic = customTitle || aiTitle || topic;
+  const worktree = detectWorktree(cwd, gitBranch);
+  const ticket = detectTicket(userTexts.join('\n') || undefined, gitBranch);
 
   return {
     timestamp,
@@ -1899,6 +1951,10 @@ export async function scanClaudeSession(filePath: string): Promise<ClaudeSession
     costUsd: sawCost ? costUsd : undefined,
     durationMs,
     contentText: userTexts.length > 0 ? userTexts.join('\n') : undefined,
+    prUrl,
+    prNumber,
+    worktreeSlug: worktree?.slug,
+    ticketId: ticket?.id,
   };
 }
 
@@ -1920,6 +1976,9 @@ async function scanCodexSession(filePath: string): Promise<CodexSessionScan> {
   let firstTsMs: number | undefined;
   let lastTsMs: number | undefined;
   const userTexts: string[] = [];
+  let sawPrCreate = false;
+  let prUrl: string | undefined;
+  let prNumber: number | undefined;
 
   try {
     for await (const line of rl) {
@@ -1930,6 +1989,24 @@ async function scanCodexSession(filePath: string): Promise<CodexSessionScan> {
         parsed = JSON.parse(line);
       } catch {
         continue;
+      }
+
+      // PR signal, structurally: a Codex `function_call` whose command is
+      // `gh pr create`, then the pull URL from a `function_call_output`.
+      if (!prUrl && parsed.type === 'response_item') {
+        const p = parsed.payload || {};
+        if (!sawPrCreate && p.type === 'function_call') {
+          let cmd = '';
+          try {
+            const args = typeof p.arguments === 'string' ? JSON.parse(p.arguments) : (p.arguments || {});
+            cmd = String(args.command || args.cmd || '');
+          } catch { /* non-JSON args */ }
+          if (isPrCreateCommand(cmd)) sawPrCreate = true;
+        }
+        if (sawPrCreate && p.type === 'function_call_output') {
+          const pr = extractPrUrl(String(p.output || ''));
+          if (pr) { prUrl = pr.url; prNumber = pr.number; }
+        }
       }
 
       // Track duration across every timestamped event.
@@ -2000,6 +2077,9 @@ async function scanCodexSession(filePath: string): Promise<CodexSessionScan> {
       ? lastTsMs - firstTsMs
       : undefined;
 
+  const worktree = detectWorktree(cwd, gitBranch);
+  const ticket = detectTicket(userTexts.join('\n') || undefined, gitBranch);
+
   return {
     sessionId,
     timestamp,
@@ -2012,6 +2092,10 @@ async function scanCodexSession(filePath: string): Promise<CodexSessionScan> {
     costUsd,
     durationMs,
     contentText: userTexts.length > 0 ? userTexts.join('\n') : undefined,
+    prUrl,
+    prNumber,
+    worktreeSlug: worktree?.slug,
+    ticketId: ticket?.id,
   };
 }
 

--- a/src/lib/session/parse.ts
+++ b/src/lib/session/parse.ts
@@ -44,6 +44,11 @@ function sanitizeArgsDeep(value: any): any {
   return value;
 }
 
+/** In-place sanitize every user-visible string field on a list of events. */
+export function sanitizeEvents(events: SessionEvent[]): void {
+  for (const e of events) sanitizeEvent(e);
+}
+
 /** In-place sanitize all user-visible string fields on an event. */
 function sanitizeEvent(e: SessionEvent): void {
   if (e.content) e.content = sanitizeForTerminal(e.content);
@@ -188,7 +193,16 @@ function shortenPath(p: string): string {
 
 /** Parse a Claude JSONL session file into normalized events. */
 export function parseClaude(filePath: string): SessionEvent[] {
-  const content = safeReadSessionFile(filePath);
+  return parseClaudeContent(safeReadSessionFile(filePath));
+}
+
+/**
+ * Parse Claude JSONL *content* (already read into a string) into normalized
+ * events. Split from `parseClaude` so the tail reader can parse just the last
+ * chunk of a file without re-reading the whole thing. Malformed leading lines
+ * (a tail that starts mid-line) are skipped by the per-line try/catch below.
+ */
+export function parseClaudeContent(content: string): SessionEvent[] {
   const lines = content.split('\n').filter(l => l.trim());
   const events: SessionEvent[] = [];
 
@@ -377,7 +391,15 @@ export function parseClaude(filePath: string): SessionEvent[] {
 
 /** Parse a Codex JSONL session file into normalized events. */
 export function parseCodex(filePath: string): SessionEvent[] {
-  const content = safeReadSessionFile(filePath);
+  return parseCodexContent(safeReadSessionFile(filePath));
+}
+
+/**
+ * Parse Codex JSONL *content* (already read into a string) into normalized
+ * events. Split from `parseCodex` so the tail reader can parse just the last
+ * chunk without re-reading the whole file.
+ */
+export function parseCodexContent(content: string): SessionEvent[] {
   const lines = content.split('\n').filter(l => l.trim());
   const events: SessionEvent[] = [];
 

--- a/src/lib/session/remote.ts
+++ b/src/lib/session/remote.ts
@@ -28,6 +28,7 @@ import { createHash } from 'crypto';
 import chalk from 'chalk';
 import { getCacheDir } from '../state.js';
 import { formatRelativeTime } from './relative-time.js';
+import { terminalWidth } from './width.js';
 
 /**
  * SSH target: a bare ssh-config host alias (e.g. `yosemite-s1`) or `user@host`.
@@ -90,9 +91,13 @@ export function buildForwardedArgs(argv: string[], hosts: Set<string> = new Set(
  * are quoted for the inner login shell, then the whole `agents …` invocation is
  * quoted again so it survives `bash -lc <...>`.
  */
-export function buildRemoteCommand(forwardedArgs: string[]): string {
+export function buildRemoteCommand(forwardedArgs: string[], columns?: number): string {
   const inner = ['agents', ...forwardedArgs].map(shellQuote).join(' ');
-  return `bash -lc ${shellQuote(inner)}`;
+  // Forward the caller's terminal width so the remote renders the table to the
+  // local screen (over SSH the remote's own COLUMNS is unset/wrong). `VAR=val
+  // cmd` scopes the env to that process — the remote's terminalWidth() reads it.
+  const withCols = columns && columns > 0 ? `COLUMNS=${columns} ${inner}` : inner;
+  return `bash -lc ${shellQuote(withCols)}`;
 }
 
 const SSH_OPTS = [
@@ -186,7 +191,7 @@ export function runRemoteSessions(hosts: string[], argv: string[] = process.argv
   for (const host of hosts) assertValidSshTarget(host); // fail fast on any bad target
 
   const forwarded = buildForwardedArgs(argv, new Set(hosts));
-  const remoteCmd = buildRemoteCommand(forwarded);
+  const remoteCmd = buildRemoteCommand(forwarded, terminalWidth());
   const multi = hosts.length > 1;
   let failures = 0;
 

--- a/src/lib/session/state.test.ts
+++ b/src/lib/session/state.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import type { SessionEvent } from './types.js';
+import {
+  inferActivity,
+  inferSessionState,
+  detectWorktree,
+  detectTicket,
+  extractPrUrl,
+  isPrCreateCommand,
+  detectDurableSignals,
+} from './state.js';
+
+const now = Date.now();
+const fresh = now - 5_000;      // within the 2-min window
+const stale = now - 20 * 60_000; // well outside
+
+function msg(role: 'user' | 'assistant', content: string): SessionEvent {
+  return { type: 'message', agent: 'claude', timestamp: '', role, content };
+}
+function tool(toolName: string, args: Record<string, any> = {}, command?: string): SessionEvent {
+  return { type: 'tool_use', agent: 'claude', timestamp: '', tool: toolName, args, command };
+}
+function toolResult(toolName: string, output: string): SessionEvent {
+  return { type: 'tool_result', agent: 'claude', timestamp: '', tool: toolName, success: true, output };
+}
+
+describe('inferActivity — waiting signals', () => {
+  it('ExitPlanMode as the last event ⇒ waiting / plan_review', () => {
+    const s = inferActivity([msg('user', 'plan it'), tool('ExitPlanMode')], { pidAlive: true, mtimeMs: fresh });
+    expect(s.activity).toBe('waiting_input');
+    expect(s.awaitingReason).toBe('plan_review');
+  });
+
+  it('AskUserQuestion as the last event ⇒ waiting / question', () => {
+    const s = inferActivity([msg('user', 'go'), tool('AskUserQuestion')], { pidAlive: true, mtimeMs: fresh });
+    expect(s.activity).toBe('waiting_input');
+    expect(s.awaitingReason).toBe('question');
+  });
+
+  it('an answered AskUserQuestion (tool_result after) is no longer waiting', () => {
+    const s = inferActivity(
+      [tool('AskUserQuestion'), toolResult('AskUserQuestion', 'user picked B'), msg('assistant', 'Proceeding with B.')],
+      { pidAlive: true, mtimeMs: fresh },
+    );
+    expect(s.activity).not.toBe('waiting_input');
+  });
+
+  it('assistant message ending in a question ⇒ waiting / question', () => {
+    const s = inferActivity([msg('assistant', 'I can do A or B. Which do you prefer?')], { pidAlive: true, mtimeMs: stale });
+    expect(s.activity).toBe('waiting_input');
+    expect(s.awaitingReason).toBe('question');
+  });
+
+  it('assistant statement (no question) with stale mtime ⇒ idle', () => {
+    const s = inferActivity([msg('assistant', 'Done — tests pass.')], { pidAlive: true, mtimeMs: stale });
+    expect(s.activity).toBe('idle');
+  });
+});
+
+describe('inferActivity — working signals', () => {
+  it('pending tool call while fresh ⇒ working', () => {
+    const s = inferActivity([msg('user', 'run tests'), tool('Bash', { command: 'bun test' }, 'bun test')], { pidAlive: true, mtimeMs: fresh });
+    expect(s.activity).toBe('working');
+    expect(s.preview).toContain('bun test');
+  });
+
+  it('pending non-plan tool, alive but stale ⇒ waiting / permission', () => {
+    const s = inferActivity([tool('Bash', { command: 'rm -rf x' }, 'rm -rf x')], { pidAlive: true, mtimeMs: stale });
+    expect(s.activity).toBe('waiting_input');
+    expect(s.awaitingReason).toBe('permission');
+  });
+
+  it('a dead process is never working', () => {
+    const s = inferActivity([tool('Bash', { command: 'bun test' }, 'bun test')], { pidAlive: false, mtimeMs: fresh });
+    expect(s.activity).toBe('idle');
+  });
+
+  it('user spoke last and process alive ⇒ working (owes a reply)', () => {
+    const s = inferActivity([msg('assistant', 'anything else?'), msg('user', 'yes, add logging')], { pidAlive: true, mtimeMs: fresh });
+    expect(s.activity).toBe('working');
+  });
+});
+
+describe('detectWorktree', () => {
+  it('extracts slug + branch from a worktree cwd', () => {
+    const wt = detectWorktree('/home/u/repo/.agents/worktrees/tree-view', 'agents/tree-view');
+    expect(wt).toEqual({ path: '/home/u/repo/.agents/worktrees/tree-view', slug: 'tree-view', branch: 'agents/tree-view' });
+  });
+  it('returns undefined for a normal cwd', () => {
+    expect(detectWorktree('/home/u/repo', 'main')).toBeUndefined();
+  });
+});
+
+describe('detectTicket', () => {
+  it('finds an uppercase ref in prompt text', () => {
+    expect(detectTicket('please fix RUSH-1234 today')?.id).toBe('RUSH-1234');
+  });
+  it('does not match utf-8 style noise', () => {
+    expect(detectTicket('decode the utf-8 bytes')).toBeUndefined();
+  });
+  it('recovers a ref from a lowercase Linear branch', () => {
+    expect(detectTicket(undefined, 'muqsit/rush-1234-fix-thing')?.id).toBe('RUSH-1234');
+  });
+  it('ignores denylisted keys in branches (sha-256)', () => {
+    expect(detectTicket(undefined, 'add-sha-256-hash')).toBeUndefined();
+  });
+});
+
+describe('PR detection', () => {
+  it('recognizes gh pr create commands', () => {
+    expect(isPrCreateCommand('gh pr create --fill')).toBe(true);
+    expect(isPrCreateCommand('gh pr view 4')).toBe(false);
+  });
+  it('extracts a PR url + number from output', () => {
+    const pr = extractPrUrl('Created: https://github.com/phnx-labs/agents-cli/pull/482');
+    expect(pr).toEqual({ url: 'https://github.com/phnx-labs/agents-cli/pull/482', number: 482 });
+  });
+  it('correlates gh pr create with the following result url', () => {
+    const events: SessionEvent[] = [
+      tool('Bash', { command: 'gh pr create --fill' }, 'gh pr create --fill'),
+      toolResult('Bash', 'https://github.com/phnx-labs/agents-cli/pull/491'),
+    ];
+    expect(detectDurableSignals(events).pr?.number).toBe(491);
+  });
+
+  it('does NOT flag a PR from prose mentioning the command + a URL (no real tool call)', () => {
+    // A session that merely discusses PRs (like this one) must not self-report a PR.
+    const events: SessionEvent[] = [
+      msg('assistant', 'You could run `gh pr create` and it prints https://github.com/x/y/pull/482'),
+      msg('user', 'ok'),
+    ];
+    expect(detectDurableSignals(events).pr).toBeUndefined();
+  });
+});
+
+describe('ticket false positives', () => {
+  it('does NOT treat a regex snippet like [A-Z0-9]-\\d as a ticket', () => {
+    expect(detectTicket('the pattern /([A-Z0-9]-\\d)/ matches')).toBeUndefined();
+  });
+  it('does NOT treat a digit-bearing key like Z0-9 as a ticket', () => {
+    expect(detectTicket('bucket Z0-9 rotated')).toBeUndefined();
+  });
+  it('still detects a real letters-only key', () => {
+    expect(detectTicket('working on ENG-42')?.id).toBe('ENG-42');
+  });
+});
+
+describe('inferSessionState — composed', () => {
+  it('attaches worktree + ticket + pr alongside activity', () => {
+    const events: SessionEvent[] = [
+      msg('user', 'ship RUSH-77 in a worktree'),
+      tool('Bash', { command: 'gh pr create' }, 'gh pr create'),
+      toolResult('Bash', 'https://github.com/x/y/pull/9'),
+      msg('assistant', 'Opened the PR. Anything else?'),
+    ];
+    const s = inferSessionState(events, {
+      cwd: '/home/u/repo/.agents/worktrees/rush-77',
+      gitBranch: 'agents/rush-77',
+      pidAlive: true,
+      mtimeMs: stale,
+    });
+    expect(s.activity).toBe('waiting_input');
+    expect(s.pr?.number).toBe(9);
+    expect(s.worktree?.slug).toBe('rush-77');
+    expect(s.ticket?.id).toBe('RUSH-77');
+  });
+});

--- a/src/lib/session/state.ts
+++ b/src/lib/session/state.ts
@@ -1,0 +1,278 @@
+/**
+ * Session state inference.
+ *
+ * Turns a chronological slice of normalized `SessionEvent`s (typically the tail
+ * of a transcript) plus lightweight context (file mtime, cwd, branch, whether
+ * the owning process is alive) into a `SessionState`: is the agent working,
+ * waiting on the user, or idle — and did it open a PR, is it in a worktree, is
+ * it tied to a tracker ticket. Pure functions, no I/O, so the whole thing is
+ * unit-testable and shared by both the live `--active` path and the incremental
+ * scanner (which persists the durable signals to the index).
+ *
+ * Structural signals are preferred over prose heuristics: Claude's
+ * `ExitPlanMode` / `AskUserQuestion` tool calls are exact "waiting on you"
+ * markers. Codex has no such tools, so it falls back to last-role + question
+ * shape + mtime — same function, driven off the normalized events.
+ */
+
+import type { SessionEvent } from './types.js';
+import { summarizeToolUse } from './parse.js';
+
+export type SessionActivity = 'working' | 'waiting_input' | 'idle';
+export type AwaitingReason = 'question' | 'plan_review' | 'permission';
+
+export interface DetectedPr {
+  url: string;
+  number?: number;
+}
+export interface DetectedWorktree {
+  /** Absolute worktree path (the session cwd). */
+  path: string;
+  /** The `<slug>` under `.agents/worktrees/`. */
+  slug: string;
+  branch?: string;
+}
+export interface DetectedTicket {
+  /** Tracker key, e.g. `RUSH-1234`. */
+  id: string;
+  url?: string;
+}
+
+export interface SessionState {
+  activity: SessionActivity;
+  awaitingReason?: AwaitingReason;
+  lastRole?: 'user' | 'assistant';
+  lastEventKind?: SessionEvent['type'];
+  /** Single-line description of the latest turn (message text or tool action). */
+  preview?: string;
+  lastActivityMs?: number;
+  pr?: DetectedPr;
+  worktree?: DetectedWorktree;
+  ticket?: DetectedTicket;
+}
+
+export interface StateContext {
+  /** Session file mtime; drives running-vs-stale. */
+  mtimeMs?: number;
+  cwd?: string;
+  gitBranch?: string;
+  /** Whether the owning OS process is alive (from the active scanner). */
+  pidAlive?: boolean;
+  /** Override the running window (defaults to 2 min, matching active.ts). */
+  activeWindowMs?: number;
+}
+
+/** A healthy live session writes several times a minute; 2 min ⇒ "recently active". */
+const ACTIVE_WINDOW_MS = 2 * 60_000;
+
+/** Claude tool names that structurally mean "the agent handed control back to you". */
+const PLAN_TOOL = 'ExitPlanMode';
+const ASK_TOOL = 'AskUserQuestion';
+
+/** Trailing '?' or a leading interrogative — a question aimed at the user. */
+const QUESTION_TRAILING = /\?["'”)\]]?\s*$/;
+const QUESTION_PHRASE =
+  /\b(shall i|should i|do you want|would you like|which (?:one|option|approach|of)|can you (?:confirm|clarify)|please (?:confirm|clarify|advise)|let me know|are you (?:ok|okay|sure)|proceed\?)\b/i;
+
+/**
+ * Linear/Jira-style ref, e.g. RUSH-1234. Team key is letters-only (2–6) so a
+ * regex snippet like `[A-Z0-9]-\d` in a code discussion can't masquerade as a
+ * ticket. Uppercase-only so we don't match `utf-8`.
+ */
+const TICKET_RE = /\b([A-Z]{2,6}-\d{1,6})\b/;
+/** Lowercase branch form (Linear branch names): muqsit/rush-1234-fix. */
+const TICKET_BRANCH_RE = /(?:^|[/_-])([a-z]{2,6})-(\d{2,6})(?=[/_-]|$)/;
+/** Keys that look like tickets but aren't — avoid false positives from branches. */
+const TICKET_DENYLIST = new Set(['UTF', 'SHA', 'ISO', 'RFC', 'IPV', 'X86', 'ARM', 'MP', 'H']);
+
+const PR_URL_RE = /https:\/\/github\.com\/[^\s"'()<>]+\/pull\/(\d+)/;
+const WORKTREE_RE = /\/\.agents\/worktrees\/([^/]+)/;
+/** gh invocations that create/open a PR. */
+const GH_PR_CREATE_RE = /\bgh\s+pr\s+(?:create|new)\b/;
+
+/** Collapse to a single trimmed line for a one-row preview cell. */
+function oneLine(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+/** Detect a worktree from the session cwd, per the `.agents/worktrees/<slug>/` convention. */
+export function detectWorktree(cwd?: string, branch?: string): DetectedWorktree | undefined {
+  if (!cwd) return undefined;
+  const m = cwd.match(WORKTREE_RE);
+  if (!m) return undefined;
+  return { path: cwd, slug: m[1], branch: branch || undefined };
+}
+
+/** Detect a tracker ticket from free text (prompt/topic) then a branch name. */
+export function detectTicket(text?: string, branch?: string): DetectedTicket | undefined {
+  if (text) {
+    const m = text.match(TICKET_RE);
+    if (m && !TICKET_DENYLIST.has(m[1].split('-')[0])) return { id: m[1] };
+  }
+  if (branch) {
+    const m = branch.match(TICKET_BRANCH_RE);
+    if (m) {
+      const key = m[1].toUpperCase();
+      if (!TICKET_DENYLIST.has(key)) return { id: `${key}-${m[2]}` };
+    }
+  }
+  return undefined;
+}
+
+/** Pull a PR URL + number out of tool-result output text. */
+export function extractPrUrl(output?: string): DetectedPr | undefined {
+  if (!output) return undefined;
+  const m = output.match(PR_URL_RE);
+  if (!m) return undefined;
+  return { url: m[0], number: Number.parseInt(m[1], 10) };
+}
+
+/** True when a Bash/exec command string is a `gh pr create`. */
+export function isPrCreateCommand(command?: string): boolean {
+  return !!command && GH_PR_CREATE_RE.test(command);
+}
+
+/** Does an assistant message read as a question directed at the user? */
+function looksLikeQuestion(text: string): boolean {
+  const t = text.trim();
+  if (!t) return false;
+  // Only weigh the final line — a long answer that ends with a question is a question.
+  const lastLine = t.split('\n').filter(Boolean).pop() ?? t;
+  return QUESTION_TRAILING.test(lastLine) || QUESTION_PHRASE.test(lastLine);
+}
+
+/** Human-readable one-liner for the latest event (message text or tool action). */
+function describeEvent(e: SessionEvent): string | undefined {
+  if (e.type === 'message' && e.content) return oneLine(e.content);
+  if (e.type === 'tool_use' && e.tool) return oneLine(summarizeToolUse(e.tool, e.args));
+  if (e.type === 'thinking') return 'thinking…';
+  if (e.type === 'tool_result') return e.tool ? `↳ ${e.tool}` : undefined;
+  if (e.type === 'error') return oneLine(e.content || 'error');
+  return e.content ? oneLine(e.content) : undefined;
+}
+
+/** Last event of a given type, scanning from the end. */
+function lastOf(events: SessionEvent[], pred: (e: SessionEvent) => boolean): SessionEvent | undefined {
+  for (let i = events.length - 1; i >= 0; i--) if (pred(events[i])) return events[i];
+  return undefined;
+}
+
+/**
+ * Infer live activity + a preview from a chronological event slice. `pr` /
+ * `ticket` / `worktree` are attached by `inferSessionState`; this focuses on the
+ * running-vs-waiting-vs-idle decision and the preview line.
+ */
+export function inferActivity(events: SessionEvent[], ctx: StateContext = {}): SessionState {
+  const windowMs = ctx.activeWindowMs ?? ACTIVE_WINDOW_MS;
+  const fresh = ctx.mtimeMs != null && Date.now() - ctx.mtimeMs < windowMs;
+  // A non-live process (pidAlive === false) can never be "working"; the strongest
+  // it gets is "waiting on you" (a dangling question) or "idle".
+  const canWork = ctx.pidAlive !== false && (ctx.pidAlive === true || fresh);
+
+  const meaningful = events.filter(
+    e => e.type === 'message' || e.type === 'tool_use' || e.type === 'tool_result' || e.type === 'thinking' || e.type === 'error',
+  );
+  const last = meaningful[meaningful.length - 1];
+  const lastMsg = lastOf(meaningful, e => e.type === 'message');
+  const lastToolUse = lastOf(meaningful, e => e.type === 'tool_use');
+
+  // The most informative recent line: a message or tool call as-is, but for a
+  // trailing tool_result/thinking show the tool *call* that produced it (its
+  // command) rather than a bare "↳ Bash".
+  const previewSource = !last
+    ? undefined
+    : last.type === 'message' || last.type === 'tool_use'
+      ? last
+      : (lastToolUse ?? last);
+
+  const base: SessionState = {
+    activity: 'idle',
+    lastRole: lastMsg?.role,
+    lastEventKind: last?.type,
+    lastActivityMs: ctx.mtimeMs,
+    preview: previewSource ? describeEvent(previewSource) : undefined,
+  };
+
+  if (!last) return base;
+
+  // Structural "waiting on you" — Claude handed control back via a plan/question
+  // tool and nothing has come after it.
+  const lastPlanOrAsk = lastOf(
+    meaningful,
+    e => e.type === 'tool_use' && (e.tool === PLAN_TOOL || e.tool === ASK_TOOL),
+  );
+  if (lastPlanOrAsk && meaningful.indexOf(lastPlanOrAsk) === meaningful.length - 1) {
+    return {
+      ...base,
+      activity: 'waiting_input',
+      awaitingReason: lastPlanOrAsk.tool === PLAN_TOOL ? 'plan_review' : 'question',
+      preview: lastPlanOrAsk.tool === PLAN_TOOL ? 'Plan ready — awaiting your review' : 'Asked you a question',
+    };
+  }
+
+  // Pending tool call (tool_use with no following tool_result): mid-turn.
+  if (last.type === 'tool_use') {
+    if (canWork && fresh) return { ...base, activity: 'working' };
+    // Alive but the file hasn't moved — likely blocked on a permission prompt.
+    if (ctx.pidAlive) return { ...base, activity: 'waiting_input', awaitingReason: 'permission' };
+    return { ...base, activity: 'idle' };
+  }
+
+  // Thinking or a tool result just landed → agent is mid-turn if recently active.
+  if (last.type === 'thinking' || last.type === 'tool_result' || last.type === 'error') {
+    return { ...base, activity: canWork && fresh ? 'working' : 'idle' };
+  }
+
+  // Last event is a message.
+  if (last.type === 'message') {
+    if (last.role === 'user') {
+      // User spoke last; the agent owes a reply → working if it's alive/fresh.
+      return { ...base, activity: canWork ? 'working' : 'idle' };
+    }
+    // Assistant spoke last and stopped. A trailing question → waiting; else idle.
+    if (looksLikeQuestion(last.content ?? '')) {
+      return { ...base, activity: 'waiting_input', awaitingReason: 'question' };
+    }
+    return { ...base, activity: 'idle' };
+  }
+
+  return base;
+}
+
+/**
+ * Scan an event slice for the durable signals (PR opened, ticket) that aren't
+ * about the cwd. Correlates each `gh pr create` with the nearest following
+ * tool_result URL; keeps the last PR found.
+ */
+export function detectDurableSignals(events: SessionEvent[]): { pr?: DetectedPr; ticket?: DetectedTicket } {
+  let pr: DetectedPr | undefined;
+  let sawPrCreate = false;
+  let ticket: DetectedTicket | undefined;
+
+  for (const e of events) {
+    // Structural PR signal: a real `gh pr create` tool call, then the pull URL
+    // from a following tool_result — never a bare URL mentioned in prose.
+    if (e.type === 'tool_use' && isPrCreateCommand(e.command)) sawPrCreate = true;
+    if (sawPrCreate && e.type === 'tool_result') {
+      const found = extractPrUrl(e.output);
+      if (found) { pr = found; sawPrCreate = false; }
+    }
+    if (!ticket && e.type === 'message' && e.role === 'user') {
+      ticket = detectTicket(e.content);
+    }
+  }
+  return { pr, ticket };
+}
+
+/** Full inference: activity + preview + durable signals + worktree/ticket from ctx. */
+export function inferSessionState(events: SessionEvent[], ctx: StateContext = {}): SessionState {
+  const state = inferActivity(events, ctx);
+  const { pr, ticket } = detectDurableSignals(events);
+  const worktree = detectWorktree(ctx.cwd, ctx.gitBranch);
+  return {
+    ...state,
+    pr: pr ?? state.pr,
+    worktree: worktree ?? state.worktree,
+    ticket: ticket ?? detectTicket(undefined, ctx.gitBranch) ?? state.ticket,
+  };
+}

--- a/src/lib/session/tail.test.ts
+++ b/src/lib/session/tail.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import * as path from 'path';
+import { readSessionTail } from './tail.js';
+import { inferSessionState } from './state.js';
+
+const FIXTURE = path.join(import.meta.dirname, 'testdata', 'tail-sample-claude.jsonl');
+
+describe('readSessionTail', () => {
+  it('parses the tail of a real JSONL into normalized events', () => {
+    const events = readSessionTail(FIXTURE, 'claude');
+    expect(events.length).toBeGreaterThan(0);
+    const last = events[events.length - 1];
+    expect(last.type).toBe('message');
+    expect(last.role).toBe('assistant');
+    expect(last.content).toContain('--tree the default');
+  });
+
+  it('drops a partial leading line when starting mid-file', () => {
+    // A tiny byte budget forces the read to begin mid-file; the first (partial)
+    // line must be discarded rather than producing a garbage event.
+    const events = readSessionTail(FIXTURE, 'claude', 400);
+    expect(events.length).toBeGreaterThan(0);
+    // Every returned event still parsed cleanly (no malformed leftovers).
+    for (const e of events) expect(typeof e.type).toBe('string');
+  });
+
+  it('returns [] for unsupported agents', () => {
+    expect(readSessionTail(FIXTURE, 'gemini')).toEqual([]);
+  });
+
+  it('feeds inferSessionState to a waiting verdict on a trailing question', () => {
+    const events = readSessionTail(FIXTURE, 'claude');
+    const state = inferSessionState(events, {
+      cwd: '/home/u/repo/.agents/worktrees/tree-view',
+      gitBranch: 'agents/tree-view',
+      pidAlive: true,
+      mtimeMs: Date.now() - 20 * 60_000,
+    });
+    expect(state.activity).toBe('waiting_input');
+    expect(state.awaitingReason).toBe('question');
+    expect(state.worktree?.slug).toBe('tree-view');
+  });
+});

--- a/src/lib/session/tail.ts
+++ b/src/lib/session/tail.ts
@@ -1,0 +1,64 @@
+/**
+ * Fast tail read of a session transcript.
+ *
+ * The live `--active` view needs the *last* few events of a possibly-huge JSONL
+ * to infer state — parsing the whole file per row would make the view crawl. We
+ * read only the final chunk from an fd (mirroring the bounded head-read in
+ * active.ts's `quickExtractTopic`), drop a partial leading line, and hand the
+ * chunk to the existing content parsers so there's zero duplicated parse logic.
+ */
+
+import * as fs from 'fs';
+import type { SessionAgentId, SessionEvent } from './types.js';
+import { parseClaudeContent, parseCodexContent, sanitizeEvents } from './parse.js';
+
+const DEFAULT_MAX_BYTES = 128 * 1024;
+const DEFAULT_MAX_EVENTS = 60;
+
+/**
+ * Read the last `maxBytes` of a JSONL transcript and return its last
+ * `maxEvents` normalized events. A tail that begins mid-line yields one
+ * malformed leading line, which the per-line JSON try/catch in the content
+ * parsers skips. Only Claude and Codex are supported (the prioritized harnesses
+ * for live state); other agents return `[]`.
+ */
+export function readSessionTail(
+  filePath: string,
+  agent: SessionAgentId,
+  maxBytes = DEFAULT_MAX_BYTES,
+  maxEvents = DEFAULT_MAX_EVENTS,
+): SessionEvent[] {
+  if (agent !== 'claude' && agent !== 'codex') return [];
+
+  let fd: number;
+  try {
+    fd = fs.openSync(filePath, 'r');
+  } catch {
+    return [];
+  }
+
+  try {
+    const size = fs.fstatSync(fd).size;
+    if (size === 0) return [];
+    const start = Math.max(0, size - maxBytes);
+    const len = size - start;
+    const buf = Buffer.alloc(len);
+    fs.readSync(fd, buf, 0, len, start);
+    let content = buf.toString('utf8');
+
+    // If we started mid-file, the first line is almost certainly partial — drop it.
+    if (start > 0) {
+      const nl = content.indexOf('\n');
+      content = nl >= 0 ? content.slice(nl + 1) : '';
+    }
+    if (!content.trim()) return [];
+
+    const events = agent === 'codex' ? parseCodexContent(content) : parseClaudeContent(content);
+    sanitizeEvents(events);
+    return events.length > maxEvents ? events.slice(-maxEvents) : events;
+  } catch {
+    return [];
+  } finally {
+    fs.closeSync(fd);
+  }
+}

--- a/src/lib/session/testdata/tail-sample-claude.jsonl
+++ b/src/lib/session/testdata/tail-sample-claude.jsonl
@@ -1,0 +1,4 @@
+{"type":"user","message":{"role":"user","content":"Add a --tree flag to agents sessions"},"timestamp":"2026-06-30T10:00:00.000Z","cwd":"/home/u/repo/.agents/worktrees/tree-view","gitBranch":"agents/tree-view","sessionId":"aaaa1111"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"On it."},{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"bun test src/lib/session/"}}],"usage":{"input_tokens":10,"output_tokens":5}},"timestamp":"2026-06-30T10:00:05.000Z"}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"12 pass"}]},"timestamp":"2026-06-30T10:00:09.000Z"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Tests pass. Should the flat table stay the default, or make --tree the default?"}]},"timestamp":"2026-06-30T10:00:12.000Z"}

--- a/src/lib/session/types.ts
+++ b/src/lib/session/types.ts
@@ -70,6 +70,15 @@ export interface SessionMeta {
   label?: string;
   /** Set when this session was spawned by `agents teams`. */
   teamOrigin?: TeamOrigin;
+  /** Durable state signals extracted at scan time by the session-state engine. */
+  /** PR URL, if the session opened one (`gh pr create`). */
+  prUrl?: string;
+  /** PR number parsed from prUrl, for compact display. */
+  prNumber?: number;
+  /** Worktree slug when cwd is under `.agents/worktrees/<slug>/`. */
+  worktreeSlug?: string;
+  /** Tracker ticket ref (e.g. RUSH-1234) from the prompt or branch. */
+  ticketId?: string;
   /**
    * True when the session was spawned programmatically (SDK entrypoint) rather
    * than by a human at the Claude CLI. Captured at scan time from the JSONL

--- a/src/lib/session/width.test.ts
+++ b/src/lib/session/width.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { stringWidth, stripAnsi, truncateToWidth, padToWidth, terminalWidth } from './width.js';
+
+describe('stringWidth', () => {
+  it('counts ASCII as one cell each', () => {
+    expect(stringWidth('hello')).toBe(5);
+  });
+
+  it('ignores ANSI colour escapes', () => {
+    // chalk.green('ok') style input must measure as the visible text only.
+    const colored = '\x1b[32mok\x1b[39m';
+    expect(stringWidth(colored)).toBe(2);
+    expect(stripAnsi(colored)).toBe('ok');
+  });
+
+  it('counts CJK as two cells', () => {
+    expect(stringWidth('日本語')).toBe(6);
+  });
+
+  it('counts emoji as two cells', () => {
+    expect(stringWidth('🔧')).toBe(2);
+  });
+
+  it('treats combining marks as zero-width', () => {
+    // 'e' + combining acute accent renders in one cell.
+    expect(stringWidth('é')).toBe(1);
+  });
+});
+
+describe('truncateToWidth', () => {
+  it('leaves short strings untouched', () => {
+    expect(truncateToWidth('short', 10)).toBe('short');
+  });
+
+  it('truncates ASCII with an ellipsis at the target width', () => {
+    const out = truncateToWidth('abcdefghij', 5);
+    expect(stringWidth(out)).toBeLessThanOrEqual(5);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('never splits a wide glyph across the boundary', () => {
+    // Two CJK chars = 4 cells; truncate to 3 must keep one char + ellipsis (2+1=3).
+    const out = truncateToWidth('日本', 3);
+    expect(stringWidth(out)).toBeLessThanOrEqual(3);
+    expect(out).toBe('日…');
+  });
+
+  it('measures the coloured input by visible width, not escape length', () => {
+    const colored = '\x1b[32mhello world\x1b[39m';
+    const out = truncateToWidth(colored, 5);
+    expect(stringWidth(out)).toBeLessThanOrEqual(5);
+  });
+});
+
+describe('padToWidth', () => {
+  it('pads to the visible target width', () => {
+    expect(padToWidth('ab', 5)).toBe('ab   ');
+  });
+  it('pads accounting for wide chars', () => {
+    // '日' is 2 cells, so pad to 5 adds 3 spaces.
+    expect(padToWidth('日', 5)).toBe('日   ');
+  });
+  it('does not truncate when already wider', () => {
+    expect(padToWidth('abcdef', 3)).toBe('abcdef');
+  });
+});
+
+describe('terminalWidth', () => {
+  it('prefers $COLUMNS and clamps to the sane band', () => {
+    const prev = process.env.COLUMNS;
+    process.env.COLUMNS = '120';
+    expect(terminalWidth()).toBe(120);
+    process.env.COLUMNS = '5000';
+    expect(terminalWidth()).toBe(200);
+    process.env.COLUMNS = '10';
+    expect(terminalWidth()).toBe(60);
+    if (prev === undefined) delete process.env.COLUMNS;
+    else process.env.COLUMNS = prev;
+  });
+});

--- a/src/lib/session/width.ts
+++ b/src/lib/session/width.ts
@@ -1,0 +1,94 @@
+/**
+ * Terminal display-width helpers.
+ *
+ * `String.length` is the wrong ruler for a terminal: it over-counts ANSI colour
+ * escapes (chalk output) and under-counts wide glyphs (CJK, emoji) which occupy
+ * two cells. The result is the drifting, wrapping session-table line users see
+ * under tmux and over `--host` SSH. Every renderer that sizes a session-table
+ * cell measures and truncates through this module so alignment is computed once,
+ * correctly, from the same source of truth.
+ */
+
+/** SGR colour sequences emitted by chalk (e.g. `\x1b[32m`). */
+const SGR_REGEX = /\x1b\[[0-9;]*m/g;
+
+/** Strip SGR colour escapes so width is measured on visible characters only. */
+export function stripAnsi(s: string): string {
+  return s.replace(SGR_REGEX, '');
+}
+
+/**
+ * Display cells for one code point: 0 for zero-width combining/ZWJ/variation
+ * selectors, 2 for East-Asian-wide and emoji ranges, 1 otherwise. Compact and
+ * dependency-free — covers the glyphs that actually show up in prompts/titles.
+ */
+function charWidth(cp: number): number {
+  if (cp === 0) return 0;
+  // Zero-width: combining marks, zero-width joiner, variation selectors.
+  if (
+    (cp >= 0x0300 && cp <= 0x036f) ||
+    cp === 0x200b || cp === 0x200d ||
+    (cp >= 0xfe00 && cp <= 0xfe0f)
+  ) return 0;
+  // Wide (2 cells): CJK, Hangul, fullwidth forms, emoji & pictographs.
+  if (
+    (cp >= 0x1100 && cp <= 0x115f) ||   // Hangul Jamo
+    (cp >= 0x2e80 && cp <= 0xa4cf) ||   // CJK radicals … Yi
+    (cp >= 0xac00 && cp <= 0xd7a3) ||   // Hangul syllables
+    (cp >= 0xf900 && cp <= 0xfaff) ||   // CJK compatibility ideographs
+    (cp >= 0xfe30 && cp <= 0xfe4f) ||   // CJK compatibility forms
+    (cp >= 0xff00 && cp <= 0xff60) ||   // Fullwidth forms
+    (cp >= 0xffe0 && cp <= 0xffe6) ||   // Fullwidth signs
+    (cp >= 0x1f300 && cp <= 0x1faff) || // emoji & symbols
+    (cp >= 0x20000 && cp <= 0x3fffd)    // CJK Ext-B and beyond
+  ) return 2;
+  return 1;
+}
+
+/** Visible display width of a string, ANSI-aware and wide-char-aware. */
+export function stringWidth(s: string): number {
+  const plain = stripAnsi(s);
+  let w = 0;
+  for (const ch of plain) w += charWidth(ch.codePointAt(0)!);
+  return w;
+}
+
+/**
+ * Truncate to a target display width, appending '…' when shortened. Operates on
+ * the visible (ANSI-stripped) string; callers colour the result afterwards so
+ * the ellipsis is never inserted mid-escape.
+ */
+export function truncateToWidth(s: string, max: number): string {
+  if (max <= 0) return '';
+  const plain = stripAnsi(s);
+  if (stringWidth(plain) <= max) return plain;
+  let w = 0;
+  let out = '';
+  for (const ch of plain) {
+    const cw = charWidth(ch.codePointAt(0)!);
+    if (w + cw > max - 1) break; // reserve one cell for the ellipsis
+    out += ch;
+    w += cw;
+  }
+  return out + '…';
+}
+
+/** Right-pad with spaces to a target display width. Never truncates. */
+export function padToWidth(s: string, width: number): string {
+  const pad = width - stringWidth(s);
+  return pad > 0 ? s + ' '.repeat(pad) : s;
+}
+
+/**
+ * Effective terminal width. Reads `$COLUMNS` first so it survives tmux and
+ * `--host` SSH (where `process.stdout.columns` is unset or wrong), falls back to
+ * the TTY's reported width, then to `fallback`. Clamped to a sane band so a
+ * bogus value can't produce a 0-wide or absurdly long table.
+ */
+export function terminalWidth(fallback = 100): number {
+  const env = Number.parseInt(process.env.COLUMNS ?? '', 10);
+  const raw = Number.isFinite(env) && env > 0
+    ? env
+    : (process.stdout.columns || fallback);
+  return Math.max(60, Math.min(200, raw));
+}


### PR DESCRIPTION
## What

Gives `agents sessions` a real understanding of what each session is doing — for **Claude and Codex** — and fixes the preview line that rendered inconsistently under tmux / `--host`.

Before, `--active` only knew `running` vs `idle` (file mtime), and the preview was each session's *first* prompt. Now it infers **working / waiting / idle**, shows the **latest turn**, and detects **PR-opened**, **worktree**, and **Linear/Jira ticket** automatically.

## Engine (new, pure + unit-tested)

- **`state.ts`** — `inferSessionState()`. Structural signals first (Claude `ExitPlanMode`/`AskUserQuestion` = waiting), question + mtime fallback for Codex. PR detection is **structural** (a real `gh pr create` Bash command + the pull URL from its tool result — never prose that merely mentions it). Worktree from the `.agents/worktrees/<slug>/` cwd. Ticket keys are letters-only so regex snippets can't false-positive.
- **`tail.ts`** — fast reverse tail read so `--active` never parses whole files; reuses split-out `parseClaudeContent`/`parseCodexContent`.
- **`width.ts`** — ANSI- and wide-char-aware width + `COLUMNS`-first `terminalWidth()`. This is the preview-line fix.

## Surfaces

- `--active`: working/waiting/idle + latest-turn preview + PR/worktree/ticket badges; leads with the 8-char session id (the address to read/resume it).
- `--active --waiting`: only sessions blocked on you; **exits non-zero** (scriptable gate).
- Main table + picker: width-aware, persisted badges. Arrow-key nav unchanged.
- `--tree`: group by directory, drop the version column, keep the id.
- `--json`: full `SessionState` / persisted signals.
- `--host`: forwards `COLUMNS` so the remote renders to your width.

Index schema **v7** adds `pr_url` / `pr_number` / `worktree_slug` / `ticket_id`, captured at scan time so historical sessions show them too.

## Testing

- New unit suites: `state.test.ts`, `width.test.ts`, `tail.test.ts` (incl. regression tests for the prose-`gh pr create` and `[A-Z0-9]-\d` false positives). Full session suite green under vitest/Node: **294 tests pass**.
- Verified end-to-end against real Claude + Codex sessions on-device: `--active` shows `working`/`waiting perm`/`idle` with live previews; `--waiting` exits 1; `--tree` groups by dir; a fresh structural re-scan cleared the false `PR#482`/`Z0-9` and now surfaces real `RUSH-1214`, `DRIVER-332`, `PR#491`, etc.

Note: `bun test` shows pre-existing `bun:sqlite` named-param failures (CI runs vitest on Node's `node:sqlite`, which passes). Unrelated to this change.