### PR TITLE
feat(computer): drive `agents computer` off-macOS + against a remote Windows host over SSH

### DIFF
--- a/scripts/build-win.sh
+++ b/scripts/build-win.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Cross-publish the Windows computer-use daemon (packages/computer-helper-win)
+# into a single self-contained win-x64 exe — from a macOS or Linux build host.
+#
+# The csproj already sets EnableWindowsTargeting=true, so `dotnet publish` for a
+# win-x64 target works off Windows. The result is a runtime-free single file the
+# box needs no .NET install to run; `agents computer setup --host <device>`
+# pushes it over ssh.
+#
+# Usage: scripts/build-win.sh [--clean]
+#
+#   --clean   wipe the publish output dir first
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+dim()   { printf '\033[2m%s\033[0m\n'  "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+red()   { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+bold()  { printf '\033[1m%s\033[0m'    "$*"; }
+die()   { red "  Error: $*"; exit 1; }
+
+CLEAN=false
+for arg in "$@"; do
+  case "$arg" in
+    --clean) CLEAN=true ;;
+    -h|--help) sed -n '3,13p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) die "unknown flag: $arg" ;;
+  esac
+done
+
+# Resolve dotnet: PATH first, then a user-local SDK at ~/.dotnet (what the
+# dot.net install script drops in). CI installs the SDK on PATH.
+DOTNET="$(command -v dotnet || true)"
+if [[ -z "$DOTNET" && -x "$HOME/.dotnet/dotnet" ]]; then
+  DOTNET="$HOME/.dotnet/dotnet"
+fi
+[[ -n "$DOTNET" ]] || die "dotnet not found. Install the .NET 10 SDK: curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 10.0"
+
+PROJECT="packages/computer-helper-win"
+OUT="$PROJECT/dist"
+
+bold "Build (win-x64)"; echo "  $("$DOTNET" --version) — $PROJECT"
+echo
+
+if $CLEAN; then
+  dim "  Cleaning $OUT/"
+  rm -rf "$OUT"
+fi
+
+dim "  Publishing self-contained single-file exe"
+"$DOTNET" publish "$PROJECT" \
+  -c Release \
+  -r win-x64 \
+  --self-contained true \
+  -p:PublishSingleFile=true \
+  -o "$OUT"
+
+EXE="$OUT/computer-helper-win.exe"
+[[ -f "$EXE" ]] || die "publish finished but $EXE is missing"
+
+# Byte size, portable across GNU/BSD stat.
+BYTES=$(stat -c %s "$EXE" 2>/dev/null || stat -f %z "$EXE")
+MB=$(( BYTES / 1024 / 1024 ))
+
+echo
+green "  Ready"
+dim   "  $EXE"
+dim   "  ${BYTES} bytes (~${MB} MB)"

--- a/src/commands/computer-actions.ts
+++ b/src/commands/computer-actions.ts
@@ -201,11 +201,15 @@ function emit(result: Record<string, unknown>, json: boolean, human: () => strin
   }
 }
 
-// Add the shared --pid/--bundle target options to a verb.
+// Add the shared --pid/--bundle/--host target options to a verb. `--host` routes
+// the verb at a remote Windows device: the `computer` preAction hook hydrates
+// COMPUTER_HELPER_TCP from the tunnel `start --host` recorded, so withClient's
+// openComputerClient() transparently selects the TCP transport.
 function addTargetOpts(cmd: Command): Command {
   return cmd
     .option('--bundle <id>', 'Bundle id of the target app (default: frontmost allow-listed app)')
-    .option('--pid <n>', 'Target pid directly (overrides --bundle)', (v) => parseInt(v, 10));
+    .option('--pid <n>', 'Target pid directly (overrides --bundle)', (v) => parseInt(v, 10))
+    .option('--host <device>', 'Drive a remote Windows device (requires `agents computer start --host <device>` first)');
 }
 
 // Add the shared --id/--x/--y element-or-coords options to a verb.
@@ -216,7 +220,7 @@ function addElementOrCoordOpts(cmd: Command): Command {
     .option('--y <n>', 'Y coordinate (global, points)', (v) => parseInt(v, 10));
 }
 
-type TargetOpts = { pid?: number; bundle?: string; json?: boolean };
+type TargetOpts = { pid?: number; bundle?: string; host?: string; json?: boolean };
 type ElemOpts = TargetOpts & { id?: string; x?: number; y?: number };
 
 export function registerActionCommands(program: Command): void {

--- a/src/commands/computer.test.ts
+++ b/src/commands/computer.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { shouldBlockOffPlatform } from './computer.js';
+
+// The `computer` preAction hook calls process.exit(1) exactly when
+// shouldBlockOffPlatform() is true. These cases pin the rule that off-macOS
+// invocations are NOT blocked once a remote daemon is reachable.
+describe('shouldBlockOffPlatform', () => {
+  it('never blocks on macOS (local Accessibility path)', () => {
+    expect(shouldBlockOffPlatform({ platform: 'darwin', tcpConfigured: false })).toBe(false);
+    expect(shouldBlockOffPlatform({ platform: 'darwin', tcpConfigured: true, host: 'win-mini' })).toBe(false);
+  });
+
+  it('blocks off macOS with no remote path configured', () => {
+    expect(shouldBlockOffPlatform({ platform: 'linux', tcpConfigured: false })).toBe(true);
+    expect(shouldBlockOffPlatform({ platform: 'win32', tcpConfigured: false })).toBe(true);
+  });
+
+  it('does NOT block off macOS when COMPUTER_HELPER_TCP is configured', () => {
+    // This is the regression the transport fix targets: a Linux host with a
+    // tunnel to a Windows daemon must be allowed to drive it.
+    expect(shouldBlockOffPlatform({ platform: 'linux', tcpConfigured: true })).toBe(false);
+  });
+
+  it('does NOT block off macOS when a --host remote device is given', () => {
+    // The remote path resolves its own endpoint before the client opens.
+    expect(shouldBlockOffPlatform({ platform: 'linux', tcpConfigured: false, host: 'win-mini' })).toBe(false);
+  });
+});

--- a/src/commands/computer.ts
+++ b/src/commands/computer.ts
@@ -13,11 +13,18 @@ import {
   resolvePolicyPath,
   resolvePeersPath,
   describeTransport,
+  resolveTcpEndpoint,
   loadComputerAllowList,
   loadDefaultPeers,
   writeComputerPolicy,
   writeComputerPeers,
 } from '../lib/computer-rpc.js';
+import {
+  setupRemoteHelper,
+  startRemoteTunnel,
+  stopRemoteHelper,
+  hydrateRemoteEnvFromState,
+} from '../lib/ssh-tunnel.js';
 import { registerActionCommands, withClient, unwrap, pickTarget, type AppInfo } from './computer-actions.js';
 
 // Help groups — mirror `agents browser` so the mental model carries over.
@@ -28,15 +35,47 @@ const COMPUTER_HELP_GROUPS = [
   { title: 'Interact', names: ['launch', 'raise', 'click', 'right-click', 'type', 'type-text', 'key', 'drag', 'scroll', 'ax-action', 'focus', 'wait'] },
 ] as const;
 
+// Subcommands that manage the `--host` remote path themselves (provisioning /
+// tunnel lifecycle). Every other `--host`-bearing subcommand is a plain verb
+// that just needs the TCP endpoint hydrated before it runs.
+const REMOTE_LIFECYCLE = new Set(['setup', 'start', 'stop']);
+
+/**
+ * Pure platform gate. The computer subsystem is macOS-only for LOCAL driving
+ * (Accessibility / launchctl). It is NOT blocked off macOS when a remote daemon
+ * is reachable — either a configured TCP endpoint (COMPUTER_HELPER_TCP, e.g. a
+ * Windows daemon over a tunnel) or a `--host <device>` remote invocation. Kept
+ * pure so the gating rule is unit-testable without a live command tree.
+ */
+export function shouldBlockOffPlatform(opts: {
+  platform: NodeJS.Platform;
+  tcpConfigured: boolean;
+  host?: string;
+}): boolean {
+  if (opts.platform === 'darwin') return false;
+  if (opts.tcpConfigured) return false; // remote (Windows) daemon over a tunnel
+  if (opts.host) return false; // remote path resolves its own endpoint
+  return true;
+}
+
 export function registerComputerCommand(program: Command): void {
   const computer = program
     .command('computer')
-    .description('Drive macOS apps via Accessibility — list, screenshot, click, type (macOS only)')
-    // The whole subsystem is macOS Accessibility / TCC. Fail fast with a clear
-    // message on other platforms instead of a downstream ENOENT / launchctl error.
-    .hook('preAction', () => {
-      if (process.platform !== 'darwin') {
-        console.error('agents computer: macOS only — it drives apps via the macOS Accessibility API.');
+    .description('Drive macOS apps via Accessibility, or a remote Windows host with --host — list, screenshot, click, type')
+    // The whole subsystem is macOS Accessibility / TCC for LOCAL driving. Off
+    // macOS it still works against a remote daemon (COMPUTER_HELPER_TCP set, or
+    // a `--host <device>` invocation). Fail fast with a clear message only when
+    // neither remote path is available, instead of a downstream launchctl error.
+    .hook('preAction', async (_thisCommand, actionCommand) => {
+      const host = actionCommand.opts().host as string | undefined;
+      // Verbs with --host reconnect to the tunnel `start --host` recorded; this
+      // sets COMPUTER_HELPER_TCP so the shared client picks the TCP transport.
+      if (host && !REMOTE_LIFECYCLE.has(actionCommand.name())) {
+        hydrateRemoteEnvFromState(host);
+      }
+      if (shouldBlockOffPlatform({ platform: process.platform, tcpConfigured: resolveTcpEndpoint() != null, host })) {
+        console.error('agents computer: macOS only for local driving — it uses the macOS Accessibility API.');
+        console.error('For a remote Windows host: register it with `agents devices`, then use --host (or set COMPUTER_HELPER_TCP).');
         process.exit(1);
       }
     });
@@ -117,6 +156,7 @@ function registerScreenshotCommand(program: Command): void {
     .description('Capture a window (default: largest), enumerate windows (--list), or the whole display (--display)')
     .option('--bundle <id>', 'Bundle id to capture (default: frontmost allow-listed app)')
     .option('--pid <n>', 'Target pid directly (overrides --bundle)', (v) => parseInt(v, 10))
+    .option('--host <device>', 'Drive a remote Windows device (requires `agents computer start --host <device>` first)')
     .option('--list', 'List the app\'s windows (id/title/layer/bounds) instead of capturing — reveals modals/popups')
     .option('--window-id <n>', 'Capture a specific window by id (from --list)', (v) => parseInt(v, 10))
     .option('--display', 'Capture the whole display the app is on (composites stacked modals)')
@@ -126,6 +166,7 @@ function registerScreenshotCommand(program: Command): void {
     .action(async (opts: {
       bundle?: string;
       pid?: number;
+      host?: string;
       list?: boolean;
       windowId?: number;
       display?: boolean;
@@ -215,8 +256,23 @@ function registerSetupCommand(program: Command): void {
   program
     .command('setup')
     .alias('install-helper')
-    .description('Install ComputerHelper.app to /Applications/ (does NOT activate the daemon — run `start` to enable)')
-    .action(async () => {
+    .description('Install the helper — locally to /Applications/ (macOS), or to a remote Windows host with --host')
+    .option('--host <device>', 'Provision a remote Windows device (push the exe + register a LOGON task) instead of installing locally')
+    .action(async (opts: { host?: string }) => {
+      if (opts.host) {
+        try {
+          const { target, taskName } = await setupRemoteHelper(opts.host);
+          console.log(`pushed computer-helper-win.exe to ${target}`);
+          console.log(`registered LOGON scheduled task "${taskName}" (interactive session, started now)`);
+          console.log('');
+          console.log(`Next:  agents computer start --host ${opts.host}`);
+        } catch (err) {
+          console.error(`error: ${(err as Error).message}`);
+          process.exit(1);
+        }
+        return;
+      }
+
       const srcApp = resolveHelperApp();
       if (!srcApp || !fs.existsSync(srcApp)) {
         console.error('helper not built. Run: ./packages/computer-helper/scripts/build.sh debug');
@@ -305,8 +361,24 @@ function registerSetupCommand(program: Command): void {
 function registerStartCommand(program: Command): void {
   program
     .command('start')
-    .description('Activate the helper daemon (loads launchd, opens socket)')
-    .action(async () => {
+    .description('Activate the helper daemon — local launchd (macOS) or a remote Windows tunnel with --host')
+    .option('--host <device>', 'Open a tunnel to the remote Windows daemon and record it for --host verbs')
+    .action(async (opts: { host?: string }) => {
+      if (opts.host) {
+        try {
+          const state = await startRemoteTunnel(opts.host);
+          console.log(`tunnel: 127.0.0.1:${state.localPort} -> ${state.target} (127.0.0.1:${state.remotePort})`);
+          console.log(`daemon: answering (ssh pid ${state.tunnelPid})`);
+          console.log('');
+          console.log(`Drive it:  agents computer apps --host ${opts.host}`);
+          console.log(`Stop:      agents computer stop --host ${opts.host}`);
+        } catch (err) {
+          console.error(`error: ${(err as Error).message}`);
+          process.exit(1);
+        }
+        return;
+      }
+
       const home = os.homedir();
       const plistPath = path.join(home, 'Library', 'LaunchAgents', `${HELPER_LABEL}.plist`);
       const socketPath = resolveSocketPath();
@@ -488,8 +560,21 @@ function registerReloadCommand(program: Command): void {
 function registerStopCommand(program: Command): void {
   program
     .command('stop')
-    .description('Deactivate the helper daemon (bootout, removes socket)')
-    .action(async () => {
+    .description('Deactivate the helper daemon — local launchd (macOS) or a remote Windows tunnel with --host')
+    .option('--host <device>', 'Tear down the remote tunnel and unregister the scheduled task')
+    .action(async (opts: { host?: string }) => {
+      if (opts.host) {
+        try {
+          const { tunnelKilled, taskRemoved } = await stopRemoteHelper(opts.host);
+          console.log(`tunnel: ${tunnelKilled ? 'closed' : 'not running'}`);
+          console.log(`task:   ${taskRemoved ? 'unregistered' : 'not removed (device offline?)'}`);
+        } catch (err) {
+          console.error(`error: ${(err as Error).message}`);
+          process.exit(1);
+        }
+        return;
+      }
+
       const home = os.homedir();
       const plistPath = path.join(home, 'Library', 'LaunchAgents', `${HELPER_LABEL}.plist`);
       const socketPath = resolveSocketPath();

--- a/src/lib/browser/drivers/ssh.ts
+++ b/src/lib/browser/drivers/ssh.ts
@@ -9,6 +9,10 @@ import type { BrowserProfile } from '../types.js';
 // so existing importers of `shellQuote` from this module keep working.
 import { shellQuote } from '../../ssh-exec.js';
 export { shellQuote };
+// The `ssh -L` tunnel spawn is shared with `agents computer --host`; it lives in
+// the single ssh-tunnel helper. Calling it with no options preserves this
+// driver's original foreground, stderr-captured behavior exactly.
+import { startSSHTunnel } from '../../ssh-tunnel.js';
 
 export interface SSHConnection {
   cdp: CDPClient;
@@ -129,50 +133,6 @@ export async function connectSSH(
       clearProfileRuntime(profile.name);
     },
   };
-}
-
-function startSSHTunnel(
-  user: string,
-  host: string,
-  localPort: number,
-  remotePort: number
-): Promise<ChildProcess> {
-  return new Promise((resolve, reject) => {
-    const args = [
-      '-L',
-      `${localPort}:127.0.0.1:${remotePort}`,
-      `${user}@${host}`,
-      '-N',
-      '-o',
-      'StrictHostKeyChecking=accept-new',
-      '-o',
-      'BatchMode=yes',
-      '-o',
-      'ConnectTimeout=10',
-    ];
-
-    const tunnel = spawn('ssh', args, {
-      stdio: ['ignore', 'ignore', 'pipe'],
-      detached: false,
-    });
-
-    let stderr = '';
-    tunnel.stderr?.on('data', (data) => {
-      stderr += data.toString();
-    });
-
-    tunnel.on('error', (err) => {
-      reject(new Error(`SSH tunnel failed: ${err.message}`));
-    });
-
-    setTimeout(() => {
-      if (tunnel.killed) {
-        reject(new Error(`SSH tunnel died: ${stderr}`));
-      } else {
-        resolve(tunnel);
-      }
-    }, 500);
-  });
 }
 
 async function waitForPort(port: number, timeoutMs: number): Promise<void> {

--- a/src/lib/computer-rpc.test.ts
+++ b/src/lib/computer-rpc.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { describeTransport, resolveTcpEndpoint } from './computer-rpc.js';
+
+// Snapshot + restore the two env vars the TCP transport reads so tests don't
+// leak into each other (or into the rest of the suite).
+const SAVED = {
+  tcp: process.env.COMPUTER_HELPER_TCP,
+  token: process.env.COMPUTER_HELPER_TOKEN,
+};
+afterEach(() => {
+  if (SAVED.tcp === undefined) delete process.env.COMPUTER_HELPER_TCP;
+  else process.env.COMPUTER_HELPER_TCP = SAVED.tcp;
+  if (SAVED.token === undefined) delete process.env.COMPUTER_HELPER_TOKEN;
+  else process.env.COMPUTER_HELPER_TOKEN = SAVED.token;
+});
+
+describe('resolveTcpEndpoint', () => {
+  it('is null when COMPUTER_HELPER_TCP is unset', () => {
+    delete process.env.COMPUTER_HELPER_TCP;
+    expect(resolveTcpEndpoint()).toBeNull();
+  });
+
+  it('parses host:port and defaults the host to loopback for a bare port', () => {
+    process.env.COMPUTER_HELPER_TCP = '9999';
+    delete process.env.COMPUTER_HELPER_TOKEN;
+    expect(resolveTcpEndpoint()).toEqual({ host: '127.0.0.1', port: 9999, token: null });
+
+    process.env.COMPUTER_HELPER_TCP = '10.0.0.4:8765';
+    process.env.COMPUTER_HELPER_TOKEN = 'sekret';
+    expect(resolveTcpEndpoint()).toEqual({ host: '10.0.0.4', port: 8765, token: 'sekret' });
+  });
+
+  it('rejects a non-numeric / non-positive port', () => {
+    process.env.COMPUTER_HELPER_TCP = 'localhost:notaport';
+    expect(resolveTcpEndpoint()).toBeNull();
+  });
+});
+
+describe('describeTransport', () => {
+  it('reports the tcp transport when COMPUTER_HELPER_TCP is set', () => {
+    // This is exactly what withClient() guards on: kind !== 'none' means it
+    // opens the client instead of exiting with "helper not built". Setting the
+    // env var must flip the transport to tcp even off macOS (no socket, no .app).
+    process.env.COMPUTER_HELPER_TCP = '127.0.0.1:8765';
+    const t = describeTransport();
+    expect(t.kind).toBe('tcp');
+    expect(t.kind).not.toBe('none');
+    expect(t.path).toBeNull();
+  });
+
+  it('TCP takes precedence over every other transport', () => {
+    // Even if a local socket/app existed, an explicit endpoint wins — mirrors
+    // openComputerClient()'s precedence so status and driving agree.
+    process.env.COMPUTER_HELPER_TCP = '127.0.0.1:8765';
+    expect(describeTransport().kind).toBe('tcp');
+  });
+});

--- a/src/lib/computer-rpc.ts
+++ b/src/lib/computer-rpc.ts
@@ -433,8 +433,13 @@ class StdioClient extends BaseClient {
 }
 
 // Describe which transport is currently in use. Useful for diagnostics
-// like `agents computer status`.
-export function describeTransport(): { kind: 'socket' | 'stdio' | 'none'; path: string | null } {
+// like `agents computer status`. TCP takes precedence to match
+// openComputerClient() — when COMPUTER_HELPER_TCP is set we drive a remote
+// (Windows) daemon over a tunnel, so callers off macOS (no socket, no local
+// .app) must not be told "no transport". `path` is null: the endpoint is an
+// env-configured host:port, not an on-disk path.
+export function describeTransport(): { kind: 'socket' | 'stdio' | 'tcp' | 'none'; path: string | null } {
+  if (resolveTcpEndpoint()) return { kind: 'tcp', path: null };
   const sockPath = resolveSocketPath();
   if (fs.existsSync(sockPath)) return { kind: 'socket', path: sockPath };
   const exec = resolveHelperExec();

--- a/src/lib/ssh-tunnel.test.ts
+++ b/src/lib/ssh-tunnel.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  buildTunnelArgs,
+  buildPushScript,
+  buildRegisterTaskScript,
+  buildUnregisterTaskScript,
+  pickFreePort,
+  readRemoteState,
+  writeRemoteState,
+  clearRemoteState,
+  REMOTE_HELPER_PORT,
+  REMOTE_TASK_NAME,
+  WIN_HELPER_EXE,
+} from './ssh-tunnel.js';
+import { encodePowerShell } from './browser/drivers/ssh.js';
+
+describe('buildTunnelArgs', () => {
+  it('forwards localPort to the remote loopback port and stays hardened', () => {
+    const args = buildTunnelArgs('muqsit', 'win-mini', 55000, 8765);
+    // The -L mapping is the whole point: local -> 127.0.0.1:remote on the box.
+    expect(args).toContain('-L');
+    expect(args).toContain('55000:127.0.0.1:8765');
+    expect(args).toContain('muqsit@win-mini');
+    expect(args).toContain('-N'); // no remote command, just forwarding
+    expect(args.join(' ')).toContain('StrictHostKeyChecking=accept-new');
+    expect(args.join(' ')).toContain('BatchMode=yes');
+    expect(args.join(' ')).toContain('ConnectTimeout=10');
+  });
+
+  it('matches the args the browser driver historically spawned (behavior unchanged)', () => {
+    // The browser CDP driver used exactly this argv shape before extraction.
+    expect(buildTunnelArgs('u', 'h', 9222, 9222)).toEqual([
+      '-L',
+      '9222:127.0.0.1:9222',
+      'u@h',
+      '-N',
+      '-o',
+      'StrictHostKeyChecking=accept-new',
+      '-o',
+      'BatchMode=yes',
+      '-o',
+      'ConnectTimeout=10',
+    ]);
+  });
+});
+
+describe('buildPushScript', () => {
+  it('streams a base64 decode from stdin to %LOCALAPPDATA%\\agents (memory-safe)', () => {
+    const s = buildPushScript();
+    expect(s).toContain('$env:LOCALAPPDATA');
+    expect(s).toContain(WIN_HELPER_EXE);
+    // Streaming decode — not a single giant [Convert]::FromBase64String string.
+    expect(s).toContain('FromBase64Transform');
+    expect(s).toContain('CryptoStream');
+    expect(s).toContain('OpenStandardInput');
+    expect(s).not.toContain('FromBase64String');
+  });
+
+  it('stops a running instance first so the exe file is not locked', () => {
+    expect(buildPushScript()).toContain("Stop-Process");
+  });
+
+  it('rides through ssh as a single quote-free EncodedCommand token', () => {
+    const b64 = encodePowerShell(buildPushScript()).replace('powershell -NoProfile -EncodedCommand ', '');
+    expect(b64).toMatch(/^[A-Za-z0-9+/=]+$/);
+  });
+});
+
+describe('buildRegisterTaskScript', () => {
+  it('registers an interactive LOGON task running the exe with --port', () => {
+    const s = buildRegisterTaskScript(REMOTE_HELPER_PORT, REMOTE_TASK_NAME);
+    expect(s).toContain('-AtLogOn'); // survives ssh disconnect
+    expect(s).toContain('-LogonType Interactive'); // real desktop session for UIA/screenshot
+    expect(s).toContain('-RunLevel Highest');
+    expect(s).toContain(`--port ${REMOTE_HELPER_PORT}`);
+    expect(s).toContain(REMOTE_TASK_NAME);
+    expect(s).toContain('Register-ScheduledTask');
+    expect(s).toContain('Start-ScheduledTask'); // start now, no logout/in
+    expect(s).toContain(WIN_HELPER_EXE);
+  });
+});
+
+describe('buildUnregisterTaskScript', () => {
+  it('unregisters the task and stops the daemon process', () => {
+    const s = buildUnregisterTaskScript(REMOTE_TASK_NAME);
+    expect(s).toContain('Unregister-ScheduledTask');
+    expect(s).toContain(REMOTE_TASK_NAME);
+    expect(s).toContain('Stop-Process');
+  });
+});
+
+describe('pickFreePort', () => {
+  it('reserves a real, positive, unprivileged local port', async () => {
+    const p = await pickFreePort();
+    expect(Number.isInteger(p)).toBe(true);
+    expect(p).toBeGreaterThan(1024);
+  });
+});
+
+describe('remote tunnel state round-trip', () => {
+  const device = '__ssh_tunnel_test_device__';
+  afterEach(() => clearRemoteState(device));
+
+  it('persists and reloads a tunnel record, then clears it', () => {
+    expect(readRemoteState(device)).toBeNull();
+    writeRemoteState({
+      device,
+      target: 'muqsit@win-mini',
+      localPort: 55001,
+      remotePort: REMOTE_HELPER_PORT,
+      tunnelPid: 4242,
+      token: null,
+      taskName: REMOTE_TASK_NAME,
+      startedAt: 1_700_000_000_000,
+    });
+    const got = readRemoteState(device);
+    expect(got?.localPort).toBe(55001);
+    expect(got?.target).toBe('muqsit@win-mini');
+    clearRemoteState(device);
+    expect(readRemoteState(device)).toBeNull();
+  });
+});

--- a/src/lib/ssh-tunnel.ts
+++ b/src/lib/ssh-tunnel.ts
@@ -1,0 +1,407 @@
+/**
+ * Shared SSH port-forward tunnel + remote computer-helper provisioning.
+ *
+ * Two layers live here:
+ *
+ *  1. `startSSHTunnel` — the generic `ssh -L localPort:127.0.0.1:remotePort -N`
+ *     spawn, extracted verbatim from the browser CDP driver so both the browser
+ *     and `agents computer --host` reach a remote loopback service through one
+ *     hardened tunnel. Behavior for the browser caller is unchanged (default,
+ *     foreground, stderr-captured).
+ *
+ *  2. Remote computer-helper orchestration — resolve a registered device to an
+ *     ssh target, push the cross-published Windows daemon exe, register it as a
+ *     LOGON scheduled task (interactive session so real-desktop UIA/screenshot
+ *     works and it survives the ssh disconnect), and open a tunnel the TS RPC
+ *     client drives via TCP. Everything rides the existing `ssh-exec` /
+ *     `devices/connect` primitives — no parallel SSH implementation.
+ */
+
+import { spawn, type ChildProcess } from 'child_process';
+import * as net from 'net';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { randomBytes } from 'crypto';
+import { sshExec } from './ssh-exec.js';
+import { encodePowerShell } from './browser/drivers/ssh.js';
+import { getDevice, type DeviceProfile } from './devices/registry.js';
+import { sshTargetFor } from './devices/connect.js';
+import { hostNameFor } from './devices/ssh-config.js';
+import { getCacheDir } from './state.js';
+import { openComputerClient, resolveTcpEndpoint, type ComputerClient } from './computer-rpc.js';
+
+// ---------------------------------------------------------------------------
+// 1. Generic ssh -L tunnel (shared with the browser CDP driver)
+// ---------------------------------------------------------------------------
+
+export interface StartTunnelOptions {
+  /**
+   * Detach the tunnel so it OUTLIVES this CLI process. Used by
+   * `agents computer start --host` — the tunnel must persist across separate
+   * verb invocations (`apps`, `click`, …) until `stop --host` tears it down.
+   * The browser driver leaves this false: it holds the tunnel for the lifetime
+   * of one CDP session and kills it on cleanup.
+   */
+  detached?: boolean;
+}
+
+/** Build the ssh argv (after the `ssh` program name) for an `-L` tunnel. Pure. */
+export function buildTunnelArgs(
+  user: string,
+  host: string,
+  localPort: number,
+  remotePort: number,
+): string[] {
+  return [
+    '-L',
+    `${localPort}:127.0.0.1:${remotePort}`,
+    `${user}@${host}`,
+    '-N',
+    '-o',
+    'StrictHostKeyChecking=accept-new',
+    '-o',
+    'BatchMode=yes',
+    '-o',
+    'ConnectTimeout=10',
+  ];
+}
+
+/**
+ * Spawn `ssh -L localPort:127.0.0.1:remotePort -N user@host`.
+ *
+ * Foreground (default): stderr is captured so a tunnel that dies inside 500ms
+ * rejects with the ssh error — the browser driver's original contract. Detached
+ * mode ignores stdio and `unref`s the child so the parent can exit while the
+ * tunnel lives; liveness is then confirmed by the caller probing the service.
+ */
+export function startSSHTunnel(
+  user: string,
+  host: string,
+  localPort: number,
+  remotePort: number,
+  opts: StartTunnelOptions = {},
+): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const args = buildTunnelArgs(user, host, localPort, remotePort);
+
+    const tunnel = spawn('ssh', args, {
+      stdio: opts.detached ? 'ignore' : ['ignore', 'ignore', 'pipe'],
+      detached: Boolean(opts.detached),
+    });
+
+    let stderr = '';
+    tunnel.stderr?.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    tunnel.on('error', (err) => {
+      reject(new Error(`SSH tunnel failed: ${err.message}`));
+    });
+
+    setTimeout(() => {
+      if (tunnel.killed) {
+        reject(new Error(`SSH tunnel died: ${stderr}`));
+      } else {
+        // Let the CLI exit without waiting on a persistent tunnel.
+        if (opts.detached) tunnel.unref();
+        resolve(tunnel);
+      }
+    }, 500);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 2. Remote computer-helper orchestration
+// ---------------------------------------------------------------------------
+
+/** Loopback TCP port the Windows daemon binds on the remote (Program.cs default). */
+export const REMOTE_HELPER_PORT = 8765;
+
+/** Task Scheduler task name for the daemon. Stable so setup/stop pair up. */
+export const REMOTE_TASK_NAME = 'AgentsComputerHelper';
+
+/** Basename of the cross-published exe under packages/computer-helper-win/dist. */
+export const WIN_HELPER_EXE = 'computer-helper-win.exe';
+
+/**
+ * Locate the cross-published Windows daemon exe. Only the local build output is
+ * a candidate — `scripts/build-win.sh` writes it to packages/.../dist/.
+ */
+export function resolveWinHelperExe(): string | null {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    // Running from the agents-cli checkout (src/lib -> repo root).
+    path.resolve(here, '..', '..', 'packages', 'computer-helper-win', 'dist', WIN_HELPER_EXE),
+    // Bundled with the npm package (dist/lib -> package root).
+    path.resolve(here, '..', 'computer-helper-win', WIN_HELPER_EXE),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  return null;
+}
+
+/** Persisted per-device tunnel state so verbs can reconnect after `start --host`. */
+export interface RemoteTunnelState {
+  device: string;
+  target: string;
+  localPort: number;
+  remotePort: number;
+  tunnelPid: number;
+  token: string | null;
+  taskName: string;
+  startedAt: number;
+}
+
+function remoteStateDir(): string {
+  return path.join(getCacheDir(), 'computer', 'remote');
+}
+
+/** State file path for a device. Device names are ssh-alias safe (validated). */
+export function remoteStatePath(device: string): string {
+  return path.join(remoteStateDir(), `${device}.json`);
+}
+
+export function readRemoteState(device: string): RemoteTunnelState | null {
+  try {
+    return JSON.parse(fs.readFileSync(remoteStatePath(device), 'utf-8')) as RemoteTunnelState;
+  } catch {
+    return null;
+  }
+}
+
+export function writeRemoteState(state: RemoteTunnelState): void {
+  const dir = remoteStateDir();
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(remoteStatePath(state.device), JSON.stringify(state, null, 2), { mode: 0o600 });
+}
+
+export function clearRemoteState(device: string): void {
+  try {
+    fs.unlinkSync(remoteStatePath(device));
+  } catch {
+    /* already gone */
+  }
+}
+
+/** Resolve a registered device to its ssh pieces, or throw a clear error. */
+export async function resolveRemoteDevice(
+  name: string,
+): Promise<{ device: DeviceProfile; target: string; user: string; host: string }> {
+  const device = await getDevice(name);
+  if (!device) {
+    throw new Error(`Unknown device '${name}'. Register it with \`agents devices add\` / \`agents devices sync\`, then retry.`);
+  }
+  if (device.platform !== 'windows') {
+    throw new Error(`Device '${name}' is ${device.platform}, not windows. \`agents computer --host\` drives the Windows computer-helper daemon.`);
+  }
+  const target = sshTargetFor(device); // validates address + injection guard
+  const host = hostNameFor(device)!; // sshTargetFor already threw if absent
+  const user = device.user || process.env.USER || 'Administrator';
+  return { device, target, user, host };
+}
+
+/**
+ * PowerShell that streams base64 from stdin, decodes it incrementally to
+ * %LOCALAPPDATA%\agents\computer-helper-win.exe, and stops any running instance
+ * first so the file isn't locked. The CryptoStream/FromBase64Transform decode
+ * is streaming — the ~156MB exe never lands in memory whole on the remote.
+ */
+export function buildPushScript(): string {
+  return [
+    `$dir = Join-Path $env:LOCALAPPDATA 'agents'`,
+    `New-Item -ItemType Directory -Force -Path $dir | Out-Null`,
+    `$dst = Join-Path $dir '${WIN_HELPER_EXE}'`,
+    `Get-Process -Name 'computer-helper-win' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue`,
+    `$si = [Console]::OpenStandardInput()`,
+    `$t = New-Object Security.Cryptography.FromBase64Transform`,
+    `$cs = New-Object Security.Cryptography.CryptoStream($si, $t, [Security.Cryptography.CryptoStreamMode]::Read)`,
+    `$fs = [IO.File]::Create($dst)`,
+    `$cs.CopyTo($fs)`,
+    `$fs.Close(); $cs.Close()`,
+    `Write-Output $dst`,
+  ].join('; ');
+}
+
+/**
+ * PowerShell that registers the daemon as a LOGON scheduled task. Interactive
+ * logon type + Highest run level so the daemon runs in the real desktop session
+ * (UIAutomation and ScreenCapture need a live session, not Session 0) and
+ * survives ssh disconnect — the same rationale as the browser WMI launch. The
+ * task is started immediately so the caller need not log out/in.
+ */
+export function buildRegisterTaskScript(port: number, taskName: string): string {
+  return [
+    `$exe = Join-Path (Join-Path $env:LOCALAPPDATA 'agents') '${WIN_HELPER_EXE}'`,
+    `$action = New-ScheduledTaskAction -Execute $exe -Argument '--port ${port}'`,
+    `$trigger = New-ScheduledTaskTrigger -AtLogOn`,
+    `$principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Highest`,
+    `$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit ([TimeSpan]::Zero)`,
+    `Register-ScheduledTask -TaskName '${taskName}' -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Force | Out-Null`,
+    `Start-ScheduledTask -TaskName '${taskName}'`,
+  ].join('; ');
+}
+
+/** PowerShell that unregisters the task and stops any running daemon process. */
+export function buildUnregisterTaskScript(taskName: string): string {
+  return [
+    `Unregister-ScheduledTask -TaskName '${taskName}' -Confirm:$false -ErrorAction SilentlyContinue`,
+    `Get-Process -Name 'computer-helper-win' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue`,
+  ].join('; ');
+}
+
+/**
+ * `setup --host`: push the exe, then register + start the LOGON task. Both hops
+ * go through `sshExec` (BatchMode key auth — the same hardening the browser
+ * driver and `agents ssh` use). Throws with the remote stderr on any failure.
+ */
+export async function setupRemoteHelper(name: string): Promise<{ target: string; taskName: string }> {
+  const { target } = await resolveRemoteDevice(name);
+
+  const exe = resolveWinHelperExe();
+  if (!exe) {
+    throw new Error(`Windows helper exe not built. Run: bash scripts/build-win.sh`);
+  }
+
+  // Push: base64 the exe locally, stream it over ssh stdin to the decoder.
+  const b64 = fs.readFileSync(exe).toString('base64');
+  const push = sshExec(target, encodePowerShell(buildPushScript()), {
+    input: b64,
+    timeoutMs: 600_000, // ~156MB over the wire — allow up to 10 minutes
+  });
+  if (push.code !== 0) {
+    throw new Error(`pushing helper exe to '${name}' failed (exit ${push.code ?? 'null'}): ${push.stderr.trim() || push.stdout.trim()}`);
+  }
+
+  // Register + start the LOGON task.
+  const reg = sshExec(target, encodePowerShell(buildRegisterTaskScript(REMOTE_HELPER_PORT, REMOTE_TASK_NAME)), {
+    timeoutMs: 60_000,
+  });
+  if (reg.code !== 0) {
+    throw new Error(`registering scheduled task on '${name}' failed (exit ${reg.code ?? 'null'}): ${reg.stderr.trim() || reg.stdout.trim()}`);
+  }
+
+  return { target, taskName: REMOTE_TASK_NAME };
+}
+
+/** Reserve a free local TCP port by binding :0 and reading the assigned port. */
+export function pickFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      srv.close(() => (port ? resolve(port) : reject(new Error('could not reserve a local port'))));
+    });
+  });
+}
+
+/**
+ * `start --host`: open a detached ssh -L tunnel to the remote daemon, verify it
+ * answers over TCP, and persist the tunnel state so verbs can reconnect. Returns
+ * the state (and leaves the tunnel running in the background).
+ */
+export async function startRemoteTunnel(name: string): Promise<RemoteTunnelState> {
+  const { target, user, host } = await resolveRemoteDevice(name);
+  const remotePort = REMOTE_HELPER_PORT;
+  const localPort = await pickFreePort();
+
+  const tunnel = await startSSHTunnel(user, host, localPort, remotePort, { detached: true });
+  const tunnelPid = tunnel.pid ?? 0;
+
+  // Verify the daemon answers through the tunnel before we record it. This is
+  // the real end-to-end check: tunnel up + daemon listening + RPC round-trips.
+  const token: string | null = null; // tunnel-gated; the daemon runs token-less
+  const prevTcp = process.env.COMPUTER_HELPER_TCP;
+  process.env.COMPUTER_HELPER_TCP = `127.0.0.1:${localPort}`;
+  const client = openComputerClient();
+  let ok = false;
+  let probeErr = '';
+  try {
+    const r = await client.call('list_apps');
+    ok = !r.error;
+    if (r.error) probeErr = `${r.error.code}: ${r.error.message}`;
+  } catch (e) {
+    probeErr = (e as Error).message;
+  } finally {
+    await client.close();
+    if (prevTcp === undefined) delete process.env.COMPUTER_HELPER_TCP;
+    else process.env.COMPUTER_HELPER_TCP = prevTcp;
+  }
+  if (!ok) {
+    try { if (tunnelPid) process.kill(tunnelPid); } catch { /* gone */ }
+    throw new Error(
+      `tunnel to '${name}' opened but the daemon did not answer (${probeErr}). ` +
+        `Is it installed? Run: agents computer setup --host ${name}`,
+    );
+  }
+
+  const state: RemoteTunnelState = {
+    device: name,
+    target,
+    localPort,
+    remotePort,
+    tunnelPid,
+    token,
+    taskName: REMOTE_TASK_NAME,
+    startedAt: Date.now(),
+  };
+  writeRemoteState(state);
+  return state;
+}
+
+/**
+ * `stop --host`: kill the local tunnel, unregister the remote task (best-effort
+ * — the box may be offline), and clear the persisted state.
+ */
+export async function stopRemoteHelper(name: string): Promise<{ tunnelKilled: boolean; taskRemoved: boolean }> {
+  const state = readRemoteState(name);
+  let tunnelKilled = false;
+  if (state?.tunnelPid) {
+    try {
+      process.kill(state.tunnelPid);
+      tunnelKilled = true;
+    } catch {
+      /* already gone */
+    }
+  }
+
+  let taskRemoved = false;
+  try {
+    const { target } = await resolveRemoteDevice(name);
+    const res = sshExec(target, encodePowerShell(buildUnregisterTaskScript(REMOTE_TASK_NAME)), { timeoutMs: 60_000 });
+    taskRemoved = res.code === 0;
+  } catch {
+    /* device gone / offline — local teardown still succeeds */
+  }
+
+  clearRemoteState(name);
+  return { tunnelKilled, taskRemoved };
+}
+
+/**
+ * Point this process's RPC client at a device's live tunnel by setting
+ * COMPUTER_HELPER_TCP / COMPUTER_HELPER_TOKEN from persisted state. Called for
+ * remote verbs (`apps --host`, `click --host`, …) so the shared
+ * openComputerClient() transparently selects the TcpClient transport — no
+ * per-verb wiring. Exits with guidance when there is no active tunnel.
+ */
+export function hydrateRemoteEnvFromState(name: string): void {
+  const state = readRemoteState(name);
+  if (!state) {
+    console.error(`No active remote tunnel for '${name}'.`);
+    console.error(`Run:  agents computer start --host ${name}`);
+    process.exit(1);
+  }
+  process.env.COMPUTER_HELPER_TCP = `127.0.0.1:${state.localPort}`;
+  if (state.token) process.env.COMPUTER_HELPER_TOKEN = state.token;
+  // Touch resolveTcpEndpoint so a later platform-gate check sees the endpoint.
+  void resolveTcpEndpoint();
+}
+
+/** Generate a shared-secret token (reserved for token-file provisioning). */
+export function generateToken(): string {
+  return randomBytes(24).toString('hex');
+}


### PR DESCRIPTION
## What

Makes `agents computer` drivable **off macOS** and against a **remote Windows host over SSH**, and adds the cross-publish build script for the Windows daemon.

The TS TCP transport already existed (`TcpClient`, `resolveTcpEndpoint`, `openComputerClient` precedence in `src/lib/computer-rpc.ts`) — this PR fixes the two wiring bugs that kept it unreachable and adds remote provisioning + tunneling.

## Changes

**1. `describeTransport` (`src/lib/computer-rpc.ts`)** — added `'tcp'` to the return union and a leading `if (resolveTcpEndpoint()) return { kind: 'tcp', path: null }`. `withClient`'s `describeTransport().kind === 'none'` guard (`computer-actions.ts:157`) no longer false-exits when `COMPUTER_HELPER_TCP` is set.

**2. Platform gate (`src/commands/computer.ts`)** — the blanket non-darwin `preAction` exit is now a pure, unit-tested predicate `shouldBlockOffPlatform({ platform, tcpConfigured, host })`. Off-macOS is allowed when a TCP endpoint is configured **or** a `--host <device>` remote invocation is in play. The launchctl-based lifecycle (setup/start/stop local paths) stays darwin-only.

**3. `scripts/build-win.sh`** — cross-publishes the self-contained single-file `win-x64` exe from Linux/macOS (`EnableWindowsTargeting` is already in the csproj), emitting `packages/computer-helper-win/dist/computer-helper-win.exe`. Verified: **164,617,914 bytes (~157 MB)**.

**4. Remote path `agents computer <verb|setup|start|stop> --host <device>`** — new `src/lib/ssh-tunnel.ts`:
- `startSSHTunnel` **extracted** from the browser CDP driver (`src/lib/browser/drivers/ssh.ts`); the driver now imports it (behavior unchanged — browser tests still pass).
- Device resolved via `getDevice()` (platform must be `windows`) → ssh target via `sshTargetFor`.
- `setup --host`: push the exe over ssh (`sshExec` + streaming base64 decoder — memory-safe for the 157 MB file) and register an **interactive LOGON** Task Scheduler task (`encodePowerShell`) so real-desktop UIA/screenshot works and it survives ssh disconnect.
- `start --host`: open a detached `ssh -L`, verify the daemon answers over TCP, record the tunnel.
- verbs `--host`: the `preAction` hook hydrates `COMPUTER_HELPER_TCP` from the recorded tunnel, so the shared `openComputerClient()` picks the TCP transport with **zero per-verb wiring**.
- `stop --host`: tear down the tunnel + unregister the task.
- Reuses `ssh-exec` / `devices/connect` / `encodePowerShell` — **no parallel SSH implementation**.

## Tests

- `src/lib/computer-rpc.test.ts` — `describeTransport` returns `'tcp'` (≠ `'none'`, so `withClient` won't exit) when `COMPUTER_HELPER_TCP` is set; `resolveTcpEndpoint` parsing.
- `src/commands/computer.test.ts` — `shouldBlockOffPlatform` allows off-macOS with TCP configured or `--host`, blocks otherwise.
- `src/lib/ssh-tunnel.test.ts` — tunnel argv shape (matches the browser driver's historical args), push/register/unregister PowerShell scripts, `pickFreePort`, state round-trip.

`bun run build` + `bun run test` green on Linux (the 4 failing `secrets/bundles-storage` tests are **pre-existing** — confirmed identical on `origin/main`, and this branch touches no secrets files).

### Verified end-to-end on Linux (tasks 1+2)

- `agents computer apps` → blocked (`macOS only`).
- `COMPUTER_HELPER_TCP=127.0.0.1:59999 agents computer apps` → gate passes, reaches TCP transport (`ECONNREFUSED`, not `macOS only`).
- `agents computer apps --host win-mini` → tunnel-not-active guidance.
- `agents computer setup --host <unknown>` → device-resolution error (remote path reached off-darwin).

Windows E2E against `win-mini` is the reviewer/user hand-off step (build the exe, `setup`/`start`/drive/`stop`).