### PR TITLE
fix(auth): persist droid/antigravity/kimi login across version switches (RUSH-1318)

### DIFF
--- a/src/lib/agents.test.ts
+++ b/src/lib/agents.test.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
 import { spawnSync } from 'child_process';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AGENTS, ALL_AGENT_IDS, getAccountInfo, resolveAgentName, resolveLastActive } from './agents.js';
 import { IS_WINDOWS } from './platform/index.js';
 import type { CapabilityName } from './types.js';
@@ -345,6 +345,20 @@ function makeJwt(payload: Record<string, unknown>): string {
 }
 
 describe('getAccountInfo — token-only agents (no local email)', () => {
+  // Sign-in is account-global: getAccountInfo falls back from the passed
+  // per-version home to the active config under AGENTS_REAL_HOME. Pin that to a
+  // fresh empty dir so "signed out" assertions don't leak into the developer's
+  // real ~/.factory / ~/.kimi-code / ~/.gemini login (RUSH-1318 fallback).
+  let prevRealHome: string | undefined;
+  beforeEach(() => {
+    prevRealHome = process.env.AGENTS_REAL_HOME;
+    process.env.AGENTS_REAL_HOME = makeTempDir();
+  });
+  afterEach(() => {
+    if (prevRealHome === undefined) delete process.env.AGENTS_REAL_HOME;
+    else process.env.AGENTS_REAL_HOME = prevRealHome;
+  });
+
   it('marks Antigravity signed in when a refresh token is present', async () => {
     const home = makeTempDir();
     const dir = path.join(home, '.gemini', 'antigravity-cli');

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -433,6 +433,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     npmPackage: '',
     installScript: 'curl -fsSL https://antigravity.google/cli/install.sh | bash',
     configDir: path.join(HOME, '.gemini', 'antigravity-cli'),
+    authFiles: ['antigravity-oauth-token'],
     commandsDir: path.join(HOME, '.gemini', 'antigravity-cli', 'commands'),
     commandsSubdir: 'commands',
     skillsDir: path.join(HOME, '.gemini', 'antigravity-cli', 'skills'),
@@ -493,6 +494,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     npmPackage: '@moonshot-ai/kimi-code',
     installScript: 'curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash',
     configDir: path.join(HOME, '.kimi-code'),
+    authFiles: ['credentials/kimi-code.json'],
     commandsDir: '',
     commandsSubdir: '',
     skillsDir: path.join(HOME, '.kimi-code', 'skills'),
@@ -532,6 +534,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     npmPackage: '',
     installScript: 'curl -fsSL https://app.factory.ai/cli | sh',
     configDir: path.join(HOME, '.factory'),
+    authFiles: ['auth.v2.file', 'auth.v2.key'],
     commandsDir: path.join(HOME, '.factory', 'commands'),
     commandsSubdir: 'commands',
     skillsDir: '', // no skills concept
@@ -846,6 +849,26 @@ export async function getAccountEmail(
  * Extract full account information (identity, plan, usage status, credits) from
  * the agent's local auth/config files. Supports Claude, Codex, and Gemini.
  */
+/**
+ * Resolve a file-auth agent's credential file. Sign-in is account-global, but
+ * each installed version gets an isolated home; the credential physically lives
+ * only in the home the user logged in under (the one the `~/.<config>` symlink
+ * targets). Check the per-version `base` first, then fall back to the active
+ * config location under the real HOME so every installed version reflects the
+ * true account state (droid/antigravity/kimi all stored login per-version-home
+ * and showed non-active versions as "not signed in"). Returns the first
+ * existing path, or null.
+ */
+function resolveAccountCredentialPath(base: string, ...segments: string[]): string | null {
+  const perVersion = path.join(base, ...segments);
+  try { if (fs.existsSync(perVersion)) return perVersion; } catch { /* unreadable */ }
+  const active = path.join(process.env.AGENTS_REAL_HOME || os.homedir(), ...segments);
+  if (active !== perVersion) {
+    try { if (fs.existsSync(active)) return active; } catch { /* unreadable */ }
+  }
+  return null;
+}
+
 export async function getAccountInfo(
   agentId: AgentId,
   home?: string
@@ -1008,8 +1031,8 @@ export async function getAccountInfo(
         // OAuth grant (access + refresh token, no id_token), so there's no email
         // claim to read locally — presence of a refresh token is the only
         // signed-in signal we can derive without a network call.
-        const tokenPath = path.join(base, '.gemini', 'antigravity-cli', 'antigravity-oauth-token');
-        if (!fs.existsSync(tokenPath)) return { ...empty, lastActive };
+        const tokenPath = resolveAccountCredentialPath(base, '.gemini', 'antigravity-cli', 'antigravity-oauth-token');
+        if (!tokenPath) return { ...empty, lastActive };
         const data = JSON.parse(await fs.promises.readFile(tokenPath, 'utf-8'));
         const hasToken =
           typeof data?.token?.refresh_token === 'string' && !!data.token.refresh_token;
@@ -1021,8 +1044,8 @@ export async function getAccountInfo(
         // ~/.kimi-code/credentials/kimi-code.json. The access token is a JWT
         // whose payload carries an opaque user_id (no email), so we report
         // signed-in state plus a stable account key for usage dedup.
-        const credPath = path.join(base, '.kimi-code', 'credentials', 'kimi-code.json');
-        if (!fs.existsSync(credPath)) return { ...empty, lastActive };
+        const credPath = resolveAccountCredentialPath(base, '.kimi-code', 'credentials', 'kimi-code.json');
+        if (!credPath) return { ...empty, lastActive };
         const data = JSON.parse(await fs.promises.readFile(credPath, 'utf-8'));
         const accessToken = data?.access_token;
         if (typeof accessToken !== 'string' || !accessToken) return { ...empty, lastActive };
@@ -1038,8 +1061,8 @@ export async function getAccountInfo(
         // network call — same pattern as antigravity/kimi. `.factory` is the
         // config dir on every platform (macOS/Linux ~/.factory, Windows
         // %USERPROFILE%\.factory), so path.join keeps this cross-platform.
-        const authPath = path.join(base, '.factory', 'auth.v2.file');
-        if (!fs.existsSync(authPath)) return { ...empty, lastActive };
+        const authPath = resolveAccountCredentialPath(base, '.factory', 'auth.v2.file');
+        if (!authPath) return { ...empty, lastActive };
         return { ...empty, signedIn: true, lastActive };
       }
       default:

--- a/src/lib/shims.auth-carry.test.ts
+++ b/src/lib/shims.auth-carry.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Auth persistence across version switches (RUSH-1318): droid/antigravity/kimi
+ * store login as files inside the per-version config home. Switching versions
+ * repoints the ~/.<config> symlink to a home that was never logged in, silently
+ * logging the CLI out. carryForwardAuthFiles seeds the target home with the
+ * freshest credential; getAccountInfo falls back to the active HOME config so
+ * non-active versions still report the account-global sign-in state.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let TEST_VERSIONS_DIR = '';
+let TEST_BACKUPS_DIR = '';
+
+vi.mock('./state.js', async () => {
+  const actual = await vi.importActual<typeof import('./state.js')>('./state.js');
+  return {
+    ...actual,
+    getVersionsDir: () => TEST_VERSIONS_DIR,
+    getBackupsDir: () => TEST_BACKUPS_DIR,
+    ensureAgentsDir: () => {},
+  };
+});
+
+import { switchConfigSymlink, carryForwardAuthFiles } from './shims.js';
+import { getAccountInfo } from './agents.js';
+
+const tempDirs: string[] = [];
+
+function makeHome(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'auth-carry-'));
+  tempDirs.push(root);
+  TEST_VERSIONS_DIR = path.join(root, '.agents', 'versions');
+  TEST_BACKUPS_DIR = path.join(root, '.agents', 'backups');
+  fs.mkdirSync(TEST_VERSIONS_DIR, { recursive: true });
+  process.env.AGENTS_REAL_HOME = root;
+  return root;
+}
+
+function droidHome(v: string): string {
+  const h = path.join(TEST_VERSIONS_DIR, 'droid', v, 'home');
+  fs.mkdirSync(path.join(h, '.factory'), { recursive: true });
+  return h;
+}
+
+function writeDroidAuth(home: string, body: string, mtimeMs?: number): void {
+  const dir = path.join(home, '.factory');
+  fs.writeFileSync(path.join(dir, 'auth.v2.file'), body, { mode: 0o600 });
+  fs.writeFileSync(path.join(dir, 'auth.v2.key'), 'KEY', { mode: 0o600 });
+  if (mtimeMs) {
+    const t = new Date(mtimeMs);
+    fs.utimesSync(path.join(dir, 'auth.v2.file'), t, t);
+    fs.utimesSync(path.join(dir, 'auth.v2.key'), t, t);
+  }
+}
+
+afterEach(() => {
+  delete process.env.AGENTS_REAL_HOME;
+  for (const d of tempDirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+describe('carryForwardAuthFiles / switchConfigSymlink — auth survives version switch (RUSH-1318)', () => {
+  let home: string;
+  beforeEach(() => { home = makeHome(); });
+
+  it('carries droid auth.v2.file + auth.v2.key into the version being switched to, preserving 0600, leaving source intact', async () => {
+    const v1 = droidHome('latest');
+    const v2 = droidHome('0.159.1');
+    writeDroidAuth(v1, 'LOGGED_IN_BLOB');
+    // Active config symlink starts at v1 (where the user logged in).
+    const link = path.join(home, '.factory');
+    fs.symlinkSync(path.join(v1, '.factory'), link);
+
+    const res = await switchConfigSymlink('droid', '0.159.1');
+    expect(res.success).toBe(true);
+
+    // v2 now has the login...
+    const dst = path.join(v2, '.factory', 'auth.v2.file');
+    expect(fs.existsSync(dst)).toBe(true);
+    expect(fs.readFileSync(dst, 'utf8')).toBe('LOGGED_IN_BLOB');
+    expect(fs.existsSync(path.join(v2, '.factory', 'auth.v2.key'))).toBe(true);
+    expect(fs.statSync(dst).mode & 0o777).toBe(0o600);
+    // ...and the source is untouched (copy, not move).
+    expect(fs.existsSync(path.join(v1, '.factory', 'auth.v2.file'))).toBe(true);
+  });
+
+  it('overwrites an OLDER credential in the target but keeps a NEWER one', () => {
+    const v1 = droidHome('latest');
+    const v2 = droidHome('0.159.1');
+
+    // Case A: v1 newer than v2 -> v2 gets overwritten with v1's blob.
+    writeDroidAuth(v1, 'FRESH', 2_000_000);
+    writeDroidAuth(v2, 'STALE', 1_000_000);
+    carryForwardAuthFiles('droid', path.join(v2, '.factory'));
+    expect(fs.readFileSync(path.join(v2, '.factory', 'auth.v2.file'), 'utf8')).toBe('FRESH');
+
+    // Case B: target already newest -> left alone.
+    writeDroidAuth(v1, 'OLDER', 1_000_000);
+    writeDroidAuth(v2, 'NEWEST', 3_000_000);
+    carryForwardAuthFiles('droid', path.join(v2, '.factory'));
+    expect(fs.readFileSync(path.join(v2, '.factory', 'auth.v2.file'), 'utf8')).toBe('NEWEST');
+  });
+
+  it('carries antigravity nested token across a switch', async () => {
+    const relDir = path.join('.gemini', 'antigravity-cli');
+    const v1 = path.join(TEST_VERSIONS_DIR, 'antigravity', '1.0.13', 'home');
+    const v2 = path.join(TEST_VERSIONS_DIR, 'antigravity', '1.0.12', 'home');
+    fs.mkdirSync(path.join(v1, relDir), { recursive: true });
+    fs.mkdirSync(path.join(v2, relDir), { recursive: true });
+    fs.writeFileSync(path.join(v1, relDir, 'antigravity-oauth-token'), '{"token":{"refresh_token":"r"}}', { mode: 0o600 });
+    fs.mkdirSync(path.join(home, '.gemini'), { recursive: true });
+    fs.symlinkSync(path.join(v1, relDir), path.join(home, relDir));
+
+    const res = await switchConfigSymlink('antigravity', '1.0.12');
+    expect(res.success).toBe(true);
+    expect(fs.existsSync(path.join(v2, relDir, 'antigravity-oauth-token'))).toBe(true);
+  });
+
+  it('is a no-op for agents without authFiles (claude)', () => {
+    const cHome = path.join(TEST_VERSIONS_DIR, 'claude', '2.1.0', 'home', '.claude');
+    fs.mkdirSync(cHome, { recursive: true });
+    // Must not throw and must not create any file.
+    expect(() => carryForwardAuthFiles('claude', cHome)).not.toThrow();
+    expect(fs.readdirSync(cHome)).toEqual([]);
+  });
+});
+
+describe('getAccountInfo — non-active version reflects account-global sign-in (screenshot bug)', () => {
+  let home: string;
+  beforeEach(() => { home = makeHome(); });
+
+  it('reports droid signed-in for a version whose isolated home lacks auth, via active HOME fallback', async () => {
+    const v1 = droidHome('latest');     // logged-in home
+    const v2 = droidHome('0.159.1');    // isolated, empty
+    writeDroidAuth(v1, 'BLOB');
+    // Active ~/.factory -> v1 (has auth).
+    fs.symlinkSync(path.join(v1, '.factory'), path.join(home, '.factory'));
+
+    // Querying the EMPTY v2 home still resolves signed-in via the HOME fallback.
+    const info = await getAccountInfo('droid', path.join(v2));
+    expect(info.signedIn).toBe(true);
+  });
+
+  it('reports not-signed-in when neither the version home nor active HOME has auth', async () => {
+    const v2 = droidHome('0.159.1');
+    const info = await getAccountInfo('droid', path.join(v2));
+    expect(info.signedIn).toBe(false);
+  });
+});

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -17,7 +17,7 @@ import type { AgentId } from './types.js';
 import { IS_WINDOWS, prependToWindowsUserPath } from './platform/index.js';
 import { getShimsDir, getVersionsDir, getBackupsDir, ensureAgentsDir } from './state.js';
 export { getShimsDir };
-import { AGENTS } from './agents.js';
+import { AGENTS, agentConfigDirName } from './agents.js';
 
 /**
  * Files and directories to always skip during conflict detection and migration.
@@ -940,6 +940,62 @@ function detectMigrationConflicts(agent: AgentId, version: string): ConflictInfo
  *
  * Returns: { success: boolean, backupPath?: string, error?: string }
  */
+/**
+ * Seed a version's config home with the account credential so switching versions
+ * doesn't log the CLI out. Droid/antigravity/kimi (registry `authFiles`) store
+ * login as files inside the per-version config dir; sign-in is account-global,
+ * so we copy the FRESHEST existing copy (by mtime, across all installed version
+ * homes) into `toConfigDir` when its copy is missing or older. mtime is
+ * preserved so the "freshest" comparison stays stable and switches don't
+ * ping-pong. Best-effort: a failed copy just means the user re-logs in.
+ */
+export function carryForwardAuthFiles(agent: AgentId, toConfigDir: string): void {
+  const authFiles = AGENTS[agent].authFiles;
+  if (!authFiles || authFiles.length === 0) return;
+
+  const configDirName = agentConfigDirName(agent);
+  const versionsBase = path.join(getVersionsDir(), agent);
+  let sourceDirs: string[] = [];
+  try {
+    sourceDirs = fs
+      .readdirSync(versionsBase)
+      .map(v => path.join(versionsBase, v, 'home', configDirName));
+  } catch {
+    return; // no installed versions to source from
+  }
+
+  for (const rel of authFiles) {
+    const dest = path.join(toConfigDir, rel);
+    const destResolved = path.resolve(dest);
+
+    // Newest existing source copy across all version homes (excluding dest).
+    let newest: { path: string; mtimeMs: number } | null = null;
+    for (const dir of sourceDirs) {
+      const src = path.join(dir, rel);
+      if (path.resolve(src) === destResolved) continue;
+      let st: fs.Stats;
+      try { st = fs.statSync(src); } catch { continue; }
+      if (!st.isFile()) continue;
+      if (!newest || st.mtimeMs > newest.mtimeMs) newest = { path: src, mtimeMs: st.mtimeMs };
+    }
+    if (!newest) continue;
+
+    // Skip when the target already has an at-least-as-fresh copy.
+    try {
+      const dstat = fs.statSync(dest);
+      if (dstat.mtimeMs >= newest.mtimeMs) continue;
+    } catch { /* dest missing — copy below */ }
+
+    try {
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      const srcStat = fs.statSync(newest.path);
+      fs.copyFileSync(newest.path, dest);
+      fs.chmodSync(dest, (srcStat.mode & 0o777) || 0o600);
+      fs.utimesSync(dest, srcStat.atime, srcStat.mtime);
+    } catch { /* best-effort; a failed carry just means a re-login */ }
+  }
+}
+
 export async function switchConfigSymlink(
   agent: AgentId,
   version: string
@@ -951,6 +1007,13 @@ export async function switchConfigSymlink(
   if (!fs.existsSync(versionConfigPath)) {
     fs.mkdirSync(versionConfigPath, { recursive: true });
   }
+
+  // Carry the account credential into the version we're switching to. Droid /
+  // antigravity / kimi store login as files INSIDE the per-version config home;
+  // switching versions repoints the symlink to a home that was never logged in,
+  // silently logging the CLI out. Sign-in is account-global, so seed the target
+  // home with the freshest existing credential before we flip the symlink.
+  carryForwardAuthFiles(agent, versionConfigPath);
 
   try {
     const stat = fs.lstatSync(configPath);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -85,6 +85,7 @@ export interface AgentConfig {
   installScript?: string;
   configDir: string;
   homeFiles?: string[]; // Files at $HOME level that need per-version symlink switching (e.g., '.claude.json')
+  authFiles?: string[]; // Credential files inside configDir (relative to it) that must be carried across version-homes on switch so sign-in survives version changes (e.g., droid 'auth.v2.file'). Account-global, not version-specific.
   commandsDir: string;
   commandsSubdir: string;
   skillsDir: string;


### PR DESCRIPTION
Closes RUSH-1318. Also fixes the antigravity/kimi "not signed in" display reported on Linux (screenshot: Antigravity 1.0.13 signed in but 1.0.12 not; Kimi not signed in).

## Root cause (one bug, three harnesses)
droid / antigravity / kimi store their login as **files inside the per-version config home**:
- droid: `~/.factory/auth.v2.file` (+ `auth.v2.key`)
- antigravity: `~/.gemini/antigravity-cli/antigravity-oauth-token`
- kimi: `~/.kimi-code/credentials/kimi-code.json`

agents-cli isolates config per version via the `~/.<config>` symlink. You log in under version A (auth written into A's home); switching the active version to B repoints the symlink to B's home, which was never logged in. Result: the **CLI is silently logged out** after a version switch, and `agents view` shows every non-active version as "not signed in" — even though sign-in is **account-global**.

## Fix — two parts
1. **Runtime (`carryForwardAuthFiles`, `shims.ts`):** on `switchConfigSymlink`, seed the target version home with the freshest credential (newest by mtime across all installed version homes), preserving mode (`0600`) and mtime. Driven by a new registry field `AgentConfig.authFiles`.
2. **Display (`resolveAccountCredentialPath`, `agents.ts`):** `getAccountInfo` checks the per-version home first, then falls back to the active config under the real `$HOME`, so every installed version reflects the true account state.

## Verified
- E2E: `agents view droid` now shows **all three** installed versions "signed in" (was all "not signed in"); `agents view kimi` likewise.
- New `shims.auth-carry.test.ts` (6): carry-forward preserves mode/mtime, overwrites older / keeps newer, handles antigravity's nested path, no-ops for agents without `authFiles`; fallback reports signed-in via HOME and signed-out when absent everywhere.
- Made the existing `getAccountInfo` "signed out" tests hermetic (pin `AGENTS_REAL_HOME`) so the new fallback doesn't leak into the dev's real login.
- 335-test lib regression (agents/shims/session/versions) green; `tsc` clean.

## Notes
- Complements #493 (which added droid sign-in detection reading the active `~/.factory`). This makes that detection correct for **non-active** versions and makes the CLI actually stay logged in across switches.
- Related: RUSH-1320 (stale `latest` home), RUSH-1321 (droid version model).