### PR TITLE
feat(menubar): smart clip reference paste (Cmd-Shift-V)

### DIFF
--- a/packages/menubar-helper/Package.swift
+++ b/packages/menubar-helper/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
             linkerSettings: [
                 .linkedFramework("AppKit"),
                 .linkedFramework("CoreGraphics"),
+                .linkedFramework("Carbon"),
                 .linkedLibrary("sqlite3"),
             ]
         )

--- a/packages/menubar-helper/Sources/MenubarHelper/Clip.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/Clip.swift
@@ -16,7 +16,8 @@ import UniformTypeIdentifiers
 //   • a copied file (PDF, image, …) → copied into the attachments dir for a
 //     stable snapshot that survives Desktop/Screenshots sweeps, scp-safe name.
 //   • a copied directory → referenced IN PLACE (copying a whole tree is
-//     unreasonable); the agent fetches it with `scp -r` / `rsync -a`.
+//     unreasonable); the agent fetches it with `scp -r` / `rsync -a`. Its path
+//     can't be renamed, so the token POSIX-quotes it when it isn't shell-safe.
 enum Clip {
     // ~/.agents/.history/attachments — .history is gitignored (never pushed) and
     // DURABLE (unlike .cache, a cache-clear won't sweep an in-flight reference).
@@ -29,8 +30,7 @@ enum Clip {
     // inject the reference. Nothing referenceable on the clipboard → no-op.
     static func run() {
         guard let path = persistFromPasteboard() else { return }
-        let token = "\(localHostName()):\(path.path)"
-        inject(token)
+        inject(referenceToken(for: path))
     }
 
     // Test/debug entry: resolve + print the token, no keystroke injection (so it
@@ -40,9 +40,23 @@ enum Clip {
             FileHandle.standardError.write(Data("no file, directory, or image on clipboard\n".utf8))
             exit(1)
         }
-        let token = "\(localHostName()):\(path.path)"
-        print(token)
+        print(referenceToken(for: path))
         exit(0)
+    }
+
+    // The `<host>:<path>` reference typed into the terminal. Copied files land on
+    // a sanitized, space-free name, but a directory referenced in place keeps its
+    // original path — which may contain spaces or shell metacharacters. Since the
+    // token is typed into a live shell, POSIX-single-quote the path when it isn't
+    // already shell-safe so `scp -r <token>` parses as one argument. Clean paths
+    // stay unquoted.
+    static func referenceToken(for url: URL) -> String {
+        let path = url.path
+        let safe = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-@/"
+        let rendered = path.allSatisfy { safe.contains($0) }
+            ? path
+            : "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        return "\(localHostName()):\(rendered)"
     }
 
     // MARK: - pasteboard → reference path

--- a/packages/menubar-helper/Sources/MenubarHelper/Clip.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/Clip.swift
@@ -1,0 +1,192 @@
+import AppKit
+import ApplicationServices
+import UniformTypeIdentifiers
+
+// Smart clip reference paste. When the clipboard holds a file, directory, or a
+// screenshot and the user presses the hotkey while a terminal is focused, we do
+// NOT paste raw bytes (which mangle a terminal / an SSH'd Claude Code session).
+// Instead we type a NATIVE scp-style reference — `<host>:<abs-path>` — into the
+// terminal. An agent already understands that token: if `host` is its own
+// machine it Reads the path; otherwise it `scp`s it (`-r` for a directory). No
+// invented syntax, no wrapper CLI (agents ssh natively).
+//
+// Handling by kind:
+//   • screenshot bytes → written as PNG into the attachments dir (only lives on
+//     the clipboard, so it must be persisted).
+//   • a copied file (PDF, image, …) → copied into the attachments dir for a
+//     stable snapshot that survives Desktop/Screenshots sweeps, scp-safe name.
+//   • a copied directory → referenced IN PLACE (copying a whole tree is
+//     unreasonable); the agent fetches it with `scp -r` / `rsync -a`.
+enum Clip {
+    // ~/.agents/.history/attachments — .history is gitignored (never pushed) and
+    // DURABLE (unlike .cache, a cache-clear won't sweep an in-flight reference).
+    private static var attachmentsDir: URL {
+        URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".agents/.history/attachments", isDirectory: true)
+    }
+
+    // Entry point wired to the hotkey. Resolve the clipboard item to a path, then
+    // inject the reference. Nothing referenceable on the clipboard → no-op.
+    static func run() {
+        guard let path = persistFromPasteboard() else { return }
+        let token = "\(localHostName()):\(path.path)"
+        inject(token)
+    }
+
+    // Test/debug entry: resolve + print the token, no keystroke injection (so it
+    // needs no Accessibility grant). Driven by MENUBAR_CLIP_TEST=1.
+    static func printTokenAndExit() -> Never {
+        guard let path = persistFromPasteboard() else {
+            FileHandle.standardError.write(Data("no file, directory, or image on clipboard\n".utf8))
+            exit(1)
+        }
+        let token = "\(localHostName()):\(path.path)"
+        print(token)
+        exit(0)
+    }
+
+    // MARK: - pasteboard → reference path
+
+    // Resolve whatever is on the clipboard to a path we can hand an agent.
+    static func persistFromPasteboard() -> URL? {
+        let pb = NSPasteboard.general
+        try? FileManager.default.createDirectory(at: attachmentsDir, withIntermediateDirectories: true)
+
+        // 1. A file or directory already on disk (Finder copy, CleanShot file, …).
+        if let urls = pb.readObjects(
+                forClasses: [NSURL.self],
+                options: [.urlReadingFileURLsOnly: true]
+            ) as? [URL], let src = urls.first(where: { $0.isFileURL }) {
+            let isDir = (try? src.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
+            if isDir {
+                // Reference the tree in place — the agent fetches with `scp -r`.
+                return src
+            }
+            // Copy the file for a stable, scp-safe snapshot; sidecar the metadata.
+            let dst = attachmentsDir.appendingPathComponent(uniqueName(sanitize(src.lastPathComponent)))
+            if (try? FileManager.default.copyItem(at: src, to: dst)) != nil {
+                writeSidecar(for: dst, sourcePath: src.path, kind: uti(of: src))
+                return dst
+            }
+        }
+
+        // 2. Raw bitmap (a screenshot that lives only on the clipboard) → PNG.
+        let dst = attachmentsDir.appendingPathComponent("clip-\(Int(Date().timeIntervalSince1970)).png")
+        if let png = pb.data(forType: .png)
+            ?? pngFrom(tiff: pb.data(forType: .tiff))
+            ?? pngFrom(tiff: NSImage(pasteboard: pb)?.tiffRepresentation) {
+            if (try? png.write(to: dst)) != nil {
+                writeSidecar(for: dst, sourcePath: nil, kind: "public.png")
+                return dst
+            }
+        }
+        return nil
+    }
+
+    private static func pngFrom(tiff: Data?) -> Data? {
+        guard let tiff, let rep = NSBitmapImageRep(data: tiff) else { return nil }
+        return rep.representation(using: .png, properties: [:])
+    }
+
+    // scp-safe: `host:path` splits on spaces and chokes on shell metacharacters,
+    // so map anything outside a conservative allowlist to '-'.
+    private static func sanitize(_ name: String) -> String {
+        let allowed = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-@")
+        return String(name.map { allowed.contains($0) ? $0 : "-" })
+    }
+
+    // Avoid clobbering an existing attachment of the same name.
+    private static func uniqueName(_ preferred: String) -> String {
+        let candidate = attachmentsDir.appendingPathComponent(preferred)
+        guard FileManager.default.fileExists(atPath: candidate.path) else { return preferred }
+        let ext = (preferred as NSString).pathExtension
+        let base = (preferred as NSString).deletingPathExtension
+        let stamped = "\(base)-\(Int(Date().timeIntervalSince1970))"
+        return ext.isEmpty ? stamped : "\(stamped).\(ext)"
+    }
+
+    private static func uti(of url: URL) -> String {
+        (try? url.resourceValues(forKeys: [.contentTypeKey]))?.contentType?.identifier ?? "public.data"
+    }
+
+    // Sidecar: a `<file>.json` next to the attachment recording where/when it came
+    // from. Leaves the file itself byte-for-byte untouched; the agent can scp the
+    // .json alongside for context. (Source app isn't on the pasteboard — omit it
+    // rather than guess.)
+    private static func writeSidecar(for file: URL, sourcePath: String?, kind: String) {
+        var meta: [String: Any] = [
+            "host": localHostName(),
+            "capturedAt": ISO8601DateFormatter().string(from: Date()),
+            "kind": kind,
+        ]
+        if let sourcePath { meta["sourcePath"] = sourcePath }
+        if let size = (try? FileManager.default.attributesOfItem(atPath: file.path))?[.size] as? Int {
+            meta["bytes"] = size
+        }
+        if let data = try? JSONSerialization.data(withJSONObject: meta,
+                                                  options: [.prettyPrinted, .sortedKeys]) {
+            try? data.write(to: URL(fileURLWithPath: file.path + ".json"))
+        }
+    }
+
+    // MARK: - hostname
+
+    // The single-label LocalHostName ("zion") that Tailscale MagicDNS / ssh
+    // aliases resolve — NOT ProcessInfo.hostName (may be "zion.local") or the
+    // Computer Name ("Zion's MacBook"). Absolute /usr/sbin path: a GUI/launchd
+    // process inherits a minimal PATH.
+    static func localHostName() -> String {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/sbin/scutil")
+        p.arguments = ["--get", "LocalHostName"]
+        let out = Pipe()
+        p.standardOutput = out
+        p.standardError = FileHandle.nullDevice
+        if (try? p.run()) != nil {
+            let data = out.fileHandleForReading.readDataToEndOfFile()
+            p.waitUntilExit()
+            if p.terminationStatus == 0,
+               let name = String(data: data, encoding: .utf8)?
+                   .trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
+                return name
+            }
+        }
+        // Fallback: strip any DNS suffix from the Bonjour host name.
+        return ProcessInfo.processInfo.hostName.components(separatedBy: ".").first
+            ?? ProcessInfo.processInfo.hostName
+    }
+
+    // MARK: - inject
+
+    // Put the token on the pasteboard and synthesize Cmd-V into the frontmost app
+    // (the terminal — this .accessory app never becomes key). Mirrors the proven
+    // pattern in computer-helper/AX.swift. Uses a .hidSystemState source so
+    // terminals wrapped in Electron/webview accept the event.
+    private static func inject(_ text: String) {
+        guard ensureAccessibility() else { return }
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(text, forType: .string)
+        usleep(20_000)
+
+        let src = CGEventSource(stateID: .hidSystemState)
+        guard let down = CGEvent(keyboardEventSource: src, virtualKey: 0x09, keyDown: true),
+              let up = CGEvent(keyboardEventSource: src, virtualKey: 0x09, keyDown: false) else { return }
+        down.flags = .maskCommand
+        up.flags = .maskCommand
+        if let pid = NSWorkspace.shared.frontmostApplication?.processIdentifier {
+            down.postToPid(pid)
+            up.postToPid(pid)
+        } else {
+            down.post(tap: .cghidEventTap)
+            up.post(tap: .cghidEventTap)
+        }
+    }
+
+    // Posting synthesized keystrokes needs Accessibility. Prompt once if missing.
+    private static func ensureAccessibility() -> Bool {
+        if AXIsProcessTrusted() { return true }
+        let opts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
+        return AXIsProcessTrustedWithOptions(opts)
+    }
+}

--- a/packages/menubar-helper/Sources/MenubarHelper/Hotkey.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/Hotkey.swift
@@ -1,0 +1,37 @@
+import AppKit
+import Carbon.HIToolbox
+
+// Global hotkey via Carbon RegisterEventHotKey. Chosen over an NSEvent global
+// monitor (passive, can't act cleanly) or a CGEvent tap (needs Input-Monitoring
+// TCC and can be disabled under load): RegisterEventHotKey needs NO extra TCC to
+// register, and because we use a DEDICATED chord (Cmd-Shift-V) we never hijack
+// the OS Cmd-V. The Accessibility grant is only needed later, for the paste
+// injection itself (Clip.inject).
+final class HotkeyManager {
+    // The InstallEventHandler callback is a bare C function pointer with no
+    // captured context, so route through a static singleton.
+    static var shared: HotkeyManager?
+
+    private var hotKeyRef: EventHotKeyRef?
+    private var handlerRef: EventHandlerRef?
+    private let onFire: () -> Void
+
+    init(onFire: @escaping () -> Void) { self.onFire = onFire }
+
+    func register() {
+        HotkeyManager.shared = self
+
+        var spec = EventTypeSpec(eventClass: OSType(kEventClassKeyboard),
+                                 eventKind: UInt32(kEventHotKeyPressed))
+        InstallEventHandler(GetApplicationEventTarget(), { _, _, _ -> OSStatus in
+            HotkeyManager.shared?.onFire()
+            return noErr
+        }, 1, &spec, nil, &handlerRef)
+
+        // 'AGCT' signature keeps our hotkey id namespaced from other apps'.
+        let id = EventHotKeyID(signature: OSType(0x41474354), id: 1)
+        let modifiers = UInt32(cmdKey | shiftKey)
+        RegisterEventHotKey(UInt32(kVK_ANSI_V), modifiers, id,
+                            GetApplicationEventTarget(), 0, &hotKeyRef)
+    }
+}

--- a/packages/menubar-helper/Sources/MenubarHelper/Hotkey.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/Hotkey.swift
@@ -23,7 +23,7 @@ final class HotkeyManager {
 
         var spec = EventTypeSpec(eventClass: OSType(kEventClassKeyboard),
                                  eventKind: UInt32(kEventHotKeyPressed))
-        InstallEventHandler(GetApplicationEventTarget(), { _, _, _ -> OSStatus in
+        let installed = InstallEventHandler(GetApplicationEventTarget(), { _, _, _ -> OSStatus in
             HotkeyManager.shared?.onFire()
             return noErr
         }, 1, &spec, nil, &handlerRef)
@@ -31,7 +31,14 @@ final class HotkeyManager {
         // 'AGCT' signature keeps our hotkey id namespaced from other apps'.
         let id = EventHotKeyID(signature: OSType(0x41474354), id: 1)
         let modifiers = UInt32(cmdKey | shiftKey)
-        RegisterEventHotKey(UInt32(kVK_ANSI_V), modifiers, id,
-                            GetApplicationEventTarget(), 0, &hotKeyRef)
+        let registered = RegisterEventHotKey(UInt32(kVK_ANSI_V), modifiers, id,
+                                             GetApplicationEventTarget(), 0, &hotKeyRef)
+
+        // Registration fails if another app already owns the chord — surface it
+        // rather than silently never firing.
+        if installed != noErr || registered != noErr {
+            FileHandle.standardError.write(Data(
+                "clip: hotkey registration failed (install=\(installed) register=\(registered))\n".utf8))
+        }
     }
 }

--- a/packages/menubar-helper/Sources/MenubarHelper/main.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/main.swift
@@ -16,6 +16,12 @@ if ProcessInfo.processInfo.environment["MENUBAR_BENCH"] == "1" {
     exit(0)
 }
 
+// Clip test: persist the current clipboard image + print the scp token, then
+// exit. No GUI, no hotkey, no Accessibility grant — verifies persist+format.
+if ProcessInfo.processInfo.environment["MENUBAR_CLIP_TEST"] == "1" {
+    Clip.printTokenAndExit()
+}
+
 let app = NSApplication.shared
 app.setActivationPolicy(.accessory)
 
@@ -24,8 +30,10 @@ let controller = StatusItemController()
 final class AppDelegate: NSObject, NSApplicationDelegate {
     let controller: StatusItemController
     init(_ c: StatusItemController) { self.controller = c }
+    let hotkey = HotkeyManager(onFire: { Clip.run() })
     func applicationDidFinishLaunching(_ notification: Notification) {
         controller.install()
+        hotkey.register()
     }
 }
 


### PR DESCRIPTION
Adds a global **Cmd-Shift-V** hotkey to the menu-bar helper that turns whatever is on the clipboard into a **native scp-style reference** — `<host>:<abs-path>` — typed into the focused terminal. This makes a screenshot/file/folder on one machine usable by an agent on another: an SSH’d Claude Code session sees e.g. `zion:/Users/me/Downloads/proto`, and fetches it with `scp` / `scp -r`, then Reads it. No invented syntax, no wrapper CLI (agents ssh natively).

## Why
Pasting a screenshot/file into an SSH’d agent session mangles the terminal (raw bytes) — the remote agent can’t read the local clipboard. Locally, Claude Code already turns a paste into an `[Image: source: …]` reference, so the value here is the **remote** case: hand the agent a `host:path` it can fetch.

## Behavior by clipboard kind
- **Screenshot bytes** → written as PNG into `~/.agents/.history/attachments/` (durable + gitignored; a cache-clear won’t sweep an in-flight reference).
- **File** (PDF, image, …) → copied into the attachments dir for a stable, **scp-safe** snapshot (spaces/metacharacters sanitized), with a `<file>.json` **sidecar** (`host`, `capturedAt`, `kind`, `sourcePath`, `bytes`).
- **Directory** → referenced **in place** (copying a tree is unreasonable); agent uses `scp -r`.
- Nothing referenceable on the clipboard → **no-op** (never a raw paste).

## Implementation
- `Hotkey.swift` — Carbon `RegisterEventHotKey` for a **dedicated** chord. Chosen over an `NSEvent` global monitor (passive) or a CGEvent tap (needs Input-Monitoring TCC, can be disabled): a dedicated chord never hijacks the OS Cmd-V and needs **no extra TCC to register**.
- `Clip.swift` — pasteboard → path resolution + injection. Injection reuses the proven `computer-helper/AX.swift` Cmd-V pattern (pasteboard string + synthesized Cmd-V to the frontmost pid via a `.hidSystemState` source). Guards on `AXIsProcessTrusted()`.
- `Package.swift` — links `Carbon`.
- `main.swift` — registers the hotkey in `applicationDidFinishLaunching`; adds a `MENUBAR_CLIP_TEST` entrypoint that prints the token without needing the Accessibility grant.

## Testing
- Built clean (SwiftPM). `MENUBAR_CLIP_TEST` verified all three paths: file-with-spaces → sanitized name + sidecar; directory → in-place, nothing copied; bitmap → PNG + sidecar.
- Remote fetch proven separately: `scp <token>` from `yosemite-s0` pulled a real screenshot from `zion`, sha256 byte-for-byte identical.
- **Live**: with the helper Accessibility-granted, Cmd-Shift-V injected `zion:/Users/muqsit/Downloads/factory-floor-prototype` into a Claude Code session running in an SSH’d tmux — the real target scenario.

## Follow-up (separate)
- Agent rule teaching the `host:/path` convention (ships from `.agents-system`, reaches all hosts).
- Optional: configurable shortcut, one-key Cmd-V auto-detect (native local / token when SSH’d).