### PR TITLE
feat(devices): auto-populate the registry + curate with a persistent ignore-list

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -129,16 +129,13 @@ export async function runSetup(program: Command, options: { force?: boolean; sup
     }
   }
 
-  // Populate the device registry from the tailnet on first setup. Soft: no
-  // tailscale is a clean no-op, never a setup failure.
-  try {
-    const { runDeviceSync } = await import('../lib/devices/sync.js');
-    const dev = await runDeviceSync({ soft: true });
-    if (dev.ok && dev.synced > 0) {
-      console.log(chalk.gray(`Discovered ${dev.synced} device${dev.synced === 1 ? '' : 's'} on your tailnet (agents devices list).`));
-    }
-  } catch {
-    // Never let device discovery block setup.
+  // Populate the device registry from the tailnet on first setup. Soft mode is
+  // guaranteed non-throwing (no tailscale / corrupt file / lock contention all
+  // resolve to ok:false), so this can never block setup.
+  const { runDeviceSync } = await import('../lib/devices/sync.js');
+  const dev = await runDeviceSync({ soft: true });
+  if (dev.ok && dev.synced > 0) {
+    console.log(chalk.gray(`Discovered ${dev.synced} device${dev.synced === 1 ? '' : 's'} on your tailnet (agents devices list).`));
   }
 
   // Offer to import existing unmanaged installations

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -129,6 +129,18 @@ export async function runSetup(program: Command, options: { force?: boolean; sup
     }
   }
 
+  // Populate the device registry from the tailnet on first setup. Soft: no
+  // tailscale is a clean no-op, never a setup failure.
+  try {
+    const { runDeviceSync } = await import('../lib/devices/sync.js');
+    const dev = await runDeviceSync({ soft: true });
+    if (dev.ok && dev.synced > 0) {
+      console.log(chalk.gray(`Discovered ${dev.synced} device${dev.synced === 1 ? '' : 's'} on your tailnet (agents devices list).`));
+    }
+  } catch {
+    // Never let device discovery block setup.
+  }
+
   // Offer to import existing unmanaged installations
   if (unmanaged.length > 0 && isInteractiveTerminal()) {
     console.log(chalk.bold('\nFound existing installations:\n'));

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -214,9 +214,14 @@ Typical workflow:
     .command('list')
     .alias('ls')
     .description('List registered devices with platform, address, and reachability.')
-    .action(async () => {
+    .option('--json', 'output the registry as a JSON array (for scripts and hooks)')
+    .action(async (opts: { json?: boolean }) => {
       const reg = await loadDevices();
       const names = Object.keys(reg).sort();
+      if (opts.json) {
+        process.stdout.write(JSON.stringify(names.map((n) => reg[n]), null, 2) + '\n');
+        return;
+      }
       if (names.length === 0) {
         console.log(chalk.gray("No devices. Run 'agents devices sync' or 'agents devices add <name> <user@host>'."));
         return;

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -35,7 +35,7 @@ import {
   parseTailscaleStatus,
   tailscaleStatusJson,
 } from '../lib/devices/tailscale.js';
-import { runDeviceSync } from '../lib/devices/sync.js';
+import { planDeviceReconciliation, runDeviceSync } from '../lib/devices/sync.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
 import { hostNameFor, renderSshConfig } from '../lib/devices/ssh-config.js';
 import {
@@ -104,13 +104,16 @@ async function runInteractiveDeviceSync(): Promise<void> {
   let selected: string[];
   try {
     selected = await checkbox({
-      message: 'Devices to keep registered (unchecked = removed and ignored):',
+      // Everything not already dismissed starts checked, so pressing Enter keeps
+      // the fleet as-is (matching what auto-sync would register). Unchecking a
+      // device removes it AND dismisses it so auto-sync never re-adds it.
+      message: 'Your fleet — uncheck a device to remove and stop suggesting it:',
       pageSize: Math.min(nodes.length, 20),
       choices: nodes.map((n) => {
         const flags = [n.platform, n.online ? undefined : 'offline', ignored.has(n.name) ? 'ignored' : undefined]
           .filter(Boolean)
           .join(', ');
-        return { value: n.name, name: `${n.name}  ${chalk.gray(`(${flags})`)}`, checked: registered.has(n.name) };
+        return { value: n.name, name: `${n.name}  ${chalk.gray(`(${flags})`)}`, checked: !ignored.has(n.name) };
       }),
     });
   } catch (err) {
@@ -121,30 +124,17 @@ async function runInteractiveDeviceSync(): Promise<void> {
     throw err;
   }
 
-  const keep = new Set(selected);
   const byName = new Map(nodes.map((n) => [n.name, n]));
-  let registeredCount = 0;
-  let removedCount = 0;
-  let ignoredCount = 0;
-  for (const node of nodes) {
-    if (keep.has(node.name)) {
-      await upsertDevice(node.name, nodeToDeviceInput(byName.get(node.name)!));
-      if (ignored.has(node.name)) await removeIgnored(node.name);
-      registeredCount++;
-    } else {
-      if (registered.has(node.name)) {
-        await removeDevice(node.name);
-        removedCount++;
-      }
-      await addIgnored(node.name);
-      ignoredCount++;
-    }
-  }
+  const plan = planDeviceReconciliation(byName.keys(), selected, registered, ignored);
+  for (const name of plan.toRegister) await upsertDevice(name, nodeToDeviceInput(byName.get(name)!));
+  for (const name of plan.toUnignore) await removeIgnored(name);
+  for (const name of plan.toRemove) await removeDevice(name);
+  for (const name of plan.toIgnore) await addIgnored(name);
 
   const parts = [
-    chalk.green(`${registeredCount} registered`),
-    removedCount ? chalk.yellow(`${removedCount} removed`) : null,
-    ignoredCount ? chalk.gray(`${ignoredCount} ignored`) : null,
+    chalk.green(`${plan.toRegister.length} registered`),
+    plan.toRemove.length ? chalk.yellow(`${plan.toRemove.length} removed`) : null,
+    plan.toIgnore.length ? chalk.gray(`${plan.toIgnore.length} ignored`) : null,
   ].filter(Boolean);
   console.log(parts.join(chalk.gray(' · ')));
 }

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -19,9 +19,12 @@ import chalk from 'chalk';
 import ora from 'ora';
 import { readAndResolveBundleEnv } from '../lib/secrets/bundles.js';
 import {
+  addIgnored,
   getDevice,
   loadDevices,
+  loadIgnored,
   removeDevice,
+  removeIgnored,
   upsertDevice,
   type DeviceAuthMethod,
   type DevicePlatform,
@@ -32,6 +35,8 @@ import {
   parseTailscaleStatus,
   tailscaleStatusJson,
 } from '../lib/devices/tailscale.js';
+import { runDeviceSync } from '../lib/devices/sync.js';
+import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
 import { hostNameFor, renderSshConfig } from '../lib/devices/ssh-config.js';
 import {
   ASKPASS_BUNDLE_ENV,
@@ -69,6 +74,81 @@ async function mustGetDevice(name: string): Promise<DeviceProfile> {
   return d;
 }
 
+/**
+ * Interactive `agents devices sync`: discover tailscale nodes, present a
+ * checkbox pre-checked with what's already registered, and reconcile the
+ * choice. Checked = registered (and un-ignored). Unchecked = removed from the
+ * registry AND added to the ignore-list, so auto-discovery never re-suggests
+ * it — this is the "click to register/unregister" surface, with dismissals that
+ * stick.
+ */
+async function runInteractiveDeviceSync(): Promise<void> {
+  const spinner = ora('Reading tailscale status...').start();
+  let nodes;
+  try {
+    nodes = parseTailscaleStatus(tailscaleStatusJson());
+  } catch (err: any) {
+    spinner.fail(err.message);
+    process.exit(1);
+  }
+  const [reg, ignored] = await Promise.all([loadDevices(), loadIgnored()]);
+  const registered = new Set(Object.keys(reg));
+  spinner.stop();
+
+  if (nodes.length === 0) {
+    console.log(chalk.gray('No tailscale nodes found.'));
+    return;
+  }
+
+  const { checkbox } = await import('@inquirer/prompts');
+  let selected: string[];
+  try {
+    selected = await checkbox({
+      message: 'Devices to keep registered (unchecked = removed and ignored):',
+      pageSize: Math.min(nodes.length, 20),
+      choices: nodes.map((n) => {
+        const flags = [n.platform, n.online ? undefined : 'offline', ignored.has(n.name) ? 'ignored' : undefined]
+          .filter(Boolean)
+          .join(', ');
+        return { value: n.name, name: `${n.name}  ${chalk.gray(`(${flags})`)}`, checked: registered.has(n.name) };
+      }),
+    });
+  } catch (err) {
+    if (isPromptCancelled(err)) {
+      console.log(chalk.gray('Cancelled — no changes.'));
+      return;
+    }
+    throw err;
+  }
+
+  const keep = new Set(selected);
+  const byName = new Map(nodes.map((n) => [n.name, n]));
+  let registeredCount = 0;
+  let removedCount = 0;
+  let ignoredCount = 0;
+  for (const node of nodes) {
+    if (keep.has(node.name)) {
+      await upsertDevice(node.name, nodeToDeviceInput(byName.get(node.name)!));
+      if (ignored.has(node.name)) await removeIgnored(node.name);
+      registeredCount++;
+    } else {
+      if (registered.has(node.name)) {
+        await removeDevice(node.name);
+        removedCount++;
+      }
+      await addIgnored(node.name);
+      ignoredCount++;
+    }
+  }
+
+  const parts = [
+    chalk.green(`${registeredCount} registered`),
+    removedCount ? chalk.yellow(`${removedCount} removed`) : null,
+    ignoredCount ? chalk.gray(`${ignoredCount} ignored`) : null,
+  ].filter(Boolean);
+  console.log(parts.join(chalk.gray(' · ')));
+}
+
 /** Register the `agents devices` command tree. */
 function registerDevicesCommands(program: Command): void {
   const devicesCmd = program
@@ -76,28 +156,58 @@ function registerDevicesCommands(program: Command): void {
     .description('Registry of SSH device profiles (platform, user, address, auth), self-populated from Tailscale.')
     .addHelpText('after', `
 Typical workflow:
-  agents devices sync            # ingest tailscale nodes (auto-detect platform)
+  agents devices sync            # curate: pick which tailscale nodes to keep (TTY)
+  agents devices sync --yes      # non-interactive: register all non-ignored nodes
   agents devices list            # see what's registered
+  agents devices ignore ipad165  # dismiss a node so it's never re-suggested
   agents devices set win-mini --auth password --bundle muqsit
   agents devices render --write  # write ~/.ssh/config.d/agents include
 `);
 
   devicesCmd
     .command('sync')
-    .description('Ingest `tailscale status --json` and create/update device profiles (auto-detects platform, address, reachability).')
-    .action(async () => {
+    .description('Ingest `tailscale status --json` into device profiles. In a terminal, opens a checkbox to register/unregister nodes; with --yes, registers every non-ignored node.')
+    .option('--yes', 'skip the picker; register all discovered non-ignored nodes')
+    .action(async (opts: { yes?: boolean }) => {
+      if (isInteractiveTerminal() && !opts.yes) {
+        await runInteractiveDeviceSync();
+        return;
+      }
       const spinner = ora('Reading tailscale status...').start();
       try {
-        const nodes = parseTailscaleStatus(tailscaleStatusJson());
-        spinner.text = `Updating ${nodes.length} device${nodes.length === 1 ? '' : 's'}...`;
-        for (const node of nodes) {
-          await upsertDevice(node.name, nodeToDeviceInput(node));
-        }
-        spinner.succeed(`Synced ${nodes.length} device${nodes.length === 1 ? '' : 's'} from Tailscale`);
+        const res = await runDeviceSync();
+        const extra = res.pending.length ? chalk.gray(` (${res.pending.length} new)`) : '';
+        spinner.succeed(`Synced ${res.synced} device${res.synced === 1 ? '' : 's'} from Tailscale${extra}`);
       } catch (err: any) {
         spinner.fail(err.message);
         process.exit(1);
       }
+    });
+
+  devicesCmd
+    .command('ignore <name>')
+    .description('Dismiss a node from auto-discovery so it is never re-suggested (and remove it from the registry if present).')
+    .action(async (name: string) => {
+      try {
+        await removeDevice(name);
+        await addIgnored(name);
+        console.log(chalk.green(`Ignored '${name}'`) + chalk.gray(" — it won't be suggested again. Undo with `agents devices unignore`."));
+      } catch (err: any) {
+        console.error(chalk.red(err.message));
+        process.exit(1);
+      }
+    });
+
+  devicesCmd
+    .command('unignore <name>')
+    .description('Undo `ignore`: allow a node to be discovered and registered again.')
+    .action(async (name: string) => {
+      const ok = await removeIgnored(name);
+      if (!ok) {
+        console.error(chalk.gray(`'${name}' was not ignored.`));
+        return;
+      }
+      console.log(chalk.green(`No longer ignoring '${name}'`) + chalk.gray(' — run `agents devices sync` to register it.'));
     });
 
   devicesCmd

--- a/src/lib/devices/ignored.test.ts
+++ b/src/lib/devices/ignored.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Persistence guarantees for the device ignore-list.
+ *
+ * The ignore-list is what makes "a dismissed device never resurfaces" true, so
+ * the real bugs to guard:
+ *   1. addIgnored must survive a reload (a dismissal that evaporates would let
+ *      the node re-appear on the next sync — exactly what the user asked us to
+ *      prevent).
+ *   2. addIgnored is idempotent and removeIgnored is the exact inverse.
+ *   3. A malformed file throws rather than silently returning an empty set that
+ *      the next write would clobber (the data-loss path, mirroring the registry).
+ */
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+// Set HOME before state.ts loads so its module-level root picks up the override.
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-devices-ignored-test-'));
+process.env.HOME = TEST_HOME;
+
+const { loadIgnored, addIgnored, removeIgnored, isIgnored } = await import('./registry.js');
+
+function ignoredPath(): string {
+  return path.join(TEST_HOME, '.agents', '.history', 'devices', 'ignored.json');
+}
+
+beforeEach(async () => {
+  await fsp.rm(ignoredPath(), { force: true });
+  await fsp.rm(`${ignoredPath()}.lock`, { recursive: true, force: true });
+});
+
+afterAll(async () => {
+  await fsp.rm(TEST_HOME, { recursive: true, force: true });
+});
+
+describe('device ignore-list', () => {
+  it('returns an empty set when the file does not exist', async () => {
+    expect([...(await loadIgnored())]).toEqual([]);
+  });
+
+  it('persists a dismissal across reloads', async () => {
+    await addIgnored('ipad165');
+    expect(await isIgnored('ipad165')).toBe(true);
+    // Fresh read from disk — not the in-memory set from addIgnored.
+    expect([...(await loadIgnored())]).toEqual(['ipad165']);
+  });
+
+  it('is idempotent and stores names sorted', async () => {
+    await addIgnored('win-mini');
+    await addIgnored('ipad165');
+    await addIgnored('win-mini');
+    expect([...(await loadIgnored())]).toEqual(['ipad165', 'win-mini']);
+  });
+
+  it('removeIgnored is the exact inverse and reports miss vs hit', async () => {
+    await addIgnored('mac-mini');
+    expect(await removeIgnored('mac-mini')).toBe(true);
+    expect(await isIgnored('mac-mini')).toBe(false);
+    expect(await removeIgnored('mac-mini')).toBe(false);
+  });
+
+  it('throws on a corrupted file instead of silently emptying it', async () => {
+    await fsp.mkdir(path.dirname(ignoredPath()), { recursive: true });
+    await fsp.writeFile(ignoredPath(), '{ this is not json');
+    await expect(loadIgnored()).rejects.toThrow(/corrupted/);
+  });
+});

--- a/src/lib/devices/registry.ts
+++ b/src/lib/devices/registry.ts
@@ -18,7 +18,7 @@ import * as fsSync from 'fs';
 import * as path from 'path';
 import { randomBytes } from 'crypto';
 import lockfile from 'proper-lockfile';
-import { getDevicesRegistryPath } from '../state.js';
+import { getDevicesRegistryPath, getDevicesIgnoredPath } from '../state.js';
 
 /** Operating-system family of a device, used to pick the remote shell. */
 export type DevicePlatform = 'windows' | 'linux' | 'macos' | 'unknown';
@@ -236,6 +236,74 @@ export async function removeDevice(name: string): Promise<boolean> {
     if (!reg[name]) return false;
     delete reg[name];
     await saveDevices(reg);
+    return true;
+  });
+}
+
+/**
+ * The ignore-list: tailscale node names the user explicitly dismissed from
+ * auto-discovery. A dismissed node is NOT a device (it never enters the
+ * registry), so it lives in a sibling file. Auto-discovery (`runDeviceSync`'s
+ * pending diff) subtracts this set, so an ignored node never re-surfaces as a
+ * suggestion. Stored under the same devices/ dir, guarded by the same lock and
+ * atomic-write plumbing as the registry.
+ */
+interface IgnoredFile {
+  ignored: string[];
+  updatedAt: string;
+}
+
+function ignoredPath(): string {
+  return getDevicesIgnoredPath();
+}
+
+/** Load the set of ignored node names. Missing file => empty set. A malformed
+ * file is a hard error for the same reason the registry is: silently returning
+ * [] would let the next write wipe the user's dismissals. */
+export async function loadIgnored(): Promise<Set<string>> {
+  const p = ignoredPath();
+  let raw: string;
+  try {
+    raw = await fs.readFile(p, 'utf-8');
+  } catch (err: any) {
+    if (err && err.code === 'ENOENT') return new Set();
+    throw err;
+  }
+  try {
+    const parsed = JSON.parse(raw) as IgnoredFile;
+    return new Set(Array.isArray(parsed.ignored) ? parsed.ignored : []);
+  } catch (err: any) {
+    throw new Error(
+      `Device ignore-list corrupted at ${p}: ${err?.message ?? err}. Inspect and restore from backup.`,
+    );
+  }
+}
+
+/** True if `name` is on the ignore-list. */
+export async function isIgnored(name: string): Promise<boolean> {
+  return (await loadIgnored()).has(name);
+}
+
+/** Add a node name to the ignore-list. Idempotent. Returns the resulting set. */
+export async function addIgnored(name: string): Promise<Set<string>> {
+  assertValidDeviceName(name);
+  const p = ignoredPath();
+  return withRegistryLock(p, async () => {
+    const set = await loadIgnored();
+    set.add(name);
+    await atomicWriteJson(p, { ignored: [...set].sort(), updatedAt: new Date().toISOString() });
+    return set;
+  });
+}
+
+/** Remove a node name from the ignore-list (un-ignore). Returns false if it was
+ * not ignored. */
+export async function removeIgnored(name: string): Promise<boolean> {
+  const p = ignoredPath();
+  return withRegistryLock(p, async () => {
+    const set = await loadIgnored();
+    if (!set.delete(name)) return false;
+    await atomicWriteJson(p, { ignored: [...set].sort(), updatedAt: new Date().toISOString() });
     return true;
   });
 }

--- a/src/lib/devices/sync.test.ts
+++ b/src/lib/devices/sync.test.ts
@@ -1,0 +1,37 @@
+/**
+ * The pending-device diff is the logic the auto-sync, the curation picker, and
+ * (later) the menu-bar probe all depend on. The real bugs it must not have:
+ *   1. A node already in the registry is NOT "new" (no re-suggesting known kit).
+ *   2. A dismissed (ignored) node is NEVER "new" — this is the whole point of
+ *      the ignore-list: an unchecked phone must not resurface every sync.
+ *   3. A genuinely-new, non-ignored node IS surfaced.
+ */
+import { describe, expect, it } from 'vitest';
+import { computePendingDevices } from './sync.js';
+import type { TailscaleNode } from './tailscale.js';
+
+function node(name: string): TailscaleNode {
+  return { name, platform: 'linux', online: true, direct: true };
+}
+
+describe('computePendingDevices', () => {
+  it('surfaces only nodes that are neither registered nor ignored', () => {
+    const nodes = ['zion', 'yosemite-s0', 'ipad165', 'win-mini'].map(node);
+    const pending = computePendingDevices(nodes, ['yosemite-s0'], ['ipad165']);
+    expect(pending).toEqual(['zion', 'win-mini']);
+  });
+
+  it('treats a node that is both registered and ignored as not-pending', () => {
+    const nodes = [node('mac-mini')];
+    expect(computePendingDevices(nodes, ['mac-mini'], ['mac-mini'])).toEqual([]);
+  });
+
+  it('returns everything when nothing is registered or ignored', () => {
+    const nodes = ['a', 'b', 'c'].map(node);
+    expect(computePendingDevices(nodes, [], [])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns nothing for an empty tailnet', () => {
+    expect(computePendingDevices([], ['zion'], ['ipad165'])).toEqual([]);
+  });
+});

--- a/src/lib/devices/sync.test.ts
+++ b/src/lib/devices/sync.test.ts
@@ -7,7 +7,7 @@
  *   3. A genuinely-new, non-ignored node IS surfaced.
  */
 import { describe, expect, it } from 'vitest';
-import { computePendingDevices } from './sync.js';
+import { computePendingDevices, planDeviceReconciliation } from './sync.js';
 import type { TailscaleNode } from './tailscale.js';
 
 function node(name: string): TailscaleNode {
@@ -33,5 +33,41 @@ describe('computePendingDevices', () => {
 
   it('returns nothing for an empty tailnet', () => {
     expect(computePendingDevices([], ['zion'], ['ipad165'])).toEqual([]);
+  });
+});
+
+describe('planDeviceReconciliation', () => {
+  const all = ['zion', 'yosemite-s0', 'ipad165', 'win-mini', 'mac-mini'];
+
+  it('registers checked, removes+ignores unchecked-that-were-registered', () => {
+    // registered: zion, yosemite-s0, win-mini. ignored: ipad165. mac-mini is new.
+    // user keeps zion + yosemite-s0, unchecks win-mini (registered) and leaves
+    // ipad165/mac-mini unchecked.
+    const plan = planDeviceReconciliation(
+      all,
+      ['zion', 'yosemite-s0'],
+      ['zion', 'yosemite-s0', 'win-mini'],
+      ['ipad165'],
+    );
+    expect(plan.toRegister).toEqual(['zion', 'yosemite-s0']);
+    expect(plan.toRemove).toEqual(['win-mini']); // was registered, now unchecked
+    expect(plan.toIgnore).toEqual(['ipad165', 'win-mini', 'mac-mini']); // every unchecked
+    expect(plan.toUnignore).toEqual([]);
+  });
+
+  it('un-ignores a previously-dismissed node when the user re-checks it', () => {
+    const plan = planDeviceReconciliation(['ipad165'], ['ipad165'], [], ['ipad165']);
+    expect(plan.toRegister).toEqual(['ipad165']);
+    expect(plan.toUnignore).toEqual(['ipad165']);
+    expect(plan.toRemove).toEqual([]);
+    expect(plan.toIgnore).toEqual([]);
+  });
+
+  it('does not try to remove an unchecked node that was never registered', () => {
+    // mac-mini is newly discovered (not registered, not ignored) and left
+    // unchecked: it should be ignored but NOT removed (nothing to remove).
+    const plan = planDeviceReconciliation(['mac-mini'], [], [], []);
+    expect(plan.toRemove).toEqual([]);
+    expect(plan.toIgnore).toEqual(['mac-mini']);
   });
 });

--- a/src/lib/devices/sync.ts
+++ b/src/lib/devices/sync.ts
@@ -62,28 +62,68 @@ export function computePendingDevices(
  * "new" means "not previously registered and not ignored".
  */
 export async function runDeviceSync(opts: { soft?: boolean } = {}): Promise<DeviceSyncResult> {
-  let nodes: TailscaleNode[];
+  // Soft mode must be non-fatal for ANY failure, not just a missing tailscale:
+  // a corrupted registry/ignore file (both throw by design), a disk error, or
+  // registry lock contention (plausible when many agents SessionStart-autosync
+  // the same host at once) would otherwise abort the whole `agents sync`. The
+  // whole body is inside the guard so the "never a sync failure" promise holds.
   try {
-    nodes = parseTailscaleStatus(tailscaleStatusJson());
+    const nodes = parseTailscaleStatus(tailscaleStatusJson());
+    const [registeredBefore, ignored] = await Promise.all([loadDevices(), loadIgnored()]);
+    const pending = computePendingDevices(nodes, Object.keys(registeredBefore), ignored);
+
+    // Register/refresh every node the user has NOT dismissed. Skipping ignored
+    // nodes is what makes the "register all" default safe: a phone or someone
+    // else's laptop the user once dismissed never silently comes back.
+    let synced = 0;
+    for (const node of nodes) {
+      if (ignored.has(node.name)) continue;
+      await upsertDevice(node.name, nodeToDeviceInput(node));
+      synced++;
+    }
+
+    return { ok: true, synced, pending };
   } catch (err: any) {
     if (opts.soft) {
       return { ok: false, synced: 0, pending: [], reason: err?.message ?? String(err) };
     }
     throw err;
   }
+}
 
-  const [registeredBefore, ignored] = await Promise.all([loadDevices(), loadIgnored()]);
-  const pending = computePendingDevices(nodes, Object.keys(registeredBefore), ignored);
+/**
+ * The register/remove/ignore decision for the interactive curation picker.
+ * Pure so the highest-risk reconcile logic is unit-testable without a tailnet
+ * or a live prompt. `keep` is the set the user left checked; everything else is
+ * dismissed. Checked => register (and un-ignore if it was ignored). Unchecked
+ * => remove from the registry if it was there, and ignore it so auto-sync never
+ * re-adds it.
+ */
+export interface DeviceReconciliation {
+  toRegister: string[];
+  toUnignore: string[];
+  toRemove: string[];
+  toIgnore: string[];
+}
 
-  // Register/refresh every node the user has NOT dismissed. Skipping ignored
-  // nodes is what makes the "register all" default safe: a phone or someone
-  // else's laptop the user once dismissed never silently comes back.
-  let synced = 0;
-  for (const node of nodes) {
-    if (ignored.has(node.name)) continue;
-    await upsertDevice(node.name, nodeToDeviceInput(node));
-    synced++;
+export function planDeviceReconciliation(
+  allNames: Iterable<string>,
+  keep: Iterable<string>,
+  registered: Iterable<string>,
+  ignored: Iterable<string>,
+): DeviceReconciliation {
+  const keepSet = new Set(keep);
+  const regSet = new Set(registered);
+  const ignSet = new Set(ignored);
+  const out: DeviceReconciliation = { toRegister: [], toUnignore: [], toRemove: [], toIgnore: [] };
+  for (const name of allNames) {
+    if (keepSet.has(name)) {
+      out.toRegister.push(name);
+      if (ignSet.has(name)) out.toUnignore.push(name);
+    } else {
+      if (regSet.has(name)) out.toRemove.push(name);
+      out.toIgnore.push(name);
+    }
   }
-
-  return { ok: true, synced, pending };
+  return out;
 }

--- a/src/lib/devices/sync.ts
+++ b/src/lib/devices/sync.ts
@@ -1,0 +1,89 @@
+/**
+ * Reusable device discovery.
+ *
+ * `agents devices sync` was the only thing that ever populated the registry,
+ * and it was purely user-invoked — so the registry sat empty until someone
+ * remembered to run it. This module extracts the ingest so it can be triggered
+ * automatically (from `agents sync` and `agents setup`) without duplicating the
+ * tailscale-parse-and-upsert loop, and exposes the pure pending-device diff the
+ * curation picker and the menu-bar probe both need.
+ *
+ * Two failure modes, one function:
+ *   - hard (default): the CLI `agents devices sync` action wants a clear error
+ *     and a non-zero exit when tailscale is missing.
+ *   - soft (`soft: true`): auto-callers must never abort setup/sync because a
+ *     machine has no tailscale — they get a result with `ok: false` instead.
+ */
+import {
+  loadDevices,
+  loadIgnored,
+  upsertDevice,
+} from './registry.js';
+import {
+  nodeToDeviceInput,
+  parseTailscaleStatus,
+  tailscaleStatusJson,
+  type TailscaleNode,
+} from './tailscale.js';
+
+export interface DeviceSyncResult {
+  /** False when discovery could not run (e.g. tailscale absent) in soft mode. */
+  ok: boolean;
+  /** Number of tailscale nodes upserted into the registry. */
+  synced: number;
+  /** Node names discovered but neither registered-before nor ignored. */
+  pending: string[];
+  /** Populated when ok is false: why discovery was skipped. */
+  reason?: string;
+}
+
+/**
+ * Node names present on the tailnet but neither already in the registry nor on
+ * the ignore-list — i.e. genuinely new devices worth surfacing. Pure so the
+ * flag matrix is unit-testable without a live tailnet.
+ */
+export function computePendingDevices(
+  nodes: TailscaleNode[],
+  registered: Iterable<string>,
+  ignored: Iterable<string>,
+): string[] {
+  const known = new Set<string>(registered);
+  const skip = new Set<string>(ignored);
+  return nodes
+    .map((n) => n.name)
+    .filter((name) => !known.has(name) && !skip.has(name));
+}
+
+/**
+ * Ingest `tailscale status --json` into the registry. In soft mode a missing
+ * tailscale binary / unreachable daemon resolves to `{ ok: false }` instead of
+ * throwing, so callers wiring this into setup/sync never abort the whole run.
+ * The `pending` list is computed against the registry state BEFORE this sync so
+ * "new" means "not previously registered and not ignored".
+ */
+export async function runDeviceSync(opts: { soft?: boolean } = {}): Promise<DeviceSyncResult> {
+  let nodes: TailscaleNode[];
+  try {
+    nodes = parseTailscaleStatus(tailscaleStatusJson());
+  } catch (err: any) {
+    if (opts.soft) {
+      return { ok: false, synced: 0, pending: [], reason: err?.message ?? String(err) };
+    }
+    throw err;
+  }
+
+  const [registeredBefore, ignored] = await Promise.all([loadDevices(), loadIgnored()]);
+  const pending = computePendingDevices(nodes, Object.keys(registeredBefore), ignored);
+
+  // Register/refresh every node the user has NOT dismissed. Skipping ignored
+  // nodes is what makes the "register all" default safe: a phone or someone
+  // else's laptop the user once dismissed never silently comes back.
+  let synced = 0;
+  for (const node of nodes) {
+    if (ignored.has(node.name)) continue;
+    await upsertDevice(node.name, nodeToDeviceInput(node));
+    synced++;
+  }
+
+  return { ok: true, synced, pending };
+}

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -419,6 +419,9 @@ export function getTeamsRegistryPath(): string { return path.join(HISTORY_DIR, '
 /** Path to the device registry — SSH device profiles with platform/auth metadata. Durable runtime, per-machine (host list + addresses are NOT pulled by `agents repo push`). */
 export function getDevicesRegistryPath(): string { return path.join(HISTORY_DIR, 'devices', 'registry.json'); }
 
+/** Path to the device ignore-list — tailscale node names the user dismissed, so auto-discovery never re-suggests them. Per-machine, same dir as the registry. */
+export function getDevicesIgnoredPath(): string { return path.join(HISTORY_DIR, 'devices', 'ignored.json'); }
+
 /** Path to cloud dispatch cache (~/.agents/.cache/cloud/). */
 export function getCloudDir(): string { return CLOUD_DIR; }
 

--- a/src/lib/sync-umbrella.ts
+++ b/src/lib/sync-umbrella.ts
@@ -67,6 +67,7 @@ export interface UmbrellaResult {
   repos?: { pulled: number; errors: string[] };
   secrets?: { pulled: number; skipped: boolean; reason?: string; errors: string[] };
   sessions?: { ran: boolean; pushed: number; pulled: number; merged: number };
+  devices?: { synced: number; pending: number; skipped: boolean };
   reconciled: boolean;
 }
 
@@ -157,6 +158,17 @@ export async function runUmbrellaSync(args: RunUmbrellaArgs): Promise<UmbrellaRe
     const { refresh } = await import('./refresh.js');
     await refresh({ skipPrompts: yes });
     result.reconciled = true;
+
+    // Keep the local device registry current with the tailnet. Soft: a machine
+    // without tailscale is a clean no-op, never a sync failure. This is the
+    // wiring that fixes the "registry stays empty until you remember to run
+    // `agents devices sync`" gap — the SessionStart autosync now populates it.
+    const { runDeviceSync } = await import('./devices/sync.js');
+    const dev = await runDeviceSync({ soft: true });
+    result.devices = { synced: dev.synced, pending: dev.pending.length, skipped: !dev.ok };
+    if (dev.ok) {
+      log(`devices: ${dev.synced} synced${dev.pending.length ? `, ${dev.pending.length} new` : ''}`);
+    }
   }
 
   return result;


### PR DESCRIPTION
## Why

`agents devices` shipped a registry that was **always empty** — `agents devices sync` was the only thing that populated it, and it was never auto-invoked (`setup.ts`, `sync.ts`, `daemon.ts` had zero device calls; `registry.json` didn't even exist on a fresh machine). Tailscale sees the whole fleet; nothing ingested it. This is Component A of a larger device-awareness effort (a SessionStart topology hook and a menu-bar new-device notifier build on top of this).

## What

- **`runDeviceSync()`** (`src/lib/devices/sync.ts`) — extracts the tailscale ingest so it can be triggered automatically without duplicating the parse-and-upsert loop. Soft mode (no tailscale → clean no-op, never aborts a run) for auto-callers; hard mode for the CLI. Exposes the pure `computePendingDevices()` diff (tailnet − registered − ignored).
- **Auto-population** — soft `runDeviceSync()` runs in the umbrella `agents sync` reconcile step (the path the SessionStart autosync hook already fires ~4h) and once in `agents setup`. The registry now stays current on its own.
- **Curation picker** — `agents devices sync` in a TTY opens an `@inquirer` checkbox (house pattern): checked = registered, unchecked = removed **and** ignored. `--yes` / non-TTY keeps the register-all behavior.
- **Persistent ignore-list** — `~/.agents/.history/devices/ignored.json` (helpers in `registry.ts`, reusing the registry's lock + atomic-write plumbing). A dismissed node is never re-registered by auto-sync and never re-suggested. New `agents devices ignore <name>` / `unignore <name>`.

## Design note (opt-out vs opt-in)

Auto-sync currently **registers all non-ignored** tailnet nodes (opt-out; makes `agents devices` useful out of the box, ignore-list handles curation). The follow-up menu-bar PR can layer an approval-based "NEW DEVICES → Register/Ignore" flow on top using `computePendingDevices()` — the ignore-list is shared.

## Verification

- `bun test src/lib/devices/` — 29 pass (new: `computePendingDevices` excludes registered+ignored; ignore-list persists across reloads, idempotent, throws on corruption). `sync-umbrella` tests green. `tsc --noEmit` clean.
- **End-to-end on a live 12-node tailnet:** `ignore ipad165` → removed from registry + written to `ignored.json`; `sync` → registered 11, **ipad165 did not resurface**; `unignore` + `sync` → back to 12 (reported "1 new"). Registry restored to baseline.
- Not verified headlessly: the interactive checkbox keystroke path (inquirer reads its own PTY, not piped stdin) — but every operation it performs (`upsertDevice`/`removeDevice`/`addIgnored`/`removeIgnored`) is covered by the E2E above.