### PR TITLE
feat(devices): mark the current machine in `devices list`

### DIFF
--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -28,6 +28,7 @@ import {
   type DeviceProfile,
 } from '../lib/devices/registry.js';
 import {
+  currentDeviceName,
   nodeToDeviceInput,
   parseTailscaleStatus,
   tailscaleStatusJson,
@@ -47,8 +48,9 @@ function parseTarget(target: string): { host: string; user?: string } {
   return { user: target.slice(0, at), host: target.slice(at + 1) };
 }
 
-/** One-line summary of a device for `list`. */
-function deviceSummary(d: DeviceProfile): string {
+/** One-line summary of a device for `list`. `isSelf` marks the machine this
+ * command is running on so it stands out from the rest of the tailnet. */
+function deviceSummary(d: DeviceProfile, isSelf = false): string {
   const addr = hostNameFor(d) ?? chalk.gray('no address');
   const online = d.tailscale
     ? d.tailscale.online
@@ -56,7 +58,10 @@ function deviceSummary(d: DeviceProfile): string {
       : chalk.gray('offline')
     : chalk.gray('unknown');
   const reach = d.tailscale?.online && !d.tailscale.direct ? chalk.yellow(' (relayed)') : '';
-  return `  ${chalk.bold(d.name.padEnd(16))} ${String(d.platform).padEnd(8)} ${(d.user ? d.user + '@' : '') + addr}  ${online}${reach}`;
+  const marker = isSelf ? chalk.cyan('▸ ') : '  ';
+  const name = isSelf ? chalk.bold.cyan(d.name.padEnd(16)) : chalk.bold(d.name.padEnd(16));
+  const here = isSelf ? chalk.cyan('  ← this machine') : '';
+  return `${marker}${name} ${String(d.platform).padEnd(8)} ${(d.user ? d.user + '@' : '') + addr}  ${online}${reach}${here}`;
 }
 
 /** Resolve a device or exit with a clear error. */
@@ -111,8 +116,9 @@ Typical workflow:
         console.log(chalk.gray("No devices. Run 'agents devices sync' or 'agents devices add <name> <user@host>'."));
         return;
       }
+      const self = currentDeviceName();
       console.log(chalk.bold(`Devices (${names.length})`));
-      for (const name of names) console.log(deviceSummary(reg[name]));
+      for (const name of names) console.log(deviceSummary(reg[name], name === self));
     });
 
   devicesCmd

--- a/src/lib/devices/tailscale.test.ts
+++ b/src/lib/devices/tailscale.test.ts
@@ -6,7 +6,7 @@
  * IPv6 address ssh can't use, and mislabeling a relayed connection as direct.
  */
 import { describe, expect, it } from 'vitest';
-import { parseTailscaleStatus, nodeToDeviceInput, slugifyHostName } from './tailscale.js';
+import { parseTailscaleStatus, nodeToDeviceInput, slugifyHostName, deviceNameFromHostname } from './tailscale.js';
 
 const FIXTURE = JSON.stringify({
   Self: {
@@ -81,6 +81,14 @@ describe('parseTailscaleStatus', () => {
     expect(slugifyHostName("Bisma's MacBook Pro")).toBe('bismas-macbook-pro');
     expect(slugifyHostName('WIN-MINI')).toBe('win-mini');
     expect(slugifyHostName('  edge_case! ')).toBe('edge_case');
+  });
+
+  it('derives the current device name the same way a node name is derived', () => {
+    // Linux: bare hostname is already the MagicDNS label.
+    expect(deviceNameFromHostname('yosemite-s0')).toBe('yosemite-s0');
+    // macOS: LocalHostName carries a `.local` domain that must be dropped, and
+    // the label slugified to match the tailnet's derived name.
+    expect(deviceNameFromHostname('Bismas-MacBook-Pro.local')).toBe('bismas-macbook-pro');
   });
 
   it('projects a node into registry fields', () => {

--- a/src/lib/devices/tailscale.ts
+++ b/src/lib/devices/tailscale.ts
@@ -10,6 +10,7 @@
  * unit-testable without a live tailnet.
  */
 import { spawnSync } from 'child_process';
+import * as os from 'os';
 import {
   type DeviceInput,
   type DevicePlatform,
@@ -84,6 +85,25 @@ function deviceNameFor(raw: RawTsNode, dnsName: string | undefined): string | nu
   if (!host) return null;
   const slug = slugifyHostName(host);
   return slug.length > 0 ? slug : null;
+}
+
+/**
+ * The logical device name of the machine this process is running on, derived
+ * the same way `deviceNameFor` derives a node's name from Tailscale: take the
+ * first label of the hostname (drop any DNS domain like macOS's `.local`) and
+ * slugify it into the ssh-alias charset. This mirrors the MagicDNS label
+ * Tailscale assigns to Self, so the result matches the name that
+ * `agents devices sync` registered for this host — letting `list` flag "this
+ * machine" without a live tailscale call, and staying correct even when the
+ * registry is synced across machines.
+ */
+export function deviceNameFromHostname(hostname: string): string {
+  const label = hostname.split('.')[0];
+  return slugifyHostName(label);
+}
+
+export function currentDeviceName(): string {
+  return deviceNameFromHostname(os.hostname());
 }
 
 function toNode(raw: RawTsNode): TailscaleNode | null {

--- a/src/lib/devices/tailscale.ts
+++ b/src/lib/devices/tailscale.ts
@@ -96,6 +96,10 @@ function deviceNameFor(raw: RawTsNode, dnsName: string | undefined): string | nu
  * `agents devices sync` registered for this host — letting `list` flag "this
  * machine" without a live tailscale call, and staying correct even when the
  * registry is synced across machines.
+ *
+ * Limitation: if the device's MagicDNS name was renamed in the Tailscale admin
+ * console after the last `sync`, the registry key no longer matches the local
+ * hostname and the "this machine" marker silently won't fire until re-sync.
  */
 export function deviceNameFromHostname(hostname: string): string {
   const label = hostname.split('.')[0];


### PR DESCRIPTION
## What

`ag devices list` gave no visual cue for which row is the host you're actually on. This flags it:

```
Devices (12)
  bismas-macbook-pro macos    bismas-macbook-pro.tail1a85a1.ts.net  offline
  ...
▸ yosemite-s0      linux    yosemite-s0.tail1a85a1.ts.net  online (relayed)  ← this machine
  yosemite-s1      linux    yosemite-s1.tail1a85a1.ts.net  online (relayed)
  zion             macos    zion.tail1a85a1.ts.net  online
```

The self row gets a cyan `▸` marker, a bold-cyan name, and a `← this machine` tag. Every other row is unchanged.

## How self is detected

New `deviceNameFromHostname()` / `currentDeviceName()` in `tailscale.ts` derive the local device name **the same way `agents devices sync` derives a node name from Tailscale** — first label of the hostname (drops macOS's `.local`), then `slugifyHostName`. So it matches the name the registry already stored for this host.

Detection is **dynamic at list time**, not a stored `self` flag on the profile: the device registry can be synced across machines, where a persisted flag would be wrong everywhere but the machine that wrote it. This keeps it correct on every host and adds **no live `tailscale` call** to `list` (it stays offline/fast).

## Tests

`src/lib/devices/tailscale.test.ts` covers Linux (`yosemite-s0` → `yosemite-s0`) and macOS (`Bismas-MacBook-Pro.local` → `bismas-macbook-pro`). Full build + tests green in a clean worktree; verified end-to-end by running `ag devices list` on yosemite-s0.