### PR TITLE
feat(sessions): catch-up digest — changes lifecycle, tool histogram, tests, --active dedupe

### DIFF
--- a/src/commands/sessions-picker.ts
+++ b/src/commands/sessions-picker.ts
@@ -12,6 +12,7 @@ import { cleanSessionPrompt, extractSessionTopic } from '../lib/session/prompt.j
 import { linkPath, relativeToCwd } from '../lib/session/render.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { itemPicker } from '../lib/picker.js';
+import { classifyFileChanges, changeCounts, toolHistogram, detectTestResult } from '../lib/session/digest.js';
 
 /**
  * SessionMeta originates in discover.ts (gitBranch, cwd, label, etc. read from
@@ -202,8 +203,8 @@ interface TodoItem {
 function formatCompactPreview(events: ReturnType<typeof parseSession>, session: SessionMeta): string {
   let firstUser = '';
   let lastAssistant = '';
-  const filesModified = new Set<string>();
   const filesRead = new Set<string>();
+  const toolCounts: Record<string, number> = {};
   let toolCalls = 0;
   let planFile = '';
   let latestTodos: TodoItem[] | null = null;
@@ -221,9 +222,7 @@ function formatCompactPreview(events: ReturnType<typeof parseSession>, session: 
     } else if (event.type === 'tool_use' && !event._local) {
       const tool = event.tool || '';
       const p = event.path || event.args?.file_path || event.args?.path || '';
-      if (['Write', 'Edit', 'write_file', 'edit_file', 'create_file', 'replace', 'patch'].includes(tool) && p) {
-        filesModified.add(p);
-      } else if (['Read', 'read_file', 'view_file', 'cat_file', 'get_file'].includes(tool) && p) {
+      if (['Read', 'read_file', 'view_file', 'cat_file', 'get_file'].includes(tool) && p) {
         filesRead.add(p);
       }
       if (!planFile && p && /\/plans\/[^/]+\.md$/.test(p)) {
@@ -232,9 +231,14 @@ function formatCompactPreview(events: ReturnType<typeof parseSession>, session: 
       if (tool === 'TodoWrite' && Array.isArray(event.args?.todos)) {
         latestTodos = event.args.todos as TodoItem[];
       }
+      if (tool) toolCounts[tool] = (toolCounts[tool] ?? 0) + 1;
       toolCalls++;
     }
   }
+
+  // Digest signals folded into the preview: change lifecycle, tool mix, tests.
+  const changes = classifyFileChanges(events);
+  const chg = changeCounts(changes);
 
   const lines: string[] = [];
   const termWidth = process.stdout.columns || 80;
@@ -247,11 +251,36 @@ function formatCompactPreview(events: ReturnType<typeof parseSession>, session: 
   }
 
   const activity: string[] = [];
-  if (filesModified.size) activity.push(`${filesModified.size} modified`);
-  if (filesRead.size) activity.push(`${filesRead.size} read`);
-  if (toolCalls) activity.push(`${toolCalls} tool${toolCalls === 1 ? '' : 's'}`);
+  const changed = chg.created + chg.modified + chg.deleted;
+  if (changed) {
+    const parts = [
+      chg.created ? chalk.green(`+${chg.created}`) : '',
+      chg.modified ? chalk.yellow(`~${chg.modified}`) : '',
+      chg.deleted ? chalk.red(`−${chg.deleted}`) : '',
+    ].filter(Boolean).join(' ');
+    activity.push(`${parts} ${chalk.gray('changed')}`);
+  }
+  if (filesRead.size) activity.push(chalk.gray(`${filesRead.size} read`));
+  if (toolCalls) activity.push(chalk.gray(`${toolCalls} tool${toolCalls === 1 ? '' : 's'}`));
   if (activity.length) {
-    lines.push(chalk.cyan('Activity: ') + chalk.gray(activity.join(' · ')));
+    lines.push(chalk.cyan('Changes:  ') + activity.join(chalk.gray(' · ')));
+  }
+
+  // Tool mix (top 4) — what kind of work this was.
+  const hist = toolHistogram(toolCounts, 4);
+  if (hist.length) {
+    lines.push(chalk.cyan('Tools:    ') + chalk.gray(hist.map(h => `${h.tool} ${h.count}`).join(' · ')));
+  }
+
+  // Last test/build verdict.
+  const test = detectTestResult(events);
+  if (test?.ok) {
+    const bits = [
+      test.passed !== undefined ? chalk.green(`${test.passed} pass`) : '',
+      test.failed ? chalk.red(`${test.failed} fail`) : '',
+    ].filter(Boolean).join(chalk.gray(' · '));
+    const mark = test.failed ? chalk.red('✗') : chalk.green('✓');
+    lines.push(chalk.cyan('Tests:    ') + `${mark} ${test.runner}${bits ? ' ' + bits : ''}`);
   }
 
   if (planFile) {

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -296,7 +296,8 @@ function printActiveRow(s: ActiveSession, indent: string): void {
   const kindCol = colorAgent(s.kind as any)(padToWidth(truncateToWidth(s.kind, 8), 9));
   const hostCol = chalk.gray(padToWidth(truncateToWidth(s.host ?? '-', 8), 9));
   const statusCol = statusColor(s.status)(padToWidth(truncateToWidth(activityLabel(s), 8), 9));
-  const badges = signalBadges(s);
+  const fork = s.pidCount && s.pidCount > 1 ? chalk.dim(`×${s.pidCount} `) : '';
+  const badges = (fork ? fork : '') + signalBadges(s);
   const desc = buildSessionDescription(s) || '-';
   // Fill the remaining width with the preview so nothing wraps under tmux/SSH.
   const fixed = stringWidth(indent) + 9 + 9 + 9 + 9 + (badges ? stringWidth(badges) + 1 : 0);
@@ -801,6 +802,13 @@ async function renderSession(
     const branchStr = session.gitBranch ? chalk.gray(` (${session.gitBranch})`) : '';
     const absTime = formatAbsoluteTime(session.timestamp);
 
+    // Auto-inferred title headline (user /rename > Claude ai-title > first-prompt
+    // topic) — the fastest way to recognize which task this session is.
+    const title = (session as any).label || session.topic;
+    if (title) {
+      const badges = signalBadges(metaSignals(session));
+      console.log(chalk.bold.white(title) + (badges ? '  ' + badges : ''));
+    }
     console.log(
       agentColor(session.agent) +
       (session.version ? chalk.yellow(` ${session.version}`) : '') +

--- a/src/lib/session/__tests__/render.test.ts
+++ b/src/lib/session/__tests__/render.test.ts
@@ -577,6 +577,7 @@ describe('renderSummaryHeader', () => {
       userTurns: 10,
       assistantTurns: 10,
       toolCount: 50,
+      toolCounts: { Edit: 30, Bash: 20 },
       errorCount: 2,
       outputTokens: 361_000,
       cacheReadTokens: 67_500_000,
@@ -598,6 +599,7 @@ describe('renderSummaryHeader', () => {
       userTurns: 5,
       assistantTurns: 5,
       toolCount: 0,
+      toolCounts: {},
       errorCount: 0,
       outputTokens: 0,
       cacheReadTokens: 0,
@@ -628,8 +630,8 @@ describe('renderSummary', () => {
       makeEvent({ type: 'tool_use', tool: 'Edit', args: { file_path: '/project/src/a.ts' }, path: '/project/src/a.ts' }),
     ];
     const out = renderSummary(events, '/project');
-    // a.ts should appear in Modified, not in Read
-    expect(out).toContain('Modified');
+    // a.ts should appear in Changes (modified), not in Read
+    expect(out).toContain('Changes');
     // The Read section should not appear since the only read file was also modified
     // (and would be deduped out, leaving 0 read-only files)
     const readMatch = out.match(/Read\s+\((\d+)\)/);
@@ -721,13 +723,13 @@ describe('renderSummary', () => {
     expect(out).toContain('Bash');
   });
 
-  it('separates external edits (outside cwd) from in-project Modified', () => {
+  it('separates external edits (outside cwd) from in-project Changes', () => {
     const events: SessionEvent[] = [
       makeEvent({ type: 'tool_use', tool: 'Edit', args: { file_path: '/project/src/a.ts' }, path: '/project/src/a.ts' }),
       makeEvent({ type: 'tool_use', tool: 'Edit', args: { file_path: '/tmp/scratch.md' }, path: '/tmp/scratch.md' }),
     ];
     const out = renderSummary(events, '/project');
-    expect(out).toContain('Modified');
+    expect(out).toContain('Changes');
     expect(out).toContain('src/a.ts');
     expect(out).toContain('External edits');
     expect(out).toContain('/tmp/scratch.md');
@@ -744,7 +746,7 @@ describe('renderSummary', () => {
     expect(out).toContain('Migrate to FTS5 index');
   });
 
-  it('uses cwd-relative paths in Modified section', () => {
+  it('uses cwd-relative paths in Changes section', () => {
     const events: SessionEvent[] = [
       makeEvent({ type: 'tool_use', tool: 'Edit', args: { file_path: '/project/src/lib/render.ts' }, path: '/project/src/lib/render.ts' }),
     ];
@@ -767,7 +769,7 @@ describe('renderSummary', () => {
     const out = renderSummary(events, '/p');
     const promptIdx = out.indexOf('Prompt:');
     const recentIdx = out.indexOf('Recent Activity');
-    const modifiedIdx = out.indexOf('Modified');
+    const modifiedIdx = out.indexOf('Changes');
     expect(promptIdx).toBeGreaterThanOrEqual(0);
     expect(recentIdx).toBeGreaterThan(promptIdx);
     expect(modifiedIdx).toBeGreaterThan(recentIdx);
@@ -802,7 +804,7 @@ describe('renderSummary', () => {
       makeEvent({ role: 'assistant', content: 'all done now', timestamp: '2024-01-01T00:00:05Z' }),
     ];
     const out = renderSummary(events, '/p');
-    const recentBlock = out.slice(out.indexOf('Recent Activity'), out.indexOf('Modified'));
+    const recentBlock = out.slice(out.indexOf('Recent Activity'), out.indexOf('Changes'));
     expect(recentBlock).toContain('Edit');
     expect(recentBlock).toContain('a.ts');
     expect(recentBlock).toContain('Bash');
@@ -822,7 +824,7 @@ describe('renderSummary', () => {
     ];
     const out = renderSummary(events, '/p');
     const errorsIdx = out.indexOf('Errors');
-    const modifiedIdx = out.indexOf('Modified');
+    const modifiedIdx = out.indexOf('Changes');
     const commandsIdx = out.indexOf('Commands');
     expect(errorsIdx).toBeGreaterThan(-1);
     expect(errorsIdx).toBeLessThan(modifiedIdx);

--- a/src/lib/session/active.ts
+++ b/src/lib/session/active.ts
@@ -63,6 +63,8 @@ export interface ActiveSession {
   sessionFile?: string;
   startedAtMs?: number;
   status: ActiveStatus;
+  /** How many live PIDs resolve to this same session (subagents/forks). 1 unless collapsed. */
+  pidCount?: number;
   teamName?: string;
   agentId?: string;
   cloudProvider?: string;
@@ -599,5 +601,30 @@ export async function getActiveSessions(opts: ActiveQueryOptions = {}): Promise<
 
   const unattributed = opts.skipHeadless ? [] : await listUnattributedActive(knownPids);
 
-  return [...teams, ...terminals, ...cloud, ...unattributed];
+  return dedupeBySession([...teams, ...terminals, ...cloud, ...unattributed]);
+}
+
+/**
+ * Collapse rows that resolve to the *same* session — a session with many
+ * subagent/fork PIDs (all matched to one transcript file) would otherwise print
+ * dozens of identical rows. Keyed by session id (falling back to the file), the
+ * first row wins and carries a `pidCount`. Rows with no session identity (cloud,
+ * unresolved headless) pass through untouched.
+ */
+function dedupeBySession(sessions: ActiveSession[]): ActiveSession[] {
+  const out: ActiveSession[] = [];
+  const byKey = new Map<string, ActiveSession>();
+  for (const s of sessions) {
+    const key = s.sessionId || s.sessionFile;
+    if (!key) { out.push(s); continue; }
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.pidCount = (existing.pidCount ?? 1) + 1;
+    } else {
+      s.pidCount = 1;
+      byKey.set(key, s);
+      out.push(s);
+    }
+  }
+  return out;
 }

--- a/src/lib/session/digest.test.ts
+++ b/src/lib/session/digest.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import type { SessionEvent } from './types.js';
+import {
+  classifyFileChanges,
+  changeCounts,
+  toolHistogram,
+  detectTestResult,
+  extractDeletedPaths,
+} from './digest.js';
+
+function tool(toolName: string, path?: string, command?: string): SessionEvent {
+  return { type: 'tool_use', agent: 'claude', timestamp: '2026-06-30T10:00:00Z', tool: toolName, path, command, args: path ? { file_path: path } : {} };
+}
+function result(output: string): SessionEvent {
+  return { type: 'tool_result', agent: 'claude', timestamp: '2026-06-30T10:00:01Z', success: true, output };
+}
+
+describe('classifyFileChanges', () => {
+  it('Write to a fresh path is a creation; Edit is a modification', () => {
+    const changes = classifyFileChanges([tool('Write', 'src/new.ts'), tool('Edit', 'src/existing.ts')]);
+    expect(changes).toContainEqual({ path: 'src/new.ts', op: 'created' });
+    expect(changes).toContainEqual({ path: 'src/existing.ts', op: 'modified' });
+  });
+
+  it('a Read before a Write means modified, not created', () => {
+    const changes = classifyFileChanges([tool('Read', 'src/a.ts'), tool('Write', 'src/a.ts')]);
+    expect(changes).toContainEqual({ path: 'src/a.ts', op: 'modified' });
+    expect(changes.find(c => c.path === 'src/a.ts')?.op).not.toBe('created');
+  });
+
+  it('created then edited nets to created (still a new file)', () => {
+    const changes = classifyFileChanges([tool('Write', 'src/n.ts'), tool('Edit', 'src/n.ts')]);
+    expect(changes.filter(c => c.path === 'src/n.ts')).toEqual([{ path: 'src/n.ts', op: 'created' }]);
+  });
+
+  it('a deletion wins over an earlier create/modify', () => {
+    const changes = classifyFileChanges([tool('Write', 'tmp/x'), tool('Bash', undefined, 'rm tmp/x')]);
+    expect(changes).toContainEqual({ path: 'tmp/x', op: 'deleted' });
+    expect(changes.find(c => c.path === 'tmp/x')?.op).toBe('deleted');
+  });
+
+  it('excludes plan files', () => {
+    const changes = classifyFileChanges([tool('Write', '/home/u/.claude/plans/foo.md')]);
+    expect(changes).toHaveLength(0);
+  });
+});
+
+describe('extractDeletedPaths', () => {
+  it('parses rm and git rm, skipping flags and globs', () => {
+    expect(extractDeletedPaths('rm -rf dist a.txt')).toEqual(['dist', 'a.txt']);
+    expect(extractDeletedPaths('git rm old.ts')).toEqual(['old.ts']);
+    expect(extractDeletedPaths('rm *.log')).toEqual([]); // glob skipped
+  });
+  it('ignores non-delete commands', () => {
+    expect(extractDeletedPaths('echo rm not-a-delete')).toEqual([]);
+  });
+});
+
+describe('changeCounts', () => {
+  it('tallies per op', () => {
+    const c = changeCounts([
+      { path: 'a', op: 'created' }, { path: 'b', op: 'created' },
+      { path: 'c', op: 'modified' }, { path: 'd', op: 'deleted' },
+    ]);
+    expect(c).toEqual({ created: 2, modified: 1, deleted: 1 });
+  });
+});
+
+describe('toolHistogram', () => {
+  it('sorts by count descending and caps', () => {
+    const h = toolHistogram({ Read: 5, Edit: 20, Bash: 12 }, 2);
+    expect(h).toEqual([{ tool: 'Edit', count: 20 }, { tool: 'Bash', count: 12 }]);
+  });
+});
+
+describe('detectTestResult', () => {
+  it('correlates a runner with the following result (vitest pass/fail)', () => {
+    const r = detectTestResult([
+      tool('Bash', undefined, 'bun run test'),
+      result('Test Files 1 failed | 16 passed\nTests 4 failed | 294 passed'),
+    ]);
+    expect(r?.runner).toBe('tests');
+    expect(r?.passed).toBe(294);
+    expect(r?.failed).toBe(4);
+  });
+
+  it('reads tsc as clean when no TS errors', () => {
+    const r = detectTestResult([tool('Bash', undefined, 'npx tsc --noEmit'), result('')]);
+    expect(r?.runner).toBe('tsc');
+    expect(r?.failed).toBe(0);
+    expect(r?.ok).toBe(true);
+  });
+
+  it('returns the LAST run when several happen', () => {
+    const r = detectTestResult([
+      tool('Bash', undefined, 'bun test'), result('1 passed'),
+      tool('Bash', undefined, 'pytest'), result('3 passed, 1 failed'),
+    ]);
+    expect(r?.runner).toBe('pytest');
+    expect(r?.passed).toBe(3);
+  });
+
+  it('returns undefined when nothing ran', () => {
+    expect(detectTestResult([tool('Read', 'a.ts')])).toBeUndefined();
+  });
+});

--- a/src/lib/session/digest.test.ts
+++ b/src/lib/session/digest.test.ts
@@ -43,6 +43,15 @@ describe('classifyFileChanges', () => {
     const changes = classifyFileChanges([tool('Write', '/home/u/.claude/plans/foo.md')]);
     expect(changes).toHaveLength(0);
   });
+
+  it('created then deleted then recreated nets to created (file exists)', () => {
+    const changes = classifyFileChanges([
+      tool('Write', 'tmp/x'),
+      tool('Bash', undefined, 'rm tmp/x'),
+      tool('Write', 'tmp/x'),
+    ]);
+    expect(changes.filter(c => c.path === 'tmp/x')).toEqual([{ path: 'tmp/x', op: 'created' }]);
+  });
 });
 
 describe('extractDeletedPaths', () => {
@@ -50,6 +59,9 @@ describe('extractDeletedPaths', () => {
     expect(extractDeletedPaths('rm -rf dist a.txt')).toEqual(['dist', 'a.txt']);
     expect(extractDeletedPaths('git rm old.ts')).toEqual(['old.ts']);
     expect(extractDeletedPaths('rm *.log')).toEqual([]); // glob skipped
+  });
+  it('parses a delete chained after another command', () => {
+    expect(extractDeletedPaths('bun run build && rm dist/old.js')).toEqual(['dist/old.js']);
   });
   it('ignores non-delete commands', () => {
     expect(extractDeletedPaths('echo rm not-a-delete')).toEqual([]);
@@ -102,5 +114,23 @@ describe('detectTestResult', () => {
 
   it('returns undefined when nothing ran', () => {
     expect(detectTestResult([tool('Read', 'a.ts')])).toBeUndefined();
+  });
+
+  it('reads go test PASS/FAIL markers', () => {
+    const pass = detectTestResult([tool('Bash', undefined, 'go test ./...'), result('--- PASS: TestA (0.01s)\nok  \tpkg\t0.2s')]);
+    expect(pass?.runner).toBe('go test');
+    expect(pass?.failed).toBe(0);
+    const fail = detectTestResult([tool('Bash', undefined, 'go test ./...'), result('--- FAIL: TestB (0.01s)\nFAIL\tpkg\t0.2s')]);
+    expect(fail?.failed).toBe(1);
+    expect(fail?.ok).toBe(true);
+  });
+
+  it('marks the runner failed when the result is an error event', () => {
+    const r = detectTestResult([
+      { type: 'tool_use', agent: 'claude', timestamp: '2026-06-30T10:00:00Z', tool: 'Bash', command: 'bun test' },
+      { type: 'error', agent: 'claude', timestamp: '2026-06-30T10:00:01Z', tool: 'Bash', content: 'exit 1' },
+    ]);
+    expect(r?.runner).toBe('tests');
+    expect(r?.failed).toBe(1);
   });
 });

--- a/src/lib/session/digest.ts
+++ b/src/lib/session/digest.ts
@@ -1,0 +1,166 @@
+/**
+ * Catch-up digest extractors.
+ *
+ * Pure functions that turn a session's events into the signals a developer needs
+ * to reload a task fast when switching between many agents: which files changed
+ * and how (created / modified / deleted), which tools dominated the work, and the
+ * last test/build result. Consumed by the single-session view and the picker
+ * preview. No I/O — fully unit-testable.
+ */
+
+import type { SessionEvent } from './types.js';
+
+export type FileOp = 'created' | 'modified' | 'deleted';
+export interface FileChange {
+  path: string;
+  op: FileOp;
+}
+
+// Tool vocab mirrors parse.ts / render.ts so classification matches what those
+// modules already recognize across Claude/Codex/others.
+const READ_TOOLS = new Set(['Read', 'read_file', 'view_file', 'cat_file', 'get_file']);
+const WRITE_TOOLS = new Set(['Write', 'write_file', 'create_file']);
+const EDIT_TOOLS = new Set(['Edit', 'edit_file', 'replace', 'patch', 'MultiEdit', 'apply_patch']);
+
+/** Extract file paths deleted by a shell command (rm / git rm / unlink). Conservative. */
+export function extractDeletedPaths(command: string): string[] {
+  const out: string[] = [];
+  // Split on && ; | to inspect each simple command separately.
+  for (const seg of command.split(/&&|\|\||;|\|/)) {
+    const m = seg.trim().match(/^(?:sudo\s+)?(?:git\s+rm|rm|unlink)\s+(.+)$/);
+    if (!m) continue;
+    for (const tok of m[1].split(/\s+/)) {
+      if (tok.startsWith('-')) continue;          // flags (-r, -f, --force)
+      if (/[*?{}]/.test(tok)) continue;           // globs — too imprecise to attribute
+      out.push(tok.replace(/^['"]|['"]$/g, ''));  // unquote
+    }
+  }
+  return out;
+}
+
+/**
+ * Classify every touched file as created / modified / deleted from the event
+ * stream. Heuristics: a Write to a path never previously Read and not seen
+ * before is a *creation*; an Edit (or a Write to a known/read path) is a
+ * *modification*; a path in an `rm`/`git rm` command is a *deletion* (and wins
+ * over create/modify — a created-then-deleted file nets to gone). Plan files
+ * (`.claude/plans/*.md`) are excluded; they're surfaced by detectPlan.
+ */
+export function classifyFileChanges(events: SessionEvent[]): FileChange[] {
+  const readBefore = new Set<string>();
+  const created = new Set<string>();
+  const modified = new Set<string>();
+  const deleted = new Set<string>();
+  const seen = new Set<string>();
+
+  for (const e of events) {
+    if (e.type !== 'tool_use' || e._local) continue;
+    if (e.command) for (const d of extractDeletedPaths(e.command)) deleted.add(d);
+
+    const tool = e.tool || '';
+    const args = e.args || {};
+    const p = e.path || args.file_path || args.path || '';
+    if (!p) continue;
+    if (p.includes('.claude/plans/') && p.endsWith('.md')) continue;
+
+    if (READ_TOOLS.has(tool)) {
+      readBefore.add(p);
+    } else if (WRITE_TOOLS.has(tool)) {
+      if (!seen.has(p) && !readBefore.has(p)) created.add(p);
+      else modified.add(p);
+      seen.add(p);
+    } else if (EDIT_TOOLS.has(tool)) {
+      modified.add(p);
+      seen.add(p);
+    }
+  }
+
+  const out: FileChange[] = [];
+  for (const p of created) if (!deleted.has(p)) out.push({ path: p, op: 'created' });
+  for (const p of modified) if (!created.has(p) && !deleted.has(p)) out.push({ path: p, op: 'modified' });
+  for (const p of deleted) out.push({ path: p, op: 'deleted' });
+  return out;
+}
+
+/** Net change summary: counts per op. */
+export function changeCounts(changes: FileChange[]): { created: number; modified: number; deleted: number } {
+  const c = { created: 0, modified: 0, deleted: 0 };
+  for (const ch of changes) c[ch.op]++;
+  return c;
+}
+
+/** Tool histogram sorted highest-first, capped to `top` entries. */
+export function toolHistogram(toolCounts: Record<string, number>, top = 8): Array<{ tool: string; count: number }> {
+  return Object.entries(toolCounts)
+    .map(([tool, count]) => ({ tool, count }))
+    .sort((a, b) => b.count - a.count || a.tool.localeCompare(b.tool))
+    .slice(0, top);
+}
+
+export interface TestResult {
+  runner: string;
+  passed?: number;
+  failed?: number;
+  /** True when we could parse a pass/fail verdict. */
+  ok: boolean;
+  ts: number;
+}
+
+/** Recognized test/build runners → the label we show. */
+const TEST_RUNNERS: Array<{ re: RegExp; label: string }> = [
+  { re: /\b((?:bun|npm|yarn|pnpm)\s+(?:run\s+)?test|vitest|jest)\b/, label: 'tests' },
+  { re: /\bpytest\b/, label: 'pytest' },
+  { re: /\bgo\s+test\b/, label: 'go test' },
+  { re: /\bcargo\s+test\b/, label: 'cargo test' },
+  { re: /\b(tsc|tsc\s+--noEmit)\b/, label: 'tsc' },
+];
+
+/** Parse pass/fail counts from common runner output. */
+function parseTestOutput(runner: string, output: string): { passed?: number; failed?: number; ok: boolean } {
+  // vitest/jest/bun: "N passed", "N failed"; pytest: "N passed, N failed".
+  // Take the LAST occurrence — runners print a per-file line first, then the
+  // authoritative aggregate ("Tests 4 failed | 294 passed") at the end.
+  const lastNum = (re: RegExp): number | undefined => {
+    let m: RegExpExecArray | null;
+    let val: number | undefined;
+    const g = new RegExp(re.source, 'gi');
+    while ((m = g.exec(output)) !== null) val = +m[1];
+    return val;
+  };
+  const passed = lastNum(/(\d+)\s+pass(?:ed)?/);
+  const failed = lastNum(/(\d+)\s+fail(?:ed|ures?)?/);
+  if (passed !== undefined || failed !== undefined) {
+    return { passed, failed, ok: true };
+  }
+  // tsc: no news is good news; "error TSxxxx" means failure.
+  if (runner === 'tsc') {
+    const errs = output.match(/error\s+TS\d+/gi);
+    return { failed: errs ? errs.length : 0, ok: true };
+  }
+  return { ok: false };
+}
+
+/**
+ * The most recent test/build run and its verdict. Correlates a runner command
+ * (tool_use) with the next tool_result's output. Returns undefined if none ran.
+ */
+export function detectTestResult(events: SessionEvent[]): TestResult | undefined {
+  let pending: { runner: string; ts: number } | null = null;
+  let last: TestResult | undefined;
+
+  for (const e of events) {
+    const ts = new Date(e.timestamp).getTime() || 0;
+    if (e.type === 'tool_use' && e.command) {
+      const hit = TEST_RUNNERS.find(r => r.re.test(e.command!));
+      pending = hit ? { runner: hit.label, ts } : pending;
+    } else if (e.type === 'tool_result' && pending) {
+      const parsed = parseTestOutput(pending.runner, e.output || '');
+      last = { runner: pending.runner, ts: pending.ts, ...parsed };
+      pending = null;
+    } else if (e.type === 'error' && pending) {
+      last = { runner: pending.runner, ts: pending.ts, ok: true, failed: 1 };
+      pending = null;
+    }
+  }
+  return last;
+}

--- a/src/lib/session/digest.ts
+++ b/src/lib/session/digest.ts
@@ -69,9 +69,11 @@ export function classifyFileChanges(events: SessionEvent[]): FileChange[] {
       if (!seen.has(p) && !readBefore.has(p)) created.add(p);
       else modified.add(p);
       seen.add(p);
+      deleted.delete(p); // a write after a delete recreates the file
     } else if (EDIT_TOOLS.has(tool)) {
       modified.add(p);
       seen.add(p);
+      deleted.delete(p);
     }
   }
 
@@ -136,6 +138,17 @@ function parseTestOutput(runner: string, output: string): { passed?: number; fai
   if (runner === 'tsc') {
     const errs = output.match(/error\s+TS\d+/gi);
     return { failed: errs ? errs.length : 0, ok: true };
+  }
+  // go test: no pass/fail counts — uses `--- PASS/FAIL:` lines and an ok/FAIL
+  // summary. Count the per-test markers; fall back to the summary verdict.
+  if (runner === 'go test') {
+    const passCount = (output.match(/---\s+PASS/gi) || []).length;
+    const failCount = (output.match(/---\s+FAIL/gi) || []).length;
+    const sawFail = failCount > 0 || /(^|\s)FAIL($|\s)/.test(output);
+    const sawOk = /(^|\s)(ok|PASS)($|\s)/.test(output);
+    if (sawFail || sawOk) {
+      return { passed: passCount || undefined, failed: sawFail ? failCount || 1 : 0, ok: true };
+    }
   }
   return { ok: false };
 }

--- a/src/lib/session/render.ts
+++ b/src/lib/session/render.ts
@@ -13,6 +13,7 @@ import { summarizeToolUse } from './parse.js';
 import { cleanSessionPrompt, extractSessionTopic } from './prompt.js';
 import { renderMarkdown } from '../markdown.js';
 import { redactSecrets } from '../redact.js';
+import { classifyFileChanges, changeCounts, toolHistogram, detectTestResult, type FileChange, type FileOp } from './digest.js';
 
 // ── Path helpers ──────────────────────────────────────────────────────────────
 
@@ -179,6 +180,8 @@ export interface SessionStats {
   userTurns: number;
   assistantTurns: number;
   toolCount: number;
+  /** Per-tool call counts (histogram), highest first when rendered. */
+  toolCounts: Record<string, number>;
   errorCount: number;
   outputTokens: number;
   cacheReadTokens: number;
@@ -189,6 +192,7 @@ export interface SessionStats {
 /** Compute aggregate statistics (turns, tools, tokens, duration) from session events. */
 export function computeSummaryStats(events: SessionEvent[]): SessionStats {
   const modelSet = new Set<string>();
+  const toolCounts: Record<string, number> = {};
   let userTurns = 0;
   let assistantTurns = 0;
   let toolCount = 0;
@@ -209,6 +213,7 @@ export function computeSummaryStats(events: SessionEvent[]): SessionStats {
       else if (e.role === 'assistant') assistantTurns++;
     } else if (e.type === 'tool_use' && !e._local) {
       toolCount++;
+      if (e.tool) toolCounts[e.tool] = (toolCounts[e.tool] ?? 0) + 1;
     } else if (e.type === 'error') {
       errorCount++;
     } else if (e.type === 'usage') {
@@ -223,6 +228,7 @@ export function computeSummaryStats(events: SessionEvent[]): SessionStats {
     userTurns,
     assistantTurns,
     toolCount,
+    toolCounts,
     errorCount,
     outputTokens,
     cacheReadTokens,
@@ -487,6 +493,76 @@ function renderActivityLine(item: {
   }
 }
 
+// ── Catch-up digest sections ──────────────────────────────────────────────────
+
+const OP_GLYPH: Record<FileOp, (s: string) => string> = {
+  created: (s) => chalk.green(s),
+  modified: (s) => chalk.yellow(s),
+  deleted: (s) => chalk.red(s),
+};
+const OP_MARK: Record<FileOp, string> = { created: '+', modified: '~', deleted: '−' };
+
+/**
+ * Render the Changes section: files grouped by directory, each tagged with its
+ * create/modify/delete lifecycle, plus a `+N ~N −N` summary. Replaces the old
+ * flat "Modified" list. Returns true if anything was rendered.
+ */
+function renderChangesSection(lines: string[], events: SessionEvent[], cwd?: string): boolean {
+  // In-project changes only; edits outside cwd (e.g. /tmp) keep their own
+  // "External edits" section so they don't clutter the project's changeset.
+  const inCwd = (p: string): boolean => !cwd || !p.startsWith('/') || p.startsWith(cwd + '/');
+  const changes = classifyFileChanges(events).filter(ch => inCwd(ch.path));
+  if (changes.length === 0) return false;
+  const c = changeCounts(changes);
+  const opByRel = new Map<string, FileOp>();
+  for (const ch of changes) opByRel.set(relativeToCwd(ch.path, cwd), ch.op);
+
+  const summary = [
+    c.created ? chalk.green(`+${c.created}`) : '',
+    c.modified ? chalk.yellow(`~${c.modified}`) : '',
+    c.deleted ? chalk.red(`−${c.deleted}`) : '',
+  ].filter(Boolean).join(' ');
+  lines.push(chalk.bold('Changes') + chalk.gray(` (${changes.length})  `) + summary);
+
+  const groups = groupByParentDir(changes.map(ch => ch.path), cwd);
+  const single = groups.size === 1;
+  for (const [dir, files] of groups) {
+    // Single dir: show the full relative path per file (dir/base). Multiple
+    // dirs: a dir header, then bare filenames under it.
+    if (!single) lines.push('  ' + chalk.dim(dir + '/'));
+    for (const f of files.sort()) {
+      const rel = dir === '.' ? f : `${dir}/${f}`;
+      const op = opByRel.get(rel) ?? 'modified';
+      const shown = single ? rel : f;
+      const name = op === 'deleted' ? chalk.strikethrough(chalk.gray(shown)) : shown;
+      lines.push((single ? '  ' : '    ') + OP_GLYPH[op](OP_MARK[op]) + ' ' + name);
+    }
+  }
+  lines.push('');
+  return true;
+}
+
+/** Render the tool histogram: `Edit 61 · Bash 48 · Read 35 …`. */
+function renderToolsSection(lines: string[], stats: SessionStats): void {
+  const hist = toolHistogram(stats.toolCounts, 8);
+  if (hist.length === 0) return;
+  const parts = hist.map(h => `${chalk.white(h.tool)} ${chalk.gray(String(h.count))}`);
+  lines.push(chalk.bold('Tools') + '  ' + parts.join(chalk.gray(' · ')));
+  lines.push('');
+}
+
+/** Render the last test/build verdict, e.g. `Tests  tests: 294 pass · 4 fail`. */
+function renderTestsLine(lines: string[], events: SessionEvent[]): void {
+  const r = detectTestResult(events);
+  if (!r || !r.ok) return;
+  const bits: string[] = [];
+  if (r.passed !== undefined) bits.push(chalk.green(`${r.passed} pass`));
+  if (r.failed !== undefined) bits.push(r.failed > 0 ? chalk.red(`${r.failed} fail`) : chalk.gray('0 fail'));
+  const verdict = r.failed && r.failed > 0 ? chalk.red('✗') : chalk.green('✓');
+  lines.push(chalk.bold('Tests') + `  ${verdict} ${chalk.cyan(r.runner)} ${bits.join(chalk.gray(' · '))}`);
+  lines.push('');
+}
+
 // ── Main summary renderer ─────────────────────────────────────────────────────
 
 /**
@@ -723,16 +799,16 @@ export function renderSummary(events: SessionEvent[], cwd?: string): string {
     lines.push('');
   }
 
-  // 6. Modified files
-  if (filesModifiedAbs.size > 0) {
-    lines.push(chalk.bold('Modified') + chalk.gray(` (${filesModifiedAbs.size})`));
-    const groups = groupByParentDir(filesModifiedAbs, cwd);
-    renderFileGroup(lines, groups, modifiedAbsMap);
-    lines.push('');
-  }
+  // 6. Changes — files grouped by directory with create/modify/delete lifecycle
+  // (replaces the old flat "Modified" + "External edits" lists).
+  renderChangesSection(lines, events, cwd);
 
-  // 6b. External edits (files edited outside the project root — typically /tmp)
-  // Filter out plan files (already shown in Plan section)
+  // 6b. Catch-up signals: last test/build verdict, then the tool histogram.
+  renderTestsLine(lines, events);
+  renderToolsSection(lines, computeSummaryStats(events));
+
+  // 6c. External edits (files edited outside the project root — typically /tmp).
+  // Filter out plan files (already shown in Plan section).
   const externalNonPlan = [...filesModifiedExternal].filter(p => !(p.includes('.claude/plans/') && p.endsWith('.md')));
   if (externalNonPlan.length > 0) {
     const externalList = externalNonPlan.sort();

--- a/src/lib/session/render.ts
+++ b/src/lib/session/render.ts
@@ -710,7 +710,6 @@ export function renderSummary(events: SessionEvent[], cwd?: string): string {
     return m;
   };
 
-  const modifiedAbsMap = buildAbsMap(filesModifiedAbs);
   const readAbsMap = buildAbsMap(filesReadAbs);
 
   // ── Render sections ───────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Follow-on to #494 (session-state engine, merged). Turns `agents sessions <id>` into a fast **catch-up view** for developers switching between many agents, and collapses the noisy duplicate rows in `--active`.

## Summary view — `agents sessions <id>`

- **Auto-inferred title headline** (user rename > Claude `ai-title` > first-prompt topic) + PR / worktree / ticket badges.
- **Changes** section replaces the flat "Modified" list: files **grouped by directory**, each tagged created `+` / modified `~` / deleted `−`, with a `+N ~N −N` summary. External edits keep their own section.
- **Tools** histogram (per-tool call counts) and a **Tests** verdict line (last vitest/jest/pytest/go/cargo/tsc run, pass/fail).

Real output:

```
Fix ag sync command argument parsing  PR#491
...
Changes (21)  +9 ~11 −1
  src/lib/session/
    ~ active.ts   ~ db.ts   + digest.ts   + state.ts   + tail.ts   + width.ts   ~ render.ts …
  src/commands/
    ~ sessions.ts   ~ sessions-picker.ts

Tools  Bash 103 · Edit 84 · Read 65 · Write 12 · Agent 3 · AskUserQuestion 2 · ExitPlanMode 1
Tests  ✓ tsc 0 fail
```

## `agents sessions --active` — dedupe

Collapses the N subagent/fork PIDs of one session into a single `×N` row (was dozens of identical lines):

```
~/src/github.com/muqsitnawaz (3)
  59a62ff1 claude  tmux  waiting  ×16 ask   Good catch — and I was wrong to call it …
  258f1765 claude  tmux  working  ×13       Bash: cd /home/muqsit/src/github.com/…
  019efac7 codex   tmux  waiting  perm      Bash: rg -n "function readAndResolveBundleEnv…
```

## Engine + tests

New pure module `digest.ts` (`classifyFileChanges` / `toolHistogram` / `detectTestResult`), unit-tested. The same lifecycle/tools/tests signals are folded into the interactive picker preview. Full session + commands suite green: **473 tests** (vitest/Node — the CI path). Verified end-to-end on real Claude/Codex sessions on-device.