### PR TITLE
feat(devices): mark the current machine in `devices list`

### DIFF
--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -18,6 +18,7 @@ import * as path from 'path';
 import chalk from 'chalk';
 import ora from 'ora';
 import { readAndResolveBundleEnv } from '../lib/secrets/bundles.js';
+import { machineId } from '../lib/session/sync/config.js';
 import {
   addIgnored,
   getDevice,
@@ -52,8 +53,9 @@ function parseTarget(target: string): { host: string; user?: string } {
   return { user: target.slice(0, at), host: target.slice(at + 1) };
 }
 
-/** One-line summary of a device for `list`. */
-function deviceSummary(d: DeviceProfile): string {
+/** One-line summary of a device for `list`. `isSelf` marks the machine this
+ * command is running on so it stands out from the rest of the tailnet. */
+function deviceSummary(d: DeviceProfile, isSelf = false): string {
   const addr = hostNameFor(d) ?? chalk.gray('no address');
   const online = d.tailscale
     ? d.tailscale.online
@@ -61,7 +63,10 @@ function deviceSummary(d: DeviceProfile): string {
       : chalk.gray('offline')
     : chalk.gray('unknown');
   const reach = d.tailscale?.online && !d.tailscale.direct ? chalk.yellow(' (relayed)') : '';
-  return `  ${chalk.bold(d.name.padEnd(16))} ${String(d.platform).padEnd(8)} ${(d.user ? d.user + '@' : '') + addr}  ${online}${reach}`;
+  const marker = isSelf ? chalk.cyan('▸ ') : '  ';
+  const name = isSelf ? chalk.bold.cyan(d.name.padEnd(16)) : chalk.bold(d.name.padEnd(16));
+  const here = isSelf ? chalk.cyan('  ← this machine') : '';
+  return `${marker}${name} ${String(d.platform).padEnd(8)} ${(d.user ? d.user + '@' : '') + addr}  ${online}${reach}${here}`;
 }
 
 /** Resolve a device or exit with a clear error. */
@@ -216,8 +221,9 @@ Typical workflow:
         console.log(chalk.gray("No devices. Run 'agents devices sync' or 'agents devices add <name> <user@host>'."));
         return;
       }
+      const self = machineId();
       console.log(chalk.bold(`Devices (${names.length})`));
-      for (const name of names) console.log(deviceSummary(reg[name]));
+      for (const name of names) console.log(deviceSummary(reg[name], name === self));
     });
 
   devicesCmd


### PR DESCRIPTION
## What

`ag devices list` gave no visual cue for which row is the host you're actually on. This flags it:

```
Devices (12)
  ...
▸ yosemite-s0      linux    yosemite-s0.tail1a85a1.ts.net  online (relayed)  ← this machine
  yosemite-s1      linux    yosemite-s1.tail1a85a1.ts.net  online (relayed)
  zion             macos    zion.tail1a85a1.ts.net  online
```

The self row gets a cyan `▸` marker, a bold-cyan name, and a `← this machine` tag. Every other row (and the `--json` output added in #499) is unchanged.

## How self is detected

Self = the registry key equal to `machineId()` — the existing hostname->stable-id helper in `src/lib/session/sync/config.js` already used by session sync. It strips the DNS domain and lowercase-slugs the hostname, which matches the MagicDNS label the registry stores for this host. So:

- **No new helper** — reuses tested code (`config.test.ts`), no parallel slug logic.
- **Offline** — no live `tailscale` call added to `list`; stays fast.
- **Sync-safe** — dynamic at list time, not a stored `self` flag, so it's correct even when the registry is synced across machines.

Single-file, 10-line change on top of #499.

## Testing

`bunx tsc --noEmit` clean; devices + sync + config suites pass (38 tests). Verified end-to-end: `ag devices list` on yosemite-s0 marks the `yosemite-s0` row; `--json` output unchanged.