### PR TITLE
fix(auth): correct sign-in detection for antigravity (macOS keychain) and grok (nested auth.json)

### DIFF
--- a/src/lib/agents.test.ts
+++ b/src/lib/agents.test.ts
@@ -449,3 +449,51 @@ describe('getAccountInfo — token-only agents (no local email)', () => {
     expect(info.email).toBeNull();
   });
 });
+
+describe('getAccountInfo — grok (nested auth.json)', () => {
+  // Isolate the HOME fallback so a missing fixture doesn't read the dev's real ~/.grok.
+  let prevRealHome: string | undefined;
+  beforeEach(() => { prevRealHome = process.env.AGENTS_REAL_HOME; process.env.AGENTS_REAL_HOME = makeTempDir(); });
+  afterEach(() => {
+    if (prevRealHome === undefined) delete process.env.AGENTS_REAL_HOME;
+    else process.env.AGENTS_REAL_HOME = prevRealHome;
+  });
+
+  it('reads the nested "<issuer>::<client_id>" record — signed in with email + ids', async () => {
+    const home = makeTempDir();
+    const dir = path.join(home, '.grok');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'auth.json'), JSON.stringify({
+      'https://auth.x.ai::abc-123': {
+        email: 'muqsitnawaz@icloud.com',
+        user_id: '5b5643da',
+        team_id: '4af61418',
+        refresh_token: 'rt_xxx',
+        create_time: '2026-07-01T03:11:20Z',
+        auth_mode: 'oidc',
+      },
+    }));
+
+    const info = await getAccountInfo('grok', home);
+    expect(info.signedIn).toBe(true);
+    expect(info.email).toBe('muqsitnawaz@icloud.com');
+    expect(info.accountId).toBe('5b5643da');
+  });
+
+  it('picks the newest record when multiple providers are present', async () => {
+    const home = makeTempDir();
+    const dir = path.join(home, '.grok');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'auth.json'), JSON.stringify({
+      old: { email: 'old@x.ai', refresh_token: 'a', create_time: '2026-01-01T00:00:00Z' },
+      new: { email: 'new@x.ai', refresh_token: 'b', create_time: '2026-07-01T00:00:00Z' },
+    }));
+    const info = await getAccountInfo('grok', home);
+    expect(info.email).toBe('new@x.ai');
+  });
+
+  it('treats grok as signed out when auth.json is absent', async () => {
+    const info = await getAccountInfo('grok', makeTempDir());
+    expect(info.signedIn).toBe(false);
+  });
+});

--- a/src/lib/agents.test.ts
+++ b/src/lib/agents.test.ts
@@ -349,14 +349,21 @@ describe('getAccountInfo — token-only agents (no local email)', () => {
   // per-version home to the active config under AGENTS_REAL_HOME. Pin that to a
   // fresh empty dir so "signed out" assertions don't leak into the developer's
   // real ~/.factory / ~/.kimi-code / ~/.gemini login (RUSH-1318 fallback).
+  // Antigravity on macOS stores its token in the real keychain, which can't be
+  // sandboxed per-test — opt out of the probe so "signed out" is hermetic.
   let prevRealHome: string | undefined;
+  let prevNoKeychain: string | undefined;
   beforeEach(() => {
     prevRealHome = process.env.AGENTS_REAL_HOME;
     process.env.AGENTS_REAL_HOME = makeTempDir();
+    prevNoKeychain = process.env.AGENTS_NO_KEYCHAIN_PROBE;
+    process.env.AGENTS_NO_KEYCHAIN_PROBE = '1';
   });
   afterEach(() => {
     if (prevRealHome === undefined) delete process.env.AGENTS_REAL_HOME;
     else process.env.AGENTS_REAL_HOME = prevRealHome;
+    if (prevNoKeychain === undefined) delete process.env.AGENTS_NO_KEYCHAIN_PROBE;
+    else process.env.AGENTS_NO_KEYCHAIN_PROBE = prevNoKeychain;
   });
 
   it('marks Antigravity signed in when a refresh token is present', async () => {

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -1044,13 +1044,28 @@ export async function getAccountInfo(
         return { ...empty, email, signedIn: !!email, lastActive };
       }
       case 'grok': {
-        // Grok stores auth in ~/.grok/auth.json
+        // Grok stores auth in ~/.grok/auth.json as a map keyed by
+        // "<oidc_issuer>::<client_id>" -> { email, user_id, refresh_token,
+        // create_time, expires_at, team_id, ... }. (Older builds wrote a flat
+        // object with a top-level email.) The old code only read a TOP-LEVEL
+        // `email`, so the current nested format always looked signed-out even
+        // when logged in. Read the newest account record: a refresh token means
+        // signed in, and we surface the email/ids like claude/codex.
+        const authPath = resolveAccountCredentialPath(base, '.grok', 'auth.json');
+        if (!authPath) return { ...empty, lastActive };
         try {
-          const authPath = path.join(base, '.grok', 'auth.json');
-          if (fs.existsSync(authPath)) {
-            const data = JSON.parse(await fs.promises.readFile(authPath, 'utf-8'));
-            const email = data.email || data.user?.email || data.account?.email || null;
-            return { ...empty, email, signedIn: !!email, lastActive };
+          const data = JSON.parse(await fs.promises.readFile(authPath, 'utf-8'));
+          const records = (data && typeof data === 'object' ? [data, ...Object.values(data)] : [])
+            .filter((r): r is Record<string, any> => !!r && typeof r === 'object');
+          const account = records
+            .filter(r => typeof r.refresh_token === 'string' || typeof r.email === 'string')
+            .sort((a, b) => String(b.create_time || '').localeCompare(String(a.create_time || '')))[0];
+          if (account) {
+            const email = typeof account.email === 'string' ? account.email : null;
+            const accountId = normalizeIdentityPart(account.user_id ?? account.principal_id);
+            const organizationId = normalizeIdentityPart(account.team_id);
+            const accountKey = buildIdentityKey(agentId, [['user', accountId], ['org', organizationId]]);
+            return { ...empty, email, accountId, organizationId, accountKey, signedIn: true, lastActive };
           }
         } catch {}
         return { ...empty, lastActive };

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -869,6 +869,36 @@ function resolveAccountCredentialPath(base: string, ...segments: string[]): stri
   return null;
 }
 
+let cachedAgyKeychainSignedIn: boolean | undefined;
+
+/**
+ * Antigravity (`agy`, a Codeium/Windsurf-based CLI) stores its OAuth token in
+ * the macOS keychain — service `gemini`, account `antigravity` — NOT a file.
+ * The file path (`antigravity-oauth-token`) only exists on Linux, where the Go
+ * keyring falls back to disk. Probe the keychain for existence (metadata only;
+ * `-w` omitted so it never prompts). Cached per process — the keychain is
+ * account-global, so one probe covers every installed version. Returns false on
+ * non-macOS (the file path handles those).
+ */
+async function antigravityKeychainSignedIn(): Promise<boolean> {
+  if (cachedAgyKeychainSignedIn !== undefined) return cachedAgyKeychainSignedIn;
+  // Test isolation: the real macOS keychain can't be sandboxed per-test, so
+  // allow suites asserting "signed out" to opt out of the probe (same spirit as
+  // AGENTS_REAL_HOME). Not cached, so tests can toggle it.
+  if (process.env.AGENTS_NO_KEYCHAIN_PROBE === '1') return false;
+  if (process.platform !== 'darwin') {
+    cachedAgyKeychainSignedIn = false;
+    return false;
+  }
+  try {
+    await execFileAsync('security', ['find-generic-password', '-s', 'gemini', '-a', 'antigravity'], { timeout: 3000 });
+    cachedAgyKeychainSignedIn = true;
+  } catch {
+    cachedAgyKeychainSignedIn = false;
+  }
+  return cachedAgyKeychainSignedIn;
+}
+
 export async function getAccountInfo(
   agentId: AgentId,
   home?: string
@@ -1026,18 +1056,22 @@ export async function getAccountInfo(
         return { ...empty, lastActive };
       }
       case 'antigravity': {
-        // Antigravity (`agy`) stores a Google OAuth token at
-        // ~/.gemini/antigravity-cli/antigravity-oauth-token. It's a consumer
-        // OAuth grant (access + refresh token, no id_token), so there's no email
-        // claim to read locally — presence of a refresh token is the only
-        // signed-in signal we can derive without a network call.
+        // Antigravity (`agy`) stores a consumer Google OAuth grant (access +
+        // refresh token, no id_token) — presence of a refresh token is the only
+        // signed-in signal we can derive without a network call. Storage is
+        // platform-split: on Linux it's a file at
+        // ~/.gemini/antigravity-cli/antigravity-oauth-token; on macOS the Go
+        // keyring puts it in the keychain (service 'gemini', account
+        // 'antigravity'), so no file exists — check both.
         const tokenPath = resolveAccountCredentialPath(base, '.gemini', 'antigravity-cli', 'antigravity-oauth-token');
-        if (!tokenPath) return { ...empty, lastActive };
-        const data = JSON.parse(await fs.promises.readFile(tokenPath, 'utf-8'));
-        const hasToken =
-          typeof data?.token?.refresh_token === 'string' && !!data.token.refresh_token;
-        if (!hasToken) return { ...empty, lastActive };
-        return { ...empty, signedIn: true, lastActive };
+        if (tokenPath) {
+          const data = JSON.parse(await fs.promises.readFile(tokenPath, 'utf-8'));
+          if (typeof data?.token?.refresh_token === 'string' && data.token.refresh_token) {
+            return { ...empty, signedIn: true, lastActive };
+          }
+        }
+        if (await antigravityKeychainSignedIn()) return { ...empty, signedIn: true, lastActive };
+        return { ...empty, lastActive };
       }
       case 'kimi': {
         // Kimi Code stores OAuth credentials at


### PR DESCRIPTION
Two false "not signed in" bugs in `agents view`, both where the CLI *is* logged in but detection reads the wrong place.

## 1. Antigravity (macOS) — token in the keychain, not a file
Antigravity (`agy`, a Codeium/Windsurf CLI) stores its OAuth token platform-split: **Linux** = file `~/.gemini/antigravity-cli/antigravity-oauth-token` (existing check reads it); **macOS** = login keychain, service `gemini` / account `antigravity` (Go keyring) — **no file**, so the file-only check always said signed-out. Confirmed on-machine (`security find-generic-password -s gemini -a antigravity` → exit 0, no token file).
- Fix: macOS keychain probe as a fallback (metadata only, never prompts; cached; `darwin`-guarded). `AGENTS_NO_KEYCHAIN_PROBE=1` opts tests out of the un-sandboxable keychain.

## 2. Grok — nested auth.json + email-gated
`~/.grok/auth.json` is a map keyed by `"<oidc_issuer>::<client_id>"` → `{ email, user_id, refresh_token, team_id, ... }`. The old code read only a **top-level** `email` and gated `signedIn` on it → the current nested format always looked signed-out.
- Fix: traverse the records (nested + legacy flat), newest by `create_time`, `refresh_token` ⇒ signed in, and surface email + accountId + org — so grok renders like claude/codex.

## Verified (E2E on macOS)
- `agents view antigravity` → **signed in** (was not).
- `agents view grok` → **muqsitnawaz@icloud.com + last-active** (was "not signed in").
- droid/kimi detection unaffected. 29-test agents suite + shims regression green; `tsc` clean.

## Follow-ups (filed)
- RUSH-1329: antigravity Linux libsecret variant.