### PR TITLE
feat(devices): menu-bar NEW DEVICES notifier — daemon probe + Register/Ignore

### DIFF
--- a/packages/menubar-helper/Sources/MenubarHelper/AgentsCLI.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/AgentsCLI.swift
@@ -91,6 +91,12 @@ enum AgentsCLI {
     static func startScheduler() { runDetached(argv(["routines", "start"])) }
     static func stopDaemon() { runDetached(argv(["routines", "stop"])) }
 
+    // NEW DEVICES actions. `register` adds the pending node to the registry;
+    // `ignore` dismisses it for good. Both clear the pending sentinel CLI-side,
+    // so the badge/section updates on the next 10s poll. TS owns the truth.
+    static func deviceRegister(_ name: String) { runDetached(argv(["devices", "register", name])) }
+    static func deviceIgnore(_ name: String) { runDetached(argv(["devices", "ignore", name])) }
+
     // Surface CLI health in a terminal — `agents doctor` is interactive output.
     static func runDoctor() {
         let cmd = "\(shellQuote(binary)) doctor"

--- a/packages/menubar-helper/Sources/MenubarHelper/LocalState.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/LocalState.swift
@@ -29,6 +29,12 @@ struct Session {
     let detail: String
 }
 
+// A newly-discovered tailnet node awaiting the user's Register / Ignore.
+struct PendingDevice {
+    let name: String
+    let platform: String
+}
+
 enum LocalState {
     private static let home = NSHomeDirectory()
     private static let fm = FileManager.default
@@ -93,6 +99,20 @@ enum LocalState {
         let dir = "\(home)/.agents/.cache/state/attention"
         let names = (try? fm.contentsOfDirectory(atPath: dir)) ?? []
         return Set(names.filter { !$0.hasPrefix(".") })
+    }
+
+    // MARK: Pending devices (written by the daemon device probe)
+    // Each sentinel file's NAME is the tailscale node name; its CONTENT is the
+    // platform. Cheap dir read, safe on the badge poll path. Mirrors the
+    // attention sentinel contract (src/lib/devices/pending.ts).
+    static func pendingDevices() -> [PendingDevice] {
+        let dir = "\(home)/.agents/.cache/state/devices-pending"
+        let names = (try? fm.contentsOfDirectory(atPath: dir)) ?? []
+        return names.filter { !$0.hasPrefix(".") }.sorted().map { name in
+            let raw = (try? String(contentsOfFile: "\(dir)/\(name)", encoding: .utf8)) ?? ""
+            let platform = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            return PendingDevice(name: name, platform: platform.isEmpty ? "unknown" : platform)
+        }
     }
 
     // MARK: All active sessions

--- a/packages/menubar-helper/Sources/MenubarHelper/StatusItemController.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/StatusItemController.swift
@@ -14,9 +14,12 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     private let idleC = NSColor(srgbRed: 0x6b / 255.0, green: 0x72 / 255.0, blue: 0x80 / 255.0, alpha: 1) // #6B7280
     private let wait  = NSColor(srgbRed: 0xd4 / 255.0, green: 0xa7 / 255.0, blue: 0x2c / 255.0, alpha: 1) // #D4A72C
     private let fail  = NSColor(srgbRed: 0xef / 255.0, green: 0x44 / 255.0, blue: 0x44 / 255.0, alpha: 1) // #EF4444
+    private let info  = NSColor(srgbRed: 0x58 / 255.0, green: 0xa6 / 255.0, blue: 0xff / 255.0, alpha: 1) // #58a6ff (new devices)
 
     // Cached cheap snapshot for the badge (no teams scan).
     private var badgeSessions: [Session] = []
+    // New tailnet devices awaiting Register/Ignore (cheap sentinel-dir read).
+    private var badgePending: [PendingDevice] = []
 
     // These three reads shell the CLI or touch the sessions DB. They are kept
     // off the click path and rendered from warm caches when the menu opens.
@@ -64,8 +67,10 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     private func tick() {
         DispatchQueue.global(qos: .utility).async { [weak self] in
             let s = LocalState.sessions(includeTeams: false)
+            let pending = LocalState.pendingDevices()
             DispatchQueue.main.async {
                 self?.badgeSessions = s
+                self?.badgePending = pending
                 self?.refreshBadge()
             }
         }
@@ -141,8 +146,12 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         guard let button = statusItem.button else { return }
         let attention = badgeSessions.filter { $0.status == .attention }.count
         let running = badgeSessions.filter { $0.status == .running }.count
+        let pending = badgePending.count
         if attention > 0 {
             button.attributedTitle = badge("⚠", wait)
+        } else if pending > 0 {
+            // New devices to review — a blue count (◆) distinct from run/attention.
+            button.attributedTitle = badge(" ◆\(pending)", info)
         } else if running > 0 {
             button.attributedTitle = badge(" \(running)", run)
         } else {
@@ -164,10 +173,12 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         let sessions = LocalState.sessions(includeTeams: true)
         let browserTasks = LocalState.browserTasks(limit: 3)
         let daemonPid = AgentsCLI.daemonPid()
+        let pending = LocalState.pendingDevices()
         badgeSessions = sessions
+        badgePending = pending
         rebuild(menu, sessions: sessions, browserTasks: browserTasks,
                 recentSessions: cachedRecentSessions, routines: cachedRoutines,
-                doctor: cachedDoctorOverview, daemonPid: daemonPid)
+                doctor: cachedDoctorOverview, daemonPid: daemonPid, pending: pending)
         refreshBadge()
         refreshRoutines()
         refreshRecentSessions()
@@ -176,7 +187,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
 
     private func rebuild(_ menu: NSMenu, sessions: [Session], browserTasks: [BrowserTask],
                          recentSessions: [RecentSession], routines: [Routine],
-                         doctor: DoctorOverview?, daemonPid: Int?) {
+                         doctor: DoctorOverview?, daemonPid: Int?, pending: [PendingDevice]) {
         menu.removeAllItems()
 
         addHeader(menu, sessions: sessions)
@@ -184,6 +195,11 @@ final class StatusItemController: NSObject, NSMenuDelegate {
 
         // What needs me now — rendered only when there's something actionable.
         if addNeedsAttention(menu, sessions: sessions, routines: routines, daemonPid: daemonPid) {
+            menu.addItem(.separator())
+        }
+
+        // New tailnet devices to approve — only when there are any.
+        if addNewDevices(menu, pending: pending) {
             menu.addItem(.separator())
         }
 
@@ -280,6 +296,30 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             let it = statusRow(glyph, color, text)
             it.submenu = sub
             menu.addItem(it)
+        }
+        return true
+    }
+
+    // Returns true if anything was rendered (caller adds the trailing separator).
+    // One row per newly-discovered tailnet node, each with a Register / Ignore
+    // submenu that shells `agents devices register|ignore` (which also clear the
+    // sentinel, so the row disappears on the next poll).
+    private func addNewDevices(_ menu: NSMenu, pending: [PendingDevice]) -> Bool {
+        if pending.isEmpty { return false }
+        addSectionTitle(menu, "◆ NEW DEVICES (\(pending.count))", color: info)
+        for d in pending {
+            let sub = NSMenu()
+            let reg = NSMenuItem(title: "Register", action: #selector(onRegisterDevice(_:)), keyEquivalent: "")
+            reg.target = self
+            reg.representedObject = d.name
+            sub.addItem(reg)
+            let ign = NSMenuItem(title: "Ignore", action: #selector(onIgnoreDevice(_:)), keyEquivalent: "")
+            ign.target = self
+            ign.representedObject = d.name
+            sub.addItem(ign)
+            let row = statusRow("◆", info, "\(d.name) — \(d.platform)")
+            row.submenu = sub
+            menu.addItem(row)
         }
         return true
     }
@@ -543,6 +583,21 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     @objc private func onOpenAgentsHome() { AgentsCLI.openPath("\(AgentsCLI.home)/.agents") }
     @objc private func onStartScheduler() { AgentsCLI.startScheduler() }
     @objc private func onRunDoctor() { AgentsCLI.runDoctor() }
+
+    @objc private func onRegisterDevice(_ sender: NSMenuItem) {
+        withName(sender) { name in
+            AgentsCLI.deviceRegister(name)
+            badgePending.removeAll { $0.name == name } // optimistic; CLI clears the sentinel
+            refreshBadge()
+        }
+    }
+    @objc private func onIgnoreDevice(_ sender: NSMenuItem) {
+        withName(sender) { name in
+            AgentsCLI.deviceIgnore(name)
+            badgePending.removeAll { $0.name == name }
+            refreshBadge()
+        }
+    }
     @objc private func onStopScheduler() { AgentsCLI.stopDaemon() }
     @objc private func onQuit() { AgentsCLI.menubarDisable(); NSApp.terminate(nil) }
 

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -36,6 +36,7 @@ import {
   tailscaleStatusJson,
 } from '../lib/devices/tailscale.js';
 import { planDeviceReconciliation, runDeviceSync } from '../lib/devices/sync.js';
+import { clearPendingSentinel } from '../lib/devices/pending.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
 import { hostNameFor, renderSshConfig } from '../lib/devices/ssh-config.js';
 import {
@@ -175,12 +176,34 @@ Typical workflow:
     });
 
   devicesCmd
+    .command('register <name>')
+    .description('Register a discovered (pending) node by name — used by the menu-bar "NEW DEVICES → Register" action.')
+    .action(async (name: string) => {
+      try {
+        const nodes = parseTailscaleStatus(tailscaleStatusJson());
+        const node = nodes.find((n) => n.name === name);
+        if (!node) {
+          console.error(chalk.red(`'${name}' is not a current tailscale node. See 'agents devices sync'.`));
+          process.exit(1);
+        }
+        await removeIgnored(name); // a re-registered node is no longer dismissed
+        const d = await upsertDevice(name, nodeToDeviceInput(node));
+        clearPendingSentinel(name); // drop the notification immediately
+        console.log(chalk.green(`Registered '${name}'`) + chalk.gray(` (${d.platform})`));
+      } catch (err: any) {
+        console.error(chalk.red(err.message));
+        process.exit(1);
+      }
+    });
+
+  devicesCmd
     .command('ignore <name>')
     .description('Dismiss a node from auto-discovery so it is never re-suggested (and remove it from the registry if present).')
     .action(async (name: string) => {
       try {
         await removeDevice(name);
         await addIgnored(name);
+        clearPendingSentinel(name); // drop the notification immediately
         console.log(chalk.green(`Ignored '${name}'`) + chalk.gray(" — it won't be suggested again. Undo with `agents devices unignore`."));
       } catch (err: any) {
         console.error(chalk.red(err.message));

--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -288,6 +288,34 @@ export async function runDaemon(): Promise<void> {
   const healInterval = setInterval(() => { void runHealCheck(); }, 6 * 60 * 60_000);
   const healKickoff = setTimeout(() => { void runHealCheck(); }, 30_000);
 
+  // Device probe: refresh registered devices' reachability and detect newly
+  // appeared tailnet nodes, dropping a sentinel per pending device so the
+  // menu-bar helper can surface "NEW DEVICES → Register / Ignore". Refresh mode
+  // never auto-registers a newcomer. Soft + overlap-guarded like session sync;
+  // a machine without tailscale is a clean no-op. ~every 3 min.
+  let probingDevices = false;
+  const runDeviceProbe = async () => {
+    if (probingDevices) return;
+    probingDevices = true;
+    try {
+      const { runDeviceSync } = await import('./devices/sync.js');
+      const { reconcilePendingSentinels } = await import('./devices/pending.js');
+      const dev = await runDeviceSync({ soft: true, mode: 'refresh' });
+      if (dev.ok) {
+        reconcilePendingSentinels(dev.pending);
+        if (dev.pending.length) {
+          log('INFO', `devices: ${dev.pending.length} new pending (${dev.pending.map((p) => p.name).join(', ')})`);
+        }
+      }
+    } catch (err) {
+      log('ERROR', `device probe failed: ${(err as Error).message}`);
+    } finally {
+      probingDevices = false;
+    }
+  };
+  const deviceProbeInterval = setInterval(() => { void runDeviceProbe(); }, 3 * 60_000);
+  const deviceProbeKickoff = setTimeout(() => { void runDeviceProbe(); }, 15_000);
+
   const handleReload = () => {
     log('INFO', 'Reloading jobs (SIGHUP)');
     scheduler.reloadAll();
@@ -306,6 +334,8 @@ export async function runDaemon(): Promise<void> {
     clearInterval(syncInterval);
     clearInterval(healInterval);
     clearTimeout(healKickoff);
+    clearInterval(deviceProbeInterval);
+    clearTimeout(deviceProbeKickoff);
     removeDaemonPid();
     process.exit(0);
   };

--- a/src/lib/devices/pending.test.ts
+++ b/src/lib/devices/pending.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Pending-device sentinel dir is the contract between the daemon probe (writer)
+ * and the menu-bar helper (reader). Real bugs this guards:
+ *   1. reconcile must ADD a sentinel for a new pending device and REMOVE one for
+ *      a device that is no longer pending (registered/ignored/left the tailnet) —
+ *      a stale sentinel would show a phantom "NEW DEVICE" forever.
+ *   2. the file content is the platform (so the tray can label it) and survives
+ *      a read-back.
+ *   3. clearPendingSentinel removes exactly one and is a no-op when absent (the
+ *      Register/Ignore actions call it; a throw would surface as a CLI error).
+ *   4. a path-traversal name can never escape the sentinel dir.
+ */
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-devices-pending-test-'));
+process.env.HOME = TEST_HOME;
+
+const { reconcilePendingSentinels, clearPendingSentinel, readPendingSentinels } = await import('./pending.js');
+
+function pendingDir(): string {
+  return path.join(TEST_HOME, '.agents', '.cache', 'state', 'devices-pending');
+}
+
+beforeEach(async () => {
+  await fsp.rm(pendingDir(), { recursive: true, force: true });
+});
+
+afterAll(async () => {
+  await fsp.rm(TEST_HOME, { recursive: true, force: true });
+});
+
+describe('pending-device sentinels', () => {
+  it('creates one sentinel per pending device with the platform as content', () => {
+    reconcilePendingSentinels([{ name: 'zion', platform: 'macos' }, { name: 'win-mini', platform: 'windows' }]);
+    const read = readPendingSentinels().sort((a, b) => a.name.localeCompare(b.name));
+    expect(read).toEqual([
+      { name: 'win-mini', platform: 'windows' },
+      { name: 'zion', platform: 'macos' },
+    ]);
+  });
+
+  it('removes a sentinel that is no longer pending on the next reconcile', () => {
+    reconcilePendingSentinels([{ name: 'zion', platform: 'macos' }, { name: 'win-mini', platform: 'windows' }]);
+    // zion got registered → only win-mini remains pending.
+    reconcilePendingSentinels([{ name: 'win-mini', platform: 'windows' }]);
+    expect(readPendingSentinels().map((p) => p.name)).toEqual(['win-mini']);
+  });
+
+  it('reconcile to empty clears everything', () => {
+    reconcilePendingSentinels([{ name: 'zion', platform: 'macos' }]);
+    reconcilePendingSentinels([]);
+    expect(readPendingSentinels()).toEqual([]);
+  });
+
+  it('clearPendingSentinel removes exactly one and no-ops when absent', () => {
+    reconcilePendingSentinels([{ name: 'zion', platform: 'macos' }, { name: 'win-mini', platform: 'windows' }]);
+    clearPendingSentinel('zion');
+    expect(readPendingSentinels().map((p) => p.name)).toEqual(['win-mini']);
+    expect(() => clearPendingSentinel('zion')).not.toThrow(); // already gone
+  });
+
+  it('ignores a path-traversal device name (never escapes the dir)', () => {
+    reconcilePendingSentinels([{ name: '../evil', platform: 'linux' }]);
+    // Nothing written outside; the unsafe name is filtered out.
+    expect(fs.existsSync(path.join(TEST_HOME, '.agents', '.cache', 'state', 'evil'))).toBe(false);
+    expect(readPendingSentinels()).toEqual([]);
+  });
+});

--- a/src/lib/devices/pending.ts
+++ b/src/lib/devices/pending.ts
@@ -1,0 +1,85 @@
+/**
+ * "Pending device" sentinels.
+ *
+ * When the daemon's tailscale probe finds a node that is neither registered nor
+ * ignored, it drops a sentinel file under ~/.agents/.cache/state/devices-pending/
+ * — the same filesystem-signal pattern the attention hook uses for the menu bar.
+ * The Swift helper polls that dir every 10s and renders a "NEW DEVICES" section
+ * with Register / Ignore. The file NAME is the device name; the file CONTENT is
+ * the platform (one line), so the tray can show "zion (macos)" without opening
+ * the registry.
+ *
+ * The daemon owns writes (reconcile to match the current pending set); the CLI
+ * `agents devices register|ignore` clears a single sentinel the moment the user
+ * acts, so the badge updates immediately instead of waiting for the next probe.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { getDevicesPendingDir } from '../state.js';
+
+export interface PendingDevice {
+  name: string;
+  platform: string;
+}
+
+/** Device-name sentinels must be safe filenames (no path traversal). The device
+ * name charset is already the ssh-alias set, but guard defensively. */
+function isSafeName(name: string): boolean {
+  return /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(name);
+}
+
+/**
+ * Make the sentinel dir exactly match `pending`: create a file per pending
+ * device (content = platform), and delete any leftover sentinel whose device is
+ * no longer pending (it got registered, ignored, or left the tailnet). Best-
+ * effort — a filesystem error here must never crash the daemon, so callers pass
+ * this through their existing try/catch.
+ */
+export function reconcilePendingSentinels(pending: PendingDevice[]): void {
+  const dir = getDevicesPendingDir();
+  fs.mkdirSync(dir, { recursive: true });
+  const want = new Map(pending.filter((p) => isSafeName(p.name)).map((p) => [p.name, p.platform]));
+
+  const existing = fs.readdirSync(dir).filter((n) => !n.startsWith('.'));
+  // Remove sentinels that are no longer pending.
+  for (const name of existing) {
+    if (!want.has(name)) {
+      try { fs.unlinkSync(path.join(dir, name)); } catch { /* already gone */ }
+    }
+  }
+  // Write/refresh the sentinels that should exist.
+  for (const [name, platform] of want) {
+    const p = path.join(dir, name);
+    const body = `${platform}\n`;
+    // Only write when missing or changed, to avoid needless mtime churn.
+    let current: string | null = null;
+    try { current = fs.readFileSync(p, 'utf-8'); } catch { current = null; }
+    if (current !== body) {
+      try { fs.writeFileSync(p, body); } catch { /* best-effort */ }
+    }
+  }
+}
+
+/** Remove one device's pending sentinel (after the user registers or ignores it).
+ * No-op if it doesn't exist. */
+export function clearPendingSentinel(name: string): void {
+  if (!isSafeName(name)) return;
+  try { fs.unlinkSync(path.join(getDevicesPendingDir(), name)); } catch { /* already gone */ }
+}
+
+/** Read the current pending sentinels (name + platform). Used by tests and any
+ * TS-side consumer; the menu-bar helper reads the dir directly in Swift. */
+export function readPendingSentinels(): PendingDevice[] {
+  const dir = getDevicesPendingDir();
+  let names: string[];
+  try {
+    names = fs.readdirSync(dir).filter((n) => !n.startsWith('.'));
+  } catch {
+    return [];
+  }
+  return names.map((name) => {
+    let platform = 'unknown';
+    try { platform = fs.readFileSync(path.join(dir, name), 'utf-8').trim() || 'unknown'; } catch { /* keep default */ }
+    return { name, platform };
+  });
+}

--- a/src/lib/devices/pending.ts
+++ b/src/lib/devices/pending.ts
@@ -37,10 +37,19 @@ function isSafeName(name: string): boolean {
  */
 export function reconcilePendingSentinels(pending: PendingDevice[]): void {
   const dir = getDevicesPendingDir();
-  fs.mkdirSync(dir, { recursive: true });
   const want = new Map(pending.filter((p) => isSafeName(p.name)).map((p) => [p.name, p.platform]));
 
-  const existing = fs.readdirSync(dir).filter((n) => !n.startsWith('.'));
+  // Whole body is best-effort: a filesystem error here must never propagate into
+  // the daemon loop or `agents sync`. The top-level mkdir/readdir are guarded
+  // too, so no caller needs its own try/catch.
+  let existing: string[];
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    existing = fs.readdirSync(dir).filter((n) => !n.startsWith('.'));
+  } catch {
+    return;
+  }
+
   // Remove sentinels that are no longer pending.
   for (const name of existing) {
     if (!want.has(name)) {

--- a/src/lib/devices/sync.test.ts
+++ b/src/lib/devices/sync.test.ts
@@ -7,7 +7,7 @@
  *   3. A genuinely-new, non-ignored node IS surfaced.
  */
 import { describe, expect, it } from 'vitest';
-import { computePendingDevices, planDeviceReconciliation } from './sync.js';
+import { computePendingDevices, planDeviceReconciliation, selectNodesToUpsert } from './sync.js';
 import type { TailscaleNode } from './tailscale.js';
 
 function node(name: string): TailscaleNode {
@@ -33,6 +33,29 @@ describe('computePendingDevices', () => {
 
   it('returns nothing for an empty tailnet', () => {
     expect(computePendingDevices([], ['zion'], ['ipad165'])).toEqual([]);
+  });
+});
+
+describe('selectNodesToUpsert (bootstrap vs refresh)', () => {
+  const nodes = ['zion', 'yosemite-s0', 'ipad165', 'win-mini'].map(node);
+  const registered = new Set(['yosemite-s0', 'win-mini']);
+  const ignored = new Set(['ipad165']);
+
+  it('bootstrap upserts every non-ignored node, newcomers included', () => {
+    const got = selectNodesToUpsert(nodes, registered, ignored, 'bootstrap').map((n) => n.name);
+    expect(got).toEqual(['zion', 'yosemite-s0', 'win-mini']); // ipad165 ignored, zion (new) INCLUDED
+  });
+
+  it('refresh upserts only already-registered non-ignored nodes — newcomers are skipped', () => {
+    const got = selectNodesToUpsert(nodes, registered, ignored, 'refresh').map((n) => n.name);
+    expect(got).toEqual(['yosemite-s0', 'win-mini']); // zion (new) SKIPPED so it can stay pending
+  });
+
+  it('never upserts an ignored node in either mode', () => {
+    for (const mode of ['bootstrap', 'refresh'] as const) {
+      const got = selectNodesToUpsert(nodes, registered, ignored, mode).map((n) => n.name);
+      expect(got).not.toContain('ipad165');
+    }
   });
 });
 

--- a/src/lib/devices/sync.ts
+++ b/src/lib/devices/sync.ts
@@ -67,6 +67,25 @@ export function computePendingDevices(
 }
 
 /**
+ * Which discovered nodes to upsert this run — the mode-defining decision, pure
+ * so it is unit-testable without a tailnet. Ignored nodes are always skipped.
+ * In `refresh` mode a node that isn't already registered is skipped too (it
+ * stays pending for approval); `bootstrap` includes every non-ignored node.
+ */
+export function selectNodesToUpsert(
+  nodes: TailscaleNode[],
+  registered: Set<string>,
+  ignored: Set<string>,
+  mode: DeviceSyncMode,
+): TailscaleNode[] {
+  return nodes.filter((n) => {
+    if (ignored.has(n.name)) return false;
+    if (mode === 'refresh' && !registered.has(n.name)) return false;
+    return true;
+  });
+}
+
+/**
  * Ingest `tailscale status --json` into the registry. In soft mode a missing
  * tailscale binary / unreachable daemon resolves to `{ ok: false }` instead of
  * throwing, so callers wiring this into setup/sync never abort the whole run.
@@ -93,18 +112,12 @@ export async function runDeviceSync(
       platform: byName.get(name)?.platform ?? 'unknown',
     }));
 
-    // bootstrap: register/refresh every non-ignored node (newcomers included).
-    // refresh: only refresh nodes already in the registry — newcomers stay in
-    // `pending` for the user to approve, they are never silently added.
-    let synced = 0;
-    for (const node of nodes) {
-      if (ignored.has(node.name)) continue;
-      if (mode === 'refresh' && !registered.has(node.name)) continue;
+    const toUpsert = selectNodesToUpsert(nodes, registered, ignored, mode);
+    for (const node of toUpsert) {
       await upsertDevice(node.name, nodeToDeviceInput(node));
-      synced++;
     }
 
-    return { ok: true, synced, pending };
+    return { ok: true, synced: toUpsert.length, pending };
   } catch (err: any) {
     if (opts.soft) {
       return { ok: false, synced: 0, pending: [], reason: err?.message ?? String(err) };

--- a/src/lib/devices/sync.ts
+++ b/src/lib/devices/sync.ts
@@ -25,14 +25,26 @@ import {
   tailscaleStatusJson,
   type TailscaleNode,
 } from './tailscale.js';
+import type { PendingDevice } from './pending.js';
+
+/**
+ * bootstrap — register every non-ignored node (opt-out). First-run `agents
+ *   setup` and manual `agents devices sync`, so the fleet is usable out of box.
+ * refresh — only refresh reachability of already-registered nodes; a brand-new
+ *   node is NOT auto-added, it is surfaced as `pending` for the user to approve
+ *   (opt-in). Ongoing autosync and the daemon probe use this, so newcomers flow
+ *   through the menu-bar "NEW DEVICES → Register / Ignore" gate instead of
+ *   silently landing in the registry.
+ */
+export type DeviceSyncMode = 'bootstrap' | 'refresh';
 
 export interface DeviceSyncResult {
   /** False when discovery could not run (e.g. tailscale absent) in soft mode. */
   ok: boolean;
   /** Number of tailscale nodes upserted into the registry. */
   synced: number;
-  /** Node names discovered but neither registered-before nor ignored. */
-  pending: string[];
+  /** Nodes discovered but neither registered-before nor ignored (name+platform). */
+  pending: PendingDevice[];
   /** Populated when ok is false: why discovery was skipped. */
   reason?: string;
 }
@@ -61,7 +73,10 @@ export function computePendingDevices(
  * The `pending` list is computed against the registry state BEFORE this sync so
  * "new" means "not previously registered and not ignored".
  */
-export async function runDeviceSync(opts: { soft?: boolean } = {}): Promise<DeviceSyncResult> {
+export async function runDeviceSync(
+  opts: { soft?: boolean; mode?: DeviceSyncMode } = {},
+): Promise<DeviceSyncResult> {
+  const mode: DeviceSyncMode = opts.mode ?? 'bootstrap';
   // Soft mode must be non-fatal for ANY failure, not just a missing tailscale:
   // a corrupted registry/ignore file (both throw by design), a disk error, or
   // registry lock contention (plausible when many agents SessionStart-autosync
@@ -70,14 +85,21 @@ export async function runDeviceSync(opts: { soft?: boolean } = {}): Promise<Devi
   try {
     const nodes = parseTailscaleStatus(tailscaleStatusJson());
     const [registeredBefore, ignored] = await Promise.all([loadDevices(), loadIgnored()]);
-    const pending = computePendingDevices(nodes, Object.keys(registeredBefore), ignored);
+    const registered = new Set(Object.keys(registeredBefore));
+    const pendingNames = computePendingDevices(nodes, registered, ignored);
+    const byName = new Map(nodes.map((n) => [n.name, n]));
+    const pending: PendingDevice[] = pendingNames.map((name) => ({
+      name,
+      platform: byName.get(name)?.platform ?? 'unknown',
+    }));
 
-    // Register/refresh every node the user has NOT dismissed. Skipping ignored
-    // nodes is what makes the "register all" default safe: a phone or someone
-    // else's laptop the user once dismissed never silently comes back.
+    // bootstrap: register/refresh every non-ignored node (newcomers included).
+    // refresh: only refresh nodes already in the registry — newcomers stay in
+    // `pending` for the user to approve, they are never silently added.
     let synced = 0;
     for (const node of nodes) {
       if (ignored.has(node.name)) continue;
+      if (mode === 'refresh' && !registered.has(node.name)) continue;
       await upsertDevice(node.name, nodeToDeviceInput(node));
       synced++;
     }

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -422,6 +422,9 @@ export function getDevicesRegistryPath(): string { return path.join(HISTORY_DIR,
 /** Path to the device ignore-list — tailscale node names the user dismissed, so auto-discovery never re-suggests them. Per-machine, same dir as the registry. */
 export function getDevicesIgnoredPath(): string { return path.join(HISTORY_DIR, 'devices', 'ignored.json'); }
 
+/** Dir of "pending device" sentinels (~/.agents/.cache/state/devices-pending/) — one empty-ish file per newly-discovered, not-yet-approved tailnet node. Written by the daemon probe, read by the menu-bar helper (mirrors the attention sentinel dir). */
+export function getDevicesPendingDir(): string { return path.join(RUNTIME_STATE_DIR, 'devices-pending'); }
+
 /** Path to cloud dispatch cache (~/.agents/.cache/cloud/). */
 export function getCloudDir(): string { return CLOUD_DIR; }
 

--- a/src/lib/sync-umbrella.ts
+++ b/src/lib/sync-umbrella.ts
@@ -159,15 +159,18 @@ export async function runUmbrellaSync(args: RunUmbrellaArgs): Promise<UmbrellaRe
     await refresh({ skipPrompts: yes });
     result.reconciled = true;
 
-    // Keep the local device registry current with the tailnet. Soft: a machine
-    // without tailscale is a clean no-op, never a sync failure. This is the
-    // wiring that fixes the "registry stays empty until you remember to run
-    // `agents devices sync`" gap — the SessionStart autosync now populates it.
+    // Keep already-registered devices' reachability current, and surface newly
+    // appeared tailnet nodes as "pending" for the menu-bar Register/Ignore gate
+    // rather than silently adding them (refresh mode). Soft: a machine without
+    // tailscale is a clean no-op, never a sync failure. First-run population is
+    // `agents setup` / manual `agents devices sync` (bootstrap).
     const { runDeviceSync } = await import('./devices/sync.js');
-    const dev = await runDeviceSync({ soft: true });
+    const { reconcilePendingSentinels } = await import('./devices/pending.js');
+    const dev = await runDeviceSync({ soft: true, mode: 'refresh' });
+    if (dev.ok) reconcilePendingSentinels(dev.pending);
     result.devices = { synced: dev.synced, pending: dev.pending.length, skipped: !dev.ok };
     if (dev.ok) {
-      log(`devices: ${dev.synced} synced${dev.pending.length ? `, ${dev.pending.length} new` : ''}`);
+      log(`devices: ${dev.synced} refreshed${dev.pending.length ? `, ${dev.pending.length} new pending` : ''}`);
     }
   }
 


### PR DESCRIPTION
Component D — surfaces newly-connected tailnet devices in the macOS menu bar for one-click approval. Builds on #499 (`computePendingDevices`, ignore-list).

## Detection is now opt-in (behavior change)
`runDeviceSync` gains **bootstrap** vs **refresh** modes:
- **bootstrap** (first-run `agents setup`, manual `agents devices sync`): register all non-ignored nodes — fleet usable out of the box.
- **refresh** (ongoing `agents sync` autosync + the new daemon probe): refresh already-registered devices' reachability and surface newcomers as `pending` **without** auto-adding them.

This shift is what makes the tray's Register/Ignore meaningful — otherwise autosync would register a newcomer before the user ever saw it. Existing registries are unaffected (refresh keeps them fresh); only *new* nodes now wait for approval.

## Signal: pending sentinels
The daemon probe (~3 min, soft, overlap-guarded — mirrors session-sync) writes one file per pending device under `~/.agents/.cache/state/devices-pending/<name>` (content = platform), the same filesystem-signal pattern the attention hook uses. `src/lib/devices/pending.ts` owns reconcile/clear.

## Menu bar (Swift)
The helper reads that dir on its existing 10s poll:
- status-item badge folds in a blue `◆N` new-devices count (priority: ⚠ attention > ◆ new > running).
- a **NEW DEVICES (n)** section with per-device **Register / Ignore** submenus that shell `agents devices register|ignore` (both clear the sentinel, so the row + badge clear on the next poll).

New CLI: `agents devices register <name>`; `ignore` now also clears the pending sentinel.

## Verification
- **TS (Linux):** removed `zion`, ran the refresh probe → it refreshed the 11 remaining, surfaced `zion(macos)` as pending, wrote the sentinel, and did **not** re-register it; `register zion` restored + cleared. 44 tests pass (new `pending.test.ts`: reconcile add/remove/clear, platform round-trip, path-traversal guard). `tsc` clean.
- **Swift (zion/macOS):** `swift build` clean; `MENUBAR_DUMP=1` rendered `◆ NEW DEVICES (2)` with `testdev — macos [Register | Ignore]` / `testwin — windows [...]` from seeded sentinels.

## Release note
The shipped `bin/MenubarHelper.app` must be rebuilt at release (`scripts/build` → `verify-menubar-helper.sh`) to include these Swift changes — the PR ships source only.

## Depends on
#499 (merged).