### PR TITLE
fix(droid): fold stale `latest` version-home on view, not just install (RUSH-1320)

### DIFF
--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -52,6 +52,7 @@ import {
   syncResourcesToVersion,
   removeVersion,
   printTrashFooter,
+  reconcileStaleLatestForAgent,
 } from '../lib/versions.js';
 import {
   getShimsDir,
@@ -1481,6 +1482,17 @@ export async function viewAction(
     cli: options?.cli,
   };
   const filterIsSet = SECTION_KEYS.some((k) => filter[k]);
+
+  // RUSH-1320: fold any stale literal `latest` version-home into its concrete
+  // version before rendering, so it stops appearing as a bogus "version" next
+  // to the real ones. Best-effort — must never break `agents view`. Scoped to
+  // the queried agent when one is given (cheap no-op for agents with no
+  // `latest` dir, i.e. almost all of them).
+  {
+    const target = agentArg ? resolveAgentName(agentArg.split('@')[0]) : null;
+    const toReconcile = agentArg ? (target ? [target] : []) : ALL_AGENT_IDS;
+    await Promise.all(toReconcile.map((a) => reconcileStaleLatestForAgent(a).catch(() => {})));
+  }
 
   if (!agentArg) {
     if (prune) {

--- a/src/lib/versions.test.ts
+++ b/src/lib/versions.test.ts
@@ -119,6 +119,62 @@ describe('reconcileStaleLatestDir', () => {
   });
 });
 
+// Full path (RUSH-1320): resolve the live CLI version via a real `--version`
+// shell-out, then fold the stale `latest` dir onto it. Uses a fake `droid` on
+// PATH — no mocking — so getCliVersionFromPath returns a concrete version.
+function runReconcileForAgent(home: string, agent: string, fakeBinDir: string): void {
+  const moduleUrl = pathToFileURL(path.resolve('src/lib/versions.ts')).href;
+  const tsxBin = path.resolve('node_modules/tsx/dist/cli.mjs');
+  const child = spawnSync(process.execPath, [tsxBin, '-e', `
+    import { reconcileStaleLatestForAgent } from ${JSON.stringify(moduleUrl)};
+    (async () => { await reconcileStaleLatestForAgent(${JSON.stringify(agent)}); })();
+  `], {
+    // Prepend the fake-bin dir so `droid --version` resolves to our stub.
+    env: { ...process.env, HOME: home, PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH}` },
+    encoding: 'utf-8',
+  });
+  expect(child.status, child.stderr).toBe(0);
+}
+
+describe('reconcileStaleLatestForAgent (proactive)', () => {
+  it.skipIf(process.platform === 'win32')('folds a stale `latest` onto the live CLI version, preserving home/', () => {
+    const home = makeTempHome();
+    // Stale latest home with a credential-like file that must survive the fold.
+    const latestFactory = path.join(droidVersionDir(home, 'latest'), 'home', '.factory');
+    fs.mkdirSync(latestFactory, { recursive: true });
+    fs.writeFileSync(path.join(latestFactory, 'auth.v2.file'), 'LOGIN');
+
+    // Fake `droid --version` -> 0.161.0.
+    const binDir = path.join(home, 'fakebin');
+    fs.mkdirSync(binDir, { recursive: true });
+    const droidStub = path.join(binDir, 'droid');
+    fs.writeFileSync(droidStub, '#!/bin/sh\necho "droid 0.161.0"\n');
+    fs.chmodSync(droidStub, 0o755);
+
+    runReconcileForAgent(home, 'droid', binDir);
+
+    // `latest` is gone; its home (incl. the login file) now lives under 0.161.0.
+    expect(fs.existsSync(droidVersionDir(home, 'latest'))).toBe(false);
+    expect(fs.readFileSync(path.join(droidVersionDir(home, '0.161.0'), 'home', '.factory', 'auth.v2.file'), 'utf8')).toBe('LOGIN');
+  });
+
+  it.skipIf(process.platform === 'win32')('is a no-op when there is no stale `latest` dir', () => {
+    const home = makeTempHome();
+    fs.mkdirSync(path.join(droidVersionDir(home, '0.161.0'), 'home'), { recursive: true });
+    const binDir = path.join(home, 'fakebin');
+    fs.mkdirSync(binDir, { recursive: true });
+    const droidStub = path.join(binDir, 'droid');
+    fs.writeFileSync(droidStub, '#!/bin/sh\necho "droid 0.161.0"\n');
+    fs.chmodSync(droidStub, 0o755);
+
+    runReconcileForAgent(home, 'droid', binDir);
+
+    // 0.161.0 untouched, no `latest` created.
+    expect(fs.existsSync(droidVersionDir(home, '0.161.0'))).toBe(true);
+    expect(fs.existsSync(droidVersionDir(home, 'latest'))).toBe(false);
+  });
+});
+
 describe('version resource sync path handling', () => {
   it('intersects explicit resource selections with discovered resources before syncing', async () => {
     const home = makeTempHome();

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1321,6 +1321,25 @@ function removeInstallArtifacts(versionDir: string): void {
  * when nothing was resolved or no stale dir is present, so it is safe to call
  * on every script-based install. Returns the action taken (for tests/logging).
  */
+/**
+ * Proactively fold a stale `latest` version-home into its concrete version,
+ * WITHOUT needing a fresh install (RUSH-1320). `reconcileStaleLatestDir` only
+ * fires at install time, so a `latest` dir left by an old probe-failed install
+ * lingers in `agents view` indefinitely. This resolves the live CLI version and
+ * reconciles — cheap no-op when there's no `latest` dir (the common case, so
+ * `agents view` pays a `--version` shell-out only the once, until it's folded).
+ * Skipped when the active config symlink still points at `latest`, since
+ * renaming that dir would dangle the live symlink.
+ */
+export async function reconcileStaleLatestForAgent(agent: AgentId): Promise<void> {
+  if (!fs.existsSync(getVersionDir(agent, 'latest'))) return;
+  if (getConfigSymlinkVersion(agent) === 'latest') return;
+  const concrete = await getCliVersionFromPath(agent);
+  if (concrete && concrete !== 'latest') {
+    await reconcileStaleLatestDir(agent, concrete);
+  }
+}
+
 export async function reconcileStaleLatestDir(
   agent: AgentId,
   installedVersion: string,


### PR DESCRIPTION
Closes RUSH-1320. `agents view` listed a bogus `latest` "version" for Droid next to the real ones:
```
Droid (available)
  0.159.1 (default)  signed in
  latest             signed in   <-- not a real version
  0.158.0            signed in
```

## Root cause
A script-install (droid) whose post-install `--version` probe returned null fell back to the literal string `"latest"`, creating `versions/droid/latest/`. `reconcileStaleLatestDir` folds such a dir onto the concrete version — but only fires on the **next install**, so the stale `latest` lingered forever. (Droid's `getBinaryPath` points at one global self-updating binary regardless of version dir, so `latest` never gets replaced.)

## Fix
`reconcileStaleLatestForAgent(agent)` — resolve the live CLI version (`droid --version`) and fold the stale `latest` dir onto it (rename, preserving `home/` incl. login + sessions; soft-delete to trash if the concrete dir already exists). Skipped when the active config symlink still points at `latest` (renaming would dangle it). Wired into the top of `viewAction`, so both the human and `--json` paths self-heal on the next `agents view`. Cheap no-op when there's no `latest` dir (almost always).

## Verified (E2E, real machine)
Droid homes went `{0.158.0, 0.159.1, latest}` → `{0.158.0, 0.159.1, 0.161.0}` — `latest` folded onto the live `droid --version`, **login + session preserved**, all versions still "signed in". Tests use a fake `droid` on PATH (no mocking) to drive the real version-probe → fold path. 87-test versions/agents/shims regression green; `tsc` clean.

## Related
- RUSH-1321: droid's version labels are still fictional (single self-updating binary) — separate, deeper issue.