### PR TITLE
feat(sessions): capture per-session provenance (host / SSH / tmux pane)

### DIFF
--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -285,6 +285,20 @@ function signalBadges(s: Pick<ActiveSession, 'awaitingReason' | 'pr' | 'worktree
 }
 
 /**
+ * Compact provenance badge: how to reach the session, not what it's doing.
+ * `ssh` flags a remote host; the tmux pane id is the send-keys target the feed
+ * would type back into. Local, non-tmux sessions add nothing (the common case).
+ */
+function provenanceBadge(p?: ActiveSession['provenance']): string {
+  if (!p) return '';
+  const parts: string[] = [];
+  if (p.transport === 'ssh') parts.push(chalk.red('ssh'));
+  if (p.mux?.kind === 'tmux' && p.mux.pane) parts.push(chalk.green(`tmux ${p.mux.pane}`));
+  else if (p.mux?.kind === 'screen') parts.push(chalk.green('screen'));
+  return parts.join(' ');
+}
+
+/**
  * Render a single agent-session row inside an already-printed group header.
  * Indent is the leading whitespace (2 spaces for flat groups, 4 inside a
  * window sub-group). Leads with the 8-char session id (the address to read or
@@ -297,7 +311,7 @@ function printActiveRow(s: ActiveSession, indent: string): void {
   const hostCol = chalk.gray(padToWidth(truncateToWidth(s.host ?? '-', 8), 9));
   const statusCol = statusColor(s.status)(padToWidth(truncateToWidth(activityLabel(s), 8), 9));
   const fork = s.pidCount && s.pidCount > 1 ? chalk.dim(`×${s.pidCount} `) : '';
-  const badges = (fork ? fork : '') + signalBadges(s);
+  const badges = (fork ? fork : '') + [signalBadges(s), provenanceBadge(s.provenance)].filter(Boolean).join(' ');
   const desc = buildSessionDescription(s) || '-';
   // Fill the remaining width with the preview so nothing wraps under tmux/SSH.
   const fixed = stringWidth(indent) + 9 + 9 + 9 + 9 + (badges ? stringWidth(badges) + 1 : 0);

--- a/src/lib/session/active.ts
+++ b/src/lib/session/active.ts
@@ -29,6 +29,7 @@ import { latestSessionFileForCwd } from './db.js';
 import { extractSessionTopic } from './prompt.js';
 import { readSessionTail } from './tail.js';
 import { inferSessionState, type SessionState, type SessionActivity, type AwaitingReason, type DetectedPr, type DetectedWorktree, type DetectedTicket } from './state.js';
+import { detectProvenance, type SessionProvenance } from './provenance.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -65,6 +66,13 @@ export interface ActiveSession {
   status: ActiveStatus;
   /** How many live PIDs resolve to this same session (subagents/forks). 1 unless collapsed. */
   pidCount?: number;
+  /**
+   * Where the process actually lives — machine host, local vs SSH, tmux pane,
+   * and whether a rail exists to type back into it. Read from the process env
+   * (`/proc/<pid>/environ` on Linux, `ps eww` on macOS) during enrichment.
+   * Absent for cloud sessions (no local pid) and any pid whose env is unreadable.
+   */
+  provenance?: SessionProvenance;
   teamName?: string;
   agentId?: string;
   cloudProvider?: string;
@@ -601,7 +609,25 @@ export async function getActiveSessions(opts: ActiveQueryOptions = {}): Promise<
 
   const unattributed = opts.skipHeadless ? [] : await listUnattributedActive(knownPids);
 
-  return dedupeBySession([...teams, ...terminals, ...cloud, ...unattributed]);
+  const merged = dedupeBySession([...teams, ...terminals, ...cloud, ...unattributed]);
+  await enrichProvenance(merged);
+  return merged;
+}
+
+/**
+ * Attach provenance (host / local-vs-SSH / tmux pane / reply rail) to every
+ * session that has a live pid. Mutates in place. Runs after dedupe so we probe
+ * each session once, not once per fork pid. Probes run in parallel — each is a
+ * single /proc read (Linux) or `ps` call (macOS); failures leave `provenance`
+ * undefined rather than blocking the listing.
+ */
+async function enrichProvenance(sessions: ActiveSession[]): Promise<void> {
+  await Promise.all(
+    sessions.map(async (s) => {
+      if (s.provenance || !s.pid) return;
+      s.provenance = await detectProvenance(s.pid);
+    }),
+  );
 }
 
 /**

--- a/src/lib/session/provenance.test.ts
+++ b/src/lib/session/provenance.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  parseProcEnviron,
+  extractKnownEnv,
+  parseSshConnection,
+  deriveProvenance,
+  detectProvenance,
+  PROVENANCE_ENV_KEYS,
+} from './provenance.js';
+
+describe('parseProcEnviron', () => {
+  it('parses the NUL-separated /proc/<pid>/environ body', () => {
+    const raw = 'SHELL=/bin/zsh\0TERM_PROGRAM=iTerm.app\0TMUX_PANE=%3\0';
+    expect(parseProcEnviron(raw)).toEqual({
+      SHELL: '/bin/zsh',
+      TERM_PROGRAM: 'iTerm.app',
+      TMUX_PANE: '%3',
+    });
+  });
+
+  it('keeps values that themselves contain =', () => {
+    const raw = 'FOO=a=b=c\0BAR=x\0';
+    expect(parseProcEnviron(raw)).toEqual({ FOO: 'a=b=c', BAR: 'x' });
+  });
+
+  it('ignores empty entries and malformed (no =) pairs', () => {
+    const raw = '\0JUSTNAME\0OK=1\0';
+    expect(parseProcEnviron(raw)).toEqual({ OK: '1' });
+  });
+});
+
+describe('extractKnownEnv (macOS `ps eww` output)', () => {
+  it('extracts known keys from a command+env line, preserving spaces in values', () => {
+    // Real shape: the full command, then space-joined KEY=VALUE env entries.
+    const line =
+      '/usr/local/bin/node /path/to/claude --resume LANG=en_US.UTF-8 ' +
+      'SSH_CONNECTION=203.0.113.7 51828 10.0.0.3 22 TMUX=/tmp/tmux-501/default,914,2 ' +
+      'TMUX_PANE=%5 TERM_PROGRAM=iTerm.app PWD=/Users/m/src';
+    const env = extractKnownEnv(line, PROVENANCE_ENV_KEYS);
+    // SSH_CONNECTION has three internal spaces — must survive intact.
+    expect(env.SSH_CONNECTION).toBe('203.0.113.7 51828 10.0.0.3 22');
+    expect(env.TMUX).toBe('/tmp/tmux-501/default,914,2');
+    expect(env.TMUX_PANE).toBe('%5');
+    expect(env.TERM_PROGRAM).toBe('iTerm.app');
+    // Unknown keys (LANG, PWD) are not captured.
+    expect(env.LANG).toBeUndefined();
+  });
+
+  it('returns empty when no known keys are present', () => {
+    expect(extractKnownEnv('node script.js PWD=/tmp HOME=/root', PROVENANCE_ENV_KEYS)).toEqual({});
+  });
+});
+
+describe('parseSshConnection', () => {
+  it('parses the four space-joined fields', () => {
+    expect(parseSshConnection('203.0.113.7 51828 10.0.0.3 22')).toEqual({
+      clientIp: '203.0.113.7',
+      clientPort: 51828,
+      serverIp: '10.0.0.3',
+      serverPort: 22,
+    });
+  });
+
+  it('rejects malformed values', () => {
+    expect(parseSshConnection('nope')).toBeUndefined();
+    expect(parseSshConnection('a b c d')).toBeUndefined(); // non-numeric ports
+  });
+});
+
+describe('deriveProvenance', () => {
+  it('local + tmux pane yields a tmux reply rail (addressable)', () => {
+    const p = deriveProvenance(
+      { TMUX: '/tmp/tmux-501/default,914,2', TMUX_PANE: '%5', TERM_PROGRAM: 'tmux' },
+      'zion',
+    );
+    expect(p.host).toBe('zion');
+    expect(p.transport).toBe('local');
+    expect(p.mux).toEqual({ kind: 'tmux', socket: '/tmp/tmux-501/default', pane: '%5' });
+    expect(p.reply).toEqual({ rail: 'tmux', target: '%5', socket: '/tmp/tmux-501/default' });
+  });
+
+  it('ssh session flags transport and captures the origin', () => {
+    const p = deriveProvenance(
+      { SSH_CONNECTION: '203.0.113.7 51828 10.0.0.3 22', SSH_TTY: '/dev/pts/4' },
+      'phoenix-horizon',
+    );
+    expect(p.transport).toBe('ssh');
+    expect(p.ssh).toEqual({ clientIp: '203.0.113.7', clientPort: 51828, serverIp: '10.0.0.3', serverPort: 22 });
+  });
+
+  it('no tmux, no ssh => local and NOT addressable (reply null)', () => {
+    const p = deriveProvenance({ TERM_PROGRAM: 'vscode' }, 'this-mac');
+    expect(p.transport).toBe('local');
+    expect(p.mux).toBeUndefined();
+    expect(p.reply).toBeNull(); // inherited/ignored stdin — feed shows read-only
+  });
+
+  it('screen session is recognized but not (yet) addressable', () => {
+    const p = deriveProvenance({ STY: '12345.pts-0.host' }, 'box');
+    expect(p.mux).toEqual({ kind: 'screen', session: '12345.pts-0.host' });
+    expect(p.reply).toBeNull();
+  });
+});
+
+describe('detectProvenance (real process, no mocks)', () => {
+  it('reads the running test process env and reports its own host', async () => {
+    const p = await detectProvenance(process.pid);
+    // On Linux (/proc) and macOS (ps eww) this must resolve; other platforms undefined.
+    if (process.platform === 'linux' || process.platform === 'darwin') {
+      expect(p).toBeDefined();
+      expect(p!.host.length).toBeGreaterThan(0);
+      expect(p!.transport === 'local' || p!.transport === 'ssh').toBe(true);
+      // transport must agree with the actual env of this very process.
+      expect(p!.transport).toBe(process.env.SSH_CONNECTION ? 'ssh' : 'local');
+    } else {
+      expect(p).toBeUndefined();
+    }
+  });
+
+  it('returns undefined for an impossible pid', async () => {
+    expect(await detectProvenance(0)).toBeUndefined();
+    expect(await detectProvenance(-1)).toBeUndefined();
+  });
+});

--- a/src/lib/session/provenance.test.ts
+++ b/src/lib/session/provenance.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect } from 'vitest';
 import {
   parseProcEnviron,
   extractKnownEnv,

--- a/src/lib/session/provenance.ts
+++ b/src/lib/session/provenance.ts
@@ -1,0 +1,196 @@
+/**
+ * Session provenance — where an active agent process actually lives.
+ *
+ * `detectHost()` in active.ts walks the ppid chain to name the *terminal app*
+ * (iterm / code / tmux). That answers "what UI is above it" but not the three
+ * things the Agent Feed needs to group and route:
+ *
+ *   1. Which machine    — os.hostname(), for the HOSTS sidebar.
+ *   2. Local vs SSH     — is SSH_CONNECTION in the process env?
+ *   3. Exact tmux pane  — TMUX_PANE ('%3'), the send-keys target.
+ *
+ * All three are inherited env vars, so we read them straight off the running
+ * process (no cooperation from the agent needed): `/proc/<pid>/environ` on
+ * Linux, `ps eww` on macOS. The read is best-effort — a process we can't stat
+ * (gone, or owned by another uid) yields `undefined`, never a guess.
+ *
+ * `reply` is a read-only hint, not a send channel: it reports whether a rail
+ * that can type back into this session exists today (tmux pane => addressable;
+ * inherited/ignored stdin => null). The feed uses it to decide whether to show
+ * a Send box. Actually delivering the keystrokes is Gap 2 (pty/tmux send-keys).
+ */
+import * as os from 'os';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { readFile } from 'fs/promises';
+
+const execFileAsync = promisify(execFile);
+
+export interface SshOrigin {
+  clientIp: string;
+  clientPort: number;
+  serverIp: string;
+  serverPort: number;
+}
+
+export interface MuxLocation {
+  kind: 'tmux' | 'screen';
+  /** tmux server socket path (first comma-field of $TMUX). Undefined for screen. */
+  socket?: string;
+  /** Exact pane id from $TMUX_PANE, e.g. '%3' — the send-keys target. */
+  pane?: string;
+  /** screen session name from $STY, e.g. '12345.pts-0.host'. */
+  session?: string;
+}
+
+/** How the feed can type back into a session, derived from rails that exist today. */
+export type ReplyRail =
+  | { rail: 'tmux'; target: string; socket?: string }
+  | null;
+
+export interface SessionProvenance {
+  /** Machine the process runs on — os.hostname(). Drives HOSTS grouping. */
+  host: string;
+  /** 'ssh' when SSH_CONNECTION is present in the process env, else 'local'. */
+  transport: 'local' | 'ssh';
+  /** Populated when transport === 'ssh'. */
+  ssh?: SshOrigin;
+  /** TERM_PROGRAM: 'iTerm.app', 'vscode', 'WezTerm', 'tmux', 'Apple_Terminal', … */
+  term?: string;
+  /** Multiplexer the process sits inside, from $TMUX / $STY. */
+  mux?: MuxLocation;
+  /** Whether an existing rail can type back into this session (see module doc). */
+  reply: ReplyRail;
+}
+
+/** Env vars that carry provenance. Kept small so the macOS `ps` scan stays cheap. */
+export const PROVENANCE_ENV_KEYS = [
+  'SSH_CONNECTION',
+  'SSH_TTY',
+  'TMUX',
+  'TMUX_PANE',
+  'TERM_PROGRAM',
+  'STY',
+] as const;
+
+/** Parse the NUL-separated body of /proc/<pid>/environ into a plain object. */
+export function parseProcEnviron(buf: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const pair of buf.split('\0')) {
+    if (!pair) continue;
+    const eq = pair.indexOf('=');
+    if (eq <= 0) continue;
+    env[pair.slice(0, eq)] = pair.slice(eq + 1);
+  }
+  return env;
+}
+
+/**
+ * How many whitespace-separated tokens each key's value spans. macOS
+ * `ps eww -o command=` space-joins the env after the command, so a value that
+ * itself contains spaces (SSH_CONNECTION is four fields) can't be recovered by
+ * boundary-guessing when the next token is an *unknown* var. Every provenance
+ * key except SSH_CONNECTION is a single token, so we read exactly its arity.
+ */
+const ENV_VALUE_TOKENS: Record<string, number> = { SSH_CONNECTION: 4 };
+
+/**
+ * Pull known env vars out of a macOS `ps eww` command+env line. For each
+ * `KEY=` match we consume the declared number of tokens (default 1), so
+ * SSH_CONNECTION's internal spaces survive while a following unknown var
+ * (e.g. `PWD=…`) is not swallowed into the previous value.
+ */
+export function extractKnownEnv(text: string, keys: readonly string[]): Record<string, string> {
+  const alt = keys.map((k) => k.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+  const boundary = new RegExp(`(?:^|\\s)(${alt})=`, 'g');
+  const env: Record<string, string> = {};
+  let m: RegExpExecArray | null;
+  while ((m = boundary.exec(text)) !== null) {
+    const key = m[1];
+    const rest = text.slice(m.index + m[0].length);
+    const tokens = rest.split(/\s+/);
+    const want = ENV_VALUE_TOKENS[key] ?? 1;
+    env[key] = tokens.slice(0, want).join(' ');
+  }
+  return env;
+}
+
+/** `<client_ip> <client_port> <server_ip> <server_port>` → structured origin. */
+export function parseSshConnection(value: string): SshOrigin | undefined {
+  const parts = value.trim().split(/\s+/);
+  if (parts.length < 4) return undefined;
+  const clientPort = parseInt(parts[1], 10);
+  const serverPort = parseInt(parts[3], 10);
+  if (!Number.isFinite(clientPort) || !Number.isFinite(serverPort)) return undefined;
+  return { clientIp: parts[0], clientPort, serverIp: parts[2], serverPort };
+}
+
+/** Build a SessionProvenance from a raw env map + the local hostname. Pure. */
+export function deriveProvenance(env: Record<string, string>, hostname: string): SessionProvenance {
+  const ssh = env.SSH_CONNECTION ? parseSshConnection(env.SSH_CONNECTION) : undefined;
+
+  let mux: MuxLocation | undefined;
+  if (env.TMUX) {
+    mux = {
+      kind: 'tmux',
+      socket: env.TMUX.split(',')[0] || undefined,
+      pane: env.TMUX_PANE || undefined,
+    };
+  } else if (env.STY) {
+    mux = { kind: 'screen', session: env.STY };
+  }
+
+  // A tmux pane is the one rail that lets an external process type into an
+  // already-running interactive agent (`tmux send-keys -t <pane>`). Everything
+  // else (inherited stdin from `agents run`, ignored stdin from teams) is not
+  // externally addressable without relaunching under a pty/tmux rail.
+  const reply: ReplyRail = mux?.kind === 'tmux' && mux.pane
+    ? { rail: 'tmux', target: mux.pane, socket: mux.socket }
+    : null;
+
+  return {
+    host: hostname,
+    transport: ssh ? 'ssh' : 'local',
+    ssh,
+    term: env.TERM_PROGRAM || undefined,
+    mux,
+    reply,
+  };
+}
+
+/** Read a process's environment. Linux: /proc. macOS: `ps eww`. Best-effort. */
+async function readProcEnv(pid: number): Promise<Record<string, string> | undefined> {
+  if (process.platform === 'linux') {
+    try {
+      const buf = await readFile(`/proc/${pid}/environ`, 'utf8');
+      return parseProcEnviron(buf);
+    } catch {
+      return undefined;
+    }
+  }
+  if (process.platform === 'darwin') {
+    try {
+      const { stdout } = await execFileAsync('ps', ['eww', '-p', String(pid), '-o', 'command='], {
+        encoding: 'utf8',
+        maxBuffer: 1024 * 1024,
+      });
+      if (!stdout.trim()) return undefined;
+      return extractKnownEnv(stdout, PROVENANCE_ENV_KEYS);
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve provenance for a live pid. Returns undefined when the process env
+ * can't be read (process gone, foreign uid, unsupported platform) — we never
+ * fabricate a 'local' answer we can't back with the env.
+ */
+export async function detectProvenance(pid: number): Promise<SessionProvenance | undefined> {
+  if (!pid || pid < 1) return undefined;
+  const env = await readProcEnv(pid);
+  if (!env) return undefined;
+  return deriveProvenance(env, os.hostname());
+}


### PR DESCRIPTION
## Why

The Agent Feed / Inbox (group agents by host, show what each *needs input on*, and type a reply back into the right one) needs to know **where each running agent actually lives**. Today `agents sessions --active` walks the ppid chain to name the terminal app, but flattens everything past it to a coarse `host` string — an agent running in tmux over SSH just reads `tmux`: no machine, no local-vs-remote, no pane to route back to.

## What

A provenance probe that reads the running process env — `/proc/<pid>/environ` on Linux, `ps eww` on macOS — and derives per active session:

| field | source | powers |
|---|---|---|
| `host` | `os.hostname()` | the **HOSTS** grouping (this-mac / zion / yosemite-s1) |
| `transport` | `SSH_CONNECTION` present? | local vs ssh badge (+ SSH origin when remote) |
| `term` | `TERM_PROGRAM` | terminal app |
| `mux` | `$TMUX` / `$TMUX_PANE` / `$STY` | tmux socket + **exact pane id** (`%39`) |
| `reply` | derived | read-only hint: tmux pane ⇒ addressable via `send-keys`; else `null` (inherited/ignored stdin) |

No agent cooperation needed — env vars are inherited, so we read them straight off the process. Enrichment runs once per deduped session in `getActiveSessions()`; a pid whose env can't be read leaves `provenance` undefined (no guessing — `reply: null` is honest about non-addressable sessions).

The `--active` renderer gains an `ssh` / `tmux %N` badge; `--active --json` carries the full struct — the addressing the feed consumes.

## Scope

Additive only. No existing `ActiveSession` field changes. This is **Gap 1** of the feed design (provenance capture); the actual send rail (`send-keys` into `reply.target`) is Gap 2, deliberately out of scope here.

## Verification

- `bun test src/lib/session/provenance.test.ts` — 13/13 pass (pure parsers with real `/proc` + `ps eww` formats, plus `detectProvenance(process.pid)` against the real runner process, no mocks).
- Full session suite: **10 pre-existing failures on both `origin/main` and this branch** (keychain/db env on Linux), **+13 new passing**. Zero regressions.
- **End-to-end on `yosemite-s1`:** all 4 live sessions resolved to host + SSH origin (v4 & v6) + exact tmux pane + populated reply rail, e.g.

  ```json
  {"kind":"claude","context":"terminal","pid":4032047,
   "provenance":{"host":"yosemite-s1","transport":"ssh",
     "ssh":{"clientIp":"100.126.152.114","clientPort":56981,"serverIp":"100.93.177.123","serverPort":22},
     "term":"tmux","mux":{"kind":"tmux","socket":"/tmp/tmux-1000/default","pane":"%39"},
     "reply":{"rail":"tmux","target":"%39","socket":"/tmp/tmux-1000/default"}}}
  ```

  Human render: `claude   tmux   idle   ssh tmux %39   This was a research task…`