### PR TITLE
chore(release): auto-roll changelog + label shipped digest as 1.20.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.20.31
+
 **`agents sessions <id>`: a catch-up digest for switching between many agents (#502)**
 
 - Opening a single session now leads with its auto-inferred title (user `/rename` > Claude `ai-title` > first-prompt topic) and PR / worktree / ticket badges, then a **Changes** section that groups touched files by directory and tags each as created / modified / deleted (with a `+N ~N -N` summary) instead of the old flat "Modified" list, a **Tools** histogram (per-tool call counts), and a **Tests** verdict parsed from the last `vitest` / `jest` / `pytest` / `go test` / `cargo test` / `tsc` run. The same signals are folded into the interactive picker preview.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -375,6 +375,31 @@ fi
 # committing it. Disable the auto-revert.
 PKG_BUMPED=false
 
+# ----- Roll the changelog: promote "## Unreleased" -> "## $TARGET" -----
+# Without this, every release leaves its notes stranded under "Unreleased" and
+# the section grows across releases with no per-version headers. Only fires when
+# the Unreleased section actually has content, so a notes-less release can't
+# create an empty version header.
+if [[ -f CHANGELOG.md ]]; then
+  unrel_content="$(awk '/^## Unreleased[[:space:]]*$/{f=1;next} f&&/^## /{exit} f&&/[^[:space:]]/{print}' CHANGELOG.md)"
+  if [[ -n "$unrel_content" ]]; then
+    tmp_cl="$(mktemp)"
+    awk -v ver="$TARGET" '
+      ins { print; next }
+      seen && /^## / { print; ins=1; seen=0; next }
+      seen && /[^[:space:]]/ { print "## " ver; print ""; print; ins=1; seen=0; next }
+      seen { print; next }
+      /^## Unreleased[[:space:]]*$/ { print; seen=1; next }
+      { print }
+    ' CHANGELOG.md > "$tmp_cl"
+    mv "$tmp_cl" CHANGELOG.md
+    git add CHANGELOG.md
+    green "Rolled CHANGELOG: ## Unreleased -> ## $TARGET"
+  else
+    gray "CHANGELOG: no Unreleased content to roll"
+  fi
+fi
+
 # ----- Commit (idempotent on package.json diff alone) -----
 git add package.json
 if ! git diff --cached --quiet; then


### PR DESCRIPTION
Fixes the recurring changelog drift (why 1.20.8–1.20.30 all piled under `## Unreleased` and 1.20.31 shipped with no version header).

- **`release.sh`** now promotes `## Unreleased` → `## <version>` inside the release commit — only when the section has content (a notes-less release can't create an empty header). This was the missing step: the script bumped `package.json` + tagged but never versioned the changelog.
- **`CHANGELOG.md`**: the catch-up digest (#502) moves under `## 1.20.31` (it shipped there); `## Unreleased` is now empty for the next cycle.

Roll logic tested for has-content (rolls) and empty-Unreleased (no-op) cases; `bash -n` clean.