### PR TITLE
feat(run): agents run --lease — run an agent on a disposable cloud box

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -56,6 +56,8 @@ interface ExecCommandActionOptions {
   remoteCwd?: string;
   follow?: boolean; // --no-follow sets this false
   any?: boolean;
+  lease?: string | boolean; // --lease [backend]: true when bare, backend string when given
+  keepBox?: boolean; // --keep-box: don't tear down the leased box after the run
 }
 
 /** Type guard that narrows a string to a known AgentId. */
@@ -247,7 +249,12 @@ export function registerRunCommand(program: Command): void {
     )
     .option('--remote-cwd <dir>', 'Working directory on the host for --host runs.')
     .option('--no-follow', 'With --host, dispatch detached and return immediately (track via `agents hosts ps/logs`).')
-    .option('--any', 'With --host <cap> (a capability tag), pick any matching host instead of erroring when several match.');
+    .option('--any', 'With --host <cap> (a capability tag), pick any matching host instead of erroring when several match.')
+    .option(
+      '--lease [backend]',
+      'Invent a disposable cloud box for this run and tear it down after (via crabbox). Optional backend selects the cloud (hetzner/aws/do). Unlike --host, no machine is registered.',
+    )
+    .option('--keep-box', 'With --lease, keep the box after the run instead of stopping it.');
 
   // `--on` and `--computer` are hidden aliases of `--host` — same behavior.
   runCmd.addOption(new Option('--on <name>', 'Alias of --host.').hideHelp());
@@ -305,6 +312,62 @@ export function registerRunCommand(program: Command): void {
       // Use command.args (all positional strings) and strip the declared positional args from the front.
       const declaredArgCount = prompt !== undefined ? 2 : 1;
       const passthroughArgs = command.args.slice(declaredArgCount);
+
+      // --lease: invent a disposable cloud box for this run (via crabbox), run
+      // the agent there, then tear it down. Unlike --host, nothing is registered.
+      if (options.lease) {
+        if (prompt === undefined) {
+          console.error(chalk.red('A prompt is required for leased runs: agents run <agent> "<task>" --lease'));
+          process.exit(1);
+        }
+        const backend = typeof options.lease === 'string' ? options.lease : undefined;
+        const { detectSignedInRuntimes, pickRuntimes } = await import('../lib/crabbox/runtimes.js');
+        const { leaseAndRun } = await import('../lib/crabbox/lease.js');
+        const { confirm } = await import('@inquirer/prompts');
+
+        const detected = await detectSignedInRuntimes();
+        const runtimes = await pickRuntimes(detected);
+        if (runtimes.length === 0) {
+          console.error(chalk.yellow('No runtimes selected. Sign into one locally (e.g. run `claude` once) then retry.'));
+          process.exit(1);
+        }
+
+        // Security gate: copying auth tokens to an ephemeral cloud box is opt-in
+        // per run. Name the runtimes + accounts so the user sees what ships.
+        const names = runtimes
+          .map((id) => {
+            const d = detected.find((x) => x.id === id);
+            return `${d?.label ?? id}${d?.email ? ` (${d.email})` : ''}`;
+          })
+          .join(', ');
+        const ok = await confirm({
+          message: `Copy credentials for ${names} to a disposable cloud box, run there, then destroy it?`,
+          default: false,
+        });
+        if (!ok) {
+          console.error(chalk.yellow('Aborted — no credentials pushed, no box leased.'));
+          process.exit(1);
+        }
+
+        try {
+          const { exitCode, box, toreDown } = await leaseAndRun({
+            agent: agentSpec.split('@')[0],
+            prompt,
+            mode: options.mode,
+            model: options.model,
+            backend,
+            runtimes,
+            detected,
+            secretsBundle: process.env.AGENTS_LEASE_SECRETS_BUNDLE,
+            keep: options.keepBox,
+          });
+          console.error(chalk.gray(toreDown ? `Box ${box.slug} destroyed.` : `Box ${box.slug} kept${box.ip ? ` (${box.ip})` : ''}. Stop it: crabbox stop --id ${box.slug}`));
+          process.exit(exitCode === null ? 1 : exitCode);
+        } catch (err) {
+          console.error(chalk.red((err as Error).message));
+          process.exit(1);
+        }
+      }
 
       // --host/--on/--computer: offload this run onto a registered agent host
       // over SSH instead of running locally. The three flags are aliases.

--- a/src/lib/crabbox/cli.ts
+++ b/src/lib/crabbox/cli.ts
@@ -1,0 +1,269 @@
+/**
+ * Typed wrapper over the external `crabbox` binary (github.com/openclaw/crabbox).
+ *
+ * crabbox leases ephemeral cloud boxes (Hetzner/DO/EC2/…), syncs the dirty
+ * checkout, and runs commands on them. We use it as the transport for
+ * `agents run --lease`: warm a box → run the agent on it via `crabbox run` →
+ * stop it. crabbox owns the SSH connection, so agents-cli never needs a direct
+ * ssh target (unlike the `agents hosts` model).
+ *
+ * crabbox talks to its cloud provider's API for list/status/warmup/stop, which
+ * needs a provider token (e.g. HCLOUD_TOKEN) in the environment. We inject it
+ * from a secrets bundle when one is configured (see `crabboxEnv`).
+ */
+
+import { spawn, spawnSync } from 'child_process';
+import { readAndResolveBundleEnv } from '../secrets/bundles.js';
+
+/** A crabbox machine as reported by `crabbox list --json`. */
+export interface CrabboxBox {
+  /** Provider machine name, e.g. `crabbox-blue-hermit-1039689b`. */
+  name: string;
+  /** Provider run state, e.g. `running`. */
+  status: string;
+  /** Friendly slug used with `--id`, e.g. `blue-hermit`. */
+  slug: string;
+  /** Lease id, e.g. `cbx_9968746bb15c`. */
+  lease: string;
+  /** crabbox bootstrap state; `ready` once the box is usable. */
+  state: string;
+  /** Public IPv4, when the provider exposes one. */
+  ip?: string;
+  profile?: string;
+  class?: string;
+  /** True when running + bootstrap-complete. */
+  ready: boolean;
+}
+
+export interface CrabboxOptions {
+  /**
+   * Name of a secrets bundle whose env (e.g. `HCLOUD_TOKEN`) crabbox needs to
+   * reach its cloud provider. Resolved via agents-cli's own keychain-backed
+   * secrets. When unset, crabbox runs with the ambient environment / its own
+   * `crabbox login` credentials.
+   */
+  secretsBundle?: string;
+}
+
+/** Locate the crabbox binary, or throw an actionable error. */
+export function findCrabbox(): string {
+  const r = spawnSync('crabbox', ['--help'], { encoding: 'utf-8' });
+  if (r.error) {
+    throw new Error(
+      'crabbox is not installed or not on PATH. Install it and run `crabbox login`, then `crabbox doctor` to verify provider access.',
+    );
+  }
+  return 'crabbox';
+}
+
+/** Build the child env for crabbox, injecting a secrets bundle when configured. */
+export function crabboxEnv(opts: CrabboxOptions): NodeJS.ProcessEnv {
+  const bundle = opts.secretsBundle ?? process.env.AGENTS_LEASE_SECRETS_BUNDLE;
+  if (!bundle) return process.env;
+  try {
+    // Reuse the same resolver `agents secrets exec` uses so a keychain-backed
+    // bundle (e.g. hetzner.com → HCLOUD_TOKEN) reaches crabbox without ever
+    // touching disk.
+    const { env } = readAndResolveBundleEnv(bundle, { caller: 'agents run --lease (crabbox)' });
+    return { ...process.env, ...env };
+  } catch (e) {
+    throw new Error(
+      `Could not load secrets bundle "${bundle}" for crabbox: ${(e as Error).message}. ` +
+        `Fix the bundle (agents secrets view ${bundle}) or unset lease.secretsBundle to use crabbox's own login.`,
+    );
+  }
+}
+
+function normalizeBox(raw: Record<string, unknown>): CrabboxBox | null {
+  const labels = (raw.labels ?? {}) as Record<string, string>;
+  const slug = labels.slug ?? '';
+  if (!slug) return null;
+  const status = String(raw.status ?? '');
+  const state = String(labels.state ?? '');
+  const publicNet = (raw.public_net ?? {}) as { ipv4?: { ip?: string } };
+  return {
+    name: String(raw.name ?? ''),
+    status,
+    slug,
+    lease: labels.lease ?? '',
+    state,
+    ip: publicNet.ipv4?.ip || undefined,
+    profile: labels.profile,
+    class: labels.class,
+    ready: status === 'running' && state === 'ready',
+  };
+}
+
+/** All crabbox machines the broker knows about. */
+export function crabboxList(opts: CrabboxOptions = {}): CrabboxBox[] {
+  findCrabbox();
+  const r = spawnSync('crabbox', ['list', '--json'], { encoding: 'utf-8', env: crabboxEnv(opts) });
+  if (r.status !== 0) {
+    throw new Error(`crabbox list failed: ${(r.stderr || r.stdout || '').trim() || 'unknown error'}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(r.stdout || '[]');
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed.map((b) => normalizeBox(b as Record<string, unknown>)).filter((b): b is CrabboxBox => b !== null);
+}
+
+/** Find one box by slug, or null. */
+export function crabboxFind(slug: string, opts: CrabboxOptions = {}): CrabboxBox | null {
+  return crabboxList(opts).find((b) => b.slug === slug) ?? null;
+}
+
+export interface WarmupOptions extends CrabboxOptions {
+  class?: string;
+  profile?: string;
+  /** Provision web code-server capability on the box. */
+  code?: boolean;
+  /** Cloud backend override (crabbox provider id, e.g. hetzner/aws/do). */
+  provider?: string;
+}
+
+/**
+ * Lease a box and block until it is ready. Returns the leased box.
+ *
+ * We diff `crabbox list` before/after so we reliably identify the box this call
+ * created even if warmup's stdout format changes — the new lease id is the one
+ * that wasn't present before.
+ */
+export function crabboxWarmup(opts: WarmupOptions = {}): CrabboxBox {
+  findCrabbox();
+  const env = crabboxEnv(opts);
+  const before = new Set(crabboxList(opts).map((b) => b.lease));
+
+  const args = ['warmup'];
+  if (opts.class) args.push('--class', opts.class);
+  if (opts.profile) args.push('--profile', opts.profile);
+  if (opts.provider) args.push('--provider', opts.provider);
+  if (opts.code) args.push('--code');
+
+  const r = spawnSync('crabbox', args, { encoding: 'utf-8', env, stdio: ['ignore', 'pipe', 'pipe'] });
+  if (r.status !== 0) {
+    const detail = (r.stderr || r.stdout || '').trim();
+    throw new Error(
+      `crabbox warmup failed: ${detail || 'unknown error'}. ` +
+        `Check provider access with \`crabbox doctor\`; a missing cloud token often means \`crabbox login\` or a lease.secretsBundle is needed.`,
+    );
+  }
+
+  // Prefer the freshly-created box (lease absent from the pre-warmup snapshot).
+  const after = crabboxList(opts);
+  const fresh = after.filter((b) => !before.has(b.lease));
+  if (fresh.length === 1) return fresh[0];
+
+  // Fallback: parse the cbx_ lease id crabbox prints and match it.
+  const m = (r.stdout || '').match(/cbx_[0-9a-f]+/i);
+  if (m) {
+    const byLease = after.find((b) => b.lease === m[0]);
+    if (byLease) return byLease;
+  }
+  if (fresh.length > 1) {
+    // Multiple new boxes (concurrent warmups) — pick the newest ready one.
+    const ready = fresh.filter((b) => b.ready);
+    if (ready.length) return ready[ready.length - 1];
+    return fresh[fresh.length - 1];
+  }
+  throw new Error('crabbox warmup succeeded but the new box could not be located in `crabbox list`.');
+}
+
+/**
+ * Poll until the box reports ready, or throw after timeoutMs.
+ * `sleep` is injectable so tests don't wall-clock wait.
+ */
+export async function crabboxWaitReady(
+  slug: string,
+  opts: CrabboxOptions & { timeoutMs?: number; intervalMs?: number; sleep?: (ms: number) => Promise<void> } = {},
+): Promise<CrabboxBox> {
+  const timeoutMs = opts.timeoutMs ?? 180_000;
+  const intervalMs = opts.intervalMs ?? 5_000;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise((res) => setTimeout(res, ms)));
+  const deadline = Date.now() + timeoutMs;
+  let last: CrabboxBox | null = null;
+  // First check is immediate (warmup usually returns an already-ready box).
+  for (;;) {
+    last = crabboxFind(slug, opts);
+    if (last?.ready) return last;
+    if (Date.now() >= deadline) break;
+    await sleep(intervalMs);
+  }
+  throw new Error(
+    `crabbox box "${slug}" did not become ready within ${Math.round(timeoutMs / 1000)}s (state: ${last?.state ?? 'gone'}).`,
+  );
+}
+
+export interface CrabboxRunOptions extends CrabboxOptions {
+  /** Called with each chunk of combined stdout/stderr as it streams. */
+  onData?: (chunk: string) => void;
+  /** Force a full remote resync before running. */
+  fullResync?: boolean;
+}
+
+/**
+ * Run `remoteCmd` on the leased box via `crabbox run` (crabbox syncs the dirty
+ * checkout and owns the SSH). Streams combined output; resolves with the remote
+ * exit code (or null if crabbox itself failed to dispatch).
+ */
+export function crabboxRun(slug: string, remoteCmd: string, opts: CrabboxRunOptions = {}): Promise<number | null> {
+  findCrabbox();
+  const args = ['run', '--id', slug, '--reclaim'];
+  if (opts.fullResync) args.push('--full-resync');
+  args.push('--', 'bash', '-lc', remoteCmd);
+  return new Promise((resolve) => {
+    const proc = spawn('crabbox', args, { env: crabboxEnv(opts), stdio: ['ignore', 'pipe', 'pipe'] });
+    const pump = (chunk: Buffer) => {
+      const s = chunk.toString('utf-8');
+      if (opts.onData) opts.onData(s);
+      else process.stdout.write(s);
+    };
+    proc.stdout.on('data', pump);
+    proc.stderr.on('data', pump);
+    proc.on('error', () => resolve(null));
+    proc.on('close', (code) => resolve(code));
+  });
+}
+
+/**
+ * Upload `script` to the box via `crabbox run --script-stdin` and run it.
+ *
+ * The script body travels over stdin and is written to a file on the box before
+ * execution — it never appears in argv / `ps` / shell history, which is why this
+ * is the transport for credential provisioning (the token contents live only in
+ * the uploaded script, then the file is removed by the script itself).
+ * Streams combined output; resolves with the remote exit code (null on dispatch failure).
+ */
+export function crabboxRunScript(slug: string, script: string, opts: CrabboxRunOptions = {}): Promise<number | null> {
+  findCrabbox();
+  const args = ['run', '--id', slug, '--reclaim'];
+  if (opts.fullResync) args.push('--full-resync');
+  args.push('--script-stdin');
+  return new Promise((resolve) => {
+    const proc = spawn('crabbox', args, { env: crabboxEnv(opts), stdio: ['pipe', 'pipe', 'pipe'] });
+    const pump = (chunk: Buffer) => {
+      const s = chunk.toString('utf-8');
+      if (opts.onData) opts.onData(s);
+      else process.stdout.write(s);
+    };
+    proc.stdout.on('data', pump);
+    proc.stderr.on('data', pump);
+    proc.on('error', () => resolve(null));
+    proc.on('close', (code) => resolve(code));
+    proc.stdin.write(script);
+    proc.stdin.end();
+  });
+}
+
+/** Release the lease / delete the box. Best-effort; never throws. */
+export function crabboxStop(slug: string, opts: CrabboxOptions = {}): boolean {
+  try {
+    const r = spawnSync('crabbox', ['stop', '--id', slug], { encoding: 'utf-8', env: crabboxEnv(opts) });
+    return r.status === 0;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/crabbox/lease.test.ts
+++ b/src/lib/crabbox/lease.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { buildBootstrapScript } from './lease.js';
+import type { DetectedRuntime } from './runtimes.js';
+
+describe('buildBootstrapScript', () => {
+  const detected: DetectedRuntime[] = [
+    { id: 'claude', label: 'Claude Code', email: 'a@b.com', signedIn: true, credPath: null },
+  ];
+
+  it('ensures agents-cli, installs runtimes, runs the agent, and shreds creds', () => {
+    const script = buildBootstrapScript({
+      agent: 'claude',
+      prompt: 'print hostname',
+      runtimes: ['claude'],
+      detected,
+    });
+    expect(script).toContain('command -v agents');
+    expect(script).toContain('npm install -g @phnx-labs/agents-cli');
+    expect(script).toContain("agents add 'claude'");
+    expect(script).toContain("agents run 'claude' 'print hostname' --quiet");
+    expect(script).toContain('rm -f "$HOME/.claude.json"'); // shred
+    expect(script).toContain('exit $rc');
+  });
+
+  it('threads mode/model into the remote run', () => {
+    const script = buildBootstrapScript({
+      agent: 'codex',
+      prompt: 'fix it',
+      mode: 'edit',
+      model: 'gpt-5',
+      runtimes: ['codex'],
+      detected,
+    });
+    expect(script).toContain("agents run 'codex' 'fix it' --quiet --mode 'edit' --model 'gpt-5'");
+  });
+
+  it('single-quote-escapes a prompt containing quotes (no argv injection)', () => {
+    const script = buildBootstrapScript({
+      agent: 'claude',
+      prompt: "don't break; rm -rf /",
+      runtimes: [],
+      detected,
+    });
+    // The dangerous prompt is fully contained in a single-quoted argument.
+    expect(script).toContain("'don'\\''t break; rm -rf /'");
+  });
+});

--- a/src/lib/crabbox/lease.ts
+++ b/src/lib/crabbox/lease.ts
@@ -1,0 +1,103 @@
+/**
+ * `agents run --lease` orchestrator.
+ *
+ * Lease an ephemeral crabbox → provision the picked runtime(s) + their
+ * credentials → run the agent on the box (via `crabbox run`, which owns the
+ * SSH) → tear the box down. The whole box-side sequence rides a single
+ * `--script-stdin` body so the token contents never touch argv.
+ */
+
+import type { AgentId } from '../types.js';
+import { crabboxWarmup, crabboxWaitReady, crabboxRunScript, crabboxStop, type CrabboxBox } from './cli.js';
+import { buildCredentialScript, type DetectedRuntime } from './runtimes.js';
+
+export interface LeaseRunOptions {
+  agent: string;
+  prompt: string;
+  mode?: string;
+  model?: string;
+  /** Cloud backend crabbox provisions on (hetzner/aws/do/…). */
+  backend?: string;
+  boxClass?: string;
+  profile?: string;
+  /** Runtimes to install + authenticate on the box (from the picker). */
+  runtimes: AgentId[];
+  detected: DetectedRuntime[];
+  /** Secrets bundle providing crabbox's provider token. */
+  secretsBundle?: string;
+  onData?: (s: string) => void;
+  /** Keep the box after the run instead of stopping it. */
+  keep?: boolean;
+}
+
+export interface LeaseRunResult {
+  box: CrabboxBox;
+  exitCode: number | null;
+  toreDown: boolean;
+}
+
+/** POSIX single-quote for safe embedding in the generated bootstrap script. */
+function q(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+/**
+ * Build the single bootstrap script run on the box: ensure agents-cli, install
+ * the picked runtime CLIs, write their credentials, run the agent, then shred
+ * the credential files. Best-effort install steps never abort the run.
+ */
+export function buildBootstrapScript(opts: LeaseRunOptions): string {
+  const credScript = buildCredentialScript(opts.runtimes, opts.detected);
+  const runParts = ['agents', 'run', q(opts.agent), q(opts.prompt), '--quiet'];
+  if (opts.mode) runParts.push('--mode', q(opts.mode));
+  if (opts.model) runParts.push('--model', q(opts.model));
+
+  // Credential files to shred after the run (home-level paths written above).
+  const shred = opts.runtimes
+    .map((id) => {
+      const cred = { claude: '.claude.json', codex: '.codex/auth.json', gemini: '.gemini/google_accounts.json', grok: '.grok/auth.json' }[id as string];
+      return cred ? `rm -f "$HOME/${cred}" 2>/dev/null || true` : '';
+    })
+    .filter(Boolean)
+    .join('\n');
+
+  const installRuntimes = opts.runtimes.map((id) => `agents add ${q(id)} >/dev/null 2>&1 || true`).join('\n');
+
+  return [
+    'set -uo pipefail',
+    'if ! command -v agents >/dev/null 2>&1; then npm install -g @phnx-labs/agents-cli >/dev/null 2>&1 || true; fi',
+    installRuntimes,
+    credScript,
+    `${runParts.join(' ')}`,
+    'rc=$?',
+    shred,
+    'exit $rc',
+  ]
+    .filter((l) => l.length > 0)
+    .join('\n');
+}
+
+export async function leaseAndRun(opts: LeaseRunOptions): Promise<LeaseRunResult> {
+  const box = crabboxWarmup({
+    class: opts.boxClass,
+    profile: opts.profile,
+    provider: opts.backend,
+    secretsBundle: opts.secretsBundle,
+  });
+  await crabboxWaitReady(box.slug, { secretsBundle: opts.secretsBundle });
+
+  const script = buildBootstrapScript(opts);
+  let exitCode: number | null = null;
+  let toreDown = false;
+  try {
+    exitCode = await crabboxRunScript(box.slug, script, {
+      secretsBundle: opts.secretsBundle,
+      onData: opts.onData,
+    });
+  } finally {
+    // Always attempt teardown (bounds credential lifetime to the run) unless the
+    // caller explicitly asked to keep the box.
+    if (!opts.keep) toreDown = crabboxStop(box.slug, { secretsBundle: opts.secretsBundle });
+  }
+  return { box, exitCode, toreDown };
+}

--- a/src/lib/crabbox/runtimes.test.ts
+++ b/src/lib/crabbox/runtimes.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import { buildCredentialScript, pickRuntimes, type DetectedRuntime } from './runtimes.js';
+
+describe('buildCredentialScript', () => {
+  let tmpDir: string;
+  let claudeCred: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lease-cred-'));
+    claudeCred = path.join(tmpDir, 'claude.json');
+    fs.writeFileSync(claudeCred, '{"oauthAccount":{"emailAddress":"a@b.com"}}');
+  });
+  afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  it('writes the picked runtime token via a quoted heredoc + chmod 600', () => {
+    const detected: DetectedRuntime[] = [
+      { id: 'claude', label: 'Claude Code', email: 'a@b.com', signedIn: true, credPath: claudeCred },
+    ];
+    const script = buildCredentialScript(['claude'], detected);
+    expect(script).toContain('cat > "$HOME/.claude.json" <<');
+    expect(script).toContain('{"oauthAccount":{"emailAddress":"a@b.com"}}');
+    expect(script).toContain('chmod 600 "$HOME/.claude.json"');
+    // Quoted heredoc delimiter → no shell expansion of the token body.
+    expect(script).toMatch(/<<'AGENTS_LEASE_CRED_EOF_[0-9a-f]+'/);
+  });
+
+  it('skips runtimes with no local credential', () => {
+    const detected: DetectedRuntime[] = [
+      { id: 'codex', label: 'Codex CLI', email: null, signedIn: false, credPath: null },
+    ];
+    expect(buildCredentialScript(['codex'], detected)).toBe('');
+  });
+
+  it('creates the parent dir for nested remote paths (codex)', () => {
+    const codexCred = path.join(tmpDir, 'codex.json');
+    fs.writeFileSync(codexCred, '{"tokens":{}}');
+    const detected: DetectedRuntime[] = [
+      { id: 'codex', label: 'Codex CLI', email: 'x@y.com', signedIn: true, credPath: codexCred },
+    ];
+    const script = buildCredentialScript(['codex'], detected);
+    expect(script).toContain('mkdir -p "$HOME/.codex"');
+    expect(script).toContain('cat > "$HOME/.codex/auth.json" <<');
+  });
+});
+
+describe('pickRuntimes', () => {
+  const detected: DetectedRuntime[] = [
+    { id: 'claude', label: 'Claude Code', email: 'a@b.com', signedIn: true, credPath: '/tmp/claude.json' },
+    { id: 'codex', label: 'Codex CLI', email: null, signedIn: false, credPath: null },
+  ];
+
+  it('defaults the checkbox to signed-in runtimes that have a credential', async () => {
+    let captured: any[] = [];
+    await pickRuntimes(detected, async (choices) => {
+      captured = choices;
+      return choices.filter((c) => c.checked).map((c) => c.value);
+    });
+    const claude = captured.find((c) => c.value === 'claude');
+    const codex = captured.find((c) => c.value === 'codex');
+    expect(claude.checked).toBe(true);
+    expect(codex.checked).toBe(false);
+    // No local credential → disabled with an explanation.
+    expect(typeof codex.disabled).toBe('string');
+  });
+
+  it('returns exactly the selected runtime ids', async () => {
+    const picked = await pickRuntimes(detected, async () => ['claude']);
+    expect(picked).toEqual(['claude']);
+  });
+});

--- a/src/lib/crabbox/runtimes.ts
+++ b/src/lib/crabbox/runtimes.ts
@@ -1,0 +1,138 @@
+/**
+ * Runtime detection + picker + credential-script builder for `agents run --lease`.
+ *
+ * The picker asks which coding-agent runtime(s) to provision on a leased box.
+ * The default selection is whatever the user is currently signed into locally
+ * (via `getAccountInfo`, the same source `agents view` uses). The chosen runtimes
+ * drive both what gets installed on the box and which auth token file is copied
+ * over — the token contents ride the uploaded `--script-stdin` body, never argv.
+ *
+ * SECURITY: copying a runtime's auth token to an ephemeral cloud box is a
+ * credential transfer. It is strictly opt-in (a confirm prompt in the command
+ * layer), the token never appears in argv/`ps`, and `--lease` one-shot runs tear
+ * the box down afterward so the credential's lifetime is bounded by the run.
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import type { AgentId } from '../types.js';
+import { getAccountInfo } from '../agents.js';
+
+/**
+ * Credential file locations per runtime. `localCandidates` are read in order
+ * (first existing wins); `remote` is where the box's CLI reads it by default
+ * (home-level — no per-version shim). Source of truth for these paths is
+ * `getAccountInfo` in src/lib/agents.ts; keep them in sync.
+ */
+interface RuntimeCred {
+  id: AgentId;
+  label: string;
+  localCandidates: string[];
+  remote: string;
+}
+
+export const LEASE_RUNTIMES: RuntimeCred[] = [
+  { id: 'claude', label: 'Claude Code', localCandidates: ['.claude/.claude.json', '.claude.json'], remote: '.claude.json' },
+  { id: 'codex', label: 'Codex CLI', localCandidates: ['.codex/auth.json'], remote: '.codex/auth.json' },
+  { id: 'gemini', label: 'Gemini CLI', localCandidates: ['.gemini/google_accounts.json'], remote: '.gemini/google_accounts.json' },
+  { id: 'grok', label: 'Grok CLI', localCandidates: ['.grok/auth.json'], remote: '.grok/auth.json' },
+];
+
+export interface DetectedRuntime {
+  id: AgentId;
+  label: string;
+  email: string | null;
+  signedIn: boolean;
+  /** Absolute local path of the credential file, if found. */
+  credPath: string | null;
+}
+
+/** First existing candidate path under the real home, or null. */
+function findLocalCred(cred: RuntimeCred): string | null {
+  const home = process.env.AGENTS_REAL_HOME || os.homedir();
+  for (const rel of cred.localCandidates) {
+    const p = path.join(home, rel);
+    try {
+      if (fs.existsSync(p)) return p;
+    } catch {
+      /* unreadable — skip */
+    }
+  }
+  return null;
+}
+
+/** Which lease-capable runtimes the user is signed into on this machine. */
+export async function detectSignedInRuntimes(): Promise<DetectedRuntime[]> {
+  const out: DetectedRuntime[] = [];
+  for (const cred of LEASE_RUNTIMES) {
+    let info;
+    try {
+      info = await getAccountInfo(cred.id);
+    } catch {
+      info = null;
+    }
+    out.push({
+      id: cred.id,
+      label: cred.label,
+      email: info?.email ?? null,
+      signedIn: !!info?.signedIn,
+      credPath: findLocalCred(cred),
+    });
+  }
+  return out;
+}
+
+/**
+ * Interactive checkbox: which runtimes to provision on the box. Defaults to the
+ * signed-in ones. Runtimes with no local credential are shown disabled.
+ * `prompt` is injected so tests don't require a TTY.
+ */
+export async function pickRuntimes(
+  detected: DetectedRuntime[],
+  prompt?: (choices: { name: string; value: AgentId; checked: boolean; disabled: boolean | string }[]) => Promise<AgentId[]>,
+): Promise<AgentId[]> {
+  const choices = detected.map((d) => ({
+    name: `${d.label}${d.email ? ` (${d.email})` : d.signedIn ? ' (signed in)' : ''}`,
+    value: d.id,
+    checked: d.signedIn && !!d.credPath,
+    disabled: d.credPath ? false : 'no local credential — sign in first',
+  }));
+  if (prompt) return prompt(choices);
+  const { checkbox } = await import('@inquirer/prompts');
+  return checkbox({ message: 'Provision which runtime(s) on the leased box?', choices });
+}
+
+// A long random sentinel makes an accidental (or malicious) collision with a
+// token's contents effectively impossible, so the quoted heredoc can never be
+// closed early by the credential body.
+const CRED_EOF = 'AGENTS_LEASE_CRED_EOF_9f3c1a7b5e2d4068';
+
+/**
+ * Build a bash snippet that writes each picked runtime's token file to the box's
+ * home-level config path (0600), from the token contents read locally. Returns
+ * `''` when no runtimes were selected. The snippet is meant to be embedded in
+ * the `--script-stdin` body (never argv).
+ */
+export function buildCredentialScript(picked: AgentId[], detected: DetectedRuntime[]): string {
+  const byId = new Map(detected.map((d) => [d.id, d]));
+  const parts: string[] = [];
+  for (const id of picked) {
+    const d = byId.get(id);
+    const cred = LEASE_RUNTIMES.find((c) => c.id === id);
+    if (!d?.credPath || !cred) continue;
+    let contents: string;
+    try {
+      contents = fs.readFileSync(d.credPath, 'utf-8');
+    } catch {
+      continue;
+    }
+    const dir = path.posix.dirname(cred.remote);
+    const mkdir = dir && dir !== '.' ? `mkdir -p "$HOME/${dir}"\n` : '';
+    parts.push(
+      `${mkdir}cat > "$HOME/${cred.remote}" <<'${CRED_EOF}'\n${contents}${contents.endsWith('\n') ? '' : '\n'}${CRED_EOF}\n` +
+        `chmod 600 "$HOME/${cred.remote}"`,
+    );
+  }
+  return parts.join('\n');
+}


### PR DESCRIPTION
## What

Adds `agents run <agent> \"<task>\" --lease [backend]` — an opt-in path that invents a **disposable cloud box** (via crabbox: Hetzner/AWS/DO/…), runs the agent there, and tears it down after. An interactive picker chooses which locally-signed-in runtime(s) to provision on the box.

`--host` stays "a machine you own"; `--lease` is "a machine invented on demand." The crabbox brand never appears in the flag — `backend` selects the cloud.

## Why

Running heavy agents locally pins the laptop. crabbox already provisions ephemeral boxes across clouds; this lets a run offload onto one and clean up automatically, picking up whatever runtime the user is signed into.

## How

- **`src/lib/crabbox/cli.ts`** — typed wrapper over the `crabbox` binary (`list` / `warmup` / `waitReady` / `run` / `runScript` / `stop`). Injects the cloud-provider token from a secrets bundle using the same `readAndResolveBundleEnv` that `agents secrets exec` uses (env var `AGENTS_LEASE_SECRETS_BUNDLE`). Transport is **`crabbox run`** (crabbox owns the SSH) — not the `agents hosts` direct-SSH model, so no tailnet/key-auth setup is needed.
- **`src/lib/crabbox/runtimes.ts`** — `detectSignedInRuntimes()` (via `getAccountInfo`, the same source `agents view` uses), `pickRuntimes()` (checkbox, defaults to signed-in), and `buildCredentialScript()` (writes each token file via a quoted heredoc + `chmod 600`).
- **`src/lib/crabbox/lease.ts`** — orchestrator: warmup → a single `--script-stdin` bootstrap (ensure agents-cli, install picked runtimes, write creds, run the agent, shred creds) → stop.
- **`src/commands/exec.ts`** — `--lease [backend]` + `--keep-box`, gated behind an explicit credential-push confirm.

## Security

Copying an auth token to an ephemeral cloud box is a credential transfer, so:
- **opt-in per run** — a confirm names each runtime + account before anything ships;
- token contents ride the uploaded `--script-stdin` body, **never argv/`ps`**;
- one-shot `--lease` runs **destroy the box afterward**, bounding credential lifetime to the run; the box-side script shreds the token files.

## Verification

- `tsc --noEmit` clean; **8 unit tests** pass (credential-script heredoc + `chmod`, nested-dir handling, picker defaults to signed-in, shell-quote injection safety, bootstrap script shape).
- The crabbox wrapper is **live-verified against the real broker**: `crabboxList({secretsBundle:'hetzner.com'})` resolved the bundle and parsed 3 running boxes (slug/lease/ready/ip/class) correctly; `--lease` + `--keep-box` register in `agents run --help`.
- **Not yet exercised end-to-end against a fresh lease** (warmup → box-side bootstrap → agent run). That needs a real leased box + a signed-in runtime and is the remaining E2E gate — flagged rather than claimed.

## Follow-ups

- Per-version remote home: creds are written to home-level paths (what the CLIs read without a relocating shim); a box whose agents-cli relocates config may need the per-version path.
- `agents lease ls/down` convenience surface (today: `crabbox list` / `crabbox stop`).