### PR TITLE
feat(agent-spec): onboard read/list commands onto the engine

### DIFF
--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -47,7 +47,6 @@ import {
 import {
   listInstalledVersions,
   getGlobalDefault,
-  resolveVersionAlias,
   syncResourcesToVersion,
   promptAgentVersionSelection,
   getVersionHomePath,
@@ -65,6 +64,7 @@ import {
   promptRemovalTargets,
   resolveAgentTargetsAutoInstalling,
   type RemovalTarget,
+  resolveListFilterOrExit,
 } from './utils.js';
 
 /** Register the `agents commands` command tree (list, add, remove, sync, prune, view). */
@@ -117,7 +117,7 @@ When to use:
           process.exit(1);
         }
         filterAgent = resolved;
-        filterVersion = resolveVersionAlias(resolved, parts[1]);
+        filterVersion = resolveListFilterOrExit(resolved, parts[1]);
       }
 
       const rows = buildCommandRows({ filterAgent, filterVersion });

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -38,7 +38,6 @@ import {
 import {
   listInstalledVersions,
   getGlobalDefault,
-  resolveVersionAlias,
   syncResourcesToVersion,
   promptAgentVersionSelection,
   getVersionHomePath,
@@ -55,6 +54,7 @@ import {
   promptRemovalTargets,
   resolveAgentTargetsAutoInstalling,
   type RemovalTarget,
+  resolveListFilterOrExit,
 } from './utils.js';
 
 /** Register the `agents hooks` command tree (list, add, remove, sync, prune, view). */
@@ -111,7 +111,7 @@ When to use:
           console.log(chalk.red(formatAgentError(agentName, [...capableAgents('hooks')])));
           process.exit(1);
         }
-        requestedVersion = resolveVersionAlias(agentId, parts[1]) ?? null;
+        requestedVersion = resolveListFilterOrExit(agentId, parts[1]) ?? null;
       }
 
       // Load hook manifest for event display

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -42,7 +42,6 @@ import {
   getVersionHomePath,
   resolveInstalledAgentTargets,
   resolveConfiguredAgentTargets,
-  resolveVersionAlias,
   syncResourcesToVersion,
 } from '../lib/versions.js';
 import { getUserAgentsDir } from '../lib/state.js';
@@ -57,6 +56,7 @@ import {
   resolveInstalledAgentTargetsAutoInstalling,
   VersionNotInstalledError,
   type RemovalTarget,
+  resolveListFilterOrExit,
 } from './utils.js';
 import {
   showResourceList,
@@ -233,7 +233,7 @@ When to use:
           process.exit(1);
         }
         filterAgent = resolved;
-        filterVersion = resolveVersionAlias(resolved, parts[1]);
+        filterVersion = resolveListFilterOrExit(resolved, parts[1]);
       }
 
       const rows = buildMcpRows({ filterAgent, filterVersion });

--- a/src/commands/permissions.ts
+++ b/src/commands/permissions.ts
@@ -43,7 +43,6 @@ import {
   getVersionHomePath,
   promptAgentVersionSelection,
   resolveAgentVersionTargets,
-  resolveVersionAlias,
 } from '../lib/versions.js';
 import { recordVersionResources } from '../lib/state.js';
 import {
@@ -53,6 +52,7 @@ import {
   printWithPager,
   requireInteractiveSelection,
   resolveAgentTargetsAutoInstalling,
+  resolveListFilterOrExit,
 } from './utils.js';
 
 export function shouldRefuseBroadPermissions(
@@ -179,7 +179,7 @@ When to use:
           console.log(chalk.red(formatAgentError(agentName, capableAgents('allowlist'))));
           process.exit(1);
         }
-        const requestedVersion = resolveVersionAlias(agentId, parts[1]) ?? null;
+        const requestedVersion = resolveListFilterOrExit(agentId, parts[1]) ?? null;
 
         if (!isCapable(agentId, 'allowlist')) {
           console.log(chalk.yellow(`${AGENTS[agentId].name} does not support fine-grained permissions`));

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -55,6 +55,7 @@ import {
   requireInteractiveSelection,
   requireDestructiveArg,
   resolveAgentTargetsAutoInstalling,
+  resolveListFilterOrExit,
 } from './utils.js';
 
 /** Register the `agents rules` command tree (list, add, view, remove). */
@@ -122,7 +123,7 @@ Project rules & @-imports:
           console.log(chalk.red(formatAgentError(agentName)));
           process.exit(1);
         }
-        requestedVersion = resolveVersionAlias(agentId, parts[1]) ?? null;
+        requestedVersion = resolveListFilterOrExit(agentId, parts[1]) ?? null;
       }
 
       const renderVersionRules = (

--- a/src/commands/skills.ts
+++ b/src/commands/skills.ts
@@ -44,7 +44,6 @@ import {
 import {
   listInstalledVersions,
   getGlobalDefault,
-  resolveVersionAlias,
   syncResourcesToVersion,
   promptAgentVersionSelection,
   getVersionHomePath,
@@ -60,6 +59,7 @@ import {
   resolveAgentTargetsAutoInstalling,
   promptRemovalTargets,
   type RemovalTarget,
+  resolveListFilterOrExit,
 } from './utils.js';
 import {
   showResourceList,
@@ -118,7 +118,7 @@ When to use:
           process.exit(1);
         }
         filterAgent = resolved;
-        filterVersion = resolveVersionAlias(resolved, parts[1]);
+        filterVersion = resolveListFilterOrExit(resolved, parts[1]);
       }
 
       const rows = await buildSkillRows({ filterAgent, filterVersion });

--- a/src/commands/utils.ts
+++ b/src/commands/utils.ts
@@ -21,6 +21,26 @@ import {
   type InstalledAgentTargetResult,
   type VersionSelectionResult,
 } from '../lib/versions.js';
+import { resolveListFilter, AgentSpecError } from '../lib/agent-spec/index.js';
+
+/**
+ * Resolve a read/list command's `@version` filter through the agent-spec engine,
+ * exiting cleanly on a bad spec. Drop-in for the old
+ * `resolveVersionAlias(agent, parts[1])`:
+ *   undefined → show all · @default/@pinned → the default version ·
+ *   @latest/@oldest/@x.y.z → concrete.
+ */
+export function resolveListFilterOrExit(agent: AgentId, qualifier: string | undefined | null): string | undefined {
+  try {
+    return resolveListFilter(agent, qualifier);
+  } catch (e) {
+    if (e instanceof AgentSpecError) {
+      console.error(chalk.red(e.message));
+      process.exit(1);
+    }
+    throw e;
+  }
+}
 
 /**
  * Check if an error is from user cancelling a prompt (Ctrl+C)

--- a/src/commands/workflows.ts
+++ b/src/commands/workflows.ts
@@ -31,7 +31,6 @@ import {
 import {
   getVersionHomePath,
   getGlobalDefault,
-  resolveVersionAlias,
   syncResourcesToVersion,
   promptAgentVersionSelection,
   resolveAgentVersionTargets,
@@ -46,6 +45,7 @@ import {
   parseCommaSeparatedList,
   resolveAgentTargetsAutoInstalling,
   type RemovalTarget,
+  resolveListFilterOrExit,
 } from './utils.js';
 import {
   showResourceList,
@@ -118,7 +118,7 @@ Examples:
           process.exit(1);
         }
         filterAgent = resolved;
-        filterVersion = parts[1] ? resolveVersionAlias(resolved, parts[1]) : undefined;
+        filterVersion = resolveListFilterOrExit(resolved, parts[1]);
       }
 
       const rows = buildWorkflowRows({ filterAgent, filterVersion });

--- a/src/lib/agent-spec/index.ts
+++ b/src/lib/agent-spec/index.ts
@@ -45,3 +45,12 @@ export function resolveVersionFilter(
 ): VersionFilter {
   return core.resolveVersionFilter(agent, qualifier, defaultVersionProvider, opts);
 }
+
+/** Concrete version filter for list/display commands (undefined → show all, @default → the default version). */
+export function resolveListFilter(
+  agent: AgentId,
+  qualifier: string | undefined | null,
+  opts: ResolveOptions = {},
+): string | undefined {
+  return core.resolveListFilter(agent, qualifier, defaultVersionProvider, opts);
+}

--- a/src/lib/agent-spec/resolve.test.ts
+++ b/src/lib/agent-spec/resolve.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import type { AgentId } from '../types.js';
 import { compareVersions } from './primitives.js';
 import { AgentSpecError, type VersionProvider } from './types.js';
-import { resolveAgentTargets, resolveSingleAgentTarget, resolveVersionFilter } from './resolve.js';
+import { resolveAgentTargets, resolveSingleAgentTarget, resolveVersionFilter, resolveListFilter } from './resolve.js';
 
 // In-memory provider — the whole point of the DI seam: no fs, no $HOME.
 function providerOf(state: {
@@ -158,5 +158,31 @@ describe('resolveVersionFilter (read/list commands)', () => {
 
   it('a bad exact filter throws', () => {
     expect(() => resolveVersionFilter(CLAUDE, '9.9.9', p)).toThrow(AgentSpecError);
+  });
+});
+
+describe('resolveListFilter (list commands — concrete version, not the sentinel)', () => {
+  it('bare / @any → undefined (show all installed)', () => {
+    const p = providerOf({ installed: { claude: ['2.1.0', '2.1.1'] }, global: { claude: '2.1.0' } });
+    expect(resolveListFilter(CLAUDE, undefined, p)).toBeUndefined();
+    expect(resolveListFilter(CLAUDE, 'any', p)).toBeUndefined();
+  });
+
+  it('@default / @pinned → the configured default VERSION (the behavior change)', () => {
+    const p = providerOf({ installed: { claude: ['2.1.0', '2.1.1'] }, global: { claude: '2.1.0' } });
+    expect(resolveListFilter(CLAUDE, 'default', p)).toBe('2.1.0');
+    expect(resolveListFilter(CLAUDE, 'pinned', p)).toBe('2.1.0');
+  });
+
+  it('@default with no default set → undefined (falls back to show-all, never errors)', () => {
+    const p = providerOf({ installed: { claude: ['2.1.0', '2.1.1'] } });
+    expect(resolveListFilter(CLAUDE, 'default', p)).toBeUndefined();
+  });
+
+  it('@latest / exact → a concrete version; bad exact throws', () => {
+    const p = providerOf({ installed: { claude: ['2.1.0', '2.1.1'] } });
+    expect(resolveListFilter(CLAUDE, 'latest', p)).toBe('2.1.1');
+    expect(resolveListFilter(CLAUDE, '2.1.0', p)).toBe('2.1.0');
+    expect(() => resolveListFilter(CLAUDE, '9.9.9', p)).toThrow(AgentSpecError);
   });
 });

--- a/src/lib/agent-spec/resolve.ts
+++ b/src/lib/agent-spec/resolve.ts
@@ -180,3 +180,23 @@ export function resolveVersionFilter(
   const { version, source } = resolveSingleAgentTarget(`${agent}@${q}`, provider, { ...opts, availableAgents: [agent] });
   return { version, source };
 }
+
+/**
+ * Concrete version filter for list/display commands whose downstream code
+ * filters by an exact version string (not the `'default'` sentinel `view` uses).
+ *   undefined / '' / @any → undefined  (no filter → show all installed)
+ *   @default / @pinned    → the configured default version, or undefined if none
+ *                           is set (falls back to show-all rather than erroring)
+ *   @latest/@oldest/x.y.z → a concrete version (throws AgentSpecError if bad)
+ */
+export function resolveListFilter(
+  agent: AgentId,
+  qualifier: string | undefined | null,
+  provider: VersionProvider,
+  opts: ResolveOptions = {},
+): string | undefined {
+  const q = qualifier?.trim();
+  if (!q || q === 'any') return undefined;
+  if (q === 'default' || q === 'pinned') return provider.getGlobalDefault(agent) ?? undefined;
+  return resolveSingleAgentTarget(`${agent}@${q}`, provider, { ...opts, availableAgents: [agent] }).version;
+}


### PR DESCRIPTION
Replaces #503 (rebased onto post-#501 main to avoid the squash-stack conflict — identical content, already independently reviewed & APPROVED on #503).

## What
Routes the version filter of the read-only **list** commands — `rules` / `hooks` / `commands` / `skills` / `workflows` / `permissions` / `mcp list` — through the agent-spec engine (merged in #501) via a new `resolveListFilter`, replacing the per-command inline `resolveVersionAlias(agentId, parts[1]) ?? null`.

- `agent-spec/resolve.ts` — `resolveListFilter`: concrete-version filter (undefined → show all; `@default`/`@pinned` → the configured default **version**, or undefined if none set → safe show-all; `@latest`/`@oldest`/`@x.y.z` → concrete). `index.ts` binds it.
- `commands/utils.ts` — `resolveListFilterOrExit`: CLI-boundary wrapper printing `AgentSpecError.message` + exit.

## Behavior change
`@default`/`@pinned` in a list command now scopes to the pinned version (matching `view`) instead of showing all. Bare still shows all; other qualifiers unchanged; bad exact → clean error. `rules` keeps `resolveVersionAlias` for view/remove/switch (only `list` migrated).

## Test
New `resolveListFilter` unit cases; 31 engine tests pass; `tsc --noEmit` clean. All 7 commands verified end-to-end on the dev CLI.