### PR TITLE
fix(secrets): stop listing every bundle twice under the Linux file fallback

### DIFF
--- a/src/lib/secrets/__tests__/bundles-linux-fallback.test.ts
+++ b/src/lib/secrets/__tests__/bundles-linux-fallback.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Regression: `secrets list` on a headless Linux box listed every bundle twice.
+ *
+ * When the Secret Service collection is locked, the Linux backend transparently
+ * routes to the encrypted-file store (linux.ts). `listBundles()` enumerates the
+ * keychain store AND the file store — but under that fallback BOTH enumerations
+ * read the same file store, so `listKeychainItems()` returned the file items
+ * (mislabeled `keychain`) and the direct file enumeration returned the same
+ * items again (labeled `[file]`). Every file-backed bundle appeared twice.
+ *
+ * The fix: `listBundles()` skips the keychain enumeration when the keychain
+ * backend is in the file fallback (keychainUsesFileFallback()), because the file
+ * enumeration already covers every bundle exactly once.
+ *
+ * Linux-only: the double-count is specific to the Linux `secret-tool` fallback.
+ * On macOS/Windows the platform branch isn't taken, so the scenario can't occur;
+ * CI runs this suite on Linux.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { listBundles, writeBundle, type SecretsBundle } from '../bundles.js';
+import { _resetForTest as resetLinux } from '../linux.js';
+import { keychainUsesFileFallback, setKeychainBackendForTest } from '../index.js';
+
+const PASS = 'fallback-passphrase';
+let tmpDir: string;
+
+const linuxOnly = process.platform === 'linux' ? describe : describe.skip;
+
+linuxOnly('listBundles under the Linux file fallback', () => {
+  beforeEach(() => {
+    // No injected keychain backend: keychainUsesFileFallback() must consult the
+    // real Linux path, not be short-circuited by a test backend.
+    setKeychainBackendForTest(null);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-linux-fallback-'));
+    process.env.AGENTS_SECRETS_PASSPHRASE = PASS;
+    // Force the locked-collection fallback and point the file store at tmp.
+    resetLinux({ fileDir: tmpDir, forceFileFallback: true, passphrase: PASS });
+  });
+
+  afterEach(() => {
+    delete process.env.AGENTS_SECRETS_PASSPHRASE;
+    resetLinux();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reports that the keychain backend is routing to the file store', () => {
+    expect(keychainUsesFileFallback()).toBe(true);
+  });
+
+  it('lists each file-backed bundle exactly once (no keychain/[file] double)', () => {
+    const names = ['alpha', 'bravo', 'charlie'];
+    for (const name of names) {
+      const b: SecretsBundle = { name, backend: 'file', vars: { A: 'x' } };
+      writeBundle(b);
+    }
+
+    const listed = listBundles();
+    const listedNames = listed.map((b) => b.name).sort();
+
+    // Exactly one row per bundle — the pre-fix bug produced two rows each.
+    expect(listedNames).toEqual([...names].sort());
+    expect(listed).toHaveLength(names.length);
+
+    // Every row is correctly attributed to the file store, not mislabeled
+    // `keychain` (which would render without the `[file]` tag).
+    for (const b of listed) {
+      expect(b.backend).toBe('file');
+    }
+  });
+});

--- a/src/lib/secrets/__tests__/bundles-storage.test.ts
+++ b/src/lib/secrets/__tests__/bundles-storage.test.ts
@@ -55,6 +55,7 @@ import {
   setKeychainBackendForTest,
   type KeychainBackend,
 } from '../index.js';
+import { _resetFileStoreForTest } from '../filestore.js';
 
 interface StoredItem { value: string }
 
@@ -76,15 +77,24 @@ function makeMemoryBackend(): { backend: KeychainBackend; store: Map<string, Sto
 
 let restore: KeychainBackend | null = null;
 let store: Map<string, StoredItem>;
+let fileTmpDir: string;
 
 beforeEach(() => {
   const m = makeMemoryBackend();
   store = m.store;
   restore = setKeychainBackendForTest(m.backend);
+  // Isolate the encrypted-file store to an empty temp dir. Without this,
+  // listBundles() enumerates the developer's REAL ~/.agents/.cache/secrets on
+  // any machine that has file-backed bundles (e.g. a headless Linux box under
+  // the secret-service fallback), leaking those into the counts asserted here.
+  fileTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-bundles-storage-'));
+  _resetFileStoreForTest({ fileDir: fileTmpDir });
 });
 
 afterEach(() => {
   setKeychainBackendForTest(restore);
+  _resetFileStoreForTest();
+  fs.rmSync(fileTmpDir, { recursive: true, force: true });
 });
 
 describe('writeBundle + readBundle round-trip', () => {

--- a/src/lib/secrets/bundles.ts
+++ b/src/lib/secrets/bundles.ts
@@ -27,6 +27,7 @@ import {
   getKeychainToken,
   getKeychainTokens,
   hasKeychainToken,
+  keychainUsesFileFallback,
   listKeychainItems,
   parseBundleValue,
   resolveRef,
@@ -467,22 +468,31 @@ export function listBundles(): SecretsBundle[] {
   // prompt instead of N. Bundle metadata items carry user-presence ACLs (same
   // as secret values), so a naive loop over readBundle() spawns a fresh
   // LAContext per item — meaning N biometric prompts for `secrets list`.
-  let keychainServices: string[] = [];
-  try {
-    keychainServices = listKeychainItems(BUNDLE_META_PREFIX);
-  } catch {
-    keychainServices = [];
-  }
-  const keychainNames = keychainServices
-    .map((s) => s.slice(BUNDLE_META_PREFIX.length))
-    .filter((n) => BUNDLE_NAME_PATTERN.test(n));
-  if (keychainNames.length > 0) {
-    const fetched = getKeychainTokens(keychainNames.map(bundleMetaItem));
-    for (const name of keychainNames) {
-      const json = fetched.get(bundleMetaItem(name));
-      if (json === undefined) continue;
-      const bundle = parseBundleMeta(name, json, 'keychain');
-      if (bundle) out.push(bundle);
+  //
+  // SKIP this entirely when the keychain backend is routing to the encrypted
+  // file store (Linux headless / locked-collection fallback): there,
+  // listKeychainItems() returns the SAME items the file enumeration below
+  // reads, so running both would list every file-backed bundle twice — once
+  // mislabeled `keychain`, once correctly `[file]`. Under the fallback the
+  // file store is the single source of truth, so the block below covers all.
+  if (!keychainUsesFileFallback()) {
+    let keychainServices: string[] = [];
+    try {
+      keychainServices = listKeychainItems(BUNDLE_META_PREFIX);
+    } catch {
+      keychainServices = [];
+    }
+    const keychainNames = keychainServices
+      .map((s) => s.slice(BUNDLE_META_PREFIX.length))
+      .filter((n) => BUNDLE_NAME_PATTERN.test(n));
+    if (keychainNames.length > 0) {
+      const fetched = getKeychainTokens(keychainNames.map(bundleMetaItem));
+      for (const name of keychainNames) {
+        const json = fetched.get(bundleMetaItem(name));
+        if (json === undefined) continue;
+        const bundle = parseBundleMeta(name, json, 'keychain');
+        if (bundle) out.push(bundle);
+      }
     }
   }
 

--- a/src/lib/secrets/index.ts
+++ b/src/lib/secrets/index.ts
@@ -24,7 +24,7 @@ import { execFileSync, spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { linuxBackend } from './linux.js';
+import { linuxBackend, usesFileFallback as linuxUsesFileFallback } from './linux.js';
 import { getKeychainHelperPath } from './install-helper.js';
 
 const SERVICE_PREFIX = 'agents-cli';
@@ -299,6 +299,22 @@ export function deleteKeychainToken(item: string): boolean {
   return spawnSync(bin, ['delete', item, os.userInfo().username], {
     stdio: ['ignore', 'pipe', 'pipe'],
   }).status === 0;
+}
+
+/**
+ * True when the active keychain backend transparently routes reads/writes to
+ * the encrypted-file store instead of the OS credential store. This only
+ * happens on Linux under the headless / locked-collection fallback
+ * (src/lib/secrets/linux.ts); macOS and the test backend always return false.
+ *
+ * Callers that ALSO enumerate the file store directly (e.g. `listBundles`)
+ * use this to avoid double-counting: under the fallback `listKeychainItems`
+ * and the direct file enumeration return the same items.
+ */
+export function keychainUsesFileFallback(): boolean {
+  if (backend) return false;
+  if (isLinux()) return linuxUsesFileFallback();
+  return false;
 }
 
 /** Enumerate keychain/keyring item names starting with the given prefix. */

--- a/src/lib/secrets/linux.ts
+++ b/src/lib/secrets/linux.ts
@@ -112,6 +112,27 @@ function preflight(): 'file' | 'secret-tool' {
   return 'secret-tool';
 }
 
+/**
+ * True when secret operations currently route to the encrypted-file store
+ * instead of the Secret Service (the headless / locked-collection fallback).
+ *
+ * Runs the same `preflight()` decision every read and write uses, so it can't
+ * drift from where bytes actually land. `preflight()` throws only in the
+ * interactive / no-secret-tool / no-passphrase case — where nothing is stored
+ * — so treat that as "not on the file path".
+ *
+ * `listBundles()` needs this: under the fallback the keychain enumeration
+ * (`linuxBackend.list`) and the file enumeration read the SAME store, so
+ * without this signal every file-backed bundle would be listed twice.
+ */
+export function usesFileFallback(): boolean {
+  try {
+    return preflight() === 'file';
+  } catch {
+    return false;
+  }
+}
+
 // ---------- secret-tool ops with fallback ----------
 
 /** secret-tool lookup attributes:


### PR DESCRIPTION
## Problem

On a headless Linux machine (e.g. `yosemite-s0`), `agents secrets list` renders **every bundle twice** — once normally and once tagged `[file]`:

```
agents-cli-supabase  5  daily  ...  Supabase backend for agents-cli ...
agents-cli-supabase  5  daily  ...  [file] Supabase backend for agents-cli ...
attio.com            3  daily  ...
attio.com            3  daily  ...  [file]
...
```

## Root cause

When the Secret Service collection is locked (no graphical login), the Linux backend transparently falls back to the AES-256-GCM encrypted-file store (`src/lib/secrets/linux.ts`). `preflight()` commits the whole process to the file store the moment `fileStoreHasItems()` is true.

`listBundles()` (`src/lib/secrets/bundles.ts`) enumerates **both** the keychain store and the file store and concatenates them. Under the fallback that double-counts, because both enumerations read the *same* file store:

- `listKeychainItems(prefix)` → `linuxBackend.list` → `listSecretToolItems` returns `fileStore.list()` under fallback (`linux.ts:246`), labeled `keychain`.
- The direct `fileStore.list()` (`bundles.ts:494`) returns the same items, labeled `[file]`.

(`wt-hostflag-e2e` showed once only because its meta fails to decrypt — the batch keychain path drops it, the file path's catch surfaces it.)

## Fix

Fix at the source rather than dedup after the fact:

1. `usesFileFallback()` in `linux.ts` — reuses the single `preflight()` decision so it can't drift from where bytes actually land.
2. `keychainUsesFileFallback()` in `index.ts` — platform-boundary accessor (macOS / test backend → always `false`).
3. `listBundles()` skips the keychain enumeration when the fallback is active; the file enumeration already covers every bundle exactly once with the correct `file` backend.

macOS and non-fallback Linux are unchanged: the predicate is `false` there, so a genuine keychain bundle and a same-named file bundle still render as distinct rows.

## Verification

Real `agents secrets list` on this Linux box, built from this branch — each bundle now appears exactly once:

```
agents-cli-supabase  5  daily  ...  [file] Supabase backend for agents-cli ...
attio.com            3  daily  ...  [file]
elevenlabs           1  daily  ...  [file] ElevenLabs API key ...
...
wt-hostflag-e2e      0  daily  ...  [file]
```

Tests:
- **New** `bundles-linux-fallback.test.ts` — forces the fallback, asserts each file-backed bundle is listed once with backend `file`. Verified it **fails pre-fix** (duplicate rows) and passes post-fix.
- `bundles-storage.test.ts` — isolate the file store to a temp dir so `listBundles` counts don't leak the developer's real `~/.agents/.cache/secrets` (a pre-existing, machine-dependent flake surfaced during verification).
- Full suite: **3314 passed, 0 failed**.