### PR TITLE
fix(test): skip POSIX-mode assertion on Windows in auth-carry test (RUSH-1318)

### DIFF
--- a/src/lib/shims.auth-carry.test.ts
+++ b/src/lib/shims.auth-carry.test.ts
@@ -81,7 +81,11 @@ describe('carryForwardAuthFiles / switchConfigSymlink — auth survives version 
     expect(fs.existsSync(dst)).toBe(true);
     expect(fs.readFileSync(dst, 'utf8')).toBe('LOGGED_IN_BLOB');
     expect(fs.existsSync(path.join(v2, '.factory', 'auth.v2.key'))).toBe(true);
-    expect(fs.statSync(dst).mode & 0o777).toBe(0o600);
+    // POSIX perms don't survive on Windows — Node reports 0o666 regardless of the
+    // mode copyFileSync was given, so asserting 0o600 there tests the OS, not us.
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(dst).mode & 0o777).toBe(0o600);
+    }
     // ...and the source is untouched (copy, not move).
     expect(fs.existsSync(path.join(v1, '.factory', 'auth.v2.file'))).toBe(true);
   });


### PR DESCRIPTION
## Problem

`build (windows-latest, *)` has been red on **every PR and `main` push** — not from the change under test, but from one assertion in `src/lib/shims.auth-carry.test.ts`:

```
AssertionError: expected 438 to be 384   // 0o666 vs 0o600
 ❯ src/lib/shims.auth-carry.test.ts:84
```

`carryForwardAuthFiles` copies droid/antigravity/kimi credentials via `copyFileSync`, which preserves `0600` on POSIX. Windows has no Unix permission bits — Node reports `0o666` regardless of the mode — so `expect(statSync(dst).mode & 0o777).toBe(0o600)` asserts the OS, not our code, and can only fail on Windows.

## Fix

Guard just that one assertion behind `process.platform !== 'win32'`, matching the existing repo convention (`hooks/cache.test.ts:95`, `settings-manifest.test.ts:152`). The rest of the test — credential carried, key present, content correct, source left intact — still runs on Windows. Linux/macOS keep asserting `0600` exactly as before.

Scoped to the single assertion; no production code touched.

## Verification

- `vitest run src/lib/shims.auth-carry.test.ts` on Linux → **6/6 pass** (the `0600` assertion still executes off-Windows, so coverage is unchanged there).
- Windows CI on this branch will confirm the previously-red job goes green.

Note: this is the pre-existing failure surfaced while landing #512 (session provenance) — that PR's own code was green on all platforms; this is the unrelated repo-wide Windows red.