### PR TITLE
fix(computer-win): stream setup --host push + add --host to launch

### DIFF
--- a/src/commands/computer-actions.ts
+++ b/src/commands/computer-actions.ts
@@ -556,8 +556,9 @@ export function registerActionCommands(program: Command): void {
     .option('--bundle <id>', 'Bundle id (e.g. com.apple.TextEdit)')
     .option('--path <p>', 'Path to the .app bundle')
     .option('--name <s>', 'App name (resolved via /Applications and LaunchServices)')
+    .option('--host <device>', 'Drive a remote Windows device (requires `agents computer start --host <device>` first)')
     .option('--json', 'Emit JSON')
-    .action(async (opts: { bundle?: string; path?: string; name?: string; json?: boolean }) => {
+    .action(async (opts: { bundle?: string; path?: string; name?: string; host?: string; json?: boolean }) => {
       if (!opts.bundle && !opts.path && !opts.name) {
         console.error('pass one of --bundle, --path, --name');
         process.exit(1);

--- a/src/lib/ssh-tunnel.ts
+++ b/src/lib/ssh-tunnel.ts
@@ -23,7 +23,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { randomBytes } from 'crypto';
-import { sshExec } from './ssh-exec.js';
+import { Transform } from 'stream';
+import { sshExec, SSH_OPTS } from './ssh-exec.js';
 import { encodePowerShell } from './browser/drivers/ssh.js';
 import { getDevice, type DeviceProfile } from './devices/registry.js';
 import { sshTargetFor } from './devices/connect.js';
@@ -256,6 +257,69 @@ export function buildUnregisterTaskScript(taskName: string): string {
  * go through `sshExec` (BatchMode key auth — the same hardening the browser
  * driver and `agents ssh` use). Throws with the remote stderr on any failure.
  */
+/**
+ * Base64-encode a byte stream in 3-byte-aligned chunks so the concatenated
+ * output is valid (every chunk boundary lands on a base64 quantum).
+ */
+class Base64Encode extends Transform {
+  private leftover = Buffer.alloc(0);
+  override _transform(chunk: Buffer, _enc: BufferEncoding, cb: () => void): void {
+    const buf = this.leftover.length ? Buffer.concat([this.leftover, chunk]) : chunk;
+    const usable = buf.length - (buf.length % 3);
+    this.leftover = Buffer.from(buf.subarray(usable));
+    if (usable > 0) this.push(buf.subarray(0, usable).toString('base64'));
+    cb();
+  }
+  override _flush(cb: () => void): void {
+    if (this.leftover.length) this.push(this.leftover.toString('base64'));
+    cb();
+  }
+}
+
+/**
+ * Stream a local file to a remote command's stdin over ssh, base64-encoded on
+ * the fly. Async spawn + piping honors backpressure; the previous
+ * `spawnSync({ input })` blob deadlocked once the ssh socket buffer filled
+ * (~4MB) on large files (the 157MB Windows helper reproduced this reliably),
+ * and worse, reported a false success leaving a 0-byte remote file. Rejects on
+ * any pipe error so a broken transfer fails loudly instead.
+ */
+function streamFileOverSsh(
+  target: string,
+  remoteCmd: string,
+  filePath: string,
+  timeoutMs = 600_000,
+): Promise<{ code: number | null; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('ssh', [...SSH_OPTS, target, remoteCmd], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stderr = '';
+    let stdout = '';
+    child.stderr.on('data', (d) => (stderr += d.toString()));
+    child.stdout.on('data', (d) => (stdout += d.toString()));
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`ssh push to ${target} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    const fail = (e: Error) => {
+      clearTimeout(timer);
+      child.kill('SIGKILL');
+      reject(e);
+    };
+    child.on('error', fail);
+    child.stdin.on('error', fail); // EPIPE if the remote decoder dies mid-stream
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({ code, stderr: stderr || stdout });
+    });
+    const src = fs.createReadStream(filePath);
+    src.on('error', fail);
+    // disk -> aligned base64 -> ssh stdin; .pipe() applies backpressure
+    src.pipe(new Base64Encode()).pipe(child.stdin);
+  });
+}
+
 export async function setupRemoteHelper(name: string): Promise<{ target: string; taskName: string }> {
   const { target } = await resolveRemoteDevice(name);
 
@@ -264,14 +328,12 @@ export async function setupRemoteHelper(name: string): Promise<{ target: string;
     throw new Error(`Windows helper exe not built. Run: bash scripts/build-win.sh`);
   }
 
-  // Push: base64 the exe locally, stream it over ssh stdin to the decoder.
-  const b64 = fs.readFileSync(exe).toString('base64');
-  const push = sshExec(target, encodePowerShell(buildPushScript()), {
-    input: b64,
-    timeoutMs: 600_000, // ~156MB over the wire — allow up to 10 minutes
-  });
+  // Push: stream the exe from disk, base64-encoded on the fly, to the remote
+  // decoder. Streaming (vs a single spawnSync `input` blob) honors ssh socket
+  // backpressure — the blob path deadlocks once the socket buffer fills (~4MB).
+  const push = await streamFileOverSsh(target, encodePowerShell(buildPushScript()), exe);
   if (push.code !== 0) {
-    throw new Error(`pushing helper exe to '${name}' failed (exit ${push.code ?? 'null'}): ${push.stderr.trim() || push.stdout.trim()}`);
+    throw new Error(`pushing helper exe to '${name}' failed (exit ${push.code ?? 'null'}): ${push.stderr.trim()}`);
   }
 
   // Register + start the LOGON task.


### PR DESCRIPTION
Two fixes surfaced by a **live end-to-end test of the Windows computer-use remote path** against a real box (`win-mini`), following #495/#496.

## Fixes

**1. `setup --host` exe push — stream it (was a deadlocking blob)**
`setupRemoteHelper` did `fs.readFileSync(exe).toString('base64')` and handed the whole ~210 MB string to `ssh` as one `spawnSync({input})` blob. On the 157 MB self-contained helper this **deadlocks** once the ssh socket buffer fills (~4 MB) — and worse, **reports a false success**, leaving a **0-byte** file on the remote. Replaced with a streaming push (`disk → 3-byte-aligned base64 Transform → ssh stdin`, `.pipe()` backpressure) that rejects on any pipe error so a broken transfer fails loudly.

**2. `launch` was the only verb missing `--host`**
The other 12 action verbs get `--host` via `addTargetOpts`; `launch` defines its options manually and skipped it, so `agents computer launch --host <dev>` errored `unknown option '--host'`. Added the option so the `computer` preAction hook hydrates the tunnel TCP endpoint for it.

## Verification
- `tsc` clean; 18/18 `computer` / `ssh-tunnel` / `computer-rpc` tests pass.
- `launch --help` now lists `--host`.
- Remote drive E2E against real `win-mini` over the ssh tunnel: `apps`, `screenshot` (real 2560×1440 capture), `scroll`, `drag`, `right-click`, `wait` all ✅.

## Follow-ups (tracked separately — not in this PR)
- **UIAutomation dead in the self-contained single-file exe** — `describe`/`get-text`/`focus`/`ax-action` throw an `AutomationElement` type-init exception in the `build-win.sh` (`PublishSingleFile`, self-contained) artifact, but pass in CI (which uses framework-dependent `dotnet build`). CI is green while the shipped artifact is half-broken.
- **Transfer robustness** — even the streaming push can't complete a 157 MB transfer over a flaky/relayed link; an HTTP-pull (win-mini fetches from the controller) proved fully reliable and may be the better mechanism.
- **`screenshot`** writes PNG but defaults the filename to `.jpg`.