### PR TITLE
test(daemon): make OAuth-token tests hermetic — bypass the secrets-agent

### DIFF
--- a/src/lib/daemon.test.ts
+++ b/src/lib/daemon.test.ts
@@ -52,15 +52,27 @@ function seedLiteral(value: string): void {
 }
 
 let restore: KeychainBackend | null = null;
+let prevNoAgent: string | undefined;
 
 beforeEach(() => {
   const m = makeMemoryBackend();
   restore = setKeychainBackendForTest(m.backend);
+  // Hermeticity: readAndResolveBundleEnv consults the running secrets-agent
+  // (bundles.ts agentGetSync fast-path) BEFORE the injected keychain backend.
+  // On a dev machine where the agent is live and the real `claude` bundle is
+  // unlocked, that returns the machine's real CLAUDE_CODE_OAUTH_TOKEN and this
+  // test reads a live credential instead of the seeded value (CI has no agent,
+  // so it only bites locally). Disable the agent so the read falls through to
+  // the in-memory backend above — hermetic regardless of host state.
+  prevNoAgent = process.env.AGENTS_SECRETS_NO_AGENT;
+  process.env.AGENTS_SECRETS_NO_AGENT = '1';
 });
 
 afterEach(() => {
   try { deleteBundle('claude'); } catch { /* not created */ }
   setKeychainBackendForTest(restore);
+  if (prevNoAgent === undefined) delete process.env.AGENTS_SECRETS_NO_AGENT;
+  else process.env.AGENTS_SECRETS_NO_AGENT = prevNoAgent;
 });
 
 describe('readDaemonClaudeOAuthToken', () => {


### PR DESCRIPTION
## Problem

Cutting the `1.20.33` release on zion (macOS) failed the pre-release test gate: **12 tests in `src/lib/daemon.test.ts` failed, and one printed a live `CLAUDE_CODE_OAUTH_TOKEN`**. The same suite is green in CI.

## Root cause — a two-layer keychain seam

`daemon.test.ts` installs an in-memory keychain backend via `setKeychainBackendForTest`. But the code under test reads the token like this:

```
readDaemonClaudeOAuthToken() → readAndResolveBundleEnv('claude') → agentGetSync('claude')   ← fast-path, hits the live secrets-agent
                                                                 → itemStore('keychain')     ← the layer the test backend controls
```

`readAndResolveBundleEnv` (bundles.ts:672) consults the **running secrets-agent** *before* the injected backend. On a dev box where the agent is live and the real `claude` bundle is unlocked, that fast-path returns the machine's real OAuth token and short-circuits the store read — so the test read a real credential instead of the seeded value. CI has no agent running, so the fast-path returns null and the store read (which *does* honor the test backend) wins — masking the leak.

## Fix

Set `AGENTS_SECRETS_NO_AGENT=1` for the duration of each test — the exact lever `bundles.ts:672` already honors (`&& process.env.AGENTS_SECRETS_NO_AGENT !== '1'`). The read falls through to the injected in-memory backend, hermetic regardless of whether the host's agent is running. Saved/restored per test so it can't bleed into other suites.

Test-only change — no production code touched. The agent fast-path stays intact for real runs (it's what dedups Touch ID).

## Verification

- **Locally (Linux):** `vitest run src/lib/daemon.test.ts` → 13/13 (unchanged — it always passed here).
- **On zion, agent live + real `claude` unlocked** (the machine that reproduced the failure): 13/13, **zero token in output**, and the real `claude` bundle verified intact afterward (`agents secrets list` unchanged).
- Full suite re-run on zion to confirm the `1.20.33` release gate now passes.