### PR TITLE
feat(teams): advisory sign-in in doctor + warn-and-proceed on add/start

### DIFF
--- a/src/commands/teams.ts
+++ b/src/commands/teams.ts
@@ -13,9 +13,12 @@ import * as path from 'path';
 import {
   AgentManager,
   checkAllClis,
+  checkCliSignedIn,
   getAgentsDir,
+  resolveSignInAdvisory,
   VALID_TASK_TYPES,
   type AgentType,
+  type SignInAdvisory,
   type TaskType,
 } from '../lib/teams/agents.js';
 import { resolveProvider } from '../lib/cloud/registry.js';
@@ -47,6 +50,7 @@ import {
   removeWorktree,
 } from '../lib/teams/worktree.js';
 import { isVersionInstalled, resolveVersionAlias, resolveVersionAliasLoose } from '../lib/versions.js';
+import { AGENTS } from '../lib/agents.js';
 import type { AgentId } from '../lib/types.js';
 import { discoverSessions, parseTimeFilter, resolveSessionById } from '../lib/session/discover.js';
 import type { SessionMeta } from '../lib/session/types.js';
@@ -193,7 +197,7 @@ function parseTeammate(spec: string): {
 
   die(
     `Unknown teammate '${spec}'. Available agents: ${VALID_AGENTS.join(', ')}.\n` +
-      `  Use 'claude', 'claude@2.1.112', or the name of a profile from 'agents view'.`
+      `  Use 'claude', 'kimi@latest', 'kimi@0.19.2' (a version from 'agents view'), or a profile name.`
   );
 }
 
@@ -252,6 +256,32 @@ export function wireCloudDispatcher(mgr: AgentManager): void {
     const cloudTask = await prov.dispatch(dispatchOpts);
     return { cloudSessionId: cloudTask.id };
   });
+}
+
+/**
+ * Advisory: warn once per agent type of any still-pending (staged `--after`)
+ * teammate whose CLI may not be signed in. Warn-only — never blocks `start`.
+ * Local teammates only; cloud teammates authenticate through their provider.
+ */
+async function warnUnsignedTeammates(mgr: AgentManager, team: string): Promise<void> {
+  let pending;
+  try {
+    pending = (await mgr.listByTask(team)).filter((a) => a.status === 'pending' && !a.cloudProvider);
+  } catch {
+    return; // team not loadable yet — nothing to warn about
+  }
+  const seen = new Set<AgentType>();
+  for (const a of pending) {
+    const agent = a.agentType as AgentType;
+    if (seen.has(agent) || !AGENT_NAMES[agent]) continue;
+    seen.add(agent);
+    if (!(await checkCliSignedIn(agent))) {
+      console.error(
+        chalk.yellow(`⚠ ${AGENT_NAMES[agent]} may not be signed in (detection is unreliable). Launching anyway.`) +
+          chalk.gray(`\n  If it fails to start, run \`${AGENTS[agent].cliCommand}\` to log in, or pass --force to silence this.`)
+      );
+    }
+  }
 }
 
 /** Single-wave start used by `teams start` without --watch. */
@@ -963,11 +993,12 @@ export function registerTeamsCommands(program: Command): void {
     .option('--cloud <provider>', `Dispatch to cloud backend instead of local CLI: ${VALID_CLOUD_PROVIDERS.join('|')}`)
     .option('--repo <owner/repo>', 'GitHub repository (required for --cloud rush)')
     .option('--branch <name>', 'Target git branch for cloud dispatch')
+    .option('--force', "Skip the advisory 'may not be signed in' warning (detection is unreliable)")
     .option('--json', 'Output machine-readable JSON')
     .action(async (team: string, teammate: string, task: string, opts: {
       name?: string; mode: string; effort: string; model?: string; env: string[];
       cwd?: string; worktree?: string; after?: string; json?: boolean;
-      taskType?: string; cloud?: string; repo?: string; branch?: string;
+      taskType?: string; cloud?: string; repo?: string; branch?: string; force?: boolean;
     }) => {
       if (!(VALID_MODES as readonly string[]).includes(opts.mode)) {
         die(`Invalid mode '${opts.mode}'. Use one of: ${VALID_MODES.join(', ')}`);
@@ -1000,7 +1031,17 @@ export function registerTeamsCommands(program: Command): void {
         die(
           `${AGENT_NAMES[agent]} ${version} isn't installed.\n` +
             `  Install it:  agents add ${agent}@${version}\n` +
-            `  Or see what's installed:  agents view ${agent}`
+            `  Or see what's installed (incl. @latest):  agents view ${agent}`
+        );
+      }
+
+      // Advisory sign-in check: warn but NEVER block. Detection is unreliable
+      // for opaque-cred agents, so a false negative must not stop a team. Cloud
+      // dispatch authenticates through the provider, not the local CLI — skip it.
+      if (!opts.force && !cloudProviderId && !(await checkCliSignedIn(agent))) {
+        console.error(
+          chalk.yellow(`⚠ ${AGENT_NAMES[agent]} may not be signed in (detection is unreliable). Adding anyway.`) +
+            chalk.gray(`\n  If it fails to start, run \`${AGENTS[agent].cliCommand}\` to log in, or pass --force to silence this.`)
         );
       }
 
@@ -1315,7 +1356,8 @@ export function registerTeamsCommands(program: Command): void {
     .option('--watch', 'Keep running: poll every --interval seconds, fire new waves, exit when the DAG drains.')
     .option('--interval <seconds>', 'Seconds between waves in --watch mode (default 8)', '8')
     .option('--max-waves <n>', 'Safety cap on waves in --watch mode (default 1000)', '1000')
-    .action(async (team: string | undefined, opts: { json?: boolean; watch?: boolean; interval: string; maxWaves: string }) => {
+    .option('--force', "Skip the advisory 'may not be signed in' warning for staged teammates (detection is unreliable)")
+    .action(async (team: string | undefined, opts: { json?: boolean; watch?: boolean; interval: string; maxWaves: string; force?: boolean }) => {
       const mgr = mkManager();
       wireCloudDispatcher(mgr);
 
@@ -1324,6 +1366,8 @@ export function registerTeamsCommands(program: Command): void {
         if (!picked) return;
         team = picked;
       }
+
+      if (!opts.force && !isJsonMode(opts)) await warnUnsignedTeammates(mgr, team);
 
       if (!opts.watch) {
         await runOneWave(mgr, team, Boolean(opts.json));
@@ -1644,19 +1688,47 @@ export function registerTeamsCommands(program: Command): void {
   teams
     .command('doctor')
     .alias('dr')
-    .description('Check which agents are installed and available to join a team. Verifies CLI paths.')
+    .description('Check which agents are installed and available to join a team. Verifies CLI paths and shows an advisory sign-in hint.')
     .option('--json', 'Output machine-readable JSON')
     .action(async (opts: { json?: boolean }) => {
       const info = checkAllClis();
+
+      // Advisory enrichment only. Sign-in detection is UNRELIABLE, so it never
+      // changes the authoritative installed/ready column — it annotates. And an
+      // agent that is actually running in a team is treated as signed in
+      // regardless of the probe, so doctor never reports a working agent as
+      // logged out ("don't show wrong stuff").
+      const running = new Set<string>();
+      try {
+        for (const a of await mkManager().listRunning()) running.add(a.agentType);
+      } catch { /* no teams yet — leave running empty */ }
+
+      const auth: Record<string, SignInAdvisory> = {};
+      await Promise.all(
+        Object.entries(info).map(async ([name, entry]) => {
+          const isRunning = running.has(name);
+          const probe = entry.installed && !isRunning ? await checkCliSignedIn(name as AgentType) : false;
+          auth[name] = resolveSignInAdvisory(entry.installed, isRunning, probe);
+        })
+      );
+
       if (isJsonMode(opts)) {
-        console.log(JSON.stringify(info, null, 2));
+        const merged: Record<string, unknown> = {};
+        for (const [name, entry] of Object.entries(info)) merged[name] = { ...entry, ...auth[name] };
+        console.log(JSON.stringify(merged, null, 2));
         return;
       }
       console.log(chalk.bold('Who can join a team:'));
       for (const [name, entry] of Object.entries(info)) {
         const pretty = AGENT_NAMES[name as AgentType] || name;
         if (entry.installed) {
-          console.log(`  ${chalk.green('ready')}  ${pretty.padEnd(10)} ${chalk.gray(entry.path || '')}`);
+          const { signedIn, running: isRunning } = auth[name];
+          const hint = isRunning
+            ? chalk.gray('in use')
+            : signedIn
+              ? chalk.gray('signed in')
+              : chalk.gray('sign-in unverified');
+          console.log(`  ${chalk.green('ready')}  ${pretty.padEnd(10)} ${chalk.gray(entry.path || '')}  ${hint}`);
         } else {
           console.log(`  ${chalk.red('no   ')}  ${pretty.padEnd(10)} ${chalk.gray(entry.error || 'not installed')}`);
         }

--- a/src/lib/teams/agents.sign-in.test.ts
+++ b/src/lib/teams/agents.sign-in.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { checkCliSignedIn, resolveSignInAdvisory } from './agents.js';
+
+// The advisory sign-in status shown by `teams doctor`. The load-bearing rule:
+// a RUNNING teammate is live proof the agent works, so it overrides a
+// (frequently false-negative) sign-in probe — doctor must never report a
+// working agent as logged out.
+describe('resolveSignInAdvisory', () => {
+  it('running overrides a negative probe (never show a working agent as logged out)', () => {
+    expect(resolveSignInAdvisory(true, true, false)).toEqual({ signedIn: true, running: true });
+  });
+
+  it('installed + probe positive → signed in', () => {
+    expect(resolveSignInAdvisory(true, false, true)).toEqual({ signedIn: true, running: false });
+  });
+
+  it('installed + probe negative + not running → unverified (false, not null)', () => {
+    expect(resolveSignInAdvisory(true, false, false)).toEqual({ signedIn: false, running: false });
+  });
+
+  it('not installed → signedIn null and running forced false regardless of inputs', () => {
+    expect(resolveSignInAdvisory(false, true, true)).toEqual({ signedIn: null, running: false });
+  });
+});
+
+// checkCliSignedIn is advisory and must NEVER throw — a probe failure returns
+// false so callers warn-and-proceed instead of crashing the team.
+describe('checkCliSignedIn', () => {
+  let tmpHome: string;
+  let realHome: string;
+  let origHome: string | undefined;
+  let origRealHome: string | undefined;
+  let origKeychain: string | undefined;
+
+  beforeEach(() => {
+    origHome = process.env.HOME;
+    origRealHome = process.env.AGENTS_REAL_HOME;
+    origKeychain = process.env.AGENTS_NO_KEYCHAIN_PROBE;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'signin-home-'));
+    realHome = fs.mkdtempSync(path.join(os.tmpdir(), 'signin-real-'));
+    // Sign-in is account-global: getAccountInfo falls back from the base home to
+    // the active config under AGENTS_REAL_HOME. Pin both to empty dirs so the
+    // "signed out" assertion doesn't leak into the developer's real login.
+    process.env.HOME = tmpHome;
+    process.env.AGENTS_REAL_HOME = realHome;
+    process.env.AGENTS_NO_KEYCHAIN_PROBE = '1';
+  });
+
+  afterEach(() => {
+    if (origHome === undefined) delete process.env.HOME; else process.env.HOME = origHome;
+    if (origRealHome === undefined) delete process.env.AGENTS_REAL_HOME; else process.env.AGENTS_REAL_HOME = origRealHome;
+    if (origKeychain === undefined) delete process.env.AGENTS_NO_KEYCHAIN_PROBE; else process.env.AGENTS_NO_KEYCHAIN_PROBE = origKeychain;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    fs.rmSync(realHome, { recursive: true, force: true });
+  });
+
+  it('returns false for a logged-out home without throwing', async () => {
+    await expect(checkCliSignedIn('claude' as never)).resolves.toBe(false);
+  });
+
+  it('returns a boolean (never throws) for an odd agent type', async () => {
+    await expect(checkCliSignedIn('not-a-real-agent' as never)).resolves.toBe(false);
+  });
+});

--- a/src/lib/teams/agents.ts
+++ b/src/lib/teams/agents.ts
@@ -20,7 +20,7 @@ import { debug } from './debug.js';
 import { setGeminiAutoUpdateDisabled, updateGeminiSettings } from '../gemini-settings.js';
 import type { AgentId } from '../types.js';
 import { getAgentsDir as getSystemAgentsDir, getShimsDir } from '../state.js';
-import { AGENTS } from '../agents.js';
+import { AGENTS, getAccountInfo } from '../agents.js';
 import { sanitizeProcessEnv } from '../secrets/bundles.js';
 
 let lastMemoryWarnAt = 0;
@@ -386,6 +386,47 @@ export function checkAllClis(): Record<string, { installed: boolean; path: strin
     }
   }
   return results;
+}
+
+/**
+ * Advisory sign-in probe for a teammate's agent. Reads the account-global login
+ * (no `home` → active config) via `getAccountInfo`. Deliberately best-effort:
+ * sign-in detection is UNRELIABLE for opaque-credential agents (Kimi/Antigravity
+ * store an OAuth/JWT with no email claim) and for keychain-probed agents, so a
+ * `false` here is often a false negative. Callers must WARN and continue — never
+ * block a team on this result. Never throws (returns false on any error).
+ */
+export async function checkCliSignedIn(agentType: AgentType): Promise<boolean> {
+  try {
+    const info = await getAccountInfo(agentType as AgentId);
+    return info.signedIn;
+  } catch {
+    return false;
+  }
+}
+
+/** Advisory sign-in status for a `teams doctor` row. */
+export interface SignInAdvisory {
+  /** true / false from the probe, or null when the agent isn't installed. */
+  signedIn: boolean | null;
+  /** Whether the agent is currently a running teammate. */
+  running: boolean;
+}
+
+/**
+ * Resolve the advisory sign-in status shown by `teams doctor`. An agent that is
+ * currently RUNNING in a team is live proof it works, so it overrides a
+ * (frequently false-negative) sign-in probe — doctor must never report a
+ * working agent as logged out. Not installed → `signedIn: null` (nothing to
+ * probe). Never flips the authoritative installed/ready column.
+ */
+export function resolveSignInAdvisory(
+  installed: boolean,
+  running: boolean,
+  probeSignedIn: boolean
+): SignInAdvisory {
+  if (!installed) return { signedIn: null, running: false };
+  return { signedIn: running ? true : probeSignedIn, running };
 }
 
 let AGENTS_DIR: string | null = null;


### PR DESCRIPTION
## Why

When an agent spins up a team, sign-in detection is **unreliable** — opaque-cred agents (Kimi/Antigravity store an OAuth/JWT with no email) and keychain probes produce frequent false "not signed in" results. Today `teams doctor` reports install-only (a logged-out CLI still shows `ready`), and `teams add` does no login check at all, so a doomed teammate is accepted silently and only fails at spawn.

This makes sign-in **advisory everywhere, never a gate**.

## What

- **`teams add` / `start`** — probe login and **warn**, but always add/launch the teammate. New `--force` silences the (possibly false-negative) warning. Cloud teammates authenticate through their provider and are skipped.
- **`teams doctor`** — the authoritative `ready`/`no` column stays install-driven; a soft `signed in` / `sign-in unverified` hint is layered on. A teammate currently **RUNNING** in a team is live proof it works, so it renders `in use` regardless of the probe — doctor never reports a working agent as logged out. `--json` gains `signedIn` / `running` per agent.
- **Version pinning discoverability** — `agent@latest` / `@oldest` / `@<version>` already worked via `resolveVersionAlias`; the add error/hint text now advertises `@latest` instead of only a hardcoded version.

New `checkCliSignedIn()` wraps `getAccountInfo().signedIn` and never throws. `resolveSignInAdvisory()` isolates the running-overrides-probe rule for unit testing.

## Testing

- New `src/lib/teams/agents.sign-in.test.ts` (6 tests, no mocking) covering the advisory rule (running overrides a negative probe) and the never-throw contract.
- Full teams suite green: **73/73**, `tsc --noEmit` clean.
- Verified end-to-end against the real CLI: doctor renders soft hints and flips a running teammate to `in use`; `add` warns but still registers a not-signed-in teammate; `--force` silences the warning; `kimi@latest` resolves to the installed `0.19.2`.