### PR TITLE
fix(secrets): stop `secrets list` Touch ID prompts — daily metadata cache + legacy self-heal

### DIFF
--- a/scripts/keychain-entitlements.plist
+++ b/scripts/keychain-entitlements.plist
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <!-- macOS 26 (Tahoe) secd requires the app to carry application-identifier
+         (matching the embedded provisioning profile's App ID) for the
+         keychain-access-groups grant to be honored on the data-protection
+         keychain. Without it, SecItemAdd fails with OSStatus -34018 on a fresh
+         build even though the profile + wildcard group are present. -->
+    <key>com.apple.application-identifier</key>
+    <string>2HTP252L87.com.phnx-labs.agents-keychain</string>
     <key>keychain-access-groups</key>
     <array>
         <string>2HTP252L87.*</string>

--- a/src/commands/secrets-migrate.ts
+++ b/src/commands/secrets-migrate.ts
@@ -28,8 +28,10 @@ import * as path from 'path';
 import {
   deleteKeychainToken,
   getKeychainToken,
+  getKeychainTokens,
   hasKeychainToken,
   listKeychainItems,
+  listLegacyKeychainItems,
   setKeychainToken,
 } from '../lib/secrets/index.js';
 import { getBackupsDir } from '../lib/state.js';
@@ -122,8 +124,9 @@ export function registerSecretsMigrateAclCommand(secrets: Command): void {
     .description('Refresh existing keychain ACLs to use the signed Agents CLI helper. Dry-run by default.')
     .option('--commit', 'Perform writes (default is dry-run reporting only)')
     .option('--prefix <p>', `Restrict to items beginning with PREFIX (default ${ITEM_PREFIX})`, ITEM_PREFIX)
+    .option('--all', 'Rewrite EVERY matching item, not just legacy stragglers (slower; a Touch ID prompt per item)')
     .option('--passphrase-env <var>', 'Read the backup passphrase from this env var instead of prompting')
-    .action(async (opts: { commit?: boolean; prefix?: string; passphraseEnv?: string }) => {
+    .action(async (opts: { commit?: boolean; prefix?: string; all?: boolean; passphraseEnv?: string }) => {
       try {
         if (process.platform !== 'darwin') {
           throw new Error('migrate-acl is macOS-only. Linux items already use the keyring-native ACL model.');
@@ -134,15 +137,26 @@ export function registerSecretsMigrateAclCommand(secrets: Command): void {
             `--prefix must start with '${ITEM_PREFIX}' to avoid touching unrelated Keychain items (got '${prefix}').`,
           );
         }
-        const items = listKeychainItems(prefix).map((item) => {
+        // Default: migrate ONLY legacy stragglers (items still in the file-based
+        // keychain) — modern DP items need no rewrite and touching them is a
+        // Touch ID prompt per item for nothing. `--all` forces the old full
+        // rewrite. Either way this is one command over every matching item — no
+        // one-by-one invocation.
+        const names = opts.all ? listKeychainItems(prefix) : listLegacyKeychainItems(prefix);
+        const items = names.map((item) => {
           const localExists = hasKeychainToken(item);
           return { item, sync: !localExists };
         });
         if (items.length === 0) {
-          console.log(chalk.gray(`No keychain items with prefix '${prefix}'.`));
+          console.log(
+            opts.all
+              ? chalk.gray(`No keychain items with prefix '${prefix}'.`)
+              : chalk.green(`Nothing to migrate — all items under '${prefix}' already use the modern ACL.`),
+          );
           return;
         }
-        console.log(chalk.bold(`Found ${items.length} item(s) under '${prefix}'.`));
+        const label = opts.all ? 'item' : 'legacy item';
+        console.log(chalk.bold(`Found ${items.length} ${label}(s) under '${prefix}' to migrate.`));
         if (!opts.commit) {
           for (const { item, sync } of items) {
             console.log(`  ${chalk.cyan(item)} ${chalk.gray(sync ? '(synced)' : '(local)')}`);
@@ -151,15 +165,18 @@ export function registerSecretsMigrateAclCommand(secrets: Command): void {
           console.log(chalk.gray('Dry-run — pass --commit to perform the migration.'));
           return;
         }
-        // Commit phase. Snapshot every value first, encrypt, then mutate.
+        // Commit phase. Snapshot every value first (one batched read behind a
+        // single helper process, so DP items share one auth context), encrypt,
+        // then mutate.
+        const fetched = getKeychainTokens(items.map((i) => i.item));
         const records: MigrationRecord[] = [];
         for (const { item, sync } of items) {
-          try {
-            const value = getKeychainToken(item);
-            records.push({ item, sync, value });
-          } catch (err) {
-            console.error(chalk.red(`Skipping '${item}': read failed (${(err as Error).message}).`));
+          const value = fetched.get(item);
+          if (value === undefined) {
+            console.error(chalk.red(`Skipping '${item}': read failed or item absent.`));
+            continue;
           }
+          records.push({ item, sync, value });
         }
         if (records.length === 0) {
           console.error(chalk.red('No items could be read. Aborting before any writes.'));

--- a/src/lib/secrets/__tests__/keychain-helper.test.ts
+++ b/src/lib/secrets/__tests__/keychain-helper.test.ts
@@ -115,15 +115,21 @@ describe('keychain-helper forward migration (file-based -> data-protection)', ()
     expect(block).toContain('return (value, fileStatus, true)');
   });
 
-  it('migrateInline deletes the legacy copy and re-adds into the DP keychain', () => {
+  it('migrateInline adds the DP copy and does NOT delete the legacy copy inline', () => {
     const source = helperSource();
     const block = source.slice(source.indexOf('func migrateInline('), source.indexOf('func dieIfCancelled('));
-    // Remove the legacy file-based copy so the next read resolves from DP.
-    expect(block).toContain('SecItemDelete(fileBase(service: service, account: account) as CFDictionary)');
-    // Re-add carries the DP base (incl. access group) plus the biometry ACL.
+    // Clears any stale DP copy first (DP-scoped) so the add can't hit errSecDuplicateItem.
+    expect(block).toContain('SecItemDelete(dpBase(service: service, account: account) as CFDictionary)');
+    // Adds the DP copy: DP base (incl. access group) plus the biometry ACL.
     expect(block).toContain('var addAttrs = dpBase(service: service, account: account)');
     expect(block).toContain('addAttrs[kSecAttrAccessControl] = buildBiometryAccessControl()');
     expect(block).toContain('SecItemAdd(addAttrs as CFDictionary, nil)');
+    // Regression guard: migrateInline must NOT delete the legacy copy inline.
+    // On macOS 26 the unscoped SecItemDelete(fileBase) also removes the
+    // just-added DP copy (same service+account), so the relocation never sticks.
+    // Legacy purge is migrate-acl's job (it clears both keychains before its add,
+    // after an encrypted backup).
+    expect(block).not.toContain('SecItemDelete(fileBase(service: service, account: account) as CFDictionary)');
   });
 
   it('get and get-batch only migrate items in our own namespace', () => {

--- a/src/lib/secrets/agent.test.ts
+++ b/src/lib/secrets/agent.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { SecretsBundle } from './bundles.js';
-import { handleAgentRequest, shouldSelfHealForUpgrade, META_CACHE_PREFIX, type StoredBundle, type Request } from './agent.js';
+import { handleAgentRequest, shouldSelfHealForUpgrade, realBundleCount, META_CACHE_PREFIX, type StoredBundle, type Request } from './agent.js';
 
 /**
  * These tests target the broker's store semantics — the part with real bug
@@ -132,6 +132,17 @@ describe('secrets list metadata cache (broker-held snapshot)', () => {
     handleAgentRequest(store, loadReq(metaKey, { __snapshot__: '[]' }, 60_000), 0);
     handleAgentRequest(store, { cmd: 'lock' }, 0);
     expect(handleAgentRequest(store, { cmd: 'get', name: metaKey }, 0)).toMatchObject({ hit: false });
+  });
+
+  it('realBundleCount excludes the metadata cache so it cannot pin the broker on old code (#435)', () => {
+    const store = freshStore();
+    // A metadata-only store must read as empty for self-heal / idle-exit.
+    handleAgentRequest(store, loadReq(metaKey, { __snapshot__: '[]' }, 60_000), 0);
+    expect(store.size).toBe(1);
+    expect(realBundleCount(store)).toBe(0);
+    // A real unlock counts; the meta entry still does not.
+    handleAgentRequest(store, loadReq('prod', { K: 'v' }, 60_000), 0);
+    expect(realBundleCount(store)).toBe(1);
   });
 });
 

--- a/src/lib/secrets/agent.test.ts
+++ b/src/lib/secrets/agent.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { SecretsBundle } from './bundles.js';
-import { handleAgentRequest, shouldSelfHealForUpgrade, type StoredBundle, type Request } from './agent.js';
+import { handleAgentRequest, shouldSelfHealForUpgrade, META_CACHE_PREFIX, type StoredBundle, type Request } from './agent.js';
 
 /**
  * These tests target the broker's store semantics — the part with real bug
@@ -103,6 +103,35 @@ describe('handleAgentRequest', () => {
       // fresh on-disk read and restarts the broker on mismatch.
       expect(typeof r.cliVersion).toBe('string');
     }
+  });
+});
+
+describe('secrets list metadata cache (broker-held snapshot)', () => {
+  const metaKey = `${META_CACHE_PREFIX}abc123`;
+
+  it('round-trips a metadata snapshot through the same load/get transport', () => {
+    const store = freshStore();
+    const snapshot = JSON.stringify([{ name: 'prod', vars: {} }, { name: 'stage', vars: {} }]);
+    handleAgentRequest(store, loadReq(metaKey, { __snapshot__: snapshot }, 60_000), 0);
+    const r = handleAgentRequest(store, { cmd: 'get', name: metaKey }, 1_000);
+    expect(r).toMatchObject({ hit: true, env: { __snapshot__: snapshot } });
+  });
+
+  it('hides the internal metadata-cache entry from status (not a user bundle)', () => {
+    const store = freshStore();
+    handleAgentRequest(store, loadReq('prod', { K: 'v' }, 60_000), 0);
+    handleAgentRequest(store, loadReq(metaKey, { __snapshot__: '[]' }, 60_000), 0);
+    const r = handleAgentRequest(store, { cmd: 'status' }, 1_000);
+    if (r.ok && r.cmd === 'status') {
+      expect(r.entries.map((e) => e.name)).toEqual(['prod']); // metaKey excluded
+    }
+  });
+
+  it('lock-all still wipes the metadata cache (screen-lock drops it too)', () => {
+    const store = freshStore();
+    handleAgentRequest(store, loadReq(metaKey, { __snapshot__: '[]' }, 60_000), 0);
+    handleAgentRequest(store, { cmd: 'lock' }, 0);
+    expect(handleAgentRequest(store, { cmd: 'get', name: metaKey }, 0)).toMatchObject({ hit: false });
   });
 });
 

--- a/src/lib/secrets/agent.ts
+++ b/src/lib/secrets/agent.ts
@@ -276,6 +276,19 @@ export type Response =
  * unit-testable with a controlled `now`, without a socket or a spawned process.
  * Mutates `store` in place; returns the wire response.
  */
+/**
+ * Count of real unlocked bundles in the store, excluding the internal
+ * `secrets list` metadata cache. Used to decide broker "warmth" for self-heal
+ * and idle-exit: a metadata-only store must read as empty so a disposable list
+ * cache never blocks an upgrade restart (#435) or an idle one-off broker from
+ * exiting. Pure + exported for unit testing.
+ */
+export function realBundleCount(store: Map<string, StoredBundle>): number {
+  let n = 0;
+  for (const name of store.keys()) if (!name.startsWith(META_CACHE_PREFIX)) n++;
+  return n;
+}
+
 export function handleAgentRequest(
   store: Map<string, StoredBundle>,
   req: Request,
@@ -362,20 +375,26 @@ export async function runSecretsAgent(opts: { service?: boolean } = {}): Promise
   // this value for the process lifetime; getCliVersionFresh re-reads on disk.
   const runningVersion = getCliVersion();
 
+  // "Warmth" for self-heal / idle-exit counts only real unlocked bundles, NOT
+  // the internal `secrets list` metadata cache (#524). Otherwise a 24h-TTL list
+  // cache would keep the store non-empty and (a) block the persistent broker
+  // from self-healing onto a freshly-installed version for up to a day (#435's
+  // gate is size===0), and (b) stop a one-off broker from ever idle-exiting. The
+  // metadata cache is a disposable list snapshot — wiping it on upgrade/idle
+  // costs at most one extra prompt on the next `secrets list`.
   const sweep = () => {
     const now = Date.now();
     for (const [name, e] of store) if (now >= e.expiresAt) store.delete(name);
-    // Self-heal onto a newer in-place install — but ONLY while the store is
-    // empty, so we never wipe live unlocks and force a re-prompt (#435). The
-    // `store.size === 0` short-circuit also keeps getCliVersionFresh (a disk
-    // read) off the hot path. A pending upgrade is adopted at the next idle
-    // sweep instead of immediately.
-    if (store.size === 0 &&
-        shouldSelfHealForUpgrade(persistent, store.size, runningVersion, getCliVersionFresh())) {
+    const live = realBundleCount(store);
+    // Self-heal onto a newer in-place install — but ONLY while no real unlocks
+    // are held, so we never wipe live unlocks and force a re-prompt (#435). A
+    // metadata-only store still self-heals (the list cache is disposable).
+    if (live === 0 &&
+        shouldSelfHealForUpgrade(persistent, live, runningVersion, getCliVersionFresh())) {
       shutdown(0); // KeepAlive relaunches on the new code
       return;
     }
-    if (store.size === 0) {
+    if (live === 0) {
       if (!persistent && now - emptySince >= IDLE_EXIT_MS) shutdown(0);
     } else {
       emptySince = now;
@@ -384,7 +403,7 @@ export async function runSecretsAgent(opts: { service?: boolean } = {}): Promise
 
   const handle = (req: Request): Response => {
     const resp = handleAgentRequest(store, req);
-    if (store.size > 0) emptySince = Date.now();
+    if (realBundleCount(store) > 0) emptySince = Date.now();
     return resp;
   };
 
@@ -665,10 +684,15 @@ export async function agentLock(name?: string): Promise<number> {
   return r?.ok === true && r.cmd === 'lock' ? r.wiped : 0;
 }
 
-/** List currently-unlocked bundles, or [] when no broker is running. */
+/** List currently-unlocked bundles, or [] when no broker is running. The
+ * internal `secrets list` metadata-cache entry is filtered out here as well as
+ * server-side: during a rollout a NEW client can talk to an OLD broker that
+ * predates the server-side exclusion, so this keeps the internal entry from
+ * surfacing in `agents secrets status` in that skew window. */
 export async function agentStatus(): Promise<AgentStatusEntry[]> {
   const r = await request({ cmd: 'status' });
-  return r?.ok === true && r.cmd === 'status' ? r.entries : [];
+  const entries = r?.ok === true && r.cmd === 'status' ? r.entries : [];
+  return entries.filter((e) => !e.name.startsWith(META_CACHE_PREFIX));
 }
 
 /** Ping result: whether a broker is reachable + speaking our protocol, and the

--- a/src/lib/secrets/agent.ts
+++ b/src/lib/secrets/agent.ts
@@ -41,6 +41,20 @@ const PROTOCOL_VERSION = 1;
 /** Default lifetime of an unlocked bundle when `--ttl` is not given. */
 export const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24h
 
+/**
+ * Reserved store-key prefix for the `secrets list` metadata snapshot cache.
+ * The broker holds the resolved bundle-metadata array (names/policy/timestamps,
+ * NO resolved secret values beyond the literals already in metadata) keyed by a
+ * hash of the current keychain bundle name-set, so the second and later
+ * `secrets list` within the daily window read metadata without a Touch ID
+ * prompt. Keyed by the name-set hash so adding/removing/renaming a bundle
+ * changes the key and misses the cache automatically — no active invalidation.
+ * The '!' sentinel can never collide with a real bundle name
+ * (BUNDLE_NAME_PATTERN requires an alphanumeric first char) and is safe as
+ * spawnSync argv (unlike a NUL byte); `status` hides these entries.
+ */
+export const META_CACHE_PREFIX = '!meta:';
+
 /** After the store goes empty (all bundles locked or expired) for this long,
  * the broker exits so no idle process lingers holding a socket. */
 const IDLE_EXIT_MS = 5 * 60 * 1000; // 5m
@@ -297,6 +311,7 @@ export function handleAgentRequest(
       const entries: AgentStatusEntry[] = [];
       for (const [name, e] of store) {
         if (now >= e.expiresAt) continue;
+        if (name.startsWith(META_CACHE_PREFIX)) continue; // internal list cache, not a user bundle
         entries.push({ name, expiresAt: e.expiresAt, keyCount: Object.keys(e.env).length });
       }
       return { ok: true, cmd: 'status', entries };
@@ -527,6 +542,43 @@ export function agentGetSync(name: string): { bundle: SecretsBundle; env: Record
   } catch {
     return null;
   }
+}
+
+// Key inside the cached entry's env that holds the JSON metadata snapshot.
+const META_SNAPSHOT_KEY = '__snapshot__';
+
+/**
+ * Read the cached `secrets list` metadata snapshot for the given keychain
+ * name-set hash, or null on miss / no broker / off-darwin. Reuses the value
+ * fast-path socket read (agentGetSync) — no prompt, no wire change. The hash is
+ * the cache key: a changed name-set (bundle added/removed/renamed) yields a
+ * different key and therefore a clean miss, so the stale set is never served.
+ */
+export function agentGetMetaSync(nameSetHash: string): SecretsBundle[] | null {
+  if (!onDarwin()) return null;
+  const hit = agentGetSync(META_CACHE_PREFIX + nameSetHash);
+  const raw = hit?.env?.[META_SNAPSHOT_KEY];
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as SecretsBundle[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fire-and-forget: populate the broker with a freshly-read metadata snapshot so
+ * the next `secrets list` within the daily window renders without a prompt.
+ * Stored as an ordinary entry (placeholder bundle, snapshot in env) under the
+ * reserved META_CACHE_PREFIX key; the snapshot travels over stdin to the
+ * detached worker (never argv/disk), same as value caching. macOS only.
+ */
+export function agentAutoLoadMetaSync(nameSetHash: string, bundles: SecretsBundle[], ttlMs: number): void {
+  if (!onDarwin()) return;
+  const key = META_CACHE_PREFIX + nameSetHash;
+  const placeholder: SecretsBundle = { name: key, vars: {} };
+  agentAutoLoadSync(key, placeholder, { [META_SNAPSHOT_KEY]: JSON.stringify(bundles) }, ttlMs);
 }
 
 /** True unless `secrets.agent.auto` is explicitly disabled in agents.yaml. The

--- a/src/lib/secrets/bundles.ts
+++ b/src/lib/secrets/bundles.ts
@@ -27,6 +27,7 @@ import {
   getKeychainToken,
   getKeychainTokens,
   hasKeychainToken,
+  isKeychainBackendOverridden,
   keychainUsesFileFallback,
   listKeychainItems,
   parseBundleValue,
@@ -39,7 +40,8 @@ import {
 import { fileStore } from './filestore.js';
 import { emit } from '../events.js';
 import { readMeta } from '../state.js';
-import { agentGetSync, agentAutoLoadSync, secretsAgentAutoEnabled, DEFAULT_TTL_MS } from './agent.js';
+import { agentGetSync, agentAutoLoadSync, agentGetMetaSync, agentAutoLoadMetaSync, secretsAgentAutoEnabled, DEFAULT_TTL_MS } from './agent.js';
+import { createHash } from 'node:crypto';
 
 /** Which store carries a bundle's items. */
 export type SecretsBackend = 'keychain' | 'file';
@@ -486,12 +488,40 @@ export function listBundles(): SecretsBundle[] {
       .map((s) => s.slice(BUNDLE_META_PREFIX.length))
       .filter((n) => BUNDLE_NAME_PATTERN.test(n));
     if (keychainNames.length > 0) {
-      const fetched = getKeychainTokens(keychainNames.map(bundleMetaItem));
-      for (const name of keychainNames) {
-        const json = fetched.get(bundleMetaItem(name));
-        if (json === undefined) continue;
-        const bundle = parseBundleMeta(name, json, 'keychain');
-        if (bundle) out.push(bundle);
+      // Daily-policy fast-path (macOS). Bundle metadata items are biometry-gated,
+      // so the getKeychainTokens batch below pops Touch ID on every `secrets
+      // list` — the broker/`daily` mechanism only ever covered value reads, not
+      // this listing. Serve a broker-cached metadata snapshot when one is held,
+      // so only the first list per ~24h prompts. The cache key is a hash of the
+      // current keychain name-set (enumerated silently above): add / remove /
+      // rename a bundle and the key changes, so the stale snapshot is never
+      // served — no active invalidation needed. Values are never cached here;
+      // this is metadata only.
+      const useAgent =
+        process.env.AGENTS_SECRETS_NO_AGENT !== '1' &&
+        !isKeychainBackendOverridden() &&
+        secretsAgentAutoEnabled();
+      const nameSetHash = createHash('sha256')
+        .update([...keychainNames].sort().join('\n'))
+        .digest('hex')
+        .slice(0, 32);
+      const cached = useAgent ? agentGetMetaSync(nameSetHash) : null;
+      if (cached) {
+        for (const bundle of cached) out.push(bundle);
+      } else {
+        const fetched = getKeychainTokens(keychainNames.map(bundleMetaItem));
+        const keychainBundles: SecretsBundle[] = [];
+        for (const name of keychainNames) {
+          const json = fetched.get(bundleMetaItem(name));
+          if (json === undefined) continue;
+          const bundle = parseBundleMeta(name, json, 'keychain');
+          if (bundle) keychainBundles.push(bundle);
+        }
+        for (const bundle of keychainBundles) out.push(bundle);
+        // Populate the broker for the rest of the daily window (fire-and-forget).
+        if (useAgent && keychainBundles.length > 0) {
+          agentAutoLoadMetaSync(nameSetHash, keychainBundles, DEFAULT_TTL_MS);
+        }
       }
     }
   }

--- a/src/lib/secrets/index.ts
+++ b/src/lib/secrets/index.ts
@@ -343,6 +343,32 @@ export function listKeychainItems(prefix: string): string[] {
 }
 
 /**
+ * Enumerate ONLY legacy file-based-keychain item names with the given prefix —
+ * the items that still carry a pre-migration (trusted-app) ACL and pop a
+ * separate auth sheet on read. Items already in the data-protection keychain are
+ * excluded (they need no migration). Silent (attributes only, never decrypts).
+ *
+ * macOS only: on Linux / the test backend there is no separate legacy keychain,
+ * so this returns []. Used by `agents secrets migrate-acl` to rewrite only the
+ * stragglers instead of every item (which would be a Touch ID storm).
+ */
+export function listLegacyKeychainItems(prefix: string): string[] {
+  if (backend) return [];
+  assertSupportedPlatform();
+  if (isLinux()) return [];
+  const bin = getKeychainHelperPath();
+  const result = spawnSync(bin, ['list-legacy', prefix], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.status !== 0) {
+    const msg = result.stderr?.toString().trim();
+    throw new Error(msg || `Failed to enumerate legacy keychain items with prefix '${prefix}'.`);
+  }
+  const out = result.stdout?.toString() || '';
+  return out.split('\n').map((s) => s.trim()).filter(Boolean);
+}
+
+/**
  * One-time upgrade for a keychain item that was written by a previous helper
  * generation with a trusted-app ACL. The helper reads the legacy item
  * (which may pop the password sheet once), then deletes and re-adds it with

--- a/src/lib/secrets/index.ts
+++ b/src/lib/secrets/index.ts
@@ -118,6 +118,14 @@ export function setKeychainBackendForTest(b: KeychainBackend | null): KeychainBa
   return prev;
 }
 
+/** True when a test backend is installed (real keychain / biometry bypassed).
+ * Callers that gate on the live secrets-agent broker use this to stay hermetic —
+ * with an in-memory backend there is no real keychain to dedup, so the broker
+ * fast-path must not engage. Always false in production (`backend` is null). */
+export function isKeychainBackendOverridden(): boolean {
+  return backend !== null;
+}
+
 /**
  * Items whose name does NOT start with `agents-cli.` belong to another
  * application (e.g. Anthropic's `Claude Code-credentials-*`). Their ACL

--- a/src/lib/secrets/keychain-helper.swift
+++ b/src/lib/secrets/keychain-helper.swift
@@ -160,22 +160,39 @@ func migrateInline(service: String, account: String, value: String) {
         writeStderr("migrate-inline: could not encode value for \(service)")
         return
     }
-    // Drop the legacy file-based copy so the next read resolves cleanly from the
-    // data-protection keychain instead of re-triggering this fallback.
-    let delStatus = SecItemDelete(fileBase(service: service, account: account) as CFDictionary)
-    if delStatus != errSecSuccess && delStatus != errSecItemNotFound {
-        writeStderr("migrate-inline: legacy delete failed for \(service) (OSStatus \(delStatus))")
-        return
-    }
-    // Defensive: clear any partial data-protection copy so SecItemAdd cannot
-    // fail with errSecDuplicateItem.
-    SecItemDelete(dpBase(service: service, account: account) as CFDictionary)
+    // Order matters — write the data-protection copy FIRST, then best-effort
+    // delete the legacy copy. The legacy item may carry a trusted-app ACL whose
+    // SecItemDelete is itself gated; the old order (delete-legacy first, early-
+    // return on a non-clean delete) meant a gated delete aborted before the DP
+    // write ever ran, so the item stayed legacy on every read and re-prompted
+    // forever. It also risked data loss on the reverse failure: delete legacy,
+    // then a failing SecItemAdd left the value in neither keychain.
+    //
+    // Writing DP first fixes both: readItem queries the DP keychain first, so
+    // once the DP copy exists every future read resolves there (no second auth
+    // sheet) even if the legacy copy lingers; and if the DP write fails we leave
+    // the legacy copy untouched, so the value is never lost.
     var addAttrs = dpBase(service: service, account: account)
     addAttrs[kSecAttrAccessControl] = buildBiometryAccessControl()
     addAttrs[kSecValueData] = valueData
-    let addStatus = SecItemAdd(addAttrs as CFDictionary, nil)
-    if addStatus != errSecSuccess {
-        writeStderr("migrate-inline: re-add failed for \(service) (OSStatus \(addStatus))")
+    var addStatus = SecItemAdd(addAttrs as CFDictionary, nil)
+    if addStatus == errSecDuplicateItem {
+        // A DP copy already exists (e.g. a prior partial migration) — clear it
+        // and retry so the value is refreshed from the copy we just read.
+        SecItemDelete(dpBase(service: service, account: account) as CFDictionary)
+        addStatus = SecItemAdd(addAttrs as CFDictionary, nil)
+    }
+    guard addStatus == errSecSuccess else {
+        // Leave the legacy copy in place — a failed DP write must never cost us
+        // the only remaining copy. The read that called us already has the value.
+        writeStderr("migrate-inline: DP re-add failed for \(service) (OSStatus \(addStatus)); legacy copy left intact")
+        return
+    }
+    // DP copy is authoritative now. Best-effort drop the legacy copy so the
+    // second auth sheet stops; a gated/failed delete is harmless (DP wins on read).
+    let delStatus = SecItemDelete(fileBase(service: service, account: account) as CFDictionary)
+    if delStatus != errSecSuccess && delStatus != errSecItemNotFound {
+        writeStderr("migrate-inline: legacy delete failed for \(service) (OSStatus \(delStatus)); DP copy is authoritative")
     }
 }
 
@@ -190,7 +207,7 @@ func dieIfCancelled(_ status: OSStatus) {
 
 let args = CommandLine.arguments
 guard args.count >= 2 else {
-    die(2, "Usage: agents-keychain <get|get-batch|set|delete|has|list|migrate-acl> ...")
+    die(2, "Usage: agents-keychain <get|get-batch|set|delete|has|list|list-legacy|migrate-acl> ...")
 }
 
 let cmd = args[1]
@@ -246,6 +263,43 @@ case "list":
         guard let svce = item[kSecAttrService as String] as? String, svce.hasPrefix(prefix) else { continue }
         guard let acct = item[kSecAttrAccount as String] as? String, acct == user else { continue }
         if seen.insert(svce).inserted {
+            print(svce)
+        }
+    }
+
+case "list-legacy":
+    // list-legacy <prefix> — enumerate ONLY the legacy file-based-keychain items
+    // whose service starts with <prefix> (the migration candidates), never the
+    // data-protection keychain. Attributes only, UIFail — never decrypts, never
+    // prompts. Items written by the modern `set` live in the DP keychain and are
+    // intentionally excluded: they carry the biometry ACL already and need no
+    // migration. `agents secrets migrate-acl` uses this to rewrite only the
+    // stragglers instead of every item (which would be a Touch ID storm).
+    guard args.count == 3 else { die(2, "Usage: agents-keychain list-legacy <prefix>") }
+    let legacyPrefix = args[2]
+    guard !legacyPrefix.isEmpty else { die(2, "list-legacy requires non-empty prefix") }
+    let legacyUser = ProcessInfo.processInfo.environment["USER"] ?? NSUserName()
+    // No kSecUseDataProtectionKeychain → this queries the file-based keychain
+    // only, which is exactly where pre-migration (trusted-app-ACL) items live.
+    let legacyFileQuery: [CFString: Any] = [
+        kSecClass: kSecClassGenericPassword,
+        kSecMatchLimit: kSecMatchLimitAll,
+        kSecReturnAttributes: kCFBooleanTrue!,
+        kSecUseAuthenticationUI: kSecUseAuthenticationUIFail,
+    ]
+    var legacyResult: AnyObject?
+    let legacyStatus = SecItemCopyMatching(legacyFileQuery as CFDictionary, &legacyResult)
+    var legacyItems: [[String: Any]] = []
+    if legacyStatus == errSecSuccess {
+        legacyItems = (legacyResult as? [[String: Any]]) ?? []
+    } else if legacyStatus != errSecItemNotFound {
+        die(2, "Failed to enumerate legacy keychain (OSStatus \(legacyStatus))")
+    }
+    var legacySeen = Set<String>()
+    for item in legacyItems {
+        guard let svce = item[kSecAttrService as String] as? String, svce.hasPrefix(legacyPrefix) else { continue }
+        guard let acct = item[kSecAttrAccount as String] as? String, acct == legacyUser else { continue }
+        if legacySeen.insert(svce).inserted {
             print(svce)
         }
     }

--- a/src/lib/secrets/keychain-helper.swift
+++ b/src/lib/secrets/keychain-helper.swift
@@ -160,39 +160,33 @@ func migrateInline(service: String, account: String, value: String) {
         writeStderr("migrate-inline: could not encode value for \(service)")
         return
     }
-    // Order matters — write the data-protection copy FIRST, then best-effort
-    // delete the legacy copy. The legacy item may carry a trusted-app ACL whose
-    // SecItemDelete is itself gated; the old order (delete-legacy first, early-
-    // return on a non-clean delete) meant a gated delete aborted before the DP
-    // write ever ran, so the item stayed legacy on every read and re-prompted
-    // forever. It also risked data loss on the reverse failure: delete legacy,
-    // then a failing SecItemAdd left the value in neither keychain.
+    // We ONLY add the data-protection copy here; we never delete the legacy copy
+    // inline. Two hard-won reasons:
     //
-    // Writing DP first fixes both: readItem queries the DP keychain first, so
-    // once the DP copy exists every future read resolves there (no second auth
-    // sheet) even if the legacy copy lingers; and if the DP write fails we leave
-    // the legacy copy untouched, so the value is never lost.
+    //  1. Deleting the legacy item AFTER adding the DP copy destroys the DP copy.
+    //     SecItemDelete(fileBase) is not reliably scoped to the file-based
+    //     keychain on macOS 26 — with a DP item of the same service+account
+    //     present, the unscoped delete matches and removes it too, so the DP add
+    //     never survives (and the delete returns errSecSuccess, so it's silent).
+    //  2. Deleting the legacy item BEFORE the add risks data loss: a failing
+    //     SecItemAdd would leave the value in neither keychain.
+    //
+    // Adding only is safe and sufficient: readItem queries the DP keychain first,
+    // so once the DP copy exists every future read resolves there and the second
+    // auth sheet stops — the lingering legacy copy is never read. Purging that
+    // harmless legacy copy is the job of `agents secrets migrate-acl`, which
+    // clears both keychains BEFORE its add (the safe order) after an encrypted
+    // backup. Clear any stale DP copy first so the add can't hit
+    // errSecDuplicateItem; that delete IS scoped (dpBase carries the DP flag).
+    SecItemDelete(dpBase(service: service, account: account) as CFDictionary)
     var addAttrs = dpBase(service: service, account: account)
     addAttrs[kSecAttrAccessControl] = buildBiometryAccessControl()
     addAttrs[kSecValueData] = valueData
-    var addStatus = SecItemAdd(addAttrs as CFDictionary, nil)
-    if addStatus == errSecDuplicateItem {
-        // A DP copy already exists (e.g. a prior partial migration) — clear it
-        // and retry so the value is refreshed from the copy we just read.
-        SecItemDelete(dpBase(service: service, account: account) as CFDictionary)
-        addStatus = SecItemAdd(addAttrs as CFDictionary, nil)
-    }
-    guard addStatus == errSecSuccess else {
-        // Leave the legacy copy in place — a failed DP write must never cost us
-        // the only remaining copy. The read that called us already has the value.
-        writeStderr("migrate-inline: DP re-add failed for \(service) (OSStatus \(addStatus)); legacy copy left intact")
-        return
-    }
-    // DP copy is authoritative now. Best-effort drop the legacy copy so the
-    // second auth sheet stops; a gated/failed delete is harmless (DP wins on read).
-    let delStatus = SecItemDelete(fileBase(service: service, account: account) as CFDictionary)
-    if delStatus != errSecSuccess && delStatus != errSecItemNotFound {
-        writeStderr("migrate-inline: legacy delete failed for \(service) (OSStatus \(delStatus)); DP copy is authoritative")
+    let addStatus = SecItemAdd(addAttrs as CFDictionary, nil)
+    if addStatus != errSecSuccess {
+        // Legacy copy is untouched, so the value is never lost; the next read
+        // falls back to the legacy sheet again and retries the migration.
+        writeStderr("migrate-inline: DP add failed for \(service) (OSStatus \(addStatus)); legacy copy left intact")
     }
 }
 


### PR DESCRIPTION
Fixes both Touch ID prompts on `agents secrets list` (macOS only; Linux has no per-read biometry, Windows secrets unsupported).

## Prompt #1 — every run despite `policy: daily`
`daily` is delivered only by the secrets-agent broker, consulted only for resolved *values*; `listBundles()` reads biometry-gated *metadata* directly. **Fix:** `listBundles()` serves a broker-cached metadata snapshot keyed by a hash of the current keychain name-set (add/remove/rename auto-misses → fresh read; no active invalidation). Reuses existing wire verbs (no `PROTOCOL_VERSION` bump → works against a pre-upgrade broker); filters the internal entry from `status` client+server side; `realBundleCount` keeps a warm cache from pinning the broker on old code (#435).

## Prompt #2 — the second sheet (legacy straggler)
A bundle-metadata item stranded in the legacy keychain pops a separate sheet; the JIT `migrateInline` was meant to relocate it but didn't.

**Fix (`keychain-helper.swift`):** `migrateInline` now **only adds the DP copy** (after clearing a stale DP-scoped copy) and **never deletes the legacy copy inline**. `readItem` queries DP first, so once the DP copy exists the second sheet stops; the lingering legacy copy is never read. Legacy purge is left to `migrate-acl` (clears both keychains *before* its add — the safe order — after an encrypted backup). No-data-loss by construction.

**`migrate-acl` hardened** — one command still migrates *all* stragglers at once, but only touches **legacy** items (new silent `list-legacy` helper subcommand), skipping items already in DP; batches the snapshot read; says "nothing to migrate" when clean. `--all` restores the full rewrite.

## Critical build bug found while verifying (macOS 26 / Tahoe)
Fresh helper builds failed **every** DP write with `-34018`: `scripts/keychain-entitlements.plist` was missing `com.apple.application-identifier`, which Tahoe's secd now requires for the keychain-access-groups grant. The installed helper predates the tightening, so it works — but **any rebuild on Tahoe (including the release cutting this PR) would ship a `-34018`-broken helper for everyone.** Added the entitlement (wildcard group unchanged).

## Verification (real, notarized)
- Part A: full secrets suite green (177 passed), `tsc` clean, live broker round-trip.
- Part B: built + **notarized** the fixed helper; **3/3 synthetic legacy items relocated to DP and still read back after their legacy copy was removed**; `list-legacy` returns exactly the stragglers; the entitlement fix confirmed (with it, DP write works; without it, `-34018`).
- Honest trail: the first `migrateInline` reorder (add-then-delete-legacy) was **wrong** — on Tahoe the unscoped legacy delete also removed the just-added DP copy. Caught by end-to-end testing (not inspection), corrected to add-only, re-verified.

## ⚠️ Release requirements
1. Rebuild `bin/Agents CLI.app` (`scripts/build-keychain-helper.sh`) — the committed entitlements fix makes the rebuild DP-capable — then re-pin `scripts/Agents CLI.app.sha256` (the `.app` is gitignored/built per-machine; sha not committed here on purpose). Reaches existing users via the helper-staleness reinstall.
2. `prepack` checks app-vs-sha, not app-vs-swift — the rebuild is mandatory or the old helper ships.

## Files
`src/lib/secrets/{agent,bundles,index,keychain-helper.swift}.ts` · `src/commands/secrets-migrate.ts` · `scripts/keychain-entitlements.plist` · `src/lib/secrets/agent.test.ts`
