### PR TITLE
feat(release): run the test suite on crabbox, not the local machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
     "test": "node ./node_modules/vitest/vitest.mjs run",
+    "test:remote": "scripts/sandbox.sh 'bun install && bun run build && bun run test'",
     "test:watch": "node ./node_modules/vitest/vitest.mjs"
   },
   "keywords": [

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -270,18 +270,26 @@ fi
 rm -f "$BUILD_LOG"
 green "Build clean."
 
-# ----- Tests -----
+# ----- Tests (remote, on crabbox) -----
+# The full suite runs on a leased crabbox VM, NOT locally: a release test run
+# freezes the mac for minutes and the box matches the Linux CI environment.
+# Publishing still happens here (the signed macOS keychain helper can only be
+# produced + notarized locally) -- only the test gate is offloaded. sandbox.sh
+# rsyncs this checkout to the box and runs the suite there. TASK_ID pins a
+# stable remote workspace so re-runs of the same release reuse it.
 if $SKIP_TESTS; then
   yellow "Skipping tests (--skip-tests)"
 else
-  # pipefail is on, so a failure in `npm test` would propagate even through a
-  # pipe. We don't pipe -- show the full output so a developer can scroll back
-  # through any individual failure. The summary line is captured for the
-  # tarball-preview section regardless.
-  bold "Running tests (npm test)..."
+  # pipefail is on, so a failure in the remote run propagates through the pipe.
+  # We tee the streamed output so a developer can scroll back through any
+  # individual failure; the log is also scanned for silent unhandled errors.
+  bold "Running tests on crabbox (scripts/sandbox.sh)..."
   TEST_LOG="$(mktemp "${TMPDIR:-/tmp}/agents-cli-test.XXXXXX")"
-  if ! npm test 2>&1 | tee "$TEST_LOG"; then
-    red "Tests failed."
+  # `bun run build` before test: crabbox's sync honors .gitignore, so the
+  # gitignored dist/ never reaches the box -- the integration tests that spawn
+  # a child importing dist/ need it built there. Matches ci.yml (Build->Test).
+  if ! TASK_ID="release-$TARGET" "$ROOT/scripts/sandbox.sh" "bun install && bun run build && bun run test" 2>&1 | tee "$TEST_LOG"; then
+    red "Tests failed (crabbox)."
     rm -f "$TEST_LOG"
     die "fix failing tests before releasing"
   fi

--- a/scripts/sandbox.sh
+++ b/scripts/sandbox.sh
@@ -21,7 +21,10 @@ BOX_CLASS="${CRABBOX_CLASS:-cpx62}"
 
 # Read profile from .crabbox.yaml so we only pick boxes warmed for THIS repo.
 # Falls back to "default" if the file is missing or unparseable.
-PROFILE="${CRABBOX_PROFILE:-$(awk '/^profile:/ {print $2; exit}' "$REPO_ROOT/.crabbox.yaml" 2>/dev/null)}"
+# `|| true` is required: under `set -e`, awk exiting non-zero on a missing
+# .crabbox.yaml would abort the whole script inside this assignment before the
+# `:-default` fallback below could run.
+PROFILE="${CRABBOX_PROFILE:-$(awk '/^profile:/ {print $2; exit}' "$REPO_ROOT/.crabbox.yaml" 2>/dev/null || true)}"
 PROFILE="${PROFILE:-default}"
 export PROFILE
 
@@ -35,7 +38,7 @@ command -v crabbox >/dev/null || die "crabbox not installed"
 # otherwise fall back to the agents-cli Keychain bundle (local dev path).
 if [[ -z "${HCLOUD_TOKEN:-}" ]]; then
   command -v agents >/dev/null || die "HCLOUD_TOKEN not set and agents-cli not installed"
-  eval "$(agents secrets export hetzner.com 2>/dev/null)" || die "Failed to load hetzner.com secrets"
+  eval "$(agents secrets export hetzner.com --plaintext 2>/dev/null)" || die "Failed to load hetzner.com secrets"
 fi
 [[ -n "${HCLOUD_TOKEN:-}" ]] || die "HCLOUD_TOKEN is empty after secret resolution"
 export HCLOUD_TOKEN
@@ -45,7 +48,7 @@ export HCLOUD_TOKEN
 # works regardless of whether the App is installed on a user or an org.
 # TOKEN_REPO env var (required) picks which installation.
 generate_github_token() {
-  eval "$(agents secrets export github.com 2>/dev/null)" || return 1
+  eval "$(agents secrets export github.com --plaintext 2>/dev/null)" || return 1
   [[ -n "${APP_ID:-}" && -n "${APP_PRIVATE_KEY:-}" ]] || return 1
 
   local target_repo="${TOKEN_REPO:?TOKEN_REPO must be set (e.g. owner/.agents) to pick the GitHub App installation}"
@@ -113,7 +116,7 @@ fi
 
 # Load Claude token for running agents on sandbox. Honor a pre-set env var first.
 if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]] && command -v agents >/dev/null; then
-  eval "$(agents secrets export anthropic.com 2>/dev/null)" || true
+  eval "$(agents secrets export anthropic.com --plaintext 2>/dev/null)" || true
 fi
 CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN:-}"
 
@@ -215,32 +218,38 @@ if [[ -n "${GITHUB_TOKEN:-}" ]]; then
   echo "GitHub App token configured for private repos"
 fi
 
-# agents-cli + coding agents (for running agents in sandbox)
-if ! command -v agents &>/dev/null; then
-  echo "Installing agents-cli..."
-  sudo npm install -g @phnx-labs/agents-cli 2>/dev/null || true
-fi
-if command -v agents &>/dev/null; then
-  # First-time setup: clones ~/.agents/.system (public) and provisions ~/.agents
-  if [[ ! -d ~/.agents/.system ]]; then
-    echo "Setting up agents-cli..."
-    agents setup 2>&1 | tail -3 || true
+# agents-cli + coding agents: PR mode only. Agents run in the sandbox only when
+# authoring PRs; test mode just builds + runs the suite and needs none of this.
+# Skipping the install in test mode also keeps the box matching GitHub CI, where
+# claude is absent so the claude-dependent model-catalog tests skip rather than
+# fail on a partially-installed CLI (0 models => "mid-install", see models.ts).
+if [[ "$PR_MODE" == "1" ]]; then
+  if ! command -v agents &>/dev/null; then
+    echo "Installing agents-cli..."
+    sudo npm install -g @phnx-labs/agents-cli 2>/dev/null || true
   fi
-  # Put agents shims on PATH so installed CLIs (claude, codex, etc.) are reachable
-  export PATH="$HOME/.agents/.cache/shims:$PATH"
-  if ! grep -q '\.agents/\.cache/shims' ~/.bashrc 2>/dev/null; then
-    echo 'export PATH="$HOME/.agents/.cache/shims:$PATH"' >> ~/.bashrc
+  if command -v agents &>/dev/null; then
+    # First-time setup: clones ~/.agents/.system (public) and provisions ~/.agents
+    if [[ ! -d ~/.agents/.system ]]; then
+      echo "Setting up agents-cli..."
+      agents setup 2>&1 | tail -3 || true
+    fi
+    # Put agents shims on PATH so installed CLIs (claude, codex, etc.) are reachable
+    export PATH="$HOME/.agents/.cache/shims:$PATH"
+    if ! grep -q '\.agents/\.cache/shims' ~/.bashrc 2>/dev/null; then
+      echo 'export PATH="$HOME/.agents/.cache/shims:$PATH"' >> ~/.bashrc
+    fi
+    # Install Claude Code if not present
+    if ! command -v claude &>/dev/null; then
+      echo "Installing Claude Code via agents-cli..."
+      agents add claude 2>&1 | tail -3 || true
+    fi
   fi
-  # Install Claude Code if not present
-  if ! command -v claude &>/dev/null; then
-    echo "Installing Claude Code via agents-cli..."
-    agents add claude 2>&1 | tail -3 || true
-  fi
-fi
 
-# Claude Code auth (passed from local via env)
-if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
-  echo "Claude Code OAuth token configured"
+  # Claude Code auth (passed from local via env)
+  if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+    echo "Claude Code OAuth token configured"
+  fi
 fi
 
 echo "Bootstrap complete."


### PR DESCRIPTION
## What

Route the **test gate** for `release.sh` (and a new `test:remote` npm script) onto a leased **crabbox** VM instead of running it on the local machine, and fix three bugs in `scripts/sandbox.sh` that prevented the remote path from working at all.

Publishing stays local — only the signed macOS keychain helper can be produced + notarized here, and crabbox boxes are Linux.

## Why

A release test run froze the mac for minutes. The remote-test intent was already documented (CHANGELOG, CLAUDE.md) but never wired — `release.sh` still ran `npm test` locally.

## Changes

**Feature**
- `release.sh`: test gate now runs `bun install && bun run build && bun run test` on a crabbox via `sandbox.sh`, matching CI's Build→Test order.
- `package.json`: adds `test:remote` for local dev to offload the suite the same way.

**Fixes to `sandbox.sh` (all found while verifying the above end-to-end)**
1. **Secrets couldn't load.** `agents secrets export <bundle>` now hard-errors requiring `--plaintext`; the three export calls omitted it, so `HCLOUD_TOKEN` / `GITHUB_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` silently failed (exit 1). Added `--plaintext`.
2. **Silent exit 2 on missing `.crabbox.yaml`.** Under `set -e`, `awk` exiting non-zero aborted the script inside a `PROFILE=...` assignment before the `:-default` fallback. Guarded with `|| true`.
3. **`dist/`-dependent tests + claude.** `bun run build` is now run before tests (crabbox's sync honors `.gitignore`, so the gitignored `dist/` never reaches the box). The agents-cli/claude install is gated behind PR mode — test mode needs no coding agent and this matches GitHub CI (no claude ⇒ the claude model-catalog tests skip instead of failing on a partial install).

## Verification

Ran the full suite on a real leased Hetzner box end-to-end:
- With the build step: **3,177 passed**, 46 skipped; the single remaining failure was `models.test.ts` on a *partially-installed* claude (0 models parsed = "mid-install", per `models.ts`) — resolved by gating the claude install to PR mode.
- Final test-mode run on a fresh box confirms the suite goes fully green (claude absent ⇒ model-catalog tests skip, exactly like CI).

## Not changed

- Publish path (stays macOS-local).
- CI workflows (`ci.yml`, `sandbox.yml`) — untouched; the misnamed "Sandbox tests" workflow is a separate follow-up.
