### PR TITLE
fix(computer-win): extract native UIA libs in self-contained exe + CI publish smoke (#519)

### DIFF
--- a/.github/workflows/computer-helper-win.yml
+++ b/.github/workflows/computer-helper-win.yml
@@ -44,3 +44,37 @@ jobs:
           if (-not $exe) { throw "built exe not found under bin/Release" }
           Write-Host "exe: $($exe.FullName)"
           node smoke/smoke.mjs --exe "$($exe.FullName)" --port 8771
+
+  # Reproduces GitHub #519: the framework-dependent `dotnet build` above leaves
+  # WPF/UIAutomation native DLLs loose next to the exe, so its smoke passes even
+  # when the SHIPPED artifact is broken. This leg publishes the SAME
+  # self-contained single-file exe `scripts/build-win.sh` ships and smokes THAT,
+  # so a single-file host that can't resolve the native UIA libraries fails here
+  # (describe/get_text walk the UIA tree). Required check: a failure blocks merge.
+  publish-and-smoke:
+    runs-on: windows-latest
+    permissions: {}
+    defaults:
+      run:
+        working-directory: packages/computer-helper-win
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        with:
+          dotnet-version: '10.0.x'
+
+      # Exact flags scripts/build-win.sh uses, so CI smokes the shipped artifact.
+      - name: Publish (self-contained single-file win-x64)
+        run: dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -o dist
+
+      - name: Smoke test published single-file exe (UIA roundtrip + screenshot)
+        shell: pwsh
+        run: |
+          $exe = "dist/computer-helper-win.exe"
+          if (-not (Test-Path $exe)) { throw "published single-file exe not found at $exe" }
+          $full = (Resolve-Path $exe).Path
+          Write-Host "exe: $full"
+          node smoke/smoke.mjs --exe "$full" --port 8772

--- a/packages/computer-helper-win/computer-helper-win.csproj
+++ b/packages/computer-helper-win/computer-helper-win.csproj
@@ -13,6 +13,17 @@
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>
+    <!--
+      Extract native support libs from the single-file bundle to disk at startup.
+      WPF/UIAutomation (System.Windows.Automation) resolves its client through
+      COM/native libraries (PresentationNative, wpfgfx, UIAutomationCore) that the
+      single-file host does NOT map from memory — they must exist as real files on
+      disk for LoadLibrary/CoCreateInstance to find them. Without this, the shipped
+      self-contained exe throws at the first UIA tree walk (describe/get-text/focus/
+      ax-action) even though the framework-dependent build works (loose DLLs on disk).
+      See GitHub #519.
+    -->
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <!-- Allow cross-publishing a Windows target from macOS/Linux build hosts. -->
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <!-- WindowsForms pulls in System.Drawing (screen capture) + SystemInformation. -->


### PR DESCRIPTION
## Problem (#519)

The Windows computer-use daemon's UIAutomation verbs (`describe` / `get-text` / `focus` / `ax-action`) fail in the shipped **self-contained single-file** exe, yet pass in CI.

Root cause: CI only ran `dotnet build -c Release` (framework-dependent — WPF/UIAutomation native DLLs sit loose on disk next to the exe). But `scripts/build-win.sh` ships a `PublishSingleFile` self-contained exe, and the single-file host maps *managed* DLLs from memory while leaving *native* support libs (PresentationNative, wpfgfx, UIAutomationCore) unextracted — so `LoadLibrary`/`CoCreateInstance` can't resolve them and the first UIA tree walk throws.

## Fix

1. **`computer-helper-win.csproj`** — add `<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>` so the single-file host extracts the native UIA deps to disk at startup.
2. **`.github/workflows/computer-helper-win.yml`** — add a `publish-and-smoke` job that publishes the exact self-contained single-file exe `scripts/build-win.sh` ships (`dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true`) and runs `smoke/smoke.mjs` against **that** exe. The smoke's `describe` and `get_text` verbs walk the real UIA tree, so a broken single-file host fails the leg — this reproduces #519 on `windows-latest` with no external Windows box. The existing framework-dependent build+smoke leg is kept.

`scripts/build-win.sh` already uses those exact publish flags — no drift, left unchanged.

## Verification

The new `publish-and-smoke` CI leg IS the reproduction: it exercises the exact path that fails today. Merge-blocking once green.