### PR TITLE
docs: agent-spec resolution + devices/hosts concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,30 @@ Profile YAML has no secrets -- safe to `agents repo push` to a shared repo. `age
 
 ---
 
+## Run on your own machines
+
+Dispatch any read-only or config command -- and `agents run` itself -- to another machine over SSH. No daemon.
+
+```bash
+# Enroll a machine (from ~/.ssh/config, or inline with user@address)
+agents hosts add gpu-box
+agents hosts check gpu-box              # reachable? which agents-cli version?
+
+# Run there instead of locally
+agents run claude --host gpu-box "profile this build"
+agents view claude --host gpu-box       # inspect the remote install
+agents sync --host gpu-box              # make the remote machine current
+
+# Your Tailscale fleet, auto-discovered
+agents devices sync                     # ingest `tailscale status`
+agents ssh mac-mini                     # hardened SSH: fails fast if offline,
+                                        # PowerShell on Windows, password-from-Keychain
+```
+
+**Hosts** (`agents hosts`) are git-synced dispatch targets in `agents.yaml`; **devices** (`agents devices`) are your Tailscale machines in a local registry. Both ride SSH. See [docs/00-concepts.md](docs/00-concepts.md#devices--hosts).
+
+---
+
 ## Teams
 
 ```bash

--- a/docs/00-concepts.md
+++ b/docs/00-concepts.md
@@ -90,6 +90,41 @@ See [01-version-management.md](01-version-management.md) for install and switchi
 
 ---
 
+## Devices & Hosts
+
+agents-cli can run commands on **other machines**, not just the local one. Two
+independent registries back this, both using SSH as the only transport (no daemon).
+
+**Devices** — your Tailscale fleet, made addressable. `agents devices sync` reads
+`tailscale status --json` and records a profile per machine (platform, login user,
+Tailscale DNS name / IP, auth method, online status) in
+`~/.agents/.history/devices/registry.json`. That registry is **machine-local** — it
+embeds addresses, so it lives under `.history/` and is *not* carried by
+`agents repo push`. `agents ssh <name>` connects through it: it fails fast when a
+device is offline, runs PowerShell or POSIX per platform, and can pull an SSH
+password from a Keychain bundle via an askpass shim. `agents devices render --write`
+emits a `~/.ssh/config.d/agents` include so plain `ssh`/`scp`/`rsync` resolve the
+same logical names.
+
+**Hosts** — machines you dispatch agent work to. `agents hosts add` enrolls a
+target either from an existing `~/.ssh/config` stanza (connection details stay in
+ssh config; agents-cli stores only a caps/os overlay) or *inline* (with its own
+`user@address`). The host registry lives in `agents.yaml` under `hosts:` and **is**
+git-synced with `agents repo push`/`pull`, so a fleet definition travels between
+machines. The `-H, --host <name>` flag routes a command over SSH to that machine —
+supported today on the read-only/config commands (`view`, `inspect`, `usage`,
+`cost`, `doctor`, `list`, `sync`), on `agents run`, and across the `agents teams`
+lifecycle. The target may be a registered host name, a capability tag
+(`--host gpu --any`), or a raw `user@host`.
+
+The two systems are parallel and independent — a machine can appear in both.
+Devices auto-populate from Tailscale and back the interactive `agents ssh`; hosts
+are enrolled deliberately and back `--host` dispatch. `agents devices render --write`
+bridges them one way (device → ssh_config → enrollable as a host). See
+[hosts.md](hosts.md) for the `--host` execution model.
+
+---
+
 ## Capability matrix
 
 `src/lib/agents.ts` is the canonical capability matrix for resource sync. Every gateable resource kind is declared per agent so prompt, sync, and staleness code can share the same source of truth.

--- a/docs/01-version-management.md
+++ b/docs/01-version-management.md
@@ -51,6 +51,58 @@ User runs: claude --help
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
+## Agent-Spec Resolution
+
+The shim above resolves a version from config for a *bare* `claude` launch. Every
+CLI subcommand that takes an `<agent>[@<qualifier>]` argument — `view`, `inspect`,
+`sync`, `run`, and the `*list*` commands — resolves that spec through one engine,
+[`src/lib/agent-spec/`](../src/lib/agent-spec/). The core is **pure**: it takes a
+`VersionProvider` instead of touching the filesystem (so it is unit-tested with
+in-memory fixtures), and `provider.ts` binds the real one. Entry points:
+`resolveAgentTargets` (multi), `resolveSingleAgentTarget` (exactly one),
+`resolveVersionFilter` / `resolveListFilter` (read/list filters).
+
+### Qualifier vocabulary
+
+| Spec | Resolves to |
+|------|-------------|
+| `claude` (bare) | project pin (`agents.yaml`) → global default → the sole installed version. If more than one is installed with no default, state-changing commands error ("specify one"); `run`/`exec` pick the newest with a note. |
+| `claude@2.1.187` | that exact version (must be installed) |
+| `claude@latest` | newest **installed** version |
+| `claude@oldest` | oldest installed version |
+| `claude@pinned` / `claude@default` | the configured global default (synonyms) |
+| `claude@all` | every installed version (multi-target; rejected where exactly one is required) |
+| `claude@all,codex@latest` | comma-separated multi-spec |
+
+Each resolved target carries a `source` provenance tag (`project-pin`,
+`global-default`, `sole-installed`, `newest-installed`, `alias-latest`/`-oldest`,
+`explicit`, `none`). Exact versions are validated against `VERSION_RE` before any
+filesystem or exec use.
+
+### Two meanings of `latest`
+
+- **Install** — `agents add claude@latest` → the newest version published on
+  **npm** (`getLatestNpmVersion`, network).
+- **Resolve** — `agents view/run/sync claude@latest` → the newest **installed**
+  version (no network).
+
+The engine's domain is installed versions only.
+
+### Non-semver versions
+
+Ordering is by `compareVersions` (numeric per `.`-segment), so date-style schemes
+like OpenClaw's `yyyy.m.d` sort correctly. A trailing `-N` rebuild suffix
+(`2026.2.19-2`) breaks same-day ties — a higher `-N` is newer. This is
+deliberately **not** full semver: OpenClaw's `-N` means *newer*, the opposite of a
+semver pre-release, so a semver comparator would invert it. Suffix-free versions
+are unaffected.
+
+### `@default` in read/list commands
+
+For the read/list commands (`skills list`, `hooks list`, `rules list`, …) a bare
+spec shows **all** installed versions; `@default` / `@pinned` scopes to the
+**configured default version** (matching `view`).
+
 ## Installation Flow
 
 ```

--- a/docs/02-resource-sync.md
+++ b/docs/02-resource-sync.md
@@ -90,6 +90,23 @@ agents use claude@2.0.65
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
+## Sync Targets: Version Selectors and Repo Scoping
+
+`agents sync` accepts the full [agent-spec vocabulary](01-version-management.md#agent-spec-resolution)
+plus an optional repo scope:
+
+```bash
+agents sync claude              # the resolved default version (interactive preview in a TTY)
+agents sync claude@all          # every installed Claude version
+agents sync claude@all system   # scope to one DotAgent repo: system | user | project | <alias>
+agents sync claude --repo user  # same, via the flag form
+```
+
+A repo scope reconciles **only** that layer's resources into the target
+version(s), leaving the other layers' already-synced resources untouched. Bare
+`agents sync` (no agent) runs the umbrella verb — fetch remote state, then
+reconcile every installed agent.
+
 ## MCP Servers: Per-Agent JSON Write
 
 MCP is the one resource that isn't symlinked. Each agent stores MCP server

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -1,7 +1,11 @@
-# Hosts — dispatch agents to your own machines (design)
+# Hosts — dispatch agents to your own machines
 
-> **Status:** Design / RFC. No implementation yet. This document is for review
-> before any code lands.
+> **Status:** Implemented. `agents hosts` and the `-H, --host` flag ship today —
+> on the read-only/config commands (`view`, `inspect`, `usage`, `cost`, `doctor`,
+> `list`, `sync`), on `agents run`, and across the `agents teams` lifecycle. This
+> document is the design rationale; see
+> [00-concepts.md](00-concepts.md#devices--hosts) for the concept overview and how
+> hosts relate to the Tailscale-backed `agents devices` registry.
 
 `agents hosts` lets you run any agent (`claude`, `codex`, `droid`, …) on any of
 *your* machines — a Mac mini, a Windows mini, a couple of DGX Sparks — addressed


### PR DESCRIPTION
Docs-only. Fills two documentation gaps for features that shipped but were never written up.

## Agent-spec resolution (engine merged in #501 / #515)
- **`docs/01-version-management.md`** — new **Agent-Spec Resolution** section: the `<agent>[@qualifier]` vocabulary (`@latest`/`@oldest`/`@pinned`/`@default`/`@all`/exact/bare), the pure `VersionProvider` engine, the install-time (npm) vs resolve-time (installed) meaning of `latest`, non-semver/date-version ordering (OpenClaw `yyyy.m.d` + `-N` tiebreak), and the `@default`-shows-pinned behavior in list commands.
- **`docs/02-resource-sync.md`** — new **Sync Targets** section documenting `agents sync <agent>@all [repo]` / `--repo` scoping (#491).

## Devices & Hosts (`agents devices` / `agents ssh` / `--host`, #482 / #510)
- **`docs/00-concepts.md`** — new **Devices & Hosts** section: the two parallel SSH-backed registries — Tailscale-discovered, machine-local **devices** vs git-synced dispatch **hosts** — how they relate, and which commands accept `--host`.
- **`README.md`** — new **Run on your own machines** showcase section.
- **`docs/hosts.md`** — flip the stale `Design / RFC. No implementation yet.` banner (it shipped) and point at the concepts overview.

All grounded in the source (registry data models, `addHostOption` call sites, the SSH passthrough transport). No code changes.