### PR TITLE
feat(secrets): Windows Credential Manager backend (closes secrets half of #339)

### DIFF
--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -17,7 +17,7 @@ Store credentials in your OS keychain and inject them into agent runs. Nothing t
 | macOS | Keychain | Built-in |
 | Linux (desktop) | GNOME Keyring (libsecret) | `sudo apt install libsecret-tools` |
 | Linux (headless/server) | Use `env:` refs | See below |
-| Windows | Not yet supported | — |
+| Windows | Credential Manager (encrypted-file fallback) | Built-in |
 
 **Desktop Linux:** GNOME Keyring (or another Secret Service provider) must be running. Most desktop environments start it automatically.
 

--- a/src/lib/browser/drivers/ssh.ts
+++ b/src/lib/browser/drivers/ssh.ts
@@ -13,6 +13,7 @@ export { shellQuote };
 // the single ssh-tunnel helper. Calling it with no options preserves this
 // driver's original foreground, stderr-captured behavior exactly.
 import { startSSHTunnel } from '../../ssh-tunnel.js';
+import { encodePwshBase64 } from '../../pwsh.js';
 
 export interface SSHConnection {
   cdp: CDPClient;
@@ -194,8 +195,7 @@ function psSingleQuote(s: string): string {
  * `powershell -Command "…"` is fragile the moment a path or URL is involved).
  */
 export function encodePowerShell(script: string): string {
-  const b64 = Buffer.from(script, 'utf16le').toString('base64');
-  return `powershell -NoProfile -EncodedCommand ${b64}`;
+  return `powershell -NoProfile -EncodedCommand ${encodePwshBase64(script)}`;
 }
 
 /**

--- a/src/lib/pwsh.ts
+++ b/src/lib/pwsh.ts
@@ -1,0 +1,13 @@
+/**
+ * PowerShell `-EncodedCommand` helper.
+ *
+ * Base64 of a script's UTF-16LE bytes is a single quote-free token, so it rides
+ * through Node spawn → Windows sshd → cmd.exe with zero escaping hazards
+ * (hand-quoted `powershell -Command "…"` is fragile the moment a path, URL, or
+ * newline is involved). Shared by the browser SSH driver (which builds a
+ * `powershell -EncodedCommand …` string) and the Windows secrets backend (which
+ * spawns powershell.exe with an argv array).
+ */
+export function encodePwshBase64(script: string): string {
+  return Buffer.from(script, 'utf16le').toString('base64');
+}

--- a/src/lib/secrets/index.ts
+++ b/src/lib/secrets/index.ts
@@ -12,7 +12,10 @@
  * Linux: libsecret (GNOME Keyring) via the `secret-tool` CLI. No biometry —
  * items are unlocked when the keyring is open.
  *
- * Windows: not supported.
+ * Windows: Windows Credential Manager (CRED_TYPE_GENERIC,
+ * CRED_PERSIST_LOCAL_MACHINE) via a PowerShell P/Invoke shim, with the same
+ * AES-256-GCM encrypted-file fallback used on Linux when the credential store
+ * is unreachable (no logon session / no powershell.exe). No biometry.
  *
  * Items are device-local: the biometry access control requires the OS to
  * treat them as bound to this device, so cross-machine propagation goes
@@ -25,6 +28,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { linuxBackend, usesFileFallback as linuxUsesFileFallback } from './linux.js';
+import { windowsBackend, usesFileFallback as windowsUsesFileFallback } from './windows.js';
 import { getKeychainHelperPath } from './install-helper.js';
 
 const SERVICE_PREFIX = 'agents-cli';
@@ -68,17 +72,20 @@ export function serializeRef(ref: SecretRef): string {
 }
 
 function assertSupportedPlatform(): void {
-  if (process.platform !== 'darwin' && process.platform !== 'linux') {
+  if (process.platform !== 'darwin' && process.platform !== 'linux' && process.platform !== 'win32') {
     throw new Error(
-      'agents secrets requires macOS Keychain or Linux libsecret.\n' +
-      'Windows is not supported — use environment variables or a .env file instead.\n' +
-      'WSL2 is supported (libsecret via gnome-keyring).'
+      'agents secrets requires macOS Keychain, Linux libsecret, or Windows Credential Manager.\n' +
+      'Use environment variables or a .env file on unsupported platforms.'
     );
   }
 }
 
 function isLinux(): boolean {
   return process.platform === 'linux';
+}
+
+function isWindows(): boolean {
+  return process.platform === 'win32';
 }
 
 /** Build the keychain item name for a profile provider token. */
@@ -136,6 +143,7 @@ export function hasKeychainToken(item: string): boolean {
   if (backend) return backend.has(item);
   assertSupportedPlatform();
   if (isLinux()) return linuxBackend.has(item);
+  if (isWindows()) return windowsBackend.has(item);
   if (!isOurItem(item)) {
     return spawnSync('/usr/bin/security', ['find-generic-password', '-a', os.userInfo().username, '-s', item], {
       stdio: ['ignore', 'ignore', 'ignore'],
@@ -158,6 +166,7 @@ export function getKeychainToken(item: string): string {
   if (backend) return backend.get(item);
   assertSupportedPlatform();
   if (isLinux()) return linuxBackend.get(item);
+  if (isWindows()) return windowsBackend.get(item);
   if (!isOurItem(item)) {
     const sec = spawnSync('/usr/bin/security', ['find-generic-password', '-a', os.userInfo().username, '-s', item, '-w'], {
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -209,6 +218,12 @@ export function getKeychainTokens(items: string[]): Map<string, string> {
     }
     return result;
   }
+  if (isWindows()) {
+    for (const item of items) {
+      try { result.set(item, windowsBackend.get(item)); } catch { /* missing — skip */ }
+    }
+    return result;
+  }
   const bin = getKeychainHelperPath();
   const child = spawnSync(bin, ['get-batch', os.userInfo().username, ...items], {
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -257,6 +272,7 @@ export function setKeychainToken(item: string, value: string): void {
   if (/[\x00=\r\n]/.test(item)) throw new Error('Secret item name contains invalid characters.');
 
   if (isLinux()) { linuxBackend.set(item, value); return; }
+  if (isWindows()) { windowsBackend.set(item, value); return; }
 
   // Bare (non-`agents-cli.`) items are written WITHOUT the biometry ACL so
   // they round-trip with the no-prompt read path in getKeychainToken (which
@@ -295,6 +311,7 @@ export function deleteKeychainToken(item: string): boolean {
   if (backend) return backend.delete(item);
   assertSupportedPlatform();
   if (isLinux()) return linuxBackend.delete(item);
+  if (isWindows()) return windowsBackend.delete(item);
   const bin = getKeychainHelperPath();
   return spawnSync(bin, ['delete', item, os.userInfo().username], {
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -314,6 +331,7 @@ export function deleteKeychainToken(item: string): boolean {
 export function keychainUsesFileFallback(): boolean {
   if (backend) return false;
   if (isLinux()) return linuxUsesFileFallback();
+  if (isWindows()) return windowsUsesFileFallback();
   return false;
 }
 
@@ -322,6 +340,7 @@ export function listKeychainItems(prefix: string): string[] {
   if (backend) return backend.list(prefix);
   assertSupportedPlatform();
   if (isLinux()) return linuxBackend.list(prefix);
+  if (isWindows()) return windowsBackend.list(prefix);
   const bin = getKeychainHelperPath();
   const result = spawnSync(bin, ['list', prefix], {
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -346,6 +365,7 @@ export function migrateKeychainItem(item: string): boolean {
   if (backend) return backend.has(item);
   assertSupportedPlatform();
   if (isLinux()) return linuxBackend.has(item);
+  if (isWindows()) return windowsBackend.has(item);
   const bin = getKeychainHelperPath();
   const result = spawnSync(bin, ['migrate-acl', item, os.userInfo().username], {
     stdio: ['ignore', 'pipe', 'pipe'],

--- a/src/lib/secrets/windows.test.ts
+++ b/src/lib/secrets/windows.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Mock only spawnSync; keep execSync et al. real so the filestore fallback
+// (which uses execSync for the TTY prompt) still loads. Pattern mirrors
+// remote.test.ts:4-18 (vi.hoisted + vi.mock with importActual).
+const { spawnSyncMock } = vi.hoisted(() => ({ spawnSyncMock: vi.fn() }));
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return { ...actual, spawnSync: spawnSyncMock };
+});
+
+import {
+  parseWindowsCredList,
+  windowsBackend,
+  getCredManToken,
+  setCredManToken,
+  CRED_MAX_CREDENTIAL_BLOB_SIZE,
+  _resetForTest,
+} from './windows.js';
+
+const PREFIX = 'agents-cli.bundles.';
+
+// ---- spawnSync dispatch harness ----
+type Resp = { status: number; stdout?: string; stderr?: string; error?: Error };
+let responder: (op: string, ctx: { env: any; input?: string }) => Resp;
+
+let tmpDir: string;
+
+beforeEach(() => {
+  responder = () => { throw new Error('unexpected spawnSync in this test'); };
+  spawnSyncMock.mockReset();
+  spawnSyncMock.mockImplementation((_cmd: string, _args: string[], options: any) => {
+    const op = options?.env?.AGENTS_CRED_OP;
+    if (!op) return { status: 0, stdout: Buffer.from(''), stderr: Buffer.from('') }; // availability probe
+    const r = responder(op, { env: options.env, input: options.input });
+    return {
+      status: r.status,
+      stdout: Buffer.from(r.stdout ?? ''),
+      stderr: Buffer.from(r.stderr ?? ''),
+      error: r.error,
+    };
+  });
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-win-'));
+  delete process.env.AGENTS_SECRETS_PASSPHRASE;
+});
+
+afterEach(() => {
+  _resetForTest();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// (a) pure parser
+describe('parseWindowsCredList', () => {
+  it('returns [] on empty output', () => {
+    expect(parseWindowsCredList('', PREFIX)).toEqual([]);
+    expect(parseWindowsCredList('\n\n', PREFIX)).toEqual([]);
+  });
+
+  it('filters by prefix and trims CRLF', () => {
+    const out = [
+      'agents-cli.bundles.demo',
+      'agents-cli.secrets.demo.API_KEY',
+      'some-other-app/token',
+      'agents-cli.bundles.prod',
+    ].join('\r\n');
+    expect(parseWindowsCredList(out, PREFIX)).toEqual([
+      'agents-cli.bundles.demo',
+      'agents-cli.bundles.prod',
+    ]);
+  });
+
+  it('dedupes repeated target names', () => {
+    const out = [
+      'agents-cli.bundles.alpha',
+      'agents-cli.bundles.beta',
+      'agents-cli.bundles.alpha',
+    ].join('\n');
+    expect(parseWindowsCredList(out, PREFIX)).toEqual([
+      'agents-cli.bundles.alpha',
+      'agents-cli.bundles.beta',
+    ]);
+  });
+});
+
+// (b) base64 get-output round-trip
+describe('get base64 decode', () => {
+  const cases = [
+    'plain-token',
+    'unicode: café ☕ 日本語',
+    'has=equals=signs==',
+    '  leading and trailing spaces kept-internally  ',
+    'sk-proj-AbC123/xyz+789',
+  ];
+  for (const value of cases) {
+    it(`round-trips ${JSON.stringify(value)}`, () => {
+      _resetForTest({ forceAvailable: true, fileDir: tmpDir });
+      const b64 = Buffer.from(value, 'utf8').toString('base64');
+      responder = (op) => {
+        expect(op).toBe('get');
+        return { status: 0, stdout: b64 };
+      };
+      // Whitespace values still decode faithfully; only the base64 wire form is trimmed.
+      expect(getCredManToken('agents-cli.secrets.demo.KEY')).toBe(value);
+    });
+  }
+});
+
+// (c) dispatch + fallback routing
+describe('CredMan dispatch', () => {
+  it('routes has/get/set/delete/list to the PS ops on success', () => {
+    _resetForTest({ forceAvailable: true, fileDir: tmpDir });
+
+    responder = (op, ctx) => {
+      switch (op) {
+        case 'has':
+          expect(ctx.env.AGENTS_CRED_TARGET).toBe('agents-cli.bundles.demo');
+          return { status: 0 };
+        case 'get':
+          return { status: 0, stdout: Buffer.from('hello', 'utf8').toString('base64') };
+        case 'set':
+          expect(ctx.input).toBe('secret-value');
+          return { status: 0 };
+        case 'delete':
+          return { status: 0 };
+        case 'list':
+          expect(ctx.env.AGENTS_CRED_PREFIX).toBe(PREFIX);
+          return { status: 0, stdout: 'agents-cli.bundles.demo\nagents-cli.bundles.prod\n' };
+        default:
+          throw new Error(`unexpected op ${op}`);
+      }
+    };
+
+    expect(windowsBackend.has('agents-cli.bundles.demo')).toBe(true);
+    expect(windowsBackend.get('agents-cli.secrets.demo.KEY')).toBe('hello');
+    windowsBackend.set('agents-cli.secrets.demo.KEY', 'secret-value');
+    expect(windowsBackend.delete('agents-cli.bundles.demo')).toBe(true);
+    expect(windowsBackend.list(PREFIX)).toEqual([
+      'agents-cli.bundles.demo',
+      'agents-cli.bundles.prod',
+    ]);
+  });
+
+  it('reports clean not-found (exit 3) as false/throw without fallback', () => {
+    _resetForTest({ forceAvailable: true, fileDir: tmpDir });
+    responder = (op) => ({ status: 3 });
+    expect(windowsBackend.has('agents-cli.bundles.missing')).toBe(false);
+    expect(windowsBackend.delete('agents-cli.bundles.missing')).toBe(false);
+    expect(() => windowsBackend.get('agents-cli.bundles.missing')).toThrow(/not found/i);
+  });
+
+  it('falls back to the encrypted file store on ERROR_NO_SUCH_LOGON_SESSION (1312)', () => {
+    _resetForTest({ forceAvailable: true, fileDir: tmpDir, passphrase: 'test-pass' });
+    const item = 'agents-cli.secrets.demo.KEY';
+
+    // First a set: CredMan reports 1312 -> value lands in the file store instead.
+    responder = (op) => ({ status: 1, stderr: 'CredMan error 1312' });
+    windowsBackend.set(item, 'file-routed-value');
+
+    // Once the fallback is active, subsequent ops don't spawn PowerShell at all.
+    responder = () => { throw new Error('should not spawn after fallback'); };
+    expect(windowsBackend.has(item)).toBe(true);
+    expect(windowsBackend.get(item)).toBe('file-routed-value');
+    expect(windowsBackend.list('agents-cli.secrets.demo.')).toEqual([item]);
+    expect(windowsBackend.delete(item)).toBe(true);
+    expect(windowsBackend.has(item)).toBe(false);
+
+    // The encrypted file really exists on disk (ciphertext, not plaintext).
+    _resetForTest({ forceAvailable: true, fileDir: tmpDir, passphrase: 'test-pass' });
+    responder = (op) => ({ status: 1, stderr: 'CredMan error 1312' });
+    windowsBackend.set(item, 'persisted');
+    const enc = fs.readFileSync(path.join(tmpDir, `${item}.enc`), 'utf8');
+    expect(enc).not.toContain('persisted');
+    expect(JSON.parse(enc)).toHaveProperty('ciphertext');
+  });
+});
+
+// (d) blob-size guard
+describe('CRED_MAX_CREDENTIAL_BLOB_SIZE guard', () => {
+  it('throws a clear error before spawning when the value exceeds the limit', () => {
+    _resetForTest({ forceAvailable: true, fileDir: tmpDir });
+    responder = () => { throw new Error('guard should throw before spawnSync'); };
+    const big = 'x'.repeat(CRED_MAX_CREDENTIAL_BLOB_SIZE + 1);
+    expect(() => setCredManToken('agents-cli.secrets.demo.BIG', big)).toThrow(
+      /CRED_MAX_CREDENTIAL_BLOB_SIZE/
+    );
+  });
+
+  it('accepts a value exactly at the limit', () => {
+    _resetForTest({ forceAvailable: true, fileDir: tmpDir });
+    let sawSet = false;
+    responder = (op) => { if (op === 'set') sawSet = true; return { status: 0 }; };
+    const atLimit = 'x'.repeat(CRED_MAX_CREDENTIAL_BLOB_SIZE);
+    setCredManToken('agents-cli.secrets.demo.MAX', atLimit);
+    expect(sawSet).toBe(true);
+  });
+});
+
+// (e) real Credential Manager round-trip — only on Windows CI leg.
+describe.skipIf(process.platform !== 'win32')('real Windows Credential Manager', () => {
+  it('set -> has -> get -> list -> delete against real advapi32', async () => {
+    const cp = await vi.importActual<typeof import('child_process')>('child_process');
+    spawnSyncMock.mockImplementation((...a: any[]) => (cp.spawnSync as any)(...a));
+    _resetForTest({ forceAvailable: true });
+
+    const item = `agents-cli.secrets.wintest.${Date.now()}`;
+    const value = 'real-round-trip: café ☕ =+/';
+    try {
+      windowsBackend.set(item, value);
+      expect(windowsBackend.has(item)).toBe(true);
+      expect(windowsBackend.get(item)).toBe(value);
+      expect(windowsBackend.list('agents-cli.secrets.wintest.')).toContain(item);
+    } finally {
+      expect(windowsBackend.delete(item)).toBe(true);
+      expect(windowsBackend.has(item)).toBe(false);
+    }
+  });
+});

--- a/src/lib/secrets/windows.ts
+++ b/src/lib/secrets/windows.ts
@@ -1,0 +1,479 @@
+/**
+ * Windows secret storage via Windows Credential Manager (wincred).
+ *
+ * Primary backend: the Credential Manager `advapi32` API (CredReadW /
+ * CredWriteW / CredDeleteW / CredEnumerateW), reached through a static
+ * PowerShell script that P/Invokes the C# shim below. PowerShell (Windows
+ * PowerShell 5.1) ships with every supported Windows, so there is no separate
+ * install step. Items are stored as CRED_TYPE_GENERIC with
+ * CRED_PERSIST_LOCAL_MACHINE — device-local, matching the biometry-bound model
+ * on macOS (src/lib/secrets/index.ts).
+ *
+ * Zero injection surface: the PS script is a single STATIC constant. All
+ * dynamic data rides in the child ENV (target name, list prefix) or STDIN (the
+ * secret value) — nothing is string-interpolated into the script. The child is
+ * spawned with a spawnSync ARGV ARRAY (`-EncodedCommand <base64>`), never a
+ * shell string.
+ *
+ * Headless fallback: when Credential Manager is unreachable (no logon session —
+ * ERROR_NO_SUCH_LOGON_SESSION 1312 — or powershell.exe missing from PATH), we
+ * transparently switch to the AES-256-GCM encrypted-file store in
+ * ./filestore.ts, exactly like the Linux locked-collection fallback. The
+ * decision is cached per process; one stderr line is emitted the first time.
+ *
+ * Item names are stored VERBATIM as the credential TargetName
+ * (`agents-cli.bundles.<name>` / `agents-cli.secrets.<bundle>.<key>` — the
+ * scheme shared with the file store, see ./filestore.ts) so `list` returns item
+ * names directly.
+ */
+
+import { spawnSync } from 'child_process';
+import type { KeychainBackend } from './index.js';
+import { encodePwshBase64 } from '../pwsh.js';
+import {
+  fileStore,
+  fileDir,
+  fileStoreHasItems,
+  machinePassphraseExists,
+  _resetFileStoreForTest,
+} from './filestore.js';
+
+// Re-exported so importers (and tests) can keep reaching these via './windows.js'.
+export {
+  encryptForFallback,
+  decryptForFallback,
+  fileBackend,
+  type EncFile,
+} from './filestore.js';
+
+const POWERSHELL = 'powershell.exe';
+
+/**
+ * CRED_MAX_CREDENTIAL_BLOB_SIZE — Credential Manager rejects a generic
+ * credential blob larger than 2560 bytes with an opaque CredWrite failure. We
+ * guard against it in `set` with a clear message. Only pathologically large
+ * bundle metadata could hit this; such an item should live in a file-backed
+ * bundle (AGENTS_SECRETS_PASSPHRASE) instead.
+ */
+export const CRED_MAX_CREDENTIAL_BLOB_SIZE = 2560;
+
+/**
+ * The static PowerShell driver. Dispatches on $env:AGENTS_CRED_OP; reads the
+ * target name from $env:AGENTS_CRED_TARGET, the list prefix from
+ * $env:AGENTS_CRED_PREFIX, and (for `set`) the raw secret value from stdin.
+ * Nothing dynamic is interpolated into this string.
+ *
+ * Exit codes: 0 = success, 3 = clean "not found", 1 = error (message on stderr,
+ * carrying the Win32 code so the Node side can detect an unavailable store).
+ * `get` emits the blob as base64 (dodges PowerShell CRLF/encoding corruption);
+ * `list` prints one target name per line.
+ */
+const PS_SCRIPT = `
+$ErrorActionPreference = 'Stop'
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+using System.Collections.Generic;
+
+public static class AgentsCred {
+    const uint CRED_TYPE_GENERIC = 1;
+    const uint CRED_PERSIST_LOCAL_MACHINE = 2;
+    const int ERROR_NOT_FOUND = 1168;
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    struct CREDENTIAL {
+        public uint Flags;
+        public uint Type;
+        public IntPtr TargetName;
+        public IntPtr Comment;
+        public System.Runtime.InteropServices.ComTypes.FILETIME LastWritten;
+        public uint CredentialBlobSize;
+        public IntPtr CredentialBlob;
+        public uint Persist;
+        public uint AttributeCount;
+        public IntPtr Attributes;
+        public IntPtr TargetAlias;
+        public IntPtr UserName;
+    }
+
+    [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    static extern bool CredReadW(string target, uint type, uint flags, out IntPtr cred);
+    [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    static extern bool CredWriteW(ref CREDENTIAL cred, uint flags);
+    [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    static extern bool CredDeleteW(string target, uint type, uint flags);
+    [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    static extern bool CredEnumerateW(string filter, uint flags, out uint count, out IntPtr creds);
+    [DllImport("advapi32.dll", SetLastError = false)]
+    static extern void CredFree(IntPtr buffer);
+
+    public static bool Has(string target) {
+        IntPtr p;
+        if (CredReadW(target, CRED_TYPE_GENERIC, 0, out p)) { CredFree(p); return true; }
+        int err = Marshal.GetLastWin32Error();
+        if (err == ERROR_NOT_FOUND) return false;
+        throw new Exception("CredMan error " + err);
+    }
+
+    public static byte[] Get(string target) {
+        IntPtr p;
+        if (!CredReadW(target, CRED_TYPE_GENERIC, 0, out p)) {
+            int err = Marshal.GetLastWin32Error();
+            if (err == ERROR_NOT_FOUND) throw new Exception("NOTFOUND");
+            throw new Exception("CredMan error " + err);
+        }
+        try {
+            CREDENTIAL cred = (CREDENTIAL)Marshal.PtrToStructure(p, typeof(CREDENTIAL));
+            byte[] blob = new byte[cred.CredentialBlobSize];
+            if (cred.CredentialBlobSize > 0)
+                Marshal.Copy(cred.CredentialBlob, blob, 0, (int)cred.CredentialBlobSize);
+            return blob;
+        } finally { CredFree(p); }
+    }
+
+    public static void Set(string target, byte[] blob) {
+        CREDENTIAL cred = new CREDENTIAL();
+        cred.Type = CRED_TYPE_GENERIC;
+        cred.TargetName = Marshal.StringToCoTaskMemUni(target);
+        cred.CredentialBlobSize = (uint)blob.Length;
+        cred.CredentialBlob = (blob.Length > 0) ? Marshal.AllocCoTaskMem(blob.Length) : IntPtr.Zero;
+        if (blob.Length > 0) Marshal.Copy(blob, 0, cred.CredentialBlob, blob.Length);
+        cred.Persist = CRED_PERSIST_LOCAL_MACHINE;
+        cred.UserName = Marshal.StringToCoTaskMemUni(Environment.UserName);
+        try {
+            if (!CredWriteW(ref cred, 0)) {
+                int err = Marshal.GetLastWin32Error();
+                throw new Exception("CredMan error " + err);
+            }
+        } finally {
+            Marshal.FreeCoTaskMem(cred.TargetName);
+            if (cred.CredentialBlob != IntPtr.Zero) Marshal.FreeCoTaskMem(cred.CredentialBlob);
+            Marshal.FreeCoTaskMem(cred.UserName);
+        }
+    }
+
+    public static bool Delete(string target) {
+        if (CredDeleteW(target, CRED_TYPE_GENERIC, 0)) return true;
+        int err = Marshal.GetLastWin32Error();
+        if (err == ERROR_NOT_FOUND) return false;
+        throw new Exception("CredMan error " + err);
+    }
+
+    public static List<string> List(string filter) {
+        uint count;
+        IntPtr credsPtr;
+        List<string> results = new List<string>();
+        string f = string.IsNullOrEmpty(filter) ? null : filter;
+        if (!CredEnumerateW(f, 0, out count, out credsPtr)) {
+            int err = Marshal.GetLastWin32Error();
+            if (err == ERROR_NOT_FOUND) return results;
+            throw new Exception("CredMan error " + err);
+        }
+        try {
+            for (int i = 0; i < count; i++) {
+                IntPtr credPtr = Marshal.ReadIntPtr(credsPtr, i * IntPtr.Size);
+                CREDENTIAL cred = (CREDENTIAL)Marshal.PtrToStructure(credPtr, typeof(CREDENTIAL));
+                if (cred.TargetName != IntPtr.Zero)
+                    results.Add(Marshal.PtrToStringUni(cred.TargetName));
+            }
+        } finally { CredFree(credsPtr); }
+        return results;
+    }
+}
+'@
+
+try {
+    $op = $env:AGENTS_CRED_OP
+    $target = $env:AGENTS_CRED_TARGET
+    switch ($op) {
+        'has' {
+            if ([AgentsCred]::Has($target)) { exit 0 } else { exit 3 }
+        }
+        'get' {
+            $blob = [AgentsCred]::Get($target)
+            [Console]::Out.Write([Convert]::ToBase64String($blob))
+            exit 0
+        }
+        'set' {
+            $value = [Console]::In.ReadToEnd()
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes($value)
+            [AgentsCred]::Set($target, $bytes)
+            exit 0
+        }
+        'delete' {
+            if ([AgentsCred]::Delete($target)) { exit 0 } else { exit 3 }
+        }
+        'list' {
+            $prefix = $env:AGENTS_CRED_PREFIX
+            $filter = ''
+            if (-not [string]::IsNullOrEmpty($prefix)) { $filter = $prefix + '*' }
+            foreach ($n in [AgentsCred]::List($filter)) { [Console]::Out.WriteLine($n) }
+            exit 0
+        }
+        default {
+            [Console]::Error.Write('unknown op: ' + $op)
+            exit 1
+        }
+    }
+} catch {
+    $m = $_.Exception.Message
+    if ($m -match 'NOTFOUND') { exit 3 }
+    [Console]::Error.Write($m)
+    exit 1
+}
+`;
+
+const ENCODED_SCRIPT = encodePwshBase64(PS_SCRIPT);
+
+// ---------- spawn ----------
+
+interface CredResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  /** True when powershell.exe could not be spawned at all (ENOENT etc.). */
+  spawnError: boolean;
+}
+
+function runCred(
+  op: 'has' | 'get' | 'set' | 'delete' | 'list',
+  opts: { target?: string; prefix?: string; input?: string },
+): CredResult {
+  const env: NodeJS.ProcessEnv = { ...process.env, AGENTS_CRED_OP: op };
+  if (opts.target !== undefined) env.AGENTS_CRED_TARGET = opts.target;
+  if (opts.prefix !== undefined) env.AGENTS_CRED_PREFIX = opts.prefix;
+  // ARGV ARRAY — never a shell string. -EncodedCommand rides base64 of the
+  // UTF-16LE script with zero escaping hazards.
+  const result = spawnSync(POWERSHELL, ['-NoProfile', '-NonInteractive', '-EncodedCommand', ENCODED_SCRIPT], {
+    env,
+    input: opts.input,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout?.toString() ?? '',
+    stderr: result.stderr?.toString() ?? '',
+    spawnError: !!result.error,
+  };
+}
+
+// ---------- powershell availability ----------
+
+function powershellAvailable(): boolean {
+  const result = spawnSync(POWERSHELL, ['-NoProfile', '-NonInteractive', '-Command', 'exit 0'], {
+    stdio: ['ignore', 'ignore', 'ignore'],
+  });
+  return !result.error && result.status === 0;
+}
+
+let checkedAvailability = false;
+let isAvailable = false;
+
+// ---------- file fallback state ----------
+
+let useFileFallback = false;
+let warnedFallback = false;
+
+function activateFileFallback(): void {
+  if (useFileFallback) return;
+  useFileFallback = true;
+  if (!warnedFallback) {
+    warnedFallback = true;
+    process.stderr.write(
+      `[agents] Windows Credential Manager unavailable, using file-based store at ${fileDir()}\n`
+    );
+  }
+}
+
+/**
+ * Credential Manager is "unavailable" (as opposed to a plain not-found or a
+ * malformed item) when there's no logon session to hold credentials
+ * (ERROR_NO_SUCH_LOGON_SESSION 1312 — common under a service account / SSH
+ * session with no interactive logon) or powershell.exe can't be spawned at all.
+ * Those cases route to the encrypted-file fallback, exactly like the Linux
+ * locked-collection error.
+ */
+function isCredManUnavailableError(r: CredResult): boolean {
+  if (r.spawnError) return true; // powershell.exe not found
+  return /\b1312\b/.test(r.stderr) || /NO_SUCH_LOGON_SESSION/i.test(r.stderr);
+}
+
+/**
+ * Decide which backend a given op should use. Activates the file fallback if a
+ * previous run already committed to it (encrypted items on disk), or if
+ * powershell.exe is missing and a passphrase source exists (explicit
+ * AGENTS_SECRETS_PASSPHRASE, a provisioned machine-local key, or a headless
+ * context). The disk-items check makes the fallback persistent across the many
+ * short-lived `agents secrets ...` Node processes.
+ */
+function preflight(): 'file' | 'credman' {
+  if (useFileFallback) return 'file';
+  if (fileStoreHasItems()) {
+    activateFileFallback();
+    return 'file';
+  }
+  if (!checkedAvailability) {
+    isAvailable = powershellAvailable();
+    checkedAvailability = true;
+  }
+  if (!isAvailable) {
+    if (process.env.AGENTS_SECRETS_PASSPHRASE || machinePassphraseExists() || !process.stdin.isTTY) {
+      activateFileFallback();
+      return 'file';
+    }
+    throw new Error(
+      'powershell.exe not found on PATH; cannot reach Windows Credential Manager.\n' +
+      'Set AGENTS_SECRETS_PASSPHRASE to use the encrypted-file fallback.'
+    );
+  }
+  return 'credman';
+}
+
+/**
+ * True when secret operations currently route to the encrypted-file store
+ * instead of Windows Credential Manager. Mirrors linux.ts:usesFileFallback so
+ * `listBundles()` doesn't double-count file-backed bundles under the fallback.
+ */
+export function usesFileFallback(): boolean {
+  try {
+    return preflight() === 'file';
+  } catch {
+    return false;
+  }
+}
+
+// ---------- Credential Manager ops with fallback ----------
+
+export function hasCredManToken(item: string): boolean {
+  if (preflight() === 'file') return fileStore.has(item);
+  const r = runCred('has', { target: item });
+  if (r.status === 0) return true;
+  if (r.status === 3) return false;
+  if (isCredManUnavailableError(r)) {
+    activateFileFallback();
+    return fileStore.has(item);
+  }
+  return false;
+}
+
+export function getCredManToken(item: string): string {
+  if (preflight() === 'file') return fileStore.get(item);
+  const r = runCred('get', { target: item });
+  if (r.status === 0) {
+    // stdout is base64 of the raw UTF-8 blob (dodges PowerShell encoding corruption).
+    return Buffer.from(r.stdout.trim(), 'base64').toString('utf8');
+  }
+  if (r.status === 3) throw new Error(`Secret '${item}' not found in Credential Manager.`);
+  if (isCredManUnavailableError(r)) {
+    activateFileFallback();
+    return fileStore.get(item);
+  }
+  throw new Error(`Failed to read secret '${item}': ${r.stderr.trim() || 'unknown error'}`);
+}
+
+export function setCredManToken(item: string, value: string): void {
+  if (!value || !value.trim()) throw new Error('Secret value is empty.');
+  if (preflight() === 'file') { fileStore.set(item, value); return; }
+  const byteLen = Buffer.byteLength(value, 'utf8');
+  if (byteLen > CRED_MAX_CREDENTIAL_BLOB_SIZE) {
+    throw new Error(
+      `Secret '${item}' is ${byteLen} bytes, exceeding the Windows Credential Manager limit of ` +
+      `${CRED_MAX_CREDENTIAL_BLOB_SIZE} bytes (CRED_MAX_CREDENTIAL_BLOB_SIZE). ` +
+      'Use a file-backed bundle (set AGENTS_SECRETS_PASSPHRASE) for values this large.'
+    );
+  }
+  const r = runCred('set', { target: item, input: value });
+  if (r.status === 0) return;
+  if (isCredManUnavailableError(r)) {
+    activateFileFallback();
+    fileStore.set(item, value);
+    return;
+  }
+  throw new Error(`Failed to store secret '${item}': ${r.stderr.trim() || 'unknown error'}`);
+}
+
+export function deleteCredManToken(item: string): boolean {
+  if (preflight() === 'file') return fileStore.delete(item);
+  const r = runCred('delete', { target: item });
+  if (r.status === 0) return true;
+  if (r.status === 3) return false;
+  if (isCredManUnavailableError(r)) {
+    activateFileFallback();
+    return fileStore.delete(item);
+  }
+  return false;
+}
+
+export function listCredManItems(prefix: string): string[] {
+  if (preflight() === 'file') return fileStore.list(prefix);
+  const r = runCred('list', { prefix });
+  if (r.status === 0) return parseWindowsCredList(r.stdout, prefix);
+  if (isCredManUnavailableError(r)) {
+    activateFileFallback();
+    return fileStore.list(prefix);
+  }
+  return [];
+}
+
+/**
+ * Parse the target names printed by the `list` op (one per line), keeping only
+ * those starting with `prefix` and deduping. Same contract as
+ * parseSecretToolItems (linux.ts). Exported for tests.
+ */
+export function parseWindowsCredList(output: string, prefix: string): string[] {
+  const items = output
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .filter((s) => s.startsWith(prefix));
+  return [...new Set(items)]; // dedupe
+}
+
+/**
+ * KeychainBackend implementation for Windows. Routes through Windows Credential
+ * Manager (via PowerShell P/Invoke) with a transparent encrypted-file fallback
+ * when the credential store is unreachable.
+ */
+export const windowsBackend: KeychainBackend = {
+  has(item: string): boolean {
+    return hasCredManToken(item);
+  },
+  get(item: string): string {
+    return getCredManToken(item);
+  },
+  set(item: string, value: string): void {
+    setCredManToken(item, value);
+  },
+  delete(item: string): boolean {
+    return deleteCredManToken(item);
+  },
+  list(prefix: string): string[] {
+    return listCredManItems(prefix);
+  },
+};
+
+/**
+ * Test-only: reset module state so independent test cases don't bleed
+ * availability / fallback decisions across each other. Pass `forceAvailable` to
+ * pin the powershell-availability probe (skips the real spawn); pass `fileDir`
+ * to redirect the encrypted-file store to a temp dir. File-store state lives in
+ * ./filestore.ts and is reset there.
+ */
+export function _resetForTest(opts: {
+  fileDir?: string | null;
+  forceFileFallback?: boolean;
+  passphrase?: string | null;
+  forceAvailable?: boolean | null;
+} = {}): void {
+  _resetFileStoreForTest({ fileDir: opts.fileDir ?? null, passphrase: opts.passphrase ?? null });
+  useFileFallback = opts.forceFileFallback ?? false;
+  warnedFallback = false;
+  if (opts.forceAvailable === undefined || opts.forceAvailable === null) {
+    checkedAvailability = false;
+    isAvailable = false;
+  } else {
+    checkedAvailability = true;
+    isAvailable = opts.forceAvailable;
+  }
+}


### PR DESCRIPTION
## What

Adds a Windows backend to `agents secrets` so it works on Windows via **Windows Credential Manager**, with the same **AES-256-GCM encrypted-file fallback** used on Linux when the credential store is unreachable. Closes the secrets half of #339 — `assertSupportedPlatform()` no longer hard-throws on win32.

## How

**`src/lib/secrets/windows.ts` (new)** — structural clone of `linux.ts`:
- Primary backend = Credential Manager (`CRED_TYPE_GENERIC`, `CRED_PERSIST_LOCAL_MACHINE` — device-local, matches the macOS model) reached through a **single STATIC PowerShell script** that `Add-Type`s a C# shim P/Invoking `CredReadW` / `CredWriteW` / `CredDeleteW` / `CredEnumerateW`.
- **Zero injection surface**: target name → `$env:AGENTS_CRED_TARGET`, list prefix → `$env:AGENTS_CRED_PREFIX`, secret **value → stdin** (`[Console]::In.ReadToEnd()`). Nothing dynamic is interpolated into the script. Child spawned with a `spawnSync` **argv array** (`-NoProfile -NonInteractive -EncodedCommand <base64>`), never a shell string.
- **Encoding-safe I/O**: `get` emits `[Convert]::ToBase64String($blob)` and Node base64-decodes to the UTF-8 value (dodges PS CRLF/encoding corruption); `set` stores raw stdin bytes; `list` prints one target name per line.
- `parseWindowsCredList(out, prefix)` — pure: prefix-filter + dedupe, same contract as `parseSecretToolItems`.
- Fallback control flow copied from `linux.ts`: `preflight()` / `activateFileFallback()` / `fileStoreHasItems()`, with `secretToolAvailable()` → PowerShell probe and `isLockedCollectionError` → `isCredManUnavailableError` (matches `ERROR_NO_SUCH_LOGON_SESSION` 1312 + powershell-not-found).
- `CRED_MAX_CREDENTIAL_BLOB_SIZE` (2560) guard in `set` throws a clear error instead of an opaque CredWrite failure.

**`src/lib/secrets/index.ts`** — relax `assertSupportedPlatform` for win32, add `isWindows()`, mirror **every** `isLinux()` branch (has / get / getBatch / set / delete / keychainUsesFileFallback / list / migrate) with a `windowsBackend` one.

**`src/lib/pwsh.ts` (new)** — extracted the shared UTF-16LE `-EncodedCommand` base64 encoder (`encodePwshBase64`); `browser/drivers/ssh.ts:encodePowerShell` now builds on it (Tier-2 no-dup), and `windows.ts` uses it too.

**`bundles.ts` — no edits needed.** It delegates the keychain path through `index.ts` (`keychainStore`) and its file guards are already non-darwin-aware (`FILE_ALLOW_AUTO_PROVISION = process.platform !== 'darwin'`).

**`skills/secrets/SKILL.md`** — platform table now shows Credential Manager + encrypted-file fallback.

## Tests

`src/lib/secrets/windows.test.ts` runs on all three CI OSes:
- Pure `parseWindowsCredList` (dedupe / prefix-filter / empty / CRLF).
- Base64 `get` round-trip (unicode / `=` / spaces).
- `vi.mock('child_process')` dispatch + fallback routing to a temp `fileDir` (asserts ciphertext-on-disk, not plaintext).
- `CRED_MAX_CREDENTIAL_BLOB_SIZE` guard (over-limit throws, at-limit passes).
- `describe.skipIf(process.platform !== 'win32')` — **real advapi32 set→has→get→list→delete round-trip** via real PowerShell, so the required **windows-latest** leg proves the real flow.

## Verification

- `bun run build` — clean (tsc).
- `bun run test` — **3372 passed, 47 skipped** (272 files). Windows mocked/pure tests pass on the Linux dev machine; the real CredMan round-trip runs on the windows-latest CI leg.