### PR TITLE
fix(computer): screenshot default extension matches PNG bytes (#521)

### DIFF
--- a/src/commands/computer.test.ts
+++ b/src/commands/computer.test.ts
@@ -1,5 +1,48 @@
 import { describe, expect, it } from 'vitest';
-import { shouldBlockOffPlatform } from './computer.js';
+import { detectImageFormat, reconcileScreenshotExt, shouldBlockOffPlatform } from './computer.js';
+
+// Real leading magic bytes, matching what each helper actually encodes.
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]); // Windows helper (ImageFormat.Png)
+const JPEG = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]); // macOS helper (.jpeg representation)
+
+describe('detectImageFormat', () => {
+  it('recognizes PNG from its 8-byte signature', () => {
+    expect(detectImageFormat(PNG)).toBe('.png');
+  });
+  it('recognizes JPEG from FF D8 FF', () => {
+    expect(detectImageFormat(JPEG)).toBe('.jpg');
+  });
+  it('returns null for unknown/empty bytes', () => {
+    expect(detectImageFormat(Buffer.from([0x00, 0x01, 0x02, 0x03]))).toBeNull();
+    expect(detectImageFormat(Buffer.alloc(0))).toBeNull();
+  });
+});
+
+describe('reconcileScreenshotExt', () => {
+  it('corrects the .jpg default when the Windows helper returns PNG (issue #521)', () => {
+    // The exact bug: default out is ./computer-screenshot.jpg, bytes are PNG.
+    expect(reconcileScreenshotExt('/tmp/computer-screenshot.jpg', PNG)).toEqual({
+      path: '/tmp/computer-screenshot.png',
+      corrected: true,
+    });
+  });
+  it('leaves a matching .jpg alone for JPEG bytes (macOS default path)', () => {
+    expect(reconcileScreenshotExt('/tmp/shot.jpg', JPEG)).toEqual({ path: '/tmp/shot.jpg', corrected: false });
+  });
+  it('treats .jpeg as already-matching for JPEG bytes', () => {
+    expect(reconcileScreenshotExt('/tmp/shot.jpeg', JPEG)).toEqual({ path: '/tmp/shot.jpeg', corrected: false });
+  });
+  it('appends the real extension when the path has none', () => {
+    expect(reconcileScreenshotExt('/tmp/shot-test', PNG)).toEqual({ path: '/tmp/shot-test.png', corrected: true });
+  });
+  it('swaps a wrong .png to .jpg for JPEG bytes', () => {
+    expect(reconcileScreenshotExt('/tmp/shot.png', JPEG)).toEqual({ path: '/tmp/shot.jpg', corrected: true });
+  });
+  it('passes unknown bytes through untouched', () => {
+    const junk = Buffer.from([0x00, 0x01]);
+    expect(reconcileScreenshotExt('/tmp/shot.jpg', junk)).toEqual({ path: '/tmp/shot.jpg', corrected: false });
+  });
+});
 
 // The `computer` preAction hook calls process.exit(1) exactly when
 // shouldBlockOffPlatform() is true. These cases pin the rule that off-macOS

--- a/src/commands/computer.ts
+++ b/src/commands/computer.ts
@@ -58,6 +58,40 @@ export function shouldBlockOffPlatform(opts: {
   return true;
 }
 
+/**
+ * Sniff the image format from the leading magic bytes: PNG starts with the
+ * 8-byte signature `89 50 4E 47` ("\x89PNG"), JPEG with `FF D8 FF`. Returns the
+ * canonical file extension, or null for anything else.
+ */
+export function detectImageFormat(buf: Buffer): '.png' | '.jpg' | null {
+  if (buf.length >= 4 && buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return '.png';
+  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return '.jpg';
+  return null;
+}
+
+/**
+ * Make the screenshot filename honest about its bytes. The two helper backends
+ * encode DIFFERENT formats and neither re-encodes to match the requested name:
+ * the macOS helper (ScreenCaptureKit) returns JPEG
+ * (packages/computer-helper/Sources/ComputerHelper/Screenshot.swift:207,212),
+ * the Windows helper returns PNG
+ * (packages/computer-helper-win/Screenshot.cs:33). So a fixed default extension
+ * cannot be correct for both — the only honest path is to sniff the real format
+ * and swap the extension to match. Pure so it's unit-testable.
+ *
+ * Returns the path to write to (caller's path with its extension corrected) and
+ * whether a correction was made. Unknown formats pass through unchanged.
+ */
+export function reconcileScreenshotExt(outPath: string, buf: Buffer): { path: string; corrected: boolean } {
+  const actual = detectImageFormat(buf);
+  if (!actual) return { path: outPath, corrected: false };
+  const cur = path.extname(outPath).toLowerCase();
+  const alreadyMatches = cur === actual || (actual === '.jpg' && (cur === '.jpg' || cur === '.jpeg'));
+  if (alreadyMatches) return { path: outPath, corrected: false };
+  const base = outPath.slice(0, outPath.length - path.extname(outPath).length);
+  return { path: base + actual, corrected: true };
+}
+
 export function registerComputerCommand(program: Command): void {
   const computer = program
     .command('computer')
@@ -160,8 +194,8 @@ function registerScreenshotCommand(program: Command): void {
     .option('--list', 'List the app\'s windows (id/title/layer/bounds) instead of capturing — reveals modals/popups')
     .option('--window-id <n>', 'Capture a specific window by id (from --list)', (v) => parseInt(v, 10))
     .option('--display', 'Capture the whole display the app is on (composites stacked modals)')
-    .option('--out <path>', 'Output JPEG path', './computer-screenshot.jpg')
-    .option('--quality <n>', 'JPEG quality 1-100', (v) => parseInt(v, 10), 85)
+    .option('--out <path>', 'Output image path — extension auto-corrected to the encoded format (JPEG on macOS, PNG on a Windows --host)', './computer-screenshot.jpg')
+    .option('--quality <n>', 'JPEG quality 1-100 (macOS capture only; the Windows helper encodes lossless PNG and ignores this)', (v) => parseInt(v, 10), 85)
     .option('--json', 'Emit JSON (metadata for captures; window list for --list)')
     .action(async (opts: {
       bundle?: string;
@@ -218,7 +252,10 @@ function registerScreenshotCommand(program: Command): void {
           process.exit(1);
         }
         const buf = Buffer.from(b64, 'base64');
-        const outPath = path.resolve(opts.out);
+        // Sniff the real format and correct the extension so the filename never
+        // lies about its bytes (macOS -> JPEG, Windows helper -> PNG).
+        const requested = path.resolve(opts.out);
+        const { path: outPath, corrected } = reconcileScreenshotExt(requested, buf);
         fs.writeFileSync(outPath, buf);
 
         if (opts.json) {
@@ -226,6 +263,9 @@ function registerScreenshotCommand(program: Command): void {
           const meta = { ...res, image_data: `<saved to ${outPath}>` };
           console.log(JSON.stringify(meta, null, 2));
         } else {
+          if (corrected) {
+            console.log(`note: bytes are ${path.extname(outPath).slice(1).toUpperCase()}; corrected extension from ${path.basename(requested)}`);
+          }
           const origin = (res.origin as number[]) || [];
           const originStr = origin.length === 2 ? `, origin [${origin.join(',')}], scale ${res.scale ?? '?'}` : '';
           console.log(`saved: ${outPath} (${res.width ?? '?'}x${res.height ?? '?'}, ${buf.byteLength} bytes${originStr})`);


### PR DESCRIPTION
## Problem (#521)

`agents computer screenshot` defaulted `--out` to `./computer-screenshot.jpg` and labeled the option `Output JPEG path`, but the file extension lied about its bytes.

The two helper backends encode **different** formats and neither re-encodes to match the requested name:

- **Windows helper** — PNG: `bmp.Save(ms, ImageFormat.Png)` (`packages/computer-helper-win/Screenshot.cs:33`), no `mime_type`, ignores `quality`.
- **macOS helper** — JPEG: `rep.representation(using: .jpeg, ...)` + `"mime_type": "image/jpeg"` (`packages/computer-helper/Sources/ComputerHelper/Screenshot.swift:207,212`), uses `quality`.

So a fixed default extension can't be honest for both. On the Windows `--host` path (the one #521 hit), PNG bytes landed in a `.jpg` file.

## Fix

Sniff the actual format from the leading magic bytes and correct the output extension to match — honest regardless of backend, no invented re-encode path:

- `detectImageFormat(buf)` — PNG (`\x89PNG`) vs JPEG (`\xFF\xD8\xFF`).
- `reconcileScreenshotExt(outPath, buf)` — swaps the extension to match the bytes (or appends one when absent); pure and unit-tested.
- Wired into the write path (`src/commands/computer.ts`); prints a `note:` when it corrects.
- Relabeled `--out` and `--quality` (PNG/Windows is lossless and ignores quality).

## Verification

**Unit** — `src/commands/computer.test.ts`: 13/13 pass (magic-byte detection + extension reconciliation incl. the exact #521 case).

**End-to-end** — drove the compiled `reconcileScreenshotExt` + write with a real PNG payload (what the Windows helper emits) and the buggy default `--out .../shot-test.jpg`:

```
requested: /tmp/shot-test.jpg
written:   /tmp/shot-test.png  corrected: true
$ file /tmp/shot-test.png  -> PNG image data, 1 x 1, ...
$ xxd -l 8 /tmp/shot-test.png -> 8950 4e47 0d0a 1a0a  (.PNG....)
$ ls /tmp/shot-test.jpg -> No such file or directory   (no .jpg lie on disk)
```

`bun run build` passes. (The `bun test` full-suite shows ~293 pre-existing failures from cross-test races on shared temp-HOME state — reproduced identically on clean `origin/main` — all unrelated suites pass in isolation.)

## Scope

Touches only `src/commands/computer.ts` + its test. #520 (ssh-tunnel HTTP-pull hardening) intentionally not included — it needs a human-authorized win-mini E2E and is out of scope for this honest-extension fix.