### PR TITLE
docs(gemini): note Gemini CLI deprecation + Antigravity successor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ Not every harness supports every capability — the registry decides per harness
 | ★ Antigravity CLI | `antigravity` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | — | edit·skip |
 | ★ Grok CLI | `grok` | ✓ | ✓ | ✓ | ✓ | — | ✓ | — | — | plan·edit·skip |
 | ★ OpenCode | `opencode` | — | ✓ | — | ✓ | ✓ | — | — | — | plan·edit |
-| Gemini | `gemini` | ≥0.26 | ✓ | — | ✓ | ✓ | — | — | — | plan·edit·skip |
+| Gemini † | `gemini` | ≥0.26 | ✓ | — | ✓ | ✓ | — | — | — | plan·edit·skip |
 | Cursor | `cursor` | — | ✓ | — | ✓ | ✓ | — | — | — | edit·skip |
 | OpenClaw | `openclaw` | ✓ | ✓ | — | ✓ | — | ✓ | ✓ | — | plan·edit·skip |
 | Copilot | `copilot` | — | ✓ | — | ✓ | ✓ | — | — | — | plan·edit·auto·skip |
@@ -100,6 +100,7 @@ Not every harness supports every capability — the registry decides per harness
 - `rules` (the memory file) is supported by **all 15** — each writes its own file (see config matrix below). `workflows` is **Claude-only**. `mcp` is universal.
 - `allowlist` (granular per-tool permission rules) is limited to `claude`, `antigravity`, `grok`, `kimi`.
 - `subagents` is limited to `claude`, `openclaw`, `droid`.
+- **† Gemini (`gemini`) is deprecated by Google.** The Gemini CLI was retired for free/Pro/Ultra tiers on June 18, 2026 (announced at Google I/O 2026); **Antigravity CLI (`antigravity`) is the official successor.** agents-cli still manages existing installs but warns on `agents add gemini` / `agents teams add … gemini` (`warnAgentDeprecated` in [`src/lib/agents.ts`](src/lib/agents.ts); marker on the `gemini` registry entry).
 
 ### Config matrix
 

--- a/README.md
+++ b/README.md
@@ -646,11 +646,13 @@ By default, secrets sync via iCloud Keychain to your other Macs. With `--no-iclo
 
 Which DotAgents resources each agent CLI can load. Source of truth: [src/lib/agents.ts](src/lib/agents.ts) (`capabilities`); gates use `supports(agent, cap, version)` from [src/lib/capabilities.ts](src/lib/capabilities.ts). Full matrix also in [docs/00-concepts.md](docs/00-concepts.md).
 
+> **† Gemini CLI is deprecated.** Google retired it for free, Pro, and Ultra tiers on **June 18, 2026** (announced at Google I/O 2026); the `gemini` command no longer serves requests on those tiers. agents-cli still manages existing installs, but warns on `agents add gemini` and `agents teams add … gemini`. New setups should use **Antigravity CLI** (`antigravity`), Google's official successor — see [the transition notice](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/).
+
 | Agent | Versions | Hooks | MCP | Permissions | Skills | Commands | Plugins | Subagents | Rules | Workflows |
 |-------|----------|-------|-----|-------------|--------|----------|---------|-----------|-------|-----------|
 | Claude Code | yes | yes | yes | yes | yes | yes | yes | yes | `CLAUDE.md` | yes |
 | Codex CLI | yes | >= 0.116.0 | yes | no | yes | < 0.117.0 · skills ($name, >= 0.117) | >= 0.128.0 | no | `AGENTS.md` | no |
-| Gemini CLI | yes | >= 0.26.0 | yes | no | yes | yes (.toml) | no | no | `GEMINI.md` | no |
+| Gemini CLI † | yes | >= 0.26.0 | yes | no | yes | yes (.toml) | no | no | `GEMINI.md` | no |
 | Antigravity | yes | yes | yes | yes | yes | yes | yes | no | `AGENTS.md` | no |
 | Grok Build | yes | yes | yes | yes | yes | skills ($name) | yes | no | `AGENTS.md` | no |
 | OpenClaw | yes | yes | yes | no | yes | gateway | yes | yes | `workspace/AGENTS.md` | no |
@@ -672,7 +674,7 @@ Which DotAgents resources each agent CLI can load. Source of truth: [src/lib/age
 |-------|----------|-------|---------------|
 | Claude Code | yes | yes | yes |
 | Codex CLI | yes | yes | yes |
-| Gemini CLI | yes | yes | yes |
+| Gemini CLI † | yes | yes | yes |
 | Cursor | -- | yes | -- |
 | OpenCode | -- | yes | -- |
 | Grok Build | -- | yes | yes |

--- a/docs/00-concepts.md
+++ b/docs/00-concepts.md
@@ -98,7 +98,7 @@ See [01-version-management.md](01-version-management.md) for install and switchi
 |------|-------|-----|-------------|--------|----------|---------|-----------|-------|-----------|
 | Claude | yes | yes | yes | yes | yes | yes | yes | `CLAUDE.md` | yes |
 | Codex | >= 0.116.0 | yes | no | yes | < 0.117.0 · skills ($name, >= 0.117) | >= 0.128.0 | no | `AGENTS.md` | no |
-| Gemini | >= 0.26.0 | yes | no | yes | yes (.toml) | no | no | `GEMINI.md` | no |
+| Gemini † | >= 0.26.0 | yes | no | yes | yes (.toml) | no | no | `GEMINI.md` | no |
 | Cursor | no | yes | no | yes | yes | no | no | `.cursorrules` | no |
 | OpenCode | no | yes | no | yes | yes | no | no | `AGENTS.md` | no |
 | OpenClaw | yes | yes | no | yes | gateway | yes | yes | `workspace/AGENTS.md` | no |
@@ -109,6 +109,8 @@ See [01-version-management.md](01-version-management.md) for install and switchi
 | Roo Code | no | yes | no | yes | yes | no | no | `AGENTS.md` | no |
 | Antigravity | yes | yes | yes | yes | yes | yes | no | `AGENTS.md` | no |
 | Grok | yes | yes | yes | yes | skills ($name) | yes | no | `AGENTS.md` | no |
+
+**† Gemini is deprecated.** Google retired the Gemini CLI for free/Pro/Ultra tiers on June 18, 2026 (announced at Google I/O 2026); Antigravity CLI (`antigravity`) is the successor. agents-cli still manages existing Gemini installs but warns on `agents add gemini` / `agents teams add … gemini`.
 
 Permissions sync is gated on the `allowlist` capability (Claude, Antigravity, Grok only). **Host CLIs** (`agents cli`) are agent-agnostic PATH binaries — not in this matrix. Install paths call `supports(agent, cap, version)` before writing; gated capabilities skip with a clear reason instead of silently ignored config.
 


### PR DESCRIPTION
## What

Reflects the Gemini CLI deprecation (shipped as a runtime warning in #507) in the docs, so the harness tables no longer present Gemini as an unqualified ongoing choice.

- **README.md** — deprecation callout in the Compatibility section + `†` on both `Gemini CLI` rows (the capability table and the agents-cli-features table).
- **AGENTS.md** — `†` on the feature-support matrix row + a note bullet (points at `warnAgentDeprecated` / the registry marker). `CLAUDE.md` / `GEMINI.md` are symlinks to it, so they inherit the change.
- **docs/00-concepts.md** — `†` on the capability matrix row + a note.

Each `†` resolves to: Google retired the Gemini CLI for free/Pro/Ultra tiers on **June 18, 2026** (announced at Google I/O 2026); **Antigravity CLI (`antigravity`) is the official successor**; agents-cli still manages existing installs but warns on `agents add gemini` / `agents teams add … gemini`.

## Why

Follow-up to #507 (the code that emits the warning). Without this, the docs still list Gemini as a plain supported harness with no signal that Google has retired it — a user reading the compatibility matrix would have no idea. Source: [Google Developers Blog — Transitioning Gemini CLI to Antigravity CLI](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/).

## Scope

Docs-only, no code change. Deliberately did **not** touch the many generic "Claude, Codex, Gemini, …" example/prose mentions — the tool still manages Gemini (enterprise tiers still work), so only the places that present it as a *harness choice* (the three capability tables) get the note.