### PR TITLE
ci(bench): Linux-only non-gating benchmark workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,52 @@
+name: Bench
+
+# Perf benchmark harnesses (bench/ + tests/bench-*). Deliberately Linux-only
+# and NON-gating:
+#
+#   * No per-OS bench legs. The correctness matrix (ubuntu/macOS/Windows x
+#     node 22/24) lives in ci.yml — cross-platform bench numbers add noise
+#     without signal right now, so there is no Windows/macOS/Linux bench fan-out.
+#   * The bench steps are `continue-on-error` — a regression or a nonzero exit
+#     never fails the job or blocks a merge. Numbers are informational; read
+#     them in the step log. Infra failures (checkout/install) still surface red.
+#
+# Each harness runs against a fresh HOME (mktemp -d) so results depend on the
+# harness, not on leftover runner state. resolve-perf no-ops when no agent
+# versions are installed (the CI case) — it smoke-tests the harness itself.
+
+on:
+  push:
+    branches: ['main', 'release/**']
+  pull_request:
+    branches: ['main', 'release/**']
+  workflow_dispatch:
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    permissions: {}
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: bun install --ignore-scripts
+
+      - name: Bench — agent-spec resolution
+        continue-on-error: true
+        run: HOME="$(mktemp -d)" bun bench/resolve-perf.ts
+
+      - name: Bench — sessions indexing pipeline
+        continue-on-error: true
+        run: HOME="$(mktemp -d)" bun bench/sessions-perf.ts
+
+      - name: Bench — concurrent session writes
+        continue-on-error: true
+        run: HOME="$(mktemp -d)" bun tests/bench-concurrent-writes.ts

--- a/bench/resolve-perf.ts
+++ b/bench/resolve-perf.ts
@@ -17,7 +17,7 @@
 
 import { performance } from 'perf_hooks';
 import { listInstalledVersions, invalidateInstalledVersionsCache, getGlobalDefault } from '../src/lib/versions.js';
-import { resolveAgentTargets } from '../src/lib/agent-spec.js';
+import { resolveAgentTargets } from '../src/lib/agent-spec/index.js';
 import { ALL_AGENT_IDS } from '../src/lib/agents.js';
 import type { AgentId } from '../src/lib/types.js';
 


### PR DESCRIPTION
Adds a `Bench` CI workflow that runs the existing perf harnesses. Mirrors `ci.yml`'s checkout/bun/node setup but is deliberately scoped down:

- **Linux-only.** No Windows/macOS/Linux bench fan-out — the correctness matrix (ubuntu/macOS/Windows x node 22/24) already lives in `ci.yml`. Cross-platform bench numbers add noise without signal right now, so there are no per-OS bench legs.
- **Non-gating.** The three bench steps are `continue-on-error` — a regression or nonzero exit never fails the job or blocks a merge. Numbers are informational (read them in the step log). Infra failures (checkout/install) still surface red.
- **Hermetic.** Each harness runs against a fresh `HOME` (`mktemp -d`) so results depend on the harness, not leftover runner state.

## Harnesses wired in
| Step | Script | On a clean runner |
|---|---|---|
| agent-spec resolution | `bench/resolve-perf.ts` | no-ops (no installed versions) — smoke-tests the harness |
| sessions indexing | `bench/sessions-perf.ts` | runs against empty state, real numbers |
| concurrent session writes | `tests/bench-concurrent-writes.ts` | fully self-contained, 4 workers x 300 rows |

`bench/offload-smoke.sh` and `bench/tty-vs-headless.py` are intentionally excluded — they need real agent API keys / a TUI and can't run headless in CI.

## Drive-by fix
`bench/resolve-perf.ts` imported `../src/lib/agent-spec.js`, but #501 moved that module to `src/lib/agent-spec/index.js`; the harness threw `Cannot find module` on every run. Repaired the import so the step actually executes.

## Verification
Ran all three commands locally on Linux against a fresh `HOME` (the CI case):
- `resolve-perf` → `{"error":"no agent has installed versions on this host"}`, exit 0
- `sessions-perf` → full JSON, 0 sessions, exit 0
- `bench-concurrent-writes` → `failures: 0/4`, exit 0

Workflow YAML parses clean and reuses `ci.yml`'s exact pinned action SHAs.