### PR TITLE
chore: deprecate + remove archived Roo Code harness (RUSH-1341)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,11 +65,11 @@ See [`docs/00-concepts.md`](docs/00-concepts.md) for the full mental model and r
 
 ## Supported harnesses
 
-15 harnesses ship support today. The full id list is `AgentId` ([`src/lib/types.ts:10`](src/lib/types.ts)); per-harness config + capabilities live in the `AGENTS` registry ([`src/lib/agents.ts:215-550`](src/lib/agents.ts)) and are gated through `supports()` ([`src/lib/capabilities.ts`](src/lib/capabilities.ts)).
+14 harnesses ship support today. The full id list is `AgentId` ([`src/lib/types.ts:10`](src/lib/types.ts)); per-harness config + capabilities live in the `AGENTS` registry ([`src/lib/agents.ts:215-550`](src/lib/agents.ts)) and are gated through `supports()` ([`src/lib/capabilities.ts`](src/lib/capabilities.ts)).
 
 ### Prioritized (first-class) harnesses
 
-These six are the support-priority set — new features and parity work target them first. When a feature can't reach all 15 at once, it must reach these:
+These six are the support-priority set — new features and parity work target them first. When a feature can't reach all 14 at once, it must reach these:
 
 **Claude Code** (`claude`) · **Codex CLI** (`codex`) · **Kimi CLI** (`kimi`) · **Antigravity CLI** (`antigravity`) · **Grok CLI** (`grok`) · **OpenCode** (`opencode`)
 
@@ -92,12 +92,11 @@ Not every harness supports every capability — the registry decides per harness
 | Amp | `amp` | — | ✓ | — | ✓ | ✓ | — | — | — | plan·edit |
 | Kiro | `kiro` | — | ✓ | — | ✓ | ✓ | — | — | — | edit |
 | Goose | `goose` | — | ✓ | — | — | — | — | — | — | edit |
-| Roo Code | `roo` | — | ✓ | — | ✓ | ✓ | — | — | — | plan·edit |
 | Droid | `droid` | — | ✓ | — | — | ✓ | — | ✓ | — | plan·edit·auto·skip |
 
 ✓ = supported · — = not supported · version cell = supported only within that range (e.g. `≥0.116` needs version `>= 0.116.0`; `<0.117` only below `0.117.0`). Out-of-range cells are **skipped silently** — `supports()` returns false and the resource is never written.
 
-- `rules` (the memory file) is supported by **all 15** — each writes its own file (see config matrix below). `workflows` is **Claude-only**. `mcp` is universal.
+- `rules` (the memory file) is supported by **all 14** — each writes its own file (see config matrix below). `workflows` is **Claude-only**. `mcp` is universal.
 - `allowlist` (granular per-tool permission rules) is limited to `claude`, `antigravity`, `grok`, `kimi`.
 - `subagents` is limited to `claude`, `openclaw`, `droid`.
 

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -293,7 +293,7 @@ When to use:
   pointing at the existing install — nothing is copied or moved (except the
   agent's config dir, which is moved into the version's home). Works for both
   npm-style packages (claude, codex, gemini, opencode, openclaw) and
-  installScript-based agents (grok, antigravity, cursor, kiro, goose, roo).
+  installScript-based agents (grok, antigravity, cursor, kiro, goose).
 `)
     .action(runImport);
 }

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -97,7 +97,7 @@ Project rules & @-imports:
   @path imports inside AGENTS.md/CLAUDE.md are resolved at session start by the agent
   itself, not by agents-cli. Support is per-agent:
     Inlined natively:  claude, gemini
-    Literal text:      codex, cursor, opencode, copilot, amp, kiro, goose, roo
+    Literal text:      codex, cursor, opencode, copilot, amp, kiro, goose
 
   For rules that need to work across all agents, inline the content rather than using
   @-imports — the second group will load '@path/to/file.md' as a literal string.

--- a/src/lib/acp/harnesses.ts
+++ b/src/lib/acp/harnesses.ts
@@ -2,7 +2,7 @@
  * Per-harness spawn configuration for Agent Client Protocol (ACP) mode.
  *
  * Each entry describes how to launch a coding agent CLI as an ACP server
- * (stdio JSON-RPC). Unsupported harnesses (amp, roo, goose-stdio) are omitted;
+ * (stdio JSON-RPC). Unsupported harnesses (amp, goose-stdio) are omitted;
  * callers should fall back to the legacy direct-exec path for those.
  *
  * Sources: https://agentclientprotocol.com/get-started/agents + vendor docs.
@@ -76,7 +76,7 @@ export const ACP_HARNESSES: Partial<Record<AgentId, AcpHarnessSpec>> = {
   // goose: ACP over HTTP via `goosed`, not a clean stdio subcommand.
   // copilot, kiro: excluded for now (not installed in the reference environment,
   //                no local verification possible).
-  // amp, roo: not on the ACP agents list.
+  // amp: not on the ACP agents list.
 };
 
 /** Returns the ACP spawn spec for an agent, or undefined if the harness does not speak ACP. */

--- a/src/lib/agents.test.ts
+++ b/src/lib/agents.test.ts
@@ -322,7 +322,6 @@ describe('resolveAgentName', () => {
 
   it('corrects a single typo against multi-letter aliases', () => {
     expect(resolveAgentName('clw')).toBe('openclaw'); // claw minus a letter
-    expect(resolveAgentName('roocod')).toBe('roo'); // roocode minus a letter
   });
 
   it('returns null when the correction is ambiguous', () => {

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -2,7 +2,7 @@
  * Core agent configuration and detection module.
  *
  * Defines the canonical registry of all supported AI coding agents (Claude, Codex,
- * Gemini, Cursor, OpenCode, OpenClaw, Copilot, Amp, Kiro, Goose, Roo, Grok) with their
+ * Gemini, Cursor, OpenCode, OpenClaw, Copilot, Amp, Kiro, Goose, Grok) with their
  * CLI commands, config paths, capability flags, and MCP integration points.
  *
  * Provides functions for detecting installed CLIs, resolving version-managed binaries,
@@ -407,24 +407,6 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     variableSyntax: '$ARGUMENTS',
     supportsHooks: false,
     capabilities: { hooks: false, mcp: true, allowlist: false, skills: false, commands: false, plugins: false, subagents: false, rules: { file: 'AGENTS.md' }, workflows: false, modes: ['edit'] },
-  },
-  roo: {
-    id: 'roo',
-    name: 'Roo Code',
-    color: 'cyanBright',
-    cliCommand: 'roo',
-    npmPackage: '',
-    installScript: 'curl -fsSL https://raw.githubusercontent.com/RooCodeInc/Roo-Code/main/apps/cli/install.sh | sh',
-    configDir: path.join(HOME, '.roo'),
-    commandsDir: path.join(HOME, '.roo', 'commands'),
-    commandsSubdir: 'commands',
-    skillsDir: path.join(HOME, '.roo', 'skills'),
-    hooksDir: 'hooks',
-    instructionsFile: 'AGENTS.md',
-    format: 'markdown',
-    variableSyntax: '$ARGUMENTS',
-    supportsHooks: false,
-    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, subagents: false, rules: { file: 'AGENTS.md' }, workflows: false, modes: ['plan', 'edit'] },
   },
   // Google Antigravity CLI (`agy`) — official replacement for Gemini CLI as of IO 2026.
   // configDir nests inside `~/.gemini/` since agy shares the parent dir with the Gemini
@@ -1745,8 +1727,6 @@ export function getMcpConfigPathForHome(agentId: AgentId, home: string): string 
       return path.join(home, '.kiro', 'settings', 'mcp.json');
     case 'goose':
       return path.join(home, '.config', 'goose', 'config.yaml');
-    case 'roo':
-      return path.join(home, '.roo', 'mcp.json');
     case 'antigravity':
       return path.join(home, '.gemini', 'antigravity-cli', 'mcp_config.json');
     case 'grok':
@@ -1784,8 +1764,6 @@ function getProjectMcpConfigPath(agentId: AgentId, cwd: string = process.cwd()):
       return path.join(cwd, '.kiro', 'settings', 'mcp.json');
     case 'goose':
       return path.join(cwd, '.goose', 'config.yaml');
-    case 'roo':
-      return path.join(cwd, '.roo', 'mcp.json');
     case 'antigravity':
       return path.join(cwd, '.gemini', 'antigravity-cli', 'mcp_config.json');
     case 'grok':
@@ -1937,9 +1915,6 @@ export const AGENT_NAME_ALIASES: Record<string, AgentId> = {
   'kiro-cli': 'kiro',
   goose: 'goose',
   'block-goose': 'goose',
-  roo: 'roo',
-  'roo-code': 'roo',
-  roocode: 'roo',
   antigravity: 'antigravity',
   'google-antigravity': 'antigravity',
   agy: 'antigravity',

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -474,15 +474,6 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
       edit: [],
     },
   },
-  roo: {
-    base: ['roo'],
-    promptFlag: 'positional',
-    modeFlags: {
-      plan: ['--mode', 'architect'],
-      edit: ['--mode', 'code'],
-    },
-    modelFlag: '--model',
-  },
   // TODO: --output-format json is documented but currently broken upstream
   // ("flags provided but not defined: -output-format"). Track resolution at
   // https://github.com/google-antigravity/antigravity-cli/issues/7 before

--- a/src/lib/fuzzy.test.ts
+++ b/src/lib/fuzzy.test.ts
@@ -39,7 +39,7 @@ describe('damerauLevenshtein', () => {
 });
 
 describe('fuzzyMatch', () => {
-  const agents = ['claude', 'codex', 'gemini', 'cursor', 'opencode', 'openclaw', 'copilot', 'amp', 'kiro', 'goose', 'roo', 'antigravity', 'grok'];
+  const agents = ['claude', 'codex', 'gemini', 'cursor', 'opencode', 'openclaw', 'copilot', 'amp', 'kiro', 'goose', 'antigravity', 'grok'];
 
   it('returns null for exact matches (fuzzy is for non-exact)', () => {
     expect(fuzzyMatch('claude', agents, FUZZY_PRESETS.agents)).toBeNull();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,7 +9,7 @@
 import type { CloudProviderId } from './cloud/types.js';
 
 /** Unique identifier for a supported AI coding agent. */
-export type AgentId = 'claude' | 'codex' | 'gemini' | 'cursor' | 'opencode' | 'openclaw' | 'copilot' | 'amp' | 'kiro' | 'goose' | 'roo' | 'antigravity' | 'grok' | 'kimi' | 'droid';
+export type AgentId = 'claude' | 'codex' | 'gemini' | 'cursor' | 'opencode' | 'openclaw' | 'copilot' | 'amp' | 'kiro' | 'goose' | 'antigravity' | 'grok' | 'kimi' | 'droid';
 
 /** How `agents run <agent>` chooses an installed version when none is pinned. */
 export type RunStrategy = 'pinned' | 'available' | 'balanced';

--- a/tests/fixtures/cli-command-spec.json
+++ b/tests/fixtures/cli-command-spec.json
@@ -207,23 +207,6 @@
     "registry_divergence": "agents-cli registry has commandsSubdir='commands' for kiro; per docs Kiro uses skills/ only — no commands/ directory."
   },
 
-  "roo": {
-    "supported": true,
-    "docs": {
-      "url": "https://docs.roocode.com/features/slash-commands",
-      "quote_path": "Commands are markdown files stored in .roo/commands/ directories",
-      "quote_priority": "project > global > built-in"
-    },
-    "formats": [
-      {
-        "kind": "markdown-flat",
-        "path_template": "{HOME}/.roo/commands/{name}.md",
-        "frontmatter": { "required": [], "optional": ["description","argument-hint","mode"] },
-        "name_from": "filename-lowercase-dashes"
-      }
-    ]
-  },
-
   "antigravity": {
     "supported": true,
     "docs": {


### PR DESCRIPTION
## Why

Roo Code's upstream repo ([RooCodeInc/Roo-Code](https://github.com/RooCodeInc/Roo-Code)) was **archived and made read-only on 2026-05-15** (`gh api` → `"archived": true`). No further releases; it never shipped a hooks or plugin system. Keeping a dead harness in the registry is drift — it surfaces in `agents add`, fuzzy resolution, and the capability matrix for something no user should install.

## What

Removes the `roo` harness end-to-end:

- `src/lib/agents.ts` — drop the `roo` `AgentConfig`, the two mcp-path `case 'roo'` branches, and the `roo`/`roo-code`/`roocode` alias-map entries
- `src/lib/types.ts` — remove `'roo'` from the `AgentId` union (15 → 14)
- `src/lib/exec.ts` — remove the roo exec base-command entry
- `src/commands/import.ts`, `src/commands/rules.ts` — drop roo from help text
- `src/lib/acp/harnesses.ts` — drop roo from the ACP comments
- `src/lib/fuzzy.test.ts`, `src/lib/agents.test.ts` — remove roo fuzzy/alias cases
- `tests/fixtures/cli-command-spec.json` — remove the roo conformance entry
- `AGENTS.md` — 15 → 14 harnesses, drop the Roo Code matrix row

## Verification

- `tsc --noEmit` clean.
- Change-relevant unit tests (agents, fuzzy, capabilities, import, exec) pass 57/57 in isolation.
- `cli-command-sync-spec` conformance passes (roo fixture removed).
- Full-suite failure count on this branch (688) is **lower** than the pristine `origin/main` baseline (718) measured in the same local env — the mass failures are pre-existing integration tests needing real binaries/network (spawn-`ENOENT`, sandbox, teams), unaffected by this change. CI is the clean-room gate.
