### PR TITLE
ci: run the full cross-platform matrix at release time only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,20 @@
 name: CI
 
+# The cross-platform build matrix is EXPENSIVE (macOS is billed 10x, Windows 2x
+# on GitHub-hosted runners) and largely redundant per-PR: every PR to main
+# already runs the real suite cheaply on Linux via `test` (sandbox.yml) plus
+# `gitleaks` (secret-scan.yml). So the full matrix runs only where a green
+# cross-platform picture actually matters — release/** branches and v* tags —
+# plus manual dispatch. It does NOT run on main pushes/PRs. The release flow
+# (scripts/release.sh) opens each release as a chore PR on a release/v<version>
+# branch, which fires this workflow before the release is merged + published.
 on:
   push:
-    branches: ['main', 'release/**']
+    branches: ['release/**']
     tags: ['v*']
   pull_request:
-    branches: ['main', 'release/**']
+    branches: ['release/**']
+  workflow_dispatch:
 
 jobs:
   build:
@@ -18,9 +27,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [22, 24]
-    # All three OSes gate merges. Windows is now green and required alongside
-    # Linux and macOS — no leg is allowed to fail (was: continue-on-error on
-    # windows-latest while the native-Windows gaps were brought up).
+    # Runs pre-release only (release/** branches + v* tags + manual dispatch),
+    # so this is the last cross-platform gate before a version ships. None of
+    # these legs are required on main PRs — the main-protection ruleset gates
+    # merges on the cheap `test` + `gitleaks` checks instead.
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ src/
 bun install && bun run build && bun test
 ```
 
-Tests are `*.test.ts` next to source; integration in `tests/`. CI runs Node 22 + 24 on every PR ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)).
+Tests are `*.test.ts` next to source; integration in `tests/`. Every PR to `main` runs the real suite cheaply on Linux — `test` ([`sandbox.yml`](.github/workflows/sandbox.yml)) plus `gitleaks` ([`secret-scan.yml`](.github/workflows/secret-scan.yml)); those two are the required checks. The full cross-platform matrix (ubuntu + macOS + Windows × Node 22/24, [`ci.yml`](.github/workflows/ci.yml)) is cost-gated to `release/**` branches and `v*` tags (plus manual dispatch), so it runs before a release, not on every PR.
 
 **Local dev build:** `scripts/install.sh --skip-tests` builds the working tree and installs at `$HOME/.local/agents-cli-dev/`, symlinked into `$HOME/.local/bin/agents`. The npm-installed global is never touched. Version stamps as `0.0.0-dev.<sha>[-dirty]` so `agents --version` disambiguates which build is on PATH.
 


### PR DESCRIPTION
## Why
The `ci.yml` build matrix (ubuntu/macOS/Windows × node 22/24) ran on **every** push/PR to `main`. macOS (10×) and Windows (2×) are billed GitHub-hosted runners, and agents merge into `main` at a high pace — so per-PR cross-platform builds were burning real money for little marginal signal.

That matrix is largely **redundant per-PR**: every PR to main already runs the real suite cheaply on Linux via the `test` check (`sandbox.yml`: `bun install && bun run build && bun run test`) plus `gitleaks` (`secret-scan.yml`).

## What
- **`ci.yml` triggers** narrowed to `release/**` branches + `v*` tags + `workflow_dispatch`. Dropped `main`. The matrix itself is unchanged — full cross-platform coverage still runs, just where it matters: the last gate before a version ships.
- **Ruleset `main-protection` (already applied)** now requires only `test` + `gitleaks`. The four `build (ubuntu/macos-latest, 22|24)` contexts no longer run on main PRs, so leaving them required would hang every PR. Windows was never in the required set (the old "Windows is required" comment was stale — now fixed).
- **`AGENTS.md`** updated to describe the new split.

## How the release flow uses this
`scripts/release.sh` (separate follow-up PR) will open each release as a chore PR on a `release/v<version>` branch — that branch push fires this workflow, so the full matrix runs and is verified green before the release is merged + published.

## Verification
- This PR's own checks should show only `test`, `gitleaks` (+ `bench`) — no `build (…)` legs — and be mergeable under the updated ruleset.
- After merge: pushing a `release/**` branch or a `v*` tag fires the full 6-way matrix; main PRs do not.