### PR TITLE
release: gate publishing behind a CI-green release PR

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,17 +2,23 @@
 #
 # Release script for agents-cli.
 #
-# Publishes a single version to TWO npm packages:
-#   1. @phnx-labs/agents-cli  -- the canonical package (real code)
-#   2. @companion/agents-cli   -- legacy shim that re-exports @phnx-labs
+# Publishes @phnx-labs/agents-cli (the canonical package) to npm. The legacy
+# @swarmify/agents-cli shim is built + previewed for reference but NOT published
+# (frozen at 1.19.x since v1.20.0).
 #
-# The shim keeps existing @companion installs auto-updating into the new code.
+# Flow (--apply): open the release as a chore(release) PR on a release/v<version>
+# branch -- which fires the full cross-platform CI matrix (.github/workflows/
+# ci.yml) plus the test + gitleaks checks -- wait for that CI to go green,
+# squash-merge the PR, verify the merged tree matches what we built, then tag
+# v<version> at the merge commit and npm-publish locally (publishing must stay on
+# macOS because the tarball bundles the signed + notarized keychain helper).
 #
 # Usage: scripts/release.sh <version> [--apply]
 #
-# Default mode is DRY-RUN: every check runs (type-check, build, tests, tarball
-# preview) but no publish, commit, tag, or push happens. Add --apply to
-# actually release.
+# Default mode is DRY-RUN: every local check runs (type-check, build, tarball
+# preview) and the detected release state is reported, but nothing is pushed,
+# opened, merged, tagged, or published. Add --apply to actually release. Tests
+# run in CI on the release PR, not locally.
 #
 # Validates that <version> is a single-step bump from the current published
 # @phnx-labs latest -- patch+1, or minor+1 with patch=0, or major+1 with
@@ -58,7 +64,7 @@ done
 if $APPLY; then
   bold "Mode: APPLY (real publish)"
 else
-  yellow "Mode: DRY-RUN (no publish, no commit, no tag, no push -- pass --apply to actually release)"
+  yellow "Mode: DRY-RUN (no branch, PR, merge, tag, publish, or push -- pass --apply to actually release)"
 fi
 echo
 
@@ -67,18 +73,25 @@ command -v npm >/dev/null    || die "npm not found"
 command -v node >/dev/null   || die "node not found"
 command -v git >/dev/null    || die "git not found"
 command -v jq >/dev/null     || die "jq not found (brew install jq)"
+command -v gh >/dev/null      || die "gh (GitHub CLI) not found (brew install gh) -- needed to open + merge the release PR"
+gh auth status >/dev/null 2>&1 || die "gh is not authenticated -- run 'gh auth login'"
 
-# Working tree must be clean
+# Working tree must be clean. This is load-bearing: the release commit is built
+# straight from the index via 'git write-tree' (see the apply phase), so a dirty
+# tree would smuggle unrelated changes into the release PR + published tarball.
 if [[ -n "$(git status --porcelain)" ]]; then
   die "working tree is dirty -- commit or stash first"
 fi
 
-# Must be on main, up to date with origin
+# Resolve the default branch dynamically; must be on it and in sync with origin.
+git fetch --quiet origin
+DEFAULT_BRANCH="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+[[ -n "$DEFAULT_BRANCH" ]] || DEFAULT_BRANCH="main"
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-git fetch --quiet origin main
-LOCAL="$(git rev-parse HEAD)"
-REMOTE="$(git rev-parse origin/main)"
-[[ "$LOCAL" == "$REMOTE" ]] || die "main is not in sync with origin/main (run 'git push' first)"
+[[ "$BRANCH" == "$DEFAULT_BRANCH" ]] || die "not on $DEFAULT_BRANCH (on '$BRANCH') -- release runs from the default branch"
+BASE_SHA="$(git rev-parse HEAD)"
+REMOTE="$(git rev-parse "origin/$DEFAULT_BRANCH")"
+[[ "$BASE_SHA" == "$REMOTE" ]] || die "$DEFAULT_BRANCH is not in sync with origin/$DEFAULT_BRANCH (run 'git push' first)"
 
 # ----- npm auth via token (skips 2FA OTP prompts) -----
 # Resolve NPM_TOKEN. Honor an env-supplied token first (lets CI and machines
@@ -270,39 +283,18 @@ fi
 rm -f "$BUILD_LOG"
 green "Build clean."
 
-# ----- Tests (remote, on crabbox) -----
-# The full suite runs on a leased crabbox VM, NOT locally: a release test run
-# freezes the mac for minutes and the box matches the Linux CI environment.
-# Publishing still happens here (the signed macOS keychain helper can only be
-# produced + notarized locally) -- only the test gate is offloaded. sandbox.sh
-# rsyncs this checkout to the box and runs the suite there. TASK_ID pins a
-# stable remote workspace so re-runs of the same release reuse it.
+# ----- Tests: run in CI on the release PR, not here -----
+# The suite is no longer run locally / on crabbox at release time. The apply
+# phase opens the release as a PR on a release/v<version> branch, which triggers
+# the full cross-platform CI matrix (.github/workflows/ci.yml) plus the 'test'
+# and 'gitleaks' checks; the script blocks on that CI being green before it
+# merges and publishes (see "Wait for CI" below). Running the suite here too
+# would double-run it (a crabbox lease + minutes) and create a second source of
+# truth. Local 'tsc --noEmit' + 'bun run build' above stay as the fast pre-PR
+# fail-fast (and the build is needed for the tarball preview + publish anyway).
+# --skip-tests is accepted for backward compatibility but is now a no-op.
 if $SKIP_TESTS; then
-  yellow "Skipping tests (--skip-tests)"
-else
-  # pipefail is on, so a failure in the remote run propagates through the pipe.
-  # We tee the streamed output so a developer can scroll back through any
-  # individual failure; the log is also scanned for silent unhandled errors.
-  bold "Running tests on crabbox (scripts/sandbox.sh)..."
-  TEST_LOG="$(mktemp "${TMPDIR:-/tmp}/agents-cli-test.XXXXXX")"
-  # `bun run build` before test: crabbox's sync honors .gitignore, so the
-  # gitignored dist/ never reaches the box -- the integration tests that spawn
-  # a child importing dist/ need it built there. Matches ci.yml (Build->Test).
-  if ! TASK_ID="release-$TARGET" "$ROOT/scripts/sandbox.sh" "bun install && bun run build && bun run test" 2>&1 | tee "$TEST_LOG"; then
-    red "Tests failed (crabbox)."
-    rm -f "$TEST_LOG"
-    die "fix failing tests before releasing"
-  fi
-  # vitest sometimes prints "Unhandled error between tests" without failing
-  # the run. Catch that and treat it as a release blocker.
-  if grep -E 'Unhandled error|UnhandledPromiseRejection' "$TEST_LOG" >/dev/null 2>&1; then
-    red "test run had unhandled errors:"
-    grep -E 'Unhandled error|UnhandledPromiseRejection' "$TEST_LOG" >&2
-    rm -f "$TEST_LOG"
-    die "investigate the unhandled errors above before releasing"
-  fi
-  rm -f "$TEST_LOG"
-  green "Tests clean."
+  gray "(--skip-tests: tests run in CI on the release PR now; flag is a no-op)"
 fi
 echo
 
@@ -319,7 +311,13 @@ SHIM_TMP="$(mktemp -d "${TMPDIR:-/tmp}/agents-cli-shim.XXXXXX")"
 # package.json on abort). bash only keeps the most recent EXIT trap, so we
 # define a combined cleanup function.
 cleanup_all() {
-  restore_package_json
+  # Revert any working-tree edits to package.json / CHANGELOG.md back to HEAD so
+  # that an abort (or a dry-run exit) always leaves a clean, re-runnable
+  # checkout. HEAD never moves during a release (the release commit is pushed via
+  # commit-tree, and the merge lands on origin only), so HEAD is the pre-release
+  # state. The success path already restores these before exiting, making this a
+  # no-op there. Falls back to the jq revert if git checkout is unavailable.
+  git checkout -q HEAD -- package.json CHANGELOG.md 2>/dev/null || restore_package_json
   rm -rf "${SHIM_TMP:-}"
   rm -f "${NPMRC_TMP:-}"
 }
@@ -360,89 +358,207 @@ bold "Tarball preview ($SWARMIFY_PKG@$TARGET shim)"
 ( cd "$SHIM_TMP" && npm pack --dry-run 2>&1 | tail -10 )
 echo
 
+# ----- Detect prior-run state (for idempotent re-runs + dry-run reporting) -----
+# Everything keys off external truth (npm registry + git + open PRs), never off
+# local commit subjects, so a half-finished release re-runs cleanly.
+RELEASE_BRANCH="release/v$TARGET"
+MAIN_AT_TARGET=false
+if [[ "$(git show "origin/$DEFAULT_BRANCH:package.json" 2>/dev/null | jq -r .version 2>/dev/null || echo '')" == "$TARGET" ]]; then
+  MAIN_AT_TARGET=true   # a prior run already merged the chore(release) PR
+fi
+EXISTING_PR="$(gh pr list --head "$RELEASE_BRANCH" --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+
 # ----- Bail out here in DRY-RUN mode -----
 if ! $APPLY; then
-  green "Dry run looks good. Re-run with --apply to publish $TARGET to both packages."
+  green "Dry run looks good. Re-run with --apply to release $TARGET via a PR."
   echo
-  yellow "Will run on --apply (using NPM_TOKEN from npmjs.com bundle, no 2FA prompts):"
-  yellow "  1. git commit -m 'chore(release): $TARGET'  (skipped if HEAD already is)"
-  yellow "  2. git tag v$TARGET                          (skipped if tag exists)"
-  yellow "  3. npm publish $PHNX_PKG@$TARGET             (skipped if already on registry)"
-  yellow "  4. npm publish $SWARMIFY_PKG@$TARGET shim    (skipped if already on registry)"
-  yellow "  5. git push origin main + tag"
+  bold "Detected state:"
+  gray "  default branch            $DEFAULT_BRANCH @ ${BASE_SHA:0:9}"
+  gray "  $PHNX_PKG@$TARGET on npm     $($PHNX_TARGET_PUBLISHED && echo yes || echo no)"
+  gray "  origin/$DEFAULT_BRANCH at $TARGET   $($MAIN_AT_TARGET && echo yes || echo no)"
+  gray "  open release PR           ${EXISTING_PR:-none} ($RELEASE_BRANCH)"
+  echo
+  yellow "Will run on --apply (NPM_TOKEN from npmjs.com bundle, no 2FA prompts):"
+  yellow "  1. roll CHANGELOG '## Unreleased' -> '## $TARGET'"
+  yellow "  2. push branch $RELEASE_BRANCH (chore(release): $TARGET) -> fires the full CI matrix"
+  yellow "  3. open a PR into $DEFAULT_BRANCH"
+  yellow "  4. wait for CI green (matrix + test + gitleaks), fail-closed"
+  yellow "  5. squash-merge the PR"
+  yellow "  6. verify merged tree == built tree, tag v$TARGET at the merge commit"
+  yellow "  7. npm publish $PHNX_PKG@$TARGET, push the tag"
+  gray   "  (steps already done in a prior run are skipped: published / merged / PR-open / tag-exists)"
   exit 0
 fi
 
 # ----- Confirmation (--apply only) -----
 if ! $YES; then
-  read -r -p "Publish $TARGET to BOTH $PHNX_PKG and $SWARMIFY_PKG? [y/N] " yn
+  read -r -p "Release $TARGET via a PR into $DEFAULT_BRANCH, then publish $PHNX_PKG? [y/N] " yn
   [[ "$yn" =~ ^[Yy]$ ]] || die "aborted"
 fi
 
-# Past this point we want to keep the bumped package.json, since we're
-# committing it. Disable the auto-revert.
+# Auto-revert of the package.json bump is no longer wanted here — the bump is
+# carried into the release branch commit (and the cleanup trap reverts the
+# working tree to HEAD on any abort, keeping re-runs clean).
 PKG_BUMPED=false
 
-# ----- Roll the changelog: promote "## Unreleased" -> "## $TARGET" -----
-# Without this, every release leaves its notes stranded under "Unreleased" and
-# the section grows across releases with no per-version headers. Only fires when
-# the Unreleased section actually has content, so a notes-less release can't
-# create an empty version header.
-if [[ -f CHANGELOG.md ]]; then
-  unrel_content="$(awk '/^## Unreleased[[:space:]]*$/{f=1;next} f&&/^## /{exit} f&&/[^[:space:]]/{print}' CHANGELOG.md)"
-  if [[ -n "$unrel_content" ]]; then
-    tmp_cl="$(mktemp)"
-    awk -v ver="$TARGET" '
-      ins { print; next }
-      seen && /^## / { print; ins=1; seen=0; next }
-      seen && /[^[:space:]]/ { print "## " ver; print ""; print; ins=1; seen=0; next }
-      seen { print; next }
-      /^## Unreleased[[:space:]]*$/ { print; seen=1; next }
-      { print }
-    ' CHANGELOG.md > "$tmp_cl"
-    mv "$tmp_cl" CHANGELOG.md
-    git add CHANGELOG.md
-    green "Rolled CHANGELOG: ## Unreleased -> ## $TARGET"
-  else
-    gray "CHANGELOG: no Unreleased content to roll"
-  fi
-fi
-
-# ----- Commit (idempotent on package.json diff alone) -----
-git add package.json
-if ! git diff --cached --quiet; then
-  git commit -m "chore(release): $TARGET"
-  green "Created release commit"
-else
-  gray "package.json already at $TARGET, no commit needed"
-fi
-
-# ----- Tag at HEAD (idempotent on tag presence) -----
-if git rev-parse --verify --quiet "refs/tags/v$TARGET" >/dev/null; then
-  gray "Tag v$TARGET already exists, leaving alone"
-else
-  git tag "v$TARGET"
-  green "Created tag v$TARGET at HEAD ($(git rev-parse --short HEAD))"
-fi
-
-# ----- Publish @phnx-labs (skip if pre-flight saw it on registry) -----
-bold "Publishing $PHNX_PKG@$TARGET..."
+# ----- Short-circuit: already published -----
+# Registry is the source of truth. If the version is live, the release happened;
+# just make sure the tag exists on the merged commit and is pushed.
 if $PHNX_TARGET_PUBLISHED; then
-  yellow "$PHNX_PKG@$TARGET is already on the registry, skipping publish"
-elif ! npm publish --access=public --provenance=false; then
-  red "publish failed for $PHNX_PKG"
-  red "the version commit and tag remain locally; rerun: $0 $TARGET --apply"
-  exit 1
-else
-  green "Published $PHNX_PKG@$TARGET"
+  green "$PHNX_PKG@$TARGET is already on the registry."
+  if ! git ls-remote --exit-code --tags origin "v$TARGET" >/dev/null 2>&1; then
+    git tag -f "v$TARGET" "origin/$DEFAULT_BRANCH" >/dev/null
+    git push origin "v$TARGET" && green "Pushed missing tag v$TARGET"
+  else
+    gray "Tag v$TARGET already on origin, nothing to do."
+  fi
+  exit 0
 fi
+
+# ----- Wait for CI to go green on a PR (fail-closed) -----
+# gh pr checks --watch can exit 0 on an empty/partial check set right after the
+# push, so this brackets the watch with a readiness poll and a final re-assert
+# that every expected context is present AND passed. It waits on the WHOLE
+# matrix (incl. windows, which the main ruleset does not require) because the
+# whole point is a green cross-platform picture before we publish.
+EXPECTED_CHECKS=(test gitleaks \
+  "build (ubuntu-latest, 22)" "build (ubuntu-latest, 24)" \
+  "build (macos-latest, 22)"  "build (macos-latest, 24)" \
+  "build (windows-latest, 22)" "build (windows-latest, 24)")
+wait_for_ci_green() {
+  local pr="$1" names ctx b results problem=0
+  bold "Waiting for CI checks to register on PR #$pr..."
+  local deadline=$(( $(date +%s) + 600 ))
+  while :; do
+    names="$(gh pr checks "$pr" --json name --jq '.[].name' 2>/dev/null || true)"
+    local missing=0
+    for ctx in "${EXPECTED_CHECKS[@]}"; do grep -qxF "$ctx" <<<"$names" || { missing=1; break; }; done
+    [[ "$missing" == 0 ]] && break
+    (( $(date +%s) > deadline )) && { yellow "Timed out waiting for all checks to register; watching what did."; break; }
+    sleep 10
+  done
+  bold "Watching CI to completion (this waits on the full matrix)..."
+  gh pr checks "$pr" --watch --interval 20 >/dev/null 2>&1 || true
+  results="$(gh pr checks "$pr" --json name,bucket 2>/dev/null || echo '[]')"
+  for ctx in "${EXPECTED_CHECKS[@]}"; do
+    b="$(jq -r --arg n "$ctx" 'map(select(.name==$n)) | (.[0].bucket // "missing")' <<<"$results")"
+    [[ "$b" == "pass" ]] || { red "  $ctx: $b"; problem=1; }
+  done
+  (( problem == 0 )) || die "CI not all-green on PR #$pr -- PR left OPEN. Fix on a normal PR to $DEFAULT_BRANCH, then re-run this script."
+  green "CI all-green on PR #$pr."
+}
+
+# ----- Open (or reuse) the release PR + merge, unless already merged -----
+if ! $MAIN_AT_TARGET; then
+  # Roll the changelog: promote "## Unreleased" -> "## $TARGET". Only fires when
+  # the Unreleased section has content, so a notes-less release can't create an
+  # empty version header. The rolled notes become the PR body.
+  PR_BODY="Release $TARGET."
+  if [[ -f CHANGELOG.md ]]; then
+    unrel_content="$(awk '/^## Unreleased[[:space:]]*$/{f=1;next} f&&/^## /{exit} f&&/[^[:space:]]/{print}' CHANGELOG.md)"
+    if [[ -n "$unrel_content" ]]; then
+      tmp_cl="$(mktemp)"
+      awk -v ver="$TARGET" '
+        ins { print; next }
+        seen && /^## / { print; ins=1; seen=0; next }
+        seen && /[^[:space:]]/ { print "## " ver; print ""; print; ins=1; seen=0; next }
+        seen { print; next }
+        /^## Unreleased[[:space:]]*$/ { print; seen=1; next }
+        { print }
+      ' CHANGELOG.md > "$tmp_cl"
+      mv "$tmp_cl" CHANGELOG.md
+      green "Rolled CHANGELOG: ## Unreleased -> ## $TARGET"
+      PR_BODY="$(printf '## %s\n\n%s' "$TARGET" "$unrel_content")"
+    else
+      gray "CHANGELOG: no Unreleased content to roll"
+    fi
+  fi
+
+  # Build the release commit from the index WITHOUT moving HEAD. The signed +
+  # notarized macOS apps under bin/ are untracked, so we must build + publish
+  # from THIS checkout; a worktree off origin/main would fail prepack. write-tree
+  # is safe because the working tree is clean apart from our package.json +
+  # CHANGELOG edits (enforced by the clean-tree preflight).
+  git add package.json CHANGELOG.md
+  BRANCH_TREE="$(git write-tree)"
+  RELEASE_COMMIT="$(git commit-tree "$BRANCH_TREE" -p "$BASE_SHA" -m "chore(release): $TARGET")"
+
+  PR_NUMBER=""
+  if [[ -n "$EXISTING_PR" ]]; then
+    PR_NUMBER="$EXISTING_PR"
+    EXISTING_HEAD="$(gh pr view "$EXISTING_PR" --json headRefOid --jq .headRefOid 2>/dev/null || true)"
+    if [[ -n "$EXISTING_HEAD" && "$(git rev-parse "$EXISTING_HEAD^{tree}" 2>/dev/null || true)" == "$BRANCH_TREE" ]]; then
+      gray "Reusing open PR #$PR_NUMBER ($RELEASE_BRANCH); branch tree already matches."
+    else
+      git push --force-with-lease origin "$RELEASE_COMMIT:refs/heads/$RELEASE_BRANCH"
+      gray "Updated PR #$PR_NUMBER branch to the freshly built release commit."
+    fi
+  else
+    git push origin "$RELEASE_COMMIT:refs/heads/$RELEASE_BRANCH"
+    green "Pushed $RELEASE_BRANCH"
+  fi
+
+  # The branch commit now durably holds the bump + changelog; restore the working
+  # tree to clean so a CI-red abort leaves a re-runnable checkout.
+  git checkout -q HEAD -- package.json CHANGELOG.md
+
+  if [[ -z "$PR_NUMBER" ]]; then
+    PR_NUMBER="$(gh pr create --base "$DEFAULT_BRANCH" --head "$RELEASE_BRANCH" \
+      --title "chore(release): $TARGET" --body "$PR_BODY" | grep -oE '[0-9]+$' | tail -1)"
+    [[ -n "$PR_NUMBER" ]] || die "failed to open release PR for $RELEASE_BRANCH"
+    green "Opened release PR #$PR_NUMBER"
+  fi
+
+  wait_for_ci_green "$PR_NUMBER"
+
+  # Squash-merge. Never --admin: branch protection must hold, and the ruleset has
+  # no PR-review rule, so green test+gitleaks is a sufficient, non-bypass merge.
+  bold "Merging PR #$PR_NUMBER (squash)..."
+  gh pr merge "$PR_NUMBER" --squash --delete-branch || die "merge failed for PR #$PR_NUMBER (left open)"
+  green "Merged PR #$PR_NUMBER"
+fi
+
+# ----- Resolve the merged commit + integrity guards (before any publish) -----
+git fetch --quiet origin "$DEFAULT_BRANCH"
+MERGED_SHA="$(git rev-parse "origin/$DEFAULT_BRANCH")"
+MERGED_VER="$(git show "$MERGED_SHA:package.json" | jq -r .version)"
+[[ "$MERGED_VER" == "$TARGET" ]] || die "merged $DEFAULT_BRANCH is at $MERGED_VER, not $TARGET -- refusing to tag/publish"
+if [[ -n "${BRANCH_TREE:-}" ]]; then
+  # A single-commit squash onto an unchanged base yields a tree identical to what
+  # we built + published from. A mismatch means a concurrent merge or a stray
+  # push landed on the branch -- the local tarball would not match merged main.
+  [[ "$(git rev-parse "$MERGED_SHA^{tree}")" == "$BRANCH_TREE" ]] \
+    || die "merged tree != built tree -- refusing to publish (concurrent merge or stray push on $RELEASE_BRANCH)"
+fi
+
+# Bring the working-tree package.json/CHANGELOG to exactly the merged code so the
+# published tarball matches merged main. dist/ was already built from the same
+# source (base + bump) earlier and is unaffected.
+git checkout -q "$MERGED_SHA" -- package.json CHANGELOG.md
+
+# ----- Tag at the merged commit (idempotent) -----
+if git rev-parse --verify --quiet "refs/tags/v$TARGET" >/dev/null; then
+  gray "Tag v$TARGET already exists locally, leaving alone"
+else
+  git tag "v$TARGET" "$MERGED_SHA"
+  green "Created tag v$TARGET at $(git rev-parse --short "$MERGED_SHA")"
+fi
+
+# ----- Publish @phnx-labs -----
+bold "Publishing $PHNX_PKG@$TARGET..."
+if ! npm publish --access=public --provenance=false; then
+  red "publish failed for $PHNX_PKG"
+  red "the PR is merged and the tag exists locally; rerun to retry publish: $0 $TARGET --apply"
+  exit 1
+fi
+green "Published $PHNX_PKG@$TARGET"
 echo
 
 # @swarmify/agents-cli legacy shim no longer published as of v1.20.0.
 
-# ----- Push commit + tag -----
-bold "Pushing commit and tag to origin..."
-git push origin main
+# ----- Push the tag; restore the working tree to a clean state -----
 git push origin "v$TARGET"
+git checkout -q HEAD -- package.json CHANGELOG.md 2>/dev/null || true
 
-green "Released $TARGET to both packages"
+green "Released $TARGET"
+gray "Local $DEFAULT_BRANCH is behind origin by the release commit -- run: git pull --ff-only"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -415,33 +415,40 @@ if $PHNX_TARGET_PUBLISHED; then
   exit 0
 fi
 
-# ----- Wait for CI to go green on a PR (fail-closed) -----
-# gh pr checks --watch can exit 0 on an empty/partial check set right after the
-# push, so this brackets the watch with a readiness poll and a final re-assert
-# that every expected context is present AND passed. It waits on the WHOLE
-# matrix (incl. windows, which the main ruleset does not require) because the
-# whole point is a green cross-platform picture before we publish.
+# ----- Wait for CI to go green on a PR (bounded + fail-closed) -----
+# Poll `gh pr checks` on a hard deadline rather than `gh pr checks --watch`: the
+# watch is UNBOUNDED (a check that registers then stalls -- e.g. sandbox.yml's
+# self-hosted `test` runner offline -- would hang the release forever) and it can
+# exit 0 on a partial set. This loop waits until every expected context is
+# present AND terminal (capped at 60m), then re-asserts each is a pass and dies
+# otherwise. It waits on the WHOLE matrix (incl. windows, which the main ruleset
+# does not require) because the point is a green cross-platform picture before we
+# publish. NOTE: these names are the job/matrix labels of ci.yml (the build
+# matrix), sandbox.yml (test), and secret-scan.yml (gitleaks) -- a rename there
+# must be mirrored here, or the release times out (fail-closed, never publishes).
 EXPECTED_CHECKS=(test gitleaks \
   "build (ubuntu-latest, 22)" "build (ubuntu-latest, 24)" \
   "build (macos-latest, 22)"  "build (macos-latest, 24)" \
   "build (windows-latest, 22)" "build (windows-latest, 24)")
+check_bucket() { jq -r --arg n "$1" 'map(select(.name==$n)) | (.[0].bucket // "missing")' <<<"$2"; }
 wait_for_ci_green() {
-  local pr="$1" names ctx b results problem=0
-  bold "Waiting for CI checks to register on PR #$pr..."
-  local deadline=$(( $(date +%s) + 600 ))
+  local pr="$1" ctx b results problem=0
+  bold "Waiting for CI on PR #$pr (full matrix + test + gitleaks; up to 60m)..."
+  local deadline=$(( $(date +%s) + 3600 ))
   while :; do
-    names="$(gh pr checks "$pr" --json name --jq '.[].name' 2>/dev/null || true)"
-    local missing=0
-    for ctx in "${EXPECTED_CHECKS[@]}"; do grep -qxF "$ctx" <<<"$names" || { missing=1; break; }; done
-    [[ "$missing" == 0 ]] && break
-    (( $(date +%s) > deadline )) && { yellow "Timed out waiting for all checks to register; watching what did."; break; }
-    sleep 10
+    results="$(gh pr checks "$pr" --json name,bucket 2>/dev/null || echo '[]')"
+    local waiting=0
+    for ctx in "${EXPECTED_CHECKS[@]}"; do
+      b="$(check_bucket "$ctx" "$results")"
+      [[ "$b" == "missing" || "$b" == "pending" ]] && { waiting=1; break; }
+    done
+    (( waiting == 0 )) && break
+    (( $(date +%s) > deadline )) && { red "Timed out after 60m waiting for CI on PR #$pr."; break; }
+    sleep 20
   done
-  bold "Watching CI to completion (this waits on the full matrix)..."
-  gh pr checks "$pr" --watch --interval 20 >/dev/null 2>&1 || true
   results="$(gh pr checks "$pr" --json name,bucket 2>/dev/null || echo '[]')"
   for ctx in "${EXPECTED_CHECKS[@]}"; do
-    b="$(jq -r --arg n "$ctx" 'map(select(.name==$n)) | (.[0].bucket // "missing")' <<<"$results")"
+    b="$(check_bucket "$ctx" "$results")"
     [[ "$b" == "pass" ]] || { red "  $ctx: $b"; problem=1; }
   done
   (( problem == 0 )) || die "CI not all-green on PR #$pr -- PR left OPEN. Fix on a normal PR to $DEFAULT_BRANCH, then re-run this script."
@@ -494,7 +501,12 @@ if ! $MAIN_AT_TARGET; then
       gray "Updated PR #$PR_NUMBER branch to the freshly built release commit."
     fi
   else
-    git push origin "$RELEASE_COMMIT:refs/heads/$RELEASE_BRANCH"
+    # force-with-lease, not a plain push: a prior run may have left a stale
+    # release/v<version> branch with no open PR. RELEASE_COMMIT is a fresh
+    # commit-tree (a sibling of that stale tip, not a descendant), so a non-force
+    # push would be rejected non-fast-forward and brick the re-run. The lease is
+    # safe -- preflight fetched origin, so we only overwrite a ref we have seen.
+    git push --force-with-lease origin "$RELEASE_COMMIT:refs/heads/$RELEASE_BRANCH"
     green "Pushed $RELEASE_BRANCH"
   fi
 
@@ -503,9 +515,11 @@ if ! $MAIN_AT_TARGET; then
   git checkout -q HEAD -- package.json CHANGELOG.md
 
   if [[ -z "$PR_NUMBER" ]]; then
-    PR_NUMBER="$(gh pr create --base "$DEFAULT_BRANCH" --head "$RELEASE_BRANCH" \
-      --title "chore(release): $TARGET" --body "$PR_BODY" | grep -oE '[0-9]+$' | tail -1)"
-    [[ -n "$PR_NUMBER" ]] || die "failed to open release PR for $RELEASE_BRANCH"
+    gh pr create --base "$DEFAULT_BRANCH" --head "$RELEASE_BRANCH" \
+      --title "chore(release): $TARGET" --body "$PR_BODY" >/dev/null \
+      || die "failed to open release PR for $RELEASE_BRANCH"
+    PR_NUMBER="$(gh pr view "$RELEASE_BRANCH" --json number --jq .number 2>/dev/null || true)"
+    [[ -n "$PR_NUMBER" ]] || die "opened PR but could not resolve its number for $RELEASE_BRANCH"
     green "Opened release PR #$PR_NUMBER"
   fi
 


### PR DESCRIPTION
Depends conceptually on #536 (which gates the full CI matrix to `release/**` + tags). This rewires `scripts/release.sh` so a release **is** a `release/v<version>` PR — which fires that matrix — and only publishes after it's green.

## New `--apply` flow
1. Roll the CHANGELOG (`## Unreleased` → `## <version>`) and build the release commit with `git commit-tree` — **no HEAD move**. The signed+notarized macOS apps under `bin/` are untracked, so build+publish must run from this checkout (a worktree off origin/main would fail `prepack`).
2. Push `release/v<version>` (fires the full matrix) and open a PR into the default branch, with the rolled notes as the body.
3. **Wait fail-closed** for CI green: readiness poll (all 8 contexts registered) → `gh pr checks --watch` → re-assert every expected context is present **and** `bucket==pass` (the whole matrix incl. Windows). Any fail/pending/missing → abort, PR left open.
4. `gh pr merge --squash` (never `--admin`).
5. **Tree-identity guard:** `merged^{tree} == BRANCH_TREE` before publishing — catches a concurrent merge or stray push so the local tarball can't diverge from merged main.
6. Tag `v<version>` at the merge commit, `npm publish` locally, push the tag.

## Other changes
- Removes the local crabbox test gate (the release PR's CI runs the suite now); keeps local `tsc`+`build` as the pre-PR fail-fast.
- Preflight: `gh auth status` check; default branch resolved dynamically (no hardcoded `main`).
- Idempotent re-runs keyed on external truth (published / merged-not-published / PR-open / tag-exists). The cleanup trap reverts working-tree edits to HEAD on any abort, so a CI-red run stays re-runnable.
- Fixes stale header + dry-run text (publishes one package; the `@swarmify` shim is built for preview but not published since 1.20.0).

## Verification
- `bash -n` clean.
- Verified in a scratch repo: the `commit-tree` mechanic leaves HEAD unmoved; the tree-identity guard **passes** on a clean squash and **catches** a diverged tree; the CHANGELOG roll produces the correct output.
- Verified the `wait_for_ci_green` bucket parser blocks on a failing leg **and** on a missing check, and greenlights an all-pass set (ignoring extra checks like `bench`).
- **Not exercised here:** the live `npm publish` + `gh pr create/merge` path needs a real version bump on the macOS release machine (that's where releases run). Recommend a dry-run (`scripts/release.sh <next>`) there first — it's side-effect-free and prints the detected state + plan.