### PR TITLE
feat(view): surface Droid email + Kimi usage/id in agents view

### DIFF
--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -77,8 +77,24 @@ import { confirm } from '@inquirer/prompts';
 import { formatPath, isInteractiveTerminal, isPromptCancelled } from './utils.js';
 
 // Shown in the email column for agents that are signed in but expose no email
-// address locally (Antigravity, Kimi store an opaque OAuth/JWT credential).
+// address locally (Antigravity stores an opaque OAuth grant with no identity).
 const SIGNED_IN_LABEL = 'signed in';
+
+/**
+ * Text for the account (email) column. Prefers the real email; otherwise, for a
+ * signed-in agent whose credential carries no email but does carry an opaque
+ * account id (Kimi's user_id), show `id:<user_id>` so distinct accounts read
+ * distinctly instead of a generic "signed in". Falls back to "signed in" when we
+ * have neither (Antigravity), and empty when signed out.
+ */
+function accountColumnLabel(
+  info?: Pick<AccountInfo, 'email' | 'accountId' | 'signedIn'> | null
+): string {
+  if (!info) return '';
+  if (info.email) return info.email;
+  if (info.signedIn) return info.accountId ? `id:${info.accountId}` : SIGNED_IN_LABEL;
+  return '';
+}
 
 /**
  * Group profile summaries by their host harness, optionally filtered to a
@@ -395,7 +411,10 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
     if (!canon) return info;
     return {
       ...info,
-      plan: canon.plan,
+      // Prefer a plan the live usage fetch surfaced (Kimi reports membership
+      // tier in /usages; its local auth file has none) and fall back to the
+      // account-derived plan (Claude's billingType).
+      plan: usageByKey.get(key)?.snapshot?.plan ?? canon.plan,
       // Throttle state comes from the live usage windows, not the pay-as-you-go
       // overage flag that AccountInfo.usageStatus used to carry. A maxed window
       // means rate-limited; no snapshot means no badge. See
@@ -440,8 +459,8 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
         maxVerLabel = Math.max(maxVerLabel, label.length);
         const rawInfo = infoMap.get(`${agentId}:${v}`);
         const info = rawInfo ? mergeCanonical(rawInfo) : undefined;
-        if (info?.email) maxEmail = Math.max(maxEmail, info.email.length);
-        else if (info?.signedIn) maxEmail = Math.max(maxEmail, SIGNED_IN_LABEL.length);
+        const accountLabel = accountColumnLabel(info);
+        if (accountLabel) maxEmail = Math.max(maxEmail, accountLabel.length);
         if (info?.plan) maxPlanWidth = Math.max(maxPlanWidth, info.plan.length);
       }
       // Profile rows share these columns with version rows so they line up.
@@ -517,9 +536,10 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
           parts.push(chalk.gray('(not signed in — run ' + agent.cliCommand + ' to log in)'));
         } else {
           if (hasEmail || hasUsage || hasActive || signedIn) {
-            // Signed-in agents without a local email (Antigravity, Kimi) show a
-            // "signed in" placeholder so they read as logged in, not blank.
-            const display = vInfo?.email || (signedIn ? SIGNED_IN_LABEL : '');
+            // Signed-in agents without a local email show their account id
+            // (Kimi's user_id) or a "signed in" placeholder (Antigravity) so they
+            // read as logged in, not blank.
+            const display = accountColumnLabel(vInfo);
             const emailCol = display.padEnd(maxEmail);
             parts.push(display ? chalk.cyan(emailCol) : ' '.repeat(maxEmail));
           }
@@ -608,7 +628,7 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
       const gUsageStr = formatUsageSummary(gInfo?.plan || null, gUsage?.snapshot || null);
       const gActiveStr = gInfo ? formatLastActive(gInfo.lastActive) : '';
       if (gInfo?.email || gUsageStr || gActiveStr || gInfo?.signedIn) {
-        const gDisplay = gInfo?.email || (gInfo?.signedIn ? SIGNED_IN_LABEL : '');
+        const gDisplay = accountColumnLabel(gInfo);
         parts.push(gDisplay ? chalk.cyan(gDisplay) : '');
       }
       if (gUsageStr || gActiveStr) parts.push(gUsageStr);
@@ -915,13 +935,10 @@ async function showAgentResources(
       cliVersion: version,
       info: accountInfo,
     });
-    const emailStr = accountInfo.email
-      ? chalk.cyan(`  ${accountInfo.email}`)
-      : accountInfo.signedIn
-        ? chalk.cyan(`  ${SIGNED_IN_LABEL}`)
-        : '';
+    const accountLabel = accountColumnLabel(accountInfo);
+    const emailStr = accountLabel ? chalk.cyan(`  ${accountLabel}`) : '';
     const status = chalk.green(version);
-    const usageStr = formatUsageSummary(accountInfo.plan, null);
+    const usageStr = formatUsageSummary(usageInfo.snapshot?.plan ?? accountInfo.plan, null);
     const usagePart = usageStr ? `  ${usageStr}` : '';
     console.log(`  ${colorAgent(agentId)(AGENTS[agentId].name.padEnd(14))} ${status}${emailStr}${usagePart}`);
 
@@ -1067,6 +1084,9 @@ export interface ViewJsonVersion {
   isDefault: boolean;
   signedIn: boolean;
   email: string | null;
+  // Opaque account identifier when the credential exposes one but no email
+  // (Kimi's user_id). Optional for backward compatibility with older consumers.
+  accountId?: string | null;
   plan: string | null;
   usageStatus: 'available' | 'rate_limited' | 'out_of_credits' | null;
   // Optional so existing TypeScript consumers compiled against the prior
@@ -1307,7 +1327,10 @@ async function collectAgentsJson(filterAgentId?: AgentId, resourceSections?: Set
     if (!canon) return info;
     return {
       ...info,
-      plan: canon.plan,
+      // Prefer a plan the live usage fetch surfaced (Kimi reports membership
+      // tier in /usages; its local auth file has none) and fall back to the
+      // account-derived plan (Claude's billingType).
+      plan: usageByKey.get(key)?.snapshot?.plan ?? canon.plan,
       // Throttle state comes from the live usage windows, not the pay-as-you-go
       // overage flag that AccountInfo.usageStatus used to carry. A maxed window
       // means rate-limited; no snapshot means no badge. See
@@ -1330,6 +1353,7 @@ async function collectAgentsJson(filterAgentId?: AgentId, resourceSections?: Set
       isDefault: version === globalDefault,
       signedIn: info.signedIn,
       email: info.email,
+      accountId: info.accountId,
       plan: info.plan,
       usageStatus: info.usageStatus,
       overageCredits: info.overageCredits,

--- a/src/lib/__tests__/usage.test.ts
+++ b/src/lib/__tests__/usage.test.ts
@@ -15,6 +15,9 @@ import {
   readClaudeUsageCache,
   isClaudeUsageOrgMatch,
   writeClaudeUsageCache,
+  normalizeKimiWindows,
+  formatKimiPlan,
+  type KimiUsagesResponse,
   type UsageSnapshot,
   type UsageWindow,
 } from '../usage.js';
@@ -380,5 +383,49 @@ describe('Claude usage cache', () => {
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('normalizeKimiWindows', () => {
+  // A real /usages response body captured live from api.kimi.com. Numbers arrive
+  // as strings; the short limit is a 300-minute bucket, and `usage` is the
+  // rolling account quota.
+  const payload: KimiUsagesResponse = {
+    user: { userId: 'd483kfq783mkn8of1gtg', membership: { level: 'LEVEL_INTERMEDIATE' } },
+    usage: { limit: '100', used: '1', remaining: '99', resetTime: '2026-07-06T03:47:50.921944Z' },
+    limits: [
+      {
+        window: { duration: 300, timeUnit: 'TIME_UNIT_MINUTE' },
+        detail: { limit: '100', used: '4', remaining: '96', resetTime: '2026-07-01T13:47:50.921944Z' },
+      },
+    ],
+    subType: 'TYPE_PURCHASE',
+  };
+
+  it('maps the 300-minute limit to a session bar and the rolling quota to a week bar', () => {
+    const windows = normalizeKimiWindows(payload);
+    expect(windows.map((w) => w.shortLabel)).toEqual(['S', 'W']);
+    const session = windows.find((w) => w.key === 'session')!;
+    const week = windows.find((w) => w.key === 'week')!;
+    // used/limit as a percentage: 4/100 and 1/100.
+    expect(session.usedPercent).toBe(4);
+    expect(week.usedPercent).toBe(1);
+    // 300-minute window (TIME_UNIT_MINUTE) carries through as-is.
+    expect(session.windowMinutes).toBe(300);
+    expect(session.resetsAt?.toISOString()).toBe('2026-07-01T13:47:50.921Z');
+  });
+
+  it('drops a bucket with a zero or missing limit rather than dividing by zero', () => {
+    const windows = normalizeKimiWindows({
+      usage: { limit: '0', used: '5' },
+      limits: [{ detail: { used: '4' } }], // no limit
+    });
+    expect(windows).toEqual([]);
+  });
+
+  it('derives the plan label from the membership tier, falling back to subType', () => {
+    expect(formatKimiPlan(payload)).toBe('Intermediate');
+    expect(formatKimiPlan({ subType: 'TYPE_PURCHASE' })).toBe('Purchase');
+    expect(formatKimiPlan({})).toBeNull();
   });
 });

--- a/src/lib/agents.test.ts
+++ b/src/lib/agents.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as crypto from 'crypto';
 import { pathToFileURL } from 'url';
 import { spawnSync } from 'child_process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -343,6 +344,26 @@ function makeJwt(payload: Record<string, unknown>): string {
   return `${b64({ alg: 'ES256', typ: 'JWT' })}.${b64(payload)}.sig`;
 }
 
+// Write a Droid credential the way the CLI does: a JSON blob (with a WorkOS
+// access_token JWT) encrypted AES-256-GCM as `ivB64:tagB64:ctB64`, keyed by the
+// base64 contents of auth.v2.key. Uses real crypto — no mocking.
+function writeDroidCredential(dir: string, claims: Record<string, unknown>): void {
+  fs.mkdirSync(dir, { recursive: true });
+  const key = crypto.randomBytes(32);
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  const credential = JSON.stringify({
+    access_token: makeJwt(claims),
+    refresh_token: 'rt',
+    active_organization_id: 'org_local',
+  });
+  const ct = Buffer.concat([cipher.update(credential, 'utf-8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  const blob = [iv, tag, ct].map((b) => b.toString('base64')).join(':');
+  fs.writeFileSync(path.join(dir, 'auth.v2.file'), blob, 'utf-8');
+  fs.writeFileSync(path.join(dir, 'auth.v2.key'), key.toString('base64'), 'utf-8');
+}
+
 describe('getAccountInfo — token-only agents (no local email)', () => {
   // Sign-in is account-global: getAccountInfo falls back from the passed
   // per-version home to the active config under AGENTS_REAL_HOME. Pin that to a
@@ -429,12 +450,28 @@ describe('getAccountInfo — token-only agents (no local email)', () => {
     expect(info.signedIn).toBe(false);
   });
 
-  it('marks Droid signed in when ~/.factory/auth.v2.file is present', async () => {
+  it('decrypts auth.v2.file and surfaces the email + org from the WorkOS JWT', async () => {
+    const home = makeTempDir();
+    writeDroidCredential(path.join(home, '.factory'), {
+      email: 'muqsit@getrush.ai',
+      org_id: 'org_abc',
+      role: 'owner',
+      first_name: 'Muqsit',
+    });
+
+    const info = await getAccountInfo('droid', home);
+    expect(info.signedIn).toBe(true);
+    expect(info.email).toBe('muqsit@getrush.ai');
+    expect(info.organizationId).toBe('org_abc');
+    expect(info.accountKey).toBe('droid:org=org_abc');
+  });
+
+  it('falls back to signed-in with no email when the blob cannot be decrypted', async () => {
     const home = makeTempDir();
     const dir = path.join(home, '.factory');
     fs.mkdirSync(dir, { recursive: true });
-    // auth.v2.file is an opaque encrypted blob (paired with auth.v2.key); its
-    // mere presence is the signed-in signal — no email/JWT is readable locally.
+    // Garbage blob with no matching key file: decrypt fails, but the auth file's
+    // presence still reads as signed in (the conservative floor).
     fs.writeFileSync(path.join(dir, 'auth.v2.file'), 'opaque-encrypted-blob', 'utf-8');
 
     const info = await getAccountInfo('droid', home);

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -10,6 +10,7 @@
  */
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -861,6 +862,50 @@ function resolveAccountCredentialPath(base: string, ...segments: string[]): stri
   return null;
 }
 
+/**
+ * Factory Droid stores its OAuth credential encrypted at ~/.factory/auth.v2.file
+ * (AES-256-GCM, format `ivB64:tagB64:ctB64`) with the 32-byte key base64-stored
+ * in ~/.factory/auth.v2.key. On the keyfile-v2 source there is no OS-keychain /
+ * device binding — the key is on disk — so we can decrypt locally with no
+ * network call. The decrypted JSON credential's `access_token` is a WorkOS JWT
+ * carrying an `email` claim (plus org_id / role). We decode the claim WITHOUT
+ * verifying `exp`: the email is stable identity for display, not an
+ * authorization decision, so an expired token still yields the right address.
+ * Every failure (missing key file — e.g. a keyring-v2/legacy login with no
+ * on-disk key, a bad GCM tag, malformed JSON, or no email claim) returns null so
+ * the caller falls back to the file-presence signed-in signal. Never throws.
+ */
+function decryptDroidCredential(
+  base: string
+): { email: string | null; orgId: string | null; role: string | null } | null {
+  const filePath = resolveAccountCredentialPath(base, '.factory', 'auth.v2.file');
+  const keyPath = resolveAccountCredentialPath(base, '.factory', 'auth.v2.key');
+  if (!filePath || !keyPath) return null;
+  try {
+    const blob = fs.readFileSync(filePath, 'utf-8').trim();
+    const key = Buffer.from(fs.readFileSync(keyPath, 'utf-8').trim(), 'base64');
+    if (key.length !== 32) return null;
+    const [ivB64, tagB64, ctB64] = blob.split(':');
+    if (!ivB64 || !tagB64 || !ctB64) return null;
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, Buffer.from(ivB64, 'base64'));
+    decipher.setAuthTag(Buffer.from(tagB64, 'base64'));
+    const plaintext = Buffer.concat([
+      decipher.update(Buffer.from(ctB64, 'base64')),
+      decipher.final(),
+    ]).toString('utf-8');
+    const cred = JSON.parse(plaintext);
+    const claims = typeof cred?.access_token === 'string' ? decodeJwtPayload(cred.access_token) : null;
+    if (!claims) return null;
+    return {
+      email: typeof claims.email === 'string' ? claims.email : null,
+      orgId: normalizeIdentityPart(claims.org_id ?? cred.active_organization_id),
+      role: typeof claims.role === 'string' ? claims.role : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
 let cachedAgyKeychainSignedIn: boolean | undefined;
 
 /**
@@ -1096,12 +1141,29 @@ export async function getAccountInfo(
         return { ...empty, signedIn: true, accountId: userId, accountKey, lastActive };
       }
       case 'droid': {
-        // Factory Droid stores auth at ~/.factory/auth.v2.file (+ auth.v2.key,
-        // an encrypted blob). No email/JWT is readable locally, so presence of
-        // the auth file is the only signed-in signal we can derive without a
-        // network call — same pattern as antigravity/kimi. `.factory` is the
-        // config dir on every platform (macOS/Linux ~/.factory, Windows
-        // %USERPROFILE%\.factory), so path.join keeps this cross-platform.
+        // Factory Droid stores auth at ~/.factory/auth.v2.file (AES-256-GCM,
+        // decrypted with the on-disk ~/.factory/auth.v2.key). We decrypt locally
+        // — no network — and surface the email/org/role from the WorkOS
+        // access-token JWT, same as claude/codex/grok. If the credential can't be
+        // decrypted (a keyring-v2/legacy login with no on-disk key, or a decrypt
+        // failure) we fall back to the file-presence signed-in signal so the row
+        // still reads as logged in — the conservative floor antigravity/kimi use.
+        // `.factory` is the config dir on every platform (macOS/Linux
+        // ~/.factory, Windows %USERPROFILE%\.factory).
+        const decoded = decryptDroidCredential(base);
+        if (decoded?.email) {
+          const organizationId = decoded.orgId;
+          const accountKey = buildIdentityKey(agentId, [['org', organizationId]]);
+          return {
+            ...empty,
+            email: decoded.email,
+            organizationId,
+            accountId: organizationId,
+            accountKey,
+            signedIn: true,
+            lastActive,
+          };
+        }
         const authPath = resolveAccountCredentialPath(base, '.factory', 'auth.v2.file');
         if (!authPath) return { ...empty, lastActive };
         return { ...empty, signedIn: true, lastActive };

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -43,6 +43,8 @@ const CLAUDE_KEYCHAIN_SERVICE = 'Claude Code-credentials';
 const getClaudeUsageCachePath = () => path.join(getCacheDir(), 'claude-usage.json');
 const CACHED_CLAUDE_USAGE_SOURCE_LABEL = 'last seen live account data';
 
+const KIMI_USAGES_URL = 'https://api.kimi.com/coding/v1/usages';
+
 const COMPACT_BAR_LEN = 5;
 const USAGE_BAR_LEN = 10;
 const FULL = '\u2588';
@@ -67,6 +69,11 @@ export interface UsageSnapshot {
   sourceLabel: string;
   capturedAt: Date | null;
   windows: UsageWindow[];
+  // Subscription tier, when the usage source also reports it in the same
+  // response (Kimi's /usages returns membership.level). Account-level plan
+  // otherwise comes from the local auth file via AccountInfo.plan; this field
+  // lets a network usage fetch surface a plan the local credential can't.
+  plan?: string | null;
 }
 
 /** Usage data plus any error encountered while fetching. */
@@ -163,6 +170,7 @@ interface CachedUsageWindow {
 interface CachedUsageSnapshot {
   capturedAt: string | null;
   windows: CachedUsageWindow[];
+  plan?: string | null;
 }
 
 /** Parsed rate-limit data extracted from a Codex session file. */
@@ -178,6 +186,8 @@ export async function getUsageInfo(agentId: AgentId, options?: UsageOptions): Pr
       return getClaudeUsageInfo(options);
     case 'codex':
       return getCodexUsageInfo(options);
+    case 'kimi':
+      return getKimiUsageInfo(options);
     default:
       return { snapshot: null, error: null };
   }
@@ -269,8 +279,14 @@ const inFlightRefreshes = new Map<string, Promise<void>>();
 export async function getUsageInfoForIdentity(input: UsageIdentityInput): Promise<UsageInfo> {
   const usageKey = getUsageLookupKey(input.info);
 
-  // Non-Claude or no identity: legacy path, blocking fetch.
-  if (input.agentId !== 'claude' || !usageKey) {
+  // Agents whose usage comes from a live network call (Claude, Kimi) go through
+  // the stale-while-revalidate cache below so `agents run`/`agents view` stay off
+  // the network on the hot path. Everything else (Codex reads local session
+  // logs) takes the legacy blocking path. The on-disk cache is shared and keyed
+  // by usageKey, which is namespaced per agent (`claude:org=…`, `kimi:user=…`),
+  // so one cache file holds every account without collision.
+  const usesNetworkUsage = input.agentId === 'claude' || input.agentId === 'kimi';
+  if (!usesNetworkUsage || !usageKey) {
     return getUsageInfo(input.agentId, {
       home: input.home,
       cliVersion: input.cliVersion,
@@ -541,6 +557,186 @@ async function getClaudeUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
   } catch {
     return { snapshot: null, error: 'Usage data unavailable right now.' };
   }
+}
+
+/** Raw quota bucket from the Kimi /usages response (numbers arrive as strings). */
+interface KimiUsageQuota {
+  limit?: string | number | null;
+  used?: string | number | null;
+  remaining?: string | number | null;
+  resetTime?: string | null;
+}
+
+/** Response shape from the Kimi Code /usages endpoint (subset we render). */
+export interface KimiUsagesResponse {
+  user?: { userId?: string | null; membership?: { level?: string | null } | null } | null;
+  usage?: KimiUsageQuota | null;
+  limits?: Array<{
+    window?: { duration?: number | null; timeUnit?: string | null } | null;
+    detail?: KimiUsageQuota | null;
+  } | null> | null;
+  subType?: string | null;
+}
+
+/**
+ * Resolve Kimi's OAuth credential file. Sign-in is account-global but each
+ * installed version has an isolated home; the file physically lives only in the
+ * home the user logged in under. Check the per-version home first, then the
+ * active location under the real HOME — mirrors resolveAccountCredentialPath in
+ * agents.ts so every version reflects the true account state.
+ */
+function resolveKimiCredentialPath(home?: string): string | null {
+  const rel = ['.kimi-code', 'credentials', 'kimi-code.json'];
+  const perVersion = path.join(home || os.homedir(), ...rel);
+  try { if (fs.existsSync(perVersion)) return perVersion; } catch { /* unreadable */ }
+  const active = path.join(process.env.AGENTS_REAL_HOME || os.homedir(), ...rel);
+  if (active !== perVersion) {
+    try { if (fs.existsSync(active)) return active; } catch { /* unreadable */ }
+  }
+  return null;
+}
+
+/**
+ * Fetch Kimi usage via the Kimi Code /usages API. Kimi's JWT has no email
+ * claim, so the account row can't show an address — but /usages returns quota
+ * windows and the membership tier, which is what we render.
+ *
+ * Deliberately NO token refresh: `agents view` is a read/inspect command and
+ * must not rotate the user's Kimi OAuth credential (rewriting the file,
+ * invalidating the old refresh token, racing a concurrently-running kimi CLI).
+ * The kimi CLI refreshes on its own launch; if the stored token is expired we
+ * skip the live fetch and let the SWR cache serve the last-seen snapshot.
+ */
+async function getKimiUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
+  try {
+    const credPath = resolveKimiCredentialPath(options?.home);
+    if (!credPath) return { snapshot: null, error: null };
+
+    const cred = JSON.parse(fs.readFileSync(credPath, 'utf-8'));
+    const accessToken = cred?.access_token;
+    if (typeof accessToken !== 'string' || !accessToken) {
+      return { snapshot: null, error: null };
+    }
+
+    const expiresAt = typeof cred?.expires_at === 'number' ? cred.expires_at : null;
+    if (expiresAt !== null && Date.now() / 1000 >= expiresAt) {
+      return { snapshot: null, error: null };
+    }
+
+    const response = await fetch(KIMI_USAGES_URL, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(5000),
+    });
+
+    // 401/403/404 => expired token or no Kimi For Coding subscription; render
+    // nothing rather than a misleading empty bar.
+    if (!response.ok) {
+      return { snapshot: null, error: null };
+    }
+
+    const data = await response.json() as KimiUsagesResponse;
+    const windows = normalizeKimiWindows(data);
+    if (windows.length === 0) {
+      return { snapshot: null, error: null };
+    }
+
+    return {
+      snapshot: {
+        source: 'live',
+        sourceLabel: 'live account data',
+        capturedAt: new Date(),
+        windows,
+        plan: formatKimiPlan(data),
+      },
+      error: null,
+    };
+  } catch {
+    return { snapshot: null, error: null };
+  }
+}
+
+/** Normalize the Kimi /usages payload into the common UsageWindow shape. */
+export function normalizeKimiWindows(data: KimiUsagesResponse): UsageWindow[] {
+  const windows: UsageWindow[] = [];
+
+  // Per-window rate limit (e.g. a 300-minute bucket) -> "session".
+  const shortLimit = Array.isArray(data.limits)
+    ? data.limits.find((entry) => entry?.detail)
+    : null;
+  const session = normalizeKimiWindow(
+    shortLimit?.detail,
+    'session',
+    'Current session',
+    'S',
+    kimiWindowMinutes(shortLimit?.window)
+  );
+  if (session) windows.push(session);
+
+  // Rolling account quota -> "week".
+  const period = normalizeKimiWindow(data.usage, 'week', 'Current period', 'W', null);
+  if (period) windows.push(period);
+
+  return windows;
+}
+
+/** Normalize a single Kimi quota bucket (used/limit strings) into a UsageWindow. */
+function normalizeKimiWindow(
+  quota: KimiUsageQuota | null | undefined,
+  key: UsageWindowKey,
+  label: string,
+  shortLabel: string,
+  windowMinutes: number | null
+): UsageWindow | null {
+  const limit = kimiNumber(quota?.limit);
+  const used = kimiNumber(quota?.used);
+  if (limit === null || used === null || limit <= 0) return null;
+
+  const usedPercent = normalizePercent((used / limit) * 100);
+  if (usedPercent === null) return null;
+
+  return {
+    key,
+    label,
+    shortLabel,
+    usedPercent,
+    resetsAt: parseDateValue(quota?.resetTime),
+    windowMinutes: windowMinutes ?? inferWindowMinutes(key),
+  };
+}
+
+/** Parse a numeric field that Kimi serializes as a string (e.g. "100"). */
+function kimiNumber(value: string | number | null | undefined): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim() !== '' && !Number.isNaN(Number(value))) {
+    return Number(value);
+  }
+  return null;
+}
+
+/** Convert a Kimi limit window (duration + timeUnit enum) to minutes. */
+function kimiWindowMinutes(
+  window: { duration?: number | null; timeUnit?: string | null } | null | undefined
+): number | null {
+  const duration = typeof window?.duration === 'number' ? window.duration : null;
+  if (duration === null || duration <= 0) return null;
+  switch (window?.timeUnit) {
+    case 'TIME_UNIT_HOUR': return duration * 60;
+    case 'TIME_UNIT_SECOND': return duration / 60;
+    default: return duration; // TIME_UNIT_MINUTE or unknown -> minutes
+  }
+}
+
+/** Derive a display plan label from Kimi's membership tier or subscription type. */
+export function formatKimiPlan(data: KimiUsagesResponse): string | null {
+  const level = data.user?.membership?.level;
+  const raw = (typeof level === 'string' && level) || (typeof data.subType === 'string' && data.subType) || '';
+  const tail = raw.split('_').pop() || ''; // LEVEL_INTERMEDIATE -> INTERMEDIATE
+  if (!tail) return null;
+  return tail.charAt(0).toUpperCase() + tail.slice(1).toLowerCase();
 }
 
 /** Collect Codex JSONL session files sorted newest-first. */
@@ -824,6 +1020,7 @@ function writeClaudeUsageCacheFile(
 function serializeClaudeUsageSnapshot(snapshot: UsageSnapshot): CachedUsageSnapshot {
   return {
     capturedAt: snapshot.capturedAt?.toISOString() || null,
+    plan: snapshot.plan ?? null,
     windows: snapshot.windows.map((window) => ({
       key: window.key,
       label: window.label,
@@ -866,6 +1063,7 @@ function deserializeClaudeUsageSnapshot(
     sourceLabel: CACHED_CLAUDE_USAGE_SOURCE_LABEL,
     capturedAt,
     windows,
+    plan: snapshot.plan ?? null,
   };
 }
 


### PR DESCRIPTION
## Problem

In `agents view`, Codex/Grok show the signed-in account (email, plan, usage bars), but **Droid** and **Kimi** rendered only a bare `signed in` with no account — even when logged in. This was a data-availability gap, not a rendering bug: `getAccountInfo` is a local-only pass and neither agent's local credential *appeared* to carry an identity.

Research showed that's only half true, and the two agents are asymmetric:

- **Droid** — the credential *is* readable locally. `~/.factory/auth.v2.file` is AES-256-GCM (`ivB64:tagB64:ctB64`) with the 32-byte key on disk at `~/.factory/auth.v2.key` (no keychain/device binding for the keyfile-v2 source). The decrypted `access_token` is a WorkOS JWT carrying an `email` claim (+ org/role). Decryptable offline, even with an expired token.
- **Kimi** — email is impossible by any path (not in the JWT; no endpoint returns it). But `GET api.kimi.com/coding/v1/usages` returns quota windows + `membership.level`, and the JWT has an opaque `user_id`.

## Changes

**Droid email (local, no network)** — new `decryptDroidCredential` in `agents.ts` decrypts the credential and surfaces `email`/`org` from the JWT, so Droid rows show a real address like codex/grok. Falls back to the file-presence `signed in` signal when the blob can't be decrypted (keyring-v2/legacy logins) — no regression.

**Kimi usage bars + plan** — new `getKimiUsageInfo` fetches `/usages` through the same stale-while-revalidate path Claude uses (shared on-disk cache, keyed per-account). Renders S:/W: bars and the membership tier as the plan. **No token refresh**: `agents view` is read-only and must not rotate the user's OAuth credential or race the kimi CLI — an expired token falls back to cache.

**Kimi account id** — surface the opaque `user_id` as `id:<user_id>` in the account column (and `accountId` in `--json`) so distinct signed-in accounts without an email read distinctly. Antigravity (no email, no id) still shows `signed in`.

## Before → After (`agents view`, real accounts)

Before:
```
  Kimi (available) (no default)
    0.12.1             signed in
  Droid (available) (no default)
    0.161.0            signed in
    0.159.1            signed in
    0.158.0            signed in
```

After:
```
  Kimi (available)
    0.12.1 (default)   id:d483kfq783mkn8of1gtg  Intermediate  S: █░░░░ W: █░░░░
  Droid (available) (no default)
    0.161.0            muqsit@getrush.ai                                 10h ago
    0.159.1            muqsit@getrush.ai
    0.158.0            muqsit@getrush.ai
```

`--json` now carries the new fields:
```
kimi  0.12.1  email=null                 accountId=d483kfq783mkn8of1gtg  plan=Intermediate  windows=2
droid 0.161.0 email=muqsit@getrush.ai    accountId=org_01KPEDY…          plan=null          windows=0
```

## Tests

New coverage (real crypto / real captured payload, no mocking):
- `agents.test.ts` — Droid: decrypts a real AES-256-GCM fixture and asserts email/org; garbage blob falls back to `signed in`/no-email; missing file → signed out.
- `usage.test.ts` — Kimi: `normalizeKimiWindows` maps the 300-min limit → session bar and the rolling quota → week bar (used/limit %, window minutes, reset time); zero-limit bucket is dropped (no divide-by-zero); `formatKimiPlan` derives `Intermediate` from `LEVEL_INTERMEDIATE`, falls back to subType.

Full suite: **3410 passed / 56 skipped / 0 failed**. Typecheck clean. Verified end-to-end against real Droid + Kimi logins (output above).
