### PR TITLE
fix(browser): Windows Edge per-user path, tunnel-reuse, graceful kill

### DIFF
--- a/src/lib/browser/chrome.test.ts
+++ b/src/lib/browser/chrome.test.ts
@@ -51,6 +51,21 @@ describe('findFirstInstalledBrowser', () => {
     expect(result?.browserType).toBe('edge');
   });
 
+  it('auto-detects a per-user (Store) Edge install under LOCALAPPDATA', () => {
+    // Per-user / Microsoft Store Edge installs land in %LOCALAPPDATA%, not
+    // Program Files. Edge is the win32 default, so missing this candidate meant
+    // auto-detect silently failed on machines with only a per-user Edge.
+    const localAppData = process.env.LOCALAPPDATA || `${os.homedir()}\\AppData\\Local`;
+    presentPaths.add(`${localAppData}\\Microsoft\\Edge\\Application\\msedge.exe`);
+
+    const result = findFirstInstalledBrowser('win32');
+
+    expect(result).toEqual({
+      browserType: 'edge',
+      binary: `${localAppData}\\Microsoft\\Edge\\Application\\msedge.exe`,
+    });
+  });
+
   it('walks the Linux priority list (chrome > chromium > brave > edge)', () => {
     presentPaths.add('/usr/bin/chromium');
     presentPaths.add('/usr/bin/brave-browser');

--- a/src/lib/browser/chrome.ts
+++ b/src/lib/browser/chrome.ts
@@ -57,6 +57,7 @@ const BROWSER_PATHS: Record<string, Record<BrowserType, string[]>> = {
     edge: [
       `${WIN_PROGRAMFILES}\\Microsoft\\Edge\\Application\\msedge.exe`,
       `${WIN_PROGRAMFILES_X86}\\Microsoft\\Edge\\Application\\msedge.exe`,
+      `${WIN_LOCALAPPDATA}\\Microsoft\\Edge\\Application\\msedge.exe`,
     ],
     custom: [],
   },

--- a/src/lib/browser/chrome.ts
+++ b/src/lib/browser/chrome.ts
@@ -318,6 +318,23 @@ export async function attachToChrome(port: number): Promise<string> {
 }
 
 export function killChrome(pid: number): void {
+  if (process.platform === 'win32') {
+    // On Windows `process.kill(pid, 'SIGINT')` maps to TerminateProcess — a
+    // hard kill that skips Chromium's on-exit profile flush (leaving a dirty
+    // "Chrome didn't shut down correctly" state). Ask taskkill for a graceful
+    // stop first (no /F → posts WM_CLOSE), and only force-kill the tree if that
+    // fails or the process is still around.
+    try {
+      execFileSync('taskkill', ['/pid', String(pid)], { stdio: 'ignore' });
+    } catch {
+      try {
+        execFileSync('taskkill', ['/pid', String(pid), '/t', '/f'], { stdio: 'ignore' });
+      } catch {
+        // Process already dead
+      }
+    }
+    return;
+  }
   try {
     process.kill(pid, 'SIGINT');
   } catch {

--- a/src/lib/browser/drivers/ssh.test.ts
+++ b/src/lib/browser/drivers/ssh.test.ts
@@ -1,14 +1,23 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+
+// isOwnTunnel's win32 branch delegates to getPortOccupant; mock it so the test
+// exercises the branch logic without shelling out to netstat/tasklist.
+vi.mock('../chrome.js', () => ({ getPortOccupant: vi.fn() }));
+
 import {
   buildLaunchCmd,
   buildKillCmd,
   buildWindowsLaunchScript,
   buildWindowsKillScript,
   encodePowerShell,
+  isOwnTunnel,
 } from './ssh.js';
+import { getPortOccupant } from '../chrome.js';
+
+const mockedOccupant = vi.mocked(getPortOccupant);
 
 const here = dirname(fileURLToPath(import.meta.url));
 const sshSrc = readFileSync(join(here, 'ssh.ts'), 'utf8');
@@ -98,6 +107,50 @@ describe('buildLaunchCmd (posix)', () => {
   it('uses a custom binary path verbatim', () => {
     const cmd = buildLaunchCmd('posix', 'custom', 9222, '/opt/edge/edge');
     expect(cmd).toContain('/opt/edge/edge');
+  });
+});
+
+describe('isOwnTunnel (win32)', () => {
+  const realPlatform = process.platform;
+
+  function setPlatform(p: string) {
+    Object.defineProperty(process, 'platform', { value: p, configurable: true });
+  }
+
+  afterEach(() => {
+    setPlatform(realPlatform);
+    mockedOccupant.mockReset();
+  });
+
+  it('treats an ssh.exe holding our local port as our tunnel (ps is absent on Windows)', () => {
+    setPlatform('win32');
+    mockedOccupant.mockReturnValue({ pid: 4242, command: 'ssh.exe' });
+
+    expect(isOwnTunnel(4242, 'win-mini', 9222)).toBe(true);
+    // Verified via the netstat/tasklist occupant path against the local port
+    // (localPort === remotePort), not by shelling out to POSIX `ps`.
+    expect(mockedOccupant).toHaveBeenCalledWith(9222);
+  });
+
+  it('rejects a non-ssh occupant on our port', () => {
+    setPlatform('win32');
+    mockedOccupant.mockReturnValue({ pid: 4242, command: 'msedge.exe' });
+
+    expect(isOwnTunnel(4242, 'win-mini', 9222)).toBe(false);
+  });
+
+  it('rejects when the occupant pid does not match the one we found', () => {
+    setPlatform('win32');
+    mockedOccupant.mockReturnValue({ pid: 9999, command: 'ssh.exe' });
+
+    expect(isOwnTunnel(4242, 'win-mini', 9222)).toBe(false);
+  });
+
+  it('rejects when nothing occupies the port', () => {
+    setPlatform('win32');
+    mockedOccupant.mockReturnValue(null);
+
+    expect(isOwnTunnel(4242, 'win-mini', 9222)).toBe(false);
   });
 });
 

--- a/src/lib/browser/drivers/ssh.ts
+++ b/src/lib/browser/drivers/ssh.ts
@@ -363,8 +363,22 @@ function sleep(ms: number): Promise<void> {
  *
  * Best-effort match against the ssh -L command line via `ps`. If we
  * can't read the cmd or the args don't look like ours, treat as not-ours.
+ *
+ * Windows has no `ps`, so the POSIX branch below always throws there and every
+ * reuse check returned false — the second invocation to the same host:port then
+ * failed "port in use". On win32 we instead reuse the netstat -ano + tasklist
+ * occupant lookup (getPortOccupant): the tunnel binds `remotePort` locally
+ * (localPort === remotePort in the caller), so the pid holding that port is our
+ * ssh.exe. tasklist only exposes the image name, not the full command line, so
+ * we can't match host/remotePort as tightly as the POSIX branch — an ssh
+ * process on our exact local port is our tunnel in practice.
  */
-function isOwnTunnel(pid: number, host: string, remotePort: number): boolean {
+export function isOwnTunnel(pid: number, host: string, remotePort: number): boolean {
+  if (process.platform === 'win32') {
+    const occupant = getPortOccupant(remotePort);
+    if (!occupant || occupant.pid !== pid) return false;
+    return occupant.command.toLowerCase().startsWith('ssh');
+  }
   try {
     const out = execFileSync('ps', ['-p', String(pid), '-o', 'command='], {
       encoding: 'utf-8',


### PR DESCRIPTION
Three self-contained Windows bugs in browser detection + remote-drive.

## 1. Edge per-user install path missing
`edge:` candidate list only had Program Files + Program Files (x86); missing the per-user `%LOCALAPPDATA%` path that Chrome and Brave already include. Edge is the win32 auto-pick default (`win32: ['edge','chrome','brave']`, `src/lib/browser/chrome.ts:184`), so per-user / Microsoft Store Edge installs failed auto-detect.
- Fix: `src/lib/browser/chrome.ts:61` — added `${WIN_LOCALAPPDATA}\Microsoft\Edge\Application\msedge.exe`.

## 2. isOwnTunnel broken on Windows
`isOwnTunnel()` shelled out to POSIX `ps -p <pid> -o command=`. `ps` does not exist on Windows, so the catch always returned false and tunnel reuse never worked — the second invocation to the same host:port failed "port in use".
- Fix: `src/lib/browser/drivers/ssh.ts:367` — win32 branch reuses the existing `netstat -ano` + `tasklist` occupant lookup (`getPortOccupant()`, `src/lib/browser/chrome.ts:416`) to verify the pid holding the local port is an ssh process. POSIX keeps the `ps` command-line match. No new occupant-scan code.

## 3. killChrome not graceful on Windows
`killChrome()` sent SIGINT unconditionally; on Windows `process.kill(pid, 'SIGINT')` maps to TerminateProcess (hard kill, no profile flush → dirty-shutdown state).
- Fix: `src/lib/browser/chrome.ts:321` — win32 branch requests a graceful `taskkill /pid <pid>` (posts WM_CLOSE), falling back to `/t /f`. POSIX keeps SIGINT.

## Tests
- `src/lib/browser/chrome.test.ts` — auto-detects a per-user Edge install under LOCALAPPDATA.
- `src/lib/browser/drivers/ssh.test.ts` — win32 `isOwnTunnel` branch (mocks `process.platform` + `getPortOccupant`): ssh occupant → true; non-ssh occupant, pid mismatch, and empty port → false.

`bun run build && bun run test` green locally: 3420 passed, 47 skipped, 0 failed. The two touched test files run on the windows-latest CI leg.
