### PR TITLE
fix(secrets): complete Windows parity (exec shell, tty guard, multiline)

### DIFF
--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: secrets
-description: "Manage named bundles of environment variables backed by macOS Keychain. Create bundles, add secrets, generate passwords, and inject them into agent runs. Triggers on: 'API key', 'credentials', 'secrets bundle', 'inject env vars', '--secrets', 'keychain'."
+description: "Manage named bundles of environment variables backed by the OS keychain (macOS Keychain, Linux libsecret, Windows Credential Manager). Create bundles, add secrets, generate passwords, and inject them into agent runs. Triggers on: 'API key', 'credentials', 'secrets bundle', 'inject env vars', '--secrets', 'keychain', 'credential manager'."
 argument-hint: "[create|add|list|view|import|export|rotate|generate]"
 allowed-tools: Bash(agents secrets*)
 user-invocable: true
@@ -17,9 +17,11 @@ Store credentials in your OS keychain and inject them into agent runs. Nothing t
 | macOS | Keychain | Built-in |
 | Linux (desktop) | GNOME Keyring (libsecret) | `sudo apt install libsecret-tools` |
 | Linux (headless/server) | Use `env:` refs | See below |
-| Windows | Credential Manager (encrypted-file fallback) | Built-in |
+| Windows | Credential Manager (primary) + encrypted-file fallback | Built-in |
 
 **Desktop Linux:** GNOME Keyring (or another Secret Service provider) must be running. Most desktop environments start it automatically.
+
+**Headless Windows (service accounts, SSH with no interactive logon):** Credential Manager needs a logon session; without one it fails with `ERROR_NO_SUCH_LOGON_SESSION` (1312) and secrets transparently route to the AES-256-GCM encrypted-file store. Set `AGENTS_SECRETS_PASSPHRASE` so that store has an off-disk key — otherwise a machine-local key is provisioned next to the ciphertext.
 
 **Headless Linux (SSH, CI, containers):** No keyring daemon available. Use `env:` refs to pass secrets via environment:
 

--- a/src/commands/secrets.test.ts
+++ b/src/commands/secrets.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { assertValidSshTarget, bundleEnvToDotenv } from './secrets.js';
+import { assertValidSshTarget, bundleEnvToDotenv, quoteWin32ExecArg } from './secrets.js';
 import { parseDotenv } from '../lib/secrets/bundles.js';
 
 describe('assertValidSshTarget', () => {
@@ -47,5 +47,53 @@ describe('bundleEnvToDotenv', () => {
   it('rejects multi-line values instead of silently corrupting them', () => {
     expect(() => bundleEnvToDotenv({ KEY: 'line1\nline2' })).toThrow(/multi-line/);
     expect(() => bundleEnvToDotenv({ KEY: 'has\rcarriage' })).toThrow(/multi-line/);
+  });
+});
+
+// `agents secrets exec` spawns with shell:true on win32; cmd.exe does no quoting
+// of its own, so args must be quoted here or a spaced path splits into two args.
+describe('quoteWin32ExecArg', () => {
+  it('leaves simple args untouched', () => {
+    expect(quoteWin32ExecArg('npm')).toBe('npm');
+    expect(quoteWin32ExecArg('--version')).toBe('--version');
+    expect(quoteWin32ExecArg('sk-proj-AbC123_xyz.789')).toBe('sk-proj-AbC123_xyz.789');
+  });
+
+  it('quotes args containing spaces so they stay a single argument', () => {
+    expect(quoteWin32ExecArg('hello world')).toBe('"hello world"');
+    expect(quoteWin32ExecArg('C:\\Program Files\\node\\node.exe'))
+      .toBe('"C:\\Program Files\\node\\node.exe"');
+  });
+
+  it('quotes cmd metacharacters so the shell treats them literally', () => {
+    expect(quoteWin32ExecArg('a&b')).toBe('"a&b"');
+    expect(quoteWin32ExecArg('a|b')).toBe('"a|b"');
+    expect(quoteWin32ExecArg('a>b')).toBe('"a>b"');
+  });
+
+  it('escapes embedded double quotes (CommandLineToArgvW rules)', () => {
+    expect(quoteWin32ExecArg('say "hi"')).toBe('"say \\"hi\\""');
+  });
+
+  it('doubles a run of backslashes that precedes a quote', () => {
+    // a\"b -> the backslash before the quote is doubled, the quote escaped.
+    expect(quoteWin32ExecArg('a\\"b')).toBe('"a\\\\\\"b"');
+  });
+
+  it('doubles trailing backslashes before the closing quote (when quoting)', () => {
+    // Space forces quoting; the trailing backslash must be doubled so it does
+    // not escape the closing quote. Input `a b\` -> `"a b\\"`.
+    expect(quoteWin32ExecArg('a b\\')).toBe('"a b\\\\"');
+    // Interior backslashes NOT before a quote stay literal. Input `two\\ end`
+    // (2 backslashes) -> `"two\\ end"` (still 2).
+    expect(quoteWin32ExecArg('two\\\\ end')).toBe('"two\\\\ end"');
+  });
+
+  it('leaves a lone trailing backslash unquoted (no trigger char)', () => {
+    expect(quoteWin32ExecArg('ends\\')).toBe('ends\\');
+  });
+
+  it('turns an empty arg into an explicit ""', () => {
+    expect(quoteWin32ExecArg('')).toBe('""');
   });
 });

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -1379,8 +1379,17 @@ Examples:
           secretEnv = readAndResolveBundleEnv(bundleName, { caller: `command ${cmd}` }).env;
         }
         const { spawn } = await import('child_process');
-        const proc = spawn(cmd, args, {
+        // On Windows, spawn without a shell ENOENTs for `.cmd`/`.bat` launchers
+        // (npm, yarn, most JS CLIs) and shell built-ins — mirrors the win32
+        // branch in copyToClipboard below. With shell:true Node hands cmd.exe a
+        // single command line with NO quoting of its own, so args containing
+        // spaces or cmd metacharacters must be quoted here or they'd be split.
+        const useShell = process.platform === 'win32';
+        const spawnCmd = useShell ? quoteWin32ExecArg(cmd) : cmd;
+        const spawnArgs = useShell ? args.map(quoteWin32ExecArg) : args;
+        const proc = spawn(spawnCmd, spawnArgs, {
           stdio: 'inherit',
+          shell: useShell,
           env: { ...process.env, ...secretEnv },
         });
         proc.on('close', (code) => process.exit(code ?? 0));
@@ -1677,6 +1686,41 @@ function humanRemaining(expiresAt: number): string {
   if (hours < 24) return `locks in ${hours} hour${hours === 1 ? '' : 's'}`;
   const days = Math.round(hours / 24);
   return `locks in ${days} day${days === 1 ? '' : 's'}`;
+}
+
+/**
+ * Quote one argument for a Windows `cmd.exe` command line, as built by Node's
+ * `spawn(..., { shell: true })` on win32 (`agents secrets exec`). cmd.exe does
+ * NO quoting of its own, so an unquoted arg with a space is split into several
+ * args, and a cmd metacharacter (`&|<>()^`) would be interpreted by the shell.
+ * We wrap any arg with whitespace, a quote, or a metacharacter in double quotes
+ * — which also makes cmd treat the metacharacters literally — and escape
+ * embedded quotes / trailing backslashes per the CommandLineToArgvW rules so
+ * the child process reconstructs the exact original argv. An empty arg becomes
+ * `""`. Exported for tests. No-ops on non-Windows (the caller only invokes it
+ * under `process.platform === 'win32'`).
+ */
+export function quoteWin32ExecArg(arg: string): string {
+  if (arg.length > 0 && !/[\s"&|<>()^]/.test(arg)) return arg;
+  let result = '"';
+  let backslashes = 0;
+  for (const ch of arg) {
+    if (ch === '\\') {
+      backslashes += 1;
+      continue;
+    }
+    if (ch === '"') {
+      // Double the run of backslashes, then escape this quote.
+      result += '\\'.repeat(backslashes * 2 + 1) + '"';
+      backslashes = 0;
+      continue;
+    }
+    result += '\\'.repeat(backslashes) + ch;
+    backslashes = 0;
+  }
+  // Trailing backslashes precede the closing quote → must be doubled.
+  result += '\\'.repeat(backslashes * 2) + '"';
+  return result;
 }
 
 /**

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -1380,10 +1380,11 @@ Examples:
         }
         const { spawn } = await import('child_process');
         // On Windows, spawn without a shell ENOENTs for `.cmd`/`.bat` launchers
-        // (npm, yarn, most JS CLIs) and shell built-ins — mirrors the win32
-        // branch in copyToClipboard below. With shell:true Node hands cmd.exe a
-        // single command line with NO quoting of its own, so args containing
-        // spaces or cmd metacharacters must be quoted here or they'd be split.
+        // (npm, yarn, most JS CLIs) and shell built-ins, so we set shell:true.
+        // With shell:true Node hands cmd.exe a single command line with NO quoting
+        // of its own, so args containing spaces or cmd metacharacters must be
+        // quoted here (quoteWin32ExecArg) or they'd be split. See that helper for
+        // the cmd.exe %VAR%/!VAR! expansion caveat.
         const useShell = process.platform === 'win32';
         const spawnCmd = useShell ? quoteWin32ExecArg(cmd) : cmd;
         const spawnArgs = useShell ? args.map(quoteWin32ExecArg) : args;
@@ -1694,9 +1695,16 @@ function humanRemaining(expiresAt: number): string {
  * NO quoting of its own, so an unquoted arg with a space is split into several
  * args, and a cmd metacharacter (`&|<>()^`) would be interpreted by the shell.
  * We wrap any arg with whitespace, a quote, or a metacharacter in double quotes
- * — which also makes cmd treat the metacharacters literally — and escape
- * embedded quotes / trailing backslashes per the CommandLineToArgvW rules so
- * the child process reconstructs the exact original argv. An empty arg becomes
+ * and escape embedded quotes / trailing backslashes per the CommandLineToArgvW
+ * rules, so the *child's* argv parse reconstructs the original argument.
+ *
+ * CAVEAT: cmd.exe expands `%VAR%` (always) and `!VAR!` (under delayed expansion)
+ * BEFORE argv parsing, and double-quoting does NOT suppress `%`/`!` (the
+ * "BatBadBut" / CVE-2024-1874 class). We deliberately do not escape `%`/`!`:
+ * `agents secrets exec` runs a caller-supplied command against a bundle the
+ * caller owns, so caller-controlled `%`/`!` is not a privilege boundary. If that
+ * ever changes (exec'ing an untrusted command line), route through a shell that
+ * disables expansion rather than relying on this quoter. An empty arg becomes
  * `""`. Exported for tests. No-ops on non-Windows (the caller only invokes it
  * under `process.platform === 'win32'`).
  */

--- a/src/lib/secrets/filestore.test.ts
+++ b/src/lib/secrets/filestore.test.ts
@@ -10,10 +10,19 @@
  * per run, never one sitting next to the ciphertext.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+
+// Mock only spawnSync (the win32 TTY prompt path); keep execSync real so the
+// POSIX TTY branch and crypto still work. Same pattern as windows.test.ts:9-13.
+const { spawnSyncMock } = vi.hoisted(() => ({ spawnSyncMock: vi.fn() }));
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return { ...actual, spawnSync: spawnSyncMock };
+});
+
 import { fileStore, getPassphrase, _resetFileStoreForTest } from './filestore.js';
 
 describe('filestore passphrase policy (allowAutoProvision)', () => {
@@ -69,5 +78,58 @@ describe('filestore passphrase policy (allowAutoProvision)', () => {
     _resetFileStoreForTest({ fileDir: tmpDir });
     expect(() => fileStore.get('agents-cli.secrets.b.K', { allowAutoProvision: false }))
       .toThrow(/decrypt|passphrase/i);
+  });
+});
+
+// Windows has no /dev/tty; the interactive prompt must route through PowerShell
+// Read-Host instead of crashing with a raw ENOENT on fs.openSync('/dev/tty').
+describe('filestore win32 interactive passphrase branch', () => {
+  let tmpDir: string;
+  let prevTty: boolean | undefined;
+  let prevPlatform: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-filestore-win-'));
+    delete process.env.AGENTS_SECRETS_PASSPHRASE;
+    // Interactive (isTTY) + win32 so getPassphrase reaches the TTY prompt.
+    prevTty = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    prevPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    spawnSyncMock.mockReset();
+    _resetFileStoreForTest({ fileDir: tmpDir });
+  });
+
+  afterEach(() => {
+    delete process.env.AGENTS_SECRETS_PASSPHRASE;
+    Object.defineProperty(process.stdin, 'isTTY', { value: prevTty, configurable: true });
+    if (prevPlatform) Object.defineProperty(process, 'platform', prevPlatform);
+    spawnSyncMock.mockReset();
+    _resetFileStoreForTest();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reads the passphrase via PowerShell Read-Host, not /dev/tty', () => {
+    spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      expect(cmd).toBe('powershell.exe');
+      expect(args).toContain('-EncodedCommand');
+      // -NonInteractive would suppress Read-Host, so it must be absent.
+      expect(args).not.toContain('-NonInteractive');
+      return { status: 0, stdout: Buffer.from('typed-pass\r\n'), stderr: Buffer.from('') };
+    });
+    // Round-trips a value using the prompted passphrase (proves it flows through).
+    fileStore.set('agents-cli.secrets.b.K', 'sealed');
+    _resetFileStoreForTest({ fileDir: tmpDir });
+    spawnSyncMock.mockImplementation(() => ({
+      status: 0, stdout: Buffer.from('typed-pass\n'), stderr: Buffer.from(''),
+    }));
+    expect(fileStore.get('agents-cli.secrets.b.K')).toBe('sealed');
+  });
+
+  it('throws an actionable error (not ENOENT) when PowerShell cannot run', () => {
+    spawnSyncMock.mockImplementation(() => ({
+      status: 1, stdout: Buffer.from(''), stderr: Buffer.from(''), error: new Error('spawn ENOENT'),
+    }));
+    expect(() => getPassphrase()).toThrow(/AGENTS_SECRETS_PASSPHRASE/);
   });
 });

--- a/src/lib/secrets/filestore.ts
+++ b/src/lib/secrets/filestore.ts
@@ -21,12 +21,13 @@
  *   `agents-cli.bundles.<name>` and `agents-cli.secrets.<bundle>.<key>`.
  */
 
-import { execSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import type { KeychainBackend } from './index.js';
+import { encodePwshBase64 } from '../pwsh.js';
 
 // ---------- file store location ----------
 
@@ -44,7 +45,38 @@ function ensureFileDir(): void {
 
 // ---------- passphrase ----------
 
+/**
+ * Windows has no `/dev/tty` and no POSIX `stty`, so the interactive prompt runs
+ * through PowerShell's `Read-Host -AsSecureString` (which never echoes). The
+ * secure string is marshaled back out and written to stdout, which we capture.
+ * If PowerShell cannot run at all, fail with an actionable error rather than
+ * letting `fs.openSync('/dev/tty')` throw a raw ENOENT. Reached only on the rare
+ * interactive-Windows file-fallback path — the headless service-account case
+ * (no TTY) auto-provisions a machine-local key and never gets here.
+ */
+function readPassphraseFromTtyWindows(): string {
+  const script = `
+$ErrorActionPreference = 'Stop'
+$sec = Read-Host -AsSecureString -Prompt 'Enter AGENTS_SECRETS_PASSPHRASE'
+$ptr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($sec)
+try { [Console]::Out.Write([Runtime.InteropServices.Marshal]::PtrToStringBSTR($ptr)) }
+finally { [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ptr) }
+`;
+  // Not -NonInteractive: that flag would suppress the Read-Host prompt itself.
+  const res = spawnSync('powershell.exe', ['-NoProfile', '-EncodedCommand', encodePwshBase64(script)], {
+    stdio: ['inherit', 'pipe', 'inherit'],
+  });
+  if (res.error || res.status !== 0) {
+    throw new Error(
+      'Could not prompt for a passphrase on Windows. Set AGENTS_SECRETS_PASSPHRASE ' +
+      'to decrypt the file-backed secret store.'
+    );
+  }
+  return (res.stdout?.toString() ?? '').replace(/\r?\n$/, '');
+}
+
 function readPassphraseFromTty(): string {
+  if (process.platform === 'win32') return readPassphraseFromTtyWindows();
   const fd = fs.openSync('/dev/tty', 'r+');
   let echoDisabled = false;
   try {

--- a/src/lib/secrets/index.test.ts
+++ b/src/lib/secrets/index.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Tests for the platform-gated secret-value guard.
+ *
+ * The newline rejection exists ONLY to protect the macOS `get-batch` read path,
+ * which is newline-delimited (see getKeychainTokens). Windows Credential Manager
+ * (base64 blob) and the encrypted-file fallback store raw bytes and MUST accept
+ * multiline values (PEM / SSH keys), so the guard is darwin-only.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { assertValueStorable } from './index.js';
+
+describe('assertValueStorable', () => {
+  const multiline = '-----BEGIN KEY-----\nabc\ndef\n-----END KEY-----\n';
+
+  it('rejects empty / whitespace-only values on every platform', () => {
+    for (const platform of ['darwin', 'linux', 'win32'] as const) {
+      expect(() => assertValueStorable('', platform)).toThrow(/empty/i);
+      expect(() => assertValueStorable('   ', platform)).toThrow(/empty/i);
+    }
+  });
+
+  it('darwin still rejects embedded newlines (batch-read framing)', () => {
+    expect(() => assertValueStorable(multiline, 'darwin')).toThrow(/newline/i);
+    expect(() => assertValueStorable('a\rb', 'darwin')).toThrow(/newline/i);
+  });
+
+  it('darwin accepts single-line values', () => {
+    expect(() => assertValueStorable('sk-single-line-token', 'darwin')).not.toThrow();
+  });
+
+  it('win32 accepts multiline values (CredMan / file store are newline-safe)', () => {
+    expect(() => assertValueStorable(multiline, 'win32')).not.toThrow();
+  });
+
+  it('linux accepts multiline values (secret-tool / file store are newline-safe)', () => {
+    expect(() => assertValueStorable(multiline, 'linux')).not.toThrow();
+  });
+});

--- a/src/lib/secrets/index.ts
+++ b/src/lib/secrets/index.ts
@@ -88,6 +88,25 @@ function isWindows(): boolean {
   return process.platform === 'win32';
 }
 
+/**
+ * Guard a secret value before it is written to the current platform's primary
+ * backend.
+ *
+ * A value is empty on every platform → always rejected. Embedded newlines are
+ * rejected ONLY on darwin: the macOS batch read path (`get-batch`, see
+ * getKeychainTokens) is newline-delimited, so a value with a newline would
+ * corrupt record framing on read. Linux (secret-tool), Windows (Credential
+ * Manager stores the raw UTF-8 blob and emits base64), and the encrypted-file
+ * fallback all store raw bytes and round-trip multiline values (PEM / SSH keys)
+ * faithfully, so they accept newlines. `platform` is injectable for tests.
+ */
+export function assertValueStorable(value: string, platform: NodeJS.Platform = process.platform): void {
+  if (!value || !value.trim()) throw new Error('Secret value is empty.');
+  if (platform === 'darwin' && /[\r\n]/.test(value)) {
+    throw new Error('Secret value contains newlines, which are not supported.');
+  }
+}
+
 /** Build the keychain item name for a profile provider token. */
 export function profileKeychainItem(provider: string): string {
   return `${SERVICE_PREFIX}.${provider}.token`;
@@ -275,8 +294,7 @@ export function getKeychainTokens(items: string[]): Map<string, string> {
 export function setKeychainToken(item: string, value: string): void {
   if (backend) { backend.set(item, value); return; }
   assertSupportedPlatform();
-  if (!value || !value.trim()) throw new Error('Secret value is empty.');
-  if (/[\r\n]/.test(value)) throw new Error('Secret value contains newlines, which are not supported.');
+  assertValueStorable(value);
   if (/[\x00=\r\n]/.test(item)) throw new Error('Secret item name contains invalid characters.');
 
   if (isLinux()) { linuxBackend.set(item, value); return; }

--- a/src/lib/secrets/windows.test.ts
+++ b/src/lib/secrets/windows.test.ts
@@ -217,4 +217,19 @@ describe.skipIf(process.platform !== 'win32')('real Windows Credential Manager',
       expect(windowsBackend.has(item)).toBe(false);
     }
   });
+
+  it('round-trips a multiline value (PEM/SSH key) — CredMan stores raw bytes', async () => {
+    const cp = await vi.importActual<typeof import('child_process')>('child_process');
+    spawnSyncMock.mockImplementation((...a: any[]) => (cp.spawnSync as any)(...a));
+    _resetForTest({ forceAvailable: true });
+
+    const item = `agents-cli.secrets.wintest.ml.${Date.now()}`;
+    const value = '-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXk\nAAAA==\n-----END OPENSSH PRIVATE KEY-----\n';
+    try {
+      windowsBackend.set(item, value);
+      expect(windowsBackend.get(item)).toBe(value);
+    } finally {
+      expect(windowsBackend.delete(item)).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
Completes Windows `agents secrets` support to macOS/Linux parity, on top of the Credential Manager backend from #528. Four real gaps closed, each with tests.

## Fixes

1. **`secrets exec` shell dispatch** — `src/commands/secrets.ts:1382` spawned with no shell, ENOENTing on Windows for `.cmd`/`.bat` launchers (npm, yarn) and shell built-ins. Added `shell: process.platform === 'win32'` (mirrors the win32 branch in `copyToClipboard`, `src/commands/secrets.ts:1720`). Since cmd.exe does no quoting with `shell:true`, added `quoteWin32ExecArg` (`src/commands/secrets.ts:1683`) to wrap args with whitespace / cmd metacharacters / quotes per the CommandLineToArgvW rules, and quote both command + args before spawning.

2. **TTY passphrase prompt guard** — `readPassphraseFromTty` (`src/lib/secrets/filestore.ts:78`) opened `/dev/tty` + ran POSIX `stty` unconditionally, a raw ENOENT crash on Windows. Now branches on win32 to a PowerShell `Read-Host -AsSecureString` prompt (`readPassphraseFromTtyWindows`, `src/lib/secrets/filestore.ts:47`) using `encodePwshBase64` from `src/lib/pwsh.ts`; if PowerShell can't run, fails with an actionable `set AGENTS_SECRETS_PASSPHRASE` error instead of ENOENT.

3. **Scope the newline guard** — the newline rejection at `src/lib/secrets/index.ts:279` (old) blocked ALL multiline secrets, but exists only to protect the macOS `get-batch` newline-delimited read path (`getKeychainTokens`, `src/lib/secrets/index.ts:246-269`). Extracted into `assertValueStorable(value, platform)` (`src/lib/secrets/index.ts:91`) gated on darwin, so Windows CredMan (raw UTF-8 blob / base64 wire) and the encrypted-file fallback accept PEM / SSH keys. macOS path unchanged.

4. **Docs** — `skills/secrets/SKILL.md`: front-matter now names the OS keychain set incl. Credential Manager; Windows table row corrected to "Credential Manager (primary) + encrypted-file fallback"; added a headless-Windows note (service accounts, `ERROR_NO_SUCH_LOGON_SESSION` 1312 -> set `AGENTS_SECRETS_PASSPHRASE`).

## Tests

- `src/lib/secrets/index.test.ts` — `assertValueStorable` gating: win32/linux accept multiline, darwin still rejects, empty rejected everywhere (mocked platform).
- `src/lib/secrets/filestore.test.ts` — win32 TTY branch reads via mocked PowerShell (not `/dev/tty`); PowerShell failure yields the actionable error.
- `src/commands/secrets.test.ts` — `quoteWin32ExecArg` proves spaced/metacharacter/quote args survive quoting.
- `src/lib/secrets/windows.test.ts` — extended the `describe.skipIf(win32)` real CredMan round-trip with a multiline PEM set->get.

`bun run build` clean; full `bun run test` green (3430 passed, 48 skipped).