### PR TITLE
WIP: unified sync-status engine + `agents status` interactive reconcile

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -613,6 +613,12 @@ export function registerDoctorCommand(program: Command): void {
           return;
         }
         renderOverviewText(clis, syncRows, orphanRows, hostClis);
+        // Point at the interactive reconcile when anything is out of sync — the
+        // report shouldn't be a dead end. `agents status` runs the unified
+        // home-reading engine and offers to sync (opt-in, never auto-fires here).
+        if (syncRows.some((r) => r.status !== 'fresh')) {
+          console.log(chalk.gray('\nRun `agents status` to review and sync what has drifted.'));
+        }
         return;
       }
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,0 +1,98 @@
+/**
+ * `agents status` — the unified sync-status surface.
+ *
+ * One command that answers "is my fleet in sync?" the same way every other
+ * surface does, because it reads the same engine (computeSyncStatus). Human mode
+ * renders the summary and, when a TTY finds drift, offers the interactive
+ * "sync now?" flow (promptDriftSync). `--json` emits the stable UnifiedSyncStatus
+ * contract the menu-bar and Agency consume. `--yes` reconciles everything with no
+ * prompts (the "kick it" path, safe in scripts).
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { AGENTS } from '../lib/agents.js';
+import { AgentId } from '../lib/types.js';
+import { setHelpSections } from '../lib/help.js';
+import { computeSyncStatus, type AgentVersionStatus } from '../lib/sync-status.js';
+import { promptDriftSync } from '../lib/drift-sync.js';
+
+interface StatusOptions {
+  json?: boolean;
+  yes?: boolean;
+  cwd?: string;
+}
+
+const agentName = (id: AgentId): string => AGENTS[id]?.name ?? id;
+
+function versionSummary(v: AgentVersionStatus): string {
+  if (!v.everSynced) return chalk.gray('never synced');
+  if (v.needsSync) {
+    const bits: string[] = [];
+    if (v.counts.drifted) bits.push(`${v.counts.drifted} drifted`);
+    if (v.counts.missing) bits.push(`${v.counts.missing} missing`);
+    return chalk.yellow(bits.join(' · '));
+  }
+  return chalk.green('in sync');
+}
+
+export function registerStatusCommand(program: Command): void {
+  const cmd = program
+    .command('status')
+    .description('Unified sync status across the fleet — what is drifted, missing, or behind, with an option to sync it.')
+    .option('--json', 'Output the machine-readable UnifiedSyncStatus contract')
+    .option('--yes', 'Reconcile everything detected (pull .system if behind + sync drifted/missing resources) without prompting')
+    .option('--cwd <path>', 'Resolution cwd for project layer detection (default: process.cwd())');
+
+  setHelpSections(cmd, {
+    examples: `
+      # Show what's out of sync; offer to fix it (interactive)
+      agents status
+
+      # Machine-readable status for the menu-bar / Agency
+      agents status --json
+
+      # Reconcile everything with no prompts (CI / scripts / the "kick it" path)
+      agents status --yes
+    `,
+  });
+
+  cmd.action(async (opts: StatusOptions) => {
+    const cwd = opts.cwd ?? process.cwd();
+
+    if (opts.json) {
+      const status = await computeSyncStatus({ cwd });
+      console.log(JSON.stringify(status, null, 2));
+      return;
+    }
+
+    const status = await computeSyncStatus({ cwd });
+
+    // Human summary header (always) — the per-version readout.
+    console.log(chalk.bold('Fleet sync status'));
+    if (status.system.unknown) {
+      console.log(`  ${'.system repo'.padEnd(28)} ${chalk.gray('freshness unknown (no upstream)')}`);
+    } else if (status.system.behind > 0) {
+      console.log(
+        `  ${'.system repo'.padEnd(28)} ${chalk.yellow(`${status.system.behind} behind`)}`,
+      );
+    } else {
+      console.log(`  ${'.system repo'.padEnd(28)} ${chalk.green('up to date')}`);
+    }
+    if (status.agents.length === 0) {
+      console.log(chalk.gray('  (no installed agent versions)'));
+    }
+    for (const v of status.agents) {
+      const label = `${agentName(v.agent)}@${v.version}${v.isDefault ? chalk.gray(' (default)') : ''}`;
+      console.log(`  ${label.padEnd(28)} ${versionSummary(v)}`);
+    }
+    if (status.totals.orphan > 0) {
+      console.log(
+        chalk.gray(`  (${status.totals.orphan} orphan${status.totals.orphan === 1 ? '' : 's'} — run \`agents prune cleanup\`)`),
+      );
+    }
+
+    // Hand off to the shared interactive/apply flow (summary already printed above).
+    await promptDriftSync({ cwd, yes: opts.yes, status, quiet: true });
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1031,7 +1031,8 @@ if (!helpOrVersionRequested) {
   // fire-and-forget the next background sync. System repo gets a real fast-forward
   // pull (read-only locally, safe). User repo and extras get fetch-only + a
   // status marker that we'll print on the *next* invocation.
-  const { spawnDetachedSync } = await import('./lib/auto-pull.js');
+  const { spawnDetachedSync, printPendingUpdateNotices } = await import('./lib/auto-pull.js');
+  printPendingUpdateNotices();
   spawnDetachedSync();
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,7 @@ import {
   loadTrash,
   loadRestore,
   loadDoctor,
+  loadStatus,
   loadProfiles,
   loadSecrets,
   loadWallet,
@@ -890,6 +891,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadTrash);
   await reg(loadRestore);
   await reg(loadDoctor);
+  await reg(loadStatus);
   registerExecAliasCommand(program);
   await reg(loadProfiles);
   await reg(loadSecrets);

--- a/src/lib/__tests__/doctor-diff.test.ts
+++ b/src/lib/__tests__/doctor-diff.test.ts
@@ -3,6 +3,7 @@ import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { buildCommandSkillContent, commandSkillName } from '../command-skills.js';
 
 let testHome: string;
 let systemDir: string;
@@ -151,5 +152,50 @@ describe('diffVersionResources — rules', () => {
     const report2 = runDiff(projectDir, 'codex', '0.100.0', ['rules']);
     const agents2 = report2.kinds.rules.find((r) => r.name === 'AGENTS');
     expect(agents2?.status).toBe('ok');
+  });
+});
+
+describe('diffVersionResources — command-as-skill agents', () => {
+  // Kimi (and Codex >= 0.117, Grok) install commands as SKILL wrappers, not
+  // native command files. The diff must compare against the wrapper or it
+  // false-reports every command as drifted forever.
+  function installKimiCommandSkill(version: string, name: string, srcPath: string): void {
+    const agentDir = path.join(userDir, '.history', 'versions', 'kimi', version, 'home', '.kimi-code');
+    const skillDir = path.join(agentDir, 'skills', commandSkillName(name));
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), buildCommandSkillContent(name, srcPath));
+  }
+
+  it('reports ok when the installed command-skill matches source (not a false diff)', () => {
+    const srcCmds = path.join(userDir, 'commands');
+    fs.mkdirSync(srcCmds, { recursive: true });
+    const srcPath = path.join(srcCmds, 'foo.md');
+    fs.writeFileSync(srcPath, '# Foo\nrun foo\n');
+    installKimiCommandSkill('0.19.0', 'foo', srcPath);
+
+    const report = runDiff(projectDir, 'kimi', '0.19.0', ['commands']);
+    expect(report.kinds.commands.find((c) => c.name === 'foo')?.status).toBe('ok');
+  });
+
+  it('reports diff when the source changes after the command-skill was installed', () => {
+    const srcCmds = path.join(userDir, 'commands');
+    fs.mkdirSync(srcCmds, { recursive: true });
+    const srcPath = path.join(srcCmds, 'foo.md');
+    fs.writeFileSync(srcPath, '# Foo\nrun foo\n');
+    installKimiCommandSkill('0.19.0', 'foo', srcPath);
+    // Source changed after install — the wrapper no longer matches.
+    fs.writeFileSync(srcPath, '# Foo v2\nrun foo differently\n');
+
+    const report = runDiff(projectDir, 'kimi', '0.19.0', ['commands']);
+    expect(report.kinds.commands.find((c) => c.name === 'foo')?.status).toBe('diff');
+  });
+
+  it('does not report commands as missing for an agent that holds neither commands nor skills (goose)', () => {
+    fs.mkdirSync(path.join(userDir, 'commands'), { recursive: true });
+    fs.writeFileSync(path.join(userDir, 'commands', 'foo.md'), '# Foo\n');
+    fs.mkdirSync(path.join(userDir, '.history', 'versions', 'goose', '1.0.0', 'home'), { recursive: true });
+
+    const report = runDiff(projectDir, 'goose', '1.0.0', ['commands']);
+    expect(report.kinds.commands).toEqual([]);
   });
 });

--- a/src/lib/doctor-diff.ts
+++ b/src/lib/doctor-diff.ts
@@ -46,6 +46,8 @@ import { pluginInstallDir, repairableManifestFields } from './plugin-marketplace
 import { markdownToToml } from './convert.js';
 import { resolveImports, supportsRulesImports } from './rules/compile.js';
 import { listCommandsInVersionHome, getVersionCommandsDir } from './commands.js';
+import { shouldInstallCommandAsSkill, commandSkillMatches, commandSkillName } from './command-skills.js';
+import { supports } from './capabilities.js';
 import { listSkillsInVersionHome, getVersionSkillsDir } from './skills.js';
 import { listHooksInVersionHome, getVersionHooksDir, listHookEntriesFromDir } from './hooks.js';
 
@@ -162,6 +164,14 @@ function diffCommands(agent: AgentId, version: string, cwd: string, excludeProje
   const isToml = agentConfig.format === 'toml';
   const ext = isToml ? '.toml' : '.md';
   const homeDir = getVersionCommandsDir(agent, version);
+  // Command-as-skill agents (kimi, codex>=0.117, grok) install every command as a
+  // SKILL wrapper at <agentDir>/skills/<cmd>/SKILL.md, not a native command file.
+  // The compare must follow that or every command false-reports as drifted.
+  const asSkill = shouldInstallCommandAsSkill(agent, version);
+  // Agents that hold commands neither natively nor as skills (e.g. goose) must not
+  // report source commands as "missing" — they structurally can't take them.
+  if (!asSkill && !supports(agent, 'commands', version).ok) return [];
+  const agentDir = path.join(getVersionHomePath(agent, version), agentConfigDirName(agent));
   const installed = new Set(listCommandsInVersionHome(agent, version));
   const layerBases = buildLayerBases(cwd, 'commands', { excludeProject });
 
@@ -183,11 +193,24 @@ function diffCommands(agent: AgentId, version: string, cwd: string, excludeProje
 
   for (const [name, src] of sourceByName) {
     seen.add(name);
-    const homePath = path.join(homeDir, `${name}${ext}`);
     if (!installed.has(name)) {
       rows.push({ kind: 'commands', name, status: 'missing', source: src.layer, sourcePath: src.path });
       continue;
     }
+    if (asSkill) {
+      // Compare against the installed command-skill wrapper, not a native path.
+      const matches = commandSkillMatches(agentDir, name, src.path);
+      rows.push({
+        kind: 'commands',
+        name,
+        status: matches ? 'ok' : 'diff',
+        source: src.layer,
+        sourcePath: src.path,
+        homePath: path.join(agentDir, 'skills', commandSkillName(name), 'SKILL.md'),
+      });
+      continue;
+    }
+    const homePath = path.join(homeDir, `${name}${ext}`);
     const installedContent = readSafe(homePath);
     const sourceContent = readSafe(src.path);
     if (installedContent == null || sourceContent == null) {
@@ -208,7 +231,10 @@ function diffCommands(agent: AgentId, version: string, cwd: string, excludeProje
 
   for (const name of installed) {
     if (seen.has(name)) continue;
-    rows.push({ kind: 'commands', name, status: 'extra', homePath: path.join(homeDir, `${name}${ext}`) });
+    const extraHome = asSkill
+      ? path.join(agentDir, 'skills', commandSkillName(name), 'SKILL.md')
+      : path.join(homeDir, `${name}${ext}`);
+    rows.push({ kind: 'commands', name, status: 'extra', homePath: extraHome });
   }
 
   return rows.sort((a, b) => a.name.localeCompare(b.name));

--- a/src/lib/drift-sync.test.ts
+++ b/src/lib/drift-sync.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * End-to-end apply test for the drift-sync flow. The `yes` path must actually
+ * reconcile the version home: overwrite a drifted file with its source and
+ * install a missing one. No mocks — real heal, real file writes.
+ */
+
+let testHome: string;
+let userDir: string;
+let cmdsHome: string;
+let srcCmds: string;
+
+beforeEach(() => {
+  testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'drift-sync-test-'));
+  userDir = path.join(testHome, '.agents');
+  const versionDir = path.join(userDir, '.history', 'versions', 'claude', '2.0.0');
+  cmdsHome = path.join(versionDir, 'home', '.claude', 'commands');
+  srcCmds = path.join(userDir, 'commands');
+  fs.mkdirSync(cmdsHome, { recursive: true });
+  fs.mkdirSync(srcCmds, { recursive: true });
+  fs.mkdirSync(path.join(userDir, '.system'), { recursive: true });
+  const binDir = path.join(versionDir, 'node_modules', '.bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, 'claude'), '#!/bin/sh\n');
+  fs.writeFileSync(path.join(userDir, 'agents.yaml'), 'agents:\n  claude: "2.0.0"\n');
+});
+
+afterEach(() => {
+  fs.rmSync(testHome, { recursive: true, force: true });
+});
+
+function runYesApply(): { result: string; drifted: string; missingPresent: boolean; missing: string } {
+  const modulePath = path.resolve(process.cwd(), 'src/lib/drift-sync.ts');
+  const script = `
+    import { promptDriftSync } from ${JSON.stringify(modulePath)};
+    const r = await promptDriftSync({ cwd: ${JSON.stringify(userDir)}, yes: true, quiet: true });
+    console.error(JSON.stringify({ healedVersions: r.healed.length }));
+  `;
+  // heal resolves against the HOME dir; point HOME at the fixture.
+  execFileSync('bun', ['-e', script], {
+    cwd: process.cwd(),
+    env: { ...process.env, HOME: testHome },
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+  return {
+    result: '',
+    drifted: fs.readFileSync(path.join(cmdsHome, 'drifted.md'), 'utf-8'),
+    missingPresent: fs.existsSync(path.join(cmdsHome, 'missing.md')),
+    missing: fs.existsSync(path.join(cmdsHome, 'missing.md'))
+      ? fs.readFileSync(path.join(cmdsHome, 'missing.md'), 'utf-8')
+      : '',
+  };
+}
+
+describe('promptDriftSync --yes — apply path', () => {
+  it('overwrites a drifted resource with its source and installs a missing one', () => {
+    // source of truth
+    fs.writeFileSync(path.join(srcCmds, 'drifted.md'), 'ALPHA v2 (source of truth)\n');
+    fs.writeFileSync(path.join(srcCmds, 'missing.md'), 'GAMMA (new)\n');
+    // home: drifted has stale content, missing is absent
+    fs.writeFileSync(path.join(cmdsHome, 'drifted.md'), 'ALPHA v1 (stale)\n');
+
+    const after = runYesApply();
+
+    // drifted was reconciled to the source
+    expect(after.drifted.trim()).toBe('ALPHA v2 (source of truth)');
+    // missing was installed
+    expect(after.missingPresent).toBe(true);
+    expect(after.missing.trim()).toBe('GAMMA (new)');
+  });
+});

--- a/src/lib/drift-sync.ts
+++ b/src/lib/drift-sync.ts
@@ -1,0 +1,219 @@
+/**
+ * Interactive drift-sync flow — the single "we detected drift, want to fix it?"
+ * action, shared by `agents status`, `agents doctor`, and the menu-bar "NEEDS
+ * SYNC" row.
+ *
+ * It composes existing pieces, re-implementing nothing:
+ *   - computeSyncStatus()          — the unified detection engine (sync-status.ts)
+ *   - pullRepo()                   — fast-forward the `.system` repo (git.ts)
+ *   - promptAgentVersionSelection() — the "which agent types / versions?" picker
+ *   - heal({ mode: 'full' })       — the reconcile engine `doctor --fix` uses
+ *
+ * Combined flow (one confirmation): if `.system` is behind AND resources drifted,
+ * a single "Sync all detected" both pulls `.system` and reconciles the chosen
+ * version homes. The security posture is preserved — the `.system` pull only ever
+ * happens on an explicit user choice here, never silently (see auto-pull-worker.ts
+ * for why system auto-pull is off by default).
+ */
+
+import chalk from 'chalk';
+import { select, confirm } from '@inquirer/prompts';
+import { AgentId } from './types.js';
+import { AGENTS } from './agents.js';
+import { pullRepo } from './git.js';
+import { heal, type VersionHealResult } from './heal.js';
+import { promptAgentVersionSelection } from './versions.js';
+import { isInteractiveTerminal, isPromptCancelled } from '../commands/utils.js';
+import {
+  computeSyncStatus,
+  type UnifiedSyncStatus,
+  type AgentVersionStatus,
+} from './sync-status.js';
+
+export interface DriftSyncOptions {
+  cwd?: string;
+  /** Reconcile everything detected with no prompts — the "kick it" path, also the
+   * non-TTY / menu-bar-launched-with-flag behavior. Pulls `.system` if behind. */
+  yes?: boolean;
+  /** Pre-computed status, to avoid a second scan when the caller already has one. */
+  status?: UnifiedSyncStatus;
+  /** Skip the drift summary — set by callers that already printed their own. */
+  quiet?: boolean;
+}
+
+export interface DriftSyncResult {
+  systemBehindBefore: number;
+  systemPulled: boolean;
+  healed: VersionHealResult[];
+  /** True when the user declined at the prompt (nothing was changed). */
+  cancelled: boolean;
+  /** True when there was no drift to act on in the first place. */
+  nothingToDo: boolean;
+}
+
+const agentName = (id: AgentId): string => AGENTS[id]?.name ?? id;
+
+/** "claude@2.1.170  2 drifted · 1 missing" for one version. */
+function versionLine(v: AgentVersionStatus): string {
+  const bits: string[] = [];
+  if (v.counts.drifted) bits.push(`${v.counts.drifted} drifted`);
+  if (v.counts.missing) bits.push(`${v.counts.missing} missing`);
+  const label = `${agentName(v.agent)}@${v.version}`;
+  return `  ${label.padEnd(28)} ${chalk.yellow(bits.join(' · '))}`;
+}
+
+/** Render the drift summary (system freshness + each version owed a sync). */
+function renderSummary(status: UnifiedSyncStatus, needing: AgentVersionStatus[]): void {
+  console.log(chalk.bold('\nSync status'));
+  if (status.system.behind > 0) {
+    console.log(
+      `  ${'.system repo'.padEnd(28)} ${chalk.yellow(
+        `${status.system.behind} commit${status.system.behind === 1 ? '' : 's'} behind`,
+      )} ${chalk.gray('— pull recommended')}`,
+    );
+  }
+  for (const v of needing) console.log(versionLine(v));
+  if (status.totals.orphan > 0) {
+    console.log(
+      chalk.gray(`  (${status.totals.orphan} orphan${status.totals.orphan === 1 ? '' : 's'} — run \`agents prune cleanup\`)`),
+    );
+  }
+}
+
+/** Fast-forward the `.system` repo. Returns whether it actually moved. */
+async function pullSystem(status: UnifiedSyncStatus): Promise<boolean> {
+  if (status.system.behind <= 0) return false;
+  const res = await pullRepo(status.system.dir);
+  if (res.success) {
+    console.log(chalk.green(`Pulled .system (+${status.system.behind}).`));
+    return true;
+  }
+  console.log(chalk.red(`Could not pull .system: ${res.error ?? 'unknown error'}`));
+  return false;
+}
+
+/** Reconcile a set of versions grouped by agent via the shared heal engine. */
+async function healVersions(
+  versionsByAgent: Map<AgentId, string[]>,
+  cwd: string,
+): Promise<VersionHealResult[]> {
+  const out: VersionHealResult[] = [];
+  for (const [agent, versions] of versionsByAgent) {
+    if (versions.length === 0) continue;
+    const res = await heal({ mode: 'full', cwd, agent, versions });
+    out.push(...res.versions);
+  }
+  return out;
+}
+
+/** Report which agents received what after a heal. */
+function reportHealed(healed: VersionHealResult[]): void {
+  const touched = healed.filter((v) => v.healed.length > 0);
+  if (touched.length === 0) {
+    console.log(chalk.gray('Nothing to reconcile — homes already matched sources.'));
+    return;
+  }
+  const total = touched.reduce((n, v) => n + v.healed.length, 0);
+  const agents = [...new Set(touched.map((v) => agentName(v.agent)))].join(', ');
+  console.log(chalk.green(`Synced ${total} resource${total === 1 ? '' : 's'} to ${agents}.`));
+}
+
+function groupNeeding(needing: AgentVersionStatus[]): Map<AgentId, string[]> {
+  const m = new Map<AgentId, string[]>();
+  for (const v of needing) {
+    const list = m.get(v.agent) ?? [];
+    list.push(v.version);
+    m.set(v.agent, list);
+  }
+  return m;
+}
+
+/**
+ * The unified "drift detected — sync now?" flow. Returns a structured result so
+ * callers (menu-bar, doctor) can report without re-scanning.
+ */
+export async function promptDriftSync(opts: DriftSyncOptions = {}): Promise<DriftSyncResult> {
+  const cwd = opts.cwd ?? process.cwd();
+  const status = opts.status ?? (await computeSyncStatus({ cwd }));
+  const needing = status.agents.filter((a) => a.needsSync);
+  const systemBehind = status.system.behind;
+
+  const base: DriftSyncResult = {
+    systemBehindBefore: systemBehind,
+    systemPulled: false,
+    healed: [],
+    cancelled: false,
+    nothingToDo: false,
+  };
+
+  if (systemBehind <= 0 && needing.length === 0) {
+    console.log(chalk.green('Everything is in sync.'));
+    return { ...base, nothingToDo: true };
+  }
+
+  if (!opts.quiet) renderSummary(status, needing);
+
+  // Non-interactive OR explicit --yes: reconcile everything detected.
+  if (opts.yes || !isInteractiveTerminal()) {
+    if (!opts.yes) {
+      // Non-TTY without --yes: report, don't act, don't throw.
+      console.log(chalk.gray('\nRun `agents status --yes` to sync, or `agents status` in a terminal to choose.'));
+      return base;
+    }
+    const systemPulled = await pullSystem(status);
+    const healed = await healVersions(groupNeeding(needing), cwd);
+    reportHealed(healed);
+    return { ...base, systemPulled, healed };
+  }
+
+  // Interactive gate.
+  let choice: 'all' | 'choose' | 'no';
+  try {
+    choice = await select<'all' | 'choose' | 'no'>({
+      message: 'Sync now?',
+      choices: [
+        { name: 'Sync all detected', value: 'all' },
+        { name: 'Choose agents & resources', value: 'choose' },
+        { name: 'No', value: 'no' },
+      ],
+      default: 'all',
+    });
+  } catch (err) {
+    if (isPromptCancelled(err)) return { ...base, cancelled: true };
+    throw err;
+  }
+
+  if (choice === 'no') return { ...base, cancelled: true };
+
+  if (choice === 'all') {
+    const systemPulled = await pullSystem(status);
+    const healed = await healVersions(groupNeeding(needing), cwd);
+    reportHealed(healed);
+    return { ...base, systemPulled, healed };
+  }
+
+  // choice === 'choose': optional .system pull, then per-agent/version selection.
+  let systemPulled = false;
+  if (systemBehind > 0) {
+    try {
+      const pull = await confirm({ message: `Pull .system (${systemBehind} behind) first?`, default: true });
+      if (pull) systemPulled = await pullSystem(status);
+    } catch (err) {
+      if (!isPromptCancelled(err)) throw err;
+      return { ...base, systemPulled, cancelled: true };
+    }
+  }
+
+  const needingAgents = [...new Set(needing.map((a) => a.agent))];
+  let selection;
+  try {
+    selection = await promptAgentVersionSelection(needingAgents);
+  } catch (err) {
+    if (isPromptCancelled(err)) return { ...base, systemPulled, cancelled: true };
+    throw err;
+  }
+
+  const healed = await healVersions(selection.versionSelections, cwd);
+  reportHealed(healed);
+  return { ...base, systemPulled, healed };
+}

--- a/src/lib/startup/command-registry.ts
+++ b/src/lib/startup/command-registry.ts
@@ -55,6 +55,7 @@ export const loadPrune: ModuleLoader = async () => (await import('../../commands
 export const loadTrash: ModuleLoader = async () => (await import('../../commands/trash.js')).registerTrashCommands;
 export const loadRestore: ModuleLoader = async () => (await import('../../commands/trash.js')).registerRestoreCommand;
 export const loadDoctor: ModuleLoader = async () => (await import('../../commands/doctor.js')).registerDoctorCommand;
+export const loadStatus: ModuleLoader = async () => (await import('../../commands/status.js')).registerStatusCommand;
 export const loadProfiles: ModuleLoader = async () => (await import('../../commands/profiles.js')).registerProfilesCommands;
 export const loadSecrets: ModuleLoader = async () => (await import('../../commands/secrets.js')).registerSecretsCommands;
 export const loadWallet: ModuleLoader = async () => (await import('../../commands/wallet.js')).registerWalletCommands;
@@ -140,6 +141,7 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   trash: [loadTrash],
   restore: [loadRestore],
   doctor: [loadDoctor],
+  status: [loadStatus],
   profiles: [loadProfiles],
   secrets: [loadSecrets],
   wallet: [loadWallet],

--- a/src/lib/sync-status.test.ts
+++ b/src/lib/sync-status.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * Real-filesystem tests for the unified sync-status engine. No mocks: we build a
+ * temp HOME with a real version home + real sources, run computeSyncStatus in a
+ * subprocess with HOME pointed at the fixture, and assert the mapping.
+ *
+ * These target the exact bug class that motivated this module: a resource that
+ * was synced and then had its SOURCE changed must report `drifted`, not `synced`
+ * — the false-positive the old git-based `agents view` checkmark produced.
+ */
+
+let testHome: string;
+let userDir: string;
+let systemDir: string;
+let projectDir: string;
+
+beforeEach(() => {
+  testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sync-status-test-'));
+  userDir = path.join(testHome, '.agents');
+  systemDir = path.join(userDir, '.system');
+  projectDir = path.join(testHome, 'work');
+  fs.mkdirSync(userDir, { recursive: true });
+  fs.mkdirSync(systemDir, { recursive: true });
+  fs.mkdirSync(projectDir, { recursive: true });
+  // Keep the migrator from running on a missing legacy state.
+  fs.writeFileSync(path.join(userDir, 'agents.yaml'), 'agents:\n  claude: "2.0.0"\n');
+});
+
+afterEach(() => {
+  fs.rmSync(testHome, { recursive: true, force: true });
+});
+
+/** Create an installed claude version: home dirs + a binary so listInstalledVersions sees it. */
+function makeInstalledVersion(version: string): { home: string; cmdsHome: string } {
+  const versionDir = path.join(userDir, '.history', 'versions', 'claude', version);
+  const home = path.join(versionDir, 'home');
+  const cmdsHome = path.join(home, '.claude', 'commands');
+  fs.mkdirSync(cmdsHome, { recursive: true });
+  const binDir = path.join(versionDir, 'node_modules', '.bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, 'claude'), '#!/bin/sh\n');
+  return { home, cmdsHome };
+}
+
+interface Status {
+  system: { unknown: boolean; behind: number };
+  agents: Array<{
+    agent: string;
+    version: string;
+    everSynced: boolean;
+    needsSync: boolean;
+    counts: { synced: number; drifted: number; missing: number; orphan: number };
+    resources: Array<{ kind: string; name: string; status: string }>;
+  }>;
+  totals: { drifted: number; missing: number; orphan: number; versionsNeedingSync: number };
+}
+
+function runStatus(kinds?: string[]): Status {
+  const modulePath = path.resolve(process.cwd(), 'src/lib/sync-status.ts');
+  const script = `
+    import { computeSyncStatus } from ${JSON.stringify(modulePath)};
+    const r = await computeSyncStatus({
+      cwd: ${JSON.stringify(projectDir)},
+      agents: ['claude'],
+      kinds: ${kinds ? JSON.stringify(kinds) : 'undefined'},
+    });
+    console.log(JSON.stringify(r));
+  `;
+  const out = execFileSync('bun', ['-e', script], {
+    cwd: process.cwd(),
+    env: { ...process.env, HOME: testHome },
+    stdio: ['ignore', 'pipe', 'inherit'],
+  }).toString('utf-8');
+  return JSON.parse(out);
+}
+
+function statusOf(s: Status, name: string): string | undefined {
+  return s.agents[0]?.resources.find((r) => r.kind === 'commands' && r.name === name)?.status;
+}
+
+describe('computeSyncStatus — per-resource mapping', () => {
+  it('maps synced / drifted / missing / orphan against the real version home', () => {
+    const { cmdsHome } = makeInstalledVersion('2.0.0');
+    const srcCmds = path.join(userDir, 'commands');
+    fs.mkdirSync(srcCmds, { recursive: true });
+
+    // synced: source and home identical
+    fs.writeFileSync(path.join(srcCmds, 'a.md'), 'ALPHA\n');
+    fs.writeFileSync(path.join(cmdsHome, 'a.md'), 'ALPHA\n');
+    // drifted: THE key case — synced, then the source changed
+    fs.writeFileSync(path.join(srcCmds, 'b.md'), 'BETA v2 (changed)\n');
+    fs.writeFileSync(path.join(cmdsHome, 'b.md'), 'BETA v1\n');
+    // missing: source exists, nothing installed
+    fs.writeFileSync(path.join(srcCmds, 'c.md'), 'GAMMA\n');
+    // orphan: installed with no source
+    fs.writeFileSync(path.join(cmdsHome, 'orphan.md'), 'ORPHAN\n');
+
+    const s = runStatus(['commands']);
+
+    expect(statusOf(s, 'a')).toBe('synced');
+    expect(statusOf(s, 'b')).toBe('drifted'); // not a false "synced"
+    expect(statusOf(s, 'c')).toBe('missing');
+    expect(statusOf(s, 'orphan')).toBe('orphan');
+
+    expect(s.agents[0].counts).toEqual({ synced: 1, drifted: 1, missing: 1, orphan: 1 });
+    expect(s.agents[0].needsSync).toBe(true);
+    expect(s.totals.versionsNeedingSync).toBe(1);
+  });
+
+  it('an orphan alone does NOT flag needsSync (heal never deletes; orphans are prune\'s job)', () => {
+    const { cmdsHome } = makeInstalledVersion('2.0.0');
+    fs.mkdirSync(path.join(userDir, 'commands'), { recursive: true });
+    fs.writeFileSync(path.join(cmdsHome, 'orphan.md'), 'ORPHAN\n');
+
+    const s = runStatus(['commands']);
+
+    expect(s.agents[0].counts.orphan).toBe(1);
+    expect(s.agents[0].counts.drifted + s.agents[0].counts.missing).toBe(0);
+    expect(s.agents[0].needsSync).toBe(false);
+    expect(s.totals.versionsNeedingSync).toBe(0);
+  });
+
+  it('everSynced reflects .sync-manifest.json presence', () => {
+    const { home } = makeInstalledVersion('2.0.0');
+    fs.mkdirSync(path.join(userDir, 'commands'), { recursive: true });
+
+    // No manifest yet → cold.
+    expect(runStatus(['commands']).agents[0].everSynced).toBe(false);
+
+    // A valid (v:1) manifest → warm.
+    fs.writeFileSync(path.join(home, '.sync-manifest.json'), JSON.stringify({ v: 1, syncedAt: 0 }));
+    expect(runStatus(['commands']).agents[0].everSynced).toBe(true);
+  });
+
+  it('reports .system freshness as unknown when it is not a git repo', () => {
+    makeInstalledVersion('2.0.0');
+    const s = runStatus(['commands']);
+    expect(s.system.unknown).toBe(true);
+    expect(s.system.behind).toBe(0);
+  });
+});

--- a/src/lib/sync-status.ts
+++ b/src/lib/sync-status.ts
@@ -1,0 +1,220 @@
+/**
+ * Unified sync-status engine — the SINGLE source of truth for "is this resource
+ * synced to this agent version?" consumed by `agents doctor`, `agents view`, the
+ * menu-bar app, and any Agency surface.
+ *
+ * Why this exists: before this module there were four different notions of
+ * "synced" living in four files:
+ *   - doctor:  isStale() vs .sync-manifest.json  — catches SOURCE drift only.
+ *   - view:    git working-tree state of ~/.agents/ — a resource can show green
+ *              while its installed copy is stale/deleted/corrupted (false positive).
+ *   - lists:   file-exists-in-home — never reports content drift at all.
+ *   - menubar: read doctor --json (so it inherited doctor's source-only blind spot).
+ *
+ * The reliable signal is diffVersionResources() (src/lib/doctor-diff.ts): it reads
+ * the ACTUAL version home and compares it to the resolved sources, so it catches
+ * every drift class — source-side changes AND home-side rot (deleted / corrupted /
+ * hand-edited installed copies) AND orphans. This module wraps it once, maps its
+ * per-resource DiffStatus onto one stable enum, folds in `.system` repo freshness,
+ * and lets every surface render the same warnings instead of re-deriving them.
+ */
+
+import simpleGit from 'simple-git';
+import { AgentId } from './types.js';
+import { ALL_AGENT_IDS } from './agents.js';
+import {
+  diffVersionResources,
+  type VersionResourceReport,
+  type ResourceDiff,
+  type DoctorKind,
+  type DiffStatus,
+} from './doctor-diff.js';
+import { listInstalledVersions, getGlobalDefault } from './versions.js';
+import { loadManifest } from './staleness/index.js';
+import { getSystemAgentsDir } from './state.js';
+import { isGitRepo } from './git.js';
+
+/**
+ * One stable status per resource, unified across every surface.
+ *  - `synced`  — installed copy matches the resolved source (DiffStatus 'ok').
+ *  - `drifted` — installed copy exists but differs from source (DiffStatus 'diff').
+ *  - `missing` — source exists, nothing installed in the version home ('missing').
+ *  - `orphan`  — installed in the home with no source ('extra'); prune's job, not sync's.
+ */
+export type ResourceSyncStatus = 'synced' | 'drifted' | 'missing' | 'orphan';
+
+export interface ResourceStatusRow {
+  agent: AgentId;
+  version: string;
+  kind: DoctorKind;
+  name: string;
+  status: ResourceSyncStatus;
+  /** Human-readable specifics for a drifted row (e.g. plugin version delta). */
+  detail?: string;
+}
+
+export interface AgentVersionStatus {
+  agent: AgentId;
+  version: string;
+  isDefault: boolean;
+  /** False = no .sync-manifest.json: this version was never synced (cold). */
+  everSynced: boolean;
+  counts: { synced: number; drifted: number; missing: number; orphan: number };
+  /** drifted + missing > 0 — a real reconcile is owed. Orphans do NOT set this
+   * (heal never deletes; orphan removal is `agents prune cleanup`). */
+  needsSync: boolean;
+  resources: ResourceStatusRow[];
+}
+
+export interface SystemRepoStatus {
+  dir: string;
+  /** Commits the local `.system` checkout is behind its tracking branch, as of
+   * the last background fetch (no network is performed here). 0 = up to date. */
+  behind: number;
+  ahead: number;
+  branch: string | null;
+  /** True when the dir isn't a git repo or has no upstream — behind is unknown. */
+  unknown: boolean;
+}
+
+export interface UnifiedSyncStatus {
+  system: SystemRepoStatus;
+  agents: AgentVersionStatus[];
+  totals: {
+    drifted: number;
+    missing: number;
+    orphan: number;
+    /** Versions with a manifest that are behind on content. */
+    versionsNeedingSync: number;
+    /** Versions that were never synced at all. */
+    versionsNeverSynced: number;
+    /** Distinct agent ids that own at least one version needing sync. */
+    agentsNeedingSync: number;
+  };
+}
+
+const STATUS_MAP: Record<DiffStatus, ResourceSyncStatus> = {
+  ok: 'synced',
+  diff: 'drifted',
+  missing: 'missing',
+  extra: 'orphan',
+};
+
+function rowsFromReport(
+  agent: AgentId,
+  version: string,
+  report: VersionResourceReport,
+): ResourceStatusRow[] {
+  const out: ResourceStatusRow[] = [];
+  for (const list of Object.values(report.kinds) as ResourceDiff[][]) {
+    for (const r of list) {
+      out.push({
+        agent,
+        version,
+        kind: r.kind,
+        name: r.name,
+        status: STATUS_MAP[r.status],
+        ...(r.detail ? { detail: r.detail } : {}),
+      });
+    }
+  }
+  return out;
+}
+
+export interface SyncStatusOptions {
+  cwd?: string;
+  /** Restrict to specific agent ids; undefined = every supported agent. */
+  agents?: AgentId[];
+  /** Restrict to specific resource kinds; undefined = all. */
+  kinds?: DoctorKind[];
+}
+
+/**
+ * Read `.system` repo freshness WITHOUT touching the network. `git status`
+ * reports ahead/behind against the remote-tracking ref, which the detached
+ * auto-pull worker keeps warm via periodic `git fetch`. This is the same number
+ * the menu-bar surfaces; we read it once, here, so every surface agrees.
+ */
+export async function getSystemRepoStatus(): Promise<SystemRepoStatus> {
+  const dir = getSystemAgentsDir();
+  const base: SystemRepoStatus = { dir, behind: 0, ahead: 0, branch: null, unknown: true };
+  if (!isGitRepo(dir)) return base;
+  try {
+    const status = await simpleGit(dir).status();
+    return {
+      dir,
+      behind: status.behind ?? 0,
+      ahead: status.ahead ?? 0,
+      branch: status.tracking ?? status.current ?? null,
+      // Without a tracking branch there's no upstream to compare against.
+      unknown: !status.tracking,
+    };
+  } catch {
+    return base;
+  }
+}
+
+/**
+ * Compute unified sync status across the fleet. Resolves against non-project
+ * layers only (`excludeProject: true`) — the GLOBAL version home is never
+ * reconciled against per-cwd `<cwd>/.agents/` resources, so counting them as
+ * "missing" there would be a false gap (matches doctor's overview semantics).
+ */
+export async function computeSyncStatus(
+  options: SyncStatusOptions = {},
+): Promise<UnifiedSyncStatus> {
+  const cwd = options.cwd ?? process.cwd();
+  const agentIds = options.agents ?? ALL_AGENT_IDS;
+
+  const agents: AgentVersionStatus[] = [];
+  for (const agent of agentIds) {
+    const def = getGlobalDefault(agent);
+    for (const version of listInstalledVersions(agent)) {
+      const report = diffVersionResources(agent, version, {
+        cwd,
+        excludeProject: true,
+        ...(options.kinds ? { kinds: options.kinds } : {}),
+      });
+      const resources = rowsFromReport(agent, version, report);
+      const counts = { synced: 0, drifted: 0, missing: 0, orphan: 0 };
+      for (const r of resources) counts[r.status]++;
+      agents.push({
+        agent,
+        version,
+        isDefault: version === def,
+        everSynced: loadManifest(agent, version) !== null,
+        counts,
+        needsSync: counts.drifted + counts.missing > 0,
+        resources,
+      });
+    }
+  }
+
+  const system = await getSystemRepoStatus();
+
+  const agentsNeedingSync = new Set<AgentId>();
+  let drifted = 0, missing = 0, orphan = 0, versionsNeedingSync = 0, versionsNeverSynced = 0;
+  for (const v of agents) {
+    drifted += v.counts.drifted;
+    missing += v.counts.missing;
+    orphan += v.counts.orphan;
+    if (!v.everSynced) versionsNeverSynced++;
+    if (v.needsSync) {
+      versionsNeedingSync++;
+      agentsNeedingSync.add(v.agent);
+    }
+  }
+
+  return {
+    system,
+    agents,
+    totals: {
+      drifted,
+      missing,
+      orphan,
+      versionsNeedingSync,
+      versionsNeverSynced,
+      agentsNeedingSync: agentsNeedingSync.size,
+    },
+  };
+}


### PR DESCRIPTION
## Why

Sync-status detection was unreliable: **four different notions of "synced"** lived in four files, and the one users look at most — the `agents view` checkmark — was the least accurate. It reads git working-tree state of `~/.agents/`, so a resource shows green while its **installed copy** in the agent home is stale/deleted/corrupted. If a hook or slash command was synced and then its source changed, `agents view` still shows a green check.

Only `diffVersionResources()` (behind `doctor <target>`/`--fix`) actually reads the version home and catches every drift class — but nothing else used it, and it had a capability bug of its own (below).

## What

**One engine, one contract, one action.**

- **`src/lib/sync-status.ts`** — `computeSyncStatus()` wraps the home-reading `diffVersionResources()` and maps `DiffStatus` onto one enum: `synced | drifted | missing | orphan`. Folds in `.system` repo freshness (behind count via no-network `git status`) and per-version `everSynced` / `needsSync` (drift+missing, not orphans — heal never deletes). The single source of truth for doctor / view / menu-bar / Agency.
- **`agents status`** — human fleet table + interactive sync; `--json` emits the stable `UnifiedSyncStatus` contract for the menu-bar / Agency; `--yes` is the scriptable path.
- **`promptDriftSync()`** — the "drift detected — sync now?" flow. Composes existing pieces (no new sync logic): detect → pull `.system` (explicit choice only, preserves the off-by-default RCE posture) → `promptAgentVersionSelection` ("which agent types?") → `heal` (the reconcile engine `doctor --fix` uses). Combined one-confirmation flow.
- **`fix(doctor-diff)`** — `diffCommands` read the native commands path even for agents that install commands AS skills (kimi, codex≥0.117, grok), so every command false-reported as `drifted` forever (synced:0). Now compares against the installed command-skill wrapper and gates agents that hold commands neither natively nor as skills (goose). On the real fleet this dropped spurious drift by 26 rows (kimi commands 0→13 synced; codex@0.134 0→13).
- **`fix(auto-pull)`** — `printPendingUpdateNotices()` existed but was never called; `~/.agents/` and `.system` being behind origin was detected and never surfaced. Now wired at startup.
- **doctor** ends with an actionable hint pointing at `agents status` when anything is out of sync.

## Verified

- Full suite green (3423 passed), `tsc --noEmit` clean.
- Real-fs unit tests (no mocks): drift maps to `drifted` not a false `synced`; orphan-alone does not flag `needsSync`; `everSynced` tracks the manifest; command-as-skill agents report `ok`/`diff` correctly; goose gate.
- E2E apply test: `promptDriftSync({ yes: true })` reconciles a drifted file to source and installs a missing one on a real temp home.
- Ran on the real fleet (read + notice + capability-fix paths).

## Follow-ups (separate PR)

- Rewire `agents view`'s checkmark onto the engine so green means "synced to every agent on this machine that should have it" (the cross-agent coverage signal), killing the git-based false-positive.
- Menu-bar "NEEDS SYNC" row → launch `agents status`.