### PR TITLE
chore(secrets): re-pin keychain helper sha (migrateInline + entitlements rebuild)

### DIFF
--- a/scripts/Agents CLI.app.sha256
+++ b/scripts/Agents CLI.app.sha256
@@ -1,1 +1,1 @@
-74451dcfbaff1632b983b9609318f5b625826fb67d561092f3d8bbfbfa43d8f8  bin/Agents CLI.app/Contents/MacOS/Agents CLI
+72de64ffbfb733a5d9fc9fb7366e2f433a6082534eb135408c0dcb5d643f6467  bin/Agents CLI.app/Contents/MacOS/Agents CLI


### PR DESCRIPTION
Re-pins `scripts/Agents CLI.app.sha256` to the notarized rebuild of the fixed keychain helper from #524 (add-only `migrateInline` + `com.apple.application-identifier` entitlement for macOS 26). Without this, the release would prepack-verify against the old sha and ship the pre-fix helper.

The `.app` itself is gitignored/built per-machine; this pins the sha of the notarized build on the release machine. Verified locally: `set` writes the DP keychain (no `-34018`), and legacy stragglers relocate on read.

New sha: `72de64ff…` (was `74451dcf…`).