### PR TITLE
feat(sessions): per-pid registry so `--active` de-collapses co-located agents

### DIFF
--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -17,6 +17,7 @@ import { resolveModel, buildReasoningFlags } from './models.js';
 import { emitStart, maybeRotate, createTimer, redactPrompt, redactArgs } from './events.js';
 import { sanitizeProcessEnv } from './secrets/bundles.js';
 import { getShimsDir } from './state.js';
+import { writePidSessionEntry } from './session/pid-registry.js';
 
 /**
  * Agent execution modes. Canonical name `skip` (dangerously skip permissions);
@@ -829,6 +830,15 @@ interface SpawnResult {
  * unbuffered.
  */
 async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
+  // Assign a known session id up front for agents that accept one, so the
+  // launcher can record an EXACT pid -> session mapping (see pid-registry) —
+  // otherwise the headless `ag sessions --active` path can only guess
+  // "newest .jsonl in the cwd" and collapses co-located agents onto one row.
+  // Claude: `--session-id <uuid>` CREATES the session with that id (wired in
+  // buildExecCommand). Skip on resume — the id is the one being resumed.
+  if (options.agent === 'claude' && !options.resume && !options.sessionId) {
+    options = { ...options, sessionId: randomUUID() };
+  }
   const cmd = buildExecCommand(options);
   const [executable, ...args] = cmd;
 
@@ -883,6 +893,19 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
       stdio,
       env: buildExecEnv(options),
       shell: useShell,
+    });
+
+    // Record this launch so `ag sessions --active` can map the pid to its exact
+    // session (sessionId is set for Claude above) instead of guessing the newest
+    // .jsonl in the cwd — the collapse that made co-located agents indistinguishable.
+    // Best-effort: pruned when the pid dies; a failed write just degrades to the heuristic.
+    writePidSessionEntry({
+      pid: child.pid ?? 0,
+      agent: options.agent,
+      sessionId: options.sessionId,
+      cwd: options.cwd || process.cwd(),
+      tmuxPane: process.env.TMUX_PANE,
+      startedAtMs: Date.now(),
     });
 
     // Mark startup time (time from function call to process spawn)

--- a/src/lib/session/active.ts
+++ b/src/lib/session/active.ts
@@ -24,6 +24,7 @@ import { promisify } from 'util';
 import { listActiveTasks } from '../cloud/store.js';
 import { AgentManager } from '../teams/agents.js';
 import { getTerminalsDir } from '../state.js';
+import { readPidSessionEntry, prunePidSessionRegistry } from './pid-registry.js';
 import { buildClaudeLabelMap } from './discover.js';
 import { latestSessionFileForCwd } from './db.js';
 import { extractSessionTopic } from './prompt.js';
@@ -571,8 +572,13 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
   const out: ActiveSession[] = [];
   for (let i = 0; i < candidates.length; i++) {
     const { pid, kind } = candidates[i];
-    const cwd = cwds[i];
-    const sessionFile = findSessionFileForKind(kind, cwd);
+    // The per-pid registry (written by `ag run`) gives the EXACT session id this
+    // pid was launched with — so N agents in one cwd resolve to N distinct
+    // sessions instead of all collapsing onto the newest .jsonl. Absent (agent
+    // not launched via `ag run`, or one that takes no session id) → heuristic.
+    const entry = readPidSessionEntry(pid);
+    const cwd = cwds[i] ?? entry?.cwd ?? undefined;
+    const sessionFile = findSessionFileForKind(kind, cwd, entry?.sessionId);
     const topic = sessionFile ? quickExtractTopic(sessionFile) : undefined;
     const host = detectHost(pid, procByPid);
     const context: ActiveContext = host && UI_HOSTS.has(host) ? 'terminal' : 'headless';
@@ -583,11 +589,13 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
       host,
       pid,
       cwd,
-      sessionId: sessionIdFromFile(sessionFile),
+      sessionId: entry?.sessionId ?? sessionIdFromFile(sessionFile),
       topic,
       sessionFile,
     }, state, sessionFile));
   }
+  // Housekeeping: drop registry files for pids that have since died.
+  prunePidSessionRegistry(isPidAlive);
   return out;
 }
 

--- a/src/lib/session/pid-registry.test.ts
+++ b/src/lib/session/pid-registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'bun:test';
+import { describe, it, expect, afterEach } from 'vitest';
 import { writePidSessionEntry, readPidSessionEntry, prunePidSessionRegistry } from './pid-registry.js';
 
 // A pid far above any real process on this box, so the test never clobbers a

--- a/src/lib/session/pid-registry.test.ts
+++ b/src/lib/session/pid-registry.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { writePidSessionEntry, readPidSessionEntry, prunePidSessionRegistry } from './pid-registry.js';
+
+// A pid far above any real process on this box, so the test never clobbers a
+// live `ag run` entry and never collides with a real process's registry file.
+const FAKE_PID = 999_000_001;
+
+// Clean up only our own entry — a prune predicate that reports every OTHER pid
+// as alive, so real entries written by concurrent `ag run` invocations survive.
+afterEach(() => {
+  prunePidSessionRegistry((pid) => pid !== FAKE_PID);
+});
+
+describe('pid session registry', () => {
+  it('round-trips a written entry with its exact session id', () => {
+    writePidSessionEntry({
+      pid: FAKE_PID,
+      agent: 'claude',
+      sessionId: 'abc-123-uuid',
+      cwd: '/home/x/repo',
+      tmuxPane: '%18',
+      startedAtMs: 1_700_000_000_000,
+    });
+    const got = readPidSessionEntry(FAKE_PID);
+    expect(got?.sessionId).toBe('abc-123-uuid');
+    expect(got?.agent).toBe('claude');
+    expect(got?.cwd).toBe('/home/x/repo');
+    expect(got?.tmuxPane).toBe('%18');
+  });
+
+  it('returns undefined for a pid with no entry', () => {
+    expect(readPidSessionEntry(FAKE_PID + 7)).toBeUndefined();
+  });
+
+  it('ignores a pid < 1 (never writes a bogus file)', () => {
+    writePidSessionEntry({ pid: 0, agent: 'claude', startedAtMs: 1 });
+    expect(readPidSessionEntry(0)).toBeUndefined();
+  });
+
+  it('prune removes entries whose pid is dead, keeps live ones', () => {
+    writePidSessionEntry({ pid: FAKE_PID, agent: 'claude', sessionId: 's', startedAtMs: 1 });
+    expect(readPidSessionEntry(FAKE_PID)).toBeDefined();
+    // Everything dead → our entry is removed.
+    prunePidSessionRegistry(() => false);
+    expect(readPidSessionEntry(FAKE_PID)).toBeUndefined();
+  });
+
+  it('stores an entry without a session id (non-Claude agents that take none)', () => {
+    writePidSessionEntry({ pid: FAKE_PID, agent: 'grok', cwd: '/repo', startedAtMs: 2 });
+    const got = readPidSessionEntry(FAKE_PID);
+    expect(got?.agent).toBe('grok');
+    expect(got?.sessionId).toBeUndefined();
+  });
+});

--- a/src/lib/session/pid-registry.ts
+++ b/src/lib/session/pid-registry.ts
@@ -1,0 +1,89 @@
+/**
+ * Per-PID session registry — the headless equivalent of the swarmify VS Code
+ * extension's `live-terminals.json`.
+ *
+ * On a machine with no terminal extension (a bare SSH/tmux host), the only way
+ * `ag sessions --active` can attribute a `ps`-discovered agent process to a
+ * session is to guess "newest .jsonl in the cwd" — which collapses N agents
+ * sharing one repo onto a single session (all rows show the same topic/id).
+ *
+ * `ag run` closes that gap by recording, at spawn time, one file per launched
+ * agent process keyed by its OS pid: the exact session id it was launched with
+ * (Claude is started with `--session-id <uuid>`, so the launcher knows it),
+ * plus agent/cwd/tmux pane. The active-sessions headless path reads it back for
+ * an exact pid -> session match instead of a heuristic.
+ *
+ * Best-effort throughout: a failed write or a corrupt file degrades to the old
+ * heuristic, never throws into the launch or the listing path.
+ */
+import fs from 'fs';
+import path from 'path';
+import { getTerminalsDir } from '../state.js';
+
+export interface PidSessionEntry {
+  pid: number;
+  agent: string;
+  /** The launch session id. Present for agents launched with a known id (Claude). */
+  sessionId?: string;
+  cwd?: string;
+  /** `$TMUX_PANE` at launch — a second key so pid reuse can't cause a false match. */
+  tmuxPane?: string;
+  startedAtMs: number;
+}
+
+function pidRegistryDir(): string {
+  return path.join(getTerminalsDir(), 'by-pid');
+}
+
+function entryPath(pid: number): string {
+  return path.join(pidRegistryDir(), `${pid}.json`);
+}
+
+/** Record a launched agent process. Never throws — the registry is an optimization. */
+export function writePidSessionEntry(entry: PidSessionEntry): void {
+  if (!entry.pid || entry.pid < 1) return;
+  try {
+    fs.mkdirSync(pidRegistryDir(), { recursive: true });
+    fs.writeFileSync(entryPath(entry.pid), JSON.stringify(entry), 'utf8');
+  } catch {
+    /* degrade to the newest-jsonl heuristic */
+  }
+}
+
+/** Look up a live pid's recorded session. Returns undefined if absent/corrupt. */
+export function readPidSessionEntry(pid: number): PidSessionEntry | undefined {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(entryPath(pid), 'utf8');
+  } catch {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && typeof parsed.pid === 'number') {
+      return parsed as PidSessionEntry;
+    }
+  } catch {
+    /* unparseable */
+  }
+  return undefined;
+}
+
+/** Remove entries whose pid is no longer alive. Best-effort housekeeping. */
+export function prunePidSessionRegistry(isAlive: (pid: number) => boolean): void {
+  let files: string[];
+  try {
+    files = fs.readdirSync(pidRegistryDir()).filter(f => f.endsWith('.json'));
+  } catch {
+    return;
+  }
+  for (const f of files) {
+    const pid = Number(f.slice(0, -'.json'.length));
+    if (!Number.isInteger(pid) || isAlive(pid)) continue;
+    try {
+      fs.unlinkSync(path.join(pidRegistryDir(), f));
+    } catch {
+      /* raced with another writer/pruner */
+    }
+  }
+}

--- a/src/lib/session/pid-registry.ts
+++ b/src/lib/session/pid-registry.ts
@@ -26,7 +26,12 @@ export interface PidSessionEntry {
   /** The launch session id. Present for agents launched with a known id (Claude). */
   sessionId?: string;
   cwd?: string;
-  /** `$TMUX_PANE` at launch — a second key so pid reuse can't cause a false match. */
+  /**
+   * `$TMUX_PANE` at launch — stored for diagnostics and possible future
+   * disambiguation. NOT currently consulted on read: the listing path keys
+   * purely on pid (stale entries are pruned when the pid dies), so this is
+   * metadata, not an anti-collision key.
+   */
   tmuxPane?: string;
   startedAtMs: number;
 }


### PR DESCRIPTION
## Problem

On a host with no terminal extension (bare SSH/tmux — e.g. any Linux box), `ag sessions --active` can only attribute a `ps`-discovered agent process to a session by guessing **the newest `.jsonl` in its cwd**. When several agents run in the same repo, they all collapse onto one session — observed live: a single session id listed **28 times**, every row with the identical topic. This also made `/restore` unreliable (couldn't tell co-located agents apart).

Root cause: `listUnattributedActive` called `findSessionFileForKind(kind, cwd)` with **no session id** (`active.ts`).

## Fix (at the source)

A per-pid registry — the headless equivalent of the swarmify extension's `live-terminals.json`:

- **`ag run` records each launch** to `~/.agents/.cache/terminals/by-pid/<pid>.json` = `{agent, cwd, tmuxPane, sessionId, startedAtMs}`. Claude is launched with `--session-id <uuid>` (already supported + wired in `buildExecCommand`), so the launcher knows the id up front.
- **`listUnattributedActive` consults the registry** for an exact pid→session match, falling back to the old newest-`.jsonl` heuristic only when there's no entry (agent not started via `ag run`, or one that takes no session id).
- Dead-pid entries are pruned on read. Writes are best-effort — a failure degrades to the heuristic, never breaks a launch or the listing.

## Scope / follow-ups

- Exact for **Claude** today (the fleet that collapses). Grok (`$GROK_SESSION_ID`), Kimi (TOML SessionStart), Codex (trusted hook), Antigravity (PreToolUse + `$GEMINI_SESSION_ID`) can enrich their entries via a per-agent start hook in a follow-up (Layer 2) — all confirmed to expose a session id per their official docs.
- Non-Claude agents still get correct **agent + cwd + count** from the launcher entry even without a session id.

## Verification

**End-to-end through the real CLI (no stubs):**
- Ran the real `ag run claude "hi"` (worktree build). The launcher assigned session id `6f724e13-…`, wrote `by-pid/187539.json` = `{pid:187539, agent:"claude", sessionId:"6f724e13-…", cwd:…, tmuxPane:"%64"}`, **and** claude created a transcript named exactly `6f724e13-….jsonl` — proving `--session-id` was passed and honored (the full assign → inject → launch → registry-write → session-created chain).
- **Read side:** ran the real `listUnattributedActive` against the live process table with two co-located Claude pids seeded to two distinct real ids — both resolved to their exact id ("distinct? YES (collapse fixed)").

**Tests:** new `pid-registry.test.ts` (write/read/prune, no-id agents, pid<1 guard) — 5 pass. `tsc --noEmit` clean. The 10 failing session tests on this branch are **pre-existing and identical on `main`** (Linux keychain/sqlite env), not introduced here — verified by running the same suites on pristine `main`.