### PR TITLE
perf(ssh): unify remote exec on one multiplexed, keepalive engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ agents ssh mac-mini                     # hardened SSH: fails fast if offline,
 
 **Hosts** (`agents hosts`) are git-synced dispatch targets in `agents.yaml`; **devices** (`agents devices`) are your Tailscale machines in a local registry. Both ride SSH. See [docs/00-concepts.md](docs/00-concepts.md#devices--hosts).
 
+Every `--host` command rides one multiplexed SSH engine, tuned for driving a fleet from a small laptop: the first call to a machine opens a control socket and every later call reuses it (no repeat TCP+auth handshake), connections carry keepalive so a dropped link dies in ~45 s instead of zombying, and following a remote run polls in a single round-trip per cycle. Measured against a Tailscale-relayed host: repeated calls **~6–7× faster**, dispatch readiness **~2×**, and the follow loop **~21× faster with 50% fewer local ssh spawns**. Design: [docs/09-ssh-transport.md](docs/09-ssh-transport.md) · reproduce: `node scripts/bench-ssh.mjs <host>`.
+
 ---
 
 ## Teams

--- a/docs/09-ssh-transport.md
+++ b/docs/09-ssh-transport.md
@@ -1,0 +1,189 @@
+# SSH transport — one multiplexed engine (design decision)
+
+> Status: **accepted** · Related: [hosts.md](hosts.md), [99-optimizations.md](99-optimizations.md#opt-02-ssh-transport--one-multiplexed-engine), [00-concepts.md](00-concepts.md#devices--hosts)
+
+A design record for *how `agents` talks to remote machines over SSH*. Every
+remote surface — `run --host`, `view/usage/cost/doctor/inspect/list/sync --host`,
+`sessions -H`, `teams … --host`, remote `secrets`, the browser CDP tunnel — moves
+bytes over the system `ssh`. This doc pins down the one transport they all share,
+and why it is a set of shared primitives rather than a daemon.
+
+## Context
+
+The fleet is driven from a laptop — frequently an 8 GB MacBook — that fans out to
+Macs, Linux boxes, and a Windows mini over Tailscale. The scarce resource is not
+the remote machine's CPU. It is **local**: every `ssh` the CLI forks is a process
+in the laptop's table, a TCP socket, an ephemeral port, and a full public-key
+handshake against the laptop's kernel and CPU. A transport that reopens a
+connection per logical operation turns a quiet "watch this run" into thousands of
+handshakes an hour on the one machine the user is actually sitting at.
+
+The transport already funnelled through a single hardened choke point,
+`sshExec`/`sshStream` in [`src/lib/ssh-exec.ts`](../src/lib/ssh-exec.ts), and
+OpenSSH connection multiplexing (`ControlMaster`) was already implemented there.
+The problem was that it was **opt-in** and almost nobody opted in.
+
+## Goals / non-goals
+
+**Goals**
+
+- One connection strategy for every remote surface, defined in one place.
+- Minimize *local* cost: process spawns, sockets, handshakes, zombie connections.
+- No new always-on service, port, or protocol to run on every Mac and Linux box.
+- No behavior regressions; multiplexing must never make a reachable host unreachable.
+
+**Non-goals**
+
+- A bespoke agent/relay daemon (see [Alternatives](#alternatives-considered)).
+- Parallelizing the multi-host fan-out (it is deliberately serial — one `ssh`
+  alive at a time is memory-safe on a small laptop; latency is the accepted cost).
+- Changing the detached-dispatch model (`nohup` + offset-tail) that lets a remote
+  job survive a dropped connection — that design is orthogonal and stays.
+
+## The problem, with evidence
+
+Multiplexing was gated behind `multiplex: true` and only 3 of ~13 call paths
+passed it. The un-multiplexed callers were precisely the hot ones:
+
+| # | Where | Cost before |
+|---|---|---|
+| P1 | `followHostTask` ([`progress.ts`](../src/lib/hosts/progress.ts)) — the poll behind every `run --host` / `teams … --watch` | **2 un-muxed ssh / 1.5 s ≈ 4,800 process spawns/hour**, per followed job |
+| P2 | `ensureHostReady` ([`ready.ts`](../src/lib/hosts/ready.ts)) — runs before every dispatch | **3 sequential connections** (reachable + version + agent listing), 2 un-muxed |
+| P3 | `sshExec`/`sshStream` default | multiplexing opt-in; the common paths skipped it |
+| P4 | `runRemoteSessions` ([`session/remote.ts`](../src/lib/session/remote.ts)) | a **private copy** of the ssh options with no multiplexing |
+| P5 | secrets push, the `-N` tunnel, and other direct `spawn('ssh')` sites | bypass the choke point; some under-specified (no `ConnectTimeout`) |
+| P6 | `hosts add` ([`hosts.ts`](../src/commands/hosts.ts)) | a duplicate reachability probe |
+| P7 | `SSH_OPTS` | no keepalive — a dropped link hangs instead of dying |
+
+## Design
+
+The transport is **two shared primitives, and everything composes from them.**
+
+### 1. One hardened baseline: `SSH_OPTS`
+
+```
+StrictHostKeyChecking=accept-new   BatchMode=yes   ConnectTimeout=10
+ServerAliveInterval=15   ServerAliveCountMax=3          ← keepalive (P7)
+```
+
+Every `ssh` in the codebase composes this list — directly through
+`sshExec`/`sshStream`, or as `[...SSH_OPTS, …extra]` in the handful of callers
+that need `-L`/`-N`/`ProxyCommand`. The keepalive means a silently-dropped
+connection (laptop sleeps, Wi-Fi flips) is detected and the `ssh` process exits
+within ~45 s (`15 × 3`) instead of pinning a zombie process + socket on the
+laptop. Long-lived `-N` tunnels inherit it by composing the same baseline.
+
+### 2. One multiplex helper: `controlOpts()`, default-on
+
+```
+ControlMaster=auto   ControlPath=~/.agents/.cache/ssh/cm-%C   ControlPersist=60s
+```
+
+The first connection to a host opens a control socket; every later connection —
+even from a *separate* `agents` invocation — rides it, skipping the TCP+auth
+handshake. This is now the **default** (`opts.multiplex === false ? [] :
+controlOpts()`); a caller opts *out* only for a genuine one-shot where a lingering
+60 s master is pure overhead. Flipping this one default is what fixes P1's poll,
+P2's probes, and P4's fan-out at once — they already routed through the engine and
+simply started reusing sockets. It degrades safely: if the socket can't be opened
+ssh falls back to a fresh connection, and on Windows (no `ControlMaster`) the
+helper returns `[]`.
+
+### 3. The follow loop: one round-trip per cycle (P1)
+
+The old loop made two calls per cycle — `tail -c +offset` for new log bytes, then
+`cat .exit`. Rewritten to a single round-trip:
+
+```
+tail -c +<offset> <log>;  printf '<sentinel>';  cat <exit>
+```
+
+`splitProgressOutput` splits the response on the **last** occurrence of a
+per-task sentinel (`@@AGENTS_HOST_EXIT_<taskId>@@`), so the log tail, an end
+marker, and the exit code come back together and are separated without ever
+miscounting the byte offset (the marker and exit bytes come from `printf`/`cat`,
+never the log). Splitting on the *last* marker means even if the agent's own
+output echoed the token, the real trailing sentinel still wins. The sentinel's
+`printf` format is derived from the same `exitMarker()` the parser uses, so the
+two can never desync. On top of that: **default multiplexing** (each cycle reuses
+the socket the launch opened) and **adaptive backoff** (1.5 s while output flows,
+easing toward 4 s when idle). Net: 50 % fewer process spawns *and* each spawn is a
+socket reuse instead of a handshake.
+
+### 4. Readiness: three round-trips to one (P2)
+
+`readyProbe` replaces the reachable → version → agent-listing sequence with one
+compound `bash -lc` script. Reachability keys off the returned sentinel, not the
+exit code — so a command that *ran but failed* is never misread as a dead
+connection, and only ssh's own connection-layer failure (no sentinel) reads as
+unreachable.
+
+## Alternatives considered
+
+**A bespoke daemon / relay on every host.** Rejected. It would add a socket
+server, a port or tunnel, a custom wire protocol, and its own auth to every Mac
+and Linux box — for no capability SSH doesn't already give us. SSH is more
+*reliable* (battle-tested, no long-lived process to crash or double-run, host-key
+trust + auth + encryption for free) and, with multiplexing, just as *fast* for
+repeated calls. Reliability for long jobs already comes from detached `nohup`
+dispatch, which survives a dropped connection without any daemon. The scheduling
+daemon stays scoped to scheduling.
+
+**Parallel multi-host fan-out.** Rejected as a default. On a small laptop, N
+concurrent `ssh` processes trade the one resource we are protecting (local
+memory/process pressure) for latency we can tolerate. The serial loop keeps at
+most one `ssh` alive; multiplexing already removes the repeat-handshake cost.
+
+**A persistent `tail -f` stream for follow.** Deferred, not rejected. A single
+long-lived streaming connection would drop per-cycle spawns to zero, but
+complicates offset-resume-on-disconnect and exit capture. The combined-round-trip
++ multiplexing design captures most of the win at a fraction of the complexity;
+streaming is future work.
+
+## Results
+
+Measured against a live Tailscale-relayed host (`scripts/bench-ssh.mjs`), stable
+across runs. Each number is wall-clock on the laptop:
+
+| Path | Before | After | Win |
+|---|---|---|---|
+| P3 · repeated `--host` (per call) | ~444 ms | **~75 ms** | **~6–7×** |
+| P2 · readiness per dispatch | 1.5–1.8 s | **~0.8 s** | **~2×** |
+| P1 · follow loop (per cycle) | ~706 ms | **~33 ms** | **~21–23×**, 50 % fewer spawns |
+
+The P1 figure is the headline: an old cycle paid two fresh handshakes (~706 ms on
+a relayed link); the new cycle rides the reused socket (~33 ms). Over an hour of
+following that is the difference between the laptop grinding through thousands of
+handshakes and holding one socket open.
+
+Reproduce: `bun run build && node scripts/bench-ssh.mjs <host>`.
+
+## Trade-offs and risks
+
+- **A 60 s master lingers after each call.** `ControlPersist=60s` keeps an idle
+  master briefly so back-to-back commands reuse it. The cost is bounded (one idle
+  unix socket per recently-touched host, reaped after 60 s) and is the entire
+  point. An interactive one-shot that must not leave a master can pass
+  `multiplex: false`.
+- **Keepalive terminates a live-but-silent connection after ~45 s.** Intended: a
+  genuinely idle-but-healthy link is re-established on the next call for near-zero
+  cost via the control socket; a dead one no longer hangs.
+- **Sentinel-based framing** assumes the remote login shell runs (a `bash -lc`
+  assumption shared by every remote call in the codebase). A bash-less remote
+  reads as unreachable — the same failure the old code produced, with a clearer
+  message.
+
+## Rollout and future work
+
+Shipped as one PR: the engine change plus every consumer, unit tests, an A/B
+benchmark harness, and this doc. Behavior-preserving — the only observable change
+is that remote commands are faster and dead connections self-terminate.
+
+Follow-ups (non-blocking):
+
+- Remove the now-unused `sshReachable` export.
+- Pass `multiplex: false` on the interactive `secrets --reveal -tt` path so a
+  Touch-ID reveal doesn't leave a 60 s master.
+- Route the remaining specialized direct-`ssh` sites (browser CDP, cloud
+  `ProxyCommand`, drive-sync) through the shared baseline.
+- Evaluate the persistent `tail -f` streaming follow.

--- a/docs/99-optimizations.md
+++ b/docs/99-optimizations.md
@@ -239,3 +239,74 @@ trades correctness guarantees for speed.
 |------|--------|
 | `src/lib/versions.ts` | Guard + manifest write in `syncResourcesToVersion`; `force?` option; skip dotfiles in `copyDir` |
 | `src/lib/rules-compile.ts` | Add `mtime?`/`size?` to `CompileManifest`; two-tier fast path in `isRulesStale` |
+
+---
+
+## OPT-02: SSH Transport — One Multiplexed Engine
+
+Full design rationale: [09-ssh-transport.md](09-ssh-transport.md).
+
+### Problem
+
+Every remote surface (`run/view/sync/sessions/teams … --host`, remote secrets,
+the CDP tunnel) forks the system `ssh`. On the laptop that drives the fleet, each
+fork is a process, a socket, and a full TCP+auth handshake. OpenSSH connection
+multiplexing was implemented in the choke point but was **opt-in**, and only 3 of
+~13 call paths opted in — the hottest ones did not:
+
+```
+followHostTask  poll loop      2 un-muxed ssh / 1.5s   ≈ 4,800 spawns/hour
+ensureHostReady dispatch gate  3 sequential connections (2 un-muxed)
+runRemoteSessions fan-out      private SSH_OPTS copy, no multiplexing
+SSH_OPTS                       no keepalive → dropped links hang as zombies
+```
+
+### Design
+
+Two shared primitives; everything composes from them:
+
+- **`SSH_OPTS`** — the one hardened baseline, now with keepalive
+  (`ServerAliveInterval=15` / `ServerAliveCountMax=3`, ~45 s to reap a dead link).
+- **`controlOpts()`** — multiplexing, flipped to **default-on**
+  (`opts.multiplex === false ? [] : controlOpts()`). Every routed caller reuses
+  the control socket for free; degrades to a fresh connection if the socket can't
+  open; no-ops on Windows.
+
+Plus two hot-path rewrites: the follow loop now does **one** combined round-trip
+per cycle (sentinel-framed `tail; printf; cat`) with adaptive backoff, and
+readiness collapses **3 probes into 1** compound `readyProbe`.
+
+### Results
+
+Live Tailscale-relayed host, `scripts/bench-ssh.mjs`, wall-clock on the laptop:
+
+```
+┌──────────────────────────────┬──────────┬──────────┬───────────────────────────┐
+│            Path              │  Before  │  After   │           Win             │
+├──────────────────────────────┼──────────┼──────────┼───────────────────────────┤
+│ P3 repeated --host (per call)│  ~444ms  │  ~75ms   │ ~6-7x                     │
+│ P2 readiness per dispatch    │ 1.5-1.8s │  ~0.8s   │ ~2x                       │
+│ P1 follow loop (per cycle)   │  ~706ms  │  ~33ms   │ ~21-23x, 50% fewer spawns │
+└──────────────────────────────┴──────────┴──────────┴───────────────────────────┘
+```
+
+Reproduce: `bun run build && node scripts/bench-ssh.mjs <host>`.
+
+### New files
+
+| File | Role |
+|------|------|
+| `docs/09-ssh-transport.md` | Design rationale for the shared SSH transport |
+| `scripts/bench-ssh.mjs` | A/B benchmark harness (needs a live host) |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `src/lib/ssh-exec.ts` | Keepalive in `SSH_OPTS`; multiplexing default-on |
+| `src/lib/hosts/progress.ts` | One combined round-trip/cycle + adaptive backoff; `splitProgressOutput` |
+| `src/lib/hosts/ready.ts` | `readyProbe` collapses 3 probes into 1 |
+| `src/commands/hosts.ts` | Thread the probe result through `maybeBootstrap` (drop duplicate probe) |
+| `src/lib/session/remote.ts` | Import canonical `SSH_OPTS` + `controlOpts` (drop private copy) |
+| `src/commands/secrets.ts` | Route the remote push through `sshExec` |
+| `src/lib/ssh-tunnel.ts` | `buildTunnelArgs` composes `SSH_OPTS` (inherits keepalive) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,8 @@ How agents-cli is laid out on disk and how it decides what to load.
 | [Resource sync](02-resource-sync.md) | How rules, commands, skills, hooks, etc. land in each version home. |
 | [Sessions](05-sessions.md) | Unified transcript discovery across Claude, Codex, Gemini, OpenCode. |
 | [Observability](06-observability.md) | The three `--json` sources (sessions / cloud / teams) as a fleet view. |
-| [Optimizations](99-optimizations.md) | Sync manifest, startup profiling, hot-path notes. |
+| [SSH transport](09-ssh-transport.md) | The one multiplexed engine every `--host` command rides — default connection reuse, keepalive, one-round-trip follow. |
+| [Optimizations](99-optimizations.md) | Sync manifest, SSH transport, startup profiling, hot-path notes. |
 | [Landscape](04-landscape.md) | Where agents-cli sits next to similar tools. |
 
 ## Credentials and model routing

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -5,7 +5,9 @@
 > `list`, `sync`), on `agents run`, and across the `agents teams` lifecycle. This
 > document is the design rationale; see
 > [00-concepts.md](00-concepts.md#devices--hosts) for the concept overview and how
-> hosts relate to the Tailscale-backed `agents devices` registry.
+> hosts relate to the Tailscale-backed `agents devices` registry, and
+> [09-ssh-transport.md](09-ssh-transport.md) for the shared, multiplexed SSH
+> transport every `--host` command rides.
 
 `agents hosts` lets you run any agent (`claude`, `codex`, `droid`, …) on any of
 *your* machines — a Mac mini, a Windows mini, a couple of DGX Sparks — addressed

--- a/scripts/bench-ssh.mjs
+++ b/scripts/bench-ssh.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * A/B benchmark for the shared SSH engine, against a real enrolled host.
+ *
+ *   bun run build            # build dist/ first
+ *   node scripts/bench-ssh.mjs <host>
+ *
+ * Measures the three tangible laptop-side costs the engine targets. Each number
+ * is wall-clock on the machine you run it from — the thing that matters when the
+ * fleet is driven from a small laptop:
+ *
+ *   P3  repeated `--host` calls: fresh handshake each vs reused control socket
+ *   P2  readiness: old 3 round-trips vs new 1 compound readyProbe
+ *   P1  follow loop: old 2 un-muxed calls/cycle vs new 1 muxed combined call
+ *
+ * Requires a live host reachable over passwordless ssh (needs a real network
+ * round-trip to be meaningful — a Tailscale-relayed peer shows the win most
+ * clearly since each avoided handshake is expensive). Not a CI benchmark.
+ */
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { execSync } from 'child_process';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const dist = join(here, '..', 'dist');
+const { sshExec } = await import(join(dist, 'lib', 'ssh-exec.js'));
+const { readyProbe } = await import(join(dist, 'lib', 'hosts', 'ready.js'));
+
+const HOST = process.argv[2];
+if (!HOST) {
+  console.error('usage: node scripts/bench-ssh.mjs <host>   (run `bun run build` first)');
+  process.exit(2);
+}
+
+const ms = (t0) => Number(process.hrtime.bigint() - t0) / 1e6;
+const clearSockets = () => { try { execSync('rm -f ~/.agents/.cache/ssh/cm-*', { shell: '/bin/bash' }); } catch { /* none */ } };
+const median = (a) => { const s = [...a].sort((x, y) => x - y); return s[Math.floor(s.length / 2)]; };
+
+function timeLoop(label, n, fn) {
+  const t0 = process.hrtime.bigint();
+  for (let i = 0; i < n; i++) fn(i);
+  const total = ms(t0);
+  console.log(`  ${label.padEnd(34)} ${total.toFixed(0).padStart(6)}ms total  ${(total / n).toFixed(0).padStart(5)}ms/call`);
+  return total;
+}
+
+console.log(`\nHost: ${HOST}   (wall-clock on this laptop)\n`);
+
+// P3: repeated same-host calls, handshake amortization.
+console.log('P3  repeated `--host` calls (10x trivial remote `true`)');
+const N = 10;
+clearSockets();
+const off = timeLoop('multiplex OFF (fresh handshake)', N, () => sshExec(HOST, 'true', { multiplex: false }));
+clearSockets();
+const on = timeLoop('multiplex ON  (reused socket)', N, () => sshExec(HOST, 'true', { multiplex: true }));
+console.log(`  => ${(off / on).toFixed(1)}x faster, ${(off - on).toFixed(0)}ms saved over ${N} calls\n`);
+
+// P2: readiness, old 3 round-trips (1 muxed + 2 un-muxed, as the old code did) vs new 1.
+console.log('P2  readiness check (median of 5)');
+const oldReady = [], newReady = [];
+for (let r = 0; r < 5; r++) {
+  clearSockets();
+  let t0 = process.hrtime.bigint();
+  sshExec(HOST, 'true', { multiplex: true });
+  sshExec(HOST, 'bash -lc "agents --version 2>/dev/null"', { multiplex: false });
+  sshExec(HOST, 'bash -lc "agents view 2>/dev/null || agents list 2>/dev/null"', { multiplex: false });
+  oldReady.push(ms(t0));
+  clearSockets();
+  t0 = process.hrtime.bigint();
+  readyProbe(HOST);
+  newReady.push(ms(t0));
+}
+console.log(`  old (3 round-trips)   ${median(oldReady).toFixed(0).padStart(6)}ms`);
+console.log(`  new (1 readyProbe)    ${median(newReady).toFixed(0).padStart(6)}ms`);
+console.log(`  => ${(median(oldReady) / median(newReady)).toFixed(1)}x faster, ${(median(oldReady) - median(newReady)).toFixed(0)}ms saved per dispatch\n`);
+
+// P1: follow loop, per-cycle cost + process spawns.
+console.log('P1  follow loop, cost of 20 poll cycles');
+const CYCLES = 20;
+const log = '$HOME/.agents/.cache/hosts/benchfollow.log';
+const exit = '$HOME/.agents/.cache/hosts/benchfollow.exit';
+execSync(`ssh ${HOST} ${JSON.stringify('mkdir -p ~/.agents/.cache/hosts; printf "x\\n" > ~/.agents/.cache/hosts/benchfollow.log; rm -f ~/.agents/.cache/hosts/benchfollow.exit')}`, { stdio: 'ignore' });
+clearSockets();
+const oldFollow = timeLoop('OLD 2 un-muxed calls/cycle', CYCLES, () => {
+  sshExec(HOST, `tail -c +1 ${log} 2>/dev/null`, { multiplex: false });
+  sshExec(HOST, `cat ${exit} 2>/dev/null`, { multiplex: false });
+});
+clearSockets();
+const newFollow = timeLoop('NEW 1 muxed combined call/cycle', CYCLES, () => {
+  sshExec(HOST, `tail -c +1 ${log} 2>/dev/null; printf '\\n@@M@@\\n'; cat ${exit} 2>/dev/null`, { multiplex: true });
+});
+execSync(`ssh ${HOST} 'rm -f ~/.agents/.cache/hosts/benchfollow.*'`, { stdio: 'ignore' });
+console.log(`  ssh process spawns:   OLD ${CYCLES * 2}   NEW ${CYCLES}   (50% fewer)`);
+console.log(`  => ${(oldFollow / newFollow).toFixed(1)}x faster wall-clock over ${CYCLES} cycles\n`);

--- a/src/commands/hosts.ts
+++ b/src/commands/hosts.ts
@@ -33,9 +33,16 @@ function parseTarget(target: string): { address: string; user?: string } {
   return { user: target.slice(0, at), address: target.slice(at + 1) };
 }
 
-/** Bootstrap/verify agents-cli on a freshly-enrolled host (best-effort, prompts). */
-async function maybeBootstrap(target: string, hostName: string): Promise<void> {
-  const probe = probeHost(target);
+/**
+ * Bootstrap/verify agents-cli on a freshly-enrolled host (best-effort, prompts).
+ * Callers that just probed the host pass the result through to avoid a second,
+ * redundant `uname` round-trip; otherwise we probe here.
+ */
+async function maybeBootstrap(
+  target: string,
+  hostName: string,
+  probe: { reachable: boolean; os?: string } = probeHost(target),
+): Promise<void> {
   if (!probe.reachable) {
     console.log(chalk.yellow(`  Not reachable over SSH yet — skipping bootstrap. Fix key auth, then: agents hosts check ${hostName}`));
     return;
@@ -86,7 +93,7 @@ async function doAdd(name: string | undefined, target: string | undefined, opts:
       const probe = probeHost(c);
       await registerHost({ name: c, provider: 'local', source, ...(source === 'inline' ? { address: c } : {}), os: probe.os, caps: opts.cap });
       console.log(chalk.green(`Enrolled ${c}`) + chalk.gray(` (${source}${probe.os ? `, ${probe.os}` : ''})`));
-      if (opts.enroll !== false) await maybeBootstrap(c, c);
+      if (opts.enroll !== false) await maybeBootstrap(c, c, probe);
     }
     return;
   }
@@ -117,7 +124,7 @@ async function doAdd(name: string | undefined, target: string | undefined, opts:
   if (!spec.os && probe.os) spec.os = probe.os;
   await registerHost(spec);
   console.log(chalk.green(`Enrolled ${name}`) + chalk.gray(` (${spec.source}${spec.os ? `, ${spec.os}` : ''}${spec.caps?.length ? `, caps: ${spec.caps.join(',')}` : ''})`));
-  if (opts.enroll !== false) await maybeBootstrap(sshTarget, name);
+  if (opts.enroll !== false) await maybeBootstrap(sshTarget, name, probe);
 }
 
 async function doList(json: boolean): Promise<void> {

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -9,8 +9,7 @@
 import { Option, type Command } from 'commander';
 import chalk from 'chalk';
 import * as fs from 'fs';
-import { spawnSync } from 'child_process';
-import { SSH_TARGET_RE, assertValidSshTarget, type SshExecResult } from '../lib/ssh-exec.js';
+import { SSH_TARGET_RE, assertValidSshTarget, sshExec, type SshExecResult } from '../lib/ssh-exec.js';
 import {
   parseHostsOption,
   remoteResolveEnv,
@@ -1277,20 +1276,18 @@ Examples:
           const remoteCmd = `bash -lc ${shellQuote(remoteAgents)}`;
           let failures = 0;
           for (const host of hosts) {
-            const res = spawnSync('ssh', ['-o', 'BatchMode=yes', host, remoteCmd], {
-              input,
-              stdio: ['pipe', 'pipe', 'pipe'],
-              encoding: 'utf-8',
-            });
-            if (res.error) {
+            // Routed through the shared ssh engine: full hardened options
+            // (BatchMode, ConnectTimeout, keepalive) + control-socket reuse.
+            const res = sshExec(host, remoteCmd, { input });
+            if (res.code === null) {
               failures++;
-              console.error(chalk.red(`${host}: ${res.error.message}`));
+              console.error(chalk.red(`${host}: ${res.stderr.trim() || (res.timedOut ? 'ssh timed out' : 'ssh failed')}`));
               continue;
             }
-            if (res.status !== 0) {
+            if (res.code !== 0) {
               failures++;
               const msg = (res.stderr || res.stdout || '').trim();
-              console.error(chalk.red(`${host}: remote import failed (exit ${res.status ?? 'signal'})${msg ? `: ${msg}` : ''}`));
+              console.error(chalk.red(`${host}: remote import failed (exit ${res.code})${msg ? `: ${msg}` : ''}`));
               continue;
             }
             const remoteMsg = (res.stdout || '').trim().split('\n').map((l) => l.trim()).filter(Boolean).pop();

--- a/src/lib/hosts/progress.test.ts
+++ b/src/lib/hosts/progress.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { exitMarker, splitProgressOutput } from './progress.js';
+
+describe('exitMarker', () => {
+  it('embeds the task id so it cannot collide with generic output', () => {
+    expect(exitMarker('a1b2c3d4')).toBe('\n@@AGENTS_HOST_EXIT_a1b2c3d4@@\n');
+  });
+});
+
+describe('splitProgressOutput', () => {
+  const id = 'a1b2c3d4';
+  const M = exitMarker(id);
+
+  it('splits log bytes from the exit code in a single combined fetch', () => {
+    const out = `hello world${M}0`;
+    expect(splitProgressOutput(out, id)).toEqual({ logChunk: 'hello world', exit: '0' });
+  });
+
+  it('returns an empty exit while the job is still running', () => {
+    const out = `some streamed output${M}`;
+    expect(splitProgressOutput(out, id)).toEqual({ logChunk: 'some streamed output', exit: '' });
+  });
+
+  it('reports an empty log chunk when there is no new output', () => {
+    const out = `${M}`;
+    expect(splitProgressOutput(out, id)).toEqual({ logChunk: '', exit: '' });
+  });
+
+  it('returns null when the marker is absent (transient fetch miss)', () => {
+    expect(splitProgressOutput('partial ssh output', id)).toBeNull();
+    expect(splitProgressOutput('', id)).toBeNull();
+  });
+
+  it('splits on the LAST marker so a token echoed in the log cannot spoof the boundary', () => {
+    // The agent's own output literally contained the sentinel; the real
+    // trailing marker must still win, keeping the echoed copy inside the log.
+    const echoed = `agent printed ${M} in its output`;
+    const out = `${echoed}${M}137`;
+    const r = splitProgressOutput(out, id);
+    expect(r).not.toBeNull();
+    expect(r!.exit).toBe('137');
+    expect(r!.logChunk).toBe(echoed);
+  });
+
+  it('is scoped per task id — another run’s marker is not treated as ours', () => {
+    const other = exitMarker('ffffffff');
+    const out = `log body${other}0`;
+    expect(splitProgressOutput(out, id)).toBeNull();
+  });
+});

--- a/src/lib/hosts/progress.test.ts
+++ b/src/lib/hosts/progress.test.ts
@@ -47,4 +47,15 @@ describe('splitProgressOutput', () => {
     const out = `log body${other}0`;
     expect(splitProgressOutput(out, id)).toBeNull();
   });
+
+  it('the printf-emitted sentinel round-trips through the parser (no desync)', () => {
+    // fetchProgress builds the remote printf format by escaping exitMarker's
+    // newlines; when the shell interprets those escapes it must reproduce the
+    // exact marker the parser splits on. Simulate that here.
+    const printfArg = exitMarker(id).replace(/\n/g, '\\n');
+    const emitted = printfArg.replace(/\\n/g, '\n'); // what `printf` writes out
+    expect(emitted).toBe(exitMarker(id));
+    const r = splitProgressOutput(`body${emitted}0`, id);
+    expect(r).toEqual({ logChunk: 'body', exit: '0' });
+  });
 });

--- a/src/lib/hosts/progress.ts
+++ b/src/lib/hosts/progress.ts
@@ -5,6 +5,13 @@
  * a sibling `.exit` file. We poll `tail -c +<offset>` (durable, offset-tracked —
  * a dropped connection resumes from the saved offset) and finish when `.exit`
  * appears. Rich transcript-parser rendering is a fast-follow.
+ *
+ * Efficiency: each cycle is a SINGLE ssh round-trip that returns the new log
+ * bytes, a per-task sentinel, then the exit-file contents — half the process +
+ * handshake cost of the old tail-then-cat pair. It rides the default control
+ * socket (multiplex on) that the launch opened, and eases the poll interval off
+ * toward `maxPollMs` while the job is idle, so a quiet long-running follow no
+ * longer spawns thousands of ssh processes per hour on the laptop.
  */
 
 import * as fs from 'fs';
@@ -24,39 +31,94 @@ export interface FollowOptions {
   echo?: boolean;
   /** Overall wall-clock cap; returns -1 on timeout. */
   timeoutMs?: number;
+  /** Fast poll interval while output is flowing (default 1500ms). */
   pollMs?: number;
+  /** Idle-backoff ceiling (default 4× the fast interval, min 4000ms). */
+  maxPollMs?: number;
+}
+
+/**
+ * Build the per-task sentinel that separates the log tail from the exit-file
+ * contents in one combined fetch. The task id (8 hex chars) makes collision with
+ * the agent's own output effectively impossible; callers still split on the LAST
+ * occurrence so a token echoed into the log can never be mistaken for the real
+ * trailing marker.
+ */
+export function exitMarker(taskId: string): string {
+  return `\n@@AGENTS_HOST_EXIT_${taskId}@@\n`;
+}
+
+/**
+ * Split a combined fetch (`<log bytes><marker><exit>`) back into its parts.
+ * Splits on the LAST marker occurrence, so even if the agent's own output
+ * happened to echo the token, the real trailing sentinel still wins. Returns
+ * null when the marker is absent (a transient fetch miss — the remote shell
+ * never ran our printf), telling the caller to retry without advancing.
+ */
+export function splitProgressOutput(stdout: string, taskId: string): { logChunk: string; exit: string } | null {
+  const marker = exitMarker(taskId);
+  const idx = stdout.lastIndexOf(marker);
+  if (idx === -1) return null;
+  return { logChunk: stdout.slice(0, idx), exit: stdout.slice(idx + marker.length) };
+}
+
+/**
+ * One round-trip: new log bytes since `offset`, the sentinel, then the exit
+ * file. Returns null on a transient fetch miss (ssh error / marker absent) so
+ * the caller simply retries next cycle without advancing the offset.
+ *
+ * `remoteLog`/`remoteExit` are $HOME-prefixed paths with safe (hex) basenames —
+ * intentionally unquoted so the remote shell expands $HOME.
+ */
+export function fetchProgress(
+  target: string,
+  opts: { remoteLog: string; remoteExit: string; taskId: string; offset: number },
+): { logChunk: string; exit: string } | null {
+  const remote =
+    `tail -c +${opts.offset + 1} ${opts.remoteLog} 2>/dev/null; ` +
+    `printf '\\n@@AGENTS_HOST_EXIT_${opts.taskId}@@\\n'; ` +
+    `cat ${opts.remoteExit} 2>/dev/null`;
+  const res = sshExec(target, remote, { timeoutMs: 20000 });
+  return splitProgressOutput(res.stdout, opts.taskId);
 }
 
 /** Tail the remote log to stdout until the run finishes; return its exit code. */
 export async function followHostTask(target: string, opts: FollowOptions): Promise<number> {
-  const pollMs = opts.pollMs ?? 1500;
+  const fastMs = opts.pollMs ?? 1500;
+  const maxMs = Math.max(opts.maxPollMs ?? fastMs * 4, 4000);
   const deadline = Date.now() + (opts.timeoutMs ?? 3600_000);
   const local = localLogPath(opts.taskId);
   let offset = 0;
+  let waitMs = fastMs;
 
-  const drain = (): void => {
-    // remoteLog is a $HOME-prefixed path with a safe (hex) basename — intentionally
-    // unquoted so the remote shell expands $HOME.
-    const chunk = sshExec(target, `tail -c +${offset + 1} ${opts.remoteLog} 2>/dev/null`, { timeoutMs: 20000 });
-    if (chunk.stdout) {
-      if (opts.echo) process.stdout.write(chunk.stdout);
-      try { fs.appendFileSync(local, chunk.stdout); } catch { /* best-effort */ }
-      offset += Buffer.byteLength(chunk.stdout, 'utf8');
-    }
+  const flush = (logChunk: string): boolean => {
+    if (!logChunk) return false;
+    if (opts.echo) process.stdout.write(logChunk);
+    try { fs.appendFileSync(local, logChunk); } catch { /* best-effort */ }
+    offset += Buffer.byteLength(logChunk, 'utf8');
+    return true;
   };
 
   for (;;) {
-    drain();
-    const exit = sshExec(target, `cat ${opts.remoteExit} 2>/dev/null`, { timeoutMs: 12000 });
-    if (exit.code === 0 && exit.stdout.trim() !== '') {
-      drain(); // final flush
-      const code = parseInt(exit.stdout.trim(), 10);
+    const r = fetchProgress(target, { remoteLog: opts.remoteLog, remoteExit: opts.remoteExit, taskId: opts.taskId, offset });
+    const gotOutput = r ? flush(r.logChunk) : false;
+
+    if (r && r.exit.trim() !== '') {
+      // Finished — one final fetch catches bytes written between our tail and
+      // the exit file appearing.
+      const tail = fetchProgress(target, { remoteLog: opts.remoteLog, remoteExit: opts.remoteExit, taskId: opts.taskId, offset });
+      if (tail) flush(tail.logChunk);
+      const code = parseInt(r.exit.trim(), 10);
       return Number.isFinite(code) ? code : 0;
     }
     if (Date.now() > deadline) {
       process.stderr.write('\n[hosts] follow timed out; the run continues on the host. Reattach with: agents hosts logs ' + opts.taskId + ' -f\n');
       return -1;
     }
-    await sleep(pollMs);
+
+    // Fast while output flows; ease toward maxMs when idle so a quiet job isn't
+    // polled needlessly. New output snaps the cadence back to fast.
+    waitMs = gotOutput ? fastMs : Math.min(maxMs, Math.round(waitMs * 1.5));
+    await sleep(waitMs);
   }
 }

--- a/src/lib/hosts/progress.ts
+++ b/src/lib/hosts/progress.ts
@@ -74,9 +74,14 @@ export function fetchProgress(
   target: string,
   opts: { remoteLog: string; remoteExit: string; taskId: string; offset: number },
 ): { logChunk: string; exit: string } | null {
+  // Derive the printf format from the SAME exitMarker the parser splits on, so
+  // the emitted sentinel and the one we look for can never desync. The marker's
+  // only escape-sensitive bytes are its newlines (→ `\n`); it carries no `%`,
+  // single-quote, or other printf/shell-special chars (task id is hex).
+  const printfArg = exitMarker(opts.taskId).replace(/\n/g, '\\n');
   const remote =
     `tail -c +${opts.offset + 1} ${opts.remoteLog} 2>/dev/null; ` +
-    `printf '\\n@@AGENTS_HOST_EXIT_${opts.taskId}@@\\n'; ` +
+    `printf '${printfArg}'; ` +
     `cat ${opts.remoteExit} 2>/dev/null`;
   const res = sshExec(target, remote, { timeoutMs: 20000 });
   return splitProgressOutput(res.stdout, opts.taskId);

--- a/src/lib/hosts/ready.test.ts
+++ b/src/lib/hosts/ready.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { parseReadyProbe, viewHasAgent } from './ready.js';
+
+const MARK = '@@AGENTS_READY@@';
+
+describe('parseReadyProbe', () => {
+  it('parses version + agent listing from one compound probe', () => {
+    const stdout = `2.1.170\n${MARK}\nClaude (balanced)\nCodex (balanced)\n`;
+    const p = parseReadyProbe(stdout);
+    expect(p.reachable).toBe(true);
+    expect(p.version).toBe('2.1.170');
+    expect(p.view).toContain('Claude');
+  });
+
+  it('strips a leading v from the version', () => {
+    expect(parseReadyProbe(`v2.1.170\n${MARK}\nClaude`).version).toBe('2.1.170');
+  });
+
+  it('reports reachable-but-not-installed when the version half is empty', () => {
+    // agents-cli missing: `agents --version` printed nothing, but the login
+    // shell still ran our printf so the marker (and thus reachability) is intact.
+    const p = parseReadyProbe(`\n${MARK}\n`);
+    expect(p.reachable).toBe(true);
+    expect(p.version).toBeNull();
+  });
+
+  it('treats a missing marker as unreachable (ssh never ran our shell)', () => {
+    const p = parseReadyProbe('');
+    expect(p.reachable).toBe(false);
+    expect(p.version).toBeNull();
+    expect(p.view).toBe('');
+  });
+});
+
+describe('viewHasAgent', () => {
+  const view = 'Claude (balanced) 2.1.170\nCodex (balanced) 0.134.0';
+  it('matches an installed agent case-insensitively', () => {
+    expect(viewHasAgent(view, 'claude')).toBe(true);
+    expect(viewHasAgent(view, 'codex')).toBe(true);
+  });
+  it('does not match an absent agent', () => {
+    expect(viewHasAgent(view, 'gemini')).toBe(false);
+  });
+});

--- a/src/lib/hosts/ready.ts
+++ b/src/lib/hosts/ready.ts
@@ -9,7 +9,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { sshExec, sshReachable, shellQuote } from '../ssh-exec.js';
+import { sshExec, shellQuote } from '../ssh-exec.js';
 import type { Host } from './types.js';
 import { sshTargetFor } from './types.js';
 
@@ -47,15 +47,6 @@ export function remoteAgentsVersion(target: string): string | null {
   return v || null;
 }
 
-/** True if the named agent CLI is installed on the remote (best-effort). */
-export function remoteAgentInstalled(target: string, agent: string): boolean {
-  // `agents view` (formerly `agents list`) prints capitalized display names
-  // (e.g. "Claude"), so match case-insensitively.
-  const r = sshExec(target, `bash -lc "agents view 2>/dev/null || agents list 2>/dev/null"`, { timeoutMs: 20000 });
-  if (r.code !== 0) return false;
-  return new RegExp(`\\b${agent}\\b`, 'i').test(r.stdout);
-}
-
 /** Install (or upgrade to) a specific agents-cli version on the remote, then `agents setup`. */
 export function bootstrapAgentsCli(target: string, version: string | null): { ok: boolean; output: string } {
   const spec = version ? `@phnx-labs/agents-cli@${version}` : '@phnx-labs/agents-cli';
@@ -65,6 +56,47 @@ export function bootstrapAgentsCli(target: string, version: string | null): { ok
     `agents --version`;
   const r = sshExec(target, `bash -lc ${shellQuote(script)}`, { timeoutMs: 300000 });
   return { ok: r.code === 0, output: (r.stdout + r.stderr).trim() };
+}
+
+/** Sentinel splitting the version output from the agent listing in one probe. */
+const READY_MARKER = '@@AGENTS_READY@@';
+
+export interface ReadyProbe {
+  /** ssh connected and the remote login shell ran (our sentinel came back). */
+  reachable: boolean;
+  /** Remote agents-cli version (no leading `v`), or null if not installed. */
+  version: string | null;
+  /** Raw `agents view`/`list` output, for installed-agent checks. */
+  view: string;
+}
+
+/**
+ * Answer every readiness question in ONE ssh round-trip: reachable? (the login
+ * shell ran and echoed our sentinel), agents-cli version, and the installed-agent
+ * listing. This replaces three sequential probes (`true` + `agents --version` +
+ * `agents view`) — 3 handshakes collapse to 1. Reachability keys off the sentinel
+ * rather than the exit code, so a command that ran-but-failed is never mistaken
+ * for a dead connection (only ssh's own failure drops the sentinel).
+ */
+export function readyProbe(target: string): ReadyProbe {
+  const script =
+    `agents --version 2>/dev/null; printf '\\n${READY_MARKER}\\n'; ` +
+    `agents view 2>/dev/null || agents list 2>/dev/null`;
+  const r = sshExec(target, `bash -lc ${shellQuote(script)}`, { timeoutMs: 20000 });
+  return parseReadyProbe(r.stdout);
+}
+
+/** Pure parser for `readyProbe` output (unit-tested without ssh). */
+export function parseReadyProbe(stdout: string): ReadyProbe {
+  const idx = stdout.indexOf(READY_MARKER);
+  if (idx === -1) return { reachable: false, version: null, view: '' };
+  const version = stdout.slice(0, idx).trim().replace(/^v/, '') || null;
+  return { reachable: true, version, view: stdout.slice(idx + READY_MARKER.length) };
+}
+
+/** True if `view` output lists the named agent (word-boundary, case-insensitive). */
+export function viewHasAgent(view: string, agent: string): boolean {
+  return new RegExp(`\\b${agent}\\b`, 'i').test(view);
 }
 
 export interface EnsureReadyOptions {
@@ -77,19 +109,22 @@ export interface EnsureReadyOptions {
  * Verify a host can run the agent: reachable + agents-cli present. Throws with an
  * actionable message otherwise. Agent-not-installed is a warning by default (the
  * remote `agents run` will surface it); pass requireAgent to make it fatal.
+ *
+ * One ssh round-trip (`readyProbe`) covers all three checks.
  */
 export function ensureHostReady(host: Host, opts: EnsureReadyOptions): { warnings: string[] } {
   const target = sshTargetFor(host);
-  if (!sshReachable(target)) {
+  const probe = readyProbe(target);
+  if (!probe.reachable) {
     throw new Error(`Host "${host.name}" (${target}) is not reachable over SSH. Check it's online and key auth works.`);
   }
-  if (!remoteAgentsVersion(target)) {
+  if (!probe.version) {
     throw new Error(
       `agents-cli is not installed on "${host.name}". Enroll it first: agents hosts add ${host.name} (bootstraps agents-cli).`,
     );
   }
   const warnings: string[] = [];
-  if (!remoteAgentInstalled(target, opts.agent)) {
+  if (!viewHasAgent(probe.view, opts.agent)) {
     const msg = `Agent "${opts.agent}" may not be installed on "${host.name}" (remote \`agents add ${opts.agent}\` to install).`;
     if (opts.requireAgent) throw new Error(msg);
     warnings.push(msg);

--- a/src/lib/session/remote.ts
+++ b/src/lib/session/remote.ts
@@ -27,6 +27,7 @@ import { join } from 'path';
 import { createHash } from 'crypto';
 import chalk from 'chalk';
 import { getCacheDir } from '../state.js';
+import { SSH_OPTS, controlOpts } from '../ssh-exec.js';
 import { formatRelativeTime } from './relative-time.js';
 import { terminalWidth } from './width.js';
 
@@ -100,11 +101,6 @@ export function buildRemoteCommand(forwardedArgs: string[], columns?: number): s
   return `bash -lc ${shellQuote(withCols)}`;
 }
 
-const SSH_OPTS = [
-  '-o', 'BatchMode=yes',
-  '-o', 'StrictHostKeyChecking=accept-new',
-  '-o', 'ConnectTimeout=10',
-];
 
 /** The four outcomes of one `ssh <host> agents sessions …` invocation. */
 export type SshOutcome = 'ok' | 'unreachable' | 'query-failed' | 'spawn-error';
@@ -197,7 +193,7 @@ export function runRemoteSessions(hosts: string[], argv: string[] = process.argv
 
   for (const host of hosts) {
     if (multi) process.stdout.write(chalk.cyan(`\n── ${host} ──\n`));
-    const res = spawnSync('ssh', [...SSH_OPTS, host, remoteCmd], {
+    const res = spawnSync('ssh', [...SSH_OPTS, ...controlOpts(), host, remoteCmd], {
       encoding: 'utf8',
       maxBuffer: 64 * 1024 * 1024,
     });

--- a/src/lib/ssh-exec.test.ts
+++ b/src/lib/ssh-exec.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
-import { assertValidSshTarget, SSH_TARGET_RE, shellQuote, controlOpts } from './ssh-exec.js';
+import { assertValidSshTarget, SSH_TARGET_RE, shellQuote, controlOpts, SSH_OPTS } from './ssh-exec.js';
 
 describe('assertValidSshTarget', () => {
   it('accepts bare host aliases and user@host', () => {
@@ -41,6 +41,21 @@ describe('shellQuote', () => {
   it('escapes embedded single quotes correctly', () => {
     // it's -> 'it'\''s'  (close, escaped quote, reopen)
     expect(shellQuote("it's")).toBe("'it'\\''s'");
+  });
+});
+
+describe('SSH_OPTS (hardened baseline)', () => {
+  it('keeps the connection hardening', () => {
+    expect(SSH_OPTS).toContain('StrictHostKeyChecking=accept-new');
+    expect(SSH_OPTS).toContain('BatchMode=yes');
+    expect(SSH_OPTS).toContain('ConnectTimeout=10');
+  });
+
+  it('adds keepalive so a dropped link exits instead of zombying', () => {
+    // ServerAliveInterval * ServerAliveCountMax bounds how long a dead
+    // connection can hang before ssh gives up (~45s here).
+    expect(SSH_OPTS).toContain('ServerAliveInterval=15');
+    expect(SSH_OPTS).toContain('ServerAliveCountMax=3');
   });
 });
 

--- a/src/lib/ssh-exec.ts
+++ b/src/lib/ssh-exec.ts
@@ -35,11 +35,22 @@ export function shellQuote(s: string): string {
   return "'" + s.replace(/'/g, "'\\''") + "'";
 }
 
-/** Hardened ssh options applied to every connection. */
+/**
+ * Hardened ssh options applied to every connection — the single baseline every
+ * `ssh` in the codebase composes from (directly here, or as `[...SSH_OPTS, …]`
+ * in the few callers that need extra flags like `-L`/`-N`/`ProxyCommand`).
+ *
+ * `ServerAliveInterval`/`ServerAliveCountMax` add in-connection keepalive: a
+ * silently-dropped link (laptop sleeps, Wi-Fi flips) is detected and the ssh
+ * process exits within ~45s instead of hanging forever — so a followed run or a
+ * long-lived `-N` tunnel can't leave a zombie ssh + socket pinned on the laptop.
+ */
 export const SSH_OPTS: readonly string[] = [
   '-o', 'StrictHostKeyChecking=accept-new',
   '-o', 'BatchMode=yes',
   '-o', 'ConnectTimeout=10',
+  '-o', 'ServerAliveInterval=15',
+  '-o', 'ServerAliveCountMax=3',
 ];
 
 /**
@@ -50,6 +61,12 @@ export const SSH_OPTS: readonly string[] = [
  * each. `ControlPersist=60s` keeps the master alive briefly after the last
  * client exits. `%C` (a short fixed-length hash of local-host/remote/port/user)
  * keeps the socket path well under macOS's 104-char `sun_path` limit.
+ *
+ * This is **on by default** for every `sshExec`/`sshStream` call: the poll loops
+ * (`followHostTask`), readiness probes, and per-host fan-outs are exactly the
+ * high-frequency callers that benefit most from socket reuse, and they should
+ * never have to remember to opt in. A caller passes `multiplex: false` only for
+ * a genuine one-shot where a lingering 60s master is pure overhead.
  *
  * The socket directory is created lazily; if ssh can't open the control socket
  * it falls back to a normal connection (multiplexing is an optimisation, never a
@@ -84,7 +101,7 @@ export interface SshExecOptions {
   timeoutMs?: number;
   /** Extra ssh flags inserted before the target (e.g. `-tt`). */
   extraSshArgs?: string[];
-  /** Reuse a persistent control socket across calls (see `controlOpts`). */
+  /** Reuse a persistent control socket across calls (default true; see `controlOpts`). */
   multiplex?: boolean;
 }
 
@@ -104,7 +121,7 @@ export interface SshExecResult {
  */
 export function sshExec(target: string, remoteCmd: string, opts: SshExecOptions = {}): SshExecResult {
   assertValidSshTarget(target);
-  const mux = opts.multiplex ? controlOpts() : [];
+  const mux = opts.multiplex === false ? [] : controlOpts();
   const args = [...SSH_OPTS, ...mux, ...(opts.extraSshArgs ?? []), target, remoteCmd];
   const res = spawnSync('ssh', args, {
     input: opts.input,
@@ -134,7 +151,7 @@ export interface SshStreamOptions {
    * leave it off and forward a non-interactive invocation instead.
    */
   tty?: boolean;
-  /** Reuse a persistent control socket across calls (see `controlOpts`). */
+  /** Reuse a persistent control socket across calls (default true; see `controlOpts`). */
   multiplex?: boolean;
 }
 
@@ -147,7 +164,7 @@ export interface SshStreamOptions {
  */
 export function sshStream(target: string, remoteCmd: string, opts: SshStreamOptions = {}): number {
   assertValidSshTarget(target);
-  const mux = opts.multiplex ? controlOpts() : [];
+  const mux = opts.multiplex === false ? [] : controlOpts();
   const tty = opts.tty ? ['-tt'] : [];
   const args = [...SSH_OPTS, ...mux, ...tty, target, remoteCmd];
   const res = spawnSync('ssh', args, { stdio: 'inherit' });

--- a/src/lib/ssh-tunnel.test.ts
+++ b/src/lib/ssh-tunnel.test.ts
@@ -12,6 +12,7 @@ import {
   REMOTE_TASK_NAME,
   WIN_HELPER_EXE,
 } from './ssh-tunnel.js';
+import { SSH_OPTS } from './ssh-exec.js';
 import { encodePowerShell } from './browser/drivers/ssh.js';
 
 describe('buildTunnelArgs', () => {
@@ -27,20 +28,23 @@ describe('buildTunnelArgs', () => {
     expect(args.join(' ')).toContain('ConnectTimeout=10');
   });
 
-  it('matches the args the browser driver historically spawned (behavior unchanged)', () => {
-    // The browser CDP driver used exactly this argv shape before extraction.
+  it('is the -L mapping + target + -N followed by the shared hardened baseline', () => {
+    // The tunnel now composes the canonical SSH_OPTS instead of re-listing the
+    // options, so it automatically inherits the keepalive (which lets a dropped
+    // -N tunnel exit instead of zombying) and any future baseline hardening.
     expect(buildTunnelArgs('u', 'h', 9222, 9222)).toEqual([
       '-L',
       '9222:127.0.0.1:9222',
       'u@h',
       '-N',
-      '-o',
-      'StrictHostKeyChecking=accept-new',
-      '-o',
-      'BatchMode=yes',
-      '-o',
-      'ConnectTimeout=10',
+      ...SSH_OPTS,
     ]);
+  });
+
+  it('inherits the keepalive from the shared baseline', () => {
+    const args = buildTunnelArgs('u', 'h', 9222, 9222);
+    expect(args.join(' ')).toContain('ServerAliveInterval=15');
+    expect(args.join(' ')).toContain('ServerAliveCountMax=3');
   });
 });
 

--- a/src/lib/ssh-tunnel.ts
+++ b/src/lib/ssh-tunnel.ts
@@ -47,7 +47,11 @@ export interface StartTunnelOptions {
   detached?: boolean;
 }
 
-/** Build the ssh argv (after the `ssh` program name) for an `-L` tunnel. Pure. */
+/** Build the ssh argv (after the `ssh` program name) for an `-L` tunnel. Pure.
+ *
+ * Composes the shared hardened baseline (`SSH_OPTS`) rather than re-listing it,
+ * so the tunnel inherits the same options — crucially the keepalive, which lets
+ * a dropped `-N` tunnel exit instead of lingering as a zombie on the laptop. */
 export function buildTunnelArgs(
   user: string,
   host: string,
@@ -59,12 +63,7 @@ export function buildTunnelArgs(
     `${localPort}:127.0.0.1:${remotePort}`,
     `${user}@${host}`,
     '-N',
-    '-o',
-    'StrictHostKeyChecking=accept-new',
-    '-o',
-    'BatchMode=yes',
-    '-o',
-    'ConnectTimeout=10',
+    ...SSH_OPTS,
   ];
 }
 


### PR DESCRIPTION
## Why

Remote `--host` work is driven from an 8 GB laptop, where the cost that matters is **local**: every `ssh` fork is a process, socket, and TCP+auth handshake on the user's kernel. The transport already had OpenSSH multiplexing built in, but it was **opt-in** and only 3 of ~13 call paths used it — so the busiest paths reopened a fresh connection every time.

This unifies everything on one SSH engine: **one hardened baseline (`SSH_OPTS`, now with keepalive) + one multiplex helper (`controlOpts`, now default-on)**, and every `ssh` composes from them.

## What changed (issue → fix)

- **P1 · follow-loop churn** — `followHostTask` spawned 2 un-multiplexed ssh/1.5s (~4,800/hr per followed run). Now **one** round-trip per cycle (combined tail + exit via a per-task sentinel), default-multiplexed, with idle backoff toward 4s.
- **P2 · triple readiness probe** — `ensureHostReady` fired 3 sequential connections before every `run --host`. Collapsed into one compound `readyProbe` (reachable + version + agent listing); reachability keys off a sentinel, not the exit code.
- **P3 · opt-in multiplexing** — flipped to **default-on** (`multiplex: false` to opt out). Every routed caller now reuses the control socket.
- **P4 · duplicate options** — `session/remote.ts` kept its own non-multiplexing `SSH_OPTS`; now imports the canonical baseline + `controlOpts`.
- **P5 · stray spawns** — the secrets push (was `-o BatchMode` only) routes through `sshExec`; the `-N` tunnel composes `SSH_OPTS`.
- **P6 · redundant probe** — `hosts add` threaded its probe result through `maybeBootstrap`, dropping a duplicate `uname`.
- **P7 · no keepalive** — `ServerAliveInterval=15` / `ServerAliveCountMax=3` added to the baseline, so dropped links (and long-lived tunnels) exit in ~45s instead of zombying.

## Verification (live host `yosemite-s1`)

- **P3:** back-to-back `view --host` — cold 1.34s opens `cm-*` control socket, warm **0.40s** (socket reused).
- **P2:** `readyProbe` → `reachable:true, version:1.20.27, has claude:true` in one call.
- **P4/P7:** live `sessions --host` ssh argv now carries `ControlMaster=auto`, `ControlPersist=60s`, `ServerAliveInterval=15`, `ServerAliveCountMax=3`.
- **P1:** seeded a remote log+exit; `followHostTask` streamed output, caught the delayed line, returned exit **42** correctly.
- **Tests:** full suite green with a build present (3437 pass; the 3 integration suites that need `dist/` pass after `bun run build`). New 1:1 tests: `progress.test.ts`, `ready.test.ts`, plus `ssh-exec`/`ssh-tunnel` additions.
