### PR TITLE
fix(test): Windows ensureShimCurrent fixtures write to on-disk shim path

### DIFF
--- a/src/lib/__tests__/shims.test.ts
+++ b/src/lib/__tests__/shims.test.ts
@@ -392,9 +392,20 @@ describe('ensureShimCurrent — upgrade-only / newest-wins', () => {
     fs.writeFileSync(shimPath, `#!/bin/bash\n# ${marker}\nexec true\n`, { mode: 0o755 });
   }
 
+  // The file createShim actually writes on this platform: `<cmd>.cmd` on Windows,
+  // the bare script on POSIX. Fixtures must land here — since #543, shimExists /
+  // readShimSchemaVersion key off the on-disk filename (onDiskShimFile), while
+  // getShimPath returns the logical (extensionless) launch path that isn't a real
+  // file on Windows. Writing the fixture to getShimPath left Windows looking for a
+  // `.cmd` that never existed, so ensureShimCurrent always returned 'created'.
+  function onDiskShimPath(mod: typeof import('../shims.js'), agent: 'claude'): string {
+    const logical = mod.getShimPath(agent);
+    return path.join(path.dirname(logical), mod.onDiskShimFile(path.basename(logical), process.platform));
+  }
+
   it('does NOT downgrade a shim stamped by a newer install', async () => {
     const mod = await import('../shims.js');
-    const shimPath = mod.getShimPath('claude');
+    const shimPath = onDiskShimPath(mod, 'claude');
     const newer = mod.SHIM_SCHEMA_VERSION + 1;
     writeShim(shimPath, `agents-shim-version: ${newer}`);
     const before = fs.readFileSync(shimPath, 'utf8');
@@ -405,7 +416,7 @@ describe('ensureShimCurrent — upgrade-only / newest-wins', () => {
 
   it('regenerates a shim from an older install (upgrade)', async () => {
     const mod = await import('../shims.js');
-    const shimPath = mod.getShimPath('claude');
+    const shimPath = onDiskShimPath(mod, 'claude');
     writeShim(shimPath, 'agents-shim-version: 1');
 
     expect(mod.ensureShimCurrent('claude')).toBe('updated');
@@ -416,7 +427,7 @@ describe('ensureShimCurrent — upgrade-only / newest-wins', () => {
 
   it('regenerates an unversioned (pre-marker) shim', async () => {
     const mod = await import('../shims.js');
-    const shimPath = mod.getShimPath('claude');
+    const shimPath = onDiskShimPath(mod, 'claude');
     writeShim(shimPath, 'no marker here');
 
     expect(mod.ensureShimCurrent('claude')).toBe('updated');


### PR DESCRIPTION
## Problem

The `1.20.34` release (PR #550) failed its Windows CI matrix: 3 failures in `src/lib/__tests__/shims.test.ts → ensureShimCurrent — upgrade-only / newest-wins` (`shims.test.ts:402/411/422`), each `expected 'created' to be 'current'/'updated'`. The full cross-platform matrix only runs on `release/**` branches, so this slipped through the feature PR (#543) that introduced it.

## Root cause — test bug, not production

Since **#543** (`fix(windows): … drop vestigial shim`), on Windows `createShim` writes only `<cmd>.cmd`, and `shimExists` / `readShimSchemaVersion` key off that on-disk filename via `onDiskShimFile`. But the tests wrote their fixture to `getShimPath('claude')` — the **logical, extensionless** launch path, which is not a real file on Windows. So `shimExists('claude')` looked for `claude.cmd` (never written) → `ensureShimCurrent` returned `'created'`.

Production `ensureShimCurrent` is correct on Windows; only the test simulated the wrong on-disk file.

## Fix

Point the fixtures at `onDiskShimFile(basename, process.platform)` — where the code actually reads — on both platforms. POSIX is unchanged (`onDiskShimFile` is identity there).

## Verification

- macOS: `shims.test.ts` 42 passed; `tsc --noEmit` clean.
- **Simulated `win32`** (forced `process.platform`, drove production `ensureShimCurrent` through a temp HOME):
  ```
  onDiskShimFile(claude,win32) = claude.cmd
  A newer marker  -> current  PASS (file untouched)
  B older marker  -> updated  PASS
  C unversioned   -> updated  PASS
  ```

Unblocks the `1.20.34` release.
