### PR TITLE
test(shims): fix ensureShimCurrent fixtures for the Windows .cmd shim path

### DIFF
--- a/src/lib/__tests__/shims.test.ts
+++ b/src/lib/__tests__/shims.test.ts
@@ -392,9 +392,18 @@ describe('ensureShimCurrent — upgrade-only / newest-wins', () => {
     fs.writeFileSync(shimPath, `#!/bin/bash\n# ${marker}\nexec true\n`, { mode: 0o755 });
   }
 
+  // The on-disk shim file ensureShimCurrent actually stats: the `.cmd` companion
+  // on Windows (createShim writes only that), the extensionless script on POSIX.
+  // Fixtures must land where the code looks, or exists/version checks miss them
+  // and every call reports 'created'.
+  function onDiskShim(mod: typeof import('../shims.js')): string {
+    const base = mod.getShimPath('claude');
+    return process.platform === 'win32' ? `${base}.cmd` : base;
+  }
+
   it('does NOT downgrade a shim stamped by a newer install', async () => {
     const mod = await import('../shims.js');
-    const shimPath = mod.getShimPath('claude');
+    const shimPath = onDiskShim(mod);
     const newer = mod.SHIM_SCHEMA_VERSION + 1;
     writeShim(shimPath, `agents-shim-version: ${newer}`);
     const before = fs.readFileSync(shimPath, 'utf8');
@@ -405,7 +414,7 @@ describe('ensureShimCurrent — upgrade-only / newest-wins', () => {
 
   it('regenerates a shim from an older install (upgrade)', async () => {
     const mod = await import('../shims.js');
-    const shimPath = mod.getShimPath('claude');
+    const shimPath = onDiskShim(mod);
     writeShim(shimPath, 'agents-shim-version: 1');
 
     expect(mod.ensureShimCurrent('claude')).toBe('updated');
@@ -416,7 +425,7 @@ describe('ensureShimCurrent — upgrade-only / newest-wins', () => {
 
   it('regenerates an unversioned (pre-marker) shim', async () => {
     const mod = await import('../shims.js');
-    const shimPath = mod.getShimPath('claude');
+    const shimPath = onDiskShim(mod);
     writeShim(shimPath, 'no marker here');
 
     expect(mod.ensureShimCurrent('claude')).toBe('updated');


### PR DESCRIPTION
The windows-latest matrix on release PR #550 fails 3 tests in `src/lib/__tests__/shims.test.ts` (`ensureShimCurrent — upgrade-only`): `expected 'created' to be 'current'/'updated'`.

## Cause
Post-#543, `createShim`/`shimExists` stat the `.cmd` companion on Windows (the extensionless bash shim is no longer written there). But these tests write their fixture to the extensionless `getShimPath(...)` and read it back, so on Windows the fixture is invisible and `ensureShimCurrent` returns `created` (regenerate) instead of `current`/`updated`. Production behavior is correct — the test hardcoded the old extensionless assumption. It shipped red because the Windows matrix is release-gated (never ran on the #543 PR).

## Fix
A local `onDiskShim(mod)` helper returns the platform on-disk path (`.cmd` on Windows, extensionless on POSIX); the 3 fixtures + their read-backs use it. No production code change.

## Verify
- Linux: `npx vitest run src/lib/__tests__/shims.test.ts` → 42 passed.
- Windows (win-mini): confirmed the 3 previously-failing tests pass (see comment).

Unblocks the windows-latest leg of release PR #550.