### PR TITLE
feat(upgrade): compact "What's new" changelog — headings only

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,7 @@ import {
   type ModuleLoader,
 } from './lib/startup/command-registry.js';
 import { applyGlobalHelpConventions } from './lib/help.js';
+import { renderWhatsNew } from './lib/whats-new.js';
 import type { AgentId } from './lib/types.js';
 import { IS_WINDOWS } from './lib/platform/index.js';
 
@@ -252,45 +253,14 @@ async function showWhatsNew(fromVersion: string, toVersion: string): Promise<voi
     const response = await fetch(`https://unpkg.com/@phnx-labs/agents-cli@${toVersion}/CHANGELOG.md`);
     if (!response.ok) return;
 
-    const changelog = await response.text();
-    const lines = changelog.split('\n');
-
-    const relevantChanges: string[] = [];
-    let inRelevantSection = false;
-    let currentVersion = '';
-
-    for (const line of lines) {
-      const versionMatch = line.match(/^## (\d+\.\d+\.\d+)/);
-      if (versionMatch) {
-        currentVersion = versionMatch[1];
-        // Only the range the user actually moved through: (fromVersion, toVersion].
-        // Bounding the top end matters when upgrading to a specific older
-        // version, and guards against a changelog that lists unreleased entries.
-        const inRange =
-          compareVersions(currentVersion, fromVersion) > 0 &&
-          compareVersions(currentVersion, toVersion) <= 0;
-        inRelevantSection = inRange;
-        if (inRelevantSection) {
-          relevantChanges.push('');
-          relevantChanges.push(chalk.bold(`v${currentVersion}`));
-        }
-        continue;
-      }
-
-      if (inRelevantSection && line.trim()) {
-        if (line.startsWith('**') && line.endsWith('**')) {
-          relevantChanges.push(chalk.cyan(line.replace(/\*\*/g, '')));
-        } else if (line.startsWith('- ')) {
-          relevantChanges.push(chalk.gray(`  ${line}`));
-        }
-      }
-    }
+    const relevantChanges = renderWhatsNew(await response.text(), fromVersion, toVersion);
 
     if (relevantChanges.length > 0) {
       console.log(chalk.bold("\nWhat's new:\n"));
       for (const line of relevantChanges) {
         console.log(line);
       }
+      console.log(chalk.gray('\nFull notes: https://github.com/phnx-labs/agents-cli/blob/main/CHANGELOG.md'));
       console.log();
     }
   } catch {

--- a/src/lib/whats-new.test.ts
+++ b/src/lib/whats-new.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { renderWhatsNew } from './whats-new.js';
 
-// Strip ANSI so assertions read against plain text.
-const plain = (s: string) => s.replace(/\[[0-9;]*m/g, '');
+// Strip ANSI so assertions read against plain text (robust under FORCE_COLOR).
+// eslint-disable-next-line no-control-regex
+const plain = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
 
 const CHANGELOG = `# Changelog
 

--- a/src/lib/whats-new.test.ts
+++ b/src/lib/whats-new.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { renderWhatsNew } from './whats-new.js';
+
+// Strip ANSI so assertions read against plain text.
+const plain = (s: string) => s.replace(/\[[0-9;]*m/g, '');
+
+const CHANGELOG = `# Changelog
+
+## Unreleased
+
+## 1.20.34
+
+**Test suite runs remotely on a crabbox VM (#525, #540)**
+
+- \`scripts/release.sh\`'s test gate now runs on a leased crabbox VM.
+- \`scripts/sandbox.sh\` box acquisition is now robust.
+
+## 1.20.31
+
+**\`agents sessions <id>\`: a catch-up digest (#502)**
+
+- Opening a single session now leads with its title.
+
+**A second heading in the same version**
+
+- Some detail.
+- Another detail with an inline **bold** word.
+
+## 1.20.30
+
+**Older release the user already had**
+
+- Should never appear.
+`;
+
+describe('renderWhatsNew', () => {
+  it('keeps only headings as bullets and drops the verbose sub-bullets', () => {
+    const lines = renderWhatsNew(CHANGELOG, '1.20.31', '1.20.34').map(plain);
+
+    // Version header + its single heading, nothing from the detail bullets.
+    expect(lines).toContain('v1.20.34');
+    expect(lines).toContain('  • Test suite runs remotely on a crabbox VM (#525, #540)');
+    // The detail sub-bullets must be gone.
+    expect(lines.some((l) => l.includes('release.sh'))).toBe(false);
+    expect(lines.some((l) => l.includes('box acquisition'))).toBe(false);
+  });
+
+  it('emits a bullet for every heading within a single version', () => {
+    const lines = renderWhatsNew(CHANGELOG, '1.20.30', '1.20.31').map(plain);
+    expect(lines).toContain('v1.20.31');
+    expect(lines).toContain('  • `agents sessions <id>`: a catch-up digest (#502)');
+    expect(lines).toContain('  • A second heading in the same version');
+  });
+
+  it('bounds the range to (from, to] — excludes from, includes to, skips out-of-range', () => {
+    const lines = renderWhatsNew(CHANGELOG, '1.20.31', '1.20.34').map(plain);
+    // from (1.20.31) is excluded ...
+    expect(lines).not.toContain('v1.20.31');
+    // ... and versions below from are never shown.
+    expect(lines.some((l) => l.includes('Older release'))).toBe(false);
+    expect(lines).not.toContain('v1.20.30');
+  });
+
+  it('returns nothing when the range is empty', () => {
+    expect(renderWhatsNew(CHANGELOG, '1.20.34', '1.20.34')).toEqual([]);
+  });
+});

--- a/src/lib/whats-new.ts
+++ b/src/lib/whats-new.ts
@@ -1,0 +1,39 @@
+import chalk from 'chalk';
+import { compareVersions } from './agent-spec/primitives.js';
+
+/**
+ * Render a compact "What's new" summary from a CHANGELOG.md body: one bullet
+ * per feature/fix heading (the `**...**` lines) for each version in the range
+ * the user actually moved through, `(fromVersion, toVersion]`. The verbose
+ * sub-bullets are intentionally dropped — the full notes live in the changelog.
+ *
+ * Returns colored lines ready to print, empty when nothing is in range.
+ */
+export function renderWhatsNew(changelog: string, fromVersion: string, toVersion: string): string[] {
+  const out: string[] = [];
+  let inRelevantSection = false;
+
+  for (const line of changelog.split('\n')) {
+    const versionMatch = line.match(/^## (\d+\.\d+\.\d+)/);
+    if (versionMatch) {
+      const currentVersion = versionMatch[1];
+      // Bounding the top end matters when upgrading to a specific older
+      // version, and guards against a changelog that lists unreleased entries.
+      inRelevantSection =
+        compareVersions(currentVersion, fromVersion) > 0 &&
+        compareVersions(currentVersion, toVersion) <= 0;
+      if (inRelevantSection) {
+        out.push('');
+        out.push(chalk.bold(`v${currentVersion}`));
+      }
+      continue;
+    }
+
+    // Only the bold headings — one bullet per feature/fix.
+    if (inRelevantSection && line.startsWith('**') && line.endsWith('**')) {
+      out.push(`  ${chalk.cyan('•')} ${line.replace(/\*\*/g, '')}`);
+    }
+  }
+
+  return out;
+}


### PR DESCRIPTION
## What

`agents upgrade` printed the **full** changelog for every version in the upgrade range — every heading *and* every verbose sub-bullet. Upgrading across a handful of versions dumped a screenful of text.

Now it prints **one bullet per feature/fix heading** and links to the full CHANGELOG for the details.

### Before (excerpt, one version)
```
v1.20.34
Test suite runs remotely on a crabbox VM (#525, #540)
  - `scripts/release.sh`'s test gate now runs `bun install && bun run build && bun run test` on a leased crabbox VM via `scripts/sandbox.sh` instead of freezing the local machine, matching CI's Build→Test order ...
  - `scripts/sandbox.sh` box acquisition is now robust: secrets load via `agents secrets export --plaintext` ...
```

### After
```
What's new:

v1.20.34
  • Test suite runs remotely on a crabbox VM (#525, #540)

v1.20.31
  • `agents sessions <id>`: a catch-up digest for switching between many agents (#502)

Full notes: https://github.com/phnx-labs/agents-cli/blob/main/CHANGELOG.md
```

## How

- Extracted the pure parser out of `src/index.ts` into `src/lib/whats-new.ts` (`renderWhatsNew`) so it's unit-testable without triggering the CLI's import-time `program.parseAsync()`.
- Reuses the canonical `compareVersions` from `lib/agent-spec/primitives.ts` (sign-compatible with the old local one).
- The `(fromVersion, toVersion]` range bounding is unchanged.

## Verification

- `bun run build` + `tsc --noEmit` clean.
- New `src/lib/whats-new.test.ts` (4 cases: headings-only, multi-heading per version, `(from, to]` range bounds, empty range) passes.
- End-to-end: fetched the real `unpkg` CHANGELOG for `@phnx-labs/agents-cli@1.20.34` and ran it through the built module for the `1.20.30 → 1.20.34` range — produced the compact output shown above.