### PR TITLE
fix(computer): repair Windows SSH transport (#555, #520)

### DIFF
--- a/src/lib/devices/connect.test.ts
+++ b/src/lib/devices/connect.test.ts
@@ -12,6 +12,12 @@ import { describe, expect, it } from 'vitest';
 import { buildSshInvocation, sshTargetFor, wrapRemoteCommand, ASKPASS_BUNDLE_ENV, ASKPASS_KEY_ENV } from './connect.js';
 import type { DeviceProfile } from './registry.js';
 
+function decodePowerShell(cmd: string): string {
+  const m = cmd.match(/^powershell -NoProfile -EncodedCommand (\S+)$/);
+  if (!m) throw new Error(`not an EncodedCommand invocation: ${cmd}`);
+  return Buffer.from(m[1], 'base64').toString('utf16le');
+}
+
 function dev(over: Partial<DeviceProfile> & { name: string }): DeviceProfile {
   return {
     name: over.name,
@@ -34,8 +40,10 @@ describe('sshTargetFor', () => {
 });
 
 describe('wrapRemoteCommand', () => {
-  it('wraps Windows commands in PowerShell, leaves POSIX verbatim, undefined for interactive', () => {
-    expect(wrapRemoteCommand(dev({ name: 'w', shell: 'powershell' }), ['hostname'])).toBe("powershell -NoProfile -Command hostname");
+  it('wraps Windows commands in a PowerShell EncodedCommand, leaves POSIX verbatim, undefined for interactive', () => {
+    const wrapped = wrapRemoteCommand(dev({ name: 'w', shell: 'powershell' }), ['Write-Output', "'ran'"]);
+    expect(wrapped).toMatch(/^powershell -NoProfile -EncodedCommand [A-Za-z0-9+/=]+$/);
+    expect(decodePowerShell(wrapped!)).toBe("Write-Output 'ran'");
     expect(wrapRemoteCommand(dev({ name: 'l', shell: 'posix' }), ['uptime', '-p'])).toBe('uptime -p');
     expect(wrapRemoteCommand(dev({ name: 'i', shell: 'posix' }), [])).toBeUndefined();
   });
@@ -72,7 +80,7 @@ describe('buildSshInvocation', () => {
       ['hostname'],
       '/shim',
     );
-    expect(args[args.length - 1]).toBe('powershell -NoProfile -Command hostname');
+    expect(decodePowerShell(args[args.length - 1])).toBe('hostname');
     expect(env.SSH_ASKPASS).toBe('/shim');
   });
 

--- a/src/lib/devices/connect.ts
+++ b/src/lib/devices/connect.ts
@@ -16,6 +16,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { assertValidSshTarget, shellQuote } from '../ssh-exec.js';
+import { encodePwshBase64 } from '../pwsh.js';
 import { getCacheDir } from '../state.js';
 import { hostNameFor } from './ssh-config.js';
 import { type DeviceProfile } from './registry.js';
@@ -42,14 +43,15 @@ export function sshTargetFor(device: DeviceProfile): string {
 /**
  * Wrap a remote command for the device's shell. Windows devices speak
  * PowerShell, so a bare command is run through `powershell -NoProfile
- * -Command`; POSIX devices get the command verbatim (the remote login shell
- * parses it). Returns undefined when no command was given (interactive login).
+ * -EncodedCommand`; POSIX devices get the command verbatim (the remote login
+ * shell parses it). Returns undefined when no command was given (interactive
+ * login).
  */
 export function wrapRemoteCommand(device: DeviceProfile, cmd: string[]): string | undefined {
   if (cmd.length === 0) return undefined;
   const joined = cmd.join(' ');
   if (device.shell === 'powershell') {
-    return `powershell -NoProfile -Command ${shellQuote(joined)}`;
+    return `powershell -NoProfile -EncodedCommand ${encodePwshBase64(joined)}`;
   }
   return joined;
 }

--- a/src/lib/ssh-tunnel.test.ts
+++ b/src/lib/ssh-tunnel.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   buildTunnelArgs,
+  buildScpArgs,
   buildPushScript,
+  buildVerifyPushScript,
   buildRegisterTaskScript,
   buildUnregisterTaskScript,
   pickFreePort,
@@ -11,8 +13,8 @@ import {
   REMOTE_HELPER_PORT,
   REMOTE_TASK_NAME,
   WIN_HELPER_EXE,
+  scpRemotePath,
 } from './ssh-tunnel.js';
-import { encodePowerShell } from './browser/drivers/ssh.js';
 
 describe('buildTunnelArgs', () => {
   it('forwards localPort to the remote loopback port and stays hardened', () => {
@@ -45,14 +47,14 @@ describe('buildTunnelArgs', () => {
 });
 
 describe('buildPushScript', () => {
-  it('streams a base64 decode from stdin to %LOCALAPPDATA%\\agents (memory-safe)', () => {
+  it('resolves %LOCALAPPDATA%\\agents and does not decode base64 from stdin', () => {
     const s = buildPushScript();
     expect(s).toContain('$env:LOCALAPPDATA');
     expect(s).toContain(WIN_HELPER_EXE);
-    // Streaming decode — not a single giant [Convert]::FromBase64String string.
-    expect(s).toContain('FromBase64Transform');
-    expect(s).toContain('CryptoStream');
-    expect(s).toContain('OpenStandardInput');
+    expect(s).toContain('Write-Output $dst');
+    expect(s).not.toContain('FromBase64Transform');
+    expect(s).not.toContain('CryptoStream');
+    expect(s).not.toContain('OpenStandardInput');
     expect(s).not.toContain('FromBase64String');
   });
 
@@ -60,9 +62,25 @@ describe('buildPushScript', () => {
     expect(buildPushScript()).toContain("Stop-Process");
   });
 
-  it('rides through ssh as a single quote-free EncodedCommand token', () => {
-    const b64 = encodePowerShell(buildPushScript()).replace('powershell -NoProfile -EncodedCommand ', '');
-    expect(b64).toMatch(/^[A-Za-z0-9+/=]+$/);
+  it('builds scp args for a binary transfer with BatchMode enabled', () => {
+    const args = buildScpArgs('muqsit@win-mini', String.raw`C:\Users\muqsit\AppData\Local\agents\computer-helper-win.exe`, '/tmp/helper.exe');
+    expect(args).toContain('BatchMode=yes');
+    expect(args).toContain('/tmp/helper.exe');
+    expect(args[args.length - 1]).toBe('muqsit@win-mini:C:/Users/muqsit/AppData/Local/agents/computer-helper-win.exe');
+    expect(args.join(' ')).not.toContain('powershell');
+    expect(args.join(' ')).not.toContain('base64');
+  });
+
+  it('normalizes Windows paths for scp without changing the remote destination', () => {
+    expect(scpRemotePath(String.raw`C:\Users\muqsit\AppData\Local\agents\computer-helper-win.exe`))
+      .toBe('C:/Users/muqsit/AppData/Local/agents/computer-helper-win.exe');
+  });
+
+  it('verifies the copied helper byte count with LiteralPath', () => {
+    const s = buildVerifyPushScript(String.raw`C:\Users\muqsit\AppData\Local\agents\computer-helper-win.exe`, 165);
+    expect(s).toContain('Get-Item -LiteralPath $dst -ErrorAction Stop');
+    expect(s).toContain('$item.Length -ne 165');
+    expect(s).toContain('helper copy length mismatch');
   });
 });
 

--- a/src/lib/ssh-tunnel.ts
+++ b/src/lib/ssh-tunnel.ts
@@ -23,7 +23,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { randomBytes } from 'crypto';
-import { Transform } from 'stream';
 import { sshExec, SSH_OPTS } from './ssh-exec.js';
 import { encodePowerShell } from './browser/drivers/ssh.js';
 import { getDevice, type DeviceProfile } from './devices/registry.js';
@@ -204,10 +203,16 @@ export async function resolveRemoteDevice(
 }
 
 /**
- * PowerShell that streams base64 from stdin, decodes it incrementally to
- * %LOCALAPPDATA%\agents\computer-helper-win.exe, and stops any running instance
- * first so the file isn't locked. The CryptoStream/FromBase64Transform decode
- * is streaming — the ~156MB exe never lands in memory whole on the remote.
+ * Single-quote a string for embedding inside a PowerShell literal.
+ */
+function psSingleQuote(s: string): string {
+  return "'" + s.replace(/'/g, "''") + "'";
+}
+
+/**
+ * PowerShell that resolves the destination under %LOCALAPPDATA%\agents and
+ * stops any running instance first so the file is not locked. The caller copies
+ * the exe with scp and then verifies the byte count separately.
  */
 export function buildPushScript(): string {
   return [
@@ -215,13 +220,17 @@ export function buildPushScript(): string {
     `New-Item -ItemType Directory -Force -Path $dir | Out-Null`,
     `$dst = Join-Path $dir '${WIN_HELPER_EXE}'`,
     `Get-Process -Name 'computer-helper-win' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue`,
-    `$si = [Console]::OpenStandardInput()`,
-    `$t = New-Object Security.Cryptography.FromBase64Transform`,
-    `$cs = New-Object Security.Cryptography.CryptoStream($si, $t, [Security.Cryptography.CryptoStreamMode]::Read)`,
-    `$fs = [IO.File]::Create($dst)`,
-    `$cs.CopyTo($fs)`,
-    `$fs.Close(); $cs.Close()`,
     `Write-Output $dst`,
+  ].join('; ');
+}
+
+/** PowerShell that verifies scp wrote the expected number of bytes. */
+export function buildVerifyPushScript(remotePath: string, expectedBytes: number): string {
+  return [
+    `$dst = ${psSingleQuote(remotePath)}`,
+    `$item = Get-Item -LiteralPath $dst -ErrorAction Stop`,
+    `if ($item.Length -ne ${expectedBytes}) { throw "helper copy length mismatch: expected ${expectedBytes}, got $($item.Length)" }`,
+    `Write-Output "$dst $($item.Length)"`,
   ].join('; ');
 }
 
@@ -252,55 +261,39 @@ export function buildUnregisterTaskScript(taskName: string): string {
   ].join('; ');
 }
 
-/**
- * `setup --host`: push the exe, then register + start the LOGON task. Both hops
- * go through `sshExec` (BatchMode key auth — the same hardening the browser
- * driver and `agents ssh` use). Throws with the remote stderr on any failure.
- */
-/**
- * Base64-encode a byte stream in 3-byte-aligned chunks so the concatenated
- * output is valid (every chunk boundary lands on a base64 quantum).
- */
-class Base64Encode extends Transform {
-  private leftover = Buffer.alloc(0);
-  override _transform(chunk: Buffer, _enc: BufferEncoding, cb: () => void): void {
-    const buf = this.leftover.length ? Buffer.concat([this.leftover, chunk]) : chunk;
-    const usable = buf.length - (buf.length % 3);
-    this.leftover = Buffer.from(buf.subarray(usable));
-    if (usable > 0) this.push(buf.subarray(0, usable).toString('base64'));
-    cb();
-  }
-  override _flush(cb: () => void): void {
-    if (this.leftover.length) this.push(this.leftover.toString('base64'));
-    cb();
-  }
+/** Convert a Windows path returned by PowerShell into the scp/SFTP path form. */
+export function scpRemotePath(remotePath: string): string {
+  return remotePath.replace(/\\/g, '/');
 }
 
 /**
- * Stream a local file to a remote command's stdin over ssh, base64-encoded on
- * the fly. Async spawn + piping honors backpressure; the previous
- * `spawnSync({ input })` blob deadlocked once the ssh socket buffer filled
- * (~4MB) on large files (the 157MB Windows helper reproduced this reliably),
- * and worse, reported a false success leaving a 0-byte remote file. Rejects on
- * any pipe error so a broken transfer fails loudly instead.
+ * Build the scp argv used for the helper exe transfer. Exported so tests can
+ * assert the real binary copy path keeps BatchMode and does not route bytes
+ * through a PowerShell decoder.
  */
-function streamFileOverSsh(
+export function buildScpArgs(target: string, remotePath: string, filePath: string): string[] {
+  return [...SSH_OPTS, filePath, `${target}:${scpRemotePath(remotePath)}`];
+}
+
+/**
+ * Copy a local file to the remote destination with scp. This is a binary
+ * transfer; no base64 transform runs on either side.
+ */
+function copyFileOverScp(
   target: string,
-  remoteCmd: string,
+  remotePath: string,
   filePath: string,
   timeoutMs = 600_000,
 ): Promise<{ code: number | null; stderr: string }> {
   return new Promise((resolve, reject) => {
-    const child = spawn('ssh', [...SSH_OPTS, target, remoteCmd], {
-      stdio: ['pipe', 'pipe', 'pipe'],
+    const child = spawn('scp', buildScpArgs(target, remotePath, filePath), {
+      stdio: ['ignore', 'ignore', 'pipe'],
     });
     let stderr = '';
-    let stdout = '';
     child.stderr.on('data', (d) => (stderr += d.toString()));
-    child.stdout.on('data', (d) => (stdout += d.toString()));
     const timer = setTimeout(() => {
       child.kill('SIGKILL');
-      reject(new Error(`ssh push to ${target} timed out after ${timeoutMs}ms`));
+      reject(new Error(`scp push to ${target} timed out after ${timeoutMs}ms`));
     }, timeoutMs);
     const fail = (e: Error) => {
       clearTimeout(timer);
@@ -308,17 +301,19 @@ function streamFileOverSsh(
       reject(e);
     };
     child.on('error', fail);
-    child.stdin.on('error', fail); // EPIPE if the remote decoder dies mid-stream
     child.on('close', (code) => {
       clearTimeout(timer);
-      resolve({ code, stderr: stderr || stdout });
+      resolve({ code, stderr });
     });
-    const src = fs.createReadStream(filePath);
-    src.on('error', fail);
-    // disk -> aligned base64 -> ssh stdin; .pipe() applies backpressure
-    src.pipe(new Base64Encode()).pipe(child.stdin);
   });
 }
+
+/**
+ * `setup --host`: push the exe, then register + start the LOGON task. Remote
+ * PowerShell hops go through `sshExec` (BatchMode key auth — the same hardening
+ * the browser driver and `agents ssh` use), and the large exe rides a binary
+ * scp transfer. Throws with the remote stderr on any failure.
+ */
 
 export async function setupRemoteHelper(name: string): Promise<{ target: string; taskName: string }> {
   const { target } = await resolveRemoteDevice(name);
@@ -328,12 +323,24 @@ export async function setupRemoteHelper(name: string): Promise<{ target: string;
     throw new Error(`Windows helper exe not built. Run: bash scripts/build-win.sh`);
   }
 
-  // Push: stream the exe from disk, base64-encoded on the fly, to the remote
-  // decoder. Streaming (vs a single spawnSync `input` blob) honors ssh socket
-  // backpressure — the blob path deadlocks once the socket buffer fills (~4MB).
-  const push = await streamFileOverSsh(target, encodePowerShell(buildPushScript()), exe);
+  const prep = sshExec(target, encodePowerShell(buildPushScript()), { timeoutMs: 60_000 });
+  if (prep.code !== 0) {
+    throw new Error(`preparing helper exe path on '${name}' failed (exit ${prep.code ?? 'null'}): ${prep.stderr.trim() || prep.stdout.trim()}`);
+  }
+  const remotePath = prep.stdout.trim().split(/\r?\n/).filter(Boolean).at(-1);
+  if (!remotePath) {
+    throw new Error(`preparing helper exe path on '${name}' did not return a destination path`);
+  }
+
+  const push = await copyFileOverScp(target, remotePath, exe);
   if (push.code !== 0) {
     throw new Error(`pushing helper exe to '${name}' failed (exit ${push.code ?? 'null'}): ${push.stderr.trim()}`);
+  }
+
+  const expectedBytes = fs.statSync(exe).size;
+  const verify = sshExec(target, encodePowerShell(buildVerifyPushScript(remotePath, expectedBytes)), { timeoutMs: 60_000 });
+  if (verify.code !== 0) {
+    throw new Error(`verifying helper exe on '${name}' failed (exit ${verify.code ?? 'null'}): ${verify.stderr.trim() || verify.stdout.trim()}`);
   }
 
   // Register + start the LOGON task.


### PR DESCRIPTION
## Summary
- Fixes #555 by wrapping `agents ssh` PowerShell device commands with `-EncodedCommand` UTF-16LE base64 instead of `-Command` plus POSIX quoting.
- Fixes #520 by replacing the PowerShell base64/CryptoStream helper exe upload with a binary `scp` copy, followed by a remote byte-count verification before task registration.
- Adds focused coverage for the computer-use SSH path, discharging #561 for this subsystem: encoded command round-trip, binary-copy argv, no PowerShell base64 decoder, path normalization, and remote length verification.

## Verification
- `npm run build`
- `npx vitest run src/lib/devices/connect.test.ts src/lib/ssh-tunnel.test.ts`