### PR TITLE
fix(computer): stabilize input permission admissions (#557)

### DIFF
--- a/src/commands/computer-actions.test.ts
+++ b/src/commands/computer-actions.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
   pickTarget,
   parseXY,
@@ -6,11 +9,26 @@ import {
   buildRaiseParams,
   buildWaitParams,
   clampCharDelay,
+  resolveTargetPidDecision,
   CHAR_DELAY_MIN_MS,
   CHAR_DELAY_MAX_MS,
   type AppInfo,
 } from './computer-actions.js';
-import { resolveRpcTimeoutMs, RPC_TIMEOUT_MS } from '../lib/computer-rpc.js';
+import { resolveRpcTimeoutMs, RPC_TIMEOUT_MS, type ComputerClient, type RPCResponse } from '../lib/computer-rpc.js';
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-computer-actions-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 const apps: AppInfo[] = [
   { pid: 100, name: 'Finder', bundle_id: 'com.apple.finder', active: false },
@@ -62,6 +80,128 @@ describe('pickTarget', () => {
     const noneActive = apps.map((a) => ({ ...a, active: false }));
     const r = pickTarget(noneActive, {});
     expect(r.ok).toBe(false);
+  });
+});
+
+describe('resolveTargetPidDecision session admissions', () => {
+  it('keeps an admitted input target stable for repeated type-text calls in the same session', async () => {
+    const cachePath = path.join(makeTempDir(), 'admissions.json');
+    let calls = 0;
+    const client: ComputerClient = {
+      async call(method: string): Promise<RPCResponse> {
+        expect(method).toBe('list_apps');
+        calls += 1;
+        return {
+          id: calls,
+          result: {
+            apps: calls === 1
+              ? [{ pid: 4242, name: 'Notepad', bundle_id: 'Microsoft.WindowsNotepad', active: true }]
+              : [],
+          },
+        };
+      },
+      async close(): Promise<void> {},
+    };
+    const env = {
+      CODEX_THREAD_ID: 'session-557',
+      AGENTS_COMPUTER_ADMISSION_CACHE: cachePath,
+    } as NodeJS.ProcessEnv;
+
+    await expect(resolveTargetPidDecision(client, {}, { verb: 'type-text', env, nowMs: 10 }))
+      .resolves.toEqual({ ok: true, pid: 4242, source: 'list_apps' });
+    await expect(resolveTargetPidDecision(client, {}, { verb: 'type-text', env, nowMs: 11 }))
+      .resolves.toEqual({ ok: true, pid: 4242, source: 'session_admission' });
+  });
+
+  it('shares the admitted target across input verbs in the same session', async () => {
+    const cachePath = path.join(makeTempDir(), 'admissions.json');
+    let calls = 0;
+    const client: ComputerClient = {
+      async call(method: string): Promise<RPCResponse> {
+        expect(method).toBe('list_apps');
+        calls += 1;
+        return {
+          id: calls,
+          result: {
+            apps: calls === 1
+              ? [{ pid: 5150, name: 'Notepad', bundle_id: 'Microsoft.WindowsNotepad', active: true }]
+              : [],
+          },
+        };
+      },
+      async close(): Promise<void> {},
+    };
+    const env = {
+      CODEX_THREAD_ID: 'session-557-cross-verb',
+      AGENTS_COMPUTER_ADMISSION_CACHE: cachePath,
+    } as NodeJS.ProcessEnv;
+
+    await expect(resolveTargetPidDecision(client, {}, { verb: 'type-text', env, nowMs: 20 }))
+      .resolves.toEqual({ ok: true, pid: 5150, source: 'list_apps' });
+    await expect(resolveTargetPidDecision(client, {}, { verb: 'key', env, nowMs: 21 }))
+      .resolves.toEqual({ ok: true, pid: 5150, source: 'session_admission' });
+  });
+
+  it('keeps an admitted explicit bundle stable for repeated input calls', async () => {
+    const cachePath = path.join(makeTempDir(), 'admissions.json');
+    let calls = 0;
+    const client: ComputerClient = {
+      async call(method: string): Promise<RPCResponse> {
+        expect(method).toBe('list_apps');
+        calls += 1;
+        return {
+          id: calls,
+          result: {
+            apps: calls === 1
+              ? [{ pid: 7070, name: 'Notepad', bundle_id: 'Microsoft.WindowsNotepad', active: true }]
+              : [],
+          },
+        };
+      },
+      async close(): Promise<void> {},
+    };
+    const env = {
+      CODEX_THREAD_ID: 'session-557-bundle',
+      AGENTS_COMPUTER_ADMISSION_CACHE: cachePath,
+    } as NodeJS.ProcessEnv;
+
+    await expect(resolveTargetPidDecision(client, { bundle: 'Microsoft.WindowsNotepad' }, { verb: 'type-text', env, nowMs: 25 }))
+      .resolves.toEqual({ ok: true, pid: 7070, source: 'list_apps' });
+    await expect(resolveTargetPidDecision(client, { bundle: 'Microsoft.WindowsNotepad' }, { verb: 'key', env, nowMs: 26 }))
+      .resolves.toEqual({ ok: true, pid: 7070, source: 'session_admission' });
+  });
+
+  it('does not reuse an input admission outside the session that admitted it', async () => {
+    const cachePath = path.join(makeTempDir(), 'admissions.json');
+    let calls = 0;
+    const client: ComputerClient = {
+      async call(method: string): Promise<RPCResponse> {
+        calls += 1;
+        return {
+          id: calls,
+          result: {
+            apps: calls === 1
+              ? [{ pid: 6001, name: 'Notepad', bundle_id: 'Microsoft.WindowsNotepad', active: true }]
+              : [],
+          },
+        };
+      },
+      async close(): Promise<void> {},
+    };
+
+    await expect(resolveTargetPidDecision(client, {}, {
+      verb: 'type-text',
+      env: { CODEX_THREAD_ID: 'session-a', AGENTS_COMPUTER_ADMISSION_CACHE: cachePath } as NodeJS.ProcessEnv,
+      nowMs: 30,
+    })).resolves.toEqual({ ok: true, pid: 6001, source: 'list_apps' });
+
+    const denied = await resolveTargetPidDecision(client, {}, {
+      verb: 'type-text',
+      env: { CODEX_THREAD_ID: 'session-b', AGENTS_COMPUTER_ADMISSION_CACHE: cachePath } as NodeJS.ProcessEnv,
+      nowMs: 31,
+    });
+    expect(denied.ok).toBe(false);
+    if (!denied.ok) expect(denied.error).toContain('no active app found in allow list');
   });
 });
 

--- a/src/commands/computer-actions.ts
+++ b/src/commands/computer-actions.ts
@@ -8,18 +8,134 @@
 // space and never hand-manage pids.
 
 import { Command } from 'commander';
+import * as fs from 'fs';
+import * as path from 'path';
 import {
   openComputerClient,
   describeTransport,
+  resolvePolicyPath,
   type ComputerClient,
   type RPCResponse,
 } from '../lib/computer-rpc.js';
+import {
+  COMPUTER_INPUT_GATED_VERBS,
+  formatComputerPermissionGrantHint,
+} from '../lib/permissions.js';
 
 export interface AppInfo {
   pid: number;
   name: string;
   bundle_id: string;
   active: boolean;
+}
+
+type ComputerInputVerb = typeof COMPUTER_INPUT_GATED_VERBS[number];
+
+interface TargetAdmission {
+  sessionId: string;
+  selector: string;
+  gateClass: 'input';
+  pid: number;
+  bundle_id: string;
+  name: string;
+  admittedAtMs: number;
+  admittedByVerb: ComputerInputVerb;
+}
+
+interface AdmissionCacheFile {
+  admissions?: TargetAdmission[];
+}
+
+function isComputerInputVerb(verb: string | undefined): verb is ComputerInputVerb {
+  return typeof verb === 'string' && (COMPUTER_INPUT_GATED_VERBS as readonly string[]).includes(verb);
+}
+
+function computerSessionId(env: NodeJS.ProcessEnv = process.env): string | null {
+  return env.CODEX_THREAD_ID
+    || env.CLAUDE_CODE_SESSION_ID
+    || env.CLAUDE_SESSION_ID
+    || env.AGENTS_SESSION_ID
+    || env.AGENTS_RUN_ID
+    || null;
+}
+
+function admissionCachePath(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.AGENTS_COMPUTER_ADMISSION_CACHE) return env.AGENTS_COMPUTER_ADMISSION_CACHE;
+  return path.join(path.dirname(resolvePolicyPath()), 'computer-target-admissions.json');
+}
+
+function targetSelector(opts: { bundle?: string }): string {
+  return opts.bundle ? `bundle:${opts.bundle}` : 'frontmost';
+}
+
+function readAdmissionCache(filePath: string): TargetAdmission[] {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as AdmissionCacheFile;
+    return Array.isArray(parsed.admissions) ? parsed.admissions.filter(isAdmission) : [];
+  } catch {
+    return [];
+  }
+}
+
+function isAdmission(v: unknown): v is TargetAdmission {
+  if (!v || typeof v !== 'object') return false;
+  const r = v as Record<string, unknown>;
+  return r.sessionId !== undefined
+    && typeof r.sessionId === 'string'
+    && typeof r.selector === 'string'
+    && r.gateClass === 'input'
+    && typeof r.pid === 'number'
+    && typeof r.bundle_id === 'string'
+    && typeof r.name === 'string'
+    && typeof r.admittedAtMs === 'number'
+    && isComputerInputVerb(r.admittedByVerb as string | undefined);
+}
+
+function rememberAdmission(app: AppInfo, opts: {
+  selector: string;
+  verb: ComputerInputVerb;
+  env?: NodeJS.ProcessEnv;
+  nowMs?: number;
+}): void {
+  const sessionId = computerSessionId(opts.env);
+  if (!sessionId) return;
+
+  const filePath = admissionCachePath(opts.env);
+  const admissions = readAdmissionCache(filePath);
+  const next: TargetAdmission = {
+    sessionId,
+    selector: opts.selector,
+    gateClass: 'input',
+    pid: app.pid,
+    bundle_id: app.bundle_id,
+    name: app.name,
+    admittedAtMs: opts.nowMs ?? Date.now(),
+    admittedByVerb: opts.verb,
+  };
+  const filtered = admissions.filter((a) =>
+    !(a.sessionId === sessionId && a.selector === opts.selector && a.gateClass === 'input')
+  );
+  filtered.push(next);
+
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify({ admissions: filtered }, null, 2), { mode: 0o600 });
+  } catch {
+    // Cache persistence is best-effort; the daemon remains the final gate.
+  }
+}
+
+function findAdmission(opts: {
+  selector: string;
+  env?: NodeJS.ProcessEnv;
+}): TargetAdmission | null {
+  const sessionId = computerSessionId(opts.env);
+  if (!sessionId) return null;
+  const admissions = readAdmissionCache(admissionCachePath(opts.env));
+  const matches = admissions
+    .filter((a) => a.sessionId === sessionId && a.selector === opts.selector && a.gateClass === 'input')
+    .sort((a, b) => b.admittedAtMs - a.admittedAtMs);
+  return matches[0] ?? null;
 }
 
 // Pure target picker — exercised by unit tests. Precedence: explicit --pid,
@@ -42,7 +158,7 @@ export function pickTarget(
     if (!app) {
       return {
         ok: false,
-        error: `bundle not in allow list (or not running): ${opts.bundle}\nadd Computer(${opts.bundle}) to a permissions group, then \`agents computer reload\``,
+        error: `bundle not in allow list (or not running): ${opts.bundle}\n${formatComputerPermissionGrantHint(opts.bundle)}`,
       };
     }
     return { ok: true, app };
@@ -51,7 +167,7 @@ export function pickTarget(
   if (!active) {
     return {
       ok: false,
-      error: 'no active app found in allow list\nadd Computer(<bundle-id>) to a permissions group, then `agents computer reload`',
+      error: `no active app found in allow list\n${formatComputerPermissionGrantHint()}`,
     };
   }
   return { ok: true, app: active };
@@ -172,19 +288,44 @@ export function unwrap(r: RPCResponse): Record<string, unknown> {
   return r.result ?? {};
 }
 
-// Resolve the target pid via list_apps + pickTarget, printing a precise error
-// and exiting when no target matches.
-async function resolveTargetPid(client: ComputerClient, opts: { pid?: number; bundle?: string }): Promise<number> {
+export async function resolveTargetPidDecision(
+  client: ComputerClient,
+  opts: { pid?: number; bundle?: string },
+  gate?: { verb?: string; env?: NodeJS.ProcessEnv; nowMs?: number },
+): Promise<{ ok: true; pid: number; source: 'pid' | 'list_apps' | 'session_admission' } | { ok: false; error: string }> {
   // A directly-supplied pid skips the list_apps roundtrip — the daemon gates.
-  if (opts.pid != null) return opts.pid;
+  if (opts.pid != null) return { ok: true, pid: opts.pid, source: 'pid' };
   const apps = unwrap(await client.call('list_apps'));
   const list = (apps.apps as AppInfo[]) || [];
   const picked = pickTarget(list, opts);
+  const verb = gate?.verb;
+  const selector = targetSelector(opts);
+  if (picked.ok && isComputerInputVerb(verb)) {
+    rememberAdmission(picked.app, { selector, verb, env: gate?.env, nowMs: gate?.nowMs });
+  }
   if (!picked.ok) {
-    console.error(picked.error);
+    if (isComputerInputVerb(verb)) {
+      const admitted = findAdmission({ selector, env: gate?.env });
+      if (admitted) return { ok: true, pid: admitted.pid, source: 'session_admission' };
+    }
+    return { ok: false, error: picked.error };
+  }
+  return { ok: true, pid: picked.app.pid, source: 'list_apps' };
+}
+
+// Resolve the target pid via list_apps + pickTarget, printing a precise error
+// and exiting when no target matches.
+async function resolveTargetPid(
+  client: ComputerClient,
+  opts: { pid?: number; bundle?: string },
+  gate?: { verb?: string },
+): Promise<number> {
+  const resolved = await resolveTargetPidDecision(client, opts, gate);
+  if (!resolved.ok) {
+    console.error(resolved.error);
     process.exit(1);
   }
-  return picked.app.pid;
+  return resolved.pid;
 }
 
 // --raise flag: app-level focus_window before the main action so coordinate
@@ -253,7 +394,7 @@ export function registerActionCommands(program: Command): void {
       .option('--json', 'Emit compact JSON (default: pretty)'),
   ).action(async (opts: TargetOpts & { depth?: number }) => {
     await withClient(async (client) => {
-      const pid = await resolveTargetPid(client, opts);
+      const pid = await resolveTargetPid(client, opts, { verb: 'describe' });
       const params: Record<string, unknown> = { pid };
       if (opts.depth != null) params.max_depth = opts.depth;
       const res = unwrap(await client.call('describe', params));
@@ -275,7 +416,7 @@ export function registerActionCommands(program: Command): void {
     ),
   ).action(async (opts: ElemOpts & { count?: number; background?: boolean; raise?: boolean }) => {
     await withClient(async (client) => {
-      const pid = await resolveTargetPid(client, opts);
+      const pid = await resolveTargetPid(client, opts, { verb: 'click' });
       const spec = buildElementOrCoords(opts);
       if (!spec.ok) {
         console.error(spec.error);
@@ -300,7 +441,7 @@ export function registerActionCommands(program: Command): void {
     ),
   ).action(async (opts: ElemOpts) => {
     await withClient(async (client) => {
-      const pid = await resolveTargetPid(client, opts);
+      const pid = await resolveTargetPid(client, opts, { verb: 'right-click' });
       const spec = buildElementOrCoords(opts);
       if (!spec.ok) {
         console.error(spec.error);
@@ -324,7 +465,7 @@ export function registerActionCommands(program: Command): void {
     ),
   ).action(async (opts: ElemOpts & { text: string; commit?: boolean; allowSecureField?: boolean }) => {
     await withClient(async (client) => {
-      const pid = await resolveTargetPid(client, opts);
+      const pid = await resolveTargetPid(client, opts, { verb: 'type' });
       const spec = buildElementOrCoords(opts);
       if (!spec.ok) {
         console.error(spec.error);
@@ -351,7 +492,7 @@ export function registerActionCommands(program: Command): void {
       .option('--json', 'Emit JSON'),
   ).action(async (opts: TargetOpts & { text: string; commit?: boolean; raise?: boolean; requireFrontmost?: boolean; charDelay?: number }) => {
     await withClient(async (client) => {
-      const pid = await resolveTargetPid(client, opts);
+      const pid = await resolveTargetPid(client, opts, { verb: 'type-text' });
       await raiseIfRequested(client, pid, opts.raise);
       const params: Record<string, unknown> = { pid, text: opts.text };
       if (opts.commit) params.commit = true;
@@ -375,7 +516,7 @@ export function registerActionCommands(program: Command): void {
       .option('--json', 'Emit JSON'),
   ).action(async (opts: TargetOpts & { keys: string; raise?: boolean; requireFrontmost?: boolean }) => {
     await withClient(async (client) => {
-      const pid = await resolveTargetPid(client, opts);
+      const pid = await resolveTargetPid(client, opts, { verb: 'key' });
       await raiseIfRequested(client, pid, opts.raise);
       const params: Record<string, unknown> = { pid, keys: opts.keys };
       if (opts.requireFrontmost) params.require_frontmost = true;
@@ -407,7 +548,7 @@ export function registerActionCommands(program: Command): void {
       process.exit(1);
     }
     await withClient(async (client) => {
-      const pid = await resolveTargetPid(client, opts);
+      const pid = await resolveTargetPid(client, opts, { verb: 'drag' });
       await raiseIfRequested(client, pid, opts.raise);
       const params: Record<string, unknown> = {
         pid,
@@ -434,7 +575,7 @@ export function registerActionCommands(program: Command): void {
     ),
   ).action(async (opts: ElemOpts & { dy?: number; dx?: number; raise?: boolean }) => {
     await withClient(async (client) => {
-      const pid = await resolveTargetPid(client, opts);
+      const pid = await resolveTargetPid(client, opts, { verb: 'scroll' });
       await raiseIfRequested(client, pid, opts.raise);
       const params: Record<string, unknown> = { pid };
       if (opts.id) params.element_id = opts.id;
@@ -457,7 +598,7 @@ export function registerActionCommands(program: Command): void {
       .option('--json', 'Emit JSON'),
   ).action(async (opts: TargetOpts & { id: string; action: string }) => {
     await withClient(async (client) => {
-      const pid = await resolveTargetPid(client, opts);
+      const pid = await resolveTargetPid(client, opts, { verb: 'ax-action' });
       const res = unwrap(await client.call('ax_action', { pid, element_id: opts.id, action: opts.action }));
       emit(res, Boolean(opts.json), () => `performed ${opts.action}`);
     });
@@ -472,7 +613,7 @@ export function registerActionCommands(program: Command): void {
       .option('--json', 'Emit JSON'),
   ).action(async (opts: TargetOpts & { id: string }) => {
     await withClient(async (client) => {
-      const pid = await resolveTargetPid(client, opts);
+      const pid = await resolveTargetPid(client, opts, { verb: 'focus' });
       const res = unwrap(await client.call('set_focus', { pid, element_id: opts.id }));
       emit(res, Boolean(opts.json), () => `focused ${opts.id}`);
     });
@@ -491,7 +632,7 @@ export function registerActionCommands(program: Command): void {
       .option('--json', 'Emit JSON'),
   ).action(async (opts: TargetOpts & { windowId?: number; title?: string }) => {
     await withClient(async (client) => {
-      const pid = await resolveTargetPid(client, opts);
+      const pid = await resolveTargetPid(client, opts, { verb: 'raise' });
       const res = unwrap(await client.call('focus_window', { pid, ...buildRaiseParams(opts) }));
       emit(res, Boolean(opts.json), () => {
         const scope = res.raised_window ? `window ${res.title ?? res.window_id ?? ''}`.trim() : 'app';
@@ -522,7 +663,7 @@ export function registerActionCommands(program: Command): void {
     await withClient(async (client) => {
       const params: Record<string, unknown> = { ...spec.params };
       // duration-only waits don't need a target pid
-      if (params.duration_ms == null) params.pid = await resolveTargetPid(client, opts);
+      if (params.duration_ms == null) params.pid = await resolveTargetPid(client, opts, { verb: 'wait' });
       const res = unwrap(await client.call('wait', params));
       emit(res, Boolean(opts.json), () =>
         res.satisfied ? `satisfied (${res.waited_ms}ms)` : `timed out (${res.waited_ms}ms)`,
@@ -540,7 +681,7 @@ export function registerActionCommands(program: Command): void {
       .option('--json', 'Emit JSON'),
   ).action(async (opts: TargetOpts & { id?: string; maxChars?: number }) => {
     await withClient(async (client) => {
-      const pid = await resolveTargetPid(client, opts);
+      const pid = await resolveTargetPid(client, opts, { verb: 'get-text' });
       const params: Record<string, unknown> = { pid };
       if (opts.id) params.element_id = opts.id;
       if (opts.maxChars != null) params.max_chars = opts.maxChars;

--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -3,7 +3,15 @@ import * as os from 'os';
 import * as path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 import * as TOML from 'smol-toml';
-import { applyPermissionsToVersion, buildPermissionsFromGroups, containsBroadGrants, convertDenyToCodexRules, convertToKimiFormat } from './permissions.js';
+import {
+  COMPUTER_APP_GATED_VERBS,
+  applyPermissionsToVersion,
+  buildPermissionsFromGroups,
+  containsBroadGrants,
+  convertDenyToCodexRules,
+  convertToKimiFormat,
+  formatComputerPermissionGrantHint,
+} from './permissions.js';
 
 const tempDirs: string[] = [];
 
@@ -55,6 +63,19 @@ describe('containsBroadGrants', () => {
     });
 
     expect(result).toBeNull();
+  });
+});
+
+describe('computer permission hints', () => {
+  it('tells users the app-targeted verbs gated by Computer(bundle-id)', () => {
+    const hint = formatComputerPermissionGrantHint('Microsoft.WindowsNotepad');
+
+    expect(hint).toContain('Computer(Microsoft.WindowsNotepad)');
+    expect(hint).toContain('agents computer reload');
+    expect(hint).toContain('type-text');
+    expect(hint).toContain('key');
+    expect(COMPUTER_APP_GATED_VERBS).toContain('type-text');
+    expect(COMPUTER_APP_GATED_VERBS).toContain('key');
   });
 });
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -39,6 +39,45 @@ export const CODEX_RULES_FILENAME = 'agents-deny.rules';
 
 export type ParsedRules = PermissionSet;
 
+export const COMPUTER_PERMISSION_RULE_PREFIX = 'Computer';
+
+export const COMPUTER_APP_GATED_VERBS = [
+  'screenshot',
+  'describe',
+  'get-text',
+  'launch',
+  'raise',
+  'click',
+  'right-click',
+  'type',
+  'type-text',
+  'key',
+  'drag',
+  'scroll',
+  'ax-action',
+  'focus',
+  'wait',
+] as const;
+
+export const COMPUTER_INPUT_GATED_VERBS = [
+  'raise',
+  'click',
+  'right-click',
+  'type',
+  'type-text',
+  'key',
+  'drag',
+  'scroll',
+  'ax-action',
+  'focus',
+] as const;
+
+export function formatComputerPermissionGrantHint(bundleId?: string): string {
+  const target = bundleId && bundleId.length > 0 ? bundleId : '<bundle-id>';
+  return `add Computer(${target}) to a permissions group, then \`agents computer reload\`\n` +
+    `app-targeted computer verbs are gated by Computer(<bundle-id>): ${COMPUTER_APP_GATED_VERBS.join(', ')}`;
+}
+
 export function containsBroadGrants(rules: ParsedRules): { broad: string[]; reason: string } | null {
   const broad: string[] = [];
   const reasons = new Set<string>();


### PR DESCRIPTION
## Summary
- Cache successful computer input target admissions per agent session and target selector, so repeated `type-text` / `key` calls reuse the admitted app when a fresh `list_apps` resolution no longer returns an active allow-listed app.
- Add shared Computer permission hint text that lists the app-targeted verbs gated by `Computer(<bundle-id>)`.

Fixes #557.
Discharges #561 for the permission-gate path with regression coverage for repeated same-session input admissions.

## Test Plan
- `npm run build`
- `npx vitest run src/commands/computer-actions.test.ts src/lib/permissions.test.ts` (49 passed)