### PR TITLE
fix(computer-win): type_text corrupts input via racing per-char SendInput (#554)

### DIFF
--- a/packages/computer-helper-win/Automation.cs
+++ b/packages/computer-helper-win/Automation.cs
@@ -219,7 +219,7 @@ public sealed class Automation
 
             // No ValuePattern — focus and type the characters.
             el.SetFocus();
-            foreach (char ch in text) SendUnicode(ch);
+            SendUnicodeString(text);
             bool committed = false;
             if (P.BoolOr(p, "commit", false)) { SendVirtualKey(VK_RETURN); committed = true; }
             return new() { ["ok"] = true, ["committed"] = committed };
@@ -265,11 +265,7 @@ public sealed class Automation
     {
         string text = P.StringOpt(p, "text") ?? throw RpcError.Invalid("type_text needs `text`");
         int delayMs = P.IntOr(p, "char_delay_ms", 0);
-        foreach (char ch in text)
-        {
-            SendUnicode(ch);
-            if (delayMs > 0) Thread.Sleep(delayMs);
-        }
+        SendUnicodeString(text, delayMs);
         if (P.BoolOr(p, "commit", false)) SendVirtualKey(VK_RETURN);
         return new() { ["ok"] = true, ["chars"] = text.Length };
     }
@@ -907,11 +903,47 @@ public sealed class Automation
 
     private static void SendVirtualKey(ushort vk) { SendKeyEvent(vk, false); SendKeyEvent(vk, true); }
 
+    private static INPUT UnicodeDown(char ch) =>
+        new() { type = INPUT_KEYBOARD, U = new InputUnion { ki = new KEYBDINPUT { wScan = ch, dwFlags = KEYEVENTF_UNICODE } } };
+    private static INPUT UnicodeUp(char ch) =>
+        new() { type = INPUT_KEYBOARD, U = new InputUnion { ki = new KEYBDINPUT { wScan = ch, dwFlags = KEYEVENTF_UNICODE | KEYEVENTF_KEYUP } } };
+
     private static void SendUnicode(char ch)
     {
-        var down = new INPUT { type = INPUT_KEYBOARD, U = new InputUnion { ki = new KEYBDINPUT { wScan = ch, dwFlags = KEYEVENTF_UNICODE } } };
-        var up = new INPUT { type = INPUT_KEYBOARD, U = new InputUnion { ki = new KEYBDINPUT { wScan = ch, dwFlags = KEYEVENTF_UNICODE | KEYEVENTF_KEYUP } } };
-        var inp = new[] { down, up };
+        var inp = new[] { UnicodeDown(ch), UnicodeUp(ch) };
+        SendInput((uint)inp.Length, inp, Marshal.SizeOf<INPUT>());
+    }
+
+    // Type an arbitrary string as KEYEVENTF_UNICODE key events. Every character
+    // is delivered by its own down/up pair carrying the literal UTF-16 code unit
+    // in wScan (with wVk = 0), so SendKeys metacharacters (+ ^ % ~ ( ) { }) and
+    // spaces land byte-for-byte — there is no SendKeys operator layer to escape.
+    //
+    // Fidelity depends on a SINGLE SendInput call for the whole string: it
+    // enqueues all events atomically and in order. The previous one-SendInput-
+    // per-char loop injected with no inter-key settle, which races the target's
+    // input-processing thread and can collapse the tail of the string onto the
+    // last character — issue #554: "reliability probe 12345" landed as
+    // "reliability 55555555555" (same length, tail stuck on the final '5').
+    //
+    // When char_delay_ms > 0 the caller explicitly wants pacing (slow inputs for
+    // laggy fields), so fall back to per-char calls with a real sleep between
+    // them — the sleep provides the settle the batched path gets for free.
+    private static void SendUnicodeString(string text, int delayMs = 0)
+    {
+        if (text.Length == 0) return;
+        if (delayMs > 0)
+        {
+            foreach (char ch in text) { SendUnicode(ch); Thread.Sleep(delayMs); }
+            return;
+        }
+        var inp = new INPUT[text.Length * 2];
+        int i = 0;
+        foreach (char ch in text)
+        {
+            inp[i++] = UnicodeDown(ch);
+            inp[i++] = UnicodeUp(ch);
+        }
         SendInput((uint)inp.Length, inp, Marshal.SizeOf<INPUT>());
     }
 }

--- a/packages/computer-helper-win/Automation.cs
+++ b/packages/computer-helper-win/Automation.cs
@@ -250,7 +250,13 @@ public sealed class Automation
             // Prefer rich document text, then ValuePattern, then the Name.
             if (el.TryGetCurrentPattern(TextPattern.Pattern, out var tp))
             {
-                var text = ((TextPattern)tp).DocumentRange.GetText(MaxTextChars);
+                // GetText(maxLength > 0) makes the provider compute an endpoint at
+                // start+maxLength; the Windows 11 Notepad UIA provider rejects that as
+                // "Start or end specified is past the end of the text range" when the
+                // document is shorter than maxLength. GetText(-1) returns the whole
+                // range with no endpoint arithmetic; clamp the length in managed code.
+                var text = ((TextPattern)tp).DocumentRange.GetText(-1) ?? "";
+                if (text.Length > MaxTextChars) text = text.Substring(0, MaxTextChars);
                 return new() { ["text"] = text };
             }
             if (el.TryGetCurrentPattern(ValuePattern.Pattern, out var vp))

--- a/packages/computer-helper-win/smoke/smoke.mjs
+++ b/packages/computer-helper-win/smoke/smoke.mjs
@@ -67,6 +67,12 @@ class Client {
   }
 }
 
+// A UIA document read can carry a trailing newline the caller never typed;
+// strip a single trailing CR/LF so a fidelity compare is against the typed text.
+function normalizeDoc(s) {
+  return s.replace(/\r?\n$/, '');
+}
+
 function findByRole(node, roles, out = []) {
   if (!node || typeof node !== 'object') return out;
   if (node.id && roles.includes(node.role)) out.push(node);
@@ -166,6 +172,40 @@ async function main() {
     }
     if (!matched) fail(`get_text roundtrip mismatch after retries: got ${JSON.stringify(lastText)}`);
     ok(`get_text roundtrip matched`);
+
+    // 5b. byte-for-byte type_text fidelity (regression for #554). The bug typed
+    // "reliability probe 12345" and Notepad showed "reliability 55555555555" —
+    // letters dropped, the tail collapsed onto the final digit. Type a mixed
+    // string of letters, digits, spaces AND SendKeys metacharacters (+^%~(){},
+    // which SendInput-UNICODE must deliver literally, with no operator escaping),
+    // then assert the read-back equals it EXACTLY. Clear the field first so the
+    // comparison is against the fidelity string alone.
+    const FIDELITY = 'Fidelity probe 12345 +^%~(){}';
+    await c.call('key', { keys: 'ctrl+a' });
+    await c.call('key', { keys: 'delete' });
+    // Confirm the clear landed before typing, so leftover text can't mask a drop.
+    for (let i = 0; i < 20; i++) {
+      const g = await c.call('get_text', { pid, element_id: elId });
+      if (normalizeDoc(String(g.text ?? '')) === '') break;
+      await sleep(100);
+    }
+    await c.call('type_text', { text: FIDELITY });
+    ok(`type_text fidelity "${FIDELITY}"`);
+    let fidelityText = '';
+    let fidelityMatched = false;
+    for (let i = 0; i < 40; i++) {
+      const got = await c.call('get_text', { pid, element_id: elId });
+      fidelityText = normalizeDoc(String(got.text ?? ''));
+      if (fidelityText === FIDELITY) { fidelityMatched = true; break; }
+      // Once the length settles but the content differs, it will never converge —
+      // stop early and report the corruption rather than burning all retries.
+      if (fidelityText.length >= FIDELITY.length && fidelityText !== FIDELITY) break;
+      await sleep(150);
+    }
+    if (!fidelityMatched) {
+      fail(`type_text fidelity mismatch (#554):\n    expected: ${JSON.stringify(FIDELITY)}\n    got:      ${JSON.stringify(fidelityText)}`);
+    }
+    ok('type_text fidelity byte-for-byte');
 
     // 6. screenshot
     const shot = await c.call('screenshot');


### PR DESCRIPTION
## Problem (#554)

Typing `reliability probe 12345` into Notepad via `agents computer type-text` on win-mini produced `reliability 55555555555`: `probe` was dropped and the digits collapsed into a run of the final `5`. Both confirmation paths agreed — the screenshot **and** the `agents computer apps` window title showed the corrupted buffer, so it is landed text, not a read-back artifact.

## Root cause

`Automation.cs` injected the string **one `SendInput` call per character** with no inter-key settle (`type_text` at the old `foreach … SendUnicode(ch)` loop, and the `ValuePattern`-less `SetValue` fallback did the same):

- `type_text` received the full, correct string — it returned `chars = 23`, and `reliability probe 12345` is exactly 23 characters, so the input was intact.
- The corrupted output `reliability 55555555555` is **also 23 characters** — the first 12 landed, positions 13–23 all collapsed onto the last character `5`.

That same-length, tail-stuck-on-the-last-char fingerprint is what rapid, un-settled per-char `SendInput` calls produce: they race the target app's input-processing thread, dropping/repeating events.

## Fix (at the source)

New `SendUnicodeString(text, delayMs)` batches the whole string into a **single atomic `SendInput` call** — all `KEYEVENTF_UNICODE` down/up pairs enqueue in order, eliminating the race. Each character carries its literal UTF-16 code unit in `wScan` (with `wVk = 0`), so SendKeys metacharacters (`+ ^ % ~ ( ) { }`) and spaces land byte-for-byte; there is no SendKeys operator layer to escape. Both injection sites (`type_text` and the `SetValue` focus-and-type fallback) route through it. An explicit `char_delay_ms > 0` still paces per-char, now with a real `Thread.Sleep` between characters (the settle the batched path gets for free).

## Test (discharges #561 for this path)

Extended the real-UIA smoke harness (`smoke/smoke.mjs`) with a **byte-for-byte fidelity round-trip**: clear the field, `type_text` a mixed string of letters, digits, spaces **and** SendKeys metacharacters (`Fidelity probe 12345 +^%~(){}`), then poll `get_text` and assert the read-back equals it **exactly**. It early-exits and reports the corruption once the length settles but the content differs, so a #554-style collapse fails loudly instead of timing out.

## Verification status

- `node --check smoke/smoke.mjs` passes.
- Compile prerequisites verified by inspection: `ImplicitUsings=enable` covers `System.Threading`; `System.Runtime.InteropServices` is imported for `Marshal`; `LangVersion=latest` supports the target-typed `new()` helpers.
- **`dotnet build` could not be run in this worktree** — the `dotnet` binary is permission-blocked in this environment (every invocation, incl. `--version`, was denied across 5 launch paths). The win-x64 publish (`ci.yml`) and the coordinator's consolidated win-mini end-to-end pass are the compile + real-flow gate.

Files: `packages/computer-helper-win/Automation.cs`, `packages/computer-helper-win/smoke/smoke.mjs`.