### PR TITLE
fix(browser): surface remote launch failures, kill remote browser on stop, harden recording (#558 #559 #560)

### DIFF
--- a/src/lib/browser/drivers/ssh.test.ts
+++ b/src/lib/browser/drivers/ssh.test.ts
@@ -7,6 +7,27 @@ import { dirname, join } from 'node:path';
 // exercises the branch logic without shelling out to netstat/tasklist.
 vi.mock('../chrome.js', () => ({ getPortOccupant: vi.fn() }));
 
+// Stub `child_process.spawn` so the ssh-transport tests (launch-failure
+// propagation, kill-on-cleanup) drive fake ssh processes instead of shelling
+// out to a real `ssh`. `execFileSync` (used by isOwnTunnel) is preserved.
+const cp = vi.hoisted(() => {
+  const { EventEmitter } = require('node:events') as typeof import('node:events');
+  const calls: { cmd: string; args: string[]; child: any }[] = [];
+  const spawn = (cmd: string, args: string[]) => {
+    const child: any = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stdin = { end: () => {} };
+    child.kill = () => {};
+    calls.push({ cmd, args, child });
+    return child;
+  };
+  return { calls, spawn };
+});
+vi.mock('child_process', async (importActual) => {
+  const actual = await importActual<typeof import('child_process')>();
+  return { ...actual, spawn: cp.spawn };
+});
+
 import {
   buildLaunchCmd,
   buildKillCmd,
@@ -14,6 +35,8 @@ import {
   buildWindowsKillScript,
   encodePowerShell,
   isOwnTunnel,
+  ensureRemoteBrowser,
+  killRemoteBrowser,
 } from './ssh.js';
 import { getPortOccupant } from '../chrome.js';
 
@@ -51,6 +74,20 @@ describe('buildWindowsLaunchScript', () => {
   it('resolves the real .exe from App Paths for a known browser', () => {
     expect(buildWindowsLaunchScript('edge', 9222)).toContain('App Paths\\msedge.exe');
     expect(buildWindowsLaunchScript('chrome', 9222)).toContain('App Paths\\chrome.exe');
+  });
+
+  it('falls back to HKCU App Paths for per-user installs (Edge/Chrome default)', () => {
+    const s = buildWindowsLaunchScript('edge', 9222);
+    // Per-user installs live under HKCU, not HKLM — an HKLM-only lookup missed
+    // the default Edge/Chrome install and the launch failed. Both hives probed.
+    expect(s).toContain("HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\msedge.exe");
+    expect(s).toContain("HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\msedge.exe");
+    // HKLM must be tried first, HKCU only as the fallback.
+    expect(s.indexOf('HKLM:')).toBeLessThan(s.indexOf('HKCU:'));
+    // PowerShell 5.1 has no `??`; the fallback is an explicit `if`.
+    expect(s).not.toContain('??');
+    // A missing exe throws so it rides out as a non-zero ssh exit.
+    expect(s).toContain('throw');
   });
 
   it('uses a custom binary path verbatim (no App Paths lookup)', () => {
@@ -169,5 +206,60 @@ describe('buildKillCmd', () => {
     expect(cmd).toContain('lsof -ti');
     expect(cmd).toContain(':9222');
     expect(cmd).not.toContain('Stop-Process');
+  });
+});
+
+describe('ensureRemoteBrowser launch-failure propagation (#558)', () => {
+  afterEach(() => {
+    cp.calls.length = 0;
+  });
+
+  it('rejects with the captured stderr on a non-zero ssh exit', async () => {
+    const p = ensureRemoteBrowser('me', 'win-mini', 'edge', 9222, 'windows');
+    const child = cp.calls.at(-1)!.child;
+    child.stderr.emit('data', Buffer.from('msedge.exe not found in HKLM/HKCU App Paths'));
+    child.emit('close', 1);
+    await expect(p).rejects.toThrow(/ssh exit 1/);
+    await expect(p).rejects.toThrow(/not found in HKLM\/HKCU/);
+  });
+
+  it('resolves on a clean (exit 0) launch — an already-running browser is fine', async () => {
+    const p = ensureRemoteBrowser('me', 'win-mini', 'edge', 9222, 'windows');
+    cp.calls.at(-1)!.child.emit('close', 0);
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  it('captures ssh auth failure (exit 255) rather than swallowing it', async () => {
+    const p = ensureRemoteBrowser('me', 'win-mini', 'edge', 9222, 'windows');
+    const child = cp.calls.at(-1)!.child;
+    child.stderr.emit('data', Buffer.from('Permission denied (publickey).'));
+    child.emit('close', 255);
+    await expect(p).rejects.toThrow(/ssh exit 255.*Permission denied/s);
+  });
+});
+
+describe('killRemoteBrowser on stop/cleanup (#559)', () => {
+  afterEach(() => {
+    cp.calls.length = 0;
+  });
+
+  it('invokes the encoded Windows kill script over ssh', async () => {
+    const p = killRemoteBrowser('me', 'win-mini', 'windows', 9222);
+    const rec = cp.calls.at(-1)!;
+    expect(rec.cmd).toBe('ssh');
+    expect(rec.args[0]).toBe('me@win-mini');
+    // The remote command is the exact encoded Get-NetTCPConnection -> Stop-Process
+    // script, so `browser stop` reaps the WMI-spawned browser (not just the tunnel).
+    expect(rec.args).toContain(buildKillCmd('windows', 9222));
+    rec.child.emit('close', 0);
+    await p;
+  });
+
+  it('tears down the posix remote via lsof + kill', async () => {
+    const p = killRemoteBrowser('me', 'host', 'posix', 9222);
+    const rec = cp.calls.at(-1)!;
+    expect(rec.args).toContain(buildKillCmd('posix', 9222));
+    rec.child.emit('close', 0);
+    await p;
   });
 });

--- a/src/lib/browser/drivers/ssh.ts
+++ b/src/lib/browser/drivers/ssh.ts
@@ -78,11 +78,12 @@ export async function connectSSH(
     );
   }
 
-  try {
-    await ensureRemoteBrowser(user, host, profile.browser, remotePort, remoteOs, profile.binary);
-  } catch {
-    // Browser may already be running, continue
-  }
+  // A non-zero remote exit (missing exe, auth failure, bad launch) now rejects
+  // with the captured stderr and propagates. An already-running browser exits 0
+  // (the launch backgrounds/WMI-spawns regardless), so this does not spuriously
+  // fail the reconnect path — only genuine launch failures reach the caller
+  // instead of being swallowed and mis-reported later as a tunnel timeout.
+  await ensureRemoteBrowser(user, host, profile.browser, remotePort, remoteOs, profile.binary);
 
   let tunnel: ChildProcess;
   if (occupant) {
@@ -130,6 +131,11 @@ export async function connectSSH(
     pid: tunnelPid,
     cleanup: () => {
       cdp.close();
+      // Kill the remote browser BEFORE tearing down the tunnel. It runs on a
+      // separate ssh connection (independent of the tunnel we're about to
+      // kill), so tunnel teardown can't cut it off. Fire-and-forget — cleanup
+      // stays synchronous, and killRemoteBrowser never rejects.
+      killRemoteBrowser(user, host, remoteOs, remotePort).catch(() => {});
       tunnel.kill();
       clearProfileRuntime(profile.name);
     },
@@ -217,21 +223,32 @@ export function buildWindowsLaunchScript(
   port: number,
   customBinary?: string
 ): string {
-  let exeExpr: string;
+  let exeStmts: string[];
   if (customBinary) {
-    exeExpr = psSingleQuote(customBinary);
+    exeStmts = [`$exe = ${psSingleQuote(customBinary)}`];
   } else if (browserType === 'custom') {
     throw new Error('browser: custom requires a binary path in the profile');
   } else {
     const exeKey = WIN_BROWSER_APPPATH[browserType];
     if (!exeKey) throw new Error(`Unknown browser type for windows remote: ${browserType}`);
-    exeExpr =
-      `(Get-ItemProperty 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\${exeKey}').'(default)'`;
+    const appPath = `SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\${exeKey}`;
+    // Per-user installs — the DEFAULT for Edge and Chrome — register App Paths
+    // under HKCU, not HKLM, so an HKLM-only lookup silently missed them and the
+    // launch failed. Resolve from HKLM first, then fall through to HKCU.
+    // Windows PowerShell 5.1 (what `powershell.exe` is) has no `??`, so the
+    // fallback is an explicit `if`. A missing exe `throw`s so the failure rides
+    // out as a non-zero ssh exit (surfaced by ensureRemoteBrowser) instead of a
+    // silent empty launch.
+    exeStmts = [
+      `$exe = (Get-ItemProperty 'HKLM:\\${appPath}' -EA SilentlyContinue).'(default)'`,
+      `if (-not $exe) { $exe = (Get-ItemProperty 'HKCU:\\${appPath}' -EA SilentlyContinue).'(default)' }`,
+      `if (-not $exe) { throw 'browser exe not found in HKLM/HKCU App Paths: ${exeKey}' }`,
+    ];
   }
   // Keep the `--remote-allow-origins=http://127.0.0.1:${port}` literal in
   // source — a test asserts CDP is never opened to `*`.
   return [
-    `$exe = ${exeExpr}`,
+    ...exeStmts,
     `$cl = '"' + $exe + '" --remote-debugging-port=${port}` +
       ` --remote-allow-origins=http://127.0.0.1:${port}` +
       ` --disable-background-timer-throttling --user-data-dir="' + $env:TEMP + '\\agents-browser-${port}"'`,
@@ -290,7 +307,7 @@ export function buildKillCmd(remoteOs: RemoteOs, port: number): string {
   return `pids=$(lsof -ti ${shellQuote(`:${port}`)} 2>/dev/null); [ -z "$pids" ] || kill -9 $pids 2>/dev/null || true`;
 }
 
-async function ensureRemoteBrowser(
+export async function ensureRemoteBrowser(
   user: string,
   host: string,
   browserType: string,
@@ -301,6 +318,11 @@ async function ensureRemoteBrowser(
   const remoteCmd = buildLaunchCmd(remoteOs, browserType, port, customBinary);
 
   return new Promise((resolve, reject) => {
+    // Capture stderr so a real launch failure (missing exe, auth denied, bad
+    // CreateProcess) surfaces here as a clear error. Previously stdio was
+    // ignored and this resolved on close regardless of exit code, so failures
+    // were swallowed and only re-emerged 8s later as a generic
+    // "SSH tunnel failed to establish".
     const child = spawn(
       'ssh',
       [
@@ -309,16 +331,48 @@ async function ensureRemoteBrowser(
         'BatchMode=yes',
         remoteCmd,
       ],
-      { stdio: 'ignore' }
+      { stdio: ['ignore', 'ignore', 'pipe'] }
     );
 
-    child.on('close', () => resolve());
-    child.on('error', reject);
+    let stderr = '';
+    child.stderr?.on('data', (d) => {
+      stderr += d.toString();
+    });
 
-    setTimeout(() => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      // ssh is still running the backgrounding launch command past our window.
+      // Killing the local ssh client does NOT reap the WMI/detached remote
+      // browser, so treat this as launched and let waitForPort confirm.
       child.kill();
       resolve();
     }, 2000);
+
+    child.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (code && code !== 0) {
+        const detail = stderr.trim();
+        reject(
+          new Error(
+            `Remote browser launch failed on ${host} (ssh exit ${code})` +
+              (detail ? `: ${detail}` : '')
+          )
+        );
+      } else {
+        resolve();
+      }
+    });
+
+    child.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
   });
 }
 
@@ -335,6 +389,21 @@ export async function restartRemoteBrowser(
   await sleep(500);
   await ensureRemoteBrowser(user, host, browserType, port, remoteOs, customBinary);
   await sleep(1500);
+}
+
+/**
+ * Kill the remote browser holding the CDP port. Invoked on stop/cleanup so the
+ * WMI-spawned (Windows) / detached (posix) browser process is not orphaned when
+ * the ssh tunnel is torn down — killing only the tunnel left it running on
+ * win-mini after every `browser stop`. Best-effort: never rejects.
+ */
+export function killRemoteBrowser(
+  user: string,
+  host: string,
+  remoteOs: RemoteOs,
+  port: number
+): Promise<void> {
+  return runSSHCommand(user, host, buildKillCmd(remoteOs, port));
 }
 
 function runSSHCommand(user: string, host: string, cmd: string): Promise<void> {

--- a/src/lib/browser/service.test.ts
+++ b/src/lib/browser/service.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import { tmpdir } from 'os';
+import { EventEmitter } from 'node:events';
 import * as yaml from 'yaml';
 import * as state from '../state.js';
 import * as profiles from './profiles.js';
@@ -353,5 +354,130 @@ describe('pickWindowTarget', () => {
     ];
     const hit = pickWindowTarget(invisibleMatches, 'url:canva.com');
     expect(hit?.targetId).toBe('BG1');
+  });
+});
+
+// -----------------------------------------------------------------------------
+// recordStop ffmpeg-exit handling (#560)
+//
+// Before the fix, recordStop's 5s wait only RESOLVED the promise — it never
+// killed a hung ffmpeg and never inspected the exit code, so a failed encode
+// (bad codec, missing encoder, corrupt output) reported success with a
+// silently-empty .webm. We inject a fake ffmpeg + recording state straight into
+// the private `recordings` map so the finalize path runs without spawning real
+// ffmpeg or CDP.
+// -----------------------------------------------------------------------------
+function fakeFfmpeg() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: { end: () => void };
+    kill: (sig?: string) => void;
+  };
+  child.stdin = { end: () => {} };
+  child.kill = () => {};
+  return child;
+}
+
+function injectRecording(
+  svc: InstanceType<typeof BrowserService>,
+  taskId: string,
+  overrides: {
+    outputPath?: string;
+    ffmpeg?: ReturnType<typeof fakeFfmpeg>;
+    ffmpegStderr?: () => string;
+  } = {}
+): ReturnType<typeof fakeFfmpeg> {
+  const ffmpeg = overrides.ffmpeg ?? fakeFfmpeg();
+  const durationTimer = setTimeout(() => {}, 1_000_000);
+  const sizeCheckInterval = setInterval(() => {}, 1_000_000);
+  (svc as unknown as { recordings: Map<string, unknown> }).recordings.set(taskId, {
+    outputPath: overrides.outputPath ?? path.join(tmpdir(), 'rec-missing.webm'),
+    startedAt: Date.now() - 1000,
+    fps: 5,
+    maxBytes: 25 * 1024 * 1024,
+    durationMs: 60_000,
+    ffmpeg,
+    ffmpegStderr: overrides.ffmpegStderr ?? (() => ''),
+    sessionId: 'sess-1',
+    conn: { cdp: { off: () => {}, send: async () => {} } },
+    frameHandler: () => {},
+    durationTimer,
+    sizeCheckInterval,
+  });
+  return ffmpeg;
+}
+
+describe('recordStop ffmpeg exit handling (#560)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('surfaces a non-zero ffmpeg exit as failure (not silent success)', async () => {
+    const svc = new BrowserService();
+    const ffmpeg = fakeFfmpeg();
+    // Closing stdin makes a broken ffmpeg flush and exit non-zero.
+    ffmpeg.stdin.end = () => setImmediate(() => ffmpeg.emit('exit', 1));
+    injectRecording(svc, 'task-fail', {
+      ffmpeg,
+      ffmpegStderr: () => '[libvpx-vp9] failed to encode frame',
+    });
+
+    await expect(svc.recordStop('task-fail')).rejects.toThrow(/exited abnormally \(code 1\)/);
+  });
+
+  it('includes ffmpeg stderr in the failure so the encode error is diagnosable', async () => {
+    const svc = new BrowserService();
+    const ffmpeg = fakeFfmpeg();
+    ffmpeg.stdin.end = () => setImmediate(() => ffmpeg.emit('exit', 234));
+    injectRecording(svc, 'task-diag', {
+      ffmpeg,
+      ffmpegStderr: () => 'Unknown encoder libvpx-vp9',
+    });
+
+    await expect(svc.recordStop('task-diag')).rejects.toThrow(/Unknown encoder libvpx-vp9/);
+  });
+
+  it('drops the recording from the map even when finalize fails', async () => {
+    const svc = new BrowserService();
+    const ffmpeg = fakeFfmpeg();
+    ffmpeg.stdin.end = () => setImmediate(() => ffmpeg.emit('exit', 1));
+    injectRecording(svc, 'task-clean', { ffmpeg });
+
+    await expect(svc.recordStop('task-clean')).rejects.toThrow();
+    const recordings = (svc as unknown as { recordings: Map<string, unknown> }).recordings;
+    expect(recordings.has('task-clean')).toBe(false);
+  });
+
+  it('kills a hung ffmpeg on the 5s timeout and reports failure', async () => {
+    vi.useFakeTimers();
+    const svc = new BrowserService();
+    const kill = vi.fn();
+    const ffmpeg = fakeFfmpeg();
+    ffmpeg.kill = kill;
+    ffmpeg.stdin.end = () => {}; // never emits 'exit' — ffmpeg is hung
+    injectRecording(svc, 'task-hang', { ffmpeg });
+
+    const p = svc.recordStop('task-hang');
+    const assertion = expect(p).rejects.toThrow(/did not exit within 5s/);
+    await vi.advanceTimersByTimeAsync(5000);
+    await assertion;
+    expect(kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('returns success with a real byte count on a clean (exit 0) finalize', async () => {
+    const svc = new BrowserService();
+    const outputPath = path.join(tmpdir(), `rec-ok-${process.pid}-${Date.now()}.webm`);
+    fs.writeFileSync(outputPath, Buffer.alloc(2048, 7));
+    try {
+      const ffmpeg = fakeFfmpeg();
+      ffmpeg.stdin.end = () => setImmediate(() => ffmpeg.emit('exit', 0));
+      injectRecording(svc, 'task-ok', { ffmpeg, outputPath });
+
+      const res = await svc.recordStop('task-ok');
+      expect(res.path).toBe(outputPath);
+      expect(res.bytes).toBe(2048);
+      expect(res.reason).toBe('manual');
+    } finally {
+      fs.rmSync(outputPath, { force: true });
+    }
   });
 });

--- a/src/lib/browser/service.ts
+++ b/src/lib/browser/service.ts
@@ -847,6 +847,7 @@ export class BrowserService {
     maxBytes: number;
     durationMs: number;
     ffmpeg: import('child_process').ChildProcess;
+    ffmpegStderr: () => string;
     sessionId: string;
     conn: ProfileConnection;
     frameHandler: (params: unknown) => void;
@@ -884,16 +885,24 @@ export class BrowserService {
 
     // Resolve ffmpeg lazily so non-recording paths don't pay the import cost.
     const { spawn } = await import('child_process');
+    // CDP `Page.startScreencast` delivers frames at a VARIABLE cadence (paints
+    // are event-driven, not clocked). Feeding those into a fixed `-framerate`
+    // input made ffmpeg assume every frame was 1/fps apart, so a page that
+    // painted slower/faster than `fps` played back at the wrong speed. Instead
+    // stamp each frame with its wall-clock arrival time
+    // (`-use_wallclock_as_timestamps 1`) and keep those timings on output
+    // (`-vsync vfr`), so playback duration matches the real capture.
     const ffmpeg = spawn(
       'ffmpeg',
       [
         '-loglevel', 'error',
         '-f', 'image2pipe',
-        '-framerate', String(fps),
+        '-use_wallclock_as_timestamps', '1',
         '-i', '-',
         '-c:v', 'libvpx-vp9',
         '-b:v', '1M',
         '-pix_fmt', 'yuv420p',
+        '-vsync', 'vfr',
         '-y',
         outputPath,
       ],
@@ -919,9 +928,15 @@ export class BrowserService {
       ffmpeg.once('spawn', onSpawn);
     });
 
-    // Surface ffmpeg's own diagnostics (encoder error, etc.) in case stderr
-    // arrives after spawn.
-    ffmpeg.stderr?.on('data', () => { /* drain so the pipe doesn't fill */ });
+    // Capture ffmpeg's own diagnostics (encoder error, bad codec, etc.) so a
+    // failing encode is DIAGNOSABLE at recordStop instead of being discarded.
+    // Cap the buffer so a chatty ffmpeg can't grow it unbounded.
+    let stderrBuf = '';
+    ffmpeg.stderr?.on('data', (d: Buffer) => {
+      stderrBuf += d.toString();
+      if (stderrBuf.length > 64 * 1024) stderrBuf = stderrBuf.slice(-64 * 1024);
+    });
+    const ffmpegStderr = () => stderrBuf;
     ffmpeg.on('error', () => { /* post-spawn errors get reported via exit code */ });
 
     // 30 fps is CDP's screencast cap; everyNthFrame = round(30/fps).
@@ -954,6 +969,7 @@ export class BrowserService {
       durationMs,
       maxBytes,
       ffmpeg,
+      ffmpegStderr,
       sessionId,
       conn,
       frameHandler,
@@ -1003,27 +1019,57 @@ export class BrowserService {
       // session may already be gone
     }
 
-    // Close ffmpeg stdin so it flushes the output file cleanly.
-    await new Promise<void>((resolve) => {
-      rec.ffmpeg.on('exit', () => resolve());
+    // Close ffmpeg stdin so it flushes the output file cleanly, and observe how
+    // it exits. A non-zero exit means the encode failed — the recording must
+    // NOT be reported as success. If ffmpeg hangs, KILL it (don't just abandon
+    // the promise, which leaked the process) and treat the recording as failed.
+    const finalize = await new Promise<{ code: number | null; timedOut: boolean }>((resolve) => {
+      let done = false;
+      const settle = (r: { code: number | null; timedOut: boolean }) => {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        resolve(r);
+      };
+      const timer = setTimeout(() => {
+        try { rec.ffmpeg.kill('SIGKILL'); } catch { /* already gone */ }
+        settle({ code: null, timedOut: true });
+      }, 5000);
+      rec.ffmpeg.once('exit', (code) => settle({ code, timedOut: false }));
       try {
         rec.ffmpeg.stdin?.end();
       } catch {
-        resolve();
+        // stdin already closed; wait for exit or the hard timeout above.
       }
-      setTimeout(resolve, 5000); // Hard timeout if ffmpeg hangs
     });
+
+    const durationMs = Date.now() - rec.startedAt;
+    // Drop the recording from the map before any throw, so a failed stop
+    // doesn't wedge the task in a permanent "already recording" state.
+    this.recordings.delete(taskId);
+
+    if (finalize.timedOut) {
+      throw new Error(
+        `ffmpeg did not exit within 5s while finalizing the recording; killed it. ` +
+          `The recording at ${rec.outputPath} is incomplete.`
+      );
+    }
+    if (finalize.code !== 0) {
+      const err = rec.ffmpegStderr().trim();
+      throw new Error(
+        `ffmpeg exited abnormally (code ${finalize.code}) while finalizing the recording at ` +
+          `${rec.outputPath}; the file is likely corrupt or empty.` +
+          (err ? ` ffmpeg: ${err.slice(-800)}` : '')
+      );
+    }
 
     let bytes = 0;
     try {
       const st = await fs.promises.stat(rec.outputPath);
       bytes = st.size;
     } catch {
-      // ffmpeg may have failed; file missing
+      // ffmpeg exited 0 but the file is missing — still a failed recording.
     }
-    const durationMs = Date.now() - rec.startedAt;
-
-    this.recordings.delete(taskId);
     return { path: rec.outputPath, bytes, durationMs, reason };
   }
 


### PR DESCRIPTION
Fixes three browser-use remote-reliability bugs surfaced in the win-mini end-to-end pass. Scoped to `src/lib/browser/drivers/ssh.ts` and `src/lib/browser/service.ts` (+ their 1:1 tests).

## #558 — surface remote launch failures + HKCU fallback

- **`ensureRemoteBrowser`** (`ssh.ts`) previously spawned ssh with `stdio: 'ignore'` and resolved on `close` OR after 2s **regardless of exit code**, so a missing exe / auth failure / bad launch was silently swallowed and only re-emerged 8s later as a generic `SSH tunnel failed to establish`. It now captures stderr and **rejects on a non-zero ssh exit** with the captured detail. `connectSSH` propagates that error instead of blanket-`catch`-ing it — an already-running browser still exits 0 (launch backgrounds / WMI-spawns regardless), so the reconnect path is unaffected.
- **`buildWindowsLaunchScript`** resolved the exe from `HKLM:\...\App Paths\<exe>` only. Per-user installs — the **default** for Edge/Chrome — register under **HKCU** and were never found. Now resolves HKLM first, falls through to HKCU (explicit `if`, since Windows PowerShell 5.1 has no `??`), and `throw`s when neither hive has it so the failure rides out as a non-zero ssh exit.

## #559 — stop/cleanup must kill the remote browser

`connectSSH`'s cleanup handler killed only the ssh **tunnel**; the WMI-spawned (Windows) / detached (posix) browser was orphaned after every `browser stop` (a real leak on win-mini). New exported **`killRemoteBrowser()`** is fired from cleanup — on a **separate** ssh connection, so tunnel teardown can't cut it off — routing through the existing `buildKillCmd` choke point (Windows: `Get-NetTCPConnection` → `Stop-Process`).

## #560 — recording error handling (`service.ts`)

- ffmpeg stderr was discarded (`.on('data', () => {})`); now **captured** (bounded to 64 KiB) so a failed encode is diagnosable.
- `recordStop`'s 5s wait only **resolved** the promise — never killed a hung ffmpeg, never checked the exit code, so a failed encode reported success with a silently-empty `.webm`. It now inspects the exit code (**non-zero → throws**, with stderr tail), **SIGKILLs** a hung ffmpeg on timeout, and drops the recording from the map before any throw so the task isn't wedged.
- `Page.startScreencast` delivers frames at variable cadence but ffmpeg was given a fixed `-framerate`, desyncing playback speed. Switched to `-use_wallclock_as_timestamps 1` + `-vsync vfr` so output timing matches real frame delivery.

## Tests — discharge #561 for the browser remote path

- `ssh.test.ts`: launch-failure propagation (non-zero exit, exit-0 already-running, ssh auth 255), HKCU fallback + ordering, and `killRemoteBrowser` invoking the encoded Windows kill script / posix lsof+kill over ssh.
- `service.test.ts`: `recordStop` surfacing a non-zero ffmpeg exit as failure, including stderr in the message, dropping the recording on failure, SIGKILL on the 5s hang, and success with a real byte count on exit 0.

`npm run build` clean; full `src/lib/browser/` suite green (209 tests).