### PR TITLE
fix(daemon): keep browser IPC daemon always-on under browser start (#556)

### DIFF
--- a/src/lib/browser/ipc.test.ts
+++ b/src/lib/browser/ipc.test.ts
@@ -1,14 +1,17 @@
 import { afterEach, describe, it, expect, vi } from 'vitest';
-import { rmSync } from 'fs';
+import { rmSync, mkdirSync, writeFileSync } from 'fs';
+import * as net from 'net';
 import * as path from 'path';
 import {
   BrowserDaemonNotRunningError,
   formatBrowserDaemonNotRunningError,
   getSocketPath,
+  isDaemonReachable,
   sendIPCRequest,
   shouldRestartStaleDaemon,
 } from './ipc.js';
 import { getHelpersDir } from '../state.js';
+import { ipcEndpoint } from '../platform/index.js';
 import { startDaemon } from '../daemon.js';
 
 const HELPER_DIR = `/tmp/agents-cli-browser-ipc-${process.pid}`;
@@ -46,6 +49,43 @@ describe('sendIPCRequest', () => {
       sendIPCRequest({ action: 'status' }, { autoStartDaemon: false })
     ).rejects.toThrow(formatBrowserDaemonNotRunningError());
     expect(startDaemon).not.toHaveBeenCalled();
+  });
+});
+
+// #556: the daemon binds its browser IPC socket, then a crash / immediate
+// self-teardown leaves the socket *file* on disk with nothing listening. The
+// old reachability check was `fs.existsSync(socketPath)`, which treats that
+// stale file as a live daemon — the client then connects and gets ECONNREFUSED.
+// isDaemonReachable must be an actual connection probe: reachable only when a
+// process is really accepting on the socket.
+describe('isDaemonReachable (connection probe, not file existence)', () => {
+  it('is false when no socket exists at all', async () => {
+    expect(await isDaemonReachable()).toBe(false);
+  });
+
+  it('is false for a stale socket file that nothing is listening on', async () => {
+    const socketPath = getSocketPath();
+    mkdirSync(path.dirname(socketPath), { recursive: true });
+    // A plain file at the socket path: exists on disk, but no listener.
+    // fs.existsSync would report this as "reachable" — the bug we are fixing.
+    writeFileSync(socketPath, '');
+    expect(await isDaemonReachable()).toBe(false);
+  });
+
+  it('is true only when a process is actually accepting on the socket', async () => {
+    const socketPath = getSocketPath();
+    mkdirSync(path.dirname(socketPath), { recursive: true });
+    const server = net.createServer();
+    // Listen on the same endpoint the probe connects to (a named pipe on
+    // Windows, the socket file path on POSIX).
+    await new Promise<void>((resolve) => server.listen(ipcEndpoint(socketPath), () => resolve()));
+    try {
+      expect(await isDaemonReachable()).toBe(true);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+    // After the listener goes away, reachability flips back to false.
+    expect(await isDaemonReachable()).toBe(false);
   });
 });
 

--- a/src/lib/browser/ipc.ts
+++ b/src/lib/browser/ipc.ts
@@ -44,8 +44,12 @@ function getIpcEndpoint(): string {
   return ipcEndpoint(getSocketPath());
 }
 
-/** Can we open a connection to the daemon right now? Used on Windows where a
- * named pipe can't be probed with fs.existsSync. Resolves false on any error. */
+/** Can we open a connection to the daemon right now? Resolves false on any
+ * error. This is the authoritative liveness check on every platform: a live
+ * daemon accepts the connection, while a stale POSIX socket file left behind by
+ * a crashed daemon (or one that "appears and is immediately destroyed", #556)
+ * rejects with ECONNREFUSED and is correctly reported as not reachable —
+ * something fs.existsSync can't distinguish. */
 function probeDaemon(endpoint: string, timeoutMs = 500): Promise<boolean> {
   return new Promise((resolve) => {
     const sock = net.createConnection(endpoint);
@@ -57,16 +61,17 @@ function probeDaemon(endpoint: string, timeoutMs = 500): Promise<boolean> {
   });
 }
 
-/** Is the daemon reachable? existsSync probe on POSIX, connect probe on Windows. */
-async function isDaemonReachable(): Promise<boolean> {
-  if (IS_WINDOWS) return probeDaemon(getIpcEndpoint());
-  return fs.existsSync(getSocketPath());
+/** Is the daemon reachable? A real connect probe on every platform — a socket
+ * file existing on disk is not proof a daemon is listening on it. */
+export async function isDaemonReachable(): Promise<boolean> {
+  return probeDaemon(getIpcEndpoint());
 }
 
-async function waitForSocket(socketPath: string, timeoutMs: number): Promise<void> {
+async function waitForSocket(_socketPath: string, timeoutMs: number): Promise<void> {
+  const endpoint = getIpcEndpoint();
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (IS_WINDOWS ? await probeDaemon(getIpcEndpoint()) : fs.existsSync(socketPath)) return;
+    if (await probeDaemon(endpoint)) return;
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
   throw new Error('Timeout waiting for browser daemon socket');

--- a/src/lib/daemon.test.ts
+++ b/src/lib/daemon.test.ts
@@ -10,12 +10,21 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as net from 'net';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { fileURLToPath } from 'url';
 import {
   generateLaunchdPlist,
   generateSystemdUnit,
   readDaemonClaudeOAuthToken,
   buildDetachedDaemonEnv,
+  getDaemonLaunch,
+  startDetached,
 } from './daemon.js';
+import { ipcEndpoint } from './platform/index.js';
 import {
   secretsKeychainItem,
   setKeychainToken,
@@ -160,4 +169,101 @@ describe('buildDetachedDaemonEnv', () => {
     const env = buildDetachedDaemonEnv({ PATH: '/usr/bin' });
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
   });
+});
+
+describe('getDaemonLaunch', () => {
+  // #556: the detached daemon must be launched as `node <entry> daemon _run`,
+  // not by executing the entry path directly. Executing a `.js`/shim path relies
+  // on a shebang (POSIX) or a console-owning shell wrapper (Windows); on Windows
+  // that wrapper's exit closes its console and tears the daemon down ~36ms after
+  // it binds the browser IPC socket.
+  it('launches a .js entry through the Node runtime', () => {
+    const { command, args } = getDaemonLaunch('/opt/agents/dist/index.js');
+    expect(command).toBe(process.execPath);
+    expect(args).toEqual(['/opt/agents/dist/index.js', 'daemon', '_run']);
+  });
+
+  it('launches .mjs and .cjs entries through the Node runtime too', () => {
+    expect(getDaemonLaunch('/x/index.mjs').command).toBe(process.execPath);
+    expect(getDaemonLaunch('/x/index.mjs').args[0]).toBe('/x/index.mjs');
+    expect(getDaemonLaunch('/x/index.cjs').command).toBe(process.execPath);
+  });
+
+  it('runs a non-JS launcher (resolved shim) directly', () => {
+    const { command, args } = getDaemonLaunch('/usr/local/bin/agents');
+    expect(command).toBe('/usr/local/bin/agents');
+    expect(args).toEqual(['daemon', '_run']);
+  });
+});
+
+/** Open a real connection to the daemon endpoint; resolve true only if a
+ * process is accepting on it (mirrors the client's own liveness probe). */
+function probeEndpoint(endpoint: string, timeoutMs = 500): Promise<boolean> {
+  return new Promise((resolve) => {
+    const sock = net.createConnection(endpoint);
+    let done = false;
+    const finish = (ok: boolean) => { if (done) return; done = true; sock.destroy(); resolve(ok); };
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    sock.on('connect', () => { clearTimeout(timer); finish(true); });
+    sock.on('error', () => { clearTimeout(timer); finish(false); });
+  });
+}
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const DIST_ENTRY = path.join(REPO_ROOT, 'dist', 'index.js');
+
+// #556 / #561 (missing e2e coverage): drive the REAL startDetached path and
+// prove the daemon it spawns is always-on — the socket comes up AND is still up
+// after >1s, i.e. it did not self-terminate the way the bug report describes
+// ("Browser IPC server started" then "Daemon shutting down" ~36ms later).
+describe('startDetached (integration: daemon stays alive)', () => {
+  it('spawns a detached daemon whose socket comes up and stays up past 1s', async () => {
+    // Exercises the built CLI entry the way `browser start` does. CI runs the
+    // build before tests; self-heal for a bare `vitest` run without a prior build.
+    if (!fs.existsSync(DIST_ENTRY)) {
+      execFileSync('npm', ['run', 'build'], { cwd: REPO_ROOT, stdio: 'ignore' });
+    }
+
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-daemon556-'));
+    // Satisfy the setup gate (`ensureInitialized`): ~/.agents/.system must be a repo.
+    const systemDir = path.join(tmpHome, '.agents', '.system');
+    fs.mkdirSync(systemDir, { recursive: true });
+    execFileSync('git', ['init', '-q', systemDir]);
+
+    const logPath = path.join(tmpHome, 'daemon-stdio.log');
+    const socketPath = path.join(tmpHome, '.agents', '.cache', 'helpers', 'browser', 'browser.sock');
+    const endpoint = ipcEndpoint(socketPath);
+    const daemonLog = path.join(tmpHome, '.agents', '.cache', 'helpers', 'daemon', 'logs.jsonl');
+
+    const childEnv = { ...process.env, HOME: tmpHome };
+    delete childEnv.CLAUDE_CODE_OAUTH_TOKEN;
+
+    const { pid } = startDetached({ agentsBin: DIST_ENTRY, logPath, env: childEnv });
+    expect(pid).toBeTruthy();
+    const alive = () => { try { process.kill(pid!, 0); return true; } catch { return false; } };
+
+    try {
+      // Wait for the browser IPC socket to accept connections (issue: ~400ms).
+      let up = false;
+      for (let i = 0; i < 80 && !up; i++) {
+        up = await probeEndpoint(endpoint);
+        if (!up) await new Promise((r) => setTimeout(r, 100));
+      }
+      expect(up).toBe(true);
+
+      // The crux of #556: it must NOT tear itself down. Wait well past the 36ms
+      // window and re-probe.
+      await new Promise((r) => setTimeout(r, 1500));
+      expect(await probeEndpoint(endpoint)).toBe(true);
+      expect(alive()).toBe(true);
+
+      // The daemon's own structured log confirms it came up and never shut down.
+      const logText = fs.existsSync(daemonLog) ? fs.readFileSync(daemonLog, 'utf-8') : '';
+      expect(logText).toContain('Browser IPC server started');
+      expect(logText).not.toContain('Daemon shutting down');
+    } finally {
+      try { if (pid) process.kill(pid, 'SIGKILL'); } catch { /* already gone */ }
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }, 30_000);
 });

--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -547,21 +547,59 @@ export function buildDetachedDaemonEnv(baseEnv: NodeJS.ProcessEnv = process.env)
   return env;
 }
 
-function startDetached(): { pid: number; method: string } {
-  const agentsBin = getAgentsBinPath();
-  const logPath = getLogPath();
+/**
+ * Resolve how to launch the daemon: `node <entry> daemon _run`, matching the
+ * exact form that works under a direct `daemon _run`.
+ *
+ * We spawn the Node runtime (`process.execPath`) with the CLI entry as an
+ * argument rather than executing the entry path directly. Executing the `.js`
+ * path relies on its shebang on POSIX, and on Windows CreateProcess can't run a
+ * `.js`/shim directly at all — it gets launched through a transient
+ * console-owning wrapper (cmd.exe / the npm shim). When that wrapper exits it
+ * closes its console, and the detached daemon sharing that console receives a
+ * console-close event that trips its shutdown handler — the daemon comes up,
+ * binds the browser IPC socket, then tears itself down ~36ms later (#556).
+ * Going through `process.execPath` means a real PE/binary is spawned with
+ * `detached: true` and no console, so nothing signals the daemon after launch.
+ *
+ * When the entry isn't a JS file (e.g. a native launcher resolved via
+ * `which agents`), run it directly — it owns its own runtime resolution.
+ */
+export function getDaemonLaunch(agentsBin: string = getAgentsBinPath()): { command: string; args: string[] } {
+  if (/\.(c|m)?js$/.test(agentsBin)) {
+    return { command: process.execPath, args: [agentsBin, 'daemon', '_run'] };
+  }
+  return { command: agentsBin, args: ['daemon', '_run'] };
+}
+
+interface StartDetachedOptions {
+  /** CLI entry to launch (defaults to the running binary). Injectable for tests. */
+  agentsBin?: string;
+  /** Log file the daemon's stdio is redirected to (defaults to the daemon log). */
+  logPath?: string;
+  /** Environment for the child (defaults to the OAuth-augmented detached env). */
+  env?: NodeJS.ProcessEnv;
+}
+
+export function startDetached(opts: StartDetachedOptions = {}): { pid: number | null; method: string } {
+  const agentsBin = opts.agentsBin ?? getAgentsBinPath();
+  const logPath = opts.logPath ?? getLogPath();
   const logFd = fs.openSync(logPath, 'a');
 
-  const child = spawn(agentsBin, ['daemon', '_run'], {
+  const { command, args } = getDaemonLaunch(agentsBin);
+  const child = spawn(command, args, {
     stdio: ['ignore', logFd, logFd],
     detached: true,
-    env: buildDetachedDaemonEnv(),
+    // No console window on Windows — a hidden, consoleless process can't be
+    // torn down by a console-close event when its launcher exits (#556).
+    windowsHide: true,
+    env: opts.env ?? buildDetachedDaemonEnv(),
   });
 
   child.unref();
   fs.closeSync(logFd);
 
-  return { pid: child.pid || null, method: 'detached' } as { pid: number; method: string };
+  return { pid: child.pid || null, method: 'detached' };
 }
 
 function waitForPid(timeoutMs: number): number | null {


### PR DESCRIPTION
## Problem (#556)

`agents browser start` fails with `Error: Timeout waiting for browser daemon socket`. The daemon log shows the daemon coming up and then tearing itself down ~36ms later:

```
Browser IPC server started
[+36ms] Daemon shutting down
```

Running the entrypoint directly (`node dist/index.js daemon _run`) works fine — so the fault is in how `browser start` brings the daemon up (`startDetached`) and how the client waits for the socket.

## Root cause — two source-level defects

**1. `startDetached` executed the CLI `.js` entry directly instead of via Node.**
`getAgentsBinPath()` returns `process.argv[1]` (the `.js` entry), and `startDetached` spawned that path directly. On POSIX this only works via the entry's shebang; on Windows `CreateProcess` can't run a `.js`/shim at all, so it's launched through a transient console-owning wrapper (cmd.exe / npm shim). When that wrapper exits it closes its console, and the detached daemon sharing that console receives a console-close event that trips its shutdown handler (`handleShutdown`, `daemon.ts:329`) — the daemon binds the browser IPC socket, then shuts down ~36ms later.

Fix: launch the daemon as `node <entry> daemon _run` via a new `getDaemonLaunch()` helper (`process.execPath` + entry), with `windowsHide: true`. This is exactly the form that works under a direct `daemon _run`, and spawns a real, consoleless detached process that nothing signals after launch.

**2. Client reachability used `fs.existsSync(socketPath)` on POSIX.**
A stale socket *file* left behind by a crashed/torn-down daemon was treated as a live daemon: the client would connect and get `ECONNREFUSED`, and `waitForSocket` would return on a socket that "appears and is immediately destroyed." Windows already used a real connect probe.

Fix: use an actual connection probe on every platform (`isDaemonReachable`, `waitForSocket`), so "reachable" means a process is genuinely accepting on the socket — not merely that a file exists.

No band-aid retry loops were added to the client; both fixes are at the source.

## Verification

- Reproduced the exact `Browser IPC server started` -> `Daemon shutting down` (36ms) signature locally, then confirmed a `node <entry> daemon _run` detached spawn survives.
- Drove the **real** `startDetached` path against the built entry under an isolated HOME: socket comes up and is still up after >1s; the daemon's own log contains `Browser IPC server started` and never `Daemon shutting down`.
- `npm run build` clean; full suite green (`3459 passed, 48 skipped`).

Windows end-to-end is left to the coordinator's consolidated win-mini pass (per team rules — the box can't be driven concurrently).

## Tests (discharges #561 e2e/integration coverage for this subsystem)

- `src/lib/daemon.test.ts` — real `startDetached` integration test asserting the daemon stays alive (socket up + still up after >1s + process alive + log assertions), plus `getDaemonLaunch` unit tests.
- `src/lib/browser/ipc.test.ts` — `isDaemonReachable` is a connection probe, not file existence: a stale socket file is not "reachable"; a live listener is.

Cross-references: #415 (daemon become always-on), #417 (spawn heavy services as children).
