### PR TITLE
feat(sessions): fleet-wide --active, live listing preview, and a devices skill

### DIFF
--- a/skills/devices/SKILL.md
+++ b/skills/devices/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: devices
+description: "Register and connect to your machines over Tailscale SSH with agents-cli. Use this skill to sync devices from the tailnet, list them, open a shell on another machine, or see agent sessions running across your whole fleet."
+argument-hint: "[sync|list|show|add|set|ssh]"
+allowed-tools: Bash(agents devices*), Bash(agents ssh*), Bash(agents sessions*)
+user-invocable: true
+---
+
+# Devices Skill
+
+Manage a registry of SSH device profiles and reach your other machines. The
+registry self-populates from `tailscale status --json`, so on a tailnet you
+rarely hand-enter a host. This skill teaches the `agents devices` and
+`agents ssh` CLIs, plus the fleet-wide `agents sessions --active` view.
+
+## Register devices
+
+```bash
+# Ingest the tailnet into device profiles. In a terminal this opens a
+# checkbox to register/unregister nodes; --yes registers every non-ignored one.
+agents devices sync
+agents devices sync --yes
+
+# Register or dismiss a single discovered node.
+agents devices register <name>
+agents devices ignore <name>      # never suggest it again
+agents devices unignore <name>    # undo an ignore
+```
+
+## Inspect
+
+```bash
+agents devices list               # platform, address, reachability (alias: ls)
+agents devices list --json        # registry as a JSON array (for scripts/hooks)
+agents devices show <name>        # full profile for one device
+```
+
+`list` marks the machine you are on with `▸ <name>  ← this machine`.
+
+## Add / edit manually
+
+```bash
+# target is user@host or host; platform is windows | linux | macos
+agents devices add <name> <target> --platform linux
+
+# Update fields on an existing device.
+agents devices set <name> --user muqsit --platform macos
+agents devices set <name> --auth password --bundle <secrets-bundle>
+
+agents devices rm <name>          # remove from the registry (alias: remove)
+```
+
+Auth is either `key` (system ssh agent / on-disk keys) or `password` (pulled
+from a Keychain-backed secrets bundle — never stored on disk).
+
+## Connect
+
+```bash
+# Open a shell (preflights reachability, picks the shell, authenticates).
+agents ssh <name>
+
+# Run a one-off command and return.
+agents ssh <name> uname -a
+```
+
+To use plain `ssh <name>`, render the registry into your ssh config:
+
+```bash
+agents devices render            # print the Host stanzas to stdout
+agents devices render --write    # write ~/.ssh/config.d/agents
+```
+
+## Fleet-wide active sessions
+
+`agents sessions --active` groups running agent sessions by machine, pins the
+local box first (`▸ <name> ← this machine`), and folds in sessions from your
+registered, online devices over SSH:
+
+```bash
+agents sessions --active           # this machine + every online device
+agents sessions --active --local   # this machine only (no SSH fan-out)
+agents sessions --active --host zion --host mac-mini   # specific machines
+agents sessions --active --json    # merged, machine-tagged, for scripts
+```
+
+Unreachable or CLI-less hosts are skipped with a note, never fatal. If no
+devices are registered, it prints a tip pointing you at `agents devices sync`.
+
+## Tips
+
+- Reachability in `list` is a snapshot from the last `sync`; rerun `sync` to
+  refresh it.
+- iOS/tablet nodes can't run the CLI and are skipped by the `--active` fan-out.
+- A device with password auth needs a bundle: `agents devices set <name>
+  --auth password --bundle <name>`.

--- a/src/commands/__tests__/sessions-columns.test.ts
+++ b/src/commands/__tests__/sessions-columns.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Tests for the ticket/PR column helper (Feature 3). The ref used to jam
+ * against a truncated topic inside the badge blob; ticketLabel pulls it into a
+ * dedicated column, and its precedence (ticket over PR) is the bit worth
+ * pinning so a session tied to both doesn't flip between them.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ticketLabel } from '../sessions.js';
+
+describe('ticketLabel', () => {
+  it('returns the tracker ticket id when present', () => {
+    expect(ticketLabel({ ticketId: 'RUSH-1332', prNumber: undefined })).toBe('RUSH-1332');
+  });
+
+  it('falls back to PR#<n> when there is no ticket', () => {
+    expect(ticketLabel({ ticketId: undefined, prNumber: 565 })).toBe('PR#565');
+  });
+
+  it('prefers the ticket over the PR when both are set', () => {
+    expect(ticketLabel({ ticketId: 'RUSH-1332', prNumber: 565 })).toBe('RUSH-1332');
+  });
+
+  it('returns empty string when neither is set', () => {
+    expect(ticketLabel({ ticketId: undefined, prNumber: undefined })).toBe('');
+  });
+});

--- a/src/commands/__tests__/sessions-live-preview.test.ts
+++ b/src/commands/__tests__/sessions-live-preview.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for the pure helpers that enrich the default `agents sessions` listing
+ * with live state (Feature 2). Correlating a historical row to the session
+ * that is still running hinges on the full-UUID key, and the glyph must reflect
+ * the coarse status — both are easy to get subtly wrong, so they're exercised
+ * directly rather than through the chalk+console renderer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { indexActiveBySessionId, liveGlyphAndPreview } from '../sessions.js';
+import type { ActiveSession } from '../../lib/session/active.js';
+
+function mk(overrides: Partial<ActiveSession>): ActiveSession {
+  return {
+    context: 'terminal',
+    kind: 'claude',
+    status: 'running',
+    ...overrides,
+  };
+}
+
+describe('indexActiveBySessionId', () => {
+  it('keys by the full session UUID', () => {
+    const a = mk({ sessionId: 'abc12345-def6-7890-1234-567890abcdef' });
+    const idx = indexActiveBySessionId([a]);
+    expect(idx.get('abc12345-def6-7890-1234-567890abcdef')).toBe(a);
+    // Not addressable by the 8-char short id — the caller matches on meta.id.
+    expect(idx.get('abc12345')).toBeUndefined();
+  });
+
+  it('skips sessions without a sessionId (uncorrelatable probes)', () => {
+    const idx = indexActiveBySessionId([
+      mk({ sessionId: undefined, context: 'cloud' }),
+      mk({ sessionId: 'keep-me' }),
+    ]);
+    expect(idx.size).toBe(1);
+    expect(idx.has('keep-me')).toBe(true);
+  });
+
+  it('last write wins when a sessionId repeats', () => {
+    const first = mk({ sessionId: 'dup', preview: 'first' });
+    const second = mk({ sessionId: 'dup', preview: 'second' });
+    const idx = indexActiveBySessionId([first, second]);
+    expect(idx.get('dup')).toBe(second);
+  });
+});
+
+describe('liveGlyphAndPreview', () => {
+  it('returns empty strings for no live match (plain historical row)', () => {
+    expect(liveGlyphAndPreview(undefined)).toEqual({ glyph: '', preview: '' });
+  });
+
+  it('running → ● and the state-engine preview', () => {
+    const { glyph, preview } = liveGlyphAndPreview(mk({ status: 'running', preview: 'editing sessions.ts' }));
+    expect(glyph).toContain('●');
+    expect(preview).toBe('editing sessions.ts');
+  });
+
+  it('waiting on input → ◐ (both status and activity forms)', () => {
+    expect(liveGlyphAndPreview(mk({ status: 'input_required' })).glyph).toContain('◐');
+    expect(liveGlyphAndPreview(mk({ status: 'running', activity: 'waiting_input' })).glyph).toContain('◐');
+  });
+
+  it('idle → ○', () => {
+    expect(liveGlyphAndPreview(mk({ status: 'idle' })).glyph).toContain('○');
+  });
+
+  it('preview falls back to label then topic when there is no live preview', () => {
+    expect(liveGlyphAndPreview(mk({ status: 'running', label: 'my-task' })).preview).toBe('my-task');
+    expect(liveGlyphAndPreview(mk({ status: 'running', topic: 'first prompt' })).preview).toBe('first prompt');
+  });
+});

--- a/src/commands/__tests__/sessions-machine-grouping.test.ts
+++ b/src/commands/__tests__/sessions-machine-grouping.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the machine-grouping layer behind `agents sessions --active`.
+ *
+ * The renderer couples grouping with chalk+console; groupSessionsByMachine and
+ * dedupeByMachineSession are the pure pieces where the real bugs live — keying
+ * off the terminal-app host instead of the machine, dropping the local box out
+ * of first place, or collapsing two different machines' identically-numbered
+ * sessions into one.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { groupSessionsByMachine, dedupeByMachineSession } from '../sessions.js';
+import type { ActiveSession } from '../../lib/session/active.js';
+
+function mk(overrides: Partial<ActiveSession>): ActiveSession {
+  return {
+    context: 'terminal',
+    kind: 'claude',
+    status: 'running',
+    ...overrides,
+  };
+}
+
+describe('groupSessionsByMachine', () => {
+  it('pins the local machine first even when it has fewer sessions', () => {
+    const layout = groupSessionsByMachine(
+      [
+        mk({ machine: 'zion', sessionId: 'z1' }),
+        mk({ machine: 'zion', sessionId: 'z2' }),
+        mk({ machine: 'yosemite-s0', sessionId: 'l1' }),
+      ],
+      'yosemite-s0',
+    );
+    expect(layout.machines.map((m) => m.machine)).toEqual(['yosemite-s0', 'zion']);
+    expect(layout.machines[0].isLocal).toBe(true);
+    expect(layout.machines[1].isLocal).toBe(false);
+  });
+
+  it('sorts non-local machines by session count desc, then name', () => {
+    const layout = groupSessionsByMachine(
+      [
+        mk({ machine: 'alpha', sessionId: 'a1' }),
+        mk({ machine: 'beta', sessionId: 'b1' }),
+        mk({ machine: 'beta', sessionId: 'b2' }),
+        mk({ machine: 'gamma', sessionId: 'g1' }),
+      ],
+      'local-box',
+    );
+    // beta (2) before alpha/gamma (1 each); alpha before gamma by name.
+    expect(layout.machines.map((m) => m.machine)).toEqual(['beta', 'alpha', 'gamma']);
+  });
+
+  it('prefers the explicit machine tag over the provenance host', () => {
+    const layout = groupSessionsByMachine(
+      [mk({ machine: 'tagged', provenance: { host: 'provhost' } as any, sessionId: 's1' })],
+      'local-box',
+    );
+    expect(layout.machines[0].machine).toBe('tagged');
+  });
+
+  it('falls back to the normalized provenance host when there is no tag', () => {
+    const layout = groupSessionsByMachine(
+      [mk({ provenance: { host: 'ZION.tail1a85a1.ts.net' } as any, sessionId: 's1' })],
+      'local-box',
+    );
+    expect(layout.machines[0].machine).toBe('zion');
+  });
+
+  it('falls back to the local machine for an untagged, provenance-less session', () => {
+    const layout = groupSessionsByMachine([mk({ sessionId: 's1' })], 'local-box');
+    expect(layout.machines).toHaveLength(1);
+    expect(layout.machines[0].machine).toBe('local-box');
+    expect(layout.machines[0].isLocal).toBe(true);
+  });
+
+  it('still splits a machine into its workspace layout', () => {
+    const layout = groupSessionsByMachine(
+      [
+        mk({ machine: 'zion', cwd: '/repo/a', sessionId: 's1' }),
+        mk({ machine: 'zion', cwd: '/repo/b', sessionId: 's2' }),
+      ],
+      'local-box',
+    );
+    expect(layout.machines[0].total).toBe(2);
+    expect(layout.machines[0].layout.workspaces).toHaveLength(2);
+  });
+});
+
+describe('dedupeByMachineSession', () => {
+  it('collapses the same session seen twice on one machine', () => {
+    const out = dedupeByMachineSession([
+      mk({ machine: 'zion', sessionId: 'dup' }),
+      mk({ machine: 'zion', sessionId: 'dup' }),
+    ]);
+    expect(out).toHaveLength(1);
+  });
+
+  it('keeps identically-numbered sessions on different machines', () => {
+    const out = dedupeByMachineSession([
+      mk({ machine: 'zion', sessionId: 'same' }),
+      mk({ machine: 'yosemite-s1', sessionId: 'same' }),
+    ]);
+    expect(out).toHaveLength(2);
+  });
+
+  it('keeps every session that has no sessionId (uncorrelatable)', () => {
+    const out = dedupeByMachineSession([
+      mk({ machine: 'zion', sessionId: undefined }),
+      mk({ machine: 'zion', sessionId: undefined }),
+    ]);
+    expect(out).toHaveLength(2);
+  });
+});

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -20,6 +20,8 @@ import { SESSION_AGENTS } from '../lib/session/types.js';
 import { discoverArtifacts, readArtifact, resolveArtifact } from '../lib/session/artifacts.js';
 import { looksLikePath, toComparablePath, homeDir } from '../lib/platform/index.js';
 import { getActiveSessions, type ActiveSession } from '../lib/session/active.js';
+import { machineId, normalizeHost } from '../lib/session/sync/config.js';
+import { gatherRemoteActive } from '../lib/session/remote-active.js';
 import { stringWidth, truncateToWidth, padToWidth, terminalWidth } from '../lib/session/width.js';
 import type { SessionActivity, AwaitingReason } from '../lib/session/state.js';
 import { discoverSessions, countSessionsInScope, resolveSessionById, searchContentIndex, parseTimeFilter, type DiscoverOptions, type ScanProgress } from '../lib/session/discover.js';
@@ -441,14 +443,143 @@ export function groupActiveSessions(sessions: ActiveSession[]): ActiveSessionsLa
   return { workspaces };
 }
 
-/** Render the unified active-session view. */
-async function renderActiveSessions(asJson: boolean, waitingOnly = false): Promise<void> {
-  const all = await getActiveSessions();
+/** One machine's active sessions, keeping the within-machine workspace layout. */
+export interface MachineGroup {
+  /** Normalized device id (machineId() form). */
+  machine: string;
+  /** The machine this command is running on — pinned first and marked. */
+  isLocal: boolean;
+  total: number;
+  layout: ActiveSessionsLayout;
+}
+
+/** Active sessions grouped by the machine they run on. */
+export interface MachineGroupedLayout {
+  machines: MachineGroup[];
+}
+
+/**
+ * The machine a session belongs to: an explicit tag (set when merging
+ * cross-machine results) wins; else the process's provenance host (normalized
+ * to the same id form); else the local machine. Never keys off `ActiveSession.host`
+ * — that is the terminal *app* (code/tmux), not the computer.
+ */
+function machineKeyFor(s: ActiveSession, localMachine: string): string {
+  if (s.machine) return s.machine;
+  if (s.provenance?.host) return normalizeHost(s.provenance.host);
+  return localMachine;
+}
+
+/**
+ * Group active sessions by machine, then delegate each machine's sessions to the
+ * existing workspace/window grouping. Local machine is pinned first and flagged;
+ * the rest sort by session count descending, then name. Pure — `localMachine` is
+ * injected so the function stays testable without reading os.hostname().
+ */
+export function groupSessionsByMachine(sessions: ActiveSession[], localMachine: string): MachineGroupedLayout {
+  const byMachine = new Map<string, ActiveSession[]>();
+  for (const s of sessions) {
+    const key = machineKeyFor(s, localMachine);
+    (byMachine.get(key) ?? byMachine.set(key, []).get(key)!).push(s);
+  }
+  const keys = Array.from(byMachine.keys()).sort((a, b) => {
+    if (a === localMachine) return -1;
+    if (b === localMachine) return 1;
+    const ac = byMachine.get(a)!.length, bc = byMachine.get(b)!.length;
+    if (ac !== bc) return bc - ac;
+    return a.localeCompare(b);
+  });
+  const machines = keys.map((machine) => ({
+    machine,
+    isLocal: machine === localMachine,
+    total: byMachine.get(machine)!.length,
+    layout: groupActiveSessions(byMachine.get(machine)!),
+  }));
+  return { machines };
+}
+
+/**
+ * Collapse duplicate sessions after a cross-machine merge. Two rows collapse
+ * only when they share both machine and session UUID (the same host listed
+ * twice, or a local/remote overlap); rows without a sessionId can't be
+ * correlated, so they're all kept.
+ */
+export function dedupeByMachineSession(sessions: ActiveSession[]): ActiveSession[] {
+  const seen = new Set<string>();
+  const out: ActiveSession[] = [];
+  for (const s of sessions) {
+    if (!s.sessionId) { out.push(s); continue; }
+    const key = `${s.machine ?? ''}:${s.sessionId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(s);
+  }
+  return out;
+}
+
+/** Print one machine's workspace tree, indented under its machine header. */
+function renderWorkspaceLayout(layout: ActiveSessionsLayout, base: string): void {
+  let first = true;
+  for (const ws of layout.workspaces) {
+    if (!first) console.log();
+    first = false;
+
+    const header = ws.key === '__cloud__'
+      ? chalk.magenta.bold('cloud')
+      : ws.key === '__unknown__'
+        ? chalk.gray.bold('unknown')
+        : chalk.cyan.bold(shortCwd(ws.key));
+    console.log(`${base}${header} ${chalk.gray(`(${ws.total})`)}`);
+
+    for (const win of ws.windows) {
+      // Host is per-process, but every terminal in the same IDE window shares
+      // an ancestor — take the first non-empty host as the window's label.
+      const host = win.sessions.find((s) => s.host)?.host ?? 'terminal';
+      const winHeader = `${chalk.gray(host)} ${chalk.gray('·')} ${chalk.gray(shortWindowLabel(win.windowId))} ${chalk.gray(`(${win.sessions.length})`)}`;
+      console.log(base + '  ' + winHeader);
+      for (const s of win.sessions) printActiveRow(s, base + '    ');
+    }
+
+    for (const s of ws.flat) printActiveRow(s, base + '  ');
+  }
+}
+
+/** Machine header: `▸ <name> ← this machine` for the local box (cyan), matching
+ * the `ag devices list` treatment; a plain `▸ <name>` for remotes. */
+function printMachineHeader(mg: MachineGroup): void {
+  const marker = mg.isLocal ? chalk.cyan('▸ ') : chalk.gray('▸ ');
+  const name = mg.isLocal ? chalk.bold.cyan(mg.machine) : chalk.bold(mg.machine);
+  const here = mg.isLocal ? chalk.cyan('  ← this machine') : '';
+  console.log(`${marker}${name} ${chalk.gray(`(${mg.total})`)}${here}`);
+}
+
+/**
+ * Render the unified active-session view, grouped by machine. Local sessions
+ * come from `getActiveSessions()`; unless `--local`, sessions from other
+ * machines are folded in over SSH (explicit `--host` targets, else the
+ * registered online devices from `ag devices`). A tip is shown when there are
+ * no other machines to include.
+ */
+async function renderActiveSessions(
+  asJson: boolean,
+  waitingOnly = false,
+  opts: { local?: boolean; hosts?: string[] } = {},
+): Promise<void> {
+  const self = machineId();
+  const local = await getActiveSessions();
+  for (const s of local) if (!s.machine) s.machine = self;
+
+  let remoteDeviceCount = 0;
+  let merged = local;
+  if (!opts.local) {
+    const remote = await gatherRemoteActive(opts.hosts);
+    remoteDeviceCount = remote.deviceCount;
+    merged = dedupeByMachineSession([...local, ...remote.sessions]);
+  }
+
   // --waiting: only sessions blocked on the user. Exits non-zero when any are
   // present so a supervising agent or hook can poll it as a gate.
-  const sessions = waitingOnly
-    ? all.filter(s => s.status === 'input_required')
-    : all;
+  const sessions = waitingOnly ? merged.filter(s => s.status === 'input_required') : merged;
 
   if (asJson) {
     process.stdout.write(JSON.stringify(sessions, null, 2) + '\n');
@@ -458,34 +589,17 @@ async function renderActiveSessions(asJson: boolean, waitingOnly = false): Promi
 
   if (sessions.length === 0) {
     console.log(chalk.gray(waitingOnly ? 'No sessions waiting on input.' : 'No active agent sessions.'));
+    if (!opts.local && !opts.hosts?.length && remoteDeviceCount === 0) printCrossMachineTip();
     return;
   }
 
-  const layout = groupActiveSessions(sessions);
-
-  let first = true;
-  for (const ws of layout.workspaces) {
-    if (!first) console.log();
-    first = false;
-
-    // Print workspace header
-    const header = ws.key === '__cloud__'
-      ? chalk.magenta.bold('cloud')
-      : ws.key === '__unknown__'
-        ? chalk.gray.bold('unknown')
-        : chalk.cyan.bold(shortCwd(ws.key));
-    console.log(`${header} ${chalk.gray(`(${ws.total})`)}`);
-
-    for (const win of ws.windows) {
-      // Host is per-process, but every terminal in the same IDE window shares
-      // an ancestor — take the first non-empty host as the window's label.
-      const host = win.sessions.find((s) => s.host)?.host ?? 'terminal';
-      const winHeader = `${chalk.gray(host)} ${chalk.gray('·')} ${chalk.gray(shortWindowLabel(win.windowId))} ${chalk.gray(`(${win.sessions.length})`)}`;
-      console.log('  ' + winHeader);
-      for (const s of win.sessions) printActiveRow(s, '    ');
-    }
-
-    for (const s of ws.flat) printActiveRow(s, '  ');
+  const grouped = groupSessionsByMachine(sessions, self);
+  let firstMachine = true;
+  for (const mg of grouped.machines) {
+    if (!firstMachine) console.log();
+    firstMachine = false;
+    printMachineHeader(mg);
+    renderWorkspaceLayout(mg.layout, '  ');
   }
 
   const runningCount = sessions.filter(s => s.status === 'running').length;
@@ -496,15 +610,29 @@ async function renderActiveSessions(asJson: boolean, waitingOnly = false): Promi
   if (runningCount > 0) parts.push(`${runningCount} running`);
   if (idleCount > 0) parts.push(`${idleCount} idle`);
   if (queuedCount > 0) parts.push(`${queuedCount} queued`);
-  console.log(chalk.gray(`\n${sessions.length} active (${parts.join(', ')}).`));
+  const machineWord = grouped.machines.length === 1 ? 'machine' : 'machines';
+  console.log(chalk.gray(`\n${sessions.length} active (${parts.join(', ')}) across ${grouped.machines.length} ${machineWord}.`));
+
+  // Tip only when nothing else could be included and the user didn't opt out.
+  if (!opts.local && !opts.hosts?.length && remoteDeviceCount === 0) printCrossMachineTip();
 
   // Scriptable gate: a non-zero exit when anything is waiting on the user.
   if (waitingOnly && sessions.length > 0) process.exitCode = 1;
 }
 
+/** Nudge shown when `--active` has no other machines to fold in. */
+function printCrossMachineTip(): void {
+  console.log(chalk.gray(
+    "\nTip: include sessions from your other machines — register them with 'ag devices sync', then rerun. Use --local to skip.",
+  ));
+}
+
 /** Main action handler for `agents sessions`. Routes to picker, table, or single-session render. */
 async function sessionsAction(query: string | undefined, options: SessionsOptions): Promise<void> {
-  if (options.host && options.host.length > 0) {
+  // --host WITHOUT --active keeps the legacy per-host stream (each remote's raw
+  // stdout under a `── host ──` banner). With --active, the hosts are folded
+  // into the merged machine-grouped view instead (handled below).
+  if (options.host && options.host.length > 0 && !options.active) {
     try {
       runRemoteSessions(options.host);
     } catch (err: any) {
@@ -515,7 +643,13 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
   }
 
   if (options.active) {
-    await renderActiveSessions(options.json === true, options.waiting === true);
+    // AGENTS_SESSIONS_LOCAL is set by a parent fan-out invocation (see
+    // remote-active.ts) so a peer answers for itself without recursing.
+    const forceLocal = options.local === true || process.env.AGENTS_SESSIONS_LOCAL === '1';
+    await renderActiveSessions(options.json === true, options.waiting === true, {
+      local: forceLocal,
+      hosts: options.host,
+    });
     return;
   }
 
@@ -1517,6 +1651,7 @@ export function registerSessionsCommands(program: Command): void {
     .option('--artifacts', 'List all files written or edited during a session')
     .option('--artifact <name>', 'Read a specific artifact by filename or path (outputs to stdout)')
     .option('--active', 'Show only sessions running right now across terminals, teams, cloud, and headless agents')
+    .option('--local', 'With --active: only this machine — skip the cross-machine SSH fan-out')
     .option('--waiting', 'With --active: show only sessions waiting on your input (exits non-zero if any)')
     .option('--tree', 'Group the listing by directory; drops the id/version columns for readability')
     .option('--no-live', 'Do not enrich the listing with live status/preview for running sessions')

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -303,6 +303,15 @@ export function liveGlyphAndPreview(a: ActiveSession | undefined): { glyph: stri
 }
 
 /**
+ * The tracker/PR ref for a session's dedicated column: the ticket id when known,
+ * else `PR#<n>`, else empty. Pulled out of the trailing badge blob so refs align
+ * into a scannable column instead of jamming against a truncated topic.
+ */
+export function ticketLabel(s: Pick<SessionMeta, 'ticketId' | 'prNumber'>): string {
+  return s.ticketId ?? (s.prNumber ? `PR#${s.prNumber}` : '');
+}
+
+/**
  * Compact, colour-coded badges for the durable/awaiting signals. Text-only (no
  * emoji, per repo convention): `plan` / `ask` / `perm` for why it's waiting,
  * `PR#N`, `wt:slug`, `TICKET-123`.
@@ -698,33 +707,42 @@ function metaSignals(s: SessionMeta): Parameters<typeof signalBadges>[0] {
   };
 }
 
-/** One flat table row: shortId · agent · version · project · topic(+badges) · time.
- * When `live` is set (the session is still running), a status glyph leads the
- * topic cell and the live preview stands in for the persisted topic. */
-function flatSessionRow(session: SessionMeta, live?: ActiveSession): string {
+/** One flat table row:
+ *   shortId · agent · version · project · [glyph] label·doing · [ticket] · [wt] · time
+ * `doing` is the live preview when running, else the topic. The `ticket` column
+ * (tracker/PR ref, pulled out of the badge blob so refs align) is only rendered
+ * when `showTicket` — otherwise a listing with no refs would waste a column of
+ * dashes and needlessly truncate the topic. Worktree stays a trailing badge. */
+function flatSessionRow(session: SessionMeta, live?: ActiveSession, showTicket = false): string {
   const agentColor = colorAgent(session.agent);
   const when = formatRelativeTime(session.timestamp);
   const project = session.project || '-';
   const tag = teamTag(session);
   const label = (session as any).label;
   const { glyph, preview } = liveGlyphAndPreview(live);
-  // A running session's live preview replaces the persisted topic: it says what
-  // the agent is doing now, not what the session opened with.
-  const topic = preview || (tag ? `${tag}${session.topic ?? ''}` : session.topic);
-  const versionStr = session.version || '-';
-  const badges = signalBadges(metaSignals(session));
-  const badgeW = badges ? stringWidth(badges) + 1 : 0;
+  // A running session's live preview says what the agent is doing now; a
+  // resting one falls back to its opening topic.
+  const doing = preview || (tag ? `${tag}${session.topic ?? ''}` : session.topic);
+  const wt = session.worktreeSlug ? chalk.magenta(`wt:${session.worktreeSlug}`) : '';
+
+  const TICKET_W = 10;
+  const ticketCell = showTicket
+    ? chalk.blue(padToWidth(truncateToWidth(ticketLabel(session) || '-', TICKET_W), TICKET_W + 1))
+    : '';
   const glyphW = glyph ? 2 : 0;
-  const topicW = Math.max(16, terminalWidth() - (10 + 9 + 8 + 16) - glyphW - badgeW - stringWidth(when) - 1);
+  const ticketW = showTicket ? TICKET_W + 1 : 0;
+  const wtW = wt ? stringWidth(wt) + 1 : 0;
+  const topicW = Math.max(16, terminalWidth() - (10 + 9 + 8 + 16) - glyphW - ticketW - wtW - stringWidth(when) - 1);
 
   return (
     chalk.white(padToWidth(truncateToWidth(session.shortId, 9), 10)) +
     agentColor(padToWidth(truncateToWidth(session.agent, 8), 9)) +
-    chalk.yellow(padToWidth(truncateToWidth(versionStr, 7), 8)) +
+    chalk.yellow(padToWidth(truncateToWidth(session.version || '-', 7), 8)) +
     chalk.cyan(padToWidth(truncateToWidth(project, 14), 16)) +
     (glyph ? glyph + ' ' : '') +
-    renderTopicCell(label, topic, '', topicW, topicW) +
-    (badges ? badges + ' ' : '') +
+    renderTopicCell(label, doing, '', topicW, topicW) +
+    ticketCell +
+    (wt ? wt + ' ' : '') +
     chalk.gray(when)
   );
 }
@@ -799,7 +817,10 @@ function printSessionTable(sessions: SessionMeta[], hiddenCount = 0, tree = fals
     return;
   }
 
-  for (const session of sessions) console.log(flatSessionRow(session, liveIndex?.get(session.id)));
+  // Only show the ticket column when at least one row carries a ref — otherwise
+  // it's a column of dashes that steals width from every topic.
+  const showTicket = sessions.some((s) => ticketLabel(s) !== '');
+  for (const session of sessions) console.log(flatSessionRow(session, liveIndex?.get(session.id), showTicket));
 
   const countLine = `${sessions.length} session${sessions.length === 1 ? '' : 's'}.`;
   console.log(chalk.gray(`\n${countLine}`));

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -68,6 +68,11 @@ interface SessionsOptions extends SessionFilterOptions {
   tree?: boolean;
   /** With --active: show only sessions waiting on user input; exit 1 if any. */
   waiting?: boolean;
+  /** Enrich the listing with live glyphs/preview for running rows. Default on;
+   * `--no-live` sets this false. Commander's `--no-` convention. */
+  live?: boolean;
+  /** With --active: force local-only, skip cross-machine SSH fan-out. */
+  local?: boolean;
 }
 
 interface ClaudeHistoryEntry {
@@ -266,6 +271,35 @@ function activityLabel(s: ActiveSession): string {
   if (s.activity === 'working') return 'working';
   if (s.activity === 'idle') return 'idle';
   return s.status === 'input_required' ? 'waiting' : s.status;
+}
+
+/**
+ * Index live sessions by their full session UUID so a historical `SessionMeta`
+ * row (`meta.id`) can be matched to the session that is still running now.
+ * Rows without a sessionId (some cloud/headless probes) are skipped — they
+ * can't be correlated back to a transcript on disk.
+ */
+export function indexActiveBySessionId(active: ActiveSession[]): Map<string, ActiveSession> {
+  const byId = new Map<string, ActiveSession>();
+  for (const a of active) {
+    if (a.sessionId) byId.set(a.sessionId, a);
+  }
+  return byId;
+}
+
+/**
+ * The live decoration for a listing row: a status glyph and the latest-turn
+ * preview, when the session is still running. `●` running / `◐` waiting on the
+ * user / `○` idle, colored by the same `statusColor` the --active view uses.
+ * Returns empty strings when there is no live match, so callers render the
+ * plain historical row unchanged.
+ */
+export function liveGlyphAndPreview(a: ActiveSession | undefined): { glyph: string; preview: string } {
+  if (!a) return { glyph: '', preview: '' };
+  const waiting = a.status === 'input_required' || a.activity === 'waiting_input';
+  const running = a.status === 'running' || a.activity === 'working';
+  const shape = waiting ? '◐' : running ? '●' : '○';
+  return { glyph: statusColor(a.status)(shape), preview: buildSessionDescription(a) };
 }
 
 /**
@@ -634,7 +668,8 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
 
     // Non-interactive fallback (piped output)
     const filtered = searchQuery ? filterSessionsByQuery(sessions, searchQuery) : sessions;
-    printSessionTable(filtered, hiddenCount, options.tree === true);
+    const liveIndex = await maybeLiveIndex(options);
+    printSessionTable(filtered, hiddenCount, options.tree === true, liveIndex);
   } catch (err: any) {
     tracker.stop();
     spinner?.stop();
@@ -663,24 +698,31 @@ function metaSignals(s: SessionMeta): Parameters<typeof signalBadges>[0] {
   };
 }
 
-/** One flat table row: shortId · agent · version · project · topic(+badges) · time. */
-function flatSessionRow(session: SessionMeta): string {
+/** One flat table row: shortId · agent · version · project · topic(+badges) · time.
+ * When `live` is set (the session is still running), a status glyph leads the
+ * topic cell and the live preview stands in for the persisted topic. */
+function flatSessionRow(session: SessionMeta, live?: ActiveSession): string {
   const agentColor = colorAgent(session.agent);
   const when = formatRelativeTime(session.timestamp);
   const project = session.project || '-';
   const tag = teamTag(session);
   const label = (session as any).label;
-  const topic = tag ? `${tag}${session.topic ?? ''}` : session.topic;
+  const { glyph, preview } = liveGlyphAndPreview(live);
+  // A running session's live preview replaces the persisted topic: it says what
+  // the agent is doing now, not what the session opened with.
+  const topic = preview || (tag ? `${tag}${session.topic ?? ''}` : session.topic);
   const versionStr = session.version || '-';
   const badges = signalBadges(metaSignals(session));
   const badgeW = badges ? stringWidth(badges) + 1 : 0;
-  const topicW = Math.max(16, terminalWidth() - (10 + 9 + 8 + 16) - badgeW - stringWidth(when) - 1);
+  const glyphW = glyph ? 2 : 0;
+  const topicW = Math.max(16, terminalWidth() - (10 + 9 + 8 + 16) - glyphW - badgeW - stringWidth(when) - 1);
 
   return (
     chalk.white(padToWidth(truncateToWidth(session.shortId, 9), 10)) +
     agentColor(padToWidth(truncateToWidth(session.agent, 8), 9)) +
     chalk.yellow(padToWidth(truncateToWidth(versionStr, 7), 8)) +
     chalk.cyan(padToWidth(truncateToWidth(project, 14), 16)) +
+    (glyph ? glyph + ' ' : '') +
     renderTopicCell(label, topic, '', topicW, topicW) +
     (badges ? badges + ' ' : '') +
     chalk.gray(when)
@@ -688,28 +730,49 @@ function flatSessionRow(session: SessionMeta): string {
 }
 
 /** One tree-mode row (grouped under a dir header): id · agent · badges · topic · time. No version/project column. */
-function treeSessionRow(session: SessionMeta): string {
+function treeSessionRow(session: SessionMeta, live?: ActiveSession): string {
   const agentColor = colorAgent(session.agent);
   const when = formatRelativeTime(session.timestamp);
   const tag = teamTag(session);
   const label = (session as any).label;
-  const topic = (tag ? `${tag}${session.topic ?? ''}` : session.topic) || '-';
+  const { glyph, preview } = liveGlyphAndPreview(live);
+  const topic = (preview || (tag ? `${tag}${session.topic ?? ''}` : session.topic)) || '-';
   const badges = signalBadges(metaSignals(session));
   const badgeW = badges ? stringWidth(badges) + 1 : 0;
   const head = label ? `${label} · ${topic}` : topic;
-  const topicW = Math.max(12, terminalWidth() - (2 + 9 + 8) - badgeW - stringWidth(when) - 1);
+  const glyphW = glyph ? 2 : 0;
+  const topicW = Math.max(12, terminalWidth() - (2 + 9 + 8) - glyphW - badgeW - stringWidth(when) - 1);
 
   return (
     '  ' +
     chalk.dim(padToWidth(session.shortId, 9)) +
     agentColor(padToWidth(truncateToWidth(session.agent, 7), 8)) +
     (badges ? badges + ' ' : '') +
+    (glyph ? glyph + ' ' : '') +
     padToWidth(chalk.white(truncateToWidth(head, topicW)), topicW) +
     ' ' + chalk.gray(when)
   );
 }
 
-function printSessionTable(sessions: SessionMeta[], hiddenCount = 0, tree = false): void {
+/**
+ * Live-session index for enriching the default listing, or undefined when
+ * enrichment is off (`--no-live`) or irrelevant (`--json`, which serializes
+ * SessionMeta). Full detection (incl. the headless `ps` scan) is deliberate:
+ * bare-CLI and tmux agents are the common case here, and skipping them would
+ * leave the glyph almost never showing. The listing is a one-shot user action,
+ * not a hot loop, so the `ps`/`lsof` cost is acceptable; `--no-live` is the
+ * escape hatch. Never throws — a probe failure just yields a plain listing.
+ */
+async function maybeLiveIndex(options: SessionsOptions): Promise<Map<string, ActiveSession> | undefined> {
+  if (options.live === false || options.json) return undefined;
+  try {
+    return indexActiveBySessionId(await getActiveSessions());
+  } catch {
+    return undefined;
+  }
+}
+
+function printSessionTable(sessions: SessionMeta[], hiddenCount = 0, tree = false, liveIndex?: Map<string, ActiveSession>): void {
   if (tree) {
     // Group by directory; drop the id/version columns from view. The short id
     // stays as each row's leading handle (the address to read/resume it).
@@ -728,7 +791,7 @@ function printSessionTable(sessions: SessionMeta[], hiddenCount = 0, tree = fals
       first = false;
       const group = byDir.get(key)!;
       console.log(`${chalk.cyan.bold(shortCwd(key))} ${chalk.gray(`(${group.length})`)}`);
-      for (const s of group) console.log(treeSessionRow(s));
+      for (const s of group) console.log(treeSessionRow(s, liveIndex?.get(s.id)));
     }
     const dirWord = keys.length === 1 ? 'directory' : 'directories';
     console.log(chalk.gray(`\n${sessions.length} session${sessions.length === 1 ? '' : 's'} across ${keys.length} ${dirWord}.`));
@@ -736,7 +799,7 @@ function printSessionTable(sessions: SessionMeta[], hiddenCount = 0, tree = fals
     return;
   }
 
-  for (const session of sessions) console.log(flatSessionRow(session));
+  for (const session of sessions) console.log(flatSessionRow(session, liveIndex?.get(session.id)));
 
   const countLine = `${sessions.length} session${sessions.length === 1 ? '' : 's'}.`;
   console.log(chalk.gray(`\n${countLine}`));
@@ -1435,6 +1498,7 @@ export function registerSessionsCommands(program: Command): void {
     .option('--active', 'Show only sessions running right now across terminals, teams, cloud, and headless agents')
     .option('--waiting', 'With --active: show only sessions waiting on your input (exits non-zero if any)')
     .option('--tree', 'Group the listing by directory; drops the id/version columns for readability')
+    .option('--no-live', 'Do not enrich the listing with live status/preview for running sessions')
     .option('--cloud', 'Source sessions from Rush Cloud (captured runs) instead of local disk')
     .option('-H, --host <target...>', 'Run this query on remote machine(s) over SSH (host alias or user@host; repeatable)');
 

--- a/src/lib/session/__tests__/remote-active.test.ts
+++ b/src/lib/session/__tests__/remote-active.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Tests for parsing a peer's `--active --json` output during cross-machine
+ * fan-out. The parser must be defensive: a peer may run an older/newer agents
+ * whose stdout is truncated, non-JSON, or shaped slightly differently, and one
+ * bad peer must never throw and blank the whole merged view.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseRemoteActive } from '../remote-active.js';
+
+describe('parseRemoteActive', () => {
+  it('tags every parsed session with the source machine', () => {
+    const stdout = JSON.stringify([
+      { context: 'terminal', kind: 'claude', status: 'running', sessionId: 'a' },
+      { context: 'cloud', kind: 'codex', status: 'queued' },
+    ]);
+    const out = parseRemoteActive(stdout, 'zion');
+    expect(out).toHaveLength(2);
+    expect(out.every((s) => s.machine === 'zion')).toBe(true);
+    expect(out[0].sessionId).toBe('a');
+  });
+
+  it('returns [] on non-JSON (a login-shell banner leaked into stdout)', () => {
+    expect(parseRemoteActive('bash: agents: command not found\n', 'zion')).toEqual([]);
+  });
+
+  it('returns [] when the top level is not an array', () => {
+    expect(parseRemoteActive(JSON.stringify({ error: 'nope' }), 'zion')).toEqual([]);
+  });
+
+  it('drops non-object entries but keeps the valid ones', () => {
+    const stdout = JSON.stringify([null, 'weird', 42, { kind: 'claude', context: 'teams', status: 'idle' }]);
+    const out = parseRemoteActive(stdout, 'mark');
+    expect(out).toHaveLength(1);
+    expect(out[0].machine).toBe('mark');
+  });
+
+  it('returns [] on empty stdout (peer produced nothing)', () => {
+    expect(parseRemoteActive('', 'zion')).toEqual([]);
+  });
+});

--- a/src/lib/session/active.ts
+++ b/src/lib/session/active.ts
@@ -74,6 +74,13 @@ export interface ActiveSession {
    * Absent for cloud sessions (no local pid) and any pid whose env is unreadable.
    */
   provenance?: SessionProvenance;
+  /**
+   * The machine this session runs on, as a normalized device id (machineId()
+   * form). Set when merging cross-machine results so the grouped `--active`
+   * view can bucket by computer. Absent for a purely local query (the renderer
+   * falls back to provenance.host, then the local machine).
+   */
+  machine?: string;
   teamName?: string;
   agentId?: string;
   cloudProvider?: string;

--- a/src/lib/session/remote-active.ts
+++ b/src/lib/session/remote-active.ts
@@ -1,0 +1,147 @@
+/**
+ * Cross-machine fan-out for `agents sessions --active`.
+ *
+ * A single `getActiveSessions()` only sees the local machine. To show the whole
+ * fleet in one view, we run `agents sessions --active --json --local` on each
+ * peer over SSH and merge the parsed results, tagging every row with the machine
+ * it came from so the renderer can bucket by computer.
+ *
+ * Peers are the registered, online devices from `ag devices` (or an explicit
+ * `--host` list). `--local` on the remote invocation is critical: it stops the
+ * peer from fanning out to *its* devices, so the sweep never recurses.
+ *
+ * A dead or slow host is skipped with a stderr note, never fatal — one asleep
+ * laptop must not blank the whole view. SSH runs are async + parallel (a fresh
+ * `spawn`, not the sync `sshExec`) so N peers cost one round-trip, not N.
+ */
+import { spawn } from 'child_process';
+import chalk from 'chalk';
+import { SSH_OPTS, controlOpts, assertValidSshTarget, shellQuote } from '../ssh-exec.js';
+import { sshTargetFor } from '../devices/connect.js';
+import { loadDevices, type DeviceProfile } from '../devices/registry.js';
+import { machineId, normalizeHost } from './sync/config.js';
+import type { ActiveSession } from './active.js';
+
+/** Per-host SSH budget. Slightly above SSH_OPTS' ConnectTimeout=10 so a
+ * reachable-but-slow remote still answers before we give up. */
+const REMOTE_TIMEOUT_MS = 12_000;
+
+/**
+ * Recursion guard, passed as an env var (not a CLI flag) so an OLDER remote
+ * `agents` that predates this feature ignores it harmlessly instead of erroring
+ * on an unknown option. A remote new enough to fan out reads it and stays local.
+ */
+export const NO_FANOUT_ENV = 'AGENTS_SESSIONS_LOCAL';
+
+/** The command run on each peer: answer for itself, as JSON, without recursing. */
+function remoteActiveCommand(): string {
+  const inner = `${NO_FANOUT_ENV}=1 agents sessions --active --json`;
+  return `bash -lc ${shellQuote(inner)}`;
+}
+
+/**
+ * Parse a peer's `--active --json` stdout into active sessions, tagging each
+ * with `machine`. Defensive against version skew / partial output: non-JSON or
+ * a non-array yields `[]`, and non-object entries are dropped rather than
+ * throwing. Exported for unit testing without a live tailnet.
+ */
+export function parseRemoteActive(stdout: string, machine: string): ActiveSession[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const out: ActiveSession[] = [];
+  for (const x of parsed) {
+    if (x && typeof x === 'object' && !Array.isArray(x)) {
+      out.push({ ...(x as ActiveSession), machine });
+    }
+  }
+  return out;
+}
+
+/** Run one remote `agents sessions --active --json --local` and capture stdout.
+ * Resolves `{ code: null }` on spawn error or timeout (host treated as dead). */
+function sshCapture(target: string, remoteCmd: string, timeoutMs: number): Promise<{ code: number | null; stdout: string }> {
+  assertValidSshTarget(target);
+  return new Promise((resolve) => {
+    const args = [...SSH_OPTS, ...controlOpts(), target, remoteCmd];
+    const child = spawn('ssh', args, { stdio: ['ignore', 'pipe', 'ignore'] });
+    let stdout = '';
+    let settled = false;
+    const done = (code: number | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ code, stdout });
+    };
+    const timer = setTimeout(() => { child.kill('SIGKILL'); done(null); }, timeoutMs);
+    child.stdout.on('data', (d) => { stdout += d.toString(); });
+    child.on('error', () => done(null));
+    child.on('close', (code) => done(code));
+  });
+}
+
+async function fetchByTarget(target: string, machine: string, display: string): Promise<ActiveSession[]> {
+  const { code, stdout } = await sshCapture(target, remoteActiveCommand(), REMOTE_TIMEOUT_MS);
+  if (code !== 0) {
+    process.stderr.write(chalk.gray(`  ${display}: unreachable or no agents CLI — skipped\n`));
+    return [];
+  }
+  return parseRemoteActive(stdout, machine);
+}
+
+export interface RemoteActiveResult {
+  sessions: ActiveSession[];
+  /** How many peer machines we attempted to reach (drives the empty-fleet tip). */
+  deviceCount: number;
+}
+
+/**
+ * Gather active sessions from other machines. With an explicit `hosts` list
+ * (from `--host`), fan out to exactly those. Otherwise sweep the registered,
+ * online devices from `ag devices`, excluding this machine and any without an
+ * address. Results from all peers run in parallel and are flattened.
+ */
+export async function gatherRemoteActive(hosts?: string[]): Promise<RemoteActiveResult> {
+  const self = machineId();
+  const targets: Array<{ target: string; machine: string; name: string }> = [];
+
+  if (hosts && hosts.length > 0) {
+    for (const h of hosts) {
+      try {
+        assertValidSshTarget(h);
+      } catch {
+        process.stderr.write(chalk.gray(`  ${h}: not a valid ssh target — skipped\n`));
+        continue;
+      }
+      const bareHost = h.split('@').pop() || h;
+      targets.push({ target: h, machine: normalizeHost(bareHost), name: h });
+    }
+  } else {
+    let reg: Record<string, DeviceProfile>;
+    try {
+      reg = await loadDevices();
+    } catch {
+      return { sessions: [], deviceCount: 0 };
+    }
+    for (const d of Object.values(reg)) {
+      if (d.tailscale?.online !== true) continue;
+      if (normalizeHost(d.name) === self) continue;
+      // Only machines that can actually run the CLI. iOS/tablet nodes register as
+      // `unknown` platform and can never answer, so skip them rather than burn a
+      // full ConnectTimeout on each.
+      if (d.platform !== 'windows' && d.platform !== 'linux' && d.platform !== 'macos') continue;
+      try {
+        targets.push({ target: sshTargetFor(d), machine: normalizeHost(d.name), name: d.name });
+      } catch {
+        // No address on the profile — nothing to dial; skip silently.
+      }
+    }
+  }
+
+  const results = await Promise.all(targets.map((t) => fetchByTarget(t.target, t.machine, t.name)));
+  return { sessions: results.flat(), deviceCount: targets.length };
+}

--- a/src/lib/session/sync/config.ts
+++ b/src/lib/session/sync/config.ts
@@ -110,12 +110,22 @@ export function isSyncConfigured(now: number = Date.now()): boolean {
 }
 
 /**
+ * Normalize a raw hostname into a stable device id: first label only,
+ * lowercased, non-alphanumerics collapsed to hyphens. `zion.tail…ts.net` and
+ * `ZION` both become `zion`. The single source for this transform — machineId()
+ * and cross-machine session grouping must agree or the local machine won't
+ * match its own registry key.
+ */
+export function normalizeHost(raw: string): string {
+  return raw.split('.')[0].trim().toLowerCase().replace(/[^a-z0-9_-]/g, '-') || 'unknown';
+}
+
+/**
  * This machine's stable, human-readable id, used as its R2 prefix and mirror
  * directory name. Tailnet hostnames (zion, yosemite-s0, mac-mini) are already
  * unique and readable; we lowercase and strip any domain suffix. Overridable
  * via AGENTS_SYNC_MACHINE_ID for tests and unusual setups.
  */
 export function machineId(): string {
-  const raw = process.env.AGENTS_SYNC_MACHINE_ID || os.hostname();
-  return raw.split('.')[0].trim().toLowerCase().replace(/[^a-z0-9_-]/g, '-') || 'unknown';
+  return normalizeHost(process.env.AGENTS_SYNC_MACHINE_ID || os.hostname());
 }


### PR DESCRIPTION
Three improvements to `agents sessions` for multi-machine work, plus a `devices` skill. Built from an interactive prototype reviewed on a real machine, then verified end-to-end against the live tailnet (yosemite-s0 / zion / yosemite-s1).

## What changed

**1. Machine-grouped `--active` with cross-machine fan-out** (`eafca1d`)
- Groups running sessions by the **computer** they run on (the old "host" column is the terminal *app* — code/tmux — not the machine).
- Pins the local box first and marks it `▸ <name> ← this machine`, matching the `ag devices list` treatment.
- Folds in sessions from your registered, **online** devices (`ag devices`) over SSH — queried in parallel, each with `agents sessions --active --json`. Explicit `--host a --host b` targets a subset; `--local` stays on this machine only.
- A dead/slow/CLI-less host is skipped with a stderr note, never fatal. iOS/tablet nodes (platform `unknown`) are skipped so they don't burn a ConnectTimeout.
- Recursion guard is an **env var** (`AGENTS_SESSIONS_LOCAL`), not a CLI flag, so an **older remote** agents ignores it instead of erroring on an unknown option — verified against a peer running 1.20.34.
- Empty fleet → a tip to run `ag devices sync`.

**2. Live status glyph + preview on the default listing** (`9bb0afe`)
- Rows whose session is still running get `●` running / `◐` waiting-on-you / `○` idle plus the live latest-turn preview. `--teams` rows too.
- Full active detection (not `skipHeadless`) — bare-CLI/tmux agents are the common case; skipping them left the glyph almost never showing. Listing is one-shot, so the cost is fine; `--no-live` opts out. `--json` is unaffected.

**3. Tracker/PR refs in their own aligned column** (`799a533`)
- Refs used to jam against a truncated topic in the badge blob; now they align in a dedicated column, shown only when a batch actually has refs (so ref-less listings keep full topic width).

**4. `devices` skill** (`ac587d0`) — teaches `ag devices` (sync/list/show/add/set/rm/render), `ag ssh <name>`, and the new fleet view.

## Design notes (adjusted after verifying on real data)
- The plan's separate **"title" column was dropped**: with no `/rename` label it duplicated the topic, and the existing `project` column already carries the worktree/repo handle it was meant to show.
- `skipHeadless` was **dropped** for listing enrichment after finding this fleet's sessions are tmux/headless-detected — otherwise the glyph never appears.

## Verification (real fleet)
- `ag sessions --active` → merged view, **14 active across 3 machines** (yosemite-s0 marked local, zion, yosemite-s1); unreachable hosts skipped.
- `ag sessions --active --local` → 0.66s, this machine only, no SSH.
- `ag sessions --active --json` → machine-tagged `{yosemite-s0, yosemite-s1, zion}`.
- `ag sessions` → `●` on the live row; `--no-live` suppresses; `--json` unchanged.
- Full suite: **3495 passed, 48 skipped, 0 failed**. New pure helpers unit-tested (grouping, dedup, live glyph, ticket label, remote parse).

## Notes for review
- New module `src/lib/session/remote-active.ts` uses an async `spawn` (not the sync `sshExec`) because the fan-out must run peers in parallel; it reuses `SSH_OPTS`/`controlOpts`/`assertValidSshTarget`/`shellQuote`.
- Branched before #551/#569/#570 landed on main; those touch none of these files and every `ssh-exec` symbol used here is unchanged on current main, so this merges cleanly.
- A matching `devices` skill for the separate `.agents-system` repo will go up as its own PR.