### PR TITLE
fix(sync): recompile rules-memory file under a repo-scoped sync (RUSH-1354)

### DIFF
--- a/src/lib/versions.test.ts
+++ b/src/lib/versions.test.ts
@@ -548,7 +548,7 @@ describe('buildRepoScopedSelection — agents sync <agent> --repo <name>', () =>
   // scoping to one repo returns only that layer's resources. Guards against
   // layer-misattribution — the bug where `--repo system` would sweep in (or
   // drop) the wrong repo's skills.
-  function runBuildScoped(home: string, repo: string): { skills?: string[]; memory?: string[] } {
+  function runBuildScoped(home: string, repo: string): { skills?: string[]; memory?: string[] | 'all' } {
     const moduleUrl = pathToFileURL(path.resolve('src/lib/versions.ts')).href;
     const tsxBin = path.resolve('node_modules/tsx/dist/cli.mjs');
     const child = spawnSync(process.execPath, [tsxBin, '-e', `
@@ -583,12 +583,14 @@ describe('buildRepoScopedSelection — agents sync <agent> --repo <name>', () =>
     expect(sel.skills).toEqual(['user-only']);
   });
 
-  it('skips the memory file through a real sync — leaves merged rules untouched', () => {
+  it('recompiles a STALE memory file through a real repo-scoped sync (RUSH-1354)', () => {
     const home = makeTempHome();
-    // Same fixture the "writes missing grok AGENTS.md" test uses to PROVE the
-    // memory file IS written for a partial selection. Under a repo scope the
-    // memory:[] sentinel must make syncResourcesToVersion skip it entirely —
-    // so this is a real negative control, not a check of the returned object.
+    // The composed rules-memory file is a merge of ALL layers, so a repo-scoped
+    // sync must still recompile it — otherwise a rules change followed by a
+    // repo-scoped `agents sync <agent> <repo>` silently strands the file at its
+    // old content. Same rules fixture the "writes missing grok AGENTS.md" test
+    // uses; here we PRE-SEED a stale AGENTS.md and prove the scoped sync
+    // overwrites it with the freshly composed content.
     const rulesDir = path.join(home, '.agents', '.system', 'rules');
     fs.mkdirSync(path.join(rulesDir, 'subrules'), { recursive: true });
     fs.writeFileSync(
@@ -596,18 +598,28 @@ describe('buildRepoScopedSelection — agents sync <agent> --repo <name>', () =>
       'presets:\n  default:\n    subrules:\n      - core\n',
       'utf-8'
     );
-    fs.writeFileSync(path.join(rulesDir, 'subrules', 'core.md'), 'scoped memory body\n', 'utf-8');
+    fs.writeFileSync(path.join(rulesDir, 'subrules', 'core.md'), 'fresh scoped memory body\n', 'utf-8');
 
-    // The empty-array sentinel is what the skipMemory gate keys on.
-    expect(runBuildScoped(home, 'system').memory).toEqual([]);
+    // Pre-seed a stale memory file in the version home — this is what a prior
+    // sync left behind before the rules changed.
+    const agentDir = path.join(home, '.agents', '.history', 'versions', 'grok', '0.2.33', 'home', '.grok');
+    const agentsPath = path.join(agentDir, 'AGENTS.md');
+    fs.mkdirSync(agentDir, { recursive: true });
+    fs.writeFileSync(agentsPath, 'STALE memory body — must be overwritten\n', 'utf-8');
+
+    // The scoped selection now recomposes memory from all layers (memory:'all',
+    // not the old []-skip sentinel).
+    expect(runBuildScoped(home, 'system').memory).toEqual('all');
 
     const result = runVersionSync(
       home,
       "syncResourcesToVersion('grok', '0.2.33', buildRepoScopedSelection('system', home), { cwd: home })"
     ) as { memory: string[] };
 
-    const agentsPath = path.join(home, '.agents', '.history', 'versions', 'grok', '0.2.33', 'home', '.grok', 'AGENTS.md');
-    expect(result.memory).toEqual([]);
-    expect(fs.existsSync(agentsPath)).toBe(false);
+    expect(result.memory).toContain('AGENTS.md');
+    expect(fs.existsSync(agentsPath)).toBe(true);
+    const written = fs.readFileSync(agentsPath, 'utf-8');
+    expect(written).toContain('fresh scoped memory body');
+    expect(written).not.toContain('STALE memory body');
   });
 });

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1858,9 +1858,13 @@ function resourceSourceMap(kind: SelectableKind, cwd: string, available: Availab
  * sync path uses. Passing the result as an explicit `selection` means the sync
  * touches only that repo's resources — no orphan-sweep of the other layers.
  *
- * `memory` is set to `[]` (not omitted): that empty-array sentinel is what
- * `syncResourcesToVersion`'s `skipMemory` gate keys on to leave the memory
- * file untouched — it's a merge of all layers, not a per-repo artifact.
+ * `memory` is set to `'all'`, NOT `[]`: the composed rules-memory file is a
+ * merge of ALL layers, so scoping the sync to a single repo must still
+ * recompile it in the same pass (RUSH-1354). Leaving it out — or using the
+ * `[]` skip-sentinel — silently strands the memory file at its old content
+ * whenever a repo-scoped sync runs after a rules change. `'all'` makes
+ * `syncResourcesToVersion` recompose from every layer via the active preset,
+ * exactly as an unscoped full reconcile does.
  */
 export function buildRepoScopedSelection(repo: string, cwd: string = process.cwd()): ResourceSelection {
   const patterns = [`${repo}:*`];
@@ -1873,8 +1877,9 @@ export function buildRepoScopedSelection(repo: string, cwd: string = process.cwd
     if (names.length > 0) selection[kind] = names;
   }
 
-  // Empty-array sentinel → skip the memory writer (see skipMemory below).
-  selection.memory = [];
+  // Recompile the memory file from all layers even under a repo scope — it is
+  // composed, not a per-repo artifact (see skipMemory below and RUSH-1354).
+  selection.memory = 'all';
   return selection;
 }
 


### PR DESCRIPTION
## RUSH-1354

A **repo-scoped** sync — `agents sync <agent>@all <repo>` (e.g. `agents sync codex@all system`) — reconciled commands / skills / hooks / permissions but **silently skipped recompiling the composed rules-memory file** (`CLAUDE.md` / `AGENTS.md`). Only an **unscoped** full reconcile (`agents sync <agent>@all`) rewrote it. After changing a rules preset and running a repo-scoped sync, the agent's memory file stayed stale.

## Root cause

`buildRepoScopedSelection` set `selection.memory = []` — the empty-array sentinel that `syncResourcesToVersion`'s `skipMemory` gate keys on to skip the rules writer:

- `src/lib/versions.ts` — `buildRepoScopedSelection` set `selection.memory = []` (the skip sentinel).
- `src/lib/versions.ts` — `const skipMemory = selection && Array.isArray(selection.memory) && selection.memory.length === 0;` → skips the rules writer.

But the memory file is **composed from ALL layers** (project > user > extras > system) via `composeRulesFromState` (`src/lib/staleness/writers/rules.ts`) — it is not a per-repo artifact. Scoping to one repo must therefore still recompile it.

## Fix (the "order" fix — recompile in the same pass, at the source)

`buildRepoScopedSelection` now sets `selection.memory = 'all'`. Since `'all'` is not an empty array, `skipMemory` is false and the rules writer recomposes the memory file from every layer via the active preset — exactly what an unscoped full reconcile does. No special-case branch; the composed-from-all-layers invariant is honored under any scope.

## Before / after (real built CLI, isolated HOME)

Repro: system rules preset composing one subrule, a faked codex install, a **pre-seeded stale** `AGENTS.md`, then `agents sync codex system --yes`.

**Before the fix:**
```
$ agents sync codex system --yes
Already in sync — Codex@0.116.0
$ cat .../.codex/AGENTS.md
STALE memory body — must be overwritten by scoped sync
```

**After the fix:**
```
$ agents sync codex system --yes
Synced to Codex@0.116.0:
  memory    (1)  AGENTS.md
$ cat .../.codex/AGENTS.md
FRESH end-to-end memory body v2
```

The `memory (1) AGENTS.md` summary line — previously seen only on an unscoped reconcile — now appears for the repo-scoped sync, and the stale file is recomposed.

## Test

Inverted the prior negative-control test (`src/lib/versions.test.ts`, "skips the memory file through a real sync") into a real regression: **"recompiles a STALE memory file through a real repo-scoped sync (RUSH-1354)"**. It pre-seeds a stale `AGENTS.md`, runs a repo-scoped sync via `syncResourcesToVersion(buildRepoScopedSelection('system', home), ...)`, and asserts the file is overwritten with the freshly composed content.

- Fails before the fix (`memory:[]` → `expected [] to deeply equal 'all'`, file left stale).
- Passes after (`memory:'all'`, file recomposed).
- Full `src/lib/versions.test.ts` suite: **31/31 pass**. `tsc --noEmit`: clean.