### PR TITLE
fix(devices): encode powershell remote commands via -EncodedCommand (#555)

### DIFF
--- a/src/lib/devices/connect.test.ts
+++ b/src/lib/devices/connect.test.ts
@@ -12,6 +12,12 @@ import { describe, expect, it } from 'vitest';
 import { buildSshInvocation, sshTargetFor, wrapRemoteCommand, ASKPASS_BUNDLE_ENV, ASKPASS_KEY_ENV } from './connect.js';
 import type { DeviceProfile } from './registry.js';
 
+function decodeEncodedCommand(wrapped: string): string {
+  const encoded = wrapped.split(' ').at(-1);
+  if (!encoded) throw new Error(`missing encoded command in ${wrapped}`);
+  return Buffer.from(encoded, 'base64').toString('utf16le');
+}
+
 function dev(over: Partial<DeviceProfile> & { name: string }): DeviceProfile {
   return {
     name: over.name,
@@ -34,8 +40,12 @@ describe('sshTargetFor', () => {
 });
 
 describe('wrapRemoteCommand', () => {
-  it('wraps Windows commands in PowerShell, leaves POSIX verbatim, undefined for interactive', () => {
-    expect(wrapRemoteCommand(dev({ name: 'w', shell: 'powershell' }), ['hostname'])).toBe("powershell -NoProfile -Command hostname");
+  it('wraps Windows commands in PowerShell EncodedCommand, leaves POSIX verbatim, undefined for interactive', () => {
+    const command = 'echo AGENTS_HELLO_123';
+    const wrapped = wrapRemoteCommand(dev({ name: 'w', shell: 'powershell' }), [command]);
+
+    expect(wrapped).toMatch(/^powershell -NoProfile -EncodedCommand [A-Za-z0-9+/=]+$/);
+    expect(decodeEncodedCommand(wrapped!)).toBe(command);
     expect(wrapRemoteCommand(dev({ name: 'l', shell: 'posix' }), ['uptime', '-p'])).toBe('uptime -p');
     expect(wrapRemoteCommand(dev({ name: 'i', shell: 'posix' }), [])).toBeUndefined();
   });
@@ -72,7 +82,8 @@ describe('buildSshInvocation', () => {
       ['hostname'],
       '/shim',
     );
-    expect(args[args.length - 1]).toBe('powershell -NoProfile -Command hostname');
+    expect(args[args.length - 1]).toMatch(/^powershell -NoProfile -EncodedCommand [A-Za-z0-9+/=]+$/);
+    expect(decodeEncodedCommand(args[args.length - 1]!)).toBe('hostname');
     expect(env.SSH_ASKPASS).toBe('/shim');
   });
 

--- a/src/lib/devices/connect.ts
+++ b/src/lib/devices/connect.ts
@@ -15,6 +15,7 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
+import { encodePwshBase64 } from '../pwsh.js';
 import { assertValidSshTarget, shellQuote } from '../ssh-exec.js';
 import { getCacheDir } from '../state.js';
 import { hostNameFor } from './ssh-config.js';
@@ -42,14 +43,15 @@ export function sshTargetFor(device: DeviceProfile): string {
 /**
  * Wrap a remote command for the device's shell. Windows devices speak
  * PowerShell, so a bare command is run through `powershell -NoProfile
- * -Command`; POSIX devices get the command verbatim (the remote login shell
- * parses it). Returns undefined when no command was given (interactive login).
+ * -EncodedCommand`; POSIX devices get the command verbatim (the remote login
+ * shell parses it). Returns undefined when no command was given (interactive
+ * login).
  */
 export function wrapRemoteCommand(device: DeviceProfile, cmd: string[]): string | undefined {
   if (cmd.length === 0) return undefined;
   const joined = cmd.join(' ');
   if (device.shell === 'powershell') {
-    return `powershell -NoProfile -Command ${shellQuote(joined)}`;
+    return `powershell -NoProfile -EncodedCommand ${encodePwshBase64(joined)}`;
   }
   return joined;
 }


### PR DESCRIPTION
## Summary
- src/lib/devices/connect.ts:18 imports `encodePwshBase64` from the shared PowerShell helper.
- src/lib/devices/connect.ts:53-54 now emits `powershell -NoProfile -EncodedCommand ${encodePwshBase64(joined)}` when `device.shell === 'powershell'`.
- src/lib/devices/connect.ts:56 keeps the non-PowerShell path as `return joined;`.

## Tests
- `npx vitest run src/lib/devices/connect.test.ts`
- `bun run build`

Fixes #555