### PR TITLE
feat(cli): responsive skills/commands/plugins/mcp list

### DIFF
--- a/src/commands/resource-view.test.ts
+++ b/src/commands/resource-view.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { resourceLayout } from './resource-view.js';
+
+// resourceLayout is the pure column arithmetic behind the piped `skills/commands/
+// plugins/mcp list` tables. The bug it fixes: the old layout used fixed 22+10+16+42
+// columns plus an uncapped Sync column and a hardcoded 100-char separator, so it
+// overflowed every terminal narrower than ~130 cols. These tests pin the two things
+// that actually matter: the description column flexes with width, and a too-narrow
+// terminal drops to cards instead of overflowing.
+
+describe('resourceLayout', () => {
+  const base = { hasExtra: false, hasExtra2: false, nameW: 22, syncW: 12 };
+
+  it('flexes the description column to fill the terminal width', () => {
+    const narrow = resourceLayout(90, base);
+    const wide = resourceLayout(140, base);
+    expect(wide.descW).toBeGreaterThan(narrow.descW);
+    // descW is exactly what is left after name + gap + gap + capped sync.
+    expect(wide.descW).toBe(140 - (22 + 1 + 1 + wide.syncW));
+  });
+
+  it('falls back to cards when the description would be too thin to read', () => {
+    // Plenty of fixed columns + a small terminal leaves < MIN_DESC_W for description.
+    const layout = resourceLayout(70, { hasExtra: true, hasExtra2: true, nameW: 22, syncW: 30 });
+    expect(layout.mode).toBe('cards');
+  });
+
+  it('stays a table when there is real room for a description', () => {
+    const layout = resourceLayout(140, { hasExtra: true, hasExtra2: true, nameW: 22, syncW: 20 });
+    expect(layout.mode).toBe('table');
+    expect(layout.descW).toBeGreaterThanOrEqual(24);
+  });
+
+  it('reserves the extra / extra2 columns only when their labels exist', () => {
+    const none = resourceLayout(140, base);
+    const both = resourceLayout(140, { ...base, hasExtra: true, hasExtra2: true });
+    expect(none.extraW).toBe(0);
+    expect(none.extra2W).toBe(0);
+    expect(both.extraW).toBe(10);
+    expect(both.extra2W).toBe(16);
+    // Extra columns eat into the description budget, never overflow the row.
+    expect(both.descW).toBe(none.descW - (10 + 1) - (16 + 1));
+  });
+
+  it('caps the sync column so a long "missing on …" tail cannot starve description', () => {
+    const layout = resourceLayout(120, { ...base, syncW: 200 });
+    expect(layout.syncW).toBeLessThanOrEqual(Math.floor(120 * 0.32));
+  });
+});

--- a/src/commands/resource-view.ts
+++ b/src/commands/resource-view.ts
@@ -12,6 +12,7 @@ import type { AgentId } from '../lib/types.js';
 import { agentLabel } from '../lib/agents.js';
 import { itemPicker } from '../lib/picker.js';
 import { isInteractiveTerminal, isPromptCancelled, printWithPager } from './utils.js';
+import { terminalWidth, truncateToWidth, padToWidth, stringWidth, stripAnsi } from '../lib/session/width.js';
 
 export type SyncStatus = 'synced' | 'stale' | 'missing';
 
@@ -116,24 +117,67 @@ function formatPickerRow(row: ResourceRow, opts: ResourceViewOptions): string {
   return `${name} ${extra}${extra2}${desc} ${sync}`;
 }
 
-/** Render resources as a plain-text table (used when output is piped). */
-function printResourceTable(opts: ResourceViewOptions): void {
-  const header = buildTableHeader(opts);
-  console.log(header);
-  console.log(chalk.gray('─'.repeat(Math.min(process.stdout.columns || 100, 120))));
+/** Max width for the Name column in the wide table. */
+const NAME_CAP = 22;
+/** Below this many columns of description budget, the list stacks into cards. */
+const MIN_DESC_W = 24;
 
-  for (const row of opts.rows) {
-    const name = chalk.cyan(padRight(row.name, 22));
-    const extra = opts.extraLabel
-      ? padRight(row.extra ?? '-', 10)
-      : '';
-    const extra2 = opts.extra2Label
-      ? padRight(row.extra2 ?? '-', 16)
-      : '';
-    const descRaw = row.description ? truncate(row.description, 40) : '-';
-    const desc = padRight(chalk.gray(descRaw), 42);
-    const sync = formatSyncSummary(row.targets, opts);
-    console.log(`${name} ${extra}${extra2}${desc} ${sync}`);
+export interface ResourceLayout {
+  mode: 'table' | 'cards';
+  nameW: number;
+  extraW: number;
+  extra2W: number;
+  descW: number;
+  syncW: number;
+}
+
+/**
+ * Pure column arithmetic. Decides table vs. cards for the effective terminal
+ * width and sizes the flexible Description column from whatever is left after the
+ * fixed columns and a capped Sync column — so the table fits `cols` instead of
+ * the old fixed 22+10+16+42+∞ layout that overflowed every narrow terminal.
+ */
+export function resourceLayout(
+  cols: number,
+  o: { hasExtra: boolean; hasExtra2: boolean; nameW: number; syncW: number },
+): ResourceLayout {
+  const extraW = o.hasExtra ? 10 : 0;
+  const extra2W = o.hasExtra2 ? 16 : 0;
+  // Cap Sync so a long "missing on …" tail can't starve the description.
+  const syncW = Math.min(o.syncW, Math.max(14, Math.floor(cols * 0.32)));
+  const fixed =
+    o.nameW + 1 + (extraW ? extraW + 1 : 0) + (extra2W ? extra2W + 1 : 0) + 1 + syncW;
+  const descW = cols - fixed;
+  return {
+    mode: descW >= MIN_DESC_W ? 'table' : 'cards',
+    nameW: o.nameW,
+    extraW,
+    extra2W,
+    descW,
+    syncW,
+  };
+}
+
+/** Render resources (used when output is piped). Responsive: wide table or cards. */
+function printResourceTable(opts: ResourceViewOptions): void {
+  const cols = terminalWidth();
+  const syncStrings = opts.rows.map((r) => formatSyncSummary(r.targets, opts));
+  const nameW = Math.min(
+    NAME_CAP,
+    Math.max('Name'.length, ...opts.rows.map((r) => stringWidth(r.name))),
+  );
+  const syncMax = Math.max('Synced'.length, ...syncStrings.map((s) => stringWidth(s)));
+  const layout = resourceLayout(cols, {
+    hasExtra: Boolean(opts.extraLabel),
+    hasExtra2: Boolean(opts.extra2Label),
+    nameW,
+    syncW: syncMax,
+  });
+
+  if (layout.mode === 'cards') {
+    renderResourceCards(opts, cols, syncStrings);
+  } else {
+    renderResourceWideTable(opts, layout, syncStrings);
   }
 
   console.log();
@@ -146,18 +190,59 @@ function printResourceTable(opts: ResourceViewOptions): void {
   console.log(chalk.gray(summary.join(' · ')));
 }
 
-/** Build the column header line for the plain-text table. */
-function buildTableHeader(opts: ResourceViewOptions): string {
-  const name = chalk.bold(padRight('Name', 22));
-  const extra = opts.extraLabel
-    ? chalk.bold(padRight(opts.extraLabel, 10))
-    : '';
-  const extra2 = opts.extra2Label
-    ? chalk.bold(padRight(opts.extra2Label, 16))
-    : '';
-  const desc = padRight(chalk.bold('Description'), 42);
-  const sync = chalk.bold('Synced');
-  return `${name} ${extra}${extra2}${desc} ${sync}`;
+/** Wide aligned table: Name · [Extra] · [Extra2] · Description (flex) · Synced. */
+function renderResourceWideTable(
+  opts: ResourceViewOptions,
+  L: ResourceLayout,
+  syncStrings: string[],
+): void {
+  const cell = (text: string, width: number, color?: (s: string) => string): string => {
+    const clipped = truncateToWidth(text, width);
+    return padToWidth(color ? color(clipped) : clipped, width);
+  };
+
+  const headerParts = [cell(chalk.bold('Name'), L.nameW)];
+  if (L.extraW) headerParts.push(cell(chalk.bold(opts.extraLabel ?? ''), L.extraW));
+  if (L.extra2W) headerParts.push(cell(chalk.bold(opts.extra2Label ?? ''), L.extra2W));
+  headerParts.push(cell(chalk.bold('Description'), L.descW));
+  headerParts.push(chalk.bold('Synced'));
+  console.log(headerParts.join(' '));
+
+  const contentW =
+    L.nameW + 1 + (L.extraW ? L.extraW + 1 : 0) + (L.extra2W ? L.extra2W + 1 : 0) + L.descW + 1 + L.syncW;
+  console.log(chalk.gray('─'.repeat(Math.min(contentW, terminalWidth()))));
+
+  opts.rows.forEach((row, i) => {
+    const parts = [cell(row.name, L.nameW, chalk.cyan)];
+    if (L.extraW) parts.push(cell(row.extra ?? '-', L.extraW));
+    if (L.extra2W) parts.push(cell(row.extra2 ?? '-', L.extra2W));
+    parts.push(cell(row.description ?? '-', L.descW, chalk.gray));
+    let sync = syncStrings[i] ?? '';
+    if (stringWidth(sync) > L.syncW) sync = chalk.gray(truncateToWidth(sync, L.syncW));
+    parts.push(sync);
+    console.log(parts.join(' '));
+  });
+}
+
+/** Stacked cards for narrow terminals: name + meta on one line, description below. */
+function renderResourceCards(
+  opts: ResourceViewOptions,
+  cols: number,
+  syncStrings: string[],
+): void {
+  opts.rows.forEach((row, i) => {
+    const meta = [row.extra, row.extra2, stripAnsi(syncStrings[i] ?? '')]
+      .filter((s): s is string => Boolean(s && s.trim()))
+      .join(' · ');
+    const metaBudget = Math.max(8, cols - stringWidth(row.name) - 2);
+    const line1 = meta
+      ? `${chalk.cyan(row.name)}  ${chalk.gray(truncateToWidth(meta, metaBudget))}`
+      : chalk.cyan(row.name);
+    console.log(line1);
+    if (row.description) {
+      console.log(`    ${chalk.gray(truncateToWidth(row.description, cols - 4))}`);
+    }
+  });
 }
 
 /** Compact sync summary: "everywhere", "14 of 16 installs", or "not installed". */

--- a/src/commands/resource-view.ts
+++ b/src/commands/resource-view.ts
@@ -201,10 +201,12 @@ function renderResourceWideTable(
     return padToWidth(color ? color(clipped) : clipped, width);
   };
 
-  const headerParts = [cell(chalk.bold('Name'), L.nameW)];
-  if (L.extraW) headerParts.push(cell(chalk.bold(opts.extraLabel ?? ''), L.extraW));
-  if (L.extra2W) headerParts.push(cell(chalk.bold(opts.extra2Label ?? ''), L.extra2W));
-  headerParts.push(cell(chalk.bold('Description'), L.descW));
+  // Pass the colour as the third arg: cell() truncates the plain text first, then
+  // colours the result. Pre-colouring here would be stripped by truncateToWidth.
+  const headerParts = [cell('Name', L.nameW, chalk.bold)];
+  if (L.extraW) headerParts.push(cell(opts.extraLabel ?? '', L.extraW, chalk.bold));
+  if (L.extra2W) headerParts.push(cell(opts.extra2Label ?? '', L.extra2W, chalk.bold));
+  headerParts.push(cell('Description', L.descW, chalk.bold));
   headerParts.push(chalk.bold('Synced'));
   console.log(headerParts.join(' '));
 


### PR DESCRIPTION
## What

The shared `resource-view.ts` table (used by `ag skills/commands/plugins/mcp list` when piped) used fixed 22+10+16+42 columns, an **uncapped Sync column**, and a **hardcoded 100-char separator** — so every list overflowed terminals narrower than ~130 cols and the separator was a 100-char rule over an 80-col terminal.

## Change

- Size to `terminalWidth()`. The **Description column flexes** to fill whatever remains after the fixed columns and a **capped Sync column**; when too little is left, the list **stacks into cards**. Separator now matches real content width.
- New pure `resourceLayout()` holds the column math (unit-tested).

## Verified (real CLI, piped)

| cmd | @80 before | @80 after | @140 after |
|---|--:|--:|--:|
| plugins list | 108 | **80** (cards) | **140** (table, desc fills) |
| skills / commands / mcp list | 118–130 | **≤80** | **≤140** |

Fixes 4 commands in one shared change. `resource-view.test.ts`: 5 tests.