### PR TITLE
feat(logs): add top-level `agents logs` run-log viewer (RUSH-1358)

### DIFF
--- a/src/commands/hosts.ts
+++ b/src/commands/hosts.ts
@@ -20,9 +20,8 @@ import {
   bootstrapAgentsCli,
   localCliVersion,
 } from '../lib/hosts/ready.js';
-import { listTasks, loadTask, localLogPath } from '../lib/hosts/tasks.js';
-import { followHostTask } from '../lib/hosts/progress.js';
-import * as fs from 'fs';
+import { listTasks } from '../lib/hosts/tasks.js';
+import { showHostTaskLog } from '../lib/hosts/logs.js';
 
 interface AddOptions { cap?: string[]; os?: string; enroll?: boolean; }
 
@@ -193,22 +192,13 @@ async function doPs(json: boolean): Promise<void> {
 }
 
 async function doLogs(id: string, follow: boolean): Promise<void> {
-  const task = loadTask(id);
-  if (!task) {
+  const res = await showHostTaskLog(id, follow);
+  if (!res.found) {
     console.log(chalk.red(`Unknown task "${id}".`));
     process.exitCode = 1;
     return;
   }
-  if (follow && task.status === 'running') {
-    const code = await followHostTask(task.target, { remoteLog: task.remoteLog, remoteExit: task.remoteExit, taskId: id, echo: true });
-    process.exitCode = code === -1 ? 1 : code;
-    return;
-  }
-  try {
-    process.stdout.write(fs.readFileSync(localLogPath(id), 'utf-8'));
-  } catch {
-    console.log(chalk.gray('(no local log captured for this task)'));
-  }
+  if (res.exitCode !== undefined) process.exitCode = res.exitCode;
 }
 
 /** Register the `agents hosts` command tree. */

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -1,0 +1,160 @@
+/**
+ * `agents logs` — unified, discoverable run-log viewer.
+ *
+ * Resolves a run across two substrates and shows (or `-f` follows) its log:
+ *  - host-dispatch tasks (`agents run --host`) → combined-stdout log, offset-tailed
+ *  - sessions (the local index) → transcript, tailed via the sessions tailer
+ *
+ * `[id]`/`--session` load directly (host task tried first, then session). With no
+ * id, `--host`/`--agent`/`--version` filter a merged candidate list; one match is
+ * shown, several open the fuzzy picker (or, non-TTY, print the list).
+ *
+ * Additive: `agents hosts logs` and `agents sessions tail` are unchanged and share
+ * the same underlying helpers (showHostTaskLog / streamSessionTail).
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import type { SessionMeta } from '../lib/session/types.js';
+import { discoverSessions, resolveSessionById } from '../lib/session/discover.js';
+import { parseAgentFilter, renderSessionLog } from './sessions.js';
+import { streamSessionTail, isTailable } from './sessions-tail.js';
+import { showHostTaskLog } from '../lib/hosts/logs.js';
+import { listTasks, type HostTask } from '../lib/hosts/tasks.js';
+import { itemPicker } from '../lib/picker.js';
+
+interface LogsOptions {
+  host?: string;
+  agent?: string;
+  version?: string;
+  session?: string;
+  follow?: boolean;
+}
+
+type Candidate =
+  | { kind: 'task'; task: HostTask }
+  | { kind: 'session'; session: SessionMeta };
+
+/** Compact one-line label used by both the picker and the non-TTY list. */
+function candidateLabel(c: Candidate): string {
+  if (c.kind === 'task') {
+    const t = c.task;
+    const status = t.status === 'completed' ? chalk.green(t.status)
+      : t.status === 'failed' ? chalk.red(t.status)
+      : chalk.yellow(t.status);
+    return `${chalk.gray('task')} ${t.id.slice(0, 8).padEnd(9)} ${t.host.padEnd(14)} ${t.agent.padEnd(8)} ${status}  ${t.prompt.slice(0, 40)}`;
+  }
+  const s = c.session;
+  const ver = s.version ? chalk.gray(`@${s.version}`) : '';
+  const title = (s as { label?: string }).label || s.topic || '';
+  return `${chalk.gray('sess')} ${s.shortId.padEnd(9)} ${(s.agent + ver).padEnd(14)} ${chalk.gray(s.timestamp.slice(0, 16))}  ${title.slice(0, 40)}`;
+}
+
+/** Show a resolved session — follow (tail) or render its transcript. */
+async function showSession(session: SessionMeta, follow: boolean): Promise<void> {
+  if (follow) {
+    if (!isTailable(session.agent)) {
+      console.error(chalk.red(`Tailing is supported for claude and codex sessions only (got ${session.agent}).`));
+      process.exit(2);
+    }
+    await streamSessionTail(session, {});
+    return;
+  }
+  await renderSessionLog(session);
+}
+
+async function showCandidate(c: Candidate, follow: boolean): Promise<void> {
+  if (c.kind === 'task') {
+    const res = await showHostTaskLog(c.task.id, follow);
+    if (res.exitCode !== undefined) process.exitCode = res.exitCode;
+    return;
+  }
+  await showSession(c.session, follow);
+}
+
+/** Resolve an explicit id/--session: host task first, then a session. */
+async function showById(id: string, follow: boolean): Promise<void> {
+  const hostRes = await showHostTaskLog(id, follow);
+  if (hostRes.found) {
+    if (hostRes.exitCode !== undefined) process.exitCode = hostRes.exitCode;
+    return;
+  }
+  const sessions = await discoverSessions({ all: true, limit: 5000 });
+  const matches = resolveSessionById(sessions, id);
+  if (matches.length === 0) {
+    console.error(chalk.red(`No run or session found matching "${id}".`));
+    process.exit(1);
+  }
+  await showSession(matches[0], follow);
+}
+
+async function runLogs(id: string | undefined, opts: LogsOptions): Promise<void> {
+  const follow = !!opts.follow;
+
+  const directId = opts.session ?? id;
+  if (directId) {
+    await showById(directId, follow);
+    return;
+  }
+
+  const { agent, version } = parseAgentFilter(opts.agent);
+  const wantVersion = opts.version ?? version;
+
+  // Host tasks carry no session-index metadata; sessions carry no host tag.
+  // So --host scopes to dispatched tasks, and --version to sessions.
+  const candidates: Candidate[] = [];
+
+  let tasks = listTasks();
+  if (opts.host) tasks = tasks.filter((t) => t.host === opts.host);
+  if (agent) tasks = tasks.filter((t) => t.agent === agent);
+  for (const t of tasks) candidates.push({ kind: 'task', task: t });
+
+  if (!opts.host) {
+    const sessions = await discoverSessions({ agent, version: wantVersion, limit: 50 });
+    for (const s of sessions) candidates.push({ kind: 'session', session: s });
+  }
+
+  if (candidates.length === 0) {
+    console.error(chalk.yellow('No matching runs. Dispatch one: agents run <agent> "<task>" [--host <name>]'));
+    process.exit(1);
+  }
+
+  if (candidates.length === 1) {
+    await showCandidate(candidates[0], follow);
+    return;
+  }
+
+  // Multiple sessions matched → picker if interactive, else a list to pick from.
+  if (!process.stdin.isTTY) {
+    console.error(chalk.yellow(`${candidates.length} runs match. Pass an id or --session <id>:`));
+    for (const c of candidates.slice(0, 30)) console.error('  ' + candidateLabel(c));
+    process.exit(1);
+  }
+
+  const picked = await itemPicker<Candidate>({
+    message: 'Select a run to view its log:',
+    items: candidates,
+    filter: (query: string) => {
+      const q = query.trim().toLowerCase();
+      if (!q) return candidates;
+      return candidates.filter((c) => candidateLabel(c).toLowerCase().includes(q));
+    },
+    labelFor: (c: Candidate) => candidateLabel(c),
+    shortIdFor: (c: Candidate) => (c.kind === 'task' ? c.task.id : c.session.shortId),
+  });
+  if (!picked) return;
+  await showCandidate(picked.item, follow);
+}
+
+/** Register the top-level `agents logs` command. */
+export function registerLogsCommand(program: Command): void {
+  program
+    .command('logs [id]')
+    .description('Show a run’s log — a host-dispatch task or a session. -f to follow a live one.')
+    .option('--host <name>', 'Scope to runs dispatched to a host')
+    .option('-a, --agent <agent>', 'Filter by agent (e.g. claude, codex@0.116.0)')
+    .option('--version <version>', 'Filter by agent version')
+    .option('--session <id>', 'Select a session/run by id (same as the positional id)')
+    .option('-f, --follow', 'Follow live output')
+    .action((id: string | undefined, opts: LogsOptions) => runLogs(id, opts));
+}

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -16,6 +16,11 @@ import { setHelpSections } from '../lib/help.js';
 
 const TAIL_SUPPORTED: SessionAgentId[] = ['claude', 'codex'];
 
+/** Whether a session's transcript can be live-tailed (append-only JSONL agents). */
+export function isTailable(agent: SessionAgentId): boolean {
+  return TAIL_SUPPORTED.includes(agent);
+}
+
 export interface TailFileOptions {
   /** If true, emit every line from byte 0 first, then follow. Default false (EOF). */
   fromStart?: boolean;
@@ -191,6 +196,17 @@ async function runTail(sessionId: string | undefined, options: TailOptions): Pro
     session = resolved;
   }
 
+  await streamSessionTail(session, { fromStart: options.fromStart });
+}
+
+/**
+ * Live-tail one already-resolved session's transcript to stdout until Ctrl+C.
+ * Shared by `agents sessions tail` and `agents logs -f`.
+ */
+export async function streamSessionTail(
+  session: SessionMeta,
+  options: { fromStart?: boolean } = {},
+): Promise<void> {
   const filePath = session.filePath.split('#')[0];
 
   if (process.stderr.isTTY) {

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1001,6 +1001,15 @@ function resolveViewMode(options: SessionsOptions, filters: FilterOptions): View
   return 'summary';
 }
 
+/**
+ * Render a session's full transcript to stdout — the non-follow view behind
+ * `agents logs <sessionId>`. Reuses the same markdown renderer as
+ * `agents sessions <id> --markdown`.
+ */
+export async function renderSessionLog(session: SessionMeta): Promise<void> {
+  await renderSession(session, 'markdown', {});
+}
+
 async function renderSession(
   session: SessionMeta,
   mode: ViewMode,
@@ -1341,7 +1350,7 @@ interface AgentFilter {
   version?: string;
 }
 
-function parseAgentFilter(agentName?: string): AgentFilter {
+export function parseAgentFilter(agentName?: string): AgentFilter {
   if (!agentName) return {};
   const [name, version] = agentName.split('@', 2);
   let agent: SessionAgentId | null = SESSION_AGENTS.includes(name as SessionAgentId)

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,7 @@ import {
   loadBrowser,
   loadComputer,
   loadHosts,
+  loadLogs,
   loadSsh,
   loadPull,
   loadPush,
@@ -199,6 +200,7 @@ Run and dispatch:
   teams                           Coordinate multiple agents on shared work
   routines                        Run agents on a cron schedule (scheduler auto-starts)
   sessions                        Browse, search, and replay past runs (live-search in TTY; grouped by workspace)
+  logs [id]                       Show a run's log — host-dispatch task or session; -f to follow
   browser                         Automate a browser — navigate, click, screenshot, console, network
   pty                             Drive interactive terminal programs (REPLs, TUIs) via a persistent PTY session
 
@@ -882,6 +884,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadBrowser);
   await reg(loadComputer);
   await reg(loadHosts);
+  await reg(loadLogs);
   await reg(loadSsh);
   registerJobsCronAliasCommand(program, 'jobs');
   registerJobsCronAliasCommand(program, 'cron');

--- a/src/lib/hosts/logs.test.ts
+++ b/src/lib/hosts/logs.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, mkdtempSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import * as state from '../state.js';
+
+// Redirect the cache dir to a temp tree (real fs, no service mocking) so we can
+// stage real task sidecars + log files the way a dispatch would.
+let CACHE_ROOT: string;
+vi.spyOn(state, 'getCacheDir').mockImplementation(() => CACHE_ROOT);
+
+import { showHostTaskLog } from './logs.js';
+import { saveTask, localLogPath, type HostTask } from './tasks.js';
+
+function makeTask(overrides: Partial<HostTask> = {}): HostTask {
+  return {
+    id: 'abc12345',
+    host: 'box',
+    target: 'user@box',
+    agent: 'claude',
+    prompt: 'do a thing',
+    remoteLog: '$HOME/.agents/.cache/hosts/abc12345.log',
+    remoteExit: '$HOME/.agents/.cache/hosts/abc12345.exit',
+    status: 'completed',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+let out: string;
+let writeSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  CACHE_ROOT = mkdtempSync(join(tmpdir(), 'agents-cli-hostlogs-'));
+  mkdirSync(join(CACHE_ROOT, 'hosts'), { recursive: true });
+  out = '';
+  writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+    out += String(chunk);
+    return true;
+  });
+});
+
+afterEach(() => {
+  writeSpy.mockRestore();
+  rmSync(CACHE_ROOT, { recursive: true, force: true });
+});
+
+describe('showHostTaskLog', () => {
+  it('returns found:false for an unknown id (so callers can fall through to sessions)', async () => {
+    const res = await showHostTaskLog('nope-not-a-task', false);
+    expect(res.found).toBe(false);
+    expect(res.exitCode).toBeUndefined();
+    expect(out).toBe('');
+  });
+
+  it('prints the captured local log for a finished task and reports exit 0', async () => {
+    const task = makeTask();
+    saveTask(task);
+    writeFileSync(localLogPath(task.id), 'PONG\n');
+
+    const res = await showHostTaskLog(task.id, false);
+
+    expect(res.found).toBe(true);
+    expect(res.exitCode).toBe(0);
+    expect(out).toBe('PONG\n');
+  });
+
+  it('found:true with a friendly note when the task exists but no log was captured', async () => {
+    const task = makeTask({ id: 'nolog001' });
+    saveTask(task);
+    // No log file written.
+
+    const res = await showHostTaskLog(task.id, false);
+
+    expect(res.found).toBe(true);
+    expect(res.exitCode).toBe(0);
+  });
+
+  it('does NOT follow (no SSH) a finished task even when follow is requested', async () => {
+    // status !== 'running' → the follow branch is skipped, so no sshExec fires.
+    const task = makeTask({ id: 'done0001', status: 'completed' });
+    saveTask(task);
+    writeFileSync(localLogPath(task.id), 'final output\n');
+
+    const res = await showHostTaskLog(task.id, true);
+
+    expect(res.found).toBe(true);
+    expect(res.exitCode).toBe(0);
+    expect(out).toBe('final output\n');
+  });
+});

--- a/src/lib/hosts/logs.ts
+++ b/src/lib/hosts/logs.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared host-task log viewer — the show-or-follow core behind both
+ * `agents hosts logs <id>` and the top-level `agents logs <id>`.
+ *
+ * A running task with follow re-enters the offset-tail (`followHostTask`);
+ * otherwise the captured local mirror (`localLogPath`) is printed. Kept in one
+ * place so the two commands can never drift.
+ */
+
+import * as fs from 'fs';
+import chalk from 'chalk';
+import { loadTask, localLogPath } from './tasks.js';
+import { followHostTask } from './progress.js';
+
+export interface HostLogResult {
+  /** False when no host task with this id exists (caller may fall through to sessions). */
+  found: boolean;
+  /** Process exit code to adopt when the task was shown/followed. */
+  exitCode?: number;
+}
+
+/** Show (or follow, when running) a dispatched host task's combined-stdout log. */
+export async function showHostTaskLog(id: string, follow: boolean): Promise<HostLogResult> {
+  const task = loadTask(id);
+  if (!task) return { found: false };
+
+  if (follow && task.status === 'running') {
+    const code = await followHostTask(task.target, {
+      remoteLog: task.remoteLog,
+      remoteExit: task.remoteExit,
+      taskId: id,
+      echo: true,
+    });
+    return { found: true, exitCode: code === -1 ? 1 : code };
+  }
+
+  try {
+    process.stdout.write(fs.readFileSync(localLogPath(id), 'utf-8'));
+  } catch {
+    console.log(chalk.gray('(no local log captured for this task)'));
+  }
+  return { found: true, exitCode: 0 };
+}

--- a/src/lib/startup/command-registry.ts
+++ b/src/lib/startup/command-registry.ts
@@ -75,6 +75,7 @@ export const loadTmux: ModuleLoader = async () => (await import('../../commands/
 export const loadBrowser: ModuleLoader = async () => (await import('../../commands/browser.js')).registerBrowserCommand;
 export const loadComputer: ModuleLoader = async () => (await import('../../commands/computer.js')).registerComputerCommand;
 export const loadHosts: ModuleLoader = async () => (await import('../../commands/hosts.js')).registerHostsCommand;
+export const loadLogs: ModuleLoader = async () => (await import('../../commands/logs.js')).registerLogsCommand;
 export const loadSsh: ModuleLoader = async () => (await import('../../commands/ssh.js')).registerSshCommands;
 export const loadPull: ModuleLoader = async () => (await import('../../commands/pull.js')).registerPullCommand;
 export const loadPush: ModuleLoader = async () => (await import('../../commands/push.js')).registerPushCommand;
@@ -161,6 +162,7 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   browser: [loadBrowser],
   computer: [loadComputer],
   hosts: [loadHosts],
+  logs: [loadLogs],
   ssh: [loadSsh],
   devices: [loadSsh],
   pull: [loadPull],


### PR DESCRIPTION
Closes RUSH-1358.

## Why

Viewing a dispatched run's output was fragmented and undiscoverable: the `logs` verb only existed nested under `agents hosts logs <id>` and `agents daemon logs`, there was no top-level `agents logs` (`agents logs` → `error: unknown command 'logs'`), and `agents hosts` wasn't even listed in `agents --help`. `ps`/`logs` are *run* verbs that were mis-filed under the `hosts` *registry* namespace.

## What

A top-level **`agents logs`** — a unified, sessions-first run-log viewer.

```
agents logs [id]              show a run's log by id
  --host <name>               scope to runs dispatched to a host
  -a, --agent <agent>         filter by agent (e.g. claude, codex@0.116.0)
  --version <version>         filter by agent version
  --session <id>              select a session/run by id
  -f, --follow                follow live output
```

Resolves across **two substrates**: host-dispatch task stdout (`agents run --host`) and the local session index. `[id]`/`--session` load directly (host task tried first, then session); with no id, `--host`/`--agent`/`--version` filter a merged candidate list — one match shows, several open the fuzzy picker (non-TTY prints the list). `-f` tails a live run (host offset-tail via `followHostTask`, or session transcript via the sessions tailer).

**Additive — no deprecation.** `agents hosts logs` and `agents sessions tail` are unchanged; both now share the extracted helpers (`showHostTaskLog`, `streamSessionTail`) so the two paths can't drift.

## Reuse, not new infra

- `discoverSessions` / `resolveSessionById` / `parseAgentFilter` for listing/filter/id resolution
- `itemPicker` for the merged fuzzy picker; `renderSessionLog` (markdown) for the non-follow session view
- `showHostTaskLog` (new, extracted from `hosts.ts doLogs`) for host-task stdout
- `streamSessionTail` / `isTailable` (extracted from `sessions-tail.ts runTail`) for `-f`

## Verified end-to-end

Dispatched a real run to localhost over SSH (`agents run claude "…PONG…" --host localbox`), then:

- `agents logs <taskId>` → prints `PONG` (host stdout)
- `agents logs <sessionId>` → renders the session transcript
- `agents logs --host localbox` (non-TTY) → lists the matching tasks
- `agents hosts logs <taskId>` → still prints `PONG` (unchanged path)
- `agents logs` appears in `agents --help`

Tests: new `src/lib/hosts/logs.test.ts` (4, `showHostTaskLog` found/not-found + show contract). Full local suite green except one pre-existing, environment-dependent failure in `src/lib/session/sync/config.test.ts` (its mock keychain backend leaks to this machine's real drive-sync bundle; unrelated to this change, passes on clean CI).

## Follow-ups (noted, not in scope)

- Structured remote host-task lookup over SSH (`--host` currently scopes to local task records).
- `hosts` itself still absent from `agents --help` groups (only `logs` added here).
