### PR TITLE
feat(cli): responsive output for inspect/doctor/models/cost/view

### DIFF
--- a/src/commands/cost.test.ts
+++ b/src/commands/cost.test.ts
@@ -72,7 +72,7 @@ describe('agents cost', () => {
     const big = costOfUsage({ model: 'claude-opus-4', inputTokens: 2_000_000, outputTokens: 1_000_000 });   // ~$35
     const mid = costOfUsage({ model: 'claude-opus-4', inputTokens: 1_000_000, outputTokens: 200_000 });      // ~$10
     const small = costOfUsage({ model: 'claude-haiku-4', inputTokens: 500_000, outputTokens: 100_000 });     // ~$1
-    seed('big0001', 'claude', '2026-05-20T10:00:00.000Z', big, 3_600_000, 'rush', 'expensive refactor');
+    seed('big0001', 'claude', '2026-05-20T10:00:00.000Z', big, 3_600_000, 'rush', 'expensive refactor with a long topic that used to push narrow terminals past eighty columns');
     seed('mid0002', 'claude', '2026-05-21T10:00:00.000Z', mid, 1_800_000, 'agents-cli', 'mid task');
     seed('sml0003', 'codex', '2026-05-21T12:00:00.000Z', small, 300_000, 'agents-cli', 'small fix');
   });
@@ -108,6 +108,22 @@ describe('agents cost', () => {
     expect(out).toContain('expensive refactor');
     // dollar figure rendered cents-precise
     expect(out).toMatch(/\$\d+\.\d{2}/);
+  });
+
+  it('keeps human output within an 80-column terminal', async () => {
+    const prev = process.env.COLUMNS;
+    process.env.COLUMNS = '80';
+    try {
+      const out = await runCost([]);
+      const lines = out.split('\n');
+      expect(Math.max(...lines.map((line) => line.length))).toBeLessThanOrEqual(80);
+      const topRows = lines.filter((line) => line.includes('big0001'));
+      expect(topRows).toHaveLength(1);
+      expect(topRows[0]).not.toContain(' rush ');
+    } finally {
+      if (prev === undefined) delete process.env.COLUMNS;
+      else process.env.COLUMNS = prev;
+    }
   });
 
   it('--by project groups the breakdown by project', async () => {

--- a/src/commands/cost.ts
+++ b/src/commands/cost.ts
@@ -21,6 +21,7 @@ import {
 } from '../lib/session/db.js';
 import { formatUsd, PRICING_VERSION } from '../lib/pricing/index.js';
 import { formatDuration } from '../lib/session/render.js';
+import { terminalWidth, truncateToWidth, stringWidth, padToWidth } from '../lib/session/width.js';
 
 interface CostOptions {
   json?: boolean;
@@ -126,16 +127,19 @@ async function costAction(options: CostOptions): Promise<void> {
   // Top sessions by cost.
   if (top.length > 0) {
     out.push(chalk.bold('Top sessions by cost'));
+    const cols = terminalWidth();
+    const showProject = cols >= 100;
     const costW = Math.max(...top.map(t => formatUsd(t.costUsd).length), 4);
     for (const t of top) {
       const cost = formatUsd(t.costUsd).padStart(costW);
       const dur = t.durationMs > 0 ? formatDuration(t.durationMs) : '—';
-      const label = t.meta.label || t.meta.topic || '(untitled)';
-      const proj = t.meta.project ? chalk.gray(` ${t.meta.project}`) : '';
+      const label = (t.meta.label || t.meta.topic || '(untitled)').replace(/\s+/g, ' ').trim();
+      const proj = showProject && t.meta.project ? chalk.gray(` ${t.meta.project}`) : '';
+      const prefix = `  ${chalk.green(cost)}  ${chalk.gray(t.meta.shortId)}  ${chalk.cyan(t.meta.agent.padEnd(7))} `;
+      const suffix = proj + chalk.gray(`  ${dur}`);
+      const topicW = Math.max(12, cols - stringWidth(prefix) - stringWidth(suffix));
       out.push(
-        `  ${chalk.green(cost)}  ${chalk.gray(t.meta.shortId)}  ${chalk.cyan(t.meta.agent.padEnd(7))} ${truncate(label, 48)}` +
-          proj +
-          chalk.gray(`  ${dur}`),
+        prefix + truncateToWidth(label, topicW) + suffix,
       );
     }
     out.push('');
@@ -144,13 +148,19 @@ async function costAction(options: CostOptions): Promise<void> {
   // Per-agent / per-project / per-day breakdown.
   const groupLabel = groupBy === 'agent' ? 'agent' : groupBy === 'project' ? 'project' : 'day';
   out.push(chalk.bold(`By ${groupLabel}`));
-  const keyW = Math.max(...breakdown.map(r => r.key.length), groupLabel.length);
+  const cols = terminalWidth();
   const costW2 = Math.max(...breakdown.map(r => formatUsd(r.costUsd).length), 4);
+  const countW = Math.max(...breakdown.map(r => String(r.sessionCount).length), 1);
+  const sessionW = Math.max(...breakdown.map(r => `${String(r.sessionCount).padStart(countW)} session${r.sessionCount !== 1 ? 's' : ''}`.length));
+  const durationW = Math.max(...breakdown.map(r => r.durationMs > 0 ? stringWidth(formatDuration(r.durationMs)) : 1), 1);
+  const fixedW = 2 + 2 + costW2 + 2 + sessionW + 2 + durationW;
+  const keyW = Math.max(8, Math.min(Math.max(...breakdown.map(r => stringWidth(r.key)), groupLabel.length), cols - fixedW));
   for (const r of breakdown) {
     const cost = formatUsd(r.costUsd).padStart(costW2);
     const dur = r.durationMs > 0 ? formatDuration(r.durationMs) : '—';
+    const sessions = `${String(r.sessionCount).padStart(countW)} session${r.sessionCount !== 1 ? 's' : ''}`;
     out.push(
-      `  ${r.key.padEnd(keyW)}  ${chalk.green(cost)}  ${chalk.gray(`${r.sessionCount} session${r.sessionCount !== 1 ? 's' : ''}`)}  ${chalk.gray(dur)}`,
+      `  ${padToWidth(truncateToWidth(r.key, keyW), keyW)}  ${chalk.green(cost)}  ${chalk.gray(padToWidth(sessions, sessionW))}  ${chalk.gray(padToWidth(dur, durationW))}`,
     );
   }
 
@@ -181,10 +191,4 @@ function renderDailyHistogram(daily: Array<{ key: string; costUsd: number }>): s
     lines.push(`  ${chalk.gray(d.key)}  ${chalk.green(formatUsd(d.costUsd).padStart(costW))}`);
   }
   return lines.join('\n');
-}
-
-/** Truncate a string to n chars with an ellipsis. */
-function truncate(s: string, n: number): string {
-  const oneLine = s.replace(/\s+/g, ' ').trim();
-  return oneLine.length > n ? oneLine.slice(0, n - 1) + '…' : oneLine;
 }

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { execPolicyWarningLines } from './doctor.js';
+import { execPolicyWarningLines, wrapLine } from './doctor.js';
+import { stringWidth } from '../lib/session/width.js';
 
 describe('execPolicyWarningLines (Windows exec-policy advisory in `agents doctor`)', () => {
   it('fires when the policy blocks local scripts (Restricted) — with the RemoteSigned remediation', () => {
@@ -26,5 +27,18 @@ describe('execPolicyWarningLines (Windows exec-policy advisory in `agents doctor
   it('never fires off Windows, even under a blocking policy', () => {
     expect(execPolicyWarningLines('linux', 'Restricted')).toEqual([]);
     expect(execPolicyWarningLines('darwin', 'AllSigned')).toEqual([]);
+  });
+});
+
+describe('wrapLine', () => {
+  it('wraps advisory text under its prefix', () => {
+    const lines = wrapLine('  ', 'Reconcile with `agents doctor claude@latest --fix` or `agents sync claude@latest` (not applied on launch).', 62);
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines.every((line) => stringWidth(line) <= 62)).toBe(true);
+    expect(lines[1].startsWith('  ')).toBe(true);
+  });
+
+  it('collapses embedded newlines before wrapping', () => {
+    expect(wrapLine('  ', 'one\n\n  two\tthree', 80)).toEqual(['  one two three']);
   });
 });

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -50,6 +50,7 @@ import { listCliStatus } from '../lib/cli-resources.js';
 import { setHelpSections } from '../lib/help.js';
 import { heal, healChangedAnything, type HealResult } from '../lib/heal.js';
 import { blocksLocalScripts, getEffectiveExecutionPolicy } from '../lib/platform/winpath.js';
+import { terminalWidth, truncateToWidth, stringWidth, padToWidth } from '../lib/session/width.js';
 import * as fs from 'fs';
 
 const AGENT_NAMES: Record<string, string> = Object.fromEntries(
@@ -94,7 +95,6 @@ function divergenceLines(report: VersionResourceReport): string[] {
     if (p.status === 'missing') lines.push(`plugin ${p.name} — not installed`);
     else if (p.status === 'diff') lines.push(`plugin ${p.name} — ${p.detail ?? 'mirror drifted'}`);
   }
-  const counts: string[] = [];
   for (const kind of ['commands', 'skills', 'hooks', 'rules', 'mcp', 'permissions', 'subagents'] as const) {
     const rows = report.kinds[kind];
     const miss = rows.filter((r) => r.status === 'missing').length;
@@ -102,10 +102,43 @@ function divergenceLines(report: VersionResourceReport): string[] {
     const bits: string[] = [];
     if (miss) bits.push(`${miss} missing`);
     if (dif) bits.push(`${dif} drifted`);
-    if (bits.length) counts.push(`${kind} ${bits.join('/')}`);
+    if (bits.length) lines.push(`${kind.padEnd(11)} ${bits.join(' · ')}`);
   }
-  if (counts.length) lines.push(counts.join(' · '));
   return lines;
+}
+
+function collapseWhitespace(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+export function wrapLine(prefix: string, text: string, width = terminalWidth()): string[] {
+  const words = collapseWhitespace(text).split(' ').filter(Boolean);
+  if (words.length === 0) return [prefix.trimEnd()];
+  const continuation = ' '.repeat(stringWidth(prefix));
+  const lines: string[] = [];
+  let linePrefix = prefix;
+  let line = prefix;
+  let hasWord = false;
+  for (const word of words) {
+    const room = Math.max(1, width - stringWidth(linePrefix));
+    const piece = stringWidth(word) > room ? truncateToWidth(word, room) : word;
+    const candidate = hasWord ? `${line} ${piece}` : `${line}${piece}`;
+    if (hasWord && stringWidth(candidate) > width) {
+      lines.push(line);
+      linePrefix = continuation;
+      line = continuation + piece;
+      hasWord = true;
+    } else {
+      line = candidate;
+      hasWord = true;
+    }
+  }
+  lines.push(line);
+  return lines;
+}
+
+function printWrappedLine(prefix: string, text: string): void {
+  for (const line of wrapLine(prefix, text)) console.log(chalk.gray(line));
 }
 
 function checkSyncStatus(cwd: string): SyncStatusRow[] {
@@ -196,7 +229,7 @@ function renderOverviewText(
     }
   }
   if (hidden.length > 0) {
-    console.log(chalk.gray(`  +${hidden.length} more supported (${hidden.join(', ')}) — \`agents add <name>\` to manage`));
+    printWrappedLine('  ', `+${hidden.length} more supported (${hidden.join(', ')}) — \`agents add <name>\` to manage`);
   }
   console.log();
 
@@ -226,7 +259,7 @@ function renderOverviewText(
     // Version homes are reconciled only by management commands, so point at one
     // rather than promising an auto-sync that never happens.
     if (anyOutOfSync) {
-      console.log(chalk.gray('  Reconcile with `agents doctor <agent>@<version> --fix` or `agents sync <agent>@<version>` (not applied on launch).'));
+      printWrappedLine('  ', 'Reconcile with `agents doctor <agent>@<version> --fix` or `agents sync <agent>@<version>` (not applied on launch).');
     }
   }
   console.log();
@@ -260,7 +293,11 @@ function renderOverviewText(
       const label = manifest.name.padEnd(nameWidth);
       const src = chalk.gray(`[${manifest.source}]`);
       if (installed) {
-        console.log(`  ${chalk.green('ready')}  ${label}  ${src}  ${chalk.gray(manifest.description || '')}`);
+        const prefix = `  ${chalk.green('ready')}  ${label}  ${src}`;
+        const desc = manifest.description
+          ? `  ${truncateToWidth(collapseWhitespace(manifest.description), Math.max(1, terminalWidth() - stringWidth(prefix) - 2))}`
+          : '';
+        console.log(prefix + chalk.gray(desc));
       } else {
         console.log(`  ${chalk.red('miss ')}  ${label}  ${src}  ${chalk.gray(`not installed — run \`agents cli install ${manifest.name}\``)}`);
       }
@@ -427,8 +464,12 @@ function renderKindSection(
 
   for (const r of visible) {
     const src = sourceLabel(r, layers);
-    const detail = r.detail ? chalk.gray(`  ${r.detail}`) : '';
-    console.log(`    ${statusLabel(r.status)}  ${r.name.padEnd(28)} ${src}${detail}`);
+    const name = padToWidth(truncateToWidth(r.name, 28), 28);
+    const prefix = `    ${statusLabel(r.status)}  ${name} ${src}`;
+    const detail = r.detail
+      ? chalk.gray(`  ${truncateToWidth(collapseWhitespace(r.detail), Math.max(1, terminalWidth() - stringWidth(prefix) - 2))}`)
+      : '';
+    console.log(prefix + detail);
 
     if (options.showDiff && r.status === 'diff' && r.sourcePath && r.homePath) {
       const expected = readExpectedForDiff(kind, r);
@@ -461,8 +502,10 @@ function readExpectedForDiff(kind: DoctorKind, row: ResourceDiff): string | null
 function renderTargetText(report: VersionResourceReport, options: { showDiff: boolean; requestedKinds?: Set<DoctorKind> }): void {
   const label = `${AGENT_NAMES[report.agent] || report.agent}@${report.version}`;
   console.log(chalk.bold(label));
-  console.log(chalk.gray(`  home: ${report.home}`));
-  console.log(chalk.gray(`  cwd:  ${report.cwd}`));
+  const homePrefix = '  home: ';
+  const cwdPrefix = '  cwd:  ';
+  console.log(chalk.gray(homePrefix + truncateToWidth(report.home, Math.max(1, terminalWidth() - stringWidth(homePrefix)))));
+  console.log(chalk.gray(cwdPrefix + truncateToWidth(report.cwd, Math.max(1, terminalWidth() - stringWidth(cwdPrefix)))));
   const layerStr = [
     report.layers.project ? `project=${report.layers.project}` : null,
     `user=${report.layers.user}`,
@@ -471,7 +514,7 @@ function renderTargetText(report: VersionResourceReport, options: { showDiff: bo
       ? `extras=[${report.layers.extras.map((e) => e.alias).join(',')}]`
       : null,
   ].filter(Boolean).join(' ');
-  console.log(chalk.gray(`  layers: ${layerStr}`));
+  printWrappedLine('  layers: ', layerStr);
 
   // Staleness manifest verdict — single-line summary from the staleness
   // library, sitting alongside the detailed per-resource diff below.
@@ -508,7 +551,7 @@ function renderTargetText(report: VersionResourceReport, options: { showDiff: bo
     console.log(chalk.green(`  Verdict: ${ok} resource${ok === 1 ? '' : 's'} reconciled. Version home matches resolved sources.`));
   } else {
     console.log(`  Verdict: ${verdictParts.join(', ')}.`);
-    console.log(chalk.gray(`  Run \`agents doctor ${report.agent}@${report.version} --fix\` to heal, or \`agents prune cleanup\` to drop extras.`));
+    printWrappedLine('  ', `Run \`agents doctor ${report.agent}@${report.version} --fix\` to heal, or \`agents prune cleanup\` to drop extras.`);
   }
 }
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -299,7 +299,10 @@ function renderOverviewText(
           : '';
         console.log(prefix + chalk.gray(desc));
       } else {
-        console.log(`  ${chalk.red('miss ')}  ${label}  ${src}  ${chalk.gray(`not installed — run \`agents cli install ${manifest.name}\``)}`);
+        const prefix = `  ${chalk.red('miss ')}  ${label}  ${src}`;
+        const msg = `not installed — run \`agents cli install ${manifest.name}\``;
+        const budget = Math.max(1, terminalWidth() - stringWidth(prefix) - 2);
+        console.log(prefix + chalk.gray(`  ${truncateToWidth(msg, budget)}`));
       }
     }
   }

--- a/src/commands/inspect.test.ts
+++ b/src/commands/inspect.test.ts
@@ -13,9 +13,11 @@ import {
   summarizeHook,
   summarizeMcp,
   hookManifestByScript,
+  wrapJoined,
 } from './inspect.js';
 import type { ManifestHook } from '../lib/types.js';
 import { getUserAgentsDir, getSystemAgentsDir } from '../lib/state.js';
+import { stringWidth } from '../lib/session/width.js';
 
 const tempDirs: string[] = [];
 
@@ -171,6 +173,24 @@ describe('formatBytes', () => {
     expect(formatBytes(1024)).toBe('1.0 KB');
     expect(formatBytes(86 * 1024)).toBe('86 KB');
     expect(formatBytes(3.1 * 1024 * 1024)).toBe('3.1 MB');
+  });
+});
+
+describe('wrapJoined', () => {
+  it('wraps separator-joined values with a hanging indent', () => {
+    const lines = wrapJoined('  versions  ', ['claude 1.0.0', 'codex 2.0.0', 'kimi 3.0.0'], ' · ', 34);
+    expect(lines).toEqual([
+      '  versions  claude 1.0.0',
+      '            codex 2.0.0',
+      '            kimi 3.0.0',
+    ]);
+    expect(lines.every((line) => stringWidth(line) <= 34)).toBe(true);
+  });
+
+  it('keeps a wide row on one line', () => {
+    expect(wrapJoined('  run       ', ['claude:balanced', 'codex:pinned'], ' · ', 80)).toEqual([
+      '  run       claude:balanced · codex:pinned',
+    ]);
   });
 });
 

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -46,6 +46,7 @@ import { PLUGIN_GROUP_COLORS } from './plugins.js';
 import { countSessionsInScope } from '../lib/session/discover.js';
 import type { SessionAgentId } from '../lib/session/types.js';
 import { damerauLevenshtein } from '../lib/fuzzy.js';
+import { terminalWidth, truncateToWidth, stringWidth, stripAnsi } from '../lib/session/width.js';
 
 /** Resource kinds the inspect command can drill into. */
 const DRILLABLE_KINDS = [
@@ -88,6 +89,44 @@ const SINGULAR_DRILL_ALIASES: Record<string, DrillableKind> = {
 const CAPABILITY_NAMES: readonly CapabilityName[] = [
   'hooks', 'mcp', 'skills', 'commands', 'subagents', 'plugins', 'workflows', 'rules', 'allowlist',
 ];
+
+/** Wrap a separator-joined value list under `prefix`, preserving a hanging indent. */
+export function wrapJoined(prefix: string, items: string[], sep: string, width: number): string[] {
+  if (items.length === 0) return [];
+  const continuation = ' '.repeat(stringWidth(prefix));
+  const fitItem = (item: string, linePrefix: string): string => {
+    const room = Math.max(1, width - stringWidth(linePrefix));
+    return stringWidth(item) > room ? truncateToWidth(item, room) : item;
+  };
+
+  const lines: string[] = [];
+  let linePrefix = prefix;
+  let line = prefix;
+  let hasItem = false;
+  for (const raw of items) {
+    const item = fitItem(raw, linePrefix);
+    const candidate = hasItem ? `${line}${sep}${item}` : `${line}${item}`;
+    if (hasItem && stringWidth(candidate) > width) {
+      lines.push(line);
+      linePrefix = continuation;
+      line = continuation + fitItem(raw, linePrefix);
+      hasItem = true;
+    } else {
+      line = candidate;
+      hasItem = true;
+    }
+  }
+  if (hasItem) lines.push(line);
+  return lines;
+}
+
+function printWrappedJoined(prefix: string, items: string[], sep: string): void {
+  for (const line of wrapJoined(prefix, items, sep, terminalWidth())) console.log(line);
+}
+
+function truncateValueForPrefix(prefix: string, value: string): string {
+  return truncateToWidth(stripAnsi(value), Math.max(1, terminalWidth() - stringWidth(prefix)));
+}
 
 interface ResourceItem {
   name: string;
@@ -493,7 +532,10 @@ function renderRepoSummary(repo: RepoTarget, options: InspectOptions): void {
     console.log(`  ${'git'.padEnd(10)} ${git.branch}${dirty}${url}`);
     if (git.lastCommit) {
       const rel = git.lastCommit.relative ? `  ${chalk.gray(`(${git.lastCommit.relative})`)}` : '';
-      sub('last', `${chalk.cyan(git.lastCommit.sha)}  ${truncate(git.lastCommit.subject, 60)}${rel}`);
+      const prefix = `  ${''.padEnd(10)} ${chalk.gray('last'.padEnd(8))} `;
+      const sha = chalk.cyan(git.lastCommit.sha);
+      const subjectWidth = Math.max(8, terminalWidth() - stringWidth(prefix) - stringWidth(sha) - 2 - stringWidth(rel));
+      console.log(`${prefix}${sha}  ${truncateToWidth(git.lastCommit.subject, subjectWidth)}${rel}`);
     }
     if (git.ahead !== null && git.behind !== null && (git.ahead > 0 || git.behind > 0)) {
       sub('sync', `ahead ${git.ahead} ${chalk.gray('·')} behind ${git.behind}`);
@@ -509,10 +551,12 @@ function renderRepoSummary(repo: RepoTarget, options: InspectOptions): void {
     console.log(`  ${'manifests'.padEnd(10)} ${manifests.join(', ')}`);
     if (manifest) {
       if (manifest.versions.length > 0) {
-        sub('versions', manifest.versions.map(v => `${v.agent} ${chalk.cyan(v.version)}`).join(chalk.gray(' · ')));
+        const prefix = `  ${''.padEnd(10)} ${chalk.gray('versions'.padEnd(8))} `;
+        printWrappedJoined(prefix, manifest.versions.map(v => `${v.agent} ${chalk.cyan(v.version)}`), chalk.gray(' · '));
       }
       if (manifest.strategies.length > 0) {
-        sub('run', manifest.strategies.map(s => `${s.agent}:${s.strategy}`).join(chalk.gray(' · ')));
+        const prefix = `  ${''.padEnd(10)} ${chalk.gray('run'.padEnd(8))} `;
+        printWrappedJoined(prefix, manifest.strategies.map(s => `${s.agent}:${s.strategy}`), chalk.gray(' · '));
       }
     }
   }
@@ -638,7 +682,10 @@ async function renderSummary(agent: AgentId, version: string, versionHome: strin
     ['alias', aliasPath],
     ['strategy', strategy],
   ];
-  for (const [k, v] of rows) console.log(`  ${k.padEnd(10)} ${v}`);
+  for (const [k, v] of rows) {
+    const prefix = `  ${k.padEnd(10)} `;
+    console.log(prefix + truncateValueForPrefix(prefix, v));
+  }
 
   console.log('\n' + chalk.bold('Capabilities'));
   for (const cap of CAPABILITY_NAMES) {
@@ -699,7 +746,8 @@ function renderItemList(header: string, jsonHead: Record<string, unknown>, kind:
     const tag = chalk.gray(`[${item.source}]`.padEnd(10));
     console.log(`  ${tag} ${termLink(chalk.cyan(item.name), item.linkTarget)}`);
     if (item.description) {
-      console.log(`             ${chalk.gray(truncate(item.description, 90))}`);
+      const prefix = '             ';
+      console.log(prefix + chalk.gray(truncateToWidth(item.description, Math.max(1, terminalWidth() - stringWidth(prefix)))));
     }
     if (item.groups) printGroupRows(item.groups);
   }
@@ -1279,7 +1327,7 @@ function readFirstProseLine(p: string): string {
 // ─── OSC-8 + path helpers ────────────────────────────────────────────────────
 
 function termLink(text: string, filePath: string): string {
-  if (!filePath) return text;
+  if (!filePath || !process.stdout.isTTY) return text;
   const url = `file://${filePath}`;
   return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`;
 }

--- a/src/commands/models.test.ts
+++ b/src/commands/models.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { formatModelAliasLines, formatModelSourceLine, formatModelSummaryLine } from './models.js';
+import { stringWidth, stripAnsi } from '../lib/session/width.js';
+
+describe('models responsive formatting', () => {
+  it('truncates the source path to the requested width', () => {
+    const line = formatModelSourceLine('bundle', '~/very/long/path/inside/a/version/home/models/catalog.json', 44);
+    expect(stringWidth(line)).toBeLessThanOrEqual(44);
+    expect(line).toMatch(/^  source: bundle \(/);
+  });
+
+  it('wraps aliases under a hanging indent', () => {
+    const lines = formatModelAliasLines([
+      'opus=claude-opus-4-20250514',
+      'sonnet=claude-sonnet-4-20250514',
+      'haiku=claude-haiku-4-20250514',
+    ], 54);
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines.every((line) => stringWidth(line) <= 54)).toBe(true);
+    expect(stripAnsi(lines[1]).startsWith('           ')).toBe(true);
+  });
+
+  it('caps model id and display name rows', () => {
+    const line = formatModelSummaryLine('*', 'provider/super-long-model-id-with-extra-suffix', 'A display name that is also too long', 'daily-driver', 60);
+    expect(stringWidth(line)).toBeLessThanOrEqual(60);
+    expect(stripAnsi(line)).toContain('provider/super-long-model-id');
+  });
+});

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -20,6 +20,8 @@ import {
 import type { AgentId } from '../lib/types.js';
 import { listInstalledVersions, getGlobalDefault, resolveVersion, resolveVersionAlias } from '../lib/versions.js';
 import { getModelCatalog, locateModelSource } from '../lib/models.js';
+import { terminalWidth, truncateToWidth, stringWidth } from '../lib/session/width.js';
+import { wrapJoined } from './inspect.js';
 
 const MODEL_CAPABLE_AGENTS: AgentId[] = ['claude', 'codex', 'gemini', 'opencode', 'cursor', 'openclaw', 'antigravity', 'kimi'];
 
@@ -155,25 +157,22 @@ function printCatalog(agent: AgentId, version: string, isDefault: boolean, optio
     return;
   }
 
-  console.log(chalk.gray(`  source: ${src.kind} (${shortPath(src.path)})`));
+  console.log(chalk.gray(formatModelSourceLine(src.kind, shortPath(src.path))));
 
   if (Object.keys(catalog.aliases).length > 0) {
     const parts = Object.entries(catalog.aliases).map(([alias, id]) => `${chalk.cyan(alias)}=${id}`);
-    console.log(chalk.gray(`  aliases: `) + parts.join(', '));
+    for (const line of formatModelAliasLines(parts)) console.log(line);
   }
 
   console.log();
 
   for (const model of catalog.models) {
     const star = model.isDefault ? chalk.green('*') : ' ';
-    const display = model.displayName && model.displayName !== model.id
-      ? chalk.gray(` (${model.displayName})`)
-      : '';
-    const aliasTag = model.alias ? chalk.cyan(` [${model.alias}]`) : '';
-    console.log(`  ${star} ${chalk.bold(model.id)}${display}${aliasTag}`);
+    console.log(formatModelSummaryLine(star, model.id, model.displayName, model.alias));
 
     if (model.description) {
-      console.log(chalk.gray(`      ${model.description}`));
+      const descPrefix = '      ';
+      console.log(chalk.gray(descPrefix + truncateToWidth(model.description, Math.max(1, terminalWidth() - stringWidth(descPrefix)))));
     }
 
     if (options.cloud && model.perCloud) {
@@ -201,4 +200,32 @@ function printCatalog(agent: AgentId, version: string, isDefault: boolean, optio
 /** Abbreviate a path by replacing the home directory with ~. */
 function shortPath(p: string): string {
   return p.replace(homeDir(), '~');
+}
+
+export function formatModelSourceLine(kind: string, sourcePath: string, width = terminalWidth()): string {
+  const prefix = `  source: ${kind} (`;
+  const suffix = ')';
+  const room = Math.max(1, width - stringWidth(prefix) - stringWidth(suffix));
+  return prefix + truncateToWidth(sourcePath, room) + suffix;
+}
+
+export function formatModelAliasLines(parts: string[], width = terminalWidth()): string[] {
+  return wrapJoined(chalk.gray('  aliases: '), parts, ', ', width);
+}
+
+export function formatModelSummaryLine(
+  star: string,
+  id: string,
+  displayName?: string,
+  alias?: string,
+  width = terminalWidth(),
+): string {
+  const display = displayName && displayName !== id ? ` (${displayName})` : '';
+  const aliasTag = alias ? ` [${alias}]` : '';
+  const prefix = `  ${star} `;
+  const plain = `${id}${display}${aliasTag}`;
+  if (stringWidth(plain) > Math.max(1, width - stringWidth(prefix))) {
+    return prefix + truncateToWidth(plain, Math.max(1, width - stringWidth(prefix)));
+  }
+  return prefix + chalk.bold(id) + chalk.gray(display) + chalk.cyan(aliasTag);
 }

--- a/src/commands/view.resources.test.ts
+++ b/src/commands/view.resources.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
-import { parseResourceSections } from './view.js';
+import { descriptionForPrefix, parseResourceSections, summarizeDescription } from './view.js';
+import { stringWidth } from '../lib/session/width.js';
 
 // parseResourceSections is the merge point between the --resources/--detailed
 // flags and the historically-ignored per-section booleans in --json mode. These
@@ -58,5 +59,25 @@ describe('parseResourceSections', () => {
 
   test('--resources value unions with section booleans', () => {
     expect(sections({ resources: 'skills', plugins: true }, true)).toEqual(['plugins', 'skills']);
+  });
+});
+
+describe('responsive descriptions', () => {
+  test('summarizeDescription collapses whitespace and truncates to display width', () => {
+    expect(summarizeDescription('one\n\n two\tthree', 80)).toBe('one two three');
+    expect(stringWidth(summarizeDescription('abcdef', 4))).toBeLessThanOrEqual(4);
+  });
+
+  test('descriptionForPrefix budgets against the visible row prefix', () => {
+    const prev = process.env.COLUMNS;
+    process.env.COLUMNS = '60';
+    try {
+      const prefix = '    long-resource-name [system] [synced]  ';
+      const desc = descriptionForPrefix('a long description that should fit the remaining cells only', prefix);
+      expect(stringWidth(prefix + desc)).toBeLessThanOrEqual(60);
+    } finally {
+      if (prev === undefined) delete process.env.COLUMNS;
+      else process.env.COLUMNS = prev;
+    }
   });
 });

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -75,6 +75,7 @@ import { listProfiles, profileSummary, type ProfileSummary } from '../lib/profil
 import { loadManifest, isStale } from '../lib/staleness/index.js';
 import { confirm } from '@inquirer/prompts';
 import { formatPath, isInteractiveTerminal, isPromptCancelled } from './utils.js';
+import { terminalWidth, truncateToWidth, stringWidth } from '../lib/session/width.js';
 
 // Shown in the email column for agents that are signed in but expose no email
 // address locally (Antigravity stores an opaque OAuth grant with no identity).
@@ -120,6 +121,7 @@ function profileKindAndModel(model: string, planWidth: number): string {
 }
 
 function termLink(text: string, filePath: string): string {
+  if (!process.stdout.isTTY) return text;
   const url = `file://${filePath}`;
   return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`;
 }
@@ -224,11 +226,17 @@ function shouldRenderSection(key: SectionKey, filter: ViewSectionFilter | undefi
 }
 
 /** Trim a description to a column-friendly snippet. Strips newlines, collapses whitespace. */
-function summarizeDescription(desc: string | undefined, maxLen = 80): string {
+export function summarizeDescription(desc: string | undefined, maxLen = 80): string {
   if (!desc) return '';
   const cleaned = desc.replace(/\s+/g, ' ').trim();
-  if (cleaned.length <= maxLen) return cleaned;
-  return cleaned.slice(0, maxLen - 1).trimEnd() + '…';
+  return truncateToWidth(cleaned, maxLen);
+}
+
+export function descriptionForPrefix(desc: string | undefined, prefix: string): string {
+  if (!desc) return '';
+  const visiblePrefix = prefix.replace(/\x1b]8;;[^\x1b]*(?:\x1b\\|\x07)/g, '');
+  const budget = Math.max(1, terminalWidth() - stringWidth(visiblePrefix));
+  return summarizeDescription(desc, budget);
 }
 
 function getProfileSummaries(filterAgentId?: AgentId): ProfileSummary[] {
@@ -299,8 +307,10 @@ function renderHostClisSection(cwd: string): void {
       const status = installed ? chalk.green('installed') : chalk.red('missing  ');
       const linkedName = termLink(manifest.name.padEnd(nameWidth), linkTarget(manifest.path));
       const tag = hostCliSourceTag(manifest.source);
-      const desc = manifest.description ? chalk.gray(`  ${summarizeDescription(manifest.description, 60)}`) : '';
-      console.log(`  ${status}  ${chalk.cyan(linkedName)} ${tag}${desc}`);
+      const prefix = `  ${status}  ${chalk.cyan(linkedName)} ${tag}`;
+      const descSnippet = descriptionForPrefix(manifest.description, `${prefix}  `);
+      const desc = descSnippet ? chalk.gray(`  ${descSnippet}`) : '';
+      console.log(prefix + desc);
     }
     if (anyMissing) {
       console.log(chalk.gray('  Install missing with `agents cli install`'));
@@ -901,9 +911,10 @@ async function showAgentResources(
         : chalk.gray('[system]');
       display += ` ${sourceTag}`;
       const syncStr = r.syncState ? chalk.gray(` [${r.syncState}]`) : '';
-      const descSnippet = summarizeDescription(r.description);
+      const prefix = `    ${display}${syncStr}`;
+      const descSnippet = descriptionForPrefix(r.description, `${prefix}  `);
       const descStr = descSnippet ? chalk.gray(`  ${descSnippet}`) : '';
-      console.log(`    ${display}${syncStr}${descStr}`);
+      console.log(prefix + descStr);
     }
   }
 


### PR DESCRIPTION
## Summary

Make five command renderers size variable columns to the effective terminal width using the shared width helpers.

## COLUMNS=80 max line widths

- `agents inspect user`: 171 -> 80
- `agents doctor`: 138 -> 80
- `agents models codex`: 145 -> 80
- `agents cost`: 100 -> 80
- `agents view codex --skills`: 243 -> 80

## Verification

- `npm run build`
- `npx vitest run src/commands/inspect.test.ts src/commands/doctor.test.ts src/commands/models.test.ts src/commands/cost.test.ts src/commands/view.resources.test.ts`
- `COLUMNS=80 node dist/index.js inspect user | cat | awk '{ if (length($0)>m) m=length($0); print length, $0 } END { print "MAX", m+0 }'`
- `COLUMNS=80 node dist/index.js doctor | cat | awk '{ if (length($0)>m) m=length($0); print length, $0 } END { print "MAX", m+0 }'`
- `COLUMNS=80 node dist/index.js models codex | cat | awk '{ if (length($0)>m) m=length($0); print length, $0 } END { print "MAX", m+0 }'`
- `COLUMNS=80 node dist/index.js cost | cat | awk '{ if (length($0)>m) m=length($0); print length, $0 } END { print "MAX", m+0 }'`
- `COLUMNS=80 node dist/index.js view codex --skills | cat | awk '{ if (length($0)>m) m=length($0); print length, $0 } END { print "MAX", m+0 }'`
- `COLUMNS=140` spot-check for the same commands
