### PR TITLE
feat(droid): wire Factory CLI hooks (RUSH-1327) and plugins (RUSH-1340)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Not every harness supports every capability — the registry decides per harness
 | Amp | `amp` | — | ✓ | — | ✓ | ✓ | — | — | — | plan·edit |
 | Kiro | `kiro` | — | ✓ | — | ✓ | ✓ | — | — | — | edit |
 | Goose | `goose` | — | ✓ | — | — | — | — | — | — | edit |
-| Droid | `droid` | — | ✓ | — | — | ✓ | — | ✓ | — | plan·edit·auto·skip |
+| Droid | `droid` | ✓ | ✓ | — | — | ✓ | ✓ | ✓ | — | plan·edit·auto·skip |
 
 ✓ = supported · — = not supported · version cell = supported only within that range (e.g. `≥0.116` needs version `>= 0.116.0`; `<0.117` only below `0.117.0`). Out-of-range cells are **skipped silently** — `supports()` returns false and the resource is never written.
 
@@ -111,7 +111,7 @@ Not every harness supports every capability — the registry decides per harness
 | Cursor | `commands/` (md) | `.cursorrules` |
 | OpenCode | `commands/` (md) | `OPENCODE.md` |
 | Grok | skills + `.grok/` (hooks, plugins, agents, `config.toml`) | `AGENTS.md` + `~/.grok/memory/` |
-| Droid | `commands/` (md) + `.factory/` (`mcp.json`, `droids/`) | `AGENTS.md` (native) |
+| Droid | `commands/` (md) + `.factory/` (`settings.json` hooks, `mcp.json`, `droids/`, `plugins/`) | `AGENTS.md` (native) |
 
 ## Source layout
 

--- a/src/lib/__tests__/hooks.test.ts
+++ b/src/lib/__tests__/hooks.test.ts
@@ -847,3 +847,87 @@ describe('registerHooksToSettings - Claude', () => {
     expect(resolvedCommand(settings.hooks.UserPromptSubmit[0].hooks[0].command)).toBe(toPosix(scriptPath));
   });
 });
+
+describe('registerHooksToSettings - Droid', () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-test-'));
+    agentsDir = path.join(tmpDir, '.agents');
+    fs.mkdirSync(path.join(agentsDir, 'hooks'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeDroidVersionHome(): string {
+    const home = path.join(tmpDir, 'droid-home');
+    fs.mkdirSync(path.join(home, '.factory'), { recursive: true });
+    return home;
+  }
+
+  function readDroidSettings(home: string): Record<string, any> {
+    return JSON.parse(
+      fs.readFileSync(path.join(home, '.factory', 'settings.json'), 'utf-8')
+    );
+  }
+
+  it('writes Claude-shaped matcher groups into .factory/settings.json', () => {
+    const versionHome = makeDroidVersionHome();
+    const scriptPath = makeScript('pre-tool.sh');
+
+    const manifest: Record<string, ManifestHook> = {
+      'pre-tool': { script: 'pre-tool.sh', events: ['PreToolUse'], matcher: 'Bash', timeout: 45 },
+    };
+
+    const result = registerHooksToSettings('droid', versionHome, manifest, agentsDir);
+    expect(result.errors).toHaveLength(0);
+    expect(result.registered).toContain('pre-tool -> PreToolUse');
+
+    const settings = readDroidSettings(versionHome);
+    expect(settings.hooks.PreToolUse).toHaveLength(1);
+    expect(settings.hooks.PreToolUse[0].matcher).toBe('Bash');
+    expect(settings.hooks.PreToolUse[0].hooks).toHaveLength(1);
+    expect(settings.hooks.PreToolUse[0].hooks[0].type).toBe('command');
+    expect(settings.hooks.PreToolUse[0].hooks[0].timeout).toBe(45);
+    expect(resolvedCommand(settings.hooks.PreToolUse[0].hooks[0].command)).toBe(toPosix(scriptPath));
+  });
+
+  it('registers the events droid supports natively (SessionStart, UserPromptSubmit, Stop)', () => {
+    const versionHome = makeDroidVersionHome();
+    makeScript('start.sh');
+    makeScript('prompt.sh');
+    makeScript('stop.sh');
+
+    const manifest: Record<string, ManifestHook> = {
+      start: { script: 'start.sh', events: ['SessionStart'] },
+      prompt: { script: 'prompt.sh', events: ['UserPromptSubmit'] },
+      stop: { script: 'stop.sh', events: ['Stop'] },
+    };
+
+    const result = registerHooksToSettings('droid', versionHome, manifest, agentsDir);
+    expect(result.errors).toHaveLength(0);
+
+    const settings = readDroidSettings(versionHome);
+    expect(settings.hooks.SessionStart).toHaveLength(1);
+    expect(settings.hooks.UserPromptSubmit).toHaveLength(1);
+    expect(settings.hooks.Stop).toHaveLength(1);
+  });
+
+  it('preserves pre-existing non-hooks settings.json content', () => {
+    const versionHome = makeDroidVersionHome();
+    const settingsPath = path.join(versionHome, '.factory', 'settings.json');
+    fs.writeFileSync(settingsPath, JSON.stringify({ logoAnimation: 'off' }, null, 2));
+
+    makeScript('pre-tool.sh');
+    const manifest: Record<string, ManifestHook> = {
+      'pre-tool': { script: 'pre-tool.sh', events: ['PreToolUse'] },
+    };
+
+    const result = registerHooksToSettings('droid', versionHome, manifest, agentsDir);
+    expect(result.errors).toHaveLength(0);
+
+    const settings = readDroidSettings(versionHome);
+    expect(settings.logoAnimation).toBe('off');
+    expect(settings.hooks.PreToolUse).toHaveLength(1);
+  });
+});

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -514,11 +514,26 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
   // Install: `curl -fsSL https://app.factory.ai/cli | sh` (no npm package).
   // Binary is NOT in node_modules/.bin — the shim resolves the fixed install
   // path ~/.local/bin/droid directly (see the droid branch in shims.ts).
-  // Config: `~/.factory/` (settings.json, mcp.json, droids/, commands/).
-  // Memory: native AGENTS.md. Subagents = custom droids (top-level .md files
-  // in ~/.factory/droids/). Config isolation rides the ~/.factory symlink
-  // switch (no FACTORY_HOME env var exists). Headless: `droid exec "<prompt>"`
-  // with --auto low|medium|high, -o stream-json, -m <model>, -r <effort>.
+  // Config: `~/.factory/` (settings.json, mcp.json, droids/, commands/, hooks/,
+  // plugins/). Memory: native AGENTS.md. Subagents = custom droids (top-level
+  // .md files in ~/.factory/droids/). Config isolation rides the ~/.factory
+  // symlink switch (no FACTORY_HOME env var exists). Headless:
+  // `droid exec "<prompt>"` with --auto low|medium|high, -o stream-json,
+  // -m <model>, -r <effort>.
+  //
+  // Hooks: Claude-shaped. settings.json carries a top-level `hooks` object keyed
+  // by event (PreToolUse, PostToolUse, UserPromptSubmit, SessionStart,
+  // SessionEnd, Stop, SubagentStop, Notification, PreCompact), each an array of
+  // `{ matcher?, hooks: [{ type: "command", command, timeout? }] }` matcher
+  // groups — verified against the droid binary's zod schema. So the Claude
+  // registrar is reused verbatim, just targeting `.factory/settings.json`.
+  //
+  // Plugins: native `droid plugin` command group + ~/.factory/plugins/ with the
+  // same marketplace layout Claude uses (known_marketplaces.json +
+  // marketplaces/<name>/plugins/<plugin>/). Droid's plugin manifest dir is
+  // `.factory-plugin/` (it also reads `.claude-plugin/` for compatibility) — set
+  // pluginManifestDir so syncPluginToVersion mirrors the manifest into it, the
+  // same pattern codex uses with `.codex-plugin`.
   droid: {
     id: 'droid',
     name: 'Droid',
@@ -532,20 +547,21 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     commandsSubdir: 'commands',
     skillsDir: '', // no skills concept
     hooksDir: 'hooks',
+    pluginManifestDir: '.factory-plugin',
     instructionsFile: 'AGENTS.md',
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
-    supportsHooks: false,
+    supportsHooks: true,
     // Factory Droid Computers (cloud VMs) reached via `droid computer ssh` +
     // remote headless `droid exec`.
     cloudProvider: 'factory',
     capabilities: {
-      hooks: false,
+      hooks: true,
       mcp: true,
       allowlist: false,
       skills: false,
       commands: true,
-      plugins: false,
+      plugins: true,
       subagents: true,
       rules: { file: 'AGENTS.md' },
       workflows: false,

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1036,6 +1036,18 @@ export function registerHooksToSettings(
   if (agentId === 'claude') {
     return registerHooksForClaude(versionHome, manifest, resolveScript, managedPrefixes);
   }
+  if (agentId === 'droid') {
+    // Droid's settings.json hooks schema is identical to Claude's (top-level
+    // `hooks` object → event → matcher-group array), so reuse the Claude
+    // registrar targeting `.factory/settings.json` (agentConfigDirName('droid')).
+    return registerHooksForClaude(
+      versionHome,
+      manifest,
+      resolveScript,
+      managedPrefixes,
+      agentConfigDirName('droid')
+    );
+  }
   if (agentId === 'codex') {
     return registerHooksForCodex(versionHome, manifest, resolveScript, managedPrefixes);
   }
@@ -1086,12 +1098,13 @@ function registerHooksForClaude(
   versionHome: string,
   manifest: Record<string, ManifestHook>,
   resolveScript: (script: string) => string | null,
-  managedPrefixes: string[]
+  managedPrefixes: string[],
+  configDirName = '.claude'
 ): { registered: string[]; errors: string[] } {
   const registered: string[] = [];
   const errors: string[] = [];
 
-  const configDir = path.join(versionHome, '.claude');
+  const configDir = path.join(versionHome, configDirName);
   const settingsPath = path.join(configDir, 'settings.json');
 
   let config: Record<string, unknown> = {};

--- a/src/lib/plugin-marketplace.ts
+++ b/src/lib/plugin-marketplace.ts
@@ -44,9 +44,33 @@ export const SYSTEM_MARKETPLACE_NAME = 'agents-system';
 export const PROJECT_MARKETPLACE_NAME = 'agents-project';
 
 interface KnownMarketplaceEntry {
-  source: { source: 'directory'; path: string };
+  source: { source: 'directory' | 'local'; path: string };
   installLocation: string;
   lastUpdated: string;
+  autoUpdate?: boolean;
+}
+
+/**
+ * Droid tracks INSTALLED plugins in .factory/plugins/installed_plugins.json —
+ * a registry distinct from the marketplace catalog. A plugin is only visible to
+ * `droid plugin list` (and loaded at runtime) when it has an entry here; the
+ * marketplace copy + enabledPlugins alone are not enough. Verified against the
+ * Factory CLI (droid 0.161.0): `droid plugin install` writes exactly this shape,
+ * and pointing `installPath` at the marketplace install dir (no separate cache
+ * copy) lists the plugin as Active.
+ */
+interface DroidInstalledEntry {
+  scope: string;
+  installPath: string;
+  version: string;
+  installedAt: string;
+  lastUpdated: string;
+  source: string;
+}
+
+interface DroidInstalledPlugins {
+  schemaVersion: number;
+  plugins: Record<string, DroidInstalledEntry[]>;
 }
 
 interface MarketplacePluginEntry {
@@ -456,14 +480,121 @@ export function registerMarketplace(spec: MarketplaceSpec, agent: AgentId, versi
     }
   }
 
+  // Droid names the on-disk source type "local" (Claude/OpenClaw use
+  // "directory") and stamps autoUpdate — verified against `droid plugin
+  // marketplace add`. A "directory" entry is silently ignored by the Factory
+  // CLI, so the plugin never resolves.
+  const isDroid = agent === 'droid';
   known[name] = {
-    source: { source: 'directory', path: root },
+    source: { source: isDroid ? 'local' : 'directory', path: root },
     installLocation: root,
     lastUpdated: new Date().toISOString(),
+    ...(isDroid ? { autoUpdate: true } : {}),
   };
 
   fs.mkdirSync(path.dirname(knownPath), { recursive: true });
   fs.writeFileSync(knownPath, JSON.stringify(known, null, 2) + '\n', 'utf-8');
+}
+
+// ─── Droid installed-plugins registry ─────────────────────────────────────────
+
+function installedPluginsPath(agent: AgentId, versionHome: string): string {
+  return path.join(pluginsRootForVersion(agent, versionHome), 'installed_plugins.json');
+}
+
+function readInstalledPlugins(agent: AgentId, versionHome: string): DroidInstalledPlugins {
+  const p = installedPluginsPath(agent, versionHome);
+  if (fs.existsSync(p)) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(p, 'utf-8')) as Partial<DroidInstalledPlugins>;
+      if (parsed && typeof parsed === 'object' && parsed.plugins && typeof parsed.plugins === 'object') {
+        return { schemaVersion: parsed.schemaVersion ?? 1, plugins: parsed.plugins };
+      }
+    } catch { /* fall through to fresh registry */ }
+  }
+  return { schemaVersion: 1, plugins: {} };
+}
+
+/**
+ * Record a plugin in Droid's installed_plugins.json (user scope), pointing
+ * installPath at the marketplace install dir so no second copy is needed. This
+ * is what makes `droid plugin list` show the plugin (Active once enabledPlugins
+ * is set). Idempotent: re-running refreshes lastUpdated and preserves the
+ * original installedAt plus any non-user scope entries.
+ */
+export function registerDroidInstalledPlugin(
+  pluginName: string,
+  marketplaceName: string,
+  installDir: string,
+  version: string,
+  agent: AgentId,
+  versionHome: string
+): void {
+  const registry = readInstalledPlugins(agent, versionHome);
+  const key = `${pluginName}@${marketplaceName}`;
+  const now = new Date().toISOString();
+  const existing = registry.plugins[key] ?? [];
+  const priorUser = existing.find(e => e.scope === 'user');
+  const others = existing.filter(e => e.scope !== 'user');
+  registry.plugins[key] = [
+    ...others,
+    {
+      scope: 'user',
+      installPath: installDir,
+      version,
+      installedAt: priorUser?.installedAt ?? now,
+      lastUpdated: now,
+      source: marketplaceName,
+    },
+  ];
+
+  const p = installedPluginsPath(agent, versionHome);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(registry, null, 2) + '\n', 'utf-8');
+}
+
+/** True when Droid's installed_plugins.json carries a user-scope entry for the plugin. */
+export function isDroidPluginInstalled(
+  pluginName: string,
+  marketplaceName: string,
+  agent: AgentId,
+  versionHome: string
+): boolean {
+  const registry = readInstalledPlugins(agent, versionHome);
+  const entries = registry.plugins[`${pluginName}@${marketplaceName}`];
+  return Array.isArray(entries) && entries.some(e => e.scope === 'user');
+}
+
+/**
+ * Remove a plugin's user-scope entry from Droid's installed_plugins.json.
+ * Inverse of registerDroidInstalledPlugin. Drops the key when no scopes remain
+ * and deletes the file when the registry is empty.
+ */
+export function unregisterDroidInstalledPlugin(
+  pluginName: string,
+  marketplaceName: string,
+  agent: AgentId,
+  versionHome: string
+): void {
+  const p = installedPluginsPath(agent, versionHome);
+  if (!fs.existsSync(p)) return;
+  const registry = readInstalledPlugins(agent, versionHome);
+  const key = `${pluginName}@${marketplaceName}`;
+  const entries = registry.plugins[key];
+  if (!Array.isArray(entries)) return;
+
+  const kept = entries.filter(e => e.scope !== 'user');
+  if (kept.length > 0) {
+    registry.plugins[key] = kept;
+  } else {
+    delete registry.plugins[key];
+  }
+
+  if (Object.keys(registry.plugins).length === 0) {
+    try { fs.unlinkSync(p); } catch { /* ignore */ }
+    return;
+  }
+  fs.writeFileSync(p, JSON.stringify(registry, null, 2) + '\n', 'utf-8');
 }
 
 /**

--- a/src/lib/plugins.test.ts
+++ b/src/lib/plugins.test.ts
@@ -893,6 +893,142 @@ describe('syncPluginToVersion (native marketplace install)', () => {
   });
 });
 
+// ─── syncPluginToVersion: Droid (.factory + .factory-plugin manifest) ─────────
+
+describe('syncPluginToVersion (droid native marketplace install)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function setupDroidPlugin(name = 'myplugin'): { pluginRoot: string; versionHome: string; plugin: DiscoveredPlugin } {
+    const pluginRoot = path.join(tmpDir, name);
+    fs.mkdirSync(path.join(pluginRoot, '.claude-plugin'), { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginRoot, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name, version: '1.0.0', description: 'test', author: { name: 'tester' } })
+    );
+    const versionHome = path.join(tmpDir, `${name}-home`);
+    fs.mkdirSync(path.join(versionHome, '.factory'), { recursive: true });
+
+    const plugin: DiscoveredPlugin = {
+      name,
+      root: pluginRoot,
+      manifest: { name, version: '1.0.0', description: 'test' },
+      skills: [],
+      hooks: [],
+      scripts: [],
+      commands: [],
+      agentDefs: [],
+      bin: [],
+      mcpServers: [],
+      lspServers: [],
+      monitors: [],
+      hasMcp: false,
+      hasSettings: false,
+    };
+    return { pluginRoot, versionHome, plugin };
+  }
+
+  it('copies plugin source into .factory/plugins/marketplaces/agents-cli/plugins/<name>/', async () => {
+    const { pluginRoot, versionHome, plugin } = setupDroidPlugin();
+    fs.writeFileSync(path.join(pluginRoot, 'README.md'), '# hi');
+
+    const { syncPluginToVersion } = await import('./plugins.js');
+    syncPluginToVersion(plugin, 'droid', versionHome);
+
+    const installDir = path.join(versionHome, '.factory', 'plugins', 'marketplaces', 'agents-cli', 'plugins', 'myplugin');
+    expect(fs.existsSync(path.join(installDir, '.claude-plugin', 'plugin.json'))).toBe(true);
+    expect(fs.existsSync(path.join(installDir, 'README.md'))).toBe(true);
+  });
+
+  it('mirrors the manifest into .factory-plugin/plugin.json (droid native manifest dir)', async () => {
+    const { versionHome, plugin } = setupDroidPlugin();
+
+    const { syncPluginToVersion } = await import('./plugins.js');
+    syncPluginToVersion(plugin, 'droid', versionHome);
+
+    const installDir = path.join(versionHome, '.factory', 'plugins', 'marketplaces', 'agents-cli', 'plugins', 'myplugin');
+    const factoryManifest = path.join(installDir, '.factory-plugin', 'plugin.json');
+    expect(fs.existsSync(factoryManifest)).toBe(true);
+    const parsed = JSON.parse(fs.readFileSync(factoryManifest, 'utf-8'));
+    expect(parsed.name).toBe('myplugin');
+    expect(parsed.version).toBe('1.0.0');
+  });
+
+  it('registers the marketplace with source "local" and enables the plugin (top-level)', async () => {
+    const { versionHome, plugin } = setupDroidPlugin();
+    fs.writeFileSync(path.join(versionHome, '.factory', 'settings.json'), JSON.stringify({ logoAnimation: 'off' }));
+
+    const { syncPluginToVersion } = await import('./plugins.js');
+    syncPluginToVersion(plugin, 'droid', versionHome);
+
+    // Droid ignores a "directory" source; it must be "local" (+ autoUpdate).
+    const knownPath = path.join(versionHome, '.factory', 'plugins', 'known_marketplaces.json');
+    const known = JSON.parse(fs.readFileSync(knownPath, 'utf-8'));
+    expect(known['agents-cli'].source.source).toBe('local');
+    expect(known['agents-cli'].autoUpdate).toBe(true);
+
+    const settings = JSON.parse(fs.readFileSync(path.join(versionHome, '.factory', 'settings.json'), 'utf-8'));
+    expect(settings.enabledPlugins).toEqual({ 'myplugin@agents-cli': true });
+    // Pre-existing keys are preserved.
+    expect(settings.logoAnimation).toBe('off');
+  });
+
+  it('records the plugin in installed_plugins.json pointing at the marketplace install dir', async () => {
+    const { versionHome, plugin } = setupDroidPlugin();
+
+    const { syncPluginToVersion } = await import('./plugins.js');
+    syncPluginToVersion(plugin, 'droid', versionHome);
+
+    const installedPath = path.join(versionHome, '.factory', 'plugins', 'installed_plugins.json');
+    expect(fs.existsSync(installedPath)).toBe(true);
+    const registry = JSON.parse(fs.readFileSync(installedPath, 'utf-8'));
+    expect(registry.schemaVersion).toBe(1);
+    const entries = registry.plugins['myplugin@agents-cli'];
+    expect(Array.isArray(entries)).toBe(true);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].scope).toBe('user');
+    expect(entries[0].version).toBe('1.0.0');
+    expect(entries[0].source).toBe('agents-cli');
+    const installDir = path.join(versionHome, '.factory', 'plugins', 'marketplaces', 'agents-cli', 'plugins', 'myplugin');
+    expect(entries[0].installPath).toBe(installDir);
+    expect(fs.existsSync(path.join(entries[0].installPath, '.claude-plugin', 'plugin.json'))).toBe(true);
+  });
+
+  it('isPluginSynced is true after sync, and false once the installed registry entry is dropped', async () => {
+    const { versionHome, plugin } = setupDroidPlugin();
+    const { syncPluginToVersion, isPluginSynced } = await import('./plugins.js');
+    syncPluginToVersion(plugin, 'droid', versionHome);
+    expect(isPluginSynced(plugin, 'droid', versionHome)).toBe(true);
+
+    // Marketplace copy present but registry entry gone => not synced (droid can't see it).
+    fs.rmSync(path.join(versionHome, '.factory', 'plugins', 'installed_plugins.json'));
+    expect(isPluginSynced(plugin, 'droid', versionHome)).toBe(false);
+  });
+
+  it('removePluginFromVersion clears the installed registry entry', async () => {
+    const { versionHome, plugin } = setupDroidPlugin();
+    const { syncPluginToVersion, removePluginFromVersion, isPluginSynced } = await import('./plugins.js');
+    syncPluginToVersion(plugin, 'droid', versionHome);
+    expect(isPluginSynced(plugin, 'droid', versionHome)).toBe(true);
+
+    removePluginFromVersion(plugin.name, plugin.root, 'droid', versionHome);
+    const installedPath = path.join(versionHome, '.factory', 'plugins', 'installed_plugins.json');
+    // File removed (registry emptied) or no longer carries the entry.
+    if (fs.existsSync(installedPath)) {
+      const registry = JSON.parse(fs.readFileSync(installedPath, 'utf-8'));
+      expect(registry.plugins['myplugin@agents-cli']).toBeUndefined();
+    }
+    expect(isPluginSynced(plugin, 'droid', versionHome)).toBe(false);
+  });
+});
+
 // ─── syncPluginToVersion: per-marketplace routing ────────────────────────────
 
 describe('syncPluginToVersion (per-marketplace routing)', () => {

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -28,6 +28,9 @@ import {
   addPluginToSettings,
   removePluginFromSettings,
   removePluginFromMarketplace,
+  registerDroidInstalledPlugin,
+  unregisterDroidInstalledPlugin,
+  isDroidPluginInstalled,
   marketplaceIsEmpty,
   removeEmptyMarketplaceDir,
   isInstalledInMarketplace,
@@ -485,7 +488,7 @@ export function marketplaceSpecForName(name: string | undefined, cwd: string = p
  * carries, not just the user one.
  */
 function listVersionMarketplaceNames(agent: AgentId, versionHome: string): string[] {
-  const dir = path.join(versionHome, `.${agent}`, 'plugins', 'marketplaces');
+  const dir = path.join(versionHome, agentConfigDirName(agent), 'plugins', 'marketplaces');
   if (!fs.existsSync(dir)) return [];
   try {
     return fs.readdirSync(dir, { withFileTypes: true })
@@ -513,6 +516,11 @@ function listVersionMarketplaceNames(agent: AgentId, versionHome: string): strin
  * MCP servers, bin/, settings.json, and permissions once the plugin lives at the
  * native install path and is marked enabled — see
  * https://code.claude.com/docs/en/plugins.
+ *
+ * Droid (Factory CLI) reuses this same marketplace layout but additionally
+ * requires an installed_plugins.json registry entry and a "local"-source
+ * known_marketplaces.json entry before `droid plugin list` will see the plugin
+ * (steps handled by registerMarketplace's droid branch + step 5c below).
  */
 export function syncPluginToVersion(
   plugin: DiscoveredPlugin,
@@ -582,8 +590,24 @@ export function syncPluginToVersion(
   // .mcp.json, settings.json, permissions/) are only auto-enabled when the
   // caller explicitly opts in. addPluginToSettings does no gating — that moved
   // here, where plugin capabilities are inspected.
-  if (options.allowExecSurfaces === true || !hasPluginExecSurfaces(inspectPluginCapabilities(plugin.root))) {
+  const enablePlugin = options.allowExecSurfaces === true || !hasPluginExecSurfaces(inspectPluginCapabilities(plugin.root));
+  if (enablePlugin) {
     addPluginToSettings(plugin.name, marketplaceName, agent, versionHome);
+  }
+
+  // 5c. Droid diverges from Claude's marketplace+enabledPlugins model: it only
+  //     "sees" a plugin that also has an entry in installed_plugins.json (with
+  //     the marketplace registered as source "local"). Register the install so
+  //     `droid plugin list` shows it — Active when enabled, Inactive otherwise.
+  if (agent === 'droid') {
+    registerDroidInstalledPlugin(
+      plugin.name,
+      marketplaceName,
+      installDir,
+      plugin.manifest.version,
+      agent,
+      versionHome
+    );
   }
 
   // 5b. Convert plugin commands/ to skills for agents that dropped command support
@@ -809,7 +833,14 @@ export function isPluginSynced(
   versionHome: string
 ): boolean {
   if (!isCapable(agent, 'plugins')) return false;
-  return isInstalledInMarketplace(plugin.name, marketplaceSpecForName(plugin.marketplace), agent, versionHome);
+  const spec = marketplaceSpecForName(plugin.marketplace);
+  if (!isInstalledInMarketplace(plugin.name, spec, agent, versionHome)) return false;
+  // Droid additionally requires its installed_plugins.json registry entry —
+  // without it the marketplace copy is invisible to `droid plugin list`.
+  if (agent === 'droid') {
+    return isDroidPluginInstalled(plugin.name, marketplaceNameFor(spec), agent, versionHome);
+  }
+  return true;
 }
 
 // ─── Removal ─────────────────────────────────────────────────────────────────
@@ -853,6 +884,9 @@ export function removePluginFromVersion(
       removedAny = true;
     }
     removePluginFromSettings(pluginName, name, agent, versionHome);
+    if (agent === 'droid') {
+      unregisterDroidInstalledPlugin(pluginName, name, agent, versionHome);
+    }
 
     // Refresh marketplace.json so it reflects what's left under plugins/.
     syncMarketplaceManifest(spec, agent, versionHome);
@@ -1042,6 +1076,9 @@ export function cleanOrphanedPluginSkills(
         fs.mkdirSync(trashDir, { recursive: true, mode: 0o700 });
         fs.renameSync(path.join(mktPluginsDir, entry.name), trashDest);
         removePluginFromSettings(entry.name, name, agent, versionHome);
+        if (agent === 'droid') {
+          unregisterDroidInstalledPlugin(entry.name, name, agent, versionHome);
+        }
         removed.push(entry.name);
         trashedHere = true;
       } catch { /* skip on error */ }

--- a/src/lib/staleness/writers/hooks.ts
+++ b/src/lib/staleness/writers/hooks.ts
@@ -36,7 +36,7 @@ function buildHooksWriter(agent: AgentId): ResourceWriter<string[]> {
 
       // Native hook registration in settings.json/hooks.json. Grok auto-
       // discovers from ~/.grok/hooks/ so the file copy is sufficient.
-      if (agent === 'claude' || agent === 'codex' || agent === 'gemini' || agent === 'antigravity' || agent === 'kimi') {
+      if (agent === 'claude' || agent === 'codex' || agent === 'gemini' || agent === 'antigravity' || agent === 'kimi' || agent === 'droid') {
         registerHooksToSettings(agent, versionHome);
       }
       return { synced };

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -38,15 +38,19 @@ describe('capableAgents("commands")', () => {
 });
 
 describe('droid (Factory AI)', () => {
-  it('is registered with the four supported resource capabilities', () => {
+  it('is registered with its supported resource capabilities', () => {
     expect(ALL_AGENT_IDS).toContain('droid');
     expect(capableAgents('mcp')).toContain('droid');
     expect(capableAgents('commands')).toContain('droid');
     expect(capableAgents('subagents')).toContain('droid');
+    // Factory CLI (droid) supports Claude-shaped hooks in .factory/settings.json
+    // (RUSH-1327) and plugins via the marketplace + installed_plugins.json model
+    // (RUSH-1340). Both route through supports() like every other capability.
+    expect(capableAgents('hooks')).toContain('droid');
+    expect(capableAgents('plugins')).toContain('droid');
     // No Droid equivalent for these — must stay false so the registry
     // assertion doesn't demand writers we can't provide.
     expect(capableAgents('skills')).not.toContain('droid');
-    expect(capableAgents('plugins')).not.toContain('droid');
     expect(capableAgents('workflows')).not.toContain('droid');
   });
 


### PR DESCRIPTION
## Summary

Wire **Droid (Factory CLI, `droid`)** hooks (**RUSH-1327**) and plugins (**RUSH-1340**) into agents-cli. Both capability flags flip to `true` and everything routes through `supports()` — no per-call agent checks are added.

Verified against the on-machine `droid` **0.161.0** binary and `~/.factory` layout before writing any code (no guessing).

## Hooks (RUSH-1327)

Droid's hook schema in `.factory/settings.json` is **byte-identical to Claude's** (verified in the binary: `{ matcher, hooks: [{ type: "command", command, timeout }] }` under an event map, same event names). So `registerHooksToSettings` reuses the Claude registrar, parametrized by config-dir name (`.factory`). `staleness/writers/hooks.ts` adds `droid` to the native-registration allowlist; the registry auto-wires the detector.

## Plugins (RUSH-1340)

Droid reuses the Claude marketplace layout (it reads `.claude-plugin/marketplace.json` as a fallback — confirmed live), **but diverges** in two ways that the Claude path did not satisfy:

1. `known_marketplaces.json` source type must be `"local"` (not `"directory"`), plus `autoUpdate: true`.
2. A plugin is only visible to `droid plugin list` when it has an entry in `.factory/plugins/installed_plugins.json`. Top-level `enabledPlugins` (already written) then flips it Active.

`syncPluginToVersion` now writes those droid-native artifacts. `installPath` points at the existing marketplace install dir, so **no second copy** is needed. Removal/orphan/staleness paths clear the registry entry too.

Also fixes `listVersionMarketplaceNames` to use `agentConfigDirName(agent)` instead of a hardcoded `.<agent>` path, so removal/orphan/diff work for droid (config dir `.factory`, not `.droid`).

## End-to-end verification (real `droid`)

A real `syncPluginToVersion('droid', …)` into an isolated `HOME`, then:

```
$ droid plugin list
Installed plugins:
Active:
  agents-demo@agents-cli  [user]  1.0.0
```

No manual patching — the sync alone produces an Active plugin. Hooks are written in droid's exact schema and parsed by droid from the same settings file.

## Tests

Real sync path, no mocking (1:1 next to source):
- `src/lib/plugins.test.ts` — droid native marketplace install (source `local`, `installed_plugins.json`, `isPluginSynced`, removal).
- `src/lib/__tests__/hooks.test.ts` — droid Claude-shaped hooks in `.factory/settings.json`.
- `tests/agents.test.ts` — updated droid capability assertions (hooks/plugins now supported).

`tsc --noEmit` clean; affected suites green (189 tests). The only failing suite in the full run is the pre-existing `session/sync/config.test.ts` (R2/secrets keychain, environment-dependent) which fails identically on clean `main`.

Refs RUSH-1327, RUSH-1340.
