### PR TITLE
fix(browser): accept Edge "edg" CDP identity, unblocking Windows Edge (#580)

### DIFF
--- a/src/lib/browser/cdp.test.ts
+++ b/src/lib/browser/cdp.test.ts
@@ -76,6 +76,14 @@ describe('verifyBrowserIdentity', () => {
     expect(() => verifyBrowserIdentity('microsoft-edge', 'edge', 9222)).not.toThrow();
   });
 
+  it('accepts "edg" for edge (Windows Edge reports "Edg/<version>" in /json/version)', () => {
+    // normalizeBrowserName('Edg/120.0.0.0') === 'edg' — the real identity a
+    // WMI-launched Windows Edge serves. Regression test for #580: this used to
+    // throw a false "identity mismatch" that blocked all Windows Edge browser-use.
+    expect(normalizeBrowserName('Edg/120.0.0.0')).toBe('edg');
+    expect(() => verifyBrowserIdentity('edg', 'edge', 9222)).not.toThrow();
+  });
+
   it('accepts brave-browser for brave', () => {
     expect(() => verifyBrowserIdentity('brave-browser', 'brave', 9222)).not.toThrow();
   });

--- a/src/lib/browser/cdp.ts
+++ b/src/lib/browser/cdp.ts
@@ -278,7 +278,11 @@ export function verifyBrowserIdentity(
     // to a Comet instance doesn't trip a false "identity mismatch".
     comet: ['comet', 'chrome'],
     brave: ['brave', 'brave-browser', 'chrome'],
-    edge: ['edge', 'microsoft-edge', 'msedge', 'chrome'],
+    // Windows/Chromium Edge reports its /json/version "Browser" field as
+    // "Edg/<version>" (the `Edg` token, not `Edge`), which normalizeBrowserName
+    // reduces to "edg". Accept it so attaching to a real Edge doesn't trip a
+    // false identity mismatch (the profile enum only allows "edge").
+    edge: ['edge', 'edg', 'microsoft-edge', 'msedge', 'chrome'],
   };
 
   const accepted = matches[expected] || [expected];


### PR DESCRIPTION
Fixes #580.

## Problem
`browser start` against a Windows Edge profile hard-failed with:
```
Browser identity mismatch: profile expects "edge" but win-mini:9222 is serving "edg".
```
Windows/Chromium Edge advertises its `/json/version` **Browser** field as `Edg/<version>` (the `Edg` token). `normalizeBrowserName` reduces that to `edg`, but the `edge` alias list in `verifyBrowserIdentity` (`src/lib/browser/cdp.ts:281`) only contained `edge`/`microsoft-edge`/`msedge`/`chrome`. So a profile that passes creation (`edge` is the only Edge id the enum accepts) always failed the runtime check (`edg`) — and the error’s own suggested fix (`browser=edg`) is rejected by `profiles create`. No working combination existed; Windows Edge browser-use was fully blocked.

## Fix
Add `edg` to the `edge` alias list. One-line change + regression test asserting `normalizeBrowserName("Edg/120.0.0.0") === "edg"` and that `verifyBrowserIdentity("edg", "edge", …)` no longer throws.

## Verification
- `tsc` clean; `cdp.test.ts` 21/21 pass.
- **Hardware-verified on a real Windows host (win-mini):** with this fix, `browser start --profile <edge> --url …` launches Edge via WMI and attaches CDP (`Started task "…" with tab …`) instead of throwing the mismatch. Before the fix, identical invocation threw on every run.

Found during the win-mini browser e2e; independent of the #567 remote-browser hardening.