### PR TITLE
fix(shims): end the kimi/grok binary-resolution re-exec loop

### DIFF
--- a/src/lib/__tests__/shims.test.ts
+++ b/src/lib/__tests__/shims.test.ts
@@ -95,8 +95,8 @@ describe('addShimsToPath', () => {
 });
 
 describe('SHIM_SCHEMA_VERSION', () => {
-  it('is 20 (kimi resolves via generic node_modules branch in dispatcher)', () => {
-    expect(SHIM_SCHEMA_VERSION).toBe(20);
+  it('is 21 (kimi via generic branch + grok anti-loop guard in dispatcher)', () => {
+    expect(SHIM_SCHEMA_VERSION).toBe(21);
   });
 });
 
@@ -156,7 +156,7 @@ describe('generateShimScript — config-dir env vars', () => {
 describe('generateVersionedAliasScript', () => {
   it('uses ~/.agents/.history for direct alias binary and config paths', () => {
     const script = generateVersionedAliasScript('codex', '0.125.0');
-    expect(VERSIONED_ALIAS_SCHEMA_VERSION).toBe(9);
+    expect(VERSIONED_ALIAS_SCHEMA_VERSION).toBe(10);
     expect(script).toContain('$HOME/.agents/.history/versions/codex/0.125.0');
     expect(script).not.toContain('$HOME/.agents-system/versions/codex/0.125.0');
   });
@@ -181,6 +181,22 @@ describe('generateVersionedAliasScript', () => {
     expect(script).toContain('GROK_DOWNLOADS="$HOME/.grok/downloads"');
     expect(script).not.toContain('node_modules/.bin/grok');
     expect(script).toContain('export GROK_HOME=');
+  });
+
+  // Regression (re-exec loop): when ~/.grok/downloads is empty, the grok
+  // fallback runs `command -v grok`, which resolves to this alias's sibling
+  // dispatcher shim (shims dir ahead of ~/.local/bin on PATH). Without a guard
+  // it exec-loops forever. The guard must null out any shims-dir match.
+  it('guards grok command -v fallback against the shims dir (alias)', () => {
+    const script = generateVersionedAliasScript('grok', '0.2.33');
+    expect(script).toContain('command -v grok');
+    expect(script).toContain('"$HOME/.agents/.cache/shims/"*) BINARY="" ;;');
+  });
+
+  it('guards grok command -v fallback against the shims dir (dispatcher)', () => {
+    const script = generateShimScript('grok');
+    expect(script).toContain('command -v grok');
+    expect(script).toContain('"$AGENTS_USER_DIR/.cache/shims/"*) BINARY="" ;;');
   });
 
   it('resolves grok for the pinned version', () => {

--- a/src/lib/__tests__/shims.test.ts
+++ b/src/lib/__tests__/shims.test.ts
@@ -95,8 +95,8 @@ describe('addShimsToPath', () => {
 });
 
 describe('SHIM_SCHEMA_VERSION', () => {
-  it('is 19 (droid binary resolution branch in dispatcher)', () => {
-    expect(SHIM_SCHEMA_VERSION).toBe(19);
+  it('is 20 (kimi resolves via generic node_modules branch in dispatcher)', () => {
+    expect(SHIM_SCHEMA_VERSION).toBe(20);
   });
 });
 
@@ -135,6 +135,17 @@ describe('generateShimScript — config-dir env vars', () => {
     expect(script).toContain('"$VERSION_DIR/home/.kimi-code"');
   });
 
+  // Regression (re-exec loop): the dispatcher must resolve kimi through the
+  // generic node_modules/.bin branch, never the old ~/.kimi-code/bin path whose
+  // `command -v kimi` fallback resolves to this dispatcher itself (the shims dir
+  // sits ahead of ~/.local/bin on PATH) and re-execs forever.
+  it('resolves kimi from node_modules/.bin in the dispatcher, without a command -v loop', () => {
+    const script = generateShimScript('kimi');
+    expect(script).toContain('"$VERSION_DIR/node_modules/.bin/$CLI_COMMAND"');
+    expect(script).not.toContain('BINARY=$(command -v kimi');
+    expect(script).not.toContain('KIMI_BINARY="$HOME/.kimi-code/bin/kimi"');
+  });
+
   it('does not export a managed config-dir var for other agents', () => {
     const script = generateShimScript('opencode');
     expect(script).not.toContain('export CLAUDE_CONFIG_DIR=');
@@ -145,7 +156,7 @@ describe('generateShimScript — config-dir env vars', () => {
 describe('generateVersionedAliasScript', () => {
   it('uses ~/.agents/.history for direct alias binary and config paths', () => {
     const script = generateVersionedAliasScript('codex', '0.125.0');
-    expect(VERSIONED_ALIAS_SCHEMA_VERSION).toBe(8);
+    expect(VERSIONED_ALIAS_SCHEMA_VERSION).toBe(9);
     expect(script).toContain('$HOME/.agents/.history/versions/codex/0.125.0');
     expect(script).not.toContain('$HOME/.agents-system/versions/codex/0.125.0');
   });
@@ -179,10 +190,17 @@ describe('generateVersionedAliasScript', () => {
     expect(script).not.toContain('node_modules/.bin');
   });
 
-  it('resolves kimi from ~/.kimi-code/bin, not node_modules', () => {
+  // Regression (re-exec loop): kimi npm-installs @moonshot-ai/kimi-code, so its
+  // binary is at node_modules/.bin/kimi — NOT ~/.kimi-code/bin (that path only
+  // exists for a curl install, and even then installVersion symlinks it into
+  // node_modules/.bin). The old ~/.kimi-code/bin special-case fell back to
+  // `command -v kimi`, which resolves to the sibling dispatcher shim and
+  // re-execs forever. Resolve via node_modules; keep KIMI_CODE_HOME isolation.
+  it('resolves kimi from node_modules/.bin, not ~/.kimi-code/bin', () => {
     const script = generateVersionedAliasScript('kimi', '0.12.1');
-    expect(script).toContain('KIMI_BINARY="$HOME/.kimi-code/bin/kimi"');
-    expect(script).not.toContain('node_modules/.bin/kimi');
+    expect(script).toContain('node_modules/.bin/kimi');
+    expect(script).not.toContain('KIMI_BINARY="$HOME/.kimi-code/bin/kimi"');
+    expect(script).not.toContain('BINARY=$(command -v kimi');
     expect(script).toContain('export KIMI_CODE_HOME=');
   });
 

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -231,7 +231,11 @@ async function promptConflictStrategy(
  *         top-level entry add/remove — deep edits to plugin contents won't
  *         trigger auto-resync, run `agents sync` for that.
  */
-export const SHIM_SCHEMA_VERSION = 19;
+// v20 — stop treating kimi like grok/droid: it npm-installs into
+//        node_modules/.bin/kimi, so resolve it via the generic branch. The old
+//        ~/.kimi-code/bin special-case never existed for npm installs and
+//        re-exec-looped through `command -v kimi` (the dispatcher itself).
+export const SHIM_SCHEMA_VERSION = 20;
 
 /** Internal marker string used to embed the schema version in shim scripts. */
 const SHIM_VERSION_MARKER = 'agents-shim-version:';
@@ -439,16 +443,14 @@ if [ "$AGENT" = "grok" ]; then
     # Last resort: whatever is on PATH (user may have installed grok globally)
     BINARY=$(command -v grok 2>/dev/null || echo "")
   fi
-# Kimi special case: binary lives in ~/.kimi-code/bin/, not node_modules.
-# We still use the agents-cli version dir purely for KIMI_CODE_HOME isolation.
-elif [ "$AGENT" = "kimi" ]; then
-  KIMI_BINARY="$HOME/.kimi-code/bin/kimi"
-  if [ -x "$KIMI_BINARY" ]; then
-    BINARY="$KIMI_BINARY"
-  else
-    # Last resort: whatever is on PATH
-    BINARY=$(command -v kimi 2>/dev/null || echo "")
-  fi
+# Kimi is a normal npm agent: "agents add kimi" npm-installs
+# @moonshot-ai/kimi-code into the version dir and the binary lands at
+# node_modules/.bin/kimi (a curl-installed kimi is symlinked to the same spot
+# by installVersion). So kimi resolves via the generic node_modules branch
+# below -- never a bespoke ~/.kimi-code/bin path that does not exist for npm
+# installs and fell back to "command -v kimi", which resolves to THIS
+# dispatcher (shims dir is ahead on PATH) and re-execs forever. Only
+# KIMI_CODE_HOME (config isolation) stays special-cased, separately below.
 # Droid (Factory AI) special case: the official installer drops a standalone
 # native binary at ~/.local/bin/droid — there is no npm package and nothing
 # lands in node_modules/.bin. Resolve the fixed install path directly. The
@@ -663,8 +665,14 @@ export function removeShim(agent: AgentId): boolean {
  *        hardcoded node_modules/.bin, which never exists for these three and
  *        made every versioned alias (the path `agents teams` pins to) fail
  *        with "<agent>@<version> not installed". Also emit GROK_HOME.
+ *   v9 — kimi was wrong in v8: it npm-installs @moonshot-ai/kimi-code into
+ *        node_modules/.bin/kimi (grok/droid ship native binaries elsewhere,
+ *        kimi does not). The ~/.kimi-code/bin path never existed for an npm
+ *        install and the `command -v kimi` fallback resolved to this alias's
+ *        sibling dispatcher shim, re-exec-looping forever. Resolve kimi via the
+ *        generic node_modules/.bin branch.
  */
-export const VERSIONED_ALIAS_SCHEMA_VERSION = 8;
+export const VERSIONED_ALIAS_SCHEMA_VERSION = 9;
 
 /** Internal marker string used to embed the schema version in versioned alias scripts. */
 const VERSIONED_ALIAS_VERSION_MARKER = 'agents-versioned-alias-version:';
@@ -728,12 +736,16 @@ export KIMI_CODE_HOME="$HOME/.agents/.history/versions/${agent}/${version}/home/
   const launchArgs = agent === 'codex' ? ' -c check_for_update_on_startup=false' : '';
 
   // Resolve the binary the same way the main shim does (see generateShimScript).
-  // Grok, Kimi, and Droid do NOT ship into node_modules/.bin — Grok downloads a
-  // native binary to ~/.grok/downloads, Kimi to ~/.kimi-code/bin, and Droid
-  // (Factory AI) installs a standalone binary to ~/.local/bin. Hardcoding the
-  // node_modules path made every versioned alias for these three fail with
-  // "<agent>@<version> not installed", which is exactly the path `agents teams`
-  // takes once it pins a teammate's version.
+  // Grok and Droid do NOT ship into node_modules/.bin — Grok downloads a native
+  // binary to ~/.grok/downloads and Droid (Factory AI) installs a standalone
+  // binary to ~/.local/bin. Hardcoding the node_modules path made every
+  // versioned alias for those two fail with "<agent>@<version> not installed",
+  // which is exactly the path `agents teams` takes once it pins a teammate's
+  // version. Kimi is NOT one of them: `agents add kimi` npm-installs
+  // @moonshot-ai/kimi-code so its binary is at node_modules/.bin/kimi (the
+  // generic branch below). The old ~/.kimi-code/bin path never exists for an
+  // npm install and fell back to `command -v kimi`, which resolves to this
+  // alias's sibling dispatcher shim and re-execs forever.
   // This template is unix-only — on Windows the .cmd companion delegates to
   // "agents __shim" which resolves via getBinaryPath() instead.
   const versionDir = `$HOME/.agents/.history/versions/${agent}/${version}`;
@@ -747,15 +759,7 @@ if [ -d "$GROK_DOWNLOADS" ]; then
   [ -n "$BINARY" ] || BINARY=$(ls "$GROK_DOWNLOADS"/grok-* 2>/dev/null | head -1)
 fi
 [ -n "$BINARY" ] && [ -x "$BINARY" ] || BINARY=$(command -v grok 2>/dev/null || echo "")`
-      : agent === 'kimi'
-        ? `# Kimi ships its binary in ~/.kimi-code/bin, not node_modules.
-KIMI_BINARY="$HOME/.kimi-code/bin/kimi"
-if [ -x "$KIMI_BINARY" ]; then
-  BINARY="$KIMI_BINARY"
-else
-  BINARY=$(command -v kimi 2>/dev/null || echo "")
-fi`
-        : agent === 'droid'
+      : agent === 'droid'
           ? `# Droid (Factory AI) installs a standalone native binary at ~/.local/bin/droid;
 # there is no npm package and nothing lands in node_modules/.bin. The PATH
 # fallback refuses anything under our shims dir to avoid an infinite re-exec.

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -235,7 +235,9 @@ async function promptConflictStrategy(
 //        node_modules/.bin/kimi, so resolve it via the generic branch. The old
 //        ~/.kimi-code/bin special-case never existed for npm installs and
 //        re-exec-looped through `command -v kimi` (the dispatcher itself).
-export const SHIM_SCHEMA_VERSION = 20;
+// v21 — guard grok's `command -v grok` fallback against resolving to our own
+//        shims dir (same infinite re-exec loop), mirroring droid.
+export const SHIM_SCHEMA_VERSION = 21;
 
 /** Internal marker string used to embed the schema version in shim scripts. */
 const SHIM_VERSION_MARKER = 'agents-shim-version:';
@@ -440,8 +442,16 @@ if [ "$AGENT" = "grok" ]; then
     fi
   fi
   if [ -z "$BINARY" ] || [ ! -x "$BINARY" ]; then
-    # Last resort: whatever is on PATH (user may have installed grok globally)
+    # Last resort: whatever is on PATH (user may have installed grok globally).
+    # Refuse anything under our own shims dir: the shims dir sits ahead of
+    # ~/.local/bin on PATH, so "command -v grok" resolves to THIS dispatcher.
+    # exec-ing it would re-enter and spin in an infinite re-exec loop (the same
+    # bug the droid branch below guards against). Fall through to the clean
+    # "not installed" error instead.
     BINARY=$(command -v grok 2>/dev/null || echo "")
+    case "$BINARY" in
+      "$AGENTS_USER_DIR/.cache/shims/"*) BINARY="" ;;
+    esac
   fi
 # Kimi is a normal npm agent: "agents add kimi" npm-installs
 # @moonshot-ai/kimi-code into the version dir and the binary lands at
@@ -671,8 +681,10 @@ export function removeShim(agent: AgentId): boolean {
  *        install and the `command -v kimi` fallback resolved to this alias's
  *        sibling dispatcher shim, re-exec-looping forever. Resolve kimi via the
  *        generic node_modules/.bin branch.
+ *  v10 — guard grok's `command -v grok` fallback against resolving to our own
+ *        shims dir (same infinite re-exec loop), mirroring droid.
  */
-export const VERSIONED_ALIAS_SCHEMA_VERSION = 9;
+export const VERSIONED_ALIAS_SCHEMA_VERSION = 10;
 
 /** Internal marker string used to embed the schema version in versioned alias scripts. */
 const VERSIONED_ALIAS_VERSION_MARKER = 'agents-versioned-alias-version:';
@@ -758,7 +770,15 @@ if [ -d "$GROK_DOWNLOADS" ]; then
   BINARY=$(ls "$GROK_DOWNLOADS"/grok-* 2>/dev/null | grep -i "${version}" | head -1)
   [ -n "$BINARY" ] || BINARY=$(ls "$GROK_DOWNLOADS"/grok-* 2>/dev/null | head -1)
 fi
-[ -n "$BINARY" ] && [ -x "$BINARY" ] || BINARY=$(command -v grok 2>/dev/null || echo "")`
+# Refuse a PATH match under our own shims dir — it resolves to this alias's
+# sibling dispatcher shim (shims dir is ahead of ~/.local/bin on PATH) and
+# re-execs forever. Fall through to the clean "not installed" error instead.
+if [ -z "$BINARY" ] || [ ! -x "$BINARY" ]; then
+  BINARY=$(command -v grok 2>/dev/null || echo "")
+  case "$BINARY" in
+    "$HOME/.agents/.cache/shims/"*) BINARY="" ;;
+  esac
+fi`
       : agent === 'droid'
           ? `# Droid (Factory AI) installs a standalone native binary at ~/.local/bin/droid;
 # there is no npm package and nothing lands in node_modules/.bin. The PATH


### PR DESCRIPTION
## Problem

`ag run kimi` hangs forever. It execs the versioned alias `kimi@0.19.2 --plan`, which spins in an infinite re-exec loop. The same bug class also affects **grok**.

**Root cause:** the shim generator special-cases grok/kimi/droid to resolve a binary *outside* node_modules, with a `command -v <cli>` fallback. When the hardcoded path is empty, `command -v` resolves to the dispatcher shim itself (the shims dir sits ahead of `~/.local/bin` on `PATH`) → `exec` re-enters the shim → loops forever. Only **droid** had the anti-loop guard.

- **kimi** was mis-classified: it is a normal npm agent. `agents add kimi` runs `npm install @moonshot-ai/kimi-code` (`versions.ts:1104,1232`) → binary at `node_modules/.bin/kimi`. `getBinaryPath` (`versions.ts:912`) and `models.ts:251` already resolve there; only the shim looked at the non-existent `~/.kimi-code/bin/kimi` and then looped.
- **grok**'s `command -v grok` fallback had no guard, so an empty `~/.grok/downloads` produces the identical hang.

## Fix

- **kimi:** dropped from the grok/droid special-case in both generators → uses the generic `node_modules/.bin/<cli>` branch (matching `getBinaryPath`). `KIMI_CODE_HOME` isolation unchanged.
- **grok:** added the shims-dir anti-loop guard to both generators, mirroring droid → a missing grok binary now yields a clean `grok@<v> not installed` error instead of hanging.
- **Auto-heal:** bumped `SHIM_SCHEMA_VERSION` 19→21 and `VERSIONED_ALIAS_SCHEMA_VERSION` 8→10 so existing broken shims regenerate on the next interactive `agents` call, `agents view`, or `agents sync`.
- **Cross-platform:** Windows was already correct (`__shim` → `getBinaryPath` → `node_modules/.bin/kimi`); this aligns unix with it.

## Not fixed here (flagged for follow-up)

The grok shim resolves the binary from the **global** `~/.grok/downloads` while `getBinaryPath` (`versions.ts:888`) and the exported `GROK_HOME` use the **per-version** dir — they can disagree. Left for a separate change since it needs a working grok install to verify end-to-end.

## Verification

- `vitest run` full suite: **3563 passed, 0 failed**. Inverted the test that pinned the buggy kimi behavior; added grok anti-loop guard regression tests (both generators).
- **kimi E2E:** regenerated the real shims and ran `kimi@0.19.2 --plan` (the exact failing path) — launched the real Kimi Code TUI in plan mode, exit 0, instead of hanging. Also verified live on my machine: `ag run kimi` now launches.
- **grok E2E:** with `command -v grok` pointed at the shim itself, both the dispatcher and the alias exit `rc=1` "not installed" instead of hanging (`rc=124`).