### PR TITLE
fix(browser): stop --profile actually kills the remote browser (#559 completion)

### DIFF
--- a/src/lib/browser/service.test.ts
+++ b/src/lib/browser/service.test.ts
@@ -481,3 +481,42 @@ describe('recordStop ffmpeg exit handling (#560)', () => {
     }
   });
 });
+
+describe('BrowserService.stopProfile — composite-key cleanup (#559)', () => {
+  it('cleans up a connection stored under the composite `<profile>@<endpoint>` when called with the bare profile name', async () => {
+    writeProfile('winmini', ['ssh://muqsit@win-mini?port=9222&os=windows'], 'edge');
+    const service = new BrowserService();
+
+    const cleanup = vi.fn();
+    const fakeConn = {
+      cdp: { close: vi.fn() },
+      pid: 2_000_000_000, // non-existent → killChrome's process.kill throws ESRCH (caught)
+      cleanup,
+      tasks: new Map(),
+      sessionCache: new Map(),
+    };
+    // start() keys the map on the composite, not the bare name.
+    const conns = (service as unknown as { connections: Map<string, unknown> }).connections;
+    conns.set('winmini@win-mini', fakeConn);
+
+    await service.stopProfile('winmini');
+
+    // Before the fix, get('winmini') missed the composite key and cleanup never ran.
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(fakeConn.cdp.close).toHaveBeenCalledTimes(1);
+    expect(conns.has('winmini@win-mini')).toBe(false);
+  });
+
+  it('does not touch a different profile that happens to share a name prefix', async () => {
+    const service = new BrowserService();
+    const conns = (service as unknown as { connections: Map<string, unknown> }).connections;
+    const otherCleanup = vi.fn();
+    conns.set('winmini2@ep', { cdp: { close: vi.fn() }, pid: 2_000_000_000, cleanup: otherCleanup, tasks: new Map() });
+
+    await service.stopProfile('winmini');
+
+    // "winmini2@ep" must NOT match the "winmini" stop (prefix must be `winmini@`).
+    expect(otherCleanup).not.toHaveBeenCalled();
+    expect(conns.has('winmini2@ep')).toBe(true);
+  });
+});

--- a/src/lib/browser/service.ts
+++ b/src/lib/browser/service.ts
@@ -502,12 +502,24 @@ export class BrowserService {
   }
 
   async stopProfile(profileName: string): Promise<void> {
-    const conn = this.connections.get(profileName);
-    if (conn) {
+    // Connections are keyed by the composite `<profile>@<endpoint>` (see start()),
+    // but callers pass the bare profile name (or, occasionally, an exact composite).
+    // A plain `connections.get(profileName)` therefore missed every real remote
+    // connection, so `cleanup()` never ran — leaving the SSH tunnel and, on
+    // Windows, the WMI-spawned browser orphaned on the remote host after every
+    // `browser stop --profile` (#559). Match the exact key AND every
+    // `<profileName>@<endpoint>` composite so all of a profile's live connections
+    // are torn down.
+    const keys = [...this.connections.keys()].filter(
+      (k) => k === profileName || k.startsWith(`${profileName}@`)
+    );
+    for (const key of keys) {
+      const conn = this.connections.get(key);
+      if (!conn) continue;
       conn.cdp.close();
       killChrome(conn.pid);
       conn.cleanup?.();
-      this.connections.delete(profileName);
+      this.connections.delete(key);
     }
 
     const runtimeDir = getProfileRuntimeDir(profileName);


### PR DESCRIPTION
Completes #559. #567 wired `killRemoteBrowser` into `connectSSH.cleanup()`, but hardware testing on win-mini showed the remote Edge is **still orphaned** after `browser stop --profile` (CDP port 9222 keeps a listener).

## Root cause
`start()` keys the connection map on the **composite** `<profile>@<endpoint>` (`service.ts:323,383`), but `stopProfile(profileName)` looked it up by the **bare** name (`service.ts:505` `this.connections.get(profileName)`). For any real remote profile the `get` returned `undefined`, so `if (conn)` was false and `cleanup()` — where `killRemoteBrowser` lives — never ran. The kill command itself is correct (verified: running it directly frees port 9222); it was simply never invoked.

## Fix
Match the exact key **and** every `<profileName>@<endpoint>` composite, and clean up each. A prefix-guard test ensures `winmini` does not match `winmini2@ep`.

## Verification
- `tsc` clean; `service.test.ts` 29/29 pass (2 new tests: composite cleanup runs `cleanup()`; sibling-prefix profile is untouched).
- **Hardware-verified on win-mini:** with this fix, remote CDP port 9222 listeners go **1 → 0** after `browser stop --profile` (and stay 0); before the fix they stayed at **1** across repeated polls. (Requires #582 so Edge can launch on Windows.)

Note: `stop --task` intentionally leaves the shared browser alive (only forked connections clean up) — unchanged. This fix is specific to the documented "detach the whole profile" path.