### PR TITLE
fix(hosts): don't self-append the log mirror on a localhost follow

### DIFF
--- a/src/lib/hosts/progress.test.ts
+++ b/src/lib/hosts/progress.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { exitMarker, splitProgressOutput } from './progress.js';
+import { exitMarker, splitProgressOutput, mirrorAliasesSource } from './progress.js';
 
 describe('exitMarker', () => {
   it('embeds the task id so it cannot collide with generic output', () => {
@@ -57,5 +57,23 @@ describe('splitProgressOutput', () => {
     expect(emitted).toBe(exitMarker(id));
     const r = splitProgressOutput(`body${emitted}0`, id);
     expect(r).toEqual({ logChunk: 'body', exit: '0' });
+  });
+});
+
+describe('mirrorAliasesSource', () => {
+  it('flags aliasing when local and remote are the same file (localhost host)', () => {
+    // Same dev:ino → the mirror IS the tailed file → skip the append.
+    expect(mirrorAliasesSource('66306:1234567', '66306:1234567')).toBe(true);
+  });
+
+  it('does not flag distinct files (a genuine remote host)', () => {
+    expect(mirrorAliasesSource('66306:1234567', '2049:9999999')).toBe(false);
+  });
+
+  it('does not flag when either identity is unknown', () => {
+    // Missing local (mirror not created yet) or unstattable remote → keep mirroring.
+    expect(mirrorAliasesSource(null, '2049:9999999')).toBe(false);
+    expect(mirrorAliasesSource('66306:1234567', null)).toBe(false);
+    expect(mirrorAliasesSource(null, null)).toBe(false);
   });
 });

--- a/src/lib/hosts/progress.ts
+++ b/src/lib/hosts/progress.ts
@@ -87,6 +87,30 @@ export function fetchProgress(
   return splitProgressOutput(res.stdout, opts.taskId);
 }
 
+/**
+ * File identity (`dev:ino`) of a path on the remote host, or null if it can't be
+ * stat'd. GNU (`-c`) then BSD (`-f`) format, so it works on Linux and macOS hosts.
+ */
+export function readRemoteFileId(target: string, remotePath: string): string | null {
+  const res = sshExec(
+    target,
+    `stat -c '%d:%i' ${remotePath} 2>/dev/null || stat -f '%d:%i' ${remotePath} 2>/dev/null`,
+    { timeoutMs: 8000 },
+  );
+  const id = res.stdout.trim();
+  return id || null;
+}
+
+/**
+ * True when the local mirror file IS the very file we're tailing — the
+ * localhost-as-host case, where `remoteLog` ($HOME-expanded) and `localLogPath`
+ * resolve to the same inode. Appending our read bytes back into it would feed the
+ * tail and multiply the log, so the caller must skip the mirror write.
+ */
+export function mirrorAliasesSource(localId: string | null, remoteId: string | null): boolean {
+  return localId !== null && remoteId !== null && localId === remoteId;
+}
+
 /** Tail the remote log to stdout until the run finishes; return its exit code. */
 export async function followHostTask(target: string, opts: FollowOptions): Promise<number> {
   const fastMs = opts.pollMs ?? 1500;
@@ -96,10 +120,22 @@ export async function followHostTask(target: string, opts: FollowOptions): Promi
   let offset = 0;
   let waitMs = fastMs;
 
+  // localhost-as-host guard: when the local mirror and the remote log are the
+  // same physical file, appending our read bytes back would feed the tail and
+  // multiply the log (a plain `--host localhost` follow otherwise tripled it).
+  // Detect via file identity and echo-only in that case.
+  let mirror = true;
+  try {
+    const s = fs.statSync(local);
+    if (mirrorAliasesSource(`${s.dev}:${s.ino}`, readRemoteFileId(target, opts.remoteLog))) {
+      mirror = false;
+    }
+  } catch { /* mirror absent or unstattable → distinct file, keep mirroring */ }
+
   const flush = (logChunk: string): boolean => {
     if (!logChunk) return false;
     if (opts.echo) process.stdout.write(logChunk);
-    try { fs.appendFileSync(local, logChunk); } catch { /* best-effort */ }
+    if (mirror) { try { fs.appendFileSync(local, logChunk); } catch { /* best-effort */ } }
     offset += Buffer.byteLength(logChunk, 'utf8');
     return true;
   };


### PR DESCRIPTION
## Bug

`followHostTask` mirrors every fetched log chunk into `localLogPath(taskId)` so `agents hosts logs`/`agents logs` can replay locally. But when the host is **localhost**, that mirror path and the remote log — `$HOME/.agents/.cache/hosts/<id>.log` on both sides — are the **same physical file**. So `flush()` appends the bytes it just read straight back into the file the next `tail` reads, feeding itself.

Deterministic repro (found while verifying #575):

```
size BEFORE follow: 110 bytes, PONG x1
run: agents logs <id> -f
size AFTER  follow: 330 bytes, PONG x3   <-- log tripled + echoed 3x
```

Pre-existing in `followHostTask` (not introduced by #575) — `agents hosts logs -f` had it too. It corrupts the on-disk log and triple-prints the follow output.

## Fix

Detect the aliasing once at follow start via **file identity** — compare the local mirror's `dev:ino` (`fs.statSync`) to the remote file's `dev:ino` (`stat -c '%d:%i'` with a BSD `stat -f` fallback for macOS hosts). When they match, skip the mirror append and echo only.

Genuine remote hosts are unaffected:
- fresh follow → the local mirror doesn't exist yet → `statSync` throws → mirror stays on;
- reconnect → the local mirror is a distinct file with a different `dev:ino` → mirror stays on.

The SSH `stat` only runs when the local mirror already exists (i.e. the localhost case), so the common remote path adds zero round-trips.

## Verified

Same repro after the fix — log stays **110 bytes / PONG ×1** across two consecutive `agents logs -f`, and each follow still echoes `PONG` exactly once:

```
size BEFORE follow: 110 bytes, PONG x1
follow#1 printed PONG x1
follow#2 printed PONG x1
size AFTER two follows: 110 bytes, PONG x1
```

Tests: `src/lib/hosts/progress.test.ts` gains `mirrorAliasesSource` cases (same-file → skip, distinct → mirror, unknown identity → mirror). `tsc` clean, 11/11 pass.

## Not in scope (separate follow-up)

`offset` is advanced by `Buffer.byteLength(logChunk, 'utf8')` on the decoded string; a multibyte UTF-8 char split at a `tail -c` byte boundary decodes to U+FFFD and drifts the offset. Real but only bites non-ASCII output landing on a poll boundary; a byte-accurate fetch is a deeper change left for its own PR.
