### PR TITLE
fix(hosts): byte-accurate offset in the host-follow log tailer

### DIFF
--- a/src/lib/hosts/progress.test.ts
+++ b/src/lib/hosts/progress.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { exitMarker, splitProgressOutput, mirrorAliasesSource } from './progress.js';
+import { exitMarker, splitProgressBytes, mirrorAliasesSource } from './progress.js';
 
 describe('exitMarker', () => {
   it('embeds the task id so it cannot collide with generic output', () => {
@@ -7,56 +7,66 @@ describe('exitMarker', () => {
   });
 });
 
-describe('splitProgressOutput', () => {
+describe('splitProgressBytes', () => {
   const id = 'a1b2c3d4';
   const M = exitMarker(id);
+  const buf = (s: string): Buffer => Buffer.from(s, 'utf8');
 
   it('splits log bytes from the exit code in a single combined fetch', () => {
-    const out = `hello world${M}0`;
-    expect(splitProgressOutput(out, id)).toEqual({ logChunk: 'hello world', exit: '0' });
+    const r = splitProgressBytes(buf(`hello world${M}0`), id)!;
+    expect(r.logChunk.toString('utf8')).toBe('hello world');
+    expect(r.exit.toString('utf8')).toBe('0');
+    expect(r.consumed).toBe(11); // 'hello world'
   });
 
   it('returns an empty exit while the job is still running', () => {
-    const out = `some streamed output${M}`;
-    expect(splitProgressOutput(out, id)).toEqual({ logChunk: 'some streamed output', exit: '' });
+    const r = splitProgressBytes(buf(`some streamed output${M}`), id)!;
+    expect(r.logChunk.toString('utf8')).toBe('some streamed output');
+    expect(r.exit.toString('utf8')).toBe('');
   });
 
   it('reports an empty log chunk when there is no new output', () => {
-    const out = `${M}`;
-    expect(splitProgressOutput(out, id)).toEqual({ logChunk: '', exit: '' });
+    const r = splitProgressBytes(buf(`${M}`), id)!;
+    expect(r.logChunk.length).toBe(0);
+    expect(r.consumed).toBe(0);
+    expect(r.exit.toString('utf8')).toBe('');
   });
 
   it('returns null when the marker is absent (transient fetch miss)', () => {
-    expect(splitProgressOutput('partial ssh output', id)).toBeNull();
-    expect(splitProgressOutput('', id)).toBeNull();
+    expect(splitProgressBytes(buf('partial ssh output'), id)).toBeNull();
+    expect(splitProgressBytes(buf(''), id)).toBeNull();
   });
 
   it('splits on the LAST marker so a token echoed in the log cannot spoof the boundary', () => {
-    // The agent's own output literally contained the sentinel; the real
-    // trailing marker must still win, keeping the echoed copy inside the log.
     const echoed = `agent printed ${M} in its output`;
-    const out = `${echoed}${M}137`;
-    const r = splitProgressOutput(out, id);
-    expect(r).not.toBeNull();
-    expect(r!.exit).toBe('137');
-    expect(r!.logChunk).toBe(echoed);
+    const r = splitProgressBytes(buf(`${echoed}${M}137`), id)!;
+    expect(r.exit.toString('utf8')).toBe('137');
+    expect(r.logChunk.toString('utf8')).toBe(echoed);
   });
 
   it('is scoped per task id — another run’s marker is not treated as ours', () => {
     const other = exitMarker('ffffffff');
-    const out = `log body${other}0`;
-    expect(splitProgressOutput(out, id)).toBeNull();
+    expect(splitProgressBytes(buf(`log body${other}0`), id)).toBeNull();
   });
 
-  it('the printf-emitted sentinel round-trips through the parser (no desync)', () => {
-    // fetchProgress builds the remote printf format by escaping exitMarker's
-    // newlines; when the shell interprets those escapes it must reproduce the
-    // exact marker the parser splits on. Simulate that here.
-    const printfArg = exitMarker(id).replace(/\n/g, '\\n');
-    const emitted = printfArg.replace(/\\n/g, '\n'); // what `printf` writes out
-    expect(emitted).toBe(exitMarker(id));
-    const r = splitProgressOutput(`body${emitted}0`, id);
-    expect(r).toEqual({ logChunk: 'body', exit: '0' });
+  // The load-bearing cases: byte-exact counting across a multibyte character.
+  it('counts exact wire bytes when a multibyte char precedes the marker', () => {
+    // 'héllo' is 6 UTF-8 bytes (é = 2); a string split would report 5 chars.
+    const r = splitProgressBytes(buf(`héllo${M}0`), id)!;
+    expect(r.consumed).toBe(6);
+    expect(r.logChunk.length).toBe(6);
+    expect(r.logChunk.toString('utf8')).toBe('héllo');
+  });
+
+  it('counts a multibyte char truncated at the buffer end by its raw bytes', () => {
+    // 'café' = 5 bytes; drop the last byte so 'é' is split mid-character. The
+    // next poll must resume exactly 4 bytes on — not skip/re-read — so consumed
+    // MUST be 4, which a re-encoded U+FFFD (3 bytes) string count would get wrong.
+    const half = buf('café').subarray(0, 4);
+    const combined = Buffer.concat([half, Buffer.from(M, 'utf8')]);
+    const r = splitProgressBytes(combined, id)!;
+    expect(r.consumed).toBe(4);
+    expect(r.logChunk.length).toBe(4);
   });
 });
 

--- a/src/lib/hosts/progress.ts
+++ b/src/lib/hosts/progress.ts
@@ -15,7 +15,7 @@
  */
 
 import * as fs from 'fs';
-import { sshExec } from '../ssh-exec.js';
+import { sshExec, sshExecRaw } from '../ssh-exec.js';
 import { localLogPath } from './tasks.js';
 
 function sleep(ms: number): Promise<void> {
@@ -49,17 +49,31 @@ export function exitMarker(taskId: string): string {
 }
 
 /**
- * Split a combined fetch (`<log bytes><marker><exit>`) back into its parts.
- * Splits on the LAST marker occurrence, so even if the agent's own output
- * happened to echo the token, the real trailing sentinel still wins. Returns
- * null when the marker is absent (a transient fetch miss — the remote shell
- * never ran our printf), telling the caller to retry without advancing.
+ * Split a combined fetch (`<log bytes><marker><exit>`) back into its parts at the
+ * BYTE level. Splits on the LAST marker occurrence, so even if the agent's own
+ * output happened to echo the token, the real trailing sentinel still wins.
+ * Returns null when the marker is absent (a transient fetch miss — the remote
+ * shell never ran our printf), telling the caller to retry without advancing.
+ *
+ * Byte-level (not string) is load-bearing: `logChunk.length` is the EXACT number
+ * of log bytes consumed on the wire, which the follow loop adds to its offset. A
+ * string split would first UTF-8-decode, turning any multibyte char split at the
+ * `tail -c` boundary into a U+FFFD whose re-encoded length ≠ the wire bytes,
+ * drifting the offset (see followHostTask). `consumed` is returned explicitly for
+ * clarity; it always equals `logChunk.length`.
  */
-export function splitProgressOutput(stdout: string, taskId: string): { logChunk: string; exit: string } | null {
-  const marker = exitMarker(taskId);
-  const idx = stdout.lastIndexOf(marker);
+export function splitProgressBytes(
+  buf: Buffer,
+  taskId: string,
+): { logChunk: Buffer; exit: Buffer; consumed: number } | null {
+  const marker = Buffer.from(exitMarker(taskId), 'utf8'); // ASCII-only, unambiguous
+  const idx = buf.lastIndexOf(marker);
   if (idx === -1) return null;
-  return { logChunk: stdout.slice(0, idx), exit: stdout.slice(idx + marker.length) };
+  return {
+    logChunk: buf.subarray(0, idx),
+    exit: buf.subarray(idx + marker.length),
+    consumed: idx,
+  };
 }
 
 /**
@@ -73,7 +87,7 @@ export function splitProgressOutput(stdout: string, taskId: string): { logChunk:
 export function fetchProgress(
   target: string,
   opts: { remoteLog: string; remoteExit: string; taskId: string; offset: number },
-): { logChunk: string; exit: string } | null {
+): { logChunk: Buffer; exit: string } | null {
   // Derive the printf format from the SAME exitMarker the parser splits on, so
   // the emitted sentinel and the one we look for can never desync. The marker's
   // only escape-sensitive bytes are its newlines (→ `\n`); it carries no `%`,
@@ -83,8 +97,14 @@ export function fetchProgress(
     `tail -c +${opts.offset + 1} ${opts.remoteLog} 2>/dev/null; ` +
     `printf '${printfArg}'; ` +
     `cat ${opts.remoteExit} 2>/dev/null`;
-  const res = sshExec(target, remote, { timeoutMs: 20000 });
-  return splitProgressOutput(res.stdout, opts.taskId);
+  // Raw bytes (no UTF-8 decode): the log tail must be counted and re-emitted
+  // byte-for-byte so a multibyte char split at the `tail -c` boundary neither
+  // drifts the offset nor renders as U+FFFD. The exit code is pure ASCII → safe
+  // to decode to a string for the caller's `.trim()`.
+  const res = sshExecRaw(target, remote, { timeoutMs: 20000 });
+  const parts = splitProgressBytes(res.stdout, opts.taskId);
+  if (!parts) return null;
+  return { logChunk: parts.logChunk, exit: parts.exit.toString('utf8') };
 }
 
 /**
@@ -132,11 +152,11 @@ export async function followHostTask(target: string, opts: FollowOptions): Promi
     }
   } catch { /* mirror absent or unstattable → distinct file, keep mirroring */ }
 
-  const flush = (logChunk: string): boolean => {
-    if (!logChunk) return false;
+  const flush = (logChunk: Buffer): boolean => {
+    if (logChunk.length === 0) return false;
     if (opts.echo) process.stdout.write(logChunk);
     if (mirror) { try { fs.appendFileSync(local, logChunk); } catch { /* best-effort */ } }
-    offset += Buffer.byteLength(logChunk, 'utf8');
+    offset += logChunk.length; // exact wire bytes — no re-encode drift
     return true;
   };
 

--- a/src/lib/ssh-exec.ts
+++ b/src/lib/ssh-exec.ts
@@ -138,6 +138,39 @@ export function sshExec(target: string, remoteCmd: string, opts: SshExecOptions 
   };
 }
 
+export interface SshExecRawResult {
+  code: number | null;
+  stdout: Buffer;
+  stderr: Buffer;
+  timedOut: boolean;
+}
+
+/**
+ * Like {@link sshExec} but returns raw stdout/stderr Buffers — no UTF-8 decode.
+ *
+ * Use when byte-exactness matters, e.g. offset-tracked log tailing: a multibyte
+ * character split across a read boundary must stay raw bytes, not collapse to a
+ * U+FFFD replacement char (which would desync a byte offset from the wire).
+ */
+export function sshExecRaw(target: string, remoteCmd: string, opts: SshExecOptions = {}): SshExecRawResult {
+  assertValidSshTarget(target);
+  const mux = opts.multiplex === false ? [] : controlOpts();
+  const args = [...SSH_OPTS, ...mux, ...(opts.extraSshArgs ?? []), target, remoteCmd];
+  const res = spawnSync('ssh', args, {
+    input: opts.input,
+    // No `encoding` → spawnSync returns Buffers.
+    timeout: opts.timeoutMs,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const timedOut = !!(res.error && (res.error as NodeJS.ErrnoException).code === 'ETIMEDOUT');
+  return {
+    code: typeof res.status === 'number' ? res.status : null,
+    stdout: (res.stdout as Buffer | null) ?? Buffer.alloc(0),
+    stderr: (res.stderr as Buffer | null) ?? Buffer.alloc(0),
+    timedOut,
+  };
+}
+
 /** True if `target` is reachable over ssh (a passwordless `true` succeeds quickly). */
 export function sshReachable(target: string, timeoutMs = 10000): boolean {
   return sshExec(target, 'true', { timeoutMs, multiplex: true }).code === 0;


### PR DESCRIPTION
## Bug

`followHostTask` tails a remote log by tracking a **wire byte** `offset` (`tail -c +<offset+1>`), but advanced it with `offset += Buffer.byteLength(logChunk, 'utf8')` on a `logChunk` that `sshExec` had **already UTF-8-decoded** (`spawnSync … encoding: 'utf-8'`).

When a multibyte UTF-8 character straddles the `tail -c` read boundary, its partial bytes decode to U+FFFD (`` — 3 bytes when re-encoded). So `Buffer.byteLength(decoded)` no longer equals the bytes actually consumed on the wire, and `offset` **drifts** — the next poll skips or re-reads bytes, corrupting the streamed log for any non-ASCII output landing on a poll boundary.

Flagged during #586's review as the separate latent issue.

## Fix

Make the tail byte-exact end-to-end:

- **`sshExecRaw`** (`ssh-exec.ts`) — sibling of `sshExec` that returns raw `Buffer` stdout/stderr (no lossy decode). Zero blast radius: existing string callers untouched.
- **`splitProgressBytes`** (`progress.ts`) — byte-level counterpart of the old `splitProgressOutput`, splitting the `<log><marker><exit>` buffer with `Buffer.lastIndexOf` (marker is ASCII → unambiguous) and returning `logChunk`/`exit` as Buffers plus `consumed` (exact log byte count).
- **`fetchProgress`** returns a `Buffer` logChunk (exit decoded to string — it's ASCII); **`flush`** takes a Buffer, writes it directly to stdout/mirror, and does `offset += logChunk.length` (exact wire bytes).

Writing the raw Buffer also fixes *display*: a char split across two polls streams as its raw bytes in two pieces and the terminal/file reassembles it — instead of each half becoming U+FFFD.

## Verified

- Unit (`progress.test.ts`, 12 pass): `splitProgressBytes` counts `héllo` as **6** bytes (not 5 chars), and a `café` buffer truncated mid-`é` as **4** bytes (not a 3-byte U+FFFD re-encode) — the exact drift the old code got wrong.
- E2E: followed a real localhost run whose reply was `café_日本語_PONG` — it streamed through `agents logs -f` **intact** (no mojibake), and the log stayed byte-stable (126B, #586 mirror guard preserved).
- `tsc` clean.

Preserves the "split on the LAST marker" anti-spoof property (`Buffer.lastIndexOf`) and the per-task scoping.
