### PR TITLE
docs(logs): document agents logs + host-follow surface (docs & skills)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+**`agents logs`: a top-level, unified run-log viewer (#575)**
+
+- Viewing a dispatched run's output used to be nested and undiscoverable — only `agents hosts logs <id>` and `agents daemon logs` existed, and `agents hosts` wasn't even in `--help`. `agents logs [id]` is now a discoverable top-level command that resolves a run across **two substrates** — host-dispatch task stdout (`agents run --host`) and the local session index — and shows or (`-f`) follows it. `[id]`/`--session` load directly (host task tried first, then session); with no id, `--host`/`--agent`/`--version` filter a merged candidate list (one match shows, several open a fuzzy picker, non-TTY prints the list). Additive: `agents hosts logs` and `agents sessions tail` are unchanged and share the same helpers. Source: `src/commands/logs.ts`, `src/lib/hosts/logs.ts`.
+
+**Host-follow log tailer: no self-corruption on localhost, byte-accurate offsets (#586, #589)**
+
+- Following a run dispatched to **localhost** tripled the on-disk log and triple-printed the output, because the local mirror file and the remote log were the same file and the tailer appended its own reads back into it; it now detects that aliasing by file identity (`dev:ino`) and echoes only. Separately, the offset tracker advanced by a re-encoded string length, so a multibyte UTF-8 char split at a poll boundary drifted the offset and corrupted the stream on non-ASCII output; the tail is now byte-exact (raw `Buffer` via `sshExecRaw`). Source: `src/lib/hosts/progress.ts`, `src/lib/ssh-exec.ts`.
+
 **`agents upgrade`: the "What's new" changelog is now a compact heading list (#562)**
 
 - The post-upgrade changelog dumped every heading *and* every verbose sub-bullet for each version in the range — a screenful across a multi-version jump. It now prints one bullet per feature/fix heading and links to the full CHANGELOG for the details. The parser was extracted to a pure, unit-tested `renderWhatsNew` so it can be exercised without the CLI's import-time side effects. Source: `src/lib/whats-new.ts`, `src/index.ts`.

--- a/README.md
+++ b/README.md
@@ -240,7 +240,9 @@ agents hosts add gpu-box
 agents hosts check gpu-box              # reachable? which agents-cli version?
 
 # Run there instead of locally
-agents run claude --host gpu-box "profile this build"
+agents run claude --host gpu-box "profile this build"   # follows live by default
+agents logs --host gpu-box              # pick a dispatched run and view its log
+agents logs <id> -f                     # re-attach to a running one and follow
 agents view claude --host gpu-box       # inspect the remote install
 agents sync --host gpu-box              # make the remote machine current
 

--- a/docs/05-sessions.md
+++ b/docs/05-sessions.md
@@ -205,6 +205,7 @@ rescan so every existing session is re-priced.
 
 ## Related
 
+- `agents logs [id]` — one viewer over both a run's log **and** its session transcript: resolves a host-dispatch task (`agents run --host`) or a session by id/`--session`, filters by `--host`/`--agent`/`--version`, and `-f` follows a live one (a session tail is `agents sessions tail` under the hood, claude/codex only). See [Hosts](hosts.md).
 - `agents sessions <id> --artifacts` — list files created/modified in a session
 - `agents teams status` — session state for team-coordinated runs
 - `agents cloud logs <id>` — for remote cloud dispatches (different subsystem)

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ How agents-cli is laid out on disk and how it decides what to load.
 |---|---|
 | [Teams](teams.md) | Multi-agent DAG teams, boundary contracts, `--watch` supervisor, `--worktree` isolation, `--cloud` dispatch. |
 | [Cloud](cloud.md) | Unified dispatch across Rush Cloud / Codex Cloud / Factory. Multi-repo tasks, balanced routing, SSE streaming. |
+| [Hosts](hosts.md) | Offload `agents run` to your own machines over SSH (`--host`); track with `agents hosts ps` and view/follow with `agents logs`. |
 | [Routines](03-routines.md) | Cron-scheduled agent runs with sandboxed permissions and a long-running daemon. |
 
 ## Extensibility

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -209,9 +209,17 @@ agents run <agent> "<task>" --on <host>
   │     durable log. Offset-tracked reads (like session/active.ts), parsed
   │     by the existing per-agent parsers (session/parse.ts).
   │
-  └─ track in the cloud store (a `host` provider) so                       [Phase 1.5]
-        agents cloud list / status / logs see host runs
+  └─ track in a local host-task store (src/lib/hosts/tasks.ts) so          [shipped]
+        agents hosts ps / agents hosts logs <id> — and the top-level
+        agents logs [id] [-f] — list and follow host runs
 ```
+
+> Shipped surface: dispatch is `agents run <agent> "<task>" --host <name>` (follows
+> live by default; `--no-follow` detaches). Track with `agents hosts ps`; view or
+> `-f` follow a run's log with `agents hosts logs <id>` or the unified
+> `agents logs [id]` (which also resolves session transcripts). Host runs are
+> tracked in a **local** task store, not `agents cloud` (a separate subsystem for
+> Rush/Codex/Factory backends).
 
 ### Host sources — owned (registered) + leased on demand (crabbox)
 

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -193,7 +193,7 @@ is a fast-follow `HostProvider`, opt-in when logged in — not a v1 dependency.
 ## Architecture
 
 ```
-agents run <agent> "<task>" --on <host>
+agents run <agent> "<task>" --host <host>
   │
   ├─ resolveHost(name)         registry lookup in agents.yaml → {address,user,caps} [Phase 1]
   │

--- a/skills/devices/SKILL.md
+++ b/skills/devices/SKILL.md
@@ -2,7 +2,7 @@
 name: devices
 description: "Register and connect to your machines over Tailscale SSH with agents-cli. Use this skill to sync devices from the tailnet, list them, open a shell on another machine, or see agent sessions running across your whole fleet."
 argument-hint: "[sync|list|show|add|set|ssh]"
-allowed-tools: Bash(agents devices*), Bash(agents ssh*), Bash(agents sessions*)
+allowed-tools: Bash(agents devices*), Bash(agents ssh*), Bash(agents sessions*), Bash(agents run*), Bash(agents hosts*), Bash(agents logs*)
 user-invocable: true
 ---
 
@@ -85,6 +85,24 @@ agents sessions --active --json    # merged, machine-tagged, for scripts
 
 Unreachable or CLI-less hosts are skipped with a note, never fatal. If no
 devices are registered, it prints a tip pointing you at `agents devices sync`.
+
+## Dispatch a run to a machine
+
+Offload `agents run` itself to a registered host over SSH — it follows live by
+default; `--no-follow` detaches and returns immediately.
+
+```bash
+agents run claude "profile this build" --host gpu-box   # run there, follow live
+agents run claude "..." --host gpu-box --no-follow        # detach
+
+agents hosts ps              # list dispatched runs and their status
+agents logs --host gpu-box   # pick a run on that host and view its log
+agents logs <id> -f          # re-attach to a running one and follow
+```
+
+`agents logs [id]` is the unified viewer — it resolves a host-dispatch run OR a
+local session by id, filters with `--host`/`--agent`/`--version`, and `-f`
+follows a live one. `agents hosts logs <id>` is the host-only equivalent.
 
 ## Tips
 

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -163,6 +163,24 @@ agents run claude "..." --verbose
 
 `--quiet` drops the rotation banner and "Running:" preamble.
 
+## Offload to another machine
+
+`agents run --host <name>` runs the agent on a registered host over SSH instead
+of locally (see the `devices` skill). It follows live by default; `--no-follow`
+detaches and returns immediately.
+
+```bash
+agents run claude "profile this build" --host gpu-box   # follows live
+agents run claude "..." --host gpu-box --no-follow       # detach
+
+agents hosts ps          # list dispatched runs
+agents logs --host gpu-box   # pick one and view its log
+agents logs <id> -f          # re-attach to a running one and follow
+```
+
+`agents logs [id]` is the unified viewer over both host-dispatch runs and local
+session transcripts; `agents hosts logs <id>` is the host-only equivalent.
+
 ## Bounded runs
 
 Kill the agent after a duration. Useful in CI and scheduled jobs.

--- a/skills/sessions/SKILL.md
+++ b/skills/sessions/SKILL.md
@@ -72,6 +72,12 @@ agents sessions --artifact <filename> <session-id>
 # Live-tail a session file (Claude and Codex only)
 agents sessions tail <session-id>
 # Press Ctrl+C to stop
+
+# Or the unified viewer: resolves a session id OR a host-dispatch run (from
+# `agents run --host`), and -f follows either (a session tail here is
+# `sessions tail` under the hood)
+agents logs <id>          # show the transcript / run log
+agents logs <id> -f       # follow a live one
 ```
 
 ## Cost & Duration


### PR DESCRIPTION
Docs + skills for the `agents logs` viewer and the host-dispatch follow surface (follows #575 / #586 / #589).

## Docs
- **CHANGELOG.md** — Unreleased entries for `agents logs` (#575) and the follow-tailer fixes (#586 localhost self-corruption, #589 UTF-8 offset).
- **docs/05-sessions.md** — `agents logs` added to the Related list (unified viewer over a run's log *and* its session transcript).
- **README.md** — `agents logs` in the "Run on your own machines" example.
- **docs/README.md** — index a **Hosts** row under Orchestration (`hosts.md` was previously unlinked).
- **docs/hosts.md** — correct the stale architecture line that said host runs surface via `agents cloud list/status/logs`; the shipped surface is `agents hosts ps` / `agents hosts logs <id>` + the top-level `agents logs`, tracked in a **local** task store (not `agents cloud`).

## Skills
- **skills/run** — new "Offload to another machine" section (`--host`, `--no-follow`, `agents logs`).
- **skills/devices** — new "Dispatch a run to a machine" section; `allowed-tools` extended (`agents run*`, `agents hosts*`, `agents logs*`).
- **skills/sessions** — `agents logs` added alongside `agents sessions tail` in Live Tailing.

Note: these are the **repo** `skills/`. The diverged system copies (`~/.agents/.system/skills/run`, `/sessions`) get the equivalent update in a separate PR to `phnx-labs/.agents-system`.

Docs/markdown only — no code change. `cli-command-sync-spec` still green (38 pass).
