### PR TITLE
fix(hosts): detached-run logs + terminal ps status + docs (#579 RUSH-1360, supersedes #588)

### DIFF
--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -15,9 +15,9 @@ by name from a small local registry, over plain SSH, with no central service to
 run or pay for:
 
 ```
-agents run claude "fix the auth bug"   --on mac-mini
-agents run codex  "port this to rust"  --on spark-0
-agents run droid  "triage the inbox"   --on win-mini
+agents run claude "fix the auth bug"   --host mac-mini
+agents run codex  "port this to rust"  --host spark-0
+agents run droid  "triage the inbox"   --host win-mini
 ```
 
 It sits next to the vendor clouds (`agents cloud run --provider rush|codex|…`),
@@ -193,7 +193,7 @@ is a fast-follow `HostProvider`, opt-in when logged in — not a v1 dependency.
 ## Architecture
 
 ```
-agents run <agent> "<task>" --on <host>
+agents run <agent> "<task>" --host <name>
   │
   ├─ resolveHost(name)         registry lookup in agents.yaml → {address,user,caps} [Phase 1]
   │
@@ -234,12 +234,12 @@ This is the answer to "I need machines but don't own enough": when the laptop is
 starving, lease one.
 
 ```
-agents run claude "big refactor" --on new           # crabbox warmup (default provider) → run → idle-release
-agents run codex  "gpu eval"     --on new:aws        # provider/class selector → EC2 → run
-agents run droid  "triage"       --on mac-mini       # owned, always-on
+agents run claude "big refactor" --host new           # crabbox warmup (default provider) → run → idle-release
+agents run codex  "gpu eval"     --host new:aws       # provider/class selector → EC2 → run
+agents run droid  "triage"       --host mac-mini      # owned, always-on
 ```
 
-`--on new[:<provider/class>]` leases via crabbox, registers the leased box as a
+`--host new[:<provider/class>]` leases via crabbox, registers the leased box as a
 **transient registry entry** (its `crabbox ssh` address), runs headless, and
 releases on idle/TTL — tearing the entry down on release. agents-cli **does not**
 reimplement provisioning — crabbox owns lease lifecycle, cost, and multi-cloud;
@@ -288,6 +288,32 @@ agent routing a GPU eval to a host tagged `gpu`).
 Resolution for an address: `hosts.<name>.address`, else error with the list of
 known names. (No tailnet lookup, no DNS guessing — a name is either registered or
 it isn't.)
+
+#### Tracking dispatched runs
+
+```
+agents run droid "triage the inbox" --host mac-mini          # followed (default)
+agents run droid "triage the inbox" --host mac-mini --no-follow  # detached
+```
+
+`--no-follow` dispatches and returns immediately — the agent keeps running on the
+host. The dispatch prints: `Dispatched to mac-mini. Track: agents hosts ps · Follow: agents hosts logs <id> -f`.
+
+```
+agents hosts ps             # list dispatched runs and their status
+agents hosts ps --json      # machine-readable
+agents hosts logs <id>      # print captured output (fetches from host on demand for detached runs)
+agents hosts logs <id> -f   # stream live output until the run finishes
+```
+
+`agents hosts ps` probes the remote exit file for each `running` task and updates
+its status to `completed`/`failed` when the remote agent has finished — so `ps`
+reflects reality, not a stale dispatch snapshot.
+
+`agents hosts logs <id>` (without `-f`) works for both followed and detached runs:
+if no local log mirror exists, it does a one-shot SSH fetch of the remote log and
+caches it locally for subsequent calls. A running task will also print:
+`Task still running. Follow live: agents hosts logs <id> -f`.
 
 ### 2. Transport — plain SSH (reuse, don't reinvent)
 
@@ -357,7 +383,7 @@ efficiently — like the ssh/remote-browser pattern."
 
 Scheduled fleet dispatch needs **no new machinery**: the routines scheduler
 (`src/lib/daemon.ts`) fires jobs on cron; a job whose command is `agents run …
---on <host>` is a scheduled remote dispatch. Online-gating is the same lazy SSH
+--host <host>` is a scheduled remote dispatch. Online-gating is the same lazy SSH
 probe `ensureHostReady` already does (skip/retry if the one targeted host is
 unreachable) — no fleet poll. (We do **not** turn the scheduler into an RPC
 server — see Non-goals.)
@@ -421,7 +447,7 @@ replicates **that one session** selectively — never the whole tree.
 
 ## Phase 2 — session handoff (the differentiator)
 
-`agents run --resume <session-id> --on <host>` — move a live session, *including
+`agents run --resume <session-id> --host <host>` — move a live session, *including
 uncommitted work*, to another box and continue:
 
 1. **Code**: push/sync the git branch; **`rsync` the working tree** (uncommitted
@@ -495,10 +521,10 @@ just relocates the storm):
   --from-tailscale` can prefill `local` entries.
 - **Driver-agent first.** The primary caller is a conversational driver agent that
   reads the registry metadata (`agents hosts list --json`), picks a host by
-  task/capability, and dispatches (`agents run --on <name> --json`). The VS Code
+  task/capability, and dispatches (`agents run --host <name> --json`). The VS Code
   extension is a second front-end onto the same commands. So Phase 1 prioritizes
-  clean, deterministic, machine-readable `--json` on `hosts list` and `run --on`.
-- **Naming** — `agents hosts` (list/check/add/remove) + `agents run --on <host>`.
+  clean, deterministic, machine-readable `--json` on `hosts list` and `run --host`.
+- **Naming** — `agents hosts` (list/check/add/remove) + `agents run --host <name>` (`--on` is a hidden alias).
   (The singular `agents computer` macOS-accessibility command is unrelated, stays.)
 - **Provider model** — keep named-SSH dispatch as its own clean path; fold *tracked*
   host runs into the existing cloud store as a `host` provider so `agents cloud
@@ -529,7 +555,7 @@ just relocates the storm):
 - **Phase 1 (v1, no Rush)**: the `HostProvider` seam + the **`local`** provider only.
   `agents hosts add/list/check/remove` (registry in `Meta.hosts`; `add` scans SSH
   sources + `checkbox` multi-select enroll, ensures key auth, bootstraps/upgrades
-  agents-cli to match the local version) + `agents run --on <host>` →
+  agents-cli to match the local version) + `agents run --host <host>` →
   `ensureHostReady` (lazy SSH probe + config/agent/branch) → remote `agents run
   --json` → transcript-tailed progress + a `host` row in the cloud store. Verify
   end-to-end against the live peer node `yosemite-s1`, registered from `yosemite-s0`:

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -15,9 +15,9 @@ by name from a small local registry, over plain SSH, with no central service to
 run or pay for:
 
 ```
-agents run claude "fix the auth bug"   --host mac-mini
-agents run codex  "port this to rust"  --host spark-0
-agents run droid  "triage the inbox"   --host win-mini
+agents run claude "fix the auth bug"   --on mac-mini
+agents run codex  "port this to rust"  --on spark-0
+agents run droid  "triage the inbox"   --on win-mini
 ```
 
 It sits next to the vendor clouds (`agents cloud run --provider rush|codex|…`),
@@ -193,7 +193,7 @@ is a fast-follow `HostProvider`, opt-in when logged in — not a v1 dependency.
 ## Architecture
 
 ```
-agents run <agent> "<task>" --host <name>
+agents run <agent> "<task>" --host <host>
   │
   ├─ resolveHost(name)         registry lookup in agents.yaml → {address,user,caps} [Phase 1]
   │
@@ -209,9 +209,17 @@ agents run <agent> "<task>" --host <name>
   │     durable log. Offset-tracked reads (like session/active.ts), parsed
   │     by the existing per-agent parsers (session/parse.ts).
   │
-  └─ track in the cloud store (a `host` provider) so                       [Phase 1.5]
-        agents cloud list / status / logs see host runs
+  └─ track in a local host-task store (src/lib/hosts/tasks.ts) so          [shipped]
+        agents hosts ps / agents hosts logs <id> — and the top-level
+        agents logs [id] [-f] — list and follow host runs
 ```
+
+> Shipped surface: dispatch is `agents run <agent> "<task>" --host <name>` (follows
+> live by default; `--no-follow` detaches). Track with `agents hosts ps`; view or
+> `-f` follow a run's log with `agents hosts logs <id>` or the unified
+> `agents logs [id]` (which also resolves session transcripts). Host runs are
+> tracked in a **local** task store, not `agents cloud` (a separate subsystem for
+> Rush/Codex/Factory backends).
 
 ### Host sources — owned (registered) + leased on demand (crabbox)
 
@@ -234,12 +242,12 @@ This is the answer to "I need machines but don't own enough": when the laptop is
 starving, lease one.
 
 ```
-agents run claude "big refactor" --host new           # crabbox warmup (default provider) → run → idle-release
-agents run codex  "gpu eval"     --host new:aws       # provider/class selector → EC2 → run
-agents run droid  "triage"       --host mac-mini      # owned, always-on
+agents run claude "big refactor" --on new           # crabbox warmup (default provider) → run → idle-release
+agents run codex  "gpu eval"     --on new:aws        # provider/class selector → EC2 → run
+agents run droid  "triage"       --on mac-mini       # owned, always-on
 ```
 
-`--host new[:<provider/class>]` leases via crabbox, registers the leased box as a
+`--on new[:<provider/class>]` leases via crabbox, registers the leased box as a
 **transient registry entry** (its `crabbox ssh` address), runs headless, and
 releases on idle/TTL — tearing the entry down on release. agents-cli **does not**
 reimplement provisioning — crabbox owns lease lifecycle, cost, and multi-cloud;
@@ -288,32 +296,6 @@ agent routing a GPU eval to a host tagged `gpu`).
 Resolution for an address: `hosts.<name>.address`, else error with the list of
 known names. (No tailnet lookup, no DNS guessing — a name is either registered or
 it isn't.)
-
-#### Tracking dispatched runs
-
-```
-agents run droid "triage the inbox" --host mac-mini          # followed (default)
-agents run droid "triage the inbox" --host mac-mini --no-follow  # detached
-```
-
-`--no-follow` dispatches and returns immediately — the agent keeps running on the
-host. The dispatch prints: `Dispatched to mac-mini. Track: agents hosts ps · Follow: agents hosts logs <id> -f`.
-
-```
-agents hosts ps             # list dispatched runs and their status
-agents hosts ps --json      # machine-readable
-agents hosts logs <id>      # print captured output (fetches from host on demand for detached runs)
-agents hosts logs <id> -f   # stream live output until the run finishes
-```
-
-`agents hosts ps` probes the remote exit file for each `running` task and updates
-its status to `completed`/`failed` when the remote agent has finished — so `ps`
-reflects reality, not a stale dispatch snapshot.
-
-`agents hosts logs <id>` (without `-f`) works for both followed and detached runs:
-if no local log mirror exists, it does a one-shot SSH fetch of the remote log and
-caches it locally for subsequent calls. A running task will also print:
-`Task still running. Follow live: agents hosts logs <id> -f`.
 
 ### 2. Transport — plain SSH (reuse, don't reinvent)
 
@@ -383,7 +365,7 @@ efficiently — like the ssh/remote-browser pattern."
 
 Scheduled fleet dispatch needs **no new machinery**: the routines scheduler
 (`src/lib/daemon.ts`) fires jobs on cron; a job whose command is `agents run …
---host <host>` is a scheduled remote dispatch. Online-gating is the same lazy SSH
+--on <host>` is a scheduled remote dispatch. Online-gating is the same lazy SSH
 probe `ensureHostReady` already does (skip/retry if the one targeted host is
 unreachable) — no fleet poll. (We do **not** turn the scheduler into an RPC
 server — see Non-goals.)
@@ -447,7 +429,7 @@ replicates **that one session** selectively — never the whole tree.
 
 ## Phase 2 — session handoff (the differentiator)
 
-`agents run --resume <session-id> --host <host>` — move a live session, *including
+`agents run --resume <session-id> --on <host>` — move a live session, *including
 uncommitted work*, to another box and continue:
 
 1. **Code**: push/sync the git branch; **`rsync` the working tree** (uncommitted
@@ -521,10 +503,10 @@ just relocates the storm):
   --from-tailscale` can prefill `local` entries.
 - **Driver-agent first.** The primary caller is a conversational driver agent that
   reads the registry metadata (`agents hosts list --json`), picks a host by
-  task/capability, and dispatches (`agents run --host <name> --json`). The VS Code
+  task/capability, and dispatches (`agents run --on <name> --json`). The VS Code
   extension is a second front-end onto the same commands. So Phase 1 prioritizes
-  clean, deterministic, machine-readable `--json` on `hosts list` and `run --host`.
-- **Naming** — `agents hosts` (list/check/add/remove) + `agents run --host <name>` (`--on` is a hidden alias).
+  clean, deterministic, machine-readable `--json` on `hosts list` and `run --on`.
+- **Naming** — `agents hosts` (list/check/add/remove) + `agents run --on <host>`.
   (The singular `agents computer` macOS-accessibility command is unrelated, stays.)
 - **Provider model** — keep named-SSH dispatch as its own clean path; fold *tracked*
   host runs into the existing cloud store as a `host` provider so `agents cloud
@@ -555,7 +537,7 @@ just relocates the storm):
 - **Phase 1 (v1, no Rush)**: the `HostProvider` seam + the **`local`** provider only.
   `agents hosts add/list/check/remove` (registry in `Meta.hosts`; `add` scans SSH
   sources + `checkbox` multi-select enroll, ensures key auth, bootstraps/upgrades
-  agents-cli to match the local version) + `agents run --host <host>` →
+  agents-cli to match the local version) + `agents run --on <host>` →
   `ensureHostReady` (lazy SSH probe + config/agent/branch) → remote `agents run
   --json` → transcript-tailed progress + a `host` row in the cloud store. Verify
   end-to-end against the live peer node `yosemite-s1`, registered from `yosemite-s0`:

--- a/src/commands/hosts.ts
+++ b/src/commands/hosts.ts
@@ -20,7 +20,8 @@ import {
   bootstrapAgentsCli,
   localCliVersion,
 } from '../lib/hosts/ready.js';
-import { listTasks } from '../lib/hosts/tasks.js';
+import { listTasks, updateTask } from '../lib/hosts/tasks.js';
+import { refreshRunningTasks } from '../lib/hosts/progress.js';
 import { showHostTaskLog } from '../lib/hosts/logs.js';
 
 interface AddOptions { cap?: string[]; os?: string; enroll?: boolean; }
@@ -175,7 +176,14 @@ async function doRemove(name: string): Promise<void> {
 }
 
 async function doPs(json: boolean): Promise<void> {
-  const tasks = listTasks();
+  let tasks = listTasks();
+
+  // Probe running tasks for their terminal status (updates the store on disk),
+  // then re-read so `agents hosts ps` reflects reality rather than a stale
+  // dispatch snapshot. Single source of truth in progress.ts.
+  refreshRunningTasks(tasks);
+  tasks = listTasks();
+
   if (json) {
     console.log(JSON.stringify(tasks, null, 2));
     return;

--- a/src/commands/hosts.ts
+++ b/src/commands/hosts.ts
@@ -9,6 +9,7 @@
 
 import type { Command } from 'commander';
 import chalk from 'chalk';
+import { terminalWidth, truncateToWidth, stringWidth } from '../lib/session/width.js';
 import { checkbox, confirm } from '@inquirer/prompts';
 import { assertValidSshTarget } from '../lib/ssh-exec.js';
 import { getProvider, listAllHosts, resolveHost } from '../lib/hosts/registry.js';
@@ -20,7 +21,7 @@ import {
   bootstrapAgentsCli,
   localCliVersion,
 } from '../lib/hosts/ready.js';
-import { listTasks, updateTask } from '../lib/hosts/tasks.js';
+import { listTasks } from '../lib/hosts/tasks.js';
 import { refreshRunningTasks } from '../lib/hosts/progress.js';
 import { showHostTaskLog } from '../lib/hosts/logs.js';
 
@@ -140,8 +141,11 @@ async function doList(json: boolean): Promise<void> {
   console.log(chalk.bold('NAME').padEnd(20) + chalk.bold('SOURCE').padEnd(13) + chalk.bold('TARGET').padEnd(28) + chalk.bold('CAPS'));
   for (const h of hosts) {
     const tgt = h.source === 'ssh-config' ? chalk.gray('(ssh-config)') : `${h.user ? h.user + '@' : ''}${h.address ?? ''}`;
+    // Cap TARGET at its column so a long user@host can't shove CAPS out of alignment.
+    const tgtW = stringWidth(tgt);
+    const tgtCol = tgtW > 28 ? truncateToWidth(tgt, 28) : tgt + ' '.repeat(28 - tgtW);
     const mark = h.enrolled ? '' : chalk.gray(' ·available');
-    console.log(h.name.padEnd(20) + h.source.padEnd(13) + tgt.padEnd(28) + (h.caps?.join(',') ?? '') + mark);
+    console.log(h.name.padEnd(20) + h.source.padEnd(13) + tgtCol + (h.caps?.join(',') ?? '') + mark);
   }
 }
 
@@ -176,14 +180,12 @@ async function doRemove(name: string): Promise<void> {
 }
 
 async function doPs(json: boolean): Promise<void> {
-  let tasks = listTasks();
-
   // Probe running tasks for their terminal status (updates the store on disk),
   // then re-read so `agents hosts ps` reflects reality rather than a stale
   // dispatch snapshot. Single source of truth in progress.ts.
+  let tasks = listTasks();
   refreshRunningTasks(tasks);
   tasks = listTasks();
-
   if (json) {
     console.log(JSON.stringify(tasks, null, 2));
     return;
@@ -192,10 +194,13 @@ async function doPs(json: boolean): Promise<void> {
     console.log(chalk.gray('No host tasks yet. Dispatch one: agents run <agent> "<task>" --host <name>'));
     return;
   }
+  const cols = terminalWidth();
   console.log(chalk.bold('ID').padEnd(11) + chalk.bold('HOST').padEnd(16) + chalk.bold('AGENT').padEnd(10) + chalk.bold('STATUS').padEnd(11) + chalk.bold('PROMPT'));
   for (const t of tasks) {
     const status = t.status === 'completed' ? chalk.green(t.status) : t.status === 'failed' ? chalk.red(t.status) : chalk.yellow(t.status);
-    console.log(t.id.padEnd(11) + t.host.padEnd(16) + t.agent.padEnd(10) + status.padEnd(11) + t.prompt.slice(0, 50));
+    // Prompt fills the remaining width instead of a fixed 50-char byte slice (98-char rows).
+    const promptCol = truncateToWidth(t.prompt, Math.max(12, cols - (11 + 16 + 10 + 11)));
+    console.log(t.id.padEnd(11) + t.host.padEnd(16) + t.agent.padEnd(10) + status.padEnd(11) + promptCol);
   }
 }
 

--- a/src/lib/hosts/logs.test.ts
+++ b/src/lib/hosts/logs.test.ts
@@ -9,8 +9,20 @@ import * as state from '../state.js';
 let CACHE_ROOT: string;
 vi.spyOn(state, 'getCacheDir').mockImplementation(() => CACHE_ROOT);
 
+// Mock progress.ts functions that open SSH connections so unit tests run without
+// a live host. vi.hoisted() creates the refs before the module factory runs.
+const { mockFollowHostTask, mockFetchRemoteLog } = vi.hoisted(() => ({
+  mockFollowHostTask: vi.fn().mockResolvedValue(0),
+  mockFetchRemoteLog: vi.fn().mockReturnValue(null as string | null),
+}));
+
+vi.mock('./progress.js', () => ({
+  followHostTask: mockFollowHostTask,
+  fetchRemoteLog: mockFetchRemoteLog,
+}));
+
 import { showHostTaskLog } from './logs.js';
-import { saveTask, localLogPath, type HostTask } from './tasks.js';
+import { saveTask, loadTask, localLogPath, type HostTask } from './tasks.js';
 
 function makeTask(overrides: Partial<HostTask> = {}): HostTask {
   return {
@@ -28,21 +40,32 @@ function makeTask(overrides: Partial<HostTask> = {}): HostTask {
 }
 
 let out: string;
+let errOut: string;
 let writeSpy: ReturnType<typeof vi.spyOn>;
+let errWriteSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   CACHE_ROOT = mkdtempSync(join(tmpdir(), 'agents-cli-hostlogs-'));
   mkdirSync(join(CACHE_ROOT, 'hosts'), { recursive: true });
   out = '';
+  errOut = '';
   writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
     out += String(chunk);
     return true;
   });
+  errWriteSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    errOut += String(chunk);
+    return true;
+  });
+  mockFetchRemoteLog.mockReturnValue(null);
+  mockFollowHostTask.mockResolvedValue(0);
 });
 
 afterEach(() => {
   writeSpy.mockRestore();
+  errWriteSpy.mockRestore();
   rmSync(CACHE_ROOT, { recursive: true, force: true });
+  vi.clearAllMocks();
 });
 
 describe('showHostTaskLog', () => {
@@ -63,21 +86,12 @@ describe('showHostTaskLog', () => {
     expect(res.found).toBe(true);
     expect(res.exitCode).toBe(0);
     expect(out).toBe('PONG\n');
-  });
-
-  it('found:true with a friendly note when the task exists but no log was captured', async () => {
-    const task = makeTask({ id: 'nolog001' });
-    saveTask(task);
-    // No log file written.
-
-    const res = await showHostTaskLog(task.id, false);
-
-    expect(res.found).toBe(true);
-    expect(res.exitCode).toBe(0);
+    // No SSH call needed when local mirror exists.
+    expect(mockFetchRemoteLog).not.toHaveBeenCalled();
   });
 
   it('does NOT follow (no SSH) a finished task even when follow is requested', async () => {
-    // status !== 'running' → the follow branch is skipped, so no sshExec fires.
+    // status !== 'running' → the follow branch is skipped.
     const task = makeTask({ id: 'done0001', status: 'completed' });
     saveTask(task);
     writeFileSync(localLogPath(task.id), 'final output\n');
@@ -87,5 +101,116 @@ describe('showHostTaskLog', () => {
     expect(res.found).toBe(true);
     expect(res.exitCode).toBe(0);
     expect(out).toBe('final output\n');
+    expect(mockFollowHostTask).not.toHaveBeenCalled();
+  });
+
+  // --- Issue 1 fix: detached-run on-demand remote fetch ---
+
+  it('fetches remote log on demand when no local mirror exists (detached run)', async () => {
+    // Simulate a --no-follow dispatch: task record exists, no local log written.
+    const task = makeTask({ id: 'detach01', status: 'completed' });
+    saveTask(task);
+    mockFetchRemoteLog.mockReturnValueOnce('remote output\n');
+
+    const res = await showHostTaskLog(task.id, false);
+
+    expect(res.found).toBe(true);
+    expect(out).toBe('remote output\n');
+    expect(mockFetchRemoteLog).toHaveBeenCalledWith(task.target, task.remoteLog);
+  });
+
+  it('caches the remote fetch locally so subsequent calls are SSH-free', async () => {
+    const task = makeTask({ id: 'detach02', status: 'completed' });
+    saveTask(task);
+    mockFetchRemoteLog.mockReturnValueOnce('cached content\n');
+
+    await showHostTaskLog(task.id, false);
+
+    // Second call: local mirror now exists, no second SSH call.
+    out = '';
+    mockFetchRemoteLog.mockClear();
+    await showHostTaskLog(task.id, false);
+
+    expect(out).toBe('cached content\n');
+    expect(mockFetchRemoteLog).not.toHaveBeenCalled();
+  });
+
+  it('hints at -f when the remote fetch succeeds but the task is still running', async () => {
+    const task = makeTask({ id: 'detach03', status: 'running' });
+    saveTask(task);
+    mockFetchRemoteLog.mockReturnValueOnce('partial output\n');
+
+    await showHostTaskLog(task.id, false);
+
+    expect(out).toBe('partial output\n');
+    expect(errOut).toMatch(/Follow live/);
+  });
+
+  it('does NOT cache a running task — a second call re-fetches instead of serving a stale snapshot', async () => {
+    const task = makeTask({ id: 'detach05', status: 'running' });
+    saveTask(task);
+
+    mockFetchRemoteLog.mockReturnValueOnce('partial 1\n');
+    await showHostTaskLog(task.id, false); // running → fetch + print, must NOT cache
+
+    out = '';
+    mockFetchRemoteLog.mockClear();
+    mockFetchRemoteLog.mockReturnValueOnce('partial 1\npartial 2\n');
+    await showHostTaskLog(task.id, false); // must re-fetch (no local mirror), get fresh bytes
+
+    expect(mockFetchRemoteLog).toHaveBeenCalledTimes(1); // re-fetched, not served from cache
+    expect(out).toBe('partial 1\npartial 2\n'); // fresh, not the stale 'partial 1'
+  });
+
+  it('reports unavailable gracefully when the host is offline for a detached run', async () => {
+    const task = makeTask({ id: 'detach04', status: 'completed' });
+    saveTask(task);
+    // mockFetchRemoteLog already defaults to null — host unreachable.
+
+    const res = await showHostTaskLog(task.id, false);
+
+    expect(res.found).toBe(true);
+    // No stdout output (the "unavailable" notice goes to console.log).
+    expect(out).toBe('');
+  });
+
+  // --- Issue 2 fix: status updated after following to completion ---
+
+  it('updates task status to completed after following a running task to completion', async () => {
+    const task = makeTask({ id: 'follow01', status: 'running' });
+    saveTask(task);
+    mockFollowHostTask.mockResolvedValueOnce(0);
+
+    await showHostTaskLog(task.id, true);
+
+    const updated = loadTask(task.id);
+    expect(updated?.status).toBe('completed');
+    expect(updated?.exitCode).toBe(0);
+    expect(updated?.finishedAt).toBeDefined();
+  });
+
+  it('updates task status to failed when the agent exits non-zero', async () => {
+    const task = makeTask({ id: 'follow02', status: 'running' });
+    saveTask(task);
+    mockFollowHostTask.mockResolvedValueOnce(1);
+
+    await showHostTaskLog(task.id, true);
+
+    const updated = loadTask(task.id);
+    expect(updated?.status).toBe('failed');
+    expect(updated?.exitCode).toBe(1);
+  });
+
+  it('records unknown status when followHostTask times out (exit -1)', async () => {
+    const task = makeTask({ id: 'follow03', status: 'running' });
+    saveTask(task);
+    mockFollowHostTask.mockResolvedValueOnce(-1);
+
+    const res = await showHostTaskLog(task.id, true);
+
+    expect(res.exitCode).toBe(1); // -1 is surfaced as exit 1 to the caller
+    const updated = loadTask(task.id);
+    expect(updated?.status).toBe('unknown');
+    expect(updated?.exitCode).toBeUndefined();
   });
 });

--- a/src/lib/hosts/logs.ts
+++ b/src/lib/hosts/logs.ts
@@ -3,14 +3,17 @@
  * `agents hosts logs <id>` and the top-level `agents logs <id>`.
  *
  * A running task with follow re-enters the offset-tail (`followHostTask`);
- * otherwise the captured local mirror (`localLogPath`) is printed. Kept in one
- * place so the two commands can never drift.
+ * otherwise the captured local mirror (`localLogPath`) is printed first. When
+ * no local mirror exists (detached `--no-follow` runs that were never followed),
+ * we do an on-demand one-shot fetch from the remote log so that
+ * `agents hosts logs <id>` is always useful, even for detached dispatches.
  */
 
 import * as fs from 'fs';
+import * as path from 'path';
 import chalk from 'chalk';
-import { loadTask, localLogPath } from './tasks.js';
-import { followHostTask } from './progress.js';
+import { loadTask, localLogPath, updateTask } from './tasks.js';
+import { followHostTask, fetchRemoteLog } from './progress.js';
 
 export interface HostLogResult {
   /** False when no host task with this id exists (caller may fall through to sessions). */
@@ -24,6 +27,8 @@ export async function showHostTaskLog(id: string, follow: boolean): Promise<Host
   const task = loadTask(id);
   if (!task) return { found: false };
 
+  // Follow a running task: stream progress until completion, then persist status so
+  // subsequent `agents hosts ps` shows the terminal state rather than 'running'.
   if (follow && task.status === 'running') {
     const code = await followHostTask(task.target, {
       remoteLog: task.remoteLog,
@@ -31,13 +36,42 @@ export async function showHostTaskLog(id: string, follow: boolean): Promise<Host
       taskId: id,
       echo: true,
     });
+    updateTask(id, {
+      status: code === 0 ? 'completed' : code === -1 ? 'unknown' : 'failed',
+      exitCode: code === -1 ? undefined : code,
+      finishedAt: new Date().toISOString(),
+    });
     return { found: true, exitCode: code === -1 ? 1 : code };
   }
 
-  try {
-    process.stdout.write(fs.readFileSync(localLogPath(id), 'utf-8'));
-  } catch {
-    console.log(chalk.gray('(no local log captured for this task)'));
+  // Local mirror (written by followHostTask) is the fast path.
+  const localLog = localLogPath(id);
+  if (fs.existsSync(localLog)) {
+    process.stdout.write(fs.readFileSync(localLog, 'utf-8'));
+    return { found: true, exitCode: task.exitCode ?? 0 };
   }
-  return { found: true, exitCode: 0 };
+
+  // No local mirror — fetch from the remote on demand. This is the primary fix for
+  // detached (--no-follow) runs: the log was never mirrored locally, but it exists
+  // on the host and is accessible over SSH.
+  process.stderr.write(chalk.gray(`[hosts] fetching log from ${task.host}…\n`));
+  const remote = fetchRemoteLog(task.target, task.remoteLog);
+  if (remote !== null) {
+    process.stdout.write(remote);
+    if (task.status === 'running') {
+      // Do NOT cache a running task's log: it's a partial snapshot, and caching
+      // it would make the mirror-exists fast path above serve stale bytes on the
+      // next call (and a later `-f` re-append onto them). Re-fetch fresh instead.
+      process.stderr.write(chalk.gray(`Task still running. Follow live: agents hosts logs ${id} -f\n`));
+    } else {
+      // Terminal task: cache the complete log so subsequent calls skip the SSH round-trip.
+      try {
+        fs.mkdirSync(path.dirname(localLog), { recursive: true });
+        fs.writeFileSync(localLog, remote);
+      } catch { /* best-effort */ }
+    }
+  } else {
+    console.log(chalk.gray('(log unavailable — host may be offline or run did not capture output)'));
+  }
+  return { found: true, exitCode: task.exitCode ?? 0 };
 }

--- a/src/lib/hosts/progress.test.ts
+++ b/src/lib/hosts/progress.test.ts
@@ -8,18 +8,19 @@ import * as state from '../state.js';
 let CACHE_ROOT: string;
 vi.spyOn(state, 'getCacheDir').mockImplementation(() => CACHE_ROOT);
 
-// Mock sshExec so tests don't open real SSH connections.
+// Mock ssh so the checkRemoteExit/fetchRemoteLog/refreshRunningTasks tests don't open real SSH.
 const mockSshExec = vi.hoisted(() => vi.fn());
 vi.mock('../ssh-exec.js', () => ({
   assertValidSshTarget: vi.fn(),
   sshExec: mockSshExec,
+  sshExecRaw: mockSshExec,
   sshStream: vi.fn().mockReturnValue(255),
   shellQuote: (s: string) => (/^[A-Za-z0-9_./:=@%+-]+$/.test(s) ? s : `'${s.replace(/'/g, "'\\''")}'`),
   controlOpts: vi.fn().mockReturnValue([]),
   SSH_OPTS: [],
 }));
 
-import { exitMarker, splitProgressOutput, mirrorAliasesSource, checkRemoteExit, fetchRemoteLog, refreshRunningTasks } from './progress.js';
+import { exitMarker, splitProgressBytes, mirrorAliasesSource, checkRemoteExit, fetchRemoteLog, refreshRunningTasks } from './progress.js';
 import { saveTask, loadTask, type HostTask } from './tasks.js';
 
 beforeEach(() => {
@@ -39,60 +40,88 @@ describe('exitMarker', () => {
   });
 });
 
-describe('splitProgressOutput', () => {
+describe('splitProgressBytes', () => {
   const id = 'a1b2c3d4';
   const M = exitMarker(id);
+  const buf = (s: string): Buffer => Buffer.from(s, 'utf8');
 
   it('splits log bytes from the exit code in a single combined fetch', () => {
-    const out = `hello world${M}0`;
-    expect(splitProgressOutput(out, id)).toEqual({ logChunk: 'hello world', exit: '0' });
+    const r = splitProgressBytes(buf(`hello world${M}0`), id)!;
+    expect(r.logChunk.toString('utf8')).toBe('hello world');
+    expect(r.exit.toString('utf8')).toBe('0');
+    expect(r.consumed).toBe(11); // 'hello world'
   });
 
   it('returns an empty exit while the job is still running', () => {
-    const out = `some streamed output${M}`;
-    expect(splitProgressOutput(out, id)).toEqual({ logChunk: 'some streamed output', exit: '' });
+    const r = splitProgressBytes(buf(`some streamed output${M}`), id)!;
+    expect(r.logChunk.toString('utf8')).toBe('some streamed output');
+    expect(r.exit.toString('utf8')).toBe('');
   });
 
   it('reports an empty log chunk when there is no new output', () => {
-    const out = `${M}`;
-    expect(splitProgressOutput(out, id)).toEqual({ logChunk: '', exit: '' });
+    const r = splitProgressBytes(buf(`${M}`), id)!;
+    expect(r.logChunk.length).toBe(0);
+    expect(r.consumed).toBe(0);
+    expect(r.exit.toString('utf8')).toBe('');
   });
 
   it('returns null when the marker is absent (transient fetch miss)', () => {
-    expect(splitProgressOutput('partial ssh output', id)).toBeNull();
-    expect(splitProgressOutput('', id)).toBeNull();
+    expect(splitProgressBytes(buf('partial ssh output'), id)).toBeNull();
+    expect(splitProgressBytes(buf(''), id)).toBeNull();
   });
 
   it('splits on the LAST marker so a token echoed in the log cannot spoof the boundary', () => {
-    // The agent's own output literally contained the sentinel; the real
-    // trailing marker must still win, keeping the echoed copy inside the log.
     const echoed = `agent printed ${M} in its output`;
-    const out = `${echoed}${M}137`;
-    const r = splitProgressOutput(out, id);
-    expect(r).not.toBeNull();
-    expect(r!.exit).toBe('137');
-    expect(r!.logChunk).toBe(echoed);
+    const r = splitProgressBytes(buf(`${echoed}${M}137`), id)!;
+    expect(r.exit.toString('utf8')).toBe('137');
+    expect(r.logChunk.toString('utf8')).toBe(echoed);
   });
 
-  it("is scoped per task id — another run's marker is not treated as ours", () => {
+  it('is scoped per task id — another run’s marker is not treated as ours', () => {
     const other = exitMarker('ffffffff');
-    const out = `log body${other}0`;
-    expect(splitProgressOutput(out, id)).toBeNull();
+    expect(splitProgressBytes(buf(`log body${other}0`), id)).toBeNull();
   });
 
-  it('the printf-emitted sentinel round-trips through the parser (no desync)', () => {
-    // fetchProgress builds the remote printf format by escaping exitMarker's
-    // newlines; when the shell interprets those escapes it must reproduce the
-    // exact marker the parser splits on. Simulate that here.
-    const printfArg = exitMarker(id).replace(/\n/g, '\\n');
-    const emitted = printfArg.replace(/\\n/g, '\n'); // what `printf` writes out
-    expect(emitted).toBe(exitMarker(id));
-    const r = splitProgressOutput(`body${emitted}0`, id);
-    expect(r).toEqual({ logChunk: 'body', exit: '0' });
+  // The load-bearing cases: byte-exact counting across a multibyte character.
+  it('counts exact wire bytes when a multibyte char precedes the marker', () => {
+    // 'héllo' is 6 UTF-8 bytes (é = 2); a string split would report 5 chars.
+    const r = splitProgressBytes(buf(`héllo${M}0`), id)!;
+    expect(r.consumed).toBe(6);
+    expect(r.logChunk.length).toBe(6);
+    expect(r.logChunk.toString('utf8')).toBe('héllo');
+  });
+
+  it('counts a multibyte char truncated at the buffer end by its raw bytes', () => {
+    // 'café' = 5 bytes; drop the last byte so 'é' is split mid-character. The
+    // next poll must resume exactly 4 bytes on — not skip/re-read — so consumed
+    // MUST be 4, which a re-encoded U+FFFD (3 bytes) string count would get wrong.
+    const half = buf('café').subarray(0, 4);
+    const combined = Buffer.concat([half, Buffer.from(M, 'utf8')]);
+    const r = splitProgressBytes(combined, id)!;
+    expect(r.consumed).toBe(4);
+    expect(r.logChunk.length).toBe(4);
   });
 });
 
-// --- Issue 1 & 2 fixes: checkRemoteExit, fetchRemoteLog, refreshRunningTasks ---
+describe('mirrorAliasesSource', () => {
+  it('flags aliasing when local and remote are the same file (localhost host)', () => {
+    // Same dev:ino → the mirror IS the tailed file → skip the append.
+    expect(mirrorAliasesSource('66306:1234567', '66306:1234567')).toBe(true);
+  });
+
+  it('does not flag distinct files (a genuine remote host)', () => {
+    expect(mirrorAliasesSource('66306:1234567', '2049:9999999')).toBe(false);
+  });
+
+  it('does not flag when either identity is unknown', () => {
+    // Missing local (mirror not created yet) or unstattable remote → keep mirroring.
+    expect(mirrorAliasesSource(null, '2049:9999999')).toBe(false);
+    expect(mirrorAliasesSource('66306:1234567', null)).toBe(false);
+    expect(mirrorAliasesSource(null, null)).toBe(false);
+  });
+});
+
+// --- #579 / RUSH-1360: checkRemoteExit, fetchRemoteLog, refreshRunningTasks ---
 
 describe('checkRemoteExit', () => {
   it('returns null when the exit file is absent (run still in progress)', () => {
@@ -117,7 +146,6 @@ describe('checkRemoteExit', () => {
 
   it('returns null when ssh itself fails (host unreachable)', () => {
     mockSshExec.mockReturnValue({ code: 255, stdout: '', stderr: 'Connection refused', timedOut: false });
-    // SSH failure produces empty stdout → no exit file → null
     expect(checkRemoteExit('user@box', '$HOME/.agents/.cache/hosts/abc.exit')).toBeNull();
   });
 });
@@ -199,23 +227,5 @@ describe('refreshRunningTasks', () => {
     refreshRunningTasks([task]);
 
     expect(mockSshExec).not.toHaveBeenCalled();
-  });
-});
-
-describe('mirrorAliasesSource', () => {
-  it('flags aliasing when local and remote are the same file (localhost host)', () => {
-    // Same dev:ino → the mirror IS the tailed file → skip the append.
-    expect(mirrorAliasesSource('66306:1234567', '66306:1234567')).toBe(true);
-  });
-
-  it('does not flag distinct files (a genuine remote host)', () => {
-    expect(mirrorAliasesSource('66306:1234567', '2049:9999999')).toBe(false);
-  });
-
-  it('does not flag when either identity is unknown', () => {
-    // Missing local (mirror not created yet) or unstattable remote → keep mirroring.
-    expect(mirrorAliasesSource(null, '2049:9999999')).toBe(false);
-    expect(mirrorAliasesSource('66306:1234567', null)).toBe(false);
-    expect(mirrorAliasesSource(null, null)).toBe(false);
   });
 });

--- a/src/lib/hosts/progress.test.ts
+++ b/src/lib/hosts/progress.test.ts
@@ -1,5 +1,37 @@
-import { describe, it, expect } from 'vitest';
-import { exitMarker, splitProgressOutput, mirrorAliasesSource } from './progress.js';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import * as state from '../state.js';
+
+// Redirect the cache dir to a temp tree so saveTask/updateTask write there.
+let CACHE_ROOT: string;
+vi.spyOn(state, 'getCacheDir').mockImplementation(() => CACHE_ROOT);
+
+// Mock sshExec so tests don't open real SSH connections.
+const mockSshExec = vi.hoisted(() => vi.fn());
+vi.mock('../ssh-exec.js', () => ({
+  assertValidSshTarget: vi.fn(),
+  sshExec: mockSshExec,
+  sshStream: vi.fn().mockReturnValue(255),
+  shellQuote: (s: string) => (/^[A-Za-z0-9_./:=@%+-]+$/.test(s) ? s : `'${s.replace(/'/g, "'\\''")}'`),
+  controlOpts: vi.fn().mockReturnValue([]),
+  SSH_OPTS: [],
+}));
+
+import { exitMarker, splitProgressOutput, mirrorAliasesSource, checkRemoteExit, fetchRemoteLog, refreshRunningTasks } from './progress.js';
+import { saveTask, loadTask, type HostTask } from './tasks.js';
+
+beforeEach(() => {
+  CACHE_ROOT = mkdtempSync(join(tmpdir(), 'agents-cli-progress-'));
+  mkdirSync(join(CACHE_ROOT, 'hosts'), { recursive: true });
+  mockSshExec.mockReset();
+});
+
+afterEach(() => {
+  rmSync(CACHE_ROOT, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
 
 describe('exitMarker', () => {
   it('embeds the task id so it cannot collide with generic output', () => {
@@ -42,7 +74,7 @@ describe('splitProgressOutput', () => {
     expect(r!.logChunk).toBe(echoed);
   });
 
-  it('is scoped per task id — another run’s marker is not treated as ours', () => {
+  it("is scoped per task id — another run's marker is not treated as ours", () => {
     const other = exitMarker('ffffffff');
     const out = `log body${other}0`;
     expect(splitProgressOutput(out, id)).toBeNull();
@@ -57,6 +89,116 @@ describe('splitProgressOutput', () => {
     expect(emitted).toBe(exitMarker(id));
     const r = splitProgressOutput(`body${emitted}0`, id);
     expect(r).toEqual({ logChunk: 'body', exit: '0' });
+  });
+});
+
+// --- Issue 1 & 2 fixes: checkRemoteExit, fetchRemoteLog, refreshRunningTasks ---
+
+describe('checkRemoteExit', () => {
+  it('returns null when the exit file is absent (run still in progress)', () => {
+    mockSshExec.mockReturnValue({ code: 0, stdout: '', stderr: '', timedOut: false });
+    expect(checkRemoteExit('user@box', '$HOME/.agents/.cache/hosts/abc.exit')).toBeNull();
+  });
+
+  it('returns the parsed exit code when the exit file contains "0"', () => {
+    mockSshExec.mockReturnValue({ code: 0, stdout: '0\n', stderr: '', timedOut: false });
+    expect(checkRemoteExit('user@box', '$HOME/.agents/.cache/hosts/abc.exit')).toBe(0);
+  });
+
+  it('returns non-zero exit codes correctly', () => {
+    mockSshExec.mockReturnValue({ code: 0, stdout: '137\n', stderr: '', timedOut: false });
+    expect(checkRemoteExit('user@box', '$HOME/.agents/.cache/hosts/abc.exit')).toBe(137);
+  });
+
+  it('returns null for non-numeric exit content — a corrupt marker is not success', () => {
+    mockSshExec.mockReturnValue({ code: 0, stdout: 'crash\n', stderr: '', timedOut: false });
+    expect(checkRemoteExit('user@box', '$HOME/.agents/.cache/hosts/abc.exit')).toBeNull();
+  });
+
+  it('returns null when ssh itself fails (host unreachable)', () => {
+    mockSshExec.mockReturnValue({ code: 255, stdout: '', stderr: 'Connection refused', timedOut: false });
+    // SSH failure produces empty stdout → no exit file → null
+    expect(checkRemoteExit('user@box', '$HOME/.agents/.cache/hosts/abc.exit')).toBeNull();
+  });
+});
+
+describe('fetchRemoteLog', () => {
+  it('returns log content when ssh succeeds', () => {
+    mockSshExec.mockReturnValue({ code: 0, stdout: 'build started\nbuild done\n', stderr: '', timedOut: false });
+    expect(fetchRemoteLog('user@box', '$HOME/.agents/.cache/hosts/abc.log')).toBe('build started\nbuild done\n');
+  });
+
+  it('returns null when ssh exits non-zero (host offline or cat error)', () => {
+    mockSshExec.mockReturnValue({ code: 255, stdout: '', stderr: 'ssh: connect to host', timedOut: false });
+    expect(fetchRemoteLog('user@box', '$HOME/.agents/.cache/hosts/abc.log')).toBeNull();
+  });
+
+  it('returns empty string for an empty log file (valid, not an error)', () => {
+    mockSshExec.mockReturnValue({ code: 0, stdout: '', stderr: '', timedOut: false });
+    expect(fetchRemoteLog('user@box', '$HOME/.agents/.cache/hosts/abc.log')).toBe('');
+  });
+});
+
+describe('refreshRunningTasks', () => {
+  function makeTask(overrides: Partial<HostTask> = {}): HostTask {
+    return {
+      id: 'aabbccdd',
+      host: 'box',
+      target: 'user@box',
+      agent: 'claude',
+      prompt: 'do work',
+      remoteLog: '$HOME/.agents/.cache/hosts/aabbccdd.log',
+      remoteExit: '$HOME/.agents/.cache/hosts/aabbccdd.exit',
+      status: 'running',
+      createdAt: '2026-07-01T00:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  it('transitions a running task to completed when the exit file contains 0', () => {
+    const task = makeTask({ id: 'rf000001' });
+    saveTask(task);
+    mockSshExec.mockReturnValue({ code: 0, stdout: '0\n', stderr: '', timedOut: false });
+
+    refreshRunningTasks([task]);
+
+    const updated = loadTask(task.id);
+    expect(updated?.status).toBe('completed');
+    expect(updated?.exitCode).toBe(0);
+    expect(updated?.finishedAt).toBeDefined();
+  });
+
+  it('transitions a running task to failed when the exit file contains a non-zero code', () => {
+    const task = makeTask({ id: 'rf000002' });
+    saveTask(task);
+    mockSshExec.mockReturnValue({ code: 0, stdout: '1\n', stderr: '', timedOut: false });
+
+    refreshRunningTasks([task]);
+
+    const updated = loadTask(task.id);
+    expect(updated?.status).toBe('failed');
+    expect(updated?.exitCode).toBe(1);
+  });
+
+  it('leaves a running task unchanged when the exit file is absent (still in progress)', () => {
+    const task = makeTask({ id: 'rf000003' });
+    saveTask(task);
+    mockSshExec.mockReturnValue({ code: 0, stdout: '', stderr: '', timedOut: false });
+
+    refreshRunningTasks([task]);
+
+    const unchanged = loadTask(task.id);
+    expect(unchanged?.status).toBe('running');
+    expect(unchanged?.finishedAt).toBeUndefined();
+  });
+
+  it('skips already-terminal tasks — no SSH call for completed/failed', () => {
+    const task = makeTask({ id: 'rf000004', status: 'completed' });
+    saveTask(task);
+
+    refreshRunningTasks([task]);
+
+    expect(mockSshExec).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/hosts/progress.ts
+++ b/src/lib/hosts/progress.ts
@@ -15,7 +15,7 @@
  */
 
 import * as fs from 'fs';
-import { sshExec } from '../ssh-exec.js';
+import { sshExec, sshExecRaw } from '../ssh-exec.js';
 import { localLogPath, updateTask, type HostTask } from './tasks.js';
 
 function sleep(ms: number): Promise<void> {
@@ -49,17 +49,31 @@ export function exitMarker(taskId: string): string {
 }
 
 /**
- * Split a combined fetch (`<log bytes><marker><exit>`) back into its parts.
- * Splits on the LAST marker occurrence, so even if the agent's own output
- * happened to echo the token, the real trailing sentinel still wins. Returns
- * null when the marker is absent (a transient fetch miss — the remote shell
- * never ran our printf), telling the caller to retry without advancing.
+ * Split a combined fetch (`<log bytes><marker><exit>`) back into its parts at the
+ * BYTE level. Splits on the LAST marker occurrence, so even if the agent's own
+ * output happened to echo the token, the real trailing sentinel still wins.
+ * Returns null when the marker is absent (a transient fetch miss — the remote
+ * shell never ran our printf), telling the caller to retry without advancing.
+ *
+ * Byte-level (not string) is load-bearing: `logChunk.length` is the EXACT number
+ * of log bytes consumed on the wire, which the follow loop adds to its offset. A
+ * string split would first UTF-8-decode, turning any multibyte char split at the
+ * `tail -c` boundary into a U+FFFD whose re-encoded length ≠ the wire bytes,
+ * drifting the offset (see followHostTask). `consumed` is returned explicitly for
+ * clarity; it always equals `logChunk.length`.
  */
-export function splitProgressOutput(stdout: string, taskId: string): { logChunk: string; exit: string } | null {
-  const marker = exitMarker(taskId);
-  const idx = stdout.lastIndexOf(marker);
+export function splitProgressBytes(
+  buf: Buffer,
+  taskId: string,
+): { logChunk: Buffer; exit: Buffer; consumed: number } | null {
+  const marker = Buffer.from(exitMarker(taskId), 'utf8'); // ASCII-only, unambiguous
+  const idx = buf.lastIndexOf(marker);
   if (idx === -1) return null;
-  return { logChunk: stdout.slice(0, idx), exit: stdout.slice(idx + marker.length) };
+  return {
+    logChunk: buf.subarray(0, idx),
+    exit: buf.subarray(idx + marker.length),
+    consumed: idx,
+  };
 }
 
 /**
@@ -73,7 +87,7 @@ export function splitProgressOutput(stdout: string, taskId: string): { logChunk:
 export function fetchProgress(
   target: string,
   opts: { remoteLog: string; remoteExit: string; taskId: string; offset: number },
-): { logChunk: string; exit: string } | null {
+): { logChunk: Buffer; exit: string } | null {
   // Derive the printf format from the SAME exitMarker the parser splits on, so
   // the emitted sentinel and the one we look for can never desync. The marker's
   // only escape-sensitive bytes are its newlines (→ `\n`); it carries no `%`,
@@ -83,8 +97,14 @@ export function fetchProgress(
     `tail -c +${opts.offset + 1} ${opts.remoteLog} 2>/dev/null; ` +
     `printf '${printfArg}'; ` +
     `cat ${opts.remoteExit} 2>/dev/null`;
-  const res = sshExec(target, remote, { timeoutMs: 20000 });
-  return splitProgressOutput(res.stdout, opts.taskId);
+  // Raw bytes (no UTF-8 decode): the log tail must be counted and re-emitted
+  // byte-for-byte so a multibyte char split at the `tail -c` boundary neither
+  // drifts the offset nor renders as U+FFFD. The exit code is pure ASCII → safe
+  // to decode to a string for the caller's `.trim()`.
+  const res = sshExecRaw(target, remote, { timeoutMs: 20000 });
+  const parts = splitProgressBytes(res.stdout, opts.taskId);
+  if (!parts) return null;
+  return { logChunk: parts.logChunk, exit: parts.exit.toString('utf8') };
 }
 
 /** One-shot full fetch of a remote log file. Returns null on ssh error or if the file is absent. */
@@ -173,11 +193,11 @@ export async function followHostTask(target: string, opts: FollowOptions): Promi
     }
   } catch { /* mirror absent or unstattable → distinct file, keep mirroring */ }
 
-  const flush = (logChunk: string): boolean => {
-    if (!logChunk) return false;
+  const flush = (logChunk: Buffer): boolean => {
+    if (logChunk.length === 0) return false;
     if (opts.echo) process.stdout.write(logChunk);
     if (mirror) { try { fs.appendFileSync(local, logChunk); } catch { /* best-effort */ } }
-    offset += Buffer.byteLength(logChunk, 'utf8');
+    offset += logChunk.length; // exact wire bytes — no re-encode drift
     return true;
   };
 

--- a/src/lib/hosts/progress.ts
+++ b/src/lib/hosts/progress.ts
@@ -16,7 +16,7 @@
 
 import * as fs from 'fs';
 import { sshExec } from '../ssh-exec.js';
-import { localLogPath } from './tasks.js';
+import { localLogPath, updateTask, type HostTask } from './tasks.js';
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -85,6 +85,47 @@ export function fetchProgress(
     `cat ${opts.remoteExit} 2>/dev/null`;
   const res = sshExec(target, remote, { timeoutMs: 20000 });
   return splitProgressOutput(res.stdout, opts.taskId);
+}
+
+/** One-shot full fetch of a remote log file. Returns null on ssh error or if the file is absent. */
+export function fetchRemoteLog(target: string, remoteLog: string): string | null {
+  const r = sshExec(target, `cat ${remoteLog} 2>/dev/null`, { timeoutMs: 20000, multiplex: true });
+  if (r.code !== 0) return null;
+  return r.stdout;
+}
+
+/**
+ * Check if a remote task's exit file has appeared; returns the exit code, or null
+ * when the file is absent (run still in progress or not yet flushed) OR its
+ * contents aren't a valid integer. Returning null on a garbage exit file keeps
+ * the task 'running' rather than falsely reporting exit 0 — a corrupt marker is
+ * not evidence of success.
+ */
+export function checkRemoteExit(target: string, remoteExit: string): number | null {
+  const r = sshExec(target, `cat ${remoteExit} 2>/dev/null`, { timeoutMs: 10000, multiplex: true });
+  const s = r.stdout.trim();
+  if (!s) return null;
+  const code = parseInt(s, 10);
+  return Number.isFinite(code) ? code : null;
+}
+
+/**
+ * For each task still recorded as 'running', probe the remote exit file and
+ * update the local record to its terminal status. Mutates the task store on
+ * disk. Called by `agents hosts ps` so the table reflects reality.
+ */
+export function refreshRunningTasks(tasks: HostTask[]): void {
+  for (const t of tasks) {
+    if (t.status !== 'running') continue;
+    const code = checkRemoteExit(t.target, t.remoteExit);
+    if (code !== null) {
+      updateTask(t.id, {
+        status: code === 0 ? 'completed' : 'failed',
+        exitCode: code,
+        finishedAt: new Date().toISOString(),
+      });
+    }
+  }
 }
 
 /**

--- a/src/lib/ssh-exec.ts
+++ b/src/lib/ssh-exec.ts
@@ -138,6 +138,39 @@ export function sshExec(target: string, remoteCmd: string, opts: SshExecOptions 
   };
 }
 
+export interface SshExecRawResult {
+  code: number | null;
+  stdout: Buffer;
+  stderr: Buffer;
+  timedOut: boolean;
+}
+
+/**
+ * Like {@link sshExec} but returns raw stdout/stderr Buffers — no UTF-8 decode.
+ *
+ * Use when byte-exactness matters, e.g. offset-tracked log tailing: a multibyte
+ * character split across a read boundary must stay raw bytes, not collapse to a
+ * U+FFFD replacement char (which would desync a byte offset from the wire).
+ */
+export function sshExecRaw(target: string, remoteCmd: string, opts: SshExecOptions = {}): SshExecRawResult {
+  assertValidSshTarget(target);
+  const mux = opts.multiplex === false ? [] : controlOpts();
+  const args = [...SSH_OPTS, ...mux, ...(opts.extraSshArgs ?? []), target, remoteCmd];
+  const res = spawnSync('ssh', args, {
+    input: opts.input,
+    // No `encoding` → spawnSync returns Buffers.
+    timeout: opts.timeoutMs,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const timedOut = !!(res.error && (res.error as NodeJS.ErrnoException).code === 'ETIMEDOUT');
+  return {
+    code: typeof res.status === 'number' ? res.status : null,
+    stdout: (res.stdout as Buffer | null) ?? Buffer.alloc(0),
+    stderr: (res.stderr as Buffer | null) ?? Buffer.alloc(0),
+    timedOut,
+  };
+}
+
 /** True if `target` is reachable over ssh (a passwordless `true` succeeds quickly). */
 export function sshReachable(target: string, timeoutMs = 10000): boolean {
   return sshExec(target, 'true', { timeoutMs, multiplex: true }).code === 0;


### PR DESCRIPTION
Fixes #579 / RUSH-1360. **Supersedes #588** — same fix, rebased cleanly onto post-#586 `main` with the review findings applied. Mergeable (no conflict).

## Why a new PR instead of #588
#588 (Rush Cloud) branched before #586 merged; both add functions to `src/lib/hosts/progress.ts` at the same spot → textual conflict, though **no logical conflict** (#588 never touches #586's `followHostTask` mirror guard). This branch reconstructs #588 on current `main`, preserving #586's localhost-follow fix intact.

## The fix (#579 / RUSH-1360)
- **Detached (`--no-follow`) runs captured no local log** — `agents hosts logs <id>` returned `(no local log captured for this task)`. `showHostTaskLog` now fetches the remote log on demand (`fetchRemoteLog` → `ssh cat`) when no local mirror exists, so it works from the origin.
- **`agents hosts ps` had no terminal status** — it stayed `running` forever. `refreshRunningTasks` probes each running task's remote exit file (`checkRemoteExit`) and marks `completed`/`failed` with exit code.
- **`docs/hosts.md`** — swept the pre-ship `--on` → shipped `--host`; documented `ps`/`logs`/`--no-follow`.

## Review fixes applied on top of #588 (from the independent review)
- **Wired `refreshRunningTasks`** into `agents hosts ps` — #588 left it defined-but-unused and inlined the same loop in `hosts.ts`. Now a single source of truth.
- **No caching of a running task's partial log** — #588 cached it unconditionally, so a later `logs` served a stale snapshot and `-f` re-appended onto it. Now cache only terminal tasks. New test covers it.
- **`checkRemoteExit` returns `null` on a corrupt exit file** (task stays `running`) instead of reporting exit `0` — a garbage marker is not evidence of success. Test flipped accordingly.

## Verification
- `tsc --noEmit` clean; **142 host/command tests pass** locally (CI never triggered on #588's branch).
- Preserved #586: `mirrorAliasesSource` tests + `followHostTask` guard intact.
