### PR TITLE
fix(hosts): self-healing bookkeeping for remote --host runs

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -416,7 +416,11 @@ export function registerRunCommand(program: Command): void {
             console.log(chalk.green(`Dispatched to ${host.name}.`) + chalk.gray(' Track: agents hosts ps · Follow: agents hosts logs <id> -f'));
             process.exit(0);
           }
-          process.exit(exitCode === undefined || exitCode === -1 ? 1 : exitCode);
+          // -1 = the follow window closed but the run continues on the host (the
+          // reattach hint is already printed). That's a detach, not a failure —
+          // exit 0. Any real remote code passes through.
+          if (exitCode === -1) process.exit(0);
+          process.exit(exitCode ?? 1);
         } catch (err) {
           console.error(chalk.red((err as Error).message));
           process.exit(1);

--- a/src/commands/hosts.ts
+++ b/src/commands/hosts.ts
@@ -21,6 +21,7 @@ import {
   localCliVersion,
 } from '../lib/hosts/ready.js';
 import { listTasks } from '../lib/hosts/tasks.js';
+import { reconcileRunningTasks } from '../lib/hosts/reconcile.js';
 import { showHostTaskLog } from '../lib/hosts/logs.js';
 
 interface AddOptions { cap?: string[]; os?: string; enroll?: boolean; }
@@ -175,7 +176,10 @@ async function doRemove(name: string): Promise<void> {
 }
 
 async function doPs(json: boolean): Promise<void> {
-  const tasks = listTasks();
+  // Heal any 'running' record whose local follower died (dropped connection,
+  // laptop sleep) against the remote `.exit` before listing, so `ps` never shows
+  // a finished run stuck at 'running'.
+  const tasks = reconcileRunningTasks(listTasks());
   if (json) {
     console.log(JSON.stringify(tasks, null, 2));
     return;

--- a/src/lib/hosts/dispatch.ts
+++ b/src/lib/hosts/dispatch.ts
@@ -14,7 +14,7 @@ import { sshExec, shellQuote } from '../ssh-exec.js';
 import type { Host } from './types.js';
 import { sshTargetFor } from './types.js';
 import { ensureHostReady } from './ready.js';
-import { saveTask, updateTask, type HostTask } from './tasks.js';
+import { saveTask, updateTask, terminalPatch, type HostTask } from './tasks.js';
 import { followHostTask } from './progress.js';
 
 // Use $HOME (not ~) so the path is correct whether or not it's quoted and
@@ -89,12 +89,11 @@ async function launchDetached(host: Host, target: string, opts: LaunchOptions): 
     echo: true,
     timeoutMs: opts.timeoutMs,
   });
-  const finished = updateTask(id, {
-    status: exitCode === 0 ? 'completed' : exitCode === -1 ? 'unknown' : 'failed',
-    exitCode: exitCode === -1 ? undefined : exitCode,
-    finishedAt: new Date().toISOString(),
-  });
-  return { task: finished ?? task, exitCode };
+  // -1 = the follow window closed while the run continues on the host. Leave the
+  // record 'running' (do NOT freeze it terminal) so a later `hosts ps`/`logs`
+  // reconcile against the remote `.exit` resolves the true final status.
+  const finished = exitCode === -1 ? task : (updateTask(id, terminalPatch(exitCode)) ?? task);
+  return { task: finished, exitCode };
 }
 
 export interface DispatchOptions {

--- a/src/lib/hosts/logs.ts
+++ b/src/lib/hosts/logs.ts
@@ -9,8 +9,9 @@
 
 import * as fs from 'fs';
 import chalk from 'chalk';
-import { loadTask, localLogPath } from './tasks.js';
+import { loadTask, localLogPath, updateTask, terminalPatch } from './tasks.js';
 import { followHostTask } from './progress.js';
+import { reconcileTask } from './reconcile.js';
 
 export interface HostLogResult {
   /** False when no host task with this id exists (caller may fall through to sessions). */
@@ -31,9 +32,18 @@ export async function showHostTaskLog(id: string, follow: boolean): Promise<Host
       taskId: id,
       echo: true,
     });
-    return { found: true, exitCode: code === -1 ? 1 : code };
+    // -1 = follow window closed; the run continues on the host (not a failure,
+    // so exit 0). Any real code is the finished run — persist the terminal
+    // status the killed dispatch follower would have written.
+    if (code === -1) return { found: true, exitCode: 0 };
+    updateTask(id, terminalPatch(code));
+    return { found: true, exitCode: code };
   }
 
+  // Non-follow view: heal a still-'running' record from the remote `.exit` so a
+  // plain `logs <id>` also unsticks a task whose follower was killed. No-op (no
+  // ssh) once the record is already terminal.
+  reconcileTask(task);
   try {
     process.stdout.write(fs.readFileSync(localLogPath(id), 'utf-8'));
   } catch {

--- a/src/lib/hosts/reconcile.test.ts
+++ b/src/lib/hosts/reconcile.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import * as state from '../state.js';
+
+// Redirect the cache dir to a temp tree (real fs, no service mocking) so
+// reconcile can read/write real task sidecars the way a dispatch would.
+let CACHE_ROOT: string;
+vi.spyOn(state, 'getCacheDir').mockImplementation(() => CACHE_ROOT);
+
+import { classifyExit, reconcileTask, reconcileRunningTasks } from './reconcile.js';
+import { saveTask, loadTask, terminalPatch, type HostTask } from './tasks.js';
+
+function makeTask(overrides: Partial<HostTask> = {}): HostTask {
+  return {
+    id: 'abc12345',
+    host: 'box',
+    target: 'user@box',
+    agent: 'claude',
+    prompt: 'do a thing',
+    remoteLog: '$HOME/.agents/.cache/hosts/abc12345.log',
+    remoteExit: '$HOME/.agents/.cache/hosts/abc12345.exit',
+    status: 'running',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  CACHE_ROOT = mkdtempSync(join(tmpdir(), 'agents-cli-reconcile-'));
+  mkdirSync(join(CACHE_ROOT, 'hosts'), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(CACHE_ROOT, { recursive: true, force: true });
+});
+
+// The classifier is where every bug-prone branch lives; readRemoteExit is just a
+// thin ssh wrapper around it, so exercising it with plain SshExecResult-shaped
+// data (NOT a mocked ssh layer) covers the real decision logic.
+describe('classifyExit', () => {
+  it('ssh connection failure (code 255) → unreachable, never a guessed status', () => {
+    expect(classifyExit({ code: 255, stdout: '', timedOut: false })).toEqual({ state: 'unreachable' });
+  });
+
+  it('spawn error / null code → unreachable', () => {
+    expect(classifyExit({ code: null, stdout: '', timedOut: false })).toEqual({ state: 'unreachable' });
+  });
+
+  it('timeout → unreachable even if a code came back', () => {
+    expect(classifyExit({ code: 0, stdout: '', timedOut: true })).toEqual({ state: 'unreachable' });
+  });
+
+  it('reachable but empty .exit (absent or mid-write) → running', () => {
+    expect(classifyExit({ code: 0, stdout: '', timedOut: false })).toEqual({ state: 'running' });
+    expect(classifyExit({ code: 0, stdout: '   \n', timedOut: false })).toEqual({ state: 'running' });
+  });
+
+  it('.exit holds 0 → done with code 0', () => {
+    expect(classifyExit({ code: 0, stdout: '0\n', timedOut: false })).toEqual({ state: 'done', code: 0 });
+  });
+
+  it('.exit holds a non-zero code → done with that code', () => {
+    expect(classifyExit({ code: 0, stdout: '137\n', timedOut: false })).toEqual({ state: 'done', code: 137 });
+  });
+
+  it('garbage in .exit coerces to 0 (matches the follow-loop parse)', () => {
+    expect(classifyExit({ code: 0, stdout: 'not-a-number\n', timedOut: false })).toEqual({ state: 'done', code: 0 });
+  });
+});
+
+describe('terminalPatch', () => {
+  it('code 0 → completed', () => {
+    const p = terminalPatch(0);
+    expect(p.status).toBe('completed');
+    expect(p.exitCode).toBe(0);
+    expect(typeof p.finishedAt).toBe('string');
+  });
+
+  it('non-zero code → failed, code preserved', () => {
+    const p = terminalPatch(2);
+    expect(p.status).toBe('failed');
+    expect(p.exitCode).toBe(2);
+  });
+});
+
+describe('reconcileTask — terminal records are immutable (no ssh)', () => {
+  // A non-'running' status short-circuits before any ssh, so these run offline.
+  it('leaves a completed record untouched', () => {
+    const task = makeTask({ status: 'completed', exitCode: 0 });
+    saveTask(task);
+    const out = reconcileTask(task);
+    expect(out.status).toBe('completed');
+    expect(loadTask(task.id)?.status).toBe('completed');
+  });
+
+  it('leaves a failed record untouched', () => {
+    const task = makeTask({ id: 'fail0001', status: 'failed', exitCode: 1 });
+    saveTask(task);
+    const out = reconcileTask(task);
+    expect(out.status).toBe('failed');
+    expect(out.exitCode).toBe(1);
+  });
+});
+
+describe('reconcileRunningTasks — no running tasks means no ssh', () => {
+  it('returns the input unchanged when nothing is running', () => {
+    const tasks = [
+      makeTask({ id: 'done0001', status: 'completed', exitCode: 0 }),
+      makeTask({ id: 'fail0002', status: 'failed', exitCode: 3 }),
+    ];
+    const out = reconcileRunningTasks(tasks);
+    expect(out).toEqual(tasks);
+  });
+
+  it('returns an empty list unchanged', () => {
+    expect(reconcileRunningTasks([])).toEqual([]);
+  });
+});

--- a/src/lib/hosts/reconcile.test.ts
+++ b/src/lib/hosts/reconcile.test.ts
@@ -1,16 +1,26 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdirSync, rmSync, mkdtempSync } from 'fs';
+import { mkdirSync, rmSync, mkdtempSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import * as state from '../state.js';
+import { sshReachable } from '../ssh-exec.js';
 
 // Redirect the cache dir to a temp tree (real fs, no service mocking) so
 // reconcile can read/write real task sidecars the way a dispatch would.
-let CACHE_ROOT: string;
+// Initialized eagerly (not just in beforeEach) so the module-load reachability
+// probe below sees a valid dir for ssh's control socket; beforeEach reassigns it
+// per test.
+let CACHE_ROOT: string = mkdtempSync(join(tmpdir(), 'agents-cli-reconcile-boot-'));
 vi.spyOn(state, 'getCacheDir').mockImplementation(() => CACHE_ROOT);
 
 import { classifyExit, reconcileTask, reconcileRunningTasks } from './reconcile.js';
 import { saveTask, loadTask, terminalPatch, type HostTask } from './tasks.js';
+
+// The heal path needs a real ssh round-trip (no mocking, per repo policy). Gate
+// it on localhost being ssh-reachable so it exercises the true path where a host
+// is available (dev machines, self-hosted runners) and skips cleanly where it
+// isn't (hosted CI), rather than flaking.
+const LOCALHOST_SSH = sshReachable('localhost', 5000);
 
 function makeTask(overrides: Partial<HostTask> = {}): HostTask {
   return {
@@ -30,6 +40,10 @@ function makeTask(overrides: Partial<HostTask> = {}): HostTask {
 beforeEach(() => {
   CACHE_ROOT = mkdtempSync(join(tmpdir(), 'agents-cli-reconcile-'));
   mkdirSync(join(CACHE_ROOT, 'hosts'), { recursive: true });
+  // ssh's control-socket dir lives under getCacheDir(); ssh-exec only ensures it
+  // once (module-level flag), so with a fresh cache dir per test we must create
+  // it ourselves or multiplexed ssh can't open its socket and reports 255.
+  mkdirSync(join(CACHE_ROOT, 'ssh'), { recursive: true, mode: 0o700 });
 });
 
 afterEach(() => {
@@ -116,5 +130,58 @@ describe('reconcileRunningTasks — no running tasks means no ssh', () => {
 
   it('returns an empty list unchanged', () => {
     expect(reconcileRunningTasks([])).toEqual([]);
+  });
+});
+
+// The literal bug the PR fixes: a 'running' record whose remote `.exit` now
+// holds a code must be healed to a terminal status AND persisted to disk. Driven
+// over a real `ssh localhost` cat of a real `.exit` file — no mocking.
+describe.skipIf(!LOCALHOST_SSH)('reconcile over real ssh (localhost)', () => {
+  let exitFile: string;
+
+  beforeEach(() => {
+    exitFile = join(CACHE_ROOT, 'run.exit');
+  });
+
+  it('heals a running record from a code-0 .exit and persists it', () => {
+    writeFileSync(exitFile, '0\n');
+    const task = makeTask({ id: 'heal0000', target: 'localhost', remoteExit: exitFile });
+    saveTask(task);
+
+    const out = reconcileTask(task);
+
+    expect(out.status).toBe('completed');
+    expect(out.exitCode).toBe(0);
+    expect(loadTask('heal0000')?.status).toBe('completed'); // written through to disk
+  });
+
+  it('heals a non-zero .exit to failed with the code preserved', () => {
+    writeFileSync(exitFile, '137\n');
+    const task = makeTask({ id: 'heal0137', target: 'localhost', remoteExit: exitFile });
+    saveTask(task);
+
+    reconcileTask(task);
+
+    const disk = loadTask('heal0137');
+    expect(disk?.status).toBe('failed');
+    expect(disk?.exitCode).toBe(137);
+  });
+
+  it('leaves a running record running when the .exit is absent (still going)', () => {
+    const task = makeTask({ id: 'still001', target: 'localhost', remoteExit: join(CACHE_ROOT, 'nope.exit') });
+    saveTask(task);
+
+    expect(reconcileTask(task).status).toBe('running');
+    expect(loadTask('still001')?.status).toBe('running');
+  });
+
+  it('reconcileRunningTasks: unreachable host stays running, never failed', () => {
+    const down = makeTask({ id: 'downhost', target: 'no-such-host-xyzzy-12345', remoteExit: exitFile });
+    saveTask(down);
+
+    const [out] = reconcileRunningTasks([down]);
+
+    expect(out.status).toBe('running');
+    expect(loadTask('downhost')?.status).toBe('running');
   });
 });

--- a/src/lib/hosts/reconcile.ts
+++ b/src/lib/hosts/reconcile.ts
@@ -1,0 +1,84 @@
+/**
+ * Reconcile a local host-task record against the remote run's ground truth.
+ *
+ * A detached `--host` run outlives the local follower: it keeps running and
+ * writes its exit code to `<id>.exit` on the host even if the laptop sleeps or
+ * the SSH connection drops mid-follow. When that happens the local record is
+ * left at `status:'running'` forever, because the only path that finalizes it
+ * (dispatch's post-follow `updateTask`) never runs. This module re-reads the
+ * remote `.exit` on demand — from `agents hosts ps` / `logs` — and heals the
+ * record. We only ever CONFIRM completion; an unreachable host or an absent
+ * `.exit` leaves the record `running` (we never guess failure).
+ */
+
+import { sshExec, sshReachable, type SshExecResult } from '../ssh-exec.js';
+import { updateTask, terminalPatch, type HostTask } from './tasks.js';
+
+export type RemoteExitState =
+  | { state: 'running' } //     .exit absent, or present-but-empty (mid-write) → not finished
+  | { state: 'done'; code: number } // .exit holds an exit code → finished
+  | { state: 'unreachable' }; //  ssh itself failed → can't tell, don't touch the record
+
+/**
+ * Classify a `cat <remoteExit>` result into a remote run state. Pure: all the
+ * bug-prone branching (ssh-failure vs absent vs empty vs coded) lives here so it
+ * can be unit-tested without a live host. ssh's own connection failure surfaces
+ * as code 255, a spawn error/timeout as `code === null`; neither is the remote
+ * command's exit and both mean "unreachable". An empty read is "still running"
+ * (the `.exit` is written only after the run ends, so absent `cat` → exit 1 →
+ * empty stdout, and a truncate-then-write mid-race is a sub-ms empty window).
+ */
+export function classifyExit(res: Pick<SshExecResult, 'code' | 'stdout' | 'timedOut'>): RemoteExitState {
+  if (res.timedOut || res.code === null || res.code === 255) return { state: 'unreachable' };
+  const out = res.stdout.trim();
+  if (out === '') return { state: 'running' };
+  const code = parseInt(out, 10);
+  return { state: 'done', code: Number.isFinite(code) ? code : 0 };
+}
+
+/**
+ * Read a task's remote `.exit` over ssh and classify it. `remoteExit` is a
+ * $HOME-prefixed path with a safe (hex) basename — intentionally unquoted so the
+ * remote shell expands $HOME (same contract as progress.ts's fetch).
+ */
+export function readRemoteExit(target: string, remoteExit: string, timeoutMs = 6000): RemoteExitState {
+  return classifyExit(sshExec(target, `cat ${remoteExit} 2>/dev/null`, { timeoutMs, multiplex: true }));
+}
+
+/**
+ * Heal one record. Terminal records are immutable (and never re-probed); a
+ * `running` record is resolved to completed/failed only when the remote `.exit`
+ * holds a code. Returns the (possibly updated) task.
+ */
+export function reconcileTask(task: HostTask): HostTask {
+  if (task.status !== 'running') return task;
+  const st = readRemoteExit(task.target, task.remoteExit);
+  if (st.state !== 'done') return task;
+  return updateTask(task.id, terminalPatch(st.code)) ?? task;
+}
+
+/**
+ * Heal a list of records for a listing (`agents hosts ps`). Only `running` tasks
+ * are probed; each host is reachability-checked ONCE (deduped by target) so a
+ * down host costs a single short timeout instead of one per task, and its tasks
+ * are left `running` rather than falsely failed. Sequential by design — with the
+ * shared ssh control socket the live-host reads are sub-100ms, and a parallel
+ * (async) ssh path is deliberately out of scope.
+ */
+export function reconcileRunningTasks(tasks: HostTask[]): HostTask[] {
+  const running = tasks.filter((t) => t.status === 'running');
+  if (running.length === 0) return tasks;
+
+  const reachable = new Map<string, boolean>();
+  const patched = new Map<string, HostTask>();
+  for (const t of running) {
+    if (!reachable.has(t.target)) reachable.set(t.target, sshReachable(t.target, 6000));
+    if (!reachable.get(t.target)) continue; // host down → leave running
+    const st = readRemoteExit(t.target, t.remoteExit);
+    if (st.state === 'done') {
+      const updated = updateTask(t.id, terminalPatch(st.code));
+      if (updated) patched.set(t.id, updated);
+    }
+  }
+  return tasks.map((t) => patched.get(t.id) ?? t);
+}

--- a/src/lib/hosts/tasks.ts
+++ b/src/lib/hosts/tasks.ts
@@ -64,6 +64,21 @@ export function updateTask(id: string, patch: Partial<HostTask>): HostTask | nul
   return next;
 }
 
+/**
+ * The record patch for a run that has finished with `code`. The single authority
+ * for the exit-code → status mapping, so the dispatch, reconcile, and log-follow
+ * paths can never disagree. A genuine remote exit code is never -1 (that sentinel
+ * means "follow window closed while the run continues"), so callers must resolve
+ * -1 as still-running and never pass it here.
+ */
+export function terminalPatch(code: number): Partial<HostTask> {
+  return {
+    status: code === 0 ? 'completed' : 'failed',
+    exitCode: code,
+    finishedAt: new Date().toISOString(),
+  };
+}
+
 export function listTasks(): HostTask[] {
   let files: string[];
   try {


### PR DESCRIPTION
## Problem

A remote `--host` run is launched detached (`nohup … &`) so the agent **survives a dropped connection** — but the local task record didn't track that. Three status bugs:

1. **Stuck `running` forever.** The terminal status is written only when `followHostTask` returns and `updateTask` runs (`dispatch.ts`). Kill the local follower (dropped connection, laptop sleep, Ctrl-C) and that never happens; nothing re-reads the remote `.exit`, so `agents hosts ps` shows `running` indefinitely.
2. **Reattach doesn't persist.** `hosts logs -f` re-followed to completion but never called `updateTask`, so even a clean reattach left the record `running`.
3. **Long run looks like a failure.** `followHostTask` returns `-1` on the follow deadline; `run --host` mapped `-1 → exit 1` and dispatch froze the record at `unknown`. A healthy detached job reported a local failure.

The remote `<id>.exit` file is ground truth (`dispatch.ts` writes `echo $? > …`) and the follow loop already reads it — it was just never consulted again after the follower died.

## Fix — reconcile-on-read (no daemon, no held channel)

Events are rare (a run finishes once) and watchers are intermittent, so instead of holding a connection open we cheaply re-read `.exit` whenever someone runs `ps`/`logs`.

- **`terminalPatch(code)`** (`tasks.ts`) — the single exit-code → status authority, reused everywhere so the paths can't disagree.
- **`reconcile.ts`** (new) — `classifyExit` (pure), `readRemoteExit` (one `ssh cat`), `reconcileTask`, and `reconcileRunningTasks` (one reachability probe per host, deduped). Only ever **confirms** completion; an unreachable host or absent/empty `.exit` leaves the record `running` — never guesses failure.
- **`hosts ps`** reconciles running records before listing.
- **`hosts logs -f`** persists the terminal status after following; a plain `logs <id>` self-heals a stuck record too.
- **`-1` (follow timeout)** now means "still running, detached": dispatch leaves the record `running` (not terminal `unknown`), and `run --host` / `logs -f` exit `0`, not `1`.

## Verification

- **Typecheck:** `tsc --noEmit` clean.
- **Unit:** new `reconcile.test.ts` covers every `classifyExit` branch (255/null/timeout → unreachable, empty → running, integer → done, garbage → 0), the `terminalPatch` mapping, and terminal-record immutability — no live host, no mocking. Full host suite: **60/60**. Full suite: **3579 passed** (the only reds were pre-existing flaky npm-404/spawn integration tests, green on rerun).
- **Live E2E** — drove the real path against `ssh localhost` with real `.exit` files:
  - finished run (`.exit`=0) → `running → completed`, exit 0, **persisted to disk** ✓
  - still running (`.exit` absent) → stays `running` ✓
  - unreachable host → stays `running` ✓

## Scope guardrails

No daemon, no async `ssh-exec` rewrite, no file locks (reconcile is idempotent), no PID-liveness heuristics, and the vestigial `unknown` status is left in place (unrelated churn). Independently plan-verified by two blind agents before implementation.
