### PR TITLE
feat(events): wire up the audit event log + agents events

### DIFF
--- a/docs/06-observability.md
+++ b/docs/06-observability.md
@@ -2,6 +2,46 @@
 
 Using agents-cli as a programmatic observability layer for agent fleets.
 
+## Audit Event Log (`agents events`)
+
+Separate from the fleet-state sources below (which answer "what's running *now*"),
+the **audit event log** answers "who did what, and from where". Every
+`agents <module> <command>` invocation is recorded — team create/disband, agent
+run, secrets access, version installs — as a structured JSONL line at
+`~/.agents/.cache/logs/events-YYYY-MM-DD.jsonl` (dir `0700`, files `0600`, 7-day
+rotation).
+
+The recording is a single choke point — a commander `preAction`/`postAction`
+hook on the root program ([`src/index.ts`](../src/index.ts)) emits `command.start`
+/ `command.end` for *every* subcommand, so coverage is automatic and no per-command
+wiring can drift out of date. Richer typed events (`secrets.get`, `version.install`,
+…) layer on top where the extra payload earns it.
+
+Every record carries **attribution** computed once per process
+([`src/lib/events.ts`](../src/lib/events.ts)):
+
+- `osUser` — the OS account that ran it.
+- `transport` — `local`, or `ssh` when `$SSH_CONNECTION` is present.
+- `sshClientIp` — the remote client IP when over SSH.
+
+So "was this agent started on the host by a remote user?" is answerable for any
+event, not just runs. The write is a synchronous single-line append (durable
+before the action proceeds); `AGENTS_DISABLE_EVENT_LOG=1` turns it off.
+
+```bash
+agents events                          # recent activity across everything
+agents events --module teams           # team lifecycle (create / add / disband)
+agents events --module secrets         # every secret accessed or revealed
+agents events --command "teams create" # a command path — prefix match
+agents events --event secrets.get --since 7d --json
+agents events -f                       # live tail of today's log
+```
+
+`--module` filters the top-level group; `--command` matches a command path by
+prefix (`teams` catches `teams create`); `--event` filters a typed event
+(repeatable); `--since` takes `2h`/`7d`/`4w` or an ISO date. `--json` emits the
+raw records for external consumers.
+
 External tools (dashboards, voice assistants, CI runners, monitoring) can read
 fleet state via three canonical `--json` sources. No direct DB access, no re-parsing
 of agent-specific formats, no auth to manage.

--- a/src/commands/events.ts
+++ b/src/commands/events.ts
@@ -1,0 +1,182 @@
+/**
+ * `agents events` — read the structured audit/event log.
+ *
+ * The event log (`~/.agents/.cache/logs/events-YYYY-MM-DD.jsonl`) records every
+ * `agents <module> <cmd>` invocation plus richer typed events (secrets access,
+ * version installs, ...), each stamped with who ran it and from where (OS user,
+ * local vs SSH, remote client IP). This command reads it back — the audit trail
+ * for "who accessed a secret / created a team / started an agent, and from which
+ * host?".
+ *
+ * Filter by `--module` (top-level group, e.g. teams), `--command` (path prefix,
+ * e.g. "teams create"), `--event` (typed event), `--agent`, and `--since`.
+ * `--follow` tails today's log live.
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import * as fs from 'fs';
+import { query, LOGS_PATH, type EventRecord, type EventType } from '../lib/events.js';
+
+interface EventsOptions {
+  module?: string;
+  command?: string;
+  event?: string[];
+  agent?: string;
+  since?: string;
+  limit?: string;
+  json?: boolean;
+  follow?: boolean;
+}
+
+/** Parse `--since`: relative offsets (30s/5m/2h/7d/4w) or an ISO/absolute date. */
+function parseSince(s: string): Date {
+  const m = s.match(/^(\d+)([smhdw])$/);
+  if (m) {
+    const n = parseInt(m[1], 10);
+    const unitMs: Record<string, number> = {
+      s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000, w: 604_800_000,
+    };
+    return new Date(Date.now() - n * unitMs[m[2]]);
+  }
+  const ms = Date.parse(s);
+  if (isNaN(ms)) throw new Error(`Invalid --since value: ${s} (use e.g. 2h, 7d, or an ISO date)`);
+  return new Date(ms);
+}
+
+/** How the run reached this host — 'local' or 'ssh 203.0.113.7'. */
+function originLabel(r: EventRecord): string {
+  if (r.transport === 'ssh') {
+    return chalk.yellow(`ssh${r.sshClientIp ? ' ' + r.sshClientIp : ''}`);
+  }
+  return chalk.gray('local');
+}
+
+/** The most useful one-line detail for a record, by event family. */
+function detailFor(r: EventRecord): string {
+  if (r.command) return r.command;
+  const bits: string[] = [];
+  if (typeof r.bundle === 'string') bits.push(`bundle=${r.bundle}`);
+  if (typeof r.skill === 'string') bits.push(`skill=${r.skill}`);
+  if (typeof r.version === 'string') bits.push(`v=${r.version}`);
+  if (typeof r.profile === 'string') bits.push(`profile=${r.profile}`);
+  if (typeof r.error === 'string') bits.push(chalk.red(r.error));
+  return bits.join(' ');
+}
+
+function renderRow(r: EventRecord): string {
+  const time = chalk.gray(r.ts.slice(0, 19).replace('T', ' '));
+  const user = `${r.osUser ?? '?'}@${r.hostname}`;
+  const ev = r.event.startsWith('error') ? chalk.red(r.event) : chalk.cyan(r.event);
+  const agent = r.agent ? chalk.gray(` ${r.agent}`) : '';
+  return `${time}  ${originLabel(r).padEnd(24)} ${user.padEnd(22)} ${ev.padEnd(26)}${agent}  ${detailFor(r)}`;
+}
+
+export function registerEventsCommand(program: Command): void {
+  program
+    .command('events')
+    .description('Read the structured audit/event log (who ran what, from where)')
+    .option('--module <name>', 'Only events from this command group (e.g. teams, secrets)')
+    .option('--command <path>', 'Only this command path — prefix match (e.g. "teams create")')
+    .option('--event <type>', 'Only this typed event (repeatable, e.g. secrets.get)', collect, [])
+    .option('--agent <name>', 'Only events tagged with this agent')
+    .option('--since <time>', 'Only events newer than this (e.g. 2h, 7d, or ISO date)')
+    .option('--limit <n>', 'Max records to show (default 50)', '50')
+    .option('--json', 'Output raw records as JSON')
+    .option('-f, --follow', "Tail today's log live")
+    .addHelpText('after', `
+Examples:
+  agents events                          Recent activity across everything
+  agents events --module teams           Team lifecycle (create / add / disband)
+  agents events --module secrets         Every secret accessed or revealed
+  agents events --command "teams create" Just team creations
+  agents events --event secrets.get --since 7d --json
+  agents events -f                       Live tail`)
+    .action(async (options: EventsOptions) => {
+      if (options.follow) {
+        await followLog();
+        return;
+      }
+
+      const limit = Math.max(1, parseInt(options.limit ?? '50', 10) || 50);
+      let startDate: Date | undefined;
+      try {
+        startDate = options.since ? parseSince(options.since) : undefined;
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(2);
+      }
+
+      const records = query({
+        startDate,
+        eventTypes: options.event && options.event.length ? (options.event as EventType[]) : undefined,
+        agent: options.agent,
+        command: options.command,
+        module: options.module,
+        limit,
+      });
+
+      if (options.json) {
+        console.log(JSON.stringify(records, null, 2));
+        return;
+      }
+
+      if (records.length === 0) {
+        console.log(chalk.gray('No matching events.'));
+        return;
+      }
+
+      // query() returns newest-first; print oldest-first so a tail reads naturally.
+      for (const r of records.slice().reverse()) console.log(renderRow(r));
+      console.log(chalk.gray(`\n${records.length} event(s). Log: ${LOGS_PATH}`));
+    });
+}
+
+/** commander repeatable-option collector. */
+function collect(value: string, previous: string[]): string[] {
+  return previous.concat([value]);
+}
+
+/** Tail today's event file, printing new lines as they land. */
+async function followLog(): Promise<void> {
+  const today = new Date();
+  const file = `${LOGS_PATH}/events-${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}.jsonl`;
+  let offset = 0;
+  try {
+    offset = fs.statSync(file).size;
+  } catch {
+    // File may not exist yet — start at 0 and pick it up on first write.
+  }
+  console.log(chalk.gray(`Tailing ${file} — Ctrl-C to stop`));
+  const drain = () => {
+    let size = 0;
+    try {
+      size = fs.statSync(file).size;
+    } catch {
+      return;
+    }
+    if (size <= offset) {
+      if (size < offset) offset = 0; // rotated/truncated
+      return;
+    }
+    const fd = fs.openSync(file, 'r');
+    try {
+      const buf = Buffer.alloc(size - offset);
+      fs.readSync(fd, buf, 0, buf.length, offset);
+      offset = size;
+      for (const line of buf.toString('utf-8').split('\n').filter(Boolean)) {
+        try {
+          console.log(renderRow(JSON.parse(line) as EventRecord));
+        } catch {
+          // Skip malformed lines.
+        }
+      }
+    } finally {
+      fs.closeSync(fd);
+    }
+  };
+  // Poll — simpler and more portable than fs.watch across platforms/editors.
+  await new Promise<void>(() => {
+    setInterval(drain, 500);
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,7 @@ import {
   loadComputer,
   loadHosts,
   loadLogs,
+  loadEvents,
   loadSsh,
   loadPull,
   loadPush,
@@ -129,6 +130,7 @@ import { applyGlobalHelpConventions } from './lib/help.js';
 import { renderWhatsNew } from './lib/whats-new.js';
 import type { AgentId } from './lib/types.js';
 import { IS_WINDOWS } from './lib/platform/index.js';
+import { emit, redactArgs } from './lib/events.js';
 
 // Transparent shim delegate: the generated Windows `.cmd` shims invoke
 // `agents __shim <agent>[@version] <raw args>`. Intercept here, before commander
@@ -153,6 +155,57 @@ program
   .version(VERSION)
   .helpOption('-h, --help', 'Show help')
   .addHelpCommand(false);
+
+// ─── Audit backbone ────────────────────────────────────────────────────────────
+// One choke point logs every `agents <module> <cmd>` invocation to the structured
+// event log — so team create/disband, agent run, secrets access, and everything
+// else is captured generically (with SSH/remote-user attribution added in emit()),
+// no per-command wiring. `agents events` reads it back. Attached to the root
+// program, so it's inherited by every subcommand regardless of lazy registration.
+
+/** Command path from the acting command up to (but excluding) the `agents` root. */
+function auditCommandPath(cmd: Command): string[] {
+  const parts: string[] = [];
+  let c: Command | null | undefined = cmd;
+  while (c && c.name() && c.name() !== 'agents') {
+    parts.unshift(c.name());
+    c = c.parent;
+  }
+  return parts;
+}
+
+const auditStarts = new WeakMap<Command, number>();
+
+program.hook('preAction', (_thisCommand, actionCommand) => {
+  try {
+    const parts = auditCommandPath(actionCommand);
+    if (parts.length === 0) return;
+    auditStarts.set(actionCommand, Date.now());
+    emit('command.start', {
+      module: parts[0],
+      command: parts.join(' '),
+      args: redactArgs(actionCommand.args),
+      cwd: process.cwd(),
+    });
+  } catch {
+    // Audit logging must never break command dispatch.
+  }
+});
+
+program.hook('postAction', (_thisCommand, actionCommand) => {
+  try {
+    const parts = auditCommandPath(actionCommand);
+    if (parts.length === 0) return;
+    const started = auditStarts.get(actionCommand);
+    emit('command.end', {
+      module: parts[0],
+      command: parts.join(' '),
+      ...(started !== undefined ? { durationMs: Date.now() - started } : {}),
+    });
+  } catch {
+    // Best-effort completion record; the start line is the durable audit fact.
+  }
+});
 
 // Custom help for the main program only
 const originalHelpInformation = program.helpInformation.bind(program);
@@ -885,6 +938,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadComputer);
   await reg(loadHosts);
   await reg(loadLogs);
+  await reg(loadEvents);
   await reg(loadSsh);
   registerJobsCronAliasCommand(program, 'jobs');
   registerJobsCronAliasCommand(program, 'cron');

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -16,6 +16,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { createHash } from 'node:crypto';
+import { parseSshConnection } from './session/provenance.js';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -106,6 +107,11 @@ export interface EventMeta {
   pid: number;
   ppid: number;
   event: EventType;
+  // Audit attribution — who ran this and from where. Answers "was this agent
+  // started on the host by a remote user?" for every event, not just runs.
+  osUser: string;
+  transport: 'local' | 'ssh';
+  sshClientIp?: string;
 }
 
 export interface EventPayload {
@@ -116,6 +122,9 @@ export interface EventPayload {
 
   // Context
   cwd?: string;
+  /** Top-level command group, e.g. 'teams', 'secrets' — the audit filter key. */
+  module?: string;
+  /** Full command path, e.g. 'teams create', 'secrets get'. */
   command?: string;
   args?: string[];
 
@@ -247,6 +256,37 @@ function truncatePayload(payload: EventPayload, maxLength: number = DEFAULT_TRUN
   return result;
 }
 
+// ─── Audit attribution ────────────────────────────────────────────────────────
+
+interface AuditOrigin {
+  osUser: string;
+  transport: 'local' | 'ssh';
+  sshClientIp?: string;
+}
+
+/**
+ * Who is running this process and from where. Derived once per process from the
+ * OS user and $SSH_CONNECTION (via the same parser the sessions layer uses), then
+ * cached — provenance can't change mid-process, so every emit() pays for it once.
+ */
+let _origin: AuditOrigin | undefined;
+function auditOrigin(): AuditOrigin {
+  if (_origin) return _origin;
+  let osUser = 'unknown';
+  try {
+    osUser = os.userInfo().username;
+  } catch {
+    // Container/edge cases where the uid has no passwd entry.
+  }
+  const ssh = process.env.SSH_CONNECTION ? parseSshConnection(process.env.SSH_CONNECTION) : undefined;
+  _origin = {
+    osUser,
+    transport: ssh ? 'ssh' : 'local',
+    ...(ssh ? { sshClientIp: ssh.clientIp } : {}),
+  };
+  return _origin;
+}
+
 // ─── Core API ─────────────────────────────────────────────────────────────────
 
 /**
@@ -271,23 +311,34 @@ export function emit(event: EventType, payload: EventPayload = {}): void {
       pid: process.pid,
       ppid: process.ppid,
       event,
+      ...auditOrigin(),
       ...truncatePayload(payload),
     };
 
     const line = JSON.stringify(record) + '\n';
     const logPath = getLogFilePath();
+    const isNew = !fs.existsSync(logPath);
     fs.appendFileSync(logPath, line, { mode: FILE_MODE });
 
-    // Ensure file permissions (appendFileSync doesn't respect mode on existing files)
-    try {
-      fs.chmodSync(logPath, FILE_MODE);
-    } catch {
-      // May fail if not owner
+    // appendFileSync's mode only applies when it CREATES the file, so we chmod
+    // to guarantee 0600 — but only on first write to a given path this process.
+    // command.start/end fire on every invocation; chmod-per-append would double
+    // the syscalls on the hot path for no gain (perms don't drift mid-run).
+    if (isNew || logPath !== _chmoddedPath) {
+      _chmoddedPath = logPath;
+      try {
+        fs.chmodSync(logPath, FILE_MODE);
+      } catch {
+        // May fail if not owner
+      }
     }
   } catch {
     // Silent failure - logging should never break the CLI
   }
 }
+
+/** Last log path this process chmod'd — avoids a redundant chmod per append. */
+let _chmoddedPath: string | undefined;
 
 /**
  * Convenience wrapper for timed operations.
@@ -566,9 +617,10 @@ export function query(options: {
   eventTypes?: EventType[];
   agent?: string;
   command?: string;
+  module?: string;
   limit?: number;
 }): EventRecord[] {
-  const { startDate, endDate = new Date(), eventTypes, agent, command, limit } = options;
+  const { startDate, endDate = new Date(), eventTypes, agent, command, module, limit } = options;
   const results: EventRecord[] = [];
 
   if (!fs.existsSync(LOGS_DIR)) return results;
@@ -597,7 +649,12 @@ export function query(options: {
 
         if (eventTypes && !eventTypes.includes(record.event)) continue;
         if (agent && record.agent !== agent) continue;
-        if (command && record.command !== command) continue;
+        // `--command` matches by path prefix on a word boundary, so a coarse
+        // "teams" catches "teams create"/"teams remove" while an exact
+        // "teams create" stays exact.
+        if (command && record.command !== command &&
+            !(typeof record.command === 'string' && record.command.startsWith(command + ' '))) continue;
+        if (module && record.module !== module) continue;
 
         results.push(record);
 

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,7 +1,7 @@
 /**
  * Centralized event logging for agents-cli.
  *
- * Structured JSONL logs at ~/.agents/logs/events-YYYY-MM-DD.jsonl
+ * Structured JSONL logs at ~/.agents/.cache/logs/events-YYYY-MM-DD.jsonl
  * with automatic daily rotation and rich metadata for debugging/auditing.
  *
  * Features:
@@ -630,6 +630,19 @@ export function query(options: {
     .sort()
     .reverse();
 
+  // Coarse file skip works on whole days, so floor the bounds to midnight —
+  // otherwise a sub-day window (`--since 2h` at 15:00 → startDate 13:00) would
+  // drop *today's* file, whose date stamps to 00:00. Precise filtering below is
+  // per-record on `ts`.
+  const startDay = startDate
+    ? new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate())
+    : undefined;
+  const endDay = endDate
+    ? new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate())
+    : undefined;
+  const startMs = startDate?.getTime();
+  const endMs = endDate?.getTime();
+
   for (const file of files) {
     const match = file.match(/^events-(\d{4})-(\d{2})-(\d{2})\.jsonl$/);
     if (!match) continue;
@@ -637,8 +650,8 @@ export function query(options: {
     const [, yyyy, mm, dd] = match;
     const fileDate = new Date(parseInt(yyyy), parseInt(mm) - 1, parseInt(dd));
 
-    if (startDate && fileDate < startDate) continue;
-    if (endDate && fileDate > endDate) continue;
+    if (startDay && fileDate < startDay) continue;
+    if (endDay && fileDate > endDay) continue;
 
     const content = fs.readFileSync(path.join(LOGS_DIR, file), 'utf-8');
     const lines = content.trim().split('\n').filter(Boolean);
@@ -646,6 +659,11 @@ export function query(options: {
     for (const line of lines.reverse()) {
       try {
         const record = JSON.parse(line) as EventRecord;
+
+        // Precise per-record window — the file skip above is day-granular only.
+        const recMs = Date.parse(record.ts);
+        if (startMs !== undefined && !isNaN(recMs) && recMs < startMs) continue;
+        if (endMs !== undefined && !isNaN(recMs) && recMs > endMs) continue;
 
         if (eventTypes && !eventTypes.includes(record.event)) continue;
         if (agent && record.agent !== agent) continue;

--- a/src/lib/startup/command-registry.ts
+++ b/src/lib/startup/command-registry.ts
@@ -76,6 +76,7 @@ export const loadBrowser: ModuleLoader = async () => (await import('../../comman
 export const loadComputer: ModuleLoader = async () => (await import('../../commands/computer.js')).registerComputerCommand;
 export const loadHosts: ModuleLoader = async () => (await import('../../commands/hosts.js')).registerHostsCommand;
 export const loadLogs: ModuleLoader = async () => (await import('../../commands/logs.js')).registerLogsCommand;
+export const loadEvents: ModuleLoader = async () => (await import('../../commands/events.js')).registerEventsCommand;
 export const loadSsh: ModuleLoader = async () => (await import('../../commands/ssh.js')).registerSshCommands;
 export const loadPull: ModuleLoader = async () => (await import('../../commands/pull.js')).registerPullCommand;
 export const loadPush: ModuleLoader = async () => (await import('../../commands/push.js')).registerPushCommand;
@@ -163,6 +164,7 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   computer: [loadComputer],
   hosts: [loadHosts],
   logs: [loadLogs],
+  events: [loadEvents],
   ssh: [loadSsh],
   devices: [loadSsh],
   pull: [loadPull],

--- a/tests/events-audit.test.ts
+++ b/tests/events-audit.test.ts
@@ -1,0 +1,119 @@
+/**
+ * End-to-end audit-log tests. Drive the REAL CLI entry (via tsx) with a temp
+ * HOME so the event log lands under the temp dir, then assert the structured
+ * records. Covers the three things the audit backbone must guarantee:
+ *   1. Every command fires a `command.start` with module + full command path.
+ *   2. Every record carries who ran it (osUser) and from where (transport).
+ *   3. SSH origin is attributed — "started on the host by a remote user".
+ *   4. `agents events --module` filters the trail back out.
+ *
+ * No mocking — the same code path a real invocation takes.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PACKAGE_VERSION = (JSON.parse(
+  fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf-8'),
+) as { version: string }).version;
+
+const tempHomes: string[] = [];
+
+function makeTempHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-events-'));
+  tempHomes.push(home);
+  const systemDir = path.join(home, '.agents', '.system');
+  fs.mkdirSync(path.join(systemDir, '.git'), { recursive: true });
+  fs.writeFileSync(
+    path.join(systemDir, '.update-check'),
+    JSON.stringify({ lastCheck: Date.now(), latestVersion: PACKAGE_VERSION }),
+  );
+  return home;
+}
+
+function runCli(home: string, args: string[], extraEnv: Record<string, string> = {}) {
+  return spawnSync('node', ['--import', 'tsx', 'src/index.ts', ...args], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, HOME: home, SHELL: '/bin/zsh', ...extraEnv },
+    encoding: 'utf-8',
+  });
+}
+
+/** Read every event record written under a temp HOME's log dir. */
+function readEvents(home: string): Array<Record<string, unknown>> {
+  const dir = path.join(home, '.agents', '.cache', 'logs');
+  if (!fs.existsSync(dir)) return [];
+  const out: Array<Record<string, unknown>> = [];
+  for (const f of fs.readdirSync(dir).filter((n) => n.startsWith('events-') && n.endsWith('.jsonl'))) {
+    for (const line of fs.readFileSync(path.join(dir, f), 'utf-8').split('\n').filter(Boolean)) {
+      try {
+        out.push(JSON.parse(line));
+      } catch {
+        /* skip */
+      }
+    }
+  }
+  return out;
+}
+
+afterEach(() => {
+  for (const h of tempHomes.splice(0)) {
+    try {
+      fs.rmSync(h, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+});
+
+describe('audit event log', () => {
+  it('records a command.start with module, command path, and local-user attribution', () => {
+    const home = makeTempHome();
+    // `secrets list` exercises a two-level command path (module=secrets,
+    // command="secrets list"). The preAction hook fires before the action, so
+    // the audit record lands even if the action itself no-ops on this platform.
+    // Clear SSH_CONNECTION so the local case is exercised even when the test
+    // runner itself is on an SSH session.
+    runCli(home, ['secrets', 'list'], { SSH_CONNECTION: '' });
+
+    const events = readEvents(home);
+    const start = events.find((e) => e.event === 'command.start' && e.command === 'secrets list');
+    expect(start, `no command.start for "secrets list" in ${JSON.stringify(events.map((e) => e.command))}`).toBeTruthy();
+    expect(start!.module).toBe('secrets');
+    expect(typeof start!.osUser).toBe('string');
+    expect((start!.osUser as string).length).toBeGreaterThan(0);
+    expect(start!.transport).toBe('local');
+    expect(start!.sshClientIp).toBeUndefined();
+  });
+
+  it('attributes an SSH origin to a remote user (SSH_CONNECTION → transport + client IP)', () => {
+    const home = makeTempHome();
+    runCli(home, ['secrets', 'list'], {
+      SSH_CONNECTION: '203.0.113.7 51828 10.0.0.3 22',
+      SSH_TTY: '/dev/pts/4',
+    });
+
+    const events = readEvents(home);
+    const start = events.find((e) => e.event === 'command.start');
+    expect(start).toBeTruthy();
+    expect(start!.transport).toBe('ssh');
+    expect(start!.sshClientIp).toBe('203.0.113.7');
+  });
+
+  it('reads the trail back out and filters by module', () => {
+    const home = makeTempHome();
+    runCli(home, ['secrets', 'list']);
+    runCli(home, ['events', '--json']); // a second, different module
+
+    const res = runCli(home, ['events', '--module', 'secrets', '--json']);
+    expect(res.status).toBe(0);
+    const records = JSON.parse(res.stdout) as Array<Record<string, unknown>>;
+    expect(records.length).toBeGreaterThan(0);
+    // Every returned record is from the secrets module, none from events.
+    expect(records.every((r) => r.module === 'secrets')).toBe(true);
+  });
+});

--- a/tests/events-audit.test.ts
+++ b/tests/events-audit.test.ts
@@ -116,4 +116,53 @@ describe('audit event log', () => {
     // Every returned record is from the secrets module, none from events.
     expect(records.every((r) => r.module === 'secrets')).toBe(true);
   });
+
+  it('--command matches a command path by prefix', () => {
+    const home = makeTempHome();
+    runCli(home, ['secrets', 'list']); // command path: "secrets list"
+
+    // A coarse "secrets" must catch the "secrets list" record...
+    const coarse = JSON.parse(runCli(home, ['events', '--command', 'secrets', '--json']).stdout) as Array<Record<string, unknown>>;
+    expect(coarse.some((r) => r.command === 'secrets list')).toBe(true);
+    // ...while a non-matching prefix returns nothing.
+    const none = JSON.parse(runCli(home, ['events', '--command', 'teams', '--json']).stdout) as Array<Record<string, unknown>>;
+    expect(none.length).toBe(0);
+  });
+
+  it('redacts a token-like positional arg before it hits the log', () => {
+    const home = makeTempHome();
+    // `secrets get <name>` no-ops (rc!=0) but the preAction hook still records
+    // the invocation; the token-shaped positional must be masked, not stored.
+    runCli(home, ['secrets', 'get', 'ghp_FAKETOKENVALUE123'], { SSH_CONNECTION: '' });
+
+    const raw = fs.readFileSync(
+      path.join(home, '.agents', '.cache', 'logs',
+        `events-${new Date().toISOString().slice(0, 10)}.jsonl`),
+      'utf-8',
+    );
+    expect(raw).not.toContain('ghp_FAKETOKENVALUE123');
+    expect(raw).toContain('[REDACTED]');
+  });
+
+  it('--since with a sub-day window returns today\'s events (not just whole days)', () => {
+    const home = makeTempHome();
+    runCli(home, ['secrets', 'list']);
+
+    // Regression: query() used to skip today's file when startDate was later
+    // than midnight, so a 2h window returned nothing on the day it was written.
+    const res = runCli(home, ['events', '--since', '2h', '--json']);
+    expect(res.status).toBe(0);
+    const records = JSON.parse(res.stdout) as Array<Record<string, unknown>>;
+    expect(records.length).toBeGreaterThan(0);
+  });
+
+  it('records command.end with a numeric durationMs', () => {
+    const home = makeTempHome();
+    runCli(home, ['secrets', 'list']);
+
+    const end = readEvents(home).find((e) => e.event === 'command.end' && e.command === 'secrets list');
+    expect(end).toBeTruthy();
+    expect(typeof end!.durationMs).toBe('number');
+    expect(end!.durationMs as number).toBeGreaterThanOrEqual(0);
+  });
 });


### PR DESCRIPTION
## What

Wires up the structured **audit event log** so security-sensitive actions are actually recorded, and adds `agents events` to read the trail back.

Before this, `src/lib/events.ts` was a solid engine (JSONL at `~/.agents/.cache/logs`, `0700`/`0600`, rotation, redaction) but only *partly* wired: secrets access fired events, yet **team create/disband and agent starts were never logged**, nothing captured **who** ran a command or **from where**, and there was **no CLI to read the log**.

## How

Rather than hand-wire ~20 `emit()` calls into individual call sites, the audit "push" lives at one **command-dispatch choke point**:

- **Backbone** — a commander `preAction`/`postAction` hook on the root program (`src/index.ts`) emits `command.start`/`command.end` for *every* `agents <module> <cmd>`. Team create/disband, `run`, secrets access — all captured generically, so coverage can't drift as new commands are added. Fully guarded; never throws into dispatch.
- **Attribution** — every event's base record now carries `osUser`, `transport` (`local`/`ssh`), and `sshClientIp` (parsed from `$SSH_CONNECTION` via the existing sessions provenance parser), computed once per process. This answers *"was this agent started on the host by a remote user?"* for any event.
- **Read surface** — `agents events` exposes the log with `--module`, `--command` (path-prefix), `--event`, `--agent`, `--since`, `--limit`, `--json`, and `-f` (live tail).
- **Fast insert** — kept the synchronous single-line append (durable before the action proceeds), and dropped the redundant per-append `chmod` to once-per-file, since `command.start/end` now fire on every invocation.

## Verified end-to-end

Real CLI, temp HOME:

```
$ agents teams create audit-demo   (with SSH_CONNECTION set)
$ agents events --module teams
2026-07-01 15:22:04  ssh 198.51.100.23   muqsit@yosemite-s0  command.start   teams create
2026-07-01 15:22:04  ssh 198.51.100.23   muqsit@yosemite-s0  command.end     teams create
```

Persisted JSONL: `{"event":"command.start","module":"teams","command":"teams create","osUser":"muqsit","transport":"ssh","sshClientIp":"198.51.100.23", ...}`

## Tests

`tests/events-audit.test.ts` drives the real CLI under a temp HOME and asserts: command-path + `osUser` + local transport, SSH-origin attribution from `SSH_CONNECTION`, and `--module` filtering. Full suite green (3569 passed).
