### PR TITLE
feat(events): semantic teams.create/teams.disband audit events

### DIFF
--- a/docs/06-observability.md
+++ b/docs/06-observability.md
@@ -15,7 +15,9 @@ The recording is a single choke point — a commander `preAction`/`postAction`
 hook on the root program ([`src/index.ts`](../src/index.ts)) emits `command.start`
 / `command.end` for *every* subcommand, so coverage is automatic and no per-command
 wiring can drift out of date. Richer typed events (`secrets.get`, `version.install`,
-…) layer on top where the extra payload earns it.
+`teams.create`, `teams.disband`, …) layer on top where the extra payload earns it —
+e.g. team lifecycle events are emitted at the registry source with the team name,
+so they fire for every path (`teams create` and the auto-create in `teams add`).
 
 Every record carries **attribution** computed once per process
 ([`src/lib/events.ts`](../src/lib/events.ts)):
@@ -33,6 +35,7 @@ agents events                          # recent activity across everything
 agents events --module teams           # team lifecycle (create / add / disband)
 agents events --module secrets         # every secret accessed or revealed
 agents events --command "teams create" # a command path — prefix match
+agents events --event teams.disband    # a semantic event: a team torn down
 agents events --event secrets.get --since 7d --json
 agents events -f                       # live tail of today's log
 ```

--- a/src/commands/events.ts
+++ b/src/commands/events.ts
@@ -56,6 +56,7 @@ function originLabel(r: EventRecord): string {
 function detailFor(r: EventRecord): string {
   if (r.command) return r.command;
   const bits: string[] = [];
+  if (typeof r.team === 'string') bits.push(`team=${r.team}`);
   if (typeof r.bundle === 'string') bits.push(`bundle=${r.bundle}`);
   if (typeof r.skill === 'string') bits.push(`skill=${r.skill}`);
   if (typeof r.version === 'string') bits.push(`v=${r.version}`);

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -77,6 +77,7 @@ export type EventType =
   | 'teams.add'
   | 'teams.start'
   | 'teams.complete'
+  | 'teams.disband'
   // Hooks
   | 'hook.fire'
   | 'hook.complete'

--- a/src/lib/teams/registry.ts
+++ b/src/lib/teams/registry.ts
@@ -13,6 +13,7 @@ import * as path from 'path';
 import { randomBytes } from 'crypto';
 import lockfile from 'proper-lockfile';
 import { getTeamsRegistryPath } from '../state.js';
+import { emit } from '../events.js';
 
 /** Metadata for a registered team. */
 export interface TeamMeta {
@@ -118,46 +119,59 @@ export async function createTeam(name: string, options?: CreateTeamOptions): Pro
     throw new Error('Cannot use both --enable-worktrees and --use-worktree. Pick one.');
   }
   const p = await registryPath();
-  return withRegistryLock(p, async () => {
+  const meta = await withRegistryLock(p, async () => {
     const reg = await loadTeams();
     if (reg[name]) {
       throw new Error(`Team '${name}' already exists`);
     }
-    const meta: TeamMeta = {
+    const m: TeamMeta = {
       created_at: new Date().toISOString(),
       ...(options?.description ? { description: options.description } : {}),
       ...(options?.enableWorktrees ? { enable_worktrees: true } : {}),
       ...(options?.useWorktree ? { use_worktree: options.useWorktree } : {}),
     };
-    reg[name] = meta;
+    reg[name] = m;
     await saveTeams(reg);
-    return meta;
+    return m;
   });
+  // Audit the lifecycle boundary, not the CLI shell — captures every creation
+  // path (create + ensure) with team metadata the generic command log lacks.
+  emit('teams.create', { team: name, worktrees: Boolean(options?.enableWorktrees || options?.useWorktree) });
+  return meta;
 }
 
 /** Return existing team metadata or create a new team if it does not exist. */
 export async function ensureTeam(name: string): Promise<TeamMeta> {
   const p = await registryPath();
-  return withRegistryLock(p, async () => {
+  let created = false;
+  const meta = await withRegistryLock(p, async () => {
     const reg = await loadTeams();
     if (reg[name]) return reg[name];
-    const meta: TeamMeta = { created_at: new Date().toISOString() };
-    reg[name] = meta;
+    const m: TeamMeta = { created_at: new Date().toISOString() };
+    reg[name] = m;
     await saveTeams(reg);
-    return meta;
+    created = true;
+    return m;
   });
+  // `teams add` auto-creates the team on first teammate — audit that creation
+  // too, but only when it actually happened (not the get-existing path).
+  if (created) emit('teams.create', { team: name, worktrees: false });
+  return meta;
 }
 
 /** Remove a team from the registry. Returns false if the team did not exist. */
 export async function removeTeam(name: string): Promise<boolean> {
   const p = await registryPath();
-  return withRegistryLock(p, async () => {
+  const existed = await withRegistryLock(p, async () => {
     const reg = await loadTeams();
     if (!reg[name]) return false;
     delete reg[name];
     await saveTeams(reg);
     return true;
   });
+  // "Disband" — only fires when a real team was removed, not a no-op.
+  if (existed) emit('teams.disband', { team: name });
+  return existed;
 }
 
 /** Check whether a team with the given name exists in the registry. */

--- a/src/lib/teams/registry.ts
+++ b/src/lib/teams/registry.ts
@@ -136,7 +136,7 @@ export async function createTeam(name: string, options?: CreateTeamOptions): Pro
   });
   // Audit the lifecycle boundary, not the CLI shell — captures every creation
   // path (create + ensure) with team metadata the generic command log lacks.
-  emit('teams.create', { team: name, worktrees: Boolean(options?.enableWorktrees || options?.useWorktree) });
+  emit('teams.create', { module: 'teams', team: name, worktrees: Boolean(options?.enableWorktrees || options?.useWorktree) });
   return meta;
 }
 
@@ -155,7 +155,7 @@ export async function ensureTeam(name: string): Promise<TeamMeta> {
   });
   // `teams add` auto-creates the team on first teammate — audit that creation
   // too, but only when it actually happened (not the get-existing path).
-  if (created) emit('teams.create', { team: name, worktrees: false });
+  if (created) emit('teams.create', { module: 'teams', team: name, worktrees: false });
   return meta;
 }
 
@@ -170,7 +170,7 @@ export async function removeTeam(name: string): Promise<boolean> {
     return true;
   });
   // "Disband" — only fires when a real team was removed, not a no-op.
-  if (existed) emit('teams.disband', { team: name });
+  if (existed) emit('teams.disband', { module: 'teams', team: name });
   return existed;
 }
 

--- a/tests/teams-events.test.ts
+++ b/tests/teams-events.test.ts
@@ -77,10 +77,18 @@ describe('team lifecycle audit events', () => {
 
     expect(create.length).toBe(1);
     expect(create[0].worktrees).toBe(true); // --enable-worktrees captured in payload
+    expect(create[0].module).toBe('teams'); // so `--module teams` surfaces it
     expect(disband.length).toBe(1);
     // Attribution rides along like every other event.
     expect(typeof create[0].osUser).toBe('string');
     expect(create[0].transport).toBe('local');
+
+    // The advertised `--module teams` filter must catch the semantic events,
+    // not just the generic command.* pair.
+    const byModule = JSON.parse(
+      runCli(home, ['events', '--module', 'teams', '--event', 'teams.create', '--json']).stdout,
+    ) as Array<Record<string, unknown>>;
+    expect(byModule.some((e) => e.event === 'teams.create' && e.team === 'audit-team')).toBe(true);
   });
 
   it('does NOT emit teams.disband when the team does not exist', () => {

--- a/tests/teams-events.test.ts
+++ b/tests/teams-events.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Semantic team-lifecycle audit events. `teams.create` / `teams.disband` are
+ * emitted at the registry source (createTeam / ensureTeam / removeTeam), so they
+ * fire for every path with team metadata the generic command.* log lacks — and
+ * ONLY when a real mutation happened. Driven through the real CLI under a temp
+ * HOME; no mocking.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PACKAGE_VERSION = (JSON.parse(
+  fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf-8'),
+) as { version: string }).version;
+
+const tempHomes: string[] = [];
+
+function makeTempHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-teamsev-'));
+  tempHomes.push(home);
+  const systemDir = path.join(home, '.agents', '.system');
+  fs.mkdirSync(path.join(systemDir, '.git'), { recursive: true });
+  fs.writeFileSync(
+    path.join(systemDir, '.update-check'),
+    JSON.stringify({ lastCheck: Date.now(), latestVersion: PACKAGE_VERSION }),
+  );
+  return home;
+}
+
+function runCli(home: string, args: string[]) {
+  return spawnSync('node', ['--import', 'tsx', 'src/index.ts', ...args], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, HOME: home, SHELL: '/bin/zsh', SSH_CONNECTION: '' },
+    encoding: 'utf-8',
+  });
+}
+
+function readEvents(home: string): Array<Record<string, unknown>> {
+  const dir = path.join(home, '.agents', '.cache', 'logs');
+  if (!fs.existsSync(dir)) return [];
+  const out: Array<Record<string, unknown>> = [];
+  for (const f of fs.readdirSync(dir).filter((n) => n.startsWith('events-') && n.endsWith('.jsonl'))) {
+    for (const line of fs.readFileSync(path.join(dir, f), 'utf-8').split('\n').filter(Boolean)) {
+      try {
+        out.push(JSON.parse(line));
+      } catch {
+        /* skip */
+      }
+    }
+  }
+  return out;
+}
+
+afterEach(() => {
+  for (const h of tempHomes.splice(0)) {
+    try {
+      fs.rmSync(h, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+});
+
+describe('team lifecycle audit events', () => {
+  it('emits teams.create (with metadata) and teams.disband for a real team', () => {
+    const home = makeTempHome();
+    runCli(home, ['teams', 'create', 'audit-team', '--enable-worktrees']);
+    runCli(home, ['teams', 'disband', 'audit-team']);
+
+    const events = readEvents(home);
+    const create = events.filter((e) => e.event === 'teams.create' && e.team === 'audit-team');
+    const disband = events.filter((e) => e.event === 'teams.disband' && e.team === 'audit-team');
+
+    expect(create.length).toBe(1);
+    expect(create[0].worktrees).toBe(true); // --enable-worktrees captured in payload
+    expect(disband.length).toBe(1);
+    // Attribution rides along like every other event.
+    expect(typeof create[0].osUser).toBe('string');
+    expect(create[0].transport).toBe('local');
+  });
+
+  it('does NOT emit teams.disband when the team does not exist', () => {
+    const home = makeTempHome();
+    const res = runCli(home, ['teams', 'disband', 'never-existed']);
+    // The command reports existed:false (no real removal), so no semantic
+    // teams.disband event fires — only the generic command.* pair.
+    expect(res.stdout).toContain('"existed": false');
+    expect(readEvents(home).some((e) => e.event === 'teams.disband')).toBe(false);
+  });
+
+  it('does NOT emit a second teams.create when create fails on a duplicate', () => {
+    const home = makeTempHome();
+    runCli(home, ['teams', 'create', 'dup-team']);
+    const second = runCli(home, ['teams', 'create', 'dup-team']); // already exists → error
+    expect(second.status).not.toBe(0);
+
+    const creates = readEvents(home).filter((e) => e.event === 'teams.create' && e.team === 'dup-team');
+    expect(creates.length).toBe(1); // emit is post-commit, so the failed create logs nothing
+  });
+});


### PR DESCRIPTION
## What

Follow-up to #593 (audit event log). Adds distinct **semantic team-lifecycle events** — `teams.create` and a new `teams.disband` — on top of the generic `command.*` backbone.

## Why

The generic hook already logs `teams create` / `teams disband` *invocations*, but as opaque command records. The semantic events carry the **team name** (and worktrees flag) as first-class payload, so `agents events --event teams.disband` answers "which teams were torn down, by whom, from where" directly — the headline case from the original ask ("an agent team is created or disbanded").

## How

Wired at the **registry source** (`src/lib/teams/registry.ts`), not the CLI shell, so every path is covered and can't drift:

- `createTeam` → `teams.create` (with `worktrees` flag) — the `teams create` command.
- `ensureTeam` → `teams.create` — the auto-create when `teams add` targets a new team; only when it actually creates (not the get-existing path).
- `removeTeam` → `teams.disband` — the `teams disband` command; only when a real team was removed.

Emits fire **after** the registry mutation commits (outside the lock), so a failed create or a no-op disband logs nothing. `agents events` renders `team=<name>` for these. Attribution (osUser / transport / sshClientIp) rides along from the shared `emit()`.

The still-dead `teams.add` / `teams.start` / `teams.complete` types remain covered by the generic `command.*` layer — they go through the manager/supervisor wave machinery with no single-source boundary worth a semantic event yet.

## Verified end-to-end

```
$ agents teams create audit-team --enable-worktrees
$ agents teams disband audit-team
$ agents events --event teams.create --event teams.disband
2026-07-01 18:07:38  local  muqsit@yosemite-s0  teams.create    team=audit-team
2026-07-01 18:07:38  local  muqsit@yosemite-s0  teams.disband   team=audit-team
```

## Tests

`tests/teams-events.test.ts` (real CLI, temp HOME): create+disband emits both with team + worktrees + attribution; disband of a missing team and a duplicate create emit nothing (post-commit guard). Full suite green (3594 passed).
