### PR TITLE
fix(session): parse Kimi tool args from event.args

### DIFF
--- a/src/lib/session/__tests__/parse-kimi.test.ts
+++ b/src/lib/session/__tests__/parse-kimi.test.ts
@@ -225,6 +225,75 @@ describe('parseKimi', () => {
     });
   });
 
+  // Tests for the event.args shape (real Kimi wire format as of 2026-06)
+  test('maps Bash tool.call with event.args shape to tool_use with command', () => {
+    const statePath = makeKimiSession(JSON.stringify({
+      type: 'context.append_loop_event',
+      event: {
+        type: 'tool.call',
+        uuid: 'tool_bash_001',
+        toolCallId: 'tool_bash_001',
+        name: 'Bash',
+        args: { command: 'ls -la /tmp', cwd: '/tmp' },
+      },
+      time: 1750723200000,
+    }));
+
+    const events = parseKimi(statePath);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'tool_use',
+      agent: 'kimi',
+      tool: 'Bash',
+      command: 'ls -la /tmp',
+      args: { command: 'ls -la /tmp', cwd: '/tmp' },
+    });
+  });
+
+  test('maps Read tool.call with event.args shape to tool_use with path', () => {
+    const statePath = makeKimiSession(JSON.stringify({
+      type: 'context.append_loop_event',
+      event: {
+        type: 'tool.call',
+        uuid: 'tool_read_002',
+        toolCallId: 'tool_read_002',
+        name: 'Read',
+        args: { path: '/tmp/testfile.txt' },
+      },
+      time: 1750723200001,
+    }));
+
+    const events = parseKimi(statePath);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'tool_use',
+      agent: 'kimi',
+      tool: 'Read',
+      path: '/tmp/testfile.txt',
+      args: { path: '/tmp/testfile.txt' },
+    });
+    expect((events[0] as any).command).toBeUndefined();
+  });
+
+  test('parses kimi-tool-args.jsonl fixture via event.args shape', () => {
+    const fixturePath = path.join(__dirname, '..', 'testdata', 'kimi-tool-args.jsonl');
+    const wireContent = fs.readFileSync(fixturePath, 'utf-8');
+    const statePath = makeKimiSession(wireContent);
+
+    const events = parseKimi(statePath);
+    const toolEvents = events.filter(e => e.type === 'tool_use') as any[];
+    expect(toolEvents.length).toBeGreaterThanOrEqual(3);
+
+    const bash = toolEvents.find(e => e.tool === 'Bash');
+    expect(bash).toBeDefined();
+    expect(bash.command).toBe('ls -la /tmp');
+    expect(bash.args.cwd).toBe('/tmp');
+
+    const read = toolEvents.find(e => e.tool === 'Read');
+    expect(read).toBeDefined();
+    expect(read.path).toBe('/tmp/testfile.txt');
+  });
+
   test('maps usage.record to usage event', () => {
     const statePath = makeKimiSession(JSON.stringify({
       type: 'usage.record',

--- a/src/lib/session/parse.ts
+++ b/src/lib/session/parse.ts
@@ -1092,7 +1092,9 @@ export function parseKimi(filePath: string): SessionEvent[] {
         const fn = event.function || {};
         const toolName = typeof event.name === 'string' ? event.name : (fn.name || 'unknown');
         let args: Record<string, any> = {};
-        if (typeof fn.arguments === 'string') {
+        if (event.args && typeof event.args === 'object') {
+          args = event.args;
+        } else if (typeof fn.arguments === 'string') {
           try {
             args = JSON.parse(fn.arguments);
           } catch {

--- a/src/lib/session/testdata/kimi-tool-args.jsonl
+++ b/src/lib/session/testdata/kimi-tool-args.jsonl
@@ -1,0 +1,3 @@
+{"type":"context.append_loop_event","event":{"type":"tool.call","uuid":"tool_bash_001","toolCallId":"tool_bash_001","name":"Bash","args":{"command":"ls -la /tmp","cwd":"/tmp"}},"time":1750723200000}
+{"type":"context.append_loop_event","event":{"type":"tool.call","uuid":"tool_read_002","toolCallId":"tool_read_002","name":"Read","args":{"path":"/tmp/testfile.txt"}},"time":1750723200001}
+{"type":"context.append_loop_event","event":{"type":"tool.call","uuid":"tool_skill_003","toolCallId":"tool_skill_003","name":"Skill","args":{"skill":"browser","args":"open https://example.com"}},"time":1750723200002}


### PR DESCRIPTION
## Bug

`parseKimi` in `src/lib/session/parse.ts` read tool-call arguments from `event.function.arguments` (a JSON string). Real Kimi wire.jsonl `tool.call` events store args in `event.args` (already an object) with the tool name in `event.name`.

Evidence: across all local Kimi sessions, **187 `tool.call` events use `event.args`, zero use `event.function`**. Sample wire line:

```json
{"type":"context.append_loop_event","event":{"type":"tool.call","uuid":"tool_yH23KjlUxa2Zlm57pMffaPUG","toolCallId":"tool_yH23KjlUxa2Zlm57pMffaPUG","name":"Read","args":{"path":"/tmp/rabbit-review/BRIEF.md"},...},"time":1782348599771}
```

Result: every Kimi tool's `path`/`command`/`args` were dropped — tool names survived but `args` was always `{}`.

## Fix

In the `eventType === 'tool.call'` branch of `parseKimi` (parse.ts:1091-1118), prefer `event.args` (object) first, then fall back to `event.function.arguments` (string or object) for backward compatibility with older Kimi versions. Tool name resolution (`event.name` first, then `event.function?.name`) and `toolCallId` mapping are unchanged.

**Before/after on real Kimi session (28 total tool_use events):**

| Metric | Before fix | After fix |
|--------|-----------|-----------|
| Bash with `command` set | 0 | 1 |
| Read with `path` set | 0 | 22 |

## Tests

- Added `src/lib/session/testdata/kimi-tool-args.jsonl` — synthetic fixture with Bash + Read + Skill events using the real `event.args` shape (no real user data)
- Added 3 new tests in `src/lib/session/__tests__/parse-kimi.test.ts`:
  - `maps Bash tool.call with event.args shape to tool_use with command`
  - `maps Read tool.call with event.args shape to tool_use with path`
  - `parses kimi-tool-args.jsonl fixture via event.args shape`
- All 15 parse-kimi tests pass; 0 failures introduced