### PR TITLE
fix(session): capture Droid Execute command + Create writes

### DIFF
--- a/src/lib/session/__tests__/parse-droid.test.ts
+++ b/src/lib/session/__tests__/parse-droid.test.ts
@@ -10,6 +10,8 @@ import * as os from 'os';
 import * as path from 'path';
 import { parseDroid, detectAgent, parseSession } from '../parse.js';
 
+const TESTDATA = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'testdata');
+
 function writeTmp(content: string): string {
   const dir = path.join(os.tmpdir(), `droid-parse-${Date.now()}-${Math.random()}`, '.factory', 'sessions', 'proj');
   fs.mkdirSync(dir, { recursive: true });
@@ -87,6 +89,42 @@ describe('parseDroid', () => {
     try {
       const events = parseDroid(p);
       expect(events.find((e) => e.type === 'error')).toMatchObject({ type: 'error', tool: 'Bash', content: 'boom' });
+    } finally {
+      fs.rmSync(path.dirname(p), { recursive: true, force: true });
+    }
+  });
+});
+
+describe('parseDroid Execute and Create tools', () => {
+  test('Execute tool_use sets command from fixture', () => {
+    // Uses synthetic fixture: testdata/droid-execute-create.jsonl
+    // Routes through a tmp .factory path so detectAgent works correctly.
+    const fixtureContent = fs.readFileSync(path.join(TESTDATA, 'droid-execute-create.jsonl'), 'utf-8');
+    const dir = path.join(os.tmpdir(), `droid-exec-${Date.now()}`, '.factory', 'sessions', 'proj');
+    fs.mkdirSync(dir, { recursive: true });
+    const p = path.join(dir, 'sess.jsonl');
+    fs.writeFileSync(p, fixtureContent);
+    try {
+      const events = parseDroid(p);
+      const execEvent = events.find((e) => e.type === 'tool_use' && e.tool === 'Execute');
+      expect(execEvent).toBeDefined();
+      expect(execEvent).toMatchObject({ type: 'tool_use', tool: 'Execute', command: 'ls -la' });
+    } finally {
+      fs.rmSync(path.dirname(p), { recursive: true, force: true });
+    }
+  });
+
+  test('Create tool_use sets path from file_path field', () => {
+    const fixtureContent = fs.readFileSync(path.join(TESTDATA, 'droid-execute-create.jsonl'), 'utf-8');
+    const dir = path.join(os.tmpdir(), `droid-create-${Date.now()}`, '.factory', 'sessions', 'proj');
+    fs.mkdirSync(dir, { recursive: true });
+    const p = path.join(dir, 'sess.jsonl');
+    fs.writeFileSync(p, fixtureContent);
+    try {
+      const events = parseDroid(p);
+      const createEvent = events.find((e) => e.type === 'tool_use' && e.tool === 'Create');
+      expect(createEvent).toBeDefined();
+      expect(createEvent).toMatchObject({ type: 'tool_use', tool: 'Create', path: '/work/hello.ts' });
     } finally {
       fs.rmSync(path.dirname(p), { recursive: true, force: true });
     }

--- a/src/lib/session/parse.ts
+++ b/src/lib/session/parse.ts
@@ -1221,7 +1221,7 @@ export function parseDroid(filePath: string): SessionEvent[] {
           tool: toolName,
           args: toolInput,
           path: toolInput.file_path || toolInput.path || undefined,
-          command: toolName === 'Bash' ? toolInput.command : undefined,
+          command: (toolName === 'Bash' || toolName === 'Execute') ? toolInput.command : undefined,
         });
       } else if (block.type === 'tool_result') {
         const toolId = block.tool_use_id;

--- a/src/lib/session/render.ts
+++ b/src/lib/session/render.ts
@@ -618,7 +618,7 @@ export function renderSummary(events: SessionEvent[], cwd?: string): string {
 
       if (['Read', 'read_file', 'view_file', 'cat_file', 'get_file'].includes(tool)) {
         if (p) filesReadAbs.add(p);
-      } else if (['Write', 'Edit', 'write_file', 'edit_file', 'create_file', 'replace', 'patch'].includes(tool)) {
+      } else if (['Write', 'Edit', 'Create', 'write_file', 'edit_file', 'create_file', 'replace', 'patch'].includes(tool)) {
         if (p) {
           if (p.includes('.claude/plans/') && p.endsWith('.md')) {
             planFilePath = p;

--- a/src/lib/session/testdata/droid-execute-create.jsonl
+++ b/src/lib/session/testdata/droid-execute-create.jsonl
@@ -1,0 +1,5 @@
+{"type":"session_start","id":"s-droid-exec-create","title":"droid execute+create fixture","cwd":"/work"}
+{"type":"message","timestamp":"2026-07-01T10:00:00Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu-exec-1","name":"Execute","input":{"command":"ls -la","riskLevelReason":"read-only","summary":"List files"}}]}}
+{"type":"message","timestamp":"2026-07-01T10:00:01Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu-exec-1","content":"total 0\ndrwxr-xr-x 2 user group 64 Jul  1 10:00 ."}]}}
+{"type":"message","timestamp":"2026-07-01T10:00:02Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu-create-1","name":"Create","input":{"file_path":"/work/hello.ts","content":"console.log('hello');\n"}}]}}
+{"type":"message","timestamp":"2026-07-01T10:00:03Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu-create-1","content":"File created successfully."}]}}


### PR DESCRIPTION
## Bug

`parseDroid` in `src/lib/session/parse.ts` only set the `command` field when `toolName === 'Bash'`. Droid (Factory) names its shell tool `Execute`, not `Bash`, so all 62 Execute calls in a real session had `command=undefined`.

Additionally, `render.ts` file-modified detection list did not include `'Create'` (Droid's write tool), so Droid-created files were not counted as modified.

## Evidence

Real session: `03fac085-f659-46e5-b2eb-a21aee5a0538.jsonl` (62 Execute calls, 1 Create call).

Before fix — `parseDroid` output:
```
Execute: n=62 command=0 path=0
Create:  n=1  command=0 path=1
```

After fix:
```
Execute: n=62 command=62 path=0
Create:  n=1  command=0  path=1
```

## Changes

- `src/lib/session/parse.ts` line 1224: `toolName === 'Bash'` → `(toolName === 'Bash' || toolName === 'Execute')`
- `src/lib/session/render.ts` line 621: added `'Create'` to the write/modified-detection list
- `src/lib/session/__tests__/parse-droid.test.ts`: two new tests covering `Execute` command capture and `Create` path capture
- `src/lib/session/testdata/droid-execute-create.jsonl`: synthetic fixture (no real user data)

## Tests

6 tests pass in `parse-droid.test.ts` (0 fail). The 10 failures in the full suite (`db.test.ts` SQLite constraints, `sync/config.test.ts` R2 config) are pre-existing and unrelated to this change.