### PR TITLE
feat(session): add Antigravity session parser (protobuf SQLite)

### DIFF
--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1246,6 +1246,7 @@ export function buildResumeCommand(session: SessionMeta): string[] | null {
     case 'opencode':
       return ['opencode', '--session', session.id];
     case 'gemini':
+    case 'antigravity':
     case 'openclaw':
     case 'rush':
     case 'hermes':

--- a/src/lib/session/__tests__/parse-antigravity.test.ts
+++ b/src/lib/session/__tests__/parse-antigravity.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Verifies parseAntigravity decodes Antigravity's protobuf-in-SQLite step
+ * payloads into the shared SessionEvent shape, normalizes tool names onto the
+ * existing vocabulary (run_command -> Bash, view_file -> Read, ...), dedupes the
+ * request + completion steps that share a call id, and that detectAgent routes
+ * antigravity-cli conversation DBs to this parser.
+ *
+ * The fixture is built here from scratch — a tiny SQLite `steps` table whose
+ * `step_payload` BLOBs are hand-encoded protobuf messages (deterministic,
+ * synthetic, no private conversation content). This exercises the real critical
+ * path (real sqlite3 subprocess, real protobuf decode), not a mock.
+ */
+
+import { describe, expect, test } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { parseAntigravity, detectAgent, parseSession } from '../parse.js';
+
+// ── Minimal protobuf wire encoder (mirror of the decoder under test) ────────
+
+/** Encode a non-negative integer as a base-128 varint. */
+function varint(n: number): number[] {
+  const out: number[] = [];
+  let v = n;
+  while (v > 0x7f) {
+    out.push((v & 0x7f) | 0x80);
+    v = Math.floor(v / 128);
+  }
+  out.push(v & 0x7f);
+  return out;
+}
+
+/** Encode a length-delimited string field: tag (field<<3|2) + len + utf8 bytes. */
+function strField(field: number, s: string): number[] {
+  const bytes = Array.from(Buffer.from(s, 'utf-8'));
+  return [...varint((field << 3) | 2), ...varint(bytes.length), ...bytes];
+}
+
+/**
+ * Build a step_payload for a tool call. Fields mirror the reverse-engineered
+ * layout: f1 = call id, f2 = tool name, f3 = JSON args (must contain
+ * "toolAction" for the decoder's JSON sniff). Optionally nests the tool-call
+ * message one level deep to exercise the recursive descent.
+ */
+function toolStep(opts: {
+  id: string;
+  name: string;
+  args: Record<string, any>;
+  nested?: boolean;
+}): Buffer {
+  const inner = [
+    ...strField(1, opts.id),
+    ...strField(2, opts.name),
+    ...strField(3, JSON.stringify(opts.args)),
+  ];
+  if (!opts.nested) return Buffer.from(inner);
+  // Wrap `inner` as a sub-message under an arbitrary field number (7) so the
+  // parser has to recurse to find the tool-call node.
+  return Buffer.from([...varint((7 << 3) | 2), ...varint(inner.length), ...inner]);
+}
+
+/** Create a temp Antigravity conversation DB with the given step payloads. */
+function buildDb(steps: Array<{ stepType: number; payload: Buffer }>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ag-parse-'));
+  const conv = path.join(dir, '.gemini', 'antigravity-cli', 'conversations');
+  fs.mkdirSync(conv, { recursive: true });
+  const dbPath = path.join(conv, 'fixture-uuid.db');
+
+  const inserts = steps
+    .map(
+      (s, i) =>
+        `INSERT INTO steps (idx, step_type, step_payload) VALUES (${i}, ${s.stepType}, X'${s.payload.toString('hex')}');`,
+    )
+    .join('\n');
+
+  const sql = [
+    'CREATE TABLE steps (idx integer PRIMARY KEY, step_type integer NOT NULL DEFAULT 0, step_payload blob);',
+    inserts,
+  ].join('\n');
+
+  execFileSync('sqlite3', [dbPath, sql], { encoding: 'utf-8' });
+  return dbPath;
+}
+
+describe('parseAntigravity', () => {
+  test('decodes protobuf steps, normalizes tool names, dedupes by call id', () => {
+    // Three raw steps -> two unique tools. The run_command appears twice (a
+    // request step + a completion step sharing call id "aaaa1111").
+    const dbPath = buildDb([
+      {
+        stepType: 15,
+        payload: toolStep({
+          id: 'aaaa1111',
+          name: 'run_command',
+          args: { CommandLine: 'echo hi', Cwd: '/work', toolAction: 'Running echo', toolSummary: 'Run echo' },
+        }),
+      },
+      {
+        stepType: 21, // completion — same id, must be deduped away
+        payload: toolStep({
+          id: 'aaaa1111',
+          name: 'run_command',
+          args: { CommandLine: 'echo hi', Cwd: '/work', toolAction: 'Running echo', toolSummary: 'Run echo' },
+        }),
+      },
+      {
+        stepType: 15,
+        payload: toolStep({
+          id: 'bbbb2222',
+          name: 'view_file',
+          args: { AbsolutePath: '/tmp/x', toolAction: 'Viewing x', toolSummary: 'View x' },
+          nested: true, // force recursive descent for this one
+        }),
+      },
+    ]);
+
+    const events = parseAntigravity(dbPath);
+
+    // Deduped: 3 steps -> 2 events.
+    expect(events).toHaveLength(2);
+
+    const bash = events[0];
+    expect(bash.type).toBe('tool_use');
+    expect(bash.agent).toBe('antigravity');
+    expect(bash.tool).toBe('Bash');
+    expect(bash.command).toBe('echo hi');
+    expect(bash.content).toBe('Run echo');
+
+    const read = events[1];
+    expect(read.tool).toBe('Read');
+    expect(read.path).toBe('/tmp/x');
+    expect(read.command).toBeUndefined();
+    expect(read.content).toBe('View x');
+
+    fs.rmSync(path.dirname(path.dirname(path.dirname(path.dirname(dbPath)))), { recursive: true, force: true });
+  });
+
+  test('maps the remaining tool names onto the shared vocabulary + passes unknowns through', () => {
+    const dbPath = buildDb([
+      { stepType: 15, payload: toolStep({ id: 'c1', name: 'list_dir', args: { DirectoryPath: '/d', toolAction: 'x', toolSummary: 'List' } }) },
+      { stepType: 15, payload: toolStep({ id: 'c2', name: 'grep_search', args: { SearchPath: '/g', Query: 'q', toolAction: 'x', toolSummary: 'Grep' } }) },
+      { stepType: 15, payload: toolStep({ id: 'c3', name: 'replace_file_content', args: { TargetFile: '/e', toolAction: 'x', toolSummary: 'Edit' } }) },
+      { stepType: 15, payload: toolStep({ id: 'c4', name: 'write_to_file', args: { TargetFile: '/w', toolAction: 'x', toolSummary: 'Write' } }) },
+      { stepType: 15, payload: toolStep({ id: 'c5', name: 'some_future_tool', args: { Foo: 'bar', toolAction: 'x', toolSummary: 'Future' } }) },
+    ]);
+
+    const events = parseAntigravity(dbPath);
+    expect(events.map(e => e.tool)).toEqual(['LS', 'Grep', 'Edit', 'Write', 'some_future_tool']);
+    expect(events[0].path).toBe('/d');
+    expect(events[1].path).toBe('/g');
+    expect(events[2].path).toBe('/e');
+    expect(events[3].path).toBe('/w');
+    // Unknown tool passes through with its raw args preserved.
+    expect(events[4].tool).toBe('some_future_tool');
+    expect(events[4].args?.Foo).toBe('bar');
+
+    fs.rmSync(path.dirname(path.dirname(path.dirname(path.dirname(dbPath)))), { recursive: true, force: true });
+  });
+
+  test('detectAgent + parseSession route antigravity conversation DBs here', () => {
+    const dbPath = buildDb([
+      { stepType: 15, payload: toolStep({ id: 'd1', name: 'run_command', args: { CommandLine: 'ls', toolAction: 'x', toolSummary: 'List dir' } }) },
+    ]);
+
+    // The path is under ~/.gemini/antigravity-cli/conversations/ (also matches
+    // /.gemini/), so this asserts antigravity wins over the gemini fallback.
+    expect(detectAgent(dbPath)).toBe('antigravity');
+
+    const events = parseSession(dbPath);
+    expect(events).toHaveLength(1);
+    expect(events[0].agent).toBe('antigravity');
+    expect(events[0].tool).toBe('Bash');
+    expect(events[0].command).toBe('ls');
+
+    fs.rmSync(path.dirname(path.dirname(path.dirname(path.dirname(dbPath)))), { recursive: true, force: true });
+  });
+});

--- a/src/lib/session/discover.ts
+++ b/src/lib/session/discover.ts
@@ -24,6 +24,7 @@ import { walkForFiles } from '../fs-walk.js';
 import { getConfigSymlinkVersion } from '../shims.js';
 import { SESSION_AGENTS } from './types.js';
 import { extractSessionTopic } from './prompt.js';
+import { parseAntigravity } from './parse.js';
 import { extractPrUrl, detectWorktree, detectTicket, isPrCreateCommand } from './state.js';
 import { costOfUsage } from '../pricing/index.js';
 import {
@@ -171,6 +172,7 @@ export async function discoverSessions(options?: DiscoverOptions): Promise<Sessi
             case 'claude': return scanClaudeIncremental(onProgress);
             case 'codex': return scanCodexIncremental(onProgress);
             case 'gemini': return scanGeminiIncremental(onProgress);
+            case 'antigravity': return scanAntigravityIncremental(onProgress);
             case 'opencode': return scanOpenCodeIncremental();
             case 'openclaw': return scanOpenClawIncremental();
             case 'rush': return scanRushIncremental(onProgress);
@@ -1036,6 +1038,105 @@ function buildGeminiProjectMap(): Map<string, { name: string; path: string }> {
   }
 
   return map;
+}
+
+// ---------------------------------------------------------------------------
+// Antigravity
+//
+// Antigravity stores one SQLite DB per conversation at
+// ~/.gemini/antigravity-cli/conversations/<trajectory-uuid>.db. The filename
+// (minus .db) is the canonical session id. Each DB is stat'd against the ledger;
+// only changed DBs are re-parsed (via parseAntigravity, which shells out to
+// sqlite3). Tool count doubles as the message count; the toolSummary of the
+// first tool call becomes the topic, and any run_command's Cwd fills in cwd.
+// ---------------------------------------------------------------------------
+
+/** Incrementally re-scan changed Antigravity conversation DBs and upsert into the DB. */
+async function scanAntigravityIncremental(onProgress?: (p: ScanProgress) => void): Promise<void> {
+  const currentVersion = await getCurrentAgentVersion('antigravity');
+
+  const filePaths: string[] = [];
+  const seenPaths = new Set<string>();
+  for (const conversationsDir of getAgentSessionDirs('antigravity', 'conversations')) {
+    let files: string[];
+    try {
+      files = fs.readdirSync(conversationsDir).filter(f => f.endsWith('.db'));
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      const fp = path.join(conversationsDir, file);
+      if (seenPaths.has(fp)) continue;
+      seenPaths.add(fp);
+      filePaths.push(fp);
+    }
+  }
+
+  const changed = filterChangedFiles(filePaths);
+  if (changed.length === 0) return;
+
+  onProgress?.({ agent: 'antigravity', parsed: 0, total: changed.length });
+
+  const entries: ScanEntry[] = [];
+  const touched: Array<{ filePath: string; scan: ScanStamp }> = [];
+  const seen = new Set<string>();
+  let parsed = 0;
+  for (const { filePath, scan } of changed) {
+    try {
+      const result = readAntigravityMeta(filePath, currentVersion);
+      if (result && !seen.has(result.meta.id)) {
+        seen.add(result.meta.id);
+        entries.push({ meta: result.meta, content: result.content, scan });
+      } else {
+        touched.push({ filePath, scan });
+      }
+    } catch {
+      touched.push({ filePath, scan });
+    }
+    parsed++;
+    onProgress?.({ agent: 'antigravity', parsed, total: changed.length });
+  }
+
+  upsertSessionsBatch(entries);
+  recordScans(touched);
+}
+
+/** Parse a single Antigravity conversation DB to extract session metadata. */
+function readAntigravityMeta(
+  filePath: string,
+  currentVersion?: string,
+): { meta: SessionMeta; content: string } | null {
+  const sessionId = path.basename(filePath).replace(/\.db$/, '');
+  if (!sessionId) return null;
+
+  const events = parseAntigravity(filePath);
+
+  // cwd: first run_command carries the working directory in its Cwd arg.
+  let cwd: string | undefined;
+  const contentParts: string[] = [];
+  for (const e of events) {
+    if (!cwd && typeof e.args?.Cwd === 'string' && e.args.Cwd) cwd = e.args.Cwd;
+    if (e.content) contentParts.push(e.content);
+  }
+  const normalizedCwd = cwd ? normalizeCwd(cwd) : undefined;
+
+  // Topic: the first tool's human summary is a decent one-line label.
+  const topic = events.find(e => e.content)?.content;
+
+  const stat = safeStatSync(filePath);
+  const meta: SessionMeta = {
+    id: sessionId,
+    shortId: sessionId.slice(0, 8),
+    agent: 'antigravity',
+    timestamp: stat ? stat.mtime.toISOString() : new Date().toISOString(),
+    project: normalizedCwd ? path.basename(normalizedCwd) : undefined,
+    cwd: normalizedCwd,
+    filePath,
+    version: resolveSessionVersion('antigravity', filePath, undefined, currentVersion),
+    topic: topic ? topic.slice(0, 120) : undefined,
+    messageCount: events.length,
+  };
+  return { meta, content: contentParts.join('\n') };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/session/parse.ts
+++ b/src/lib/session/parse.ts
@@ -90,6 +90,7 @@ export function parseSession(filePath: string, agent?: SessionAgentId): SessionE
     case 'claude': events = parseClaude(filePath); break;
     case 'codex': events = parseCodex(filePath); break;
     case 'gemini': events = parseGemini(filePath); break;
+    case 'antigravity': events = parseAntigravity(filePath); break;
     case 'opencode': events = parseOpenCode(filePath); break;
     case 'grok': events = parseGrok(filePath); break;
     case 'rush': events = parseRush(filePath); break;
@@ -110,6 +111,11 @@ export function parseSession(filePath: string, agent?: SessionAgentId): SessionE
 export function detectAgent(filePath: string): SessionAgentId | null {
   if (filePath.includes('/.claude/') || filePath.includes('\\.claude\\')) return 'claude';
   if (filePath.includes('/.codex/') || filePath.includes('\\.codex\\')) return 'codex';
+  // Antigravity lives under ~/.gemini/antigravity-cli/conversations/<uuid>.db, so
+  // it must be matched BEFORE the generic /.gemini/ check below or it would be
+  // misdetected as Gemini.
+  if ((filePath.includes('/antigravity-cli/conversations/') || filePath.includes('\\antigravity-cli\\conversations\\'))
+      && filePath.endsWith('.db')) return 'antigravity';
   if (filePath.includes('/.gemini/') || filePath.includes('\\.gemini\\')) return 'gemini';
   if (filePath.includes('/.grok/') || filePath.includes('\\.grok\\')) return 'grok';
   if (filePath.includes('/.rush/') || filePath.includes('\\.rush\\')) return 'rush';
@@ -657,6 +663,233 @@ function extractGeminiContent(content: any): string {
       .trim();
   }
   return '';
+}
+
+// ---------------------------------------------------------------------------
+// Antigravity parser
+//
+// Antigravity (Google's Gemini-CLI successor) stores each conversation as a
+// SQLite DB at ~/.gemini/antigravity-cli/conversations/<trajectory-uuid>.db.
+// Table `steps(idx, step_type, ..., step_payload BLOB, ...)`; step_payload is
+// protobuf with no .proto shipped. The wire layout, reverse-engineered and
+// uniform across every tool step, nests a tool-call sub-message with:
+//   f1  (string) = call id       (shared by the request + completion steps)
+//   f2  (string) = tool name     e.g. run_command / view_file / grep_search
+//   f3  (string) = JSON args     e.g. {"CommandLine":"date","Cwd":"…","toolAction":…}
+//   f30 (string) = toolSummary   short human label ("Run date")
+//   f31 (string) = toolAction    ("Running date command")
+// We never decode the step_type enum: extracting the tool name (f2) + JSON args
+// (f3) generically keeps the parser tool-agnostic, so a future tool (web search,
+// etc.) is captured automatically. Each tool surfaces TWICE — a request step
+// (step_type 15) and a completion step share the same f1 call id — so we dedupe
+// by that id. Mirrors parseOpenCode(): shell out to sqlite3, normalize to
+// SessionEvent[].
+// ---------------------------------------------------------------------------
+
+/** One decoded protobuf field at a single nesting level. */
+type ProtoField = { field: number; wire: number; value: number | Uint8Array };
+
+/** Read a base-128 varint from `b` at offset `i`; returns [value, nextOffset]. */
+function readVarint(b: Uint8Array, i: number): [number, number] {
+  let shift = 0;
+  let val = 0;
+  for (;;) {
+    const byte = b[i++];
+    val += (byte & 0x7f) * 2 ** shift;
+    if ((byte & 0x80) === 0) break;
+    shift += 7;
+  }
+  return [val, i];
+}
+
+/** Decode a protobuf message into a flat list of fields (one nesting level). */
+function decodeProtoMessage(b: Uint8Array): ProtoField[] {
+  const out: ProtoField[] = [];
+  let i = 0;
+  while (i < b.length) {
+    let tag: number;
+    [tag, i] = readVarint(b, i);
+    const field = tag >>> 3;
+    const wire = tag & 7;
+    if (wire === 0) {
+      let v: number;
+      [v, i] = readVarint(b, i);
+      out.push({ field, wire, value: v });
+    } else if (wire === 2) {
+      let len: number;
+      [len, i] = readVarint(b, i);
+      out.push({ field, wire, value: b.subarray(i, i + len) });
+      i += len;
+    } else if (wire === 5) {
+      i += 4; // fixed32 — skipped
+      out.push({ field, wire, value: 0 });
+    } else if (wire === 1) {
+      i += 8; // fixed64 — skipped
+      out.push({ field, wire, value: 0 });
+    } else {
+      break; // unknown wire type — stop to avoid runaway reads
+    }
+  }
+  return out;
+}
+
+const ANTIGRAVITY_TEXT_DECODER = new TextDecoder('utf-8', { fatal: false });
+
+/** A tool-call node recovered from a step payload. */
+interface AntigravityToolCall {
+  id?: string;
+  name: string;
+  args: Record<string, any>;
+  summary?: string;
+  action?: string;
+}
+
+/**
+ * Recursively locate the tool-call node: the first sub-message that carries an
+ * f2 string tool-name AND an f3 JSON-args string. Also captures the f1 call id
+ * (used to dedupe the request + completion steps) and the f30/f31 human labels.
+ */
+function findAntigravityToolCall(fields: ProtoField[]): AntigravityToolCall | null {
+  let id: string | undefined;
+  let name: string | undefined;
+  let argsJson: string | undefined;
+  let summary: string | undefined;
+  let action: string | undefined;
+  const subs: ProtoField[][] = [];
+
+  for (const f of fields) {
+    if (f.wire !== 2) continue;
+    const bytes = f.value as Uint8Array;
+    const s = ANTIGRAVITY_TEXT_DECODER.decode(bytes);
+    if (f.field === 1 && !id && /^[a-z0-9]{4,16}$/.test(s)) id = s;
+    else if (f.field === 2 && !name && /^[a-z][a-z_]{2,30}$/.test(s)) name = s;
+    else if (f.field === 3 && !argsJson && s.startsWith('{') && s.includes('"toolAction"')) argsJson = s;
+    else if (f.field === 30 && !summary) summary = s;
+    else if (f.field === 31 && !action) action = s;
+    else {
+      try {
+        subs.push(decodeProtoMessage(bytes));
+      } catch {
+        /* not a nested message */
+      }
+    }
+  }
+
+  if (name && argsJson) {
+    let args: Record<string, any> = {};
+    try {
+      args = JSON.parse(argsJson);
+    } catch {
+      args = { _raw: argsJson };
+    }
+    return { id, name, args, summary, action };
+  }
+  for (const sub of subs) {
+    const hit = findAntigravityToolCall(sub);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/**
+ * Map an Antigravity tool name onto the shared normalized vocabulary that the
+ * renderer already handles (so no render.ts changes are needed). Unknown tools
+ * pass through untouched (with their JSON args) so future tools are captured.
+ */
+const ANTIGRAVITY_TOOL_MAP: Record<string, string> = {
+  run_command: 'Bash',
+  view_file: 'Read',
+  read_file: 'Read',
+  list_dir: 'LS',
+  grep_search: 'Grep',
+  replace_file_content: 'Edit',
+  write_to_file: 'Write',
+  // Web tools surface identically once observed:
+  search_web: 'WebSearch',
+  read_url: 'WebFetch',
+  execute_url: 'WebFetch',
+};
+
+/**
+ * Parse an Antigravity conversation SQLite DB into normalized tool_use events.
+ * Deduped by the tool-call id so each tool appears once (Antigravity writes a
+ * request step and a completion step that share the id).
+ */
+export function parseAntigravity(dbPath: string): SessionEvent[] {
+  let rows: string;
+  try {
+    rows = execFileSync(
+      'sqlite3',
+      ['-separator', '\t', dbPath, 'SELECT idx, step_type, quote(step_payload) FROM steps ORDER BY idx;'],
+      {
+        encoding: 'utf-8',
+        timeout: 10000,
+        maxBuffer: 64 * 1024 * 1024,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      },
+    );
+  } catch {
+    /* DB not accessible, sqlite3 missing, or query failed */
+    return [];
+  }
+
+  // Single timestamp for the whole session: the steps table carries no per-step
+  // time column, so fall back to the DB file's mtime for a stable, sortable value.
+  let timestamp = new Date().toISOString();
+  try {
+    timestamp = fs.statSync(dbPath).mtime.toISOString();
+  } catch {
+    /* file vanished between query and stat — keep now() */
+  }
+
+  const events: SessionEvent[] = [];
+  const seenCallIds = new Set<string>();
+
+  for (const line of rows.split('\n')) {
+    if (!line.trim()) continue;
+    const tab1 = line.indexOf('\t');
+    if (tab1 === -1) continue;
+    const tab2 = line.indexOf('\t', tab1 + 1);
+    if (tab2 === -1) continue;
+    const hex = line.slice(tab2 + 1).trim();
+    // sqlite3 quote() renders a BLOB as X'...'; anything else (NULL) is skipped.
+    if (!hex.startsWith("X'") || !hex.endsWith("'")) continue;
+
+    const bytes = Uint8Array.from(Buffer.from(hex.slice(2, -1), 'hex'));
+    let fields: ProtoField[];
+    try {
+      fields = decodeProtoMessage(bytes);
+    } catch {
+      continue;
+    }
+    const call = findAntigravityToolCall(fields);
+    if (!call) continue;
+
+    // Dedupe: the request + completion steps of one tool share the f1 call id.
+    if (call.id) {
+      if (seenCallIds.has(call.id)) continue;
+      seenCallIds.add(call.id);
+    }
+
+    const norm = ANTIGRAVITY_TOOL_MAP[call.name] || call.name;
+    const a = call.args || {};
+    events.push({
+      type: 'tool_use',
+      agent: 'antigravity',
+      timestamp,
+      tool: norm,
+      args: a,
+      command: norm === 'Bash' ? a.CommandLine : undefined,
+      // Antigravity uses PascalCase arg keys; probe the known path-bearing ones.
+      path: a.AbsolutePath || a.TargetFile || a.DirectoryPath || a.SearchPath || undefined,
+      // Antigravity's own short human label — free, high quality. It surfaces
+      // either as the f30 string or (more reliably) as `toolSummary` inside the
+      // f3 JSON args.
+      content: call.summary || (typeof a.toolSummary === 'string' ? a.toolSummary : undefined) || undefined,
+    });
+  }
+
+  return events;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/session/types.ts
+++ b/src/lib/session/types.ts
@@ -8,10 +8,10 @@
  */
 
 /** Agents that store session data on disk and can be discovered by `agents sessions`. */
-export type SessionAgentId = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'rush' | 'hermes' | 'grok' | 'kimi' | 'droid';
+export type SessionAgentId = 'claude' | 'codex' | 'gemini' | 'antigravity' | 'opencode' | 'openclaw' | 'rush' | 'hermes' | 'grok' | 'kimi' | 'droid';
 
 /** All agents with session discovery support, in display order. */
-export const SESSION_AGENTS: SessionAgentId[] = ['claude', 'codex', 'gemini', 'opencode', 'openclaw', 'rush', 'hermes', 'grok', 'kimi', 'droid'];
+export const SESSION_AGENTS: SessionAgentId[] = ['claude', 'codex', 'gemini', 'antigravity', 'opencode', 'openclaw', 'rush', 'hermes', 'grok', 'kimi', 'droid'];
 
 /** A single normalized event within a session (message, tool call, thinking, etc.). */
 export interface SessionEvent {


### PR DESCRIPTION
## Antigravity session parser

Adds a session parser for the **Antigravity CLI** (Google's Gemini-CLI successor) so its conversations are discoverable and renderable by `agents sessions`.

### Format
Antigravity stores each conversation as a SQLite DB at `~/.gemini/antigravity-cli/conversations/<trajectory-uuid>.db`, table `steps(idx, step_type, ..., step_payload BLOB, ...)`. `step_payload` is **protobuf with no `.proto` shipped**. The reverse-engineered wire layout nests a tool-call sub-message:

| field | type | meaning |
|---|---|---|
| f1 | string | call id (shared by the request + completion steps) |
| f2 | string | tool name (`run_command`, `view_file`, ...) |
| f3 | string | JSON args (`{"CommandLine":"date","Cwd":"…","toolAction":…,"toolSummary":…}`) |
| f30 | string | toolSummary (short human label) |
| f31 | string | toolAction |

The parser never decodes the `step_type` enum — it extracts the tool name (f2) + JSON args (f3) **generically**, so any future tool (e.g. a web search) is captured automatically. It shells out to `sqlite3` exactly like `parseOpenCode` (`execFileSync`, `maxBuffer`, `timeout`, `stdio`).

### 7 tools mapped onto the existing shared vocabulary (no render.ts changes)
`run_command → Bash` (command ← `args.CommandLine`) · `view_file`/`read_file → Read` · `list_dir → LS` · `grep_search → Grep` · `replace_file_content → Edit` · `write_to_file → Write`. Unknown tool names pass through as-is with their JSON args. `content` is set to the high-quality `toolSummary` label.

### Dedupe
Antigravity emits each tool **twice** — a request step (`step_type=15`) and a completion step share the same **f1 call id**. The parser dedupes by that id so each tool_use appears once.

### Real-session verification
Parsed the real 116-step session `91c71c54-…941a.db`: 112 raw tool steps → **56 deduped tool_use events**:

```
Read    30   (all with real paths)
Grep     9
Bash     8   (all with commands: `date`, `git status && git diff --stat`, python one-liners, …)
LS       5
Edit     3
Write    1
```

Cross-checked paths (`/tmp/rabbit-review/BRIEF.md`, `…/agents/AGENTS.md`) and commands against raw `sqlite3` dumps; `content` labels populate (`Run echo`, `View x`, `List files`).

### Wiring
- `types.ts`: `'antigravity'` added to the `SessionAgentId` union + `SESSION_AGENTS`.
- `parse.ts`: `parseAntigravity()` + `parseSession` switch case + `detectAgent` (matches `/antigravity-cli/conversations/` `.db`, ordered **before** the generic `/.gemini/` check so it isn't misrouted to Gemini).
- `discover.ts`: `scanAntigravityIncremental()` — registers the conversations dir, one DB per session, session id = trajectory uuid; cwd from the first `run_command`'s `Cwd`, topic from the first tool summary.
- `sessions.ts`: antigravity added to the non-resumable list in `buildResumeCommand` (captured artifacts).

### Tests
`src/lib/session/__tests__/parse-antigravity.test.ts` builds a tiny **synthetic** SQLite fixture with hand-encoded protobuf tool-call steps (no private conversation data) and asserts normalized `Bash`/`Read`/`LS`/`Grep`/`Edit`/`Write` events, dedupe, unknown-tool passthrough, and `detectAgent`/`parseSession` routing. Real sqlite3 + real protobuf decode, no mocks.

`bunx tsc --noEmit` clean; `bun run build` clean; the 11 `__tests__` session suites (175 tests) pass.
