### PR TITLE
feat(plugins): wire GitHub Copilot CLI plugin support (RUSH-1337)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ Not every harness supports every capability — the registry decides per harness
 | Gemini † | `gemini` | ≥0.26 | ✓ | — | ✓ | ✓ | — | — | — | plan·edit·skip |
 | Cursor | `cursor` | — | ✓ | — | ✓ | ✓ | — | — | — | edit·skip |
 | OpenClaw | `openclaw` | ✓ | ✓ | — | ✓ | — | ✓ | ✓ | — | plan·edit·skip |
-| Copilot | `copilot` | — | ✓ | — | ✓ | ✓ | — | — | — | plan·edit·auto·skip |
+| Copilot | `copilot` | — | ✓ | — | ✓ | ✓ | ✓ | — | — | plan·edit·auto·skip |
 | Amp | `amp` | — | ✓ | — | ✓ | ✓ | — | — | — | plan·edit |
 | Kiro | `kiro` | — | ✓ | — | ✓ | ✓ | — | — | — | edit |
 | Goose | `goose` | — | ✓ | — | — | — | — | — | — | edit |

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -350,11 +350,16 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     commandsSubdir: 'commands',
     skillsDir: path.join(HOME, '.copilot', 'skills'),
     hooksDir: 'hooks',
+    // Copilot reads a plugin's manifest from the plugin ROOT (plugin.json),
+    // not `.claude-plugin/plugin.json`. Mirror it there. Verified against the
+    // GitHub Copilot CLI (1.0.56): `copilot plugin install` produces an
+    // installed plugin dir whose manifest sits at the root.
+    pluginManifestDir: '.',
     instructionsFile: 'AGENTS.md',
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
     supportsHooks: false,
-    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: false, subagents: false, rules: { file: 'AGENTS.md' }, workflows: false, modes: ['plan', 'edit', 'auto', 'skip'] },
+    capabilities: { hooks: false, mcp: true, allowlist: false, skills: true, commands: true, plugins: true, subagents: false, rules: { file: 'AGENTS.md' }, workflows: false, modes: ['plan', 'edit', 'auto', 'skip'] },
   },
   amp: {
     id: 'amp',

--- a/src/lib/plugin-marketplace.test.ts
+++ b/src/lib/plugin-marketplace.test.ts
@@ -27,6 +27,8 @@ import {
   unregisterMarketplace,
   addPluginToSettings,
   removePluginFromSettings,
+  registerCopilotInstalledPlugin,
+  unregisterCopilotInstalledPlugin,
   validateClaudePluginManifest,
 } from './plugin-marketplace.js';
 import type { DiscoveredPlugin, MarketplaceSpec } from './types.js';
@@ -359,6 +361,101 @@ describe('register/unregister marketplace', () => {
     registerMarketplace(SPECS.user, 'claude', versionHome);
     unregisterMarketplace('agents-cli', 'claude', versionHome);
     expect(fs.existsSync(knownMarketplacesPath('claude', versionHome))).toBe(false);
+  });
+});
+
+// ─── Copilot plugin registration ─────────────────────────────────────────────
+
+describe('copilot plugin registration', () => {
+  let tmpDir: string;
+  let versionHome: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cp-'));
+    versionHome = path.join(tmpDir, 'home');
+    fs.mkdirSync(path.join(versionHome, '.copilot'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const settingsPath = () => path.join(versionHome, '.copilot', 'settings.json');
+  const configPath = () => path.join(versionHome, '.copilot', 'config.json');
+  const readSettings = () => JSON.parse(fs.readFileSync(settingsPath(), 'utf-8'));
+  const readConfig = () => JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
+
+  it('marketplace manifest for copilot lives at the marketplace ROOT (not .claude-plugin/)', () => {
+    const p = marketplaceManifestPath(SPECS.user, 'copilot', versionHome);
+    expect(p).toBe(path.join(marketplaceRoot(SPECS.user, 'copilot', versionHome), 'marketplace.json'));
+    // Claude keeps the canonical .claude-plugin/ location.
+    expect(marketplaceManifestPath(SPECS.user, 'claude', versionHome)).toContain(
+      path.join('.claude-plugin', 'marketplace.json')
+    );
+  });
+
+  it('registerMarketplace writes settings.json#extraKnownMarketplaces, not known_marketplaces.json', () => {
+    registerMarketplace(SPECS.user, 'copilot', versionHome);
+    const settings = readSettings();
+    expect(settings.extraKnownMarketplaces['agents-cli']).toEqual({
+      source: { source: 'directory', path: marketplaceRoot(SPECS.user, 'copilot', versionHome) },
+    });
+    expect(fs.existsSync(knownMarketplacesPath('copilot', versionHome))).toBe(false);
+  });
+
+  it('registerMarketplace preserves unrelated settings and other marketplaces', () => {
+    fs.writeFileSync(settingsPath(), JSON.stringify({ theme: 'dark', enabledPlugins: { 'x@y': true } }));
+    registerMarketplace(SPECS.user, 'copilot', versionHome);
+    registerMarketplace(SPECS.project('/p/plugins'), 'copilot', versionHome);
+    const settings = readSettings();
+    expect(settings.theme).toBe('dark');
+    expect(settings.enabledPlugins).toEqual({ 'x@y': true });
+    expect(Object.keys(settings.extraKnownMarketplaces).sort()).toEqual(['agents-cli', 'agents-project']);
+  });
+
+  it('unregisterMarketplace drops only its own extraKnownMarketplaces entry', () => {
+    registerMarketplace(SPECS.user, 'copilot', versionHome);
+    registerMarketplace(SPECS.extra('extras', '/x/plugins'), 'copilot', versionHome);
+    unregisterMarketplace(SPECS.extra('extras', '/x/plugins'), 'copilot', versionHome);
+    expect(Object.keys(readSettings().extraKnownMarketplaces)).toEqual(['agents-cli']);
+  });
+
+  it('unregisterMarketplace prunes the empty key when the last marketplace goes', () => {
+    registerMarketplace(SPECS.user, 'copilot', versionHome);
+    unregisterMarketplace('agents-cli', 'copilot', versionHome);
+    expect(readSettings().extraKnownMarketplaces).toBeUndefined();
+  });
+
+  it('registerCopilotInstalledPlugin records config.json#installedPlugins with a cache_path', () => {
+    const installDir = marketplaceRoot(SPECS.user, 'copilot', versionHome) + '/plugins/demo';
+    registerCopilotInstalledPlugin('demo', 'agents-cli', installDir, '2.0.0', true, 'copilot', versionHome);
+    const config = readConfig();
+    expect(config.installedPlugins).toHaveLength(1);
+    expect(config.installedPlugins[0]).toMatchObject({
+      name: 'demo', marketplace: 'agents-cli', version: '2.0.0', enabled: true, cache_path: installDir,
+    });
+    expect(typeof config.installedPlugins[0].installed_at).toBe('string');
+  });
+
+  it('registerCopilotInstalledPlugin is idempotent and preserves installed_at + other keys', () => {
+    fs.writeFileSync(configPath(), '// managed\n' + JSON.stringify({ someKey: 1, installedPlugins: [] }));
+    registerCopilotInstalledPlugin('demo', 'agents-cli', '/i/demo', '1.0.0', true, 'copilot', versionHome);
+    const first = readConfig().installedPlugins[0].installed_at;
+    registerCopilotInstalledPlugin('demo', 'agents-cli', '/i/demo', '1.1.0', false, 'copilot', versionHome);
+    const config = readConfig();
+    expect(config.someKey).toBe(1);
+    expect(config.installedPlugins).toHaveLength(1);
+    expect(config.installedPlugins[0].version).toBe('1.1.0');
+    expect(config.installedPlugins[0].enabled).toBe(false);
+    expect(config.installedPlugins[0].installed_at).toBe(first);
+  });
+
+  it('unregisterCopilotInstalledPlugin removes only the matching entry', () => {
+    registerCopilotInstalledPlugin('a', 'agents-cli', '/i/a', '1.0.0', true, 'copilot', versionHome);
+    registerCopilotInstalledPlugin('b', 'agents-cli', '/i/b', '1.0.0', true, 'copilot', versionHome);
+    unregisterCopilotInstalledPlugin('a', 'agents-cli', 'copilot', versionHome);
+    const names = readConfig().installedPlugins.map((e: { name: string }) => e.name);
+    expect(names).toEqual(['b']);
   });
 });
 

--- a/src/lib/plugin-marketplace.ts
+++ b/src/lib/plugin-marketplace.ts
@@ -73,6 +73,38 @@ interface DroidInstalledPlugins {
   plugins: Record<string, DroidInstalledEntry[]>;
 }
 
+/**
+ * GitHub Copilot CLI records plugin state across TWO files under COPILOT_HOME
+ * (`~/.copilot`), both distinct from the marketplace catalog. Verified against
+ * Copilot CLI 1.0.56 (`plugin marketplace add` + `plugin install`):
+ *
+ *   settings.json  { extraKnownMarketplaces, enabledPlugins }  (user-editable)
+ *   config.json    { installedPlugins }                        (auto-managed)
+ *
+ * A plugin is only visible to `copilot plugin list` (and loaded at runtime) when
+ * it has an installedPlugins entry in config.json; the marketplace + enabledPlugins
+ * alone are not enough. `cache_path` may point at the marketplace install dir —
+ * no separate copy is needed (confirmed: `plugin list` lists it and `plugin
+ * marketplace list` shows the marketplace as registered).
+ */
+interface CopilotExtraMarketplace {
+  source: { source: 'directory'; path: string };
+}
+
+interface CopilotInstalledPluginEntry {
+  name: string;
+  marketplace: string;
+  version: string;
+  installed_at: string;
+  enabled: boolean;
+  cache_path: string;
+}
+
+interface CopilotConfig {
+  installedPlugins: CopilotInstalledPluginEntry[];
+  [key: string]: unknown;
+}
+
 interface MarketplacePluginEntry {
   name: string;
   source: string;
@@ -198,7 +230,13 @@ export function marketplaceRoot(specOrName: MarketplaceSpec | string, agent: Age
 }
 
 export function marketplaceManifestPath(specOrName: MarketplaceSpec | string, agent: AgentId, versionHome: string): string {
-  return path.join(marketplaceRoot(specOrName, agent, versionHome), '.claude-plugin', 'marketplace.json');
+  const root = marketplaceRoot(specOrName, agent, versionHome);
+  // Copilot resolves a marketplace's catalog from `marketplace.json` at the
+  // marketplace ROOT (also `.plugin/marketplace.json`, `.github/plugin/
+  // marketplace.json`) — NOT `.claude-plugin/marketplace.json`. Verified against
+  // GitHub Copilot CLI 1.0.56 (`plugin marketplace add`).
+  if (agent === 'copilot') return path.join(root, 'marketplace.json');
+  return path.join(root, '.claude-plugin', 'marketplace.json');
 }
 
 export function pluginInstallDir(plugin: DiscoveredPlugin, specOrName: MarketplaceSpec | string, agent: AgentId, versionHome: string): string {
@@ -469,6 +507,16 @@ export function syncMarketplaceManifest(spec: MarketplaceSpec, agent: AgentId, v
 export function registerMarketplace(spec: MarketplaceSpec, agent: AgentId, versionHome: string): void {
   const name = marketplaceNameFor(spec);
   const root = marketplaceRoot(spec, agent, versionHome);
+
+  // Copilot diverges from Claude's known_marketplaces.json: it reads registered
+  // marketplaces from settings.json#extraKnownMarketplaces. Verified against
+  // GitHub Copilot CLI 1.0.56 (`plugin marketplace add <dir>` writes exactly
+  // this shape). A "directory"-source entry points at the on-disk catalog root.
+  if (agent === 'copilot') {
+    registerCopilotMarketplace(name, root, agent, versionHome);
+    return;
+  }
+
   const knownPath = knownMarketplacesPath(agent, versionHome);
 
   let known: Record<string, KnownMarketplaceEntry> = {};
@@ -597,6 +645,125 @@ export function unregisterDroidInstalledPlugin(
   fs.writeFileSync(p, JSON.stringify(registry, null, 2) + '\n', 'utf-8');
 }
 
+// ─── Copilot marketplace + installed-plugin registry ──────────────────────────
+
+function copilotConfigPath(agent: AgentId, versionHome: string): string {
+  return path.join(versionHome, agentConfigDirName(agent), 'config.json');
+}
+
+function readCopilotSettings(agent: AgentId, versionHome: string): Record<string, unknown> {
+  const p = settingsPath(agent, versionHome);
+  if (fs.existsSync(p)) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(p, 'utf-8')) as Record<string, unknown>;
+      if (parsed && typeof parsed === 'object') return parsed;
+    } catch { /* fall through */ }
+  }
+  return {};
+}
+
+function writeCopilotSettings(agent: AgentId, versionHome: string, settings: Record<string, unknown>): void {
+  const p = settingsPath(agent, versionHome);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(settings, null, 2) + '\n', 'utf-8');
+}
+
+/** Register a marketplace in Copilot's settings.json#extraKnownMarketplaces. */
+function registerCopilotMarketplace(name: string, root: string, agent: AgentId, versionHome: string): void {
+  const settings = readCopilotSettings(agent, versionHome);
+  const known = (settings.extraKnownMarketplaces && typeof settings.extraKnownMarketplaces === 'object'
+    ? settings.extraKnownMarketplaces
+    : {}) as Record<string, CopilotExtraMarketplace>;
+  known[name] = { source: { source: 'directory', path: root } };
+  settings.extraKnownMarketplaces = known;
+  writeCopilotSettings(agent, versionHome, settings);
+}
+
+/** Inverse of registerCopilotMarketplace: drop the entry, prune the empty key. */
+function unregisterCopilotMarketplace(name: string, agent: AgentId, versionHome: string): void {
+  const p = settingsPath(agent, versionHome);
+  if (!fs.existsSync(p)) return;
+  const settings = readCopilotSettings(agent, versionHome);
+  const known = settings.extraKnownMarketplaces as Record<string, CopilotExtraMarketplace> | undefined;
+  if (!known || !(name in known)) return;
+  delete known[name];
+  if (Object.keys(known).length === 0) delete settings.extraKnownMarketplaces;
+  writeCopilotSettings(agent, versionHome, settings);
+}
+
+function readCopilotConfig(agent: AgentId, versionHome: string): CopilotConfig {
+  const p = copilotConfigPath(agent, versionHome);
+  if (fs.existsSync(p)) {
+    try {
+      // config.json may carry a leading `//` comment banner written by Copilot;
+      // strip line comments before parsing so we never clobber a real config.
+      const raw = fs.readFileSync(p, 'utf-8').replace(/^\s*\/\/.*$/gm, '');
+      const parsed = JSON.parse(raw) as Partial<CopilotConfig>;
+      if (parsed && typeof parsed === 'object') {
+        return { ...parsed, installedPlugins: Array.isArray(parsed.installedPlugins) ? parsed.installedPlugins : [] };
+      }
+    } catch { /* fall through to fresh config */ }
+  }
+  return { installedPlugins: [] };
+}
+
+/**
+ * Record a plugin in Copilot's config.json#installedPlugins (the registry that
+ * makes `copilot plugin list` see it). `cache_path` points at the marketplace
+ * install dir — no separate copy. Idempotent: re-running refreshes the entry and
+ * preserves the original installed_at plus every other config key.
+ */
+export function registerCopilotInstalledPlugin(
+  pluginName: string,
+  marketplaceName: string,
+  installDir: string,
+  version: string,
+  enabled: boolean,
+  agent: AgentId,
+  versionHome: string
+): void {
+  const config = readCopilotConfig(agent, versionHome);
+  const now = new Date().toISOString();
+  const prior = config.installedPlugins.find(e => e.name === pluginName && e.marketplace === marketplaceName);
+  const others = config.installedPlugins.filter(e => !(e.name === pluginName && e.marketplace === marketplaceName));
+  config.installedPlugins = [
+    ...others,
+    {
+      name: pluginName,
+      marketplace: marketplaceName,
+      version,
+      installed_at: prior?.installed_at ?? now,
+      enabled,
+      cache_path: installDir,
+    },
+  ];
+
+  const p = copilotConfigPath(agent, versionHome);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}
+
+/**
+ * Remove a plugin's entry from Copilot's config.json#installedPlugins. Inverse
+ * of registerCopilotInstalledPlugin. Leaves the file (with an empty
+ * installedPlugins) rather than deleting it, since config.json may hold other
+ * Copilot-managed keys.
+ */
+export function unregisterCopilotInstalledPlugin(
+  pluginName: string,
+  marketplaceName: string,
+  agent: AgentId,
+  versionHome: string
+): void {
+  const p = copilotConfigPath(agent, versionHome);
+  if (!fs.existsSync(p)) return;
+  const config = readCopilotConfig(agent, versionHome);
+  const kept = config.installedPlugins.filter(e => !(e.name === pluginName && e.marketplace === marketplaceName));
+  if (kept.length === config.installedPlugins.length) return;
+  config.installedPlugins = kept;
+  fs.writeFileSync(p, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}
+
 /**
  * Drop a marketplace entry from known_marketplaces.json. Called when the last
  * plugin under it is removed. Removes only its own entry; deletes the file only
@@ -604,6 +771,14 @@ export function unregisterDroidInstalledPlugin(
  */
 export function unregisterMarketplace(specOrName: MarketplaceSpec | string, agent: AgentId, versionHome: string): void {
   const name = nameOf(specOrName);
+
+  // Copilot stores registrations in settings.json#extraKnownMarketplaces, not
+  // known_marketplaces.json. Mirror the branch in registerMarketplace.
+  if (agent === 'copilot') {
+    unregisterCopilotMarketplace(name, agent, versionHome);
+    return;
+  }
+
   const knownPath = knownMarketplacesPath(agent, versionHome);
   if (!fs.existsSync(knownPath)) return;
 

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -31,6 +31,8 @@ import {
   registerDroidInstalledPlugin,
   unregisterDroidInstalledPlugin,
   isDroidPluginInstalled,
+  registerCopilotInstalledPlugin,
+  unregisterCopilotInstalledPlugin,
   marketplaceIsEmpty,
   removeEmptyMarketplaceDir,
   isInstalledInMarketplace,
@@ -610,6 +612,23 @@ export function syncPluginToVersion(
     );
   }
 
+  // 5d. Copilot, like Droid, only "sees" a plugin that also has an entry in its
+  //     auto-managed config.json#installedPlugins (registerMarketplace already
+  //     wrote settings.json#extraKnownMarketplaces, and addPluginToSettings the
+  //     enabledPlugins flag). cache_path points at the marketplace copy; the
+  //     `enabled` flag mirrors the exec-surface trust gate above.
+  if (agent === 'copilot') {
+    registerCopilotInstalledPlugin(
+      plugin.name,
+      marketplaceName,
+      installDir,
+      plugin.manifest.version,
+      enablePlugin,
+      agent,
+      versionHome
+    );
+  }
+
   // 5b. Convert plugin commands/ to skills for agents that dropped command support
   //     (Codex >= 0.117.0). Skill name is prefixed with plugin name to avoid
   //     collision with standalone command skills.
@@ -887,6 +906,9 @@ export function removePluginFromVersion(
     if (agent === 'droid') {
       unregisterDroidInstalledPlugin(pluginName, name, agent, versionHome);
     }
+    if (agent === 'copilot') {
+      unregisterCopilotInstalledPlugin(pluginName, name, agent, versionHome);
+    }
 
     // Refresh marketplace.json so it reflects what's left under plugins/.
     syncMarketplaceManifest(spec, agent, versionHome);
@@ -1078,6 +1100,9 @@ export function cleanOrphanedPluginSkills(
         removePluginFromSettings(entry.name, name, agent, versionHome);
         if (agent === 'droid') {
           unregisterDroidInstalledPlugin(entry.name, name, agent, versionHome);
+        }
+        if (agent === 'copilot') {
+          unregisterCopilotInstalledPlugin(entry.name, name, agent, versionHome);
         }
         removed.push(entry.name);
         trashedHere = true;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -97,6 +97,13 @@ export interface AgentConfig {
    */
   nativeCommandRuntime?: boolean;
   hooksDir: string;
+  /**
+   * Directory (relative to a plugin's install dir) the agent reads its plugin
+   * manifest from, when it differs from the canonical `.claude-plugin/`. Codex
+   * uses `.codex-plugin`, Droid `.factory-plugin`. Set to `.` when the agent
+   * reads the manifest from the plugin ROOT (Copilot). syncPluginToVersion
+   * mirrors `.claude-plugin/plugin.json` into this dir.
+   */
   pluginManifestDir?: string;
   instructionsFile: string;
   format: 'markdown' | 'toml';


### PR DESCRIPTION
## What

Wires GitHub Copilot CLI plugin support end-to-end. Copilot gets its **own** plugin-writer branch (not a mirror of grok/kimi/antigravity) because its on-disk model diverges from Claude's on three axes. Every divergence below was verified against the real Copilot CLI binary (1.0.56) on Linux.

## The Copilot plugin model (ground-truthed)

Ran `copilot plugin marketplace add` + `copilot plugin install` against an isolated `COPILOT_HOME` and inspected the resulting files:

- **Plugin manifest at the ROOT** (`plugin.json`), not `.claude-plugin/plugin.json`.
- **Marketplace catalog at the marketplace ROOT** (`marketplace.json`), not `.claude-plugin/marketplace.json`. `owner` is required.
- **Registered marketplaces** live in `~/.copilot/settings.json` → `extraKnownMarketplaces`, NOT `known_marketplaces.json`.
- **Installed plugins** are tracked in `~/.copilot/config.json` → `installedPlugins[]` with a `cache_path`. This (not `enabledPlugins` alone) is what makes `copilot plugin list` see the plugin — exactly analogous to Droid's `installed_plugins.json`. `cache_path` can point straight at the marketplace copy, so no third copy is needed. There is **no `copilot plugin enable` subcommand** in 1.0.56 (`install` enables).

## Changes

- `src/lib/agents.ts` — copilot `plugins: false` → `true`; add `pluginManifestDir: '.'` (mirror manifest to plugin root).
- `src/lib/plugin-marketplace.ts` — `marketplaceManifestPath` writes root `marketplace.json` for copilot; `registerMarketplace`/`unregisterMarketplace` branch to `settings.json#extraKnownMarketplaces`; new `registerCopilotInstalledPlugin`/`unregisterCopilotInstalledPlugin` manage `config.json#installedPlugins`.
- `src/lib/plugins.ts` — `syncPluginToVersion` registers the copilot installed-plugin (parallel to the droid branch); both removal paths unregister it.
- `src/lib/types.ts` — document `pluginManifestDir` (incl. `.` = plugin root).
- `src/lib/plugin-marketplace.test.ts` — 9 new tests for the copilot marketplace + installed-plugin registry.
- `AGENTS.md` — flip the Copilot `plugins` cell to ✓.

## Verification

**End-to-end (real binary, no mocks):** drove agents-cli's `syncPluginToVersion('copilot', …)` on a demo plugin, then pointed the real Copilot CLI at the synced home:

```
$ copilot plugin list
Installed plugins:
  • demo-plugin@agents-cli (v1.2.3)

$ copilot plugin marketplace list
Registered marketplaces:
  • agents-cli (Local: …/.copilot/plugins/marketplaces/agents-cli)
```

Removal path clears `extraKnownMarketplaces`, `enabledPlugins`, and `installedPlugins`.

**Tests:** `plugin-marketplace.test.ts` 42/42 pass; `tsc --noEmit` clean. Full suite otherwise green — the only failures (`session/sync/config.test.ts`, R2/keychain cache) reproduce on untouched `main` and are unrelated (environment-dependent keychain fallback on this host).

## Note

The RUSH-1337 brief anticipated marketplaces under `~/.cache/copilot/marketplaces/` and a `plugin enable` command; the real 1.0.56 binary instead keeps registration in `COPILOT_HOME` (`settings.json` + `config.json`) and has no `enable` subcommand — which agents-cli already isolates per-version via `COPILOT_HOME`, so no shim/cache-env changes were needed.