### PR TITLE
feat(sessions): multi-select `resume` — fan sessions out to terminal tabs

### DIFF
--- a/src/commands/sessions-resume.ts
+++ b/src/commands/sessions-resume.ts
@@ -1,0 +1,204 @@
+/**
+ * `agents sessions resume` — multi-select sessions and fan each one out into a
+ * terminal tab.
+ *
+ * Unlike the single-select picker behind bare `agents sessions` (which resumes
+ * one session in place), this opens a checkbox picker, then asks where the
+ * chosen sessions should resume: a new tab in the terminal you're in now
+ * (auto-detected), a new iTerm tab, or a new Ghostty tab — one tab per session.
+ */
+import * as fs from 'fs';
+import chalk from 'chalk';
+import type { Command } from 'commander';
+import type { SessionMeta } from '../lib/session/types.js';
+import { discoverSessions } from '../lib/session/discover.js';
+import { filterTeamSessions } from '../lib/session/team-filter.js';
+import { multiItemPicker, itemPicker } from '../lib/picker.js';
+import { buildPreview } from './sessions-picker.js';
+import {
+  filterSessionsByQuery,
+  formatPickerLabel,
+  buildResumeCommand,
+  resumeSessionInPlace,
+  parseAgentFilter,
+} from './sessions.js';
+import {
+  availableDestinations,
+  launchResumeInTab,
+  type DestinationChoice,
+  type ResumeTarget,
+} from '../lib/session/launch.js';
+import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
+import { setHelpSections } from '../lib/help.js';
+import { confirm } from '@inquirer/prompts';
+
+/** Opening more than this many live sessions at once asks for confirmation first. */
+const CONFIRM_THRESHOLD = 5;
+/** Stagger between tab launches so N tabs don't stampede the launcher. */
+const STAGGER_MS = 700;
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+interface ResumeOptions {
+  agent?: string;
+  all?: boolean;
+  teams?: boolean;
+  since?: string;
+  limit?: string;
+}
+
+export function registerSessionsResumeCommand(sessionsCmd: Command): void {
+  const cmd = sessionsCmd
+    .command('resume')
+    .argument('[query]', 'Filter sessions before selecting (topic, path, or id fragment)')
+    .description('Multi-select sessions and resume each in a new tab (this terminal, iTerm, or Ghostty).')
+    .option('-a, --agent <agent>', 'Filter by agent type and version (e.g., claude, codex@0.116.0)')
+    .option('--all', 'Include sessions from every directory (not just current project)')
+    .option('--teams', 'Include team-spawned sessions (hidden by default)')
+    .option('--since <time>', 'Only sessions newer than this (e.g., 2h, 7d, 4w, or ISO date)')
+    .option('-n, --limit <n>', 'Maximum number of sessions to load into the picker', '200');
+
+  setHelpSections(cmd, {
+    examples: `
+      # Pick several sessions, choose where they resume
+      agents sessions resume
+
+      # Pre-filter the pool before selecting
+      agents sessions resume "auth middleware"
+
+      # Include every directory, not just this project
+      agents sessions resume --all
+    `,
+    notes: `
+      - space toggles a session, enter confirms; tab toggles the preview pane.
+      - Destinations: "This terminal" auto-detects your emulator (iTerm / Ghostty / tmux);
+        iTerm and Ghostty are offered on macOS when the app is installed.
+      - Each selected session opens in its own tab, version-pinned, in its own cwd.
+    `,
+  });
+
+  cmd.action(async (query: string | undefined, options: ResumeOptions) => {
+    await sessionsResumeAction(query, options);
+  });
+}
+
+async function sessionsResumeAction(query: string | undefined, options: ResumeOptions): Promise<void> {
+  if (!isInteractiveTerminal()) {
+    console.error(chalk.red('sessions resume needs an interactive terminal.'));
+    process.exitCode = 1;
+    return;
+  }
+
+  const { agent, version } = parseAgentFilter(options.agent);
+  const limit = parseInt(options.limit || '200', 10);
+  const since = options.since ?? (options.all ? undefined : '30d');
+
+  let sessions = await discoverSessions({
+    agent,
+    version,
+    all: options.all,
+    cwd: process.cwd(),
+    since,
+    sortBy: 'timestamp',
+    limit,
+    excludeTeamOrigin: !options.teams,
+  });
+  const { visible } = filterTeamSessions(sessions, !!options.teams);
+  sessions = visible;
+
+  if (sessions.length === 0) {
+    console.log(chalk.gray('No sessions found. Try --all or a different --since window.'));
+    return;
+  }
+
+  // 1. Multi-select the sessions.
+  let chosen: SessionMeta[] | null;
+  try {
+    chosen = await multiItemPicker<SessionMeta>({
+      message: 'Select sessions to resume:',
+      items: sessions,
+      filter: (q: string) => (q.trim() ? filterSessionsByQuery(sessions, q) : sessions),
+      labelFor: (s, q) => formatPickerLabel(s, q),
+      keyFor: (s) => s.id,
+      buildPreview,
+      pageSize: 15,
+      initialSearch: query,
+      emptyMessage: 'No sessions match.',
+      enterHint: 'resume',
+    });
+  } catch (err) {
+    if (isPromptCancelled(err)) return;
+    throw err;
+  }
+  if (!chosen || chosen.length === 0) return;
+
+  // 2. Choose the destination.
+  const dests = availableDestinations();
+  let target: ResumeTarget;
+  if (dests.length === 1) {
+    target = dests[0].target;
+  } else {
+    let pickedDest;
+    try {
+      pickedDest = await itemPicker<DestinationChoice>({
+        message: `Resume ${chosen.length} session${chosen.length === 1 ? '' : 's'} where?`,
+        items: dests,
+        filter: () => dests,
+        labelFor: (d) => `${chalk.bold(d.label.padEnd(14))}${chalk.gray(d.detail)}`,
+        shortIdFor: (d) => d.label,
+        enterHint: 'open',
+      });
+    } catch (err) {
+      if (isPromptCancelled(err)) return;
+      throw err;
+    }
+    if (!pickedDest) return;
+    target = pickedDest.item.target;
+  }
+
+  // 3. Guard against opening a flood of live agents.
+  if (chosen.length > CONFIRM_THRESHOLD) {
+    const proceed = await confirm({
+      message: `Open ${chosen.length} live sessions at once?`,
+      default: false,
+    }).catch(() => false);
+    if (!proceed) return;
+  }
+
+  // 4. Launch.
+  if (target === 'inplace') {
+    // No emulator we can open tabs into — resume sequentially in this terminal.
+    if (chosen.length > 1) {
+      console.log(chalk.gray(`Resuming ${chosen.length} sessions one at a time (no tab-capable terminal detected).`));
+    }
+    for (const s of chosen) {
+      await resumeSessionInPlace(s);
+    }
+    return;
+  }
+
+  await launchTabs(chosen, target);
+}
+
+/** Open one tab per session in the chosen emulator, staggered, reporting each. */
+async function launchTabs(chosen: SessionMeta[], target: Exclude<ResumeTarget, 'inplace'>): Promise<void> {
+  let opened = 0;
+  for (let i = 0; i < chosen.length; i++) {
+    const s = chosen[i];
+    const resume = buildResumeCommand(s);
+    if (!resume) {
+      console.log(chalk.yellow(`  skip ${s.shortId} — resume is not supported for ${s.agent} sessions yet`));
+      continue;
+    }
+    const cwd = s.cwd && fs.existsSync(s.cwd) ? s.cwd : process.cwd();
+    const res = await launchResumeInTab(target, cwd, resume);
+    if (res.ok) {
+      opened++;
+      console.log(chalk.green(`  opened ${s.shortId}`) + chalk.gray(` — ${resume.join(' ')}  (${cwd})`));
+    } else {
+      console.log(chalk.red(`  failed ${s.shortId} — ${res.error}`));
+    }
+    if (i < chosen.length - 1) await sleep(STAGGER_MS);
+  }
+  console.log(chalk.gray(`\nOpened ${opened} ${target} tab${opened === 1 ? '' : 's'}.`));
+}

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -39,6 +39,7 @@ import { sessionPicker, type PickedSession } from './sessions-picker.js';
 import { setHelpSections } from '../lib/help.js';
 import { registerSessionsTailCommand } from './sessions-tail.js';
 import { registerSessionsSyncCommand } from './sessions-sync.js';
+import { registerSessionsResumeCommand } from './sessions-resume.js';
 
 const SESSION_AGENT_FILTER_HELP = `Filter by agent, e.g. claude, codex, claude@2.0.65`;
 
@@ -1126,7 +1127,7 @@ function renderTopicCell(
   return out + padding;
 }
 
-function formatPickerLabel(s: SessionMeta, query: string): string {
+export function formatPickerLabel(s: SessionMeta, query: string): string {
   const agentColor = colorAgent(s.agent);
   const when = formatRelativeTime(s.timestamp);
   const project = s.project || '-';
@@ -1179,17 +1180,27 @@ async function handlePickedSession(picked: PickedSession): Promise<void> {
     await renderSession(picked.session, 'summary', {});
     return;
   }
+  await resumeSessionInPlace(picked.session);
+}
 
-  const cwd = picked.session.cwd && fs.existsSync(picked.session.cwd)
-    ? picked.session.cwd
+/**
+ * Resume a session in the current terminal — a foreground takeover of this
+ * process. Used by the single-select picker and by `sessions resume` when the
+ * chosen destination is "in place" (unknown emulator / off-macOS, single pick).
+ * Falls back to the current version via `/continue` when the version-pinned
+ * binary is missing (ENOENT).
+ */
+export async function resumeSessionInPlace(session: SessionMeta): Promise<void> {
+  const cwd = session.cwd && fs.existsSync(session.cwd)
+    ? session.cwd
     : process.cwd();
 
-  const resume = buildResumeCommand(picked.session);
+  const resume = buildResumeCommand(session);
   if (!resume) {
     console.log(chalk.yellow(
-      `Resume is not supported for ${picked.session.agent} sessions yet. Showing summary instead.`
+      `Resume is not supported for ${session.agent} sessions yet. Showing summary instead.`
     ));
-    await renderSession(picked.session, 'summary', {});
+    await renderSession(session, 'summary', {});
     return;
   }
 
@@ -1202,11 +1213,11 @@ async function handlePickedSession(picked: PickedSession): Promise<void> {
       shell: false,
     });
     child.on('error', (err: any) => {
-      if (err.code === 'ENOENT' && picked.session.version) {
-        const fallback = buildFallbackCommand(picked.session);
+      if (err.code === 'ENOENT' && session.version) {
+        const fallback = buildFallbackCommand(session);
         if (fallback) {
           console.log(chalk.gray(
-            `Version ${picked.session.version} is not installed. Falling back to current version via /continue...`
+            `Version ${session.version} is not installed. Falling back to current version via /continue...`
           ));
           const fb = spawn(fallback[0], fallback.slice(1), { cwd, stdio: 'inherit', shell: false });
           fb.on('error', (e: any) => { console.error(chalk.red(`Failed: ${e.message}`)); resolve(); });
@@ -1709,6 +1720,7 @@ export function registerSessionsCommands(program: Command): void {
 
   registerSessionsTailCommand(sessionsCmd);
   registerSessionsSyncCommand(sessionsCmd);
+  registerSessionsResumeCommand(sessionsCmd);
 }
 
 function formatNoSessionsMessage(

--- a/src/lib/picker.ts
+++ b/src/lib/picker.ts
@@ -51,6 +51,21 @@ export interface PickedItem<T> {
   item: T;
 }
 
+/** Configuration for the multi-select picker prompt. */
+export interface MultiPickerConfig<T> {
+  message: string;
+  items: T[];
+  filter: (query: string) => T[];
+  labelFor: (item: T, query: string) => string;
+  /** Stable identity for an item — drives the selected set. */
+  keyFor: (item: T) => string;
+  buildPreview?: (item: T) => string;
+  pageSize?: number;
+  initialSearch?: string;
+  emptyMessage?: string;
+  enterHint?: string;
+}
+
 interface Choice<T> {
   value: T;
   label: string;
@@ -238,6 +253,148 @@ export function itemPicker<T>(config: PickerConfig<T>): Promise<PickedItem<T> | 
       : chalk.gray(
           `↑↓ navigate${hasPreview ? ' · space: preview' : ''} · ⏎ ${enter} · esc: cancel`
         );
+
+    const parts: string[] = [header, page];
+    if (results.length === 0) {
+      parts.push(chalk.gray(`  ${cfg.emptyMessage ?? 'No matches.'}`));
+    }
+
+    if (previewOpen && selected && cfg.buildPreview) {
+      const width = terminalWidth();
+      const separator = chalk.gray('─'.repeat(Math.min(width, 80)));
+      const fixedRows =
+        renderedRows(header, width) +
+        renderedRows(parts.slice(1).join('\n'), width) +
+        renderedRows(separator, width) +
+        renderedRows(help, width);
+      const availablePreviewRows = terminalRows() - fixedRows;
+      const preview = limitPreviewHeight(cfg.buildPreview(selected.value), availablePreviewRows, width);
+      if (preview) {
+        parts.push(separator);
+        parts.push(preview);
+      }
+    }
+
+    parts.push(help);
+
+    return [header, parts.slice(1).join('\n')];
+  });
+  return prompt(config);
+}
+
+/**
+ * Multi-select variant of {@link itemPicker}. Same searchable, paginated list
+ * and preview pane, but `space` toggles a checkbox on the active row instead of
+ * the preview (preview moves to `tab`), and `enter` confirms every checked row.
+ *
+ * Returns the selected items (in the config's `items` order) or `null` on
+ * cancel. Pressing `enter` with nothing checked confirms just the highlighted
+ * row, so a quick single-pick still works.
+ */
+export function multiItemPicker<T>(config: MultiPickerConfig<T>): Promise<T[] | null> {
+  const prompt = createPrompt<T[] | null, MultiPickerConfig<T>>((cfg, done) => {
+    const theme = makeTheme({});
+    const [status, setStatus] = useState<'idle' | 'done'>('idle');
+    const [searchTerm, setSearchTerm] = useState(cfg.initialSearch ?? '');
+    const [previewOpen, setPreviewOpen] = useState(false);
+    const [selectedKeys, setSelectedKeys] = useState<ReadonlySet<string>>(new Set());
+    const [active, setActive] = useState(0);
+    const prefix = usePrefix({ status, theme });
+
+    const results = useMemo(() => {
+      const filtered = cfg.filter(searchTerm).slice(0, 200);
+      return filtered.map<Choice<T>>((item) => ({
+        value: item,
+        label: cfg.labelFor(item, searchTerm),
+      }));
+    }, [searchTerm]);
+
+    useEffect(() => {
+      if (active >= results.length) setActive(0);
+    }, [results]);
+
+    const selected = results[active];
+
+    // Selected items resolved in the original list order for deterministic fan-out.
+    const collectSelected = (): T[] => cfg.items.filter((it) => selectedKeys.has(cfg.keyFor(it)));
+
+    useKeypress((key, rl) => {
+      if (isEnterKey(key)) {
+        const chosen = selectedKeys.size > 0 ? collectSelected() : selected ? [selected.value] : [];
+        if (chosen.length === 0) return;
+        setStatus('done');
+        done(chosen);
+        return;
+      }
+
+      // space toggles the active row's checkbox; strip the space from the buffer
+      // so it never leaks into the filter.
+      if (isSpaceKey(key)) {
+        rl.clearLine(0);
+        if (selected) {
+          const k = cfg.keyFor(selected.value);
+          const next = new Set(selectedKeys);
+          if (next.has(k)) next.delete(k);
+          else next.add(k);
+          setSelectedKeys(next);
+        }
+        return;
+      }
+
+      if (key.name === 'tab' && cfg.buildPreview) {
+        rl.clearLine(0);
+        setPreviewOpen(!previewOpen);
+        return;
+      }
+
+      if (isUpKey(key)) {
+        rl.clearLine(0);
+        if (results.length > 0) setActive((active - 1 + results.length) % results.length);
+        return;
+      }
+
+      if (isDownKey(key)) {
+        rl.clearLine(0);
+        if (results.length > 0) setActive((active + 1) % results.length);
+        return;
+      }
+
+      setSearchTerm(rl.line);
+    });
+
+    const message = theme.style.message(cfg.message, status);
+    const count = selectedKeys.size;
+
+    if (status === 'done') {
+      return `${prefix} ${message} ${chalk.cyan(`${count || 1} session${(count || 1) === 1 ? '' : 's'}`)}`;
+    }
+
+    const placeholder = '(type to filter · space to toggle · enter to resume)';
+    const searchStr = searchTerm ? chalk.cyan(searchTerm) : chalk.gray(placeholder);
+    const header = [prefix, message, searchStr].filter(Boolean).join(' ');
+
+    const page = usePagination({
+      items: results as any,
+      active,
+      renderItem({ item, isActive }: { item: Choice<T>; isActive: boolean }) {
+        if (Separator.isSeparator(item)) return ` ${(item as any).separator}`;
+        const checked = selectedKeys.has(cfg.keyFor(item.value));
+        const box = checked ? chalk.green('[x]') : chalk.gray('[ ]');
+        const cursor = isActive ? chalk.cyan('>') : ' ';
+        const row = isActive ? chalk.bold(item.label) : item.label;
+        return `${cursor} ${box} ${row}`;
+      },
+      pageSize: cfg.pageSize ?? 10,
+      loop: false,
+    });
+
+    const enter = cfg.enterHint ?? 'resume';
+    const countStr = count > 0 ? chalk.green(`${count} selected`) : chalk.gray('0 selected');
+    const help = chalk.gray(
+      `${countStr}${chalk.gray(' · ↑↓ navigate · space toggle')}${
+        cfg.buildPreview ? chalk.gray(' · tab preview') : ''
+      }${chalk.gray(` · ⏎ ${enter} · esc cancel`)}`,
+    );
 
     const parts: string[] = [header, page];
     if (results.length === 0) {

--- a/src/lib/session/launch.test.ts
+++ b/src/lib/session/launch.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  shellQuote,
+  appleScriptStr,
+  detectCurrentTerminal,
+  availableDestinations,
+  itermTabScript,
+  ghosttyTabScript,
+  buildLaunchArgv,
+} from './launch.js';
+
+const RESUME = ['claude@2.1.187', '--resume', 'cad0e546'];
+
+describe('shellQuote', () => {
+  it('wraps plain strings in single quotes', () => {
+    expect(shellQuote('/Users/me/src')).toBe(`'/Users/me/src'`);
+  });
+  it('escapes embedded single quotes', () => {
+    // a path with an apostrophe must not break out of the quoting
+    expect(shellQuote(`/Users/o'brien/dev`)).toBe(`'/Users/o'\\''brien/dev'`);
+  });
+});
+
+describe('appleScriptStr', () => {
+  it('escapes backslashes before quotes', () => {
+    expect(appleScriptStr('a\\b"c')).toBe('"a\\\\b\\"c"');
+  });
+});
+
+describe('detectCurrentTerminal', () => {
+  it('prefers tmux when $TMUX is set, over TERM_PROGRAM', () => {
+    expect(detectCurrentTerminal({ TMUX: '/tmp/tmux-501/default,1,0', TERM_PROGRAM: 'iTerm.app' })).toBe('tmux');
+  });
+  it('maps iTerm.app', () => {
+    expect(detectCurrentTerminal({ TERM_PROGRAM: 'iTerm.app' })).toBe('iterm');
+  });
+  it('maps ghostty', () => {
+    expect(detectCurrentTerminal({ TERM_PROGRAM: 'ghostty' })).toBe('ghostty');
+  });
+  it('falls back to inplace for unknown / bare terminals', () => {
+    expect(detectCurrentTerminal({ TERM_PROGRAM: 'Apple_Terminal' })).toBe('inplace');
+    expect(detectCurrentTerminal({})).toBe('inplace');
+  });
+});
+
+describe('availableDestinations', () => {
+  it('off macOS offers only "this terminal"', () => {
+    const dests = availableDestinations('linux', { TERM_PROGRAM: 'iTerm.app' });
+    expect(dests.map(d => d.id)).toEqual(['this']);
+    // "this terminal" still resolves to the detected emulator
+    expect(dests[0].target).toBe('iterm');
+  });
+  it('on macOS the first choice is always "this terminal"', () => {
+    const dests = availableDestinations('darwin', { TERM_PROGRAM: 'ghostty' });
+    expect(dests[0].id).toBe('this');
+    expect(dests[0].target).toBe('ghostty');
+  });
+});
+
+describe('itermTabScript', () => {
+  it('creates a tab in the current window, or a window when none is open', () => {
+    const s = itermTabScript('/Users/me/dev', RESUME);
+    expect(s).toContain('tell application "iTerm2"');
+    expect(s).toContain('create tab with default profile command');
+    expect(s).toContain('if (count of windows) is 0 then');
+    // the resume command is wrapped in a login shell that cd's into the session cwd
+    expect(s).toContain('zsh -lc');
+    expect(s).toContain('/Users/me/dev');
+    expect(s).toContain('exec claude@2.1.187 --resume cad0e546');
+  });
+});
+
+describe('ghosttyTabScript', () => {
+  it('sets cwd + command as native surface properties (no cd wrapper)', () => {
+    const s = ghosttyTabScript('/Users/me/dev', RESUME);
+    expect(s).toContain('tell application "Ghostty"');
+    expect(s).toContain('new surface configuration');
+    expect(s).toContain('set initial working directory of cfg to "/Users/me/dev"');
+    expect(s).toContain('new tab in front window with configuration cfg');
+    // cwd is native, so the command execs without a cd
+    expect(s).toContain('exec claude@2.1.187 --resume cad0e546');
+    expect(s).not.toContain('cd ');
+  });
+});
+
+describe('buildLaunchArgv', () => {
+  it('routes iterm/ghostty through osascript', () => {
+    expect(buildLaunchArgv('iterm', '/x', RESUME)[0]).toBe('osascript');
+    expect(buildLaunchArgv('ghostty', '/x', RESUME)[0]).toBe('osascript');
+  });
+  it('opens a tmux window with the cwd and joined command', () => {
+    expect(buildLaunchArgv('tmux', '/x/y', RESUME)).toEqual([
+      'tmux', 'new-window', '-c', '/x/y', 'claude@2.1.187 --resume cad0e546',
+    ]);
+  });
+  it('inplace returns the resume argv verbatim', () => {
+    expect(buildLaunchArgv('inplace', '/x', RESUME)).toEqual(RESUME);
+  });
+});

--- a/src/lib/session/launch.ts
+++ b/src/lib/session/launch.ts
@@ -1,0 +1,171 @@
+/**
+ * Launch a resumed session into a terminal tab.
+ *
+ * `agents sessions resume` multi-selects sessions and fans them out — one tab
+ * per session — into the terminal the user picks: the one they're in now
+ * (auto-detected via TERM_PROGRAM), a new iTerm tab, or a new Ghostty tab.
+ *
+ * The builders here are pure argv/AppleScript factories so they can be
+ * unit-tested without a display; `launchResumeInTab` is the thin spawn wrapper.
+ * They take a pre-built resume argv (from `buildResumeCommand`) rather than a
+ * SessionMeta so this module stays free of any command-layer dependency.
+ */
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+
+/** A concrete place a resume can open. `inplace` takes over the current process. */
+export type ResumeTarget = 'inplace' | 'iterm' | 'ghostty' | 'tmux';
+
+/** A destination offered in the picker: a label plus the concrete target it resolves to. */
+export interface DestinationChoice {
+  id: 'this' | 'iterm' | 'ghostty';
+  label: string;
+  detail: string;
+  target: ResumeTarget;
+}
+
+const ITERM_APP = '/Applications/iTerm.app';
+const GHOSTTY_APP = '/Applications/Ghostty.app';
+
+function appExists(p: string): boolean {
+  try {
+    return fs.existsSync(p);
+  } catch {
+    return false;
+  }
+}
+
+/** POSIX single-quote a string for safe embedding in a shell command. */
+export function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/** AppleScript double-quoted string literal (escape backslash, then quote). */
+export function appleScriptStr(s: string): string {
+  return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Detect which terminal emulator the CLI is currently running in, mapped to a
+ * concrete launch target. iTerm and Ghostty both set TERM_PROGRAM; tmux exposes
+ * $TMUX. Anything we can't open a tab into resolves to `inplace`.
+ */
+export function detectCurrentTerminal(env: NodeJS.ProcessEnv = process.env): ResumeTarget {
+  if (env.TMUX) return 'tmux';
+  const term = (env.TERM_PROGRAM || '').toLowerCase();
+  if (term.includes('iterm')) return 'iterm';
+  if (term.includes('ghostty')) return 'ghostty';
+  return 'inplace';
+}
+
+/**
+ * The destinations offered in the chooser, given platform + which terminal
+ * we're in + what's installed. Off macOS only "this terminal" is meaningful
+ * (tmux window or in-place); the iTerm/Ghostty app targets are macOS-only and
+ * appear only when the app is actually installed.
+ */
+export function availableDestinations(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): DestinationChoice[] {
+  const current = detectCurrentTerminal(env);
+  const currentLabel =
+    current === 'iterm' ? 'iTerm' :
+    current === 'ghostty' ? 'Ghostty' :
+    current === 'tmux' ? 'tmux window' : 'in place';
+  const out: DestinationChoice[] = [{
+    id: 'this',
+    label: 'This terminal',
+    detail: `new tab in the terminal you're in now (${currentLabel})`,
+    target: current,
+  }];
+  if (platform === 'darwin') {
+    if (appExists(ITERM_APP)) {
+      out.push({ id: 'iterm', label: 'iTerm', detail: 'one new iTerm tab per session', target: 'iterm' });
+    }
+    if (appExists(GHOSTTY_APP)) {
+      out.push({ id: 'ghostty', label: 'Ghostty', detail: 'one new Ghostty tab per session', target: 'ghostty' });
+    }
+  }
+  return out;
+}
+
+/** Login-shell string that cd's into cwd and execs the resume argv. */
+function loginExec(cwd: string, resume: string[]): string {
+  return `cd ${shellQuote(cwd)} && exec ${resume.join(' ')}`;
+}
+
+/** AppleScript that opens an iTerm tab (a window if none is open) running the resume. */
+export function itermTabScript(cwd: string, resume: string[]): string {
+  const cmd = appleScriptStr(`zsh -lc ${shellQuote(loginExec(cwd, resume))}`);
+  return [
+    'tell application "iTerm2"',
+    '  activate',
+    '  if (count of windows) is 0 then',
+    `    create window with default profile command ${cmd}`,
+    '  else',
+    `    tell current window to create tab with default profile command ${cmd}`,
+    '  end if',
+    'end tell',
+  ].join('\n');
+}
+
+/** AppleScript that opens a Ghostty tab (a window if none is open) running the resume. */
+export function ghosttyTabScript(cwd: string, resume: string[]): string {
+  // Ghostty (>=1.3) runs `command` directly; wrap it in a login shell so the
+  // version-pinned shim (e.g. claude@2.1.187) resolves on PATH and login env
+  // is loaded. cwd is a native surface property, so no `cd` is needed.
+  const cmd = appleScriptStr(`zsh -lc ${shellQuote(`exec ${resume.join(' ')}`)}`);
+  return [
+    'tell application "Ghostty"',
+    '  activate',
+    '  set cfg to new surface configuration',
+    `  set initial working directory of cfg to ${appleScriptStr(cwd)}`,
+    `  set command of cfg to ${cmd}`,
+    '  if (count of windows) is 0 then',
+    '    new window with configuration cfg',
+    '  else',
+    '    new tab in front window with configuration cfg',
+    '  end if',
+    'end tell',
+  ].join('\n');
+}
+
+/**
+ * Build the spawn argv that opens the resume in the given target.
+ * `inplace` returns the resume argv itself (the caller spawns it with inherited
+ * stdio so it takes over the current terminal).
+ */
+export function buildLaunchArgv(target: ResumeTarget, cwd: string, resume: string[]): string[] {
+  switch (target) {
+    case 'iterm':   return ['osascript', '-e', itermTabScript(cwd, resume)];
+    case 'ghostty': return ['osascript', '-e', ghosttyTabScript(cwd, resume)];
+    case 'tmux':    return ['tmux', 'new-window', '-c', cwd, resume.join(' ')];
+    case 'inplace': return resume;
+  }
+}
+
+export interface LaunchResult {
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * Fire off a tab launch (any target except `inplace`). Resolves when the
+ * launcher process (osascript / tmux) exits. Never rejects — a failed launch
+ * comes back as `{ ok: false, error }` so a fan-out loop can keep going.
+ */
+export function launchResumeInTab(
+  target: Exclude<ResumeTarget, 'inplace'>,
+  cwd: string,
+  resume: string[],
+): Promise<LaunchResult> {
+  const argv = buildLaunchArgv(target, cwd, resume);
+  return new Promise((resolve) => {
+    const child = spawn(argv[0], argv.slice(1), { stdio: 'ignore' });
+    child.on('error', (err: any) => resolve({ ok: false, error: err.message }));
+    child.on('close', (code) =>
+      resolve(code === 0 ? { ok: true } : { ok: false, error: `${argv[0]} exited with code ${code}` }),
+    );
+  });
+}


### PR DESCRIPTION
## What

Adds a dedicated `agents sessions resume` subcommand: multi-select sessions from the same rich picker, then choose where each one resumes — **a new tab in this terminal, a new iTerm tab, or a new Ghostty tab** (one tab per session, version-pinned, in its own cwd).

Bare `agents sessions` still resumes one session in place; this is the new multi + destination flow.

## Flow

1. **Multi-select** — checkbox picker (`space` toggles, `tab` previews, `enter` confirms). Reuses the existing session list rendering + preview.
2. **Destination** — `This terminal` (auto-detected via `TERM_PROGRAM`) · `iTerm` · `Ghostty`. iTerm/Ghostty appear on macOS when the app is installed; off-macOS collapses to "this terminal".
3. **Launch** — one tab per session, staggered ~0.7s; confirms before opening more than five at once.

## How tabs open

- **iTerm** — `tell current window to create tab with default profile command "zsh -lc 'cd CWD && exec RESUME'"` (new window if none open), via `osascript`.
- **Ghostty 1.3+** — `new surface configuration` with native `initial working directory` + `command`, then `new tab in front window with configuration`.
- **tmux** — `tmux new-window -c CWD`. **In place** — foreground takeover (single pick) or sequential.

`RESUME` comes from the existing `buildResumeCommand()` (claude / codex / opencode); non-resumable agents are skipped with a printed note, never silently dropped.

## Files

- **new** `src/lib/session/launch.ts` (+ test) — pure argv/AppleScript builders, emulator detection, destination gating.
- **new** `src/commands/sessions-resume.ts` — the subcommand.
- **edit** `src/lib/picker.ts` — `multiItemPicker` (single-select `itemPicker` unchanged).
- **edit** `src/commands/sessions.ts` — extract `resumeSessionInPlace`, export `formatPickerLabel`, register the subcommand.

## Verification

- **End-to-end on real apps (zion, macOS):** ran the exact generated AppleScript against **iTerm 3.6.11** and **Ghostty 1.3.1** — both opened a new tab and honored the cwd (`/usr/local` written back from inside the tab). Quoting survives the nested shell + AppleScript escaping.
- **Unit:** 14 new tests for quoting, emulator detection, destination gating, and per-target argv. Full suite green except 5 pre-existing `sync/config.test.ts` failures that reproduce on untouched `main` (environment has a sync bundle configured).
- **CLI smoke:** `sessions resume --help` renders; non-interactive invocation guards with a clear error.