### PR TITLE
fix(sessions): resume tabs need an interactive login shell (`zsh -ilc`)

### DIFF
--- a/src/lib/session/launch.test.ts
+++ b/src/lib/session/launch.test.ts
@@ -63,8 +63,9 @@ describe('itermTabScript', () => {
     expect(s).toContain('tell application "iTerm2"');
     expect(s).toContain('create tab with default profile command');
     expect(s).toContain('if (count of windows) is 0 then');
-    // the resume command is wrapped in a login shell that cd's into the session cwd
-    expect(s).toContain('zsh -lc');
+    // wrapped in an INTERACTIVE login shell (-i) that cd's into the session cwd —
+    // -i is required so ~/.zshrc puts the version-shim dir on PATH
+    expect(s).toContain('zsh -ilc');
     expect(s).toContain('/Users/me/dev');
     expect(s).toContain('exec claude@2.1.187 --resume cad0e546');
   });
@@ -77,7 +78,8 @@ describe('ghosttyTabScript', () => {
     expect(s).toContain('new surface configuration');
     expect(s).toContain('set initial working directory of cfg to "/Users/me/dev"');
     expect(s).toContain('new tab in front window with configuration cfg');
-    // cwd is native, so the command execs without a cd
+    // interactive login shell so the version shim resolves; cwd is native (no cd)
+    expect(s).toContain('zsh -ilc');
     expect(s).toContain('exec claude@2.1.187 --resume cad0e546');
     expect(s).not.toContain('cd ');
   });
@@ -88,9 +90,9 @@ describe('buildLaunchArgv', () => {
     expect(buildLaunchArgv('iterm', '/x', RESUME)[0]).toBe('osascript');
     expect(buildLaunchArgv('ghostty', '/x', RESUME)[0]).toBe('osascript');
   });
-  it('opens a tmux window with the cwd and joined command', () => {
+  it('opens a tmux window with the cwd and an interactive-login-wrapped command', () => {
     expect(buildLaunchArgv('tmux', '/x/y', RESUME)).toEqual([
-      'tmux', 'new-window', '-c', '/x/y', 'claude@2.1.187 --resume cad0e546',
+      'tmux', 'new-window', '-c', '/x/y', "zsh -ilc 'exec claude@2.1.187 --resume cad0e546'",
     ]);
   });
   it('inplace returns the resume argv verbatim', () => {

--- a/src/lib/session/launch.ts
+++ b/src/lib/session/launch.ts
@@ -90,14 +90,22 @@ export function availableDestinations(
   return out;
 }
 
-/** Login-shell string that cd's into cwd and execs the resume argv. */
+/**
+ * Shell string that cd's into cwd and execs the resume argv.
+ *
+ * The wrappers below run this via `zsh -ilc` — an *interactive* login shell.
+ * `-i` is load-bearing, not cosmetic: the version-pinned shims (`claude@2.1.187`)
+ * live in `~/.agents/.cache/shims`, which `.zshrc` puts on PATH for interactive
+ * shells only. A plain `zsh -lc` (login, non-interactive) skips `.zshrc`, so the
+ * shim isn't found and the tab dies with "command not found". Do not drop `-i`.
+ */
 function loginExec(cwd: string, resume: string[]): string {
   return `cd ${shellQuote(cwd)} && exec ${resume.join(' ')}`;
 }
 
 /** AppleScript that opens an iTerm tab (a window if none is open) running the resume. */
 export function itermTabScript(cwd: string, resume: string[]): string {
-  const cmd = appleScriptStr(`zsh -lc ${shellQuote(loginExec(cwd, resume))}`);
+  const cmd = appleScriptStr(`zsh -ilc ${shellQuote(loginExec(cwd, resume))}`);
   return [
     'tell application "iTerm2"',
     '  activate',
@@ -112,10 +120,10 @@ export function itermTabScript(cwd: string, resume: string[]): string {
 
 /** AppleScript that opens a Ghostty tab (a window if none is open) running the resume. */
 export function ghosttyTabScript(cwd: string, resume: string[]): string {
-  // Ghostty (>=1.3) runs `command` directly; wrap it in a login shell so the
-  // version-pinned shim (e.g. claude@2.1.187) resolves on PATH and login env
-  // is loaded. cwd is a native surface property, so no `cd` is needed.
-  const cmd = appleScriptStr(`zsh -lc ${shellQuote(`exec ${resume.join(' ')}`)}`);
+  // Ghostty (>=1.3) runs `command` directly; wrap it in an interactive login
+  // shell so the version-pinned shim (e.g. claude@2.1.187) resolves on PATH.
+  // cwd is a native surface property, so no `cd` is needed.
+  const cmd = appleScriptStr(`zsh -ilc ${shellQuote(`exec ${resume.join(' ')}`)}`);
   return [
     'tell application "Ghostty"',
     '  activate',
@@ -140,7 +148,9 @@ export function buildLaunchArgv(target: ResumeTarget, cwd: string, resume: strin
   switch (target) {
     case 'iterm':   return ['osascript', '-e', itermTabScript(cwd, resume)];
     case 'ghostty': return ['osascript', '-e', ghosttyTabScript(cwd, resume)];
-    case 'tmux':    return ['tmux', 'new-window', '-c', cwd, resume.join(' ')];
+    // Wrap in an interactive login shell for the same PATH reason as loginExec:
+    // tmux runs new-window commands via a non-interactive shell otherwise.
+    case 'tmux':    return ['tmux', 'new-window', '-c', cwd, `zsh -ilc ${shellQuote(`exec ${resume.join(' ')}`)}`];
     case 'inplace': return resume;
   }
 }


### PR DESCRIPTION
## The bug

The `agents sessions resume` launchers (merged in #601) wrapped the resume command in **`zsh -lc`** — a login but **non-interactive** shell. The version-pinned shims (`claude@2.1.187`) live in `~/.agents/.cache/shims`, which `.zshrc` adds to PATH **for interactive shells only**. So in a fresh iTerm/Ghostty tab the shim isn't found, `exec claude@<ver> …` fails with *command not found*, and the tab opens then immediately dies — no session.

`command -v claude@2.1.187` under `zsh -lc` → empty; under `zsh -ilc` → resolves.

## The fix

Wrap iTerm, Ghostty, and tmux launches in **`zsh -ilc`** (interactive login) — the same environment the user gets when they open a tab and type the command themselves. tmux had the same latent issue (`tmux new-window` runs via a non-interactive shell), fixed alongside.

`-i` is now called out as load-bearing in a comment so it isn't "simplified" back.

## Verified end-to-end on zion (real apps, real sessions)

| | before (`-lc`) | after (`-ilc`) |
|---|---|---|
| iTerm 3.6 | tab opens, **no process** | tab opens, `claude --resume bce16291…` **running** |
| Ghostty 1.3 | tab opens, **no process** | tab opens, `claude --resume 6ef21e46…` **running** |

Confirmed via `ps` on zion that the resolved `…/versions/claude/<ver>/…/claude --resume <id>` process is live in the right cwd after the fix, and absent before it.

14 launch unit tests updated + passing; build clean.