### PR TITLE
feat(terminal): vscodium-agent backend

### DIFF
--- a/docs/terminal-engine.md
+++ b/docs/terminal-engine.md
@@ -61,9 +61,11 @@ Each backend opens either a **tab** or a **split** (`right` = side-by-side,
 | `iterm` | macOS + `/Applications/iTerm.app` | `create tab … command` (a window if none open) | `split vertically`/`split horizontally … command` |
 | `ghostty` | macOS + `/Applications/Ghostty.app` | `new tab … with configuration cfg` | `split (focused terminal of selected tab of front window) direction …` |
 | `tmux` | inside tmux (`$TMUX` set) | `tmux new-window -c <cwd>` | `tmux split-window -h`/`-v -c <cwd>` |
+| `vscodium-agent` | macOS + `/Applications/VSCodium.app` | `codium --open-url 'vscodium://swarmify.swarm-ext/spawn?…'` | same URL with `&split=right\|down` |
 
 `buildTab`/`buildSplit` return a `LaunchSpec { argv }`. Ghostty carries `cwd`
 natively via the surface configuration; iTerm/tmux `cd` inside the wrapped shell.
+`vscodium-agent` is different in kind — see [VSCodium agent terminals](#vscodium-agent-terminals).
 
 ## Layout policy — two panes per tab
 
@@ -95,13 +97,19 @@ works".
 Caveat: driving a GUI app (iTerm/Ghostty) over SSH needs the remote user logged
 into the Mac's GUI session — `osascript` reaches the app through it. `tmux` over
 `--host` is unconditional (headless), which is why remote defaults to `tmux`.
+`vscodium-agent` also needs a running editor: `codium --open-url` forwards the URL
+to the already-open VSCodium instance over its user-scoped IPC socket, so it works
+from an SSH session as the same user (no `osascript`, no new window spawned).
 
 ## Interactive login shell
 
-Every backend wraps its command in `zsh -ilc '…'`. The `-i` is load-bearing: the
-version-pinned shims (`claude@2.1.187`) live in `~/.agents/.cache/shims`, which
-`.zshrc` adds to PATH for *interactive* shells only. A non-interactive
-`zsh -lc` can't find the shim and the surface dies with "command not found".
+The `iterm`, `ghostty`, and `tmux` backends wrap their command in `zsh -ilc '…'`.
+The `-i` is load-bearing: the version-pinned shims (`claude@2.1.187`) live in
+`~/.agents/.cache/shims`, which `.zshrc` adds to PATH for *interactive* shells
+only. A non-interactive `zsh -lc` can't find the shim and the surface dies with
+"command not found". The `vscodium-agent` backend does **not** wrap — the command
+is sent (via the extension's `sendText`) into an editor terminal that is already
+an interactive login shell, so the shims are on PATH already.
 
 ## Usage
 
@@ -121,7 +129,7 @@ await openSurfaces(items, {
 
 | Flag | Effect |
 |---|---|
-| `--iterm` / `--ghostty` / `--tmux` | Force a backend (else auto-detect / prompt). |
+| `--iterm` / `--ghostty` / `--tmux` / `--vscodium` | Force a backend (else auto-detect / prompt). |
 | `--host <alias>` | Resume on a remote host over SSH (defaults to `tmux`). |
 | `--tabs` | One tab per session (default packs two-per-tab). |
 
@@ -129,12 +137,32 @@ Non-resumable agents (where `buildResumeCommand` returns null) are skipped with 
 note, never silently dropped. With no GUI backend and no tmux, resume falls back
 to an in-place, sequential takeover of the current terminal.
 
-## Not yet: VSCodium agent terminals
+## VSCodium agent terminals
 
-A `vscodium-agent` backend is planned but needs a change in the **swarmify**
-extension: it can only *focus* existing terminals from outside (its
-`vscode://…/focus` URI handler and `~/.agents/.tmp/watchdog.sock`), with no
-"open a terminal" verb. Adding a `/spawn` path to that URI handler — wired to the
-extension's `openSingleAgent` — is the seam; the engine backend would then just
-build an `open "vscode://…/spawn?…"` argv, which flows over `--host` like the
-rest. Tracked as a separate, cross-repo change.
+The `vscodium-agent` backend opens each session as an **agent terminal tab** in a
+running VSCodium (or Cursor / VS Code) window, driven by the **swarmify**
+`swarm-ext` extension. Unlike the terminal-app backends, the editor is already
+running — the engine hands it a URL rather than scripting a GUI app:
+
+```
+codium --open-url 'vscodium://swarmify.swarm-ext/spawn?cwd=<dir>&command=<cmd>[&split=right|down]'
+```
+
+- **The `/spawn` verb** (swarmify `extension.ts`) opens an editor-tab terminal in
+  `cwd`, sends `command`, and arms *shell adoption* — so a resume command like
+  `claude --resume <id>` is auto-promoted to the Claude chip with session
+  tracking. `split` splits beside the previous `/spawn` pane, giving the same
+  two-per-tab packing as the other backends.
+- **Why `--open-url`, not `open`** — the editor CLI forwards the URL to the
+  running instance over a user-scoped IPC socket. That needs no OS URL-scheme
+  handler registration, works on Linux, and flows over `--host` (the SSH session
+  reaches the same socket as the logged-in user). The per-product scheme must
+  match the CLI: `codium`→`vscodium://`, `cursor`→`cursor://`, `code`→`vscode://`
+  (see `EDITOR_VARIANTS` / `makeVscodiumAgentBackend`).
+- **No `zsh -ilc` wrap** — the command runs in an editor terminal that is already
+  an interactive login shell (see [above](#interactive-login-shell)).
+
+Auto-detection is intentionally *not* wired for this backend: a VS Code integrated
+terminal reports `TERM_PROGRAM=vscode` for all three products, so the engine can't
+tell which one to target. Select it explicitly with `--vscodium` (defaults to
+VSCodium), or it appears in the picker when `/Applications/VSCodium.app` is present.

--- a/docs/terminal-engine.md
+++ b/docs/terminal-engine.md
@@ -61,7 +61,7 @@ Each backend opens either a **tab** or a **split** (`right` = side-by-side,
 | `iterm` | macOS + `/Applications/iTerm.app` | `create tab … command` (a window if none open) | `split vertically`/`split horizontally … command` |
 | `ghostty` | macOS + `/Applications/Ghostty.app` | `new tab … with configuration cfg` | `split (focused terminal of selected tab of front window) direction …` |
 | `tmux` | inside tmux (`$TMUX` set) | `tmux new-window -c <cwd>` | `tmux split-window -h`/`-v -c <cwd>` |
-| `vscodium-agent` | macOS + `/Applications/VSCodium.app` | `codium --open-url 'vscodium://swarmify.swarm-ext/spawn?…'` | same URL with `&split=right\|down` |
+| `vscodium-agent` | macOS + `/Applications/VSCodium.app` | `codium --open-url 'vscodium://swarmify.swarm-ext/spawn?p=<payload>'` | same URL, payload carries `split` |
 
 `buildTab`/`buildSplit` return a `LaunchSpec { argv }`. Ghostty carries `cwd`
 natively via the surface configuration; iTerm/tmux `cd` inside the wrapped shell.
@@ -145,20 +145,25 @@ running VSCodium (or Cursor / VS Code) window, driven by the **swarmify**
 running — the engine hands it a URL rather than scripting a GUI app:
 
 ```
-codium --open-url 'vscodium://swarmify.swarm-ext/spawn?cwd=<dir>&command=<cmd>[&split=right|down]'
+codium --open-url 'vscodium://swarmify.swarm-ext/spawn?p=<base64url(JSON)>'
 ```
 
+- **The payload is one base64url-encoded JSON param** (`{command, cwd, split?}`),
+  not one param per field. VS Code percent-*decodes* `uri.query` once before the
+  extension parses it, so a `command`/`cwd` containing `&` or `=` would be
+  mis-split by a multi-param query; base64url (`[A-Za-z0-9_-]`) survives that
+  decode untouched and round-trips exactly (see `spawnUri`).
 - **The `/spawn` verb** (swarmify `extension.ts`) opens an editor-tab terminal in
   `cwd`, sends `command`, and arms *shell adoption* — so a resume command like
   `claude --resume <id>` is auto-promoted to the Claude chip with session
   tracking. `split` splits beside the previous `/spawn` pane, giving the same
   two-per-tab packing as the other backends.
 - **Why `--open-url`, not `open`** — the editor CLI forwards the URL to the
-  running instance over a user-scoped IPC socket. That needs no OS URL-scheme
-  handler registration, works on Linux, and flows over `--host` (the SSH session
-  reaches the same socket as the logged-in user). The per-product scheme must
-  match the CLI: `codium`→`vscodium://`, `cursor`→`cursor://`, `code`→`vscode://`
-  (see `EDITOR_VARIANTS` / `makeVscodiumAgentBackend`).
+  running instance. That needs no OS URL-scheme handler registration, works on
+  Linux, and flows over `--host` (the SSH session reaches the same user's editor).
+  The per-product scheme must match the CLI: `codium`→`vscodium://`,
+  `cursor`→`cursor://`, `code`→`vscode://` (see `EDITOR_VARIANTS` /
+  `makeVscodiumAgentBackend`).
 - **No `zsh -ilc` wrap** — the command runs in an editor terminal that is already
   an interactive login shell (see [above](#interactive-login-shell)).
 

--- a/src/commands/sessions-resume.ts
+++ b/src/commands/sessions-resume.ts
@@ -49,6 +49,7 @@ interface ResumeOptions {
   iterm?: boolean;
   ghostty?: boolean;
   tmux?: boolean;
+  vscodium?: boolean;
   tabs?: boolean;
 }
 
@@ -56,7 +57,7 @@ export function registerSessionsResumeCommand(sessionsCmd: Command): void {
   const cmd = sessionsCmd
     .command('resume')
     .argument('[query]', 'Filter sessions before selecting (topic, path, or id fragment)')
-    .description('Multi-select sessions and resume each in a terminal tab/split (this terminal, iTerm, Ghostty, tmux; local or --host).')
+    .description('Multi-select sessions and resume each in a terminal tab/split (this terminal, iTerm, Ghostty, tmux, VSCodium; local or --host).')
     .option('-a, --agent <agent>', 'Filter by agent type and version (e.g., claude, codex@0.116.0)')
     .option('--all', 'Include sessions from every directory (not just current project)')
     .option('--teams', 'Include team-spawned sessions (hidden by default)')
@@ -66,6 +67,7 @@ export function registerSessionsResumeCommand(sessionsCmd: Command): void {
     .option('--iterm', 'Force the iTerm backend')
     .option('--ghostty', 'Force the Ghostty backend')
     .option('--tmux', 'Force the tmux backend')
+    .option('--vscodium', 'Force the VSCodium agent-terminal backend (swarm-ext)')
     .option('--tabs', 'One tab per session (default: pack two panes per tab)');
 
   setHelpSections(cmd, {
@@ -78,13 +80,15 @@ export function registerSessionsResumeCommand(sessionsCmd: Command): void {
 
       # Force a backend / one tab each / a remote host
       agents sessions resume --ghostty
+      agents sessions resume --vscodium
       agents sessions resume --tabs
       agents sessions resume --host zion --tmux
     `,
     notes: `
       - space toggles a session, enter confirms; tab toggles the preview pane.
       - Layout: two-per-tab by default (session 1 → new tab, session 2 → split beside it, …). --tabs disables splitting.
-      - Backend: auto-detected from the terminal you're in (iTerm / Ghostty / tmux); override with --iterm/--ghostty/--tmux.
+      - Backend: auto-detected from the terminal you're in (iTerm / Ghostty / tmux); override with --iterm/--ghostty/--tmux/--vscodium.
+      - --vscodium opens each session as an agent terminal tab in VSCodium via the swarm-ext extension (works with --host too).
       - --host <alias> resumes on a remote machine over the same SSH transport as 'sessions --host' (defaults to tmux).
       - Each session opens version-pinned, in its own cwd. Non-resumable agents are skipped with a note.
     `,
@@ -219,7 +223,11 @@ async function resolveBackend(
   count: number,
 ): Promise<Backend | 'inplace' | 'cancel'> {
   const forced: Backend | undefined =
-    options.iterm ? 'iterm' : options.ghostty ? 'ghostty' : options.tmux ? 'tmux' : undefined;
+    options.iterm ? 'iterm'
+      : options.ghostty ? 'ghostty'
+      : options.tmux ? 'tmux'
+      : options.vscodium ? 'vscodium-agent'
+      : undefined;
   if (forced) return forced;
   // Remote defaults to tmux (headless, no GUI session assumptions); override with a backend flag.
   if (options.host) return 'tmux';

--- a/src/lib/terminal/backends/backends.test.ts
+++ b/src/lib/terminal/backends/backends.test.ts
@@ -69,32 +69,39 @@ describe('tmux backend', () => {
   });
 });
 
+// Decode the base64url `p` payload the way the swarm-ext handler does.
+const payloadOf = (url: string): any => {
+  const p = new URLSearchParams(url.split('?')[1]).get('p')!;
+  return JSON.parse(Buffer.from(p, 'base64url').toString('utf8'));
+};
+
 describe('vscodium-agent backend', () => {
   it('tab: codium --open-url with a vscodium:// spawn URI carrying cwd + raw command (no zsh wrap)', () => {
     const argv = vscodiumAgentBackend.buildTab('/Users/me/dev', CMD);
     expect(argv.argv[0]).toBe('codium');
     expect(argv.argv[1]).toBe('--open-url');
     const url = argv.argv[2];
-    expect(url.startsWith('vscodium://swarmify.swarm-ext/spawn?')).toBe(true);
+    expect(url.startsWith('vscodium://swarmify.swarm-ext/spawn?p=')).toBe(true);
     // the editor terminal is already an interactive login shell — no zsh -ilc wrap
     expect(url).not.toContain('zsh');
-    const q = new URLSearchParams(url.split('?')[1]);
-    expect(q.get('cwd')).toBe('/Users/me/dev');
-    expect(q.get('command')).toBe('claude@2.1.187 --resume cad0e546');
-    expect(q.get('split')).toBeNull();
+    const payload = payloadOf(url);
+    expect(payload.cwd).toBe('/Users/me/dev');
+    expect(payload.command).toBe('claude@2.1.187 --resume cad0e546');
+    expect(payload.split).toBeUndefined();
   });
   it('split: carries the direction so the extension splits beside the prior pane', () => {
-    const right = new URLSearchParams(vscodiumAgentBackend.buildSplit('/d', CMD, 'right').argv[2].split('?')[1]);
-    expect(right.get('split')).toBe('right');
-    const down = new URLSearchParams(vscodiumAgentBackend.buildSplit('/d', CMD, 'down').argv[2].split('?')[1]);
-    expect(down.get('split')).toBe('down');
+    expect(payloadOf(vscodiumAgentBackend.buildSplit('/d', CMD, 'right').argv[2]).split).toBe('right');
+    expect(payloadOf(vscodiumAgentBackend.buildSplit('/d', CMD, 'down').argv[2]).split).toBe('down');
   });
-  it('spawnUri percent-encodes spaces and special chars in cwd + command', () => {
-    const url = spawnUri('vscodium', '/Users/me/my project', ['claude', '--resume', 'a b&c']);
-    expect(url).not.toContain(' ');
-    const q = new URLSearchParams(url.split('?')[1]);
-    expect(q.get('cwd')).toBe('/Users/me/my project');
-    expect(q.get('command')).toBe('claude --resume a b&c');
+  it('spawnUri survives &, spaces, and = in cwd + command (base64url payload, URL-safe)', () => {
+    const url = spawnUri('vscodium', '/Users/me/my project', ['claude', '--resume', 'a b&c=d']);
+    // base64url payload — no raw special chars VS Code would decode or mis-split on
+    const query = url.split('?')[1];
+    expect(query.startsWith('p=')).toBe(true);
+    expect(/^p=[A-Za-z0-9_-]+$/.test(query)).toBe(true);
+    const payload = payloadOf(url);
+    expect(payload.cwd).toBe('/Users/me/my project');
+    expect(payload.command).toBe('claude --resume a b&c=d');
   });
   it('makeVscodiumAgentBackend binds a variant CLI + scheme (Cursor, VS Code)', () => {
     const cursor = makeVscodiumAgentBackend(EDITOR_VARIANTS[1]);

--- a/src/lib/terminal/backends/backends.test.ts
+++ b/src/lib/terminal/backends/backends.test.ts
@@ -3,6 +3,12 @@ import type { EngineContext } from '../types.js';
 import { itermTabScript, itermSplitScript, itermBackend } from './iterm.js';
 import { ghosttyTabScript, ghosttySplitScript, ghosttyBackend } from './ghostty.js';
 import { tmuxTabArgv, tmuxSplitArgv, tmuxBackend } from './tmux.js';
+import {
+  vscodiumAgentBackend,
+  makeVscodiumAgentBackend,
+  spawnUri,
+  EDITOR_VARIANTS,
+} from './vscodium-agent.js';
 import { detectCurrentBackend, availableBackends, BACKENDS } from './index.js';
 
 const CMD = ['claude@2.1.187', '--resume', 'cad0e546'];
@@ -63,6 +69,46 @@ describe('tmux backend', () => {
   });
 });
 
+describe('vscodium-agent backend', () => {
+  it('tab: codium --open-url with a vscodium:// spawn URI carrying cwd + raw command (no zsh wrap)', () => {
+    const argv = vscodiumAgentBackend.buildTab('/Users/me/dev', CMD);
+    expect(argv.argv[0]).toBe('codium');
+    expect(argv.argv[1]).toBe('--open-url');
+    const url = argv.argv[2];
+    expect(url.startsWith('vscodium://swarmify.swarm-ext/spawn?')).toBe(true);
+    // the editor terminal is already an interactive login shell — no zsh -ilc wrap
+    expect(url).not.toContain('zsh');
+    const q = new URLSearchParams(url.split('?')[1]);
+    expect(q.get('cwd')).toBe('/Users/me/dev');
+    expect(q.get('command')).toBe('claude@2.1.187 --resume cad0e546');
+    expect(q.get('split')).toBeNull();
+  });
+  it('split: carries the direction so the extension splits beside the prior pane', () => {
+    const right = new URLSearchParams(vscodiumAgentBackend.buildSplit('/d', CMD, 'right').argv[2].split('?')[1]);
+    expect(right.get('split')).toBe('right');
+    const down = new URLSearchParams(vscodiumAgentBackend.buildSplit('/d', CMD, 'down').argv[2].split('?')[1]);
+    expect(down.get('split')).toBe('down');
+  });
+  it('spawnUri percent-encodes spaces and special chars in cwd + command', () => {
+    const url = spawnUri('vscodium', '/Users/me/my project', ['claude', '--resume', 'a b&c']);
+    expect(url).not.toContain(' ');
+    const q = new URLSearchParams(url.split('?')[1]);
+    expect(q.get('cwd')).toBe('/Users/me/my project');
+    expect(q.get('command')).toBe('claude --resume a b&c');
+  });
+  it('makeVscodiumAgentBackend binds a variant CLI + scheme (Cursor, VS Code)', () => {
+    const cursor = makeVscodiumAgentBackend(EDITOR_VARIANTS[1]);
+    expect(cursor.buildTab('/d', CMD).argv[0]).toBe('cursor');
+    expect(cursor.buildTab('/d', CMD).argv[2].startsWith('cursor://')).toBe(true);
+    const code = makeVscodiumAgentBackend(EDITOR_VARIANTS[2]);
+    expect(code.buildTab('/d', CMD).argv[0]).toBe('code');
+    expect(code.buildTab('/d', CMD).argv[2].startsWith('vscode://')).toBe(true);
+  });
+  it('is darwin-only (VSCodium.app presence checked at runtime)', () => {
+    expect(vscodiumAgentBackend.isAvailable(ctx({}, 'linux'))).toBe(false);
+  });
+});
+
 describe('availability + detection', () => {
   it('tmux is available iff $TMUX is set (any platform)', () => {
     expect(tmuxBackend.isAvailable(ctx({ TMUX: '/tmp/x,1,0' }, 'linux'))).toBe(true);
@@ -82,7 +128,7 @@ describe('availability + detection', () => {
     const a = availableBackends(ctx({ TMUX: 'x' }, 'linux'));
     expect(a.map((b) => b.id)).toEqual(['tmux']);
   });
-  it('registry has all three backends', () => {
-    expect(Object.keys(BACKENDS).sort()).toEqual(['ghostty', 'iterm', 'tmux']);
+  it('registry has all four backends', () => {
+    expect(Object.keys(BACKENDS).sort()).toEqual(['ghostty', 'iterm', 'tmux', 'vscodium-agent']);
   });
 });

--- a/src/lib/terminal/backends/index.ts
+++ b/src/lib/terminal/backends/index.ts
@@ -5,12 +5,14 @@ import type { Backend, EngineContext, TerminalBackend } from '../types.js';
 import { itermBackend } from './iterm.js';
 import { ghosttyBackend } from './ghostty.js';
 import { tmuxBackend } from './tmux.js';
+import { vscodiumAgentBackend } from './vscodium-agent.js';
 
 /** All known interactive backends, keyed by id. */
 export const BACKENDS: Record<Backend, TerminalBackend> = {
   iterm: itermBackend,
   ghostty: ghosttyBackend,
   tmux: tmuxBackend,
+  'vscodium-agent': vscodiumAgentBackend,
 };
 
 /**
@@ -31,4 +33,4 @@ export function availableBackends(ctx: EngineContext): TerminalBackend[] {
   return Object.values(BACKENDS).filter((b) => b.isAvailable(ctx));
 }
 
-export { itermBackend, ghosttyBackend, tmuxBackend };
+export { itermBackend, ghosttyBackend, tmuxBackend, vscodiumAgentBackend };

--- a/src/lib/terminal/backends/vscodium-agent.ts
+++ b/src/lib/terminal/backends/vscodium-agent.ts
@@ -48,18 +48,28 @@ function appExists(p: string): boolean {
   }
 }
 
-/** The `<scheme>://swarmify.swarm-ext/spawn?…` URL the extension handles. */
+/**
+ * The `<scheme>://swarmify.swarm-ext/spawn?p=<payload>` URL the extension handles.
+ *
+ * The payload is base64url-encoded JSON in a single `p` param — NOT one param per
+ * field. VS Code percent-*decodes* `uri.query` once before the extension parses
+ * it, so a `command`/`cwd` containing `&` (or `=`) would be mis-split by a naive
+ * multi-param query. base64url is `[A-Za-z0-9_-]` only (no `&`, `=`, `%`, `+`,
+ * `/`), so it survives that decode untouched and round-trips exactly.
+ */
 export function spawnUri(
   scheme: string,
   cwd: string,
   command: string[],
   direction?: SplitDirection,
 ): string {
-  const params = new URLSearchParams();
-  params.set('cwd', cwd);
-  params.set('command', command.join(' '));
-  if (direction) params.set('split', direction);
-  return `${scheme}://${EXTENSION_AUTHORITY}/spawn?${params.toString()}`;
+  const payload: { command: string; cwd: string; split?: SplitDirection } = {
+    command: command.join(' '),
+    cwd,
+  };
+  if (direction) payload.split = direction;
+  const p = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+  return `${scheme}://${EXTENSION_AUTHORITY}/spawn?p=${p}`;
 }
 
 /** Build a backend bound to one editor variant. */

--- a/src/lib/terminal/backends/vscodium-agent.ts
+++ b/src/lib/terminal/backends/vscodium-agent.ts
@@ -1,0 +1,83 @@
+/**
+ * VSCodium agent-terminal backend — opens an agent terminal in a VSCodium /
+ * Cursor / VS Code window via the swarmify `swarm-ext` extension's URI handler.
+ *
+ * Unlike iTerm/Ghostty (GUI terminal apps driven by AppleScript), the editor is
+ * already running; we hand it a `<scheme>://swarmify.swarm-ext/spawn?…` URL via
+ * the editor CLI's `--open-url` flag. The extension opens an editor-tab terminal
+ * in `cwd`, runs `command`, and its shell-adoption promotes a resume command
+ * (e.g. `claude --resume <id>`) to the matching agent chip. Driving the editor
+ * CLI (not macOS `open`) means this works over `--host` SSH and on Linux, needs
+ * no OS URL-scheme handler registration, and sends the command into an
+ * already-interactive login shell — so no `zsh -ilc` wrap (the other backends'
+ * wrapper) is applied here.
+ */
+import * as fs from 'fs';
+import type { TerminalBackend, LaunchSpec, SplitDirection, EngineContext } from '../types.js';
+
+/** The swarmify extension identifier that owns the `/spawn` URI verb. */
+const EXTENSION_AUTHORITY = 'swarmify.swarm-ext';
+
+/** An editor flavour that speaks the swarm-ext URI protocol. */
+export interface EditorVariant {
+  /** CLI on PATH, invoked with `--open-url`. */
+  cli: string;
+  /** URL scheme the product registers (must match the CLI's product). */
+  scheme: string;
+  /** macOS app bundle, for local availability detection. */
+  app: string;
+  label: string;
+}
+
+/**
+ * Known editors, in preference order. VSCodium first — the backend is named for
+ * it and is the user's editor; Cursor and VS Code also ship the extension and
+ * are wired here for `makeVscodiumAgentBackend` / future registration.
+ */
+export const EDITOR_VARIANTS: EditorVariant[] = [
+  { cli: 'codium', scheme: 'vscodium', app: '/Applications/VSCodium.app', label: 'VSCodium' },
+  { cli: 'cursor', scheme: 'cursor', app: '/Applications/Cursor.app', label: 'Cursor' },
+  { cli: 'code', scheme: 'vscode', app: '/Applications/Visual Studio Code.app', label: 'VS Code' },
+];
+
+function appExists(p: string): boolean {
+  try {
+    return fs.existsSync(p);
+  } catch {
+    return false;
+  }
+}
+
+/** The `<scheme>://swarmify.swarm-ext/spawn?…` URL the extension handles. */
+export function spawnUri(
+  scheme: string,
+  cwd: string,
+  command: string[],
+  direction?: SplitDirection,
+): string {
+  const params = new URLSearchParams();
+  params.set('cwd', cwd);
+  params.set('command', command.join(' '));
+  if (direction) params.set('split', direction);
+  return `${scheme}://${EXTENSION_AUTHORITY}/spawn?${params.toString()}`;
+}
+
+/** Build a backend bound to one editor variant. */
+export function makeVscodiumAgentBackend(variant: EditorVariant): TerminalBackend {
+  return {
+    id: 'vscodium-agent',
+    label: `${variant.label} agent`,
+    isAvailable(ctx: EngineContext): boolean {
+      return ctx.platform === 'darwin' && appExists(variant.app);
+    },
+    buildTab(cwd: string, command: string[]): LaunchSpec {
+      return { argv: [variant.cli, '--open-url', spawnUri(variant.scheme, cwd, command)] };
+    },
+    buildSplit(cwd: string, command: string[], direction: SplitDirection): LaunchSpec {
+      return { argv: [variant.cli, '--open-url', spawnUri(variant.scheme, cwd, command, direction)] };
+    },
+  };
+}
+
+/** Default backend: VSCodium (`codium` CLI, `vscodium://` scheme). */
+export const vscodiumAgentBackend: TerminalBackend = makeVscodiumAgentBackend(EDITOR_VARIANTS[0]);

--- a/src/lib/terminal/index.ts
+++ b/src/lib/terminal/index.ts
@@ -18,7 +18,8 @@ export type {
 } from './types.js';
 export { currentContext } from './types.js';
 
-export { BACKENDS, detectCurrentBackend, availableBackends, itermBackend, ghosttyBackend, tmuxBackend } from './backends/index.js';
+export { BACKENDS, detectCurrentBackend, availableBackends, itermBackend, ghosttyBackend, tmuxBackend, vscodiumAgentBackend } from './backends/index.js';
+export { makeVscodiumAgentBackend, spawnUri, EDITOR_VARIANTS, type EditorVariant } from './backends/vscodium-agent.js';
 export { planLayouts, type Packing } from './policy.js';
 export {
   specForRequest,

--- a/src/lib/terminal/types.ts
+++ b/src/lib/terminal/types.ts
@@ -9,7 +9,7 @@
  */
 
 /** An interactive terminal backend the engine can drive. */
-export type Backend = 'iterm' | 'ghostty' | 'tmux';
+export type Backend = 'iterm' | 'ghostty' | 'tmux' | 'vscodium-agent';
 
 /** Which way a split pane grows. `right` = side-by-side; `down` = stacked. */
 export type SplitDirection = 'right' | 'down';


### PR DESCRIPTION
## What

Adds a `vscodium-agent` backend to the terminal launch engine (Phase 2 of the engine work). It opens each resumed session as an **agent-terminal tab** in a running VSCodium / Cursor / VS Code window via the swarmify `swarm-ext` extension's new `/spawn` URI verb, instead of scripting a GUI terminal app.

## How

- `backends/vscodium-agent.ts` builds `<cli> --open-url '<scheme>://swarmify.swarm-ext/spawn?cwd=…&command=…[&split=right|down]'`. Default variant is VSCodium (`codium` / `vscodium://`); `makeVscodiumAgentBackend` covers Cursor and VS Code.
- `--open-url` forwards the URL to the running editor over its user-scoped IPC socket — no OS scheme-handler registration, works on Linux, and flows over `--host` (SSH) like the other backends.
- No `zsh -ilc` wrap: the command is sent into an editor terminal that is already an interactive login shell.
- Wired into the `Backend` union, `BACKENDS` registry, the package barrel, and `agents sessions resume` (`--vscodium`).
- Auto-detect is intentionally omitted — a VS Code integrated terminal reports `TERM_PROGRAM=vscode` for all three products, so the engine can't tell which to target.

## Companion change

Requires the swarmify `/spawn` verb: muqsitnawaz/swarmify#spawn-uri-verb (PR linked separately). The extension side is what actually opens the terminal.

## Tests

- 5 new backend unit tests (tab/split URL shape, percent-encoding, per-variant CLI+scheme, darwin-only availability). Full terminal suite: 29 pass.
- `docs/terminal-engine.md` updated (backends table, remote caveat, login-shell note, flag table, and a full "VSCodium agent terminals" section replacing the old "Not yet").

Verified end-to-end against a real VSCodium on macOS (see PR comment).