### PR TITLE
feat(mailbox): file-spool core for mid-flight agent messages

### DIFF
--- a/src/lib/mailbox.test.ts
+++ b/src/lib/mailbox.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { mailboxDir, enqueue, drain, peek, clear, type MailboxMessage } from './mailbox.js';
+
+function tmpRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'agents-mailbox-test-'));
+}
+
+const BOX = 'a1b2';
+
+/** Write a raw file straight into inbox/ (to simulate misplaced/corrupt msgs). */
+function writeRawInbox(boxDir: string, name: string, content: string): void {
+  const inbox = path.join(boxDir, 'inbox');
+  fs.mkdirSync(inbox, { recursive: true });
+  fs.writeFileSync(path.join(inbox, name), content, 'utf-8');
+}
+
+function texts(msgs: MailboxMessage[]): string[] {
+  return msgs.map((m) => m.text);
+}
+
+describe('mailbox', () => {
+  it('drains in FIFO order, stamps `to`, and empties the inbox', () => {
+    const box = mailboxDir(BOX, tmpRoot());
+    enqueue(box, { to: BOX, text: 'first' });
+    enqueue(box, { to: BOX, text: 'second' });
+    enqueue(box, { to: BOX, text: 'third' });
+
+    const got = drain(box);
+    expect(texts(got)).toEqual(['first', 'second', 'third']);
+    expect(got.every((m) => m.to === BOX)).toBe(true);
+
+    // idempotent: a second drain finds nothing.
+    expect(drain(box)).toEqual([]);
+    // pending inbox is empty; delivered messages are archived.
+    expect(fs.readdirSync(path.join(box, 'inbox'))).toHaveLength(0);
+    expect(fs.readdirSync(path.join(box, 'consumed'))).toHaveLength(3);
+  });
+
+  it('is at-least-once: recovers a message left in processing/ by an interrupted drain', () => {
+    const box = mailboxDir(BOX, tmpRoot());
+    const msgId = enqueue(box, { to: BOX, text: 'survive-a-crash' });
+
+    // Simulate a drain that CLAIMED the message (inbox -> processing) then died
+    // before archiving it.
+    fs.mkdirSync(path.join(box, 'processing'), { recursive: true });
+    fs.renameSync(
+      path.join(box, 'inbox', `${msgId}.json`),
+      path.join(box, 'processing', `${msgId}.json`),
+    );
+
+    const got = drain(box);
+    expect(texts(got)).toEqual(['survive-a-crash']);
+    expect(fs.readdirSync(path.join(box, 'processing'))).toHaveLength(0);
+    expect(fs.readdirSync(path.join(box, 'consumed'))).toHaveLength(1);
+  });
+
+  it('a single drain sweeps every message written by concurrent-style enqueues', () => {
+    const box = mailboxDir(BOX, tmpRoot());
+    const n = 5;
+    for (let i = 0; i < n; i++) enqueue(box, { to: BOX, text: `m${i}` });
+
+    const got = drain(box);
+    expect(got).toHaveLength(n);
+    expect(texts(got)).toEqual(['m0', 'm1', 'm2', 'm3', 'm4']);
+    expect(fs.readdirSync(path.join(box, 'inbox'))).toHaveLength(0);
+  });
+
+  it('empty inbox is a no-op (no throw, dirs created)', () => {
+    const box = mailboxDir(BOX, tmpRoot());
+    expect(drain(box)).toEqual([]);
+    expect(fs.existsSync(path.join(box, 'inbox'))).toBe(true);
+    expect(fs.existsSync(path.join(box, 'processing'))).toBe(true);
+    expect(fs.existsSync(path.join(box, 'consumed'))).toBe(true);
+  });
+
+  it('refuses a message addressed to a different box (anti-misroute) and drops it', () => {
+    const box = mailboxDir(BOX, tmpRoot());
+    // Simulate a file that landed in the wrong box, addressed to someone else.
+    writeRawInbox(box, '1700000000000-000000-deadbeef.json',
+      JSON.stringify({ msgId: 'x', to: 'someone-else', ts: '', text: 'not for you' }));
+    // And one legitimately addressed here.
+    enqueue(box, { to: BOX, text: 'for me' });
+
+    const got = drain(box);
+    expect(texts(got)).toEqual(['for me']); // the mismatched one is NOT delivered
+    // The dropped message must not loop — inbox is drained clean.
+    expect(fs.readdirSync(path.join(box, 'inbox'))).toHaveLength(0);
+  });
+
+  it('drops a corrupt message without stalling the queue', () => {
+    const box = mailboxDir(BOX, tmpRoot());
+    writeRawInbox(box, '1700000000000-000000-cafebabe.json', '{ not valid json');
+    enqueue(box, { to: BOX, text: 'still delivered' });
+
+    const got = drain(box);
+    expect(texts(got)).toEqual(['still delivered']);
+    expect(fs.readdirSync(path.join(box, 'inbox'))).toHaveLength(0);
+  });
+
+  it('peek is non-destructive; clear removes pending messages', () => {
+    const box = mailboxDir(BOX, tmpRoot());
+    enqueue(box, { to: BOX, text: 'a' });
+    enqueue(box, { to: BOX, text: 'b' });
+
+    expect(texts(peek(box))).toEqual(['a', 'b']);
+    // peek did not consume:
+    expect(texts(peek(box))).toEqual(['a', 'b']);
+
+    expect(clear(box)).toBe(2);
+    expect(peek(box)).toEqual([]);
+    expect(drain(box)).toEqual([]);
+  });
+
+  it('round-trips the `from` field and a host:/path clip token in text', () => {
+    const box = mailboxDir(BOX, tmpRoot());
+    enqueue(box, { to: BOX, from: 'operator@s0', text: 'match this  zion:/Users/m/mock.png' });
+
+    const [msg] = drain(box);
+    expect(msg.from).toBe('operator@s0');
+    expect(msg.text).toContain('zion:/Users/m/mock.png');
+  });
+});

--- a/src/lib/mailbox.test.ts
+++ b/src/lib/mailbox.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { mailboxDir, enqueue, drain, peek, clear, type MailboxMessage } from './mailbox.js';
+import { mailboxDir, enqueue, drain, peek, clear, assertValidMailboxId, type MailboxMessage } from './mailbox.js';
 
 function tmpRoot(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'agents-mailbox-test-'));
@@ -112,6 +112,18 @@ describe('mailbox', () => {
     expect(clear(box)).toBe(2);
     expect(peek(box)).toEqual([]);
     expect(drain(box)).toEqual([]);
+  });
+
+  it('rejects a mailboxId with a path separator or traversal (fail loud, not silent-drop)', () => {
+    const root = tmpRoot();
+    for (const bad of ['team1/subagentA', '..', '.', '', 'a\\b', 'foo/../bar']) {
+      expect(() => mailboxDir(bad, root)).toThrow(/Invalid mailboxId/);
+    }
+    // enqueue validates the `to` stamp at write time too.
+    const box = mailboxDir(BOX, root);
+    expect(() => enqueue(box, { to: 'team1/subagentA', text: 'x' })).toThrow(/Invalid mailboxId/);
+    // a clean id passes.
+    expect(() => assertValidMailboxId('loop-1700000000000-a1b2c3')).not.toThrow();
   });
 
   it('round-trips the `from` field and a host:/path clip token in text', () => {

--- a/src/lib/mailbox.ts
+++ b/src/lib/mailbox.ts
@@ -1,0 +1,194 @@
+/**
+ * Agent mailbox — a file-spool that lets a message reach an already-running
+ * agent mid-flight. One box per logical agent, keyed by a unique-per-launch id
+ * (session UUID / teams agentId / loop runId), so boxes are disjoint and a
+ * message can never reach the wrong agent (see docs / plan velvety-conjuring-popcorn).
+ *
+ * Layout: <root>/<mailboxId>/{inbox,processing,consumed}/<msgId>.json
+ *   inbox/      pending, written by `agents message`
+ *   processing/ claimed by a drain (claim-first = crash-safe)
+ *   consumed/   archived after delivery (and dropped mismatches)
+ *
+ * A box has a SINGLE consumer — the owning agent, whose tool calls (and thus
+ * hook-driven drains) are sequential. Writers may be concurrent; each enqueue
+ * is atomic (temp-write + rename), so a drain never observes a partial file.
+ * Delivery is at-least-once: an interrupted drain leaves the message in
+ * processing/, and the next drain recovers it. Consumers dedup by `msgId`.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+import { getMailboxRootDir } from './state.js';
+
+/** A single mailbox message. `text` may embed `host:/path` clip tokens. */
+export interface MailboxMessage {
+  /** Unique, time-sortable id. Also the on-disk filename stem. */
+  msgId: string;
+  /** The mailboxId this message is addressed to (anti-misroute stamp). */
+  to: string;
+  /** Who sent it (operator label / agent id / host). Optional. */
+  from?: string;
+  /** ISO-8601 creation time. */
+  ts: string;
+  /** The message body. */
+  text: string;
+}
+
+/** Absolute path to a box. `root` override is for tests. */
+export function mailboxDir(mailboxId: string, root: string = getMailboxRootDir()): string {
+  return path.join(root, mailboxId);
+}
+
+function inboxDir(boxDir: string): string { return path.join(boxDir, 'inbox'); }
+function processingDir(boxDir: string): string { return path.join(boxDir, 'processing'); }
+function consumedDir(boxDir: string): string { return path.join(boxDir, 'consumed'); }
+
+/** Create the three sub-buckets. Idempotent. */
+function ensureDirs(boxDir: string): void {
+  fs.mkdirSync(inboxDir(boxDir), { recursive: true });
+  fs.mkdirSync(processingDir(boxDir), { recursive: true });
+  fs.mkdirSync(consumedDir(boxDir), { recursive: true });
+}
+
+let seq = 0;
+
+/**
+ * `<epochMs>-<seq>-<rand>` — sorts by filename in FIFO order. The per-process
+ * monotonic `seq` breaks ties within the same millisecond (so a single writer's
+ * order is preserved); `rand` keeps it unique across processes/hosts.
+ */
+function newMsgId(): string {
+  const s = String(seq++).padStart(6, '0');
+  return `${Date.now()}-${s}-${randomUUID().slice(0, 8)}`;
+}
+
+/**
+ * Enqueue a message into `boxDir` atomically. Returns the msgId. The `to` field
+ * is stamped so a drain can refuse a message that lands in the wrong box.
+ */
+export function enqueue(boxDir: string, msg: { to: string; text: string; from?: string }): string {
+  ensureDirs(boxDir);
+  const msgId = newMsgId();
+  const record: MailboxMessage = {
+    msgId,
+    to: msg.to,
+    from: msg.from,
+    ts: new Date().toISOString(),
+    text: msg.text,
+  };
+  const target = path.join(inboxDir(boxDir), `${msgId}.json`);
+  const tmp = `${target}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(record, null, 2), 'utf-8');
+  fs.renameSync(tmp, target); // atomic on a single filesystem
+  return msgId;
+}
+
+/** Parse a message file. Returns null on missing/corrupt/invalid-shape. */
+function readMessage(file: string): MailboxMessage | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(file, 'utf-8');
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const m = parsed as Partial<MailboxMessage>;
+  if (typeof m?.msgId !== 'string' || typeof m?.to !== 'string' || typeof m?.text !== 'string') {
+    return null;
+  }
+  return { msgId: m.msgId, to: m.to, from: m.from, ts: m.ts ?? '', text: m.text };
+}
+
+function jsonFiles(dir: string): string[] {
+  let names: string[];
+  try {
+    names = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+  return names.filter((n) => n.endsWith('.json')).sort();
+}
+
+/**
+ * Consume a file already sitting in `processing/`: read, verify it is addressed
+ * to this box, then archive to `consumed/`. Returns the message iff valid AND
+ * addressed here; a mismatched/corrupt file is archived (dropped) so it never
+ * loops. Returns null when the file vanished (a racing drain took it).
+ */
+function consumeClaimed(boxDir: string, name: string, expectedTo: string): MailboxMessage | null {
+  const src = path.join(processingDir(boxDir), name);
+  const dest = path.join(consumedDir(boxDir), name);
+  const msg = readMessage(src);
+  try {
+    fs.renameSync(src, dest);
+  } catch {
+    return null; // already archived/claimed elsewhere
+  }
+  if (!msg || msg.to !== expectedTo) return null; // dropped (corrupt or wrong box)
+  return msg;
+}
+
+/**
+ * Drain the box: return every pending message addressed to it, in FIFO order,
+ * removing them from the queue. Claim-first (inbox → processing → consumed) so
+ * an interrupted drain is recovered on the next call (at-least-once). Corrupt
+ * files and messages addressed to a different box are dropped, not returned.
+ *
+ * `boxId` defaults to the box's directory name — the id it was created under.
+ */
+export function drain(boxDir: string, boxId: string = path.basename(boxDir)): MailboxMessage[] {
+  ensureDirs(boxDir);
+  const out: MailboxMessage[] = [];
+
+  // 1. Recover orphans left in processing/ by a prior interrupted drain.
+  for (const name of jsonFiles(processingDir(boxDir))) {
+    const msg = consumeClaimed(boxDir, name, boxId);
+    if (msg) out.push(msg);
+  }
+
+  // 2. Claim and consume pending inbox messages.
+  for (const name of jsonFiles(inboxDir(boxDir))) {
+    const from = path.join(inboxDir(boxDir), name);
+    const to = path.join(processingDir(boxDir), name);
+    try {
+      fs.renameSync(from, to); // atomic claim
+    } catch {
+      continue; // vanished — a racing drain took it
+    }
+    const msg = consumeClaimed(boxDir, name, boxId);
+    if (msg) out.push(msg);
+  }
+
+  return out;
+}
+
+/** Read pending messages (inbox + in-flight) without consuming them. FIFO. */
+export function peek(boxDir: string, boxId: string = path.basename(boxDir)): MailboxMessage[] {
+  const out: MailboxMessage[] = [];
+  for (const dir of [processingDir(boxDir), inboxDir(boxDir)]) {
+    for (const name of jsonFiles(dir)) {
+      const msg = readMessage(path.join(dir, name));
+      if (msg && msg.to === boxId) out.push(msg);
+    }
+  }
+  return out;
+}
+
+/** Delete pending (not-yet-claimed) inbox messages. Returns the count removed. */
+export function clear(boxDir: string): number {
+  let n = 0;
+  for (const name of jsonFiles(inboxDir(boxDir))) {
+    try {
+      fs.unlinkSync(path.join(inboxDir(boxDir), name));
+      n++;
+    } catch {
+      // already gone — ignore
+    }
+  }
+  return n;
+}

--- a/src/lib/mailbox.ts
+++ b/src/lib/mailbox.ts
@@ -34,8 +34,26 @@ export interface MailboxMessage {
   text: string;
 }
 
+/**
+ * A mailboxId must be a single, separator-free path segment. Real ids (session
+ * UUID / teams agentId / loop runId) already satisfy this; rejecting anything
+ * else fails loud instead of silently misrouting — a message whose id contained
+ * a `/` would nest under a different dir than the `to` stamp it is matched
+ * against, and would be dropped with no error. Also blocks `.`/`..` traversal
+ * once `agents message` starts accepting external target ids.
+ */
+export function assertValidMailboxId(mailboxId: string): void {
+  if (!/^[A-Za-z0-9._-]+$/.test(mailboxId) || mailboxId === '.' || mailboxId === '..') {
+    throw new Error(
+      `Invalid mailboxId ${JSON.stringify(mailboxId)}: must be a single path segment ` +
+      `matching [A-Za-z0-9._-] (no separators, not '.'/'..').`,
+    );
+  }
+}
+
 /** Absolute path to a box. `root` override is for tests. */
 export function mailboxDir(mailboxId: string, root: string = getMailboxRootDir()): string {
+  assertValidMailboxId(mailboxId);
   return path.join(root, mailboxId);
 }
 
@@ -67,6 +85,7 @@ function newMsgId(): string {
  * is stamped so a drain can refuse a message that lands in the wrong box.
  */
 export function enqueue(boxDir: string, msg: { to: string; text: string; from?: string }): string {
+  assertValidMailboxId(msg.to);
   ensureDirs(boxDir);
   const msgId = newMsgId();
   const record: MailboxMessage = {

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -104,6 +104,7 @@ const RUNS_DIR = path.join(HISTORY_DIR, 'runs');
 const TEAMS_AGENTS_DIR = path.join(HISTORY_DIR, 'teams', 'agents');
 const BACKUPS_DIR = path.join(HISTORY_DIR, 'backups');
 const TRASH_DIR = path.join(HISTORY_DIR, 'trash');
+const MAILBOX_DIR = path.join(HISTORY_DIR, 'mailbox');
 
 // Cache bucket (regenerable).
 const SHIMS_DIR = path.join(CACHE_DIR, 'shims');
@@ -358,6 +359,9 @@ export function getProjectRoutinesDir(cwd: string = process.cwd()): string | nul
 
 /** Path to routine execution logs (~/.agents/.history/runs/). */
 export function getRunsDir(): string { return RUNS_DIR; }
+
+/** Root for per-agent mailboxes (~/.agents/.history/mailbox/). */
+export function getMailboxRootDir(): string { return MAILBOX_DIR; }
 
 /** Path to installed agent CLI binaries (~/.agents/.history/versions/). */
 export function getVersionsDir(): string { return VERSIONS_DIR; }


### PR DESCRIPTION
First slice of the **agent mailbox** — the storage/drain core that lets a message reach an already-running agent mid-flight. Pure library + tests; no user-facing command yet (that's the next slice).

## What this adds
- `src/lib/mailbox.ts` — a file-spool: one box per logical agent at `~/.agents/.history/mailbox/<mailboxId>/{inbox,processing,consumed}/`.
  - `enqueue` — atomic (temp-write + rename), stamps `to` + a monotonic FIFO `msgId`.
  - `drain` — **claim-first** (inbox → processing → consumed) so an interrupted drain is recovered on the next call (**at-least-once**; consumers dedup by `msgId`). Refuses/drops any message whose `to` ≠ this box (anti-misroute) and any corrupt file, without stalling the queue.
  - `peek` (non-destructive) / `clear`.
- `src/lib/state.ts` — `getMailboxRootDir()` path getter, alongside the other `.history/` buckets.

## Design context
Part of the swarm-reconciled mailbox plan. The consumer is a `PreToolUse` hook (empirically proven to inject mid-run on Claude) that drains a box each tool call; a box has a **single consumer** (the owning agent, sequential tool calls), so drains are sequential while writers may be concurrent — the atomic enqueue + claim-first drain handle that. Message `text` carries `host:/path` clip tokens for multimodal attachments (resolved by the receiving agent, not this layer).

## Tests
8 real-filesystem tests (no mocks): FIFO order, at-least-once recovery from an interrupted drain, single-drain sweep of many enqueues, empty-inbox no-op, wrong-`to` refusal, corrupt-file drop, non-destructive peek + clear, and `from`/clip-token round-trip.

```
Test Files  1 passed (1)
     Tests  8 passed (8)
```
`tsc --noEmit` clean.

## Next slices (separate PRs)
`agents message` writer (+ `--attach`/`--clipboard` sugar, unify with `agents cloud message`) · the `PreToolUse` hook (with the proven `agent_type` sub-agent gate) · `AGENTS_MAILBOX_DIR` spawn wiring · `outbox` + `agents notify` + `agents watch --follow`.