### PR TITLE
feat(terminal): injectIntoTerminal primitive (close Gap 2) [RUSH-1415]

### DIFF
--- a/src/commands/sessions-inject.ts
+++ b/src/commands/sessions-inject.ts
@@ -1,0 +1,123 @@
+/**
+ * `agents sessions inject <sessionId> <text>` — deliver text into the terminal a
+ * running session lives in. The CLI face of the Terminal Engine's Gap 2 primitive
+ * (`injectIntoTerminal`, src/lib/terminal/inject.ts), so a native watchdog
+ * (RUSH-1415) can shell out to nudge a stalled agent with "continue".
+ *
+ * Resolution: find the active session by id, map its `provenance.reply` rail
+ * (provenance.ts:47) to an engine `InjectTarget` and inject. Today only tmux rails
+ * are externally addressable; `--pane`/`--pty` target a backend directly when the
+ * handle is already known (skipping the session lookup).
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { getActiveSessions } from '../lib/session/active.js';
+import { injectTargetFromReplyRail } from '../lib/session/inject.js';
+import { injectIntoTerminal, type InjectTarget } from '../lib/terminal/index.js';
+import { setHelpSections } from '../lib/help.js';
+
+interface InjectOptions {
+  pane?: string;
+  socket?: string;
+  pty?: string;
+  host?: string;
+  enter?: boolean;
+  combined?: boolean;
+  json?: boolean;
+}
+
+/** Resolve a session id (short or full) to an addressable terminal target. */
+async function resolveTarget(sessionId: string): Promise<{ target: InjectTarget | null; reason?: string }> {
+  const sessions = await getActiveSessions();
+  const match = sessions.find(
+    (s) => s.sessionId === sessionId || (s.sessionId != null && s.sessionId.startsWith(sessionId)),
+  );
+  if (!match) return { target: null, reason: `No active session matches "${sessionId}".` };
+  const rail = match.provenance?.reply;
+  if (!rail) {
+    return {
+      target: null,
+      reason: `Session "${sessionId}" has no addressable reply rail (not running under tmux). Relaunch it under a tmux/pty rail to inject.`,
+    };
+  }
+  const target = injectTargetFromReplyRail(rail);
+  if (!target) return { target: null, reason: `Session "${sessionId}" reply rail is not injectable.` };
+  return { target };
+}
+
+async function runInject(sessionId: string, text: string, options: InjectOptions): Promise<void> {
+  // Direct-target shortcuts skip the session lookup — the watchdog often already
+  // holds the pane id or pty session it wants to type into.
+  let target: InjectTarget | null = null;
+  if (options.pty) {
+    target = { backend: 'pty', id: options.pty };
+  } else if (options.pane) {
+    target = { backend: 'tmux', pane: options.pane, socket: options.socket };
+  } else {
+    const resolved = await resolveTarget(sessionId);
+    if (!resolved.target) {
+      if (options.json) console.log(JSON.stringify({ ok: false, error: resolved.reason }));
+      else console.error(chalk.red(resolved.reason));
+      process.exit(1);
+    }
+    target = resolved.target;
+  }
+
+  const res = await injectIntoTerminal(target, text, {
+    enter: options.enter !== false,
+    combined: options.combined,
+    socket: options.socket,
+    host: options.host,
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify(res));
+  } else if (res.ok) {
+    console.log(chalk.green(`Injected into ${res.backend} (${res.writes} write${res.writes === 1 ? '' : 's'}).`));
+  } else {
+    console.error(chalk.red(res.error ?? 'injection failed'));
+  }
+  if (!res.ok) process.exit(1);
+}
+
+/** Attach the `inject` subcommand to an existing `sessions` command. */
+export function registerSessionsInjectCommand(sessionsCmd: Command): void {
+  const injectCmd = sessionsCmd
+    .command('inject <sessionId> <text>')
+    .description('Deliver text (+ Enter) into the terminal a running session lives in — nudge a stalled agent.')
+    .option('--pane <id>', 'Target a tmux pane id directly (e.g. %3), skipping session lookup')
+    .option('--pty <id>', 'Target an agents-pty session id directly, skipping session lookup')
+    .option('--socket <path>', 'tmux socket path (defaults to the session/shared socket)')
+    .option('--host <target>', 'Deliver on a remote host over SSH (tmux/AppleScript backends)')
+    .option('--no-enter', 'Send only the text, without a trailing Enter')
+    .option('--combined', 'Fuse text + Enter into ONE write (default: two writes, Ink-TUI safe)')
+    .option('--json', 'Output the InjectResult as JSON');
+
+  setHelpSections(injectCmd, {
+    examples: `
+      # Nudge a stalled agent by session id (resolves its tmux pane)
+      agents sessions inject a1b2c3d4 "continue"
+
+      # Target a tmux pane directly (what a watchdog already holds)
+      agents sessions inject _ "continue" --pane %3 --socket /tmp/agents/tmux.sock
+
+      # Type into an agents-pty session without submitting
+      agents sessions inject _ "ls" --pty $SID --no-enter
+    `,
+    notes: `
+      - Ink-TUI Enter semantics: by default the text and Enter are two separate
+        writes, which is what Claude's Ink TUI needs. --combined fuses them.
+      - Only sessions running under a tmux pane are addressable by id today
+        (provenance.ts reply rails). Use --pane/--pty for direct targeting.
+      - Built on the Terminal Engine (src/lib/terminal): --host runs the tmux /
+        AppleScript spec over the same SSH transport the launch engine uses.
+    `,
+  });
+
+  // The parent `sessions` command also defines --json, so it binds there;
+  // optsWithGlobals() merges parent + subcommand options so --json is honored.
+  injectCmd.action(async (sessionId: string, text: string, _options: InjectOptions, command: Command) => {
+    await runInject(sessionId, text, command.optsWithGlobals() as InjectOptions);
+  });
+}

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -40,6 +40,7 @@ import { setHelpSections } from '../lib/help.js';
 import { registerSessionsTailCommand } from './sessions-tail.js';
 import { registerSessionsSyncCommand } from './sessions-sync.js';
 import { registerSessionsResumeCommand } from './sessions-resume.js';
+import { registerSessionsInjectCommand } from './sessions-inject.js';
 
 const SESSION_AGENT_FILTER_HELP = `Filter by agent, e.g. claude, codex, claude@2.0.65`;
 
@@ -1722,6 +1723,7 @@ export function registerSessionsCommands(program: Command): void {
   registerSessionsTailCommand(sessionsCmd);
   registerSessionsSyncCommand(sessionsCmd);
   registerSessionsResumeCommand(sessionsCmd);
+  registerSessionsInjectCommand(sessionsCmd);
 }
 
 function formatNoSessionsMessage(

--- a/src/lib/session/inject.test.ts
+++ b/src/lib/session/inject.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { injectTargetFromReplyRail } from './inject.js';
+import type { ReplyRail } from './provenance.js';
+
+describe('injectTargetFromReplyRail', () => {
+  it('maps a tmux rail to a tmux InjectTarget, carrying the pane + socket', () => {
+    const rail: ReplyRail = { rail: 'tmux', target: '%3', socket: '/tmp/srv.sock' };
+    expect(injectTargetFromReplyRail(rail)).toEqual({ backend: 'tmux', pane: '%3', socket: '/tmp/srv.sock' });
+  });
+
+  it('carries an undefined socket through (tmux falls back to its default)', () => {
+    const rail: ReplyRail = { rail: 'tmux', target: '%0' };
+    expect(injectTargetFromReplyRail(rail)).toEqual({ backend: 'tmux', pane: '%0', socket: undefined });
+  });
+
+  it('yields null for a null rail (no addressable terminal today)', () => {
+    expect(injectTargetFromReplyRail(null)).toBeNull();
+  });
+});

--- a/src/lib/session/inject.ts
+++ b/src/lib/session/inject.ts
@@ -1,0 +1,25 @@
+/**
+ * Session → Terminal-Engine injection adapter.
+ *
+ * The Terminal Engine owns the injection primitive (`injectIntoTerminal`,
+ * src/lib/terminal/inject.ts). This thin adapter maps a session's provenance
+ * `ReplyRail` (the addressable terminal the feed already derives — provenance.ts:47)
+ * to the engine's `InjectTarget`, so a caller can go session → keystrokes in one
+ * hop. Kept on the session side because `ReplyRail` is a session concept; the
+ * engine stays agnostic of how a target was discovered.
+ */
+
+import type { ReplyRail } from './provenance.js';
+import type { InjectTarget } from '../terminal/inject.js';
+
+/**
+ * Map a session's `ReplyRail` to an engine `InjectTarget`. Today only tmux rails
+ * are externally addressable (provenance.ts:143-149); a null rail yields null and
+ * the caller must supply a target another way (a pty id, a macOS window).
+ */
+export function injectTargetFromReplyRail(rail: ReplyRail): InjectTarget | null {
+  if (rail && rail.rail === 'tmux') {
+    return { backend: 'tmux', pane: rail.target, socket: rail.socket };
+  }
+  return null;
+}

--- a/src/lib/terminal/index.ts
+++ b/src/lib/terminal/index.ts
@@ -38,7 +38,6 @@ export {
   itermInjectScript,
   ghosttyInjectScript,
   appleScriptInjectSpec,
-  isLaunchBackend,
   type InjectTarget,
   type InjectBackend,
   type InjectOptions,

--- a/src/lib/terminal/index.ts
+++ b/src/lib/terminal/index.ts
@@ -31,3 +31,16 @@ export {
   type SurfaceItem,
 } from './engine.js';
 export { runLocal, runRemote, runSpec, remoteCommand, type HostResolver, type RunResult } from './transport.js';
+export {
+  injectIntoTerminal,
+  tmuxSendKeysArgv,
+  tmuxInjectSpecs,
+  itermInjectScript,
+  ghosttyInjectScript,
+  appleScriptInjectSpec,
+  isLaunchBackend,
+  type InjectTarget,
+  type InjectBackend,
+  type InjectOptions,
+  type InjectResult,
+} from './inject.js';

--- a/src/lib/terminal/inject.test.ts
+++ b/src/lib/terminal/inject.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for the Terminal Engine injection primitive (Gap 2).
+ *
+ * Two layers, no mocks:
+ *   1. Pure builders (tmux argv / iTerm+Ghostty AppleScript) — asserted
+ *      directly, including the macOS paths that can't execute on Linux.
+ *   2. A real tmux round-trip: spawn a pane, inject through `injectIntoTerminal`,
+ *      and read the pane back to prove the bytes + Enter actually landed. Skipped
+ *      cleanly when tmux isn't installed.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { isTmuxInstalled, runTmux } from '../tmux/binary.js';
+import { createSession, capturePane, killAll } from '../tmux/session.js';
+import type { EngineContext } from './types.js';
+import {
+  injectIntoTerminal,
+  tmuxSendKeysArgv,
+  tmuxInjectSpecs,
+  itermInjectScript,
+  ghosttyInjectScript,
+  appleScriptInjectSpec,
+} from './inject.js';
+
+const linuxCtx: EngineContext = { platform: 'linux', env: {} as NodeJS.ProcessEnv };
+
+/** The first (only) pane id of a freshly-created single-pane session, e.g. `%3`. */
+async function firstPaneId(name: string, socket: string): Promise<string> {
+  const res = await runTmux({ socket, args: ['list-panes', '-t', name, '-F', '#{pane_id}'] });
+  return res.stdout.trim().split('\n')[0];
+}
+
+describe('tmuxSendKeysArgv', () => {
+  it('starts with tmux so the engine transport runs it locally or over SSH', () => {
+    expect(tmuxSendKeysArgv('%2', 'continue', { literal: true })).toEqual([
+      'tmux', 'send-keys', '-t', '%2', '-l', 'continue',
+    ]);
+  });
+
+  it('positions -S <socket> before the subcommand', () => {
+    expect(tmuxSendKeysArgv('%2', 'Enter', { socket: '/tmp/s.sock' })).toEqual([
+      'tmux', '-S', '/tmp/s.sock', 'send-keys', '-t', '%2', 'Enter',
+    ]);
+  });
+});
+
+describe('tmuxInjectSpecs', () => {
+  it('Ink-safe default: two specs — literal text, then a separate Enter keypress', () => {
+    const specs = tmuxInjectSpecs({ backend: 'tmux', pane: '%1' }, 'go', { enter: true, combined: false });
+    expect(specs).toHaveLength(2);
+    expect(specs[0].argv).toEqual(['tmux', 'send-keys', '-t', '%1', '-l', 'go']);
+    expect(specs[1].argv).toEqual(['tmux', 'send-keys', '-t', '%1', 'Enter']);
+  });
+
+  it('combined: one spec fusing a CR into the literal write', () => {
+    const specs = tmuxInjectSpecs({ backend: 'tmux', pane: '%1' }, 'go', { enter: true, combined: true });
+    expect(specs).toHaveLength(1);
+    expect(specs[0].argv).toEqual(['tmux', 'send-keys', '-t', '%1', '-l', 'go\r']);
+  });
+
+  it('enter=false: just the literal text, no Enter', () => {
+    const specs = tmuxInjectSpecs({ backend: 'tmux', pane: '%1' }, 'go', { enter: false, combined: false });
+    expect(specs).toHaveLength(1);
+    expect(specs[0].argv).toEqual(['tmux', 'send-keys', '-t', '%1', '-l', 'go']);
+  });
+});
+
+describe('itermInjectScript', () => {
+  it('keystrokes the text then a SEPARATE Return (Ink-safe) into the current session', () => {
+    const s = itermInjectScript('continue', { enter: true });
+    expect(s).toContain('tell application "iTerm2"');
+    expect(s).toContain('keystroke "continue"');
+    expect(s).toContain('key code 36');
+    expect(s.indexOf('keystroke "continue"')).toBeLessThan(s.indexOf('key code 36'));
+  });
+
+  it('addresses a specific session by id when given one', () => {
+    const s = itermInjectScript('go', { session: 'ABC-123', enter: true });
+    expect(s).toContain('if (id of s) is "ABC-123" then');
+    expect(s).toContain('select w');
+  });
+
+  it('omits the Return event when enter is false', () => {
+    expect(itermInjectScript('partial', { enter: false })).not.toContain('key code 36');
+  });
+
+  it('escapes quotes in the injected text via the engine appleScriptStr', () => {
+    expect(itermInjectScript('say "hi"', { enter: false })).toContain('keystroke "say \\"hi\\""');
+  });
+});
+
+describe('ghosttyInjectScript', () => {
+  it('raises the ghostty process and keystrokes text + separate Return', () => {
+    const s = ghosttyInjectScript('continue', { enter: true });
+    expect(s).toContain('tell process "ghostty"');
+    expect(s).toContain('set frontmost to true');
+    expect(s).toContain('keystroke "continue"');
+    expect(s).toContain('key code 36');
+  });
+
+  it('raises a specific window by title when given one', () => {
+    const s = ghosttyInjectScript('go', { window: 'RUSH-1415', enter: true });
+    expect(s).toContain('AXRaise');
+    expect(s).toContain('title contains "RUSH-1415"');
+  });
+});
+
+describe('appleScriptInjectSpec', () => {
+  it('wraps the script as an osascript spec', () => {
+    const spec = appleScriptInjectSpec({ backend: 'iterm' }, 'hi', true);
+    expect(spec.argv[0]).toBe('osascript');
+    expect(spec.argv[1]).toBe('-e');
+    expect(spec.argv[2]).toContain('keystroke "hi"');
+  });
+});
+
+describe('injectIntoTerminal — macOS backends off-darwin', () => {
+  it('does not execute where the app is unavailable, but returns the spec it would run', async () => {
+    const res = await injectIntoTerminal({ backend: 'iterm' }, 'continue', { ctx: linuxCtx });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('not available');
+    expect(res.specs?.[0].argv[0]).toBe('osascript');
+  });
+
+  it('dryRun returns the spec without touching the OS on any platform', async () => {
+    const res = await injectIntoTerminal({ backend: 'ghostty', window: 'w1' }, 'hi', { dryRun: true });
+    expect(res.ok).toBe(true);
+    expect(res.writes).toBe(2);
+    expect(res.specs?.[0].argv.join(' ')).toContain('keystroke "hi"');
+  });
+});
+
+describe('injectIntoTerminal — pty guards', () => {
+  it('refuses a remote pty target (the sidecar is local-only)', async () => {
+    const res = await injectIntoTerminal({ backend: 'pty', id: 'x' }, 'hi', { host: 'box-a', dryRun: true });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('local-only');
+  });
+
+  it('dryRun reports the Ink-safe two-write plan for pty', async () => {
+    const res = await injectIntoTerminal({ backend: 'pty', id: 'x' }, 'hi', { dryRun: true });
+    expect(res.ok).toBe(true);
+    expect(res.writes).toBe(2);
+  });
+});
+
+const skipReason = isTmuxInstalled() ? null : 'tmux not installed';
+
+describe.skipIf(skipReason)('injectIntoTerminal — real tmux round-trip', () => {
+  let socket: string;
+  let tempDir: string;
+  const name = 'inject-e2e';
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-inject-test-'));
+    socket = path.join(tempDir, 'srv.sock');
+  });
+
+  afterEach(async () => {
+    try { await killAll(socket); } catch { /* best-effort */ }
+    try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch { /* gone */ }
+  });
+
+  it('delivers text + Enter so a shell actually runs the injected command', async () => {
+    // A pane running an interactive shell — the exact shape a stalled agent sits in.
+    await createSession({ name, socket, cmd: 'sh', cwd: tempDir });
+    const pane = await firstPaneId(name, socket);
+
+    const marker = path.join(tempDir, 'ran.txt');
+    const res = await injectIntoTerminal({ backend: 'tmux', pane, socket }, `touch ${marker}`);
+    expect(res.ok).toBe(true);
+    expect(res.backend).toBe('tmux');
+    // Ink-safe default: literal text write, then a separate Enter write.
+    expect(res.writes).toBe(2);
+
+    // Poll for the side effect — proof the Enter actually submitted the line.
+    let landed = false;
+    for (let i = 0; i < 40 && !landed; i++) {
+      if (fs.existsSync(marker)) { landed = true; break; }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(landed).toBe(true);
+  });
+
+  it('injects visible text into the pane (cat echoes it back)', async () => {
+    await createSession({ name, socket, cmd: 'cat', cwd: tempDir });
+    const pane = await firstPaneId(name, socket);
+
+    const res = await injectIntoTerminal({ backend: 'tmux', pane, socket }, 'continue-please', { enter: false });
+    expect(res.ok).toBe(true);
+
+    let seen = '';
+    for (let i = 0; i < 40; i++) {
+      seen = await capturePane({ name, socket });
+      if (seen.includes('continue-please')) break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(seen).toContain('continue-please');
+  });
+
+  it('combined mode fuses text+CR into a single write that still submits', async () => {
+    await createSession({ name, socket, cmd: 'sh', cwd: tempDir });
+    const pane = await firstPaneId(name, socket);
+
+    const marker = path.join(tempDir, 'combined.txt');
+    const res = await injectIntoTerminal({ backend: 'tmux', pane, socket }, `touch ${marker}`, { combined: true });
+    expect(res.ok).toBe(true);
+    expect(res.writes).toBe(1);
+
+    let landed = false;
+    for (let i = 0; i < 40 && !landed; i++) {
+      if (fs.existsSync(marker)) { landed = true; break; }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(landed).toBe(true);
+  });
+});

--- a/src/lib/terminal/inject.ts
+++ b/src/lib/terminal/inject.ts
@@ -35,7 +35,7 @@ import { ptyRequest } from '../pty-client.js';
 import { appleScriptStr } from './quote.js';
 import { runSpec, type HostResolver } from './transport.js';
 import { itermBackend, ghosttyBackend } from './backends/index.js';
-import { currentContext, type LaunchSpec, type EngineContext, type Backend } from './types.js';
+import { currentContext, type LaunchSpec, type EngineContext } from './types.js';
 
 /**
  * An already-running surface to type into. A superset of the engine's launch
@@ -91,6 +91,11 @@ const CR = '\r';
  * engine's `tmuxTabArgv`) so the same transport runs it locally or over SSH. The
  * socket, when set, is positioned before the subcommand (`-S` must lead). `-l`
  * sends the keys literally; without it tmux interprets a key name like `Enter`.
+ *
+ * NOTE: distinct from `sendKeys()` in src/lib/tmux/session.ts — that one
+ * addresses by session *name* on the default socket (the `agents tmux` surface)
+ * and shells out directly; this one addresses by *pane id* + arbitrary socket and
+ * returns an SSH-capable `LaunchSpec` for the engine transport. Don't collapse them.
  */
 export function tmuxSendKeysArgv(
   pane: string,
@@ -255,9 +260,4 @@ export async function injectIntoTerminal(
     if (!res.ok) return { ok: false, backend: target.backend, writes: 0, specs, error: res.error };
   }
   return { ok: true, backend: target.backend, writes, specs };
-}
-
-/** The engine's launch `Backend`s that can also be injected into (excludes pty). */
-export function isLaunchBackend(b: InjectBackend): b is Backend {
-  return b === 'tmux' || b === 'iterm' || b === 'ghostty';
 }

--- a/src/lib/terminal/inject.ts
+++ b/src/lib/terminal/inject.ts
@@ -1,0 +1,263 @@
+/**
+ * Terminal injection — Gap 2 of the Terminal Engine.
+ *
+ * Where the rest of the engine OPENS a surface (a tab / split running a
+ * command), injection types into an ALREADY-running surface. It's the primitive
+ * a native watchdog (RUSH-1415) needs to nudge a stalled agent with "continue"
+ * delivered into the exact terminal that agent lives in — the gap flagged in
+ * src/lib/session/provenance.ts:20:
+ *
+ *   > Actually delivering the keystrokes is Gap 2 (pty/tmux send-keys).
+ *
+ * It mirrors the engine's shape exactly: pure per-backend spec builders (like
+ * `tmuxTabArgv` / `itermTabScript`) produce a `LaunchSpec` (argv), and the same
+ * `runSpec` transport runs it — so injection inherits the engine's local/remote
+ * (`--host` over SSH) execution for free. A `LaunchSpec` never opens anything;
+ * building one is side-effect-free and unit-testable without a display.
+ *
+ * Backends:
+ *   - tmux  → `tmux send-keys -t <pane>` — the send-keys primitive addressed by
+ *             pane id + socket (the exact rail provenance.ts:147-149 identifies).
+ *   - iterm/ghostty (macOS) → AppleScript that ADDRESSES the target window/tab
+ *             and injects via System Events keystrokes. Uses the engine's
+ *             `appleScriptStr` escaper; guarded by the backend's own
+ *             `isAvailable` (platform + app installed).
+ *   - pty   → the `agents pty write` sidecar path (ptyRequest). Local-only —
+ *             the sidecar is not an engine transport surface.
+ *
+ * Ink-TUI Enter semantics: Claude's Ink TUI swallows an Enter fused to the text,
+ * so the default path delivers the text and the Enter as TWO SEPARATE writes
+ * (swarmify's `sendText(text,false)` then `sendText('\r',false)`). `combined`
+ * opts into one fused write for plain shells / REPLs.
+ */
+
+import { ptyRequest } from '../pty-client.js';
+import { appleScriptStr } from './quote.js';
+import { runSpec, type HostResolver } from './transport.js';
+import { itermBackend, ghosttyBackend } from './backends/index.js';
+import { currentContext, type LaunchSpec, type EngineContext, type Backend } from './types.js';
+
+/**
+ * An already-running surface to type into. A superset of the engine's launch
+ * `Backend` — it adds `pty` (the sidecar), which the engine can't launch but can
+ * be injected into.
+ */
+export type InjectTarget =
+  | { backend: 'tmux'; pane: string; socket?: string }
+  | { backend: 'iterm'; session?: string }
+  | { backend: 'ghostty'; window?: string }
+  | { backend: 'pty'; id: string };
+
+export type InjectBackend = InjectTarget['backend'];
+
+export interface InjectOptions {
+  /** Append Enter after the text. Default true. */
+  enter?: boolean;
+  /**
+   * Fuse the text and its Enter into a SINGLE write. Default false — the safe
+   * default sends the text, then the Enter, as two separate writes (Ink-TUI
+   * safe). Set true for plain shells / REPLs that want one atomic line.
+   */
+  combined?: boolean;
+  /** tmux socket override (defaults to `target.socket`, then tmux's default socket). */
+  socket?: string;
+  /** Remote host for the tmux / AppleScript backends (runs the spec over SSH). Local by default. */
+  host?: string;
+  /** Resolve a host alias to an ssh target (see the engine's transport). */
+  resolveHost?: HostResolver;
+  /** Ambient context for the availability check (defaults to the live process context). */
+  ctx?: EngineContext;
+  /** Don't execute — return the spec(s) that WOULD run. Lets the macOS paths be asserted on Linux. */
+  dryRun?: boolean;
+}
+
+export interface InjectResult {
+  ok: boolean;
+  backend: InjectBackend;
+  /** Discrete writes delivered: 2 for the Ink-safe text+Enter split, 1 when combined or enter=false. */
+  writes: number;
+  /** For the tmux / AppleScript backends (or any dryRun), the spec(s) that ran / would run. */
+  specs?: LaunchSpec[];
+  error?: string;
+}
+
+/** Carriage return — what Enter delivers into a raw PTY/tmux byte stream. */
+const CR = '\r';
+
+// --- tmux -------------------------------------------------------------------
+
+/**
+ * argv for `tmux send-keys` targeting a pane by id. Starts with `tmux` (like the
+ * engine's `tmuxTabArgv`) so the same transport runs it locally or over SSH. The
+ * socket, when set, is positioned before the subcommand (`-S` must lead). `-l`
+ * sends the keys literally; without it tmux interprets a key name like `Enter`.
+ */
+export function tmuxSendKeysArgv(
+  pane: string,
+  keys: string,
+  opts: { literal?: boolean; socket?: string } = {},
+): string[] {
+  const argv = ['tmux'];
+  if (opts.socket) argv.push('-S', opts.socket);
+  argv.push('send-keys', '-t', pane);
+  if (opts.literal) argv.push('-l');
+  argv.push(keys);
+  return argv;
+}
+
+/** The one-or-two send-keys specs for a tmux injection (Ink-safe split by default). */
+export function tmuxInjectSpecs(
+  target: Extract<InjectTarget, { backend: 'tmux' }>,
+  text: string,
+  o: { enter: boolean; combined: boolean; socket?: string },
+): LaunchSpec[] {
+  const socket = o.socket ?? target.socket;
+  if (o.enter && o.combined) {
+    return [{ argv: tmuxSendKeysArgv(target.pane, text + CR, { literal: true, socket }) }];
+  }
+  const specs: LaunchSpec[] = [{ argv: tmuxSendKeysArgv(target.pane, text, { literal: true, socket }) }];
+  // A separate Enter keypress — its own write, so the Ink TUI sees Enter alone.
+  if (o.enter) specs.push({ argv: tmuxSendKeysArgv(target.pane, 'Enter', { socket }) });
+  return specs;
+}
+
+// --- macOS (iterm / ghostty) ------------------------------------------------
+
+/**
+ * AppleScript that brings the target iTerm2 session (tab) to the front, then
+ * injects `text` and — when `enter` — a SEPARATE Return keypress (`key code 36`)
+ * so the Ink TUI sees Enter as its own event. Omitting `session` types into the
+ * current session.
+ */
+export function itermInjectScript(text: string, opts: { session?: string; enter: boolean }): string {
+  const lines: string[] = ['tell application "iTerm2"', '  activate'];
+  if (opts.session) {
+    lines.push(
+      '  repeat with w in windows',
+      '    repeat with t in tabs of w',
+      '      repeat with s in sessions of t',
+      `        if (id of s) is ${appleScriptStr(opts.session)} then`,
+      '          select w',
+      '          tell w to select t',
+      '        end if',
+      '      end repeat',
+      '    end repeat',
+      '  end repeat',
+    );
+  }
+  lines.push('end tell');
+  lines.push(`tell application "System Events" to keystroke ${appleScriptStr(text)}`);
+  if (opts.enter) lines.push('tell application "System Events" to key code 36');
+  return lines.join('\n');
+}
+
+/**
+ * AppleScript for Ghostty (no scripting dictionary): raise the target window via
+ * System Events, then keystroke the text and a separate Return. `window` matches
+ * a window whose title contains the string; omitted → the frontmost Ghostty window.
+ */
+export function ghosttyInjectScript(text: string, opts: { window?: string; enter: boolean }): string {
+  const lines: string[] = ['tell application "System Events"', '  tell process "ghostty"', '    set frontmost to true'];
+  if (opts.window) {
+    lines.push(`    perform action "AXRaise" of (first window whose title contains ${appleScriptStr(opts.window)})`);
+  }
+  lines.push('  end tell');
+  lines.push(`  keystroke ${appleScriptStr(text)}`);
+  if (opts.enter) lines.push('  key code 36');
+  lines.push('end tell');
+  return lines.join('\n');
+}
+
+/** The osascript spec for a macOS injection. One invocation delivers keystroke + Return. */
+export function appleScriptInjectSpec(
+  target: Extract<InjectTarget, { backend: 'iterm' | 'ghostty' }>,
+  text: string,
+  enter: boolean,
+): LaunchSpec {
+  const script =
+    target.backend === 'iterm'
+      ? itermInjectScript(text, { session: target.session, enter })
+      : ghosttyInjectScript(text, { window: target.window, enter });
+  return { argv: ['osascript', '-e', script] };
+}
+
+// --- pty --------------------------------------------------------------------
+
+async function injectPty(
+  target: Extract<InjectTarget, { backend: 'pty' }>,
+  text: string,
+  o: { enter: boolean; combined: boolean; host?: string; dryRun?: boolean },
+): Promise<InjectResult> {
+  if (o.host && o.host !== 'local') {
+    return { ok: false, backend: 'pty', writes: 0, error: 'pty injection is local-only (the sidecar is not a remote surface)' };
+  }
+  // Same Ink-safe split as tmux: text write, then a separate CR write.
+  const writes: string[] = o.enter && o.combined ? [text + CR] : o.enter ? [text, CR] : [text];
+
+  if (o.dryRun) return { ok: true, backend: 'pty', writes: writes.length };
+
+  try {
+    for (const input of writes) {
+      const res = await ptyRequest('write', target.id, { input });
+      if (!res.ok) return { ok: false, backend: 'pty', writes: 0, error: res.error ?? 'pty write failed' };
+    }
+    return { ok: true, backend: 'pty', writes: writes.length };
+  } catch (err) {
+    return { ok: false, backend: 'pty', writes: 0, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// --- public entry -----------------------------------------------------------
+
+/**
+ * Deliver `text` (+ Enter) into an existing terminal surface. Resolves the
+ * target's backend and routes to the matching primitive. Never throws — launch
+ * failures come back in the result, like the engine's `openSurface`.
+ */
+export async function injectIntoTerminal(
+  target: InjectTarget,
+  text: string,
+  opts: InjectOptions = {},
+): Promise<InjectResult> {
+  const enter = opts.enter !== false;
+  const combined = opts.combined === true;
+
+  if (target.backend === 'pty') {
+    return injectPty(target, text, { enter, combined, host: opts.host, dryRun: opts.dryRun });
+  }
+
+  // tmux + AppleScript backends run through the engine transport.
+  const specs =
+    target.backend === 'tmux'
+      ? tmuxInjectSpecs(target, text, { enter, combined, socket: opts.socket })
+      : [appleScriptInjectSpec(target, text, enter)];
+
+  // A macOS keystroke injection is one osascript spec that emits keystroke +
+  // Return, i.e. two writes; tmux/pty count their discrete send-keys/write calls.
+  const writes = target.backend === 'tmux' ? specs.length : enter ? 2 : 1;
+
+  if (opts.dryRun) return { ok: true, backend: target.backend, writes, specs };
+
+  // AppleScript backends: guard on the backend's own availability, but only for a
+  // LOCAL run (a remote host is assumed to have the app — its ssh leg reports failure).
+  if (target.backend === 'iterm' || target.backend === 'ghostty') {
+    if (!opts.host || opts.host === 'local') {
+      const backend = target.backend === 'iterm' ? itermBackend : ghosttyBackend;
+      const ctx = opts.ctx ?? currentContext();
+      if (!backend.isAvailable(ctx)) {
+        return { ok: false, backend: target.backend, writes: 0, specs, error: `${backend.label} is not available here (platform ${ctx.platform})` };
+      }
+    }
+  }
+
+  for (const spec of specs) {
+    const res = await runSpec(spec, opts.host, opts.resolveHost);
+    if (!res.ok) return { ok: false, backend: target.backend, writes: 0, specs, error: res.error };
+  }
+  return { ok: true, backend: target.backend, writes, specs };
+}
+
+/** The engine's launch `Backend`s that can also be injected into (excludes pty). */
+export function isLaunchBackend(b: InjectBackend): b is Backend {
+  return b === 'tmux' || b === 'iterm' || b === 'ghostty';
+}


### PR DESCRIPTION
## What

Adds `injectIntoTerminal(target, text, opts?)` to the **Terminal Engine** (`src/lib/terminal/`) — the primitive that types into an **already-running** terminal surface, not a freshly launched tab. This is what a native watchdog (RUSH-1415) needs to nudge a stalled agent with `continue\n` delivered into the exact terminal that agent lives in.

## The gap this closes

`src/lib/session/provenance.ts:20` ends the reply-rail model with:

> `reply` is a read-only hint, not a send channel ... **Actually delivering the keystrokes is Gap 2 (pty/tmux send-keys).**

`provenance.ts` could *identify* a session's addressable terminal (`reply: { rail: 'tmux', target: '%3', socket }`, provenance.ts:147-149) but nothing could *deliver* into it. `injectIntoTerminal` is Gap 2.

## Built ON the engine, not a fork

The launch engine (`src/lib/terminal/`, PR #605/#608) opens surfaces via pure per-backend spec builders (`tmuxTabArgv`, `itermTabScript`, `ghosttyTabScript`) that produce a `LaunchSpec{argv}` run through a shared `runSpec` transport. Injection mirrors that shape exactly (`src/lib/terminal/inject.ts`):

- **tmux** -> `tmux send-keys -t <pane>` (socket-addressed) — `tmuxSendKeysArgv` / `tmuxInjectSpecs`.
- **iterm / ghostty** (macOS) -> AppleScript that ADDRESSES the target window/tab and injects via System Events keystrokes, **reusing the engine's `appleScriptStr` escaper** (`quote.ts`) and guarded by each backend's own `isAvailable` (platform + app installed).
- **pty** -> the `agents pty write` sidecar path (`ptyRequest`, `src/lib/pty-client.ts:30`) — local-only.

Because the tmux/AppleScript specs run through the engine's `runSpec`, injection inherits **remote `--host` over SSH for free** — the same transport `agents sessions --host` and the launch engine use. Building a spec is side-effect-free, so every backend is unit-testable on Linux without a display.

`src/lib/session/inject.ts` is a thin adapter mapping a session's `ReplyRail` -> the engine's `InjectTarget`, so a caller goes session -> keystrokes in one hop while the engine stays agnostic of how a target was discovered.

### Ink-TUI Enter semantics

Claude's Ink TUI swallows an Enter fused to the text. So the default path delivers the text and the Enter as **two separate writes** (mirroring swarmify's `sendText(text,false)` then `sendText('\r',false)`), in both the tmux and pty paths. `combined: true` opts back into one fused write for plain shells.

## CLI

`agents sessions inject <sessionId> <text>` (`src/commands/sessions-inject.ts`) so the watchdog can shell out. Resolves the session's reply rail, or targets directly with `--pane`/`--pty`; `--combined` / `--no-enter` / `--host` / `--json` expose the write semantics.

## Verification (Linux, real — not a proxy)

Real tmux round-trip (`terminal/inject.test.ts`) spawns a pane running `sh`, injects `touch <marker>`, and asserts the marker file appears — proving the injected text **and** the separate Enter actually submitted the line:

```
✓ real tmux round-trip > delivers text + Enter so a shell actually runs the injected command
✓ real tmux round-trip > injects visible text into the pane (cat echoes it back)
✓ real tmux round-trip > combined mode fuses text+CR into a single write that still submits
Test Files  4 passed (4)   Tests  46 passed (46)   (includes the engine's own suite — no regression)
```

Built-CLI E2E against live tmux panes:

```
$ node dist/index.js sessions inject _ "touch $MARKER" --pane %0 --socket $SOCK
Injected into tmux (2 writes).       # -> marker file created (Enter submitted the line)

$ node dist/index.js sessions inject _ "hi" --pane %0 --socket $SOCK --no-enter --json
{"ok":true,"backend":"tmux","writes":1,"specs":[{"argv":["tmux","-S",...,"send-keys","-t","%0","-l","hi"]}]}
```

Full suite: `3668 passed`. The one unrelated red file (`src/lib/session/sync/config.test.ts`, 5 tests) fails identically on a clean checkout of this branch's base — it reads this machine's real `~/.agents` R2 sync bundle via a module-cached global (`isSyncConfigured`, config.ts:98); untouched by this PR, passes on a clean CI runner.

## Scope

- OWN: `src/lib/terminal/inject.ts` (+ test, + one export line in `terminal/index.ts`); `src/lib/session/inject.ts` (adapter, + test); `src/commands/sessions-inject.ts` (+ one registration line in `sessions.ts`).
- Did NOT touch: `src/lib/watchdog/*`, menu-bar Swift.

Closes RUSH-1415.
