### PR TITLE
feat(watchdog): port stall-detection + nudge-decision core [RUSH-1415]

### DIFF
--- a/src/lib/watchdog/index.ts
+++ b/src/lib/watchdog/index.ts
@@ -1,0 +1,6 @@
+// Watchdog stall-detection + nudge-decision core. Pure logic ported from
+// Swarmify; terminal-injection delivery and menu-bar wiring live elsewhere.
+
+export * from './watchdog.js';
+export * from './watchdogTail.js';
+export * from './read.js';

--- a/src/lib/watchdog/read.test.ts
+++ b/src/lib/watchdog/read.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { readTailLines, findSessionJsonlIn, readWatchdogTail } from './read.js';
+import { summarizeWatchdogTail } from './watchdogTail.js';
+import { isLikelyTrulyBlocked } from './watchdog.js';
+
+const FIXTURE = path.join(import.meta.dirname, 'testdata', 'tail-sample-claude.jsonl');
+
+describe('readTailLines', () => {
+  it('returns the last N non-empty JSONL lines of a real transcript', () => {
+    const lines = readTailLines(FIXTURE, 2);
+    expect(lines).toHaveLength(2);
+    // Last line of the fixture is the assistant promise.
+    expect(lines[1]).toContain('I will write the module and run the tests next.');
+    // Second-to-last is the tool_result user turn.
+    expect(lines[0]).toContain('tool_result');
+  });
+
+  it('returns every line when maxLines exceeds the file length', () => {
+    const lines = readTailLines(FIXTURE, 100);
+    expect(lines).toHaveLength(5);
+    expect(lines[0]).toContain('port the watchdog into agents-cli');
+  });
+
+  it('returns [] for a missing file', () => {
+    expect(readTailLines('/no/such/transcript.jsonl', 20)).toEqual([]);
+  });
+
+  describe('with generated temp files', () => {
+    let dir: string;
+    let empty: string;
+    let big: string;
+    const BIG_LINES = 5000; // guarantees the read spans multiple 64KB chunks
+
+    beforeAll(() => {
+      dir = fs.mkdtempSync(path.join(os.tmpdir(), 'watchdog-read-'));
+      empty = path.join(dir, 'empty.jsonl');
+      fs.writeFileSync(empty, '');
+      big = path.join(dir, 'big.jsonl');
+      const rows: string[] = [];
+      for (let i = 0; i < BIG_LINES; i++) {
+        rows.push(JSON.stringify({ type: 'assistant', seq: i, message: { content: [{ type: 'text', text: `row ${i} ${'x'.repeat(40)}` }] } }));
+      }
+      fs.writeFileSync(big, rows.join('\n') + '\n');
+    });
+
+    afterAll(() => {
+      fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('returns [] for an empty file', () => {
+      expect(readTailLines(empty, 20)).toEqual([]);
+    });
+
+    it('reads the true tail across chunk boundaries, not a mid-chunk slice', () => {
+      const lines = readTailLines(big, 20);
+      expect(lines).toHaveLength(20);
+      // The very last row must be present and parseable (no partial-line corruption).
+      const last = JSON.parse(lines[lines.length - 1]);
+      expect(last.seq).toBe(BIG_LINES - 1);
+      const first = JSON.parse(lines[0]);
+      expect(first.seq).toBe(BIG_LINES - 20);
+    });
+  });
+});
+
+describe('findSessionJsonlIn', () => {
+  let root: string;
+  const sessionId = 'a1b2c3d4-1111-2222-3333-444455556666';
+
+  beforeAll(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'watchdog-resolve-'));
+    // Mimic the Claude layout: projects/<enc>/<sessionId>.jsonl
+    const proj = path.join(root, 'projects', '-home-user-repo');
+    fs.mkdirSync(proj, { recursive: true });
+    fs.writeFileSync(path.join(proj, `${sessionId}.jsonl`), '{}\n');
+    fs.writeFileSync(path.join(proj, 'other-session.jsonl'), '{}\n');
+  });
+
+  afterAll(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('locates a Claude-style <enc>/<sessionId>.jsonl under the projects root', () => {
+    const dirs = [path.join(root, 'projects')];
+    const found = findSessionJsonlIn(dirs, sessionId);
+    expect(found).toBeDefined();
+    expect(path.basename(found!)).toBe(`${sessionId}.jsonl`);
+  });
+
+  it('matches a Codex-style filename that merely embeds the uuid', () => {
+    const cdir = path.join(root, 'sessions');
+    fs.mkdirSync(cdir, { recursive: true });
+    fs.writeFileSync(path.join(cdir, `rollout-2026-07-01T10-00-00-${sessionId}.jsonl`), '{}\n');
+    const found = findSessionJsonlIn([cdir], sessionId);
+    expect(found).toBeDefined();
+    expect(found!).toContain(sessionId);
+  });
+
+  it('returns undefined when the session is absent', () => {
+    expect(findSessionJsonlIn([path.join(root, 'projects')], 'ffffffff-0000-0000-0000-000000000000')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty session id', () => {
+    expect(findSessionJsonlIn([path.join(root, 'projects')], '')).toBeUndefined();
+  });
+});
+
+describe('watchdog tail pipeline (read -> summarize -> detect)', () => {
+  it('feeds real transcript lines into the pure detectors', () => {
+    const tail = readTailLines(FIXTURE, 20);
+    const summary = summarizeWatchdogTail(tail, 'claude');
+    expect(summary.lastUserMessage).toBe('port the watchdog into agents-cli');
+    expect(summary.lastAssistantMessage).toContain('I will write the module');
+
+    // The last assistant turn promises action with no tool_use after it, so the
+    // detector should flag it as likely blocked.
+    const blocked = isLikelyTrulyBlocked({
+      terminalId: 'CC-1',
+      agentType: 'claude',
+      tailLines: tail,
+      stalledForMs: 120_000,
+    });
+    expect(blocked).toBe(true);
+  });
+
+  it('readWatchdogTail returns [] when the session cannot be resolved', () => {
+    expect(readWatchdogTail('nonexistent-session-id', 'claude')).toEqual([]);
+  });
+});

--- a/src/lib/watchdog/read.test.ts
+++ b/src/lib/watchdog/read.test.ts
@@ -99,6 +99,20 @@ describe('findSessionJsonlIn', () => {
     expect(found!).toContain(sessionId);
   });
 
+  it('finds a Codex rollout in a DEEP date partition (sessions/YYYY/MM/DD/)', () => {
+    // Real Codex layout is 3 levels deep — the sessions root is passed, not the
+    // leaf. A one-level scan (the pre-fix bug) descends into `2026/` and stops,
+    // never reaching the `.jsonl`, so this fixture returns [] against the old code.
+    const deepSid = 'deadbeef-1111-2222-3333-444455556666';
+    const sessionsRoot = path.join(root, 'sessions-deep');
+    const partition = path.join(sessionsRoot, '2026', '05', '27');
+    fs.mkdirSync(partition, { recursive: true });
+    const rollout = path.join(partition, `rollout-2026-05-27T09-30-00-${deepSid}.jsonl`);
+    fs.writeFileSync(rollout, '{}\n');
+    const found = findSessionJsonlIn([sessionsRoot], deepSid);
+    expect(found).toBe(rollout);
+  });
+
   it('returns undefined when the session is absent', () => {
     expect(findSessionJsonlIn([path.join(root, 'projects')], 'ffffffff-0000-0000-0000-000000000000')).toBeUndefined();
   });

--- a/src/lib/watchdog/read.ts
+++ b/src/lib/watchdog/read.ts
@@ -12,6 +12,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { getAgentSessionDirs } from '../session/discover.js';
+import { walkForFiles } from '../fs-walk.js';
 
 /** Default watchdog thresholds, mirrored from the Swarmify VS Code runtime. */
 export const WATCHDOG_TAIL_LINES = 20;
@@ -21,6 +22,28 @@ export const WATCHDOG_DORMANT_MS = 3_600_000; // 1h — DORMANT_MS
 
 const CHUNK_SIZE = 64 * 1024;
 const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+
+/** Cap on files walked per transcript root — matches session/discover.ts. */
+const WATCHDOG_WALK_CAP = 100_000;
+
+/**
+ * Per-agent transcript layout, mirroring the `getAgentSessionDirs()` call sites
+ * in session/discover.ts so the resolver never diverges from the rest of the CLI:
+ * Claude keeps per-project folders under `projects/` (discover.ts:486); Codex and
+ * Droid date-/work-partition rollout `.jsonl` deep under `sessions/`
+ * (discover.ts:665, :1673); Gemini nests chat `.json` under `tmp/<hash>/chats/`
+ * (discover.ts:820). Subdir + extension are driven from this table instead of the
+ * old hardcoded `codex ? 'sessions' : 'projects'` ternary, which sent every
+ * non-Codex agent (Gemini included) to the wrong root.
+ */
+const WATCHDOG_SESSION_LAYOUT: Record<string, { subdir: string; ext: string }> = {
+  claude: { subdir: 'projects', ext: '.jsonl' },
+  codex: { subdir: 'sessions', ext: '.jsonl' },
+  droid: { subdir: 'sessions', ext: '.jsonl' },
+  gemini: { subdir: 'tmp', ext: '.json' },
+};
+
+const WATCHDOG_SESSION_LAYOUT_DEFAULT = { subdir: 'projects', ext: '.jsonl' };
 
 /**
  * Read the last `maxLines` non-empty lines of a JSONL transcript by seeking
@@ -66,59 +89,43 @@ export function readTailLines(filePath: string, maxLines: number): string[] {
 }
 
 /**
- * Given candidate transcript-root directories, find the JSONL file for a
- * session. Handles both the flat Claude layout (`<sessionId>.jsonl` inside a
- * per-project `<enc>/` subfolder) and Codex-style names that merely embed the
- * uuid (`rollout-…-<sessionId>.jsonl`). One level of per-project subdirs is
- * scanned. Newest mtime wins when a uuid appears in more than one root (e.g.
- * across version homes). Pure over its `dirs` argument, so it is testable
- * without touching the real home directory.
+ * Given candidate transcript-root directories, find the transcript file for a
+ * session. Handles the flat Claude layout (`<sessionId>.jsonl` inside a
+ * per-project `<enc>/` subfolder), Codex-style names that merely embed the uuid
+ * (`rollout-…-<sessionId>.jsonl`), and — critically — the DEEP date partitions
+ * Codex/Droid use (`sessions/YYYY/MM/DD/rollout-…-<uuid>.jsonl`). The scan is
+ * fully recursive via `walkForFiles` (the same walker session/discover.ts uses),
+ * so no fixed number of subdir levels is assumed — a hand-rolled one-level scan
+ * silently missed every Codex transcript. Newest mtime wins when a uuid appears
+ * in more than one root (e.g. across version homes). Pure over its `dirs`
+ * argument, so it is testable without touching the real home directory.
  */
-export function findSessionJsonlIn(dirs: string[], sessionId: string): string | undefined {
+export function findSessionJsonlIn(
+  dirs: string[],
+  sessionId: string,
+  ext: string = '.jsonl',
+): string | undefined {
   if (!sessionId) return undefined;
-  let best: { file: string; mtime: number } | undefined;
-
-  const consider = (file: string): void => {
-    let mtime: number;
-    try {
-      mtime = fs.statSync(file).mtimeMs;
-    } catch {
-      return;
-    }
-    if (!best || mtime > best.mtime) best = { file, mtime };
-  };
 
   const matches = (name: string): boolean => {
-    if (!name.endsWith('.jsonl')) return false;
-    const stem = name.slice(0, -'.jsonl'.length);
+    if (!name.endsWith(ext)) return false;
+    const stem = name.slice(0, -ext.length);
     if (stem === sessionId) return true;
     // Codex embeds the uuid in a longer filename (rollout-<ts>-<uuid>.jsonl).
     return name.includes(sessionId) || (UUID_RE.test(sessionId) && stem.includes(sessionId));
   };
 
+  let best: { file: string; mtime: number } | undefined;
   for (const dir of dirs) {
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        // Per-project subfolder (Claude `<enc>/`, Codex date partitions).
-        let sub: string[];
-        try {
-          sub = fs.readdirSync(full);
-        } catch {
-          continue;
-        }
-        for (const name of sub) {
-          if (matches(name)) consider(path.join(full, name));
-        }
-      } else if (entry.isFile() && matches(entry.name)) {
-        consider(full);
+    for (const file of walkForFiles(dir, ext, WATCHDOG_WALK_CAP)) {
+      if (!matches(path.basename(file))) continue;
+      let mtime: number;
+      try {
+        mtime = fs.statSync(file).mtimeMs;
+      } catch {
+        continue;
       }
+      if (!best || mtime > best.mtime) best = { file, mtime };
     }
   }
 
@@ -130,12 +137,14 @@ export function findSessionJsonlIn(dirs: string[], sessionId: string): string | 
  * per-version transcript roots. Returns `undefined` if no transcript is found.
  */
 export function resolveWatchdogSessionPath(sessionId: string, agent: string): string | undefined {
-  // Claude/Gemini keep per-project transcript folders under `projects/`;
-  // Codex date-partitions rollouts under `sessions/`. Search both so the
-  // resolver is agent-agnostic.
-  const subdir = agent === 'codex' ? 'sessions' : 'projects';
-  const dirs = getAgentSessionDirs(agent, subdir);
-  return findSessionJsonlIn(dirs, sessionId);
+  // Subdir + transcript extension are driven per-agent from WATCHDOG_SESSION_LAYOUT
+  // (which mirrors the getAgentSessionDirs() convention in session/discover.ts),
+  // not a hardcoded `codex ? 'sessions' : 'projects'` — that ternary sent Codex to
+  // a root it only scanned one level deep, and every other agent (Gemini included)
+  // to the wrong subdir entirely.
+  const layout = WATCHDOG_SESSION_LAYOUT[agent] ?? WATCHDOG_SESSION_LAYOUT_DEFAULT;
+  const dirs = getAgentSessionDirs(agent, layout.subdir);
+  return findSessionJsonlIn(dirs, sessionId, layout.ext);
 }
 
 /**

--- a/src/lib/watchdog/read.ts
+++ b/src/lib/watchdog/read.ts
@@ -1,0 +1,153 @@
+// Watchdog tail reader: locate a session transcript from its id + agent and
+// pull the last N raw JSONL lines. The raw lines feed the pure detectors in
+// watchdog.ts (isLikelyTrulyBlocked / renderWatchdogPrompt) and the pure
+// summarizer in watchdogTail.ts.
+//
+// Adapted from Swarmify's readTailLines (extension/src/vscode/sessions.vscode.ts)
+// to agents-cli's session layout. Path resolution REUSES getAgentSessionDirs()
+// from src/lib/session/discover.ts — the same resolver the rest of the CLI uses
+// to enumerate per-version transcript roots — instead of hardcoding
+// ~/.agents/.history/versions/<agent>/.../projects/<enc>/<sessionId>.jsonl.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { getAgentSessionDirs } from '../session/discover.js';
+
+/** Default watchdog thresholds, mirrored from the Swarmify VS Code runtime. */
+export const WATCHDOG_TAIL_LINES = 20;
+export const WATCHDOG_STALL_MS = 300_000; // 5m — stallSeconds default
+export const WATCHDOG_COOLDOWN_MS = 1_200_000; // 20m — cooldownSeconds default
+export const WATCHDOG_DORMANT_MS = 3_600_000; // 1h — DORMANT_MS
+
+const CHUNK_SIZE = 64 * 1024;
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+
+/**
+ * Read the last `maxLines` non-empty lines of a JSONL transcript by seeking
+ * backward from EOF in 64KB chunks. A tail that begins mid-line yields one
+ * malformed leading line, which the callers' per-line JSON try/catch tolerates.
+ * Returns `[]` on any read error or empty file.
+ */
+export function readTailLines(filePath: string, maxLines: number): string[] {
+  let fd: number;
+  try {
+    fd = fs.openSync(filePath, 'r');
+  } catch {
+    return [];
+  }
+
+  try {
+    const fileSize = fs.fstatSync(fd).size;
+    if (fileSize === 0) return [];
+
+    let position = fileSize;
+    let buffer = '';
+    let collected: string[] = [];
+
+    while (position > 0 && collected.length <= maxLines) {
+      const readSize = Math.min(CHUNK_SIZE, position);
+      position -= readSize;
+      const chunk = Buffer.alloc(readSize);
+      fs.readSync(fd, chunk, 0, readSize, position);
+      buffer = chunk.toString('utf-8') + buffer;
+      collected = buffer.split(/\r?\n/).filter((l) => l.trim());
+    }
+
+    return collected.slice(-maxLines);
+  } catch {
+    return [];
+  } finally {
+    try {
+      fs.closeSync(fd);
+    } catch {
+      /* fd already gone */
+    }
+  }
+}
+
+/**
+ * Given candidate transcript-root directories, find the JSONL file for a
+ * session. Handles both the flat Claude layout (`<sessionId>.jsonl` inside a
+ * per-project `<enc>/` subfolder) and Codex-style names that merely embed the
+ * uuid (`rollout-…-<sessionId>.jsonl`). One level of per-project subdirs is
+ * scanned. Newest mtime wins when a uuid appears in more than one root (e.g.
+ * across version homes). Pure over its `dirs` argument, so it is testable
+ * without touching the real home directory.
+ */
+export function findSessionJsonlIn(dirs: string[], sessionId: string): string | undefined {
+  if (!sessionId) return undefined;
+  let best: { file: string; mtime: number } | undefined;
+
+  const consider = (file: string): void => {
+    let mtime: number;
+    try {
+      mtime = fs.statSync(file).mtimeMs;
+    } catch {
+      return;
+    }
+    if (!best || mtime > best.mtime) best = { file, mtime };
+  };
+
+  const matches = (name: string): boolean => {
+    if (!name.endsWith('.jsonl')) return false;
+    const stem = name.slice(0, -'.jsonl'.length);
+    if (stem === sessionId) return true;
+    // Codex embeds the uuid in a longer filename (rollout-<ts>-<uuid>.jsonl).
+    return name.includes(sessionId) || (UUID_RE.test(sessionId) && stem.includes(sessionId));
+  };
+
+  for (const dir of dirs) {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        // Per-project subfolder (Claude `<enc>/`, Codex date partitions).
+        let sub: string[];
+        try {
+          sub = fs.readdirSync(full);
+        } catch {
+          continue;
+        }
+        for (const name of sub) {
+          if (matches(name)) consider(path.join(full, name));
+        }
+      } else if (entry.isFile() && matches(entry.name)) {
+        consider(full);
+      }
+    }
+  }
+
+  return best?.file;
+}
+
+/**
+ * Resolve a session transcript path from its id + agent, reusing the CLI's
+ * per-version transcript roots. Returns `undefined` if no transcript is found.
+ */
+export function resolveWatchdogSessionPath(sessionId: string, agent: string): string | undefined {
+  // Claude/Gemini keep per-project transcript folders under `projects/`;
+  // Codex date-partitions rollouts under `sessions/`. Search both so the
+  // resolver is agent-agnostic.
+  const subdir = agent === 'codex' ? 'sessions' : 'projects';
+  const dirs = getAgentSessionDirs(agent, subdir);
+  return findSessionJsonlIn(dirs, sessionId);
+}
+
+/**
+ * Read the last `maxLines` JSONL lines for a session by id + agent. Returns
+ * `[]` when the transcript cannot be located or read.
+ */
+export function readWatchdogTail(
+  sessionId: string,
+  agent: string,
+  maxLines: number = WATCHDOG_TAIL_LINES,
+): string[] {
+  const filePath = resolveWatchdogSessionPath(sessionId, agent);
+  if (!filePath) return [];
+  return readTailLines(filePath, maxLines);
+}

--- a/src/lib/watchdog/testdata/tail-sample-claude.jsonl
+++ b/src/lib/watchdog/testdata/tail-sample-claude.jsonl
@@ -1,0 +1,5 @@
+{"type":"user","message":{"content":[{"type":"text","text":"port the watchdog into agents-cli"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Reading the reference files now."}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"watchdog.ts"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","content":"...file contents..."}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"I will write the module and run the tests next."}]}}

--- a/src/lib/watchdog/watchdog.test.ts
+++ b/src/lib/watchdog/watchdog.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyTerminal,
+  composePromptWithPlaybook,
+  renderWatchdogPrompt,
+  parseWatchdogResponse,
+  isLikelyTrulyBlocked,
+  WATCHDOG_SYSTEM_PROMPT,
+} from './watchdog.js';
+
+describe('classifyTerminal', () => {
+  const base = {
+    nowMs: 1_000_000,
+    lastNudgeMs: null,
+    optedOut: false,
+    stallMs: 90_000,
+    cooldownMs: 300_000,
+    dormantMs: 3_600_000,
+  };
+
+  it('active when within stall window', () => {
+    const r = classifyTerminal({ ...base, lastActivityMs: base.nowMs - 10_000 });
+    expect(r.kind).toBe('active');
+  });
+
+  it('opted_out when user disabled watchdog for terminal', () => {
+    const r = classifyTerminal({
+      ...base,
+      lastActivityMs: base.nowMs - 120_000,
+      optedOut: true,
+    });
+    expect(r.kind).toBe('opted_out');
+  });
+
+  it('dormant when session is older than dormant window', () => {
+    const r = classifyTerminal({ ...base, lastActivityMs: base.nowMs - 3_600_001 });
+    expect(r.kind).toBe('dormant');
+  });
+
+  it('rate_limited when recently nudged', () => {
+    const r = classifyTerminal({
+      ...base,
+      lastActivityMs: base.nowMs - 120_000,
+      lastNudgeMs: base.nowMs - 60_000,
+    });
+    expect(r.kind).toBe('rate_limited');
+    if (r.kind === 'rate_limited') {
+      expect(r.cooldownRemainingMs).toBe(240_000);
+    }
+  });
+
+  it('stalled when past threshold, not dormant, not rate limited, not opted out', () => {
+    const r = classifyTerminal({ ...base, lastActivityMs: base.nowMs - 120_000 });
+    expect(r.kind).toBe('stalled');
+    if (r.kind === 'stalled') {
+      expect(r.stalledForMs).toBe(120_000);
+    }
+  });
+
+  it('opt-out wins over active', () => {
+    const r = classifyTerminal({
+      ...base,
+      lastActivityMs: base.nowMs - 10_000,
+      optedOut: true,
+    });
+    expect(r.kind).toBe('opted_out');
+  });
+
+  it('cooldown expired lets terminal go back to stalled', () => {
+    const r = classifyTerminal({
+      ...base,
+      lastActivityMs: base.nowMs - 400_000,
+      lastNudgeMs: base.nowMs - 310_000,
+    });
+    expect(r.kind).toBe('stalled');
+  });
+
+  it('active takes priority even when a nudge is on cooldown (boundary just under stall)', () => {
+    const r = classifyTerminal({
+      ...base,
+      lastActivityMs: base.nowMs - 89_999,
+      lastNudgeMs: base.nowMs - 1_000,
+    });
+    expect(r.kind).toBe('active');
+  });
+
+  it('exactly at the stall threshold is not yet active (age === stallMs)', () => {
+    const r = classifyTerminal({ ...base, lastActivityMs: base.nowMs - 90_000 });
+    expect(r.kind).toBe('stalled');
+  });
+});
+
+describe('composePromptWithPlaybook', () => {
+  it('returns the base prompt unchanged when playbook is empty', () => {
+    expect(composePromptWithPlaybook(WATCHDOG_SYSTEM_PROMPT, '')).toBe(WATCHDOG_SYSTEM_PROMPT);
+  });
+
+  it('returns the base prompt unchanged when playbook is only whitespace', () => {
+    expect(composePromptWithPlaybook(WATCHDOG_SYSTEM_PROMPT, '   \n\n   ')).toBe(WATCHDOG_SYSTEM_PROMPT);
+  });
+
+  it('appends a House Rules section with the trimmed playbook content', () => {
+    const playbook = '\n\n- Nudge with TEST_MARKER when lint hangs.\n- Skip in plan mode.\n\n';
+    const out = composePromptWithPlaybook(WATCHDOG_SYSTEM_PROMPT, playbook);
+    expect(out.startsWith(WATCHDOG_SYSTEM_PROMPT + '\n\n## House Rules')).toBe(true);
+    expect(out).toContain('TEST_MARKER');
+    expect(out).toContain('Skip in plan mode');
+    // trailing whitespace stripped
+    expect(out.endsWith('\n')).toBe(false);
+  });
+});
+
+describe('renderWatchdogPrompt', () => {
+  it('matches base prompt when no playbook is passed (zero regression)', () => {
+    const out = renderWatchdogPrompt([
+      { terminalId: 'CC-1', agentType: 'claude', tailLines: ['{}'], stalledForMs: 60_000 },
+    ]);
+    expect(out).toContain(WATCHDOG_SYSTEM_PROMPT);
+    expect(out).not.toContain('## House Rules');
+  });
+
+  it('appends House Rules block when a non-empty playbook is passed', () => {
+    const out = renderWatchdogPrompt(
+      [{ terminalId: 'CC-1', agentType: 'claude', tailLines: ['{}'], stalledForMs: 60_000 }],
+      '- Nudge with TEST_MARKER when stuck on lint.'
+    );
+    expect(out).toContain('## House Rules');
+    expect(out).toContain('TEST_MARKER');
+    // House Rules must be ABOVE the stalled-terminals payload, not after it.
+    const houseIdx = out.indexOf('## House Rules');
+    const stalledIdx = out.indexOf('STALLED TERMINALS:');
+    expect(houseIdx).toBeGreaterThan(-1);
+    expect(stalledIdx).toBeGreaterThan(houseIdx);
+  });
+
+  it('embeds terminal id, agent type, stall duration, and JSONL tail', () => {
+    const out = renderWatchdogPrompt([
+      {
+        terminalId: 'CC-1',
+        agentType: 'claude',
+        tailLines: [
+          '{"type":"assistant","message":{"content":[{"type":"text","text":"I\'ll write inventory.sh."}]}}',
+        ],
+        stalledForMs: 120_000,
+      },
+    ]);
+    expect(out).toContain('CC-1');
+    expect(out).toContain('claude');
+    expect(out).toContain('idle 120s');
+    expect(out).toContain("I'll write inventory.sh");
+    expect(out).toContain('JSON array');
+  });
+
+  it('separates multiple terminals into labeled sections', () => {
+    const out = renderWatchdogPrompt([
+      { terminalId: 'CC-1', agentType: 'claude', tailLines: ['{"a":1}'], stalledForMs: 100_000 },
+      { terminalId: 'CX-2', agentType: 'codex', tailLines: ['{"b":2}'], stalledForMs: 200_000 },
+    ]);
+    expect(out).toContain('terminal CC-1');
+    expect(out).toContain('terminal CX-2');
+    expect(out).toContain('idle 100s');
+    expect(out).toContain('idle 200s');
+  });
+});
+
+describe('parseWatchdogResponse', () => {
+  it('parses a clean JSON array', () => {
+    const d = parseWatchdogResponse(
+      '[{"terminalId":"CC-1","action":"nudge","text":"Show the file.","reason":"broken_promise"}]'
+    );
+    expect(d).toHaveLength(1);
+    expect(d[0]).toEqual({
+      terminalId: 'CC-1',
+      action: 'nudge',
+      text: 'Show the file.',
+      reason: 'broken_promise',
+    });
+  });
+
+  it('tolerates leading and trailing prose', () => {
+    const d = parseWatchdogResponse(
+      'Here is the response:\n[{"terminalId":"CC-1","action":"skip","text":"","reason":"waiting_on_user"}]\nThanks.'
+    );
+    expect(d).toHaveLength(1);
+    expect(d[0].action).toBe('skip');
+  });
+
+  it('returns empty on malformed JSON', () => {
+    expect(parseWatchdogResponse('not json at all')).toEqual([]);
+    expect(parseWatchdogResponse('[{invalid]')).toEqual([]);
+  });
+
+  it('skips entries missing required fields', () => {
+    const d = parseWatchdogResponse(
+      '[{"terminalId":"CC-1","action":"nudge","text":"ok","reason":"r"},{"action":"nudge"},{"terminalId":"CX-2"}]'
+    );
+    expect(d).toHaveLength(1);
+    expect(d[0].terminalId).toBe('CC-1');
+  });
+
+  it('rejects unknown action values', () => {
+    const d = parseWatchdogResponse(
+      '[{"terminalId":"CC-1","action":"explode","text":"","reason":""}]'
+    );
+    expect(d).toEqual([]);
+  });
+
+  it('handles empty input', () => {
+    expect(parseWatchdogResponse('')).toEqual([]);
+    expect(parseWatchdogResponse('   \n ')).toEqual([]);
+  });
+
+  it('extracts the array even when wrapped in a markdown code fence', () => {
+    const d = parseWatchdogResponse(
+      '```json\n[{"terminalId":"CC-1","action":"nudge","text":"Run tests.","reason":"stalled"}]\n```'
+    );
+    expect(d).toHaveLength(1);
+    expect(d[0].text).toBe('Run tests.');
+  });
+});
+
+describe('isLikelyTrulyBlocked', () => {
+  it('returns true for explicit blocked/error hints', () => {
+    expect(
+      isLikelyTrulyBlocked({
+        terminalId: 'CC-1',
+        agentType: 'claude',
+        stalledForMs: 120_000,
+        tailLines: ['{"type":"assistant","message":{"content":[{"type":"text","text":"The command failed with permission denied."}]}}'],
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when assistant promised action but no tool call followed', () => {
+    expect(
+      isLikelyTrulyBlocked({
+        terminalId: 'CC-1',
+        agentType: 'claude',
+        stalledForMs: 120_000,
+        tailLines: ['{"type":"assistant","message":{"content":[{"type":"text","text":"I will run bun test now."}]}}'],
+      })
+    ).toBe(true);
+  });
+
+  it('returns false when a tool call happened after the promise', () => {
+    expect(
+      isLikelyTrulyBlocked({
+        terminalId: 'CC-1',
+        agentType: 'claude',
+        stalledForMs: 120_000,
+        tailLines: [
+          '{"type":"assistant","message":{"content":[{"type":"text","text":"I will run bun test now."}]}}',
+          '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"bun test"}}]}}',
+        ],
+      })
+    ).toBe(false);
+  });
+
+  it('returns false for waiting-on-user hints', () => {
+    expect(
+      isLikelyTrulyBlocked({
+        terminalId: 'CC-1',
+        agentType: 'claude',
+        stalledForMs: 120_000,
+        tailLines: ['{"type":"assistant","message":{"content":[{"type":"text","text":"Waiting on user response."}]}}'],
+      })
+    ).toBe(false);
+  });
+
+  it('returns true for very long stalls even without textual hints', () => {
+    expect(
+      isLikelyTrulyBlocked({
+        terminalId: 'CC-1',
+        agentType: 'claude',
+        stalledForMs: 901_000,
+        tailLines: ['{"type":"assistant","message":{"content":[{"type":"text","text":"thinking"}]}}'],
+      })
+    ).toBe(true);
+  });
+
+  it('returns false on an empty tail below the force-review threshold', () => {
+    expect(
+      isLikelyTrulyBlocked({
+        terminalId: 'CC-1',
+        agentType: 'claude',
+        stalledForMs: 120_000,
+        tailLines: [],
+      })
+    ).toBe(false);
+  });
+
+  it('completion hints suppress a nudge even when a promise is present', () => {
+    expect(
+      isLikelyTrulyBlocked({
+        terminalId: 'CC-1',
+        agentType: 'claude',
+        stalledForMs: 120_000,
+        tailLines: ['{"type":"assistant","message":{"content":[{"type":"text","text":"I will stop here, all set and finished."}]}}'],
+      })
+    ).toBe(false);
+  });
+});

--- a/src/lib/watchdog/watchdog.ts
+++ b/src/lib/watchdog/watchdog.ts
@@ -1,0 +1,194 @@
+// Watchdog: pure logic for detecting stalled agent terminals and rendering
+// prompts to a headless decider instance that decides whether to nudge them.
+// Ported from Swarmify (extension/src/core/watchdog.ts) — behavior verbatim.
+// Terminal/session delivery lives elsewhere; this module reads no files and
+// touches no host APIs so it can be unit-tested in isolation.
+
+export interface WatchdogCandidate {
+  terminalId: string;
+  agentType: 'claude' | 'codex' | 'gemini';
+  tailLines: string[];
+  stalledForMs: number;
+}
+
+export interface Decision {
+  terminalId: string;
+  action: 'nudge' | 'skip';
+  text: string;
+  reason: string;
+}
+
+const FORCE_REVIEW_STALL_MS = 15 * 60 * 1000;
+const BLOCKED_HINTS = [
+  'blocked',
+  'stuck',
+  "can't",
+  'cannot',
+  'unable',
+  'failed',
+  'error',
+  'exception',
+  'traceback',
+  'timed out',
+  'timeout',
+  'rate limit',
+  'permission denied',
+];
+const WAITING_HINTS = [
+  'waiting on user',
+  'awaiting user',
+  'askuserquestion',
+];
+const COMPLETION_HINTS = [
+  'done',
+  'completed',
+  'all set',
+  'finished',
+];
+const TOOL_CALL_HINTS = [
+  '"type":"tool_use"',
+  '"type":"tool_call"',
+  '"type":"function_call"',
+];
+const ASSISTANT_LINE_HINTS = [
+  '"type":"assistant"',
+  '"role":"assistant"',
+  '"payload":{"type":"message"',
+];
+const PROMISE_HINTS = [
+  "i'll",
+  'i will',
+  'let me',
+  'going to',
+  "next i'll",
+  'next i will',
+];
+
+export type StallStatus =
+  | { kind: 'active' }
+  | { kind: 'dormant' }
+  | { kind: 'opted_out' }
+  | { kind: 'rate_limited'; cooldownRemainingMs: number }
+  | { kind: 'stalled'; stalledForMs: number };
+
+export interface ClassifyInput {
+  lastActivityMs: number;
+  nowMs: number;
+  lastNudgeMs: number | null;
+  optedOut: boolean;
+  stallMs: number;
+  cooldownMs: number;
+  dormantMs: number;
+}
+
+export function classifyTerminal(input: ClassifyInput): StallStatus {
+  if (input.optedOut) return { kind: 'opted_out' };
+  const age = input.nowMs - input.lastActivityMs;
+  if (age < input.stallMs) return { kind: 'active' };
+  if (age > input.dormantMs) return { kind: 'dormant' };
+  if (input.lastNudgeMs !== null) {
+    const sinceNudge = input.nowMs - input.lastNudgeMs;
+    if (sinceNudge < input.cooldownMs) {
+      return { kind: 'rate_limited', cooldownRemainingMs: input.cooldownMs - sinceNudge };
+    }
+  }
+  return { kind: 'stalled', stalledForMs: age };
+}
+
+export const WATCHDOG_SYSTEM_PROMPT = `You are a watchdog monitoring AI coding agents that run in terminals.
+For each stalled terminal below, decide: NUDGE (send a short message to unstick it) or SKIP.
+
+Nudge when:
+- The last assistant turn announced an action ("I'll write X", "let me run Y")
+  but no matching tool call followed.
+- The agent appears stuck mid-task with no recent progress and the task is incomplete.
+
+Skip when:
+- The agent asked the user a direct question (waiting on human input).
+- The task looks complete.
+- You cannot tell what the agent is doing.
+
+Nudge text must be:
+- One sentence, imperative ("Show me the file.", "Run the tests.").
+- No emojis. No apologies. Under 120 characters.
+
+Respond with ONLY a JSON array (no prose, no code fence):
+[{"terminalId":"<id>","action":"nudge"|"skip","text":"<message or empty>","reason":"<brief>"}]`;
+
+// User-editable playbook appended below the built-in prompt. The user maintains
+// the source at ~/.agents/playbooks/watchdog.md (read by the delivery layer);
+// this function is pure so it can be tested without filesystem access.
+export function composePromptWithPlaybook(basePrompt: string, playbook: string): string {
+  const trimmed = playbook.trim();
+  if (!trimmed) return basePrompt;
+  return `${basePrompt}\n\n## House Rules (user playbook)\n\n${trimmed}`;
+}
+
+export function renderWatchdogPrompt(candidates: WatchdogCandidate[], playbook = ''): string {
+  const systemPrompt = composePromptWithPlaybook(WATCHDOG_SYSTEM_PROMPT, playbook);
+  const parts: string[] = [systemPrompt, '', 'STALLED TERMINALS:', ''];
+  for (const c of candidates) {
+    const seconds = Math.round(c.stalledForMs / 1000);
+    parts.push(`--- terminal ${c.terminalId} (${c.agentType}, idle ${seconds}s) ---`);
+    parts.push('last JSONL lines:');
+    for (const line of c.tailLines) {
+      parts.push(line);
+    }
+    parts.push('');
+  }
+  return parts.join('\n');
+}
+
+export function parseWatchdogResponse(stdout: string): Decision[] {
+  if (!stdout || !stdout.trim()) return [];
+
+  const arrayMatch = stdout.match(/\[[\s\S]*\]/);
+  if (!arrayMatch) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(arrayMatch[0]);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+
+  const decisions: Decision[] = [];
+  for (const d of parsed) {
+    if (!d || typeof d !== 'object') continue;
+    const obj = d as Record<string, unknown>;
+    const terminalId = typeof obj.terminalId === 'string' ? obj.terminalId : '';
+    const action = obj.action === 'nudge' || obj.action === 'skip' ? obj.action : null;
+    const text = typeof obj.text === 'string' ? obj.text : '';
+    const reason = typeof obj.reason === 'string' ? obj.reason : '';
+    if (!terminalId || !action) continue;
+    decisions.push({ terminalId, action, text, reason });
+  }
+  return decisions;
+}
+
+export function isLikelyTrulyBlocked(candidate: WatchdogCandidate): boolean {
+  if (candidate.stalledForMs >= FORCE_REVIEW_STALL_MS) return true;
+  if (candidate.tailLines.length === 0) return false;
+
+  const lowerTail = candidate.tailLines.join('\n').toLowerCase();
+  if (WAITING_HINTS.some((hint) => lowerTail.includes(hint))) return false;
+  if (COMPLETION_HINTS.some((hint) => lowerTail.includes(hint))) return false;
+  if (BLOCKED_HINTS.some((hint) => lowerTail.includes(hint))) return true;
+
+  let sawToolAfter = false;
+  for (let i = candidate.tailLines.length - 1; i >= 0; i--) {
+    const line = candidate.tailLines[i].toLowerCase();
+    if (TOOL_CALL_HINTS.some((hint) => line.includes(hint))) {
+      sawToolAfter = true;
+      continue;
+    }
+    if (!sawToolAfter) {
+      const isAssistantLine = ASSISTANT_LINE_HINTS.some((hint) => line.includes(hint));
+      const hasPromise = PROMISE_HINTS.some((hint) => line.includes(hint));
+      if (isAssistantLine && hasPromise) return true;
+    }
+  }
+
+  return false;
+}

--- a/src/lib/watchdog/watchdogTail.test.ts
+++ b/src/lib/watchdog/watchdogTail.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeWatchdogTail } from './watchdogTail.js';
+
+describe('summarizeWatchdogTail (claude)', () => {
+  it('pulls the last user and assistant text blocks', () => {
+    const tail = [
+      JSON.stringify({ type: 'user', message: { content: [{ type: 'text', text: 'first ask' }] } }),
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'reading file' }] } }),
+      JSON.stringify({ type: 'user', message: { content: [{ type: 'text', text: 'fix the auth bug' }] } }),
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'investigating tokens' }] } }),
+    ];
+    const summary = summarizeWatchdogTail(tail, 'claude');
+    expect(summary.lastUserMessage).toBe('fix the auth bug');
+    expect(summary.lastAssistantMessage).toBe('investigating tokens');
+  });
+
+  it('handles string-content shape', () => {
+    const tail = [
+      JSON.stringify({ type: 'user', message: { content: 'plain string' } }),
+    ];
+    expect(summarizeWatchdogTail(tail, 'claude').lastUserMessage).toBe('plain string');
+  });
+
+  it('clips very long messages with an ellipsis', () => {
+    const long = 'x'.repeat(2000);
+    const tail = [JSON.stringify({ type: 'user', message: { content: [{ type: 'text', text: long }] } })];
+    const summary = summarizeWatchdogTail(tail, 'claude');
+    expect(summary.lastUserMessage!.length).toBe(600);
+    expect(summary.lastUserMessage!.endsWith('…')).toBe(true);
+  });
+});
+
+describe('summarizeWatchdogTail (codex)', () => {
+  it('reads response_item messages by role', () => {
+    const tail = [
+      JSON.stringify({
+        type: 'response_item',
+        payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'codex user msg' }] },
+      }),
+      JSON.stringify({
+        type: 'response_item',
+        payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'codex reply' }] },
+      }),
+    ];
+    const summary = summarizeWatchdogTail(tail, 'codex');
+    expect(summary.lastUserMessage).toBe('codex user msg');
+    expect(summary.lastAssistantMessage).toBe('codex reply');
+  });
+});
+
+describe('summarizeWatchdogTail (gemini)', () => {
+  it('reads user_message and agent_message events', () => {
+    const tail = [
+      JSON.stringify({ type: 'user_message', text: 'gemini user' }),
+      JSON.stringify({ type: 'agent_message', text: 'gemini reply' }),
+    ];
+    const summary = summarizeWatchdogTail(tail, 'gemini');
+    expect(summary.lastUserMessage).toBe('gemini user');
+    expect(summary.lastAssistantMessage).toBe('gemini reply');
+  });
+});
+
+describe('summarizeWatchdogTail (resilience)', () => {
+  it('skips malformed JSON lines', () => {
+    const tail = [
+      'not json',
+      JSON.stringify({ type: 'user', message: { content: [{ type: 'text', text: 'still found' }] } }),
+    ];
+    expect(summarizeWatchdogTail(tail, 'claude').lastUserMessage).toBe('still found');
+  });
+
+  it('skips synthetic <local-command-stdout> and <system-reminder> wrappers', () => {
+    const tail = [
+      JSON.stringify({ type: 'user', message: { content: [{ type: 'text', text: 'real human prompt' }] } }),
+      JSON.stringify({ type: 'user', message: { content: [{ type: 'text', text: '<local-command-stdout>blah</local-command-stdout>' }] } }),
+      JSON.stringify({ type: 'user', message: { content: [{ type: 'text', text: '<system-reminder>noise</system-reminder>' }] } }),
+    ];
+    // Walks from the end; the synthetic ones should be skipped so the human prompt surfaces.
+    expect(summarizeWatchdogTail(tail, 'claude').lastUserMessage).toBe('real human prompt');
+  });
+
+  it('returns empty summary for unknown agent', () => {
+    const tail = [JSON.stringify({ type: 'user', message: { content: 'x' } })];
+    expect(summarizeWatchdogTail(tail, 'unknown')).toEqual({});
+  });
+
+  it('returns empty summary when no messages present', () => {
+    const tail = [JSON.stringify({ type: 'tool_call', tool_name: 'Read' })];
+    expect(summarizeWatchdogTail(tail, 'gemini')).toEqual({});
+  });
+});

--- a/src/lib/watchdog/watchdogTail.ts
+++ b/src/lib/watchdog/watchdogTail.ts
@@ -1,0 +1,149 @@
+// Watchdog tail summarization: pull the most recent user / assistant message
+// out of the session JSONL window the watchdog read this tick. Pure functions —
+// the watchdog runtime hands us tailLines + agentType and we read no files.
+// Ported from Swarmify (extension/src/core/watchdogTail.ts) — behavior verbatim.
+
+export interface TailSummary {
+  lastUserMessage?: string;
+  lastAssistantMessage?: string;
+}
+
+const MAX_MESSAGE_CHARS = 600;
+
+export function summarizeWatchdogTail(
+  tailLines: string[],
+  agentType: string | undefined,
+): TailSummary {
+  let lastUser: string | undefined;
+  let lastAssistant: string | undefined;
+
+  for (let i = tailLines.length - 1; i >= 0; i--) {
+    if (lastUser && lastAssistant) break;
+    let raw: unknown;
+    try {
+      raw = JSON.parse(tailLines[i]);
+    } catch {
+      continue;
+    }
+    if (!raw || typeof raw !== 'object') continue;
+
+    if (agentType === 'claude') {
+      const claim = readClaude(raw as Record<string, unknown>);
+      if (claim?.role === 'user' && !lastUser) lastUser = claim.text;
+      else if (claim?.role === 'assistant' && !lastAssistant) lastAssistant = claim.text;
+    } else if (agentType === 'codex') {
+      const claim = readCodex(raw as Record<string, unknown>);
+      if (claim?.role === 'user' && !lastUser) lastUser = claim.text;
+      else if (claim?.role === 'assistant' && !lastAssistant) lastAssistant = claim.text;
+    } else if (agentType === 'gemini') {
+      const claim = readGemini(raw as Record<string, unknown>);
+      if (claim?.role === 'user' && !lastUser) lastUser = claim.text;
+      else if (claim?.role === 'assistant' && !lastAssistant) lastAssistant = claim.text;
+    }
+  }
+
+  return {
+    lastUserMessage: clip(lastUser),
+    lastAssistantMessage: clip(lastAssistant),
+  };
+}
+
+type Claim = { role: 'user' | 'assistant'; text: string };
+
+function readClaude(raw: Record<string, unknown>): Claim | null {
+  const t = raw.type;
+  if (t !== 'user' && t !== 'assistant') return null;
+  const msg = raw.message as Record<string, unknown> | undefined;
+  if (!msg) return null;
+  const text = pickContentText(msg.content);
+  if (!text) return null;
+  return { role: t, text };
+}
+
+function readCodex(raw: Record<string, unknown>): Claim | null {
+  if (raw.type !== 'response_item') return null;
+  const payload = raw.payload as Record<string, unknown> | undefined;
+  if (!payload || payload.type !== 'message') return null;
+  const role = payload.role;
+  if (role !== 'user' && role !== 'assistant') return null;
+  const text = pickContentText(payload.content);
+  if (!text) return null;
+  return { role, text };
+}
+
+// Gemini stores chats as a single pretty-printed JSON document — readTailLines
+// returns partial fragments that JSON.parse rejects. So in practice this
+// branch only fires for the JSONL-style events that some Gemini wrappers emit
+// during a live session. Acceptable: the result is an empty summary, which
+// the UI handles gracefully.
+function readGemini(raw: Record<string, unknown>): Claim | null {
+  const t = raw.type;
+  if (t === 'user_message') {
+    const text = typeof raw.text === 'string' ? raw.text : null;
+    return text ? { role: 'user', text } : null;
+  }
+  if (t === 'agent_message' || t === 'model_message') {
+    const text = typeof raw.text === 'string' ? raw.text : null;
+    return text ? { role: 'assistant', text } : null;
+  }
+  if (t === 'message') {
+    const role = raw.role === 'user' ? 'user' : raw.role === 'assistant' ? 'assistant' : null;
+    if (!role) return null;
+    const text = typeof raw.text === 'string' ? raw.text : pickContentText(raw.content);
+    return text ? { role, text } : null;
+  }
+  return null;
+}
+
+function pickContentText(content: unknown): string | null {
+  if (typeof content === 'string') return isSyntheticTagged(content) ? null : content;
+  if (!Array.isArray(content)) return null;
+  const parts: string[] = [];
+  for (const part of content) {
+    if (!part || typeof part !== 'object') continue;
+    const p = part as Record<string, unknown>;
+    if ((p.type === 'text' || p.type === 'input_text' || p.type === 'output_text') && typeof p.text === 'string') {
+      if (isSyntheticTagged(p.text)) continue;
+      parts.push(p.text);
+    }
+  }
+  return parts.length ? parts.join('\n') : null;
+}
+
+// Mirrors the synthetic-tag filter in the session readers so a "User: …"
+// surfaced in the watchdog UI never shows a <local-command-stdout>,
+// <system-reminder>, or similar harness chunk that Claude wraps tool output in.
+const SYNTHETIC_TAG_PREFIXES = [
+  '<local-command-caveat',
+  '<local-command-stdout',
+  '<local-command-stderr',
+  '<command-name',
+  '<command-message',
+  '<command-args',
+  '<bash-input',
+  '<bash-stdout',
+  '<bash-stderr',
+  '<system-reminder',
+  '<user-prompt-submit-hook',
+  '<task-notification',
+  '<persisted-output',
+];
+
+function isSyntheticTagged(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return true;
+  const lower = trimmed.toLowerCase();
+  for (const prefix of SYNTHETIC_TAG_PREFIXES) {
+    if (lower.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+function clip(text: string | undefined): string | undefined {
+  if (!text) return undefined;
+  const cleaned = text.replace(/\s+/g, ' ').trim();
+  if (!cleaned) return undefined;
+  return cleaned.length > MAX_MESSAGE_CHARS
+    ? cleaned.slice(0, MAX_MESSAGE_CHARS - 1) + '…'
+    : cleaned;
+}


### PR DESCRIPTION
## What

Ports the **pure** Swarmify watchdog core into agents-cli as a new, unit-tested TypeScript module under `src/lib/watchdog/`. Agents stop mid-task and ask "good place to stop?" instead of continuing; Swarmify detected these stalls and auto-nudged agents forward. This lands the detection/decision logic only — terminal-injection delivery (Gap 2) and the Swift menu-bar wiring are separate tickets/agents and are **not** touched here.

Closes RUSH-1415.

## Swarmify functions ported

From `extension/src/core/watchdog.ts` → `src/lib/watchdog/watchdog.ts` (behavior verbatim):
- `classifyTerminal(input): StallStatus` — active | dormant | opted_out | rate_limited | stalled, using stall/cooldown/dormant thresholds.
- `isLikelyTrulyBlocked(candidate)` — blocked/waiting/completion hint heuristics + the "assistant announced an action but no tool_use followed" (promise-without-toolcall) detector, plus the 15-min force-review floor.
- `renderWatchdogPrompt()` + `composePromptWithPlaybook()` + `WATCHDOG_SYSTEM_PROMPT`.
- `parseWatchdogResponse(stdout)` — tolerant JSON-array extraction.

From `extension/src/core/watchdogTail.ts` → `src/lib/watchdog/watchdogTail.ts` (verbatim):
- `summarizeWatchdogTail()` — last user/assistant message extraction across claude/codex/gemini transcript shapes, with synthetic-tag (`<system-reminder>`, `<local-command-stdout>`, …) filtering and `clip()`.

Adapted from Swarmify's `readTailLines` (`extension/src/vscode/sessions.vscode.ts`) → `src/lib/watchdog/read.ts`:
- `readTailLines(filePath, maxLines)` — reads the last N raw JSONL lines by seeking backward from EOF in 64KB chunks.
- `resolveWatchdogSessionPath(sessionId, agent)` / `findSessionJsonlIn(dirs, sessionId)` — locate a transcript by id, **reusing `getAgentSessionDirs()`** from `src/lib/session/discover.ts` rather than hardcoding the `~/.agents/.history/versions/<agent>/…/projects/<enc>/<sessionId>.jsonl` layout.
- `readWatchdogTail(sessionId, agent, maxLines)` — resolve + read.

## Tests

`src/lib/watchdog/{watchdog,watchdogTail,read}.test.ts` — **50 tests, all green** (vitest). Load-bearing coverage: `classifyTerminal` threshold boundaries (incl. `age === stallMs`), the promise-without-toolcall path in `isLikelyTrulyBlocked`, malformed-JSON / code-fence tolerance in `parseWatchdogResponse`, and `readTailLines` reading the true tail across chunk boundaries. Fixture at `src/lib/watchdog/testdata/tail-sample-claude.jsonl`.

## Boundaries respected

Owns `src/lib/watchdog/**` only. Did not touch `src/lib/session/launch.ts`, terminal-injection code, `packages/menubar-helper/`, or `src/lib/loop.ts`.

## Verification

- `bun run build` — clean (tsc).
- `node ./node_modules/vitest/vitest.mjs run src/lib/watchdog/` — 50 passed.
- Full suite: the only failures are 5 pre-existing `src/lib/session/sync/config.test.ts` (R2/keychain, env-specific) that also fail on `origin/main` — unrelated to this change.