### PR TITLE
feat(message): agents message writer — enqueue to a running agent or cloud task

### DIFF
--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -30,6 +30,9 @@ export function registerMessageCommand(program: Command): void {
     .description('Send a message to a running agent (delivered at its next tool call) or a cloud task.')
     .option('--from <who>', 'Label recorded as the sender of this message')
     .action(async (target: string, text: string, opts: { from?: string }) => {
+      if (!target.trim()) {
+        die('Target must be a session/agent id or cloud task id. Run `agents sessions --active` to list running agents.');
+      }
       const sessions = await getActiveSessions();
       const res = resolveMessageTarget(target, sessions, (id) => getTaskById(id) != null);
 
@@ -47,11 +50,15 @@ export function registerMessageCommand(program: Command): void {
           return;
         }
         case 'local': {
-          const msgId = enqueue(mailboxDir(res.id), { to: res.id, text, from: opts.from });
-          console.log(
-            chalk.green(`Queued message ${msgId} for ${res.id}. `) +
-              chalk.dim('The agent will see it at its next tool call.'),
-          );
+          try {
+            const msgId = enqueue(mailboxDir(res.id), { to: res.id, text, from: opts.from });
+            console.log(
+              chalk.green(`Queued message ${msgId} for ${res.id}. `) +
+                chalk.dim('The agent will see it at its next tool call.'),
+            );
+          } catch (err) {
+            die((err as Error).message);
+          }
           return;
         }
         case 'ambiguous': {

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -1,0 +1,66 @@
+/**
+ * `agents message <target> <text>` — send a message to a running agent.
+ *
+ * Unifies two delivery paths behind one verb:
+ *   - a live LOCAL/teams/loop agent → enqueue into its file-spool mailbox; the
+ *     PreToolUse hook injects it at the agent's next tool call.
+ *   - a CLOUD task id → the existing provider follow-up path (was
+ *     `agents cloud message`).
+ *
+ * Cross-host is handled one layer up: `--host <h>` routes the whole command over
+ * ssh via `REMOTE_PASSTHROUGH` (see src/lib/hosts/passthrough.ts), so the box is
+ * written on the host that actually owns the agent.
+ */
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { getActiveSessions } from '../lib/session/active.js';
+import { getTaskById, updateTaskStatus } from '../lib/cloud/store.js';
+import { resolveProvider } from '../lib/cloud/registry.js';
+import { mailboxDir, enqueue } from '../lib/mailbox.js';
+import { resolveMessageTarget } from '../lib/mailbox-target.js';
+
+function die(msg: string, code = 1): never {
+  console.error(chalk.red(msg));
+  process.exit(code);
+}
+
+export function registerMessageCommand(program: Command): void {
+  program
+    .command('message <target> <text>')
+    .description('Send a message to a running agent (delivered at its next tool call) or a cloud task.')
+    .option('--from <who>', 'Label recorded as the sender of this message')
+    .action(async (target: string, text: string, opts: { from?: string }) => {
+      const sessions = await getActiveSessions();
+      const res = resolveMessageTarget(target, sessions, (id) => getTaskById(id) != null);
+
+      switch (res.kind) {
+        case 'cloud': {
+          const task = getTaskById(res.id)!;
+          const provider = resolveProvider(task.provider);
+          try {
+            await provider.message(res.id, text);
+            updateTaskStatus(res.id, 'running');
+            console.log(chalk.green(`Message sent to cloud task ${res.id}. Agent is continuing.`));
+          } catch (err) {
+            die((err as Error).message);
+          }
+          return;
+        }
+        case 'local': {
+          const msgId = enqueue(mailboxDir(res.id), { to: res.id, text, from: opts.from });
+          console.log(
+            chalk.green(`Queued message ${msgId} for ${res.id}. `) +
+              chalk.dim('The agent will see it at its next tool call.'),
+          );
+          return;
+        }
+        case 'ambiguous': {
+          const lines = res.candidates.map((c) => `  ${c.id}  ${chalk.dim(c.label)}`).join('\n');
+          die(`"${target}" matches ${res.candidates.length} running agents:\n${lines}\nRe-run with a full id.`);
+          return;
+        }
+        case 'none':
+          die(`No running agent or cloud task matches "${target}". List targets with \`agents sessions --active\`.`);
+      }
+    });
+}

--- a/src/lib/hosts/passthrough.ts
+++ b/src/lib/hosts/passthrough.ts
@@ -45,6 +45,7 @@ const REMOTE_PASSTHROUGH: Record<string, RemoteSpec> = {
   list: {},
   sync: { nonInteractive: ['--yes'] },
   teams: {},
+  message: {},
 };
 
 /** `--no-tty` is stripped like the routing flags but carries no value. */

--- a/src/lib/mailbox-target.test.ts
+++ b/src/lib/mailbox-target.test.ts
@@ -56,6 +56,13 @@ describe('resolveMessageTarget', () => {
     expect(resolveMessageTarget('aaaa-1111', sessions, noCloud)).toEqual({ kind: 'local', id: 'aaaa-1111' });
   });
 
+  it('treats an empty target as no match (no startsWith-matches-everything footgun)', () => {
+    const sessions = [mk({ sessionId: 'aaaa-1111' }), mk({ sessionId: 'bbbb-2222' })];
+    expect(resolveMessageTarget('', sessions, noCloud)).toEqual({ kind: 'none' });
+    // even with a single running agent, empty must not silently deliver.
+    expect(resolveMessageTarget('', [mk({ sessionId: 'only-one' })], noCloud)).toEqual({ kind: 'none' });
+  });
+
   it('exact match wins over a prefix that would be ambiguous', () => {
     const sessions = [mk({ sessionId: 'aaaa' }), mk({ sessionId: 'aaaa-longer' })];
     // 'aaaa' is an exact id of the first AND a prefix of the second — exact wins.

--- a/src/lib/mailbox-target.test.ts
+++ b/src/lib/mailbox-target.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { resolveMessageTarget, mailboxIdForActiveSession } from './mailbox-target.js';
+import type { ActiveSession } from './session/active.js';
+
+/** Minimal live-session builder (only the fields the resolver reads). */
+function mk(over: Partial<ActiveSession>): ActiveSession {
+  return { context: 'headless', kind: 'claude', status: 'running', ...over };
+}
+
+const noCloud = () => false;
+
+describe('resolveMessageTarget', () => {
+  it('routes a cloud task id to the cloud path (checked first)', () => {
+    const res = resolveMessageTarget('task-123', [], (id) => id === 'task-123');
+    expect(res).toEqual({ kind: 'cloud', id: 'task-123' });
+  });
+
+  it('resolves an exact sessionId to that one local box', () => {
+    const sessions = [mk({ sessionId: 'aaaa-1111' }), mk({ sessionId: 'bbbb-2222' })];
+    expect(resolveMessageTarget('aaaa-1111', sessions, noCloud)).toEqual({ kind: 'local', id: 'aaaa-1111' });
+  });
+
+  it('resolves a unique prefix to one box', () => {
+    const sessions = [mk({ sessionId: 'aaaa-1111' }), mk({ sessionId: 'bbbb-2222' })];
+    expect(resolveMessageTarget('aaaa', sessions, noCloud)).toEqual({ kind: 'local', id: 'aaaa-1111' });
+  });
+
+  it('errors (never guesses) when a prefix matches more than one agent', () => {
+    const sessions = [
+      mk({ sessionId: 'aaaa-1111', topic: 'refactor' }),
+      mk({ sessionId: 'aaaa-2222', topic: 'tests' }),
+    ];
+    const res = resolveMessageTarget('aaaa', sessions, noCloud);
+    expect(res.kind).toBe('ambiguous');
+    if (res.kind === 'ambiguous') {
+      expect(res.candidates.map((c) => c.id).sort()).toEqual(['aaaa-1111', 'aaaa-2222']);
+      expect(res.candidates[0].label).toBeTruthy();
+    }
+  });
+
+  it('returns none when nothing matches', () => {
+    expect(resolveMessageTarget('zzzz', [mk({ sessionId: 'aaaa-1111' })], noCloud)).toEqual({ kind: 'none' });
+  });
+
+  it('keys a teams teammate box by agentId', () => {
+    const s = mk({ context: 'teams', agentId: 'agent-uuid', sessionId: 'agent-uuid', teamName: 'feat' });
+    expect(mailboxIdForActiveSession(s)).toBe('agent-uuid');
+    expect(resolveMessageTarget('agent-uuid', [s], noCloud)).toEqual({ kind: 'local', id: 'agent-uuid' });
+  });
+
+  it('collapses multiple rows that share one canonical id (subagents/forks) to a single box', () => {
+    const sessions = [
+      mk({ sessionId: 'aaaa-1111', pidCount: 2 }),
+      mk({ sessionId: 'aaaa-1111', pidCount: 2 }),
+    ];
+    expect(resolveMessageTarget('aaaa-1111', sessions, noCloud)).toEqual({ kind: 'local', id: 'aaaa-1111' });
+  });
+
+  it('exact match wins over a prefix that would be ambiguous', () => {
+    const sessions = [mk({ sessionId: 'aaaa' }), mk({ sessionId: 'aaaa-longer' })];
+    // 'aaaa' is an exact id of the first AND a prefix of the second — exact wins.
+    expect(resolveMessageTarget('aaaa', sessions, noCloud)).toEqual({ kind: 'local', id: 'aaaa' });
+  });
+});

--- a/src/lib/mailbox-target.ts
+++ b/src/lib/mailbox-target.ts
@@ -1,0 +1,66 @@
+/**
+ * Resolve an `agents message <target>` argument to exactly one destination —
+ * a cloud task, one live local/teams/loop agent, or an error. The anti-misroute
+ * rule lives here: a target that matches zero or more-than-one live agent is
+ * NEVER guessed; the caller reports it. Pure (no I/O) so it is unit-testable.
+ */
+import type { ActiveSession } from './session/active.js';
+
+export type MessageResolution =
+  | { kind: 'cloud'; id: string }
+  | { kind: 'local'; id: string }
+  | { kind: 'none' }
+  | { kind: 'ambiguous'; candidates: Array<{ id: string; label: string }> };
+
+/**
+ * The mailbox id a live session's box is keyed by. Teams stamp a durable
+ * `agentId` (== the Claude session id for Claude teammates); a bare run has
+ * only its `sessionId`. The spawn-time `AGENTS_MAILBOX_DIR` wiring must key the
+ * box by this same id — this is the single source of truth for both sides.
+ */
+export function mailboxIdForActiveSession(s: ActiveSession): string | undefined {
+  return s.agentId ?? s.sessionId;
+}
+
+function labelFor(s: ActiveSession): string {
+  return s.label ?? s.topic ?? s.teamName ?? s.host ?? s.context;
+}
+
+/**
+ * Resolve `target` against the live sessions. Exact id matches win over prefix
+ * matches; results are de-duped by canonical mailbox id (collapsed subagents
+ * share one). `isCloudTask` is consulted first so a cloud task id routes to the
+ * cloud provider.
+ */
+export function resolveMessageTarget(
+  target: string,
+  sessions: ActiveSession[],
+  isCloudTask: (id: string) => boolean,
+): MessageResolution {
+  if (isCloudTask(target)) return { kind: 'cloud', id: target };
+
+  const exact = sessions.filter(
+    (s) => s.sessionId === target || s.agentId === target || s.cloudTaskId === target,
+  );
+  const chosen =
+    exact.length > 0
+      ? exact
+      : sessions.filter(
+          (s) => Boolean(s.sessionId?.startsWith(target)) || Boolean(s.agentId?.startsWith(target)),
+        );
+
+  // De-dupe by canonical mailbox id (one box per logical agent).
+  const byId = new Map<string, ActiveSession>();
+  for (const s of chosen) {
+    const id = mailboxIdForActiveSession(s);
+    if (id && !byId.has(id)) byId.set(id, s);
+  }
+
+  const ids = [...byId.keys()];
+  if (ids.length === 0) return { kind: 'none' };
+  if (ids.length === 1) return { kind: 'local', id: ids[0] };
+  return {
+    kind: 'ambiguous',
+    candidates: [...byId.entries()].map(([id, s]) => ({ id, label: labelFor(s) })),
+  };
+}

--- a/src/lib/mailbox-target.ts
+++ b/src/lib/mailbox-target.ts
@@ -38,10 +38,10 @@ export function resolveMessageTarget(
   isCloudTask: (id: string) => boolean,
 ): MessageResolution {
   if (isCloudTask(target)) return { kind: 'cloud', id: target };
+  // An empty target would make every `startsWith` prefix match — never guess.
+  if (target.length === 0) return { kind: 'none' };
 
-  const exact = sessions.filter(
-    (s) => s.sessionId === target || s.agentId === target || s.cloudTaskId === target,
-  );
+  const exact = sessions.filter((s) => s.sessionId === target || s.agentId === target);
   const chosen =
     exact.length > 0
       ? exact

--- a/src/lib/startup/command-registry.ts
+++ b/src/lib/startup/command-registry.ts
@@ -85,6 +85,7 @@ export const loadSetup: ModuleLoader = async () => (await import('../../commands
 export const loadSessions: ModuleLoader = async () => (await import('../../commands/sessions.js')).registerSessionsCommands;
 export const loadTeams: ModuleLoader = async () => (await import('../../commands/teams.js')).registerTeamsCommands;
 export const loadCloud: ModuleLoader = async () => (await import('../../commands/cloud.js')).registerCloudCommands;
+export const loadMessage: ModuleLoader = async () => (await import('../../commands/message.js')).registerMessageCommand;
 
 /**
  * Commands whose modules pull in the SQLite-backed session/cloud stack. They are
@@ -93,7 +94,7 @@ export const loadCloud: ModuleLoader = async () => (await import('../../commands
  * inherit the root's custom help formatter rather than getting the per-command
  * recursive pass. Keeping that ordering preserves their `--help` output exactly.
  */
-export const LAZY_COMMAND_NAMES: ReadonlySet<string> = new Set(['sessions', 'teams', 'cloud']);
+export const LAZY_COMMAND_NAMES: ReadonlySet<string> = new Set(['sessions', 'teams', 'cloud', 'message']);
 
 /**
  * User-typed top-level command name -> ordered list of module loaders to run.
@@ -174,4 +175,5 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   sessions: [loadSessions],
   teams: [loadTeams],
   cloud: [loadCloud],
+  message: [loadMessage],
 };


### PR DESCRIPTION
Second slice of the **agent mailbox** (stacks on the merged `mailbox.ts` core, #609). Adds the user-facing `agents message` writer. No injection yet — that's the `PreToolUse` hook + spawn-wiring slice — but the enqueue path is verified end-to-end on real services.

## What this adds
- **`agents message <target> <text>`** (`src/commands/message.ts`) — one verb, two paths:
  - a **live local/teams/loop agent** → `enqueue()` into its mailbox; the hook (next slice) injects it at the agent's next tool call.
  - a **cloud task id** → the existing `provider.message()` follow-up (subsumes `agents cloud message`).
- **`resolveMessageTarget()`** (`src/lib/mailbox-target.ts`) — the pure, testable **anti-misroute gate**: exact id wins over prefix; de-dupes by canonical mailbox id; a target matching **0 or >1** live agents is **never guessed** — it errors with the candidates. `mailboxIdForActiveSession()` is the single source of truth for a box's id (`agentId ?? sessionId`), shared with the future spawn-wiring.
- **Wiring** — registered as a lazy (SQLite-backed) command like `cloud`/`sessions`/`teams`; `message: {}` added to `REMOTE_PASSTHROUGH` so `--host <h>` runs on the owning host.

## Verification (real services, no mocks)
- `src/lib/mailbox-target.test.ts` — 8 tests: cloud routing, exact/prefix resolution, ambiguity-errors-not-guesses, none, teams-agentId keying, subagent-row collapse, exact-beats-ambiguous-prefix.
- **End-to-end**: built the CLI, spawned a real live Claude agent, ran `agents message <sessionId> "…" --from e2e@s0`, and confirmed the message landed in `~/.agents/.history/mailbox/<id>/inbox/<msgId>.json` with correct `to`/`from`/`ts`/`text`. Negative path (`no-such-agent`) resolves against the real active set and errors with exit 1.
- `tsc --noEmit` clean.

## Next slices
`PreToolUse` hook (with the proven `agent_type` sub-agent gate) + `AGENTS_MAILBOX_DIR` spawn wiring in `exec.ts`/`loop.ts` — that closes the loop so a queued message is actually injected mid-run. Then `--attach`/`--clipboard` sugar, and the reverse `outbox` + `agents notify` + `agents watch --follow`.