### PR TITLE
feat(mailbox): AGENTS_MAILBOX_DIR spawn wiring (loop-closer, agents-cli half)

### DIFF
--- a/src/lib/exec.test.ts
+++ b/src/lib/exec.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { shouldTapStdout, resolveInteractive, buildExecCommand, nativeResume, resolveShimSpawn } from './exec.js';
+import { shouldTapStdout, resolveInteractive, buildExecCommand, nativeResume, resolveShimSpawn, buildExecEnv } from './exec.js';
 import type { ExecOptions } from './exec.js';
+import { mailboxDir } from './mailbox.js';
 
 /** Minimal ExecOptions with required fields, overridable per test. */
 function execOpts(over: Partial<ExecOptions> & { agent: ExecOptions['agent'] }): ExecOptions {
@@ -11,6 +12,29 @@ function execOpts(over: Partial<ExecOptions> & { agent: ExecOptions['agent'] }):
 function idx(cmd: string[], tok: string): number {
   return cmd.indexOf(tok);
 }
+
+describe('buildExecEnv — AGENTS_MAILBOX_DIR wiring (mailbox loop-closer)', () => {
+  it('points the agent at its own box, keyed by sessionId', () => {
+    const sid = '96aa7271-0c8f-4ed7-8811-1ad1d305e46e';
+    const env = buildExecEnv(execOpts({ agent: 'claude', sessionId: sid }));
+    expect(env.AGENTS_MAILBOX_DIR).toBe(mailboxDir(sid));
+  });
+
+  it('sets nothing when there is no session id (nothing to key a box on)', () => {
+    const env = buildExecEnv(execOpts({ agent: 'claude' }));
+    expect(env.AGENTS_MAILBOX_DIR).toBeUndefined();
+  });
+
+  it('lets a caller override the box via options.env (how the loop pins the run-level box)', () => {
+    const runBox = mailboxDir('loop-1782947000000-abc123');
+    const env = buildExecEnv(execOpts({
+      agent: 'claude',
+      sessionId: 'per-iteration-uuid-aaaa',
+      env: { AGENTS_MAILBOX_DIR: runBox },
+    }));
+    expect(env.AGENTS_MAILBOX_DIR).toBe(runBox);
+  });
+});
 
 describe('nativeResume (Tier-1 capability derives from the command template)', () => {
   it('claude and codex resume natively', () => {

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -18,6 +18,7 @@ import { emitStart, maybeRotate, createTimer, redactPrompt, redactArgs } from '.
 import { sanitizeProcessEnv } from './secrets/bundles.js';
 import { getShimsDir } from './state.js';
 import { writePidSessionEntry } from './session/pid-registry.js';
+import { mailboxDir, isValidMailboxId } from './mailbox.js';
 
 /**
  * Agent execution modes. Canonical name `skip` (dangerously skip permissions);
@@ -307,6 +308,15 @@ export function buildExecEnv(options: ExecOptions): NodeJS.ProcessEnv {
     delete result.CODEX_HOME;
     delete result.COPILOT_HOME;
     delete result.KIMI_CODE_HOME;
+  }
+
+  // Point the agent at its own mailbox so the PreToolUse `mailbox-inject` hook
+  // knows which box to drain and inject mid-run. Keyed by the session id — the
+  // same id the writer resolves via mailboxIdForActiveSession(). A loop run
+  // overrides this to its run-level box via options.env (spread below), so all
+  // iterations share one inbox.
+  if (options.sessionId && isValidMailboxId(options.sessionId)) {
+    result.AGENTS_MAILBOX_DIR = mailboxDir(options.sessionId);
   }
 
   return {

--- a/src/lib/loop.ts
+++ b/src/lib/loop.ts
@@ -29,6 +29,7 @@ import { buildExecCommand, buildExecEnv } from './exec.js';
 import { extractUsageEvents } from './budget/enforce.js';
 import { parseTimeout } from './routines.js';
 import { writeCheckpoint, type Checkpoint } from './checkpoint.js';
+import { mailboxDir } from './mailbox.js';
 
 /** Loop block config (docs/07-entrypoints-and-loops.md → "The loop block"). */
 export interface LoopConfig {
@@ -306,6 +307,10 @@ export async function runLoop(
     );
   }
 
+  // Surface the run-level mailbox id (otherwise undiscoverable — runId is not in
+  // the session registry) so an operator can message the loop mid-flight.
+  process.stderr.write(`[loop] mailbox: agents message ${ctx.runId} "<text>"\n`);
+
   let tokens = ctx.startTokens ?? 0;
   let lastSignal: LoopSignal | undefined;
 
@@ -379,6 +384,10 @@ export async function runLoop(
           AGENTS_RUN_DIR: ctx.runDir,
           AGENTS_LOOP_SIGNAL: loopSignalPath(ctx.runDir),
           AGENTS_LOOP_ITERATION: String(iteration),
+          // Every iteration is a fresh session, so key the mailbox by the stable
+          // run id — one box for the whole loop. Overrides the per-iteration
+          // AGENTS_MAILBOX_DIR that buildExecEnv would derive from sessionId.
+          AGENTS_MAILBOX_DIR: mailboxDir(ctx.runId),
         },
       };
 

--- a/src/lib/mailbox.ts
+++ b/src/lib/mailbox.ts
@@ -42,8 +42,12 @@ export interface MailboxMessage {
  * against, and would be dropped with no error. Also blocks `.`/`..` traversal
  * once `agents message` starts accepting external target ids.
  */
+export function isValidMailboxId(mailboxId: string): boolean {
+  return /^[A-Za-z0-9._-]+$/.test(mailboxId) && mailboxId !== '.' && mailboxId !== '..';
+}
+
 export function assertValidMailboxId(mailboxId: string): void {
-  if (!/^[A-Za-z0-9._-]+$/.test(mailboxId) || mailboxId === '.' || mailboxId === '..') {
+  if (!isValidMailboxId(mailboxId)) {
     throw new Error(
       `Invalid mailboxId ${JSON.stringify(mailboxId)}: must be a single path segment ` +
       `matching [A-Za-z0-9._-] (no separators, not '.'/'..').`,


### PR DESCRIPTION
Third slice of the **agent mailbox** — the spawn-side half of the loop-closer. Sets `AGENTS_MAILBOX_DIR` so a companion `PreToolUse` hook (shipped separately in `.agents-system`) can drain each agent's box and inject queued messages mid-run. Stacks on the merged core (#609) and writer (#613).

## What this adds
- **`buildExecEnv`** (`src/lib/exec.ts`) sets `AGENTS_MAILBOX_DIR = mailboxDir(sessionId)` for every run — pointing each agent at its own box, keyed by the same id the writer resolves (`mailboxIdForActiveSession = agentId ?? sessionId`). agents-cli sets it (not the user), so it's trustworthy + isolated.
- **`loop.ts`** overrides it to the **run-level** box (`mailboxDir(runId)`) via `options.env` so every iteration shares one inbox, and **prints the `runId` at loop start** (Kimi's review: runId is otherwise undiscoverable, so a loop couldn't be targeted).
- **`isValidMailboxId`** extracted from `assertValidMailboxId` (`src/lib/mailbox.ts`) — non-throwing, so spawn never throws on an odd id.

## Verification (real services, no mocks)
- **Full injection e2e** — built the hook, pre-queued a message with a `PINEAPPLE` sentinel, ran a live Claude agent that made a tool call: the `PreToolUse` hook drained `AGENTS_MAILBOX_DIR`, injected the message as a **trusted** `[operator-mailbox]` system-reminder, and the agent **obeyed it mid-run** (replied PINEAPPLE). Message moved `inbox → consumed` (drained once). This proves the whole chain: `agents message` (shipped) → box → hook → injected → acted on.
- 3 `buildExecEnv` tests (box keyed by sessionId; none without a session; `options.env` override wins — the loop path). 56 tests green across loop+exec+mailbox, `tsc` clean.

## The other half
The `PreToolUse` `mailbox-inject` hook (with the proven `agent_type` sub-agent gate) + `hooks.yaml` registration ship in `gh:phnx-labs/.agents-system` (separate PR). Once both land, `agents message` is live end-to-end for Claude (Codex/Antigravity probe-gated next).