### PR TITLE
feat(sessions): machine, PR/worktree, and a filter tip in the picker

### DIFF
--- a/src/commands/__tests__/sessions-columns.test.ts
+++ b/src/commands/__tests__/sessions-columns.test.ts
@@ -89,6 +89,34 @@ describe('formatPickerLabel', () => {
   });
 });
 
+describe('formatPickerLabel width fits the gutter (no wrap)', () => {
+  // Wide enough that the topic cell isn't pinned to its 16-col floor, so the
+  // test isolates gutter accounting rather than the narrow-terminal floor.
+  const WIDTH = 120;
+  function rowFits(gutter: number): boolean {
+    const orig = process.stdout.columns;
+    try {
+      (process.stdout as any).columns = WIDTH;
+      const cols = { showTicket: true, gutter };
+      // Long topic forces the topic cell to the binding width so the row fills the line.
+      const row = strip(formatPickerLabel(meta({ prNumber: 569, worktreeSlug: 'responsive-list', topic: 'x'.repeat(300) }), '', cols));
+      return row.length + gutter <= WIDTH;
+    } finally {
+      (process.stdout as any).columns = orig;
+    }
+  }
+
+  it('single-select rows fit with the 2-cell cursor gutter', () => {
+    expect(rowFits(2)).toBe(true);
+  });
+
+  it('multi-select rows fit with the 6-cell cursor+checkbox gutter', () => {
+    // Regression: the resume picker prepends "> [x] " (6 cells). If the width
+    // calc reserved only 2, the row would overflow by 4 and wrap every line.
+    expect(rowFits(6)).toBe(true);
+  });
+});
+
 describe('formatPickerTip', () => {
   it('returns a tip and is stable for a given pool size', () => {
     const pool = [meta(), meta()];

--- a/src/commands/__tests__/sessions-columns.test.ts
+++ b/src/commands/__tests__/sessions-columns.test.ts
@@ -6,7 +6,23 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { ticketLabel } from '../sessions.js';
+import { ticketLabel, machineLabeler, formatPickerLabel, formatPickerTip } from '../sessions.js';
+import type { SessionMeta } from '../../lib/session/types.js';
+
+const strip = (s: string) => s.replace(/\[[0-9;]*m/g, '');
+
+function meta(over: Partial<SessionMeta> = {}): SessionMeta {
+  return {
+    id: 'abcdef01-2345-6789-abcd-ef0123456789',
+    shortId: 'abcdef01',
+    agent: 'claude',
+    timestamp: '2026-06-30T12:00:00.000Z',
+    filePath: '/home/x/.claude/projects/foo/sess.jsonl',
+    project: 'agents-cli',
+    topic: 'do a thing',
+    ...over,
+  };
+}
 
 describe('ticketLabel', () => {
   it('returns the tracker ticket id when present', () => {
@@ -23,5 +39,61 @@ describe('ticketLabel', () => {
 
   it('returns empty string when neither is set', () => {
     expect(ticketLabel({ ticketId: undefined, prNumber: undefined })).toBe('');
+  });
+});
+
+describe('machineLabeler', () => {
+  it('strips the shared dash-delimited prefix (yosemite-s0/s1 -> s0/s1)', () => {
+    const label = machineLabeler(['yosemite-s0', 'yosemite-s1']);
+    expect(label('yosemite-s0')).toBe('s0');
+    expect(label('yosemite-s1')).toBe('s1');
+  });
+
+  it('leaves ids whole when there is no shared prefix', () => {
+    const label = machineLabeler(['zion', 'mac-mini']);
+    expect(label('zion')).toBe('zion');
+    expect(label('mac-mini')).toBe('mac-mini');
+  });
+
+  it('is identity for a single machine', () => {
+    const label = machineLabeler(['yosemite-s0']);
+    expect(label('yosemite-s0')).toBe('yosemite-s0');
+  });
+
+  it('never strips away the whole id', () => {
+    const label = machineLabeler(['prod-1', 'prod']);
+    expect(label('prod')).toBe('prod');
+  });
+});
+
+describe('formatPickerLabel', () => {
+  it('shows the PR ref and worktree badge when enabled', () => {
+    const row = strip(formatPickerLabel(meta({ prNumber: 569, worktreeSlug: 'responsive-list' }), '', { showTicket: true }));
+    expect(row).toContain('PR#569');
+    expect(row).toContain('wt:responsive-list');
+  });
+
+  it('omits the ticket column when no row carries a ref', () => {
+    const row = strip(formatPickerLabel(meta(), '', { showTicket: false }));
+    expect(row).not.toContain('PR#');
+  });
+
+  it('renders the compact machine label only when the machine column is on', () => {
+    const cols = { showMachine: true, machineLabel: machineLabeler(['yosemite-s0', 'yosemite-s1']) };
+    const on = strip(formatPickerLabel(meta({ machine: 'yosemite-s0' }), '', cols));
+    expect(on).toContain('s0');
+    expect(on).not.toContain('yosemite-s0');
+
+    const off = strip(formatPickerLabel(meta({ machine: 'yosemite-s0' }), '', { showMachine: false }));
+    expect(off).not.toContain('s0');
+  });
+});
+
+describe('formatPickerTip', () => {
+  it('returns a tip and is stable for a given pool size', () => {
+    const pool = [meta(), meta()];
+    const a = strip(formatPickerTip(pool));
+    expect(a).toContain('Tip:');
+    expect(strip(formatPickerTip(pool))).toBe(a);
   });
 });

--- a/src/commands/sessions-picker.ts
+++ b/src/commands/sessions-picker.ts
@@ -44,6 +44,8 @@ export interface PickedSession {
 
 export interface SessionPickerConfig {
   message: string;
+  /** Dim hint line shown under the header (filters/flags tip). */
+  subtitle?: string;
   sessions: SessionMeta[];
   filter: (query: string) => SessionMeta[];
   labelFor: (s: SessionMeta, query: string) => string;
@@ -373,6 +375,7 @@ function truncate(s: string, max: number): string {
 export async function sessionPicker(config: SessionPickerConfig): Promise<PickedSession | null> {
   const picked = await itemPicker<SessionMeta>({
     message: config.message,
+    subtitle: config.subtitle,
     items: config.sessions,
     filter: config.filter,
     labelFor: config.labelFor,

--- a/src/commands/sessions-resume.ts
+++ b/src/commands/sessions-resume.ts
@@ -125,8 +125,9 @@ async function sessionsResumeAction(query: string | undefined, options: ResumeOp
     return;
   }
 
-  // 1. Multi-select the sessions.
-  const cols = pickerColumnsFor(sessions);
+  // 1. Multi-select the sessions. gutter: 6 = the multi-select cursor + checkbox
+  // ('> [x] ') that multiItemPicker prepends, so rows size to fit without wrapping.
+  const cols = { ...pickerColumnsFor(sessions), gutter: 6 };
   let chosen: SessionMeta[] | null;
   try {
     chosen = await multiItemPicker<SessionMeta>({

--- a/src/commands/sessions-resume.ts
+++ b/src/commands/sessions-resume.ts
@@ -19,6 +19,7 @@ import { buildPreview } from './sessions-picker.js';
 import {
   filterSessionsByQuery,
   formatPickerLabel,
+  pickerColumnsFor,
   buildResumeCommand,
   resumeSessionInPlace,
   parseAgentFilter,
@@ -125,13 +126,14 @@ async function sessionsResumeAction(query: string | undefined, options: ResumeOp
   }
 
   // 1. Multi-select the sessions.
+  const cols = pickerColumnsFor(sessions);
   let chosen: SessionMeta[] | null;
   try {
     chosen = await multiItemPicker<SessionMeta>({
       message: 'Select sessions to resume:',
       items: sessions,
       filter: (q: string) => (q.trim() ? filterSessionsByQuery(sessions, q) : sessions),
-      labelFor: (s, q) => formatPickerLabel(s, q),
+      labelFor: (s, q) => formatPickerLabel(s, q, cols),
       keyFor: (s) => s.id,
       buildPreview,
       pageSize: 15,

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1160,6 +1160,20 @@ export function machineLabeler(machines: string[]): (m: string) => string {
   };
 }
 
+/**
+ * Column flags for a picker, computed once over the whole pool so every row
+ * aligns: the machine column only earns its width when the listing spans more
+ * than one box, the ticket column only when some row carries a PR/ticket ref.
+ */
+export function pickerColumnsFor(sessions: SessionMeta[]): PickerColumns {
+  const machines = sessions.map((s) => s.machine).filter((m): m is string => !!m);
+  return {
+    showMachine: new Set(machines).size > 1,
+    machineLabel: machineLabeler(machines),
+    showTicket: sessions.some((s) => ticketLabel(s) !== ''),
+  };
+}
+
 export function formatPickerLabel(s: SessionMeta, query: string, cols: PickerColumns = {}): string {
   const agentColor = colorAgent(s.agent);
   const when = formatRelativeTime(s.timestamp);
@@ -1228,15 +1242,7 @@ export async function pickSessionInteractive(
   if (hiddenCount > 0) {
     console.log(chalk.gray(formatTeamHiddenFooter(hiddenCount)));
   }
-  // Machine column only earns its width when the listing actually spans boxes;
-  // the ticket column only when some row carries a PR/ticket ref. Both computed
-  // once over the whole pool so every row aligns.
-  const machines = sessions.map((s) => s.machine).filter((m): m is string => !!m);
-  const cols: PickerColumns = {
-    showMachine: new Set(machines).size > 1,
-    machineLabel: machineLabeler(machines),
-    showTicket: sessions.some((s) => ticketLabel(s) !== ''),
-  };
+  const cols = pickerColumnsFor(sessions);
   try {
     return await sessionPicker({
       message,

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1136,6 +1136,12 @@ export interface PickerColumns {
   machineLabel?: (m: string) => string;
   /** Render the ticket/PR column (only when at least one row carries a ref). */
   showTicket?: boolean;
+  /**
+   * Cells the picker prepends before each row: 2 for the single-select cursor
+   * ('> '), 6 for the multi-select cursor + checkbox ('> [x] '). Reserved from
+   * the topic width so rows never wrap. Defaults to 2.
+   */
+  gutter?: number;
 }
 
 const PICKER_MACHINE_W = 11;
@@ -1193,15 +1199,16 @@ export function formatPickerLabel(s: SessionMeta, query: string, cols: PickerCol
     ? chalk.blue(padRight(truncate(ticketLabel(s) || '-', TICKET_W), TICKET_W + 1))
     : '';
 
-  // The picker prepends a 2-cell cursor ('> '/'  '); reserve it, plus the
-  // conditional columns, so the topic shrinks to fit and rows never wrap.
-  const CURSOR_W = 2;
+  // The picker prepends a gutter (cursor, plus a checkbox in multi-select mode);
+  // reserve it, plus the conditional columns, so the topic shrinks to fit and
+  // rows never wrap.
+  const gutter = cols.gutter ?? 2;
   const machineW = cols.showMachine ? PICKER_MACHINE_W : 0;
   const ticketW = cols.showTicket ? TICKET_W + 1 : 0;
   const wtW = wt ? stringWidth(wt) + 1 : 0;
   const topicW = Math.max(
     16,
-    terminalWidth() - CURSOR_W - (10 + 9 + 8 + 16) - machineW - ticketW - wtW - stringWidth(when) - 1,
+    terminalWidth() - gutter - (10 + 9 + 8 + 16) - machineW - ticketW - wtW - stringWidth(when) - 1,
   );
 
   return (

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1128,7 +1128,39 @@ function renderTopicCell(
   return out + padding;
 }
 
-export function formatPickerLabel(s: SessionMeta, query: string): string {
+/** Column-visibility flags for the picker row, computed once over the whole pool. */
+export interface PickerColumns {
+  /** Render the machine column (only when the pool spans more than one machine). */
+  showMachine?: boolean;
+  /** Map a full machine id to its compact display form (shared prefix stripped). */
+  machineLabel?: (m: string) => string;
+  /** Render the ticket/PR column (only when at least one row carries a ref). */
+  showTicket?: boolean;
+}
+
+const PICKER_MACHINE_W = 11;
+
+/**
+ * Compact display form for machine ids: strip the longest shared dash-delimited
+ * prefix so "yosemite-s0"/"yosemite-s1" read as "s0"/"s1" while unrelated ids
+ * ("zion", "mac-mini") stay whole. Stripping a *common* prefix can't collide,
+ * and at least one segment is always kept.
+ */
+export function machineLabeler(machines: string[]): (m: string) => string {
+  const uniq = [...new Set(machines.filter(Boolean))];
+  if (uniq.length < 2) return (m) => m;
+  const parts = uniq.map((m) => m.split('-'));
+  const min = Math.min(...parts.map((p) => p.length));
+  let shared = 0;
+  while (shared < min - 1 && parts.every((p) => p[shared] === parts[0][shared])) shared++;
+  if (shared === 0) return (m) => m;
+  return (m) => {
+    const p = m.split('-');
+    return p.length > shared ? p.slice(shared).join('-') : m;
+  };
+}
+
+export function formatPickerLabel(s: SessionMeta, query: string, cols: PickerColumns = {}): string {
   const agentColor = colorAgent(s.agent);
   const when = formatRelativeTime(s.timestamp);
   const project = s.project || '-';
@@ -1136,15 +1168,55 @@ export function formatPickerLabel(s: SessionMeta, query: string): string {
   const label = (s as any).label;
   const topic = tag ? `${tag}${s.topic ?? ''}` : s.topic;
   const versionStr = s.version || '-';
+  const wt = s.worktreeSlug ? chalk.magenta(`wt:${s.worktreeSlug}`) : '';
+
+  const machineCell = cols.showMachine
+    ? chalk.gray(padRight(truncate((cols.machineLabel?.(s.machine ?? '') ?? s.machine ?? '') || '-', PICKER_MACHINE_W - 1), PICKER_MACHINE_W))
+    : '';
+
+  const TICKET_W = 10;
+  const ticketCell = cols.showTicket
+    ? chalk.blue(padRight(truncate(ticketLabel(s) || '-', TICKET_W), TICKET_W + 1))
+    : '';
+
+  // The picker prepends a 2-cell cursor ('> '/'  '); reserve it, plus the
+  // conditional columns, so the topic shrinks to fit and rows never wrap.
+  const CURSOR_W = 2;
+  const machineW = cols.showMachine ? PICKER_MACHINE_W : 0;
+  const ticketW = cols.showTicket ? TICKET_W + 1 : 0;
+  const wtW = wt ? stringWidth(wt) + 1 : 0;
+  const topicW = Math.max(
+    16,
+    terminalWidth() - CURSOR_W - (10 + 9 + 8 + 16) - machineW - ticketW - wtW - stringWidth(when) - 1,
+  );
 
   return (
     chalk.white(padRight(s.shortId, 10)) +
     agentColor(padRight(truncate(s.agent, 8), 9)) +
     chalk.yellow(padRight(truncate(versionStr, 7), 8)) +
+    machineCell +
     chalk.cyan(padRight(truncate(project, 14), 16)) +
-    renderTopicCell(label, topic, query, 48, 50) +
+    renderTopicCell(label, topic, query, topicW, topicW) +
+    ticketCell +
+    (wt ? wt + ' ' : '') +
     chalk.gray(when)
   );
+}
+
+/** Hints rotated above the picker so the flags/features stay discoverable. */
+const PICKER_TIPS: string[] = [
+  'Tip: narrow with -a/--agent (e.g. -a codex), or --project <name> for another folder.',
+  "Tip: --all searches every directory; -H/--host <machine> folds in another box's sessions.",
+  'Tip: just type to fuzzy-search prompts and responses; press space to preview a session.',
+  'Tip: --since 2d / --until <date> bound the time window; pass a session id to open it directly.',
+];
+
+/**
+ * Pick a hint to show above the picker. Deterministic (keys off the pool size)
+ * so it stays fixed across the picker's re-renders within a single run.
+ */
+export function formatPickerTip(sessions: SessionMeta[]): string {
+  return chalk.gray(PICKER_TIPS[sessions.length % PICKER_TIPS.length]);
 }
 
 export async function pickSessionInteractive(
@@ -1156,9 +1228,19 @@ export async function pickSessionInteractive(
   if (hiddenCount > 0) {
     console.log(chalk.gray(formatTeamHiddenFooter(hiddenCount)));
   }
+  // Machine column only earns its width when the listing actually spans boxes;
+  // the ticket column only when some row carries a PR/ticket ref. Both computed
+  // once over the whole pool so every row aligns.
+  const machines = sessions.map((s) => s.machine).filter((m): m is string => !!m);
+  const cols: PickerColumns = {
+    showMachine: new Set(machines).size > 1,
+    machineLabel: machineLabeler(machines),
+    showTicket: sessions.some((s) => ticketLabel(s) !== ''),
+  };
   try {
     return await sessionPicker({
       message,
+      subtitle: formatPickerTip(sessions),
       sessions,
       filter: (query: string) => {
         // No query: show the full pool (picker viewport still paginates via pageSize).
@@ -1166,7 +1248,7 @@ export async function pickSessionInteractive(
         if (!query.trim()) return sessions;
         return filterSessionsByQuery(sessions, query);
       },
-      labelFor: (s: SessionMeta, query: string) => formatPickerLabel(s, query),
+      labelFor: (s: SessionMeta, query: string) => formatPickerLabel(s, query, cols),
       pageSize: PICKER_RECENT_COUNT,
       initialSearch,
     });

--- a/src/lib/picker.ts
+++ b/src/lib/picker.ts
@@ -35,6 +35,8 @@ import { stripVTControlCharacters } from 'node:util';
 /** Configuration for the interactive picker prompt. */
 export interface PickerConfig<T> {
   message: string;
+  /** Optional dim hint line rendered directly under the header (above the rows). */
+  subtitle?: string;
   items: T[];
   filter: (query: string) => T[];
   labelFor: (item: T, query: string) => string;
@@ -254,7 +256,9 @@ export function itemPicker<T>(config: PickerConfig<T>): Promise<PickedItem<T> | 
           `↑↓ navigate${hasPreview ? ' · space: preview' : ''} · ⏎ ${enter} · esc: cancel`
         );
 
-    const parts: string[] = [header, page];
+    const parts: string[] = [header];
+    if (cfg.subtitle) parts.push(cfg.subtitle);
+    parts.push(page);
     if (results.length === 0) {
       parts.push(chalk.gray(`  ${cfg.emptyMessage ?? 'No matches.'}`));
     }

--- a/src/lib/session/__tests__/discover.test.ts
+++ b/src/lib/session/__tests__/discover.test.ts
@@ -4,7 +4,26 @@ import * as os from 'os';
 import * as path from 'path';
 import Database from '../../sqlite.js';
 import { buildFtsQuery } from '../db.js';
-import { scanClaudeSession, parseCodexThreadNameIndex, shouldDeferRecentAppend } from '../discover.js';
+import { scanClaudeSession, parseCodexThreadNameIndex, shouldDeferRecentAppend, machineForSessionFile } from '../discover.js';
+import { machineId } from '../sync/config.js';
+import { getHistoryDir } from '../../state.js';
+
+describe('machineForSessionFile', () => {
+  it('reads the origin machine from the cross-machine mirror path', () => {
+    const p = path.join(getHistoryDir(), 'backups', 'claude', 'zion', 'projects', 'foo', 'sess.jsonl');
+    expect(machineForSessionFile(p, 'claude')).toBe('zion');
+  });
+
+  it('keys the mirror machine off the correct agent segment', () => {
+    const p = path.join(getHistoryDir(), 'backups', 'codex', 'yosemite-s1', 'sessions', 'x.jsonl');
+    expect(machineForSessionFile(p, 'codex')).toBe('yosemite-s1');
+  });
+
+  it('falls back to the local machine for live-home (non-mirror) files', () => {
+    const p = path.join(os.homedir(), '.claude', 'projects', 'foo', 'sess.jsonl');
+    expect(machineForSessionFile(p, 'claude')).toBe(machineId());
+  });
+});
 
 describe('buildFtsQuery', () => {
   it('returns empty expression for whitespace-only input', () => {

--- a/src/lib/session/discover.ts
+++ b/src/lib/session/discover.ts
@@ -27,6 +27,7 @@ import { extractSessionTopic } from './prompt.js';
 import { parseAntigravity } from './parse.js';
 import { extractPrUrl, detectWorktree, detectTicket, isPrCreateCommand } from './state.js';
 import { costOfUsage } from '../pricing/index.js';
+import { machineId } from './sync/config.js';
 import {
   getDB,
   getScanStampByPath,
@@ -188,7 +189,26 @@ export async function discoverSessions(options?: DiscoverOptions): Promise<Sessi
   }
 
   const sessions = querySessions(buildQueryOptions(options, agents, { includeLimit: true }));
+  for (const s of sessions) s.machine = machineForSessionFile(s.filePath, s.agent);
   return sessions;
+}
+
+let _localMachineId: string | undefined;
+
+/**
+ * The machine a discovered session originated on. Cross-machine sync mirrors a
+ * remote transcript to backups/<agent>/<machine>/<subdir>/… (see mirrorPath in
+ * sync/agents.ts); every other transcript is a live-home file on this box. So:
+ * when the path sits under the agent's backups root, the first segment below it
+ * is the origin machine id; otherwise it's the local machine.
+ */
+export function machineForSessionFile(filePath: string, agent: string): string {
+  const base = path.join(getHistoryDir(), 'backups', agent) + path.sep;
+  if (filePath.startsWith(base)) {
+    const seg = filePath.slice(base.length).split(path.sep)[0];
+    if (seg) return seg;
+  }
+  return (_localMachineId ??= machineId());
 }
 
 /**

--- a/src/lib/session/types.ts
+++ b/src/lib/session/types.ts
@@ -85,6 +85,14 @@ export interface SessionMeta {
    * `entrypoint` field ('sdk-cli' for team spawns, 'cli' for real sessions).
    */
   isTeamOrigin?: boolean;
+  /**
+   * The machine (normalized hostname) this session's transcript originated on:
+   * the local machine for live-home sessions, or the origin machine parsed from
+   * the cross-machine mirror path (backups/<agent>/<machine>/…, see
+   * sync/agents.ts). Populated by discoverSessions for the listing/picker;
+   * undefined for sessions obtained outside that path.
+   */
+  machine?: string;
   /** Terms that matched the current search query */
   _matchedTerms?: string[];
   /** BM25 relevance score from the most recent content-index search */


### PR DESCRIPTION
## Why

The interactive `agents sessions` picker was thinner than the piped table: it never showed which machine a session ran on, and it silently dropped the PR/ticket ref and worktree badge that `flatSessionRow` already renders. There was also no hint that the command has filter flags at all.

## What

**1. Origin machine on `SessionMeta`.** `discoverSessions` now tags every session with the machine it originated on — the local host for live-home transcripts, or the origin host parsed from the cross-machine mirror layout (`backups/<agent>/<machine>/…`). Single derivation point, no schema change.

**2. Richer picker rows.** `formatPickerLabel` gained pool-computed column flags (`pickerColumnsFor`), shared by the browse picker and the multi-select resume picker:
- **machine column** — only when the listing spans more than one box, rendered compact (shared prefix stripped, so `yosemite-s0`/`yosemite-s1` → `s0`/`s1`);
- **PR#/ticket column** — only when some row carries a ref (same `ticketLabel` precedence as the table);
- **`wt:<slug>` worktree badge**;
- topic width is now terminal-aware, so the extra columns never wrap.

**3. Tip line.** A dim, rotating hint above the rows surfaces the filter flags (`-a/--agent`, `--project`, `--all`, `-H/--host`, `--since`). Implemented as an optional `subtitle` on the single-select picker.

## Rendered against real session data

```
Tip: narrow with -a/--agent (e.g. -a codex), or --project <name> for another folder.
  9924b2de  claude   2.1.170 agents-cli      You are working autonomously, end-to-end…RUSH-1415  1 hour ago
  019f2003  codex    0.134.0 mailbox-messa.  ## Apps (Connectors)              -          wt:mailbox-message 1 hour ago
```

With a multi-machine pool the machine column appears (`s0`/`s1`); with one machine it stays hidden — no wasted width day-to-day.

## Testing

- New unit tests: machine derivation from mirror vs live-home paths (`discover.test.ts`); `machineLabeler` prefix-strip / collision safety, machine+PR+wt rendering, tip determinism (`sessions-columns.test.ts`).
- Full suite: 3765 pass. The one red (`events-audit.test.ts`) is a pre-existing timezone date-rollover flake that fails identically on `main` — unrelated to this change.
- Verified end-to-end against the live sessions DB via the compiled build (`machine` populated; tip + PR/ticket + `wt:` badges + conditional machine column all render).
