### PR TITLE
feat(terminal): resolve session -> precise inject target (iterm/vscodium/tmux, safe Ghostty skip) [RUSH-1415]

### DIFF
--- a/src/lib/session/provenance.test.ts
+++ b/src/lib/session/provenance.test.ts
@@ -3,6 +3,7 @@ import {
   parseProcEnviron,
   extractKnownEnv,
   parseSshConnection,
+  parseItermSession,
   deriveProvenance,
   detectProvenance,
   PROVENANCE_ENV_KEYS,
@@ -67,6 +68,21 @@ describe('parseSshConnection', () => {
   });
 });
 
+describe('parseItermSession', () => {
+  it('extracts the UUID after the wNtNpN: prefix (what `id of session` returns)', () => {
+    expect(parseItermSession('w0t1p0:9F2A-UUID')).toBe('9F2A-UUID');
+  });
+
+  it('tolerates a bare value with no colon', () => {
+    expect(parseItermSession('9F2A-UUID')).toBe('9F2A-UUID');
+  });
+
+  it('returns undefined for empty / absent', () => {
+    expect(parseItermSession(undefined)).toBeUndefined();
+    expect(parseItermSession('')).toBeUndefined();
+  });
+});
+
 describe('deriveProvenance', () => {
   it('local + tmux pane yields a tmux reply rail (addressable)', () => {
     const p = deriveProvenance(
@@ -88,11 +104,28 @@ describe('deriveProvenance', () => {
     expect(p.ssh).toEqual({ clientIp: '203.0.113.7', clientPort: 51828, serverIp: '10.0.0.3', serverPort: 22 });
   });
 
-  it('no tmux, no ssh => local and NOT addressable (reply null)', () => {
+  it('iTerm split (no tmux) yields an iterm reply rail carrying the session UUID', () => {
+    const p = deriveProvenance(
+      { TERM_PROGRAM: 'iTerm.app', ITERM_SESSION_ID: 'w0t2p1:AAAA-BBBB' },
+      'zion',
+    );
+    expect(p.mux).toBeUndefined();
+    expect(p.reply).toEqual({ rail: 'iterm', session: 'AAAA-BBBB' });
+  });
+
+  it('tmux inside iTerm still prefers the tmux rail (works inside any host app)', () => {
+    const p = deriveProvenance(
+      { TERM_PROGRAM: 'iTerm.app', ITERM_SESSION_ID: 'w0t0p0:UUID', TMUX: '/tmp/s,1,0', TMUX_PANE: '%7' },
+      'zion',
+    );
+    expect(p.reply).toEqual({ rail: 'tmux', target: '%7', socket: '/tmp/s' });
+  });
+
+  it('no tmux, no iterm, no ssh => local and NOT addressable (reply null)', () => {
     const p = deriveProvenance({ TERM_PROGRAM: 'vscode' }, 'this-mac');
     expect(p.transport).toBe('local');
     expect(p.mux).toBeUndefined();
-    expect(p.reply).toBeNull(); // inherited/ignored stdin — feed shows read-only
+    expect(p.reply).toBeNull(); // plain VS Code integrated terminal — resolver checks disk instead
   });
 
   it('screen session is recognized but not (yet) addressable', () => {

--- a/src/lib/session/provenance.ts
+++ b/src/lib/session/provenance.ts
@@ -15,9 +15,22 @@
  * (gone, or owned by another uid) yields `undefined`, never a guess.
  *
  * `reply` is a read-only hint, not a send channel: it reports whether a rail
- * that can type back into this session exists today (tmux pane => addressable;
- * inherited/ignored stdin => null). The feed uses it to decide whether to show
- * a Send box. Actually delivering the keystrokes is Gap 2 (pty/tmux send-keys).
+ * that can type back into this session exists today and, if so, the exact
+ * address to type into. Two env-derived rails, in precedence order:
+ *
+ *   - tmux  — `$TMUX_PANE` (+ `$TMUX` socket): `tmux send-keys -t <pane>`. Works
+ *             inside ANY host app (a tmux pane can live under iTerm/Ghostty/VS
+ *             Code), so it wins whenever present.
+ *   - iterm — `$ITERM_SESSION_ID` (`w<n>t<n>p<n>:<UUID>`): the exact iTerm2
+ *             split, addressable by its session UUID via `tell session id …`
+ *             (focus-safe, no `activate`). Used when there's no tmux above it.
+ *
+ * Both are inherited env vars, so the split the agent lives in is recovered with
+ * zero cooperation from the agent. Inherited/ignored stdin with neither rail =>
+ * null (not env-addressable — resolution may still find an IDE rail off disk,
+ * see src/lib/terminal/resolve.ts). The feed uses `reply` to decide whether to
+ * show a Send box; the resolver turns it into a concrete inject target (Gap 2,
+ * src/lib/terminal/inject.ts).
  */
 import * as os from 'os';
 import { execFile } from 'child_process';
@@ -43,9 +56,11 @@ export interface MuxLocation {
   session?: string;
 }
 
-/** How the feed can type back into a session, derived from rails that exist today. */
+/** How the feed can type back into a session, derived from env rails that exist today. */
 export type ReplyRail =
   | { rail: 'tmux'; target: string; socket?: string }
+  /** iTerm2 split addressed by its session UUID (the part of $ITERM_SESSION_ID after ':'). */
+  | { rail: 'iterm'; session: string }
   | null;
 
 export interface SessionProvenance {
@@ -71,7 +86,20 @@ export const PROVENANCE_ENV_KEYS = [
   'TMUX_PANE',
   'TERM_PROGRAM',
   'STY',
+  'ITERM_SESSION_ID',
 ] as const;
+
+/**
+ * Extract the iTerm2 session UUID from `$ITERM_SESSION_ID`, whose value is
+ * `w<window>t<tab>p<pane>:<UUID>` — the `:`-suffix is exactly what iTerm2's
+ * `id of session` returns, so it's the address for `tell session id …`. Returns
+ * undefined for an empty/absent value; tolerates a bare value with no `:`.
+ */
+export function parseItermSession(value?: string): string | undefined {
+  if (!value) return undefined;
+  const uuid = value.includes(':') ? value.slice(value.lastIndexOf(':') + 1) : value;
+  return uuid.trim() || undefined;
+}
 
 /** Parse the NUL-separated body of /proc/<pid>/environ into a plain object. */
 export function parseProcEnviron(buf: string): Record<string, string> {
@@ -140,13 +168,19 @@ export function deriveProvenance(env: Record<string, string>, hostname: string):
     mux = { kind: 'screen', session: env.STY };
   }
 
-  // A tmux pane is the one rail that lets an external process type into an
-  // already-running interactive agent (`tmux send-keys -t <pane>`). Everything
-  // else (inherited stdin from `agents run`, ignored stdin from teams) is not
-  // externally addressable without relaunching under a pty/tmux rail.
-  const reply: ReplyRail = mux?.kind === 'tmux' && mux.pane
-    ? { rail: 'tmux', target: mux.pane, socket: mux.socket }
-    : null;
+  // Env-addressable rails, in precedence order. A tmux pane wins because it can
+  // live inside any host app (`tmux send-keys -t <pane>` reaches it regardless of
+  // whether iTerm/Ghostty/VS Code is above it). Absent tmux, an iTerm2 split is
+  // addressable by its session UUID. Everything else (inherited stdin from
+  // `agents run`, ignored stdin from teams, a plain VS Code integrated terminal)
+  // is not env-addressable — the resolver may still find an IDE rail off disk.
+  const itermSession = parseItermSession(env.ITERM_SESSION_ID);
+  const reply: ReplyRail =
+    mux?.kind === 'tmux' && mux.pane
+      ? { rail: 'tmux', target: mux.pane, socket: mux.socket }
+      : itermSession
+        ? { rail: 'iterm', session: itermSession }
+        : null;
 
   return {
     host: hostname,

--- a/src/lib/terminal/index.ts
+++ b/src/lib/terminal/index.ts
@@ -38,8 +38,17 @@ export {
   itermInjectScript,
   ghosttyInjectScript,
   appleScriptInjectSpec,
+  vscodiumInjectUri,
+  vscodiumInjectSpec,
   type InjectTarget,
   type InjectBackend,
   type InjectOptions,
   type InjectResult,
 } from './inject.js';
+export {
+  resolveInjectTarget,
+  resolveInjectTargetForSession,
+  type InjectResolution,
+  type InjectRail,
+  type ResolveOptions,
+} from './resolve.js';

--- a/src/lib/terminal/inject.test.ts
+++ b/src/lib/terminal/inject.test.ts
@@ -184,6 +184,15 @@ describe('injectIntoTerminal — macOS backends off-darwin', () => {
     expect(res.writes).toBe(2);
     expect(res.specs?.[0].argv.join(' ')).toContain('keystroke "hi"');
   });
+
+  it('ghostty write-count tracks enter alone (its coarse script ignores combined)', async () => {
+    // The keystroke path always emits keystroke + a separate Return, so combined
+    // does NOT fuse it — the count must stay 2, not collapse to 1.
+    const combined = await injectIntoTerminal({ backend: 'ghostty' }, 'hi', { dryRun: true, combined: true });
+    expect(combined.writes).toBe(2);
+    const noEnter = await injectIntoTerminal({ backend: 'ghostty' }, 'hi', { dryRun: true, enter: false });
+    expect(noEnter.writes).toBe(1);
+  });
 });
 
 describe('injectIntoTerminal — vscodium routing', () => {

--- a/src/lib/terminal/inject.test.ts
+++ b/src/lib/terminal/inject.test.ts
@@ -23,6 +23,8 @@ import {
   itermInjectScript,
   ghosttyInjectScript,
   appleScriptInjectSpec,
+  vscodiumInjectUri,
+  vscodiumInjectSpec,
 } from './inject.js';
 
 const linuxCtx: EngineContext = { platform: 'linux', env: {} as NodeJS.ProcessEnv };
@@ -69,26 +71,71 @@ describe('tmuxInjectSpecs', () => {
 });
 
 describe('itermInjectScript', () => {
-  it('keystrokes the text then a SEPARATE Return (Ink-safe) into the current session', () => {
+  it('writes into the current session with NO activate (focus-safe) and a separate CR Enter', () => {
     const s = itermInjectScript('continue', { enter: true });
     expect(s).toContain('tell application "iTerm2"');
-    expect(s).toContain('keystroke "continue"');
-    expect(s).toContain('key code 36');
-    expect(s.indexOf('keystroke "continue"')).toBeLessThan(s.indexOf('key code 36'));
+    expect(s).toContain('tell current session of current window');
+    // Focus-safe: never activates iTerm or steals the frontmost split.
+    expect(s).not.toContain('activate');
+    // Ink-safe: text without a fused newline, then a SEPARATE lone CR.
+    expect(s).toContain('write text "continue" newline no');
+    expect(s).toContain('write text (character id 13) newline no');
+    expect(s.indexOf('write text "continue"')).toBeLessThan(s.indexOf('character id 13'));
   });
 
-  it('addresses a specific session by id when given one', () => {
+  it('addresses the EXACT split by session id (tell session id …), never the frontmost', () => {
     const s = itermInjectScript('go', { session: 'ABC-123', enter: true });
-    expect(s).toContain('if (id of s) is "ABC-123" then');
-    expect(s).toContain('select w');
+    expect(s).toContain('tell session id "ABC-123"');
+    expect(s).not.toContain('current session');
+    expect(s).not.toContain('activate');
   });
 
-  it('omits the Return event when enter is false', () => {
-    expect(itermInjectScript('partial', { enter: false })).not.toContain('key code 36');
+  it('combined fuses text+Enter into one auto-newline write (plain shells / REPLs)', () => {
+    const s = itermInjectScript('go', { enter: true, combined: true });
+    expect(s).toContain('write text "go"');
+    expect(s).not.toContain('newline no');
+    expect(s).not.toContain('character id 13');
+  });
+
+  it('omits the Return event when enter is false (text only, no newline)', () => {
+    const s = itermInjectScript('partial', { enter: false });
+    expect(s).toContain('write text "partial" newline no');
+    expect(s).not.toContain('character id 13');
   });
 
   it('escapes quotes in the injected text via the engine appleScriptStr', () => {
-    expect(itermInjectScript('say "hi"', { enter: false })).toContain('keystroke "say \\"hi\\""');
+    expect(itermInjectScript('say "hi"', { enter: false })).toContain('write text "say \\"hi\\"" newline no');
+  });
+});
+
+describe('vscodiumInjectUri', () => {
+  it('builds a base64url /inject URL whose decoded payload carries id + text + flags', () => {
+    const uri = vscodiumInjectUri('vscodium', 'sess-uuid', 'continue', { enter: true, combined: false });
+    expect(uri.startsWith('vscodium://swarmify.swarm-ext/inject?p=')).toBe(true);
+    const p = uri.split('p=')[1];
+    // base64url alphabet only — survives VS Code's single percent-decode of uri.query.
+    expect(p).toMatch(/^[A-Za-z0-9_-]+$/);
+    const payload = JSON.parse(Buffer.from(p, 'base64url').toString('utf8'));
+    expect(payload).toEqual({ terminalId: 'sess-uuid', text: 'continue', enter: true, combined: false });
+  });
+
+  it('round-trips a text containing & and = untouched (the reason for base64url)', () => {
+    const uri = vscodiumInjectUri('cursor', 't1', 'echo a && b = c', { enter: true, combined: false });
+    const payload = JSON.parse(Buffer.from(uri.split('p=')[1], 'base64url').toString('utf8'));
+    expect(payload.text).toBe('echo a && b = c');
+  });
+});
+
+describe('vscodiumInjectSpec', () => {
+  it('invokes the editor CLI with --open-url and the inject URI', () => {
+    const spec = vscodiumInjectSpec(
+      { backend: 'vscodium', terminalId: 't1', cli: 'codium', scheme: 'vscodium' },
+      'hi',
+      { enter: true, combined: false },
+    );
+    expect(spec.argv[0]).toBe('codium');
+    expect(spec.argv[1]).toBe('--open-url');
+    expect(spec.argv[2].startsWith('vscodium://swarmify.swarm-ext/inject?p=')).toBe(true);
   });
 });
 
@@ -109,10 +156,16 @@ describe('ghosttyInjectScript', () => {
 });
 
 describe('appleScriptInjectSpec', () => {
-  it('wraps the script as an osascript spec', () => {
+  it('wraps the iterm write-text script as an osascript spec', () => {
     const spec = appleScriptInjectSpec({ backend: 'iterm' }, 'hi', true);
     expect(spec.argv[0]).toBe('osascript');
     expect(spec.argv[1]).toBe('-e');
+    expect(spec.argv[2]).toContain('write text "hi"');
+  });
+
+  it('wraps the ghostty keystroke script as an osascript spec (coarse path)', () => {
+    const spec = appleScriptInjectSpec({ backend: 'ghostty' }, 'hi', true);
+    expect(spec.argv[0]).toBe('osascript');
     expect(spec.argv[2]).toContain('keystroke "hi"');
   });
 });
@@ -130,6 +183,31 @@ describe('injectIntoTerminal — macOS backends off-darwin', () => {
     expect(res.ok).toBe(true);
     expect(res.writes).toBe(2);
     expect(res.specs?.[0].argv.join(' ')).toContain('keystroke "hi"');
+  });
+});
+
+describe('injectIntoTerminal — vscodium routing', () => {
+  it('dryRun returns the editor-CLI --open-url spec and the Ink-safe two-write count', async () => {
+    const res = await injectIntoTerminal(
+      { backend: 'vscodium', terminalId: 't1', cli: 'codium', scheme: 'vscodium' },
+      'continue',
+      { dryRun: true },
+    );
+    expect(res.ok).toBe(true);
+    expect(res.backend).toBe('vscodium');
+    expect(res.writes).toBe(2);
+    expect(res.specs?.[0].argv[0]).toBe('codium');
+    expect(res.specs?.[0].argv[1]).toBe('--open-url');
+    expect(res.specs?.[0].argv[2]).toContain('swarmify.swarm-ext/inject');
+  });
+
+  it('combined collapses to a single write on the extension side', async () => {
+    const res = await injectIntoTerminal(
+      { backend: 'vscodium', terminalId: 't1', cli: 'cursor', scheme: 'cursor' },
+      'ls',
+      { dryRun: true, combined: true },
+    );
+    expect(res.writes).toBe(1);
   });
 });
 

--- a/src/lib/terminal/inject.ts
+++ b/src/lib/terminal/inject.ts
@@ -15,13 +15,24 @@
  * (`--host` over SSH) execution for free. A `LaunchSpec` never opens anything;
  * building one is side-effect-free and unit-testable without a display.
  *
- * Backends:
+ * Backends (each addresses the EXACT split, not the frontmost surface):
  *   - tmux  → `tmux send-keys -t <pane>` — the send-keys primitive addressed by
- *             pane id + socket (the exact rail provenance.ts:147-149 identifies).
- *   - iterm/ghostty (macOS) → AppleScript that ADDRESSES the target window/tab
- *             and injects via System Events keystrokes. Uses the engine's
- *             `appleScriptStr` escaper; guarded by the backend's own
- *             `isAvailable` (platform + app installed).
+ *             pane id + socket (the exact rail provenance.ts identifies).
+ *   - iterm (macOS) → AppleScript `tell session id "<uuid>" to write text` —
+ *             addresses the precise iTerm2 split by its session UUID WITHOUT
+ *             `activate`, so it never steals focus or types into the wrong split.
+ *             Uses the engine's `appleScriptStr` escaper; guarded by the iterm
+ *             backend's `isAvailable` (platform + app installed).
+ *   - vscodium (VSCodium / Cursor / VS Code) → the editor CLI's `--open-url`
+ *             into the swarmify `swarm-ext` extension's `/inject` verb, targeting
+ *             a live-terminals.json terminal by id. Focus-independent, exact
+ *             terminal, and (like the launch backend, src/lib/terminal/backends/
+ *             vscodium-agent.ts) works over `--host` SSH and on Linux.
+ *   - ghostty (macOS) → COARSE only: Ghostty has no scripting dictionary, so
+ *             there is no per-split addressing — this raises a window and types
+ *             via System Events keystrokes, stealing focus. The resolver refuses
+ *             to route here by default (see resolve.ts); it stays behind an
+ *             explicit opt-in.
  *   - pty   → the `agents pty write` sidecar path (ptyRequest). Local-only —
  *             the sidecar is not an engine transport surface.
  *
@@ -45,6 +56,13 @@ import { currentContext, type LaunchSpec, type EngineContext } from './types.js'
 export type InjectTarget =
   | { backend: 'tmux'; pane: string; socket?: string }
   | { backend: 'iterm'; session?: string }
+  /**
+   * A VSCodium / Cursor / VS Code integrated terminal, addressed by the id the
+   * swarm-ext extension keys `live-terminals.json` on (the session UUID). `cli`
+   * is the editor CLI on PATH (`codium` / `cursor` / `code`); `scheme` is its
+   * URL scheme (`vscodium` / `cursor` / `vscode`) — the resolver fills both.
+   */
+  | { backend: 'vscodium'; terminalId: string; cli: string; scheme: string }
   | { backend: 'ghostty'; window?: string }
   | { backend: 'pty'; id: string };
 
@@ -129,31 +147,46 @@ export function tmuxInjectSpecs(
 // --- macOS (iterm / ghostty) ------------------------------------------------
 
 /**
- * AppleScript that brings the target iTerm2 session (tab) to the front, then
- * injects `text` and — when `enter` — a SEPARATE Return keypress (`key code 36`)
- * so the Ink TUI sees Enter as its own event. Omitting `session` types into the
- * current session.
+ * AppleScript that types into a SPECIFIC iTerm2 split via `tell session id
+ * "<uuid>" to write text` — the exact split provenance's iterm rail identifies,
+ * addressed by its session UUID. Crucially there is NO `activate`: `write text`
+ * delivers to that session directly, so injection never brings iTerm forward or
+ * types into whatever split happens to be focused. Omitting `session` targets
+ * the current session (a direct-call convenience; the resolver always supplies
+ * one).
+ *
+ * Enter semantics — iTerm's `write text` appends a trailing newline, which fuses
+ * text+Enter into ONE write and Claude's Ink TUI swallows it. So the Ink-safe
+ * default (enter, not combined) suppresses that newline (`write text … newline
+ * no`) and sends the Return as a SEPARATE `write text` of a lone CR (`character
+ * id 13`) — two distinct pty writes, Enter seen on its own. `combined` opts into
+ * the single fused `write text` (auto-newline) for plain shells / REPLs.
+ *
+ * NOTE (macOS-only verification pending): the two-write CR path is the safe
+ * choice because it mirrors the tmux/pty Ink-safe split that IS verified here on
+ * Linux; whether a single `write text T` would also submit under Ink can only be
+ * confirmed on a Mac running iTerm (see the PR body).
  */
-export function itermInjectScript(text: string, opts: { session?: string; enter: boolean }): string {
-  const lines: string[] = ['tell application "iTerm2"', '  activate'];
-  if (opts.session) {
-    lines.push(
-      '  repeat with w in windows',
-      '    repeat with t in tabs of w',
-      '      repeat with s in sessions of t',
-      `        if (id of s) is ${appleScriptStr(opts.session)} then`,
-      '          select w',
-      '          tell w to select t',
-      '        end if',
-      '      end repeat',
-      '    end repeat',
-      '  end repeat',
-    );
-  }
-  lines.push('end tell');
-  lines.push(`tell application "System Events" to keystroke ${appleScriptStr(text)}`);
-  if (opts.enter) lines.push('tell application "System Events" to key code 36');
-  return lines.join('\n');
+export function itermInjectScript(text: string, opts: { session?: string; enter: boolean; combined?: boolean }): string {
+  // Two writes for the Ink-safe default; one fused write for combined / enter=false.
+  const body: string[] =
+    opts.enter && opts.combined
+      ? [`write text ${appleScriptStr(text)}`]
+      : opts.enter
+        ? [`write text ${appleScriptStr(text)} newline no`, 'write text (character id 13) newline no']
+        : [`write text ${appleScriptStr(text)} newline no`];
+
+  const target = opts.session
+    ? `session id ${appleScriptStr(opts.session)}`
+    : 'current session of current window';
+
+  return [
+    'tell application "iTerm2"',
+    `  tell ${target}`,
+    ...body.map((l) => `    ${l}`),
+    '  end tell',
+    'end tell',
+  ].join('\n');
 }
 
 /**
@@ -173,17 +206,62 @@ export function ghosttyInjectScript(text: string, opts: { window?: string; enter
   return lines.join('\n');
 }
 
-/** The osascript spec for a macOS injection. One invocation delivers keystroke + Return. */
+/** The osascript spec for a macOS injection. One invocation delivers the text + Return. */
 export function appleScriptInjectSpec(
   target: Extract<InjectTarget, { backend: 'iterm' | 'ghostty' }>,
   text: string,
   enter: boolean,
+  combined = false,
 ): LaunchSpec {
   const script =
     target.backend === 'iterm'
-      ? itermInjectScript(text, { session: target.session, enter })
+      ? itermInjectScript(text, { session: target.session, enter, combined })
       : ghosttyInjectScript(text, { window: target.window, enter });
   return { argv: ['osascript', '-e', script] };
+}
+
+// --- vscodium (VSCodium / Cursor / VS Code integrated terminal) -------------
+
+/** The swarmify extension identifier that owns the swarm-ext URI verbs (matches the launch backend). */
+const EXTENSION_AUTHORITY = 'swarmify.swarm-ext';
+
+/**
+ * The `<scheme>://swarmify.swarm-ext/inject?p=<payload>` URL the extension
+ * handles to type into an ALREADY-open integrated terminal (the inject sibling
+ * of the launch backend's `/spawn`, src/lib/terminal/backends/vscodium-agent.ts).
+ *
+ * Payload is base64url-encoded JSON in a single `p` param — identical encoding
+ * to `spawnUri`, and for the same reason: VS Code percent-decodes `uri.query`
+ * once before the extension parses it, so a naive multi-param query would
+ * mis-split a text containing `&`/`=`; base64url (`[A-Za-z0-9_-]`) survives that
+ * decode untouched. `terminalId` is the id the extension keys live-terminals.json
+ * on (the session UUID); `enter` tells the extension to submit; `combined` asks
+ * it to fuse text+Enter into one write (default is the Ink-safe two-write split,
+ * mirroring the tmux/iterm paths — the extension owns that split on its side).
+ *
+ * DEPENDENCY: the `/inject` verb ships in the swarm-ext extension via PR #608's
+ * successor (PR #608 introduces `/spawn`; the inject verb + `write`/`enter`
+ * handling is its follow-up). Until that lands, this routes correctly on the CLI
+ * side but the extension will no-op the unknown verb. See the PR body.
+ */
+export function vscodiumInjectUri(
+  scheme: string,
+  terminalId: string,
+  text: string,
+  opts: { enter: boolean; combined: boolean },
+): string {
+  const payload = { terminalId, text, enter: opts.enter, combined: opts.combined };
+  const p = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+  return `${scheme}://${EXTENSION_AUTHORITY}/inject?p=${p}`;
+}
+
+/** The editor-CLI spec for a VSCodium/Cursor/VS Code injection (one `--open-url` invocation). */
+export function vscodiumInjectSpec(
+  target: Extract<InjectTarget, { backend: 'vscodium' }>,
+  text: string,
+  opts: { enter: boolean; combined: boolean },
+): LaunchSpec {
+  return { argv: [target.cli, '--open-url', vscodiumInjectUri(target.scheme, target.terminalId, text, opts)] };
 }
 
 // --- pty --------------------------------------------------------------------
@@ -231,15 +309,18 @@ export async function injectIntoTerminal(
     return injectPty(target, text, { enter, combined, host: opts.host, dryRun: opts.dryRun });
   }
 
-  // tmux + AppleScript backends run through the engine transport.
+  // tmux + AppleScript + editor-CLI backends all run through the engine transport.
   const specs =
     target.backend === 'tmux'
       ? tmuxInjectSpecs(target, text, { enter, combined, socket: opts.socket })
-      : [appleScriptInjectSpec(target, text, enter)];
+      : target.backend === 'vscodium'
+        ? [vscodiumInjectSpec(target, text, { enter, combined })]
+        : [appleScriptInjectSpec(target, text, enter, combined)];
 
-  // A macOS keystroke injection is one osascript spec that emits keystroke +
-  // Return, i.e. two writes; tmux/pty count their discrete send-keys/write calls.
-  const writes = target.backend === 'tmux' ? specs.length : enter ? 2 : 1;
+  // tmux counts its discrete send-keys calls; the single-invocation backends
+  // (osascript / editor CLI) deliver text + a separate Return = two writes on
+  // their side (one when there's no Enter, or when fused via `combined`).
+  const writes = target.backend === 'tmux' ? specs.length : enter && !combined ? 2 : 1;
 
   if (opts.dryRun) return { ok: true, backend: target.backend, writes, specs };
 

--- a/src/lib/terminal/inject.ts
+++ b/src/lib/terminal/inject.ts
@@ -317,10 +317,16 @@ export async function injectIntoTerminal(
         ? [vscodiumInjectSpec(target, text, { enter, combined })]
         : [appleScriptInjectSpec(target, text, enter, combined)];
 
-  // tmux counts its discrete send-keys calls; the single-invocation backends
-  // (osascript / editor CLI) deliver text + a separate Return = two writes on
-  // their side (one when there's no Enter, or when fused via `combined`).
-  const writes = target.backend === 'tmux' ? specs.length : enter && !combined ? 2 : 1;
+  // Discrete writes delivered on the far side. tmux counts its send-keys calls.
+  // iterm/vscodium honor `combined` (text+Enter fused into one write). ghostty's
+  // coarse keystroke path ignores `combined` (it always emits keystroke + a
+  // separate Return), so its count tracks `enter` alone.
+  const writes =
+    target.backend === 'tmux'
+      ? specs.length
+      : target.backend === 'ghostty'
+        ? enter ? 2 : 1
+        : enter && !combined ? 2 : 1;
 
   if (opts.dryRun) return { ok: true, backend: target.backend, writes, specs };
 

--- a/src/lib/terminal/resolve.test.ts
+++ b/src/lib/terminal/resolve.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for the inject-target resolver (RUSH-1415) — the safety choke point.
+ *
+ * `resolveInjectTargetForSession` is PURE (takes an ActiveSession, returns a
+ * resolution), so the whole tmux > iterm > vscodium > pty precedence and the
+ * Ghostty refusal are asserted here without touching the process table. The
+ * fixtures mirror what active.ts produces: provenance (env-derived rails) + host
+ * (detectHost) + sessionId.
+ */
+import { describe, it, expect } from 'vitest';
+import type { ActiveSession } from '../session/active.js';
+import type { SessionProvenance, ReplyRail, MuxLocation } from '../session/provenance.js';
+import { resolveInjectTargetForSession } from './resolve.js';
+
+/** Minimal ActiveSession with the fields the resolver reads. */
+function session(over: {
+  sessionId?: string;
+  host?: string;
+  mux?: MuxLocation;
+  reply?: ReplyRail;
+}): ActiveSession {
+  const provenance: SessionProvenance = {
+    host: 'zion',
+    transport: 'local',
+    mux: over.mux,
+    reply: over.reply ?? null,
+  };
+  return {
+    context: 'terminal',
+    kind: 'claude',
+    host: over.host,
+    sessionId: over.sessionId,
+    status: 'idle',
+    provenance,
+  };
+}
+
+describe('resolveInjectTargetForSession — tmux (highest precedence)', () => {
+  it('resolves a tmux pane regardless of host app', () => {
+    const r = resolveInjectTargetForSession(
+      session({ host: 'iterm', mux: { kind: 'tmux', pane: '%3', socket: '/tmp/s' }, reply: { rail: 'tmux', target: '%3', socket: '/tmp/s' } }),
+    );
+    expect(r).toEqual({ addressable: true, rail: 'tmux', target: { backend: 'tmux', pane: '%3', socket: '/tmp/s' } });
+  });
+
+  it('tmux wins even when the session is IDE-hosted (works inside VS Code)', () => {
+    const r = resolveInjectTargetForSession(
+      session({ host: 'codium', sessionId: 'abc', mux: { kind: 'tmux', pane: '%1' }, reply: { rail: 'tmux', target: '%1' } }),
+    );
+    expect(r.addressable).toBe(true);
+    if (r.addressable) expect(r.rail).toBe('tmux');
+  });
+});
+
+describe('resolveInjectTargetForSession — iterm', () => {
+  it('resolves the exact iTerm split by session UUID from the env rail', () => {
+    const r = resolveInjectTargetForSession(session({ host: 'iterm', reply: { rail: 'iterm', session: 'UUID-1' } }));
+    expect(r).toEqual({ addressable: true, rail: 'iterm', target: { backend: 'iterm', session: 'UUID-1' } });
+  });
+});
+
+describe('resolveInjectTargetForSession — vscodium', () => {
+  it('resolves a codium integrated terminal to the editor CLI + scheme, id = sessionId', () => {
+    const r = resolveInjectTargetForSession(session({ host: 'codium', sessionId: 'sess-9' }));
+    expect(r).toEqual({
+      addressable: true,
+      rail: 'vscodium',
+      target: { backend: 'vscodium', terminalId: 'sess-9', cli: 'codium', scheme: 'vscodium' },
+    });
+  });
+
+  it('maps cursor and code hosts to their CLI/scheme', () => {
+    const cur = resolveInjectTargetForSession(session({ host: 'cursor', sessionId: 's' }));
+    const code = resolveInjectTargetForSession(session({ host: 'code', sessionId: 's' }));
+    expect(cur.addressable && cur.target).toMatchObject({ cli: 'cursor', scheme: 'cursor' });
+    expect(code.addressable && code.target).toMatchObject({ cli: 'code', scheme: 'vscode' });
+  });
+
+  it('refuses an IDE terminal with no session id (nothing to address) rather than guessing', () => {
+    const r = resolveInjectTargetForSession(session({ host: 'codium' }));
+    expect(r.addressable).toBe(false);
+    if (!r.addressable) expect(r.reason).toContain('no session id');
+  });
+});
+
+describe('resolveInjectTargetForSession — ghostty (honest degradation)', () => {
+  it('refuses a Ghostty session with no tmux by default (watchdog skips)', () => {
+    const r = resolveInjectTargetForSession(session({ host: 'ghostty', sessionId: 's' }));
+    expect(r.addressable).toBe(false);
+    if (!r.addressable) expect(r.reason).toContain('un-addressable (ghostty');
+  });
+
+  it('emits the coarse window path only under the explicit opt-in, with a not-precise note', () => {
+    const r = resolveInjectTargetForSession(session({ host: 'ghostty', sessionId: 's' }), { allowGhosttyFocus: true });
+    expect(r.addressable).toBe(true);
+    if (r.addressable) {
+      expect(r.rail).toBe('ghostty');
+      expect(r.target).toEqual({ backend: 'ghostty' });
+      expect(r.note).toContain('not split-precise');
+    }
+  });
+
+  it('a Ghostty session INSIDE tmux is still tmux-addressable (tmux precedence beats the refusal)', () => {
+    const r = resolveInjectTargetForSession(
+      session({ host: 'ghostty', mux: { kind: 'tmux', pane: '%2' }, reply: { rail: 'tmux', target: '%2' } }),
+    );
+    expect(r.addressable).toBe(true);
+    if (r.addressable) expect(r.rail).toBe('tmux');
+  });
+});
+
+describe('resolveInjectTargetForSession — pty + refusals', () => {
+  it('emits pty only when a sidecar id is supplied (lowest precedence)', () => {
+    const r = resolveInjectTargetForSession(session({ host: undefined }), { ptyId: 'pty-7' });
+    expect(r).toEqual({ addressable: true, rail: 'pty', target: { backend: 'pty', id: 'pty-7' } });
+  });
+
+  it('refuses with an honest reason when no rail exists', () => {
+    const r = resolveInjectTargetForSession(session({ host: undefined }));
+    expect(r.addressable).toBe(false);
+    if (!r.addressable) expect(r.reason).toContain('not inside tmux');
+  });
+
+  it('names an unrecognised host in the refusal reason', () => {
+    const r = resolveInjectTargetForSession(session({ host: 'warp' }));
+    expect(r.addressable).toBe(false);
+    if (!r.addressable) expect(r.reason).toContain('warp');
+  });
+});

--- a/src/lib/terminal/resolve.ts
+++ b/src/lib/terminal/resolve.ts
@@ -1,0 +1,146 @@
+/**
+ * Inject-target resolution — the safety choke point (RUSH-1415).
+ *
+ * The watchdog knows a session has stalled and wants to nudge it with "continue".
+ * `injectIntoTerminal` (inject.ts) can DELIVER into a target; this module decides
+ * the RIGHT target for a given sessionId — the exact split the agent lives in —
+ * and NEVER guesses. If it can't name a precise rail it returns `addressable:
+ * false` with a reason, and the watchdog skips rather than typing into the
+ * frontmost / wrong split.
+ *
+ * Resolution reads the agent's INHERITED ENV (via session provenance) plus the
+ * IDE's live-terminals registry (off disk) — no cooperation from the agent:
+ *
+ *   tmux  > iterm > vscodium > pty
+ *
+ * tmux wins whenever present: a `tmux send-keys -t <pane>` reaches the pane no
+ * matter which host app (iTerm / Ghostty / VS Code) is above it, so it's correct
+ * inside ANY of them. Absent tmux, the host-app rail: iTerm2's exact split by
+ * session UUID (env), or a VSCodium/Cursor/VS Code integrated terminal addressed
+ * by its live-terminals id. Ghostty has no per-split addressing (no scripting
+ * dictionary), so a Ghostty-hosted session with no tmux is honestly reported
+ * un-addressable — the coarse focus-stealing window path stays behind an explicit
+ * opt-in and is never chosen by default.
+ */
+import type { ActiveSession } from '../session/active.js';
+import { getActiveSessions } from '../session/active.js';
+import type { InjectTarget } from './inject.js';
+
+/** A resolved rail, or an honest refusal. The watchdog acts only on `addressable: true`. */
+export type InjectRail = 'tmux' | 'iterm' | 'vscodium' | 'ghostty' | 'pty';
+export type InjectResolution =
+  | { addressable: true; rail: InjectRail; target: InjectTarget; note?: string }
+  | { addressable: false; reason: string };
+
+export interface ResolveOptions {
+  /**
+   * Allow the COARSE Ghostty path (raise the frontmost/opt-in window and type via
+   * System Events keystrokes — steals focus, not split-precise). Off by default:
+   * a Ghostty session with no tmux resolves to un-addressable instead.
+   */
+  allowGhosttyFocus?: boolean;
+  /**
+   * A known `agents pty` sidecar id for this session, if the caller has one. No
+   * automatic sessionId -> pty mapping exists yet, so pty is only emitted when
+   * supplied here (the lowest-precedence rail).
+   */
+  ptyId?: string;
+}
+
+/** The editor CLIs that speak the swarm-ext URI protocol, keyed by the host detectHost() reports. */
+const IDE_INJECT_VARIANTS: Record<string, { cli: string; scheme: string }> = {
+  codium: { cli: 'codium', scheme: 'vscodium' },
+  cursor: { cli: 'cursor', scheme: 'cursor' },
+  code: { cli: 'code', scheme: 'vscode' },
+};
+
+/**
+ * Resolve a target from an already-fetched ActiveSession. Pure — no I/O — so the
+ * precedence logic is unit-testable without the process table. This is where the
+ * tmux > iterm > vscodium > pty precedence and the Ghostty refusal live.
+ */
+export function resolveInjectTargetForSession(
+  session: ActiveSession,
+  opts: ResolveOptions = {},
+): InjectResolution {
+  const prov = session.provenance;
+
+  // 1. tmux — correct inside any host app, so it takes precedence whenever the
+  //    env carries a pane. (provenance.reply already encodes tmux-over-iterm.)
+  if (prov?.mux?.kind === 'tmux' && prov.mux.pane) {
+    return {
+      addressable: true,
+      rail: 'tmux',
+      target: { backend: 'tmux', pane: prov.mux.pane, socket: prov.mux.socket },
+    };
+  }
+
+  // 2. iterm — the exact split by session UUID (env-derived, focus-safe).
+  if (prov?.reply?.rail === 'iterm') {
+    return {
+      addressable: true,
+      rail: 'iterm',
+      target: { backend: 'iterm', session: prov.reply.session },
+    };
+  }
+
+  // 3. vscodium — a VSCodium/Cursor/VS Code integrated terminal, addressed by the
+  //    id the extension keys live-terminals.json on (the session UUID). Only when
+  //    the session is IDE-hosted AND we know its id.
+  const variant = session.host ? IDE_INJECT_VARIANTS[session.host] : undefined;
+  if (variant) {
+    if (!session.sessionId) {
+      return { addressable: false, reason: `IDE terminal (${session.host}) has no session id to address` };
+    }
+    return {
+      addressable: true,
+      rail: 'vscodium',
+      target: { backend: 'vscodium', terminalId: session.sessionId, cli: variant.cli, scheme: variant.scheme },
+    };
+  }
+
+  // 4. pty — lowest precedence, only when the caller supplied a sidecar id.
+  if (opts.ptyId) {
+    return { addressable: true, rail: 'pty', target: { backend: 'pty', id: opts.ptyId } };
+  }
+
+  // 5. Ghostty — no per-split addressing exists. Refuse by default; the coarse,
+  //    focus-stealing window path is opt-in only.
+  if (session.host === 'ghostty') {
+    if (opts.allowGhosttyFocus) {
+      return {
+        addressable: true,
+        rail: 'ghostty',
+        target: { backend: 'ghostty' },
+        note: 'coarse Ghostty window path (opt-in): raises a window and types into the FOCUSED split — not split-precise',
+      };
+    }
+    return { addressable: false, reason: 'un-addressable (ghostty, no tmux): no per-split addressing; watchdog skips' };
+  }
+
+  return {
+    addressable: false,
+    reason: session.host
+      ? `no precise inject rail for host '${session.host}' (no tmux/iterm/IDE terminal detected)`
+      : 'no inject rail: session is not inside tmux, iTerm, or an IDE terminal',
+  };
+}
+
+/**
+ * The single resolver the watchdog calls: sessionId -> a precise InjectTarget or
+ * an honest refusal. Fetches the active session (which carries provenance, host,
+ * and pid), then applies the pure precedence above. Returns `addressable: false`
+ * when the session isn't live / can't be found — never a guess.
+ */
+export async function resolveInjectTarget(sessionId: string, opts: ResolveOptions = {}): Promise<InjectResolution> {
+  if (!sessionId) return { addressable: false, reason: 'no sessionId given' };
+  let sessions: ActiveSession[];
+  try {
+    sessions = await getActiveSessions();
+  } catch (err) {
+    return { addressable: false, reason: `could not list active sessions: ${err instanceof Error ? err.message : String(err)}` };
+  }
+  const session = sessions.find((s) => s.sessionId === sessionId);
+  if (!session) return { addressable: false, reason: `no live session found for id ${sessionId}` };
+  return resolveInjectTargetForSession(session, opts);
+}


### PR DESCRIPTION
## Mission

Given a **stalled sessionId**, produce the exact `InjectTarget` and inject there — never the frontmost / wrong split. The merged `inject.ts` already DELIVERS to a target (PR #611); the gap was **resolution + precision**. Everything reads the agent's **inherited env** (via provenance) + the IDE's live-terminals registry (off disk) — zero cooperation from the agent.

## Starting point (quoted)

- `src/lib/session/provenance.ts` derived a precise `ReplyRail` for **tmux only** — `deriveProvenance` returned `mux?.kind === 'tmux' && mux.pane ? { rail: 'tmux', … } : null` (the old L147), and `PROVENANCE_ENV_KEYS` had no `ITERM_SESSION_ID`.
- `src/lib/terminal/inject.ts` `itermInjectScript` (old L137) opened with `'tell application "iTerm2"', '  activate'` and injected via `tell application "System Events" to keystroke …` — **focus-stealing and not split-precise** (it typed into the frontmost split).
- `ghosttyInjectScript` (old L164) matched a window by title only, via System Events keystroke.
- tmux was already precise: `tmuxSendKeysArgv` / `tmuxInjectSpecs` address a pane id + socket.

## Per-backend resolution + precision

| Rail | How resolved | Precision | Focus |
|---|---|---|---|
| **tmux** | `provenance.mux` (`$TMUX_PANE` + `$TMUX` socket) | Exact pane (`%N`) | none — `send-keys` |
| **iterm** | `provenance.reply` iterm rail (`$ITERM_SESSION_ID` UUID) | Exact split (`tell session id`) | **none** — no `activate` |
| **vscodium** | `host` ∈ {codium,cursor,code} → editor CLI + scheme; `terminalId` = sessionId (live-terminals.json key) | Exact integrated terminal | none — extension IPC |
| **ghostty** | `host === 'ghostty'` | **none possible** (no AppleScript dictionary) | — |
| **pty** | only if caller supplies a sidecar id | Exact pty | none |

**Precedence: `tmux > iterm > vscodium > pty`.** tmux wins whenever present because a `send-keys -t <pane>` reaches the pane inside *any* host app (iTerm / Ghostty / VS Code) — so a Ghostty-or-iTerm session that sits inside tmux is tmux-addressable. Absent tmux, the host-app rail applies.

### Safety rule (the choke point)

`resolveInjectTarget(sessionId)` returns a **precise** `InjectTarget` or `{ addressable: false, reason }` — **never a guess**. Ghostty degrades honestly: no per-split addressing exists, so a Ghostty session with no tmux resolves `addressable: false` (`"un-addressable (ghostty, no tmux)…"`) and the watchdog **skips + flags**. The coarse, focus-stealing window path is kept only behind an explicit `allowGhosttyFocus` opt-in.

## Changes

- **`provenance.ts`** — `ITERM_SESSION_ID` added to `PROVENANCE_ENV_KEYS`; new `parseItermSession()` (splits `wNtNpN:<UUID>` at `:`); `ReplyRail` gains `{ rail: 'iterm'; session }`; `deriveProvenance` now returns tmux-then-iterm-then-null.
- **`inject.ts`** — `itermInjectScript` rewritten to `tell session id "<uuid>" to write text` (no `activate`); Ink-safe Enter = `write text … newline no` + a separate lone CR `write text (character id 13) newline no` (mirrors the *verified* tmux/pty two-write split), `combined` fuses to one `write text`. New `vscodium` `InjectTarget` + `vscodiumInjectUri` / `vscodiumInjectSpec` — `<scheme>://swarmify.swarm-ext/inject?p=<base64url {terminalId,text,enter,combined}>` over the editor CLI's `--open-url`.
- **`resolve.ts`** (new) — pure `resolveInjectTargetForSession(session, opts)` + async `resolveInjectTarget(sessionId, opts)`.

## Dependency on PR #608 (open)

The vscodium rail delivers over the **same extension IPC #608 introduces** (`vscodium-agent.ts` `spawnUri` → editor CLI `--open-url`, base64url single-`p` payload — I mirror its encoding exactly and reuse the `swarmify.swarm-ext` authority). #608 ships the `/spawn` verb; this needs its sibling **`/inject` verb** (write into an already-open terminal by id). Until that lands in the extension, the CLI routes correctly but the extension no-ops the unknown verb. When #608 merges, the `EDITOR_VARIANTS` (cli/scheme) table should be shared rather than the small `IDE_INJECT_VARIANTS` map I added in `resolve.ts`.

## Testing

- `bun run build` (tsc) clean.
- New/updated unit tests: `provenance.test.ts` (iterm rail, tmux-over-iterm precedence, parseItermSession), `inject.test.ts` (focus-safe iterm `write text` — asserts **no `activate`**, exact `tell session id`, base64url round-trip of `&`/`=`, vscodium routing), `resolve.test.ts` (full precedence + Ghostty refusal/opt-in matrix, pure).
- **Real tmux round-trip** tests execute here (tmux installed) and pass — bytes + Enter actually land in a spawned pane.
- Full suite: **3776 pass**, only the **6 pre-existing failures on origin/main** remain (R2/keychain config cache + one token-redaction audit test — verified identical on a clean `origin/main` checkout; none import my modules).

**macOS end-to-end verification pending (human, on zion):** iTerm `write text` and the VSCodium extension IPC can't run on Linux — the AppleScript / IPC are asserted via `dryRun`. Specifically worth confirming on a Mac: whether a single `write text T` also submits under Claude's Ink TUI (the two-write CR path is the safe default regardless).