### PR TITLE
feat(watchdog): agents watchdog consumer — tick -> resolve -> inject [RUSH-1415]

### DIFF
--- a/src/commands/watchdog.ts
+++ b/src/commands/watchdog.ts
@@ -1,0 +1,243 @@
+/**
+ * `agents watchdog` — the watchdog CONSUMER (RUSH-1415).
+ *
+ * Runs the tick loop that ties the merged pieces together: list active sessions,
+ * classify stalls, read the tail, decide (deterministic promise-without-toolcall
+ * by default), run the resolver safety gate, and inject "Continue." into the EXACT
+ * split — all without the Swift menu-bar. See src/lib/watchdog/runner.ts.
+ *
+ *   agents watchdog                    one tick, dry — prints what it WOULD nudge/skip and why
+ *   agents watchdog --nudge            one tick, actually injects (explicit opt-in)
+ *   agents watchdog --watch            daemon loop (poll every --interval)
+ *   agents watchdog --json             machine-readable tick output (for the menu-bar)
+ *   agents watchdog enable|disable     flip the global auto-nudge sentinel (default OFF)
+ *   agents watchdog policy <id> <p>    per-session policy: off | keep | handsoff
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import * as fs from 'fs';
+import * as path from 'path';
+import { setHelpSections } from '../lib/help.js';
+import { parseDuration } from '../lib/hooks/cache.js';
+import { getRuntimeStateDir } from '../lib/state.js';
+import {
+  runWatchdogTick,
+  writePolicySentinel,
+  DEFAULT_THRESHOLDS,
+  type WatchdogPolicy,
+  type WatchdogThresholds,
+  type WatchdogTickResult,
+  type SessionOutcome,
+} from '../lib/watchdog/runner.js';
+
+/** Default state dir the runner and these subcommands share. */
+function stateDir(): string {
+  return path.join(getRuntimeStateDir(), 'watchdog');
+}
+
+/** Global auto-nudge sentinel — present = enabled. Default OFF (opt-in). */
+function enabledSentinelPath(): string {
+  return path.join(stateDir(), 'enabled');
+}
+function isGloballyEnabled(): boolean {
+  return fs.existsSync(enabledSentinelPath());
+}
+function setGloballyEnabled(on: boolean): void {
+  const p = enabledSentinelPath();
+  if (on) {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, 'enabled\n');
+  } else {
+    try { fs.rmSync(p); } catch { /* already off */ }
+  }
+}
+
+/** Parse a duration flag ("60s", "5m", "1h") to ms, or fall back to `fallbackMs`. */
+function durationMsOr(raw: string | undefined, fallbackMs: number): number {
+  if (raw === undefined) return fallbackMs;
+  const secs = parseDuration(raw);
+  return secs === null ? fallbackMs : secs * 1000;
+}
+
+function humanMs(ms: number): string {
+  if (ms >= 3600_000) return `${Math.round(ms / 3600_000)}h`;
+  if (ms >= 60_000) return `${Math.round(ms / 60_000)}m`;
+  return `${Math.round(ms / 1000)}s`;
+}
+
+function colorForOutcome(o: SessionOutcome): (s: string) => string {
+  if (o.injected) return chalk.green;
+  if (o.addressable === false) return chalk.yellow;
+  if (o.stall === 'stalled' && o.decision === 'nudge') return chalk.cyan;
+  return chalk.dim;
+}
+
+/** Render one tick's outcomes as a human status block. */
+function printTick(result: WatchdogTickResult, willInject: boolean): void {
+  const { counts } = result;
+  const mode = willInject ? chalk.green('nudge') : chalk.dim('dry');
+  console.log(
+    `${chalk.bold('watchdog')} ${mode}  ` +
+      `${counts.total} live · ${counts.stalled} stalled · ` +
+      `${chalk.green(String(counts.nudged))} nudged · ` +
+      `${chalk.yellow(String(counts.unaddressable))} un-addressable`,
+  );
+  for (const o of result.outcomes) {
+    const tag =
+      o.injected ? 'NUDGED'
+      : o.addressable === false ? 'FLAGGED'
+      : o.decision === 'nudge' ? 'WOULD-NUDGE'
+      : 'skip';
+    const c = colorForOutcome(o);
+    const who = o.label || o.sessionId?.slice(0, 8) || o.kind;
+    const where = o.host ? chalk.dim(`[${o.host}]`) : '';
+    const rail = o.rail ? chalk.dim(`→${o.rail}`) : '';
+    console.log(`  ${c(tag.padEnd(11))} ${chalk.bold(who)} ${where} ${rail}`);
+    console.log(`    ${chalk.dim(o.reason)}`);
+  }
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Register the `agents watchdog` command tree. */
+export function registerWatchdogCommand(program: Command): void {
+  const cmd = program
+    .command('watchdog')
+    .description('Auto-nudge stalled agent terminals: detect stalls, resolve the exact split, inject "Continue." — no menu-bar needed.')
+    .option('--nudge', 'Actually inject (default is a dry run that only reports what it would do)')
+    .option('--watch', 'Daemon loop: run a tick every --interval until interrupted')
+    .option('--interval <dur>', 'Poll interval in --watch mode (e.g. 30s, 1m)', '30s')
+    .option('--stall <dur>', 'Idle time before a session counts as stalled', humanMs(DEFAULT_THRESHOLDS.stallMs))
+    .option('--cooldown <dur>', 'Minimum time between nudges to the same session', humanMs(DEFAULT_THRESHOLDS.cooldownMs))
+    .option('--dormant <dur>', 'Idle time after which a session is left alone (dormant)', humanMs(DEFAULT_THRESHOLDS.dormantMs))
+    .option('--text <text>', 'Nudge text delivered into the terminal', 'Continue.')
+    .option('--smart', 'Use the LLM decider (agents run) instead of the deterministic path (non-reproducible)')
+    .option('--smart-agent <agent>', 'Agent the --smart decider runs as', 'claude')
+    .option('--allow-ghostty-focus', 'Permit the coarse, focus-stealing Ghostty path (off by default)')
+    .option('--json', 'Emit the tick result as JSON (for the menu-bar / scripts)')
+    .action(async (opts) => {
+      const thresholds: WatchdogThresholds = {
+        stallMs: durationMsOr(opts.stall, DEFAULT_THRESHOLDS.stallMs),
+        cooldownMs: durationMsOr(opts.cooldown, DEFAULT_THRESHOLDS.cooldownMs),
+        dormantMs: durationMsOr(opts.dormant, DEFAULT_THRESHOLDS.dormantMs),
+      };
+      // Injection gate: --nudge is the explicit per-run opt-in; the global sentinel
+      // enables the automatic daemon. Default OFF: bare `agents watchdog` is dry.
+      const globalEnabled = isGloballyEnabled();
+      const willInject = opts.nudge === true || (opts.watch === true && globalEnabled);
+
+      const tickOnce = async (): Promise<WatchdogTickResult> =>
+        runWatchdogTick({
+          nudge: willInject,
+          nudgeText: opts.text,
+          smart: opts.smart === true,
+          smartAgent: opts.smartAgent,
+          thresholds,
+          allowGhosttyFocus: opts.allowGhosttyFocus === true,
+          stateDir: stateDir(),
+        });
+
+      if (!opts.watch) {
+        const result = await tickOnce();
+        if (opts.json) console.log(JSON.stringify(result, null, 2));
+        else printTick(result, willInject);
+        return;
+      }
+
+      // Daemon loop.
+      const intervalMs = durationMsOr(opts.interval, 30_000);
+      if (!willInject && !opts.json) {
+        console.log(chalk.yellow(
+          `watchdog --watch is DETECT-ONLY (global auto-nudge is ${globalEnabled ? 'on' : 'off'}). ` +
+          `Pass --nudge or run 'agents watchdog enable' to inject.`,
+        ));
+      }
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const result = await tickOnce();
+        if (opts.json) console.log(JSON.stringify(result));
+        else printTick(result, willInject);
+        await sleep(intervalMs);
+      }
+    });
+
+  setHelpSections(cmd, {
+    examples: `
+      # One tick, dry — see what it WOULD nudge and why (safe, no injection)
+      agents watchdog
+
+      # One tick, actually inject "Continue." into stalled+addressable splits
+      agents watchdog --nudge
+
+      # Watch loop every 30s, tighter stall threshold
+      agents watchdog --watch --interval 30s --stall 60s --cooldown 5m
+
+      # Machine-readable for the menu-bar
+      agents watchdog --json
+
+      # Turn on the global auto-nudge (so --watch injects without --nudge)
+      agents watchdog enable
+
+      # Leave one session detected-but-untouched
+      agents watchdog policy <sessionId> handsoff
+    `,
+    notes: `
+      Decision path (default, deterministic): a session is nudged only when its
+      transcript tail shows it ANNOUNCED an action but no tool call followed
+      (promise-without-toolcall) AND it is not waiting on the user. Completions and
+      open questions are skipped.
+
+      Safety gate: a nudge is delivered ONLY when the resolver can name the EXACT
+      split the agent lives in (tmux / iTerm / IDE terminal). Un-addressable stalls
+      (e.g. Ghostty with no tmux) are flagged for the menu-bar and SKIPPED — never
+      a guessed or frontmost target.
+
+      Policy: global auto-nudge defaults OFF (opt-in via 'enable' or --nudge).
+      Per-session: off (ignore), keep (default), handsoff (detect + flag, never inject).
+
+      State (tray-readable): ${path.join('~/.agents/.cache/state/watchdog', '{nudges,flags,last-tick}.json')}
+    `,
+  });
+
+  // --- global enable/disable/status -----------------------------------------
+
+  cmd.command('enable')
+    .description('Turn ON global auto-nudge (so `agents watchdog --watch` injects without --nudge).')
+    .action(() => {
+      setGloballyEnabled(true);
+      console.log(chalk.green('watchdog: global auto-nudge ENABLED'));
+    });
+
+  cmd.command('disable')
+    .description('Turn OFF global auto-nudge (back to detect-only unless --nudge is passed).')
+    .action(() => {
+      setGloballyEnabled(false);
+      console.log(chalk.yellow('watchdog: global auto-nudge DISABLED'));
+    });
+
+  cmd.command('status')
+    .description('Show whether global auto-nudge is on and where state is written.')
+    .action(() => {
+      const on = isGloballyEnabled();
+      console.log(`global auto-nudge: ${on ? chalk.green('ON') : chalk.dim('off')}`);
+      console.log(`state dir: ${chalk.dim(stateDir())}`);
+    });
+
+  // --- per-session policy ----------------------------------------------------
+
+  cmd.command('policy <sessionId> <policy>')
+    .description('Set per-session policy: off (ignore) | keep (default) | handsoff (detect + flag, never inject).')
+    .action((sessionId: string, policy: string) => {
+      const p = policy.toLowerCase();
+      if (p !== 'off' && p !== 'keep' && p !== 'handsoff') {
+        console.error(chalk.red(`invalid policy '${policy}'. Use: off | keep | handsoff`));
+        process.exitCode = 1;
+        return;
+      }
+      writePolicySentinel(stateDir(), sessionId, p as WatchdogPolicy);
+      console.log(`watchdog: session ${chalk.bold(sessionId.slice(0, 8))} policy = ${chalk.cyan(p)}`);
+    });
+}

--- a/src/commands/watchdog.ts
+++ b/src/commands/watchdog.ts
@@ -126,10 +126,13 @@ export function registerWatchdogCommand(program: Command): void {
       };
       // Injection gate: --nudge is the explicit per-run opt-in; the global sentinel
       // enables the automatic daemon. Default OFF: bare `agents watchdog` is dry.
-      const globalEnabled = isGloballyEnabled();
-      const willInject = opts.nudge === true || (opts.watch === true && globalEnabled);
+      // Re-read the sentinel every tick so a running `--watch` daemon reflects a
+      // later `agents watchdog enable`/`disable` (or the Swift menu-bar toggle)
+      // from another shell without a restart.
+      const computeWillInject = (): boolean =>
+        opts.nudge === true || (opts.watch === true && isGloballyEnabled());
 
-      const tickOnce = async (): Promise<WatchdogTickResult> =>
+      const tickOnce = async (willInject: boolean): Promise<WatchdogTickResult> =>
         runWatchdogTick({
           nudge: willInject,
           nudgeText: opts.text,
@@ -141,7 +144,8 @@ export function registerWatchdogCommand(program: Command): void {
         });
 
       if (!opts.watch) {
-        const result = await tickOnce();
+        const willInject = computeWillInject();
+        const result = await tickOnce(willInject);
         if (opts.json) console.log(JSON.stringify(result, null, 2));
         else printTick(result, willInject);
         return;
@@ -149,15 +153,17 @@ export function registerWatchdogCommand(program: Command): void {
 
       // Daemon loop.
       const intervalMs = durationMsOr(opts.interval, 30_000);
-      if (!willInject && !opts.json) {
+      if (!computeWillInject() && !opts.json) {
         console.log(chalk.yellow(
-          `watchdog --watch is DETECT-ONLY (global auto-nudge is ${globalEnabled ? 'on' : 'off'}). ` +
+          `watchdog --watch is DETECT-ONLY (global auto-nudge is ${isGloballyEnabled() ? 'on' : 'off'}). ` +
           `Pass --nudge or run 'agents watchdog enable' to inject.`,
         ));
       }
       // eslint-disable-next-line no-constant-condition
       while (true) {
-        const result = await tickOnce();
+        // Re-evaluated each tick: picks up enable/disable flips mid-run.
+        const willInject = computeWillInject();
+        const result = await tickOnce(willInject);
         if (opts.json) console.log(JSON.stringify(result));
         else printTick(result, willInject);
         await sleep(intervalMs);

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,7 @@ import {
   loadAlias,
   loadPty,
   loadTmux,
+  loadWatchdog,
   loadBrowser,
   loadComputer,
   loadHosts,
@@ -934,6 +935,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadAlias);
   await reg(loadPty);
   await reg(loadTmux);
+  await reg(loadWatchdog);
   await reg(loadBrowser);
   await reg(loadComputer);
   await reg(loadHosts);

--- a/src/lib/startup/command-registry.ts
+++ b/src/lib/startup/command-registry.ts
@@ -72,6 +72,7 @@ export const loadBudget: ModuleLoader = async () => (await import('../../command
 export const loadAlias: ModuleLoader = async () => (await import('../../commands/alias.js')).registerAliasCommand;
 export const loadPty: ModuleLoader = async () => (await import('../../commands/pty.js')).registerPtyCommands;
 export const loadTmux: ModuleLoader = async () => (await import('../../commands/tmux.js')).registerTmuxCommands;
+export const loadWatchdog: ModuleLoader = async () => (await import('../../commands/watchdog.js')).registerWatchdogCommand;
 export const loadBrowser: ModuleLoader = async () => (await import('../../commands/browser.js')).registerBrowserCommand;
 export const loadComputer: ModuleLoader = async () => (await import('../../commands/computer.js')).registerComputerCommand;
 export const loadHosts: ModuleLoader = async () => (await import('../../commands/hosts.js')).registerHostsCommand;
@@ -161,6 +162,7 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   alias: [loadAlias],
   pty: [loadPty],
   tmux: [loadTmux],
+  watchdog: [loadWatchdog],
   browser: [loadBrowser],
   computer: [loadComputer],
   hosts: [loadHosts],

--- a/src/lib/watchdog/runner.test.ts
+++ b/src/lib/watchdog/runner.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for the watchdog runner (RUSH-1415) — the CONSUMER tick.
+ *
+ * Drives real synthetic ActiveSession inputs through runWatchdogTick with the I/O
+ * seams supplied (sessions, clock, tail, policy) and dryRun injection, so no live
+ * terminal is needed. The pure logic (classifyTerminal / isLikelyTrulyBlocked /
+ * resolveInjectTargetForSession) runs for real — nothing is mocked. Each case
+ * asserts the exact tick behavior: nudge fires only on promise-without-toolcall +
+ * addressable, and it SKIPS on waiting-on-user, completion, addressable:false, and
+ * within cooldown; handsoff never injects.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { ActiveSession } from '../session/active.js';
+import type { SessionProvenance, MuxLocation } from '../session/provenance.js';
+import { runWatchdogTick, DEFAULT_THRESHOLDS, type WatchdogPolicy } from './runner.js';
+
+const NOW = 1_700_000_000_000;
+const STALE_AGO = NOW - 6 * 60_000; // 6m ago: past the 5m stall, before the 1h dormant window.
+
+/** A tmux-addressable session (highest-precedence rail) whose activity is `stale`. */
+function tmuxSession(over: Partial<ActiveSession> & { mux?: MuxLocation } = {}): ActiveSession {
+  const provenance: SessionProvenance = {
+    host: 'zion',
+    transport: 'local',
+    mux: over.mux ?? { kind: 'tmux', pane: '%3', socket: '/tmp/s' },
+    reply: { rail: 'tmux', target: '%3', socket: '/tmp/s' },
+  };
+  return {
+    context: 'terminal',
+    kind: 'claude',
+    host: over.host ?? 'iterm',
+    sessionId: over.sessionId ?? 'sess-tmux',
+    status: 'idle',
+    startedAtMs: over.startedAtMs ?? STALE_AGO, // defaultLastActivity falls back to this (no transcript file)
+    provenance,
+    ...over,
+  };
+}
+
+/** A Ghostty session with NO tmux — the resolver reports it un-addressable. */
+function ghosttySession(over: Partial<ActiveSession> = {}): ActiveSession {
+  return {
+    context: 'terminal',
+    kind: 'claude',
+    host: 'ghostty',
+    sessionId: over.sessionId ?? 'sess-ghostty',
+    status: 'idle',
+    startedAtMs: STALE_AGO,
+    provenance: { host: 'zion', transport: 'local', reply: null },
+    ...over,
+  };
+}
+
+// A Claude assistant turn that ANNOUNCES an action with no tool call after it —
+// the promise-without-toolcall signal isLikelyTrulyBlocked looks for.
+const PROMISE_TAIL = [
+  '{"type":"user","message":{"role":"user","content":[{"type":"text","text":"add the flag"}]}}',
+  '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Let me run the tests now."}]}}',
+];
+// A completed turn — COMPLETION_HINTS ("finished") make isLikelyTrulyBlocked refuse.
+const DONE_TAIL = [
+  '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"The feature is finished and pushed."}]}}',
+];
+
+let stateDir: string;
+beforeEach(() => {
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'watchdog-runner-'));
+});
+afterEach(() => {
+  try { fs.rmSync(stateDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+function readLedger(): Record<string, number> {
+  try { return JSON.parse(fs.readFileSync(path.join(stateDir, 'nudges.json'), 'utf8')); } catch { return {}; }
+}
+function readFlags(): Record<string, { reason: string; host?: string; atMs: number }> {
+  try { return JSON.parse(fs.readFileSync(path.join(stateDir, 'flags.json'), 'utf8')); } catch { return {}; }
+}
+
+describe('runWatchdogTick — nudge fires', () => {
+  it('injects on promise-without-toolcall + addressable, and records the cooldown', async () => {
+    const s = tmuxSession();
+    const result = await runWatchdogTick({
+      sessions: [s], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
+      tailFor: () => PROMISE_TAIL,
+    });
+
+    const o = result.outcomes[0];
+    expect(o.stall).toBe('stalled');
+    expect(o.decision).toBe('nudge');
+    expect(o.addressable).toBe(true);
+    expect(o.rail).toBe('tmux');
+    expect(o.injected).toBe(true);
+    expect(o.nudgeText).toBe('Continue.');
+    expect(result.counts.nudged).toBe(1);
+    // Cooldown ledger updated so the next tick within cooldownMs is rate-limited.
+    expect(readLedger()['sess-tmux']).toBe(NOW);
+  });
+
+  it('honors a custom nudge text', async () => {
+    const result = await runWatchdogTick({
+      sessions: [tmuxSession()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
+      nudgeText: 'Keep going.', tailFor: () => PROMISE_TAIL,
+    });
+    expect(result.outcomes[0].injected).toBe(true);
+    expect(result.outcomes[0].nudgeText).toBe('Keep going.');
+  });
+});
+
+describe('runWatchdogTick — skips (no nudge)', () => {
+  it('SKIPS a session waiting on the user (AskUserQuestion), even if stalled', async () => {
+    const s = tmuxSession({ activity: 'waiting_input', awaitingReason: 'question' });
+    const result = await runWatchdogTick({
+      sessions: [s], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
+      tailFor: () => PROMISE_TAIL, // promise present, but activity=waiting_input wins
+    });
+    const o = result.outcomes[0];
+    expect(o.decision).toBe('skip');
+    expect(o.injected).toBeUndefined();
+    expect(o.reason).toMatch(/waiting on user/i);
+    expect(readLedger()['sess-tmux']).toBeUndefined();
+  });
+
+  it('SKIPS a completed session (no promise-without-toolcall)', async () => {
+    const result = await runWatchdogTick({
+      sessions: [tmuxSession()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
+      tailFor: () => DONE_TAIL,
+    });
+    const o = result.outcomes[0];
+    expect(o.stall).toBe('stalled');
+    expect(o.decision).toBe('skip');
+    expect(o.injected).toBeUndefined();
+    expect(result.counts.nudged).toBe(0);
+  });
+
+  it('SKIPS and FLAGS an un-addressable stall (ghostty, no tmux) — never injects a guessed target', async () => {
+    const result = await runWatchdogTick({
+      sessions: [ghosttySession()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
+      tailFor: () => PROMISE_TAIL,
+    });
+    const o = result.outcomes[0];
+    expect(o.decision).toBe('skip');
+    expect(o.addressable).toBe(false);
+    expect(o.injected).toBeUndefined();
+    expect(o.reason).toMatch(/un-addressable/i);
+    expect(result.counts.unaddressable).toBe(1);
+    // Flagged for the menu-bar to surface.
+    const flags = readFlags();
+    expect(flags['sess-ghostty']).toBeDefined();
+    expect(flags['sess-ghostty'].host).toBe('ghostty');
+    // Nothing delivered → no cooldown entry.
+    expect(readLedger()['sess-ghostty']).toBeUndefined();
+  });
+
+  it('SKIPS within cooldown (rate-limited by a recent nudge)', async () => {
+    // Seed a nudge 1 minute ago — inside the 20m default cooldown.
+    fs.writeFileSync(path.join(stateDir, 'nudges.json'), JSON.stringify({ 'sess-tmux': NOW - 60_000 }));
+    const result = await runWatchdogTick({
+      sessions: [tmuxSession()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
+      tailFor: () => PROMISE_TAIL,
+    });
+    const o = result.outcomes[0];
+    expect(o.stall).toBe('rate_limited');
+    expect(o.decision).toBe('skip');
+    expect(o.injected).toBeUndefined();
+    // The seeded timestamp is untouched (no re-nudge).
+    expect(readLedger()['sess-tmux']).toBe(NOW - 60_000);
+  });
+
+  it('handsoff policy: detects + flags a nudge-worthy stall but NEVER injects', async () => {
+    const policyFor = (): WatchdogPolicy => 'handsoff';
+    const result = await runWatchdogTick({
+      sessions: [tmuxSession()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
+      tailFor: () => PROMISE_TAIL, policyFor,
+    });
+    const o = result.outcomes[0];
+    expect(o.policy).toBe('handsoff');
+    expect(o.decision).toBe('nudge');       // it WOULD nudge...
+    expect(o.addressable).toBe(true);
+    expect(o.injected).toBe(false);          // ...but never does
+    expect(o.reason).toMatch(/handsoff/i);
+    expect(readLedger()['sess-tmux']).toBeUndefined();
+  });
+
+  it('policy off: fully opted out, not even classified as stalled', async () => {
+    const result = await runWatchdogTick({
+      sessions: [tmuxSession()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
+      tailFor: () => PROMISE_TAIL, policyFor: () => 'off',
+    });
+    const o = result.outcomes[0];
+    expect(o.stall).toBe('opted_out');
+    expect(o.decision).toBe('skip');
+    expect(o.injected).toBeUndefined();
+  });
+});
+
+describe('runWatchdogTick — dry run (default, no --nudge)', () => {
+  it('reports WOULD-nudge without injecting or touching the cooldown', async () => {
+    const result = await runWatchdogTick({
+      sessions: [tmuxSession()], nowMs: NOW, nudge: false, injectDryRun: true, stateDir,
+      tailFor: () => PROMISE_TAIL,
+    });
+    const o = result.outcomes[0];
+    expect(o.decision).toBe('nudge');
+    expect(o.addressable).toBe(true);
+    expect(o.injected).toBe(false);
+    expect(o.reason).toMatch(/would nudge/i);
+    expect(result.didNudge).toBe(false);
+    expect(readLedger()['sess-tmux']).toBeUndefined();
+  });
+});
+
+describe('runWatchdogTick — active / not-yet-stalled', () => {
+  it('SKIPS an active session (recent activity)', async () => {
+    const s = tmuxSession({ startedAtMs: NOW - 5_000 }); // 5s ago — well under the stall threshold
+    const result = await runWatchdogTick({
+      sessions: [s], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
+      tailFor: () => PROMISE_TAIL,
+    });
+    const o = result.outcomes[0];
+    expect(o.stall).toBe('active');
+    expect(o.decision).toBe('skip');
+    expect(o.injected).toBeUndefined();
+    // Sanity: the default stall threshold is 5m, so 5s is active.
+    expect(DEFAULT_THRESHOLDS.stallMs).toBe(300_000);
+  });
+
+  it('SKIPS a session with no session id (cannot address or track)', async () => {
+    const s = tmuxSession({ sessionId: undefined });
+    const result = await runWatchdogTick({
+      sessions: [s], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
+      tailFor: () => PROMISE_TAIL,
+    });
+    expect(result.outcomes[0].decision).toBe('skip');
+    expect(result.outcomes[0].reason).toMatch(/no session id/i);
+  });
+});

--- a/src/lib/watchdog/runner.test.ts
+++ b/src/lib/watchdog/runner.test.ts
@@ -19,6 +19,7 @@ import { runWatchdogTick, DEFAULT_THRESHOLDS, type WatchdogPolicy } from './runn
 
 const NOW = 1_700_000_000_000;
 const STALE_AGO = NOW - 6 * 60_000; // 6m ago: past the 5m stall, before the 1h dormant window.
+const FORCE_REVIEW_AGO = NOW - 20 * 60_000; // 20m ago: PAST the 15m FORCE_REVIEW_STALL_MS, still under the 1h dormant window.
 
 /** A tmux-addressable session (highest-precedence rail) whose activity is `stale`. */
 function tmuxSession(over: Partial<ActiveSession> & { mux?: MuxLocation } = {}): ActiveSession {
@@ -136,6 +137,26 @@ describe('runWatchdogTick — skips (no nudge)', () => {
     expect(result.counts.nudged).toBe(0);
   });
 
+  it('SKIPS a completed session even PAST the 15m force-review window (never nudges a finished session)', async () => {
+    // Regression: isLikelyTrulyBlocked short-circuits to `true` at >=15m stall
+    // (FORCE_REVIEW_STALL_MS) BEFORE its completion check, so the deterministic
+    // path must screen completions out itself. This session is idle 20m with a
+    // "finished" tail — it must still be skipped, not injected with "Continue.".
+    const s = tmuxSession({ startedAtMs: FORCE_REVIEW_AGO });
+    const result = await runWatchdogTick({
+      sessions: [s], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
+      tailFor: () => DONE_TAIL,
+    });
+    const o = result.outcomes[0];
+    expect(o.stall).toBe('stalled');
+    expect(o.stalledForMs).toBeGreaterThanOrEqual(15 * 60_000); // past FORCE_REVIEW
+    expect(o.decision).toBe('skip');
+    expect(o.injected).toBeUndefined();
+    expect(o.reason).toMatch(/completion/i);
+    expect(result.counts.nudged).toBe(0);
+    expect(readLedger()['sess-tmux']).toBeUndefined();
+  });
+
   it('SKIPS and FLAGS an un-addressable stall (ghostty, no tmux) — never injects a guessed target', async () => {
     const result = await runWatchdogTick({
       sessions: [ghosttySession()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
@@ -183,6 +204,11 @@ describe('runWatchdogTick — skips (no nudge)', () => {
     expect(o.injected).toBe(false);          // ...but never does
     expect(o.reason).toMatch(/handsoff/i);
     expect(readLedger()['sess-tmux']).toBeUndefined();
+    // Flagged for the tray to surface "would-nudge but hands-off".
+    const flags = readFlags();
+    expect(flags['sess-tmux']).toBeDefined();
+    expect(flags['sess-tmux'].reason).toMatch(/hands-off/i);
+    expect(flags['sess-tmux'].host).toBe('iterm');
   });
 
   it('policy off: fully opted out, not even classified as stalled', async () => {

--- a/src/lib/watchdog/runner.ts
+++ b/src/lib/watchdog/runner.ts
@@ -1,0 +1,442 @@
+/**
+ * Watchdog runner — the CONSUMER that wires the merged pure pieces into a
+ * working auto-nudge (RUSH-1415). The `agents watchdog` command drives it, so
+ * the whole loop runs WITHOUT the Swift menu-bar.
+ *
+ * One tick, per session:
+ *
+ *   getActiveSessions()                            (session/active.ts)
+ *     -> classifyTerminal(...)                     (watchdog/watchdog.ts)  — stalled?
+ *       -> readWatchdogTail(...)                   (watchdog/read.ts)      — the transcript tail
+ *         -> isLikelyTrulyBlocked(...)             (watchdog/watchdog.ts)  — promise-without-toolcall, NOT waiting-on-user
+ *           -> resolveInjectTargetForSession(...)  (terminal/resolve.ts)   — THE safety gate: addressable or an honest refusal
+ *             -> injectIntoTerminal(target,text)   (terminal/inject.ts)    — deliver "Continue." into the EXACT split
+ *
+ * The safety gate is absolute: a nudge is delivered ONLY when the resolver
+ * returns `addressable: true`. On `addressable: false` the reason is recorded to
+ * a state file the menu-bar can surface later and the session is SKIPPED — never
+ * a guessed / frontmost target.
+ *
+ * Persistence (all under ~/.agents/.cache/state/watchdog/, tray-readable):
+ *   - nudges.json  — { [sessionId]: lastNudgeMs } — enforces the cooldown.
+ *   - flags.json   — { [sessionId]: { reason, host, atMs } } — un-addressable stalls.
+ *   - last-tick.json — the full outcome list from the most recent tick.
+ *   - policy/<sessionId> — per-session sentinel: off | keep | handsoff.
+ *
+ * The pure logic (classifyTerminal / isLikelyTrulyBlocked) is imported and never
+ * re-implemented; the runner only supplies its I/O (sessions, tails, clock,
+ * policy, injection) — each an injectable seam so runner.test.ts drives real
+ * synthetic sessions without a live terminal.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ActiveSession } from '../session/active.js';
+import { getActiveSessions } from '../session/active.js';
+import {
+  resolveInjectTargetForSession,
+  type InjectResolution,
+  type InjectRail,
+} from '../terminal/resolve.js';
+import { injectIntoTerminal, type InjectResult } from '../terminal/inject.js';
+import {
+  classifyTerminal,
+  isLikelyTrulyBlocked,
+  renderWatchdogPrompt,
+  parseWatchdogResponse,
+  type StallStatus,
+  type WatchdogCandidate,
+} from './watchdog.js';
+import {
+  readWatchdogTail,
+  WATCHDOG_STALL_MS,
+  WATCHDOG_COOLDOWN_MS,
+  WATCHDOG_DORMANT_MS,
+  WATCHDOG_TAIL_LINES,
+} from './read.js';
+import { getRuntimeStateDir } from '../state.js';
+
+/** Per-session policy sentinel. `keep` is the default (watchdog may nudge). */
+export type WatchdogPolicy = 'off' | 'keep' | 'handsoff';
+
+/** Stall / cooldown / dormant thresholds (ms). Defaults mirror read.ts. */
+export interface WatchdogThresholds {
+  stallMs: number;
+  cooldownMs: number;
+  dormantMs: number;
+}
+
+export const DEFAULT_THRESHOLDS: WatchdogThresholds = {
+  stallMs: WATCHDOG_STALL_MS,
+  cooldownMs: WATCHDOG_COOLDOWN_MS,
+  dormantMs: WATCHDOG_DORMANT_MS,
+};
+
+/** The default nudge text — a short imperative, configurable via opts.nudgeText. */
+export const DEFAULT_NUDGE_TEXT = 'Continue.';
+
+export interface WatchdogTickOptions {
+  /** Actually inject when a nudge is decided. Default false (dry status). */
+  nudge?: boolean;
+  /** Nudge text delivered into the terminal. Default "Continue." */
+  nudgeText?: string;
+  /**
+   * Use the LLM decider (`agents run`) to decide + choose nudge text instead of
+   * the deterministic promise-without-toolcall path. Default false so ticks are
+   * reproducible. Best-effort: a decider failure falls back to skip.
+   */
+  smart?: boolean;
+  /** Agent the smart decider runs as. Default 'claude'. */
+  smartAgent?: string;
+  /** Threshold overrides. Missing fields fall back to DEFAULT_THRESHOLDS. */
+  thresholds?: Partial<WatchdogThresholds>;
+  /** Permit the coarse, focus-stealing Ghostty path. Off by default. */
+  allowGhosttyFocus?: boolean;
+  /** Pass dryRun through to injectIntoTerminal (tests set true — no real terminal). */
+  injectDryRun?: boolean;
+
+  // --- injectable I/O seams (production defaults resolve the real thing) ---
+  /** Session list. Default getActiveSessions(). Tests pass synthetic sessions. */
+  sessions?: ActiveSession[];
+  /** Clock. Default Date.now(). Tests pin it. */
+  nowMs?: number;
+  /** Override the state directory (tests point at a tmpdir). */
+  stateDir?: string;
+  /** lastActivity (ms) for a session. Default = its transcript mtime. */
+  lastActivityFor?: (s: ActiveSession) => number | undefined;
+  /** Transcript tail lines for a session. Default readWatchdogTail(). */
+  tailFor?: (s: ActiveSession) => string[];
+  /** Per-session policy. Default = the on-disk sentinel. */
+  policyFor?: (s: ActiveSession) => WatchdogPolicy;
+}
+
+/** What the tick decided for a single session — the row `--json` / the tray reads. */
+export interface SessionOutcome {
+  sessionId?: string;
+  kind: string;
+  host?: string;
+  cwd?: string;
+  label?: string;
+  /** classifyTerminal's verdict for this session. */
+  stall: StallStatus['kind'];
+  /** stalled duration (ms), when stalled. */
+  stalledForMs?: number;
+  policy: WatchdogPolicy;
+  decision: 'nudge' | 'skip';
+  reason: string;
+  /** The resolved rail, when addressable. */
+  rail?: InjectRail;
+  /** True when resolveInjectTarget said addressable (only meaningful once we'd nudge). */
+  addressable?: boolean;
+  /** True when a nudge was actually delivered this tick. */
+  injected?: boolean;
+  /** The text that was (or would be) delivered. */
+  nudgeText?: string;
+}
+
+export interface WatchdogTickResult {
+  atMs: number;
+  /** Whether this tick was allowed to inject (opts.nudge). */
+  didNudge: boolean;
+  outcomes: SessionOutcome[];
+  /** Convenience counts for the menu-bar / status line. */
+  counts: {
+    total: number;
+    stalled: number;
+    nudged: number;
+    unaddressable: number;
+    skipped: number;
+  };
+}
+
+// --- state persistence ------------------------------------------------------
+
+function watchdogStateDir(opts: WatchdogTickOptions): string {
+  return opts.stateDir ?? path.join(getRuntimeStateDir(), 'watchdog');
+}
+
+function readJsonFile<T>(file: string, fallback: T): T {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8')) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJsonFile(file: string, value: unknown): void {
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify(value, null, 2));
+  } catch {
+    /* best-effort: the tray tolerates a missing/partial state file */
+  }
+}
+
+/** Last-nudge timestamps keyed by sessionId (the cooldown ledger). */
+function readNudgeLedger(dir: string): Record<string, number> {
+  return readJsonFile<Record<string, number>>(path.join(dir, 'nudges.json'), {});
+}
+
+/**
+ * On-disk per-session policy sentinel: `<stateDir>/policy/<sessionId>` whose
+ * contents are `off` | `keep` | `handsoff`. Absent / unreadable / unknown → keep.
+ */
+export function readPolicySentinel(dir: string, sessionId: string): WatchdogPolicy {
+  if (!sessionId) return 'keep';
+  let raw: string;
+  try {
+    raw = fs.readFileSync(path.join(dir, 'policy', sessionId), 'utf8').trim().toLowerCase();
+  } catch {
+    return 'keep';
+  }
+  return raw === 'off' || raw === 'handsoff' ? raw : 'keep';
+}
+
+/** Write a per-session policy sentinel (used by the CLI `agents watchdog policy`). */
+export function writePolicySentinel(dir: string, sessionId: string, policy: WatchdogPolicy): void {
+  const file = path.join(dir, 'policy', sessionId);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, policy + '\n');
+}
+
+// --- helpers ----------------------------------------------------------------
+
+function defaultLastActivity(s: ActiveSession): number | undefined {
+  if (s.sessionFile) {
+    try {
+      return fs.statSync(s.sessionFile).mtimeMs;
+    } catch {
+      /* file vanished */
+    }
+  }
+  return s.startedAtMs;
+}
+
+/**
+ * The deterministic v1 decision: nudge only when the tail shows a
+ * promise-without-toolcall (isLikelyTrulyBlocked) AND the session is not waiting
+ * on the user. isLikelyTrulyBlocked already refuses on WAITING/COMPLETION hints;
+ * the state engine's `waiting_input` activity is an extra, stronger guard against
+ * typing over an open AskUserQuestion.
+ */
+/** A decide result shared by the deterministic and smart paths. `text` overrides the default nudge text. */
+interface NudgeDecision {
+  nudge: boolean;
+  reason: string;
+  text?: string;
+}
+
+function deterministicDecision(
+  session: ActiveSession,
+  candidate: WatchdogCandidate,
+): NudgeDecision {
+  if (session.activity === 'waiting_input') {
+    return { nudge: false, reason: `waiting on user${session.awaitingReason ? ` (${session.awaitingReason})` : ''}` };
+  }
+  if (isLikelyTrulyBlocked(candidate)) {
+    return { nudge: true, reason: 'stalled after announcing an action with no follow-through' };
+  }
+  return { nudge: false, reason: 'no promise-without-toolcall signal in tail (completion / question / unclear)' };
+}
+
+/**
+ * The optional LLM decider. Shells out to `agents run <agent>` with the watchdog
+ * prompt and parses its JSON verdict. Best-effort and NON-deterministic — the
+ * default path is deterministicDecision. Isolated here so the tick stays pure
+ * over its seams; the command layer opts in with --smart.
+ */
+async function smartDecision(
+  candidate: WatchdogCandidate,
+  agent: string,
+): Promise<NudgeDecision> {
+  const prompt = renderWatchdogPrompt([candidate]);
+  try {
+    const { execFile } = await import('child_process');
+    const { promisify } = await import('util');
+    const execFileAsync = promisify(execFile);
+    const { stdout } = await execFileAsync('agents', ['run', agent, '--mode', 'plan', prompt], {
+      encoding: 'utf8',
+      maxBuffer: 4 * 1024 * 1024,
+      timeout: 120_000,
+    });
+    const decisions = parseWatchdogResponse(stdout);
+    const d = decisions.find((x) => x.terminalId === candidate.terminalId) ?? decisions[0];
+    if (!d) return { nudge: false, reason: 'smart decider returned no verdict' };
+    return { nudge: d.action === 'nudge', reason: d.reason || `smart: ${d.action}`, text: d.text || undefined };
+  } catch (err) {
+    return { nudge: false, reason: `smart decider unavailable: ${err instanceof Error ? err.message : String(err)}` };
+  }
+}
+
+// --- the tick ---------------------------------------------------------------
+
+/**
+ * Run ONE watchdog pass. Returns a structured outcome per live session; injects
+ * only when `opts.nudge` is set AND the safety gate says addressable AND policy
+ * permits. Persists the cooldown ledger, un-addressable flags, and a last-tick
+ * snapshot to the tray-readable state dir.
+ */
+export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<WatchdogTickResult> {
+  const nowMs = opts.nowMs ?? Date.now();
+  const nudgeText = opts.nudgeText ?? DEFAULT_NUDGE_TEXT;
+  const thresholds: WatchdogThresholds = { ...DEFAULT_THRESHOLDS, ...opts.thresholds };
+  const dir = watchdogStateDir(opts);
+  const lastActivityFor = opts.lastActivityFor ?? defaultLastActivity;
+  const tailFor = opts.tailFor ?? ((s) => (s.sessionId ? readWatchdogTail(s.sessionId, s.kind, WATCHDOG_TAIL_LINES) : []));
+  const policyFor = opts.policyFor ?? ((s) => (s.sessionId ? readPolicySentinel(dir, s.sessionId) : 'keep'));
+
+  const sessions = opts.sessions ?? (await getActiveSessions());
+  const ledger = readNudgeLedger(dir);
+  const flags: Record<string, { reason: string; host?: string; atMs: number }> = {};
+  const outcomes: SessionOutcome[] = [];
+
+  for (const session of sessions) {
+    const policy = policyFor(session);
+    const base: SessionOutcome = {
+      sessionId: session.sessionId,
+      kind: session.kind,
+      host: session.host,
+      cwd: session.cwd,
+      label: session.label,
+      policy,
+      stall: 'active',
+      decision: 'skip',
+      reason: '',
+      nudgeText,
+    };
+
+    // A session with no id can neither be addressed nor cooldown-tracked.
+    if (!session.sessionId) {
+      outcomes.push({ ...base, reason: 'no session id (cannot address or track)' });
+      continue;
+    }
+    // `off` = fully opted out. classifyTerminal short-circuits to opted_out too,
+    // but we report the policy reason explicitly.
+    if (policy === 'off') {
+      outcomes.push({ ...base, stall: 'opted_out', reason: 'policy: off (opted out)' });
+      continue;
+    }
+
+    const lastActivityMs = lastActivityFor(session);
+    if (lastActivityMs === undefined) {
+      outcomes.push({ ...base, reason: 'no activity timestamp (no transcript / start time)' });
+      continue;
+    }
+
+    const status = classifyTerminal({
+      lastActivityMs,
+      nowMs,
+      lastNudgeMs: ledger[session.sessionId] ?? null,
+      optedOut: false,
+      stallMs: thresholds.stallMs,
+      cooldownMs: thresholds.cooldownMs,
+      dormantMs: thresholds.dormantMs,
+    });
+    base.stall = status.kind;
+
+    if (status.kind !== 'stalled') {
+      const reason =
+        status.kind === 'active' ? `active (last activity ${Math.round((nowMs - lastActivityMs) / 1000)}s ago)`
+        : status.kind === 'dormant' ? 'dormant (idle past the dormant window)'
+        : status.kind === 'rate_limited' ? `cooling down (${Math.round(status.cooldownRemainingMs / 1000)}s left)`
+        : 'opted out';
+      outcomes.push({ ...base, reason });
+      continue;
+    }
+
+    base.stalledForMs = status.stalledForMs;
+
+    // Stalled — read the tail and decide.
+    const tailLines = tailFor(session);
+    const candidate: WatchdogCandidate = {
+      terminalId: session.sessionId,
+      agentType: (session.kind === 'codex' || session.kind === 'gemini' ? session.kind : 'claude'),
+      tailLines,
+      stalledForMs: status.stalledForMs,
+    };
+
+    const decision: NudgeDecision = opts.smart
+      ? await smartDecision(candidate, opts.smartAgent ?? 'claude')
+      : deterministicDecision(session, candidate);
+    const chosenText = decision.text ?? nudgeText;
+
+    if (!decision.nudge) {
+      outcomes.push({ ...base, decision: 'skip', reason: decision.reason });
+      continue;
+    }
+
+    // A nudge is warranted — run it past the safety gate BEFORE any delivery.
+    const resolution: InjectResolution = resolveInjectTargetForSession(session, {
+      allowGhosttyFocus: opts.allowGhosttyFocus,
+    });
+
+    if (!resolution.addressable) {
+      // Flag the un-addressable stall for the tray; NEVER guess a target.
+      flags[session.sessionId] = { reason: resolution.reason, host: session.host, atMs: nowMs };
+      outcomes.push({
+        ...base, decision: 'skip', addressable: false,
+        reason: `nudge-worthy but un-addressable — ${resolution.reason}`,
+        nudgeText: chosenText,
+      });
+      continue;
+    }
+
+    // handsoff = detect + flag, but never inject.
+    if (policy === 'handsoff') {
+      outcomes.push({
+        ...base, decision: 'nudge', addressable: true, rail: resolution.rail, injected: false,
+        reason: `handsoff: flagged, not injected (would nudge via ${resolution.rail})`,
+        nudgeText: chosenText,
+      });
+      continue;
+    }
+
+    // Dry status (no --nudge): report what WOULD happen, deliver nothing.
+    if (!opts.nudge) {
+      outcomes.push({
+        ...base, decision: 'nudge', addressable: true, rail: resolution.rail, injected: false,
+        reason: `would nudge via ${resolution.rail} (dry — pass --nudge to inject)`,
+        nudgeText: chosenText,
+      });
+      continue;
+    }
+
+    // Deliver into the EXACT resolved split.
+    let result: InjectResult;
+    try {
+      result = await injectIntoTerminal(resolution.target, chosenText, { dryRun: opts.injectDryRun });
+    } catch (err) {
+      result = { ok: false, backend: resolution.target.backend, writes: 0, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    if (result.ok) {
+      ledger[session.sessionId] = nowMs; // start the cooldown clock
+      outcomes.push({
+        ...base, decision: 'nudge', addressable: true, rail: resolution.rail, injected: true,
+        reason: `nudged via ${resolution.rail}`,
+        nudgeText: chosenText,
+      });
+    } else {
+      outcomes.push({
+        ...base, decision: 'skip', addressable: true, rail: resolution.rail, injected: false,
+        reason: `inject failed via ${resolution.rail}: ${result.error ?? 'unknown error'}`,
+        nudgeText: chosenText,
+      });
+    }
+  }
+
+  // Persist the tray-readable state.
+  writeJsonFile(path.join(dir, 'nudges.json'), ledger);
+  writeJsonFile(path.join(dir, 'flags.json'), flags);
+
+  const counts = {
+    total: outcomes.length,
+    stalled: outcomes.filter((o) => o.stall === 'stalled').length,
+    nudged: outcomes.filter((o) => o.injected).length,
+    unaddressable: outcomes.filter((o) => o.addressable === false).length,
+    skipped: outcomes.filter((o) => o.decision === 'skip').length,
+  };
+  const result: WatchdogTickResult = { atMs: nowMs, didNudge: opts.nudge === true, outcomes, counts };
+  writeJsonFile(path.join(dir, 'last-tick.json'), result);
+  return result;
+}

--- a/src/lib/watchdog/runner.ts
+++ b/src/lib/watchdog/runner.ts
@@ -226,12 +226,34 @@ interface NudgeDecision {
   text?: string;
 }
 
+/**
+ * Minimal local mirror of COMPLETION_HINTS in watchdog.ts:42-47. We cannot lean
+ * on isLikelyTrulyBlocked to screen completions out: its FORCE_REVIEW_STALL_MS
+ * short-circuit (watchdog.ts:171 — `stalledForMs >= 15m` returns true) fires
+ * BEFORE its own COMPLETION_HINTS check (watchdog.ts:176), so a session idle
+ * 15m-60m whose tail says "done"/"finished" would be reported as blocked. Keep
+ * this list in sync with the core.
+ */
+const COMPLETION_HINTS = ['done', 'completed', 'all set', 'finished'];
+
+function tailShowsCompletion(candidate: WatchdogCandidate): boolean {
+  if (candidate.tailLines.length === 0) return false;
+  const lowerTail = candidate.tailLines.join('\n').toLowerCase();
+  return COMPLETION_HINTS.some((hint) => lowerTail.includes(hint));
+}
+
 function deterministicDecision(
   session: ActiveSession,
   candidate: WatchdogCandidate,
 ): NudgeDecision {
   if (session.activity === 'waiting_input') {
     return { nudge: false, reason: `waiting on user${session.awaitingReason ? ` (${session.awaitingReason})` : ''}` };
+  }
+  // Completion is checked EXPLICITLY here — never nudge a finished session, even
+  // past the 15m force-review window where isLikelyTrulyBlocked would return true
+  // before reaching its completion check (see COMPLETION_HINTS note above).
+  if (tailShowsCompletion(candidate)) {
+    return { nudge: false, reason: 'tail shows completion (done / finished / all set) — skip regardless of stall age' };
   }
   if (isLikelyTrulyBlocked(candidate)) {
     return { nudge: true, reason: 'stalled after announcing an action with no follow-through' };
@@ -310,8 +332,9 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
       outcomes.push({ ...base, reason: 'no session id (cannot address or track)' });
       continue;
     }
-    // `off` = fully opted out. classifyTerminal short-circuits to opted_out too,
-    // but we report the policy reason explicitly.
+    // `off` = fully opted out. We short-circuit here rather than relying on
+    // classifyTerminal (which is always called with optedOut: false below), so the
+    // policy reason is reported explicitly.
     if (policy === 'off') {
       outcomes.push({ ...base, stall: 'opted_out', reason: 'policy: off (opted out)' });
       continue;
@@ -381,8 +404,14 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
       continue;
     }
 
-    // handsoff = detect + flag, but never inject.
+    // handsoff = detect + flag, but never inject. Record a flag so the tray can
+    // surface "would-nudge but hands-off" alongside the un-addressable flags.
     if (policy === 'handsoff') {
+      flags[session.sessionId] = {
+        reason: `handsoff: would nudge via ${resolution.rail} but policy is hands-off`,
+        host: session.host,
+        atMs: nowMs,
+      };
       outcomes.push({
         ...base, decision: 'nudge', addressable: true, rail: resolution.rail, injected: false,
         reason: `handsoff: flagged, not injected (would nudge via ${resolution.rail})`,


### PR DESCRIPTION
## What

Builds the **watchdog consumer** — the tick that wires the already-merged pieces (#611 `injectIntoTerminal`, #612 watchdog core, #616 `resolveInjectTarget`) into a working auto-nudge, runnable as `agents watchdog` **without the Swift menu-bar**. Until now `src/lib/watchdog/` was pure logic with no caller.

## The tick pipeline

`src/lib/watchdog/runner.ts` → `runWatchdogTick()`, one pass per invocation:

1. **List** — `getActiveSessions()` (`src/lib/session/active.ts:607`) for the live session set (provenance, host, activity, cwd).
2. **Classify** — `classifyTerminal()` (`src/lib/watchdog/watchdog.ts:84`) → `active` / `dormant` / `rate_limited` / `stalled`. Last-activity = transcript mtime, cooldown from the persisted ledger.
3. **Read tail** — `readWatchdogTail()` (`src/lib/watchdog/read.ts:154`) for stalled sessions.
4. **Decide (deterministic v1 default)** — nudge only when `isLikelyTrulyBlocked()` (`src/lib/watchdog/watchdog.ts:170`) sees a **promise-without-toolcall** AND the session isn't waiting on the user. The state engine's `activity === 'waiting_input'` is an extra guard (`runner.ts` `deterministicDecision`); completions/questions are skipped. `--smart` optionally spawns `agents run` with `renderWatchdogPrompt`/`parseWatchdogResponse` to decide + pick nudge text, but the default stays reproducible.
5. **Resolve — the safety gate** — `resolveInjectTargetForSession()` (`src/lib/terminal/resolve.ts:62`). A nudge is delivered **only** on `addressable: true`. On `addressable: false` the reason is written to a tray-readable flag file and the session is **skipped** — never a guessed/frontmost target.
6. **Inject** — `injectIntoTerminal(target, "Continue.")` (`src/lib/terminal/inject.ts:300`) into the exact split. Honors cooldown via the persisted per-session ledger.

## Safety gate (skip on `addressable:false`)

`resolveInjectTargetForSession` returns `{ addressable: false, reason }` for anything it can't precisely address (e.g. Ghostty with no tmux, `resolve.ts:118`). The runner records `{ reason, host, atMs }` to `flags.json` and skips. Verified live on this box: a headless session surfaced as `FLAGGED  no inject rail: session is not inside tmux, iTerm, or an IDE terminal`, `unaddressable: 1`, zero injections.

State (all under `~/.agents/.cache/state/watchdog/`, menu-bar can read):
- `nudges.json` — `{ [sessionId]: lastNudgeMs }` (the cooldown ledger)
- `flags.json` — un-addressable stalls for the tray
- `last-tick.json` — the full outcome list
- `policy/<sessionId>` — the per-session sentinel

## Policy model

- **Global auto-nudge: default OFF (opt-in).** Bare `agents watchdog` is a dry run; `--nudge` is the explicit per-run opt-in; `agents watchdog enable` flips the sentinel so `--watch` injects automatically.
- **Per-session:** `off` (ignore) · `keep` (default) · `handsoff` (detect + flag, **never** inject).

## CLI

```
agents watchdog                         one dry tick — what it WOULD nudge/skip and why
agents watchdog --nudge                 inject for real
agents watchdog --watch [--interval 30s]  daemon loop
agents watchdog --stall 60s --cooldown 5m --dormant 30m   overridable thresholds
agents watchdog --json                  machine-readable (menu-bar)
agents watchdog enable|disable|status   global sentinel
agents watchdog policy <id> off|keep|handsoff
```

Registered next to `pty`/`tmux` in `src/lib/startup/command-registry.ts` + the eager tree in `src/index.ts`.

## Tests

`src/lib/watchdog/runner.test.ts` (11 tests) drives real synthetic `ActiveSession` inputs through the pure logic (nothing mocked) with `dryRun` injection:
- nudge fires on promise-without-toolcall + addressable, cooldown ledger updated
- skips on waiting-on-user, on completion, on `addressable:false` (+ flag written), within cooldown
- `handsoff` detects + flags but never injects; `off` fully opts out
- dry-run reports would-nudge without touching the ledger

## Verification

- `tsc --noEmit` clean.
- `bun run build` OK.
- `bun run test` (vitest, the CI command): **3801 passed**, 6 pre-existing env-only failures (5 R2-config-keychain in `session/sync/config.test.ts`, 1 audit-redaction in `events-audit.test.ts`) — none touch watchdog/terminal/session code.
- Real command run end-to-end against live sessions on this machine: detected 5 live / 2 stalled, correctly flagged 1 un-addressable, skipped a waiting-on-user session, injected nothing in dry mode; `enable`/`disable`/`status`/`policy` all verified.

## Boundaries

Only adds `src/commands/watchdog.ts`, `src/lib/watchdog/runner.ts` (+test), and registry/index wiring. Does not modify `resolve.ts` / `inject.ts` / the watchdog pure core / menubar.
