### PR TITLE
fix: support Windows remotes in --host SSH command layer (RUSH-1429)

### DIFF
--- a/src/commands/hosts.ts
+++ b/src/commands/hosts.ts
@@ -21,6 +21,7 @@ import {
   bootstrapAgentsCli,
   localCliVersion,
 } from '../lib/hosts/ready.js';
+import { resolveRemoteOsSync } from '../lib/hosts/remote-os.js';
 import { listTasks } from '../lib/hosts/tasks.js';
 import { reconcileRunningTasks } from '../lib/hosts/reconcile.js';
 import { showHostTaskLog } from '../lib/hosts/logs.js';
@@ -42,19 +43,21 @@ function parseTarget(target: string): { address: string; user?: string } {
 async function maybeBootstrap(
   target: string,
   hostName: string,
-  probe: { reachable: boolean; os?: string } = probeHost(target),
+  probe: { reachable: boolean; os?: string } = probeHost(target, resolveRemoteOsSync(hostName)),
 ): Promise<void> {
   if (!probe.reachable) {
     console.log(chalk.yellow(`  Not reachable over SSH yet — skipping bootstrap. Fix key auth, then: agents hosts check ${hostName}`));
     return;
   }
-  const remoteVer = remoteAgentsVersion(target);
+  // Prefer the OS the probe just observed; fall back to the registry hint.
+  const os = probe.os ?? resolveRemoteOsSync(hostName);
+  const remoteVer = remoteAgentsVersion(target, os);
   const localVer = localCliVersion();
   if (!remoteVer) {
     const ok = await confirm({ message: `  agents-cli not found on ${hostName}. Install ${localVer ? `v${localVer}` : 'latest'} now?`, default: true });
     if (ok) {
       console.log(chalk.gray('  Installing agents-cli on the host…'));
-      const r = bootstrapAgentsCli(target, localVer);
+      const r = bootstrapAgentsCli(target, localVer, os);
       console.log(r.ok ? chalk.green('  Installed.') : chalk.red(`  Install failed:\n${r.output}`));
     }
     return;
@@ -63,7 +66,7 @@ async function maybeBootstrap(
   if (localVer && remoteClean !== localVer) {
     const ok = await confirm({ message: `  ${hostName} has agents-cli ${remoteClean}, you have ${localVer}. Upgrade to match?`, default: false });
     if (ok) {
-      const r = bootstrapAgentsCli(target, localVer);
+      const r = bootstrapAgentsCli(target, localVer, os);
       console.log(r.ok ? chalk.green('  Upgraded.') : chalk.red(`  Upgrade failed:\n${r.output}`));
     }
   }
@@ -157,15 +160,16 @@ async function doCheck(name: string): Promise<void> {
     return;
   }
   const target = sshTargetFor(host);
+  const os = host.os ?? resolveRemoteOsSync(name);
   process.stdout.write(`Probing ${chalk.cyan(name)} (${target})… `);
-  const probe = probeHost(target);
+  const probe = probeHost(target, os);
   if (!probe.reachable) {
     console.log(chalk.red('unreachable'));
     process.exitCode = 1;
     return;
   }
   console.log(chalk.green('reachable') + chalk.gray(probe.os ? ` · ${probe.os}` : ''));
-  const ver = remoteAgentsVersion(target);
+  const ver = remoteAgentsVersion(target, probe.os ?? os);
   console.log(`  agents-cli: ${ver ? chalk.green(ver) : chalk.yellow('not installed')}`);
 }
 

--- a/src/lib/devices/registry.ts
+++ b/src/lib/devices/registry.ts
@@ -179,6 +179,30 @@ export async function loadDevices(): Promise<DeviceRegistry> {
   }
 }
 
+/**
+ * Synchronous {@link loadDevices} for callers already on a sync path (e.g. the
+ * `agents sessions --host` fan-out builds its ssh command strings synchronously
+ * and only needs the target's platform to pick POSIX vs PowerShell). Same
+ * missing-file/corruption contract as {@link loadDevices}.
+ */
+export function loadDevicesSync(): DeviceRegistry {
+  const p = registryPath();
+  let raw: string;
+  try {
+    raw = fsSync.readFileSync(p, 'utf-8');
+  } catch (err: any) {
+    if (err && err.code === 'ENOENT') return {};
+    throw err;
+  }
+  try {
+    return JSON.parse(raw) as DeviceRegistry;
+  } catch (err: any) {
+    throw new Error(
+      `Device registry corrupted at ${p}: ${err?.message ?? err}. Inspect and restore from backup.`,
+    );
+  }
+}
+
 async function saveDevices(reg: DeviceRegistry): Promise<void> {
   await atomicWriteJson(registryPath(), reg);
 }

--- a/src/lib/hosts/dispatch.ts
+++ b/src/lib/hosts/dispatch.ts
@@ -14,6 +14,8 @@ import { sshExec, shellQuote } from '../ssh-exec.js';
 import type { Host } from './types.js';
 import { sshTargetFor } from './types.js';
 import { ensureHostReady } from './ready.js';
+import { remoteShellFor, encodePowershell, powershellQuote } from './remote-cmd.js';
+import { resolveRemoteOsSync } from './remote-os.js';
 import { saveTask, updateTask, terminalPatch, type HostTask } from './tasks.js';
 import { followHostTask } from './progress.js';
 
@@ -42,6 +44,30 @@ interface LaunchOptions {
 }
 
 /**
+ * Windows counterpart of the POSIX `nohup bash -lc` launch line. ssh lands in
+ * cmd.exe/PowerShell on Windows, so we detach via `Start-Process -WindowStyle
+ * Hidden` instead of nohup, redirect all streams to the log with `*>`, and drop
+ * the exit code into the sibling `.exit` file — the same log+exit contract the
+ * POSIX path writes. Both the inner (detached) and outer scripts are shipped as
+ * `-EncodedCommand` payloads so they survive cmd.exe re-parsing. `$HOME`-rooted
+ * paths stay double-quoted so PowerShell expands them; user args/cwd are
+ * single-quoted literals.
+ */
+function windowsDetachedLaunch(args: string[], remoteLog: string, remoteExit: string, remoteCwd?: string): string {
+  const inner: string[] = [];
+  if (remoteCwd) inner.push(`Set-Location -LiteralPath ${powershellQuote(remoteCwd)}`);
+  inner.push(`& ${['agents', ...args].map(powershellQuote).join(' ')} *> "${remoteLog}"`);
+  inner.push(`Set-Content -LiteralPath "${remoteExit}" -Value $LASTEXITCODE`);
+  const innerEnc = encodePowershell(inner.join('; '));
+  const outer = [
+    `New-Item -ItemType Directory -Force -Path "${REMOTE_DIR}" | Out-Null`,
+    `$p = Start-Process -FilePath 'powershell' -ArgumentList @('-NoProfile','-EncodedCommand','${innerEnc}') -WindowStyle Hidden -PassThru`,
+    `$p.Id`,
+  ].join('; ');
+  return `powershell -NoProfile -EncodedCommand ${encodePowershell(outer)}`;
+}
+
+/**
  * The launch + task-record + optional follow core. Both `dispatchToHost` (run)
  * and `dispatchAgentsCommand` (teams) build their `forwardedArgs` and call here,
  * so the nohup/exit-file/offset-tail machinery lives in exactly one place.
@@ -51,13 +77,18 @@ async function launchDetached(host: Host, target: string, opts: LaunchOptions): 
   const remoteLog = `${REMOTE_DIR}/${id}.log`;
   const remoteExit = `${REMOTE_DIR}/${id}.exit`;
 
-  // Inner command run under a login shell so PATH resolves `agents`.
-  const invocation = ['agents', ...opts.forwardedArgs].map(shellQuote).join(' ');
-  const cwd = opts.remoteCwd ? `cd ${shellQuote(opts.remoteCwd)} && ` : '';
-  const inner = `${cwd}${invocation} > ${remoteLog} 2>&1; echo $? > ${remoteExit}`;
-
-  // Outer: ensure dir, launch detached under bash -lc, print the PID.
-  const launch = `mkdir -p ${REMOTE_DIR}; nohup bash -lc ${shellQuote(inner)} >/dev/null 2>&1 & echo $!`;
+  // Pick the remote shell: POSIX `nohup bash -lc` vs Windows Start-Process.
+  let launch: string;
+  if (remoteShellFor(resolveRemoteOsSync(host.name)) === 'powershell') {
+    launch = windowsDetachedLaunch(opts.forwardedArgs, remoteLog, remoteExit, opts.remoteCwd);
+  } else {
+    // Inner command run under a login shell so PATH resolves `agents`.
+    const invocation = ['agents', ...opts.forwardedArgs].map(shellQuote).join(' ');
+    const cwd = opts.remoteCwd ? `cd ${shellQuote(opts.remoteCwd)} && ` : '';
+    const inner = `${cwd}${invocation} > ${remoteLog} 2>&1; echo $? > ${remoteExit}`;
+    // Outer: ensure dir, launch detached under bash -lc, print the PID.
+    launch = `mkdir -p ${REMOTE_DIR}; nohup bash -lc ${shellQuote(inner)} >/dev/null 2>&1 & echo $!`;
+  }
   const res = sshExec(target, launch, { timeoutMs: 30000, multiplex: true });
   if (res.code !== 0) {
     throw new Error(`Failed to launch on "${host.name}": ${(res.stderr || res.stdout).trim() || 'ssh error'}`);

--- a/src/lib/hosts/dispatch.ts
+++ b/src/lib/hosts/dispatch.ts
@@ -14,7 +14,7 @@ import { sshExec, shellQuote } from '../ssh-exec.js';
 import type { Host } from './types.js';
 import { sshTargetFor } from './types.js';
 import { ensureHostReady } from './ready.js';
-import { remoteShellFor, encodePowershell, powershellQuote } from './remote-cmd.js';
+import { remoteShellFor } from './remote-cmd.js';
 import { resolveRemoteOsSync } from './remote-os.js';
 import { saveTask, updateTask, terminalPatch, type HostTask } from './tasks.js';
 import { followHostTask } from './progress.js';
@@ -44,51 +44,38 @@ interface LaunchOptions {
 }
 
 /**
- * Windows counterpart of the POSIX `nohup bash -lc` launch line. ssh lands in
- * cmd.exe/PowerShell on Windows, so we detach via `Start-Process -WindowStyle
- * Hidden` instead of nohup, redirect all streams to the log with `*>`, and drop
- * the exit code into the sibling `.exit` file — the same log+exit contract the
- * POSIX path writes. Both the inner (detached) and outer scripts are shipped as
- * `-EncodedCommand` payloads so they survive cmd.exe re-parsing. `$HOME`-rooted
- * paths stay double-quoted so PowerShell expands them; user args/cwd are
- * single-quoted literals.
- */
-function windowsDetachedLaunch(args: string[], remoteLog: string, remoteExit: string, remoteCwd?: string): string {
-  const inner: string[] = [];
-  if (remoteCwd) inner.push(`Set-Location -LiteralPath ${powershellQuote(remoteCwd)}`);
-  inner.push(`& ${['agents', ...args].map(powershellQuote).join(' ')} *> "${remoteLog}"`);
-  inner.push(`Set-Content -LiteralPath "${remoteExit}" -Value $LASTEXITCODE`);
-  const innerEnc = encodePowershell(inner.join('; '));
-  const outer = [
-    `New-Item -ItemType Directory -Force -Path "${REMOTE_DIR}" | Out-Null`,
-    `$p = Start-Process -FilePath 'powershell' -ArgumentList @('-NoProfile','-EncodedCommand','${innerEnc}') -WindowStyle Hidden -PassThru`,
-    `$p.Id`,
-  ].join('; ');
-  return `powershell -NoProfile -EncodedCommand ${encodePowershell(outer)}`;
-}
-
-/**
  * The launch + task-record + optional follow core. Both `dispatchToHost` (run)
  * and `dispatchAgentsCommand` (teams) build their `forwardedArgs` and call here,
  * so the nohup/exit-file/offset-tail machinery lives in exactly one place.
+ *
+ * Windows remotes are refused up front: the detached launch is only half the
+ * contract — the follow/reconcile layer (`progress.ts`/`reconcile.ts`) offset-
+ * tails the log with POSIX `tail -c`/`printf`/`cat`/`stat`, which do not exist
+ * in cmd.exe/PowerShell. Shipping the launch alone would leave `run --host
+ * <windows>` dispatching but hanging on follow forever, so we fail fast with an
+ * actionable message instead. Read-only `--host` commands (view/sessions/…) run
+ * a single round-trip with no follow protocol and DO work against Windows.
  */
 async function launchDetached(host: Host, target: string, opts: LaunchOptions): Promise<DispatchResult> {
+  if (remoteShellFor(resolveRemoteOsSync(host.name)) === 'powershell') {
+    throw new Error(
+      `Detached dispatch to Windows host "${host.name}" is not supported yet — the run ` +
+        `follow/reconcile layer is POSIX-only (offset-tails the remote log with tail/cat/stat). ` +
+        `Read-only --host commands (view, sessions, usage, cost, doctor, list, teams) do work ` +
+        `against Windows.`,
+    );
+  }
   const id = randomUUID().slice(0, 8);
   const remoteLog = `${REMOTE_DIR}/${id}.log`;
   const remoteExit = `${REMOTE_DIR}/${id}.exit`;
 
-  // Pick the remote shell: POSIX `nohup bash -lc` vs Windows Start-Process.
-  let launch: string;
-  if (remoteShellFor(resolveRemoteOsSync(host.name)) === 'powershell') {
-    launch = windowsDetachedLaunch(opts.forwardedArgs, remoteLog, remoteExit, opts.remoteCwd);
-  } else {
-    // Inner command run under a login shell so PATH resolves `agents`.
-    const invocation = ['agents', ...opts.forwardedArgs].map(shellQuote).join(' ');
-    const cwd = opts.remoteCwd ? `cd ${shellQuote(opts.remoteCwd)} && ` : '';
-    const inner = `${cwd}${invocation} > ${remoteLog} 2>&1; echo $? > ${remoteExit}`;
-    // Outer: ensure dir, launch detached under bash -lc, print the PID.
-    launch = `mkdir -p ${REMOTE_DIR}; nohup bash -lc ${shellQuote(inner)} >/dev/null 2>&1 & echo $!`;
-  }
+  // Inner command run under a login shell so PATH resolves `agents`.
+  const invocation = ['agents', ...opts.forwardedArgs].map(shellQuote).join(' ');
+  const cwd = opts.remoteCwd ? `cd ${shellQuote(opts.remoteCwd)} && ` : '';
+  const inner = `${cwd}${invocation} > ${remoteLog} 2>&1; echo $? > ${remoteExit}`;
+
+  // Outer: ensure dir, launch detached under bash -lc, print the PID.
+  const launch = `mkdir -p ${REMOTE_DIR}; nohup bash -lc ${shellQuote(inner)} >/dev/null 2>&1 & echo $!`;
   const res = sshExec(target, launch, { timeoutMs: 30000, multiplex: true });
   if (res.code !== 0) {
     throw new Error(`Failed to launch on "${host.name}": ${(res.stderr || res.stdout).trim() || 'ssh error'}`);

--- a/src/lib/hosts/passthrough.ts
+++ b/src/lib/hosts/passthrough.ts
@@ -28,6 +28,7 @@ import {
   HOST_ROUTING_SPECS,
   type StripSpec,
 } from './remote-cmd.js';
+import { resolveRemoteOsSync } from './remote-os.js';
 import { machineId } from '../session/sync/config.js';
 
 /** Per-command remote behaviour. Absence from this map = not host-routable here. */
@@ -144,7 +145,7 @@ export async function maybeRunOnHost(command: string, allArgs: string[]): Promis
     return true;
   }
 
-  const remoteCmd = buildRemoteAgentsInvocation(forwarded, remoteCwd);
+  const remoteCmd = buildRemoteAgentsInvocation(forwarded, remoteCwd, resolveRemoteOsSync(host.name));
   const code = sshStream(target, remoteCmd, { tty: interactive, multiplex: true });
   if (code === 255) {
     console.error(

--- a/src/lib/hosts/ready.test.ts
+++ b/src/lib/hosts/ready.test.ts
@@ -1,7 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { parseReadyProbe, viewHasAgent } from './ready.js';
+import {
+  parseReadyProbe,
+  viewHasAgent,
+  buildProbeCommand,
+  buildRemoteVersionCommand,
+  buildBootstrapCommand,
+  buildReadyProbeCommand,
+} from './ready.js';
+import { decodePowershell } from './remote-cmd.js';
 
 const MARK = '@@AGENTS_READY@@';
+
+/** Decode the PowerShell script off a `-EncodedCommand` remote command. */
+function decodeWindows(cmd: string): string {
+  const m = cmd.match(/^powershell -NoProfile -EncodedCommand (\S+)$/);
+  expect(m, `not an encoded PowerShell command: ${cmd}`).not.toBeNull();
+  return decodePowershell(m![1]);
+}
 
 describe('parseReadyProbe', () => {
   it('parses version + agent listing from one compound probe', () => {
@@ -40,5 +55,54 @@ describe('viewHasAgent', () => {
   });
   it('does not match an absent agent', () => {
     expect(viewHasAgent(view, 'gemini')).toBe(false);
+  });
+});
+
+describe('ready commands — POSIX branch unchanged', () => {
+  it('probe uses uname, version/readyProbe/bootstrap use bash -lc', () => {
+    expect(buildProbeCommand()).toBe('uname -s 2>/dev/null || echo unknown');
+    expect(buildProbeCommand('linux')).toBe('uname -s 2>/dev/null || echo unknown');
+    expect(buildRemoteVersionCommand('darwin')).toBe('bash -lc "agents --version 2>/dev/null"');
+    expect(buildReadyProbeCommand()).toBe(
+      `bash -lc 'agents --version 2>/dev/null; printf '\\''\\n${MARK}\\n'\\''; agents view 2>/dev/null || agents list 2>/dev/null'`,
+    );
+    expect(buildBootstrapCommand('@phnx-labs/agents-cli@2.1.170')).toBe(
+      "bash -lc 'npm install -g @phnx-labs/agents-cli@2.1.170 2>&1 | tail -3; " +
+        "if [ ! -d ~/.agents/.system ]; then agents setup 2>&1 | tail -3 || true; fi; agents --version'",
+    );
+  });
+});
+
+describe('ready commands — Windows branch speaks PowerShell', () => {
+  it('probe runs a PowerShell OS check instead of uname', () => {
+    const cmd = buildProbeCommand('windows');
+    expect(cmd).not.toContain('uname');
+    expect(decodeWindows(cmd)).toBe('[System.Environment]::OSVersion.Platform.ToString()');
+  });
+
+  it('version probe runs `agents --version` via PowerShell', () => {
+    expect(decodeWindows(buildRemoteVersionCommand('windows'))).toBe("& 'agents' '--version'; exit $LASTEXITCODE");
+  });
+
+  it('readyProbe emits the sentinel with Write-Output and branches on $LASTEXITCODE', () => {
+    // Parser keys off the sentinel substring — this output must still parse.
+    const script = decodeWindows(buildReadyProbeCommand('windows'));
+    expect(script).toBe(
+      `agents --version 2>$null; Write-Output "${MARK}"; agents view 2>$null; if ($LASTEXITCODE -ne 0) { agents list 2>$null }`,
+    );
+    // The script's stdout shape (marker on its own line) round-trips through parseReadyProbe.
+    const p = parseReadyProbe(`2.1.170\n${MARK}\nClaude (balanced)\n`);
+    expect(p.reachable).toBe(true);
+    expect(p.version).toBe('2.1.170');
+  });
+
+  it('bootstrap uses Select-Object -Last / Test-Path, never tail / [ -d ]', () => {
+    const script = decodeWindows(buildBootstrapCommand('@phnx-labs/agents-cli@2.1.170', 'windows'));
+    expect(script).toBe(
+      "npm install -g '@phnx-labs/agents-cli@2.1.170' 2>&1 | Select-Object -Last 3; " +
+        'if (-not (Test-Path "$HOME/.agents/.system")) { agents setup 2>&1 | Select-Object -Last 3 }; agents --version',
+    );
+    expect(script).not.toContain('tail -3');
+    expect(script).not.toContain('[ ! -d');
   });
 });

--- a/src/lib/hosts/ready.ts
+++ b/src/lib/hosts/ready.ts
@@ -33,57 +33,67 @@ export function localCliVersion(): string | null {
   return null;
 }
 
+/** ssh command that confirms reachability and echoes the OS. POSIX boxes answer
+ * `uname -s`; a Windows target has no `uname` (ssh lands in cmd.exe/PowerShell),
+ * so it runs a tiny PowerShell probe. Pure/exported so both branches are
+ * unit-testable without ssh. */
+export function buildProbeCommand(os?: string): string {
+  if (remoteShellFor(os) === 'powershell') {
+    return `powershell -NoProfile -EncodedCommand ${encodePowershell('[System.Environment]::OSVersion.Platform.ToString()')}`;
+  }
+  return 'uname -s 2>/dev/null || echo unknown';
+}
+
 /**
- * Reachability + OS probe over ssh. POSIX boxes answer `uname -s`; a Windows
- * target has no `uname` and ssh lands in cmd.exe/PowerShell, so we run a tiny
- * PowerShell probe instead and report the already-known platform. `os` is the
- * caller's hint (device-registry platform / enrolled `HostEntry.os`); when it
- * marks the host Windows we take the PowerShell path, otherwise POSIX.
+ * Reachability + OS probe over ssh. `os` is the caller's hint (device-registry
+ * platform / enrolled `HostEntry.os`); when it marks the host Windows we take
+ * the PowerShell path and report that known platform, otherwise POSIX + uname.
  */
 export function probeHost(target: string, os?: string): { reachable: boolean; os?: string } {
-  if (remoteShellFor(os) === 'powershell') {
-    const probe = encodePowershell('[System.Environment]::OSVersion.Platform.ToString()');
-    const r = sshExec(target, `powershell -NoProfile -EncodedCommand ${probe}`, { timeoutMs: 12000 });
-    if (r.code !== 0) return { reachable: false };
-    return { reachable: true, os };
-  }
-  const r = sshExec(target, 'uname -s 2>/dev/null || echo unknown', { timeoutMs: 12000 });
+  const r = sshExec(target, buildProbeCommand(os), { timeoutMs: 12000 });
   if (r.code !== 0) return { reachable: false };
+  if (remoteShellFor(os) === 'powershell') return { reachable: true, os };
   const uname = r.stdout.trim();
   return { reachable: true, os: uname && uname !== 'unknown' ? uname : undefined };
 }
 
+/** ssh command that prints the remote agents-cli version. Pure/exported. */
+export function buildRemoteVersionCommand(os?: string): string {
+  return remoteShellFor(os) === 'powershell'
+    ? buildWindowsAgentsCommand({ args: ['--version'] })
+    : 'bash -lc "agents --version 2>/dev/null"';
+}
+
 /** Remote agents-cli version (PATH-resolved on the remote), or null if not installed. */
 export function remoteAgentsVersion(target: string, os?: string): string | null {
-  const cmd =
-    remoteShellFor(os) === 'powershell'
-      ? buildWindowsAgentsCommand({ args: ['--version'] })
-      : 'bash -lc "agents --version 2>/dev/null"';
-  const r = sshExec(target, cmd, { timeoutMs: 20000 });
+  const r = sshExec(target, buildRemoteVersionCommand(os), { timeoutMs: 20000 });
   if (r.code !== 0) return null;
   const v = r.stdout.trim();
   return v || null;
 }
 
-/** Install (or upgrade to) a specific agents-cli version on the remote, then `agents setup`. */
-export function bootstrapAgentsCli(target: string, version: string | null, os?: string): { ok: boolean; output: string } {
-  const spec = version ? `@phnx-labs/agents-cli@${version}` : '@phnx-labs/agents-cli';
-  let cmd: string;
+/** ssh command that installs/upgrades agents-cli to `spec` then `agents setup`.
+ * PowerShell has no `tail`/`[ -d ]`/`||`, so the Windows branch uses native
+ * equivalents (`Select-Object -Last`, `Test-Path`). Pure/exported. */
+export function buildBootstrapCommand(spec: string, os?: string): string {
   if (remoteShellFor(os) === 'powershell') {
-    // PowerShell has no `tail`/`[ -d ]`/`||`; use its native equivalents.
     const script =
       `npm install -g ${powershellQuote(spec)} 2>&1 | Select-Object -Last 3; ` +
       `if (-not (Test-Path "$HOME/.agents/.system")) { agents setup 2>&1 | Select-Object -Last 3 }; ` +
       `agents --version`;
-    cmd = `powershell -NoProfile -EncodedCommand ${encodePowershell(script)}`;
-  } else {
-    const script =
-      `npm install -g ${shellQuote(spec)} 2>&1 | tail -3; ` +
-      `if [ ! -d ~/.agents/.system ]; then agents setup 2>&1 | tail -3 || true; fi; ` +
-      `agents --version`;
-    cmd = `bash -lc ${shellQuote(script)}`;
+    return `powershell -NoProfile -EncodedCommand ${encodePowershell(script)}`;
   }
-  const r = sshExec(target, cmd, { timeoutMs: 300000 });
+  const script =
+    `npm install -g ${shellQuote(spec)} 2>&1 | tail -3; ` +
+    `if [ ! -d ~/.agents/.system ]; then agents setup 2>&1 | tail -3 || true; fi; ` +
+    `agents --version`;
+  return `bash -lc ${shellQuote(script)}`;
+}
+
+/** Install (or upgrade to) a specific agents-cli version on the remote, then `agents setup`. */
+export function bootstrapAgentsCli(target: string, version: string | null, os?: string): { ok: boolean; output: string } {
+  const spec = version ? `@phnx-labs/agents-cli@${version}` : '@phnx-labs/agents-cli';
+  const r = sshExec(target, buildBootstrapCommand(spec, os), { timeoutMs: 300000 });
   return { ok: r.code === 0, output: (r.stdout + r.stderr).trim() };
 }
 
@@ -107,22 +117,28 @@ export interface ReadyProbe {
  * rather than the exit code, so a command that ran-but-failed is never mistaken
  * for a dead connection (only ssh's own failure drops the sentinel).
  */
-export function readyProbe(target: string, os?: string): ReadyProbe {
-  let cmd: string;
+/**
+ * The one-shot readiness command (version + sentinel + agent listing). The
+ * Windows branch emits the sentinel with `Write-Output` and branches on
+ * `$LASTEXITCODE` (no `printf`/`||`); `parseReadyProbe` keys off the sentinel
+ * substring, so the missing leading newline vs the POSIX `printf '\n…'` form is
+ * absorbed by its `.trim()`. Pure/exported so both branches are unit-testable.
+ */
+export function buildReadyProbeCommand(os?: string): string {
   if (remoteShellFor(os) === 'powershell') {
-    // No `printf`/`||`; emit the sentinel with Write-Output and branch on
-    // $LASTEXITCODE. Reachability still keys off the sentinel, not the code.
     const script =
       `agents --version 2>$null; Write-Output "${READY_MARKER}"; ` +
       `agents view 2>$null; if ($LASTEXITCODE -ne 0) { agents list 2>$null }`;
-    cmd = `powershell -NoProfile -EncodedCommand ${encodePowershell(script)}`;
-  } else {
-    const script =
-      `agents --version 2>/dev/null; printf '\\n${READY_MARKER}\\n'; ` +
-      `agents view 2>/dev/null || agents list 2>/dev/null`;
-    cmd = `bash -lc ${shellQuote(script)}`;
+    return `powershell -NoProfile -EncodedCommand ${encodePowershell(script)}`;
   }
-  const r = sshExec(target, cmd, { timeoutMs: 20000 });
+  const script =
+    `agents --version 2>/dev/null; printf '\\n${READY_MARKER}\\n'; ` +
+    `agents view 2>/dev/null || agents list 2>/dev/null`;
+  return `bash -lc ${shellQuote(script)}`;
+}
+
+export function readyProbe(target: string, os?: string): ReadyProbe {
+  const r = sshExec(target, buildReadyProbeCommand(os), { timeoutMs: 20000 });
   return parseReadyProbe(r.stdout);
 }
 

--- a/src/lib/hosts/ready.ts
+++ b/src/lib/hosts/ready.ts
@@ -12,6 +12,8 @@ import { fileURLToPath } from 'url';
 import { sshExec, shellQuote } from '../ssh-exec.js';
 import type { Host } from './types.js';
 import { sshTargetFor } from './types.js';
+import { remoteShellFor, buildWindowsAgentsCommand, encodePowershell, powershellQuote } from './remote-cmd.js';
+import { resolveRemoteOsSync } from './remote-os.js';
 
 /** Resolve this CLI's own version by walking up to the nearest package.json. */
 export function localCliVersion(): string | null {
@@ -31,30 +33,57 @@ export function localCliVersion(): string | null {
   return null;
 }
 
-/** uname over ssh → reachable + OS string. */
-export function probeHost(target: string): { reachable: boolean; os?: string } {
+/**
+ * Reachability + OS probe over ssh. POSIX boxes answer `uname -s`; a Windows
+ * target has no `uname` and ssh lands in cmd.exe/PowerShell, so we run a tiny
+ * PowerShell probe instead and report the already-known platform. `os` is the
+ * caller's hint (device-registry platform / enrolled `HostEntry.os`); when it
+ * marks the host Windows we take the PowerShell path, otherwise POSIX.
+ */
+export function probeHost(target: string, os?: string): { reachable: boolean; os?: string } {
+  if (remoteShellFor(os) === 'powershell') {
+    const probe = encodePowershell('[System.Environment]::OSVersion.Platform.ToString()');
+    const r = sshExec(target, `powershell -NoProfile -EncodedCommand ${probe}`, { timeoutMs: 12000 });
+    if (r.code !== 0) return { reachable: false };
+    return { reachable: true, os };
+  }
   const r = sshExec(target, 'uname -s 2>/dev/null || echo unknown', { timeoutMs: 12000 });
   if (r.code !== 0) return { reachable: false };
-  const os = r.stdout.trim();
-  return { reachable: true, os: os && os !== 'unknown' ? os : undefined };
+  const uname = r.stdout.trim();
+  return { reachable: true, os: uname && uname !== 'unknown' ? uname : undefined };
 }
 
-/** Remote agents-cli version (login shell for PATH), or null if not installed. */
-export function remoteAgentsVersion(target: string): string | null {
-  const r = sshExec(target, 'bash -lc "agents --version 2>/dev/null"', { timeoutMs: 20000 });
+/** Remote agents-cli version (PATH-resolved on the remote), or null if not installed. */
+export function remoteAgentsVersion(target: string, os?: string): string | null {
+  const cmd =
+    remoteShellFor(os) === 'powershell'
+      ? buildWindowsAgentsCommand({ args: ['--version'] })
+      : 'bash -lc "agents --version 2>/dev/null"';
+  const r = sshExec(target, cmd, { timeoutMs: 20000 });
   if (r.code !== 0) return null;
   const v = r.stdout.trim();
   return v || null;
 }
 
 /** Install (or upgrade to) a specific agents-cli version on the remote, then `agents setup`. */
-export function bootstrapAgentsCli(target: string, version: string | null): { ok: boolean; output: string } {
+export function bootstrapAgentsCli(target: string, version: string | null, os?: string): { ok: boolean; output: string } {
   const spec = version ? `@phnx-labs/agents-cli@${version}` : '@phnx-labs/agents-cli';
-  const script =
-    `npm install -g ${shellQuote(spec)} 2>&1 | tail -3; ` +
-    `if [ ! -d ~/.agents/.system ]; then agents setup 2>&1 | tail -3 || true; fi; ` +
-    `agents --version`;
-  const r = sshExec(target, `bash -lc ${shellQuote(script)}`, { timeoutMs: 300000 });
+  let cmd: string;
+  if (remoteShellFor(os) === 'powershell') {
+    // PowerShell has no `tail`/`[ -d ]`/`||`; use its native equivalents.
+    const script =
+      `npm install -g ${powershellQuote(spec)} 2>&1 | Select-Object -Last 3; ` +
+      `if (-not (Test-Path "$HOME/.agents/.system")) { agents setup 2>&1 | Select-Object -Last 3 }; ` +
+      `agents --version`;
+    cmd = `powershell -NoProfile -EncodedCommand ${encodePowershell(script)}`;
+  } else {
+    const script =
+      `npm install -g ${shellQuote(spec)} 2>&1 | tail -3; ` +
+      `if [ ! -d ~/.agents/.system ]; then agents setup 2>&1 | tail -3 || true; fi; ` +
+      `agents --version`;
+    cmd = `bash -lc ${shellQuote(script)}`;
+  }
+  const r = sshExec(target, cmd, { timeoutMs: 300000 });
   return { ok: r.code === 0, output: (r.stdout + r.stderr).trim() };
 }
 
@@ -78,11 +107,22 @@ export interface ReadyProbe {
  * rather than the exit code, so a command that ran-but-failed is never mistaken
  * for a dead connection (only ssh's own failure drops the sentinel).
  */
-export function readyProbe(target: string): ReadyProbe {
-  const script =
-    `agents --version 2>/dev/null; printf '\\n${READY_MARKER}\\n'; ` +
-    `agents view 2>/dev/null || agents list 2>/dev/null`;
-  const r = sshExec(target, `bash -lc ${shellQuote(script)}`, { timeoutMs: 20000 });
+export function readyProbe(target: string, os?: string): ReadyProbe {
+  let cmd: string;
+  if (remoteShellFor(os) === 'powershell') {
+    // No `printf`/`||`; emit the sentinel with Write-Output and branch on
+    // $LASTEXITCODE. Reachability still keys off the sentinel, not the code.
+    const script =
+      `agents --version 2>$null; Write-Output "${READY_MARKER}"; ` +
+      `agents view 2>$null; if ($LASTEXITCODE -ne 0) { agents list 2>$null }`;
+    cmd = `powershell -NoProfile -EncodedCommand ${encodePowershell(script)}`;
+  } else {
+    const script =
+      `agents --version 2>/dev/null; printf '\\n${READY_MARKER}\\n'; ` +
+      `agents view 2>/dev/null || agents list 2>/dev/null`;
+    cmd = `bash -lc ${shellQuote(script)}`;
+  }
+  const r = sshExec(target, cmd, { timeoutMs: 20000 });
   return parseReadyProbe(r.stdout);
 }
 
@@ -114,7 +154,7 @@ export interface EnsureReadyOptions {
  */
 export function ensureHostReady(host: Host, opts: EnsureReadyOptions): { warnings: string[] } {
   const target = sshTargetFor(host);
-  const probe = readyProbe(target);
+  const probe = readyProbe(target, host.os ?? resolveRemoteOsSync(host.name));
   if (!probe.reachable) {
     throw new Error(`Host "${host.name}" (${target}) is not reachable over SSH. Check it's online and key auth works.`);
   }

--- a/src/lib/hosts/remote-cmd.test.ts
+++ b/src/lib/hosts/remote-cmd.test.ts
@@ -3,9 +3,22 @@ import { spawnSync } from 'child_process';
 import {
   stripRoutingFlags,
   buildRemoteAgentsInvocation,
+  buildWindowsAgentsCommand,
+  remoteShellFor,
+  powershellQuote,
+  decodePowershell,
   HOST_ROUTING_SPECS,
   type StripSpec,
 } from './remote-cmd.js';
+
+/** Decode the PowerShell script a Windows `--host` invocation ships, by pulling
+ * the base64 payload off `powershell -NoProfile -EncodedCommand <b64>` and
+ * reversing the UTF-16LE encoding — the exact bytes the remote PowerShell runs. */
+function decodeWindows(cmd: string): string {
+  const m = cmd.match(/^powershell -NoProfile -EncodedCommand (\S+)$/);
+  expect(m, `not an encoded PowerShell command: ${cmd}`).not.toBeNull();
+  return decodePowershell(m![1]);
+}
 
 const SPECS: StripSpec[] = [...HOST_ROUTING_SPECS, { long: 'no-tty', takesValue: false }];
 
@@ -88,5 +101,80 @@ describe('buildRemoteAgentsInvocation (two-layer quoting is injection-safe)', ()
   it('prefixes a cd for --remote-cwd without leaking it into argv', () => {
     // The shim's cwd change is observable only via the cd prefix; argv stays clean.
     expect(decodeRemoteArgv(['view'], '/tmp')).toEqual(['view']);
+  });
+});
+
+describe('remoteShellFor', () => {
+  it('maps Windows platform/OS strings to PowerShell', () => {
+    for (const os of ['windows', 'Windows', 'win32', 'WIN32']) {
+      expect(remoteShellFor(os)).toBe('powershell');
+    }
+  });
+
+  it('defaults every non-Windows / unknown / absent OS to POSIX', () => {
+    for (const os of ['linux', 'Linux', 'darwin', 'macos', 'Darwin', 'unknown', '', undefined]) {
+      expect(remoteShellFor(os as string | undefined)).toBe('posix');
+    }
+  });
+});
+
+describe('powershellQuote', () => {
+  it('wraps in single quotes and doubles embedded single quotes', () => {
+    expect(powershellQuote('agents')).toBe("'agents'");
+    expect(powershellQuote("it's")).toBe("'it''s'");
+    // `$()`, `;`, and spaces are all literal inside a single-quoted PS string.
+    expect(powershellQuote('$(whoami); rm')).toBe("'$(whoami); rm'");
+  });
+});
+
+describe('buildRemoteAgentsInvocation — POSIX targets stay byte-identical', () => {
+  it('produces the same bash -lc string for undefined and non-Windows OS', () => {
+    const base = buildRemoteAgentsInvocation(['view', 'claude']);
+    expect(base).toBe("bash -lc 'agents view claude'");
+    expect(buildRemoteAgentsInvocation(['view', 'claude'], undefined, 'linux')).toBe(base);
+    expect(buildRemoteAgentsInvocation(['view', 'claude'], undefined, 'darwin')).toBe(base);
+    expect(buildRemoteAgentsInvocation(['view', 'claude'], undefined, 'macos')).toBe(base);
+  });
+
+  it('keeps the cd prefix for --remote-cwd on POSIX unchanged', () => {
+    expect(buildRemoteAgentsInvocation(['view'], '/srv/app')).toBe("bash -lc 'cd /srv/app && agents view'");
+  });
+
+  it('still round-trips through a real bash login shell (no OS = POSIX)', () => {
+    expect(decodeRemoteArgv(['view', 'claude'])).toEqual(['view', 'claude']);
+  });
+});
+
+describe('buildRemoteAgentsInvocation — Windows targets speak PowerShell', () => {
+  it('emits powershell -EncodedCommand instead of bash -lc', () => {
+    const cmd = buildRemoteAgentsInvocation(['view', 'claude'], undefined, 'windows');
+    expect(cmd.startsWith('powershell -NoProfile -EncodedCommand ')).toBe(true);
+    expect(cmd).not.toContain('bash -lc');
+    expect(decodeWindows(cmd)).toBe("& 'agents' 'view' 'claude'; exit $LASTEXITCODE");
+  });
+
+  it('prefixes Set-Location for --remote-cwd', () => {
+    const cmd = buildRemoteAgentsInvocation(['view'], 'C:\\srv\\app', 'windows');
+    expect(decodeWindows(cmd)).toBe("Set-Location -LiteralPath 'C:\\srv\\app'; & 'agents' 'view'; exit $LASTEXITCODE");
+  });
+
+  it('neutralizes injection — metacharacters are literal inside single quotes', () => {
+    const cmd = buildRemoteAgentsInvocation(['view', '$(whoami); rm -rf /', '--json'], undefined, 'windows');
+    expect(decodeWindows(cmd)).toBe("& 'agents' 'view' '$(whoami); rm -rf /' '--json'; exit $LASTEXITCODE");
+  });
+
+  it('carries env vars as $env: assignments (buildWindowsAgentsCommand)', () => {
+    const cmd = buildWindowsAgentsCommand({
+      args: ['sessions', '--active', '--json'],
+      env: { AGENTS_SESSIONS_LOCAL: '1', COLUMNS: '120' },
+    });
+    expect(decodeWindows(cmd)).toBe(
+      "$env:AGENTS_SESSIONS_LOCAL = '1'; $env:COLUMNS = '120'; & 'agents' 'sessions' '--active' '--json'; exit $LASTEXITCODE",
+    );
+  });
+
+  it('can drop the exit-code propagation for sentinel-based probes', () => {
+    const cmd = buildWindowsAgentsCommand({ args: ['--version'], propagateExit: false });
+    expect(decodeWindows(cmd)).toBe("& 'agents' '--version'");
   });
 });

--- a/src/lib/hosts/remote-cmd.ts
+++ b/src/lib/hosts/remote-cmd.ts
@@ -60,9 +60,99 @@ export const HOST_ROUTING_SPECS: StripSpec[] = [
  * are quoted for the inner login shell, then the whole `agents …` invocation is
  * quoted again so it survives `bash -lc <...>` — `bash -lc` so the remote login
  * PATH resolves `agents`. An optional `cd` runs first for `--remote-cwd`.
+ *
+ * `os` selects the remote shell dialect: a Windows target gets a PowerShell
+ * invocation instead (ssh lands in cmd.exe/PowerShell there, where `bash -lc`
+ * does not exist). Anything else — including an unknown/absent OS — keeps the
+ * POSIX form, so linux/macos are byte-for-byte unchanged.
  */
-export function buildRemoteAgentsInvocation(forwardedArgs: string[], remoteCwd?: string): string {
+export function buildRemoteAgentsInvocation(forwardedArgs: string[], remoteCwd?: string, os?: string): string {
+  if (remoteShellFor(os) === 'powershell') {
+    return buildWindowsAgentsCommand({ args: forwardedArgs, cwd: remoteCwd });
+  }
   const inner = ['agents', ...forwardedArgs].map(shellQuote).join(' ');
   const withCwd = remoteCwd ? `cd ${shellQuote(remoteCwd)} && ${inner}` : inner;
   return `bash -lc ${shellQuote(withCwd)}`;
+}
+
+/** The two remote shell dialects we build commands for. */
+export type RemoteShell = 'posix' | 'powershell';
+
+/**
+ * Pick the remote shell dialect from a recorded OS/platform string. A Windows
+ * host (device-registry `platform: 'windows'`, or an enrolled `HostEntry.os`
+ * that reads `windows`/`Windows`/`win32`/…) speaks PowerShell; everything else,
+ * including `undefined`/unknown, defaults to POSIX so linux/macos never regress.
+ */
+export function remoteShellFor(os: string | undefined): RemoteShell {
+  return /^win/i.test((os ?? '').trim()) ? 'powershell' : 'posix';
+}
+
+/**
+ * PowerShell single-quoted literal: wrap in `'…'` and double any embedded `'`.
+ * Single-quoted PS strings are fully literal (no `$var`, no backtick escapes),
+ * so this neutralises every metacharacter the same way POSIX `shellQuote` does.
+ */
+export function powershellQuote(s: string): string {
+  return "'" + s.replace(/'/g, "''") + "'";
+}
+
+/**
+ * Encode a PowerShell script for `powershell -EncodedCommand`: base64 of its
+ * UTF-16LE bytes. The payload is a bare base64 word (no spaces or shell
+ * metacharacters), so it survives being handed to ssh as a single argument and
+ * re-parsed by the remote's cmd.exe/PowerShell with zero quoting hazards —
+ * the robust way to ship a complex command to a Windows box over SSH.
+ */
+export function encodePowershell(script: string): string {
+  return Buffer.from(script, 'utf16le').toString('base64');
+}
+
+/** Inverse of {@link encodePowershell} — decode an `-EncodedCommand` payload
+ * back to its script. Used by tests to assert on the built command. */
+export function decodePowershell(encoded: string): string {
+  return Buffer.from(encoded, 'base64').toString('utf16le');
+}
+
+/** A single `agents …` invocation to run on a Windows remote. */
+export interface WindowsAgentsCommand {
+  /** `agents` argv (command name NOT included; `agents` is prepended). */
+  args: string[];
+  /** Env vars scoped to this invocation (POSIX `VAR=val` ↔ PS `$env:VAR=…`). */
+  env?: Record<string, string>;
+  /** Directory to enter before running (`--remote-cwd`). */
+  cwd?: string;
+  /**
+   * Append `exit $LASTEXITCODE` so a native `agents` exit code propagates out
+   * through `powershell.exe` (which otherwise exits 0 regardless). Default true;
+   * pass false for probes whose reachability keys off a sentinel, not the code.
+   */
+  propagateExit?: boolean;
+}
+
+/**
+ * The PowerShell script (pre-encoding) that {@link buildWindowsAgentsCommand}
+ * runs. Exposed so tests can decode the `-EncodedCommand` payload and compare
+ * against the exact script, without needing PowerShell on the test host.
+ *
+ * `& agents …` invokes the CLI from the machine PATH (Windows has no login
+ * shell, so there is no `bash -lc` equivalent — the shim is simply on PATH).
+ */
+export function windowsAgentsScript(cmd: WindowsAgentsCommand): string {
+  const { args, env, cwd, propagateExit = true } = cmd;
+  const parts: string[] = [];
+  if (env) for (const [k, v] of Object.entries(env)) parts.push(`$env:${k} = ${powershellQuote(v)}`);
+  if (cwd) parts.push(`Set-Location -LiteralPath ${powershellQuote(cwd)}`);
+  parts.push(`& ${['agents', ...args].map(powershellQuote).join(' ')}`);
+  if (propagateExit) parts.push('exit $LASTEXITCODE');
+  return parts.join('; ');
+}
+
+/**
+ * Build the `ssh <target> <cmd>` string for one `agents …` invocation on a
+ * Windows remote: a `powershell -NoProfile -EncodedCommand <base64>` call. The
+ * Windows counterpart of `bash -lc '<...>'`, shared by every `--host` site.
+ */
+export function buildWindowsAgentsCommand(cmd: WindowsAgentsCommand): string {
+  return `powershell -NoProfile -EncodedCommand ${encodePowershell(windowsAgentsScript(cmd))}`;
 }

--- a/src/lib/hosts/remote-os.ts
+++ b/src/lib/hosts/remote-os.ts
@@ -1,0 +1,30 @@
+/**
+ * Resolve a remote host's OS family so the SSH command layer can pick the right
+ * shell dialect (POSIX `bash -lc` vs Windows PowerShell). See `remoteShellFor`
+ * in `remote-cmd.ts` for how the string is consumed.
+ *
+ * Two sources, in priority order:
+ *   1. The device registry `platform` (`windows`/`linux`/`macos`), which is
+ *      populated fleet-wide by Tailscale sync — the reliable answer for a box
+ *      like `win-mini` that was discovered, not hand-enrolled.
+ *   2. The enrolled `HostEntry.os` overlay in agents.yaml (the `uname` captured
+ *      at `agents hosts add` time), for hosts that live only in that overlay.
+ *
+ * Missing/unknown from both → `undefined`, which `remoteShellFor` maps to POSIX.
+ * Kept synchronous so the sync `agents sessions --host` fan-out can use it.
+ */
+
+import { loadDevicesSync } from '../devices/registry.js';
+import { readMeta } from '../state.js';
+
+/** Resolve the OS/platform string for a host name, or undefined if unknown. */
+export function resolveRemoteOsSync(name: string): string | undefined {
+  try {
+    const platform = loadDevicesSync()[name]?.platform;
+    if (platform && platform !== 'unknown') return platform;
+  } catch {
+    // A corrupt/unreadable device registry must never break command building —
+    // fall through to the host overlay and ultimately the POSIX default.
+  }
+  return readMeta().hosts?.[name]?.os;
+}

--- a/src/lib/secrets/remote.ts
+++ b/src/lib/secrets/remote.ts
@@ -16,11 +16,20 @@
  * in argv / `ps` / remote shell history. Nothing is persisted locally.
  */
 
-import { sshExec, assertValidSshTarget, shellQuote, type SshExecResult } from '../ssh-exec.js';
+import { sshExec, assertValidSshTarget, type SshExecResult } from '../ssh-exec.js';
 import { resolveHost } from '../hosts/registry.js';
 import { sshTargetFor } from '../hosts/types.js';
+import { buildRemoteAgentsInvocation } from '../hosts/remote-cmd.js';
+import { resolveRemoteOsSync } from '../hosts/remote-os.js';
 
 const REMOTE_TIMEOUT_MS = 30_000;
+
+/** Remote OS for a target string (bare alias matches a device entry; a raw
+ * `user@host` falls back to POSIX). Threaded into the command builder so a
+ * Windows host gets PowerShell instead of `bash -lc`. */
+function osForTarget(target: string): string | undefined {
+  return resolveRemoteOsSync(target.split('@').pop() ?? target);
+}
 
 /**
  * Resolve a `--host` value to an ssh target string. Tries the `agents hosts`
@@ -82,8 +91,7 @@ export function remoteSecretsRaw(
   args: string[],
   opts: { tty?: boolean; input?: string } = {},
 ): SshExecResult {
-  const inner = ['agents', 'secrets', ...args].map(shellQuote).join(' ');
-  const remoteCmd = `bash -lc ${shellQuote(inner)}`;
+  const remoteCmd = buildRemoteAgentsInvocation(['secrets', ...args], undefined, osForTarget(target));
   return sshExec(target, remoteCmd, {
     timeoutMs: REMOTE_TIMEOUT_MS,
     input: opts.input,
@@ -106,8 +114,12 @@ export function remoteSecretsRaw(
  */
 export async function remoteResolveEnv(target: string, bundle: string): Promise<Record<string, string>> {
   assertValidSshTarget(target);
-  const exportCmd = `agents secrets export ${shellQuote(bundle)} --plaintext --format json`;
-  const res: SshExecResult = sshExec(target, `bash -lc ${shellQuote(exportCmd)}`, {
+  const remoteCmd = buildRemoteAgentsInvocation(
+    ['secrets', 'export', bundle, '--plaintext', '--format', 'json'],
+    undefined,
+    osForTarget(target),
+  );
+  const res: SshExecResult = sshExec(target, remoteCmd, {
     timeoutMs: REMOTE_TIMEOUT_MS,
   });
 

--- a/src/lib/session/remote-active.ts
+++ b/src/lib/session/remote-active.ts
@@ -19,6 +19,8 @@ import chalk from 'chalk';
 import { SSH_OPTS, controlOpts, assertValidSshTarget, shellQuote } from '../ssh-exec.js';
 import { sshTargetFor } from '../devices/connect.js';
 import { loadDevices, type DeviceProfile } from '../devices/registry.js';
+import { remoteShellFor, buildWindowsAgentsCommand } from '../hosts/remote-cmd.js';
+import { resolveRemoteOsSync } from '../hosts/remote-os.js';
 import { machineId, normalizeHost } from './sync/config.js';
 import type { ActiveSession } from './active.js';
 
@@ -33,8 +35,16 @@ const REMOTE_TIMEOUT_MS = 12_000;
  */
 export const NO_FANOUT_ENV = 'AGENTS_SESSIONS_LOCAL';
 
-/** The command run on each peer: answer for itself, as JSON, without recursing. */
-function remoteActiveCommand(): string {
+/** The command run on each peer: answer for itself, as JSON, without recursing.
+ * A Windows peer gets a PowerShell invocation (ssh lands in cmd.exe/PowerShell
+ * there, where `bash -lc` is not a command); every other OS keeps `bash -lc`. */
+function remoteActiveCommand(os?: string): string {
+  if (remoteShellFor(os) === 'powershell') {
+    return buildWindowsAgentsCommand({
+      args: ['sessions', '--active', '--json'],
+      env: { [NO_FANOUT_ENV]: '1' },
+    });
+  }
   const inner = `${NO_FANOUT_ENV}=1 agents sessions --active --json`;
   return `bash -lc ${shellQuote(inner)}`;
 }
@@ -84,8 +94,8 @@ function sshCapture(target: string, remoteCmd: string, timeoutMs: number): Promi
   });
 }
 
-async function fetchByTarget(target: string, machine: string, display: string): Promise<ActiveSession[]> {
-  const { code, stdout } = await sshCapture(target, remoteActiveCommand(), REMOTE_TIMEOUT_MS);
+async function fetchByTarget(target: string, machine: string, display: string, os?: string): Promise<ActiveSession[]> {
+  const { code, stdout } = await sshCapture(target, remoteActiveCommand(os), REMOTE_TIMEOUT_MS);
   if (code !== 0) {
     process.stderr.write(chalk.gray(`  ${display}: unreachable or no agents CLI — skipped\n`));
     return [];
@@ -107,7 +117,7 @@ export interface RemoteActiveResult {
  */
 export async function gatherRemoteActive(hosts?: string[]): Promise<RemoteActiveResult> {
   const self = machineId();
-  const targets: Array<{ target: string; machine: string; name: string }> = [];
+  const targets: Array<{ target: string; machine: string; name: string; os?: string }> = [];
 
   if (hosts && hosts.length > 0) {
     for (const h of hosts) {
@@ -118,7 +128,9 @@ export async function gatherRemoteActive(hosts?: string[]): Promise<RemoteActive
         continue;
       }
       const bareHost = h.split('@').pop() || h;
-      targets.push({ target: h, machine: normalizeHost(bareHost), name: h });
+      // Resolve the OS by the name the user passed (a bare alias like `win-mini`
+      // matches a device-registry entry; a raw `user@host` falls back to POSIX).
+      targets.push({ target: h, machine: normalizeHost(bareHost), name: h, os: resolveRemoteOsSync(h) });
     }
   } else {
     let reg: Record<string, DeviceProfile>;
@@ -135,13 +147,13 @@ export async function gatherRemoteActive(hosts?: string[]): Promise<RemoteActive
       // full ConnectTimeout on each.
       if (d.platform !== 'windows' && d.platform !== 'linux' && d.platform !== 'macos') continue;
       try {
-        targets.push({ target: sshTargetFor(d), machine: normalizeHost(d.name), name: d.name });
+        targets.push({ target: sshTargetFor(d), machine: normalizeHost(d.name), name: d.name, os: d.platform });
       } catch {
         // No address on the profile — nothing to dial; skip silently.
       }
     }
   }
 
-  const results = await Promise.all(targets.map((t) => fetchByTarget(t.target, t.machine, t.name)));
+  const results = await Promise.all(targets.map((t) => fetchByTarget(t.target, t.machine, t.name, t.os)));
   return { sessions: results.flat(), deviceCount: targets.length };
 }

--- a/src/lib/session/remote.ts
+++ b/src/lib/session/remote.ts
@@ -28,6 +28,8 @@ import { createHash } from 'crypto';
 import chalk from 'chalk';
 import { getCacheDir } from '../state.js';
 import { SSH_OPTS, controlOpts } from '../ssh-exec.js';
+import { remoteShellFor, buildWindowsAgentsCommand } from '../hosts/remote-cmd.js';
+import { resolveRemoteOsSync } from '../hosts/remote-os.js';
 import { formatRelativeTime } from './relative-time.js';
 import { terminalWidth } from './width.js';
 
@@ -91,8 +93,18 @@ export function buildForwardedArgs(argv: string[], hosts: Set<string> = new Set(
  * Build the single remote command string for `ssh <host> <cmd>`. Forwarded args
  * are quoted for the inner login shell, then the whole `agents …` invocation is
  * quoted again so it survives `bash -lc <...>`.
+ *
+ * `os` selects the remote shell: a Windows host gets a PowerShell invocation
+ * (ssh lands in cmd.exe/PowerShell there, where `bash -lc` does not exist);
+ * anything else — including unknown/absent — keeps the POSIX form unchanged.
+ * The forwarded terminal width rides across as an env var either way so the
+ * remote renders its table to the local screen.
  */
-export function buildRemoteCommand(forwardedArgs: string[], columns?: number): string {
+export function buildRemoteCommand(forwardedArgs: string[], columns?: number, os?: string): string {
+  if (remoteShellFor(os) === 'powershell') {
+    const env = columns && columns > 0 ? { COLUMNS: String(columns) } : undefined;
+    return buildWindowsAgentsCommand({ args: forwardedArgs, env });
+  }
   const inner = ['agents', ...forwardedArgs].map(shellQuote).join(' ');
   // Forward the caller's terminal width so the remote renders the table to the
   // local screen (over SSH the remote's own COLUMNS is unset/wrong). `VAR=val
@@ -187,12 +199,14 @@ export function runRemoteSessions(hosts: string[], argv: string[] = process.argv
   for (const host of hosts) assertValidSshTarget(host); // fail fast on any bad target
 
   const forwarded = buildForwardedArgs(argv, new Set(hosts));
-  const remoteCmd = buildRemoteCommand(forwarded, terminalWidth());
+  const cols = terminalWidth();
   const multi = hosts.length > 1;
   let failures = 0;
 
   for (const host of hosts) {
     if (multi) process.stdout.write(chalk.cyan(`\n── ${host} ──\n`));
+    // Per-host: a Windows peer needs a PowerShell command, POSIX peers `bash -lc`.
+    const remoteCmd = buildRemoteCommand(forwarded, cols, resolveRemoteOsSync(host));
     const res = spawnSync('ssh', [...SSH_OPTS, ...controlOpts(), host, remoteCmd], {
       encoding: 'utf8',
       maxBuffer: 64 * 1024 * 1024,


### PR DESCRIPTION
## RUSH-1429: `--host` operations fail against Windows remotes

Every remote `--host` invocation wrapped the command in `bash -lc`. On a
Windows box ssh lands in cmd.exe/PowerShell, where `bash` does not exist, so
probe, session-query, inventory, and secrets-read all failed against Windows
nodes (e.g. `win-mini`).

### Reproduce (before / after)

`agents sessions --active --json --host win-mini`

- **Before:** the remote query runs `bash -lc '…'` → `'bash' is not recognized as
  an internal or external command` → the host is reported as a failed remote
  query / skipped.
- **After (proven with the real device registry on yosemite-s1):** the same
  invocation builds `powershell -NoProfile -EncodedCommand <base64>`, which
  decodes (UTF-16LE) to:

  ```
  & 'agents' 'sessions' '--active' '--json'; exit $LASTEXITCODE
  ```

  A POSIX peer (`alpha`, linux) is byte-identical to before:
  `bash -lc 'agents sessions --active --json'`.

> **Live end-to-end against win-mini is blocked from yosemite-s1:** SSH to
> win-mini uses password auth via the `muqsit` secrets bundle, which is not
> present on this host (`Permission denied (publickey,password,keyboard-interactive)`),
> so the box is unreachable here **regardless of this change**. The command-layer
> fix is verified via unit tests + a decoded build-output demonstration against
> the real device-registry `platform: windows`; the full round-trip needs a host
> that holds win-mini's credentials.

### Approach

- **OS → shell dialect at the source.** `remoteShellFor(os)` maps `windows` →
  PowerShell and everything else (incl. unknown/absent) → POSIX, so linux/macos
  never regress. `resolveRemoteOsSync(name)` reads the OS from the device
  registry (`platform`, fleet-wide via tailscale) and falls back to enrolled
  `HostEntry.os`.
- **Windows invocation.** `buildWindowsAgentsCommand` emits
  `powershell -NoProfile -EncodedCommand <base64-utf16le>`. `-EncodedCommand`
  sidesteps every cmd.exe/PowerShell quoting hazard; `agents` resolves from the
  machine PATH (Windows has no login shell).

### Files changed

| File | What |
|---|---|
| `src/lib/hosts/remote-cmd.ts` | shared shell-dialect builders (`remoteShellFor`, `buildWindowsAgentsCommand`, `powershellQuote`, `encode/decodePowershell`) + read-only passthrough builder |
| `src/lib/hosts/remote-os.ts` (new) | `resolveRemoteOsSync` — device platform → `HostEntry.os` → POSIX |
| `src/lib/devices/registry.ts` | `loadDevicesSync` for the sync sessions fan-out |
| `src/lib/hosts/ready.ts` | reachability probe (`:44,57,85`) — Windows PowerShell probe / native install / sentinel readyProbe, via extracted pure builders |
| `src/lib/hosts/dispatch.ts` | detached `run --host` (`:60`) — **fails fast on Windows** (see below) |
| `src/lib/session/remote-active.ts` | `sessions --active --host` fan-out (**the reproduce**) |
| `src/lib/session/remote.ts` | `sessions --host` query |
| `src/lib/secrets/remote.ts` | `secrets` browse + remote-bundle resolve over `--host` |
| `src/lib/hosts/passthrough.ts`, `src/commands/hosts.ts` | thread resolved OS in |

The three sites the ticket named are fixed; `remote.ts` / `remote-active.ts`
were fixed too because that is the actual code path the reproduce command flows
through, and the two `secrets` read sites because they are the same
single-round-trip `--host` shape.

### Detached dispatch to Windows: fail-fast, not a partial

A first pass converted the `dispatch.ts` *launch* to `Start-Process`, but the
detached-run *read-back* (`progress.ts`/`reconcile.ts`) offset-tails the remote
log with POSIX `tail -c`/`printf`/`cat`/`stat` and is **not** OS-aware — so
`run --host <windows>` would launch but hang on follow forever. Rather than ship
that half, `launchDetached` now **refuses a Windows target with an actionable
error**. Making detached dispatch fully work on Windows (a PowerShell
follow/reconcile dialect) is a scoped follow-up.

### Also out of scope (documented follow-up)

`secrets export/import --host` (the *write* path, `commands/secrets.ts:1303`)
stays POSIX-only — it uses `IFS= read` / `/dev/stdin` / `export`, which need a
real PowerShell rewrite, and the flow is keychain-bound (unverifiable here).

### Tests

- `remote-cmd.test.ts`: Windows target → `-EncodedCommand`, decoded script
  matches exactly (args, `--remote-cwd` `Set-Location`, `$env:` vars,
  injection-safety); POSIX byte-identical.
- `ready.test.ts`: the extracted Windows probe / version / readyProbe / bootstrap
  builders decoded and asserted (the quoting-sensitive `Select-Object -Last`,
  `Test-Path`, `Write-Output` sentinel scripts), plus the POSIX branch byte-for-byte.

`bun run test` (vitest): **3811 passed**. The only failures (6, in
`sync/config.test.ts` and `events-audit.test.ts`) reproduce identically on a
clean `origin/main` checkout — pre-existing environmental failures (locked
keychain on this Linux host), untouched by this change.
