### PR TITLE
feat(menubar): wire watchdog auto-nudge into the native tick (RUSH-1415)

### DIFF
--- a/packages/menubar-helper/Sources/MenubarHelper/AgentsCLI.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/AgentsCLI.swift
@@ -68,6 +68,29 @@ enum AgentsCLI {
         return try? JSONDecoder().decode(DoctorOverview.self, from: data)
     }
 
+    // RUSH-1415: is global auto-nudge on? The Swift menu-bar toggle drives this
+    // sentinel via watchdogSetEnabled; the tick reads it back to decide whether
+    // to inject or stay detect-only.
+    static func watchdogStatus() -> WatchdogStatus? {
+        guard let data = capture(argv(["watchdog", "status", "--json"])) else { return nil }
+        return try? JSONDecoder().decode(WatchdogStatus.self, from: data)
+    }
+
+    // RUSH-1415: run one watchdog tick. `nudge` actually injects "Continue." into
+    // stalled+addressable splits; without it the tick is detect-only (for the
+    // badge). The CLI's own cooldown ledger prevents re-nudging the same split, so
+    // this is safe to call on every 10s menu-bar poll.
+    static func watchdogTick(nudge: Bool) -> WatchdogTick? {
+        var a = ["watchdog", "--json"]
+        if nudge { a.append("--nudge") }
+        guard let data = capture(argv(a)) else { return nil }
+        return try? JSONDecoder().decode(WatchdogTick.self, from: data)
+    }
+
+    static func watchdogSetEnabled(_ on: Bool) {
+        runDetached(argv(["watchdog", on ? "enable" : "disable"]))
+    }
+
     // MARK: Actions
     // New interactive session: open a Terminal window running `agents run <agent>`.
     // A status-bar click can't host a TUI, so hand off to the user's terminal.

--- a/packages/menubar-helper/Sources/MenubarHelper/Models.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/Models.swift
@@ -62,6 +62,27 @@ struct DoctorSync: Decodable {
     let status: String
 }
 
+// `agents watchdog --json` tick result (RUSH-1415). The menu-bar reads the
+// convenience counts; `didNudge` reflects whether this tick was allowed to inject.
+struct WatchdogTick: Decodable {
+    let didNudge: Bool
+    let counts: WatchdogCounts
+}
+
+struct WatchdogCounts: Decodable {
+    let total: Int
+    let stalled: Int
+    let nudged: Int
+    let unaddressable: Int
+    let skipped: Int
+}
+
+// `agents watchdog status --json` — is global auto-nudge on?
+struct WatchdogStatus: Decodable {
+    let enabled: Bool
+    let stateDir: String?
+}
+
 struct DoctorOrphan: Decodable {
     let agent: String
     let version: String?

--- a/packages/menubar-helper/Sources/MenubarHelper/StatusItemController.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/StatusItemController.swift
@@ -38,6 +38,13 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     private var doctorInFlight = false
     private var doctorFetchedAt: Date?
 
+    // RUSH-1415: watchdog auto-nudge. Each tick runs `agents watchdog`; when the
+    // toggle (watchdogEnabled) is on it injects "Continue." into stalled splits.
+    private var cachedWatchdog: WatchdogTick?
+    private var watchdogEnabled = false
+    private var watchdogInFlight = false
+    private var watchdogFetchedAt: Date?
+
     func install() {
         if let button = statusItem.button {
             button.image = Icon.make()
@@ -77,6 +84,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         refreshRoutines()
         refreshRecentSessions()
         refreshDoctorOverview()
+        refreshWatchdog()
     }
 
     private func loadDumpCaches() {
@@ -142,6 +150,26 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         }
     }
 
+    // RUSH-1415: run one watchdog tick each poll. Reads the enable sentinel first,
+    // then ticks with nudge=enabled so auto-nudge fires only when the toggle is on
+    // (detect-only otherwise). No time-throttle: nudging must be timely, and the
+    // CLI's cooldown ledger already prevents re-nudging the same split.
+    private func refreshWatchdog() {
+        if watchdogInFlight { return }
+        watchdogInFlight = true
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let enabled = AgentsCLI.watchdogStatus()?.enabled ?? false
+            let tick = AgentsCLI.watchdogTick(nudge: enabled)
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.watchdogEnabled = enabled
+                self.cachedWatchdog = tick
+                self.watchdogFetchedAt = Date()
+                self.watchdogInFlight = false
+            }
+        }
+    }
+
     private func refreshBadge() {
         guard let button = statusItem.button else { return }
         let attention = badgeSessions.filter { $0.status == .attention }.count
@@ -183,6 +211,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         refreshRoutines()
         refreshRecentSessions()
         refreshDoctorOverview()
+        refreshWatchdog()
     }
 
     private func rebuild(_ menu: NSMenu, sessions: [Session], browserTasks: [BrowserTask],
@@ -218,6 +247,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
 
         addRoutinesRow(menu, routines: routines)
         addSetup(menu, doctor: doctor)
+        addWatchdog(menu)
 
         menu.addItem(.separator())
         addFooter(menu, daemonPid: daemonPid)
@@ -399,6 +429,24 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         menu.addItem(item)
     }
 
+    // RUSH-1415: a checkable row that toggles global auto-nudge. Checked = the tick
+    // injects "Continue." into stalled+addressable splits; unchecked = detect-only.
+    private func addWatchdog(_ menu: NSMenu) {
+        let toggle = NSMenuItem(title: "\(pad("Auto-nudge"))\(watchdogSummary())",
+                                action: #selector(onToggleWatchdog), keyEquivalent: "")
+        toggle.target = self
+        toggle.state = watchdogEnabled ? .on : .off
+        menu.addItem(toggle)
+    }
+
+    private func watchdogSummary() -> String {
+        guard let c = cachedWatchdog?.counts, c.stalled > 0 else {
+            return watchdogEnabled ? "on" : "off"
+        }
+        let action = watchdogEnabled ? "\(c.nudged) nudged" : "detect-only"
+        return "\(c.stalled) stalled · \(action)"
+    }
+
     private func addFooter(_ menu: NSMenu, daemonPid: Int?) {
         if daemonPid != nil {
             let stop = NSMenuItem(title: "Stop scheduler", action: #selector(onStopScheduler), keyEquivalent: "")
@@ -572,6 +620,12 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     // MARK: Actions
     @objc private func onNewSession(_ s: NSMenuItem) {
         if let a = s.representedObject as? String { AgentsCLI.newSession(agent: a) }
+    }
+    // RUSH-1415: flip global auto-nudge. Optimistically update local state so the
+    // checkmark reflects immediately; the next tick re-reads the sentinel as truth.
+    @objc private func onToggleWatchdog() {
+        watchdogEnabled.toggle()
+        AgentsCLI.watchdogSetEnabled(watchdogEnabled)
     }
     @objc private func onRoutineRun(_ s: NSMenuItem) { withName(s, AgentsCLI.routineRun) }
     @objc private func onRoutinePause(_ s: NSMenuItem) { withName(s, AgentsCLI.routinePause) }

--- a/packages/menubar-helper/Sources/MenubarHelper/StatusItemController.swift
+++ b/packages/menubar-helper/Sources/MenubarHelper/StatusItemController.swift
@@ -156,6 +156,10 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     // CLI's cooldown ledger already prevents re-nudging the same split.
     private func refreshWatchdog() {
         if watchdogInFlight { return }
+        // Throttle like the sibling refreshers: a 30s floor keeps this well under
+        // the 5m stall threshold (still timely) while cutting the two subprocess
+        // spawns per tick from 6x/min to ~2x/min on a battery-sensitive helper.
+        if let t = watchdogFetchedAt, Date().timeIntervalSince(t) < 30 { return }
         watchdogInFlight = true
         DispatchQueue.global(qos: .utility).async { [weak self] in
             let enabled = AgentsCLI.watchdogStatus()?.enabled ?? false

--- a/src/commands/watchdog.test.ts
+++ b/src/commands/watchdog.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for the `agents watchdog` command surface (RUSH-1415).
+ *
+ * Focus: `watchdog status --json` — the read the Swift menu-bar helper decodes to
+ * drive its auto-nudge toggle. The parent `watchdog` command ALSO declares --json
+ * and greedily parses it before dispatching to `status`, so the flag lands on the
+ * parent, not the subcommand. The action reads it via optsWithGlobals(); if that
+ * regressed to plain opts.json, `status --json` would silently emit human text and
+ * the Swift JSONDecoder would get nothing. These tests lock that behavior.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import { registerWatchdogCommand } from './watchdog.js';
+
+/** Run `agents watchdog <args...>`, capturing stdout lines the action prints. */
+async function runWatchdog(args: string[]): Promise<string[]> {
+  const program = new Command();
+  program.exitOverride(); // throw instead of process.exit on parse errors
+  registerWatchdogCommand(program);
+
+  const lines: string[] = [];
+  const orig = console.log;
+  console.log = (...a: unknown[]) => { lines.push(a.map(String).join(' ')); };
+  try {
+    await program.parseAsync(['node', 'agents', 'watchdog', ...args]);
+  } finally {
+    console.log = orig;
+  }
+  return lines;
+}
+
+describe('watchdog status --json', () => {
+  let origLog: typeof console.log;
+  beforeEach(() => { origLog = console.log; });
+  afterEach(() => { console.log = origLog; });
+
+  it('emits a single JSON object with a boolean `enabled` and a `stateDir`', async () => {
+    const lines = await runWatchdog(['status', '--json']);
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]) as { enabled: unknown; stateDir: unknown };
+    expect(typeof parsed.enabled).toBe('boolean');
+    expect(typeof parsed.stateDir).toBe('string');
+    expect((parsed.stateDir as string).length).toBeGreaterThan(0);
+  });
+
+  it('without --json prints human text, not JSON', async () => {
+    const lines = await runWatchdog(['status']);
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    // The human path is two lines starting with the enable-state label.
+    expect(lines[0]).toContain('global auto-nudge');
+    expect(() => JSON.parse(lines[0])).toThrow();
+  });
+});

--- a/src/commands/watchdog.ts
+++ b/src/commands/watchdog.ts
@@ -226,8 +226,18 @@ export function registerWatchdogCommand(program: Command): void {
 
   cmd.command('status')
     .description('Show whether global auto-nudge is on and where state is written.')
-    .action(() => {
+    .option('--json', 'Emit status as JSON (for the menu-bar / scripts)')
+    .action((_opts, command) => {
+      // The parent `watchdog` command also declares --json and greedily parses it
+      // before dispatching here, so `watchdog status --json` lands the flag on the
+      // parent, not this subcommand. optsWithGlobals() merges both levels, so we
+      // read it correctly regardless of which command commander bound it to.
+      const json = command.optsWithGlobals().json === true;
       const on = isGloballyEnabled();
+      if (json) {
+        console.log(JSON.stringify({ enabled: on, stateDir: stateDir() }));
+        return;
+      }
       console.log(`global auto-nudge: ${on ? chalk.green('ON') : chalk.dim('off')}`);
       console.log(`state dir: ${chalk.dim(stateDir())}`);
     });


### PR DESCRIPTION
## What

Wires the shipped \`agents watchdog\` consumer (PR #619) into the native macOS menu-bar helper's tick — the parked piece of RUSH-1415. Before this, the 10s \`tick()\` refreshed install/sync status only, so the tray never auto-nudged stalled agents.

## Changes

- **`StatusItemController.tick()`** now calls `refreshWatchdog()`: reads the enable sentinel, then runs one watchdog tick with `nudge=enabled` (detect-only when off). No time-throttle — the CLI's own cooldown ledger already prevents re-nudging the same split.
- **Checkable "Auto-nudge" menu row** toggles global auto-nudge via `agents watchdog enable|disable`, and surfaces `N stalled · M nudged` (or `detect-only` when off).
- **`AgentsCLI`** gains `watchdogStatus()` / `watchdogTick(nudge:)` / `watchdogSetEnabled()`, mirroring the existing `doctorOverview()` shell-and-decode pattern.
- **`watchdog status --json`** added for the Swift helper to read. The parent \`watchdog\` command also declares `--json` and greedily parses it, so the status action reads it via `optsWithGlobals()`; a colocated test locks this (reverting to plain `opts.json` makes `status --json` emit human text and fails the test).

## Design decision

The tick **detects every poll** and **injects only when the menu-bar toggle is on** — matching the `isGloballyEnabled()` sentinel the CLI already anticipated for "the Swift menu-bar toggle."

## Verification

- `swift build` clean (menubar-helper)
- 65 watchdog tests pass (`src/lib/watchdog` + new `src/commands/watchdog.test.ts`)
- `tsc --noEmit` clean
- Live round-trip against the real CLI: `watchdog status --json` → `{"enabled":false,...}`; `enable`→`true`→`disable`→`false` (restored); `watchdog --json` dry tick emits the exact `counts` shape the Swift `WatchdogTick` decodes

## Not covered (needs a GUI round-trip on a real screen)

Live iTerm/VSCodium injection delivery and a full auto-nudge of a genuinely stalled agent — the honest gaps carried over from the original watchdog work; the addressing logic is already verified, GUI delivery needs an interactive run.