### PR TITLE
fix(sessions): resume session via shell on Windows (spawn EFTYPE)

### DIFF
--- a/src/commands/__tests__/sessions.test.ts
+++ b/src/commands/__tests__/sessions.test.ts
@@ -7,6 +7,7 @@ import { spawnSync } from 'child_process';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 import { buildResumeCommand } from '../sessions.js';
+import { needsWindowsShell } from '../../lib/platform/index.js';
 import type { SessionMeta } from '../../lib/session/types.js';
 
 const repoRoot = process.cwd();
@@ -887,5 +888,23 @@ describe('buildResumeCommand version-pinned resume', () => {
   it('returns null for agents without resume support', () => {
     expect(buildResumeCommand(baseSession({ agent: 'gemini', version: '1.0.0' }))).toBeNull();
     expect(buildResumeCommand(baseSession({ agent: 'openclaw', version: '1.0.0' }))).toBeNull();
+  });
+
+  // Regression: resumeSessionInPlace must spawn the resume launcher through the
+  // shell on Windows. The launcher is a bare command / `.cmd` shim
+  // (`claude@2.1.138`, `codex`), which `spawn` can't exec directly on win32 —
+  // a `shell:false` spawn there threw `EFTYPE` and surfaced as a misleading
+  // "Failed to discover sessions" error. Off Windows it must stay a direct exec.
+  it('resume launcher requires a shell on win32 and not on posix', () => {
+    for (const session of [
+      baseSession({ version: '2.1.138' }),                       // claude@2.1.138
+      baseSession({ version: undefined }),                       // bare claude
+      baseSession({ agent: 'codex', version: '0.116.0' }),       // codex@0.116.0
+      baseSession({ agent: 'opencode', version: '0.5.0' }),      // opencode
+    ]) {
+      const launcher = buildResumeCommand(session)![0];
+      expect(needsWindowsShell(launcher, 'win32')).toBe(true);
+      expect(needsWindowsShell(launcher, 'linux')).toBe(false);
+    }
   });
 });

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -10,7 +10,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { spawn } from 'child_process';
+import { spawn, type ChildProcess } from 'child_process';
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
@@ -18,7 +18,7 @@ import type { AgentId } from '../lib/types.js';
 import type { SessionAgentId, SessionMeta, ViewMode } from '../lib/session/types.js';
 import { SESSION_AGENTS } from '../lib/session/types.js';
 import { discoverArtifacts, readArtifact, resolveArtifact } from '../lib/session/artifacts.js';
-import { looksLikePath, toComparablePath, homeDir } from '../lib/platform/index.js';
+import { looksLikePath, toComparablePath, homeDir, needsWindowsShell, findExecutable } from '../lib/platform/index.js';
 import { getActiveSessions, type ActiveSession } from '../lib/session/active.js';
 import { machineId, normalizeHost } from '../lib/session/sync/config.js';
 import { gatherRemoteActive } from '../lib/session/remote-active.js';
@@ -1302,28 +1302,52 @@ export async function resumeSessionInPlace(session: SessionMeta): Promise<void> 
 
   console.log(chalk.gray(`Resuming: ${resume.join(' ')} (cwd: ${cwd})`));
 
-  await new Promise<void>((resolve) => {
-    const child = spawn(resume[0], resume.slice(1), {
-      cwd,
-      stdio: 'inherit',
-      shell: false,
-    });
+  // Resolve the (possibly version-pinned) launcher up front. On Windows the
+  // agent shim is a `.cmd`/`.ps1` and, under the shell needed to run it (see
+  // spawnResumeCommand), a missing command exits non-zero rather than emitting
+  // an ENOENT `error` event — so detect a removed version here instead of
+  // relying on that event, keeping the /continue fallback working on every OS.
+  if (!findExecutable(resume[0]) && session.version) {
+    const fallback = buildFallbackCommand(session);
+    if (fallback) {
+      console.log(chalk.gray(
+        `Version ${session.version} is not installed. Falling back to current version via /continue...`
+      ));
+      await spawnResumeCommand(fallback, cwd);
+      return;
+    }
+  }
+
+  await spawnResumeCommand(resume, cwd);
+}
+
+/**
+ * Spawn a resume command as a foreground takeover (inherited stdio), resolving
+ * when it exits. On Windows the agent launcher is a `.cmd`/PATHEXT shim that
+ * `spawn` can't exec directly — a bare-name `shell:false` spawn throws
+ * `EFTYPE`/`ENOENT` there — so we go through the shell via `needsWindowsShell`.
+ * The spawn is guarded because such a failure can be thrown synchronously;
+ * without the guard it would surface under an unrelated "Failed to discover
+ * sessions" catch upstream instead of a truthful launch error.
+ */
+function spawnResumeCommand(cmd: string[], cwd: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let child: ChildProcess;
+    try {
+      child = spawn(cmd[0], cmd.slice(1), {
+        cwd,
+        stdio: 'inherit',
+        shell: needsWindowsShell(cmd[0]),
+      });
+    } catch (err: any) {
+      console.error(chalk.red(`Failed to launch ${cmd[0]}: ${err.message}`));
+      resolve();
+      return;
+    }
     child.on('error', (err: any) => {
-      if (err.code === 'ENOENT' && session.version) {
-        const fallback = buildFallbackCommand(session);
-        if (fallback) {
-          console.log(chalk.gray(
-            `Version ${session.version} is not installed. Falling back to current version via /continue...`
-          ));
-          const fb = spawn(fallback[0], fallback.slice(1), { cwd, stdio: 'inherit', shell: false });
-          fb.on('error', (e: any) => { console.error(chalk.red(`Failed: ${e.message}`)); resolve(); });
-          fb.on('close', () => resolve());
-          return;
-        }
-      }
-      console.error(chalk.red(`Failed to launch ${resume[0]}: ${err.message}`));
+      console.error(chalk.red(`Failed to launch ${cmd[0]}: ${err.message}`));
       if (err.code === 'ENOENT') {
-        console.error(chalk.gray(`Make sure '${resume[0]}' is on your PATH.`));
+        console.error(chalk.gray(`Make sure '${cmd[0]}' is on your PATH.`));
       }
       resolve();
     });


### PR DESCRIPTION
## Problem

On Windows, `agents sessions` → pick a session → resume fails with:

```
✔ Search sessions: 94a8f70b
Resuming: claude@2.1.196 --resume 94a8f70b-... (cwd: C:\Users\...\Boros)
Failed to discover sessions: spawn EFTYPE
```

Discovery actually worked (it populated the picker). The crash was in the **resume** step and the error message was **mis-attributed** to discovery.

## Root cause

`resumeSessionInPlace` spawned the version-pinned launcher (`claude@2.1.196`) with `shell: false` hard-coded (`sessions.ts:1306`). On Windows that shim is a `.cmd`/extensionless file, not a literal `.exe`, so `spawn` with `shell:false` throws `EFTYPE` **synchronously** — which escaped the inner `child.on('error')` handler and bubbled up to the generic `discoverSessions` catch that prints "Failed to discover sessions".

The rest of the codebase already fixes this with the `needsWindowsShell` helper (`agents.ts:1457/1481`, `mcp.ts:346`); the resume spawns were simply never migrated.

## Fix (`src/commands/sessions.ts`)

1. Spawn through the shell on Windows via `shell: needsWindowsShell(cmd[0])`, so cmd.exe resolves the `.cmd` shim through PATHEXT.
2. Guard the spawn in a `spawnResumeCommand` helper so a synchronous launch failure is reported truthfully ("Failed to launch …") instead of masquerading as a discovery error.
3. Preserve the "version not installed → /continue" fallback by pre-resolving with `findExecutable` (the old ENOENT-event trigger can't fire under `shell:true`).

Both entry points — the interactive picker and `agents sessions resume` — route through `resumeSessionInPlace`, so both are fixed.

The resume args (a bare command + a session UUID) contain no spaces or shell metacharacters, so `shell:true` concatenation is safe here.

## Verification

- **Real-OS reproduction** on Windows: old spawn (`shell:false`) throws `EFTYPE`; new spawn (`shell:needsWindowsShell` → `true`) exits 0.
- **Regression test** added in `sessions.test.ts`: asserts the resume launcher requires a shell on `win32` and not on posix — passes.
- `tsc --noEmit`: clean.
- The one pre-existing unrelated test failure (`lists Gemini sessions…`) fails identically on `main` and is untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)