### PR TITLE
fix(windows): portable hook commands survive as ~/ + guard against stale dev-link dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "scripts": {
     "build": "tsc && rm -rf 'dist/lib/secrets/AgentsKeychain.app' 'dist/lib/secrets/Agents CLI.app' 'dist/lib/menubar/MenubarHelper.app' && ([ \"$(uname)\" = \"Darwin\" ] && cp -R 'bin/Agents CLI.app' 'dist/lib/secrets/Agents CLI.app' || true) && ([ \"$(uname)\" = \"Darwin\" ] && [ -d 'bin/MenubarHelper.app' ] && mkdir -p 'dist/lib/menubar' && cp -R 'bin/MenubarHelper.app' 'dist/lib/menubar/MenubarHelper.app' || true)",
     "build:bin": "scripts/build-bin.sh",
+    "prepare": "npm run build",
     "prepack": "scripts/verify-keychain-helper.sh && scripts/verify-menubar-helper.sh",
     "postinstall": "node scripts/postinstall.js",
     "dev": "tsx src/index.ts",

--- a/src/lib/__tests__/hooks.test.ts
+++ b/src/lib/__tests__/hooks.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
-import { registerHooksToSettings, unmanagedHookNames, computeCodexHookTrustHash } from '../hooks.js';
+import { registerHooksToSettings, unmanagedHookNames, computeCodexHookTrustHash, toPortableCommand } from '../hooks.js';
 import * as TOML from 'smol-toml';
 import { CODEX_HOOKS_MIN_VERSION } from '../agents.js';
 import { compareVersions } from '../versions.js';
@@ -929,5 +929,46 @@ describe('registerHooksToSettings - Droid', () => {
     const settings = readDroidSettings(versionHome);
     expect(settings.logoAnimation).toBe('off');
     expect(settings.hooks.PreToolUse).toHaveLength(1);
+  });
+});
+
+// Regression for the Windows hook-path bug: hook commands stored as absolute
+// Windows paths with backslashes ("C:\\Users\\...\\06-attention-sentinel.sh")
+// break at exec time because Claude runs hooks via bash, which strips the
+// backslashes -> "No such file or directory". The registrar must store the
+// portable "~/..." form. `sep` is injected so the Windows case is exercised on
+// a POSIX CI host (where path.sep is '/'), which is the only way the required
+// Linux `test` gate can catch a Windows-only path regression.
+describe('toPortableCommand — portable hook commands (Windows path regression)', () => {
+  const WIN_SEP = '\\';
+  const winHome = 'C:\\Users\\me';
+  const winHook =
+    'C:\\Users\\me\\.agents\\.history\\versions\\claude\\2.1.201\\home\\.claude\\hooks\\06-attention-sentinel.sh';
+
+  it('folds a Windows abs path under HOME to ~/ with forward slashes', () => {
+    const out = toPortableCommand(winHook, winHome, WIN_SEP);
+    expect(out).toBe(
+      '~/.agents/.history/versions/claude/2.1.201/home/.claude/hooks/06-attention-sentinel.sh'
+    );
+  });
+
+  it('never emits a backslash or drive-letter for a Windows path under HOME', () => {
+    const out = toPortableCommand(winHook, winHome, WIN_SEP);
+    expect(out).not.toContain('\\');
+    expect(out).not.toMatch(/^[a-zA-Z]:/);
+    expect(out.startsWith('~/')).toBe(true);
+  });
+
+  it('forward-slashes a Windows path OUTSIDE HOME (no verbatim backslashes)', () => {
+    const out = toPortableCommand('D:\\tools\\hooks\\g.sh', winHome, WIN_SEP);
+    // Not under HOME, so no ~/ fold — but it must still be backslash-free so
+    // bash does not mangle it.
+    expect(out).toBe('D:/tools/hooks/g.sh');
+    expect(out).not.toContain('\\');
+  });
+
+  it('folds a POSIX abs path under HOME to ~/ (macOS/Linux behavior unchanged)', () => {
+    const out = toPortableCommand('/home/me/.agents/hooks/g.sh', '/home/me', '/');
+    expect(out).toBe('~/.agents/hooks/g.sh');
   });
 });

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -71,11 +71,19 @@ function getManagedHookPrefixes(): string[] {
  * absolute Windows paths break in bash because backslashes are stripped as
  * escape characters, whereas ~/... paths expand correctly via the ~/.claude
  * symlink/junction on both platforms.
+ *
+ * `home` and `sep` are injectable so the Windows behavior (backslash sep,
+ * drive-letter home) is unit-testable on a POSIX CI host — pass sep='\\' to
+ * simulate Windows. With the defaults this is byte-identical to reading
+ * os.homedir()/path.sep at the call site.
  */
-function toPortableCommand(absPath: string): string {
-  const home = os.homedir();
-  const normalized = absPath.split(path.sep).join('/');
-  const homeNorm = home.split(path.sep).join('/');
+export function toPortableCommand(
+  absPath: string,
+  home: string = os.homedir(),
+  sep: string = path.sep
+): string {
+  const normalized = absPath.split(sep).join('/');
+  const homeNorm = home.split(sep).join('/');
   if (normalized.startsWith(homeNorm + '/')) {
     return '~/' + normalized.slice(homeNorm.length + 1);
   }


### PR DESCRIPTION
## Problem

On Windows, hook commands stored as absolute paths with backslashes (e.g. `C:\Users\me\...\hooks\06-attention-sentinel.sh`) break at exec time: Claude runs hooks via `bash`, which strips the backslashes → `C:Usersme...` → **"No such file or directory"**. This surfaced as repeated `UserPromptSubmit`/`Notification`/`Stop` hook errors.

The registrar already stores the portable `~/...` form (`toPortableCommand`, PR #303). Two gaps let the bug reach a running CLI anyway:

1. **No test asserted portability.** Every hook test routes the command through a `resolvedCommand()` helper that expands `~/` *and* posix-folds backslashes, so it passes whether the stored command is portable or a raw `C:\...` path. And the required `test` gate runs on `ubuntu-latest` only, where `path.sep` is `/` — a Windows-only separator bug is invisible there.
2. **Stale `dist/` on a dev link.** A global `npm link` points `agents` at the repo's gitignored `dist/`, which only updates on an explicit build. A checkout whose `dist/` predates the fix silently runs the old behavior.

## Changes

- **`toPortableCommand` is now pure/exported with injectable `home` + `sep`** (defaults `os.homedir()`/`path.sep`, so real-platform behavior is byte-identical). This makes the Windows case unit-testable on a POSIX CI host by passing `sep='\'`.
- **4 regression tests** simulate the Windows layout on any host and assert a backslash path under HOME folds to `~/...` with no backslash / no drive letter.
- **`prepare: npm run build`** rebuilds `dist/` on install/link in-repo (and before publish), so a stale dev-link `dist/` can't silently ship old behavior again.

## Testing

- `4 passed` new tests; existing Claude/Codex/Droid hook tests green; `tsc --noEmit` clean.
- `npm run build` clean on Windows; built `dist/lib/hooks.js` contains the fix.
- The 1 local suite failure is a **pre-existing** Windows file-symlink `EPERM` test, untouched by this diff.

## Follow-up (separate PR)

- Path-filtered `windows-latest` CI job for `src/lib/hooks.ts` / `src/lib/platform/**` so this class is caught on PRs.
- Green the pre-existing Windows-only test failures (symlink `EPERM` needs a junction fallback or Developer Mode; 3 `cache-integration` cases under bash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)