### PR TITLE
ci(windows): path-filtered Windows test gate + fix hook-cache python3 stub

### DIFF
--- a/.github/workflows/tests-windows-noop.yml
+++ b/.github/workflows/tests-windows-noop.yml
@@ -1,0 +1,32 @@
+name: Tests (Windows)
+
+# Companion shim for tests-windows.yml. GitHub leaves a required status check
+# stuck "Expected" (blocking the merge forever) when its workflow never
+# triggers because of an `on.paths` filter. This workflow carries the inverse
+# filter (`paths-ignore` with the identical list) and reports a passing
+# `test-windows` context for PRs that touch none of the separator-prone paths,
+# so `test-windows` can be a required check without deadlocking those PRs.
+# Keep this list byte-identical to the `paths` list in tests-windows.yml.
+
+on:
+  pull_request:
+    branches: ['main', 'release/**']
+    paths-ignore:
+      - 'src/lib/hooks.ts'
+      - 'src/lib/hooks/**'
+      - 'src/lib/platform/**'
+      - 'src/lib/shims*.ts'
+      - 'hooks/**'
+      - '.github/workflows/tests-windows.yml'
+
+concurrency:
+  group: tests-windows-noop-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-windows:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - run: echo "No separator-prone paths changed; Windows suite not required for this PR."

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -1,0 +1,44 @@
+name: Tests (Windows)
+
+# Path-filtered Windows gate. The required `test` job in tests.yml runs on
+# ubuntu-latest, where path.sep is '/', so a Windows-only separator bug (e.g.
+# hook commands stored as "C:\...\x.sh" that bash strips to garbage) is
+# invisible there and could only surface at release on ci.yml's cost-gated
+# matrix. This job runs the suite on windows-latest, but only when the
+# separator-prone code changes, so most PRs skip it and CI cost stays low.
+#
+# This is NOT the required `test` context (that stays Linux in tests.yml and is
+# matched by scripts/release.sh EXPECTED_CHECKS -- don't reuse that job name).
+# Add `test-windows` to branch protection to make it blocking.
+#
+# Tool versions are NOT pinned here -- setup-bun reads them from package.json.
+
+on:
+  pull_request:
+    branches: ['main', 'release/**']
+    paths:
+      - 'src/lib/hooks.ts'
+      - 'src/lib/hooks/**'
+      - 'src/lib/platform/**'
+      - 'src/lib/shims.ts'
+      - 'src/lib/shims*.ts'
+      - 'hooks/**'
+      - '.github/workflows/tests-windows.yml'
+
+concurrency:
+  group: tests-windows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-windows:
+    runs-on: windows-latest
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - run: bun install --frozen-lockfile
+      - run: bun run build
+      - run: bun run test

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -9,7 +9,11 @@ name: Tests (Windows)
 #
 # This is NOT the required `test` context (that stays Linux in tests.yml and is
 # matched by scripts/release.sh EXPECTED_CHECKS -- don't reuse that job name).
-# Add `test-windows` to branch protection to make it blocking.
+# Add `test-windows` to branch protection to make it blocking. That is safe
+# only because tests-windows-noop.yml reports the same `test-windows` context
+# on PRs whose changes all fall outside the paths below -- a path-filtered
+# workflow that never triggers would otherwise leave a required check stuck
+# "Expected" and block the merge. Keep the two path lists identical.
 #
 # Tool versions are NOT pinned here -- setup-bun reads them from package.json.
 
@@ -20,7 +24,6 @@ on:
       - 'src/lib/hooks.ts'
       - 'src/lib/hooks/**'
       - 'src/lib/platform/**'
-      - 'src/lib/shims.ts'
       - 'src/lib/shims*.ts'
       - 'hooks/**'
       - '.github/workflows/tests-windows.yml'

--- a/src/lib/hooks/cache.ts
+++ b/src/lib/hooks/cache.ts
@@ -114,9 +114,10 @@ export function generateHookShim(args: {
 }
 
 /**
- * Render the bash shim. Bash 3.2-compatible (macOS default). Uses python3 for
- * monotonic-ish nanosecond timing — already a hard dependency of other hooks
- * in this repo (04-capture-session-start-metadata.sh does the same).
+ * Render the bash shim. Bash 3.2-compatible (macOS default). Uses Python for
+ * hashing + monotonic-ish nanosecond timing + portable mtime, resolved at
+ * runtime (python3, then python) so a Windows Microsoft Store `python3` alias
+ * stub — which exits non-zero without running — doesn't silently break caching.
  */
 function renderShim(
   name: string,
@@ -149,12 +150,25 @@ KEY_MODE=${q(key)}
 
 mkdir -p "$CACHE_DIR" "$LOGS_DIR"
 
+# Resolve a real Python. On Windows, bare python3 is often a Microsoft Store
+# app-execution alias stub that prints to stderr and exits non-zero (0 bytes on
+# stdout) -- command -v finds it but it cannot run, which silently empties the
+# hash + mtime primitives below and makes EVERY call a cache miss (the hook
+# re-runs every time). Probe by executing, not by lookup, and fall back to python.
+PY=""
+for _cand in python3 python; do
+  if command -v "$_cand" >/dev/null 2>&1 && "$_cand" -c 'import sys' >/dev/null 2>&1; then
+    PY="$_cand"; break
+  fi
+done
+[ -z "$PY" ] && PY=python3
+
 # Read stdin once (Claude/Codex/Gemini pass JSON on stdin to every hook).
 STDIN_PAYLOAD="$(cat || true)"
 
 # Portable sha1 — \`shasum\` is Perl, missing on minimal Linux images;
 # \`sha1sum\` is coreutils, missing on macOS. Truncate to 12 hex chars.
-sha1_12() { python3 -c 'import hashlib,sys; print(hashlib.sha1(sys.stdin.read().encode()).hexdigest()[:12])'; }
+sha1_12() { "$PY" -c 'import hashlib,sys; print(hashlib.sha1(sys.stdin.read().encode()).hexdigest()[:12])'; }
 
 # Derive cache key suffix from KEY_MODE. All untrusted inputs (cwd, session_id,
 # project path) are hashed before going into the filename so a malicious stdin
@@ -162,14 +176,14 @@ sha1_12() { python3 -c 'import hashlib,sys; print(hashlib.sha1(sys.stdin.read().
 cache_suffix=""
 case "$KEY_MODE" in
   per-cwd)
-    cwd_val="$(printf '%s' "$STDIN_PAYLOAD" | python3 -c 'import json,sys
+    cwd_val="$(printf '%s' "$STDIN_PAYLOAD" | "$PY" -c 'import json,sys
 try: print(json.load(sys.stdin).get("cwd","") or "")
 except Exception: pass' 2>/dev/null || true)"
     [ -z "$cwd_val" ] && cwd_val="$PWD"
     cache_suffix=".$(printf '%s' "$cwd_val" | sha1_12)"
     ;;
   per-session)
-    sid_val="$(printf '%s' "$STDIN_PAYLOAD" | python3 -c 'import json,sys
+    sid_val="$(printf '%s' "$STDIN_PAYLOAD" | "$PY" -c 'import json,sys
 try: print(json.load(sys.stdin).get("session_id","") or "")
 except Exception: pass' 2>/dev/null || true)"
     # Hash + fall back to a sentinel so missing-session doesn't silently
@@ -189,7 +203,7 @@ esac
 CACHE_FILE="$CACHE_DIR/$HOOK_NAME$cache_suffix.out"
 
 # Monotonic-ish nanosecond timer (macOS \`date\` has no %N).
-now_ns() { python3 -c 'import time; print(int(time.time()*1e9))'; }
+now_ns() { "$PY" -c 'import time; print(int(time.time()*1e9))'; }
 START_NS=$(now_ns)
 
 CACHE_STATUS=miss
@@ -197,10 +211,10 @@ CACHE_AGE=-1
 EXIT=0
 
 if [ -f "$CACHE_FILE" ]; then
-  # python3 is already a hard dep (used for now_ns) and gives portable mtime
+  # $PY is already resolved (used for now_ns) and gives portable mtime
   # without the macOS-vs-Linux \`stat\` flag divergence (-f %m vs -c %Y) that
   # blew up under \`set -u\` when the wrong flag produced literal "%m".
-  mtime=$(python3 -c 'import os,sys; print(int(os.path.getmtime(sys.argv[1])))' "$CACHE_FILE" 2>/dev/null)
+  mtime=$("$PY" -c 'import os,sys; print(int(os.path.getmtime(sys.argv[1])))' "$CACHE_FILE" 2>/dev/null)
   mtime=\${mtime:-0}
   now_s=$(date +%s)
   CACHE_AGE=$((now_s - mtime))


### PR DESCRIPTION
Follow-up to #624. Adds Windows CI defense-in-depth and fixes one genuine Windows product bug found while scoping it.

## 1. Hook-cache shim broke on Windows (real bug)

The generated hook-cache shim hardcoded `python3` for its SHA hash, nanosecond timer, and cache-file mtime. On Windows, `python3` is commonly the **Microsoft Store app-execution alias stub**: `command -v` finds it, but it prints to stderr and exits non-zero with **0 bytes on stdout**. That silently emptied `mtime` → defaults to `0` → `CACHE_AGE = now - 0` always exceeds the TTL → **every call is a cache miss and the wrapped hook re-runs every time** (caching entirely defeated for any hook with `cache:`).

Fix: probe for a runnable interpreter (`python3`, then `python`) by executing `-c 'import sys'` instead of trusting `command -v`, and use `"$PY"` throughout. **3 cache-integration tests now pass (21/21); no change on macOS/Linux.**

## 2. Path-filtered Windows CI job

The required `test` gate runs on `ubuntu-latest` (where `path.sep` is `/`), so a Windows-only separator bug is invisible on PRs — exactly how the backslash-hook-path bug in #624 reached a running CLI. Adds `test-windows` on `windows-latest`, **path-filtered** to `src/lib/hooks*`, `src/lib/platform/**`, `src/lib/shims*`, `hooks/**`, so most PRs skip it and cost stays low. Distinct job name so it doesn't collide with the required `test` context; add to branch protection to make it blocking.

## Scope notes

While scoping, 16 path-sensitive tests failed on a **local** non-elevated Windows box; ~13 were `fs.symlinkSync` `EPERM` — Developer Mode being off, not real bugs. GitHub's hosted `windows-latest` runners create symlinks, so those are expected to pass on CI; this PR deliberately does **not** junction-patch them. The first `test-windows` run will confirm empirically; if any symlink tests do fail on the hosted runner, that's a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)