### PR TITLE
fix(security): neutralize MCP name option-injection (#478)

### DIFF
--- a/src/lib/mcp.test.ts
+++ b/src/lib/mcp.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { pathToFileURL } from 'url';
 import { spawnSync } from 'child_process';
 import { afterEach, describe, expect, it } from 'vitest';
-import { parseMcpServerConfig, buildWorkflowMcpConfig, type InstalledMcpServer } from './mcp.js';
+import { parseMcpServerConfig, buildWorkflowMcpConfig, validateMcpServerName, registerMcpCommandToTargets, type InstalledMcpServer } from './mcp.js';
 import { IS_WINDOWS } from './platform/index.js';
 
 const tempDirs: string[] = [];
@@ -58,6 +58,40 @@ describe('MCP sync execution', () => {
     expect(() => parseMcpServerConfig(configPath)).toThrow('args must be a string array');
   });
 
+  it('rejects YAML configs whose name starts with a dash', () => {
+    const home = makeTempHome();
+    const configPath = path.join(home, 'evil.yaml');
+    fs.writeFileSync(
+      configPath,
+      [
+        'name: --dangerous-flag',
+        'transport: stdio',
+        'command: node',
+        '',
+      ].join('\n'),
+      'utf-8'
+    );
+
+    expect(() => parseMcpServerConfig(configPath)).toThrow("names cannot start with '-'");
+  });
+
+  it('rejects YAML configs whose name contains whitespace', () => {
+    const home = makeTempHome();
+    const configPath = path.join(home, 'evil.yaml');
+    fs.writeFileSync(
+      configPath,
+      [
+        'name: bad name',
+        'transport: stdio',
+        'command: node',
+        '',
+      ].join('\n'),
+      'utf-8'
+    );
+
+    expect(() => parseMcpServerConfig(configPath)).toThrow('whitespace or control characters');
+  });
+
   // Proves installMcpServers spawns the CLI with an argv array (no shell), so a
   // `command: "/bin/echo; touch"` payload can't execute. The proof uses a
   // `#!/bin/sh` argv-logger fake binary, which is POSIX-only — on Windows the
@@ -101,8 +135,8 @@ describe('MCP sync execution', () => {
     const log = fs.readFileSync(logPath, 'utf-8');
     expect(result.success).toBe(true);
     expect(fs.existsSync(pwnedPath)).toBe(false);
-    expect(log).toContain('ARG:mcp\nARG:add\nARG:demo');
-    expect(log).toContain('ARG:/bin/echo; touch');
+    expect(log).toContain('ARG:mcp\nARG:add\nARG:--\nARG:demo');
+    expect(log).toContain('ARG:--\nARG:demo\nARG:/bin/echo; touch');
     expect(log).toContain(`ARG:${pwnedPath}`);
   });
 });
@@ -138,5 +172,124 @@ describe('buildWorkflowMcpConfig', () => {
 
   it('returns an empty mcpServers map for no servers', () => {
     expect(JSON.parse(buildWorkflowMcpConfig([]))).toEqual({ mcpServers: {} });
+  });
+});
+
+describe('validateMcpServerName', () => {
+  it('accepts common safe names', () => {
+    expect(() => validateMcpServerName('demo')).not.toThrow();
+    expect(() => validateMcpServerName('my_server')).not.toThrow();
+    expect(() => validateMcpServerName('server-123')).not.toThrow();
+    expect(() => validateMcpServerName('a.b')).not.toThrow();
+  });
+
+  it('rejects names starting with -', () => {
+    expect(() => validateMcpServerName('--dangerous-flag')).toThrow("names cannot start with '-'");
+    expect(() => validateMcpServerName('-rf')).toThrow("names cannot start with '-'");
+  });
+
+  it('rejects names containing whitespace or control characters', () => {
+    expect(() => validateMcpServerName('bad name')).toThrow('whitespace or control characters');
+    expect(() => validateMcpServerName('bad\tname')).toThrow('whitespace or control characters');
+    expect(() => validateMcpServerName('bad\nname')).toThrow('whitespace or control characters');
+    expect(() => validateMcpServerName('bad\x00name')).toThrow('whitespace or control characters');
+  });
+});
+
+describe('MCP argv construction', () => {
+  function makeServerYaml(home: string, fileName: string, lines: string[]): void {
+    const mcpDir = path.join(home, '.agents', 'mcp');
+    fs.mkdirSync(mcpDir, { recursive: true });
+    fs.writeFileSync(path.join(mcpDir, fileName), lines.join('\n') + '\n', 'utf-8');
+  }
+
+  function runInstall(agent: string, version: string, versionHome: string, home: string, logPath: string): ReturnType<typeof spawnSync> {
+    const moduleUrl = pathToFileURL(path.resolve('dist/lib/mcp.js')).href;
+    return spawnSync(process.execPath, ['--input-type=module', '-e', `
+      import { installMcpServers } from ${JSON.stringify(moduleUrl)};
+      const result = installMcpServers(${JSON.stringify(agent)}, ${JSON.stringify(version)}, ${JSON.stringify(versionHome)});
+      console.log(JSON.stringify(result));
+    `], {
+      env: { ...process.env, HOME: home, LOG_PATH: logPath },
+      encoding: 'utf-8',
+    });
+  }
+
+  it.skipIf(IS_WINDOWS)('puts Claude stdio name and command after --', async () => {
+    const home = makeTempHome();
+    const version = '0.1.0';
+    const logPath = path.join(home, 'argv.log');
+    writeVersionBinary(home, 'claude', version, 'claude');
+    makeServerYaml(home, 'demo.yaml', [
+      'name: demo',
+      'transport: stdio',
+      'command: node',
+      'args: ["server.js"]',
+      'env:',
+      '  TOKEN: x',
+    ]);
+    const versionHome = path.join(home, '.agents', '.history', 'versions', 'claude', version, 'home');
+    const child = runInstall('claude', version, versionHome, home, logPath);
+    expect(child.status, child.stderr).toBe(0);
+    const result = JSON.parse(child.stdout.trim());
+    expect(result.success).toBe(true);
+    const log = fs.readFileSync(logPath, 'utf-8');
+    expect(log).toMatch(/ARG:--\nARG:demo\nARG:node\nARG:server\.js/);
+  });
+
+  it.skipIf(IS_WINDOWS)('puts Claude http name and url after --', async () => {
+    const home = makeTempHome();
+    const version = '0.1.0';
+    const logPath = path.join(home, 'argv.log');
+    writeVersionBinary(home, 'claude', version, 'claude');
+    makeServerYaml(home, 'remote.yaml', [
+      'name: remote',
+      'transport: http',
+      'url: https://e.x/mcp',
+    ]);
+    const versionHome = path.join(home, '.agents', '.history', 'versions', 'claude', version, 'home');
+    const child = runInstall('claude', version, versionHome, home, logPath);
+    expect(child.status, child.stderr).toBe(0);
+    const result = JSON.parse(child.stdout.trim());
+    expect(result.success).toBe(true);
+    const log = fs.readFileSync(logPath, 'utf-8');
+    expect(log).toMatch(/ARG:--\nARG:remote\nARG:https:\/\/e\.x\/mcp/);
+  });
+
+  it('rejects option-like names from registerMcpCommand before spawning', async () => {
+    const result = await registerMcpCommandToTargets(
+      { directAgents: ['codex'], versionSelections: new Map() },
+      '--dangerous-flag',
+      { command: 'node', args: [] }
+    );
+    expect(result[0].success).toBe(false);
+    expect(result[0].error).toContain("names cannot start with '-'");
+  });
+
+  it.skipIf(IS_WINDOWS)('puts registerMcpCommand args after --', async () => {
+    const home = makeTempHome();
+    const version = '0.1.0';
+    const logPath = path.join(home, 'argv.log');
+    writeVersionBinary(home, 'claude', version, 'claude');
+    const moduleUrl = pathToFileURL(path.resolve('dist/lib/mcp.js')).href;
+    const child = spawnSync(process.execPath, ['--input-type=module', '-e', `
+      import { registerMcpCommandToTargets } from ${JSON.stringify(moduleUrl)};
+      const result = await registerMcpCommandToTargets(
+        { directAgents: [], versionSelections: new Map([['claude', ['${version}']]]) },
+        'demo',
+        { command: 'node', args: ['server.js'] },
+        'user',
+        'stdio'
+      );
+      console.log(JSON.stringify(result));
+    `], {
+      env: { ...process.env, HOME: home, LOG_PATH: logPath },
+      encoding: 'utf-8',
+    });
+    expect(child.status, child.stderr).toBe(0);
+    const result = JSON.parse(child.stdout.trim());
+    expect(result[0].success).toBe(true);
+    const log = fs.readFileSync(logPath, 'utf-8');
+    expect(log).toMatch(/ARG:--\nARG:demo\nARG:node\nARG:server\.js/);
   });
 });

--- a/src/lib/mcp.ts
+++ b/src/lib/mcp.ts
@@ -74,12 +74,26 @@ export function parseMcpServerConfig(filePath: string): McpYamlConfig | null {
   return validateMcpYamlConfig(parsed);
 }
 
+/**
+ * Validate an MCP server name. Rejects names that could be misinterpreted as
+ * command-line options or that contain characters unsafe for argv/identifier use.
+ */
+export function validateMcpServerName(name: string): void {
+  if (name.startsWith('-')) {
+    throw new Error(`Invalid MCP server name '${name}': names cannot start with '-'`);
+  }
+  if (/[\s\0-\x1f\x7f]/.test(name)) {
+    throw new Error(`Invalid MCP server name '${name}': names cannot contain whitespace or control characters`);
+  }
+}
+
 function validateMcpYamlConfig(parsed: unknown): McpYamlConfig | null {
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     return null;
   }
   const config = parsed as Record<string, unknown>;
   if (typeof config.name !== 'string' || config.name.length === 0) return null;
+  validateMcpServerName(config.name);
   if (config.transport !== 'stdio' && config.transport !== 'http') return null;
 
   const result: McpYamlConfig = {
@@ -250,12 +264,12 @@ function installMcpViaClaude(binaryPath: string, server: InstalledMcpServer, ver
       }
     }
 
-    // claude mcp add --scope user --transport stdio <name> [--env K=V]... -- <cmd> [args...]
+    // claude mcp add --scope user --transport stdio [--env K=V]... -- <name> <cmd> [args...]
     const args = [
       'mcp', 'add', '--scope', 'user', '--transport', 'stdio',
-      server.name,
       ...envArgs,
       '--',
+      server.name,
       server.config.command!,
       ...(server.config.args || [])
     ];
@@ -267,8 +281,8 @@ function installMcpViaClaude(binaryPath: string, server: InstalledMcpServer, ver
       shell: needsWindowsShell(binaryPath),
     });
   } else {
-    // claude mcp add --scope user --transport http <name> <url>
-    execFileSync(binaryPath, ['mcp', 'add', '--scope', 'user', '--transport', 'http', server.name, server.config.url!], {
+    // claude mcp add --scope user --transport http -- <name> <url>
+    execFileSync(binaryPath, ['mcp', 'add', '--scope', 'user', '--transport', 'http', '--', server.name, server.config.url!], {
       stdio: 'pipe',
       timeout: 30000,
       env: execEnv,
@@ -283,10 +297,11 @@ function installMcpViaClaude(binaryPath: string, server: InstalledMcpServer, ver
  */
 function installMcpViaCodex(binaryPath: string, server: InstalledMcpServer, versionHome: string): void {
   if (server.config.transport === 'stdio') {
-    // codex mcp add <name> -- <cmd> [args...]
+    // codex mcp add -- <name> <cmd> [args...]
     const args = [
-      'mcp', 'add', server.name,
+      'mcp', 'add',
       '--',
+      server.name,
       server.config.command!,
       ...(server.config.args || [])
     ];
@@ -337,11 +352,12 @@ function registerMcpCommand(
   options: { home?: string; binary?: string } = {}
 ): { success: boolean; error?: string } {
   try {
+    validateMcpServerName(name);
     const bin = options.binary || AGENTS[agentId].cliCommand;
     const commandArgs = [commandSpec.command, ...commandSpec.args];
     const args = agentId === 'claude'
-      ? ['mcp', 'add', '--transport', transport, '--scope', scope, name, '--', ...commandArgs]
-      : ['mcp', 'add', name, '--', ...commandArgs];
+      ? ['mcp', 'add', '--transport', transport, '--scope', scope, '--', name, ...commandArgs]
+      : ['mcp', 'add', '--', name, ...commandArgs];
     const env = options.home ? { ...process.env, HOME: options.home } : process.env;
     execFileSync(bin, args, { stdio: 'pipe', timeout: 30000, env, shell: needsWindowsShell(bin) });
     return { success: true };
@@ -598,6 +614,7 @@ export function installMcpServers(
  * Write an MCP server config to ~/.agents/mcp/.
  */
 export function writeMcpServerConfig(config: McpYamlConfig): string {
+  validateMcpServerName(config.name);
   const mcpDir = getUserMcpDir();
   fs.mkdirSync(mcpDir, { recursive: true });
 


### PR DESCRIPTION
Closes #478.

- Validates MCP server names in `parseMcpServerConfig`, `registerMcpCommand`, and `writeMcpServerConfig`: rejects names starting with `-` and names containing whitespace or control characters.
- Moves every user-controlled positional argument (`name`, `command`, `args`, `url`) behind a `--` end-of-options separator in all downstream `mcp add` argv paths:
  - Claude stdio: `claude mcp add --scope user --transport stdio [--env ...] -- <name> <cmd> [args...]`
  - Claude http: `claude mcp add --scope user --transport http -- <name> <url>`
  - Codex: `codex mcp add -- <name> <cmd> [args...]`
  - `registerMcpCommand`: adds `--` before `<name>` for both Claude and non-Claude agents.
- Adds `src/lib/mcp.test.ts` coverage proving `--dangerous-flag` / `-rf` names are rejected and that valid names are logged after `--` in the spawned argv.