### PR TITLE
fix(security): npm install with --ignore-scripts for per-version installs (#476)

### DIFF
--- a/src/lib/versions.installscripts.test.ts
+++ b/src/lib/versions.installscripts.test.ts
@@ -1,0 +1,63 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Isolated in its own file: mocking `child_process` module-wide (below) would
+// otherwise pollute the subprocess-based tests in versions.test.ts and break
+// them under the node test runner. Keep this test's mock contained here.
+
+const tempDirs: string[] = [];
+
+function makeTempHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-installscripts-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const npmInstallCapture = vi.hoisted(() => ({ argv: undefined as string[] | undefined }));
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execFile: vi.fn((file, args, options, callback) => {
+      const cb = typeof options === 'function' ? options : callback;
+      if (file === 'npm' && Array.isArray(args) && args[0] === 'install') {
+        npmInstallCapture.argv = args;
+        if (cb) cb(null, 'mock npm install success', '');
+      } else if (file === 'npm' && Array.isArray(args) && args[0] === '--version') {
+        if (cb) cb(null, '10.0.0', '');
+      } else {
+        if (cb) cb(new Error(`unexpected execFile call: ${file} ${args?.join(' ')}`), '', '');
+      }
+      return undefined;
+    }),
+  };
+});
+
+describe('installVersion npm install argv', () => {
+  it('includes --ignore-scripts in npm install arguments', async () => {
+    const home = makeTempHome();
+    const originalHome = process.env.HOME;
+    process.env.HOME = home;
+    try {
+      vi.resetModules();
+      const { installVersion } = await import('./versions.js');
+      const result = await installVersion('codex', '0.116.0');
+      expect(result.success).toBe(true);
+      expect(npmInstallCapture.argv).toBeDefined();
+      expect(npmInstallCapture.argv).toContain('install');
+      expect(npmInstallCapture.argv).toContain('--ignore-scripts');
+    } finally {
+      process.env.HOME = originalHome;
+    }
+  });
+});

--- a/src/lib/versions.test.ts
+++ b/src/lib/versions.test.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
 import { spawnSync } from 'child_process';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 const tempDirs: string[] = [];
 
@@ -671,46 +671,6 @@ describe('unionResourceSelections + mergeRepoScopedSelections — interactive mu
     const home = makeTempHome();
     const out = evalExpr(home, "V.mergeRepoScopedSelections(['project'], home)");
     expect(out.memory).toEqual([]); // neither user nor system → skip sentinel
-  });
-});
-
-const npmInstallCapture = vi.hoisted(() => ({ argv: undefined as string[] | undefined }));
-
-vi.mock('child_process', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('child_process')>();
-  return {
-    ...actual,
-    execFile: vi.fn((file, args, options, callback) => {
-      const cb = typeof options === 'function' ? options : callback;
-      if (file === 'npm' && Array.isArray(args) && args[0] === 'install') {
-        npmInstallCapture.argv = args;
-        if (cb) cb(null, 'mock npm install success', '');
-      } else if (file === 'npm' && Array.isArray(args) && args[0] === '--version') {
-        if (cb) cb(null, '10.0.0', '');
-      } else {
-        if (cb) cb(new Error(`unexpected execFile call: ${file} ${args?.join(' ')}`), '', '');
-      }
-      return undefined;
-    }),
-  };
-});
-
-describe('installVersion npm install argv', () => {
-  it('includes --ignore-scripts in npm install arguments', async () => {
-    const home = makeTempHome();
-    const originalHome = process.env.HOME;
-    process.env.HOME = home;
-    try {
-      vi.resetModules();
-      const { installVersion } = await import('./versions.js');
-      const result = await installVersion('codex', '0.116.0');
-      expect(result.success).toBe(true);
-      expect(npmInstallCapture.argv).toBeDefined();
-      expect(npmInstallCapture.argv).toContain('install');
-      expect(npmInstallCapture.argv).toContain('--ignore-scripts');
-    } finally {
-      process.env.HOME = originalHome;
-    }
   });
 });
 

--- a/src/lib/versions.test.ts
+++ b/src/lib/versions.test.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
 import { spawnSync } from 'child_process';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const tempDirs: string[] = [];
 
@@ -673,3 +673,44 @@ describe('unionResourceSelections + mergeRepoScopedSelections — interactive mu
     expect(out.memory).toEqual([]); // neither user nor system → skip sentinel
   });
 });
+
+const npmInstallCapture = vi.hoisted(() => ({ argv: undefined as string[] | undefined }));
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execFile: vi.fn((file, args, options, callback) => {
+      const cb = typeof options === 'function' ? options : callback;
+      if (file === 'npm' && Array.isArray(args) && args[0] === 'install') {
+        npmInstallCapture.argv = args;
+        if (cb) cb(null, 'mock npm install success', '');
+      } else if (file === 'npm' && Array.isArray(args) && args[0] === '--version') {
+        if (cb) cb(null, '10.0.0', '');
+      } else {
+        if (cb) cb(new Error(`unexpected execFile call: ${file} ${args?.join(' ')}`), '', '');
+      }
+      return undefined;
+    }),
+  };
+});
+
+describe('installVersion npm install argv', () => {
+  it('includes --ignore-scripts in npm install arguments', async () => {
+    const home = makeTempHome();
+    const originalHome = process.env.HOME;
+    process.env.HOME = home;
+    try {
+      vi.resetModules();
+      const { installVersion } = await import('./versions.js');
+      const result = await installVersion('codex', '0.116.0');
+      expect(result.success).toBe(true);
+      expect(npmInstallCapture.argv).toBeDefined();
+      expect(npmInstallCapture.argv).toContain('install');
+      expect(npmInstallCapture.argv).toContain('--ignore-scripts');
+    } finally {
+      process.env.HOME = originalHome;
+    }
+  });
+});
+

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1229,7 +1229,7 @@ export async function installVersion(
     }
 
     onProgress?.(`Installing ${packageSpec}...`);
-    const { stdout } = await execFileAsync('npm', ['install', packageSpec], { cwd: versionDir, shell: winShell });
+    const { stdout } = await execFileAsync('npm', ['install', packageSpec, '--ignore-scripts'], { cwd: versionDir, shell: winShell });
 
     // Determine the actual installed version
     let installedVersion = version;


### PR DESCRIPTION
Closes #476.

Passes `--ignore-scripts` to `npm install` in `installVersion` to match the existing self-update path, and adds a fast unit test that asserts the generated npm argv includes the flag without spawning a real install.