### PR TITLE
feat(sessions): live cross-machine listing (this machine first, labelled by host)

### DIFF
--- a/src/commands/__tests__/sessions-machine-grouping.test.ts
+++ b/src/commands/__tests__/sessions-machine-grouping.test.ts
@@ -9,14 +9,26 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { groupSessionsByMachine, dedupeByMachineSession } from '../sessions.js';
+import { groupSessionsByMachine, dedupeByMachineSession, mergeLocalFirst } from '../sessions.js';
 import type { ActiveSession } from '../../lib/session/active.js';
+import type { SessionMeta } from '../../lib/session/types.js';
 
 function mk(overrides: Partial<ActiveSession>): ActiveSession {
   return {
     context: 'terminal',
     kind: 'claude',
     status: 'running',
+    ...overrides,
+  };
+}
+
+function mkMeta(overrides: Partial<SessionMeta>): SessionMeta {
+  return {
+    id: overrides.id ?? 's',
+    shortId: overrides.shortId ?? overrides.id ?? 's',
+    agent: 'claude',
+    timestamp: '2026-07-01T00:00:00Z',
+    filePath: '/x.jsonl',
     ...overrides,
   };
 }
@@ -109,5 +121,62 @@ describe('dedupeByMachineSession', () => {
       mk({ machine: 'zion', sessionId: undefined }),
     ]);
     expect(out).toHaveLength(2);
+  });
+});
+
+describe('mergeLocalFirst', () => {
+  it('puts the local machine block first, then remotes by count desc then name', () => {
+    const merged = mergeLocalFirst(
+      [
+        mkMeta({ id: 'a1', machine: 'alpha' }),
+        mkMeta({ id: 'l1', machine: 'yosemite-s0' }),
+        mkMeta({ id: 'b1', machine: 'beta' }),
+        mkMeta({ id: 'b2', machine: 'beta' }),
+      ],
+      'yosemite-s0',
+    );
+    expect(merged.map((s) => s.machine)).toEqual(['yosemite-s0', 'beta', 'beta', 'alpha']);
+  });
+
+  it('treats an untagged session as local (discover leaves local rows implicit)', () => {
+    const merged = mergeLocalFirst(
+      [mkMeta({ id: 'r1', machine: 'zion' }), mkMeta({ id: 'x1', machine: undefined })],
+      'yosemite-s0',
+    );
+    expect(merged[0].machine).toBeUndefined();
+    expect(merged[1].machine).toBe('zion');
+  });
+
+  it('preserves incoming (timestamp) order within a machine block', () => {
+    const merged = mergeLocalFirst(
+      [
+        mkMeta({ id: 'l-new', machine: 'local' }),
+        mkMeta({ id: 'l-old', machine: 'local' }),
+      ],
+      'local',
+    );
+    expect(merged.map((s) => s.id)).toEqual(['l-new', 'l-old']);
+  });
+
+  it('collapses a session present both locally and via fan-out (same machine + id)', () => {
+    const merged = mergeLocalFirst(
+      [
+        mkMeta({ id: 'dup', machine: 'zion' }),
+        mkMeta({ id: 'dup', machine: 'zion' }),
+      ],
+      'local',
+    );
+    expect(merged).toHaveLength(1);
+  });
+
+  it('keeps identically-numbered sessions that live on different machines', () => {
+    const merged = mergeLocalFirst(
+      [
+        mkMeta({ id: 'same', machine: 'local' }),
+        mkMeta({ id: 'same', machine: 'zion' }),
+      ],
+      'local',
+    );
+    expect(merged).toHaveLength(2);
   });
 });

--- a/src/commands/sessions-picker.ts
+++ b/src/commands/sessions-picker.ts
@@ -13,13 +13,13 @@ import { linkPath, relativeToCwd } from '../lib/session/render.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { itemPicker } from '../lib/picker.js';
 import { classifyFileChanges, changeCounts, toolHistogram, detectTestResult } from '../lib/session/digest.js';
-import { machineId } from '../lib/session/sync/config.js';
-
-/** A session whose transcript lives on another machine (folded in over the
+/** A session whose transcript lives on another machine (folded in over the live
  * cross-machine fan-out): its `filePath` is on that peer's disk, so the preview
- * can't parse it locally — it shows metadata + a "resume there" note instead. */
+ * can't parse it locally — it shows metadata + a "resume there" note instead.
+ * Keys off `_remote`, not the machine tag, so locally-readable synced mirrors
+ * still parse their file normally. */
 function remoteMachineOf(session: SessionMeta): string | undefined {
-  return session.machine && session.machine !== machineId() ? session.machine : undefined;
+  return session._remote ? session.machine : undefined;
 }
 
 /**

--- a/src/commands/sessions-picker.ts
+++ b/src/commands/sessions-picker.ts
@@ -13,6 +13,14 @@ import { linkPath, relativeToCwd } from '../lib/session/render.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { itemPicker } from '../lib/picker.js';
 import { classifyFileChanges, changeCounts, toolHistogram, detectTestResult } from '../lib/session/digest.js';
+import { machineId } from '../lib/session/sync/config.js';
+
+/** A session whose transcript lives on another machine (folded in over the
+ * cross-machine fan-out): its `filePath` is on that peer's disk, so the preview
+ * can't parse it locally — it shows metadata + a "resume there" note instead. */
+function remoteMachineOf(session: SessionMeta): string | undefined {
+  return session.machine && session.machine !== machineId() ? session.machine : undefined;
+}
 
 /**
  * SessionMeta originates in discover.ts (gitBranch, cwd, label, etc. read from
@@ -57,8 +65,23 @@ const previewCache = new Map<string, string>();
 
 /** Build a cached multi-line preview string for display in the session picker. */
 export function buildPreview(session: SessionMeta): string {
-  const cached = previewCache.get(session.id);
+  const remote = remoteMachineOf(session);
+  const cacheKey = remote ? `${remote}:${session.id}` : session.id;
+  const cached = previewCache.get(cacheKey);
   if (cached) return cached;
+
+  const safe = sanitizeMeta(session);
+
+  // Remote session: the transcript is on the peer's disk, so there is nothing to
+  // parse here. Show the metadata header (agent, cwd, msgs, tokens — all carried
+  // over in the fan-out) plus where it lives and how to open it.
+  if (remote) {
+    const note = '  ' + chalk.gray(`on `) + chalk.bold.white(remote)
+      + chalk.gray(` — enter to resume there, or space then enter to read it over SSH`);
+    const output = [formatHeader(safe, []), '', note].join('\n');
+    previewCache.set(cacheKey, output);
+    return output;
+  }
 
   let events: SessionEvent[] = [];
   let parseError: string | undefined;
@@ -68,13 +91,12 @@ export function buildPreview(session: SessionMeta): string {
     parseError = sanitizeForTerminal(err?.message ?? String(err));
   }
 
-  const safe = sanitizeMeta(session);
   const header = formatHeader(safe, events);
   const body = parseError
     ? '  ' + chalk.red(`Failed to parse session: ${parseError}`)
     : formatCompactPreview(events, safe);
   const output = [header, '', body].filter(Boolean).join('\n');
-  previewCache.set(session.id, output);
+  previewCache.set(cacheKey, output);
   return output;
 }
 

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1357,7 +1357,7 @@ function remoteMachineOf(session: SessionMeta): string | undefined {
  * remote pick never dead-ends silently. */
 function warnNoPeerTarget(machine: string, session: SessionMeta): void {
   console.log(chalk.yellow(`Session ${session.shortId} lives on ${machine}, which isn't a reachable device right now.`));
-  console.log(chalk.gray(`Register/​wake it (ag devices), or run there: agents ssh ${machine}`));
+  console.log(chalk.gray(`Register/wake it (ag devices), or run there: agents ssh ${machine}`));
 }
 
 async function handlePickedSession(picked: PickedSession): Promise<void> {

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -21,13 +21,14 @@ import { discoverArtifacts, readArtifact, resolveArtifact } from '../lib/session
 import { looksLikePath, toComparablePath, homeDir, needsWindowsShell, findExecutable } from '../lib/platform/index.js';
 import { getActiveSessions, type ActiveSession } from '../lib/session/active.js';
 import { machineId, normalizeHost } from '../lib/session/sync/config.js';
-import { gatherRemoteActive } from '../lib/session/remote-active.js';
+import { gatherRemoteActive, NO_FANOUT_ENV } from '../lib/session/remote-active.js';
+import { gatherRemoteList } from '../lib/session/remote-list.js';
 import { stringWidth, truncateToWidth, padToWidth, terminalWidth } from '../lib/session/width.js';
 import type { SessionActivity, AwaitingReason } from '../lib/session/state.js';
 import { discoverSessions, countSessionsInScope, resolveSessionById, searchContentIndex, parseTimeFilter, type DiscoverOptions, type ScanProgress } from '../lib/session/discover.js';
 import { filterTeamSessions } from '../lib/session/team-filter.js';
 import { parseSession } from '../lib/session/parse.js';
-import { runRemoteSessions } from '../lib/session/remote.js';
+import { runRemoteSessions, buildForwardedArgs } from '../lib/session/remote.js';
 import { formatRelativeTime } from '../lib/session/relative-time.js';
 import { renderConversationMarkdown, renderSummary, renderSummaryHeader, computeSummaryStats, renderJson, filterEvents, parseRoleList, type FilterOptions } from '../lib/session/render.js';
 import { renderMarkdown } from '../lib/markdown.js';
@@ -75,7 +76,8 @@ interface SessionsOptions extends SessionFilterOptions {
   /** Enrich the listing with live glyphs/preview for running rows. Default on;
    * `--no-live` sets this false. Commander's `--no-` convention. */
   live?: boolean;
-  /** With --active: force local-only, skip cross-machine SSH fan-out. */
+  /** Force local-only: skip the cross-machine SSH fan-out (both the default
+   * listing and --active). */
   local?: boolean;
 }
 
@@ -519,6 +521,38 @@ export function dedupeByMachineSession(sessions: ActiveSession[]): ActiveSession
   return out;
 }
 
+/**
+ * Order a merged listing so the local machine's sessions come first, then each
+ * remote machine as a contiguous block (more sessions first, then name), with
+ * every machine keeping its incoming order (timestamp) within the block. Also
+ * dedupes: a session present both locally (a synced mirror copy) and via live
+ * fan-out collapses to one, keyed by machine + session id. Rows are keyed by
+ * `machine` (discover tags local rows with the local id; fan-out tags remote
+ * rows with the peer id) falling back to `localMachine` when untagged. Pure —
+ * `localMachine` is injected so the ordering is testable without os.hostname().
+ */
+export function mergeLocalFirst(sessions: SessionMeta[], localMachine: string): SessionMeta[] {
+  const byMachine = new Map<string, SessionMeta[]>();
+  const seen = new Set<string>();
+  for (const s of sessions) {
+    const machine = s.machine || localMachine;
+    if (s.id) {
+      const dedupeKey = `${machine}:${s.id}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+    }
+    (byMachine.get(machine) ?? byMachine.set(machine, []).get(machine)!).push(s);
+  }
+  const keys = Array.from(byMachine.keys()).sort((a, b) => {
+    if (a === localMachine) return -1;
+    if (b === localMachine) return 1;
+    const ac = byMachine.get(a)!.length, bc = byMachine.get(b)!.length;
+    if (ac !== bc) return bc - ac;
+    return a.localeCompare(b);
+  });
+  return keys.flatMap((k) => byMachine.get(k)!);
+}
+
 /** Print one machine's workspace tree, indented under its machine header. */
 function renderWorkspaceLayout(layout: ActiveSessionsLayout, base: string): void {
   let first = true;
@@ -785,6 +819,31 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
       return;
     }
 
+    // Cross-machine fan-out: unless --local (or we ARE a peer answering a
+    // parent's sweep), fold in other online machines' sessions live over SSH so
+    // the list spans the fleet without any sync — each remote row carries the
+    // machine it came from, and the picker/table label + group by it. Only the
+    // interactive picker and the printed table get this; --json and single-id
+    // resolution above stay local (a peer answers for itself; scripts get a
+    // deterministic local slice). Best-effort: a fan-out failure leaves the
+    // local list intact rather than erroring the whole command.
+    const forceLocal = options.local === true || process.env[NO_FANOUT_ENV] === '1';
+    if (!forceLocal) {
+      const forwarded = buildForwardedArgs(process.argv);
+      if (!forwarded.includes('--json')) forwarded.push('--json');
+      const fanSpinner = isInteractiveTerminal() ? ora('Reaching other machines...').start() : null;
+      try {
+        const { sessions: remoteSessions } = await gatherRemoteList(forwarded, options.host);
+        if (remoteSessions.length > 0) {
+          sessions = mergeLocalFirst([...sessions, ...remoteSessions], machineId());
+        }
+      } catch {
+        // fan-out is an enrichment, never a hard dependency
+      } finally {
+        fanSpinner?.stop();
+      }
+    }
+
     if (sessions.length === 0) {
       if (pathFilter) {
         console.log(chalk.gray(`No sessions found for ${pathFilter}.`));
@@ -849,7 +908,7 @@ function metaSignals(s: SessionMeta): Parameters<typeof signalBadges>[0] {
  * (tracker/PR ref, pulled out of the badge blob so refs align) is only rendered
  * when `showTicket` — otherwise a listing with no refs would waste a column of
  * dashes and needlessly truncate the topic. Worktree stays a trailing badge. */
-function flatSessionRow(session: SessionMeta, live?: ActiveSession, showTicket = false): string {
+function flatSessionRow(session: SessionMeta, live?: ActiveSession, showTicket = false, cols: PickerColumns = {}): string {
   const agentColor = colorAgent(session.agent);
   const when = formatRelativeTime(session.timestamp);
   const project = session.project || '-';
@@ -861,19 +920,27 @@ function flatSessionRow(session: SessionMeta, live?: ActiveSession, showTicket =
   const doing = preview || (tag ? `${tag}${session.topic ?? ''}` : session.topic);
   const wt = session.worktreeSlug ? chalk.magenta(`wt:${session.worktreeSlug}`) : '';
 
+  // The machine column only earns its width when the listing spans more than one
+  // box (i.e. the cross-machine fan-out folded remotes in) — same rule as the picker.
+  const machineCell = cols.showMachine
+    ? chalk.gray(padToWidth(truncateToWidth((cols.machineLabel?.(session.machine ?? '') ?? session.machine ?? '') || '-', PICKER_MACHINE_W - 1), PICKER_MACHINE_W))
+    : '';
+
   const TICKET_W = 10;
   const ticketCell = showTicket
     ? chalk.blue(padToWidth(truncateToWidth(ticketLabel(session) || '-', TICKET_W), TICKET_W + 1))
     : '';
   const glyphW = glyph ? 2 : 0;
+  const machineW = cols.showMachine ? PICKER_MACHINE_W : 0;
   const ticketW = showTicket ? TICKET_W + 1 : 0;
   const wtW = wt ? stringWidth(wt) + 1 : 0;
-  const topicW = Math.max(16, terminalWidth() - (10 + 9 + 8 + 16) - glyphW - ticketW - wtW - stringWidth(when) - 1);
+  const topicW = Math.max(16, terminalWidth() - (10 + 9 + 8 + 16) - glyphW - machineW - ticketW - wtW - stringWidth(when) - 1);
 
   return (
     chalk.white(padToWidth(truncateToWidth(session.shortId, 9), 10)) +
     agentColor(padToWidth(truncateToWidth(session.agent, 8), 9)) +
     chalk.yellow(padToWidth(truncateToWidth(session.version || '-', 7), 8)) +
+    machineCell +
     chalk.cyan(padToWidth(truncateToWidth(project, 14), 16)) +
     (glyph ? glyph + ' ' : '') +
     renderTopicCell(label, doing, '', topicW, topicW) +
@@ -954,9 +1021,11 @@ function printSessionTable(sessions: SessionMeta[], hiddenCount = 0, tree = fals
   }
 
   // Only show the ticket column when at least one row carries a ref — otherwise
-  // it's a column of dashes that steals width from every topic.
+  // it's a column of dashes that steals width from every topic. The machine
+  // column (and its compact labels) is computed the same way the picker does it.
   const showTicket = sessions.some((s) => ticketLabel(s) !== '');
-  for (const session of sessions) console.log(flatSessionRow(session, liveIndex?.get(session.id), showTicket));
+  const cols = pickerColumnsFor(sessions);
+  for (const session of sessions) console.log(flatSessionRow(session, liveIndex?.get(session.id), showTicket, cols));
 
   const countLine = `${sessions.length} session${sessions.length === 1 ? '' : 's'}.`;
   console.log(chalk.gray(`\n${countLine}`));
@@ -1271,7 +1340,45 @@ export async function pickSessionInteractive(
   }
 }
 
+/**
+ * The machine a picked session lives on, or undefined when it is local. A
+ * session tagged with a machine other than this one came in over the
+ * cross-machine fan-out: its `filePath` points at the peer's disk, so reading
+ * or resuming it has to hop back over SSH rather than touch the local FS.
+ */
+function remoteMachineOf(session: SessionMeta): string | undefined {
+  return session.machine && session.machine !== machineId() ? session.machine : undefined;
+}
+
+/** Re-run this CLI against a peer's own index over SSH (`--host <machine>`),
+ * inheriting stdio so its picker/markdown renders straight to this terminal. */
+function runOnRemote(args: string[], machine: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const child = spawn('agents', ['sessions', ...args, '--host', machine], {
+      stdio: 'inherit',
+      shell: needsWindowsShell('agents'),
+    });
+    child.on('error', (err: any) => {
+      console.error(chalk.red(`Failed to reach ${machine}: ${err.message}`));
+      resolve();
+    });
+    child.on('close', () => resolve());
+  });
+}
+
 async function handlePickedSession(picked: PickedSession): Promise<void> {
+  // A session on another machine is resumed/viewed on that machine over SSH —
+  // its transcript and agent binary live there, not here.
+  const remote = remoteMachineOf(picked.session);
+  if (remote) {
+    if (picked.action === 'view') {
+      await runOnRemote([picked.session.shortId, '--markdown'], remote);
+    } else {
+      console.log(chalk.gray(`Resuming on ${remote} over SSH...`));
+      await runOnRemote(['resume', picked.session.shortId], remote);
+    }
+    return;
+  }
   if (picked.action === 'view') {
     await renderSession(picked.session, 'summary', {});
     return;
@@ -1792,7 +1899,7 @@ export function registerSessionsCommands(program: Command): void {
     .option('--artifacts', 'List all files written or edited during a session')
     .option('--artifact <name>', 'Read a specific artifact by filename or path (outputs to stdout)')
     .option('--active', 'Show only sessions running right now across terminals, teams, cloud, and headless agents')
-    .option('--local', 'With --active: only this machine — skip the cross-machine SSH fan-out')
+    .option('--local', 'Only this machine — skip the cross-machine SSH fan-out (default listing and --active)')
     .option('--waiting', 'With --active: show only sessions waiting on your input (exits non-zero if any)')
     .option('--tree', 'Group the listing by directory; drops the id/version columns for readability')
     .option('--no-live', 'Do not enrich the listing with live status/preview for running sessions')
@@ -1813,6 +1920,10 @@ export function registerSessionsCommands(program: Command): void {
       # Show only what's running right now (terminals, teams, cloud, headless)
       agents sessions --active
 
+      # The interactive list folds in other online machines automatically,
+      # labelled by host with this machine first. Stay local with --local:
+      agents sessions --local
+
       # Search across every directory, not just this project
       agents sessions "topic" --all
 
@@ -1826,6 +1937,7 @@ export function registerSessionsCommands(program: Command): void {
       agents sessions --all "deploy script" --host box-a --host box-b
     `,
     notes: `
+      - The interactive listing folds in your other online machines automatically (live over SSH, no sync) — each row is labelled by host, this machine first. Use --local to skip the fan-out; --json and single-id lookups stay local.
       - --host runs the query on the remote's own index over SSH (host alias or user@host); repeat or pass several to fan out. SSH access is the only auth.
       - --include and --exclude are mutually exclusive.
       - --first and --last are mutually exclusive.

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -22,7 +22,7 @@ import { looksLikePath, toComparablePath, homeDir, needsWindowsShell, findExecut
 import { getActiveSessions, type ActiveSession } from '../lib/session/active.js';
 import { machineId, normalizeHost } from '../lib/session/sync/config.js';
 import { gatherRemoteActive, NO_FANOUT_ENV } from '../lib/session/remote-active.js';
-import { gatherRemoteList } from '../lib/session/remote-list.js';
+import { gatherRemoteList, runOnPeer } from '../lib/session/remote-list.js';
 import { stringWidth, truncateToWidth, padToWidth, terminalWidth } from '../lib/session/width.js';
 import type { SessionActivity, AwaitingReason } from '../lib/session/state.js';
 import { discoverSessions, countSessionsInScope, resolveSessionById, searchContentIndex, parseTimeFilter, type DiscoverOptions, type ScanProgress } from '../lib/session/discover.js';
@@ -812,7 +812,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
     if (options.json) {
       const filtered = searchQuery ? filterSessionsByQuery(sessions, searchQuery) : sessions;
       const serializable = filtered.map(s => {
-        const { _matchedTerms, _bm25Score, ...rest } = s;
+        const { _matchedTerms, _bm25Score, _remote, ...rest } = s;
         return rest;
       });
       process.stdout.write(JSON.stringify(serializable, null, 2) + '\n');
@@ -829,7 +829,10 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
     // local list intact rather than erroring the whole command.
     const forceLocal = options.local === true || process.env[NO_FANOUT_ENV] === '1';
     if (!forceLocal) {
-      const forwarded = buildForwardedArgs(process.argv);
+      // Pass the hosts set so a variadic `--host a b` never leaks a host as a
+      // query (defensive: the --host-without-active early return above already
+      // means we only get here in auto-discovery mode, with no --host in argv).
+      const forwarded = buildForwardedArgs(process.argv, new Set(options.host ?? []));
       if (!forwarded.includes('--json')) forwarded.push('--json');
       const fanSpinner = isInteractiveTerminal() ? ora('Reaching other machines...').start() : null;
       try {
@@ -1341,41 +1344,36 @@ export async function pickSessionInteractive(
 }
 
 /**
- * The machine a picked session lives on, or undefined when it is local. A
- * session tagged with a machine other than this one came in over the
- * cross-machine fan-out: its `filePath` points at the peer's disk, so reading
- * or resuming it has to hop back over SSH rather than touch the local FS.
+ * The machine a picked session lives on when its transcript is on that peer's
+ * disk (folded in over the live fan-out), else undefined. Keys off `_remote`,
+ * NOT `machine !== local`: a synced mirror is machine-tagged too, but its file
+ * is a local mirror path, so it must be read/resumed locally like any other.
  */
 function remoteMachineOf(session: SessionMeta): string | undefined {
-  return session.machine && session.machine !== machineId() ? session.machine : undefined;
+  return session._remote ? session.machine : undefined;
 }
 
-/** Re-run this CLI against a peer's own index over SSH (`--host <machine>`),
- * inheriting stdio so its picker/markdown renders straight to this terminal. */
-function runOnRemote(args: string[], machine: string): Promise<void> {
-  return new Promise<void>((resolve) => {
-    const child = spawn('agents', ['sessions', ...args, '--host', machine], {
-      stdio: 'inherit',
-      shell: needsWindowsShell('agents'),
-    });
-    child.on('error', (err: any) => {
-      console.error(chalk.red(`Failed to reach ${machine}: ${err.message}`));
-      resolve();
-    });
-    child.on('close', () => resolve());
-  });
+/** True when the peer wasn't a dialable device; prints one clear line so a
+ * remote pick never dead-ends silently. */
+function warnNoPeerTarget(machine: string, session: SessionMeta): void {
+  console.log(chalk.yellow(`Session ${session.shortId} lives on ${machine}, which isn't a reachable device right now.`));
+  console.log(chalk.gray(`Register/​wake it (ag devices), or run there: agents ssh ${machine}`));
 }
 
 async function handlePickedSession(picked: PickedSession): Promise<void> {
-  // A session on another machine is resumed/viewed on that machine over SSH —
-  // its transcript and agent binary live there, not here.
+  // A session on another machine is read/resumed ON that machine over SSH — its
+  // transcript and agent binary live there. Both actions execute on the peer
+  // (not a local `--host` hop, which would discover locally and dead-end for a
+  // session that exists only on the peer).
   const remote = remoteMachineOf(picked.session);
   if (remote) {
     if (picked.action === 'view') {
-      await runOnRemote([picked.session.shortId, '--markdown'], remote);
+      const rc = await runOnPeer(['sessions', picked.session.shortId, '--markdown'], remote);
+      if (rc === 'no-target') warnNoPeerTarget(remote, picked.session);
     } else {
-      console.log(chalk.gray(`Resuming on ${remote} over SSH...`));
-      await runOnRemote(['resume', picked.session.shortId], remote);
+      console.log(chalk.gray(`Resuming ${picked.session.shortId} on ${remote} over SSH...`));
+      const rc = await runOnPeer(['sessions', 'resume', picked.session.shortId], remote, { tty: true });
+      if (rc === 'no-target') warnNoPeerTarget(remote, picked.session);
     }
     return;
   }

--- a/src/lib/session/__tests__/remote-list.test.ts
+++ b/src/lib/session/__tests__/remote-list.test.ts
@@ -21,6 +21,14 @@ describe('parseRemoteList', () => {
     expect(out[0].id).toBe('a');
   });
 
+  it('marks every parsed row _remote so it routes read/resume back over SSH', () => {
+    const stdout = JSON.stringify([
+      { id: 'a', shortId: 'a', agent: 'claude', timestamp: '2026-07-01T00:00:00Z', filePath: '/peer/a.jsonl' },
+    ]);
+    const out = parseRemoteList(stdout, 'zion');
+    expect(out[0]._remote).toBe(true);
+  });
+
   it('overrides any machine tag the peer set on its own rows', () => {
     // The peer's discover tags rows with ITS local id; we must relabel to the
     // machine we dialed, else two peers that both call themselves "local" collide.

--- a/src/lib/session/__tests__/remote-list.test.ts
+++ b/src/lib/session/__tests__/remote-list.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for parsing a peer's `sessions --json` output during the browse-listing
+ * fan-out. Like the --active parser, this must be defensive: a peer may run an
+ * older/newer agents whose stdout is truncated, non-JSON, or carries its own
+ * `machine` tag — one bad peer must never throw and blank the merged list, and
+ * the machine we dialed must win so grouping keys off the computer we asked.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseRemoteList, remoteListCommand } from '../remote-list.js';
+
+describe('parseRemoteList', () => {
+  it('tags every parsed session with the source machine', () => {
+    const stdout = JSON.stringify([
+      { id: 'a', shortId: 'a', agent: 'claude', timestamp: '2026-07-01T00:00:00Z', filePath: '/r/a.jsonl' },
+      { id: 'b', shortId: 'b', agent: 'codex', timestamp: '2026-07-02T00:00:00Z', filePath: '/r/b.jsonl' },
+    ]);
+    const out = parseRemoteList(stdout, 'zion');
+    expect(out).toHaveLength(2);
+    expect(out.every((s) => s.machine === 'zion')).toBe(true);
+    expect(out[0].id).toBe('a');
+  });
+
+  it('overrides any machine tag the peer set on its own rows', () => {
+    // The peer's discover tags rows with ITS local id; we must relabel to the
+    // machine we dialed, else two peers that both call themselves "local" collide.
+    const stdout = JSON.stringify([
+      { id: 'a', shortId: 'a', agent: 'claude', timestamp: '2026-07-01T00:00:00Z', filePath: '/r/a.jsonl', machine: 'their-local-name' },
+    ]);
+    const out = parseRemoteList(stdout, 'mark');
+    expect(out[0].machine).toBe('mark');
+  });
+
+  it('returns [] on non-JSON (a login-shell banner leaked into stdout)', () => {
+    expect(parseRemoteList('bash: agents: command not found\n', 'zion')).toEqual([]);
+  });
+
+  it('returns [] when the top level is not an array', () => {
+    expect(parseRemoteList(JSON.stringify({ error: 'nope' }), 'zion')).toEqual([]);
+  });
+
+  it('drops non-object entries but keeps the valid ones', () => {
+    const stdout = JSON.stringify([null, 'weird', 42, { id: 'x', shortId: 'x', agent: 'claude', timestamp: '2026-07-01T00:00:00Z', filePath: '/r/x.jsonl' }]);
+    const out = parseRemoteList(stdout, 'mark');
+    expect(out).toHaveLength(1);
+    expect(out[0].machine).toBe('mark');
+  });
+
+  it('returns [] on empty stdout (peer produced nothing)', () => {
+    expect(parseRemoteList('', 'zion')).toEqual([]);
+  });
+});
+
+describe('remoteListCommand', () => {
+  it('passes the recursion guard so the peer stays local and never re-fans-out', () => {
+    const cmd = remoteListCommand(['sessions', 'auth bug', '--json']);
+    expect(cmd).toContain('AGENTS_SESSIONS_LOCAL=1');
+    expect(cmd).toContain('agents');
+  });
+
+  it('carries the caller query + filters over to the peer', () => {
+    const cmd = remoteListCommand(['sessions', 'deploy', '--since', '2d', '--json']);
+    expect(cmd).toContain('deploy');
+    expect(cmd).toContain('--since');
+    expect(cmd).toContain('--json');
+  });
+});

--- a/src/lib/session/remote-list.ts
+++ b/src/lib/session/remote-list.ts
@@ -195,6 +195,7 @@ export async function resolvePeerTarget(machine: string): Promise<{ target: stri
 export async function runOnPeer(args: string[], machine: string, opts: { tty?: boolean } = {}): Promise<'ok' | 'no-target'> {
   const peer = await resolvePeerTarget(machine);
   if (!peer) return 'no-target';
+  assertValidSshTarget(peer.target); // registry-sourced, but validate like the fan-out does
 
   const cols = terminalWidth();
   const remoteCmd = remoteShellFor(peer.os) === 'powershell'
@@ -207,9 +208,13 @@ export async function runOnPeer(args: string[], machine: string, opts: { tty?: b
 
   return new Promise((resolve) => {
     const child = spawn('ssh', sshArgs, { stdio: 'inherit' });
-    // ssh prints its own connection errors to the inherited stderr; either way
-    // we return once it exits so the picker flow completes.
-    child.on('error', () => resolve('ok'));
+    // ssh prints its own connection errors to the inherited stderr; a spawn
+    // failure (e.g. ssh not on PATH) has no such output, so name it. Either way
+    // we resolve once it settles so the picker flow completes.
+    child.on('error', (err: any) => {
+      process.stderr.write(chalk.red(`Failed to reach ${machine}: ${err?.message ?? 'ssh failed to launch'}\n`));
+      resolve('ok');
+    });
     child.on('close', () => resolve('ok'));
   });
 }

--- a/src/lib/session/remote-list.ts
+++ b/src/lib/session/remote-list.ts
@@ -1,0 +1,159 @@
+/**
+ * Cross-machine fan-out for the default `agents sessions` listing.
+ *
+ * `discoverSessions()` only scans the local disk. To browse the whole fleet in
+ * one list — without syncing anything — we run `agents sessions <same query>
+ * --json` on each peer over SSH and merge the parsed `SessionMeta[]`, tagging
+ * every row with the machine it came from so the picker/table can label and
+ * group by computer.
+ *
+ * This is the browse-listing sibling of `remote-active.ts` (which fans out
+ * `--active`): same transport, same device set, same recursion guard. The peer
+ * runs with `AGENTS_SESSIONS_LOCAL=1` so it answers only for itself and the
+ * sweep never recurses. A dead or slow host is skipped with a stderr note,
+ * never fatal — one asleep laptop must not blank the list.
+ */
+import { spawn } from 'child_process';
+import chalk from 'chalk';
+import { SSH_OPTS, controlOpts, assertValidSshTarget, shellQuote } from '../ssh-exec.js';
+import { sshTargetFor } from '../devices/connect.js';
+import { loadDevices, type DeviceProfile } from '../devices/registry.js';
+import { remoteShellFor, buildWindowsAgentsCommand } from '../hosts/remote-cmd.js';
+import { resolveRemoteOsSync } from '../hosts/remote-os.js';
+import { machineId, normalizeHost } from './sync/config.js';
+import { NO_FANOUT_ENV } from './remote-active.js';
+import type { SessionMeta } from './types.js';
+
+/** Per-host SSH budget. Slightly above SSH_OPTS' ConnectTimeout=10 so a
+ * reachable-but-slow remote still answers before we give up. */
+const REMOTE_TIMEOUT_MS = 12_000;
+
+/**
+ * The command run on each peer: answer for itself, as JSON, without recursing.
+ * `forwardedArgs` carry the caller's own query/filters (already including the
+ * leading `sessions` and a `--json`) so each peer returns a comparable slice.
+ * A Windows peer gets a PowerShell invocation (ssh lands in cmd.exe/PowerShell
+ * there, where `bash -lc` is not a command); every other OS keeps `bash -lc`.
+ */
+export function remoteListCommand(forwardedArgs: string[], os?: string): string {
+  if (remoteShellFor(os) === 'powershell') {
+    return buildWindowsAgentsCommand({
+      args: forwardedArgs,
+      env: { [NO_FANOUT_ENV]: '1' },
+    });
+  }
+  const inner = [`${NO_FANOUT_ENV}=1`, 'agents', ...forwardedArgs].map((t, i) =>
+    i === 0 ? t : shellQuote(t),
+  ).join(' ');
+  return `bash -lc ${shellQuote(inner)}`;
+}
+
+/**
+ * Parse a peer's `sessions --json` stdout into `SessionMeta[]`, tagging each
+ * with `machine`. Defensive against version skew / partial output: non-JSON or
+ * a non-array yields `[]`, and non-object entries are dropped rather than
+ * throwing. The `machine` we dialed always wins over any value the peer set on
+ * its own rows, so grouping keys off the computer we asked. Exported for unit
+ * testing without a live tailnet.
+ */
+export function parseRemoteList(stdout: string, machine: string): SessionMeta[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const out: SessionMeta[] = [];
+  for (const x of parsed) {
+    if (x && typeof x === 'object' && !Array.isArray(x)) {
+      out.push({ ...(x as SessionMeta), machine });
+    }
+  }
+  return out;
+}
+
+/** Run one remote `agents sessions … --json` and capture stdout. Resolves
+ * `{ code: null }` on spawn error or timeout (host treated as dead). */
+function sshCapture(target: string, remoteCmd: string, timeoutMs: number): Promise<{ code: number | null; stdout: string }> {
+  assertValidSshTarget(target);
+  return new Promise((resolve) => {
+    const args = [...SSH_OPTS, ...controlOpts(), target, remoteCmd];
+    const child = spawn('ssh', args, { stdio: ['ignore', 'pipe', 'ignore'] });
+    let stdout = '';
+    let settled = false;
+    const done = (code: number | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ code, stdout });
+    };
+    const timer = setTimeout(() => { child.kill('SIGKILL'); done(null); }, timeoutMs);
+    child.stdout.on('data', (d) => { stdout += d.toString(); });
+    child.on('error', () => done(null));
+    child.on('close', (code) => done(code));
+  });
+}
+
+async function fetchByTarget(target: string, machine: string, display: string, forwardedArgs: string[], os?: string): Promise<SessionMeta[]> {
+  const { code, stdout } = await sshCapture(target, remoteListCommand(forwardedArgs, os), REMOTE_TIMEOUT_MS);
+  if (code !== 0) {
+    process.stderr.write(chalk.gray(`  ${display}: unreachable or no agents CLI — skipped\n`));
+    return [];
+  }
+  return parseRemoteList(stdout, machine);
+}
+
+export interface RemoteListResult {
+  sessions: SessionMeta[];
+  /** How many peer machines we attempted to reach (drives the empty-fleet tip). */
+  deviceCount: number;
+}
+
+/**
+ * Gather listing sessions from other machines. With an explicit `hosts` list
+ * (from `--host`), fan out to exactly those. Otherwise sweep the registered,
+ * online devices from `ag devices`, excluding this machine and any without an
+ * address. `forwardedArgs` are the caller's own sessions args (query + filters,
+ * already `--json`) so every peer returns the same slice this machine asked for.
+ */
+export async function gatherRemoteList(forwardedArgs: string[], hosts?: string[]): Promise<RemoteListResult> {
+  const self = machineId();
+  const targets: Array<{ target: string; machine: string; name: string; os?: string }> = [];
+
+  if (hosts && hosts.length > 0) {
+    for (const h of hosts) {
+      try {
+        assertValidSshTarget(h);
+      } catch {
+        process.stderr.write(chalk.gray(`  ${h}: not a valid ssh target — skipped\n`));
+        continue;
+      }
+      const bareHost = h.split('@').pop() || h;
+      targets.push({ target: h, machine: normalizeHost(bareHost), name: h, os: resolveRemoteOsSync(h) });
+    }
+  } else {
+    let reg: Record<string, DeviceProfile>;
+    try {
+      reg = await loadDevices();
+    } catch {
+      return { sessions: [], deviceCount: 0 };
+    }
+    for (const d of Object.values(reg)) {
+      if (d.tailscale?.online !== true) continue;
+      if (normalizeHost(d.name) === self) continue;
+      // Only machines that can actually run the CLI. iOS/tablet nodes register as
+      // `unknown` platform and can never answer, so skip them rather than burn a
+      // full ConnectTimeout on each.
+      if (d.platform !== 'windows' && d.platform !== 'linux' && d.platform !== 'macos') continue;
+      try {
+        targets.push({ target: sshTargetFor(d), machine: normalizeHost(d.name), name: d.name, os: d.platform });
+      } catch {
+        // No address on the profile — nothing to dial; skip silently.
+      }
+    }
+  }
+
+  const results = await Promise.all(targets.map((t) => fetchByTarget(t.target, t.machine, t.name, forwardedArgs, t.os)));
+  return { sessions: results.flat(), deviceCount: targets.length };
+}

--- a/src/lib/session/remote-list.ts
+++ b/src/lib/session/remote-list.ts
@@ -22,6 +22,7 @@ import { remoteShellFor, buildWindowsAgentsCommand } from '../hosts/remote-cmd.j
 import { resolveRemoteOsSync } from '../hosts/remote-os.js';
 import { machineId, normalizeHost } from './sync/config.js';
 import { NO_FANOUT_ENV } from './remote-active.js';
+import { terminalWidth } from './width.js';
 import type { SessionMeta } from './types.js';
 
 /** Per-host SSH budget. Slightly above SSH_OPTS' ConnectTimeout=10 so a
@@ -67,7 +68,9 @@ export function parseRemoteList(stdout: string, machine: string): SessionMeta[] 
   const out: SessionMeta[] = [];
   for (const x of parsed) {
     if (x && typeof x === 'object' && !Array.isArray(x)) {
-      out.push({ ...(x as SessionMeta), machine });
+      // `_remote` marks these as living on the peer's disk (not a local mirror),
+      // so the picker routes read/resume back over SSH instead of the local FS.
+      out.push({ ...(x as SessionMeta), machine, _remote: true });
     }
   }
   return out;
@@ -156,4 +159,57 @@ export async function gatherRemoteList(forwardedArgs: string[], hosts?: string[]
 
   const results = await Promise.all(targets.map((t) => fetchByTarget(t.target, t.machine, t.name, forwardedArgs, t.os)));
   return { sessions: results.flat(), deviceCount: targets.length };
+}
+
+/** Resolve a peer's SSH target (and OS) from the device registry by its
+ * normalized machine id — the same id the fan-out tags rows with. Returns
+ * undefined when no registered device with an address matches. */
+export async function resolvePeerTarget(machine: string): Promise<{ target: string; os?: string } | undefined> {
+  let reg: Record<string, DeviceProfile>;
+  try {
+    reg = await loadDevices();
+  } catch {
+    return undefined;
+  }
+  for (const d of Object.values(reg)) {
+    if (normalizeHost(d.name) !== machine) continue;
+    try {
+      return { target: sshTargetFor(d), os: d.platform };
+    } catch {
+      return undefined; // matched the machine, but it has no address to dial
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Run `agents <args>` ON a peer over SSH, attached to this terminal (inherited
+ * stdio). `args` is the full arg vector after the binary — callers pass e.g.
+ * `['sessions', id, '--markdown']` or `['sessions', 'resume', id]`. Used when a
+ * picked session lives on another machine: its transcript and agent binary are
+ * there, so both reading (no TTY) and resuming (TTY) must execute on the peer —
+ * not via a local `--host` hop, which would discover locally and dead-end for a
+ * session that exists only on the peer. Resolves 'no-target' when the machine
+ * isn't a dialable registered device; the caller surfaces a clear message.
+ */
+export async function runOnPeer(args: string[], machine: string, opts: { tty?: boolean } = {}): Promise<'ok' | 'no-target'> {
+  const peer = await resolvePeerTarget(machine);
+  if (!peer) return 'no-target';
+
+  const cols = terminalWidth();
+  const remoteCmd = remoteShellFor(peer.os) === 'powershell'
+    ? buildWindowsAgentsCommand({ args, env: cols > 0 ? { COLUMNS: String(cols) } : undefined })
+    : `bash -lc ${shellQuote((cols > 0 ? [`COLUMNS=${cols}`] : []).concat(['agents', ...args].map(shellQuote)).join(' '))}`;
+
+  const sshArgs = [...SSH_OPTS, ...controlOpts()];
+  if (opts.tty) sshArgs.push('-tt'); // force a PTY so the resumed agent is interactive
+  sshArgs.push(peer.target, remoteCmd);
+
+  return new Promise((resolve) => {
+    const child = spawn('ssh', sshArgs, { stdio: 'inherit' });
+    // ssh prints its own connection errors to the inherited stderr; either way
+    // we return once it exits so the picker flow completes.
+    child.on('error', () => resolve('ok'));
+    child.on('close', () => resolve('ok'));
+  });
 }

--- a/src/lib/session/types.ts
+++ b/src/lib/session/types.ts
@@ -93,6 +93,15 @@ export interface SessionMeta {
    * undefined for sessions obtained outside that path.
    */
   machine?: string;
+  /**
+   * True only for rows pulled from another machine over the live cross-machine
+   * fan-out (`remote-list.ts`) — their transcript is on that peer's disk, so
+   * reading/resuming has to hop back over SSH. Distinct from `machine`, which is
+   * also set on locally-readable synced mirrors: a mirror is machine-tagged but
+   * its `filePath` is a local path, so it must NOT be treated as remote. Set by
+   * `parseRemoteList`; transient (never persisted, stripped from --json).
+   */
+  _remote?: boolean;
   /** Terms that matched the current search query */
   _matchedTerms?: string[];
   /** BM25 relevance score from the most recent content-index search */


### PR DESCRIPTION
## What

`agents sessions` (the interactive listing and its piped table) now folds in **every online machine's sessions live over SSH** — no sync needed. This machine's sessions come first; each remote box is a contiguous block below, and every row is labelled with the host it came from.

Answers the ask directly: *"show sessions from this computer at the top, sessions from other computers in a separate group below, preview clearly indicating the hostname."*

## How

Most of the machinery already existed — this wires the last piece:

- **Display was already built.** The picker computes a machine column when the pool spans >1 box (`pickerColumnsFor` → `formatPickerLabel`), and `SessionMeta` already carries `machine` (populated by `discoverSessions` from the sync-mirror path). The gap was that the browse pool never contained live remote sessions.
- **New `remote-list.ts`** — the browse-listing sibling of `remote-active.ts`. Same SSH transport, same online-device set from `ag devices`, same `AGENTS_SESSIONS_LOCAL` recursion guard. Runs `agents sessions <same query> --json` on each peer, parses `SessionMeta[]`, tags each row with the machine dialed. Defensive parse (non-JSON / version skew → `[]`, never throws).
- **`mergeLocalFirst`** — local block first, then remotes by count desc then name, preserving timestamp order within each block; dedupes on `(machine, id)` so a session present both locally (synced mirror) and via fan-out collapses to one.
- **Flat/piped table parity** — reuses `pickerColumnsFor` so the machine column also renders in `printSessionTable` (no duplicated logic).
- **Remote selection is correct end-to-end** — picking a remote session resumes/views it *on that machine* over SSH (`sessions resume --host` / `sessions <id> --markdown --host`). The preview panel shows metadata + a "resume there" note instead of a red local-parse error.
- **`--local`** skips the fan-out (now covers the default listing as well as `--active`). `--json` and single-id lookups stay local so scripts — and peers answering a parent's sweep — stay deterministic.

## Verification

- `bunx tsc --noEmit` clean.
- **460 tests pass** (37 files), including new `remote-list.test.ts` (defensive parse + recursion-guard command) and `mergeLocalFirst` cases (local-first ordering, dedupe, cross-machine same-id).
- **Real end-to-end** from `yosemite-s0`: default listing fanned out to **yosemite-s1, zion, and win-mini** (the Windows peer answered via the PowerShell path) — 604 sessions rendered in contiguous per-machine blocks with the host column. `--local` stays sub-second (no SSH).

## Notes / follow-ups

- Explicit `--host` is left on its existing per-host banner path (unchanged); auto-discovery is the new merged default. Unifying `--host` into the merged view is a reasonable follow-up.
- Each peer applies its own default limit (50) under `--json`; per-machine cap, not a global one.