### PR TITLE
fix(security): contain hook shim name path traversal (#477)

### DIFF
--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -120,7 +120,7 @@ function isManagedHookCommand(command: string, prefixes: string[]): boolean {
 }
 import { getEffectiveHome, getVersionHomePath, listInstalledVersions } from './versions.js';
 import type { AgentId, InstalledHook, ManifestHook } from './types.js';
-import { generateHookShim, getHookShimPath, parseCacheConfig, removeHookShim } from './hooks/cache.js';
+import { generateHookShim, isValidHookShimName, parseCacheConfig, removeHookShim } from './hooks/cache.js';
 import { getHookShimsDir } from './state.js';
 
 export type HookEntry = { name: string; scriptPath: string; dataFile?: string };
@@ -140,6 +140,7 @@ function resolveHookCommand(
 ): string | null {
   const scriptPath = resolveScript(hookDef.script);
   if (!scriptPath) return null;
+  if (!isValidHookShimName(name)) return null;
   const cache = parseCacheConfig(hookDef.cache);
   if (!cache) {
     // No caching opted in — make sure a previously generated shim from an

--- a/src/lib/hooks/cache.test.ts
+++ b/src/lib/hooks/cache.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { generateHookShim, getHookShimPath, parseCacheConfig, parseDuration, removeHookShim } from './cache.js';
+import {
+  generateHookShim,
+  getHookShimPath,
+  isValidHookShimName,
+  parseCacheConfig,
+  parseDuration,
+  removeHookShim,
+} from './cache.js';
 import { toPosix } from '../platform/index.js';
 
 describe('parseDuration', () => {
@@ -144,6 +151,35 @@ describe('generateHookShim', () => {
     // value — what matters is that production callers (who don't pass `paths`)
     // get a consistent location.
     expect(toPosix(getHookShimPath('foo'))).toMatch(/\.cache\/shims\/hooks\/foo\.sh$/);
+  });
+
+  it('rejects hook names that would escape the shims directory', () => {
+    const escapeTarget = path.join(tmpHome, 'outside-pwned.sh');
+    const cache = { ttl: 30, key: 'global' as const, prefetch: 'none' as const };
+    const args = {
+      scriptPath: '/x/y.sh',
+      cache,
+      paths: testPaths,
+    };
+
+    for (const badName of ['../evil', '../../tmp/pwned', 'foo/bar', 'a\\b', '-dash', '', '.', '..']) {
+      expect(isValidHookShimName(badName)).toBe(false);
+      expect(() => getHookShimPath(badName)).toThrow(/Invalid hook shim name/);
+      expect(() => generateHookShim({ ...args, name: badName })).toThrow(/Invalid hook shim name/);
+    }
+
+    expect(fs.existsSync(escapeTarget)).toBe(false);
+    expect(fs.existsSync(testPaths.shimsDir)).toBe(false);
+  });
+
+  it('removeHookShim no-ops on invalid names instead of deleting outside the shims dir', () => {
+    const outside = path.join(tmpHome, 'victim.sh');
+    fs.writeFileSync(outside, '#!/bin/sh\necho pwned\n', { mode: 0o755 });
+
+    removeHookShim('../victim', testPaths.shimsDir);
+    removeHookShim('../../tmp/pwned', testPaths.shimsDir);
+
+    expect(fs.existsSync(outside)).toBe(true);
   });
 
   it('removeHookShim deletes the file if it exists', () => {

--- a/src/lib/hooks/cache.ts
+++ b/src/lib/hooks/cache.ts
@@ -65,9 +65,39 @@ export function parseDuration(d: number | string | undefined): number | null {
   return value;
 }
 
+/**
+ * Reject hook names that could escape the shims directory when interpolated
+ * into a filename. Mirrors the containment gate on hook script resolution in
+ * hooks.ts (`resolveContainedHookPath`).
+ */
+export function isValidHookShimName(name: string): boolean {
+  return (
+    !!name &&
+    name !== '.' &&
+    name !== '..' &&
+    !name.startsWith('-') &&
+    !/[\/\\\x00]/.test(name) &&
+    name.length <= 255
+  );
+}
+
+/** Resolve shimsDir + `${name}.sh` and assert the result stays inside shimsDir. */
+function resolveContainedHookShimPath(shimsDir: string, name: string): string {
+  if (!isValidHookShimName(name)) {
+    throw new Error(`Invalid hook shim name: ${name}`);
+  }
+  const resolvedRoot = path.resolve(shimsDir);
+  const candidate = path.join(shimsDir, `${name}.sh`);
+  const resolved = path.resolve(candidate);
+  if (!resolved.startsWith(resolvedRoot + path.sep)) {
+    throw new Error(`Invalid hook shim name: ${name}`);
+  }
+  return resolved;
+}
+
 /** Absolute path of the generated shim for a hook name. */
 export function getHookShimPath(name: string): string {
-  return path.join(getHookShimsDir(), `${name}.sh`);
+  return resolveContainedHookShimPath(getHookShimsDir(), name);
 }
 
 /**
@@ -96,7 +126,7 @@ export function generateHookShim(args: {
   const shimsDir = args.paths?.shimsDir ?? getHookShimsDir();
   const cacheDir = args.paths?.cacheDir ?? getHookCacheDir();
   const logsDir = args.paths?.logsDir ?? getLogsDir();
-  const shimPath = path.join(shimsDir, `${args.name}.sh`);
+  const shimPath = resolveContainedHookShimPath(shimsDir, args.name);
   const content = renderShim(args.name, args.scriptPath, args.cache, { cacheDir, logsDir });
   fs.mkdirSync(shimsDir, { recursive: true });
 
@@ -262,8 +292,9 @@ exit "$EXIT"
  * hook is renamed/deleted or has its `cache:` field removed.
  */
 export function removeHookShim(name: string, shimsDir?: string): void {
+  if (!isValidHookShimName(name)) return;
   const dir = shimsDir ?? getHookShimsDir();
-  const shimPath = path.join(dir, `${name}.sh`);
+  const shimPath = resolveContainedHookShimPath(dir, name);
   if (fs.existsSync(shimPath)) {
     try { fs.unlinkSync(shimPath); } catch { /* best effort */ }
   }


### PR DESCRIPTION
Closes #477.

Hook manifest keys were interpolated into shim filenames without validation, so a name like `../evil` could write an executable outside `~/.agents/.cache/shims/hooks/`.

## Fix
- Add `isValidHookShimName()` and `resolveContainedHookShimPath()` in `cache.ts` — reject `/`, `\`, `.`, `..`, NUL, and leading `-`, then assert the resolved `${name}.sh` path stays under the shims dir (mirrors `resolveContainedHookPath` for hook scripts).
- Apply the guard on every shim path in `getHookShimPath`, `generateHookShim`, and `removeHookShim`.
- Reject invalid names early in `resolveHookCommand` before any shim write.

## Tests
- `src/lib/hooks/cache.test.ts`: traversal names (`../evil`, `../../tmp/pwned`, etc.) throw and do not create files outside the shims dir; `removeHookShim` no-ops on bad names.

## Verify
- `bunx tsc --noEmit`
- `bun test src/lib/hooks/cache.test.ts` (19 pass)