### PR TITLE
fix(security): Linux secret-store hardening — passphrase, child env, plist TOCTOU (#479)

### DIFF
--- a/src/commands/secrets.test.ts
+++ b/src/commands/secrets.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { assertValidSshTarget, bundleEnvToDotenv, quoteWin32ExecArg } from './secrets.js';
+import { assertValidSshTarget, buildSecretsExecEnv, bundleEnvToDotenv, quoteWin32ExecArg } from './secrets.js';
 import { parseDotenv } from '../lib/secrets/bundles.js';
 
 describe('assertValidSshTarget', () => {
@@ -47,6 +47,37 @@ describe('bundleEnvToDotenv', () => {
   it('rejects multi-line values instead of silently corrupting them', () => {
     expect(() => bundleEnvToDotenv({ KEY: 'line1\nline2' })).toThrow(/multi-line/);
     expect(() => bundleEnvToDotenv({ KEY: 'has\rcarriage' })).toThrow(/multi-line/);
+  });
+});
+
+describe('buildSecretsExecEnv', () => {
+  it('strips AGENTS_SECRETS_PASSPHRASE and loader-hijack vars from the child env', () => {
+    const parent = {
+      PATH: '/usr/bin',
+      HOME: '/home/user',
+      AGENTS_SECRETS_PASSPHRASE: 'master-key',
+      LD_PRELOAD: '/evil.so',
+      NODE_OPTIONS: '--require /evil',
+      DYLD_INSERT_LIBRARIES: '/evil.dylib',
+    };
+    const secretEnv = { API_KEY: 'sk-live', AGENTS_SECRETS_PASSPHRASE: 'bundle-leak' };
+    const child = buildSecretsExecEnv(parent, secretEnv);
+    expect(child.API_KEY).toBe('sk-live');
+    expect(child.PATH).toBe('/usr/bin');
+    expect(child.HOME).toBe('/home/user');
+    expect(child.AGENTS_SECRETS_PASSPHRASE).toBeUndefined();
+    expect(child.LD_PRELOAD).toBeUndefined();
+    expect(child.NODE_OPTIONS).toBeUndefined();
+    expect(child.DYLD_INSERT_LIBRARIES).toBeUndefined();
+  });
+
+  it('bundle vars override sanitized parent vars but not the stripped master key', () => {
+    const child = buildSecretsExecEnv(
+      { PATH: '/old', AGENTS_SECRETS_PASSPHRASE: 'parent' },
+      { PATH: '/new/from-bundle' },
+    );
+    expect(child.PATH).toBe('/new/from-bundle');
+    expect(child.AGENTS_SECRETS_PASSPHRASE).toBeUndefined();
   });
 });
 

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -33,6 +33,7 @@ import {
   readBundle,
   renameBundle,
   rotateBundleSecret,
+  sanitizeProcessEnv,
   validateBundleName,
   validateEnvKey,
   validateExpiresFutureDated,
@@ -197,6 +198,21 @@ function readStdinSync(): string {
 // SSH target validation is defined canonically in src/lib/ssh-exec.ts and
 // re-exported here for back-compat with existing importers of these symbols.
 export { SSH_TARGET_RE, assertValidSshTarget };
+
+/**
+ * Build the child environment for `agents secrets exec`. Strips
+ * loader/interpreter hijack vars (matching agent spawns in exec.ts) and never
+ * forwards AGENTS_SECRETS_PASSPHRASE — the master decryption key must not reach
+ * the executed command.
+ */
+export function buildSecretsExecEnv(
+  parentEnv: NodeJS.ProcessEnv,
+  secretEnv: Record<string, string>,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...sanitizeProcessEnv(parentEnv), ...secretEnv };
+  delete env.AGENTS_SECRETS_PASSPHRASE;
+  return env;
+}
 
 /** POSIX single-quote a string for safe interpolation into a remote shell command. */
 function shellQuote(s: string): string {
@@ -1415,7 +1431,7 @@ Examples:
         const proc = spawn(spawnCmd, spawnArgs, {
           stdio: 'inherit',
           shell: useShell,
-          env: { ...process.env, ...secretEnv },
+          env: buildSecretsExecEnv(process.env, secretEnv),
         });
         proc.on('close', (code) => process.exit(code ?? 0));
         proc.on('error', (err) => {

--- a/src/lib/daemon.test.ts
+++ b/src/lib/daemon.test.ts
@@ -23,6 +23,7 @@ import {
   buildDetachedDaemonEnv,
   getDaemonLaunch,
   startDetached,
+  writeOwnerOnlyServiceManifest,
 } from './daemon.js';
 import { ipcEndpoint } from './platform/index.js';
 import {
@@ -107,6 +108,20 @@ describe('readDaemonClaudeOAuthToken', () => {
   it('treats an empty/whitespace-only token as absent', () => {
     seedKeychainBacked('   ');
     expect(readDaemonClaudeOAuthToken()).toBeNull();
+  });
+});
+
+describe('writeOwnerOnlyServiceManifest', () => {
+  it('creates the file with mode 0600 immediately (no world-readable TOCTOU window)', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-daemon-manifest-'));
+    const manifestPath = path.join(tmpDir, 'com.agents.daemon.plist');
+    writeOwnerOnlyServiceManifest(manifestPath, generateLaunchdPlist());
+    expect(fs.existsSync(manifestPath)).toBe(true);
+    // NTFS has no POSIX mode bits — the 0o600 lockdown is a no-op on Windows.
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(manifestPath).mode & 0o777).toBe(0o600);
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 });
 

--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -374,6 +374,19 @@ function xmlEscape(s: string): string {
     .replace(/>/g, '&gt;');
 }
 
+/**
+ * Write a launchd plist or systemd unit with owner-only permissions atomically.
+ * Uses writeFileSync `{ mode: 0o600 }` so there is no TOCTOU window between
+ * create and chmod when the manifest embeds long-lived credentials.
+ */
+export function writeOwnerOnlyServiceManifest(filePath: string, content: string): void {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(filePath, content, { encoding: 'utf-8', mode: 0o600 });
+}
+
 /** Generate a macOS launchd plist for auto-starting the daemon. */
 export function generateLaunchdPlist(): string {
   const agentsBin = getAgentsBinPath();
@@ -483,10 +496,9 @@ function startDaemonLocked(): { pid: number | null; method: string } {
       if (!fs.existsSync(plistDir)) {
         fs.mkdirSync(plistDir, { recursive: true });
       }
-      fs.writeFileSync(plistPath, generateLaunchdPlist(), 'utf-8');
       // The plist may embed a long-lived OAuth token in EnvironmentVariables;
-      // keep it owner-only so it isn't world/group readable on disk.
-      fs.chmodSync(plistPath, 0o600);
+      // create owner-only atomically (no world-readable window before chmod).
+      writeOwnerOnlyServiceManifest(plistPath, generateLaunchdPlist());
 
       try {
         execFileSync('launchctl', ['unload', plistPath], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
@@ -512,9 +524,8 @@ function startDaemonLocked(): { pid: number | null; method: string } {
       if (!fs.existsSync(unitDir)) {
         fs.mkdirSync(unitDir, { recursive: true });
       }
-      fs.writeFileSync(unitPath, generateSystemdUnit(), 'utf-8');
       // May embed a long-lived OAuth token in an Environment= line; owner-only.
-      fs.chmodSync(unitPath, 0o600);
+      writeOwnerOnlyServiceManifest(unitPath, generateSystemdUnit());
 
       execFileSync('systemctl', ['--user', 'daemon-reload'], { encoding: 'utf-8' });
       execFileSync('systemctl', ['--user', 'enable', SYSTEMD_UNIT], { encoding: 'utf-8' });

--- a/src/lib/secrets/__tests__/linux.test.ts
+++ b/src/lib/secrets/__tests__/linux.test.ts
@@ -238,16 +238,19 @@ describe('headless auto-provisioned passphrase (no env, locked keyring)', () => 
     delete process.env.AGENTS_SECRETS_PASSPHRASE;
     Object.defineProperty(process.stdin, 'isTTY', { value: prevTty, configurable: true });
     _resetForTest();
+    const keyDir = path.resolve(tmpDir, '..', `${path.basename(tmpDir)}-key`);
+    fs.rmSync(keyDir, { recursive: true, force: true });
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('set/get works without env or keyring, and writes a 0600 .passphrase', () => {
+  it('set/get works without env or keyring, and writes a 0600 passphrase outside the store', () => {
     // Previously this threw "no AGENTS_SECRETS_PASSPHRASE is set".
     linuxBackend.set('agents-cli.secrets.work.API_KEY', 'sk-headless-123');
     expect(linuxBackend.get('agents-cli.secrets.work.API_KEY')).toBe('sk-headless-123');
 
-    const passFp = path.join(tmpDir, '.passphrase');
+    const passFp = path.join(path.resolve(tmpDir, '..', `${path.basename(tmpDir)}-key`), 'passphrase');
     expect(fs.existsSync(passFp)).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, '.passphrase'))).toBe(false);
     // NTFS has no POSIX mode bits — the 0o600 lockdown is a no-op on Windows.
     if (process.platform !== 'win32') expect(fs.statSync(passFp).mode & 0o777).toBe(0o600);
     // The on-disk item is ciphertext, not the plaintext value.
@@ -255,15 +258,16 @@ describe('headless auto-provisioned passphrase (no env, locked keyring)', () => 
     expect(enc).not.toContain('sk-headless-123');
   });
 
-  it('the .passphrase file is stable across processes (decrypts later)', () => {
+  it('the machine passphrase is stable across processes (decrypts later)', () => {
     linuxBackend.set('agents-cli.secrets.work.API_KEY', 'persisted');
-    const provisioned = fs.readFileSync(path.join(tmpDir, '.passphrase'), 'utf8');
+    const keyDir = path.resolve(tmpDir, '..', `${path.basename(tmpDir)}-key`);
+    const provisioned = fs.readFileSync(path.join(keyDir, 'passphrase'), 'utf8');
 
     // Fresh process: clear in-memory cache, keep the same store dir.
     _resetForTest({ fileDir: tmpDir, forceFileFallback: true });
     expect(linuxBackend.get('agents-cli.secrets.work.API_KEY')).toBe('persisted');
     // Same passphrase reused, not regenerated.
-    expect(fs.readFileSync(path.join(tmpDir, '.passphrase'), 'utf8')).toBe(provisioned);
+    expect(fs.readFileSync(path.join(keyDir, 'passphrase'), 'utf8')).toBe(provisioned);
   });
 
   it('.passphrase is not surfaced as a secret item', () => {

--- a/src/lib/secrets/filestore.test.ts
+++ b/src/lib/secrets/filestore.test.ts
@@ -26,70 +26,96 @@ vi.mock('child_process', async () => {
 import { fileStore, getPassphrase, _resetFileStoreForTest } from './filestore.js';
 
 describe('filestore passphrase policy (allowAutoProvision)', () => {
-  let tmpDir: string;
+  let tmpRoot: string;
+  let storeDir: string;
+  let keyDir: string;
   let prevTty: boolean | undefined;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-filestore-'));
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-filestore-'));
+    storeDir = path.join(tmpRoot, 'store');
+    keyDir = path.join(tmpRoot, 'key');
     delete process.env.AGENTS_SECRETS_PASSPHRASE;
     // Force the headless branch deterministically regardless of how the runner
     // was launched (a real TTY would otherwise hit the interactive prompt).
     prevTty = process.stdin.isTTY;
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
-    _resetFileStoreForTest({ fileDir: tmpDir });
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
   });
 
   afterEach(() => {
     delete process.env.AGENTS_SECRETS_PASSPHRASE;
     Object.defineProperty(process.stdin, 'isTTY', { value: prevTty, configurable: true });
     _resetFileStoreForTest();
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  it('with allowAutoProvision:false and no passphrase, getPassphrase throws (no .passphrase written)', () => {
+  it('with allowAutoProvision:false and no passphrase, getPassphrase throws (no passphrase written)', () => {
     expect(() => getPassphrase({ allowAutoProvision: false })).toThrow(/AGENTS_SECRETS_PASSPHRASE/);
-    expect(fs.existsSync(path.join(tmpDir, '.passphrase'))).toBe(false);
+    expect(fs.existsSync(path.join(keyDir, 'passphrase'))).toBe(false);
+    expect(fs.existsSync(path.join(storeDir, '.passphrase'))).toBe(false);
   });
 
   it('with allowAutoProvision:false, fileStore.set refuses and writes nothing to disk', () => {
     expect(() => fileStore.set('agents-cli.secrets.b.K', 'v', { allowAutoProvision: false }))
       .toThrow(/AGENTS_SECRETS_PASSPHRASE/);
     // No ciphertext, no provisioned key — the box holds nothing decryptable.
-    expect(fs.readdirSync(tmpDir)).toEqual([]);
+    const storeEntries = fs.existsSync(storeDir) ? fs.readdirSync(storeDir) : [];
+    expect(storeEntries.filter((e) => e.endsWith('.enc'))).toEqual([]);
+    expect(storeEntries).not.toContain('.passphrase');
+    expect(fs.existsSync(path.join(keyDir, 'passphrase'))).toBe(false);
   });
 
   it('with an explicit AGENTS_SECRETS_PASSPHRASE, set/get round-trips with auto-provision OFF', () => {
     process.env.AGENTS_SECRETS_PASSPHRASE = 'per-run-key';
-    _resetFileStoreForTest({ fileDir: tmpDir });
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
     const opts = { allowAutoProvision: false } as const;
     fileStore.set('agents-cli.secrets.b.K', 'sealed', opts);
     expect(fileStore.get('agents-cli.secrets.b.K', opts)).toBe('sealed');
     // Encrypted on disk; the machine key was never provisioned.
-    expect(fs.existsSync(path.join(tmpDir, '.passphrase'))).toBe(false);
-    const enc = fs.readFileSync(path.join(tmpDir, 'agents-cli.secrets.b.K.enc'), 'utf8');
+    expect(fs.existsSync(path.join(keyDir, 'passphrase'))).toBe(false);
+    expect(fs.existsSync(path.join(storeDir, '.passphrase'))).toBe(false);
+    const enc = fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.b.K.enc'), 'utf8');
     expect(enc).not.toContain('sealed');
   });
 
   it('with the wrong passphrase, get fails the auth tag with a clear message (auto-provision OFF)', () => {
     process.env.AGENTS_SECRETS_PASSPHRASE = 'right';
-    _resetFileStoreForTest({ fileDir: tmpDir });
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
     fileStore.set('agents-cli.secrets.b.K', 'sealed', { allowAutoProvision: false });
     process.env.AGENTS_SECRETS_PASSPHRASE = 'wrong';
-    _resetFileStoreForTest({ fileDir: tmpDir });
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
     expect(() => fileStore.get('agents-cli.secrets.b.K', { allowAutoProvision: false }))
       .toThrow(/decrypt|passphrase/i);
+  });
+
+  it('auto-provisions the passphrase outside the encrypted store dir (#479)', () => {
+    fileStore.set('agents-cli.secrets.b.K', 'sealed');
+    const storeEntries = fs.readdirSync(storeDir);
+    expect(storeEntries).toContain('agents-cli.secrets.b.K.enc');
+    expect(storeEntries).not.toContain('.passphrase');
+    expect(storeEntries).not.toContain('passphrase');
+    expect(fs.existsSync(path.join(keyDir, 'passphrase'))).toBe(true);
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(path.join(keyDir, 'passphrase')).mode & 0o777).toBe(0o600);
+      expect(fs.statSync(keyDir).mode & 0o777).toBe(0o700);
+    }
   });
 });
 
 // Windows has no /dev/tty; the interactive prompt must route through PowerShell
 // Read-Host instead of crashing with a raw ENOENT on fs.openSync('/dev/tty').
 describe('filestore win32 interactive passphrase branch', () => {
-  let tmpDir: string;
+  let tmpRoot: string;
+  let storeDir: string;
+  let keyDir: string;
   let prevTty: boolean | undefined;
   let prevPlatform: PropertyDescriptor | undefined;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-filestore-win-'));
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-filestore-win-'));
+    storeDir = path.join(tmpRoot, 'store');
+    keyDir = path.join(tmpRoot, 'key');
     delete process.env.AGENTS_SECRETS_PASSPHRASE;
     // Interactive (isTTY) + win32 so getPassphrase reaches the TTY prompt.
     prevTty = process.stdin.isTTY;
@@ -97,7 +123,7 @@ describe('filestore win32 interactive passphrase branch', () => {
     prevPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
     spawnSyncMock.mockReset();
-    _resetFileStoreForTest({ fileDir: tmpDir });
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
   });
 
   afterEach(() => {
@@ -106,7 +132,7 @@ describe('filestore win32 interactive passphrase branch', () => {
     if (prevPlatform) Object.defineProperty(process, 'platform', prevPlatform);
     spawnSyncMock.mockReset();
     _resetFileStoreForTest();
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
   });
 
   it('reads the passphrase via PowerShell Read-Host, not /dev/tty', () => {
@@ -119,7 +145,7 @@ describe('filestore win32 interactive passphrase branch', () => {
     });
     // Round-trips a value using the prompted passphrase (proves it flows through).
     fileStore.set('agents-cli.secrets.b.K', 'sealed');
-    _resetFileStoreForTest({ fileDir: tmpDir });
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
     spawnSyncMock.mockImplementation(() => ({
       status: 0, stdout: Buffer.from('typed-pass\n'), stderr: Buffer.from(''),
     }));

--- a/src/lib/secrets/filestore.ts
+++ b/src/lib/secrets/filestore.ts
@@ -32,6 +32,7 @@ import { encodePwshBase64 } from '../pwsh.js';
 // ---------- file store location ----------
 
 let fileDirOverride: string | null = null;
+let passphraseDirOverride: string | null = null;
 let cachedPassphrase: string | null = null;
 let warnedAutoPassphrase = false;
 
@@ -107,29 +108,43 @@ function readPassphraseFromTty(): string {
   }
 }
 
-/** Path of the auto-provisioned machine-local passphrase. Lives alongside the
- *  encrypted items but is never itself an item (no `.enc` suffix, so it's
- *  excluded from list/has/get and from fileFallbackPreviouslyActivated). */
+/**
+ * Directory for the auto-provisioned machine-local passphrase. Kept outside
+ * `fileDir()` so a scan of the encrypted store never co-locates key + ciphertext.
+ */
+function passphraseDir(): string {
+  return passphraseDirOverride ?? path.join(os.homedir(), '.agents', '.secrets-key');
+}
+
+function ensurePassphraseDir(): void {
+  fs.mkdirSync(passphraseDir(), { recursive: true, mode: 0o700 });
+}
+
+/** Path of the auto-provisioned machine-local passphrase (not an `.enc` item). */
 function passphraseFilePath(): string {
+  return path.join(passphraseDir(), 'passphrase');
+}
+
+/** Legacy co-located path — read-only for machines provisioned before #479. */
+function legacyPassphraseFilePath(): string {
   return path.join(fileDir(), '.passphrase');
 }
 
 /** True if a machine-local passphrase has already been provisioned. */
 export function machinePassphraseExists(): boolean {
-  try {
-    return fs.readFileSync(passphraseFilePath(), 'utf8').trim().length > 0;
-  } catch {
-    return false;
-  }
+  return readMachinePassphrase() !== null;
 }
 
 function readMachinePassphrase(): string | null {
-  try {
-    const p = fs.readFileSync(passphraseFilePath(), 'utf8').trim();
-    return p.length > 0 ? p : null;
-  } catch {
-    return null;
+  for (const fp of [passphraseFilePath(), legacyPassphraseFilePath()]) {
+    try {
+      const p = fs.readFileSync(fp, 'utf8').trim();
+      if (p.length > 0) return p;
+    } catch {
+      // try next location
+    }
   }
+  return null;
 }
 
 /**
@@ -148,7 +163,7 @@ function provisionMachinePassphrase(): string {
   const existing = readMachinePassphrase();
   if (existing) return existing;
 
-  ensureFileDir();
+  ensurePassphraseDir();
   const generated = randomBytes(32).toString('base64');
   const fp = passphraseFilePath();
   try {
@@ -344,9 +359,11 @@ export const fileBackend: KeychainBackend = {
 /** Test-only: reset module state (file dir + cached passphrase). */
 export function _resetFileStoreForTest(opts: {
   fileDir?: string | null;
+  passphraseDir?: string | null;
   passphrase?: string | null;
 } = {}): void {
   fileDirOverride = opts.fileDir ?? null;
+  passphraseDirOverride = opts.passphraseDir ?? null;
   cachedPassphrase = opts.passphrase ?? null;
   warnedAutoPassphrase = false;
 }

--- a/src/lib/secrets/filestore.ts
+++ b/src/lib/secrets/filestore.ts
@@ -356,6 +356,11 @@ export const fileBackend: KeychainBackend = {
   list: fileList,
 };
 
+/** Resolved passphrase directory (exported for integration tests). */
+export function resolvePassphraseDir(): string {
+  return passphraseDir();
+}
+
 /** Test-only: reset module state (file dir + cached passphrase). */
 export function _resetFileStoreForTest(opts: {
   fileDir?: string | null;
@@ -363,7 +368,14 @@ export function _resetFileStoreForTest(opts: {
   passphrase?: string | null;
 } = {}): void {
   fileDirOverride = opts.fileDir ?? null;
-  passphraseDirOverride = opts.passphraseDir ?? null;
+  if (opts.passphraseDir !== undefined) {
+    passphraseDirOverride = opts.passphraseDir;
+  } else if (opts.fileDir) {
+    // Hermetic sibling when only the store dir is overridden (linux.test.ts).
+    passphraseDirOverride = path.resolve(opts.fileDir, '..', `${path.basename(opts.fileDir)}-key`);
+  } else {
+    passphraseDirOverride = null;
+  }
   cachedPassphrase = opts.passphrase ?? null;
   warnedAutoPassphrase = false;
 }


### PR DESCRIPTION
Closes #479.

Three security hardening fixes from the parallel audit:

1. **Passphrase co-location** — machine-local passphrases are provisioned at `~/.agents/.secrets-key/passphrase` (mode 0600, dir 0700), not alongside `~/.agents/.cache/secrets/*.enc`. Legacy co-located `.passphrase` files are still read for migration.

2. **`secrets exec` child env** — child processes now inherit `sanitizeProcessEnv(process.env)` merged with bundle vars, with `AGENTS_SECRETS_PASSPHRASE` stripped. Matches the agent-spawn posture in `exec.ts`.

3. **Daemon plist/unit TOCTOU** — launchd plist and systemd unit files are written with `writeFileSync({ mode: 0o600 })` atomically, closing the world-readable window before chmod.

## Verification
- `bunx tsc --noEmit`
- `vitest run` on `filestore.test.ts`, `secrets.test.ts`, `daemon.test.ts` (targeted security cases)