### PR TITLE
fix(cli): bare `agents` prints root help instead of exiting silently

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1161,6 +1161,16 @@ if (process.platform === 'darwin' && process.env.AGENTS_SKIP_MIGRATION !== '1') 
   } catch { /* never block CLI startup on the menu bar */ }
 }
 
+// Bare invocation prints the root help. Commander only auto-displays help on
+// an empty parse when subcommands are registered, and the lazy-startup path
+// registers none for a bare call — without this branch, `agents` exits
+// silently. Runs after first-run setup and migrations so those still fire;
+// exits 0 to match `agents --help` (and the pre-fix exit code).
+if (passedArgs.length === 0) {
+  program.outputHelp();
+  process.exit(0);
+}
+
 try {
   await maybeBootstrapShimIntegration(requestedCommand, helpOrVersionRequested);
   await program.parseAsync();

--- a/tests/bare-invocation.test.ts
+++ b/tests/bare-invocation.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+// Regression: bare `agents` must print the root help. The lazy-startup path
+// registers no subcommands for a bare invocation, and commander only
+// auto-displays help on an empty parse when subcommands exist — so without the
+// explicit bare-invocation branch in src/index.ts the CLI exits silently.
+describe('bare `agents` invocation', () => {
+  it('prints the root help instead of exiting silently', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-bare-home-'));
+    // A populated config makes this a non-first-run home; spawnSync is non-TTY
+    // anyway, so the interactive setup path cannot trigger.
+    fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.agents', 'agents.yaml'), 'agents: {}\n');
+
+    const result = spawnSync('node', ['--import', 'tsx', 'src/index.ts'], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        AGENTS_SKIP_MIGRATION: '1',
+      },
+      encoding: 'utf-8',
+    });
+
+    expect(result.stdout).toContain('Usage: agents [command] [options]');
+    expect(result.stdout).toContain('Quick start:');
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

Bare `agents` (no args) exits 0 with no output. Regression from the lazy-startup refactor (#431): a bare invocation registers zero subcommands (by design, for cold-start speed), but commander only auto-displays help on an empty parse when subcommands are registered — so the empty, command-less program parses successfully and prints nothing. Latent until now for dev-link users whose stale `dist` predated the refactor (#624 made those rebuilds automatic, surfacing this).

## Fix

Print the static root help explicitly when `passedArgs` is empty, placed after first-run setup and the migration fold so both still fire on a bare call. Exit 0 — matches `agents --help` and the (silent) pre-fix exit code, so no script-visible change.

## Testing

- New `tests/bare-invocation.test.ts` spawns the entrypoint with no args and asserts the root help reaches stdout with exit 0 (fails on current main, which produces no output).
- Verified manually: `node --import tsx src/index.ts` prints the full root help; `tsc --noEmit` clean.