### PR TITLE
test(inspect): skip sh-specific injection probe on Windows (#474 follow-up)

### DIFF
--- a/src/commands/inspect.test.ts
+++ b/src/commands/inspect.test.ts
@@ -280,7 +280,12 @@ describe('repoGitInfo', () => {
     expect(info.dirty).toBe(1);
   });
 
-  it('treats a repo path with shell metacharacters as a literal argument', () => {
+  // The `$(touch …)` payload is POSIX-shell syntax and embeds an absolute
+  // sentinel path (which contains `:` / `\` on Windows — illegal in a filename),
+  // so the demonstrator runs on POSIX only. The fix (argv-form execFileSync)
+  // removes the shell on every platform, so Windows is covered by construction,
+  // not by this sh-specific probe.
+  it.skipIf(process.platform === 'win32')('treats a repo path with shell metacharacters as a literal argument', () => {
     const base = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-inject-'));
     tempDirs.push(base);
     const sentinel = path.join(base, 'pwned');


### PR DESCRIPTION
The #474 command-injection test (`treats a repo path with shell metacharacters as a literal argument`) turned the `test-windows` CI leg red after the security batch merged.

Root cause: the test constructs a directory name from an **absolute sentinel path** plus `$(touch …)` POSIX-shell syntax. On Windows that name contains `:` and `\` (illegal filename chars) and `$()` is not cmd.exe syntax, so the probe cannot run.

The security fix itself (argv-form `execFileSync`, no shell on any platform) is **not** a regression — it protects Windows by construction. This gates the sh-specific *demonstrator* to POSIX with `it.skipIf(process.platform === "win32")`. Linux still runs all 29 inspect tests (verified: 29 passed); Windows skips this one probe.