### PR TITLE
fix(security): re-lock stale world-readable daemon manifests on overwrite (#479 follow-up)

### DIFF
--- a/src/lib/daemon.test.ts
+++ b/src/lib/daemon.test.ts
@@ -123,6 +123,25 @@ describe('writeOwnerOnlyServiceManifest', () => {
     }
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
+
+  it('re-locks a pre-existing world-readable manifest to 0600 on overwrite', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-daemon-manifest-'));
+    const manifestPath = path.join(tmpDir, 'com.agents.daemon.plist');
+    // Simulate a stale manifest left world-readable by an older install.
+    fs.writeFileSync(manifestPath, 'stale', { mode: 0o644 });
+    if (process.platform !== 'win32') {
+      fs.chmodSync(manifestPath, 0o644);
+      expect(fs.statSync(manifestPath).mode & 0o777).toBe(0o644);
+    }
+    writeOwnerOnlyServiceManifest(manifestPath, generateLaunchdPlist());
+    expect(fs.readFileSync(manifestPath, 'utf-8')).not.toBe('stale');
+    // writeFileSync's mode is a no-op when overwriting an existing file, so the
+    // unlink-before-create is what forces this back to 0600.
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(manifestPath).mode & 0o777).toBe(0o600);
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
 });
 
 describe('generateLaunchdPlist', () => {

--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -376,14 +376,19 @@ function xmlEscape(s: string): string {
 
 /**
  * Write a launchd plist or systemd unit with owner-only permissions atomically.
- * Uses writeFileSync `{ mode: 0o600 }` so there is no TOCTOU window between
- * create and chmod when the manifest embeds long-lived credentials.
+ *
+ * `writeFileSync`'s `mode` is honored only when the file is *created*, so we
+ * unlink any pre-existing manifest first. That guarantees every write is a
+ * fresh 0600 create — closing the TOCTOU window on new files AND re-locking a
+ * stale world-readable manifest left by an older install — since these files
+ * embed long-lived credentials.
  */
 export function writeOwnerOnlyServiceManifest(filePath: string, content: string): void {
   const dir = path.dirname(filePath);
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
+  fs.rmSync(filePath, { force: true });
   fs.writeFileSync(filePath, content, { encoding: 'utf-8', mode: 0o600 });
 }
 


### PR DESCRIPTION
Follow-up hardening on the #479 daemon-manifest fix (which already landed on main).

An independent security review caught a residual gap: `writeOwnerOnlyServiceManifest` creates the plist/unit with mode `0600`, but `writeFileSync`s `mode` is honored **only on create**. Overwriting a pre-existing world-readable manifest (e.g. one left by an older install) leaves it `0644` — so `daemon start` re-injects a fresh OAuth token into a still-world-readable file.

Fix: `fs.rmSync(filePath, { force: true })` before the write, so every write is a fresh atomic `0600` create — closing the TOCTOU window for both new and overwritten manifests. Adds an overwrite-case test (verified: 19/19 daemon tests pass, tsc clean).