### PR TITLE
docs: fix stale profiles beta-gate and phantom add flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Backed by a SQLite + FTS5 index at `~/.agents/.history/sessions/sessions.db` wit
 
 ## Run open models through Claude Code (experimental)
 
-> **Note:** Profiles are experimental. Enable with `agents beta profiles enable`.
+> **Note:** Profiles are experimental, but available by default — no enable step needed.
 
 ```bash
 # Kimi K2.5 responding inside Claude Code's UI, tools, and skills.
@@ -785,7 +785,7 @@ No — it's a SQLite + FTS5 full-text index. Fast, flexible, and robust. Agents 
 
 ### How do I use custom or local models?
 
-Profiles (experimental — enable with `agents beta profiles enable`). Works with LiteLLM Proxy, Ollama, or any OpenAI-compatible endpoint. Drop a YAML in `~/.agents/profiles/` pointing to your endpoint.
+Profiles (experimental — available by default). Works with LiteLLM Proxy, Ollama, or any OpenAI-compatible endpoint. Drop a YAML in `~/.agents/profiles/` pointing to your endpoint.
 
 ### Can I add support for a new agent?
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -8,7 +8,7 @@ A profile pins a host agent binary to a non-default API endpoint and model, with
 
 Built-in presets cover the top open-weight models via OpenRouter (one shared key) and native CLI providers (xAI, Google). Custom profiles work with any OpenAI-compatible endpoint: Ollama, vLLM, LiteLLM Proxy. Profile YAML files live under `~/.agents/profiles/` and are resolved by name at `agents run` time.
 
-> **Status:** Profiles are experimental. Enable with `agents beta profiles enable`.
+> **Status:** Profiles are experimental, but available by default — no enable step needed.
 
 ## Architecture
 

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -121,7 +121,7 @@ Primary runs first; on rate-limit error, the next agent picks up.
 Run any OpenAI-compatible model (Kimi, DeepSeek, Qwen, etc.) through a host CLI by passing a profile name in the agent slot.
 
 ```bash
-agents profiles add kimi --host claude --endpoint https://api.moonshot.ai/anthropic --model kimi-k2-thinking
+agents profiles add kimi          # kimi is a built-in preset (host + endpoint + model baked in)
 agents run kimi "..."
 ```
 


### PR DESCRIPTION
## What

Two doc/skill inaccuracies about **profiles**, both verified against source:

1. **Phantom beta gate.** `docs/profiles.md`, `README.md` (x2) tell users to run `agents beta profiles enable`. But `profiles` is not a beta feature — `ALL_BETA_FEATURES` is only `['drive', 'factory']` (`src/lib/beta.ts:16`) and the `profiles` command is registered unconditionally (`src/lib/startup/command-registry.ts:149`). `agents profiles --help` runs with no beta flag set. The enable instruction is a no-op; removed it.

2. **Non-existent `add` flags.** `skills/run/SKILL.md` showed `agents profiles add kimi --host claude --endpoint … --model …`. The real `add` command only accepts `--preset`, `--version`, `--key-stdin`, `--force` (`src/commands/profiles.ts:365-371`) — endpoint/model come from the preset. Fixed the example to the real invocation (`kimi` is a built-in preset).

## Verification

- `agents profiles --help` → exit 0, no beta enable required
- `grep ALL_BETA_FEATURES src/lib/beta.ts` → `['drive', 'factory']` (no `profiles`)
- `agents profiles add --help` → only `--preset/--version/--key-stdin/--force`

Docs-only change.