### PR TITLE
fix(sessions): dynamic machine-column width (no more 'yosemite-…' truncation)

### DIFF
--- a/src/commands/__tests__/sessions-machine-grouping.test.ts
+++ b/src/commands/__tests__/sessions-machine-grouping.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { groupSessionsByMachine, dedupeByMachineSession, mergeLocalFirst } from '../sessions.js';
+import { groupSessionsByMachine, dedupeByMachineSession, mergeLocalFirst, pickerColumnsFor } from '../sessions.js';
 import type { ActiveSession } from '../../lib/session/active.js';
 import type { SessionMeta } from '../../lib/session/types.js';
 
@@ -180,3 +180,33 @@ describe('mergeLocalFirst', () => {
     expect(merged).toHaveLength(2);
   });
 });
+
+describe('pickerColumnsFor machine column width', () => {
+  it('sizes the column to fit the widest hostname whole (no ellipsis truncation)', () => {
+    // 'yosemite-s0' (11) shares no prefix with 'zion', so it is shown whole and
+    // the column must be wide enough (>= 12) to render it without truncating.
+    const cols = pickerColumnsFor([
+      mkMeta({ id: 'a', machine: 'yosemite-s0' }),
+      mkMeta({ id: 'b', machine: 'zion' }),
+    ]);
+    expect(cols.showMachine).toBe(true);
+    expect(cols.machineWidth).toBe(12); // 11 + 1 trailing space
+  });
+
+  it('uses the COMPACTED label width when a shared prefix is stripped', () => {
+    // 'yosemite-s0'/'yosemite-s1' compact to 's0'/'s1' (width 2) → floored to MIN.
+    const cols = pickerColumnsFor([
+      mkMeta({ id: 'a', machine: 'yosemite-s0' }),
+      mkMeta({ id: 'b', machine: 'yosemite-s1' }),
+    ]);
+    expect(cols.machineWidth).toBe(8); // MIN floor, not the full 11
+  });
+
+  it('caps the column so a pathological hostname cannot devour the row', () => {
+    const cols = pickerColumnsFor([
+      mkMeta({ id: 'a', machine: 'a-really-absurdly-long-hostname-that-goes-on' }),
+      mkMeta({ id: 'b', machine: 'zion' }),
+    ]);
+    expect(cols.machineWidth).toBe(18); // MAX cap
+  });
+})

--- a/src/commands/__tests__/sessions-machine-grouping.test.ts
+++ b/src/commands/__tests__/sessions-machine-grouping.test.ts
@@ -209,4 +209,4 @@ describe('pickerColumnsFor machine column width', () => {
     ]);
     expect(cols.machineWidth).toBe(18); // MAX cap
   });
-})
+});

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -924,9 +924,11 @@ function flatSessionRow(session: SessionMeta, live?: ActiveSession, showTicket =
   const wt = session.worktreeSlug ? chalk.magenta(`wt:${session.worktreeSlug}`) : '';
 
   // The machine column only earns its width when the listing spans more than one
-  // box (i.e. the cross-machine fan-out folded remotes in) — same rule as the picker.
+  // box (i.e. the cross-machine fan-out folded remotes in) — same rule and
+  // pool-derived width as the picker.
+  const machineColW = cols.machineWidth ?? PICKER_MACHINE_W;
   const machineCell = cols.showMachine
-    ? chalk.gray(padToWidth(truncateToWidth((cols.machineLabel?.(session.machine ?? '') ?? session.machine ?? '') || '-', PICKER_MACHINE_W - 1), PICKER_MACHINE_W))
+    ? chalk.gray(padToWidth(truncateToWidth((cols.machineLabel?.(session.machine ?? '') ?? session.machine ?? '') || '-', machineColW - 1), machineColW))
     : '';
 
   const TICKET_W = 10;
@@ -934,7 +936,7 @@ function flatSessionRow(session: SessionMeta, live?: ActiveSession, showTicket =
     ? chalk.blue(padToWidth(truncateToWidth(ticketLabel(session) || '-', TICKET_W), TICKET_W + 1))
     : '';
   const glyphW = glyph ? 2 : 0;
-  const machineW = cols.showMachine ? PICKER_MACHINE_W : 0;
+  const machineW = cols.showMachine ? machineColW : 0;
   const ticketW = showTicket ? TICKET_W + 1 : 0;
   const wtW = wt ? stringWidth(wt) + 1 : 0;
   const topicW = Math.max(16, terminalWidth() - (10 + 9 + 8 + 16) - glyphW - machineW - ticketW - wtW - stringWidth(when) - 1);
@@ -1206,6 +1208,9 @@ export interface PickerColumns {
   showMachine?: boolean;
   /** Map a full machine id to its compact display form (shared prefix stripped). */
   machineLabel?: (m: string) => string;
+  /** Total width of the machine column, sized to the widest compacted hostname
+   * in the pool (capped). Falls back to PICKER_MACHINE_W when absent. */
+  machineWidth?: number;
   /** Render the ticket/PR column (only when at least one row carries a ref). */
   showTicket?: boolean;
   /**
@@ -1216,7 +1221,20 @@ export interface PickerColumns {
   gutter?: number;
 }
 
+/** Fallback machine-column width when a pool-derived width isn't supplied.
+ * `pickerColumnsFor` normally computes `machineWidth` sized to the actual
+ * hostnames, floored/capped by these bounds so common ids like `yosemite-s0`
+ * (11) fit whole while a pathological hostname can't devour the topic column. */
 const PICKER_MACHINE_W = 11;
+const PICKER_MACHINE_MIN = 8;
+const PICKER_MACHINE_MAX = 18;
+
+/** Column width that shows every compacted hostname in `machines` whole (one
+ * trailing space for separation), bounded by MIN/MAX. */
+function machineColumnWidth(machines: string[], label: (m: string) => string): number {
+  const widest = machines.reduce((w, m) => Math.max(w, stringWidth(label(m))), 0);
+  return Math.min(PICKER_MACHINE_MAX, Math.max(PICKER_MACHINE_MIN, widest + 1));
+}
 
 /**
  * Compact display form for machine ids: strip the longest shared dash-delimited
@@ -1245,9 +1263,12 @@ export function machineLabeler(machines: string[]): (m: string) => string {
  */
 export function pickerColumnsFor(sessions: SessionMeta[]): PickerColumns {
   const machines = sessions.map((s) => s.machine).filter((m): m is string => !!m);
+  const distinct = [...new Set(machines)];
+  const machineLabel = machineLabeler(machines);
   return {
-    showMachine: new Set(machines).size > 1,
-    machineLabel: machineLabeler(machines),
+    showMachine: distinct.length > 1,
+    machineLabel,
+    machineWidth: machineColumnWidth(distinct, machineLabel),
     showTicket: sessions.some((s) => ticketLabel(s) !== ''),
   };
 }
@@ -1262,8 +1283,9 @@ export function formatPickerLabel(s: SessionMeta, query: string, cols: PickerCol
   const versionStr = s.version || '-';
   const wt = s.worktreeSlug ? chalk.magenta(`wt:${s.worktreeSlug}`) : '';
 
+  const machineW = cols.machineWidth ?? PICKER_MACHINE_W;
   const machineCell = cols.showMachine
-    ? chalk.gray(padRight(truncate((cols.machineLabel?.(s.machine ?? '') ?? s.machine ?? '') || '-', PICKER_MACHINE_W - 1), PICKER_MACHINE_W))
+    ? chalk.gray(padRight(truncate((cols.machineLabel?.(s.machine ?? '') ?? s.machine ?? '') || '-', machineW - 1), machineW))
     : '';
 
   const TICKET_W = 10;
@@ -1275,12 +1297,12 @@ export function formatPickerLabel(s: SessionMeta, query: string, cols: PickerCol
   // reserve it, plus the conditional columns, so the topic shrinks to fit and
   // rows never wrap.
   const gutter = cols.gutter ?? 2;
-  const machineW = cols.showMachine ? PICKER_MACHINE_W : 0;
+  const machineColW = cols.showMachine ? machineW : 0;
   const ticketW = cols.showTicket ? TICKET_W + 1 : 0;
   const wtW = wt ? stringWidth(wt) + 1 : 0;
   const topicW = Math.max(
     16,
-    terminalWidth() - gutter - (10 + 9 + 8 + 16) - machineW - ticketW - wtW - stringWidth(when) - 1,
+    terminalWidth() - gutter - (10 + 9 + 8 + 16) - machineColW - ticketW - wtW - stringWidth(when) - 1,
   );
 
   return (


### PR DESCRIPTION
## What

Follow-up to #634. The machine column in `agents sessions` was a fixed 11 cells, so a common 11-char hostname like `yosemite-s0` truncated to `yosemite-…`. Size the column to the widest **compacted** hostname actually present in the pool, floored at 8 and capped at 18 (so a pathological hostname can't eat the topic column). Shared by the picker (`formatPickerLabel`) and the flat/piped table (`flatSessionRow`).

## Before / after

```
before:  d66114ed  kimi   -   yosemite-…  npmscripts-476   FINISH A NEARLY-DONE FI…
after:   d66114ed  kimi   -   yosemite-s0 npmscripts-476   FINISH A NEARLY-DONE FIX…
```

Verified end-to-end: `agents sessions --all` now renders `yosemite-s0`, `yosemite-s1`, `zion`, `mac-mini`, `win-mini` whole, no ellipsis.

## How

- `PickerColumns.machineWidth` — computed once per pool by `machineColumnWidth(distinctMachines, machineLabel)` = `clamp(widestCompactedLabel + 1, 8, 18)`.
- Both cell renderers use `cols.machineWidth ?? PICKER_MACHINE_W` (the constant stays as the fallback).
- When machines share a prefix (`yosemite-s0`/`yosemite-s1` → `s0`/`s1`), the compacted width wins — the column stays narrow.

## Tests

- New `pickerColumnsFor` width cases: fits a whole 11-char hostname (width 12), uses the compacted width when a prefix is stripped (floored to 8), caps at 18 for an absurd hostname.
- `bunx tsc --noEmit` clean; machine-grouping suite 17 pass.