### PR TITLE
fix(exec): disable Claude Code auto-updater for managed pinned installs

### DIFF
--- a/src/lib/__tests__/shims.test.ts
+++ b/src/lib/__tests__/shims.test.ts
@@ -95,8 +95,8 @@ describe('addShimsToPath', () => {
 });
 
 describe('SHIM_SCHEMA_VERSION', () => {
-  it('is 21 (kimi via generic branch + grok anti-loop guard in dispatcher)', () => {
-    expect(SHIM_SCHEMA_VERSION).toBe(21);
+  it('is 22 (claude auto-updater disabled for managed pinned installs)', () => {
+    expect(SHIM_SCHEMA_VERSION).toBe(22);
   });
 });
 
@@ -156,7 +156,7 @@ describe('generateShimScript — config-dir env vars', () => {
 describe('generateVersionedAliasScript', () => {
   it('uses ~/.agents/.history for direct alias binary and config paths', () => {
     const script = generateVersionedAliasScript('codex', '0.125.0');
-    expect(VERSIONED_ALIAS_SCHEMA_VERSION).toBe(10);
+    expect(VERSIONED_ALIAS_SCHEMA_VERSION).toBe(11);
     expect(script).toContain('$HOME/.agents/.history/versions/codex/0.125.0');
     expect(script).not.toContain('$HOME/.agents-system/versions/codex/0.125.0');
   });

--- a/src/lib/exec.test.ts
+++ b/src/lib/exec.test.ts
@@ -36,6 +36,39 @@ describe('buildExecEnv — AGENTS_MAILBOX_DIR wiring (mailbox loop-closer)', () 
   });
 });
 
+describe('buildExecEnv — Claude Code auto-updater suppression for pinned managed installs', () => {
+  it('injects DISABLE_AUTOUPDATER=1 for a managed (pinned) claude version', () => {
+    // Pinned per-version installs must never self-mutate: Claude Code's own
+    // background auto-updater would rewrite the pinned binary in place.
+    const env = buildExecEnv(execOpts({ agent: 'claude', version: '2.1.196' }));
+    expect(env.DISABLE_AUTOUPDATER).toBe('1');
+  });
+
+  it('does not clobber a DISABLE_AUTOUPDATER already in the environment (the guard)', () => {
+    const prev = process.env.DISABLE_AUTOUPDATER;
+    process.env.DISABLE_AUTOUPDATER = '0';
+    try {
+      const env = buildExecEnv(execOpts({ agent: 'claude', version: '2.1.196' }));
+      expect(env.DISABLE_AUTOUPDATER).toBe('0');
+    } finally {
+      if (prev === undefined) delete process.env.DISABLE_AUTOUPDATER;
+      else process.env.DISABLE_AUTOUPDATER = prev;
+    }
+  });
+
+  it('lets a caller override the value via options.env', () => {
+    const env = buildExecEnv(execOpts({
+      agent: 'claude', version: '2.1.196', env: { DISABLE_AUTOUPDATER: '0' },
+    }));
+    expect(env.DISABLE_AUTOUPDATER).toBe('0');
+  });
+
+  it('leaves codex untouched — no DISABLE_AUTOUPDATER injected', () => {
+    const env = buildExecEnv(execOpts({ agent: 'codex', version: '0.20.0' }));
+    expect(env.DISABLE_AUTOUPDATER).toBeUndefined();
+  });
+});
+
 describe('nativeResume (Tier-1 capability derives from the command template)', () => {
   it('claude and codex resume natively', () => {
     expect(nativeResume('claude')).toBe(true);

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -259,6 +259,14 @@ export function buildExecEnv(options: ExecOptions): NodeJS.ProcessEnv {
       : (resolvedVersion && isVersionInstalled('claude', resolvedVersion) ? resolvedVersion : null);
     if (version) {
       result.CLAUDE_CONFIG_DIR = path.join(getVersionHomePath('claude', version), '.claude');
+      // A managed pin lives in a per-version dir; Claude Code's own background
+      // auto-updater would rewrite that pinned binary in place (and has left it
+      // half-swapped and broken). Disable it so a pin stays a pin. Honor an
+      // explicit user value — from process.env (already in result) or from
+      // options.env (spread over result below).
+      if (result.DISABLE_AUTOUPDATER === undefined) {
+        result.DISABLE_AUTOUPDATER = '1';
+      }
     }
     delete result.CODEX_HOME;
     delete result.COPILOT_HOME;

--- a/src/lib/shims.test.ts
+++ b/src/lib/shims.test.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { spawnSync } from 'child_process';
 import { afterEach, describe, expect, it } from 'vitest';
-import { generateShimScript, hasAliasShadowingShim, shimTargetsFor, onDiskShimFile, SHIM_SCHEMA_VERSION } from './shims.js';
+import { generateShimScript, generateVersionedAliasScript, hasAliasShadowingShim, shimTargetsFor, onDiskShimFile, SHIM_SCHEMA_VERSION } from './shims.js';
 import { getProjectVersion } from './versions.js';
 
 const tempDirs: string[] = [];
@@ -41,6 +41,33 @@ describe('generateShimScript', () => {
   it('does not include .oauth_token fallback for codex shim', () => {
     const script = generateShimScript('codex');
     expect(script).not.toContain('.oauth_token');
+  });
+
+  it('disables the Claude Code auto-updater in the claude shim, honoring an explicit value', () => {
+    // Pinned per-version installs must not self-mutate. The `:-1` default lets a
+    // user-set DISABLE_AUTOUPDATER win while defaulting to disabled otherwise.
+    const script = generateShimScript('claude');
+    expect(script).toContain('export DISABLE_AUTOUPDATER="${DISABLE_AUTOUPDATER:-1}"');
+  });
+
+  it('does not touch DISABLE_AUTOUPDATER for the codex shim (codex path unchanged)', () => {
+    const script = generateShimScript('codex');
+    expect(script).not.toContain('DISABLE_AUTOUPDATER');
+    // codex keeps its own suppression flag, injected at exec.
+    expect(script).toContain('-c check_for_update_on_startup=false');
+  });
+});
+
+describe('generateVersionedAliasScript', () => {
+  it('disables the Claude Code auto-updater in a claude@version alias, honoring an explicit value', () => {
+    const script = generateVersionedAliasScript('claude', '2.1.196');
+    expect(script).toContain('export DISABLE_AUTOUPDATER="${DISABLE_AUTOUPDATER:-1}"');
+  });
+
+  it('does not touch DISABLE_AUTOUPDATER for a codex@version alias (codex path unchanged)', () => {
+    const script = generateVersionedAliasScript('codex', '0.20.0');
+    expect(script).not.toContain('DISABLE_AUTOUPDATER');
+    expect(script).toContain('-c check_for_update_on_startup=false');
   });
 
   it('execs normally for a valid project agents.yaml version', () => {

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -237,7 +237,10 @@ async function promptConflictStrategy(
 //        re-exec-looped through `command -v kimi` (the dispatcher itself).
 // v21 — guard grok's `command -v grok` fallback against resolving to our own
 //        shims dir (same infinite re-exec loop), mirroring droid.
-export const SHIM_SCHEMA_VERSION = 21;
+// v22 — export DISABLE_AUTOUPDATER=1 for claude shims so a pinned per-version
+//        install can't self-mutate: Claude Code's background auto-updater would
+//        otherwise rewrite the pinned binary in place. Explicit user value wins.
+export const SHIM_SCHEMA_VERSION = 22;
 
 /** Internal marker string used to embed the schema version in shim scripts. */
 const SHIM_VERSION_MARKER = 'agents-shim-version:';
@@ -269,6 +272,10 @@ export function generateShimScript(agent: AgentId): string {
 # selected version's config directory so switching versions also switches the
 # live Claude account.
 export CLAUDE_CONFIG_DIR="$VERSION_DIR/home/${configDirName}"
+# Managed installs are pinned in a per-version dir; Claude Code's background
+# auto-updater would rewrite the pinned binary in place. Disable it so a pin
+# stays a pin. An explicit user value always wins.
+export DISABLE_AUTOUPDATER="\${DISABLE_AUTOUPDATER:-1}"
 # On Linux sandboxes (no keychain), fall back to a per-version token file.
 # The env var always wins if already set; no-op on macOS.
 if [ "\$(uname -s)" = "Linux" ] && [ -z "\${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -f "\$CLAUDE_CONFIG_DIR/.oauth_token" ]; then
@@ -683,8 +690,11 @@ export function removeShim(agent: AgentId): boolean {
  *        generic node_modules/.bin branch.
  *  v10 — guard grok's `command -v grok` fallback against resolving to our own
  *        shims dir (same infinite re-exec loop), mirroring droid.
+ *  v11 — export DISABLE_AUTOUPDATER=1 for claude aliases so a pinned per-version
+ *        install can't self-mutate via Claude Code's background auto-updater.
+ *        Explicit user value wins.
  */
-export const VERSIONED_ALIAS_SCHEMA_VERSION = 10;
+export const VERSIONED_ALIAS_SCHEMA_VERSION = 11;
 
 /** Internal marker string used to embed the schema version in versioned alias scripts. */
 const VERSIONED_ALIAS_VERSION_MARKER = 'agents-versioned-alias-version:';
@@ -716,6 +726,10 @@ export function generateVersionedAliasScript(agent: AgentId, version: string): s
 # Claude stores OAuth credentials in the macOS keychain. Scope them to this
 # version's config directory so direct aliases also switch the live account.
 export CLAUDE_CONFIG_DIR="$HOME/.agents/.history/versions/${agent}/${version}/home/${configDirName}"
+# Managed installs are pinned in a per-version dir; Claude Code's background
+# auto-updater would rewrite the pinned binary in place. Disable it so a pin
+# stays a pin. An explicit user value always wins.
+export DISABLE_AUTOUPDATER="\${DISABLE_AUTOUPDATER:-1}"
 `
     : agent === 'codex'
       ? `


### PR DESCRIPTION
## Problem

agents-cli pins agent versions in per-version dirs (`~/.agents/.history/versions/claude/<v>/`), but Claude Code's own background auto-updater was left enabled for `claude` launches. A pinned install therefore updated itself in place — observed on a Windows machine repeatedly rewriting a pinned `claude@2.1.196` and eventually leaving it half-swapped and broken (no working `claude.exe`), so every launch failed. The CLI already suppressed self-updating for `codex` but not for `claude`.

Per the official Claude Code docs (`code.claude.com/docs/en/setup`, "Disable auto-updates"): *"Set `DISABLE_AUTOUPDATER` to `\"1\"` in the `env` key… `DISABLE_AUTOUPDATER` only stops the background check; `claude update` and `claude install` still work."* That is exactly the right lever — it stops the unsolicited in-place mutation without breaking explicit management commands.

## Root cause (file:line)

Env for a managed claude launch is built in three places, none of which disabled the updater:

- `src/lib/exec.ts:251` — `buildExecEnv`, the `options.agent === 'claude'` branch, pins `CLAUDE_CONFIG_DIR` but set nothing to stop the updater. This is the canonical spot for `agents run` and, via `execShimPassthrough` (`src/lib/exec.ts:837` calls `buildExecEnv`), the Windows `.cmd` shim path that hit this bug.
- `src/lib/shims.ts:266` — `generateShimScript`, the claude `managedEnv` block exports `CLAUDE_CONFIG_DIR` for the POSIX bash shim, but nothing else.
- `src/lib/shims.ts:714` — `generateVersionedAliasScript`, the claude `managedEnv` block for `claude@<version>` aliases, likewise.

The existing codex suppression, for contrast, lives at `src/lib/exec.ts:834` (`check_for_update_on_startup=false` in `execShimPassthrough`), `src/lib/shims.ts:309` (bash shim), and `src/lib/shims.ts:748` (alias) — the same three sites, left unchanged here.

## Fix

Inject `DISABLE_AUTOUPDATER=1` for a managed (pinned) claude version at each of the three env-construction sites, mirroring the existing codex pattern:

- `src/lib/exec.ts` — inside the `if (version)` block of the claude branch in `buildExecEnv`, set `result.DISABLE_AUTOUPDATER = '1'` only when undefined. `result` already carries `process.env`, and `options.env` is spread over `result` afterward, so an explicit user value wins from either source.
- `src/lib/shims.ts` — the claude `managedEnv` in both `generateShimScript` and `generateVersionedAliasScript` now emit `export DISABLE_AUTOUPDATER="${DISABLE_AUTOUPDATER:-1}"`; the `:-1` default lets a user-set value win while defaulting to disabled.
- Bumped `SHIM_SCHEMA_VERSION` 21→22 and `VERSIONED_ALIAS_SCHEMA_VERSION` 10→11 so existing on-disk shims/aliases regenerate.

Codex is untouched — it keeps its own `-c check_for_update_on_startup=false` flag.

## Tests

Colocated per repo convention (vitest, neighboring `*.test.ts`); no real `~/.agents` touched.

`src/lib/exec.test.ts` (`buildExecEnv`):
- injects `DISABLE_AUTOUPDATER=1` for a managed pinned claude version
- does not clobber a `DISABLE_AUTOUPDATER` already in `process.env` (the guard)
- lets a caller override via `options.env`
- leaves codex untouched (no `DISABLE_AUTOUPDATER`)

`src/lib/shims.test.ts` (`generateShimScript`, `generateVersionedAliasScript`):
- claude shim and alias emit the `DISABLE_AUTOUPDATER="${DISABLE_AUTOUPDATER:-1}"` export
- codex shim and alias contain no `DISABLE_AUTOUPDATER` and keep `-c check_for_update_on_startup=false`

`npx tsc --noEmit` clean. `vitest run src/lib/exec.test.ts src/lib/shims.test.ts` → 2 files, 51 passed (8 new).
