### PR TITLE
fix(setup): point the pull-failure hint at the repo that actually failed

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -93,11 +93,17 @@ export async function runSetup(program: Command, options: { force?: boolean; sup
     console.log(chalk.gray('Skipping system repo clone (--no-system-repo).'));
     console.log(chalk.gray(`Populate ~/.agents/.system/ yourself before running other commands that depend on it.\n`));
   } else {
-    console.log(chalk.gray(`Cloning the system repo from ${systemRepoSlug(systemRepo)} into ~/.agents/.system/.\n`));
+    console.log(
+      chalk.gray(
+        alreadyConfigured
+          ? `Updating the system repo from ${systemRepoSlug(systemRepo)} in ~/.agents/.system/.\n`
+          : `Cloning the system repo from ${systemRepoSlug(systemRepo)} into ~/.agents/.system/.\n`,
+      ),
+    );
 
     ensureAgentsDir();
 
-    const spinner = ora('Cloning system repo...').start();
+    const spinner = ora(alreadyConfigured ? 'Updating system repo...' : 'Cloning system repo...').start();
 
     if (isGitRepo(agentsDir)) {
       // --force on an existing repo: pull instead of re-clone

--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -12,7 +12,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import simpleGit from 'simple-git';
-import { assertSafeGitTransport, parseSource, syncRepoGit } from './git.js';
+import { assertSafeGitTransport, displayHomePath, parseSource, pullRepo, syncRepoGit } from './git.js';
 
 describe('assertSafeGitTransport', () => {
   const allowed = [
@@ -174,5 +174,43 @@ describe('syncRepoGit', () => {
     await simpleGit().clone(remote, verify);
     expect(fs.existsSync(path.join(verify, 'down.txt'))).toBe(true);
     expect(fs.existsSync(path.join(verify, 'up.txt'))).toBe(true);
+  });
+});
+
+describe('displayHomePath', () => {
+  it('renders a home-anchored path in ~-relative form with forward slashes', () => {
+    const abs = os.homedir() + path.sep + '.agents' + path.sep + '.system';
+    expect(displayHomePath(abs)).toBe('~/.agents/.system');
+  });
+
+  it('leaves a path outside the home directory unchanged (bar slash normalization)', () => {
+    expect(displayHomePath('/opt/other/repo')).toBe('/opt/other/repo');
+    expect(displayHomePath('C:\\some\\win\\path')).toBe('C:/some/win/path');
+  });
+});
+
+describe('pullRepo dirty-tree hint', () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(() => {
+    for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true });
+    tmpDirs.length = 0;
+  });
+
+  it('points the remediation hint at the repo that actually failed, not a hardcoded path', async () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'git-pull-'));
+    tmpDirs.push(repo);
+    await simpleGit(repo).init();
+    fs.writeFileSync(path.join(repo, 'dirty.txt'), 'uncommitted');
+
+    const res = await pullRepo(repo);
+
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Working tree has uncommitted changes');
+    // The hint must reference this repo's own directory ...
+    expect(res.error).toContain(path.basename(repo));
+    expect(res.error).toContain(`cd ${displayHomePath(repo)} && git status`);
+    // ... not the old hardcoded ~/.agents (which is not even a git repo).
+    expect(res.error).not.toContain('cd ~/.agents ');
   });
 });

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -7,6 +7,7 @@
  */
 import simpleGit, { SimpleGit } from 'simple-git';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { IS_WINDOWS, isWindowsAbsolutePath } from './platform/index.js';
 import { getPackageLocalPath } from './state.js';
@@ -578,6 +579,16 @@ export async function hasLocalChanges(dir: string): Promise<boolean> {
 }
 
 /**
+ * Render an absolute path in ~-relative form with forward slashes, matching the
+ * way the rest of the CLI prints home-anchored paths (e.g. `~/.agents/.system`).
+ */
+export function displayHomePath(dir: string): string {
+  const home = os.homedir();
+  const rel = dir.startsWith(home) ? '~' + dir.slice(home.length) : dir;
+  return rel.replace(/\\/g, '/');
+}
+
+/**
  * Pull changes in an existing repo.
  * Refuses to pull if the working tree is dirty -- user must commit or discard changes first.
  */
@@ -590,7 +601,7 @@ export async function pullRepo(dir: string): Promise<{ success: boolean; commit:
       return {
         success: false,
         commit: '',
-        error: 'Working tree has uncommitted changes. Commit or discard them before pulling.\n\n  cd ~/.agents && git status',
+        error: `Working tree has uncommitted changes. Commit or discard them before pulling.\n\n  cd ${displayHomePath(dir)} && git status`,
       };
     }
 


### PR DESCRIPTION
## Problem

Running `agents setup --force` when the system repo (`~/.agents/.system`) has a dirty working tree printed:

```
Welcome to agents-cli.
Cloning the system repo from phnx-labs/.agents-system into ~/.agents/.system/.

✖ Pull failed: Working tree has uncommitted changes. Commit or discard them before pulling.

  cd ~/.agents && git status
Fix the issue and re-run: agents setup --force
```

Two misleading things:
1. The remediation hint says `cd ~/.agents && git status`, but the dirty repo is `~/.agents/.system`. `~/.agents` is not a git repo, so following the hint prints `fatal: not a git repository` and strands the user.
2. The header says "Cloning the system repo ... into ~/.agents/.system/." even though the repo already exists and the operation is actually a pull/update.

## Root cause

- The hint was hardcoded and pointed at the wrong directory, regardless of which repo `pullRepo` was invoked on. `src/lib/git.ts:593` (pre-fix):
  ```
  error: 'Working tree has uncommitted changes. Commit or discard them before pulling.\n\n  cd ~/.agents && git status',
  ```
  `pullRepo(dir)` (`src/lib/git.ts:584`) operates on its `dir` argument, and callers pass different repos — `setup.ts:104` passes `agentsDir` (which is `getAgentsDir()` → `SYSTEM_AGENTS_DIR` = `~/.agents/.system/`, per `src/lib/state.ts:157-160`), `repo.ts:921`/`repo.ts:936` pass `t.dir`, `drift-sync.ts:86` passes `status.system.dir`, `sync-umbrella.ts:110` passes `dir`. The single hardcoded `~/.agents` was wrong for all of them.
- The header was unconditional. `src/commands/setup.ts:96` (pre-fix):
  ```
  console.log(chalk.gray(`Cloning the system repo from ${systemRepoSlug(systemRepo)} into ~/.agents/.system/.\n`));
  ```
  printed before the pull-vs-clone branch at `src/commands/setup.ts:102` (`if (isGitRepo(agentsDir))` → pull), so an update always announced itself as a clone. The spinner at `src/commands/setup.ts:100` (`ora('Cloning system repo...')`) had the same issue.

## Fix

- `src/lib/git.ts`: build the hint from the `dir` that `pullRepo` actually operates on, rendered in `~`-relative form (forward slashes) to match the rest of the CLI. Added a small exported helper `displayHomePath(dir)` and used it in the error:
  ```
  error: `Working tree has uncommitted changes. Commit or discard them before pulling.\n\n  cd ${displayHomePath(dir)} && git status`,
  ```
  Fixing it at the source means every caller (`setup`, `repo pull`, `drift-sync`, `sync-umbrella`) now gets a correct hint.
- `src/commands/setup.ts`: made the header and spinner conditional on `alreadyConfigured` (`isGitRepo(agentsDir)`, computed at `setup.ts:71`) — "Updating the system repo ... in ~/.agents/.system/." / "Updating system repo..." when the repo exists (pull), "Cloning ... into ..." / "Cloning system repo..." otherwise.

## Tests

Added to the existing `src/lib/git.test.ts` (real repos, no mocking, temp fixtures):
- `displayHomePath` — home-anchored path → `~/.agents/.system`; outside-home path unchanged; backslash normalization.
- `pullRepo` dirty-tree hint — inits a temp repo, dirties it, asserts the error hint references that repo's own directory (`cd <dir> && git status`) and not the old hardcoded `cd ~/.agents`.

`npx tsc --noEmit` clean; `git.test.ts` 27/27 pass.
