### PR TITLE
fix(migrate): never modify the system mirror during the agents.yaml split

### DIFF
--- a/src/lib/__tests__/migrate-system-mirror.test.ts
+++ b/src/lib/__tests__/migrate-system-mirror.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { migrateAgentsYaml } from '../migrate.js';
+
+// Regression coverage for the v11 split migration wedging the system mirror.
+//
+// The system repo (~/.agents/.system) is a pull-only git mirror of the
+// npm-shipped defaults. A prior version of migrateAgentsYaml() moved/deleted the
+// TRACKED agents.yaml out of it, leaving ` D agents.yaml` in the working tree.
+// Because the mirror sync refuses a dirty tree, that single deletion permanently
+// broke `agents setup`, `agents sync`, and background auto-pull with
+// "Working tree has uncommitted changes." The migration must treat the mirror as
+// read-only.
+
+let tmp: string;
+let systemDir: string;
+let userDir: string;
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync('git', args, {
+    cwd,
+    stdio: 'ignore',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    },
+  });
+}
+
+function porcelain(cwd: string): string {
+  return execFileSync('git', ['status', '--porcelain'], { cwd, encoding: 'utf-8' }).trim();
+}
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'migrate-mirror-'));
+  systemDir = path.join(tmp, '.agents', '.system');
+  userDir = path.join(tmp, '.agents');
+  fs.mkdirSync(systemDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('migrateAgentsYaml — system mirror is read-only', () => {
+  it('never dirties the tracked agents.yaml in a pull-only system mirror', () => {
+    // Build the mirror as a real git repo with a committed agents.yaml (the
+    // npm-shipped defaults).
+    const shipped = 'hooks:\n  session-start:\n    events:\n      - SessionStart\n';
+    fs.writeFileSync(path.join(systemDir, 'agents.yaml'), shipped);
+    git(systemDir, 'init', '-q');
+    git(systemDir, 'add', 'agents.yaml');
+    git(systemDir, 'commit', '-q', '-m', 'ship defaults', '--no-gpg-sign');
+
+    expect(porcelain(systemDir)).toBe(''); // clean baseline
+
+    migrateAgentsYaml(systemDir, userDir);
+
+    // The tracked file must still exist AND the working tree must stay clean —
+    // otherwise the mirror sync wedges every subsequent run.
+    expect(fs.existsSync(path.join(systemDir, 'agents.yaml'))).toBe(true);
+    expect(fs.readFileSync(path.join(systemDir, 'agents.yaml'), 'utf-8')).toBe(shipped);
+    expect(porcelain(systemDir)).toBe('');
+
+    // The shipped defaults are read in place by readMeta(); the migration must
+    // NOT seed a duplicate into the user dir (that would freeze the defaults).
+    expect(fs.existsSync(path.join(userDir, 'agents.yaml'))).toBe(false);
+  });
+
+  it('is idempotent against a tracked mirror across repeated runs', () => {
+    fs.writeFileSync(path.join(systemDir, 'agents.yaml'), 'hooks: {}\n');
+    git(systemDir, 'init', '-q');
+    git(systemDir, 'add', 'agents.yaml');
+    git(systemDir, 'commit', '-q', '-m', 'ship', '--no-gpg-sign');
+
+    migrateAgentsYaml(systemDir, userDir);
+    migrateAgentsYaml(systemDir, userDir);
+
+    expect(fs.existsSync(path.join(systemDir, 'agents.yaml'))).toBe(true);
+    expect(porcelain(systemDir)).toBe('');
+  });
+
+  it('still migrates an UNTRACKED legacy agents.yaml out of a non-git system dir', () => {
+    // Pre-split residue: the system dir is not a git repo, so the file is safe
+    // to move into the user dir.
+    fs.writeFileSync(path.join(systemDir, 'agents.yaml'), 'agents:\n  claude: "1.0.0"\n');
+
+    migrateAgentsYaml(systemDir, userDir);
+
+    expect(fs.existsSync(path.join(systemDir, 'agents.yaml'))).toBe(false);
+    expect(fs.readFileSync(path.join(userDir, 'agents.yaml'), 'utf-8')).toContain('claude');
+  });
+});

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -75,25 +75,51 @@ export function foldLegacySystemRepo(): void {
   } catch { /* best-effort */ }
 }
 
+/** True when `relPath` is a file tracked by a git repo rooted at `repoDir`. */
+function isTrackedInGitRepo(repoDir: string, relPath: string): boolean {
+  try {
+    execSync(`git ls-files --error-unmatch -- ${relPath}`, { cwd: repoDir, stdio: 'ignore' });
+    return true;
+  } catch {
+    // Not a git repo, or the file is untracked — either way, not tracked.
+    return false;
+  }
+}
+
 /**
- * Move ~/.agents-system/agents.yaml -> ~/.agents/agents.yaml.
- * No-op if user file already exists or system file absent.
- * (This is also handled inline in state.ts readMeta, but is exposed here
- *  for explicit migration calls from postinstall / CLI entry points.)
+ * Migrate a legacy single-repo agents.yaml into ~/.agents/agents.yaml.
+ *
+ * The post-fold system dir (~/.agents/.system) is a pull-only mirror of the
+ * npm-shipped defaults. Its agents.yaml is a TRACKED file that readMeta() reads
+ * in place as the defaults base (see SYSTEM_META_FILE in state.ts). Deleting or
+ * moving a tracked file out of the mirror dirties its working tree, which
+ * permanently wedges `agents setup`, `agents sync`, and background auto-pull
+ * ("Working tree has uncommitted changes.") because the mirror sync refuses a
+ * dirty tree. So when agents.yaml is tracked there, treat the mirror as strictly
+ * read-only and leave the file alone.
+ *
+ * Only an UNTRACKED agents.yaml is residue from the pre-split single-repo layout
+ * (or a legacy ~/.agents-system fold) and is safe to move/drop.
+ *
+ * Params default to the real on-disk locations; they are injectable so tests can
+ * drive a fixture tree without touching the user's ~/.agents.
  */
-function migrateAgentsYaml(): void {
-  const src = path.join(SYSTEM_DIR, 'agents.yaml');
-  const dest = path.join(USER_DIR, 'agents.yaml');
+export function migrateAgentsYaml(systemDir: string = SYSTEM_DIR, userDir: string = USER_DIR): void {
+  const src = path.join(systemDir, 'agents.yaml');
+  const dest = path.join(userDir, 'agents.yaml');
   if (!fs.existsSync(src)) return;
+
+  // Tracked in the system mirror → npm-shipped defaults; never mutate. readMeta()
+  // already surfaces it in place, so no user-dir copy is needed either.
+  if (isTrackedInGitRepo(systemDir, 'agents.yaml')) return;
+
   if (fs.existsSync(dest)) {
-    // User copy is authoritative — drop the stale system leftover. The system
-    // repo (npm-shipped) does not track agents.yaml; any copy here is residue
-    // from the pre-split layout.
+    // User copy is authoritative — drop the untracked stale system leftover.
     try { fs.unlinkSync(src); } catch { /* best-effort */ }
     return;
   }
   try {
-    fs.mkdirSync(USER_DIR, { recursive: true, mode: 0o700 });
+    fs.mkdirSync(userDir, { recursive: true, mode: 0o700 });
     fs.renameSync(src, dest);
     console.error('Migrated agents.yaml to ~/.agents/');
   } catch { /* best-effort */ }


### PR DESCRIPTION
## Problem

The v11 split migration (PR #538) deleted the git-tracked `agents.yaml` from the **working tree** of the pull-only system mirror at `~/.agents/.system`. Observed on a real machine:

- `git -C ~/.agents/.system status --short` showed ` D agents.yaml` while the file was still tracked in both local HEAD and `origin/main` (mirror 0 ahead / 0 behind).
- Simultaneously a user-level `~/.agents/agents.yaml` (different content) was created by the migration.

Because the system repo is a pull-only mirror whose sync refuses a dirty tree, that one deletion permanently wedged `agents setup`, `agents sync`, and background auto-pull with `Pull failed: Working tree has uncommitted changes.` on every subsequent run.

## Root cause

`migrateAgentsYaml()` in `src/lib/migrate.ts` operated on `SYSTEM_DIR = ~/.agents/.system` (`src/lib/migrate.ts:22`) and mutated the tracked file:

- User file absent → `fs.renameSync(src, dest)` (`src/lib/migrate.ts:97`) — **moved** the tracked `agents.yaml` out of the mirror.
- User file present → `fs.unlinkSync(src)` (`src/lib/migrate.ts:92`) — **deleted** it.

The stale comment claimed *"The system repo (npm-shipped) does not track agents.yaml; any copy here is residue"* (`src/lib/migrate.ts:89-91`) — but it **is** tracked. `~/.agents/.system/agents.yaml` is the npm-shipped **defaults** file that `readMeta()` reads in place and merges as its base:

- `SYSTEM_META_FILE = ~/.agents/.system/agents.yaml` — `src/lib/state.ts:71`
- `if (fs.existsSync(SYSTEM_META_FILE)) { ... systemMeta = yaml.parse(content) }` — `src/lib/state.ts:806-810`
- `const meta = { ...base, ...systemMeta, ...userMeta, ... }` (*"system as base, user overwrites"*) — `src/lib/state.ts:821-828`

Existing tests never caught this because they only exercise the **legacy non-git** `~/.agents-system` path (`src/lib/__tests__/migrate.test.ts:13`, `:42-75`), where the file is untracked and moving it is correct.

## Fix

`migrateAgentsYaml()` now treats the mirror as strictly read-only: when `agents.yaml` is **git-tracked** in the `.system` repo, it is left untouched (no move, no delete, no user-dir copy — `readMeta()` already reads it in place). Only an **untracked** `agents.yaml` (pre-split single-repo residue / legacy `~/.agents-system` fold) is still migrated into the user dir.

- Added a small `isTrackedInGitRepo(repoDir, relPath)` helper (`git ls-files --error-unmatch`).
- Made `migrateAgentsYaml(systemDir?, userDir?)` injectable for testing, matching the existing convention (`src/lib/migrate.ts:681`, `:1589`). `runMigration()` still calls it with defaults.

## Tests

New colocated file `src/lib/__tests__/migrate-system-mirror.test.ts` (3 tests, all real fs + real git, no mocks). The existing `migrate.test.ts` spawns a `bun` subprocess; this file runs in-process under vitest.

- **Tracked mirror stays clean**: builds a real git repo with a committed `agents.yaml`, runs the migration, asserts `git status --porcelain` is empty, the file still exists with identical content, and no duplicate is seeded into the user dir. Fails against the old code (rename left ` D agents.yaml`).
- **Idempotent** across repeated runs against a tracked mirror.
- **Untracked legacy path still migrates** out of a non-git system dir (guards the legacy behavior).

```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

`npx tsc --noEmit` passes clean.
