### PR TITLE
fix(versions): probe the launch binary in installed checks; repair gutted installs on add

### DIFF
--- a/src/lib/versions.test.ts
+++ b/src/lib/versions.test.ts
@@ -674,3 +674,107 @@ describe('unionResourceSelections + mergeRepoScopedSelections — interactive mu
   });
 });
 
+// ── isVersionInstalled / listInstalledVersions probe the real launch binary ──
+//
+// Regression for the "gutted install" bug: a vendor auto-updater destroyed the
+// real per-version claude binary (node_modules/@anthropic-ai/claude-code/bin/
+// claude.exe) while leaving the version dir, its package.json, and the tiny
+// node_modules/.bin/claude(+.cmd) wrappers in place. The old check keyed
+// "installed" on the wrapper, so `agents add` skipped repair and the picker
+// counted the dead install healthy — `agents run` then died at spawn.
+
+function versionDir(home: string, agent: string, version: string): string {
+  return path.join(home, '.agents', '.history', 'versions', agent, version);
+}
+
+// The name of the real launch binary the package's `bin` entry points at. We
+// don't use ".exe" so the fixture is platform-neutral — getPackageBinaryPath
+// reads whatever the installed package.json declares, which is exactly the
+// point of the fix.
+const CLAUDE_BIN_REL = 'bin/claude-launcher';
+
+/**
+ * Build a claude version dir. Always writes the version-dir marker package.json
+ * and the node_modules/.bin/claude(+.cmd) wrappers npm leaves behind. When
+ * `realBinary` is true, also writes the package's actual launch binary — omit
+ * it to reproduce a gutted install.
+ */
+function makeClaudeVersion(home: string, version: string, opts: { realBinary: boolean }): void {
+  const dir = versionDir(home, 'claude', version);
+  const pkgRoot = path.join(dir, 'node_modules', '@anthropic-ai', 'claude-code');
+  fs.mkdirSync(path.join(dir, 'node_modules', '.bin'), { recursive: true });
+  fs.mkdirSync(path.join(pkgRoot, 'bin'), { recursive: true });
+
+  // Version-dir marker (present even on a gutted install).
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: `agents-claude-${version}`, private: true }), 'utf-8');
+  // Installed package's package.json — declares the real launch binary.
+  fs.writeFileSync(path.join(pkgRoot, 'package.json'), JSON.stringify({ name: '@anthropic-ai/claude-code', version, bin: { claude: CLAUDE_BIN_REL } }), 'utf-8');
+  // The node_modules/.bin wrappers npm always leaves behind (getBinaryPath's target).
+  fs.writeFileSync(path.join(dir, 'node_modules', '.bin', 'claude'), '#!/bin/sh\nexit 0\n', 'utf-8');
+  fs.writeFileSync(path.join(dir, 'node_modules', '.bin', 'claude.cmd'), '@echo off\r\n', 'utf-8');
+
+  if (opts.realBinary) {
+    fs.writeFileSync(path.join(pkgRoot, CLAUDE_BIN_REL), 'REAL BINARY', 'utf-8');
+  }
+}
+
+function runNamedExport(home: string, importName: string, callExpr: string): unknown {
+  const moduleUrl = pathToFileURL(path.resolve('src/lib/versions.ts')).href;
+  const tsxBin = path.resolve('node_modules/tsx/dist/cli.mjs');
+  const child = spawnSync(process.execPath, [tsxBin, '-e', `
+    import { ${importName} } from ${JSON.stringify(moduleUrl)};
+    const home = ${JSON.stringify(home)};
+    console.log(JSON.stringify(${callExpr}));
+  `], { env: { ...process.env, HOME: home }, encoding: 'utf-8' });
+  expect(child.status, child.stderr).toBe(0);
+  return JSON.parse(child.stdout.trim());
+}
+
+describe('isVersionInstalled — probes the real launch binary', () => {
+  it('reports a healthy install (package bin present) as installed', () => {
+    const home = makeTempHome();
+    makeClaudeVersion(home, '2.1.196', { realBinary: true });
+    expect(runNamedExport(home, 'isVersionInstalled', "isVersionInstalled('claude', '2.1.196')")).toBe(true);
+  });
+
+  it('reports a gutted install (real bin destroyed, wrappers + package.json left behind) as NOT installed', () => {
+    const home = makeTempHome();
+    makeClaudeVersion(home, '2.1.196', { realBinary: false });
+    // The node_modules/.bin/claude wrapper still exists — the old dir/wrapper
+    // check would call this installed. The launch binary is gone, so it isn't.
+    expect(fs.existsSync(path.join(versionDir(home, 'claude', '2.1.196'), 'node_modules', '.bin', 'claude'))).toBe(true);
+    expect(runNamedExport(home, 'isVersionInstalled', "isVersionInstalled('claude', '2.1.196')")).toBe(false);
+  });
+
+  it('reports a dir-only install (package.json marker, no node_modules) as NOT installed', () => {
+    const home = makeTempHome();
+    const dir = versionDir(home, 'claude', '2.1.196');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'agents-claude-2.1.196' }), 'utf-8');
+    expect(runNamedExport(home, 'isVersionInstalled', "isVersionInstalled('claude', '2.1.196')")).toBe(false);
+  });
+});
+
+describe('the add fast-path gate flips a gutted install to the repair branch', () => {
+  it('a gutted dir is NOT alreadyInstalled, so `agents add` proceeds to installVersion', () => {
+    // `agents add` computes `alreadyInstalled = isVersionInstalled(agent, version)`
+    // and only skips install when it is true (src/commands/versions.ts). A gutted
+    // dir must return false so add re-runs its install step to repair it rather
+    // than printing "already installed".
+    const home = makeTempHome();
+    makeClaudeVersion(home, '2.1.196', { realBinary: false });
+    const alreadyInstalled = runNamedExport(home, 'isVersionInstalled', "isVersionInstalled('claude', '2.1.196')");
+    expect(alreadyInstalled).toBe(false);
+  });
+});
+
+describe('listInstalledVersions — excludes gutted installs from the picker', () => {
+  it('returns only versions whose real launch binary exists', () => {
+    const home = makeTempHome();
+    makeClaudeVersion(home, '2.1.195', { realBinary: true });
+    makeClaudeVersion(home, '2.1.196', { realBinary: false }); // gutted
+    const versions = runNamedExport(home, 'listInstalledVersions', "listInstalledVersions('claude')");
+    expect(versions).toEqual(['2.1.195']);
+  });
+});
+

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -922,11 +922,60 @@ export function getVersionHomePath(agent: AgentId, version: string): string {
 }
 
 /**
+ * Resolve the REAL launch binary for an npm-package agent version: the file the
+ * installed package's `bin` entry points to — e.g.
+ * node_modules/@anthropic-ai/claude-code/bin/claude.exe on Windows. This is the
+ * executable that the node_modules/.bin/<cli>.cmd wrapper ultimately execs (and
+ * what `agents run` spawns), NOT the wrapper itself.
+ *
+ * The distinction is load-bearing: npm leaves the tiny node_modules/.bin/<cli>
+ * and <cli>.cmd wrappers in place even after a vendor auto-updater destroys the
+ * multi-hundred-MB real binary the wrapper points at. Keying "installed" on the
+ * wrapper (getBinaryPath) — or on the version dir — therefore reports a gutted
+ * install as healthy, and `agents run` then dies at spawn with
+ * "'...claude.exe' is not recognized".
+ *
+ * Returns null for agents without an npm package (grok/droid/installScript,
+ * whose getBinaryPath already resolves the real per-host binary) or when the
+ * installed package.json can't be read/parsed — callers fall back to the
+ * generic getBinaryPath check in those cases.
+ */
+function getPackageBinaryPath(agent: AgentId, version: string): string | null {
+  const agentConfig = AGENTS[agent];
+  if (!agentConfig.npmPackage) return null;
+  const pkgRoot = path.join(getVersionDir(agent, version), 'node_modules', agentConfig.npmPackage);
+  let bin: unknown;
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(pkgRoot, 'package.json'), 'utf-8'));
+    bin = pkg.bin;
+  } catch {
+    return null;
+  }
+  let rel: string | undefined;
+  if (typeof bin === 'string') {
+    rel = bin;
+  } else if (bin && typeof bin === 'object') {
+    const map = bin as Record<string, string>;
+    // Prefer the entry named after our launch command; else the first bin.
+    rel = map[agentConfig.cliCommand] ?? Object.values(map)[0];
+  }
+  if (!rel || typeof rel !== 'string') return null;
+  return path.join(pkgRoot, rel);
+}
+
+/**
  * Check if a specific version is installed.
+ *
+ * Probes the actual launch binary (the same executable the shims run), not just
+ * the version dir or the node_modules/.bin/<cli> wrapper. For npm agents that
+ * means statting the package's real `bin` target (getPackageBinaryPath), so a
+ * present-but-gutted install (vendor auto-updater destroyed the binary) reports
+ * as NOT installed and `agents add` re-runs its install step to repair it.
  */
 export function isVersionInstalled(agent: AgentId, version: string): boolean {
-  const binaryPath = getBinaryPath(agent, version);
-  return fs.existsSync(binaryPath);
+  const packageBinary = getPackageBinaryPath(agent, version);
+  if (packageBinary !== null) return fs.existsSync(packageBinary);
+  return fs.existsSync(getBinaryPath(agent, version));
 }
 
 /**
@@ -1022,8 +1071,10 @@ export function listInstalledVersions(agent: AgentId): string[] {
 
   for (const entry of entries) {
     if (entry.isDirectory()) {
-      const binaryPath = getBinaryPath(agent, entry.name);
-      if (fs.existsSync(binaryPath)) {
+      // Probe the real launch binary (isVersionInstalled), not just the
+      // node_modules/.bin wrapper — a gutted install must not count as healthy
+      // in the balanced account/version picker.
+      if (isVersionInstalled(agent, entry.name)) {
         versions.push(entry.name);
       }
     }
@@ -1053,7 +1104,7 @@ export function listInstalledVersionDirs(agent: AgentId): Array<{ version: strin
     if (!entry.isDirectory()) continue;
     out.push({
       version: entry.name,
-      hasBinary: fs.existsSync(getBinaryPath(agent, entry.name)),
+      hasBinary: isVersionInstalled(agent, entry.name),
     });
   }
   return out.sort((a, b) => compareVersions(a.version, b.version));


### PR DESCRIPTION
## Problem

On this machine, version install dirs under `~/.agents/.history/versions/claude/<v>/` were "gutted": `package.json` and `node_modules` were present, but the real per-version launch binary (`node_modules/@anthropic-ai/claude-code/bin/claude.exe`) had been destroyed by the vendor auto-updater. Despite the dead install:

- `agents add claude@2.1.196 -y` printed "already installed" and skipped any repair.
- The balanced account/version picker counted the gutted install healthy, and `agents run claude` died at spawn with `'...claude.exe' is not recognized`.
- Only `agents use` refused with "not installed".

## Root cause

The installed/health check probed the npm **wrapper**, not the executable that actually runs.

- `getBinaryPath` returns the wrapper path `node_modules/.bin/<cli>` (`src/lib/versions.ts:912-913`):
  ```ts
  const versionDir = getVersionDir(agent, version);
  return path.join(versionDir, 'node_modules', '.bin', agentConfig.cliCommand);
  ```
- `isVersionInstalled` statted only that wrapper (`src/lib/versions.ts:927-930` on base):
  ```ts
  export function isVersionInstalled(agent: AgentId, version: string): boolean {
    const binaryPath = getBinaryPath(agent, version);
    return fs.existsSync(binaryPath);
  }
  ```
- On Windows the wrapper is a delegator: `.bin/claude.cmd` runs `"%dp0%\..\@anthropic-ai\claude-code\bin\claude.exe" %*`, and the package declares `"bin": { "claude": "bin/claude.exe" }`. npm leaves the tiny `.bin/claude`, `.bin/claude.cmd` wrappers behind even after the ~241MB `claude.exe` they point at is gone — so statting the wrapper reports a gutted install as healthy.
- The picker didn't even use `isVersionInstalled`: `listInstalledVersions` statted `getBinaryPath` directly (`src/lib/versions.ts:1025-1026` on base), so it counted the wrapper too.
- `agents add`'s fast path gates on `alreadyInstalled = isVersionInstalled(agent, version)` (`src/commands/versions.ts:385`); the launch path (`execShimPassthrough`, `src/lib/exec.ts:821-831`) resolves `getBinaryPath` then `.cmd`, ultimately exec'ing the missing `claude.exe`.

## Fix

`src/lib/versions.ts`:

- Add `getPackageBinaryPath(agent, version)`: for npm agents, read the installed package's `package.json` and resolve its `bin` entry to the real launch binary (e.g. `node_modules/@anthropic-ai/claude-code/bin/claude.exe`) — the exact file the `.cmd` wrapper execs. Returns `null` for grok/droid/installScript agents (whose `getBinaryPath` already points at the real per-host binary) or when the package.json can't be read, so those callers fall back to the existing wrapper check.
- `isVersionInstalled` now statts that real binary when resolvable, else falls back to `getBinaryPath`.
- Route `listInstalledVersions` and `listInstalledVersionDirs` through `isVersionInstalled` so the picker agrees with the launch path.

With the gate honest, `agents add`'s `alreadyInstalled` fast path flips a gutted dir to the else/install branch, re-running `installVersion` (which mkdirs the existing dir, rewrites package.json, and re-runs `npm install`) to repair it — no new add-side code needed.

## Tests

Colocated in `src/lib/versions.test.ts` (vitest, temp-dir HOME fixtures only, never touches the real `~/.agents`):

- `isVersionInstalled` reports a healthy install (package bin present) as installed.
- `isVersionInstalled` reports a **gutted** install (real bin destroyed, `.bin/claude`+`.cmd` wrappers and package.json left behind) as NOT installed.
- `isVersionInstalled` reports a dir-only install (package.json marker, no node_modules) as NOT installed.
- The add fast-path gate returns false for a gutted dir, so `agents add` proceeds to `installVersion` (repair) instead of "already installed".
- `listInstalledVersions` excludes the gutted version from the picker, returning only the healthy one.

`npx tsc --noEmit` clean. New tests pass (`node ./node_modules/vitest/vitest.mjs run src/lib/versions.test.ts`): 5 passed. The one unrelated failure in the file (`resolveVersionAliasLoose — @any`) is pre-existing on base — it uses the Windows-broken `node_modules/.bin/tsx` shim path, untouched by this PR.
