### PR TITLE
fix(remove): reassign or clear the default when removing the default version

### DIFF
--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -231,10 +231,8 @@ async function versionPruneAction(
           moved.push({ agent, version: v });
         }
 
-        if (globalDefault && toRemove.includes(globalDefault)) {
-          setGlobalDefault(agent, undefined);
-          console.log(chalk.yellow(`Default version removed. Run: agents use ${agent}@<version> to set a new default`));
-        }
+        // Default reassignment/clearing is handled at the source in
+        // removeVersion() so it applies to every removal path uniformly.
 
         const remaining = listInstalledVersions(agent);
         if (remaining.length === 0) {

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -659,10 +659,16 @@ function writeMetaUnlocked(meta: Meta): void {
 
   // Write the machine-local files FIRST, then strip central — so a crash mid-write
   // never removes pins/versions from central before they're persisted elsewhere.
+  const devicePath = getDeviceMetaPath();
   if (agents && Object.keys(agents).length > 0) {
-    const devicePath = getDeviceMetaPath();
     fs.mkdirSync(path.dirname(devicePath), { recursive: true });
     writeIfChanged(devicePath, META_HEADER + yaml.stringify({ agents }));
+  } else if (fs.existsSync(devicePath)) {
+    // Every pin was cleared. Persist the emptied map instead of skipping the
+    // write — otherwise the stale device file survives and overlayMachineLocal
+    // re-applies the removed pin on the next read, leaving a dangling default
+    // (e.g. a launcher pointing at a version that was just uninstalled).
+    writeIfChanged(devicePath, META_HEADER + yaml.stringify({ agents: {} }));
   }
 
   if (versions && Object.keys(versions).length > 0) {

--- a/src/lib/versions.test.ts
+++ b/src/lib/versions.test.ts
@@ -778,3 +778,65 @@ describe('listInstalledVersions — excludes gutted installs from the picker', (
   });
 });
 
+// Regression (RUSH-1420): removing the version that is the current global
+// default must never leave a dangling default pointer — every launcher shim
+// resolves the default, so a stale pointer breaks `agents run` and the default
+// shim outright ("no installed default for claude"). The fix reassigns the
+// default to the newest remaining install, or clears it cleanly when the last
+// version goes.
+describe('removeVersion — default reassignment when removing the pinned default', () => {
+  // Lay down a claude version on disk the way listInstalledVersions expects:
+  // a real binary file at <versionDir>/node_modules/.bin/claude.
+  function installClaudeVersion(home: string, version: string): void {
+    const binDir = path.join(home, '.agents', '.history', 'versions', 'claude', version, 'node_modules', '.bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, 'claude'), '#!/bin/sh\n', 'utf-8');
+  }
+
+  // One subprocess so the module-level HOME + version caches stay consistent:
+  // set the default, remove a version, then read back the resolved default.
+  function runRemoveScenario(home: string, defaultVersion: string, versionToRemove: string): { removed: boolean; defaultAfter: string | null } {
+    const moduleUrl = pathToFileURL(path.resolve('src/lib/versions.ts')).href;
+    const tsxBin = path.resolve('node_modules/tsx/dist/cli.mjs');
+    const child = spawnSync(process.execPath, [tsxBin, '-e', `
+      import { setGlobalDefault, getGlobalDefault, removeVersion } from ${JSON.stringify(moduleUrl)};
+      setGlobalDefault('claude', ${JSON.stringify(defaultVersion)});
+      const removed = removeVersion('claude', ${JSON.stringify(versionToRemove)});
+      // removeVersion prints a human notice to stdout; tag the machine-readable
+      // result so the parent can pick it out of the surrounding output.
+      console.log('__RESULT__' + JSON.stringify({ removed, defaultAfter: getGlobalDefault('claude') }));
+    `], { env: { ...process.env, HOME: home }, encoding: 'utf-8' });
+    expect(child.status, child.stderr).toBe(0);
+    const line = child.stdout.split('\n').find((l) => l.startsWith('__RESULT__'));
+    expect(line, child.stdout).toBeTruthy();
+    return JSON.parse(line!.slice('__RESULT__'.length));
+  }
+
+  it('reassigns the default to the newest remaining version when siblings exist', () => {
+    const home = makeTempHome();
+    installClaudeVersion(home, '2.1.185');
+    installClaudeVersion(home, '2.1.196');
+    installClaudeVersion(home, '2.1.201');
+
+    // 2.1.196 is the default and gets removed; 2.1.185 + 2.1.201 remain.
+    const { removed, defaultAfter } = runRemoveScenario(home, '2.1.196', '2.1.196');
+
+    expect(removed).toBe(true);
+    // Newest remaining is 2.1.201 — not the newest overall (which was removed).
+    expect(defaultAfter).toBe('2.1.201');
+    // The removed version's binary is gone (soft-deleted to trash).
+    expect(fs.existsSync(path.join(home, '.agents', '.history', 'versions', 'claude', '2.1.196', 'node_modules', '.bin', 'claude'))).toBe(false);
+  });
+
+  it('clears the default without a dangling pointer when the last version is removed', () => {
+    const home = makeTempHome();
+    installClaudeVersion(home, '2.1.196');
+
+    const { removed, defaultAfter } = runRemoveScenario(home, '2.1.196', '2.1.196');
+
+    expect(removed).toBe(true);
+    // No versions remain → default cleared cleanly, not left pointing at a ghost.
+    expect(defaultAfter).toBe(null);
+  });
+});
+

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1484,16 +1484,19 @@ export function removeVersion(agent: AgentId, version: string): boolean {
   // Remove versioned alias (e.g., claude@2.0.65)
   removeVersionedAlias(agent, version);
 
-  // Clear default if it was the removed version - user must explicitly pick a new one
+  // If the removed version was the global default, keep launchers working:
+  // reassign the default to the newest remaining version, or clear it outright
+  // only when nothing is left. Leaving a dangling default pointer here is what
+  // broke every launcher after removing the pinned default.
   if (getGlobalDefault(agent) === version) {
-    const meta = readMeta();
-    if (meta.agents?.[agent]) {
-      delete meta.agents[agent];
-      writeMeta(meta);
-    }
     const remaining = listInstalledVersions(agent);
     if (remaining.length > 0) {
-      console.log(chalk.yellow(`Default version removed. Run: agents use ${agent}@<version> to set a new default`));
+      const newestRemaining = remaining[remaining.length - 1];
+      setGlobalDefault(agent, newestRemaining);
+      console.log(chalk.yellow(`Default ${agent} was ${version} (removed); reassigned to ${newestRemaining}. Change it with: agents use ${agent}@<version>`));
+    } else {
+      setGlobalDefault(agent, undefined);
+      console.log(chalk.yellow(`Removed the last installed ${agent} version and cleared its default. Reinstall with: agents add ${agent}, then set one with: agents use ${agent}@<version>`));
     }
   }
 


### PR DESCRIPTION
## Problem

Running `agents remove claude@2.1.196` while `2.1.196` was the global default uninstalled it silently — no warning, no reassignment. Afterward every launcher broke: the default shim printed `agents: no installed default for claude. Set one with: agents use claude <version>` and `agents run claude` failed, even though other installed versions (`2.1.185`, `2.1.201`) remained usable.

## Root cause

Two source-level defects combined:

1. **The explicit-version removal path never touched the default.** `agents remove <agent>@<version>` routes to `versionPruneAction`, which calls `removeVersion` at `src/commands/versions.ts:254` — but the default-handling block only existed in the *interactive* branch (`src/commands/versions.ts:234-237`), not the explicit one. `removeVersion` itself only ever *cleared* the default, never reassigned it (`src/lib/versions.ts:1436-1447`, pre-fix):

   ```ts
   // Clear default if it was the removed version - user must explicitly pick a new one
   if (getGlobalDefault(agent) === version) {
     const meta = readMeta();
     if (meta.agents?.[agent]) {
       delete meta.agents[agent];
       writeMeta(meta);
     }
     ...
   }
   ```

2. **Clearing the last pin never actually persisted — a dangling pointer.** The default lives in a per-device file (`~/.agents/devices/<machineId>/agents.yaml`), written by `writeMetaUnlocked` (`src/lib/state.ts:657-666`) and re-applied on every read by `overlayMachineLocal` (`src/lib/state.ts:685-692`). The device write was guarded by `if (agents && Object.keys(agents).length > 0)` (`src/lib/state.ts:662`). When the removed version was the *only* pin, `agents` became `{}`, the guard was false, so the stale device file was left on disk — and `overlayMachineLocal` re-applied the removed pin on the next read (`src/lib/state.ts:690`):

   ```ts
   if (dm?.agents) meta.agents = { ...meta.agents, ...dm.agents };
   ```

   So `getGlobalDefault` kept returning the just-uninstalled version, and the shim resolved to a version whose binary was gone.

## Fix

Kept at the source (the removal + persistence logic), not scattered across consumers:

- `src/lib/versions.ts` (`removeVersion`): when the removed version is the current default, reassign to the newest remaining install (`remaining[remaining.length - 1]`) with a one-line notice; only clear the default when nothing remains, with explicit restore guidance.
- `src/commands/versions.ts`: removed the redundant interactive-only `setGlobalDefault(agent, undefined)` block — every removal path now inherits default handling from `removeVersion`, including the explicit `<agent>@<version>` path that was the reported trigger.
- `src/lib/state.ts` (`writeMetaUnlocked`): when all pins are cleared, rewrite an existing device file to `{ agents: {} }` instead of skipping the write, so a stale pin can't be re-overlaid. Still never *creates* a device file when there are no pins.

## Tests

`src/lib/versions.test.ts` — real fs in an isolated temp `HOME`, no mocking:

- removing the default with siblings reassigns to the newest remaining version (`2.1.196` default among `2.1.185`/`2.1.201` -> `2.1.201`);
- removing the last version clears the default to `null` with no dangling pointer.

Verified with `npx tsc --noEmit` (clean) and the two new tests pass. Pre-existing failures in the suite (`bun`-based `state.test.ts` cases and the `strictAny` test that spawns `node_modules/.bin/tsx` directly) are unrelated Windows/local-env issues that fail on `origin/main` as well.
