### PR TITLE
fix(hooks): prune stale per-version hook entries on sync and remove

### DIFF
--- a/src/lib/__tests__/hooks.test.ts
+++ b/src/lib/__tests__/hooks.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
-import { registerHooksToSettings, unmanagedHookNames, computeCodexHookTrustHash, toPortableCommand } from '../hooks.js';
+import { registerHooksToSettings, unmanagedHookNames, computeCodexHookTrustHash, toPortableCommand, pruneVersionHomeHookEntriesFromSettings } from '../hooks.js';
 import * as TOML from 'smol-toml';
 import { CODEX_HOOKS_MIN_VERSION } from '../agents.js';
 import { compareVersions } from '../versions.js';
@@ -970,5 +970,163 @@ describe('toPortableCommand — portable hook commands (Windows path regression)
   it('folds a POSIX abs path under HOME to ~/ (macOS/Linux behavior unchanged)', () => {
     const out = toPortableCommand('/home/me/.agents/hooks/g.sh', '/home/me', '/');
     expect(out).toBe('~/.agents/hooks/g.sh');
+  });
+});
+
+// Regression for the per-version hook accumulation bug: because sync registers
+// each guard hook by a version-scoped path
+// (~/.agents/.history/versions/claude/<version>/home/.claude/hooks/git-guard.sh),
+// entries for every version installed over time piled up in one settings.json —
+// string-level dedup can't collapse them (paths differ), and `agents remove`
+// deleted a version's files without ever cleaning its settings entries, leaving
+// dead hooks that error on every tool call.
+describe('per-version hook entry pruning (settings accumulation regression)', () => {
+  // Portable version-home guard-hook command for a given version (the form sync
+  // actually writes — see toPortableCommand).
+  function guardCmd(version: string): string {
+    return `~/.agents/.history/versions/claude/${version}/home/.claude/hooks/git-guard.sh`;
+  }
+  const SYSTEM_HOOK = '~/.agents/.system/hooks/00-agent-verify-work-complete.sh';
+  const CUSTOM_HOOK = '~/dotfiles/hooks/my-personal-guard.sh';
+
+  function preToolUseGroup(commands: string[]) {
+    return {
+      PreToolUse: [
+        {
+          matcher: 'Bash',
+          hooks: commands.map((command) => ({ type: 'command', command, timeout: 600 })),
+        },
+      ],
+    };
+  }
+
+  function collectCommands(settings: Record<string, any>): string[] {
+    const out: string[] = [];
+    for (const groups of Object.values(settings.hooks ?? {})) {
+      for (const group of groups as Array<{ hooks?: Array<{ command: string }> }>) {
+        for (const h of group.hooks ?? []) out.push(h.command);
+      }
+    }
+    return out;
+  }
+
+  describe('sync (registerHooksToSettings)', () => {
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-prune-test-'));
+      agentsDir = path.join(tmpDir, '.agents');
+      fs.mkdirSync(path.join(agentsDir, 'hooks'), { recursive: true });
+    });
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('drops sibling-version entries, keeps the current version + .system + custom hooks', () => {
+      // A version-home-shaped path so registrar knows which version it is syncing.
+      const versionHome = path.join(
+        tmpDir, '.agents', '.history', 'versions', 'claude', '2.1.201', 'home'
+      );
+      const settingsPath = path.join(versionHome, '.claude', 'settings.json');
+      fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+
+      // Seed: three version homes (two stale, one current) + a system hook + a
+      // user's own custom hook, all in one PreToolUse/Bash matcher group.
+      fs.writeFileSync(settingsPath, JSON.stringify({
+        hooks: preToolUseGroup([
+          guardCmd('2.1.186'),   // stale sibling -> prune
+          guardCmd('2.1.191'),   // stale sibling -> prune
+          guardCmd('2.1.201'),   // current version -> keep
+          SYSTEM_HOOK,           // .system path -> keep (never a prune target)
+          CUSTOM_HOOK,           // user's own hook -> keep (never a prune target)
+        ]),
+      }, null, 2));
+
+      makeScript('git-guard.sh');
+      const manifest: Record<string, ManifestHook> = {
+        'git-guard': { script: 'git-guard.sh', events: ['PreToolUse'], matcher: 'Bash' },
+      };
+
+      const result = registerHooksToSettings('claude', versionHome, manifest, agentsDir);
+      expect(result.errors).toHaveLength(0);
+
+      const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      const commands = collectCommands(settings);
+
+      // Both sibling versions gone.
+      expect(commands).not.toContain(guardCmd('2.1.186'));
+      expect(commands).not.toContain(guardCmd('2.1.191'));
+      // Exactly one version-home guard entry survives, and it is the current one.
+      const versionHomeCmds = commands.filter((c) => c.includes('.history/versions/claude/'));
+      expect(versionHomeCmds).toEqual([guardCmd('2.1.201')]);
+      // System + custom hooks untouched.
+      expect(commands).toContain(SYSTEM_HOOK);
+      expect(commands).toContain(CUSTOM_HOOK);
+    });
+  });
+
+  describe('remove (pruneVersionHomeHookEntriesFromSettings)', () => {
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-remove-test-'));
+    });
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('removes only the removed version’s entries, keeping siblings + .system + custom', () => {
+      const settingsPath = path.join(tmpDir, 'settings.json');
+      fs.writeFileSync(settingsPath, JSON.stringify({
+        hooks: preToolUseGroup([
+          guardCmd('2.1.186'),
+          guardCmd('2.1.191'),   // removed version -> prune
+          guardCmd('2.1.201'),
+          SYSTEM_HOOK,
+          CUSTOM_HOOK,
+        ]),
+      }, null, 2));
+
+      const removed = pruneVersionHomeHookEntriesFromSettings(settingsPath, 'claude', '2.1.191');
+      expect(removed).toBe(1);
+
+      const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      const commands = collectCommands(settings);
+      expect(commands).not.toContain(guardCmd('2.1.191'));
+      expect(commands).toContain(guardCmd('2.1.186'));
+      expect(commands).toContain(guardCmd('2.1.201'));
+      expect(commands).toContain(SYSTEM_HOOK);
+      expect(commands).toContain(CUSTOM_HOOK);
+    });
+
+    it('never touches another agent’s version or non-version-home hooks', () => {
+      const settingsPath = path.join(tmpDir, 'settings.json');
+      fs.writeFileSync(settingsPath, JSON.stringify({
+        hooks: preToolUseGroup([
+          // Same version number but a DIFFERENT agent — must not be pruned.
+          '~/.agents/.history/versions/droid/2.1.191/home/.factory/hooks/git-guard.sh',
+          SYSTEM_HOOK,
+          CUSTOM_HOOK,
+        ]),
+      }, null, 2));
+
+      const removed = pruneVersionHomeHookEntriesFromSettings(settingsPath, 'claude', '2.1.191');
+      expect(removed).toBe(0);
+
+      const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      const commands = collectCommands(settings);
+      expect(commands).toHaveLength(3);
+      expect(commands).toContain(SYSTEM_HOOK);
+      expect(commands).toContain(CUSTOM_HOOK);
+    });
+
+    it('collapses a matcher group left empty after the prune', () => {
+      const settingsPath = path.join(tmpDir, 'settings.json');
+      fs.writeFileSync(settingsPath, JSON.stringify({
+        hooks: preToolUseGroup([guardCmd('2.1.191')]),
+      }, null, 2));
+
+      const removed = pruneVersionHomeHookEntriesFromSettings(settingsPath, 'claude', '2.1.191');
+      expect(removed).toBe(1);
+
+      const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      expect(settings.hooks.PreToolUse).toEqual([]);
+    });
   });
 });

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -118,6 +118,41 @@ function isManagedHookCommand(command: string, prefixes: string[]): boolean {
   }
   return false;
 }
+
+/**
+ * Per-version-home command detection. Sync copies each hook script into the
+ * active version's home and registers the command by that version-scoped path
+ * (`~/.agents/.history/versions/<agent>/<version>/home/…`). Because the path
+ * embeds the version number, a later version's sync appends a fresh set whose
+ * paths never string-match (and thus never prune) the prior version's entries —
+ * so entries for every version installed over time pile up in one settings
+ * file, and once a version is removed its entries become dead hooks that error
+ * on every tool call. `versionHomeIdentity` extracts the `<agent>/<version>` a
+ * command (or home path) belongs to so stale sibling-version entries can be
+ * pruned. Returns null for any path outside a per-version home (system hooks,
+ * the user's own custom hooks) — those are never a prune target.
+ */
+const VERSION_HOME_SEGMENT_RE = /\.history\/versions\/([^/]+)\/([^/]+)\/home(?:\/|$)/;
+function versionHomeIdentity(commandOrPath: string): { agent: string; version: string } | null {
+  const norm = commandOrPath.split(/[\\/]/).join('/');
+  const m = VERSION_HOME_SEGMENT_RE.exec(norm);
+  return m ? { agent: m[1], version: m[2] } : null;
+}
+
+/**
+ * True when `command` points into a DIFFERENT version home of the same agent as
+ * `current` — i.e. a stale entry left behind by an earlier version's sync.
+ * Non-version-home commands (system + user-custom hooks) always return false.
+ */
+function isStaleSiblingVersionCommand(
+  command: string,
+  current: { agent: string; version: string } | null
+): boolean {
+  if (!current) return false;
+  const id = versionHomeIdentity(command);
+  return id !== null && id.agent === current.agent && id.version !== current.version;
+}
+
 import { getEffectiveHome, getVersionHomePath, listInstalledVersions } from './versions.js';
 import type { AgentId, InstalledHook, ManifestHook } from './types.js';
 import { generateHookShim, isValidHookShimName, parseCacheConfig, removeHookShim } from './hooks/cache.js';
@@ -1141,8 +1176,14 @@ function registerHooksForClaude(
     if (resolved) currentManifestPaths.add(resolved);
   }
 
-  // Remove stale entries: any hook command under a managed root that isn't
-  // in the current manifest is a leftover from a renamed/deleted hook script.
+  // Identity of the version home being synced. Used to prune entries that point
+  // at a DIFFERENT version home of the same agent (see isStaleSiblingVersionCommand).
+  const currentVh = versionHomeIdentity(versionHome);
+
+  // Remove stale entries: any hook command under a managed root that isn't in
+  // the current manifest is a leftover from a renamed/deleted hook script; any
+  // command pointing at a sibling version's home is a leftover from that
+  // version's sync (its version-scoped path never matches the current set).
   for (const eventEntries of Object.values(hooks)) {
     if (!Array.isArray(eventEntries)) continue;
     for (const group of eventEntries as Array<{
@@ -1151,7 +1192,9 @@ function registerHooksForClaude(
     }>) {
       if (!group.hooks) continue;
       group.hooks = group.hooks.filter(
-        (h) => !isManagedHookCommand(h.command, managedPrefixes) || currentManifestPaths.has(h.command)
+        (h) =>
+          (!isManagedHookCommand(h.command, managedPrefixes) || currentManifestPaths.has(h.command)) &&
+          !isStaleSiblingVersionCommand(h.command, currentVh)
       );
     }
   }
@@ -1217,6 +1260,68 @@ function registerHooksForClaude(
   }
 
   return { registered, errors };
+}
+
+/**
+ * Prune every Claude-family (`settings.json`) hook entry whose command lives
+ * under a removed version's home
+ * (`~/.agents/.history/versions/<agent>/<removedVersion>/home/…`).
+ *
+ * `agents remove <agent>@<version>` soft-deletes the version's files but leaves
+ * the hook entries other version homes registered against it — dead hooks that
+ * error on every tool call ("No such file or directory") until the next sync.
+ * This clears them from a remaining version's settings immediately. Only the
+ * removed version's entries are touched; the current version's entries, system
+ * hooks, and the user's own custom hooks are left intact. Returns the number of
+ * entries removed.
+ */
+export function pruneVersionHomeHookEntriesFromSettings(
+  settingsPath: string,
+  agent: AgentId,
+  removedVersion: string
+): number {
+  if (!fs.existsSync(settingsPath)) return 0;
+
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+  } catch {
+    return 0;
+  }
+  if (!config.hooks || typeof config.hooks !== 'object') return 0;
+  const hooks = config.hooks as Record<string, unknown[]>;
+
+  let removed = 0;
+  for (const eventEntries of Object.values(hooks)) {
+    if (!Array.isArray(eventEntries)) continue;
+    for (const group of eventEntries as Array<{ hooks?: Array<{ command: string }> }>) {
+      if (!group.hooks) continue;
+      const before = group.hooks.length;
+      group.hooks = group.hooks.filter((h) => {
+        const id = versionHomeIdentity(h.command);
+        return !(id !== null && id.agent === agent && id.version === removedVersion);
+      });
+      removed += before - group.hooks.length;
+    }
+  }
+  if (removed === 0) return 0;
+
+  // Drop matcher groups left empty by the prune.
+  for (const [event, eventEntries] of Object.entries(hooks)) {
+    if (!Array.isArray(eventEntries)) continue;
+    hooks[event] = (eventEntries as Array<{ hooks?: unknown[] }>).filter(
+      (g) => g.hooks && g.hooks.length > 0
+    );
+  }
+
+  try {
+    fs.writeFileSync(settingsPath, JSON.stringify(config, null, 2), 'utf-8');
+  } catch {
+    // Best-effort cleanup: a write failure leaves the dead entry to be pruned
+    // on the next sync (see isStaleSiblingVersionCommand).
+    return 0;
+  }
+  return removed;
 }
 
 function registerHooksForCodex(

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -40,7 +40,7 @@ import { importInstallScriptBinary } from './import.js';
 import { IS_WINDOWS } from './platform/index.js';
 import { listInstalledSubagents, transformSubagentForClaude, syncSubagentToOpenclaw } from './subagents.js';
 import { listInstalledWorkflows, syncWorkflowToVersion } from './workflows.js';
-import { parseHookManifest, registerHooksToSettings } from './hooks.js';
+import { parseHookManifest, registerHooksToSettings, pruneVersionHomeHookEntriesFromSettings } from './hooks.js';
 import { supports, explainSkip, capableAgents } from './capabilities.js';
 import { discoverPlugins, syncPluginToVersion, isPluginSynced, pluginSupportsAgent, cleanOrphanedPluginSkills } from './plugins.js';
 import { composeRulesFromState } from './rules/compose.js';
@@ -1508,6 +1508,19 @@ export function removeVersion(agent: AgentId, version: string): boolean {
       fs.unlinkSync(configPath);
     } catch {
       // Ignore if already gone
+    }
+  }
+
+  // Clear dead per-version hook entries the removed version left behind in the
+  // remaining versions' settings. Their command paths point under the now-gone
+  // version home, so they error on every tool call until the next sync. Scoped
+  // to the Claude-family settings.json format (claude + droid) — the surface
+  // where per-version guard hooks accumulate; other agents self-heal on sync.
+  if (agent === 'claude' || agent === 'droid') {
+    const configDir = agentConfigDirName(agent);
+    for (const remaining of listInstalledVersions(agent)) {
+      const settingsPath = path.join(getVersionHomePath(agent, remaining), configDir, 'settings.json');
+      pruneVersionHomeHookEntriesFromSettings(settingsPath, agent, version);
     }
   }
 


### PR DESCRIPTION
## Problem

The Claude `settings.json` that agents-cli syncs accumulated `PreToolUse` guard-hook entries (`git-guard.sh`, `rm-guard.sh`, `large-file-add-guard.sh`) for multiple version homes simultaneously — command paths under `~/.agents/.history/versions/claude/2.1.186/`, `2.1.191/`, `2.1.193/`, `2.1.196/`, and `2.1.201/` all in one file. Once a version's files were removed, its entries became dead hooks that error on every tool call ("No such file or directory", non-blocking hook errors).

## Root cause

Sync registers each hook by a **version-scoped** path. `registerHooksToSettings` prefers the copied-in local hooks dir of the version home (`src/lib/hooks.ts:1015-1017`), and `toPortableCommand` folds it to `~/.agents/.history/versions/<agent>/<version>/home/.claude/hooks/<hook>.sh` (`src/lib/hooks.ts:80-91`). Production sync passes the real version home so this version-scoped form is what lands in settings (`src/commands/sync.ts:251`).

The Claude registrar's stale-entry GC only drops commands under a *managed prefix* not in the current manifest (`src/lib/hooks.ts:1146-1157` pre-change). The managed prefixes are the user/system/extra hooks dirs plus **only the current** version's local hooks dir (`src/lib/hooks.ts:1034-1043`). A sibling version's home path matches none of those prefixes, so its entries are never pruned — and because each version's path differs, string-level dedup can't collapse them either. Every version installed over time piled up.

Separately, `removeVersion` soft-deletes the version dir (`src/lib/versions.ts:1421-1462` pre-change) but never cleaned settings entries referencing it, leaving the dead hooks the user observed.

## Fix (at the source, two parts)

**a. Sync-side prune** — `src/lib/hooks.ts`:
- New `versionHomeIdentity()` extracts the `<agent>/<version>` a command/home path belongs to (null for system + custom hooks), and `isStaleSiblingVersionCommand()` flags a command pointing at a *different* version home of the *same* agent.
- The Claude/droid registrar computes the synced version's identity (`currentVh`) and adds `&& !isStaleSiblingVersionCommand(...)` to the existing GC filter. After sync: exactly one set of version-home entries (the current version's) survives; `.system` paths and the user's own custom hooks are never a prune target.

**b. Remove-side prune** — new exported `pruneVersionHomeHookEntriesFromSettings()` in `src/lib/hooks.ts` drops every settings entry whose command lives under a removed version's home (collapsing empty matcher groups). Wired into `removeVersion` (`src/lib/versions.ts`) to run over the remaining versions' settings for the Claude family (claude + droid) after soft-delete, so dead hooks are cleared immediately instead of lingering until the next sync. Other agents self-heal on their next sync via part (a).

Scoped to the Claude-family `settings.json` — the surface where per-version guard hooks accumulate and where the bug was observed. Does not undo PR #624 (`toPortableCommand`) or PR #625 (hook cache shim).

## Tests

Colocated in `src/lib/__tests__/hooks.test.ts` (vitest, temp fixtures only — the real `~/.agents` is never touched):
- **sync**: fixture with three version homes (two stale + current) + one `.system` path + one custom user hook → after sync only the current version's version-home entry survives, `.system` and custom untouched.
- **remove**: fixture with three version homes + `.system` + custom → `pruneVersionHomeHookEntriesFromSettings(..., '2.1.191')` removes exactly the removed version's entry; siblings, `.system`, and custom remain.
- a different agent's same-numbered version is never pruned (agent-scoped match).
- an emptied matcher group is collapsed after prune.

`npx tsc --noEmit` clean; `hooks.test.ts` → 53 passed (4 new).
