### PR TITLE
fix(exec): compose quoted command strings for Windows shell spawns (DEP0190)

### DIFF
--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -11,6 +11,7 @@ import chalk from 'chalk';
 import { terminalWidth, truncateToWidth, stringWidth } from '../lib/session/width.js';
 import * as fs from 'fs';
 import { SSH_TARGET_RE, assertValidSshTarget, sshExec, type SshExecResult } from '../lib/ssh-exec.js';
+import { quoteWin32ExecArg, composeWin32CommandLine } from '../lib/platform/index.js';
 import {
   parseHostsOption,
   remoteResolveEnv,
@@ -1422,12 +1423,13 @@ Examples:
         // On Windows, spawn without a shell ENOENTs for `.cmd`/`.bat` launchers
         // (npm, yarn, most JS CLIs) and shell built-ins, so we set shell:true.
         // With shell:true Node hands cmd.exe a single command line with NO quoting
-        // of its own, so args containing spaces or cmd metacharacters must be
-        // quoted here (quoteWin32ExecArg) or they'd be split. See that helper for
+        // of its own. Compose that line ourselves (composeWin32CommandLine quotes
+        // every token) and pass an EMPTY args array so Node never concatenates the
+        // user-supplied args unescaped (DEP0190 + injection). See that helper for
         // the cmd.exe %VAR%/!VAR! expansion caveat.
         const useShell = process.platform === 'win32';
-        const spawnCmd = useShell ? quoteWin32ExecArg(cmd) : cmd;
-        const spawnArgs = useShell ? args.map(quoteWin32ExecArg) : args;
+        const spawnCmd = useShell ? composeWin32CommandLine(cmd, args) : cmd;
+        const spawnArgs = useShell ? [] : args;
         const proc = spawn(spawnCmd, spawnArgs, {
           stdio: 'inherit',
           shell: useShell,
@@ -1729,47 +1731,9 @@ function humanRemaining(expiresAt: number): string {
   return `locks in ${days} day${days === 1 ? '' : 's'}`;
 }
 
-/**
- * Quote one argument for a Windows `cmd.exe` command line, as built by Node's
- * `spawn(..., { shell: true })` on win32 (`agents secrets exec`). cmd.exe does
- * NO quoting of its own, so an unquoted arg with a space is split into several
- * args, and a cmd metacharacter (`&|<>()^`) would be interpreted by the shell.
- * We wrap any arg with whitespace, a quote, or a metacharacter in double quotes
- * and escape embedded quotes / trailing backslashes per the CommandLineToArgvW
- * rules, so the *child's* argv parse reconstructs the original argument.
- *
- * CAVEAT: cmd.exe expands `%VAR%` (always) and `!VAR!` (under delayed expansion)
- * BEFORE argv parsing, and double-quoting does NOT suppress `%`/`!` (the
- * "BatBadBut" / CVE-2024-1874 class). We deliberately do not escape `%`/`!`:
- * `agents secrets exec` runs a caller-supplied command against a bundle the
- * caller owns, so caller-controlled `%`/`!` is not a privilege boundary. If that
- * ever changes (exec'ing an untrusted command line), route through a shell that
- * disables expansion rather than relying on this quoter. An empty arg becomes
- * `""`. Exported for tests. No-ops on non-Windows (the caller only invokes it
- * under `process.platform === 'win32'`).
- */
-export function quoteWin32ExecArg(arg: string): string {
-  if (arg.length > 0 && !/[\s"&|<>()^]/.test(arg)) return arg;
-  let result = '"';
-  let backslashes = 0;
-  for (const ch of arg) {
-    if (ch === '\\') {
-      backslashes += 1;
-      continue;
-    }
-    if (ch === '"') {
-      // Double the run of backslashes, then escape this quote.
-      result += '\\'.repeat(backslashes * 2 + 1) + '"';
-      backslashes = 0;
-      continue;
-    }
-    result += '\\'.repeat(backslashes) + ch;
-    backslashes = 0;
-  }
-  // Trailing backslashes precede the closing quote → must be doubled.
-  result += '\\'.repeat(backslashes * 2) + '"';
-  return result;
-}
+// `quoteWin32ExecArg` now lives in lib/platform/exec.ts (shared with the agent
+// run/shim spawn paths); re-exported here for the colocated secrets tests.
+export { quoteWin32ExecArg };
 
 /**
  * Copy text to the system clipboard, cross-platform.

--- a/src/lib/exec.test.ts
+++ b/src/lib/exec.test.ts
@@ -143,16 +143,28 @@ describe('resolveShimSpawn (Windows .cmd shim exec, #shims)', () => {
     expect(r).toEqual({ command: '/home/u/.agents/.../claude', args: ['--help'], shell: false });
   });
 
-  it('win32 keeps the common .cmd-present path on the shell (unchanged)', () => {
+  it('win32 .cmd path goes through the shell as ONE composed line with empty args (DEP0190-safe)', () => {
     const r = resolveShimSpawn('win32', 'C:\\bin\\claude.cmd', ['run']);
-    expect(r.command).toBe('C:\\bin\\claude.cmd');
-    expect(r.args).toEqual(['run']);
+    // No unescaped args array left for Node to concatenate: the command is the
+    // whole quoted line and args is empty.
+    expect(r.command).toBe('C:\\bin\\claude.cmd run');
+    expect(r.args).toEqual([]);
     expect(r.shell).toBe(true);
   });
 
   it('win32 sends a bare (non-absolute) name to the shell for PATHEXT resolution', () => {
     const r = resolveShimSpawn('win32', 'claude', []);
     expect(r.command).toBe('claude');
+    expect(r.args).toEqual([]);
+    expect(r.shell).toBe(true);
+  });
+
+  it('win32 quotes prompt args with spaces/metachars into the composed line', () => {
+    // The injection/splitting surface: a multi-word prompt and cmd metacharacters
+    // must survive as ONE argument to the child, not be split or interpreted.
+    const r = resolveShimSpawn('win32', 'C:\\bin\\claude.cmd', ['-p', 'review my code & ship']);
+    expect(r.command).toBe('C:\\bin\\claude.cmd -p "review my code & ship"');
+    expect(r.args).toEqual([]);
     expect(r.shell).toBe(true);
   });
 });

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -19,6 +19,7 @@ import { sanitizeProcessEnv } from './secrets/bundles.js';
 import { getShimsDir } from './state.js';
 import { writePidSessionEntry } from './session/pid-registry.js';
 import { mailboxDir, isValidMailboxId } from './mailbox.js';
+import { composeWin32CommandLine } from './platform/index.js';
 
 /**
  * Agent execution modes. Canonical name `skip` (dangerously skip permissions);
@@ -798,7 +799,14 @@ export function resolveShimSpawn(
     // Use win32 path semantics regardless of the host running this (the platform
     // is the parameter, not process.platform) so `C:\...` reads as absolute.
     const useShell = !path.win32.isAbsolute(binary) || binary.endsWith('.cmd');
-    return { command: binary, args: extraArgs, shell: useShell };
+    if (useShell) {
+      // DEP0190-safe: hand cmd.exe ONE fully-quoted command line with an EMPTY
+      // args array, so Node never concatenates `extraArgs` (which carry the
+      // user's raw prompt/flags) into the shell line unescaped — that concat is
+      // both the deprecation and a command-injection surface.
+      return { command: composeWin32CommandLine(binary, extraArgs), args: [], shell: true };
+    }
+    return { command: binary, args: extraArgs, shell: false };
   }
   return { command: binary, args: extraArgs, shell: false };
 }
@@ -918,11 +926,17 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
       : ['inherit', tapStdout ? 'pipe' : 'inherit', 'pipe'];
 
     // On Windows, .cmd batch wrappers (npm-installed CLIs) require shell:true
-    // whether addressed by name or absolute path.
+    // whether addressed by name or absolute path. On that shell path, compose a
+    // single fully-quoted command line and pass an EMPTY args array (see
+    // composeWin32CommandLine) so Node never concatenates the args array — which
+    // carries the user's prompt — into the cmd.exe line unescaped (DEP0190 +
+    // command injection).
     const useShell = process.platform === 'win32' && (
       !path.isAbsolute(executable) || executable.endsWith('.cmd')
     );
-    const child = spawn(executable, args, {
+    const spawnCommand = useShell ? composeWin32CommandLine(executable, args) : executable;
+    const spawnArgs = useShell ? [] : args;
+    const child = spawn(spawnCommand, spawnArgs, {
       cwd: options.cwd || process.cwd(),
       stdio,
       env: buildExecEnv(options),

--- a/src/lib/loop.ts
+++ b/src/lib/loop.ts
@@ -30,6 +30,7 @@ import { extractUsageEvents } from './budget/enforce.js';
 import { parseTimeout } from './routines.js';
 import { writeCheckpoint, type Checkpoint } from './checkpoint.js';
 import { mailboxDir } from './mailbox.js';
+import { composeWin32CommandLine } from './platform/index.js';
 
 /** Loop block config (docs/07-entrypoints-and-loops.md → "The loop block"). */
 export interface LoopConfig {
@@ -215,10 +216,16 @@ export function defaultRunIteration(options: ExecOptions): Promise<IterationResu
   const model = execOptions.model ?? `${execOptions.agent}-default`;
 
   return new Promise((resolve, reject) => {
+    // DEP0190-safe shell spawn: on the win32 shell path compose ONE fully-quoted
+    // command line and pass an EMPTY args array (see composeWin32CommandLine) so
+    // Node never concatenates the args array — which carries the re-injected
+    // prompt — into the cmd.exe line unescaped.
     const useShell = process.platform === 'win32' && (
       !path.isAbsolute(executable) || executable.endsWith('.cmd')
     );
-    const child = spawn(executable, args, {
+    const spawnCommand = useShell ? composeWin32CommandLine(executable, args) : executable;
+    const spawnArgs = useShell ? [] : args;
+    const child = spawn(spawnCommand, spawnArgs, {
       cwd,
       stdio: ['inherit', 'pipe', 'pipe'],
       env,

--- a/src/lib/platform/exec.test.ts
+++ b/src/lib/platform/exec.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { whichCommand, findExecutable, needsWindowsShell } from './exec.js';
+import { spawnSync } from 'child_process';
+import { whichCommand, findExecutable, needsWindowsShell, quoteWin32ExecArg, composeWin32CommandLine } from './exec.js';
 
 describe('whichCommand', () => {
   it('is `where` on win32, `which` elsewhere', () => {
@@ -43,5 +44,112 @@ describe('needsWindowsShell', () => {
 
   it('on win32, a direct absolute .exe does NOT need the shell', () => {
     expect(needsWindowsShell('C:\\Program Files\\nodejs\\node.exe', 'win32')).toBe(false);
+  });
+});
+
+describe('quoteWin32ExecArg', () => {
+  it('leaves simple args untouched (byte-identical to the old unquoted join)', () => {
+    expect(quoteWin32ExecArg('npm')).toBe('npm');
+    expect(quoteWin32ExecArg('--version')).toBe('--version');
+    expect(quoteWin32ExecArg('sk-proj-AbC123_xyz.789')).toBe('sk-proj-AbC123_xyz.789');
+    expect(quoteWin32ExecArg('C:\\bin\\claude.cmd')).toBe('C:\\bin\\claude.cmd');
+  });
+
+  it('quotes whitespace so it stays a single argument', () => {
+    expect(quoteWin32ExecArg('hello world')).toBe('"hello world"');
+    expect(quoteWin32ExecArg('a\tb')).toBe('"a\tb"');
+    expect(quoteWin32ExecArg('C:\\Program Files\\node\\node.exe'))
+      .toBe('"C:\\Program Files\\node\\node.exe"');
+  });
+
+  it('quotes cmd metacharacters so the shell treats them literally', () => {
+    expect(quoteWin32ExecArg('a&b')).toBe('"a&b"');
+    expect(quoteWin32ExecArg('a|b')).toBe('"a|b"');
+    expect(quoteWin32ExecArg('a>b')).toBe('"a>b"');
+    expect(quoteWin32ExecArg('a<b')).toBe('"a<b"');
+    expect(quoteWin32ExecArg('a^b')).toBe('"a^b"');
+    expect(quoteWin32ExecArg('(sub)')).toBe('"(sub)"');
+  });
+
+  it('escapes embedded double quotes (CommandLineToArgvW rules)', () => {
+    expect(quoteWin32ExecArg('say "hi"')).toBe('"say \\"hi\\""');
+  });
+
+  it('doubles a run of backslashes that precedes a quote', () => {
+    expect(quoteWin32ExecArg('a\\"b')).toBe('"a\\\\\\"b"');
+  });
+
+  it('doubles trailing backslashes before the closing quote (when quoting)', () => {
+    expect(quoteWin32ExecArg('a b\\')).toBe('"a b\\\\"');
+    expect(quoteWin32ExecArg('two\\\\ end')).toBe('"two\\\\ end"');
+  });
+
+  it('leaves a lone trailing backslash unquoted (no trigger char)', () => {
+    expect(quoteWin32ExecArg('ends\\')).toBe('ends\\');
+  });
+
+  it('turns an empty arg into an explicit ""', () => {
+    expect(quoteWin32ExecArg('')).toBe('""');
+  });
+
+  it('leaves %VAR%/!VAR! untouched at the quoting layer (documented cmd-expansion caveat)', () => {
+    // We deliberately do NOT escape % / ! — matching the pre-change behavior where
+    // these tokens were passed to cmd.exe unquoted. No trigger char, so passthrough.
+    expect(quoteWin32ExecArg('%PATH%')).toBe('%PATH%');
+    expect(quoteWin32ExecArg('!DELAYED!')).toBe('!DELAYED!');
+  });
+
+  it('passes unicode text through untouched (no trigger char)', () => {
+    expect(quoteWin32ExecArg('café')).toBe('café');
+    expect(quoteWin32ExecArg('日本語')).toBe('日本語');
+    // With a space it gets quoted, but the codepoints are preserved verbatim.
+    expect(quoteWin32ExecArg('café ☕')).toBe('"café ☕"');
+  });
+});
+
+describe('composeWin32CommandLine', () => {
+  it('joins a simple command + args byte-identically to the old unquoted join', () => {
+    expect(composeWin32CommandLine('claude', [])).toBe('claude');
+    expect(composeWin32CommandLine('npm', ['view', 'pkg', 'version']))
+      .toBe('npm view pkg version');
+  });
+
+  it('quotes only the tokens that need it', () => {
+    expect(composeWin32CommandLine('C:\\bin\\claude.cmd', ['-p', 'hello world']))
+      .toBe('C:\\bin\\claude.cmd -p "hello world"');
+    expect(composeWin32CommandLine('C:\\Program Files\\x\\node.exe', ['-e', 'a&b']))
+      .toBe('"C:\\Program Files\\x\\node.exe" -e "a&b"');
+  });
+});
+
+// Real Windows spawn round-trip: prove that a command line composed by
+// composeWin32CommandLine, spawned with { shell: true } and an EMPTY args array,
+// reconstructs the child's argv BYTE-EXACT — including spaces, embedded quotes,
+// cmd metacharacters, backslashes, unicode, and a command PATH that has a space.
+// This exercises the exact DEP0190-safe path the agent run/shim spawns use.
+describe('composeWin32CommandLine spawn round-trip (win32)', () => {
+  const runOnWin32 = process.platform === 'win32' ? it : it.skip;
+
+  runOnWin32('the child receives the tricky args byte-exact', () => {
+    // `node -e "<code>" A B ...` -> the child's process.argv is [nodePath, A, B, ...]
+    // (with -e there is no script filename), so argv.slice(1) is our tricky args.
+    const script = 'process.stdout.write(JSON.stringify(process.argv.slice(1)))';
+    const trickyArgs = [
+      'hello world',
+      'say "hi"',
+      'a&b|c',
+      'less<more>than',
+      'C:\\Program Files\\thing',
+      'trailing\\',
+      'café ☕ 日本語',
+      '',
+    ];
+    // process.execPath is `C:\Program Files\nodejs\node.exe` — its space forces the
+    // command token itself to be quoted, covering the spaced-executable case too.
+    const line = composeWin32CommandLine(process.execPath, ['-e', script, ...trickyArgs]);
+    const res = spawnSync(line, [], { shell: true, encoding: 'utf-8' });
+    expect(res.status).toBe(0);
+    expect(res.error).toBeUndefined();
+    expect(JSON.parse(res.stdout)).toEqual(trickyArgs);
   });
 });

--- a/src/lib/platform/exec.ts
+++ b/src/lib/platform/exec.ts
@@ -40,3 +40,65 @@ export function findExecutable(name: string, platform: NodeJS.Platform = process
     return null;
   }
 }
+
+/**
+ * Quote one argument for a Windows `cmd.exe` command line, as built by Node's
+ * `spawn(..., { shell: true })` on win32 (the `.cmd` agent shims, `agents secrets
+ * exec`, ...). cmd.exe does NO quoting of its own, so an unquoted arg with a space
+ * is split into several args, and a cmd metacharacter (`&|<>()^`) would be
+ * interpreted by the shell. We wrap any arg with whitespace, a quote, or a
+ * metacharacter in double quotes and escape embedded quotes / trailing
+ * backslashes per the CommandLineToArgvW rules, so the *child's* argv parse
+ * reconstructs the original argument.
+ *
+ * CAVEAT: cmd.exe expands `%VAR%` (always) and `!VAR!` (under delayed expansion)
+ * BEFORE argv parsing, and double-quoting does NOT suppress `%`/`!` (the
+ * "BatBadBut" / CVE-2024-1874 class). We deliberately do not escape `%`/`!`:
+ * the callers here run a command whose `%`/`!`-bearing tokens are the caller's
+ * own (an agent prompt against the caller's shell, a bundle the caller owns), so
+ * caller-controlled `%`/`!` is not a privilege boundary. If that ever changes
+ * (composing an untrusted command line), route through a shell that disables
+ * expansion rather than relying on this quoter. An empty arg becomes `""`.
+ */
+export function quoteWin32ExecArg(arg: string): string {
+  if (arg.length > 0 && !/[\s"&|<>()^]/.test(arg)) return arg;
+  let result = '"';
+  let backslashes = 0;
+  for (const ch of arg) {
+    if (ch === '\\') {
+      backslashes += 1;
+      continue;
+    }
+    if (ch === '"') {
+      // Double the run of backslashes, then escape this quote.
+      result += '\\'.repeat(backslashes * 2 + 1) + '"';
+      backslashes = 0;
+      continue;
+    }
+    result += '\\'.repeat(backslashes) + ch;
+    backslashes = 0;
+  }
+  // Trailing backslashes precede the closing quote → must be doubled.
+  result += '\\'.repeat(backslashes * 2) + '"';
+  return result;
+}
+
+/**
+ * Compose a DEP0190-safe Windows shell command line from a command and its args.
+ *
+ * Node's `spawn(cmd, args, { shell: true })` on win32 concatenates `cmd` and
+ * every element of `args` into a single cmd.exe line WITHOUT escaping — that is
+ * both Node's DEP0190 deprecation (a future hard error) and a real injection
+ * surface, since user-controlled text (an agent prompt, a secrets-exec command)
+ * flows through `args`. Passing the fully-composed line as the SOLE `command`
+ * with an EMPTY args array sidesteps both: we quote every token with
+ * `quoteWin32ExecArg` so the child's CommandLineToArgvW parse reconstructs the
+ * exact original argv, and Node has no args array left to concatenate.
+ *
+ * Callers spawn the result as `spawn(line, [], { shell: true })`. A simple arg
+ * (no whitespace/quote/metachar) is passed through untouched, so the composed
+ * line is byte-identical to the old unquoted join for the common case.
+ */
+export function composeWin32CommandLine(command: string, args: string[]): string {
+  return [command, ...args].map(quoteWin32ExecArg).join(' ');
+}


### PR DESCRIPTION
## Problem

On Windows 11, every managed agent launch prints:

```
(node:27544) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
```

agents-cli spawns the npm-installed `.cmd` shims with `shell: true` **and** an args array. Node concatenates those args into a single `cmd.exe` command line **without escaping** — that is both the DEP0190 deprecation (a future hard error) and a real command-injection surface, because the user's prompt flows through those args (`agents run claude "<arbitrary text>"`). A multi-word or metacharacter-bearing prompt was also silently mis-split before this fix.

## Root cause — every `shell:true` + args-array spawn

The launch paths that carry user input and trigger DEP0190:

- `src/lib/exec.ts:801` — `resolveShimSpawn` returned `{ command: binary, args: extraArgs, shell: true }`, spawned at `src/lib/exec.ts:841` (`execShimPassthrough`, the `.cmd` shim passthrough for `agents run`).
- `src/lib/exec.ts:925` (`shell: useShell` at `:929`) — `spawnAgent`, the main `agents run` path: `spawn(executable, args, { ..., shell: useShell })`.
- `src/lib/loop.ts:221` (`shell: useShell` at `:225`) — `defaultRunIteration`, the loop re-injection path (re-runs the agent with the prompt).
- `src/commands/secrets.ts:1431` (`shell: useShell` at `:1433`) — `agents secrets exec`: already pre-quoted each arg via `quoteWin32ExecArg`, but still passed an args array, so it still emitted DEP0190.

## Fix

On the win32 shell path, compose **one** fully-quoted command line and spawn it with an **empty** args array — Node then has nothing to concatenate, and the child's `CommandLineToArgvW` parse reconstructs the exact original argv.

- Relocated the existing, well-tested `quoteWin32ExecArg` quoter from `src/commands/secrets.ts` to `src/lib/platform/exec.ts` (a `lib` module — the run/shim paths live in `lib` and cannot import from `commands`). `secrets.ts` re-exports it for its colocated tests.
- Added `composeWin32CommandLine(command, args)` in `src/lib/platform/exec.ts`: quotes every token with `quoteWin32ExecArg` and joins with spaces. A simple token (no whitespace/quote/metachar) passes through untouched, so the composed line is **byte-identical** to the old unquoted join for the common case.
- Rewired all four sites to `spawn(composeWin32CommandLine(exe, args), [], { shell: true })` on the shell path; the non-shell (POSIX / direct `.exe`) path is unchanged (`spawn(executable, args, { shell: false })`).

Quoting neutralizes whitespace, embedded double quotes, and cmd metacharacters (`& | < > ( ) ^`) per CommandLineToArgvW rules. `%VAR%`/`!VAR!` are deliberately **not** escaped (documented caveat) — the callers run a command whose `%`/`!` tokens are the caller's own, matching the pre-change behavior where these reached cmd.exe unquoted.

## Tests

- `src/lib/platform/exec.test.ts` — exhaustive unit tests for `quoteWin32ExecArg` (simple passthrough, whitespace/tab, all cmd metachars, embedded quotes, backslash-run-before-quote, trailing backslashes, lone trailing backslash, empty arg, unicode, `%VAR%`/`!VAR!` passthrough) and `composeWin32CommandLine` (byte-identical simple join, selective quoting). Plus a **real Windows spawn round-trip** (`process.platform === 'win32'` gated): composes a line, `spawnSync(line, [], { shell: true })` through `node -e`, and asserts the child's `process.argv` is **byte-exact** for `['hello world', 'say "hi"', 'a&b|c', 'less<more>than', 'C:\Program Files\thing', 'trailing\', 'café ☕ 日本語', '']` — with a spaced executable path (`C:\Program Files\nodejs\node.exe`).
- `src/lib/exec.test.ts` — updated the `resolveShimSpawn` win32 tests for the new DEP0190-safe contract (composed command, empty args) and added a case asserting a spaced/metachar prompt is quoted into the line.
- The relocated `quoteWin32ExecArg` tests in `src/commands/secrets.test.ts` still pass unchanged (via the re-export).

Run (worktree, only the affected files):

```
$ node ./node_modules/vitest/vitest.mjs run src/lib/platform/exec.test.ts src/lib/exec.test.ts src/commands/secrets.test.ts
 Test Files  3 passed (3)
      Tests  57 passed (57)
```

`npx tsc --noEmit` → clean (exit 0).

End-to-end DEP0190 proof on this machine (Node v24.17.0), capturing the parent process stderr:

```
OLD (args array + shell:true):        grep -c DEP0190 -> 1
NEW (composed line + [] + shell:true): grep -c DEP0190 -> 0
NEW composed line: "C:\Program Files\nodejs\node.exe" -e "process.exit(0)" "hello world"
```

## Intentionally out of scope

Other `shell:true` + args sites that emit the same DEP0190 but do **not** carry a user prompt (fixed args, or admin/maintenance commands) — left for a focused follow-up to keep this security-sensitive PR minimal:

- `src/lib/agents.ts:1457`, `:1481` — `registerMcp` / `unregisterMcp` (`execFileAsync` with `shell: needsWindowsShell(bin)`).
- `src/lib/mcp.ts:281`, `:289`, `:313`, `:362` — MCP config probes.
- `src/lib/self-update.ts:172`, `:189` — `npm`/`bun` global install.
- `src/lib/versions.ts:940`, `:955`, `:1633` — `npm view` / `--version` probes.
- `src/commands/sessions.ts:1445` — session-open launcher.

These pass fixed subcommands or non-prompt arguments, so they are not the injection surface the reported bug concerns; the shared `composeWin32CommandLine` helper is now in place for a straightforward follow-up conversion.
