### PR TITLE
feat(sessions): grouped project overview as the default listing

### DIFF
--- a/src/commands/sessions.overview.test.ts
+++ b/src/commands/sessions.overview.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { overviewProjectKey, buildOverviewGroups } from './sessions.js';
+import type { SessionMeta } from '../lib/session/types.js';
+
+function s(id: string, project: string | undefined, timestamp: string, cwd?: string): SessionMeta {
+  return { id, shortId: id.slice(0, 8), agent: 'claude', timestamp, project, cwd, filePath: '' } as SessionMeta;
+}
+
+describe('overviewProjectKey', () => {
+  it('prefers the indexed project name', () => {
+    expect(overviewProjectKey({ project: 'agents-cli', cwd: '/anything' })).toBe('agents-cli');
+  });
+
+  it('folds a worktree path back to its repo', () => {
+    expect(overviewProjectKey({ project: undefined, cwd: '/home/me/src/swarmify/.agents/worktrees/floor-redesign' })).toBe('swarmify');
+  });
+
+  it('falls back to the leaf dir for a monorepo subdir with no project', () => {
+    // A monorepo subdir with no indexed project name groups by its leaf dir — the
+    // customizable path->project mapping is a separate follow-up.
+    expect(overviewProjectKey({ project: undefined, cwd: '/home/me/src/agents/prix/api' })).toBe('api');
+  });
+
+  it('returns a sentinel for an empty cwd and no project', () => {
+    expect(overviewProjectKey({ project: undefined, cwd: '' })).toBe('(no project)');
+    expect(overviewProjectKey({ project: '  ', cwd: undefined })).toBe('(no project)');
+  });
+});
+
+describe('buildOverviewGroups', () => {
+  // Pool is recency-descending, as discoverSessions returns it.
+  const pool: SessionMeta[] = [
+    s('a1', 'agents-cli', '2026-07-04T10:00:05.000Z'),
+    s('b1', 'swarmify', '2026-07-04T10:00:04.000Z'),
+    s('a2', 'agents-cli', '2026-07-04T10:00:03.000Z'),
+    s('c1', 'rush', '2026-07-04T10:00:02.000Z'),
+    s('a3', 'agents-cli', '2026-07-04T10:00:01.000Z'),
+  ];
+
+  it('groups by project with accurate per-project totals (cap not exceeded)', () => {
+    const { groups, projectCount } = buildOverviewGroups(pool, 5);
+    expect(projectCount).toBe(3);
+    const cli = groups.find((g) => g.key === 'agents-cli')!;
+    expect(cli.total).toBe(3);
+    expect(cli.shown.map((x) => x.id)).toEqual(['a1', 'a2', 'a3']);
+    expect(cli.more).toBe(0);
+  });
+
+  it('orders groups by most-recent activity, NOT by count', () => {
+    // 'newproj' has one very recent session; 'bigproj' has three older ones.
+    const p: SessionMeta[] = [
+      s('x', 'newproj', '2026-07-04T09:00:09.000Z'),
+      s('g1', 'bigproj', '2026-07-04T09:00:08.000Z'),
+      s('g2', 'bigproj', '2026-07-04T09:00:07.000Z'),
+      s('g3', 'bigproj', '2026-07-04T09:00:06.000Z'),
+    ];
+    const { groups } = buildOverviewGroups(p, 4);
+    expect(groups.map((g) => g.key)).toEqual(['newproj', 'bigproj']);
+  });
+
+  it('caps rows per project and rolls the rest into "more"', () => {
+    // cap 1 → each project shows only its most-recent row; every project still appears.
+    const { groups } = buildOverviewGroups(pool, 1);
+    expect(groups.map((g) => g.key)).toEqual(['agents-cli', 'swarmify', 'rush']); // recency order
+    const cli = groups.find((g) => g.key === 'agents-cli')!;
+    expect(cli.shown.map((x) => x.id)).toEqual(['a1']); // most-recent only
+    expect(cli.total).toBe(3);
+    expect(cli.more).toBe(2); // a2, a3 rolled into "more"
+    const rush = groups.find((g) => g.key === 'rush')!;
+    expect(rush.shown.map((x) => x.id)).toEqual(['c1']);
+    expect(rush.more).toBe(0);
+  });
+
+  it('expands every row when the cap is Infinity', () => {
+    const { groups } = buildOverviewGroups(pool, Infinity);
+    const cli = groups.find((g) => g.key === 'agents-cli')!;
+    expect(cli.shown).toHaveLength(3);
+    expect(cli.more).toBe(0);
+  });
+});

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -71,6 +71,8 @@ interface SessionsOptions extends SessionFilterOptions {
   host?: string[];
   /** Group the listing by directory and drop the id/version columns. */
   tree?: boolean;
+  /** Force the plain flat table instead of the grouped default overview. */
+  flat?: boolean;
   /** With --active: show only sessions waiting on user input; exit 1 if any. */
   waiting?: boolean;
   /** Enrich the listing with live glyphs/preview for running rows. Default on;
@@ -149,6 +151,12 @@ function createScanProgressTracker(
 
 const PICKER_RECENT_COUNT = 15;
 const PICKER_POOL_LIMIT = 200;
+// The grouped default view ("overview"): fetch a generous recency-ordered pool
+// for accurate per-project totals, show each project's most-recent rows grouped
+// by project, newest-active project first.
+const OVERVIEW_ROWS_PER_PROJECT = 5; // recent rows shown per project before "· N more"
+const OVERVIEW_POOL_LIMIT = 1000; // fetch cap — accurate per-project totals up to this
+const OVERVIEW_MAX_PROJECTS = 12; // project groups shown before "+N more projects"
 
 /**
  * Resolve a path-like query to an absolute directory path.
@@ -745,8 +753,18 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
   // Interactive picker loads a deep pool but shows only recent sessions
   // until the user starts typing. Non-interactive/JSON uses the explicit limit.
   const isInteractive = !options.json && isInteractiveTerminal();
-  const limit = parseInt(options.limit || (isInteractive ? String(PICKER_POOL_LIMIT) : '50'), 10);
-  const since = options.since ?? (isInteractive && !options.all ? '30d' : undefined);
+  // The grouped project overview is the default for a bare interactive listing:
+  // no query, no path drill-in, not explicitly --flat/--tree. It drops the silent
+  // cwd-scope + 50-cap + 30-day window that hide most of a large index.
+  const wantsOverview = isInteractive && !searchQuery && !pathFilter && !options.flat && !options.tree;
+  const limit = wantsOverview
+    ? OVERVIEW_POOL_LIMIT
+    : parseInt(options.limit || (isInteractive ? String(PICKER_POOL_LIMIT) : '50'), 10);
+  // Overview: recency order across the whole index, no default window; an explicit
+  // --since still narrows. Non-overview keeps the prior interactive-30d default.
+  const since = wantsOverview
+    ? options.since
+    : (options.since ?? (isInteractive && !options.all ? '30d' : undefined));
   const spinner = options.json ? null : ora().start();
   const tracker = createScanProgressTracker(LOAD_VERBS, 'sessions', spinner);
 
@@ -762,7 +780,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
     const scope: DiscoverOptions = {
       agent,
       version,
-      all: pathFilter ? undefined : options.all,
+      all: pathFilter ? undefined : (wantsOverview ? true : options.all),
       cwd: process.cwd(),
       cwdPrefix: pathFilter,
       project: options.project,
@@ -859,9 +877,20 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
       return;
     }
 
-    // --tree is a printed grouped listing, not an interactive pick — render it
-    // directly even in a TTY.
-    if (isInteractiveTerminal() && !options.tree) {
+    // The grouped project overview is the bare interactive default: a scannable
+    // dashboard of the whole fleet grouped by project, newest-active first.
+    // Interact/resume via `agents sessions <project>` or `agents sessions resume`.
+    if (wantsOverview) {
+      const liveIndex = await maybeLiveIndex(options);
+      // Per-project row cap is fixed (--limit carries a default of 50 and drives
+      // the fetch pool, not the display); `--all` expands every group instead.
+      printSessionOverview(sessions, hiddenCount, liveIndex, { perProjectCap: OVERVIEW_ROWS_PER_PROJECT, expand: !!options.all });
+      return;
+    }
+
+    // --tree / --flat are printed listings, not an interactive pick — render them
+    // directly even in a TTY. A search query keeps the interactive picker.
+    if (isInteractiveTerminal() && !options.tree && !options.flat) {
       const message = pathFilter
         ? `Search sessions (${path.basename(pathFilter)}):`
         : formatSearchMessage(options);
@@ -873,7 +902,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
       return;
     }
 
-    // Non-interactive fallback (piped output)
+    // Non-interactive fallback (piped output) or --flat/--tree.
     const filtered = searchQuery ? filterSessionsByQuery(sessions, searchQuery) : sessions;
     const liveIndex = await maybeLiveIndex(options);
     printSessionTable(filtered, hiddenCount, options.tree === true, liveIndex);
@@ -994,6 +1023,94 @@ async function maybeLiveIndex(options: SessionsOptions): Promise<Map<string, Act
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Group key for the overview: prefer the indexed project name; else fold the cwd
+ * to its repo — a worktree (`.../<repo>/.agents/worktrees/<slug>`) folds to the
+ * repo, and a monorepo subdir falls back to its leaf dir basename. Pure.
+ */
+export function overviewProjectKey(s: Pick<SessionMeta, 'project' | 'cwd'>): string {
+  if (s.project && s.project.trim()) return s.project.trim();
+  const cwd = (s.cwd ?? '').replace(/\/+$/, '');
+  if (!cwd) return '(no project)';
+  const wt = cwd.match(/\/([^/]+)\/\.agents\/worktrees\//);
+  if (wt) return wt[1];
+  const parts = cwd.split('/');
+  return parts[parts.length - 1] || cwd;
+}
+
+export interface OverviewGroup {
+  key: string;
+  total: number; // total sessions for this project in the fetched pool
+  shown: SessionMeta[]; // the recent slice that fell within the display budget
+  more: number; // total - shown.length
+  maxTs: string; // most-recent timestamp in the group
+}
+
+/**
+ * Turn a recency-descending pool into project groups: each group shows its
+ * `perProjectCap` most-recent sessions (the rest become `· N more`), and groups
+ * are ordered by their most-recent session so the newest-active project leads.
+ * `perProjectCap = Infinity` expands every group. Pure — unit-tested.
+ */
+export function buildOverviewGroups(
+  pool: SessionMeta[],
+  perProjectCap: number,
+): { groups: OverviewGroup[]; projectCount: number } {
+  const byKey = new Map<string, SessionMeta[]>();
+  for (const s of pool) {
+    const k = overviewProjectKey(s);
+    (byKey.get(k) ?? byKey.set(k, []).get(k)!).push(s);
+  }
+  const cap = Math.max(1, perProjectCap);
+  const groups: OverviewGroup[] = [];
+  for (const [key, rows] of byKey) {
+    const shown = rows.slice(0, cap); // rows are recency-desc (pool was sorted)
+    groups.push({ key, total: rows.length, shown, more: rows.length - shown.length, maxTs: rows[0].timestamp });
+  }
+  groups.sort((a, b) => (a.maxTs < b.maxTs ? 1 : a.maxTs > b.maxTs ? -1 : a.key.localeCompare(b.key)));
+  return { groups, projectCount: byKey.size };
+}
+
+/**
+ * The grouped project overview — the bare interactive default. Shows the latest
+ * sessions grouped under their project, newest-active project first, with a
+ * `· N more` per project and a `+N more projects` when the list is capped.
+ */
+function printSessionOverview(
+  pool: SessionMeta[],
+  hiddenCount: number,
+  liveIndex: Map<string, ActiveSession> | undefined,
+  opts: { perProjectCap: number; expand: boolean },
+): void {
+  const { groups } = buildOverviewGroups(pool, opts.expand ? Infinity : opts.perProjectCap);
+  const shownGroups = opts.expand ? groups : groups.slice(0, OVERVIEW_MAX_PROJECTS);
+  const hiddenProjects = groups.length - shownGroups.length;
+
+  const total = pool.length;
+  const projWord = groups.length === 1 ? 'project' : 'projects';
+  console.log(chalk.gray(`${total} session${total === 1 ? '' : 's'} · ${groups.length} ${projWord} · recent activity\n`));
+
+  let first = true;
+  for (const g of shownGroups) {
+    if (!first) console.log();
+    first = false;
+    const { glyph } = liveGlyphAndPreview(liveIndex?.get(g.shown[0].id));
+    const head =
+      `${chalk.cyan('▸')} ${chalk.cyan.bold(g.key)}  ${chalk.gray(String(g.total))}` +
+      `${glyph ? '  ' + glyph : ''} ${chalk.gray(formatRelativeTime(g.maxTs))}`;
+    console.log(head);
+    for (const s of g.shown) console.log(treeSessionRow(s, liveIndex?.get(s.id)));
+    if (g.more > 0) console.log('  ' + chalk.gray(`· ${g.more} more`));
+  }
+
+  console.log();
+  const parts = [chalk.gray('newest first')];
+  if (hiddenProjects > 0) parts.push(chalk.gray(`+${hiddenProjects} more project${hiddenProjects === 1 ? '' : 's'} · agents sessions --all`));
+  parts.push(chalk.gray('agents sessions <project> to drill in · --flat for the plain list'));
+  console.log(parts.join(chalk.gray('  ·  ')));
+  if (hiddenCount > 0) console.log(chalk.gray(formatTeamHiddenFooter(hiddenCount)));
 }
 
 function printSessionTable(sessions: SessionMeta[], hiddenCount = 0, tree = false, liveIndex?: Map<string, ActiveSession>): void {
@@ -1900,6 +2017,7 @@ export function registerSessionsCommands(program: Command): void {
     .option('--local', 'Only this machine — skip the cross-machine SSH fan-out (default listing and --active)')
     .option('--waiting', 'With --active: show only sessions waiting on your input (exits non-zero if any)')
     .option('--tree', 'Group the listing by directory; drops the id/version columns for readability')
+    .option('--flat', 'Plain flat table (one row per session) instead of the grouped project overview')
     .option('--no-live', 'Do not enrich the listing with live status/preview for running sessions')
     .option('--cloud', 'Source sessions from Rush Cloud (captured runs) instead of local disk')
     .option('-H, --host <target...>', 'Run this query on remote machine(s) over SSH (host alias or user@host; repeatable)');


### PR DESCRIPTION
## Problem
Bare `agents sessions` prints a flat table silently **capped at 50 rows, scoped to the current directory, and windowed to 30 days**. With 50-100 agents and thousands of sessions across many projects, that surfaces ~24 of them — you come back after a break and see almost nothing. The `--fleet` flag (#629) was closed as a band-aid: the person with the problem won't know to type it. This fixes the **default**.

## Before / after (real, on yosemite-s0)
```
before:  agents sessions   →  ~24 rows, cwd-scoped, one flat list

after:   agents sessions
  219 sessions · 23 projects · recent activity

  ▸ muqsitnawaz  111  2 hours ago
    e226da44 kimi    New Session                                      2 hours ago
    7832ab53 claude  PR#634 cross-device session display              2 hours ago
    … (5 rows)
    · 106 more
  ▸ agents-cli   23   3 days ago
    …
    · 18 more
  ▸ .system  2  3 days ago
    …
  newest first  ·  +11 more projects · agents sessions --all  ·  agents sessions <project> to drill in · --flat
```

## Behavior
The grouped overview is the bare interactive default. Recency is the primary axis; project grouping is the display organization.
- **Newest-active project first** (groups ordered by their most-recent session, not by count).
- **Each project shows its 5 most-recent sessions** + `· N more`; up to 12 projects, then `+N more projects · agents sessions --all`.
- **No silent cwd-scope, no 50-cap, no 30-day window.** `--since` still narrows.
- **`--flat`** restores the plain one-row-per-session table; a **search query** keeps the interactive picker; **`--json` / piped** output is byte-unchanged; **`--all`** expands every group; **`--active`** (live cross-machine view) untouched.

## Implementation
All in `src/commands/sessions.ts`, no schema changes. Loosen the no-args fetch defaults in `sessionsAction`; new `printSessionOverview` renderer; pure exported helpers `overviewProjectKey` + `buildOverviewGroups` (fold a worktree to its repo, monorepo subdir → leaf dir, recency ordering, per-project cap). Reuses `treeSessionRow`, `liveGlyphAndPreview`, `formatRelativeTime`, `shortCwd`, the `indexActiveBySessionId` live bridge.

## Tests
`src/commands/sessions.overview.test.ts` — 8 pass / 0 fail (project-key derivation incl. worktree/monorepo, recency-not-count ordering, per-project cap + `· N more` math, `--all` expand). Verified end-to-end on this machine (node build): grouped output renders and exits in ~1s; `--flat` returns the old table.

## Out of scope (follow-ups)
- **Customizable path→project mapping** (like the Floor's #126) — right now a monorepo subdir with no indexed `project` groups by its leaf dir.
- A "needs-you-first" band above the groups.
