### PR TITLE
fix(hooks): wire extra-repo hook events in parseHookManifest (Closes #602)

### DIFF
--- a/src/lib/__tests__/hooks-layering.test.ts
+++ b/src/lib/__tests__/hooks-layering.test.ts
@@ -14,6 +14,7 @@ import * as os from 'os';
 let TEST_ROOT: string;
 let SYSTEM_DIR: string;
 let USER_DIR: string;
+let ENABLED_EXTRAS: Array<{ alias: string; dir: string; url: string }>;
 
 vi.mock('../state.js', () => ({
   get getAgentsDir() { return () => SYSTEM_DIR; },
@@ -23,7 +24,7 @@ vi.mock('../state.js', () => ({
   get getSystemHooksDir() { return () => path.join(SYSTEM_DIR, 'hooks'); },
   get getUserHooksDir() { return () => path.join(USER_DIR, 'hooks'); },
   get getProjectAgentsDir() { return () => null; },
-  get getEnabledExtraRepos() { return () => []; },
+  get getEnabledExtraRepos() { return () => ENABLED_EXTRAS; },
 }));
 
 vi.mock('../agents.js', () => ({
@@ -52,6 +53,7 @@ describe('parseHookManifest layering', () => {
     USER_DIR = path.join(TEST_ROOT, '.agents');
     fs.mkdirSync(SYSTEM_DIR, { recursive: true });
     fs.mkdirSync(USER_DIR, { recursive: true });
+    ENABLED_EXTRAS = [];
   });
 
   afterEach(() => {
@@ -155,5 +157,91 @@ describe('parseHookManifest layering', () => {
     const out = parseHookManifest();
     expect(out['shared'].script).toBe('user.sh');
     expect(warn).not.toHaveBeenCalled();
+  });
+
+  // Regression for #602: an enabled extra repo declaring a hook (with its
+  // event, e.g. SessionStart) must surface in parseHookManifest so the event
+  // actually registers. Before the fix parseHookManifest read only the system
+  // and user agents.yaml, so extra-repo hook scripts resolved but their events
+  // never wired.
+  it('includes hook events declared in an enabled extra repo (#602)', () => {
+    const extraDir = path.join(TEST_ROOT, 'extra-work');
+    fs.mkdirSync(extraDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(extraDir, 'agents.yaml'),
+      'hooks:\n  work-session:\n    script: session-start.sh\n    events: [SessionStart]\n    timeout: 7\n',
+      'utf-8'
+    );
+    ENABLED_EXTRAS = [{ alias: 'work', dir: extraDir, url: 'gh:me/.agents-work' }];
+
+    const out = parseHookManifest();
+    expect(out['work-session']).toBeDefined();
+    expect(out['work-session'].script).toBe('session-start.sh');
+    expect(out['work-session'].events).toEqual(['SessionStart']);
+    expect(out['work-session'].timeout).toBe(7);
+  });
+
+  it('extra-repo hooks sit above system but below user in precedence (#602)', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const extraDir = path.join(TEST_ROOT, 'extra-work');
+    fs.mkdirSync(extraDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(SYSTEM_DIR, 'agents.yaml'),
+      'hooks:\n  shared:\n    script: system.sh\n    events: [Stop]\n',
+      'utf-8'
+    );
+    fs.writeFileSync(
+      path.join(extraDir, 'agents.yaml'),
+      'hooks:\n  shared:\n    script: extra.sh\n    events: [Stop]\n',
+      'utf-8'
+    );
+    ENABLED_EXTRAS = [{ alias: 'work', dir: extraDir, url: 'gh:me/.agents-work' }];
+
+    // Extra beats system.
+    expect(parseHookManifest()['shared'].script).toBe('extra.sh');
+
+    // User beats extra.
+    fs.writeFileSync(
+      path.join(USER_DIR, 'agents.yaml'),
+      'hooks:\n  shared:\n    override: true\n    script: user.sh\n    events: [Stop]\n',
+      'utf-8'
+    );
+    expect(parseHookManifest()['shared'].script).toBe('user.sh');
+  });
+
+  it('earlier extra repo wins over a later one on name collision (#602)', () => {
+    const workDir = path.join(TEST_ROOT, 'extra-work');
+    const teamDir = path.join(TEST_ROOT, 'extra-team');
+    fs.mkdirSync(workDir, { recursive: true });
+    fs.mkdirSync(teamDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(workDir, 'agents.yaml'),
+      'hooks:\n  shared:\n    script: from-work.sh\n    events: [SessionStart]\n',
+      'utf-8'
+    );
+    fs.writeFileSync(
+      path.join(teamDir, 'agents.yaml'),
+      'hooks:\n  shared:\n    script: from-team.sh\n    events: [SessionStart]\n',
+      'utf-8'
+    );
+    ENABLED_EXTRAS = [
+      { alias: 'work', dir: workDir, url: 'gh:me/.agents-work' },
+      { alias: 'team', dir: teamDir, url: 'gh:team/.agents' },
+    ];
+
+    expect(parseHookManifest()['shared'].script).toBe('from-work.sh');
+  });
+
+  it('enabled: false on an extra-repo hook strips it (#602)', () => {
+    const extraDir = path.join(TEST_ROOT, 'extra-work');
+    fs.mkdirSync(extraDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(extraDir, 'agents.yaml'),
+      'hooks:\n  work-session:\n    enabled: false\n    script: session-start.sh\n    events: [SessionStart]\n',
+      'utf-8'
+    );
+    ENABLED_EXTRAS = [{ alias: 'work', dir: extraDir, url: 'gh:me/.agents-work' }];
+
+    expect(parseHookManifest()).not.toHaveProperty('work-session');
   });
 });

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -864,6 +864,21 @@ export function parseHookManifest(opts: { warn?: boolean } = {}): Record<string,
     } catch { /* skip unreadable manifest */ }
   }
 
+  // Extra-repo layer: hooks: section of each enabled extra repo's agents.yaml.
+  // Sits above system but below user, mirroring resolveHookScriptPath's
+  // first-found order (user > extra > system). Without this layer the script
+  // path of an extra-repo hook resolves but its events never register (#602).
+  // Earlier extras win over later ones, so iterate in reverse: the last write
+  // for a given name comes from the earliest-registered repo.
+  for (const { dir } of [...getEnabledExtraRepos()].reverse()) {
+    const extraMetaPath = path.join(dir, 'agents.yaml');
+    if (!fs.existsSync(extraMetaPath)) continue;
+    try {
+      const meta = yaml.parse(fs.readFileSync(extraMetaPath, 'utf-8')) as { hooks?: Record<string, ManifestHook> } | null;
+      if (meta?.hooks) for (const [name, def] of Object.entries(meta.hooks)) merged[name] = def;
+    } catch { /* skip unreadable extra-repo manifest */ }
+  }
+
   // User layer: hooks: section of agents.yaml.
   const userMetaPath = path.join(getUserAgentsDir(), 'agents.yaml');
   if (fs.existsSync(userMetaPath)) {


### PR DESCRIPTION
## Root cause

Extra-repo hooks installed their script but never wired the event.

- `resolveHookScriptPath()` ([`src/lib/hooks.ts:38-45`](../blob/main/src/lib/hooks.ts#L38)) resolves a hook script across `[user, ...enabledExtraRepos, system]`, first-found wins — so an extra-repo hook's **script path** resolves fine.
- `parseHookManifest()` ([`src/lib/hooks.ts:842`](../blob/main/src/lib/hooks.ts#L842)) is what feeds **event wiring** into `settings.json` (via `registerHooksToSettings`, called from `src/lib/refresh.ts` and `src/commands/sync.ts`). It read only the subrule layer + the **system** `agents.yaml` + the **user** `agents.yaml` — it omitted the extra-repo layer entirely.

Net: an enabled extra repo could ship a hook whose script resolves on disk, but its event (`SessionStart`, etc.) never registers. That asymmetry between the two functions is the bug (#602).

## Fix

Add the enabled extra-repo layer to `parseHookManifest()`, inserted **between the system and user blocks** so precedence mirrors `resolveHookScriptPath` exactly:

**user > extra > system** (and earlier extra wins over later).

Because `merged` is last-write-wins, the extra repos are iterated in **reverse**, so the earliest-registered repo wins a name collision — matching the `listInstalledSkills` extra-repo semantics. Unreadable/missing extra `agents.yaml` files are skipped silently, consistent with the existing system/user layers.

```ts
// Extra-repo layer: hooks: section of each enabled extra repo's agents.yaml.
// Sits above system but below user, mirroring resolveHookScriptPath's
// first-found order (user > extra > system).
for (const { dir } of [...getEnabledExtraRepos()].reverse()) {
  const extraMetaPath = path.join(dir, 'agents.yaml');
  if (!fs.existsSync(extraMetaPath)) continue;
  try {
    const meta = yaml.parse(fs.readFileSync(extraMetaPath, 'utf-8')) as { hooks?: Record<string, ManifestHook> } | null;
    if (meta?.hooks) for (const [name, def] of Object.entries(meta.hooks)) merged[name] = def;
  } catch { /* skip unreadable extra-repo manifest */ }
}
```

## Test

Extended `src/lib/__tests__/hooks-layering.test.ts` (the canonical `parseHookManifest` layering suite — real temp DotAgents dirs, real on-disk `agents.yaml`, real parser) with four cases:

1. An **enabled extra repo** declaring a `SessionStart` hook now surfaces in `parseHookManifest` output (script, events, timeout all present) — the direct #602 repro.
2. Extra beats system, user beats extra (precedence).
3. Earlier extra repo wins over a later one on name collision.
4. `enabled: false` on an extra-repo hook strips it.

Cases 1–3 **fail without the fix** and pass with it. Verified:

```
# without the fix
Tests  3 failed | 8 passed (11)

# with the fix
Test Files  4 passed (4)   # hooks-layering + extra-repos + hook-doc-sidecar + hooks-soft-delete
Tests  32 passed (32)
```

`tsc --noEmit` clean.
