### PR TITLE
feat(profiles): per-profile fallback_model (Closes #325)

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -548,6 +548,7 @@ export function registerRunCommand(program: Command): void {
       let version: string | undefined = rawVersion || undefined;
       let profileEnv: Record<string, string> | undefined;
       let fromProfile = false;
+      let profileFallbackModel: { envKey: string; model: string } | undefined;
       let workflowModel: string | undefined;
       // WORKFLOW.md capability scoping, translated to Claude headless flags below.
       let workflowToolsRestrict: string[] | undefined;
@@ -569,6 +570,7 @@ export function registerRunCommand(program: Command): void {
           agent = resolved.agent;
           if (!version) version = resolved.version;
           profileEnv = resolved.env;
+          profileFallbackModel = resolved.fallbackModel;
           fromProfile = true;
           process.stderr.write(chalk.gray(`Resolved profile '${resolved.profileName}' -> ${agent}${version ? `@${version}` : ''}\n`));
         } catch (err) {
@@ -1095,6 +1097,19 @@ export function registerRunCommand(program: Command): void {
           }
           fallback.push({ agent: fbAgent, version: resolveVersionAlias(fbAgent, fbVersion || undefined) });
         }
+      }
+
+      // Profile-declared same-host model swap (issue #325). Inserted BEFORE any
+      // user --fallback entries so a rate limit first tries the cheaper/backup
+      // model on the same provider (auth + base URL preserved via envOverride);
+      // only if THAT still rate-limits do we cascade to a different agent CLI.
+      // Requires a prompt for the same reason --fallback does — headless-only.
+      if (fromProfile && profileFallbackModel && prompt !== undefined && !options.interactive) {
+        fallback.unshift({
+          agent,
+          version,
+          envOverride: { [profileFallbackModel.envKey]: profileFallbackModel.model },
+        });
       }
 
       if (options.acp) {

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -1142,6 +1142,12 @@ export interface FallbackEntry {
   agent: AgentId;
   /** Optional pinned version (e.g. '0.116.0'). When set, takes precedence over the active default. */
   version?: string;
+  /**
+   * Env vars merged over options.env for THIS attempt only. Used by profiles
+   * with `fallback_model` to swap the model env key (e.g. ANTHROPIC_MODEL) on
+   * a same-agent retry without touching auth or base URL.
+   */
+  envOverride?: Record<string, string>;
 }
 
 /** ExecOptions extended with a fallback chain for rate-limit cascading. */
@@ -1231,10 +1237,15 @@ export async function runWithFallback(options: FallbackOptions): Promise<number>
   }
 
   for (let i = 0; i < chain.length; i++) {
-    const { agent, version } = chain[i];
+    const { agent, version, envOverride } = chain[i];
     const pinnedSessionId = agent === 'claude' ? randomUUID() : undefined;
 
-    const prompt = prevAgent
+    // Same-host retry (same agent+version as previous entry — used by profile
+    // `fallback_model` swaps) keeps the original prompt: the model changed,
+    // not the CLI, so a `/continue` handoff prompt would be misleading.
+    const prev = i > 0 ? chain[i - 1] : undefined;
+    const sameHostRetry = !!prev && prev.agent === agent && prev.version === version;
+    const prompt = prevAgent && !sameHostRetry
       ? buildFallbackPrompt(prevAgent, prevSessionId, agent, options.prompt)
       : options.prompt;
 
@@ -1243,13 +1254,19 @@ export async function runWithFallback(options: FallbackOptions): Promise<number>
       agent,
       version,
       prompt,
+      env: envOverride ? { ...(options.env ?? {}), ...envOverride } : options.env,
       sessionId: pinnedSessionId ?? (i === 0 ? options.sessionId : undefined),
     };
 
     const label = version ? `${agent}@${version}` : agent;
+    const modelSwapNote = sameHostRetry && envOverride
+      ? ` (retry with ${Object.entries(envOverride).map(([k, v]) => `${k}=${v}`).join(', ')})`
+      : '';
     const banner = i === 0
       ? `[agents] running ${label}`
-      : `[agents] fallback → ${label}`;
+      : sameHostRetry
+        ? `[agents] retry → ${label}${modelSwapNote}`
+        : `[agents] fallback → ${label}`;
     process.stderr.write(`${banner}${pinnedSessionId ? ` (session ${pinnedSessionId.slice(0, 8)})` : ''}\n`);
 
     let result: SpawnResult;
@@ -1274,7 +1291,9 @@ export async function runWithFallback(options: FallbackOptions): Promise<number>
 
     const next = chain[i + 1];
     const nextLabel = next.version ? `${next.agent}@${next.version}` : next.agent;
-    process.stderr.write(`[agents] ${label} hit rate limit. Handing off to ${nextLabel}...\n`);
+    const nextSameHost = next.agent === agent && next.version === version;
+    const handoffVerb = nextSameHost ? 'Retrying on same host' : 'Handing off';
+    process.stderr.write(`[agents] ${label} hit rate limit. ${handoffVerb} to ${nextLabel}...\n`);
     prevAgent = agent;
     prevSessionId = pinnedSessionId;
   }

--- a/src/lib/profiles.test.ts
+++ b/src/lib/profiles.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as state from './state.js';
+import {
+  profileModelEnvKey,
+  readProfile,
+  resolveProfileForRun,
+  writeProfile,
+  type Profile,
+} from './profiles.js';
+
+let TEST_ROOT: string;
+let USER_DIR: string;
+
+beforeEach(() => {
+  TEST_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'profiles-test-'));
+  USER_DIR = path.join(TEST_ROOT, '.agents');
+  fs.mkdirSync(path.join(USER_DIR, 'profiles'), { recursive: true });
+  vi.spyOn(state, 'getUserAgentsDir').mockReturnValue(USER_DIR);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe('Profile fallback_model round-trip', () => {
+  it('writes fallback_model to YAML and reads it back unchanged', () => {
+    const profile: Profile = {
+      name: 'kimi',
+      host: { agent: 'claude' },
+      env: {
+        ANTHROPIC_BASE_URL: 'https://openrouter.ai/api',
+        ANTHROPIC_MODEL: 'moonshotai/kimi-k2.5',
+      },
+      provider: 'openrouter',
+      fallback_model: 'moonshotai/kimi-k2-0905',
+    };
+    writeProfile(profile);
+
+    const raw = fs.readFileSync(path.join(USER_DIR, 'profiles', 'kimi.yml'), 'utf-8');
+    expect(raw).toContain('fallback_model: moonshotai/kimi-k2-0905');
+
+    const roundTripped = readProfile('kimi');
+    expect(roundTripped.fallback_model).toBe('moonshotai/kimi-k2-0905');
+    expect(roundTripped.env.ANTHROPIC_MODEL).toBe('moonshotai/kimi-k2.5');
+  });
+
+  it('omits fallback_model when not set (backward compatible)', () => {
+    const profile: Profile = {
+      name: 'plain',
+      host: { agent: 'claude' },
+      env: { ANTHROPIC_MODEL: 'claude-sonnet-4-6' },
+    };
+    writeProfile(profile);
+
+    const roundTripped = readProfile('plain');
+    expect(roundTripped.fallback_model).toBeUndefined();
+  });
+});
+
+describe('profileModelEnvKey', () => {
+  it('returns ANTHROPIC_MODEL when set', () => {
+    const p: Profile = {
+      name: 'p',
+      host: { agent: 'claude' },
+      env: { ANTHROPIC_MODEL: 'claude-x' },
+    };
+    expect(profileModelEnvKey(p)).toBe('ANTHROPIC_MODEL');
+  });
+
+  it('returns OPENAI_MODEL for codex-shaped profiles', () => {
+    const p: Profile = {
+      name: 'p',
+      host: { agent: 'codex' },
+      env: { OPENAI_MODEL: 'gpt-x', OPENAI_BASE_URL: 'https://x' },
+    };
+    expect(profileModelEnvKey(p)).toBe('OPENAI_MODEL');
+  });
+
+  it('falls back to any *_MODEL suffix when no known key matches', () => {
+    const p: Profile = {
+      name: 'p',
+      host: { agent: 'claude' },
+      env: { CUSTOM_MODEL: 'x' },
+    };
+    expect(profileModelEnvKey(p)).toBe('CUSTOM_MODEL');
+  });
+
+  it('returns null when no model env is present', () => {
+    const p: Profile = {
+      name: 'p',
+      host: { agent: 'claude' },
+      env: { ANTHROPIC_BASE_URL: 'https://x' },
+    };
+    expect(profileModelEnvKey(p)).toBeNull();
+  });
+});
+
+describe('resolveProfileForRun surfaces fallback_model as an env-swap', () => {
+  it('reports the model env key + fallback value so the fallback cascade can swap it', () => {
+    writeProfile({
+      name: 'kimi',
+      host: { agent: 'claude' },
+      env: {
+        ANTHROPIC_BASE_URL: 'https://openrouter.ai/api',
+        ANTHROPIC_MODEL: 'moonshotai/kimi-k2.5',
+      },
+      fallback_model: 'moonshotai/kimi-k2-0905',
+    });
+
+    const resolved = resolveProfileForRun('kimi');
+    expect(resolved.fallbackModel).toEqual({
+      envKey: 'ANTHROPIC_MODEL',
+      model: 'moonshotai/kimi-k2-0905',
+    });
+    // Primary env still points at the primary model — the swap only applies
+    // on retry via the runWithFallback envOverride.
+    expect(resolved.env.ANTHROPIC_MODEL).toBe('moonshotai/kimi-k2.5');
+  });
+
+  it('leaves fallbackModel undefined when the profile omits fallback_model', () => {
+    writeProfile({
+      name: 'plain',
+      host: { agent: 'claude' },
+      env: { ANTHROPIC_MODEL: 'claude-sonnet-4-6' },
+    });
+    expect(resolveProfileForRun('plain').fallbackModel).toBeUndefined();
+  });
+
+  it('leaves fallbackModel undefined when the profile has no recognizable model env key', () => {
+    writeProfile({
+      name: 'weird',
+      host: { agent: 'claude' },
+      env: { ANTHROPIC_BASE_URL: 'https://x' },
+      fallback_model: 'ignored-because-no-key-to-swap',
+    });
+    expect(resolveProfileForRun('weird').fallbackModel).toBeUndefined();
+  });
+});

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -29,6 +29,14 @@ export interface Profile {
   description?: string;
   preset?: string;
   provider?: string;
+  /**
+   * Optional secondary model retried on the same host when the primary model
+   * env value hits a rate limit. Reuses the `--fallback` cascade in
+   * `runWithFallback` (src/lib/exec.ts) — the swap is expressed as an
+   * envOverride on a same-agent FallbackEntry, so only the model env var
+   * changes; auth, base URL, and every other profile env value are preserved.
+   */
+  fallback_model?: string;
 }
 
 /**
@@ -155,14 +163,24 @@ const MODEL_ENV_KEYS = [
 
 /** Return the configured model env value for display. */
 export function profileModelLabel(profile: Profile): string {
+  const key = profileModelEnvKey(profile);
+  return key ? profile.env[key] : '-';
+}
+
+/**
+ * Return the env var key that carries this profile's model (e.g.
+ * `ANTHROPIC_MODEL`), or null when the profile has no recognizable model env.
+ * `fallback_model` swaps THIS key so provider selection, auth, and base URL
+ * are all preserved on retry.
+ */
+export function profileModelEnvKey(profile: Profile): string | null {
   for (const key of MODEL_ENV_KEYS) {
-    const value = profile.env[key];
-    if (value) return value;
+    if (profile.env[key]) return key;
   }
   for (const [key, value] of Object.entries(profile.env)) {
-    if ((key === 'MODEL' || key.endsWith('_MODEL')) && value) return value;
+    if ((key === 'MODEL' || key.endsWith('_MODEL')) && value) return key;
   }
-  return '-';
+  return null;
 }
 
 function decodeJwtPayload(token: string): Record<string, unknown> | null {
@@ -285,6 +303,13 @@ export interface ResolvedProfileRun {
   version?: string;
   env: Record<string, string>;
   profileName: string;
+  /**
+   * Same-host model swap for the `--fallback` cascade. Present only when the
+   * profile declares `fallback_model` AND the profile has an identifiable
+   * model env key to swap. `envKey` names the var (e.g. `ANTHROPIC_MODEL`),
+   * `model` is the value to write on the retry attempt.
+   */
+  fallbackModel?: { envKey: string; model: string };
 }
 
 /**
@@ -294,12 +319,19 @@ export interface ResolvedProfileRun {
  */
 export function resolveProfileForRun(name: string): ResolvedProfileRun {
   const profile = readProfile(name);
-  return {
+  const resolved: ResolvedProfileRun = {
     agent: profile.host.agent,
     version: profile.host.version,
     env: resolveProfileEnv(profile),
     profileName: profile.name,
   };
+  if (profile.fallback_model) {
+    const envKey = profileModelEnvKey(profile);
+    if (envKey) {
+      resolved.fallbackModel = { envKey, model: profile.fallback_model };
+    }
+  }
+  return resolved;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #325. Adds an optional `fallback_model` field on profiles: when the primary model in a profile hits a rate limit, the same host is retried with the swap applied only to the model env var (auth, base URL, and every other profile env value preserved).

## Reused mechanism

Wires into the existing `--fallback` cascade in `runWithFallback` (`src/lib/exec.ts`) rather than inventing a parallel mechanism:

- New optional `envOverride?: Record<string, string>` on `FallbackEntry` — merged over `options.env` for that attempt only.
- `runWithFallback` detects same-host retries (same `agent + version` as previous entry) and keeps the original prompt (a `/continue` handoff would be misleading — the CLI didn't change, only the model did). Banner reads `retry → …` instead of `fallback → …`.
- `resolveProfileForRun` now surfaces `{ envKey, model }` when the profile has `fallback_model` AND a recognizable model env key (`ANTHROPIC_MODEL`, `OPENAI_MODEL`, `GEMINI_MODEL`, `GROK_MODEL`, `MODEL`, or `*_MODEL`).
- `src/commands/exec.ts` `unshift`s a same-agent `FallbackEntry` (with the model swap as `envOverride`) ahead of any user `--fallback` chain, so a rate limit tries the cheaper/backup model on the same provider first, then cascades to a different agent CLI.
- Headless-only (mirrors `--fallback`'s existing constraint — no prompt / interactive session, no fallback).

## Test plan

New file `src/lib/profiles.test.ts` (vitest, real temp dirs via `getUserAgentsDir` spy — no mocks):

- [x] `fallback_model` round-trips through `writeProfile` → YAML → `readProfile`
- [x] Missing `fallback_model` stays undefined (backward compatible)
- [x] `profileModelEnvKey` returns `ANTHROPIC_MODEL` / `OPENAI_MODEL` / a `*_MODEL` fallback / `null` per profile shape
- [x] `resolveProfileForRun` reports `{ envKey, model }` when profile declares `fallback_model` with a recognizable model env
- [x] `resolveProfileForRun.fallbackModel` is undefined when no model env key exists to swap

Run:
```
bun test src/lib/profiles.test.ts    # 9 pass, 0 fail
bunx tsc --noEmit                    # clean
```