### PR TITLE
feat(check): add `agents check` drift command with CI exit code (Closes #329)

### DIFF
--- a/src/commands/check.test.ts
+++ b/src/commands/check.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { execFileSync, spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * Real-filesystem, real-CLI tests for `agents check` — the scriptable CI drift
+ * gate. No mocks: we build a temp HOME with a real installed version + real
+ * source resources, drive the actual `agents sync` to snapshot the manifest,
+ * then run `agents check` in a subprocess and assert the EXIT CODE.
+ *
+ * The contract (issue #329): a clean, in-sync install exits 0; drift (a source
+ * changed since last sync) exits non-zero. This is the gap `agents doctor` left
+ * — it returned 0 even under drift, so CI could never gate on it.
+ */
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const INDEX = path.join(REPO_ROOT, 'src', 'index.ts');
+
+let testHome: string;
+let projectDir: string;
+
+afterEach(() => {
+  if (testHome) fs.rmSync(testHome, { recursive: true, force: true });
+  if (projectDir) fs.rmSync(projectDir, { recursive: true, force: true });
+});
+
+/** Build a temp HOME with an installed claude@2.0.0 and one source command. */
+function seedHome(): { commandSrc: string } {
+  testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-check-home-'));
+  // A separate, empty project dir so the project layer resolves to nothing —
+  // both `sync` and `check` are pointed at it via --cwd so they see the same
+  // (user-only) source set.
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-check-proj-'));
+
+  const userDir = path.join(testHome, '.agents');
+  const systemDir = path.join(userDir, '.system');
+  // `.system/.git` keeps ensureInitialized() from blocking; `.update-check`
+  // keeps the update probe from reaching the network.
+  fs.mkdirSync(path.join(systemDir, '.git'), { recursive: true });
+  fs.writeFileSync(
+    path.join(systemDir, '.update-check'),
+    JSON.stringify({ lastCheck: 4102444800000, latestVersion: '0.0.0' }),
+  );
+  fs.writeFileSync(path.join(userDir, 'agents.yaml'), 'agents:\n  claude: "2.0.0"\n');
+
+  // A fake installed version: a binary so listInstalledVersions() sees it.
+  const binDir = path.join(userDir, '.history', 'versions', 'claude', '2.0.0', 'node_modules', '.bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, 'claude'), '#!/bin/sh\nexit 0\n');
+  fs.chmodSync(path.join(binDir, 'claude'), 0o755);
+
+  // One user-layer source command.
+  const commandsDir = path.join(userDir, 'commands');
+  fs.mkdirSync(commandsDir, { recursive: true });
+  const commandSrc = path.join(commandsDir, 'demo.md');
+  fs.writeFileSync(commandSrc, '---\ndescription: demo\n---\n\n# demo\n');
+
+  return { commandSrc };
+}
+
+/** Snapshot the manifest so the version reads as `fresh` (real sync, no mocks). */
+function syncSnapshot(): void {
+  execFileSync('bun', [INDEX, 'sync', 'claude@2.0.0', '-y', '--cwd', projectDir], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, HOME: testHome },
+    stdio: 'ignore',
+  });
+}
+
+function runCheck(...args: string[]): { status: number | null; stdout: string; stderr: string } {
+  const r = spawnSync('bun', [INDEX, 'check', '--cwd', projectDir, ...args], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, HOME: testHome },
+    encoding: 'utf-8',
+  });
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+describe('agents check — CI drift gate exit code', () => {
+  it('exits 0 when the install is clean (synced, sources unchanged)', () => {
+    seedHome();
+    syncSnapshot();
+
+    const r = runCheck();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('in sync');
+  });
+
+  it('exits non-zero when a source drifted since last sync', () => {
+    const { commandSrc } = seedHome();
+    syncSnapshot();
+    // Change the SOURCE after the snapshot — the exact drift doctor detects but
+    // never failed on.
+    fs.writeFileSync(commandSrc, '---\ndescription: demo CHANGED\n---\n\n# demo v2\n');
+
+    const r = runCheck();
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain('drift');
+  });
+
+  it('exits non-zero for a never-synced installed version (no manifest)', () => {
+    seedHome();
+    // No syncSnapshot() → no manifest → the version reads as never-synced.
+    const r = runCheck();
+    expect(r.status).not.toBe(0);
+  });
+
+  it('--json reports hasDrift and mirrors the exit code', () => {
+    const { commandSrc } = seedHome();
+    syncSnapshot();
+
+    const clean = runCheck('--json');
+    expect(clean.status).toBe(0);
+    expect(JSON.parse(clean.stdout).hasDrift).toBe(false);
+
+    fs.writeFileSync(commandSrc, '---\ndescription: changed again\n---\n\n# v3\n');
+    const drifted = runCheck('--json');
+    expect(drifted.status).not.toBe(0);
+    const parsed = JSON.parse(drifted.stdout);
+    expect(parsed.hasDrift).toBe(true);
+    expect(parsed.stale).toBe(1);
+  });
+});

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -1,0 +1,114 @@
+/**
+ * `agents check` — scriptable drift gate for CI.
+ *
+ * Runs the SAME drift/divergence diagnostic `agents doctor` computes (via the
+ * shared `computeDrift` in `../lib/drift.js`) and turns it into an exit code:
+ * non-zero when any installed version is stale or never-synced, zero when the
+ * whole install is fresh. `agents doctor` is the human report; `agents check`
+ * is the machine gate — same engine, different output.
+ *
+ * Orphans are surfaced informationally but never fail the check: they are a
+ * `prune` concern, not sync drift (mirrors the sync-status engine, where an
+ * orphan alone never flags needsSync).
+ */
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { AGENTS, ALL_AGENT_IDS } from '../lib/agents.js';
+import { setHelpSections } from '../lib/help.js';
+import { computeDrift, type SyncStatusRow } from '../lib/drift.js';
+
+const AGENT_NAMES: Record<string, string> = Object.fromEntries(
+  ALL_AGENT_IDS.map((id) => [id, AGENTS[id].name]),
+);
+
+interface CheckOptions {
+  json?: boolean;
+  quiet?: boolean;
+  cwd?: string;
+}
+
+function label(row: SyncStatusRow): string {
+  return `${AGENT_NAMES[row.agent] || row.agent}@${row.version}`;
+}
+
+export function registerCheckCommand(program: Command): void {
+  const checkCmd = program
+    .command('check')
+    .description('CI drift gate: exit non-zero when any installed version is out of sync (stale or never-synced), zero when clean.')
+    .option('--json', 'Output machine-readable JSON')
+    .option('-q, --quiet', 'Suppress per-version lines; print only the one-line verdict')
+    .option('--cwd <path>', 'Resolution cwd for project layer detection (default: process.cwd())');
+
+  setHelpSections(checkCmd, {
+    examples: `
+      # Fail the build if anything drifted (exit 1), pass if clean (exit 0)
+      agents check
+
+      # Just the verdict line, nothing per-version
+      agents check --quiet
+
+      # Machine-readable, for scripting
+      agents check --json
+
+      # Gate in a CI step
+      agents check || { echo "resources drifted — run 'agents doctor --fix'"; exit 1; }
+    `,
+  });
+
+  checkCmd.action((opts: CheckOptions) => {
+    const cwd = opts.cwd ? opts.cwd : process.cwd();
+    const drift = computeDrift(cwd);
+
+    if (opts.json) {
+      console.log(JSON.stringify({
+        hasDrift: drift.hasDrift,
+        stale: drift.staleCount,
+        neverSynced: drift.neverSyncedCount,
+        orphanVersions: drift.orphanVersionCount,
+        versions: drift.syncRows.map((r) => ({
+          agent: r.agent,
+          version: r.version,
+          status: r.status,
+          isDefault: r.isDefault,
+          divergence: r.divergence ?? [],
+        })),
+      }, null, 2));
+      process.exit(drift.hasDrift ? 1 : 0);
+    }
+
+    if (drift.syncRows.length === 0) {
+      // Nothing installed is a clean state, not a failure — CI on a fresh
+      // checkout with no versions should pass, not error.
+      console.log(chalk.gray('check: no installed versions — nothing to verify'));
+      process.exit(0);
+    }
+
+    if (!drift.hasDrift) {
+      const orphanNote = drift.orphanVersionCount > 0
+        ? chalk.gray(` (${drift.orphanVersionCount} version(s) carry orphans — run \`agents prune cleanup\`)`)
+        : '';
+      console.log(`${chalk.green('ok')}  ${drift.syncRows.length} version(s) in sync${orphanNote}`);
+      process.exit(0);
+    }
+
+    // Drift: one-line verdict always, per-version detail unless --quiet.
+    const parts: string[] = [];
+    if (drift.staleCount > 0) parts.push(`${drift.staleCount} stale`);
+    if (drift.neverSyncedCount > 0) parts.push(`${drift.neverSyncedCount} never-synced`);
+    console.error(`${chalk.red('drift')}  ${parts.join(', ')} of ${drift.syncRows.length} version(s)`);
+
+    if (!opts.quiet) {
+      for (const row of drift.syncRows) {
+        if (row.status === 'fresh') continue;
+        const tag = row.status === 'stale' ? chalk.yellow('stale') : chalk.gray('cold ');
+        console.error(`  ${tag}  ${label(row)}`);
+        for (const line of row.divergence ?? []) {
+          console.error(chalk.gray(`           ${line}`));
+        }
+      }
+      console.error(chalk.gray('\nReconcile with `agents doctor --fix` (or `agents doctor <agent>@<version> --fix`).'));
+    }
+
+    process.exit(1);
+  });
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -35,9 +35,6 @@ import {
   parseAgentSpec,
 } from '../lib/versions.js';
 import { loadManifest, isStale } from '../lib/staleness/index.js';
-import { diffVersionCommands, iterCommandsCapableVersions } from '../lib/commands.js';
-import { diffVersionSkills, iterSkillsCapableVersions } from '../lib/skills.js';
-import { iterHooksCapableVersions, listUnmanagedHooksInVersionHome } from '../lib/hooks.js';
 import {
   diffVersionResources,
   DOCTOR_ALL_KINDS,
@@ -45,6 +42,7 @@ import {
   type ResourceDiff,
   type VersionResourceReport,
 } from '../lib/doctor-diff.js';
+import { checkSyncStatus, countOrphans, type SyncStatusRow, type OrphanRow } from '../lib/drift.js';
 import { unifiedDiff, colorizeUnifiedDiff } from '../lib/diff-text.js';
 import { listCliStatus } from '../lib/cli-resources.js';
 import { setHelpSections } from '../lib/help.js';
@@ -65,47 +63,7 @@ interface DoctorOptions {
   fix?: boolean;
 }
 
-interface SyncStatusRow {
-  agent: AgentId;
-  version: string;
-  status: 'fresh' | 'stale' | 'never-synced';
-  isDefault: boolean;
-  /** For stale rows: prioritized lines naming exactly what diverged (plugins first). */
-  divergence?: string[];
-}
-
-interface OrphanRow {
-  agent: AgentId;
-  version: string;
-  commands: number;
-  skills: number;
-  hooks: number;
-}
-
 // ─── overview mode (no target) ────────────────────────────────────────────────
-
-// Lines naming exactly what's out of sync for a version, plugins prioritized:
-// each divergent plugin gets its own line with specifics (stale mirror version,
-// invalid manifest, or the bundled skills/commands missing from the mirror —
-// the system-repo plugin content that matters most). Other kinds collapse to
-// compact counts so the readout stays scannable.
-function divergenceLines(report: VersionResourceReport): string[] {
-  const lines: string[] = [];
-  for (const p of report.kinds.plugins) {
-    if (p.status === 'missing') lines.push(`plugin ${p.name} — not installed`);
-    else if (p.status === 'diff') lines.push(`plugin ${p.name} — ${p.detail ?? 'mirror drifted'}`);
-  }
-  for (const kind of ['commands', 'skills', 'hooks', 'rules', 'mcp', 'permissions', 'subagents'] as const) {
-    const rows = report.kinds[kind];
-    const miss = rows.filter((r) => r.status === 'missing').length;
-    const dif = rows.filter((r) => r.status === 'diff').length;
-    const bits: string[] = [];
-    if (miss) bits.push(`${miss} missing`);
-    if (dif) bits.push(`${dif} drifted`);
-    if (bits.length) lines.push(`${kind.padEnd(11)} ${bits.join(' · ')}`);
-  }
-  return lines;
-}
 
 function collapseWhitespace(s: string): string {
   return s.replace(/\s+/g, ' ').trim();
@@ -139,66 +97,6 @@ export function wrapLine(prefix: string, text: string, width = terminalWidth()):
 
 function printWrappedLine(prefix: string, text: string): void {
   for (const line of wrapLine(prefix, text)) console.log(chalk.gray(line));
-}
-
-function checkSyncStatus(cwd: string): SyncStatusRow[] {
-  const rows: SyncStatusRow[] = [];
-  // Every installed version, not just the default — a stale NON-default version
-  // (e.g. one you launched from yesterday) is exactly the rot that silently
-  // serves outdated/invalid resources and that `--fix` now heals. Hiding it here
-  // is why that class of bug went unnoticed.
-  for (const agent of ALL_AGENT_IDS) {
-    const def = getGlobalDefault(agent);
-    for (const version of listInstalledVersions(agent)) {
-      const manifest = loadManifest(agent, version);
-      const status: SyncStatusRow['status'] = !manifest
-        ? 'never-synced'
-        : isStale(manifest, agent, version, cwd) ? 'stale' : 'fresh';
-      const row: SyncStatusRow = { agent, version, status, isDefault: version === def };
-      if (status === 'stale') {
-        // Resolve the specifics against non-project layers (the global home is
-        // never reconciled against per-cwd project resources).
-        const report = diffVersionResources(agent, version, { cwd, excludeProject: true });
-        const lines = divergenceLines(report);
-        if (lines.length) row.divergence = lines;
-      }
-      rows.push(row);
-    }
-  }
-  return rows;
-}
-
-function countOrphans(): OrphanRow[] {
-  const byKey = new Map<string, OrphanRow>();
-
-  const ensure = (agent: AgentId, version: string): OrphanRow => {
-    const key = `${agent}@${version}`;
-    let row = byKey.get(key);
-    if (!row) {
-      row = { agent, version, commands: 0, skills: 0, hooks: 0 };
-      byKey.set(key, row);
-    }
-    return row;
-  };
-
-  for (const { agent, version } of iterCommandsCapableVersions()) {
-    const diff = diffVersionCommands(agent, version);
-    if (diff.orphans.length > 0) ensure(agent, version).commands = diff.orphans.length;
-  }
-  for (const { agent, version } of iterSkillsCapableVersions()) {
-    const diff = diffVersionSkills(agent, version);
-    if (diff.orphans.length > 0) ensure(agent, version).skills = diff.orphans.length;
-  }
-  // Orphan hooks are scripts in the version home that no agents.yaml/hooks.yaml
-  // entry registers — so the registrar never wires them to an event and they
-  // never fire. (Distinct from the source-diff `diffVersionHooks().orphans`,
-  // which false-flags valid system-sourced registered hooks.)
-  for (const { agent, version } of iterHooksCapableVersions()) {
-    const dead = listUnmanagedHooksInVersionHome(agent, version);
-    if (dead.length > 0) ensure(agent, version).hooks = dead.length;
-  }
-
-  return Array.from(byKey.values()).filter((r) => r.commands + r.skills + r.hooks > 0);
 }
 
 function renderOverviewText(

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,7 @@ import {
   loadTrash,
   loadRestore,
   loadDoctor,
+  loadCheck,
   loadStatus,
   loadProfiles,
   loadSecrets,
@@ -264,6 +265,7 @@ Credentials and profiles:
 
 Diagnostics:
   doctor [agent[@version]]        Diagnose CLI availability, sync status, and resource divergence
+  check                           CI drift gate: exit non-zero when resources are out of sync
   usage [agent]                   Show rate-limit and quota usage per agent
 
 Config sync:
@@ -917,6 +919,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadTrash);
   await reg(loadRestore);
   await reg(loadDoctor);
+  await reg(loadCheck);
   await reg(loadStatus);
   registerExecAliasCommand(program);
   await reg(loadProfiles);

--- a/src/lib/drift.ts
+++ b/src/lib/drift.ts
@@ -1,0 +1,155 @@
+/**
+ * Shared drift-detection internals for `agents doctor` (overview mode) and
+ * `agents check` (the scriptable, CI-friendly gate).
+ *
+ * This is the single source of truth for "is the install out of sync?": the
+ * per-version sync status (fresh / stale / never-synced) and the orphan census.
+ * `agents doctor` renders it as a human report; `agents check` reduces it to an
+ * exit code. Neither reimplements the diagnostic — both call `computeDrift`.
+ */
+import type { AgentId } from './types.js';
+import { ALL_AGENT_IDS } from './agents.js';
+import { getGlobalDefault, listInstalledVersions } from './versions.js';
+import { loadManifest, isStale } from './staleness/index.js';
+import { diffVersionResources, type VersionResourceReport } from './doctor-diff.js';
+import { diffVersionCommands, iterCommandsCapableVersions } from './commands.js';
+import { diffVersionSkills, iterSkillsCapableVersions } from './skills.js';
+import { iterHooksCapableVersions, listUnmanagedHooksInVersionHome } from './hooks.js';
+
+export interface SyncStatusRow {
+  agent: AgentId;
+  version: string;
+  status: 'fresh' | 'stale' | 'never-synced';
+  isDefault: boolean;
+  /** For stale rows: prioritized lines naming exactly what diverged (plugins first). */
+  divergence?: string[];
+}
+
+export interface OrphanRow {
+  agent: AgentId;
+  version: string;
+  commands: number;
+  skills: number;
+  hooks: number;
+}
+
+// Lines naming exactly what's out of sync for a version, plugins prioritized:
+// each divergent plugin gets its own line with specifics (stale mirror version,
+// invalid manifest, or the bundled skills/commands missing from the mirror —
+// the system-repo plugin content that matters most). Other kinds collapse to
+// compact counts so the readout stays scannable.
+export function divergenceLines(report: VersionResourceReport): string[] {
+  const lines: string[] = [];
+  for (const p of report.kinds.plugins) {
+    if (p.status === 'missing') lines.push(`plugin ${p.name} — not installed`);
+    else if (p.status === 'diff') lines.push(`plugin ${p.name} — ${p.detail ?? 'mirror drifted'}`);
+  }
+  for (const kind of ['commands', 'skills', 'hooks', 'rules', 'mcp', 'permissions', 'subagents'] as const) {
+    const rows = report.kinds[kind];
+    const miss = rows.filter((r) => r.status === 'missing').length;
+    const dif = rows.filter((r) => r.status === 'diff').length;
+    const bits: string[] = [];
+    if (miss) bits.push(`${miss} missing`);
+    if (dif) bits.push(`${dif} drifted`);
+    if (bits.length) lines.push(`${kind.padEnd(11)} ${bits.join(' · ')}`);
+  }
+  return lines;
+}
+
+export function checkSyncStatus(cwd: string): SyncStatusRow[] {
+  const rows: SyncStatusRow[] = [];
+  // Every installed version, not just the default — a stale NON-default version
+  // (e.g. one you launched from yesterday) is exactly the rot that silently
+  // serves outdated/invalid resources and that `--fix` now heals. Hiding it here
+  // is why that class of bug went unnoticed.
+  for (const agent of ALL_AGENT_IDS) {
+    const def = getGlobalDefault(agent);
+    for (const version of listInstalledVersions(agent)) {
+      const manifest = loadManifest(agent, version);
+      const status: SyncStatusRow['status'] = !manifest
+        ? 'never-synced'
+        : isStale(manifest, agent, version, cwd) ? 'stale' : 'fresh';
+      const row: SyncStatusRow = { agent, version, status, isDefault: version === def };
+      if (status === 'stale') {
+        // Resolve the specifics against non-project layers (the global home is
+        // never reconciled against per-cwd project resources).
+        const report = diffVersionResources(agent, version, { cwd, excludeProject: true });
+        const lines = divergenceLines(report);
+        if (lines.length) row.divergence = lines;
+      }
+      rows.push(row);
+    }
+  }
+  return rows;
+}
+
+export function countOrphans(): OrphanRow[] {
+  const byKey = new Map<string, OrphanRow>();
+
+  const ensure = (agent: AgentId, version: string): OrphanRow => {
+    const key = `${agent}@${version}`;
+    let row = byKey.get(key);
+    if (!row) {
+      row = { agent, version, commands: 0, skills: 0, hooks: 0 };
+      byKey.set(key, row);
+    }
+    return row;
+  };
+
+  for (const { agent, version } of iterCommandsCapableVersions()) {
+    const diff = diffVersionCommands(agent, version);
+    if (diff.orphans.length > 0) ensure(agent, version).commands = diff.orphans.length;
+  }
+  for (const { agent, version } of iterSkillsCapableVersions()) {
+    const diff = diffVersionSkills(agent, version);
+    if (diff.orphans.length > 0) ensure(agent, version).skills = diff.orphans.length;
+  }
+  // Orphan hooks are scripts in the version home that no agents.yaml/hooks.yaml
+  // entry registers — so the registrar never wires them to an event and they
+  // never fire. (Distinct from the source-diff `diffVersionHooks().orphans`,
+  // which false-flags valid system-sourced registered hooks.)
+  for (const { agent, version } of iterHooksCapableVersions()) {
+    const dead = listUnmanagedHooksInVersionHome(agent, version);
+    if (dead.length > 0) ensure(agent, version).hooks = dead.length;
+  }
+
+  return Array.from(byKey.values()).filter((r) => r.commands + r.skills + r.hooks > 0);
+}
+
+export interface DriftSummary {
+  syncRows: SyncStatusRow[];
+  orphanRows: OrphanRow[];
+  /** Versions whose sources changed since last sync. */
+  staleCount: number;
+  /** Versions installed but never synced. */
+  neverSyncedCount: number;
+  /** Versions carrying orphan resources (informational — not a drift signal). */
+  orphanVersionCount: number;
+  /**
+   * True when any installed version is stale or never-synced — the exact signal
+   * `agents doctor` surfaces as "run `agents status` to review what has drifted".
+   * Orphans are a `prune` concern, not sync drift, so they do NOT set this flag
+   * (mirrors the sync-status engine: an orphan alone never flags needsSync).
+   */
+  hasDrift: boolean;
+}
+
+/**
+ * Compute the same drift/divergence diagnostic `agents doctor` prints, reduced
+ * to a summary with a single `hasDrift` boolean. The gate `agents check` maps
+ * to an exit code; the readout `agents doctor` renders in full.
+ */
+export function computeDrift(cwd: string): DriftSummary {
+  const syncRows = checkSyncStatus(cwd);
+  const orphanRows = countOrphans();
+  const staleCount = syncRows.filter((r) => r.status === 'stale').length;
+  const neverSyncedCount = syncRows.filter((r) => r.status === 'never-synced').length;
+  return {
+    syncRows,
+    orphanRows,
+    staleCount,
+    neverSyncedCount,
+    orphanVersionCount: orphanRows.length,
+    hasDrift: syncRows.some((r) => r.status !== 'fresh'),
+  };
+}

--- a/src/lib/startup/command-registry.ts
+++ b/src/lib/startup/command-registry.ts
@@ -55,6 +55,7 @@ export const loadPrune: ModuleLoader = async () => (await import('../../commands
 export const loadTrash: ModuleLoader = async () => (await import('../../commands/trash.js')).registerTrashCommands;
 export const loadRestore: ModuleLoader = async () => (await import('../../commands/trash.js')).registerRestoreCommand;
 export const loadDoctor: ModuleLoader = async () => (await import('../../commands/doctor.js')).registerDoctorCommand;
+export const loadCheck: ModuleLoader = async () => (await import('../../commands/check.js')).registerCheckCommand;
 export const loadStatus: ModuleLoader = async () => (await import('../../commands/status.js')).registerStatusCommand;
 export const loadProfiles: ModuleLoader = async () => (await import('../../commands/profiles.js')).registerProfilesCommands;
 export const loadSecrets: ModuleLoader = async () => (await import('../../commands/secrets.js')).registerSecretsCommands;
@@ -145,6 +146,7 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   trash: [loadTrash],
   restore: [loadRestore],
   doctor: [loadDoctor],
+  check: [loadCheck],
   status: [loadStatus],
   profiles: [loadProfiles],
   secrets: [loadSecrets],


### PR DESCRIPTION
## What

Adds `agents check` — a scriptable, CI-friendly drift gate.

`agents doctor` with no target returned **0 even when there was resource drift** (`src/commands/doctor.ts` — it printed a hint and returned). There was no command that exits non-zero on drift for use in CI. `agents check` fills that gap.

- **Exit code**: non-zero when any installed version is `stale` or `never-synced`, `0` when the whole install is fresh — the exact signal doctor's overview surfaces (`syncRows.some(r => r.status !== 'fresh')`).
- **Output**: concise one-line verdict by default (`ok  N version(s) in sync` / `drift  N stale of N version(s)` + per-version detail). Flags kept minimal: `--quiet` (verdict only), `--json`, `--cwd`.
- Orphans are surfaced informationally but **never fail the check** — they're a `prune` concern, not sync drift (mirrors the sync-status engine, where an orphan alone never flags `needsSync`).

## Reused doctor internals (no reimplementation)

Extracted doctor's inline drift logic — `checkSyncStatus`, `countOrphans`, `divergenceLines` — into `src/lib/drift.ts` behind a shared `computeDrift(cwd)`. `doctor.ts` now imports them; its overview is **behaviorally unchanged** (same functions, same call sites). `check` calls the same `computeDrift` and just maps `hasDrift` to an exit code.

Files:
- `src/lib/drift.ts` (new) — shared drift engine + `computeDrift`
- `src/commands/check.ts` (new) — the command
- `src/commands/doctor.ts` — imports the extracted functions instead of defining them inline
- `src/index.ts`, `src/lib/startup/command-registry.ts` — command registration + help line

## Test

`src/commands/check.test.ts` — real temp HOME, real `agents sync` to snapshot the manifest, real CLI subprocess, **no mocks**:
- clean install → exit 0
- a source changed after sync → exit non-zero (`drift` on stderr)
- a never-synced installed version → exit non-zero
- `--json` reports `hasDrift` and mirrors the exit code

Fails pre-change (the command didn't exist). Passing locally:

```
Test Files  4 passed (4)   # check + doctor + sync-status + drift-sync
     Tests  16 passed (16)
```
`bunx tsc --noEmit` clean.