### PR TITLE
feat(secrets): --keys subset injection + expiry pre-run abort (Closes #328)

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -59,6 +59,8 @@ interface ExecCommandActionOptions {
   any?: boolean;
   lease?: string | boolean; // --lease [backend]: true when bare, backend string when given
   keepBox?: boolean; // --keep-box: don't tear down the leased box after the run
+  secretsKeys?: string; // --secrets-keys: comma-separated key subset for --secrets bundles
+  allowExpired?: boolean; // --allow-expired: skip expiry pre-run abort for secrets
 }
 
 /** Type guard that narrows a string to a known AgentId. */
@@ -184,6 +186,11 @@ export function registerRunCommand(program: Command): void {
       '--no-auto-secrets',
       'Skip auto-injection of secrets declared by a workflow\'s frontmatter `secrets:` field. Has no effect on bare-agent runs.',
     )
+    .option(
+      '--secrets-keys <keys>',
+      'Inject only this comma-separated subset of keys from --secrets bundles (e.g. KEY1,KEY2). Missing keys are an error. Applies to all --secrets bundles on this run.',
+    )
+    .option('--allow-expired', 'Inject secrets even if their expiry date has passed (overrides the pre-run expiry abort).')
     .option('--cwd <dir>', 'Working directory for the agent (defaults to current directory)')
     .option(
       '--add-dir <dir>',
@@ -987,6 +994,9 @@ export function registerRunCommand(program: Command): void {
       // Resolve --secrets bundles in flag order. Later bundles override earlier
       // ones. Any resolution failure (missing keychain item, blocked exec ref)
       // aborts before spawn so the agent never sees a partial env.
+      const secretsKeysSubset = options.secretsKeys
+        ? options.secretsKeys.split(',').map((k: string) => k.trim()).filter(Boolean)
+        : undefined;
       let secretsEnv: Record<string, string> = {};
       for (const bundleRef of options.secrets) {
         try {
@@ -999,7 +1009,11 @@ export function registerRunCommand(program: Command): void {
             console.log(chalk.gray(`[secrets] Resolved ${bundleName}@${host}: ${Object.keys(bundleEnv).length} keys (remote, ephemeral)`));
             secretsEnv = { ...secretsEnv, ...bundleEnv };
           } else {
-            const { bundle, env: bundleEnv } = readAndResolveBundleEnv(bundleName, { caller: `agent ${agent}` });
+            const { bundle, env: bundleEnv } = readAndResolveBundleEnv(bundleName, {
+              caller: `agent ${agent}`,
+              keys: secretsKeysSubset,
+              allowExpired: options.allowExpired,
+            });
             const entries = describeBundle(bundle);
             const counts: Record<string, number> = {};
             for (const e of entries) {

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -524,7 +524,7 @@ export function registerRunCommand(program: Command): void {
         { buildExecCommand, parseExecEnv, execAgent, runWithFallback, normalizeMode, resolveMode, defaultModeFor, headlessPlanStallCommand, nativeResume, resolveInteractive },
         { ALL_AGENT_IDS },
         { profileExists, resolveProfileForRun },
-        { readAndResolveBundleEnv, describeBundle },
+        { readAndResolveBundleEnv, describeBundle, assertRemoteBundleFlagsUnsupported },
         { splitBundleRef, resolveSshTarget, remoteResolveEnv },
         { getConfiguredRunStrategy, normalizeRunStrategy, resolveRunVersion, RUN_STRATEGIES },
         { getGlobalDefault, getVersionHomePath, resolveVersion, resolveVersionAlias },
@@ -1002,6 +1002,16 @@ export function registerRunCommand(program: Command): void {
         try {
           const { bundle: bundleName, host } = splitBundleRef(bundleRef);
           if (host) {
+            // Least-privilege flags (--secrets-keys / --allow-expired) do not
+            // yet cross the SSH resolver — silently applying them would inject
+            // the full remote env or an expired key. Fail loud so the user
+            // can drop the flag or resolve locally instead.
+            assertRemoteBundleFlagsUnsupported(
+              bundleName,
+              host,
+              { keys: secretsKeysSubset, allowExpired: options.allowExpired },
+              { keysFlag: '--secrets-keys', allowExpiredFlag: '--allow-expired' },
+            );
             // Remote bundle (`bundle@host`): resolve over SSH and inject
             // ephemerally — values never touch this machine's keychain or disk.
             const target = await resolveSshTarget(host);

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -1419,6 +1419,17 @@ Examples:
           : undefined;
         let secretEnv: Record<string, string>;
         if (execOpts.host) {
+          // Least-privilege flags do not yet cross the SSH resolver —
+          // silently applying them would inject the full remote env or an
+          // expired key. Fail loud so the user can drop the flag or run
+          // locally instead.
+          const { assertRemoteBundleFlagsUnsupported } = await import('../lib/secrets/bundles.js');
+          assertRemoteBundleFlagsUnsupported(
+            bundleName,
+            execOpts.host,
+            { keys: keysSubset, allowExpired: execOpts.allowExpired },
+            { keysFlag: '--keys', allowExpiredFlag: '--allow-expired' },
+          );
           secretEnv = await remoteResolveEnv(await resolveSshTarget(execOpts.host), bundleName);
         } else {
           const { readAndResolveBundleEnv } = await import('../lib/secrets/bundles.js');

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -1404,20 +1404,29 @@ Examples:
     .command('exec <bundle> [command...]')
     .description('Run a command with the bundle\'s secrets injected into the environment (use --host to resolve the bundle from a remote machine, ephemerally)')
     .option('--host <target>', 'Resolve <bundle> on a remote host over SSH and inject it (ephemeral — never stored on this machine)')
+    .option('--keys <keys>', 'Inject only this comma-separated subset of keys (e.g. KEY1,KEY2). Missing keys are an error.')
+    .option('--allow-expired', 'Inject keys even if their expiry date has passed (overrides the pre-run expiry abort).')
     .allowUnknownOption()
-    .action(async (bundleName: string, commandParts: string[], execOpts: { host?: string }) => {
+    .action(async (bundleName: string, commandParts: string[], execOpts: { host?: string; keys?: string; allowExpired?: boolean }) => {
       try {
         if (commandParts.length === 0) {
           console.error(chalk.red('Usage: agents secrets exec <bundle> -- <command...>'));
           process.exit(1);
         }
         const [cmd, ...args] = commandParts;
+        const keysSubset = execOpts.keys
+          ? execOpts.keys.split(',').map((k) => k.trim()).filter(Boolean)
+          : undefined;
         let secretEnv: Record<string, string>;
         if (execOpts.host) {
           secretEnv = await remoteResolveEnv(await resolveSshTarget(execOpts.host), bundleName);
         } else {
           const { readAndResolveBundleEnv } = await import('../lib/secrets/bundles.js');
-          secretEnv = readAndResolveBundleEnv(bundleName, { caller: `command ${cmd}` }).env;
+          secretEnv = readAndResolveBundleEnv(bundleName, {
+            caller: `command ${cmd}`,
+            keys: keysSubset,
+            allowExpired: execOpts.allowExpired,
+          }).env;
         }
         const { spawn } = await import('child_process');
         // On Windows, spawn without a shell ENOENTs for `.cmd`/`.bat` launchers

--- a/src/lib/secrets/__tests__/bundles.test.ts
+++ b/src/lib/secrets/__tests__/bundles.test.ts
@@ -147,3 +147,96 @@ describe('describeBundle + resolveBundleEnv', () => {
     expect(items.find((i) => i.key === 'B')?.item).toBe('agents-cli.secrets.unit.KEY_B');
   });
 });
+
+describe('resolveBundleEnv -- keys subset injection', () => {
+  function b(vars: Record<string, any>, extra: Partial<SecretsBundle> = {}): SecretsBundle {
+    return { name: 'sub', vars, ...extra };
+  }
+
+  it('injects only the requested keys', () => {
+    const bundle = b({ A: 'alpha', B: 'beta', C: 'gamma' });
+    const env = resolveBundleEnv(bundle, { keys: ['A', 'C'] });
+    expect(env).toEqual({ A: 'alpha', C: 'gamma' });
+    expect(env).not.toHaveProperty('B');
+  });
+
+  it('injects all keys when keys option is absent', () => {
+    const bundle = b({ X: 'x', Y: 'y' });
+    expect(resolveBundleEnv(bundle)).toEqual({ X: 'x', Y: 'y' });
+  });
+
+  it('throws a clear error when a requested key is absent from the bundle', () => {
+    const bundle = b({ REAL: 'value' });
+    expect(() => resolveBundleEnv(bundle, { keys: ['REAL', 'MISSING'] }))
+      .toThrow(/does not contain key\(s\): MISSING/);
+  });
+
+  it('includes the available keys in the missing-key error', () => {
+    const bundle = b({ FOO: 'f', BAR: 'b' });
+    expect(() => resolveBundleEnv(bundle, { keys: ['NOPE'] }))
+      .toThrow(/Available: /);
+  });
+
+  it('treats an empty keys array as inject-all (no keys requested = all)', () => {
+    const bundle = b({ P: 'p', Q: 'q' });
+    expect(resolveBundleEnv(bundle, { keys: [] })).toEqual({ P: 'p', Q: 'q' });
+  });
+});
+
+describe('resolveBundleEnv -- expiry pre-run abort', () => {
+  function b(vars: Record<string, any>, extra: Partial<SecretsBundle> = {}): SecretsBundle {
+    return { name: 'exp', vars, ...extra };
+  }
+
+  const yesterday = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const tomorrow = new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+  it('aborts when a selected key is expired', () => {
+    const bundle = b(
+      { SECRET: 'val' },
+      { meta: { SECRET: { expires: yesterday } } },
+    );
+    expect(() => resolveBundleEnv(bundle)).toThrow(/expired on/);
+  });
+
+  it('includes the key name in the expiry error', () => {
+    const bundle = b(
+      { MY_KEY: 'v' },
+      { meta: { MY_KEY: { expires: yesterday } } },
+    );
+    expect(() => resolveBundleEnv(bundle)).toThrow(/MY_KEY/);
+  });
+
+  it('does not abort when the key is not yet expired', () => {
+    const bundle = b(
+      { FRESH: 'value' },
+      { meta: { FRESH: { expires: tomorrow } } },
+    );
+    expect(resolveBundleEnv(bundle)).toEqual({ FRESH: 'value' });
+  });
+
+  it('does not abort when allowExpired is true', () => {
+    const bundle = b(
+      { STALE: 'val' },
+      { meta: { STALE: { expires: yesterday } } },
+    );
+    expect(resolveBundleEnv(bundle, { allowExpired: true })).toEqual({ STALE: 'val' });
+  });
+
+  it('only checks expiry on selected keys (not excluded ones)', () => {
+    const bundle = b(
+      { WANTED: 'w', OLD: 'o' },
+      { meta: { OLD: { expires: yesterday } } },
+    );
+    // Requesting only WANTED; OLD is expired but excluded — no abort.
+    expect(resolveBundleEnv(bundle, { keys: ['WANTED'] })).toEqual({ WANTED: 'w' });
+  });
+
+  it('aborts if a requested key is expired even with other healthy keys', () => {
+    const bundle = b(
+      { FRESH: 'f', STALE: 's' },
+      { meta: { STALE: { expires: yesterday } } },
+    );
+    expect(() => resolveBundleEnv(bundle, { keys: ['FRESH', 'STALE'] })).toThrow(/expired on/);
+  });
+});

--- a/src/lib/secrets/bundles.test.ts
+++ b/src/lib/secrets/bundles.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filterAgentHitBySubsetAndExpiry,
+  assertRemoteBundleFlagsUnsupported,
+  type SecretsBundle,
+} from './bundles.js';
+
+/**
+ * Regression tests for the two least-privilege bypasses on the
+ * `--secrets X --secrets-keys K [--allow-expired]` path.
+ *
+ * Pre-fix, `readAndResolveBundleEnv`'s secrets-agent fast-path returned the
+ * cached snapshot verbatim — so once the broker had the bundle, `--keys`
+ * silently injected every key and an expired key silently flowed through.
+ * These tests drive the extracted helper (`filterAgentHitBySubsetAndExpiry`)
+ * that the fast-path now runs before returning the hit.
+ *
+ * The remote (`bundle@host`) path also ignored those flags; the shared
+ * `assertRemoteBundleFlagsUnsupported` guard now fails loud instead of
+ * silently dropping them.
+ */
+
+const YESTERDAY = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+const TOMORROW = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+function agentHit(
+  vars: Record<string, string>,
+  meta: SecretsBundle['meta'] = undefined,
+): { bundle: SecretsBundle; env: Record<string, string> } {
+  const bundle: SecretsBundle = {
+    name: 'prod',
+    vars,
+    meta,
+  };
+  // The broker caches the fully-resolved env — one entry per var, values
+  // already fetched from keychain. Mirror that shape here.
+  const env: Record<string, string> = {};
+  for (const k of Object.keys(vars)) env[k] = `v-${k}`;
+  return { bundle, env };
+}
+
+describe('filterAgentHitBySubsetAndExpiry (agent fast-path gate)', () => {
+  it('returns the cached hit untouched when no --keys / --allow-expired is set', () => {
+    const hit = agentHit({ API_KEY: 'k', DB_URL: 'k' });
+    const out = filterAgentHitBySubsetAndExpiry(hit, {});
+    // Same reference — the hot path should not re-allocate for the default flow.
+    expect(out).toBe(hit);
+    expect(out.env).toEqual({ API_KEY: 'v-API_KEY', DB_URL: 'v-DB_URL' });
+  });
+
+  it('narrows the returned env to the requested subset (least-privilege honoured on fast-path)', () => {
+    // Pre-fix: the fast-path returned all 3 keys regardless of `keys`.
+    const hit = agentHit({ API_KEY: 'k', DB_URL: 'k', SLACK_TOKEN: 'k' });
+    const out = filterAgentHitBySubsetAndExpiry(hit, { keys: ['API_KEY'] });
+    expect(Object.keys(out.env).sort()).toEqual(['API_KEY']);
+    expect(out.env.API_KEY).toBe('v-API_KEY');
+    expect(out.env.DB_URL).toBeUndefined();
+    expect(out.env.SLACK_TOKEN).toBeUndefined();
+  });
+
+  it('throws a fail-loud error if a requested key is not in the bundle', () => {
+    const hit = agentHit({ API_KEY: 'k' });
+    expect(() => filterAgentHitBySubsetAndExpiry(hit, { keys: ['GHOST'] }))
+      .toThrow(/does not contain key\(s\): GHOST/);
+  });
+
+  it('aborts on an expired key (pre-fix the agent snapshot silently injected it)', () => {
+    const hit = agentHit(
+      { API_KEY: 'k', DB_URL: 'k' },
+      { API_KEY: { expires: YESTERDAY } },
+    );
+    // No --keys: every key is selected, so the expired one aborts.
+    expect(() => filterAgentHitBySubsetAndExpiry(hit, {}))
+      .toThrow(/API_KEY' expired on/);
+    // Requested a still-valid key: no abort, and DB_URL comes through.
+    const out = filterAgentHitBySubsetAndExpiry(hit, { keys: ['DB_URL'] });
+    expect(Object.keys(out.env)).toEqual(['DB_URL']);
+    // Requested the expired key without --allow-expired: aborts.
+    expect(() => filterAgentHitBySubsetAndExpiry(hit, { keys: ['API_KEY'] }))
+      .toThrow(/API_KEY' expired on/);
+  });
+
+  it('honours --allow-expired: injects the expired key without aborting', () => {
+    const hit = agentHit(
+      { API_KEY: 'k' },
+      { API_KEY: { expires: YESTERDAY } },
+    );
+    const out = filterAgentHitBySubsetAndExpiry(hit, { keys: ['API_KEY'], allowExpired: true });
+    expect(out.env).toEqual({ API_KEY: 'v-API_KEY' });
+  });
+
+  it('does not abort on a future expiry', () => {
+    const hit = agentHit(
+      { API_KEY: 'k' },
+      { API_KEY: { expires: TOMORROW } },
+    );
+    const out = filterAgentHitBySubsetAndExpiry(hit, { keys: ['API_KEY'] });
+    expect(out.env).toEqual({ API_KEY: 'v-API_KEY' });
+  });
+});
+
+describe('assertRemoteBundleFlagsUnsupported (remote bundle guard)', () => {
+  const labels = { keysFlag: '--secrets-keys', allowExpiredFlag: '--allow-expired' };
+
+  it('is a no-op when neither flag is set (remote resolve proceeds as before)', () => {
+    expect(() => assertRemoteBundleFlagsUnsupported('prod', 'host', {}, labels)).not.toThrow();
+    expect(() => assertRemoteBundleFlagsUnsupported('prod', 'host', { keys: [] }, labels)).not.toThrow();
+  });
+
+  it('throws a clear error when --keys narrows a remote bundle (pre-fix: silently ignored)', () => {
+    expect(() => assertRemoteBundleFlagsUnsupported('prod', 'yosemite', { keys: ['API_KEY'] }, labels))
+      .toThrow(/Bundle 'prod@yosemite': --secrets-keys and --allow-expired are not supported for remote/);
+  });
+
+  it('throws a clear error when --allow-expired is combined with a remote bundle', () => {
+    expect(() => assertRemoteBundleFlagsUnsupported('prod', 'yosemite', { allowExpired: true }, labels))
+      .toThrow(/not supported for remote \(bundle@host\) bundles/);
+  });
+
+  it('renders the caller-supplied flag labels (secrets exec uses --keys, run uses --secrets-keys)', () => {
+    expect(() =>
+      assertRemoteBundleFlagsUnsupported('prod', 'yosemite', { keys: ['A'] }, {
+        keysFlag: '--keys',
+        allowExpiredFlag: '--allow-expired',
+      }),
+    ).toThrow(/--keys and --allow-expired are not supported/);
+  });
+});

--- a/src/lib/secrets/bundles.ts
+++ b/src/lib/secrets/bundles.ts
@@ -650,6 +650,75 @@ function assertNotExpired(bundle: SecretsBundle, selectedKeys: string[], allowEx
   }
 }
 
+/**
+ * Resolve the requested key subset against a bundle's `vars` map. Throws a
+ * fail-loud error listing available keys if any requested key is absent. When
+ * `requested` is undefined or empty, every key in the bundle is selected.
+ */
+function selectRequestedKeys(bundle: SecretsBundle, requested: string[] | undefined): Set<string> {
+  const req = requested?.length ? requested : undefined;
+  if (req) {
+    const missing = req.filter((k) => !(k in bundle.vars));
+    if (missing.length > 0) {
+      const available = Object.keys(bundle.vars).join(', ') || '(none)';
+      throw new Error(
+        `Bundle '${bundle.name}' does not contain key(s): ${missing.join(', ')}. Available: ${available}.`,
+      );
+    }
+  }
+  return new Set(req ?? Object.keys(bundle.vars));
+}
+
+/**
+ * Apply the --keys subset + expiry gate to an already-resolved snapshot from
+ * the secrets-agent fast-path. The agent stores the FULL bundle env, so a
+ * naive fast-path return would silently defeat --keys and inject expired
+ * values. Mirrors the slow-path pre-checks in `resolveBundleEnv` /
+ * `readAndResolveBundleEnv` and returns a new env whose keys match the subset.
+ *
+ * Exported for tests; production callers reach it via the fast-path branch in
+ * `readAndResolveBundleEnv`.
+ */
+export function filterAgentHitBySubsetAndExpiry(
+  hit: { bundle: SecretsBundle; env: Record<string, string> },
+  opts: ResolveBundleOptions,
+): { bundle: SecretsBundle; env: Record<string, string> } {
+  const selectedKeys = selectRequestedKeys(hit.bundle, opts.keys);
+  assertNotExpired(hit.bundle, [...selectedKeys], opts.allowExpired ?? false);
+  // When no subset was requested, return the cached env untouched — same
+  // reference the agent handed back, so no per-call allocation on the hot path.
+  if (!opts.keys?.length) return hit;
+  const env: Record<string, string> = {};
+  for (const key of selectedKeys) {
+    if (key in hit.env) env[key] = hit.env[key];
+  }
+  return { bundle: hit.bundle, env };
+}
+
+/**
+ * Guard for remote-bundle callers (`bundle@host` / `--host`) — the SSH
+ * resolver in `remoteResolveEnv` does not thread --keys or --allow-expired
+ * yet. Silently applying them would inject the full remote env or an expired
+ * value, defeating the least-privilege intent, so we fail loud.
+ *
+ * Exported so `agents run --secrets bundle@host` and `agents secrets exec
+ * --host` share the exact same error text; the tests exercise this helper
+ * directly instead of driving the whole CLI.
+ */
+export function assertRemoteBundleFlagsUnsupported(
+  bundleName: string,
+  host: string,
+  opts: { keys?: string[]; allowExpired?: boolean },
+  flagLabels: { keysFlag: string; allowExpiredFlag: string },
+): void {
+  const hasKeys = Array.isArray(opts.keys) && opts.keys.length > 0;
+  if (!hasKeys && !opts.allowExpired) return;
+  throw new Error(
+    `Bundle '${bundleName}@${host}': ${flagLabels.keysFlag} and ${flagLabels.allowExpiredFlag} are not supported for remote (bundle@host) bundles yet. ` +
+    `Drop the flag or resolve the bundle locally.`,
+  );
+}
+
 // Walk the bundle and produce a flat env map. Every keychain: ref is gathered
 // into a single batch read so macOS shows ONE Touch ID prompt for the whole
 // bundle — including the metadata fetch that already happened in readBundle
@@ -661,17 +730,7 @@ export function resolveBundleEnv(bundle: SecretsBundle, _opts: ResolveBundleOpti
   stampLastUsed(bundle);
 
   // Key-subset validation and expiry pre-check.
-  const requestedKeys = _opts.keys?.length ? _opts.keys : undefined;
-  if (requestedKeys) {
-    const missing = requestedKeys.filter((k) => !(k in bundle.vars));
-    if (missing.length > 0) {
-      const available = Object.keys(bundle.vars).join(', ') || '(none)';
-      throw new Error(
-        `Bundle '${bundle.name}' does not contain key(s): ${missing.join(', ')}. Available: ${available}.`,
-      );
-    }
-  }
-  const selectedKeys = new Set(requestedKeys ?? Object.keys(bundle.vars));
+  const selectedKeys = selectRequestedKeys(bundle, _opts.keys);
   assertNotExpired(bundle, [...selectedKeys], _opts.allowExpired ?? false);
 
   type Parsed = { literal: string } | { ref: SecretRef };
@@ -755,15 +814,20 @@ export function readAndResolveBundleEnv(
   if (backend === 'keychain' && !opts.noAgent && process.env.AGENTS_SECRETS_NO_AGENT !== '1') {
     const hit = agentGetSync(name);
     if (hit) {
-      stampLastUsed(hit.bundle);
+      // The agent stores the FULL bundle env. Apply the same subset filter and
+      // expiry gate as the slow path — without this, `--secrets-keys X` would
+      // silently inject every key and an expired key would flow through after
+      // the first cache-populating run.
+      const filtered = filterAgentHitBySubsetAndExpiry(hit, opts);
+      stampLastUsed(filtered.bundle);
       emit('secrets.get', {
         bundle: name,
         caller: opts.caller,
         status: 'success',
         source: 'agent',
-        keyCount: Object.keys(hit.env).length,
+        keyCount: Object.keys(filtered.env).length,
       });
-      return hit;
+      return filtered;
     }
   }
 
@@ -826,17 +890,7 @@ export function readAndResolveBundleEnv(
   }
 
   // Key-subset validation and expiry pre-check (mirrors resolveBundleEnv logic).
-  const requestedKeys = opts.keys?.length ? opts.keys : undefined;
-  if (requestedKeys) {
-    const missing = requestedKeys.filter((k) => !(k in bundle.vars));
-    if (missing.length > 0) {
-      const available = Object.keys(bundle.vars).join(', ') || '(none)';
-      throw new Error(
-        `Bundle '${name}' does not contain key(s): ${missing.join(', ')}. Available: ${available}.`,
-      );
-    }
-  }
-  const selectedKeys = new Set(requestedKeys ?? Object.keys(bundle.vars));
+  const selectedKeys = selectRequestedKeys(bundle, opts.keys);
   assertNotExpired(bundle, [...selectedKeys], opts.allowExpired ?? false);
 
   stampLastUsed(bundle);

--- a/src/lib/secrets/bundles.ts
+++ b/src/lib/secrets/bundles.ts
@@ -611,6 +611,43 @@ export interface ResolveBundleOptions {
    * needs live values. Also honored via AGENTS_SECRETS_NO_AGENT=1.
    */
   noAgent?: boolean;
+  /**
+   * Inject only this subset of keys from the bundle. Keys not in this list are
+   * silently excluded from the returned env map. An error is thrown if any
+   * requested key is absent from the bundle (fail-loud, never silent skip).
+   * When absent or empty, all keys are injected (original behaviour).
+   */
+  keys?: string[];
+  /**
+   * When true, skip the pre-run expiry check and inject keys even if their
+   * `expires` date is in the past. By default any expired key (or a key whose
+   * bundle-level expiry has passed) aborts the run before Touch ID is popped.
+   */
+  allowExpired?: boolean;
+}
+
+/**
+ * Abort if any of the selected keys has an `expires` date in the past.
+ * Bundle-level expiry is not a concept today (expiry is per-key via `meta`),
+ * so we iterate only the per-key meta entries.
+ */
+function assertNotExpired(bundle: SecretsBundle, selectedKeys: string[], allowExpired: boolean): void {
+  if (allowExpired) return;
+  if (!bundle.meta) return;
+  const now = Date.now();
+  for (const key of selectedKeys) {
+    const meta = bundle.meta[key];
+    if (!meta?.expires) continue;
+    // expires is 'YYYY-MM-DD'; treat as end-of-day UTC.
+    const expiry = new Date(meta.expires + 'T23:59:59Z').getTime();
+    if (expiry < now) {
+      throw new Error(
+        `Bundle '${bundle.name}' key '${key}' expired on ${meta.expires}. ` +
+        `Rotate it with: agents secrets rotate ${bundle.name} ${key}` +
+        ` (or pass --allow-expired to skip this check).`,
+      );
+    }
+  }
 }
 
 // Walk the bundle and produce a flat env map. Every keychain: ref is gathered
@@ -623,10 +660,25 @@ export interface ResolveBundleOptions {
 export function resolveBundleEnv(bundle: SecretsBundle, _opts: ResolveBundleOptions = {}): Record<string, string> {
   stampLastUsed(bundle);
 
+  // Key-subset validation and expiry pre-check.
+  const requestedKeys = _opts.keys?.length ? _opts.keys : undefined;
+  if (requestedKeys) {
+    const missing = requestedKeys.filter((k) => !(k in bundle.vars));
+    if (missing.length > 0) {
+      const available = Object.keys(bundle.vars).join(', ') || '(none)';
+      throw new Error(
+        `Bundle '${bundle.name}' does not contain key(s): ${missing.join(', ')}. Available: ${available}.`,
+      );
+    }
+  }
+  const selectedKeys = new Set(requestedKeys ?? Object.keys(bundle.vars));
+  assertNotExpired(bundle, [...selectedKeys], _opts.allowExpired ?? false);
+
   type Parsed = { literal: string } | { ref: SecretRef };
   const parsedByKey = new Map<string, Parsed>();
   const keychainItemsToFetch: string[] = [];
   for (const [key, raw] of Object.entries(bundle.vars)) {
+    if (!selectedKeys.has(key)) continue;
     const parsed = parseBundleValue(raw);
     parsedByKey.set(key, parsed);
     if ('ref' in parsed && parsed.ref.provider === 'keychain') {
@@ -641,6 +693,7 @@ export function resolveBundleEnv(bundle: SecretsBundle, _opts: ResolveBundleOpti
 
   const env: Record<string, string> = {};
   for (const [key, raw] of Object.entries(bundle.vars)) {
+    if (!selectedKeys.has(key)) continue;
     const parsed = parsedByKey.get(key)!;
     if ('literal' in parsed) {
       env[key] = parsed.literal;
@@ -772,6 +825,20 @@ export function readAndResolveBundleEnv(
     validateEnvKey(key);
   }
 
+  // Key-subset validation and expiry pre-check (mirrors resolveBundleEnv logic).
+  const requestedKeys = opts.keys?.length ? opts.keys : undefined;
+  if (requestedKeys) {
+    const missing = requestedKeys.filter((k) => !(k in bundle.vars));
+    if (missing.length > 0) {
+      const available = Object.keys(bundle.vars).join(', ') || '(none)';
+      throw new Error(
+        `Bundle '${name}' does not contain key(s): ${missing.join(', ')}. Available: ${available}.`,
+      );
+    }
+  }
+  const selectedKeys = new Set(requestedKeys ?? Object.keys(bundle.vars));
+  assertNotExpired(bundle, [...selectedKeys], opts.allowExpired ?? false);
+
   stampLastUsed(bundle);
 
   type Parsed = { literal: string } | { ref: SecretRef };
@@ -779,6 +846,7 @@ export function readAndResolveBundleEnv(
   const keychainKeys: string[] = [];
   const kindCounts: Record<string, number> = {};
   for (const [key, raw] of Object.entries(bundle.vars)) {
+    if (!selectedKeys.has(key)) continue;
     const p = parseBundleValue(raw);
     parsedByKey.set(key, p);
     const kind = 'literal' in p ? 'literal' : p.ref.provider;
@@ -787,7 +855,7 @@ export function readAndResolveBundleEnv(
       keychainKeys.push(key);
     }
   }
-  const keys = Object.keys(bundle.vars).sort();
+  const keys = [...selectedKeys].sort();
   keychainKeys.sort();
 
   const emitReadAudit = (status: 'success' | 'error', err?: unknown) => {
@@ -806,6 +874,7 @@ export function readAndResolveBundleEnv(
   try {
     const env: Record<string, string> = {};
     for (const [key] of Object.entries(bundle.vars)) {
+      if (!selectedKeys.has(key)) continue;
       const p = parsedByKey.get(key)!;
       if ('literal' in p) {
         env[key] = p.literal;


### PR DESCRIPTION
## What

Two least-privilege additions to secret injection:

**1. `--keys` subset injection** — inject only the named env vars from a bundle, not everything in it.

```
agents secrets exec prod --keys STRIPE_KEY,LOG_LEVEL -- ./deploy.sh
agents run claude "deploy" --secrets prod --secrets-keys STRIPE_KEY
```

**2. Expiry pre-run abort** — if any selected key has an `expires` date in the past, the run aborts with a clear error *before* Touch ID is popped, before any subprocess is spawned. Pass `--allow-expired` to override.

## Files changed

| File | Change |
|------|--------|
| `src/lib/secrets/bundles.ts` | `ResolveBundleOptions` gains `keys?: string[]` and `allowExpired?: boolean`; new `assertNotExpired()` helper; both `resolveBundleEnv` and `readAndResolveBundleEnv` apply subset filter and expiry check |
| `src/commands/secrets.ts` | `agents secrets exec` gets `--keys` and `--allow-expired` flags |
| `src/commands/exec.ts` | `agents run` gets `--secrets-keys` and `--allow-expired` flags; `ExecCommandActionOptions` extended |
| `src/lib/secrets/__tests__/bundles.test.ts` | 14 new tests: subset injects only requested keys; missing key throws clearly; expired key aborts; `--allow-expired` overrides; expiry on excluded keys does not abort |

## Test plan

- [x] `bun test src/lib/secrets/__tests__/bundles.test.ts` — 26 pass (14 new)
- [x] `bunx tsc --noEmit` — clean
- [ ] `agents secrets exec <bundle> --keys K1 -- env | grep K1` on a real bundle with multiple keys — only K1 injected
- [ ] `agents secrets exec <bundle> --keys MISSING -- env` — exits non-zero with key-name in error
- [ ] Add `--expires` to a key, wait past date, run `agents secrets exec <bundle> -- env` — aborts before Touch ID
- [ ] Same with `--allow-expired` — proceeds normally