### PR TITLE
fix(hosts): capture retrievable logs for detached --no-follow runs (Closes #579)

### DIFF
--- a/src/lib/hosts/logs.test.ts
+++ b/src/lib/hosts/logs.test.ts
@@ -1,16 +1,23 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdirSync, rmSync, mkdtempSync, writeFileSync } from 'fs';
+import { mkdirSync, rmSync, mkdtempSync, writeFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import * as state from '../state.js';
+import { sshReachable } from '../ssh-exec.js';
 
 // Redirect the cache dir to a temp tree (real fs, no service mocking) so we can
 // stage real task sidecars + log files the way a dispatch would.
-let CACHE_ROOT: string;
+// Initialized eagerly (not just in beforeEach) so the module-load LOCALHOST_SSH
+// probe below sees a valid dir for ssh's control socket.
+let CACHE_ROOT: string = mkdtempSync(join(tmpdir(), 'agents-cli-hostlogs-boot-'));
 vi.spyOn(state, 'getCacheDir').mockImplementation(() => CACHE_ROOT);
 
 import { showHostTaskLog } from './logs.js';
 import { saveTask, localLogPath, type HostTask } from './tasks.js';
+
+// Gate real-SSH tests on localhost being reachable so they pass on dev machines
+// and self-hosted runners, but skip cleanly in hosted CI without SSH access.
+const LOCALHOST_SSH = sshReachable('localhost', 5000);
 
 function makeTask(overrides: Partial<HostTask> = {}): HostTask {
   return {
@@ -33,6 +40,10 @@ let writeSpy: ReturnType<typeof vi.spyOn>;
 beforeEach(() => {
   CACHE_ROOT = mkdtempSync(join(tmpdir(), 'agents-cli-hostlogs-'));
   mkdirSync(join(CACHE_ROOT, 'hosts'), { recursive: true });
+  // ssh's control-socket dir lives under getCacheDir(); ssh-exec only ensures it
+  // once (module-level flag), so with a fresh cache dir per test we must create
+  // it ourselves or multiplexed ssh can't open its socket and reports 255.
+  mkdirSync(join(CACHE_ROOT, 'ssh'), { recursive: true, mode: 0o700 });
   out = '';
   writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
     out += String(chunk);
@@ -87,5 +98,57 @@ describe('showHostTaskLog', () => {
     expect(res.found).toBe(true);
     expect(res.exitCode).toBe(0);
     expect(out).toBe('final output\n');
+  });
+});
+
+// Detached-dispatch log retrieval over real ssh (localhost). The literal bug
+// closed by this PR: a --no-follow dispatch captured no local log, so
+// `agents hosts logs <id>` always printed "(no local log captured for this task)".
+// These tests drive a real `ssh localhost cat <file>` through showHostTaskLog to
+// confirm the remote-fetch path works end-to-end.
+describe.skipIf(!LOCALHOST_SSH)('detached-run log fetch over real ssh (localhost)', () => {
+  it('fetches and prints the remote log when no local log exists (detached dispatch)', async () => {
+    // Simulate a detached dispatch: task sidecar exists, local log does NOT, but
+    // the remote log (a real local file we point at via ssh localhost) has content.
+    const remoteLogFile = join(CACHE_ROOT, 'remote-abc00001.log');
+    writeFileSync(remoteLogFile, 'detached run output\n');
+
+    const task = makeTask({ id: 'abc00001', target: 'localhost', remoteLog: remoteLogFile });
+    saveTask(task);
+    // No writeFileSync(localLogPath(task.id), …) — intentionally absent.
+
+    const res = await showHostTaskLog(task.id, false);
+
+    expect(res.found).toBe(true);
+    expect(res.exitCode).toBe(0);
+    expect(out).toBe('detached run output\n');
+  });
+
+  it('caches the fetched log locally so subsequent calls read it from disk (no SSH)', async () => {
+    const remoteLogFile = join(CACHE_ROOT, 'remote-abc00002.log');
+    writeFileSync(remoteLogFile, 'cached output\n');
+
+    const task = makeTask({ id: 'abc00002', target: 'localhost', remoteLog: remoteLogFile });
+    saveTask(task);
+
+    await showHostTaskLog(task.id, false);
+
+    // After the first fetch the local mirror must exist.
+    expect(existsSync(localLogPath(task.id))).toBe(true);
+  });
+
+  it('still shows the no-log note when the remote log is also absent', async () => {
+    // console.log routes through process.stdout.write, which writeSpy intercepts.
+    const task = makeTask({
+      id: 'abc00003',
+      target: 'localhost',
+      remoteLog: join(CACHE_ROOT, 'nonexistent.log'),
+    });
+    saveTask(task);
+
+    const res = await showHostTaskLog(task.id, false);
+
+    expect(res.found).toBe(true);
+    expect(out).toContain('no local log');
   });
 });

--- a/src/lib/hosts/logs.ts
+++ b/src/lib/hosts/logs.ts
@@ -54,7 +54,7 @@ export async function showHostTaskLog(id: string, follow: boolean): Promise<Host
     if (remote !== null) {
       process.stdout.write(remote);
     } else {
-      console.log(chalk.gray('(no local log captured for this task)'));
+      process.stdout.write(chalk.gray('(no local log captured for this task)\n'));
     }
   }
   return { found: true, exitCode: 0 };

--- a/src/lib/hosts/logs.ts
+++ b/src/lib/hosts/logs.ts
@@ -9,9 +9,10 @@
 
 import * as fs from 'fs';
 import chalk from 'chalk';
-import { loadTask, localLogPath, updateTask, terminalPatch } from './tasks.js';
+import { loadTask, localLogPath, updateTask, terminalPatch, type HostTask } from './tasks.js';
 import { followHostTask } from './progress.js';
 import { reconcileTask } from './reconcile.js';
+import { sshExecRaw } from '../ssh-exec.js';
 
 export interface HostLogResult {
   /** False when no host task with this id exists (caller may fall through to sessions). */
@@ -47,7 +48,31 @@ export async function showHostTaskLog(id: string, follow: boolean): Promise<Host
   try {
     process.stdout.write(fs.readFileSync(localLogPath(id), 'utf-8'));
   } catch {
-    console.log(chalk.gray('(no local log captured for this task)'));
+    // No local log — task was dispatched with --no-follow. Fetch from the remote
+    // on demand and cache locally so subsequent calls are instant.
+    const remote = fetchAndCacheRemoteLog(task);
+    if (remote !== null) {
+      process.stdout.write(remote);
+    } else {
+      console.log(chalk.gray('(no local log captured for this task)'));
+    }
   }
   return { found: true, exitCode: 0 };
+}
+
+/**
+ * Fetch a task's remote log over SSH, write it to the local mirror path (for
+ * future instant reads), and return its content. Returns null when the host is
+ * unreachable or the remote log is empty/absent.
+ *
+ * `remoteLog` is a $HOME-prefixed path with a safe (hex) basename — intentionally
+ * unquoted so the remote shell expands $HOME, matching the contract in reconcile.ts
+ * and progress.ts.
+ */
+function fetchAndCacheRemoteLog(task: HostTask): Buffer | null {
+  const res = sshExecRaw(task.target, `cat ${task.remoteLog} 2>/dev/null`, { timeoutMs: 30000, multiplex: true });
+  if (res.code !== 0 || res.stdout.length === 0) return null;
+  // The hosts cache dir already exists (saveTask created it) — write is best-effort.
+  try { fs.writeFileSync(localLogPath(task.id), res.stdout); } catch { /* best-effort cache */ }
+  return res.stdout;
 }


### PR DESCRIPTION
## Gap closed

`agents run --host <h> ... --no-follow` dispatched the remote process but never started the `followHostTask` loop, so no bytes were mirrored to the local log file. `agents hosts logs <id>` always hit the catch branch and printed:

```
(no local log captured for this task)
```

even after the run had fully finished on the remote.

## Approach

On-demand SSH fetch in `showHostTaskLog` (option b from the issue): when the local mirror is absent, `fetchAndCacheRemoteLog` runs `cat <remoteLog>` over SSH, writes the result to `localLogPath(id)` so subsequent calls are served from disk, and returns the bytes. The fallback message is now only shown when the remote log is also absent or the host is unreachable.

```
src/lib/hosts/logs.ts  +26 lines
src/lib/hosts/logs.test.ts  +55 lines
```

Follows the `$HOME`-prefixed-path / unquoted-for-shell-expansion contract already established by `reconcile.ts` and `progress.ts`.

## Changes

**`src/lib/hosts/logs.ts`** (`logs.ts:72–78`)
- Added `sshExecRaw` import and `type HostTask`.
- Replaced the unconditional fallback `console.log` with a call to `fetchAndCacheRemoteLog`.
- `fetchAndCacheRemoteLog` calls `sshExecRaw(task.target, \`cat ${task.remoteLog} 2>/dev/null\`, { timeoutMs: 30000, multiplex: true })`, writes to `localLogPath(task.id)` on success, returns `null` when the host is unreachable or log is empty.

**`src/lib/hosts/logs.test.ts`** (`logs.test.ts:109–154`)
- Eager `CACHE_ROOT` init + `LOCALHOST_SSH` gate matching the `reconcile.test.ts` pattern.
- `ssh` control-socket dir created in `beforeEach` (the `controlDirEnsured` module flag means it's never auto-recreated after the first `CACHE_ROOT` reassignment).
- Three new tests in `describe.skipIf(!LOCALHOST_SSH)`: fetch+print, local cache, and absent-remote fallback.

## Test plan

- [ ] `bun test src/lib/hosts/logs.test.ts` — 4 pass, 3 skip (localhost SSH unavailable in hosted CI) / 7 pass on machines with localhost SSH
- [ ] `bunx tsc --noEmit` — clean
- [ ] On a machine with localhost SSH enabled, all 7 tests pass including the real-SSH detached-fetch path