### PR TITLE
fix(workflows): fail-closed prune of stale workflow subagents in shared dir (Closes #401)

### DIFF
--- a/skills/workflows/SKILL.md
+++ b/skills/workflows/SKILL.md
@@ -208,7 +208,7 @@ These fields are not just displayed — on Claude they translate to headless fla
 | `tools: [Read, Grep]` | `--tools Read Grep` (+ matching `--allowedTools`) | Read-only sandbox — `Write`, `Bash`, and `Edit` are unavailable in the session |
 | `mcpServers: [github]` | `--mcp-config <ephemeral json>` + `--strict-mcp-config` | ONLY the named registry servers load (the config flag alone would merely add them) |
 | `mcpServers: [missing]` (none installed) | `--mcp-config <empty {}>` + `--strict-mcp-config` | **Fail-closed:** declaring `mcpServers` with no installed match scopes the run to NO MCP servers — never the user's full ambient set |
-| `allowedAgents: [security]` | copies only `security.md` into the run's agents dir | Unlisted subagents have no definition on disk, so the orchestrator can't dispatch them. (A subagent left over from a prior unrestricted run can persist in the shared dir — not removed here.) |
+| `allowedAgents: [security]` | copies only `security.md` into the run's agents dir | Unlisted subagents have no definition on disk, so the orchestrator can't dispatch them. **Fail-closed prune (issue #401):** before copying, any workflow-managed subagent left over from a prior unrestricted run that is no longer permitted is removed from the shared dir (a user's own hand-placed subagent is never touched), and the run's copies are torn down afterward. |
 | `allowedAgents: []` (explicit empty) | copies NO subagent files | **Fail-closed:** allow none. Omitting the field entirely copies all subagents; an empty list copies zero |
 
 Read-only review example — this workflow can read and search but cannot write files or shell out:

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -522,7 +522,7 @@ export function registerRunCommand(program: Command): void {
         { getConfiguredRunStrategy, normalizeRunStrategy, resolveRunVersion, RUN_STRATEGIES },
         { getGlobalDefault, getVersionHomePath, resolveVersion, resolveVersionAlias },
         { buildDiscoveredPlugin, loadPluginManifest, syncPluginToVersion },
-        { parseWorkflowFrontmatter, resolveWorkflowRef, resolveAllowedSubagents },
+        { parseWorkflowFrontmatter, resolveWorkflowRef, resolveAllowedSubagents, pruneStaleWorkflowSubagents },
         { resolveRunDefaults },
         { getMcpServersByName, buildWorkflowMcpConfig },
         { supports },
@@ -553,6 +553,10 @@ export function registerRunCommand(program: Command): void {
       // WORKFLOW.md capability scoping, translated to Claude headless flags below.
       let workflowToolsRestrict: string[] | undefined;
       let workflowMcpConfigPath: string | undefined;
+      // Full paths of workflow subagent files THIS run copied into the shared
+      // per-agent agents dir. Torn down after the run to restore the shared dir
+      // (issue #401), mirroring cleanupWorkflowMcpConfig for the mcp-config.
+      const workflowSubagentTargets: string[] = [];
       // WORKFLOW.md `loop:` block (issue #332). When a workflow declares it,
       // `agents run <workflow>` honors the loop without a --loop flag.
       let workflowLoop: import('../lib/workflows.js').LoopConfigRaw | undefined;
@@ -613,6 +617,15 @@ export function registerRunCommand(program: Command): void {
           const allFiles = fs.readdirSync(subagentsDir).filter(f => f.endsWith('.md'));
           const { allowedStems, missing } = resolveAllowedSubagents(allFiles, allowedAgents);
           const allowStemSet = new Set(allowedStems);
+          // Fail-closed prune (issue #401, follow-up to #324). A prior
+          // unrestricted run may have left workflow subagent files that THIS
+          // scoped run does not permit; they linger in the shared dir and stay
+          // dispatchable. Remove those no-longer-permitted workflow-managed
+          // files BEFORE writing the allowed set — never a user's own subagent.
+          const pruned = pruneStaleWorkflowSubagents(claudeAgentsDir, allFiles, allowedStems);
+          if (pruned.length > 0) {
+            process.stderr.write(chalk.gray(`[workflow] pruned ${pruned.length} stale workflow subagent(s) from shared dir: ${pruned.join(', ')}\n`));
+          }
           let copied = 0;
           let skipped = 0;
           for (const file of allFiles) {
@@ -621,7 +634,9 @@ export function registerRunCommand(program: Command): void {
               skipped++;
               continue;
             }
-            fs.copyFileSync(path.join(subagentsDir, file), path.join(claudeAgentsDir, file));
+            const dest = path.join(claudeAgentsDir, file);
+            fs.copyFileSync(path.join(subagentsDir, file), dest);
+            workflowSubagentTargets.push(dest);
             copied++;
           }
           if (allowedAgents !== undefined) {
@@ -1216,6 +1231,20 @@ export function registerRunCommand(program: Command): void {
         }
       };
 
+      // Restore the shared per-agent agents dir after the run (issue #401):
+      // remove the workflow subagent files THIS run copied in, so a scoped
+      // workflow never leaves definitions behind for the next, unrelated run to
+      // inherit. Mirrors cleanupWorkflowMcpConfig — tear down only what we made.
+      const cleanupWorkflowSubagents = () => {
+        for (const target of workflowSubagentTargets) {
+          try {
+            fs.rmSync(target, { force: true });
+          } catch {
+            // best-effort: nothing actionable if the file is already gone.
+          }
+        }
+      };
+
       // Loop dispatch (issue #332). Active when --loop is passed OR a workflow
       // declares a `loop:` block. The loop path runs AFTER the #346 pre-flight
       // gate above (which fired once) — the loop's token budget is an ADDITIONAL
@@ -1254,10 +1283,12 @@ export function registerRunCommand(program: Command): void {
             version,
           });
           cleanupWorkflowMcpConfig();
+          cleanupWorkflowSubagents();
           process.stderr.write(chalk.gray(`[loop] stopped: ${result.stoppedBy} after ${result.iterations} iteration(s), ${result.tokens} tokens (checkpoint: ${path.join(runDir, 'checkpoint.json')})\n`));
           process.exit(loopExitCode(result.stoppedBy));
         } catch (err) {
           cleanupWorkflowMcpConfig();
+          cleanupWorkflowSubagents();
           console.error(chalk.red(`Loop failed for ${agent}: ${(err as Error).message}`));
           process.exit(1);
         }
@@ -1272,9 +1303,11 @@ export function registerRunCommand(program: Command): void {
           exitCode = await execAgent(execOptions);
         }
         cleanupWorkflowMcpConfig();
+        cleanupWorkflowSubagents();
         process.exit(exitCode);
       } catch (err) {
         cleanupWorkflowMcpConfig();
+        cleanupWorkflowSubagents();
         console.error(chalk.red(`Failed to execute ${agent}: ${(err as Error).message}`));
         process.exit(1);
       }

--- a/src/lib/workflows.test.ts
+++ b/src/lib/workflows.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { parseLoopBlock, parseWorkflowFrontmatter } from './workflows.js';
+import {
+  parseLoopBlock,
+  parseWorkflowFrontmatter,
+  resolveAllowedSubagents,
+  pruneStaleWorkflowSubagents,
+} from './workflows.js';
 
 describe('parseLoopBlock — defensive coercion (issue #332)', () => {
   it('parses a well-formed loop block', () => {
@@ -43,6 +48,81 @@ describe('parseLoopBlock — defensive coercion (issue #332)', () => {
   it('returns undefined when an all-garbage block leaves no recognized field', () => {
     expect(parseLoopBlock({ until: 'nope', max_iterations: -1, budget: 'x', interval: 5 }))
       .toBeUndefined();
+  });
+});
+
+describe('pruneStaleWorkflowSubagents — fail-closed cleanup (issue #401)', () => {
+  function makeSharedDir(files: Record<string, string>): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-shared-agents-'));
+    for (const [name, body] of Object.entries(files)) {
+      fs.writeFileSync(path.join(dir, name), body, 'utf-8');
+    }
+    return dir;
+  }
+
+  it('removes a stale non-permitted workflow subagent while preserving the user\'s own', () => {
+    // Shared per-agent agents dir as left by a PRIOR unrestricted run: it holds
+    // a workflow subagent (`danger.md`) that this scoped run does NOT permit,
+    // plus the user's own hand-placed subagent (`myhelper.md`) and the permitted
+    // `security.md`.
+    const shared = makeSharedDir({
+      'security.md': 'stale security',
+      'danger.md': 'leftover from unrestricted run',
+      'myhelper.md': 'user hand-placed subagent',
+    });
+
+    // The workflow declares subagents security + danger, but allows only security.
+    const workflowSubagentFiles = ['security.md', 'danger.md'];
+    const { allowedStems } = resolveAllowedSubagents(workflowSubagentFiles, ['security']);
+    expect(allowedStems).toEqual(['security']);
+
+    const pruned = pruneStaleWorkflowSubagents(shared, workflowSubagentFiles, allowedStems);
+
+    // The unlisted workflow subagent is gone (fail-closed); it can no longer be
+    // dispatched despite lingering from a prior run.
+    expect(pruned).toEqual(['danger.md']);
+    expect(fs.existsSync(path.join(shared, 'danger.md'))).toBe(false);
+
+    // The user's own subagent — NOT part of the workflow's subagents/ — survives.
+    expect(fs.existsSync(path.join(shared, 'myhelper.md'))).toBe(true);
+
+    // The permitted subagent is left in place for the copy step to (re)write.
+    expect(fs.existsSync(path.join(shared, 'security.md'))).toBe(true);
+
+    fs.rmSync(shared, { recursive: true, force: true });
+  });
+
+  it('prunes every workflow subagent when allowedAgents is explicitly empty', () => {
+    const shared = makeSharedDir({
+      'security.md': 'stale',
+      'danger.md': 'stale',
+      'notes.md': 'user file',
+    });
+    const workflowSubagentFiles = ['security.md', 'danger.md'];
+    const { allowedStems } = resolveAllowedSubagents(workflowSubagentFiles, []);
+    expect(allowedStems).toEqual([]);
+
+    const pruned = pruneStaleWorkflowSubagents(shared, workflowSubagentFiles, allowedStems);
+
+    expect(pruned.sort()).toEqual(['danger.md', 'security.md']);
+    expect(fs.existsSync(path.join(shared, 'security.md'))).toBe(false);
+    expect(fs.existsSync(path.join(shared, 'danger.md'))).toBe(false);
+    // The user's own file is untouched.
+    expect(fs.existsSync(path.join(shared, 'notes.md'))).toBe(true);
+
+    fs.rmSync(shared, { recursive: true, force: true });
+  });
+
+  it('prunes nothing on a fresh dir or when all subagents are permitted', () => {
+    const shared = makeSharedDir({ 'security.md': 'present' });
+    // allowedAgents absent -> everything permitted -> nothing pruned.
+    const { allowedStems } = resolveAllowedSubagents(['security.md'], undefined);
+    expect(pruneStaleWorkflowSubagents(shared, ['security.md'], allowedStems)).toEqual([]);
+    expect(fs.existsSync(path.join(shared, 'security.md'))).toBe(true);
+    fs.rmSync(shared, { recursive: true, force: true });
+
+    // A shared dir that does not exist yet is a no-op, never a throw.
+    expect(pruneStaleWorkflowSubagents(path.join(os.tmpdir(), 'agents-missing-xyz-401'), ['a.md'], [])).toEqual([]);
   });
 });
 

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -187,6 +187,47 @@ export function resolveAllowedSubagents(
   };
 }
 
+/**
+ * Prune stale workflow-managed subagent files from the shared per-agent agents
+ * dir before a scoped run writes the permitted set (issue #401, follow-up to
+ * #324). A prior *unrestricted* run of a workflow copies every subagent
+ * definition into the shared `~/.claude/agents/` dir; a later run that declares
+ * `allowedAgents:` copies only the permitted ones but never removes the
+ * leftovers — so an unlisted subagent stays on disk and remains dispatchable,
+ * silently defeating the fail-closed scope.
+ *
+ * Fail-closed fix (mirrors how `cleanupWorkflowMcpConfig` only tears down what
+ * the workflow itself created): remove any file that (a) belongs to THIS
+ * workflow's subagents/ — matched by filename, i.e. the workflow-managed
+ * universe — and (b) is NOT in the permitted set. A user's own hand-placed
+ * subagent shares no name with a workflow subagent file, so it is never
+ * touched. Permitted files are left in place; the caller (re)copies them.
+ *
+ * `workflowSubagentFiles` are the .md filenames in the workflow's subagents/
+ * dir (e.g. `security.md`); `allowedStems` are the permitted stems from
+ * `resolveAllowedSubagents`. Returns the filenames actually removed.
+ */
+export function pruneStaleWorkflowSubagents(
+  sharedAgentsDir: string,
+  workflowSubagentFiles: string[],
+  allowedStems: string[],
+): string[] {
+  if (!fs.existsSync(sharedAgentsDir)) return [];
+  const allow = new Set(allowedStems);
+  const pruned: string[] = [];
+  for (const file of workflowSubagentFiles) {
+    if (!file.endsWith('.md')) continue;
+    const stem = file.replace(/\.md$/, '');
+    if (allow.has(stem)) continue; // permitted → the copy step will (re)write it
+    const target = path.join(sharedAgentsDir, file);
+    if (fs.existsSync(target)) {
+      fs.rmSync(target, { force: true });
+      pruned.push(file);
+    }
+  }
+  return pruned;
+}
+
 /** Count subagent .md files in a workflow's subagents/ directory. */
 export function countWorkflowSubagents(workflowDir: string): number {
   const subagentsDir = path.join(workflowDir, 'subagents');


### PR DESCRIPTION
## The gap (follow-up to #324)

The #324 workflow enforcement copies **only** the allowed subagent files into the shared per-agent agents dir (`~/.claude/agents/`) but never **prunes** that dir first. So a subagent left over from a prior, *unrestricted* run persists in the shared dir and stays dispatchable — silently defeating the fail-closed `allowedAgents:` scope.

The only cleanup that existed was for the MCP config (`cleanupWorkflowMcpConfig`, `src/commands/exec.ts`), **not** for subagents. The hole was documented at `skills/workflows/SKILL.md` ("A subagent left over from a prior unrestricted run can persist in the shared dir — not removed here").

## The fix (fail-closed, mirrors the MCP cleanup)

- **`pruneStaleWorkflowSubagents()`** (`src/lib/workflows.ts`) — before writing the permitted set, remove any file that (a) belongs to **this** workflow's `subagents/` (the workflow-managed universe, matched by filename) and (b) is no longer permitted. A user's own hand-placed subagent shares no name with a workflow subagent file, so it is **never** touched. Permitted files are left in place for the copy step to (re)write.
- **Wired into the copy path** (`src/commands/exec.ts`): prune runs immediately before the allowedAgents copy loop, with an auditable stderr line.
- **Teardown restore** (`src/commands/exec.ts`): the run's copied files are tracked and removed via `cleanupWorkflowSubagents()` on the same four teardown sites where `cleanupWorkflowMcpConfig()` runs (loop success/fail, main success/fail), so the shared dir is restored after the run.
- Only workflow-managed entries are removed — never a user's own subagents, and the mechanism is reversible/self-cleaning, exactly like the MCP config teardown.

## Test (`src/lib/workflows.test.ts`, real temp dirs, no mocking)

`pruneStaleWorkflowSubagents — fail-closed cleanup (issue #401)`:
- Pre-seeds a shared dir as a prior unrestricted run would leave it (`security.md`, stale `danger.md`, user's `myhelper.md`), runs `resolveAllowedSubagents([security,danger], [security])` then the prune, and asserts **`danger.md` removed** while **`myhelper.md` preserved** and `security.md` left for recopy.
- `allowedAgents: []` prunes every workflow subagent, user file untouched.
- Fresh/all-permitted/missing-dir cases prune nothing and never throw.

Verified the removal assertions **fail without the prune** (2 failed) and pass with it (13 passed). `tsc --noEmit` clean.