### PR TITLE
feat(cloud): wire images + skills dispatch fields (Closes #326)

### DIFF
--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -8,12 +8,40 @@
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import * as fs from 'fs';
+import * as path from 'path';
 import ora from 'ora';
 import { resolveProvider, getAllProviders, getDefaultProviderId } from '../lib/cloud/registry.js';
 import { insertTask, updateTaskStatus, getTaskById, listTasks as listStoredTasks, listActiveTasks } from '../lib/cloud/store.js';
 import { renderStream } from '../lib/cloud/stream.js';
-import type { CloudProvider, CloudProviderId, CloudTarget, CloudTaskStatus, DispatchOptions } from '../lib/cloud/types.js';
-import { MissingTargetError } from '../lib/cloud/types.js';
+import type { CloudProvider, CloudProviderId, CloudTarget, CloudTaskStatus, DispatchOptions, ImageAttachment, SkillRef } from '../lib/cloud/types.js';
+import { MissingTargetError, MAX_IMAGES_PER_DISPATCH } from '../lib/cloud/types.js';
+
+/** Map a supported image file extension to its wire mimeType. Rejects anything else. */
+function imageMimeFromPath(file: string): ImageAttachment['mimeType'] {
+  const ext = path.extname(file).toLowerCase();
+  if (ext === '.png') return 'image/png';
+  if (ext === '.jpg' || ext === '.jpeg') return 'image/jpeg';
+  if (ext === '.webp') return 'image/webp';
+  die(`Unsupported image type ${JSON.stringify(ext || file)}. Use .png, .jpg/.jpeg, or .webp.`);
+}
+
+/** Read one image file into a base64 ImageAttachment, dying with a clear error if it's missing. */
+function readImageAttachment(file: string): ImageAttachment {
+  if (!fs.existsSync(file) || !fs.statSync(file).isFile()) {
+    die(`Image not found: ${file}`);
+  }
+  const mimeType = imageMimeFromPath(file);
+  return { data: fs.readFileSync(file).toString('base64'), mimeType };
+}
+
+/** Parse a `--skill <id>` value (`id` or `id@version`) into a SkillRef. */
+function parseSkillRef(raw: string): SkillRef {
+  const at = raw.lastIndexOf('@');
+  if (at > 0) {
+    return { id: raw.slice(0, at), version: raw.slice(at + 1) };
+  }
+  return { id: raw };
+}
 
 /** Print an error message to stderr and exit. */
 function die(msg: string, code = 1): never {
@@ -173,6 +201,24 @@ Examples:
     .option('--autonomy <level>', 'Factory/Droid autonomy: low, medium, high (default high)')
     .option('--mode <mode>', 'Execution mode (e.g., plan, edit, full)')
     .option(
+      '--image <path>',
+      `Attach an image (.png/.jpg/.webp) for vision dispatch. Repeatable, up to ${MAX_IMAGES_PER_DISPATCH} (Rush Cloud only).`,
+      (value: string, previous: string[] | undefined) => {
+        const acc = Array.isArray(previous) ? previous : [];
+        acc.push(value);
+        return acc;
+      },
+    )
+    .option(
+      '--skill <id>',
+      'Ride-along skill by id (or id@version). Repeatable (Rush Cloud only).',
+      (value: string, previous: string[] | undefined) => {
+        const acc = Array.isArray(previous) ? previous : [];
+        acc.push(value);
+        return acc;
+      },
+    )
+    .option(
       '-b, --balanced',
       'Shortcut for --strategy balanced. Route the factory run across all healthy accounts.',
     )
@@ -252,6 +298,24 @@ Examples:
         dispatchOptions.providerOptions!.strategy = 'balanced';
       }
       if (options.uploadAccountTokens) dispatchOptions.providerOptions!.uploadAccountTokens = true;
+
+      // Vision attachments + ride-along skills. Only wire them when the resolved
+      // provider advertises support — otherwise fail loud rather than silently
+      // drop the flags the user passed.
+      const imagePaths = Array.isArray(options.image) ? (options.image as string[]) : [];
+      const skillIds = Array.isArray(options.skill) ? (options.skill as string[]) : [];
+      const caps = provider.capabilities();
+      if (imagePaths.length > 0) {
+        if (!caps.images) die(`${provider.name} does not support image attachments.`);
+        if (imagePaths.length > MAX_IMAGES_PER_DISPATCH) {
+          die(`Too many images: ${imagePaths.length}. Max is ${MAX_IMAGES_PER_DISPATCH} per dispatch.`);
+        }
+        dispatchOptions.images = imagePaths.map(readImageAttachment);
+      }
+      if (skillIds.length > 0) {
+        if (!caps.skills) die(`${provider.name} does not support ride-along skills.`);
+        dispatchOptions.skills = skillIds.map(parseSkillRef);
+      }
 
       // Dispatch. On a missing pre-provisioned target (Codex env / Factory
       // computer), offer an interactive picker instead of a raw error.

--- a/src/lib/cloud/codex.ts
+++ b/src/lib/cloud/codex.ts
@@ -117,6 +117,10 @@ export class CodexCloudProvider implements CloudProvider {
       cancel: false,
       message: false,
       multiRepo: false,
+      // `codex cloud exec --env <id> <prompt>` is the only dispatch surface the
+      // codex CLI exposes — it has no flag to attach images or ride-along skills,
+      // and the env bundles its own context at creation time. Both stay false
+      // until the upstream CLI grows an attachment surface.
       skills: false,
       images: false,
     };

--- a/src/lib/cloud/rush.test.ts
+++ b/src/lib/cloud/rush.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { accountTokensFingerprint, buildDispatchBody, hasRushUploadConsent } from './rush.js';
+import { accountTokensFingerprint, buildDispatchBody, hasRushUploadConsent, RushCloudProvider } from './rush.js';
+import { MAX_IMAGES_PER_DISPATCH } from './types.js';
+import type { ImageAttachment, SkillRef } from './types.js';
 
 const ORIGINAL_UPLOAD_ENV = process.env.AGENTS_RUSH_UPLOAD_TOKENS;
 let tmpDir: string;
@@ -149,6 +151,82 @@ describe('buildDispatchBody', () => {
       resolvedRepos: [{ installation_id: 1, repo_owner: 'a', repo_name: 'b' }],
     });
     expect(body.strategy).toBeUndefined();
+  });
+
+  it('includes skills[] verbatim when supplied', () => {
+    const skills: SkillRef[] = [{ id: 'linear' }, { id: 'browser', version: '2.0.0' }];
+    const body = buildDispatchBody({
+      prompt: 'x',
+      resolvedRepos: [{ installation_id: 1, repo_owner: 'a', repo_name: 'b' }],
+      skills,
+    });
+    expect(body.skills).toEqual(skills);
+  });
+
+  it('omits skills when not supplied or empty', () => {
+    const none = buildDispatchBody({
+      prompt: 'x',
+      resolvedRepos: [{ installation_id: 1, repo_owner: 'a', repo_name: 'b' }],
+    });
+    expect(none.skills).toBeUndefined();
+    const empty = buildDispatchBody({
+      prompt: 'x',
+      resolvedRepos: [{ installation_id: 1, repo_owner: 'a', repo_name: 'b' }],
+      skills: [],
+    });
+    expect(empty.skills).toBeUndefined();
+  });
+
+  it('includes images[] when supplied', () => {
+    const images: ImageAttachment[] = [
+      { data: 'aGVsbG8=', mimeType: 'image/png' },
+      { data: 'd29ybGQ=', mimeType: 'image/jpeg' },
+    ];
+    const body = buildDispatchBody({
+      prompt: 'x',
+      resolvedRepos: [{ installation_id: 1, repo_owner: 'a', repo_name: 'b' }],
+      images,
+    });
+    expect(body.images).toEqual(images);
+  });
+
+  it('caps images at MAX_IMAGES_PER_DISPATCH, dropping the overflow', () => {
+    const images: ImageAttachment[] = Array.from(
+      { length: MAX_IMAGES_PER_DISPATCH + 3 },
+      (_, i) => ({ data: `img${i}`, mimeType: 'image/png' as const }),
+    );
+    const body = buildDispatchBody({
+      prompt: 'x',
+      resolvedRepos: [{ installation_id: 1, repo_owner: 'a', repo_name: 'b' }],
+      images,
+    });
+    expect(Array.isArray(body.images)).toBe(true);
+    expect((body.images as ImageAttachment[]).length).toBe(MAX_IMAGES_PER_DISPATCH);
+    // The kept slice is the first MAX_IMAGES_PER_DISPATCH, in order.
+    expect((body.images as ImageAttachment[])[0].data).toBe('img0');
+    expect((body.images as ImageAttachment[])[MAX_IMAGES_PER_DISPATCH - 1].data).toBe(
+      `img${MAX_IMAGES_PER_DISPATCH - 1}`,
+    );
+  });
+
+  it('omits images when not supplied or empty', () => {
+    const none = buildDispatchBody({
+      prompt: 'x',
+      resolvedRepos: [{ installation_id: 1, repo_owner: 'a', repo_name: 'b' }],
+    });
+    expect(none.images).toBeUndefined();
+    const empty = buildDispatchBody({
+      prompt: 'x',
+      resolvedRepos: [{ installation_id: 1, repo_owner: 'a', repo_name: 'b' }],
+      images: [],
+    });
+    expect(empty.images).toBeUndefined();
+  });
+
+  it('advertises skills + images support in capabilities', () => {
+    const caps = new RushCloudProvider().capabilities();
+    expect(caps.skills).toBe(true);
+    expect(caps.images).toBe(true);
   });
 
   it('balanced strategy coexists with no account_manifest', () => {

--- a/src/lib/cloud/rush.ts
+++ b/src/lib/cloud/rush.ts
@@ -18,8 +18,10 @@ import type {
   CloudEvent,
   DispatchOptions,
   ProviderCapabilities,
+  ImageAttachment,
+  SkillRef,
 } from './types.js';
-import { resolveDispatchRepos } from './types.js';
+import { resolveDispatchRepos, MAX_IMAGES_PER_DISPATCH } from './types.js';
 import { parseSSE } from './stream.js';
 import { listInstalledVersions, getVersionHomePath } from '../versions.js';
 import { getAccountInfo } from '../agents.js';
@@ -337,6 +339,17 @@ export function buildDispatchBody(input: {
   resolvedRepos: Array<{ installation_id: number; repo_owner: string; repo_name: string }>;
   accountManifest?: AccountManifest | null;
   accountTokens?: AccountTokenEntry[] | null;
+  /**
+   * Skill ride-alongs so the cloud pod isn't context-blind. Forwarded verbatim
+   * as `skills` so the Factory Floor can mount them by id/version before the
+   * agent runs. Omitted when empty.
+   */
+  skills?: SkillRef[] | null;
+  /**
+   * Base64 image attachments for vision dispatch. Sliced to
+   * MAX_IMAGES_PER_DISPATCH — extras are dropped, never sent. Omitted when empty.
+   */
+  images?: ImageAttachment[] | null;
 }): Record<string, unknown> {
   if (input.resolvedRepos.length === 0) {
     throw new Error('buildDispatchBody: resolvedRepos must have at least one entry');
@@ -359,6 +372,12 @@ export function buildDispatchBody(input: {
   }
   if (input.accountTokens && input.accountTokens.length > 0) {
     body.account_tokens = input.accountTokens;
+  }
+  if (input.skills && input.skills.length > 0) {
+    body.skills = input.skills;
+  }
+  if (input.images && input.images.length > 0) {
+    body.images = input.images.slice(0, MAX_IMAGES_PER_DISPATCH);
   }
   return body;
 }
@@ -423,8 +442,8 @@ export class RushCloudProvider implements CloudProvider {
       cancel: true,
       message: true,
       multiRepo: true,
-      skills: false,
-      images: false,
+      skills: true,
+      images: true,
     };
   }
 
@@ -486,6 +505,8 @@ export class RushCloudProvider implements CloudProvider {
       resolvedRepos,
       accountManifest,
       strategy,
+      skills: options.skills,
+      images: options.images,
     });
 
     let res = await api('POST', '/api/v1/cloud-runs', token, body);
@@ -537,6 +558,8 @@ export class RushCloudProvider implements CloudProvider {
           resolvedRepos,
           accountManifest,
           accountTokens,
+          skills: options.skills,
+          images: options.images,
         });
         res = await api('POST', '/api/v1/cloud-runs', token, retryBody);
 


### PR DESCRIPTION
## What

`DispatchOptions.images`/`skills`, `MAX_IMAGES_PER_DISPATCH`, and `ProviderCapabilities.{images,skills}` were all defined but never wired into the dispatch path — Rush hardcoded both capabilities to `false` and `buildDispatchBody()` omitted both fields. Cloud agents ran context-blind (no skill ride-along) and couldn't take image input. This finishes the wiring.

## Changes

- **`src/lib/cloud/rush.ts`**
  - `buildDispatchBody()` now attaches `skills` (forwarded verbatim as `SkillRef[]`) and `images` (base64 `ImageAttachment[]`, **sliced to `MAX_IMAGES_PER_DISPATCH`** — overflow is dropped, never sent). Both omitted when empty/absent.
  - Both `dispatch()` call sites (initial POST + the credential-retry POST) forward `options.skills`/`options.images`.
  - `RushCloudProvider.capabilities()` flips `skills`/`images` to `true`.
- **`src/lib/cloud/codex.ts`** — left `skills`/`images` at `false` with an inline reason: `codex cloud exec --env <id> <prompt>` is the only dispatch surface the codex CLI exposes and it has no image/skill attachment flag (the env bundles its context at creation time). Degrades cleanly.
- **`src/commands/cloud.ts`** — `agents cloud run` gains repeatable `--image <path>` (`.png`/`.jpg`/`.jpeg`/`.webp`, read + base64-encoded, count capped at `MAX_IMAGES_PER_DISPATCH`) and `--skill <id>` (`id` or `id@version` → `SkillRef`). Both are gated behind the resolved provider's capability flags — passing them to a provider that doesn't support them fails loud rather than silently dropping.

## Which provider

Only **Rush Cloud** advertises + wires support. Codex stays `false` (no CLI attachment surface); Factory/Antigravity unchanged.

## Capability assumptions

The Rush body carries `skills` as `SkillRef[]` (`{id, version?}`) rather than tarring + uploading skill contents to a separate endpoint (the heavier option the issue floated). This assumes the Factory Floor resolves ride-along skills by id/version from the user's synced `~/.agents` repo. If the backend instead needs raw skill bytes, the client-side plumbing here stays valid — only the server-side resolution differs. The wiring is gated behind `capabilities().skills`, so nothing ships to a backend that hasn't opted in.

## Test

`src/lib/cloud/rush.test.ts` (colocated, no mocking of code under test): asserts `buildDispatchBody` includes `skills`/`images` when supplied, **caps images at `MAX_IMAGES_PER_DISPATCH` keeping the first N in order**, omits both when absent/empty, and that `capabilities()` advertises support. The 4 new assertions fail against pre-change `buildDispatchBody`, pass after. Full cloud suite: **96 passing**. `tsc --noEmit` clean.

Verified end-to-end via the built CLI:
- `cloud run --help` lists `--image`/`--skill`.
- `--image /nonexistent.png` → `Image not found: ...`
- `--provider codex --image t.png` → `Codex Cloud does not support image attachments.`
- `--provider codex --skill linear` → `Codex Cloud does not support ride-along skills.`