### PR TITLE
feat(routines): wire the loop driver into JobConfig (Closes #400)

### DIFF
--- a/src/lib/routines.ts
+++ b/src/lib/routines.ts
@@ -15,6 +15,7 @@ import { getRoutinesDir, getRunsDir, ensureAgentsDir, getProjectRoutinesDir } fr
 import { safeJoin } from './paths.js';
 import type { AgentId } from './types.js';
 import { ALL_AGENT_IDS } from './agents.js';
+import type { LoopConfig } from './loop.js';
 
 /** Tool/site/directory allow-list for sandboxed job execution. */
 export interface JobAllowConfig {
@@ -45,6 +46,8 @@ export interface JobConfig {
   runOnce?: boolean;
   // RFC3339 timestamp; routine auto-disables at the next fire on/after this time.
   endAt?: string;
+  /** When set, executeJob runs this job through the loop driver instead of once. */
+  loop?: LoopConfig;
 }
 
 /** Metadata for a single job execution, persisted as JSON in the run directory. */

--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -24,6 +24,8 @@ import { prepareJobHome, buildSpawnEnv } from './sandbox.js';
 import { resolveModel, buildReasoningFlags } from './models.js';
 import { createTimer, maybeRotate, redactPrompt } from './events.js';
 import { normalizeMode } from './exec.js';
+import type { ExecOptions, ExecEffort } from './exec.js';
+import type { LoopDeps } from './loop.js';
 
 /** Result of a completed job execution, including metadata and optional report. */
 export interface RunResult {
@@ -177,8 +179,16 @@ function generateRunId(): string {
   return new Date().toISOString().replace(/[:.]/g, '-');
 }
 
-/** Execute a job synchronously (waits for completion or timeout before resolving). */
-export async function executeJob(config: JobConfig): Promise<RunResult> {
+/**
+ * Execute a job synchronously (waits for completion or timeout before resolving).
+ *
+ * When `config.loop` is set the job is routed through the loop driver (`runLoop`
+ * from loop.ts) instead of a single spawn — same driver as `agents run --loop` and
+ * workflow `loop:` blocks (issue #400). The optional `deps` parameter provides
+ * injectable seams (runIteration, sleep, writeCheckpoint) used by tests; production
+ * callers omit it and get the defaults.
+ */
+export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<RunResult> {
   maybeRotate();
   const timer = createTimer('agent.run', {
     agent: config.agent,
@@ -190,7 +200,6 @@ export async function executeJob(config: JobConfig): Promise<RunResult> {
   });
 
   const resolvedPrompt = resolveJobPrompt(config);
-  const cmd = buildJobCommand(config, resolvedPrompt);
 
   const useSandbox = config.sandbox !== false;
   const overlayHome = useSandbox ? prepareJobHome(config) : undefined;
@@ -198,9 +207,6 @@ export async function executeJob(config: JobConfig): Promise<RunResult> {
   const runId = generateRunId();
   const runDir = getRunDir(config.name, runId);
   fs.mkdirSync(runDir, { recursive: true });
-
-  const stdoutPath = path.join(runDir, 'stdout.log');
-  const stdoutFd = fs.openSync(stdoutPath, 'w', 0o600);
 
   let spawnEnv = useSandbox ? buildSpawnEnv(overlayHome!) : { ...process.env } as Record<string, string>;
   if (config.timezone) {
@@ -225,6 +231,44 @@ export async function executeJob(config: JobConfig): Promise<RunResult> {
   writeRunMeta(meta);
 
   const timeoutMs = parseTimeout(config.timeout) || 10 * 60 * 1000;
+
+  // Loop path: delegate to runLoop (same driver as `agents run --loop` / workflow loop:).
+  if (config.loop) {
+    const execOptions: ExecOptions = {
+      agent: effectiveAgent,
+      version: config.version,
+      prompt: resolvedPrompt,
+      mode: normalizeMode(config.mode),
+      effort: config.effort as ExecEffort,
+      env: spawnEnv as Record<string, string>,
+      json: true,
+      headless: true,
+      ...(config.config?.model ? { model: config.config.model as string } : {}),
+      ...(config.allow?.dirs ? {
+        addDirs: config.allow.dirs
+          .filter((d) => !d.startsWith('-'))
+          .map((d) => d.replace(/^~/, os.homedir())),
+      } : {}),
+    };
+    const { runLoop } = await import('./loop.js');
+    const loopResult = await runLoop(execOptions, config.loop, {
+      runId,
+      runDir,
+      agent: effectiveAgent,
+      version: config.version,
+    }, deps);
+    meta.status = loopResult.stoppedBy === 'error' ? 'failed' : 'completed';
+    meta.completedAt = new Date().toISOString();
+    meta.exitCode = loopResult.stoppedBy === 'error' ? 1 : 0;
+    writeRunMeta(meta);
+    timer.end({ status: meta.status, exitCode: meta.exitCode ?? undefined, runId });
+    return { meta, reportPath: null };
+  }
+
+  // Single-shot path (no loop): build the command, open a log file, and spawn once.
+  const cmd = buildJobCommand(config, resolvedPrompt);
+  const stdoutPath = path.join(runDir, 'stdout.log');
+  const stdoutFd = fs.openSync(stdoutPath, 'w', 0o600);
 
   return new Promise<RunResult>((resolve) => {
     const child = spawn(cmd[0], cmd.slice(1), {

--- a/tests/runner-loop.test.ts
+++ b/tests/runner-loop.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the loop driver wired into executeJob (issue #400).
+ *
+ * Proves:
+ *   1. A job with config.loop runs through runLoop (the loop driver is invoked,
+ *      counting iterations via the injectable runIteration seam).
+ *   2. A job without config.loop does NOT invoke the loop driver.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { JobConfig } from '../src/lib/routines.js';
+import type { ExecOptions } from '../src/lib/exec.js';
+import type { LoopDeps, IterationResult } from '../src/lib/loop.js';
+
+// Hoist state the same way jobs.test.ts does (works with both vitest's hoist and Bun).
+// The string literal is used inside vi.mock to avoid TDZ issues with const references.
+interface LoopTestState { TEST_DIR: string }
+const hoistedState: LoopTestState =
+  ((globalThis as Record<string, unknown>)['__agents_cli_runner_loop_test_state__'] as LoopTestState | undefined)
+  ?? (((globalThis as Record<string, unknown>)['__agents_cli_runner_loop_test_state__'] = { TEST_DIR: '' }) as LoopTestState);
+
+vi.mock('../src/lib/state.js', () => {
+  const nodePath = require('node:path') as typeof import('path');
+  const gt = globalThis as Record<string, unknown>;
+  if (!gt['__agents_cli_runner_loop_test_state__']) {
+    gt['__agents_cli_runner_loop_test_state__'] = { TEST_DIR: '' };
+  }
+  const state = () => gt['__agents_cli_runner_loop_test_state__'] as LoopTestState;
+  return {
+    get getRoutinesDir() { return () => nodePath.join(state().TEST_DIR, 'routines'); },
+    get getRunsDir() { return () => nodePath.join(state().TEST_DIR, 'runs'); },
+    get getUserAgentsDir() { return () => state().TEST_DIR; },
+    get getCliVersionCachePath() { return () => nodePath.join(state().TEST_DIR, '.cli-version-cache.json'); },
+    get ensureAgentsDir() { return () => {}; },
+    get getProjectRoutinesDir() { return () => null; },
+  };
+});
+
+import { executeJob } from '../src/lib/runner.js';
+
+function makeConfig(overrides: Partial<JobConfig> = {}): JobConfig {
+  return {
+    name: 'loop-test-job',
+    schedule: '0 9 * * *',
+    agent: 'claude',
+    mode: 'plan',
+    effort: 'auto',
+    timeout: '10m',
+    enabled: true,
+    prompt: 'iterate over the task',
+    sandbox: false,  // skip HOME overlay so tests need no real filesystem setup
+    ...overrides,
+  };
+}
+
+function makeLoopDeps(calls: ExecOptions[]): LoopDeps {
+  return {
+    runIteration: async (o: ExecOptions): Promise<IterationResult> => {
+      calls.push(o);
+      return { exitCode: 0, tokens: 0 };
+    },
+    sleep: async () => {},
+    writeCheckpoint: () => {},
+  };
+}
+
+beforeEach(() => {
+  hoistedState.TEST_DIR = mkdtempSync(join(tmpdir(), 'agents-runner-loop-'));
+  mkdirSync(join(hoistedState.TEST_DIR, 'runs'), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(hoistedState.TEST_DIR, { recursive: true, force: true });
+});
+
+describe('executeJob — loop driver (issue #400)', () => {
+  it('runs exactly maxIterations iterations through runLoop when config.loop is set', async () => {
+    const calls: ExecOptions[] = [];
+    const config = makeConfig({ loop: { maxIterations: 3, interval: '0' } });
+
+    const result = await executeJob(config, makeLoopDeps(calls));
+
+    expect(calls.length).toBe(3);
+    expect(result.meta.status).toBe('completed');
+    expect(result.meta.exitCode).toBe(0);
+  });
+
+  it('passes the resolved prompt through to each loop iteration', async () => {
+    const calls: ExecOptions[] = [];
+    const config = makeConfig({ loop: { maxIterations: 2, interval: '0' }, prompt: 'do the work' });
+
+    await executeJob(config, makeLoopDeps(calls));
+
+    // Iteration 1 gets the bare entrypoint; iterations >= 2 get the /continue prefix —
+    // check that the entrypoint appears in every call.
+    for (const call of calls) {
+      expect(call.prompt).toContain('do the work');
+    }
+  });
+
+  it('does NOT invoke the loop driver when config.loop is absent', async () => {
+    const calls: ExecOptions[] = [];
+    const deps = makeLoopDeps(calls);
+
+    // No loop field — should go to the single-shot spawn path.
+    // Use agent 'cursor' which buildJobCommand rejects immediately (unsupported),
+    // so executeJob throws without ever reaching a real spawn or the loop driver.
+    await expect(
+      executeJob(makeConfig({ agent: 'cursor' as any }), deps),
+    ).rejects.toThrow('Unsupported agent for daemon jobs');
+
+    // Loop driver must not have been invoked.
+    expect(calls.length).toBe(0);
+  });
+
+  it('marks status failed when runLoop stops with error', async () => {
+    const config = makeConfig({ loop: { maxIterations: 5, interval: '0' } });
+    const deps: LoopDeps = {
+      runIteration: async (): Promise<IterationResult> => ({ exitCode: 1, tokens: 0 }),
+      sleep: async () => {},
+      writeCheckpoint: () => {},
+    };
+
+    const result = await executeJob(config, deps);
+
+    expect(result.meta.status).toBe('failed');
+    expect(result.meta.exitCode).toBe(1);
+  });
+});

--- a/tests/runner-loop.test.ts
+++ b/tests/runner-loop.test.ts
@@ -22,20 +22,26 @@ const hoistedState: LoopTestState =
   ((globalThis as Record<string, unknown>)['__agents_cli_runner_loop_test_state__'] as LoopTestState | undefined)
   ?? (((globalThis as Record<string, unknown>)['__agents_cli_runner_loop_test_state__'] = { TEST_DIR: '' }) as LoopTestState);
 
-vi.mock('../src/lib/state.js', () => {
-  const nodePath = require('node:path') as typeof import('path');
+// Partial mock: keep the real state.js exports (getModelsCachePath, loaded at
+// models.ts import time, and getMailboxRootDir, used by runLoop) and override
+// only the path getters to the isolated TEST_DIR. A full replacement drops
+// those transitive exports and fails under vitest (the CI runner).
+vi.mock('../src/lib/state.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/lib/state.js')>();
   const gt = globalThis as Record<string, unknown>;
   if (!gt['__agents_cli_runner_loop_test_state__']) {
     gt['__agents_cli_runner_loop_test_state__'] = { TEST_DIR: '' };
   }
   const state = () => gt['__agents_cli_runner_loop_test_state__'] as LoopTestState;
   return {
-    get getRoutinesDir() { return () => nodePath.join(state().TEST_DIR, 'routines'); },
-    get getRunsDir() { return () => nodePath.join(state().TEST_DIR, 'runs'); },
-    get getUserAgentsDir() { return () => state().TEST_DIR; },
-    get getCliVersionCachePath() { return () => nodePath.join(state().TEST_DIR, '.cli-version-cache.json'); },
-    get ensureAgentsDir() { return () => {}; },
-    get getProjectRoutinesDir() { return () => null; },
+    ...actual,
+    getRoutinesDir: () => join(state().TEST_DIR, 'routines'),
+    getRunsDir: () => join(state().TEST_DIR, 'runs'),
+    getUserAgentsDir: () => state().TEST_DIR,
+    getCliVersionCachePath: () => join(state().TEST_DIR, '.cli-version-cache.json'),
+    ensureAgentsDir: () => {},
+    getProjectRoutinesDir: () => null,
+    getMailboxRootDir: () => join(state().TEST_DIR, 'mailbox'),
   };
 });
 


### PR DESCRIPTION
## What

Adds a `loop` option to `JobConfig` and wires it into `executeJob` so a scheduled routine, when it fires, runs through the same `runLoop` driver as `agents run --loop` and workflow `loop:` frontmatter blocks (#332). Jobs without `loop` behave exactly as today — fully backward-compatible.

## Changes

**`src/lib/routines.ts`** — `JobConfig` schema addition:
- `import type { LoopConfig } from './loop.js'` (type-only import, no circular runtime dependency — `loop.ts` already imports `parseTimeout` from `routines.ts` at runtime)
- `loop?: LoopConfig` field on `JobConfig`

**`src/lib/runner.ts`** — `executeJob` dispatch:
- Accept optional `deps?: LoopDeps` for injectable test seams (same pattern as `runLoop` itself)
- When `config.loop` is set: build `ExecOptions` from the job config (agent, prompt, mode, effort, sandbox env, allow.dirs → addDirs, model) and call `runLoop` — no single spawn
- Map `LoopResult.stoppedBy` to `RunMeta.status`/`exitCode`
- Single-shot path (no loop) is unchanged

**`tests/runner-loop.test.ts`** — new test file proving:
- Job with `loop.maxIterations = 3` calls `runIteration` exactly 3 times
- Resolved prompt is threaded to every iteration
- Job without `loop` never invokes the loop driver
- `stoppedBy = error` maps to `meta.status = failed`

## Test

```
bun test tests/runner-loop.test.ts  → 4 pass, 0 fail
bun test tests/runner.test.ts tests/jobs.test.ts tests/runner-loop.test.ts tests/scheduler.test.ts  → 76 pass, 0 fail
bunx tsc --noEmit  → clean
```