### PR TITLE
feat(daemon): ensure the daemon on secrets unlock, not just routines (Closes #415)

### DIFF
--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -12,6 +12,7 @@ import { terminalWidth, truncateToWidth, stringWidth } from '../lib/session/widt
 import * as fs from 'fs';
 import { SSH_TARGET_RE, assertValidSshTarget, sshExec, type SshExecResult } from '../lib/ssh-exec.js';
 import { quoteWin32ExecArg, composeWin32CommandLine } from '../lib/platform/index.js';
+import { ensureDaemonStarted } from '../lib/daemon.js';
 import {
   parseHostsOption,
   remoteResolveEnv,
@@ -1578,6 +1579,12 @@ Examples:
         console.error(chalk.red('Could not start the secrets-agent.'));
         process.exit(1);
       }
+      // #415: the daemon should be always-on for any background need, not only
+      // after `routines add`. A user who only ever unlocks secrets still gets
+      // the daemon installed + running here. `ensureAgentRunning` above only
+      // brings up the standalone secrets broker, not the daemon. Idempotent
+      // (single-instance start lock, #414) and best-effort — never blocks unlock.
+      ensureDaemonStarted();
       let loaded = 0;
       for (const name of targets) {
         try {

--- a/src/lib/daemon.test.ts
+++ b/src/lib/daemon.test.ts
@@ -24,6 +24,11 @@ import {
   getDaemonLaunch,
   startDetached,
   writeOwnerOnlyServiceManifest,
+  ensureDaemonStarted,
+  isDaemonRunning,
+  readDaemonPid,
+  writeDaemonPid,
+  removeDaemonPid,
 } from './daemon.js';
 import { ipcEndpoint } from './platform/index.js';
 import {
@@ -381,4 +386,45 @@ describe('daemon single-instance (#414)', () => {
       fs.rmSync(tmpHome, { recursive: true, force: true });
     }
   }, 60_000);
+});
+
+/**
+ * #415: the daemon must be always-on for any background need, not only after
+ * `routines add`. `ensureDaemonStarted` is the shared side-effect entrypoint the
+ * secrets-unlock path (src/commands/secrets.ts) now calls after bringing up the
+ * standalone secrets broker. It must reuse the single `startDaemon` entrypoint,
+ * so the #414 single-instance guard makes a second unlock a no-op rather than a
+ * relaunch. We seed the pid file with our own (guaranteed-alive) pid so
+ * startDaemon takes its already-running branch and never spawns a real daemon.
+ */
+describe('ensureDaemonStarted (#415: always-on beyond routines)', () => {
+  let priorPid: number | null = null;
+
+  beforeEach(() => { priorPid = readDaemonPid(); });
+  afterEach(() => {
+    // Leave any real daemon on this machine exactly as we found it.
+    if (priorPid === null) removeDaemonPid();
+    else writeDaemonPid(priorPid);
+  });
+
+  it('is an idempotent no-op when a daemon is already running', () => {
+    writeDaemonPid(process.pid);
+    expect(isDaemonRunning()).toBe(true);
+
+    // First unlock brings the daemon "up" — but it's already running, so this
+    // reports the existing owner without spawning a second process.
+    const first = ensureDaemonStarted();
+    expect(first).not.toBeNull();
+    expect(first!.method).toBe('already-running');
+    expect(first!.pid).toBe(process.pid);
+
+    // A second unlock (or any later background trigger) is a steady-state
+    // no-op, never a relaunch — the always-on guarantee, not a restart loop.
+    const second = ensureDaemonStarted();
+    expect(second!.method).toBe('already-running');
+    expect(second!.pid).toBe(process.pid);
+
+    // The pid file still points at the single owning process throughout.
+    expect(readDaemonPid()).toBe(process.pid);
+  });
 });

--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -615,6 +615,24 @@ export function startDaemon(): { pid: number | null; method: string } {
   }
 }
 
+/**
+ * Bring the always-on daemon up as a side effect of a background-adjacent
+ * command (secrets unlock, browser start, ...), not only from `routines add`.
+ *
+ * Delegates to the single `startDaemon` entrypoint, so it honors the
+ * single-instance start lock and is a no-op when a daemon is already running
+ * (returns `already-running`). Best-effort: any failure is swallowed and null
+ * returned, so ensuring the daemon can never break the foreground command that
+ * happened to bring it up. See issue #415.
+ */
+export function ensureDaemonStarted(): { pid: number | null; method: string } | null {
+  try {
+    return startDaemon();
+  } catch {
+    return null;
+  }
+}
+
 function startDaemonLocked(): { pid: number | null; method: string } {
   const platform = os.platform();
 


### PR DESCRIPTION
## The gap

Issue #415 wants the daemon to be always-on for **any** background need, not only after `routines add`.

Two entrypoints already start it: browser-start (#568, `src/lib/browser/ipc.ts` boots the daemon when the IPC socket is unreachable) and the launchd/systemd manifests (`RunAtLoad`/`KeepAlive`, `Restart=always`).

But one path was still missed: a fresh install whose user **only ever runs `agents secrets unlock`** never installed or started the daemon. The unlock action (`src/commands/secrets.ts`) only called `ensureAgentRunning()` — which brings up the standalone secrets **broker** (`src/lib/secrets/agent.ts`), not the daemon. So the daemon was never "always-on" for that user.

## The fix

Wire the secrets-unlock path to also ensure the daemon, reusing the **same** `startDaemon` entrypoint browser-start uses — no reimplementation of daemon install/launch.

- **`src/lib/daemon.ts`** — add a thin `ensureDaemonStarted()` wrapper that delegates to `startDaemon()`. It is:
  - **Idempotent** — `startDaemon()` checks `isDaemonRunning()` and returns `already-running` without spawning, honoring the single-instance start lock added in #414. A second unlock is a no-op, not a relaunch.
  - **Best-effort** — swallows any failure and returns `null`, so bringing up the daemon can never break the foreground `secrets unlock`.
- **`src/commands/secrets.ts`** — the `unlock` action calls `ensureDaemonStarted()` right after the broker is confirmed up. The secrets-agent behavior itself is unchanged; the daemon is only *additionally* ensured.

## Test

`src/lib/daemon.test.ts` adds an idempotency test proving `ensureDaemonStarted` reuses `startDaemon`'s already-running branch: it seeds the daemon pid file with the live test process pid (guaranteed alive), so `startDaemon` reports `already-running` and never spawns a real daemon. Two calls in a row both return the same owning pid — the always-on guarantee as a steady-state no-op. Real fs, no mocking; saves/restores any pre-existing pid file. Fails pre-change (the symbol doesn't exist).

Full-file run: unmodified `origin/main` is `19 pass / 2 fail`; this branch is `20 pass / 2 fail` — the +1 is the new #415 test. The 2 failing tests are the pre-existing heavy real-daemon spawn integration tests (`startDetached` / `#414 single-instance`), which flake identically on the unmodified baseline under concurrent socket contention in this sandbox and pass in isolation (3/3) and on GitHub Linux CI. This change touches none of that runtime path.

`bunx tsc --noEmit` clean.

Closes #415.