### PR TITLE
feat(budget): live mid-run kill-switch for teams + cloud dispatch (Closes #399)

### DIFF
--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -362,11 +362,31 @@ Examples:
       if (options.follow === false) return;
 
       try {
-        const result = await renderStream(provider.stream(task.id), { json });
+        // Live budget kill-switch (issue #399). Reuses makeLiveSpendWatcher to
+        // feed the provider's `usage` events into a shared watcher; on a cap
+        // breach we call provider.cancel(task.id) mid-stream. Dormant (returns
+        // null) when no caps are configured, so the raw stream flows unchanged.
+        const { wrapStreamWithBudgetGate } = await import('../lib/budget/live-cloud.js');
+        const gated = wrapStreamWithBudgetGate({
+          provider,
+          taskId: task.id,
+          project: task.repo ?? task.repos?.[0] ?? process.cwd(),
+          agent: task.agent ?? 'cloud',
+          cwd: process.cwd(),
+        });
+        const eventSource = gated ? gated.wrap(provider.stream(task.id)) : provider.stream(task.id);
+        const result = await renderStream(eventSource, { json });
         updateTaskStatus(task.id, result.status as CloudTaskStatus, {
           summary: result.summary,
           prUrl: result.prUrl,
         });
+        if (gated?.gate.breached()) {
+          const b = gated.gate.breach();
+          process.stderr.write(
+            `[budget] cap ${b?.cap} exceeded — cancelled cloud task ${task.id}\n`,
+          );
+          process.exitCode = 7; // Mirrors BUDGET_KILL_EXIT_CODE for CI/headless.
+        }
       } catch (err) {
         // Stream disconnect is OK — task keeps running
         process.stderr.write(chalk.dim(`\nStream disconnected. Task ${task.id} continues running.\n`));
@@ -516,11 +536,25 @@ Examples:
       const provider = resolveProvider(task.provider);
 
       try {
-        const result = await renderStream(provider.stream(id), { json });
+        // Live budget kill-switch (issue #399) — wrap the stream so a cap
+        // breach mid-stream cancels the task server-side. Dormant when no caps.
+        const { wrapStreamWithBudgetGate } = await import('../lib/budget/live-cloud.js');
+        const gated = wrapStreamWithBudgetGate({
+          provider,
+          taskId: id,
+          project: task.repo ?? task.repos?.[0] ?? process.cwd(),
+          agent: task.agent ?? 'cloud',
+          cwd: process.cwd(),
+        });
+        const eventSource = gated ? gated.wrap(provider.stream(id)) : provider.stream(id);
+        const result = await renderStream(eventSource, { json });
         updateTaskStatus(id, result.status as CloudTaskStatus, {
           summary: result.summary,
           prUrl: result.prUrl,
         });
+        if (gated?.gate.breached()) {
+          process.exitCode = 7;
+        }
       } catch (err) {
         process.stderr.write(chalk.dim(`\nStream ended. ${(err as Error).message}\n`));
       }

--- a/src/commands/teams.ts
+++ b/src/commands/teams.ts
@@ -1379,10 +1379,25 @@ export function registerTeamsCommands(program: Command): void {
       const maxWaves = Math.max(1, Number.parseInt(opts.maxWaves, 10) || 1000);
       const json = isJsonMode(opts);
 
+      // Live budget kill-switch (issue #399). Dormant when no caps set — the
+      // factory dropping this in returns null and runSupervisor short-circuits.
+      const { createTeamBudgetWatcher } = await import('../lib/budget/live-team.js');
+      const budgetWatcher = createTeamBudgetWatcher({
+        manager: mgr,
+        team,
+        cwd: process.cwd(),
+        onBreach: (b) => {
+          process.stderr.write(
+            `[budget] cap ${b.cap} exceeded ($${b.spend.toFixed(2)} > $${b.limit.toFixed(2)}) — stopping team ${team}\n`,
+          );
+        },
+      });
+
       const result = await runSupervisor(mgr, {
         team,
         intervalMs,
         maxWaves,
+        budgetWatcher,
         onWave: (s) => {
           const ts = s.timestamp.slice(11, 19);
           if (json) {
@@ -1408,6 +1423,14 @@ export function registerTeamsCommands(program: Command): void {
         console.error(chalk.yellow(`Hit --max-waves=${maxWaves}; stopping. Re-run to continue.`));
       } else if (result.stoppedBy === 'signal') {
         console.error(chalk.yellow(`Stopped by signal after ${result.waves} waves.`));
+      } else if (result.stoppedBy === 'budget') {
+        const b = result.budgetBreach;
+        console.error(chalk.red(
+          `Budget kill-switch tripped after ${result.waves} waves` +
+            (b ? ` (cap ${b.cap}: $${b.spend.toFixed(2)} > $${b.limit.toFixed(2)})` : '') +
+            `.`,
+        ));
+        process.exitCode = 7; // Mirrors BUDGET_KILL_EXIT_CODE for CI/headless.
       }
     });
 

--- a/src/lib/budget/live-cloud.test.ts
+++ b/src/lib/budget/live-cloud.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for the cloud dispatch live budget kill-switch (issue #399).
+ *
+ * The wrapper wraps a provider's SSE stream, feeds `usage` frames into a
+ * shared `makeLiveSpendWatcher`, and calls `provider.cancel(taskId)` on the
+ * first breach. Verifies:
+ *  - `wrapStreamWithBudgetGate` returns null when no caps are set (dormant).
+ *  - The wrapped stream forwards `usage` events downstream unchanged when
+ *    spend is under cap.
+ *  - On a mid-stream cap breach it (a) calls provider.cancel exactly once,
+ *    (b) emits a synthetic error + cancelled status downstream, (c) stops
+ *    yielding further events from the source.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Pin HOME BEFORE any state.ts import so getHistoryDir() points at a temp dir.
+const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'live-cloud-home-'));
+process.env.HOME = fakeHome;
+fs.mkdirSync(path.join(fakeHome, '.agents'), { recursive: true });
+
+const { wrapStreamWithBudgetGate } = await import('./live-cloud.js');
+import type { CloudEvent, CloudProvider, CloudTask, CloudTaskStatus, DispatchOptions, ProviderCapabilities } from '../cloud/types.js';
+
+let projectDir: string;
+
+beforeEach(() => {
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'live-cloud-proj-'));
+});
+
+afterEach(() => {
+  fs.rmSync(projectDir, { recursive: true, force: true });
+});
+
+/**
+ * A stub CloudProvider that only implements what the gate touches: `cancel`.
+ * Every other method throws — a fail-loud contract, so if the gate ever
+ * calls something it shouldn't, the test surfaces it immediately.
+ */
+class StubProvider implements CloudProvider {
+  id = 'rush' as const;
+  name = 'stub';
+  cancelCalls: string[] = [];
+  cancelShouldThrow = false;
+
+  capabilities(): ProviderCapabilities {
+    return {
+      available: true,
+      dispatch: true, status: true, list: true, stream: true, cancel: true,
+      message: false, multiRepo: false, skills: false, images: false,
+    };
+  }
+  async dispatch(_o: DispatchOptions): Promise<CloudTask> { throw new Error('dispatch called'); }
+  async status(_id: string): Promise<CloudTask> { throw new Error('status called'); }
+  async list(): Promise<CloudTask[]> { throw new Error('list called'); }
+  async *stream(_id: string): AsyncIterable<CloudEvent> { throw new Error('stream called'); }
+  async cancel(taskId: string): Promise<void> {
+    this.cancelCalls.push(taskId);
+    if (this.cancelShouldThrow) throw new Error('cancel failed');
+  }
+  async message(_id: string, _c: string): Promise<void> { throw new Error('message called'); }
+}
+
+/** Build a synthetic SSE stream from a fixed event list. */
+async function* mkStream(events: CloudEvent[]): AsyncIterable<CloudEvent> {
+  for (const e of events) yield e;
+}
+
+/**
+ * Collect every event a wrapped stream yields. Used to assert both that
+ * pre-breach events pass through AND that post-breach events are dropped.
+ */
+async function collect(stream: AsyncIterable<CloudEvent>): Promise<CloudEvent[]> {
+  const out: CloudEvent[] = [];
+  for await (const e of stream) out.push(e);
+  return out;
+}
+
+describe('wrapStreamWithBudgetGate', () => {
+  it('returns null when no caps are configured (feature dormant)', () => {
+    // No agents.yaml, no user meta → hasAnyCap = false.
+    const provider = new StubProvider();
+    const wrapped = wrapStreamWithBudgetGate({
+      provider,
+      taskId: 'task-1',
+      project: 'owner/repo',
+      agent: 'claude',
+      cwd: projectDir,
+    });
+    expect(wrapped).toBeNull();
+  });
+
+  it('forwards events unchanged when spend stays under cap', async () => {
+    fs.writeFileSync(
+      path.join(projectDir, 'agents.yaml'),
+      'budget:\n  per_project: 100\n',
+    );
+    const provider = new StubProvider();
+    const wrapped = wrapStreamWithBudgetGate({
+      provider,
+      taskId: 'task-1',
+      project: 'owner/repo',
+      agent: 'claude',
+      cwd: projectDir,
+    });
+    expect(wrapped).not.toBeNull();
+
+    // 1M input on claude-opus-4 = $5, well under $100.
+    const events: CloudEvent[] = [
+      { type: 'text', content: 'hello' },
+      { type: 'usage', model: 'claude-opus-4', inputTokens: 1_000_000, outputTokens: 0 },
+      { type: 'done', status: 'completed' },
+    ];
+    const collected = await collect(wrapped!.wrap(mkStream(events)));
+    expect(collected).toEqual(events);
+    expect(provider.cancelCalls).toEqual([]);
+    expect(wrapped!.gate.breached()).toBe(false);
+  });
+
+  it('cancels the cloud task and emits an error frame on cap breach', async () => {
+    // per_project = $3; one 1M-input Claude turn is $5 → breach.
+    fs.writeFileSync(
+      path.join(projectDir, 'agents.yaml'),
+      'budget:\n  per_project: 3\n  on_exceed: block\n',
+    );
+    const provider = new StubProvider();
+    const wrapped = wrapStreamWithBudgetGate({
+      provider,
+      taskId: 'task-XYZ',
+      project: 'owner/repo',
+      agent: 'claude',
+      cwd: projectDir,
+    });
+
+    // Include events AFTER the breaching usage frame — they must NOT come out
+    // downstream. If they did, the renderer would keep printing text after
+    // the task was already cancelled.
+    const events: CloudEvent[] = [
+      { type: 'text', content: 'hi' },
+      { type: 'usage', model: 'claude-opus-4', inputTokens: 1_000_000 },
+      { type: 'text', content: 'this-must-not-appear' },
+      { type: 'done', status: 'completed' },
+    ];
+    const collected = await collect(wrapped!.wrap(mkStream(events)));
+
+    // Cancel called exactly once with the task id we handed the wrapper.
+    expect(provider.cancelCalls).toEqual(['task-XYZ']);
+    expect(wrapped!.gate.breached()).toBe(true);
+    expect(wrapped!.gate.breach()?.cap).toBe('per_project');
+
+    // Downstream sees: pre-breach text, the breaching usage, then the
+    // synthetic error + cancelled status. NO events after the breach.
+    expect(collected[0]).toEqual({ type: 'text', content: 'hi' });
+    // Last two frames are the gate's own signals.
+    expect(collected[collected.length - 2].type).toBe('error');
+    expect(collected[collected.length - 1]).toMatchObject({ type: 'status', status: 'cancelled' });
+    expect(collected.some((e) => e.type === 'text' && e.content === 'this-must-not-appear')).toBe(false);
+  });
+
+  it('surfaces cancel-failure to the caller (never silently drops the breach)', async () => {
+    fs.writeFileSync(
+      path.join(projectDir, 'agents.yaml'),
+      'budget:\n  per_project: 3\n',
+    );
+    const provider = new StubProvider();
+    provider.cancelShouldThrow = true;
+    const wrapped = wrapStreamWithBudgetGate({
+      provider,
+      taskId: 'task-oom',
+      project: 'owner/repo',
+      agent: 'claude',
+      cwd: projectDir,
+    });
+
+    const events: CloudEvent[] = [
+      { type: 'usage', model: 'claude-opus-4', inputTokens: 1_000_000 },
+    ];
+    const collected = await collect(wrapped!.wrap(mkStream(events)));
+    expect(provider.cancelCalls).toEqual(['task-oom']);
+    // Even when cancel fails we must still surface the breach + cancelled
+    // status downstream so the CLI exits with a visible reason.
+    expect(collected.some((e) => e.type === 'error' && /cancel FAILED/.test(e.message))).toBe(true);
+    expect(collected[collected.length - 1]).toMatchObject({ type: 'status', status: 'cancelled' });
+  });
+
+  it('per_agent cap trips ONLY when the dispatch agent matches', async () => {
+    // per_agent.codex $1 → only codex would breach, not claude.
+    fs.writeFileSync(
+      path.join(projectDir, 'agents.yaml'),
+      'budget:\n  per_agent:\n    codex: 1\n',
+    );
+    const provider = new StubProvider();
+    // Dispatch registered as agent=claude → $5 of "usage" attributed to
+    // claude does NOT breach the codex cap.
+    const wrapped = wrapStreamWithBudgetGate({
+      provider,
+      taskId: 't',
+      project: 'owner/repo',
+      agent: 'claude',
+      cwd: projectDir,
+    });
+    const events: CloudEvent[] = [
+      { type: 'usage', model: 'claude-opus-4', inputTokens: 1_000_000 },
+    ];
+    await collect(wrapped!.wrap(mkStream(events)));
+    expect(provider.cancelCalls).toEqual([]);
+    expect(wrapped!.gate.breached()).toBe(false);
+  });
+});

--- a/src/lib/budget/live-cloud.ts
+++ b/src/lib/budget/live-cloud.ts
@@ -1,0 +1,119 @@
+/**
+ * Live budget kill-switch for `agents cloud` dispatch (issue #399).
+ *
+ * Follow-up to #346, which shipped a pre-flight budget gate for cloud runs but
+ * no live mid-run enforcement — a runaway cloud task would keep spending until
+ * the user hit Ctrl-C. This wires the same `makeLiveSpendWatcher` the local
+ * headless run uses (src/lib/exec.ts) into the cloud SSE stream: each `usage`
+ * event from the provider feeds the watcher, and on breach we call
+ * `provider.cancel(taskId)` to terminate server-side.
+ *
+ * Wrapper shape mirrors `renderStream`'s input — it takes an
+ * `AsyncIterable<CloudEvent>` and yields the same events downstream. Dormant
+ * (returns the source stream unchanged) when no caps are configured.
+ */
+import type { CloudProvider, CloudEvent } from '../cloud/types.js';
+import {
+  capsFromConfig,
+  makeLiveSpendWatcher,
+  type BreachInfo,
+} from './enforce.js';
+import { resolveBudgetConfig, hasAnyCap } from './config.js';
+import { loadLedger, localDay, spendForDay, spendForProject } from './ledger.js';
+
+/** Result surface exposed to the caller so it can act on a mid-stream breach. */
+export interface CloudBudgetGate {
+  /** True once a cap crossed and cancel() was invoked. */
+  breached(): boolean;
+  breach(): BreachInfo | null;
+}
+
+/**
+ * Wrap a cloud event stream with a live budget watcher. On a `usage` event we
+ * feed the shared watcher; on the first breach we call `provider.cancel(taskId)`
+ * and forward a synthetic `status:'cancelled'` + `error` frame so the renderer
+ * shows why the task stopped. Returns null when no caps are configured; callers
+ * fall through to the raw stream in that case.
+ */
+export function wrapStreamWithBudgetGate(args: {
+  provider: CloudProvider;
+  taskId: string;
+  /** Project attribution key — repo slug for Rush, or cwd. */
+  project: string;
+  /** Agent the dispatch runs under (for per_agent cap accounting). */
+  agent: string;
+  /** cwd used to resolve the effective budget config. */
+  cwd?: string;
+}): {
+  wrap: (source: AsyncIterable<CloudEvent>) => AsyncIterable<CloudEvent>;
+  gate: CloudBudgetGate;
+} | null {
+  const cfg = resolveBudgetConfig(args.cwd);
+  if (!hasAnyCap(cfg)) return null;
+
+  const today = localDay();
+  const entries = loadLedger();
+  const caps = capsFromConfig(cfg, {
+    daySpend: spendForDay(today, entries),
+    projectSpend: spendForProject(args.project, entries),
+  });
+
+  let firstBreach: BreachInfo | null = null;
+  const watcher = makeLiveSpendWatcher({
+    caps,
+    onBreach: (b) => {
+      firstBreach = b;
+    },
+  });
+
+  async function* wrap(source: AsyncIterable<CloudEvent>): AsyncIterable<CloudEvent> {
+    try {
+      for await (const event of source) {
+        if (event.type === 'usage') {
+          watcher.feedUsage({
+            agent: args.agent,
+            model: event.model,
+            inputTokens: event.inputTokens ?? 0,
+            outputTokens: event.outputTokens ?? 0,
+          });
+          if (watcher.breached() && firstBreach) {
+            // Cancel server-side FIRST so we stop the meter; then surface the
+            // breach to the renderer as an error + cancelled status so the CLI
+            // exits with a visible reason (not a silent stream close).
+            try {
+              await args.provider.cancel(args.taskId);
+            } catch (err) {
+              // Best-effort — even if cancel fails, break the stream: the
+              // caller sees the error frame and can retry manually.
+              yield {
+                type: 'error',
+                message: `[budget] cap ${firstBreach.cap} exceeded ($${firstBreach.spend.toFixed(2)} > $${firstBreach.limit.toFixed(2)}); cancel FAILED: ${(err as Error).message}`,
+                timestamp: new Date().toISOString(),
+              };
+              yield { type: 'status', status: 'cancelled', timestamp: new Date().toISOString() };
+              return;
+            }
+            yield {
+              type: 'error',
+              message: `[budget] cap ${firstBreach.cap} exceeded ($${firstBreach.spend.toFixed(2)} > $${firstBreach.limit.toFixed(2)}) — cancelled cloud task ${args.taskId}`,
+              timestamp: new Date().toISOString(),
+            };
+            yield { type: 'status', status: 'cancelled', timestamp: new Date().toISOString() };
+            return;
+          }
+        }
+        yield event;
+      }
+    } finally {
+      watcher.dispose();
+    }
+  }
+
+  return {
+    wrap,
+    gate: {
+      breached: () => watcher.breached(),
+      breach: () => firstBreach,
+    },
+  };
+}

--- a/src/lib/budget/live-team.test.ts
+++ b/src/lib/budget/live-team.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for the teams live budget kill-switch (issue #399).
+ *
+ * Verifies the two contracts the supervisor relies on:
+ *  1. `createTeamBudgetWatcher.poll()` reads new bytes from every running
+ *     teammate's stdout.log, feeds real stream-json usage events into a
+ *     shared `makeLiveSpendWatcher`, and calls `onBreach` when a cap is
+ *     crossed by aggregated cross-teammate spend.
+ *  2. `runSupervisor` — when given the watcher — stops the team via
+ *     `AgentManager.stopByTask` on breach and returns `stoppedBy: 'budget'`.
+ *
+ * No mocking of the code under test: the watcher operates on a real
+ * AgentManager backed by a temp dir, a real stdout.log with real Claude
+ * stream-json shape, and the real pricing table (claude-opus-4 at $5/Mtok in).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawn, type ChildProcess } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// HOME must be pinned BEFORE any import that reaches state.ts, so
+// getHistoryDir() (which loadLedger uses) points at our temp dir and the
+// ledger starts empty regardless of the developer's real ~/.agents.
+const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'live-team-home-'));
+process.env.HOME = fakeHome;
+fs.mkdirSync(path.join(fakeHome, '.agents'), { recursive: true });
+
+const { AgentManager, AgentProcess, AgentStatus, captureProcessStartTime } = await import('../teams/agents.js');
+const { runSupervisor } = await import('../teams/supervisor.js');
+const { createTeamBudgetWatcher } = await import('./live-team.js');
+import type { AgentType } from '../teams/agents.js';
+import type { BreachInfo } from './enforce.js';
+import type { TeamBudgetWatcher } from './live-team.js';
+
+let tmpBase: string;
+let projectDir: string;
+let mgr: InstanceType<typeof AgentManager>;
+/** Every child we spawn — cleaned up in afterEach so a failed test can't leak processes. */
+let spawnedChildren: ChildProcess[] = [];
+
+/**
+ * One Claude stream-json assistant turn that costs exactly $5 on
+ * claude-opus-4 (1M input tokens @ $5/Mtok). This is the same fixture shape
+ * the LOCAL exec.ts watcher reads off a headless run's stdout, so tapping
+ * teammate stdout.logs with this must behave identically.
+ */
+function claudeAssistantTurnJson(): string {
+  return JSON.stringify({
+    type: 'assistant',
+    message: { model: 'claude-opus-4', usage: { input_tokens: 1_000_000 } },
+  });
+}
+
+beforeEach(async () => {
+  tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'live-team-'));
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'live-team-proj-'));
+  mgr = new AgentManager(50, tmpBase);
+  await mgr.listAll();
+});
+
+afterEach(() => {
+  // Reap any live children — a supervisor breach cascade may leave them
+  // dead already; force-kill is idempotent, and unref() lets vitest exit.
+  for (const c of spawnedChildren) {
+    try { if (c.pid) process.kill(-c.pid, 'SIGKILL'); } catch { /* already gone */ }
+    try { if (c.pid) process.kill(c.pid, 'SIGKILL'); } catch { /* already gone */ }
+  }
+  spawnedChildren = [];
+  fs.rmSync(tmpBase, { recursive: true, force: true });
+  fs.rmSync(projectDir, { recursive: true, force: true });
+});
+
+/**
+ * Plant a RUNNING teammate backed by a real, killable `sleep` process, so
+ * `AgentProcess.isProcessAlive()` sees a live PID with a real matching
+ * startTime and does NOT prematurely flip the teammate to COMPLETED via
+ * `updateStatusFromProcess()`. When the supervisor's breach path calls
+ * `stopByTask`, the SIGTERM/SIGKILL lands on our sleep and cleans up.
+ */
+async function plantRunningTeammate(
+  taskName: string,
+  agentType: AgentType,
+  stdoutLines: string[],
+): Promise<InstanceType<typeof AgentProcess>> {
+  const agentId = `agent-${Math.random().toString(36).slice(2, 10)}`;
+  // Detached so kill(-pid) reaches the whole group — the same pattern the
+  // teams launcher uses in production.
+  const child = spawn('sleep', ['30'], { detached: true, stdio: 'ignore' });
+  child.unref();
+  spawnedChildren.push(child);
+  if (!child.pid) throw new Error('Failed to spawn sleep child');
+
+  const agent = new AgentProcess(
+    agentId,
+    taskName,
+    agentType,
+    'test-prompt',
+    projectDir,
+    'edit',
+    child.pid,
+    AgentStatus.RUNNING,
+    new Date(),
+    null,
+    tmpBase,
+  );
+  agent.startTime = captureProcessStartTime(child.pid);
+  await agent.saveMeta();
+  mgr.registerAgent(agent);
+  const stdoutPath = await agent.getStdoutPath();
+  fs.writeFileSync(stdoutPath, stdoutLines.join('\n') + (stdoutLines.length ? '\n' : ''));
+  return agent;
+}
+
+describe('createTeamBudgetWatcher', () => {
+  it('returns null when no caps are configured (feature dormant)', () => {
+    // Empty project — no agents.yaml at any parent. resolveBudgetConfig
+    // returns { on_exceed: 'block' } with zero caps → hasAnyCap = false.
+    const w = createTeamBudgetWatcher({
+      manager: mgr,
+      team: 't1',
+      cwd: projectDir,
+      onBreach: () => {},
+    });
+    expect(w).toBeNull();
+  });
+
+  it('trips per_project when aggregated teammate spend crosses the cap', async () => {
+    // per_project = $8; two teammates each emit $5 of Claude usage → $10 > $8.
+    // This is the exact cross-vendor property the local exec watcher CANNOT
+    // enforce (each child sees only its own $5): the supervisor watcher must.
+    fs.writeFileSync(
+      path.join(projectDir, 'agents.yaml'),
+      'budget:\n  per_project: 8\n  on_exceed: block\n',
+    );
+    await plantRunningTeammate('t1', 'claude', [claudeAssistantTurnJson()]);
+    await plantRunningTeammate('t1', 'claude', [claudeAssistantTurnJson()]);
+
+    let breach: BreachInfo | null = null;
+    const w = createTeamBudgetWatcher({
+      manager: mgr,
+      team: 't1',
+      cwd: projectDir,
+      onBreach: (b) => { breach = b; },
+    });
+    expect(w).not.toBeNull();
+    await w!.poll();
+    expect(w!.breached()).toBe(true);
+    expect(breach!.cap).toBe('per_project');
+    expect(breach!.spend).toBeCloseTo(10, 6);
+    expect(breach!.limit).toBe(8);
+  });
+
+  it('does NOT trip when only one teammate spends under the aggregate cap', async () => {
+    fs.writeFileSync(
+      path.join(projectDir, 'agents.yaml'),
+      'budget:\n  per_project: 20\n',
+    );
+    await plantRunningTeammate('t1', 'claude', [claudeAssistantTurnJson()]); // $5
+    const w = createTeamBudgetWatcher({
+      manager: mgr,
+      team: 't1',
+      cwd: projectDir,
+      onBreach: () => {},
+    });
+    await w!.poll();
+    expect(w!.breached()).toBe(false);
+  });
+
+  it('is idempotent — polling twice with no new bytes does not double-count', async () => {
+    fs.writeFileSync(
+      path.join(projectDir, 'agents.yaml'),
+      'budget:\n  per_project: 8\n',
+    );
+    await plantRunningTeammate('t1', 'claude', [claudeAssistantTurnJson()]); // $5
+    const w = createTeamBudgetWatcher({
+      manager: mgr,
+      team: 't1',
+      cwd: projectDir,
+      onBreach: () => {},
+    });
+    await w!.poll();
+    await w!.poll();
+    // Two polls, one $5 event → still $5, not $10. No breach against $8 cap.
+    expect(w!.breached()).toBe(false);
+  });
+});
+
+describe('runSupervisor + TeamBudgetWatcher', () => {
+  it('stops the team via stopByTask and returns stoppedBy=budget on breach', async () => {
+    fs.writeFileSync(
+      path.join(projectDir, 'agents.yaml'),
+      'budget:\n  per_project: 3\n  on_exceed: block\n',
+    );
+    // One teammate whose stdout blows the cap on its first emitted turn.
+    const teammate = await plantRunningTeammate('t-kill', 'claude', [claudeAssistantTurnJson()]);
+    const watcher = createTeamBudgetWatcher({
+      manager: mgr,
+      team: 't-kill',
+      cwd: projectDir,
+      onBreach: () => {},
+    });
+    expect(watcher).not.toBeNull();
+
+    let onBreachSaw: BreachInfo | null = null;
+    const result = await runSupervisor(mgr, {
+      team: 't-kill',
+      intervalMs: 10,
+      maxWaves: 5,
+      budgetWatcher: watcher,
+      onBudgetBreach: (b) => { onBreachSaw = b; },
+      onWave: () => {},
+    });
+
+    // The supervisor must recognize the breach, terminate via stopByTask,
+    // and surface it as a distinct exit reason so the CLI can map it to
+    // BUDGET_KILL_EXIT_CODE.
+    expect(result.stoppedBy).toBe('budget');
+    expect(onBreachSaw).not.toBeNull();
+    expect(onBreachSaw!.cap).toBe('per_project');
+    expect(result.budgetBreach?.cap).toBe('per_project');
+
+    // The running teammate must have been stopped by the supervisor's
+    // stopByTask call (state must be STOPPED, not RUNNING).
+    const after = await mgr.get(teammate.agentId);
+    expect(after?.status).toBe(AgentStatus.STOPPED);
+  });
+
+  it('supervisor with a null budgetWatcher behaves exactly as before', async () => {
+    // Regression guard: passing budgetWatcher: null must be a no-op — the
+    // team drains normally with no budget path exercised at all.
+    fs.writeFileSync(path.join(projectDir, 'agents.yaml'), '');
+    const result = await runSupervisor(mgr, {
+      team: 'no-work',
+      intervalMs: 10,
+      maxWaves: 5,
+      budgetWatcher: null,
+      onWave: () => {},
+    });
+    expect(result.stoppedBy).toBe('drained');
+    expect(result.budgetBreach).toBeUndefined();
+  });
+});
+
+describe('TeamBudgetWatcher.dispose', () => {
+  it('is idempotent and stops accepting new events', async () => {
+    fs.writeFileSync(
+      path.join(projectDir, 'agents.yaml'),
+      'budget:\n  per_project: 100\n',
+    );
+    await plantRunningTeammate('t1', 'claude', [claudeAssistantTurnJson()]);
+    const w = createTeamBudgetWatcher({
+      manager: mgr,
+      team: 't1',
+      cwd: projectDir,
+      onBreach: () => {},
+    }) as TeamBudgetWatcher;
+    w.dispose();
+    // Second dispose must not throw.
+    expect(() => w.dispose()).not.toThrow();
+    // A poll after dispose is a no-op — no crash, no state change.
+    await w.poll();
+    expect(w.breached()).toBe(false);
+  });
+});

--- a/src/lib/budget/live-team.ts
+++ b/src/lib/budget/live-team.ts
@@ -1,0 +1,151 @@
+/**
+ * Live budget kill-switch for `agents teams` supervisor (issue #399).
+ *
+ * Follow-up to #346, which wired `makeLiveSpendWatcher` into local `agents run`
+ * only. Teams spawns each teammate as its own `agents run --headless --json`
+ * process, so per-teammate `per_run` caps already fire from those child
+ * watchers. What was still missing was aggregate cross-teammate enforcement
+ * (`per_project` / `per_day` / `per_agent` combined), because the ledger only
+ * gets written on child close — a long-running teammate would blow the shared
+ * cap without any single child watcher noticing.
+ *
+ * This module reuses `makeLiveSpendWatcher` verbatim: on each supervisor wave
+ * we tail every running teammate's stdout.log through `extractUsageEvents`
+ * (the same primitive the local run path uses in src/lib/exec.ts), feed the
+ * usage events into ONE shared watcher, and expose `breached()` so the
+ * supervisor can call `stopByTask` to terminate the whole team.
+ *
+ * Dormant (returns null) when no caps are configured — same zero-cost contract
+ * as the local watcher.
+ */
+import * as fs from 'fs';
+import type { AgentManager } from '../teams/agents.js';
+import {
+  capsFromConfig,
+  extractUsageEvents,
+  makeLiveSpendWatcher,
+  type BreachInfo,
+  type LiveSpendWatcher,
+} from './enforce.js';
+import { resolveBudgetConfig, hasAnyCap } from './config.js';
+import { loadLedger, localDay, spendForDay, spendForProject } from './ledger.js';
+
+/** Public surface of the team-scoped budget watcher. */
+export interface TeamBudgetWatcher {
+  /** Feed any new usage events from every running teammate's stdout.log. */
+  poll(): Promise<void>;
+  /** True once any cap has been crossed (mirrors LiveSpendWatcher). */
+  breached(): boolean;
+  /** The first breach seen, or null if none yet. */
+  breach(): BreachInfo | null;
+  /** Release references and stop tapping streams. Idempotent. */
+  dispose(): void;
+}
+
+/** Per-teammate cursor tracking how far we've read the stdout.log. */
+interface StreamCursor {
+  offset: number;
+  pending: string;
+}
+
+/**
+ * Build a team-scoped budget watcher for the given team. Returns null when the
+ * effective budget config has no caps — matching the local watcher's dormant
+ * contract so callers pay nothing when the feature is off.
+ *
+ * The watcher is seeded with prior-day and prior-project spend from the ledger
+ * so a partway-through day counts today's earlier runs against `per_day`.
+ * Each `poll()` reads new bytes from every running teammate's stdout.log and
+ * feeds parsed usage events into the shared watcher — `onBreach` fires exactly
+ * once, mirroring `makeLiveSpendWatcher`.
+ */
+export function createTeamBudgetWatcher(args: {
+  manager: AgentManager;
+  team: string;
+  /** Project/cwd used to (a) resolve budget config and (b) seed project spend. */
+  cwd: string;
+  onBreach: (breach: BreachInfo) => void;
+}): TeamBudgetWatcher | null {
+  const cfg = resolveBudgetConfig(args.cwd);
+  if (!hasAnyCap(cfg)) return null;
+
+  const today = localDay();
+  const entries = loadLedger();
+  const caps = capsFromConfig(cfg, {
+    daySpend: spendForDay(today, entries),
+    projectSpend: spendForProject(args.cwd, entries),
+  });
+
+  let firstBreach: BreachInfo | null = null;
+  const watcher: LiveSpendWatcher = makeLiveSpendWatcher({
+    caps,
+    onBreach: (b) => {
+      firstBreach = b;
+      args.onBreach(b);
+    },
+  });
+
+  const cursors = new Map<string, StreamCursor>();
+  let disposed = false;
+
+  return {
+    async poll(): Promise<void> {
+      if (disposed || watcher.breached()) return;
+      const teammates = await args.manager.listByTask(args.team);
+      for (const agent of teammates) {
+        // Only tap running local teammates: PENDING has no output yet, cloud
+        // teammates emit through a different channel (their own SSE stream),
+        // and terminal states produce no new bytes.
+        if (agent.status !== 'running') continue;
+        if (agent.cloudProvider) continue;
+
+        const stdoutPath = await agent.getStdoutPath();
+        let stat: fs.Stats;
+        try {
+          stat = fs.statSync(stdoutPath);
+        } catch {
+          continue; // File not yet created — nothing to read.
+        }
+
+        const cursor = cursors.get(agent.agentId) ?? { offset: 0, pending: '' };
+        if (stat.size <= cursor.offset) {
+          cursors.set(agent.agentId, cursor);
+          continue;
+        }
+
+        const fd = fs.openSync(stdoutPath, 'r');
+        try {
+          const toRead = stat.size - cursor.offset;
+          const buffer = Buffer.alloc(toRead);
+          const bytesRead = fs.readSync(fd, buffer, 0, toRead, cursor.offset);
+          const chunk = buffer.toString('utf-8', 0, bytesRead);
+          cursor.offset += bytesRead;
+
+          const { events, rest } = extractUsageEvents(
+            chunk,
+            cursor.pending,
+            undefined,
+            agent.agentType,
+          );
+          cursor.pending = rest;
+          for (const ev of events) {
+            watcher.feedUsage(ev);
+            if (watcher.breached()) break;
+          }
+        } finally {
+          fs.closeSync(fd);
+        }
+        cursors.set(agent.agentId, cursor);
+        if (watcher.breached()) return;
+      }
+    },
+    breached: () => watcher.breached(),
+    breach: () => firstBreach,
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      watcher.dispose();
+      cursors.clear();
+    },
+  };
+}

--- a/src/lib/teams/supervisor.ts
+++ b/src/lib/teams/supervisor.ts
@@ -18,6 +18,8 @@
  * terminal output, json-per-wave output, or a TUI.
  */
 import type { AgentManager, AgentProcess } from './agents.js';
+import type { TeamBudgetWatcher } from '../budget/live-team.js';
+import type { BreachInfo } from '../budget/enforce.js';
 
 export interface WaveSummary {
   wave: number;
@@ -37,12 +39,23 @@ export interface SupervisorOptions {
   maxWaves?: number;
   /** Called once per wave. Return false to stop the loop gracefully. */
   onWave: (summary: WaveSummary) => void | Promise<void> | boolean | Promise<boolean>;
+  /**
+   * Optional live-spend watcher (issue #399). Polled once per wave; on first
+   * breach the supervisor calls `manager.stopByTask(team)` and exits with
+   * `stoppedBy: 'budget'`. Dormant when null — supervisor behavior is unchanged
+   * for teams that never opt into budget enforcement.
+   */
+  budgetWatcher?: TeamBudgetWatcher | null;
+  /** Called with the breach details when the budget watcher trips. */
+  onBudgetBreach?: (breach: BreachInfo) => void;
 }
 
 export interface SupervisorResult {
   waves: number;
-  stoppedBy: 'drained' | 'max-waves' | 'signal' | 'callback';
+  stoppedBy: 'drained' | 'max-waves' | 'signal' | 'callback' | 'budget';
   elapsed_ms: number;
+  /** Set when `stoppedBy === 'budget'` — the breach that terminated the team. */
+  budgetBreach?: BreachInfo;
 }
 
 /**
@@ -93,6 +106,25 @@ export async function runSupervisor(
       const keepGoing = await opts.onWave(summary);
       if (keepGoing === false) {
         return { waves: wave, stoppedBy: 'callback', elapsed_ms: Date.now() - startedAt };
+      }
+
+      // Live budget kill (issue #399). Poll AFTER the wave's callback so the
+      // most recent teammate stdout is already flushed to disk. On breach we
+      // stop every RUNNING teammate — the DAG effectively drains this wave.
+      if (opts.budgetWatcher) {
+        await opts.budgetWatcher.poll();
+        if (opts.budgetWatcher.breached()) {
+          const breach = opts.budgetWatcher.breach();
+          await mgr.stopByTask(team);
+          if (breach && opts.onBudgetBreach) opts.onBudgetBreach(breach);
+          opts.budgetWatcher.dispose();
+          return {
+            waves: wave,
+            stoppedBy: 'budget',
+            elapsed_ms: Date.now() - startedAt,
+            budgetBreach: breach ?? undefined,
+          };
+        }
       }
 
       // Re-check drain AFTER the callback. The callback may have added new


### PR DESCRIPTION
## Summary

Follow-up to #346. That PR shipped `makeLiveSpendWatcher` and wired it into local `agents run` only. Teams and cloud kept a pre-flight budget gate but no live enforcement — a team blowing `per_project` across teammates or a runaway cloud task would keep spending until the user hit Ctrl-C.

This PR reuses `makeLiveSpendWatcher` **verbatim** (no reimplementation) in two new provider-agnostic wrappers and hooks the existing kill / cancel primitives.

## What's new

**`src/lib/budget/live-team.ts` — `createTeamBudgetWatcher`**
- Seeded from the ledger with prior day + project spend so partway-through-day accounting is right.
- `poll()` tails every RUNNING teammate's `stdout.log` incrementally with the same `extractUsageEvents` primitive `exec.ts` uses locally, feeding aggregated cross-teammate cost into ONE shared watcher.
- Dormant (returns `null`) when no caps configured — mirrors the local watcher's zero-cost contract.
- `runSupervisor` accepts `opts.budgetWatcher` and polls it once per wave. On breach: `mgr.stopByTask(team)` → returns `stoppedBy: 'budget'` + `budgetBreach`.
- `agents teams start --watch` wires it up and sets `process.exitCode = 7` (matches `BUDGET_KILL_EXIT_CODE`) so CI/headless can tell a budget kill apart from a normal failure.

**`src/lib/budget/live-cloud.ts` — `wrapStreamWithBudgetGate`**
- Wraps a provider's SSE `CloudEvent` stream. On each `usage` frame, feeds `makeLiveSpendWatcher`; on breach calls `provider.cancel(taskId)` and emits a synthetic `error` + `status: 'cancelled'` frame downstream so the renderer shows why the task stopped.
- Cancel-failure is surfaced (never silently dropped) — the wrapper still yields the error + cancelled frame so the CLI exits with a visible reason.
- Wired at both `agents cloud run` (post-dispatch stream) and `agents cloud logs` (attach-to-existing). Sets `process.exitCode = 7` on trip.

## Tests

`src/lib/budget/live-team.test.ts` (7 tests) — real `AgentManager` backed by real `sleep` child processes (so `isProcessAlive` stays true through `listByTask`), real Claude stream-json shape, real pricing table. Asserts the cross-vendor property, poll idempotence, and that `runSupervisor` calls `stopByTask` + returns `stoppedBy: 'budget'` on breach.

`src/lib/budget/live-cloud.test.ts` (5 tests) — stub `CloudProvider` (fails-loud on any method the gate shouldn't call). Asserts pass-through under cap, cancel called exactly once on breach, post-breach source events dropped, cancel-failure surfaced, and per-agent scoping.

**Confirmed the supervisor breach test FAILS with `stoppedBy: 'max-waves'` when the wiring is reverted and PASSES with it.**

Full vitest run: 3996 passed, 65 skipped. `bunx tsc --noEmit` clean.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun run test` — 3996/3996 pass (one unrelated tmux socket flake, passes standalone)
- [x] Pre-change failure verified: reverting `supervisor.ts` diff makes the teams breach test fail with `stoppedBy: 'max-waves'`
- [x] Zero-cost dormant path verified — `createTeamBudgetWatcher` / `wrapStreamWithBudgetGate` return `null` with no caps