### PR TITLE
feat(workflows): declarative for_each dynamic fan-out (Closes #343)

### DIFF
--- a/src/lib/teams/__tests__/forEach.test.ts
+++ b/src/lib/teams/__tests__/forEach.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Declarative dynamic fan-out (issue #343).
+ *
+ * The `for_each:` construct is a declarative layer over the existing teams
+ * substrate: a producer emits a list at runtime, one stage teammate runs per
+ * item, optionally gated by a verify panel. These tests exercise the real
+ * critical path with no mocking:
+ *
+ *   - `parseForEachBlock` / `parseVerifyBlock` — the defensive frontmatter parse.
+ *   - `expandForEach` — the pure expansion into teammate descriptors.
+ *   - Real `AgentProcess` + `AgentManager` persistence — proving the expansion
+ *     stages a valid `--after` DAG the supervisor can pick up mid-flight.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+import {
+  AgentManager,
+  AgentProcess,
+  AgentStatus,
+  type AgentType,
+} from '../agents.js';
+import {
+  parseForEachBlock,
+  parseVerifyBlock,
+  expandForEach,
+  renderForEachTemplate,
+  DEFAULT_FOR_EACH_CAP,
+  type ForEachSpec,
+  type ForEachTeammate,
+} from '../../workflows.js';
+
+describe('parseForEachBlock — defensive coercion (issue #343)', () => {
+  it('parses a well-formed for_each block with a verify panel', () => {
+    const spec = parseForEachBlock({
+      produce: "rg -l 'router\\.(get|post)' src/routes/",
+      agent: 'auth-checker',
+      name: 'audit',
+      prompt: 'Audit {{item}} for missing auth checks',
+      concurrency: 8,
+      max_items: 50,
+      verify: { agent: 'skeptic', votes: 3, keep_if: 'majority' },
+    });
+    expect(spec).toEqual({
+      produce: "rg -l 'router\\.(get|post)' src/routes/",
+      agent: 'auth-checker',
+      name: 'audit',
+      prompt: 'Audit {{item}} for missing auth checks',
+      concurrency: 8,
+      max_items: 50,
+      verify: { agent: 'skeptic', votes: 3, keep_if: 'majority' },
+    });
+  });
+
+  it('drops the block unless both agent and prompt are present', () => {
+    expect(parseForEachBlock({ agent: 'x' })).toBeUndefined();
+    expect(parseForEachBlock({ prompt: 'do {{item}}' })).toBeUndefined();
+    expect(parseForEachBlock({ agent: '  ', prompt: 'p' })).toBeUndefined();
+    expect(parseForEachBlock(undefined)).toBeUndefined();
+    expect(parseForEachBlock([1, 2])).toBeUndefined();
+    expect(parseForEachBlock('for_each')).toBeUndefined();
+  });
+
+  it('captures an itemsRef from a for_each reference or items_ref', () => {
+    expect(parseForEachBlock({ for_each: '${endpoints}', agent: 'a', prompt: 'p' }))
+      .toMatchObject({ itemsRef: '${endpoints}' });
+    expect(parseForEachBlock({ items_ref: '${prior}', agent: 'a', prompt: 'p' }))
+      .toMatchObject({ itemsRef: '${prior}' });
+  });
+
+  it('drops malformed numeric fields rather than passing a bad shape', () => {
+    const spec = parseForEachBlock({
+      agent: 'a',
+      prompt: 'p',
+      concurrency: 0,
+      max_items: 2.5,
+    })!;
+    expect(spec.concurrency).toBeUndefined();
+    expect(spec.max_items).toBeUndefined();
+  });
+
+  it('parseVerifyBlock defaults votes to 1 and keep_if to majority', () => {
+    expect(parseVerifyBlock({ agent: 'skeptic' }))
+      .toEqual({ agent: 'skeptic', votes: 1, keep_if: 'majority' });
+    // An unknown keep_if falls back to majority; a bad votes falls back to 1.
+    expect(parseVerifyBlock({ agent: 'skeptic', votes: -3, keep_if: 'whenever' }))
+      .toEqual({ agent: 'skeptic', votes: 1, keep_if: 'majority' });
+    // No agent -> no panel.
+    expect(parseVerifyBlock({ votes: 3 })).toBeUndefined();
+  });
+
+  it('drops a malformed verify sub-block but keeps the for_each', () => {
+    const spec = parseForEachBlock({ agent: 'a', prompt: 'p', verify: { votes: 3 } })!;
+    expect(spec.verify).toBeUndefined();
+    expect(spec.agent).toBe('a');
+  });
+});
+
+describe('renderForEachTemplate', () => {
+  it('substitutes item, index (0-based), and n (1-based)', () => {
+    expect(renderForEachTemplate('audit {{item}} (#{{n}}, idx {{index}})', 'src/a.ts', 2))
+      .toBe('audit src/a.ts (#3, idx 2)');
+  });
+  it('leaves unknown tokens intact', () => {
+    expect(renderForEachTemplate('{{item}} — {{unknown}}', 'x', 0)).toBe('x — {{unknown}}');
+  });
+});
+
+describe('expandForEach — one stage per produced item + verify (issue #343)', () => {
+  const spec: ForEachSpec = {
+    agent: 'auth-checker',
+    name: 'audit',
+    prompt: 'Audit {{item}} for missing auth checks',
+    verify: { agent: 'skeptic', votes: 3, keep_if: 'majority' },
+  };
+
+  it('fans out exactly one stage teammate per item, N unknown until produced', () => {
+    const items = ['src/routes/a.ts', 'src/routes/b.ts', 'src/routes/c.ts'];
+    const { teammates, producedCount, usedCount, truncated } = expandForEach(spec, items);
+
+    const stages = teammates.filter((t) => t.role === 'stage');
+    expect(stages).toHaveLength(items.length);
+    expect(stages.map((t) => t.item)).toEqual(items);
+    expect(stages.map((t) => t.name)).toEqual(['audit-1', 'audit-2', 'audit-3']);
+    // Template substitution happened per item.
+    expect(stages[0].prompt).toBe('Audit src/routes/a.ts for missing auth checks');
+    expect(producedCount).toBe(3);
+    expect(usedCount).toBe(3);
+    expect(truncated).toBe(0);
+  });
+
+  it('expands `votes` skeptics per item, each depending on that item stage', () => {
+    const items = ['a', 'b'];
+    const { teammates } = expandForEach(spec, items);
+
+    const verifiers = teammates.filter((t) => t.role === 'verify');
+    // 2 items * 3 votes.
+    expect(verifiers).toHaveLength(6);
+
+    // Each item's skeptics wait on ONLY that item's stage teammate.
+    const forA = verifiers.filter((t) => t.item === 'a');
+    expect(forA.map((t) => t.name)).toEqual(['audit-1-verify-1', 'audit-1-verify-2', 'audit-1-verify-3']);
+    expect(forA.every((t) => t.after.length === 1 && t.after[0] === 'audit-1')).toBe(true);
+    expect(forA.every((t) => t.agentType === 'skeptic')).toBe(true);
+    expect(forA.every((t) => t.votes === 3 && t.keep_if === 'majority')).toBe(true);
+  });
+
+  it('links stage teammates after the producer when a producerName is given', () => {
+    const { teammates } = expandForEach(spec, ['a'], { producerName: 'endpoints' });
+    const stage = teammates.find((t) => t.role === 'stage')!;
+    expect(stage.after).toEqual(['endpoints']);
+  });
+
+  it('omits verify teammates when no verify panel is declared', () => {
+    const bare: ForEachSpec = { agent: 'x', prompt: 'do {{item}}' };
+    const { teammates } = expandForEach(bare, ['a', 'b']);
+    expect(teammates).toHaveLength(2);
+    expect(teammates.every((t) => t.role === 'stage')).toBe(true);
+  });
+
+  it('enforces the runaway-producer hard cap (default and explicit)', () => {
+    const many = Array.from({ length: DEFAULT_FOR_EACH_CAP + 25 }, (_, i) => `item-${i}`);
+    const dflt = expandForEach({ agent: 'x', prompt: 'p' }, many);
+    expect(dflt.usedCount).toBe(DEFAULT_FOR_EACH_CAP);
+    expect(dflt.truncated).toBe(25);
+    expect(dflt.teammates.filter((t) => t.role === 'stage')).toHaveLength(DEFAULT_FOR_EACH_CAP);
+
+    const capped = expandForEach({ agent: 'x', prompt: 'p', max_items: 4 }, many);
+    expect(capped.usedCount).toBe(4);
+    expect(capped.producedCount).toBe(DEFAULT_FOR_EACH_CAP + 25);
+    expect(capped.truncated).toBe(DEFAULT_FOR_EACH_CAP + 21);
+  });
+});
+
+describe('expandForEach stages a valid teams DAG through real persistence', () => {
+  let tmpBase: string;
+
+  beforeEach(() => {
+    tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'foreach-dag-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  /**
+   * Persist an expanded descriptor as a real `AgentProcess` meta.json — the
+   * same on-disk shape `AgentManager.spawn` writes and the supervisor rescans.
+   * (We plant directly rather than `spawn` so the test needs no installed CLI,
+   * exactly like supervisor.test.ts's `plantAgent`.)
+   */
+  async function plant(team: string, t: ForEachTeammate): Promise<void> {
+    const agent = new AgentProcess(
+      `agent-${t.name}`,
+      team,
+      t.agentType as AgentType,
+      t.prompt,
+      null,
+      'edit',
+      null,
+      AgentStatus.PENDING,
+      new Date(),
+      null,
+      tmpBase,
+      null, null, null, null, null, null, null,
+      t.name,
+      t.after,
+      'medium', null, null,
+      null,
+    );
+    await agent.saveMeta();
+  }
+
+  it('reloads the fanned-out DAG with correct --after linkage', async () => {
+    const spec: ForEachSpec = {
+      agent: 'auth-checker',
+      name: 'audit',
+      prompt: 'Audit {{item}}',
+      verify: { agent: 'skeptic', votes: 2, keep_if: 'majority' },
+    };
+    const items = ['src/routes/a.ts', 'src/routes/b.ts'];
+    const { teammates } = expandForEach(spec, items, { producerName: 'endpoints' });
+
+    // Plant the producer plus every expanded teammate as the substrate would.
+    const producer = new AgentProcess(
+      'agent-endpoints', 'sweep', 'claude' as AgentType, 'produce list',
+      null, 'edit', null, AgentStatus.COMPLETED,
+      new Date(Date.now() - 100), new Date(),
+      tmpBase, null, null, null, null, null, null, null,
+      'endpoints', [], 'medium', null, null, null,
+    );
+    await producer.saveMeta();
+    for (const t of teammates) await plant('sweep', t);
+
+    // A fresh manager reads the persisted DAG back off disk — the real path
+    // the supervisor uses via rescanFromDisk().
+    const mgr = new AgentManager(50, tmpBase);
+    const loaded = await mgr.listByTask('sweep');
+    const byName = new Map(loaded.map((a) => [a.name, a]));
+
+    // 2 stages + (2 items * 2 votes) verifiers + 1 producer.
+    expect(loaded).toHaveLength(2 + 4 + 1);
+
+    // Stages depend on the producer.
+    expect(byName.get('audit-1')!.after).toEqual(['endpoints']);
+    expect(byName.get('audit-2')!.after).toEqual(['endpoints']);
+
+    // Skeptics depend only on their own item's stage — the verify gate.
+    expect(byName.get('audit-1-verify-1')!.after).toEqual(['audit-1']);
+    expect(byName.get('audit-1-verify-2')!.after).toEqual(['audit-1']);
+    expect(byName.get('audit-2-verify-1')!.after).toEqual(['audit-2']);
+
+    // Everything staged PENDING, waiting on its deps.
+    expect(loaded.filter((a) => a.status === AgentStatus.PENDING)).toHaveLength(6);
+  });
+});

--- a/src/lib/teams/forEach.ts
+++ b/src/lib/teams/forEach.ts
@@ -1,0 +1,87 @@
+/**
+ * Runtime wiring for declarative dynamic fan-out (issue #343).
+ *
+ * The declarative shape (`for_each:` in WORKFLOW.md / routine `run:` blocks) is
+ * parsed and expanded by `src/lib/workflows.ts` (`parseForEachBlock`,
+ * `expandForEach`). This module is the thin bridge that stages the expanded
+ * teammate descriptors into the EXISTING teams substrate — one
+ * `AgentManager.spawn` per descriptor, which the DAG supervisor then picks up
+ * mid-flight via `rescanFromDisk` / `startReady`
+ * (`src/lib/teams/supervisor.ts:98-103`).
+ *
+ * It deliberately adds NO new orchestration engine: `spawn` with an `--after`
+ * chain is the whole mechanism, so cycle detection, wave scheduling, and
+ * cross-vendor/rotation dispatch all carry over unchanged.
+ */
+import type { AgentManager, AgentProcess, EffortLevel } from './agents.js';
+import type { AgentType } from './parsers.js';
+import { expandForEach, type ForEachSpec, type ForEachTeammate } from '../workflows.js';
+
+export interface RunForEachOptions {
+  /** Working directory for the spawned teammates. */
+  cwd?: string | null;
+  /**
+   * Name of the producer teammate the stage teammates should depend on. When
+   * set, each stage runs `--after` the producer so it can't start before the
+   * list is available.
+   */
+  producerName?: string;
+  /** Default effort for spawned teammates (per-item overrides live in the spec). */
+  effort?: EffortLevel;
+  /** Concurrency cap for the wave; falls back to the spec's `concurrency`. */
+  concurrency?: number;
+}
+
+export interface RunForEachResult {
+  /** The expanded descriptors (stage + verify), in spawn order. */
+  teammates: ForEachTeammate[];
+  /** The AgentProcess handles returned by `spawn`, aligned to `teammates`. */
+  spawned: AgentProcess[];
+  /** Items the producer emitted (pre-cap). */
+  producedCount: number;
+  /** Items actually fanned out (post-cap). */
+  usedCount: number;
+  /** How many items the runaway guard dropped. */
+  truncated: number;
+}
+
+/**
+ * Expand a `for_each` spec against a producer's output and stage every
+ * resulting teammate into the given team via the dynamic-add path.
+ *
+ * Returns the descriptors and the spawned handles so a caller can drive the
+ * supervisor and later gather results (e.g. to evaluate a `verify` panel's
+ * `keep_if` gate — that vote-counting lives downstream, not here).
+ */
+export async function runForEach(
+  mgr: AgentManager,
+  teamName: string,
+  spec: ForEachSpec,
+  items: string[],
+  opts: RunForEachOptions = {},
+): Promise<RunForEachResult> {
+  const { teammates, producedCount, usedCount, truncated } = expandForEach(spec, items, {
+    producerName: opts.producerName,
+  });
+
+  const effort: EffortLevel = opts.effort ?? 'medium';
+  const spawned: AgentProcess[] = [];
+  for (const t of teammates) {
+    const agent = await mgr.spawn(
+      teamName,
+      t.agentType as AgentType,
+      t.prompt,
+      opts.cwd ?? null,
+      null, // mode: inherit team default
+      effort,
+      null, // parentSessionId
+      null, // workspaceDir
+      null, // version
+      t.name,
+      t.after,
+    );
+    spawned.push(agent);
+  }
+
+  return { teammates, spawned, producedCount, usedCount, truncated };
+}

--- a/src/lib/teams/index.ts
+++ b/src/lib/teams/index.ts
@@ -65,6 +65,12 @@ export { extractFileOpsFromBash } from './file_ops.js';
 export { debug } from './debug.js';
 
 export {
+  runForEach,
+  type RunForEachOptions,
+  type RunForEachResult,
+} from './forEach.js';
+
+export {
   createWorktree,
   removeWorktree,
   isGitRepo,

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -40,6 +40,73 @@ export interface LoopConfigRaw {
   interval?: string;
 }
 
+/**
+ * The `verify:` sub-block of a `for_each:` construct (issue #343).
+ *
+ * Each produced item's stage teammate can be gated by a panel of independent
+ * skeptics: `votes` of them run (as teammates that depend on the stage), and
+ * `keep_if` records how their verdicts converge (`majority` / `all` / `any`).
+ * The vote-counting itself is a downstream concern — the declarative layer's
+ * job is to expand the panel; see `expandForEach`.
+ */
+export interface ForEachVerifySpec {
+  /** Subagent / agent id that plays skeptic for each item. */
+  agent: string;
+  /** Prompt template for each skeptic (`{{item}}`, `{{index}}` substituted). */
+  prompt?: string;
+  /** How many independent skeptics run per item (>= 1). */
+  votes: number;
+  /** Convergence rule for keeping a finding. */
+  keep_if: 'majority' | 'all' | 'any';
+}
+
+/**
+ * The `for_each:` block as it appears in WORKFLOW.md frontmatter (issue #343).
+ *
+ * Declarative dynamic fan-out: a producer emits a list at runtime, one stage
+ * teammate runs per produced item (runtime-computed N), optionally followed by
+ * a `verify` panel. This is a thin declarative layer over the existing teams
+ * substrate — each expanded teammate is staged into the supervisor's
+ * mid-flight-add path (`AgentManager.spawn`), NOT a new engine. See
+ * `expandForEach` and `src/lib/teams/forEach.ts`.
+ *
+ * Parsed defensively (mirrors `parseLoopBlock`): a malformed block drops to
+ * undefined rather than passing a bad shape downstream.
+ */
+export interface ForEachSpec {
+  /**
+   * The producer: a shell command or subagent whose stdout is a JSON array (or
+   * newline-delimited list) of items. Alternatively `itemsRef` names a prior
+   * step's output. At least one of the two is expected for a runnable spec.
+   */
+  produce?: string;
+  /** `${step}`-style reference to a prior step's produced list. */
+  itemsRef?: string;
+  /** Subagent / agent id for the per-item stage. */
+  agent: string;
+  /** Base name for the expanded teammates (default `item`). */
+  name?: string;
+  /** Per-item prompt template (`{{item}}`, `{{index}}` substituted). */
+  prompt: string;
+  /** In-flight cap — maps to the supervisor's wave size (>= 1). */
+  concurrency?: number;
+  /**
+   * Hard runaway guard: the producer can emit at most this many items before
+   * the fan-out is truncated. Defaults to `DEFAULT_FOR_EACH_CAP`.
+   */
+  max_items?: number;
+  /** Optional convergence gate run after each item's stage. */
+  verify?: ForEachVerifySpec;
+}
+
+/**
+ * Hard upper bound on items a single `for_each` expands, absent an explicit
+ * `max_items`. A guard against a runaway producer spawning unbounded teammates
+ * (acceptance criterion in issue #343). Anthropic's Dynamic Workflows cap at
+ * 1000; we default lower and let authors raise it deliberately.
+ */
+export const DEFAULT_FOR_EACH_CAP = 256;
+
 /** Parsed WORKFLOW.md frontmatter. */
 export interface WorkflowFrontmatter {
   name: string;
@@ -62,6 +129,12 @@ export interface WorkflowFrontmatter {
    * `--loop` flag. Validated/coerced in parseWorkflowFrontmatter.
    */
   loop?: LoopConfigRaw;
+  /**
+   * Optional declarative dynamic fan-out (issue #343): a producer emits a list
+   * and one stage teammate runs per item, with an optional verify panel.
+   * Validated/coerced in parseWorkflowFrontmatter via `parseForEachBlock`.
+   */
+  forEach?: ForEachSpec;
 }
 
 /** A workflow found during repo discovery. */
@@ -112,6 +185,7 @@ export function parseWorkflowFrontmatter(workflowDir: string): WorkflowFrontmatt
       allowedAgents: asStringArray(parsed.allowedAgents),
       secrets: asStringArray(parsed.secrets),
       loop: parseLoopBlock(parsed.loop),
+      forEach: parseForEachBlock(parsed.for_each),
     };
   } catch {
     return null;
@@ -154,6 +228,200 @@ export function parseLoopBlock(v: unknown): LoopConfigRaw | undefined {
   if (typeof raw.interval === 'string') out.interval = raw.interval;
 
   return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/** A finite positive integer, or undefined. Shared guard for count-like fields. */
+function asPosInt(v: unknown): number | undefined {
+  return typeof v === 'number' && Number.isFinite(v) && Number.isInteger(v) && v > 0
+    ? v
+    : undefined;
+}
+
+/** A non-empty trimmed string, or undefined. */
+function asNonEmptyString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim().length > 0 ? v : undefined;
+}
+
+/**
+ * Defensively coerce a frontmatter `verify:` sub-block into a ForEachVerifySpec.
+ *
+ * Requires an `agent`; drops the whole block otherwise (a verify panel with no
+ * skeptic is meaningless). `votes` defaults to 1 (a single confirmation) and
+ * `keep_if` to `majority`; both are validated against their allowed shapes.
+ */
+export function parseVerifyBlock(v: unknown): ForEachVerifySpec | undefined {
+  if (!v || typeof v !== 'object' || Array.isArray(v)) return undefined;
+  const raw = v as Record<string, unknown>;
+
+  const agent = asNonEmptyString(raw.agent);
+  if (!agent) return undefined;
+
+  const keepIf = raw.keep_if;
+  const out: ForEachVerifySpec = {
+    agent,
+    votes: asPosInt(raw.votes) ?? 1,
+    keep_if:
+      keepIf === 'all' || keepIf === 'any' || keepIf === 'majority'
+        ? keepIf
+        : 'majority',
+  };
+  const prompt = asNonEmptyString(raw.prompt);
+  if (prompt) out.prompt = prompt;
+  return out;
+}
+
+/**
+ * Defensively coerce a frontmatter `for_each:` block into a ForEachSpec (issue
+ * #343). Mirrors `parseLoopBlock`'s discipline: a block missing the two
+ * load-bearing fields (`agent` + `prompt`) drops to undefined rather than
+ * passing a half-formed spec to the expander. Optional numeric/verify fields
+ * are individually validated and dropped when malformed.
+ */
+export function parseForEachBlock(v: unknown): ForEachSpec | undefined {
+  if (!v || typeof v !== 'object' || Array.isArray(v)) return undefined;
+  const raw = v as Record<string, unknown>;
+
+  const agent = asNonEmptyString(raw.agent);
+  const prompt = asNonEmptyString(raw.prompt);
+  if (!agent || !prompt) return undefined;
+
+  const out: ForEachSpec = { agent, prompt };
+
+  const produce = asNonEmptyString(raw.produce);
+  if (produce) out.produce = produce;
+  // `for_each: ${step}` references a prior step's list. Accept either the
+  // snake-case `for_each` key or an explicit `items_ref`.
+  const itemsRef = asNonEmptyString(raw.for_each) ?? asNonEmptyString(raw.items_ref);
+  if (itemsRef) out.itemsRef = itemsRef;
+
+  const name = asNonEmptyString(raw.name);
+  if (name) out.name = name;
+
+  const concurrency = asPosInt(raw.concurrency);
+  if (concurrency) out.concurrency = concurrency;
+
+  const maxItems = asPosInt(raw.max_items);
+  if (maxItems) out.max_items = maxItems;
+
+  const verify = parseVerifyBlock(raw.verify);
+  if (verify) out.verify = verify;
+
+  return out;
+}
+
+/** One teammate produced by expanding a `for_each` spec against a produced list. */
+export interface ForEachTeammate {
+  /** `stage` runs the per-item work; `verify` is a skeptic in the panel. */
+  role: 'stage' | 'verify';
+  /** Unique teammate name within the team (used for `--after` linkage). */
+  name: string;
+  /** Subagent / agent id this teammate runs as. */
+  agentType: string;
+  /** Fully-resolved prompt (template variables already substituted). */
+  prompt: string;
+  /** Names of sibling teammates this one waits on (`--after` semantics). */
+  after: string[];
+  /** The produced item this teammate handles. */
+  item: string;
+  /** Zero-based index of the item in the (capped) produced list. */
+  itemIndex: number;
+  /** For `verify` teammates: 1-based vote index and the panel's gate config. */
+  vote?: number;
+  votes?: number;
+  keep_if?: 'majority' | 'all' | 'any';
+}
+
+/** Result of expanding a `for_each` spec: the teammates plus cap accounting. */
+export interface ForEachExpansion {
+  teammates: ForEachTeammate[];
+  /** How many items the producer emitted (pre-cap). */
+  producedCount: number;
+  /** How many items were actually expanded (post-cap). */
+  usedCount: number;
+  /** producedCount - usedCount; > 0 means the runaway guard truncated. */
+  truncated: number;
+  /** The effective per-`for_each` item cap that was applied. */
+  cap: number;
+}
+
+/**
+ * Substitute `{{item}}` / `{{index}}` (and 1-based `{{n}}`) in a prompt
+ * template. Unknown `{{...}}` tokens are left intact so a template can carry
+ * placeholders the caller resolves elsewhere.
+ */
+export function renderForEachTemplate(template: string, item: string, index: number): string {
+  return template
+    .replace(/\{\{\s*item\s*\}\}/g, item)
+    .replace(/\{\{\s*index\s*\}\}/g, String(index))
+    .replace(/\{\{\s*n\s*\}\}/g, String(index + 1));
+}
+
+/**
+ * Expand a `for_each` spec against a producer's output into concrete teammate
+ * descriptors (issue #343) — the heart of the declarative fan-out.
+ *
+ * Pure and deterministic: no I/O, no spawning. `src/lib/teams/forEach.ts`
+ * feeds the result to `AgentManager.spawn`, staging each descriptor into the
+ * supervisor's existing mid-flight-add path — so this reuses the dynamic-DAG
+ * substrate rather than introducing a new engine.
+ *
+ * For N produced items (capped at `spec.max_items` / `DEFAULT_FOR_EACH_CAP`):
+ *   - one `stage` teammate per item, depending on `producerName` if given;
+ *   - when `verify` is set, `votes` `verify` teammates per item, each
+ *     depending on that item's stage teammate.
+ *
+ * Names are unique (`<base>-<n>` and `<base>-<n>-verify-<v>`) so `--after`
+ * linkage and the teams cycle check carry over unchanged.
+ */
+export function expandForEach(
+  spec: ForEachSpec,
+  items: string[],
+  opts: { producerName?: string } = {},
+): ForEachExpansion {
+  const cap = spec.max_items ?? DEFAULT_FOR_EACH_CAP;
+  const producedCount = items.length;
+  const used = items.slice(0, cap);
+  const base = spec.name ?? 'item';
+  const teammates: ForEachTeammate[] = [];
+
+  used.forEach((item, itemIndex) => {
+    const stageName = `${base}-${itemIndex + 1}`;
+    teammates.push({
+      role: 'stage',
+      name: stageName,
+      agentType: spec.agent,
+      prompt: renderForEachTemplate(spec.prompt, item, itemIndex),
+      after: opts.producerName ? [opts.producerName] : [],
+      item,
+      itemIndex,
+    });
+
+    if (spec.verify) {
+      const verifyPrompt = spec.verify.prompt ?? spec.prompt;
+      for (let vote = 1; vote <= spec.verify.votes; vote++) {
+        teammates.push({
+          role: 'verify',
+          name: `${stageName}-verify-${vote}`,
+          agentType: spec.verify.agent,
+          prompt: renderForEachTemplate(verifyPrompt, item, itemIndex),
+          after: [stageName],
+          item,
+          itemIndex,
+          vote,
+          votes: spec.verify.votes,
+          keep_if: spec.verify.keep_if,
+        });
+      }
+    }
+  });
+
+  return {
+    teammates,
+    producedCount,
+    usedCount: used.length,
+    truncated: producedCount - used.length,
+    cap,
+  };
 }
 
 /**


### PR DESCRIPTION
## What

Adds a declarative `for_each:` construct — the cross-vendor answer to Anthropic Dynamic Workflows (#343). A *producer* emits a list at runtime, one *stage* teammate runs per produced item (runtime-computed N), optionally gated by a *verify* panel.

```yaml
for_each:
  produce: "rg -l 'router\\.(get|post)' src/routes/"
  agent: auth-checker
  name: audit
  prompt: "Audit {{item}} for missing auth checks"
  concurrency: 8
  max_items: 50
  verify:
    agent: skeptic
    votes: 3
    keep_if: majority
```

## Reused substrate (not a new engine)

This is a thin **declarative layer** over the existing teams DAG. Each expanded item becomes a teammate staged into the supervisor's **mid-flight teammate-add path** — `AgentManager.spawn` + `--after` — which `runSupervisor` already picks up each wave via `rescanFromDisk`/`startReady` (`src/lib/teams/supervisor.ts:98-103`). No new orchestration engine, so cycle detection, wave scheduling (`concurrency`), and cross-vendor/rotation dispatch all carry over unchanged.

- **`src/lib/workflows.ts`** — `ForEachSpec`/`ForEachVerifySpec` types + `forEach?` on `WorkflowFrontmatter`; defensive `parseForEachBlock`/`parseVerifyBlock` (mirrors the existing `parseLoopBlock` coercion discipline); the pure `expandForEach()` that turns a produced list into `stage` + `verify` teammate descriptors with correct `--after` linkage, `{{item}}`/`{{index}}`/`{{n}}` template substitution, and a runaway hard cap (`DEFAULT_FOR_EACH_CAP = 256`).
- **`src/lib/teams/forEach.ts`** — `runForEach()` bridge that stages each descriptor via `AgentManager.spawn`; exported from `src/lib/teams/index.ts`.

## Tests (vitest, no mocking of code under test)

`src/lib/teams/__tests__/forEach.test.ts`:
- Parser defensiveness (drops blocks missing `agent`/`prompt`, malformed numerics, bad verify sub-block; `votes`/`keep_if` defaults).
- One `stage` teammate per produced item, N unknown until the producer runs.
- `votes` skeptics per item, each `--after` only that item's stage.
- Stage `--after` producer; template substitution; runaway hard cap (default + explicit `max_items`).
- A real `AgentProcess`/`AgentManager` persistence round-trip proving the fan-out reloads off disk as a valid staged DAG (the same meta.json the supervisor rescans).

`bunx tsc --noEmit` clean; new + `workflows.test.ts` green under vitest (the CI runner). Full suite: only pre-existing, environment-specific failures in `src/lib/session/sync/config.test.ts` (unrelated to this diff — reproduces identically on `origin/main`; depends on a locally-configured secrets bundle absent on CI).

## Deferred scope (kept tight per issue guidance)

The issue's L-sized surface is larger than one PR; this lands the load-bearing **declarative parse + expansion + wiring** primitive. Explicitly deferred to follow-ups:
- Executing the `produce` command / subagent at runtime and feeding its stdout list into `runForEach` (the expander already accepts the produced list).
- Evaluating the `verify` panel's `keep_if` vote tally to actually drop refuted findings (the descriptors carry `votes`/`keep_if`; the gate math is downstream).
- The `WORKFLOW.md`/routine `run:` → teams CLI entrypoint that invokes `runForEach`, plus per-item cross-vendor agent targeting UX.