### PR TITLE
feat(rotation): mid-run rate-limit failover to a healthy account (Closes #348)

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -526,7 +526,7 @@ export function registerRunCommand(program: Command): void {
         { profileExists, resolveProfileForRun },
         { readAndResolveBundleEnv, describeBundle, assertRemoteBundleFlagsUnsupported },
         { splitBundleRef, resolveSshTarget, remoteResolveEnv },
-        { getConfiguredRunStrategy, normalizeRunStrategy, resolveRunVersion, RUN_STRATEGIES },
+        { getConfiguredRunStrategy, normalizeRunStrategy, resolveRunVersion, rotationFailoverChain, RUN_STRATEGIES },
         { getGlobalDefault, getVersionHomePath, resolveVersion, resolveVersionAlias },
         { buildDiscoveredPlugin, loadPluginManifest, syncPluginToVersion },
         { parseWorkflowFrontmatter, resolveWorkflowRef, resolveAllowedSubagents, pruneStaleWorkflowSubagents },
@@ -889,6 +889,10 @@ export function registerRunCommand(program: Command): void {
 
       const configuredStrategy = getConfiguredRunStrategy(agent, cwd);
       const explicitStrategy = options.strategy ? normalizeRunStrategy(options.strategy) : null;
+      // Captured from resolveRunVersion below so mid-run rate-limit failover can
+      // synthesize a same-agent fallback chain from the other healthy accounts
+      // (issue #348). Stays null unless a non-pinned strategy actually rotated.
+      let rotationResult: import('../lib/rotate.js').RotateResult | null = null;
       if (options.strategy && !explicitStrategy) {
         console.error(chalk.red(`Invalid strategy: ${options.strategy}. Use ${RUN_STRATEGIES.join(', ')}.`));
         process.exit(1);
@@ -913,6 +917,7 @@ export function registerRunCommand(program: Command): void {
             const resolved = await resolveRunVersion(agent, strategy, cwd);
             if (resolved.version) {
               version = resolved.version;
+              rotationResult = resolved.rotation;
               if (resolved.rotation && !options.quiet) {
                 const banner = formatRotationBanner(resolved.rotation, strategy);
                 process.stderr.write(chalk.gray(banner + '\n'));
@@ -1149,6 +1154,27 @@ export function registerRunCommand(program: Command): void {
           version,
           envOverride: { [profileFallbackModel.envKey]: profileFallbackModel.model },
         });
+      }
+
+      // Mid-run rate-limit failover (issue #348). When a non-pinned strategy
+      // rotated to an account pre-flight and there are OTHER healthy accounts
+      // for the same agent, synthesize a same-agent fallback chain from them so
+      // a 429 mid-run re-dispatches on the next healthy account via the SAME
+      // runWithFallback path (continuing the session via /continue). Gated on an
+      // actual rotation with alternatives, so single-account and pinned runs are
+      // unchanged; skipped when the user set an explicit --fallback chain (its
+      // entries already define recovery) or for interactive/no-prompt runs (a
+      // live TTY session can't be re-dispatched). version is set here because
+      // rotationResult is only populated when resolveRunVersion picked one.
+      if (rotationResult && fallback.length === 0 && prompt !== undefined && !options.interactive && version) {
+        const failover = rotationFailoverChain(rotationResult, version);
+        if (failover.length > 0) {
+          fallback.push(...failover);
+          if (!options.quiet) {
+            const accounts = failover.map(f => `${f.agent}@${f.version}`).join(', ');
+            process.stderr.write(chalk.gray(`[agents] rate-limit failover armed: ${accounts}\n`));
+          }
+        }
       }
 
       if (options.acp) {

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -526,7 +526,7 @@ export function registerRunCommand(program: Command): void {
         { profileExists, resolveProfileForRun },
         { readAndResolveBundleEnv, describeBundle, assertRemoteBundleFlagsUnsupported },
         { splitBundleRef, resolveSshTarget, remoteResolveEnv },
-        { getConfiguredRunStrategy, normalizeRunStrategy, resolveRunVersion, rotationFailoverChain, RUN_STRATEGIES },
+        { getConfiguredRunStrategy, normalizeRunStrategy, resolveRunVersion, rotationFailoverChain, shouldArmRotationFailover, RUN_STRATEGIES },
         { getGlobalDefault, getVersionHomePath, resolveVersion, resolveVersionAlias },
         { buildDiscoveredPlugin, loadPluginManifest, syncPluginToVersion },
         { parseWorkflowFrontmatter, resolveWorkflowRef, resolveAllowedSubagents, pruneStaleWorkflowSubagents },
@@ -1156,18 +1156,32 @@ export function registerRunCommand(program: Command): void {
         });
       }
 
-      // Mid-run rate-limit failover (issue #348). When a non-pinned strategy
-      // rotated to an account pre-flight and there are OTHER healthy accounts
-      // for the same agent, synthesize a same-agent fallback chain from them so
-      // a 429 mid-run re-dispatches on the next healthy account via the SAME
-      // runWithFallback path (continuing the session via /continue). Gated on an
-      // actual rotation with alternatives, so single-account and pinned runs are
-      // unchanged; skipped when the user set an explicit --fallback chain (its
-      // entries already define recovery) or for interactive/no-prompt runs (a
-      // live TTY session can't be re-dispatched). version is set here because
-      // rotationResult is only populated when resolveRunVersion picked one.
-      if (rotationResult && fallback.length === 0 && prompt !== undefined && !options.interactive && version) {
-        const failover = rotationFailoverChain(rotationResult, version);
+      // Mid-run rate-limit failover (issue #348). When a pre-flight rotation
+      // picked an account and there are OTHER healthy accounts for the same
+      // agent, synthesize a same-agent fallback chain from them so a 429 mid-run
+      // re-dispatches on the next healthy account via the SAME runWithFallback
+      // path (continuing the session via /continue). Because this injects into
+      // the same `fallback` array `--fallback` uses, it must only arm for run
+      // shapes that accept a fallback chain — shouldArmRotationFailover excludes
+      // acp/loop/resume-checkpoint (which reject a non-empty fallback below),
+      // interactive/no-prompt runs, and runs that already have an explicit or
+      // profile fallback. Pinned/single-account runs stay unchanged because
+      // rotationResult is null or rotationFailoverChain returns []. version is
+      // set here because rotationResult is only populated when resolveRunVersion
+      // picked one.
+      if (
+        shouldArmRotationFailover({
+          hasRotation: !!rotationResult,
+          hasVersion: !!version,
+          hasPrompt: prompt !== undefined,
+          explicitFallback: fallback.length > 0,
+          interactive: !!options.interactive,
+          acp: !!options.acp,
+          loop: !!options.loop,
+          resumeCheckpoint: !!options.resumeCheckpoint,
+        })
+      ) {
+        const failover = rotationFailoverChain(rotationResult!, version!);
         if (failover.length > 0) {
           fallback.push(...failover);
           if (!options.quiet) {

--- a/src/lib/rotate.test.ts
+++ b/src/lib/rotate.test.ts
@@ -4,10 +4,12 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   rotationFailoverChain,
+  shouldArmRotationFailover,
   DEFAULT_ROTATION_FAILOVER_LIMIT,
   pickBalancedCandidate,
   type RotateCandidate,
   type RotateResult,
+  type FailoverArmingContext,
 } from './rotate.js';
 import { runWithFallback } from './exec.js';
 
@@ -89,6 +91,53 @@ describe('rotationFailoverChain (#348 — synthesize a same-agent failover chain
     expect(chain[0].version).not.toBe(result!.picked.version);
     expect(chain.some(e => e.version === '3.0.0')).toBe(false);
     expect(['1.0.0', '2.0.0']).toContain(chain[0].version);
+  });
+});
+
+describe('shouldArmRotationFailover (#348 — arming gate; must not trip --acp/--loop guards)', () => {
+  // The eligible baseline: a real rotation picked a version, there is a prompt,
+  // no explicit/profile fallback, and the run is a plain headless prompt run.
+  const armable: FailoverArmingContext = {
+    hasRotation: true,
+    hasVersion: true,
+    hasPrompt: true,
+    explicitFallback: false,
+    interactive: false,
+    acp: false,
+    loop: false,
+    resumeCheckpoint: false,
+  };
+
+  it('arms for a plain headless rotation run with alternatives', () => {
+    expect(shouldArmRotationFailover(armable)).toBe(true);
+  });
+
+  // The regression this guards: arming injected into `fallback` before the
+  // --acp / --loop guards made those runs hard-exit on a flag never passed.
+  it('does NOT arm for --acp runs (they reject a non-empty fallback array)', () => {
+    expect(shouldArmRotationFailover({ ...armable, acp: true })).toBe(false);
+  });
+
+  it('does NOT arm for --loop runs (they reject a non-empty fallback array)', () => {
+    expect(shouldArmRotationFailover({ ...armable, loop: true })).toBe(false);
+  });
+
+  it('does NOT arm for --resume-checkpoint runs (they take the loop path)', () => {
+    expect(shouldArmRotationFailover({ ...armable, resumeCheckpoint: true })).toBe(false);
+  });
+
+  it('does NOT arm for interactive or no-prompt runs', () => {
+    expect(shouldArmRotationFailover({ ...armable, interactive: true })).toBe(false);
+    expect(shouldArmRotationFailover({ ...armable, hasPrompt: false })).toBe(false);
+  });
+
+  it('does NOT arm when an explicit or profile fallback is already set', () => {
+    expect(shouldArmRotationFailover({ ...armable, explicitFallback: true })).toBe(false);
+  });
+
+  it('does NOT arm for pinned / non-rotation runs (no rotation or no picked version)', () => {
+    expect(shouldArmRotationFailover({ ...armable, hasRotation: false })).toBe(false);
+    expect(shouldArmRotationFailover({ ...armable, hasVersion: false })).toBe(false);
   });
 });
 

--- a/src/lib/rotate.test.ts
+++ b/src/lib/rotate.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  rotationFailoverChain,
+  DEFAULT_ROTATION_FAILOVER_LIMIT,
+  pickBalancedCandidate,
+  type RotateCandidate,
+  type RotateResult,
+} from './rotate.js';
+import { runWithFallback } from './exec.js';
+
+/**
+ * Build a healthy RotateCandidate (email present, auth valid, no live snapshot
+ * => treated as full capacity). Pass overrides — e.g. `usageStatus:
+ * 'rate_limited'` — to make it unhealthy.
+ */
+function candidate(over: Partial<RotateCandidate> & { version: string }): RotateCandidate {
+  return {
+    agent: 'claude',
+    email: `${over.version}@example.com`,
+    usageKey: `claude:org=${over.version}`,
+    usageStatus: 'available',
+    usageSnapshot: null,
+    authValid: true,
+    lastActive: null,
+    ...over,
+  };
+}
+
+/** A RotateResult with `healthy` in the given order and `picked` = healthy[pickedIdx]. */
+function rotation(healthy: RotateCandidate[], pickedIdx = 0): RotateResult {
+  return { picked: healthy[pickedIdx], healthy, excluded: [] };
+}
+
+describe('rotationFailoverChain (#348 — synthesize a same-agent failover chain)', () => {
+  it('turns the other healthy accounts into fallback entries, skipping the picked one', () => {
+    const a = candidate({ version: '1.0.0' });
+    const b = candidate({ version: '2.0.0' });
+    const c = candidate({ version: '3.0.0' });
+    // A is the account picked pre-flight; B and C are the healthy alternatives.
+    const chain = rotationFailoverChain(rotation([a, b, c], 0), a.version);
+    expect(chain).toEqual([
+      { agent: 'claude', version: '2.0.0' },
+      { agent: 'claude', version: '3.0.0' },
+    ]);
+  });
+
+  it('preserves rotation.healthy order (freshest account first) and never re-lists the primary', () => {
+    const healthy = [
+      candidate({ version: '1.0.0' }),
+      candidate({ version: '2.0.0' }),
+      candidate({ version: '3.0.0' }),
+    ];
+    // Primary is the middle account; failover keeps the other two in order.
+    const chain = rotationFailoverChain(rotation(healthy, 1), '2.0.0');
+    expect(chain.map(e => e.version)).toEqual(['1.0.0', '3.0.0']);
+    expect(chain.some(e => e.version === '2.0.0')).toBe(false);
+  });
+
+  it('bounds the chain to the failover limit', () => {
+    const healthy = Array.from({ length: 6 }, (_, i) => candidate({ version: `${i}.0.0` }));
+    const chain = rotationFailoverChain(rotation(healthy, 0), '0.0.0');
+    expect(chain.length).toBe(DEFAULT_ROTATION_FAILOVER_LIMIT);
+    const custom = rotationFailoverChain(rotation(healthy, 0), '0.0.0', 2);
+    expect(custom.length).toBe(2);
+  });
+
+  it('returns [] for a non-rotation run (pinned strategy => null rotation) — behavior unchanged', () => {
+    expect(rotationFailoverChain(null, '1.0.0')).toEqual([]);
+  });
+
+  it('returns [] when the picked account is the only healthy one (single-account user)', () => {
+    const only = candidate({ version: '1.0.0' });
+    expect(rotationFailoverChain(rotation([only], 0), '1.0.0')).toEqual([]);
+  });
+
+  it('consumes the healthy set produced by the real pickBalancedCandidate (rate-limited account is never a failover target)', () => {
+    const healthyA = candidate({ version: '1.0.0' });
+    const healthyB = candidate({ version: '2.0.0' });
+    const limited = candidate({ version: '3.0.0', usageStatus: 'rate_limited' });
+    const result = pickBalancedCandidate([healthyA, healthyB, limited]);
+    expect(result).not.toBeNull();
+    const chain = rotationFailoverChain(result, result!.picked.version);
+    // Exactly one alternative (the other healthy account); the picked and the
+    // already-rate-limited account are both absent.
+    expect(chain.length).toBe(1);
+    expect(chain[0].version).not.toBe(result!.picked.version);
+    expect(chain.some(e => e.version === '3.0.0')).toBe(false);
+    expect(['1.0.0', '2.0.0']).toContain(chain[0].version);
+  });
+});
+
+// End-to-end proof that a synthesized chain actually recovers a 429 through the
+// SAME runWithFallback engine: a real child process (no mocking of the code under
+// test) 429s on the first ("account A") dispatch and succeeds on the re-dispatch
+// ("account B"). A non-rate-limit failure must NOT cascade.
+describe('runWithFallback re-dispatch on a mid-run 429 (the reused failover path)', () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(() => {
+    for (const d of tmpDirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  /** Write a stateful fake `amp` on a temp PATH; returns its bin dir + state file. */
+  function fakeAmp(): { binDir: string; stateFile: string } {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rotate-failover-'));
+    tmpDirs.push(root);
+    const binDir = path.join(root, 'bin');
+    fs.mkdirSync(binDir);
+    const stateFile = path.join(root, 'calls');
+    const script = `#!/usr/bin/env node
+const fs = require('fs');
+const stateFile = process.env.AGENTS_TEST_STATE;
+const mode = process.env.AGENTS_TEST_MODE;
+let n = 0;
+try { n = parseInt(fs.readFileSync(stateFile, 'utf8'), 10) || 0; } catch {}
+n += 1;
+fs.writeFileSync(stateFile, String(n));
+if (mode === 'plain-fail') {
+  process.stderr.write('Error: compile failure — not a limit\\n');
+  process.exit(1);
+}
+if (n === 1) {
+  process.stderr.write('API request failed: 429 Too Many Requests (rate limit exceeded)\\n');
+  process.exit(1);
+}
+process.stdout.write('done\\n');
+process.exit(0);
+`;
+    const bin = path.join(binDir, 'amp');
+    fs.writeFileSync(bin, script);
+    fs.chmodSync(bin, 0o755);
+    return { binDir, stateFile };
+  }
+
+  it('a 429 on the primary account re-dispatches on the next account and succeeds', async () => {
+    const { binDir, stateFile } = fakeAmp();
+    const code = await runWithFallback({
+      agent: 'amp',
+      prompt: 'do the task',
+      mode: 'edit',
+      effort: 'auto',
+      headless: true,
+      cwd: binDir,
+      env: {
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+        AGENTS_TEST_MODE: 'ratelimit-then-ok',
+        AGENTS_TEST_STATE: stateFile,
+      },
+      // The synthesized "next healthy account" entry (same agent, different account).
+      fallback: [{ agent: 'amp' }],
+    });
+    expect(code).toBe(0);
+    // Primary 429'd (call 1), re-dispatched once and succeeded (call 2).
+    expect(fs.readFileSync(stateFile, 'utf8')).toBe('2');
+  });
+
+  it('a non-rate-limit failure does NOT re-dispatch (only 429s cascade)', async () => {
+    const { binDir, stateFile } = fakeAmp();
+    const code = await runWithFallback({
+      agent: 'amp',
+      prompt: 'do the task',
+      mode: 'edit',
+      effort: 'auto',
+      headless: true,
+      cwd: binDir,
+      env: {
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+        AGENTS_TEST_MODE: 'plain-fail',
+        AGENTS_TEST_STATE: stateFile,
+      },
+      fallback: [{ agent: 'amp' }],
+    });
+    expect(code).toBe(1);
+    // Ran the primary exactly once — a plain failure is surfaced, not retried.
+    expect(fs.readFileSync(stateFile, 'utf8')).toBe('1');
+  });
+});

--- a/src/lib/rotate.ts
+++ b/src/lib/rotate.ts
@@ -8,6 +8,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { AgentId, RunStrategy } from './types.js';
+import type { FallbackEntry } from './exec.js';
 import { getAccountInfo, type AccountInfo } from './agents.js';
 import { readMeta, writeMeta, getHelpersDir } from './state.js';
 import { listInstalledVersions, getVersionHomePath, resolveVersion } from './versions.js';
@@ -403,4 +404,49 @@ export async function resolveRunVersion(agent: AgentId, strategy: RunStrategy, c
   }
 
   return { version: fallback, rotation: null };
+}
+
+/**
+ * Cap on the number of healthy accounts a single run will re-dispatch through
+ * after a mid-run rate limit. Bounds the synthesized chain so a machine signed
+ * into many accounts can't turn one 429 into an unbounded cascade of retries.
+ */
+export const DEFAULT_ROTATION_FAILOVER_LIMIT = 3;
+
+/**
+ * Synthesize a same-agent, cross-account fallback chain from a pre-flight
+ * rotation result (issue #348: mid-run rate-limit failover).
+ *
+ * The account rotation picks ONE version pre-spawn; today a 429 mid-run kills
+ * the run with no recovery. `runWithFallback` + `detectRateLimit` already
+ * re-dispatch to the NEXT chain entry on a rate limit and hand off the session
+ * via `/continue <id>` — but only for explicit `--fallback` chains. This turns
+ * the OTHER healthy rotation candidates (every account except the one already
+ * picked as the primary) into `FallbackEntry`s so that SAME machinery re-runs
+ * the task on the next healthy account of the same agent when the primary 429s.
+ *
+ * Each account is a distinct installed version (its own home/auth), so the
+ * entries are same-agent, different-version — exactly what runWithFallback
+ * spawns and what buildFallbackPrompt continues (claude→claude via `/continue`).
+ * Candidates are consumed in `rotation.healthy` order, which is sorted by
+ * remaining capacity (most headroom first, see compareCandidates), so failover
+ * prefers the freshest account.
+ *
+ * Returns `[]` when there is no rotation (pinned strategy) or the picked account
+ * is the only healthy one — so single-account users and non-rotation runs are
+ * completely unchanged.
+ */
+export function rotationFailoverChain(
+  rotation: RotateResult | null,
+  pickedVersion: string,
+  limit: number = DEFAULT_ROTATION_FAILOVER_LIMIT,
+): FallbackEntry[] {
+  if (!rotation || limit <= 0) return [];
+  const chain: FallbackEntry[] = [];
+  for (const candidate of rotation.healthy) {
+    if (candidate.version === pickedVersion) continue; // the primary account
+    chain.push({ agent: candidate.agent, version: candidate.version });
+    if (chain.length >= limit) break;
+  }
+  return chain;
 }

--- a/src/lib/rotate.ts
+++ b/src/lib/rotate.ts
@@ -450,3 +450,46 @@ export function rotationFailoverChain(
   }
   return chain;
 }
+
+/**
+ * Whether a run is eligible to have a mid-run rate-limit failover chain armed
+ * (issue #348). Failover injects synthesized `FallbackEntry`s into the same
+ * `fallback` array that `--fallback` uses — so it must NOT arm for run shapes
+ * that reject a non-empty fallback chain, or the run hard-exits on a flag the
+ * user never passed. Specifically:
+ *
+ * - `acp` and `loop` runs bail with "not compatible with --fallback yet" the
+ *   moment `fallback.length > 0` (src/commands/exec.ts), so arming failover
+ *   would break a previously-working `agents run … --loop` / `--acp`.
+ * - `resumeCheckpoint` runs take the loop path (same guard).
+ * - `interactive` / no-prompt runs can't be re-dispatched headlessly.
+ * - `explicitFallback` (a user `--fallback` chain OR a profile fallback already
+ *   unshifted) defines its own recovery; don't layer rotation failover on top.
+ * - `hasRotation`/`hasVersion` gate on an actual pre-flight rotation having
+ *   picked an account, so pinned and non-rotation runs are untouched.
+ *
+ * Pure so the arming matrix is unit-testable without invoking the run command.
+ */
+export interface FailoverArmingContext {
+  hasRotation: boolean;
+  hasVersion: boolean;
+  hasPrompt: boolean;
+  explicitFallback: boolean;
+  interactive: boolean;
+  acp: boolean;
+  loop: boolean;
+  resumeCheckpoint: boolean;
+}
+
+export function shouldArmRotationFailover(ctx: FailoverArmingContext): boolean {
+  return (
+    ctx.hasRotation &&
+    ctx.hasVersion &&
+    ctx.hasPrompt &&
+    !ctx.explicitFallback &&
+    !ctx.interactive &&
+    !ctx.acp &&
+    !ctx.loop &&
+    !ctx.resumeCheckpoint
+  );
+}


### PR DESCRIPTION
## What

Account rotation today is **pre-flight only**: `pickBalancedCandidate` / `resolveRunVersion` (`src/lib/rotate.ts`) pick one account before spawn, and a 429 **mid-run** kills the run with no recovery. This closes that gap by re-dispatching the same work on the next healthy account of the same agent when the primary account rate-limits — the single loudest Claude Code complaint of 2026.

## How (reuses existing machinery — no new engine)

The substrate already exists: `runWithFallback` + `detectRateLimit` (`src/lib/exec.ts`) re-dispatch to the next fallback entry on a rate limit and continue the session via the `/continue` handoff (`buildFallbackPrompt`); #325 extended this path with same-host retries. This change simply **synthesizes fallback entries from the rotation candidates** and feeds them into that same call:

- **`src/lib/rotate.ts`** — new pure `rotationFailoverChain(rotation, pickedVersion, limit?)`. Maps a `RotateResult`'s `healthy` accounts (every version **except** the picked primary, in capacity order) into `FallbackEntry[]`, bounded by `DEFAULT_ROTATION_FAILOVER_LIMIT` (3). Each account is a distinct installed version = its own home/auth, so entries are same-agent / different-version — exactly what `runWithFallback` spawns and `buildFallbackPrompt` continues (claude→claude via `/continue`). Returns `[]` for a null rotation (pinned) or a single healthy account.
- **`src/commands/exec.ts`** — captures the `RotateResult` from `resolveRunVersion`, and when a non-pinned strategy actually rotated **and** alternatives exist, pushes the synthesized chain into the existing `runWithFallback({ ...execOptions, fallback })` call.

## Gating (opt-in preserved)

Failover only arms when **all** hold: a non-pinned strategy rotated pre-flight, there's ≥1 *other* healthy account, it's a headless prompt run, and the user set no explicit `--fallback`. Single-account users, `--strategy pinned`, profile runs, and interactive sessions are byte-for-byte unchanged (empty chain → existing `execAgent` path). No cross-provider proxying — stays within the agent's own accounts (per #321).

## Tests (`src/lib/rotate.test.ts`, fail pre-change)

- **Synthesis unit tests** (via the real `pickBalancedCandidate`): selects the other healthy account(s), excludes the picked and already-`rate_limited` accounts, respects the bound, and is empty for pinned / single-account.
- **Integration test — no mocking of the code under test**: drives the real `runWithFallback` with a stateful fake agent binary on a temp `PATH` that **429s on the first ("account A") dispatch and succeeds on the re-dispatch ("account B")** — asserts exit 0 and exactly 2 spawns. A non-429 failure is proven to **not** cascade (1 spawn, exit 1).

`bunx tsc --noEmit` clean; `bun run test` (vitest) green for the change. The only red in the suite is a pre-existing, host-environment-dependent failure in `src/lib/session/sync/config.test.ts` (identical failures on untouched `main`; passes on clean CI).