### PR TITLE
feat(browser): pdf export + HAR export from the request buffer (Closes #327)

### DIFF
--- a/src/commands/browser.pdf-har.test.ts
+++ b/src/commands/browser.pdf-har.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Command } from 'commander';
+
+// Stub the IPC layer — the command registration tests never actually contact
+// the browser daemon; they inspect Commander's tree and options.
+vi.mock('../lib/browser/ipc.js', () => ({
+  BrowserDaemonNotRunningError: class extends Error {},
+  formatBrowserDaemonNotRunningError: () => 'stub',
+  sendIPCRequest: vi.fn(),
+}));
+
+const { registerBrowserCommand } = await import('./browser.js');
+
+function programWithBrowser(): Command {
+  const program = new Command();
+  program.exitOverride();
+  registerBrowserCommand(program);
+  return program;
+}
+
+function getBrowser(program: Command): Command {
+  const cmd = program.commands.find((c) => c.name() === 'browser');
+  if (!cmd) throw new Error('browser command not registered');
+  return cmd;
+}
+
+describe('agents browser pdf', () => {
+  it('registers a `pdf` subcommand that accepts an optional [output] positional', () => {
+    const browser = getBrowser(programWithBrowser());
+    const pdf = browser.commands.find((c) => c.name() === 'pdf');
+    expect(pdf, 'pdf subcommand should be registered').toBeDefined();
+    // Commander stores positional arg names on `_args` — presence check plus
+    // required=false guarantees `browser pdf` runs without a path.
+    const args = (pdf as unknown as { _args: Array<{ _name: string; required: boolean }> })._args;
+    expect(args).toHaveLength(1);
+    expect(args[0]._name).toBe('output');
+    expect(args[0].required).toBe(false);
+  });
+
+  it('pdf subcommand exposes --task and --tab options', () => {
+    const browser = getBrowser(programWithBrowser());
+    const pdf = browser.commands.find((c) => c.name() === 'pdf')!;
+    const longs = pdf.options.map((o) => o.long);
+    expect(longs).toEqual(expect.arrayContaining(['--task', '--tab']));
+  });
+
+  it('description mentions the CDP command it delegates to', () => {
+    const browser = getBrowser(programWithBrowser());
+    const pdf = browser.commands.find((c) => c.name() === 'pdf')!;
+    expect(pdf.description()).toMatch(/Page\.printToPDF/);
+  });
+});
+
+describe('agents browser requests --format', () => {
+  it('registers a `requests` subcommand with a --format option', () => {
+    const browser = getBrowser(programWithBrowser());
+    const requests = browser.commands.find((c) => c.name() === 'requests');
+    expect(requests, 'requests subcommand should be registered').toBeDefined();
+    const format = requests!.options.find((o) => o.long === '--format');
+    expect(format, '--format option should exist on requests').toBeDefined();
+  });
+
+  it('--format defaults to "table" so the existing tabular output is unchanged', () => {
+    const browser = getBrowser(programWithBrowser());
+    const requests = browser.commands.find((c) => c.name() === 'requests')!;
+    const format = requests.options.find((o) => o.long === '--format')!;
+    // Commander stores the default on `defaultValue`.
+    expect((format as unknown as { defaultValue: string }).defaultValue).toBe('table');
+  });
+
+  it('description advertises the HAR export path', () => {
+    const browser = getBrowser(programWithBrowser());
+    const requests = browser.commands.find((c) => c.name() === 'requests')!;
+    expect(requests.description()).toMatch(/HAR/);
+  });
+});

--- a/src/commands/browser.ts
+++ b/src/commands/browser.ts
@@ -30,6 +30,8 @@ import {
 import { browserTaskPicker, type BrowserTask } from './browser-picker.js';
 import { isInteractiveTerminal } from './utils.js';
 import { registerCommandGroups, setHelpSections } from '../lib/help.js';
+import { buildHar } from '../lib/browser/har.js';
+import { getCliVersion } from '../lib/version.js';
 
 /**
  * Resolve which browser task a command targets. Order:
@@ -67,7 +69,7 @@ const BROWSER_HELP_GROUPS = [
   },
   {
     title: 'Capture evidence',
-    names: ['console', 'errors', 'requests', 'responsebody', 'record', 'logs'],
+    names: ['console', 'errors', 'requests', 'responsebody', 'record', 'pdf', 'logs'],
   },
 ] as const;
 
@@ -851,6 +853,35 @@ function registerTaskCommands(browser: Command): void {
     });
 
   browser
+    .command('pdf [output]')
+    .description('Export the current tab as PDF via CDP Page.printToPDF — auto-saved under sessions/<task>/ when [output] is omitted')
+    .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
+    .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
+    .action(async (output: string | undefined, opts) => {
+      const task = resolveTaskName(opts);
+      const response = await sendIPCRequest({
+        action: 'pdf',
+        task,
+        tabId: opts.tab,
+        path: output,
+      });
+
+      if (!response.ok) {
+        console.error(response.error);
+        process.exit(1);
+      }
+
+      console.log(response.path);
+      const size = humanizeBytes(response.bytes);
+      console.error(`Saved PDF to ${response.path} (${size})`);
+
+      if (!output && response.path) {
+        const dir = path.dirname(response.path);
+        console.error(`Tip: auto-saving to ${dir}. Pass a path argument to choose one.`);
+      }
+    });
+
+  browser
     .command('evaluate')
     .description('Evaluate JavaScript in current tab')
     .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
@@ -1570,13 +1601,18 @@ function registerTaskCommands(browser: Command): void {
 
   browser
     .command('requests')
-    .description('Read captured network requests')
+    .description('Read captured network requests. --format har emits a HAR 1.2 JSON document.')
     .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
     .option('-f, --filter <text>', 'Filter URLs containing text')
     .option('--clear', 'Clear requests after reading')
+    .option('--format <format>', 'Output format: table (default) or har', 'table')
     .action(async (opts) => {
       const task = resolveTaskName(opts);
+      if (opts.format !== 'table' && opts.format !== 'har') {
+        console.error('--format must be "table" or "har"');
+        process.exit(1);
+      }
       const response = await sendIPCRequest({
         action: 'requests',
         task,
@@ -1590,14 +1626,25 @@ function registerTaskCommands(browser: Command): void {
         process.exit(1);
       }
 
-      if (!response.requests || response.requests.length === 0) {
+      const requests = response.requests ?? [];
+
+      if (opts.format === 'har') {
+        const har = buildHar(requests, {
+          creatorName: 'agents-cli',
+          creatorVersion: getCliVersion(),
+        });
+        console.log(JSON.stringify(har, null, 2));
+        return;
+      }
+
+      if (requests.length === 0) {
         console.log('No requests captured');
         return;
       }
 
       console.log('METHOD'.padEnd(8) + 'STATUS'.padEnd(8) + 'URL');
       console.log('-'.repeat(72));
-      for (const req of response.requests) {
+      for (const req of requests) {
         const status = req.status ? String(req.status) : '...';
         console.log(`${req.method.padEnd(8)}${status.padEnd(8)}${req.url.slice(0, 100)}`);
       }

--- a/src/lib/browser/har.test.ts
+++ b/src/lib/browser/har.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { buildHar } from './har.js';
+import type { NetworkRequest } from './types.js';
+
+describe('buildHar', () => {
+  it('produces a HAR 1.2 log with version, creator, one page, and matching entry count', () => {
+    const requests: NetworkRequest[] = [
+      { id: '1', url: 'https://example.com/', method: 'GET', status: 200, mimeType: 'text/html', timestamp: 1_700_000_000_000 },
+      { id: '2', url: 'https://example.com/app.js', method: 'GET', status: 200, mimeType: 'application/javascript', timestamp: 1_700_000_001_000 },
+    ];
+
+    const { log } = buildHar(requests, { creatorName: 'agents-cli', creatorVersion: '1.2.3' });
+
+    expect(log.version).toBe('1.2');
+    expect(log.creator).toEqual({ name: 'agents-cli', version: '1.2.3' });
+    expect(log.pages).toHaveLength(1);
+    expect(log.entries).toHaveLength(2);
+  });
+
+  it('page.startedDateTime is the earliest request timestamp as ISO 8601', () => {
+    const requests: NetworkRequest[] = [
+      { id: 'later', url: 'https://a/', method: 'GET', timestamp: 1_700_000_005_000 },
+      { id: 'first', url: 'https://a/', method: 'GET', timestamp: 1_700_000_001_000 },
+    ];
+
+    const { log } = buildHar(requests);
+    expect(log.pages[0].startedDateTime).toBe(new Date(1_700_000_001_000).toISOString());
+  });
+
+  it('entry.request preserves method + url and parses queryString from the URL', () => {
+    const requests: NetworkRequest[] = [
+      { id: '1', url: 'https://example.com/search?q=hello&limit=10', method: 'POST', timestamp: 1_700_000_000_000 },
+    ];
+    const { log } = buildHar(requests);
+    const req = log.entries[0].request;
+    expect(req.method).toBe('POST');
+    expect(req.url).toBe('https://example.com/search?q=hello&limit=10');
+    expect(req.queryString).toEqual([
+      { name: 'q', value: 'hello' },
+      { name: 'limit', value: '10' },
+    ]);
+    expect(req.headers).toEqual([]);
+    expect(req.cookies).toEqual([]);
+  });
+
+  it('unknown sizes / timings surface as -1 sentinels (spec requirement)', () => {
+    const { log } = buildHar([
+      { id: '1', url: 'https://a/', method: 'GET', timestamp: 1_700_000_000_000 },
+    ]);
+    const e = log.entries[0];
+    expect(e.time).toBe(-1);
+    expect(e.timings).toEqual({ send: -1, wait: -1, receive: -1 });
+    expect(e.request.headersSize).toBe(-1);
+    expect(e.request.bodySize).toBe(-1);
+    expect(e.response.headersSize).toBe(-1);
+    expect(e.response.bodySize).toBe(-1);
+    expect(e.response.content.size).toBe(-1);
+    expect(log.pages[0].pageTimings).toEqual({ onContentLoad: -1, onLoad: -1 });
+  });
+
+  it('missing response fields default to status=0 and mimeType=""', () => {
+    const { log } = buildHar([
+      { id: '1', url: 'https://a/', method: 'GET', timestamp: 1_700_000_000_000 },
+    ]);
+    expect(log.entries[0].response.status).toBe(0);
+    expect(log.entries[0].response.content.mimeType).toBe('');
+  });
+
+  it('serializes to JSON that round-trips (validator-friendly shape)', () => {
+    const requests: NetworkRequest[] = [
+      { id: '1', url: 'https://example.com/', method: 'GET', status: 200, mimeType: 'text/html', timestamp: 1_700_000_000_000 },
+    ];
+    const json = JSON.stringify(buildHar(requests));
+    const parsed = JSON.parse(json);
+    expect(parsed.log.version).toBe('1.2');
+    expect(parsed.log.entries[0].request.url).toBe('https://example.com/');
+  });
+
+  it('empty request buffer still produces a valid single-page HAR log', () => {
+    const { log } = buildHar([]);
+    expect(log.version).toBe('1.2');
+    expect(log.entries).toEqual([]);
+    expect(log.pages).toHaveLength(1);
+    // startedDateTime must still be a valid ISO string.
+    expect(() => new Date(log.pages[0].startedDateTime).toISOString()).not.toThrow();
+  });
+
+  it('opaque URLs (data:, malformed) leave queryString empty rather than throwing', () => {
+    const { log } = buildHar([
+      { id: '1', url: 'data:text/plain,hello', method: 'GET', timestamp: 1_700_000_000_000 },
+    ]);
+    expect(log.entries[0].request.queryString).toEqual([]);
+  });
+});

--- a/src/lib/browser/har.ts
+++ b/src/lib/browser/har.ts
@@ -1,0 +1,151 @@
+import type { NetworkRequest } from './types.js';
+
+/**
+ * Minimal HAR 1.2 shapes. We only produce what our request buffer can back —
+ * fields the buffer doesn't populate (headers, cookies, bodies, timings) are
+ * emitted with the spec-mandated empty defaults or `-1` sentinels so validators
+ * still accept the document.
+ *
+ * Spec: http://www.softwareishard.com/blog/har-12-spec/
+ */
+export interface HarLog {
+  version: '1.2';
+  creator: { name: string; version: string };
+  pages: HarPage[];
+  entries: HarEntry[];
+}
+
+export interface HarPage {
+  startedDateTime: string;
+  id: string;
+  title: string;
+  pageTimings: { onContentLoad: number; onLoad: number };
+}
+
+export interface HarEntry {
+  startedDateTime: string;
+  time: number;
+  request: HarRequest;
+  response: HarResponse;
+  cache: Record<string, never>;
+  timings: HarTimings;
+}
+
+export interface HarRequest {
+  method: string;
+  url: string;
+  httpVersion: string;
+  cookies: never[];
+  headers: never[];
+  queryString: Array<{ name: string; value: string }>;
+  headersSize: number;
+  bodySize: number;
+}
+
+export interface HarResponse {
+  status: number;
+  statusText: string;
+  httpVersion: string;
+  cookies: never[];
+  headers: never[];
+  content: { size: number; mimeType: string; text?: string };
+  redirectURL: string;
+  headersSize: number;
+  bodySize: number;
+}
+
+export interface HarTimings {
+  send: number;
+  wait: number;
+  receive: number;
+}
+
+export interface BuildHarOptions {
+  creatorName?: string;
+  creatorVersion?: string;
+}
+
+/**
+ * Serialize a buffered `NetworkRequest[]` into a HAR 1.2 document.
+ *
+ * The buffer only records `url`, `method`, `status`, `mimeType`, `timestamp`.
+ * Everything downstream — cookies, headers, bodies, per-phase timings — is
+ * unknown and must be emitted as the spec's "unknown" sentinels: `-1` for
+ * sizes / timings, empty arrays for cookies / headers. HAR validators accept
+ * this shape (browsers do the same for opaque cross-origin responses).
+ */
+export function buildHar(
+  requests: NetworkRequest[],
+  opts: BuildHarOptions = {}
+): { log: HarLog } {
+  const creator = {
+    name: opts.creatorName ?? 'agents-cli',
+    version: opts.creatorVersion ?? '',
+  };
+
+  const startedAt = requests.length > 0 ? Math.min(...requests.map((r) => r.timestamp)) : Date.now();
+
+  const page: HarPage = {
+    startedDateTime: new Date(startedAt).toISOString(),
+    id: 'page_1',
+    title: 'agents browser session',
+    pageTimings: { onContentLoad: -1, onLoad: -1 },
+  };
+
+  const entries: HarEntry[] = requests.map((r) => {
+    const queryString = extractQueryString(r.url);
+    const mimeType = r.mimeType ?? '';
+    return {
+      startedDateTime: new Date(r.timestamp).toISOString(),
+      time: -1,
+      request: {
+        method: r.method,
+        url: r.url,
+        httpVersion: 'HTTP/1.1',
+        cookies: [],
+        headers: [],
+        queryString,
+        headersSize: -1,
+        bodySize: -1,
+      },
+      response: {
+        status: r.status ?? 0,
+        statusText: '',
+        httpVersion: 'HTTP/1.1',
+        cookies: [],
+        headers: [],
+        content: { size: -1, mimeType },
+        redirectURL: '',
+        headersSize: -1,
+        bodySize: -1,
+      },
+      cache: {},
+      timings: { send: -1, wait: -1, receive: -1 },
+    };
+  });
+
+  return {
+    log: {
+      version: '1.2',
+      creator,
+      pages: [page],
+      entries,
+    },
+  };
+}
+
+/**
+ * Pull `?a=1&b=2` off a URL into HAR's `queryString` array. Returns `[]` when
+ * the URL has no query or fails to parse (opaque URLs like `data:` shouldn't
+ * abort the whole HAR).
+ */
+function extractQueryString(url: string): Array<{ name: string; value: string }> {
+  try {
+    const u = new URL(url);
+    const out: Array<{ name: string; value: string }> = [];
+    u.searchParams.forEach((value, name) => out.push({ name, value }));
+    return out;
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/browser/ipc.ts
+++ b/src/lib/browser/ipc.ts
@@ -334,6 +334,18 @@ export class BrowserIPCServer {
         return { ok: true, path: shot.path, bytes: shot.bytes, width: shot.width, height: shot.height };
       }
 
+      case 'pdf': {
+        if (!request.task) {
+          return { ok: false, error: 'Task required' };
+        }
+        const doc = await this.service.printToPdf(
+          request.task,
+          request.tabId,
+          request.path
+        );
+        return { ok: true, path: doc.path, bytes: doc.bytes };
+      }
+
       case 'refs': {
         if (!request.task) {
           return { ok: false, error: 'Task required' };

--- a/src/lib/browser/service.ts
+++ b/src/lib/browser/service.ts
@@ -846,6 +846,46 @@ export class BrowserService {
     return { path: finalPath, bytes: buffer.length, width: dims.width, height: dims.height };
   }
 
+  /**
+   * Export the current tab as a PDF via CDP `Page.printToPDF`. Reuses the
+   * screenshot session + tab resolution so `--tab`, path sandboxing, and the
+   * auto-path (`sessions/<task>/<ts>.pdf`) all behave identically to
+   * `screenshot`. `printBackground: true` matches Chrome's default print flow
+   * — without it, dark-mode pages render on a blank sheet.
+   */
+  async printToPdf(
+    taskId: string,
+    tabHint?: string,
+    outputPath?: string
+  ): Promise<{ path: string; bytes: number }> {
+    const { conn, task } = await this.findTask(taskId);
+
+    const shortId = tabHint ? await this.resolveTabHint(conn, task, tabHint) : this.resolveCurrentTab(task);
+    const cdpTargetId = this.getCdpTargetId(task, shortId);
+
+    const target = await this.getTarget(conn, cdpTargetId);
+    if (!target) {
+      throw new Error(`Tab ${shortId} not found`);
+    }
+
+    const sessionId = await this.getSessionId(conn, target.targetId);
+
+    const { data } = (await conn.cdp.send(
+      'Page.printToPDF',
+      { printBackground: true, preferCSSPageSize: true },
+      sessionId
+    )) as { data: string };
+    const buffer = Buffer.from(data, 'base64');
+
+    const sessionsDir = path.join(getBrowserRuntimeDir(), 'sessions', task.name);
+    const automaticPath = path.join(sessionsDir, `${Date.now()}.pdf`);
+    const finalPath = resolveScreenshotOutputPath(outputPath, automaticPath);
+    await fs.promises.mkdir(path.dirname(finalPath), { recursive: true });
+    await fs.promises.writeFile(finalPath, buffer);
+
+    return { path: finalPath, bytes: buffer.length };
+  }
+
   // ─── Recording ──────────────────────────────────────────────────────────────
   //
   // CDP `Page.startScreencast` emits a JPEG frame per `everyNthFrame`. We pipe

--- a/src/lib/browser/types.ts
+++ b/src/lib/browser/types.ts
@@ -128,6 +128,7 @@ export type IPCAction =
   | 'tab-list'
   | 'evaluate'
   | 'screenshot'
+  | 'pdf'
   | 'refs'
   | 'click'
   | 'type'


### PR DESCRIPTION
## What

Adds two additions to the `browser` command, both reusing existing CDP/service plumbing:

1. **`browser pdf [path]`** — exports the current page to PDF via CDP `Page.printToPDF`, saving to the given path or a sensible default. Follows the existing subcommand pattern for resolving the active task/tab and reuses the current CDP session.
2. **`browser requests --format har`** — serializes the buffered network requests as a standard HAR 1.2 JSON document. Default output is unchanged.

## Files
- `src/lib/browser/har.ts` — HAR 1.2 serializer (spec-mandated empty defaults / -1 sentinels for fields the buffer cannot back).
- `src/commands/browser.ts` — `pdf` subcommand + `--format har` option wiring.
- `src/lib/browser/{ipc,service,types}.ts` — printToPDF IPC + service plumbing.

## Tests
- `src/lib/browser/har.test.ts` (8) — HAR 1.2 shape/validity from a buffered request set.
- `src/commands/browser.pdf-har.test.ts` (6) — pdf command wiring + har format path.
All green under vitest; tsc clean.