### PR TITLE
feat(workflows): wire for_each producer exec + keep_if tally + run CLI surface (Closes #343)

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -163,6 +163,116 @@ export function loopExitCode(stoppedBy: import('../lib/loop.js').LoopStoppedBy):
   }
 }
 
+/**
+ * Drive a workflow's declarative `for_each:` fan-out end-to-end (issue #343).
+ *
+ * Runs the producer, expands one stage teammate per produced item (respecting
+ * `max_items` / `DEFAULT_FOR_EACH_CAP`, surfacing any truncation — never a
+ * silent cap), stages them into a fresh team via the existing `runForEach`
+ * bridge, then drives the teams supervisor until the DAG drains. When a verify
+ * panel is declared, tallies each item's `keep_if` gate from the skeptics'
+ * terminal status and logs which items survived.
+ *
+ * Reuses the teams substrate wholesale — no new orchestration engine. Returns
+ * the process exit code (0 on drain, 1 on producer failure / non-drain).
+ */
+export async function runWorkflowForEach(
+  spec: import('../lib/workflows.js').ForEachSpec,
+  opts: { workflowName: string; cwd: string; effort?: ExecEffort },
+): Promise<number> {
+  const [{ produceItems, runForEach, tallyForEach }, { expandForEach, DEFAULT_FOR_EACH_CAP }, { AgentManager }, { createTeam }, { runSupervisor }, { ALL_AGENT_IDS }] = await Promise.all([
+    import('../lib/teams/forEach.js'),
+    import('../lib/workflows.js'),
+    import('../lib/teams/agents.js'),
+    import('../lib/teams/registry.js'),
+    import('../lib/teams/supervisor.js'),
+    import('../lib/agents.js'),
+  ]);
+
+  // The teams substrate spawns teammates as a real harness. When `agent:` names
+  // a known harness id, honor it; otherwise fall back to claude (the workflow
+  // harness) so a subagent-style name in `agent:` still runs.
+  const isHarness = (a: string): boolean => (ALL_AGENT_IDS as readonly string[]).includes(a);
+  const runSpec: import('../lib/workflows.js').ForEachSpec = {
+    ...spec,
+    agent: isHarness(spec.agent) ? spec.agent : 'claude',
+    ...(spec.verify
+      ? { verify: { ...spec.verify, agent: isHarness(spec.verify.agent) ? spec.verify.agent : 'claude' } }
+      : {}),
+  };
+  if (runSpec.agent !== spec.agent) {
+    process.stderr.write(chalk.gray(`[for_each] '${spec.agent}' is not a harness id — staging stage teammates as claude\n`));
+  }
+
+  // 1. Producer: run the shell command (or resolve itemsRef) into the item list.
+  let items: string[];
+  try {
+    items = await produceItems(runSpec, { cwd: opts.cwd });
+  } catch (err) {
+    console.error(chalk.red(`[for_each] producer failed: ${(err as Error).message}`));
+    return 1;
+  }
+  if (items.length === 0) {
+    process.stderr.write(chalk.yellow('[for_each] producer emitted no items — nothing to fan out.\n'));
+    return 0;
+  }
+
+  // 2. Cap accounting (surfaced, never silent — acceptance criterion in #343).
+  const cap = runSpec.max_items ?? DEFAULT_FOR_EACH_CAP;
+  const { truncated } = expandForEach(runSpec, items);
+  if (truncated > 0) {
+    process.stderr.write(chalk.yellow(
+      `[for_each] producer emitted ${items.length} items; capping at ${cap} (${truncated} dropped). Raise \`max_items\` to fan out more.\n`,
+    ));
+  }
+  process.stderr.write(chalk.gray(`[for_each] ${Math.min(items.length, cap)} stage teammate(s) from ${items.length} produced item(s)\n`));
+
+  // 3. Stage the expanded teammates into a fresh team via the existing bridge.
+  const team = `foreach-${opts.workflowName.replace(/[^a-zA-Z0-9_-]/g, '-')}-${Date.now().toString(36)}`;
+  await createTeam(team, { description: `for_each fan-out from workflow '${opts.workflowName}'` });
+  const mgr = new AgentManager();
+  const { teammates } = await runForEach(mgr, team, runSpec, items, {
+    cwd: opts.cwd,
+    effort: opts.effort,
+    concurrency: runSpec.concurrency,
+  });
+
+  // 4. Drive the supervisor until the DAG drains (the same loop `teams start
+  // --watch` uses; it absorbs the staged teammates via rescanFromDisk).
+  const result = await runSupervisor(mgr, {
+    team,
+    onWave: (s) => {
+      const ts = s.timestamp.slice(11, 19);
+      process.stderr.write(
+        `[${ts}] [for_each] wave ${s.wave}  launched=${s.launched.length}  running=${s.running}  pending=${s.pending}  done=${s.completed}  failed=${s.failed}\n`,
+      );
+    },
+  });
+
+  // 5. keep_if tally: a skeptic that COMPLETED is a keep vote; a failed skeptic
+  // votes to drop. Gate each item and report which survived.
+  if (runSpec.verify) {
+    const loaded = await mgr.listByTask(team);
+    const statusByName = new Map(loaded.map((a) => [a.name, a.status]));
+    const verdicts = tallyForEach(teammates, (v) => statusByName.get(v.name) === 'completed');
+    const kept = verdicts.filter((v) => v.kept);
+    process.stderr.write(chalk.gray(
+      `[for_each] keep_if=${runSpec.verify.keep_if}: kept ${kept.length}/${verdicts.length} item(s)\n`,
+    ));
+    for (const v of verdicts) {
+      const tag = v.kept ? chalk.green('keep') : chalk.red('drop');
+      process.stderr.write(chalk.gray(`  [${tag}] ${v.item} (${v.votes.filter(Boolean).length}/${v.votes.length} votes)\n`));
+    }
+  }
+
+  if (result.stoppedBy === 'drained') {
+    process.stderr.write(chalk.green(`[for_each] drained in ${Math.floor(result.elapsed_ms / 1000)}s (${result.waves} waves). Team: ${team}\n`));
+    return 0;
+  }
+  process.stderr.write(chalk.yellow(`[for_each] stopped by ${result.stoppedBy} after ${result.waves} waves. Team: ${team}\n`));
+  return 1;
+}
+
 /** Register the `agents run <agent> [prompt]` command. */
 export function registerRunCommand(program: Command): void {
   const runCmd = program
@@ -586,6 +696,11 @@ export function registerRunCommand(program: Command): void {
       // WORKFLOW.md `loop:` block (issue #332). When a workflow declares it,
       // `agents run <workflow>` honors the loop without a --loop flag.
       let workflowLoop: import('../lib/workflows.js').LoopConfigRaw | undefined;
+      // WORKFLOW.md `for_each:` block (issue #343). When a workflow declares it,
+      // `agents run <workflow>` runs the producer, expands one stage teammate per
+      // produced item, and drives the teams supervisor to drain — no `teams`
+      // subcommands needed.
+      let workflowForEach: import('../lib/workflows.js').ForEachSpec | undefined;
       const cwd = options.cwd ?? process.cwd();
 
       if (isValidAgent(rawAgent)) {
@@ -620,6 +735,7 @@ export function registerRunCommand(program: Command): void {
           workflowModel = workflowFrontmatter.model.trim();
         }
         workflowLoop = workflowFrontmatter?.loop;
+        workflowForEach = workflowFrontmatter?.forEach;
 
         const resolvedVersion = resolveVersionAlias('claude', version);
         const versionHome = getVersionHomePath('claude', resolvedVersion ?? getGlobalDefault('claude') ?? '');
@@ -1327,6 +1443,23 @@ export function registerRunCommand(program: Command): void {
           }
         }
       };
+
+      // for_each dispatch (issue #343). A workflow that declares `for_each:` is a
+      // declarative dynamic fan-out, not a single-agent run: execute the producer,
+      // expand one stage teammate per produced item (+ optional verify panel),
+      // stage them into a team, then drive the supervisor until the DAG drains.
+      // This is mutually exclusive with the single-agent loop/fallback paths — the
+      // fan-out IS the run.
+      if (workflowForEach) {
+        cleanupWorkflowMcpConfig();
+        cleanupWorkflowSubagents();
+        const exitCode = await runWorkflowForEach(workflowForEach, {
+          workflowName: rawAgent,
+          cwd,
+          effort: options.effort,
+        });
+        process.exit(exitCode);
+      }
 
       // Loop dispatch (issue #332). Active when --loop is passed OR a workflow
       // declares a `loop:` block. The loop path runs AFTER the #346 pre-flight

--- a/src/lib/teams/__tests__/forEach.test.ts
+++ b/src/lib/teams/__tests__/forEach.test.ts
@@ -31,6 +31,12 @@ import {
   type ForEachSpec,
   type ForEachTeammate,
 } from '../../workflows.js';
+import {
+  parseProducedItems,
+  produceItems,
+  evaluateKeepIf,
+  tallyForEach,
+} from '../forEach.js';
 
 describe('parseForEachBlock — defensive coercion (issue #343)', () => {
   it('parses a well-formed for_each block with a verify panel', () => {
@@ -171,6 +177,145 @@ describe('expandForEach — one stage per produced item + verify (issue #343)', 
     expect(capped.usedCount).toBe(4);
     expect(capped.producedCount).toBe(DEFAULT_FOR_EACH_CAP + 25);
     expect(capped.truncated).toBe(DEFAULT_FOR_EACH_CAP + 21);
+  });
+});
+
+describe('parseProducedItems — JSON array OR newline-delimited (issue #343)', () => {
+  it('parses a JSON array of strings', () => {
+    expect(parseProducedItems('["a","b","c"]')).toEqual(['a', 'b', 'c']);
+  });
+  it('parses newline-delimited output, trimming and dropping blanks', () => {
+    expect(parseProducedItems('a\nb\n\n  c  \n')).toEqual(['a', 'b', 'c']);
+  });
+  it('coerces non-string JSON array elements to trimmed strings', () => {
+    expect(parseProducedItems('[1, 2, "x", null, "  y  "]')).toEqual(['1', '2', 'x', 'y']);
+  });
+  it('returns [] for empty output or an empty JSON array', () => {
+    expect(parseProducedItems('')).toEqual([]);
+    expect(parseProducedItems('   \n  ')).toEqual([]);
+    expect(parseProducedItems('[]')).toEqual([]);
+  });
+  it('falls back to a single line when a JSON-looking line does not parse', () => {
+    expect(parseProducedItems('[not json')).toEqual(['[not json']);
+  });
+});
+
+describe('produceItems — real producer command executes and parses (issue #343)', () => {
+  it('runs a JSON-array producer and expands to one stage teammate per item', async () => {
+    const spec: ForEachSpec = {
+      produce: `printf '["a","b","c"]'`,
+      agent: 'claude',
+      prompt: 'do {{item}}',
+    };
+    const items = await produceItems(spec);
+    expect(items).toEqual(['a', 'b', 'c']);
+
+    const { teammates } = expandForEach(spec, items);
+    const stages = teammates.filter((t) => t.role === 'stage');
+    expect(stages).toHaveLength(3);
+    expect(stages.map((t) => t.item)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('runs a newline-delimited producer and expands to one stage teammate per item', async () => {
+    const spec: ForEachSpec = {
+      produce: `printf 'a\\nb\\nc\\n'`,
+      agent: 'claude',
+      prompt: 'do {{item}}',
+    };
+    const items = await produceItems(spec);
+    expect(items).toEqual(['a', 'b', 'c']);
+
+    const { teammates } = expandForEach(spec, items);
+    expect(teammates.filter((t) => t.role === 'stage')).toHaveLength(3);
+  });
+
+  it('resolves an itemsRef via the supplied resolver, skipping the producer', async () => {
+    const spec: ForEachSpec = {
+      itemsRef: '${endpoints}',
+      produce: `printf 'SHOULD-NOT-RUN'`,
+      agent: 'claude',
+      prompt: 'do {{item}}',
+    };
+    const items = await produceItems(spec, {
+      resolveItemsRef: (ref) => (ref === '${endpoints}' ? ['x', 'y'] : undefined),
+    });
+    expect(items).toEqual(['x', 'y']);
+  });
+
+  it('throws when neither a producer nor a resolvable itemsRef is available', async () => {
+    await expect(produceItems({ itemsRef: '${missing}', agent: 'a', prompt: 'p' }, {}))
+      .rejects.toThrow(/could not be resolved/);
+  });
+
+  it('applies max_items truncation to a real producer list and surfaces the drop count', async () => {
+    // Producer emits 5 items; max_items caps the fan-out at 2.
+    const spec: ForEachSpec = {
+      produce: `printf '["a","b","c","d","e"]'`,
+      agent: 'claude',
+      prompt: 'do {{item}}',
+      max_items: 2,
+    };
+    const items = await produceItems(spec);
+    expect(items).toHaveLength(5);
+
+    const { teammates, producedCount, usedCount, truncated } = expandForEach(spec, items);
+    expect(producedCount).toBe(5);
+    expect(usedCount).toBe(2);
+    expect(truncated).toBe(3); // surfaced so the CLI can log "3 dropped"
+    expect(teammates.filter((t) => t.role === 'stage')).toHaveLength(2);
+    expect(teammates.filter((t) => t.role === 'stage').map((t) => t.item)).toEqual(['a', 'b']);
+  });
+});
+
+describe('evaluateKeepIf — vote tally gate (issue #343)', () => {
+  it('all: every vote must be keep', () => {
+    expect(evaluateKeepIf([true, true, true], 'all')).toBe(true);
+    expect(evaluateKeepIf([true, false, true], 'all')).toBe(false);
+  });
+  it('any: at least one keep vote', () => {
+    expect(evaluateKeepIf([false, false, true], 'any')).toBe(true);
+    expect(evaluateKeepIf([false, false, false], 'any')).toBe(false);
+  });
+  it('majority: strictly more than half (a tie does not pass)', () => {
+    expect(evaluateKeepIf([true, true, false], 'majority')).toBe(true); // 2/3
+    expect(evaluateKeepIf([true, false, false], 'majority')).toBe(false); // 1/3
+    expect(evaluateKeepIf([true, false], 'majority')).toBe(false); // 1/2 tie
+    expect(evaluateKeepIf([true, true], 'majority')).toBe(true); // 2/2
+  });
+  it('an empty panel drops the item (nothing affirms it)', () => {
+    expect(evaluateKeepIf([], 'any')).toBe(false);
+    expect(evaluateKeepIf([], 'all')).toBe(false);
+    expect(evaluateKeepIf([], 'majority')).toBe(false);
+  });
+});
+
+describe('tallyForEach — per-item gate over expanded teammates (issue #343)', () => {
+  const spec: ForEachSpec = {
+    agent: 'claude',
+    name: 'audit',
+    prompt: 'audit {{item}}',
+    verify: { agent: 'skeptic', votes: 3, keep_if: 'majority' },
+  };
+
+  it('keeps the item whose panel reaches the keep_if gate, drops the other', () => {
+    const items = ['keepme', 'dropme'];
+    const { teammates } = expandForEach(spec, items);
+    // keepme's skeptics all vote keep; dropme's none do.
+    const verdicts = tallyForEach(teammates, (v) => v.item === 'keepme');
+    const byItem = new Map(verdicts.map((v) => [v.item, v]));
+    expect(byItem.get('keepme')!.kept).toBe(true);
+    expect(byItem.get('keepme')!.votes).toEqual([true, true, true]);
+    expect(byItem.get('dropme')!.kept).toBe(false);
+    expect(byItem.get('dropme')!.votes).toEqual([false, false, false]);
+  });
+
+  it('keeps an item unconditionally when it has no verify panel', () => {
+    const bare: ForEachSpec = { agent: 'claude', prompt: 'do {{item}}' };
+    const { teammates } = expandForEach(bare, ['a']);
+    const verdicts = tallyForEach(teammates, () => false);
+    expect(verdicts).toHaveLength(1);
+    expect(verdicts[0].kept).toBe(true);
+    expect(verdicts[0].votes).toEqual([]);
   });
 });
 

--- a/src/lib/teams/forEach.ts
+++ b/src/lib/teams/forEach.ts
@@ -13,9 +13,199 @@
  * chain is the whole mechanism, so cycle detection, wave scheduling, and
  * cross-vendor/rotation dispatch all carry over unchanged.
  */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import type { AgentManager, AgentProcess, EffortLevel } from './agents.js';
 import type { AgentType } from './parsers.js';
 import { expandForEach, type ForEachSpec, type ForEachTeammate } from '../workflows.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Parse a producer's stdout into the item list `expandForEach` fans out over.
+ *
+ * Two shapes are accepted (issue #343), tried in order:
+ *   1. A JSON array — `["a","b","c"]` (each element coerced to a trimmed string).
+ *   2. Newline-delimited — one item per line.
+ *
+ * Empty lines / entries are dropped so a trailing newline or a `[]` never
+ * fabricates a phantom teammate. Pure and deterministic — no I/O.
+ */
+export function parseProducedItems(stdout: string): string[] {
+  const trimmed = stdout.trim();
+  if (trimmed === '') return [];
+
+  // JSON array form first — only when it actually looks like one, so a plain
+  // line that happens to start with '[' doesn't get swallowed by a parse error.
+  if (trimmed.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed
+          .map((x) => (x == null ? '' : typeof x === 'string' ? x : String(x)))
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0);
+      }
+    } catch {
+      // Not valid JSON — fall through to newline parsing.
+    }
+  }
+
+  // Newline-delimited form.
+  return trimmed
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export interface ProduceItemsOptions {
+  /** Working directory for the producer command. */
+  cwd?: string | null;
+  /** Environment for the producer command (defaults to the current process env). */
+  env?: NodeJS.ProcessEnv;
+  /** Kill the producer after this many ms (default 120_000). */
+  timeoutMs?: number;
+  /**
+   * Resolve an `itemsRef` (`${step}`-style reference) to a prior step's produced
+   * list. When a spec carries `itemsRef` and this resolver returns a list, the
+   * producer command is skipped entirely.
+   */
+  resolveItemsRef?: (ref: string) => string[] | undefined;
+}
+
+/**
+ * Resolve a `for_each` spec's item list at runtime (issue #343): either by
+ * running its `produce:` shell command and parsing stdout, or by resolving an
+ * `itemsRef` to a prior step's list. The resulting items feed `expandForEach` /
+ * `runForEach`.
+ *
+ * `itemsRef` wins when a resolver is supplied and returns a list; otherwise the
+ * `produce` command runs. A spec with neither a resolvable ref nor a produce
+ * command is a hard error — there is nothing to fan out over.
+ */
+export async function produceItems(
+  spec: ForEachSpec,
+  opts: ProduceItemsOptions = {},
+): Promise<string[]> {
+  if (spec.itemsRef && opts.resolveItemsRef) {
+    const resolved = opts.resolveItemsRef(spec.itemsRef);
+    if (resolved) return resolved;
+  }
+
+  if (!spec.produce) {
+    if (spec.itemsRef) {
+      throw new Error(
+        `for_each itemsRef '${spec.itemsRef}' could not be resolved and no produce command is set`,
+      );
+    }
+    throw new Error('for_each has neither a produce command nor a resolvable itemsRef');
+  }
+
+  // The producer is a shell command string (e.g. "rg -l 'x' src/"), so it runs
+  // under /bin/sh -c exactly like a teammate command. maxBuffer is raised well
+  // above the default 1MB so a producer emitting a large list isn't truncated
+  // silently mid-stream.
+  const { stdout } = await execFileAsync('/bin/sh', ['-c', spec.produce], {
+    cwd: opts.cwd ?? undefined,
+    env: opts.env ?? process.env,
+    timeout: opts.timeoutMs ?? 120_000,
+    maxBuffer: 64 * 1024 * 1024,
+    encoding: 'utf-8',
+  });
+  return parseProducedItems(stdout);
+}
+
+/**
+ * Evaluate a verify panel's `keep_if` gate against its boolean votes (issue
+ * #343). A `true` vote is a skeptic confirming the finding should be kept.
+ *
+ *   - `all`      — every skeptic must vote keep.
+ *   - `any`      — at least one skeptic votes keep.
+ *   - `majority` — strictly more than half vote keep (a tie does NOT pass).
+ *
+ * An empty panel returns false: with no votes there is nothing affirming the
+ * item, so the conservative gate drops it.
+ */
+export function evaluateKeepIf(
+  votes: boolean[],
+  keepIf: 'majority' | 'all' | 'any',
+): boolean {
+  const total = votes.length;
+  if (total === 0) return false;
+  const yes = votes.reduce((n, v) => (v ? n + 1 : n), 0);
+  switch (keepIf) {
+    case 'all':
+      return yes === total;
+    case 'any':
+      return yes >= 1;
+    case 'majority':
+      return yes * 2 > total;
+  }
+}
+
+/** Per-item verdict after tallying its verify panel. */
+export interface ForEachItemVerdict {
+  /** The produced item this verdict is for. */
+  item: string;
+  /** Zero-based index in the (capped) produced list. */
+  itemIndex: number;
+  /** The stage teammate that handled this item. */
+  stageName: string;
+  /** Whether the item survives its `keep_if` gate (true when it has no panel). */
+  kept: boolean;
+  /** The votes that were tallied (empty when the item has no verify panel). */
+  votes: boolean[];
+  /** The gate applied (undefined when the item has no verify panel). */
+  keepIf?: 'majority' | 'all' | 'any';
+}
+
+/**
+ * Tally the verify panels of an expanded `for_each` and gate each item (issue
+ * #343). Groups verify teammates by the stage teammate they depend on, reads a
+ * boolean vote per verify teammate via `readVote`, and applies `keep_if`.
+ *
+ * An item with no verify panel is kept unconditionally (there is no gate).
+ * Pure and deterministic: `readVote` is the only place runtime state enters, so
+ * this is unit-testable with a synthetic vote reader.
+ */
+export function tallyForEach(
+  teammates: ForEachTeammate[],
+  readVote: (verify: ForEachTeammate) => boolean,
+): ForEachItemVerdict[] {
+  const stages = teammates.filter((t) => t.role === 'stage');
+  const verifiersByStage = new Map<string, ForEachTeammate[]>();
+  for (const t of teammates) {
+    if (t.role !== 'verify') continue;
+    const stageName = t.after[0];
+    if (!stageName) continue;
+    const list = verifiersByStage.get(stageName) ?? [];
+    list.push(t);
+    verifiersByStage.set(stageName, list);
+  }
+
+  return stages.map((stage) => {
+    const panel = verifiersByStage.get(stage.name) ?? [];
+    if (panel.length === 0) {
+      return {
+        item: stage.item,
+        itemIndex: stage.itemIndex,
+        stageName: stage.name,
+        kept: true,
+        votes: [],
+      };
+    }
+    const keepIf = panel[0].keep_if ?? 'majority';
+    const votes = panel.map((v) => readVote(v));
+    return {
+      item: stage.item,
+      itemIndex: stage.itemIndex,
+      stageName: stage.name,
+      kept: evaluateKeepIf(votes, keepIf),
+      votes,
+      keepIf,
+    };
+  });
+}
 
 export interface RunForEachOptions {
   /** Working directory for the spawned teammates. */


### PR DESCRIPTION
## What

Wires the three explicitly-deferred pieces of declarative dynamic fan-out (issue #343) onto the parse/expand primitive already on `main` (`ForEachSpec`, `expandForEach`, `runForEach`, `DEFAULT_FOR_EACH_CAP`), so the feature is user-usable end-to-end via `agents run <workflow>`.

### 1. Producer execution
- `produceItems(spec, opts)` runs the `produce:` shell command under `/bin/sh -c` (64MB buffer, 120s timeout) and parses stdout.
- `parseProducedItems(stdout)` accepts **JSON array** (`["a","b","c"]`) **or** newline-delimited output; trims, drops blanks, coerces non-string JSON elements.
- `itemsRef` (`${step}`) resolves via an optional `resolveItemsRef` callback, skipping the producer.

### 2. `keep_if` vote tally
- `evaluateKeepIf(votes: boolean[], keepIf)` — pure gate: `all` / `any` / `majority` (majority = strictly more than half; a tie fails; an empty panel drops).
- `tallyForEach(teammates, readVote)` — groups verify teammates by their stage and gates each item; items with no panel are kept unconditionally.

### 3. CLI surface (`agents run <workflow>`)
- `runWorkflowForEach()` in `src/commands/exec.ts` reads `workflowFrontmatter.forEach`, executes the producer, expands respecting `max_items` / `DEFAULT_FOR_EACH_CAP` (**truncation is logged, never silently capped**), stages teammates via the existing `runForEach` bridge into a fresh team, drives the existing supervisor (`src/lib/teams/supervisor.ts`) until the DAG drains, then tallies `keep_if` from skeptic terminal status.

## Reuse, not reinvention

No new orchestration engine. Producer output feeds the existing `expandForEach`/`runForEach`; staged teammates are absorbed by the supervisor's existing mid-flight-add path (`rescanFromDisk`/`startReady`).

## Tests

Colocated in `src/lib/teams/__tests__/forEach.test.ts` (fail pre-change — they reference the new exports). Real `printf` producers, no mocking of code under test:
- (a) producer stdout `["a","b","c"]` **and** `a\nb\nc\n` both parse to 3 items and `expandForEach` produces 3 stage teammates.
- (b) `evaluateKeepIf` correct gates for majority/all/any (incl. tie + empty-panel cases).
- (c) `max_items` truncation applied to a real producer list and surfaced (`producedCount`/`usedCount`/`truncated`).
- plus `tallyForEach` per-item gating and `itemsRef` resolution.

`bunx tsc --noEmit` clean; the 30 tests in the for_each suite pass. (5 unrelated pre-existing failures in `session/sync/config.test.ts` are byte-identical to `origin/main` and stem from host keychain state, not this change.)