### PR TITLE
fix(secrets): atomic pull-restore with rollback on partial failure (#316 Finding 2)

### DIFF
--- a/src/lib/secrets/sync.test.ts
+++ b/src/lib/secrets/sync.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  setKeychainBackendForTest,
+  secretsKeychainItem,
+  type KeychainBackend,
+} from './index.js';
+import { readBundle, type SecretsBundle } from './bundles.js';
+import {
+  encryptBlob,
+  pullBundle,
+  setSyncBackend,
+  type BundleSnapshot,
+} from './sync.js';
+import type { SyncBackend, SyncEnvelope, RemoteBundleSummary } from './sync-backend.js';
+
+/**
+ * In-memory keychain backend that can be told to throw on a specific item's
+ * write, so we can inject a mid-restore failure and assert the rollback leaves
+ * the store exactly as it was. This swaps the STORAGE layer only — the code
+ * under test (restoreSnapshot, reached through pullBundle) runs for real.
+ */
+class FailingKeychain implements KeychainBackend {
+  readonly store = new Map<string, string>();
+  /** Item name whose `set` should throw; null = never fail. */
+  failOnSet: string | null = null;
+
+  has(item: string): boolean {
+    return this.store.has(item);
+  }
+  get(item: string): string {
+    if (!this.store.has(item)) throw new Error(`Keychain item '${item}' not found.`);
+    return this.store.get(item)!;
+  }
+  set(item: string, value: string): void {
+    if (this.failOnSet !== null && item === this.failOnSet) {
+      throw new Error(`injected write failure for '${item}'`);
+    }
+    this.store.set(item, value);
+  }
+  delete(item: string): boolean {
+    return this.store.delete(item);
+  }
+  list(prefix: string): string[] {
+    return [...this.store.keys()].filter((k) => k.startsWith(prefix));
+  }
+}
+
+/** A sync backend that hands back a single fixed envelope for getEnvelope. */
+function fixedBackend(envelope: SyncEnvelope): SyncBackend {
+  return {
+    async putEnvelope(): Promise<void> {},
+    async getEnvelope(): Promise<SyncEnvelope | null> {
+      return envelope;
+    },
+    async deleteEnvelope(): Promise<boolean> {
+      return true;
+    },
+    async listEnvelopes(): Promise<RemoteBundleSummary[]> {
+      return [];
+    },
+  };
+}
+
+const PASSPHRASE = 'correct-horse-battery-staple';
+const NAME = 'demo';
+
+// Order matters: AKEY (pre-existing) is overwritten, CKEY (new) is created,
+// then the write of BKEY fails — so rollback must both restore AKEY to its
+// original value AND delete the freshly-created CKEY, and leave metadata
+// untouched.
+function makeSnapshot(): BundleSnapshot {
+  const bundle: SecretsBundle = {
+    name: NAME,
+    vars: {
+      AKEY: 'keychain:AKEY',
+      CKEY: 'keychain:CKEY',
+      BKEY: 'keychain:BKEY',
+    },
+  };
+  const secrets: Record<string, string> = {
+    AKEY: 'new-a',
+    CKEY: 'new-c',
+    BKEY: 'new-b',
+  };
+  return { bundle, secrets };
+}
+
+function envelopeFor(snap: BundleSnapshot): SyncEnvelope {
+  return {
+    envelope: encryptBlob(JSON.stringify(snap), PASSPHRASE),
+    updated_at: '2026-07-05T00:00:00.000Z',
+  };
+}
+
+let kc: FailingKeychain;
+let prevKc: KeychainBackend | null;
+let prevBackend: SyncBackend;
+const prevNoAgent = process.env.AGENTS_SECRETS_NO_AGENT;
+const prevNoUsage = process.env.AGENTS_NO_USAGE_TRACK;
+
+beforeEach(() => {
+  kc = new FailingKeychain();
+  prevKc = setKeychainBackendForTest(kc);
+  // Keep the restore path hermetic — no secrets-agent socket, no last_used write.
+  process.env.AGENTS_SECRETS_NO_AGENT = '1';
+  process.env.AGENTS_NO_USAGE_TRACK = '1';
+});
+
+afterEach(() => {
+  setKeychainBackendForTest(prevKc);
+  if (prevBackend) setSyncBackend(prevBackend);
+  if (prevNoAgent === undefined) delete process.env.AGENTS_SECRETS_NO_AGENT;
+  else process.env.AGENTS_SECRETS_NO_AGENT = prevNoAgent;
+  if (prevNoUsage === undefined) delete process.env.AGENTS_NO_USAGE_TRACK;
+  else process.env.AGENTS_NO_USAGE_TRACK = prevNoUsage;
+});
+
+describe('pullBundle restore atomicity', () => {
+  it('rolls back completely when a keychain write fails mid-restore', async () => {
+    const aItem = secretsKeychainItem(NAME, 'AKEY');
+    const bItem = secretsKeychainItem(NAME, 'BKEY');
+    const cItem = secretsKeychainItem(NAME, 'CKEY');
+    const metaItem = `agents-cli.bundles.${NAME}`;
+
+    // Pre-existing store: AKEY + BKEY carry original values; metadata is a
+    // sentinel we can check stayed untouched. CKEY does not exist yet.
+    kc.store.set(aItem, 'old-a');
+    kc.store.set(bItem, 'old-b');
+    kc.store.set(metaItem, JSON.stringify({ vars: { AKEY: 'keychain:AKEY', BKEY: 'keychain:BKEY' }, sentinel: true }));
+
+    // Make the write of BKEY (the 3rd write) throw, after AKEY was overwritten
+    // and CKEY was freshly created.
+    kc.failOnSet = bItem;
+
+    prevBackend = setSyncBackend(fixedBackend(envelopeFor(makeSnapshot())));
+
+    await expect(pullBundle(NAME, { passphrase: PASSPHRASE, force: true })).rejects.toThrow(
+      /rolled back to the pre-restore state/,
+    );
+
+    // Pre-existing items restored to their ORIGINAL values.
+    expect(kc.store.get(aItem)).toBe('old-a');
+    expect(kc.store.get(bItem)).toBe('old-b');
+    // The item that did not exist before must not linger.
+    expect(kc.store.has(cItem)).toBe(false);
+    // Metadata never advanced — writeBundle is only reached on full success.
+    expect(JSON.parse(kc.store.get(metaItem)!).sentinel).toBe(true);
+  });
+
+  it('commits all secrets and metadata on a fully successful restore', async () => {
+    const aItem = secretsKeychainItem(NAME, 'AKEY');
+    const bItem = secretsKeychainItem(NAME, 'BKEY');
+    const cItem = secretsKeychainItem(NAME, 'CKEY');
+
+    // AKEY pre-exists (to prove overwrite), BKEY/CKEY are new.
+    kc.store.set(aItem, 'old-a');
+
+    kc.failOnSet = null;
+    prevBackend = setSyncBackend(fixedBackend(envelopeFor(makeSnapshot())));
+
+    const bundle = await pullBundle(NAME, { passphrase: PASSPHRASE, force: true });
+    expect(bundle.name).toBe(NAME);
+
+    // Every secret committed to its pulled value.
+    expect(kc.store.get(aItem)).toBe('new-a');
+    expect(kc.store.get(bItem)).toBe('new-b');
+    expect(kc.store.get(cItem)).toBe('new-c');
+
+    // Metadata written and readable, with all three vars.
+    const persisted = readBundle(NAME);
+    expect(Object.keys(persisted.vars).sort()).toEqual(['AKEY', 'BKEY', 'CKEY']);
+  });
+});

--- a/src/lib/secrets/sync.test.ts
+++ b/src/lib/secrets/sync.test.ts
@@ -23,6 +23,13 @@ class FailingKeychain implements KeychainBackend {
   readonly store = new Map<string, string>();
   /** Item name whose `set` should throw; null = never fail. */
   failOnSet: string | null = null;
+  /**
+   * When non-null, `failOnSet` only throws for a `set` whose value equals this —
+   * letting a test fail the forward write (new value) while the rollback's
+   * restore of the OLD value succeeds. Leave null to fail every set of
+   * `failOnSet`, modelling a keyring that also errors on the reversal write.
+   */
+  failOnSetValue: string | null = null;
 
   has(item: string): boolean {
     return this.store.has(item);
@@ -32,7 +39,11 @@ class FailingKeychain implements KeychainBackend {
     return this.store.get(item)!;
   }
   set(item: string, value: string): void {
-    if (this.failOnSet !== null && item === this.failOnSet) {
+    if (
+      this.failOnSet !== null &&
+      item === this.failOnSet &&
+      (this.failOnSetValue === null || value === this.failOnSetValue)
+    ) {
       throw new Error(`injected write failure for '${item}'`);
     }
     this.store.set(item, value);
@@ -128,9 +139,12 @@ describe('pullBundle restore atomicity', () => {
     kc.store.set(bItem, 'old-b');
     kc.store.set(metaItem, JSON.stringify({ vars: { AKEY: 'keychain:AKEY', BKEY: 'keychain:BKEY' }, sentinel: true }));
 
-    // Make the write of BKEY (the 3rd write) throw, after AKEY was overwritten
-    // and CKEY was freshly created.
+    // Make the forward write of BKEY (its NEW value, the 3rd write) throw, after
+    // AKEY was overwritten and CKEY was freshly created. Scoping the injection to
+    // the new value lets the rollback's restore of BKEY's OLD value succeed, so
+    // this exercises a COMPLETE rollback (the incomplete case is below).
     kc.failOnSet = bItem;
+    kc.failOnSetValue = 'new-b';
 
     prevBackend = setSyncBackend(fixedBackend(envelopeFor(makeSnapshot())));
 
@@ -145,6 +159,41 @@ describe('pullBundle restore atomicity', () => {
     expect(kc.store.has(cItem)).toBe(false);
     // Metadata never advanced — writeBundle is only reached on full success.
     expect(JSON.parse(kc.store.get(metaItem)!).sentinel).toBe(true);
+  });
+
+  it('reports an INCOMPLETE rollback (naming the dirty item) when a reversal write also fails', async () => {
+    const aItem = secretsKeychainItem(NAME, 'AKEY');
+    const bItem = secretsKeychainItem(NAME, 'BKEY');
+    const cItem = secretsKeychainItem(NAME, 'CKEY');
+
+    kc.store.set(aItem, 'old-a');
+    kc.store.set(bItem, 'old-b');
+
+    // The realistic trigger: the same backend that fails the restore write of
+    // BKEY ALSO fails the rollback's attempt to write BKEY back. Leaving
+    // failOnSetValue null makes EVERY set of bItem throw — both the forward
+    // write (new-b) and the reversal restore (old-b).
+    kc.failOnSet = bItem;
+    kc.failOnSetValue = null;
+
+    prevBackend = setSyncBackend(fixedBackend(envelopeFor(makeSnapshot())));
+
+    // The thrown error must NOT claim a clean rollback: it must say the rollback
+    // was INCOMPLETE and name the still-dirty item.
+    const err = await pullBundle(NAME, { passphrase: PASSPHRASE, force: true }).then(
+      () => {
+        throw new Error('expected pullBundle to reject');
+      },
+      (e: Error) => e,
+    );
+    expect(err.message).toMatch(/rollback was INCOMPLETE/i);
+    expect(err.message).toContain(bItem);
+    expect(err.message).not.toMatch(/rolled back to the pre-restore state/);
+
+    // The items whose reversal succeeded were still reverted (best-effort
+    // continuation): AKEY back to its original value, CKEY (never existed) gone.
+    expect(kc.store.get(aItem)).toBe('old-a');
+    expect(kc.store.has(cItem)).toBe(false);
   });
 
   it('commits all secrets and metadata on a fully successful restore', async () => {

--- a/src/lib/secrets/sync.ts
+++ b/src/lib/secrets/sync.ts
@@ -166,17 +166,24 @@ function restoreSnapshot(snap: BundleSnapshot): void {
   }
 
   // Best-effort reversal to the captured pre-restore state. Each item is
-  // restored independently so one failure doesn't abort the rest of the
-  // rollback; the original throw is what surfaces to the caller.
-  const rollback = (): void => {
+  // reverted independently so one failure doesn't abort the rest of the
+  // rollback. Reversal writes hit the SAME backend that just failed the restore
+  // (a locked/erroring keyring is the realistic trigger), so a reversal can
+  // itself throw — those items are collected and returned so the caller can
+  // report an INCOMPLETE rollback instead of falsely claiming a clean one.
+  const rollback = (): string[] => {
+    const stillDirty: string[] = [];
     for (const prior of priors) {
       try {
         if (prior.existed) setKeychainToken(prior.item, prior.value!);
         else deleteKeychainToken(prior.item);
       } catch {
-        // Nothing better to do — keep undoing the remaining items.
+        // Keep undoing the remaining items, but remember this one couldn't be
+        // reverted — it may now hold an orphaned or wrong value.
+        stillDirty.push(prior.item);
       }
     }
+    return stillDirty;
   };
 
   try {
@@ -185,11 +192,7 @@ function restoreSnapshot(snap: BundleSnapshot): void {
       setKeychainToken(item, value);
     }
   } catch (err) {
-    rollback();
-    throw new Error(
-      `Restore of bundle '${bundle.name}' failed while writing secrets; ` +
-      `rolled back to the pre-restore state. (${(err as Error).message})`,
-    );
+    throw new Error(rollbackFailureMessage(bundle.name, 'writing secrets', err as Error, rollback()));
   }
 
   // Commit metadata last. If it fails, undo the secret writes so nothing
@@ -197,12 +200,25 @@ function restoreSnapshot(snap: BundleSnapshot): void {
   try {
     writeBundle(bundle);
   } catch (err) {
-    rollback();
-    throw new Error(
-      `Restore of bundle '${bundle.name}' failed while writing metadata; ` +
-      `rolled back to the pre-restore state. (${(err as Error).message})`,
-    );
+    throw new Error(rollbackFailureMessage(bundle.name, 'writing metadata', err as Error, rollback()));
   }
+}
+
+/**
+ * Build the error thrown when a restore fails. When the rollback reverted every
+ * touched item (`dirty` empty) we truthfully say the keychain is back to the
+ * pre-restore state. When some reversal writes ALSO failed we must NOT claim a
+ * clean rollback — the message names the still-dirty items so the user knows the
+ * keychain is half-restored and which secrets to check.
+ */
+function rollbackFailureMessage(name: string, phase: string, err: Error, dirty: string[]): string {
+  if (dirty.length === 0) {
+    return `Restore of bundle '${name}' failed while ${phase}; ` +
+      `rolled back to the pre-restore state. (${err.message})`;
+  }
+  return `Restore of bundle '${name}' failed while ${phase}, and the rollback was INCOMPLETE — ` +
+    `these keychain items could not be reverted and may hold orphaned or wrong values: ${dirty.join(', ')}. ` +
+    `(original error: ${err.message})`;
 }
 
 /** Options for pushBundle. */

--- a/src/lib/secrets/sync.ts
+++ b/src/lib/secrets/sync.ts
@@ -13,6 +13,7 @@
 
 import * as crypto from 'crypto';
 import {
+  deleteKeychainToken,
   getKeychainToken,
   hasKeychainToken,
   secretsKeychainItem,
@@ -123,14 +124,85 @@ function snapshotBundle(name: string): BundleSnapshot {
   return { bundle, secrets };
 }
 
+/** Prior state of one keychain item a restore is about to overwrite. */
+interface PriorItem {
+  item: string;
+  /** Whether the item already existed before the restore touched it. */
+  existed: boolean;
+  /** Its value when it existed (undefined for items that didn't exist). */
+  value?: string;
+}
+
+/**
+ * Materialize a decrypted snapshot locally, atomically.
+ *
+ * A naive "set each secret, then write metadata" is not crash-safe: if one
+ * `setKeychainToken` throws midway, the keychain is left with a half-applied
+ * set — some items carry the pulled values, others the old ones — and the
+ * bundle metadata may never be written, leaving orphaned/wrong items readable.
+ *
+ * So we snapshot the PRIOR value of every item we're about to touch, apply all
+ * writes, and on ANY failure roll back to exactly the pre-restore state
+ * (restore previously-existing items, delete items that didn't exist) before
+ * rethrowing. Metadata is committed only after every secret write succeeds; if
+ * that final write fails, the secret writes are rolled back too. Either the
+ * whole pull lands or the keychain is untouched.
+ */
 function restoreSnapshot(snap: BundleSnapshot): void {
   const bundle = snap.bundle;
   validateBundleName(bundle.name);
-  for (const [shortId, value] of Object.entries(snap.secrets)) {
+
+  // Capture the pre-restore state of every item so a partial failure can be
+  // undone. hasKeychainToken never prompts; getKeychainToken reads the existing
+  // value via the same path the rest of the module uses.
+  const priors: PriorItem[] = [];
+  for (const shortId of Object.keys(snap.secrets)) {
     const item = secretsKeychainItem(bundle.name, shortId);
-    setKeychainToken(item, value);
+    if (hasKeychainToken(item)) {
+      priors.push({ item, existed: true, value: getKeychainToken(item) });
+    } else {
+      priors.push({ item, existed: false });
+    }
   }
-  writeBundle(bundle);
+
+  // Best-effort reversal to the captured pre-restore state. Each item is
+  // restored independently so one failure doesn't abort the rest of the
+  // rollback; the original throw is what surfaces to the caller.
+  const rollback = (): void => {
+    for (const prior of priors) {
+      try {
+        if (prior.existed) setKeychainToken(prior.item, prior.value!);
+        else deleteKeychainToken(prior.item);
+      } catch {
+        // Nothing better to do — keep undoing the remaining items.
+      }
+    }
+  };
+
+  try {
+    for (const [shortId, value] of Object.entries(snap.secrets)) {
+      const item = secretsKeychainItem(bundle.name, shortId);
+      setKeychainToken(item, value);
+    }
+  } catch (err) {
+    rollback();
+    throw new Error(
+      `Restore of bundle '${bundle.name}' failed while writing secrets; ` +
+      `rolled back to the pre-restore state. (${(err as Error).message})`,
+    );
+  }
+
+  // Commit metadata last. If it fails, undo the secret writes so nothing
+  // partial lingers.
+  try {
+    writeBundle(bundle);
+  } catch (err) {
+    rollback();
+    throw new Error(
+      `Restore of bundle '${bundle.name}' failed while writing metadata; ` +
+      `rolled back to the pre-restore state. (${(err as Error).message})`,
+    );
+  }
 }
 
 /** Options for pushBundle. */


### PR DESCRIPTION
## What shipped (Finding 2 — atomic pull-restore)

`restoreSnapshot` (`src/lib/secrets/sync.ts`) previously wrote each keychain item one at a time and wrote bundle metadata **last**:

```ts
for (const [shortId, value] of Object.entries(snap.secrets)) {
  setKeychainToken(secretsKeychainItem(bundle.name, shortId), value);
}
writeBundle(bundle);
```

If any `setKeychainToken` threw midway, the keychain was left with a half-applied set — some items carrying the pulled values, others the stale ones — and the metadata write often never happened. The result: orphaned / wrong but still-readable secret items after a failed `agents secrets pull`.

This makes the restore **atomic**:

1. Before writing, snapshot the **prior value and existence** of every item the restore will touch (via the existing `hasKeychainToken` / `getKeychainToken` path).
2. Apply all `setKeychainToken` writes. On **any** failure, roll back — restore each previously-existing item to its prior value, delete items that did not exist before — then rethrow with a clear message, leaving the keychain exactly as it was pre-restore.
3. Commit metadata (`writeBundle`) **only after every secret write succeeds**. If that final write fails, the secret writes are rolled back too.

Either the whole pull lands, or the keychain is untouched. Minimal, at the source — reuses the existing `deleteKeychainToken` / `getKeychainToken` / `hasKeychainToken` / `setKeychainToken` helpers, no new fallback paths.

## Test

New colocated `src/lib/secrets/sync.test.ts` drives the real `restoreSnapshot` through the public `pullBundle` path, with an in-memory `KeychainBackend` (the existing `setKeychainBackendForTest` storage seam) that throws on a chosen item's write:

- **Rollback:** a pre-existing item is overwritten and a brand-new item is created before the Nth write fails — asserts pre-existing items retain their **original** values, the freshly-created item is deleted (no lingering partial), and metadata is untouched.
- **Commit:** a fully-successful restore writes all pulled values and persists the bundle metadata.

Verified the rollback test **fails against the pre-change code** (the raw injected error escapes, `AKEY` stays `new-a`, `CKEY` lingers) and passes with the fix. Full secrets suite green (227 passed) locally.

## Deferred — Finding 1 (keychain-list metadata HMAC) is OUT OF SCOPE here

Finding 1 (hardening the keychain-list metadata with an HMAC) requires a **Swift keychain-helper change**, a **re-key migration**, and a design decision on the keying scheme — it can't ride this pure-TypeScript PR. Left explicitly for a follow-up; **the issue stays open** for it.

Part of #316.