### PR TITLE
feat(routines): event/webhook trigger model (Closes #331)

### DIFF
--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -15,6 +15,8 @@ import { insertTask, updateTaskStatus, getTaskById, listTasks as listStoredTasks
 import { renderStream } from '../lib/cloud/stream.js';
 import type { CloudProvider, CloudProviderId, CloudTarget, CloudTaskStatus, DispatchOptions, ImageAttachment, SkillRef } from '../lib/cloud/types.js';
 import { MissingTargetError, MAX_IMAGES_PER_DISPATCH } from '../lib/cloud/types.js';
+import type { JobConfig, JobTrigger } from '../lib/routines.js';
+import { normalizeTriggerEvent, validateTrigger, writeJob, jobExists, GITHUB_TRIGGER_EVENTS } from '../lib/routines.js';
 
 /** Map a supported image file extension to its wire mimeType. Rejects anything else. */
 function imageMimeFromPath(file: string): ImageAttachment['mimeType'] {
@@ -193,6 +195,11 @@ Examples:
       },
     )
     .option('--branch <name>', 'Target git branch')
+    .option(
+      '--on <event>',
+      'Register this run as an event trigger instead of dispatching now: pull_request (pr), push, issue_comment, workflow_run. Persists a trigger-bound routine.',
+    )
+    .option('--name <name>', 'Routine name to register under (with --on). Defaults to a generated name.')
     .option('-p, --prompt <text>', 'Inline prompt (alternative to positional argument)')
     .option('--timeout <duration>', 'Kill after duration (e.g., 30m, 2h)')
     .option('--model <model>', 'Model override')
@@ -298,6 +305,55 @@ Examples:
         dispatchOptions.providerOptions!.strategy = 'balanced';
       }
       if (options.uploadAccountTokens) dispatchOptions.providerOptions!.uploadAccountTokens = true;
+
+      // --on <event>: register this run as an event trigger instead of
+      // dispatching now. We parse + validate the event, attach it to
+      // dispatchOptions.trigger, and persist a trigger-bound routine so the
+      // local webhook receiver can fire it (src/lib/triggers/webhook.ts).
+      // Remote firing of the trigger is a follow-up.
+      if (options.on) {
+        const event = normalizeTriggerEvent(options.on as string);
+        if (!event) {
+          die(`Unknown --on event "${options.on}". Use one of: ${GITHUB_TRIGGER_EVENTS.join(', ')} (aliases: pr, comment, workflow).`);
+        }
+        const trigger: JobTrigger = { type: 'github_event', event: event! };
+        if (repoValues[0]) trigger.repo = repoValues[0];
+        if (options.branch) trigger.branch = options.branch as string;
+
+        const triggerErrors = validateTrigger(trigger);
+        if (triggerErrors.length > 0) die(`Invalid trigger: ${triggerErrors.join(', ')}`);
+
+        dispatchOptions.trigger = trigger;
+
+        const routineName = (options.name as string | undefined)
+          || `cloud-${event}-${(repoValues[0] || 'any').replace(/[^a-z0-9]+/gi, '-')}`.toLowerCase();
+        if (jobExists(routineName)) {
+          die(`A routine named "${routineName}" already exists. Pass --name to register under a different name.`);
+        }
+
+        const routine: JobConfig = {
+          name: routineName,
+          trigger,
+          agent: (options.agent as string as JobConfig['agent']) || 'claude',
+          mode: 'plan',
+          effort: 'auto',
+          timeout: (options.timeout as string) || '10m',
+          enabled: true,
+          prompt,
+        };
+        if (repoValues[0]) routine.repo = repoValues[0];
+        writeJob(routine);
+
+        if (json) {
+          console.log(JSON.stringify({ ok: true, registered: routineName, trigger }, null, 2));
+        } else {
+          console.log(chalk.green(`Registered trigger routine "${routineName}"`));
+          console.log(`  ${chalk.dim('on:')}    ${event}${trigger.repo ? ` (${trigger.repo}${trigger.branch ? `@${trigger.branch}` : ''})` : ''}`);
+          console.log(`  ${chalk.dim('agent:')} ${routine.agent}`);
+          console.log(chalk.dim(`\nFires when a matching GitHub webhook is delivered to the local receiver. Remote firing is a follow-up.`));
+        }
+        return;
+      }
 
       // Vision attachments + ride-along skills. Only wire them when the resolved
       // provider advertises support — otherwise fail loud rather than silently

--- a/src/commands/routines-webhook.test.ts
+++ b/src/commands/routines-webhook.test.ts
@@ -1,0 +1,129 @@
+/**
+ * End-to-end tests for `agents routines webhook`.
+ *
+ * The webhook receiver logic (`matchJobsToWebhook` / `fireWebhookJobs` in
+ * `../lib/triggers/webhook.ts`) is unit-tested in isolation, but until this
+ * command existed nothing CALLED it — a `--on-registered` (trigger) routine had
+ * no reachable local entrypoint. These tests drive the REAL CLI as a subprocess
+ * against an isolated HOME, so they exercise the full path a user hits:
+ *
+ *   payload (--file) -> listJobs() (real disk read) -> matchJobsToWebhook
+ *     -> executeJobDetached (the same dispatch cron uses)
+ *
+ * Nothing here is mocked: the matcher, the job loader, and the dispatch path all
+ * run for real. Before the `webhook` subcommand is registered these fail with
+ * commander's "unknown command" (non-zero exit, no run dirs created).
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+// src/commands/ -> repo root is two levels up.
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/** A realistic GitHub `pull_request` delivery body for repo owner/name @ base. */
+function pullRequestPayload(fullName: string, baseRef = 'main'): Record<string, unknown> {
+  return {
+    action: 'opened',
+    repository: { full_name: fullName },
+    pull_request: { base: { ref: baseRef }, head: { ref: 'feature' } },
+  };
+}
+
+/** Provision an isolated ~/.agents HOME with the given routine YAMLs on disk. */
+function makeHome(jobs: Record<string, unknown>[]): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-webhook-home-'));
+  const routinesDir = path.join(home, '.agents', 'routines');
+  fs.mkdirSync(routinesDir, { recursive: true });
+  // A populated config marks this a non-first-run home so the interactive setup
+  // path can never trigger (spawnSync is non-TTY anyway).
+  fs.writeFileSync(path.join(home, '.agents', 'agents.yaml'), 'agents: {}\n');
+  // ensureInitialized() gates every non-setup command on the system repo being a
+  // git checkout (isGitRepo → ~/.agents/.system/.git exists). Seed it so the
+  // command runs instead of erroring "agents-cli is not set up".
+  fs.mkdirSync(path.join(home, '.agents', '.system', '.git'), { recursive: true });
+  for (const job of jobs) {
+    const yamlLines = Object.entries(job).map(([k, v]) =>
+      typeof v === 'object' ? `${k}: ${JSON.stringify(v)}` : `${k}: ${JSON.stringify(v)}`,
+    );
+    fs.writeFileSync(path.join(routinesDir, `${job.name}.yml`), yamlLines.join('\n') + '\n');
+  }
+  return home;
+}
+
+/** Run the real CLI (`agents routines webhook ...`) against an isolated HOME. */
+function runWebhook(home: string, args: string[]): ReturnType<typeof spawnSync> {
+  return spawnSync('node', ['--import', 'tsx', 'src/index.ts', 'routines', 'webhook', ...args], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, HOME: home, USERPROFILE: home, AGENTS_SKIP_MIGRATION: '1' },
+    encoding: 'utf-8',
+  });
+}
+
+const matchingJob = {
+  name: 'pr-job',
+  agent: 'claude',
+  mode: 'plan',
+  prompt: 'review the PR',
+  sandbox: false, // keep the detached dispatch a plain spawn (no overlay-home setup)
+  trigger: { type: 'github_event', event: 'pull_request', repo: 'octo/repo' },
+};
+
+// A schedule-only routine: it has no trigger, so no webhook must ever fire it.
+const nonMatchingJob = {
+  name: 'nightly',
+  agent: 'claude',
+  mode: 'plan',
+  prompt: 'nightly digest',
+  schedule: '0 3 * * *',
+};
+
+describe('agents routines webhook', () => {
+  it('dry-run selects the matching trigger routine and leaves the schedule-only one out', () => {
+    const home = makeHome([matchingJob, nonMatchingJob]);
+    try {
+      const payloadPath = path.join(home, 'pr.json');
+      fs.writeFileSync(payloadPath, JSON.stringify(pullRequestPayload('octo/repo')));
+
+      const res = runWebhook(home, ['--event', 'pull_request', '--file', payloadPath, '--dry-run']);
+
+      expect(res.status).toBe(0);
+      expect(res.stdout).toContain('pr-job');
+      expect(res.stdout).not.toContain('nightly');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('fires the matching routine through the cron dispatch path and not the non-matching one', () => {
+    const home = makeHome([matchingJob, nonMatchingJob]);
+    try {
+      // Pre-seed a live daemon pid (this test process) so the command sees the
+      // scheduler as already running and does NOT spawn a real daemon.
+      const daemonDir = path.join(home, '.agents', '.cache', 'helpers', 'daemon');
+      fs.mkdirSync(daemonDir, { recursive: true });
+      fs.writeFileSync(path.join(daemonDir, 'daemon.pid'), String(process.pid));
+
+      const payloadPath = path.join(home, 'pr.json');
+      fs.writeFileSync(payloadPath, JSON.stringify(pullRequestPayload('octo/repo')));
+
+      // No --dry-run: fireWebhookJobs -> executeJobDetached actually runs.
+      // executeJobDetached writes the run's meta.json synchronously, then spawns
+      // the (absent-in-test) agent binary detached — so exit code is irrelevant;
+      // the run directory is the observable proof the routine was dispatched.
+      runWebhook(home, ['--event', 'pull_request', '--file', payloadPath]);
+
+      const runsDir = path.join(home, '.agents', '.history', 'runs');
+      const firedMatching = fs.existsSync(path.join(runsDir, 'pr-job'));
+      const firedNonMatching = fs.existsSync(path.join(runsDir, 'nightly'));
+
+      expect(firedMatching).toBe(true);
+      expect(firedNonMatching).toBe(false);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/commands/routines.ts
+++ b/src/commands/routines.ts
@@ -36,6 +36,7 @@ import {
   parseAtTime,
 } from '../lib/routines.js';
 import type { JobConfig } from '../lib/routines.js';
+import { fireWebhookJobs, matchJobsToWebhook, type GithubWebhook } from '../lib/triggers/webhook.js';
 import { getRoutinesDir } from '../lib/state.js';
 import { IS_WINDOWS } from '../lib/platform/index.js';
 import { safeJoin } from '../lib/paths.js';
@@ -665,6 +666,86 @@ export function registerRoutinesCommands(program: Command): void {
         } catch (err) {
           console.log(`  ${job.name} → ${chalk.red('failed to start')}: ${(err as Error).message}`);
         }
+      }
+      console.log(chalk.gray('\nTrack progress with: agents routines runs <name>'));
+    });
+
+  routinesCmd
+    .command('webhook')
+    .description('Fire trigger-based routines from a single GitHub webhook payload (read from --file or stdin). One-shot: matches and fires, then exits. For a long-running receiver, run this behind your own HTTP forwarder.')
+    .requiredOption('--event <name>', 'GitHub event name, as sent in the X-GitHub-Event header (e.g. pull_request, push, workflow_run)')
+    .option('--file <path>', 'Read the webhook JSON payload from this file instead of stdin')
+    .option('--dry-run', 'Show which routines would fire without firing them')
+    .action(async (options: { event: string; file?: string; dryRun?: boolean }) => {
+      // Load the raw JSON payload: --file wins, else drain stdin.
+      let raw: string;
+      if (options.file) {
+        const resolved = path.resolve(options.file);
+        if (!fs.existsSync(resolved)) {
+          console.log(chalk.red(`File not found: ${resolved}`));
+          process.exit(1);
+        }
+        raw = fs.readFileSync(resolved, 'utf-8');
+      } else {
+        if (process.stdin.isTTY) {
+          console.log(chalk.red('No payload provided. Pass --file <path> or pipe the webhook JSON on stdin.'));
+          process.exit(1);
+        }
+        const chunks: Buffer[] = [];
+        for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+        raw = Buffer.concat(chunks).toString('utf-8');
+      }
+
+      let payload: Record<string, unknown>;
+      try {
+        const parsed = raw.trim() ? JSON.parse(raw) : {};
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          throw new Error('payload must be a JSON object');
+        }
+        payload = parsed as Record<string, unknown>;
+      } catch (err) {
+        console.log(chalk.red(`Invalid webhook payload JSON: ${(err as Error).message}`));
+        process.exit(1);
+      }
+
+      const webhook: GithubWebhook = { event: options.event, payload };
+
+      // Matching is intentionally user-layer only (fireWebhookJobs defaults to
+      // listJobs() with no cwd), mirroring `run`/`catchup`: a webhook must never
+      // fire a cloned project repo's `.agents/routines/*.yml` and run an
+      // attacker-supplied prompt under the user's agent session.
+      if (options.dryRun) {
+        const matched = matchJobsToWebhook(listAllJobs(), webhook);
+        if (matched.length === 0) {
+          console.log(chalk.gray(`No routines match a ${options.event} event for this payload.`));
+          return;
+        }
+        console.log(chalk.bold(`${matched.length} routine(s) would fire on ${options.event}:\n`));
+        for (const job of matched) {
+          console.log(`  ${chalk.cyan(job.name)} — ${fireConditionLabel(job)}`);
+        }
+        console.log(chalk.gray('\n(dry run — no routines triggered)'));
+        return;
+      }
+
+      // Fired jobs run detached via executeJobDetached (the same path cron
+      // uses). Keep the daemon alive so each run's meta.json is finalized.
+      if (!isDaemonRunning()) {
+        const started = startDaemon();
+        if (started.pid) {
+          console.log(chalk.gray(`Started scheduler (PID: ${started.pid}) so webhook runs are monitored.`));
+        }
+      }
+
+      const fired = await fireWebhookJobs(webhook);
+      if (fired.length === 0) {
+        console.log(chalk.gray(`No routines match a ${options.event} event for this payload.`));
+        return;
+      }
+
+      console.log(chalk.bold(`Fired ${fired.length} routine(s) on ${options.event}:\n`));
+      for (const f of fired) {
+        console.log(`  ${chalk.cyan(f.jobName)} → ${chalk.green('started')} (run: ${f.runId})`);
       }
       console.log(chalk.gray('\nTrack progress with: agents routines runs <name>'));
     });

--- a/src/commands/routines.ts
+++ b/src/commands/routines.ts
@@ -45,6 +45,21 @@ import { detectOverdueJobs } from '../lib/overdue.js';
 import { isInteractiveTerminal, requireInteractiveSelection } from './utils.js';
 import { setHelpSections } from '../lib/help.js';
 
+/**
+ * Human label for what fires a job: its cron schedule, or its event trigger
+ * for schedule-less (trigger-only) routines.
+ */
+function fireConditionLabel(job: JobConfig): string {
+  if (job.schedule) return humanizeCron(job.schedule, job.timezone);
+  if (job.trigger) {
+    const scope = job.trigger.repo
+      ? ` (${job.trigger.repo}${job.trigger.branch ? `@${job.trigger.branch}` : ''})`
+      : '';
+    return `on ${job.trigger.event}${scope}`;
+  }
+  return '-';
+}
+
 /** Start or reload the background scheduler so newly-added jobs fire on time. */
 function ensureSchedulerRunning(): void {
   if (isDaemonRunning()) {
@@ -108,7 +123,7 @@ async function pickJob(
       message,
       choices: jobs.map((job) => ({
         value: job.name,
-        name: `${job.name} ${chalk.gray(`(${job.workflow ? `wf:${job.workflow}` : job.agent}, ${job.schedule})`)}`,
+        name: `${job.name} ${chalk.gray(`(${job.workflow ? `wf:${job.workflow}` : job.agent}, ${job.schedule ?? fireConditionLabel(job)})`)}`,
       })),
     });
   } catch (err) {
@@ -197,8 +212,9 @@ export function registerRoutinesCommands(program: Command): void {
             agent: job.agent ?? null,
             workflow: job.workflow ?? null,
             repo: job.repo ?? null,
-            schedule: job.schedule,
-            scheduleHuman: humanizeCron(job.schedule, job.timezone),
+            schedule: job.schedule ?? null,
+            scheduleHuman: fireConditionLabel(job),
+            trigger: job.trigger ?? null,
             timezone: job.timezone ?? null,
             enabled: job.enabled,
             overdue: overdueSet.has(job.name),
@@ -239,7 +255,7 @@ export function registerRoutinesCommands(program: Command): void {
       for (const job of jobs) {
         const nextRun = scheduler.getNextRun(job.name);
         const nextStr = humanizeNextRun(nextRun ?? null, now, job.timezone);
-        let schedStr = humanizeCron(job.schedule, job.timezone);
+        let schedStr = fireConditionLabel(job);
         if (job.endAt) {
           const end = new Date(job.endAt);
           const endLabel = Number.isFinite(end.getTime())

--- a/src/lib/cloud/types.ts
+++ b/src/lib/cloud/types.ts
@@ -6,6 +6,8 @@
  * the dispatch pipeline.
  */
 
+import type { JobTrigger } from '../routines.js';
+
 /**
  * Identifier for a supported cloud dispatch backend.
  *
@@ -101,6 +103,14 @@ export const MAX_IMAGES_PER_DISPATCH = 5;
 export interface DispatchOptions {
   prompt: string;
   agent?: string;
+  /**
+   * Event/webhook trigger to register with this dispatch. Set by
+   * `agents cloud run --on <event>`: instead of dispatching immediately, the
+   * dispatch is persisted as a trigger-bound routine so the local webhook
+   * receiver can fire it when the event arrives. Remote firing of the trigger
+   * is a follow-up; today the flag parses, validates, and persists.
+   */
+  trigger?: JobTrigger;
   /**
    * Legacy single-repo target. Still honored: if `repos` is empty, this
    * becomes the only repo. Providers that support multi-repo treat

--- a/src/lib/overdue.ts
+++ b/src/lib/overdue.ts
@@ -55,6 +55,8 @@ export function detectOverdueJobs(now: Date = new Date()): OverdueJob[] {
 
   for (const job of listJobs()) {
     if (!job.enabled || job.runOnce) continue;
+    // Trigger-only jobs (no cron schedule) never have an expected fire time.
+    if (!job.schedule) continue;
 
     let expected: Date | null = null;
     try {

--- a/src/lib/routines.test.ts
+++ b/src/lib/routines.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { validateJob, validateTrigger, normalizeTriggerEvent, type JobConfig } from './routines.js';
+
+/** Minimal valid schedule-based job. */
+function baseJob(partial: Partial<JobConfig> = {}): Partial<JobConfig> {
+  return {
+    name: 'j',
+    agent: 'claude',
+    prompt: 'do it',
+    ...partial,
+  };
+}
+
+describe('validateJob — schedule OR trigger', () => {
+  it('accepts a schedule-only job (existing cron behavior unchanged)', () => {
+    expect(validateJob(baseJob({ schedule: '0 3 * * *' }))).toEqual([]);
+  });
+
+  it('accepts a trigger-only job (no schedule)', () => {
+    const errors = validateJob(baseJob({ trigger: { type: 'github_event', event: 'pull_request', repo: 'x/y' } }));
+    expect(errors).toEqual([]);
+  });
+
+  it('accepts a job with both schedule and trigger', () => {
+    const errors = validateJob(baseJob({
+      schedule: '0 3 * * *',
+      trigger: { type: 'github_event', event: 'push' },
+    }));
+    expect(errors).toEqual([]);
+  });
+
+  it('rejects a job with neither schedule nor trigger', () => {
+    const errors = validateJob(baseJob({}));
+    expect(errors.some((e) => /schedule .* or trigger is required/.test(e))).toBe(true);
+  });
+
+  it('still rejects an invalid cron expression', () => {
+    const errors = validateJob(baseJob({ schedule: 'not a cron' }));
+    expect(errors.some((e) => /invalid cron expression/.test(e))).toBe(true);
+  });
+
+  it('surfaces trigger validation errors', () => {
+    const errors = validateJob(baseJob({ trigger: { type: 'github_event', event: 'nope' as never } }));
+    expect(errors.some((e) => /trigger\.event must be one of/.test(e))).toBe(true);
+  });
+});
+
+describe('validateTrigger', () => {
+  it('accepts a well-formed github_event trigger', () => {
+    expect(validateTrigger({ type: 'github_event', event: 'pull_request', repo: 'x/y', branch: 'main' })).toEqual([]);
+  });
+
+  it('rejects a bad type', () => {
+    expect(validateTrigger({ type: 'gitlab', event: 'pull_request' })).toContain("trigger.type must be 'github_event'");
+  });
+
+  it('rejects an unknown event', () => {
+    const errors = validateTrigger({ type: 'github_event', event: 'deploy' });
+    expect(errors.some((e) => /trigger\.event must be one of/.test(e))).toBe(true);
+  });
+
+  it('rejects a malformed repo', () => {
+    const errors = validateTrigger({ type: 'github_event', event: 'push', repo: 'not-a-repo' });
+    expect(errors).toContain('trigger.repo must be in owner/name form');
+  });
+});
+
+describe('normalizeTriggerEvent', () => {
+  it('maps canonical names and aliases', () => {
+    expect(normalizeTriggerEvent('pull_request')).toBe('pull_request');
+    expect(normalizeTriggerEvent('pr')).toBe('pull_request');
+    expect(normalizeTriggerEvent('pr_opened')).toBe('pull_request');
+    expect(normalizeTriggerEvent('PUSH')).toBe('push');
+    expect(normalizeTriggerEvent('comment')).toBe('issue_comment');
+    expect(normalizeTriggerEvent('workflow')).toBe('workflow_run');
+  });
+
+  it('returns null for unknown events', () => {
+    expect(normalizeTriggerEvent('deploy')).toBeNull();
+  });
+});

--- a/src/lib/routines.ts
+++ b/src/lib/routines.ts
@@ -24,10 +24,66 @@ export interface JobAllowConfig {
   dirs?: string[];
 }
 
-/** Full configuration for a scheduled routine (persisted as YAML). */
+/** GitHub webhook events a routine can be triggered by. */
+export type GithubTriggerEvent = 'pull_request' | 'push' | 'issue_comment' | 'workflow_run';
+
+/** Canonical set of accepted GitHub trigger events — single source for validation. */
+export const GITHUB_TRIGGER_EVENTS: readonly GithubTriggerEvent[] = [
+  'pull_request',
+  'push',
+  'issue_comment',
+  'workflow_run',
+];
+
+/**
+ * Map a user-facing `--on` alias to a canonical GitHub trigger event.
+ * Accepts the canonical names plus friendly shortcuts (e.g. `pr`, `pr_opened`
+ * → `pull_request`, `comment` → `issue_comment`). Returns null when unknown.
+ */
+export function normalizeTriggerEvent(input: string): GithubTriggerEvent | null {
+  const key = input.trim().toLowerCase();
+  const aliases: Record<string, GithubTriggerEvent> = {
+    pull_request: 'pull_request',
+    pr: 'pull_request',
+    pr_opened: 'pull_request',
+    pull: 'pull_request',
+    push: 'push',
+    issue_comment: 'issue_comment',
+    comment: 'issue_comment',
+    workflow_run: 'workflow_run',
+    workflow: 'workflow_run',
+  };
+  return aliases[key] ?? null;
+}
+
+/**
+ * Event-based fire condition for a routine — an alternative (or complement) to
+ * `schedule`. Currently only `github_event`: an incoming GitHub webhook whose
+ * event (and optional repo/branch) match fires the job through the same
+ * dispatch path a cron fire uses. See `src/lib/triggers/webhook.ts`.
+ */
+export interface JobTrigger {
+  type: 'github_event';
+  event: GithubTriggerEvent;
+  /** `owner/name` — when set, only payloads for this repo match. */
+  repo?: string;
+  /** git branch (ref short name) — when set, only payloads for this branch match. */
+  branch?: string;
+}
+
+/**
+ * Full configuration for a routine (persisted as YAML).
+ *
+ * A job fires on a `schedule` (cron), on a `trigger` (event/webhook), or both.
+ * `schedule` remains a first-class field; trigger-only jobs omit it and are
+ * skipped by the cron scheduler (they fire only via the webhook receiver).
+ */
 export interface JobConfig {
   name: string;
-  schedule: string;
+  /** Cron expression. Optional when `trigger` is set (event-only routine). */
+  schedule?: string;
+  /** Event/webhook fire condition. Optional when `schedule` is set. */
+  trigger?: JobTrigger;
   agent: AgentId;  // required when workflow is absent
   workflow?: string;
   // 'full' is accepted as a permanent silent alias for 'skip' (see normalizeMode).
@@ -188,15 +244,25 @@ export function validateJob(config: Partial<JobConfig>): string[] {
   if (!config.name || typeof config.name !== 'string') {
     errors.push('name is required');
   }
-  if (!config.schedule || typeof config.schedule !== 'string') {
-    errors.push('schedule (cron expression) is required');
-  } else {
-    // Validate cron expression is parseable
-    try {
-      new Cron(config.schedule);
-    } catch {
-      errors.push(`invalid cron expression: "${config.schedule}"`);
+  const hasSchedule = Boolean(config.schedule && typeof config.schedule === 'string');
+  const hasTrigger = config.trigger !== undefined;
+  if (!hasSchedule && !hasTrigger) {
+    errors.push('schedule (cron expression) or trigger is required');
+  }
+  if (config.schedule !== undefined) {
+    if (typeof config.schedule !== 'string') {
+      errors.push('schedule must be a cron expression string');
+    } else {
+      // Validate cron expression is parseable
+      try {
+        new Cron(config.schedule);
+      } catch {
+        errors.push(`invalid cron expression: "${config.schedule}"`);
+      }
     }
+  }
+  if (config.trigger !== undefined) {
+    errors.push(...validateTrigger(config.trigger));
   }
   const hasAgent = Boolean(config.agent && typeof config.agent === 'string');
   const hasWorkflow = Boolean(config.workflow && typeof config.workflow === 'string');
@@ -231,6 +297,28 @@ export function validateJob(config: Partial<JobConfig>): string[] {
     }
   }
 
+  return errors;
+}
+
+/** Validate a job trigger block, returning a list of human-readable errors. */
+export function validateTrigger(trigger: unknown): string[] {
+  const errors: string[] = [];
+  if (!trigger || typeof trigger !== 'object') {
+    return ['trigger must be an object'];
+  }
+  const t = trigger as Partial<JobTrigger>;
+  if (t.type !== 'github_event') {
+    errors.push("trigger.type must be 'github_event'");
+  }
+  if (!t.event || !GITHUB_TRIGGER_EVENTS.includes(t.event as GithubTriggerEvent)) {
+    errors.push(`trigger.event must be one of: ${GITHUB_TRIGGER_EVENTS.join(', ')}`);
+  }
+  if (t.repo !== undefined && (typeof t.repo !== 'string' || !/^[^/\s]+\/[^/\s]+$/.test(t.repo))) {
+    errors.push('trigger.repo must be in owner/name form');
+  }
+  if (t.branch !== undefined && typeof t.branch !== 'string') {
+    errors.push('trigger.branch must be a string');
+  }
   return errors;
 }
 

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -28,13 +28,17 @@ export class JobScheduler {
   loadAll(): void {
     const configs = listJobs();
     for (const config of configs) {
-      if (config.enabled) {
+      // Trigger-only jobs (no cron schedule) fire via the webhook receiver,
+      // not the cron loop — skip them here.
+      if (config.enabled && config.schedule) {
         this.schedule(config);
       }
     }
   }
 
   schedule(config: JobConfig): void {
+    // A schedule-less (trigger-only) job has nothing to hand to croner.
+    if (!config.schedule) return;
     this.unschedule(config.name);
 
     // catch: true — a throw from one job's callback should not kill the

--- a/src/lib/triggers/webhook.test.ts
+++ b/src/lib/triggers/webhook.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import type { JobConfig, RunMeta } from '../routines.js';
+import {
+  matchJobsToWebhook,
+  jobMatchesWebhook,
+  webhookRepo,
+  webhookBranches,
+  fireWebhookJobs,
+  type GithubWebhook,
+} from './webhook.js';
+
+/** Build a JobConfig with sensible defaults for tests. */
+function job(partial: Partial<JobConfig> & Pick<JobConfig, 'name'>): JobConfig {
+  return {
+    agent: 'claude',
+    mode: 'plan',
+    effort: 'auto',
+    timeout: '10m',
+    enabled: true,
+    prompt: 'do the thing',
+    ...partial,
+  } as JobConfig;
+}
+
+/** A realistic `pull_request` webhook for repo x/y targeting branch main. */
+function pullRequestWebhook(repoFullName: string, baseRef = 'main', headRef = 'feature'): GithubWebhook {
+  return {
+    event: 'pull_request',
+    payload: {
+      action: 'opened',
+      repository: { full_name: repoFullName },
+      pull_request: { base: { ref: baseRef }, head: { ref: headRef } },
+    },
+  };
+}
+
+/** A `push` webhook for repo x/y on branch main. */
+function pushWebhook(repoFullName: string, ref = 'refs/heads/main'): GithubWebhook {
+  return {
+    event: 'push',
+    payload: { repository: { full_name: repoFullName }, ref },
+  };
+}
+
+describe('matchJobsToWebhook', () => {
+  const prJob = job({
+    name: 'pr-job',
+    trigger: { type: 'github_event', event: 'pull_request', repo: 'x/y' },
+  });
+
+  it('selects a job whose trigger matches the pull_request event + repo', () => {
+    const matched = matchJobsToWebhook([prJob], pullRequestWebhook('x/y'));
+    expect(matched.map((j) => j.name)).toEqual(['pr-job']);
+  });
+
+  it('does NOT match a push payload against a pull_request trigger', () => {
+    const matched = matchJobsToWebhook([prJob], pushWebhook('x/y'));
+    expect(matched).toEqual([]);
+  });
+
+  it('does NOT match a pull_request payload for a different repo', () => {
+    const matched = matchJobsToWebhook([prJob], pullRequestWebhook('a/b'));
+    expect(matched).toEqual([]);
+  });
+
+  it('leaves a time-based (schedule-only) job unaffected by any webhook', () => {
+    const cronJob = job({ name: 'nightly', schedule: '0 3 * * *' });
+    // A schedule-only job has no trigger, so it is never selected — not by the
+    // matching event, not by a mismatching one.
+    expect(matchJobsToWebhook([cronJob], pullRequestWebhook('x/y'))).toEqual([]);
+    expect(matchJobsToWebhook([cronJob], pushWebhook('x/y'))).toEqual([]);
+  });
+
+  it('matches a repo-agnostic trigger (no repo filter) against any repo', () => {
+    const anyRepo = job({ name: 'any', trigger: { type: 'github_event', event: 'pull_request' } });
+    expect(matchJobsToWebhook([anyRepo], pullRequestWebhook('who/ever')).map((j) => j.name)).toEqual(['any']);
+  });
+
+  it('honors a branch filter (base or head ref)', () => {
+    const mainOnly = job({
+      name: 'main-only',
+      trigger: { type: 'github_event', event: 'pull_request', repo: 'x/y', branch: 'main' },
+    });
+    expect(jobMatchesWebhook(mainOnly, pullRequestWebhook('x/y', 'main', 'topic'))).toBe(true);
+    // base=develop head=topic → neither is main
+    expect(jobMatchesWebhook(mainOnly, pullRequestWebhook('x/y', 'develop', 'topic'))).toBe(false);
+  });
+
+  it('honors a branch filter for push (refs/heads/<b>)', () => {
+    const mainOnly = job({
+      name: 'push-main',
+      trigger: { type: 'github_event', event: 'push', repo: 'x/y', branch: 'main' },
+    });
+    expect(jobMatchesWebhook(mainOnly, pushWebhook('x/y', 'refs/heads/main'))).toBe(true);
+    expect(jobMatchesWebhook(mainOnly, pushWebhook('x/y', 'refs/heads/dev'))).toBe(false);
+  });
+
+  it('skips disabled jobs', () => {
+    const disabled = job({
+      name: 'off',
+      enabled: false,
+      trigger: { type: 'github_event', event: 'pull_request', repo: 'x/y' },
+    });
+    expect(matchJobsToWebhook([disabled], pullRequestWebhook('x/y'))).toEqual([]);
+  });
+});
+
+describe('payload extraction helpers', () => {
+  it('reads repository.full_name', () => {
+    expect(webhookRepo({ repository: { full_name: 'x/y' } })).toBe('x/y');
+    expect(webhookRepo({})).toBeNull();
+  });
+
+  it('extracts branches per event type', () => {
+    expect(webhookBranches('push', { ref: 'refs/heads/main' })).toEqual(['main']);
+    expect(
+      webhookBranches('pull_request', { pull_request: { base: { ref: 'main' }, head: { ref: 'feat' } } }).sort(),
+    ).toEqual(['feat', 'main']);
+    expect(webhookBranches('workflow_run', { workflow_run: { head_branch: 'release' } })).toEqual(['release']);
+    expect(webhookBranches('issue_comment', {})).toEqual([]);
+  });
+});
+
+describe('fireWebhookJobs', () => {
+  it('dispatches each matched job through the injected dispatch path, not schedule-only jobs', async () => {
+    const jobs: JobConfig[] = [
+      job({ name: 'pr-job', trigger: { type: 'github_event', event: 'pull_request', repo: 'x/y' } }),
+      job({ name: 'nightly', schedule: '0 3 * * *' }),
+    ];
+    const dispatched: string[] = [];
+    const dispatch = async (config: JobConfig): Promise<RunMeta> => {
+      dispatched.push(config.name);
+      return {
+        jobName: config.name,
+        runId: `run-${config.name}`,
+        agent: config.agent,
+        pid: 1234,
+        status: 'running',
+        startedAt: new Date().toISOString(),
+        completedAt: null,
+        exitCode: null,
+      };
+    };
+
+    const fired = await fireWebhookJobs(pullRequestWebhook('x/y'), { jobs, dispatch });
+
+    expect(dispatched).toEqual(['pr-job']);
+    expect(fired).toEqual([{ jobName: 'pr-job', runId: 'run-pr-job' }]);
+  });
+});

--- a/src/lib/triggers/webhook.ts
+++ b/src/lib/triggers/webhook.ts
@@ -1,0 +1,194 @@
+/**
+ * GitHub webhook trigger receiver for routines.
+ *
+ * A routine may declare a `trigger` block instead of (or alongside) a cron
+ * `schedule` (see `JobConfig.trigger` in `../routines.ts`). This module turns
+ * an incoming GitHub webhook into the set of routines it should fire, and
+ * dispatches those routines through the exact same path a cron fire uses
+ * (`executeJobDetached`).
+ *
+ * The matching logic (`matchJobsToWebhook`) is a pure, side-effect-free
+ * function so it can be unit-tested without a running daemon or http server.
+ * The optional http listener (`startWebhookServer`) is a thin adapter over it.
+ */
+
+import * as http from 'http';
+import type { JobConfig, RunMeta } from '../routines.js';
+import { listJobs } from '../routines.js';
+import { executeJobDetached } from '../runner.js';
+
+/**
+ * A parsed GitHub webhook: the event name (from the `X-GitHub-Event` HTTP
+ * header) plus the decoded JSON body. Kept deliberately loose (`payload` is an
+ * arbitrary object) because callers may hand us any of GitHub's event shapes.
+ */
+export interface GithubWebhook {
+  /** The GitHub event name, e.g. `pull_request`, `push`, `issue_comment`. */
+  event: string;
+  /** The decoded JSON request body. */
+  payload: Record<string, unknown>;
+}
+
+/** Read `repository.full_name` (`owner/name`) from a webhook payload, if present. */
+export function webhookRepo(payload: Record<string, unknown>): string | null {
+  const repo = payload?.repository as { full_name?: unknown } | undefined;
+  const fullName = repo?.full_name;
+  return typeof fullName === 'string' && fullName.length > 0 ? fullName : null;
+}
+
+/** Strip a `refs/heads/` (or `refs/tags/`) prefix to the short branch/tag name. */
+function shortRef(ref: string): string {
+  return ref.replace(/^refs\/(heads|tags)\//, '');
+}
+
+/**
+ * Extract every candidate branch a webhook payload references, per event type.
+ * A trigger's `branch` matches if it equals any of these. Different events
+ * carry the branch in different places:
+ *   - push:          `ref` (refs/heads/<b>)
+ *   - pull_request:  base + head refs of the PR
+ *   - workflow_run:  `workflow_run.head_branch`
+ *   - issue_comment: no branch (comments aren't branch-scoped)
+ */
+export function webhookBranches(event: string, payload: Record<string, unknown>): string[] {
+  const branches = new Set<string>();
+  const add = (v: unknown) => {
+    if (typeof v === 'string' && v.length > 0) branches.add(shortRef(v));
+  };
+
+  switch (event) {
+    case 'push':
+      add(payload.ref);
+      break;
+    case 'pull_request': {
+      const pr = payload.pull_request as { base?: { ref?: unknown }; head?: { ref?: unknown } } | undefined;
+      add(pr?.base?.ref);
+      add(pr?.head?.ref);
+      break;
+    }
+    case 'workflow_run': {
+      const run = payload.workflow_run as { head_branch?: unknown } | undefined;
+      add(run?.head_branch);
+      break;
+    }
+    default:
+      break;
+  }
+  return [...branches];
+}
+
+/** True when a single job's trigger matches the given webhook. Pure. */
+export function jobMatchesWebhook(job: JobConfig, webhook: GithubWebhook): boolean {
+  const trigger = job.trigger;
+  if (!trigger || trigger.type !== 'github_event') return false;
+  if (trigger.event !== webhook.event) return false;
+
+  if (trigger.repo) {
+    const repo = webhookRepo(webhook.payload);
+    if (!repo || repo.toLowerCase() !== trigger.repo.toLowerCase()) return false;
+  }
+
+  if (trigger.branch) {
+    const branches = webhookBranches(webhook.event, webhook.payload);
+    if (!branches.some((b) => b === trigger.branch)) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Pure matcher: given a set of jobs and an incoming webhook, return the jobs
+ * whose `trigger` matches (event + optional repo + optional branch). Jobs
+ * without a trigger (schedule-only routines) are never selected — proving
+ * time-based jobs are unaffected by webhook delivery.
+ */
+export function matchJobsToWebhook(jobs: JobConfig[], webhook: GithubWebhook): JobConfig[] {
+  return jobs.filter((job) => job.enabled !== false && jobMatchesWebhook(job, webhook));
+}
+
+/** Options for firing webhook-matched jobs (dispatch is injectable for tests). */
+export interface FireWebhookOptions {
+  /** Job source. Defaults to all persisted routines (`listJobs()`). */
+  jobs?: JobConfig[];
+  /**
+   * How to dispatch a matched job. Defaults to `executeJobDetached` — the SAME
+   * path a cron fire uses (see `daemon.ts`). Injectable so tests can assert
+   * matching without spawning real agent processes.
+   */
+  dispatch?: (config: JobConfig) => Promise<RunMeta>;
+}
+
+/** Result of firing one matched job. */
+export interface FiredJob {
+  jobName: string;
+  runId: string;
+}
+
+/**
+ * Match an incoming webhook against the persisted routines and fire each match
+ * through the cron dispatch path. Returns one entry per fired job.
+ */
+export async function fireWebhookJobs(
+  webhook: GithubWebhook,
+  options: FireWebhookOptions = {},
+): Promise<FiredJob[]> {
+  const jobs = options.jobs ?? listJobs();
+  const dispatch = options.dispatch ?? executeJobDetached;
+  const matched = matchJobsToWebhook(jobs, webhook);
+
+  const fired: FiredJob[] = [];
+  for (const job of matched) {
+    const meta = await dispatch(job);
+    fired.push({ jobName: job.name, runId: meta.runId });
+  }
+  return fired;
+}
+
+/** Options for the local webhook http listener. */
+export interface WebhookServerOptions {
+  port?: number;
+  host?: string;
+  /** Override the fire options (mainly for tests). */
+  fire?: FireWebhookOptions;
+  /** Called after each delivery is handled (mainly for tests/observability). */
+  onDelivery?: (event: string, fired: FiredJob[]) => void;
+}
+
+/**
+ * Start a minimal local webhook receiver. POSTs are read as JSON, the GitHub
+ * event is taken from the `X-GitHub-Event` header, and matching routines are
+ * fired via {@link fireWebhookJobs}. Returns the underlying server so callers
+ * can `close()` it. The heavy lifting is the pure matcher above; this is only
+ * the transport.
+ */
+export function startWebhookServer(options: WebhookServerOptions = {}): http.Server {
+  const server = http.createServer((req, res) => {
+    if (req.method !== 'POST') {
+      res.writeHead(405, { 'content-type': 'text/plain' });
+      res.end('method not allowed');
+      return;
+    }
+
+    const event = (req.headers['x-github-event'] as string | undefined) ?? '';
+    const chunks: Buffer[] = [];
+    req.on('data', (c) => chunks.push(c as Buffer));
+    req.on('end', () => {
+      void (async () => {
+        try {
+          const raw = Buffer.concat(chunks).toString('utf-8');
+          const payload = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+          const fired = await fireWebhookJobs({ event, payload }, options.fire);
+          options.onDelivery?.(event, fired);
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, fired: fired.map((f) => f.jobName) }));
+        } catch (err) {
+          res.writeHead(400, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ ok: false, error: (err as Error).message }));
+        }
+      })();
+    });
+  });
+
+  server.listen(options.port ?? 0, options.host ?? '127.0.0.1');
+  return server;
+}

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -87,7 +87,7 @@ describe('validateJob', () => {
 
   it('requires schedule', () => {
     const errors = validateJob({ name: 'test', agent: 'claude', prompt: 'hi' });
-    expect(errors).toContain('schedule (cron expression) is required');
+    expect(errors).toContain('schedule (cron expression) or trigger is required');
   });
 
   it('requires agent or workflow', () => {


### PR DESCRIPTION
## What shipped (first increment)

Routines can now fire on a **GitHub event (webhook)** as an alternative to — or alongside — a cron `schedule`. Reuses the existing JobConfig persistence and the cron dispatch path; no parallel scheduler was introduced.

**1. `trigger` block on `JobConfig`** (`src/lib/routines.ts`)
- New `JobTrigger` type: `{ type:'github_event'; event:'pull_request'|'push'|'issue_comment'|'workflow_run'; repo?; branch? }`.
- `schedule` is now optional; `schedule` and `trigger` are first-class siblings (a job may have either or both).
- `validateJob` requires **schedule OR trigger** and validates the trigger via new `validateTrigger`.
- Cron scheduler (`scheduler.ts`) and overdue detection (`overdue.ts`) **skip schedule-less (trigger-only) jobs**, so existing cron/`--at` jobs are untouched.

**2. `agents cloud run --on <event>`** (`src/commands/cloud.ts`, `src/lib/cloud/types.ts`)
- `DispatchOptions` gains an optional `trigger?` field.
- `--on pull_request|push|issue_comment|workflow_run` (aliases: `pr`, `pr_opened`, `comment`, `workflow`) **parses, validates, and persists** a trigger-bound routine via `writeJob` (with `--repo`/`--branch`/`--name`). It registers the trigger instead of dispatching immediately.

**3. Local webhook receiver** (`src/lib/triggers/webhook.ts`)
- `matchJobsToWebhook(jobs, webhook)` — a **pure, unit-testable** matcher selecting jobs whose `trigger` matches a parsed GitHub payload (event + optional repo + optional branch).
- `fireWebhookJobs` dispatches each match through **`executeJobDetached`** — the exact path a cron fire uses (`daemon.ts`).
- `startWebhookServer` — a thin http listener that reads `X-GitHub-Event` + JSON body and delegates to the matcher.

## Reuse anchors
- Dispatch path: `executeJobDetached` (`src/lib/runner.ts:303`), the same call the daemon's cron `onTrigger` makes (`src/lib/daemon.ts:175`).
- Persistence: `writeJob` / `readJobFile` / `validateJob` (`src/lib/routines.ts`) — `trigger` round-trips through the existing YAML path with no new store.

## Tests (colocated; fail pre-change)
- `src/lib/triggers/webhook.test.ts` — a `pull_request` payload for `x/y` selects a job with `trigger:{event:'pull_request',repo:'x/y'}`; a `push` payload or a different repo does **not** match; a **time-based (schedule-only) job is never selected** by any webhook; branch filters (base/head ref for PR, `refs/heads/*` for push); `fireWebhookJobs` dispatches only matched jobs via an injected dispatch.
- `src/lib/routines.test.ts` — schedule-only / trigger-only / both / neither validation; trigger shape validation; `--on` alias normalization.
- Full suite: **4075 passed**. The only failures (6, in `src/lib/session/sync/config.test.ts`) are **pre-existing and environmental** — they fail identically on untouched `origin/main` on this machine (a real `r2.backups` keychain bundle leaks into the in-memory backend test) and are unrelated to this diff, which touches no `session/sync` code. `bunx tsc --noEmit` is clean.

## Deferred (follow-up)
- **Actual remote firing** of `--on`-registered triggers from a hosted webhook endpoint (today it parses/validates/persists locally; the local receiver fires it).
- Webhook **signature verification** (`X-Hub-Signature-256`) and a managed public ingress.
- `agents routines add --on ...` surface + docs, and wiring `startWebhookServer` into the daemon lifecycle.
- Richer event filters (PR `action` = opened/synchronize, label filters).