### PR TITLE
feat(secrets): JIT credential delivery via MCP get_secret server (Closes #333)

### DIFF
--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -216,6 +216,20 @@ export function buildSecretsExecEnv(
   return env;
 }
 
+/**
+ * Resolve the CLI version for the MCP server's `serverInfo.version`. package.json
+ * sits at the repo root — two levels up from both `src/commands/` (bun/tsx dev)
+ * and `dist/commands/` (built). Cosmetic only, so any failure falls back cleanly.
+ */
+function getCliVersion(): string {
+  try {
+    const pkgPath = new URL('../../package.json', import.meta.url);
+    return JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
 /** POSIX single-quote a string for safe interpolation into a remote shell command. */
 function shellQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
@@ -575,7 +589,7 @@ export function registerSecretsCommands(program: Command): void {
     { title: 'Agent commands', names: ['start', 'stop', 'unlock', 'lock', 'status', 'policy'] },
     { title: 'Raw item commands', names: ['get', 'set'] },
     { title: 'Sync commands', names: ['push', 'pull', 'remote-list'] },
-    { title: 'Utilities', names: ['exec', 'generate', 'migrate-acl'] },
+    { title: 'Utilities', names: ['exec', 'mcp', 'generate', 'migrate-acl'] },
   ]);
 
   cmd
@@ -1466,6 +1480,18 @@ Examples:
         console.error(chalk.red((err as Error).message));
         process.exit(1);
       }
+    });
+
+  cmd
+    .command('mcp')
+    .description('Run a stdio MCP server exposing get_secret(bundle, key) — hand credentials to an MCP-speaking agent by name at call time, never through the child process environment')
+    .action(async () => {
+      // JIT credential delivery (#333): unlike `secrets exec`, which bakes every
+      // resolved value into the child's env, this speaks MCP over stdio so a
+      // framework requests one secret at a time and the raw value never enters
+      // process.env. stdout is the JSON-RPC channel — nothing else may print there.
+      const { runSecretsMcpServer } = await import('../lib/secrets/mcp.js');
+      await runSecretsMcpServer({ version: getCliVersion() });
     });
 
   cmd

--- a/src/lib/secrets/mcp.test.ts
+++ b/src/lib/secrets/mcp.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for the JIT credential MCP server (issue #333).
+ *
+ * Setup mirrors bundles-file-backend.test.ts: a REAL temp-dir AES-256-GCM file
+ * store (real crypto — the Linux libsecret backend's own headless / locked-
+ * collection fallback) keyed by AGENTS_SECRETS_PASSPHRASE, plus an in-memory
+ * keychain backend so the `listBundles` keychain branch never reaches the
+ * developer's real keyring. The code under test — the MCP request handler and
+ * `resolveSecret` — is NOT mocked; secrets flow through the genuine
+ * readBundle -> readAndResolveBundleEnv read path.
+ *
+ * The guarantees pinned here: get_secret returns the value; a missing key /
+ * missing bundle errors clearly; and `tools/list` advertises bundle + key NAMES
+ * but never a value.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { PassThrough } from 'stream';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  bundleItemStore,
+  keychainRef,
+  writeBundle,
+  type SecretsBundle,
+} from './bundles.js';
+import { _resetFileStoreForTest } from './filestore.js';
+import {
+  secretsKeychainItem,
+  setKeychainBackendForTest,
+  type KeychainBackend,
+} from './index.js';
+import {
+  GET_SECRET_TOOL,
+  MCP_PROTOCOL_VERSION,
+  handleMcpRequest,
+  listSecretMetadata,
+  resolveSecret,
+  runSecretsMcpServer,
+} from './mcp.js';
+
+function makeMemoryBackend(): { backend: KeychainBackend; store: Map<string, string> } {
+  const store = new Map<string, string>();
+  const backend: KeychainBackend = {
+    has: (item) => store.has(item),
+    get: (item) => {
+      const v = store.get(item);
+      if (v === undefined) throw new Error(`Keychain item '${item}' not found.`);
+      return v;
+    },
+    set: (item, value) => { store.set(item, value); },
+    delete: (item) => store.delete(item),
+    list: (prefix) => Array.from(store.keys()).filter((k) => k.startsWith(prefix)),
+  };
+  return { backend, store };
+}
+
+const PASS = 'per-run-passphrase';
+const SECRET_VALUE = 'resolved-jit-credential-value-abc';
+let restore: KeychainBackend | null = null;
+let tmpDir: string;
+let prevNoAgent: string | undefined;
+let prevNoTrack: string | undefined;
+
+/** Create a file-backed bundle with one keychain-style secret + one literal. */
+function createFileBundle(name: string, key: string, value: string): void {
+  const bundle: SecretsBundle = { name, backend: 'file', vars: {} };
+  bundleItemStore('file').set(secretsKeychainItem(name, key), value);
+  bundle.vars[key] = keychainRef(key);
+  bundle.vars.LOG_LEVEL = 'info'; // literal, non-sensitive
+  writeBundle(bundle);
+}
+
+beforeEach(() => {
+  const m = makeMemoryBackend();
+  restore = setKeychainBackendForTest(m.backend);
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-secrets-mcp-'));
+  // Keep resolution hermetic: no secrets-agent broker, no last_used writeback.
+  prevNoAgent = process.env.AGENTS_SECRETS_NO_AGENT;
+  prevNoTrack = process.env.AGENTS_NO_USAGE_TRACK;
+  process.env.AGENTS_SECRETS_NO_AGENT = '1';
+  process.env.AGENTS_NO_USAGE_TRACK = '1';
+  process.env.AGENTS_SECRETS_PASSPHRASE = PASS;
+  _resetFileStoreForTest({ fileDir: tmpDir, passphrase: PASS });
+  createFileBundle('prod', 'STRIPE_KEY', SECRET_VALUE);
+});
+
+afterEach(() => {
+  setKeychainBackendForTest(restore);
+  delete process.env.AGENTS_SECRETS_PASSPHRASE;
+  if (prevNoAgent === undefined) delete process.env.AGENTS_SECRETS_NO_AGENT;
+  else process.env.AGENTS_SECRETS_NO_AGENT = prevNoAgent;
+  if (prevNoTrack === undefined) delete process.env.AGENTS_NO_USAGE_TRACK;
+  else process.env.AGENTS_NO_USAGE_TRACK = prevNoTrack;
+  _resetFileStoreForTest();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('resolveSecret (real file store)', () => {
+  it('returns the value for an existing bundle + key', () => {
+    expect(resolveSecret('prod', 'STRIPE_KEY')).toBe(SECRET_VALUE);
+  });
+
+  it('resolves a literal value too', () => {
+    expect(resolveSecret('prod', 'LOG_LEVEL')).toBe('info');
+  });
+
+  it('throws a clear error for a missing key (listing the available keys)', () => {
+    expect(() => resolveSecret('prod', 'NOPE')).toThrow(/Key 'NOPE' not found in bundle 'prod'/);
+    expect(() => resolveSecret('prod', 'NOPE')).toThrow(/STRIPE_KEY/); // lists what IS there
+  });
+
+  it('throws for a missing bundle', () => {
+    expect(() => resolveSecret('ghost', 'STRIPE_KEY')).toThrow(/not found/i);
+  });
+});
+
+describe('tools/call get_secret', () => {
+  const call = (bundle: unknown, key: unknown) =>
+    handleMcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: GET_SECRET_TOOL, arguments: { bundle, key } },
+    });
+
+  it('returns the value in the tool result content', () => {
+    const res = call('prod', 'STRIPE_KEY') as any;
+    expect(res.result.isError).toBeUndefined();
+    expect(res.result.content).toEqual([{ type: 'text', text: SECRET_VALUE }]);
+  });
+
+  it('reports a missing key as an in-band tool error (isError), not a value', () => {
+    const res = call('prod', 'MISSING') as any;
+    expect(res.result.isError).toBe(true);
+    expect(res.result.content[0].text).toMatch(/Key 'MISSING' not found/);
+    expect(res.result.content[0].text).not.toContain(SECRET_VALUE);
+  });
+
+  it('reports a missing bundle as an in-band tool error', () => {
+    const res = call('ghost', 'STRIPE_KEY') as any;
+    expect(res.result.isError).toBe(true);
+    expect(res.result.content[0].text).toMatch(/not found/i);
+  });
+
+  it('validates that bundle and key are non-empty strings', () => {
+    const res = call('prod', '') as any;
+    expect(res.result.isError).toBe(true);
+    expect(res.result.content[0].text).toMatch(/requires non-empty string/);
+  });
+});
+
+describe('tools/list (names only, never values)', () => {
+  it('advertises the get_secret tool with bundle + key names but no value', () => {
+    const res = handleMcpRequest({ jsonrpc: '2.0', id: 2, method: 'tools/list' }) as any;
+    const tools = res.result.tools;
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe(GET_SECRET_TOOL);
+    expect(tools[0].inputSchema.required).toEqual(['bundle', 'key']);
+
+    // Names are advertised...
+    const serialized = JSON.stringify(res);
+    expect(serialized).toContain('prod');
+    expect(serialized).toContain('STRIPE_KEY');
+    // ...but the secret VALUE never appears anywhere in the listing.
+    expect(serialized).not.toContain(SECRET_VALUE);
+  });
+
+  it('listSecretMetadata surfaces key names but carries no value', () => {
+    const meta = listSecretMetadata();
+    const prod = meta.find((m) => m.bundle === 'prod');
+    expect(prod?.keys).toContain('STRIPE_KEY');
+    expect(JSON.stringify(meta)).not.toContain(SECRET_VALUE);
+  });
+});
+
+describe('protocol handshake', () => {
+  it('initialize negotiates the protocol version and reports serverInfo', () => {
+    const res = handleMcpRequest(
+      { jsonrpc: '2.0', id: 0, method: 'initialize', params: {} },
+      { version: '9.9.9' },
+    ) as any;
+    expect(res.result.protocolVersion).toBe(MCP_PROTOCOL_VERSION);
+    expect(res.result.capabilities.tools).toBeDefined();
+    expect(res.result.serverInfo.version).toBe('9.9.9');
+  });
+
+  it('notifications/initialized gets no reply', () => {
+    expect(handleMcpRequest({ jsonrpc: '2.0', method: 'notifications/initialized' })).toBeNull();
+  });
+
+  it('unknown method returns a JSON-RPC method-not-found error', () => {
+    const res = handleMcpRequest({ jsonrpc: '2.0', id: 5, method: 'no/such' }) as any;
+    expect(res.error.code).toBe(-32601);
+  });
+});
+
+describe('stdio transport end-to-end', () => {
+  it('drives initialize + tools/call over newline-delimited JSON-RPC', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const chunks: Buffer[] = [];
+    output.on('data', (c) => chunks.push(Buffer.from(c)));
+
+    const done = runSecretsMcpServer({ input, output, version: '1.2.3' });
+
+    input.write(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }) + '\n');
+    input.write(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: GET_SECRET_TOOL, arguments: { bundle: 'prod', key: 'STRIPE_KEY' } },
+      }) + '\n',
+    );
+    input.end();
+    await done;
+
+    const lines = Buffer.concat(chunks).toString('utf8').trim().split('\n').filter(Boolean);
+    const msgs = lines.map((l) => JSON.parse(l));
+    expect(msgs[0].result.protocolVersion).toBe(MCP_PROTOCOL_VERSION);
+    expect(msgs[1].result.content).toEqual([{ type: 'text', text: SECRET_VALUE }]);
+  });
+});

--- a/src/lib/secrets/mcp.ts
+++ b/src/lib/secrets/mcp.ts
@@ -1,0 +1,253 @@
+/**
+ * Zero-knowledge / JIT secret delivery over MCP (issue #333).
+ *
+ * A stdio MCP server exposing a single `get_secret(bundle, key)` tool. Unlike
+ * `agents secrets exec`, which spawns the child process with EVERY resolved
+ * value baked into `process.env` (any subprocess can `printenv` the lot — see
+ * buildSecretsExecEnv in src/commands/secrets.ts), this server hands an
+ * MCP-speaking agent framework ONE credential at a time, by name, at call
+ * time. The raw value is returned only inside the tool result: it never enters
+ * the child's environment, is never logged, and never appears in `tools/list`
+ * metadata (names only).
+ *
+ * Resolution reuses the canonical bundle read path
+ * (readAndResolveBundleEnv -> getKeychainToken); no keychain access is
+ * re-implemented here. On Linux the libsecret backend (or its encrypted-file
+ * fallback for locked/headless collections) applies transparently through that
+ * abstraction, so the server stays backend-agnostic and works unchanged on
+ * macOS.
+ *
+ * Transport: the MCP stdio transport is newline-delimited JSON-RPC 2.0 (one
+ * message per line, UTF-8, no embedded newlines). That framing is trivial, so
+ * we implement it directly rather than pull in the @modelcontextprotocol/sdk
+ * server dependency — keeping the tree dependency-free and the handler pure and
+ * unit-testable in-process.
+ */
+
+import * as readline from 'readline';
+import {
+  listBundles,
+  readAndResolveBundleEnv,
+  readBundle,
+  validateBundleName,
+} from './bundles.js';
+
+/** MCP protocol revision this server negotiates. */
+export const MCP_PROTOCOL_VERSION = '2024-11-05';
+/** The single tool this server exposes. */
+export const GET_SECRET_TOOL = 'get_secret';
+/** serverInfo.name reported at `initialize`. */
+export const MCP_SERVER_NAME = 'agents-secrets';
+
+// JSON-RPC 2.0 error codes we use.
+const JSONRPC_PARSE_ERROR = -32700;
+const JSONRPC_INVALID_REQUEST = -32600;
+const JSONRPC_METHOD_NOT_FOUND = -32601;
+const JSONRPC_INVALID_PARAMS = -32602;
+
+export interface JsonRpcRequest {
+  jsonrpc?: string;
+  id?: string | number | null;
+  method?: string;
+  params?: unknown;
+}
+
+interface JsonRpcSuccess {
+  jsonrpc: '2.0';
+  id: string | number | null;
+  result: unknown;
+}
+
+interface JsonRpcErrorResponse {
+  jsonrpc: '2.0';
+  id: string | number | null;
+  error: { code: number; message: string };
+}
+
+export type JsonRpcResponse = JsonRpcSuccess | JsonRpcErrorResponse;
+
+/** Per-bundle metadata for `tools/list` — names only, NEVER values. */
+export interface BundleKeyMetadata {
+  bundle: string;
+  description?: string;
+  keys: string[];
+}
+
+/**
+ * Enumerate every bundle and its key names WITHOUT resolving or reading any
+ * value. Mirrors how `agents secrets list` surfaces bundle metadata: names are
+ * safe to expose, values are not. `listBundles()` reads only the bundle
+ * metadata items (var definitions), never the secret items behind them.
+ */
+export function listSecretMetadata(): BundleKeyMetadata[] {
+  return listBundles()
+    .map((b) => ({
+      bundle: b.name,
+      description: b.description,
+      keys: Object.keys(b.vars).sort(),
+    }))
+    .sort((a, b) => a.bundle.localeCompare(b.bundle));
+}
+
+/**
+ * Resolve a single secret value by bundle + key through the canonical read
+ * path. Throws a clear error when the bundle or the key is absent.
+ *
+ * The bundle metadata is read first (readBundle) so a missing key is reported
+ * without triggering resolution — and, on macOS, without prompting Touch ID —
+ * for the other keys in the bundle.
+ */
+export function resolveSecret(bundle: string, key: string): string {
+  validateBundleName(bundle);
+  // readBundle throws `Secrets bundle '<name>' not found.` for a missing bundle.
+  const meta = readBundle(bundle);
+  if (!Object.prototype.hasOwnProperty.call(meta.vars, key)) {
+    const available = Object.keys(meta.vars).sort();
+    throw new Error(
+      `Key '${key}' not found in bundle '${bundle}'.` +
+        (available.length ? ` Available keys: ${available.join(', ')}.` : ' Bundle has no keys.'),
+    );
+  }
+  const { env } = readAndResolveBundleEnv(bundle, { caller: 'secrets-mcp' });
+  const value = env[key];
+  if (value === undefined) {
+    throw new Error(`Key '${key}' in bundle '${bundle}' could not be resolved.`);
+  }
+  return value;
+}
+
+/** Build the `get_secret` tool definition, advertising available names only. */
+function getSecretToolDefinition() {
+  let catalog = '(no bundles configured)';
+  try {
+    const meta = listSecretMetadata();
+    if (meta.length > 0) {
+      catalog = meta
+        .map((b) => `${b.bundle}: ${b.keys.length ? b.keys.join(', ') : '(no keys)'}`)
+        .join(' | ');
+    }
+  } catch {
+    // Listing is best-effort decoration; never fail tools/list because the
+    // keychain enumeration hiccuped.
+    catalog = '(unavailable)';
+  }
+  return {
+    name: GET_SECRET_TOOL,
+    description:
+      'Fetch a single secret value by bundle + key, resolved at call time. The value ' +
+      'is returned only in this tool result and never enters the process environment. ' +
+      `Available bundles and keys (names only): ${catalog}`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        bundle: { type: 'string', description: 'Secrets bundle name' },
+        key: { type: 'string', description: 'Key / env-var name within the bundle' },
+      },
+      required: ['bundle', 'key'],
+      additionalProperties: false,
+    },
+  };
+}
+
+function success(id: string | number | null, result: unknown): JsonRpcSuccess {
+  return { jsonrpc: '2.0', id, result };
+}
+
+function rpcError(id: string | number | null, code: number, message: string): JsonRpcErrorResponse {
+  return { jsonrpc: '2.0', id, error: { code, message } };
+}
+
+/**
+ * A tool-execution failure. Per the MCP spec, tool errors are reported IN the
+ * result (`isError: true`) — not as a JSON-RPC error — so the model sees and
+ * can react to the message. The value channel (`content`) still carries no
+ * secret here.
+ */
+function toolError(id: string | number | null, message: string): JsonRpcSuccess {
+  return success(id, { content: [{ type: 'text', text: message }], isError: true });
+}
+
+function handleToolCall(id: string | number | null, params: unknown): JsonRpcResponse {
+  const p = (params ?? {}) as { name?: unknown; arguments?: unknown };
+  if (p.name !== GET_SECRET_TOOL) {
+    return rpcError(id, JSONRPC_INVALID_PARAMS, `Unknown tool: ${String(p.name)}`);
+  }
+  const args = (p.arguments ?? {}) as { bundle?: unknown; key?: unknown };
+  if (typeof args.bundle !== 'string' || !args.bundle || typeof args.key !== 'string' || !args.key) {
+    return toolError(id, `${GET_SECRET_TOOL} requires non-empty string 'bundle' and 'key' arguments.`);
+  }
+  try {
+    const value = resolveSecret(args.bundle, args.key);
+    return success(id, { content: [{ type: 'text', text: value }] });
+  } catch (err) {
+    return toolError(id, (err as Error).message);
+  }
+}
+
+/**
+ * Handle one parsed JSON-RPC request. Returns the response object, or `null`
+ * for notifications (which take no reply). Pure — no I/O, no logging — so tests
+ * drive it directly.
+ */
+export function handleMcpRequest(
+  req: JsonRpcRequest,
+  ctx: { version?: string } = {},
+): JsonRpcResponse | null {
+  const id = req.id ?? null;
+  const isNotification = req.id === undefined || req.id === null;
+  switch (req.method) {
+    case 'initialize':
+      return success(id, {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: { name: MCP_SERVER_NAME, version: ctx.version ?? '0.0.0' },
+      });
+    case 'notifications/initialized':
+    case 'initialized':
+      return null; // notification — no response
+    case 'ping':
+      return success(id, {});
+    case 'tools/list':
+      return success(id, { tools: [getSecretToolDefinition()] });
+    case 'tools/call':
+      return handleToolCall(id, req.params);
+    default:
+      if (isNotification) return null; // unknown notification — stay silent
+      return rpcError(id, JSONRPC_METHOD_NOT_FOUND, `Method not found: ${String(req.method)}`);
+  }
+}
+
+function writeMessage(output: NodeJS.WritableStream, msg: JsonRpcResponse): void {
+  output.write(JSON.stringify(msg) + '\n');
+}
+
+/**
+ * Run the stdio MCP server: read newline-delimited JSON-RPC requests from
+ * `input`, write responses to `output`. Resolves when the input stream ends.
+ * Streams are injectable so tests can drive a full request/response loop
+ * without spawning a process.
+ */
+export async function runSecretsMcpServer(
+  opts: { input?: NodeJS.ReadableStream; output?: NodeJS.WritableStream; version?: string } = {},
+): Promise<void> {
+  const input = opts.input ?? process.stdin;
+  const output = opts.output ?? process.stdout;
+  const rl = readline.createInterface({ input, crlfDelay: Infinity });
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let req: JsonRpcRequest;
+    try {
+      req = JSON.parse(trimmed) as JsonRpcRequest;
+    } catch {
+      writeMessage(output, rpcError(null, JSONRPC_PARSE_ERROR, 'Parse error'));
+      continue;
+    }
+    if (!req || typeof req !== 'object' || typeof req.method !== 'string') {
+      writeMessage(output, rpcError((req && req.id) ?? null, JSONRPC_INVALID_REQUEST, 'Invalid Request'));
+      continue;
+    }
+    const res = handleMcpRequest(req, { version: opts.version });
+    if (res) writeMessage(output, res);
+  }
+}


### PR DESCRIPTION
## What ships

`agents secrets mcp` — a stdio **MCP server** exposing a single `get_secret(bundle, key)` tool. An MCP-speaking agent framework requests a credential **by name, at call time**, and the raw value is returned **only in the tool result**. It never enters the child process's environment.

### The leak this closes
`agents secrets exec` spawns the child with `env: { ...process.env, ...secretEnv }` (`buildSecretsExecEnv`, `src/commands/secrets.ts`), so any subprocess can `printenv` every credential. The MCP server closes that hole for frameworks that speak MCP: nothing is written to `process.env`.

### Design
- **`src/lib/secrets/mcp.ts`** — a pure JSON-RPC 2.0 request handler (`handleMcpRequest`) plus a newline-delimited stdio transport (`runSecretsMcpServer`). The handler is I/O-free so it's driven directly in tests.
- **Reuses the canonical read path**, does **not** re-implement keychain reads: `resolveSecret` calls `readBundle` (bundle/key existence + clear errors) then `readAndResolveBundleEnv` → `getKeychainToken`. Backend-agnostic by construction — macOS Keychain, **Linux libsecret**, or the encrypted-file fallback all work unchanged through that abstraction.
- **`tools/list`** advertises available bundle + key **names only** (mirrors `agents secrets list`), never values.
- **Tool errors are in-band** (`isError: true` in the result) per the MCP spec, so the model sees "bundle/key not found" and can react; the value channel still carries no secret on the error path.
- **Zero new dependencies.** MCP's stdio transport is newline-delimited JSON-RPC 2.0; the framing is trivial, so it's implemented directly rather than pulling in `@modelcontextprotocol/sdk`. Keeps the tree dep-free and the handler unit-testable.

### No-env-leak guarantee
The value is produced by `resolveSecret` and placed only into the JSON-RPC `result.content` written to stdout. It is never assigned to `process.env`, never logged, and never included in `tools/list`. Contrast with `secrets exec`, which is env-injection by design.

## Test
`src/lib/secrets/mcp.test.ts` (14 cases) drives the server's request handler **in-process** against a **real temp AES-256-GCM file store** (the Linux libsecret headless/locked-collection fallback — real crypto, real `readAndResolveBundleEnv`), with an in-memory keychain backend only to keep `listBundles`' keychain branch off the host keyring:
- `tools/call get_secret` returns the value for a real bundle/key (keychain-ref **and** literal).
- Missing key / missing bundle → in-band `isError` with a clear message and **no value**.
- `tools/list` returns tool + bundle/key names but **not** the secret value (asserts the serialized listing never contains it).
- `initialize` handshake, notification-gets-no-reply, unknown-method JSON-RPC error.
- Full stdio round-trip through `PassThrough` streams (`initialize` + `tools/call`).

Verified end-to-end against the real CLI process (`bun src/index.ts secrets mcp`): `initialize` returns `serverInfo.version` = the real package version; a missing-bundle `tools/call` returns a clean in-band error. `bunx tsc --noEmit` clean; the full suite is green except 5 pre-existing failures in `src/lib/session/sync/config.test.ts` that are **host-specific** (this dev box has a real `r2.backups` file bundle on disk; they pass on a clean CI runner and are unrelated to this change — the file is untouched here).

## Deferred (explicit follow-up)
The **HTTP transport proxy** variant — a local credential-injecting proxy so non-MCP tools reach secrets over a loopback endpoint without env exposure — is **not** in this PR. This increment covers the MCP credential-server variant only.