### PR TITLE
feat(governance): agents.lock + install --frozen reproducible resources (Closes #337)

### DIFF
--- a/src/commands/lock.ts
+++ b/src/commands/lock.ts
@@ -1,0 +1,93 @@
+/**
+ * `agents lock` — write a deterministic `agents.lock` for the resolved resource
+ * set at the project root; `agents lock --frozen` verifies the live resources
+ * match that lock EXACTLY and fails closed (non-zero exit + a clear diff) on any
+ * drift. The reproducible-CI slice of governance #337.
+ *
+ * This is OFF the default path: normal `agents add` / `agents sync` never touch
+ * the lock. Generation and verification only run when this command is invoked.
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import {
+  enumerateLockSources,
+  buildLock,
+  writeLock,
+  readLock,
+  verifyLock,
+  lockDiffIsClean,
+  resolveProjectRoot,
+  LOCK_FILENAME,
+} from '../lib/lock.js';
+
+interface LockOpts {
+  cwd?: string;
+  frozen?: boolean;
+}
+
+/** Register the `agents lock` command. */
+export function registerLockCommand(program: Command): void {
+  program
+    .command('lock')
+    .summary('Write or verify agents.lock — a SHA-256 manifest of resolved resources')
+    .description(
+      'Capture a deterministic SHA-256 per resolved resource file (commands, skills, hooks, rules, mcp, permissions, subagents — project > user > system > extras) into an agents.lock at the project root.\n\n' +
+        'Run bare to (re)generate the lock. Pass --frozen to VERIFY the live resolved resources match an existing agents.lock exactly — it exits non-zero with an added/removed/changed diff on any mismatch, and errors if no lock exists yet. That is the reproducible-CI gate; normal installs and syncs are unaffected.',
+    )
+    .option('--cwd <path>', 'Working directory to resolve resources and the project root from')
+    .option('--frozen', 'Verify resolved resources match agents.lock exactly; fail (non-zero) on any drift', false)
+    .action((opts: LockOpts) => {
+      runLock(opts);
+    });
+}
+
+function runLock(opts: LockOpts): void {
+  const cwd = opts.cwd || process.cwd();
+  const projectRoot = resolveProjectRoot(cwd);
+  const sources = enumerateLockSources(cwd);
+
+  if (opts.frozen) {
+    verifyFrozen(projectRoot, sources);
+    return;
+  }
+
+  const lock = buildLock(sources);
+  const written = writeLock(projectRoot, lock);
+  const count = Object.keys(lock.resources).length;
+  console.log(
+    chalk.green(`Wrote ${LOCK_FILENAME}`) +
+      chalk.gray(` — ${count} resource file(s) → ${written}`),
+  );
+}
+
+function verifyFrozen(projectRoot: string, sources: ReturnType<typeof enumerateLockSources>): void {
+  let existing;
+  try {
+    existing = readLock(projectRoot);
+  } catch (e) {
+    console.error(chalk.red(`agents lock --frozen: ${(e as Error).message}`));
+    process.exitCode = 1;
+    return;
+  }
+  if (!existing) {
+    console.error(chalk.red(`No ${LOCK_FILENAME} at ${projectRoot}.`));
+    console.error(chalk.gray('Generate one first: agents lock'));
+    process.exitCode = 1;
+    return;
+  }
+
+  const diff = verifyLock(existing, sources);
+  if (lockDiffIsClean(diff)) {
+    const count = Object.keys(existing.resources).length;
+    console.log(chalk.green(`✓ ${count} resource file(s) match ${LOCK_FILENAME}`));
+    return;
+  }
+
+  console.error(chalk.red(`✗ resources drifted from ${LOCK_FILENAME}:`));
+  for (const key of diff.changed) console.error(chalk.yellow(`  changed  ${key}`));
+  for (const key of diff.added) console.error(chalk.yellow(`  added    ${key}`));
+  for (const key of diff.removed) console.error(chalk.yellow(`  removed  ${key}`));
+  console.error(chalk.gray('Re-lock once the change is intended: agents lock'));
+  process.exitCode = 1;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,7 @@ import {
   loadMenubar,
   loadBeta,
   loadSync,
+  loadLock,
   loadRefreshRules,
   loadDrive,
   loadFactory,
@@ -273,6 +274,7 @@ Config sync:
   pull                            Clone or pull the system repo at ~/.agents/.system/
   repo init --path <dir>          Scaffold your own editable repo from a template
   repo add <path|gh:user/repo>    Merge an extra repo after the system repo
+  lock [--frozen]                 Write/verify agents.lock (SHA-256 of resolved resources); --frozen fails on drift
 
 Beta features:
   beta                            Enable preview features (factory, drive, and more)
@@ -929,6 +931,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadMenubar);
   await reg(loadBeta);
   await reg(loadSync);
+  await reg(loadLock);
   await reg(loadRefreshRules);
   await reg(loadDrive);
   await reg(loadFactory);

--- a/src/lib/lock.test.ts
+++ b/src/lib/lock.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  buildLock,
+  serializeLock,
+  writeLock,
+  readLock,
+  verifyLock,
+  diffLock,
+  lockDiffIsClean,
+  LOCK_VERSION,
+  type LockSource,
+} from './lock.js';
+
+/**
+ * Build a temp resource root with the layout the lock captures:
+ *   commands/plan.md, commands/test.md   (single files)
+ *   skills/debug/SKILL.md + a nested file (a directory resource)
+ *   hooks/guard.sh + hooks/guard.yaml    (script + sidecar — must not collide)
+ *   mcp/server.yaml                       (single file)
+ */
+function makeResourceRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-lock-test-'));
+  fs.mkdirSync(path.join(root, 'commands'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'commands', 'plan.md'), '# plan\nrun the plan\n');
+  fs.writeFileSync(path.join(root, 'commands', 'test.md'), '# test\nrun the tests\n');
+  fs.mkdirSync(path.join(root, 'skills', 'debug', 'refs'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'skills', 'debug', 'SKILL.md'), '---\nname: debug\n---\nbody\n');
+  fs.writeFileSync(path.join(root, 'skills', 'debug', 'refs', 'notes.md'), 'notes\n');
+  fs.mkdirSync(path.join(root, 'hooks'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'hooks', 'guard.sh'), '#!/bin/sh\necho guard\n');
+  fs.writeFileSync(path.join(root, 'hooks', 'guard.yaml'), 'matches: []\n');
+  fs.mkdirSync(path.join(root, 'mcp'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'mcp', 'server.yaml'), 'name: server\n');
+  return root;
+}
+
+/**
+ * Enumerate the temp root's resources into LockSource[] — mirrors the mapping
+ * enumerateLockSources() does per layer, but confined to this one dir so the
+ * test is deterministic (no dependency on the real ~/.agents layers).
+ */
+function sourcesFor(root: string): LockSource[] {
+  const out: LockSource[] = [];
+  for (const kind of ['commands', 'skills', 'hooks', 'mcp']) {
+    const kindDir = path.join(root, kind);
+    if (!fs.existsSync(kindDir)) continue;
+    for (const name of fs.readdirSync(kindDir)) {
+      out.push({ path: path.join(kindDir, name), key: `${kind}/${name}` });
+    }
+  }
+  return out;
+}
+
+describe('agents.lock generation', () => {
+  it('captures a sha256 per resolved file, keyed by relpath', () => {
+    const root = makeResourceRoot();
+    const lock = buildLock(sourcesFor(root));
+
+    expect(lock.version).toBe(LOCK_VERSION);
+    const keys = Object.keys(lock.resources);
+    // Directory resources expand to every contained file; files map 1:1.
+    expect(keys).toContain('commands/plan.md');
+    expect(keys).toContain('commands/test.md');
+    expect(keys).toContain('skills/debug/SKILL.md');
+    expect(keys).toContain('skills/debug/refs/notes.md');
+    expect(keys).toContain('mcp/server.yaml');
+    // Script + sidecar with the same basename stay distinct — no collision.
+    expect(keys).toContain('hooks/guard.sh');
+    expect(keys).toContain('hooks/guard.yaml');
+    // Every value is a 64-char hex sha256.
+    for (const v of Object.values(lock.resources)) expect(v).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic and sorted (byte-stable serialization)', () => {
+    const root = makeResourceRoot();
+    const a = serializeLock(buildLock(sourcesFor(root)));
+    const b = serializeLock(buildLock(sourcesFor(root)));
+    expect(a).toBe(b);
+    const keys = Object.keys(JSON.parse(a).resources);
+    expect(keys).toEqual([...keys].sort());
+    expect(a.endsWith('\n')).toBe(true);
+  });
+
+  it('round-trips through write + read', () => {
+    const root = makeResourceRoot();
+    const lock = buildLock(sourcesFor(root));
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-lock-root-'));
+    writeLock(projectRoot, lock);
+    const back = readLock(projectRoot);
+    expect(back).toEqual(lock);
+  });
+});
+
+describe('agents lock --frozen verification', () => {
+  it('passes when nothing changed', () => {
+    const root = makeResourceRoot();
+    const lock = buildLock(sourcesFor(root));
+    const diff = verifyLock(lock, sourcesFor(root));
+    expect(lockDiffIsClean(diff)).toBe(true);
+  });
+
+  it('reports the exact changed path when a file is mutated', () => {
+    const root = makeResourceRoot();
+    const lock = buildLock(sourcesFor(root));
+
+    fs.writeFileSync(path.join(root, 'commands', 'plan.md'), '# plan\nMUTATED\n');
+
+    const diff = verifyLock(lock, sourcesFor(root));
+    expect(lockDiffIsClean(diff)).toBe(false);
+    expect(diff.changed).toEqual(['commands/plan.md']);
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+  });
+
+  it('detects a mutated file nested inside a directory resource', () => {
+    const root = makeResourceRoot();
+    const lock = buildLock(sourcesFor(root));
+
+    fs.writeFileSync(path.join(root, 'skills', 'debug', 'refs', 'notes.md'), 'CHANGED\n');
+
+    const diff = verifyLock(lock, sourcesFor(root));
+    expect(diff.changed).toEqual(['skills/debug/refs/notes.md']);
+  });
+
+  it('detects an added file', () => {
+    const root = makeResourceRoot();
+    const lock = buildLock(sourcesFor(root));
+
+    fs.writeFileSync(path.join(root, 'commands', 'ship.md'), '# ship\n');
+
+    const diff = verifyLock(lock, sourcesFor(root));
+    expect(diff.added).toEqual(['commands/ship.md']);
+    expect(diff.changed).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(lockDiffIsClean(diff)).toBe(false);
+  });
+
+  it('detects a removed file', () => {
+    const root = makeResourceRoot();
+    const lock = buildLock(sourcesFor(root));
+
+    fs.rmSync(path.join(root, 'mcp', 'server.yaml'));
+
+    const diff = verifyLock(lock, sourcesFor(root));
+    expect(diff.removed).toEqual(['mcp/server.yaml']);
+    expect(diff.added).toEqual([]);
+    expect(diff.changed).toEqual([]);
+  });
+
+  it('reports added, removed, and changed together', () => {
+    const root = makeResourceRoot();
+    const lock = buildLock(sourcesFor(root));
+
+    fs.writeFileSync(path.join(root, 'commands', 'plan.md'), 'changed\n'); // changed
+    fs.rmSync(path.join(root, 'commands', 'test.md')); // removed
+    fs.writeFileSync(path.join(root, 'hooks', 'extra.sh'), '#!/bin/sh\n'); // added
+
+    const diff = diffLock(lock, buildLock(sourcesFor(root)));
+    expect(diff.changed).toEqual(['commands/plan.md']);
+    expect(diff.removed).toEqual(['commands/test.md']);
+    expect(diff.added).toEqual(['hooks/extra.sh']);
+  });
+});
+
+describe('readLock error handling', () => {
+  it('returns null when no lock exists (distinct from malformed)', () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-lock-empty-'));
+    expect(readLock(projectRoot)).toBeNull();
+  });
+
+  it('throws (fails closed) on a malformed lock rather than treating it as absent', () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-lock-bad-'));
+    fs.writeFileSync(path.join(projectRoot, 'agents.lock'), '{ not json');
+    expect(() => readLock(projectRoot)).toThrow();
+  });
+
+  it('throws on an unsupported lock version', () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-lock-ver-'));
+    fs.writeFileSync(path.join(projectRoot, 'agents.lock'), JSON.stringify({ version: 999, resources: {} }));
+    expect(() => readLock(projectRoot)).toThrow(/version/);
+  });
+});

--- a/src/lib/lock.ts
+++ b/src/lib/lock.ts
@@ -1,0 +1,240 @@
+/**
+ * `agents.lock` — a deterministic SHA-256 manifest of the resolved resource set
+ * at a project root, plus the `--frozen` verification that fails closed on any
+ * drift. This is the reproducible-CI slice of the governance work (#337); org
+ * version pins and bundle signing are deferred follow-ups.
+ *
+ * Design:
+ *  - Content hashing REUSES `fingerprintDir` / `fingerprintFile`
+ *    (src/lib/staleness/fingerprint.ts) — the same two-tier fingerprinter every
+ *    staleness checker uses. No new recursive file walker is introduced here.
+ *  - The resource SET is the layered, resolved source union (project > user >
+ *    system > extras), the same precedence `resolveResource` / `syncResourcesToVersion`
+ *    read from. It is enumerated agent-independently on purpose: the lock must be
+ *    reproducible on a fresh CI checkout that has no installed agent VERSIONS, so
+ *    it snapshots the SOURCES sync copies FROM, not any per-version home.
+ *
+ * Lock shape (JSON): `{ "version": 1, "resources": { "<relpath>": "<sha256>" } }`,
+ * keys sorted so the file is byte-stable across machines and runs.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { fingerprintDir, fingerprintFile } from './staleness/fingerprint.js';
+import {
+  getProjectAgentsDir,
+  getUserAgentsDir,
+  getSystemAgentsDir,
+  getEnabledExtraRepos,
+} from './state.js';
+
+export const LOCK_FILENAME = 'agents.lock';
+export const LOCK_VERSION = 1 as const;
+
+/**
+ * Resource kinds captured by the lock — the file/dir-backed layered resources
+ * shared across every agent. Presence-only kinds handled specially by the sync
+ * differ (plugins/promptcuts) are intentionally out of this first slice.
+ */
+export const LOCK_KINDS = [
+  'commands',
+  'skills',
+  'hooks',
+  'rules',
+  'mcp',
+  'permissions',
+  'subagents',
+] as const;
+
+/** The on-disk lockfile: relpath -> sha256 hex digest, keys sorted. */
+export interface AgentsLock {
+  version: typeof LOCK_VERSION;
+  resources: Record<string, string>;
+}
+
+/**
+ * One resolved resource to fingerprint. `path` is an absolute file or directory;
+ * `key` is the stable relpath prefix under which its hashes are recorded
+ * (e.g. `skills/debug` for a directory, `commands/plan.md` for a single file).
+ */
+export interface LockSource {
+  path: string;
+  key: string;
+}
+
+/** Added/removed/changed keys between an expected lock and the live resources. */
+export interface LockDiff {
+  /** Present in the live resources, absent from the lock. */
+  added: string[];
+  /** Present in the lock, absent from the live resources. */
+  removed: string[];
+  /** Present in both but the sha256 differs. */
+  changed: string[];
+}
+
+/** Normalise a filesystem-relative path to POSIX separators for stable keys. */
+function toPosix(rel: string): string {
+  return rel.split(path.sep).join('/');
+}
+
+/**
+ * Hash every resolved source into a flat `relpath -> sha256` map. Directories are
+ * expanded with `fingerprintDir` (every contained file, sorted); single files use
+ * `fingerprintFile`. Unreadable / missing sources are skipped — enumeration only
+ * ever hands us paths that existed at scan time.
+ */
+export function hashLockSources(sources: LockSource[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const src of sources) {
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(src.path);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      for (const fp of fingerprintDir(src.path)) {
+        const rel = toPosix(path.relative(src.path, fp.path));
+        out[`${src.key}/${rel}`] = fp.sha256;
+      }
+    } else if (stat.isFile()) {
+      const fp = fingerprintFile(src.path);
+      if (fp) out[src.key] = fp.sha256;
+    }
+  }
+  return out;
+}
+
+/** Build a fully-sorted lock object from a resolved source set. */
+export function buildLock(sources: LockSource[]): AgentsLock {
+  return { version: LOCK_VERSION, resources: sortRecord(hashLockSources(sources)) };
+}
+
+/** Return a new record with keys inserted in sorted order (deterministic JSON). */
+function sortRecord(record: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const key of Object.keys(record).sort()) out[key] = record[key];
+  return out;
+}
+
+/** Serialise a lock to the canonical, sorted, newline-terminated JSON form. */
+export function serializeLock(lock: AgentsLock): string {
+  return JSON.stringify({ version: lock.version, resources: sortRecord(lock.resources) }, null, 2) + '\n';
+}
+
+/** Absolute path to the lockfile for a project root. */
+export function lockPath(projectRoot: string): string {
+  return path.join(projectRoot, LOCK_FILENAME);
+}
+
+/**
+ * Read + validate an existing lock. Returns null ONLY when the file is absent —
+ * a present-but-malformed lock throws, so `--frozen` fails closed instead of
+ * silently treating corruption as "no lock".
+ */
+export function readLock(projectRoot: string): AgentsLock | null {
+  const p = lockPath(projectRoot);
+  if (!fs.existsSync(p)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(p, 'utf-8'));
+  } catch (e) {
+    throw new Error(`${LOCK_FILENAME} is not valid JSON: ${(e as Error).message}`);
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(`${LOCK_FILENAME} is malformed (expected an object).`);
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (obj.version !== LOCK_VERSION) {
+    throw new Error(`${LOCK_FILENAME} version ${String(obj.version)} is unsupported (expected ${LOCK_VERSION}).`);
+  }
+  if (!obj.resources || typeof obj.resources !== 'object') {
+    throw new Error(`${LOCK_FILENAME} is missing a resources map.`);
+  }
+  return { version: LOCK_VERSION, resources: obj.resources as Record<string, string> };
+}
+
+/** Write the lock to `<projectRoot>/agents.lock`, returning the path written. */
+export function writeLock(projectRoot: string, lock: AgentsLock): string {
+  const p = lockPath(projectRoot);
+  fs.writeFileSync(p, serializeLock(lock));
+  return p;
+}
+
+/** Diff a recorded lock against a freshly-computed one. */
+export function diffLock(expected: AgentsLock, actual: AgentsLock): LockDiff {
+  const e = expected.resources;
+  const a = actual.resources;
+  const added: string[] = [];
+  const removed: string[] = [];
+  const changed: string[] = [];
+  for (const k of Object.keys(a)) if (!(k in e)) added.push(k);
+  for (const k of Object.keys(e)) {
+    if (!(k in a)) removed.push(k);
+    else if (e[k] !== a[k]) changed.push(k);
+  }
+  added.sort();
+  removed.sort();
+  changed.sort();
+  return { added, removed, changed };
+}
+
+/** True when a diff has no added/removed/changed entries. */
+export function lockDiffIsClean(diff: LockDiff): boolean {
+  return diff.added.length === 0 && diff.removed.length === 0 && diff.changed.length === 0;
+}
+
+/** Verify a recorded lock against the live resolved sources. */
+export function verifyLock(expected: AgentsLock, sources: LockSource[]): LockDiff {
+  return diffLock(expected, buildLock(sources));
+}
+
+/**
+ * The project root the lockfile lives at: the parent of the discovered project
+ * `.agents/` dir, or the cwd itself when none is found.
+ */
+export function resolveProjectRoot(cwd: string = process.cwd()): string {
+  const projectDir = getProjectAgentsDir(cwd);
+  return projectDir ? path.dirname(projectDir) : path.resolve(cwd);
+}
+
+/**
+ * Enumerate the resolved resource sources for a cwd: for each lockable kind, the
+ * winning entry per name across layers (project > user > system > extras), keyed
+ * `<kind>/<entryName>`. This is a single-level `readdir` per kind dir — the
+ * recursive fingerprinting is delegated to `fingerprintDir`.
+ *
+ * Entry names keep their extension in the key, so a hook script `foo.sh` and its
+ * sidecar `foo.yaml` stay distinct (a name-stripped enumerator would collide
+ * them). Dotfiles at the kind-dir top level are skipped as noise.
+ */
+export function enumerateLockSources(cwd: string = process.cwd()): LockSource[] {
+  const roots: string[] = [];
+  const projectDir = getProjectAgentsDir(cwd);
+  if (projectDir) roots.push(projectDir);
+  roots.push(getUserAgentsDir());
+  roots.push(getSystemAgentsDir());
+  for (const extra of getEnabledExtraRepos()) roots.push(extra.dir);
+
+  const sources: LockSource[] = [];
+  const seen = new Set<string>();
+  for (const kind of LOCK_KINDS) {
+    for (const root of roots) {
+      const kindDir = path.join(root, kind);
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(kindDir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        if (entry.name.startsWith('.')) continue;
+        const key = `${kind}/${entry.name}`;
+        if (seen.has(key)) continue; // project layer wins on same name
+        seen.add(key);
+        sources.push({ path: path.join(kindDir, entry.name), key });
+      }
+    }
+  }
+  return sources.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+}

--- a/src/lib/startup/command-registry.ts
+++ b/src/lib/startup/command-registry.ts
@@ -64,6 +64,7 @@ export const loadHelper: ModuleLoader = async () => (await import('../../command
 export const loadMenubar: ModuleLoader = async () => (await import('../../commands/menubar.js')).registerMenubarCommands;
 export const loadBeta: ModuleLoader = async () => (await import('../../commands/beta.js')).registerBetaCommands;
 export const loadSync: ModuleLoader = async () => (await import('../../commands/sync.js')).registerSyncCommand;
+export const loadLock: ModuleLoader = async () => (await import('../../commands/lock.js')).registerLockCommand;
 export const loadRefreshRules: ModuleLoader = async () => (await import('../../commands/refresh-rules.js')).registerRefreshRulesCommand;
 export const loadDrive: ModuleLoader = async () => (await import('../../commands/drive.js')).registerDriveCommands;
 export const loadFactory: ModuleLoader = async () => (await import('../../commands/factory.js')).registerFactoryCommands;
@@ -155,6 +156,7 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   menubar: [loadMenubar],
   beta: [loadBeta],
   sync: [loadSync],
+  lock: [loadLock],
   'refresh-rules': [loadRefreshRules],
   drive: [loadDrive],
   factory: [loadFactory],


### PR DESCRIPTION
## What shipped (first increment of #337)

The **agents.lock + `--frozen`** slice — reproducible resource verification.

- **`agents lock`** — writes `agents.lock` at the project root: a deterministic, sorted JSON manifest `{ "version": 1, "resources": { "<relpath>": "<sha256>" } }` capturing a SHA-256 per resolved resource file across `commands / skills / hooks / rules / mcp / permissions / subagents` (resolution order project > user > system > extras).
- **`agents lock --frozen`** — verifies the live resolved resource set matches an existing `agents.lock` **exactly** and **fails closed** (non-zero exit + a clear `added` / `removed` / `changed` diff) on any mismatch. If no lock exists yet, it errors telling you to run `agents lock` first. This is the reproducible-CI gate.
- **Off the default path.** Normal `agents add` / `agents sync` are unchanged — no behavior change for existing users, no fallbacks. Generation and verification only run when `lock` is invoked.

### Command naming
The issue sketched `agents install --frozen`, but `agents install` already exists (it installs registry packages — `mcp:name`, `skill:user/repo`). To avoid overloading an unrelated verb, the surface is a dedicated **`agents lock` / `agents lock --frozen`** command, registered the same lazy way as its siblings (`command-registry.ts` loader + `COMMAND_LOADERS` entry + eager registration in `index.ts`).

## Reuse anchors (as directed)
- Content hashing reuses **`fingerprintDir` / `fingerprintFile`** (`src/lib/staleness/fingerprint.ts`) — the existing two-tier fingerprinter. No new recursive file walker was written; enumeration is a single-level `readdir` per kind dir, recursion/hashing is delegated to `fingerprintDir`.
- The resource set is enumerated via the existing layered resolvers (`getProjectAgentsDir` / `getUserAgentsDir` / `getSystemAgentsDir` / `getEnabledExtraRepos`), the same precedence `resolveResource` / `syncResourcesToVersion` read from.

**Why agent-independent enumeration** (not per-version `diffVersionResources` / `computeSyncStatus`): the lock must be reproducible on a fresh CI checkout that has **no installed agent versions**. It snapshots the SOURCES sync copies *from*, not any per-version home — so `--frozen` works in CI where `computeSyncStatus` would see zero installed versions and lock nothing.

## Tests
`src/lib/lock.test.ts` (colocated, fails pre-change — imports the new module). Builds a temp resource dir and asserts, with no mocking of code under test:
- a SHA-256 is captured per file, directory resources expand to every contained file, and a hook script + same-basename sidecar (`guard.sh` / `guard.yaml`) stay distinct (no name collision);
- deterministic + sorted, byte-stable serialization, and write→read round-trip;
- `--frozen` verification reports the **exact** changed path (top-level and nested-in-a-directory), and detects added / removed / combined drift;
- `readLock` returns null when absent but **throws** (fails closed) on a malformed / wrong-version lock.

12/12 lock tests pass; `tsc --noEmit` clean. Verified end-to-end via the real CLI: generate → `--frozen` clean (exit 0) → mutate a file → `--frozen` reports `changed`/`removed` and exits 1 → no-lock case errors with a clear hint (exit 1).

> Pre-existing failures in `mcp.test.ts`, `session/sync/config.test.ts`, `versions.test.ts` are environment-dependent (keychain / R2 config / real launch-binary probing) and are byte-identical to `origin/main` — untouched by this PR.

## Deferred follow-ups (explicit, from #337)
- **Org-level version pins** — enforce org policy on agent versions.
- **Resource signing** — signed bundles + signature verification on `--frozen`.