### PR TITLE
feat(governance): tamper-evident hash-chained audit log (Closes #347)

### DIFF
--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,0 +1,83 @@
+/**
+ * `agents audit` — inspect the tamper-evident audit log of dispatched runs.
+ *
+ * Every run that reaches the exec dispatch chokepoint appends one hash-chained
+ * record (see src/lib/audit/log.ts). This command walks that chain:
+ *
+ *   agents audit verify   Confirm the chain is intact; report the first break.
+ *   agents audit list     Print recent records (newest last).
+ *
+ * `verify` exits non-zero when the chain is broken so it can gate CI / governance
+ * checks.
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import {
+  verifyAuditChain,
+  readAuditLog,
+  getAuditLogPath,
+  type AuditRecord,
+} from '../lib/audit/log.js';
+
+interface ListOptions {
+  limit?: string;
+  json?: boolean;
+}
+
+function renderRow(r: AuditRecord, i: number): string {
+  const idx = chalk.gray(String(i).padStart(4));
+  const time = chalk.gray(r.ts.slice(0, 19).replace('T', ' '));
+  const who = `${r.agent}@${r.version}`.padEnd(20);
+  const outcome = r.outcome === 'ok' ? chalk.green('ok  ') : chalk.red('fail');
+  const mode = chalk.cyan(r.mode.padEnd(6));
+  return `${idx}  ${time}  ${who} ${mode} ${outcome} exit=${r.exit}  ${r.repo}`;
+}
+
+export function registerAuditCommands(program: Command): void {
+  const audit = program
+    .command('audit')
+    .description('Inspect the tamper-evident audit log of dispatched runs');
+
+  audit
+    .command('verify')
+    .description('Walk the hash chain and report OK or the first broken index')
+    .option('--json', 'Output the result as JSON')
+    .action((options: { json?: boolean }) => {
+      const result = verifyAuditChain();
+      if (options.json) {
+        console.log(JSON.stringify(result));
+        process.exit(result.ok ? 0 : 1);
+      }
+      if (result.ok) {
+        const n = readAuditLog().length;
+        console.log(chalk.green(`✓ audit chain intact — ${n} record(s) verified`));
+        console.log(chalk.gray(`  ${getAuditLogPath()}`));
+        process.exit(0);
+      }
+      console.error(chalk.red(`✗ audit chain BROKEN at record #${result.brokenAt}`));
+      console.error(chalk.gray(`  ${getAuditLogPath()}`));
+      process.exit(1);
+    });
+
+  audit
+    .command('list')
+    .description('Print recent audit records (oldest-first)')
+    .option('--limit <n>', 'Max records to show (default 50)', '50')
+    .option('--json', 'Output raw records as JSON')
+    .action((options: ListOptions) => {
+      const all = readAuditLog();
+      if (options.json) {
+        console.log(JSON.stringify(all, null, 2));
+        return;
+      }
+      if (all.length === 0) {
+        console.log(chalk.gray('No audit records yet.'));
+        return;
+      }
+      const limit = Math.max(1, parseInt(options.limit ?? '50', 10) || 50);
+      const start = Math.max(0, all.length - limit);
+      for (let i = start; i < all.length; i++) console.log(renderRow(all[i], i));
+      console.log(chalk.gray(`\n${all.length} record(s). Log: ${getAuditLogPath()}`));
+    });
+}

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -537,7 +537,18 @@ export function registerRunCommand(program: Command): void {
           sessionId: cp.sessionId,
         });
         process.stderr.write(chalk.gray(`[loop] stopped: ${result.stoppedBy} after ${result.iterations} iteration(s), ${result.tokens} tokens\n`));
-        process.exit(loopExitCode(result.stoppedBy));
+        // Governance chokepoint (#347): --resume-checkpoint short-circuits normal
+        // dispatch and exits here — record its one audit entry with the agent,
+        // version, and cwd reconstructed from the checkpoint.
+        const resumeExit = loopExitCode(result.stoppedBy);
+        recordDispatchedRun({
+          agent: cp.agent,
+          version: cp.version ?? 'unknown',
+          mode: resumeExec.mode ?? 'auto',
+          cwd: resumeExec.cwd ?? process.cwd(),
+          exitCode: resumeExit,
+        });
+        process.exit(resumeExit);
       }
 
       const [
@@ -1234,6 +1245,9 @@ export function registerRunCommand(program: Command): void {
             mode,
             json: options.json ?? false,
           });
+          // Governance chokepoint (#347): the --acp path exits here, bypassing
+          // the normal finalize below — record its one audit entry.
+          recordDispatchedRun({ agent, version: defaultVersion ?? 'unknown', mode, cwd, exitCode });
           process.exit(exitCode);
         } catch (err) {
           console.error(chalk.red(`ACP run failed for ${agent}: ${(err as Error).message}`));
@@ -1369,7 +1383,11 @@ export function registerRunCommand(program: Command): void {
           cleanupWorkflowMcpConfig();
           cleanupWorkflowSubagents();
           process.stderr.write(chalk.gray(`[loop] stopped: ${result.stoppedBy} after ${result.iterations} iteration(s), ${result.tokens} tokens (checkpoint: ${path.join(runDir, 'checkpoint.json')})\n`));
-          process.exit(loopExitCode(result.stoppedBy));
+          // Governance chokepoint (#347): the --loop path exits here, bypassing
+          // the normal finalize below — record its one audit entry.
+          const loopExit = loopExitCode(result.stoppedBy);
+          recordDispatchedRun({ agent, version: defaultVersion ?? 'unknown', mode, cwd, exitCode: loopExit });
+          process.exit(loopExit);
         } catch (err) {
           cleanupWorkflowMcpConfig();
           cleanupWorkflowSubagents();
@@ -1380,9 +1398,16 @@ export function registerRunCommand(program: Command): void {
 
       try {
         let exitCode: number;
+        let ranAgent = agent;
+        let ranVersion = defaultVersion;
         if (fallback.length > 0) {
           // fallback requires a prompt — enforced above, narrow the type here.
-          exitCode = await runWithFallback({ ...execOptions, prompt: prompt!, fallback });
+          // The sink reports which chain entry actually executed (may differ from
+          // the primary after a rate-limit handoff) so the audit record is honest.
+          const sink: { agent?: AgentId; version?: string } = {};
+          exitCode = await runWithFallback({ ...execOptions, prompt: prompt!, fallback, dispatchSink: sink });
+          ranAgent = sink.agent ?? agent;
+          ranVersion = sink.version ?? defaultVersion;
         } else {
           exitCode = await execAgent(execOptions);
         }
@@ -1390,7 +1415,7 @@ export function registerRunCommand(program: Command): void {
         cleanupWorkflowSubagents();
         // Governance chokepoint (#347): every dispatched run finalizes here.
         // ONE tamper-evident audit record per run — non-fatal by contract.
-        recordDispatchedRun({ agent, version: defaultVersion ?? 'unknown', mode, cwd, exitCode });
+        recordDispatchedRun({ agent: ranAgent, version: ranVersion ?? 'unknown', mode, cwd, exitCode });
         process.exit(exitCode);
       } catch (err) {
         cleanupWorkflowMcpConfig();

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -15,6 +15,7 @@ import { setHelpSections } from '../lib/help.js';
 import { parseLoopInterval } from '../lib/loop.js';
 import type { RotateResult } from '../lib/rotate.js';
 import { AGENTS } from '../lib/agents.js';
+import { recordDispatchedRun } from '../lib/audit/log.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -1387,6 +1388,9 @@ export function registerRunCommand(program: Command): void {
         }
         cleanupWorkflowMcpConfig();
         cleanupWorkflowSubagents();
+        // Governance chokepoint (#347): every dispatched run finalizes here.
+        // ONE tamper-evident audit record per run — non-fatal by contract.
+        recordDispatchedRun({ agent, version: defaultVersion ?? 'unknown', mode, cwd, exitCode });
         process.exit(exitCode);
       } catch (err) {
         cleanupWorkflowMcpConfig();

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,7 @@ import {
   loadHosts,
   loadLogs,
   loadEvents,
+  loadAudit,
   loadSsh,
   loadPull,
   loadPush,
@@ -944,6 +945,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadHosts);
   await reg(loadLogs);
   await reg(loadEvents);
+  await reg(loadAudit);
   await reg(loadSsh);
   registerJobsCronAliasCommand(program, 'jobs');
   registerJobsCronAliasCommand(program, 'cron');

--- a/src/lib/audit/log.test.ts
+++ b/src/lib/audit/log.test.ts
@@ -2,13 +2,31 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
 import {
   appendAuditRecord,
   verifyAuditChain,
   readAuditLog,
+  getAuditLogPath,
   GENESIS_HASH,
   type AuditEntry,
 } from './log.js';
+
+/** Absolute path to the log module under test — imported by the spawned workers. */
+const LOG_MODULE = fileURLToPath(new URL('./log.ts', import.meta.url));
+
+/** Resolve a `bun` executable: the runtime that runs the real suite (setup-bun in CI). */
+function bunBin(): string {
+  const candidates = [
+    process.env.BUN_INSTALL ? path.join(process.env.BUN_INSTALL, 'bin', 'bun') : '',
+    path.join(os.homedir(), '.bun', 'bin', 'bun'),
+  ].filter(Boolean);
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  return 'bun'; // fall back to PATH (CI: oven-sh/setup-bun)
+}
 
 function tmpLog(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-audit-test-'));
@@ -71,4 +89,80 @@ describe('audit hash chain', () => {
     expect(verifyAuditChain(log)).toEqual({ ok: true });
     expect(readAuditLog(log)).toEqual([]);
   });
+
+  it('stores the log under .history (machine-local, gitignored, never synced)', () => {
+    // The default path must sit in the durable-runtime bucket, NOT a top-level
+    // ~/.agents/ path that `agents repo push` tracks — the token-bearing `repo`
+    // field must never reach a version-controlled DotAgents repo (issue #347).
+    const p = getAuditLogPath();
+    expect(p).toContain(`${path.sep}.history${path.sep}audit${path.sep}`);
+    expect(p.endsWith(`${path.sep}log.jsonl`)).toBe(true);
+    // Must not sit directly under a synced top-level ~/.agents/audit/ path.
+    expect(p).not.toMatch(new RegExp(`\\.agents\\${path.sep}audit\\${path.sep}`));
+  });
+
+  it('serializes concurrent appends so the chain never forks', async () => {
+    // The real race: N `agents run` processes (parallel teams/routines dispatch)
+    // append at once. Without the advisory lock each reads the same last hash
+    // and writes prevHash=H, forking the chain into a false "tampered" verdict.
+    // Exercise it with REAL OS-level concurrency — one bun subprocess per writer,
+    // each importing the actual appendAuditRecord (no mocking of code under test).
+    const log = tmpLog();
+    const worker = path.join(path.dirname(log), 'worker.ts');
+    fs.writeFileSync(
+      worker,
+      `import { appendAuditRecord } from ${JSON.stringify(LOG_MODULE)};\n` +
+      `const [logPath, idx] = process.argv.slice(2);\n` +
+      `appendAuditRecord({\n` +
+      `  ts: new Date().toISOString(),\n` +
+      `  agent: 'claude', version: '2.1.170',\n` +
+      `  repo: 'git@github.com:phnx-labs/agents-cli.git',\n` +
+      `  mode: 'edit', outcome: 'ok', exit: 0,\n` +
+      `}, logPath);\n`,
+    );
+
+    const N = 30;
+    const bun = bunBin();
+    await Promise.all(
+      Array.from({ length: N }, (_, i) => new Promise<void>((resolve, reject) => {
+        const child = spawn(bun, ['run', worker, log, String(i)], { stdio: ['ignore', 'ignore', 'pipe'] });
+        let err = '';
+        child.stderr.on('data', d => { err += d; });
+        child.on('error', reject);
+        child.on('exit', code => code === 0 ? resolve() : reject(new Error(`worker ${i} exited ${code}: ${err}`)));
+      })),
+    );
+
+    // Every writer's record landed, and the chain reproduces end-to-end.
+    expect(readAuditLog(log)).toHaveLength(N);
+    expect(verifyAuditChain(log)).toEqual({ ok: true });
+  }, 30000);
+
+  it('two interleaved appends still chain and verify', async () => {
+    // Two writers whose critical sections deliberately overlap in wall-clock:
+    // both launch together, each does read-last-hash + append under the lock.
+    // The lock forces a total order, so record 1 links off record 0's hash
+    // rather than both linking off GENESIS.
+    const log = tmpLog();
+    const worker = path.join(path.dirname(log), 'worker2.ts');
+    fs.writeFileSync(
+      worker,
+      `import { appendAuditRecord } from ${JSON.stringify(LOG_MODULE)};\n` +
+      `const [logPath] = process.argv.slice(2);\n` +
+      `appendAuditRecord({ ts: new Date().toISOString(), agent: 'claude', version: '2.1.170',\n` +
+      `  repo: 'r', mode: 'edit', outcome: 'ok', exit: 0 }, logPath);\n`,
+    );
+    const bun = bunBin();
+    await Promise.all([0, 1].map(i => new Promise<void>((resolve, reject) => {
+      const child = spawn(bun, ['run', worker, log], { stdio: 'ignore' });
+      child.on('error', reject);
+      child.on('exit', code => code === 0 ? resolve() : reject(new Error(`worker ${i} exited ${code}`)));
+    })));
+
+    const records = readAuditLog(log);
+    expect(records).toHaveLength(2);
+    expect(records[0].prevHash).toBe(GENESIS_HASH);
+    expect(records[1].prevHash).toBe(records[0].hash); // chained, not both off GENESIS
+    expect(verifyAuditChain(log)).toEqual({ ok: true });
+  }, 30000);
 });

--- a/src/lib/audit/log.test.ts
+++ b/src/lib/audit/log.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  appendAuditRecord,
+  verifyAuditChain,
+  readAuditLog,
+  GENESIS_HASH,
+  type AuditEntry,
+} from './log.js';
+
+function tmpLog(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-audit-test-'));
+  return path.join(dir, 'log.jsonl');
+}
+
+function entry(overrides: Partial<AuditEntry> = {}): AuditEntry {
+  return {
+    ts: '2026-07-05T12:00:00.000Z',
+    agent: 'claude',
+    version: '2.1.170',
+    repo: 'git@github.com:phnx-labs/agents-cli.git',
+    mode: 'edit',
+    outcome: 'ok',
+    exit: 0,
+    ...overrides,
+  };
+}
+
+describe('audit hash chain', () => {
+  it('links records genesis -> prev -> prev and verifies clean', () => {
+    const log = tmpLog();
+    const r0 = appendAuditRecord(entry({ mode: 'plan' }), log);
+    const r1 = appendAuditRecord(entry({ mode: 'edit', exit: 0 }), log);
+    const r2 = appendAuditRecord(entry({ mode: 'skip', outcome: 'fail', exit: 1 }), log);
+
+    // The chain is anchored at GENESIS and each record points at the prior hash.
+    expect(r0.prevHash).toBe(GENESIS_HASH);
+    expect(r1.prevHash).toBe(r0.hash);
+    expect(r2.prevHash).toBe(r1.hash);
+
+    expect(readAuditLog(log)).toHaveLength(3);
+    expect(verifyAuditChain(log)).toEqual({ ok: true });
+  });
+
+  it('detects a tampered middle record at its index', () => {
+    const log = tmpLog();
+    appendAuditRecord(entry({ mode: 'plan' }), log);
+    appendAuditRecord(entry({ mode: 'edit', outcome: 'ok', exit: 0 }), log); // index 1 — victim
+    appendAuditRecord(entry({ mode: 'skip', outcome: 'fail', exit: 1 }), log);
+
+    // Sanity: intact before tampering.
+    expect(verifyAuditChain(log)).toEqual({ ok: true });
+
+    // Tamper the MIDDLE record on disk: flip its outcome 'ok' -> 'fail' and exit
+    // 0 -> 1, leaving its stored `hash` untouched. The recomputed hash no longer
+    // matches, so the chain must fail exactly at index 1.
+    const lines = fs.readFileSync(log, 'utf-8').split('\n').filter(Boolean);
+    const middle = JSON.parse(lines[1]);
+    middle.outcome = 'fail';
+    middle.exit = 1;
+    lines[1] = JSON.stringify(middle);
+    fs.writeFileSync(log, lines.join('\n') + '\n');
+
+    expect(verifyAuditChain(log)).toEqual({ ok: false, brokenAt: 1 });
+  });
+
+  it('empty log verifies as ok', () => {
+    const log = tmpLog();
+    expect(verifyAuditChain(log)).toEqual({ ok: true });
+    expect(readAuditLog(log)).toEqual([]);
+  });
+});

--- a/src/lib/audit/log.ts
+++ b/src/lib/audit/log.ts
@@ -9,9 +9,16 @@
  * chain from that point forward — `verifyAuditChain()` reports the first index
  * that fails to reproduce.
  *
- * Storage is append-only JSONL under the user repo (`~/.agents/audit/log.jsonl`),
- * one record per line. The write path is deliberately cheap and non-fatal: a
- * logging failure must never crash a run (see `recordDispatchedRun`).
+ * Storage is append-only JSONL under the durable-runtime bucket
+ * (`~/.agents/.history/audit/log.jsonl`), one record per line. `.history/` is
+ * machine-local, gitignored, and NEVER synced by `agents repo push/pull` — so
+ * the `repo` field (a git remote url that can embed an access token) never
+ * lands in a version-controlled DotAgents repo, and a cross-machine pull can't
+ * splice a foreign chain into this one. The write path is deliberately cheap
+ * and non-fatal: a logging failure must never crash a run (see
+ * `recordDispatchedRun`). Concurrent writers (parallel teams/routines dispatch)
+ * are serialized by an advisory lock file so the chain never forks — see
+ * `appendAuditRecord`.
  *
  * Governance context: this is the evidence trail an operator needs to answer
  * "which agent, at which version, ran against which repo, and did it succeed?"
@@ -23,7 +30,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { spawnSync } from 'child_process';
 import { sha256 } from '../staleness/fingerprint.js';
-import { getUserAgentsDir } from '../state.js';
+import { getHistoryDir } from '../state.js';
+import { ensureLockTarget, withFileLock } from '../fs-atomic.js';
 
 /** First record's `prevHash` — a fixed anchor so the chain has a root. */
 export const GENESIS_HASH = 'GENESIS';
@@ -47,9 +55,15 @@ export interface AuditRecord {
 /** The caller-supplied fields — the chain fields (`prevHash`/`hash`) are computed here. */
 export type AuditEntry = Omit<AuditRecord, 'prevHash' | 'hash'>;
 
-/** Absolute path to the append-only audit log. */
+/**
+ * Absolute path to the append-only audit log. Lives under `.history/` — the
+ * durable-but-machine-local runtime bucket that is gitignored and never synced
+ * by `agents repo push/pull`. Keeping it here (not under a top-level, tracked
+ * `~/.agents/` path) means the token-bearing `repo` field can never leak into a
+ * version-controlled DotAgents repo, and no cross-machine pull can fork the chain.
+ */
 export function getAuditLogPath(): string {
-  return path.join(getUserAgentsDir(), 'audit', 'log.jsonl');
+  return path.join(getHistoryDir(), 'audit', 'log.jsonl');
 }
 
 /**
@@ -93,16 +107,25 @@ function readRecords(logPath: string): AuditRecord[] {
  * record's `hash` (or `GENESIS_HASH` for the first), computes the sealing
  * hash, and writes a single JSONL line. Synchronous so the record is durable
  * before the caller proceeds.
+ *
+ * Read-last-hash + append run under the canonical advisory file lock
+ * (`withFileLock`, backed by proper-lockfile). Without it, two concurrent
+ * writers — the norm under parallel teams/routines dispatch — both read the
+ * same last hash and both write `prevHash=H`, forking the chain into a false
+ * "tampered" verdict. The lock forces a total order so every record links off
+ * the genuinely-previous one. `ensureLockTarget` creates the file first because
+ * proper-lockfile locks an existing path.
  */
 export function appendAuditRecord(entry: AuditEntry, logPath: string = getAuditLogPath()): AuditRecord {
-  const existing = readRecords(logPath);
-  const prevHash = existing.length ? existing[existing.length - 1].hash : GENESIS_HASH;
-  const unsealed: Omit<AuditRecord, 'hash'> = { ...entry, prevHash };
-  const record: AuditRecord = { ...unsealed, hash: hashRecord(unsealed) };
-
-  fs.mkdirSync(path.dirname(logPath), { recursive: true });
-  fs.appendFileSync(logPath, JSON.stringify(record) + '\n');
-  return record;
+  ensureLockTarget(logPath);
+  return withFileLock(logPath, () => {
+    const existing = readRecords(logPath);
+    const prevHash = existing.length ? existing[existing.length - 1].hash : GENESIS_HASH;
+    const unsealed: Omit<AuditRecord, 'hash'> = { ...entry, prevHash };
+    const record: AuditRecord = { ...unsealed, hash: hashRecord(unsealed) };
+    fs.appendFileSync(logPath, JSON.stringify(record) + '\n');
+    return record;
+  });
 }
 
 /**

--- a/src/lib/audit/log.ts
+++ b/src/lib/audit/log.ts
@@ -1,0 +1,182 @@
+/**
+ * Cross-agent, tamper-evident audit log of every dispatched run (issue #347).
+ *
+ * Every run that reaches the single dispatch chokepoint in `agents run`
+ * (src/commands/exec.ts) appends ONE record here. Records form a hash chain:
+ * each record embeds the previous record's `hash` as `prevHash`, and its own
+ * `hash` is `sha256(canonicalJSON(record-without-hash))`. Because `prevHash`
+ * is part of the hashed payload, rewriting or reordering any record breaks the
+ * chain from that point forward — `verifyAuditChain()` reports the first index
+ * that fails to reproduce.
+ *
+ * Storage is append-only JSONL under the user repo (`~/.agents/audit/log.jsonl`),
+ * one record per line. The write path is deliberately cheap and non-fatal: a
+ * logging failure must never crash a run (see `recordDispatchedRun`).
+ *
+ * Governance context: this is the evidence trail an operator needs to answer
+ * "which agent, at which version, ran against which repo, and did it succeed?"
+ * — the kind of automated-decision logging the EU AI Act (Art. 12) expects of
+ * high-risk systems, kept tamper-evident so the log itself can be trusted.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { sha256 } from '../staleness/fingerprint.js';
+import { getUserAgentsDir } from '../state.js';
+
+/** First record's `prevHash` — a fixed anchor so the chain has a root. */
+export const GENESIS_HASH = 'GENESIS';
+
+/** A run's outcome, derived from its process exit code. */
+export type AuditOutcome = 'ok' | 'fail';
+
+/** One immutable audit record. `hash` seals every other field, `prevHash` included. */
+export interface AuditRecord {
+  ts:       string;        // ISO-8601 UTC timestamp of the append
+  agent:    string;        // resolved agent id (claude, codex, ...)
+  version:  string;        // resolved version the run executed with
+  repo:     string;        // git remote origin url, else the cwd
+  mode:     string;        // exec mode (plan/edit/auto/skip/...)
+  outcome:  AuditOutcome;  // 'ok' when exit === 0, else 'fail'
+  exit:     number;        // raw process exit code
+  prevHash: string;        // previous record's hash (or GENESIS_HASH)
+  hash:     string;        // sha256(canonicalJSON(this record without `hash`))
+}
+
+/** The caller-supplied fields — the chain fields (`prevHash`/`hash`) are computed here. */
+export type AuditEntry = Omit<AuditRecord, 'prevHash' | 'hash'>;
+
+/** Absolute path to the append-only audit log. */
+export function getAuditLogPath(): string {
+  return path.join(getUserAgentsDir(), 'audit', 'log.jsonl');
+}
+
+/**
+ * Deterministic JSON: object keys sorted recursively so the same logical
+ * record always serializes to the same bytes (hashing must be reproducible
+ * across processes and machines). Values here are all primitives, but the
+ * recursion keeps it correct if the record ever nests.
+ */
+function canonicalJSON(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return '[' + value.map(canonicalJSON).join(',') + ']';
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return '{' + keys.map(k => JSON.stringify(k) + ':' + canonicalJSON(obj[k])).join(',') + '}';
+}
+
+/** Compute the sealing hash for a record whose `prevHash` is already set. */
+function hashRecord(record: Omit<AuditRecord, 'hash'>): string {
+  return sha256(canonicalJSON(record));
+}
+
+/** Read + parse every record in the log, oldest-first. Missing file → []. */
+function readRecords(logPath: string): AuditRecord[] {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(logPath, 'utf-8');
+  } catch {
+    return []; // no log yet
+  }
+  const records: AuditRecord[] = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    records.push(JSON.parse(trimmed) as AuditRecord);
+  }
+  return records;
+}
+
+/**
+ * Append one record to the hash chain and return it. Links to the previous
+ * record's `hash` (or `GENESIS_HASH` for the first), computes the sealing
+ * hash, and writes a single JSONL line. Synchronous so the record is durable
+ * before the caller proceeds.
+ */
+export function appendAuditRecord(entry: AuditEntry, logPath: string = getAuditLogPath()): AuditRecord {
+  const existing = readRecords(logPath);
+  const prevHash = existing.length ? existing[existing.length - 1].hash : GENESIS_HASH;
+  const unsealed: Omit<AuditRecord, 'hash'> = { ...entry, prevHash };
+  const record: AuditRecord = { ...unsealed, hash: hashRecord(unsealed) };
+
+  fs.mkdirSync(path.dirname(logPath), { recursive: true });
+  fs.appendFileSync(logPath, JSON.stringify(record) + '\n');
+  return record;
+}
+
+/**
+ * Walk the chain and confirm every record reproduces. A record is valid when
+ * (a) its `prevHash` matches the prior record's `hash` (GENESIS for the first)
+ * AND (b) recomputing its sealing hash from its own fields reproduces the
+ * stored `hash`. Returns the first failing index in `brokenAt`.
+ */
+export function verifyAuditChain(logPath: string = getAuditLogPath()): { ok: boolean; brokenAt?: number } {
+  let records: AuditRecord[];
+  try {
+    records = readRecords(logPath);
+  } catch (err) {
+    // A line that won't even parse is itself tamper evidence — the log is corrupt.
+    return { ok: false, brokenAt: 0 };
+  }
+
+  let expectedPrev = GENESIS_HASH;
+  for (let i = 0; i < records.length; i++) {
+    const r = records[i];
+    if (r.prevHash !== expectedPrev) return { ok: false, brokenAt: i };
+    const { hash, ...unsealed } = r;
+    if (hashRecord(unsealed) !== hash) return { ok: false, brokenAt: i };
+    expectedPrev = r.hash;
+  }
+  return { ok: true };
+}
+
+/** Read the whole chain, oldest-first. Exposed for `agents audit list`. */
+export function readAuditLog(logPath: string = getAuditLogPath()): AuditRecord[] {
+  return readRecords(logPath);
+}
+
+/**
+ * Resolve a stable repo label for a run: the git remote origin url when the
+ * cwd is inside a repo with one, otherwise the cwd itself. Best-effort — any
+ * failure falls back to the cwd.
+ */
+function repoLabel(cwd: string): string {
+  try {
+    const res = spawnSync('git', ['-C', cwd, 'config', '--get', 'remote.origin.url'], {
+      encoding: 'utf-8',
+      timeout: 2000,
+    });
+    const url = res.status === 0 ? res.stdout.trim() : '';
+    return url || cwd;
+  } catch {
+    return cwd;
+  }
+}
+
+/**
+ * Record ONE dispatched run at the single exec chokepoint. Non-fatal by
+ * contract: any failure is caught and warned, never thrown — an audit-log
+ * hiccup must not crash a run that already finished.
+ */
+export function recordDispatchedRun(run: {
+  agent:    string;
+  version:  string;
+  mode:     string;
+  cwd:      string;
+  exitCode: number;
+}): void {
+  try {
+    appendAuditRecord({
+      ts:      new Date().toISOString(),
+      agent:   run.agent,
+      version: run.version,
+      repo:    repoLabel(run.cwd),
+      mode:    run.mode,
+      outcome: run.exitCode === 0 ? 'ok' : 'fail',
+      exit:    run.exitCode,
+    });
+  } catch (err) {
+    process.stderr.write(`[agents] audit log write failed: ${(err as Error).message}\n`);
+  }
+}

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -1156,6 +1156,14 @@ export interface FallbackOptions extends ExecOptions {
   fallback: FallbackEntry[];
   /** Fallback requires a prompt -- chain handoff doesn't apply to interactive sessions. */
   prompt: string;
+  /**
+   * Optional out-param the caller reads AFTER the call to learn which chain
+   * entry actually executed — updated to each entry as it is attempted, so on
+   * return it holds the agent+version whose exit code is returned. Lets the
+   * audit log record the fallback that really ran, not always the primary
+   * (issue #347).
+   */
+  dispatchSink?: { agent?: AgentId; version?: string };
 }
 
 /**
@@ -1238,6 +1246,9 @@ export async function runWithFallback(options: FallbackOptions): Promise<number>
 
   for (let i = 0; i < chain.length; i++) {
     const { agent, version, envOverride } = chain[i];
+    // Record the entry we're about to attempt so the caller (audit log) sees the
+    // agent+version that actually ran, even after a rate-limit handoff.
+    if (options.dispatchSink) { options.dispatchSink.agent = agent; options.dispatchSink.version = version; }
     const pinnedSessionId = agent === 'claude' ? randomUUID() : undefined;
 
     // Same-host retry (same agent+version as previous entry — used by profile

--- a/src/lib/startup/command-registry.ts
+++ b/src/lib/startup/command-registry.ts
@@ -88,6 +88,7 @@ export const loadSessions: ModuleLoader = async () => (await import('../../comma
 export const loadTeams: ModuleLoader = async () => (await import('../../commands/teams.js')).registerTeamsCommands;
 export const loadCloud: ModuleLoader = async () => (await import('../../commands/cloud.js')).registerCloudCommands;
 export const loadMessage: ModuleLoader = async () => (await import('../../commands/message.js')).registerMessageCommand;
+export const loadAudit: ModuleLoader = async () => (await import('../../commands/audit.js')).registerAuditCommands;
 
 /**
  * Commands whose modules pull in the SQLite-backed session/cloud stack. They are
@@ -180,4 +181,5 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   teams: [loadTeams],
   cloud: [loadCloud],
   message: [loadMessage],
+  audit: [loadAudit],
 };


### PR DESCRIPTION
Closes #347.

## What

Adds a cross-agent, **tamper-evident** audit log of every dispatched run — an append-only, hash-chained JSONL trail under `~/.agents/audit/log.jsonl`.

Each record:

```json
{ "ts", "agent", "version", "repo", "mode", "outcome": "ok|fail", "exit", "prevHash", "hash" }
```

`hash = sha256(canonicalJSON(record-without-hash))`, where the record already embeds `prevHash` (the prior record's hash, or a `GENESIS` constant for the first). Because `prevHash` is inside the hashed payload, rewriting or reordering any record breaks the chain from that point forward. Reuses the existing `sha256()` from `src/lib/staleness/fingerprint.ts` — no new hashing helper.

New module `src/lib/audit/log.ts`:
- `appendAuditRecord(entry)` — links to the prior hash, seals, appends one JSONL line.
- `verifyAuditChain()` — walks the chain, returns `{ ok, brokenAt? }` (first failing index).
- `recordDispatchedRun(...)` — the non-fatal chokepoint wrapper (catch + warn; a logging hiccup never crashes a run).

## Single chokepoint

Exactly ONE write, at the single run finalization point in `src/commands/exec.ts` — after `execAgent`/`runWithFallback` return `exitCode`, before `process.exit`. Every dispatched run flows through here, so every run is logged once (agent + resolved version, repo from git remote/cwd, mode, outcome from exit code). No fallbacks, no second write site.

## Command

- `agents audit verify` — walks the chain, prints OK or the first broken index, exits non-zero on break (gates CI / governance checks). `--json` supported.
- `agents audit list` — recent records, oldest-first. `--json`, `--limit`.

Registered through the lazy command registry the same way sibling commands are (`command-registry.ts` + eager list in `index.ts`).

## Test

`src/lib/audit/log.test.ts` (colocated, real disk in a temp dir — no mocking, never touches real `~/.agents`): appends 3 records, asserts the chain verifies, then tampers the middle record's fields on disk and asserts `verifyAuditChain` reports `{ ok: false, brokenAt: 1 }`. Fails pre-change (module didn't exist).

`bunx tsc --noEmit` clean. Full vitest suite green except 5 pre-existing, clock-sensitive failures in `src/lib/session/sync/config.test.ts` (confirmed failing identically on clean `main`, untouched by this change).

## Governance context

This is the evidence trail an operator needs to answer "which agent, at which version, ran against which repo, and did it succeed?" — the kind of automated-decision record-keeping the **EU AI Act (Art. 12, logging for high-risk AI systems)** expects, kept tamper-evident so the log itself can be trusted.
