### PR TITLE
feat(browser): self-healing refs + coordinate click (Closes #335)

### DIFF
--- a/src/commands/browser.ts
+++ b/src/commands/browser.ts
@@ -1271,6 +1271,19 @@ function registerTaskCommands(browser: Command): void {
         process.exit(1);
       }
 
+      // Warn (on stderr, so it never corrupts --json stdout) when the a11y tree
+      // exposed nothing to click — the caller should fall back to a screenshot
+      // plus coordinate click.
+      const count = response.nodes?.length ?? 0;
+      if (count === 0) {
+        const scope = opts.all ? 'elements' : 'interactive elements';
+        console.error(
+          `No ${scope} found. The page may render its UI on a canvas or in a custom widget ` +
+            `the accessibility tree doesn't expose. Take a screenshot ` +
+            `(\`browser screenshot\`) and click by position with \`browser click --at X,Y\`.`
+        );
+      }
+
       if (opts.json) {
         console.log(JSON.stringify(response.nodes ?? [], null, 2));
         return;
@@ -1280,17 +1293,40 @@ function registerTaskCommands(browser: Command): void {
     });
 
   browser
-    .command('click <ref>')
-    .description('Click an element by ref')
+    .command('click [ref]')
+    .description('Click an element by ref, or raw coordinates with --at X,Y')
     .option(TASK_OPTION_FLAG, TASK_OPTION_DESC)
     .option('-t, --tab <tabId>', 'Tab ID (defaults to current)')
-    .action(async (ref: string, opts) => {
+    .option('--at <x,y>', 'Click viewport coordinates (e.g. --at 320,540), bypassing ref resolution')
+    .action(async (ref: string | undefined, opts) => {
       const task = resolveTaskName(opts);
+
+      let requestExtra: { ref?: number; atX?: number; atY?: number };
+      if (opts.at !== undefined) {
+        const parts = String(opts.at).split(',').map((s) => Number(s.trim()));
+        if (parts.length !== 2 || parts.some((n) => !Number.isFinite(n))) {
+          console.error(`Invalid --at value "${opts.at}". Expected X,Y (e.g. --at 320,540).`);
+          process.exit(1);
+        }
+        requestExtra = { atX: parts[0], atY: parts[1] };
+      } else if (ref !== undefined) {
+        const parsed = parseInt(ref, 10);
+        if (!Number.isFinite(parsed)) {
+          console.error(`Invalid ref "${ref}". Pass an integer ref or use --at X,Y.`);
+          process.exit(1);
+        }
+        requestExtra = { ref: parsed };
+      } else {
+        console.error('Provide a ref (e.g. `click 5`) or coordinates (`click --at X,Y`).');
+        process.exit(1);
+        return;
+      }
+
       const response = await sendIPCRequest({
         action: 'click',
         task,
         tabId: opts.tab,
-        ref: parseInt(ref, 10),
+        ...requestExtra,
       });
 
       if (!response.ok) {
@@ -1298,7 +1334,7 @@ function registerTaskCommands(browser: Command): void {
         process.exit(1);
       }
 
-      console.log('Clicked');
+      console.log(response.message ? `Clicked (${response.message})` : 'Clicked');
     });
 
   browser

--- a/src/lib/browser/ipc.ts
+++ b/src/lib/browser/ipc.ts
@@ -363,10 +363,24 @@ export class BrowserIPCServer {
       }
 
       case 'click': {
-        if (!request.task || request.ref === undefined) {
-          return { ok: false, error: 'Task and ref required' };
+        if (!request.task) {
+          return { ok: false, error: 'Task required' };
         }
-        await this.service.click(request.task, request.ref, request.tabId);
+        // Coordinate click (`--at X,Y`) bypasses ref resolution entirely.
+        if (request.atX !== undefined && request.atY !== undefined) {
+          await this.service.clickAt(request.task, request.atX, request.atY, request.tabId);
+          return { ok: true };
+        }
+        if (request.ref === undefined) {
+          return { ok: false, error: 'Task and ref (or --at X,Y) required' };
+        }
+        const { healed } = await this.service.click(request.task, request.ref, request.tabId);
+        if (healed) {
+          return {
+            ok: true,
+            message: `self-healed ref ${healed.from} -> ${healed.to} (${healed.role} "${healed.name}")`,
+          };
+        }
         return { ok: true };
       }
 

--- a/src/lib/browser/refs.test.ts
+++ b/src/lib/browser/refs.test.ts
@@ -49,6 +49,70 @@ describe('healRef', () => {
   });
 });
 
+describe('healRef — duplicate (role,name) disambiguation', () => {
+  it('tie-breaks on cached attrs so the right twin wins even when farther', () => {
+    // Cached ref 5 was the DISABLED "Submit". A (role,name)-only heal would
+    // grab whichever Submit it hit first — here the nearer, ENABLED one at
+    // ref 4 — and silently click the wrong element.
+    const cached = { ref: 5, role: 'button', name: 'Submit', attrs: ['disabled'] };
+    const fresh = new Map<number, RefNode>([
+      [4, { ref: 4, role: 'button', name: 'Submit', attrs: [], backendNodeId: 404 }],
+      [9, { ref: 9, role: 'button', name: 'Submit', attrs: ['disabled'], backendNodeId: 909 }],
+    ]);
+    expect(healRef(cached, fresh)).toBe(9);
+  });
+
+  it('tie-breaks on positional proximity when attrs are identical', () => {
+    // Repeated list-row action: two identical "Delete" buttons. The one
+    // nearest the original ref index is the intended twin.
+    const cached = { ref: 5, role: 'button', name: 'Delete', attrs: [] };
+    const fresh = new Map<number, RefNode>([
+      [4, { ref: 4, role: 'button', name: 'Delete', attrs: [], backendNodeId: 404 }],
+      [9, { ref: 9, role: 'button', name: 'Delete', attrs: [], backendNodeId: 909 }],
+    ]);
+    expect(healRef(cached, fresh)).toBe(4);
+  });
+
+  it('attrs outrank proximity — the exact-state twin wins over the nearer one', () => {
+    const cached = { ref: 2, role: 'checkbox', name: 'Agree', attrs: ['checked'] };
+    const fresh = new Map<number, RefNode>([
+      [1, { ref: 1, role: 'checkbox', name: 'Agree', attrs: [], backendNodeId: 11 }], // nearer, wrong state
+      [8, { ref: 8, role: 'checkbox', name: 'Agree', attrs: ['checked'], backendNodeId: 88 }], // farther, exact
+    ]);
+    expect(healRef(cached, fresh)).toBe(8);
+  });
+});
+
+describe('drift across a refs-once-then-many-clicks sequence', () => {
+  it('heals on EVERY click because the cached listing is never clobbered', () => {
+    // `browser refs` (interactive numbering): Submit is ref 5. This snapshot is
+    // owned by refs() — click()/type() read it and must never overwrite it.
+    const listing = new Map<number, RefNode>([
+      [4, node(4, 'link', 'Home', 104)],
+      [5, node(5, 'button', 'Submit', 105)],
+    ]);
+    const snapshot = describeRefs(listing);
+
+    // The page re-rendered: Submit drifted to ref 8; ref 5 is now a different
+    // button. Both clicks rebuild against this same fresh tree.
+    const afterRerender = new Map<number, RefNode>([
+      [5, node(5, 'button', 'Cancel', 205)],
+      [8, node(8, 'button', 'Submit', 208)],
+    ]);
+
+    const cachedForRef5 = () => snapshot.find((d) => d.ref === 5)!;
+
+    // First click heals 5 -> 8.
+    expect(healRef(cachedForRef5(), afterRerender)).toBe(8);
+    // Second click reads the SAME untouched snapshot and heals 5 -> 8 again.
+    // The old bug re-cached descriptors from the post-click map, so ref 5's
+    // cached descriptor became "Cancel" and the second click stopped healing
+    // and silently hit the wrong element.
+    expect(cachedForRef5()).toMatchObject({ role: 'button', name: 'Submit' });
+    expect(healRef(cachedForRef5(), afterRerender)).toBe(8);
+  });
+});
+
 describe('describeRefs', () => {
   it('captures the stable (role,name,attrs) identity without the backendNodeId', () => {
     const nodeMap = new Map<number, RefNode>([

--- a/src/lib/browser/refs.test.ts
+++ b/src/lib/browser/refs.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { describeRefs, healRef, type RefNode } from './refs.js';
+
+function node(ref: number, role: string, name: string, backendNodeId?: number): RefNode {
+  return { ref, role, name, attrs: [], backendNodeId };
+}
+
+describe('healRef', () => {
+  it('re-resolves to the new ref when the integer drifted but (role,name) is stable', () => {
+    // Cached from an earlier getRefs: ref 1 was the Submit button.
+    const cached = { ref: 1, role: 'button', name: 'Submit', attrs: [] };
+
+    // Fresh tree (e.g. after a re-render / different interactive filter): the
+    // same button now sits at ref 3, and ref 1 is a different element.
+    const fresh = new Map<number, RefNode>([
+      [1, node(1, 'heading', 'Welcome', 101)],
+      [2, node(2, 'link', 'Home', 102)],
+      [3, node(3, 'button', 'Submit', 103)],
+    ]);
+
+    expect(healRef(cached, fresh)).toBe(3);
+  });
+
+  it('reports unhealable (null) when no node shares the cached role+name', () => {
+    const cached = { ref: 1, role: 'button', name: 'Submit', attrs: [] };
+    const fresh = new Map<number, RefNode>([
+      [1, node(1, 'button', 'Cancel', 201)],
+      [2, node(2, 'link', 'Submit', 202)], // same name, wrong role
+    ]);
+
+    expect(healRef(cached, fresh)).toBeNull();
+  });
+
+  it('prefers a DOM-backed match over a role+name match with no backendNodeId', () => {
+    const cached = { ref: 5, role: 'button', name: 'Save', attrs: [] };
+    const fresh = new Map<number, RefNode>([
+      [1, node(1, 'button', 'Save')], // no backendNodeId
+      [2, node(2, 'button', 'Save', 302)], // resolvable — should win
+    ]);
+
+    expect(healRef(cached, fresh)).toBe(2);
+  });
+
+  it('still heals to a role+name match that lacks a backendNodeId when that is all there is', () => {
+    const cached = { ref: 5, role: 'textbox', name: 'Email', attrs: [] };
+    const fresh = new Map<number, RefNode>([[7, node(7, 'textbox', 'Email')]]);
+
+    expect(healRef(cached, fresh)).toBe(7);
+  });
+});
+
+describe('describeRefs', () => {
+  it('captures the stable (role,name,attrs) identity without the backendNodeId', () => {
+    const nodeMap = new Map<number, RefNode>([
+      [1, { ref: 1, role: 'button', name: 'Submit', attrs: ['disabled'], backendNodeId: 42 }],
+    ]);
+
+    const descriptors = describeRefs(nodeMap);
+    expect(descriptors).toEqual([{ ref: 1, role: 'button', name: 'Submit', attrs: ['disabled'] }]);
+    // backendNodeId must not leak into the persisted descriptor.
+    expect('backendNodeId' in descriptors[0]).toBe(false);
+  });
+});

--- a/src/lib/browser/refs.ts
+++ b/src/lib/browser/refs.ts
@@ -38,9 +38,22 @@ export interface RefDescriptor {
   attrs: string[];
   /**
    * Best-effort CSS selector captured via DOM. Reserved for future
-   * selector-based healing; matching today is role+name only.
+   * selector-based healing; matching today is role+name+attrs+position.
    */
   selector?: string;
+}
+
+/**
+ * A cached ref listing for one tab: the stable descriptors plus the resolved
+ * {@link RefOpts} the listing was built with. A later `click`/`type` MUST
+ * rebuild its node map with these same opts, or the integer refs it looks up
+ * are numbered against a *different* accessibility filter than the one the
+ * user saw in `browser refs` — the drift that makes self-heal silently click
+ * the wrong element on the second click.
+ */
+export interface RefSnapshot {
+  descriptors: RefDescriptor[];
+  opts: { interactive: boolean; limit: number };
 }
 
 /** Snapshot the stable descriptor for every ref in a freshly-built node map. */
@@ -55,31 +68,70 @@ export function describeRefs(nodeMap: Map<number, RefNode>): RefDescriptor[] {
 
 /**
  * Re-resolve a stale ref against a freshly-built node map by matching the
- * cached (role, name) descriptor. Pure — no CDP, no DOM.
+ * cached descriptor. Pure — no CDP, no DOM.
  *
  * The integer ref assigned by {@link getRefs} is positional: it shifts whenever
  * the accessibility tree changes (navigation, re-render, or even a different
- * `interactive` filter). The descriptor's (role, name) pair is the stable
- * identity, so we scan the fresh map for the node that still carries it.
+ * `interactive` filter). The descriptor's (role, name) pair is the coarse
+ * identity, but a page can carry duplicate (role, name) elements — two "Submit"
+ * buttons, one action button per repeated list row. Matching on (role, name)
+ * alone would heal to whichever duplicate the fresh scan happens to hit first,
+ * which can be the wrong one. So among (role, name) matches we tie-break, in
+ * priority order:
+ *
+ *   1. **DOM-backed** — a candidate with a `backendNodeId` is resolvable to
+ *      coordinates; one without is unclickable, so healing to it is useless.
+ *   2. **Attribute similarity** — the cached `attrs` (disabled / checked /
+ *      selected / …) disambiguate otherwise-identical twins (the *disabled*
+ *      Submit vs the enabled one).
+ *   3. **Positional proximity** — the fresh ref closest to the original cached
+ *      ref index wins, so a repeated list-row action heals to its nearest
+ *      positional twin rather than jumping across the page.
  *
  * Returns the new integer ref, or `null` when no node with the same role+name
  * exists in the fresh map (unhealable — the element is genuinely gone).
  */
 export function healRef(
-  descriptor: Pick<RefDescriptor, 'role' | 'name'>,
+  descriptor: Pick<RefDescriptor, 'ref' | 'role' | 'name' | 'attrs'>,
   freshNodeMap: Map<number, RefNode>
 ): number | null {
-  const { role, name } = descriptor;
-  // Prefer a match that still has a DOM backing (resolvable to coordinates);
-  // fall back to a role+name match without one so we never fail a heal that a
-  // strict variant would have found.
-  let fallback: number | null = null;
+  const { ref, role, name, attrs } = descriptor;
+  const cachedAttrs = new Set(attrs);
+
+  // How well a candidate's attribute set matches the cached one: reward shared
+  // attrs, penalize both extras the candidate carries and cached attrs it is
+  // missing. Exact set equality scores highest; an all-attrs-empty comparison
+  // scores 0 for every candidate (so the tie-break falls through to proximity).
+  const attrScore = (node: RefNode): number => {
+    let shared = 0;
+    for (const a of node.attrs) if (cachedAttrs.has(a)) shared += 1;
+    const extra = node.attrs.length - shared;
+    const missing = cachedAttrs.size - shared;
+    return shared * 2 - extra - missing;
+  };
+
+  let best: RefNode | null = null;
+  let bestKey: [number, number, number] | null = null;
   for (const node of freshNodeMap.values()) {
     if (node.role !== role || node.name !== name) continue;
-    if (node.backendNodeId !== undefined) return node.ref;
-    if (fallback === null) fallback = node.ref;
+    // Lexicographic key, all "higher is better":
+    //   [ DOM-backed, attribute similarity, -distance-to-original-ref ].
+    const key: [number, number, number] = [
+      node.backendNodeId !== undefined ? 1 : 0,
+      attrScore(node),
+      -Math.abs(node.ref - ref),
+    ];
+    if (
+      bestKey === null ||
+      key[0] > bestKey[0] ||
+      (key[0] === bestKey[0] && key[1] > bestKey[1]) ||
+      (key[0] === bestKey[0] && key[1] === bestKey[1] && key[2] > bestKey[2])
+    ) {
+      best = node;
+      bestKey = key;
+    }
   }
-  return fallback;
+  return best ? best.ref : null;
 }
 
 const EDITOR_DETECT_FN = `(function() {
@@ -146,7 +198,11 @@ export async function getRefs(
   cdp: CDPClient,
   sessionId: string,
   opts: RefOpts = {}
-): Promise<{ refs: string; nodeMap: Map<number, RefNode> }> {
+): Promise<{
+  refs: string;
+  nodeMap: Map<number, RefNode>;
+  opts: { interactive: boolean; limit: number };
+}> {
   const { interactive = true, limit = 500, compact = false } = opts;
 
   const { nodes } = (await cdp.send(
@@ -206,7 +262,7 @@ export async function getRefs(
     lines.push(line);
   }
 
-  return { refs: lines.join('\n'), nodeMap };
+  return { refs: lines.join('\n'), nodeMap, opts: { interactive, limit } };
 }
 
 function truncate(s: string, max: number): string {

--- a/src/lib/browser/refs.ts
+++ b/src/lib/browser/refs.ts
@@ -24,6 +24,64 @@ export interface RefNode {
   editor?: string;
 }
 
+/**
+ * Stable, navigation-surviving identity for a ref. Unlike {@link RefNode}, this
+ * carries no `backendNodeId` (which goes stale the moment the DOM re-renders) —
+ * only the accessible descriptor a fresh `getRefs` can be re-matched against.
+ * Cached in per-task state so a later `click <ref>` can self-heal when the
+ * integer ref has drifted (see {@link healRef}).
+ */
+export interface RefDescriptor {
+  ref: number;
+  role: string;
+  name: string;
+  attrs: string[];
+  /**
+   * Best-effort CSS selector captured via DOM. Reserved for future
+   * selector-based healing; matching today is role+name only.
+   */
+  selector?: string;
+}
+
+/** Snapshot the stable descriptor for every ref in a freshly-built node map. */
+export function describeRefs(nodeMap: Map<number, RefNode>): RefDescriptor[] {
+  return Array.from(nodeMap.values()).map((n) => ({
+    ref: n.ref,
+    role: n.role,
+    name: n.name,
+    attrs: n.attrs.slice(),
+  }));
+}
+
+/**
+ * Re-resolve a stale ref against a freshly-built node map by matching the
+ * cached (role, name) descriptor. Pure — no CDP, no DOM.
+ *
+ * The integer ref assigned by {@link getRefs} is positional: it shifts whenever
+ * the accessibility tree changes (navigation, re-render, or even a different
+ * `interactive` filter). The descriptor's (role, name) pair is the stable
+ * identity, so we scan the fresh map for the node that still carries it.
+ *
+ * Returns the new integer ref, or `null` when no node with the same role+name
+ * exists in the fresh map (unhealable — the element is genuinely gone).
+ */
+export function healRef(
+  descriptor: Pick<RefDescriptor, 'role' | 'name'>,
+  freshNodeMap: Map<number, RefNode>
+): number | null {
+  const { role, name } = descriptor;
+  // Prefer a match that still has a DOM backing (resolvable to coordinates);
+  // fall back to a role+name match without one so we never fail a heal that a
+  // strict variant would have found.
+  let fallback: number | null = null;
+  for (const node of freshNodeMap.values()) {
+    if (node.role !== role || node.name !== name) continue;
+    if (node.backendNodeId !== undefined) return node.ref;
+    if (fallback === null) fallback = node.ref;
+  }
+  return fallback;
+}
+
 const EDITOR_DETECT_FN = `(function() {
   let el = this;
   for (let i = 0; i < 5; i++) {

--- a/src/lib/browser/service.ts
+++ b/src/lib/browser/service.ts
@@ -34,7 +34,7 @@ import {
   type BrowserProfile,
   type HistoricalTask,
 } from './types.js';
-import { getRefs, resolveRefToCoords, type RefOpts, type RefNode } from './refs.js';
+import { getRefs, resolveRefToCoords, describeRefs, healRef, type RefOpts, type RefNode } from './refs.js';
 import { clickAtCoords, hoverAtCoords, scrollAtCoords, typeText, pressKey, focusNode } from './input.js';
 import { typeEditorText } from './editor.js';
 import {
@@ -289,6 +289,14 @@ type TargetInfo = {
   url?: string;
   title?: string;
 };
+
+/** Describes a ref that was re-resolved from a drifted integer via its cached descriptor. */
+export interface HealInfo {
+  from: number;
+  to: number;
+  role: string;
+  name: string;
+}
 
 export class BrowserService {
   private static readonly SOURCE_PREFIX: Record<string, string> = {
@@ -1131,8 +1139,6 @@ export class BrowserService {
     return { recording: true, path: rec.outputPath, elapsedMs: Date.now() - rec.startedAt };
   }
 
-  private refsCache = new Map<string, { refs: string; nodeMap: Map<number, RefNode>; ts: number }>();
-
   async refs(
     taskId: string,
     tabHint?: string,
@@ -1146,10 +1152,21 @@ export class BrowserService {
     if (!target) throw new Error(`Tab ${shortId} not found`);
 
     const sessionId = await this.getSessionId(conn, target.targetId);
-    return getRefs(conn.cdp, sessionId, opts);
+    const result = await getRefs(conn.cdp, sessionId, opts);
+    // Snapshot the stable descriptors so a later click can self-heal a drifted
+    // ref. Persist to tasks.json — the cache must survive a daemon restart.
+    this.cacheRefDescriptors(task, shortId, result.nodeMap);
+    await this.saveTaskState(task.profile, conn.tasks);
+    return result;
   }
 
-  async click(taskId: string, ref: number, tabHint?: string): Promise<void> {
+  /** Record the last ref descriptors for a tab into persisted task state. */
+  private cacheRefDescriptors(task: Task, shortId: string, nodeMap: Map<number, RefNode>): void {
+    if (!task.refDescriptors) task.refDescriptors = {};
+    task.refDescriptors[shortId] = describeRefs(nodeMap);
+  }
+
+  async click(taskId: string, ref: number, tabHint?: string): Promise<{ healed?: HealInfo }> {
     const { conn, task } = await this.findTask(taskId);
     const shortId = tabHint ? await this.resolveTabHint(conn, task, tabHint) : this.resolveCurrentTab(task);
     const cdpTargetId = this.getCdpTargetId(task, shortId);
@@ -1158,7 +1175,68 @@ export class BrowserService {
 
     const sessionId = await this.getSessionId(conn, target.targetId);
     const { nodeMap } = await getRefs(conn.cdp, sessionId, { interactive: false, limit: 1000 });
-    const { x, y } = await resolveRefToCoords(conn.cdp, sessionId, nodeMap, ref);
+
+    // Self-healing: the integer ref is positional and drifts on re-render (or
+    // simply because `refs` numbers interactive-only nodes while this rebuild
+    // counts all of them). If we have a cached descriptor for this ref and the
+    // fresh node at that position no longer matches it, re-resolve by (role,
+    // name) BEFORE clicking the wrong element.
+    const cached = task.refDescriptors?.[shortId]?.find((d) => d.ref === ref);
+    let targetRef = ref;
+    let healed: HealInfo | undefined;
+
+    if (cached) {
+      const fresh = nodeMap.get(ref);
+      const stillMatches =
+        fresh !== undefined &&
+        fresh.role === cached.role &&
+        fresh.name === cached.name &&
+        fresh.backendNodeId !== undefined;
+      if (!stillMatches) {
+        const newRef = healRef(cached, nodeMap);
+        if (newRef === null) {
+          throw new Error(
+            `Ref ${ref} (${cached.role} "${cached.name}") could not be re-resolved: ` +
+              `no matching element on the current page. Re-run 'browser refs', or ` +
+              `click by position with 'browser click --at X,Y'.`
+          );
+        }
+        if (newRef !== ref) {
+          healed = { from: ref, to: newRef, role: cached.role, name: cached.name };
+          targetRef = newRef;
+          console.error(
+            `[browser] self-healed ref ${ref} -> ${newRef} (${cached.role} "${cached.name}") — ` +
+              `cached descriptor re-matched after the ref drifted`
+          );
+        }
+      }
+    }
+
+    const { x, y } = await resolveRefToCoords(conn.cdp, sessionId, nodeMap, targetRef);
+    await clickAtCoords(conn.cdp, sessionId, x, y);
+
+    // Refresh the cache from this rebuild so the next click heals against a
+    // like-for-like snapshot.
+    this.cacheRefDescriptors(task, shortId, nodeMap);
+    await this.saveTaskState(task.profile, conn.tasks);
+
+    return healed ? { healed } : {};
+  }
+
+  /**
+   * Click raw viewport coordinates, bypassing ref resolution entirely. Backs
+   * `browser click --at X,Y` — the escape hatch when the accessibility tree
+   * exposes no usable ref (canvas apps, custom-drawn UI) and the caller has
+   * located the target from a screenshot.
+   */
+  async clickAt(taskId: string, x: number, y: number, tabHint?: string): Promise<void> {
+    const { conn, task } = await this.findTask(taskId);
+    const shortId = tabHint ? await this.resolveTabHint(conn, task, tabHint) : this.resolveCurrentTab(task);
+    const cdpTargetId = this.getCdpTargetId(task, shortId);
+    const target = await this.getTarget(conn, cdpTargetId);
+    if (!target) throw new Error(`Tab ${shortId} not found`);
+
+    const sessionId = await this.getSessionId(conn, target.targetId);
     await clickAtCoords(conn.cdp, sessionId, x, y);
   }
 

--- a/src/lib/browser/service.ts
+++ b/src/lib/browser/service.ts
@@ -34,7 +34,7 @@ import {
   type BrowserProfile,
   type HistoricalTask,
 } from './types.js';
-import { getRefs, resolveRefToCoords, describeRefs, healRef, type RefOpts, type RefNode } from './refs.js';
+import { getRefs, resolveRefToCoords, describeRefs, healRef, type RefOpts, type RefNode, type RefSnapshot } from './refs.js';
 import { clickAtCoords, hoverAtCoords, scrollAtCoords, typeText, pressKey, focusNode } from './input.js';
 import { typeEditorText } from './editor.js';
 import {
@@ -1153,17 +1153,65 @@ export class BrowserService {
 
     const sessionId = await this.getSessionId(conn, target.targetId);
     const result = await getRefs(conn.cdp, sessionId, opts);
-    // Snapshot the stable descriptors so a later click can self-heal a drifted
-    // ref. Persist to tasks.json — the cache must survive a daemon restart.
-    this.cacheRefDescriptors(task, shortId, result.nodeMap);
+    // Snapshot the stable descriptors AND the opts they were numbered against
+    // so a later click/type can self-heal a drifted ref by rebuilding with the
+    // same filter. `refs()` is the sole owner of this cache — actions read it,
+    // never overwrite it. Persist to tasks.json so it survives a daemon
+    // restart.
+    this.cacheRefDescriptors(task, shortId, result.nodeMap, result.opts);
     await this.saveTaskState(task.profile, conn.tasks);
-    return result;
+    return { refs: result.refs, nodeMap: result.nodeMap };
   }
 
-  /** Record the last ref descriptors for a tab into persisted task state. */
-  private cacheRefDescriptors(task: Task, shortId: string, nodeMap: Map<number, RefNode>): void {
+  /** Record the last ref listing (descriptors + opts) for a tab into state. */
+  private cacheRefDescriptors(
+    task: Task,
+    shortId: string,
+    nodeMap: Map<number, RefNode>,
+    opts: { interactive: boolean; limit: number }
+  ): void {
     if (!task.refDescriptors) task.refDescriptors = {};
-    task.refDescriptors[shortId] = describeRefs(nodeMap);
+    task.refDescriptors[shortId] = { descriptors: describeRefs(nodeMap), opts };
+  }
+
+  /**
+   * Re-resolve a caller-supplied ref against a freshly-built node map, healing
+   * it back to the right element when the integer ref has drifted since the
+   * cached `refs` listing. Shared by `click` and `type` so both self-heal
+   * identically. Returns the ref to act on plus, when a heal occurred, the
+   * {@link HealInfo} to surface. Throws when the cached element is gone.
+   */
+  private resolveHealedRef(
+    snapshot: RefSnapshot | undefined,
+    nodeMap: Map<number, RefNode>,
+    ref: number
+  ): { targetRef: number; healed?: HealInfo } {
+    const cached = snapshot?.descriptors.find((d) => d.ref === ref);
+    if (!cached) return { targetRef: ref };
+
+    const fresh = nodeMap.get(ref);
+    const stillMatches =
+      fresh !== undefined &&
+      fresh.role === cached.role &&
+      fresh.name === cached.name &&
+      fresh.backendNodeId !== undefined;
+    if (stillMatches) return { targetRef: ref };
+
+    const newRef = healRef(cached, nodeMap);
+    if (newRef === null) {
+      throw new Error(
+        `Ref ${ref} (${cached.role} "${cached.name}") could not be re-resolved: ` +
+          `no matching element on the current page. Re-run 'browser refs' to ` +
+          `refresh the ref numbers, or act by position with 'browser click --at X,Y'.`
+      );
+    }
+    if (newRef === ref) return { targetRef: ref };
+
+    console.error(
+      `[browser] self-healed ref ${ref} -> ${newRef} (${cached.role} "${cached.name}") — ` +
+        `cached descriptor re-matched after the ref drifted`
+    );
+    return { targetRef: newRef, healed: { from: ref, to: newRef, role: cached.role, name: cached.name } };
   }
 
   async click(taskId: string, ref: number, tabHint?: string): Promise<{ healed?: HealInfo }> {
@@ -1174,51 +1222,24 @@ export class BrowserService {
     if (!target) throw new Error(`Tab ${shortId} not found`);
 
     const sessionId = await this.getSessionId(conn, target.targetId);
-    const { nodeMap } = await getRefs(conn.cdp, sessionId, { interactive: false, limit: 1000 });
+    // Rebuild the node map with the SAME opts the cached listing was numbered
+    // against, so the caller's ref lands on the element they saw in `browser
+    // refs`. Rebuilding with a different filter (the old interactive:false)
+    // renumbers every ref and defeats self-heal on the second click. Default
+    // to the user-facing interactive numbering when no listing was cached yet.
+    const snapshot = task.refDescriptors?.[shortId];
+    const buildOpts = snapshot?.opts ?? { interactive: true, limit: 500 };
+    const { nodeMap } = await getRefs(conn.cdp, sessionId, buildOpts);
 
-    // Self-healing: the integer ref is positional and drifts on re-render (or
-    // simply because `refs` numbers interactive-only nodes while this rebuild
-    // counts all of them). If we have a cached descriptor for this ref and the
-    // fresh node at that position no longer matches it, re-resolve by (role,
-    // name) BEFORE clicking the wrong element.
-    const cached = task.refDescriptors?.[shortId]?.find((d) => d.ref === ref);
-    let targetRef = ref;
-    let healed: HealInfo | undefined;
-
-    if (cached) {
-      const fresh = nodeMap.get(ref);
-      const stillMatches =
-        fresh !== undefined &&
-        fresh.role === cached.role &&
-        fresh.name === cached.name &&
-        fresh.backendNodeId !== undefined;
-      if (!stillMatches) {
-        const newRef = healRef(cached, nodeMap);
-        if (newRef === null) {
-          throw new Error(
-            `Ref ${ref} (${cached.role} "${cached.name}") could not be re-resolved: ` +
-              `no matching element on the current page. Re-run 'browser refs', or ` +
-              `click by position with 'browser click --at X,Y'.`
-          );
-        }
-        if (newRef !== ref) {
-          healed = { from: ref, to: newRef, role: cached.role, name: cached.name };
-          targetRef = newRef;
-          console.error(
-            `[browser] self-healed ref ${ref} -> ${newRef} (${cached.role} "${cached.name}") — ` +
-              `cached descriptor re-matched after the ref drifted`
-          );
-        }
-      }
-    }
+    // Self-heal: the integer ref is positional and drifts on re-render. If the
+    // fresh node at this position no longer matches the cached descriptor,
+    // re-resolve (by attrs/proximity-tie-broken role+name) BEFORE clicking the
+    // wrong element. The cache is owned by refs() and NOT rewritten here — the
+    // caller's ref numbers stay anchored to the listing they came from.
+    const { targetRef, healed } = this.resolveHealedRef(snapshot, nodeMap, ref);
 
     const { x, y } = await resolveRefToCoords(conn.cdp, sessionId, nodeMap, targetRef);
     await clickAtCoords(conn.cdp, sessionId, x, y);
-
-    // Refresh the cache from this rebuild so the next click heals against a
-    // like-for-like snapshot.
-    this.cacheRefDescriptors(task, shortId, nodeMap);
-    await this.saveTaskState(task.profile, conn.tasks);
 
     return healed ? { healed } : {};
   }
@@ -1248,8 +1269,14 @@ export class BrowserService {
     if (!target) throw new Error(`Tab ${shortId} not found`);
 
     const sessionId = await this.getSessionId(conn, target.targetId);
-    const { nodeMap } = await getRefs(conn.cdp, sessionId, { interactive: false, limit: 1000 });
-    const node = nodeMap.get(ref);
+    // Same self-healing story as click(): rebuild against the cached listing's
+    // opts so refs line up with what the user saw, then heal a drifted ref
+    // before typing into the wrong field.
+    const snapshot = task.refDescriptors?.[shortId];
+    const buildOpts = snapshot?.opts ?? { interactive: true, limit: 500 };
+    const { nodeMap } = await getRefs(conn.cdp, sessionId, buildOpts);
+    const { targetRef } = this.resolveHealedRef(snapshot, nodeMap, ref);
+    const node = nodeMap.get(targetRef);
     if (!node) throw new Error(`Ref ${ref} not found`);
     if (node.editor) {
       await typeEditorText(conn.cdp, sessionId, node, text, clear);

--- a/src/lib/browser/types.ts
+++ b/src/lib/browser/types.ts
@@ -73,6 +73,12 @@ export interface Task {
   currentTabId?: string; // shortId of current tab
   createdAt: number;
   pid: number;
+  /**
+   * Per-tab snapshot of the last ref descriptors captured for that tab
+   * (shortId -> descriptors). Persisted to tasks.json so a later `click <ref>`
+   * can self-heal a drifted ref by matching (role,name). See RefDescriptor.
+   */
+  refDescriptors?: Record<string, import('./refs.js').RefDescriptor[]>;
 }
 
 export interface TabInfo {
@@ -158,6 +164,9 @@ export interface IPCRequest {
   expr?: string;
   path?: string;
   ref?: number;
+  // Coordinate click (`browser click --at X,Y`): bypasses ref resolution.
+  atX?: number;
+  atY?: number;
   text?: string;
   key?: string;
   scrollX?: number;
@@ -237,6 +246,8 @@ export interface IPCResponse {
   height?: number;
   refs?: string;
   nodes?: RefNodeJson[];
+  /** Human-readable note surfaced to the CLI (e.g. a self-heal notice on click). */
+  message?: string;
   port?: number;
   pid?: number;
   // Recording

--- a/src/lib/browser/types.ts
+++ b/src/lib/browser/types.ts
@@ -74,11 +74,14 @@ export interface Task {
   createdAt: number;
   pid: number;
   /**
-   * Per-tab snapshot of the last ref descriptors captured for that tab
-   * (shortId -> descriptors). Persisted to tasks.json so a later `click <ref>`
-   * can self-heal a drifted ref by matching (role,name). See RefDescriptor.
+   * Per-tab snapshot of the last ref listing captured for that tab
+   * (shortId -> {descriptors, opts}). Persisted to tasks.json so a later
+   * `click`/`type <ref>` can self-heal a drifted ref — the cached `opts` let
+   * the action rebuild its node map with the SAME accessibility filter the
+   * listing was numbered against. Owned by `refs()`; actions never overwrite
+   * it. See RefSnapshot / RefDescriptor.
    */
-  refDescriptors?: Record<string, import('./refs.js').RefDescriptor[]>;
+  refDescriptors?: Record<string, import('./refs.js').RefSnapshot>;
 }
 
 export interface TabInfo {


### PR DESCRIPTION
Closes #335.

First increment — the highest-leverage, self-contained slices. `browser act`
(natural-language pick loop) is deferred with a note below.

## What shipped

### 1. Self-healing refs
The integer `ref` from `getRefs` is **positional** and drifts whenever the
accessibility tree changes — on navigation, on re-render, or simply because
`browser refs` numbers interactive-only nodes while the `click` path rebuilds
over *all* nodes (so `refs` says `button "Submit" [ref=2]` but the click path
has that same button at a higher ref). Today that silently clicks the wrong
element.

Now each ref's **stable descriptor** `(role, name, attrs)` is cached in
per-task state and persisted to `tasks.json` (`Task.refDescriptors`, keyed by
tab). On `click <ref>`, if the fresh node at that position no longer matches the
cached `(role, name)`, we **re-resolve by matching the cached descriptor against
a fresh `getRefs`** before clicking — and log the heal
(`Clicked (self-healed ref 2 -> 4 (button "Target Button"))`). Unhealable refs
fail with an actionable error suggesting `refs` / `--at`.

The dead `refsCache` field (declared at `service.ts` but never written) is
removed — the real cache lives in task state.

### 2. Coordinate click
`browser click --at X,Y` routes straight to the existing `clickAtCoords`
(`src/lib/browser/input.ts`), bypassing ref resolution — the escape hatch for
canvas / custom-drawn UIs the a11y tree doesn't expose. `browser refs` also now
**warns** (on stderr, so `--json` stdout stays clean) with an `--at` / screenshot
suggestion when it finds **zero interactive elements**.

## Reuse anchors
- `clickAtCoords` — `src/lib/browser/input.ts:4` (already used by every ref click)
- `getRefs` / `resolveRefToCoords` — `src/lib/browser/refs.ts`
- `Task` state + `tasks.json` persistence — `src/lib/browser/service.ts` (`saveTaskState`)

## Test
`src/lib/browser/refs.test.ts` — pure unit tests for the self-heal matcher
(`healRef`) and `describeRefs`: a drifted integer ref with a stable `(role,name)`
re-resolves to the new ref; no match reports unhealable (`null`); DOM-backed
matches win; the persisted descriptor never leaks `backendNodeId`. `bunx tsc
--noEmit` clean; full browser + commands suites green (522 tests).

## Verified end-to-end (real headless Chromium)
- `refs` shows `button "Target Button" [ref=2]`; `click 2` logs
  `self-healed ref 2 -> 4` and the button's `onclick` fires (page title →
  `XYZ-CLICKED`) — proving it healed to the **correct** node, not ref 2's element.
- `click --at 123,90` clicks the button by coordinate (title → `XYZ-CLICKED`),
  bypassing refs.
- The zero-interactive-elements warning fires on an AX-empty page.

## Deferred
`browser act --instruction "<text>"` (natural-language element pick) — the
self-heal + coordinate click were the must-lands. `act` can be layered on top as
a thin command that runs `getRefs` and returns `{ refs, instruction }` for the
caller's model, with no heavy agent loop.
