### PR TITLE
feat(serve): read-only local web companion — team diffs + routines + cloud status (Closes #330)

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1,0 +1,47 @@
+/**
+ * `agents serve` — read-only local web companion.
+ *
+ * Boots a localhost-only (127.0.0.1) HTTP + SSE server that renders a live
+ * dashboard of team status + per-worktree diffs, scheduled routines, and cloud
+ * tasks. Everything is a viewer over data other commands already own — there
+ * are no mutation endpoints. See src/lib/serve/.
+ */
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { startServeServer, DEFAULT_SERVE_PORT, SERVE_HOST } from '../lib/serve/server.js';
+
+export function registerServeCommand(program: Command): void {
+  program
+    .command('serve')
+    .description('Read-only local web companion: team diffs, routines, and cloud status (binds 127.0.0.1 only).')
+    .option('-p, --port <n>', `Port to bind on ${SERVE_HOST}`, String(DEFAULT_SERVE_PORT))
+    .option('--interval <ms>', 'SSE refresh cadence in milliseconds', '3000')
+    .action(async (opts: { port?: string; interval?: string }) => {
+      const port = parseInt(opts.port ?? '', 10) || DEFAULT_SERVE_PORT;
+      const intervalMs = parseInt(opts.interval ?? '', 10) || 3000;
+
+      try {
+        const { server, port: bound } = await startServeServer(port, {
+          cwd: process.cwd(),
+          intervalMs,
+        });
+        const url = `http://${SERVE_HOST}:${bound}`;
+        console.log(`${chalk.green('agents serve')} ${chalk.dim('→')} ${chalk.cyan(url)}`);
+        console.log(chalk.dim('read-only · localhost only · Ctrl-C to stop'));
+
+        const shutdown = () => {
+          server.close(() => process.exit(0));
+        };
+        process.on('SIGINT', shutdown);
+        process.on('SIGTERM', shutdown);
+      } catch (err) {
+        const msg = String((err as Error)?.message ?? err);
+        if (msg.includes('EADDRINUSE')) {
+          console.error(chalk.red(`Port ${port} is already in use. Pass --port <n> to pick another.`));
+        } else {
+          console.error(chalk.red(`Could not start serve: ${msg}`));
+        }
+        process.exit(1);
+      }
+    });
+}

--- a/src/lib/serve/data.test.ts
+++ b/src/lib/serve/data.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for the read-only serve data assembly + the gitDiff helper.
+ *
+ * These exercise the real critical path: a real temp git repo with a real
+ * commit and a real uncommitted modification, run through the real `git diff`
+ * helper — no mocking of the code under test.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+import { gitDiff } from '../teams/worktree.js';
+import { buildWorktreeDiffs } from './data.js';
+import type { WorktreeAgentLike } from './data.js';
+
+const execFileAsync = promisify(execFile);
+
+async function git(cwd: string, ...args: string[]): Promise<void> {
+  await execFileAsync('git', args, { cwd });
+}
+
+describe('gitDiff', () => {
+  let repo: string;
+
+  beforeEach(async () => {
+    repo = await fs.mkdtemp(path.join(os.tmpdir(), 'serve-git-'));
+    await git(repo, 'init', '-q');
+    await git(repo, 'config', 'user.email', 'test@example.com');
+    await git(repo, 'config', 'user.name', 'Test');
+    await fs.writeFile(path.join(repo, 'file.txt'), 'original line\n');
+    await git(repo, 'add', '.');
+    await git(repo, 'commit', '-q', '-m', 'initial');
+  });
+
+  afterEach(async () => {
+    await fs.rm(repo, { recursive: true, force: true });
+  });
+
+  it('returns the uncommitted diff for a modified tracked file', async () => {
+    await fs.writeFile(path.join(repo, 'file.txt'), 'modified line\n');
+    const diff = await gitDiff(repo);
+    expect(diff).toContain('file.txt');
+    expect(diff).toContain('-original line');
+    expect(diff).toContain('+modified line');
+  });
+
+  it('returns empty string for a clean worktree', async () => {
+    const diff = await gitDiff(repo);
+    expect(diff).toBe('');
+  });
+
+  it('returns empty string for a non-git directory (no throw)', async () => {
+    const notGit = await fs.mkdtemp(path.join(os.tmpdir(), 'serve-notgit-'));
+    try {
+      expect(await gitDiff(notGit)).toBe('');
+    } finally {
+      await fs.rm(notGit, { recursive: true, force: true });
+    }
+  });
+
+  it('caps the diff at maxBytes and marks it truncated', async () => {
+    const big = 'x'.repeat(5000) + '\n';
+    await fs.writeFile(path.join(repo, 'file.txt'), big);
+    const diff = await gitDiff(repo, 500);
+    expect(diff.length).toBeLessThan(700);
+    expect(diff).toContain('[diff truncated at 500 bytes]');
+  });
+});
+
+describe('buildWorktreeDiffs', () => {
+  let repo: string;
+
+  beforeEach(async () => {
+    repo = await fs.mkdtemp(path.join(os.tmpdir(), 'serve-wt-'));
+    await git(repo, 'init', '-q');
+    await git(repo, 'config', 'user.email', 'test@example.com');
+    await git(repo, 'config', 'user.name', 'Test');
+    await fs.writeFile(path.join(repo, 'app.ts'), 'export const x = 1;\n');
+    await git(repo, 'add', '.');
+    await git(repo, 'commit', '-q', '-m', 'initial');
+  });
+
+  afterEach(async () => {
+    await fs.rm(repo, { recursive: true, force: true });
+  });
+
+  it('attaches a real diff to a teammate that has a worktree with changes', async () => {
+    await fs.writeFile(path.join(repo, 'app.ts'), 'export const x = 2;\n');
+    const agents: WorktreeAgentLike[] = [
+      {
+        agentId: 'abc123',
+        name: 'builder',
+        agentType: 'claude',
+        status: 'running',
+        worktreeName: 'feature',
+        worktreePath: repo,
+        prUrl: 'https://github.com/o/r/pull/1',
+      },
+    ];
+    const diffs = await buildWorktreeDiffs(agents);
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0].agent_id).toBe('abc123');
+    expect(diffs[0].pr_url).toBe('https://github.com/o/r/pull/1');
+    expect(diffs[0].diff).toContain('-export const x = 1;');
+    expect(diffs[0].diff).toContain('+export const x = 2;');
+  });
+
+  it('skips teammates that have no worktree path', async () => {
+    const agents: WorktreeAgentLike[] = [
+      {
+        agentId: 'noweave',
+        name: null,
+        agentType: 'codex',
+        status: 'completed',
+        worktreeName: null,
+        worktreePath: null,
+        prUrl: null,
+      },
+    ];
+    expect(await buildWorktreeDiffs(agents)).toHaveLength(0);
+  });
+});

--- a/src/lib/serve/data.ts
+++ b/src/lib/serve/data.ts
@@ -1,0 +1,161 @@
+/**
+ * Read-only state assembly for `agents serve`.
+ *
+ * Reuses the SAME structured data the CLI already emits — no recomputation:
+ *  - teams: {@link handleTasks} + {@link handleStatus} + {@link toTaskStatusSummary}
+ *    (the shape behind `agents teams status --json`), plus a per-worktree
+ *    `git diff` via {@link gitDiff}.
+ *  - routines: {@link listJobs} (the shape behind `agents routines list --json`).
+ *  - cloud: {@link listTasks} from the local SQLite store (behind `agents cloud list --json`).
+ *
+ * Every panel is assembled independently: if one subsystem throws (e.g. the
+ * SQLite cloud store isn't provisioned on this box), that panel reports an
+ * `error` string and the others still render. This is an aggregator dashboard,
+ * not a fallback that hides a bug in a single code path.
+ */
+import { AgentManager } from '../teams/agents.js';
+import type { AgentProcess } from '../teams/agents.js';
+import { handleTasks, handleStatus, toTaskStatusSummary } from '../teams/api.js';
+import type { AgentStatusSummary } from '../teams/api.js';
+import { gitDiff } from '../teams/worktree.js';
+import { listJobs } from '../routines.js';
+import type { JobConfig } from '../routines.js';
+import { listTasks as listCloudTasks } from '../cloud/store.js';
+import type { CloudTask } from '../cloud/types.js';
+
+/** One teammate's worktree and its current uncommitted diff. */
+export interface WorktreeDiff {
+  agent_id: string;
+  name: string | null;
+  agent_type: string;
+  status: string;
+  worktree_name: string | null;
+  worktree_path: string | null;
+  pr_url: string | null;
+  /** Uncommitted `git diff HEAD` for the worktree, capped. '' when clean/absent. */
+  diff: string;
+}
+
+/** One team: its per-teammate status summary plus per-worktree diffs. */
+export interface TeamPanel {
+  task_name: string;
+  agent_count: number;
+  running: number;
+  completed: number;
+  failed: number;
+  agents: AgentStatusSummary[];
+  worktrees: WorktreeDiff[];
+}
+
+/** A panel that either carries data or an error string (never both). */
+export type PanelResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+/** The full read-only snapshot streamed to the browser. */
+export interface ServeState {
+  generated_at: string;
+  teams: PanelResult<TeamPanel[]>;
+  routines: PanelResult<JobConfig[]>;
+  cloud: PanelResult<CloudTask[]>;
+}
+
+/** Shape of the teammate fields needed to build a worktree diff. */
+export interface WorktreeAgentLike {
+  agentId: string;
+  name: string | null;
+  agentType: string;
+  status: string;
+  worktreeName: string | null;
+  worktreePath: string | null;
+  prUrl: string | null;
+}
+
+/**
+ * Build the per-worktree diffs for a set of teammates. Only teammates with a
+ * `worktreePath` produce a diff; each gets a real `git diff HEAD` via
+ * {@link gitDiff}. Pure over its inputs (no manager, no globals) so it can be
+ * unit-tested against a real temp git worktree.
+ */
+export async function buildWorktreeDiffs(agents: WorktreeAgentLike[]): Promise<WorktreeDiff[]> {
+  const withTree = agents.filter((a) => !!a.worktreePath);
+  return Promise.all(
+    withTree.map(async (a) => ({
+      agent_id: a.agentId,
+      name: a.name,
+      agent_type: a.agentType,
+      status: a.status,
+      worktree_name: a.worktreeName,
+      worktree_path: a.worktreePath,
+      pr_url: a.prUrl,
+      diff: await gitDiff(a.worktreePath as string),
+    })),
+  );
+}
+
+/** Assemble the teams panel: overview counts, status summaries, worktree diffs. */
+async function assembleTeams(manager: AgentManager): Promise<TeamPanel[]> {
+  const { tasks } = await handleTasks(manager, 1000);
+  const panels: TeamPanel[] = [];
+  for (const t of tasks) {
+    const status = toTaskStatusSummary(await handleStatus(manager, t.task_name, 'all'));
+    const teamAgents = await manager.listByTask(t.task_name);
+    const worktrees = await buildWorktreeDiffs(
+      teamAgents.map((a: AgentProcess) => ({
+        agentId: a.agentId,
+        name: a.name,
+        agentType: a.agentType,
+        status: a.status,
+        worktreeName: a.worktreeName,
+        worktreePath: a.worktreePath,
+        prUrl: a.prUrl,
+      })),
+    );
+    panels.push({
+      task_name: t.task_name,
+      agent_count: t.agent_count,
+      running: t.running,
+      completed: t.completed,
+      failed: t.failed,
+      agents: status.agents,
+      worktrees,
+    });
+  }
+  return panels;
+}
+
+/**
+ * Assemble the full read-only snapshot. Each panel degrades independently to an
+ * `error` string so one unavailable subsystem never blanks the whole dashboard.
+ *
+ * @param cwd - Project root used for project-scoped routine discovery.
+ * @param manager - Injectable for tests; defaults to a fresh {@link AgentManager}.
+ */
+export async function assembleState(
+  cwd: string = process.cwd(),
+  manager: AgentManager = new AgentManager(),
+): Promise<ServeState> {
+  const [teams, routines, cloud] = await Promise.all([
+    assembleTeams(manager).then(
+      (data): PanelResult<TeamPanel[]> => ({ ok: true, data }),
+      (err): PanelResult<TeamPanel[]> => ({ ok: false, error: String(err?.message ?? err) }),
+    ),
+    Promise.resolve()
+      .then(() => listJobs(cwd))
+      .then(
+        (data): PanelResult<JobConfig[]> => ({ ok: true, data }),
+        (err): PanelResult<JobConfig[]> => ({ ok: false, error: String(err?.message ?? err) }),
+      ),
+    Promise.resolve()
+      .then(() => listCloudTasks({ limit: 50 }))
+      .then(
+        (data): PanelResult<CloudTask[]> => ({ ok: true, data }),
+        (err): PanelResult<CloudTask[]> => ({ ok: false, error: String(err?.message ?? err) }),
+      ),
+  ]);
+
+  return {
+    generated_at: new Date().toISOString(),
+    teams,
+    routines,
+    cloud,
+  };
+}

--- a/src/lib/serve/page.ts
+++ b/src/lib/serve/page.ts
@@ -67,6 +67,10 @@ export function renderPage(): string {
 <script>
 const $ = (id) => document.getElementById(id);
 const esc = (s) => String(s == null ? '' : s).replace(/[&<>"]/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+// href allowlist: only http(s) URLs are linkable. esc() blocks attribute
+// breakout, but a javascript:/data: URL would still execute on click — so a
+// non-http(s) pr_url renders as an inert '#' rather than a live link.
+const safeUrl = (u) => { const s = String(u == null ? '' : u); return /^https?:\\/\\//i.test(s) ? s : '#'; };
 function colorDiff(text) {
   return esc(text).split('\\n').map((line) => {
     if (line.startsWith('+')) return '<span class="a">' + line + '</span>';
@@ -86,7 +90,7 @@ function renderTeams(res) {
     const agents = t.agents.map((a) =>
       '<div class="row"><span>' + esc(a.name || a.agent_id.slice(0,8)) +
       ' <span class="muted">' + esc(a.agent_type) + '</span>' +
-      (a.pr_url ? ' <a href="' + esc(a.pr_url) + '" target="_blank">PR</a>' : '') +
+      (a.pr_url ? ' <a href="' + esc(safeUrl(a.pr_url)) + '" target="_blank">PR</a>' : '') +
       '</span><span class="badge ' + esc(a.status) + '">' + esc(a.status) + '</span></div>'
     ).join('');
     const worktrees = t.worktrees.map((w) => {
@@ -116,7 +120,7 @@ function renderCloud(res) {
   el.innerHTML = '<div class="card"><table><tr><th>id</th><th>provider</th><th>status</th><th>repo</th><th></th></tr>' +
     res.data.map((c) => '<tr><td>' + esc(c.id.slice(0,10)) + '</td><td>' + esc(c.provider) + '</td><td><span class="badge ' + esc(c.status) + '">' +
       esc(c.status) + '</span></td><td class="muted">' + esc(c.repo || '') + '</td><td>' +
-      (c.prUrl ? '<a href="' + esc(c.prUrl) + '" target="_blank">PR</a>' : '') + '</td></tr>').join('') +
+      (c.prUrl ? '<a href="' + esc(safeUrl(c.prUrl)) + '" target="_blank">PR</a>' : '') + '</td></tr>').join('') +
     '</table></div>';
 }
 function render(state) {

--- a/src/lib/serve/page.ts
+++ b/src/lib/serve/page.ts
@@ -1,0 +1,136 @@
+/**
+ * Self-contained HTML page for `agents serve`. No framework, no external assets
+ * — a single inline <style> + <script> that subscribes to /events (SSE) and
+ * re-renders the panels on each snapshot. Terminal-coded per the agents-cli
+ * brand: #0a0a0a bg, #a3e635 lime accent, JetBrains Mono.
+ */
+export function renderPage(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>agents serve</title>
+<style>
+  :root {
+    --bg: #0a0a0a; --panel: #121212; --border: #262626; --fg: #e5e5e5;
+    --dim: #737373; --accent: #a3e635; --add: #4ade80; --del: #f87171; --hunk: #60a5fa;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--fg);
+    font-family: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
+    font-size: 13px; line-height: 1.5;
+  }
+  header {
+    position: sticky; top: 0; z-index: 10; background: var(--bg);
+    border-bottom: 1px solid var(--border); padding: 12px 20px;
+    display: flex; align-items: center; gap: 12px;
+  }
+  header .mark { color: var(--accent); font-weight: 700; letter-spacing: .5px; }
+  header .status { color: var(--dim); }
+  header .dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: var(--del); margin-right: 6px; vertical-align: middle; }
+  header .dot.live { background: var(--accent); }
+  main { padding: 20px; max-width: 1100px; margin: 0 auto; display: grid; gap: 24px; }
+  h2 { font-size: 14px; color: var(--accent); border-bottom: 1px solid var(--border); padding-bottom: 6px; margin: 0 0 12px; text-transform: uppercase; letter-spacing: 1px; }
+  .card { background: var(--panel); border: 1px solid var(--border); border-radius: 6px; padding: 14px; margin-bottom: 12px; }
+  .row { display: flex; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
+  .muted { color: var(--dim); }
+  .badge { font-size: 11px; padding: 1px 7px; border-radius: 10px; border: 1px solid var(--border); }
+  .badge.running { color: var(--accent); border-color: var(--accent); }
+  .badge.completed { color: var(--add); border-color: var(--add); }
+  .badge.failed { color: var(--del); border-color: var(--del); }
+  a { color: var(--hunk); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  details { margin-top: 8px; }
+  summary { cursor: pointer; color: var(--dim); }
+  pre.diff { overflow-x: auto; background: #0d0d0d; border: 1px solid var(--border); border-radius: 4px; padding: 10px; margin: 8px 0 0; white-space: pre; }
+  pre.diff .a { color: var(--add); } pre.diff .d { color: var(--del); } pre.diff .h { color: var(--hunk); } pre.diff .m { color: var(--dim); }
+  .err { color: var(--del); }
+  .empty { color: var(--dim); font-style: italic; }
+  table { width: 100%; border-collapse: collapse; }
+  td, th { text-align: left; padding: 4px 8px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { color: var(--dim); font-weight: 500; }
+</style>
+</head>
+<body>
+<header>
+  <span class="mark">agents serve</span>
+  <span class="status"><span class="dot" id="dot"></span><span id="conn">connecting…</span></span>
+  <span class="status" id="ts"></span>
+</header>
+<main>
+  <section><h2>Teams &amp; Diffs</h2><div id="teams"></div></section>
+  <section><h2>Routines</h2><div id="routines"></div></section>
+  <section><h2>Cloud</h2><div id="cloud"></div></section>
+</main>
+<script>
+const $ = (id) => document.getElementById(id);
+const esc = (s) => String(s == null ? '' : s).replace(/[&<>"]/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+function colorDiff(text) {
+  return esc(text).split('\\n').map((line) => {
+    if (line.startsWith('+')) return '<span class="a">' + line + '</span>';
+    if (line.startsWith('-')) return '<span class="d">' + line + '</span>';
+    if (line.startsWith('@@')) return '<span class="h">' + line + '</span>';
+    if (line.startsWith('diff ') || line.startsWith('index ')) return '<span class="m">' + line + '</span>';
+    return line;
+  }).join('\\n');
+}
+function panelError(el, error) { el.innerHTML = '<div class="card err">error: ' + esc(error) + '</div>'; }
+
+function renderTeams(res) {
+  const el = $('teams');
+  if (!res.ok) return panelError(el, res.error);
+  if (!res.data.length) { el.innerHTML = '<div class="empty">no teams</div>'; return; }
+  el.innerHTML = res.data.map((t) => {
+    const agents = t.agents.map((a) =>
+      '<div class="row"><span>' + esc(a.name || a.agent_id.slice(0,8)) +
+      ' <span class="muted">' + esc(a.agent_type) + '</span>' +
+      (a.pr_url ? ' <a href="' + esc(a.pr_url) + '" target="_blank">PR</a>' : '') +
+      '</span><span class="badge ' + esc(a.status) + '">' + esc(a.status) + '</span></div>'
+    ).join('');
+    const worktrees = t.worktrees.map((w) => {
+      const body = w.diff
+        ? '<details><summary>diff · ' + esc(w.worktree_name || w.worktree_path) + '</summary><pre class="diff">' + colorDiff(w.diff) + '</pre></details>'
+        : '<div class="muted">' + esc(w.worktree_name || w.worktree_path) + ' — no uncommitted changes</div>';
+      return body;
+    }).join('');
+    return '<div class="card"><div class="row"><strong>' + esc(t.task_name) + '</strong>' +
+      '<span class="muted">' + t.running + ' running · ' + t.completed + ' done · ' + t.failed + ' failed</span></div>' +
+      agents + worktrees + '</div>';
+  }).join('');
+}
+function renderRoutines(res) {
+  const el = $('routines');
+  if (!res.ok) return panelError(el, res.error);
+  if (!res.data.length) { el.innerHTML = '<div class="empty">no routines</div>'; return; }
+  el.innerHTML = '<div class="card"><table><tr><th>name</th><th>schedule</th><th>agent</th><th>enabled</th></tr>' +
+    res.data.map((j) => '<tr><td>' + esc(j.name) + '</td><td class="muted">' + esc(j.schedule) + '</td><td>' +
+      esc(j.workflow ? 'wf:' + j.workflow : j.agent) + '</td><td>' + (j.enabled ? 'yes' : '<span class="muted">no</span>') + '</td></tr>').join('') +
+    '</table></div>';
+}
+function renderCloud(res) {
+  const el = $('cloud');
+  if (!res.ok) return panelError(el, res.error);
+  if (!res.data.length) { el.innerHTML = '<div class="empty">no cloud tasks</div>'; return; }
+  el.innerHTML = '<div class="card"><table><tr><th>id</th><th>provider</th><th>status</th><th>repo</th><th></th></tr>' +
+    res.data.map((c) => '<tr><td>' + esc(c.id.slice(0,10)) + '</td><td>' + esc(c.provider) + '</td><td><span class="badge ' + esc(c.status) + '">' +
+      esc(c.status) + '</span></td><td class="muted">' + esc(c.repo || '') + '</td><td>' +
+      (c.prUrl ? '<a href="' + esc(c.prUrl) + '" target="_blank">PR</a>' : '') + '</td></tr>').join('') +
+    '</table></div>';
+}
+function render(state) {
+  renderTeams(state.teams); renderRoutines(state.routines); renderCloud(state.cloud);
+  $('ts').textContent = 'updated ' + new Date(state.generated_at).toLocaleTimeString();
+}
+function setConn(live) {
+  $('dot').className = 'dot' + (live ? ' live' : '');
+  $('conn').textContent = live ? 'live' : 'reconnecting…';
+}
+const src = new EventSource('/events');
+src.addEventListener('state', (e) => { setConn(true); render(JSON.parse(e.data)); });
+src.onerror = () => setConn(false);
+</script>
+</body>
+</html>`;
+}

--- a/src/lib/serve/server.test.ts
+++ b/src/lib/serve/server.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Boots the read-only serve server on an ephemeral loopback port and asserts
+ * the real HTTP surface: the HTML page, the JSON snapshot shape, SSE framing,
+ * loopback-only binding, and the read-only (GET-only) contract.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import type { Server } from 'http';
+import { startServeServer, SERVE_HOST } from './server.js';
+
+let server: Server | null = null;
+
+afterEach(async () => {
+  if (server) {
+    await new Promise<void>((r) => server!.close(() => r()));
+    server = null;
+  }
+});
+
+async function boot(): Promise<string> {
+  const started = await startServeServer(0, { cwd: process.cwd(), intervalMs: 50 });
+  server = started.server;
+  return `http://${SERVE_HOST}:${started.port}`;
+}
+
+describe('serve server', () => {
+  it('binds loopback only', async () => {
+    const started = await startServeServer(0, { cwd: process.cwd() });
+    server = started.server;
+    const addr = started.server.address();
+    expect(typeof addr).toBe('object');
+    expect((addr as { address: string }).address).toBe('127.0.0.1');
+  });
+
+  it('serves the HTML page at /', async () => {
+    const base = await boot();
+    const res = await fetch(base + '/');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+    const body = await res.text();
+    expect(body).toContain('agents serve');
+    expect(body).toContain('/events');
+  });
+
+  it('returns a well-formed JSON snapshot at /api/state', async () => {
+    const base = await boot();
+    const res = await fetch(base + '/api/state');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const state = await res.json();
+    expect(typeof state.generated_at).toBe('string');
+    for (const panel of ['teams', 'routines', 'cloud'] as const) {
+      expect(state[panel]).toBeDefined();
+      expect(typeof state[panel].ok).toBe('boolean');
+      if (state[panel].ok) expect(Array.isArray(state[panel].data)).toBe(true);
+      else expect(typeof state[panel].error).toBe('string');
+    }
+  });
+
+  it('rejects non-GET methods (read-only)', async () => {
+    const base = await boot();
+    const res = await fetch(base + '/api/state', { method: 'POST' });
+    expect(res.status).toBe(405);
+    expect(res.headers.get('allow')).toBe('GET');
+  });
+
+  it('streams an SSE state event', async () => {
+    const base = await boot();
+    const res = await fetch(base + '/events');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+    const reader = res.body!.getReader();
+    const { value } = await reader.read();
+    const chunk = new TextDecoder().decode(value);
+    expect(chunk).toContain('event: state');
+    expect(chunk).toContain('data: ');
+    await reader.cancel();
+  });
+
+  it('404s unknown paths', async () => {
+    const base = await boot();
+    const res = await fetch(base + '/nope');
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/lib/serve/server.test.ts
+++ b/src/lib/serve/server.test.ts
@@ -4,8 +4,10 @@
  * loopback-only binding, and the read-only (GET-only) contract.
  */
 import { describe, it, expect, afterEach } from 'vitest';
-import type { Server } from 'http';
+import type { Server, IncomingMessage } from 'http';
+import net from 'net';
 import { startServeServer, SERVE_HOST } from './server.js';
+import type { ServeState } from './data.js';
 
 let server: Server | null = null;
 
@@ -80,5 +82,76 @@ describe('serve server', () => {
     const base = await boot();
     const res = await fetch(base + '/nope');
     expect(res.status).toBe(404);
+  });
+
+  // Regression: an SSE client that disconnects DURING the first (slow) snapshot
+  // must not leak the push interval. The one-shot 'close' has to be registered
+  // BEFORE the first `await push()`, and the interval must not arm once closed —
+  // otherwise it keeps calling assembleState()/res.write() on a dead socket
+  // forever. We reproduce the race deterministically by gating the first
+  // snapshot: disconnect, confirm the server observed the close, THEN release
+  // the snapshot. A correct server calls the snapshot exactly once (no interval
+  // ever fires); the buggy version calls it repeatedly.
+  it('does not leak the SSE interval when the client disconnects during the first snapshot', async () => {
+    const STATE: ServeState = {
+      generated_at: '2026-07-05T00:00:00.000Z',
+      teams: { ok: true, data: [] },
+      routines: { ok: true, data: [] },
+      cloud: { ok: true, data: [] },
+    };
+
+    let snapshotCalls = 0;
+    let signalEntered!: () => void;
+    const enteredFirstSnapshot = new Promise<void>((r) => (signalEntered = r));
+    let releaseFirstSnapshot!: () => void;
+    const gate = new Promise<void>((r) => (releaseFirstSnapshot = r));
+
+    const snapshot = async (): Promise<ServeState> => {
+      snapshotCalls += 1;
+      if (snapshotCalls === 1) {
+        signalEntered();
+        await gate; // hold the first snapshot open so we can disconnect mid-flight
+      }
+      return STATE;
+    };
+
+    const started = await startServeServer(0, { cwd: process.cwd(), intervalMs: 20, snapshot });
+    server = started.server;
+
+    // Observe the server-side close independently of the handler under test, so
+    // we can wait until the disconnect is truly seen before releasing the gate.
+    let serverSawClose = false;
+    server.on('request', (req: IncomingMessage) => {
+      if ((req.url || '').startsWith('/events')) req.on('close', () => (serverSawClose = true));
+    });
+
+    // Raw socket so we control exactly when the client goes away.
+    const sock = net.connect(started.port, SERVE_HOST);
+    await new Promise<void>((resolve, reject) => {
+      sock.once('connect', () => resolve());
+      sock.once('error', reject);
+    });
+    sock.write(`GET /events HTTP/1.1\r\nHost: ${SERVE_HOST}\r\nConnection: keep-alive\r\n\r\n`);
+
+    // Wait until we're inside the first snapshot, then kill the client.
+    await enteredFirstSnapshot;
+    sock.destroy();
+
+    // Deterministically wait for the server to register the disconnect before
+    // releasing the snapshot — this is what makes the assertion non-flaky.
+    const deadline = Date.now() + 2000;
+    while (!serverSawClose && Date.now() < deadline) {
+      await new Promise<void>((r) => setTimeout(r, 5));
+    }
+    expect(serverSawClose).toBe(true);
+
+    // Let the (now-orphaned) first snapshot finish, then give any leaked
+    // interval many cadences to fire.
+    releaseFirstSnapshot();
+    await new Promise<void>((r) => setTimeout(r, 200)); // 10x the 20ms interval
+
+    // Exactly one snapshot: the first frame. No interval ever armed, so no
+    // write-after-close and no leaked timer.
+    expect(snapshotCalls).toBe(1);
   });
 });

--- a/src/lib/serve/server.ts
+++ b/src/lib/serve/server.ts
@@ -1,0 +1,123 @@
+/**
+ * Read-only localhost HTTP + Server-Sent-Events server for `agents serve`.
+ *
+ * There is deliberately NO framework and NO mutation surface:
+ *  - binds 127.0.0.1 only (loopback) — never reachable off the machine;
+ *  - answers GET only (every other method → 405);
+ *  - routes: `GET /` → HTML page, `GET /api/state` → JSON snapshot,
+ *    `GET /events` → SSE stream that re-pushes the snapshot on an interval.
+ *
+ * The whole thing is a viewer over data other commands already own
+ * ({@link assembleState}); it writes nothing.
+ */
+import http from 'http';
+import { assembleState } from './data.js';
+import type { ServeState } from './data.js';
+import { renderPage } from './page.js';
+
+/** Loopback address — the server binds here and nowhere else. */
+export const SERVE_HOST = '127.0.0.1';
+/** Default port for `agents serve`. */
+export const DEFAULT_SERVE_PORT = 4477;
+/** Default SSE push cadence. */
+export const DEFAULT_INTERVAL_MS = 3000;
+
+export interface ServeOptions {
+  /** Project root for project-scoped routine discovery. Defaults to process.cwd(). */
+  cwd?: string;
+  /** SSE push cadence in ms. Defaults to {@link DEFAULT_INTERVAL_MS}. */
+  intervalMs?: number;
+}
+
+/**
+ * Create (but do not start) the read-only serve server. Caller invokes
+ * `.listen(port, SERVE_HOST)`. Returned so tests can bind an ephemeral port.
+ */
+export function createServeServer(opts: ServeOptions = {}): http.Server {
+  const cwd = opts.cwd ?? process.cwd();
+  const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+
+  const snapshot = (): Promise<ServeState> => assembleState(cwd);
+
+  const server = http.createServer(async (req, res) => {
+    // Read-only: reject anything that could mutate. Only GET is served.
+    if (req.method !== 'GET') {
+      res.writeHead(405, { 'content-type': 'text/plain', allow: 'GET' });
+      res.end('method not allowed');
+      return;
+    }
+
+    const url = (req.url || '/').split('?')[0];
+
+    if (url === '/' || url === '/index.html') {
+      const html = renderPage();
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      res.end(html);
+      return;
+    }
+
+    if (url === '/api/state') {
+      try {
+        const state = await snapshot();
+        res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
+        res.end(JSON.stringify(state));
+      } catch (err) {
+        res.writeHead(500, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ error: String((err as Error)?.message ?? err) }));
+      }
+      return;
+    }
+
+    if (url === '/events') {
+      res.writeHead(200, {
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+        connection: 'keep-alive',
+      });
+
+      let closed = false;
+      const push = async () => {
+        if (closed) return;
+        try {
+          const state = await snapshot();
+          if (closed) return;
+          res.write(`event: state\ndata: ${JSON.stringify(state)}\n\n`);
+        } catch (err) {
+          if (!closed) res.write(`event: error\ndata: ${JSON.stringify({ error: String(err) })}\n\n`);
+        }
+      };
+
+      await push(); // immediate first frame
+      const timer = setInterval(push, intervalMs);
+      req.on('close', () => {
+        closed = true;
+        clearInterval(timer);
+      });
+      return;
+    }
+
+    res.writeHead(404, { 'content-type': 'text/plain' });
+    res.end('not found');
+  });
+
+  return server;
+}
+
+/**
+ * Start the serve server on `port`, bound to loopback. Resolves with the
+ * actual bound port (useful when `port === 0` for tests).
+ */
+export function startServeServer(
+  port: number = DEFAULT_SERVE_PORT,
+  opts: ServeOptions = {},
+): Promise<{ server: http.Server; port: number }> {
+  const server = createServeServer(opts);
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, SERVE_HOST, () => {
+      const addr = server.address();
+      const boundPort = typeof addr === 'object' && addr ? addr.port : port;
+      resolve({ server, port: boundPort });
+    });
+  });
+}

--- a/src/lib/serve/server.ts
+++ b/src/lib/serve/server.ts
@@ -27,6 +27,13 @@ export interface ServeOptions {
   cwd?: string;
   /** SSE push cadence in ms. Defaults to {@link DEFAULT_INTERVAL_MS}. */
   intervalMs?: number;
+  /**
+   * Snapshot data source. Defaults to {@link assembleState}. Read-only DI seam
+   * so tests can drive SSE lifecycle timing deterministically (e.g. gate the
+   * first snapshot to reproduce a mid-snapshot disconnect); production never
+   * sets it.
+   */
+  snapshot?: () => Promise<ServeState>;
 }
 
 /**
@@ -37,7 +44,7 @@ export function createServeServer(opts: ServeOptions = {}): http.Server {
   const cwd = opts.cwd ?? process.cwd();
   const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
 
-  const snapshot = (): Promise<ServeState> => assembleState(cwd);
+  const snapshot = opts.snapshot ?? ((): Promise<ServeState> => assembleState(cwd));
 
   const server = http.createServer(async (req, res) => {
     // Read-only: reject anything that could mutate. Only GET is served.
@@ -76,6 +83,17 @@ export function createServeServer(opts: ServeOptions = {}): http.Server {
       });
 
       let closed = false;
+      // Declare the timer first and register the disconnect cleanup BEFORE the
+      // first `await push()`. `assembleState()` (team scan + git diffs) can be
+      // slow; if the client disconnects during it, the one-shot 'close' must
+      // already have a listener — otherwise it fires into the void, the interval
+      // starts anyway, and we leak a timer writing to a destroyed socket forever.
+      let timer: ReturnType<typeof setInterval> | undefined;
+      req.on('close', () => {
+        closed = true;
+        if (timer) clearInterval(timer);
+      });
+
       const push = async () => {
         if (closed) return;
         try {
@@ -88,11 +106,10 @@ export function createServeServer(opts: ServeOptions = {}): http.Server {
       };
 
       await push(); // immediate first frame
-      const timer = setInterval(push, intervalMs);
-      req.on('close', () => {
-        closed = true;
-        clearInterval(timer);
-      });
+      // Only arm the interval if the client is still connected. If 'close' fired
+      // during the first push, `closed` is already true (and the handler ran
+      // while `timer` was undefined), so starting an interval here would leak.
+      if (!closed) timer = setInterval(push, intervalMs);
       return;
     }
 

--- a/src/lib/startup/command-registry.ts
+++ b/src/lib/startup/command-registry.ts
@@ -89,6 +89,7 @@ export const loadSessions: ModuleLoader = async () => (await import('../../comma
 export const loadTeams: ModuleLoader = async () => (await import('../../commands/teams.js')).registerTeamsCommands;
 export const loadCloud: ModuleLoader = async () => (await import('../../commands/cloud.js')).registerCloudCommands;
 export const loadMessage: ModuleLoader = async () => (await import('../../commands/message.js')).registerMessageCommand;
+export const loadServe: ModuleLoader = async () => (await import('../../commands/serve.js')).registerServeCommand;
 
 /**
  * Commands whose modules pull in the SQLite-backed session/cloud stack. They are
@@ -97,7 +98,7 @@ export const loadMessage: ModuleLoader = async () => (await import('../../comman
  * inherit the root's custom help formatter rather than getting the per-command
  * recursive pass. Keeping that ordering preserves their `--help` output exactly.
  */
-export const LAZY_COMMAND_NAMES: ReadonlySet<string> = new Set(['sessions', 'teams', 'cloud', 'message']);
+export const LAZY_COMMAND_NAMES: ReadonlySet<string> = new Set(['sessions', 'teams', 'cloud', 'message', 'serve']);
 
 /**
  * User-typed top-level command name -> ordered list of module loaders to run.
@@ -182,4 +183,5 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   teams: [loadTeams],
   cloud: [loadCloud],
   message: [loadMessage],
+  serve: [loadServe],
 };

--- a/src/lib/teams/worktree.ts
+++ b/src/lib/teams/worktree.ts
@@ -53,16 +53,24 @@ export async function gitDiff(
   worktreePath: string,
   maxBytes: number = DEFAULT_DIFF_MAX_BYTES,
 ): Promise<string> {
+  // Size the capture buffer off the cap (not an arbitrary 1MB floor) so a diff
+  // that overshoots gets TRUNCATED, never silently dropped. A diff larger than
+  // the buffer overflows maxBuffer, but Node still hands us the captured prefix
+  // on the rejection — we truncate that below rather than losing it to ''.
+  const maxBuffer = maxBytes * 4;
+  const truncate = (s: string) => s.slice(0, maxBytes) + `\n… [diff truncated at ${maxBytes} bytes]`;
   try {
     const { stdout } = await execFileAsync('git', ['diff', 'HEAD'], {
       cwd: worktreePath,
-      maxBuffer: Math.max(maxBytes * 4, 1_000_000),
+      maxBuffer,
     });
-    if (stdout.length > maxBytes) {
-      return stdout.slice(0, maxBytes) + `\n… [diff truncated at ${maxBytes} bytes]`;
-    }
-    return stdout;
-  } catch {
+    return stdout.length > maxBytes ? truncate(stdout) : stdout;
+  } catch (err) {
+    // ENOBUFS on an oversized diff still carries the partial capture; truncate
+    // it so the dashboard shows "[diff truncated]" instead of "no changes".
+    // A genuine non-git-worktree error has no stdout → fall through to ''.
+    const partial = (err as { stdout?: string })?.stdout;
+    if (typeof partial === 'string' && partial.length > 0) return truncate(partial);
     return '';
   }
 }

--- a/src/lib/teams/worktree.ts
+++ b/src/lib/teams/worktree.ts
@@ -40,6 +40,33 @@ export async function hasUncommittedChanges(worktreePath: string): Promise<boole
   }
 }
 
+/** Default cap on diff text so one giant worktree can't blow up the serve dashboard. */
+export const DEFAULT_DIFF_MAX_BYTES = 200_000;
+
+/**
+ * Return the uncommitted working-tree diff for a worktree (staged + unstaged,
+ * relative to HEAD), capped so a huge diff can't overwhelm the read-only serve
+ * dashboard. Read-only: shells out to `git diff HEAD` and never mutates state.
+ * Returns '' when the path isn't a git worktree or has no pending changes.
+ */
+export async function gitDiff(
+  worktreePath: string,
+  maxBytes: number = DEFAULT_DIFF_MAX_BYTES,
+): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync('git', ['diff', 'HEAD'], {
+      cwd: worktreePath,
+      maxBuffer: Math.max(maxBytes * 4, 1_000_000),
+    });
+    if (stdout.length > maxBytes) {
+      return stdout.slice(0, maxBytes) + `\n… [diff truncated at ${maxBytes} bytes]`;
+    }
+    return stdout;
+  } catch {
+    return '';
+  }
+}
+
 /**
  * Create a new git worktree for a teammate.
  *


### PR DESCRIPTION
## What shipped

`agents serve [--port N]` — a **localhost-only (127.0.0.1), read-only** HTTP + Server-Sent-Events server that renders a live dashboard over data other commands already own. No framework, no external deps (Node `http` + a single inline HTML/JS page), **no mutation endpoints** (GET-only; every other method → 405).

**Panels** (all reuse existing structured data — nothing recomputed):

1. **Teams & diffs** — reuses `handleTasks` / `handleStatus` / `toTaskStatusSummary` (the shape behind `agents teams status --json`). For every teammate with a worktree it shows a per-worktree `git diff` via a **new `gitDiff()` helper** added right next to `hasUncommittedChanges`.
2. **Routines** — reuses `listJobs()` (the shape behind `agents routines list --json`).
3. **Cloud** — reuses `listTasks()` from the local SQLite store (behind `agents cloud list --json`).

SSE re-pushes the full snapshot on an interval (`--interval`, default 3s); the page auto-refreshes each panel. Each panel degrades **independently** to an `error` string, so one unavailable subsystem (e.g. no cloud DB) never blanks the whole dashboard. Terminal-coded styling per the agents-cli brand (`#0a0a0a` bg, `#a3e635` lime accent, JetBrains Mono).

## Reuse anchors

| Reused | Location |
|---|---|
| `handleTasks` / `handleStatus` / `toTaskStatusSummary` | `src/lib/teams/api.ts:243,377` + `src/commands/teams.ts:1278-1286` |
| Agent `worktreePath` / `worktreeName` / `prUrl` (via `listByTask`) | `src/lib/teams/agents.ts:467,496-497,796-797` + `:1590` |
| `hasUncommittedChanges` (new `gitDiff` sibling) | `src/lib/teams/worktree.ts:34-41` |
| `listJobs()` | `src/lib/routines.ts:77` |
| `listTasks()` (SQLite cloud store) | `src/lib/cloud/store.ts:101` |
| Lazy command registration | `src/lib/startup/command-registry.ts` (added `loadServe`, `serve` to `LAZY_COMMAND_NAMES` + `COMMAND_LOADERS`) |

## Files

- `src/commands/serve.ts` — the `agents serve` command
- `src/lib/serve/data.ts` — `assembleState()` + `buildWorktreeDiffs()`
- `src/lib/serve/server.ts` — `createServeServer()` / `startServeServer()` (http + SSE, loopback-bound)
- `src/lib/serve/page.ts` — self-contained inline HTML/JS page
- `src/lib/teams/worktree.ts` — new `gitDiff()` helper (capped, read-only)

## Tests

`src/lib/serve/data.test.ts` + `src/lib/serve/server.test.ts` (12 tests, all green):

- `gitDiff` against a **real temp git repo**: commit → modify a tracked file → assert `-original`/`+modified` appear; clean-tree → `''`; non-git dir → `''` (no throw); byte-cap + truncation marker.
- `buildWorktreeDiffs` attaches a real diff to a teammate whose `worktreePath` points at a real worktree; skips teammates with no worktree.
- Boots the server on an **ephemeral loopback port** and asserts: `address` is `127.0.0.1`; `GET /` → 200 HTML; `GET /api/state` → 200 well-formed JSON (`generated_at` + three panels with `ok` flags); `POST` → 405; `GET /events` → SSE `event: state` frame; unknown path → 404.

Verified end-to-end: `node dist/index.js serve --port 4491` boots, `GET /` returns the page, `GET /api/state` returns all three panels `ok:true`, `POST` returns 405.

> Full suite note: 172 pre-existing tests fail on the CI-less dev box used here purely with `spawnSync bun ENOENT` (they shell out to a `bun` binary not installed locally); none touch `src/lib/serve/`. They pass on the real Linux CI runner (which has bun).

## Deferred (explicit follow-ups, not blockers)

- **Usage / cost panel (#323 data)** — the issue calls this out as a follow-up; wiring the usage/cost surface into a fourth panel is left for a subsequent PR.
- **TUI companion** — this increment ships the web surface only.