### PR TITLE
feat(computer): built-in agent loop (computer run) with local-LLM + AX->vision fallback (Closes #334)

### DIFF
--- a/src/commands/computer.ts
+++ b/src/commands/computer.ts
@@ -26,11 +26,15 @@ import {
   hydrateRemoteEnvFromState,
 } from '../lib/ssh-tunnel.js';
 import { registerActionCommands, withClient, unwrap, pickTarget, type AppInfo } from './computer-actions.js';
+import { runComputerLoop, type LoopEvent } from '../lib/computer/loop.js';
+import { makeVerbDispatcher } from '../lib/computer/dispatch.js';
+import { makeClaudeResponder, resolveApiKey, DEFAULT_CLAUDE_MODEL, DEFAULT_CLAUDE_BASE_URL } from '../lib/computer/model.js';
 
 // Help groups — mirror `agents browser` so the mental model carries over.
 const COMPUTER_HELP_GROUPS = [
   { title: 'Installation', names: ['setup'] },
   { title: 'Daemon lifecycle', names: ['start', 'stop', 'reload', 'status'] },
+  { title: 'Autonomous', names: ['run'] },
   { title: 'Observe', names: ['apps', 'describe', 'screenshot', 'get-text'] },
   { title: 'Interact', names: ['launch', 'raise', 'click', 'right-click', 'type', 'type-text', 'key', 'drag', 'scroll', 'ax-action', 'focus', 'wait'] },
 ] as const;
@@ -124,6 +128,7 @@ export function registerComputerSubcommands(program: Command): void {
   registerStopCommand(program);
   registerReloadCommand(program);
   registerStatusCommand(program);
+  registerRunCommand(program);
   registerScreenshotCommand(program);
   registerActionCommands(program);
   registerCommandGroups(program, COMPUTER_HELP_GROUPS);
@@ -182,6 +187,94 @@ function registerStatusCommand(program: Command): void {
         await client.close();
       }
     });
+}
+
+// run — the embedded observe -> act -> verify agent loop. A reasoning model
+// (Claude API by default, or any Anthropic-shaped endpoint via --base-url for
+// Ollama / vLLM / LiteLLM) drives the EXISTING computer verbs as tools over the
+// daemon socket. New subcommand: the explicit verb interface external agents
+// use is unchanged. The loop auto-switches to the screenshot/coordinate path
+// when an app's AX tree comes back opaque (WebView / canvas).
+function registerRunCommand(program: Command): void {
+  program
+    .command('run')
+    .description('Autonomously drive an app from a natural-language task (embedded model loop over the computer verbs)')
+    .requiredOption('--task <s>', 'Natural-language task, e.g. "open Notes and write a haiku"')
+    .option('--bundle <id>', 'Bundle id to focus the loop on (default: frontmost allow-listed app)')
+    .option('--base-url <url>', `Reasoning model base URL — Anthropic wire shape (default: ${DEFAULT_CLAUDE_BASE_URL}; set to a local Ollama/vLLM/LiteLLM endpoint for offline parity)`)
+    .option('--model <id>', `Model id (default: ${DEFAULT_CLAUDE_MODEL})`)
+    .option('--max-steps <n>', 'Max model turns before giving up', (v) => parseInt(v, 10), 12)
+    .option('--max-tokens <n>', 'Max tokens per model turn', (v) => parseInt(v, 10), 1024)
+    .option('--host <device>', 'Drive a remote Windows device (requires `agents computer start --host <device>` first)')
+    .option('--json', 'Emit the final loop result as JSON')
+    .action(async (opts: {
+      task: string;
+      bundle?: string;
+      baseUrl?: string;
+      model?: string;
+      maxSteps: number;
+      maxTokens: number;
+      host?: string;
+      json?: boolean;
+    }) => {
+      const apiKey = resolveApiKey({ apiKey: undefined, baseUrl: opts.baseUrl });
+      // The Claude API needs a key; a local/offline endpoint (non-default base
+      // URL) usually ignores it, so only hard-fail on the default endpoint.
+      if (!apiKey && !opts.baseUrl) {
+        console.error('no API key. Set ANTHROPIC_API_KEY (or AGENTS_COMPUTER_API_KEY), or point --base-url at a local endpoint.');
+        process.exit(1);
+      }
+
+      const responder = makeClaudeResponder({
+        baseUrl: opts.baseUrl,
+        model: opts.model,
+        maxTokens: opts.maxTokens,
+      });
+
+      await withClient(async (client) => {
+        const dispatch = makeVerbDispatcher(client);
+        const targetInput = opts.bundle ? { bundle: opts.bundle } : {};
+
+        const result = await runComputerLoop({
+          task: opts.task,
+          responder: (state) => responder({ ...state, task: describeTaskWithTarget(opts.task, opts.bundle) }),
+          dispatch: (call) => dispatch({ ...call, input: { ...targetInput, ...call.input } }),
+          maxSteps: opts.maxSteps,
+          onEvent: opts.json ? undefined : (e) => printLoopEvent(e),
+        });
+
+        if (opts.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        console.log('');
+        if (result.status === 'done') {
+          console.log(`done (${result.turns} turn${result.turns === 1 ? '' : 's'}): ${result.finalText ?? ''}`);
+        } else {
+          console.log(`stopped: hit max-steps (${result.turns} turns) without a completion signal`);
+        }
+      });
+    });
+}
+
+// Fold the target bundle into the task text so the model biases toward it.
+function describeTaskWithTarget(task: string, bundle?: string): string {
+  return bundle ? `${task}\n(Target app bundle id: ${bundle})` : task;
+}
+
+// Human progress line per loop event — verb + a one-line result digest.
+function printLoopEvent(e: LoopEvent): void {
+  if (e.kind === 'turn') {
+    console.log(`--- turn ${e.index + 1} ---`);
+  } else if (e.kind === 'dispatch') {
+    const tag = e.visionFallback ? ' [ax opaque]' : '';
+    const status = e.result.ok ? 'ok' : `error: ${e.result.error ?? 'unknown'}`;
+    console.log(`  ${e.call.name}${tag} -> ${status}`);
+  } else if (e.kind === 'vision_switch') {
+    console.log('  (switching to vision path: screenshot + coordinate clicks)');
+  } else if (e.kind === 'done') {
+    console.log(`  model: ${e.text}`);
+  }
 }
 
 function registerScreenshotCommand(program: Command): void {

--- a/src/lib/computer/dispatch.test.ts
+++ b/src/lib/computer/dispatch.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import { rpcMethodFor, toRpcParams, makeVerbDispatcher } from './dispatch.js';
+import type { ComputerClient, RPCResponse } from '../computer-rpc.js';
+
+// The verb -> RPC translation in dispatch.ts is the load-bearing seam behind
+// `computer run`: a single wrong param key silently breaks every gated macOS
+// action, with no cross-platform CI guard. These tests pin the exact renames.
+//
+// rpcMethodFor / toRpcParams are pure — exercised directly, no daemon, no
+// mocking of the code under test. For the target-resolution skip logic we drive
+// the real makeVerbDispatcher against a recording ComputerClient; the client is
+// the daemon transport boundary (a legitimate stand-in), not code under test.
+
+describe('rpcMethodFor', () => {
+  it('renames CLI verbs to their daemon RPC method names', () => {
+    // Exact target method names quoted from dispatch.ts:15-24 (RPC_METHOD).
+    expect(rpcMethodFor('apps')).toBe('list_apps');
+    expect(rpcMethodFor('get-text')).toBe('get_text');
+    expect(rpcMethodFor('type-text')).toBe('type_text');
+    expect(rpcMethodFor('ax-action')).toBe('ax_action');
+    expect(rpcMethodFor('right-click')).toBe('right_click');
+    expect(rpcMethodFor('launch')).toBe('launch_app');
+    expect(rpcMethodFor('focus')).toBe('set_focus');
+    expect(rpcMethodFor('raise')).toBe('focus_window');
+  });
+
+  it('passes through verbs that share their RPC method name', () => {
+    expect(rpcMethodFor('describe')).toBe('describe');
+    expect(rpcMethodFor('click')).toBe('click');
+    expect(rpcMethodFor('type')).toBe('type');
+    // An unknown verb passes through unchanged (RPC_METHOD[verb] ?? verb).
+    expect(rpcMethodFor('screenshot')).toBe('screenshot');
+    expect(rpcMethodFor('key')).toBe('key');
+  });
+});
+
+describe('toRpcParams', () => {
+  it('injects pid only when supplied', () => {
+    expect(toRpcParams('describe', {}, 42)).toEqual({ pid: 42 });
+    expect(toRpcParams('describe', {})).toEqual({});
+  });
+
+  it('remaps describe depth -> max_depth', () => {
+    expect(toRpcParams('describe', { depth: 3 }, 7)).toEqual({ pid: 7, max_depth: 3 });
+  });
+
+  it('remaps get-text id -> element_id and maxChars -> max_chars', () => {
+    expect(toRpcParams('get-text', { id: 'e5', maxChars: 200 }, 7)).toEqual({
+      pid: 7,
+      element_id: 'e5',
+      max_chars: 200,
+    });
+  });
+
+  it('remaps click id -> element_id and passes coords/count through', () => {
+    expect(toRpcParams('click', { id: 'e1', x: 10, y: 20, count: 2 }, 7)).toEqual({
+      pid: 7,
+      element_id: 'e1',
+      x: 10,
+      y: 20,
+      count: 2,
+    });
+  });
+
+  it('remaps launch bundle -> bundle_id, path/name pass through', () => {
+    expect(toRpcParams('launch', { bundle: 'com.apple.Finder', name: 'Finder' })).toEqual({
+      bundle_id: 'com.apple.Finder',
+      name: 'Finder',
+    });
+  });
+
+  it('remaps ax-action id -> element_id and passes action through', () => {
+    expect(toRpcParams('ax-action', { id: 'e9', action: 'AXPress' }, 7)).toEqual({
+      pid: 7,
+      element_id: 'e9',
+      action: 'AXPress',
+    });
+  });
+
+  it('remaps focus id -> element_id', () => {
+    expect(toRpcParams('focus', { id: 'e3' }, 7)).toEqual({ pid: 7, element_id: 'e3' });
+  });
+
+  describe('wait', () => {
+    it('remaps duration -> duration_ms', () => {
+      expect(toRpcParams('wait', { duration: 500 })).toEqual({ duration_ms: 500 });
+    });
+
+    it('builds a locator object from role/label/identifier', () => {
+      expect(
+        toRpcParams('wait', { until: 'exists', role: 'AXButton', label: 'OK', identifier: 'ok-btn' }, 7),
+      ).toEqual({
+        pid: 7,
+        until: 'exists',
+        locator: { role: 'AXButton', label: 'OK', identifier: 'ok-btn' },
+      });
+    });
+
+    it('omits the locator entirely when no locator key is present', () => {
+      const params = toRpcParams('wait', { until: 'exists' }, 7);
+      expect(params).toEqual({ pid: 7, until: 'exists' });
+      expect('locator' in params).toBe(false);
+    });
+
+    it('includes only the locator keys that are set', () => {
+      expect(toRpcParams('wait', { role: 'AXButton' })).toEqual({
+        locator: { role: 'AXButton' },
+      });
+    });
+  });
+
+  it('drops keys whose input value is null/undefined', () => {
+    // copyIf only copies when input[from] != null.
+    expect(toRpcParams('get-text', { id: undefined, maxChars: null }, 7)).toEqual({ pid: 7 });
+  });
+});
+
+// A recording ComputerClient: captures every method invocation so we can assert
+// whether the target-resolution roundtrip (`list_apps`) ran. `apps` returns a
+// one-app list so resolveTargetPidDecision could pick a target if it were called.
+function recordingClient(): { client: ComputerClient; calls: Array<{ method: string; params?: Record<string, unknown> }> } {
+  const calls: Array<{ method: string; params?: Record<string, unknown> }> = [];
+  const client: ComputerClient = {
+    async call(method: string, params?: Record<string, unknown>): Promise<RPCResponse> {
+      calls.push({ method, params });
+      if (method === 'list_apps') {
+        return { id: 1, result: { apps: [{ pid: 999, name: 'Finder', bundle_id: 'com.apple.Finder', active: true }] } };
+      }
+      return { id: 1, result: {} };
+    },
+  };
+  return { client, calls };
+}
+
+describe('makeVerbDispatcher target resolution', () => {
+  it('skips resolution for NO_TARGET verb apps (single list_apps call, no pid)', async () => {
+    const { client, calls } = recordingClient();
+    const dispatch = makeVerbDispatcher(client);
+    const res = await dispatch({ name: 'apps', input: {} });
+    expect(res.ok).toBe(true);
+    // `apps` own RPC method IS list_apps; if resolution had also run we'd see a
+    // SECOND list_apps call. Exactly one, with no injected pid, proves the skip.
+    expect(calls).toEqual([{ method: 'list_apps', params: {} }]);
+  });
+
+  it('skips resolution for NO_TARGET verb launch (no list_apps, no pid)', async () => {
+    const { client, calls } = recordingClient();
+    const dispatch = makeVerbDispatcher(client);
+    const res = await dispatch({ name: 'launch', input: { bundle: 'com.apple.Finder' } });
+    expect(res.ok).toBe(true);
+    expect(calls).toEqual([{ method: 'launch_app', params: { bundle_id: 'com.apple.Finder' } }]);
+    expect(calls.some((c) => c.method === 'list_apps')).toBe(false);
+  });
+
+  it('skips resolution for wait with a duration (no list_apps, no pid)', async () => {
+    const { client, calls } = recordingClient();
+    const dispatch = makeVerbDispatcher(client);
+    const res = await dispatch({ name: 'wait', input: { duration: 250 } });
+    expect(res.ok).toBe(true);
+    expect(calls).toEqual([{ method: 'wait', params: { duration_ms: 250 } }]);
+    expect(calls.some((c) => c.method === 'list_apps')).toBe(false);
+  });
+
+  it('DOES resolve the target (list_apps first) for a non-NO_TARGET verb without a pid', async () => {
+    const { client, calls } = recordingClient();
+    const dispatch = makeVerbDispatcher(client);
+    const res = await dispatch({ name: 'describe', input: { depth: 2 } });
+    expect(res.ok).toBe(true);
+    // Contrast case: resolution runs first, then the verb call carries the pid.
+    expect(calls).toEqual([
+      { method: 'list_apps', params: undefined },
+      { method: 'describe', params: { pid: 999, max_depth: 2 } },
+    ]);
+  });
+
+  it('a directly-supplied pid short-circuits resolution (no list_apps)', async () => {
+    const { client, calls } = recordingClient();
+    const dispatch = makeVerbDispatcher(client);
+    const res = await dispatch({ name: 'describe', input: { pid: 321, depth: 1 } });
+    expect(res.ok).toBe(true);
+    expect(calls).toEqual([{ method: 'describe', params: { pid: 321, max_depth: 1 } }]);
+  });
+});

--- a/src/lib/computer/dispatch.ts
+++ b/src/lib/computer/dispatch.ts
@@ -1,0 +1,135 @@
+// Verb dispatcher for the `computer run` loop.
+//
+// Maps a loop VerbCall (CLI-verb name + friendly input) onto the EXISTING
+// computer-helper RPC methods over the daemon socket. It reimplements no verb —
+// it names the same RPC methods the explicit `agents computer <verb>` commands
+// call, so the external-agent verb surface is untouched. The daemon stays the
+// single authority on permissions and targeting.
+
+import type { ComputerClient } from '../computer-rpc.js';
+import { resolveTargetPidDecision, type AppInfo } from '../../commands/computer-actions.js';
+import type { VerbCall, VerbResult, VerbDispatcher } from './loop.js';
+
+// CLI verb -> daemon RPC method. Only the rename cases need listing; the rest
+// pass through by name.
+const RPC_METHOD: Record<string, string> = {
+  apps: 'list_apps',
+  'get-text': 'get_text',
+  'type-text': 'type_text',
+  'ax-action': 'ax_action',
+  'right-click': 'right_click',
+  launch: 'launch_app',
+  focus: 'set_focus',
+  raise: 'focus_window',
+};
+
+// Verbs that do not need a resolved target pid.
+const NO_TARGET = new Set(['apps', 'launch']);
+
+function rpcMethodFor(verb: string): string {
+  return RPC_METHOD[verb] ?? verb;
+}
+
+// Translate the model's friendly input keys into the daemon's param names.
+// pid is injected by the caller after target resolution.
+function toRpcParams(verb: string, input: Record<string, unknown>, pid?: number): Record<string, unknown> {
+  const p: Record<string, unknown> = {};
+  if (pid != null) p.pid = pid;
+
+  const copyIf = (from: string, to: string) => {
+    if (input[from] != null) p[to] = input[from];
+  };
+
+  switch (verb) {
+    case 'describe':
+      copyIf('depth', 'max_depth');
+      break;
+    case 'screenshot':
+      copyIf('quality', 'quality');
+      break;
+    case 'get-text':
+      copyIf('id', 'element_id');
+      copyIf('maxChars', 'max_chars');
+      break;
+    case 'click':
+    case 'right-click':
+    case 'scroll':
+      copyIf('id', 'element_id');
+      copyIf('x', 'x');
+      copyIf('y', 'y');
+      copyIf('count', 'count');
+      copyIf('dx', 'dx');
+      copyIf('dy', 'dy');
+      break;
+    case 'type':
+      copyIf('id', 'element_id');
+      copyIf('x', 'x');
+      copyIf('y', 'y');
+      copyIf('text', 'text');
+      copyIf('commit', 'commit');
+      break;
+    case 'type-text':
+      copyIf('text', 'text');
+      copyIf('commit', 'commit');
+      break;
+    case 'key':
+      copyIf('keys', 'keys');
+      break;
+    case 'ax-action':
+      copyIf('id', 'element_id');
+      copyIf('action', 'action');
+      break;
+    case 'focus':
+      copyIf('id', 'element_id');
+      break;
+    case 'launch':
+      copyIf('bundle', 'bundle_id');
+      copyIf('path', 'path');
+      copyIf('name', 'name');
+      break;
+    case 'wait': {
+      if (input.duration != null) p.duration_ms = input.duration;
+      copyIf('id', 'element_id');
+      copyIf('until', 'until');
+      const locator: Record<string, unknown> = {};
+      for (const k of ['role', 'label', 'identifier'] as const) {
+        if (input[k] != null) locator[k] = input[k];
+      }
+      if (Object.keys(locator).length > 0) p.locator = locator;
+      break;
+    }
+    default:
+      break;
+  }
+  return p;
+}
+
+// Build a dispatcher bound to a live client. Every call is a single daemon
+// round-trip; errors are returned (never thrown) so the loop can feed them
+// back to the model as a tool_result.
+export function makeVerbDispatcher(client: ComputerClient): VerbDispatcher {
+  return async (call: VerbCall): Promise<VerbResult> => {
+    const verb = call.name;
+    const input = call.input ?? {};
+
+    let pid: number | undefined;
+    if (!NO_TARGET.has(verb) && !(verb === 'wait' && input.duration != null)) {
+      const resolved = await resolveTargetPidDecision(
+        client,
+        { pid: input.pid as number | undefined, bundle: input.bundle as string | undefined },
+      );
+      if (!resolved.ok) return { ok: false, error: resolved.error };
+      pid = resolved.pid;
+    }
+
+    const method = rpcMethodFor(verb);
+    const params = toRpcParams(verb, input, pid);
+    const res = await client.call(method, params);
+    if (res.error) return { ok: false, error: `${res.error.code}: ${res.error.message}` };
+    return { ok: true, result: res.result ?? {} };
+  };
+}
+
+// Exposed for tests/diagnostics.
+export { rpcMethodFor, toRpcParams };
+export type { AppInfo };

--- a/src/lib/computer/loop.test.ts
+++ b/src/lib/computer/loop.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import {
+  runComputerLoop,
+  isAxOpaque,
+  AX_OPAQUE_ELEMENT_THRESHOLD,
+  type ModelDecision,
+  type ModelResponder,
+  type VerbCall,
+  type VerbResult,
+} from './loop.js';
+
+// A scripted model: returns each decision in sequence, one per turn. The LLM is
+// a boundary, so we inject a deterministic stand-in — the loop is the code
+// under test, never the model.
+function scriptResponder(script: ModelDecision[]): ModelResponder {
+  let i = 0;
+  return () => {
+    const next = script[i] ?? { toolCalls: [] };
+    i++;
+    return next;
+  };
+}
+
+// A dispatcher that records every verb it saw and returns a scripted result per
+// verb name (falling back to a generic ok). Records ordering so tests can
+// assert the loop drove verbs in the right sequence.
+function fakeDispatcher(results: Record<string, VerbResult> = {}) {
+  const seen: VerbCall[] = [];
+  const dispatch = (call: VerbCall): VerbResult => {
+    seen.push(call);
+    return results[call.name] ?? { ok: true, result: {} };
+  };
+  return { dispatch, seen };
+}
+
+describe('isAxOpaque', () => {
+  it('honors an explicit ax_opaque flag from the daemon', () => {
+    expect(isAxOpaque({ ok: true, result: { ax_opaque: true, element_count: 999 } })).toBe(true);
+  });
+
+  it('treats a shallow tree (element_count at/under threshold) as opaque', () => {
+    expect(isAxOpaque({ ok: true, result: { element_count: AX_OPAQUE_ELEMENT_THRESHOLD } })).toBe(true);
+    expect(isAxOpaque({ ok: true, result: { element_count: AX_OPAQUE_ELEMENT_THRESHOLD + 1 } })).toBe(false);
+  });
+
+  it('treats a childless tree as opaque when no element_count is present', () => {
+    expect(isAxOpaque({ ok: true, result: { tree: { role: 'AXApplication', children: [] } } })).toBe(true);
+    expect(isAxOpaque({ ok: true, result: { tree: { role: 'AXApplication', children: [{}, {}] } } })).toBe(false);
+  });
+
+  it('does not call a failed describe opaque — an error is not an empty tree', () => {
+    expect(isAxOpaque({ ok: false, error: 'app_missing' })).toBe(false);
+  });
+});
+
+describe('runComputerLoop', () => {
+  it('dispatches the model tool calls in order', async () => {
+    const script: ModelDecision[] = [
+      { toolCalls: [{ name: 'describe', input: { pid: 42 } }] },
+      { toolCalls: [{ name: 'click', input: { pid: 42, id: '@e1' } }] },
+      { toolCalls: [], done: { text: 'done' } },
+    ];
+    // describe returns a rich tree so the vision fallback does NOT fire.
+    const { dispatch, seen } = fakeDispatcher({
+      describe: { ok: true, result: { element_count: 50, tree: { children: [{}, {}] } } },
+    });
+
+    const res = await runComputerLoop({ task: 't', responder: scriptResponder(script), dispatch, maxSteps: 10 });
+
+    expect(res.status).toBe('done');
+    expect(res.finalText).toBe('done');
+    expect(res.dispatched).toEqual(['describe', 'click']);
+    expect(seen.map((c) => c.name)).toEqual(['describe', 'click']);
+    expect(res.visionMode).toBe(false);
+  });
+
+  it('honors maxSteps when the model never declares done', async () => {
+    // Model asks for a key press every turn, forever.
+    const responder: ModelResponder = () => ({ toolCalls: [{ name: 'key', input: { keys: 'esc' } }] });
+    const { dispatch, seen } = fakeDispatcher();
+
+    const res = await runComputerLoop({ task: 't', responder, dispatch, maxSteps: 3 });
+
+    expect(res.status).toBe('max_steps');
+    expect(res.turns).toBe(3);
+    // One key dispatch per turn, capped at maxSteps.
+    expect(seen.map((c) => c.name)).toEqual(['key', 'key', 'key']);
+  });
+
+  it('switches to the vision path when describe returns ax_opaque', async () => {
+    const script: ModelDecision[] = [
+      { toolCalls: [{ name: 'describe', input: { pid: 7, bundle: 'com.example.web' } }] },
+      { toolCalls: [{ name: 'click', input: { x: 100, y: 200 } }] },
+      { toolCalls: [], done: { text: 'ok' } },
+    ];
+    // Opaque describe (WebView-style): explicit flag from the daemon.
+    const { dispatch, seen } = fakeDispatcher({
+      describe: { ok: true, result: { ax_opaque: true, element_count: 1 } },
+      screenshot: { ok: true, result: { width: 800, height: 600 } },
+    });
+
+    const res = await runComputerLoop({ task: 't', responder: scriptResponder(script), dispatch, maxSteps: 10 });
+
+    // The loop auto-injects a screenshot right after the opaque describe — the
+    // vision switch — then continues with the model's coordinate click.
+    expect(res.dispatched).toEqual(['describe', 'screenshot', 'click']);
+    expect(res.visionMode).toBe(true);
+
+    // The auto-injected screenshot inherits the describe's target selector.
+    const shot = seen.find((c) => c.name === 'screenshot');
+    expect(shot?.input).toEqual({ pid: 7, bundle: 'com.example.web' });
+
+    // The opaque describe step is marked as the fallback trigger.
+    const describeStep = res.steps.find((s) => s.call.name === 'describe');
+    expect(describeStep?.visionFallback).toBe(true);
+  });
+
+  it('does not fire the vision fallback for a rich describe', async () => {
+    const script: ModelDecision[] = [
+      { toolCalls: [{ name: 'describe', input: { pid: 1 } }] },
+      { toolCalls: [], done: { text: 'ok' } },
+    ];
+    const { dispatch } = fakeDispatcher({
+      describe: { ok: true, result: { element_count: 120, tree: { children: [{}, {}, {}] } } },
+    });
+
+    const res = await runComputerLoop({ task: 't', responder: scriptResponder(script), dispatch, maxSteps: 10 });
+
+    expect(res.dispatched).toEqual(['describe']);
+    expect(res.visionMode).toBe(false);
+  });
+
+  it('streams events for turns, dispatches, and the vision switch', async () => {
+    const script: ModelDecision[] = [
+      { toolCalls: [{ name: 'describe', input: { pid: 9 } }] },
+      { toolCalls: [], done: { text: 'fin' } },
+    ];
+    const { dispatch } = fakeDispatcher({
+      describe: { ok: true, result: { ax_opaque: true } },
+    });
+    const events: string[] = [];
+
+    await runComputerLoop({
+      task: 't',
+      responder: scriptResponder(script),
+      dispatch,
+      maxSteps: 10,
+      onEvent: (e) => events.push(e.kind),
+    });
+
+    expect(events).toContain('vision_switch');
+    expect(events).toContain('done');
+    expect(events.filter((e) => e === 'dispatch').length).toBe(2); // describe + auto screenshot
+  });
+});

--- a/src/lib/computer/loop.ts
+++ b/src/lib/computer/loop.ts
@@ -1,0 +1,183 @@
+// The embedded observe -> act -> verify loop behind `agents computer run`.
+//
+// This module owns ONLY the decision logic: given a reasoning model (a
+// boundary, injected as `responder`) and a verb dispatcher (the existing
+// computer-helper RPC surface, injected as `dispatch`), it drives the model's
+// tool calls against the daemon, step by step, until the model declares the
+// task done or `maxSteps` is hit.
+//
+// The model and the daemon are boundaries — neither is code under test. The
+// loop itself (verb ordering, max-steps, the AX -> vision fallback) is the
+// unit under test. See loop.test.ts, which injects a scripted fake responder
+// and a fake dispatcher.
+
+// A single tool call the model wants to run this turn. `name` is a CLI verb
+// (describe, screenshot, click, ...), NOT an RPC method — the dispatcher owns
+// the verb -> RPC mapping so external-agent callers of the verbs are untouched.
+export interface VerbCall {
+  name: string;
+  input: Record<string, unknown>;
+}
+
+// The outcome of dispatching one verb. Mirrors the RPC envelope shape
+// (result-or-error) so the real dispatcher is a thin adapter over
+// openComputerClient().call().
+export interface VerbResult {
+  ok: boolean;
+  result?: Record<string, unknown>;
+  error?: string;
+}
+
+// One step of the transcript: the call the model made and what came back.
+// `visionFallback` marks the describe step that tripped the AX -> vision
+// switch (its auto-injected screenshot follows as the next step).
+export interface LoopStep {
+  call: VerbCall;
+  result: VerbResult;
+  visionFallback?: boolean;
+}
+
+// The running state handed to the responder each turn so it can decide the
+// next move. Kept serialisable so the default Claude responder can render it
+// straight into a messages array.
+export interface LoopState {
+  task: string;
+  steps: LoopStep[];
+  // Flipped true the first time a describe comes back AX-opaque. Once set, the
+  // loop steers the model toward the coordinate/vision path for that surface.
+  visionMode: boolean;
+}
+
+// What the model decides for a turn: either run some tool calls, or finish.
+export interface ModelDecision {
+  toolCalls: VerbCall[];
+  done?: { text: string };
+}
+
+export type ModelResponder = (state: LoopState) => ModelDecision | Promise<ModelDecision>;
+export type VerbDispatcher = (call: VerbCall) => VerbResult | Promise<VerbResult>;
+
+export interface LoopConfig {
+  task: string;
+  responder: ModelResponder;
+  dispatch: VerbDispatcher;
+  // Max model turns before the loop gives up. A "turn" is one responder call,
+  // regardless of how many tool calls it emits.
+  maxSteps: number;
+  // Fired after every dispatched verb (incl. auto-injected screenshots) so the
+  // command layer can stream progress. Optional; pure loop logic ignores it.
+  onEvent?: (event: LoopEvent) => void;
+}
+
+export type LoopEvent =
+  | { kind: 'turn'; index: number }
+  | { kind: 'dispatch'; call: VerbCall; result: VerbResult; visionFallback?: boolean }
+  | { kind: 'vision_switch'; describe: VerbResult }
+  | { kind: 'done'; text: string }
+  | { kind: 'max_steps' };
+
+export interface LoopResult {
+  status: 'done' | 'max_steps';
+  finalText?: string;
+  steps: LoopStep[];
+  // Every verb name dispatched, in order, including auto-injected screenshots.
+  // The primary assertion surface for the loop's ordering behavior.
+  dispatched: string[];
+  visionMode: boolean;
+  turns: number;
+}
+
+// Below this many AX elements the tree is treated as opaque — a WebView, a
+// Qt/Electron surface that never populated its AX tree, or a canvas app. The
+// model then works from pixels + coordinate clicks instead of element ids.
+export const AX_OPAQUE_ELEMENT_THRESHOLD = 3;
+
+// Describe-time heuristic. An explicit `ax_opaque: true` from the daemon wins.
+// Otherwise: a failed describe is NOT opaque (it's an error, surface it), and a
+// successful one is opaque when its element_count is at/under the threshold or
+// its tree has no children. Pure so the rule is unit-testable in isolation.
+export function isAxOpaque(result: VerbResult): boolean {
+  const r = result.result ?? {};
+  if (r.ax_opaque === true) return true;
+  if (!result.ok) return false;
+
+  const count = typeof r.element_count === 'number' ? r.element_count : undefined;
+  if (count !== undefined) return count <= AX_OPAQUE_ELEMENT_THRESHOLD;
+
+  const tree = r.tree as { children?: unknown } | null | undefined;
+  const children = tree && Array.isArray(tree.children) ? tree.children : [];
+  return children.length === 0;
+}
+
+// Drive the loop to completion. Returns the transcript, the ordered verb names
+// dispatched, and whether the vision fallback ever fired.
+export async function runComputerLoop(config: LoopConfig): Promise<LoopResult> {
+  const state: LoopState = { task: config.task, steps: [], visionMode: false };
+  const dispatched: string[] = [];
+  const emit = config.onEvent ?? (() => {});
+
+  let turns = 0;
+  while (turns < config.maxSteps) {
+    emit({ kind: 'turn', index: turns });
+    turns++;
+
+    const decision = await config.responder(state);
+
+    if (decision.done) {
+      emit({ kind: 'done', text: decision.done.text });
+      return {
+        status: 'done',
+        finalText: decision.done.text,
+        steps: state.steps,
+        dispatched,
+        visionMode: state.visionMode,
+        turns,
+      };
+    }
+
+    for (const call of decision.toolCalls) {
+      const result = await config.dispatch(call);
+      dispatched.push(call.name);
+
+      // AX -> vision fallback. When a describe comes back opaque, the element
+      // ids the model would click are useless, so the loop flips visionMode and
+      // immediately hands the model pixels: it auto-dispatches a screenshot of
+      // the same target. The explicit verbs stay untouched for external callers
+      // — this switch lives entirely in the loop.
+      if (call.name === 'describe' && isAxOpaque(result)) {
+        state.visionMode = true;
+        state.steps.push({ call, result, visionFallback: true });
+        emit({ kind: 'dispatch', call, result, visionFallback: true });
+        emit({ kind: 'vision_switch', describe: result });
+
+        const shotCall: VerbCall = { name: 'screenshot', input: pickTargetInput(call.input) };
+        const shot = await config.dispatch(shotCall);
+        dispatched.push(shotCall.name);
+        state.steps.push({ call: shotCall, result: shot });
+        emit({ kind: 'dispatch', call: shotCall, result: shot });
+        continue;
+      }
+
+      state.steps.push({ call, result });
+      emit({ kind: 'dispatch', call, result });
+    }
+  }
+
+  emit({ kind: 'max_steps' });
+  return {
+    status: 'max_steps',
+    steps: state.steps,
+    dispatched,
+    visionMode: state.visionMode,
+    turns,
+  };
+}
+
+// Carry the target selector (pid/bundle) from the describe call onto the
+// auto-injected screenshot so the vision fallback captures the same surface.
+function pickTargetInput(input: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (input.pid != null) out.pid = input.pid;
+  if (input.bundle != null) out.bundle = input.bundle;
+  return out;
+}

--- a/src/lib/computer/model.ts
+++ b/src/lib/computer/model.ts
@@ -1,0 +1,195 @@
+// Default reasoning model for the `computer run` loop.
+//
+// This is a BOUNDARY, not loop logic. It turns the loop's LoopState into an
+// Anthropic Messages API request (tool use), sends it to the Claude API by
+// default OR to a configurable base URL (Ollama / vLLM / LiteLLM serving the
+// Anthropic wire shape) for local/offline parity, and parses the reply back
+// into a ModelDecision the loop can act on.
+//
+// The loop (loop.ts) never imports this — it takes a ModelResponder callback,
+// so the unit tests inject a scripted fake instead of ever hitting a network.
+
+import type { LoopState, ModelDecision, ModelResponder, VerbCall } from './loop.js';
+
+// The verb surface exposed to the model as tools. Names match the CLI verbs
+// (and the dispatcher's verb -> RPC mapping), so nothing here reimplements a
+// verb — the model just names one and the dispatcher runs it over the daemon.
+interface ToolSpec {
+  name: string;
+  description: string;
+  input_schema: { type: 'object'; properties: Record<string, unknown>; required?: string[] };
+}
+
+const TARGET_PROPS = {
+  bundle: { type: 'string', description: 'Bundle id of the target app (default: frontmost allow-listed app)' },
+  pid: { type: 'number', description: 'Target pid (overrides bundle)' },
+};
+
+export const COMPUTER_TOOLS: ToolSpec[] = [
+  { name: 'apps', description: 'List allow-listed apps currently running.', input_schema: { type: 'object', properties: {} } },
+  {
+    name: 'describe',
+    description: 'Dump the accessibility tree of the target app. Element ids feed click/type via id. If the tree is opaque the loop auto-captures a screenshot for you.',
+    input_schema: { type: 'object', properties: { ...TARGET_PROPS, depth: { type: 'number' } } },
+  },
+  {
+    name: 'screenshot',
+    description: 'Capture the target app window as an image (the vision path — use coordinate clicks off it).',
+    input_schema: { type: 'object', properties: { ...TARGET_PROPS } },
+  },
+  {
+    name: 'get-text',
+    description: 'Extract visible text from the target app (or a subtree via id).',
+    input_schema: { type: 'object', properties: { ...TARGET_PROPS, id: { type: 'string' } } },
+  },
+  {
+    name: 'click',
+    description: 'Click an element (id from describe) or a screen coordinate (x,y). Use x,y after a vision screenshot.',
+    input_schema: { type: 'object', properties: { ...TARGET_PROPS, id: { type: 'string' }, x: { type: 'number' }, y: { type: 'number' } } },
+  },
+  {
+    name: 'type',
+    description: 'Set a field value (id) or paste at a coordinate. Set commit=true to submit.',
+    input_schema: { type: 'object', properties: { ...TARGET_PROPS, id: { type: 'string' }, x: { type: 'number' }, y: { type: 'number' }, text: { type: 'string' }, commit: { type: 'boolean' } }, required: ['text'] },
+  },
+  {
+    name: 'type-text',
+    description: 'Type a unicode string into the focused field. Focus it first with click or focus.',
+    input_schema: { type: 'object', properties: { ...TARGET_PROPS, text: { type: 'string' }, commit: { type: 'boolean' } }, required: ['text'] },
+  },
+  {
+    name: 'key',
+    description: 'Send a key chord, e.g. "cmd+s", "enter", "esc".',
+    input_schema: { type: 'object', properties: { ...TARGET_PROPS, keys: { type: 'string' } }, required: ['keys'] },
+  },
+  {
+    name: 'launch',
+    description: 'Launch an app by bundle id, path, or name.',
+    input_schema: { type: 'object', properties: { bundle: { type: 'string' }, path: { type: 'string' }, name: { type: 'string' } } },
+  },
+  {
+    name: 'wait',
+    description: 'Wait for a duration (ms) or for an element to appear.',
+    input_schema: { type: 'object', properties: { ...TARGET_PROPS, duration: { type: 'number' }, id: { type: 'string' }, role: { type: 'string' }, label: { type: 'string' } } },
+  },
+];
+
+export interface ClaudeResponderConfig {
+  baseUrl?: string;
+  apiKey?: string;
+  model?: string;
+  maxTokens?: number;
+  // Injectable for tests; defaults to the global fetch.
+  fetchImpl?: typeof fetch;
+}
+
+export const DEFAULT_CLAUDE_BASE_URL = 'https://api.anthropic.com';
+export const DEFAULT_CLAUDE_MODEL = 'claude-sonnet-4-6';
+export const ANTHROPIC_VERSION = '2023-06-01';
+
+// Resolve the API key: explicit config, then the standard Anthropic env var,
+// then a computer-run-specific override. A local Anthropic-shaped endpoint
+// (Ollama/vLLM/LiteLLM) usually ignores the key, so an empty key is allowed
+// when a non-default base URL is set.
+export function resolveApiKey(config: ClaudeResponderConfig, env: NodeJS.ProcessEnv = process.env): string {
+  return config.apiKey || env.AGENTS_COMPUTER_API_KEY || env.ANTHROPIC_API_KEY || '';
+}
+
+// Build the system prompt. In vision mode we steer the model onto coordinate
+// clicks off screenshots, because element ids from an opaque tree are useless.
+export function buildSystemPrompt(state: LoopState): string {
+  const lines = [
+    'You are driving a macOS desktop through accessibility + vision tools to accomplish a task.',
+    'Loop: observe (describe / screenshot / get-text), act (click / type / key), then verify the result before the next step.',
+    'Prefer element ids from describe. When you are confident the task is complete, stop calling tools and reply with a short completion summary.',
+    `Task: ${state.task}`,
+  ];
+  if (state.visionMode) {
+    lines.push('NOTE: the accessibility tree for the current surface is opaque (WebView / canvas). Work from the screenshot and click by x,y coordinates instead of element ids.');
+  }
+  return lines.join('\n');
+}
+
+type AnthropicBlock =
+  | { type: 'text'; text: string }
+  | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+  | { type: 'tool_result'; tool_use_id: string; content: string };
+
+interface AnthropicMessage {
+  role: 'user' | 'assistant';
+  content: AnthropicBlock[];
+}
+
+// Reconstruct the Anthropic message array from the loop transcript. We rebuild
+// from scratch each turn (the loop holds canonical state), synthesizing stable
+// tool_use ids per step so each tool_result pairs with its call.
+export function buildMessages(state: LoopState): AnthropicMessage[] {
+  const messages: AnthropicMessage[] = [
+    { role: 'user', content: [{ type: 'text', text: `Begin. Task: ${state.task}` }] },
+  ];
+  state.steps.forEach((step, i) => {
+    const id = `call_${i}`;
+    messages.push({ role: 'assistant', content: [{ type: 'tool_use', id, name: step.call.name, input: step.call.input }] });
+    const summary = step.result.ok
+      ? JSON.stringify(step.result.result ?? {}).slice(0, 4000)
+      : `error: ${step.result.error ?? 'unknown'}`;
+    const note = step.visionFallback ? ' [ax tree opaque — auto-captured screenshot follows; use coordinate clicks]' : '';
+    messages.push({ role: 'user', content: [{ type: 'tool_result', tool_use_id: id, content: summary + note }] });
+  });
+  return messages;
+}
+
+// Parse the Anthropic response body into a ModelDecision. tool_use blocks
+// become tool calls; a reply with no tool calls is treated as the model
+// finishing, with its text as the summary.
+export function parseDecision(body: unknown): ModelDecision {
+  const content = (body as { content?: unknown }).content;
+  const blocks = Array.isArray(content) ? content : [];
+  const toolCalls: VerbCall[] = [];
+  const texts: string[] = [];
+  for (const block of blocks) {
+    const b = block as { type?: string; name?: string; input?: unknown; text?: string };
+    if (b.type === 'tool_use' && typeof b.name === 'string') {
+      toolCalls.push({ name: b.name, input: (b.input as Record<string, unknown>) ?? {} });
+    } else if (b.type === 'text' && typeof b.text === 'string') {
+      texts.push(b.text);
+    }
+  }
+  if (toolCalls.length === 0) {
+    return { toolCalls: [], done: { text: texts.join('\n').trim() || 'no further action' } };
+  }
+  return { toolCalls };
+}
+
+// The default responder: one Anthropic Messages call per turn.
+export function makeClaudeResponder(config: ClaudeResponderConfig = {}): ModelResponder {
+  const baseUrl = (config.baseUrl || DEFAULT_CLAUDE_BASE_URL).replace(/\/+$/, '');
+  const model = config.model || DEFAULT_CLAUDE_MODEL;
+  const maxTokens = config.maxTokens ?? 1024;
+  const doFetch = config.fetchImpl ?? fetch;
+  const apiKey = resolveApiKey(config);
+
+  return async (state: LoopState): Promise<ModelDecision> => {
+    const res = await doFetch(`${baseUrl}/v1/messages`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': ANTHROPIC_VERSION,
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: maxTokens,
+        system: buildSystemPrompt(state),
+        tools: COMPUTER_TOOLS,
+        messages: buildMessages(state),
+      }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`model request failed: ${res.status} ${res.statusText} ${text.slice(0, 500)}`);
+    }
+    const body = await res.json();
+    return parseDecision(body);
+  };
+}


### PR DESCRIPTION
## What shipped

First increment of #334 — the embedded agent loop, a configurable model endpoint, and the AX->vision fallback. Kept tight; full task-success benchmarking is follow-up.

**`agents computer run --task "<natural language>"`** — an embedded observe -> act -> verify loop that drives the **existing** computer verbs (describe/screenshot/click/type/key/...) as tools over the launchd daemon socket.

- **Configurable reasoning endpoint.** Claude API by default, or any Anthropic-wire-shape endpoint via `--base-url` (Ollama / vLLM / LiteLLM) for local/offline parity. `--model`, `--max-steps`, `--max-tokens` too.
- **Auto AX->vision fallback.** `isAxOpaque()` (describe-time heuristic) flags an empty/shallow AX tree — or an explicit daemon `ax_opaque: true`. When a `describe` comes back opaque (WebView / canvas), the loop flips `visionMode`, auto-captures a screenshot of the same target, and steers the model onto coordinate clicks. The explicit verbs stay untouched for external agents.
- **New subcommand, zero regression.** `computer run` is additive. The existing verb tool interface external-agent callers use is unchanged.

## Reuse anchors (no verb reimplemented)

- Verb dispatch over the daemon: `src/lib/computer/dispatch.ts` calls the same RPC methods as `src/commands/computer-actions.ts`, reusing `resolveTargetPidDecision` for targeting and `openComputerClient` (`src/lib/computer-rpc.ts`) for transport.
- Registered in the command tree at `src/commands/computer.ts` (`registerRunCommand`), gated by the existing macOS `preAction` hook.

## Test

`src/lib/computer/loop.test.ts` (9 tests, deterministic) unit-tests the **pure decision logic** with an injected fake model responder + fake dispatcher — no real LLM, no real screen:

- dispatches scripted tool calls in order
- honors `--max-steps` when the model never finishes
- switches to the vision path (`describe -> screenshot -> click`) when `describe` returns `ax_opaque:true`, inheriting the describe target
- does **not** fire the fallback for a rich tree
- `isAxOpaque` heuristic edges (explicit flag, element_count threshold, childless tree, failed describe)

`src/lib/computer/dispatch.test.ts` (19 tests, cross-platform, no daemon) pins the **verb -> RPC translation seam** — the highest-risk macOS-gated surface, previously untested. Exercises the pure `rpcMethodFor` / `toRpcParams` directly, and the real `makeVerbDispatcher` against a recording `ComputerClient` (daemon transport boundary; no mocking of code under test):

- `rpcMethodFor` renames (`apps->list_apps`, `get-text->get_text`, `type-text->type_text`, `ax-action->ax_action`, `right-click->right_click`, `launch->launch_app`, `focus->set_focus`, `raise->focus_window`) + pass-through for `describe`/`click`/`type`
- `toRpcParams` key remaps (`id->element_id`, `depth->max_depth`, `maxChars->max_chars`, `duration->duration_ms`, launch `bundle->bundle_id`) and the `wait` locator `{role,label,identifier}` shape
- `NO_TARGET` verbs (`apps`, `launch`) and `wait`-with-duration skip the `list_apps` target-resolution roundtrip; a supplied `pid` short-circuits it

Guards against a silent param-key drift that would otherwise only surface on a macOS host at runtime.

> Note: `COMPUTER_TOOLS` (`src/lib/computer/model.ts`) intentionally exposes a **curated verb subset** to the model — `scroll`/`drag`/`right-click`/`ax-action`/`focus`/`raise` are omitted as a disclosed v1 subset. The dispatcher still maps all of them (kept general), so widening the model surface later needs no dispatch change.

## Verification

- `bunx tsc --noEmit`: clean.
- `bun run test src/lib/computer/loop.test.ts`: 9/9 green. `dispatch.test.ts`: 19/19 green.
- Full suite green apart from a pre-existing CPU-starvation flake in `tests/daemon.test.ts` (a *different* synchronous string-generator times out per run; passes 12/12 with `--no-file-parallelism`) — unrelated to this change.
- Smoke-tested on macOS: `computer run --help`, the no-API-key guard, and the `--base-url` path reaching the daemon boundary.

## Follow-up

- Full task-success benchmarking / eval harness.
- Optional daemon-side `ax_opaque` emission (currently computed describe-time in the loop).
