### PR TITLE
feat(secrets): accept 'never' prompt-policy surface + no-ACL Swift path (Part of #421)

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -167,8 +167,9 @@ Source: `src/lib/secrets/remote.ts` (transport + resolve), wired into `list` /
 | `secrets unlock <name> --ttl <dur>` | Hold for a custom lifetime (default 24h) | `agents secrets unlock prod --ttl 30m` |
 | `secrets lock [names...]` | Wipe held bundles from the agent (default: all) — next read re-prompts | `agents secrets lock` |
 | `secrets status` | Show which bundles the agent holds and when they lock | `agents secrets status` |
-| `secrets policy <bundle> [policy]` | Show or set a bundle's prompt policy: `daily` (default) or `always` | `agents secrets policy signing always` |
+| `secrets policy <bundle> [policy]` | Show or set a bundle's prompt policy: `daily` (default), `always`, or `never` (silent, no biometry ACL — needs `--i-understand`) | `agents secrets policy signing always` |
 | `secrets create <name> --policy always` | Create a bundle that prompts on every read | `agents secrets create signing --policy always` |
+| `secrets create <name> --policy never --i-understand` | Create a silent, unprotected (no biometry ACL) automation-only bundle | `agents secrets create ci-cache --policy never --i-understand` |
 
 See [The secrets-agent](#the-secrets-agent-macos) below for the model and the security trade-off.
 
@@ -389,6 +390,8 @@ What the macOS Keychain ACL actually protects:
 - Keychain items are written with `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` plus an access control of `biometryCurrentSet OR devicePasscode`. Source: `src/lib/secrets/keychain-helper.swift:32-44`.
 - That ACL is **user-presence**, not **code-identity**. The OS does not pin the item to the helper binary's code signature. Any same-user process that calls `SecItemCopyMatching` with the same service+account names and pops Touch ID (or the password sheet) gets the value.
 
+The **`never` prompt-policy drops even the user-presence check.** A `never` bundle is stored *without* the biometry access control (`set-no-acl` in the helper uses a plain `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` and attaches no `kSecAttrAccessControl`), so reads are fully silent — no Touch ID, no broker, no user-presence gate at all. That means **any code running as your user reads it with zero interaction**, which is exactly the on-disk-plaintext-equivalent exposure the biometry ACL otherwise mitigates. Reserve `never` for low-sensitivity, automation-only credentials, and never put a high-value secret (signing keys, long-lived cloud tokens) in a `never` bundle. Creating or switching to `never` requires an explicit confirmation (`--i-understand`, or an interactive "are you sure" prompt) precisely because it is the global downgrade the rest of this model is built to avoid. See [Prompt policy and auto-cache](#prompt-policy-and-auto-cache) for the operational details.
+
 Practical implications:
 
 - A malicious binary running as your user, with you logged in at the keyboard, can read any bundle by popping Touch ID with a prompt that says "Unlock agents-cli secrets". Don't approve Touch ID prompts you didn't initiate.
@@ -430,10 +433,11 @@ Each bundle has a **prompt policy** that controls how often macOS asks for Touch
 
 - **`daily`** (default): ask once, then hold it silently. The **first real keychain read auto-loads it** into the broker (in the background, no added latency), so the next concurrent run reads it silently without you running `unlock` at all — one Touch ID per ~24h. Held from that unlock (not refreshed on use) — re-asks sooner after screen-lock, sleep, logout, or `lock`. Despite the name, it is **not** tied to one calendar day or one login session; it's the rolling ~24h hold.
 - **`always`**: ask every time. Only an explicit `unlock` ever puts it in the agent; every other read pops Touch ID. Opt high-value bundles (signing keys, etc.) into this when you want to confirm every single read.
+- **`never`**: stored **without** the biometry access control — reads are fully silent (no Touch ID, no broker, no user-presence check). This is the least-safe tier and is [documented in the security model](#security-model) as an on-disk-plaintext-equivalent downgrade: any code running as your user reads it with zero interaction. It is marked loudly (`never · NO ACL`, in red) in `agents secrets list` and `view`, and creating or switching to it requires an explicit confirmation — an interactive "are you sure" prompt, or `--i-understand` in a headless shell. Reserve it for low-sensitivity, automation-only credentials. Writing a `never` item needs a signed helper that carries the `set-no-acl` path; an older pinned helper rejects the write loudly rather than silently storing an `always`-style ACL'd item.
 
-Change the **default** for all bundles globally in `agents.yaml` (`secrets.policy: always` to flip it back), or override per bundle with `agents secrets policy <bundle> always`.
+Change the **default** for all bundles globally in `agents.yaml` (`secrets.policy: always` to flip it back), or override per bundle with `agents secrets policy <bundle> always`. `never` is never a *default* — it can only be set explicitly per bundle, behind the confirmation gate.
 
-> Wire-format note: the policy persists under the legacy `tier` key (`session` == `daily`, `biometry` == explicit `always`, absent == inherit the default) so bundles stay readable across mixed CLI versions on synced machines. `--tier`/`agents secrets tier` and the old `biometry`/`session` values still work as aliases.
+> Wire-format note: the policy persists under the legacy `tier` key (`session` == `daily`, `biometry` == explicit `always`, `none` == `never`, absent == inherit the default) so bundles stay readable across mixed CLI versions on synced machines. `--tier`/`agents secrets tier` and the old `biometry`/`session`/`none` values still work as aliases. An older CLI that doesn't know `none` reads it as absent and falls back to its own default — safe, since it also lacks the no-ACL write path.
 
 ```yaml
 # ~/.agents/agents.yaml
@@ -443,7 +447,7 @@ secrets:
     auto: false   # opt OUT of daily-policy self-caching (on by default)
 ```
 
-Auto-cache is **on by default** and only ever applies to `daily`-policy bundles — an `always` bundle is never auto-held. (A third `never` policy — items stored without the biometry ACL for fully silent reads with no agent — is intentionally not offered yet; it needs a separate signed-helper change and is the global downgrade the agent is designed to avoid. Tracked in [issue #421](https://github.com/phnx-labs/agents-cli/issues/421).)
+Auto-cache is **on by default** and only ever applies to `daily`-policy bundles — an `always` bundle is never auto-held, and a `never` bundle needs no agent at all (it is already silent). The `never` policy (items stored without the biometry ACL for fully silent reads with no broker) is the global downgrade the agent is otherwise designed to avoid, so it stays gated behind an explicit confirmation and a signed helper with the `set-no-acl` write path; see the [security model](#security-model). Tracked in [issue #421](https://github.com/phnx-labs/agents-cli/issues/421).
 
 **The trade-off (read this):** while a bundle is unlocked, a same-user process that can reach the socket reads it **silently** — today it would at least have to pop a visible "Unlock agents-cli secrets" prompt you might notice. That is the same trust boundary the keychain already concedes above ("any same-user process can pop the prompt and read"), minus the prompt. Bound it by unlocking only the bundles you need, keeping a short TTL, locking when you step away, and never unlocking high-value bundles you'd rather always confirm.
 

--- a/src/commands/secrets.test.ts
+++ b/src/commands/secrets.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { assertValidSshTarget, buildSecretsExecEnv, bundleEnvToDotenv, quoteWin32ExecArg } from './secrets.js';
-import { parseDotenv } from '../lib/secrets/bundles.js';
+import {
+  assertValidSshTarget,
+  assertNeverPolicyAcknowledged,
+  buildSecretsExecEnv,
+  bundleEnvToDotenv,
+  parsePolicyOpt,
+  quoteWin32ExecArg,
+  renderPolicyCol,
+} from './secrets.js';
+import { parseDotenv, type SecretsBundle } from '../lib/secrets/bundles.js';
 
 describe('assertValidSshTarget', () => {
   it('accepts bare ssh-config aliases and user@host', () => {
@@ -20,6 +28,65 @@ describe('assertValidSshTarget', () => {
     expect(() => assertValidSshTarget('a`id`')).toThrow();
     expect(() => assertValidSshTarget('a@b@c')).toThrow();
     expect(() => assertValidSshTarget('')).toThrow();
+  });
+});
+
+describe('parsePolicyOpt', () => {
+  it('accepts the three policies and their legacy aliases', () => {
+    expect(parsePolicyOpt('always')).toBe('always');
+    expect(parsePolicyOpt('biometry')).toBe('always');
+    expect(parsePolicyOpt('daily')).toBe('daily');
+    expect(parsePolicyOpt('session')).toBe('daily');
+    // The whole point of #421: `never` (and its `none` alias) is now accepted,
+    // not rejected by the old stub.
+    expect(parsePolicyOpt('never')).toBe('never');
+    expect(parsePolicyOpt('none')).toBe('never');
+    expect(parsePolicyOpt('NEVER')).toBe('never');
+  });
+
+  it('throws on an unknown policy', () => {
+    expect(() => parsePolicyOpt('sometimes')).toThrow(/Invalid policy/);
+  });
+});
+
+describe('assertNeverPolicyAcknowledged', () => {
+  it('is a no-op for non-never policies regardless of flags', () => {
+    expect(assertNeverPolicyAcknowledged('always', { interactive: false })).toBe('ok');
+    expect(assertNeverPolicyAcknowledged('daily', { interactive: false })).toBe('ok');
+    expect(assertNeverPolicyAcknowledged(undefined, { interactive: false })).toBe('ok');
+  });
+
+  it('REQUIRES confirmation for never: headless without --i-understand is rejected', () => {
+    // This is the guard — a headless `create --policy never` must not silently
+    // downgrade a bundle's protection.
+    expect(() => assertNeverPolicyAcknowledged('never', { interactive: false }))
+      .toThrow(/Refusing to set the 'never' prompt-policy/);
+  });
+
+  it('accepts never when --i-understand is passed (headless opt-in)', () => {
+    expect(assertNeverPolicyAcknowledged('never', { iUnderstand: true, interactive: false })).toBe('ok');
+  });
+
+  it('defers to an interactive prompt for never in a TTY', () => {
+    expect(assertNeverPolicyAcknowledged('never', { interactive: true })).toBe('prompt');
+  });
+});
+
+describe('renderPolicyCol', () => {
+  const bundle = (policy: SecretsBundle['policy']): SecretsBundle => ({ name: 'b', vars: {}, policy });
+
+  it('marks a never bundle distinctly and loudly', () => {
+    const never = renderPolicyCol(bundle('never'));
+    expect(never).toMatch(/never/);
+    expect(never).toMatch(/NO ACL/i);
+    // Distinct from the other tiers — the marking is not shared.
+    expect(never).not.toBe(renderPolicyCol(bundle('always')));
+    expect(never).not.toBe(renderPolicyCol(bundle('daily')));
+  });
+
+  it('does not label always/daily bundles as never', () => {
+    expect(renderPolicyCol(bundle('always'))).not.toMatch(/never/i);
+    expect(renderPolicyCol(bundle('daily'))).not.toMatch(/never/i);
   });
 });
 

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -346,7 +346,9 @@ function compactRemaining(expiresAt: number): string {
 /** The POLICY column for `secrets list`: the prompt policy, plus a "Nh left"
  * hint when a `daily` bundle is currently held by the secrets-agent. `held`
  * maps bundle name → expiry epoch-ms (from agentStatus()). */
-function renderPolicyCol(b: SecretsBundle, held?: Map<string, number>): string {
+export function renderPolicyCol(b: SecretsBundle, held?: Map<string, number>): string {
+  // `never` is loud on purpose — it's the only tier with no user-presence gate.
+  if (bundlePolicy(b) === 'never') return chalk.red.bold('never · NO ACL');
   if (bundlePolicy(b) === 'always') return chalk.yellow('always ask');
   const exp = held?.get(b.name);
   return exp ? chalk.green(`daily · ${compactRemaining(exp)} left`) : chalk.gray('daily');
@@ -668,11 +670,15 @@ export function registerSecretsCommands(program: Command): void {
         if (bundle.description) console.log(chalk.gray(safePrint(bundle.description)));
         if (bundle.allow_exec) console.log(chalk.yellow('allow_exec: true'));
         if (bundle.backend === 'file') console.log(chalk.gray('backend: file (passphrase-encrypted; reads need AGENTS_SECRETS_PASSPHRASE, no Touch ID)'));
-        console.log(
-          bundlePolicy(bundle) === 'daily'
-            ? chalk.gray('policy: daily (ask once, then held ~24h until screen-lock / sleep / logout)')
-            : chalk.gray('policy: always (asks for Touch ID every time — never auto-held)'),
-        );
+        if (bundlePolicy(bundle) === 'never') {
+          console.log(chalk.red.bold('policy: never — NO biometry ACL; reads are silent (no Touch ID, no user-presence check). Automation-only.'));
+        } else {
+          console.log(
+            bundlePolicy(bundle) === 'daily'
+              ? chalk.gray('policy: daily (ask once, then held ~24h until screen-lock / sleep / logout)')
+              : chalk.gray('policy: always (asks for Touch ID every time — never auto-held)'),
+          );
+        }
         if (bundle.created_at) console.log(chalk.gray(`created_at: ${bundle.created_at} (${humanAge(bundle.created_at)})`));
         if (bundle.updated_at) console.log(chalk.gray(`updated_at: ${bundle.updated_at} (${humanAge(bundle.updated_at)})`));
         if (bundle.last_used) console.log(chalk.gray(`last_used:  ${bundle.last_used} (${humanAge(bundle.last_used)})`));
@@ -782,11 +788,12 @@ export function registerSecretsCommands(program: Command): void {
     .description('Create an empty bundle')
     .option('--description <text>', 'Free-form description')
     .option('--allow-exec', 'Allow exec: refs in this bundle (off by default)')
-    .option('--policy <policy>', 'prompt policy: daily (default, ask once a day) or always (ask every time)')
+    .option('--policy <policy>', 'prompt policy: daily (default, ask once a day), always (ask every time), or never (silent, NO biometry ACL — needs --i-understand)')
     .addOption(new Option('--tier <policy>', 'deprecated alias for --policy').hideHelp())
+    .option('--i-understand', 'Confirm creating a "never"-policy bundle (no biometry ACL) without an interactive prompt')
     .option('--backend <backend>', 'storage backend: keychain (default) or file (passphrase-encrypted, headless-readable)', 'keychain')
     .option('--force', 'Overwrite an existing bundle')
-    .action(async (name: string | undefined, opts: { description?: string; allowExec?: boolean; policy?: string; tier?: string; backend?: string; force?: boolean }) => {
+    .action(async (name: string | undefined, opts: { description?: string; allowExec?: boolean; policy?: string; tier?: string; iUnderstand?: boolean; backend?: string; force?: boolean }) => {
       try {
         const resolvedName = name ?? (await promptBundleName());
         validateBundleName(resolvedName);
@@ -799,6 +806,13 @@ export function registerSecretsCommands(program: Command): void {
           console.error(chalk.red(`Bundle '${resolvedName}' already exists. Use --force to overwrite.`));
           process.exit(1);
         }
+        // The `never` tier is the least-safe option — gate it loudly. Throws in a
+        // headless shell without --i-understand; prompts otherwise.
+        const ack = assertNeverPolicyAcknowledged(policy, { iUnderstand: opts.iUnderstand, interactive: isInteractiveTerminal() });
+        if (ack === 'prompt' && !(await confirmNeverPolicyInteractive(resolvedName))) {
+          console.error(chalk.yellow('Aborted.'));
+          return;
+        }
         const bundle: SecretsBundle = {
           name: resolvedName,
           description: opts.description,
@@ -808,11 +822,16 @@ export function registerSecretsCommands(program: Command): void {
           vars: {},
         };
         writeBundle(bundle);
-        const tags = [
-          bundlePolicy(bundle) === 'daily' ? 'policy: daily' : 'policy: always ask',
-          backend === 'file' ? 'backend: file' : null,
-        ].filter(Boolean);
+        const policyTag = bundlePolicy(bundle) === 'daily'
+          ? 'policy: daily'
+          : bundlePolicy(bundle) === 'always'
+            ? 'policy: always ask'
+            : 'policy: never (NO biometry ACL)';
+        const tags = [policyTag, backend === 'file' ? 'backend: file' : null].filter(Boolean);
         console.log(chalk.green(`Bundle '${resolvedName}' created (${tags.join(', ')}).`));
+        if (bundlePolicy(bundle) === 'never') {
+          console.log(chalk.red('Stored without biometry protection — reads are silent. Automation-only; rotate anything sensitive out of it.'));
+        }
         if (backend === 'file') {
           console.log(chalk.gray('File-backed: items are AES-256-GCM encrypted under AGENTS_SECRETS_PASSPHRASE (no Touch ID).'));
         }
@@ -951,7 +970,7 @@ export function registerSecretsCommands(program: Command): void {
           secretValue = await promptForSecret(`Enter value for ${resolvedBundleName}.${resolvedKey}`);
         }
         const item = secretsKeychainItem(resolvedBundleName, resolvedKey);
-        bundleItemStore(bundle.backend).set(item, secretValue);
+        bundleItemStore(bundle.backend, { noAcl: bundlePolicy(bundle) === 'never' }).set(item, secretValue);
         bundle.vars[resolvedKey] = keychainRef(resolvedKey);
         applyMeta();
         writeBundle(bundle);
@@ -1207,7 +1226,7 @@ Examples:
             vars: {},
           };
         }
-        const store = bundleItemStore(bundle.backend);
+        const store = bundleItemStore(bundle.backend, { noAcl: bundlePolicy(bundle) === 'never' });
         let added = 0;
         let skipped = 0;
 
@@ -1679,8 +1698,9 @@ Examples:
   cmd
     .command('policy <bundle> [policy]')
     .alias('tier')
-    .description("Show or set a bundle's prompt policy: daily (default, ask once a day) or always (ask every time).")
-    .action((bundleName: string, policyArg: string | undefined) => {
+    .description("Show or set a bundle's prompt policy: daily (default, ask once a day), always (ask every time), or never (silent, NO biometry ACL).")
+    .option('--i-understand', 'Confirm switching to the "never" policy (no biometry ACL) without an interactive prompt')
+    .action(async (bundleName: string, policyArg: string | undefined, opts: { iUnderstand?: boolean }) => {
       try {
         const bundle = readBundle(bundleName);
         if (policyArg === undefined) {
@@ -1688,13 +1708,21 @@ Examples:
           return;
         }
         const next = parsePolicyOpt(policyArg);
+        // Switching to `never` drops the biometry ACL — gate it exactly like create.
+        const ack = assertNeverPolicyAcknowledged(next, { iUnderstand: opts.iUnderstand, interactive: isInteractiveTerminal() });
+        if (ack === 'prompt' && !(await confirmNeverPolicyInteractive(bundle.name))) {
+          console.error(chalk.yellow('Aborted.'));
+          return;
+        }
         bundle.policy = next;
         writeBundle(bundle);
         console.log(chalk.green(`${bundle.name} policy set to ${next}.`));
         if (next === 'daily') {
           console.log(chalk.gray('Held by the secrets-agent for ~24h after one unlock (auto-cache is on by default; disable with `secrets.agent.auto: false` in agents.yaml).'));
-        } else {
+        } else if (next === 'always') {
           console.log(chalk.gray('Asks for Touch ID every time — never auto-held.'));
+        } else {
+          console.log(chalk.red('Stored without biometry protection — reads are silent. Automation-only.'));
         }
       } catch (err) {
         console.error(chalk.red((err as Error).message));
@@ -1747,21 +1775,54 @@ Examples:
   registerSecretsMigrateAclCommand(cmd);
 }
 
-/** Validate a prompt-policy value, exiting with a clear message on a bad one.
- * Accepts the legacy `biometry`/`session` tokens as aliases for `always`/`daily`
- * so older flags and scripts keep working. `never`/`none` (no biometry ACL) is
- * rejected explicitly — it needs a separate signed-helper change (see
- * https://github.com/phnx-labs/agents-cli/issues/421). */
-function parsePolicyOpt(raw: string | undefined): SecretsPolicy {
+/** Validate a prompt-policy value, throwing a clear message on a bad one (the
+ * caller's try/catch renders it and exits). Accepts the legacy `biometry` /
+ * `session` / `none` tokens as aliases for `always` / `daily` / `never` so older
+ * flags and scripts keep working. `never`/`none` is the no-biometry-ACL tier —
+ * accepted here, then gated behind a loud confirmation in the command layer. */
+export function parsePolicyOpt(raw: string | undefined): SecretsPolicy {
   const v = (raw ?? 'always').toLowerCase();
   if (v === 'always' || v === 'biometry') return 'always';
   if (v === 'daily' || v === 'session') return 'daily';
-  if (v === 'never' || v === 'none') {
-    console.error(chalk.red("policy 'never' (no biometry ACL) is not available yet — see https://github.com/phnx-labs/agents-cli/issues/421. Use 'always' or 'daily'."));
-    process.exit(1);
+  if (v === 'never' || v === 'none') return 'never';
+  throw new Error(`Invalid policy '${raw}'. Use 'always', 'daily', or 'never'.`);
+}
+
+/**
+ * Gate a create/switch to the `never` prompt-policy behind an explicit,
+ * deliberate acknowledgement — it is the least-safe tier (no user-presence
+ * check on any read). Returns:
+ *   - `'ok'`    — not `never`, or already acknowledged via `--i-understand`.
+ *   - `'prompt'` — interactive shell: caller must run a loud confirm prompt.
+ * Throws in a non-interactive shell when the flag is absent, so a headless
+ * `create --policy never` can't silently downgrade a bundle's protection.
+ */
+export function assertNeverPolicyAcknowledged(
+  policy: SecretsPolicy | undefined,
+  opts: { iUnderstand?: boolean; interactive: boolean },
+): 'ok' | 'prompt' {
+  if (policy !== 'never') return 'ok';
+  if (opts.iUnderstand) return 'ok';
+  if (!opts.interactive) {
+    throw new Error(
+      "Refusing to set the 'never' prompt-policy without confirmation. This tier stores " +
+      'the bundle WITHOUT the biometry access control: every read is silent, with no Touch ID ' +
+      'and no user-presence check — any code running as you can read it. Re-run with ' +
+      '--i-understand to confirm you want an unprotected, automation-only bundle.',
+    );
   }
-  console.error(chalk.red(`Invalid policy '${raw}'. Use 'always' or 'daily'.`));
-  process.exit(1);
+  return 'prompt';
+}
+
+/** Loud confirm prompt shown before creating/switching to `never` in a TTY.
+ * Returns true to proceed. Kept separate from assertNeverPolicyAcknowledged so
+ * the decision logic stays pure and unit-testable. */
+async function confirmNeverPolicyInteractive(bundleName: string): Promise<boolean> {
+  console.error(chalk.red.bold('WARNING: policy "never" stores this bundle with NO biometry ACL.'));
+  console.error(chalk.red(`Reads of '${bundleName}' will be fully silent — no Touch ID, no user-presence check.`));
+  console.error(chalk.yellow('Use it only for low-sensitivity, automation-only credentials.'));
+  const { confirm } = await import('@inquirer/prompts');
+  return confirm({ message: `Store '${bundleName}' WITHOUT biometry protection?`, default: false });
 }
 
 /** Validate a --backend value, exiting with a clear message on a bad one. */

--- a/src/lib/secrets/__tests__/bundles-storage.test.ts
+++ b/src/lib/secrets/__tests__/bundles-storage.test.ts
@@ -124,6 +124,17 @@ describe('writeBundle + readBundle round-trip', () => {
     expect(got.description).toBeUndefined();
     expect(got.vars).toEqual({ A: 'x' });
   });
+
+  it('round-trips each explicit policy, persisting never under the legacy tier=none token', () => {
+    for (const policy of ['always', 'daily', 'never'] as const) {
+      writeBundle({ name: `pol-${policy}`, vars: { A: 'x' }, policy });
+      expect(readBundle(`pol-${policy}`).policy).toBe(policy);
+    }
+    // Wire compat: the on-disk token for `never` is `none`, so an older CLI that
+    // doesn't know `none` reads it as absent (undefined) rather than crashing.
+    const raw = JSON.parse(store.get('agents-cli.bundles.pol-never')!.value) as { tier?: string };
+    expect(raw.tier).toBe('none');
+  });
 });
 
 describe('timestamps', () => {

--- a/src/lib/secrets/bundles.ts
+++ b/src/lib/secrets/bundles.ts
@@ -54,7 +54,10 @@ interface ItemStore {
   has(item: string): boolean;
   get(item: string): string;
   getBatch(items: string[]): Map<string, string>;
-  set(item: string, value: string): void;
+  /** `opts.noAcl` writes the item WITHOUT the biometry access control (the
+   * `never` prompt-policy). Backends with no ACL concept (file store, test
+   * backend) ignore it. */
+  set(item: string, value: string, opts?: { noAcl?: boolean }): void;
   delete(item: string): boolean;
   list(prefix: string): string[];
 }
@@ -160,13 +163,20 @@ export interface VarMeta {
  * - `always`: asks every time. Never auto-held — only an explicit `agents
  *   secrets unlock` ever holds it; every other read pops Touch ID. Opt a
  *   high-value bundle into this when you want to confirm every single read.
+ * - `never`: stored WITHOUT the biometry access control — reads are fully
+ *   silent (no Touch ID, no broker). The least-safe tier: any code running as
+ *   the user reads it with no user-presence check. Reserved for low-sensitivity,
+ *   automation-only credentials. Writing a `never` item needs the signed helper's
+ *   `set-no-acl` path (see keychain-helper.swift); an older pinned helper rejects
+ *   it loudly rather than silently downgrading to `always`.
  *
  * The default is configurable via `secrets.policy` in agents.yaml. Stored on disk
  * under the legacy `tier` key (`session` == `daily`, `biometry` == explicit
- * `always`, absent == inherit the default) so bundles stay readable across mixed
- * CLI versions on synced machines. The user-facing vocabulary is `policy`/`always`/`daily`.
+ * `always`, `none` == `never`, absent == inherit the default) so bundles stay
+ * readable across mixed CLI versions on synced machines. The user-facing
+ * vocabulary is `policy`/`always`/`daily`/`never`.
  */
-export type SecretsPolicy = 'always' | 'daily';
+export type SecretsPolicy = 'always' | 'daily' | 'never';
 
 /** A named set of environment variable definitions backed by various secret providers. */
 export interface SecretsBundle {
@@ -354,6 +364,7 @@ export function readBundle(name: string): SecretsBundle {
 function parsePolicy(raw: unknown): SecretsPolicy | undefined {
   if (raw === 'daily' || raw === 'session') return 'daily';
   if (raw === 'always' || raw === 'biometry') return 'always';
+  if (raw === 'never' || raw === 'none') return 'never';
   return undefined;
 }
 
@@ -407,9 +418,14 @@ export function writeBundle(bundle: SecretsBundle): void {
     backend: backend === 'file' ? 'file' : undefined,
     // Wire format: persist the policy under the legacy `tier` token so older CLI
     // versions on other synced machines keep reading it — `daily`⇒`session`,
-    // explicit `always`⇒`biometry`. An absent policy omits the token entirely
-    // and resolves to the configured default (`daily`) on read.
-    tier: bundle.policy === 'daily' ? 'session' : bundle.policy === 'always' ? 'biometry' : undefined,
+    // explicit `always`⇒`biometry`, `never`⇒`none`. An absent policy omits the
+    // token entirely and resolves to the configured default (`daily`) on read.
+    // An older CLI that doesn't know `none` reads it as undefined and falls back
+    // to its own default — safe, since it also lacks the no-ACL write path.
+    tier: bundle.policy === 'daily' ? 'session'
+      : bundle.policy === 'always' ? 'biometry'
+      : bundle.policy === 'never' ? 'none'
+      : undefined,
     created_at: bundle.created_at,
     updated_at: bundle.updated_at,
     last_used: bundle.last_used,
@@ -417,7 +433,11 @@ export function writeBundle(bundle: SecretsBundle): void {
     meta,
   };
   const json = JSON.stringify(payload);
-  itemStore(backend).set(bundleMetaItem(bundle.name), json);
+  // A `never` bundle's metadata is stored without the biometry ACL too, so
+  // `view` and the metadata half of a read resolve silently — the whole point
+  // of the tier. On an un-updated pinned helper this write fails loudly (the
+  // no-ACL command is missing) rather than silently landing an ACL'd item.
+  itemStore(backend).set(bundleMetaItem(bundle.name), json, { noAcl: bundle.policy === 'never' });
   emit('secrets.set', { bundle: bundle.name });
 }
 
@@ -1011,7 +1031,7 @@ export function rotateBundleSecret(bundle: SecretsBundle, key: string, opts: Rot
   }
   const shortId = raw.slice('keychain:'.length);
   const item = secretsKeychainItem(bundle.name, shortId);
-  itemStore(bundle.backend ?? 'keychain').set(item, opts.newValue);
+  itemStore(bundle.backend ?? 'keychain').set(item, opts.newValue, { noAcl: bundlePolicy(bundle) === 'never' });
 
   if (opts.clearMeta) {
     if (bundle.meta) delete bundle.meta[key];
@@ -1082,7 +1102,7 @@ export function renameBundle(oldName: string, newName: string, opts: RenameOptio
     const shortId = raw.slice('keychain:'.length);
     const newItem = secretsKeychainItem(newName, shortId);
     const value = store.get(oldItem);
-    store.set(newItem, value);
+    store.set(newItem, value, { noAcl: bundlePolicy(source) === 'never' });
   }
 
   // writeBundle preserves source.created_at, refreshes updated_at, and keeps
@@ -1106,13 +1126,24 @@ export function renameBundle(oldName: string, newName: string, opts: RenameOptio
  * `import` / `remove` / `delete`. Pass the bundle's resolved backend
  * (`bundle.backend ?? 'keychain'`).
  */
-export function bundleItemStore(backend: SecretsBackend | undefined): {
+export function bundleItemStore(
+  backend: SecretsBackend | undefined,
+  opts?: { noAcl?: boolean },
+): {
   set(item: string, value: string): void;
   delete(item: string): boolean;
   get(item: string): string;
   has(item: string): boolean;
 } {
-  return itemStore(backend ?? 'keychain');
+  const store = itemStore(backend ?? 'keychain');
+  // `never`-policy bundles write their per-key values without the biometry ACL
+  // (same rationale as the metadata write in writeBundle). Wrap `set` so every
+  // value the add/import paths write inherits the no-ACL flag; reads, deletes,
+  // and existence checks are ACL-independent and pass through untouched.
+  if (opts?.noAcl) {
+    return { ...store, set: (item, value) => store.set(item, value, { noAcl: true }) };
+  }
+  return store;
 }
 
 // Iterate all keychain-backed keys in a bundle for cleanup on rm/unset.

--- a/src/lib/secrets/index.ts
+++ b/src/lib/secrets/index.ts
@@ -290,8 +290,14 @@ export function getKeychainTokens(items: string[]): Map<string, string> {
   return result;
 }
 
-/** Store or update a secret value in the keychain/keyring. Device-local; biometry-gated on macOS. */
-export function setKeychainToken(item: string, value: string): void {
+/** Store or update a secret value in the keychain/keyring. Device-local;
+ * biometry-gated on macOS. `opts.noAcl` (the `never` prompt-policy) writes our
+ * item WITHOUT the biometry access control so later reads are fully silent — it
+ * routes through the signed helper's `set-no-acl` path. A pinned helper that
+ * predates that path rejects the unknown command (exit 2) and this throws,
+ * rather than silently falling back to an ACL'd `set` (which would behave like
+ * `always`). Ignored by the Linux/Windows/test backends, which have no ACL. */
+export function setKeychainToken(item: string, value: string, opts?: { noAcl?: boolean }): void {
   if (backend) { backend.set(item, value); return; }
   assertSupportedPlatform();
   assertValueStorable(value);
@@ -322,12 +328,24 @@ export function setKeychainToken(item: string, value: string): void {
   }
 
   const bin = getKeychainHelperPath();
-  const result = spawnSync(bin, ['set', item, os.userInfo().username], {
+  // `never` policy → no-ACL write. The `set-no-acl` subcommand exists only in a
+  // re-notarized helper; an older pinned helper dies with "Unknown command:
+  // set-no-acl" (exit 2), surfaced below — never a silent ACL'd downgrade.
+  const helperCmd = opts?.noAcl ? 'set-no-acl' : 'set';
+  const result = spawnSync(bin, [helperCmd, item, os.userInfo().username], {
     input: value,
     stdio: ['pipe', 'pipe', 'pipe'],
   });
   if (result.status !== 0) {
     const msg = result.stderr?.toString().trim();
+    if (opts?.noAcl && /unknown command/i.test(msg ?? '')) {
+      throw new Error(
+        `The 'never' prompt-policy needs a Keychain helper with the no-ACL write path, ` +
+        `but the installed helper does not support it. Rebuild + re-notarize the signed ` +
+        `helper (scripts/build-keychain-helper.sh) and re-pin its sha, then retry. ` +
+        `(helper said: ${msg})`,
+      );
+    }
     throw new Error(msg || `Failed to write keychain item '${item}'.`);
   }
 }

--- a/src/lib/secrets/keychain-helper.swift
+++ b/src/lib/secrets/keychain-helper.swift
@@ -288,7 +288,7 @@ func dieIfCancelled(_ status: OSStatus) {
 
 let args = CommandLine.arguments
 guard args.count >= 2 else {
-    die(2, "Usage: agents-keychain <get|get-batch|set|delete|has|list|list-legacy|list-orphans|migrate-acl|migrate-orphans> ...")
+    die(2, "Usage: agents-keychain <get|get-batch|set|set-no-acl|delete|has|list|list-legacy|list-orphans|migrate-acl|migrate-orphans> ...")
 }
 
 let cmd = args[1]
@@ -505,6 +505,41 @@ case "set":
     addAttrs[kSecValueData] = valueData
     let status = SecItemAdd(addAttrs as CFDictionary, nil)
     guard status == errSecSuccess else { die(2, "Failed to write keychain item (OSStatus \(status))") }
+
+case "set-no-acl":
+    // set-no-acl <service> <account> — value on stdin. The `never` prompt-policy.
+    // Identical to `set` EXCEPT the item carries NO kSecAttrAccessControl: instead
+    // of the biometry-or-passcode gate we attach a plain kSecAttrAccessible of
+    // kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly. The item still lives in
+    // the data-protection keychain, device-local, pinned to our access group, and
+    // never synchronizable — it is only the user-presence check that is dropped.
+    //
+    // Consequence: reads never evaluate an ACL, so get / get-batch return the
+    // value with no Touch ID and no broker. This is the deliberate downgrade the
+    // `never` tier exists to provide, for low-sensitivity automation-only secrets.
+    // AfterFirstUnlock (not WhenUnlocked) so a headless / screen-locked background
+    // process can still read it, which is the whole point of the tier.
+    //
+    // Same delete-then-add dance as `set`: SecItemUpdate can't add/remove an ACL,
+    // so clear any prior copy (ACL'd or not, across all groups, plus the legacy
+    // keychain) and re-add fresh. Deleting an item never prompts.
+    guard args.count == 4 else { die(2, "Usage: agents-keychain set-no-acl <service> <account>") }
+    let (naService, naAccount) = (args[2], args[3])
+    let naStdin = FileHandle.standardInput.readDataToEndOfFile()
+    guard !naStdin.isEmpty, var naValue = String(data: naStdin, encoding: .utf8) else {
+        die(2, "Failed to read value from stdin")
+    }
+    while naValue.hasSuffix("\n") || naValue.hasSuffix("\r") { naValue = String(naValue.dropLast()) }
+    guard let naValueData = naValue.data(using: .utf8) else { die(2, "Failed to encode value") }
+
+    SecItemDelete(dpBaseUnpinned(service: naService, account: naAccount) as CFDictionary)
+    SecItemDelete(fileBase(service: naService, account: naAccount) as CFDictionary)
+
+    var naAddAttrs = dpBase(service: naService, account: naAccount)
+    naAddAttrs[kSecAttrAccessible] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+    naAddAttrs[kSecValueData] = naValueData
+    let naStatus = SecItemAdd(naAddAttrs as CFDictionary, nil)
+    guard naStatus == errSecSuccess else { die(2, "Failed to write no-ACL keychain item (OSStatus \(naStatus))") }
 
 case "delete":
     // delete <service> <account> — remove the item from BOTH keychains. New


### PR DESCRIPTION
Part of #421. Adds a third `never` prompt-policy alongside `always` (biometry) and `daily` (session). A `never` bundle is stored **without** the biometry access control so later reads are fully silent — the tier for low-sensitivity, automation-only secrets.

## What ships (TS surface — fully tested here)
- **`parsePolicyOpt` accepts `never`** (and its `none` alias); the old stub rejection is gone. — `src/commands/secrets.ts`
- **Loud confirmation required to set `never`.** `create --policy never` and `secrets policy <b> never` demand an interactive red-warning prompt in a TTY, or `--i-understand` when headless. Refused otherwise — a headless run must not silently downgrade a bundle's protection. (`assertNeverPolicyAcknowledged`, `confirmNeverPolicyInteractive`)
- **`list` / `view` mark `never` distinctly and loudly** — red `never · NO ACL` (`renderPolicyCol`), plus a red "reads are silent" banner in `view`.
- **Wire-format back-compat:** policy persists under the legacy `tier` key as `none`, so older CLIs stay compatible. Round-trip covered in `bundles-storage.test.ts`.

## Keychain helper (compiles unsigned here; runtime GATED)
- New **`set-no-acl`** subcommand in `keychain-helper.swift` mirrors `set` but attaches a plain `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` instead of a biometry ACL (same delete-then-add dance, same pinned access group, device-local, non-synchronizable).
- `setKeychainToken(item, value, { noAcl })` routes `never` writes to it. **Guard:** a pinned helper predating the subcommand rejects it (exit 2) and we throw a clear *"needs re-notarized helper"* error — never a silent ACL'd fallback that would behave like `always`.

## GATED — deferred follow-up (why #421 stays OPEN)
The end-to-end **"silent read, no ACL"** behavior is **not verified in this PR**. It needs the signed helper rebuilt, **re-notarized** (Apple Developer ID cert + `notarytool` creds — not available in this run), and its sha **re-pinned** in `scripts/Agents CLI.app.sha256`. Until then, `never` writes error loudly rather than silently mis-behaving. Do not close #421 on merge.

## Verification
- `tsc --noEmit` — clean.
- `swiftc -O keychain-helper.swift` — compiles (only pre-existing `kSec...UI` macOS 11 deprecation warnings; `set-no-acl` case builds).
- `vitest` secrets + bundles-storage suites — **54 passed** (new tests assert: `parsePolicyOpt` accepts `never`/`none`, headless `never` rejected without `--i-understand`, `never` marked distinctly, and `tier=none` round-trip).
- Full suite is green except a pre-existing flake in `tests/daemon.test.ts > generateLaunchdPlist` (hangs on a real-keychain **read** via `readDaemonClaudeOAuthToken`; untouched by this PR, which only changes the **write** path).