### PR TITLE
docs: document `agents upgrade` self-update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ npm install -g @phnx-labs/agents-cli
 bun install -g @phnx-labs/agents-cli
 ```
 
+Already installed? `agents upgrade` updates agents-cli itself to the latest version (`agents upgrade 1.2.3` for a specific version or dist-tag, `-y` to skip the confirm prompt).
+
 Source: [github.com/phnx-labs/agents-cli](https://github.com/phnx-labs/agents-cli)
 
 Also available as `ag` -- all commands work with both `agents` and `ag`.
@@ -774,6 +776,8 @@ The installer tries Bun first (faster), falls back to npm. Node 22.5+ required a
 Yes -- `agents run` is non-interactive by default. `--yes` auto-accepts prompts, `--json` for structured output. Pass explicit names and IDs instead of relying on interactive pickers.
 
 The auto-update prompt is suppressed automatically when stdin or stdout isn't a TTY. For headless environments where TTY detection misfires (k8s pods that allocate a PTY for stdout, cloud sandbox factories), set `AGENTS_CLI_DISABLE_AUTO_UPDATE=1` to skip the update check entirely -- no prompt, no network call.
+
+To update on demand instead of waiting for the prompt, run `agents upgrade` (add `-y` to skip the confirmation, or pass a version/dist-tag to install something other than latest).
 
 ### What happens to my config when I switch versions?
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm install -g @phnx-labs/agents-cli
 bun install -g @phnx-labs/agents-cli
 ```
 
-Already installed? `agents upgrade` updates agents-cli itself to the latest version (`agents upgrade 1.2.3` for a specific version or dist-tag, `-y` to skip the confirm prompt).
+Already installed? `agents upgrade` updates agents-cli itself to the latest version (`agents upgrade 1.2.3` for a specific version or dist-tag, `-y` to skip the confirm prompt). The command is `upgrade` on every platform -- there is no `agents update` (on macOS, `agents helper update` is a different command that reinstalls the keychain helper, not agents-cli).
 
 Source: [github.com/phnx-labs/agents-cli](https://github.com/phnx-labs/agents-cli)
 

--- a/docs/01-version-management.md
+++ b/docs/01-version-management.md
@@ -2,6 +2,10 @@
 
 How agents-cli installs, switches, and isolates multiple versions of agent CLIs.
 
+> This page covers versions of the *agent CLIs* agents-cli manages (Claude Code,
+> Codex, etc.). To update **agents-cli itself**, run `agents upgrade` (see
+> `agents upgrade --help`) -- unrelated to the mechanism below.
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## Summary

`agents upgrade [version]` is the real, working command to update agents-cli itself, but it was never mentioned in user-facing docs.

- `agents upgrade` is defined at `src/index.ts:788-817` (`registerUpgradeCommand`): description "Upgrade agents-cli to the latest version (or a specific [version])", optional `[version]` argument (default `latest`), `-y/--yes` to skip the confirm prompt. It updates the npm package `@phnx-labs/agents-cli`.
- `agents update` does **not** exist at the top level -- running it prints `error: unknown command 'update'`. The only `update` in the CLI is `agents helper update` (macOS keychain-helper reinstall, `src/commands/helper.ts:50`), which is unrelated.
- `upgrade` is currently lazy-registered / hidden from `agents --help` (`src/index.ts:878,955`), so the only way to discover it today is to already know the exact subcommand name.
- README.md had the install command (`npm install -g @phnx-labs/agents-cli`, line 39) and an auto-update note (line 776) but no mention anywhere of `agents upgrade`.

## Changes

- `README.md`: one-line note right after the install snippet ("Already installed? `agents upgrade` updates agents-cli itself...") and a second note in the CI FAQ section under the existing auto-update-prompt paragraph, both showing `agents upgrade`, `agents upgrade <version>`, and `-y`.
- `docs/01-version-management.md`: added a short callout under the title disambiguating this doc's scope (switching between installed *agent CLI* versions like Claude/Codex) from self-updating agents-cli via `agents upgrade`, since the two are easy to conflate.

No source code changes -- docs only.

## Test plan

- [x] `agents upgrade --help` run to confirm the flag/arg surface documented matches reality
- [x] `agents update` run to confirm it fails with "unknown command"
- [x] Manual read-through of README.md and docs/01-version-management.md diffs for voice/tone match