### PR TITLE
fix(windows): resolve POSIX shell portably in forEach producer + Windows-runnable rotate test fake

### DIFF
--- a/src/lib/platform/exec.test.ts
+++ b/src/lib/platform/exec.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'child_process';
-import { whichCommand, findExecutable, needsWindowsShell, quoteWin32ExecArg, composeWin32CommandLine } from './exec.js';
+import * as fs from 'fs';
+import * as path from 'path';
+import { whichCommand, findExecutable, needsWindowsShell, posixShellPath, quoteWin32ExecArg, composeWin32CommandLine } from './exec.js';
 
 describe('whichCommand', () => {
   it('is `where` on win32, `which` elsewhere', () => {
@@ -151,5 +153,24 @@ describe('composeWin32CommandLine spawn round-trip (win32)', () => {
     expect(res.status).toBe(0);
     expect(res.error).toBeUndefined();
     expect(JSON.parse(res.stdout)).toEqual(trickyArgs);
+  });
+});
+
+describe('posixShellPath', () => {
+  it('is /bin/sh on POSIX platforms', () => {
+    expect(posixShellPath('linux')).toBe('/bin/sh');
+    expect(posixShellPath('darwin')).toBe('/bin/sh');
+  });
+
+  // Host-gated: resolving sh.exe needs a real Windows PATH with Git for
+  // Windows on it (dev boxes and the windows-latest runners both have it).
+  it.runIf(process.platform === 'win32')('resolves a real sh/bash executable on Windows', () => {
+    const shell = posixShellPath('win32');
+    expect(path.win32.isAbsolute(shell)).toBe(true);
+    expect(fs.existsSync(shell)).toBe(true);
+    // The resolved shell must actually run a POSIX command string.
+    const res = spawnSync(shell, ['-c', "printf 'ok'"], { encoding: 'utf-8' });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toBe('ok');
   });
 });

--- a/src/lib/platform/exec.ts
+++ b/src/lib/platform/exec.ts
@@ -42,6 +42,19 @@ export function findExecutable(name: string, platform: NodeJS.Platform = process
 }
 
 /**
+ * Absolute path of the POSIX shell for `sh -c <command string>` composition.
+ * `/bin/sh` on POSIX; on Windows there is no /bin/sh, so resolve Git's
+ * `sh.exe`/`bash.exe` from PATH (present wherever Git for Windows is — dev
+ * boxes and the GitHub windows runners alike). Falls back to the bare name so
+ * a missing shell surfaces as a clear spawn ENOENT on `sh` rather than a
+ * misleading one on `/bin/sh`.
+ */
+export function posixShellPath(platform: NodeJS.Platform = process.platform): string {
+  if (platform !== 'win32') return '/bin/sh';
+  return findExecutable('sh', platform) ?? findExecutable('bash', platform) ?? 'sh';
+}
+
+/**
  * Quote one argument for a Windows `cmd.exe` command line, as built by Node's
  * `spawn(..., { shell: true })` on win32 (the `.cmd` agent shims, `agents secrets
  * exec`, ...). cmd.exe does NO quoting of its own, so an unquoted arg with a space

--- a/src/lib/rotate.test.ts
+++ b/src/lib/rotate.test.ts
@@ -181,6 +181,13 @@ process.exit(0);
     const bin = path.join(binDir, 'amp');
     fs.writeFileSync(bin, script);
     fs.chmodSync(bin, 0o755);
+    if (process.platform === 'win32') {
+      // cmd.exe can't exec a shebang script. spawnAgent goes through the shell
+      // on Windows (needsWindowsShell), which resolves `amp` via PATHEXT — so
+      // the runnable fake must be a `.cmd` that hands the script to node.
+      fs.writeFileSync(path.join(binDir, 'amp.js'), script);
+      fs.writeFileSync(path.join(binDir, 'amp.cmd'), `@node "%~dp0amp.js" %*\r\n`);
+    }
     return { binDir, stateFile };
   }
 

--- a/src/lib/teams/forEach.ts
+++ b/src/lib/teams/forEach.ts
@@ -15,6 +15,7 @@
  */
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { posixShellPath } from '../platform/exec.js';
 import type { AgentManager, AgentProcess, EffortLevel } from './agents.js';
 import type { AgentType } from './parsers.js';
 import { expandForEach, type ForEachSpec, type ForEachTeammate } from '../workflows.js';
@@ -102,10 +103,11 @@ export async function produceItems(
   }
 
   // The producer is a shell command string (e.g. "rg -l 'x' src/"), so it runs
-  // under /bin/sh -c exactly like a teammate command. maxBuffer is raised well
-  // above the default 1MB so a producer emitting a large list isn't truncated
-  // silently mid-stream.
-  const { stdout } = await execFileAsync('/bin/sh', ['-c', spec.produce], {
+  // under `sh -c` exactly like a teammate command — resolved portably, because
+  // /bin/sh does not exist on Windows (there it's Git's sh.exe from PATH).
+  // maxBuffer is raised well above the default 1MB so a producer emitting a
+  // large list isn't truncated silently mid-stream.
+  const { stdout } = await execFileAsync(posixShellPath(), ['-c', spec.produce], {
     cwd: opts.cwd ?? undefined,
     env: opts.env ?? process.env,
     timeout: opts.timeoutMs ?? 120_000,


### PR DESCRIPTION
## Problem

The real Windows suite (`tests-windows.yml` — path-filtered, so it only runs when shims/hooks/platform paths change) has been red on main since its last green run at 05:15Z today: the rotation-failover tests (07:07Z) and for_each producer tests (08:41Z) landed after it. PR #684 was the first to re-trigger the job and surfaced 5 failures.

## Fixes

**`produceItems` — production bug.** It hardcoded `execFile('/bin/sh', ['-c', ...])`; `/bin/sh` does not exist on Windows, so every real producer spawn failed with `spawn /bin/sh ENOENT`. Now resolves the shell via a new `posixShellPath()` in `lib/platform/exec.ts`: `/bin/sh` on POSIX, Git's `sh.exe`/`bash.exe` from PATH on Windows (present on dev boxes with Git for Windows and on the windows-latest runners).

**`rotate.test.ts` — test harness.** The fake `amp` was an extensionless shebang script on a temp PATH. cmd.exe (which `spawnAgent` routes through on Windows) can't execute it and PATHEXT finds no companion, so the fake never ran — the 429 re-dispatch test exited 1 and the state file was never written (`ENOENT ... \calls`). On win32 the fake now also writes an `amp.cmd` + `amp.js` pair.

## Verification (Windows 11)

- Before: `rotate.test.ts` 2 failed, `forEach.test.ts` 3 failed (locally and on PR #684's `test-windows` job, twice).
- After: `rotate.test.ts` 15/15, `forEach.test.ts` 30/30, `platform/exec.test.ts` 22/22 (includes a new host-gated test that the resolved shell actually executes a POSIX command string).
- `tsc --noEmit` clean.

This PR touches `src/lib/platform/**`, so the real `test-windows` job runs here and proves the fix on CI. Unblocks #684.