### PR TITLE
fix(browser): support Comet on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ Give agents access to a real browser — no relay extension, no cloud service, n
 # First run: omit --profile and we auto-pick the first installed Chromium-family
 # browser. macOS prefers Chrome > Brave > Edge > Chromium > Comet; Linux prefers
 # Chrome > Chromium > Brave > Edge; Windows prefers Edge (always preinstalled) >
-# Chrome > Brave. The auto-picked profile is saved as "default" for later runs.
+# Chrome > Brave > Comet. The auto-picked profile is saved as "default" for later runs.
 export AGENTS_BROWSER_TASK=$(agents browser start --url https://app.example.com)
 
 # Or pin a named profile to a specific browser (chrome, comet, brave, chromium,

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -72,7 +72,7 @@ first installed Chromium-family browser on your machine and saves it as the
 
 - macOS: Chrome > Brave > Edge > Chromium > Comet
 - Linux: Chrome > Chromium > Brave > Edge
-- Windows: Edge > Chrome > Brave
+- Windows: Edge > Chrome > Brave > Comet
 
 Safari and Firefox are not supported. They do not implement the Chrome
 DevTools Protocol.

--- a/src/lib/browser/chrome.test.ts
+++ b/src/lib/browser/chrome.test.ts
@@ -66,6 +66,20 @@ describe('findFirstInstalledBrowser', () => {
     });
   });
 
+  it('auto-detects Comet on Windows when no other Chromium-family browser is installed', () => {
+    // Comet ships Windows builds under Perplexity\Comet (issue: profile create
+    // refused with "comet is macOS-only" on a machine running Comet).
+    const programFiles = process.env.ProgramFiles || 'C:\\Program Files';
+    presentPaths.add(`${programFiles}\\Perplexity\\Comet\\Application\\comet.exe`);
+
+    const result = findFirstInstalledBrowser('win32');
+
+    expect(result).toEqual({
+      browserType: 'comet',
+      binary: `${programFiles}\\Perplexity\\Comet\\Application\\comet.exe`,
+    });
+  });
+
   it('walks the Linux priority list (chrome > chromium > brave > edge)', () => {
     presentPaths.add('/usr/bin/chromium');
     presentPaths.add('/usr/bin/brave-browser');

--- a/src/lib/browser/chrome.ts
+++ b/src/lib/browser/chrome.ts
@@ -45,7 +45,11 @@ const BROWSER_PATHS: Record<string, Record<BrowserType, string[]>> = {
       `${WIN_PROGRAMFILES_X86}\\Google\\Chrome\\Application\\chrome.exe`,
       `${WIN_LOCALAPPDATA}\\Google\\Chrome\\Application\\chrome.exe`,
     ],
-    comet: [],
+    comet: [
+      `${WIN_PROGRAMFILES}\\Perplexity\\Comet\\Application\\comet.exe`,
+      `${WIN_PROGRAMFILES_X86}\\Perplexity\\Comet\\Application\\comet.exe`,
+      `${WIN_LOCALAPPDATA}\\Perplexity\\Comet\\Application\\comet.exe`,
+    ],
     chromium: [
       `${WIN_LOCALAPPDATA}\\Chromium\\Application\\chrome.exe`,
     ],
@@ -164,8 +168,8 @@ export function findBrowserPath(browserType: BrowserType, customBinary?: string)
     }
   }
 
-  if (browserType === 'comet' && platform !== 'darwin') {
-    throw new Error('Browser "comet" is macOS-only (Comet is a macOS Chromium fork). Use chrome, chromium, brave, or edge on this platform.');
+  if (browserType === 'comet' && platform === 'linux') {
+    throw new Error('Browser "comet" is not available on Linux (Comet ships macOS and Windows builds only). Use chrome, chromium, brave, or edge on this platform.');
   }
   throw new Error(`Browser "${browserType}" not found. Install it first.`);
 }
@@ -181,7 +185,7 @@ const DEFAULT_BROWSER_PRIORITY: Record<string, BrowserType[]> = {
   linux: ['chrome', 'chromium', 'brave', 'edge'],
   // Windows: Edge is preinstalled on every supported build, so it's the
   // reliable always-there default.
-  win32: ['edge', 'chrome', 'brave'],
+  win32: ['edge', 'chrome', 'brave', 'comet'],
 };
 
 /**

--- a/src/lib/browser/profiles.ts
+++ b/src/lib/browser/profiles.ts
@@ -83,7 +83,7 @@ export async function getProfile(name: string): Promise<BrowserProfile | null> {
  * Re-uses an existing `default` profile as-is (we don't second-guess the user
  * if they've already customized it). On first run we walk the priority list
  * (macOS: chrome > brave > edge > chromium > comet; Linux: chrome > chromium >
- * brave > edge; Windows: edge > chrome > brave) and pin the profile to the
+ * brave > edge; Windows: edge > chrome > brave > comet) and pin the profile to the
  * first match. Throws an actionable error if none of those binaries are
  * installed so the user knows exactly which browsers we'd accept.
  */


### PR DESCRIPTION
## Problem

`agents browser profiles create <name> --browser comet` refused on Windows with:

> Browser "comet" is macOS-only (Comet is a macOS Chromium fork). Use chrome, chromium, brave, or edge on this platform.

Comet has shipped Windows builds for a while (installs under `%ProgramFiles%\Perplexity\Comet\Application\comet.exe`), but `BROWSER_PATHS.win32.comet` was empty and `findBrowserPath` hard-gated comet to darwin (`src/lib/browser/chrome.ts`).

## Fix

- Add the three standard Windows install roots (`%ProgramFiles%`, `%ProgramFiles(x86)%`, `%LOCALAPPDATA%`) for `comet.exe`.
- Restrict the unavailability error to Linux, the one platform with no Comet build, and reword it.
- Append `comet` to the win32 auto-pick priority list (last, matching its darwin placement — Edge stays the default).
- New test: `findFirstInstalledBrowser('win32')` detects Comet under `%ProgramFiles%\Perplexity`.
- Docs: priority lists in `docs/browser.md` and `README.md`.

## Evidence (Windows 11, Comet installed)

Profile create — previously the failing command:
```
$ agents browser profiles create comet-e2e-check --browser comet
Created profile: comet-e2e-check
```

Real launch through the same `findBrowserPath` + `launchBrowser` path the daemon's local driver uses:
```
findBrowserPath(comet) = C:\Program Files\Perplexity\Comet\Application\comet.exe
findFirstInstalledBrowser(win32) = {"browserType":"edge",...}   # Edge still wins auto-pick
launched pid = 36568
CDP wsUrl = pipe://14476/1
killed test instance, E2E OK
```

Tests: `vitest run src/lib/browser` — 15 files, 225 passed, 8 skipped (Linux-gated wrapper-script tests).