### PR TITLE
feat(sessions): jumpable --active rows (tmux/Ghostty locators, tty, cleaned preview, tallies)

### DIFF
--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -20,6 +20,8 @@ import { SESSION_AGENTS } from '../lib/session/types.js';
 import { discoverArtifacts, readArtifact, resolveArtifact } from '../lib/session/artifacts.js';
 import { looksLikePath, toComparablePath, homeDir, needsWindowsShell, findExecutable } from '../lib/platform/index.js';
 import { getActiveSessions, type ActiveSession } from '../lib/session/active.js';
+import { enumerateGhosttyTabs, assignGhosttyTabs } from '../lib/session/ghostty-tabs.js';
+import { mapPanesToTargets } from '../lib/tmux/session.js';
 import { machineId, normalizeHost } from '../lib/session/sync/config.js';
 import { gatherRemoteActive, NO_FANOUT_ENV } from '../lib/session/remote-active.js';
 import { gatherRemoteList, runOnPeer } from '../lib/session/remote-list.js';
@@ -261,22 +263,38 @@ function formatStartedAt(startedAtMs?: number): string {
 }
 
 /**
+ * Strip terminal/harness noise from a preview so the column stays a single line
+ * of plain prose: OSC title escapes, CSI/SGR ANSI, and the harness wrapper tags
+ * (`<local-command-stdout>`, `<task-notification>`, `<command-*>`) that leak from
+ * a captured transcript tail. Collapses runs of whitespace.
+ */
+export function cleanPreview(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')        // OSC (title) sequences
+    .replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '')                    // CSI / SGR ANSI
+    .replace(/<\/?(?:local-command-stdout|command-name|command-message|command-args|task-notification|system-reminder)>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
  * Build the live description for an active session: prefer the state engine's
  * preview (the latest turn), then a user label, then the first-prompt topic.
  */
 function buildSessionDescription(s: ActiveSession): string {
   if (s.context === 'cloud') {
-    return s.preview || `${s.cloudProvider ?? ''}${s.cloudTaskId ? ` · ${s.cloudTaskId.slice(0, 12)}` : ''}`;
+    return cleanPreview(s.preview || `${s.cloudProvider ?? ''}${s.cloudTaskId ? ` · ${s.cloudTaskId.slice(0, 12)}` : ''}`);
   }
   if (s.context === 'teams') {
     const parts = [s.teamName];
     if (s.preview) parts.push(s.preview);
     else if (s.label) parts.push(s.label);
     else if (s.topic) parts.push(s.topic);
-    return parts.filter(Boolean).join(' · ');
+    return cleanPreview(parts.filter(Boolean).join(' · '));
   }
   // Terminal or headless: prefer the live preview, then label, then topic.
-  return s.preview || s.label || s.topic || '';
+  return cleanPreview(s.preview || s.label || s.topic || '');
 }
 
 /** Short human word for a session's activity (falls back to the coarse status). */
@@ -342,16 +360,22 @@ function signalBadges(s: Pick<ActiveSession, 'awaitingReason' | 'pr' | 'worktree
 }
 
 /**
- * Compact provenance badge: how to reach the session, not what it's doing.
- * `ssh` flags a remote host; the tmux pane id is the send-keys target the feed
- * would type back into. Local, non-tmux sessions add nothing (the common case).
+ * Compact locator badge: how to JUMP to the session, not what it's doing.
+ * `ssh` flags a remote host. For tmux, prefer the resolved `session:window.pane`
+ * (a real `tmux attach -t <session:window>` target) over the raw `%pane` id. For
+ * a local Ghostty session we know the tab, show `tab N`. Local, unlocatable
+ * sessions add nothing (the common case).
  */
-function provenanceBadge(p?: ActiveSession['provenance']): string {
-  if (!p) return '';
+function locatorBadge(s: ActiveSession): string {
+  const p = s.provenance;
   const parts: string[] = [];
-  if (p.transport === 'ssh') parts.push(chalk.red('ssh'));
-  if (p.mux?.kind === 'tmux' && p.mux.pane) parts.push(chalk.green(`tmux ${p.mux.pane}`));
-  else if (p.mux?.kind === 'screen') parts.push(chalk.green('screen'));
+  if (p?.transport === 'ssh') parts.push(chalk.red('ssh'));
+  if (p?.mux?.kind === 'tmux' && (s.tmuxTarget || p.mux.pane)) {
+    parts.push(chalk.green(s.tmuxTarget ?? p.mux.pane!));
+  } else if (p?.mux?.kind === 'screen') {
+    parts.push(chalk.green('screen'));
+  }
+  if (s.ghosttyTab != null) parts.push(chalk.green(`tab ${s.ghosttyTab}`));
   return parts.join(' ');
 }
 
@@ -368,7 +392,7 @@ function printActiveRow(s: ActiveSession, indent: string): void {
   const hostCol = chalk.gray(padToWidth(truncateToWidth(s.host ?? '-', 8), 9));
   const statusCol = statusColor(s.status)(padToWidth(truncateToWidth(activityLabel(s), 8), 9));
   const fork = s.pidCount && s.pidCount > 1 ? chalk.dim(`×${s.pidCount} `) : '';
-  const badges = (fork ? fork : '') + [signalBadges(s), provenanceBadge(s.provenance)].filter(Boolean).join(' ');
+  const badges = (fork ? fork : '') + [signalBadges(s), locatorBadge(s)].filter(Boolean).join(' ');
   const desc = buildSessionDescription(s) || '-';
   // Fill the remaining width with the preview so nothing wraps under tmux/SSH.
   const fixed = stringWidth(indent) + 9 + 9 + 9 + 9 + (badges ? stringWidth(badges) + 1 : 0);
@@ -561,6 +585,24 @@ export function mergeLocalFirst(sessions: SessionMeta[], localMachine: string): 
   return keys.flatMap((k) => byMachine.get(k)!);
 }
 
+/**
+ * `running N · idle N · waiting N · queued N` for a bucket of sessions (zero
+ * buckets omitted). Same bucketing as the grand-total summary so per-group
+ * counts reconcile with the `(total)` beside the header. Empty when nothing.
+ */
+function groupTally(sessions: ActiveSession[]): string {
+  const running = sessions.filter(s => s.status === 'running').length;
+  const idle = sessions.filter(s => s.status === 'idle').length;
+  const waiting = sessions.filter(s => s.status === 'input_required').length;
+  const queued = sessions.filter(s => s.status === 'queued').length;
+  const parts: string[] = [];
+  if (running) parts.push(`${running} running`);
+  if (idle) parts.push(`${idle} idle`);
+  if (waiting) parts.push(`${waiting} waiting`);
+  if (queued) parts.push(`${queued} queued`);
+  return parts.join(' · ');
+}
+
 /** Print one machine's workspace tree, indented under its machine header. */
 function renderWorkspaceLayout(layout: ActiveSessionsLayout, base: string): void {
   let first = true;
@@ -573,7 +615,9 @@ function renderWorkspaceLayout(layout: ActiveSessionsLayout, base: string): void
       : ws.key === '__unknown__'
         ? chalk.gray.bold('unknown')
         : chalk.cyan.bold(shortCwd(ws.key));
-    console.log(`${base}${header} ${chalk.gray(`(${ws.total})`)}`);
+    const wsSessions = [...ws.windows.flatMap(w => w.sessions), ...ws.flat];
+    const tally = groupTally(wsSessions);
+    console.log(`${base}${header} ${chalk.gray(`(${ws.total})`)}${tally ? chalk.gray(`  ${tally}`) : ''}`);
 
     for (const win of ws.windows) {
       // Host is per-process, but every terminal in the same IDE window shares
@@ -595,6 +639,39 @@ function printMachineHeader(mg: MachineGroup): void {
   const name = mg.isLocal ? chalk.bold.cyan(mg.machine) : chalk.bold(mg.machine);
   const here = mg.isLocal ? chalk.cyan('  ← this machine') : '';
   console.log(`${marker}${name} ${chalk.gray(`(${mg.total})`)}${here}`);
+}
+
+/**
+ * Attach display-only jump locators onto LOCAL sessions: the Ghostty tab number
+ * (one batched read-only osascript, only when a local ghostty session exists)
+ * and the tmux `session:window.pane` target (one `list-panes -a` per socket).
+ * Every step is best-effort and swallowed — a failure just leaves the raw pane
+ * id / no tab number, and the rows render as before. Mutates the sessions.
+ */
+async function enrichLocalLocators(local: ActiveSession[]): Promise<void> {
+  // Ghostty tab numbers.
+  try {
+    const ghostty = local.filter(s => s.host === 'ghostty' && s.provenance?.transport !== 'ssh');
+    if (ghostty.length > 0) {
+      const surfaces = await enumerateGhosttyTabs();
+      for (const [sess, tab] of assignGhosttyTabs(ghostty, surfaces)) sess.ghosttyTab = tab;
+    }
+  } catch { /* non-fatal */ }
+
+  // tmux attach targets, one batched query per distinct socket.
+  try {
+    const tmux = local.filter(s => s.provenance?.mux?.kind === 'tmux' && s.provenance.mux.pane);
+    const sockets = new Set(tmux.map(s => s.provenance!.mux!.socket));
+    for (const socket of sockets) {
+      const paneMap = await mapPanesToTargets(socket);
+      if (paneMap.size === 0) continue;
+      for (const s of tmux) {
+        if (s.provenance!.mux!.socket !== socket) continue;
+        const target = paneMap.get(s.provenance!.mux!.pane!);
+        if (target) s.tmuxTarget = target;
+      }
+    }
+  } catch { /* non-fatal */ }
 }
 
 /**
@@ -637,6 +714,11 @@ async function renderActiveSessions(
     return;
   }
 
+  // Enrich LOCAL sessions with jump locators (display-only, after the --json /
+  // --waiting gates so scriptable output stays osascript-free). Remote sessions
+  // keep their raw pane id — their tmux/Ghostty live on the other machine.
+  await enrichLocalLocators(sessions.filter(s => !s.machine || s.machine === self));
+
   const grouped = groupSessionsByMachine(sessions, self);
   let firstMachine = true;
   for (const mg of grouped.machines) {
@@ -646,14 +728,7 @@ async function renderActiveSessions(
     renderWorkspaceLayout(mg.layout, '  ');
   }
 
-  const runningCount = sessions.filter(s => s.status === 'running').length;
-  const idleCount = sessions.filter(s => s.status === 'idle').length;
-  const queuedCount = sessions.filter(s => s.status === 'queued' || s.status === 'input_required').length;
-
-  const parts: string[] = [];
-  if (runningCount > 0) parts.push(`${runningCount} running`);
-  if (idleCount > 0) parts.push(`${idleCount} idle`);
-  if (queuedCount > 0) parts.push(`${queuedCount} queued`);
+  const parts = groupTally(sessions).split(' · ').filter(Boolean);
   const machineWord = grouped.machines.length === 1 ? 'machine' : 'machines';
   console.log(chalk.gray(`\n${sessions.length} active (${parts.join(', ')}) across ${grouped.machines.length} ${machineWord}.`));
 

--- a/src/lib/session/active.ts
+++ b/src/lib/session/active.ts
@@ -104,6 +104,24 @@ export interface ActiveSession {
    * two windows have the same cwd open. Only populated for `terminal` context.
    */
   windowId?: string;
+  /**
+   * Controlling TTY of the agent process (e.g. 'ttys003'), from the `ps -A`
+   * read. macOS/Linux terminal sessions only; '??'/none normalized to undefined.
+   * A disambiguation bridge (and the basis for future terminal addressing).
+   */
+  tty?: string;
+  /**
+   * Ghostty tab index (1-based) the session is shown in, when it can be matched
+   * to a Ghostty surface by working directory (+ title). Transient, populated by
+   * the renderer just before printing — NOT part of the pure discovery path.
+   */
+  ghosttyTab?: number;
+  /**
+   * Resolved tmux attach target (`session:window.pane`) for a tmux-hosted local
+   * session, from the pane id via `mapPanesToTargets`. Transient, renderer-set
+   * (after the --json/--waiting gates) — NOT emitted on the discovery path.
+   */
+  tmuxTarget?: string;
 }
 
 export interface ActiveQueryOptions {
@@ -415,6 +433,7 @@ export async function listTerminalsActive(): Promise<ActiveSession[]> {
       context: 'terminal',
       kind: t.kind,
       host: detectHost(t.pid, procByPid),
+      tty: procByPid.get(t.pid)?.tty,
       pid: t.pid,
       sessionId: t.sessionId ?? sessionIdFromFile(sessionFile),
       cwd: t.cwd ?? undefined,
@@ -451,7 +470,7 @@ export function listCloudActive(): ActiveSession[] {
   }));
 }
 
-interface ProcRow { pid: number; ppid: number; comm: string; kind?: string; }
+interface ProcRow { pid: number; ppid: number; tty?: string; comm: string; kind?: string; }
 
 /**
  * Ordered ancestor-process matchers. First match wins (most specific to least),
@@ -488,19 +507,23 @@ async function readProcessTable(): Promise<ProcRow[]> {
   if (process.platform === 'win32') return readProcessTableWin32();
   let out: string;
   try {
-    ({ stdout: out } = await execFileAsync('ps', ['-A', '-o', 'pid=,ppid=,comm='], { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 }));
+    ({ stdout: out } = await execFileAsync('ps', ['-A', '-o', 'pid=,ppid=,tty=,comm='], { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 }));
   } catch {
     return [];
   }
   const rows: ProcRow[] = [];
   for (const line of out.split('\n')) {
-    const m = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/);
+    // pid ppid tty comm — tty is a single token ('ttys003', 's003', or '??'/'?'
+    // for none); comm stays last so it may contain spaces.
+    const m = line.trim().match(/^(\d+)\s+(\d+)\s+(\S+)\s+(.+)$/);
     if (!m) continue;
     const pid = parseInt(m[1], 10);
     const ppid = parseInt(m[2], 10);
     if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue;
-    const commRaw = m[3].trim();
-    rows.push({ pid, ppid, comm: commRaw, kind: agentKindFromComm(commRaw) });
+    const ttyRaw = m[3];
+    const tty = ttyRaw === '??' || ttyRaw === '?' || ttyRaw === '-' ? undefined : ttyRaw;
+    const commRaw = m[4].trim();
+    rows.push({ pid, ppid, tty, comm: commRaw, kind: agentKindFromComm(commRaw) });
   }
   return rows;
 }
@@ -774,6 +797,7 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
       context,
       kind,
       host,
+      tty: procByPid.get(pid)?.tty,
       pid,
       cwd,
       sessionId: entry?.sessionId ?? sessionIdFromFile(sessionFile),

--- a/src/lib/session/ghostty-tabs.test.ts
+++ b/src/lib/session/ghostty-tabs.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect } from 'vitest';
 import { assignGhosttyTabs, type GhosttySurface } from './ghostty-tabs.js';
 import type { ActiveSession } from './active.js';
 

--- a/src/lib/session/ghostty-tabs.test.ts
+++ b/src/lib/session/ghostty-tabs.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'bun:test';
+import { assignGhosttyTabs, type GhosttySurface } from './ghostty-tabs.js';
+import type { ActiveSession } from './active.js';
+
+function sess(p: Partial<ActiveSession>): ActiveSession {
+  return { context: 'terminal', kind: 'claude', status: 'running', host: 'ghostty', ...p };
+}
+function surf(p: Partial<GhosttySurface>): GhosttySurface {
+  return { windowIndex: 1, tabIndex: 1, cwd: '/repo', title: '', ...p };
+}
+
+describe('assignGhosttyTabs', () => {
+  it('assigns the tab when exactly one surface matches the cwd', () => {
+    const s = sess({ cwd: '/Users/m/rush' });
+    const m = assignGhosttyTabs([s], [
+      surf({ tabIndex: 3, cwd: '/Users/m/rush' }),
+      surf({ tabIndex: 1, cwd: '/Users/m/agents' }),
+    ]);
+    expect(m.get(s)).toBe(3);
+  });
+
+  it('ignores trailing slashes when matching cwd', () => {
+    const s = sess({ cwd: '/Users/m/rush/' });
+    const m = assignGhosttyTabs([s], [surf({ tabIndex: 2, cwd: '/Users/m/rush' })]);
+    expect(m.get(s)).toBe(2);
+  });
+
+  it('only matches ghostty-hosted sessions', () => {
+    const s = sess({ cwd: '/repo', host: 'tmux' });
+    const m = assignGhosttyTabs([s], [surf({ tabIndex: 4, cwd: '/repo' })]);
+    expect(m.has(s)).toBe(false);
+  });
+
+  it('leaves a session unassigned when no surface cwd matches', () => {
+    const s = sess({ cwd: '/repo/a' });
+    const m = assignGhosttyTabs([s], [surf({ tabIndex: 1, cwd: '/repo/b' })]);
+    expect(m.has(s)).toBe(false);
+  });
+
+  it('breaks a same-cwd tie by title containment, ignoring the leading spinner glyph', () => {
+    const s = sess({ cwd: '/repo', label: 'fix auth flow' });
+    const m = assignGhosttyTabs([s], [
+      surf({ tabIndex: 1, cwd: '/repo', title: '⠐ reduce browser instances' }),
+      surf({ tabIndex: 5, cwd: '/repo', title: '✳ fix auth flow on device' }),
+    ]);
+    expect(m.get(s)).toBe(5);
+  });
+
+  it('leaves ambiguous same-cwd sessions unassigned rather than guessing', () => {
+    const s = sess({ cwd: '/repo', label: 'authentication refactor', topic: 'authentication refactor' });
+    const m = assignGhosttyTabs([s], [
+      surf({ tabIndex: 1, cwd: '/repo', title: 'unrelated one thing' }),
+      surf({ tabIndex: 2, cwd: '/repo', title: 'unrelated two thing' }),
+    ]);
+    // No title match among 2 same-cwd candidates -> no number (never a wrong jump target).
+    expect(m.has(s)).toBe(false);
+  });
+
+  it('does not assign when the tie-break matches more than one surface', () => {
+    const s = sess({ cwd: '/repo', label: 'rush deploy pipeline' });
+    const m = assignGhosttyTabs([s], [
+      surf({ tabIndex: 1, cwd: '/repo', title: 'deploy the rush deploy pipeline now' }),
+      surf({ tabIndex: 2, cwd: '/repo', title: 'rush deploy pipeline rollback' }),
+    ]);
+    expect(m.has(s)).toBe(false);
+  });
+
+  it('ignores hints shorter than 8 chars (avoids spurious short-fragment matches)', () => {
+    const s = sess({ cwd: '/repo', label: 'auth' });
+    const m = assignGhosttyTabs([s], [
+      surf({ tabIndex: 1, cwd: '/repo', title: 'authentication work' }),
+      surf({ tabIndex: 2, cwd: '/repo', title: 'something else' }),
+    ]);
+    expect(m.has(s)).toBe(false);
+  });
+
+  it('returns an empty map when there are no surfaces', () => {
+    const s = sess({ cwd: '/repo' });
+    expect(assignGhosttyTabs([s], []).size).toBe(0);
+  });
+});

--- a/src/lib/session/ghostty-tabs.ts
+++ b/src/lib/session/ghostty-tabs.ts
@@ -1,0 +1,136 @@
+/**
+ * Best-effort Ghostty tab-number detection for `agents sessions --active`.
+ *
+ * Ghostty (macOS) exposes read-only AppleScript: every tab has an `index` and a
+ * `name` (title); every surface a `working directory`. It exposes NO per-tab env
+ * var and NO tty/pid on a surface — so a session is matched to its tab by
+ * `working directory` (with title as a tiebreak). This is display sugar only:
+ * one bounded, non-fatal osascript call, run by the renderer, never on the
+ * discovery / --json / --waiting path. Any failure (Ghostty not running,
+ * Automation permission denied, timeout) degrades silently to no tab number.
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import type { ActiveSession } from './active.js';
+
+const execFileAsync = promisify(execFile);
+
+/** One Ghostty surface (terminal), flattened from window -> tab -> surface. */
+export interface GhosttySurface {
+  windowIndex: number;
+  tabIndex: number;
+  cwd: string;
+  title: string;
+}
+
+// Field delimiter: ASCII Unit Separator (0x1F). AppleScript's `tab` keyword does
+// not resolve to a tab byte via `osascript -e`, but `character id 31` does — and
+// 0x1F never appears in a cwd or a tab title, so parsing is unambiguous.
+const ENUM_SCRIPT = `tell application "Ghostty"
+  set fd to (character id 31)
+  set out to ""
+  set wi to 0
+  repeat with w in windows
+    set wi to wi + 1
+    repeat with t in tabs of w
+      set ti to index of t
+      repeat with s in terminals of t
+        set out to out & wi & fd & ti & fd & (working directory of s) & fd & (name of s) & linefeed
+      end repeat
+    end repeat
+  end repeat
+  return out
+end tell`;
+
+/**
+ * Enumerate every Ghostty surface (window/tab/cwd/title) via one read-only
+ * osascript call. Returns [] on ANY failure — Ghostty not running, Automation
+ * permission not granted, timeout, or a parse miss. Never throws, never prompts.
+ */
+export async function enumerateGhosttyTabs(timeoutMs = 1500): Promise<GhosttySurface[]> {
+  if (process.platform !== 'darwin') return [];
+  let stdout: string;
+  try {
+    ({ stdout } = await execFileAsync('osascript', ['-e', ENUM_SCRIPT], {
+      timeout: timeoutMs,
+      killSignal: 'SIGKILL',
+      maxBuffer: 1024 * 1024,
+      encoding: 'utf8',
+    }));
+  } catch {
+    return [];
+  }
+  const out: GhosttySurface[] = [];
+  for (const line of stdout.split('\n')) {
+    if (!line) continue;
+    const f = line.split('\u001f');
+    if (f.length < 4) continue;
+    const windowIndex = parseInt(f[0], 10);
+    const tabIndex = parseInt(f[1], 10);
+    if (!Number.isFinite(windowIndex) || !Number.isFinite(tabIndex)) continue;
+    out.push({ windowIndex, tabIndex, cwd: f[2], title: f[3] });
+  }
+  return out;
+}
+
+/** Trailing-slash-insensitive cwd key. */
+function cwdKey(p: string | undefined): string {
+  return (p ?? '').replace(/\/+$/, '');
+}
+
+/**
+ * Normalize a tab title / hint for containment matching: drop a leading run of
+ * non-alphanumerics (Ghostty prefixes the title with a spinner glyph like `⠐ `
+ * or `✳ ` while the agent runs) and lowercase. Without this, a title that starts
+ * with the session's exact topic still fails a substring test.
+ */
+function normText(s: string): string {
+  return s.replace(/^[^\p{L}\p{N}]+/u, '').toLowerCase().trim();
+}
+
+/**
+ * Assign a Ghostty tab number to each `host === 'ghostty'` session by matching
+ * its cwd to a surface's working directory; ties (same cwd) are broken by title
+ * containment against the session's label/topic/kind. Deliberately conservative:
+ * a session that can't be uniquely resolved gets NO number — a wrong jump target
+ * is worse than none. Pure and unit-tested.
+ */
+export function assignGhosttyTabs(
+  sessions: ActiveSession[],
+  surfaces: GhosttySurface[],
+): Map<ActiveSession, number> {
+  const result = new Map<ActiveSession, number>();
+  if (surfaces.length === 0) return result;
+
+  const byCwd = new Map<string, GhosttySurface[]>();
+  for (const s of surfaces) {
+    const k = cwdKey(s.cwd);
+    const bucket = byCwd.get(k);
+    if (bucket) bucket.push(s);
+    else byCwd.set(k, [s]);
+  }
+
+  for (const sess of sessions) {
+    if (sess.host !== 'ghostty') continue;
+    const candidates = byCwd.get(cwdKey(sess.cwd));
+    if (!candidates || candidates.length === 0) continue;
+    if (candidates.length === 1) {
+      result.set(sess, candidates[0].tabIndex);
+      continue;
+    }
+    // Tie: break by title containment (glyph-stripped, lowercased). Hints are
+    // what the session knows about itself; a good hint is >=8 chars so short
+    // fragments don't cause spurious matches.
+    const hints = [sess.label, sess.topic, sess.preview]
+      .filter((h): h is string => !!h && normText(h).length >= 8)
+      .map(normText);
+    const matches = candidates.filter(c => {
+      const title = normText(c.title);
+      return title.length >= 8 && hints.some(h => title.includes(h) || h.includes(title));
+    });
+    // Only assign when the tiebreak is unambiguous (exactly one title match).
+    if (matches.length === 1) result.set(sess, matches[0].tabIndex);
+  }
+  return result;
+}

--- a/src/lib/tmux/session.ts
+++ b/src/lib/tmux/session.ts
@@ -204,6 +204,35 @@ export async function killAll(socket?: string): Promise<number> {
 }
 
 /**
+ * Map every pane id (`%N`) on a socket to its `session:window.pane` attach
+ * target, in one batched `tmux list-panes -a` call. `%116 -> main:2.0` is a
+ * valid `tmux attach -t main:2` / `tmux select-window -t main:2` target — a
+ * human jump target, unlike the bare `%pane` send-keys id. Because it walks
+ * every pane (not just one-per-session), it also surfaces multiple agents that
+ * share a session across windows. Best-effort: returns an empty map on any
+ * failure (tmux gone, foreign socket) so callers fall back to the raw pane id.
+ */
+export async function mapPanesToTargets(socket?: string): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  let res;
+  try {
+    res = await runTmux({
+      socket,
+      args: ['list-panes', '-a', '-F', '#{pane_id} #{session_name}:#{window_index}.#{pane_index}'],
+      throwOnError: false,
+    });
+  } catch {
+    return out;
+  }
+  if (res.code !== 0) return out;
+  for (const line of res.stdout.split('\n')) {
+    const sp = line.indexOf(' ');
+    if (sp > 0) out.set(line.slice(0, sp), line.slice(sp + 1).trim());
+  }
+  return out;
+}
+
+/**
  * List live sessions on the socket. Reconciles meta JSONs against tmux's view:
  *  - tmux session with no meta → returned without `meta` (external session)
  *  - meta file with no tmux session → meta deleted (stale)


### PR DESCRIPTION

### Before → after (user-visible)

**Before** — send-keys pane id, no Ghostty locator, noisy preview, no per-group tally:
```
▸ zion (7)  ← this machine
  ~/src/github.com/muqsitnawaz (4)
    384a0be2 claude   ghostty  working  Bash: WT=/Users/…/agents-cli…
    e3d6852d claude   tmux     idle     ssh tmux %117  Confirmed — here's the full cross-plat…
    19f0f9be claude   tmux     working  ssh tmux %0  <local-command-stdout>Goodbye!</local-command-stdout>
7 active (2 running, 1 idle, 4 waiting) across 1 machine.
```

**After** — jumpable locator (`session:window.pane` / `tab N`), cleaned preview, reconciling tally:
```
▸ zion (7)  ← this machine
  ~/src/github.com/muqsitnawaz (4)  1 running · 2 idle · 1 waiting
    384a0be2 claude   ghostty  working  tab 1  Bash: WT=/Users/…/agents-cli…
    e3d6852d claude   tmux     idle     ssh main:2.0  Confirmed — here's the full cross-plat…
    19f0f9be claude   tmux     working  main:0.0  Goodbye!
7 active (2 running, 2 idle, 2 waiting, 1 queued) across 1 machine.
```

Diff at a glance: `tmux %117` → `main:2.0` (real `tmux attach -t main:2` target) · Ghostty gains `tab 1` · `<local-command-stdout>…` stripped · cwd header gains the tally.

## What

Make `agents sessions --active` rows **jumpable** — each row now shows *how to reach* the session, not just that it exists — plus cleaner previews and reconciling per-group tallies.

```
▸ zion (7)  ← this machine
  ~/src/github.com/muqsitnawaz (4)  1 running · 2 idle · 1 waiting
    384a0be2 claude   ghostty  working  tab 1  Bash: WT=/Users/muqsit/src/github.com/…
    c6bf2f38 claude   ghostty  idle     PR#141 Both fixes are now merged to `main` …
  / (1)  1 running
    019e30a2 codex    -        running  -
7 active (2 running, 2 idle, 2 waiting, 1 queued) across 1 machine.
```

## Changes

1. **TTY capture** — `active.ts` adds `tty=` to the single `ps -A` read and exposes `ActiveSession.tty`. Zero extra spawns; a disambiguation bridge.
2. **tmux jump target** — `mapPanesToTargets()` (one `tmux list-panes -a` per socket) resolves a pane id to `session:window.pane` (e.g. `main:0.1`), a real `tmux attach -t main:0` target — replacing the bare send-keys `%pane`. Also surfaces multiple agents sharing a session across windows.
3. **Ghostty tab number** — new `ghostty-tabs.ts`: one bounded, read-only `osascript` enumeration (window/tab `index`, cwd, title) + a pure `assignGhosttyTabs()` matcher (cwd, then glyph-stripped title tiebreak). Only runs when a local ghostty session exists; degrades silently (Ghostty not running / Automation denied / timeout).
4. **Output polish** — `locatorBadge()` (tmux target + `tab N`), `cleanPreview()` (strips OSC/ANSI + `<local-command-stdout>`/`<task-notification>` tags), and per-cwd `running·idle·waiting·queued` tallies that reconcile with the total. All display-only, after the `--json`/`--waiting` gates.

## Verified (macOS, live)

- `enumerateGhosttyTabs()` returns the real tabs; `assignGhosttyTabs` resolved a same-cwd tie to the correct tab via title.
- `mapPanesToTargets()` on a throwaway 3-pane server → `%0→main:0.0`, `%1→main:0.1`, `%2→main:1.0`.
- Full render shows the locator column, cleaned previews, and reconciling tallies (above).
- `tsc --noEmit` clean; `bun test` — 9/9 new matcher tests, and all session/tmux/sessions-command suites pass.

## Known limitation (Ghostty tab #)

Ghostty exposes no per-tab env var and no `tty`/`pid` on a surface, so the session→tab bridge is `working directory` + title. When **many agents share one repo cwd** (a common monorepo pattern) and the tab titles are agent-generated *summaries* that don't textually match the raw prompt, the match is ambiguous and the row shows **no** tab number rather than a wrong one. The robust fix is capturing the Ghostty surface UUID at spawn time (`ghostty.ts` → `return id of` the new tab, persisted per session) — deliberately deferred as a follow-up since it threads stdout through the terminal launch engine.

## Note

Pre-existing, unrelated: `src/lib/session/__tests__/db.test.ts` has failures (`NOT NULL constraint failed: sessions.short_id`) on the base — this diff does not touch `db.ts`, the schema, or its seed.

Session (fleet-local): zion:/Users/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/69b2b44a-1e77-4dcf-af4c-e55deb395baa.jsonl