### PR TITLE
feat(sessions): agents sessions go — jump to a live session (rich picker + tmux/ghostty/ssh attach)

### DIFF
--- a/src/commands/go.test.ts
+++ b/src/commands/go.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { describeWhere, type Where } from './go.js';
+import type { ActiveSession } from '../lib/session/active.js';
+
+/** Minimal ActiveSession builder — only the fields describeWhere reads. */
+function s(over: Partial<ActiveSession>): ActiveSession {
+  return { context: 'terminal', kind: 'claude', status: 'running', ...over } as ActiveSession;
+}
+
+describe('describeWhere — which jump path a live session takes', () => {
+  const self = 'zion';
+
+  it('local tmux → attach its tmux, label carries the pane', () => {
+    const w = describeWhere(s({ machine: self, provenance: { mux: { kind: 'tmux', pane: '%3' } } as never }), self);
+    expect(w.label).toContain('%3');
+    expect(w.action).toBe('attach its tmux');
+  });
+
+  it('remote tmux → ssh + attach on the host', () => {
+    const w = describeWhere(s({ machine: 'yosemite-s0', provenance: { mux: { kind: 'tmux', pane: '%117' } } as never }), self);
+    expect(w.label).toContain('yosemite-s0');
+    expect(w.action).toContain('ssh');
+    expect(w.action).toContain('yosemite-s0');
+  });
+
+  it('local Ghostty (no mux) → focus its tab', () => {
+    const w = describeWhere(s({ machine: self, host: 'ghostty' }), self);
+    expect(w.action).toBe('focus its Ghostty tab');
+  });
+
+  it('remote non-tmux → open a shell on the host', () => {
+    const w = describeWhere(s({ machine: 'yosemite-s1', host: 'bash' }), self);
+    expect(w.action).toContain('shell');
+    expect(w.action).toContain('yosemite-s1');
+  });
+
+  it('local, no attach rail → refuse (resume)', () => {
+    const w: Where = describeWhere(s({ machine: self, host: 'terminal' }), self);
+    expect(w.action).toContain('resume');
+  });
+
+  it('remote tmux beats the host check (a remote ghostty-hosted session still ssh-attaches)', () => {
+    const w = describeWhere(s({ machine: 'box', host: 'ghostty', provenance: { mux: { kind: 'tmux', pane: '%9' } } as never }), self);
+    expect(w.action).toContain('ssh');
+  });
+});

--- a/src/commands/go.ts
+++ b/src/commands/go.ts
@@ -1,0 +1,256 @@
+/**
+ * `agents sessions go [id]` — jump to a LIVE agent session's terminal.
+ *
+ * No id  -> the SAME rich interactive picker as `agents sessions` (worktree, PR,
+ *           changed files, tools, tests, last response — this-machine first),
+ *           filtered to sessions that are running right now.
+ * With id -> jump directly.
+ *
+ * "Jump" is not "resume" (which spawns a new process from the transcript). It walks
+ * you to the already-running terminal:
+ *   local tmux    -> attach (switch-client when already inside tmux)
+ *   local Ghostty -> focus its tab (Cmd+<n> via System Events; tab # from ghostty-tabs)
+ *   remote tmux   -> ssh -tt + tmux attach (pane->session resolved on the remote)
+ *   otherwise     -> refuse with a reason + resume hint (cloud / no attach rail)
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { getActiveSessions, findSessionFileForKind, type ActiveSession } from '../lib/session/active.js';
+import { gatherRemoteActive } from '../lib/session/remote-active.js';
+import { discoverSessions } from '../lib/session/discover.js';
+import type { SessionMeta, SessionAgentId } from '../lib/session/types.js';
+import { dedupeByMachineSession, mergeLocalFirst, pickSessionInteractive } from './sessions.js';
+import { machineId } from '../lib/session/sync/config.js';
+import { isInteractiveTerminal } from './utils.js';
+import { attachTmux, runTmux } from '../lib/tmux/binary.js';
+import { getDefaultSocketPath } from '../lib/tmux/paths.js';
+import { sshStream, assertValidSshTarget, shellQuote } from '../lib/ssh-exec.js';
+import { enumerateGhosttyTabs, assignGhosttyTabs } from '../lib/session/ghostty-tabs.js';
+
+const execFileAsync = promisify(execFile);
+
+export function registerGoCommand(program: Command): void {
+  program
+    .command('go')
+    .argument('[id]', 'Short/full session id to jump to; omit for an interactive picker')
+    .option('--local', 'Only this machine (skip the cross-host sweep)')
+    .description('Jump to a live agent session — attach its tmux, or focus its terminal tab')
+    .action(async (id: string | undefined, opts: { local?: boolean }) => {
+      await goAction(id, opts);
+    });
+}
+
+async function goAction(id: string | undefined, opts: { local?: boolean }): Promise<void> {
+  const self = machineId();
+
+  // Live jump targets (local + remote), keyed by session id.
+  const localActive = await getActiveSessions();
+  for (const s of localActive) if (!s.machine) s.machine = self;
+  let active = localActive;
+  if (!opts.local) {
+    try {
+      const remote = await gatherRemoteActive();
+      active = dedupeByMachineSession([...localActive, ...remote.sessions]);
+    } catch { /* remote sweep is best-effort */ }
+  }
+  const activeById = new Map<string, ActiveSession>();
+  for (const s of active) if (s.context !== 'cloud' && s.sessionId) activeById.set(s.sessionId, s);
+
+  if (activeById.size === 0) {
+    console.log(chalk.gray('No live agent sessions to jump to.'));
+    return;
+  }
+
+  // Direct jump by id — no picker.
+  if (id) {
+    const q = id.toLowerCase();
+    const matches = [...activeById.values()].filter((s) => s.sessionId!.toLowerCase().startsWith(q));
+    if (matches.length === 0) {
+      console.error(chalk.red(`No live session matching "${id}".`));
+      process.exitCode = 1;
+      return;
+    }
+    if (matches.length > 1) {
+      console.error(chalk.red(`"${id}" is ambiguous (${matches.length} matches). Use more of the id.`));
+      process.exitCode = 1;
+      return;
+    }
+    await jumpTo(matches[0], self);
+    return;
+  }
+
+  if (!isInteractiveTerminal()) {
+    console.error(chalk.red('go needs an interactive terminal, or pass a session id.'));
+    process.exitCode = 1;
+    return;
+  }
+
+  // Reuse the rich `sessions` picker over the live sessions' full SessionMeta.
+  const pool = await buildLivePool(activeById, self);
+  if (pool.length === 0) {
+    console.log(chalk.gray('No live sessions to jump to.'));
+    return;
+  }
+  const picked = await pickSessionInteractive(pool, 'Jump to a live session:', undefined, 0, 'jump');
+  if (!picked) return;
+  const target = activeById.get(picked.session.id);
+  if (!target) {
+    console.log(chalk.yellow(`${picked.session.shortId} is no longer live — try: `) + chalk.gray(`agents sessions resume ${picked.session.shortId}`));
+    return;
+  }
+  await jumpTo(target, self);
+}
+
+/**
+ * Map each live session to its rich SessionMeta (worktree/PR/changes/tools/tests
+ * via the shared picker), reusing `discoverSessions`. Remote or unindexed live
+ * sessions get a minimal synthesized meta so they still appear and jump.
+ */
+async function buildLivePool(activeById: Map<string, ActiveSession>, self: string): Promise<SessionMeta[]> {
+  let metas: SessionMeta[] = [];
+  try {
+    metas = await discoverSessions({ all: true, since: '30d', limit: 1000 });
+  } catch { /* fall back to synthesized metas */ }
+  const byId = new Map<string, SessionMeta>();
+  for (const m of metas) byId.set(m.id, m);
+  const pool: SessionMeta[] = [];
+  for (const [sid, s] of activeById) {
+    pool.push(byId.get(sid) ?? synthMeta(s, self));
+  }
+  return mergeLocalFirst(pool, self);
+}
+
+function synthMeta(s: ActiveSession, self: string): SessionMeta {
+  const remote = !!s.machine && s.machine !== self;
+  // For a local session, locate the real transcript on disk so the picker's
+  // buildPreview parses it directly (rich Prompt/Changes/Tools/Last response) —
+  // independent of the sessions DB. Remote transcripts live on the peer, so leave
+  // filePath empty and the preview shows a clean "not indexed here" note.
+  const filePath = remote ? '' : (findSessionFileForKind(s.kind, s.cwd, s.sessionId) ?? '');
+  return {
+    id: s.sessionId!,
+    shortId: s.sessionId!.slice(0, 8),
+    agent: s.kind as SessionAgentId,
+    timestamp: new Date(s.startedAtMs ?? Date.now()).toISOString(),
+    filePath,
+    cwd: s.cwd,
+    project: s.cwd ? path.basename(s.cwd) : undefined,
+    topic: s.topic,
+    machine: s.machine,
+    _remote: remote,
+  };
+}
+
+// ---------- the jump ----------
+
+export interface Where { label: string; action: string; }
+
+function shortId(s: ActiveSession): string {
+  return (s.sessionId ?? '').slice(0, 8) || '-';
+}
+
+/**
+ * Pure, testable mirror of `jumpTo`'s path selection (jumpTo itself has side
+ * effects — process.exit / ssh / osascript). Keep the branch ORDER in sync with
+ * `jumpTo` below: remote-tmux, then local-tmux, then ghostty, then refuse.
+ */
+export function describeWhere(s: ActiveSession, self: string): Where {
+  const remote = s.machine && s.machine !== self ? s.machine : undefined;
+  const mux = s.provenance?.mux;
+  if (mux?.kind === 'tmux' && mux.pane) {
+    return remote
+      ? { label: `tmux ${mux.pane} on ${remote}`, action: `ssh + attach on ${remote}` }
+      : { label: `tmux ${mux.pane}`, action: 'attach its tmux' };
+  }
+  if (!remote && s.host === 'ghostty') return { label: 'Ghostty', action: 'focus its Ghostty tab' };
+  if (remote) return { label: `${s.host ?? 'shell'} on ${remote}`, action: `open a shell on ${remote}` };
+  return { label: s.host ?? 'unknown terminal', action: 'resume it (no live attach rail)' };
+}
+
+async function jumpTo(s: ActiveSession, self: string): Promise<void> {
+  const remote = s.machine && s.machine !== self ? s.machine : undefined;
+  const mux = s.provenance?.mux;
+
+  // Path C: remote tmux — ssh in and attach, resolving the pane's session on the remote.
+  if (remote) {
+    if (mux?.kind === 'tmux' && mux.pane) {
+      assertValidSshTarget(remote);
+      const sock = mux.socket ? `-S ${shellQuote(mux.socket)} ` : '';
+      const p = shellQuote(mux.pane);
+      const remoteCmd =
+        `w=$(tmux ${sock}display-message -pt ${p} '#{session_name}:#{window_index}' 2>/dev/null); ` +
+        `sess=$(tmux ${sock}display-message -pt ${p} '#{session_name}' 2>/dev/null); ` +
+        `[ -n "$w" ] && tmux ${sock}select-window -t "$w" 2>/dev/null; ` +
+        `exec tmux ${sock}attach-session -t "\${sess:-${p}}"`;
+      console.log(chalk.gray(`Attaching ${shortId(s)} on ${remote} over SSH — Ctrl-b d to detach.`));
+      process.exit(sshStream(remote, remoteCmd, { tty: true }));
+    }
+    console.log(chalk.yellow(`${shortId(s)} on ${remote} isn't inside tmux — opening a shell on ${remote} instead.`));
+    assertValidSshTarget(remote);
+    process.exit(sshStream(remote, 'exec "${SHELL:-/bin/sh}" -l', { tty: true }));
+  }
+
+  // Path B: local tmux — attach (or switch-client if we're already inside tmux).
+  if (mux?.kind === 'tmux' && mux.pane) {
+    const socket = mux.socket ?? getDefaultSocketPath();
+    const { session, window } = await resolveLocalPane(socket, mux.pane);
+    if (session && window != null) {
+      await runTmux({ socket, args: ['select-window', '-t', `${session}:${window}`], throwOnError: false }).catch(() => {});
+    }
+    const tgt = session ?? mux.pane;
+    if (process.env.TMUX) {
+      await runTmux({ socket, args: ['switch-client', '-t', tgt], throwOnError: false }).catch(() => {});
+      console.log(chalk.gray(`Switched this tmux client to ${shortId(s)} (${tgt}).`));
+      return;
+    }
+    console.log(chalk.gray(`Attaching ${shortId(s)} (tmux ${tgt}) — Ctrl-b d to detach.`));
+    process.exit(await attachTmux({ socket, args: ['attach-session', '-t', tgt] }));
+  }
+
+  // Path A: local Ghostty — focus its tab (Cmd+N via System Events).
+  if (s.host === 'ghostty') {
+    let tab: number | undefined;
+    try {
+      const surfaces = await enumerateGhosttyTabs();
+      tab = assignGhosttyTabs([s], surfaces).get(s);
+    } catch { /* best-effort */ }
+    if (tab != null && tab <= 9) {
+      const script =
+        `tell application "Ghostty" to activate\n` +
+        `delay 0.15\n` +
+        `tell application "System Events" to keystroke "${tab}" using command down`;
+      await execFileAsync('osascript', ['-e', script]).catch(() => {});
+      console.log(chalk.gray(`Focused ${shortId(s)} → Ghostty tab ${tab}.`));
+      return;
+    }
+    await execFileAsync('osascript', ['-e', 'tell application "Ghostty" to activate']).catch(() => {});
+    console.log(
+      chalk.yellow(`Raised Ghostty for ${shortId(s)}`) +
+        chalk.gray(tab != null ? ` — switch to tab ${tab} (Cmd+${tab}).` : " — couldn't pinpoint its tab (same-repo forks are ambiguous); switch tabs manually."),
+    );
+    return;
+  }
+
+  // Path D: refuse with a reason.
+  console.log(
+    chalk.yellow(`Can't jump to ${shortId(s)} — it's in ${s.host ?? 'an unknown terminal'} with no attach rail (not tmux/Ghostty).`) +
+      chalk.gray(`\nTry: agents sessions resume ${shortId(s)}`),
+  );
+}
+
+/** Resolve a local tmux pane id to its session name + window index. */
+async function resolveLocalPane(socket: string, pane: string): Promise<{ session?: string; window?: number }> {
+  try {
+    const res = await runTmux({ socket, args: ['display-message', '-pt', pane, '-p', '#{session_name}\t#{window_index}'], throwOnError: false });
+    if (res.code !== 0) return {};
+    const [session, win] = res.stdout.trim().split('\t');
+    const window = Number.parseInt(win, 10);
+    return { session: session || undefined, window: Number.isFinite(window) ? window : undefined };
+  } catch {
+    return {};
+  }
+}

--- a/src/commands/sessions-picker.ts
+++ b/src/commands/sessions-picker.ts
@@ -5,6 +5,7 @@
  * Builds a compact preview for each session (prompt, activity summary, last
  * response) and delegates to the generic `itemPicker` for the interactive UI.
  */
+import fs from 'node:fs';
 import chalk from 'chalk';
 import type { SessionEvent, SessionMeta } from '../lib/session/types.js';
 import { parseSession, sanitizeForTerminal } from '../lib/session/parse.js';
@@ -59,6 +60,8 @@ export interface SessionPickerConfig {
   labelFor: (s: SessionMeta, query: string) => string;
   pageSize?: number;
   initialSearch?: string;
+  /** Verb shown on the Enter key in the footer (default 'resume'). */
+  enterHint?: string;
 }
 
 const previewCache = new Map<string, string>();
@@ -79,6 +82,15 @@ export function buildPreview(session: SessionMeta): string {
     const note = '  ' + chalk.gray(`on `) + chalk.bold.white(remote)
       + chalk.gray(` — enter to resume there, or space then enter to read it over SSH`);
     const output = [formatHeader(safe, []), '', note].join('\n');
+    previewCache.set(cacheKey, output);
+    return output;
+  }
+
+  // No transcript on disk — a live session not indexed locally, or a synthesized
+  // entry (e.g. `sessions go`). Show the header + a clean note, not a parse error.
+  if (!session.filePath || !fs.existsSync(session.filePath)) {
+    const note = '  ' + chalk.gray('Live session — full transcript not indexed here.');
+    const output = [formatHeader(safe, []), '', note].filter(Boolean).join('\n');
     previewCache.set(cacheKey, output);
     return output;
   }
@@ -406,7 +418,7 @@ export async function sessionPicker(config: SessionPickerConfig): Promise<Picked
     pageSize: config.pageSize,
     initialSearch: config.initialSearch,
     emptyMessage: 'No sessions match.',
-    enterHint: 'resume',
+    enterHint: config.enterHint ?? 'resume',
   });
   if (!picked) return null;
   return { session: picked.item, action: 'resume' };

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -43,6 +43,7 @@ import { setHelpSections } from '../lib/help.js';
 import { registerSessionsTailCommand } from './sessions-tail.js';
 import { registerSessionsSyncCommand } from './sessions-sync.js';
 import { registerSessionsResumeCommand } from './sessions-resume.js';
+import { registerGoCommand } from './go.js';
 import { registerSessionsInjectCommand } from './sessions-inject.js';
 
 const SESSION_AGENT_FILTER_HELP = `Filter by agent, e.g. claude, codex, claude@2.0.65`;
@@ -57,6 +58,7 @@ interface SessionFilterOptions {
 }
 
 interface SessionsOptions extends SessionFilterOptions {
+  query?: string;
   limit?: string;
   sort?: string;
   json?: boolean;
@@ -775,6 +777,10 @@ function printCrossMachineTip(): void {
 
 /** Main action handler for `agents sessions`. Routes to picker, table, or single-session render. */
 async function sessionsAction(query: string | undefined, options: SessionsOptions): Promise<void> {
+  // Explicit --query is interchangeable with the positional; it's how you search
+  // for text that collides with a subcommand name (e.g. `sessions --query go`).
+  query = query ?? options.query;
+
   // Normalize convenience flags before any routing reads them: per-agent
   // shorthands fold into --agent, and --device is an alias for --host (both
   // resolve against the same device registry).
@@ -1569,6 +1575,7 @@ export async function pickSessionInteractive(
   message = 'Search sessions:',
   initialSearch?: string,
   hiddenCount = 0,
+  enterHint?: string,
 ): Promise<PickedSession | null> {
   if (hiddenCount > 0) {
     console.log(chalk.gray(formatTeamHiddenFooter(hiddenCount)));
@@ -1588,6 +1595,7 @@ export async function pickSessionInteractive(
       labelFor: (s: SessionMeta, query: string) => formatPickerLabel(s, query, cols),
       pageSize: PICKER_RECENT_COUNT,
       initialSearch,
+      enterHint,
     });
   } catch (err) {
     if (isPromptCancelled(err)) return null;
@@ -2130,6 +2138,7 @@ export function registerSessionsCommands(program: Command): void {
   const sessionsCmd = program
     .command('sessions')
     .argument('[query]', 'Session ID, search query, or path (., ../, /path) to filter by project')
+    .option('--query <text>', 'Search text — use when the term collides with a subcommand name (e.g. "go")')
     .description('Find, browse, and read agent conversation transcripts across Claude, Codex, Gemini, and OpenCode.')
     .option('-a, --agent <agent>', 'Filter by agent type and version (e.g., claude, codex@0.116.0)')
     .option('--claude', 'Shorthand for --agent claude')
@@ -2212,6 +2221,7 @@ export function registerSessionsCommands(program: Command): void {
   registerSessionsTailCommand(sessionsCmd);
   registerSessionsSyncCommand(sessionsCmd);
   registerSessionsResumeCommand(sessionsCmd);
+  registerGoCommand(sessionsCmd);
   registerSessionsInjectCommand(sessionsCmd);
 }
 

--- a/src/lib/session/active.ts
+++ b/src/lib/session/active.ts
@@ -261,7 +261,7 @@ function classifyActivity(sessionFile: string | undefined): 'running' | 'idle' {
  * cwd (+ optional session uuid); Codex files are date-partitioned, so we resolve
  * the newest indexed Codex session for the cwd instead.
  */
-function findSessionFileForKind(kind: string, cwd?: string, sessionId?: string): string | undefined {
+export function findSessionFileForKind(kind: string, cwd?: string, sessionId?: string): string | undefined {
   if (!cwd) return undefined;
   if (kind === 'claude') return findClaudeSessionFile(cwd, sessionId);
   if (kind === 'codex') return latestSessionFileForCwd('codex', cwd);


### PR DESCRIPTION
## What

**`agents sessions go [id]`** — a `sessions` **subcommand** (not a top-level command) that jumps to a *live* agent session's terminal. Not `resume` (new process from transcript); `go` walks you into the already-running terminal — the right tool when an agent is blocked on you. RUSH-1488.

- **No id** → the **same rich picker** as `agents sessions` (via `pickSessionInteractive`): worktree, PR/ticket, changed files, tools, tests, last response, this-machine first — filtered to sessions running right now.
- **id / selection** → jumps by the live locator:

| Where | Action |
|---|---|
| local tmux | `attach` (or `switch-client` when already inside tmux) |
| local Ghostty | focus its tab (`Cmd+N` via System Events; tab # from `assignGhosttyTabs`) |
| remote tmux | `ssh -tt <host> 'tmux attach'` (pane→session resolved on the remote) |
| cloud / no rail | refuse with a reason + `agents sessions resume <id>` hint |

Search input for `agents sessions` moved to an explicit **`--query <text>`** flag so a term that collides with a subcommand name (e.g. "go") still searches; the positional `[query]` still works otherwise.

## Rendered (tmux capture-pane — actually verified, not claimed)

```
? Jump to a live session:
> 69b2b44a  claude  zion         The user named this session "Actionable Agents Feed"…     ← this machine first
  02ebf318  claude  yosemite-s0  What's your dev workflow and git workflow?
  ...
  Prompt:  Did we fully deliver the agents' feed in the Swarmify extension UI? …
  Changes: +12 ~17 changed · 53 read · 480 tools
  Tools:   Bash 283 · Edit 85 · Read 73 · Write 20
  Tests:   ✓ 6 pass
  Plan:    splendid-jingling-codd.md
  Last response: …
                                              ⏎ jump · esc: cancel
```

## How it stays rich even when the sessions DB is down

The preview **body** (Prompt/Changes/Tools/Tests/Last response) comes from **parsing the transcript file**, not the DB. When `discoverSessions` is unavailable (this box currently hits a `NOT NULL constraint failed: sessions.short_id` — a pre-existing/environmental DB issue, separate from this change), `go` falls back to a synthesized `SessionMeta` pointed at the real transcript via the newly-exported `findSessionFileForKind`, so the preview stays rich. Two shared-picker hardenings ride along: an optional `enterHint` on `pickSessionInteractive` (footer reads "jump"), and `buildPreview` degrading to a clean note instead of a red `Failed to parse` when a transcript isn't on local disk.

## Tests

`src/commands/go.test.ts` (vitest, no mocks) — `describeWhere` covers all four jump paths (local-tmux / remote-tmux / ghostty / refuse), including remote-tmux winning over the host check. **6 pass.** `bun run build` clean. Interactive attach + osascript verified by rendering the TUI in tmux.

Known follow-up: same-repo **forks** share a Ghostty tab # (best-effort matcher) — `go` degrades to an honest "couldn't pinpoint its tab" rather than jumping wrong.
