### PR TITLE
feat(sessions): add off-switch for automatic R2 session sync

### DIFF
--- a/src/commands/sessions-sync.ts
+++ b/src/commands/sessions-sync.ts
@@ -7,15 +7,52 @@
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import { setHelpSections } from '../lib/help.js';
-import { isSyncConfigured, SYNC_BUNDLE } from '../lib/session/sync/config.js';
+import {
+  isSyncConfigured,
+  isSyncEnabled,
+  setSyncEnabled,
+  SYNC_BUNDLE,
+} from '../lib/session/sync/config.js';
 import { syncSessions } from '../lib/session/sync/sync.js';
 
 interface SyncCmdOptions {
   verbose?: boolean;
   json?: boolean;
+  enable?: boolean;
+  disable?: boolean;
+  status?: boolean;
 }
 
 export async function runSessionsSync(options: SyncCmdOptions): Promise<void> {
+  // Toggle / status actions short-circuit before any network cycle.
+  if (options.disable) {
+    setSyncEnabled(false);
+    console.log(
+      chalk.yellow('Automatic session sync disabled') +
+      chalk.dim(' — the daemon stops pushing/pulling within ~90s. Re-enable: agents sessions sync --enable'),
+    );
+    return;
+  }
+  if (options.enable) {
+    setSyncEnabled(true);
+    console.log(chalk.green('Automatic session sync enabled') + chalk.dim(' — the daemon resumes on its next cycle.'));
+    return;
+  }
+  if (options.status) {
+    const enabled = isSyncEnabled();
+    const configured = isSyncConfigured();
+    if (options.json) {
+      console.log(JSON.stringify({ enabled, configured }, null, 2));
+    } else {
+      console.log(
+        `automatic sync: ${enabled ? chalk.green('enabled') : chalk.yellow('disabled')}` +
+        chalk.dim('  ·  ') +
+        `credentials: ${configured ? chalk.green('configured') : chalk.yellow(`missing (${SYNC_BUNDLE})`)}`,
+      );
+    }
+    return;
+  }
+
   if (!isSyncConfigured()) {
     console.error(
       chalk.red(`Sessions sync is not configured.`) +
@@ -64,7 +101,10 @@ export function registerSessionsSyncCommand(sessionsCmd: Command): void {
     .command('sync')
     .description('Sync session transcripts across machines via R2 (CRDT merge). Claude and Codex.')
     .option('-v, --verbose', 'Log each pushed and pulled session')
-    .option('--json', 'Output the sync result as JSON');
+    .option('--json', 'Output the sync result as JSON')
+    .option('--enable', 'Turn ON automatic background sync on this machine (persisted)')
+    .option('--disable', 'Turn OFF automatic background sync on this machine (persisted)')
+    .option('--status', 'Show whether automatic sync is enabled and configured');
 
   setHelpSections(syncCmd, {
     examples: `
@@ -73,16 +113,28 @@ export function registerSessionsSyncCommand(sessionsCmd: Command): void {
 
       # See exactly what moved
       agents sessions sync --verbose
+
+      # Stop this machine's daemon from auto-syncing (prefer on-demand --host reads)
+      agents sessions sync --disable
+
+      # Check the current switch + credential state
+      agents sessions sync --status
     `,
     notes: `
       - Credentials come from the '${SYNC_BUNDLE}' secrets bundle (R2 S3 API, read+write).
       - Each machine writes only its own prefix; conflicts are impossible by construction.
       - The daemon runs this automatically (~90s); this command forces an immediate cycle.
       - Sessions present locally always win; synced-in copies fill in other machines' sessions.
+      - --disable/--enable persist a machine-local switch (~/.agents/.history) that gates the
+        daemon's automatic sync; a bare 'agents sessions sync' still forces a manual cycle.
+        The AGENTS_SESSIONS_SYNC env var (on/off) overrides the switch for one invocation.
     `,
   });
 
-  syncCmd.action(async (options: SyncCmdOptions) => {
-    await runSessionsSync(options);
+  // `--json` is also declared on the parent `sessions` command, so a bare
+  // `options` arg would miss it (Commander binds the shared flag to the parent).
+  // optsWithGlobals() merges ancestor + local options so --json resolves here.
+  syncCmd.action(async (_options: SyncCmdOptions, cmd: Command) => {
+    await runSessionsSync(cmd.optsWithGlobals() as SyncCmdOptions);
   });
 }

--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -340,8 +340,10 @@ export async function runDaemon(): Promise<void> {
     if (syncing) return;
     syncing = true;
     try {
-      const { isSyncConfigured } = await import('./session/sync/config.js');
-      if (!isSyncConfigured()) return;
+      const { isSyncConfigured, isSyncEnabled } = await import('./session/sync/config.js');
+      // isSyncEnabled() first: a machine the operator turned off must skip the
+      // keychain read entirely, not just the network cycle.
+      if (!isSyncEnabled() || !isSyncConfigured()) return;
       const { syncSessions } = await import('./session/sync/sync.js');
       const r = await syncSessions();
       if (r.pushed || r.pulled || r.errors.length) {

--- a/src/lib/session/sync/config.test.ts
+++ b/src/lib/session/sync/config.test.ts
@@ -1,4 +1,17 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Redirect the durable enable-flag home to a temp dir for the enable-switch
+// tests. Every other state.ts export stays real; the secrets path used by the
+// R2-cache tests below never calls getHistoryDir, so it is unaffected.
+const hist = vi.hoisted(() => ({ dir: '' }));
+vi.mock('../../state.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../state.js')>();
+  return { ...actual, getHistoryDir: () => hist.dir };
+});
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { setKeychainBackendForTest, type KeychainBackend } from '../../secrets/index.js';
 import { writeBundle, type SecretsBundle } from '../../secrets/bundles.js';
 import {
@@ -7,6 +20,10 @@ import {
   clearR2ConfigCache,
   RESOLVE_RETRY_COOLDOWN_MS,
   SYNC_BUNDLE,
+  isSyncEnabled,
+  setSyncEnabled,
+  syncStateFilePath,
+  SYNC_ENABLED_ENV,
 } from './config.js';
 
 /**
@@ -125,5 +142,61 @@ describe('R2 config resolution cache', () => {
     // absent path does not back off, so the very next check resolves
     expect(isSyncConfigured(t0 + 1)).toBe(true);
     expect(loadR2Config().bucket).toBe('agents-sessions');
+  });
+});
+
+describe('session sync enable switch', () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    hist.dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sync-toggle-'));
+    savedEnv = process.env[SYNC_ENABLED_ENV];
+    delete process.env[SYNC_ENABLED_ENV];
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env[SYNC_ENABLED_ENV];
+    else process.env[SYNC_ENABLED_ENV] = savedEnv;
+    fs.rmSync(hist.dir, { recursive: true, force: true });
+  });
+
+  it('defaults to enabled when no flag file and no env', () => {
+    expect(fs.existsSync(syncStateFilePath())).toBe(false);
+    expect(isSyncEnabled()).toBe(true);
+  });
+
+  it('persists disabled and reads it back across calls', () => {
+    setSyncEnabled(false);
+    expect(fs.existsSync(syncStateFilePath())).toBe(true);
+    expect(isSyncEnabled()).toBe(false);
+    setSyncEnabled(true);
+    expect(isSyncEnabled()).toBe(true);
+  });
+
+  it('env off overrides an enabled flag file', () => {
+    setSyncEnabled(true);
+    process.env[SYNC_ENABLED_ENV] = 'off';
+    expect(isSyncEnabled()).toBe(false);
+  });
+
+  it('env on overrides a disabled flag file', () => {
+    setSyncEnabled(false);
+    process.env[SYNC_ENABLED_ENV] = 'true';
+    expect(isSyncEnabled()).toBe(true);
+  });
+
+  it('an unrecognized env value falls through to the persisted flag', () => {
+    setSyncEnabled(false);
+    process.env[SYNC_ENABLED_ENV] = 'maybe';
+    expect(isSyncEnabled()).toBe(false);
+  });
+
+  it('a malformed flag file falls back to the enabled default (no silent lockout)', () => {
+    fs.writeFileSync(syncStateFilePath(), 'not json', 'utf-8');
+    expect(isSyncEnabled()).toBe(true);
+  });
+
+  it('stores the flag in the durable history tree, not cache', () => {
+    expect(syncStateFilePath()).toBe(path.join(hist.dir, 'sessions-sync.json'));
   });
 });

--- a/src/lib/session/sync/config.ts
+++ b/src/lib/session/sync/config.ts
@@ -4,10 +4,68 @@
  * bundle (OS keychain on macOS, libsecret on Linux) — never from env or disk.
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
 import { readAndResolveBundleEnv } from '../../secrets/bundles.js';
+import { getHistoryDir } from '../../state.js';
 
 /** Secrets bundle holding the R2 credentials. */
 export const SYNC_BUNDLE = 'r2.backups';
+
+// ── Enable / disable switch ─────────────────────────────────────────────────
+// Whether the daemon's automatic cross-machine sync (and `agents sync
+// --sessions`) may run on THIS machine. Independent of credential presence
+// (isSyncConfigured): a machine can hold valid R2 creds yet still opt out of the
+// background push/pull — e.g. when on-demand `agents sessions --host` is
+// preferred over the ad-hoc R2 mirror. Manual `agents sessions sync` is an
+// explicit user action and is deliberately NOT gated by this switch.
+//
+// Resolution order: the AGENTS_SESSIONS_SYNC env var (a recognized on/off value
+// wins outright, for ad-hoc overrides and tests), then a durable machine-local
+// flag file, then the default (enabled). The flag lives in the durable
+// ~/.agents/.history tree — NOT .cache — so a cache wipe can never silently
+// re-enable a sync the operator turned off.
+
+/** Env var that overrides the persisted enable flag (on/off/true/false/1/0/yes/no). */
+export const SYNC_ENABLED_ENV = 'AGENTS_SESSIONS_SYNC';
+
+const SYNC_ENABLED_FILE = 'sessions-sync.json';
+const OFF_VALUES = new Set(['0', 'off', 'false', 'no', 'disabled']);
+const ON_VALUES = new Set(['1', 'on', 'true', 'yes', 'enabled']);
+
+/** Durable, machine-local path holding the sync enable flag. */
+export function syncStateFilePath(): string {
+  return path.join(getHistoryDir(), SYNC_ENABLED_FILE);
+}
+
+/**
+ * Whether automatic session sync is enabled on this machine. Defaults to true;
+ * an unrecognized env value falls through to the file; an absent/unreadable file
+ * falls through to the default. Read fresh every call (no memoization) so a
+ * `--disable` takes effect on the daemon's next ~90s cycle without a restart.
+ */
+export function isSyncEnabled(): boolean {
+  const envRaw = process.env[SYNC_ENABLED_ENV]?.trim().toLowerCase();
+  if (envRaw) {
+    if (OFF_VALUES.has(envRaw)) return false;
+    if (ON_VALUES.has(envRaw)) return true;
+    // Unrecognized value: ignore and consult the persisted flag.
+  }
+  try {
+    const parsed = JSON.parse(fs.readFileSync(syncStateFilePath(), 'utf-8'));
+    if (parsed && typeof parsed.enabled === 'boolean') return parsed.enabled;
+  } catch {
+    // Absent or unreadable → default enabled.
+  }
+  return true;
+}
+
+/** Persist the machine-local sync enable flag (durable across cache wipes). */
+export function setSyncEnabled(enabled: boolean): void {
+  const p = syncStateFilePath();
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify({ enabled }, null, 2) + '\n', 'utf-8');
+}
 
 export interface R2Config {
   accountId: string;

--- a/src/lib/sync-umbrella.ts
+++ b/src/lib/sync-umbrella.ts
@@ -149,10 +149,10 @@ export async function runUmbrellaSync(args: RunUmbrellaArgs): Promise<UmbrellaRe
   }
 
   if (plan.fetchSessions) {
-    // Gate exactly like the daemon: a missing r2.backups bundle is a clean no-op,
-    // not an error that fails the whole sync.
-    const { isSyncConfigured } = await import('./session/sync/config.js');
-    if (isSyncConfigured()) {
+    // Gate exactly like the daemon: an off switch or a missing r2.backups bundle
+    // is a clean no-op, not an error that fails the whole sync.
+    const { isSyncConfigured, isSyncEnabled } = await import('./session/sync/config.js');
+    if (isSyncEnabled() && isSyncConfigured()) {
       const { syncSessions } = await import('./session/sync/sync.js');
       const r = await syncSessions();
       result.sessions = { ran: true, pushed: r.pushed, pulled: r.pulled, merged: r.merged };


### PR DESCRIPTION
## Why

The daemon runs a cross-machine session sync every ~90s — push this machine's transcripts to R2, pull every peer's (`daemon.ts` sync loop). Today the **only** gate is credential presence (`isSyncConfigured()` = "does the `r2.backups` bundle resolve"). There's no way to say "this machine has creds but I don't want it auto-syncing" short of deleting the bundle.

With `agents sessions --host <machine>` now able to read a peer's sessions on demand over SSH, the always-on R2 mirror is often unwanted overhead. This adds a first-class off-switch so a machine can opt out of the background sync **without** deleting R2 credentials.

Motivating observation: auditing the live R2 bucket showed one machine's manifest was ~23h stale (its `r2.backups` bundle had gone missing), i.e. the sync silently no-ops when unconfigured — but there was no deliberate, discoverable way to turn it off. This makes it explicit.

## What changed

- **`session/sync/config.ts`** — `isSyncEnabled()` / `setSyncEnabled()`. The flag persists to `~/.agents/.history/sessions-sync.json` — the **durable** tree, not `.cache`, so a cache wipe can never silently re-enable a sync the operator turned off. `AGENTS_SESSIONS_SYNC` (on/off) overrides for one invocation. Read fresh each call, so `--disable` takes effect on the daemon's next ~90s cycle with no restart.
- **`daemon.ts` + `sync-umbrella.ts`** — gate on `isSyncEnabled()` **before** `isSyncConfigured()`, so a disabled machine skips the keychain read entirely, not just the network cycle.
- **`sessions sync --enable/--disable/--status`** — persisted toggle + status. A bare `agents sessions sync` still forces a manual cycle (the switch governs the *automatic* sync only). `--json` resolves via `optsWithGlobals()` because the parent `sessions` command owns `--json`.
- **Tests** — default-enabled, persist round-trip, env on/off override, unrecognized-env fallthrough, malformed-file fallback (no silent lockout), durable path.

## Evidence (real environment, `agents-dev` = this build)

Before — nothing to toggle, status reflects reality on a machine with creds:
```
$ agents-dev sessions sync --status
automatic sync: enabled  ·  credentials: configured
```

After — toggle round-trip + durable flag:
```
$ agents-dev sessions sync --disable
Automatic session sync disabled — the daemon stops pushing/pulling within ~90s. Re-enable: agents sessions sync --enable
$ cat ~/.agents/.history/sessions-sync.json
{ "enabled": false }
$ agents-dev sessions sync --status
automatic sync: disabled  ·  credentials: configured
$ agents-dev sessions sync --status --json
{ "enabled": false, "configured": true }
$ agents-dev sessions sync --enable
Automatic session sync enabled — the daemon resumes on its next cycle.
```

Tests:
```
Test Files  1 passed (1)
     Tests  13 passed (13)   # 6 existing R2-cache + 7 new toggle
```
`tsc --noEmit` clean.

## Session

zion:/Users/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/3365d23d-3ac6-4da1-a8c2-04f90a87f699.jsonl