### PR TITLE
feat(sessions): sort the overview by last activity + scope to the current repo

### DIFF
--- a/src/commands/sessions.overview.test.ts
+++ b/src/commands/sessions.overview.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { overviewProjectKey, buildOverviewGroups } from './sessions.js';
 import type { SessionMeta } from '../lib/session/types.js';
 
-function s(id: string, project: string | undefined, timestamp: string, cwd?: string): SessionMeta {
-  return { id, shortId: id.slice(0, 8), agent: 'claude', timestamp, project, cwd, filePath: '' } as SessionMeta;
+function s(id: string, project: string | undefined, timestamp: string, cwd?: string, lastActivity?: string): SessionMeta {
+  return { id, shortId: id.slice(0, 8), agent: 'claude', timestamp, lastActivity, project, cwd, filePath: '' } as SessionMeta;
 }
 
 describe('overviewProjectKey', () => {
@@ -56,6 +56,19 @@ describe('buildOverviewGroups', () => {
     ];
     const { groups } = buildOverviewGroups(p, 4);
     expect(groups.map((g) => g.key)).toEqual(['newproj', 'bigproj']);
+  });
+
+  it('orders and labels by last activity, not creation time', () => {
+    // 'revived' was CREATED long before 'fresh' but was ACTIVE most recently.
+    // The pool arrives last-activity-descending (as the SQL now returns it), so
+    // the revived project must lead and its maxTs must be the last-activity time.
+    const p: SessionMeta[] = [
+      s('r1', 'revived', '2026-06-01T09:00:00.000Z', undefined, '2026-07-04T12:00:00.000Z'),
+      s('f1', 'fresh', '2026-07-04T08:00:00.000Z', undefined, '2026-07-04T08:05:00.000Z'),
+    ];
+    const { groups } = buildOverviewGroups(p, 5);
+    expect(groups.map((g) => g.key)).toEqual(['revived', 'fresh']);
+    expect(groups[0].maxTs).toBe('2026-07-04T12:00:00.000Z'); // last activity, NOT the June creation
   });
 
   it('caps rows per project and rolls the rest into "more"', () => {

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -83,6 +83,33 @@ interface SessionsOptions extends SessionFilterOptions {
   /** Force local-only: skip the cross-machine SSH fan-out (both the default
    * listing and --active). */
   local?: boolean;
+  /** --device <target...> — alias for --host; resolves against the device registry. */
+  device?: string[];
+  /** Per-agent shorthands: aliases for `--agent <name>` (prioritized harnesses). */
+  claude?: boolean;
+  codex?: boolean;
+  kimi?: boolean;
+  antigravity?: boolean;
+  grok?: boolean;
+  opencode?: boolean;
+}
+
+/**
+ * The prioritized harnesses that get a boolean shorthand flag (e.g. `--claude`
+ * === `--agent claude`). The rest stay reachable via `--agent <name>`, which
+ * also carries version pins like `codex@0.116.0`.
+ */
+const AGENT_SHORTHANDS = ['claude', 'codex', 'kimi', 'antigravity', 'grok', 'opencode'] as const;
+
+/**
+ * Resolve a per-agent shorthand (`--claude`, `--kimi`, …) into `options.agent`.
+ * An explicit `--agent` wins; if two shorthands are passed we take the first and
+ * ignore the rest (commander gives no ordering, so this is a best-effort alias).
+ */
+function applyAgentShorthands(options: SessionsOptions): void {
+  if (options.agent) return;
+  const hit = AGENT_SHORTHANDS.find((name) => (options as Record<string, unknown>)[name] === true);
+  if (hit) options.agent = hit;
 }
 
 interface ClaudeHistoryEntry {
@@ -748,6 +775,14 @@ function printCrossMachineTip(): void {
 
 /** Main action handler for `agents sessions`. Routes to picker, table, or single-session render. */
 async function sessionsAction(query: string | undefined, options: SessionsOptions): Promise<void> {
+  // Normalize convenience flags before any routing reads them: per-agent
+  // shorthands fold into --agent, and --device is an alias for --host (both
+  // resolve against the same device registry).
+  applyAgentShorthands(options);
+  if (options.device && options.device.length > 0) {
+    options.host = [...(options.host ?? []), ...options.device];
+  }
+
   // --host WITHOUT --active keeps the legacy per-host stream (each remote's raw
   // stdout under a `── host ──` banner). With --active, the hosts are folded
   // into the merged machine-grouped view instead (handled below).
@@ -855,9 +890,12 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
     const scope: DiscoverOptions = {
       agent,
       version,
-      all: pathFilter ? undefined : (wantsOverview ? true : options.all),
+      all: pathFilter ? undefined : options.all,
       cwd: process.cwd(),
-      cwdPrefix: pathFilter,
+      // Default overview scopes to the current repo SUBTREE (prefix match), so a
+      // monorepo shows its sub-projects grouped instead of collapsing to the one
+      // exact-cwd project. `--all` clears the prefix and spans the whole index.
+      cwdPrefix: pathFilter ?? (wantsOverview && !options.all ? process.cwd() : undefined),
       project: options.project,
       since,
       until: options.until,
@@ -1017,7 +1055,7 @@ function metaSignals(s: SessionMeta): Parameters<typeof signalBadges>[0] {
  * dashes and needlessly truncate the topic. Worktree stays a trailing badge. */
 function flatSessionRow(session: SessionMeta, live?: ActiveSession, showTicket = false, cols: PickerColumns = {}): string {
   const agentColor = colorAgent(session.agent);
-  const when = formatRelativeTime(session.timestamp);
+  const when = formatRelativeTime(session.lastActivity ?? session.timestamp);
   const project = session.project || '-';
   const tag = teamTag(session);
   const label = (session as any).label;
@@ -1062,7 +1100,7 @@ function flatSessionRow(session: SessionMeta, live?: ActiveSession, showTicket =
 /** One tree-mode row (grouped under a dir header): id · agent · badges · topic · time. No version/project column. */
 function treeSessionRow(session: SessionMeta, live?: ActiveSession): string {
   const agentColor = colorAgent(session.agent);
-  const when = formatRelativeTime(session.timestamp);
+  const when = formatRelativeTime(session.lastActivity ?? session.timestamp);
   const tag = teamTag(session);
   const label = (session as any).label;
   const { glyph, preview } = liveGlyphAndPreview(live);
@@ -1144,7 +1182,7 @@ export function buildOverviewGroups(
   const groups: OverviewGroup[] = [];
   for (const [key, rows] of byKey) {
     const shown = rows.slice(0, cap); // rows are recency-desc (pool was sorted)
-    groups.push({ key, total: rows.length, shown, more: rows.length - shown.length, maxTs: rows[0].timestamp });
+    groups.push({ key, total: rows.length, shown, more: rows.length - shown.length, maxTs: rows[0].lastActivity ?? rows[0].timestamp });
   }
   groups.sort((a, b) => (a.maxTs < b.maxTs ? 1 : a.maxTs > b.maxTs ? -1 : a.key.localeCompare(b.key)));
   return { groups, projectCount: byKey.size };
@@ -1183,9 +1221,9 @@ function printSessionOverview(
   }
 
   console.log();
-  const parts = [chalk.gray('newest first')];
-  if (hiddenProjects > 0) parts.push(chalk.gray(`+${hiddenProjects} more project${hiddenProjects === 1 ? '' : 's'} · agents sessions --all`));
-  parts.push(chalk.gray('agents sessions <project> to drill in · --flat for the plain list'));
+  const parts = [chalk.gray('newest first (by last activity)')];
+  if (hiddenProjects > 0) parts.push(chalk.gray(`+${hiddenProjects} more project${hiddenProjects === 1 ? '' : 's'}`));
+  parts.push(chalk.gray('agents sessions --all spans every project on disk · <project> to drill in · --flat for the plain list'));
   console.log(parts.join(chalk.gray('  ·  ')));
   if (hiddenCount > 0) console.log(chalk.gray(formatTeamHiddenFooter(hiddenCount)));
 }
@@ -1467,7 +1505,7 @@ export function pickerColumnsFor(sessions: SessionMeta[]): PickerColumns {
 
 export function formatPickerLabel(s: SessionMeta, query: string, cols: PickerColumns = {}): string {
   const agentColor = colorAgent(s.agent);
-  const when = formatRelativeTime(s.timestamp);
+  const when = formatRelativeTime(s.lastActivity ?? s.timestamp);
   const project = s.project || '-';
   const tag = teamTag(s);
   const label = (s as any).label;
@@ -2094,6 +2132,12 @@ export function registerSessionsCommands(program: Command): void {
     .argument('[query]', 'Session ID, search query, or path (., ../, /path) to filter by project')
     .description('Find, browse, and read agent conversation transcripts across Claude, Codex, Gemini, and OpenCode.')
     .option('-a, --agent <agent>', 'Filter by agent type and version (e.g., claude, codex@0.116.0)')
+    .option('--claude', 'Shorthand for --agent claude')
+    .option('--codex', 'Shorthand for --agent codex')
+    .option('--kimi', 'Shorthand for --agent kimi')
+    .option('--antigravity', 'Shorthand for --agent antigravity')
+    .option('--grok', 'Shorthand for --agent grok')
+    .option('--opencode', 'Shorthand for --agent opencode')
     .option('--all', 'Include sessions from every directory (not just current project)')
     .option('--teams', 'Include team-spawned sessions (hidden by default)')
     .option('--project <name>', 'Filter by project name (searches across all directories)')
@@ -2117,7 +2161,8 @@ export function registerSessionsCommands(program: Command): void {
     .option('--flat', 'Plain flat table (one row per session) instead of the grouped project overview')
     .option('--no-live', 'Do not enrich the listing with live status/preview for running sessions')
     .option('--cloud', 'Source sessions from Rush Cloud (captured runs) instead of local disk')
-    .option('-H, --host <target...>', 'Run this query on remote machine(s) over SSH (host alias or user@host; repeatable)');
+    .option('-H, --host <target...>', 'Run this query on remote machine(s) over SSH (host alias or user@host; repeatable)')
+    .option('--device <target...>', 'Alias for --host (device alias from `agents devices`; repeatable)');
 
   setHelpSections(sessionsCmd, {
     examples: `

--- a/src/lib/session/__tests__/db.test.ts
+++ b/src/lib/session/__tests__/db.test.ts
@@ -140,7 +140,7 @@ describe('migration v5 -> v6 adds cost/duration columns', () => {
   it('schema_version is recorded as the current version', () => {
     const db = getDB();
     const row = db.prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string };
-    expect(row.value).toBe('7');
+    expect(row.value).toBe('8');
   });
 
   it('v7 adds the session-state columns (pr_url, worktree_slug, ticket_id)', () => {
@@ -150,6 +150,53 @@ describe('migration v5 -> v6 adds cost/duration columns', () => {
     expect(cols).toContain('pr_number');
     expect(cols).toContain('worktree_slug');
     expect(cols).toContain('ticket_id');
+  });
+
+  it('v8 adds the last_activity column', () => {
+    const db = getDB();
+    const cols = (db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>).map(c => c.name);
+    expect(cols).toContain('last_activity');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// last_activity (v8) — the listing sorts and labels by last-message time, not
+// creation time. A session created long ago but active recently must lead.
+// ---------------------------------------------------------------------------
+const ACTIVITY_FILES_DIR = path.join(TEST_HOME, 'activity-files');
+fs.mkdirSync(ACTIVITY_FILES_DIR, { recursive: true });
+
+function seedActive(id: string, timestamp: string, lastActivity: string | undefined): void {
+  const filePath = path.join(ACTIVITY_FILES_DIR, `${id}.jsonl`);
+  fs.writeFileSync(filePath, '');
+  upsertSession(
+    { id, shortId: id.slice(0, 8), agent: 'claude', timestamp, lastActivity, project: 'agents-cli', cwd: ACTIVITY_FILES_DIR, filePath },
+    '',
+  );
+}
+
+describe('default sort orders by last_activity (v8)', () => {
+  beforeAll(() => {
+    // Creation order and activity order deliberately disagree.
+    seedActive('la-oldcreate-newactive', '2026-01-01T00:00:00.000Z', '2026-07-04T12:00:00.000Z');
+    seedActive('la-midcreate-midactive', '2026-06-01T00:00:00.000Z', '2026-06-15T00:00:00.000Z');
+    seedActive('la-newcreate-oldactive', '2026-07-01T00:00:00.000Z', '2026-07-01T00:05:00.000Z');
+    seedActive('la-noactivity', '2026-05-20T00:00:00.000Z', undefined); // no lastActivity → falls back to timestamp
+  });
+
+  it('round-trips last_activity through SQLite', () => {
+    const rows = querySessions({ cwdPrefix: ACTIVITY_FILES_DIR });
+    expect(rows.find(r => r.id === 'la-oldcreate-newactive')!.lastActivity).toBe('2026-07-04T12:00:00.000Z');
+  });
+
+  it('ranks by last activity, not creation time (fallback = timestamp)', () => {
+    const rows = querySessions({ cwdPrefix: ACTIVITY_FILES_DIR });
+    expect(rows.map(r => r.id)).toEqual([
+      'la-oldcreate-newactive', // active Jul 4 (though created back in Jan)
+      'la-newcreate-oldactive', // active Jul 1
+      'la-midcreate-midactive', // active Jun 15
+      'la-noactivity',          // no activity → creation ts May 20
+    ]);
   });
 });
 

--- a/src/lib/session/__tests__/discover.test.ts
+++ b/src/lib/session/__tests__/discover.test.ts
@@ -159,6 +159,16 @@ describe('scanClaudeSession title resolution', () => {
     ]);
     expect((await scanClaudeSession(fp)).topic).toBe('real prompt here');
   });
+
+  it('sets lastActivity to the last event time, distinct from the creation timestamp', async () => {
+    const fp = write([
+      { type: 'user', timestamp: '2026-06-28T00:00:00.000Z', cwd: '/x', message: { role: 'user', content: 'start' } },
+      { type: 'assistant', timestamp: '2026-06-28T02:30:00.000Z', cwd: '/x', message: { role: 'assistant', content: 'done' } },
+    ]);
+    const scan = await scanClaudeSession(fp);
+    expect(scan.timestamp).toBe('2026-06-28T00:00:00.000Z'); // first event = creation
+    expect(scan.lastActivity).toBe('2026-06-28T02:30:00.000Z'); // last event = activity
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/session/db.ts
+++ b/src/lib/session/db.ts
@@ -17,7 +17,7 @@ const SESSIONS_DIR = getSessionsDir();
 const DB_PATH = getSessionsDbPath();
 
 /** Current schema version; bumped when migrations are added. */
-const SCHEMA_VERSION = 7;
+const SCHEMA_VERSION = 8;
 
 /**
  * Canonicalize a file path for use as a scan_ledger key. The same physical
@@ -51,6 +51,7 @@ CREATE TABLE IF NOT EXISTS sessions (
   version TEXT,
   account TEXT,
   timestamp TEXT NOT NULL,
+  last_activity TEXT,
   project TEXT,
   cwd TEXT,
   git_branch TEXT,
@@ -110,6 +111,7 @@ export interface SessionRow {
   version: string | null;
   account: string | null;
   timestamp: string;
+  last_activity: string | null;
   project: string | null;
   cwd: string | null;
   git_branch: string | null;
@@ -242,6 +244,16 @@ function migrateSchema(db: Database.Database, fromVersion: number): void {
     if (!cols.some(c => c.name === 'ticket_id')) db.exec(`ALTER TABLE sessions ADD COLUMN ticket_id TEXT`);
     db.exec(`DELETE FROM scan_ledger;`);
   }
+  if (fromVersion < 8) {
+    // v7 → v8: the listing now sorts and labels by last-activity (last message
+    // time) instead of creation time. Add the column, seed it to `timestamp` so
+    // no row sorts as NULL before the rescan lands, then force a full rescan so
+    // every session gets its true last_activity (from lastTsMs) repopulated.
+    const cols = db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>;
+    if (!cols.some(c => c.name === 'last_activity')) db.exec(`ALTER TABLE sessions ADD COLUMN last_activity TEXT`);
+    db.exec(`UPDATE sessions SET last_activity = timestamp WHERE last_activity IS NULL`);
+    db.exec(`DELETE FROM scan_ledger;`);
+  }
 }
 
 /** Open (or return the cached) sessions database, applying migrations as needed. */
@@ -269,6 +281,12 @@ export function getDB(): Database.Database {
     migrateSchema(db, currentVersion);
     db.prepare(`INSERT OR REPLACE INTO meta(key, value) VALUES ('schema_version', ?)`).run(String(SCHEMA_VERSION));
   }
+
+  // Index last_activity only after the column is guaranteed to exist — fresh DBs
+  // get it from CREATE TABLE above, existing pre-v8 DBs from the migration just
+  // run. It must NOT live in SCHEMA (executed before migration) or an existing
+  // DB would fail the index build on a column it doesn't have yet.
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_sessions_last_activity ON sessions(last_activity DESC)`);
 
   // One-shot cleanup of the pre-SQLite JSONL indexes. Safe — nothing reads
   // them anymore. Guarded by a meta flag so we only try once.
@@ -460,13 +478,13 @@ export function recordScans(entries: Array<{ filePath: string; scan: ScanStamp }
 
 const upsertSessionStmt = (db: Database.Database) => db.prepare(`
   INSERT INTO sessions (
-    id, short_id, agent, version, account, timestamp,
+    id, short_id, agent, version, account, timestamp, last_activity,
     project, cwd, git_branch, topic, label, message_count, token_count,
     cost_usd, duration_ms,
     file_path, file_mtime_ms, file_size, scanned_at, is_team_origin,
     pr_url, pr_number, worktree_slug, ticket_id
   ) VALUES (
-    @id, @short_id, @agent, @version, @account, @timestamp,
+    @id, @short_id, @agent, @version, @account, @timestamp, @last_activity,
     @project, @cwd, @git_branch, @topic, @label, @message_count, @token_count,
     @cost_usd, @duration_ms,
     @file_path, @file_mtime_ms, @file_size, @scanned_at, @is_team_origin,
@@ -478,6 +496,7 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     version = excluded.version,
     account = excluded.account,
     timestamp = excluded.timestamp,
+    last_activity = excluded.last_activity,
     project = excluded.project,
     cwd = excluded.cwd,
     git_branch = excluded.git_branch,
@@ -534,6 +553,7 @@ export function upsertSession(meta: SessionMeta, content: string, scan?: ScanSta
     version: meta.version ?? null,
     account: meta.account ?? null,
     timestamp: meta.timestamp,
+    last_activity: resolveLastActivity(meta, scan),
     project: meta.project ?? null,
     cwd: meta.cwd ?? null,
     git_branch: meta.gitBranch ?? null,
@@ -626,6 +646,7 @@ export function upsertSessionsBatch(
         version: meta.version ?? null,
         account: meta.account ?? null,
         timestamp: meta.timestamp,
+        last_activity: resolveLastActivity(meta, scan),
         project: meta.project ?? null,
         cwd: meta.cwd ?? null,
         git_branch: meta.gitBranch ?? null,
@@ -752,6 +773,7 @@ function rowToMeta(row: SessionRow): SessionMeta {
     shortId: row.short_id,
     agent: row.agent as SessionAgentId,
     timestamp: row.timestamp,
+    lastActivity: row.last_activity ?? undefined,
     project: row.project ?? undefined,
     cwd: row.cwd ?? undefined,
     filePath: row.file_path,
@@ -770,6 +792,20 @@ function rowToMeta(row: SessionRow): SessionMeta {
     worktreeSlug: row.worktree_slug ?? undefined,
     ticketId: row.ticket_id ?? undefined,
   };
+}
+
+/**
+ * The recency signal used to sort and label the listing: last-message time when
+ * a parser computed it (`meta.lastActivity` from `lastTsMs`), else the file's
+ * mtime (its last write), else creation time. Guarded on `filePath` so synthetic
+ * / cloud rows (no local file) fall to their creation timestamp rather than a
+ * bogus scan-time mtime. Always an ISO string, so it sorts lexicographically
+ * against `timestamp` and feeds `formatRelativeTime` unchanged.
+ */
+function resolveLastActivity(meta: SessionMeta, scan?: ScanStamp): string {
+  if (meta.lastActivity) return meta.lastActivity;
+  if (scan?.fileMtimeMs && meta.filePath) return new Date(scan.fileMtimeMs).toISOString();
+  return meta.timestamp;
 }
 
 /**
@@ -860,7 +896,7 @@ function buildSessionWhere(options: QueryOptions): { clause: string; params: any
   return { clause, params };
 }
 
-/** Query sessions from the database, applying filters and ordering by timestamp descending. */
+/** Query sessions from the database, applying filters and ordering by last-activity descending (default). */
 export function querySessions(options: QueryOptions = {}): SessionMeta[] {
   const db = getDB();
   const { clause, params } = buildSessionWhere(options);
@@ -877,7 +913,7 @@ export function querySessions(options: QueryOptions = {}): SessionMeta[] {
       ? 'ORDER BY cost_usd IS NULL, cost_usd DESC, timestamp DESC'
       : options.sortBy === 'duration'
         ? 'ORDER BY duration_ms IS NULL, duration_ms DESC, timestamp DESC'
-        : 'ORDER BY timestamp DESC';
+        : 'ORDER BY IFNULL(last_activity, timestamp) DESC, timestamp DESC';
   const sql = `SELECT * FROM sessions ${clause} ${orderClause} ${limitClause}`;
   const rows = db.prepare(sql).all(...params) as SessionRow[];
   // Belt-and-suspenders: drop rows whose JSONL no longer exists on disk. The

--- a/src/lib/session/discover.ts
+++ b/src/lib/session/discover.ts
@@ -107,6 +107,8 @@ interface ClaudeSessionScan {
   costUsd?: number;
   /** Wall-clock duration in ms between the first and last timestamped event. */
   durationMs?: number;
+  /** ISO time of the last timestamped event — the session's last activity. */
+  lastActivity?: string;
   /**
    * Value of the JSONL `entrypoint` field on the first event that carries it.
    * 'cli' for real interactive sessions, 'sdk-cli' for team-spawned ones.
@@ -133,6 +135,7 @@ interface CodexSessionScan {
   tokenCount?: number;
   costUsd?: number;
   durationMs?: number;
+  lastActivity?: string;
   contentText?: string;
   prUrl?: string;
   prNumber?: number;
@@ -613,6 +616,7 @@ async function readClaudeMeta(
       shortId: sessionId.slice(0, 8),
       agent: 'claude',
       timestamp: scan.timestamp,
+      lastActivity: scan.lastActivity,
       project: cwd ? path.basename(cwd) : undefined,
       cwd,
       filePath,
@@ -638,6 +642,7 @@ async function readClaudeMeta(
       shortId: sessionId.slice(0, 8),
       agent: 'claude',
       timestamp: stat ? stat.mtime.toISOString() : new Date().toISOString(),
+      lastActivity: scan.lastActivity,
       filePath,
       account,
       label,
@@ -859,6 +864,7 @@ export async function readCodexMeta(
     // Codex `session_meta` only carries the start time; use file mtime when
     // it's newer so long-running sessions register as recently active.
     timestamp: pickLatestCodexTimestamp(scan.timestamp, filePath),
+    lastActivity: scan.lastActivity,
     project: cwd ? path.basename(cwd) : undefined,
     cwd,
     filePath,
@@ -1069,6 +1075,7 @@ function readGeminiMeta(
     shortId: sessionId.slice(0, 8),
     agent: 'gemini',
     timestamp: startTime || (stat ? stat.mtime.toISOString() : new Date().toISOString()),
+    lastActivity: lastTsMs !== undefined ? new Date(lastTsMs).toISOString() : undefined,
     project,
     cwd,
     filePath,
@@ -1749,6 +1756,7 @@ interface DroidSessionScan {
   model?: string;
   messageCount: number;
   durationMs?: number;
+  lastActivity?: string;
   contentText?: string;
 }
 
@@ -1829,6 +1837,7 @@ async function readDroidMeta(
     shortId: sessionId.slice(0, 8),
     agent: 'droid',
     timestamp: scan.timestamp || (stat ? stat.mtime.toISOString() : new Date().toISOString()),
+    lastActivity: scan.lastActivity,
     project: cwd ? path.basename(cwd) : undefined,
     cwd,
     filePath,
@@ -1955,6 +1964,7 @@ async function scanDroidSession(filePath: string): Promise<DroidSessionScan> {
     model,
     messageCount,
     durationMs,
+    lastActivity: lastTsMs !== undefined ? new Date(lastTsMs).toISOString() : undefined,
     contentText: userTexts.length > 0 ? userTexts.join('\n') : undefined,
   };
 }
@@ -2143,6 +2153,7 @@ export async function scanClaudeSession(filePath: string): Promise<ClaudeSession
     tokenCount: sawTokenCount ? tokenCount : undefined,
     costUsd: sawCost ? costUsd : undefined,
     durationMs,
+    lastActivity: lastTsMs !== undefined ? new Date(lastTsMs).toISOString() : undefined,
     contentText: userTexts.length > 0 ? userTexts.join('\n') : undefined,
     prUrl,
     prNumber,
@@ -2284,6 +2295,7 @@ async function scanCodexSession(filePath: string): Promise<CodexSessionScan> {
     tokenCount,
     costUsd,
     durationMs,
+    lastActivity: lastTsMs !== undefined ? new Date(lastTsMs).toISOString() : undefined,
     contentText: userTexts.length > 0 ? userTexts.join('\n') : undefined,
     prUrl,
     prNumber,

--- a/src/lib/session/discover.ts
+++ b/src/lib/session/discover.ts
@@ -1297,6 +1297,7 @@ async function scanOpenCodeIncremental(): Promise<void> {
         s.directory,
         s.version,
         s.time_created,
+        s.time_updated,
         COALESCE(stats.message_count, 0),
         stats.token_count,
         COALESCE(stats.has_token_data, 0)
@@ -1330,14 +1331,19 @@ async function scanOpenCodeIncremental(): Promise<void> {
     const entries: ScanEntry[] = [];
     for (const line of out.split('\n')) {
       if (!line.trim()) continue;
-      const [id, title, directory, version, timeCreatedStr, messageCountStr, tokenCountStr, hasTokenDataStr] = line.split('|||');
+      const [id, title, directory, version, timeCreatedStr, timeUpdatedStr, messageCountStr, tokenCountStr, hasTokenDataStr] = line.split('|||');
       if (!id) continue;
 
       const timeCreated = parseInt(timeCreatedStr, 10);
+      const timeUpdated = parseInt(timeUpdatedStr, 10);
       const messageCount = parseInt(messageCountStr, 10);
       const tokenCount = parseInt(tokenCountStr, 10);
       const hasTokenData = hasTokenDataStr === '1';
       const timestamp = isNaN(timeCreated) ? new Date().toISOString() : new Date(timeCreated).toISOString();
+      // OpenCode is one shared DB, not one file per session — its row carries a
+      // per-session updated time. Set lastActivity explicitly (falling back to
+      // creation, never the whole-DB mtime the ScanStamp would otherwise supply).
+      const lastActivity = Number.isNaN(timeUpdated) ? timestamp : new Date(timeUpdated).toISOString();
       const topic = title || undefined;
 
       const meta: SessionMeta = {
@@ -1345,6 +1351,7 @@ async function scanOpenCodeIncremental(): Promise<void> {
         shortId: id.replace(/^ses_/, '').slice(0, 8),
         agent: 'opencode',
         timestamp,
+        lastActivity,
         project: directory ? path.basename(directory) : undefined,
         cwd: directory ? normalizeCwd(directory) : undefined,
         filePath: `${OPENCODE_DB}#${id}`,

--- a/src/lib/session/relative-time.test.ts
+++ b/src/lib/session/relative-time.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { formatRelativeTime } from './relative-time.js';
+
+// Times are pinned at 12:00Z so the local calendar day matches the UTC day in
+// every timezone the tests might run in (no midnight rollover), keeping the
+// month/day assertions deterministic on CI (UTC) and locally alike.
+describe('formatRelativeTime', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('keeps relative buckets for recent times', () => {
+    vi.setSystemTime(new Date('2026-07-04T12:00:00.000Z'));
+    expect(formatRelativeTime('2026-07-04T11:59:10.000Z')).toBe('just now');
+    expect(formatRelativeTime('2026-07-04T11:30:00.000Z')).toBe('30 min ago');
+    expect(formatRelativeTime('2026-07-04T09:00:00.000Z')).toBe('3 hours ago');
+    expect(formatRelativeTime('2026-07-02T12:00:00.000Z')).toBe('2 days ago');
+  });
+
+  it('shows a bare month/day for an older date in the current year', () => {
+    vi.setSystemTime(new Date('2026-07-04T12:00:00.000Z'));
+    expect(formatRelativeTime('2026-06-01T12:00:00.000Z')).toBe('Jun 1');
+  });
+
+  it("appends a 2-digit year for a date outside the current year", () => {
+    vi.setSystemTime(new Date('2026-07-04T12:00:00.000Z'));
+    expect(formatRelativeTime('2025-06-28T12:00:00.000Z')).toBe("Jun 28 '25");
+  });
+});

--- a/src/lib/session/relative-time.ts
+++ b/src/lib/session/relative-time.ts
@@ -19,8 +19,12 @@ export function formatRelativeTime(isoTimestamp: string): string {
   if (diffHrs < 24) return `${diffHrs} hour${diffHrs === 1 ? '' : 's'} ago`;
   if (diffDays < 7) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
 
-  // Older: show date
+  // Older: show the date. Append a 2-digit year for anything outside the current
+  // year so "Jun 28" is never ambiguous across years (e.g. "Jun 28 '25").
   const d = new Date(then);
   const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-  return `${months[d.getMonth()]} ${d.getDate()}`;
+  const label = `${months[d.getMonth()]} ${d.getDate()}`;
+  return d.getFullYear() === new Date(now).getFullYear()
+    ? label
+    : `${label} '${String(d.getFullYear()).slice(-2)}`;
 }

--- a/src/lib/session/remote.test.ts
+++ b/src/lib/session/remote.test.ts
@@ -82,6 +82,18 @@ describe('buildForwardedArgs', () => {
     ).toEqual(['sessions', 'auth bug']);
   });
 
+  it('drops --device (the --host alias) and its value, keeping the rest', () => {
+    // --device merges into the host set in the handler, so its tokens must be
+    // stripped too — else the peer would try to re-fan-out to that device.
+    expect(
+      buildForwardedArgs(argv('sessions', 'auth bug', '--device', 'yosemite-s0', '--json'), new Set(['yosemite-s0'])),
+    ).toEqual(['sessions', 'auth bug', '--json']);
+  });
+
+  it('drops the --device=value form', () => {
+    expect(buildForwardedArgs(argv('sessions', '--device=yosemite-s0', 'query'))).toEqual(['sessions', 'query']);
+  });
+
   it('stops consuming at the first token that is not a known host', () => {
     // The scan only swallows consecutive tokens present in the host set; a
     // trailing non-host token ('auth') is preserved rather than over-consumed.

--- a/src/lib/session/remote.ts
+++ b/src/lib/session/remote.ts
@@ -69,10 +69,12 @@ export function buildForwardedArgs(argv: string[], hosts: Set<string> = new Set(
   const out: string[] = [];
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
-    if (a === '--host' || a === '-H') {
+    if (a === '--host' || a === '-H' || a === '--device') {
       // Commander's `<target...>` variadic accepts both `--host a --host b` and
       // `--host a b` — consume every consecutive token that is a known host so
       // the variadic form doesn't leak the extra hosts into the remote argv.
+      // `--device` is an alias for `--host` (its values are merged into the same
+      // host set), so strip it the same way — else the peer would re-fan-out.
       // Fall back to consuming the single next token when we have no host set
       // (e.g. malformed input) so the flag value never leaks either way.
       if (hosts.size > 0) {
@@ -82,7 +84,7 @@ export function buildForwardedArgs(argv: string[], hosts: Set<string> = new Set(
       }
       continue;
     }
-    if (a.startsWith('--host=') || a.startsWith('-H=')) continue;
+    if (a.startsWith('--host=') || a.startsWith('-H=') || a.startsWith('--device=')) continue;
     if (/^-H.+/.test(a)) continue; // glued short form: -Hyosemite-s1
     out.push(a);
   }

--- a/src/lib/session/types.ts
+++ b/src/lib/session/types.ts
@@ -53,6 +53,12 @@ export interface SessionMeta {
   shortId: string;
   agent: SessionAgentId;
   timestamp: string;
+  /**
+   * Last-activity time (ISO): the last message timestamp when a parser computed
+   * it, else file mtime, else `timestamp`. This is the recency signal the
+   * listing sorts and labels by; `timestamp` stays the creation time.
+   */
+  lastActivity?: string;
   project?: string;
   cwd?: string;
   filePath: string;


### PR DESCRIPTION
## Summary

The bare `agents sessions` overview had two behaviours that made it hard to scan:

1. **It sorted and labelled every session by *creation* time.** `SessionMeta.timestamp`
   is the first user/assistant event, and every listing sorted `ORDER BY timestamp DESC`.
   A session you *started* days ago but *touched* minutes ago sank to its days-ago slot —
   and, because the overview pool is the top 1000 rows selected by SQL order, an
   old-created-but-recently-active session could be dropped before it was ever grouped.
2. **It always spanned every project on disk**, regardless of the repo you were in.

This PR sorts and labels by **last activity**, scopes the default overview to the **current
repo subtree**, and smooths the flag surface.

## Before / After

**Before** — sorted by creation time, always every project (topics genericised):

```
994 sessions · 38 projects · recent activity

▸ my-repo   235   1 hour ago          ← group time = newest session's CREATION
  a1b2c3d4 claude  Configure SSH access …                 1 hour ago
  e5f6a7b8 claude  Port extension UI …                    1 hour ago
  · 233 more
▸ other-cli 32    5 days ago
  …
newest first  ·  +26 more projects · agents sessions --all  ·  <project> to drill in
```

**After** — sorted by last activity, scoped to the repo you're in:

```
845 sessions · 26 projects · recent activity      ← scoped to this repo subtree (was 38)

▸ my-repo   246   ● just now           ← group time = last ACTIVITY, not creation
  a1b2c3d4 claude  Configure SSH access …                 just now
  e5f6a7b8 claude  Port extension UI …                    3 min ago
  · 241 more
▸ other-cli 116   5 days ago
  …
newest first (by last activity)  ·  +14 more projects  ·  agents sessions --all spans every project on disk · <project> to drill in
```

Run from a repo root, the default drops from **38 → 26 projects** (out-of-subtree projects
excluded); `agents sessions --all` widens back to **998 · 38**.

The recency flip, straight from `--json` (top rows, ordered by `lastActivity`):

```
shortId   created                   lastActive
b7957d31  2026-07-07T06:47:34Z      2026-07-07T07:26:25Z
f3c10255  2026-07-07T07:15:04Z      2026-07-07T07:26:24Z
69b2b44a  2026-07-05T08:22:30Z      2026-07-07T07:25:27Z   ← created 2 days earlier, still ranks by recent activity
```

## What changed

- **`last_activity` column** (`db.ts`), populated centrally in `upsertSession` from the
  `lastTsMs` the four timestamp-tracking parsers (Claude/Codex/Gemini/Droid) already
  compute — falling back to file mtime, then creation time, for every other agent. Default
  query order becomes `IFNULL(last_activity, timestamp) DESC`, so the fix lands at the SQL
  layer and the 1000-row pool is selected correctly.
- **Default overview scope** → current repo **subtree** via `cwdPrefix` (separator-bounded
  `cwd LIKE ?`), so a monorepo shows its sub-projects grouped instead of collapsing to one.
  `--all` spans the whole index. Group headers and every list row (tree/flat/picker) read
  the last-activity time, so the whole listing is consistent.
- **Relative time** appends a 2-digit year outside the current year (`Jun 28 '25`) so old
  dates aren't ambiguous.
- **Flags:** `--claude --codex --kimi --antigravity --grok --opencode` (the prioritized
  harnesses) as aliases for `--agent <name>`, and `--device` as an alias for `--host`
  (both already resolve against the device registry). `--device` is stripped from forwarded
  args so a peer never re-fans-out.

## Existing users — automatic

`SCHEMA_VERSION` bumps 7 → 8. On next open, `migrateSchema` runs once per DB: `ALTER TABLE
ADD COLUMN last_activity`, seeds it to `timestamp` (so no NULL-ordered window), then
`DELETE FROM scan_ledger` to force the next scan to refill the true last-message time —
the same proven pattern the `duration_ms` column shipped with. One-time cost: the first
post-upgrade run re-parses local history, then incremental scans are fast again. No manual
step.

## Tests

- `db.test.ts` — schema `7 → 8`, `last_activity` column + round-trip, default sort ranks by
  last activity (fallback = timestamp).
- `discover.test.ts` — a parsed session with last event > first persists `lastActivity >
  timestamp`.
- `sessions.overview.test.ts` — a created-old / active-recent session leads its group; group
  `maxTs` is the last-activity time, not the creation time.
- `remote.test.ts` — `--device` (and `--device=`) stripped from forwarded args like `--host`.
- `relative-time.test.ts` — year suffix appears only outside the current year.

Full suite green on a clean environment (the 2 `exec.test.ts` failures reproduce on
unmodified `main` and are host-env-specific — this branch doesn't touch `exec.*`).

## Verification (end-to-end)

Built the branch and ran the real `agents sessions` against the live DB: the v7→v8 migration
completed without error, the overview scoped to the current repo (26 vs 38 projects), rows
sorted by last activity (a 2-day-older session ranking by its recent activity), `--claude`
resolved to `agent=claude`, and the new footer rendered — all shown above.

Session transcript (this host): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/10ccaec2-c38b-4cc6-92aa-5312d18111e6.jsonl`
