### PR TITLE
fix(sessions): resolve --host/--device through the device registry

### DIFF
--- a/src/lib/devices/__tests__/resolve-target.test.ts
+++ b/src/lib/devices/__tests__/resolve-target.test.ts
@@ -1,0 +1,68 @@
+/**
+ * A `--host`/`--device` token must resolve to the SAME ssh target the
+ * auto-discovery sweep uses — through the device registry — so an explicit host
+ * and the fleet sweep never dial two different routes for one box. These tests
+ * pin that: a bare alias dials the device's registry address (not the literal
+ * alias), while a raw `user@host` stays literal.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveSshTarget } from '../resolve-target.js';
+import type { DeviceRegistry, DeviceProfile } from '../registry.js';
+
+function device(overrides: Partial<DeviceProfile>): DeviceProfile {
+  return {
+    name: 'yosemite-s0',
+    platform: 'linux',
+    shell: 'posix',
+    user: 'muqsit',
+    address: { via: 'tailscale', dnsName: 'yosemite-s0.tail1a85a1.ts.net' },
+    auth: { method: 'key' },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  } as DeviceProfile;
+}
+
+const reg: DeviceRegistry = { 'yosemite-s0': device({}) };
+
+describe('resolveSshTarget', () => {
+  it('resolves a bare alias to the registry address, not the literal alias', () => {
+    const r = resolveSshTarget('yosemite-s0', reg);
+    // The bug: without this, target would be the bare `yosemite-s0` (a different
+    // route than the sweep's registry address, breaking socket reuse).
+    expect(r).toEqual({
+      target: 'muqsit@yosemite-s0.tail1a85a1.ts.net',
+      machine: 'yosemite-s0',
+      name: 'yosemite-s0',
+      os: 'linux',
+    });
+  });
+
+  it('matches case/domain-insensitively via normalizeHost', () => {
+    expect(resolveSshTarget('YOSEMITE-S0.local', reg)?.target).toBe('muqsit@yosemite-s0.tail1a85a1.ts.net');
+  });
+
+  it('keeps an explicit user@host literal (honours the chosen account)', () => {
+    const r = resolveSshTarget('root@yosemite-s0', reg);
+    expect(r?.target).toBe('root@yosemite-s0');
+    expect(r?.machine).toBe('yosemite-s0');
+  });
+
+  it('falls back to a literal target for an unregistered host', () => {
+    const r = resolveSshTarget('some-box', {});
+    expect(r?.target).toBe('some-box');
+    expect(r?.machine).toBe('some-box');
+  });
+
+  it('falls back to the literal token when the matched device has no address', () => {
+    const addressless: DeviceRegistry = { 'no-addr': device({ name: 'no-addr', address: { via: 'manual' } }) };
+    const r = resolveSshTarget('no-addr', addressless);
+    // sshTargetFor throws with no dnsName/ip — resolver degrades to the literal.
+    expect(r?.target).toBe('no-addr');
+    expect(r?.machine).toBe('no-addr');
+  });
+
+  it('returns undefined for a token that fails the ssh-target injection guard', () => {
+    expect(resolveSshTarget('bad;rm -rf', reg)).toBeUndefined();
+  });
+});

--- a/src/lib/devices/resolve-target.ts
+++ b/src/lib/devices/resolve-target.ts
@@ -1,0 +1,88 @@
+/**
+ * The one place a `--host` / `--device` token becomes a real ssh target.
+ *
+ * A device and a host are the same thing addressed two ways, so resolution must
+ * go through the device registry — the single source of truth. A token that
+ * names a registered device dials that device's real address (its Tailscale
+ * dnsName/ip + user, via `sshTargetFor`), *identical* to the auto-discovery
+ * sweep and `agents ssh`. Before this module, the explicit `--host` fan-out
+ * instead passed the bare token straight to `ssh`, so `--host yosemite-s0`
+ * dialed whatever `~/.ssh/config`/LAN DNS resolved `yosemite-s0` to — a
+ * different route than the sweep's `yosemite-s0.<tailnet>.ts.net`. That
+ * divergence broke ControlMaster socket reuse (different target → different
+ * `%C` hash → a cold dial every time) and could read a perfectly reachable box
+ * as "unreachable" when only the non-Tailscale route was down.
+ *
+ * A raw `user@host` that matches no registered device falls back to a literal
+ * target so ad-hoc boxes still work.
+ */
+import chalk from 'chalk';
+import { assertValidSshTarget } from '../ssh-exec.js';
+import { normalizeHost } from '../machine-id.js';
+import { resolveRemoteOsSync } from '../hosts/remote-os.js';
+import { sshTargetFor } from './connect.js';
+import { loadDevices, type DeviceProfile, type DeviceRegistry } from './registry.js';
+
+/** A dialable peer: the ssh target, the machine id used to tag its rows, a
+ * display name, and the OS family that picks the remote shell dialect. */
+export interface ResolvedSshTarget {
+  target: string;
+  machine: string;
+  name: string;
+  os?: string;
+}
+
+/**
+ * Resolve one `--host`/`--device` token to a concrete ssh target through the
+ * registry. Registry hit → the device's real address + platform (so the machine
+ * id, route, and OS all match the auto-discovery sweep). Miss → a literal
+ * `user@host` fallback, its OS taken from the host overlay if enrolled. Returns
+ * undefined only when the token fails the shared ssh-target injection guard.
+ */
+export function resolveSshTarget(token: string, reg: DeviceRegistry): ResolvedSshTarget | undefined {
+  try {
+    assertValidSshTarget(token);
+  } catch {
+    return undefined;
+  }
+  const bare = token.split('@').pop() || token;
+  // An explicit `user@host` names an exact account/target — honour it literally.
+  // A bare alias (`yosemite-s0`) resolves through the registry to the device's
+  // real address, so it never diverges from the auto-discovery sweep.
+  const device: DeviceProfile | undefined = token.includes('@')
+    ? undefined
+    : reg[token] ?? Object.values(reg).find((d) => normalizeHost(d.name) === normalizeHost(bare));
+  if (device) {
+    try {
+      return { target: sshTargetFor(device), machine: normalizeHost(device.name), name: device.name, os: device.platform };
+    } catch {
+      // Registered but has no address to dial — fall through to the literal token.
+    }
+  }
+  return { target: token, machine: normalizeHost(bare), name: token, os: resolveRemoteOsSync(token) };
+}
+
+/**
+ * Resolve an explicit `--host`/`--device` list to dialable targets, reading the
+ * registry once. A token that fails the injection guard is skipped with a
+ * stderr note (never fatal — one bad token must not blank the fan-out). Shared
+ * by every cross-machine fan-out so they can never diverge onto two routes.
+ */
+export async function resolveExplicitTargets(hosts: string[]): Promise<ResolvedSshTarget[]> {
+  let reg: DeviceRegistry;
+  try {
+    reg = await loadDevices();
+  } catch {
+    reg = {};
+  }
+  const out: ResolvedSshTarget[] = [];
+  for (const h of hosts) {
+    const resolved = resolveSshTarget(h, reg);
+    if (!resolved) {
+      process.stderr.write(chalk.gray(`  ${h}: not a valid ssh target — skipped\n`));
+      continue;
+    }
+    out.push(resolved);
+  }
+  return out;
+}

--- a/src/lib/session/remote-active.ts
+++ b/src/lib/session/remote-active.ts
@@ -18,9 +18,9 @@ import { spawn } from 'child_process';
 import chalk from 'chalk';
 import { SSH_OPTS, controlOpts, assertValidSshTarget, shellQuote } from '../ssh-exec.js';
 import { sshTargetFor } from '../devices/connect.js';
+import { resolveExplicitTargets } from '../devices/resolve-target.js';
 import { loadDevices, type DeviceProfile } from '../devices/registry.js';
 import { remoteShellFor, buildWindowsAgentsCommand } from '../hosts/remote-cmd.js';
-import { resolveRemoteOsSync } from '../hosts/remote-os.js';
 import { machineId, normalizeHost } from './sync/config.js';
 import type { ActiveSession } from './active.js';
 
@@ -120,18 +120,9 @@ export async function gatherRemoteActive(hosts?: string[]): Promise<RemoteActive
   const targets: Array<{ target: string; machine: string; name: string; os?: string }> = [];
 
   if (hosts && hosts.length > 0) {
-    for (const h of hosts) {
-      try {
-        assertValidSshTarget(h);
-      } catch {
-        process.stderr.write(chalk.gray(`  ${h}: not a valid ssh target — skipped\n`));
-        continue;
-      }
-      const bareHost = h.split('@').pop() || h;
-      // Resolve the OS by the name the user passed (a bare alias like `win-mini`
-      // matches a device-registry entry; a raw `user@host` falls back to POSIX).
-      targets.push({ target: h, machine: normalizeHost(bareHost), name: h, os: resolveRemoteOsSync(h) });
-    }
+    // Resolve each token through the device registry so an explicit --host/--device
+    // dials the exact same address (and machine id) as the auto-discovery sweep.
+    targets.push(...await resolveExplicitTargets(hosts));
   } else {
     let reg: Record<string, DeviceProfile>;
     try {

--- a/src/lib/session/remote-list.ts
+++ b/src/lib/session/remote-list.ts
@@ -17,9 +17,9 @@ import { spawn } from 'child_process';
 import chalk from 'chalk';
 import { SSH_OPTS, controlOpts, assertValidSshTarget, shellQuote } from '../ssh-exec.js';
 import { sshTargetFor } from '../devices/connect.js';
+import { resolveExplicitTargets } from '../devices/resolve-target.js';
 import { loadDevices, type DeviceProfile } from '../devices/registry.js';
 import { remoteShellFor, buildWindowsAgentsCommand } from '../hosts/remote-cmd.js';
-import { resolveRemoteOsSync } from '../hosts/remote-os.js';
 import { machineId, normalizeHost } from './sync/config.js';
 import { NO_FANOUT_ENV } from './remote-active.js';
 import { terminalWidth } from './width.js';
@@ -125,16 +125,9 @@ export async function gatherRemoteList(forwardedArgs: string[], hosts?: string[]
   const targets: Array<{ target: string; machine: string; name: string; os?: string }> = [];
 
   if (hosts && hosts.length > 0) {
-    for (const h of hosts) {
-      try {
-        assertValidSshTarget(h);
-      } catch {
-        process.stderr.write(chalk.gray(`  ${h}: not a valid ssh target — skipped\n`));
-        continue;
-      }
-      const bareHost = h.split('@').pop() || h;
-      targets.push({ target: h, machine: normalizeHost(bareHost), name: h, os: resolveRemoteOsSync(h) });
-    }
+    // Resolve each token through the device registry so an explicit --host/--device
+    // dials the exact same address (and machine id) as the auto-discovery sweep.
+    targets.push(...await resolveExplicitTargets(hosts));
   } else {
     let reg: Record<string, DeviceProfile>;
     try {


### PR DESCRIPTION
## Problem

`agents sessions --active --host <name>` intermittently reports `<name>: unreachable or no agents CLI — skipped` for a host that plain `sessions --active` reaches fine seconds earlier — and even on success it still shows the local machine.

**Root cause: two SSH resolution paths that disagree.** Everything funnels through `fetchByTarget(target, …)`, but `target` was built two ways:

| Path | How `target` was built | Resolved to |
|------|------------------------|-------------|
| Auto-discovery sweep | `sshTargetFor(device)` — **registry** | `yosemite-s0.tail1a85a1.ts.net` (Tailscale MagicDNS) |
| `--host yosemite-s0` | bare token, verbatim | `yosemite-s0` (whatever `~/.ssh/config`/LAN DNS says) |

Proven live before the fix:
```
DEFAULT sweep -> sshTargetFor : yosemite-s0.tail1a85a1.ts.net
--host path   -> bare alias   : yosemite-s0
```

Consequences of the `--host` branch bypassing the registry:
1. **Different route** — the bare alias can be down/slow while the Tailscale route is up → cold `ssh` exceeds ConnectTimeout → `code !== 0` → "unreachable… skipped", even though the sweep reached the box a second earlier.
2. **Different `ControlPath %C` hash** — the `--host` call couldn't reuse the warm multiplex socket the sweep opened, so it cold-dialed every time.

The `--host` branch was a parallel, band-aid resolution path that ignored the device registry — the source of truth. `agents ssh <name>` already does it right (`getDevice` → `sshTargetFor`); the fan-out now does too.

## Fix

New `src/lib/devices/resolve-target.ts` — the one place a `--host`/`--device` token becomes an ssh target:
- **bare alias** (`yosemite-s0`) → resolves through the registry to the device's real address + machine id, identical to the sweep and `agents ssh`.
- **raw `user@host`** → stays literal (honours the chosen account).
- **bad token** → skipped with the existing stderr note.

`gatherRemoteActive` and `gatherRemoteList` both drop their divergent `--host` copies and call the shared `resolveExplicitTargets`.

## Verification

- **Unit:** 6 new resolver tests + existing remote-active/remote-list — 20 passed.
- **Typecheck:** `tsc --noEmit` clean.
- **Resolution proof (real registry):** `--host yosemite-s0` → `yosemite-s0.tail1a85a1.ts.net`; `root@10.0.0.9` → literal; `bad;rm` → skipped.
- **E2E:** real CLI `sessions --active --host yosemite-s0` reaches yosemite-s0 and renders it in the merged view.

Two `src/lib/exec.test.ts` failures are **pre-existing env pollution** (assert `AGENTS_MAILBOX_DIR`/`DISABLE_AUTOUPDATER` undefined, but they're set by the running agent session — received value is literally this session's id); untouched by this change.

## Not included (separate concern)

`--host` is still **additive** — it folds the named host in alongside the local machine rather than filtering to only it. That's a UX-semantics change distinct from this resolution fix; happy to follow up if desired.

Session transcript (secret gist): zion:/Users/muqsit/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/f3c10255-160f-4b2e-94dc-f6ee6b13ee81.jsonl