### PR TITLE
fix(shims): adopt shadowing launchers instead of looping the PATH-repair prompt

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -61,6 +61,8 @@ interface DoctorOptions {
   kind?: string;
   cwd?: string;
   fix?: boolean;
+  adopt?: string;
+  release?: string;
 }
 
 // ─── overview mode (no target) ────────────────────────────────────────────────
@@ -531,7 +533,9 @@ export function registerDoctorCommand(program: Command): void {
     .option('--diff', 'In target mode, include unified diffs for divergent files')
     .option('--fix', 'Heal gaps: install missing resources, repair invalid plugin manifests, refresh stale plugins, and reconcile drift (all installed versions, or just the target)')
     .option('--kind <kinds>', 'Restrict to comma-separated resource kinds (commands,skills,hooks,rules,mcp,permissions,subagents,plugins,promptcuts)')
-    .option('--cwd <path>', 'Resolution cwd for project layer detection (default: process.cwd())');
+    .option('--cwd <path>', 'Resolution cwd for project layer detection (default: process.cwd())')
+    .option('--adopt <agent>', "Take over the agent's native launcher that shadows the shim (symlink it to the version-managed shim; reversible with --release)")
+    .option('--release <agent>', 'Undo --adopt: restore the native launcher agents-cli previously adopted');
 
   setHelpSections(doctorCmd, {
     examples: `
@@ -560,6 +564,41 @@ export function registerDoctorCommand(program: Command): void {
 
   doctorCmd.action(async (target: string | undefined, opts: DoctorOptions) => {
       const cwd = opts.cwd ? opts.cwd : process.cwd();
+
+      // Launcher adoption escape hatch. `--adopt <agent>` forces the take-over
+      // even for a non-default agent; `--release <agent>` reverses it.
+      if (opts.adopt || opts.release) {
+        const { adoptShadowingLauncher, releaseAdoptedLauncher, getPathShadowingExecutable } = await import('../lib/shims.js');
+        const raw = (opts.adopt || opts.release) as string;
+        const agent = resolveAgentName(raw);
+        if (!agent) {
+          console.error(chalk.red(formatAgentError(raw)));
+          process.exit(1);
+        }
+        if (opts.release) {
+          const restored = releaseAdoptedLauncher(agent);
+          if (restored) {
+            console.log(chalk.green(`Released ${AGENTS[agent].cliCommand}: launcher restored to ${restored}.`));
+          } else {
+            console.log(chalk.gray(`${AGENTS[agent].cliCommand} has no adopted launcher to release.`));
+          }
+          return;
+        }
+        const shadowedBy = getPathShadowingExecutable(agent);
+        const result = adoptShadowingLauncher(agent, shadowedBy ? { shadowedBy } : undefined);
+        if (result.adopted) {
+          console.log(chalk.green(`Adopted ${AGENTS[agent].cliCommand} launcher (${result.launcher} -> shim). Original recorded for --release; version management now wins regardless of PATH order.`));
+        } else if (result.reason === 'already-adopted') {
+          console.log(chalk.gray(`${AGENTS[agent].cliCommand} launcher is already adopted.`));
+        } else if (result.reason === 'no-shadow') {
+          console.log(chalk.gray(`Nothing to adopt — ${AGENTS[agent].cliCommand} is not shadowed on PATH.`));
+        } else if (result.reason === 'not-a-symlink') {
+          console.log(chalk.yellow(`${AGENTS[agent].cliCommand} is shadowed by a real binary (${result.launcher}), not a symlink. agents-cli won't move a real binary — remove/reorder it or reorder PATH.`));
+        } else {
+          console.log(chalk.yellow(`Could not adopt ${AGENTS[agent].cliCommand} (${result.reason}).`));
+        }
+        return;
+      }
 
       // --fix turns the read-only diagnosis into a heal. With no target it heals
       // every installed version; with a target it scopes to that agent.

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -568,7 +568,11 @@ export function registerDoctorCommand(program: Command): void {
       // Launcher adoption escape hatch. `--adopt <agent>` forces the take-over
       // even for a non-default agent; `--release <agent>` reverses it.
       if (opts.adopt || opts.release) {
-        const { adoptShadowingLauncher, releaseAdoptedLauncher, getPathShadowingExecutable } = await import('../lib/shims.js');
+        if (opts.adopt && opts.release) {
+          console.error(chalk.red('--adopt and --release are mutually exclusive; pass only one.'));
+          process.exit(1);
+        }
+        const { adoptShadowingLauncher, releaseAdoptedLauncher } = await import('../lib/shims.js');
         const raw = (opts.adopt || opts.release) as string;
         const agent = resolveAgentName(raw);
         if (!agent) {
@@ -584,14 +588,16 @@ export function registerDoctorCommand(program: Command): void {
           }
           return;
         }
-        const shadowedBy = getPathShadowingExecutable(agent);
-        const result = adoptShadowingLauncher(agent, shadowedBy ? { shadowedBy } : undefined);
+        // adoptShadowingLauncher resolves the launcher itself (PATH shadow, then
+        // the durable ~/.local/bin symlink), so it forces the take-over even when
+        // this shell's PATH already has the shim first.
+        const result = adoptShadowingLauncher(agent);
         if (result.adopted) {
           console.log(chalk.green(`Adopted ${AGENTS[agent].cliCommand} launcher (${result.launcher} -> shim). Original recorded for --release; version management now wins regardless of PATH order.`));
         } else if (result.reason === 'already-adopted') {
           console.log(chalk.gray(`${AGENTS[agent].cliCommand} launcher is already adopted.`));
         } else if (result.reason === 'no-shadow') {
-          console.log(chalk.gray(`Nothing to adopt — ${AGENTS[agent].cliCommand} is not shadowed on PATH.`));
+          console.log(chalk.gray(`Nothing to adopt — no ${AGENTS[agent].cliCommand} launcher found shadowing the shim (checked PATH and ~/.local/bin).`));
         } else if (result.reason === 'not-a-symlink') {
           console.log(chalk.yellow(`${AGENTS[agent].cliCommand} is shadowed by a real binary (${result.launcher}), not a symlink. agents-cli won't move a real binary — remove/reorder it or reorder PATH.`));
         } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -647,12 +647,12 @@ async function maybeBootstrapShimIntegration(
   // Auto-adopt any harness launcher that shadows our shim. PATH-order repair
   // (below) cannot win against `~/.local/bin` — it's prepended in .zshenv for
   // every shell while our prepend only lands in .zshrc — so for symlink
-  // launchers we *become* the launcher instead. Reversible via
-  // `releaseAdoptedLauncher`; only ever rewrites a symlink. Silent + idempotent.
+  // launchers we *become* the launcher instead. Detection keys on the launcher
+  // symlink EXISTING (via adoptShadowingLauncher's own fallback), not on this
+  // shell's PATH order, so it also heals the GUI/non-interactive shadow an
+  // interactive run can't see. Reversible; only ever rewrites a symlink.
   for (const agent of defaultAgents) {
-    const shadowedBy = getPathShadowingExecutable(agent);
-    if (!shadowedBy) continue;
-    const result = adoptShadowingLauncher(agent, { shadowedBy });
+    const result = adoptShadowingLauncher(agent);
     if (result.adopted) {
       console.log(chalk.green(`Adopted ${AGENTS[agent].cliCommand} launcher (${result.launcher}) — version management now wins regardless of PATH order.`));
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -593,6 +593,7 @@ async function maybeBootstrapShimIntegration(
   const { getGlobalDefault, listInstalledVersions } = await import('./lib/versions.js');
   const {
     addShimsToPath,
+    adoptShadowingLauncher,
     ensureShimCurrent,
     ensureVersionedAliasCurrent,
     getPathShadowingExecutable,
@@ -642,86 +643,82 @@ async function maybeBootstrapShimIntegration(
   }
 
   const defaultAgents = installedAgents.filter((agent) => getGlobalDefault(agent));
+
+  // Auto-adopt any harness launcher that shadows our shim. PATH-order repair
+  // (below) cannot win against `~/.local/bin` — it's prepended in .zshenv for
+  // every shell while our prepend only lands in .zshrc — so for symlink
+  // launchers we *become* the launcher instead. Reversible via
+  // `releaseAdoptedLauncher`; only ever rewrites a symlink. Silent + idempotent.
+  for (const agent of defaultAgents) {
+    const shadowedBy = getPathShadowingExecutable(agent);
+    if (!shadowedBy) continue;
+    const result = adoptShadowingLauncher(agent, { shadowedBy });
+    if (result.adopted) {
+      console.log(chalk.green(`Adopted ${AGENTS[agent].cliCommand} launcher (${result.launcher}) — version management now wins regardless of PATH order.`));
+    }
+  }
+
+  // Recompute AFTER adoption so anything we just took over drops out. What
+  // remains is a real binary we deliberately don't touch (adoption is
+  // symlink-only) — those get an honest one-time note, never a looping prompt.
   const shadowed = defaultAgents
     .map((agent) => ({ agent, shadowedBy: getPathShadowingExecutable(agent) }))
     .filter((item): item is { agent: keyof typeof AGENTS; shadowedBy: string } => Boolean(item.shadowedBy));
 
-  // Shell aliases that call the same command with extra flags are intentional
-  // customization and don't break shim integration — `addShimsToPath` cannot
-  // touch them, so they don't belong in the repair prompt. We previously
-  // computed an `aliased` list here and inserted it into `affected`, which
-  // contradicted the comment below and surfaced false positives (e.g. an
-  // earlier `alias codex=...` cancelled by a later `unalias codex` was
-  // reported because the detector did a static rc-file regex).
-  if (shadowed.length === 0 && isShimsInPath()) {
+  // After adoption, the only things left are (a) real-binary shadows we won't
+  // touch, and (b) a genuinely missing PATH entry. Nothing else needs the user.
+  const pathMissing = !isShimsInPath();
+  if (shadowed.length === 0 && !pathMissing) {
     return;
   }
 
-  // Suppress repeated prompts within the same shell. A successful rc-file
-  // edit doesn't reload the parent shell, so the next invocation sees the
-  // same PATH and re-fires detection. The sentinel survives only as long as
-  // the parent shell process — once the user opens a new terminal, the
-  // PPID changes and the prompt is allowed again.
+  // Suppress repeated notices within the same shell. A successful rc-file edit
+  // doesn't reload the parent shell, so the next invocation re-fires detection.
+  // The sentinel survives only as long as the parent shell process — a new
+  // terminal (new PPID) is allowed to surface it again.
   const sentinelPath = path.join(os.tmpdir(), `agents-shim-prompted-${process.ppid}`);
   if (fs.existsSync(sentinelPath)) {
     return;
   }
 
-  const affected: string[] = [];
-  for (const { agent, shadowedBy } of shadowed) {
-    affected.push(`${AGENTS[agent].cliCommand} -> ${shadowedBy}`);
-  }
-  if (affected.length === 0) {
-    // Pure PATH-not-loaded case: rc may already have the shim block, but the
-    // running shell hasn't sourced it. Don't list agents here — they aren't
-    // broken; only the PATH is stale. The prompt + post-message handle it.
-    affected.push('PATH entry missing');
-  }
-
-  const shouldRepair = await confirm({
-    message: `Repair shim integration now? ${affected.join(', ')}`,
-    default: true,
-  });
-
-  if (!shouldRepair) {
-    console.log(chalk.yellow('Shim integration still needs attention.'));
-    console.log(chalk.gray(getPathSetupInstructions()));
-    try { fs.writeFileSync(sentinelPath, '1'); } catch { /* best-effort */ }
-    return;
+  // Real-binary shadows: adoption is symlink-only (we never rename a real native
+  // binary), and `addShimsToPath` provably can't outrank an early-PATH dir like
+  // ~/.local/bin across zsh's whole sourcing chain. So DON'T offer a "Repair?"
+  // prompt here — that was the infinite-loop bug (Yes was always a no-op).
+  // Inform once and point at the real levers.
+  if (shadowed.length > 0) {
+    const targets = shadowed
+      .map(({ agent, shadowedBy }) => `  ${AGENTS[agent].cliCommand}: ${shadowedBy}`)
+      .join('\n');
+    console.log(chalk.yellow('These agent commands run a native binary instead of the version-managed shim:'));
+    console.log(chalk.gray(targets));
+    console.log(chalk.gray(`It's a real binary (not a symlink), so agents-cli won't move it. To hand it to agents-cli, remove/reorder it, or put ${getShimsDir()} earlier in PATH.`));
   }
 
-  const pathResult = addShimsToPath();
-  if (!pathResult.success) {
-    console.log(chalk.yellow('Could not repair shim PATH setup automatically.'));
-    console.log(chalk.gray(pathResult.error || getPathSetupInstructions()));
-    // Write the sentinel even on failure — otherwise an unwritable rc file
-    // re-prompts every invocation in the same shell. The user opens a new
-    // terminal (new PPID) to retry.
-    try { fs.writeFileSync(sentinelPath, '1'); } catch { /* best-effort */ }
-    return;
-  }
-
-  // When the rc file already has the canonical shim block, `addShimsToPath`
-  // is a no-op — re-emitting produced byte-identical content. In this branch
-  // the user clicked "Yes" but nothing changed on disk, AND the underlying
-  // cause (a real binary shadow, or a stale shell PATH) is unaffected by
-  // this command. Be honest about it and point at the actual action.
-  if (pathResult.alreadyPresent) {
-    if (shadowed.length > 0) {
-      const targets = shadowed
-        .map(({ agent, shadowedBy }) => `  ${AGENTS[agent].cliCommand}: ${shadowedBy}`)
-        .join('\n');
-      console.log(chalk.yellow('Repair could not change anything — the shim is shadowed by another binary on PATH:'));
-      console.log(chalk.gray(targets));
-      console.log(chalk.gray(`Fix it by removing or reordering that binary, or making sure ${getShimsDir()} appears earlier in PATH than its parent dir.`));
+  // Genuinely-missing PATH entry is the one thing addShimsToPath actually fixes,
+  // so it's the only case that still earns an interactive prompt.
+  if (pathMissing) {
+    const shouldRepair = await confirm({
+      message: 'Add the agents-cli shims directory to your PATH now?',
+      default: true,
+    });
+    if (!shouldRepair) {
+      console.log(chalk.gray(getPathSetupInstructions()));
     } else {
-      console.log(chalk.yellow(`Shim PATH entry is already in ~/${pathResult.rcFile} — this shell just needs to reload it.`));
-      console.log(chalk.gray(`Run: source ~/${pathResult.rcFile}   (or open a new terminal)`));
+      const pathResult = addShimsToPath();
+      if (!pathResult.success) {
+        console.log(chalk.yellow('Could not update PATH automatically.'));
+        console.log(chalk.gray(pathResult.error || getPathSetupInstructions()));
+      } else if (pathResult.alreadyPresent) {
+        console.log(chalk.yellow(`Shim PATH entry is already in ~/${pathResult.rcFile} — this shell just needs to reload it.`));
+        console.log(chalk.gray(`Run: source ~/${pathResult.rcFile}   (or open a new terminal)`));
+      } else {
+        console.log(chalk.green(`Added shims to PATH in ~/${pathResult.rcFile}`));
+        console.log(chalk.gray(getPathSetupInstructions()));
+      }
     }
-  } else {
-    console.log(chalk.green(`Repaired shim PATH setup in ~/${pathResult.rcFile}`));
-    console.log(chalk.gray(getPathSetupInstructions()));
   }
+
   try { fs.writeFileSync(sentinelPath, '1'); } catch { /* best-effort */ }
 }
 

--- a/src/lib/__tests__/shims.test.ts
+++ b/src/lib/__tests__/shims.test.ts
@@ -95,8 +95,8 @@ describe('addShimsToPath', () => {
 });
 
 describe('SHIM_SCHEMA_VERSION', () => {
-  it('is 22 (claude auto-updater disabled for managed pinned installs)', () => {
-    expect(SHIM_SCHEMA_VERSION).toBe(22);
+  it('is 23 (adopted-launcher fall-through when no managed version resolves)', () => {
+    expect(SHIM_SCHEMA_VERSION).toBe(23);
   });
 });
 

--- a/src/lib/shims.adoption.test.ts
+++ b/src/lib/shims.adoption.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  adoptShadowingLauncher,
+  releaseAdoptedLauncher,
+  getAdoptedRecordPath,
+  generateShimScript,
+} from './shims.js';
+
+function tmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'agents-adopt-test-'));
+}
+
+// A realistic "harness installed its own launcher" layout: a real binary in the
+// harness's home, symlinked into an early-PATH dir (~/.local/bin) — exactly the
+// grok/claude/kimi shape that shadows our shim.
+function fakeLauncher(root: string, cli: string): { link: string; realBin: string } {
+  const harnessBinDir = path.join(root, `.${cli}`, 'bin');
+  fs.mkdirSync(harnessBinDir, { recursive: true });
+  const realBin = path.join(harnessBinDir, cli);
+  fs.writeFileSync(realBin, '#!/bin/bash\necho native\n');
+  fs.chmodSync(realBin, 0o755);
+
+  const localBin = path.join(root, '.local', 'bin');
+  fs.mkdirSync(localBin, { recursive: true });
+  const link = path.join(localBin, cli);
+  fs.symlinkSync(realBin, link);
+  return { link, realBin };
+}
+
+describe('adoptShadowingLauncher', () => {
+  test('symlink launcher: repoints to shim, records real original, is idempotent', () => {
+    const root = tmp();
+    const shimsDir = path.join(root, '.agents', '.cache', 'shims');
+    fs.mkdirSync(shimsDir, { recursive: true });
+    // Materialize a stand-in shim so realpath resolution has a concrete target.
+    const shimPath = path.join(shimsDir, 'grok');
+    fs.writeFileSync(shimPath, '#!/bin/bash\n');
+    fs.chmodSync(shimPath, 0o755);
+
+    const { link, realBin } = fakeLauncher(root, 'grok');
+
+    const result = adoptShadowingLauncher('grok', { shadowedBy: link, shimsDir });
+    expect(result.adopted).toBe(true);
+
+    // The launcher now points at our shim...
+    expect(fs.realpathSync(link)).toBe(fs.realpathSync(shimPath));
+    // ...and the original real binary is recorded for fall-through / restore.
+    const record = fs.readFileSync(getAdoptedRecordPath('grok', shimsDir), 'utf-8').trim();
+    expect(record).toBe(fs.realpathSync(realBin));
+
+    // Second call is a no-op (already adopted), never a double-rewrite.
+    const again = adoptShadowingLauncher('grok', { shadowedBy: link, shimsDir });
+    expect(again.adopted).toBe(false);
+    if (!again.adopted) expect(again.reason).toBe('already-adopted');
+  });
+
+  test('refuses to touch a REAL binary (only symlinks are adopted)', () => {
+    const root = tmp();
+    const shimsDir = path.join(root, '.agents', '.cache', 'shims');
+    fs.mkdirSync(shimsDir, { recursive: true });
+    fs.writeFileSync(path.join(shimsDir, 'droid'), '#!/bin/bash\n');
+
+    // droid ships a standalone native binary (not a symlink) at ~/.local/bin.
+    const localBin = path.join(root, '.local', 'bin');
+    fs.mkdirSync(localBin, { recursive: true });
+    const realBin = path.join(localBin, 'droid');
+    fs.writeFileSync(realBin, 'ELF-ish native binary');
+    fs.chmodSync(realBin, 0o755);
+
+    const result = adoptShadowingLauncher('droid', { shadowedBy: realBin, shimsDir });
+    expect(result.adopted).toBe(false);
+    if (!result.adopted) expect(result.reason).toBe('not-a-symlink');
+    // The real binary is untouched.
+    expect(fs.readFileSync(realBin, 'utf-8')).toBe('ELF-ish native binary');
+    expect(fs.existsSync(getAdoptedRecordPath('droid', shimsDir))).toBe(false);
+  });
+
+  test('release restores the launcher to the recorded original and drops the record', () => {
+    const root = tmp();
+    const shimsDir = path.join(root, '.agents', '.cache', 'shims');
+    fs.mkdirSync(shimsDir, { recursive: true });
+    fs.writeFileSync(path.join(shimsDir, 'grok'), '#!/bin/bash\n');
+
+    const { link, realBin } = fakeLauncher(root, 'grok');
+    adoptShadowingLauncher('grok', { shadowedBy: link, shimsDir });
+
+    const restored = releaseAdoptedLauncher('grok', { shadowedBy: link, shimsDir });
+    expect(restored).toBe(fs.realpathSync(realBin));
+    // Launcher points back at the native binary; record is gone.
+    expect(fs.realpathSync(link)).toBe(fs.realpathSync(realBin));
+    expect(fs.existsSync(getAdoptedRecordPath('grok', shimsDir))).toBe(false);
+
+    // Releasing again is a clean no-op.
+    expect(releaseAdoptedLauncher('grok', { shadowedBy: link, shimsDir })).toBeNull();
+  });
+});
+
+describe('generated shim fall-through', () => {
+  test('is valid bash and reads the adopted-original record by absolute path', () => {
+    const script = generateShimScript('grok');
+
+    // Valid bash (catches template-literal escaping regressions).
+    const f = path.join(tmp(), 'grok');
+    fs.writeFileSync(f, script);
+    execFileSync('bash', ['-n', f]); // throws on syntax error
+
+    // The safety net exists and is wired into failure paths.
+    expect(script).toContain('ADOPTED_ORIGINAL="$AGENTS_USER_DIR/.cache/shims/.adopted/$CLI_COMMAND"');
+    expect(script).toContain('exec_adopted_original');
+    // grok's last-resort binary resolution must prefer the recorded original
+    // over `command -v grok` — otherwise the adopted symlink re-enters the shim.
+    expect(script).toContain('adopted_original_bin');
+  });
+
+  test('droid shim prefers the adopted record before its fixed ~/.local/bin path', () => {
+    const script = generateShimScript('droid');
+    const droidBranch = script.slice(script.indexOf('AGENT" = "droid"'));
+    // adopted_original_bin is consulted before the $HOME/.local/bin/droid path,
+    // which after adoption points back at this dispatcher.
+    expect(droidBranch.indexOf('adopted_original_bin')).toBeLessThan(
+      droidBranch.indexOf('$HOME/.local/bin/droid'),
+    );
+  });
+});

--- a/src/lib/shims.adoption.test.ts
+++ b/src/lib/shims.adoption.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import {
   adoptShadowingLauncher,
   releaseAdoptedLauncher,
+  findAdoptableLauncher,
   getAdoptedRecordPath,
   generateShimScript,
 } from './shims.js';
@@ -14,10 +15,18 @@ function tmp(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'agents-adopt-test-'));
 }
 
-// A realistic "harness installed its own launcher" layout: a real binary in the
-// harness's home, symlinked into an early-PATH dir (~/.local/bin) — exactly the
-// grok/claude/kimi shape that shadows our shim.
-function fakeLauncher(root: string, cli: string): { link: string; realBin: string } {
+// Realistic layout: shims dir + a durable history dir (records live there now),
+// plus a harness that installed a real binary symlinked into ~/.local/bin —
+// exactly the grok/claude/kimi shape that shadows our shim.
+function fixture(cli: string) {
+  const root = tmp();
+  const shimsDir = path.join(root, '.agents', '.cache', 'shims');
+  const historyDir = path.join(root, '.agents', '.history');
+  fs.mkdirSync(shimsDir, { recursive: true });
+  const shimPath = path.join(shimsDir, cli);
+  fs.writeFileSync(shimPath, '#!/bin/bash\n');
+  fs.chmodSync(shimPath, 0o755);
+
   const harnessBinDir = path.join(root, `.${cli}`, 'bin');
   fs.mkdirSync(harnessBinDir, { recursive: true });
   const realBin = path.join(harnessBinDir, cli);
@@ -28,74 +37,101 @@ function fakeLauncher(root: string, cli: string): { link: string; realBin: strin
   fs.mkdirSync(localBin, { recursive: true });
   const link = path.join(localBin, cli);
   fs.symlinkSync(realBin, link);
-  return { link, realBin };
+
+  return { root, shimsDir, historyDir, shimPath, realBin, link };
 }
 
 describe('adoptShadowingLauncher', () => {
-  test('symlink launcher: repoints to shim, records real original, is idempotent', () => {
-    const root = tmp();
-    const shimsDir = path.join(root, '.agents', '.cache', 'shims');
-    fs.mkdirSync(shimsDir, { recursive: true });
-    // Materialize a stand-in shim so realpath resolution has a concrete target.
-    const shimPath = path.join(shimsDir, 'grok');
-    fs.writeFileSync(shimPath, '#!/bin/bash\n');
-    fs.chmodSync(shimPath, 0o755);
+  test('symlink launcher: repoints to shim, records original + launcher, idempotent', () => {
+    const { shimsDir, historyDir, shimPath, realBin, link } = fixture('grok');
 
-    const { link, realBin } = fakeLauncher(root, 'grok');
-
-    const result = adoptShadowingLauncher('grok', { shadowedBy: link, shimsDir });
+    const result = adoptShadowingLauncher('grok', { shadowedBy: link, shimsDir, historyDir });
     expect(result.adopted).toBe(true);
 
-    // The launcher now points at our shim...
+    // Launcher now points at our shim.
     expect(fs.realpathSync(link)).toBe(fs.realpathSync(shimPath));
-    // ...and the original real binary is recorded for fall-through / restore.
-    const record = fs.readFileSync(getAdoptedRecordPath('grok', shimsDir), 'utf-8').trim();
-    expect(record).toBe(fs.realpathSync(realBin));
+
+    // Durable record: line 1 = original binary, line 2 = launcher path.
+    const record = fs.readFileSync(getAdoptedRecordPath('grok', historyDir), 'utf-8').split('\n');
+    expect(record[0]).toBe(fs.realpathSync(realBin));
+    expect(record[1]).toBe(path.resolve(link));
+    // ...and it lives under .history (durable), not .cache (regenerable).
+    expect(getAdoptedRecordPath('grok', historyDir)).toContain(`${path.sep}.history${path.sep}`);
 
     // Second call is a no-op (already adopted), never a double-rewrite.
-    const again = adoptShadowingLauncher('grok', { shadowedBy: link, shimsDir });
+    const again = adoptShadowingLauncher('grok', { shadowedBy: link, shimsDir, historyDir });
     expect(again.adopted).toBe(false);
     if (!again.adopted) expect(again.reason).toBe('already-adopted');
   });
 
   test('refuses to touch a REAL binary (only symlinks are adopted)', () => {
-    const root = tmp();
-    const shimsDir = path.join(root, '.agents', '.cache', 'shims');
-    fs.mkdirSync(shimsDir, { recursive: true });
-    fs.writeFileSync(path.join(shimsDir, 'droid'), '#!/bin/bash\n');
-
+    const { shimsDir, historyDir, root } = fixture('droid');
     // droid ships a standalone native binary (not a symlink) at ~/.local/bin.
-    const localBin = path.join(root, '.local', 'bin');
-    fs.mkdirSync(localBin, { recursive: true });
-    const realBin = path.join(localBin, 'droid');
+    const realBin = path.join(root, '.local', 'bin', 'droid');
+    fs.rmSync(realBin);
     fs.writeFileSync(realBin, 'ELF-ish native binary');
     fs.chmodSync(realBin, 0o755);
 
-    const result = adoptShadowingLauncher('droid', { shadowedBy: realBin, shimsDir });
+    const result = adoptShadowingLauncher('droid', { shadowedBy: realBin, shimsDir, historyDir });
     expect(result.adopted).toBe(false);
     if (!result.adopted) expect(result.reason).toBe('not-a-symlink');
-    // The real binary is untouched.
     expect(fs.readFileSync(realBin, 'utf-8')).toBe('ELF-ish native binary');
-    expect(fs.existsSync(getAdoptedRecordPath('droid', shimsDir))).toBe(false);
+    expect(fs.existsSync(getAdoptedRecordPath('droid', historyDir))).toBe(false);
   });
 
-  test('release restores the launcher to the recorded original and drops the record', () => {
-    const root = tmp();
-    const shimsDir = path.join(root, '.agents', '.cache', 'shims');
-    fs.mkdirSync(shimsDir, { recursive: true });
-    fs.writeFileSync(path.join(shimsDir, 'grok'), '#!/bin/bash\n');
+  test('release restores the launcher from the record regardless of PATH (M3)', () => {
+    const { shimsDir, historyDir, realBin, link } = fixture('grok');
+    adoptShadowingLauncher('grok', { shadowedBy: link, shimsDir, historyDir });
 
-    const { link, realBin } = fakeLauncher(root, 'grok');
-    adoptShadowingLauncher('grok', { shadowedBy: link, shimsDir });
-
-    const restored = releaseAdoptedLauncher('grok', { shadowedBy: link, shimsDir });
+    // Release WITHOUT telling it the launcher — it must recover it from the
+    // record's line 2, independent of any PATH scan.
+    const restored = releaseAdoptedLauncher('grok', { shimsDir, historyDir });
     expect(restored).toBe(fs.realpathSync(realBin));
-    // Launcher points back at the native binary; record is gone.
     expect(fs.realpathSync(link)).toBe(fs.realpathSync(realBin));
-    expect(fs.existsSync(getAdoptedRecordPath('grok', shimsDir))).toBe(false);
+    expect(fs.existsSync(getAdoptedRecordPath('grok', historyDir))).toBe(false);
 
     // Releasing again is a clean no-op.
-    expect(releaseAdoptedLauncher('grok', { shadowedBy: link, shimsDir })).toBeNull();
+    expect(releaseAdoptedLauncher('grok', { shimsDir, historyDir })).toBeNull();
+  });
+
+  test('the record survives a .cache wipe (M1 — durable reverse pointer)', () => {
+    const { shimsDir, historyDir, realBin, link } = fixture('grok');
+    adoptShadowingLauncher('grok', { shadowedBy: link, shimsDir, historyDir });
+    // Nuke the regenerable cache (shims dir). The record is elsewhere (.history).
+    fs.rmSync(shimsDir, { recursive: true });
+    // Reverse pointer to the native binary is still intact and restorable.
+    const restored = releaseAdoptedLauncher('grok', { shimsDir, historyDir });
+    expect(restored).toBe(fs.realpathSync(realBin));
+  });
+});
+
+describe('findAdoptableLauncher', () => {
+  test('finds a ~/.local/bin symlink resolving outside the shims dir', () => {
+    const { root, shimsDir, link } = fixture('grok');
+    const found = findAdoptableLauncher('grok', { homeDir: root, shimsDir });
+    expect(found).toBe(link);
+  });
+
+  test('ignores a real binary and a broken symlink', () => {
+    const { root, shimsDir } = fixture('grok');
+    const localBin = path.join(root, '.local', 'bin');
+    // Replace the symlink with a real binary.
+    fs.rmSync(path.join(localBin, 'grok'));
+    fs.writeFileSync(path.join(localBin, 'grok'), 'native');
+    expect(findAdoptableLauncher('grok', { homeDir: root, shimsDir })).toBeNull();
+
+    // A broken symlink (target missing) must not be offered.
+    fs.rmSync(path.join(localBin, 'grok'));
+    fs.symlinkSync(path.join(root, 'does-not-exist'), path.join(localBin, 'grok'));
+    expect(findAdoptableLauncher('grok', { homeDir: root, shimsDir })).toBeNull();
+  });
+
+  test('ignores a launcher already pointing into the shims dir', () => {
+    const { root, shimsDir, shimPath } = fixture('grok');
+    const local = path.join(root, '.local', 'bin', 'grok');
+    fs.rmSync(local);
+    fs.symlinkSync(shimPath, local); // already ours
+    expect(findAdoptableLauncher('grok', { homeDir: root, shimsDir })).toBeNull();
   });
 });
 
@@ -103,24 +139,20 @@ describe('generated shim fall-through', () => {
   test('is valid bash and reads the adopted-original record by absolute path', () => {
     const script = generateShimScript('grok');
 
-    // Valid bash (catches template-literal escaping regressions).
     const f = path.join(tmp(), 'grok');
     fs.writeFileSync(f, script);
     execFileSync('bash', ['-n', f]); // throws on syntax error
 
-    // The safety net exists and is wired into failure paths.
-    expect(script).toContain('ADOPTED_ORIGINAL="$AGENTS_USER_DIR/.cache/shims/.adopted/$CLI_COMMAND"');
+    // Reads from the durable .history location, first line only.
+    expect(script).toContain('ADOPTED_ORIGINAL="$AGENTS_USER_DIR/.history/adopted-launchers/$CLI_COMMAND"');
+    expect(script).toContain('IFS= read -r orig < "$ADOPTED_ORIGINAL"');
     expect(script).toContain('exec_adopted_original');
-    // grok's last-resort binary resolution must prefer the recorded original
-    // over `command -v grok` — otherwise the adopted symlink re-enters the shim.
     expect(script).toContain('adopted_original_bin');
   });
 
   test('droid shim prefers the adopted record before its fixed ~/.local/bin path', () => {
     const script = generateShimScript('droid');
     const droidBranch = script.slice(script.indexOf('AGENT" = "droid"'));
-    // adopted_original_bin is consulted before the $HOME/.local/bin/droid path,
-    // which after adoption points back at this dispatcher.
     expect(droidBranch.indexOf('adopted_original_bin')).toBeLessThan(
       droidBranch.indexOf('$HOME/.local/bin/droid'),
     );

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -240,7 +240,7 @@ async function promptConflictStrategy(
 // v22 — export DISABLE_AUTOUPDATER=1 for claude shims so a pinned per-version
 //        install can't self-mutate: Claude Code's background auto-updater would
 //        otherwise rewrite the pinned binary in place. Explicit user value wins.
-export const SHIM_SCHEMA_VERSION = 22;
+export const SHIM_SCHEMA_VERSION = 23;
 
 /** Internal marker string used to embed the schema version in shim scripts. */
 const SHIM_VERSION_MARKER = 'agents-shim-version:';
@@ -330,6 +330,29 @@ if [ -z "$AGENTS_BIN" ] || [ ! -x "$AGENTS_BIN" ]; then
   exit 127
 fi
 
+# When agents-cli "adopts" a harness's own launcher (symlinks the native binary
+# in ~/.local/bin to this dispatcher so version management wins regardless of
+# PATH order), it records the real original at this path. It is the only safe
+# fall-through target: exec it by ABSOLUTE PATH so we never re-resolve through
+# PATH (which now points back at this dispatcher → infinite re-exec loop).
+ADOPTED_ORIGINAL="$AGENTS_USER_DIR/.cache/shims/.adopted/$CLI_COMMAND"
+# Print the recorded original binary iff it is an executable file, else nothing.
+adopted_original_bin() {
+  [ -f "$ADOPTED_ORIGINAL" ] || return 1
+  local orig
+  orig=$(cat "$ADOPTED_ORIGINAL" 2>/dev/null)
+  [ -n "$orig" ] && [ -x "$orig" ] || return 1
+  printf '%s' "$orig"
+}
+# Last-resort fall-through: if a managed version can't be resolved but we've
+# adopted this command's native launcher, run the original so the user's command
+# never breaks. Replaces the process; returns non-zero only when no usable record.
+exec_adopted_original() {
+  local orig
+  orig=$(adopted_original_bin) || return 1
+  exec "$orig" "$@"
+}
+
 # Find project agents.yaml walking up from cwd (skip $HOME/.agents/agents.yaml)
 find_project_version() {
   local dir="$PWD"
@@ -413,15 +436,20 @@ if [ -z "$VERSION" ]; then
           VERSION_SOURCE="default"
           ;;
         *)
+          exec_adopted_original "$@"
           echo "  Run: agents use $AGENT <version>" >&2
           exit 1
           ;;
       esac
     else
+      exec_adopted_original "$@"
       echo "  Run: agents use $AGENT <version>" >&2
       exit 1
     fi
   else
+    # No managed version at all. If we adopted this command's native launcher,
+    # run it so the command keeps working; otherwise report it's unconfigured.
+    exec_adopted_original "$@"
     echo "agents: no version of $AGENT configured" >&2
     echo "  Run: agents add $AGENT@<version>" >&2
     exit 1
@@ -449,16 +477,18 @@ if [ "$AGENT" = "grok" ]; then
     fi
   fi
   if [ -z "$BINARY" ] || [ ! -x "$BINARY" ]; then
-    # Last resort: whatever is on PATH (user may have installed grok globally).
-    # Refuse anything under our own shims dir: the shims dir sits ahead of
-    # ~/.local/bin on PATH, so "command -v grok" resolves to THIS dispatcher.
-    # exec-ing it would re-enter and spin in an infinite re-exec loop (the same
-    # bug the droid branch below guards against). Fall through to the clean
-    # "not installed" error instead.
-    BINARY=$(command -v grok 2>/dev/null || echo "")
-    case "$BINARY" in
-      "$AGENTS_USER_DIR/.cache/shims/"*) BINARY="" ;;
-    esac
+    # Last resort: the adopted native launcher (recorded absolute path) if we
+    # adopted grok, else whatever is on PATH. Prefer the adopted record — after
+    # adoption, "command -v grok" resolves to the ~/.local/bin symlink that now
+    # points at THIS dispatcher, so exec-ing it would re-enter and spin forever.
+    BINARY=$(adopted_original_bin || echo "")
+    if [ -z "$BINARY" ]; then
+      BINARY=$(command -v grok 2>/dev/null || echo "")
+      # Refuse anything that resolves into our own shims dir (the dispatcher).
+      case "$(command -v "$BINARY" 2>/dev/null; readlink -f "$BINARY" 2>/dev/null)" in
+        *"$AGENTS_USER_DIR/.cache/shims/"*) BINARY="" ;;
+      esac
+    fi
   fi
 # Kimi is a normal npm agent: "agents add kimi" npm-installs
 # @moonshot-ai/kimi-code into the version dir and the binary lands at
@@ -475,14 +505,20 @@ if [ "$AGENT" = "grok" ]; then
 # IS this dispatcher, so exec'ing it would re-enter and spin in an infinite
 # re-exec loop (the bug this branch fixes).
 elif [ "$AGENT" = "droid" ]; then
-  DROID_BINARY="$HOME/.local/bin/droid"
-  if [ -x "$DROID_BINARY" ]; then
-    BINARY="$DROID_BINARY"
-  else
-    BINARY=$(command -v droid 2>/dev/null || echo "")
-    case "$BINARY" in
-      "$AGENTS_USER_DIR/.cache/shims/"*) BINARY="" ;;
-    esac
+  # Prefer the adopted record first: if droid's ~/.local/bin/droid launcher was
+  # adopted, that fixed path now points at THIS dispatcher, so using it directly
+  # would infinite-loop. The record holds the real original binary.
+  BINARY=$(adopted_original_bin || echo "")
+  if [ -z "$BINARY" ]; then
+    DROID_BINARY="$HOME/.local/bin/droid"
+    if [ -x "$DROID_BINARY" ] && [ "$(readlink -f "$DROID_BINARY" 2>/dev/null)" != "$(readlink -f "$AGENTS_USER_DIR/.cache/shims/$CLI_COMMAND" 2>/dev/null)" ]; then
+      BINARY="$DROID_BINARY"
+    else
+      BINARY=$(command -v droid 2>/dev/null || echo "")
+      case "$(readlink -f "$BINARY" 2>/dev/null)" in
+        "$AGENTS_USER_DIR/.cache/shims/"*) BINARY="" ;;
+      esac
+    fi
   fi
 else
   BINARY="$VERSION_DIR/node_modules/.bin/$CLI_COMMAND"
@@ -516,6 +552,7 @@ if [ ! -x "$BINARY" ]; then
       echo "  ✔ Installed $AGENT@$VERSION" >&2
     else
       echo "  ✗ Failed to install $AGENT@$VERSION" >&2
+      exec_adopted_original "$@"
       exit 1
     fi
   else
@@ -533,15 +570,18 @@ if [ ! -x "$BINARY" ]; then
             BINARY="$VERSION_DIR/node_modules/.bin/$CLI_COMMAND"
             ;;
           *)
+            exec_adopted_original "$@"
             echo "  Run: agents add $AGENT@$VERSION" >&2
             exit 1
             ;;
         esac
       else
+        exec_adopted_original "$@"
         echo "  Run: agents add $AGENT@$VERSION" >&2
         exit 1
       fi
     else
+      exec_adopted_original "$@"
       echo "agents: $AGENT@$VERSION not installed" >&2
       echo "  Run: agents add $AGENT@$VERSION" >&2
       exit 1
@@ -1720,6 +1760,142 @@ export function removeLegacyUserShim(agent: AgentId, overrides?: { homeDir?: str
     return true;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Where the real original target of an adopted launcher is recorded. The shim
+ * reads this at ~/.agents/.cache/shims/.adopted/<cli> to fall through to the
+ * native binary by absolute path when no managed version resolves.
+ */
+export function getAdoptedRecordPath(agent: AgentId, shimsDir: string = getShimsDir()): string {
+  return path.join(shimsDir, '.adopted', AGENTS[agent].cliCommand);
+}
+
+/** Canonical path for identity comparison — realpath when it exists (resolves
+ * symlinks AND platform aliases like macOS /var → /private/var), else resolve. */
+function canonical(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return path.resolve(p);
+  }
+}
+
+export type AdoptResult =
+  | { adopted: true; launcher: string; original: string }
+  | { adopted: false; reason: 'no-shadow' | 'already-adopted' | 'not-a-symlink' | 'unsafe-target' | 'error'; launcher?: string };
+
+/**
+ * Adopt the harness's own launcher that shadows our shim on PATH.
+ *
+ * PATH-ordering fixes (editing rc files) can never reliably win: `~/.local/bin`
+ * (where grok/droid/etc. self-install) is prepended in `.zshenv`/`.zprofile`
+ * for *every* shell, while our shims prepend only lands in `.zshrc`
+ * (interactive). No single rc file guarantees "last prepend wins" across zsh's
+ * whole sourcing chain, so the shim loses in non-interactive / GUI-launched
+ * contexts. Instead of fighting PATH order, we *become* the launcher: replace
+ * the shadowing symlink with one pointing at our shim, and record the real
+ * original so the shim falls through to it when no managed version is selected.
+ *
+ * Regression bounds:
+ * - Only ever touches a **symlink** (never renames/deletes a real binary).
+ * - Records the resolved original for lossless restore (`releaseAdoptedLauncher`).
+ * - Idempotent: a no-op once the launcher already points at our shim.
+ * - Never records our own shim as the "original" (would loop).
+ */
+export function adoptShadowingLauncher(
+  agent: AgentId,
+  overrides?: { shadowedBy?: string; shimsDir?: string },
+): AdoptResult {
+  const shimsDir = overrides?.shimsDir ?? getShimsDir();
+  const shimPath = path.join(shimsDir, AGENTS[agent].cliCommand);
+  const shimReal = canonical(shimPath);
+  const shimsDirReal = canonical(shimsDir);
+  const launcher = overrides?.shadowedBy ?? getPathShadowingExecutable(agent);
+  if (!launcher) return { adopted: false, reason: 'no-shadow' };
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(launcher);
+  } catch {
+    return { adopted: false, reason: 'error', launcher };
+  }
+
+  // Only adopt symlinks. A real binary in an early-PATH dir is left untouched —
+  // renaming a multi-hundred-MB native binary is exactly the kind of surprise
+  // this feature must avoid. (Its shim stays reachable via the versioned name.)
+  if (!stat.isSymbolicLink()) {
+    return { adopted: false, reason: 'not-a-symlink', launcher };
+  }
+
+  const resolved = canonical(launcher);
+
+  // Already ours → nothing to do.
+  if (resolved === shimReal) {
+    return { adopted: false, reason: 'already-adopted', launcher };
+  }
+
+  // Never record a target that resolves back into our shims dir: exec-ing it
+  // from the shim would re-enter this dispatcher and spin forever.
+  if (resolved === shimsDirReal || resolved.startsWith(shimsDirReal + path.sep)) {
+    return { adopted: false, reason: 'unsafe-target', launcher };
+  }
+
+  try {
+    const recordPath = getAdoptedRecordPath(agent, shimsDir);
+    fs.mkdirSync(path.dirname(recordPath), { recursive: true });
+    fs.writeFileSync(recordPath, resolved, 'utf-8');
+    // Repoint the launcher at our shim. rm + symlink (not atomic rename) is fine
+    // here: the record is already written, so a crash between the two leaves a
+    // recoverable state and the next run re-adopts idempotently.
+    fs.rmSync(launcher);
+    fs.symlinkSync(shimPath, launcher);
+    return { adopted: true, launcher, original: resolved };
+  } catch {
+    return { adopted: false, reason: 'error', launcher };
+  }
+}
+
+/**
+ * Undo `adoptShadowingLauncher`: repoint the launcher back at the recorded
+ * original and drop the record. Reversible escape hatch for users who want the
+ * native launcher to win. Returns the restored original path, or null if there
+ * was nothing to release.
+ */
+export function releaseAdoptedLauncher(
+  agent: AgentId,
+  overrides?: { shadowedBy?: string; shimsDir?: string },
+): string | null {
+  const shimsDir = overrides?.shimsDir ?? getShimsDir();
+  const recordPath = getAdoptedRecordPath(agent, shimsDir);
+  let original: string;
+  try {
+    original = fs.readFileSync(recordPath, 'utf-8').trim();
+  } catch {
+    return null;
+  }
+  if (!original) return null;
+
+  const shimReal = canonical(path.join(shimsDir, AGENTS[agent].cliCommand));
+  const launcher = overrides?.shadowedBy ?? getPathShadowingExecutable(agent) ?? original;
+  try {
+    // Only rewrite the launcher if it currently points at our shim (i.e. we own
+    // it). If the user has since replaced it themselves, leave it alone.
+    let pointsAtShim = false;
+    try {
+      pointsAtShim = fs.lstatSync(launcher).isSymbolicLink()
+        && canonical(launcher) === shimReal;
+    } catch { /* launcher gone — recreate below */ }
+
+    if (pointsAtShim || !fs.existsSync(launcher)) {
+      try { fs.rmSync(launcher); } catch { /* may not exist */ }
+      fs.symlinkSync(original, launcher);
+    }
+    fs.rmSync(recordPath);
+    return original;
+  } catch {
+    return null;
   }
 }
 

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -15,7 +15,7 @@ import { fileURLToPath } from 'url';
 import { confirm, select } from '@inquirer/prompts';
 import type { AgentId } from './types.js';
 import { IS_WINDOWS, prependToWindowsUserPath } from './platform/index.js';
-import { getShimsDir, getVersionsDir, getBackupsDir, ensureAgentsDir } from './state.js';
+import { getShimsDir, getVersionsDir, getBackupsDir, getHistoryDir, ensureAgentsDir } from './state.js';
 export { getShimsDir };
 import { AGENTS, agentConfigDirName } from './agents.js';
 
@@ -332,15 +332,19 @@ fi
 
 # When agents-cli "adopts" a harness's own launcher (symlinks the native binary
 # in ~/.local/bin to this dispatcher so version management wins regardless of
-# PATH order), it records the real original at this path. It is the only safe
-# fall-through target: exec it by ABSOLUTE PATH so we never re-resolve through
-# PATH (which now points back at this dispatcher → infinite re-exec loop).
-ADOPTED_ORIGINAL="$AGENTS_USER_DIR/.cache/shims/.adopted/$CLI_COMMAND"
+# PATH order), it records the real original here. Durable (.history, not the
+# regenerable .cache) so the reverse pointer survives a cache wipe. Line 1 is
+# the original binary (what we fall through to); line 2 is the launcher path
+# (used by --release). It is the only safe fall-through target: exec it by
+# ABSOLUTE PATH so we never re-resolve through PATH (which now points back at
+# this dispatcher → infinite re-exec loop).
+ADOPTED_ORIGINAL="$AGENTS_USER_DIR/.history/adopted-launchers/$CLI_COMMAND"
 # Print the recorded original binary iff it is an executable file, else nothing.
 adopted_original_bin() {
   [ -f "$ADOPTED_ORIGINAL" ] || return 1
   local orig
-  orig=$(cat "$ADOPTED_ORIGINAL" 2>/dev/null)
+  # First line only — line 2 (launcher path) is for --release, not exec.
+  IFS= read -r orig < "$ADOPTED_ORIGINAL" 2>/dev/null || return 1
   [ -n "$orig" ] && [ -x "$orig" ] || return 1
   printf '%s' "$orig"
 }
@@ -1764,12 +1768,49 @@ export function removeLegacyUserShim(agent: AgentId, overrides?: { homeDir?: str
 }
 
 /**
- * Where the real original target of an adopted launcher is recorded. The shim
- * reads this at ~/.agents/.cache/shims/.adopted/<cli> to fall through to the
- * native binary by absolute path when no managed version resolves.
+ * Where an adopted launcher's provenance is recorded. Lives under durable
+ * `.history` (NOT the regenerable `.cache`) so the reverse pointer to the native
+ * binary survives a cache wipe — the shim reads it to fall through to the native
+ * binary by absolute path when no managed version resolves. Two lines:
+ * line 1 = original binary, line 2 = launcher path (for `--release`).
  */
-export function getAdoptedRecordPath(agent: AgentId, shimsDir: string = getShimsDir()): string {
-  return path.join(shimsDir, '.adopted', AGENTS[agent].cliCommand);
+export function getAdoptedRecordPath(agent: AgentId, historyDir: string = getHistoryDir()): string {
+  return path.join(historyDir, 'adopted-launchers', AGENTS[agent].cliCommand);
+}
+
+/**
+ * The launcher a harness's own installer drops in an early-PATH dir. Detection
+ * for adoption keys on the launcher *existing as a symlink resolving outside our
+ * shims dir* — NOT on current PATH order. That's deliberate: the shim only loses
+ * PATH races in non-interactive / GUI-launched shells, which an interactive
+ * `agents` run can't observe via its own PATH. Keying on the durable symlink lets
+ * auto-adoption fire for those users too. Returns the launcher path or null.
+ */
+export function findAdoptableLauncher(
+  agent: AgentId,
+  overrides?: { homeDir?: string; shimsDir?: string },
+): string | null {
+  const cliCommand = AGENTS[agent].cliCommand;
+  const homeDir = overrides?.homeDir ?? os.homedir();
+  const shimsDirReal = canonical(overrides?.shimsDir ?? getShimsDir());
+  // ~/.local/bin is where grok/kimi/antigravity/claude/codex/droid self-install.
+  const candidate = path.join(homeDir, '.local', 'bin', cliCommand);
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(candidate);
+  } catch {
+    return null;
+  }
+  if (!stat.isSymbolicLink()) return null; // real binaries are never auto-adopted
+  let resolved: string;
+  try {
+    resolved = fs.realpathSync(candidate); // broken symlink throws → skip
+  } catch {
+    return null;
+  }
+  // Already ours, or resolves into our shims dir → not adoptable.
+  if (resolved === shimsDirReal || resolved.startsWith(shimsDirReal + path.sep)) return null;
+  return candidate;
 }
 
 /** Canonical path for identity comparison — realpath when it exists (resolves
@@ -1800,19 +1841,21 @@ export type AdoptResult =
  *
  * Regression bounds:
  * - Only ever touches a **symlink** (never renames/deletes a real binary).
- * - Records the resolved original for lossless restore (`releaseAdoptedLauncher`).
+ * - Records the resolved original + launcher path for lossless restore
+ *   (`releaseAdoptedLauncher`), in durable `.history` so a cache wipe can't
+ *   orphan the reverse pointer.
  * - Idempotent: a no-op once the launcher already points at our shim.
  * - Never records our own shim as the "original" (would loop).
  */
 export function adoptShadowingLauncher(
   agent: AgentId,
-  overrides?: { shadowedBy?: string; shimsDir?: string },
+  overrides?: { shadowedBy?: string; shimsDir?: string; historyDir?: string },
 ): AdoptResult {
   const shimsDir = overrides?.shimsDir ?? getShimsDir();
   const shimPath = path.join(shimsDir, AGENTS[agent].cliCommand);
   const shimReal = canonical(shimPath);
   const shimsDirReal = canonical(shimsDir);
-  const launcher = overrides?.shadowedBy ?? getPathShadowingExecutable(agent);
+  const launcher = overrides?.shadowedBy ?? getPathShadowingExecutable(agent) ?? findAdoptableLauncher(agent, { shimsDir });
   if (!launcher) return { adopted: false, reason: 'no-shadow' };
 
   let stat: fs.Stats;
@@ -1843,9 +1886,13 @@ export function adoptShadowingLauncher(
   }
 
   try {
-    const recordPath = getAdoptedRecordPath(agent, shimsDir);
+    const recordPath = getAdoptedRecordPath(agent, overrides?.historyDir);
     fs.mkdirSync(path.dirname(recordPath), { recursive: true });
-    fs.writeFileSync(recordPath, resolved, 'utf-8');
+    // Line 1: original binary (shim fall-through target). Line 2: launcher path
+    // (release restores this exact symlink, independent of PATH order at release
+    // time — the M3 fix). Absolute launcher path so release never has to
+    // re-derive it from a PATH scan that may miss.
+    fs.writeFileSync(recordPath, `${resolved}\n${path.resolve(launcher)}\n`, 'utf-8');
     // Repoint the launcher at our shim. rm + symlink (not atomic rename) is fine
     // here: the record is already written, so a crash between the two leaves a
     // recoverable state and the next run re-adopts idempotently.
@@ -1865,20 +1912,25 @@ export function adoptShadowingLauncher(
  */
 export function releaseAdoptedLauncher(
   agent: AgentId,
-  overrides?: { shadowedBy?: string; shimsDir?: string },
+  overrides?: { shimsDir?: string; historyDir?: string },
 ): string | null {
   const shimsDir = overrides?.shimsDir ?? getShimsDir();
-  const recordPath = getAdoptedRecordPath(agent, shimsDir);
-  let original: string;
+  const recordPath = getAdoptedRecordPath(agent, overrides?.historyDir);
+  let lines: string[];
   try {
-    original = fs.readFileSync(recordPath, 'utf-8').trim();
+    lines = fs.readFileSync(recordPath, 'utf-8').split('\n').map((l) => l.trim());
   } catch {
     return null;
   }
+  const original = lines[0] ?? '';
   if (!original) return null;
+  // Line 2 is the exact launcher we rewrote at adopt time. Restoring it directly
+  // (rather than re-deriving from PATH) means release works regardless of the
+  // current shell's PATH order — the M3 fix. Fall back to a PATH scan only for
+  // records written before this format existed.
+  const launcher = lines[1] || getPathShadowingExecutable(agent) || original;
 
   const shimReal = canonical(path.join(shimsDir, AGENTS[agent].cliCommand));
-  const launcher = overrides?.shadowedBy ?? getPathShadowingExecutable(agent) ?? original;
   try {
     // Only rewrite the launcher if it currently points at our shim (i.e. we own
     // it). If the user has since replaced it themselves, leave it alone.


### PR DESCRIPTION
## The bug (every user, not just one)

`agents run …` kept prompting `Repair shim integration now? grok -> ~/.local/bin/grok` on every new shell, and clicking **Yes** never fixed anything.

**Root cause.** The only repair wired to that prompt is `addShimsToPath()`, which edits `~/.zshrc`. But the competing launcher dir — `~/.local/bin`, where grok / kimi / antigravity / droid self-install — is prepended in `~/.zshenv` (sourced by **every** shell) and `~/.zprofile` (login), while our shims prepend only lands in `~/.zshrc` (interactive). No single rc file can guarantee "last prepend wins" across zsh's whole sourcing chain (`.zshenv` → `.zprofile` → `.zshrc` → installers), so the shim wins only in interactive login shells and loses in every non-interactive / GUI-launched context. The prompt was therefore a **structural no-op**, and its PPID-keyed sentinel only suppressed it within a single shell — so it re-fired forever.

Evidence from the reporting machine:

| File | prepends | runs for |
|---|---|---|
| `.zshenv:14` | `~/.local/bin` | every zsh |
| `.zprofile:6` | `~/.local/bin` | login |
| `.zshrc:525` | `~/.agents/.cache/shims` | interactive only |

## The fix — stop fighting PATH order, adopt the launcher

- **`adoptShadowingLauncher()`** — when a harness's own launcher (a **symlink**) shadows our shim, repoint it at the shim and record the real original at `~/.agents/.cache/shims/.adopted/<cli>`. Ordering-independent, idempotent, **symlink-only** (never renames a real binary), reversible.
- **Shim fall-through** — when no managed version resolves, `exec` the recorded original by **absolute path** (never `command -v`, which after adoption re-enters the dispatcher and infinite-loops). The `grok`/`droid` bespoke branches now consult the record before their `command -v` / fixed-path fallbacks.
- **Preamble** auto-adopts silently for shadowed defaults; a remaining **real-binary** shadow gets an honest one-time note (no `Y/n`), and the interactive prompt is reserved for the one case `addShimsToPath` actually fixes (PATH genuinely missing).
- **Escape hatch** — `agents doctor --adopt <agent>` / `--release <agent>` (reversible restore).

Bumps `SHIM_SCHEMA_VERSION` 22 → 23 so shims regenerate.

## Regression bounds

- Only ever rewrites a **symlink**; a real native binary is left untouched (droid's `~/.local/bin/droid` is skipped).
- Records the resolved original for lossless restore; idempotent; never records our own shim as the "original".
- Shim fall-through is **strictly safer** than before: the old `exit 1` on an unresolved version now defers to the native binary when one was adopted, so no user with only a native install can be broken.

## Verification

- New `src/lib/shims.adoption.test.ts` (5 tests): symlink round-trip + record, real-binary refusal, release/restore, generated-shim `bash -n` validity + record-first ordering in the grok/droid branches.
- **End-to-end** (ran the generated shim in bash): with no managed version + an adopted record, the shim ran the native binary (`NATIVE GROK RAN: --hello`, exit 0) — **no loop**; with no record it gave a clean "no version configured" error — no hang.
- Full vitest suite: **4280 passed**. The only non-updated failures are 2 `exec.test.ts` cases that assert `AGENTS_MAILBOX_DIR`/`DISABLE_AUTOUPDATER` are unset — ambient contamination from running vitest *inside* a live agents session; both pass in a scrubbed env.

Session transcript (secret gist): omitted here — private repo, can attach on request.