### PR TITLE
fix(sessions): --active --host/--device filters to named machines, not local+named

### DIFF
--- a/src/commands/__tests__/sessions-host-filter.test.ts
+++ b/src/commands/__tests__/sessions-host-filter.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for the pure seed decision backing `agents sessions --active --host/--device`.
+ *
+ * The bug this pins: `--host X` used to be additive — it folded X in alongside
+ * the local machine instead of scoping to X. `shouldIncludeLocal` is the gate
+ * that keeps local out of the view unless no host is named (full fleet) or the
+ * local machine is itself named. Pure, so it tests without SSH or `ps`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { shouldIncludeLocal, remoteHostsToDial } from '../sessions.js';
+
+describe('shouldIncludeLocal', () => {
+  const self = 'zion';
+
+  it('includes local when no --host is given (full fleet view)', () => {
+    expect(shouldIncludeLocal(undefined, self)).toBe(true);
+    expect(shouldIncludeLocal([], self)).toBe(true);
+  });
+
+  it('drops local when --host names only other machines (the fix: filter, not add)', () => {
+    expect(shouldIncludeLocal(['yosemite-s0'], self)).toBe(false);
+    expect(shouldIncludeLocal(['yosemite-s0', 'yosemite-s1'], self)).toBe(false);
+  });
+
+  it('includes local when it is itself named among the hosts', () => {
+    expect(shouldIncludeLocal(['zion'], self)).toBe(true);
+    expect(shouldIncludeLocal(['yosemite-s0', 'zion'], self)).toBe(true);
+  });
+
+  it('matches self by normalized id — case, domain suffix, and user@host', () => {
+    expect(shouldIncludeLocal(['ZION'], self)).toBe(true);
+    expect(shouldIncludeLocal(['zion.tail1a85a1.ts.net'], self)).toBe(true);
+    expect(shouldIncludeLocal(['muqsit@zion'], self)).toBe(true);
+  });
+
+  it('does not treat a different machine as self', () => {
+    expect(shouldIncludeLocal(['muqsit@yosemite-s0'], self)).toBe(false);
+  });
+});
+
+describe('remoteHostsToDial', () => {
+  const self = 'zion';
+
+  it('returns undefined with no --host (auto-discovery sweep)', () => {
+    expect(remoteHostsToDial(undefined, self)).toBeUndefined();
+    expect(remoteHostsToDial([], self)).toBeUndefined();
+  });
+
+  it('dials exactly the named non-self hosts', () => {
+    expect(remoteHostsToDial(['yosemite-s0', 'yosemite-s1'], self)).toEqual(['yosemite-s0', 'yosemite-s1']);
+  });
+
+  it('drops self from the dial list (local seed covers it — no self-SSH, no spurious "unreachable")', () => {
+    expect(remoteHostsToDial(['zion', 'yosemite-s0'], self)).toEqual(['yosemite-s0']);
+  });
+
+  it('returns [] when the only named host is self (caller then skips the fan-out)', () => {
+    expect(remoteHostsToDial(['zion'], self)).toEqual([]);
+    expect(remoteHostsToDial(['zion.tail1a85a1.ts.net'], self)).toEqual([]);
+  });
+});

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -703,12 +703,46 @@ async function enrichLocalLocators(local: ActiveSession[]): Promise<void> {
   } catch { /* non-fatal */ }
 }
 
+/** Normalize a `--host`/`--device` token (`alias`, `user@host`, `host.domain`)
+ * to the machine id the fan-out and registry key off. */
+function hostToken(h: string): string {
+  return normalizeHost(h.split('@').pop() || h);
+}
+
 /**
- * Render the unified active-session view, grouped by machine. Local sessions
- * come from `getActiveSessions()`; unless `--local`, sessions from other
- * machines are folded in over SSH (explicit `--host` targets, else the
- * registered online devices from `ag devices`). A tip is shown when there are
- * no other machines to include.
+ * Whether the local machine's sessions belong in an `--active` view. Local is
+ * included by default; an explicit `--host`/`--device` list scopes the view to
+ * exactly those machines, so local is dropped unless it is itself named (by
+ * alias or `user@host`, matched on the normalized machine id). Exported for
+ * unit testing without touching SSH or the live process table.
+ */
+export function shouldIncludeLocal(hosts: string[] | undefined, self: string): boolean {
+  if (!hosts || hosts.length === 0) return true;
+  return hosts.some(h => hostToken(h) === self);
+}
+
+/**
+ * The peers to dial for an `--active` view. No `--host` → `undefined`, which
+ * tells `gatherRemoteActive` to sweep the registered online devices. An
+ * explicit list → exactly those, minus this machine (its sessions come from the
+ * local seed, so dialing self would be a wasted SSH and a spurious "unreachable"
+ * note). Returns `[]` when the only named host is self — the caller then skips
+ * the remote fan-out entirely rather than letting `[]` trigger the sweep.
+ * Exported for unit testing.
+ */
+export function remoteHostsToDial(hosts: string[] | undefined, self: string): string[] | undefined {
+  if (!hosts || hosts.length === 0) return undefined;
+  return hosts.filter(h => hostToken(h) !== self);
+}
+
+/**
+ * Render the unified active-session view, grouped by machine. With no `--host`,
+ * local sessions come from `getActiveSessions()` and (unless `--local`) the
+ * registered online devices from `ag devices` are folded in over SSH. An
+ * explicit `--host`/`--device` list SCOPES the view to exactly those machines —
+ * the local machine is included only when it is itself named — so `--host` is a
+ * filter, not an addition (matching the non-`--active` listing path). A tip is
+ * shown when there are no other machines to include.
  */
 async function renderActiveSessions(
   asJson: boolean,
@@ -716,15 +750,22 @@ async function renderActiveSessions(
   opts: { local?: boolean; hosts?: string[] } = {},
 ): Promise<void> {
   const self = machineId();
-  const local = await getActiveSessions();
+  // An explicit --host/--device list scopes the view: seed local sessions only
+  // when no hosts are named, or when this machine is one of the named targets.
+  const local = shouldIncludeLocal(opts.hosts, self) ? await getActiveSessions() : [];
   for (const s of local) if (!s.machine) s.machine = self;
 
   let remoteDeviceCount = 0;
   let merged = local;
   if (!opts.local) {
-    const remote = await gatherRemoteActive(opts.hosts);
-    remoteDeviceCount = remote.deviceCount;
-    merged = dedupeByMachineSession([...local, ...remote.sessions]);
+    const remoteHosts = remoteHostsToDial(opts.hosts, self);
+    // An explicit list naming only self leaves nothing remote to dial — skip the
+    // fan-out rather than let an empty list fall through to the device sweep.
+    if (!opts.hosts?.length || (remoteHosts && remoteHosts.length > 0)) {
+      const remote = await gatherRemoteActive(remoteHosts);
+      remoteDeviceCount = remote.deviceCount;
+      merged = dedupeByMachineSession([...local, ...remote.sessions]);
+    }
   }
 
   // --waiting: only sessions blocked on the user. Exits non-zero when any are


### PR DESCRIPTION
Closes RUSH-1491.

## Problem

`agents sessions --active --host <name>` was **additive** — it folded the named host in *alongside* the local machine instead of scoping to it. `--host yosemite-s0` showed **zion + yosemite-s0**, never just yosemite-s0. `renderActiveSessions` always seeded the merged set with `getActiveSessions()` (local) and `--host` only *added* remote peers, so it could never exclude local.

This also made `--active` inconsistent with the non-`--active` listing path, which already filters (`runRemoteSessions` returns early with no local seed).

## Fix

An explicit `--host`/`--device` list now **scopes** the view to exactly those machines. Local is included only when this machine is itself named. Two pure, unit-tested helpers carry the decision:

- `shouldIncludeLocal(hosts, self)` — seed local only when no host is named, or self is among them.
- `remoteHostsToDial(hosts, self)` — dial exactly the named non-self hosts; `undefined` (no `--host`) keeps the auto-discovery sweep; drops self so it isn't SSH'd to itself.

## Behavior (verified E2E against the live fleet)

| Command | Result |
|---|---|
| `--active` (bare) | full fleet — zion + yosemite-s0 + yosemite-s1 (unchanged) |
| `--active --host yosemite-s0` | **only** yosemite-s0 ("across 1 machine") |
| `--active --device yosemite-s1` | **only** yosemite-s1 (alias flag) |
| `--active --host zion` (self) | only zion — **no** spurious "unreachable" self-SSH |
| `--active --host yosemite-s0 --host zion` | zion + yosemite-s0 (both, self via local seed) |

## Tests

- New `src/commands/__tests__/sessions-host-filter.test.ts` — 9 cases pinning both helpers (filter, self-named, case/domain/`user@host` normalization, self-drop, empty-after-self-drop).
- Full sessions + session-lib suites: 522 passed, no regressions. Typecheck clean.

Builds on #699 (registry-backed `--host` resolution). Together they close out the `--host` semantics: consistent resolution **and** consistent filtering.

Session transcript (secret gist): zion:/Users/muqsit/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/f3c10255-160f-4b2e-94dc-f6ee6b13ee81.jsonl