### PR TITLE
fix(shims): don't re-flag an adopted launcher as a PATH shadow

### DIFF
--- a/src/lib/shims.adoption.test.ts
+++ b/src/lib/shims.adoption.test.ts
@@ -8,6 +8,7 @@ import {
   releaseAdoptedLauncher,
   findAdoptableLauncher,
   getAdoptedRecordPath,
+  getPathShadowingExecutable,
   generateShimScript,
 } from './shims.js';
 
@@ -132,6 +133,38 @@ describe('findAdoptableLauncher', () => {
     fs.rmSync(local);
     fs.symlinkSync(shimPath, local); // already ours
     expect(findAdoptableLauncher('grok', { homeDir: root, shimsDir })).toBeNull();
+  });
+});
+
+describe('getPathShadowingExecutable — adopted launcher is NOT a shadow', () => {
+  test('a symlink resolving to our shim is not reported as a shadow', () => {
+    const { shimsDir, shimPath, link } = fixture('grok');
+    // Adopt: repoint the ~/.local/bin launcher at our shim.
+    adoptShadowingLauncher('grok', {
+      shadowedBy: link,
+      shimsDir,
+      historyDir: path.join(path.dirname(shimsDir), '.history'),
+    });
+    // link now → shim, and sits AHEAD of the shims dir on PATH.
+    const shadow = getPathShadowingExecutable('grok', {
+      pathDirs: [path.dirname(link), shimsDir],
+      shimPath,
+    });
+    expect(shadow).toBeNull(); // was `link` before the fix — the false "native binary" note
+  });
+
+  test('a real competing binary ahead of the shim IS still a shadow', () => {
+    const { shimsDir, shimPath, root } = fixture('grok');
+    const otherDir = path.join(root, 'other', 'bin');
+    fs.mkdirSync(otherDir, { recursive: true });
+    const realGrok = path.join(otherDir, 'grok');
+    fs.writeFileSync(realGrok, '#!/bin/bash\necho other\n');
+    fs.chmodSync(realGrok, 0o755);
+    const shadow = getPathShadowingExecutable('grok', {
+      pathDirs: [otherDir, shimsDir],
+      shimPath,
+    });
+    expect(shadow).toBe(realGrok);
   });
 });
 

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -1711,12 +1711,20 @@ export function getShimPath(agent: AgentId): string {
  * loop because addShimsToPath() only edits the rc file, never the legacy
  * shim file itself.
  */
-export function getPathShadowingExecutable(agent: AgentId): string | null {
-  const pathDirs = (process.env.PATH || '').split(path.delimiter).filter(Boolean);
-  const shimPath = path.resolve(getShimPath(agent));
+export function getPathShadowingExecutable(
+  agent: AgentId,
+  overrides?: { pathDirs?: string[]; shimPath?: string },
+): string | null {
+  const pathDirs = overrides?.pathDirs ?? (process.env.PATH || '').split(path.delimiter).filter(Boolean);
+  const shimPath = path.resolve(overrides?.shimPath ?? getShimPath(agent));
   const cliCommand = AGENTS[agent].cliCommand;
   const legacyUserShim = path.resolve(path.join(os.homedir(), '.agents', 'shims', cliCommand));
   const managedShimExists = fs.existsSync(shimPath);
+
+  // The shim's own realpath — an adopted launcher is a symlink at a DIFFERENT
+  // path that resolves here, so identity must be by resolved target, not the
+  // literal path string.
+  const shimReal = managedShimExists ? canonicalOrNull(shimPath) : null;
 
   for (const dir of pathDirs) {
     const candidate = path.resolve(dir, cliCommand);
@@ -1724,6 +1732,11 @@ export function getPathShadowingExecutable(agent: AgentId): string | null {
       continue;
     }
     if (candidate === shimPath) return null;
+    // Adopted launcher: a symlink we repointed at our shim. Its path differs
+    // from shimPath but it resolves to the same file, so it is NOT a shadow —
+    // otherwise every adopted default would be re-flagged forever, resurfacing
+    // the false "runs a native binary" note this whole feature set out to kill.
+    if (shimReal && canonicalOrNull(candidate) === shimReal) return null;
     if (candidate === legacyUserShim && managedShimExists) {
       // Legacy file from the pre-split layout. Don't treat as shadow — the
       // repair flow deletes it via removeLegacyUserShim instead. Continue
@@ -1820,6 +1833,16 @@ function canonical(p: string): string {
     return fs.realpathSync(p);
   } catch {
     return path.resolve(p);
+  }
+}
+
+/** Like canonical(), but null when the path can't be resolved (broken/racy
+ * symlink) — used where a failed resolve must NOT collapse to the input path. */
+function canonicalOrNull(p: string): string | null {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return null;
   }
 }
 


### PR DESCRIPTION
## Follow-up to #702 — a false warning shipped in 1.20.38

Real-machine testing surfaced a bug in the launcher-adoption feature that is **live in 1.20.38 on npm**.

`getPathShadowingExecutable` decided "is this command shadowed?" by comparing **literal paths** (`candidate === shimPath`). But an *adopted* launcher is a symlink at `~/.local/bin/<cli>` that we repointed at our shim — its path differs from the shim path even though it resolves to the same file. So after auto-adoption, the run preamble recomputed `shadowed`, saw the adopted symlink, and printed a **false** one-time-per-shell note:

> These agent commands run a native binary instead of the version-managed shim:
>   grok: ~/.local/bin/grok

That's wrong — `~/.local/bin/grok` *is* the shim (via the adopted symlink). It resurfaces exactly the false-warning annoyance the adoption feature set out to kill. Not a loop (sentinel-guarded, idempotent), but wrong and confusing.

## Fix

Identity by **resolved target**, not path string: a candidate whose `realpath` equals the shim's `realpath` is our own (adopted) launcher → not a shadow → `return null`. A real competing binary still resolves to itself and is still detected. Adds a null-returning `canonicalOrNull()` so a broken/racy symlink can't collapse to the input path.

## Tests

Two regression tests in `shims.adoption.test.ts`:
- an adopted symlink ahead of the shims dir on PATH → **not** a shadow (was `~/.local/bin/grok` before the fix);
- a real competing binary ahead of the shim → **still** a shadow.

Full shim/doctor suites pass (`getPathShadowingExecutable` gains test-only `{pathDirs, shimPath}` overrides).

## Ship

This warrants a patch release (1.20.39) since the false note is live in 1.20.38.