### PR TITLE
chore(release): 1.20.39

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phnx-labs/agents-cli",
-  "version": "1.20.38",
+  "version": "1.20.39",
   "description": "One CLI for all your AI coding agents - versions, config, cloud dispatch, sessions, and teams (now with first-class Grok Build CLI support)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release 1.20.39. Bumps `package.json`; merging + pushing the `v1.20.39` tag triggers the CI publish job (`npm publish --provenance`).

Ships everything merged since v1.20.38:
- **#704** `fix(sessions): --active --host/--device filters to named machines, not local+named` (closes RUSH-1491) — `--host`/`--device` now scope the active view instead of adding to local.
- `fix(shims): don't re-flag an adopted launcher as a PATH shadow`

(#699, the registry-backed `--host` resolution, already shipped in 1.20.38.)

Regression gate (run against origin/main HEAD in a clean env before the bump):
- typecheck clean (`tsc --noEmit`, 0 errors)
- build ok (`npm run build`)
- full suite: **4311 passed, 0 failed** (4 files / 67 skipped)
- CI on main HEAD: green (node 22 + 24)