### PR TITLE
feat(sessions): make session sync an opt-in beta feature (off by default) [RUSH-1492]

### DIFF
--- a/src/commands/__tests__/beta.test.ts
+++ b/src/commands/__tests__/beta.test.ts
@@ -104,4 +104,28 @@ describe('agents beta', () => {
     expect(factory.status).toBe(1);
     expect(outputOf(factory)).toContain('FACTORY_FLOOR_URL is not set.');
   });
+
+  it('gates session sync behind the session-sync beta feature (off by default)', () => {
+    const home = makeTempHome();
+    writeUpdateCache(home);
+
+    // Fresh home: not opted in -> status is disabled and hints the beta enable.
+    const before = runAgents(['sessions', 'sync', '--status'], home);
+    expect(before.status).toBe(0);
+    expect(outputOf(before)).toContain('disabled');
+    expect(outputOf(before)).toContain('agents beta enable session-sync');
+
+    // --enable delegates to the beta framework (single source of truth).
+    const enable = runAgents(['sessions', 'sync', '--enable'], home);
+    expect(enable.status).toBe(0);
+    expect(fs.readFileSync(path.join(home, '.agents', 'agents.yaml'), 'utf-8')).toContain('- session-sync');
+
+    const after = runAgents(['sessions', 'sync', '--status'], home);
+    expect(outputOf(after)).toContain('enabled (beta)');
+
+    // --disable removes it again — no parallel switch left behind.
+    const disable = runAgents(['sessions', 'sync', '--disable'], home);
+    expect(disable.status).toBe(0);
+    expect(fs.readFileSync(path.join(home, '.agents', 'agents.yaml'), 'utf-8')).not.toContain('- session-sync');
+  });
 });

--- a/src/commands/beta.ts
+++ b/src/commands/beta.ts
@@ -11,6 +11,7 @@ import type { BetaFeatureName } from '../lib/types.js';
 const BETA_DESCRIPTIONS: Record<BetaFeatureName, string> = {
   drive: 'Google Drive integration for reading and writing files',
   factory: 'Cloud-based agent dispatch via Rush Factory',
+  'session-sync': 'Cross-machine session transcript sync via R2 (daemon push/pull)',
 };
 
 function parseFeatures(values: string[]): BetaFeatureName[] {

--- a/src/commands/sessions-sync.ts
+++ b/src/commands/sessions-sync.ts
@@ -7,13 +7,12 @@
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import { setHelpSections } from '../lib/help.js';
-import {
-  isSyncConfigured,
-  isSyncEnabled,
-  setSyncEnabled,
-  SYNC_BUNDLE,
-} from '../lib/session/sync/config.js';
+import { isSyncConfigured, SYNC_BUNDLE } from '../lib/session/sync/config.js';
+import { isBetaEnabled, setBetaEnabled, betaEnableHint } from '../lib/beta.js';
 import { syncSessions } from '../lib/session/sync/sync.js';
+
+/** The daemon's automatic session sync is gated by this beta feature. */
+const SYNC_BETA = 'session-sync' as const;
 
 interface SyncCmdOptions {
   verbose?: boolean;
@@ -24,31 +23,37 @@ interface SyncCmdOptions {
 }
 
 export async function runSessionsSync(options: SyncCmdOptions): Promise<void> {
-  // Toggle / status actions short-circuit before any network cycle.
+  // Toggle / status delegate to the `session-sync` beta feature — the single
+  // source of truth for whether the daemon auto-syncs (opt-in, off by default).
+  // These short-circuit before any network cycle.
   if (options.disable) {
-    setSyncEnabled(false);
+    setBetaEnabled([SYNC_BETA], false);
     console.log(
       chalk.yellow('Automatic session sync disabled') +
-      chalk.dim(' — the daemon stops pushing/pulling within ~90s. Re-enable: agents sessions sync --enable'),
+      chalk.dim(' — the daemon stops pushing/pulling within ~90s. (Same as: agents beta disable session-sync)'),
     );
     return;
   }
   if (options.enable) {
-    setSyncEnabled(true);
-    console.log(chalk.green('Automatic session sync enabled') + chalk.dim(' — the daemon resumes on its next cycle.'));
+    setBetaEnabled([SYNC_BETA], true);
+    console.log(
+      chalk.green('Automatic session sync enabled') +
+      chalk.dim(' — the daemon resumes on its next cycle. (Same as: agents beta enable session-sync)'),
+    );
     return;
   }
   if (options.status) {
-    const enabled = isSyncEnabled();
+    const enabled = isBetaEnabled(SYNC_BETA);
     const configured = isSyncConfigured();
     if (options.json) {
       console.log(JSON.stringify({ enabled, configured }, null, 2));
     } else {
       console.log(
-        `automatic sync: ${enabled ? chalk.green('enabled') : chalk.yellow('disabled')}` +
+        `automatic sync: ${enabled ? chalk.green('enabled (beta)') : chalk.yellow('disabled')}` +
         chalk.dim('  ·  ') +
         `credentials: ${configured ? chalk.green('configured') : chalk.yellow(`missing (${SYNC_BUNDLE})`)}`,
       );
+      if (!enabled) console.log(chalk.dim(`  ${betaEnableHint(SYNC_BETA)}`));
     }
     return;
   }
@@ -102,9 +107,9 @@ export function registerSessionsSyncCommand(sessionsCmd: Command): void {
     .description('Sync session transcripts across machines via R2 (CRDT merge). Claude and Codex.')
     .option('-v, --verbose', 'Log each pushed and pulled session')
     .option('--json', 'Output the sync result as JSON')
-    .option('--enable', 'Turn ON automatic background sync on this machine (persisted)')
-    .option('--disable', 'Turn OFF automatic background sync on this machine (persisted)')
-    .option('--status', 'Show whether automatic sync is enabled and configured');
+    .option('--enable', 'Opt in to automatic background sync (beta; alias for: agents beta enable session-sync)')
+    .option('--disable', 'Opt out of automatic background sync (alias for: agents beta disable session-sync)')
+    .option('--status', 'Show whether automatic sync is opted-in (beta) and configured');
 
   setHelpSections(syncCmd, {
     examples: `
@@ -123,11 +128,11 @@ export function registerSessionsSyncCommand(sessionsCmd: Command): void {
     notes: `
       - Credentials come from the '${SYNC_BUNDLE}' secrets bundle (R2 S3 API, read+write).
       - Each machine writes only its own prefix; conflicts are impossible by construction.
-      - The daemon runs this automatically (~90s); this command forces an immediate cycle.
       - Sessions present locally always win; synced-in copies fill in other machines' sessions.
-      - --disable/--enable persist a machine-local switch (~/.agents/.history) that gates the
-        daemon's automatic sync; a bare 'agents sessions sync' still forces a manual cycle.
-        The AGENTS_SESSIONS_SYNC env var (on/off) overrides the switch for one invocation.
+      - Automatic background sync is an opt-in BETA feature, OFF by default. The daemon only
+        syncs (~90s) once you opt in via 'agents beta enable session-sync' (or the --enable
+        alias here). A bare 'agents sessions sync' always forces a manual one-shot cycle
+        regardless of the beta opt-in.
     `,
   });
 

--- a/src/lib/beta.ts
+++ b/src/lib/beta.ts
@@ -13,7 +13,7 @@ import type { BetaFeatureName, Manifest, Meta } from './types.js';
 import { getAgentsDir, getOptionalUserAgentsDir, readMeta, writeMeta } from './state.js';
 import { readManifest, writeManifest } from './manifest.js';
 
-export const ALL_BETA_FEATURES = ['drive', 'factory'] as const satisfies readonly BetaFeatureName[];
+export const ALL_BETA_FEATURES = ['drive', 'factory', 'session-sync'] as const satisfies readonly BetaFeatureName[];
 
 function isBetaFeatureName(value: unknown): value is BetaFeatureName {
   return typeof value === 'string' && ALL_BETA_FEATURES.includes(value as BetaFeatureName);

--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -340,10 +340,13 @@ export async function runDaemon(): Promise<void> {
     if (syncing) return;
     syncing = true;
     try {
-      const { isSyncConfigured, isSyncEnabled } = await import('./session/sync/config.js');
-      // isSyncEnabled() first: a machine the operator turned off must skip the
-      // keychain read entirely, not just the network cycle.
-      if (!isSyncEnabled() || !isSyncConfigured()) return;
+      const { isBetaEnabled } = await import('./beta.js');
+      // Off by default: session sync is an opt-in beta feature. Check the beta
+      // flag FIRST so a machine that hasn't opted in skips the keychain read
+      // (isSyncConfigured) entirely, not just the network cycle.
+      if (!isBetaEnabled('session-sync')) return;
+      const { isSyncConfigured } = await import('./session/sync/config.js');
+      if (!isSyncConfigured()) return;
       const { syncSessions } = await import('./session/sync/sync.js');
       const r = await syncSessions();
       if (r.pushed || r.pulled || r.errors.length) {

--- a/src/lib/session/sync/config.test.ts
+++ b/src/lib/session/sync/config.test.ts
@@ -1,17 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-
-// Redirect the durable enable-flag home to a temp dir for the enable-switch
-// tests. Every other state.ts export stays real; the secrets path used by the
-// R2-cache tests below never calls getHistoryDir, so it is unaffected.
-const hist = vi.hoisted(() => ({ dir: '' }));
-vi.mock('../../state.js', async (importActual) => {
-  const actual = await importActual<typeof import('../../state.js')>();
-  return { ...actual, getHistoryDir: () => hist.dir };
-});
-
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { setKeychainBackendForTest, type KeychainBackend } from '../../secrets/index.js';
 import { writeBundle, type SecretsBundle } from '../../secrets/bundles.js';
 import {
@@ -20,10 +7,6 @@ import {
   clearR2ConfigCache,
   RESOLVE_RETRY_COOLDOWN_MS,
   SYNC_BUNDLE,
-  isSyncEnabled,
-  setSyncEnabled,
-  syncStateFilePath,
-  SYNC_ENABLED_ENV,
 } from './config.js';
 
 /**
@@ -142,61 +125,5 @@ describe('R2 config resolution cache', () => {
     // absent path does not back off, so the very next check resolves
     expect(isSyncConfigured(t0 + 1)).toBe(true);
     expect(loadR2Config().bucket).toBe('agents-sessions');
-  });
-});
-
-describe('session sync enable switch', () => {
-  let savedEnv: string | undefined;
-
-  beforeEach(() => {
-    hist.dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sync-toggle-'));
-    savedEnv = process.env[SYNC_ENABLED_ENV];
-    delete process.env[SYNC_ENABLED_ENV];
-  });
-
-  afterEach(() => {
-    if (savedEnv === undefined) delete process.env[SYNC_ENABLED_ENV];
-    else process.env[SYNC_ENABLED_ENV] = savedEnv;
-    fs.rmSync(hist.dir, { recursive: true, force: true });
-  });
-
-  it('defaults to enabled when no flag file and no env', () => {
-    expect(fs.existsSync(syncStateFilePath())).toBe(false);
-    expect(isSyncEnabled()).toBe(true);
-  });
-
-  it('persists disabled and reads it back across calls', () => {
-    setSyncEnabled(false);
-    expect(fs.existsSync(syncStateFilePath())).toBe(true);
-    expect(isSyncEnabled()).toBe(false);
-    setSyncEnabled(true);
-    expect(isSyncEnabled()).toBe(true);
-  });
-
-  it('env off overrides an enabled flag file', () => {
-    setSyncEnabled(true);
-    process.env[SYNC_ENABLED_ENV] = 'off';
-    expect(isSyncEnabled()).toBe(false);
-  });
-
-  it('env on overrides a disabled flag file', () => {
-    setSyncEnabled(false);
-    process.env[SYNC_ENABLED_ENV] = 'true';
-    expect(isSyncEnabled()).toBe(true);
-  });
-
-  it('an unrecognized env value falls through to the persisted flag', () => {
-    setSyncEnabled(false);
-    process.env[SYNC_ENABLED_ENV] = 'maybe';
-    expect(isSyncEnabled()).toBe(false);
-  });
-
-  it('a malformed flag file falls back to the enabled default (no silent lockout)', () => {
-    fs.writeFileSync(syncStateFilePath(), 'not json', 'utf-8');
-    expect(isSyncEnabled()).toBe(true);
-  });
-
-  it('stores the flag in the durable history tree, not cache', () => {
-    expect(syncStateFilePath()).toBe(path.join(hist.dir, 'sessions-sync.json'));
   });
 });

--- a/src/lib/session/sync/config.ts
+++ b/src/lib/session/sync/config.ts
@@ -4,68 +4,15 @@
  * bundle (OS keychain on macOS, libsecret on Linux) — never from env or disk.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
 import { readAndResolveBundleEnv } from '../../secrets/bundles.js';
-import { getHistoryDir } from '../../state.js';
 
 /** Secrets bundle holding the R2 credentials. */
 export const SYNC_BUNDLE = 'r2.backups';
 
-// ── Enable / disable switch ─────────────────────────────────────────────────
-// Whether the daemon's automatic cross-machine sync (and `agents sync
-// --sessions`) may run on THIS machine. Independent of credential presence
-// (isSyncConfigured): a machine can hold valid R2 creds yet still opt out of the
-// background push/pull — e.g. when on-demand `agents sessions --host` is
-// preferred over the ad-hoc R2 mirror. Manual `agents sessions sync` is an
-// explicit user action and is deliberately NOT gated by this switch.
-//
-// Resolution order: the AGENTS_SESSIONS_SYNC env var (a recognized on/off value
-// wins outright, for ad-hoc overrides and tests), then a durable machine-local
-// flag file, then the default (enabled). The flag lives in the durable
-// ~/.agents/.history tree — NOT .cache — so a cache wipe can never silently
-// re-enable a sync the operator turned off.
-
-/** Env var that overrides the persisted enable flag (on/off/true/false/1/0/yes/no). */
-export const SYNC_ENABLED_ENV = 'AGENTS_SESSIONS_SYNC';
-
-const SYNC_ENABLED_FILE = 'sessions-sync.json';
-const OFF_VALUES = new Set(['0', 'off', 'false', 'no', 'disabled']);
-const ON_VALUES = new Set(['1', 'on', 'true', 'yes', 'enabled']);
-
-/** Durable, machine-local path holding the sync enable flag. */
-export function syncStateFilePath(): string {
-  return path.join(getHistoryDir(), SYNC_ENABLED_FILE);
-}
-
-/**
- * Whether automatic session sync is enabled on this machine. Defaults to true;
- * an unrecognized env value falls through to the file; an absent/unreadable file
- * falls through to the default. Read fresh every call (no memoization) so a
- * `--disable` takes effect on the daemon's next ~90s cycle without a restart.
- */
-export function isSyncEnabled(): boolean {
-  const envRaw = process.env[SYNC_ENABLED_ENV]?.trim().toLowerCase();
-  if (envRaw) {
-    if (OFF_VALUES.has(envRaw)) return false;
-    if (ON_VALUES.has(envRaw)) return true;
-    // Unrecognized value: ignore and consult the persisted flag.
-  }
-  try {
-    const parsed = JSON.parse(fs.readFileSync(syncStateFilePath(), 'utf-8'));
-    if (parsed && typeof parsed.enabled === 'boolean') return parsed.enabled;
-  } catch {
-    // Absent or unreadable → default enabled.
-  }
-  return true;
-}
-
-/** Persist the machine-local sync enable flag (durable across cache wipes). */
-export function setSyncEnabled(enabled: boolean): void {
-  const p = syncStateFilePath();
-  fs.mkdirSync(path.dirname(p), { recursive: true });
-  fs.writeFileSync(p, JSON.stringify({ enabled }, null, 2) + '\n', 'utf-8');
-}
+// Whether the daemon runs automatic cross-machine sync is gated by the
+// `session-sync` beta feature (opt-in, off by default) — see isBetaEnabled()
+// in ../../beta.ts and the gates in daemon.ts / sync-umbrella.ts. This module
+// only owns credential resolution (isSyncConfigured), not the on/off switch.
 
 export interface R2Config {
   accountId: string;

--- a/src/lib/sync-umbrella.ts
+++ b/src/lib/sync-umbrella.ts
@@ -149,10 +149,12 @@ export async function runUmbrellaSync(args: RunUmbrellaArgs): Promise<UmbrellaRe
   }
 
   if (plan.fetchSessions) {
-    // Gate exactly like the daemon: an off switch or a missing r2.backups bundle
-    // is a clean no-op, not an error that fails the whole sync.
-    const { isSyncConfigured, isSyncEnabled } = await import('./session/sync/config.js');
-    if (isSyncEnabled() && isSyncConfigured()) {
+    // Gate exactly like the daemon: without the `session-sync` beta opt-in (or
+    // with a missing r2.backups bundle) this is a clean no-op, not an error that
+    // fails the whole sync.
+    const { isBetaEnabled } = await import('./beta.js');
+    const { isSyncConfigured } = await import('./session/sync/config.js');
+    if (isBetaEnabled('session-sync') && isSyncConfigured()) {
       const { syncSessions } = await import('./session/sync/sync.js');
       const r = await syncSessions();
       result.sessions = { ran: true, pushed: r.pushed, pulled: r.pulled, merged: r.merged };

--- a/src/lib/sync-umbrella.ts
+++ b/src/lib/sync-umbrella.ts
@@ -13,7 +13,7 @@
  *   secrets  -> listRemoteBundles + pullBundle (needs a passphrase; skipped
  *               cleanly when none is available — tokenized non-interactive auth
  *               arrives with `agents login`, #366/#367)
- *   sessions -> syncSessions(), gated by isSyncConfigured() exactly like the daemon
+ *   sessions -> syncSessions(), gated by the session-sync beta opt-in + isSyncConfigured(), like the daemon
  *   reconcile-> refresh({ skipPrompts }) — re-materialize resources into homes
  */
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -70,7 +70,7 @@ export interface BudgetConfig {
 }
 
 /** Preview features that users can opt into via `agents beta`. */
-export type BetaFeatureName = 'drive' | 'factory';
+export type BetaFeatureName = 'drive' | 'factory' | 'session-sync';
 
 /** Subset of chalk color names used for agent-specific terminal output. */
 export type ChalkColor = 'magenta' | 'green' | 'blue' | 'cyan' | 'yellowBright' | 'redBright' | 'whiteBright' | 'blueBright' | 'greenBright' | 'magentaBright' | 'cyanBright';


### PR DESCRIPTION
Closes RUSH-1492.

## Why

Cross-machine R2 session sync shipped in **1.20.37** (#697) as *on-by-default* with a bespoke `agents sessions sync --enable/--disable` switch. Per RUSH-1492 it should instead be an **opt-in beta feature, off by default**, using the existing `agents beta` framework — and the interim switch should be retired so there's **one mechanism, not two**.

## What changed

- **`types.ts` / `beta.ts`**: add `'session-sync'` to `BetaFeatureName` + `ALL_BETA_FEATURES`.
- **`daemon.ts` + `sync-umbrella.ts`**: gate automatic sync on `isBetaEnabled('session-sync')`, checked **first** — a machine that hasn't opted in skips the `r2.backups` keychain read entirely (also kills the over-SSH `--status` hang path for the daemon).
- **`config.ts`**: delete the bespoke `isSyncEnabled`/`setSyncEnabled` + `~/.agents/.history/sessions-sync.json` flag + `AGENTS_SESSIONS_SYNC` env. `config.ts` now owns only credential resolution.
- **`sessions sync --enable/--disable/--status`**: delegate to the beta framework (`setBetaEnabled`/`isBetaEnabled`). `--status` hints `agents beta enable session-sync` when off. A bare `agents sessions sync` still forces a manual one-shot cycle regardless of opt-in.
- **Tests**: drop the obsolete switch tests; add an end-to-end beta test (spawns the real CLI) proving default-off, `--enable` writing `agents.yaml` beta, and `--disable` removing it.

## Migration note

Machines relying on default-on sync will **stop** until they run `agents beta enable session-sync`. That is the intended opt-in behavior (and matches the fleet-wide disable already applied this cycle).

## Evidence (real binary, throwaway HOME)

```
$ agents sessions sync --status
automatic sync: disabled  ·  credentials: missing (r2.backups)
  Enable it with: agents beta enable session-sync
$ agents sessions sync --enable          # -> writes agents.yaml
beta:
  enabled:
    - session-sync
$ agents sessions sync --status
automatic sync: enabled (beta)  ·  credentials: missing (r2.backups)
$ agents sessions sync --disable         # -> beta section removed
$ agents beta list
  session-sync disabled
```

Tests: `config.test.ts` + `beta.test.ts` → 10 passed. `tsc --noEmit` clean.

## Session

zion:/Users/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/3365d23d-3ac6-4da1-a8c2-04f90a87f699.jsonl