### PR TITLE
feat(hosts): --device as a first-class alias of --host for all host-routable commands

### DIFF
--- a/src/lib/hosts/option.test.ts
+++ b/src/lib/hosts/option.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { Command } from 'commander';
+import { addHostOption } from './option.js';
+
+/**
+ * `--device` is an alias of `--host` consumed pre-parse by maybeRunOnHost for a
+ * REMOTE target. But the self-machine fall-through (maybeRunOnHost returns
+ * false) hands the flag to commander, so the flag MUST be registered here or a
+ * local `--device <this-machine>` errors with "unknown option". maybeRunOnHost's
+ * own unit tests can't catch that — they return before commander parses — so the
+ * guard lives at this layer.
+ */
+describe('addHostOption', () => {
+  function build(): Command {
+    return addHostOption(new Command('view')).exitOverride();
+  }
+
+  it('registers --device so a local fall-through does not error on the alias', () => {
+    const cmd = build();
+    expect(() => cmd.parse(['--device', 'mybox'], { from: 'user' })).not.toThrow();
+    expect(cmd.opts().device).toBe('mybox');
+  });
+
+  it('keeps --host and its family (-H/--remote-cwd/--any) working', () => {
+    const cmd = build();
+    expect(() => cmd.parse(['-H', 'mac', '--remote-cwd', '/srv', '--any'], { from: 'user' })).not.toThrow();
+    const o = cmd.opts();
+    expect(o.host).toBe('mac');
+    expect(o.remoteCwd).toBe('/srv');
+    expect(o.any).toBe(true);
+  });
+});

--- a/src/lib/hosts/option.ts
+++ b/src/lib/hosts/option.ts
@@ -19,6 +19,7 @@ export function addHostOption(cmd: Command): Command {
       '-H, --host <name>',
       'Run this command on another machine over SSH instead of locally — a device, a registered host, or user@host. See `agents devices` / `agents hosts`.',
     )
+    .option('--device <name>', 'Alias of --host: run this command on a registered device (from `agents devices`).')
     .option('--remote-cwd <dir>', 'Working directory on the host for --host runs.')
     .option('--no-tty', 'Force non-interactive output for --host runs even from a terminal.')
     .option('--any', 'With --host <cap> (a capability tag), pick any matching host instead of erroring when several match.');

--- a/src/lib/hosts/passthrough.test.ts
+++ b/src/lib/hosts/passthrough.test.ts
@@ -34,11 +34,31 @@ describe('maybeRunOnHost — local short-circuits (no SSH attempted)', () => {
     expect(await maybeRunOnHost('view', ['view', 'claude'])).toBe(false);
   });
 
+  it('returns false when neither --host nor its --device alias is given', async () => {
+    expect(await maybeRunOnHost('message', ['message', 'abc', 'hi'])).toBe(false);
+  });
+
   it('returns false when --host names this very machine (runs locally instead)', async () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
     expect(machineId()).toBe('mybox');
     expect(await maybeRunOnHost('view', ['view', '--host', 'mybox'])).toBe(false);
     // case-insensitive: the self-check must not SSH to `MyBox` either
     expect(await maybeRunOnHost('view', ['view', '--host', 'MyBox'])).toBe(false);
+  });
+
+  it('treats --device as an alias of --host for the self-machine short-circuit', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    // --device naming this machine must short-circuit to a local run, exactly
+    // like --host would — otherwise the alias would SSH to itself.
+    expect(await maybeRunOnHost('message', ['message', 'abc', 'hi', '--device', 'mybox'])).toBe(false);
+    expect(await maybeRunOnHost('message', ['message', 'abc', 'hi', '--device=mybox'])).toBe(false);
+  });
+
+  it('rejects a conflicting --host/--device pair without attempting SSH', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    // Handled (returns true) but as an error — never guesses which host wins.
+    expect(await maybeRunOnHost('message', ['message', 'abc', 'hi', '--host', 'a', '--device', 'b'])).toBe(true);
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0;
   });
 });

--- a/src/lib/hosts/passthrough.ts
+++ b/src/lib/hosts/passthrough.ts
@@ -91,9 +91,9 @@ async function resolveTargetHost(name: string, any: boolean): Promise<Host> {
 
 /**
  * Route `agents <command> … --host <name>` to a remote if the command is
- * host-routable and a `--host` was given. Returns `false` (run locally) when
- * there is no `--host`, the command isn't in the table, or the target is this
- * very machine.
+ * host-routable and a `--host` (or its `--device` alias) was given. Returns
+ * `false` (run locally) when neither flag is present, the command isn't in the
+ * table, or the target is this very machine.
  *
  * @param command the resolved subcommand name (`process.argv`'s first non-flag).
  * @param allArgs `process.argv.slice(2)` — the command name followed by its args.
@@ -102,7 +102,17 @@ export async function maybeRunOnHost(command: string, allArgs: string[]): Promis
   const spec = REMOTE_PASSTHROUGH[command];
   if (!spec) return false;
 
-  const hostName = flagValue(allArgs, 'host', 'H');
+  // `--device` is a first-class alias of `--host` (mirrors `agents run`); the
+  // device registry is the source of truth for machine identity. Reject a
+  // conflicting pair rather than silently preferring one — same rule as run.
+  const hostFlag = flagValue(allArgs, 'host', 'H');
+  const deviceFlag = flagValue(allArgs, 'device');
+  if (hostFlag && deviceFlag && hostFlag !== deviceFlag) {
+    console.error(chalk.red('Conflicting --host/--device values — pass just one.'));
+    process.exitCode = 1;
+    return true;
+  }
+  const hostName = hostFlag ?? deviceFlag;
   if (!hostName) return false;
 
   // Running against your own machine is just a local run — skip the SSH round-trip.

--- a/src/lib/hosts/remote-cmd.test.ts
+++ b/src/lib/hosts/remote-cmd.test.ts
@@ -60,6 +60,21 @@ describe('stripRoutingFlags', () => {
     ]);
   });
 
+  it('drops the --device alias and its value so it never leaks to the remote binary', () => {
+    // --device is an alias of --host; forwarding it would re-trigger routing on
+    // the remote (which only knows --host). Both space and =value forms go.
+    expect(stripRoutingFlags(['message', 'abc', 'hi', '--device', 'yosemite-s0'], SPECS)).toEqual([
+      'message',
+      'abc',
+      'hi',
+    ]);
+    expect(stripRoutingFlags(['message', 'abc', 'hi', '--device=yosemite-s0'], SPECS)).toEqual([
+      'message',
+      'abc',
+      'hi',
+    ]);
+  });
+
   it('drops the valueless --no-tty without consuming the next token', () => {
     expect(stripRoutingFlags(['view', '--no-tty', 'claude'], SPECS)).toEqual(['view', 'claude']);
   });

--- a/src/lib/hosts/remote-cmd.ts
+++ b/src/lib/hosts/remote-cmd.ts
@@ -49,9 +49,16 @@ export function stripRoutingFlags(args: string[], specs: StripSpec[]): string[] 
   return out;
 }
 
-/** The routing flags every `--host`-capable command shares. */
+/**
+ * The routing flags every `--host`-capable command shares. `--device` is a
+ * first-class alias of `--host` (the device registry is the source of truth for
+ * machine identity — see `agents devices`), mirroring `agents run --device`.
+ * Both are stripped before forwarding so the alias never leaks to the remote
+ * binary (which would re-trigger routing).
+ */
 export const HOST_ROUTING_SPECS: StripSpec[] = [
   { long: 'host', short: 'H', takesValue: true },
+  { long: 'device', takesValue: true },
   { long: 'remote-cwd', takesValue: true },
 ];
 


### PR DESCRIPTION
## Problem

`agents run` treats `--device` as an alias of `--host` (`exec.ts:498` collects `host/device/on/computer` and errors on conflict). But the **generic `--host` passthrough** that every *other* host-routable command rides — `message`, `view`, `teams`, `usage`, `cost`, `doctor`, `inspect`, `list`, `sync` — only recognized `--host`/`-H` (`HOST_ROUTING_SPECS` in `remote-cmd.ts`, value read in `passthrough.ts:maybeRunOnHost`).

Result: the alias was inconsistent.

```
agents run    ... --device yosemite-s0    # worked
agents message <id> --device yosemite-s0  # broke (commander rejected the flag)
```

The device registry (`agents devices`) is the source of truth for machine identity, so `--device` should be accepted **everywhere** `--host` is — not just on `run`.

## Fix (at the source, not per-command)

The generic passthrough is the single choke point for all 9 commands, so the fix lives there:

- **`remote-cmd.ts`** — add `--device` to `HOST_ROUTING_SPECS`. `stripRoutingFlags` now removes it before forwarding, so the alias never leaks to the remote binary (which only knows `--host` and would re-trigger routing).
- **`passthrough.ts`** — `maybeRunOnHost` reads the `--device` value as a fallback for `--host`, mirroring `run`'s precedence **and** its conflict guard: a differing `--host`/`--device` pair is rejected rather than silently guessed.

No per-command code — every host-routable command gains `--device` at once.

## Tests

- `remote-cmd.test.ts` — `--device` (space and `=value` forms) is stripped from forwarded args.
- `passthrough.test.ts` — `--device` drives the self-machine local short-circuit exactly like `--host`; a conflicting `--host`/`--device` pair errors (exit 1) without attempting SSH.

`bunx tsc --noEmit` clean; 33/33 host tests pass.

## Verified end-to-end

Built this branch and ran a live remote round-trip:

1. Launched a headless auto-mode agent on `yosemite-s0`.
2. From zion: `node dist/index.js message <id> "…EMERALD-DEVICE-77…" --device yosemite-s0`
3. The message routed over SSH, was written to the mailbox **on yosemite-s0**, drained by the remote's PreToolUse mailbox hook, and the remote agent wrote back the exact passphrase.

Session transcript (fleet-local, public repo): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/06956602-07c1-4f5b-9962-fa75376866ba.jsonl`