### PR TITLE
feat(sessions): clean JSON array for sessions --json --host

### DIFF
--- a/src/commands/sessions.serialize.test.ts
+++ b/src/commands/sessions.serialize.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { serializeSessionsJson } from './sessions.js';
+import type { SessionMeta } from '../lib/session/types.js';
+
+/**
+ * `serializeSessionsJson` is the single seam both the local `agents sessions
+ * --json` path and the new `--json --host` remote fan-out serialize through, so
+ * a VS Code extension can `JSON.parse` a remote device's recent (historical,
+ * non-active) sessions the same way it parses the local list. These assert the
+ * output is a parseable `SessionMeta[]` array and that the internal-only
+ * search/fan-out bookkeeping fields never leak into that public record.
+ */
+
+function meta(over: Partial<SessionMeta> = {}): SessionMeta {
+  return {
+    id: 'abcdef12-3456-7890-abcd-ef1234567890',
+    shortId: 'abcdef12',
+    agent: 'claude',
+    timestamp: '2026-07-07T10:00:00.000Z',
+    filePath: '/home/u/.agents/.history/sessions/abcdef12.jsonl',
+    ...over,
+  };
+}
+
+describe('serializeSessionsJson', () => {
+  it('emits a parseable JSON array of SessionMeta (the shape a caller parses)', () => {
+    const out = serializeSessionsJson([
+      meta({ shortId: 'aaa', project: 'proj-a' }),
+      meta({ id: 'ffff', shortId: 'bbb', project: 'proj-b' }),
+    ]);
+    const parsed = JSON.parse(out);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].shortId).toBe('aaa');
+    expect(parsed[0].project).toBe('proj-a');
+    expect(parsed[1].project).toBe('proj-b');
+  });
+
+  it('empty input serializes to an empty array (an offline/0-session host)', () => {
+    // The --json --host fan-out contributes [] for a dead or session-less host,
+    // so stdout must still be a valid empty array, never blank or a banner.
+    const parsed = JSON.parse(serializeSessionsJson([]));
+    expect(parsed).toEqual([]);
+  });
+
+  it('strips the internal _remote / _matchedTerms / _bm25Score fan-out+search fields', () => {
+    // Remote rows come back tagged `_remote: true` from parseRemoteList; those
+    // and the BM25 search bookkeeping are transient and must not leak to a
+    // scripted consumer.
+    const out = serializeSessionsJson([
+      meta({ _remote: true, _matchedTerms: ['auth'], _bm25Score: 3.14, machine: 'mac-mini' }),
+    ]);
+    const row = JSON.parse(out)[0];
+    expect(row).not.toHaveProperty('_remote');
+    expect(row).not.toHaveProperty('_matchedTerms');
+    expect(row).not.toHaveProperty('_bm25Score');
+    // The real machine tag (a public field, not underscore-prefixed) survives so
+    // a caller can still attribute each remote row to its host.
+    expect(row.machine).toBe('mac-mini');
+  });
+
+  it('ends with a single trailing newline (line-oriented stdout contract)', () => {
+    const out = serializeSessionsJson([meta()]);
+    expect(out.endsWith('\n')).toBe(true);
+    expect(out.endsWith('\n\n')).toBe(false);
+  });
+});

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -615,6 +615,41 @@ export function mergeLocalFirst(sessions: SessionMeta[], localMachine: string): 
 }
 
 /**
+ * Serialize a `SessionMeta[]` to the clean JSON shape the `--json` listing
+ * emits: strip the internal-only scoring/provenance fields (`_matchedTerms`,
+ * `_bm25Score`, `_remote`) that are search/fan-out bookkeeping, never part of
+ * the public record, then pretty-print as a 2-space array with a trailing
+ * newline. The single seam shared by the local `--json` path and the
+ * `--json --host` remote fan-out so both emit byte-identical row shapes.
+ */
+export function serializeSessionsJson(sessions: SessionMeta[]): string {
+  const serializable = sessions.map((s) => {
+    const { _matchedTerms, _bm25Score, _remote, ...rest } = s;
+    return rest;
+  });
+  return JSON.stringify(serializable, null, 2) + '\n';
+}
+
+/**
+ * `agents sessions --json --host <h>` — fan the RECENT (non-active) listing out
+ * to the named host(s) and emit ONE clean merged `SessionMeta[]` JSON array,
+ * the same shape the local `--json` path emits. Reuses `gatherRemoteList` (the
+ * exact SSH fan-out the interactive cross-machine listing already uses) and
+ * serializes the merged, machine-tagged rows — instead of `runRemoteSessions`,
+ * which streams each remote's raw stdout under a per-host banner and so can
+ * never be JSON.parsed. A dead host contributes `[]` (with a stderr note from
+ * the fan-out), so stdout is always a valid array and the exit stays 0.
+ */
+async function runRemoteSessionsJson(hosts: string[]): Promise<void> {
+  // Forward the caller's own filters (query, --limit, --since, …) minus --host,
+  // and guarantee --json so each peer answers with a parseable array.
+  const forwarded = buildForwardedArgs(process.argv, new Set(hosts));
+  if (!forwarded.includes('--json')) forwarded.push('--json');
+  const { sessions } = await gatherRemoteList(forwarded, hosts);
+  process.stdout.write(serializeSessionsJson(sessions));
+}
+
+/**
  * `running N · idle N · waiting N · queued N` for a bucket of sessions (zero
  * buckets omitted). Same bucketing as the grand-total summary so per-group
  * counts reconcile with the `(total)` beside the header. Empty when nothing.
@@ -830,10 +865,17 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
     options.host = [...(options.host ?? []), ...options.device];
   }
 
-  // --host WITHOUT --active keeps the legacy per-host stream (each remote's raw
-  // stdout under a `── host ──` banner). With --active, the hosts are folded
-  // into the merged machine-grouped view instead (handled below).
+  // --host WITHOUT --active. `--json` fans the recent listing out and emits ONE
+  // clean merged SessionMeta[] array (same shape as the local --json path), for
+  // scripts/extensions that JSON.parse a remote's history. Without --json it
+  // keeps the legacy per-host stream (each remote's raw stdout under a
+  // `── host ──` banner). With --active, the hosts are folded into the merged
+  // machine-grouped view instead (handled below).
   if (options.host && options.host.length > 0 && !options.active) {
+    if (options.json) {
+      await runRemoteSessionsJson(options.host);
+      return;
+    }
     try {
       runRemoteSessions(options.host);
     } catch (err: any) {
@@ -989,11 +1031,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
 
     if (options.json) {
       const filtered = searchQuery ? filterSessionsByQuery(sessions, searchQuery) : sessions;
-      const serializable = filtered.map(s => {
-        const { _matchedTerms, _bm25Score, _remote, ...rest } = s;
-        return rest;
-      });
-      process.stdout.write(JSON.stringify(serializable, null, 2) + '\n');
+      process.stdout.write(serializeSessionsJson(filtered));
       return;
     }
 


### PR DESCRIPTION
Enables the Factory Floor cockpit to fetch a remote host's RECENT sessions when it has 0 live agents (paired with swarmify#148).

`--host` without `--active` previously streamed a legacy per-host raw banner, so `--json --host` was never a parseable array. Now it emits one clean merged `SessionMeta[]` via the existing `gatherRemoteList` SSH fan-out.

- `serializeSessionsJson()` (DRY: shared by local + remote json paths)
- `runRemoteSessionsJson()` reuses `buildForwardedArgs` + `gatherRemoteList`
- routing gated on `--host && !--active && --json`; banner + `--active` paths unchanged

Verified: `sessions --json --host mac-mini --limit 5` → clean JSON array, exit 0, machine-tagged. New `sessions.serialize.test.ts` (4 tests) + tsc green.