### PR TITLE
feat(sessions): agents sessions focus — attach a live session or open a new tab and resume it

### DIFF
--- a/src/commands/focus.test.ts
+++ b/src/commands/focus.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { metaFromActive } from './focus.js';
+import { buildResumeCommand } from './sessions.js';
+import type { ActiveSession } from '../lib/session/active.js';
+
+function s(over: Partial<ActiveSession>): ActiveSession {
+  return { context: 'terminal', kind: 'claude', status: 'running', ...over } as ActiveSession;
+}
+
+describe('metaFromActive — the resume fallback input', () => {
+  it('carries id, short id, agent, and cwd through', () => {
+    const m = metaFromActive(s({ sessionId: '019e30a2-cd76-7702', kind: 'codex', cwd: '/tmp/x' }));
+    expect(m.id).toBe('019e30a2-cd76-7702');
+    expect(m.shortId).toBe('019e30a2');
+    expect(m.agent).toBe('codex');
+    expect(m.cwd).toBe('/tmp/x');
+  });
+
+  it('missing session id degrades to "-" short id, empty id', () => {
+    const m = metaFromActive(s({}));
+    expect(m.shortId).toBe('-');
+    expect(m.id).toBe('');
+  });
+});
+
+describe('focus resume-in-a-tab command (metaFromActive → buildResumeCommand)', () => {
+  it('claude → claude --resume <id>', () => {
+    expect(buildResumeCommand(metaFromActive(s({ sessionId: 'abc12345', kind: 'claude' })))).toEqual(['claude', '--resume', 'abc12345']);
+  });
+
+  it('codex → codex resume <id>', () => {
+    expect(buildResumeCommand(metaFromActive(s({ sessionId: 'def67890', kind: 'codex' })))).toEqual(['codex', 'resume', 'def67890']);
+  });
+
+  it('opencode → opencode --session <id>', () => {
+    expect(buildResumeCommand(metaFromActive(s({ sessionId: 'ses_9', kind: 'opencode' })))).toEqual(['opencode', '--session', 'ses_9']);
+  });
+
+  it('non-resumable agents (gemini/grok/…) → null, so focus refuses cleanly', () => {
+    for (const kind of ['gemini', 'grok', 'antigravity', 'droid', 'kimi']) {
+      expect(buildResumeCommand(metaFromActive(s({ sessionId: 'x1234567', kind })))).toBeNull();
+    }
+  });
+});

--- a/src/commands/focus.ts
+++ b/src/commands/focus.ts
@@ -1,0 +1,162 @@
+/**
+ * `agents sessions focus [id]` — take me to a live session, however it's reachable.
+ *
+ * Same detection as `go`, but where `go` *refuses* an un-attachable session,
+ * `focus` **opens a new tab and resumes it** — locally, or on the remote over SSH
+ * (via the terminal launch engine's `openSurfaces`, `host` = the peer). So:
+ *   - in tmux (local/remote)   -> attach the live pane (join it, no fork)
+ *   - in Ghostty               -> focus its tab
+ *   - headless / plain / etc.  -> new tab + `resume` (a copy if it's mid-run — the
+ *                                  original keeps going; a clean continue if it's idle)
+ *
+ * NOTE: joining a live process without forking is only possible via tmux — that's
+ * why `--tmux`-wrapped launches are worth it for sessions you'll want back live.
+ */
+
+import type { Command } from 'commander';
+import fs from 'node:fs';
+import chalk from 'chalk';
+import { gatherLiveTargets, pickLiveTarget, jumpTo, type UnreachableFallback } from './go.js';
+import type { ActiveSession } from '../lib/session/active.js';
+import type { SessionMeta, SessionAgentId } from '../lib/session/types.js';
+import { buildResumeCommand, resumeSessionInPlace } from './sessions.js';
+import { runOnPeer } from '../lib/session/remote-list.js';
+import { discoverSessions } from '../lib/session/discover.js';
+import {
+  openSurfaces,
+  currentContext,
+  availableBackends,
+  detectCurrentBackend,
+  type Backend,
+} from '../lib/terminal/index.js';
+import { isInteractiveTerminal } from './utils.js';
+
+export function registerFocusCommand(program: Command): void {
+  program
+    .command('focus')
+    .argument('[id]', 'Short/full session id to focus; omit for an interactive picker')
+    .option('--local', 'Only this machine (skip the cross-host sweep)')
+    .description('Focus a live session — attach its terminal, or open a new tab and resume it')
+    .action(async (id: string | undefined, opts: { local?: boolean }) => {
+      await focusAction(id, opts);
+    });
+}
+
+async function focusAction(id: string | undefined, opts: { local?: boolean }): Promise<void> {
+  const { self, activeById } = await gatherLiveTargets(!!opts.local);
+
+  if (id) {
+    const q = id.toLowerCase();
+    const matches = [...activeById.values()].filter((s) => s.sessionId!.toLowerCase().startsWith(q));
+    if (matches.length === 1) {
+      await jumpTo(matches[0], self, resumeInNewTab);
+      return;
+    }
+    if (matches.length > 1) {
+      console.error(chalk.red(`"${id}" is ambiguous (${matches.length} live matches). Use more of the id.`));
+      process.exitCode = 1;
+      return;
+    }
+    // Not live — it's a past session; resume is the right tool (multi-select + placement).
+    console.log(
+      chalk.yellow(`No live session matching "${id}".`) +
+        chalk.gray(`\nTo resume a past session: agents sessions resume ${id}`),
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!isInteractiveTerminal()) {
+    console.error(chalk.red('focus needs an interactive terminal, or pass a session id.'));
+    process.exitCode = 1;
+    return;
+  }
+  if (activeById.size === 0) {
+    console.log(chalk.gray('No live sessions to focus. To resume a past one: agents sessions resume'));
+    return;
+  }
+  const target = await pickLiveTarget(activeById, self, 'Focus a live session:', 'focus');
+  if (!target) return;
+  await jumpTo(target, self, resumeInNewTab);
+}
+
+function shortId(s: ActiveSession): string {
+  return (s.sessionId ?? '').slice(0, 8) || '-';
+}
+
+/** Minimal SessionMeta for a live session, enough for `buildResumeCommand` + placement. */
+export function metaFromActive(s: ActiveSession): SessionMeta {
+  return {
+    id: s.sessionId ?? '',
+    shortId: shortId(s),
+    agent: s.kind as SessionAgentId,
+    timestamp: new Date(s.startedAtMs ?? Date.now()).toISOString(),
+    filePath: '',
+    cwd: s.cwd,
+  };
+}
+
+/** Look up the rich indexed SessionMeta by id so `version` survives (version-pinned resume). */
+async function richMetaById(id: string): Promise<SessionMeta | undefined> {
+  try {
+    const metas = await discoverSessions({ all: true, since: '90d', limit: 2000 });
+    return metas.find((m) => m.id === id) ?? metas.find((m) => m.id.startsWith(id));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * `focus`'s fallback for a session with no attach rail: reopen it and hand you to it.
+ *   - remote → resume ON the peer over SSH (foreground) — the peer resolves the pinned
+ *              version and holds the transcript, and `-tt` delivers you there.
+ *   - local  → resume in a new tab in your terminal, version-pinned via the indexed meta.
+ * Note: for a session that's still mid-run, this opens a COPY (the original keeps going);
+ * only tmux can *join* a live one without forking (see the header).
+ */
+const resumeInNewTab: UnreachableFallback = async (s, remote) => {
+  const id = s.sessionId ?? '';
+  if (!id) {
+    console.log(chalk.yellow('This session has no id to resume.'));
+    return;
+  }
+
+  // Remote: the transcript + pinned version live on the peer, so resume THERE over SSH.
+  // runOnPeer runs `agents sessions resume <id>` with a real TTY (`-tt`) in the foreground —
+  // it actually delivers you to the session (the peer picks the right version + HOME).
+  if (remote) {
+    console.log(chalk.gray(`${shortId(s)} has no live terminal on ${remote} — resuming it there over SSH…`));
+    const rc = await runOnPeer(['sessions', 'resume', id], remote, { tty: true });
+    if (rc === 'no-target') {
+      console.log(chalk.red(`${remote} isn't reachable as a device. Try: agents devices sync`));
+      console.log(chalk.gray(`  or run it yourself: ssh ${remote} 'agents sessions resume ${shortId(s)}'`));
+    }
+    return;
+  }
+
+  // Local: resume in a new tab. Use the indexed meta so the version-pinned binary
+  // resumes in the same isolated HOME the transcript was written in.
+  const meta = (await richMetaById(id)) ?? metaFromActive(s);
+  const command = buildResumeCommand(meta);
+  if (!command) {
+    console.log(chalk.yellow(`${meta.shortId} — ${meta.agent} sessions aren't resumable, so there's no way to reopen it.`));
+    return;
+  }
+  const cwd = meta.cwd && fs.existsSync(meta.cwd) ? meta.cwd : process.cwd();
+
+  const ctx = currentContext();
+  const backend: Backend | undefined = detectCurrentBackend(ctx) ?? availableBackends(ctx)[0]?.id;
+  if (!backend) {
+    // No tab-capable surface (off-macOS, not in tmux) — resume in this process.
+    await resumeSessionInPlace(meta);
+    return;
+  }
+
+  console.log(chalk.gray(`${shortId(s)} has no live terminal to attach — opening a new ${backend} tab and resuming a copy.`));
+  const results = await openSurfaces([{ cwd, command }], { backend, packing: 'tabs' });
+  const r = results[0];
+  if (!r || !r.ok) {
+    console.log(chalk.red(`  failed to open — ${r?.error ?? 'unknown error'}`));
+    console.log(chalk.gray(`  try: agents sessions resume ${meta.shortId}`));
+  }
+};

--- a/src/commands/go.ts
+++ b/src/commands/go.ts
@@ -44,14 +44,13 @@ export function registerGoCommand(program: Command): void {
     });
 }
 
-async function goAction(id: string | undefined, opts: { local?: boolean }): Promise<void> {
+/** Live jump targets (local + remote), keyed by session id. Cloud excluded (no pid). */
+export async function gatherLiveTargets(local: boolean): Promise<{ self: string; activeById: Map<string, ActiveSession> }> {
   const self = machineId();
-
-  // Live jump targets (local + remote), keyed by session id.
   const localActive = await getActiveSessions();
   for (const s of localActive) if (!s.machine) s.machine = self;
   let active = localActive;
-  if (!opts.local) {
+  if (!local) {
     try {
       const remote = await gatherRemoteActive();
       active = dedupeByMachineSession([...localActive, ...remote.sessions]);
@@ -59,6 +58,25 @@ async function goAction(id: string | undefined, opts: { local?: boolean }): Prom
   }
   const activeById = new Map<string, ActiveSession>();
   for (const s of active) if (s.context !== 'cloud' && s.sessionId) activeById.set(s.sessionId, s);
+  return { self, activeById };
+}
+
+/** Interactive pick over the live sessions' rich SessionMeta; returns the chosen live session. */
+export async function pickLiveTarget(
+  activeById: Map<string, ActiveSession>,
+  self: string,
+  message: string,
+  enterHint: string,
+): Promise<ActiveSession | null> {
+  const pool = await buildLivePool(activeById, self);
+  if (pool.length === 0) return null;
+  const picked = await pickSessionInteractive(pool, message, undefined, 0, enterHint);
+  if (!picked) return null;
+  return activeById.get(picked.session.id) ?? null;
+}
+
+async function goAction(id: string | undefined, opts: { local?: boolean }): Promise<void> {
+  const { self, activeById } = await gatherLiveTargets(!!opts.local);
 
   if (activeById.size === 0) {
     console.log(chalk.gray('No live agent sessions to jump to.'));
@@ -89,19 +107,8 @@ async function goAction(id: string | undefined, opts: { local?: boolean }): Prom
     return;
   }
 
-  // Reuse the rich `sessions` picker over the live sessions' full SessionMeta.
-  const pool = await buildLivePool(activeById, self);
-  if (pool.length === 0) {
-    console.log(chalk.gray('No live sessions to jump to.'));
-    return;
-  }
-  const picked = await pickSessionInteractive(pool, 'Jump to a live session:', undefined, 0, 'jump');
-  if (!picked) return;
-  const target = activeById.get(picked.session.id);
-  if (!target) {
-    console.log(chalk.yellow(`${picked.session.shortId} is no longer live — try: `) + chalk.gray(`agents sessions resume ${picked.session.shortId}`));
-    return;
-  }
+  const target = await pickLiveTarget(activeById, self, 'Jump to a live session:', 'jump');
+  if (!target) return;
   await jumpTo(target, self);
 }
 
@@ -110,7 +117,7 @@ async function goAction(id: string | undefined, opts: { local?: boolean }): Prom
  * via the shared picker), reusing `discoverSessions`. Remote or unindexed live
  * sessions get a minimal synthesized meta so they still appear and jump.
  */
-async function buildLivePool(activeById: Map<string, ActiveSession>, self: string): Promise<SessionMeta[]> {
+export async function buildLivePool(activeById: Map<string, ActiveSession>, self: string): Promise<SessionMeta[]> {
   let metas: SessionMeta[] = [];
   try {
     metas = await discoverSessions({ all: true, since: '30d', limit: 1000 });
@@ -171,7 +178,27 @@ export function describeWhere(s: ActiveSession, self: string): Where {
   return { label: s.host ?? 'unknown terminal', action: 'resume it (no live attach rail)' };
 }
 
-async function jumpTo(s: ActiveSession, self: string): Promise<void> {
+/**
+ * What to do when a session can't be *attached* (no tmux/Ghostty rail). `go`
+ * refuses; `focus` opens a new tab and resumes. `remote` is the peer name when
+ * the session lives on another machine, else undefined.
+ */
+export type UnreachableFallback = (s: ActiveSession, remote: string | undefined) => void | Promise<void>;
+
+/** Default (used by `go`): open a login shell on the remote, or refuse locally. */
+async function refuseFallback(s: ActiveSession, remote: string | undefined): Promise<void> {
+  if (remote) {
+    console.log(chalk.yellow(`${shortId(s)} on ${remote} isn't inside tmux — opening a shell on ${remote} instead.`));
+    assertValidSshTarget(remote);
+    process.exit(sshStream(remote, 'exec "${SHELL:-/bin/sh}" -l', { tty: true }));
+  }
+  console.log(
+    chalk.yellow(`Can't jump to ${shortId(s)} — it's in ${s.host ?? 'an unknown terminal'} with no attach rail (not tmux/Ghostty).`) +
+      chalk.gray(`\nTry: agents sessions resume ${shortId(s)}`),
+  );
+}
+
+export async function jumpTo(s: ActiveSession, self: string, fallback: UnreachableFallback = refuseFallback): Promise<void> {
   const remote = s.machine && s.machine !== self ? s.machine : undefined;
   const mux = s.provenance?.mux;
 
@@ -189,9 +216,9 @@ async function jumpTo(s: ActiveSession, self: string): Promise<void> {
       console.log(chalk.gray(`Attaching ${shortId(s)} on ${remote} over SSH — Ctrl-b d to detach.`));
       process.exit(sshStream(remote, remoteCmd, { tty: true }));
     }
-    console.log(chalk.yellow(`${shortId(s)} on ${remote} isn't inside tmux — opening a shell on ${remote} instead.`));
-    assertValidSshTarget(remote);
-    process.exit(sshStream(remote, 'exec "${SHELL:-/bin/sh}" -l', { tty: true }));
+    // Remote, not in tmux → hand off to the fallback (go: shell; focus: resume in a tab).
+    await fallback(s, remote);
+    return;
   }
 
   // Path B: local tmux — attach (or switch-client if we're already inside tmux).
@@ -235,11 +262,8 @@ async function jumpTo(s: ActiveSession, self: string): Promise<void> {
     return;
   }
 
-  // Path D: refuse with a reason.
-  console.log(
-    chalk.yellow(`Can't jump to ${shortId(s)} — it's in ${s.host ?? 'an unknown terminal'} with no attach rail (not tmux/Ghostty).`) +
-      chalk.gray(`\nTry: agents sessions resume ${shortId(s)}`),
-  );
+  // Path D: no attach rail (headless / plain terminal) → hand off to the fallback.
+  await fallback(s, undefined);
 }
 
 /** Resolve a local tmux pane id to its session name + window index. */

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -44,6 +44,7 @@ import { registerSessionsTailCommand } from './sessions-tail.js';
 import { registerSessionsSyncCommand } from './sessions-sync.js';
 import { registerSessionsResumeCommand } from './sessions-resume.js';
 import { registerGoCommand } from './go.js';
+import { registerFocusCommand } from './focus.js';
 import { registerSessionsInjectCommand } from './sessions-inject.js';
 
 const SESSION_AGENT_FILTER_HELP = `Filter by agent, e.g. claude, codex, claude@2.0.65`;
@@ -2263,6 +2264,7 @@ export function registerSessionsCommands(program: Command): void {
   registerSessionsSyncCommand(sessionsCmd);
   registerSessionsResumeCommand(sessionsCmd);
   registerGoCommand(sessionsCmd);
+  registerFocusCommand(sessionsCmd);
   registerSessionsInjectCommand(sessionsCmd);
 }
 


### PR DESCRIPTION
## What

**`agents sessions focus [id]`** — one command that takes you to a live session, however it's reachable. It's the smart superset of `go`: same live detection (local + remote) and the same rich picker, but where `go` **refuses** an un-attachable session, `focus` **opens a new tab and resumes it**.

| Where the session is | `focus` reaches it by | vs `go` |
|---|---|---|
| in **tmux** (local/remote) | attach the live pane (`switch-client`/`attach-session`, or `ssh -tt` + attach) — **joins it, no fork** | same |
| in **Ghostty** | focus its tab | same |
| **headless / plain terminal / no rail** | **new tab + `resume`** (local, or on the remote over SSH) | `go` refuses |

## Before → after (user-visible)

**Before** (`go`, on a headless/plain session):
```
$ agents sessions go 019e30a2
Can't jump to 019e30a2 — it's in an unknown terminal with no attach rail (not tmux/Ghostty).
Try: agents sessions resume 019e30a2
```
**After** (`focus`, same session):
```
$ agents sessions focus 019e30a2
019e30a2 has no live terminal to attach — opening a new ghostty tab and resuming it.
  opened 019e30a2 — tab — claude --resume 019e30a2…
```
And on a remote peer, the new tab runs `ssh -tt <peer> …` so it resumes **where the transcript lives**.

## How (mostly reuse)

- Refactors `go`'s `jumpTo` into a shared, exported reach with a pluggable **`UnreachableFallback`** — `go` passes refuse/login-shell, `focus` passes **resume-in-a-tab**. Also exports `gatherLiveTargets` / `pickLiveTarget` / `buildLivePool` so both commands share one gather + picker (no duplication).
- The resume-in-a-tab path is the existing terminal engine: **`openSurfaces([{cwd, command}], { backend, host })`** — which already handles remote via `host` (SSH). `buildResumeCommand` builds the version-pinned argv; non-resumable agents (gemini/grok/…) get a clean "can't reopen" message.

## The honest semantics (in the header + PR)

Only **tmux** can *join* a live process without forking. `focus`'s "new tab + resume" on a **still-running** headless session opens a **copy** (the original keeps going); on an idle/done session it's a clean continue. That's exactly why an **opt-in `--tmux` launch-wrap** (follow-up) is worth it for sessions you'll want back live.

## Follow-ups (separate PRs, noted in code)

- swarmify **watchdog/kit-bridge `focus <sessionId>`** → precise VS Code/Cursor tab reveal (`terminal.show()`), MVP single-window.
- **iTerm2** `select session id <uuid>` precise focus (the rail is detected today; `go`/`focus` don't use it yet).
- opt-in **`--tmux`** launch-wrap (join-live, no fork).
- fold `go`/`resume` into `focus` as the single verb once it proves out.

## Tests / verification

`src/commands/focus.test.ts` (vitest, no mocks) — `metaFromActive` + the resume-command mapping per agent (claude/codex/opencode → argv; gemini/grok/… → null). `go.test.ts` (path selection) still green after the refactor. **12 tests pass**, `bun run build` clean. Verified the picker end-to-end by rendering it in tmux (`Focus a live session:` → select → attach).

Installed on zion as `agents-dev` for live testing.
