### PR TITLE
feat(secrets): 7-day remember policy that survives screen-lock

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -164,7 +164,7 @@ Source: `src/lib/secrets/remote.ts` (transport + resolve), wired into `list` /
 | `secrets stop` | Stop + remove the persistent service and wipe what it held | `agents secrets stop` |
 | `secrets unlock [names...]` | Read a bundle once (one Touch ID) and hold it in the secrets-agent so later runs read it silently | `agents secrets unlock prod` |
 | `secrets unlock --all` | Unlock every configured bundle | `agents secrets unlock --all` |
-| `secrets unlock <name> --ttl <dur>` | Hold for a custom lifetime (default 24h) | `agents secrets unlock prod --ttl 30m` |
+| `secrets unlock <name> --ttl <dur>` | Hold for a custom lifetime (default 7d) | `agents secrets unlock prod --ttl 30m` |
 | `secrets lock [names...]` | Wipe held bundles from the agent (default: all) — next read re-prompts | `agents secrets lock` |
 | `secrets status` | Show which bundles the agent holds and when they lock | `agents secrets status` |
 | `secrets policy <bundle> [policy]` | Show or set a bundle's prompt policy: `daily` (default), `always`, or `never` (silent, no biometry ACL — needs `--i-understand`) | `agents secrets policy signing always` |
@@ -412,7 +412,7 @@ The secrets-agent is the ssh-agent answer:
 
 - `agents secrets unlock <bundle>` reads the bundle from the keychain **once** (one Touch ID) and hands the resolved env to a small local broker that holds it in memory.
 - Every later resolution of that bundle — by any `agents run`, teammate, browser profile, or the routines daemon — is served from the broker over a user-only Unix socket (dir `~/.agents/.cache/helpers/secrets-agent/`, mode `0700`). No prompt.
-- The hold ends when its TTL expires (default 24h, `--ttl` to change), you run `agents secrets lock`, or the screen locks / the machine sleeps. Nothing is ever written to disk.
+- The hold ends when its TTL expires (default 7d, `--ttl` to change), you run `agents secrets lock`, the machine sleeps, or you log out. A bare screen-lock does **not** drop it — the login password already gates a locked screen, and re-prompting after every lock would defeat the ~7-day window. Nothing is ever written to disk.
 
 It is **opt-in by construction**: if you never run `unlock`, resolution is byte-for-byte today's keychain path. Audit events tag broker-served reads with `"source":"agent"` so you can tell them apart from real keychain reads.
 
@@ -431,7 +431,7 @@ A long-running daemon or broker keeps running the code it started with; an in-pl
 
 Each bundle has a **prompt policy** that controls how often macOS asks for Touch ID, shown in the `POLICY` column of `agents secrets list` and set with `agents secrets policy <bundle> [daily|always]` (also `--policy` on `create`):
 
-- **`daily`** (default): ask once, then hold it silently. The **first real keychain read auto-loads it** into the broker (in the background, no added latency), so the next concurrent run reads it silently without you running `unlock` at all — one Touch ID per ~24h. Held from that unlock (not refreshed on use) — re-asks sooner after screen-lock, sleep, logout, or `lock`. Despite the name, it is **not** tied to one calendar day or one login session; it's the rolling ~24h hold.
+- **`daily`** (default): ask once, then hold it silently. The **first real keychain read auto-loads it** into the broker (in the background, no added latency), so the next concurrent run reads it silently without you running `unlock` at all — one Touch ID per ~7 days. Held from that unlock (not refreshed on use) — re-asks sooner after sleep, logout, or `lock`. A bare screen-lock does **not** drop it. Despite the name, it is **not** tied to one calendar day or one login session; it's the rolling ~7-day (1 week) hold — the name is historical, from when the window was ~24h.
 - **`always`**: ask every time. Only an explicit `unlock` ever puts it in the agent; every other read pops Touch ID. Opt high-value bundles (signing keys, etc.) into this when you want to confirm every single read.
 - **`never`**: stored **without** the biometry access control — reads are fully silent (no Touch ID, no broker, no user-presence check). This is the least-safe tier and is [documented in the security model](#security-model) as an on-disk-plaintext-equivalent downgrade: any code running as your user reads it with zero interaction. It is marked loudly (`never · NO ACL`, in red) in `agents secrets list` and `view`, and creating or switching to it requires an explicit confirmation — an interactive "are you sure" prompt, or `--i-understand` in a headless shell. Reserve it for low-sensitivity, automation-only credentials. Writing a `never` item needs a signed helper that carries the `set-no-acl` path; an older pinned helper rejects the write loudly rather than silently storing an `always`-style ACL'd item.
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -453,7 +453,7 @@ Auto-cache is **on by default** and only ever applies to `daily`-policy bundles 
 
 Snapshot semantics: `unlock` stores the **resolved** env, so a bundle's dynamic refs (`exec:`, `env:`, `file:`) are frozen at unlock time until you re-unlock. Keychain and literal values — the overwhelming majority — are unaffected.
 
-Source: `src/lib/secrets/agent.ts`. Auto-lock on screen-lock/sleep uses the signed keychain helper's `watch-lock` mode (`src/lib/secrets/keychain-helper.swift`); with an older helper that predates it, the agent degrades to TTL-only locking.
+Source: `src/lib/secrets/agent.ts`. Auto-lock on sleep uses the signed keychain helper's `watch-lock` mode (`src/lib/secrets/keychain-helper.swift`) — a bare screen-lock does **not** wipe the hold (the login password already gates a locked screen); with an older helper that predates `watch-lock`, the agent degrades to TTL-only locking.
 
 ## Linux: headless servers and the encrypted-file fallback
 

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -545,7 +545,7 @@ export function registerSecretsCommands(program: Command): void {
       # See what's in the bundle (values masked); shows its prompt policy
       agents secrets view prod
 
-      # Stop a noisy automation bundle from prompting every run: ask once a day
+      # Stop a noisy automation bundle from prompting every run: ask once a week
       agents secrets policy prod daily
 
       # Eval the bundle into your current shell
@@ -565,15 +565,16 @@ export function registerSecretsCommands(program: Command): void {
       Touch ID noise: macOS pops a prompt per bundle per process. Each bundle has
       a prompt policy, shown in the POLICY column of 'agents secrets list':
         daily (default)   ask once, then hold it silently in the local agent up
-                          to ~24h, until screen-lock / sleep / logout or 'lock'.
+                          to ~7 days, until sleep / logout or 'lock' (a bare
+                          screen-lock does NOT drop it). Name is historical.
         always            ask for Touch ID every time — never auto-held.
-      The default is 'daily' (one Touch ID per ~24h); change it globally with
+      The default is 'daily' (one Touch ID per ~7 days); change it globally with
       'secrets.policy' in agents.yaml, or per bundle with 'agents secrets policy
       <bundle> always'. 'agents secrets unlock <bundle>' holds any bundle after one
       prompt regardless of policy. Nothing on disk.
 
       See also:
-        agents secrets policy <bundle> daily           ask once a day, not every run
+        agents secrets policy <bundle> daily           ask once a week, not every run
         agents secrets unlock <bundle>                 hold a bundle after one Touch ID
         agents secrets lock                            wipe held bundles (re-prompt next read)
         agents secrets status                          show held bundles + when they lock
@@ -675,7 +676,7 @@ export function registerSecretsCommands(program: Command): void {
         } else {
           console.log(
             bundlePolicy(bundle) === 'daily'
-              ? chalk.gray('policy: daily (ask once, then held ~24h until screen-lock / sleep / logout)')
+              ? chalk.gray('policy: daily (ask once, then held ~7 days until sleep / logout — screen-lock does not drop it)')
               : chalk.gray('policy: always (asks for Touch ID every time — never auto-held)'),
           );
         }
@@ -788,7 +789,7 @@ export function registerSecretsCommands(program: Command): void {
     .description('Create an empty bundle')
     .option('--description <text>', 'Free-form description')
     .option('--allow-exec', 'Allow exec: refs in this bundle (off by default)')
-    .option('--policy <policy>', 'prompt policy: daily (default, ask once a day), always (ask every time), or never (silent, NO biometry ACL — needs --i-understand)')
+    .option('--policy <policy>', 'prompt policy: daily (default, ask once a week), always (ask every time), or never (silent, NO biometry ACL — needs --i-understand)')
     .addOption(new Option('--tier <policy>', 'deprecated alias for --policy').hideHelp())
     .option('--i-understand', 'Confirm creating a "never"-policy bundle (no biometry ACL) without an interactive prompt')
     .option('--backend <backend>', 'storage backend: keychain (default) or file (passphrase-encrypted, headless-readable)', 'keychain')
@@ -1599,7 +1600,7 @@ Examples:
   cmd
     .command('unlock [names...]')
     .description('Hold a bundle in the secrets-agent after one Touch ID, so concurrent runs read it without re-prompting (macOS).')
-    .option('--ttl <duration>', 'How long to hold it (e.g. 30m, 8h). Default 24h.')
+    .option('--ttl <duration>', 'How long to hold it (e.g. 30m, 8h, 3d). Default 7d.')
     .option('--all', 'Unlock every configured bundle')
     .action(async (names: string[], opts: { ttl?: string; all?: boolean }) => {
       if (process.platform !== 'darwin') {
@@ -1615,7 +1616,7 @@ Examples:
       if (opts.ttl) {
         const secs = parseDuration(opts.ttl);
         if (!secs) {
-          console.error(chalk.red(`Invalid --ttl '${opts.ttl}'. Use e.g. 30m, 2h, 8h.`));
+          console.error(chalk.red(`Invalid --ttl '${opts.ttl}'. Use e.g. 30m, 2h, 8h, 3d.`));
           process.exit(1);
         }
         ttlMs = secs * 1000;
@@ -1698,7 +1699,7 @@ Examples:
   cmd
     .command('policy <bundle> [policy]')
     .alias('tier')
-    .description("Show or set a bundle's prompt policy: daily (default, ask once a day), always (ask every time), or never (silent, NO biometry ACL).")
+    .description("Show or set a bundle's prompt policy: daily (default, ask once a week), always (ask every time), or never (silent, NO biometry ACL).")
     .option('--i-understand', 'Confirm switching to the "never" policy (no biometry ACL) without an interactive prompt')
     .action(async (bundleName: string, policyArg: string | undefined, opts: { iUnderstand?: boolean }) => {
       try {
@@ -1718,7 +1719,7 @@ Examples:
         writeBundle(bundle);
         console.log(chalk.green(`${bundle.name} policy set to ${next}.`));
         if (next === 'daily') {
-          console.log(chalk.gray('Held by the secrets-agent for ~24h after one unlock (auto-cache is on by default; disable with `secrets.agent.auto: false` in agents.yaml).'));
+          console.log(chalk.gray('Held by the secrets-agent for ~7 days after one unlock (auto-cache is on by default; disable with `secrets.agent.auto: false` in agents.yaml).'));
         } else if (next === 'always') {
           console.log(chalk.gray('Asks for Touch ID every time — never auto-held.'));
         } else {

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -1715,8 +1715,17 @@ Examples:
           console.error(chalk.yellow('Aborted.'));
           return;
         }
+        const wasDaily = bundlePolicy(bundle) === 'daily';
         bundle.policy = next;
         writeBundle(bundle);
+        // Tightening daily -> always/never must take effect NOW, not up to the
+        // ~7d hold later. If the broker is already serving this bundle silently
+        // (auto-cached under the old `daily` policy), evict it so the next read
+        // re-prompts (`always`) or reads its no-ACL item directly (`never`).
+        // macOS-only + best-effort; agentLock no-ops off darwin / with no broker.
+        if (wasDaily && next !== 'daily') {
+          try { await agentLock(bundle.name); } catch { /* broker down — nothing held */ }
+        }
         console.log(chalk.green(`${bundle.name} policy set to ${next}.`));
         if (next === 'daily') {
           console.log(chalk.gray('Held by the secrets-agent for ~7 days after one unlock (auto-cache is on by default; disable with `secrets.agent.auto: false` in agents.yaml).'));

--- a/src/lib/hooks/cache.test.ts
+++ b/src/lib/hooks/cache.test.ts
@@ -32,6 +32,12 @@ describe('parseDuration', () => {
     expect(parseDuration('2hr')).toBe(7200);
   });
 
+  it('parses days', () => {
+    expect(parseDuration('1d')).toBe(86400);
+    expect(parseDuration('7d')).toBe(604800);
+    expect(parseDuration('2days')).toBe(172800);
+  });
+
   it('rejects garbage', () => {
     expect(parseDuration('abc')).toBeNull();
     expect(parseDuration('')).toBeNull();

--- a/src/lib/hooks/cache.ts
+++ b/src/lib/hooks/cache.ts
@@ -51,15 +51,16 @@ function parseShorthand(s: string): HookCacheConfig | null {
   return { ttl: ttlSec, key: 'global', prefetch };
 }
 
-/** Parse "30s" | "5m" | "1h" | plain seconds. Returns seconds, or null on failure. */
+/** Parse "30s" | "5m" | "1h" | "7d" | plain seconds. Returns seconds, or null on failure. */
 export function parseDuration(d: number | string | undefined): number | null {
   if (d == null) return null;
   if (typeof d === 'number') return Number.isFinite(d) && d > 0 ? Math.floor(d) : null;
-  const m = d.trim().match(/^(\d+)\s*(s|sec|secs|m|min|mins|h|hr|hrs)?$/i);
+  const m = d.trim().match(/^(\d+)\s*(s|sec|secs|m|min|mins|h|hr|hrs|d|day|days)?$/i);
   if (!m) return null;
   const value = parseInt(m[1], 10);
   if (!Number.isFinite(value) || value <= 0) return null;
   const unit = (m[2] || 's').toLowerCase();
+  if (unit.startsWith('d')) return value * 86400;
   if (unit.startsWith('h')) return value * 3600;
   if (unit.startsWith('m')) return value * 60;
   return value;

--- a/src/lib/secrets/agent.test.ts
+++ b/src/lib/secrets/agent.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { SecretsBundle } from './bundles.js';
-import { handleAgentRequest, shouldSelfHealForUpgrade, realBundleCount, META_CACHE_PREFIX, type StoredBundle, type Request } from './agent.js';
+import { handleAgentRequest, shouldSelfHealForUpgrade, realBundleCount, shouldWipeOnWatchEvent, META_CACHE_PREFIX, type StoredBundle, type Request } from './agent.js';
 
 /**
  * These tests target the broker's store semantics — the part with real bug
@@ -169,5 +169,28 @@ describe('shouldSelfHealForUpgrade (#435: never wipe a hot cache on upgrade)', (
   it('does not restart on an unknown version on either side (no spurious flap)', () => {
     expect(shouldSelfHealForUpgrade(true, 0, 'unknown', '1.20.22')).toBe(false);
     expect(shouldSelfHealForUpgrade(true, 0, '1.20.22', 'unknown')).toBe(false);
+  });
+});
+
+describe('shouldWipeOnWatchEvent (screen-lock survives, sleep wipes)', () => {
+  it('wipes on SLEEP', () => {
+    expect(shouldWipeOnWatchEvent('SLEEP')).toBe(true);
+    expect(shouldWipeOnWatchEvent('SLEEP\n')).toBe(true);
+  });
+
+  it('does NOT wipe on a bare screen-lock', () => {
+    // The whole point of the ~7d hold: locking the screen must not re-prompt.
+    expect(shouldWipeOnWatchEvent('LOCK')).toBe(false);
+    expect(shouldWipeOnWatchEvent('LOCK\n')).toBe(false);
+  });
+
+  it('ignores unrelated / empty helper chatter', () => {
+    expect(shouldWipeOnWatchEvent('')).toBe(false);
+    expect(shouldWipeOnWatchEvent('UNLOCK')).toBe(false);
+    expect(shouldWipeOnWatchEvent('ASLEEPING')).toBe(false); // word-boundary guarded
+  });
+
+  it('still wipes when SLEEP arrives batched with a LOCK line', () => {
+    expect(shouldWipeOnWatchEvent('LOCK\nSLEEP\n')).toBe(true);
   });
 });

--- a/src/lib/secrets/agent.test.ts
+++ b/src/lib/secrets/agent.test.ts
@@ -127,7 +127,7 @@ describe('secrets list metadata cache (broker-held snapshot)', () => {
     }
   });
 
-  it('lock-all still wipes the metadata cache (screen-lock drops it too)', () => {
+  it('lock-all still wipes the metadata cache (sleep / explicit lock drops it too)', () => {
     const store = freshStore();
     handleAgentRequest(store, loadReq(metaKey, { __snapshot__: '[]' }, 60_000), 0);
     handleAgentRequest(store, { cmd: 'lock' }, 0);

--- a/src/lib/secrets/agent.ts
+++ b/src/lib/secrets/agent.ts
@@ -16,8 +16,9 @@
  * trust boundary the keychain already concedes (docs/secrets.md: the ACL is
  * user-presence, not code-identity — any same-user process can pop the prompt
  * and read), minus the visible prompt. We bound it with: explicit per-bundle
- * opt-in (nothing is held unless you `unlock` it), an absolute TTL, auto-lock
- * on screen-lock / sleep, and `agents secrets lock`. Nothing ever touches disk.
+ * opt-in (nothing is held unless you `unlock` it), an absolute TTL (~7d), an
+ * auto-wipe on sleep / logout, and `agents secrets lock`. A bare screen-lock is
+ * NOT a wipe (the login password already gates it). Nothing ever touches disk.
  *
  * macOS only: Linux libsecret has no biometry prompt, so there's nothing to
  * deduplicate — every entry point here no-ops off darwin.
@@ -39,14 +40,14 @@ import type { SecretsBundle } from './bundles.js';
 const PROTOCOL_VERSION = 1;
 
 /** Default lifetime of an unlocked bundle when `--ttl` is not given. */
-export const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+export const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7d
 
 /**
  * Reserved store-key prefix for the `secrets list` metadata snapshot cache.
  * The broker holds the resolved bundle-metadata array (names/policy/timestamps,
  * NO resolved secret values beyond the literals already in metadata) keyed by a
  * hash of the current keychain bundle name-set, so the second and later
- * `secrets list` within the daily window read metadata without a Touch ID
+ * `secrets list` within the hold window read metadata without a Touch ID
  * prompt. Keyed by the name-set hash so adding/removing/renaming a bundle
  * changes the key and misses the cache automatically — no active invalidation.
  * The '!' sentinel can never collide with a real bundle name
@@ -67,7 +68,7 @@ const SWEEP_INTERVAL_MS = 30 * 1000;
  * code (exit so launchd relaunches it). Only when the store is EMPTY: exiting
  * with bundles still unlocked wipes them from memory, so the next reader falls
  * back to a direct keychain read and re-prompts for Touch ID. Deferring the
- * restart until the cache is idle (TTL-expired / screen-locked) means an
+ * restart until the cache is idle (TTL-expired / slept) means an
  * in-place `npm i -g` never wipes a hot cache — the new code is adopted at the
  * next quiet moment instead. See #435: rapid repeated upgrades wiped a hot
  * cache on every bump and produced a recurring Touch ID storm.
@@ -333,9 +334,22 @@ export function handleAgentRequest(
 }
 
 /**
+ * Decide whether a `watch-lock` helper line should wipe the in-memory store.
+ * The helper emits `LOCK` on screen-lock / screensaver and `SLEEP` on system
+ * sleep. We wipe on SLEEP only: a bare screen-lock is already gated by the login
+ * password, and with the ~7d hold, re-authing after every lock would defeat the
+ * point. Logout needs no line — it tears down the launchd session and kills the
+ * broker outright. Pure + exported so the LOCK-survives / SLEEP-wipes contract
+ * has direct regression coverage (the inline stdout handler isn't unit-testable).
+ */
+export function shouldWipeOnWatchEvent(chunk: string): boolean {
+  return /\bSLEEP\b/.test(chunk);
+}
+
+/**
  * Run the broker in the foreground. Spawned detached by ensureAgentRunning via
  * `agents secrets _agent-run`. Holds the store in memory, serves the socket,
- * sweeps expired entries, wipes on screen-lock/sleep, and self-exits when idle.
+ * sweeps expired entries, wipes on sleep, and self-exits when idle.
  */
 export async function runSecretsAgent(opts: { service?: boolean } = {}): Promise<void> {
   if (!onDarwin()) return; // nothing to broker without biometry prompts
@@ -376,9 +390,9 @@ export async function runSecretsAgent(opts: { service?: boolean } = {}): Promise
   const runningVersion = getCliVersion();
 
   // "Warmth" for self-heal / idle-exit counts only real unlocked bundles, NOT
-  // the internal `secrets list` metadata cache (#524). Otherwise a 24h-TTL list
+  // the internal `secrets list` metadata cache (#524). Otherwise a 7d-TTL list
   // cache would keep the store non-empty and (a) block the persistent broker
-  // from self-healing onto a freshly-installed version for up to a day (#435's
+  // from self-healing onto a freshly-installed version for up to a week (#435's
   // gate is size===0), and (b) stop a one-off broker from ever idle-exiting. The
   // metadata cache is a disposable list snapshot — wiping it on upgrade/idle
   // costs at most one extra prompt on the next `secrets list`.
@@ -457,15 +471,19 @@ export async function runSecretsAgent(opts: { service?: boolean } = {}): Promise
 
   sweepTimer = setInterval(sweep, SWEEP_INTERVAL_MS);
 
-  // Auto-lock on screen-lock / sleep. The signed helper emits LOCK / SLEEP
-  // lines; on any of them we wipe everything. If the installed helper predates
-  // watch-lock (exits non-zero immediately), we fall back to TTL-only and log
-  // nothing — the unlock already warned when lock_on_sleep couldn't be armed.
+  // Auto-lock on sleep. The signed helper emits LOCK / SLEEP lines; we wipe
+  // everything on SLEEP (and, implicitly, logout — that tears down the launchd
+  // session and kills this in-memory broker). A bare screen-lock is deliberately
+  // NOT a wipe: with the ~7d hold, re-prompting after every lock would defeat the
+  // point, and a locked screen is already gated by the login password. If the
+  // installed helper predates watch-lock (exits non-zero immediately), we fall
+  // back to TTL-only and log nothing — the unlock already warned when
+  // lock_on_sleep couldn't be armed.
   try {
     watcher = spawn(getKeychainHelperPath(), ['watch-lock'], { stdio: ['ignore', 'pipe', 'ignore'] });
     watcher.stdout?.setEncoding('utf-8');
     watcher.stdout?.on('data', (chunk: string) => {
-      if (/\b(LOCK|SLEEP)\b/.test(chunk)) {
+      if (shouldWipeOnWatchEvent(chunk)) {
         store.clear();
         emptySince = Date.now();
       }
@@ -588,7 +606,7 @@ export function agentGetMetaSync(nameSetHash: string): SecretsBundle[] | null {
 
 /**
  * Fire-and-forget: populate the broker with a freshly-read metadata snapshot so
- * the next `secrets list` within the daily window renders without a prompt.
+ * the next `secrets list` within the hold window renders without a prompt.
  * Stored as an ordinary entry (placeholder bundle, snapshot in env) under the
  * reserved META_CACHE_PREFIX key; the snapshot travels over stdin to the
  * detached worker (never argv/disk), same as value caching. macOS only.
@@ -602,7 +620,7 @@ export function agentAutoLoadMetaSync(nameSetHash: string, bundles: SecretsBundl
 
 /** True unless `secrets.agent.auto` is explicitly disabled in agents.yaml. The
  * broker is the mechanism that delivers the `daily` default policy (one Touch ID
- * per ~24h), so auto-caching is ON by default; opt out with
+ * per ~7d), so auto-caching is ON by default; opt out with
  * `secrets.agent.auto: false`. Best-effort; an unreadable meta reads as on. */
 export function secretsAgentAutoEnabled(): boolean {
   try {

--- a/src/lib/secrets/bundles.ts
+++ b/src/lib/secrets/bundles.ts
@@ -517,8 +517,12 @@ export function listBundles(): SecretsBundle[] {
       // so only the first list per ~7d prompts. The cache key is a hash of the
       // current keychain name-set (enumerated silently above): add / remove /
       // rename a bundle and the key changes, so the stale snapshot is never
-      // served — no active invalidation needed. Values are never cached here;
-      // this is metadata only.
+      // served. A same-name metadata edit (e.g. `secrets policy <b> always`)
+      // does NOT change the key, so the POLICY column in `secrets list` can lag
+      // by up to the hold window (~7d) until the next name-set change or `lock`.
+      // This is cosmetic only — enforcement always reads the bundle's live
+      // policy (readBundle), never this snapshot, and `secrets view <b>` shows
+      // the fresh value immediately. Values are never cached here; metadata only.
       const useAgent =
         process.env.AGENTS_SECRETS_NO_AGENT !== '1' &&
         !isKeychainBackendOverridden() &&

--- a/src/lib/secrets/bundles.ts
+++ b/src/lib/secrets/bundles.ts
@@ -155,11 +155,13 @@ export interface VarMeta {
 
 /**
  * A bundle's prompt policy — how often macOS asks for Touch ID to read it:
- * - `daily` (default): ask once, then hold it silently for up to ~24h. Eligible
- *   for the secrets-agent — the first real keychain read auto-loads it (auto-cache
- *   is on by default) so concurrent runs read it silently, or `unlock` it
- *   explicitly. Held from that unlock (not refreshed on use); re-asks sooner
- *   after screen-lock, sleep, logout, or `agents secrets lock`.
+ * - `daily` (default): ask once, then hold it silently for up to ~7 days.
+ *   (Historical name — the window is now a rolling ~1 week, not one calendar day.)
+ *   Eligible for the secrets-agent — the first real keychain read auto-loads it
+ *   (auto-cache is on by default) so concurrent runs read it silently, or `unlock`
+ *   it explicitly. Held from that unlock (not refreshed on use); re-asks sooner
+ *   after sleep, logout, or `agents secrets lock`. A bare screen-lock does NOT
+ *   drop it (the login password already gates a locked screen).
  * - `always`: asks every time. Never auto-held — only an explicit `agents
  *   secrets unlock` ever holds it; every other read pops Touch ID. Opt a
  *   high-value bundle into this when you want to confirm every single read.
@@ -370,7 +372,7 @@ function parsePolicy(raw: unknown): SecretsPolicy | undefined {
 
 /** The default prompt policy applied to bundles without an explicit per-bundle
  * policy. Configurable via `secrets.policy` in agents.yaml; `daily` (one Touch
- * ID per ~24h) unless the user explicitly opts back into prompt-every-time with
+ * ID per ~7d) unless the user explicitly opts back into prompt-every-time with
  * `always`. Best-effort: an unreadable config falls back to the `daily` default. */
 export function secretsDefaultPolicy(): SecretsPolicy {
   try {
@@ -512,7 +514,7 @@ export function listBundles(): SecretsBundle[] {
       // so the getKeychainTokens batch below pops Touch ID on every `secrets
       // list` — the broker/`daily` mechanism only ever covered value reads, not
       // this listing. Serve a broker-cached metadata snapshot when one is held,
-      // so only the first list per ~24h prompts. The cache key is a hash of the
+      // so only the first list per ~7d prompts. The cache key is a hash of the
       // current keychain name-set (enumerated silently above): add / remove /
       // rename a bundle and the key changes, so the stale snapshot is never
       // served — no active invalidation needed. Values are never cached here;
@@ -538,7 +540,7 @@ export function listBundles(): SecretsBundle[] {
           if (bundle) keychainBundles.push(bundle);
         }
         for (const bundle of keychainBundles) out.push(bundle);
-        // Populate the broker for the rest of the daily window (fire-and-forget).
+        // Populate the broker for the rest of the hold window (fire-and-forget).
         if (useAgent && keychainBundles.length > 0) {
           agentAutoLoadMetaSync(nameSetHash, keychainBundles, DEFAULT_TTL_MS);
         }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -661,9 +661,9 @@ export interface Meta {
   run?: RunConfig;
   /** macOS secrets-agent config. `policy` is the default prompt policy for
    * bundles without an explicit per-bundle policy: `daily` (the default) asks
-   * once per ~24h, `always` asks every time. `auto` (default on) lets the first
-   * real keychain read of a `daily` bundle populate the broker so concurrent
-   * runs read silently — set it `false` to force a prompt on every read. */
+   * once per ~7 days, `always` asks every time. `auto` (default on) lets the
+   * first real keychain read of a `daily` bundle populate the broker so
+   * concurrent runs read silently — set it `false` to force a prompt on every read. */
   secrets?: {
     policy?: 'always' | 'daily';
     agent?: {


### PR DESCRIPTION
## What

Changes the secrets **remember** behavior so an unlocked bundle stays held for a rolling **~7 days** instead of ~24h, and **survives a bare screen-lock** instead of re-prompting after every lock. Sleep and logout still wipe.

This is the `daily` prompt policy (the name is now historical — kept for wire/config compatibility).

## Why

The old `daily` policy held for only ~24h *and* the broker wiped everything on screen-lock. On a normal day of locking the Mac, that meant near-constant Touch ID re-prompts — nowhere near "remember me for a week."

## Changes

- `DEFAULT_TTL_MS` 24h → **7d** — drives both the daily-policy auto-cache and `unlock`'s default `--ttl`.
- `watch-lock` handler wipes on **SLEEP only**, not LOCK. Extracted to the pure, exported `shouldWipeOnWatchEvent()` so the *LOCK-survives / SLEEP-wipes* contract has direct regression coverage.
- `parseDuration()` gained a `d` (days) unit, so `--ttl 3d` / `7d` work (with tests).
- Refreshed all user-facing copy (`--help`, `secrets view` / `secrets policy` output, `docs/secrets.md`) from "~24h / once a day" to "~7 days / once a week".

Security boundary preserved: still opt-in per bundle, still wipes on sleep/logout/`lock`, nothing on disk. A locked screen is already gated by the login password.

## Verification (macOS, end-to-end)

- `agents secrets unlock <bundle>` → `agents secrets status` shows **`locks in 7 days`**.
- Posted the real `com.apple.screenIsLocked` distributed notification → the `watch-lock` helper emitted `LOCK`, and the broker **kept the bundle held** (no wipe).
- `npx vitest run src/lib/secrets/ src/lib/hooks/cache.test.ts` → **263 passed, 9 skipped**.

```
$ agents secrets status
BUNDLE                   KEYS  LOCKS IN
ttlprobe                 1     locks in 7 days
```