### PR TITLE
fix(shims): resolve the per-device default pin, not just central agents.yaml

### DIFF
--- a/src/lib/__tests__/shims.test.ts
+++ b/src/lib/__tests__/shims.test.ts
@@ -95,8 +95,8 @@ describe('addShimsToPath', () => {
 });
 
 describe('SHIM_SCHEMA_VERSION', () => {
-  it('is 23 (adopted-launcher fall-through when no managed version resolves)', () => {
-    expect(SHIM_SCHEMA_VERSION).toBe(23);
+  it('is 24 (shim resolves per-device default pins from devices/<machine>/agents.yaml)', () => {
+    expect(SHIM_SCHEMA_VERSION).toBe(24);
   });
 });
 

--- a/src/lib/shims.device-pins.test.ts
+++ b/src/lib/shims.device-pins.test.ts
@@ -25,7 +25,9 @@ describe('shim resolves the PER-DEVICE default pin', () => {
     expect(script).toContain('parse_agents_default "$AGENTS_USER_DIR/agents.yaml"');
   });
 
-  test('runs the device-pinned version WITHOUT the "no default set" prompt', () => {
+  // POSIX-only: the bash shim mechanism doesn't apply on Windows (which uses
+  // .cmd shims), and the CI runner has no `bash`.
+  test.skipIf(process.platform === 'win32')('runs the device-pinned version WITHOUT the "no default set" prompt', () => {
     const work = tmp();
     const userDir = path.join(work, '.agents');
     const mid = deviceId();

--- a/src/lib/shims.device-pins.test.ts
+++ b/src/lib/shims.device-pins.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { generateShimScript } from './shims.js';
+
+// Replicate machineId()/normalizeHost() so the fixture writes the device folder
+// the shim will actually read.
+function deviceId(): string {
+  const raw = process.env.AGENTS_SYNC_MACHINE_ID || os.hostname();
+  return raw.split('.')[0].trim().toLowerCase().replace(/[^a-z0-9_-]/g, '-') || 'unknown';
+}
+
+function tmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'agents-devpin-test-'));
+}
+
+describe('shim resolves the PER-DEVICE default pin', () => {
+  test('generated shim reads devices/<machine>/agents.yaml, then central', () => {
+    const script = generateShimScript('grok');
+    expect(script).toContain('machine_id()');
+    expect(script).toContain('devices/$(machine_id)/agents.yaml');
+    // central fallback still present for pre-split installs
+    expect(script).toContain('parse_agents_default "$AGENTS_USER_DIR/agents.yaml"');
+  });
+
+  test('runs the device-pinned version WITHOUT the "no default set" prompt', () => {
+    const work = tmp();
+    const userDir = path.join(work, '.agents');
+    const mid = deviceId();
+
+    // Default lives ONLY in the per-device file (post-split layout) ...
+    fs.mkdirSync(path.join(userDir, 'devices', mid), { recursive: true });
+    fs.writeFileSync(path.join(userDir, 'devices', mid, 'agents.yaml'), 'agents:\n  grok: 0.2.32\n');
+    // ... and the central agents.yaml has NO agents: section, like the real machine.
+    fs.writeFileSync(path.join(userDir, 'agents.yaml'), 'hooks: {}\n');
+    fs.mkdirSync(path.join(userDir, '.history', 'versions', 'grok', '0.2.32', 'home', '.grok'), { recursive: true });
+
+    // grok resolves its binary from ~/.grok/downloads; provide a fake one.
+    const grokDl = path.join(work, '.grok', 'downloads');
+    fs.mkdirSync(grokDl, { recursive: true });
+    const fakeGrok = path.join(grokDl, 'grok-0.2.32');
+    fs.writeFileSync(fakeGrok, '#!/bin/bash\necho DEVICE_PINNED_GROK_RAN\n');
+    fs.chmodSync(fakeGrok, 0o755);
+
+    // Materialize the shim; neutralize the baked AGENTS_BIN so the entrypoint
+    // guard passes without a real dist build.
+    const shimPath = path.join(work, 'grok');
+    const script = generateShimScript('grok').replace(/^AGENTS_BIN=.*$/m, "AGENTS_BIN='/usr/bin/true'");
+    fs.writeFileSync(shimPath, script);
+    fs.chmodSync(shimPath, 0o755);
+
+    const out = execFileSync('bash', [shimPath, '--hi'], {
+      env: { ...process.env, AGENTS_USER_DIR: userDir, HOME: work, PATH: '/usr/bin:/bin' },
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    // The device pin resolved → grok ran; the "no default set" branch never fired.
+    expect(out).toContain('DEVICE_PINNED_GROK_RAN');
+    expect(out).not.toContain('no default set');
+  });
+});

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -240,7 +240,7 @@ async function promptConflictStrategy(
 // v22 — export DISABLE_AUTOUPDATER=1 for claude shims so a pinned per-version
 //        install can't self-mutate: Claude Code's background auto-updater would
 //        otherwise rewrite the pinned binary in place. Explicit user value wins.
-export const SHIM_SCHEMA_VERSION = 23;
+export const SHIM_SCHEMA_VERSION = 24;
 
 /** Internal marker string used to embed the schema version in shim scripts. */
 const SHIM_VERSION_MARKER = 'agents-shim-version:';
@@ -381,16 +381,37 @@ find_project_version() {
   return 1
 }
 
-# Resolve version from agents.yaml (user default)
+# Parse the agents: default map of one agents.yaml for this AGENT's version.
+parse_agents_default() {
+  local meta="$1"
+  [ -f "$meta" ] || return 0
+  awk -v agent="$AGENT" '
+    /^agents:/ { in_agents=1; next }
+    in_agents && /^[^ ]/ { in_agents=0 }
+    in_agents && $0 ~ "^  " agent ":" { gsub(/.*:[[:space:]]*["'"'"']?|["'"'"']?[[:space:]]*$/, ""); print; exit }
+  ' "$meta"
+}
+
+# This machine's device id — mirrors machineId()/normalizeHost() in
+# src/lib/machine-id.ts: first hostname label, lowercased, non-[a-z0-9_-] -> '-'.
+# MUST stay in sync or the shim reads the wrong device folder.
+machine_id() {
+  local raw="\${AGENTS_SYNC_MACHINE_ID:-$(hostname 2>/dev/null)}"
+  raw=$(printf '%s' "$raw" | cut -d. -f1 | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]/-/g')
+  [ -n "$raw" ] && printf '%s' "$raw" || printf 'unknown'
+}
+
+# Resolve the default version. The agents: version pins are stored PER-DEVICE at
+# devices/<machine>/agents.yaml (moved there so multi-machine syncs never
+# conflict); read that first, then fall back to the central agents.yaml for
+# pre-split installs. Must match readMeta()'s central+device merge in state.ts --
+# reading only the central file (the old behavior) missed every device pin and
+# made the shim re-prompt "no default set" on every launch.
 resolve_default_version() {
-  local meta="$AGENTS_USER_DIR/agents.yaml"
-  if [ -f "$meta" ]; then
-    awk -v agent="$AGENT" '
-      /^agents:/ { in_agents=1; next }
-      in_agents && /^[^ ]/ { in_agents=0 }
-      in_agents && $0 ~ "^  " agent ":" { gsub(/.*:[[:space:]]*["'"'"']?|["'"'"']?[[:space:]]*$/, ""); print; exit }
-    ' "$meta"
-  fi
+  local v
+  v=$(parse_agents_default "$AGENTS_USER_DIR/devices/$(machine_id)/agents.yaml")
+  [ -n "$v" ] || v=$(parse_agents_default "$AGENTS_USER_DIR/agents.yaml")
+  printf '%s' "$v"
 }
 
 # Find the latest installed version by numeric component comparison.

--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -397,7 +397,8 @@ parse_agents_default() {
 # MUST stay in sync or the shim reads the wrong device folder.
 machine_id() {
   local raw="\${AGENTS_SYNC_MACHINE_ID:-$(hostname 2>/dev/null)}"
-  raw=$(printf '%s' "$raw" | cut -d. -f1 | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]/-/g')
+  # first label -> trim -> lowercase -> non-[a-z0-9_-] to '-' (matches normalizeHost order).
+  raw=$(printf '%s' "$raw" | cut -d. -f1 | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]/-/g')
   [ -n "$raw" ] && printf '%s' "$raw" || printf 'unknown'
 }
 


### PR DESCRIPTION
## The bug: grok (and any device-pinned agent) re-prompts "no default set" every launch

Running a bare shim (`grok`, `claude`, …) kept prompting:

```
agents: no default set for grok — found grok@0.2.82 installed
  Set as default and continue? [Y/n]
```

…on **every** invocation, even right after `agents use grok 0.2.32` reported "Set as global default."

## Root cause

The `agents:` version-default map was moved to **per-device** files — `~/.agents/devices/<machine>/agents.yaml` — so multi-machine syncs never conflict (`writeMetaUnlocked` strips `agents:`/`versions:` out of the central `~/.agents/agents.yaml`). `readMeta` merges central + device, so `agents use` and `getGlobalDefault` work correctly.

But the generated shim's `resolve_default_version` only ever read the **central** `~/.agents/agents.yaml` — which post-split has **no `agents:` section at all**. So the shim never saw the default, fell through to `find_latest_installed`, and re-prompted.

For grok it never self-heals: `find_latest_installed` picks the highest version *dir* (`0.2.82` — a stale `GROK_HOME`-symlink artifact, not a real install), so the fallback `agents use grok 0.2.82` fails ("not installed") and the pin never persists → infinite re-prompt. (Verified on the real machine: `getGlobalDefault('grok')` → `0.2.32`, but the shim's awk over central `agents.yaml` → empty.)

## Fix

`resolve_default_version` now reads `devices/<machine>/agents.yaml` **first**, then falls back to central for pre-split installs — matching `readMeta`'s central+device merge. Adds a `machine_id()` shim helper mirroring `machineId()`/`normalizeHost()` in `src/lib/machine-id.ts` (first hostname label, lowercased, non-`[a-z0-9_-]` → `-`). Bumps `SHIM_SCHEMA_VERSION` 23 → 24 so shims regenerate.

## Verified end-to-end

`shims.device-pins.test.ts` runs the **actual generated shim** against a fixture where the default lives only in `devices/<machine>/agents.yaml` (central has no `agents:`): the shim resolves the pinned version and launches with **no prompt**. Confirmed the bash-computed machine id matches the real device folder (`zion`). All shim suites green.