### PR TITLE
docs(release): changelog for #711 + require Unreleased notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **`agents sessions --json --host <h>` now emits a clean JSON array** of recent (non-active) sessions instead of the legacy per-host raw banner stream, so a UI can fetch a remote device's recent sessions when it has no live agents. `serializeSessionsJson()` is shared by the local and remote `--json` paths; `runRemoteSessionsJson()` reuses the existing `gatherRemoteList` SSH fan-out. The non-JSON banner path and `--active` are unchanged (#711).
+
 ## 1.20.36
 
 **[windows] `agents sessions --active` detects sessions on Windows, and shim launches carry cwd + session identity everywhere**

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -475,8 +475,13 @@ if ! $MAIN_AT_TARGET; then
       green "Rolled CHANGELOG: ## Unreleased -> ## $TARGET"
       PR_BODY="$(printf '## %s\n\n%s' "$TARGET" "$unrel_content")"
     else
-      gray "CHANGELOG: no Unreleased content to roll"
+      red "CHANGELOG: '## Unreleased' is empty — a release must document itself." >&2
+      red "  Add release notes under '## Unreleased' in CHANGELOG.md before releasing $TARGET." >&2
+      exit 1
     fi
+  else
+    red "CHANGELOG.md not found — a release must document itself." >&2
+    exit 1
   fi
 
   # Build the release commit from the index WITHOUT moving HEAD. The signed +


### PR DESCRIPTION
#711 merged without a CHANGELOG entry, and `release.sh` only *warned* (gray) on an empty `## Unreleased` before rolling it into the version — so a release could ship undocumented.

- Add the `sessions --json --host` clean-array note under `## Unreleased`.
- `release.sh`: empty `## Unreleased` (or missing CHANGELOG.md) is now a hard error before any publish — a release must document itself.

`bash -n scripts/release.sh` clean.