### PR TITLE
chore(sessions): retire `go` → `focus --attach-only`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **`agents sessions go` is retired as a deprecated alias for `agents sessions focus --attach-only`.** `go` was already a strict subset of `focus` — its only unique behavior was "attach the live terminal or refuse, never fork/resume." That behavior is now a first-class `--attach-only` flag on `focus` (`focus.ts`: `selectFallback()` picks `refuseFallback` under `--attach-only`, else the resume-in-a-new-tab fallback). `go` now prints a one-line deprecation notice and delegates to `focusAction(id, { attachOnly: true })`; the shared reach engine (`jumpTo`/`gatherLiveTargets`/`pickLiveTarget`/`refuseFallback`) still lives in `go.ts` and is imported by `focus.ts`. Source: `src/commands/go.ts`, `src/commands/focus.ts`.
 - **`agents sessions --json --host <h>` now emits a clean JSON array** of recent (non-active) sessions instead of the legacy per-host raw banner stream, so a UI can fetch a remote device's recent sessions when it has no live agents. `serializeSessionsJson()` is shared by the local and remote `--json` paths; `runRemoteSessionsJson()` reuses the existing `gatherRemoteList` SSH fan-out. The non-JSON banner path and `--active` are unchanged (#711).
 
 ## 1.20.36

--- a/src/commands/focus.test.ts
+++ b/src/commands/focus.test.ts
@@ -1,11 +1,23 @@
 import { describe, it, expect } from 'vitest';
-import { metaFromActive } from './focus.js';
+import { metaFromActive, selectFallback } from './focus.js';
+import { refuseFallback } from './go.js';
 import { buildResumeCommand } from './sessions.js';
 import type { ActiveSession } from '../lib/session/active.js';
 
 function s(over: Partial<ActiveSession>): ActiveSession {
   return { context: 'terminal', kind: 'claude', status: 'running', ...over } as ActiveSession;
 }
+
+describe('selectFallback — --attach-only (old `go`) vs default resume', () => {
+  it('--attach-only picks refuseFallback (attach or refuse, never fork)', () => {
+    expect(selectFallback(true)).toBe(refuseFallback);
+  });
+
+  it('default (undefined/false) picks resume-in-new-tab, not refuseFallback', () => {
+    expect(selectFallback(undefined)).not.toBe(refuseFallback);
+    expect(selectFallback(false)).not.toBe(refuseFallback);
+  });
+});
 
 describe('metaFromActive — the resume fallback input', () => {
   it('carries id, short id, agent, and cwd through', () => {

--- a/src/commands/focus.ts
+++ b/src/commands/focus.ts
@@ -16,7 +16,7 @@
 import type { Command } from 'commander';
 import fs from 'node:fs';
 import chalk from 'chalk';
-import { gatherLiveTargets, pickLiveTarget, jumpTo, type UnreachableFallback } from './go.js';
+import { gatherLiveTargets, pickLiveTarget, jumpTo, refuseFallback, type UnreachableFallback } from './go.js';
 import type { ActiveSession } from '../lib/session/active.js';
 import type { SessionMeta, SessionAgentId } from '../lib/session/types.js';
 import { buildResumeCommand, resumeSessionInPlace } from './sessions.js';
@@ -36,20 +36,31 @@ export function registerFocusCommand(program: Command): void {
     .command('focus')
     .argument('[id]', 'Short/full session id to focus; omit for an interactive picker')
     .option('--local', 'Only this machine (skip the cross-host sweep)')
+    .option('--attach-only', 'Attach only — never open a new tab / resume a copy (the old `go` behavior)')
     .description('Focus a live session — attach its terminal, or open a new tab and resume it')
-    .action(async (id: string | undefined, opts: { local?: boolean }) => {
+    .action(async (id: string | undefined, opts: { local?: boolean; attachOnly?: boolean }) => {
       await focusAction(id, opts);
     });
 }
 
-async function focusAction(id: string | undefined, opts: { local?: boolean }): Promise<void> {
+/**
+ * Which fallback fires when a session has no attach rail. `--attach-only` (the old
+ * `go`) refuses; the default opens a new tab and resumes a copy. Pure so it's testable
+ * without touching `jumpTo`'s side effects.
+ */
+export function selectFallback(attachOnly: boolean | undefined): UnreachableFallback {
+  return attachOnly ? refuseFallback : resumeInNewTab;
+}
+
+export async function focusAction(id: string | undefined, opts: { local?: boolean; attachOnly?: boolean }): Promise<void> {
   const { self, activeById } = await gatherLiveTargets(!!opts.local);
+  const fallback = selectFallback(opts.attachOnly);
 
   if (id) {
     const q = id.toLowerCase();
     const matches = [...activeById.values()].filter((s) => s.sessionId!.toLowerCase().startsWith(q));
     if (matches.length === 1) {
-      await jumpTo(matches[0], self, resumeInNewTab);
+      await jumpTo(matches[0], self, fallback);
       return;
     }
     if (matches.length > 1) {
@@ -77,7 +88,7 @@ async function focusAction(id: string | undefined, opts: { local?: boolean }): P
   }
   const target = await pickLiveTarget(activeById, self, 'Focus a live session:', 'focus');
   if (!target) return;
-  await jumpTo(target, self, resumeInNewTab);
+  await jumpTo(target, self, fallback);
 }
 
 function shortId(s: ActiveSession): string {

--- a/src/commands/go.ts
+++ b/src/commands/go.ts
@@ -1,17 +1,17 @@
 /**
- * `agents sessions go [id]` — jump to a LIVE agent session's terminal.
+ * `agents sessions go [id]` — DEPRECATED alias for `agents sessions focus --attach-only`.
  *
- * No id  -> the SAME rich interactive picker as `agents sessions` (worktree, PR,
- *           changed files, tools, tests, last response — this-machine first),
- *           filtered to sessions that are running right now.
- * With id -> jump directly.
+ * `go` was "attach or refuse" (never fork/resume). `focus --attach-only` is exactly
+ * that behavior, so `go` now prints a deprecation notice and delegates to `focusAction`.
  *
- * "Jump" is not "resume" (which spawns a new process from the transcript). It walks
- * you to the already-running terminal:
- *   local tmux    -> attach (switch-client when already inside tmux)
- *   local Ghostty -> focus its tab (Cmd+<n> via System Events; tab # from ghostty-tabs)
- *   remote tmux   -> ssh -tt + tmux attach (pane->session resolved on the remote)
- *   otherwise     -> refuse with a reason + resume hint (cloud / no attach rail)
+ * This file still owns the shared reach engine that `focus` imports:
+ *   - `gatherLiveTargets` / `pickLiveTarget` / `buildLivePool` — live-session discovery + picker
+ *   - `jumpTo` — the side-effecting jump: attach the already-running terminal
+ *       local tmux    -> attach (switch-client when already inside tmux)
+ *       local Ghostty -> focus its tab (Cmd+<n> via System Events; tab # from ghostty-tabs)
+ *       remote tmux   -> ssh -tt + tmux attach (pane->session resolved on the remote)
+ *       otherwise     -> hand off to the `UnreachableFallback` (attach-only refuses; focus resumes)
+ *   - `refuseFallback` — the attach-only fallback (remote -> login shell; local -> refuse)
  */
 
 import type { Command } from 'commander';
@@ -24,8 +24,8 @@ import { gatherRemoteActive } from '../lib/session/remote-active.js';
 import { discoverSessions } from '../lib/session/discover.js';
 import type { SessionMeta, SessionAgentId } from '../lib/session/types.js';
 import { dedupeByMachineSession, mergeLocalFirst, pickSessionInteractive } from './sessions.js';
+import { focusAction } from './focus.js';
 import { machineId } from '../lib/session/sync/config.js';
-import { isInteractiveTerminal } from './utils.js';
 import { attachTmux, runTmux } from '../lib/tmux/binary.js';
 import { getDefaultSocketPath } from '../lib/tmux/paths.js';
 import { sshStream, assertValidSshTarget, shellQuote } from '../lib/ssh-exec.js';
@@ -38,9 +38,10 @@ export function registerGoCommand(program: Command): void {
     .command('go')
     .argument('[id]', 'Short/full session id to jump to; omit for an interactive picker')
     .option('--local', 'Only this machine (skip the cross-host sweep)')
-    .description('Jump to a live agent session — attach its tmux, or focus its terminal tab')
+    .description('Deprecated alias for `sessions focus --attach-only`')
     .action(async (id: string | undefined, opts: { local?: boolean }) => {
-      await goAction(id, opts);
+      console.error(chalk.yellow('`sessions go` is deprecated — use `sessions focus --attach-only`'));
+      await focusAction(id, { local: opts.local, attachOnly: true });
     });
 }
 
@@ -73,43 +74,6 @@ export async function pickLiveTarget(
   const picked = await pickSessionInteractive(pool, message, undefined, 0, enterHint);
   if (!picked) return null;
   return activeById.get(picked.session.id) ?? null;
-}
-
-async function goAction(id: string | undefined, opts: { local?: boolean }): Promise<void> {
-  const { self, activeById } = await gatherLiveTargets(!!opts.local);
-
-  if (activeById.size === 0) {
-    console.log(chalk.gray('No live agent sessions to jump to.'));
-    return;
-  }
-
-  // Direct jump by id — no picker.
-  if (id) {
-    const q = id.toLowerCase();
-    const matches = [...activeById.values()].filter((s) => s.sessionId!.toLowerCase().startsWith(q));
-    if (matches.length === 0) {
-      console.error(chalk.red(`No live session matching "${id}".`));
-      process.exitCode = 1;
-      return;
-    }
-    if (matches.length > 1) {
-      console.error(chalk.red(`"${id}" is ambiguous (${matches.length} matches). Use more of the id.`));
-      process.exitCode = 1;
-      return;
-    }
-    await jumpTo(matches[0], self);
-    return;
-  }
-
-  if (!isInteractiveTerminal()) {
-    console.error(chalk.red('go needs an interactive terminal, or pass a session id.'));
-    process.exitCode = 1;
-    return;
-  }
-
-  const target = await pickLiveTarget(activeById, self, 'Jump to a live session:', 'jump');
-  if (!target) return;
-  await jumpTo(target, self);
 }
 
 /**
@@ -185,8 +149,8 @@ export function describeWhere(s: ActiveSession, self: string): Where {
  */
 export type UnreachableFallback = (s: ActiveSession, remote: string | undefined) => void | Promise<void>;
 
-/** Default (used by `go`): open a login shell on the remote, or refuse locally. */
-async function refuseFallback(s: ActiveSession, remote: string | undefined): Promise<void> {
+/** Default (attach-only): open a login shell on the remote, or refuse locally. */
+export async function refuseFallback(s: ActiveSession, remote: string | undefined): Promise<void> {
   if (remote) {
     console.log(chalk.yellow(`${shortId(s)} on ${remote} isn't inside tmux — opening a shell on ${remote} instead.`));
     assertValidSshTarget(remote);


### PR DESCRIPTION
## What

`agents sessions focus [id]` (merged in #714-era) is a superset of `sessions go`: it attaches a live session (tmux/Ghostty/remote), or — when there's no attach rail — opens a new tab and resumes it. `go` was a **strict subset**: it attaches or **refuses** (never resumes/forks). The only behavior unique to `go` is *attach-only, never fork*.

This PR preserves that one use case as a `--attach-only` flag on `focus`, then retires `go` to a thin deprecated alias.

## Before → after

**`sessions go`**
- Before: a standalone command with its own `goAction` (a near-duplicate of the `focus` id/picker flow, minus the resume fallback).
- After: prints `` `sessions go` is deprecated — use `sessions focus --attach-only` `` and delegates to `focusAction(id, { attachOnly: true })`. No duplicated flow.

**`sessions focus`**
- New `--attach-only` flag: *"Attach only — never open a new tab / resume a copy (the old `go` behavior)"*.
- `selectFallback(attachOnly)` picks `refuseFallback` (attach-or-refuse) when set, else the resume-in-a-new-tab fallback; the chosen fallback is threaded into **both** `jumpTo` calls (id path + picker path).

The shared reach engine (`jumpTo`, `gatherLiveTargets`, `pickLiveTarget`, `buildLivePool`, `refuseFallback`, `UnreachableFallback`, tmux/Ghostty jump primitives) stays in `go.ts` and is imported by `focus.ts` — unchanged.

## Preserved use case (the one thing `go` did that `focus` didn't)

**Attach-only / never-fork.** For a session with no attach rail, plain `focus` opens a new tab and resumes a *copy*. `--attach-only` refuses instead (remote → login shell; local → refuse + resume hint), so you never accidentally fork a mid-run session.

## Verification

- `bun run build` → clean (exit 0).
- vitest green: `go.test.ts` + `focus.test.ts`, 14 tests (added `selectFallback` coverage — attach-only → `refuseFallback`, default → not).
- `agents sessions go zzzz` → prints the deprecation notice **and** `No live session matching "zzzz"` (proves it delegates to focus attach-only).
- `agents sessions focus --help` → shows `--attach-only`.
- `agents sessions go --help` → still resolves (deprecated alias).

CHANGELOG: `## Unreleased` entry added (main now requires Unreleased notes to release, per #715).