### PR TITLE
test(computer): make appPathIsElectron test path-separator portable

### DIFF
--- a/src/commands/computer-actions.test.ts
+++ b/src/commands/computer-actions.test.ts
@@ -383,7 +383,11 @@ describe('shouldRaise', () => {
 describe('appPathIsElectron', () => {
   const framework = 'Contents/Frameworks/Electron Framework.framework';
   it('is true when the .app bundles the Electron framework', () => {
-    const exists = (p: string) => p === `/Applications/VSCodium.app/${framework}`;
+    // appPathIsElectron joins with path.join (platform separators), so build the
+    // expected path the same way — else on Windows ('\\') it never matches the
+    // '/'-joined literal and the test fails.
+    const expected = path.join('/Applications/VSCodium.app', framework);
+    const exists = (p: string) => p === expected;
     expect(appPathIsElectron('/Applications/VSCodium.app', exists)).toBe(true);
   });
 


### PR DESCRIPTION
## Windows CI matrix was red — blocking releases

`appPathIsElectron` correctly uses `path.join(appPath, 'Contents', 'Frameworks', 'Electron Framework.framework')` (platform separators). But its test's mock `exists()` compared against a **`/`-joined literal** (`/Applications/VSCodium.app/${framework}`). On Windows `path.join` produces `\`-separated paths, so the mock never matched → `AssertionError: expected false to be true` on both `build (windows-latest, 22)` and `(24)`.

Linux/macOS PR CI is green (same separators), so it merged unnoticed and only surfaces in the **release matrix** (cost-gated to release branches) — where it blocked the 1.20.41 release.

## Fix

Build the expected path with `path.join` too, so the mock matches the function's output on every platform. One-line, test-only.

Verified: `computer-actions.test.ts` — 51 passed locally.