### PR TITLE
test(computer): build the Electron framework path with path.join (Windows portability)

### DIFF
--- a/src/commands/computer-actions.test.ts
+++ b/src/commands/computer-actions.test.ts
@@ -381,10 +381,13 @@ describe('shouldRaise', () => {
 });
 
 describe('appPathIsElectron', () => {
-  const framework = 'Contents/Frameworks/Electron Framework.framework';
+  // Build the expected path with path.join so the fake `exists` matches what
+  // appPathIsElectron computes on any platform (Windows uses backslashes).
+  const appPath = '/Applications/VSCodium.app';
+  const frameworkPath = path.join(appPath, 'Contents', 'Frameworks', 'Electron Framework.framework');
   it('is true when the .app bundles the Electron framework', () => {
-    const exists = (p: string) => p === `/Applications/VSCodium.app/${framework}`;
-    expect(appPathIsElectron('/Applications/VSCodium.app', exists)).toBe(true);
+    const exists = (p: string) => p === frameworkPath;
+    expect(appPathIsElectron(appPath, exists)).toBe(true);
   });
 
   it('is false for a native .app with no Electron framework', () => {


### PR DESCRIPTION
## Bug

The `appPathIsElectron` test I added in #716 hardcoded a **forward-slash** expected path, but the function builds it with `path.join` — which uses **backslashes on Windows**. So the fake `exists()` never matched and `× is true when the .app bundles the Electron framework` failed on `windows-latest`, blocking the 1.20.41 release. (The cheap PR checks don't run the Windows build matrix — it only runs at release time, which is why #716 looked green.)

## Fix

Build the expected path with `path.join` too, so it matches what the function computes on any OS.

## Verified on the actual Windows machine (win-mini, win32)

```
joined: "\\Applications\\VSCodium.app\\Contents\\Frameworks\\Electron Framework.framework"
OLD_test_passes: false   # reproduces the CI failure
NEW_test_passes: true    # the fix
```