### PR TITLE
docs(agents): note prix/code-reviewer is the non-author PR review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,7 @@ scripts/release.sh <version> --apply  # commits chore(release), tags v<version>,
 - `AGENTS.md` is canonical; `CLAUDE.md` / `GEMINI.md` are symlinks. **Edit `AGENTS.md` only.**
 - `agents repo push` / `pull` operates on `~/.agents/` only. System updates ride `npm update -g @phnx-labs/agents-cli`.
 - Real services only — no mocking. Tests must exercise the actual critical path (see [CLAUDE.md](CLAUDE.md) testing rules).
+- **PRs are auto-reviewed by `prix/code-reviewer`** ([`.github/rush.yml`](.github/rush.yml)) — it reviews every PR to `main` and posts its verdict as the **`prix-cloud`** comment. That is the non-author review: rely on it and merge on green, don't spawn a redundant subagent reviewer. Review manually only if `prix-cloud` hasn't posted after CI settles or flags something to dig into. (It's a Rush Cloud app, not a `.github/workflows/` Action.)
 
 ## Security
 


### PR DESCRIPTION
## What

Adds a Conventions bullet to `AGENTS.md` recording that this repo's PRs are auto-reviewed by `prix/code-reviewer` (declared in `.github/rush.yml`), which posts its verdict as the `prix-cloud` comment.

## Why

The merge guard requires a **non-author** review before merge-on-green. `prix-cloud` already provides that here, but it's a **Rush Cloud app config**, not a `.github/workflows/` Action — so an agent scanning `.github/workflows/` won't see it and may spin up a redundant subagent review (as happened this session). This note tells agents to rely on `prix-cloud` and only review manually if it hasn't posted after CI settles or flags something.

Docs-only; no code or behavior change.