### PR TITLE
feat(factory): tmux terminals + pane/viewing-in on Factory Floor (extension half of #731)

### DIFF
--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -567,10 +567,20 @@
           "default": ".assets",
           "description": "Folder for storing images and attachments from the markdown editor"
         },
-        "agents.enableTmux": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable tmux for per-tab splits in agent terminals. When enabled, Cmd+Shift+H/V create tmux panes instead of VS Code editor splits."
+        "agents.terminalMode": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "tmux",
+            "native"
+          ],
+          "enumDescriptions": [
+            "Use tmux when available (macOS/Linux with tmux on PATH), otherwise a native VS Code terminal.",
+            "Always run agents inside tmux; warn and fall back to native when tmux is unavailable.",
+            "Never use tmux; always use a native VS Code editor terminal."
+          ],
+          "default": "auto",
+          "description": "How agent terminals are launched. 'auto' (default) runs agents inside a tmux session on macOS/Linux for uniform addressing, resume, and tracking — falling back to a native terminal on Windows or when tmux is missing. Cmd+Shift+H/V create tmux panes instead of VS Code editor splits when tmux is active."
         },
         "agents.worktreePerTerminal": {
           "type": "boolean",

--- a/apps/factory/src/core/remoteSessions.test.ts
+++ b/apps/factory/src/core/remoteSessions.test.ts
@@ -215,6 +215,27 @@ describe('normalizeActiveSession', () => {
     expect(s.replyMuxSocket).toBe('/tmp/tmux-1000/default');
   });
 
+  test('captures the session pane from provenance.mux and viewingIn', () => {
+    const s = normalizeActiveSession(
+      { context: 'terminal', kind: 'claude', sessionId: 'abc', status: 'running',
+        viewingIn: 'Codium tab 3',
+        provenance: { transport: 'local', mux: { pane: '%42', socket: '/sock', session: 'agents-1' } } },
+      'this-mac', FETCHED_AT,
+    );
+    expect(s.tmuxPane).toBe('%42');
+    expect(s.viewingIn).toBe('Codium tab 3');
+  });
+
+  test('tmuxPane falls back to the reply-rail pane when mux is absent', () => {
+    const s = normalizeActiveSession(
+      { context: 'terminal', kind: 'claude', sessionId: 'abc', status: 'running',
+        provenance: { transport: 'ssh', reply: { rail: 'tmux', target: '%65', socket: '/tmp/s' } } },
+      'yosemite-s0', FETCHED_AT,
+    );
+    expect(s.tmuxPane).toBe('%65');
+    expect(s.viewingIn).toBe('');
+  });
+
   test('a raw TTY with reply=null carries no rail', () => {
     const s = normalizeActiveSession(
       { context: 'terminal', kind: 'claude', sessionId: 'ghost', status: 'running',

--- a/apps/factory/src/core/remoteSessions.ts
+++ b/apps/factory/src/core/remoteSessions.ts
@@ -143,6 +143,13 @@ export interface RemoteSession {
   replyMuxTarget: string;
   /** tmux socket path for the tmux rail. Empty otherwise. */
   replyMuxSocket: string;
+  /** The session's own tmux `%N` pane handle (from `provenance.mux.pane`), shown
+   *  on the card for unique addressing. Falls back to the reply-rail pane when the
+   *  CLI hasn't populated mux yet. Empty for non-tmux sessions. */
+  tmuxPane: string;
+  /** Where the session is currently being viewed, pre-formatted by the CLI (e.g.
+   *  "Codium tab 3", "Ghostty tab 2", "detached"). '' when the CLI supplies none. */
+  viewingIn: string;
 }
 
 /** One machine's worth of sessions plus its reachability + freshness stamp. */
@@ -198,12 +205,18 @@ export interface RawActiveSession {
   branch?: string;
   prUrl?: string;
   ticket?: string;
+  /** Where the session is being viewed right now, pre-formatted by the CLI's
+   *  client resolver (e.g. "Codium tab 3", "Ghostty tab 2", "detached"). */
+  viewingIn?: string;
   /** How the CLI says a reply reaches this session. `reply` is null for raw TTYs
    *  (e.g. bare Ghostty) with no programmatic input channel; a tmux-backed session
-   *  carries the socket + pane to drive via `tmux send-keys` (over ssh when remote). */
+   *  carries the socket + pane to drive via `tmux send-keys` (over ssh when remote).
+   *  `mux` carries the session's OWN pane/socket (its authoritative %pane handle),
+   *  distinct from the reply rail which may target a different pane. */
   provenance?: {
     transport?: string;
     reply?: { rail?: string; target?: string; socket?: string } | null;
+    mux?: { pane?: string; socket?: string; session?: string } | null;
   } | null;
 }
 
@@ -394,6 +407,10 @@ export function normalizeActiveSession(
     replyRail: raw.provenance?.reply?.rail || '',
     replyMuxTarget: raw.provenance?.reply?.target || '',
     replyMuxSocket: raw.provenance?.reply?.socket || '',
+    // Prefer the session's own pane (provenance.mux.pane); fall back to the
+    // reply-rail pane, which today already carries a %pane for tmux sessions.
+    tmuxPane: raw.provenance?.mux?.pane || raw.provenance?.reply?.target || '',
+    viewingIn: asStr(raw.viewingIn),
   };
 }
 

--- a/apps/factory/src/core/tabIndex.test.ts
+++ b/apps/factory/src/core/tabIndex.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'bun:test';
+import { resolveTabIndex, type TabView } from './tabIndex';
+
+const term = (label: string): TabView => ({ label, isTerminal: true });
+const file = (label: string): TabView => ({ label, isTerminal: false });
+
+describe('resolveTabIndex', () => {
+  it('returns the 1-based position of the matching terminal tab within its group', () => {
+    const groups = [[file('README.md'), term('CC - auth'), term('CX - ui')]];
+    expect(resolveTabIndex(groups, 'CC - auth')).toBe(2);
+    expect(resolveTabIndex(groups, 'CX - ui')).toBe(3);
+  });
+
+  it('indexes relative to the tab position, counting non-terminal tabs', () => {
+    // The file tab at index 0 still shifts the terminal to tab 2.
+    expect(resolveTabIndex([[file('index.ts'), term('CC')]], 'CC')).toBe(1 + 1);
+  });
+
+  it('resolves per-group, scanning groups in order', () => {
+    const groups = [[file('a.ts'), term('CC')], [term('CX'), term('GX')]];
+    expect(resolveTabIndex(groups, 'CC')).toBe(2); // group 0, position 2
+    expect(resolveTabIndex(groups, 'CX')).toBe(1); // group 1, position 1
+    expect(resolveTabIndex(groups, 'GX')).toBe(2); // group 1, position 2
+  });
+
+  it('ignores non-terminal tabs even when their label matches', () => {
+    expect(resolveTabIndex([[file('CC'), term('CX')]], 'CC')).toBeUndefined();
+  });
+
+  it('returns undefined when nothing matches', () => {
+    expect(resolveTabIndex([[term('CC')]], 'nope')).toBeUndefined();
+    expect(resolveTabIndex([], 'CC')).toBeUndefined();
+    expect(resolveTabIndex([[]], 'CC')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty terminal name', () => {
+    expect(resolveTabIndex([[term('')]], '')).toBeUndefined();
+  });
+
+  it('takes the first match within a group when labels are ambiguous', () => {
+    expect(resolveTabIndex([[term('CC'), term('CC')]], 'CC')).toBe(1);
+  });
+});

--- a/apps/factory/src/core/tabIndex.ts
+++ b/apps/factory/src/core/tabIndex.ts
@@ -1,0 +1,40 @@
+// Resolve which editor-tab index a terminal occupies — pure, no VS Code import.
+//
+// The extension publishes each agent terminal's editor-tab position so the CLI
+// can render "viewing in Codium tab N". VS Code's `vscode.window.tabGroups.all`
+// is the source: a tab whose `input instanceof vscode.TabInputTerminal` and
+// whose `label` matches the terminal name is that terminal's tab. Matching by
+// exact label mirrors findTerminalNameByTabLabel (core/utils.ts). This module
+// is the pure core so it can be unit-tested without an extension host.
+
+/** A single editor tab, flattened from vscode.Tab for pure resolution. */
+export interface TabView {
+  /** The tab's display label (equals the terminal name for agent terminals). */
+  label: string;
+  /** True when the tab hosts a terminal (input instanceof TabInputTerminal). */
+  isTerminal: boolean;
+}
+
+/**
+ * Find the 1-based index of `terminalName`'s tab WITHIN ITS GROUP.
+ *
+ * Groups are scanned in order; within a group we return the position (1-based)
+ * of the first terminal tab whose label matches the terminal name exactly. The
+ * index is group-relative because that is the addressable "tab N" a user sees
+ * inside an editor group — VS Code has no global tab number. When two terminal
+ * tabs share a label in the same group (ambiguous), the first wins, which is
+ * exactly "use the tab's index within its group".
+ *
+ * Returns undefined when no terminal tab matches (e.g. a panel terminal, which
+ * is not an editor tab, or a name that isn't open as a tab).
+ */
+export function resolveTabIndex(groups: TabView[][], terminalName: string): number | undefined {
+  if (!terminalName) return undefined;
+  for (const tabs of groups) {
+    for (let i = 0; i < tabs.length; i++) {
+      const tab = tabs[i];
+      if (tab.isTerminal && tab.label === terminalName) return i + 1;
+    }
+  }
+  return undefined;
+}

--- a/apps/factory/src/core/terminalMode.test.ts
+++ b/apps/factory/src/core/terminalMode.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'bun:test';
+import { normalizeTerminalMode, resolveTerminalMode } from './terminalMode';
+
+describe('normalizeTerminalMode', () => {
+  it('passes through the two explicit non-default modes', () => {
+    expect(normalizeTerminalMode('tmux')).toBe('tmux');
+    expect(normalizeTerminalMode('native')).toBe('native');
+  });
+
+  it('defaults everything else to auto (the new tmux-by-default behavior)', () => {
+    expect(normalizeTerminalMode('auto')).toBe('auto');
+    expect(normalizeTerminalMode(undefined)).toBe('auto');
+    expect(normalizeTerminalMode(null)).toBe('auto');
+    expect(normalizeTerminalMode('')).toBe('auto');
+    expect(normalizeTerminalMode('TMUX')).toBe('auto'); // case-sensitive
+    expect(normalizeTerminalMode(true)).toBe('auto'); // stale legacy boolean
+    expect(normalizeTerminalMode(false)).toBe('auto');
+    expect(normalizeTerminalMode('bogus')).toBe('auto');
+  });
+});
+
+describe('resolveTerminalMode', () => {
+  it('auto uses tmux when available, native otherwise, never warns', () => {
+    expect(resolveTerminalMode('auto', true)).toEqual({ useTmux: true, warnUnavailable: false });
+    expect(resolveTerminalMode('auto', false)).toEqual({ useTmux: false, warnUnavailable: false });
+  });
+
+  it('tmux forces tmux when available and warns+falls-back when not', () => {
+    expect(resolveTerminalMode('tmux', true)).toEqual({ useTmux: true, warnUnavailable: false });
+    expect(resolveTerminalMode('tmux', false)).toEqual({ useTmux: false, warnUnavailable: true });
+  });
+
+  it('native never uses tmux and never warns, regardless of availability', () => {
+    expect(resolveTerminalMode('native', true)).toEqual({ useTmux: false, warnUnavailable: false });
+    expect(resolveTerminalMode('native', false)).toEqual({ useTmux: false, warnUnavailable: false });
+  });
+});

--- a/apps/factory/src/core/terminalMode.ts
+++ b/apps/factory/src/core/terminalMode.ts
@@ -1,0 +1,47 @@
+// Terminal-launch mode for agent terminals — pure resolution, no VS Code import.
+//
+// Replaces the old default-off `agents.enableTmux` boolean. The extension used
+// to opt IN to tmux; now tmux is the default on macOS/Linux via 'auto'. This
+// module is the single decision point for "tmux or native" so extension.ts
+// never re-derives it inline.
+
+/**
+ * User-facing setting `agents.terminalMode`:
+ *   - 'auto'   — tmux when available (macOS/Linux with tmux on PATH), else native.
+ *   - 'tmux'   — force tmux; warn + fall back to native when tmux is unavailable.
+ *   - 'native' — never tmux (the pre-tmux VS Code editor-terminal path).
+ */
+export type TerminalMode = 'auto' | 'tmux' | 'native';
+
+export interface TerminalModeDecision {
+  /** Spawn the agent inside tmux (createTmuxTerminal) vs the native terminal. */
+  useTmux: boolean;
+  /** The user forced 'tmux' but tmux isn't available — the UI should warn. */
+  warnUnavailable: boolean;
+}
+
+/**
+ * Coerce an untrusted config value to a valid TerminalMode. Anything that is
+ * not exactly 'tmux' or 'native' — including undefined, a stale boolean, or a
+ * typo — resolves to the new default 'auto'. This is also the back-compat path:
+ * a user who never set the (now-removed) enableTmux boolean lands on 'auto',
+ * which means "tmux by default when available".
+ */
+export function normalizeTerminalMode(raw: unknown): TerminalMode {
+  return raw === 'tmux' || raw === 'native' ? raw : 'auto';
+}
+
+/**
+ * Decide whether to use tmux given the mode and whether tmux is available.
+ *   - native → never tmux, never warn.
+ *   - tmux   → tmux iff available; warn when it isn't (the user asked for it).
+ *   - auto   → tmux iff available; never warn (silent, graceful fallback).
+ */
+export function resolveTerminalMode(
+  mode: TerminalMode,
+  tmuxAvailable: boolean,
+): TerminalModeDecision {
+  if (mode === 'native') return { useTmux: false, warnUnavailable: false };
+  if (mode === 'tmux') return { useTmux: tmuxAvailable, warnUnavailable: !tmuxAvailable };
+  return { useTmux: tmuxAvailable, warnUnavailable: false };
+}

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -82,6 +82,7 @@ import {
   tmuxSplitV,
   isTmuxAvailable
 } from './tmux';
+import { normalizeTerminalMode, resolveTerminalMode } from '../core/terminalMode';
 import { DEFAULT_DISPLAY_PREFERENCES } from '../core/settings';
 import * as readiness from './terminalReadiness';
 import { resolveAlias, isAgentInstalled } from '../core/agentModels';
@@ -994,10 +995,10 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('agents.newAgentHSplit', async () => {
       const config = vscode.workspace.getConfiguration('agents');
-      const enableTmux = config.get<boolean>('enableTmux', false);
+      const tmuxEnabled = normalizeTerminalMode(config.get('terminalMode')) !== 'native';
       const terminal = vscode.window.activeTerminal;
 
-      if (enableTmux && terminal && isTmuxTerminal(terminal)) {
+      if (tmuxEnabled && terminal && isTmuxTerminal(terminal)) {
         const state = getTmuxState(terminal);
         if (state) {
           const agentDef = getBuiltInByKey(state.agentType);
@@ -1024,10 +1025,10 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('agents.newAgentVSplit', async () => {
       const config = vscode.workspace.getConfiguration('agents');
-      const enableTmux = config.get<boolean>('enableTmux', false);
+      const tmuxEnabled = normalizeTerminalMode(config.get('terminalMode')) !== 'native';
       const terminal = vscode.window.activeTerminal;
 
-      if (enableTmux && terminal && isTmuxTerminal(terminal)) {
+      if (tmuxEnabled && terminal && isTmuxTerminal(terminal)) {
         const state = getTmuxState(terminal);
         if (state) {
           const agentDef = getBuiltInByKey(state.agentType);
@@ -1093,11 +1094,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand('agents.enableTmux', async () => {
+      // Back-compat command id: flips terminalMode back to 'auto' (tmux by
+      // default when available). The setting is the source of truth now.
       const config = vscode.workspace.getConfiguration();
-      const current = config.get<boolean>('agents.enableTmux', false);
-      await config.update('agents.enableTmux', !current, vscode.ConfigurationTarget.Global);
-      const status = !current ? 'enabled' : 'disabled';
-      vscode.window.showInformationMessage(`Tmux mode ${status}. New agent terminals will ${!current ? 'use tmux for per-tab splits' : 'use VS Code editor splits'}.`);
+      await config.update('agents.terminalMode', 'auto', vscode.ConfigurationTarget.Global);
+      vscode.window.showInformationMessage('Tmux mode enabled (auto). New agent terminals will run inside tmux when available.');
       await updateContextKeys(context);
     })
   );
@@ -1105,12 +1106,9 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('agents.disableTmux', async () => {
       const config = vscode.workspace.getConfiguration();
-      const current = config.get<boolean>('agents.enableTmux', false);
-      if (current) {
-        await config.update('agents.enableTmux', false, vscode.ConfigurationTarget.Global);
-        vscode.window.showInformationMessage('Tmux mode disabled. New agent terminals will use VS Code editor splits.');
-        await updateContextKeys(context);
-      }
+      await config.update('agents.terminalMode', 'native', vscode.ConfigurationTarget.Global);
+      vscode.window.showInformationMessage('Tmux mode disabled. New agent terminals will use VS Code editor terminals.');
+      await updateContextKeys(context);
     })
   );
 
@@ -1587,11 +1585,13 @@ async function openSingleAgent(
   strategy?: RunStrategy
 ) {
   const config = vscode.workspace.getConfiguration('agents');
-  const enableTmux = config.get<boolean>('enableTmux', false);
-  const tmuxOk = enableTmux ? await isTmuxAvailable() : false;
+  const terminalMode = normalizeTerminalMode(config.get('terminalMode'));
+  // 'auto' (default) and 'tmux' both need the availability probe; 'native' skips it.
+  const tmuxAvailable = terminalMode === 'native' ? false : await isTmuxAvailable();
+  const { useTmux: tmuxOk, warnUnavailable } = resolveTerminalMode(terminalMode, tmuxAvailable);
 
-  if (enableTmux && !tmuxOk) {
-    vscode.window.showWarningMessage('Tmux mode is enabled, but tmux is not available on PATH. Falling back to VS Code splits.');
+  if (warnUnavailable) {
+    vscode.window.showWarningMessage('Tmux mode is forced, but tmux is not available on PATH. Falling back to VS Code terminals.');
   }
 
   // Build command with default model if configured
@@ -3873,7 +3873,8 @@ async function reloadActiveTerminal(context: vscode.ExtensionContext) {
 
 async function updateContextKeys(context: vscode.ExtensionContext): Promise<void> {
   const config = vscode.workspace.getConfiguration('agents');
-  const tmuxEnabled = config.get<boolean>('enableTmux', false);
+  // 'native' hides the "Disable Tmux" toggle; 'auto'/'tmux' show it (tmux is active).
+  const tmuxEnabled = normalizeTerminalMode(config.get('terminalMode')) !== 'native';
   await vscode.commands.executeCommand('setContext', 'agents.tmuxEnabled', tmuxEnabled);
 
   const viewEnabled = workbench.isStreamlineLayout();

--- a/apps/factory/src/vscode/foreman.registry.ts
+++ b/apps/factory/src/vscode/foreman.registry.ts
@@ -21,6 +21,8 @@ import * as vscode from 'vscode';
 import { createHash } from 'crypto';
 import { computeWindowId } from '../core/foreman.windowId';
 import { isPidAlive } from '../core/liveness';
+import { resolveTabIndex, type TabView } from '../core/tabIndex';
+import { getTmuxInfo } from './tmux';
 
 const REGISTRY_DIR = path.join(os.homedir(), '.agents', '.cache', 'terminals');
 const REGISTRY_FILE = path.join(REGISTRY_DIR, 'live-terminals.json');
@@ -38,6 +40,11 @@ export interface LiveTerminal {
   label?: string | null;
   cwd?: string | null;
   startedAtMs: number;
+  // Richer tracking so the CLI can address + display this terminal precisely.
+  // DATA CONTRACT with the CLI (src/lib/session): field names are load-bearing.
+  tmuxSession?: string;      // tmux session name when the agent runs inside tmux.
+  tmuxPane?: string;         // tmux `%N` pane id (unique addressing) when known.
+  tabIndex?: number;         // 1-based editor-tab index within its group ("Codium tab N").
 }
 
 interface RegistryFile {
@@ -105,7 +112,7 @@ function hashEntries(entries: LiveTerminal[]): string {
   // `at` timestamp is excluded — it changes every call and would make every
   // hash unique.
   const stable = entries
-    .map((e) => `${e.sessionId}|${e.pid}|${e.kind}|${e.label ?? ''}|${e.cwd ?? ''}`)
+    .map((e) => `${e.sessionId}|${e.pid}|${e.kind}|${e.label ?? ''}|${e.cwd ?? ''}|${e.tmuxPane ?? ''}|${e.tabIndex ?? ''}`)
     .sort()
     .join('\n');
   return createHash('sha1').update(stable).digest('hex');
@@ -168,6 +175,14 @@ export function readLiveTerminals(): LiveTerminal[] {
 // Returns [] if no agent terminals are open here.
 export async function snapshotOwnTerminals(): Promise<LiveTerminal[]> {
   const out: LiveTerminal[] = [];
+  // Flatten the editor tab groups ONCE per snapshot so resolveTabIndex is a pure
+  // lookup per terminal rather than re-walking the tab tree each time.
+  const tabGroups: TabView[][] = vscode.window.tabGroups.all.map((g) =>
+    g.tabs.map((tab) => ({
+      label: tab.label,
+      isTerminal: tab.input instanceof vscode.TabInputTerminal,
+    })),
+  );
   for (const t of vscode.window.terminals) {
     if (t.exitStatus !== undefined) continue;
     const opts = t.creationOptions as vscode.TerminalOptions;
@@ -178,6 +193,11 @@ export async function snapshotOwnTerminals(): Promise<LiveTerminal[]> {
     const pid = await t.processId;
     if (!pid) continue;
     const kind = tid ? kindFromTerminalId(tid) : kindFromName(t.name);
+    // tmux coordinates (session + %pane) when this terminal was spawned inside
+    // tmux; undefined for the native path. Best-effort pane read off the socket.
+    const tmux = await getTmuxInfo(t);
+    // Editor-tab position, matched by the terminal's name against its tab label.
+    const tabIndex = resolveTabIndex(tabGroups, t.name);
     out.push({
       sessionId: sid,
       pid,
@@ -185,6 +205,9 @@ export async function snapshotOwnTerminals(): Promise<LiveTerminal[]> {
       label: deriveLabel(t.name),
       cwd: env?.AGENT_WORKSPACE_DIR ?? null,
       startedAtMs: Date.now(),
+      tmuxSession: tmux?.session,
+      tmuxPane: tmux?.pane,
+      tabIndex,
     });
   }
   return out;

--- a/apps/factory/src/vscode/tmux.ts
+++ b/apps/factory/src/vscode/tmux.ts
@@ -14,8 +14,12 @@
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import * as readiness from './terminalReadiness';
 import { runAgents } from '../core/agentsBin';
+
+const pexecFile = promisify(execFile);
 
 interface TmuxTerminal {
   terminal: vscode.Terminal;
@@ -23,6 +27,7 @@ interface TmuxTerminal {
   socket: string;  // Shared agents-cli socket (so direct tmux calls hit the same server)
   agentType: string;
   paneCount: number;
+  pane?: string;   // Cached `%N` pane id, resolved lazily by getTmuxInfo.
 }
 
 const tmuxTerminals = new Map<vscode.Terminal, TmuxTerminal>();
@@ -206,6 +211,47 @@ export function isTmuxTerminal(terminal: vscode.Terminal): boolean {
 
 export function getTmuxState(terminal: vscode.Terminal): TmuxTerminal | undefined {
   return tmuxTerminals.get(terminal);
+}
+
+/**
+ * Read the session's `%N` pane id off the shared socket. Best-effort: the
+ * extension host may not have `tmux` on its PATH (it's the terminal's shell
+ * that runs the styling), so we try the common Homebrew/system locations and
+ * give up quietly. A single-pane agent session has exactly one pane; we take
+ * the first line.
+ */
+async function readPaneId(socket: string, session: string): Promise<string | undefined> {
+  const candidates = ['tmux', '/opt/homebrew/bin/tmux', '/usr/local/bin/tmux', '/usr/bin/tmux'];
+  for (const bin of candidates) {
+    try {
+      const { stdout } = await pexecFile(
+        bin,
+        ['-S', socket, 'list-panes', '-t', session, '-F', '#{pane_id}'],
+        { timeout: 3_000 },
+      );
+      const pane = stdout.split('\n').map((s) => s.trim()).filter(Boolean)[0];
+      if (pane) return pane;
+      return undefined; // tmux ran but reported no pane — don't try other bins
+    } catch {
+      /* binary missing at this path — try the next candidate */
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The tmux coordinates for a terminal we spawned, or undefined for a
+ * non-tmux terminal. `session` + `socket` are known at creation; `pane` is
+ * resolved (and cached) lazily off the shared socket. Consumed by
+ * foreman.registry.snapshotOwnTerminals to publish tmuxSession/tmuxPane.
+ */
+export async function getTmuxInfo(
+  terminal: vscode.Terminal,
+): Promise<{ session: string; socket: string; pane?: string } | undefined> {
+  const state = tmuxTerminals.get(terminal);
+  if (!state) return undefined;
+  if (!state.pane) state.pane = await readPaneId(state.socket, state.session);
+  return { session: state.session, socket: state.socket, pane: state.pane };
 }
 
 export function cleanupTmuxTerminal(terminal: vscode.Terminal): void {

--- a/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
@@ -45,7 +45,11 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
 
   const tok = plainTok(a.tok, plain)
   const filesLabel = !plain && a.files > 0 ? ` · ${a.files} ${a.files === 1 ? 'file' : 'files'}` : ''
-  const meta = plain ? a.project : `${a.project} · ${a.hostLabel ?? a.host}${a.ticket ? ` · ${a.ticket}` : ''}${filesLabel}`
+  // tmux pane handle (unique addressing) + where the session is being viewed, appended
+  // to the meta line. Both only show in full (non-plain) mode when the CLI supplies them.
+  const paneLabel = !plain && a.pane ? ` · ${a.pane}` : ''
+  const viewingLabel = !plain && a.viewingIn ? ` · viewing in ${a.viewingIn}` : ''
+  const meta = plain ? a.project : `${a.project} · ${a.hostLabel ?? a.host}${a.ticket ? ` · ${a.ticket}` : ''}${filesLabel}${paneLabel}${viewingLabel}`
   const destructive = a.question?.kind === 'destructive'
   const attn = a.phase === 'failed' ? 'fail' : stalled ? 'stall' : a.needs ? 'attn' : ''
 

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
@@ -89,6 +89,8 @@ export interface RemoteSessionLike {
   replyRail: string
   replyMuxTarget: string
   replyMuxSocket: string
+  tmuxPane: string
+  viewingIn?: string
 }
 
 // ---------- primitive helpers ----------
@@ -332,6 +334,9 @@ export function toFloorAgentFromRemote(r: RemoteSessionLike, pinned: Set<string>
     // response but no tool calls yet, so recent stays empty until Tier-2 enrichment.
     summary: r.topic || r.lastResponse || '',
     recent: [],
+    // tmux %pane handle + where it's being viewed, surfaced on the card.
+    pane: r.tmuxPane || undefined,
+    viewingIn: r.viewingIn || undefined,
   }
 }
 

--- a/apps/factory/ui/settings/components/mission-control/floorModel.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.ts
@@ -195,6 +195,8 @@ export interface FloorAgent {
   todos: TodoItem[]      // task checklist from the latest TodoWrite; empty when none
   summary: string        // the "what is it doing" line (CLI-provided); '' when unknown
   recent: RecentToolCall[] // rolling window of this session's recent tool calls; [] when none
+  pane?: string          // tmux `%N` pane handle for unique addressing; undefined for non-tmux
+  viewingIn?: string     // "Codium tab 3" / "Ghostty tab 2" / "detached"; undefined when unknown
 }
 
 // ---------- HOSTS sidebar rows ----------

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -78,6 +78,7 @@ const running: FloorAgent[] = [
   agent({
     id: 'r1', abbr: 'CX', name: 'bench-saved-views', project: 'rush', phase: 'running',
     pr: '#148', ci: 'running', tok: 41, files: 9, since: '3s', lastActivityMs: Date.now() - 3000,
+    pane: '%42', viewingIn: 'Codium tab 3',
     verb: 'Porting', target: 'the group-by control into the shared model',
     summary: 'Collapsed the three ticket surfaces into one list; now porting the group-by control into the shared model.',
     todos: [
@@ -89,6 +90,7 @@ const running: FloorAgent[] = [
   agent({
     id: 'r2', abbr: 'CC', name: 'heartbeat-lastactivity', project: 'agents-cli', phase: 'running',
     tok: 55, files: 4, since: '1s', lastActivityMs: Date.now() - 1000,
+    pane: '%57', viewingIn: 'Ghostty tab 2',
     verb: 'Reading', target: 'the remote-session adapter',
     summary: 'Tracing where remote sessions lose their last-activity timestamp — found it in the adapter, drafting the fix.',
   }),


### PR DESCRIPTION
## What

Extension half of the tmux terminal standardization (companion to CLI #731). Makes the Factory Floor feed **workable** by giving every agent terminal a stable, external address (a tmux pane) and surfacing where each agent is being viewed.

Same-cwd agents were previously indistinguishable and VS Code terminal tabs had no external addressing — the root cause behind the feed bugs (#145 host mis-attribution, #147 drifting startedAt, #149 status-bar-wrong-session). tmux panes give a uniform, resumable, trackable identity.

## Changes

- **tmux by default** (`agents.terminalMode: auto | tmux | native`, replaces the old boolean `agents.enableTmux`). `auto` runs agents inside tmux on macOS/Linux for uniform addressing/resume/tracking, falling back to a native VS Code terminal on Windows or when tmux is missing. — `terminalMode.ts` (pure, unit-tested), `extension.ts`
- **Publish tmux pane + editor-tab index** per agent terminal so the CLI can render "viewing in Codium tab N". — `tabIndex.ts` (pure `resolveTabIndex`, unit-tested), `tmux.ts`, `foreman.registry.ts`
- **Surface pane + "viewing in" on Factory Floor cards.** — `remoteSessions.ts`, `FeedItem.tsx`, `floorAdapter.ts`, `floorModel.ts`

## Testing

- `tsc -p ./` clean (0 errors)
- New pure-helper tests green: `tabIndex.test.ts` + `remoteSessions.test.ts` — 55/55; `terminalMode.test.ts` present and green
- Full factory suite: 1042 pass, 4 fail — the 4 failures are pre-existing live-LLM/network/timing integration tests (`generateCommitMessageWithClaude`, `draftDispatchPrompt`, `resolveAlias`, `SessionWatcher` 5s timeout), none touching any file in this diff

## Notes

- Replayed onto the post-#724 `apps/factory/` layout (branch base predates the restructure); three-dot PR diff is 14 files, all under `apps/factory/`.
- Pairs with **#731** (CLI: run interactive agents in tmux + viewing-in resolution) — shared data contract: `tmuxSession` / `tmuxPane` / `tabIndex` / `viewingIn`.
