### PR TITLE
fix(repo): ignore relocated apps/cli/bin/ helper bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ dist/
 
 # Compiled keychain helper + provisioning profile (rebuild via scripts/build-keychain-helper.sh)
 /bin/
+# Same regenerable helper bundles after the apps/ + packages/ restructure (#724)
+/apps/cli/bin/
 
 # Caches
 .npm-cache/


### PR DESCRIPTION
The #724 restructure moved the regenerable signed keychain + menubar helper bundles from repo-root `bin/` to `apps/cli/bin/`, but the `.gitignore` rule stayed anchored at `/bin/`.

Consequence: after staging the helper bundles for a release, `apps/cli/bin/` shows as untracked (`?? apps/cli/bin/`), which trips `release.sh`'s clean-tree preflight (`git status --porcelain`) and blocks every release cut after the restructure.

Fix: add `/apps/cli/bin/` alongside the existing `/bin/` rule so the relocated regenerable bundles are ignored again.

Verified locally: with the rule in place, `git status` is clean after `cp`-ing the signed `Agents CLI.app` + `MenubarHelper.app` into `apps/cli/bin/`, and `release.sh 1.20.42` dry-run passes the prepack gate.