### PR TITLE
feat(factory): port swarmify feed fixes into apps/factory (supersedes #732)

### DIFF
--- a/apps/factory/AGENTS.md
+++ b/apps/factory/AGENTS.md
@@ -15,6 +15,24 @@ This file is a **map**, not the territory. Keep it a short paragraph per area pl
 /tests          Real-service tests (no mocks)
 ```
 
+## Testing the Factory Floor UI
+
+The Factory Floor feed + Dispatch panel are a React webview (`ui/settings`, top component `UnifiedAgentsPane.tsx`). To SEE and verify UI changes, do NOT install the packaged `.vsix` and drive VS Code via accessibility automation (`osascript` / `agents computer`) to open the dashboard — that steals your focus and is slow. Use the committed preview harness, which renders the real components with representative data in a plain browser page you can screenshot:
+
+```
+cd apps/factory/ui && bun run dev
+# open http://localhost:5173/settings/preview/?view=feed   (or ?view=dispatch)
+#   add &theme=dark  or  &theme=light
+```
+
+`ui/settings/preview/preview.tsx` mounts the same feed + DispatchPanel the webview uses; it is excluded from the shipped bundle (`vite.settings.config.ts` only inputs `settings/index.html`). Screenshot the browser page and actually inspect the render against the intent.
+
+Gotchas:
+- A built `preview-dist/index.html` opened over `file://` renders BLANK (Chromium CORS-blocks ES-module `<script src>` over file://). Serve over http (`bun run dev`), or inline the built JS/CSS into one self-contained HTML.
+- To screenshot a browser window on another macOS Space, `screencapture -o` grabs the wrong Space; use a window-targeted capture (e.g. `agents computer screenshot --bundle <id> --window-id <id>`), which is focus-safe.
+
+For logic-only changes, `bun test` in `apps/factory/` runs the `mission-control/*.test.ts` suites (floorModel, floorAdapter, dispatch, savedViews, etc.).
+
 ## Building + Testing
 
 ```bash

--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to the Factory extension are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/); `scripts/release.sh` requires a
+`## [<version>]` section for the version being published.
+
+## [0.9.283] - 2026-07-07
+
+### Fixed
+
+- **Factory Floor feed showed identical, contextless cards for co-located sessions.**
+  Ported the swarmify/extension feed fixes: fan-out remote-session enrichment now
+  attributes each row to the correct device (`machine`), surfaces the worktree slug,
+  live preview, structured ticket id, and real branch, and caches `startedAtMs` by
+  PID so a terminal's start time no longer drifts to `Date.now()` on every republish.
+  Consolidated the duplicated feed model into a single `@shared` implementation with
+  a `MISSING_EXPORT` build-time drift guard.
+
+### Added
+
+- **tmux terminals by default** (`agents.terminalMode: auto | tmux | native`) with each
+  agent terminal publishing its tmux pane (`%N`) and editor-tab index, surfaced as the
+  pane handle and "viewing in <tab>" on Factory Floor cards. Gives same-cwd agents
+  distinct, addressable identities.

--- a/apps/factory/scripts/release.sh
+++ b/apps/factory/scripts/release.sh
@@ -72,6 +72,19 @@ fi
 VERSION="$BASE_VERSION"
 if [ -n "$PRE_TAG" ]; then VERSION="${BASE_VERSION}-${PRE_TAG}"; fi
 
+# --- Pre-flight: the changelog must document this version ----------------
+#
+# A release must document itself. Require a `## [<X.Y.Z>]` section in
+# CHANGELOG.md (the base version, ignoring any --pre tag) so we can never
+# publish a version whose changes are undocumented. Cheapest check -> runs first.
+if ! grep -qE "^## \[${BASE_VERSION//./\\.}\]" CHANGELOG.md; then
+    echo "Error: no CHANGELOG.md entry for ${BASE_VERSION}." >&2
+    echo "       Add a '## [${BASE_VERSION}] - <date>' section before releasing." >&2
+    exit 1
+fi
+echo "Changelog entry for ${BASE_VERSION}: found."
+echo
+
 PUBLISHER_ID="swarmify"
 EXT_NAME="swarm-ext"
 EXT_FQN="${PUBLISHER_ID}.${EXT_NAME}"

--- a/apps/factory/src/core/processStartTime.test.ts
+++ b/apps/factory/src/core/processStartTime.test.ts
@@ -1,0 +1,51 @@
+import { test, expect } from 'bun:test';
+import { parseLstart, resolveStartedAtMs } from './processStartTime';
+
+test('parseLstart parses ps lstart output to epoch ms', () => {
+  // `ps -o lstart=` format on macOS/Linux.
+  const ms = parseLstart('Sat Jun 28 11:02:13 2026');
+  expect(ms).toBe(Date.parse('Sat Jun 28 11:02:13 2026'));
+  expect(parseLstart('not a date')).toBeUndefined();
+});
+
+// This is the regression test for the startedAtMs bug: snapshotOwnTerminals used
+// to stamp `Date.now()` on every republish, so a terminal's startedAtMs was
+// identical across terminals and changed on every write. resolveStartedAtMs must
+// instead return a STABLE value reflecting the process's REAL start time.
+test('resolveStartedAtMs is stable per pid and reflects the real start, not now', async () => {
+  const pid = process.pid; // a real, live process — no mocks
+
+  const first = await resolveStartedAtMs(pid);
+  await new Promise((r) => setTimeout(r, 40));
+  const second = await resolveStartedAtMs(pid);
+
+  // Core of the bug: two snapshots must NOT drift. The old code returned two
+  // different Date.now() values here.
+  expect(second).toBe(first);
+
+  // A start time can never be in the future, and must be a real epoch (in the
+  // past, well after 2020). That it reflects the REAL start (not a fresh
+  // Date.now() each call) is pinned by the stability assertion above plus the
+  // "different processes get different, ordered starts" test below.
+  expect(first).toBeLessThanOrEqual(Date.now());
+  expect(first).toBeGreaterThan(Date.parse('2020-01-01'));
+});
+
+// Distinct live processes must get distinct start times (the bug collapsed them
+// all onto one identical timestamp). Spawn two short-lived sleeps a beat apart.
+test('resolveStartedAtMs distinguishes processes started at different times', async () => {
+  const { spawn } = await import('child_process');
+  const a = spawn('sleep', ['5']);
+  await new Promise((r) => setTimeout(r, 1100)); // > 1s so ps 1s-granularity differs
+  const b = spawn('sleep', ['5']);
+  try {
+    const [sa, sb] = await Promise.all([
+      resolveStartedAtMs(a.pid as number),
+      resolveStartedAtMs(b.pid as number),
+    ]);
+    expect(sb).toBeGreaterThan(sa);
+  } finally {
+    a.kill();
+    b.kill();
+  }
+});

--- a/apps/factory/src/core/processStartTime.ts
+++ b/apps/factory/src/core/processStartTime.ts
@@ -23,6 +23,23 @@ export function captureProcessStartTime(pid: number): Promise<number | undefined
   });
 }
 
+// A process's real start time is fixed for its lifetime, so capture it once per
+// pid and reuse the cached value. This backs the live-terminals registry's
+// `startedAtMs`: the snapshot runs on every terminal-state change, and stamping
+// `Date.now()` each time gave every terminal an identical timestamp that shifted
+// on every republish — so the feed's "since"/elapsed showed ~0s for everyone.
+// `ps -o lstart` yields the real start on macOS/Linux; where it's unavailable
+// (e.g. Windows) we fall back to a first-seen stamp — still STABLE per pid.
+const startTimeCacheByPid = new Map<number, number>();
+export async function resolveStartedAtMs(pid: number): Promise<number> {
+  const cached = startTimeCacheByPid.get(pid);
+  if (cached !== undefined) return cached;
+  const real = await captureProcessStartTime(pid);
+  const value = real ?? Date.now();
+  startTimeCacheByPid.set(pid, value);
+  return value;
+}
+
 // Pick the item with the most recent (largest) start time. Items without a
 // captured start time are ignored. Returns undefined when none have one.
 export function pickNewestStartTime<T extends { startTimeMs?: number }>(

--- a/apps/factory/src/core/remoteSessions.enrich.test.ts
+++ b/apps/factory/src/core/remoteSessions.enrich.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeActiveSession, normalizeRecentSession } from './remoteSessions';
+
+// The active-session payload carries nested worktree/pr/preview/ticket objects that
+// were previously dropped, leaving remote cards blank. These assert the enrichment.
+
+describe('normalizeActiveSession — stop dropping nested fields', () => {
+  const base = {
+    sessionId: 's1',
+    kind: 'claude',
+    status: 'input_required',
+    cwd: '/x/agents-cli/.agents/worktrees/headless-secrets-shadow/src/lib/secrets/linux.ts',
+  };
+
+  test('reads a structured ticket id, worktree slug/branch, preview, and pr.url', () => {
+    const s = normalizeActiveSession(
+      {
+        ...base,
+        ticket: { id: 'RUSH-1251', url: 'https://linear.app/x/RUSH-1251' },
+        worktree: { slug: 'headless-secrets-shadow', path: '/x/wt', branch: 'muqsit/rush-1251' },
+        pr: { url: 'https://github.com/o/r/pull/9', number: 9 },
+        preview: 'Editing linux.ts to remove the stale resolver',
+      } as any,
+      'zion',
+      1_000_000,
+    );
+    expect(s.ticket).toBe('RUSH-1251');
+    expect(s.worktreeSlug).toBe('headless-secrets-shadow');
+    expect(s.worktreePath).toBe('/x/wt');
+    expect(s.branch).toBe('muqsit/rush-1251');
+    expect(s.prUrl).toBe('https://github.com/o/r/pull/9');
+    expect(s.lastResponse).toBe('Editing linux.ts to remove the stale resolver');
+    expect(s.phase).toBe('waiting');
+  });
+
+  test('falls back to worktreeSlugOf(cwd) when the payload omits the slug', () => {
+    const s = normalizeActiveSession(base as any, 'zion', 1_000_000);
+    expect(s.worktreeSlug).toBe('headless-secrets-shadow');
+  });
+
+  test('still accepts a bare-string ticket (older payloads)', () => {
+    const s = normalizeActiveSession({ ...base, ticket: 'RUSH-9' } as any, 'zion', 1_000_000);
+    expect(s.ticket).toBe('RUSH-9');
+  });
+});
+
+describe('normalizeRecentSession — flat SessionMeta onto the same shape', () => {
+  test('maps ticketId/gitBranch/worktreeSlug/lastActivity, phase idle', () => {
+    const s = normalizeRecentSession(
+      {
+        id: 'r1',
+        agent: 'Claude',
+        project: 'agents-cli',
+        cwd: '/x/agents-cli',
+        gitBranch: 'main',
+        worktreeSlug: 'some-slug',
+        ticketId: 'RUSH-42',
+        topic: 'Fix the thing',
+        lastActivity: '2026-07-02T01:07:45.215Z',
+      },
+      'mac-mini',
+      2_000_000,
+    );
+    expect(s.phase).toBe('idle');
+    expect(s.ticket).toBe('RUSH-42');
+    expect(s.branch).toBe('main');
+    expect(s.worktreeSlug).toBe('some-slug');
+    expect(s.topic).toBe('Fix the thing');
+    expect(s.agentType).toBe('claude');
+    expect(s.lastActivityMs).toBe(Date.parse('2026-07-02T01:07:45.215Z'));
+  });
+});

--- a/apps/factory/src/core/remoteSessions.test.ts
+++ b/apps/factory/src/core/remoteSessions.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import {
   mapStatusToPhase,
   normalizeHost,
+  resolveSessionHost,
   projectFromCwd,
   resolveProject,
   normalizeActiveSession,
@@ -40,6 +41,39 @@ describe('normalizeHost', () => {
     expect(normalizeHost('zion.tail1a85a1.ts.net')).toBe('zion');
     expect(normalizeHost("Muqsit's Mac mini")).toBe('muqsit-s-mac-mini');
     expect(normalizeHost('')).toBe('');
+  });
+});
+
+describe('resolveSessionHost', () => {
+  // This is the fix for the "all sessions attributed to the local machine" bug: a
+  // bare `sessions --active --json` fans out over the whole fleet, so we must
+  // bucket each row by ITS OWN `machine` id, not the host we queried.
+  const LOCAL_ID = 'zion';
+  const LOCAL_LABEL = 'this-mac';
+
+  test('a remote row buckets under its own machine, not the querying host', () => {
+    expect(resolveSessionHost('yosemite-s0', LOCAL_LABEL, LOCAL_ID, LOCAL_LABEL)).toBe('yosemite-s0');
+    expect(resolveSessionHost('yosemite-s1', LOCAL_LABEL, LOCAL_ID, LOCAL_LABEL)).toBe('yosemite-s1');
+  });
+
+  test("this machine's own rows fold to the local label so this-mac routing works", () => {
+    expect(resolveSessionHost('zion', LOCAL_LABEL, LOCAL_ID, LOCAL_LABEL)).toBe('this-mac');
+    // FQDN / case variants normalize to the same id before the local-fold check.
+    expect(resolveSessionHost('ZION.tail1a85a1.ts.net', LOCAL_LABEL, LOCAL_ID, LOCAL_LABEL)).toBe('this-mac');
+  });
+
+  test('a machine-less row (cloud) falls back to the querying host', () => {
+    expect(resolveSessionHost(undefined, LOCAL_LABEL, LOCAL_ID, LOCAL_LABEL)).toBe('this-mac');
+    expect(resolveSessionHost('', 'yosemite-s0', LOCAL_ID, LOCAL_LABEL)).toBe('yosemite-s0');
+  });
+
+  test('a whole mixed-fleet payload splits across the correct buckets', () => {
+    const rows = ['zion', 'zion', 'yosemite-s0', 'yosemite-s0', 'yosemite-s1', undefined];
+    const buckets = rows.map((m) => resolveSessionHost(m, LOCAL_LABEL, LOCAL_ID, LOCAL_LABEL));
+    const count: Record<string, number> = {};
+    for (const b of buckets) count[b] = (count[b] || 0) + 1;
+    // zion x2 + the machine-less cloud row fold to this-mac; remotes stay split.
+    expect(count).toEqual({ 'this-mac': 3, 'yosemite-s0': 2, 'yosemite-s1': 1 });
   });
 });
 

--- a/apps/factory/src/core/remoteSessions.ts
+++ b/apps/factory/src/core/remoteSessions.ts
@@ -16,9 +16,14 @@ import {
   computeOutputTokensPerSec,
   formatActivity,
 } from './session.activity';
-import type { ProjectRule } from './settings';
+import { resolveProject, normalizeHost, worktreeSlugOf } from '../shared/project';
+import type { ProjectRule } from '../shared/project';
 
-export type { ProjectRule } from './settings';
+// Re-exported so existing host importers keep their `from '../core/remoteSessions'`
+// path. The impls now live in src/shared/project so the webview (@shared) imports
+// the SAME source instead of a hand-mirrored copy that silently drifts.
+export { resolveProject, normalizeHost, worktreeSlugOf };
+export type { ProjectRule } from '../shared/project';
 
 /** Mirror of floorModel.FloorPhase (kept in sync by hand; not imported). */
 export type RemotePhase = 'running' | 'idle' | 'waiting' | 'failed' | 'done';
@@ -26,20 +31,26 @@ export type RemotePhase = 'running' | 'idle' | 'waiting' | 'failed' | 'done';
 /** Agent types whose session files session.activity.ts knows how to parse. */
 type ParsableAgentType = 'claude' | 'codex' | 'gemini';
 
+// normalizeHost now lives in src/shared/project.ts (imported + re-exported above).
+
 /**
- * Canonicalize a hostname to its short device label, mirroring agents-cli's
- * `normalizeHost` (machineId in its session/sync config): take the first dotted
- * label, lowercase it, and collapse any non-alphanumeric run to a single hyphen.
- * So `zion.local` and `ZION` both become `zion`, which lines up with the
- * `agents devices` registry names used under the HOSTS sidebar. Empty in → empty out.
+ * Decide which HOSTS bucket a session belongs to. A bare `agents sessions
+ * --active --json` fans out over the whole fleet, so a single query answers for
+ * many machines — each row carries its own `machine` id. Bucket by that id, NOT
+ * by the host we happened to query (`fallbackHost`), or every remote session
+ * collapses onto the querying machine. The local machine's own id maps to
+ * `localLabel` ('this-mac') so the webview's `host === 'this-mac'` routing keeps
+ * working. Rows with no machine (cloud) fall back to the querying host.
  */
-export function normalizeHost(raw: string): string {
-  return (raw || '')
-    .split('.')[0]
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+export function resolveSessionHost(
+  rawMachine: string | undefined,
+  fallbackHost: string,
+  localMachineId: string,
+  localLabel: string,
+): string {
+  const norm = normalizeHost(rawMachine || '');
+  if (!norm) return fallbackHost;
+  return norm === localMachineId ? localLabel : norm;
 }
 
 /** A registered device as seen by the host reconciler (from `agents devices list`). */
@@ -102,6 +113,13 @@ export interface RemoteSession {
   prUrl: string | null;
   ticket: string | null;
   branch: string;
+  /** The `<slug>` under `.agents/worktrees/<slug>/` — the strong per-session
+   *  disambiguator (two agents in sibling worktrees of one repo differ only here).
+   *  '' when the session isn't in a worktree. */
+  worktreeSlug: string;
+  /** Absolute worktree path (== cwd for a worktree session), for the Reveal-worktree
+   *  action. '' when not a worktree. */
+  worktreePath: string;
   /** Elapsed ms since the session started, computed against the fetch clock so
    *  host clock skew does not distort it. */
   sinceMs: number;
@@ -204,10 +222,23 @@ export interface RawActiveSession {
   cloudStatus?: string;
   branch?: string;
   prUrl?: string;
-  ticket?: string;
   /** Where the session is being viewed right now, pre-formatted by the CLI's
    *  client resolver (e.g. "Codium tab 3", "Ghostty tab 2", "detached"). */
   viewingIn?: string;
+  /** The CLI emits these NESTED objects on `sessions --active --json` (agents-cli
+   *  ActiveSession: preview / pr / worktree / ticket). Earlier this shape declared
+   *  none of them, so normalizeActiveSession silently dropped the worktree slug, the
+   *  live preview (activity line), the structured ticket id, and the real branch —
+   *  which is why remote/worktree cards showed only "Edit <file>" + a status word. */
+  preview?: string;
+  pr?: { url?: string; number?: number } | null;
+  worktree?: { slug?: string; path?: string; branch?: string } | null;
+  ticket?: string | { id?: string; url?: string } | null;
+  /** Normalized device id the CLI attributes this session to (machineId() form,
+   *  e.g. 'zion', 'yosemite-s0'). Present on every row of a fanned-out
+   *  `sessions --active --json` — the load-bearing signal for which physical
+   *  machine a session runs on. Absent for cloud rows (attributed to the querier). */
+  machine?: string;
   /** How the CLI says a reply reaches this session. `reply` is null for raw TTYs
    *  (e.g. bare Ghostty) with no programmatic input channel; a tmux-backed session
    *  carries the socket + pane to drive via `tmux send-keys` (over ssh when remote).
@@ -266,76 +297,9 @@ export function mapStatusToPhase(status: string | undefined): RemotePhase {
   }
 }
 
-/**
- * Convert a project-rule glob to a RegExp. `**` spans path separators, `*` does
- * not, `?` matches a single non-separator char. A trailing subpath always matches
- * so a rule for a directory also captures sessions running inside it.
- */
-function projectGlobToRegExp(glob: string): RegExp {
-  let re = '';
-  for (let i = 0; i < glob.length; i++) {
-    const c = glob[i];
-    if (c === '*') {
-      if (glob[i + 1] === '*') {
-        re += '.*';
-        i++;
-      } else {
-        re += '[^/]*';
-      }
-    } else if (c === '?') {
-      re += '[^/]';
-    } else {
-      re += c.replace(/[.+^${}()|[\]\\]/g, '\\$&');
-    }
-  }
-  return new RegExp('^' + re + '(?:/.*)?$');
-}
-
-/**
- * Does a rule's pattern match a cwd? A pattern with no glob metacharacters is a
- * plain path prefix (the exact dir or any descendant); otherwise it is a glob.
- */
-function matchesProjectRule(cwd: string, pattern: string): boolean {
-  const p = pattern.trim().replace(/\/+$/, '');
-  if (!p) return false;
-  if (!/[*?]/.test(p)) return cwd === p || cwd.startsWith(p + '/');
-  return projectGlobToRegExp(p).test(cwd);
-}
-
-/** Last path segment of a repo-root path (or a bare repo name). */
-function pathBasename(p: string): string {
-  const parts = p.replace(/\/+$/, '').split('/').filter(Boolean);
-  return parts[parts.length - 1] || '';
-}
-
-/**
- * Resolve a session cwd to a display project for Floor grouping. Order:
- *   1. user rules (first match wins) — glob or path-prefix against the cwd.
- *   2. worktree fold: `.../<repo>/.agents/worktrees/<slug>` -> `<repo>`.
- *   3. git repo root basename, when the caller supplies `repoRoot` — so a
- *      monorepo subdir (`.../agents/prix/api`) folds to the repo, not the leaf.
- *   4. ultimate fallback: the cwd's last path segment (legacy behavior).
- * Pure — mirrored in ui/.../floorModel.ts across the webview boundary.
- */
-export function resolveProject(
-  cwd: string,
-  rules: ProjectRule[] = [],
-  repoRoot?: string | null
-): string {
-  if (!cwd) return '';
-  const norm = cwd.replace(/\/+$/, '');
-  for (const rule of rules) {
-    if (rule && matchesProjectRule(norm, rule.pattern)) return rule.project;
-  }
-  const wt = norm.match(/\/([^/]+)\/\.agents\/worktrees\//);
-  if (wt) return wt[1];
-  if (repoRoot) {
-    const base = pathBasename(repoRoot);
-    if (base) return base;
-  }
-  const parts = norm.split('/').filter(Boolean);
-  return parts[parts.length - 1] || norm;
-}
+// projectGlobToRegExp / matchesProjectRule / pathBasename / resolveProject now
+// live in src/shared/project.ts (imported + re-exported above) — one impl shared
+// with the webview, no lockstep-mirrored copy.
 
 /**
  * Derive a display project from a working directory with no user rules — the
@@ -373,9 +337,16 @@ export function normalizeActiveSession(
     '';
   const cwd = raw.cwd || '';
   const startedAtMs = typeof raw.startedAtMs === 'number' ? raw.startedAtMs : 0;
-  const rawTicket = asStr(raw.ticket);
+  // Ticket can arrive as a structured object ({ id }) OR a bare string; read the id
+  // first, then fall back to scanning ticket/label/topic text for a RUSH-123 token.
+  const rawTicket =
+    raw.ticket && typeof raw.ticket === 'object' ? asStr(raw.ticket.id) : asStr(raw.ticket);
   const ticketText = `${rawTicket} ${asStr(raw.label)} ${asStr(raw.topic)}`;
   const ticketMatch = rawTicket || ticketText.match(TICKET_RE)?.[0] || null;
+  // The live preview (latest agent turn/tool action) is the human "what is it doing"
+  // line; it was previously never read, leaving remote cards blank.
+  const preview = asStr(raw.preview);
+  const worktreeSlug = asStr(raw.worktree?.slug) || worktreeSlugOf(cwd);
 
   return {
     host,
@@ -387,10 +358,16 @@ export function normalizeActiveSession(
     activity: '',
     tokPerSec: 0,
     waitingForInput: phase === 'waiting',
-    lastResponse: '',
-    prUrl: asStr(raw.prUrl) || null,
+    lastResponse: preview,
+    // pr is a { url, number } object on the CLI payload; keep top-level prUrl as a
+    // fallback for older shapes.
+    prUrl: asStr(raw.prUrl) || asStr(raw.pr?.url) || null,
     ticket: ticketMatch,
-    branch: asStr(raw.branch),
+    // The remote branch lives at worktree.branch; the top-level `branch` is usually
+    // absent, which is why remote branch was always empty.
+    branch: asStr(raw.branch) || asStr(raw.worktree?.branch),
+    worktreeSlug,
+    worktreePath: asStr(raw.worktree?.path) || (worktreeSlug ? cwd : ''),
     sinceMs: startedAtMs > 0 ? Math.max(0, fetchedAt - startedAtMs) : 0,
     startedAtMs,
     // 0 = no activity signal yet; the fan-out sets the real file mtime for file-backed
@@ -411,6 +388,80 @@ export function normalizeActiveSession(
     // reply-rail pane, which today already carries a %pane for tmux sessions.
     tmuxPane: raw.provenance?.mux?.pane || raw.provenance?.reply?.target || '',
     viewingIn: asStr(raw.viewingIn),
+  };
+}
+
+/**
+ * The FLAT `SessionMeta` shape emitted by `agents sessions --json` (recent, not
+ * --active). Field names differ from the active payload (ticketId vs ticket,
+ * gitBranch vs worktree.branch, lastActivity ISO vs startedAtMs), so recent sessions
+ * get their own normalizer that lands on the SAME RemoteSession shape — one card path
+ * for active AND recent. Unknown fields ignored.
+ */
+export interface RawRecentSession {
+  id?: string;
+  shortId?: string;
+  agent?: string;
+  timestamp?: string;
+  lastActivity?: string;
+  project?: string;
+  cwd?: string;
+  gitBranch?: string;
+  worktreeSlug?: string;
+  ticketId?: string;
+  prUrl?: string;
+  prNumber?: number;
+  topic?: string;
+  label?: string;
+  machine?: string;
+}
+
+/** Map a recent (historical, non-active) SessionMeta onto RemoteSession. Recent =
+ *  not live, so phase is always 'idle'; lastActivity drives the "…ago" stamp. */
+export function normalizeRecentSession(
+  raw: RawRecentSession,
+  host: string,
+  fetchedAt: number,
+  projectRules: ProjectRule[] = []
+): RemoteSession {
+  const cwd = asStr(raw.cwd);
+  const worktreeSlug = asStr(raw.worktreeSlug) || worktreeSlugOf(cwd);
+  const lastActivityMs = raw.lastActivity ? Date.parse(raw.lastActivity) || 0 : 0;
+  const startedAtMs = raw.timestamp ? Date.parse(raw.timestamp) || 0 : 0;
+  return {
+    host,
+    sessionId: asStr(raw.id),
+    agentType: asStr(raw.agent).toLowerCase(),
+    cwd,
+    project: asStr(raw.project) || resolveProject(cwd, projectRules),
+    phase: 'idle',
+    activity: '',
+    tokPerSec: 0,
+    waitingForInput: false,
+    lastResponse: '',
+    prUrl: asStr(raw.prUrl) || null,
+    ticket: asStr(raw.ticketId) || null,
+    branch: asStr(raw.gitBranch),
+    worktreeSlug,
+    worktreePath: worktreeSlug ? cwd : '',
+    sinceMs: startedAtMs > 0 ? Math.max(0, fetchedAt - startedAtMs) : 0,
+    startedAtMs,
+    lastActivityMs,
+    topic: asStr(raw.topic) || asStr(raw.label),
+    sessionFile: '',
+    context: 'recent',
+    cloudTaskId: '',
+    cloudProvider: '',
+    teamName: '',
+    pid: 0,
+    transport: '',
+    replyRail: '',
+    replyMuxTarget: '',
+    replyMuxSocket: '',
+    // Recent sessions are historical/idle, not live — no tmux pane or "viewing in"
+    // client to resolve, so both are empty (the required-string default).
+    tmuxPane: '',
+    viewingIn: '',
   };
 }
 

--- a/apps/factory/src/core/settings.ts
+++ b/apps/factory/src/core/settings.ts
@@ -112,14 +112,11 @@ export type SwarmAgentType = 'claude' | 'codex' | 'gemini';
 export const ALL_SWARM_AGENTS: SwarmAgentType[] = ['claude', 'codex', 'gemini'];
 
 // User-defined mapping from a session cwd to a Factory Floor project group.
-// Ordered: the first rule whose pattern matches a session's cwd wins. `pattern`
-// is a glob (`**` spans path separators, `*` does not) or a plain path prefix;
-// `project` is the display name cards group under. Consumed by resolveProject in
-// remoteSessions.ts (mirrored in ui/.../floorModel.ts across the webview boundary).
-export interface ProjectRule {
-  pattern: string;
-  project: string;
-}
+// Canonical definition + resolveProject live in src/shared/project.ts (imported by
+// both the host and the webview); imported for local use + re-exported so existing
+// consumers keep their `from './settings'` path.
+import type { ProjectRule } from '../shared/project';
+export type { ProjectRule };
 
 // Full agent settings structure
 export interface AgentSettings {
@@ -165,8 +162,9 @@ export interface NotificationSettings {
   enabledAgents: string[];
 }
 
-// Task source settings for multi-source Tasks tab
-export type TaskSource = 'linear' | 'github';
+// Task source settings for multi-source Tasks tab.
+// TaskSource is canonical in src/shared/tasks.ts (shared with the webview).
+export type { TaskSource } from '../shared/tasks';
 
 export interface TaskSourceSettings {
   linear: boolean;    // default: false (auto-enable if Linear MCP detected)

--- a/apps/factory/src/core/tasks.ts
+++ b/apps/factory/src/core/tasks.ts
@@ -1,39 +1,13 @@
 // Pure types for unified task management across multiple sources
 // No VS Code dependencies - testable
 
-import { TaskSource } from './settings';
-
-// Unified task interface for aggregating tasks from multiple sources
-export interface UnifiedTask {
-  id: string;                    // Unique identifier
-  source: TaskSource;            // Where this task came from
-  title: string;                 // Task title/summary
-  description?: string;          // Optional description/body
-  status: 'todo' | 'in_progress' | 'done';
-  priority?: 'urgent' | 'high' | 'medium' | 'low';
-  metadata: TaskMetadata;        // Source-specific data
-}
-
-// Source-specific metadata
-export interface TaskMetadata {
-  identifier?: string;           // Linear: PROJ-123, GitHub: #42
-  url?: string;                  // Web URL to task
-  labels?: string[];             // Labels/tags
-  assignee?: string;             // Assigned user
-  assigneeKind?: 'user' | 'agent'; // 'agent' if name matches a known CLI agent
-  state?: string;                // Raw state from source
-  createdAt?: string;            // ISO 8601 creation timestamp
-  dueDate?: string;              // ISO 8601 due date (YYYY-MM-DD from Linear)
-  project?: string;              // Linear project name (undefined for GitHub)
-  repo?: string;                 // "owner/repo" — resolved at fetch time
-  comments?: TaskComment[];      // Linear comments, newest-first when rendered
-}
-
-export interface TaskComment {
-  body: string;
-  createdAt?: string;
-  author?: string;
-}
+// UnifiedTask / TaskMetadata / TaskComment / TaskSource are canonical in
+// src/shared/tasks.ts — the ONE definition shared with the webview (@shared), so a
+// field (e.g. `project`) can never be present on one side of the postMessage
+// boundary and missing on the other. Imported for local use here + re-exported for
+// existing consumers.
+import type { TaskSource, UnifiedTask, TaskMetadata, TaskComment } from '../shared/tasks';
+export type { UnifiedTask, TaskMetadata, TaskComment, TaskSource };
 
 export interface TaskDispatchPromptInput {
   title: string;

--- a/apps/factory/src/core/utils.test.ts
+++ b/apps/factory/src/core/utils.test.ts
@@ -479,6 +479,13 @@ describe('findTerminalNameByTabLabel', () => {
     expect(findTerminalNameByTabLabel(terminalNames, 'CC - nonexistent')).toBeNull();
   });
 
+  test('is ambiguous across duplicate names — always the first (motivates identity resolution)', () => {
+    const names = ['CC', 'CC', 'CC'];
+    expect(findTerminalNameByTabLabel(names, 'CC')).toBe('CC');
+    // A caller doing `names.indexOf(result)` gets 0 no matter which tab is live.
+    expect(names.indexOf(findTerminalNameByTabLabel(names, 'CC') as string)).toBe(0);
+  });
+
   test('returns null for empty terminal list', () => {
     expect(findTerminalNameByTabLabel([], 'CC')).toBeNull();
   });

--- a/apps/factory/src/shared/project.ts
+++ b/apps/factory/src/shared/project.ts
@@ -1,0 +1,96 @@
+// Shared project/host resolution — the SINGLE source of truth for mapping a
+// session cwd to a display project, imported by BOTH the extension host (src/*)
+// and the webview (ui/* via `@shared`). These were previously hand-duplicated in
+// src/core/remoteSessions.ts AND ui/.../floorModel.ts ("keep the two in lockstep"
+// comments) — the drift that makes a session's project resolve differently on
+// each side. One impl, no lockstep. Pure functions, no vscode/node imports.
+
+/** Ordered cwd->project mapping for Factory Floor grouping. */
+export interface ProjectRule {
+  pattern: string;
+  project: string;
+}
+
+/** Glob -> RegExp. `**` spans path separators, `*` does not, `?` a single char.
+ *  A trailing subpath always matches so a rule for a dir captures work inside it. */
+function projectGlobToRegExp(glob: string): RegExp {
+  let re = '';
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === '*') {
+      if (glob[i + 1] === '*') {
+        re += '.*';
+        i++;
+      } else {
+        re += '[^/]*';
+      }
+    } else if (c === '?') {
+      re += '[^/]';
+    } else {
+      re += c.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+    }
+  }
+  return new RegExp('^' + re + '(?:/.*)?$');
+}
+
+/** A rule pattern with no glob metacharacters is a path prefix; else a glob. */
+function matchesProjectRule(cwd: string, pattern: string): boolean {
+  const p = pattern.trim().replace(/\/+$/, '');
+  if (!p) return false;
+  if (!/[*?]/.test(p)) return cwd === p || cwd.startsWith(p + '/');
+  return projectGlobToRegExp(p).test(cwd);
+}
+
+function pathBasename(p: string): string {
+  const parts = p.replace(/\/+$/, '').split('/').filter(Boolean);
+  return parts[parts.length - 1] || '';
+}
+
+/** The `<slug>` under `.agents/worktrees/<slug>/`, or '' when the cwd isn't a
+ *  worktree. This is the strong per-session disambiguator (two agents in sibling
+ *  worktrees of the same repo differ only by slug) — surfaced on the card even
+ *  though resolveProject folds it away to the repo name. */
+export function worktreeSlugOf(cwd: string | null | undefined): string {
+  if (!cwd) return '';
+  const m = cwd.match(/\/\.agents\/worktrees\/([^/]+)/);
+  return m ? m[1] : '';
+}
+
+/**
+ * Resolve a session cwd to a display project. Order:
+ *   1. user rules (first match wins) — glob or path-prefix against the cwd.
+ *   2. worktree fold: `.../<repo>/.agents/worktrees/<slug>` -> `<repo>`.
+ *   3. git repo root basename when `repoRoot` is supplied — so a monorepo subdir
+ *      folds to the repo, not the leaf dir.
+ *   4. ultimate fallback: the cwd's last path segment (legacy behavior).
+ */
+export function resolveProject(
+  cwd: string,
+  rules: ProjectRule[] = [],
+  repoRoot?: string | null,
+): string {
+  if (!cwd) return '';
+  const norm = cwd.replace(/\/+$/, '');
+  for (const rule of rules) {
+    if (rule && matchesProjectRule(norm, rule.pattern)) return rule.project;
+  }
+  const wt = norm.match(/\/([^/]+)\/\.agents\/worktrees\//);
+  if (wt) return wt[1];
+  if (repoRoot) {
+    const base = pathBasename(repoRoot);
+    if (base) return base;
+  }
+  const parts = norm.split('/').filter(Boolean);
+  return parts[parts.length - 1] || norm;
+}
+
+/** Canonicalize a host name to its device label: 'mac-mini', 'ZION', a FQDN all
+ *  fold onto the registry device id. */
+export function normalizeHost(raw: string): string {
+  return (raw || '')
+    .split('.')[0]
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/apps/factory/src/shared/tasks.ts
+++ b/apps/factory/src/shared/tasks.ts
@@ -1,0 +1,44 @@
+// Shared task types — the SINGLE source of truth for the unified backlog,
+// imported by BOTH the extension host (src/*) and the webview (ui/* via the
+// `@shared` vite alias). Do not re-declare these on either side: a hand-mirrored
+// copy is exactly how the `project` field silently vanished across the
+// postMessage boundary (the blank "Group by Project" header). Pure types only —
+// no vscode/node imports, so the webview bundle stays clean.
+
+export type TaskSource = 'linear' | 'github';
+
+export interface TaskComment {
+  body: string;
+  createdAt?: string;
+  author?: string;
+}
+
+// Source-specific metadata. Superset of what either side needs; unused fields are
+// simply absent per source (e.g. `project` is Linear-only, `file`/`line` are for
+// code-TODO sources).
+export interface TaskMetadata {
+  file?: string;                 // code-TODO source: file path
+  line?: number;                 // code-TODO source: line number
+  identifier?: string;           // Linear: PROJ-123, GitHub: #42
+  url?: string;                  // Web URL to task
+  labels?: string[];             // Labels/tags
+  assignee?: string;             // Assigned user
+  assigneeKind?: 'user' | 'agent'; // 'agent' if name matches a known CLI agent
+  state?: string;                // Raw state from source
+  createdAt?: string;            // ISO 8601 creation timestamp
+  dueDate?: string;              // ISO 8601 due date (YYYY-MM-DD from Linear)
+  project?: string;              // Linear project name (undefined for GitHub)
+  repo?: string;                 // "owner/repo" — resolved at fetch time
+  comments?: TaskComment[];      // Linear comments, newest-first when rendered
+}
+
+// Unified task interface for aggregating tasks from multiple sources.
+export interface UnifiedTask {
+  id: string;                    // Unique identifier
+  source: TaskSource;            // Where this task came from
+  title: string;                 // Task title/summary
+  description?: string;          // Optional description/body
+  status: 'todo' | 'in_progress' | 'done';
+  priority?: 'urgent' | 'high' | 'medium' | 'low';
+  metadata: TaskMetadata;        // Source-specific data
+}

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -1488,6 +1488,17 @@ export async function activate(context: vscode.ExtensionContext) {
     })
   );
 
+  // Prefer activeTerminal (identity) over a tab-label name match: same-agent
+  // terminals share a name ("CC"), so name matching always returns the first.
+  const terminalForActiveTab = (tabLabel: string | undefined): vscode.Terminal | undefined => {
+    const active = vscode.window.activeTerminal;
+    if (active) return active;
+    if (!tabLabel) return undefined;
+    const names = vscode.window.terminals.map((t) => t.name);
+    const matchedName = findTerminalNameByTabLabel(names, tabLabel);
+    return matchedName ? vscode.window.terminals.find((t) => t.name === matchedName) : undefined;
+  };
+
   // Update status bar when active editor changes
   context.subscriptions.push(
     vscode.window.onDidChangeActiveTextEditor((editor) => {
@@ -1503,14 +1514,10 @@ export async function activate(context: vscode.ExtensionContext) {
         const activeTab = activeGroup?.activeTab;
 
         if (activeTab?.input instanceof vscode.TabInputTerminal) {
-          const terminalNames = vscode.window.terminals.map(t => t.name);
-          const matchedName = findTerminalNameByTabLabel(terminalNames, activeTab.label);
-          if (matchedName) {
-            const matchedTerminal = vscode.window.terminals.find(t => t.name === matchedName);
-            if (matchedTerminal) {
-              updateStatusBarForTerminal(matchedTerminal, context.extensionPath);
-              return;
-            }
+          const matchedTerminal = terminalForActiveTab(activeTab.label);
+          if (matchedTerminal) {
+            updateStatusBarForTerminal(matchedTerminal, context.extensionPath);
+            return;
           }
         }
       }
@@ -1535,10 +1542,7 @@ export async function activate(context: vscode.ExtensionContext) {
           return;
         }
 
-        const terminalNames = vscode.window.terminals.map(t => t.name);
-        const matchedName = findTerminalNameByTabLabel(terminalNames, activeTab.label);
-        if (!matchedName) return;
-        const matchedTerminal = vscode.window.terminals.find(t => t.name === matchedName);
+        const matchedTerminal = terminalForActiveTab(activeTab.label);
         if (!matchedTerminal) return;
 
         tryFetchLabelOnFocus(matchedTerminal, context);

--- a/apps/factory/src/vscode/foreman.registry.ts
+++ b/apps/factory/src/vscode/foreman.registry.ts
@@ -23,6 +23,7 @@ import { computeWindowId } from '../core/foreman.windowId';
 import { isPidAlive } from '../core/liveness';
 import { resolveTabIndex, type TabView } from '../core/tabIndex';
 import { getTmuxInfo } from './tmux';
+import { resolveStartedAtMs } from '../core/processStartTime';
 
 const REGISTRY_DIR = path.join(os.homedir(), '.agents', '.cache', 'terminals');
 const REGISTRY_FILE = path.join(REGISTRY_DIR, 'live-terminals.json');
@@ -204,7 +205,7 @@ export async function snapshotOwnTerminals(): Promise<LiveTerminal[]> {
       kind,
       label: deriveLabel(t.name),
       cwd: env?.AGENT_WORKSPACE_DIR ?? null,
-      startedAtMs: Date.now(),
+      startedAtMs: await resolveStartedAtMs(pid),
       tmuxSession: tmux?.session,
       tmuxPane: tmux?.pane,
       tabIndex,

--- a/apps/factory/src/vscode/remoteSessions.vscode.ts
+++ b/apps/factory/src/vscode/remoteSessions.vscode.ts
@@ -20,6 +20,9 @@ import {
   ReconciledHost,
   RegisteredDeviceInput,
   normalizeActiveSession,
+  normalizeRecentSession,
+  resolveSessionHost,
+  normalizeHost,
   dedupeSessions,
   filterStaleSessions,
   reconcileHosts,
@@ -39,19 +42,21 @@ export const LOCAL_HOST = os.hostname();
  *  kept only for SSH/isLocal detection; every host string that crosses to the UI
  *  is normalized to this so the 'this-mac' checks there actually match. */
 export const LOCAL_LABEL = 'this-mac';
+/** This machine's normalized device id (machineId() form), used to recognize the
+ *  CLI's own `machine` tag on local rows and fold them back to LOCAL_LABEL. */
+export const LOCAL_MACHINE_ID = normalizeHost(LOCAL_HOST);
 
 const ACTIVE_TIMEOUT_LOCAL_MS = 6000;
 const ACTIVE_TIMEOUT_REMOTE_MS = 10000;
+// The bare fan-out is the CLI's OWN cross-machine sweep (its per-host budget is
+// ~12s, run in parallel), so it needs a wider ceiling than a single local read.
+const FANOUT_TIMEOUT_MS = 15000;
 const DETAIL_TIMEOUT_MS = 15000;
 const CACHE_TTL_MS = 4000;
 // The local-only fast path polls ~3s; a sub-poll TTL keeps two near-simultaneous
 // local ticks from double-spawning the local `agents` subprocess.
 const LOCAL_CACHE_TTL_MS = 1500;
 const LOAD_PROBE_TIMEOUT_MS = 4000;
-// Cap on concurrent host fan-out. Offline hosts are skipped before this, so the
-// online set is usually small; the cap just stops a large tailnet from spawning a
-// thundering herd of ssh handshakes at once (the M5-freeze failure mode).
-const FANOUT_CONCURRENCY = 4;
 // SSH multiplexing for the ONE ssh we invoke directly — the CPU-load probe. The
 // main session fetch runs through `agents --host`, whose SSH the CLI owns, so this
 // only warms the CPU-probe connection (reused across repeated probes to the same
@@ -214,11 +219,17 @@ async function probeCpuRatio(host: string, isLocal: boolean): Promise<number | n
   }
 }
 
-/** Run `agents sessions --active --json`, locally or on one remote via --host.
- *  `probeCpu` gates the second (CPU-load) SSH round-trip: the live feed poll passes
- *  false to fetch sessions with ONE connection per host; the Dispatch panel passes
- *  true when it needs fresh load for ranking. */
-async function fetchActiveForHost(sshTarget: string, isLocal: boolean, hostKey: string, fetchedAt: number, probeCpu: boolean, projectRules: ProjectRule[]): Promise<{
+/** Run `agents sessions --active --json` in one of three modes:
+ *   - fanOut  : bare call — the CLI does its OWN cross-machine SSH sweep and
+ *               returns every reachable machine's sessions, each tagged with its
+ *               `machine` id. This is the reliable multi-host source (the extension's
+ *               own per-host `--host` sweep is unreliable ssh-in-ssh and slow).
+ *   - --local : this machine's sessions only, no SSH (the cheap fast-tier poll).
+ *   - --host  : one specific remote — retained for completeness, but NO current
+ *               caller takes this path (both the feed sweep and the fast tier query
+ *               the local machine; on-demand remote detail uses fetchHostSessionDetail).
+ *  `probeCpu` only affects local CPU freshness now (both callers are local). */
+async function fetchActiveForHost(sshTarget: string, isLocal: boolean, hostKey: string, fetchedAt: number, probeCpu: boolean, projectRules: ProjectRule[], fanOut = false): Promise<{
   host: string;
   online: boolean;
   sessions: RemoteSession[];
@@ -227,12 +238,19 @@ async function fetchActiveForHost(sshTarget: string, isLocal: boolean, hostKey: 
   const agentsBin = await findAgentsCli();
   const args = ['sessions', '--active', '--json'];
   // `sshTarget` is the machine's SSH address (Tailscale dnsName); `hostKey` is the
-  // canonical device label that groups the sessions in the UI. They differ for a
-  // registered device, so the --host reach and the sidebar bucket stay decoupled.
-  if (!isLocal) args.push('--host', sshTarget);
+  // canonical device label used as the fallback bucket for machine-less (cloud) rows.
+  if (fanOut) {
+    // Bare — let the CLI fan out over the fleet; rows self-identify via `machine`.
+  } else if (isLocal) {
+    // Scope to this machine so the fast tier stays cheap (no SSH) and can't
+    // re-pollute the this-mac bucket with stale fleet rows.
+    args.push('--local');
+  } else {
+    args.push('--host', sshTarget);
+  }
   try {
     const { stdout } = await execFileAsync(agentsBin, args, {
-      timeout: isLocal ? ACTIVE_TIMEOUT_LOCAL_MS : ACTIVE_TIMEOUT_REMOTE_MS,
+      timeout: fanOut ? FANOUT_TIMEOUT_MS : (isLocal ? ACTIVE_TIMEOUT_LOCAL_MS : ACTIVE_TIMEOUT_REMOTE_MS),
       maxBuffer: 16 * 1024 * 1024,
       env: pathAugmentedEnv(),
     });
@@ -240,16 +258,28 @@ async function fetchActiveForHost(sshTarget: string, isLocal: boolean, hostKey: 
     const raw: any[] = Array.isArray(parsed) ? parsed : [];
     const normalized = raw
       .filter((rec) => rec && typeof rec === 'object')
-      .map((rec) => normalizeActiveSession(rec, hostKey, fetchedAt, projectRules));
+      // Attribute each row to the machine the CLI says it runs on (rec.machine),
+      // NOT the host we queried — a --host fetch returns the queried remote's
+      // sessions AND this machine's local ones, so keying on hostKey would
+      // mislabel the local rows. resolveSessionHost folds our own machine id
+      // back to LOCAL_LABEL and falls back to hostKey for machine-less (cloud) rows.
+      .map((rec) => normalizeActiveSession(
+        rec,
+        resolveSessionHost(rec.machine, hostKey, LOCAL_MACHINE_ID, LOCAL_LABEL),
+        fetchedAt,
+        projectRules,
+      ));
     // Collapse the many-processes-per-session records to one card BEFORE enriching,
     // so each session file is read once (not once per duplicate pid) and the header
     // count matches what the feed renders.
     const unique = dedupeSessions(normalized);
     const sessions: RemoteSession[] = [];
     for (let session of unique) {
-      // Only the local host can cheaply read session files to enrich activity,
-      // throughput, and waiting. Remote hosts stay status-only until Tier-2.
-      if (isLocal && session.sessionFile) {
+      // Only THIS machine's own sessions have a readable local session file to
+      // enrich activity/throughput/waiting. In fanOut mode the payload is
+      // multi-machine, so gate on the resolved bucket, not the query mode —
+      // remote rows stay status-only (their file lives on another host).
+      if (session.host === LOCAL_LABEL && session.sessionFile) {
         const tail = await readSessionTail(session.sessionFile, session.agentType);
         if (tail) {
           session = enrichWithSessionContent(session, tail.content, fetchedAt);
@@ -274,6 +304,49 @@ async function fetchActiveForHost(sshTarget: string, isLocal: boolean, hostKey: 
   }
 }
 
+/**
+ * Recent (historical, non-active) sessions for one host — what the Floor shows when a
+ * host filter has 0 live agents instead of a blank pane. Uses the clean-array
+ * `agents sessions --json [--host <t>] --limit N` path (flat SessionMeta), normalized
+ * onto the same RemoteSession shape as active sessions so the card path is identical.
+ * Fetched lazily (only when a host is empty), never on the hot poll.
+ */
+export async function fetchRecentForHost(
+  sshTarget: string,
+  isLocal: boolean,
+  hostKey: string,
+  limit: number,
+  projectRules: ProjectRule[],
+): Promise<RemoteSession[]> {
+  const agentsBin = await findAgentsCli();
+  const fetchedAt = Date.now();
+  const args = ['sessions', '--json', '--limit', String(limit)];
+  if (isLocal) args.push('--local');
+  else args.push('--host', sshTarget);
+  try {
+    const { stdout } = await execFileAsync(agentsBin, args, {
+      timeout: isLocal ? ACTIVE_TIMEOUT_LOCAL_MS : ACTIVE_TIMEOUT_REMOTE_MS,
+      maxBuffer: 16 * 1024 * 1024,
+      env: pathAugmentedEnv(),
+    });
+    const parsed = JSON.parse(stdout);
+    const raw: any[] = Array.isArray(parsed) ? parsed : [];
+    return raw
+      .filter((rec) => rec && typeof rec === 'object')
+      .map((rec) => normalizeRecentSession(
+        rec,
+        resolveSessionHost(rec.machine, hostKey, LOCAL_MACHINE_ID, LOCAL_LABEL),
+        fetchedAt,
+        projectRules,
+      ));
+  } catch {
+    // An older agents-cli (before the clean `--host --json` array) streams a
+    // non-JSON banner, so JSON.parse throws -> no recent shown. Graceful: the RECENT
+    // section simply stays empty until the engine change is released.
+    return [];
+  }
+}
+
 export interface HostSessionsResult {
   hosts: HostInfo[];
   sessions: RemoteSession[];
@@ -295,8 +368,10 @@ let localCache: { at: number; rulesKey: string; result: HostSessionsResult } | n
 let localInFlight: Promise<HostSessionsResult> | null = null;
 
 export interface FetchHostSessionsOptions {
-  /** Also probe each remote host's CPU load (a second SSH per host). The live feed
-   *  poll leaves this false; the Dispatch panel sets it true for load ranking. */
+  /** Kept for the Dispatch panel's load-ranking call. Since the feed now sources
+   *  every host from one bare fan-out (no per-host SSH), remote CPU is no longer
+   *  probed; this only affects local CPU freshness + the `hasCpu` cache key so a
+   *  Dispatch call after a feed poll can force one fresh sweep. */
   probeCpu?: boolean;
   /** Ordered cwd->project mappings applied when normalizing each session's project. */
   projectRules?: ProjectRule[];
@@ -315,11 +390,11 @@ function offlineHostInfo(name: string): HostInfo {
 }
 
 /**
- * Tier-1: enumerate hosts and fetch active sessions from each ONLINE host in
- * parallel (bounded by FANOUT_CONCURRENCY). Offline hosts are skipped entirely and
- * appear as empty offline roster entries. One dead host yields {online:false} with
- * no sessions instead of failing the batch. Cached for CACHE_TTL_MS; concurrent
- * callers share the in-flight promise.
+ * Tier-1: fetch active sessions across the whole fleet via ONE bare fan-out (the
+ * CLI's own cross-machine sweep), then reconcile against the device registry so
+ * every registered host — online or idle — appears under its canonical name with
+ * an accurate count. Cached for CACHE_TTL_MS; concurrent callers share the
+ * in-flight promise.
  */
 export async function fetchHostSessions(
   fetchedAt: number = Date.now(),
@@ -340,47 +415,43 @@ export async function fetchHostSessions(
 
   activeInFlight = (async () => {
     const hosts = await discoverHosts();
-    // Only fan out to hosts believed reachable (device registry online flag). Offline
-    // registered devices are skipped entirely and appear as empty offline roster rows.
-    const online = hosts.filter((h) => h.online);
-    const offline = hosts.filter((h) => !h.online);
-    const onlineResults = await mapWithConcurrency(online, FANOUT_CONCURRENCY, (h) => {
-      // The local machine's sessions are labelled 'this-mac' for the UI and queried
-      // directly (no --host); a registered remote is reached over ssh at its address
-      // but grouped under its canonical device name.
-      const hostKey = h.isLocal ? LOCAL_LABEL : h.name;
-      const sshTarget = h.isLocal ? hostKey : h.address;
-      // execFile's own timeout sends SIGTERM, which a hung ssh can ignore (stuck
-      // on connect / host-key / auth). Race every host against a hard wall-clock
-      // timeout that always resolves, so ONE unreachable machine can never block
-      // the batch — which was leaving the whole Floor empty.
-      return withHardTimeout(
-        fetchActiveForHost(sshTarget, h.isLocal, hostKey, fetchedAt, probeCpu, projectRules),
-        h.isLocal ? ACTIVE_TIMEOUT_LOCAL_MS + 2000 : ACTIVE_TIMEOUT_REMOTE_MS + 2000,
-        { host: hostKey, online: false, sessions: [], cpuRatio: null }
-      );
-    });
-    // Merge every host's sessions, then (1) collapse the SAME session id reported by
-    // more than one host into one — cross-host dedupe, so a session synced/reachable
-    // on two machines is counted once — and (2) drop stale (long-dead) sessions. Both
-    // run on the merged set so counts, the feed, and needs-you all reconcile.
-    const merged: RemoteSession[] = [];
-    for (const r of onlineResults) merged.push(...r.sessions);
-    const sessions = filterStaleSessions(dedupeSessions(merged), fetchedAt);
-    // Per-host live counts from the reconciled set (post dedupe + stale), so a host's
-    // agent count matches exactly the cards the feed renders for it.
+    // ONE bare fan-out: the CLI runs its own cross-machine SSH sweep and returns
+    // every reachable machine's sessions, each self-identifying via `machine`.
+    // This replaces the extension's per-host `--host` sweep, which is unreliable
+    // (ssh-in-ssh that reports "unreachable — skipped") and slow (~12s/host) — the
+    // exact reason remote hosts were showing 0 while the fleet's work ran on them.
+    const fan = await withHardTimeout(
+      fetchActiveForHost(LOCAL_LABEL, true, LOCAL_LABEL, fetchedAt, probeCpu, projectRules, true),
+      FANOUT_TIMEOUT_MS + 2000,
+      { host: LOCAL_LABEL, online: false, sessions: [], cpuRatio: null },
+    );
+    // Dedupe (many pids -> one session) + drop stale, so counts, the feed, and
+    // needs-you all reconcile against the same reconciled set.
+    const sessions = filterStaleSessions(dedupeSessions(fan.sessions), fetchedAt);
+    // Per-host live counts from the reconciled set (keyed by the machine bucket
+    // resolveSessionHost assigned), so a host's count matches its rendered cards.
     const countByHost = new Map<string, number>();
     for (const s of sessions) countByHost.set(s.host, (countByHost.get(s.host) ?? 0) + 1);
-    const resolvedHosts: HostInfo[] = onlineResults.map((r) => {
-      // agents = this host's reconciled active-session count (== HostGroup.sessions.length);
-      // load = derived from that plus the live CPU ratio ('off' when offline);
-      // uses = the same active count, the ranking tiebreak we can source today.
-      const agents = countByHost.get(r.host) ?? 0;
-      const load = r.online ? deriveHostLoad(agents, r.cpuRatio) : 'off';
-      return { name: r.host, online: r.online, agents, load, uses: agents };
-    });
-    // Keep offline registered devices visible in the roster so the sidebar lists them.
-    for (const h of offline) resolvedHosts.push(offlineHostInfo(h.name));
+    // Roster = the registered device fleet + this machine. A host is online if the
+    // registry says so OR it returned live sessions; offline registered devices stay
+    // visible with 0. Local CPU is free (os.loadavg); remote load derives from count.
+    const resolvedHosts: HostInfo[] = [];
+    const seen = new Set<string>();
+    for (const h of hosts) {
+      const key = h.isLocal ? LOCAL_LABEL : normalizeHost(h.name);
+      seen.add(key);
+      const agents = countByHost.get(key) ?? 0;
+      const isOnline = h.isLocal ? fan.online : (h.online || agents > 0);
+      if (!isOnline) { resolvedHosts.push(offlineHostInfo(key)); continue; }
+      const load = deriveHostLoad(agents, h.isLocal ? fan.cpuRatio : null);
+      resolvedHosts.push({ name: key, online: true, agents, load, uses: agents });
+    }
+    // Defensive: a machine that returned sessions but isn't in the device registry
+    // still gets a roster row so its cards aren't orphaned from the sidebar.
+    for (const [key, agents] of countByHost) {
+      if (seen.has(key)) continue;
+      resolvedHosts.push({ name: key, online: true, agents, load: deriveHostLoad(agents, null), uses: agents });
+    }
     const groups = groupByHost(sessions, resolvedHosts, fetchedAt);
     const result: HostSessionsResult = { hosts: resolvedHosts, sessions, groups, fetchedAt };
     activeCache = { at: fetchedAt, hasCpu: probeCpu, rulesKey, result };

--- a/apps/factory/src/vscode/settings.vscode.ts
+++ b/apps/factory/src/vscode/settings.vscode.ts
@@ -1942,6 +1942,25 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
         }
         break;
       }
+      case 'fetchRecentSessions': {
+        // Lazy: the Floor asks for a host's RECENT (historical) sessions only when that
+        // host has 0 live agents, so an empty host filter shows recent work instead of a
+        // blank pane. Rides its own 'recentSessions' message, keyed by host.
+        const recentHost = typeof message.host === 'string' ? message.host : '';
+        try {
+          if (!recentHost) break;
+          const { fetchRecentForHost, LOCAL_LABEL } = await import('./remoteSessions.vscode');
+          const isLocal = recentHost === 'this-mac' || recentHost === LOCAL_LABEL;
+          const sessions = await fetchRecentForHost(
+            recentHost, isLocal, recentHost, 12, getSettings(context).projectRules ?? [],
+          );
+          settingsPanel?.webview.postMessage({ type: 'recentSessions', host: recentHost, sessions });
+        } catch (err) {
+          console.error('[SETTINGS] Error fetching recent sessions:', err);
+          settingsPanel?.webview.postMessage({ type: 'recentSessions', host: recentHost, sessions: [] });
+        }
+        break;
+      }
       case 'fetchHostInventory': {
         // Host detail pane: installed agents/versions/accounts/usage/resources on
         // one host (over SSH for remotes) + registry metadata. Cached per host.
@@ -2670,6 +2689,36 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
       case 'focusTerminal': {
         const entry = terminals.getById(message.terminalId);
         entry?.terminal.show(false);
+        break;
+      }
+      case 'focusRemoteSession': {
+        // Open a terminal attached to a remote (or local-but-tabless) agent's tmux
+        // session, so a cross-host card can be "focused in a new terminal" the same
+        // way a local tab can. Reuses the tmux socket the reply channel already knows
+        // (ReplyTarget.muxSocket); ssh -t for a remote host, direct tmux locally.
+        const host = typeof message.host === 'string' && message.host !== 'this-mac' ? message.host : '';
+        const socket = typeof message.muxSocket === 'string' ? message.muxSocket : '';
+        const label = typeof message.label === 'string' && message.label ? message.label : 'session';
+        if (!socket) { break; }
+        const shq = (s: string) => `'${s.replace(/'/g, `'\\''`)}'`;
+        const attach = `tmux -S ${shq(socket)} attach`;
+        const cmd = host ? `ssh -t ${shq(host)} ${shq(attach)}` : attach;
+        const term = vscode.window.createTerminal({ name: `attach ${label}` });
+        term.sendText(cmd, true);
+        term.show(false);
+        break;
+      }
+      case 'revealWorktree': {
+        // Reveal a local worktree in the Explorer; a remote worktree can't be shown in
+        // this window's file tree, so copy its path (silent, no toast).
+        const p = typeof message.path === 'string' ? message.path : '';
+        const host = typeof message.host === 'string' && message.host !== 'this-mac' ? message.host : '';
+        if (!p) { break; }
+        if (host) {
+          await vscode.env.clipboard.writeText(p);
+        } else {
+          await vscode.commands.executeCommand('revealInExplorer', vscode.Uri.file(p));
+        }
         break;
       }
       case 'focusRushCloudTerminal': {

--- a/apps/factory/ui/settings/components/mission-control/BacklogCenter.tsx
+++ b/apps/factory/ui/settings/components/mission-control/BacklogCenter.tsx
@@ -18,6 +18,7 @@ const GROUP_OPTS: { value: TicketGroupBy; label: string }[] = [
   { value: 'priority', label: 'Priority' },
   { value: 'source', label: 'Source' },
   { value: 'status', label: 'Status' },
+  { value: 'owner', label: 'Owner' },
 ]
 const SORT_OPTS: TicketSort[] = ['priority', 'id']
 

--- a/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Icon } from './icons'
 import { AgentAvatar, agentIdFromPrefix } from './AgentAvatar'
 import { StructuredReply, type ReplyCallbacks } from './StructuredReply'
-import { heartbeatLevel, type FloorAgent, type FloorTicket } from './floorModel'
+import { heartbeatLevel, sessionTaskLine, type FloorAgent, type FloorTicket } from './floorModel'
 import { sinceFromMs } from './floorAdapter'
 import { useNow } from './useNow'
 import { TodoProgressBar } from './TodoChecklist'
@@ -49,7 +49,12 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
   // to the meta line. Both only show in full (non-plain) mode when the CLI supplies them.
   const paneLabel = !plain && a.pane ? ` · ${a.pane}` : ''
   const viewingLabel = !plain && a.viewingIn ? ` · viewing in ${a.viewingIn}` : ''
-  const meta = plain ? a.project : `${a.project} · ${a.hostLabel ?? a.host}${a.ticket ? ` · ${a.ticket}` : ''}${filesLabel}${paneLabel}${viewingLabel}`
+  // The worktree slug (or branch) sits between project and ticket so two sessions in
+  // the same repo are distinguishable at a glance (the identical-cards bug).
+  const wt = a.worktreeSlug || a.branch
+  const meta = plain
+    ? a.project
+    : `${a.project} · ${a.hostLabel ?? a.host}${wt ? ` · ${wt}` : ''}${a.ticket ? ` · ${a.ticket}` : ''}${filesLabel}${paneLabel}${viewingLabel}`
   const destructive = a.question?.kind === 'destructive'
   const attn = a.phase === 'failed' ? 'fail' : stalled ? 'stall' : a.needs ? 'attn' : ''
 
@@ -57,12 +62,13 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
   // when it just echoes the response block. Suppress the now-line when the summary
   // already says the same thing (summary fell back to the now-line's activity string).
   const nowlineText = `${a.verb} ${a.target}`.trim()
-  const showSummary =
-    !plain &&
-    !!a.summary &&
-    (a.phase === 'running' || a.phase === 'stalled') &&
-    a.summary.trim() !== a.resp.trim()
-  const showNowline = !plain && !!a.verb && !(showSummary && a.summary.trim() === nowlineText)
+  // One canonical task line (summary/preview -> response -> worktree/branch). This is
+  // what fixes the identical, contextless "needs you" cards: a waiting session with no
+  // narrative still shows its worktree slug instead of just "Edit <file>". Shown unless
+  // it merely echoes the response block or the now-line.
+  const taskLine = sessionTaskLine(a)
+  const showSummary = !plain && !!taskLine && taskLine !== a.resp.trim() && taskLine !== nowlineText
+  const showNowline = !plain && !!a.verb && !(showSummary && taskLine === nowlineText)
 
   const marker =
     a.pr ? <span className="pill pr">PR {a.pr}</span> :
@@ -101,7 +107,7 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
       </div>
       <div className="resp">{destructive ? <span className="q">{a.resp}</span> : a.resp}</div>
       {!plain && a.todos.length > 0 && <TodoProgressBar todos={a.todos} />}
-      {showSummary && <div className="summary">{a.summary}</div>}
+      {showSummary && <div className="summary">{taskLine}</div>}
       {showNowline && (
         <div className={`nowline ${stalled ? 'stall' : ''}`}>
           <Icon name="chevR" size={11} /> <span className="v">{a.verb}</span> {a.target}

--- a/apps/factory/ui/settings/components/mission-control/FloorControls.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorControls.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Icon } from './icons'
-import type { AgentAbbr, FloorSort } from './floorModel'
+import type { AgentAbbr, FloorSort, FloorGroupBy } from './floorModel'
 
 // Single Floor filter bar (Sort · Status · Agent · search · stats · toggles · Dispatch).
 // The old duplicate ".top" header (second FACTORY logo + theme toggle) was removed —
@@ -18,6 +18,16 @@ const SORT_OPTS: { value: FloorSort; label: string }[] = [
 
 const DEFAULT_AGENT_CHIPS: AgentAbbr[] = ['CC', 'CX', 'GX']
 
+// Group the live feed by an axis; 'none' keeps the default phase sections. Same axes
+// as the Backlog's group control (BacklogCenter GROUP_OPTS) so the two bars match.
+const GROUP_OPTS: { value: FloorGroupBy | 'none'; label: string }[] = [
+  { value: 'none', label: 'None' },
+  { value: 'project', label: 'Project' },
+  { value: 'host', label: 'Host' },
+  { value: 'status', label: 'Status' },
+  { value: 'agent', label: 'Agent' },
+]
+
 const SVG = { fill: 'none', stroke: 'currentColor', strokeWidth: 1.4 } as const
 
 interface FloorControlsProps {
@@ -33,6 +43,9 @@ interface FloorControlsProps {
 
   sort: FloorSort
   onSort: (s: FloorSort) => void
+  /** How the live feed is grouped ('none' = default phase sections). */
+  group: FloorGroupBy | 'none'
+  onGroup: (g: FloorGroupBy | 'none') => void
   /** Which status chips are active. */
   activeStatus: StatusChip[]
   onToggleStatus: (chip: StatusChip) => void
@@ -50,7 +63,7 @@ interface FloorControlsProps {
 export function FloorControls({
   runningCount, totalCount,
   sidebarOpen, onToggleSidebar, rightOpen, onToggleRight, plain, onTogglePlain,
-  sort, onSort, activeStatus, onToggleStatus, agentChips = DEFAULT_AGENT_CHIPS, activeAbbrs, onToggleAbbr,
+  sort, onSort, group, onGroup, activeStatus, onToggleStatus, agentChips = DEFAULT_AGENT_CHIPS, activeAbbrs, onToggleAbbr,
   search, onSearch, onDispatch,
 }: FloorControlsProps) {
   const statusOn = new Set(activeStatus)
@@ -92,6 +105,17 @@ export function FloorControls({
         {agentChips.map((ab) => (
           <span key={ab} className={`chip ${abbrOn.has(ab) ? 'on' : ''}`} onClick={() => onToggleAbbr(ab)}>{ab}</span>
         ))}
+      </div>
+
+      <div className="fsep" />
+
+      <div className="fgroup">
+        <span className="fgroup-label">Group</span>
+        <select className="sel" value={group} onChange={(e) => onGroup(e.target.value as FloorGroupBy | 'none')}>
+          {GROUP_OPTS.map((o) => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
       </div>
 
       <div className="fsep" />

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -32,7 +32,9 @@ import { StructuredReply } from './StructuredReply'
 import {
   clusterByQuestion,
   sortAgents,
+  groupAgents,
   latestTodos,
+  sessionTaskLine,
   type FloorAgent,
   type CenterMode,
   type HostInventory,
@@ -577,7 +579,14 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   const [projFilter, setProjFilter] = useState<string | null>(null)
   // Host scope: click a HOSTS row to filter the feed to that machine; click again to clear.
   const [hostFilter, setHostFilter] = useState<string | null>(null)
+  // Recent (historical) sessions per host, fetched lazily only when a host filter has
+  // 0 live agents — so an empty host shows recent work instead of a blank pane.
+  const [recentByHost, setRecentByHost] = useState<Record<string, RemoteSessionLike[]>>({})
   const [floorSort, setFloorSort] = useState<FloorSort>('needs')
+  // Group the live feed by an axis (project/host/status/agent). 'none' keeps the
+  // default phase sections (NEEDS YOU -> RUNNING -> DONE). Reuses the same
+  // groupAgents() the Backlog's group control uses, so the two bars behave alike.
+  const [floorGroup, setFloorGroup] = useState<FloorGroupBy | 'none'>('none')
   const [plain, setPlain] = useState(floorPrefs0.plain)
   const [sidebarOpen, setSidebarOpen] = useState(floorPrefs0.sidebar)
   const [rightOpen, setRightOpen] = useState(floorPrefs0.right)
@@ -689,6 +698,10 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
       } else if (msg?.type === 'localSessions') {
         const local = Array.isArray(msg.sessions) ? (msg.sessions as RemoteSessionLike[]) : []
         setRemoteSessions((prev) => [...prev.filter((s) => s.host !== 'this-mac'), ...local])
+      } else if (msg?.type === 'recentSessions') {
+        const rh = typeof msg.host === 'string' ? msg.host : ''
+        const recent = Array.isArray(msg.sessions) ? (msg.sessions as RemoteSessionLike[]) : []
+        setRecentByHost((p) => ({ ...p, [rh]: recent }))
       }
     }
     window.addEventListener('message', onMsg)
@@ -1370,6 +1383,19 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     return list
   }, [floorAgents, projFilter, hostFilter, statusChips, abbrChips, floorSearch])
 
+  // Empty host filter -> show that host's recent sessions instead of a blank pane.
+  // Fetch once per host (lazily), then adapt through the SAME card path as live agents.
+  const hostHasNoActive = !!hostFilter && scopedAgents.length === 0
+  useEffect(() => {
+    if (hostHasNoActive && hostFilter && recentByHost[hostFilter] === undefined) {
+      postMessage({ type: 'fetchRecentSessions', host: hostFilter })
+    }
+  }, [hostHasNoActive, hostFilter, recentByHost])
+  const recentAgents = useMemo(
+    () => (hostFilter && hostHasNoActive ? adaptRemote(recentByHost[hostFilter] ?? [], pinned, localHostName, projectRules) : []),
+    [hostFilter, hostHasNoActive, recentByHost, pinned, localHostName, projectRules]
+  )
+
   const needsAgents = useMemo(() => scopedAgents.filter((a) => a.needs), [scopedAgents])
   const waitingAgents = useMemo(() => needsAgents.filter((a) => a.phase === 'waiting'), [needsAgents])
   const failedAgents = useMemo(() => needsAgents.filter((a) => a.phase === 'failed'), [needsAgents])
@@ -1496,9 +1522,14 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     setProjFilter(value || null)
   }, [])
 
+  // Selecting an agent opens its detail rail — the SAME setRightOpen(true) that
+  // onSelectHost does. These two were the drifted pair: this one omitted it, so
+  // clicking an agent card silently did nothing (the rail only renders when
+  // rightOpen). Keep them symmetric.
   const selectFloorAgent = useCallback((id: string) => {
     setCenter('agents')
     setSelectedAgentId(id)
+    setRightOpen(true)
   }, [])
 
   // Host detail pane: clicking a host in the sidebar opens its detail/config on
@@ -1569,13 +1600,33 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
           <div style={{ display: 'flex', flexDirection: 'column', minHeight: 0, overflow: 'auto' }}>
             <div className="dhead" style={{ flexDirection: 'column', alignItems: 'flex-start', gap: 4 }}>
               <div className="title">{a.project} / {a.name}</div>
-              <div className="sub">host <b>{a.hostLabel ?? a.host}</b>{a.branch ? ` · ${a.branch}` : ''} · {a.phase}{a.tok ? ` · ${a.tok} tok/s` : ''}</div>
-              {a.prUrl && (
-                <ExtLink href={a.prUrl} className="opt ghost" style={{ marginTop: 8, textDecoration: 'none' }}>
-                  <Icon name="chevR" size={11} /> Open PR {a.pr ?? ''} on GitHub
-                </ExtLink>
-              )}
-              {a.summary && <div className="resp" style={{ marginTop: 8 }}>{a.summary}</div>}
+              <div className="sub">host <b>{a.hostLabel ?? a.host}</b>{(a.worktreeSlug || a.branch) ? ` · ${a.worktreeSlug || a.branch}` : ''} · {a.phase}{a.tok ? ` · ${a.tok} tok/s` : ''}{a.ticket ? ` · ${a.ticket}` : ''}</div>
+              {/* Actions: give a selected agent something to DO (issue: clicking a card
+                  offered nothing). Focus opens the session's terminal — local via the
+                  live vscode terminal, remote via an ssh + tmux-attach terminal. */}
+              <div className="opts" style={{ marginTop: 8, flexWrap: 'wrap', gap: 6 }}>
+                {a.reply.kind === 'terminal' && a.reply.terminalId && (
+                  <button className="opt" onClick={() => postMessage({ type: 'focusTerminal', terminalId: a.reply.terminalId })}>
+                    <Icon name="chevR" size={11} /> Focus terminal
+                  </button>
+                )}
+                {a.reply.kind === 'tmux' && a.reply.muxTarget && (
+                  <button className="opt" onClick={() => postMessage({ type: 'focusRemoteSession', host: a.reply.host, muxSocket: a.reply.muxSocket, muxTarget: a.reply.muxTarget, sessionId: a.reply.sessionId, label: a.name })}>
+                    <Icon name="chevR" size={11} /> Focus in terminal
+                  </button>
+                )}
+                {a.worktreePath && (
+                  <button className="opt" onClick={() => postMessage({ type: 'revealWorktree', path: a.worktreePath, host: a.host })}>
+                    <Icon name="chevR" size={11} /> Reveal worktree
+                  </button>
+                )}
+                {a.prUrl && (
+                  <ExtLink href={a.prUrl} className="opt ghost" style={{ textDecoration: 'none' }}>
+                    <Icon name="chevR" size={11} /> Open PR {a.pr ?? ''}
+                  </ExtLink>
+                )}
+              </div>
+              {(() => { const task = sessionTaskLine(a); return task && task !== a.resp.trim() ? <div className="resp" style={{ marginTop: 8 }}>{task}</div> : null })()}
               {a.resp && a.resp !== a.summary && <div className="resp" style={{ marginTop: 8 }}>{a.resp}</div>}
               {(a.verb || a.target) && <div className="nowline" style={{ marginTop: 8 }}><Icon name="chevR" size={11} /> <span className="v">{a.verb}</span> {a.target}</div>}
             </div>
@@ -1680,7 +1731,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
         </>
       )}
 
-      <div className="feed-sec">RUNNING · {runningFeed.length}<span className="ln" />
+      <div className="feed-sec">{floorGroup === 'none' ? `RUNNING · ${runningFeed.length}` : `GROUPED BY ${floorGroup.toUpperCase()} · ${runningFeed.length + doneFeed.length}`}<span className="ln" />
         <span
           className={`fresh${syncingHosts ? ' syncing' : ''}${!syncingHosts && lastRemoteSync > 0 && nowMs - lastRemoteSync > 2 * REMOTE_POLL_MS ? ' stale' : ''}`}
           title="Last cross-host sync. Click to refresh now."
@@ -1694,23 +1745,61 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               : 'not synced yet'}
         </span>
       </div>
-      {runningFeed.map((a) => (
-        <FeedItem
-          key={a.id}
-          agent={a}
-          selected={selectedFloorAgent?.id === a.id}
-          plain={plain}
-          onSelect={selectFloorAgent}
-          onOption={onAgentOption}
-          onFreeText={replyToAgent}
-          onAttach={onAttachScreenshot}
-        />
-      ))}
+      {floorGroup === 'none'
+        ? runningFeed.map((a) => (
+            <FeedItem
+              key={a.id}
+              agent={a}
+              selected={selectedFloorAgent?.id === a.id}
+              plain={plain}
+              onSelect={selectFloorAgent}
+              onOption={onAgentOption}
+              onFreeText={replyToAgent}
+              onAttach={onAttachScreenshot}
+            />
+          ))
+        : [...groupAgents([...runningFeed, ...doneFeed], floorGroup).entries()].map(([k, arr]) => (
+            <React.Fragment key={k}>
+              <div className="feed-sec">{k} · {arr.length}<span className="ln" /></div>
+              {arr.map((a) => (
+                <FeedItem
+                  key={a.id}
+                  agent={a}
+                  selected={selectedFloorAgent?.id === a.id}
+                  plain={plain}
+                  onSelect={selectFloorAgent}
+                  onOption={onAgentOption}
+                  onFreeText={replyToAgent}
+                  onAttach={onAttachScreenshot}
+                />
+              ))}
+            </React.Fragment>
+          ))}
 
-      {doneFeed.length > 0 && (
+      {floorGroup === 'none' && doneFeed.length > 0 && (
         <>
           <div className="feed-sec">DONE TODAY · {doneFeed.length}<span className="ln" /></div>
           {doneFeed.map((a) => (
+            <FeedItem
+              key={a.id}
+              agent={a}
+              selected={selectedFloorAgent?.id === a.id}
+              plain={plain}
+              onSelect={selectFloorAgent}
+              onOption={onAgentOption}
+              onFreeText={replyToAgent}
+              onAttach={onAttachScreenshot}
+            />
+          ))}
+        </>
+      )}
+
+      {hostHasNoActive && (
+        <>
+          <div className="feed-sec">RECENT · {recentAgents.length}{hostFilter ? ` · ${hostFilter}` : ''}<span className="ln" /></div>
+          {recentAgents.length === 0 ? (
+            <div className="detail-empty" style={{ padding: '10px 16px' }}>No recent sessions for this host.</div>
+          ) : recentAgents.map((a) => (
             <FeedItem
               key={a.id}
               agent={a}
@@ -1758,6 +1847,8 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
         onTogglePlain={() => setPlain((o) => !o)}
         sort={floorSort}
         onSort={setFloorSort}
+        group={floorGroup}
+        onGroup={setFloorGroup}
         activeStatus={statusChips}
         onToggleStatus={(chip) => setStatusChips((prev) => (prev.includes(chip) ? prev.filter((c) => c !== chip) : [...prev, chip]))}
         activeAbbrs={abbrChips}

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -100,7 +100,7 @@
 .swarmify-root .spark { display: inline-flex; align-items: flex-end; gap: 1px; height: 12px; }
 .swarmify-root .spark i { width: 2px; background: var(--brand-600); border-radius: 1px; display: block; opacity: .85; }
 .swarmify-root .since { color: var(--ds-text-dim); font-size: 11px; font-variant-numeric: tabular-nums; }
-.swarmify-root .tps { color: var(--brand-600); font-weight: 600; font-size: 11px; font-variant-numeric: tabular-nums; }
+.swarmify-root .tps { display: inline-flex; align-items: center; gap: 3px; white-space: nowrap; flex: 0 0 auto; color: var(--brand-600); font-weight: 600; font-size: 11px; font-variant-numeric: tabular-nums; }
 
 /* ============ LAYOUT: RAIL ============ */
 .swarmify-root .rail-wrap { display: grid; grid-template-columns: 320px 1fr; height: 100%; min-height: 0; }
@@ -262,7 +262,7 @@
 .swarmify-root .sb-item.on { background: var(--ds-bg-panel); color: var(--ds-text); font-weight: 600; box-shadow: inset 3px 0 0 var(--brand); }
 .swarmify-root .sb-item .c { margin-left: auto; font-size: 11px; color: var(--ds-text-dim); font-variant-numeric: tabular-nums; display: flex; gap: 6px; }
 .swarmify-root .sb-item .c .w { color: var(--status-pending); font-weight: 700; }
-.swarmify-root .sb-item .hd { width: 7px; height: 7px; border-radius: 50%; background: var(--status-running); }
+.swarmify-root .sb-item .hd { flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%; background: var(--status-running); }
 .swarmify-root .sb-item .hd.off { background: var(--status-failed); }
 /* HOSTS pin + drag-reorder. Grip column is reserved on every host row so the
    status dots line up whether or not a row is pinned/draggable. */

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
@@ -18,6 +18,7 @@ import {
   toFloorTicket,
   latestTodos,
   resolveProject,
+  worktreeSlugOf,
   type FloorAgent,
   type FloorTicket,
   type AgentAbbr,
@@ -77,6 +78,11 @@ export interface RemoteSessionLike {
   ci?: CiStatus | null
   ticket: string | null
   branch: string
+  /** `<slug>` under `.agents/worktrees/<slug>/` — disambiguates sibling worktree
+   *  sessions and gives the card a task label when topic/preview are empty. */
+  worktreeSlug?: string
+  /** Absolute worktree path, for the Reveal-worktree action. */
+  worktreePath?: string
   sinceMs: number
   startedAtMs: number
   topic: string
@@ -268,6 +274,8 @@ export function toFloorAgentFromUnified(
     ci,
     ticket: u.linearIssue ?? null,
     branch: u.terminal?.branch ?? u.agent?.branch ?? '',
+    worktreeSlug: worktreeSlugOf(u.terminal?.cwd ?? u.agent?.cwd),
+    worktreePath: worktreeSlugOf(u.terminal?.cwd ?? u.agent?.cwd) ? (u.terminal?.cwd ?? u.agent?.cwd ?? '') : '',
     resp,
     question: parseStructuredQuestion(resp, phase),
     reply,
@@ -325,6 +333,8 @@ export function toFloorAgentFromRemote(r: RemoteSessionLike, pinned: Set<string>
     ci,
     ticket: r.ticket,
     branch: r.branch,
+    worktreeSlug: r.worktreeSlug ?? worktreeSlugOf(r.cwd),
+    worktreePath: r.worktreePath ?? (worktreeSlugOf(r.cwd) ? r.cwd : ''),
     resp,
     question: parseStructuredQuestion(resp, phase),
     reply: deriveReplyTargetFromRemote(r),

--- a/apps/factory/ui/settings/components/mission-control/floorModel.fixes.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.fixes.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect } from 'bun:test'
+import * as fs from 'fs'
+import * as path from 'path'
+import {
+  toFloorTicket,
+  groupTickets,
+  groupAgents,
+  sessionTaskLine,
+  worktreeSlugOf,
+  type FloorAgent,
+} from './floorModel'
+import type { UnifiedTask } from '../../types'
+
+// Regression tests for the Factory Floor visibility fixes. Each asserts a
+// user-visible outcome that was broken, so a future edit that reintroduces the bug
+// fails here rather than silently in the UI.
+
+function agent(over: Partial<FloorAgent>): FloorAgent {
+  return {
+    id: 'x', host: 'this-mac', hostLabel: undefined, project: '', name: 'a', abbr: 'CC',
+    phase: 'running', verb: '', target: '', tok: 0, since: '', lastActivityMs: 0,
+    files: 0, tools: 0, needs: false, pinned: false, pr: null, prUrl: null, ci: null,
+    ticket: null, branch: '', worktreeSlug: '', worktreePath: '', resp: '',
+    question: null, reply: { kind: 'none', host: 'this-mac' }, todos: [], summary: '',
+    recent: [], ...over,
+  }
+}
+
+function task(meta: UnifiedTask['metadata'], over: Partial<UnifiedTask> = {}): UnifiedTask {
+  return { id: 'T', source: 'linear', title: 't', status: 'todo', metadata: meta, ...over }
+}
+
+describe('issue 1 — real project, generic Unlabeled key', () => {
+  test('toFloorTicket prefers the formal Linear project, then repo', () => {
+    expect(toFloorTicket(task({ project: 'Rush App', repo: 'x/y' })).project).toBe('Rush App')
+    expect(toFloorTicket(task({ repo: 'owner/repo' })).project).toBe('owner/repo')
+    expect(toFloorTicket(task({})).project).toBe('')
+  })
+
+  test('groupTickets renders an empty project as "Unlabeled", never blank', () => {
+    const tickets = [toFloorTicket(task({})), toFloorTicket(task({ project: 'Alpha' }))]
+    const keys = [...groupTickets(tickets, 'project').keys()]
+    expect(keys).toContain('Unlabeled')
+    expect(keys).toContain('Alpha')
+    expect(keys).not.toContain('')
+  })
+
+  test('groupAgents coalesces empty keys across axes', () => {
+    const groups = groupAgents([agent({ project: '' }), agent({ project: 'Beta' })], 'project')
+    expect([...groups.keys()]).toEqual(expect.arrayContaining(['Unlabeled', 'Beta']))
+    // host groups by the DISPLAY label so this-mac folds onto the device name
+    const byHost = groupAgents([agent({ host: 'this-mac', hostLabel: 'zion' })], 'host')
+    expect([...byHost.keys()]).toContain('zion')
+  })
+})
+
+describe('issue 2 — one task-line seam', () => {
+  test('sessionTaskLine falls back summary -> resp -> worktreeSlug -> branch', () => {
+    expect(sessionTaskLine(agent({ summary: 'S', resp: 'R', worktreeSlug: 'W' }))).toBe('S')
+    expect(sessionTaskLine(agent({ resp: 'R', worktreeSlug: 'W' }))).toBe('R')
+    expect(sessionTaskLine(agent({ worktreeSlug: 'headless-secrets-shadow', branch: 'b' }))).toBe('headless-secrets-shadow')
+    expect(sessionTaskLine(agent({ branch: 'my/branch' }))).toBe('my/branch')
+    expect(sessionTaskLine(agent({}))).toBe('')
+  })
+
+  test('worktreeSlugOf extracts the slug under .agents/worktrees/', () => {
+    expect(worktreeSlugOf('/x/agents-cli/.agents/worktrees/headless-secrets-shadow/src/lib/secrets/linux.ts'))
+      .toBe('headless-secrets-shadow')
+    expect(worktreeSlugOf('/x/agents-cli/src/index.ts')).toBe('')
+    expect(worktreeSlugOf(undefined)).toBe('')
+  })
+})
+
+describe('wiring guard — infra must stay wired (issue 5 was dead code)', () => {
+  // groupAgents + sessionTaskLine both existed unused once; assert their production
+  // consumer still imports them so they can't silently become dead again.
+  const pane = fs.readFileSync(path.join(__dirname, 'UnifiedAgentsPane.tsx'), 'utf8')
+  test('UnifiedAgentsPane wires groupAgents (the Group-by control)', () => {
+    expect(pane).toContain('groupAgents(')
+  })
+  test('UnifiedAgentsPane wires sessionTaskLine (the detail rail)', () => {
+    expect(pane).toContain('sessionTaskLine(')
+  })
+})

--- a/apps/factory/ui/settings/components/mission-control/floorModel.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.test.ts
@@ -448,6 +448,11 @@ describe('toFloorTicket — field mapping', () => {
     expect(bare.labels).toEqual([])
     expect(bare.desc).toBe('')
   })
+
+  test('owner maps from metadata.assignee, defaults to empty when unassigned', () => {
+    expect(toFloorTicket(makeTask({ metadata: { assignee: 'Muqsit' } })).owner).toBe('Muqsit')
+    expect(toFloorTicket(makeTask({ metadata: {} })).owner).toBe('')
+  })
 })
 
 describe('groupTickets / sortTickets', () => {
@@ -473,6 +478,19 @@ describe('groupTickets / sortTickets', () => {
     const g = groupTickets(tickets, 'project')
     expect(g.get('web')!.map((t) => t.id)).toEqual(['RUSH-2', 'RUSH-3'])
     expect(g.get('swarmify')!.map((t) => t.id)).toEqual(['#1'])
+  })
+
+  test('groupTickets by owner buckets by assignee; unassigned collapses to Unassigned', () => {
+    const owned = [
+      toFloorTicket(makeTask({ id: 'RUSH-10', metadata: { assignee: 'Muqsit' } })),
+      toFloorTicket(makeTask({ id: 'RUSH-11', metadata: { assignee: 'Bisma' } })),
+      toFloorTicket(makeTask({ id: 'RUSH-12', metadata: { assignee: 'Muqsit' } })),
+      toFloorTicket(makeTask({ id: 'RUSH-13', metadata: {} })),
+    ]
+    const g = groupTickets(owned, 'owner')
+    expect(g.get('Muqsit')!.map((t) => t.id)).toEqual(['RUSH-10', 'RUSH-12'])
+    expect(g.get('Bisma')!.map((t) => t.id)).toEqual(['RUSH-11'])
+    expect(g.get('Unassigned')!.map((t) => t.id)).toEqual(['RUSH-13'])
   })
 })
 

--- a/apps/factory/ui/settings/components/mission-control/floorModel.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.ts
@@ -13,78 +13,20 @@
 // (+ DESIGN.md). Field names mirror the prototype's AGENTS / TICKETS mock objects
 // so the port is a 1:1 translation, not a redesign.
 
-import type { UnifiedTask, RecentToolCall, ProjectRule } from '../../types'
+import type { UnifiedTask, RecentToolCall } from '../../types'
 
 export type { RecentToolCall }
 
 // ---------- project resolution ----------
 //
-// Mirror of src/core/remoteSessions.ts resolveProject (hand-kept; the src/ and ui/
-// builds cannot share imports, so the logic lives on both sides of the postMessage
-// boundary). Keep the two in lockstep.
-
-/** Glob -> RegExp. `**` spans path separators, `*` does not, `?` a single char.
- *  A trailing subpath always matches so a rule for a dir captures work inside it. */
-function projectGlobToRegExp(glob: string): RegExp {
-  let re = ''
-  for (let i = 0; i < glob.length; i++) {
-    const c = glob[i]
-    if (c === '*') {
-      if (glob[i + 1] === '*') {
-        re += '.*'
-        i++
-      } else {
-        re += '[^/]*'
-      }
-    } else if (c === '?') {
-      re += '[^/]'
-    } else {
-      re += c.replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    }
-  }
-  return new RegExp('^' + re + '(?:/.*)?$')
-}
-
-/** A rule pattern with no glob metacharacters is a path prefix; else a glob. */
-function matchesProjectRule(cwd: string, pattern: string): boolean {
-  const p = pattern.trim().replace(/\/+$/, '')
-  if (!p) return false
-  if (!/[*?]/.test(p)) return cwd === p || cwd.startsWith(p + '/')
-  return projectGlobToRegExp(p).test(cwd)
-}
-
-function pathBasename(p: string): string {
-  const parts = p.replace(/\/+$/, '').split('/').filter(Boolean)
-  return parts[parts.length - 1] || ''
-}
-
-/**
- * Resolve a session cwd to a display project. Order:
- *   1. user rules (first match wins) — glob or path-prefix against the cwd.
- *   2. worktree fold: `.../<repo>/.agents/worktrees/<slug>` -> `<repo>`.
- *   3. git repo root basename when `repoRoot` is supplied — so a monorepo subdir
- *      folds to the repo, not the leaf dir.
- *   4. ultimate fallback: the cwd's last path segment (legacy behavior).
- */
-export function resolveProject(
-  cwd: string,
-  rules: ProjectRule[] = [],
-  repoRoot?: string | null,
-): string {
-  if (!cwd) return ''
-  const norm = cwd.replace(/\/+$/, '')
-  for (const rule of rules) {
-    if (rule && matchesProjectRule(norm, rule.pattern)) return rule.project
-  }
-  const wt = norm.match(/\/([^/]+)\/\.agents\/worktrees\//)
-  if (wt) return wt[1]
-  if (repoRoot) {
-    const base = pathBasename(repoRoot)
-    if (base) return base
-  }
-  const parts = norm.split('/').filter(Boolean)
-  return parts[parts.length - 1] || norm
-}
+// resolveProject + worktreeSlugOf are canonical in src/shared/project.ts, imported
+// via @shared — the SAME impl the extension host uses, so a session's project can no
+// longer resolve differently on each side of the postMessage boundary. Re-exported
+// so existing importers (e.g. floorAdapter) keep their `from './floorModel'` path.
+import { resolveProject, worktreeSlugOf } from '@shared/project'
+import type { ProjectRule } from '@shared/project'
+export { resolveProject, worktreeSlugOf }
+export type { ProjectRule }
 
 // ---------- agent view-model ----------
 
@@ -189,6 +131,8 @@ export interface FloorAgent {
   ci: CiStatus           // CI state of the open PR; null when no PR / unknown
   ticket: string | null  // "RUSH-812" when linked
   branch: string
+  worktreeSlug: string   // "<slug>" under .agents/worktrees/; '' when not a worktree. Disambiguates sibling sessions + labels the card when topic/preview are empty.
+  worktreePath: string   // absolute worktree path, for the Reveal-worktree action; '' when not a worktree
   resp: string           // last response text (Anthropic Agent-view style)
   question: StructuredQuestion | null
   reply: ReplyTarget     // how a user reply reaches this agent (host dispatches on kind)
@@ -299,6 +243,7 @@ export interface FloorTicket {
   status: TicketStatus
   desc: string
   labels: string[]
+  owner: string        // metadata.assignee (human or agent) || '' when unassigned
 }
 
 // ---------- controls state ----------
@@ -354,7 +299,7 @@ export interface HostInventory {
 }
 export type FloorGroupBy = 'host' | 'project' | 'status' | 'agent'
 export type FloorSort = 'needs' | 'recent' | 'tok' | 'name'
-export type TicketGroupBy = 'project' | 'priority' | 'source' | 'status'
+export type TicketGroupBy = 'project' | 'priority' | 'source' | 'status' | 'owner'
 export type TicketSort = 'priority' | 'id'
 
 // ---------- stable rank constants (data — final, not stubs) ----------
@@ -413,6 +358,18 @@ function firstNonEmpty(...values: Array<string | null | undefined>): string | un
     if (typeof v === 'string' && v.trim()) return v.trim()
   }
   return undefined
+}
+
+/**
+ * The one "what is this session doing" line, used by BOTH the card and the detail
+ * rail so no surface re-derives it or renders blank. Fallback chain: the CLI summary
+ * / live preview, then the last response, then the worktree slug or branch (a task
+ * label when there's no narrative — e.g. "headless-secrets-shadow"). Returns '' when
+ * the agent carries no task signal at all; callers that need an absolute fallback add
+ * `|| a.name` (the card already shows the name separately, so it omits that).
+ */
+export function sessionTaskLine(a: FloorAgent): string {
+  return firstNonEmpty(a.summary, a.resp, a.worktreeSlug, a.branch) ?? ''
 }
 
 /**
@@ -620,9 +577,12 @@ function cleanOption(raw: string): string {
 
 /** Group agents by the chosen dimension. Prototype groupKey: factory-floor.html:412. */
 export function groupAgents(agents: FloorAgent[], by: FloorGroupBy): Map<string, FloorAgent[]> {
+  // Coalesce empty keys to a human label (same rule as groupTickets) so a Floor
+  // group header is never blank. Host groups by its DISPLAY label so 'this-mac'
+  // collapses onto the real device name, matching the HOSTS sidebar.
   const accessor: Record<FloorGroupBy, (a: FloorAgent) => string> = {
-    host: (a) => a.host,
-    project: (a) => a.project,
+    host: (a) => (a.hostLabel ?? a.host) || 'Unknown host',
+    project: (a) => a.project || 'Unlabeled',
     status: (a) => a.phase,
     agent: (a) => a.abbr,
   }
@@ -683,13 +643,16 @@ export function toFloorTicket(task: UnifiedTask): FloorTicket {
   return {
     id: task.metadata.identifier ?? task.id,
     title: task.title,
-    // UnifiedTask.metadata has no `project`; repo is the closest scope we have.
-    project: task.metadata.repo ?? '',
+    // The formal project as defined in the source: Linear's `project` (from
+    // linear-cli), else the repo scope for GitHub-sourced tickets. Empty when the
+    // source declares neither — grouping renders that as 'Unlabeled' (never blank).
+    project: task.metadata.project ?? task.metadata.repo ?? '',
     source: task.source === 'linear' ? 'LN' : 'GH',
     pri: toTicketPriority(task.priority),
     status: toTicketStatus(task.status),
     desc: task.description ?? '',
     labels: task.metadata.labels ?? [],
+    owner: task.metadata.assignee ?? '',
   }
 }
 
@@ -720,11 +683,14 @@ function toTicketStatus(s: UnifiedTask['status']): TicketStatus {
 }
 
 export function groupTickets(tickets: FloorTicket[], by: TicketGroupBy): Map<string, FloorTicket[]> {
+  // Every accessor coalesces an empty key to a human label so a group header is
+  // never blank (the "· 76" bug) — one generic rule across all axes.
   const accessor: Record<TicketGroupBy, (t: FloorTicket) => string> = {
-    project: (t) => t.project,
+    project: (t) => t.project || 'Unlabeled',
     priority: (t) => t.pri,
     source: (t) => (t.source === 'LN' ? 'Linear' : 'GitHub'),
     status: (t) => t.status.replace('-', ' '),
+    owner: (t) => t.owner || 'Unassigned',
   }
   const get = accessor[by]
   const groups = new Map<string, FloorTicket[]>()

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -3,7 +3,7 @@
 // current UI can be seen/screenshotted without the VS Code extension host. Not
 // shipped (vite.settings.config.ts only inputs settings/index.html); a dev harness.
 //
-// Run:  cd extension/ui && bun run dev  ->  open http://localhost:5173/preview/
+// Run:  cd extension/ui && bun run dev  ->  open http://localhost:5173/settings/preview/
 //   URL params:  ?view=feed|dispatch  &  ?theme=dark|light
 // (Serve over http, not file://, or ES-module imports are CORS-blocked.)
 import React, { useState } from 'react'
@@ -11,10 +11,12 @@ import ReactDOM from 'react-dom/client'
 import '../index.css'
 
 import { Icon } from '../components/mission-control/icons'
+import { FloorSidebar } from '../components/mission-control/FloorSidebar'
 import { FeedItem, TicketStrip } from '../components/mission-control/FeedItem'
 import { SavedViews } from '../components/mission-control/SavedViewsBar'
 import { DispatchPanel } from '../components/mission-control/DispatchPanel'
-import type { FloorAgent, FloorTicket, StructuredQuestion } from '../components/mission-control/floorModel'
+import { BacklogCenter } from '../components/mission-control/BacklogCenter'
+import type { FloorAgent, FloorTicket, StructuredQuestion, TicketGroupBy, TicketSort } from '../components/mission-control/floorModel'
 import type { UnifiedTask } from '../types'
 import type { InstalledAgent, DispatchHost, DispatchTarget } from '../components/mission-control/dispatch.types'
 
@@ -42,6 +44,8 @@ function agent(p: Partial<FloorAgent>): FloorAgent {
     ci: null,
     ticket: null,
     branch: 'main',
+    worktreeSlug: '',
+    worktreePath: '',
     resp: '',
     question: null,
     reply: { kind: 'terminal', host: 'this-mac' },
@@ -51,6 +55,22 @@ function agent(p: Partial<FloorAgent>): FloorAgent {
     ...p,
   }
 }
+
+// Issue-2 demo: two sessions in the SAME repo + worktree that used to render as
+// identical, contextless "Edit linux.ts / waiting_input" cards. They now carry the
+// project, the worktree slug, and a distinct task line.
+const twinA = agent({
+  id: 'twin-a', abbr: 'CC', name: '02ebf318', project: 'agents-cli', phase: 'waiting',
+  needs: true, worktreeSlug: 'headless-secrets-shadow', branch: 'muqsit/headless-secrets',
+  verb: 'Edit', target: 'src/lib/secrets/linux.ts',
+  summary: 'Removing the stale BYOK resolver and its keychain writes.', since: '0s',
+})
+const twinB = agent({
+  id: 'twin-b', abbr: 'CC', name: 'e3d6852d', project: 'agents-cli', phase: 'waiting',
+  needs: true, worktreeSlug: 'headless-secrets-shadow', branch: 'muqsit/headless-secrets',
+  verb: 'Edit', target: 'src/lib/secrets/linux.ts',
+  summary: 'Adding the Linux secret-service fallback path + a regression test.', since: '0s',
+})
 
 const dropQuestion: StructuredQuestion = {
   kind: 'destructive',
@@ -112,9 +132,12 @@ const done: FloorAgent[] = [
 
 // READY TO DISPATCH backlog.
 const tickets: FloorTicket[] = [
-  { id: 'RUSH-1262', title: '[security] rush CLI PKCE token exchange uses unpinned http client', project: 'rush', source: 'LN', pri: 'urgent', status: 'todo', desc: '', labels: ['security'] },
-  { id: 'RUSH-799', title: 'Remote agent heartbeat anchors to start time, shows false stall', project: 'agents-cli', source: 'LN', pri: 'high', status: 'todo', desc: '', labels: [] },
-  { id: '#418', title: 'Kanban / Deadline feed views are stubs -> "coming soon"', project: 'swarmify', source: 'GH', pri: 'med', status: 'todo', desc: '', labels: [] },
+  { id: 'RUSH-1262', title: '[security] rush CLI PKCE token exchange uses unpinned http client', project: 'rush', source: 'LN', pri: 'urgent', status: 'todo', desc: '', labels: ['security'], owner: 'Muqsit' },
+  { id: 'RUSH-799', title: 'Remote agent heartbeat anchors to start time, shows false stall', project: 'agents-cli', source: 'LN', pri: 'high', status: 'todo', desc: '', labels: [], owner: 'Muqsit' },
+  { id: '#418', title: 'Kanban / Deadline feed views are stubs -> "coming soon"', project: 'swarmify', source: 'GH', pri: 'med', status: 'todo', desc: '', labels: [], owner: '' },
+  // A ticket with no formal project — grouping renders it under "Unlabeled", never a
+  // blank "· N" header (issue 1).
+  { id: 'RUSH-1240', title: '[rush/app] X/social integration renders a broken avatar (not CSP)', project: '', source: 'LN', pri: 'high', status: 'todo', desc: '', labels: ['Bug'], owner: 'Muqsit' },
 ]
 
 // Dispatch panel mock data.
@@ -158,9 +181,11 @@ function Feed() {
       />
 
       <div className="feed-sec attn">
-        <Icon name="alert" size={11} /> NEEDS YOU · 2
+        <Icon name="alert" size={11} /> NEEDS YOU · 4
         <span className="ln" />
       </div>
+      <FeedItem agent={twinA} selected={false} plain={false} onSelect={noop} onOption={noop} onFreeText={noop} onAttach={noop} />
+      <FeedItem agent={twinB} selected={false} plain={false} onSelect={noop} onOption={noop} onFreeText={noop} onAttach={noop} />
       <FeedItem agent={askAgent} selected={false} plain={false} onSelect={noop} onOption={noop} onFreeText={noop} onAttach={noop} />
       <FeedItem agent={reviewAgent} selected={false} plain={false} onSelect={noop} onOption={noop} onFreeText={noop} onAttach={noop} />
 
@@ -189,6 +214,64 @@ function Feed() {
   )
 }
 
+// Backlog center with the group/sort/filter toolbar. Defaults to grouping by
+// Owner so the preview shows tickets bucketed by assignee (incl. Unassigned).
+function Backlog() {
+  const [group, setGroup] = useState<TicketGroupBy>('project')
+  const [sort, setSort] = useState<TicketSort>('priority')
+  const [srcFilter, setSrcFilter] = useState<Record<'LN' | 'GH', boolean>>({ LN: true, GH: true })
+  const [selected, setSelected] = useState<string | null>(null)
+  return (
+    <BacklogCenter
+      tickets={tickets}
+      group={group}
+      sort={sort}
+      srcFilter={srcFilter}
+      projFilter={null}
+      search=""
+      selectedTicketId={selected}
+      onGroup={setGroup}
+      onSort={setSort}
+      onToggleSrc={(s) => setSrcFilter((f) => ({ ...f, [s]: !f[s] }))}
+      onSelectTicket={setSelected}
+      onBackToAgents={noop}
+    />
+  )
+}
+
+// Sidebar with the HOSTS rail — local + online + offline devices, one pinned —
+// so the host status dots (`.hd`) can be screenshotted at their true size.
+function Sidebar() {
+  const [pins, setPins] = useState<string[]>(['zion'])
+  const sidebarAgents: FloorAgent[] = [
+    ...running,
+    agent({ id: 's1', hostLabel: 'yosemite-s0', project: 'agents-cli' }),
+    agent({ id: 's2', hostLabel: 'yosemite-s0', project: 'agents-cli' }),
+    agent({ id: 's3', hostLabel: 'yosemite-s1', project: 'agents-cli' }),
+  ]
+  const devices = [
+    { name: 'zion', online: true, agents: 8 },
+    { name: 'mac-mini', online: true, agents: 0 },
+    { name: 'win-mini', online: true, agents: 0 },
+    { name: 'yosemite-s0', online: true, agents: 2 },
+    { name: 'yosemite-s1', online: false, agents: 1 },
+  ]
+  return (
+    <FloorSidebar
+      agents={sidebarAgents}
+      tickets={tickets}
+      projFilter={null}
+      offlineHosts={['yosemite-s1']}
+      devices={devices}
+      hostPins={pins}
+      onToggleHostPin={(n) => setPins((p) => (p.includes(n) ? p.filter((x) => x !== n) : [...p, n]))}
+      onReorderHostPins={setPins}
+      onScope={noop}
+      localHost="zion"
+    />
+  )
+}
+
 function Preview() {
   const params = new URLSearchParams(location.search)
   const theme = params.get('theme') === 'light' ? 'theme-light' : 'theme-dark'
@@ -197,8 +280,8 @@ function Preview() {
   return (
     <div className={`swarmify-root ${theme}`} style={{ minHeight: '100vh' }}>
       <div className="sw-floor-dashboard" style={{ padding: 0 }}>
-        <div className="page">
-          <div className="feed-col"><Feed /></div>
+        <div className="page" style={{ display: 'flex' }}>
+          {view === 'sidebar' ? <Sidebar /> : <div className="feed-col">{view === 'backlog' ? <Backlog /> : <Feed />}</div>}
         </div>
       </div>
       <DispatchPanel

--- a/apps/factory/ui/settings/types/index.ts
+++ b/apps/factory/ui/settings/types/index.ts
@@ -128,41 +128,16 @@ export interface PromptEntry {
   accessedAt: number
 }
 
-// Task types
-export type TaskSource = 'linear' | 'github'
+// Task types. UnifiedTask / TaskMetadata / TaskComment / TaskSource are canonical
+// in src/shared/tasks.ts and imported here via @shared — the SAME definition the
+// extension host uses, so a field (e.g. Linear `project`) can never be present on
+// one side of the postMessage boundary and missing on the other.
+export type { TaskSource, UnifiedTask, TaskMetadata, TaskComment } from '@shared/tasks'
 
 export interface TaskSourceSettings {
   linear: boolean
   github: boolean
   githubAssignedOnly: boolean
-}
-
-export interface UnifiedTask {
-  id: string
-  source: TaskSource
-  title: string
-  description?: string
-  status: 'todo' | 'in_progress' | 'done'
-  priority?: 'urgent' | 'high' | 'medium' | 'low'
-  metadata: {
-    file?: string
-    line?: number
-    identifier?: string
-    url?: string
-    labels?: string[]
-    assignee?: string
-    state?: string
-    createdAt?: string
-    dueDate?: string
-    repo?: string
-    comments?: TaskComment[]
-  }
-}
-
-export interface TaskComment {
-  body: string
-  createdAt?: string
-  author?: string
 }
 
 export interface CycleInfo {
@@ -191,12 +166,11 @@ export interface NotificationSettings {
   enabledAgents: string[]
 }
 
-// Ordered cwd->project mapping for Factory Floor grouping. Mirror of
-// src/core/settings.ts ProjectRule (hand-kept; crosses the postMessage boundary).
-export interface ProjectRule {
-  pattern: string
-  project: string
-}
+// Ordered cwd->project mapping for Factory Floor grouping.
+// Canonical in src/shared/project.ts (shared with the host via @shared) — imported
+// for local use (AgentSettings.projectRules below) + re-exported for consumers.
+import type { ProjectRule } from '@shared/project'
+export type { ProjectRule }
 
 export interface AgentSettings {
   builtIn: {

--- a/apps/factory/ui/tsconfig.json
+++ b/apps/factory/ui/tsconfig.json
@@ -14,6 +14,13 @@
     "verbatimModuleSyntax": true,
     "noEmit": true,
 
+    // Types + pure logic shared with the extension host (mirrors the vite @shared
+    // alias) — one source of truth across the postMessage boundary.
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["../src/shared/*"]
+    },
+
     // Best practices
     "strict": true,
     "skipLibCheck": true,

--- a/apps/factory/ui/vite.preview.config.ts
+++ b/apps/factory/ui/vite.preview.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, 'settings'),
+      '@shared': resolve(__dirname, '../src/shared'),
     },
   },
   build: {
@@ -20,7 +21,13 @@ export default defineConfig({
     rollupOptions: {
       input: resolve(__dirname, 'settings/preview/index.html'),
       onwarn(warning, warn) {
-        if (warning.code === 'MISSING_EXPORT') return
+        if (warning.code === 'MISSING_EXPORT') {
+          const from = `${warning.exporter ?? ''} ${warning.message ?? ''}`
+          if (from.includes('src/shared')) {
+            throw new Error(`Rollup MISSING_EXPORT from shared contract: ${warning.message}`)
+          }
+          return
+        }
         warn(warning)
       },
     },

--- a/apps/factory/ui/vite.settings.config.ts
+++ b/apps/factory/ui/vite.settings.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, 'settings'),
+      // Types + pure logic shared with the extension host, imported by BOTH roots
+      // instead of hand-mirrored. See src/shared/.
+      '@shared': resolve(__dirname, '../src/shared'),
     }
   },
   build: {
@@ -21,8 +24,17 @@ export default defineConfig({
         assetFileNames: 'main.[ext]'
       },
       onwarn(warning, warn) {
-        // Suppress "is not exported" warnings for types that are definitely exported
-        if (warning.code === 'MISSING_EXPORT') return
+        if (warning.code === 'MISSING_EXPORT') {
+          // A missing export FROM the shared contract (src/shared) is real drift —
+          // the class that made the backlog `project` field vanish. Fail the build.
+          // Other MISSING_EXPORT warnings are pre-existing type-as-value imports the
+          // app tolerates (esbuild erases the type), so keep suppressing those.
+          const from = `${warning.exporter ?? ''} ${warning.message ?? ''}`
+          if (from.includes('src/shared')) {
+            throw new Error(`Rollup MISSING_EXPORT from shared contract: ${warning.message}`)
+          }
+          return
+        }
         warn(warning)
       }
     }

--- a/apps/factory/ui/vite.standalone.config.ts
+++ b/apps/factory/ui/vite.standalone.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, 'settings'),
+      '@shared': resolve(__dirname, '../src/shared'),
     }
   },
   build: {
@@ -26,7 +27,13 @@ export default defineConfig({
         assetFileNames: 'main.[ext]'
       },
       onwarn(warning, warn) {
-        if (warning.code === 'MISSING_EXPORT') return
+        if (warning.code === 'MISSING_EXPORT') {
+          const from = `${warning.exporter ?? ''} ${warning.message ?? ''}`
+          if (from.includes('src/shared')) {
+            throw new Error(`Rollup MISSING_EXPORT from shared contract: ${warning.message}`)
+          }
+          return
+        }
         warn(warning)
       }
     }


### PR DESCRIPTION
## What

Supersedes **#732**. Ports the swarmify/extension feed bug-fixes into `apps/factory`, rebuilt on current `main` (which now includes the tmux merge #734) with the feed model reconciled so **both** feature sets coexist.

#732 was based on the pre-#724/#734 layout and went CONFLICTING once #734 (tmux terminals + pane/viewing-in) merged. This PR is the clean rebuild.

## Changes (feed "workable" fixes)

- **Correct per-device attribution.** Fan-out remote-session enrichment attributes each row to the right machine (`machine`) and surfaces worktree slug + live preview + structured ticket id + real branch — so co-located sessions stop rendering as identical, contextless cards.
- **No more `startedAtMs` drift.** `resolveStartedAtMs` caches start time by PID instead of stamping `Date.now()` on every republish.
- **One shared feed model.** Collapsed the "keep two impls in lockstep" duplication into a single `@shared` implementation guarded by a `MISSING_EXPORT` build-time drift check.

## Merge reconciliation (vs the merged #734)

- `RemoteSession` / `FloorAgent` now carry **both** `viewingIn` + `tmuxPane` (#734) **and** `preview` / `pr` / `worktree` / `machine` (this PR); `ticket` uses the broader `string | {id,url} | null`.
- `foreman.registry` keeps the `resolveStartedAtMs` fix **and** publishes `tmuxSession`/`tmuxPane`/`tabIndex`.
- `FeedItem` meta line shows worktree slug **and** pane + "viewing in".
- `normalizeRecentSession` defaults the live-only tmux fields to `''` for idle/historical rows.

## Release landmine defused

Added `apps/factory/CHANGELOG.md` with a `## [0.9.283]` entry. The prix-cloud review of #732 flagged that its new `scripts/release.sh` CHANGELOG preflight (`grep '^## \[<version>\]' CHANGELOG.md`) would `exit 1` on every release because the file didn't exist. Verified the preflight grep now passes.

## Testing

- `tsc -p ./` clean; `bun run compile:ui` clean (drift guard passes)
- Merge-critical tests (remoteSessions, remoteSessions.enrich, tabIndex, processStartTime, utils, floorModel, floorModel.fixes): **237 pass, 0 fail**
- Full factory suite: **1063 pass, 4 fail** — the 4 are pre-existing live-LLM/network/timing integration tests (`generateCommitMessageWithClaude`, `draftDispatchPrompt`, `resolveAlias`, `SessionWatcher` 5s timeout), none in this diff.
