### PR TITLE
test(daemon): fix flaky ENOTEMPTY in single-instance teardown

### DIFF
--- a/apps/cli/src/lib/daemon.test.ts
+++ b/apps/cli/src/lib/daemon.test.ts
@@ -383,7 +383,18 @@ describe('daemon single-instance (#414)', () => {
       expect(alive(pidA)).toBe(true);
     } finally {
       for (const p of [pidA, pidB]) { try { if (p) process.kill(p, 'SIGKILL'); } catch { /* already gone */ } }
-      fs.rmSync(tmpHome, { recursive: true, force: true });
+      // SIGKILL is async: the kernel delivers it but the daemon can still be
+      // mid-write into tmpHome/.agents when we start removing it. Reap both PIDs
+      // first, then retry rmSync — otherwise a write landing during the tree walk
+      // makes rmdir throw ENOTEMPTY (flaky teardown, unrelated to the assertions).
+      for (const p of [pidA, pidB]) { if (p) await waitFor(() => !alive(p), 5_000); }
+      for (let attempt = 0; ; attempt++) {
+        try { fs.rmSync(tmpHome, { recursive: true, force: true }); break; }
+        catch (err) {
+          if (attempt >= 10) throw err;
+          await new Promise((r) => setTimeout(r, 100));
+        }
+      }
     }
   }, 60_000);
 });


### PR DESCRIPTION
## Why

The 1.20.42 release CI ([#740](https://github.com/phnx-labs/agents-cli/pull/740)) failed on `test` with **1 failed / 4364 passed** — a flaky teardown, not a regression:

```
FAIL src/lib/daemon.test.ts > daemon single-instance (#414) > refuses a second concurrent daemon...
Error: ENOTEMPTY: directory not empty, rmdir '/tmp/agd-si-XXXX/.agents'
  ❯ src/lib/daemon.test.ts:386  fs.rmSync(tmpHome, { recursive: true, force: true })
```

Every assertion passed (daemon A kept pid-file ownership, B exited). The failure is purely in the `finally` block: it `SIGKILL`s the two daemon PIDs then immediately `rmSync`s `tmpHome`. `SIGKILL` is asynchronous, so the dying daemon can still flush its pid file / socket / logs into `tmpHome/.agents` while `rmSync` walks the tree → `rmdir` hits `ENOTEMPTY`.

## What

- **Reap** both PIDs (`waitFor(() => !alive(p), 5s)`, reusing the helpers already in the test) before removing the temp home.
- **Retry** `rmSync` up to ~1s (10 × 100ms) to absorb any final write landing between the liveness check and the `rmdir`.

No product code touched — teardown-only. Unblocks the 1.20.42 release.