### PR TITLE
fix(security): reject leading-dash SSH targets in `sessions --host`

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Security fix: `agents sessions --host <target>` no longer accepts a leading-dash target (SSH argv-flag smuggling).** `session/remote.ts` carried its own copy of `assertValidSshTarget` that omitted the `host.startsWith('-')` guard every other SSH path enforces, so a bare flag like `-l` or `-F/path` — which passes the character allowlist — was handed straight to `ssh` as an argument (`-oProxyCommand=…`-class injection) before any connection. The duplicate validator (and its `SSH_TARGET_RE`) is deleted; `runRemoteSessions` now routes through the canonical `assertValidSshTarget` in `ssh-exec.ts`, whose dash guard is already regression-tested (`ssh-exec.test.ts`). Source: `apps/cli/src/lib/session/remote.ts`.
+
 ## 1.20.42
 
 - **Fix: exiting a split pane inside an interactive `ag run` session kicked you out of tmux entirely.** When you split the window of an interactive agent session (`ag run claude`) with Ctrl-b `"`/`%` and then `exit`ed *your* split, the whole tmux client detached and dumped you back to the parent shell — even though the agent was still running in the other pane. Cause: `runInTmux` installed a session-wide `pane-died` hook (`detach-client`) meant to fire only when the AGENT pane exits (so the attach returns and the exit status is read), but with no `#{hook_pane}` guard it fired for *any* pane's death. The hook is now scoped to the agent pane; a user split that exits is closed in place (`kill-pane`, no lingering dead husk) and the agent keeps running full-window. Source: `apps/cli/src/lib/exec.ts`, `apps/cli/src/lib/tmux/session.test.ts`.

--- a/apps/cli/src/lib/session/remote.test.ts
+++ b/apps/cli/src/lib/session/remote.test.ts
@@ -5,7 +5,6 @@ import {
   buildForwardedArgs,
   buildRemoteCommand,
   shellQuote,
-  assertValidSshTarget,
   classifySshFailure,
   remoteCachePath,
   formatStaleBanner,
@@ -136,19 +135,6 @@ describe('buildRemoteCommand', () => {
   it('neutralizes shell metacharacters in a query (no command substitution)', () => {
     expect(decodeRemoteArgv(['sessions', '$(whoami); rm -rf /', '--json']))
       .toEqual(['sessions', '$(whoami); rm -rf /', '--json']);
-  });
-});
-
-describe('assertValidSshTarget', () => {
-  it('accepts a bare host alias and user@host', () => {
-    expect(() => assertValidSshTarget('yosemite-s1')).not.toThrow();
-    expect(() => assertValidSshTarget('deploy@staging.example.com')).not.toThrow();
-  });
-
-  it('rejects a leading dash (argv flag smuggling) and shell metacharacters', () => {
-    expect(() => assertValidSshTarget('-oProxyCommand=evil')).toThrow(/Invalid SSH target/);
-    expect(() => assertValidSshTarget('box; rm -rf /')).toThrow(/Invalid SSH target/);
-    expect(() => assertValidSshTarget('box$(whoami)')).toThrow(/Invalid SSH target/);
   });
 });
 

--- a/apps/cli/src/lib/session/remote.ts
+++ b/apps/cli/src/lib/session/remote.ts
@@ -27,29 +27,18 @@ import { join } from 'path';
 import { createHash } from 'crypto';
 import chalk from 'chalk';
 import { getCacheDir } from '../state.js';
-import { SSH_OPTS, controlOpts } from '../ssh-exec.js';
+import { SSH_OPTS, controlOpts, assertValidSshTarget } from '../ssh-exec.js';
 import { remoteShellFor, buildWindowsAgentsCommand } from '../hosts/remote-cmd.js';
 import { resolveRemoteOsSync } from '../hosts/remote-os.js';
 import { formatRelativeTime } from './relative-time.js';
 import { terminalWidth } from './width.js';
 
 /**
- * SSH target: a bare ssh-config host alias (e.g. `yosemite-s1`) or `user@host`.
- * The strict allowlist blocks shell metacharacters and a leading `-`, so a target
- * can never be smuggled in as an ssh argv flag.
+ * POSIX single-quote a string for safe interpolation into a remote shell command.
+ * Always wraps (unlike the bare-passthrough variant in `ssh-exec.ts`) — the
+ * forwarded `agents` argv is embedded verbatim inside `bash -lc '<cmd>'`, so
+ * every token is quoted to keep the command boundary unambiguous.
  */
-export const SSH_TARGET_RE = /^[a-zA-Z0-9._-]+(@[a-zA-Z0-9._-]+)?$/;
-
-export function assertValidSshTarget(host: string): void {
-  if (!SSH_TARGET_RE.test(host)) {
-    throw new Error(
-      `Invalid SSH target ${JSON.stringify(host)}. Expected a host alias or user@host ` +
-        `(letters, digits, '.', '_', '-').`,
-    );
-  }
-}
-
-/** POSIX single-quote a string for safe interpolation into a remote shell command. */
 export function shellQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
 }


### PR DESCRIPTION
## Problem

`session/remote.ts` shipped its own copy of `assertValidSshTarget` that **omitted the leading-dash guard** every other SSH path in the codebase enforces (`ssh-exec.ts:26` — `host.startsWith('-')`). Its own doc-comment even claimed it blocked a leading `-`, but the code did not:

```ts
// remote.ts (before)
export function assertValidSshTarget(host: string): void {
  if (!SSH_TARGET_RE.test(host)) { throw ... }   // regex allows bare "-l"
}
```

`SSH_TARGET_RE = /^[a-zA-Z0-9._-]+(@...)?$/` accepts a bare flag like `-l` or `-F/path` (dash is in the charset, no metacharacters), so `runRemoteSessions` handed it straight to `ssh` as an **argv flag** before any connection — classic `-oProxyCommand=…`-class flag smuggling. (The one negative test that existed, `-oProxyCommand=evil`, only threw incidentally because `=` fails the charset — the dangerous flag-only case `-l` was never covered.)

Filed as **RUSH-1510** (surfaced by the read-only API-surface audit).

## Fix

- Delete the duplicate `assertValidSshTarget` + `SSH_TARGET_RE` from `session/remote.ts`.
- Route `runRemoteSessions` through the **canonical** `assertValidSshTarget` in `ssh-exec.ts` (single source of truth), whose dash guard is already regression-tested — `ssh-exec.test.ts:24-25` covers both `-oProxyCommand=evil` **and** the bare `-l`.
- Drop the now-redundant, weaker `assertValidSshTarget` block from `remote.test.ts`.
- **Kept** the local `shellQuote` — it is behaviorally distinct from the canonical bare-passthrough variant (always-quotes; test-locked at `remote.test.ts:111`), so deduping it is out of scope for this security fix.

## Verification

Typecheck clean; targeted tests green (`ssh-exec.test.ts` + `remote.test.ts`, 37 pass). End-to-end against the real exported `runRemoteSessions` — every dash target is rejected **before** `spawnSync('ssh', …)`:

```
OK: "-l" rejected -> Invalid SSH target "-l". Expected a host alias or user@...
OK: "-oProxyCommand=evil" rejected -> Invalid SSH target "-oProxyCommand=evil"...
OK: "-F/tmp/evil" rejected -> Invalid SSH target "-F/tmp/evil"...
```

`-l` is the flag-only smuggle the old local impl let through and now rejects.

Closes RUSH-1510