### PR TITLE
chore(factory): add CLAUDE.md/GEMINI.md symlinks to AGENTS.md

### DIFF
--- a/apps/factory/CLAUDE.md
+++ b/apps/factory/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/apps/factory/GEMINI.md
+++ b/apps/factory/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
`apps/factory/AGENTS.md` is the canonical memory file, but the `CLAUDE.md` and `GEMINI.md` symlinks that every other DotAgents-managed directory carries were never committed alongside it — they only existed as untracked files locally.

This adds the two symlinks, matching the repo-root convention (`CLAUDE.md`/`GEMINI.md` -> `AGENTS.md`) and the project rule that `AGENTS.md` is canonical with `CLAUDE.md`/`GEMINI.md` as symlinks.

## Verification
- Both committed as symlinks, not regular files: `git ls-files -s` reports mode `120000` for each, both pointing at the `AGENTS.md` target path (blob `47dc3e3d`).
- No content duplication — pure symlinks.

Follow-on cleanup from the #732 factory parity sync.