### PR TITLE
fix(factory): local dispatch honors a managed project's curated path

### DIFF
--- a/apps/factory/src/vscode/settings.vscode.ts
+++ b/apps/factory/src/vscode/settings.vscode.ts
@@ -245,6 +245,7 @@ interface DispatchRequestMsg {
   agent: string;
   runOn: string;
   project?: string;
+  projectPath?: string;
   repo?: string;
   branch?: string;
   mode: DispatchModeMsg;
@@ -2472,10 +2473,15 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
         }
         const agentConfig = configFromDef(context.extensionPath, def);
         const projectId = typeof req.project === 'string' ? req.project : '';
-        // A slug carrying an owner ("owner/repo") resolves to a local clone;
-        // a bare project id falls through to the workspace folder (never $HOME,
+        const curatedPath = typeof req.projectPath === 'string' ? req.projectPath.trim() : '';
+        // A curated managed project ships its absolute path — authoritative, and the
+        // only way a manual (non-"owner/repo") project resolves to its real folder.
+        // Fall back to slug resolution for a bare id: "owner/repo" resolves to a local
+        // clone; anything else falls through to the workspace folder (never $HOME,
         // which openSingleAgentWithQueue guarantees when no cwd is passed).
-        const cwd = projectId.includes('/') ? await resolveLocalRepoPath(projectId) : null;
+        const cwd = curatedPath && fs.existsSync(curatedPath)
+          ? curatedPath
+          : projectId.includes('/') ? await resolveLocalRepoPath(projectId) : null;
         for (const unit of units) {
           // Pre-mint the session id for plan-mode Claude so we can watch that
           // exact session file for the ExitPlanMode plan afterwards.

--- a/apps/factory/ui/settings/components/mission-control/DispatchPanel.tsx
+++ b/apps/factory/ui/settings/components/mission-control/DispatchPanel.tsx
@@ -346,6 +346,9 @@ export function DispatchPanel(props: DispatchPanelProps) {
       agent: effAgent.id,
       runOn: effHost.id,
       project: isCloud ? undefined : effProject?.id,
+      // Send the curated absolute path so local dispatch lands in the managed
+      // project's folder — the id alone can't resolve a manual (non-owner/repo) project.
+      projectPath: isCloud ? undefined : effProject?.path,
       repo: isCloud ? effRepo?.id : undefined,
       branch: isCloud ? S.branch : undefined,
       mode: S.mode,

--- a/apps/factory/ui/settings/components/mission-control/dispatch.types.ts
+++ b/apps/factory/ui/settings/components/mission-control/dispatch.types.ts
@@ -71,6 +71,7 @@ export interface DispatchRequest {
   agent: string                  // InstalledAgent.id
   runOn: string                  // DispatchHost.id (cloud id implies cloud)
   project?: string               // local dir id — REQUIRED for local hosts (never $HOME)
+  projectPath?: string           // curated absolute dir for local dispatch — authoritative cwd when present
   repo?: string                  // cloud repo id — for cloud hosts
   branch?: string
   mode: DispatchMode


### PR DESCRIPTION
Follow-up to #755 (managed projects).

## The gap
The consolidated Dispatch panel resolved the local working dir **only from the project id** (`settings.vscode.ts` dispatch handler):
- an `owner/repo` slug → `resolveLocalRepoPath` (a workspace-sibling search)
- a bare id (a **manually-added** managed project) → `null` → the workspace folder

Either way the managed project's stored **absolute path** was never used, so dispatching an agent onto a curated folder outside the current workspace silently ran in the wrong place — undercutting the headline "curated projects with an absolute folder" value.

## The fix
Plumb the curated path through `DispatchRequest.projectPath` and prefer it (when it exists on disk) as the authoritative cwd, falling back to the prior slug resolution:

- `dispatch.types.ts` — add `projectPath?: string` to `DispatchRequest`.
- `DispatchPanel.tsx` — send `effProject?.path` for local dispatch.
- `settings.vscode.ts` — prefer `req.projectPath` (if it exists) over id-based resolution; mirror the field on `DispatchRequestMsg`.

## Verification
- `tsc -p ./` (extension host): 0 errors.
- `ui` vite build: succeeds.
- No behavior change when `projectPath` is absent (detected `owner/repo` projects still resolve exactly as before).