### PR TITLE
feat(factory): live-update tmux pane border with the session label

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -22,3 +22,9 @@ All notable changes to the Factory extension are documented here. Format follows
   agent terminal publishing its tmux pane (`%N`) and editor-tab index, surfaced as the
   pane handle and "viewing in <tab>" on Factory Floor cards. Gives same-cwd agents
   distinct, addressable identities.
+- **tmux pane border now shows the live session label.** The border was seeded once with
+  the bare agent code (e.g. `0: CC`) and never updated. It now tracks the same auto-label
+  as the editor tab — the moment the session topic resolves (auto-label poller / focus
+  fetch / manual rename), the border re-renders to `0: CC - <topic>` on the shared socket,
+  even when the terminal isn't focused. This matters most when a session is reattached
+  from a plain terminal outside the editor, where the border is the only label surface.

--- a/apps/factory/src/core/utils.test.ts
+++ b/apps/factory/src/core/utils.test.ts
@@ -8,6 +8,8 @@ import {
   getTerminalDisplayInfo,
   findTerminalNameByTabLabel,
   formatTerminalTitle,
+  paneBorderText,
+  PANE_BORDER_LABEL_MAX,
   getSessionChunk,
   extractFirstNWords,
   extractLinearTicketId,
@@ -630,6 +632,48 @@ describe('formatTerminalTitle', () => {
       display: { showFullAgentNames: true, showLabelsInTitles: true, showSessionIdInTitles: false, labelReplacesTitle: true, showLabelOnlyOnFocus: true },
       isFocused: false
     })).toBe('Claude');
+  });
+});
+
+describe('paneBorderText', () => {
+  test('returns the bare agent code when there is no label', () => {
+    expect(paneBorderText('CC')).toBe('CC');
+    expect(paneBorderText('CC', undefined)).toBe('CC');
+    expect(paneBorderText('CC', null)).toBe('CC');
+    expect(paneBorderText('CC', '')).toBe('CC');
+    expect(paneBorderText('CC', '   ')).toBe('CC');
+  });
+
+  test('appends the resolved label like the VS Code tab', () => {
+    expect(paneBorderText('CC', 'Incomplete refactor upgrades audit'))
+      .toBe('CC - Incomplete refactor upgrades audit');
+  });
+
+  test('flattens newlines and collapses whitespace', () => {
+    expect(paneBorderText('CX', 'fix\n the  daemon\trace')).toBe('CX - fix the daemon race');
+  });
+
+  test('strips stray markup, matching formatTerminalTitle', () => {
+    expect(paneBorderText('CC', 'wire <b>the</b> label')).toBe('CC - wire the label');
+  });
+
+  test('ellipsizes labels longer than the cap', () => {
+    const long = 'a'.repeat(PANE_BORDER_LABEL_MAX + 20);
+    const out = paneBorderText('CC', long);
+    // "CC - " + PANE_BORDER_LABEL_MAX chars (last char is the … ellipsis).
+    expect(out.startsWith('CC - ')).toBe(true);
+    expect(out.endsWith('…')).toBe(true);
+    expect(out.length).toBe('CC - '.length + PANE_BORDER_LABEL_MAX);
+  });
+
+  test('does not ellipsize a label exactly at the cap', () => {
+    const exact = 'b'.repeat(PANE_BORDER_LABEL_MAX);
+    expect(paneBorderText('CC', exact)).toBe(`CC - ${exact}`);
+  });
+
+  test('doubles a literal # so tmux renders it instead of treating it as an escape', () => {
+    // GitHub-style ref keeps its # visually via tmux ## escaping.
+    expect(paneBorderText('CC', 'land PR #758')).toBe('CC - land PR ##758');
   });
 });
 

--- a/apps/factory/src/core/utils.test.ts
+++ b/apps/factory/src/core/utils.test.ts
@@ -675,6 +675,11 @@ describe('paneBorderText', () => {
     // GitHub-style ref keeps its # visually via tmux ## escaping.
     expect(paneBorderText('CC', 'land PR #758')).toBe('CC - land PR ##758');
   });
+
+  test('neutralizes a #{...} format sequence in the label (the real injection threat)', () => {
+    // Without escaping, tmux would expand `#{pane_id}` inside the border.
+    expect(paneBorderText('CC', 'debug #{pane_id} leak')).toBe('CC - debug ##{pane_id} leak');
+  });
 });
 
 describe('prompt utilities', () => {

--- a/apps/factory/src/core/utils.ts
+++ b/apps/factory/src/core/utils.ts
@@ -316,6 +316,36 @@ export function formatTerminalTitle(prefix: string, options?: TerminalTitleOptio
   return `${base} - ${label}`;
 }
 
+/** Max characters of the session label shown in a tmux pane border before we ellipsize. */
+export const PANE_BORDER_LABEL_MAX = 48;
+
+/**
+ * Build the text shown inside a tmux pane border (the ` #{pane_index}: <text> `
+ * label). Mirrors the VS Code tab: bare agent code (e.g. "CC") until a session
+ * label resolves, then "CC - <topic>". The label arrives asynchronously (the
+ * auto-label poller / focus fetch), so this is re-run live whenever it changes.
+ *
+ * The result is embedded in a tmux `pane-border-format`, which re-expands
+ * `#{...}` / `#[...]` sequences and treats a lone `#` as an escape — so any `#`
+ * in the label is doubled to render literally, and newlines are flattened.
+ */
+export function paneBorderText(
+  name: string,
+  label?: string | null,
+  maxLabelLen: number = PANE_BORDER_LABEL_MAX
+): string {
+  const clean = (label ?? '')
+    .replace(/<[^>]*>/g, '')      // drop any stray markup, matching formatTerminalTitle
+    .replace(/[\r\n]+/g, ' ')     // flatten newlines — a border is a single line
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!clean) return name;
+  const clipped =
+    clean.length > maxLabelLen ? `${clean.slice(0, maxLabelLen - 1).trimEnd()}…` : clean;
+  // Double `#` last so the ellipsis/slice math above operates on the visible text.
+  return `${name} - ${clipped}`.replace(/#/g, '##');
+}
+
 export interface TerminalDisplayInfo {
   isAgent: boolean;
   prefix: string | null;

--- a/apps/factory/src/core/utils.ts
+++ b/apps/factory/src/core/utils.ts
@@ -339,11 +339,15 @@ export function paneBorderText(
     .replace(/[\r\n]+/g, ' ')     // flatten newlines — a border is a single line
     .replace(/\s+/g, ' ')
     .trim();
-  if (!clean) return name;
+  // Double `#` so tmux renders it literally rather than as a format escape.
+  // Applied on every return path so `name` is neutralized uniformly, whatever
+  // it holds (agent codes have no `#` today, but don't rely on that here).
+  const escapeHash = (s: string): string => s.replace(/#/g, '##');
+  if (!clean) return escapeHash(name);
   const clipped =
     clean.length > maxLabelLen ? `${clean.slice(0, maxLabelLen - 1).trimEnd()}…` : clean;
-  // Double `#` last so the ellipsis/slice math above operates on the visible text.
-  return `${name} - ${clipped}`.replace(/#/g, '##');
+  // Escape last so the ellipsis/slice math above operates on the visible text.
+  return escapeHash(`${name} - ${clipped}`);
 }
 
 export interface TerminalDisplayInfo {

--- a/apps/factory/src/vscode/terminals.vscode.ts
+++ b/apps/factory/src/vscode/terminals.vscode.ts
@@ -27,6 +27,7 @@ import {
   SessionAgentType
 } from '../core/utils';
 import { registerTerminal as registerSessionTracker } from './sessionTracker';
+import { relabelTmuxPane } from './tmux';
 
 // getTerminalsByAgentType runs 5x (one per agent type) on every 10s floor poll
 // and again on every terminal open/close. Its per-terminal/per-session debug
@@ -317,6 +318,11 @@ export async function setLabel(
     schedulePersist();
 
     stopAutoLabelPoller(terminal);
+
+    // Keep the tmux pane border in sync with the tab. A manual label wins over
+    // the auto-label; clearing it (label=undefined) falls back to the auto-label.
+    // Fire-and-forget — tmux styling is best-effort, never load-bearing.
+    void relabelTmuxPane(terminal, label ?? entry.autoLabel).catch(() => { /* ignore */ });
   } else {
     console.log(`[DEBUG setLabel] No entry found for terminal - label NOT saved!`);
   }
@@ -331,6 +337,10 @@ export function setAutoLabel(terminal: vscode.Terminal, autoLabel: string | unde
       entry.autoLabelPollerId = undefined;
       console.log(`[TERMINALS] Cleared auto-label poller for terminal "${terminal.name}" - label set: "${autoLabel}"`);
     }
+    // Surface the resolved topic in the tmux pane border (a manual label, if
+    // set, still takes precedence). This fires even when the terminal isn't
+    // focused — unlike the tab rename, which must briefly activate it.
+    void relabelTmuxPane(terminal, entry.label ?? autoLabel).catch(() => { /* ignore */ });
   }
 }
 

--- a/apps/factory/src/vscode/tmux.ts
+++ b/apps/factory/src/vscode/tmux.ts
@@ -18,6 +18,7 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import * as readiness from './terminalReadiness';
 import { runAgents } from '../core/agentsBin';
+import { paneBorderText } from '../core/utils';
 
 const pexecFile = promisify(execFile);
 
@@ -28,6 +29,9 @@ interface TmuxTerminal {
   agentType: string;
   paneCount: number;
   pane?: string;   // Cached `%N` pane id, resolved lazily by getTmuxInfo.
+  borderName: string;   // Static agent code shown in the pane border (e.g. "CC"); the
+                        // session label is appended once it resolves (relabelTmuxPane).
+  borderLabel?: string; // Last label rendered into the border — skip redundant re-sets.
 }
 
 const tmuxTerminals = new Map<vscode.Terminal, TmuxTerminal>();
@@ -136,7 +140,7 @@ export function createTmuxTerminal(
   const styling = [
     `tmux -S ${shq(socket)} set-option -t ${shq(session)} mouse on`,
     `set-option -t ${shq(session)} pane-border-status top`,
-    `set-option -t ${shq(session)} pane-border-format ${shq(` #{pane_index}: ${name} `)}`,
+    `set-option -t ${shq(session)} pane-border-format ${shq(` #{pane_index}: ${paneBorderText(name)} `)}`,
   ].join(' \\; ');
   parts.push(`{ ${styling} || true; }`);
 
@@ -159,9 +163,63 @@ export function createTmuxTerminal(
     socket,
     agentType,
     paneCount: 1,
+    borderName: name,
   });
 
   return terminal;
+}
+
+/**
+ * Re-render an already-created tmux terminal's pane border to carry the
+ * session's resolved auto-label. The border is seeded at creation with the bare
+ * agent code (e.g. "CC"); the label pipeline (auto-label poller / focus fetch /
+ * manual rename) resolves the topic seconds later, and this swaps it in live —
+ * mirroring the VS Code tab ("CC - Incomplete refactor upgrades audit").
+ *
+ * Runs off the shared socket from the extension host (which may not have tmux
+ * on PATH — see hostTmux). No-op for non-tmux terminals, and idempotent: a
+ * repeat call with the same label is skipped. Fire-and-forget by contract — a
+ * styling failure must never disrupt the live agent session.
+ */
+export async function relabelTmuxPane(
+  terminal: vscode.Terminal,
+  label: string | undefined,
+): Promise<void> {
+  const state = tmuxTerminals.get(terminal);
+  if (!state) return;
+  const next = label?.trim() || undefined;
+  if (state.borderLabel === next) return;  // already showing this label
+  state.borderLabel = next;
+  const format = ` #{pane_index}: ${paneBorderText(state.borderName, next)} `;
+  await hostTmux(state.socket, [
+    'set-option', '-t', state.session, 'pane-border-format', format,
+  ]);
+}
+
+// Candidate tmux binary locations. The extension host often lacks tmux on its
+// own PATH (the terminal's login shell is what runs the CLI), so we probe the
+// common Homebrew/system spots the same way for every host-side tmux call.
+const TMUX_BIN_CANDIDATES = ['tmux', '/opt/homebrew/bin/tmux', '/usr/local/bin/tmux', '/usr/bin/tmux'] as const;
+
+/**
+ * Run a tmux command on the shared socket from the extension host, trying each
+ * candidate binary until one exists. Returns stdout on success, or undefined if
+ * no tmux binary was found or the command errored — callers treat tmux styling
+ * as best-effort, never load-bearing.
+ */
+async function hostTmux(socket: string, args: string[]): Promise<string | undefined> {
+  for (const bin of TMUX_BIN_CANDIDATES) {
+    try {
+      const { stdout } = await pexecFile(bin, ['-S', socket, ...args], { timeout: 3_000 });
+      return stdout;
+    } catch (err) {
+      // ENOENT → this binary path doesn't exist; try the next candidate.
+      // Any other error → tmux ran but the command failed; don't keep probing.
+      if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') continue;
+      return undefined;
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -221,22 +279,9 @@ export function getTmuxState(terminal: vscode.Terminal): TmuxTerminal | undefine
  * the first line.
  */
 async function readPaneId(socket: string, session: string): Promise<string | undefined> {
-  const candidates = ['tmux', '/opt/homebrew/bin/tmux', '/usr/local/bin/tmux', '/usr/bin/tmux'];
-  for (const bin of candidates) {
-    try {
-      const { stdout } = await pexecFile(
-        bin,
-        ['-S', socket, 'list-panes', '-t', session, '-F', '#{pane_id}'],
-        { timeout: 3_000 },
-      );
-      const pane = stdout.split('\n').map((s) => s.trim()).filter(Boolean)[0];
-      if (pane) return pane;
-      return undefined; // tmux ran but reported no pane — don't try other bins
-    } catch {
-      /* binary missing at this path — try the next candidate */
-    }
-  }
-  return undefined;
+  const stdout = await hostTmux(socket, ['list-panes', '-t', session, '-F', '#{pane_id}']);
+  if (stdout === undefined) return undefined;
+  return stdout.split('\n').map((s) => s.trim()).filter(Boolean)[0];
 }
 
 /**

--- a/apps/factory/src/vscode/tmux.ts
+++ b/apps/factory/src/vscode/tmux.ts
@@ -189,11 +189,15 @@ export async function relabelTmuxPane(
   if (!state) return;
   const next = label?.trim() || undefined;
   if (state.borderLabel === next) return;  // already showing this label
-  state.borderLabel = next;
   const format = ` #{pane_index}: ${paneBorderText(state.borderName, next)} `;
-  await hostTmux(state.socket, [
+  const result = await hostTmux(state.socket, [
     'set-option', '-t', state.session, 'pane-border-format', format,
   ]);
+  // Record the applied label only on success. hostTmux returns stdout (an empty
+  // string for set-option) on success and undefined on failure — so a transient
+  // tmux error leaves borderLabel unchanged and a later retry with the same
+  // label still runs, rather than being wedged stale by the idempotence guard.
+  if (result !== undefined) state.borderLabel = next;
 }
 
 // Candidate tmux binary locations. The extension host often lacks tmux on its


### PR DESCRIPTION
## Problem

With tmux terminals on by default, every agent pane draws a green top border like `0: CC`. That `CC` is a hardcoded two-letter agent code (`CLAUDE_TITLE = 'CC'` in `apps/factory/src/core/utils.ts`) baked once into `pane-border-format` at creation (`tmux.ts:139`) and **never updated**.

Meanwhile the editor tab *does* auto-label — it relabels to `CC - Incomplete refactor upgrades audit` seconds after spawn, once the session topic resolves (Claude's `/status` name via `sessionName.ts`, or an LLM-generated label). So the border ends up a strictly-worse duplicate of the tab sitting one row below it:

```
tab:    ✳ CC - Incomplete refactor upgrades audit
border: ─ 0: CC ───────────────────────────────────   ← frozen, topic-less
```

## Fix

Wire the border into the label pipeline that already exists — the label just arrives asynchronously, and tmux options are mutable at runtime, so we re-render the border when the label resolves.

- **`paneBorderText(name, label)`** — pure, in `core/utils.ts`. Builds the border text like the tab: bare code until a label resolves, then `CC - <topic>`. Flattens newlines, ellipsizes past a 48-char cap, and doubles `#` (tmux treats a lone `#` as a format escape).
- **`relabelTmuxPane(terminal, label)`** — re-sets `pane-border-format` live on the shared socket from the extension host, via a `hostTmux` helper that probes the usual tmux binary paths (generalized out of the existing `readPaneId`). Idempotent (skips a repeat of the same label) and fire-and-forget.
- **`terminals.setLabel` / `setAutoLabel`** — the choke points every label path funnels through — now call it. So the border updates on the poller, focus-fetch, and manual-rename paths, and even when the terminal isn't focused (unlike the tab rename, which must briefly activate the terminal).

Scope is deliberately minimal: it re-sets the window-level `pane-border-format`, so there's **no split regression** (multi-pane windows already showed identical `N: CC` labels; `#{pane_index}` still disambiguates them). Per-pane distinct labels remain a separate future enhancement.

## Verification

Proven against real tmux (the exact `set-option` call `relabelTmuxPane` makes):

```
seeded  => [ 0: CC ]
relabel => [ 0: CC - Incomplete refactor upgrades audit ]   # live, no respawn
# escape => [ 0: CC - land PR #758 ]                          # ## renders literal #
```

- `bun test src/core/utils.test.ts` → **100 pass, 0 fail** (incl. 7 new `paneBorderText` cases: no-label, append, whitespace/newline flatten, markup strip, cap/ellipsis, exact-cap, `#` escaping)
- `bunx tsc --noEmit` → clean
- The 3 failures in the full suite (`SessionWatcher` 5s-timeout flake, a model `resolveAlias` test, and a `dompurify` missing-package error in `ui/`) reproduce on the untouched base branch — pre-existing, unrelated to this change (which touches only `src/core` + `src/vscode`).