### PR TITLE
fix(factory): point GitHub links at phnx-labs/agents-cli, not the retired swarmify repo

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ### Fixed
 
+- **GitHub links pointed at a retired repo.** `package.json` `repository`, the
+  settings "Open GitHub" action, and the Guide tab's "Learn More" link now all point
+  to `github.com/phnx-labs/agents-cli` (`apps/factory`). Publish identity — publisher
+  `swarmify`, name `swarm-ext`, appId — is unchanged.
 - **Factory Floor feed showed identical, contextless cards for co-located sessions.**
   Ported the swarmify/extension feed fixes: fan-out remote-session enrichment now
   attributes each row to the correct device (`machine`), surfaces the worktree slug,

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -13,8 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/muqsitnawaz/swarmify",
-    "directory": "extension"
+    "url": "https://github.com/phnx-labs/agents-cli",
+    "directory": "apps/factory"
   },
   "homepage": "https://swarmify.co/#agents-ext",
   "engines": {

--- a/apps/factory/src/vscode/settings.vscode.ts
+++ b/apps/factory/src/vscode/settings.vscode.ts
@@ -3243,7 +3243,7 @@ function openGuide(context: vscode.ExtensionContext, guide: string): void {
       ).then(selection => {
         if (selection === 'Open GitHub') {
           vscode.env.openExternal(
-            vscode.Uri.parse('https://github.com/muqsitnawaz/swarmify')
+            vscode.Uri.parse('https://github.com/phnx-labs/agents-cli')
           );
         }
       });

--- a/apps/factory/ui/settings/components/tabs/GuideTab.tsx
+++ b/apps/factory/ui/settings/components/tabs/GuideTab.tsx
@@ -105,7 +105,7 @@ Task → Plan → Approval → Execution
         <SectionHeader>Learn More</SectionHeader>
         <div className="space-y-2">
           <ExtLink
-            href="https://github.com/muqsitnawaz/swarmify"
+            href="https://github.com/phnx-labs/agents-cli"
             className="flex items-center gap-3 px-4 py-3 rounded-xl bg-[var(--muted)] hover:bg-[var(--muted-foreground)]/10 transition-colors"
           >
             <ExternalLinkIcon className="w-4 h-4 text-[var(--muted-foreground)]" />


### PR DESCRIPTION
## What

The Factory extension still linked to the old standalone **`muqsitnawaz/swarmify`** repo in three user-facing spots. That repo was retired when the extension moved into this monorepo (`apps/factory`). This repoints all three at the real remote, **`phnx-labs/agents-cli`**:

| Location | Before | After |
|---|---|---|
| `apps/factory/package.json` `repository` | `muqsitnawaz/swarmify` · `directory: extension` | `phnx-labs/agents-cli` · `directory: apps/factory` |
| `src/vscode/settings.vscode.ts` — "Open GitHub" action | `muqsitnawaz/swarmify` | `phnx-labs/agents-cli` |
| `ui/settings/components/tabs/GuideTab.tsx` — "Learn More" link | `muqsitnawaz/swarmify` | `phnx-labs/agents-cli` |

## Not touched (deliberately)

- **Publish identity is frozen** (per repo policy): publisher `swarmify`, name `swarm-ext`, appId `com.swarmify.factory`, productName `Factory` — all unchanged. Only the *repository/source links* moved.
- **Test fixtures & path examples** referencing `muqsitnawaz/agents`/`swarmify` (`remoteSessions.test.ts`, `active-sessions.json`, `dispatch.test.ts`, captured git-fetch output, `bench-fs-watch.ts` default, design mockups) — these are local filesystem paths / owner-resolution test data, not links, so they stay as-is.
- The agents-cli side (`apps/cli`, root `package.json`, README badges) was already correctly on `phnx-labs/agents-cli`.

## Verify

```
grep -rn "github.com/muqsitnawaz/swarmify" apps/factory/{package.json,src,ui}
# no matches
```

Changelog: added under `apps/factory/CHANGELOG.md` `[0.9.283]`.