### PR TITLE
fix(factory): cloud tasks get their own 'Cloud' category, not folded under the local host

### DIFF
--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
@@ -340,6 +340,43 @@ describe('toFloorAgentFromRemote', () => {
     }
     expect(toFloorAgentFromRemote(r, new Set()).lastActivityMs).toBe(0)
   })
+
+  test('a cloud task gets its own "Cloud" category instead of folding under the dispatching machine', () => {
+    // The CLI attributes a cloud task to the querier ('zion') for reply routing, but
+    // it runs in a provider sandbox — the feed must NOT show it under the local host.
+    const r: RemoteSessionLike = {
+      host: 'zion',
+      sessionId: 'task_e',
+      agentType: 'codex',
+      cwd: '',
+      project: '',
+      phase: 'waiting',
+      activity: '',
+      tokPerSec: 0,
+      waitingForInput: false,
+      lastResponse: '',
+      prUrl: null,
+      ticket: null,
+      branch: '',
+      sinceMs: 0,
+      startedAtMs: NOW,
+      topic: 'Read README.md',
+      context: 'cloud',
+      cloudTaskId: 'task_e',
+      cloudProvider: 'codex',
+      teamName: '',
+      pid: 0,
+      transport: '',
+      replyRail: '',
+      replyMuxTarget: '',
+      replyMuxSocket: '',
+    }
+    const a = toFloorAgentFromRemote(r, new Set(), 'zion')
+    // Groups under "Cloud", never the local machine — grouping keys off hostLabel ?? host.
+    expect(a.hostLabel).toBe('Cloud')
+    // Reply routing still targets the real querier host, unaffected by the display label.
+    expect(a.reply.host).toBe('zion')
+  })
 })
 
 describe('deriveReplyTargetFromRemote', () => {

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
@@ -306,6 +306,10 @@ export function toFloorAgentFromRemote(r: RemoteSessionLike, pinned: Set<string>
   // Remote (Tier-1) sessions have no enriched last-response yet — fall back to the
   // session's task line (topic) so the card shows what it's working on, not blank.
   const resp = r.lastResponse || r.topic || ''
+  // Cloud tasks run in a provider sandbox, not on the dispatching machine — the CLI
+  // attributes them to the querier ('zion') for reply routing, but they should NOT
+  // fold under that local host in the feed. Give them their own "Cloud" category.
+  const isCloud = (r.context || '').toLowerCase() === 'cloud' || !!r.cloudTaskId
 
   return {
     id,
@@ -318,7 +322,7 @@ export function toFloorAgentFromRemote(r: RemoteSessionLike, pinned: Set<string>
     // This machine's own sessions reported by the machine-wide fetch carry the
     // synthetic 'this-mac'; give them the real device name so they fold into the
     // same HOSTS row as in-window local agents instead of a second bucket.
-    hostLabel: r.host === 'this-mac' ? localHostName || undefined : undefined,
+    hostLabel: isCloud ? 'Cloud' : (r.host === 'this-mac' ? localHostName || undefined : undefined),
     project: deriveProject(r.cwd, r.project, r.project || '—', projectRules),
     name,
     abbr: abbrFor(r.agentType),


### PR DESCRIPTION
## What

Cloud tasks were folding under the local machine (`zion`) in the Factory Floor feed. A cloud task runs in a provider sandbox — it isn't running *on* your laptop — so grouping it under the dispatching host is misleading.

**Before:** `task_e` (Codex cloud, queued) and `vclfel94` (Rush cloud, input-required) rendered as `— · zion`, mixed in with local sessions.

**After:** cloud-context rows get their own **"Cloud"** category and never fold under the local host.

## Why they were on `zion`

The CLI attributes a cloud row to the querying machine for **reply routing** (`agents cloud message` has to SSH through the owner). That machine id (`machine: 'zion'`) became the feed's host. This PR keeps the reply routing intact but separates the *display/grouping* identity.

## Change

`toFloorAgentFromRemote` (`floorAdapter.ts`): cloud-context rows (`context === 'cloud'` or a `cloudTaskId`) now set `hostLabel: 'Cloud'`. Grouping keys off `hostLabel ?? host`, so they form a "Cloud" group and the card meta reads `Cloud` instead of `zion`. Reply routing is untouched — `deriveReplyTargetFromRemote(r)` still uses the RemoteSession's real querier host.

## Testing

- `tsc -p ./` clean
- `floorAdapter.test.ts`: **35 pass, 0 fail**, incl. a new test asserting a cloud task maps to `hostLabel: 'Cloud'` while `reply.host` stays `zion`.

## Follow-up (separate PR)

The `019e30a2` phantom row in the same `—` group is a *different* bug — the Codex **desktop app's** `app-server` (`/Applications/Codex.app/.../codex`, basename `codex`) getting matched as a CLI session. Fixed separately in `apps/cli`.
