### PR TITLE
fix(sessions): stop listing the Codex desktop app-server as a phantom agent

### DIFF
--- a/apps/cli/src/lib/session/active.test.ts
+++ b/apps/cli/src/lib/session/active.test.ts
@@ -1,5 +1,23 @@
 import { describe, it, expect } from 'vitest';
-import { resolveCwds, LSOF_CONCURRENCY } from './active.js';
+import { resolveCwds, LSOF_CONCURRENCY, agentKindFromComm } from './active.js';
+
+describe('agentKindFromComm', () => {
+  it('matches a real agent CLI by basename (absolute path or bare name)', () => {
+    expect(agentKindFromComm('/Users/u/.bun/bin/codex')).toBe('codex');
+    expect(agentKindFromComm('claude')).toBe('claude');
+    expect(agentKindFromComm('claude.exe')).toBe('claude');
+  });
+
+  it('does NOT match the Codex desktop app-server bundled inside Codex.app', () => {
+    // The desktop app ships a binary literally named `codex`; without the bundle
+    // guard its `app-server` (cwd '/') surfaces as a phantom agent session.
+    expect(agentKindFromComm('/Applications/Codex.app/Contents/Resources/codex')).toBeUndefined();
+  });
+
+  it('does NOT match the Claude desktop app (named Claude, not the CLI claude)', () => {
+    expect(agentKindFromComm('/Applications/Claude.app/Contents/MacOS/Claude')).toBeUndefined();
+  });
+});
 
 const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
 

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -165,7 +165,15 @@ const AGENT_CLI_NAMES: Record<string, string> = {
  * absolute path (shim-launched agents), and Windows image names carry an
  * `.exe` suffix (`claude.exe`), so basename + suffix-strip before the lookup.
  */
-function agentKindFromComm(commRaw: string): string | undefined {
+export function agentKindFromComm(commRaw: string): string | undefined {
+  // A GUI desktop app can bundle a binary with the SAME name as an agent CLI: the
+  // Codex desktop app ships `/Applications/Codex.app/Contents/Resources/codex` (its
+  // `app-server`), whose basename `codex` would otherwise match the codex CLI and
+  // surface the app's background server as a phantom agent session — running at cwd
+  // '/', so it shows up unattributed in the feed. A real agent CLI is never inside a
+  // `.app` bundle, so exclude those. (The Claude desktop app is a separate case,
+  // already excluded by name below: its process is 'Claude', not the CLI's 'claude'.)
+  if (commRaw.includes('.app/Contents/')) return undefined;
   const base = path.basename(commRaw);
   const stripped = base.replace(/\.exe$/i, '');
   // Windows image names compare case-insensitively; POSIX comms stay exact —


### PR DESCRIPTION
## What

A phantom `codex` session (`019e30a2`, cwd `/`) shows up in the agents feed. It's not a coding session — it's the **Codex desktop app's background app-server**.

## Root cause (verified live)

`ps -o comm=` for that pid returns `/Applications/Codex.app/Contents/Resources/codex`. The active-session scanner's `agentKindFromComm` (`apps/cli/src/lib/session/active.ts`) keys on the executable **basename** — `codex` — so the desktop app's bundled server matches the codex CLI. GUI-app processes inherit cwd `/`, so it surfaces unattributed.

- `lsof -d cwd` on the live pids (11203 = `codex app-server`, 12731 = `SkyComputerUseService`, both children of `/Applications/Codex.app`) confirms real cwd `/`.
- The codebase already excludes the *Claude* desktop app by name (process `Claude` ≠ CLI `claude`), but Codex bundles a **lowercase** `codex`, so the name guard doesn't catch it.

## Fix

`agentKindFromComm` now rejects any executable path under `.app/Contents/` — a real agent CLI is never inside a `.app` bundle. One line + a documented rationale.

## Testing

- `tsc` clean; full `src/lib/session/` suite: **437 pass, 0 fail**
- New `agentKindFromComm` unit tests: matches a real CLI by basename/`.exe`; rejects `/Applications/Codex.app/Contents/Resources/codex`; rejects the Claude desktop app.

## Related

Pairs with #772 (factory: cloud tasks get their own "Cloud" category) — together they clean up the `—`/`zion` rows in the feed.
