### PR TITLE
fix(agents): truthful doctor, spawnable version fallback, self-recovering shims

### DIFF
--- a/agents.yaml
+++ b/agents.yaml
@@ -1,2 +1,5 @@
-agents:
-  codex: "0.116.0"
+# Project agent-version pins for this repo. Empty on purpose: use each machine's
+# installed default. A stale pin here (this file previously pinned a broken,
+# npm-unrecoverable codex 0.116.0) forces every `agents run codex` in the repo to
+# fall back / self-heal on each launch. Pin a version here only for a real reason.
+agents: {}

--- a/apps/cli/src/commands/teams.ts
+++ b/apps/cli/src/commands/teams.ts
@@ -57,7 +57,7 @@ import {
   hasUncommittedChanges,
   removeWorktree,
 } from '../lib/teams/worktree.js';
-import { isVersionInstalled, resolveVersionAlias, resolveVersionAliasLoose } from '../lib/versions.js';
+import { isVersionInstalled, resolveVersion, resolveVersionAlias, resolveVersionAliasLoose, verifyInstalledBinaryLaunches } from '../lib/versions.js';
 import { AGENTS, warnAgentDeprecated } from '../lib/agents.js';
 import type { AgentId } from '../lib/types.js';
 import { discoverSessions, parseTimeFilter, resolveSessionById } from '../lib/session/discover.js';
@@ -1970,6 +1970,29 @@ export function registerTeamsCommands(program: Command): void {
     .option('--json', 'Output machine-readable JSON')
     .action(async (opts: { json?: boolean }) => {
       const info = checkAllClis();
+
+      // Deep integrity probe. `checkAllClis` reports presence (shim + stub guard),
+      // but a GUTTED native binary (JS wrapper present, platform binary missing —
+      // the codex/kimi optional-dep partial-extract failure) still passes that. So
+      // actually launch the resolved default version and, if it won't run, flip the
+      // agent to not-installed with a repair hint — otherwise doctor says "ready"
+      // and the teammate ENOENTs at spawn. Parallel; win32 is treated as healthy by
+      // verifyInstalledBinaryLaunches.
+      await Promise.all(
+        Object.entries(info).map(async ([name, entry]) => {
+          if (!entry.installed) return;
+          const agent = name as AgentId;
+          const version = resolveVersion(agent);
+          if (!version) return;
+          const health = await verifyInstalledBinaryLaunches(agent, version);
+          if (!health.ok) {
+            entry.installed = false;
+            entry.path = null;
+            entry.error = `${AGENTS[agent]?.cliCommand ?? name}@${version} is installed but its binary won't launch`
+              + `${health.detail ? ` (${health.detail})` : ''}. Repair: agents add ${agent}@${version}`;
+          }
+        })
+      );
 
       // Advisory enrichment only. Sign-in detection is UNRELIABLE, so it never
       // changes the authoritative installed/ready column — it annotates. And an

--- a/apps/cli/src/lib/__tests__/shims.test.ts
+++ b/apps/cli/src/lib/__tests__/shims.test.ts
@@ -95,8 +95,8 @@ describe('addShimsToPath', () => {
 });
 
 describe('SHIM_SCHEMA_VERSION', () => {
-  it('is 24 (shim resolves per-device default pins from devices/<machine>/agents.yaml)', () => {
-    expect(SHIM_SCHEMA_VERSION).toBe(24);
+  it('is 25 (shim self-recovers a vanished dispatcher via `agents` on PATH)', () => {
+    expect(SHIM_SCHEMA_VERSION).toBe(25);
   });
 });
 
@@ -355,6 +355,21 @@ describe('generateShimScript', () => {
     expect(script).toContain('if [ -z "$AGENTS_BIN" ] || [ ! -x "$AGENTS_BIN" ]; then');
     expect(script).toContain('agents: agents-cli entrypoint missing or not executable: $AGENTS_BIN');
     expect(script).toContain('exit 127');
+  });
+
+  it('self-recovers a vanished dispatcher via `agents` on PATH before erroring', () => {
+    const script = generateShimScript('claude');
+    // When the baked AGENTS_BIN is gone (removed/moved dev build), resolve the
+    // real `agents` on PATH and use it, rather than bricking the launch.
+    expect(script).toContain('RECOVERED_BIN="$(command -v agents 2>/dev/null || true)"');
+    expect(script).toContain('AGENTS_BIN="$RECOVERED_BIN"');
+    // The recovery must sit INSIDE the not-executable guard, before exit 127.
+    const guard = script.indexOf('[ ! -x "$AGENTS_BIN" ]; then');
+    const recover = script.indexOf('command -v agents');
+    const bail = script.indexOf('exit 127');
+    expect(guard).toBeGreaterThanOrEqual(0);
+    expect(recover).toBeGreaterThan(guard);
+    expect(bail).toBeGreaterThan(recover);
   });
 });
 

--- a/apps/cli/src/lib/exec.test.ts
+++ b/apps/cli/src/lib/exec.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { shouldTapStdout, resolveInteractive, buildExecCommand, nativeResume, resolveShimSpawn, buildExecEnv, shouldWrapInTmux, buildTmuxAgentCommand, formatPaneTail, type TmuxWrapContext } from './exec.js';
 import type { ExecOptions } from './exec.js';
 import { mailboxDir } from './mailbox.js';
@@ -77,6 +80,45 @@ describe('nativeResume (Tier-1 capability derives from the command template)', (
   it('opencode and gemini do not (they fall back to /continue replay)', () => {
     expect(nativeResume('opencode')).toBe(false);
     expect(nativeResume('gemini')).toBe(false);
+  });
+});
+
+describe('buildExecCommand — versioned launch target (no unspawnable literal)', () => {
+  let tmpHome: string;
+  let origHome: string | undefined;
+
+  // state.ts caches HOME at module load, so set HOME then re-import exec.js fresh.
+  beforeEach(() => {
+    origHome = process.env.HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'exec-ver-'));
+    process.env.HOME = tmpHome;
+    vi.resetModules();
+  });
+  afterEach(() => {
+    if (origHome === undefined) delete process.env.HOME; else process.env.HOME = origHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  // Regression for `spawn kimi@0.19.2 ENOENT`: when a specific version is requested
+  // and no versioned shim exists on disk, we must resolve the version's REAL binary
+  // — never leave the bare `<agent>@<version>` literal as argv[0] (it's not on PATH).
+  it('resolves the version binary when no versioned shim exists', async () => {
+    const binDir = path.join(tmpHome, '.agents', '.history', 'versions', 'kimi', '0.19.2', 'node_modules', '.bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    const realBin = path.join(binDir, 'kimi');
+    fs.writeFileSync(realBin, '#!/bin/sh\n', { mode: 0o755 });
+
+    const { buildExecCommand: build } = await import('./exec.js');
+    const cmd = build(execOpts({ agent: 'kimi', version: '0.19.2', interactive: true }));
+    expect(cmd[0]).toBe(realBin);
+    expect(cmd[0]).not.toBe('kimi@0.19.2');
+  });
+
+  it('falls back to the bare versioned name only when no binary exists at all', async () => {
+    const { buildExecCommand: build } = await import('./exec.js');
+    const cmd = build(execOpts({ agent: 'kimi', version: '0.19.2', interactive: true }));
+    expect(cmd[0]).toBe('kimi@0.19.2');
   });
 });
 

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -632,7 +632,13 @@ export function buildExecCommand(options: ExecOptions): string[] {
     } else if (fs.existsSync(absPath)) {
       cmd[0] = absPath;
     } else {
-      cmd[0] = versionedName;
+      // No versioned shim on disk. Prefer the version's REAL launch binary
+      // (node_modules/.bin/<cli>) over the bare `<cli>@<version>` name — that
+      // literal is not on PATH and spawns as ENOENT (the `kimi@0.19.2` failure).
+      // Fall back to the literal only if the binary is absent (the run path's
+      // ensureAgentRunnable normally repairs/creates the alias before we reach here).
+      const realBinary = options.agent ? getBinaryPath(options.agent, options.version) : undefined;
+      cmd[0] = realBinary && fs.existsSync(realBinary) ? realBinary : versionedName;
     }
   }
 

--- a/apps/cli/src/lib/shims.ts
+++ b/apps/cli/src/lib/shims.ts
@@ -240,7 +240,10 @@ async function promptConflictStrategy(
 // v22 — export DISABLE_AUTOUPDATER=1 for claude shims so a pinned per-version
 //        install can't self-mutate: Claude Code's background auto-updater would
 //        otherwise rewrite the pinned binary in place. Explicit user value wins.
-export const SHIM_SCHEMA_VERSION = 24;
+// v25 — dispatcher self-recovery: if the baked AGENTS_BIN is gone (a removed/moved
+//        dev build that generated the shim), resolve `agents` on PATH instead of
+//        exiting 127, so a stale/vanished dev build can't brick every launch.
+export const SHIM_SCHEMA_VERSION = 25;
 
 /** Internal marker string used to embed the schema version in shim scripts. */
 const SHIM_VERSION_MARKER = 'agents-shim-version:';
@@ -326,8 +329,19 @@ AGENT="${agent}"
 CLI_COMMAND="${cliCommand}"
 
 if [ -z "$AGENTS_BIN" ] || [ ! -x "$AGENTS_BIN" ]; then
-  echo "agents: agents-cli entrypoint missing or not executable: $AGENTS_BIN" >&2
-  exit 127
+  # The baked dispatcher is gone — e.g. the build that generated this shim (often
+  # a dev build under ~/.local/agents-cli-dev) was removed, moved, or its version
+  # dir rotated. Self-recover to whatever 'agents' now resolves to on PATH instead
+  # of bricking every managed launch. 'agents' is the CLI itself, never a per-agent
+  # shim, so this cannot re-enter this dispatcher.
+  RECOVERED_BIN="$(command -v agents 2>/dev/null || true)"
+  if [ -n "$RECOVERED_BIN" ] && [ -x "$RECOVERED_BIN" ]; then
+    AGENTS_BIN="$RECOVERED_BIN"
+  else
+    echo "agents: agents-cli entrypoint missing or not executable: $AGENTS_BIN" >&2
+    echo "agents: could not resolve 'agents' on PATH to recover. Reinstall: npm i -g @phnx-labs/agents-cli" >&2
+    exit 127
+  fi
 fi
 
 # When agents-cli "adopts" a harness's own launcher (symlinks the native binary

--- a/apps/cli/src/lib/teams/agents.cli-detection.test.ts
+++ b/apps/cli/src/lib/teams/agents.cli-detection.test.ts
@@ -52,4 +52,25 @@ describe('checkCliAvailable — shims-dir detection', () => {
     expect(installed).toBe(false);
     expect(err).toMatch(/not found in PATH/);
   });
+
+  // The false-positive that made `teams doctor` say installed:true while the agent
+  // ENOENT'd at spawn: a shim file exists, but the resolved default version has no
+  // real binary (a partial/raced npm extract left a stub version dir). Doctor must
+  // report the truth, not just "a shim file is present".
+  it('reports NOT installed when the shim exists but the default version binary is missing', async () => {
+    process.env.HOME = tmpHome;
+    process.env.PATH = '';
+    const shimsDir = path.join(tmpHome, '.agents', '.cache', 'shims');
+    fs.mkdirSync(shimsDir, { recursive: true });
+    fs.writeFileSync(path.join(shimsDir, 'claude'), '#!/bin/sh\n', { mode: 0o755 });
+
+    vi.resetModules();
+    const versions = await import('../versions.js');
+    versions.setGlobalDefault('claude', '9.9.9'); // pinned default with no installed binary
+    const { checkCliAvailable } = await import('./agents.js');
+    const [installed, err] = checkCliAvailable('claude' as never);
+
+    expect(installed).toBe(false);
+    expect(err).toMatch(/not runnable|binary is missing/i);
+  });
 });

--- a/apps/cli/src/lib/teams/agents.ts
+++ b/apps/cli/src/lib/teams/agents.ts
@@ -21,6 +21,7 @@ import { setGeminiAutoUpdateDisabled, updateGeminiSettings } from '../gemini-set
 import type { AgentId } from '../types.js';
 import { getAgentsDir as getSystemAgentsDir, getShimsDir } from '../state.js';
 import { AGENTS, getAccountInfo } from '../agents.js';
+import { resolveVersion, isVersionInstalled } from '../versions.js';
 import { sanitizeProcessEnv } from '../secrets/bundles.js';
 
 let lastMemoryWarnAt = 0;
@@ -358,20 +359,28 @@ export async function ensureGeminiPlanMode(): Promise<void> {
  * (for CLIs the user installed outside agents-cli).
  */
 export function checkCliAvailable(agentType: AgentType): [boolean, string | null] {
-  const executable = AGENTS[agentType as AgentId]?.cliCommand;
+  const agent = agentType as AgentId;
+  const executable = AGENTS[agent]?.cliCommand;
   if (!executable) {
     return [false, `Unknown agent type: ${agentType}`];
   }
 
   const shimPath = path.join(getShimsDir(), executable);
-  if (fsSync.existsSync(shimPath)) {
-    return [true, shimPath];
+  const dispatch = fsSync.existsSync(shimPath) ? shimPath : findExecutable(executable);
+  if (!dispatch) {
+    return [false, `CLI tool '${executable}' not found in PATH. Install it first.`];
   }
 
-  const resolved = findExecutable(executable);
-  return resolved
-    ? [true, resolved]
-    : [false, `CLI tool '${executable}' not found in PATH. Install it first.`];
+  // A shim file (or a PATH entry) existing does NOT mean the agent is runnable:
+  // the managed default version's binary can be a stub or gutted (a partial/raced
+  // npm extract leaves the version dir + JS wrapper but no real binary). Verify
+  // the resolved default version is actually installed so `teams doctor` reports
+  // the truth instead of a false `installed: true` that ENOENTs at spawn.
+  const version = resolveVersion(agent);
+  if (version && !isVersionInstalled(agent, version)) {
+    return [false, `${executable}@${version} is not runnable — its binary is missing/incomplete. Repair: agents add ${agent}@${version}`];
+  }
+  return [true, dispatch];
 }
 
 /** Check availability of all known agent CLIs. Returns a map of agent type to install status. */


### PR DESCRIPTION
## Problem

`agents teams` failed to launch codex/kimi teammates even though they were "configured", with `spawn kimi@0.19.2 ENOENT`, and `teams doctor` reported them `installed: true`. Root cause (verified end-to-end, not inferred):

- **Broken installs go undetected.** A partial/raced npm extract leaves a stub version dir (kimi 0.19.2) or a gutted native binary (JS wrapper present, platform binary missing). `#764` already added install-time verification + run-path self-heal (`ensureAgentRunnable`), but the gaps below remained.
- **`teams doctor` lied** — `checkCliAvailable` returned `installed: true` from a *shim file* existing, never checking the real binary.
- **The exec fallback built an unspawnable literal** — when no versioned shim existed, `argv[0]` became the bare `kimi@0.19.2`, which isn't on PATH → ENOENT.
- **Shims couldn't survive their dispatcher going stale/missing** — a dev build (`~/.local/agents-cli-dev`) that generated the shims and then went stale/removed left every managed launch broken.

(Note: `--ignore-scripts` is **not** a cause — proven: fresh codex installs and runs with it. The codex vendor layout also changed across versions: `vendor/<triple>/bin/codex` now vs `codex/codex` in 0.116.0.)

## Fix

- **exec**: no versioned shim → resolve the version's **real binary** (`getBinaryPath`), never the bare `<agent>@<version>` literal.
- **`checkCliAvailable`**: verify the resolved default version is actually installed (catches stubs), not just that a shim file exists.
- **`teams doctor`**: parallel **launch probe** of each installed agent's default (`verifyInstalledBinaryLaunches`) → flips a gutted-native agent to not-installed with a repair hint. Doctor now reports the truth.
- **shims**: if the baked `AGENTS_BIN` dispatcher is gone, **self-recover** to `agents` on PATH instead of exiting 127 (survives a removed/moved dev build). `SHIM_SCHEMA` → 25.
- **repo**: drop the stale, npm-unrecoverable `codex 0.116.0` pin so codex uses the machine default.

## Verification (end-to-end, on the reporting machine)

```
[before] kimi 0.19.2 launches: {"ok":false,"detail":"binary not found ..."}
[heal] Kimi@0.19.2 is broken (platform binary missing) — repairing…
[heal] repaired Kimi@0.19.2.
[after] runnable: {"ok":true}          # kimi --version -> 0.19.2, kimi@0.19.2 shim recreated

[before] codex 0.116.0: {"ok":false,"detail":"binary not found ..."}
[heal] Codex@0.116.0 could not be repaired — using Codex@0.142.5 instead (now the default).
[after] runnable: {"ok":true}
```

- `teams doctor` now reports kimi `installed:false` (stub) with a repair hint; codex `ready` (its good default launches).
- Full suite green under vitest (clean env): 4406 pass, the only failure a pre-existing network rate-limit flake in `loop.test.ts` (passes in isolation) — none in the six touched files.
- New tests: exec versioned-fallback (real binary vs literal), doctor stub-detection, shim self-recovery ordering.
