### PR TITLE
feat(factory): expand card checklist by default (collapsible)

### DIFF
--- a/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
@@ -5,7 +5,7 @@ import { StructuredReply, type ReplyCallbacks } from './StructuredReply'
 import { heartbeatLevel, sessionTaskLine, type FloorAgent, type FloorTicket } from './floorModel'
 import { sinceFromMs } from './floorAdapter'
 import { useNow } from './useNow'
-import { TodoProgressBar } from './TodoChecklist'
+import { CardChecklist } from './TodoChecklist'
 
 // One agent row in the feed (feedItem: factory-floor.html:608-620) + the Next-Up
 // ticketStrip teaser row (:621-623). Pure presentation; selection + replies raised
@@ -113,7 +113,7 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
         </span>
       </div>
       <div className="resp">{destructive ? <span className="q">{a.resp}</span> : a.resp}</div>
-      {!plain && a.todos.length > 0 && <TodoProgressBar todos={a.todos} />}
+      {!plain && a.todos.length > 0 && <CardChecklist todos={a.todos} />}
       {showSummary && <div className="summary">{taskLine}</div>}
       {showNowline && (
         <div className={`nowline ${stalled ? 'stall' : ''}`}>

--- a/apps/factory/ui/settings/components/mission-control/TodoChecklist.tsx
+++ b/apps/factory/ui/settings/components/mission-control/TodoChecklist.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { todoProgress, type TodoItem } from './floorModel'
 
 // Per-session task checklist, parsed from the agent's latest TodoWrite call.
@@ -15,6 +15,45 @@ export function TodoProgressBar({ todos }: { todos: TodoItem[] }) {
     <div className="sw-todobar" title={`${done} of ${total} tasks done`}>
       <span className="sw-todobar-frac">{done}/{total}</span>
       <span className="sw-todobar-track"><i style={{ width: `${pct}%` }} /></span>
+    </div>
+  )
+}
+
+/**
+ * Card affordance: the progress bar with the full checklist EXPANDED beneath it by
+ * default, so the current step reads at a glance without a click. The bar doubles as a
+ * collapse/expand toggle (still collapsible for a denser feed). The in-progress item is
+ * highlighted and completed items struck through via the shared `.sw-todocheck-item`
+ * styles. Clicks are stopped so toggling never selects the card.
+ */
+export function CardChecklist({ todos }: { todos: TodoItem[] }) {
+  const { done, total } = todoProgress(todos)
+  const [open, setOpen] = useState(true)
+  if (total === 0) return null
+  const pct = Math.round((done / total) * 100)
+  return (
+    <div className="sw-cardchecklist">
+      <button
+        type="button"
+        className="sw-cardchecklist-bar"
+        aria-expanded={open}
+        title={open ? 'Collapse checklist' : 'Expand checklist'}
+        onClick={(e) => { e.stopPropagation(); setOpen((o) => !o) }}
+      >
+        <span className="sw-todobar-frac">{done}/{total}</span>
+        <span className="sw-todobar-track"><i style={{ width: `${pct}%` }} /></span>
+        <span className="sw-cardchecklist-chev">{open ? '⌄' : '›'}</span>
+      </button>
+      {open && (
+        <ul className="sw-todocheck-list">
+          {todos.map((t, i) => (
+            <li key={i} className={`sw-todocheck-item status-${t.status}`}>
+              <span className="sw-todocheck-mk" />
+              <span className="sw-todocheck-txt">{t.content}</span>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   )
 }

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -217,6 +217,11 @@
 .swarmify-root .sw-todobar-frac { font-variant-numeric: tabular-nums; font-weight: 700; color: var(--ds-text-muted); }
 .swarmify-root .sw-todobar-track { flex: 1; height: 5px; border-radius: 3px; background: var(--ds-bg-inset); overflow: hidden; }
 .swarmify-root .sw-todobar-track > i { display: block; height: 100%; background: var(--brand); border-radius: 3px; transition: width .4s ease; }
+/* Card checklist: progress bar (also the collapse toggle) with the list expanded by default. */
+.swarmify-root .sw-cardchecklist { margin: 2px 0 8px; }
+.swarmify-root .sw-cardchecklist-bar { display: flex; align-items: center; gap: 8px; width: 100%; background: none; border: 0; padding: 2px 0; margin: 0; cursor: pointer; font-size: 10.5px; color: var(--ds-text-dim); text-align: left; }
+.swarmify-root .sw-cardchecklist-chev { color: var(--ds-text-faint); font-size: 12px; margin-left: 2px; line-height: 1; }
+.swarmify-root .sw-cardchecklist .sw-todocheck-list { margin-top: 6px; }
 .swarmify-root .sw-todocheck-head { display: flex; align-items: center; gap: 10px; margin-bottom: 7px; }
 .swarmify-root .sw-todocheck-frac { font-size: 12px; font-weight: 800; color: var(--ds-text-muted); font-variant-numeric: tabular-nums; }
 .swarmify-root .sw-todocheck-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }


### PR DESCRIPTION
## What
Factory Floor feed cards now render the todo **checklist expanded by default** (was bar-only via `TodoProgressBar`), so the current step reads at a glance. The in-progress item is highlighted, completed items struck through, and the progress bar doubles as a collapse/expand toggle.

First increment of the approved Factory Floor redesign. Grounded entirely in existing data (`FloorAgent.todos`) — no CLI/data-model changes.

## How
- New `CardChecklist` in `TodoChecklist.tsx` (open defaults true, click toggles, stopPropagation so it never selects the card; reuses `.sw-todocheck-item` styles).
- `FeedItem.tsx`: `TodoProgressBar` → `CardChecklist`. `floor.css`: `.sw-cardchecklist`.

## Verified
- Preview harness (feed view): expanded, current item highlighted, collapses on click.
- `bun test` mission-control: **224 pass / 0 fail**. Settings `vite build`: clean.