### PR TITLE
feat(factory): group the live feed by project by default

### DIFF
--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -586,10 +586,12 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   // 0 live agents — so an empty host shows recent work instead of a blank pane.
   const [recentByHost, setRecentByHost] = useState<Record<string, RemoteSessionLike[]>>({})
   const [floorSort, setFloorSort] = useState<FloorSort>('needs')
-  // Group the live feed by an axis (project/host/status/agent). 'none' keeps the
-  // default phase sections (NEEDS YOU -> RUNNING -> DONE). Reuses the same
-  // groupAgents() the Backlog's group control uses, so the two bars behave alike.
-  const [floorGroup, setFloorGroup] = useState<FloorGroupBy | 'none'>('none')
+  // Group the live feed by an axis (project/host/status/agent). Defaults to 'project'
+  // so sessions cluster under the repo/Linear project they're working on (NEEDS YOU
+  // stays pinned above the groups); 'none' falls back to flat phase sections
+  // (NEEDS YOU -> RUNNING -> DONE). Reuses the same groupAgents() the Backlog's group
+  // control uses, so the two bars behave alike.
+  const [floorGroup, setFloorGroup] = useState<FloorGroupBy | 'none'>('project')
   const [plain, setPlain] = useState(floorPrefs0.plain)
   const [sidebarOpen, setSidebarOpen] = useState(floorPrefs0.sidebar)
   const [rightOpen, setRightOpen] = useState(floorPrefs0.right)


### PR DESCRIPTION
## What
The Factory Floor feed now **groups by project by default** (was flat phase sections). Sessions cluster under the repo/Linear project they're working on; **NEEDS YOU stays pinned** above the groups. Users can still switch GROUP to none/host/status/agent.

Second increment of the approved Factory Floor redesign.

## How
One-line default flip: `floorGroup` `useState('none')` → `useState('project')` in `UnifiedAgentsPane.tsx`. This pre-selects the **existing, unit-tested** `groupAgents('project')` path — no new logic (the GROUP dropdown already offered it).

## Verified
- `bun test` mission-control: **224 pass / 0 fail**. Settings `vite build`: clean.
- Note: the preview harness (`preview.tsx`) statically reconstructs the feed and does **not** render `UnifiedAgentsPane`'s grouping, so it can't show this. Verification is via the unit-tested `groupAgents` + a visual check in the installed extension (part of the redesign's install step).