### PR TITLE
feat(factory): one-click PR link on the feed card

### DIFF
--- a/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
@@ -6,6 +6,7 @@ import { heartbeatLevel, sessionTaskLine, type FloorAgent, type FloorTicket } fr
 import { sinceFromMs } from './floorAdapter'
 import { useNow } from './useNow'
 import { CardChecklist } from './TodoChecklist'
+import { ExtLink } from '../common/ExtLink'
 
 // One agent row in the feed (feedItem: factory-floor.html:608-620) + the Next-Up
 // ticketStrip teaser row (:621-623). Pure presentation; selection + replies raised
@@ -71,7 +72,11 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
   const showNowline = !plain && !!a.verb && !(showSummary && taskLine === nowlineText)
 
   const marker =
-    a.pr ? <span className="pill pr">PR {a.pr}</span> :
+    a.pr ? (
+      a.prUrl
+        ? <ExtLink href={a.prUrl} className="pill pr" title="Open pull request" style={{ textDecoration: 'none' }}>PR {a.pr}</ExtLink>
+        : <span className="pill pr">PR {a.pr}</span>
+    ) :
     stalled ? <span className="pill stall">stalled</span> :
     a.phase === 'running' ? <span className="pill run">running</span> :
     a.phase === 'done' ? <span className="pill done">done</span> : null

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -83,7 +83,7 @@ const dropQuestion: StructuredQuestion = {
 // NEEDS YOU — a CI-green PR awaiting review, and a destructive question.
 const reviewAgent = agent({
   id: 'a-review', abbr: 'CC', name: 'fix-terminal-race', project: 'rush', phase: 'done',
-  needs: true, pr: '#142', ci: 'passed', ticket: 'RUSH-1302',
+  needs: true, pr: '#142', prUrl: 'https://github.com/phnx-labs/agents-cli/pull/142', ci: 'passed', ticket: 'RUSH-1302',
   resp: 'Refactored task fetch into one model and wired the saved-views flow. Tests added, all green.',
   since: '4m',
 })


### PR DESCRIPTION
## What
The feed card's **PR pill is now a click-through link** to the pull request (opens on GitHub in one click) when the session has a `prUrl`; falls back to the static pill otherwise.

Third increment of the approved Factory Floor redesign.

## How
- `FeedItem.tsx`: the `marker` wraps `PR #N` in `ExtLink` (host `openExternal`) when `a.prUrl` is set. `ExtLink` stops propagation, so the click doesn't select the card.
- Imported `ExtLink` from `../common/ExtLink` (not the `../common` barrel — the barrel pulls a side-effecting sibling that blanks the preview harness).
- Added a `prUrl` to one PR fixture card so the harness demonstrates it.

## Verified
- Preview harness: the `PR #142` pill renders as `<a href=…/pull/142>` (DOM query + screenshot).
- `bun test` mission-control: **224 pass / 0 fail**. Settings `vite build`: clean.