### PR TITLE
fix(factory): editor send-to-agent no longer silently no-ops (#745)

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Factory extension are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); `scripts/release.sh` requires a
 `## [<version>]` section for the version being published.
 
+## [Unreleased]
+
+### Fixed
+
+- **Editor "Send to Agent" (slash-command + keyboard shortcut) silently did nothing.** The markdown editor webview may call VS Code's one-shot `acquireVsCodeApi()` only once per load, but `App.tsx` consumed it at startup while the Tiptap `KeyboardShortcuts` (`Mod-Shift-a` / `Mod-Shift-i`) and `SlashCommands` ("Send to Agent" / "Ask Agent") extensions each re-called `acquireVsCodeApi()` on use — a second acquisition that throws / yields `undefined`, so their `if (vscode)` guard fell through and the `postMessage` never fired. All four call sites plus `App.tsx` now share a single cached handle via a new `ui/editor/vscodeApi.ts` (`getVsCodeApi()`), acquired at most once. Regression test (`vscodeApi.test.ts`) simulates the single-acquire contract. Source: `apps/factory/ui/editor/vscodeApi.ts`, `App.tsx`, `extensions/KeyboardShortcuts.ts`, `extensions/SlashCommands.ts`.
+
 ## [0.9.283] - 2026-07-07
 
 ### Fixed

--- a/apps/factory/ui/editor/App.tsx
+++ b/apps/factory/ui/editor/App.tsx
@@ -4,9 +4,11 @@ import Outline from './components/Outline';
 import FrontmatterPanel from './components/FrontmatterPanel';
 import Toolbar from './components/Toolbar';
 import { Editor as TiptapEditor } from '@tiptap/core';
+import { getVsCodeApi } from './vscodeApi';
 
-declare const acquireVsCodeApi: () => any;
-const vscode = acquireVsCodeApi();
+// Acquire the single webview API handle once; the Tiptap extensions share it
+// via getVsCodeApi() rather than re-calling the one-shot acquireVsCodeApi().
+const vscode = getVsCodeApi()!;
 
 function App() {
   const [content, setContent] = useState<string>('');

--- a/apps/factory/ui/editor/extensions/KeyboardShortcuts.ts
+++ b/apps/factory/ui/editor/extensions/KeyboardShortcuts.ts
@@ -1,4 +1,5 @@
 import { Extension } from '@tiptap/core';
+import { getVsCodeApi } from '../vscodeApi';
 
 /**
  * Custom keyboard shortcuts for Notion-like editing experience
@@ -62,7 +63,7 @@ export default Extension.create({
 
       // Send selection to agent (Cmd+Shift+A)
       'Mod-Shift-a': () => {
-        const vscode = (window as any).acquireVsCodeApi?.();
+        const vscode = getVsCodeApi();
         if (vscode) {
           const selection = this.editor.state.doc.textBetween(
             this.editor.state.selection.from,
@@ -78,7 +79,7 @@ export default Extension.create({
 
       // AI improve shortcut
       'Mod-Shift-i': () => {
-        const vscode = (window as any).acquireVsCodeApi?.();
+        const vscode = getVsCodeApi();
         if (vscode) {
           const selection = this.editor.state.doc.textBetween(
             this.editor.state.selection.from,

--- a/apps/factory/ui/editor/extensions/SlashCommands.ts
+++ b/apps/factory/ui/editor/extensions/SlashCommands.ts
@@ -3,6 +3,7 @@ import { ReactRenderer } from '@tiptap/react';
 import Suggestion from '@tiptap/suggestion';
 import tippy from 'tippy.js';
 import SlashCommandsList from '../components/SlashCommandsList';
+import { getVsCodeApi } from '../vscodeApi';
 
 export default Extension.create({
   name: 'slashCommands',
@@ -119,7 +120,7 @@ export default Extension.create({
               title: 'Send to Agent',
               command: ({ editor, range }: any) => {
                 editor.chain().focus().deleteRange(range).run();
-                const vscode = (window as any).acquireVsCodeApi?.();
+                const vscode = getVsCodeApi();
                 if (vscode) {
                   // Get entire document content
                   const content = editor.storage.markdown.getMarkdown();
@@ -131,7 +132,7 @@ export default Extension.create({
               title: 'Ask Agent',
               command: ({ editor, range }: any) => {
                 editor.chain().focus().deleteRange(range).run();
-                const vscode = (window as any).acquireVsCodeApi?.();
+                const vscode = getVsCodeApi();
                 if (vscode) {
                   vscode.postMessage({ type: 'triggerAgent', action: 'ask' });
                 }

--- a/apps/factory/ui/editor/vscodeApi.test.ts
+++ b/apps/factory/ui/editor/vscodeApi.test.ts
@@ -1,0 +1,50 @@
+import { test, expect, beforeAll } from 'bun:test';
+
+// Simulate the VS Code webview contract: `acquireVsCodeApi()` may be called
+// only ONCE per load — a second call throws. This is exactly what broke the
+// editor before the fix: App.tsx acquired the handle, then KeyboardShortcuts /
+// SlashCommands each re-called acquireVsCodeApi(), which threw / yielded
+// undefined, so "send to agent" silently no-op'd.
+let acquireCalls = 0;
+const realApi = {
+  postMessage(_m: unknown) {},
+  getState() {
+    return undefined;
+  },
+  setState(_s: unknown) {},
+};
+
+beforeAll(() => {
+  (globalThis as unknown as { acquireVsCodeApi: () => unknown }).acquireVsCodeApi = () => {
+    acquireCalls += 1;
+    if (acquireCalls > 1) {
+      throw new Error('An instance of the VS Code API has already been acquired');
+    }
+    return realApi;
+  };
+});
+
+test('acquires the underlying VS Code API exactly once across many consumers', async () => {
+  const { getVsCodeApi } = await import('./vscodeApi');
+  const a = getVsCodeApi(); // App.tsx
+  const b = getVsCodeApi(); // KeyboardShortcuts
+  const c = getVsCodeApi(); // SlashCommands
+  // The bug: any consumer after the first re-acquired and threw. The singleton
+  // guarantees exactly one underlying acquisition, shared by all.
+  expect(acquireCalls).toBe(1);
+  expect(a).toBe(realApi);
+  expect(b).toBe(a);
+  expect(c).toBe(a);
+});
+
+test('the shared handle can post messages (send-to-agent path is live)', async () => {
+  const { getVsCodeApi } = await import('./vscodeApi');
+  const sent: unknown[] = [];
+  realApi.postMessage = (m: unknown) => {
+    sent.push(m);
+  };
+  const vscode = getVsCodeApi();
+  vscode?.postMessage({ type: 'sendToAgent', selection: 'hello' });
+  expect(acquireCalls).toBe(1); // still no re-acquire
+  expect(sent).toEqual([{ type: 'sendToAgent', selection: 'hello' }]);
+});

--- a/apps/factory/ui/editor/vscodeApi.ts
+++ b/apps/factory/ui/editor/vscodeApi.ts
@@ -1,0 +1,35 @@
+/**
+ * Single cached handle to the VS Code webview API for the markdown editor.
+ *
+ * `acquireVsCodeApi()` may be called only ONCE per webview load — VS Code
+ * removes it after the first call, so a second call throws / yields undefined.
+ * `App.tsx` and the Tiptap extensions (`KeyboardShortcuts`, `SlashCommands`)
+ * all live in the same editor webview, so they must share this one acquisition
+ * instead of each calling `acquireVsCodeApi()` — which is why the shortcut and
+ * slash-command "send to agent" actions were silently no-op'ing (they
+ * re-acquired after App.tsx had already consumed the one-shot handle).
+ */
+
+export interface VsCodeApi {
+  postMessage(message: unknown): void;
+  getState<T = unknown>(): T | undefined;
+  setState<T = unknown>(state: T): void;
+}
+
+declare const acquireVsCodeApi: (() => VsCodeApi) | undefined;
+
+let cached: VsCodeApi | undefined;
+
+/**
+ * Returns the editor webview's VS Code API handle, acquiring it at most once.
+ * Every subsequent call returns the same cached instance. Returns `undefined`
+ * only when running outside a VS Code webview (e.g. a plain-browser harness),
+ * so callers that may run there keep guarding with `if (vscode)`.
+ */
+export function getVsCodeApi(): VsCodeApi | undefined {
+  if (cached) return cached;
+  if (typeof acquireVsCodeApi === 'function') {
+    cached = acquireVsCodeApi();
+  }
+  return cached;
+}


### PR DESCRIPTION
Closes #745.

## Problem
In the Factory markdown editor webview, VS Code's `acquireVsCodeApi()` may be called only once per load — a second call throws / yields undefined. `App.tsx:9` consumed that one-shot handle at startup, but the Tiptap extensions each re-acquired it on use: `KeyboardShortcuts.ts:65,81` (Mod-Shift-a Send to Agent, Mod-Shift-i AI improve) and `SlashCommands.ts:122,134` (/Send to Agent, /Ask Agent). Each did `const vscode = (window as any).acquireVsCodeApi?.()` then `if (vscode)`; after App's acquisition the re-acquire failed, the guard fell through, and postMessage never fired — the actions silently did nothing. Found by the read-only rot audit.

## Fix
New `ui/editor/vscodeApi.ts` (getVsCodeApi()) acquires the handle at most once and caches it; App.tsx + both extensions share it. Scope kept tight — the cross-surface ui/shared/host/ hoist is a separate refactor.

## Verification
- `bun test editor/vscodeApi.test.ts` — 2/2 pass (stubs VS Code's single-acquire contract: 2nd call throws; asserts one shared acquisition + working postMessage on sendToAgent).
- `bun run build:editor` — clean (2171 modules); compiled bundle references acquireVsCodeApi only inside the singleton, no re-acquire survives.
- Fullest proof (slash-command send in a real .md tab) needs a packaged .vsix + focus-stealing automation; verified at the broken seam + compiled output instead.

Session transcript: zion:/private/tmp/claude-501/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/ba97feb6-2271-4f4e-8121-85f5e3e349d4/