### PR TITLE
feat(factory): unify the floor search into a single TopBar input

### DIFF
--- a/apps/factory/ui/settings/App.tsx
+++ b/apps/factory/ui/settings/App.tsx
@@ -97,6 +97,10 @@ export default function App() {
   const [openDetailTaskId, setOpenDetailTaskId] = useState<string | null>(null)
   const [openBenchTaskId, setOpenBenchTaskId] = useState<string | null>(null)
   const [floorThroughput, setFloorThroughput] = useState(0)
+  // Single live-feed filter. Lifted here (out of UnifiedAgentsPane) so the TopBar
+  // search input and the feed share one source of truth — the Floor no longer has
+  // a second search box in FloorControls.
+  const [floorSearch, setFloorSearch] = useState('')
   const [tasks, setTasks] = useState<TaskSummary[]>([])
   const [tasksLoading, setTasksLoading] = useState(false)
   const [tasksLoaded, setTasksLoaded] = useState(false)
@@ -751,6 +755,8 @@ export default function App() {
         onOpenSearch={() => setCmdKOpen(true)}
         onOpenSettings={() => setActiveTab('panel')}
         onToggleTheme={() => vscode.postMessage({ type: 'executeCommand', command: 'workbench.action.toggleLightDarkThemes' })}
+        search={activeTab === 'floor' ? floorSearch : undefined}
+        onSearch={activeTab === 'floor' ? setFloorSearch : undefined}
         throughputTokensPerSec={activeTab === 'floor' ? floorThroughput : 0}
         watchdogEnabled={watchdogEnabled}
         onToggleWatchdog={() => vscode.postMessage({ type: 'setWatchdogEnabled', value: !watchdogEnabled })}
@@ -787,6 +793,8 @@ export default function App() {
           openDetailTaskId={openDetailTaskId}
           onDetailTaskConsumed={() => setOpenDetailTaskId(null)}
           onThroughputChange={setFloorThroughput}
+          search={floorSearch}
+          onSearch={setFloorSearch}
           githubRepo={githubRepo}
           watchdogEnabled={watchdogEnabled}
           watchdogEvents={watchdogEvents}

--- a/apps/factory/ui/settings/components/mission-control/FloorControls.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorControls.tsx
@@ -55,8 +55,6 @@ interface FloorControlsProps {
   activeAbbrs: AgentAbbr[]
   onToggleAbbr: (abbr: AgentAbbr) => void
 
-  search: string
-  onSearch: (q: string) => void
   onDispatch: () => void
 }
 
@@ -64,7 +62,7 @@ export function FloorControls({
   runningCount, totalCount,
   sidebarOpen, onToggleSidebar, rightOpen, onToggleRight, plain, onTogglePlain,
   sort, onSort, group, onGroup, activeStatus, onToggleStatus, agentChips = DEFAULT_AGENT_CHIPS, activeAbbrs, onToggleAbbr,
-  search, onSearch, onDispatch,
+  onDispatch,
 }: FloorControlsProps) {
   const statusOn = new Set(activeStatus)
   const abbrOn = new Set(activeAbbrs)
@@ -117,15 +115,6 @@ export function FloorControls({
           ))}
         </select>
       </div>
-
-      <div className="fsep" />
-
-      <input
-        className="search"
-        placeholder="search agents, branches, activity…"
-        value={search}
-        onChange={(e) => onSearch(e.target.value)}
-      />
 
       <div className="grow" />
 

--- a/apps/factory/ui/settings/components/mission-control/MissionControlTab.tsx
+++ b/apps/factory/ui/settings/components/mission-control/MissionControlTab.tsx
@@ -16,13 +16,16 @@ interface MissionControlTabProps {
   openDetailTaskId?: string | null
   onDetailTaskConsumed?: () => void
   onThroughputChange?: (tokensPerSec: number) => void
+  /** The single live-feed filter, threaded from App down to UnifiedAgentsPane. */
+  search: string
+  onSearch: (q: string) => void
   githubRepo?: string | null
   watchdogEnabled?: boolean
   watchdogEvents?: WatchdogEventUI[]
   projectRules?: ProjectRule[]
 }
 
-export function MissionControlTab({ tasks, tasksLoading, terminals, unifiedTasks, unifiedTasksLoading, onDispatch, onNavigate, onOpenInBench, openDispatchTrigger, quickSpawnTrigger, openDetailTaskId, onDetailTaskConsumed, onThroughputChange, githubRepo, watchdogEnabled, watchdogEvents, projectRules }: MissionControlTabProps) {
+export function MissionControlTab({ tasks, tasksLoading, terminals, unifiedTasks, unifiedTasksLoading, onDispatch, onNavigate, onOpenInBench, openDispatchTrigger, quickSpawnTrigger, openDetailTaskId, onDetailTaskConsumed, onThroughputChange, search, onSearch, githubRepo, watchdogEnabled, watchdogEvents, projectRules }: MissionControlTabProps) {
   return (
     <UnifiedAgentsPane
       terminals={terminals}
@@ -38,6 +41,8 @@ export function MissionControlTab({ tasks, tasksLoading, terminals, unifiedTasks
       openDetailTaskId={openDetailTaskId}
       onDetailTaskConsumed={onDetailTaskConsumed}
       onThroughputChange={onThroughputChange}
+      search={search}
+      onSearch={onSearch}
       githubRepo={githubRepo}
       watchdogEnabled={watchdogEnabled}
       watchdogEvents={watchdogEvents}

--- a/apps/factory/ui/settings/components/mission-control/TopBar.tsx
+++ b/apps/factory/ui/settings/components/mission-control/TopBar.tsx
@@ -13,6 +13,13 @@ interface TopBarProps {
   onToggleTheme?: () => void
   onOpenSettings?: () => void
   onOpenSearch?: () => void
+  /**
+   * The single live feed filter. When provided, the center becomes a real search
+   * input that filters agents/branches/activity as you type; ⌘K still opens the
+   * command palette (onOpenSearch). Omit both to keep the plain command-hint button.
+   */
+  search?: string
+  onSearch?: (q: string) => void
   throughputTokensPerSec?: number
   watchdogEnabled?: boolean
   onToggleWatchdog?: () => void
@@ -27,6 +34,8 @@ export function TopBar({
   onToggleTheme,
   onOpenSettings,
   onOpenSearch,
+  search,
+  onSearch,
   throughputTokensPerSec = 0,
   watchdogEnabled = false,
   onToggleWatchdog,
@@ -70,11 +79,31 @@ export function TopBar({
         </button>
       </div>
       <div className="sw-topbar-center">
-        <button className="sw-cmd-hint" onClick={onOpenSearch}>
-          <Icon name="search" size={12} />
-          <span>Search or run command…</span>
-          <div className="spacer" />
-        </button>
+        {onSearch ? (
+          <div className="sw-cmd-hint sw-cmd-search">
+            <Icon name="search" size={12} />
+            <input
+              className="sw-cmd-input"
+              placeholder="Search agents, branches, activity…"
+              value={search ?? ''}
+              onChange={(e) => onSearch(e.target.value)}
+            />
+            <button
+              type="button"
+              className="sw-cmd-kbd"
+              title="Open command palette"
+              onClick={onOpenSearch}
+            >
+              ⌘K
+            </button>
+          </div>
+        ) : (
+          <button className="sw-cmd-hint" onClick={onOpenSearch}>
+            <Icon name="search" size={12} />
+            <span>Search or run command…</span>
+            <div className="spacer" />
+          </button>
+        )}
       </div>
       <div className="sw-topbar-right">
         {throughputTokensPerSec > 0 && (

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -495,6 +495,9 @@ interface UnifiedAgentsPaneProps {
   openDetailTaskId?: string | null
   onDetailTaskConsumed?: () => void
   onThroughputChange?: (tokensPerSec: number) => void
+  /** The single live-feed filter, lifted to App so the TopBar search drives it. */
+  search: string
+  onSearch: (q: string) => void
   githubRepo?: string | null
   watchdogEnabled?: boolean
   watchdogEvents?: WatchdogEventUI[]
@@ -521,7 +524,7 @@ function useStableList(items: UnifiedAgent[]): UnifiedAgent[] {
   }, [items])
 }
 
-export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks, unifiedTasksLoading, onDispatch, onNavigate, onOpenInBench, openDispatchTrigger, quickSpawnTrigger, openDetailTaskId, onDetailTaskConsumed, onThroughputChange, githubRepo, watchdogEnabled = false, watchdogEvents = [], projectRules = [] }: UnifiedAgentsPaneProps) {
+export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks, unifiedTasksLoading, onDispatch, onNavigate, onOpenInBench, openDispatchTrigger, quickSpawnTrigger, openDetailTaskId, onDetailTaskConsumed, onThroughputChange, search: floorSearch, onSearch: setFloorSearch, githubRepo, watchdogEnabled = false, watchdogEvents = [], projectRules = [] }: UnifiedAgentsPaneProps) {
   const panelVisible = usePanelVisibility()
   const [newMenuOpen, setNewMenuOpen] = useState(false)
   const [statPopover, setStatPopover] = useState<'shipped' | 'open' | 'running' | 'nextup' | 'files' | null>(null)
@@ -600,7 +603,6 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   const [hostPins, setHostPins] = useState<string[] | null>(floorPrefs0.hostPins)
   const [statusChips, setStatusChips] = useState<StatusChip[]>([])
   const [abbrChips, setAbbrChips] = useState<AgentAbbr[]>([])
-  const [floorSearch, setFloorSearch] = useState('')
   const [savedViews, setSavedViews] = useState<SavedView[]>(() => loadSavedViews())
 
   const activeViewName = useMemo(() => {
@@ -1912,8 +1914,6 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
         onToggleStatus={(chip) => setStatusChips((prev) => (prev.includes(chip) ? prev.filter((c) => c !== chip) : [...prev, chip]))}
         activeAbbrs={abbrChips}
         onToggleAbbr={(ab) => setAbbrChips((prev) => (prev.includes(ab) ? prev.filter((c) => c !== ab) : [...prev, ab]))}
-        search={floorSearch}
-        onSearch={setFloorSearch}
         onDispatch={() => openDispatch(selectedTicketId ? { ticketId: selectedTicketId } : undefined)}
       />
 

--- a/apps/factory/ui/settings/components/mission-control/design-system.css
+++ b/apps/factory/ui/settings/components/mission-control/design-system.css
@@ -193,6 +193,24 @@
 .sw-cmd-hint:hover { border-color: var(--ds-text-dim); color: var(--ds-text-muted); }
 .sw-cmd-hint .spacer { flex: 1; }
 
+/* Active search variant — the TopBar center is the single live feed filter. Keeps the
+   raised-recessed shell of .sw-cmd-hint but hosts a real <input> plus a click-to-open
+   command-palette (⌘K) affordance on the right. */
+.sw-cmd-search { cursor: text; }
+.sw-cmd-search:focus-within { border-color: var(--brand); box-shadow: var(--shadow-inset), 0 0 0 2px var(--brand-ring); }
+.sw-cmd-input {
+  flex: 1; min-width: 0; border: 0; outline: 0; background: transparent;
+  color: var(--ds-text); font-size: 11.5px; font-family: "Geist Mono", monospace;
+}
+.sw-cmd-input::placeholder { color: var(--ds-text-dim); }
+.sw-cmd-kbd {
+  flex: none; padding: 1px 6px; border-radius: var(--r-sm); cursor: pointer;
+  border: 1px solid var(--ds-border-strong); background: var(--ds-bg-panel);
+  color: var(--ds-text-dim); font-size: 10px; font-family: "Geist Mono", monospace;
+  transition: .12s;
+}
+.sw-cmd-kbd:hover { color: var(--ds-text); border-color: var(--ds-text-dim); }
+
 /* Icon button — raised tactile */
 .sw-icon-btn {
   width: 28px; height: 28px; display: grid; place-items: center;


### PR DESCRIPTION
## What

The Factory Floor had **two** search affordances that could drift out of sync:
1. A static command-hint button in the app **TopBar**
2. A separate live-filter `<input>` in **FloorControls** (the Sort/Status/Agent bar)

This collapses them into one. The TopBar center is now the single live feed filter; the duplicate FloorControls search box is gone.

## How

- **Lift state.** `floorSearch` moves from `UnifiedAgentsPane` internal state up to `App`, so the TopBar input and the feed share one source of truth (same pattern already used for `floorThroughput`). It's passed back down to `UnifiedAgentsPane` as a controlled `search`/`onSearch` prop.
- **TopBar** renders a real `<input>` when `onSearch` is provided; the command palette moves to a compact `⌘K` button on the right (still opens the palette on click). Falls back to the plain hint button when no `onSearch` (non-floor tabs).
- **FloorControls** loses its `search`/`onSearch` props and the `<input>` element.
- **CSS**: `.sw-cmd-search` / `.sw-cmd-input` / `.sw-cmd-kbd` keep the raised-recessed TopBar shell around the live input, with a brand focus ring.

## Verification

- `bun test` — **224 mission-control tests pass**
- `bun run build:settings` — settings webview **builds clean** in the real bundler
- The preview harness doesn't mount `UnifiedAgentsPane`, so the live behaviour verifies on install (rebuilt `.vsix` on VSCodium) — screenshot to follow in the batch install.

Part of the Factory Floor redesign (follows #777 checklist, #778 grouping, #779 PR link).