### PR TITLE
feat(sessions): extract created tickets + spawned team from a session

### DIFF
--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -75,6 +75,10 @@ export interface ActiveSession {
   worktree?: DetectedWorktree;
   /** Tracker ticket the session is tied to. */
   ticket?: DetectedTicket;
+  /** Tracker refs the session CREATED (Linear create_issue / gh issue create). */
+  createdTickets?: string[];
+  /** Team name the session SPAWNED via `agents teams create/add`. */
+  spawnedTeam?: string;
   sessionFile?: string;
   startedAtMs?: number;
   status: ActiveStatus;
@@ -345,6 +349,8 @@ function applyState(base: Omit<ActiveSession, 'status'>, state: SessionState | u
     pr: state.pr,
     worktree: state.worktree,
     ticket: state.ticket,
+    createdTickets: state.createdTickets,
+    spawnedTeam: state.spawnedTeam,
   };
 }
 

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -25,7 +25,7 @@ import { getConfigSymlinkVersion } from '../shims.js';
 import { SESSION_AGENTS } from './types.js';
 import { extractSessionTopic } from './prompt.js';
 import { parseAntigravity } from './parse.js';
-import { extractPrUrl, detectWorktree, detectTicket, isPrCreateCommand } from './state.js';
+import { extractPrUrl, detectWorktree, detectTicket, isPrCreateCommand, detectSpawnedTeam, isTicketCreateTool, extractCreatedTicket } from './state.js';
 import { costOfUsage } from '../pricing/index.js';
 import { machineId } from './sync/config.js';
 import { mapBounded } from '../concurrency.js';
@@ -123,6 +123,10 @@ interface ClaudeSessionScan {
   prNumber?: number;
   worktreeSlug?: string;
   ticketId?: string;
+  /** Tracker refs the session CREATED (Linear create_issue / gh issue create). */
+  createdTickets?: string[];
+  /** Team name this session SPAWNED via `agents teams create/add` (not team-of-origin). */
+  spawnedTeam?: string;
 }
 
 /** Lightweight metadata extracted from a Codex JSONL file during incremental scan. */
@@ -143,6 +147,8 @@ interface CodexSessionScan {
   prNumber?: number;
   worktreeSlug?: string;
   ticketId?: string;
+  createdTickets?: string[];
+  spawnedTeam?: string;
 }
 
 const cachedAgentVersions = new Map<SessionAgentId, Promise<string | undefined>>();
@@ -641,6 +647,8 @@ async function readClaudeMeta(
       prNumber: scan.prNumber,
       worktreeSlug: scan.worktreeSlug,
       ticketId: scan.ticketId,
+      createdTickets: scan.createdTickets,
+      spawnedTeam: scan.spawnedTeam,
     };
   } else {
     const stat = safeStatSync(filePath);
@@ -663,6 +671,8 @@ async function readClaudeMeta(
       prNumber: scan.prNumber,
       worktreeSlug: scan.worktreeSlug,
       ticketId: scan.ticketId,
+      createdTickets: scan.createdTickets,
+      spawnedTeam: scan.spawnedTeam,
     };
   }
 
@@ -887,6 +897,8 @@ export async function readCodexMeta(
     prNumber: scan.prNumber,
     worktreeSlug: scan.worktreeSlug,
     ticketId: scan.ticketId,
+    createdTickets: scan.createdTickets,
+    spawnedTeam: scan.spawnedTeam,
   };
   return { meta, content: scan.contentText || '' };
 }
@@ -2028,6 +2040,13 @@ export async function scanClaudeSession(filePath: string): Promise<ClaudeSession
   let prUrl: string | undefined;
   let prNumber: number | undefined;
 
+  // Artifacts the session PRODUCED: tracker refs it created and any team it spawned.
+  // Ticket creation spans two events — a create_issue tool_use, then the tool_result
+  // carrying the new id — so we hold the pending tool_use ids until their result lands.
+  const createdTickets = new Set<string>();
+  const pendingTicketTools = new Set<string>();
+  let spawnedTeam: string | undefined;
+
   try {
     for await (const line of rl) {
       if (!line.trim()) continue;
@@ -2043,6 +2062,35 @@ export async function scanClaudeSession(filePath: string): Promise<ClaudeSession
       // and is the clean structural signal for "was this a team spawn?"
       if (!entrypoint && typeof parsed.entrypoint === 'string') {
         entrypoint = parsed.entrypoint;
+      }
+
+      // Produced-artifact signals, structurally (independent of the PR gate below):
+      //   - a Bash `agents teams create/add` command → the team it spawned
+      //   - a Linear create_issue / `gh issue create` tool_use → its result carries
+      //     the new ticket ref, read from the matching tool_result.
+      if (parsed.type === 'assistant' && Array.isArray(parsed.message?.content)) {
+        for (const b of parsed.message.content) {
+          if (b?.type !== 'tool_use') continue;
+          if (!spawnedTeam && typeof b?.input?.command === 'string') {
+            const team = detectSpawnedTeam(b.input.command);
+            if (team) spawnedTeam = team;
+          }
+          if (typeof b?.id === 'string' && isTicketCreateTool(b?.name, b?.input?.command)) {
+            pendingTicketTools.add(b.id);
+          }
+        }
+      }
+      if (pendingTicketTools.size > 0 && parsed.type === 'user' && Array.isArray(parsed.message?.content)) {
+        for (const b of parsed.message.content) {
+          if (b?.type !== 'tool_result' || typeof b?.tool_use_id !== 'string') continue;
+          if (!pendingTicketTools.has(b.tool_use_id)) continue;
+          pendingTicketTools.delete(b.tool_use_id);
+          const text = typeof b.content === 'string'
+            ? b.content
+            : Array.isArray(b.content) ? b.content.map((c: any) => c?.text || '').join('\n') : '';
+          const t = extractCreatedTicket(text);
+          if (t) createdTickets.add(t);
+        }
       }
 
       // PR signal, structurally: a Bash tool_use whose command is `gh pr create`
@@ -2173,6 +2221,8 @@ export async function scanClaudeSession(filePath: string): Promise<ClaudeSession
     prNumber,
     worktreeSlug: worktree?.slug,
     ticketId: ticket?.id,
+    createdTickets: createdTickets.size > 0 ? [...createdTickets] : undefined,
+    spawnedTeam,
   };
 }
 
@@ -2197,6 +2247,10 @@ async function scanCodexSession(filePath: string): Promise<CodexSessionScan> {
   let sawPrCreate = false;
   let prUrl: string | undefined;
   let prNumber: number | undefined;
+  // Produced artifacts (mirror of the Claude scan): created tracker refs + spawned team.
+  const createdTickets = new Set<string>();
+  const pendingTicketTools = new Set<string>();
+  let spawnedTeam: string | undefined;
 
   try {
     for await (const line of rl) {
@@ -2211,19 +2265,33 @@ async function scanCodexSession(filePath: string): Promise<CodexSessionScan> {
 
       // PR signal, structurally: a Codex `function_call` whose command is
       // `gh pr create`, then the pull URL from a `function_call_output`.
-      if (!prUrl && parsed.type === 'response_item') {
+      if (parsed.type === 'response_item') {
         const p = parsed.payload || {};
-        if (!sawPrCreate && p.type === 'function_call') {
+        if (p.type === 'function_call') {
           let cmd = '';
           try {
             const args = typeof p.arguments === 'string' ? JSON.parse(p.arguments) : (p.arguments || {});
             cmd = String(args.command || args.cmd || '');
           } catch { /* non-JSON args */ }
-          if (isPrCreateCommand(cmd)) sawPrCreate = true;
+          if (!prUrl && !sawPrCreate && isPrCreateCommand(cmd)) sawPrCreate = true;
+          if (!spawnedTeam) {
+            const team = detectSpawnedTeam(cmd);
+            if (team) spawnedTeam = team;
+          }
+          if (typeof p.call_id === 'string' && isTicketCreateTool(p.name, cmd)) {
+            pendingTicketTools.add(p.call_id);
+          }
         }
-        if (sawPrCreate && p.type === 'function_call_output') {
-          const pr = extractPrUrl(String(p.output || ''));
-          if (pr) { prUrl = pr.url; prNumber = pr.number; }
+        if (p.type === 'function_call_output') {
+          if (!prUrl && sawPrCreate) {
+            const pr = extractPrUrl(String(p.output || ''));
+            if (pr) { prUrl = pr.url; prNumber = pr.number; }
+          }
+          if (typeof p.call_id === 'string' && pendingTicketTools.has(p.call_id)) {
+            pendingTicketTools.delete(p.call_id);
+            const t = extractCreatedTicket(String(p.output || ''));
+            if (t) createdTickets.add(t);
+          }
         }
       }
 
@@ -2315,6 +2383,8 @@ async function scanCodexSession(filePath: string): Promise<CodexSessionScan> {
     prNumber,
     worktreeSlug: worktree?.slug,
     ticketId: ticket?.id,
+    createdTickets: createdTickets.size > 0 ? [...createdTickets] : undefined,
+    spawnedTeam,
   };
 }
 

--- a/apps/cli/src/lib/session/state.test.ts
+++ b/apps/cli/src/lib/session/state.test.ts
@@ -8,6 +8,9 @@ import {
   extractPrUrl,
   isPrCreateCommand,
   detectDurableSignals,
+  detectSpawnedTeam,
+  isTicketCreateTool,
+  extractCreatedTicket,
 } from './state.js';
 
 const now = Date.now();
@@ -142,6 +145,48 @@ describe('ticket false positives', () => {
   });
   it('still detects a real letters-only key', () => {
     expect(detectTicket('working on ENG-42')?.id).toBe('ENG-42');
+  });
+});
+
+describe('detectSpawnedTeam', () => {
+  it('extracts the team name from `agents teams create <name>`', () => {
+    expect(detectSpawnedTeam('agents teams create my-feature')).toBe('my-feature');
+  });
+  it('extracts from the `ag` alias and `add` sub-verb, skipping flags', () => {
+    expect(detectSpawnedTeam('ag teams add auth-work claude --name auth --mode edit')).toBe('auth-work');
+  });
+  it('handles a leading `--enable-worktrees` flag before the name', () => {
+    expect(detectSpawnedTeam('agents teams create --enable-worktrees redesign')).toBe('redesign');
+  });
+  it('returns undefined for a non-spawn teams command', () => {
+    expect(detectSpawnedTeam('agents teams list')).toBeUndefined();
+    expect(detectSpawnedTeam('git commit -m "teams create fake"')).toBeUndefined();
+    expect(detectSpawnedTeam(undefined)).toBeUndefined();
+  });
+});
+
+describe('created-ticket detection', () => {
+  it('flags a Linear create_issue MCP tool by name', () => {
+    expect(isTicketCreateTool('mcp__claude_ai_Linear__create_issue', undefined)).toBe(true);
+    expect(isTicketCreateTool('mcp__linear__createIssue', undefined)).toBe(true);
+  });
+  it('flags any shell tool running `gh issue create`', () => {
+    expect(isTicketCreateTool('Bash', 'gh issue create --title x')).toBe(true);
+    expect(isTicketCreateTool('shell', 'gh issue create --title x')).toBe(true);
+  });
+  it('does NOT flag unrelated tools/commands', () => {
+    expect(isTicketCreateTool('Bash', 'gh issue list')).toBe(false);
+    expect(isTicketCreateTool('Read', undefined)).toBe(false);
+  });
+  it('extracts a Linear key from the create result', () => {
+    expect(extractCreatedTicket('Created issue RUSH-1519 (In Progress)')).toBe('RUSH-1519');
+  });
+  it('extracts a #number from a gh issue-create result URL', () => {
+    expect(extractCreatedTicket('https://github.com/phnx-labs/agents-cli/issues/812')).toBe('#812');
+  });
+  it('returns undefined when the result carries no ticket', () => {
+    expect(extractCreatedTicket('done, nothing to report')).toBeUndefined();
+    expect(extractCreatedTicket(undefined)).toBeUndefined();
   });
 });
 

--- a/apps/cli/src/lib/session/state.test.ts
+++ b/apps/cli/src/lib/session/state.test.ts
@@ -136,6 +136,35 @@ describe('PR detection', () => {
   });
 });
 
+describe('detectDurableSignals — produced artifacts', () => {
+  it('correlates a Linear create_issue tool with the created ref in its result', () => {
+    const events: SessionEvent[] = [
+      tool('mcp__claude_ai_Linear__create_issue', { title: 'Fix flaky test' }),
+      toolResult('mcp__claude_ai_Linear__create_issue', 'Created issue RUSH-1519 in Rush'),
+    ];
+    expect(detectDurableSignals(events).createdTickets).toEqual(['RUSH-1519']);
+  });
+  it('captures a gh issue-create ref and a spawned team from shell commands', () => {
+    const events: SessionEvent[] = [
+      tool('Bash', { command: 'agents teams create redesign --enable-worktrees' }, 'agents teams create redesign --enable-worktrees'),
+      tool('Bash', { command: 'gh issue create --title x' }, 'gh issue create --title x'),
+      toolResult('Bash', 'https://github.com/phnx-labs/agents-cli/issues/812'),
+    ];
+    const sig = detectDurableSignals(events);
+    expect(sig.spawnedTeam).toBe('redesign');
+    expect(sig.createdTickets).toEqual(['#812']);
+  });
+  it('leaves artifacts undefined for a session that created nothing', () => {
+    const events: SessionEvent[] = [
+      tool('Bash', { command: 'gh issue list' }, 'gh issue list'),
+      msg('user', 'just browsing'),
+    ];
+    const sig = detectDurableSignals(events);
+    expect(sig.createdTickets).toBeUndefined();
+    expect(sig.spawnedTeam).toBeUndefined();
+  });
+});
+
 describe('ticket false positives', () => {
   it('does NOT treat a regex snippet like [A-Z0-9]-\\d as a ticket', () => {
     expect(detectTicket('the pattern /([A-Z0-9]-\\d)/ matches')).toBeUndefined();

--- a/apps/cli/src/lib/session/state.ts
+++ b/apps/cli/src/lib/session/state.ts
@@ -49,6 +49,10 @@ export interface SessionState {
   pr?: DetectedPr;
   worktree?: DetectedWorktree;
   ticket?: DetectedTicket;
+  /** Tracker refs this session CREATED (Linear create_issue / gh issue create). */
+  createdTickets?: string[];
+  /** Team name this session SPAWNED via `agents teams create/add`. */
+  spawnedTeam?: string;
 }
 
 export interface StateContext {
@@ -287,14 +291,24 @@ export function inferActivity(events: SessionEvent[], ctx: StateContext = {}): S
 }
 
 /**
- * Scan an event slice for the durable signals (PR opened, ticket) that aren't
- * about the cwd. Correlates each `gh pr create` with the nearest following
- * tool_result URL; keeps the last PR found.
+ * Scan an event slice for the durable signals that aren't about the cwd: the PR
+ * opened, the injected ticket, plus the artifacts the session PRODUCED — tracker
+ * refs it created and any team it spawned. Each `gh pr create` / create-issue tool
+ * call is correlated with the nearest following tool_result; the team name comes
+ * straight off the `agents teams create/add` command.
  */
-export function detectDurableSignals(events: SessionEvent[]): { pr?: DetectedPr; ticket?: DetectedTicket } {
+export function detectDurableSignals(events: SessionEvent[]): {
+  pr?: DetectedPr;
+  ticket?: DetectedTicket;
+  createdTickets?: string[];
+  spawnedTeam?: string;
+} {
   let pr: DetectedPr | undefined;
   let sawPrCreate = false;
   let ticket: DetectedTicket | undefined;
+  let sawTicketCreate = false;
+  let spawnedTeam: string | undefined;
+  const createdTickets = new Set<string>();
 
   for (const e of events) {
     // Structural PR signal: a real `gh pr create` tool call, then the pull URL
@@ -304,22 +318,43 @@ export function detectDurableSignals(events: SessionEvent[]): { pr?: DetectedPr;
       const found = extractPrUrl(e.output);
       if (found) { pr = found; sawPrCreate = false; }
     }
+    // Produced artifacts: a team spawn is read off the command; a created ticket
+    // is a create-issue tool call whose following tool_result carries the new ref.
+    if (e.type === 'tool_use') {
+      if (!spawnedTeam) {
+        const team = detectSpawnedTeam(e.command);
+        if (team) spawnedTeam = team;
+      }
+      if (isTicketCreateTool(e.tool, e.command)) sawTicketCreate = true;
+    }
+    if (sawTicketCreate && e.type === 'tool_result') {
+      const t = extractCreatedTicket(e.output);
+      if (t) createdTickets.add(t);
+      sawTicketCreate = false;
+    }
     if (!ticket && e.type === 'message' && e.role === 'user') {
       ticket = detectTicket(e.content);
     }
   }
-  return { pr, ticket };
+  return {
+    pr,
+    ticket,
+    createdTickets: createdTickets.size > 0 ? [...createdTickets] : undefined,
+    spawnedTeam,
+  };
 }
 
 /** Full inference: activity + preview + durable signals + worktree/ticket from ctx. */
 export function inferSessionState(events: SessionEvent[], ctx: StateContext = {}): SessionState {
   const state = inferActivity(events, ctx);
-  const { pr, ticket } = detectDurableSignals(events);
+  const { pr, ticket, createdTickets, spawnedTeam } = detectDurableSignals(events);
   const worktree = detectWorktree(ctx.cwd, ctx.gitBranch);
   return {
     ...state,
     pr: pr ?? state.pr,
     worktree: worktree ?? state.worktree,
     ticket: ticket ?? detectTicket(undefined, ctx.gitBranch) ?? state.ticket,
+    createdTickets,
+    spawnedTeam,
   };
 }

--- a/apps/cli/src/lib/session/state.ts
+++ b/apps/cli/src/lib/session/state.ts
@@ -89,6 +89,16 @@ const PR_URL_RE = /https:\/\/github\.com\/[^\s"'()<>]+\/pull\/(\d+)/;
 const WORKTREE_RE = /\/\.agents\/worktrees\/([^/]+)/;
 /** gh invocations that create/open a PR. */
 const GH_PR_CREATE_RE = /\bgh\s+pr\s+(?:create|new)\b/;
+/** gh invocation that opens an issue — the created number is read from its result. */
+const GH_ISSUE_CREATE_RE = /\bgh\s+issue\s+create\b/;
+/** A created GitHub issue URL (…/issues/123) in tool-result output. */
+const GH_ISSUE_URL_RE = /https:\/\/github\.com\/[^\s"'()<>]+\/issues\/(\d+)/;
+/**
+ * `agents teams create <name>` / `agents teams add <team> …` (also the `ag` alias).
+ * The team NAME is the first bareword after the sub-verb, skipping any flags. This
+ * is the structural signal that a session SPAWNED a team (vs. was spawned by one).
+ */
+const TEAMS_SPAWN_RE = /\bag(?:ents)?\s+teams?\s+(?:create|add)\s+(?:--?[a-z][\w-]*(?:[= ]\S+)?\s+)*([A-Za-z0-9][\w-]*)/;
 
 /** Collapse to a single trimmed line for a one-row preview cell. */
 function oneLine(s: string): string {
@@ -130,6 +140,43 @@ export function extractPrUrl(output?: string): DetectedPr | undefined {
 /** True when a Bash/exec command string is a `gh pr create`. */
 export function isPrCreateCommand(command?: string): boolean {
   return !!command && GH_PR_CREATE_RE.test(command);
+}
+
+/**
+ * The team a session SPAWNED, from an `agents teams create/add <name>` command.
+ * Returns the team name, or undefined if the command isn't a team spawn. Note this
+ * is the opposite of `isTeamOrigin` (which marks sessions spawned BY a team).
+ */
+export function detectSpawnedTeam(command?: string): string | undefined {
+  if (!command) return undefined;
+  const m = command.match(TEAMS_SPAWN_RE);
+  return m ? m[1] : undefined;
+}
+
+/**
+ * True when a tool_use call CREATES a tracker ticket — a Linear MCP `create_issue`
+ * tool, or a Bash `gh issue create`. The created id is then read from the matching
+ * tool_result via {@link extractCreatedTicket}.
+ */
+export function isTicketCreateTool(name?: string, command?: string): boolean {
+  if (typeof name === 'string' && /linear/i.test(name) && /create[_-]?issue/i.test(name)) return true;
+  // Any shell tool (Bash / shell / local_shell) running `gh issue create`.
+  if (!!command && GH_ISSUE_CREATE_RE.test(command)) return true;
+  return false;
+}
+
+/**
+ * Pull a created ticket ref out of a create-issue tool_result. Linear returns a
+ * key like `RUSH-1234`; `gh issue create` returns the issue URL, from which we
+ * take `#<number>`. Returns undefined when neither shape is present.
+ */
+export function extractCreatedTicket(text?: string): string | undefined {
+  if (!text) return undefined;
+  const lin = text.match(TICKET_RE);
+  if (lin && !TICKET_DENYLIST.has(lin[1].split('-')[0])) return lin[1];
+  const gh = text.match(GH_ISSUE_URL_RE);
+  if (gh) return `#${gh[1]}`;
+  return undefined;
 }
 
 /** Does an assistant message read as a question directed at the user? */

--- a/apps/cli/src/lib/session/types.ts
+++ b/apps/cli/src/lib/session/types.ts
@@ -94,6 +94,17 @@ export interface SessionMeta {
   /** Tracker ticket ref (e.g. RUSH-1234) from the prompt or branch. */
   ticketId?: string;
   /**
+   * Tracker refs the session CREATED during its run — Linear `create_issue` MCP
+   * calls or `gh issue create` shell commands — read from the tool result. Distinct
+   * from `ticketId` (the injected/worked-on ticket from the prompt or branch).
+   */
+  createdTickets?: string[];
+  /**
+   * Team name this session SPAWNED via `agents teams create/add`. The inverse of
+   * `isTeamOrigin` (which marks sessions spawned BY a team).
+   */
+  spawnedTeam?: string;
+  /**
    * True when the session was spawned programmatically (SDK entrypoint) rather
    * than by a human at the Claude CLI. Captured at scan time from the JSONL
    * `entrypoint` field ('sdk-cli' for team spawns, 'cli' for real sessions).


### PR DESCRIPTION
## What

Session scanning surfaces the *injected* ticket (from prompt + branch) today. This adds the two artifacts a session **produces**, so the Factory Floor can show them on an agent card (follow-up PR):

- **`createdTickets`** — tracker refs the agent **created**. Correlated across the create-issue tool_use and its tool_result:
  - Linear `create_issue` MCP calls (result carries e.g. `RUSH-1519`)
  - `gh issue create` shell commands (result URL → `#number`)
  - Distinct from `ticketId` (the injected/worked-on ticket).
- **`spawnedTeam`** — the team name from an `agents teams create/add <name>` command. The inverse of `isTeamOrigin` (which marks sessions spawned *by* a team).

## How

- Three pure helpers in `state.ts`: `detectSpawnedTeam`, `isTicketCreateTool`, `extractCreatedTicket` — reusing the existing `TICKET_RE` + denylist.
- Wired symmetrically into **both** scanners: the Claude JSONL scan (`tool_use` → `tool_result`, correlated by `tool_use_id`) and the Codex scan (`function_call` → `function_call_output`, correlated by `call_id`).
- Threaded onto `SessionMeta` at all three scan→meta sites (Claude indexed, Claude fallback, Codex).

## Verification

- **13 new unit tests** in `state.test.ts` (team-name extraction incl. flags/aliases, Linear + gh-issue detection, result parsing, negative cases) — all pass.
- Full session module **typechecks clean** (`tsc --noEmit`, 0 errors).
- `discover.test.ts` passes (7/7).

Part of the Factory Floor redesign — this is the source-of-truth layer; the webview chips that consume `createdTickets`/`spawnedTeam` land in the follow-up PR.