### PR TITLE
feat(factory): show created-ticket + spawned-team chips on the card

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+### Added
+
+- **Factory Floor redesign — the card now shows the agent's outputs at a glance.**
+  A cohesive pass over the live feed:
+  - **Checklist expanded by default** on each card (still collapsible), with the
+    current step highlighted so progress reads without a click.
+  - **Feed grouped by project by default** (NEEDS YOU stays pinned above the groups).
+  - **One-click PR link** — the `PR #N` pill is now a real link to the pull request.
+  - **One unified search** — the TopBar center is the single live-feed filter; the
+    duplicate search box in the Floor controls bar is gone (⌘K still opens the palette).
+  - **Artifact chips** — cards surface the tracker refs the agent *created* (Linear
+    `create_issue` / `gh issue create`) and any team it *spawned* (`agents teams
+    create/add`), distinct from the injected/worked-on ticket. Backed by new session
+    scanning (`createdTickets` / `spawnedTeam` on both the indexed scan and live
+    session state).
+
 ### Fixed
 
 - **Editor "Send to Agent" (slash-command + keyboard shortcut) silently did nothing.** The markdown editor webview may call VS Code's one-shot `acquireVsCodeApi()` only once per load, but `App.tsx` consumed it at startup while the Tiptap `KeyboardShortcuts` (`Mod-Shift-a` / `Mod-Shift-i`) and `SlashCommands` ("Send to Agent" / "Ask Agent") extensions each re-called `acquireVsCodeApi()` on use — a second acquisition that throws / yields `undefined`, so their `if (vscode)` guard fell through and the `postMessage` never fired. All four call sites plus `App.tsx` now share a single cached handle via a new `ui/editor/vscodeApi.ts` (`getVsCodeApi()`), acquired at most once. Regression test (`vscodeApi.test.ts`) simulates the single-acquire contract. Source: `apps/factory/ui/editor/vscodeApi.ts`, `App.tsx`, `extensions/KeyboardShortcuts.ts`, `extensions/SlashCommands.ts`.

--- a/apps/factory/src/core/remoteSessions.test.ts
+++ b/apps/factory/src/core/remoteSessions.test.ts
@@ -201,6 +201,26 @@ describe('normalizeActiveSession', () => {
     }
   });
 
+  test('normalizes createdTickets to a string[] and spawnedTeam to a string', () => {
+    const base = ACTIVE.find((r) => r.context === 'terminal')!;
+    // Well-formed input passes through.
+    const ok = normalizeActiveSession(
+      { ...base, createdTickets: ['RUSH-1519', 'RUSH-1520'], spawnedTeam: 'redesign' } as unknown as RawActiveSession,
+      'this-mac', FETCHED_AT,
+    );
+    expect(ok.createdTickets).toEqual(['RUSH-1519', 'RUSH-1520']);
+    expect(ok.spawnedTeam).toBe('redesign');
+    // Malformed input (object where an array/string is expected) must not leak through
+    // as a non-array/non-string — these render as React children on the card.
+    const bad = normalizeActiveSession(
+      { ...base, createdTickets: { id: 'x' }, spawnedTeam: { name: 'foo' } } as unknown as RawActiveSession,
+      'this-mac', FETCHED_AT,
+    );
+    expect(Array.isArray(bad.createdTickets)).toBe(true);
+    expect(bad.createdTickets).toEqual([]);
+    expect(typeof bad.spawnedTeam).toBe('string');
+  });
+
   test('input_required becomes waiting + waitingForInput', () => {
     const terminal = ACTIVE.find((r) => r.status === 'input_required')!;
     const s = normalizeActiveSession(terminal, 'this-mac', FETCHED_AT);

--- a/apps/factory/src/core/remoteSessions.ts
+++ b/apps/factory/src/core/remoteSessions.ts
@@ -112,6 +112,10 @@ export interface RemoteSession {
   lastResponse: string;
   prUrl: string | null;
   ticket: string | null;
+  /** Tracker refs this session CREATED (Linear create_issue / gh issue create). */
+  createdTickets: string[];
+  /** Team name this session SPAWNED via `agents teams create/add`; '' when none. */
+  spawnedTeam: string;
   branch: string;
   /** The `<slug>` under `.agents/worktrees/<slug>/` — the strong per-session
    *  disambiguator (two agents in sibling worktrees of one repo differ only here).
@@ -234,6 +238,9 @@ export interface RawActiveSession {
   pr?: { url?: string; number?: number } | null;
   worktree?: { slug?: string; path?: string; branch?: string } | null;
   ticket?: string | { id?: string; url?: string } | null;
+  /** Tracker refs the session CREATED + team it SPAWNED, from the CLI session scan. */
+  createdTickets?: string[];
+  spawnedTeam?: string;
   /** Normalized device id the CLI attributes this session to (machineId() form,
    *  e.g. 'zion', 'yosemite-s0'). Present on every row of a fanned-out
    *  `sessions --active --json` — the load-bearing signal for which physical
@@ -363,6 +370,8 @@ export function normalizeActiveSession(
     // fallback for older shapes.
     prUrl: asStr(raw.prUrl) || asStr(raw.pr?.url) || null,
     ticket: ticketMatch,
+    createdTickets: Array.isArray(raw.createdTickets) ? raw.createdTickets.map((t: unknown) => String(t)) : [],
+    spawnedTeam: asStr(raw.spawnedTeam),
     // The remote branch lives at worktree.branch; the top-level `branch` is usually
     // absent, which is why remote branch was always empty.
     branch: asStr(raw.branch) || asStr(raw.worktree?.branch),
@@ -409,6 +418,8 @@ export interface RawRecentSession {
   gitBranch?: string;
   worktreeSlug?: string;
   ticketId?: string;
+  createdTickets?: string[];
+  spawnedTeam?: string;
   prUrl?: string;
   prNumber?: number;
   topic?: string;
@@ -441,6 +452,8 @@ export function normalizeRecentSession(
     lastResponse: '',
     prUrl: asStr(raw.prUrl) || null,
     ticket: asStr(raw.ticketId) || null,
+    createdTickets: Array.isArray(raw.createdTickets) ? raw.createdTickets.map((t: unknown) => String(t)) : [],
+    spawnedTeam: asStr(raw.spawnedTeam),
     branch: asStr(raw.gitBranch),
     worktreeSlug,
     worktreePath: worktreeSlug ? cwd : '',

--- a/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
@@ -118,6 +118,20 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
         </span>
       </div>
       <div className="resp">{destructive ? <span className="q">{a.resp}</span> : a.resp}</div>
+      {!plain && (a.spawnedTeam || (a.createdTickets?.length ?? 0) > 0) && (
+        <div className="artifacts" onClick={(e) => e.stopPropagation()}>
+          {a.spawnedTeam && (
+            <span className="artifact team" title={`Spawned a team: ${a.spawnedTeam}`}>
+              <Icon name="grip" size={10} /> team · {a.spawnedTeam}
+            </span>
+          )}
+          {(a.createdTickets ?? []).map((t) => (
+            <span key={t} className="artifact ticket" title={`Created ticket ${t}`}>
+              <Icon name="plus" size={10} /> {t}
+            </span>
+          ))}
+        </div>
+      )}
       {!plain && a.todos.length > 0 && <CardChecklist todos={a.todos} />}
       {showSummary && <div className="summary">{taskLine}</div>}
       {showNowline && (

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -210,7 +210,7 @@
    distinct from the injected/worked-on ticket. Cyan-tinted, sits below the response. */
 .swarmify-root .fitem .artifacts { display: flex; flex-wrap: wrap; gap: 5px; margin: 0 0 8px; }
 .swarmify-root .fitem .artifact { display: inline-flex; align-items: center; gap: 4px; font-size: 10px; font-weight: 600; padding: 1px 7px 1px 6px; border-radius: 999px; background: var(--status-running-bg); color: var(--status-running); border: 1px solid transparent; font-variant-numeric: tabular-nums; }
-.swarmify-root .fitem .artifact.team { background: var(--brand-50, rgba(163,230,53,0.12)); color: var(--brand-700, #65a30d); }
+.swarmify-root .fitem .artifact.team { background: var(--brand-ring); color: var(--brand); }
 .swarmify-root .fitem .summary { font-size: 12px; color: var(--ds-text-muted); line-height: 1.4; margin: 0 0 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .swarmify-root .fitem .nowline { font-family: "Geist Mono", monospace; font-size: 11px; color: var(--ds-text-muted); display: flex; align-items: center; gap: 8px; }
 .swarmify-root .fitem .nowline .v { color: var(--brand-600); }

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -206,6 +206,11 @@
 .swarmify-root .fitem .when { margin-left: auto; color: var(--ds-text-dim); font-size: 11px; display: flex; align-items: center; gap: 8px; }
 .swarmify-root .fitem .resp { font-size: 12.5px; color: var(--ds-text); line-height: 1.5; margin: 2px 0 8px; border-left: 2px solid var(--ds-border); padding-left: 10px; }
 .swarmify-root .fitem .resp .q { color: var(--status-pending); font-weight: 600; }
+/* Produced-artifact chips: what the agent SPAWNED (a team) or CREATED (tickets),
+   distinct from the injected/worked-on ticket. Cyan-tinted, sits below the response. */
+.swarmify-root .fitem .artifacts { display: flex; flex-wrap: wrap; gap: 5px; margin: 0 0 8px; }
+.swarmify-root .fitem .artifact { display: inline-flex; align-items: center; gap: 4px; font-size: 10px; font-weight: 600; padding: 1px 7px 1px 6px; border-radius: 999px; background: var(--status-running-bg); color: var(--status-running); border: 1px solid transparent; font-variant-numeric: tabular-nums; }
+.swarmify-root .fitem .artifact.team { background: var(--brand-50, rgba(163,230,53,0.12)); color: var(--brand-700, #65a30d); }
 .swarmify-root .fitem .summary { font-size: 12px; color: var(--ds-text-muted); line-height: 1.4; margin: 0 0 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .swarmify-root .fitem .nowline { font-family: "Geist Mono", monospace; font-size: 11px; color: var(--ds-text-muted); display: flex; align-items: center; gap: 8px; }
 .swarmify-root .fitem .nowline .v { color: var(--brand-600); }

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
@@ -217,6 +217,8 @@ describe('toFloorAgentFromRemote', () => {
       lastResponse: 'Merge the green PR?',
       prUrl: 'https://github.com/o/r/pull/50',
       ticket: 'RUSH-812',
+      createdTickets: ['RUSH-901'],
+      spawnedTeam: 'rate-limiter',
       branch: 'feat-x',
       sinceMs: 42_000,
       startedAtMs: NOW - 42_000,
@@ -240,6 +242,8 @@ describe('toFloorAgentFromRemote', () => {
     expect(a.needs).toBe(true)
     expect(a.pr).toBe('#50')
     expect(a.ticket).toBe('RUSH-812')
+    expect(a.createdTickets).toEqual(['RUSH-901'])
+    expect(a.spawnedTeam).toBe('rate-limiter')
     expect(a.question?.kind).toBe('confirm')
     // remote carries only session-start; heartbeat anchors to it until backend adds a stamp.
     expect(a.lastActivityMs).toBe(NOW - 42_000)

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
@@ -43,6 +43,8 @@ export interface UnifiedAgentLike {
   prUrl?: string | null
   ci?: CiStatus | null
   linearIssue?: string | null
+  createdTickets?: string[]
+  spawnedTeam?: string
   terminal?: {
     id?: string
     cwd?: string | null
@@ -77,6 +79,10 @@ export interface RemoteSessionLike {
   prUrl: string | null
   ci?: CiStatus | null
   ticket: string | null
+  /** Tracker refs this session CREATED (from the CLI session scan). */
+  createdTickets?: string[]
+  /** Team name this session SPAWNED (from the CLI session scan). */
+  spawnedTeam?: string
   branch: string
   /** `<slug>` under `.agents/worktrees/<slug>/` — disambiguates sibling worktree
    *  sessions and gives the card a task label when topic/preview are empty. */
@@ -275,6 +281,8 @@ export function toFloorAgentFromUnified(
     prUrl: u.prUrl ?? null,
     ci,
     ticket: u.linearIssue ?? null,
+    createdTickets: u.createdTickets ?? [],
+    spawnedTeam: u.spawnedTeam || undefined,
     branch: u.terminal?.branch ?? u.agent?.branch ?? '',
     worktreeSlug: worktreeSlugOf(u.terminal?.cwd ?? u.agent?.cwd),
     worktreePath: worktreeSlugOf(u.terminal?.cwd ?? u.agent?.cwd) ? (u.terminal?.cwd ?? u.agent?.cwd ?? '') : '',
@@ -343,6 +351,8 @@ export function toFloorAgentFromRemote(r: RemoteSessionLike, pinned: Set<string>
     prUrl: r.prUrl ?? null,
     ci,
     ticket: r.ticket,
+    createdTickets: r.createdTickets ?? [],
+    spawnedTeam: r.spawnedTeam || undefined,
     branch: r.branch,
     worktreeSlug: r.worktreeSlug ?? worktreeSlugOf(r.cwd),
     worktreePath: r.worktreePath ?? (worktreeSlugOf(r.cwd) ? r.cwd : ''),

--- a/apps/factory/ui/settings/components/mission-control/floorModel.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.ts
@@ -132,7 +132,9 @@ export interface FloorAgent {
   pr: string | null      // "#142" when a PR is open
   prUrl: string | null   // full PR URL (https://github.com/…/pull/N) — the real external link to open
   ci: CiStatus           // CI state of the open PR; null when no PR / unknown
-  ticket: string | null  // "RUSH-812" when linked
+  ticket: string | null  // "RUSH-812" when linked (injected/worked-on ticket from prompt or branch)
+  createdTickets?: string[] // tracker refs this session CREATED (Linear create_issue / gh issue create); [] / undefined when none
+  spawnedTeam?: string   // team name this session SPAWNED via `agents teams create/add`; undefined when none
   branch: string
   worktreeSlug: string   // "<slug>" under .agents/worktrees/; '' when not a worktree. Disambiguates sibling sessions + labels the card when topic/preview are empty.
   worktreePath: string   // absolute worktree path, for the Reveal-worktree action; '' when not a worktree

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -102,6 +102,7 @@ const running: FloorAgent[] = [
     pane: '%42', viewingIn: 'Codium tab 3',
     verb: 'Porting', target: 'the group-by control into the shared model',
     summary: 'Collapsed the three ticket surfaces into one list; now porting the group-by control into the shared model.',
+    createdTickets: ['RUSH-1519', 'RUSH-1520'],
     todos: [
       { content: 'Merge ticket surfaces', status: 'completed' },
       { content: 'Port group-by control', status: 'in_progress' },
@@ -120,6 +121,7 @@ const running: FloorAgent[] = [
     tok: 33, since: '8s', lastActivityMs: Date.now() - 8000,
     verb: 'Mapping', target: 'the two half-wired dispatch paths',
     summary: 'Mapping the two half-wired dispatch paths; will propose a single reply handler before touching code.',
+    spawnedTeam: 'dispatch-refactor',
   }),
 ]
 


### PR DESCRIPTION
## What

The card surfaced the *injected* ticket + the PR, but nothing the agent **produced**. This adds an **artifact-chips row** (below the response, above the checklist) showing:
- **`+ <ticket>`** — tracker refs the session **created** (Linear `create_issue` / `gh issue create`)
- **`⋮⋮ team · <name>`** — the team it **spawned** via `agents teams create/add`

These are the two outputs asked for alongside the one-click PR link (#779) — "whether the agent spun up a team" and "tickets the agent created, not the injected one".

## How (full data path)

The data originates in the CLI session scan (#785 — `createdTickets` / `spawnedTeam` on `SessionMeta` + live `SessionState`) and flows to the webview:

1. **remoteSessions (extension core)** — carry both fields on `RemoteSession` + the two `Raw*` inputs, so `agents sessions --json` surfaces them.
2. **floorAdapter** — forward onto `RemoteSessionLike` + `UnifiedAgentLike`, map in both builders.
3. **floorModel** — `createdTickets` + `spawnedTeam` on `FloorAgent`.
4. **FeedItem** — render the chip row; cyan/lime tinted, distinct from PR/CI pills.

## Verification

- **Rendered in the preview harness** — chips appear on the two fixture cards (created tickets `RUSH-1519`/`RUSH-1520`; team `dispatch-refactor`). Screenshot: `/Users/muqsit/.agents/.cache/browser/sessions/misty-aurora-otter-c0aa5993/1783458032019.jpg`
- **224 mission-control + 56 remoteSessions tests pass**; settings webview builds clean; touched files typecheck clean.

Stacked on **#785** (the CLI extraction). Merge #785 first.