### PR TITLE
test(tmux): de-flake pane-died-hook tests (poll for pane settle, not fixed sleep)

### DIFF
--- a/apps/cli/src/lib/tmux/session.test.ts
+++ b/apps/cli/src/lib/tmux/session.test.ts
@@ -281,12 +281,12 @@ describe.skipIf(skipReason)('tmux session lifecycle', () => {
     let panes = (await runTmux({ socket, args: ['list-panes', '-t', 'guardsplit', '-F', '#{pane_id}'] })).stdout.trim().split('\n');
     expect(panes).toHaveLength(2);
     await runTmux({ socket, args: ['send-keys', '-t', splitPaneId, 'exit', 'Enter'] });
-    await wait(400);
 
     // Session is still alive, the split is gone (no lingering dead husk), and the
-    // agent pane is still live — i.e. the user was NOT kicked out.
+    // agent pane is still live — i.e. the user was NOT kicked out. Poll for the
+    // kill-pane to land rather than racing a fixed sleep.
+    panes = await waitForPanes('guardsplit', socket, 1);
     expect(await hasSession('guardsplit', socket)).toBe(true);
-    panes = (await runTmux({ socket, args: ['list-panes', '-t', 'guardsplit', '-F', '#{pane_id}:#{pane_dead}'] })).stdout.trim().split('\n');
     expect(panes).toHaveLength(1);
     expect(panes[0]).toBe(`${agentPane}:0`);
   });
@@ -330,9 +330,8 @@ describe.skipIf(skipReason)('tmux session lifecycle', () => {
     const splitPaneId = await splitPane({ name: 'ag-reco-old', direction: 'v', cmd: '/bin/sh', socket });
     await wait(200);
     await runTmux({ socket, args: ['send-keys', '-t', splitPaneId, 'exit', 'Enter'] });
-    await wait(400);
     expect(await hasSession('ag-reco-old', socket)).toBe(true);
-    const panes = (await runTmux({ socket, args: ['list-panes', '-t', 'ag-reco-old', '-F', '#{pane_id}:#{pane_dead}'] })).stdout.trim().split('\n');
+    const panes = await waitForPanes('ag-reco-old', socket, 1);
     expect(panes).toHaveLength(1);
     expect(panes[0]).toBe(`${agentPane}:0`);
   });
@@ -354,4 +353,30 @@ describe.skipIf(skipReason)('tmux session lifecycle', () => {
 
 function wait(ms: number): Promise<void> {
   return new Promise(r => setTimeout(r, ms));
+}
+
+/**
+ * Poll `list-panes` until the session has exactly `expected` panes, or the
+ * timeout elapses. Returns the last observed `#{pane_id}:#{pane_dead}` rows.
+ *
+ * A pane exiting is asynchronous end-to-end: the shell processes `exit`, tmux
+ * fires the `pane-died` hook, and the hook's `kill-pane` then removes the dead
+ * pane — a chain that can exceed any fixed sleep under CI load, leaving the
+ * dead pane transiently listed (the `expected 1, got 2` flake). Polling settles
+ * as soon as the count is right and only fails if it genuinely never converges.
+ */
+async function waitForPanes(
+  name: string,
+  socket: string,
+  expected: number,
+  timeoutMs = 5000,
+): Promise<string[]> {
+  const deadline = Date.now() + timeoutMs;
+  let panes: string[] = [];
+  for (;;) {
+    panes = (await runTmux({ socket, args: ['list-panes', '-t', name, '-F', '#{pane_id}:#{pane_dead}'] }))
+      .stdout.trim().split('\n').filter(Boolean);
+    if (panes.length === expected || Date.now() >= deadline) return panes;
+    await wait(50);
+  }
 }


### PR DESCRIPTION
## The flake

`src/lib/tmux/session.test.ts` intermittently fails the required `test` check with:
```
AssertionError: expected [ '%0:0', '%1:1' ] to have a length of 1 but got 2
```
Two tests hit it — `pane-guarded pane-died hook: exiting a user split…` and `reconcileSessionHooks retrofits…`. This gated **unrelated** PRs (it blocked #775 across 2 CI runs — a *different* one of the two failed each run, then a later run passed all clean).

## Root cause

Not socket leakage — the suite already isolates a temp tmux socket per test (`beforeEach`). It's a **fixed-timeout race within the test**: each sends `exit` to a split `/bin/sh`, then `await wait(400)` and immediately asserts the session is back to one pane. A pane exit is async end-to-end — shell processes `exit` → tmux fires the `pane-died` hook → the hook's `kill-pane` removes the dead pane. Under CI load that chain can exceed 400ms, so `list-panes` transiently returns both the live agent pane and the not-yet-reaped dead split (`%0:0` + `%1:1`).

## Fix

Replace the fixed sleep + immediate list with `waitForPanes(name, socket, expected)`, which polls `list-panes` until the count settles (up to 5s, every 50ms). It passes the instant `kill-pane` lands and only fails if the count genuinely never converges — no more timing dependence. Test-only; no source or behavior change.

## Verification

- `tsc --noEmit` clean.
- Ran `session.test.ts` **5×** locally: **23/23 each**, 0 failures.