### PR TITLE
feat(factory): match the mockup — labels, icon rail, detail artifacts, Foreman FAB

### DIFF
--- a/apps/factory/ui/settings/components/foreman/ForemanOrb.tsx
+++ b/apps/factory/ui/settings/components/foreman/ForemanOrb.tsx
@@ -224,8 +224,8 @@ export function ForemanOrb({ vscode }: ForemanOrbProps) {
       className="foreman-orb-root"
       style={{
         position: 'fixed',
-        bottom: 76,
-        right: 48,
+        bottom: 16,
+        right: 16,
         zIndex: 50,
         display: 'flex',
         flexDirection: 'column',
@@ -425,7 +425,9 @@ function orbTitle(state: VisualState): string {
 
 function OrbBlob({ state }: { state: VisualState }) {
   const big = state === 'listening' || state === 'speaking' || state === 'connecting'
-  const size = big ? 88 : 64
+  // Corner-FAB sizing (mockup): a compact resting orb that still grows while active,
+  // so Foreman reads as a tucked affordance rather than dominating the floor.
+  const size = big ? 56 : 40
   return (
     <svg
       width={size}

--- a/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
@@ -61,7 +61,9 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
   // while the session stays identifiable. Only when the id differs from the shown name.
   const agentSlug = agentIdFromPrefix(a.abbr) ?? a.abbr.toLowerCase()
   const shortSid = a.sessionId ? a.sessionId.replace(/-/g, '').slice(0, 8) : ''
-  const sid = shortSid && a.name !== shortSid ? `${agentSlug}·${shortSid}` : ''
+  // Suppress the chip when the name is the fallback hash label ("claude-596c4c07")
+  // that already carries the same id — only show it beside a genuine human label.
+  const sid = shortSid && !a.name.endsWith(shortSid) ? `${agentSlug}·${shortSid}` : ''
   const destructive = a.question?.kind === 'destructive'
   const attn = a.phase === 'failed' ? 'fail' : stalled ? 'stall' : a.needs ? 'attn' : ''
 

--- a/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
@@ -56,6 +56,12 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
   const meta = plain
     ? a.project
     : `${a.project} · ${a.hostLabel ?? a.host}${wt ? ` · ${wt}` : ''}${a.ticket ? ` · ${a.ticket}` : ''}${filesLabel}${paneLabel}${viewingLabel}`
+  // Compact provenance chip next to the name: "<agent>·<short session id>", e.g.
+  // "claude·4de7b016" — so a human label ("terminal-race-fix") reads as the title
+  // while the session stays identifiable. Only when the id differs from the shown name.
+  const agentSlug = agentIdFromPrefix(a.abbr) ?? a.abbr.toLowerCase()
+  const shortSid = a.sessionId ? a.sessionId.replace(/-/g, '').slice(0, 8) : ''
+  const sid = shortSid && a.name !== shortSid ? `${agentSlug}·${shortSid}` : ''
   const destructive = a.question?.kind === 'destructive'
   const attn = a.phase === 'failed' ? 'fail' : stalled ? 'stall' : a.needs ? 'attn' : ''
 
@@ -104,6 +110,7 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
         <span className={`dot ${a.phase}`} />
         <AgentAvatar id={agentIdFromPrefix(a.abbr) ?? a.abbr.toLowerCase()} size={20} title={a.abbr} />
         <span className="who">{a.name}</span>
+        {!plain && sid && <span className="sid" title={a.sessionId}>{sid}</span>}
         <span className="path">{meta}</span>
         <span className="when">
           {marker}

--- a/apps/factory/ui/settings/components/mission-control/FloorRail.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorRail.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { Icon } from './icons'
+import type { FloorAgent, FloorTicket } from './floorModel'
+
+// Collapsed left nav: a narrow column of icon buttons with count/needs badges, the
+// mockup's default rail. Each button routes via the same onScope the full FloorSidebar
+// uses ('' = all, '__needs', '__queue', a project name); the » button expands back to
+// the full sidebar. Kept intentionally minimal — the rail is a summary, not the roster.
+
+interface FloorRailProps {
+  agents: FloorAgent[]
+  tickets: FloorTicket[]
+  /** Current scope: null = All agents; '__needs'/'__queue' or a project name otherwise. */
+  scope: string | null
+  onScope: (value: string) => void
+  /** Expand to the full text sidebar. */
+  onExpand: () => void
+}
+
+type RailButton = {
+  key: string
+  scope: string
+  icon: string
+  label: string
+  badge?: number
+  /** Amber (attention) badge vs neutral count badge. */
+  attn?: boolean
+}
+
+export function FloorRail({ agents, tickets, scope, onScope, onExpand }: FloorRailProps) {
+  const needs = agents.filter((a) => a.needs).length
+  const buttons: RailButton[] = [
+    { key: 'all', scope: '', icon: 'radar', label: 'All agents', badge: agents.length },
+    { key: 'needs', scope: '__needs', icon: 'alert', label: 'Needs you', badge: needs || undefined, attn: true },
+    { key: 'queue', scope: '__queue', icon: 'inbox', label: 'Backlog', badge: tickets.length || undefined },
+    { key: 'projects', scope: '__projects', icon: 'folder', label: 'Projects' },
+    { key: 'hosts', scope: '__hosts', icon: 'terminal', label: 'Hosts' },
+  ]
+  const isOn = (b: RailButton) =>
+    b.scope === '' ? scope === null || scope === '' : scope === b.scope
+
+  return (
+    <div className="floor-rail">
+      <div className="floor-rail-col">
+        {buttons.map((b) => (
+          <button
+            key={b.key}
+            type="button"
+            className={`rail-ib${isOn(b) ? ' on' : ''}`}
+            title={b.label}
+            aria-label={b.label}
+            // Projects/Hosts need the full roster — expand into the sidebar; the
+            // feed scopes route in place.
+            onClick={() => (b.scope === '__projects' || b.scope === '__hosts' ? onExpand() : onScope(b.scope))}
+          >
+            <Icon name={b.icon} size={17} />
+            {b.badge != null && b.badge > 0 && (
+              <span className={`rail-bdg${b.attn ? ' attn' : ''}`}>{b.badge}</span>
+            )}
+          </button>
+        ))}
+        <div className="rail-gap" />
+        <button
+          type="button"
+          className="rail-ib rail-expand"
+          title="Expand sidebar"
+          aria-label="Expand sidebar"
+          onClick={onExpand}
+        >
+          <Icon name="chevR" size={16} />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/factory/ui/settings/components/mission-control/FloorSidebar.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorSidebar.tsx
@@ -44,9 +44,11 @@ interface FloorSidebarProps {
   projects?: ManagedProject[]
   /** Open the Projects management pane (gear + "+N more" row). */
   onManageProjects?: () => void
+  /** Collapse back to the icon rail. */
+  onCollapse?: () => void
 }
 
-export function FloorSidebar({ agents, tickets, projFilter, hostFilter = null, offlineHosts = [], devices = [], hostPins = [], onToggleHostPin, onReorderHostPins, onScope, localHost, projects = [], onManageProjects }: FloorSidebarProps) {
+export function FloorSidebar({ agents, tickets, projFilter, hostFilter = null, offlineHosts = [], devices = [], hostPins = [], onToggleHostPin, onReorderHostPins, onScope, localHost, projects = [], onManageProjects, onCollapse }: FloorSidebarProps) {
   const byProj: Record<string, number> = {}
   const projWait: Record<string, number> = {}
   for (const a of agents) {
@@ -106,7 +108,14 @@ export function FloorSidebar({ agents, tickets, projFilter, hostFilter = null, o
 
   return (
     <div className="sidebar">
-      <div className="sb-sec">SMART</div>
+      <div className="sb-sec" style={{ display: 'flex', alignItems: 'center' }}>
+        <span>SMART</span>
+        {onCollapse && (
+          <button type="button" className="sb-collapse" title="Collapse to rail" aria-label="Collapse sidebar" onClick={onCollapse}>
+            <Icon name="chevL" size={13} />
+          </button>
+        )}
+      </div>
       <div className={`sb-item ${projFilter === null ? 'on' : ''}`} onClick={() => onScope('')}>
         <span>All agents</span>
         <span className="c">{agents.length}</span>

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -22,6 +22,7 @@ import {
 } from './dispatch'
 import { FloorControls, type StatusChip } from './FloorControls'
 import { FloorSidebar } from './FloorSidebar'
+import { FloorRail } from './FloorRail'
 import { BacklogCenter } from './BacklogCenter'
 import { TicketDetail } from './TicketDetail'
 import { HostDetail } from './HostDetail'
@@ -601,6 +602,8 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   const [floorGroup, setFloorGroup] = useState<FloorGroupBy | 'none'>('project')
   const [plain, setPlain] = useState(floorPrefs0.plain)
   const [sidebarOpen, setSidebarOpen] = useState(floorPrefs0.sidebar)
+  // Collapsed = the icon rail (mockup default); expanded = the full text sidebar.
+  const [railCollapsed, setRailCollapsed] = useState(true)
   const [rightOpen, setRightOpen] = useState(floorPrefs0.right)
   const [pinned, setPinned] = useState<Set<string>>(() => new Set(floorPrefs0.pinned))
   // Ordered pinned HOSTS names (null = default: pin the local machine).
@@ -1935,7 +1938,15 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
       />
 
       <div className="page" style={{ flex: 1, minHeight: 0, height: 'auto' }}>
-        {sidebarOpen && (
+        {sidebarOpen && (railCollapsed ? (
+          <FloorRail
+            agents={floorAgents}
+            tickets={floorTickets}
+            scope={projFilter}
+            onScope={onScope}
+            onExpand={() => setRailCollapsed(false)}
+          />
+        ) : (
           <FloorSidebar
             agents={floorAgents}
             tickets={floorTickets}
@@ -1951,6 +1962,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
             onToggleHostPin={toggleHostPin}
             onReorderHostPins={reorderHostPins}
             onScope={onScope}
+            onCollapse={() => setRailCollapsed(true)}
             onSelectHost={onSelectHost}
             selectedHost={center === 'host' ? selectedHostId : null}
             hosts={hostRoster}
@@ -1958,7 +1970,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
             projects={managedProjects}
             onManageProjects={() => { setCenter('projects'); setRightOpen(true) }}
           />
-        )}
+        ))}
         <div className="feed-col">{centerContent}</div>
         {rightOpen && <div className="detail-col">{rightContent}</div>}
       </div>

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -173,11 +173,15 @@ function buildUnifiedList(terminals: TerminalInfo[], tasks: TaskSummary[]): Unif
     const isActive = isTerminalActive(t, now)
     const files: string[] = []
     if (t.recentFiles) files.push(...t.recentFiles.slice(0, 5))
+    // Prefer a human label (manual > auto) so a card reads "terminal-race-fix" rather
+    // than "claude-596c4c07"; the hash still identifies the session via the sid chip.
+    const humanLabel = (t.label || t.autoLabel || '').trim()
     items.push({
       kind: 'terminal',
       id: `term-${t.id}`,
       agentType: t.agentType,
-      displayName: `${t.agentType}-${chunk}`,
+      sessionId: t.sessionId ?? undefined,
+      displayName: humanLabel || `${t.agentType}-${chunk}`,
       activity: t.currentActivity || t.label || (justSpawned ? 'Starting...' : t.status === 'idle' ? 'idle' : t.role ?? 'terminal'),
       active: isActive,
       duration: t.firstMessageTimestamp ? relTime(t.firstMessageTimestamp) : '',
@@ -1809,9 +1813,22 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               onAttach={onAttachScreenshot}
             />
           ))
-        : [...groupAgents([...runningFeed, ...doneFeed], floorGroup).entries()].map(([k, arr]) => (
+        : [...groupAgents([...runningFeed, ...doneFeed], floorGroup).entries()].map(([k, arr]) => {
+            // When grouped by project, enrich the header: "N agents" + a Linear project
+            // link pill (mockup: "agents-cli · 8 agents · RUSH · Agents CLI").
+            const linkedProject = floorGroup === 'project'
+              ? managedProjects.find((p) => p.name === k)?.linearProjectName
+              : undefined
+            const countLabel = floorGroup === 'project'
+              ? `${arr.length} agent${arr.length === 1 ? '' : 's'}`
+              : `${arr.length}`
+            return (
             <React.Fragment key={k}>
-              <div className="feed-sec">{k} · {arr.length}<span className="ln" /></div>
+              <div className="feed-sec">
+                {k} · {countLabel}
+                {linkedProject && <span className="proj-lk">{linkedProject}</span>}
+                <span className="ln" />
+              </div>
               {arr.map((a) => (
                 <FeedItem
                   key={a.id}
@@ -1825,7 +1842,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
                 />
               ))}
             </React.Fragment>
-          ))}
+          )})}
 
       {floorGroup === 'none' && doneFeed.length > 0 && (
         <>

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -1646,6 +1646,22 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
             <div className="dhead" style={{ flexDirection: 'column', alignItems: 'flex-start', gap: 4 }}>
               <div className="title">{a.project} / {a.name}</div>
               <div className="sub">host <b>{a.hostLabel ?? a.host}</b>{(a.worktreeSlug || a.branch) ? ` · ${a.worktreeSlug || a.branch}` : ''} · {a.phase}{a.tok ? ` · ${a.tok} tok/s` : ''}{a.ticket ? ` · ${a.ticket}` : ''}</div>
+              {/* Artifacts row: the agent's outputs at a glance — the PR (click-through),
+                  CI, the team it spawned, and tickets it created. Mirrors the card chips. */}
+              {(a.prUrl || a.ci || a.spawnedTeam || (a.createdTickets?.length ?? 0) > 0) && (
+                <div className="arts">
+                  {a.prUrl && (
+                    <ExtLink href={a.prUrl} className="art pr" style={{ textDecoration: 'none' }}>
+                      <Icon name="chevR" size={10} /> PR {a.pr ?? ''}
+                    </ExtLink>
+                  )}
+                  {a.ci && <span className={`art ci ${a.ci}`}>CI {a.ci}</span>}
+                  {a.spawnedTeam && <span className="art team"><Icon name="grip" size={10} /> team · {a.spawnedTeam}</span>}
+                  {(a.createdTickets ?? []).map((t) => (
+                    <span key={t} className="art tk"><Icon name="plus" size={10} /> {t}</span>
+                  ))}
+                </div>
+              )}
               {/* Actions: give a selected agent something to DO (issue: clicking a card
                   offered nothing). Focus opens the session's terminal — local via the
                   live vscode terminal, remote via an ssh + tmux-attach terminal.

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -195,6 +195,8 @@
 .swarmify-root .decide .qt { font-size: 13.5px; font-weight: 600; margin-bottom: 10px; }
 .swarmify-root .feed-sec { font-size: 11px; font-weight: 800; letter-spacing: .05em; color: var(--ds-text-dim); margin: 18px 4px 8px; display: flex; align-items: center; gap: 8px; }
 .swarmify-root .feed-sec.attn { color: var(--status-pending); }
+/* Linear project link pill in a project group header (mockup: "RUSH · Agents CLI"). */
+.swarmify-root .feed-sec .proj-lk { font-family: "Geist Mono", monospace; font-size: 10.5px; font-weight: 600; letter-spacing: 0; color: #4a8dff; border: 1px solid rgba(74,141,255,0.32); border-radius: 20px; padding: 2px 9px; text-transform: none; }
 .swarmify-root .feed-sec .ln { flex: 1; height: 1px; background: var(--ds-border-subtle); }
 .swarmify-root .fitem { background: var(--ds-bg-panel); border: 1px solid var(--ds-border-subtle); border-radius: var(--r-lg); padding: 12px 14px; margin-bottom: 10px; cursor: pointer; }
 .swarmify-root .fitem.selsel { box-shadow: 0 0 0 2px var(--brand); }
@@ -202,6 +204,7 @@
 .swarmify-root .fitem.fail { border-color: var(--status-failed); box-shadow: 0 0 0 1px var(--status-failed-bg); }
 .swarmify-root .fitem .head { display: flex; align-items: center; gap: 9px; margin-bottom: 8px; }
 .swarmify-root .fitem .who { font-weight: 700; font-size: 13px; }
+.swarmify-root .fitem .sid { font-family: "Geist Mono", monospace; font-size: 10.5px; color: var(--ds-text-faint); background: var(--ds-bg-recessed); border: 1px solid var(--ds-border); border-radius: 5px; padding: 1px 6px; flex: none; }
 .swarmify-root .fitem .path { color: var(--ds-text-dim); font-size: 11px; }
 .swarmify-root .fitem .when { margin-left: auto; color: var(--ds-text-dim); font-size: 11px; display: flex; align-items: center; gap: 8px; }
 .swarmify-root .fitem .resp { font-size: 12.5px; color: var(--ds-text); line-height: 1.5; margin: 2px 0 8px; border-left: 2px solid var(--ds-border); padding-left: 10px; }

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -189,6 +189,16 @@
 .swarmify-root .feed { width: 100%; max-width: 820px; padding: 14px 18px 60px; }
 .swarmify-root .detail-col { flex: 0 0 430px; border-left: 1px solid var(--ds-border); overflow: auto; background: var(--ds-bg-panel); }
 .swarmify-root .detail-empty { height: 100%; display: flex; align-items: center; justify-content: center; color: var(--ds-text-faint); font-size: 12px; padding: 20px; text-align: center; }
+/* Detail-pane artifacts row: the selected agent's outputs (PR / CI / team / tickets),
+   color-coded per the mockup — blue PR, green CI, violet team, amber created tickets. */
+.swarmify-root .detail-col .arts { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 11px; }
+.swarmify-root .detail-col .art { font-family: "Geist Mono", monospace; font-size: 11px; border-radius: 7px; padding: 4px 9px; display: inline-flex; gap: 6px; align-items: center; border: 1px solid var(--ds-border); background: var(--ds-bg-recessed); color: var(--ds-text-muted); }
+.swarmify-root .detail-col .art.pr { color: #4a8dff; border-color: rgba(74,141,255,0.35); }
+.swarmify-root .detail-col .art.ci.passed { color: var(--status-running); border-color: rgba(62,207,142,0.3); }
+.swarmify-root .detail-col .art.ci.failed { color: var(--status-failed); border-color: var(--status-failed); }
+.swarmify-root .detail-col .art.ci.running { color: var(--status-pending); border-color: rgba(245,179,1,0.3); }
+.swarmify-root .detail-col .art.team { color: #b98cff; border-color: rgba(185,140,255,0.35); }
+.swarmify-root .detail-col .art.tk { color: var(--brand); border-color: var(--brand-ring); }
 /* decision block at top of the right detail when an agent needs you */
 .swarmify-root .decide { background: var(--status-pending-bg); border: 1px solid var(--status-pending); border-radius: var(--r-lg); padding: 12px 14px; margin-bottom: 14px; }
 .swarmify-root .decide .ql { font-size: 10px; font-weight: 800; letter-spacing: .05em; color: var(--status-pending); margin-bottom: 6px; }

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -270,6 +270,19 @@
 /* page with optional project sidebar */
 .swarmify-root .page { display: flex; height: 100%; min-height: 0; }
 .swarmify-root .sidebar { width: 210px; flex: 0 0 210px; border-right: 1px solid var(--ds-border); overflow: auto; padding: 8px 0; background: var(--ds-bg); }
+/* Icon rail — collapsed left nav (mockup default): a column of 46px rounded icon
+   buttons with count/needs badges, active button lime-outlined. */
+.swarmify-root .floor-rail { flex: 0 0 68px; width: 68px; border-right: 1px solid var(--ds-border); background: var(--ds-bg); padding: 16px 0; overflow: visible; }
+.swarmify-root .floor-rail-col { display: flex; flex-direction: column; gap: 10px; align-items: center; }
+.swarmify-root .rail-ib { position: relative; width: 46px; height: 46px; border-radius: 12px; background: var(--ds-bg-recessed); border: 1px solid var(--ds-border); display: flex; align-items: center; justify-content: center; color: var(--ds-text-dim); cursor: pointer; transition: .12s; }
+.swarmify-root .rail-ib:hover { color: var(--ds-text); border-color: var(--ds-text-dim); }
+.swarmify-root .rail-ib.on { border-color: var(--brand); color: var(--brand); box-shadow: 0 0 0 1px var(--brand-ring); }
+.swarmify-root .rail-ib .rail-bdg { position: absolute; top: -6px; right: -6px; min-width: 16px; height: 16px; padding: 0 4px; border-radius: 9px; background: var(--ds-bg-panel); border: 1px solid var(--ds-border); color: var(--ds-text-dim); font-family: "Geist Mono", monospace; font-size: 9.5px; font-weight: 700; display: flex; align-items: center; justify-content: center; }
+.swarmify-root .rail-ib .rail-bdg.attn { background: var(--status-pending); border-color: var(--status-pending); color: #1a1a1a; }
+.swarmify-root .floor-rail .rail-gap { height: 6px; }
+.swarmify-root .rail-ib.rail-expand { color: var(--ds-text-faint); }
+.swarmify-root .sb-sec .sb-collapse { margin-left: auto; background: none; border: 0; padding: 0 2px; cursor: pointer; color: var(--ds-text-faint); display: inline-flex; align-items: center; }
+.swarmify-root .sb-sec .sb-collapse:hover { color: var(--ds-text); }
 .swarmify-root .sb-sec { font-size: 10px; font-weight: 800; letter-spacing: .05em; color: var(--ds-text-faint); padding: 12px 14px 4px; }
 .swarmify-root .sb-item { display: flex; align-items: center; gap: 8px; padding: 6px 14px; font-size: 12.5px; cursor: pointer; color: var(--ds-text-muted); }
 .swarmify-root .sb-item:hover { background: var(--ds-bg-panel); }

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
@@ -34,6 +34,8 @@ export interface UnifiedAgentLike {
   id: string
   agentType: string
   displayName: string
+  /** Underlying agent session id (for the card's provenance chip). */
+  sessionId?: string | null
   activity: string
   active: boolean
   timestamp: string
@@ -258,6 +260,7 @@ export function toFloorAgentFromUnified(
   return {
     id: u.id,
     host: 'this-mac',
+    sessionId: u.sessionId ?? undefined,
     // In-window tab agents are always terminal-attached.
     context: 'terminal',
     // Display the machine's real device name (e.g. 'zion') instead of the

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -12,6 +12,7 @@ import '../index.css'
 
 import { Icon } from '../components/mission-control/icons'
 import { FloorSidebar } from '../components/mission-control/FloorSidebar'
+import { FloorRail } from '../components/mission-control/FloorRail'
 import { FeedItem, TicketStrip } from '../components/mission-control/FeedItem'
 import { SavedViews } from '../components/mission-control/SavedViewsBar'
 import { DispatchPanel } from '../components/mission-control/DispatchPanel'
@@ -273,7 +274,16 @@ function Sidebar() {
     { name: 'yosemite-s0', online: true, agents: 2 },
     { name: 'yosemite-s1', online: false, agents: 1 },
   ]
-  return (
+  const [collapsed, setCollapsed] = useState(true)
+  return collapsed ? (
+    <FloorRail
+      agents={sidebarAgents}
+      tickets={tickets}
+      scope={null}
+      onScope={noop}
+      onExpand={() => setCollapsed(false)}
+    />
+  ) : (
     <FloorSidebar
       agents={sidebarAgents}
       tickets={tickets}
@@ -283,6 +293,7 @@ function Sidebar() {
       hostPins={pins}
       projects={managedProjects}
       onManageProjects={noop}
+      onCollapse={() => setCollapsed(true)}
       onToggleHostPin={(n) => setPins((p) => (p.includes(n) ? p.filter((x) => x !== n) : [...p, n]))}
       onReorderHostPins={setPins}
       onScope={noop}

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -97,7 +97,7 @@ const askAgent = agent({
 // RUNNING lane.
 const running: FloorAgent[] = [
   agent({
-    id: 'r1', abbr: 'CX', name: 'bench-saved-views', project: 'rush', phase: 'running',
+    id: 'r1', abbr: 'CX', name: 'bench-saved-views', sessionId: '4de7b016-2c1a-4f9e-b2d1-7a3c9e10ab55', project: 'rush', phase: 'running',
     pr: '#148', ci: 'running', tok: 41, files: 9, since: '3s', lastActivityMs: Date.now() - 3000,
     pane: '%42', viewingIn: 'Codium tab 3',
     verb: 'Porting', target: 'the group-by control into the shared model',


### PR DESCRIPTION
## What — the Factory Floor to match the approved mockup

The prior release added card/feed features but kept the old shell. This closes the
visual gap to the mockup (`~/Downloads/factory-redesign.html`) across four pieces:

### 1. Card polish
- **Human label first** — cards read `terminal-race-fix`, not `claude-596c4c07` (uses `label`/`autoLabel` on `TerminalDetail`).
- **Session-id chip** — compact `<agent>·<8hex>` (`claude·4de7b016`) beside the label; suppressed when the name IS the fallback hash (no double-hash — prix-cloud catch fixed).
- **Project group headers** — `N agents` + a Linear project link pill.

### 2. Icon rail
- New `FloorRail`: 68px column of 46px rounded icon buttons + count/needs badges (All · Needs · Backlog · Projects · Hosts), active lime-outlined — the mockup's default nav. `»` expands to the full sidebar (which gains a `«` collapse).

### 3. Detail-pane artifacts row
- The selected agent's outputs as color-coded chips (blue PR click-through, CI, violet spawned-team, lime created-tickets), under the detail header.

### 4. Foreman corner FAB
- Shrunk the voice orb (resting 64→40, active 88→56) and tucked it to bottom-right 16/16, so it reads as a corner FAB, not a centerpiece. Audio/state logic untouched.

## Before / After (preview harness, dark)

- **Card** — `zion:/Users/muqsit/Downloads/pr800-BEFORE-card.jpg` → `.../pr800-AFTER-card.jpg`
- **Left nav** — `zion:/Users/muqsit/Downloads/rail-BEFORE-sidebar.jpg` → `.../rail-AFTER-iconrail.jpg`

(Rail + card verified in harness; detail-artifacts + FAB verify on the 0.9.285 install — they live in UnifiedAgentsPane/App which the harness doesn't mount. Drag the images into this PR to inline-render.)

## Verified

- 224 mission-control (+ 242 ui) tests pass; settings webview builds clean; touched files typecheck.
- prix-cloud's double-hash finding fixed.

Rolls into a **0.9.285** release after merge.