### PR TITLE
fix(session): index Kimi session message counts from wire.jsonl

### DIFF
--- a/apps/cli/src/lib/session/__tests__/parse-kimi.test.ts
+++ b/apps/cli/src/lib/session/__tests__/parse-kimi.test.ts
@@ -45,6 +45,58 @@ function makeKimiSession(wireContent: string): string {
   return path.join(sessionDir, 'state.json');
 }
 
+describe('readKimiMeta message + token counting', () => {
+  test('counts context.append_message events and sums usage.record tokens from wire.jsonl', () => {
+    const jsonl = [
+      { type: 'context.append_message', message: { role: 'user', content: [{ type: 'text', text: 'Q1' }] }, time: 1 },
+      { type: 'usage.record', usage: { inputOther: 100, output: 50, inputCacheRead: 200, inputCacheCreation: 10 }, time: 2 },
+      { type: 'context.append_message', message: { role: 'assistant', content: [{ type: 'text', text: 'A1' }] }, time: 3 },
+      { type: 'usage.record', usage: { inputOther: 5, output: 5 }, time: 4 },
+      // Non-counted events must be ignored:
+      { type: 'context.append_loop_event', event: { type: 'content.part', part: { type: 'text', text: 'x' } }, time: 5 },
+      { type: 'turn.prompt', time: 6 },
+    ].map(o => JSON.stringify(o)).join('\n');
+
+    const statePath = makeKimiSession(jsonl);
+    const result = readKimiMeta(statePath);
+    expect(result).not.toBeNull();
+    // 2 append_message events -> messageCount 2
+    expect(result!.meta.messageCount).toBe(2);
+    // (100+50+200+10) + (5+5) = 370
+    expect(result!.meta.tokenCount).toBe(370);
+  });
+
+  test('tokenCount is undefined (not zero) when there are no usage records', () => {
+    const jsonl = [
+      { type: 'context.append_message', message: { role: 'user', content: [{ type: 'text', text: 'hi' }] }, time: 1 },
+    ].map(o => JSON.stringify(o)).join('\n');
+
+    const statePath = makeKimiSession(jsonl);
+    const result = readKimiMeta(statePath);
+    expect(result!.meta.messageCount).toBe(1);
+    expect(result!.meta.tokenCount).toBeUndefined();
+  });
+
+  test('skips malformed lines without aborting the count', () => {
+    const jsonl = [
+      JSON.stringify({ type: 'context.append_message', message: { role: 'user', content: [] }, time: 1 }),
+      '{ this is not valid json',
+      JSON.stringify({ type: 'context.append_message', message: { role: 'assistant', content: [] }, time: 2 }),
+    ].join('\n');
+
+    const statePath = makeKimiSession(jsonl);
+    const result = readKimiMeta(statePath);
+    expect(result!.meta.messageCount).toBe(2);
+  });
+
+  test('messageCount is 0 when wire.jsonl is absent', () => {
+    const statePath = makeKimiStateNoTimestamps(); // no agents/main/wire.jsonl
+    const result = readKimiMeta(statePath);
+    expect(result!.meta.messageCount).toBe(0);
+    expect(result!.meta.tokenCount).toBeUndefined();
+  });
+});
+
 describe('parseKimi', () => {
   test('maps user append_message to message event', () => {
     const statePath = makeKimiSession(JSON.stringify({

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -2769,7 +2769,10 @@ export function readKimiMeta(filePath: string): { meta: SessionMeta; content: st
   return { meta, content: lastPrompt || '' };
 }
 
-/** Parse Kimi's wire.jsonl to extract message count and token usage. */
+/** Parse Kimi's wire.jsonl to extract message count and token usage.
+ * TODO: optimize to stream (like scanClaudeSession) to avoid loading large files into memory.
+ * For now, synchronous readFileSync matches the pattern of reading state.json and is acceptable
+ * since session dirs are usually fresh in FS cache during incremental scans. */
 function parseKimiWireMetrics(sessionDir: string): { messageCount: number; tokenCount: number } {
   const wirePath = path.join(sessionDir, 'agents', 'main', 'wire.jsonl');
   let messageCount = 0;

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -2751,6 +2751,9 @@ export function readKimiMeta(filePath: string): { meta: SessionMeta; content: st
     }
   }
 
+  // Parse wire.jsonl to extract message count and token usage
+  const { messageCount, tokenCount } = parseKimiWireMetrics(sessionDir);
+
   const meta: SessionMeta = {
     id: sessionId,
     shortId,
@@ -2759,9 +2762,45 @@ export function readKimiMeta(filePath: string): { meta: SessionMeta; content: st
     project,
     filePath,
     topic,
+    messageCount,
+    tokenCount: tokenCount > 0 ? tokenCount : undefined,
   };
 
   return { meta, content: lastPrompt || '' };
+}
+
+/** Parse Kimi's wire.jsonl to extract message count and token usage. */
+function parseKimiWireMetrics(sessionDir: string): { messageCount: number; tokenCount: number } {
+  const wirePath = path.join(sessionDir, 'agents', 'main', 'wire.jsonl');
+  let messageCount = 0;
+  let tokenCount = 0;
+
+  if (!fs.existsSync(wirePath)) {
+    return { messageCount: 0, tokenCount: 0 };
+  }
+
+  try {
+    const lines = fs.readFileSync(wirePath, 'utf-8').split('\n');
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const event = JSON.parse(line);
+        if (event.type === 'context.append_message') {
+          messageCount++;
+        } else if (event.type === 'usage.record' && event.usage) {
+          // Kimi usage structure: inputOther + output + inputCacheRead + inputCacheCreation
+          const u = event.usage;
+          tokenCount += (u.inputOther || 0) + (u.output || 0) + (u.inputCacheRead || 0) + (u.inputCacheCreation || 0);
+        }
+      } catch {
+        // Malformed line, skip
+      }
+    }
+  } catch {
+    // If wire.jsonl can't be read, return 0s (graceful degradation)
+  }
+
+  return { messageCount, tokenCount };
 }
 
 /** Parse a time filter string (relative like '7d' or ISO timestamp) into epoch milliseconds. */


### PR DESCRIPTION
## Problem

Kimi sessions show `message_count=NULL` in the database despite having 29+ messages in their `wire.jsonl` file. This breaks Factory Floor session cards and `agents sessions --active` context display.

## Root Cause

**Cross-agent indexing gap:** While Claude, Codex, Droid, Rush, and other agents extract message/token counts during discovery, Kimi's `wire.jsonl` was never scanned.

- `readKimiMeta()` only parsed `state.json` (metadata)
- Never read `agents/main/wire.jsonl` (actual conversation)
- `messageCount` and `tokenCount` fields remained NULL
- Database insertion stored NULL, making Kimi sessions incomplete

## Evidence

**Database state before fix:**
```
sqlite3 ~/.agents/.history/sessions/sessions.db
> SELECT id, message_count, token_count FROM sessions 
  WHERE id = 'session_a35c65a1-96bf-42dc-ac80-a065e3a786e9';

session_a35c65a1-96bf-42dc-ac80-a065e3a786e9 | (null) | (null)
```

**Actual data in wire.jsonl:**
```
29 × context.append_message events
63 × usage.record events with token counts
= 580 KB of conversation data
```

**Code gap (discover.ts:2714-2765):**
```typescript
// readKimiMeta() only reads state.json:
const state = JSON.parse(fs.readFileSync(filePath, 'utf-8'));  // state.json only
// ...
const meta: SessionMeta = {
  id, shortId, agent, timestamp, project, filePath, topic,
  // ^^^ NO messageCount or tokenCount populated
};
```

## Solution

Add `parseKimiWireMetrics()` to extract counts from `wire.jsonl`:

1. Locate `agents/main/wire.jsonl` in session directory
2. Count `context.append_message` events (= message count)
3. Sum token usage from `usage.record` events:
   - `inputOther + output + inputCacheRead + inputCacheCreation`
4. Return counts to `readKimiMeta()` for database insertion

## Verification

✓ Kimi session a35c65a1 now correctly indexes:
  - 29 messages
  - Token usage extracted from 63 usage.record events

✓ Follows same pattern as other agents (Claude, Codex, Droid, Rush)
✓ Graceful degradation if wire.jsonl missing (returns 0, not error)
✓ No TypeScript errors

## Impact

- Factory Floor: Kimi session cards now show message context
- `agents sessions --active`: Kimi sessions now display message counts
- Cross-agent consistency: All agents now properly indexed