### PR TITLE
feat(factory): clean pill filter bar (match the mockup)

### DIFF
--- a/apps/factory/ui/settings/components/mission-control/FloorControls.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorControls.tsx
@@ -29,8 +29,6 @@ const GROUP_OPTS: { value: FloorGroupBy | 'none'; label: string }[] = [
 const SVG = { fill: 'none', stroke: 'currentColor', strokeWidth: 1.4 } as const
 
 interface FloorControlsProps {
-  runningCount: number
-  totalCount: number
   /** Count of agents that need you — shown as the ⚑ flag pill. */
   needsCount?: number
 
@@ -51,7 +49,7 @@ interface FloorControlsProps {
 }
 
 export function FloorControls({
-  runningCount, totalCount, needsCount = 0,
+  needsCount = 0,
   sidebarOpen, onToggleSidebar, rightOpen, onToggleRight, plain, onTogglePlain,
   sort, onSort, group, onGroup,
   onDispatch,

--- a/apps/factory/ui/settings/components/mission-control/FloorControls.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorControls.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Icon } from './icons'
-import type { AgentAbbr, FloorSort, FloorGroupBy } from './floorModel'
+import type { FloorSort, FloorGroupBy } from './floorModel'
 
 // Single Floor filter bar (Sort · Status · Agent · search · stats · toggles · Dispatch).
 // The old duplicate ".top" header (second FACTORY logo + theme toggle) was removed —
@@ -15,8 +15,6 @@ const SORT_OPTS: { value: FloorSort; label: string }[] = [
   { value: 'tok', label: 'tok/s' },
   { value: 'name', label: 'Name' },
 ]
-
-const DEFAULT_AGENT_CHIPS: AgentAbbr[] = ['CC', 'CX', 'GX']
 
 // Group the live feed by an axis; 'none' keeps the default phase sections. Same axes
 // as the Backlog's group control (BacklogCenter GROUP_OPTS) so the two bars match.
@@ -33,6 +31,8 @@ const SVG = { fill: 'none', stroke: 'currentColor', strokeWidth: 1.4 } as const
 interface FloorControlsProps {
   runningCount: number
   totalCount: number
+  /** Count of agents that need you — shown as the ⚑ flag pill. */
+  needsCount?: number
 
   sidebarOpen: boolean
   onToggleSidebar: () => void
@@ -46,83 +46,52 @@ interface FloorControlsProps {
   /** How the live feed is grouped ('none' = default phase sections). */
   group: FloorGroupBy | 'none'
   onGroup: (g: FloorGroupBy | 'none') => void
-  /** Which status chips are active. */
-  activeStatus: StatusChip[]
-  onToggleStatus: (chip: StatusChip) => void
-  /** Which agent-type chips to show (defaults to CC/CX/GX like the prototype). */
-  agentChips?: AgentAbbr[]
-  /** Which agent-type chips are active. */
-  activeAbbrs: AgentAbbr[]
-  onToggleAbbr: (abbr: AgentAbbr) => void
 
   onDispatch: () => void
 }
 
 export function FloorControls({
-  runningCount, totalCount,
+  runningCount, totalCount, needsCount = 0,
   sidebarOpen, onToggleSidebar, rightOpen, onToggleRight, plain, onTogglePlain,
-  sort, onSort, group, onGroup, activeStatus, onToggleStatus, agentChips = DEFAULT_AGENT_CHIPS, activeAbbrs, onToggleAbbr,
+  sort, onSort, group, onGroup,
   onDispatch,
 }: FloorControlsProps) {
-  const statusOn = new Set(activeStatus)
-  const abbrOn = new Set(activeAbbrs)
+  const groupLabel = (GROUP_OPTS.find((o) => o.value === group) ?? GROUP_OPTS[0]).label
+  const sortLabel = (SORT_OPTS.find((o) => o.value === sort) ?? SORT_OPTS[0]).label
 
+  // Clean pill bar (mockup): the ad-hoc Status/Agent chips and the running tally are
+  // gone — filtering lives in saved views + search. What remains reads as calm pills:
+  // Group ▾ · Sort ▾ · ⚑needs, then the panel toggles + Dispatch.
   return (
-    <div className="fbar">
-      <div className="fgroup">
-        <span className="fgroup-label">Sort</span>
-        <select className="sel" value={sort} onChange={(e) => onSort(e.target.value as FloorSort)}>
-          {SORT_OPTS.map((o) => (
-            <option key={o.value} value={o.value}>{o.label}</option>
-          ))}
-        </select>
-      </div>
+    <div className="fbar clean">
+      <div className="grow" />
 
-      <div className="fsep" />
-
-      <div className="fgroup">
-        <span className="fgroup-label">Status</span>
-        <span className={`chip needs ${statusOn.has('needs') ? 'on' : ''}`} onClick={() => onToggleStatus('needs')}>
-          <Icon name="alert" size={11} /> Needs you
-        </span>
-        <span className={`chip ${statusOn.has('running') ? 'on' : ''}`} onClick={() => onToggleStatus('running')}>
-          <span className="dot running" /> Running
-        </span>
-        <span className={`chip ${statusOn.has('idle') ? 'on' : ''}`} onClick={() => onToggleStatus('idle')}>
-          <span className="dot idle" /> Idle
-        </span>
-        <span className={`chip ${statusOn.has('failed') ? 'on' : ''}`} onClick={() => onToggleStatus('failed')}>
-          <span className="dot failed" /> Failed
-        </span>
-      </div>
-
-      <div className="fsep" />
-
-      <div className="fgroup">
-        <span className="fgroup-label">Agent</span>
-        {agentChips.map((ab) => (
-          <span key={ab} className={`chip ${abbrOn.has(ab) ? 'on' : ''}`} onClick={() => onToggleAbbr(ab)}>{ab}</span>
-        ))}
-      </div>
-
-      <div className="fsep" />
-
-      <div className="fgroup">
-        <span className="fgroup-label">Group</span>
-        <select className="sel" value={group} onChange={(e) => onGroup(e.target.value as FloorGroupBy | 'none')}>
+      <label className="fpill fpill-sel" title="Group the feed">
+        Group: <b>{groupLabel}</b>
+        <select value={group} onChange={(e) => onGroup(e.target.value as FloorGroupBy | 'none')}>
           {GROUP_OPTS.map((o) => (
             <option key={o.value} value={o.value}>{o.label}</option>
           ))}
         </select>
-      </div>
+      </label>
 
-      <div className="grow" />
+      <label className="fpill fpill-sel" title="Sort the feed">
+        <b>{sortLabel}</b>
+        <select value={sort} onChange={(e) => onSort(e.target.value as FloorSort)}>
+          {SORT_OPTS.map((o) => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
+      </label>
 
-      <div className="stat"><span className="dot running" /><b>{runningCount}</b>/<span>{totalCount}</span> running</div>
-      <button className="themebtn" onClick={onTogglePlain}>Plain language: {plain ? 'on' : 'off'}</button>
+      {needsCount > 0 && (
+        <span className="fpill fpill-flag" title={`${needsCount} need you`}><Icon name="alert" size={11} /> {needsCount}</span>
+      )}
+
+      <button className="iconbtn plainbtn" title={`Plain language: ${plain ? 'on' : 'off'}`} onClick={onTogglePlain}>Aa</button>
       <button
         className={`iconbtn ${sidebarOpen ? 'on' : ''}`}
-        title="Show / hide projects sidebar"
+        title="Show / hide the left rail"
         onClick={onToggleSidebar}
       >
         <svg width="16" height="16" viewBox="0 0 16 16" {...SVG}>

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -1936,6 +1936,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
       <FloorControls
         runningCount={floorRunning}
         totalCount={floorAgents.length}
+        needsCount={needsAgents.length}
         sidebarOpen={sidebarOpen}
         onToggleSidebar={() => setSidebarOpen((o) => !o)}
         rightOpen={rightOpen}
@@ -1946,10 +1947,6 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
         onSort={setFloorSort}
         group={floorGroup}
         onGroup={setFloorGroup}
-        activeStatus={statusChips}
-        onToggleStatus={(chip) => setStatusChips((prev) => (prev.includes(chip) ? prev.filter((c) => c !== chip) : [...prev, chip]))}
-        activeAbbrs={abbrChips}
-        onToggleAbbr={(ab) => setAbbrChips((prev) => (prev.includes(ab) ? prev.filter((c) => c !== ab) : [...prev, ab]))}
         onDispatch={() => openDispatch(selectedTicketId ? { ticketId: selectedTicketId } : undefined)}
       />
 

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -1934,8 +1934,6 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   return (
     <div className="sw-floor-dashboard" style={{ padding: 0, overflow: 'hidden' }}>
       <FloorControls
-        runningCount={floorRunning}
-        totalCount={floorAgents.length}
         needsCount={needsAgents.length}
         sidebarOpen={sidebarOpen}
         onToggleSidebar={() => setSidebarOpen((o) => !o)}

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -69,6 +69,15 @@
 
 /* ---- filter bar (grouped, never wraps — overflow-x scrolls at narrow widths) ---- */
 .swarmify-root .fbar { display: flex; align-items: center; gap: 10px; padding: 8px 16px; background: var(--ds-bg); border-bottom: 1px solid var(--ds-border-subtle); flex-wrap: nowrap; overflow-x: auto; scrollbar-width: thin; }
+/* Clean pill bar (mockup): calm rounded pills instead of the old chip clutter. */
+.swarmify-root .fbar.clean { gap: 8px; }
+.swarmify-root .fbar.clean .grow { flex: 1; }
+.swarmify-root .fpill { position: relative; display: inline-flex; align-items: center; gap: 6px; flex: 0 0 auto; font-family: "Geist Mono", monospace; font-size: 12px; color: var(--ds-text-muted); background: var(--ds-bg-recessed); border: 1px solid var(--ds-border); border-radius: 20px; padding: 6px 12px; cursor: pointer; }
+.swarmify-root .fpill:hover { border-color: var(--ds-text-dim); color: var(--ds-text); }
+.swarmify-root .fpill b { color: var(--ds-text); font-weight: 700; }
+.swarmify-root .fpill-sel select { position: absolute; inset: 0; width: 100%; height: 100%; opacity: 0; cursor: pointer; }
+.swarmify-root .fpill-flag { cursor: default; color: var(--status-pending); border-color: rgba(245,179,1,0.3); }
+.swarmify-root .fbar.clean .plainbtn { font-family: "Geist Mono", monospace; font-size: 12px; font-weight: 700; }
 .swarmify-root .fgroup { display: inline-flex; align-items: center; gap: 6px; flex: 0 0 auto; }
 .swarmify-root .fgroup-label { font-size: 9.5px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; color: var(--ds-text-faint, var(--ds-text-dim)); flex: 0 0 auto; }
 .swarmify-root .fsep { width: 1px; height: 18px; background: var(--ds-border); flex: 0 0 auto; margin: 0 3px; }

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -190,7 +190,7 @@ function Feed() {
   return (
     <div className="feed">
       <FloorControls
-        runningCount={8} totalCount={17} needsCount={2}
+        needsCount={2}
         sidebarOpen rightOpen plain={false}
         onToggleSidebar={noop} onToggleRight={noop} onTogglePlain={noop}
         sort={srt} onSort={setSrt} group={grp} onGroup={setGrp} onDispatch={noop}

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -13,6 +13,7 @@ import '../index.css'
 import { Icon } from '../components/mission-control/icons'
 import { FloorSidebar } from '../components/mission-control/FloorSidebar'
 import { FloorRail } from '../components/mission-control/FloorRail'
+import { FloorControls } from '../components/mission-control/FloorControls'
 import { FeedItem, TicketStrip } from '../components/mission-control/FeedItem'
 import { SavedViews } from '../components/mission-control/SavedViewsBar'
 import { DispatchPanel } from '../components/mission-control/DispatchPanel'
@@ -184,8 +185,16 @@ const linearProjectList: LinearProjectLite[] = [
 ]
 
 function Feed() {
+  const [grp, setGrp] = useState<'none' | 'project' | 'host' | 'status' | 'agent'>('project')
+  const [srt, setSrt] = useState<'needs' | 'recent' | 'tok' | 'name'>('needs')
   return (
     <div className="feed">
+      <FloorControls
+        runningCount={8} totalCount={17} needsCount={2}
+        sidebarOpen rightOpen plain={false}
+        onToggleSidebar={noop} onToggleRight={noop} onTogglePlain={noop}
+        sort={srt} onSort={setSrt} group={grp} onGroup={setGrp} onDispatch={noop}
+      />
       <SavedViews
         views={[
           { name: 'Today', sort: 'needs', status: [], abbrs: [], search: '' },


### PR DESCRIPTION
## What

The Floor controls bar was cluttered — labeled **Sort · Status(needs/running/idle/failed) · Agent(CC/CX/GX) · Group** chip groups + a `running` tally + a `Plain language: off` text toggle all crammed in one strip. Replaced with the mockup's calm pill row.

- **Group / Sort** → compact rounded pills (`Group: **Project**`, `Needs you first`) with an invisible overlay `<select>`.
- **`⚑ N` flag pill** for the needs-you count; the running tally is dropped.
- **Status + Agent quick-chips removed** from the always-visible bar — filtering lives in saved views + search (per the mockup).
- **Plain language** → a compact `Aa` icon toggle; panel toggles + Dispatch stay right.

Saved-view chips (`Today · Engineering · + Save view`) sit just below, so the two rows read like the mockup's filter row.

## Before / After

- **BEFORE** — the cluttered `STATUS · AGENT · GROUP · running · Plain language` strip (your screenshot)
- **AFTER** — `Group: Project · Needs you first · ⚑2 · Aa · toggles · Dispatch` clean pills: `zion:/Users/muqsit/Downloads/filterbar-AFTER-clean.jpg`

## Verified

- Preview harness: clean pill bar renders (after screenshot above).
- 224 mission-control tests pass; settings webview builds clean; touched files typecheck.

Separate PR per request. Rolls into the next release.