### PR TITLE
fix(secrets): stop the headless file-store from silently shadowing the keyring + add import-keyring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+**[secrets] Headless file-store fallback no longer silently shadows the keyring; new `secrets import-keyring`**
+
+- On Linux/Windows the encrypted-file fallback is sticky: the moment any item lands on disk, `preflight()` routes every op to the file store and never consults the native credential store (GNOME Keyring / Windows Credential Manager) again. Secrets that live in the native store — e.g. a bare `linear-api-key` a SessionStart hook reads — became invisible with no warning, reading back empty. A read now **reads through** to the native store on a file-store miss (short-circuiting once the store is seen locked/unreachable, so it never re-spawns for a dead store), and emits a one-time stderr hint pointing at the new migration command. macOS is unaffected — it has no file fallback and uses `migrate-acl` for its own item-visibility classes. Source: `src/lib/secrets/linux.ts`, `src/lib/secrets/windows.ts`, `src/lib/secrets/fallback.ts`.
+- New `agents secrets import-keyring` (Linux + Windows; dry-run by default, `--commit` to write) migrates the items agents-cli owns in the native store into the file store, so the file store becomes the complete headless-readable source of truth — parity with macOS's `migrate-orphans`. The keyring must be unlocked (a locked collection can't be read; the command reports that). Source: `src/commands/secrets-import.ts`, `src/lib/secrets/index.ts`.
+
 ## 1.20.36
 
 **[windows] `agents sessions --active` detects sessions on Windows, and shim launches carry cwd + session identity everywhere**

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -193,7 +193,8 @@ See [The secrets-agent](#the-secrets-agent-macos) below for the model and the se
 | `secrets generate --strong` | All character classes | `agents secrets generate 48 --strong` |
 | `secrets generate -c` / `--copy` | Copy to clipboard, do not print | `agents secrets generate --copy` |
 | `secrets migrate` | Interactively migrate legacy YAML bundles into Keychain | `agents secrets migrate` |
-| `secrets migrate-acl` | Upgrade legacy keychain items to the biometry ACL | `agents secrets migrate-acl` |
+| `secrets migrate-acl` | Upgrade legacy keychain items to the biometry ACL (macOS) | `agents secrets migrate-acl` |
+| `secrets import-keyring` | Migrate keyring / Credential Manager items into the file store (Linux/Windows headless) | `agents secrets import-keyring --commit` |
 
 ## Configuration Schema
 
@@ -487,6 +488,27 @@ process running as the same user. For a key held **off disk**, set
 `AGENTS_SECRETS_PASSPHRASE` (it always takes precedence) or unlock the keyring
 (e.g. configure `pam_gnome_keyring` for SSH login). To rotate, set a new
 `AGENTS_SECRETS_PASSPHRASE`, re-add the secrets, and delete `.passphrase`.
+
+### Migrating keyring secrets into the file store (`import-keyring`)
+
+Once any secret lands in the file store, that store is the source of truth for
+this machine — later reads route there. If you had already stored secrets in the
+keyring (from a session when it was unlocked), a plain file-store miss now
+**reads through** to the keyring so those items aren't silently hidden, and prints
+a one-time hint. To make them permanent (readable even after the keyring
+re-locks, and without a per-read keyring lookup), migrate them in:
+
+```bash
+agents secrets import-keyring            # dry-run: shows what would move
+agents secrets import-keyring --commit   # copy keyring items into the file store
+```
+
+It enumerates the items agents-cli owns in the native store and copies any that
+aren't already in the file store. The keyring must be **unlocked** at the time —
+a locked collection can't be read, so unlock it first (or the command reports
+that it's locked). Windows behaves the same against Credential Manager; macOS is
+unaffected (it reads the keychain directly and has no file fallback — use
+`migrate-acl` there instead).
 
 ## See Also
 

--- a/src/commands/secrets-import.ts
+++ b/src/commands/secrets-import.ts
@@ -1,0 +1,92 @@
+/**
+ * `agents secrets import-keyring` — migrate secrets out of the native OS
+ * credential store (GNOME Keyring on Linux, Windows Credential Manager) and into
+ * the encrypted file store.
+ *
+ * On a headless box the native store needs an interactive login to unlock, so a
+ * daemon / SSH session / SessionStart hook can't read it. The file store is
+ * passwordless (machine-local key), so once secrets live there they're readable
+ * without a prompt forever. This command performs that one-time move so the file
+ * store becomes the complete source of truth and the split-brain (native items
+ * shadowed by the file store) goes away.
+ *
+ * macOS is not affected — it has no file fallback and uses `migrate-acl` for its
+ * own item-visibility classes — so this command refuses to run there.
+ *
+ * Dry-run by default (mirrors `migrate-acl`); `--commit` performs the writes.
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { importNativeItems } from '../lib/secrets/index.js';
+
+/** Register `agents secrets import-keyring` on the parent secrets Command. */
+export function registerSecretsImportKeyringCommand(secrets: Command): void {
+  secrets
+    .command('import-keyring')
+    .description('Migrate secrets from the OS keyring / Credential Manager into the encrypted file store (headless-safe). Dry-run by default.')
+    .option('--commit', 'Perform the import (default is dry-run reporting only)')
+    .option('--prefix <p>', "Only import items beginning with PREFIX (default: all of agents-cli's items)")
+    .action((opts: { commit?: boolean; prefix?: string }) => {
+      try {
+        if (process.platform === 'darwin') {
+          throw new Error(
+            'import-keyring is for the Linux/Windows headless file-store fallback. ' +
+            'macOS reads the keychain directly; use `agents secrets migrate-acl` for legacy items.',
+          );
+        }
+        const prefix = opts.prefix ?? '';
+        const report = importNativeItems(prefix, !!opts.commit);
+
+        if (!report.available) {
+          console.log(chalk.gray(
+            process.platform === 'win32'
+              ? 'Windows Credential Manager is not reachable (no PowerShell) — nothing to import.'
+              : 'No keyring tooling found (install libsecret-tools) — nothing to import.',
+          ));
+          return;
+        }
+        if (report.locked) {
+          console.error(chalk.yellow(
+            'The native credential store is locked/unreachable, so its secrets can\'t be read.\n' +
+            'Unlock it (log in interactively / unlock the keyring), then re-run this command.',
+          ));
+          process.exit(1);
+        }
+        if (report.results.length === 0) {
+          console.log(chalk.green('Nothing to import — no native secrets outside the file store.'));
+          return;
+        }
+
+        const toMove = report.results.filter((r) => r.status === 'imported' || r.status === 'would-import');
+        const existing = report.results.filter((r) => r.status === 'exists');
+        const failed = report.results.filter((r) => r.status === 'failed');
+
+        for (const r of report.results) {
+          if (r.status === 'imported') console.log(`  ${chalk.green('imported')} ${r.item}`);
+          else if (r.status === 'would-import') console.log(`  ${chalk.cyan('would import')} ${r.item}`);
+          else if (r.status === 'exists') console.log(`  ${chalk.gray('exists')}   ${r.item} ${chalk.gray('(already in file store)')}`);
+          else console.log(`  ${chalk.red('failed')}   ${r.item} ${chalk.gray(r.detail ?? '')}`);
+        }
+        console.log();
+
+        if (!opts.commit) {
+          console.log(chalk.gray(
+            `Dry-run — ${toMove.length} item(s) would move` +
+            `${existing.length ? `, ${existing.length} already present` : ''}. Pass --commit to migrate.`,
+          ));
+          return;
+        }
+
+        const moved = report.results.filter((r) => r.status === 'imported').length;
+        if (failed.length > 0) {
+          console.error(chalk.yellow(`Imported ${moved} item(s); ${failed.length} failed.`));
+          process.exit(1);
+        }
+        console.log(chalk.green(`Imported ${moved} item(s) into the file store.`));
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+}

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -80,6 +80,7 @@ import { registerCommandGroups, setHelpSections } from '../lib/help.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
 import { registerSecretsSyncCommands } from './secrets-sync.js';
 import { registerSecretsMigrateAclCommand } from './secrets-migrate.js';
+import { registerSecretsImportKeyringCommand } from './secrets-import.js';
 
 /** Prompt the user for a secret value with masked input. Requires an interactive TTY. */
 async function promptForSecret(message: string): Promise<string> {
@@ -1773,6 +1774,7 @@ Examples:
 
   registerSecretsSyncCommands(cmd);
   registerSecretsMigrateAclCommand(cmd);
+  registerSecretsImportKeyringCommand(cmd);
 }
 
 /** Validate a prompt-policy value, throwing a clear message on a bad one (the

--- a/src/lib/secrets/__tests__/linux-shadow.test.ts
+++ b/src/lib/secrets/__tests__/linux-shadow.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Linux read-through de-shadow + `import-keyring` behaviour. Mocks `spawnSync`
+ * (secret-tool + `which`) so the tests are hermetic and run on any platform; the
+ * file store underneath is real (temp dir + passphrase). Harness mirrors
+ * windows.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const { spawnSyncMock } = vi.hoisted(() => ({ spawnSyncMock: vi.fn() }));
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return { ...actual, spawnSync: spawnSyncMock };
+});
+
+import {
+  getSecretToolToken,
+  setSecretToolToken,
+  importNativeSecretToolItems,
+  _resetForTest,
+} from '../linux.js';
+
+// ---- spawnSync dispatch harness ----
+type Resp = { status: number; stdout?: string; stderr?: string; error?: Error };
+// responder receives the secret-tool subcommand ('lookup'|'search'|'store'|…)
+// and the full argv so it can pick out the item name.
+let responder: (sub: string, args: string[]) => Resp;
+let tmpDir: string;
+
+beforeEach(() => {
+  responder = () => { throw new Error('unexpected secret-tool call in this test'); };
+  spawnSyncMock.mockReset();
+  spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
+    if (cmd === 'which') return { status: 0, stdout: Buffer.from('/usr/bin/secret-tool'), stderr: Buffer.from('') };
+    if (cmd === 'secret-tool') {
+      const r = responder(args[0], args);
+      return { status: r.status, stdout: Buffer.from(r.stdout ?? ''), stderr: Buffer.from(r.stderr ?? ''), error: r.error };
+    }
+    throw new Error(`unexpected spawn: ${cmd}`);
+  });
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-linux-shadow-'));
+  process.env.AGENTS_SECRETS_PASSPHRASE = 'test-pass';
+});
+
+afterEach(() => {
+  delete process.env.AGENTS_SECRETS_PASSPHRASE;
+  _resetForTest();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function itemOf(args: string[]): string {
+  return args[args.indexOf('item') + 1];
+}
+
+describe('read-through under file fallback', () => {
+  it('reads a keyring item that is not in the file store (no silent shadow)', () => {
+    _resetForTest({ forceFileFallback: true, fileDir: tmpDir, passphrase: 'test-pass' });
+    responder = (sub, args) => {
+      if (sub === 'lookup') {
+        return itemOf(args) === 'linear-api-key'
+          ? { status: 0, stdout: 'lin_api_shadowed\n' }
+          : { status: 1 };
+      }
+      throw new Error(`unexpected sub ${sub}`);
+    };
+    expect(getSecretToolToken('linear-api-key')).toBe('lin_api_shadowed');
+  });
+
+  it('throws not-found (never a false hit) when neither store has it', () => {
+    _resetForTest({ forceFileFallback: true, fileDir: tmpDir, passphrase: 'test-pass' });
+    responder = (sub) => (sub === 'lookup' ? { status: 1 } : (() => { throw new Error(sub); })());
+    expect(() => getSecretToolToken('absent')).toThrow(/not found/i);
+  });
+
+  it('stops re-probing the keyring once it is seen locked', () => {
+    _resetForTest({ forceFileFallback: true, fileDir: tmpDir, passphrase: 'test-pass' });
+    let lookups = 0;
+    responder = (sub) => {
+      if (sub === 'lookup') { lookups += 1; return { status: 1, stderr: 'Cannot create an item in a locked collection' }; }
+      throw new Error(sub);
+    };
+    expect(() => getSecretToolToken('a')).toThrow(/not found/i);
+    expect(() => getSecretToolToken('b')).toThrow(/not found/i);
+    // Second read short-circuits on the cached nativeUnreachable flag.
+    expect(lookups).toBe(1);
+  });
+});
+
+describe('importNativeSecretToolItems', () => {
+  it('copies keyring items missing from the file store, skips existing ones (commit)', () => {
+    _resetForTest({ forceFileFallback: true, fileDir: tmpDir, passphrase: 'test-pass' });
+    setSecretToolToken('agents-cli.bundles.demo', 'already'); // seeds file store
+    responder = (sub, args) => {
+      if (sub === 'search') {
+        return { status: 0, stderr: 'attribute.item = agents-cli.bundles.demo\nattribute.item = linear-api-key\n' };
+      }
+      if (sub === 'lookup') {
+        return itemOf(args) === 'linear-api-key' ? { status: 0, stdout: 'lin_val\n' } : { status: 1 };
+      }
+      throw new Error(`unexpected sub ${sub}`);
+    };
+    const report = importNativeSecretToolItems('', true);
+    expect(report.available).toBe(true);
+    expect(report.locked).toBe(false);
+    const byItem = Object.fromEntries(report.results.map((r) => [r.item, r.status]));
+    expect(byItem['agents-cli.bundles.demo']).toBe('exists');
+    expect(byItem['linear-api-key']).toBe('imported');
+    // Imported value now round-trips from the file store.
+    expect(getSecretToolToken('linear-api-key')).toBe('lin_val');
+  });
+
+  it('reports would-import without writing on a dry run', () => {
+    _resetForTest({ forceFileFallback: true, fileDir: tmpDir, passphrase: 'test-pass' });
+    responder = (sub, args) => {
+      if (sub === 'search') return { status: 0, stderr: 'attribute.item = linear-team-id\n' };
+      if (sub === 'lookup') return itemOf(args) === 'linear-team-id' ? { status: 0, stdout: 'team_123\n' } : { status: 1 };
+      throw new Error(sub);
+    };
+    const report = importNativeSecretToolItems('', false);
+    expect(report.results).toEqual([{ item: 'linear-team-id', status: 'would-import' }]);
+    // Not written: a later get must not find it in the file store.
+    responder = (sub) => (sub === 'lookup' ? { status: 1 } : (() => { throw new Error(sub); })());
+    expect(() => getSecretToolToken('linear-team-id')).toThrow(/not found/i);
+  });
+
+  it('reports locked (nothing read) when the collection is locked', () => {
+    _resetForTest({ forceFileFallback: true, fileDir: tmpDir, passphrase: 'test-pass' });
+    responder = (sub) => (sub === 'search' ? { status: 1, stderr: 'locked collection' } : (() => { throw new Error(sub); })());
+    const report = importNativeSecretToolItems('', true);
+    expect(report.locked).toBe(true);
+    expect(report.results).toEqual([]);
+  });
+});

--- a/src/lib/secrets/fallback.ts
+++ b/src/lib/secrets/fallback.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared helpers for the Linux/Windows encrypted-file fallback.
+ *
+ * When the native credential store (GNOME Keyring / Windows Credential Manager)
+ * is unreachable, both backends route to the AES-256-GCM file store. The routing
+ * is "sticky": once any item is on disk, every op stays on the file store. That
+ * is correct for perf, but on its own it would silently *shadow* secrets that
+ * still live in the native store — reads for them would return empty with no
+ * hint. This module centralizes the two pieces that keep that from being silent:
+ *
+ *   1. `noteNativeShadow()` — a one-time stderr notice, emitted when a read
+ *      falls through to the native store (found something shadowed, or hit a
+ *      locked/unreachable store), pointing at `agents secrets import-keyring`.
+ *   2. The result types for that import command.
+ *
+ * macOS has no file fallback (see ./index.ts) and uses `migrate-acl` /
+ * `migrate-orphans` for its own invisible-item classes, so none of this runs
+ * there.
+ */
+
+export type NativeImportStatus = 'imported' | 'would-import' | 'exists' | 'failed';
+
+export interface NativeImportResult {
+  item: string;
+  status: NativeImportStatus;
+  detail?: string;
+}
+
+/**
+ * Outcome of an `import-keyring` run. `available` is false when no native
+ * tooling exists (no `secret-tool` / no `powershell.exe`); `locked` is true when
+ * the native store exists but is locked/unreachable, so nothing could be read.
+ */
+export interface NativeImportReport {
+  available: boolean;
+  locked: boolean;
+  results: NativeImportResult[];
+}
+
+let noticeEmitted = false;
+
+/**
+ * Emit a one-time stderr notice that the file fallback is masking the native
+ * credential store. Both backends share the copy so the guidance is identical.
+ *
+ *   'shadowed' — a secret was just read from the native store that isn't in the
+ *                file store. It works, but each read pays a native lookup and it
+ *                won't survive the store locking; suggest migrating it.
+ *   'locked'   — the native store is locked/unreachable, so its secrets can't be
+ *                read in this session at all; the user must unlock, then migrate.
+ */
+export function noteNativeShadow(kind: 'shadowed' | 'locked', fileDir: string): void {
+  if (noticeEmitted) return;
+  noticeEmitted = true;
+  if (kind === 'locked') {
+    process.stderr.write(
+      `[agents] the native credential store is locked/unreachable — secrets stored there are not ` +
+      `readable in this session. Unlock it, then run \`agents secrets import-keyring\` to migrate ` +
+      `them into the encrypted file store at ${fileDir}.\n`
+    );
+  } else {
+    process.stderr.write(
+      `[agents] read a secret from the native credential store that is not in the file store at ` +
+      `${fileDir}. Run \`agents secrets import-keyring\` to migrate it so it stays readable headless.\n`
+    );
+  }
+}
+
+/** Test-only: clear the one-time notice guard between cases. */
+export function _resetFallbackNoticeForTest(): void {
+  noticeEmitted = false;
+}

--- a/src/lib/secrets/index.ts
+++ b/src/lib/secrets/index.ts
@@ -27,9 +27,12 @@ import { execFileSync, spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { linuxBackend, usesFileFallback as linuxUsesFileFallback } from './linux.js';
-import { windowsBackend, usesFileFallback as windowsUsesFileFallback } from './windows.js';
+import { linuxBackend, usesFileFallback as linuxUsesFileFallback, importNativeSecretToolItems } from './linux.js';
+import { windowsBackend, usesFileFallback as windowsUsesFileFallback, importNativeCredManItems } from './windows.js';
 import { getKeychainHelperPath } from './install-helper.js';
+import type { NativeImportReport } from './fallback.js';
+
+export type { NativeImportReport, NativeImportResult, NativeImportStatus } from './fallback.js';
 
 const SERVICE_PREFIX = 'agents-cli';
 const SECRETS_ITEM_PREFIX = `${SERVICE_PREFIX}.secrets.`;
@@ -530,6 +533,23 @@ export function migrateOrphanedKeychainItems(prefix: string): OrphanMigrationRes
     throw new Error(msg || `Failed to migrate orphaned keychain items with prefix '${prefix}'.`);
   }
   return parseOrphanMigrationOutput(result.stdout?.toString() || '');
+}
+
+/**
+ * Migrate secrets that live in the native store (GNOME Keyring / Windows
+ * Credential Manager) into the encrypted file store, so the file store becomes
+ * the complete headless-readable source of truth. This is the Linux/Windows
+ * counterpart to macOS's orphan/legacy migration: it exists because the file
+ * fallback would otherwise silently shadow those native items. macOS never uses
+ * the file fallback, so it returns an empty report there. Powers
+ * `agents secrets import-keyring`; dry-run unless `commit`.
+ */
+export function importNativeItems(prefix: string, commit: boolean): NativeImportReport {
+  if (backend) return { available: false, locked: false, results: [] };
+  assertSupportedPlatform();
+  if (isLinux()) return importNativeSecretToolItems(prefix, commit);
+  if (isWindows()) return importNativeCredManItems(prefix, commit);
+  return { available: false, locked: false, results: [] };
 }
 
 /** Options controlling how secret refs are resolved. */

--- a/src/lib/secrets/linux.ts
+++ b/src/lib/secrets/linux.ts
@@ -27,6 +27,12 @@ import {
   machinePassphraseExists,
   _resetFileStoreForTest,
 } from './filestore.js';
+import {
+  noteNativeShadow,
+  _resetFallbackNoticeForTest,
+  type NativeImportReport,
+  type NativeImportResult,
+} from './fallback.js';
 
 // Re-exported so existing importers (and tests) can keep reaching these via
 // './linux.js'. The implementations live in ./filestore.ts.
@@ -55,14 +61,23 @@ let isAvailable = false;
 
 let useFileFallback = false;
 let warnedFallback = false;
+// Set once the Secret Service is observed locked/unreachable in this process, so
+// read-through probes (which spawn secret-tool) stop retrying a collection we
+// already know we can't read.
+let nativeUnreachable = false;
 
-function activateFileFallback(): void {
+function activateFileFallback(opts?: { nativeUnreachable?: boolean }): void {
+  // When the fallback fires because the Secret Service was locked, record that so
+  // read-through probes don't keep re-spawning secret-tool for a collection we
+  // already know we can't read. The sticky path (file store already has items)
+  // leaves this false — the keyring may still be unlocked and readable.
+  if (opts?.nativeUnreachable) nativeUnreachable = true;
   if (useFileFallback) return;
   useFileFallback = true;
   if (!warnedFallback) {
     warnedFallback = true;
     process.stderr.write(
-      `[agents] secret-service collection locked, using file-based store at ${fileDir()}\n`
+      `[agents] using the encrypted file store at ${fileDir()}\n`
     );
   }
 }
@@ -70,6 +85,77 @@ function activateFileFallback(): void {
 function isLockedCollectionError(stderr: string): boolean {
   return /locked collection/i.test(stderr) ||
          /Prompt was dismissed/i.test(stderr);
+}
+
+/**
+ * Read one item straight from the Secret Service, bypassing preflight routing.
+ * Powers the read-through (so the file store can't silently shadow a keyring
+ * item) and `import-keyring`. Returns `{ value }` on a hit, `{ locked: true }`
+ * when the collection is locked, or `{}` on a plain miss / no tooling. Never
+ * writes to stderr — callers decide whether to surface a notice.
+ */
+function readNativeItemRaw(item: string): { value?: string; locked?: boolean } {
+  if (nativeUnreachable) return { locked: true };
+  if (!secretToolAvailable()) return {};
+  const user = os.userInfo().username;
+  const r = spawnSync('secret-tool', [
+    'lookup', 'service', SERVICE, 'account', user, 'item', item,
+  ], { stdio: ['ignore', 'pipe', 'pipe'] });
+  if (r.status === 0) {
+    const v = r.stdout?.toString().trim();
+    return { value: v && v.length > 0 ? v : undefined };
+  }
+  const stderr = r.stderr?.toString() ?? '';
+  if (isLockedCollectionError(stderr)) {
+    nativeUnreachable = true;
+    return { locked: true };
+  }
+  return {};
+}
+
+/**
+ * Enumerate every `service=agents-cli` item held in the Secret Service,
+ * regardless of preflight routing. The `service` attribute already scopes this
+ * to items agents-cli stored (including bare names like `linear-api-key`), so an
+ * empty `prefix` is safe. `locked` distinguishes "store locked" from "store
+ * empty"; `available` is false when secret-tool isn't installed.
+ */
+function listNativeItemsRaw(prefix: string): { items: string[]; locked: boolean; available: boolean } {
+  if (!secretToolAvailable()) return { items: [], locked: false, available: false };
+  const r = spawnSync('secret-tool', [
+    'search', '--all', 'service', SERVICE,
+  ], { stdio: ['ignore', 'pipe', 'pipe'] });
+  if (r.status !== 0) {
+    const stderr = r.stderr?.toString() ?? '';
+    const locked = isLockedCollectionError(stderr);
+    if (locked) nativeUnreachable = true;
+    return { items: [], locked, available: true };
+  }
+  const output = `${r.stdout?.toString() || ''}\n${r.stderr?.toString() || ''}`;
+  return { items: parseSecretToolItems(output, prefix), locked: false, available: true };
+}
+
+/**
+ * Copy every Secret Service item under `prefix` that isn't already in the file
+ * store into it, so the file store becomes the complete headless-readable source
+ * of truth. Requires an unlocked keyring (a locked one can't be read). Dry-run
+ * unless `commit`. Consumed by `agents secrets import-keyring`.
+ */
+export function importNativeSecretToolItems(prefix: string, commit: boolean): NativeImportReport {
+  const { items, locked, available } = listNativeItemsRaw(prefix);
+  if (!available || locked) return { available, locked, results: [] };
+  const results: NativeImportResult[] = [];
+  for (const item of items) {
+    if (fileStore.has(item)) { results.push({ item, status: 'exists' }); continue; }
+    const probe = readNativeItemRaw(item);
+    if (probe.value === undefined) {
+      results.push({ item, status: 'failed', detail: probe.locked ? 'keyring locked' : 'could not read value' });
+      continue;
+    }
+    if (commit) fileStore.set(item, probe.value);
+    results.push({ item, status: commit ? 'imported' : 'would-import' });
+  }
+  return { available, locked, results };
 }
 
 /**
@@ -138,7 +224,15 @@ export function usesFileFallback(): boolean {
 /** secret-tool lookup attributes:
  *   service=agents-cli account=<user> item=<itemName> */
 export function hasSecretToolToken(item: string): boolean {
-  if (preflight() === 'file') return fileStore.has(item);
+  if (preflight() === 'file') {
+    if (fileStore.has(item)) return true;
+    // Read-through: the item may predate the fallback and still live in an
+    // unlocked keyring. Don't let the file store silently shadow it.
+    const probe = readNativeItemRaw(item);
+    if (probe.value !== undefined) { noteNativeShadow('shadowed', fileDir()); return true; }
+    if (probe.locked) noteNativeShadow('locked', fileDir());
+    return false;
+  }
   const user = os.userInfo().username;
   const result = spawnSync('secret-tool', [
     'lookup',
@@ -151,14 +245,22 @@ export function hasSecretToolToken(item: string): boolean {
   }
   const stderr = result.stderr?.toString() ?? '';
   if (isLockedCollectionError(stderr)) {
-    activateFileFallback();
+    activateFileFallback({ nativeUnreachable: true });
     return fileStore.has(item);
   }
   return false;
 }
 
 export function getSecretToolToken(item: string): string {
-  if (preflight() === 'file') return fileStore.get(item);
+  if (preflight() === 'file') {
+    if (fileStore.has(item)) return fileStore.get(item);
+    // Read-through: don't let a file-store miss shadow an item that still lives
+    // in an unlocked keyring (e.g. a bare `linear-api-key` a hook reads).
+    const probe = readNativeItemRaw(item);
+    if (probe.value !== undefined) { noteNativeShadow('shadowed', fileDir()); return probe.value; }
+    if (probe.locked) noteNativeShadow('locked', fileDir());
+    throw new Error(`Secret '${item}' not found in the file store or keyring.`);
+  }
   const user = os.userInfo().username;
   const result = spawnSync('secret-tool', [
     'lookup',
@@ -173,7 +275,7 @@ export function getSecretToolToken(item: string): string {
   }
   const stderr = result.stderr?.toString() ?? '';
   if (isLockedCollectionError(stderr)) {
-    activateFileFallback();
+    activateFileFallback({ nativeUnreachable: true });
     return fileStore.get(item);
   }
   throw new Error(`Secret '${item}' not found in keyring.`);
@@ -198,7 +300,7 @@ export function setSecretToolToken(item: string, value: string): void {
 
   const stderr = result.stderr?.toString().trim() ?? '';
   if (isLockedCollectionError(stderr)) {
-    activateFileFallback();
+    activateFileFallback({ nativeUnreachable: true });
     fileStore.set(item, value);
     return;
   }
@@ -221,7 +323,7 @@ export function deleteSecretToolToken(item: string): boolean {
   if (result.status === 0) return true;
   const stderr = result.stderr?.toString() ?? '';
   if (isLockedCollectionError(stderr)) {
-    activateFileFallback();
+    activateFileFallback({ nativeUnreachable: true });
     return fileStore.delete(item);
   }
   // secret-tool clear returns 0 whether the item existed or not.
@@ -315,8 +417,10 @@ export function _resetForTest(opts: {
   passphrase?: string | null;
 } = {}): void {
   _resetFileStoreForTest({ fileDir: opts.fileDir ?? null, passphrase: opts.passphrase ?? null });
+  _resetFallbackNoticeForTest();
   useFileFallback = opts.forceFileFallback ?? false;
   warnedFallback = false;
+  nativeUnreachable = false;
   checkedAvailability = false;
   isAvailable = false;
 }

--- a/src/lib/secrets/windows.test.ts
+++ b/src/lib/secrets/windows.test.ts
@@ -17,6 +17,7 @@ import {
   windowsBackend,
   getCredManToken,
   setCredManToken,
+  importNativeCredManItems,
   CRED_MAX_CREDENTIAL_BLOB_SIZE,
   _resetForTest,
 } from './windows.js';
@@ -195,6 +196,66 @@ describe('CRED_MAX_CREDENTIAL_BLOB_SIZE guard', () => {
     const atLimit = 'x'.repeat(CRED_MAX_CREDENTIAL_BLOB_SIZE);
     setCredManToken('agents-cli.secrets.demo.MAX', atLimit);
     expect(sawSet).toBe(true);
+  });
+});
+
+// (d2) read-through de-shadow — under the file fallback, a file-store miss must
+// fall through to Credential Manager instead of silently returning "not found".
+describe('read-through under file fallback', () => {
+  it('reads a CredMan item that is not in the file store', () => {
+    _resetForTest({ forceFileFallback: true, fileDir: tmpDir, passphrase: 'test-pass' });
+    // File store is empty, so this item only lives in CredMan (get op).
+    responder = (op, ctx) => {
+      if (op === 'get') {
+        expect(ctx.env.AGENTS_CRED_TARGET).toBe('linear-api-key');
+        return { status: 0, stdout: Buffer.from('lin_api_shadowed', 'utf8').toString('base64') };
+      }
+      throw new Error(`unexpected op ${op}`);
+    };
+    expect(getCredManToken('linear-api-key')).toBe('lin_api_shadowed');
+  });
+
+  it('reports missing (not throwing a false "found") when neither store has it', () => {
+    _resetForTest({ forceFileFallback: true, fileDir: tmpDir, passphrase: 'test-pass' });
+    responder = (op) => (op === 'get' ? { status: 3 } : (() => { throw new Error(`unexpected op ${op}`); })());
+    expect(() => getCredManToken('nope')).toThrow(/not found/i);
+  });
+});
+
+// (d3) import-keyring — migrate CredMan items into the file store.
+describe('importNativeCredManItems', () => {
+  it('copies items not already in the file store and skips existing ones (commit)', () => {
+    // Force the file-fallback path so the pre-seed set() lands in the file store
+    // (import compares against the file store, not CredMan).
+    _resetForTest({ forceFileFallback: true, fileDir: tmpDir, passphrase: 'test-pass' });
+    // Pre-seed one item into the file store so import reports it as "exists".
+    windowsBackend.set('agents-cli.bundles.demo', 'already-here');
+    responder = (op, ctx) => {
+      if (op === 'set') return { status: 0 };
+      if (op === 'list') return { status: 0, stdout: 'agents-cli.bundles.demo\nagents-cli.secrets.demo.A\n' };
+      if (op === 'get') {
+        return ctx.env.AGENTS_CRED_TARGET === 'agents-cli.secrets.demo.A'
+          ? { status: 0, stdout: Buffer.from('valA', 'utf8').toString('base64') }
+          : { status: 3 };
+      }
+      throw new Error(`unexpected op ${op}`);
+    };
+    const report = importNativeCredManItems('', true);
+    expect(report.available).toBe(true);
+    expect(report.locked).toBe(false);
+    const byItem = Object.fromEntries(report.results.map((r) => [r.item, r.status]));
+    expect(byItem['agents-cli.bundles.demo']).toBe('exists');
+    expect(byItem['agents-cli.secrets.demo.A']).toBe('imported');
+    // The imported value now round-trips out of the file store.
+    expect(getCredManToken('agents-cli.secrets.demo.A')).toBe('valA');
+  });
+
+  it('reports locked (nothing read) when CredMan is unreachable', () => {
+    _resetForTest({ forceAvailable: true, fileDir: tmpDir, passphrase: 'test-pass' });
+    responder = (op) => (op === 'list' ? { status: 1, stderr: 'CredMan error 1312' } : (() => { throw new Error(`unexpected op ${op}`); })());
+    const report = importNativeCredManItems('', true);
+    expect(report.locked).toBe(true);
+    expect(report.results).toEqual([]);
   });
 });
 

--- a/src/lib/secrets/windows.ts
+++ b/src/lib/secrets/windows.ts
@@ -37,6 +37,12 @@ import {
   machinePassphraseExists,
   _resetFileStoreForTest,
 } from './filestore.js';
+import {
+  noteNativeShadow,
+  _resetFallbackNoticeForTest,
+  type NativeImportReport,
+  type NativeImportResult,
+} from './fallback.js';
 
 // Re-exported so importers (and tests) can keep reaching these via './windows.js'.
 export {
@@ -285,14 +291,22 @@ let isAvailable = false;
 
 let useFileFallback = false;
 let warnedFallback = false;
+// Set once Credential Manager is observed unreachable in this process, so the
+// read-through in get/has stops re-spawning PowerShell for a store we can't read.
+let nativeUnreachable = false;
 
-function activateFileFallback(): void {
+function activateFileFallback(opts?: { nativeUnreachable?: boolean }): void {
+  // When the fallback fires because Credential Manager itself was unreachable
+  // (no logon session), record that so read-through probes don't keep re-spawning
+  // PowerShell for a store we already know we can't reach. The sticky path
+  // (file store already has items) leaves this false — CredMan may still be live.
+  if (opts?.nativeUnreachable) nativeUnreachable = true;
   if (useFileFallback) return;
   useFileFallback = true;
   if (!warnedFallback) {
     warnedFallback = true;
     process.stderr.write(
-      `[agents] Windows Credential Manager unavailable, using file-based store at ${fileDir()}\n`
+      `[agents] using the encrypted file store at ${fileDir()}\n`
     );
   }
 }
@@ -308,6 +322,71 @@ function activateFileFallback(): void {
 function isCredManUnavailableError(r: CredResult): boolean {
   if (r.spawnError) return true; // powershell.exe not found
   return /\b1312\b/.test(r.stderr) || /NO_SUCH_LOGON_SESSION/i.test(r.stderr);
+}
+
+/**
+ * Read one item straight from Credential Manager, bypassing preflight routing.
+ * Powers the read-through (so the file store can't silently shadow a CredMan
+ * item) and `import-keyring`. Returns `{ value }` on a hit, `{ locked: true }`
+ * when the store is unreachable (no logon session), or `{}` on a plain miss / no
+ * PowerShell. Reading a specific target by name is always safe. No stderr.
+ */
+function readNativeItemRaw(item: string): { value?: string; locked?: boolean } {
+  if (nativeUnreachable) return { locked: true };
+  if (!powershellAvailable()) return {};
+  const r = runCred('get', { target: item });
+  if (r.status === 0) {
+    const v = Buffer.from(r.stdout.trim(), 'base64').toString('utf8');
+    return { value: v.length > 0 ? v : undefined };
+  }
+  if (r.status === 3) return {}; // clean not-found
+  if (isCredManUnavailableError(r)) {
+    nativeUnreachable = true;
+    return { locked: true };
+  }
+  return {};
+}
+
+/**
+ * Enumerate Credential Manager targets under `prefix`. CredMan has no service
+ * namespace — the target name is the only scope — so enumeration is floored to
+ * `agents-cli.` and never returns unrelated machine credentials. (Bare targets
+ * like `linear-api-key` are therefore out of scope for enumeration on Windows;
+ * they are still reachable by exact name via read-through.) `locked` marks an
+ * unreachable store; `available` is false when PowerShell is missing.
+ */
+function listNativeItemsRaw(prefix: string): { items: string[]; locked: boolean; available: boolean } {
+  if (!powershellAvailable()) return { items: [], locked: false, available: false };
+  const floor = prefix && prefix.length > 0 ? prefix : 'agents-cli.';
+  const r = runCred('list', { prefix: floor });
+  if (r.status === 0) return { items: parseWindowsCredList(r.stdout, floor), locked: false, available: true };
+  if (isCredManUnavailableError(r)) {
+    nativeUnreachable = true;
+    return { items: [], locked: true, available: true };
+  }
+  return { items: [], locked: false, available: true };
+}
+
+/**
+ * Copy every Credential Manager item under `prefix` that isn't already in the
+ * file store into it. Requires a reachable store (a no-logon-session store can't
+ * be read). Dry-run unless `commit`. Consumed by `agents secrets import-keyring`.
+ */
+export function importNativeCredManItems(prefix: string, commit: boolean): NativeImportReport {
+  const { items, locked, available } = listNativeItemsRaw(prefix);
+  if (!available || locked) return { available, locked, results: [] };
+  const results: NativeImportResult[] = [];
+  for (const item of items) {
+    if (fileStore.has(item)) { results.push({ item, status: 'exists' }); continue; }
+    const probe = readNativeItemRaw(item);
+    if (probe.value === undefined) {
+      results.push({ item, status: 'failed', detail: probe.locked ? 'Credential Manager unreachable' : 'could not read value' });
+      continue;
+    }
+    if (commit) fileStore.set(item, probe.value);
+    results.push({ item, status: commit ? 'imported' : 'would-import' });
+  }
+  return { available, locked, results };
 }
 
 /**
@@ -357,19 +436,31 @@ export function usesFileFallback(): boolean {
 // ---------- Credential Manager ops with fallback ----------
 
 export function hasCredManToken(item: string): boolean {
-  if (preflight() === 'file') return fileStore.has(item);
+  if (preflight() === 'file') {
+    if (fileStore.has(item)) return true;
+    const probe = readNativeItemRaw(item);
+    if (probe.value !== undefined) { noteNativeShadow('shadowed', fileDir()); return true; }
+    if (probe.locked) noteNativeShadow('locked', fileDir());
+    return false;
+  }
   const r = runCred('has', { target: item });
   if (r.status === 0) return true;
   if (r.status === 3) return false;
   if (isCredManUnavailableError(r)) {
-    activateFileFallback();
+    activateFileFallback({ nativeUnreachable: true });
     return fileStore.has(item);
   }
   return false;
 }
 
 export function getCredManToken(item: string): string {
-  if (preflight() === 'file') return fileStore.get(item);
+  if (preflight() === 'file') {
+    if (fileStore.has(item)) return fileStore.get(item);
+    const probe = readNativeItemRaw(item);
+    if (probe.value !== undefined) { noteNativeShadow('shadowed', fileDir()); return probe.value; }
+    if (probe.locked) noteNativeShadow('locked', fileDir());
+    throw new Error(`Secret '${item}' not found in the file store or Credential Manager.`);
+  }
   const r = runCred('get', { target: item });
   if (r.status === 0) {
     // stdout is base64 of the raw UTF-8 blob (dodges PowerShell encoding corruption).
@@ -377,7 +468,7 @@ export function getCredManToken(item: string): string {
   }
   if (r.status === 3) throw new Error(`Secret '${item}' not found in Credential Manager.`);
   if (isCredManUnavailableError(r)) {
-    activateFileFallback();
+    activateFileFallback({ nativeUnreachable: true });
     return fileStore.get(item);
   }
   throw new Error(`Failed to read secret '${item}': ${r.stderr.trim() || 'unknown error'}`);
@@ -397,7 +488,7 @@ export function setCredManToken(item: string, value: string): void {
   const r = runCred('set', { target: item, input: value });
   if (r.status === 0) return;
   if (isCredManUnavailableError(r)) {
-    activateFileFallback();
+    activateFileFallback({ nativeUnreachable: true });
     fileStore.set(item, value);
     return;
   }
@@ -410,7 +501,7 @@ export function deleteCredManToken(item: string): boolean {
   if (r.status === 0) return true;
   if (r.status === 3) return false;
   if (isCredManUnavailableError(r)) {
-    activateFileFallback();
+    activateFileFallback({ nativeUnreachable: true });
     return fileStore.delete(item);
   }
   return false;
@@ -421,7 +512,7 @@ export function listCredManItems(prefix: string): string[] {
   const r = runCred('list', { prefix });
   if (r.status === 0) return parseWindowsCredList(r.stdout, prefix);
   if (isCredManUnavailableError(r)) {
-    activateFileFallback();
+    activateFileFallback({ nativeUnreachable: true });
     return fileStore.list(prefix);
   }
   return [];
@@ -478,8 +569,10 @@ export function _resetForTest(opts: {
   forceAvailable?: boolean | null;
 } = {}): void {
   _resetFileStoreForTest({ fileDir: opts.fileDir ?? null, passphrase: opts.passphrase ?? null });
+  _resetFallbackNoticeForTest();
   useFileFallback = opts.forceFileFallback ?? false;
   warnedFallback = false;
+  nativeUnreachable = false;
   if (opts.forceAvailable === undefined || opts.forceAvailable === null) {
     checkedAvailability = false;
     isAvailable = false;


### PR DESCRIPTION
## Problem

On Linux/Windows the encrypted-file fallback is a **one-way sticky switch**: the moment any item lands in the file store, `preflight()` routes every op to the file store and never consults the native credential store (GNOME Keyring / Windows Credential Manager) again — no union read, no migration, no warning. Secrets that live in the native store (e.g. a bare `linear-api-key` a `SessionStart` hook reads) become invisible and read back empty.

This bit a real machine: two Linear secrets sat in the box's locked keyring, but because other bundles were in the file store, `agents secrets get linear-api-key` returned empty and the Linear hook silently failed every session.

macOS is unaffected — it has no file fallback (`keychainUsesFileFallback()` is false on darwin) and ships `migrate-acl`/`migrate-orphans` for its own invisible-item classes. Linux/Windows shared the file fallback but had **zero** repair tooling.

Root cause: `src/lib/secrets/linux.ts` `preflight()` (`if (fileStoreHasItems()) return 'file'`) and the identical check in `windows.ts`.

## Change

- **Read-through de-shadow** — under the fallback, a `get`/`has` miss falls through to the native store instead of returning a false "not found". Short-circuits once the store is observed locked/unreachable, so it never re-spawns for a store it can't read.
- **One-time notice** — a shared `fallback.ts` emits a single stderr hint pointing at `import-keyring` when a shadowed/locked native item is observed. Both backends use it (standardize-at-source).
- **`agents secrets import-keyring`** (Linux + Windows) — migrates the items agents-cli owns in the native store into the file store, so the file store becomes the complete headless-readable source of truth. Dry-run by default, `--commit` to write. Parity with macOS `migrate-orphans`.

## Tests

- `linux-shadow.test.ts` (new, mocked `secret-tool`): read-through hit/miss, lock short-circuit, import copy/skip/dry-run/locked.
- `windows.test.ts` (extended): read-through + import via the CredMan responder mock.
- Full secrets suite green locally (275 passed), typecheck clean.

## Notes / limitations

- On some distros `secret-tool` returns empty (rc 0) rather than a "locked collection" error while the collection is locked, so the *locked notice* degrades to a plain miss there — best-effort by design.
- Windows enumeration is floored to the `agents-cli.` target prefix (CredMan has no service namespace); bare targets remain reachable by exact name via read-through but aren't auto-enumerated for import.

Session transcript (fleet-local): yosemite-s0:/home/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-home-muqsit-src-github-com-muqsitnawaz/e3d6852d-22e4-4afc-986d-0f241799dfb0.jsonl
