### PR TITLE
feat(factory): comments + images in the task detail

### DIFF
--- a/apps/factory/src/core/tasks.test.ts
+++ b/apps/factory/src/core/tasks.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test';
-import { buildTaskDispatchPrompt } from './tasks';
+import {
+  buildTaskDispatchPrompt,
+  extractImageUrls,
+  githubToUnifiedTask,
+  linearToUnifiedTask,
+} from './tasks';
 
 describe('buildTaskDispatchPrompt', () => {
   test('builds the task prompt with optional reference, URL, and extra comments', () => {
@@ -26,5 +31,85 @@ describe('buildTaskDispatchPrompt', () => {
       url: '   ',
       extraComments: '  Prefer Codex for implementation.  ',
     })).toBe('Dispatch RUSH-1\n\nAdditional instructions:\nPrefer Codex for implementation.');
+  });
+});
+
+describe('extractImageUrls', () => {
+  test('pulls markdown and HTML image URLs, deduped and order-preserving', () => {
+    expect(extractImageUrls(
+      'intro ![shot](https://uploads.linear.app/a.png) and ![again](https://uploads.linear.app/a.png)',
+      'in a comment <img src="https://user-images.githubusercontent.com/b.jpg" alt="x">',
+    )).toEqual([
+      'https://uploads.linear.app/a.png',
+      'https://user-images.githubusercontent.com/b.jpg',
+    ]);
+  });
+
+  test('ignores non-http(s) URLs (data:/relative) and empty bodies', () => {
+    expect(extractImageUrls(
+      '![evil](data:image/png;base64,AAAA) ![rel](./local.png)',
+      undefined,
+      null,
+    )).toEqual([]);
+  });
+
+  test('strips markdown image titles from the captured URL', () => {
+    expect(extractImageUrls('![alt](https://example.com/c.png "a title")')).toEqual([
+      'https://example.com/c.png',
+    ]);
+  });
+});
+
+describe('linearToUnifiedTask comments + images', () => {
+  test('maps comment author/body and extracts images from description and comments', () => {
+    const task = linearToUnifiedTask({
+      id: 'iss_1',
+      identifier: 'RUSH-9',
+      title: 'Broken layout',
+      description: 'Repro ![desc](https://uploads.linear.app/desc.png)',
+      state: { name: 'In Progress', type: 'started' },
+      priority: 2,
+      url: 'https://linear.app/acme/issue/RUSH-9',
+      comments: {
+        nodes: [
+          { body: 'Here too ![cmt](https://uploads.linear.app/cmt.png)', createdAt: '2026-07-01T00:00:00Z', user: { name: 'Ada' } },
+        ],
+      },
+    });
+
+    expect(task.metadata.comments).toEqual([
+      { body: 'Here too ![cmt](https://uploads.linear.app/cmt.png)', createdAt: '2026-07-01T00:00:00Z', author: 'Ada' },
+    ]);
+    expect(task.metadata.images).toEqual([
+      'https://uploads.linear.app/desc.png',
+      'https://uploads.linear.app/cmt.png',
+    ]);
+  });
+
+  test('leaves images undefined when the body has none', () => {
+    const task = linearToUnifiedTask({
+      id: 'iss_2',
+      identifier: 'RUSH-10',
+      title: 'No images',
+      description: 'plain text',
+      state: { name: 'Todo', type: 'unstarted' },
+      priority: 0,
+      url: 'https://linear.app/acme/issue/RUSH-10',
+    });
+    expect(task.metadata.images).toBeUndefined();
+  });
+});
+
+describe('githubToUnifiedTask images', () => {
+  test('extracts image URLs from the issue body', () => {
+    const task = githubToUnifiedTask({
+      id: 42,
+      number: 7,
+      title: 'Screenshot bug',
+      body: 'See <img src="https://user-images.githubusercontent.com/z.png"> for the glitch.',
+      state: 'open',
+      html_url: 'https://github.com/acme/repo/issues/7',
+    });
+    expect(task.metadata.images).toEqual(['https://user-images.githubusercontent.com/z.png']);
   });
 });

--- a/apps/factory/src/core/tasks.ts
+++ b/apps/factory/src/core/tasks.ts
@@ -59,6 +59,35 @@ export function extractRepoNameFromLabels(labels: string[] | undefined): string 
   return null;
 }
 
+// Markdown image: ![alt](url) or ![alt](url "title")
+const MARKDOWN_IMAGE_RE = /!\[[^\]]*\]\(\s*([^)\s]+)(?:\s+["'][^"']*["'])?\s*\)/g;
+// HTML image: <img src="url"> / <img src='url'>
+const HTML_IMAGE_RE = /<img\b[^>]*?\bsrc\s*=\s*["']([^"']+)["']/gi;
+
+// Extract embedded image URLs from a markdown/HTML body. Pure. Returns deduped,
+// order-preserving http(s) URLs only. Linear uploads and GitHub issue images both
+// embed as markdown `![](…)` or raw `<img>` in the body, so scanning the body is
+// the source of image URLs available at fetch time.
+export function extractImageUrls(...bodies: (string | undefined | null)[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const body of bodies) {
+    if (!body) continue;
+    for (const re of [MARKDOWN_IMAGE_RE, HTML_IMAGE_RE]) {
+      re.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(body)) !== null) {
+        const url = m[1].trim();
+        if (!/^https?:\/\//i.test(url)) continue; // sanitize: no data:/javascript: URLs
+        if (seen.has(url)) continue;
+        seen.add(url);
+        out.push(url);
+      }
+    }
+  }
+  return out;
+}
+
 // Active cycle info from Linear
 export interface CycleInfo {
   name: string;
@@ -117,6 +146,8 @@ export function linearToUnifiedTask(
     author: n.user?.name,
   }));
 
+  const images = extractImageUrls(issue.description, ...(comments?.map(c => c.body) ?? []));
+
   return {
     id: `linear:${issue.id}`,
     source: 'linear',
@@ -136,6 +167,7 @@ export function linearToUnifiedTask(
       project: issue.project?.name ?? undefined,
       repo: repo ?? undefined,
       comments,
+      images: images.length > 0 ? images : undefined,
     }
   };
 }
@@ -156,6 +188,7 @@ export function githubToUnifiedTask(
   repo: string | null = null,
 ): UnifiedTask {
   const assignee = issue.assignee?.login;
+  const images = extractImageUrls(issue.body);
   return {
     id: `github:${issue.id}`,
     source: 'github',
@@ -171,6 +204,7 @@ export function githubToUnifiedTask(
       state: issue.state,
       createdAt: issue.createdAt,
       repo: repo ?? undefined,
+      images: images.length > 0 ? images : undefined,
     }
   };
 }

--- a/apps/factory/src/shared/tasks.ts
+++ b/apps/factory/src/shared/tasks.ts
@@ -30,6 +30,7 @@ export interface TaskMetadata {
   project?: string;              // Linear project name (undefined for GitHub)
   repo?: string;                 // "owner/repo" — resolved at fetch time
   comments?: TaskComment[];      // Linear comments, newest-first when rendered
+  images?: string[];             // Image URLs embedded in the body/comments (deduped, http(s) only)
 }
 
 // Unified task interface for aggregating tasks from multiple sources.

--- a/apps/factory/ui/bun.lock
+++ b/apps/factory/ui/bun.lock
@@ -41,6 +41,7 @@
         "tiptap-markdown": "^0.8.10",
       },
       "devDependencies": {
+        "@happy-dom/global-registrator": "^20.10.6",
         "@tailwindcss/vite": "^4.1.18",
         "@types/bun": "latest",
         "@types/react": "^19.2.7",
@@ -146,6 +147,8 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.6" } }, "sha512-Nu/IjRkkNxmeG2ywWsyJSO4d1BrWTqVzxCPL+gXj0b97klhmjd6wLzt6Bx/laNpkZ3WLW7zNCqmtMIbIlahqug=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -389,6 +392,10 @@
 
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.1.2", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.53", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ=="],
 
     "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
@@ -400,6 +407,8 @@
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.8", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-Y1fOuNDowLfgKOypdc9SPABfoWXuZHBOyCS4cD52IeZBhr4Md6CLLs6atcxVrzRmQ06E7hSlm5bHHApPKR/byA=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
     "bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
 
@@ -431,7 +440,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.18.4", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
@@ -458,6 +467,8 @@
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
+
+    "happy-dom": ["happy-dom@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw=="],
 
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
@@ -633,6 +644,10 @@
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "@radix-ui/react-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
@@ -652,6 +667,8 @@
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "markdown-it/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "markdown-it/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "prosemirror-markdown/@types/markdown-it": ["@types/markdown-it@14.1.2", "", { "dependencies": { "@types/linkify-it": "^5", "@types/mdurl": "^2" } }, "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog=="],
 

--- a/apps/factory/ui/package.json
+++ b/apps/factory/ui/package.json
@@ -9,6 +9,7 @@
     "build": "bun run build:settings && bun run build:editor"
   },
   "devDependencies": {
+    "@happy-dom/global-registrator": "^20.10.6",
     "@tailwindcss/vite": "^4.1.18",
     "@types/bun": "latest",
     "@types/react": "^19.2.7",

--- a/apps/factory/ui/settings/components/bench/TaskDetail.test.tsx
+++ b/apps/factory/ui/settings/components/bench/TaskDetail.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+// TaskDetail renders comment/description bodies through DOMPurify, whose default
+// export binds to `window` at import time. Register happy-dom BEFORE requiring
+// the component so DOMPurify.sanitize is a real function. The production surface
+// is a VS Code webview, which has a window.
+GlobalRegistrator.register()
+
+const React = require('react')
+const { renderToStaticMarkup } = require('react-dom/server')
+const { TaskDetail } = require('./TaskDetail')
+import type { FlatTask } from './TaskCard'
+
+function makeTask(overrides: Partial<FlatTask> = {}): FlatTask {
+  return {
+    id: 'linear:iss_1',
+    source: 'linear',
+    title: 'Broken layout',
+    description: 'Repro steps',
+    status: 'in_progress',
+    metadata: {
+      identifier: 'RUSH-9',
+      url: 'https://linear.app/acme/issue/RUSH-9',
+      comments: [
+        { body: 'This reproduces on Safari too', createdAt: '2026-07-01T00:00:00Z', author: 'Ada' },
+      ],
+      images: ['https://uploads.linear.app/shot.png'],
+    },
+    ...overrides,
+  }
+}
+
+describe('TaskDetail comments + images', () => {
+  test('renders a comment body and an <img> for each metadata image', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(TaskDetail, {
+        task: makeTask(),
+        onDispatch: () => {},
+        onDismiss: () => {},
+        onOpenExternal: () => {},
+      })
+    )
+
+    // Comment author + body render.
+    expect(html).toContain('Ada')
+    expect(html).toContain('This reproduces on Safari too')
+
+    // Images section renders an <img> pointing at the metadata URL.
+    expect(html).toContain('Images (1)')
+    expect(html).toContain('<img')
+    expect(html).toContain('src="https://uploads.linear.app/shot.png"')
+  })
+
+  test('omits the Images section when there are no images', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(TaskDetail, {
+        task: makeTask({
+          metadata: { identifier: 'RUSH-9', url: 'https://linear.app/x', comments: [] },
+        }),
+        onDispatch: () => {},
+        onDismiss: () => {},
+        onOpenExternal: () => {},
+      })
+    )
+    expect(html).not.toContain('Images (')
+  })
+
+  test('drops non-http(s) image URLs from render', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(TaskDetail, {
+        task: makeTask({
+          metadata: { images: ['javascript:alert(1)', 'https://ok.example/a.png'] },
+        }),
+        onDispatch: () => {},
+        onDismiss: () => {},
+        onOpenExternal: () => {},
+      })
+    )
+    expect(html).toContain('Images (1)')
+    expect(html).not.toContain('javascript:alert(1)')
+    expect(html).toContain('src="https://ok.example/a.png"')
+  })
+})

--- a/apps/factory/ui/settings/components/bench/TaskDetail.tsx
+++ b/apps/factory/ui/settings/components/bench/TaskDetail.tsx
@@ -53,6 +53,9 @@ export function TaskDetail({ task, cycleInfo, onDispatch, onDismiss, onOpenExter
   const url = task.metadata?.url
   const state = task.metadata?.state
   const comments = task.metadata?.comments ?? []
+  const images = (task.metadata?.images ?? []).filter(
+    (src): src is string => typeof src === 'string' && /^https?:\/\//i.test(src)
+  )
 
   return (
     <>
@@ -154,6 +157,37 @@ export function TaskDetail({ task, cycleInfo, onDispatch, onDismiss, onOpenExter
                   </div>
                   <div className="sw-detail-comment-body">{renderTodoDescription(c.body, false)}</div>
                 </div>
+              ))}
+            </div>
+          </>
+        )}
+
+        {images.length > 0 && (
+          <>
+            <div className="sw-panel-section-head">Images ({images.length})</div>
+            <div
+              className="sw-detail-images"
+              style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}
+            >
+              {images.map((src, i) => (
+                <img
+                  key={i}
+                  src={src}
+                  className="sw-detail-image"
+                  loading="lazy"
+                  alt=""
+                  title="Open image externally"
+                  onClick={() => onOpenExternal(src)}
+                  style={{
+                    maxWidth: '100%',
+                    maxHeight: 240,
+                    height: 'auto',
+                    borderRadius: 6,
+                    border: '1px solid var(--sw-border, rgba(255,255,255,0.1))',
+                    cursor: 'pointer',
+                    display: 'block',
+                  }}
+                />
               ))}
             </div>
           </>


### PR DESCRIPTION
## What

Surface **COMMENTS** and **IMAGES** in the Factory Bench task detail.

Comments already rendered (`TaskDetail.tsx` — author + body via `renderTodoDescription`). This adds an **Images** section and the data plumbing to populate it. Rebased onto the `apps/` restructure; canonical task types now live in `src/shared/tasks.ts`.

## Changes

- **`apps/factory/src/shared/tasks.ts`** — add `images?: string[]` to the canonical `TaskMetadata` (the single `@shared` definition consumed by both the extension and the webview, so it flows to both sides of the postMessage boundary).
- **`apps/factory/src/core/tasks.ts`** — new pure `extractImageUrls(...bodies)` helper pulls markdown `![](…)` and HTML `<img src>` URLs (http(s) only, deduped, order-preserving). Populated in both `linearToUnifiedTask` (description + comment bodies — where Linear-uploaded images embed as `uploads.linear.app` markdown) and `githubToUnifiedTask` (issue body). The Linear GraphQL fetch does not request the `attachments` connection, so body-embedded images are the source available at fetch time.
- **`apps/factory/ui/settings/components/bench/TaskDetail.tsx`** — render an **Images** section below Comments; each URL becomes a width-constrained `<img>` (`maxWidth:100%`, `maxHeight:240`) that opens externally on click via the existing `onOpenExternal` prop. Non-http(s) URLs filtered at render.

## Tests

- `apps/factory/src/core/tasks.test.ts` — `extractImageUrls` (markdown + HTML, dedupe, drops `data:`/relative/`javascript:`, strips titles); `linearToUnifiedTask` maps comment author/body and extracts images from description + comments; `githubToUnifiedTask` extracts from body.
- `apps/factory/ui/settings/components/bench/TaskDetail.test.tsx` — render assertions (via `react-dom/server`) that a comment body and an `<img src=…>` appear, that the section is omitted with no images, and that `javascript:` URLs are dropped. Adds `@happy-dom/global-registrator` (devDep) so the DOMPurify markdown path renders under `bun test`.

## Verify

- `bun test` (core `tasks.test.ts` + bench `TaskDetail.test.tsx`): **11 pass / 0 fail**
- `cd apps/factory/ui && bun run build:settings`: clean
- `tsc`: no new errors in touched files