### PR TITLE
feat(factory): sub-tab strip + contextual controls + task tabs

### DIFF
--- a/packages/factory/ui/settings/components/mission-control/BacklogCenter.test.tsx
+++ b/packages/factory/ui/settings/components/mission-control/BacklogCenter.test.tsx
@@ -1,0 +1,64 @@
+import { describe, test, expect } from 'bun:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { BacklogCenter } from './BacklogCenter'
+import type { FloorTicket, TicketSource } from './floorModel'
+
+const noop = () => {}
+const srcFilter: Record<TicketSource, boolean> = { LN: true, GH: true }
+
+const tickets: FloorTicket[] = [
+  { id: 'RUSH-1', title: 'Fix the thing', project: 'rush', source: 'LN', pri: 'high', status: 'todo', desc: '', labels: ['bug'] },
+  { id: '#42', title: 'Kanban stub', project: 'swarmify', source: 'GH', pri: 'med', status: 'in-progress', desc: '', labels: [] },
+]
+
+function markup(): string {
+  return renderToStaticMarkup(
+    <BacklogCenter
+      tickets={tickets}
+      group="project"
+      sort="priority"
+      srcFilter={srcFilter}
+      projFilter={null}
+      search=""
+      selectedTicketId={null}
+      onSelectTicket={noop}
+      onOpenTask={noop}
+    />,
+  )
+}
+
+describe('BacklogCenter', () => {
+  test('no longer renders its own toolbar — the duplicate bktoolbar is gone', () => {
+    const html = markup()
+    expect(html).not.toContain('bktoolbar')
+    // The group/sort <select>s that lived in that toolbar are gone too (they moved
+    // to the shared contextual bar). Only ticket rows + section headers remain.
+    expect(html).not.toContain('<select')
+  })
+
+  test('still renders the ticket rows it is responsible for', () => {
+    const html = markup()
+    expect(html).toContain('trow2')
+    expect(html).toContain('RUSH-1')
+    expect(html).toContain('Fix the thing')
+  })
+
+  test('respects the source filter driven by the shared bar', () => {
+    const html = renderToStaticMarkup(
+      <BacklogCenter
+        tickets={tickets}
+        group="project"
+        sort="priority"
+        srcFilter={{ LN: true, GH: false }}
+        projFilter={null}
+        search=""
+        selectedTicketId={null}
+        onSelectTicket={noop}
+        onOpenTask={noop}
+      />,
+    )
+    expect(html).toContain('RUSH-1') // LN kept
+    expect(html).not.toContain('Kanban stub') // GH filtered out
+  })
+})

--- a/packages/factory/ui/settings/components/mission-control/BacklogCenter.tsx
+++ b/packages/factory/ui/settings/components/mission-control/BacklogCenter.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Icon } from './icons'
 import {
   groupTickets,
   sortTickets,
@@ -9,43 +8,42 @@ import {
   type TicketSource,
 } from './floorModel'
 
-// Full ticket list (backlog) with group/sort/filter toolbar. Prototype
-// backlogCenter():651-665 + ticketRow():641-650. Filtering/grouping/sorting reuse the
-// canonical pure functions from floorModel — this stays presentation only.
-
-const GROUP_OPTS: { value: TicketGroupBy; label: string }[] = [
-  { value: 'project', label: 'Project' },
-  { value: 'priority', label: 'Priority' },
-  { value: 'source', label: 'Source' },
-  { value: 'status', label: 'Status' },
-]
-const SORT_OPTS: TicketSort[] = ['priority', 'id']
+// Full ticket list (backlog). Group/sort/source controls now live in the shared
+// contextual bar (FloorControls, mode='backlog') — this component's own duplicate
+// `.bktoolbar` was removed so the Backlog view renders ONE controls bar, not two.
+// Filtering/grouping/sorting still reuse the canonical pure functions from floorModel;
+// this stays presentation only. Single-click previews a ticket in the right pane;
+// double-click opens it as a task tab. Prototype ticketRow():641-650.
 
 interface BacklogCenterProps {
   tickets: FloorTicket[]
   group: TicketGroupBy
   sort: TicketSort
-  /** Which ticket sources are visible (Linear / GitHub chips). */
+  /** Which ticket sources are visible (Linear / GitHub) — driven by the shared bar. */
   srcFilter: Record<TicketSource, boolean>
   /** null = all projects; a project name scopes the list. */
   projFilter: string | null
-  /** Free-text query from the top bar (matches id / title / labels). */
+  /** Free-text query from the shared bar (matches id / title / labels). */
   search: string
   selectedTicketId: string | null
-  onGroup: (by: TicketGroupBy) => void
-  onSort: (by: TicketSort) => void
-  onToggleSrc: (src: TicketSource) => void
   onSelectTicket: (id: string) => void
-  onBackToAgents: () => void
+  /** Double-click a row to open it as a closeable task tab. */
+  onOpenTask: (ticket: FloorTicket) => void
 }
 
-function TicketRow({ ticket: t, selected, onSelect }: {
+function TicketRow({ ticket: t, selected, onSelect, onOpen }: {
   ticket: FloorTicket
   selected: boolean
   onSelect: (id: string) => void
+  onOpen: (ticket: FloorTicket) => void
 }) {
   return (
-    <div className={`trow2${selected ? ' selsel' : ''}`} data-tid={t.id} onClick={() => onSelect(t.id)}>
+    <div
+      className={`trow2${selected ? ' selsel' : ''}`}
+      data-tid={t.id}
+      onClick={() => onSelect(t.id)}
+      onDoubleClick={() => onOpen(t)}
+    >
       <span className={`pri ${t.pri}`} />
       <span className={`src ${t.source}`}>{t.source}</span>
       <span className="tid">{t.id}</span>
@@ -63,7 +61,7 @@ function TicketRow({ ticket: t, selected, onSelect }: {
 
 export function BacklogCenter({
   tickets, group, sort, srcFilter, projFilter, search, selectedTicketId,
-  onGroup, onSort, onToggleSrc, onSelectTicket, onBackToAgents,
+  onSelectTicket, onOpenTask,
 }: BacklogCenterProps) {
   // Backlog = work you can still dispatch onto, so completed tickets are excluded.
   const q = search.trim().toLowerCase()
@@ -82,29 +80,6 @@ export function BacklogCenter({
 
   return (
     <div className="feed">
-      <div className="bktoolbar">
-        <span className="seeall" onClick={onBackToAgents}><Icon name="chevL" size={11} /> Agents</span>
-        <div className="bh2">BACKLOG · {list.length} tickets</div>
-        <div className="grow" />
-        <span className="bksel">
-          Group{' '}
-          <select value={group} onChange={(e) => onGroup(e.target.value as TicketGroupBy)}>
-            {GROUP_OPTS.map((o) => (
-              <option key={o.value} value={o.value}>{o.label}</option>
-            ))}
-          </select>
-        </span>
-        <span className="bksel">
-          Sort{' '}
-          <select value={sort} onChange={(e) => onSort(e.target.value as TicketSort)}>
-            {SORT_OPTS.map((o) => (
-              <option key={o} value={o}>{o === 'id' ? 'ID' : 'Priority'}</option>
-            ))}
-          </select>
-        </span>
-        <span className={`chip ${srcFilter.LN ? 'on' : ''}`} onClick={() => onToggleSrc('LN')}>LN</span>
-        <span className={`chip ${srcFilter.GH ? 'on' : ''}`} onClick={() => onToggleSrc('GH')}>GH</span>
-      </div>
       {[...groups.entries()].map(([k, arr]) => (
         <React.Fragment key={k}>
           <div className="feed-sec">
@@ -117,6 +92,7 @@ export function BacklogCenter({
               ticket={t}
               selected={selectedTicketId === t.id}
               onSelect={onSelectTicket}
+              onOpen={onOpenTask}
             />
           ))}
         </React.Fragment>

--- a/packages/factory/ui/settings/components/mission-control/FloorControls.test.tsx
+++ b/packages/factory/ui/settings/components/mission-control/FloorControls.test.tsx
@@ -1,0 +1,73 @@
+import { describe, test, expect } from 'bun:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { FloorControls, floorControlsMode } from './FloorControls'
+import type { TicketSource } from './floorModel'
+
+describe('floorControlsMode', () => {
+  test('agents center wants the agents control set', () => {
+    expect(floorControlsMode('agents')).toBe('agents')
+  })
+  test('backlog center wants the backlog control set', () => {
+    expect(floorControlsMode('backlog')).toBe('backlog')
+  })
+  test('host center wants NO controls (bar is gated off)', () => {
+    expect(floorControlsMode('host')).toBeNull()
+  })
+})
+
+const noop = () => {}
+const srcFilter: Record<TicketSource, boolean> = { LN: true, GH: true }
+
+function markup(mode: 'agents' | 'backlog'): string {
+  return renderToStaticMarkup(
+    <FloorControls
+      mode={mode}
+      runningCount={2}
+      totalCount={5}
+      sidebarOpen
+      onToggleSidebar={noop}
+      rightOpen
+      onToggleRight={noop}
+      plain={false}
+      onTogglePlain={noop}
+      sort="needs"
+      onSort={noop}
+      activeStatus={[]}
+      onToggleStatus={noop}
+      activeAbbrs={[]}
+      onToggleAbbr={noop}
+      ticketGroup="project"
+      onTicketGroup={noop}
+      ticketSort="priority"
+      onTicketSort={noop}
+      srcFilter={srcFilter}
+      onToggleSrc={noop}
+      search=""
+      onSearch={noop}
+    />,
+  )
+}
+
+describe('FloorControls renders the correct control set per mode', () => {
+  test("agents mode shows the agents Status/Agent chips, not the backlog LN/GH source chips", () => {
+    const html = markup('agents')
+    expect(html).toContain('Needs you') // agents Status chip
+    expect(html).toContain('Running')
+    expect(html).toContain('>CC<') // agent-type chip
+    expect(html).not.toContain('>LN<') // backlog source chip must NOT be here
+  })
+
+  test('backlog mode shows Group + LN/GH source chips, not the agents Status chips', () => {
+    const html = markup('backlog')
+    expect(html).toContain('Group')
+    expect(html).toContain('>LN<')
+    expect(html).toContain('>GH<')
+    expect(html).not.toContain('Needs you') // agents Status chip must NOT be here
+  })
+
+  test('neither mode renders the Dispatch button — it moved to the sub-tab strip', () => {
+    expect(markup('agents')).not.toContain('Dispatch')
+    expect(markup('backlog')).not.toContain('Dispatch')
+  })
+})

--- a/packages/factory/ui/settings/components/mission-control/FloorControls.tsx
+++ b/packages/factory/ui/settings/components/mission-control/FloorControls.tsx
@@ -1,13 +1,32 @@
 import React from 'react'
 import { Icon } from './icons'
-import type { AgentAbbr, FloorSort } from './floorModel'
+import type {
+  AgentAbbr,
+  CenterMode,
+  FloorSort,
+  TicketGroupBy,
+  TicketSort,
+  TicketSource,
+} from './floorModel'
 
-// Single Floor filter bar (Sort · Status · Agent · search · stats · toggles · Dispatch).
-// The old duplicate ".top" header (second FACTORY logo + theme toggle) was removed —
-// the app-level TopBar is the one and only header. Controls are grouped with separators
-// and the bar never wraps (overflow-x scrolls). Prototype: factory-floor-v2.html fbar.
+// Contextual Floor filter bar. It renders ONE control set for the ACTIVE sub-tab
+// (agents vs backlog) instead of the old unconditional global bar — so the Backlog
+// view no longer stacked the agents Group/Sort bar on top of its own toolbar. The
+// Dispatch button now lives on the sub-tab strip (FloorSubtabs), not here. The right
+// cluster (running stat, plain-language, panel toggles) is chrome common to both modes.
+// Prototype: factory-floor-v2.html fbar.
 
 export type StatusChip = 'needs' | 'running' | 'idle' | 'failed'
+
+/**
+ * Which contextual control set a center wants. Pure so the parent gates the bar off
+ * for centers that have no controls (host / projects) and the choice is unit-tested.
+ */
+export function floorControlsMode(center: CenterMode): 'agents' | 'backlog' | null {
+  if (center === 'agents') return 'agents'
+  if (center === 'backlog') return 'backlog'
+  return null
+}
 
 const SORT_OPTS: { value: FloorSort; label: string }[] = [
   { value: 'needs', label: 'Needs you first' },
@@ -16,11 +35,24 @@ const SORT_OPTS: { value: FloorSort; label: string }[] = [
   { value: 'name', label: 'Name' },
 ]
 
+// Backlog group/sort options — moved here from BacklogCenter's now-removed toolbar so
+// the single contextual bar owns them (one bar, zero duplication).
+const TICKET_GROUP_OPTS: { value: TicketGroupBy; label: string }[] = [
+  { value: 'project', label: 'Project' },
+  { value: 'priority', label: 'Priority' },
+  { value: 'source', label: 'Source' },
+  { value: 'status', label: 'Status' },
+]
+const TICKET_SORT_OPTS: TicketSort[] = ['priority', 'id']
+
 const DEFAULT_AGENT_CHIPS: AgentAbbr[] = ['CC', 'CX', 'GX']
 
 const SVG = { fill: 'none', stroke: 'currentColor', strokeWidth: 1.4 } as const
 
 interface FloorControlsProps {
+  /** Which control set to render. Center 'host'/other renders no bar (parent gates). */
+  mode: 'agents' | 'backlog'
+
   runningCount: number
   totalCount: number
 
@@ -31,6 +63,7 @@ interface FloorControlsProps {
   plain: boolean
   onTogglePlain: () => void
 
+  // --- agents-mode controls ---
   sort: FloorSort
   onSort: (s: FloorSort) => void
   /** Which status chips are active. */
@@ -42,63 +75,106 @@ interface FloorControlsProps {
   activeAbbrs: AgentAbbr[]
   onToggleAbbr: (abbr: AgentAbbr) => void
 
+  // --- backlog-mode controls ---
+  ticketGroup: TicketGroupBy
+  onTicketGroup: (by: TicketGroupBy) => void
+  ticketSort: TicketSort
+  onTicketSort: (by: TicketSort) => void
+  srcFilter: Record<TicketSource, boolean>
+  onToggleSrc: (src: TicketSource) => void
+
   search: string
   onSearch: (q: string) => void
-  onDispatch: () => void
 }
 
 export function FloorControls({
+  mode,
   runningCount, totalCount,
   sidebarOpen, onToggleSidebar, rightOpen, onToggleRight, plain, onTogglePlain,
   sort, onSort, activeStatus, onToggleStatus, agentChips = DEFAULT_AGENT_CHIPS, activeAbbrs, onToggleAbbr,
-  search, onSearch, onDispatch,
+  ticketGroup, onTicketGroup, ticketSort, onTicketSort, srcFilter, onToggleSrc,
+  search, onSearch,
 }: FloorControlsProps) {
   const statusOn = new Set(activeStatus)
   const abbrOn = new Set(activeAbbrs)
 
   return (
-    <div className="fbar">
-      <div className="fgroup">
-        <span className="fgroup-label">Sort</span>
-        <select className="sel" value={sort} onChange={(e) => onSort(e.target.value as FloorSort)}>
-          {SORT_OPTS.map((o) => (
-            <option key={o.value} value={o.value}>{o.label}</option>
-          ))}
-        </select>
-      </div>
+    <div className="fbar" data-mode={mode}>
+      {mode === 'agents' ? (
+        <>
+          <div className="fgroup">
+            <span className="fgroup-label">Sort</span>
+            <select className="sel" value={sort} onChange={(e) => onSort(e.target.value as FloorSort)}>
+              {SORT_OPTS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </div>
 
-      <div className="fsep" />
+          <div className="fsep" />
 
-      <div className="fgroup">
-        <span className="fgroup-label">Status</span>
-        <span className={`chip needs ${statusOn.has('needs') ? 'on' : ''}`} onClick={() => onToggleStatus('needs')}>
-          <Icon name="alert" size={11} /> Needs you
-        </span>
-        <span className={`chip ${statusOn.has('running') ? 'on' : ''}`} onClick={() => onToggleStatus('running')}>
-          <span className="dot running" /> Running
-        </span>
-        <span className={`chip ${statusOn.has('idle') ? 'on' : ''}`} onClick={() => onToggleStatus('idle')}>
-          <span className="dot idle" /> Idle
-        </span>
-        <span className={`chip ${statusOn.has('failed') ? 'on' : ''}`} onClick={() => onToggleStatus('failed')}>
-          <span className="dot failed" /> Failed
-        </span>
-      </div>
+          <div className="fgroup">
+            <span className="fgroup-label">Status</span>
+            <span className={`chip needs ${statusOn.has('needs') ? 'on' : ''}`} onClick={() => onToggleStatus('needs')}>
+              <Icon name="alert" size={11} /> Needs you
+            </span>
+            <span className={`chip ${statusOn.has('running') ? 'on' : ''}`} onClick={() => onToggleStatus('running')}>
+              <span className="dot running" /> Running
+            </span>
+            <span className={`chip ${statusOn.has('idle') ? 'on' : ''}`} onClick={() => onToggleStatus('idle')}>
+              <span className="dot idle" /> Idle
+            </span>
+            <span className={`chip ${statusOn.has('failed') ? 'on' : ''}`} onClick={() => onToggleStatus('failed')}>
+              <span className="dot failed" /> Failed
+            </span>
+          </div>
 
-      <div className="fsep" />
+          <div className="fsep" />
 
-      <div className="fgroup">
-        <span className="fgroup-label">Agent</span>
-        {agentChips.map((ab) => (
-          <span key={ab} className={`chip ${abbrOn.has(ab) ? 'on' : ''}`} onClick={() => onToggleAbbr(ab)}>{ab}</span>
-        ))}
-      </div>
+          <div className="fgroup">
+            <span className="fgroup-label">Agent</span>
+            {agentChips.map((ab) => (
+              <span key={ab} className={`chip ${abbrOn.has(ab) ? 'on' : ''}`} onClick={() => onToggleAbbr(ab)}>{ab}</span>
+            ))}
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="fgroup">
+            <span className="fgroup-label">Group</span>
+            <select className="sel" value={ticketGroup} onChange={(e) => onTicketGroup(e.target.value as TicketGroupBy)}>
+              {TICKET_GROUP_OPTS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="fsep" />
+
+          <div className="fgroup">
+            <span className="fgroup-label">Sort</span>
+            <select className="sel" value={ticketSort} onChange={(e) => onTicketSort(e.target.value as TicketSort)}>
+              {TICKET_SORT_OPTS.map((o) => (
+                <option key={o} value={o}>{o === 'id' ? 'ID' : 'Priority'}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="fsep" />
+
+          <div className="fgroup">
+            <span className="fgroup-label">Source</span>
+            <span className={`chip ${srcFilter.LN ? 'on' : ''}`} onClick={() => onToggleSrc('LN')}>LN</span>
+            <span className={`chip ${srcFilter.GH ? 'on' : ''}`} onClick={() => onToggleSrc('GH')}>GH</span>
+          </div>
+        </>
+      )}
 
       <div className="fsep" />
 
       <input
         className="search"
-        placeholder="search agents, branches, activity…"
+        placeholder={mode === 'agents' ? 'search agents, branches, activity…' : 'search tickets, ids, labels…'}
         value={search}
         onChange={(e) => onSearch(e.target.value)}
       />
@@ -127,7 +203,6 @@ export function FloorControls({
           <line x1="10" y1="2.5" x2="10" y2="13.5" />
         </svg>
       </button>
-      <button className="disp" onClick={onDispatch}><Icon name="zap" size={12} /> Dispatch</button>
     </div>
   )
 }

--- a/packages/factory/ui/settings/components/mission-control/FloorSubtabs.test.ts
+++ b/packages/factory/ui/settings/components/mission-control/FloorSubtabs.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from 'bun:test'
+import { openTaskTab, closeTaskTab, type TaskTab } from './FloorSubtabs'
+
+const tab = (id: string): TaskTab => ({ id, title: `Task ${id}`, source: 'LN' })
+
+describe('openTaskTab', () => {
+  test('appends a new tab', () => {
+    const next = openTaskTab([], tab('A'))
+    expect(next.map((t) => t.id)).toEqual(['A'])
+  })
+
+  test('de-dupes by id — re-opening the same task does not stack a duplicate', () => {
+    const start = [tab('A'), tab('B')]
+    const next = openTaskTab(start, tab('A'))
+    expect(next).toBe(start) // same reference: no state churn
+    expect(next.map((t) => t.id)).toEqual(['A', 'B'])
+  })
+
+  test('keeps insertion order', () => {
+    let tabs: TaskTab[] = []
+    for (const id of ['A', 'B', 'C']) tabs = openTaskTab(tabs, tab(id))
+    expect(tabs.map((t) => t.id)).toEqual(['A', 'B', 'C'])
+  })
+})
+
+describe('closeTaskTab', () => {
+  test('removes the tab and leaves active untouched when a non-active tab closes', () => {
+    const res = closeTaskTab([tab('A'), tab('B'), tab('C')], 'A', 'C')
+    expect(res.tabs.map((t) => t.id)).toEqual(['A', 'B'])
+    expect(res.activeId).toBe('A')
+  })
+
+  test('closing the active middle tab focuses the LEFT neighbor', () => {
+    const res = closeTaskTab([tab('A'), tab('B'), tab('C')], 'B', 'B')
+    expect(res.tabs.map((t) => t.id)).toEqual(['A', 'C'])
+    expect(res.activeId).toBe('A')
+  })
+
+  test('closing the active FIRST tab focuses the new first tab', () => {
+    const res = closeTaskTab([tab('A'), tab('B'), tab('C')], 'A', 'A')
+    expect(res.tabs.map((t) => t.id)).toEqual(['B', 'C'])
+    expect(res.activeId).toBe('B')
+  })
+
+  test('closing the last remaining tab clears active (falls back to a fixed center tab)', () => {
+    const res = closeTaskTab([tab('A')], 'A', 'A')
+    expect(res.tabs).toEqual([])
+    expect(res.activeId).toBeNull()
+  })
+
+  test('closing an unknown id is a no-op', () => {
+    const start = [tab('A'), tab('B')]
+    const res = closeTaskTab(start, 'A', 'Z')
+    expect(res.tabs).toBe(start)
+    expect(res.activeId).toBe('A')
+  })
+})

--- a/packages/factory/ui/settings/components/mission-control/FloorSubtabs.tsx
+++ b/packages/factory/ui/settings/components/mission-control/FloorSubtabs.tsx
@@ -1,0 +1,125 @@
+import React from 'react'
+import { Icon } from './icons'
+import type { CenterMode, TicketSource } from './floorModel'
+
+// The Floor sub-tab strip. Sits UNDER the top FLOOR/BENCH/PANEL tabs and is the
+// primary nav between the CenterMode surfaces (Agents / Backlog / Hosts), replacing
+// the sidebar's onScope as the way you switch views. Fixed center tabs render as
+// rounded pills (active = lime, with a count + needs badge); dynamically-opened task
+// tabs render to their right as CLOSEABLE pills. The Dispatch button lives on the
+// right of the strip. Prototype concept: sub-tab strip + one contextual controls bar.
+
+/** A fixed center tab (Agents / Backlog / Hosts) with live counts. */
+export interface FixedTab {
+  center: CenterMode
+  label: string
+  count: number
+  /** Needs-you count; renders a red badge when > 0. Omit for centers with no needs. */
+  needs?: number
+}
+
+/** A dynamically-opened, closeable task tab. Double-clicking a ticket or agent opens one. */
+export interface TaskTab {
+  id: string
+  title: string
+  source: TicketSource
+}
+
+/**
+ * Open a task tab, de-duping by id (double-clicking the same ticket focuses the
+ * existing tab instead of stacking a duplicate). Pure so it's unit-tested.
+ */
+export function openTaskTab(tabs: TaskTab[], tab: TaskTab): TaskTab[] {
+  if (tabs.some((t) => t.id === tab.id)) return tabs
+  return [...tabs, tab]
+}
+
+/**
+ * Close a task tab. When the closed tab was active, focus falls to its left neighbor
+ * (or the right one when it was first, or null when it was the last tab — which drops
+ * the user back to the active fixed center tab). Returns the next tabs + active id.
+ * Pure so the open/close/active-fallback logic is unit-tested.
+ */
+export function closeTaskTab(
+  tabs: TaskTab[],
+  activeId: string | null,
+  closeId: string,
+): { tabs: TaskTab[]; activeId: string | null } {
+  const idx = tabs.findIndex((t) => t.id === closeId)
+  if (idx === -1) return { tabs, activeId }
+  const next = tabs.filter((t) => t.id !== closeId)
+  if (activeId !== closeId) return { tabs: next, activeId }
+  if (next.length === 0) return { tabs: next, activeId: null }
+  // Left neighbor (or first tab when the closed one led). Guaranteed in range since
+  // next.length > 0 and idx <= old length - 1, so Math.max(0, idx-1) < next.length.
+  const neighbor = next[Math.max(0, idx - 1)]!
+  return { tabs: next, activeId: neighbor.id }
+}
+
+interface FloorSubtabsProps {
+  fixed: FixedTab[]
+  /** The active fixed center (only visually active when no task tab is active). */
+  center: CenterMode
+  taskTabs: TaskTab[]
+  /** null = a fixed center tab is active; otherwise the active task-tab id. */
+  activeTaskTab: string | null
+  onSelectCenter: (c: CenterMode) => void
+  onSelectTaskTab: (id: string) => void
+  onCloseTaskTab: (id: string) => void
+  onDispatch: () => void
+}
+
+export function FloorSubtabs({
+  fixed, center, taskTabs, activeTaskTab,
+  onSelectCenter, onSelectTaskTab, onCloseTaskTab, onDispatch,
+}: FloorSubtabsProps) {
+  return (
+    <div className="fsubtabs" role="tablist">
+      {fixed.map((t) => {
+        const on = activeTaskTab === null && center === t.center
+        return (
+          <button
+            key={t.center}
+            role="tab"
+            aria-selected={on}
+            className={`fsubtab ${on ? 'on' : ''}`}
+            onClick={() => onSelectCenter(t.center)}
+          >
+            <span className="fsubtab-label">{t.label}</span>
+            <span className="fsubtab-cnt">{t.count}</span>
+            {t.needs ? <span className="fsubtab-needs">{t.needs}</span> : null}
+          </button>
+        )
+      })}
+
+      {taskTabs.map((t) => {
+        const on = activeTaskTab === t.id
+        return (
+          <span
+            key={t.id}
+            role="tab"
+            aria-selected={on}
+            className={`fsubtab tasktab ${on ? 'on' : ''}`}
+            onClick={() => onSelectTaskTab(t.id)}
+          >
+            <span className={`tasktab-src ${t.source}`}>{t.source}</span>
+            <span className="fsubtab-label">{t.title}</span>
+            <span
+              className="tasktab-x"
+              role="button"
+              aria-label={`Close ${t.title}`}
+              title="Close tab"
+              onClick={(e) => { e.stopPropagation(); onCloseTaskTab(t.id) }}
+            >
+              <Icon name="x" size={11} />
+            </span>
+          </span>
+        )
+      })}
+
+      <div className="grow" />
+
+      <button className="disp" onClick={onDispatch}><Icon name="zap" size={12} /> Dispatch</button>
+    </div>
+  )
+}

--- a/packages/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/packages/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -20,10 +20,13 @@ import {
   PENDING_DISPATCH_TTL_MS,
   type PendingDispatch,
 } from './dispatch'
-import { FloorControls, type StatusChip } from './FloorControls'
+import { FloorControls, floorControlsMode, type StatusChip } from './FloorControls'
+import { FloorSubtabs, openTaskTab, closeTaskTab, type FixedTab, type TaskTab } from './FloorSubtabs'
 import { FloorSidebar } from './FloorSidebar'
 import { BacklogCenter } from './BacklogCenter'
 import { TicketDetail } from './TicketDetail'
+import { TaskDetail } from '../bench/TaskDetail'
+import type { FlatTask } from '../bench/TaskCard'
 import { HostDetail } from './HostDetail'
 import { FeedItem, FollowUpBox } from './FeedItem'
 import { TodoChecklist } from './TodoChecklist'
@@ -34,6 +37,7 @@ import {
   sortAgents,
   latestTodos,
   type FloorAgent,
+  type FloorTicket,
   type CenterMode,
   type HostInventory,
   type FloorGroupBy,
@@ -572,6 +576,11 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   // ---------- Floor 3-pane shell state ----------
   const floorPrefs0 = useRef(loadFloorPrefs()).current
   const [center, setCenter] = useState<CenterMode>('agents')
+  // Dynamic task tabs: double-clicking a backlog ticket or agent card opens a
+  // closeable tab in the sub-tab strip. activeTaskTab === null means a fixed center
+  // tab is showing; otherwise the named task tab owns the center pane.
+  const [openTaskTabs, setOpenTaskTabs] = useState<TaskTab[]>([])
+  const [activeTaskTab, setActiveTaskTab] = useState<string | null>(null)
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
   const [selectedTicketId, setSelectedTicketId] = useState<string | null>(null)
   const [projFilter, setProjFilter] = useState<string | null>(null)
@@ -1483,6 +1492,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   }, [])
 
   const onScope = useCallback((value: string) => {
+    setActiveTaskTab(null)
     if (value === '__queue') { setCenter('backlog'); return }
     if (value === '__needs') { setCenter('agents'); setProjFilter(null); setHostFilter(null); return }
     if (value.startsWith('host:')) {
@@ -1497,13 +1507,52 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   }, [])
 
   const selectFloorAgent = useCallback((id: string) => {
+    setActiveTaskTab(null)
     setCenter('agents')
     setSelectedAgentId(id)
+  }, [])
+
+  // ---------- sub-tab strip: fixed center tabs + dynamic task tabs ----------
+  // Switch to a fixed center tab (Agents / Backlog / Hosts). Clears any active task
+  // tab so the strip highlights the center pill and the center pane shows that view.
+  const selectCenter = useCallback((c: CenterMode) => {
+    setActiveTaskTab(null)
+    setCenter(c)
+  }, [])
+
+  // Open (or focus) a task tab from a backlog ticket — the primary open path.
+  const openTaskFromTicket = useCallback((ticket: FloorTicket) => {
+    setOpenTaskTabs((prev) => openTaskTab(prev, { id: ticket.id, title: ticket.title, source: ticket.source }))
+    setActiveTaskTab(ticket.id)
+  }, [])
+
+  // Open (or focus) a task tab from an agent card. Keys off the agent's linked ticket
+  // when it has one (so it collapses with the ticket's tab); otherwise the agent id.
+  const openTaskFromAgent = useCallback((a: FloorAgent) => {
+    const id = a.ticket ?? a.id
+    const source: TicketSource = a.ticket?.startsWith('#') ? 'GH' : 'LN'
+    setOpenTaskTabs((prev) => openTaskTab(prev, { id, title: a.ticket ?? a.name, source }))
+    setActiveTaskTab(id)
+  }, [])
+
+  const selectTaskTab = useCallback((id: string) => setActiveTaskTab(id), [])
+
+  const handleCloseTaskTab = useCallback((id: string) => {
+    setActiveTaskTab((curActive) => {
+      let nextActive = curActive
+      setOpenTaskTabs((prev) => {
+        const res = closeTaskTab(prev, curActive, id)
+        nextActive = res.activeId
+        return res.tabs
+      })
+      return nextActive
+    })
   }, [])
 
   // Host detail pane: clicking a host in the sidebar opens its detail/config on
   // the right and fetches its inventory (cached backend-side).
   const onSelectHost = useCallback((hostName: string) => {
+    setActiveTaskTab(null)
     setCenter('host')
     setSelectedHostId(hostName)
     setHostConfigError(null)
@@ -1601,7 +1650,65 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     )
   }
 
-  const centerContent = center === 'backlog' ? (
+  // A feed row: the shared FeedItem (single-click selects → right-pane preview) wrapped
+  // in a display:contents span whose double-click opens the agent as a task tab. The
+  // wrapper adds no layout box, so it can't disturb the .feed spacing.
+  const renderAgentFeedItem = (a: FloorAgent) => (
+    <span key={a.id} style={{ display: 'contents' }} onDoubleClick={() => openTaskFromAgent(a)}>
+      <FeedItem
+        agent={a}
+        selected={selectedFloorAgent?.id === a.id}
+        plain={plain}
+        onSelect={selectFloorAgent}
+        onOption={onAgentOption}
+        onFreeText={replyToAgent}
+        onAttach={onAttachScreenshot}
+      />
+    </span>
+  )
+
+  // Sub-tab strip model: three fixed center tabs with live counts + needs badge.
+  const backlogOpenCount = useMemo(() => floorTickets.filter((t) => t.status !== 'done').length, [floorTickets])
+  const hostsCount = dispatchDevices.length || fleetDevices.length
+  const fixedTabs: FixedTab[] = [
+    { center: 'agents', label: 'Agents', count: floorAgents.length, needs: needsAgents.length },
+    { center: 'backlog', label: 'Backlog', count: backlogOpenCount },
+    { center: 'host', label: 'Hosts', count: hostsCount },
+  ]
+
+  // Active task tab (if any) + its backing FlatTask, resolved from the unified queue
+  // by id or Linear/GitHub identifier so the bench TaskDetail can render it read-only.
+  const activeTab = activeTaskTab ? openTaskTabs.find((t) => t.id === activeTaskTab) ?? null : null
+  const activeTabTask: FlatTask | null = activeTab
+    ? (() => {
+        const ut = unifiedTasks.find((t) => t.id === activeTab.id || t.metadata.identifier === activeTab.id)
+        return ut
+          ? { id: ut.id, source: ut.source, title: ut.title, description: ut.description, status: ut.status, priority: ut.priority, metadata: ut.metadata }
+          : null
+      })()
+    : null
+
+  const centerContent = activeTab ? (
+    <div className="feed sw-tasktab-pane">
+      <div className="sw-bench-detail">
+        {activeTabTask ? (
+          <TaskDetail
+            task={activeTabTask}
+            onDispatch={(t) => openDispatch({ ticketId: t.id })}
+            onDismiss={() => handleCloseTaskTab(activeTab.id)}
+            onOpenExternal={(url) => postMessage({ type: 'openExternal', url })}
+          />
+        ) : (
+          <div className="detail-empty" style={{ flexDirection: 'column', gap: 12 }}>
+            <span>{activeTab.title}</span>
+            <button className="disp" onClick={() => openDispatch({ ticketId: activeTab.id })}>
+              <Icon name="zap" size={12} /> Dispatch
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  ) : center === 'backlog' ? (
     <BacklogCenter
       tickets={floorTickets}
       group={ticketGroup}
@@ -1610,11 +1717,8 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
       projFilter={projFilter}
       search={floorSearch}
       selectedTicketId={selectedTicketId}
-      onGroup={setTicketGroup}
-      onSort={setTicketSort}
-      onToggleSrc={(src) => setTicketSrc((p) => ({ ...p, [src]: !p[src] }))}
       onSelectTicket={(id) => setSelectedTicketId(id)}
-      onBackToAgents={() => setCenter('agents')}
+      onOpenTask={openTaskFromTicket}
     />
   ) : (
     <div className="feed">
@@ -1644,18 +1748,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
             onBatchReply={onBatchReply}
             onReplyOne={selectFloorAgent}
           />
-          {questionClusters.filter((c) => c.length === 1).map((c) => (
-            <FeedItem
-              key={c[0].id}
-              agent={c[0]}
-              selected={selectedFloorAgent?.id === c[0].id}
-              plain={plain}
-              onSelect={selectFloorAgent}
-              onOption={onAgentOption}
-              onFreeText={replyToAgent}
-              onAttach={onAttachScreenshot}
-            />
-          ))}
+          {questionClusters.filter((c) => c.length === 1).map((c) => renderAgentFeedItem(c[0]!))}
           {failedAgents.map((a) => (
             <FailureCard
               key={a.id}
@@ -1665,18 +1758,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               onReassign={(toAgent) => reassignFloorAgent(a, toAgent)}
             />
           ))}
-          {reviewNeedsAgents.map((a) => (
-            <FeedItem
-              key={a.id}
-              agent={a}
-              selected={selectedFloorAgent?.id === a.id}
-              plain={plain}
-              onSelect={selectFloorAgent}
-              onOption={onAgentOption}
-              onFreeText={replyToAgent}
-              onAttach={onAttachScreenshot}
-            />
-          ))}
+          {reviewNeedsAgents.map((a) => renderAgentFeedItem(a))}
         </>
       )}
 
@@ -1694,34 +1776,12 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               : 'not synced yet'}
         </span>
       </div>
-      {runningFeed.map((a) => (
-        <FeedItem
-          key={a.id}
-          agent={a}
-          selected={selectedFloorAgent?.id === a.id}
-          plain={plain}
-          onSelect={selectFloorAgent}
-          onOption={onAgentOption}
-          onFreeText={replyToAgent}
-          onAttach={onAttachScreenshot}
-        />
-      ))}
+      {runningFeed.map((a) => renderAgentFeedItem(a))}
 
       {doneFeed.length > 0 && (
         <>
           <div className="feed-sec">DONE TODAY · {doneFeed.length}<span className="ln" /></div>
-          {doneFeed.map((a) => (
-            <FeedItem
-              key={a.id}
-              agent={a}
-              selected={selectedFloorAgent?.id === a.id}
-              plain={plain}
-              onSelect={selectFloorAgent}
-              onOption={onAgentOption}
-              onFreeText={replyToAgent}
-              onAttach={onAttachScreenshot}
-            />
-          ))}
+          {doneFeed.map((a) => renderAgentFeedItem(a))}
         </>
       )}
     </div>
@@ -1745,27 +1805,51 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
       : <div className="detail-empty">Select a ticket to see its details and dispatch an agent onto it.</div>)
     : renderAgentDetail()
 
+  // The contextual controls bar renders only for a center that has controls, and never
+  // while a task tab owns the pane (the task detail carries its own header). host/other
+  // centers get no bar — this is the LAYOUT fix that killed the double Group/Sort bar.
+  const controlsMode = activeTaskTab ? null : floorControlsMode(center)
+
   return (
     <div className="sw-floor-dashboard" style={{ padding: 0, overflow: 'hidden' }}>
-      <FloorControls
-        runningCount={floorRunning}
-        totalCount={floorAgents.length}
-        sidebarOpen={sidebarOpen}
-        onToggleSidebar={() => setSidebarOpen((o) => !o)}
-        rightOpen={rightOpen}
-        onToggleRight={() => setRightOpen((o) => !o)}
-        plain={plain}
-        onTogglePlain={() => setPlain((o) => !o)}
-        sort={floorSort}
-        onSort={setFloorSort}
-        activeStatus={statusChips}
-        onToggleStatus={(chip) => setStatusChips((prev) => (prev.includes(chip) ? prev.filter((c) => c !== chip) : [...prev, chip]))}
-        activeAbbrs={abbrChips}
-        onToggleAbbr={(ab) => setAbbrChips((prev) => (prev.includes(ab) ? prev.filter((c) => c !== ab) : [...prev, ab]))}
-        search={floorSearch}
-        onSearch={setFloorSearch}
+      <FloorSubtabs
+        fixed={fixedTabs}
+        center={center}
+        taskTabs={openTaskTabs}
+        activeTaskTab={activeTaskTab}
+        onSelectCenter={selectCenter}
+        onSelectTaskTab={selectTaskTab}
+        onCloseTaskTab={handleCloseTaskTab}
         onDispatch={() => openDispatch(selectedTicketId ? { ticketId: selectedTicketId } : undefined)}
       />
+
+      {controlsMode && (
+        <FloorControls
+          mode={controlsMode}
+          runningCount={floorRunning}
+          totalCount={floorAgents.length}
+          sidebarOpen={sidebarOpen}
+          onToggleSidebar={() => setSidebarOpen((o) => !o)}
+          rightOpen={rightOpen}
+          onToggleRight={() => setRightOpen((o) => !o)}
+          plain={plain}
+          onTogglePlain={() => setPlain((o) => !o)}
+          sort={floorSort}
+          onSort={setFloorSort}
+          activeStatus={statusChips}
+          onToggleStatus={(chip) => setStatusChips((prev) => (prev.includes(chip) ? prev.filter((c) => c !== chip) : [...prev, chip]))}
+          activeAbbrs={abbrChips}
+          onToggleAbbr={(ab) => setAbbrChips((prev) => (prev.includes(ab) ? prev.filter((c) => c !== ab) : [...prev, ab]))}
+          ticketGroup={ticketGroup}
+          onTicketGroup={setTicketGroup}
+          ticketSort={ticketSort}
+          onTicketSort={setTicketSort}
+          srcFilter={ticketSrc}
+          onToggleSrc={(src) => setTicketSrc((p) => ({ ...p, [src]: !p[src] }))}
+          search={floorSearch}
+          onSearch={setFloorSearch}
+        />
+      )}
 
       <div className="page" style={{ flex: 1, minHeight: 0, height: 'auto' }}>
         {sidebarOpen && (
@@ -1791,7 +1875,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
           />
         )}
         <div className="feed-col">{centerContent}</div>
-        {rightOpen && <div className="detail-col">{rightContent}</div>}
+        {rightOpen && !activeTab && <div className="detail-col">{rightContent}</div>}
       </div>
 
       {cardDragActive && (

--- a/packages/factory/ui/settings/components/mission-control/floor.css
+++ b/packages/factory/ui/settings/components/mission-control/floor.css
@@ -78,7 +78,26 @@
 .swarmify-root .chip.on { background: var(--brand); border-color: var(--brand); color: #1a1a1a; }
 .swarmify-root .chip.needs.on { background: var(--status-pending); border-color: var(--status-pending); color: #1a1a1a; }
 .swarmify-root .search { flex: 1 1 160px; min-width: 120px; max-width: 340px; background: var(--ds-bg-panel); border: 1px solid var(--ds-border); border-radius: var(--r-md); padding: 5px 10px; color: var(--ds-text); font-size: 12px; }
-.swarmify-root .disp { display: inline-flex; align-items: center; gap: 6px; background: var(--brand); color: #1a1a1a; border: none; font-weight: 700; padding: 6px 12px; border-radius: var(--r-md); font-size: 12px; white-space: nowrap; flex: 0 0 auto; }
+.swarmify-root .disp { display: inline-flex; align-items: center; gap: 6px; background: var(--brand); color: #1a1a1a; border: none; font-weight: 700; padding: 6px 12px; border-radius: var(--r-md); font-size: 12px; white-space: nowrap; flex: 0 0 auto; cursor: pointer; }
+
+/* Sub-tab strip — sits under the top FLOOR/BENCH/PANEL tabs and is the primary nav
+ * between the CenterMode surfaces. Fixed center pills (active = lime) + dynamic,
+ * closeable task tabs to their right + the Dispatch button pinned to the right. */
+.swarmify-root .fsubtabs { display: flex; align-items: center; gap: 6px; padding: 7px 16px; background: var(--ds-bg); border-bottom: 1px solid var(--ds-border-subtle); flex-wrap: nowrap; overflow-x: auto; scrollbar-width: thin; }
+.swarmify-root .fsubtab { display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--ds-border); background: var(--ds-bg-panel); border-radius: 999px; padding: 5px 12px; font-size: 12px; font-weight: 600; color: var(--ds-text-muted); flex: 0 0 auto; white-space: nowrap; cursor: pointer; line-height: 1; }
+.swarmify-root .fsubtab:hover { color: var(--ds-text); }
+.swarmify-root .fsubtab.on { background: var(--brand); border-color: var(--brand); color: #1a1a1a; }
+.swarmify-root .fsubtab-label { font-weight: 700; }
+.swarmify-root .fsubtab-cnt { font-size: 10.5px; font-weight: 700; color: var(--ds-text-dim); background: var(--ds-bg); border-radius: 999px; padding: 1px 6px; font-variant-numeric: tabular-nums; }
+.swarmify-root .fsubtab.on .fsubtab-cnt { color: #1a1a1a; background: rgba(26, 26, 26, 0.14); }
+.swarmify-root .fsubtab-needs { font-size: 10.5px; font-weight: 700; color: #1a1a1a; background: var(--status-pending); border-radius: 999px; padding: 1px 6px; font-variant-numeric: tabular-nums; }
+.swarmify-root .tasktab { padding-right: 7px; }
+.swarmify-root .tasktab-src { font-size: 9px; font-weight: 800; letter-spacing: .03em; color: var(--ds-text-dim); }
+.swarmify-root .tasktab.on .tasktab-src { color: #1a1a1a; }
+.swarmify-root .tasktab .fsubtab-label { max-width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.swarmify-root .tasktab-x { display: inline-flex; align-items: center; justify-content: center; opacity: .55; border-radius: 999px; padding: 1px; cursor: pointer; }
+.swarmify-root .tasktab-x:hover { opacity: 1; background: rgba(0, 0, 0, 0.18); }
+.swarmify-root .sw-tasktab-pane { display: block; padding: 0; }
 
 /* ---- generic dot / badges ---- */
 .swarmify-root .dot { width: 9px; height: 9px; border-radius: 50%; flex: 0 0 auto; display: inline-block; }

--- a/packages/factory/ui/settings/preview/preview.tsx
+++ b/packages/factory/ui/settings/preview/preview.tsx
@@ -14,7 +14,9 @@ import { Icon } from '../components/mission-control/icons'
 import { FeedItem, TicketStrip } from '../components/mission-control/FeedItem'
 import { SavedViews } from '../components/mission-control/SavedViewsBar'
 import { DispatchPanel } from '../components/mission-control/DispatchPanel'
-import type { FloorAgent, FloorTicket, StructuredQuestion } from '../components/mission-control/floorModel'
+import { FloorSubtabs, type FixedTab, type TaskTab, closeTaskTab } from '../components/mission-control/FloorSubtabs'
+import { FloorControls, floorControlsMode } from '../components/mission-control/FloorControls'
+import type { CenterMode, FloorAgent, FloorTicket, StructuredQuestion } from '../components/mission-control/floorModel'
 import type { UnifiedTask } from '../types'
 import type { InstalledAgent, DispatchHost, DispatchTarget } from '../components/mission-control/dispatch.types'
 
@@ -187,11 +189,89 @@ function Feed() {
   )
 }
 
+// The new Floor sub-tab strip + ONE contextual controls bar, on top of the feed.
+// Shows the fixed center pills (Agents active = lime, with count + needs badge), a
+// couple of open task tabs with their x, the Dispatch button on the right, and the
+// contextual FloorControls that swaps its pills per active center. ?view=subtabs.
+function Subtabs() {
+  const initialCenter = (new URLSearchParams(location.search).get('center') as CenterMode) || 'agents'
+  const [center, setCenter] = useState<CenterMode>(initialCenter)
+  const [taskTabs, setTaskTabs] = useState<TaskTab[]>([
+    { id: 'RUSH-1262', title: 'PKCE token exchange', source: 'LN' },
+    { id: '#418', title: 'Kanban feed views', source: 'GH' },
+  ])
+  const [activeTaskTab, setActiveTaskTab] = useState<string | null>(null)
+  const [group, setGroup] = useState<'project' | 'priority' | 'source' | 'status'>('project')
+
+  const fixed: FixedTab[] = [
+    { center: 'agents', label: 'Agents', count: running.length + done.length, needs: 2 },
+    { center: 'backlog', label: 'Backlog', count: tickets.length },
+    { center: 'host', label: 'Hosts', count: 3 },
+  ]
+  const controlsMode = activeTaskTab ? null : floorControlsMode(center)
+
+  return (
+    <div className="sw-floor-dashboard" style={{ padding: 0 }}>
+      <FloorSubtabs
+        fixed={fixed}
+        center={center}
+        taskTabs={taskTabs}
+        activeTaskTab={activeTaskTab}
+        onSelectCenter={(c) => { setActiveTaskTab(null); setCenter(c) }}
+        onSelectTaskTab={setActiveTaskTab}
+        onCloseTaskTab={(id) => {
+          const res = closeTaskTab(taskTabs, activeTaskTab, id)
+          setTaskTabs(res.tabs)
+          setActiveTaskTab(res.activeId)
+        }}
+        onDispatch={noop}
+      />
+      {controlsMode && (
+        <FloorControls
+          mode={controlsMode}
+          runningCount={2}
+          totalCount={running.length + done.length}
+          sidebarOpen
+          onToggleSidebar={noop}
+          rightOpen
+          onToggleRight={noop}
+          plain={false}
+          onTogglePlain={noop}
+          sort="needs"
+          onSort={noop}
+          activeStatus={[]}
+          onToggleStatus={noop}
+          activeAbbrs={[]}
+          onToggleAbbr={noop}
+          ticketGroup={group}
+          onTicketGroup={setGroup}
+          ticketSort="priority"
+          onTicketSort={noop}
+          srcFilter={{ LN: true, GH: true }}
+          onToggleSrc={noop}
+          search=""
+          onSearch={noop}
+        />
+      )}
+      <div className="page">
+        <div className="feed-col"><Feed /></div>
+      </div>
+    </div>
+  )
+}
+
 function Preview() {
   const params = new URLSearchParams(location.search)
   const theme = params.get('theme') === 'light' ? 'theme-light' : 'theme-dark'
   const view = params.get('view') ?? 'feed'
   const [dispatchOpen] = useState(view === 'dispatch')
+  if (view === 'subtabs') {
+    return (
+      <div className={`swarmify-root ${theme}`} style={{ minHeight: '100vh' }}>
+        <Subtabs />
+      </div>
+    )
+  }
   return (
     <div className={`swarmify-root ${theme}`} style={{ minHeight: '100vh' }}>
       <div className="sw-floor-dashboard" style={{ padding: 0 }}>


### PR DESCRIPTION
## What & why

Upgrades the Factory **FLOOR** to a proper tab system — the approved **Option A** (sub-tab strip + **ONE** contextual controls bar). This is a layout fix.

**Problem:** `FloorControls` (the global Group/Sort bar) rendered *unconditionally* on top of every view, so the **Backlog** view stacked **two** Group/Sort bars — the global one that didn't apply plus `BacklogCenter`'s own `.bktoolbar`.

## Changes

**1. Sub-tab strip — `FloorSubtabs.tsx` (new)**
Primary nav under the top FLOOR/BENCH/PANEL tabs. Fixed center pills **Agents / Backlog / Hosts** (the real `CenterMode` values) with live count + needs badge, active = lime. Dynamic, **closeable** task tabs to the right; **Dispatch** button pinned right. Pure `openTaskTab` / `closeTaskTab` reducers + `floorControlsMode` are unit-tested.

**2. Contextual controls bar — `FloorControls.tsx`**
Now takes `mode: 'agents' | 'backlog'` and renders **one** control set for the active center (`agents` → Sort/Status/Agent; `backlog` → Group/Sort/LN/GH; `host`/other → **no bar**). Dispatch moved to the strip. In `UnifiedAgentsPane` the bar is gated: `controlsMode = activeTaskTab ? null : floorControlsMode(center)`.

**3. `BacklogCenter.tsx`** — removed the duplicate `.bktoolbar` (its controls now live in the shared bar). **One bar, zero duplication.** Double-click a ticket row → opens a task tab; single-click keeps the right-pane preview.

**4. Dynamic task tabs — `UnifiedAgentsPane.tsx`**
`openTaskTabs` / `activeTaskTab` state. Double-clicking a backlog ticket **or** an agent card (via a zero-layout `display:contents` wrapper — `FeedItem` is imported read-only) opens a closeable tab whose center pane renders the bench `<TaskDetail>` (imported read-only) with its Dispatch button.

> **Note:** `CenterMode` is `agents | backlog | host` — there is no `projects` value, so the strip surfaces those three real centers. `floorModel.ts` (the protected SEAM file), `bench/TaskDetail.tsx`, `TicketDetail.tsx`, and `src/shared/tasks.ts` are **untouched**.

## Verification

- `bun test settings/components/mission-control/` → **220 pass / 0 fail** (17 new across `FloorSubtabs.test.ts`, `FloorControls.test.tsx`, `BacklogCenter.test.tsx`).
  - control-set-per-mode, task-tab open/close/active fallback, and an assertion that `BacklogCenter` **no longer renders `bktoolbar`** (via `react-dom/server`).
- `bun run build:settings` → clean (`✓ built in 1.46s`).
- `bunx tsc -p ./ --noEmit` → **no new errors** in touched files (pre-existing `noUncheckedIndexedAccess` errors in unchanged code only).

## Screenshots (preview harness — `?view=subtabs`)

Rendered via the new preview case (Chrome headless over HTTP). Available on the fleet:
- **Agents mode:** `mac-mini:/tmp/factory-subtabs/shots/subtabs-dark.png` — strip (Agents active/lime + needs badge, two task tabs, Dispatch right) over the agents contextual bar.
- **Backlog mode:** `mac-mini:/tmp/factory-subtabs/shots/subtabs-backlog.png` — Backlog active with a **single** `GROUP · SORT · SOURCE LN/GH` bar (the fixed duplicate).
- Light theme: `?theme=light`.