### PR TITLE
ci(tests): run real-tmux integration tests serially in their own job (fix shard flake)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,33 @@ jobs:
           key: bun-cache-${{ runner.os }}-${{ hashFiles('apps/cli/bun.lock') }}
           restore-keys: bun-cache-${{ runner.os }}-
       - run: bun install --frozen-lockfile
-      - run: node ./node_modules/vitest/vitest.mjs run --shard=${{ matrix.shard }}/3
+      # The real-tmux integration tests are excluded here and run serially in
+      # their own uncontended job (`test-tmux`): under the shards' fork
+      # parallelism they race on tmux session-teardown timing and flake.
+      - run: node ./node_modules/vitest/vitest.mjs run --shard=${{ matrix.shard }}/3 --exclude='**/lib/{tmux/session,terminal/inject}.test.ts'
+
+  # Real-tmux integration tests, run SERIALLY on their own runner. They spin up
+  # real tmux servers + shells; under the shards' fork parallelism they contend
+  # for CPU and their session-teardown timing races (`waitForPanes` briefly sees
+  # the split pane survive → "expected length 1 but got 2"), flaking the suite.
+  # Isolated + `--no-file-parallelism` they are deterministic — the exact
+  # condition under which they already pass locally and in isolation.
+  test-tmux:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: apps/cli
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-cache-${{ runner.os }}-${{ hashFiles('apps/cli/bun.lock') }}
+          restore-keys: bun-cache-${{ runner.os }}-
+      - run: bun install --frozen-lockfile
+      - run: node ./node_modules/vitest/vitest.mjs run src/lib/tmux/session.test.ts src/lib/terminal/inject.test.ts --no-file-parallelism
 
   # Aggregate gate: the ONLY required-check context here. Runs after typecheck and
   # every shard regardless of their outcome (`if: always()`) and fails unless ALL
@@ -69,19 +95,23 @@ jobs:
   # through this single `test` check. A matrix job's `result` is `success` only
   # when every leg passed.
   test:
-    needs: [typecheck, test-shard]
+    needs: [typecheck, test-shard, test-tmux]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Gate on typecheck + all test shards
+      - name: Gate on typecheck + all test shards + tmux integration
         run: |
           echo "typecheck:  ${{ needs.typecheck.result }}"
           echo "test-shard: ${{ needs.test-shard.result }}"
+          echo "test-tmux:  ${{ needs.test-tmux.result }}"
           if [ "${{ needs.typecheck.result }}" != "success" ]; then
             echo "::error::typecheck failed"; exit 1
           fi
           if [ "${{ needs.test-shard.result }}" != "success" ]; then
             echo "::error::one or more test shards failed"; exit 1
           fi
-          echo "typecheck + all shards green"
+          if [ "${{ needs.test-tmux.result }}" != "success" ]; then
+            echo "::error::tmux integration tests failed"; exit 1
+          fi
+          echo "typecheck + all shards + tmux green"


### PR DESCRIPTION
## Problem

The recent 3-way test sharding (`tests.yml`) runs vitest's `forks` pool at CPU-count parallelism within each shard. The **real-tmux integration tests** (`src/lib/tmux/session.test.ts`, `src/lib/terminal/inject.test.ts`) spin up real tmux servers + shells, so under that parallelism they contend for CPU and their **session-teardown timing races** — `waitForPanes` briefly sees the split pane survive, so `reconcileSessionHooks retrofits the guarded hook…` fails with `expected [ '%0:0', '%1:1' ] to have length 1 but got 2`.

This is **intermittent and composition-dependent** — it's been flaking PRs at random (three of my menubar PRs merged fine; #811 hit an unlucky shard composition and failed the same test 3× in a row).

## Fix

The tmux tests **pass deterministically when not contended** (they pass in isolation, full-file, and locally — i.e. serially). So:
- **Exclude** them from the parallel shards (`--exclude='**/lib/{tmux/session,terminal/inject}.test.ts'`).
- **Run them in a dedicated `test-tmux` job**, serially (`--no-file-parallelism`), on their own runner — no CPU contention.
- Wire `test-tmux` into the aggregate **`test`** gate (`needs` + result check). The required-check context name `test` is **unchanged**, so branch protection and `release.sh` EXPECTED_CHECKS are unaffected.

## Verification

- Confirmed the exclude glob matches both files (0 remain when targeting them with the exclude applied).
- Confirmed the tmux files pass when run serially/in-isolation (`session.test.ts`: 23/23 full-file, 2/2 isolated).
- **Self-validating:** this PR's own CI runs the tmux tests in the new serial `test-tmux` job — a green `test` here *is* the proof the fix works.

Unblocks #811 (RECENT TICKETS) and every other PR gated on `test`.

Session transcript (public repo — by path): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.170/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/a62e0f6d-8e48-45dd-930f-1477ba6fbb03.jsonl`
