### PR TITLE
feat(factory): sub-tab strip + contextual controls + task tabs

### DIFF
--- a/apps/factory/ui/settings/components/mission-control/BacklogCenter.test.tsx
+++ b/apps/factory/ui/settings/components/mission-control/BacklogCenter.test.tsx
@@ -1,0 +1,50 @@
+import { expect, test, describe } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { BacklogCenter } from './BacklogCenter'
+import type { FloorTicket } from './floorModel'
+
+// renderToStaticMarkup keeps this DOM-free and isolated (no happy-dom globals leak).
+
+const tickets: FloorTicket[] = [
+  { id: 'RUSH-1262', title: 'PKCE token exchange uses unpinned http client', project: 'rush', source: 'LN', pri: 'urgent', status: 'todo', desc: '', labels: ['security'], owner: 'Muqsit' },
+  { id: '#418', title: 'Kanban feed views are stubs', project: 'swarmify', source: 'GH', pri: 'med', status: 'todo', desc: '', labels: [], owner: '' },
+]
+const noop = () => {}
+
+function render(over?: Partial<Record<'LN' | 'GH', boolean>>) {
+  return renderToStaticMarkup(
+    <BacklogCenter
+      tickets={tickets}
+      group="project"
+      sort="priority"
+      srcFilter={{ LN: true, GH: true, ...over }}
+      projFilter={null}
+      search=""
+      selectedTicketId={null}
+      onSelectTicket={noop}
+      onOpenTask={noop}
+    />,
+  )
+}
+
+describe('BacklogCenter', () => {
+  test('no longer renders its own toolbar (controls moved to the shared bar)', () => {
+    const html = render()
+    expect(html).not.toContain('bktoolbar')
+    // The group/sort <select> controls are gone from this component entirely.
+    expect(html).not.toContain('<select')
+  })
+
+  test('renders the ticket rows it is given', () => {
+    const html = render()
+    expect(html).toContain('trow2')
+    expect(html).toContain('RUSH-1262')
+    expect(html).toContain('#418')
+  })
+
+  test('applies the source filter (GH hidden when toggled off)', () => {
+    const html = render({ GH: false })
+    expect(html).toContain('RUSH-1262')
+    expect(html).not.toContain('#418')
+  })
+})

--- a/apps/factory/ui/settings/components/mission-control/BacklogCenter.tsx
+++ b/apps/factory/ui/settings/components/mission-control/BacklogCenter.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Icon } from './icons'
 import {
   groupTickets,
   sortTickets,
@@ -9,44 +8,41 @@ import {
   type TicketSource,
 } from './floorModel'
 
-// Full ticket list (backlog) with group/sort/filter toolbar. Prototype
-// backlogCenter():651-665 + ticketRow():641-650. Filtering/grouping/sorting reuse the
-// canonical pure functions from floorModel — this stays presentation only.
-
-const GROUP_OPTS: { value: TicketGroupBy; label: string }[] = [
-  { value: 'project', label: 'Project' },
-  { value: 'priority', label: 'Priority' },
-  { value: 'source', label: 'Source' },
-  { value: 'status', label: 'Status' },
-  { value: 'owner', label: 'Owner' },
-]
-const SORT_OPTS: TicketSort[] = ['priority', 'id']
+// Full ticket list (backlog). Group/sort/source controls now live in the shared
+// contextual bar (FloorControls, mode='backlog') — this component's own duplicate
+// `.bktoolbar` was removed so the Backlog view renders ONE controls bar, not two.
+// The group/sort/srcFilter props still arrive (applied to the list here); only the
+// toolbar UI moved out. Double-click a row to open it as a closeable task tab.
 
 interface BacklogCenterProps {
   tickets: FloorTicket[]
   group: TicketGroupBy
   sort: TicketSort
-  /** Which ticket sources are visible (Linear / GitHub chips). */
+  /** Which ticket sources are visible (Linear / GitHub); set from the shared bar. */
   srcFilter: Record<TicketSource, boolean>
   /** null = all projects; a project name scopes the list. */
   projFilter: string | null
   /** Free-text query from the top bar (matches id / title / labels). */
   search: string
   selectedTicketId: string | null
-  onGroup: (by: TicketGroupBy) => void
-  onSort: (by: TicketSort) => void
-  onToggleSrc: (src: TicketSource) => void
   onSelectTicket: (id: string) => void
-  onBackToAgents: () => void
+  /** Double-click a row to open it as a closeable task tab in the sub-tab strip. */
+  onOpenTask: (ticket: FloorTicket) => void
 }
 
-function TicketRow({ ticket: t, selected, onSelect }: {
+function TicketRow({ ticket: t, selected, onSelect, onOpen }: {
   ticket: FloorTicket
   selected: boolean
   onSelect: (id: string) => void
+  onOpen: (ticket: FloorTicket) => void
 }) {
   return (
-    <div className={`trow2${selected ? ' selsel' : ''}`} data-tid={t.id} onClick={() => onSelect(t.id)}>
+    <div
+      className={`trow2${selected ? ' selsel' : ''}`}
+      data-tid={t.id}
+      onClick={() => onSelect(t.id)}
+      onDoubleClick={() => onOpen(t)}
+    >
       <span className={`pri ${t.pri}`} />
       <span className={`src ${t.source}`}>{t.source}</span>
       <span className="tid">{t.id}</span>
@@ -64,7 +60,7 @@ function TicketRow({ ticket: t, selected, onSelect }: {
 
 export function BacklogCenter({
   tickets, group, sort, srcFilter, projFilter, search, selectedTicketId,
-  onGroup, onSort, onToggleSrc, onSelectTicket, onBackToAgents,
+  onSelectTicket, onOpenTask,
 }: BacklogCenterProps) {
   // Backlog = work you can still dispatch onto, so completed tickets are excluded.
   const q = search.trim().toLowerCase()
@@ -83,29 +79,6 @@ export function BacklogCenter({
 
   return (
     <div className="feed">
-      <div className="bktoolbar">
-        <span className="seeall" onClick={onBackToAgents}><Icon name="chevL" size={11} /> Agents</span>
-        <div className="bh2">BACKLOG · {list.length} tickets</div>
-        <div className="grow" />
-        <span className="bksel">
-          Group{' '}
-          <select value={group} onChange={(e) => onGroup(e.target.value as TicketGroupBy)}>
-            {GROUP_OPTS.map((o) => (
-              <option key={o.value} value={o.value}>{o.label}</option>
-            ))}
-          </select>
-        </span>
-        <span className="bksel">
-          Sort{' '}
-          <select value={sort} onChange={(e) => onSort(e.target.value as TicketSort)}>
-            {SORT_OPTS.map((o) => (
-              <option key={o} value={o}>{o === 'id' ? 'ID' : 'Priority'}</option>
-            ))}
-          </select>
-        </span>
-        <span className={`chip ${srcFilter.LN ? 'on' : ''}`} onClick={() => onToggleSrc('LN')}>LN</span>
-        <span className={`chip ${srcFilter.GH ? 'on' : ''}`} onClick={() => onToggleSrc('GH')}>GH</span>
-      </div>
       {[...groups.entries()].map(([k, arr]) => (
         <React.Fragment key={k}>
           <div className="feed-sec">
@@ -118,6 +91,7 @@ export function BacklogCenter({
               ticket={t}
               selected={selectedTicketId === t.id}
               onSelect={onSelectTicket}
+              onOpen={onOpenTask}
             />
           ))}
         </React.Fragment>

--- a/apps/factory/ui/settings/components/mission-control/FloorControls.test.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorControls.test.tsx
@@ -1,0 +1,64 @@
+import { expect, test, describe } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { FloorControls, floorControlsMode } from './FloorControls'
+
+// renderToStaticMarkup keeps these tests DOM-free and isolated (no happy-dom globals).
+
+describe('floorControlsMode', () => {
+  test('agents center -> agents control set', () => {
+    expect(floorControlsMode('agents')).toBe('agents')
+  })
+  test('backlog center -> backlog control set', () => {
+    expect(floorControlsMode('backlog')).toBe('backlog')
+  })
+  test('projects/host centers -> no bar', () => {
+    expect(floorControlsMode('projects')).toBeNull()
+    expect(floorControlsMode('host')).toBeNull()
+  })
+})
+
+const noop = () => {}
+const common = {
+  sidebarOpen: true,
+  onToggleSidebar: noop,
+  rightOpen: true,
+  onToggleRight: noop,
+  plain: false,
+  onTogglePlain: noop,
+  sort: 'needs' as const,
+  onSort: noop,
+  group: 'project' as const,
+  onGroup: noop,
+  ticketGroup: 'project' as const,
+  onTicketGroup: noop,
+  ticketSort: 'priority' as const,
+  onTicketSort: noop,
+  srcFilter: { LN: true, GH: true },
+  onToggleSrc: noop,
+}
+
+describe('FloorControls contextual bar', () => {
+  test('agents mode renders feed Group/Sort + needs flag, NOT the source chips', () => {
+    const html = renderToStaticMarkup(<FloorControls mode="agents" needsCount={3} {...common} />)
+    // The agents Sort pill exposes the FloorSort options...
+    expect(html).toContain('Needs you first')
+    // ...the ⚑ needs flag pill shows when needsCount > 0...
+    expect(html).toContain('fpill-flag')
+    // ...and the backlog LN/GH source chips are absent.
+    expect(html).not.toContain('class="chip ')
+  })
+
+  test('backlog mode renders the LN/GH source chips + ticket Sort, NOT the feed sort', () => {
+    const html = renderToStaticMarkup(<FloorControls mode="backlog" {...common} />)
+    expect(html).toContain('class="chip on"') // LN + GH both active
+    expect(html).toContain('>LN<')
+    expect(html).toContain('>GH<')
+    // Backlog sort options are Priority/ID — the feed's 'Needs you first' must not appear.
+    expect(html).not.toContain('Needs you first')
+  })
+
+  test('no Dispatch button — it lives on the sub-tab strip now', () => {
+    const html = renderToStaticMarkup(<FloorControls mode="agents" needsCount={0} {...common} />)
+    expect(html).not.toContain('Dispatch')
+  })
+})

--- a/apps/factory/ui/settings/components/mission-control/FloorControls.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorControls.tsx
@@ -1,13 +1,24 @@
 import React from 'react'
 import { Icon } from './icons'
-import type { FloorSort, FloorGroupBy } from './floorModel'
+import type { FloorSort, FloorGroupBy, TicketGroupBy, TicketSort, TicketSource, CenterMode } from './floorModel'
 
-// Single Floor filter bar (Sort · Status · Agent · search · stats · toggles · Dispatch).
-// The old duplicate ".top" header (second FACTORY logo + theme toggle) was removed —
-// the app-level TopBar is the one and only header. Controls are grouped with separators
-// and the bar never wraps (overflow-x scrolls). Prototype: factory-floor-v2.html fbar.
+// The Floor's ONE contextual controls bar. It renders a different pill set per active
+// center (mode): 'agents' -> Group/Sort/⚑needs (the clean pill bar); 'backlog' ->
+// Group/Sort + LN/GH source chips. The projects/host centers get NO bar — the parent
+// gates rendering on floorControlsMode(center) so those tabs stay chrome-free. Dispatch
+// now lives on the sub-tab strip (FloorSubtabs), not here. Prototype: fbar.
+//
+// Before this, both the agents bar AND the Backlog's own .bktoolbar rendered Group/Sort,
+// so switching to Backlog showed two duplicate control rows. Now there is exactly one.
 
 export type StatusChip = 'needs' | 'running' | 'idle' | 'failed'
+
+/** Which control set (if any) a center wants. projects/host -> null (no bar). */
+export function floorControlsMode(center: CenterMode): 'agents' | 'backlog' | null {
+  if (center === 'agents') return 'agents'
+  if (center === 'backlog') return 'backlog'
+  return null
+}
 
 const SORT_OPTS: { value: FloorSort; label: string }[] = [
   { value: 'needs', label: 'Needs you first' },
@@ -17,7 +28,7 @@ const SORT_OPTS: { value: FloorSort; label: string }[] = [
 ]
 
 // Group the live feed by an axis; 'none' keeps the default phase sections. Same axes
-// as the Backlog's group control (BacklogCenter GROUP_OPTS) so the two bars match.
+// as the Backlog's group control (TICKET_GROUP_OPTS) so the two modes match.
 const GROUP_OPTS: { value: FloorGroupBy | 'none'; label: string }[] = [
   { value: 'none', label: 'None' },
   { value: 'project', label: 'Project' },
@@ -26,10 +37,22 @@ const GROUP_OPTS: { value: FloorGroupBy | 'none'; label: string }[] = [
   { value: 'agent', label: 'Agent' },
 ]
 
+const TICKET_GROUP_OPTS: { value: TicketGroupBy; label: string }[] = [
+  { value: 'project', label: 'Project' },
+  { value: 'priority', label: 'Priority' },
+  { value: 'source', label: 'Source' },
+  { value: 'status', label: 'Status' },
+  { value: 'owner', label: 'Owner' },
+]
+const TICKET_SORT_OPTS: TicketSort[] = ['priority', 'id']
+
 const SVG = { fill: 'none', stroke: 'currentColor', strokeWidth: 1.4 } as const
 
 interface FloorControlsProps {
-  /** Count of agents that need you — shown as the ⚑ flag pill. */
+  /** Which control set to render. projects/host centers render no bar (parent gates). */
+  mode: 'agents' | 'backlog'
+
+  /** Count of agents that need you — shown as the ⚑ flag pill (agents mode). */
   needsCount?: number
 
   sidebarOpen: boolean
@@ -39,51 +62,84 @@ interface FloorControlsProps {
   plain: boolean
   onTogglePlain: () => void
 
+  // --- agents-mode controls ---
   sort: FloorSort
   onSort: (s: FloorSort) => void
   /** How the live feed is grouped ('none' = default phase sections). */
   group: FloorGroupBy | 'none'
   onGroup: (g: FloorGroupBy | 'none') => void
 
-  onDispatch: () => void
+  // --- backlog-mode controls ---
+  ticketGroup: TicketGroupBy
+  onTicketGroup: (by: TicketGroupBy) => void
+  ticketSort: TicketSort
+  onTicketSort: (by: TicketSort) => void
+  srcFilter: Record<TicketSource, boolean>
+  onToggleSrc: (src: TicketSource) => void
 }
 
 export function FloorControls({
+  mode,
   needsCount = 0,
   sidebarOpen, onToggleSidebar, rightOpen, onToggleRight, plain, onTogglePlain,
   sort, onSort, group, onGroup,
-  onDispatch,
+  ticketGroup, onTicketGroup, ticketSort, onTicketSort, srcFilter, onToggleSrc,
 }: FloorControlsProps) {
-  const groupLabel = (GROUP_OPTS.find((o) => o.value === group) ?? GROUP_OPTS[0]).label
-  const sortLabel = (SORT_OPTS.find((o) => o.value === sort) ?? SORT_OPTS[0]).label
+  const groupLabel = (GROUP_OPTS.find((o) => o.value === group) ?? GROUP_OPTS[0]!).label
+  const sortLabel = (SORT_OPTS.find((o) => o.value === sort) ?? SORT_OPTS[0]!).label
+  const ticketGroupLabel = (TICKET_GROUP_OPTS.find((o) => o.value === ticketGroup) ?? TICKET_GROUP_OPTS[0]!).label
 
-  // Clean pill bar (mockup): the ad-hoc Status/Agent chips and the running tally are
-  // gone — filtering lives in saved views + search. What remains reads as calm pills:
-  // Group ▾ · Sort ▾ · ⚑needs, then the panel toggles + Dispatch.
   return (
     <div className="fbar clean">
       <div className="grow" />
 
-      <label className="fpill fpill-sel" title="Group the feed">
-        Group: <b>{groupLabel}</b>
-        <select value={group} onChange={(e) => onGroup(e.target.value as FloorGroupBy | 'none')}>
-          {GROUP_OPTS.map((o) => (
-            <option key={o.value} value={o.value}>{o.label}</option>
-          ))}
-        </select>
-      </label>
+      {mode === 'agents' ? (
+        <>
+          <label className="fpill fpill-sel" title="Group the feed">
+            Group: <b>{groupLabel}</b>
+            <select value={group} onChange={(e) => onGroup(e.target.value as FloorGroupBy | 'none')}>
+              {GROUP_OPTS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </label>
 
-      <label className="fpill fpill-sel" title="Sort the feed">
-        <b>{sortLabel}</b>
-        <select value={sort} onChange={(e) => onSort(e.target.value as FloorSort)}>
-          {SORT_OPTS.map((o) => (
-            <option key={o.value} value={o.value}>{o.label}</option>
-          ))}
-        </select>
-      </label>
+          <label className="fpill fpill-sel" title="Sort the feed">
+            <b>{sortLabel}</b>
+            <select value={sort} onChange={(e) => onSort(e.target.value as FloorSort)}>
+              {SORT_OPTS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </label>
 
-      {needsCount > 0 && (
-        <span className="fpill fpill-flag" title={`${needsCount} need you`}><Icon name="alert" size={11} /> {needsCount}</span>
+          {needsCount > 0 && (
+            <span className="fpill fpill-flag" title={`${needsCount} need you`}><Icon name="alert" size={11} /> {needsCount}</span>
+          )}
+        </>
+      ) : (
+        <>
+          <label className="fpill fpill-sel" title="Group the backlog">
+            Group: <b>{ticketGroupLabel}</b>
+            <select value={ticketGroup} onChange={(e) => onTicketGroup(e.target.value as TicketGroupBy)}>
+              {TICKET_GROUP_OPTS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </label>
+
+          <label className="fpill fpill-sel" title="Sort the backlog">
+            <b>{ticketSort === 'id' ? 'ID' : 'Priority'}</b>
+            <select value={ticketSort} onChange={(e) => onTicketSort(e.target.value as TicketSort)}>
+              {TICKET_SORT_OPTS.map((o) => (
+                <option key={o} value={o}>{o === 'id' ? 'ID' : 'Priority'}</option>
+              ))}
+            </select>
+          </label>
+
+          <span className={`chip ${srcFilter.LN ? 'on' : ''}`} onClick={() => onToggleSrc('LN')}>LN</span>
+          <span className={`chip ${srcFilter.GH ? 'on' : ''}`} onClick={() => onToggleSrc('GH')}>GH</span>
+        </>
       )}
 
       <button className="iconbtn plainbtn" title={`Plain language: ${plain ? 'on' : 'off'}`} onClick={onTogglePlain}>Aa</button>
@@ -107,7 +163,6 @@ export function FloorControls({
           <line x1="10" y1="2.5" x2="10" y2="13.5" />
         </svg>
       </button>
-      <button className="disp" onClick={onDispatch}><Icon name="zap" size={12} /> Dispatch</button>
     </div>
   )
 }

--- a/apps/factory/ui/settings/components/mission-control/FloorSubtabs.test.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorSubtabs.test.tsx
@@ -1,0 +1,118 @@
+import { expect, test, describe } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { FloorSubtabs, openTaskTab, closeTaskTab, type FixedTab, type TaskTab } from './FloorSubtabs'
+
+// Pure, DOM-free tests via renderToStaticMarkup — no happy-dom register, no global
+// mutation, so nothing leaks into sibling test files (each import is self-contained).
+
+describe('openTaskTab', () => {
+  test('appends a new tab', () => {
+    const out = openTaskTab([], { id: 'RUSH-1', title: 'A', source: 'LN' })
+    expect(out.map((t) => t.id)).toEqual(['RUSH-1'])
+  })
+
+  test('de-dupes by id (re-opening focuses, does not duplicate)', () => {
+    const base: TaskTab[] = [{ id: 'RUSH-1', title: 'A', source: 'LN' }]
+    const out = openTaskTab(base, { id: 'RUSH-1', title: 'A (again)', source: 'LN' })
+    expect(out).toBe(base) // identity preserved when nothing changes
+    expect(out).toHaveLength(1)
+  })
+
+  test('preserves insertion order', () => {
+    let tabs: TaskTab[] = []
+    tabs = openTaskTab(tabs, { id: 'a', title: 'a', source: 'LN' })
+    tabs = openTaskTab(tabs, { id: 'b', title: 'b', source: 'GH' })
+    tabs = openTaskTab(tabs, { id: 'c', title: 'c', source: 'LN' })
+    expect(tabs.map((t) => t.id)).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('closeTaskTab', () => {
+  const three: TaskTab[] = [
+    { id: 'a', title: 'a', source: 'LN' },
+    { id: 'b', title: 'b', source: 'GH' },
+    { id: 'c', title: 'c', source: 'LN' },
+  ]
+
+  test('closing a non-active tab keeps the active id', () => {
+    const r = closeTaskTab(three, 'a', 'c')
+    expect(r.tabs.map((t) => t.id)).toEqual(['a', 'b'])
+    expect(r.activeId).toBe('a')
+  })
+
+  test('closing the active middle tab falls back to the left neighbor', () => {
+    const r = closeTaskTab(three, 'b', 'b')
+    expect(r.tabs.map((t) => t.id)).toEqual(['a', 'c'])
+    expect(r.activeId).toBe('a')
+  })
+
+  test('closing the active leading tab falls back to the new first tab', () => {
+    const r = closeTaskTab(three, 'a', 'a')
+    expect(r.tabs.map((t) => t.id)).toEqual(['b', 'c'])
+    expect(r.activeId).toBe('b')
+  })
+
+  test('closing the last remaining tab returns null active (hands center back)', () => {
+    const r = closeTaskTab([{ id: 'a', title: 'a', source: 'LN' }], 'a', 'a')
+    expect(r.tabs).toEqual([])
+    expect(r.activeId).toBeNull()
+  })
+
+  test('closing an unknown id is a no-op', () => {
+    const r = closeTaskTab(three, 'b', 'zzz')
+    expect(r.tabs).toBe(three)
+    expect(r.activeId).toBe('b')
+  })
+})
+
+describe('FloorSubtabs render', () => {
+  const fixed: FixedTab[] = [
+    { center: 'agents', label: 'Agents', count: 8, needs: 3 },
+    { center: 'backlog', label: 'Backlog', count: 12 },
+    { center: 'projects', label: 'Projects', count: 4 },
+    { center: 'host', label: 'Hosts', count: 5 },
+  ]
+  const noop = () => {}
+
+  test('marks the active fixed center and shows count + needs badges', () => {
+    const html = renderToStaticMarkup(
+      <FloorSubtabs
+        fixed={fixed}
+        center="agents"
+        taskTabs={[]}
+        activeTaskTab={null}
+        onSelectCenter={noop}
+        onSelectTaskTab={noop}
+        onCloseTaskTab={noop}
+        onDispatch={noop}
+      />,
+    )
+    // The agents tab is active (lime `on`); the count + needs badges render.
+    expect(html).toContain('class="fsubtab on"')
+    expect(html).toContain('fsubtab-needs')
+    expect(html).toContain('>3<') // needs badge
+    expect(html).toContain('>8<') // agents count
+    expect(html).toContain('Dispatch')
+  })
+
+  test('a task tab active suppresses the fixed active state and renders a closeable tab', () => {
+    const html = renderToStaticMarkup(
+      <FloorSubtabs
+        fixed={fixed}
+        center="agents"
+        taskTabs={[{ id: 'RUSH-1262', title: 'Token exchange', source: 'LN' }]}
+        activeTaskTab="RUSH-1262"
+        onSelectCenter={noop}
+        onSelectTaskTab={noop}
+        onCloseTaskTab={noop}
+        onDispatch={noop}
+      />,
+    )
+    // No fixed tab is `on` while a task tab owns the center.
+    expect(html).not.toContain('class="fsubtab on"')
+    expect(html).toContain('tasktab on')
+    expect(html).toContain('tasktab-src')
+    expect(html).toContain('tasktab-x')
+    expect(html).toContain('Token exchange')
+  })
+})

--- a/apps/factory/ui/settings/components/mission-control/FloorSubtabs.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorSubtabs.tsx
@@ -1,0 +1,120 @@
+import React from 'react'
+import { Icon } from './icons'
+import type { CenterMode, TicketSource } from './floorModel'
+
+// The Floor's primary nav: a sub-tab strip under the top FLOOR/BENCH/PANEL tabs.
+// Fixed pills (Agents / Backlog / Projects / Hosts) map 1:1 to CenterMode and carry a
+// count + optional needs badge; double-clicking a ticket or an agent card opens a
+// closeable task tab that renders that task's detail. Dispatch is pinned to the right.
+// This replaces the FloorRail as the primary center selector — active = lime.
+
+export interface FixedTab {
+  center: CenterMode
+  label: string
+  count: number
+  /** Needs-you count; renders an amber badge when > 0. Omit for centers with no needs. */
+  needs?: number
+}
+
+export interface TaskTab {
+  id: string
+  title: string
+  source: TicketSource
+}
+
+// ---------- pure reducers (unit-tested) ----------
+
+/** Append a task tab, de-duping by id so re-opening the same task focuses it. */
+export function openTaskTab(tabs: TaskTab[], tab: TaskTab): TaskTab[] {
+  if (tabs.some((t) => t.id === tab.id)) return tabs
+  return [...tabs, tab]
+}
+
+/**
+ * Close a task tab and pick the next active tab. When the closed tab was active,
+ * fall back to its left neighbor (or the first remaining tab when it led), or null
+ * when it was the last one — null hands the center back to the fixed tabs.
+ */
+export function closeTaskTab(
+  tabs: TaskTab[],
+  activeId: string | null,
+  closeId: string,
+): { tabs: TaskTab[]; activeId: string | null } {
+  const idx = tabs.findIndex((t) => t.id === closeId)
+  if (idx === -1) return { tabs, activeId }
+  const next = tabs.filter((t) => t.id !== closeId)
+  if (activeId !== closeId) return { tabs: next, activeId }
+  if (next.length === 0) return { tabs: next, activeId: null }
+  // Left neighbor (or first tab when the closed one led). Guaranteed in range since
+  // next.length > 0 and idx <= old length - 1, so Math.max(0, idx-1) < next.length.
+  const neighbor = next[Math.max(0, idx - 1)]!
+  return { tabs: next, activeId: neighbor.id }
+}
+
+interface FloorSubtabsProps {
+  fixed: FixedTab[]
+  /** The active fixed center (only visually active when no task tab is active). */
+  center: CenterMode
+  taskTabs: TaskTab[]
+  /** null = a fixed center tab is active; otherwise the active task-tab id. */
+  activeTaskTab: string | null
+  onSelectCenter: (c: CenterMode) => void
+  onSelectTaskTab: (id: string) => void
+  onCloseTaskTab: (id: string) => void
+  onDispatch: () => void
+}
+
+export function FloorSubtabs({
+  fixed, center, taskTabs, activeTaskTab,
+  onSelectCenter, onSelectTaskTab, onCloseTaskTab, onDispatch,
+}: FloorSubtabsProps) {
+  return (
+    <div className="fsubtabs" role="tablist">
+      {fixed.map((t) => {
+        const on = activeTaskTab === null && center === t.center
+        return (
+          <button
+            key={t.center}
+            role="tab"
+            aria-selected={on}
+            className={`fsubtab ${on ? 'on' : ''}`}
+            onClick={() => onSelectCenter(t.center)}
+          >
+            <span className="fsubtab-label">{t.label}</span>
+            <span className="fsubtab-cnt">{t.count}</span>
+            {t.needs ? <span className="fsubtab-needs">{t.needs}</span> : null}
+          </button>
+        )
+      })}
+
+      {taskTabs.map((t) => {
+        const on = activeTaskTab === t.id
+        return (
+          <span
+            key={t.id}
+            role="tab"
+            aria-selected={on}
+            className={`fsubtab tasktab ${on ? 'on' : ''}`}
+            onClick={() => onSelectTaskTab(t.id)}
+          >
+            <span className={`tasktab-src ${t.source}`}>{t.source}</span>
+            <span className="fsubtab-label">{t.title}</span>
+            <span
+              className="tasktab-x"
+              role="button"
+              aria-label={`Close ${t.title}`}
+              title="Close tab"
+              onClick={(e) => { e.stopPropagation(); onCloseTaskTab(t.id) }}
+            >
+              <Icon name="x" size={11} />
+            </span>
+          </span>
+        )
+      })}
+
+      <div className="grow" />
+
+      <button className="disp" onClick={onDispatch}><Icon name="zap" size={12} /> Dispatch</button>
+    </div>
+  )
+}

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -20,10 +20,13 @@ import {
   PENDING_DISPATCH_TTL_MS,
   type PendingDispatch,
 } from './dispatch'
-import { FloorControls, type StatusChip } from './FloorControls'
+import { FloorControls, floorControlsMode, type StatusChip } from './FloorControls'
 import { FloorSidebar } from './FloorSidebar'
 import { FloorRail } from './FloorRail'
+import { FloorSubtabs, openTaskTab, closeTaskTab, type FixedTab, type TaskTab } from './FloorSubtabs'
 import { BacklogCenter } from './BacklogCenter'
+import { TaskDetail } from '../bench/TaskDetail'
+import type { FlatTask } from '../bench/TaskCard'
 import { TicketDetail } from './TicketDetail'
 import { HostDetail } from './HostDetail'
 import { ProjectsPane } from './ProjectsPane'
@@ -38,6 +41,7 @@ import {
   latestTodos,
   sessionTaskLine,
   type FloorAgent,
+  type FloorTicket,
   type CenterMode,
   type HostInventory,
   type FloorGroupBy,
@@ -529,6 +533,17 @@ function useStableList(items: UnifiedAgent[]): UnifiedAgent[] {
   }, [items])
 }
 
+// Wrap a FeedItem so double-clicking the card opens it as a closeable task tab.
+// display:contents keeps the parent grid layout intact — the span box vanishes and the
+// card stays the real grid child — while still catching the dblclick that bubbles up.
+function FeedRow({ onOpenTask, ...props }: React.ComponentProps<typeof FeedItem> & { onOpenTask: (a: FloorAgent) => void }) {
+  return (
+    <span style={{ display: 'contents' }} onDoubleClick={() => onOpenTask(props.agent)}>
+      <FeedItem {...props} />
+    </span>
+  )
+}
+
 export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks, unifiedTasksLoading, onDispatch, onNavigate, onOpenInBench, openDispatchTrigger, quickSpawnTrigger, openDetailTaskId, onDetailTaskConsumed, onThroughputChange, search: floorSearch, onSearch: setFloorSearch, githubRepo, watchdogEnabled = false, watchdogEvents = [], projectRules = [] }: UnifiedAgentsPaneProps) {
   const panelVisible = usePanelVisibility()
   const [newMenuOpen, setNewMenuOpen] = useState(false)
@@ -585,6 +600,11 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   // ---------- Floor 3-pane shell state ----------
   const floorPrefs0 = useRef(loadFloorPrefs()).current
   const [center, setCenter] = useState<CenterMode>('agents')
+  // Dynamic task tabs: double-clicking a backlog ticket or an agent card opens a
+  // closeable tab in the sub-tab strip. activeTaskTab === null means a fixed center
+  // tab is showing; otherwise the named task tab owns the center pane.
+  const [openTaskTabs, setOpenTaskTabs] = useState<TaskTab[]>([])
+  const [activeTaskTab, setActiveTaskTab] = useState<string | null>(null)
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
   const [selectedTicketId, setSelectedTicketId] = useState<string | null>(null)
   const [projFilter, setProjFilter] = useState<string | null>(null)
@@ -1553,6 +1573,41 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     setPendingPlans((prev) => prev.filter((p) => p.sessionId !== sessionId))
   }, [])
 
+  // ---------- Sub-tab strip: fixed-center selection + dynamic task tabs ----------
+  // Selecting a fixed center clears any active task tab so the center pane returns.
+  const selectCenter = useCallback((c: CenterMode) => {
+    setActiveTaskTab(null)
+    setCenter(c)
+  }, [])
+
+  const openTaskFromTicket = useCallback((ticket: FloorTicket) => {
+    setOpenTaskTabs((prev) => openTaskTab(prev, { id: ticket.id, title: ticket.title, source: ticket.source }))
+    setActiveTaskTab(ticket.id)
+  }, [])
+
+  // Open (or focus) a task tab from an agent card. Keys off the agent's linked ticket
+  // when it has one (so it collapses with the ticket's own tab); otherwise the agent id.
+  const openTaskFromAgent = useCallback((a: FloorAgent) => {
+    const id = a.ticket ?? a.id
+    const source: TicketSource = a.ticket?.startsWith('#') ? 'GH' : 'LN'
+    setOpenTaskTabs((prev) => openTaskTab(prev, { id, title: a.ticket ?? a.name, source }))
+    setActiveTaskTab(id)
+  }, [])
+
+  const selectTaskTab = useCallback((id: string) => setActiveTaskTab(id), [])
+
+  const handleCloseTaskTab = useCallback((id: string) => {
+    setActiveTaskTab((curActive) => {
+      let nextActive = curActive
+      setOpenTaskTabs((prev) => {
+        const res = closeTaskTab(prev, curActive, id)
+        nextActive = res.activeId
+        return res.tabs
+      })
+      return nextActive
+    })
+  }, [])
+
   const onScope = useCallback((value: string) => {
     if (value === '__queue') { setCenter('backlog'); return }
     if (value === '__needs') { setCenter('agents'); setProjFilter(null); setHostFilter(null); return }
@@ -1726,7 +1781,48 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     )
   }
 
-  const centerContent = center === 'backlog' ? (
+  // The fixed sub-tabs: one per CenterMode, with a live count + (agents) needs badge.
+  const fixedTabs: FixedTab[] = useMemo(() => [
+    { center: 'agents', label: 'Agents', count: floorAgents.length, needs: needsAgents.length },
+    { center: 'backlog', label: 'Backlog', count: floorTickets.length },
+    { center: 'projects', label: 'Projects', count: managedProjects.length },
+    { center: 'host', label: 'Hosts', count: fleetDevices.length },
+  ], [floorAgents.length, needsAgents.length, floorTickets.length, managedProjects.length, fleetDevices.length])
+
+  // Resolve the active task tab (if any) back to a bench FlatTask so its detail renders.
+  const activeTab = activeTaskTab ? openTaskTabs.find((t) => t.id === activeTaskTab) ?? null : null
+  const activeTabTask: FlatTask | null = activeTab
+    ? (() => {
+        const ut = unifiedTasks.find((t) => t.id === activeTab.id || t.metadata.identifier === activeTab.id)
+        return ut
+          ? { id: ut.id, source: ut.source, title: ut.title, description: ut.description, status: ut.status, priority: ut.priority, metadata: ut.metadata }
+          : null
+      })()
+    : null
+  // Only render a bar for centers that HAVE one (agents/backlog); a task tab suppresses it.
+  const controlsMode = activeTaskTab ? null : floorControlsMode(center)
+
+  const centerContent = activeTab ? (
+    <div className="feed sw-tasktab-pane">
+      <div className="sw-bench-detail">
+        {activeTabTask ? (
+          <TaskDetail
+            task={activeTabTask}
+            onDispatch={(t) => openDispatch({ ticketId: t.id })}
+            onDismiss={() => handleCloseTaskTab(activeTab.id)}
+            onOpenExternal={(url) => postMessage({ type: 'openExternal', url })}
+          />
+        ) : (
+          <div className="detail-empty" style={{ flexDirection: 'column', gap: 12 }}>
+            <span>{activeTab.title}</span>
+            <button className="disp" onClick={() => openDispatch({ ticketId: activeTab.id })}>
+              <Icon name="zap" size={12} /> Dispatch
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  ) : center === 'backlog' ? (
     <BacklogCenter
       tickets={floorTickets}
       group={ticketGroup}
@@ -1735,11 +1831,8 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
       projFilter={projFilter}
       search={floorSearch}
       selectedTicketId={selectedTicketId}
-      onGroup={setTicketGroup}
-      onSort={setTicketSort}
-      onToggleSrc={(src) => setTicketSrc((p) => ({ ...p, [src]: !p[src] }))}
       onSelectTicket={(id) => setSelectedTicketId(id)}
-      onBackToAgents={() => setCenter('agents')}
+      onOpenTask={openTaskFromTicket}
     />
   ) : (
     <div className="feed">
@@ -1770,7 +1863,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
             onReplyOne={selectFloorAgent}
           />
           {questionClusters.filter((c) => c.length === 1).map((c) => (
-            <FeedItem
+            <FeedRow onOpenTask={openTaskFromAgent}
               key={c[0].id}
               agent={c[0]}
               selected={selectedFloorAgent?.id === c[0].id}
@@ -1791,7 +1884,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
             />
           ))}
           {reviewNeedsAgents.map((a) => (
-            <FeedItem
+            <FeedRow onOpenTask={openTaskFromAgent}
               key={a.id}
               agent={a}
               selected={selectedFloorAgent?.id === a.id}
@@ -1821,7 +1914,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
       </div>
       {floorGroup === 'none'
         ? runningFeed.map((a) => (
-            <FeedItem
+            <FeedRow onOpenTask={openTaskFromAgent}
               key={a.id}
               agent={a}
               selected={selectedFloorAgent?.id === a.id}
@@ -1849,7 +1942,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
                 <span className="ln" />
               </div>
               {arr.map((a) => (
-                <FeedItem
+                <FeedRow onOpenTask={openTaskFromAgent}
                   key={a.id}
                   agent={a}
                   selected={selectedFloorAgent?.id === a.id}
@@ -1867,7 +1960,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
         <>
           <div className="feed-sec">DONE TODAY · {doneFeed.length}<span className="ln" /></div>
           {doneFeed.map((a) => (
-            <FeedItem
+            <FeedRow onOpenTask={openTaskFromAgent}
               key={a.id}
               agent={a}
               selected={selectedFloorAgent?.id === a.id}
@@ -1887,7 +1980,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
           {recentAgents.length === 0 ? (
             <div className="detail-empty" style={{ padding: '10px 16px' }}>No recent sessions for this host.</div>
           ) : recentAgents.map((a) => (
-            <FeedItem
+            <FeedRow onOpenTask={openTaskFromAgent}
               key={a.id}
               agent={a}
               selected={selectedFloorAgent?.id === a.id}
@@ -1933,20 +2026,39 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
 
   return (
     <div className="sw-floor-dashboard" style={{ padding: 0, overflow: 'hidden' }}>
-      <FloorControls
-        needsCount={needsAgents.length}
-        sidebarOpen={sidebarOpen}
-        onToggleSidebar={() => setSidebarOpen((o) => !o)}
-        rightOpen={rightOpen}
-        onToggleRight={() => setRightOpen((o) => !o)}
-        plain={plain}
-        onTogglePlain={() => setPlain((o) => !o)}
-        sort={floorSort}
-        onSort={setFloorSort}
-        group={floorGroup}
-        onGroup={setFloorGroup}
+      <FloorSubtabs
+        fixed={fixedTabs}
+        center={center}
+        taskTabs={openTaskTabs}
+        activeTaskTab={activeTaskTab}
+        onSelectCenter={selectCenter}
+        onSelectTaskTab={selectTaskTab}
+        onCloseTaskTab={handleCloseTaskTab}
         onDispatch={() => openDispatch(selectedTicketId ? { ticketId: selectedTicketId } : undefined)}
       />
+
+      {controlsMode && (
+        <FloorControls
+          mode={controlsMode}
+          needsCount={needsAgents.length}
+          sidebarOpen={sidebarOpen}
+          onToggleSidebar={() => setSidebarOpen((o) => !o)}
+          rightOpen={rightOpen}
+          onToggleRight={() => setRightOpen((o) => !o)}
+          plain={plain}
+          onTogglePlain={() => setPlain((o) => !o)}
+          sort={floorSort}
+          onSort={setFloorSort}
+          group={floorGroup}
+          onGroup={setFloorGroup}
+          ticketGroup={ticketGroup}
+          onTicketGroup={setTicketGroup}
+          ticketSort={ticketSort}
+          onTicketSort={setTicketSort}
+          srcFilter={ticketSrc}
+          onToggleSrc={(src) => setTicketSrc((p) => ({ ...p, [src]: !p[src] }))}
+        />
+      )}
 
       <div className="page" style={{ flex: 1, minHeight: 0, height: 'auto' }}>
         {sidebarOpen && (railCollapsed ? (

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -1597,16 +1597,13 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   const selectTaskTab = useCallback((id: string) => setActiveTaskTab(id), [])
 
   const handleCloseTaskTab = useCallback((id: string) => {
-    setActiveTaskTab((curActive) => {
-      let nextActive = curActive
-      setOpenTaskTabs((prev) => {
-        const res = closeTaskTab(prev, curActive, id)
-        nextActive = res.activeId
-        return res.tabs
-      })
-      return nextActive
-    })
-  }, [])
+    // Compute both next states from current state in one pass — no nested setState
+    // (an updater must be pure; nesting one inside another ran the reducer twice
+    // under StrictMode and lost the next active id). Deps keep the reads fresh.
+    const res = closeTaskTab(openTaskTabs, activeTaskTab, id)
+    setOpenTaskTabs(res.tabs)
+    setActiveTaskTab(res.activeId)
+  }, [openTaskTabs, activeTaskTab])
 
   const onScope = useCallback((value: string) => {
     if (value === '__queue') { setCenter('backlog'); return }

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -89,6 +89,24 @@
 .swarmify-root .search { flex: 1 1 160px; min-width: 120px; max-width: 340px; background: var(--ds-bg-panel); border: 1px solid var(--ds-border); border-radius: var(--r-md); padding: 5px 10px; color: var(--ds-text); font-size: 12px; }
 .swarmify-root .disp { display: inline-flex; align-items: center; gap: 6px; background: var(--brand); color: #1a1a1a; border: none; font-weight: 700; padding: 6px 12px; border-radius: var(--r-md); font-size: 12px; white-space: nowrap; flex: 0 0 auto; }
 
+/* ---- FLOOR sub-tab strip (primary nav): fixed center pills + dynamic task tabs ---- */
+.swarmify-root .fsubtabs { display: flex; align-items: center; gap: 6px; padding: 7px 16px; background: var(--ds-bg); border-bottom: 1px solid var(--ds-border-subtle); flex-wrap: nowrap; overflow-x: auto; scrollbar-width: thin; }
+.swarmify-root .fsubtabs .grow { flex: 1; }
+.swarmify-root .fsubtab { display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--ds-border); background: var(--ds-bg-recessed); border-radius: 999px; padding: 5px 12px; font-size: 12px; font-weight: 600; color: var(--ds-text-muted); flex: 0 0 auto; white-space: nowrap; cursor: pointer; line-height: 1; }
+.swarmify-root .fsubtab:hover { border-color: var(--ds-text-dim); color: var(--ds-text); }
+.swarmify-root .fsubtab.on { background: var(--brand); border-color: var(--brand); color: #1a1a1a; }
+.swarmify-root .fsubtab-label { font-weight: 700; }
+.swarmify-root .fsubtab-cnt { font-family: "Geist Mono", monospace; font-size: 10.5px; font-weight: 700; color: var(--ds-text-dim); background: var(--ds-bg); border-radius: 999px; padding: 1px 6px; font-variant-numeric: tabular-nums; }
+.swarmify-root .fsubtab.on .fsubtab-cnt { color: #1a1a1a; background: rgba(26, 26, 26, 0.14); }
+.swarmify-root .fsubtab-needs { font-family: "Geist Mono", monospace; font-size: 10.5px; font-weight: 700; color: #1a1a1a; background: var(--status-pending); border-radius: 999px; padding: 1px 6px; font-variant-numeric: tabular-nums; }
+.swarmify-root .tasktab { padding-right: 7px; }
+.swarmify-root .tasktab-src { font-size: 9px; font-weight: 800; letter-spacing: .03em; color: var(--ds-text-dim); }
+.swarmify-root .tasktab.on .tasktab-src { color: #1a1a1a; }
+.swarmify-root .tasktab .fsubtab-label { max-width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.swarmify-root .tasktab-x { display: inline-flex; align-items: center; justify-content: center; opacity: .55; border-radius: 999px; padding: 1px; cursor: pointer; }
+.swarmify-root .tasktab-x:hover { opacity: 1; background: rgba(0, 0, 0, 0.18); }
+.swarmify-root .sw-tasktab-pane { display: block; padding: 0; }
+
 /* ---- generic dot / badges ---- */
 .swarmify-root .dot { width: 9px; height: 9px; border-radius: 50%; flex: 0 0 auto; display: inline-block; }
 .swarmify-root .dot.running { background: var(--status-running); box-shadow: 0 0 0 3px var(--status-running-bg); }
@@ -341,11 +359,8 @@
 .swarmify-root .dispatch-sm { border: 1px solid var(--brand); background: transparent; color: var(--brand-600); font-weight: 700; font-size: 11px; padding: 3px 9px; border-radius: var(--r-md); }
 .swarmify-root .seeall { color: var(--brand-600); cursor: pointer; font-weight: 700; font-size: 11px; }
 
-/* backlog (tickets) view */
-.swarmify-root .bktoolbar { display: flex; align-items: center; gap: 10px; padding: 2px 2px 10px; border-bottom: 1px solid var(--ds-border-subtle); margin-bottom: 6px; }
-.swarmify-root .bh2 { font-size: 11px; font-weight: 800; letter-spacing: .04em; color: var(--ds-text-muted); }
-.swarmify-root .bksel { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; color: var(--ds-text-dim); }
-.swarmify-root .bksel select { background: var(--ds-bg-panel); border: 1px solid var(--ds-border); border-radius: var(--r-md); padding: 3px 6px; font-size: 11px; color: var(--ds-text); font-weight: 600; }
+/* backlog (tickets) view — group/sort/source controls moved to the shared FloorControls
+   bar (mode='backlog'); the old .bktoolbar was removed with them. */
 .swarmify-root .trow2 { display: flex; align-items: center; gap: 9px; padding: 8px 8px; border-bottom: 1px solid var(--ds-border-subtle); cursor: pointer; border-radius: var(--r-sm); }
 .swarmify-root .trow2:hover { background: var(--ds-bg-panel); }
 .swarmify-root .trow2.selsel { background: var(--ds-bg-panel); box-shadow: inset 3px 0 0 var(--brand); }

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -13,13 +13,14 @@ import '../index.css'
 import { Icon } from '../components/mission-control/icons'
 import { FloorSidebar } from '../components/mission-control/FloorSidebar'
 import { FloorRail } from '../components/mission-control/FloorRail'
-import { FloorControls } from '../components/mission-control/FloorControls'
+import { FloorControls, floorControlsMode } from '../components/mission-control/FloorControls'
+import { FloorSubtabs, openTaskTab, closeTaskTab, type FixedTab, type TaskTab } from '../components/mission-control/FloorSubtabs'
 import { FeedItem, TicketStrip } from '../components/mission-control/FeedItem'
 import { SavedViews } from '../components/mission-control/SavedViewsBar'
 import { DispatchPanel } from '../components/mission-control/DispatchPanel'
 import { BacklogCenter } from '../components/mission-control/BacklogCenter'
 import { ProjectsPane } from '../components/mission-control/ProjectsPane'
-import type { FloorAgent, FloorTicket, StructuredQuestion, TicketGroupBy, TicketSort, ManagedProject, LinearProjectLite } from '../components/mission-control/floorModel'
+import type { FloorAgent, FloorTicket, StructuredQuestion, FloorSort, TicketGroupBy, TicketSort, CenterMode, ManagedProject, LinearProjectLite } from '../components/mission-control/floorModel'
 import type { UnifiedTask } from '../types'
 import type { InstalledAgent, DispatchHost, DispatchTarget } from '../components/mission-control/dispatch.types'
 
@@ -190,10 +191,14 @@ function Feed() {
   return (
     <div className="feed">
       <FloorControls
+        mode="agents"
         needsCount={2}
         sidebarOpen rightOpen plain={false}
         onToggleSidebar={noop} onToggleRight={noop} onTogglePlain={noop}
-        sort={srt} onSort={setSrt} group={grp} onGroup={setGrp} onDispatch={noop}
+        sort={srt} onSort={setSrt} group={grp} onGroup={setGrp}
+        ticketGroup="project" onTicketGroup={noop}
+        ticketSort="priority" onTicketSort={noop}
+        srcFilter={{ LN: true, GH: true }} onToggleSrc={noop}
       />
       <SavedViews
         views={[
@@ -241,28 +246,110 @@ function Feed() {
   )
 }
 
-// Backlog center with the group/sort/filter toolbar. Defaults to grouping by
-// Owner so the preview shows tickets bucketed by assignee (incl. Unassigned).
+// Backlog center + its contextual controls bar (FloorControls mode='backlog'). The
+// group/sort/source controls live in the shared bar now, not a per-view toolbar.
 function Backlog() {
   const [group, setGroup] = useState<TicketGroupBy>('project')
   const [sort, setSort] = useState<TicketSort>('priority')
   const [srcFilter, setSrcFilter] = useState<Record<'LN' | 'GH', boolean>>({ LN: true, GH: true })
   const [selected, setSelected] = useState<string | null>(null)
   return (
-    <BacklogCenter
-      tickets={tickets}
-      group={group}
-      sort={sort}
-      srcFilter={srcFilter}
-      projFilter={null}
-      search=""
-      selectedTicketId={selected}
-      onGroup={setGroup}
-      onSort={setSort}
-      onToggleSrc={(s) => setSrcFilter((f) => ({ ...f, [s]: !f[s] }))}
-      onSelectTicket={setSelected}
-      onBackToAgents={noop}
-    />
+    <>
+      <FloorControls
+        mode="backlog"
+        sidebarOpen rightOpen plain={false}
+        onToggleSidebar={noop} onToggleRight={noop} onTogglePlain={noop}
+        sort="needs" onSort={noop} group="project" onGroup={noop}
+        ticketGroup={group} onTicketGroup={setGroup}
+        ticketSort={sort} onTicketSort={setSort}
+        srcFilter={srcFilter} onToggleSrc={(s) => setSrcFilter((f) => ({ ...f, [s]: !f[s] }))}
+      />
+      <BacklogCenter
+        tickets={tickets}
+        group={group}
+        sort={sort}
+        srcFilter={srcFilter}
+        projFilter={null}
+        search=""
+        selectedTicketId={selected}
+        onSelectTicket={setSelected}
+        onOpenTask={noop}
+      />
+    </>
+  )
+}
+
+// Sub-tab strip + contextual controls bar — the full Option A nav. Fixed center pills
+// (Agents/Backlog/Projects/Hosts) with count+needs badges, two pre-opened task tabs, and
+// the one contextual bar that swaps its control set per active center (or hides for a
+// task tab / projects / hosts). URL: ?view=subtabs (&center=agents|backlog|projects|host).
+function Subtabs() {
+  const params = new URLSearchParams(location.search)
+  const [center, setCenter] = useState<CenterMode>((params.get('center') as CenterMode) || 'agents')
+  const [activeTaskTab, setActiveTaskTab] = useState<string | null>(null)
+  const [taskTabs, setTaskTabs] = useState<TaskTab[]>([
+    { id: 'RUSH-1262', title: 'PKCE token exchange uses unpinned http client', source: 'LN' },
+    { id: '#418', title: 'Kanban / Deadline feed views are stubs', source: 'GH' },
+  ])
+  const [grp, setGrp] = useState<'none' | 'project' | 'host' | 'status' | 'agent'>('project')
+  const [srt, setSrt] = useState<FloorSort>('needs')
+  const [tg, setTg] = useState<TicketGroupBy>('project')
+  const [ts, setTs] = useState<TicketSort>('priority')
+  const [src, setSrc] = useState<Record<'LN' | 'GH', boolean>>({ LN: true, GH: true })
+  const [selected, setSelected] = useState<string | null>(null)
+
+  const fixed: FixedTab[] = [
+    { center: 'agents', label: 'Agents', count: running.length + 2, needs: 2 },
+    { center: 'backlog', label: 'Backlog', count: tickets.length },
+    { center: 'projects', label: 'Projects', count: managedProjects.length },
+    { center: 'host', label: 'Hosts', count: 5 },
+  ]
+  const controlsMode = activeTaskTab ? null : floorControlsMode(center)
+  return (
+    <div className="feed-col">
+      <FloorSubtabs
+        fixed={fixed}
+        center={center}
+        taskTabs={taskTabs}
+        activeTaskTab={activeTaskTab}
+        onSelectCenter={(c) => { setActiveTaskTab(null); setCenter(c) }}
+        onSelectTaskTab={setActiveTaskTab}
+        onCloseTaskTab={(id) => {
+          const r = closeTaskTab(taskTabs, activeTaskTab, id)
+          setTaskTabs(r.tabs)
+          setActiveTaskTab(r.activeId)
+        }}
+        onDispatch={noop}
+      />
+      {controlsMode && (
+        <FloorControls
+          mode={controlsMode}
+          needsCount={2}
+          sidebarOpen rightOpen plain={false}
+          onToggleSidebar={noop} onToggleRight={noop} onTogglePlain={noop}
+          sort={srt} onSort={setSrt} group={grp} onGroup={setGrp}
+          ticketGroup={tg} onTicketGroup={setTg}
+          ticketSort={ts} onTicketSort={setTs}
+          srcFilter={src} onToggleSrc={(s) => setSrc((f) => ({ ...f, [s]: !f[s] }))}
+        />
+      )}
+      {!activeTaskTab && center === 'backlog' && (
+        <BacklogCenter
+          tickets={tickets}
+          group={tg}
+          sort={ts}
+          srcFilter={src}
+          projFilter={null}
+          search=""
+          selectedTicketId={selected}
+          onSelectTicket={setSelected}
+          onOpenTask={(t) => {
+            setTaskTabs((prev) => openTaskTab(prev, { id: t.id, title: t.title, source: t.source }))
+            setActiveTaskTab(t.id)
+          }}
+        />
+      )}
+    </div>
   )
 }
 
@@ -335,7 +422,7 @@ function Preview() {
     <div className={`swarmify-root ${theme}`} style={{ minHeight: '100vh' }}>
       <div className="sw-floor-dashboard" style={{ padding: 0 }}>
         <div className="page" style={{ display: 'flex' }}>
-          {view === 'sidebar' ? <Sidebar /> : view === 'projects' ? <div className="feed-col"><Projects /></div> : <div className="feed-col">{view === 'backlog' ? <Backlog /> : <Feed />}</div>}
+          {view === 'sidebar' ? <Sidebar /> : view === 'subtabs' ? <Subtabs /> : view === 'projects' ? <div className="feed-col"><Projects /></div> : <div className="feed-col">{view === 'backlog' ? <Backlog /> : <Feed />}</div>}
         </div>
       </div>
       <DispatchPanel


### PR DESCRIPTION
Upgrades the Factory **FLOOR** to a proper tab system (approved **Option A**), re-implemented cleanly on current `main` at `apps/factory/`.

> Supersedes **#814** — that branch (`agents/tabs`) was built on a stale pre-rename base (`packages/factory/`) and is unmergeable. This PR is a clean re-implementation off current `origin/main`; #814 can be closed as superseded.

## What changed

### 1. Sub-tab strip — the new primary nav (`FloorSubtabs.tsx`)
A visible tab strip under the top FLOOR/BENCH/PANEL tabs. Fixed pills — **Agents / Backlog / Projects / Hosts** — map 1:1 to `CenterMode` with a count + needs badge (active = lime). **Dispatch moved onto the strip.** Ships pure, unit-tested reducers `openTaskTab` / `closeTaskTab`.

### 2. One contextual controls bar (`FloorControls.tsx`)
`FloorControls` now takes a `mode: 'agents' | 'backlog'` and renders **exactly one** control set per active center:
- `agents` → Group / Sort / ⚑needs (the existing clean pill bar)
- `backlog` → Group / Sort + LN/GH source chips
- `projects` / `host` → **no bar** (parent gates on the new `floorControlsMode(center)`)

`BacklogCenter` drops its own `.bktoolbar` — those controls live in the shared bar now, so the Backlog view renders **one** controls bar, not two. Dispatch removed from this bar (now on the strip).

### 3. Dynamic task tabs
`openTaskTabs` / `activeTaskTab` state in `UnifiedAgentsPane`. **Double-clicking** a backlog ticket row or an agent card opens a closeable tab in the strip that renders the existing bench `<TaskDetail>` (read-only import) with a Dispatch button; the `x` closes it (with left-neighbor active fallback). **Single-click** keeps the right-pane preview unchanged.

## Verification
- `bun test settings/components/mission-control/` → **243 pass / 0 fail** (10 files), incl. 19 new assertions across `FloorSubtabs.test.tsx`, `FloorControls.test.tsx`, `BacklogCenter.test.tsx`.
- Tests use `renderToStaticMarkup` — **DOM-free and isolated**, no happy-dom global registered, so nothing leaks across test files (per the isolation ask). They assert: the contextual bar picks the right set per center; task-tab open/close/active fallbacks; and that `BacklogCenter` no longer emits its toolbar/`<select>`.
- `bun run build:settings` → clean (1813 modules, built in 1.5s).
- `bunx tsc -p ./ --noEmit` → **no new errors** in touched files (verified against an `origin/main` baseline worktree: `UnifiedAgentsPane` 37→37, `preview` 1→1, `BacklogCenter` 0→0, `FloorSubtabs` 0; `FloorControls` 2→**0** — pre-existing index-access errors fixed). Remaining errors are all pre-existing project-wide `noUncheckedIndexedAccess` noise.
- Preview harness gains a `?view=subtabs` case (`&center=agents|backlog|projects|host`) rendering the full strip + contextual bar.

_Note: no pixel screenshot — this ran on a headless Linux factory worker with no Chromium. Render correctness is asserted via the `renderToStaticMarkup` structural tests (active-tab classes, task-tab close button, source chips, absence of the old toolbar) rather than an image._

## Files
- **new** `FloorSubtabs.tsx` (+ test) — strip component + `openTaskTab`/`closeTaskTab` reducers
- `FloorControls.tsx` (+ test) — `mode` prop, `floorControlsMode(center)`, backlog control set
- `BacklogCenter.tsx` (+ test) — toolbar removed, `onOpenTask` double-click
- `UnifiedAgentsPane.tsx` — task-tab state/handlers, `FloorSubtabs` wiring, gated `FloorControls`, `FeedRow` double-click wrapper
- `floor.css` — `.fsubtabs`/`.fsubtab`/`.tasktab` styles; dead `.bktoolbar` removed
- `preview/preview.tsx` — `?view=subtabs` harness case