### PR TITLE
ci(release-matrix): serialize the suite to de-flake the release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,15 @@ jobs:
         run: bun run build
 
       - name: Test
-        run: bun run test
+        # Run the suite serially in the release matrix. Several resource/timing-
+        # sensitive tests race under the fork pool's parallelism on loaded CI
+        # runners — the real-tmux integration teardown (`waitForPanes` sees the
+        # split pane briefly survive) and the scheduler-timer window (a 1300ms
+        # fire missed under CPU load) — flaking the release gate. This matrix is
+        # release-only and infrequent, so reliability beats the parallel speedup.
+        # (The per-PR gate keeps its fast sharded run plus a dedicated serial
+        # tmux job — see tests.yml.) One flag, cross-platform-safe.
+        run: bun run test -- --no-file-parallelism
 
   # No CI publish job — publishing happens locally on macOS via
   # `scripts/release.sh <version> --apply`.


### PR DESCRIPTION
The release-only cross-platform matrix (`ci.yml`) runs `bun run test` in parallel, so the contention flakes #815 fixed for the per-PR gate still hit the release: the real-tmux teardown race (`session.test.ts`) on ubuntu-node24 and the scheduler-timer test (`scheduler.endAt.test.ts`, a 1300ms window missed under load) on windows-node22 — both blocked the 1.20.48 release. Fix: run the release matrix serially (`--no-file-parallelism`). Reliability over speed for the infrequent release gate; the per-PR gate keeps its fast sharded run + dedicated serial tmux job. One flag, cross-platform-safe, no timeout risk (build job has no explicit timeout). Note: `ci.yml` only runs on release/** branches, so this validates when the 1.20.48 release re-runs.