### PR TITLE
test: fix flaky tmux + scheduler tests at the source; revert CI serialization (#815, #819)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,15 +76,7 @@ jobs:
         run: bun run build
 
       - name: Test
-        # Run the suite serially in the release matrix. Several resource/timing-
-        # sensitive tests race under the fork pool's parallelism on loaded CI
-        # runners — the real-tmux integration teardown (`waitForPanes` sees the
-        # split pane briefly survive) and the scheduler-timer window (a 1300ms
-        # fire missed under CPU load) — flaking the release gate. This matrix is
-        # release-only and infrequent, so reliability beats the parallel speedup.
-        # (The per-PR gate keeps its fast sharded run plus a dedicated serial
-        # tmux job — see tests.yml.) One flag, cross-platform-safe.
-        run: bun run test -- --no-file-parallelism
+        run: bun run test
 
   # No CI publish job — publishing happens locally on macOS via
   # `scripts/release.sh <version> --apply`.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,33 +61,7 @@ jobs:
           key: bun-cache-${{ runner.os }}-${{ hashFiles('apps/cli/bun.lock') }}
           restore-keys: bun-cache-${{ runner.os }}-
       - run: bun install --frozen-lockfile
-      # The real-tmux integration tests are excluded here and run serially in
-      # their own uncontended job (`test-tmux`): under the shards' fork
-      # parallelism they race on tmux session-teardown timing and flake.
-      - run: node ./node_modules/vitest/vitest.mjs run --shard=${{ matrix.shard }}/3 --exclude='**/lib/{tmux/session,terminal/inject}.test.ts'
-
-  # Real-tmux integration tests, run SERIALLY on their own runner. They spin up
-  # real tmux servers + shells; under the shards' fork parallelism they contend
-  # for CPU and their session-teardown timing races (`waitForPanes` briefly sees
-  # the split pane survive → "expected length 1 but got 2"), flaking the suite.
-  # Isolated + `--no-file-parallelism` they are deterministic — the exact
-  # condition under which they already pass locally and in isolation.
-  test-tmux:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    defaults:
-      run:
-        working-directory: apps/cli
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-cache-${{ runner.os }}-${{ hashFiles('apps/cli/bun.lock') }}
-          restore-keys: bun-cache-${{ runner.os }}-
-      - run: bun install --frozen-lockfile
-      - run: node ./node_modules/vitest/vitest.mjs run src/lib/tmux/session.test.ts src/lib/terminal/inject.test.ts --no-file-parallelism
+      - run: node ./node_modules/vitest/vitest.mjs run --shard=${{ matrix.shard }}/3
 
   # Aggregate gate: the ONLY required-check context here. Runs after typecheck and
   # every shard regardless of their outcome (`if: always()`) and fails unless ALL
@@ -95,23 +69,19 @@ jobs:
   # through this single `test` check. A matrix job's `result` is `success` only
   # when every leg passed.
   test:
-    needs: [typecheck, test-shard, test-tmux]
+    needs: [typecheck, test-shard]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Gate on typecheck + all test shards + tmux integration
+      - name: Gate on typecheck + all test shards
         run: |
           echo "typecheck:  ${{ needs.typecheck.result }}"
           echo "test-shard: ${{ needs.test-shard.result }}"
-          echo "test-tmux:  ${{ needs.test-tmux.result }}"
           if [ "${{ needs.typecheck.result }}" != "success" ]; then
             echo "::error::typecheck failed"; exit 1
           fi
           if [ "${{ needs.test-shard.result }}" != "success" ]; then
             echo "::error::one or more test shards failed"; exit 1
           fi
-          if [ "${{ needs.test-tmux.result }}" != "success" ]; then
-            echo "::error::tmux integration tests failed"; exit 1
-          fi
-          echo "typecheck + all shards + tmux green"
+          echo "typecheck + all shards green"

--- a/apps/cli/src/lib/__tests__/scheduler.endAt.test.ts
+++ b/apps/cli/src/lib/__tests__/scheduler.endAt.test.ts
@@ -75,7 +75,14 @@ describe('JobScheduler endAt enforcement', () => {
     });
     scheduler.schedule(config);
 
-    await new Promise((r) => setTimeout(r, 1300));
+    // Poll until the job fires rather than sleeping a fixed 1300ms then asserting:
+    // on a loaded CI runner the scheduler's fire can land later than a short fixed
+    // window, so the fixed sleep flaked ("expected 0 to be >= 1"). We stop the
+    // instant it fires, so the ceiling only bounds a genuinely non-firing job.
+    const deadline = Date.now() + 8000;
+    while (fired < 1 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
     scheduler.stopAll();
 
     expect(fired).toBeGreaterThanOrEqual(1);

--- a/apps/cli/src/lib/tmux/session.test.ts
+++ b/apps/cli/src/lib/tmux/session.test.ts
@@ -369,7 +369,13 @@ async function waitForPanes(
   name: string,
   socket: string,
   expected: number,
-  timeoutMs = 5000,
+  // The pane teardown this waits on (the guarded pane-died hook killing the dead
+  // split) is a real async tmux operation whose latency balloons on a loaded CI
+  // runner. 5s was too tight under the full parallel suite; give it generous
+  // headroom (still well under the 30s vitest testTimeout). The loop still
+  // returns the instant the count converges, so the ceiling only bites on a
+  // genuinely stuck teardown.
+  timeoutMs = 20000,
 ): Promise<string[]> {
   const deadline = Date.now() + timeoutMs;
   let panes: string[] = [];


### PR DESCRIPTION
## Why

Serializing CI (#815, #819) to dodge two flaky tests was slow and masked the real problem. This fixes the **tests** to be robust under load, then reverts the serialization so the suite runs **fully parallel** again.

## The two flakes (both contention/timing, not real bugs)

1. **`session.test.ts` `waitForPanes`** — polls for the guarded pane-died hook to reap the dead split pane. That's a real async tmux op whose latency balloons on a loaded runner; the **5s** ceiling was too tight (saw the unreaped husk → `length 1 but got 2`). → **20s** ceiling (still < the 30s testTimeout); the loop returns the instant the count converges, so it's only slower on a *genuinely* stuck teardown.
2. **`scheduler.endAt` 'fires in the future'** — a fixed `setTimeout(1300)` then assert, which missed the fire window under CPU load (`expected 0 to be >= 1`). → **poll-until-fired** (up to 8s), the correct async pattern; stops the instant it fires.

## Revert

Undo #815 (tests.yml exclude + dedicated serial `test-tmux` job) and #819 (ci.yml `--no-file-parallelism`). Back to the fast sharded per-PR gate + parallel release matrix.

## Verification

- Both fixed tests pass locally (25/25).
- **Self-validating:** this PR's per-PR CI runs the tmux tests **in the parallel shards again** (the serial crutch is gone) — a green `test` here proves the robustness fix holds under parallelism. The parallel release matrix is validated when 1.20.48 re-runs.

Unblocks the 1.20.48 release the right way.