### PR TITLE
test(factory): guard happy-dom registration (fix full-suite double-register)

### DIFF
--- a/apps/factory/ui/settings/components/bench/TaskDetail.test.tsx
+++ b/apps/factory/ui/settings/components/bench/TaskDetail.test.tsx
@@ -5,7 +5,10 @@ import { GlobalRegistrator } from '@happy-dom/global-registrator'
 // export binds to `window` at import time. Register happy-dom BEFORE requiring
 // the component so DOMPurify.sanitize is a real function. The production surface
 // is a VS Code webview, which has a window.
-GlobalRegistrator.register()
+// Guard: another UI test file in the same process (e.g. utils/markdown.test.ts)
+// may have already registered happy-dom globally — register() throws on a double
+// register, which fails the whole suite. Only register when no DOM exists yet.
+if (typeof (globalThis as { document?: unknown }).document === 'undefined') GlobalRegistrator.register()
 
 const React = require('react')
 const { renderToStaticMarkup } = require('react-dom/server')

--- a/apps/factory/ui/settings/utils/markdown.test.ts
+++ b/apps/factory/ui/settings/utils/markdown.test.ts
@@ -6,7 +6,10 @@ import { GlobalRegistrator } from '@happy-dom/global-registrator'
 // time. The real app runs in a VS Code webview / Electron host, so register a DOM
 // BEFORE importing markdown.ts — then the full marked -> DOMPurify pipeline runs
 // exactly as it does in production.
-GlobalRegistrator.register()
+// Guard: another UI test file in the same process (e.g. bench/TaskDetail.test.tsx)
+// may have already registered happy-dom globally — register() throws on a double
+// register, which fails the whole suite. Only register when no DOM exists yet.
+if (typeof (globalThis as { document?: unknown }).document === 'undefined') GlobalRegistrator.register()
 const { renderTodoDescription, escapeHtml } = await import('./markdown')
 
 // renderTodoDescription returns a <div> whose sanitized HTML is carried on


### PR DESCRIPTION
Two UI test files (markdown.test.ts from #812, bench/TaskDetail.test.tsx from #813) each registered happy-dom globally at module top level; running them together threw 'Happy DOM has already been globally registered' and failed the full suite — the isolation nit prix-cloud flagged on #813, and what blocked the 0.9.286 release's local test gate.

Fix: guard each register() behind `typeof globalThis.document === 'undefined'`. Verified both files pass together (9 pass, 0 fail).