### PR TITLE
fix(cloud): agents cloud cancel uses POST .../cancel, not DELETE

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **`agents cloud cancel` now actually cancels paused runs.** `RushProvider.cancel()` issued `DELETE /api/v1/cloud-runs/{id}`, which the backend doesn't implement — it 404s — so `agents cloud cancel` (and the Factory Floor's cancel affordance) silently failed on any run that wasn't actively running: `queued`, `needs_review`, and `input_required` runs stayed stuck (e.g. a 14-day-old input-required run lingering in the Floor's "NEEDS YOU" bucket forever). Switched to the cancel action endpoint `POST /api/v1/cloud-runs/{id}/cancel`, which the backend implements and which cancels paused runs too. Verified live against `api.prix.dev` (the POST returned `{"ok":true,"status":"cancelled"}` and the stuck run transitioned `needs_review` → `cancelled`). Source: `apps/cli/src/lib/cloud/rush.ts`.
+
 ## 1.20.48
 
 - **Menu-bar helper: a RECENT TICKETS section shows the issues you filed via the quick-issue bar, each clickable to open in Linear.** The completion notification is transient, so the tickets the `Cmd-Shift-O` bar creates now also persist to a small local ledger (`~/.agents/.history/menubar/recent-tickets.json`, newest-first, deduped by id, capped at 10) that the menu-bar dropdown surfaces below RECENT sessions — click a row to open the ticket. The dispatch records the id + note + Linear URL on a successful create; the section renders nothing when the ledger is empty. Source: `apps/cli/menubar/Sources/MenubarHelper/{RecentTickets,StatusItemController,AgentsCLI,IssueSelfTest}.swift`.

--- a/apps/cli/src/lib/cloud/rush.ts
+++ b/apps/cli/src/lib/cloud/rush.ts
@@ -653,7 +653,11 @@ export class RushCloudProvider implements CloudProvider {
 
   async cancel(taskId: string): Promise<void> {
     const token = readToken();
-    const res = await api('DELETE', `/api/v1/cloud-runs/${encodeURIComponent(taskId)}`, token);
+    // The cancel ACTION endpoint (POST .../cancel) is what the backend implements;
+    // it works on paused runs too (queued / needs_review / input_required). A bare
+    // DELETE on the run 404s, so `agents cloud cancel` silently failed on anything
+    // that wasn't actively running.
+    const res = await api('POST', `/api/v1/cloud-runs/${encodeURIComponent(taskId)}/cancel`, token);
     if (!res.ok) {
       throw new Error(`Failed to cancel task (${res.status}).`);
     }


### PR DESCRIPTION
## Problem
`RushProvider.cancel()` (`apps/cli/src/lib/cloud/rush.ts:654`) called `DELETE /api/v1/cloud-runs/{id}`, which the backend doesn't implement — it **404s**. So `agents cloud cancel` and the Factory Floor's cancel affordance **silently failed** on any run that wasn't actively running (queued / needs_review / input_required). Real symptom: a 14-day-old `needs_review` (input-required) run stuck in the Floor's **NEEDS YOU** bucket, uncancellable.

## Fix
Use the cancel **action** endpoint `POST /api/v1/cloud-runs/{id}/cancel`, which the backend implements and which cancels paused runs too.

## Verification (real API, no mock)
Hit `api.prix.dev` directly against the stuck run `vclfel94`:
- `DELETE /api/v1/cloud-runs/vclfel94` → **404** (the old path)
- `POST /api/v1/cloud-runs/vclfel94/cancel` → **`{"ok":true,"status":"cancelled"}`**
- `agents cloud status vclfel94` → `cancelled` ✓

Build clean, `src/lib/cloud/` tests 96 pass / 0 fail. (Per repo convention — real services, no mocking — this is verified against the live API rather than a fetch stub.)