### PR TITLE
fix(factory): show the original prompt on session cards, not just the last message

### DIFF
--- a/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Icon } from './icons'
 import { AgentAvatar, agentIdFromPrefix } from './AgentAvatar'
 import { StructuredReply, type ReplyCallbacks } from './StructuredReply'
-import { heartbeatLevel, sessionTaskLine, type FloorAgent, type FloorTicket } from './floorModel'
+import { heartbeatLevel, type FloorAgent, type FloorTicket } from './floorModel'
 import { sinceFromMs } from './floorAdapter'
 import { useNow } from './useNow'
 import { CardChecklist } from './TodoChecklist'
@@ -35,6 +35,8 @@ interface FeedItemProps {
 }
 
 function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeText, onAttach }: FeedItemProps) {
+  // A long original prompt is clamped to a few lines with an expand toggle (see below).
+  const [promptExpanded, setPromptExpanded] = useState(false)
   // Live heartbeat: only a running / stalled agent with a known last-activity stamp ticks.
   // The shared 1s ticker re-renders just this leaf, never the parent list.
   const now = useNow(1000)
@@ -67,17 +69,18 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
   const destructive = a.question?.kind === 'destructive'
   const attn = a.phase === 'failed' ? 'fail' : stalled ? 'stall' : a.needs ? 'attn' : ''
 
-  // Rolling summary line: the agent's own words for a running/stalled agent. Skip it
-  // when it just echoes the response block. Suppress the now-line when the summary
-  // already says the same thing (summary fell back to the now-line's activity string).
   const nowlineText = `${a.verb} ${a.target}`.trim()
-  // One canonical task line (summary/preview -> response -> worktree/branch). This is
-  // what fixes the identical, contextless "needs you" cards: a waiting session with no
-  // narrative still shows its worktree slug instead of just "Edit <file>". Shown unless
-  // it merely echoes the response block or the now-line.
-  const taskLine = sessionTaskLine(a)
-  const showSummary = !plain && !!taskLine && taskLine !== a.resp.trim() && taskLine !== nowlineText
-  const showNowline = !plain && !!a.verb && !(showSummary && taskLine === nowlineText)
+  // The session TOPIC line — the ORIGINAL prompt / task this session is about (RUSH-1531).
+  // Rendered prominently as the card's first content line so a card is identifiable at a
+  // glance, independent of the last message (`resp`, shown separately below). Suppressed
+  // when empty or when it would merely echo the last message.
+  const promptText = a.summary.trim()
+  const showPrompt = !plain && !!promptText && promptText !== a.resp.trim()
+  // A long prompt is clamped to a few lines with a Show more/less toggle, so the card
+  // stays compact but the full prompt is never silently truncated (acceptance #3).
+  const promptClampable = promptText.length > 160
+  // The now-line (verb + target) still shows the live activity, distinct from the topic.
+  const showNowline = !plain && !!a.verb && nowlineText !== promptText
 
   const marker =
     a.pr ? (
@@ -126,7 +129,20 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
           </span>
         </span>
       </div>
-      <div className="resp">{destructive ? <span className="q">{a.resp}</span> : a.resp}</div>
+      {showPrompt && (
+        <div className="prompt">
+          <div className={`prompt-text${promptClampable && !promptExpanded ? ' clamp' : ''}`}>{promptText}</div>
+          {promptClampable && (
+            <button
+              className="prompt-toggle"
+              onClick={(e) => { e.stopPropagation(); setPromptExpanded((v) => !v) }}
+            >
+              {promptExpanded ? 'Show less' : 'Show more'}
+            </button>
+          )}
+        </div>
+      )}
+      {a.resp && <div className="resp">{destructive ? <span className="q">{a.resp}</span> : a.resp}</div>}
       {!plain && (a.spawnedTeam || (a.createdTickets?.length ?? 0) > 0) && (
         <div className="artifacts" onClick={(e) => e.stopPropagation()}>
           {a.spawnedTeam && (
@@ -142,7 +158,6 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
         </div>
       )}
       {!plain && a.todos.length > 0 && <CardChecklist todos={a.todos} />}
-      {showSummary && <div className="summary">{taskLine}</div>}
       {showNowline && (
         <div className={`nowline ${stalled ? 'stall' : ''}`}>
           <Icon name="chevR" size={11} /> <span className="v">{a.verb}</span> {a.target}

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -226,7 +226,16 @@
 .swarmify-root .fitem .sid { font-family: "Geist Mono", monospace; font-size: 10.5px; color: var(--ds-text-faint); background: var(--ds-bg-recessed); border: 1px solid var(--ds-border); border-radius: 5px; padding: 1px 6px; flex: none; }
 .swarmify-root .fitem .path { color: var(--ds-text-dim); font-size: 11px; }
 .swarmify-root .fitem .when { margin-left: auto; color: var(--ds-text-dim); font-size: 11px; display: flex; align-items: center; gap: 8px; }
-.swarmify-root .fitem .resp { font-size: 12.5px; color: var(--ds-text); line-height: 1.5; margin: 2px 0 8px; border-left: 2px solid var(--ds-border); padding-left: 10px; }
+/* Original prompt / task topic — the card's prominent FIRST line (RUSH-1531): what the
+   session is ABOUT, so a card is identifiable at a glance. The last message (.resp) sits
+   below it and now reads as secondary. */
+.swarmify-root .fitem .prompt { margin: 2px 0 8px; }
+.swarmify-root .fitem .prompt .prompt-text { font-size: 13px; font-weight: 600; color: var(--ds-text); line-height: 1.5; white-space: pre-wrap; word-break: break-word; }
+.swarmify-root .fitem .prompt .prompt-text.clamp { display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+.swarmify-root .fitem .prompt .prompt-toggle { margin-top: 3px; padding: 0; background: none; border: none; color: var(--brand); font-size: 11px; font-family: inherit; cursor: pointer; }
+.swarmify-root .fitem .prompt .prompt-toggle:hover { text-decoration: underline; }
+/* Last message — secondary to the prompt above it: dimmer + slightly smaller. */
+.swarmify-root .fitem .resp { font-size: 12px; color: var(--ds-text-muted); line-height: 1.5; margin: 2px 0 8px; border-left: 2px solid var(--ds-border); padding-left: 10px; }
 .swarmify-root .fitem .resp .q { color: var(--status-pending); font-weight: 600; }
 /* Produced-artifact chips: what the agent SPAWNED (a team) or CREATED (tickets),
    distinct from the injected/worked-on ticket. Cyan-tinted, sits below the response. */

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
@@ -166,6 +166,35 @@ describe('toFloorAgentFromUnified', () => {
     expect(a.lastActivityMs).toBe(NOW - 5000)
   })
 
+  test('summary carries the ORIGINAL prompt (firstUserMessage), kept distinct from the last message (RUSH-1531)', () => {
+    const a = toFloorAgentFromUnified(
+      baseUnified({
+        terminal: {
+          id: 't1',
+          firstUserMessage: 'Fix the session card so it shows the original prompt',
+          narrative: 'Reading FeedItem.tsx',
+          currentActivity: 'Editing FeedItem.tsx',
+        },
+        agent: { last_messages: ['Done — the card now renders the prompt.'] },
+      }),
+      { pinned: new Set(), workspaceRepo: null, nowMs: NOW },
+    )
+    // The topic line is the original prompt, NOT the rolling narrative or the last message.
+    expect(a.summary).toBe('Fix the session card so it shows the original prompt')
+    // The last message stays separate so the card can render both.
+    expect(a.resp).toBe('Done — the card now renders the prompt.')
+  })
+
+  test('summary falls back to the live narrative when no original prompt was captured', () => {
+    const a = toFloorAgentFromUnified(
+      baseUnified({
+        terminal: { id: 't1', narrative: 'Reading the remote adapter', currentActivity: 'Editing adapter.ts' },
+      }),
+      { pinned: new Set(), workspaceRepo: null, nowMs: NOW },
+    )
+    expect(a.summary).toBe('Reading the remote adapter')
+  })
+
   test('a completed agent with an open PR is done + unreviewed (needs you)', () => {
     const a = toFloorAgentFromUnified(
       baseUnified({ status: 'completed', active: false, prUrl: 'https://github.com/o/r/pull/9' }),

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
@@ -52,6 +52,7 @@ export interface UnifiedAgentLike {
     cwd?: string | null
     branch?: string | null
     waitingForInput?: boolean
+    firstUserMessage?: string
     lastUserMessage?: string
     currentActivity?: string
     narrative?: string
@@ -293,10 +294,12 @@ export function toFloorAgentFromUnified(
     question: parseStructuredQuestion(resp, phase),
     reply,
     todos: latestTodos(u.terminal?.recentToolCalls),
-    // The rolling summary line + recent tool calls already flow over the wire on the
-    // terminal. Prefer the agent's own prose (narrative); fall back to the now-line
-    // (currentActivity) when it hasn't spoken between tool calls yet.
-    summary: u.terminal?.narrative || u.terminal?.currentActivity || '',
+    // The card's topic line: what this session is ABOUT, not what it's doing right now.
+    // Prefer the original CLI prompt (firstUserMessage) so a card is identifiable at a
+    // glance (RUSH-1531); fall back to the agent's own prose (narrative) and then the
+    // now-line (currentActivity) when the prompt wasn't captured. The last response is
+    // shown separately by the card, so it is NOT part of this line.
+    summary: u.terminal?.firstUserMessage || u.terminal?.narrative || u.terminal?.currentActivity || '',
     recent: u.terminal?.recentToolCalls ?? [],
   }
 }

--- a/apps/factory/ui/settings/components/mission-control/floorModel.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.ts
@@ -142,7 +142,7 @@ export interface FloorAgent {
   question: StructuredQuestion | null
   reply: ReplyTarget     // how a user reply reaches this agent (host dispatches on kind)
   todos: TodoItem[]      // task checklist from the latest TodoWrite; empty when none
-  summary: string        // the "what is it doing" line (CLI-provided); '' when unknown
+  summary: string        // the session TOPIC line: the original CLI prompt / task the session is about (falls back to the live narrative); '' when unknown. Rendered as the card's prominent first line, distinct from `resp` (the last message).
   recent: RecentToolCall[] // rolling window of this session's recent tool calls; [] when none
   pane?: string          // tmux `%N` pane handle for unique addressing; undefined for non-tmux
   viewingIn?: string     // "Codium tab 3" / "Ghostty tab 2" / "detached"; undefined when unknown

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -103,7 +103,8 @@ const running: FloorAgent[] = [
     pr: '#148', ci: 'running', tok: 41, files: 9, since: '3s', lastActivityMs: Date.now() - 3000,
     pane: '%42', viewingIn: 'Codium tab 3',
     verb: 'Porting', target: 'the group-by control into the shared model',
-    summary: 'Collapsed the three ticket surfaces into one list; now porting the group-by control into the shared model.',
+    summary: 'Merge the three ticket surfaces (markdown TODOs, Linear, and GitHub issues) into one unified list model, then port the group-by control onto it and delete the two dead view components it replaces.',
+    resp: 'Collapsed the surfaces into one model; wiring the group-by control now.',
     createdTickets: ['RUSH-1519', 'RUSH-1520'],
     todos: [
       { content: 'Merge ticket surfaces', status: 'completed' },


### PR DESCRIPTION
## What changed

Factory Floor session cards only ever rendered the **last message** (`resp`)
prominently and never surfaced the **original prompt**, so a card gave no
at-a-glance sense of what the session was about (RUSH-1531).

- **`floorAdapter.ts`** — local agents now carry the original CLI prompt
  (`terminal.firstUserMessage`) into `FloorAgent.summary`, falling back to the
  live narrative / now-line when no prompt was captured. Remote sessions already
  mapped `topic -> summary`, so both origins are now consistent.
- **`FeedItem.tsx`** — the topic (`summary`) renders as the card's **prominent
  first line**; the last message (`resp`) drops **below it as secondary**. A long
  prompt is clamped to 3 lines with a **Show more / Show less** toggle, so it is
  never silently truncated.
- **`floorModel.ts`** — documents `summary` as the session topic line.
- **`floor.css`** — styles for the new `.prompt` block; `.resp` dimmed to
  secondary (scoped to `.fitem`, so the detail rail is unaffected).
- **`preview.tsx`** — a fixture now carries both a long prompt and a distinct
  last message to exercise the new layout + clamp/toggle.

## Why

Acceptance from the ticket:
1. Card displays the original prompt/topic prominently — **first, bold line**.
2. Last message displays separately (secondary, below) — **dimmer `.resp` block**.
3. No truncation of the original prompt without expand/collapse — **3-line clamp
   with a Show more/less toggle**.

## Test

`floorAdapter.test.ts` adds two cases: `summary` carries `firstUserMessage`
(kept distinct from `resp`), and falls back to the live narrative when no prompt
exists. Full mission-control suite: **226 pass / 0 fail**. `bun run
build:settings` builds clean.

Verified end-to-end in the committed preview harness
(`vite --config vite.preview.config.ts`, `/preview/?view=feed`), dark + light:
- Prompt renders prominent + bold; last message renders secondary below it.
- Long prompt: collapsed clamps to 3 lines (measured 39px hidden overflow);
  clicking **Show more** expands to full text (0 overflow) and flips to
  **Show less**.

Screenshots (on `yosemite-s1`, click to preview):
- Feed, dark: `yosemite-s1:/tmp/rush1531_feed_dark.png`
- Feed, light: `yosemite-s1:/tmp/rush1531_feed_light.png`
- Long prompt collapsed: `yosemite-s1:/tmp/rush1531_r1_narrow_collapsed.png`
- Long prompt expanded: `yosemite-s1:/tmp/rush1531_r1_narrow_expanded.png`

Closes RUSH-1531
