### PR TITLE
fix(grok): resolve binary from versioned home before global ~/.grok/downloads

### DIFF
--- a/src/lib/shims.ts
+++ b/src/lib/shims.ts
@@ -489,17 +489,27 @@ fi
 
 VERSION_DIR="$AGENTS_USER_DIR/.history/versions/$AGENT/$VERSION"
 
-# Grok special case: binary lives in ~/.grok/downloads/, not node_modules.
-# We still use the agents-cli version dir purely for GROK_HOME isolation.
+# Grok special case: binary lives in the versioned home's .grok/downloads,
+# not node_modules. We still use the agents-cli version dir for GROK_HOME isolation.
 if [ "$AGENT" = "grok" ]; then
-  # Try to find a matching binary for the pinned version in the global grok downloads dir.
-  GROK_DOWNLOADS="$HOME/.grok/downloads"
+  # Check the versioned home first — this is where the binary lands when the
+  # installer runs with GROK_HOME set, or when grok self-updates under the shim.
+  GROK_DOWNLOADS="$VERSION_DIR/home/.grok/downloads"
   if [ -d "$GROK_DOWNLOADS" ]; then
     # Prefer a binary whose filename contains the exact version
     BINARY=$(ls "$GROK_DOWNLOADS"/grok-* 2>/dev/null | grep -i "$VERSION" | head -1)
     if [ -z "$BINARY" ]; then
-      # Fallback to the "current" grok binary (symlink or latest)
       BINARY=$(ls "$GROK_DOWNLOADS"/grok-* 2>/dev/null | head -1)
+    fi
+  fi
+  # Fall back to the global grok home (binary installed without GROK_HOME set)
+  if [ -z "$BINARY" ] || [ ! -x "$BINARY" ]; then
+    GROK_DOWNLOADS="$HOME/.grok/downloads"
+    if [ -d "$GROK_DOWNLOADS" ]; then
+      BINARY=$(ls "$GROK_DOWNLOADS"/grok-* 2>/dev/null | grep -i "$VERSION" | head -1)
+      if [ -z "$BINARY" ]; then
+        BINARY=$(ls "$GROK_DOWNLOADS"/grok-* 2>/dev/null | head -1)
+      fi
     fi
   fi
   if [ -z "$BINARY" ] || [ ! -x "$BINARY" ]; then
@@ -857,12 +867,20 @@ export KIMI_CODE_HOME="$HOME/.agents/.history/versions/${agent}/${version}/home/
   const versionDir = `$HOME/.agents/.history/versions/${agent}/${version}`;
   const binaryResolution =
     agent === 'grok'
-      ? `# Grok ships its native binary in ~/.grok/downloads, not node_modules.
-GROK_DOWNLOADS="$HOME/.grok/downloads"
+      ? `# Grok ships its native binary in the versioned home's .grok/downloads, not node_modules.
+GROK_DOWNLOADS="${versionDir}/home/.grok/downloads"
 BINARY=""
 if [ -d "$GROK_DOWNLOADS" ]; then
   BINARY=$(ls "$GROK_DOWNLOADS"/grok-* 2>/dev/null | grep -i "${version}" | head -1)
   [ -n "$BINARY" ] || BINARY=$(ls "$GROK_DOWNLOADS"/grok-* 2>/dev/null | head -1)
+fi
+# Fall back to the global grok home (binary installed without GROK_HOME set)
+if [ -z "$BINARY" ] || [ ! -x "$BINARY" ]; then
+  GROK_GLOBAL_DOWNLOADS="$HOME/.grok/downloads"
+  if [ -d "$GROK_GLOBAL_DOWNLOADS" ]; then
+    BINARY=$(ls "$GROK_GLOBAL_DOWNLOADS"/grok-* 2>/dev/null | grep -i "${version}" | head -1)
+    [ -n "$BINARY" ] || BINARY=$(ls "$GROK_GLOBAL_DOWNLOADS"/grok-* 2>/dev/null | head -1)
+  fi
 fi
 # Refuse a PATH match under our own shims dir — it resolves to this alias's
 # sibling dispatcher shim (shims dir is ahead of ~/.local/bin on PATH) and

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -885,16 +885,29 @@ export function getVersionDir(agent: AgentId, version: string): string {
 export function getBinaryPath(agent: AgentId, version: string): string {
   const agentConfig = AGENTS[agent];
   if (agent === 'grok') {
-    const grokDownloads = path.join(getVersionHomePath(agent, version), '.grok', 'downloads');
-    // Best effort: first matching file for this version
+    // Prefer the versioned home — this is where the binary lands when the
+    // installer runs with GROK_HOME set (i.e. via the shim or a correct
+    // `agents add grok`), or when grok self-updates from within the shim.
+    const versionedDownloads = path.join(getVersionHomePath(agent, version), '.grok', 'downloads');
     try {
-      const entries = fs.readdirSync(grokDownloads);
+      const entries = fs.readdirSync(versionedDownloads);
       const match = entries.find((e: string) => e.includes(version) && e.startsWith('grok-'));
-      if (match) return path.join(grokDownloads, match);
+      if (match) return path.join(versionedDownloads, match);
       const first = entries.find((e: string) => e.startsWith('grok-'));
-      if (first) return path.join(grokDownloads, first);
+      if (first) return path.join(versionedDownloads, first);
     } catch {}
-    return path.join(grokDownloads, `grok-${version}`);
+    // Fall back to the global grok home. The install script may have dropped the
+    // binary here if GROK_HOME was not set at install time (e.g. an earlier
+    // `agents add grok@latest` before this fix).
+    const globalDownloads = path.join(getHomeDir(), '.grok', 'downloads');
+    try {
+      const entries = fs.readdirSync(globalDownloads);
+      const match = entries.find((e: string) => e.includes(version) && e.startsWith('grok-'));
+      if (match) return path.join(globalDownloads, match);
+      const first = entries.find((e: string) => e.startsWith('grok-'));
+      if (first) return path.join(globalDownloads, first);
+    } catch {}
+    return path.join(versionedDownloads, `grok-${version}`);
   }
   if (agent === 'droid') {
     // Factory's installer drops a standalone native binary (no npm package,
@@ -1169,7 +1182,20 @@ export async function installVersion(
     try {
       const script = agentConfig.installScript.replaceAll('VERSION', version);
       onProgress?.(`Installing ${agentConfig.name}@${version} via official installer...`);
-      await execAsync(script, { timeout: 120000 });
+      // For grok, pre-create a staging home dir and point GROK_HOME at it so the
+      // official installer drops the binary inside the versioned home where
+      // getBinaryPath() will find it. We stage under 'latest' because the concrete
+      // version isn't known until after the install; reconcileStaleLatestDir renames
+      // it to the real version afterward. Without GROK_HOME the installer writes to
+      // ~/.grok/downloads, which getBinaryPath doesn't check.
+      const installEnv = agent === 'grok'
+        ? (() => {
+            const stagingGrokHome = path.join(getVersionDir(agent, 'latest'), 'home', '.grok');
+            fs.mkdirSync(stagingGrokHome, { recursive: true });
+            return { ...process.env, GROK_HOME: stagingGrokHome };
+          })()
+        : undefined;
+      await execAsync(script, { timeout: 120000, env: installEnv });
 
       if (version === 'latest') {
         installedVersion = await getCliVersionFromPath(agent) || version;


### PR DESCRIPTION
## Problem

`ag add grok@latest` appeared to succeed but `ag run grok` always failed with:

```
agents: grok@0.2.91 not installed
```

Root cause: three-way inconsistency between where the binary actually lives, where `getBinaryPath` looks, and where the shim looks.

| Location | Path checked |
|---|---|
| `getBinaryPath` | `$VERSION_DIR/home/.grok/downloads/` ✓ |
| Dispatcher shim | `$HOME/.grok/downloads/` ✗ |
| Versioned alias shim | `$HOME/.grok/downloads/` ✗ |
| `installVersion` (curl install) | no GROK_HOME set → binary goes to `~/.grok/downloads/` ✗ |

When a user runs `ag add grok@latest`, the curl installer runs without `GROK_HOME` set so the binary lands in `~/.grok/downloads/` (or in the latest already-running grok's versioned home via self-update). The shim then checks `$HOME/.grok/downloads/` which was often empty, and falls through to the "not installed" error. Meanwhile `getBinaryPath` looked in the versioned home — so `ag view` also showed the version as not installed.

## Fix

1. **`getBinaryPath`** — check the versioned home first, fall back to `~/.grok/downloads/` for pre-fix installs.

2. **Dispatcher shim template** — mirror `getBinaryPath`: check `$VERSION_DIR/home/.grok/downloads` first, then fall back to `$HOME/.grok/downloads`.

3. **Versioned alias template** — same dual-check.

4. **`installVersion`** — pre-create the `latest` staging home and set `GROK_HOME` before running the curl installer. `reconcileStaleLatestDir` renames `latest/` → the concrete version afterward. Future `ag add grok@latest` will drop the binary directly into the versioned home.

## Impact

- Existing users who ran `ag add grok@latest` before this fix: the new `getBinaryPath` fallback and shim fallback find their binary wherever the old install left it.
- New users after this fix: binary goes directly into the versioned home via the pre-set `GROK_HOME`, so no fallback needed.