### PR TITLE
feat(factory): readable agent cards — markdown, task anchor, progress timeline, streaming activity + todos

### DIFF
--- a/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
@@ -6,7 +6,15 @@ import { heartbeatLevel, sessionTaskLine, type FloorAgent, type FloorTicket } fr
 import { sinceFromMs } from './floorAdapter'
 import { useNow } from './useNow'
 import { CardChecklist } from './TodoChecklist'
+import { MiniTimeline } from './Timeline'
+import { renderMarkdown } from '../../utils/markdown'
 import { ExtLink } from '../common/ExtLink'
+
+/** First line of a block of text, trimmed — a title reads best as a single clause. */
+function firstLine(text: string): string {
+  const line = text.split('\n').map((l) => l.trim()).find((l) => l.length > 0) ?? ''
+  return line.length > 72 ? line.slice(0, 72) + '…' : line
+}
 
 // One agent row in the feed (feedItem: factory-floor.html:608-620) + the Next-Up
 // ticketStrip teaser row (:621-623). Pure presentation; selection + replies raised
@@ -50,12 +58,14 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
   // to the meta line. Both only show in full (non-plain) mode when the CLI supplies them.
   const paneLabel = !plain && a.pane ? ` · ${a.pane}` : ''
   const viewingLabel = !plain && a.viewingIn ? ` · viewing in ${a.viewingIn}` : ''
-  // The worktree slug (or branch) sits between project and ticket so two sessions in
-  // the same repo are distinguishable at a glance (the identical-cards bug).
+  // The worktree slug (or branch) disambiguates two sessions in the same repo (the
+  // identical-cards bug). It now renders as its own clean chip (below) rather than being
+  // concatenated into the meta string — so a stray `WT=<path>` can never leak into the
+  // meta line. The meta line keeps project · host · ticket · files.
   const wt = a.worktreeSlug || a.branch
   const meta = plain
     ? a.project
-    : `${a.project} · ${a.hostLabel ?? a.host}${wt ? ` · ${wt}` : ''}${a.ticket ? ` · ${a.ticket}` : ''}${filesLabel}${paneLabel}${viewingLabel}`
+    : `${a.project} · ${a.hostLabel ?? a.host}${a.ticket ? ` · ${a.ticket}` : ''}${filesLabel}${paneLabel}${viewingLabel}`
   // Compact provenance chip next to the name: "<agent>·<short session id>", e.g.
   // "claude·4de7b016" — so a human label ("terminal-race-fix") reads as the title
   // while the session stays identifiable. Only when the id differs from the shown name.
@@ -76,7 +86,18 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
   // narrative still shows its worktree slug instead of just "Edit <file>". Shown unless
   // it merely echoes the response block or the now-line.
   const taskLine = sessionTaskLine(a)
-  const showSummary = !plain && !!taskLine && taskLine !== a.resp.trim() && taskLine !== nowlineText
+  // The ORIGINAL task anchors the card. When the session carries a prompt, the title
+  // reads the task (its first line) and the prompt gets its own TASK block below; the
+  // agent name stays as context in the title's tooltip + the provenance chip. Without a
+  // prompt, the title stays the agent's own display name (prior behavior).
+  const prompt = (a.prompt ?? '').trim()
+  const title = !plain && prompt ? firstLine(prompt) : a.name
+  const showTask = !plain && !!prompt
+  // Only show the rolling summary line when it adds signal beyond the task block, the
+  // response body, and the now-line (it merely echoes the prompt when they match).
+  const showSummary =
+    !plain && !!taskLine && taskLine !== a.resp.trim() && taskLine !== nowlineText &&
+    !(showTask && taskLine === prompt)
   const showNowline = !plain && !!a.verb && !(showSummary && taskLine === nowlineText)
 
   const marker =
@@ -111,9 +132,10 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
       <div className="head">
         <span className={`dot ${a.phase}`} />
         <AgentAvatar id={agentIdFromPrefix(a.abbr) ?? a.abbr.toLowerCase()} size={20} title={a.abbr} />
-        <span className="who">{a.name}</span>
+        <span className="who" title={prompt ? `${a.name} — ${prompt}` : a.name}>{title}</span>
         {!plain && sid && <span className="sid" title={a.sessionId}>{sid}</span>}
         <span className="path">{meta}</span>
+        {!plain && wt && <span className="wtchip mono" title={a.worktreePath || wt}>{wt}</span>}
         <span className="when">
           {marker}
           {bgBadge}
@@ -126,7 +148,13 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
           </span>
         </span>
       </div>
-      <div className="resp">{destructive ? <span className="q">{a.resp}</span> : a.resp}</div>
+      {showTask && (
+        <div className="task">
+          <span className="lab">Task</span>
+          {renderMarkdown(prompt, { clamp: true })}
+        </div>
+      )}
+      {a.resp && <div className={`resp${destructive ? ' q' : ''}`}>{renderMarkdown(a.resp, { clamp: true })}</div>}
       {!plain && (a.spawnedTeam || (a.createdTickets?.length ?? 0) > 0) && (
         <div className="artifacts" onClick={(e) => e.stopPropagation()}>
           {a.spawnedTeam && (
@@ -148,6 +176,7 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
           <Icon name="chevR" size={11} /> <span className="v">{a.verb}</span> {a.target}
         </div>
       )}
+      {!plain && a.recent.length > 0 && <MiniTimeline recent={a.recent} nowMs={now} />}
       {a.needs && (
         <div onClick={(e) => e.stopPropagation()}>
           <StructuredReply

--- a/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
@@ -10,9 +10,16 @@ import { MiniTimeline } from './Timeline'
 import { renderMarkdown } from '../../utils/markdown'
 import { ExtLink } from '../common/ExtLink'
 
-/** First line of a block of text, trimmed — a title reads best as a single clause. */
+/** First line of a block of text as a plain-text title — strips leading markdown
+ *  (ATX headings, list bullets) and inline markers so a prompt like "## Problem"
+ *  or "**Fix** the bug" reads cleanly in the title chip. */
 function firstLine(text: string): string {
-  const line = text.split('\n').map((l) => l.trim()).find((l) => l.length > 0) ?? ''
+  const raw = text.split('\n').map((l) => l.trim()).find((l) => l.length > 0) ?? ''
+  const line = raw
+    .replace(/^#+\s+/, '') // ATX heading
+    .replace(/^[-*+]\s+/, '') // list bullet
+    .replace(/[*_`]/g, '') // inline emphasis / code
+    .trim()
   return line.length > 72 ? line.slice(0, 72) + '…' : line
 }
 

--- a/apps/factory/ui/settings/components/mission-control/Timeline.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/Timeline.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from 'bun:test'
+import { toolTarget, stepAgo } from './Timeline'
+import type { RecentToolCall } from './floorModel'
+
+const NOW = 1_700_000_000_000
+
+describe('toolTarget — a compact target for a tool call', () => {
+  test('a file path renders as its basename', () => {
+    const call: RecentToolCall = { name: 'Edit', input: { file_path: '/Users/x/repo/src/core/tasks.ts' } }
+    expect(toolTarget(call)).toBe('tasks.ts')
+  })
+
+  test('other path-shaped keys (target_file / path) also basename', () => {
+    expect(toolTarget({ name: 'Read', input: { path: '/a/b/floor.css' } })).toBe('floor.css')
+    expect(toolTarget({ name: 'Write', input: { target_file: '/a/b/c/Timeline.tsx' } })).toBe('Timeline.tsx')
+  })
+
+  test('a shell command renders as a short clause, truncated with an ellipsis', () => {
+    const long = 'bun run build:settings && echo done && sleep 5 && curl localhost'
+    const out = toolTarget({ name: 'Bash', input: { command: long } })
+    expect(out.length).toBeLessThanOrEqual(43)
+    expect(out.endsWith('…')).toBe(true)
+    expect(toolTarget({ name: 'Bash', input: { command: 'bun run test' } })).toBe('bun run test')
+  })
+
+  test('no recognizable arg yields empty', () => {
+    expect(toolTarget({ name: 'TodoWrite', input: { todos: [] } })).toBe('')
+    expect(toolTarget({ name: 'X' })).toBe('')
+    expect(toolTarget({ name: 'X', input: 'not-an-object' as unknown })).toBe('')
+  })
+})
+
+describe('stepAgo — relative age of a tool step', () => {
+  test('under 5s reads as "now"', () => {
+    expect(stepAgo(new Date(NOW - 2000).toISOString(), NOW)).toBe('now')
+  })
+  test('seconds / minutes / hours scale', () => {
+    expect(stepAgo(new Date(NOW - 40_000).toISOString(), NOW)).toBe('40s')
+    expect(stepAgo(new Date(NOW - 3 * 60_000).toISOString(), NOW)).toBe('3m')
+    expect(stepAgo(new Date(NOW - 2 * 3600_000).toISOString(), NOW)).toBe('2h')
+  })
+  test('a missing or unparseable timestamp yields empty', () => {
+    expect(stepAgo(undefined, NOW)).toBe('')
+    expect(stepAgo('not-a-date', NOW)).toBe('')
+  })
+  test('a future timestamp clamps to "now" (no negative ages)', () => {
+    expect(stepAgo(new Date(NOW + 10_000).toISOString(), NOW)).toBe('now')
+  })
+})

--- a/apps/factory/ui/settings/components/mission-control/Timeline.tsx
+++ b/apps/factory/ui/settings/components/mission-control/Timeline.tsx
@@ -1,0 +1,114 @@
+import React from 'react'
+import type { RecentToolCall } from './floorModel'
+
+// Progress timeline from a session's recent tool calls. Two affordances share the same
+// step derivation (toolTarget / stepAgo below):
+//   MiniTimeline — the compact last-N steps on the feed card (matches the mockup .mtl).
+//   VerticalTimeline — the detail-pane rail (matches the mockup .vtl).
+// `recent` arrives NEWEST-FIRST (session.summary.ts unshifts each call), so both render
+// OLDEST -> newest top-to-bottom, with the newest as the pulsing "now" head.
+
+/** Compact target for a tool call: the basename for a file path, else a short arg. */
+export function toolTarget(call: RecentToolCall): string {
+  const input = call.input
+  if (!input || typeof input !== 'object') return ''
+  const rec = input as Record<string, unknown>
+  // File-ish keys read best as a basename; free-text keys as a short clause.
+  const pathKeys = ['file_path', 'path', 'target_file', 'notebook_path']
+  for (const key of pathKeys) {
+    const v = rec[key]
+    if (typeof v === 'string' && v.trim()) {
+      const seg = v.split('/').filter(Boolean).pop() ?? v
+      return seg
+    }
+  }
+  const textKeys = ['command', 'query', 'pattern', 'url', 'description', 'prompt']
+  for (const key of textKeys) {
+    const v = rec[key]
+    if (typeof v === 'string' && v.trim()) {
+      const t = v.trim().replace(/\s+/g, ' ')
+      return t.length > 42 ? t.slice(0, 42) + '…' : t
+    }
+  }
+  return ''
+}
+
+/** Relative age label ("now" / "40s" / "3m" / "2h") for a tool call's timestamp. */
+export function stepAgo(timestamp: string | undefined, nowMs: number): string {
+  if (!timestamp) return ''
+  const ms = new Date(timestamp).getTime()
+  if (!isFinite(ms)) return ''
+  const s = Math.max(0, Math.floor((nowMs - ms) / 1000))
+  if (s < 5) return 'now'
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h`
+  return `${Math.floor(h / 24)}d`
+}
+
+/** Newest-first `recent` -> oldest-first steps, capped to `limit` most-recent calls. */
+function orderedSteps(recent: RecentToolCall[], limit: number): RecentToolCall[] {
+  return recent.slice(0, limit).reverse()
+}
+
+interface MiniTimelineProps {
+  recent: RecentToolCall[]
+  nowMs: number
+  /** How many recent steps to show (default 4, per the mockup). */
+  limit?: number
+}
+
+/** Compact mini-timeline for the feed card: last ~4 tool steps, current one pulsing. */
+export function MiniTimeline({ recent, nowMs, limit = 4 }: MiniTimelineProps) {
+  if (recent.length === 0) return null
+  const steps = orderedSteps(recent, limit)
+  const lastIndex = steps.length - 1
+  return (
+    <div className="mtl" onClick={(e) => e.stopPropagation()}>
+      <div className="mtl-cap">Progress · last {steps.length} {steps.length === 1 ? 'step' : 'steps'}</div>
+      {steps.map((call, i) => {
+        const now = i === lastIndex
+        const target = toolTarget(call)
+        return (
+          <div key={`${call.name}-${i}`} className={`step ${now ? 'now' : 'done'}`}>
+            <span className="mk" />
+            <span className="nm">{call.name}</span>
+            {target && <span className="tt mono">{target}</span>}
+            <span className="ago">{stepAgo(call.timestamp, nowMs)}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+interface VerticalTimelineProps {
+  recent: RecentToolCall[]
+  nowMs: number
+  /** How many recent steps to show (default 8). */
+  limit?: number
+}
+
+/** Detail-pane vertical timeline: last ~8 tool steps as a connected rail. */
+export function VerticalTimeline({ recent, nowMs, limit = 8 }: VerticalTimelineProps) {
+  if (recent.length === 0) return null
+  const steps = orderedSteps(recent, limit)
+  const lastIndex = steps.length - 1
+  return (
+    <ul className="vtl">
+      {steps.map((call, i) => {
+        const now = i === lastIndex
+        const target = toolTarget(call)
+        return (
+          <li key={`${call.name}-${i}`} className={now ? 'now' : ''}>
+            <span className="mk" />
+            <span className="nm">{call.name}{target && <span className="t mono"> {target}</span>}</span>
+            <span className="ago">{stepAgo(call.timestamp, nowMs)}</span>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -5,9 +5,10 @@ import { Icon } from './icons'
 import { relTime, taskNameToTitle, swarmOverallStatus, shortDuration } from './types'
 import { postMessage, usePanelVisibility } from '../../hooks'
 import { ExtLink } from '../common'
-import { renderTodoDescription } from '../../utils/markdown'
+import { renderTodoDescription, renderMarkdown } from '../../utils/markdown'
 import { CMD_PALETTE_EVENTS } from './CommandPalette'
 import { CloudActivityFeed } from './CloudActivityFeed'
+import { VerticalTimeline } from './Timeline'
 import {
   isTerminalActive,
   isTerminalJustSpawned,
@@ -1752,17 +1753,43 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
                   </ExtLink>
                 )}
               </div>
-              {(() => { const task = sessionTaskLine(a); return task && task !== a.resp.trim() ? <div className="resp" style={{ marginTop: 8 }}>{task}</div> : null })()}
-              {a.resp && a.resp !== a.summary && <div className="resp" style={{ marginTop: 8 }}>{a.resp}</div>}
-              {(a.verb || a.target) && <div className="nowline" style={{ marginTop: 8 }}><Icon name="chevR" size={11} /> <span className="v">{a.verb}</span> {a.target}</div>}
             </div>
+            {/* Task anchor: the ORIGINAL prompt (markdown), distinct from the last message.
+                Falls back through sessionTaskLine (prompt -> summary -> resp -> slug/branch)
+                so the detail rail always shows a task, even for a promptless session. */}
+            {(() => {
+              const task = a.prompt?.trim() || sessionTaskLine(a)
+              return task ? (
+                <div className="sw-unified-detail-section">
+                  <div className="sw-section-label">Task</div>
+                  <div className="md">{renderMarkdown(task)}</div>
+                </div>
+              ) : null
+            })()}
+            {/* Progress timeline: the recent tool calls as a vertical rail, oldest -> now.
+                For cloud rows the existing CloudActivityFeed still drives the AgentDetailView. */}
             {a.recent.length > 0 && (
               <div className="sw-unified-detail-section">
-                <div className="sw-section-label">Recent tools</div>
-                <div className="sw-floor-detail-tools">
-                  {a.recent.slice(0, 8).map((call, i) => (
-                    <RecentToolCallRow key={`${call.name}-${i}`} call={call} />
+                <div className="sw-section-label">Progress <span className="sw-section-count">{Math.min(a.recent.length, 8)} recent</span></div>
+                <VerticalTimeline recent={a.recent} nowMs={nowMs} />
+              </div>
+            )}
+            {/* Streaming Activity feed: the recent assistant messages (markdown), newest at
+                the bottom, capped by a live "now" verb/target indicator that updates on the
+                3s poll. Falls back to the single last response when only `resp` is carried. */}
+            {(a.messages.length > 0 || a.resp || a.verb || a.target) && (
+              <div className="sw-unified-detail-section">
+                <div className="sw-section-label">Activity</div>
+                <div className="sw-activity-feed">
+                  {(a.messages.length > 0 ? a.messages : (a.resp ? [a.resp] : [])).map((m, i) => (
+                    <div key={i} className="sw-activity-msg md">{renderMarkdown(m)}</div>
                   ))}
+                  {(a.verb || a.target) && (
+                    <div className={`sw-activity-now nowline ${a.phase === 'stalled' ? 'stall' : ''}`}>
+                      <span className="sw-activity-dot" />
+                      <span className="v">{a.verb}</span> {a.target}
+                    </div>
+                  )}
                 </div>
               </div>
             )}
@@ -3053,9 +3080,13 @@ function AgentDetailView({ agent, swarm, onRetry, onKill }: { agent: AgentDetail
       )}
       {agent.last_messages && agent.last_messages.length > 0 && (
         <div className="sw-unified-detail-section">
-          <div className="sw-section-label">Latest</div>
-          <div className="sw-unified-detail-text mono" style={{ fontSize: 11 }}>
-            {agent.last_messages[agent.last_messages.length - 1]?.slice(0, 300)}
+          <div className="sw-section-label">Activity</div>
+          <div className="sw-activity-feed">
+            {agent.last_messages
+              .filter((m) => typeof m === 'string' && m.trim().length > 0)
+              .map((m, i) => (
+                <div key={i} className="sw-activity-msg md">{renderMarkdown(m)}</div>
+              ))}
           </div>
         </div>
       )}

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -533,3 +533,77 @@
 .swarmify-root .host-ver-drift { justify-self: end; font-size: 10px; }
 .swarmify-root .host-drift-warn { color: #8a6d16; background: var(--status-pending-bg); padding: 1px 6px; border-radius: var(--r-sm); font-weight: 600; }
 .swarmify-root .host-drift-ok { color: var(--ds-text-faint); }
+
+/* ============================================================================
+ * Card + detail redesign (factory-card-ux). Ported from the mockup
+ * (/tmp/factory-card-redesign.html) with every local color remapped to the
+ * locked design tokens. Adds: a TASK anchor block, a clean worktree chip, a mini
+ * progress timeline on the card + a vertical one in the detail, and a streaming
+ * Activity feed. All scoped under .swarmify-root; light + dark both work via the
+ * theme-swapped --ds-* / status tokens.
+ * ========================================================================== */
+
+/* Markdown body inside the card .resp — the todo-md wrapper renders block elements,
+ * so tame their default margins to sit inside the compact card row. */
+.swarmify-root .fitem .resp .todo-md { margin: 0; }
+.swarmify-root .fitem .resp .todo-md > :first-child { margin-top: 0; }
+.swarmify-root .fitem .resp .todo-md > :last-child { margin-bottom: 0; }
+.swarmify-root .fitem .resp.q { color: var(--status-pending); font-weight: 600; border-left-color: var(--status-pending); }
+
+/* Clean worktree chip in the card head — replaces the WT=<path> leak in the meta line. */
+.swarmify-root .fitem .wtchip { font-size: 10px; color: var(--ds-text-muted); background: var(--ds-bg-recessed); border: 1px solid var(--ds-border); border-radius: 5px; padding: 1px 6px; flex: none; white-space: nowrap; max-width: 200px; overflow: hidden; text-overflow: ellipsis; }
+
+/* TASK anchor — the original prompt, rendered as markdown, brand-edged. */
+.swarmify-root .fitem .task { font-size: 12.5px; color: var(--ds-text); line-height: 1.5; margin: 2px 0 10px; background: var(--ds-bg-recessed); border-left: 2px solid var(--brand); border-radius: 0 var(--r-md) var(--r-md) 0; padding: 7px 11px; }
+.swarmify-root .fitem .task .lab { font-family: "Geist Mono", monospace; font-size: 9px; letter-spacing: .12em; color: var(--ds-text-dim); text-transform: uppercase; display: block; margin-bottom: 3px; }
+.swarmify-root .fitem .task .todo-md { margin: 0; }
+.swarmify-root .fitem .task .todo-md > :first-child { margin-top: 0; }
+.swarmify-root .fitem .task .todo-md > :last-child { margin-bottom: 0; }
+
+/* Mini progress timeline on the card — last N tool steps, current one pulsing. */
+.swarmify-root .fitem .mtl { margin-top: 8px; padding-top: 9px; border-top: 1px dashed var(--ds-border); }
+.swarmify-root .fitem .mtl-cap { font-family: "Geist Mono", monospace; font-size: 9px; letter-spacing: .12em; color: var(--ds-text-dim); text-transform: uppercase; margin-bottom: 6px; }
+.swarmify-root .fitem .mtl .step { display: flex; align-items: center; gap: 8px; font-family: "Geist Mono", monospace; font-size: 11px; color: var(--ds-text-muted); padding: 1.5px 0; }
+.swarmify-root .fitem .mtl .step .mk { width: 7px; height: 7px; border-radius: 50%; background: var(--ds-border); flex: none; }
+.swarmify-root .fitem .mtl .step.done .mk { background: var(--brand-600); }
+.swarmify-root .fitem .mtl .step.now .mk { background: var(--brand-600); box-shadow: 0 0 0 3px var(--brand-ring); animation: sw-tlpulse 1.3s infinite; }
+.swarmify-root .fitem .mtl .step.now { color: var(--ds-text); }
+.swarmify-root .fitem .mtl .step .nm { font-weight: 600; color: var(--ds-text); }
+.swarmify-root .fitem .mtl .step.done .nm { font-weight: 500; color: var(--ds-text-muted); }
+.swarmify-root .fitem .mtl .step .tt { color: var(--status-running); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.swarmify-root .fitem .mtl .step .ago { margin-left: auto; color: var(--ds-text-faint); font-size: 10px; flex: none; }
+
+@keyframes sw-tlpulse { 0%, 100% { box-shadow: 0 0 0 2px var(--brand-ring); } 50% { box-shadow: 0 0 0 5px color-mix(in srgb, var(--brand) 8%, transparent); } }
+@media (prefers-reduced-motion: reduce) {
+  .swarmify-root .fitem .mtl .step.now .mk, .swarmify-root .vtl li.now .mk { animation: none; }
+}
+
+/* Detail-pane vertical timeline (Progress section). */
+.swarmify-root .sw-section-count { margin-left: auto; color: var(--ds-text-faint); font-family: "Geist Mono", monospace; font-size: 9.5px; font-weight: 500; }
+.swarmify-root .vtl { position: relative; margin: 0; padding: 2px 0 0 4px; list-style: none; }
+.swarmify-root .vtl li { position: relative; padding: 0 0 12px 20px; border-left: 1.5px solid var(--ds-border); display: flex; align-items: baseline; gap: 6px; }
+.swarmify-root .vtl li:last-child { border-left-color: transparent; padding-bottom: 2px; }
+.swarmify-root .vtl li .mk { position: absolute; left: -5.5px; top: 3px; width: 9px; height: 9px; border-radius: 50%; background: var(--brand-600); border: 2px solid var(--ds-bg-panel); }
+.swarmify-root .vtl li.now .mk { box-shadow: 0 0 0 3px var(--brand-ring); animation: sw-tlpulse 1.3s infinite; }
+.swarmify-root .vtl li .nm { font-family: "Geist Mono", monospace; font-size: 11.5px; color: var(--ds-text); }
+.swarmify-root .vtl li .nm .t { color: var(--status-running); }
+.swarmify-root .vtl li .ago { font-family: "Geist Mono", monospace; font-size: 10px; color: var(--ds-text-faint); margin-left: auto; flex: none; }
+.swarmify-root .vtl li.now .nm { font-weight: 650; }
+
+/* Streaming Activity feed (recent assistant messages + a live now indicator). */
+.swarmify-root .sw-activity-feed { display: flex; flex-direction: column; gap: 8px; }
+.swarmify-root .sw-activity-msg { font-size: 12.5px; color: var(--ds-text); line-height: 1.55; padding: 8px 10px; background: var(--ds-bg-recessed); border: 1px solid var(--ds-border-subtle); border-radius: var(--r-md); }
+.swarmify-root .sw-activity-msg .todo-md { margin: 0; }
+.swarmify-root .sw-activity-msg .todo-md > :first-child { margin-top: 0; }
+.swarmify-root .sw-activity-msg .todo-md > :last-child { margin-bottom: 0; }
+.swarmify-root .sw-activity-now { display: flex; align-items: center; gap: 7px; font-family: "Geist Mono", monospace; font-size: 11px; color: var(--ds-text-muted); }
+.swarmify-root .sw-activity-now .v { color: var(--brand-600); font-weight: 600; }
+.swarmify-root .sw-activity-now.stall .v { color: var(--status-pending); }
+.swarmify-root .sw-activity-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--brand-600); flex: none; box-shadow: 0 0 0 3px var(--brand-ring); animation: sw-tlpulse 1.3s infinite; }
+.swarmify-root .sw-activity-now.stall .sw-activity-dot { background: var(--status-pending); }
+
+/* Markdown blocks in the detail (Task / Activity). */
+.swarmify-root .sw-unified-detail-section .md { font-size: 12.5px; color: var(--ds-text); line-height: 1.55; }
+.swarmify-root .sw-unified-detail-section .md .todo-md { margin: 0; }
+.swarmify-root .sw-unified-detail-section .md .todo-md > :first-child { margin-top: 0; }
+.swarmify-root .sw-unified-detail-section .md .todo-md > :last-child { margin-bottom: 0; }

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
@@ -9,6 +9,7 @@ import {
   toFloorAgentFromUnified,
   toFloorAgentFromRemote,
   adaptTickets,
+  cleanWorktreeSlug,
   type UnifiedAgentLike,
   type RemoteSessionLike,
 } from './floorAdapter'
@@ -199,6 +200,70 @@ describe('toFloorAgentFromUnified', () => {
     expect(a.branch).toBe('feat-rl')
     expect(a.question?.kind).toBe('choice')
     expect(a.question?.options.length).toBeGreaterThanOrEqual(2)
+  })
+
+  test('maps the ORIGINAL task (terminal firstUserMessage) into prompt, distinct from the last message', () => {
+    const a = toFloorAgentFromUnified(
+      baseUnified({
+        activity: 'Editing FeedItem.tsx',
+        terminal: { id: 't1', firstUserMessage: 'Surface the original prompt on cards' },
+        agent: { last_messages: ['Done — wired renderMarkdown into the resp line'] },
+      }),
+      { pinned: new Set(), workspaceRepo: null, nowMs: NOW },
+    )
+    expect(a.prompt).toBe('Surface the original prompt on cards')
+    // resp is the LAST message, not the prompt — the two are independent.
+    expect(a.resp).toBe('Done — wired renderMarkdown into the resp line')
+  })
+
+  test('a headless run maps its dispatch prompt into prompt', () => {
+    const a = toFloorAgentFromUnified(
+      baseUnified({
+        terminal: null,
+        agent: { prompt: 'Fix the rate limiter', last_messages: [] },
+      }),
+      { pinned: new Set(), workspaceRepo: null, nowMs: NOW },
+    )
+    expect(a.prompt).toBe('Fix the rate limiter')
+  })
+
+  test('carries the full last_messages window into messages (Activity feed), not just the last one', () => {
+    const a = toFloorAgentFromUnified(
+      baseUnified({
+        agent: { last_messages: ['first', '', '  ', 'second', 'third'] },
+      }),
+      { pinned: new Set(), workspaceRepo: null, nowMs: NOW },
+    )
+    // blank entries are dropped; order preserved; resp is still the last non-blank one.
+    expect(a.messages).toEqual(['first', 'second', 'third'])
+    expect(a.resp).toBe('third')
+  })
+
+  test('renders a clean worktree slug from a real worktree cwd (never a raw path)', () => {
+    const a = toFloorAgentFromUnified(
+      baseUnified({
+        terminal: { id: 't1', cwd: '/Users/x/src/github.com/o/agents-cli/.agents/worktrees/rush-1531' },
+      }),
+      { pinned: new Set(), workspaceRepo: null, nowMs: NOW },
+    )
+    expect(a.worktreeSlug).toBe('rush-1531')
+    expect(a.worktreeSlug).not.toContain('/')
+    expect(a.worktreeSlug).not.toContain('WT=')
+  })
+})
+
+describe('cleanWorktreeSlug — kills the WT=<path> leak', () => {
+  test('a real worktree path yields the trailing slug', () => {
+    expect(cleanWorktreeSlug('/Users/x/repo/.agents/worktrees/rush-1531')).toBe('rush-1531')
+  })
+  test('strips a WT= prefix and any surviving path down to the slug', () => {
+    expect(cleanWorktreeSlug('WT=/Users/x/repo/.agents/worktrees/card-ux')).toBe('card-ux')
+  })
+  test('a non-worktree cwd resolves to empty (no chip)', () => {
+    expect(cleanWorktreeSlug('/Users/x/src/repo')).toBe('')
+    expect(cleanWorktreeSlug('')).toBe('')
+    expect(cleanWorktreeSlug(null)).toBe('')
+    expect(cleanWorktreeSlug(undefined)).toBe('')
   })
 })
 

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
@@ -17,6 +17,7 @@ import {
   parseStructuredQuestion,
   toFloorTicket,
   latestTodos,
+  todosWithFallback,
   resolveProject,
   worktreeSlugOf,
   type FloorAgent,
@@ -24,8 +25,41 @@ import {
   type AgentAbbr,
   type ReplyTarget,
   type CiStatus,
+  type TodoItem,
 } from './floorModel'
 import type { UnifiedTask, RecentToolCall, ProjectRule } from '../../types'
+
+// Last non-empty todo set per session, so the checklist survives the recent-tool
+// window cap (see floorModel.todosWithFallback). Keyed by the FloorAgent id, which is
+// stable across polls for a given session (local: u.id; remote: `remote-<host>-<id>`).
+// Module-level (not React state) so it persists across the pane's 3s re-derives without
+// threading a store through every adapter call. Empty parses fall back to the remembered
+// set; a fresh non-empty parse overwrites it.
+const lastTodosById = new Map<string, TodoItem[]>()
+
+/** Parse fresh todos, remembering the last non-empty set so the checklist doesn't vanish. */
+function stickyTodos(id: string, toolCalls: RecentToolCall[] | undefined): TodoItem[] {
+  const fresh = latestTodos(toolCalls)
+  const merged = todosWithFallback(fresh, lastTodosById.get(id))
+  if (fresh.length > 0) lastTodosById.set(id, fresh)
+  return merged
+}
+
+/**
+ * A clean worktree slug — never a raw path. worktreeSlugOf already returns a slug for a
+ * real .agents/worktrees/<slug> path, but a raw source string can leak a `WT=<abs path>`
+ * marker (the reported `WT=/Users/.../worktrees/rush-1531` bug). Strip a `WT=` prefix and
+ * collapse any surviving absolute path down to its final path segment so the card renders
+ * a chip, not a filesystem path.
+ */
+export function cleanWorktreeSlug(raw: string | null | undefined): string {
+  const s = worktreeSlugOf(raw)
+  if (!s) return ''
+  const stripped = s.replace(/^WT=/, '')
+  // If a whole path survived, keep only the last segment (the slug).
+  const seg = stripped.split('/').filter(Boolean).pop() ?? stripped
+  return seg.trim()
+}
 
 // ---------- structural inputs ----------
 
@@ -52,6 +86,8 @@ export interface UnifiedAgentLike {
     cwd?: string | null
     branch?: string | null
     waitingForInput?: boolean
+    /** The ORIGINAL task the session opened with — anchors the card. */
+    firstUserMessage?: string
     lastUserMessage?: string
     currentActivity?: string
     narrative?: string
@@ -62,6 +98,8 @@ export interface UnifiedAgentLike {
     branch?: string | null
     repo_name?: string | null
     status?: string
+    /** Original dispatch prompt for a headless/background agent. */
+    prompt?: string
     last_messages?: string[]
   } | null
 }
@@ -124,6 +162,14 @@ const ABBR_BY_TYPE: Record<string, AgentAbbr> = {
 /** agentType string -> terminal-tab prefix. Unknown types fall back to Shell. */
 export function abbrFor(agentType: string): AgentAbbr {
   return ABBR_BY_TYPE[(agentType || '').toLowerCase()] ?? 'SH'
+}
+
+/** First non-blank string, trimmed; undefined when none. */
+function firstNonEmptyStr(...values: Array<string | null | undefined>): string | undefined {
+  for (const v of values) {
+    if (typeof v === 'string' && v.trim()) return v.trim()
+  }
+  return undefined
 }
 
 /**
@@ -248,7 +294,13 @@ export function toFloorAgentFromUnified(
   })
   const needs = deriveNeeds(phase, prOpenUnreviewed, ci)
   const lastMsgs = u.agent?.last_messages
-  const resp = (lastMsgs && lastMsgs.length ? lastMsgs[lastMsgs.length - 1] : '') || u.activity || ''
+  // The full recent-messages window (up to the CLI's last N) drives the detail Activity
+  // feed; the single last one still feeds `resp` (card body / question parsing).
+  const messages = (lastMsgs ?? []).filter((m) => typeof m === 'string' && m.trim().length > 0)
+  const resp = (messages.length ? messages[messages.length - 1] ?? '' : '') || u.activity || ''
+  // Original task anchor: a terminal session's first user message, else a headless run's
+  // dispatch prompt. Distinct from `resp` (the last message), which drifts as work goes.
+  const prompt = firstNonEmptyStr(u.terminal?.firstUserMessage, u.agent?.prompt)
   const { verb, target } = splitActivity(u.activity)
   const project = deriveProject(u.terminal?.cwd ?? u.agent?.cwd, u.agent?.repo_name, opts.workspaceRepo || '—', opts.projectRules ?? [])
   // Local unified agents ARE this window's terminal tabs, so sendText into the live
@@ -287,12 +339,15 @@ export function toFloorAgentFromUnified(
     createdTickets: u.createdTickets ?? [],
     spawnedTeam: u.spawnedTeam || undefined,
     branch: u.terminal?.branch ?? u.agent?.branch ?? '',
-    worktreeSlug: worktreeSlugOf(u.terminal?.cwd ?? u.agent?.cwd),
+    worktreeSlug: cleanWorktreeSlug(u.terminal?.cwd ?? u.agent?.cwd),
     worktreePath: worktreeSlugOf(u.terminal?.cwd ?? u.agent?.cwd) ? (u.terminal?.cwd ?? u.agent?.cwd ?? '') : '',
     resp,
+    prompt,
+    messages,
     question: parseStructuredQuestion(resp, phase),
     reply,
-    todos: latestTodos(u.terminal?.recentToolCalls),
+    // Persist the last non-empty checklist so it survives the recent-tool window cap.
+    todos: stickyTodos(u.id, u.terminal?.recentToolCalls),
     // The rolling summary line + recent tool calls already flow over the wire on the
     // terminal. Prefer the agent's own prose (narrative); fall back to the now-line
     // (currentActivity) when it hasn't spoken between tool calls yet.
@@ -357,9 +412,15 @@ export function toFloorAgentFromRemote(r: RemoteSessionLike, pinned: Set<string>
     createdTickets: r.createdTickets ?? [],
     spawnedTeam: r.spawnedTeam || undefined,
     branch: r.branch,
-    worktreeSlug: r.worktreeSlug ?? worktreeSlugOf(r.cwd),
+    // Prefer the CLI-provided slug; strip any WT= / path leak from either source.
+    worktreeSlug: r.worktreeSlug ? cleanWorktreeSlug(r.worktreeSlug) : cleanWorktreeSlug(r.cwd),
     worktreePath: r.worktreePath ?? (worktreeSlugOf(r.cwd) ? r.cwd : ''),
     resp,
+    // Remote (Tier-1) has no first-user-message enrichment yet — the session's task line
+    // (topic) is the closest durable anchor for the original task.
+    prompt: r.topic || undefined,
+    // Only the last response is carried for remote; surface it as the single-entry feed.
+    messages: r.lastResponse ? [r.lastResponse] : [],
     question: parseStructuredQuestion(resp, phase),
     reply: deriveReplyTargetFromRemote(r),
     // Remote (Tier-1) sessions are status-only; no tool calls to parse todos from yet.

--- a/apps/factory/ui/settings/components/mission-control/floorModel.fixes.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.fixes.test.ts
@@ -20,7 +20,7 @@ function agent(over: Partial<FloorAgent>): FloorAgent {
     id: 'x', host: 'this-mac', hostLabel: undefined, project: '', name: 'a', abbr: 'CC',
     phase: 'running', verb: '', target: '', tok: 0, since: '', lastActivityMs: 0,
     files: 0, tools: 0, needs: false, pinned: false, pr: null, prUrl: null, ci: null,
-    ticket: null, branch: '', worktreeSlug: '', worktreePath: '', resp: '',
+    ticket: null, branch: '', worktreeSlug: '', worktreePath: '', resp: '', messages: [],
     question: null, reply: { kind: 'none', host: 'this-mac' }, todos: [], summary: '',
     recent: [], ...over,
   }

--- a/apps/factory/ui/settings/components/mission-control/floorModel.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.test.ts
@@ -18,12 +18,15 @@ import {
   groupTickets,
   sortTickets,
   resolveProject,
+  sessionTaskLine,
+  todosWithFallback,
   PHASE_RANK,
   STALL_THRESHOLD_MS,
   type FloorAgent,
   type FloorPhase,
   type StructuredQuestion,
   type ManagedProject,
+  type TodoItem,
 } from './floorModel'
 
 describe('resolveProject', () => {
@@ -93,6 +96,7 @@ function makeAgent(overrides: Partial<FloorAgent> = {}): FloorAgent {
     ticket: null,
     branch: 'feat-auth',
     resp: '',
+    messages: [],
     question: null,
     reply: { kind: 'terminal', host: 'this-mac', terminalId: 'CC-1' },
     todos: [],
@@ -721,5 +725,52 @@ describe('orderManagedProjects', () => {
     const ordered = orderManagedProjects(projects, { a: 1 })
     expect(ordered.map((p) => p.name)).toEqual(['a', 'b'])
     expect(projects).toEqual(frozen)
+  })
+})
+
+describe('sessionTaskLine — prompt anchors the card ahead of the drifting last message', () => {
+  test('prompt wins over summary and resp when present (the task, not the last message)', () => {
+    const a = makeAgent({
+      prompt: 'Add markdown to card bodies',
+      summary: 'Editing FeedItem.tsx',
+      resp: 'All 3 remaining hits are intentional',
+      worktreeSlug: 'card-ux',
+    })
+    expect(sessionTaskLine(a)).toBe('Add markdown to card bodies')
+  })
+
+  test('falls back to summary -> resp -> worktreeSlug -> branch when there is no prompt', () => {
+    expect(sessionTaskLine(makeAgent({ prompt: undefined, summary: 'live preview' }))).toBe('live preview')
+    expect(sessionTaskLine(makeAgent({ prompt: undefined, summary: '', resp: 'last msg' }))).toBe('last msg')
+    expect(sessionTaskLine(makeAgent({ prompt: undefined, summary: '', resp: '', worktreeSlug: 'rush-1531' }))).toBe('rush-1531')
+    expect(sessionTaskLine(makeAgent({ prompt: undefined, summary: '', resp: '', worktreeSlug: '', branch: 'feat-x' }))).toBe('feat-x')
+  })
+
+  test('a blank/whitespace prompt is skipped so it does not blank the task line', () => {
+    expect(sessionTaskLine(makeAgent({ prompt: '   ', summary: 'real work' }))).toBe('real work')
+  })
+
+  test('returns empty string when the agent carries no task signal at all', () => {
+    expect(sessionTaskLine(makeAgent({ prompt: undefined, summary: '', resp: '', worktreeSlug: '', branch: '' }))).toBe('')
+  })
+})
+
+describe('todosWithFallback — the checklist survives the recent-tool window cap', () => {
+  const set = (n: number): TodoItem[] =>
+    Array.from({ length: n }, (_, i) => ({ content: `t${i}`, status: 'pending' as const }))
+
+  test('a fresh non-empty parse is used as-is', () => {
+    const fresh = set(3)
+    expect(todosWithFallback(fresh, set(1))).toBe(fresh)
+  })
+
+  test('an empty fresh parse falls back to the remembered set (checklist does not vanish)', () => {
+    const remembered = set(2)
+    expect(todosWithFallback([], remembered)).toBe(remembered)
+  })
+
+  test('empty fresh + no remembered set yields empty (no phantom checklist)', () => {
+    expect(todosWithFallback([], undefined)).toEqual([])
+    expect(todosWithFallback([], [])).toEqual([])
   })
 })

--- a/apps/factory/ui/settings/components/mission-control/floorModel.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.ts
@@ -139,6 +139,8 @@ export interface FloorAgent {
   worktreeSlug: string   // "<slug>" under .agents/worktrees/; '' when not a worktree. Disambiguates sibling sessions + labels the card when topic/preview are empty.
   worktreePath: string   // absolute worktree path, for the Reveal-worktree action; '' when not a worktree
   resp: string           // last response text (Anthropic Agent-view style)
+  prompt?: string        // the ORIGINAL task (first user message / dispatch prompt / topic); anchors the card, distinct from the last message
+  messages: string[]     // the last few assistant messages (from the CLI's last_messages window); [] when none. Drives the detail-pane Activity feed.
   question: StructuredQuestion | null
   reply: ReplyTarget     // how a user reply reaches this agent (host dispatches on kind)
   todos: TodoItem[]      // task checklist from the latest TodoWrite; empty when none
@@ -418,14 +420,31 @@ function firstNonEmpty(...values: Array<string | null | undefined>): string | un
 
 /**
  * The one "what is this session doing" line, used by BOTH the card and the detail
- * rail so no surface re-derives it or renders blank. Fallback chain: the CLI summary
- * / live preview, then the last response, then the worktree slug or branch (a task
+ * rail so no surface re-derives it or renders blank. Fallback chain: the ORIGINAL
+ * task (prompt / first user message — the durable anchor), then the CLI summary /
+ * live preview, then the last response, then the worktree slug or branch (a task
  * label when there's no narrative — e.g. "headless-secrets-shadow"). Returns '' when
  * the agent carries no task signal at all; callers that need an absolute fallback add
  * `|| a.name` (the card already shows the name separately, so it omits that).
+ *
+ * prompt is preferred first so a card anchors to what the agent was ASKED to do, not
+ * whatever it last said — the last message drifts as work progresses, the task doesn't.
  */
 export function sessionTaskLine(a: FloorAgent): string {
-  return firstNonEmpty(a.summary, a.resp, a.worktreeSlug, a.branch) ?? ''
+  return firstNonEmpty(a.prompt, a.summary, a.resp, a.worktreeSlug, a.branch) ?? ''
+}
+
+/**
+ * Persist-last-non-empty for a session's todo checklist. The tool-call window that
+ * `latestTodos` parses is capped (session.summary.ts keeps only the last 24 calls),
+ * so once >24 tool calls follow the last TodoWrite the checklist silently vanishes.
+ * Callers thread through the last KNOWN non-empty set (remembered per session id) and
+ * fall back to it when the fresh parse is empty — so a still-running agent keeps
+ * showing its progress instead of dropping to a blank card. Pure so it's unit-tested.
+ */
+export function todosWithFallback(fresh: TodoItem[], remembered: TodoItem[] | undefined): TodoItem[] {
+  if (fresh.length > 0) return fresh
+  return remembered && remembered.length > 0 ? remembered : []
 }
 
 /**

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -51,6 +51,8 @@ function agent(p: Partial<FloorAgent>): FloorAgent {
     worktreeSlug: '',
     worktreePath: '',
     resp: '',
+    prompt: undefined,
+    messages: [],
     question: null,
     reply: { kind: 'terminal', host: 'this-mac' },
     todos: [],
@@ -102,9 +104,22 @@ const running: FloorAgent[] = [
   agent({
     id: 'r1', abbr: 'CX', name: 'bench-saved-views', sessionId: '4de7b016-2c1a-4f9e-b2d1-7a3c9e10ab55', project: 'rush', phase: 'running',
     pr: '#148', ci: 'running', tok: 41, files: 9, since: '3s', lastActivityMs: Date.now() - 3000,
-    pane: '%42', viewingIn: 'Codium tab 3',
+    pane: '%42', viewingIn: 'Codium tab 3', worktreeSlug: 'bench-saved-views',
     verb: 'Porting', target: 'the group-by control into the shared model',
+    prompt: 'Collapse the **three** ticket surfaces into one list and add saved views, wiring the group-by control through the shared `floorModel`.',
     summary: 'Collapsed the three ticket surfaces into one list; now porting the group-by control into the shared model.',
+    resp: 'Merged the three surfaces into one `BacklogCenter`. Group-by now reads `groupAgents()` from the shared model — porting the last dead view next.',
+    messages: [
+      'Read `floorModel.ts` — `groupAgents()` already covers host/project/status/agent, so I can drop the local copy.',
+      'Collapsed the three ticket surfaces into one `BacklogCenter` list.',
+      'Merged the three surfaces into one `BacklogCenter`. Group-by now reads `groupAgents()` from the shared model — porting the last dead view next.',
+    ],
+    recent: [
+      { name: 'Bash', input: { command: 'bun run test bench' }, timestamp: new Date(Date.now() - 3000).toISOString() },
+      { name: 'Edit', input: { file_path: '/repo/ui/settings/components/mission-control/BacklogCenter.tsx' }, timestamp: new Date(Date.now() - 40_000).toISOString() },
+      { name: 'Edit', input: { file_path: '/repo/ui/settings/components/mission-control/floorAdapter.ts' }, timestamp: new Date(Date.now() - 80_000).toISOString() },
+      { name: 'Read', input: { file_path: '/repo/ui/settings/components/mission-control/floorModel.ts' }, timestamp: new Date(Date.now() - 130_000).toISOString() },
+    ],
     createdTickets: ['RUSH-1519', 'RUSH-1520'],
     todos: [
       { content: 'Merge ticket surfaces', status: 'completed' },

--- a/apps/factory/ui/settings/utils/markdown.ts
+++ b/apps/factory/ui/settings/utils/markdown.ts
@@ -42,13 +42,20 @@ marked.setOptions({
 })
 
 /**
- * Render markdown description with sanitization
- * @param desc - The markdown description
- * @param clamp - Whether to clamp the content (default: true)
+ * Render an arbitrary markdown string to a sanitized React element. This is the
+ * general renderer used everywhere a card / detail surface shows agent prose that
+ * may contain markdown (the last message, the original task/prompt) — a plain
+ * string still renders fine (it's just markdown with no markup). Uses the SAME
+ * marked + DOMPurify allowlist as the todo renderer, so no new sanitization path
+ * is introduced.
+ *
+ * @param text  - The markdown (or plain) text
+ * @param opts.clamp - Line-clamp the block for compact surfaces (default: false)
  * @returns React element with rendered markdown
  */
-export function renderTodoDescription(desc: string, clamp: boolean = true): React.ReactElement {
-  const raw = marked.parse(desc)
+export function renderMarkdown(text: string, opts: { clamp?: boolean } = {}): React.ReactElement {
+  const clamp = opts.clamp ?? false
+  const raw = marked.parse(text)
   const safe = DOMPurify.sanitize(raw, {
     ALLOWED_TAGS: TODO_MARKDOWN_ALLOWED_TAGS,
     ALLOWED_ATTR: TODO_MARKDOWN_ALLOWED_ATTRS
@@ -73,4 +80,16 @@ export function renderTodoDescription(desc: string, clamp: boolean = true): Reac
     onClick,
     dangerouslySetInnerHTML: { __html: safe }
   })
+}
+
+/**
+ * Render a todo description with sanitization. Thin wrapper over renderMarkdown
+ * kept for existing callers; the `clamp` default stays `true` (a checklist item
+ * clamps by default).
+ * @param desc - The markdown description
+ * @param clamp - Whether to clamp the content (default: true)
+ * @returns React element with rendered markdown
+ */
+export function renderTodoDescription(desc: string, clamp: boolean = true): React.ReactElement {
+  return renderMarkdown(desc, { clamp })
 }


### PR DESCRIPTION
## What
Redesigns Factory Floor agent cards + detail pane so you can tell what an agent is doing at a glance. Closes **RUSH-1530** (markdown broken), **RUSH-1531** (last message not task), **RUSH-1519** (surface progress/worktree).

**Card:** title = task · markdown Task anchor · markdown body · mini progress timeline (last ~4 tool calls, current pulsing) · clean worktree chip (kills `WT=/…/path` leak) · sticky todos.
**Detail:** Task → vertical timeline (replaces flat recent-tools list) → streaming Activity feed (last_messages as markdown, newest last, live verb/target now-indicator) → todos → PR/CI. Cloud keeps CloudActivityFeed.

Mostly reuse (marked+DOMPurify + todos[]/recent[] already existed). New Timeline.tsx. No new deps.

## Verify
- `bun test mission-control/` → 265 pass / 0 fail
- `bun run compile` (tsc host + vite ui) → clean
- Full suite 1158 pass / 2 fail (both pre-existing/unrelated)

## Phase 2 limitation
Remote (`--host`) sessions hardcode `recent:[]`/`todos:[]`; timeline/todos empty until Tier-2 enrichment (RUSH-1512). Local + cloud fully covered.

Mockup: `zion:/tmp/factory-card-redesign.html`