### PR TITLE
chore(release): factory 0.9.288 — readable agent cards

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.9.288] - 2026-07-08
+
+### Added
+
+- **Readable agent cards on the Factory Floor.** Cards now lead with the agent's
+  original **task** (not its last message), render **markdown** in message bodies,
+  add a live **progress timeline** of recent tool calls plus a **streaming activity
+  feed** of the agent's messages, keep the **todo checklist** from silently
+  vanishing, and show a clean **worktree chip** instead of a raw `WT=/…/path`. The
+  detail pane is reordered for legibility: Task → Progress timeline → Todos →
+  Activity → PR/CI.
+
 ### Fixed
 
 - **Shell (`SH`) tabs now load your full interactive shell environment.** Every

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -3,7 +3,7 @@
   "displayName": "Agents",
   "publisher": "swarmify",
   "description": "Run Claude, Codex, Gemini, Cursor, and other coding agents from one IDE workspace.",
-  "version": "0.9.286",
+  "version": "0.9.288",
   "license": "MIT",
   "author": "Muqsit Nawaz <dev@muqsitnawaz.com>",
   "icon": "assets/agents.png",


### PR DESCRIPTION
Version bump + changelog to ship the Floor card redesign (#832) to users.

- `apps/factory/package.json` → 0.9.288
- CHANGELOG `## [0.9.288]` — readable agent cards (markdown, task anchor, progress timeline, streaming activity feed, sticky todos, worktree chip)

Built + installed locally (`swarm-ext-0.9.288.vsix`, vsce 2.32.0 — note vsce 3.9.2 has a secretlint `EISDIR` bug), activated in code + codium; active bundle verified to carry the redesign. After merge: `scripts/release.sh 0.9.288 --confirm` publishes to Marketplace + Open VSX.