### PR TITLE
fix(release): correct stale keychain-helper sha pin

### DIFF
--- a/apps/cli/scripts/Agents CLI.app.sha256
+++ b/apps/cli/scripts/Agents CLI.app.sha256
@@ -1,1 +1,1 @@
-72de64ffbfb733a5d9fc9fb7366e2f433a6082534eb135408c0dcb5d643f6467  bin/Agents CLI.app/Contents/MacOS/Agents CLI
+ea5bfaab1beac560330a23edb18232c29643b9ffa1d077205337ed5ebc0157c6  bin/Agents CLI.app/Contents/MacOS/Agents CLI


### PR DESCRIPTION
The committed `scripts/Agents CLI.app.sha256` pins `72de64ff`, but the keychain helper actually published in `@phnx-labs/agents-cli@1.20.49` (verified by unpacking the npm tarball) **and** the notarized `.app` in `bin/` are both `ea5bfaab`. Both are validly Developer-ID-signed + notarized (`spctl: accepted, source=Notarized Developer ID`) — codesign is non-deterministic, so the last release's rebuild changed the hash and the pin was never updated. `prepack`'s `verify-keychain-helper.sh` gate then blocked every release on the mismatch. This realigns the pin to the already-published, notarized binary so releases proceed. No binary change.