### PR TITLE
fix(factory): 0.9.289 — repackage with node_modules (0.9.288 failed to activate)

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.9.289] - 2026-07-08
+
+### Fixed
+
+- **0.9.288 failed to activate** — it was packaged without `node_modules`, so the
+  extension host threw on `require()` of runtime deps (`ws`, `yaml`, MCP SDK, …) and
+  no commands registered (`command 'agents.configure' not found`). Repackaged with
+  dependencies included. The 0.9.288 card redesign is unchanged; this only restores
+  the shipped dependencies.
+
 ## [0.9.288] - 2026-07-08
 
 ### Added

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -3,7 +3,7 @@
   "displayName": "Agents",
   "publisher": "swarmify",
   "description": "Run Claude, Codex, Gemini, Cursor, and other coding agents from one IDE workspace.",
-  "version": "0.9.288",
+  "version": "0.9.289",
   "license": "MIT",
   "author": "Muqsit Nawaz <dev@muqsitnawaz.com>",
   "icon": "assets/agents.png",


### PR DESCRIPTION
**Hotfix for 0.9.288.** 0.9.288 was packaged with `vsce --no-dependencies`, which stripped `node_modules` from the `.vsix`. The extension host isn't bundled — it `require()`s runtime deps (`ws`, `yaml`, `node-pty`, `sql.js`, MCP SDK) — so `activate()` threw and no commands registered (`command 'agents.configure' not found`).

0.9.289 repackages **with** dependencies. Verified: `.vsix` is 23.4 MB with 566 `node_modules` files incl. `node-pty` prebuilds; installed `require('node-pty')` loads (`spawn` is a function); ws/yaml/sql.js present. The 0.9.288 card redesign is unchanged.

Already published to Marketplace + Open VSX to un-break users; this PR lands the version/changelog bump.