### PR TITLE
fix(cli): detect .cmd-shim host CLIs and silence where.exe noise on Windows

### DIFF
--- a/apps/cli/src/lib/cli-resources.test.ts
+++ b/apps/cli/src/lib/cli-resources.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   parseCliManifest,
   selectInstallMethod,
   describeMethod,
   buildInstallCommand,
+  hasCommand,
+  isCliInstalled,
   type CliManifest,
   type InstallMethod,
 } from './cli-resources.js';
@@ -163,5 +168,53 @@ describe('selectInstallMethod', () => {
     if (picked) {
       expect(picked).toEqual({ npm: 'foo' });
     }
+  });
+});
+
+describe('host detection', () => {
+  it('hasCommand finds node and rejects garbage on every platform', () => {
+    // node is guaranteed: it is running this test.
+    expect(hasCommand('node')).toBe(true);
+    expect(hasCommand('definitely-not-a-real-command-xyz')).toBe(false);
+  });
+
+  it('isCliInstalled is false for a version check on a missing command', () => {
+    const m = manifest([{ npm: 'foo' }]);
+    m.check = { kind: 'version', cmd: 'definitely-not-a-real-command-xyz', args: ['--version'] };
+    expect(isCliInstalled(m)).toBe(false);
+  });
+
+  describe.runIf(process.platform === 'win32')('win32 .cmd shims', () => {
+    // npm installs and script installers put `.cmd`/`.bat` shims on PATH, which
+    // Node cannot spawn without a shell — the version check must still pass.
+    let tmpDir: string | undefined;
+    const savedPath = process.env.Path ?? process.env.PATH;
+
+    afterEach(() => {
+      if (process.env.Path !== undefined) process.env.Path = savedPath;
+      else process.env.PATH = savedPath;
+      if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    });
+
+    it('isCliInstalled passes a version check backed by a .cmd shim', () => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-shim-'));
+      fs.writeFileSync(path.join(tmpDir, 'fake-shim-tool.cmd'), '@exit /b 0\r\n');
+      const key = process.env.Path !== undefined ? 'Path' : 'PATH';
+      process.env[key] = `${tmpDir};${savedPath}`;
+      const m = manifest([{ npm: 'foo' }]);
+      m.check = { kind: 'version', cmd: 'fake-shim-tool', args: ['--version'] };
+      expect(isCliInstalled(m)).toBe(true);
+    });
+
+    it('isCliInstalled stays false when the .cmd shim exits non-zero', () => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-shim-'));
+      fs.writeFileSync(path.join(tmpDir, 'fake-shim-fail.cmd'), '@exit /b 1\r\n');
+      const key = process.env.Path !== undefined ? 'Path' : 'PATH';
+      process.env[key] = `${tmpDir};${savedPath}`;
+      const m = manifest([{ npm: 'foo' }]);
+      m.check = { kind: 'version', cmd: 'fake-shim-fail', args: ['--version'] };
+      expect(isCliInstalled(m)).toBe(false);
+    });
   });
 });

--- a/apps/cli/src/lib/cli-resources.ts
+++ b/apps/cli/src/lib/cli-resources.ts
@@ -21,6 +21,7 @@ import * as path from 'path';
 import { spawnSync } from 'child_process';
 import * as yaml from 'yaml';
 import { listResources, resolveResource } from './resources.js';
+import { composeWin32CommandLine } from './platform/index.js';
 
 // ─── Validation primitives ───────────────────────────────────────────────────
 
@@ -331,18 +332,25 @@ export function resolveCliManifest(name: string, cwd?: string): CliManifest | nu
 
 /**
  * Return true if a command resolves on the current PATH. Uses POSIX `command -v`
- * via spawn argv (no shell); results are cached for the lifetime of the process.
+ * (or `where` on Windows) via spawn argv (no shell); results are cached for the
+ * lifetime of the process.
  */
 const cmdExistsCache = new Map<string, boolean>();
 export function hasCommand(cmd: string): boolean {
   if (cmdExistsCache.has(cmd)) return cmdExistsCache.get(cmd)!;
-  // `command` is a shell builtin on most POSIX shells; invoking `sh -c 'command -v X'`
-  // with X as an *argument* (not interpolated) is the safe path. `cmd` may be passed
-  // by callers that haven't validated it, so we route via argv to neutralize metas.
-  const result = spawnSync('sh', ['-c', 'command -v "$1" >/dev/null 2>&1', '_', cmd], {
-    stdio: 'ignore',
-  });
-  const ok = result.status === 0;
+  let ok: boolean;
+  if (process.platform === 'win32') {
+    // `sh` only exists when Git Bash is installed; `where` is the native PATH
+    // probe (resolves .exe/.cmd/.bat via PATHEXT). Argv keeps `cmd` uninterpolated.
+    ok = spawnSync('where', [cmd], { stdio: 'ignore' }).status === 0;
+  } else {
+    // `command` is a shell builtin on most POSIX shells; invoking `sh -c 'command -v X'`
+    // with X as an *argument* (not interpolated) is the safe path. `cmd` may be passed
+    // by callers that haven't validated it, so we route via argv to neutralize metas.
+    ok = spawnSync('sh', ['-c', 'command -v "$1" >/dev/null 2>&1', '_', cmd], {
+      stdio: 'ignore',
+    }).status === 0;
+  }
   cmdExistsCache.set(cmd, ok);
   return ok;
 }
@@ -358,7 +366,18 @@ export function isCliInstalled(manifest: CliManifest): boolean {
     return hasCommand(c.cmd);
   }
   const result = spawnSync(c.cmd, c.args, { stdio: 'ignore', timeout: 10_000 });
-  return result.status === 0;
+  if (result.status === 0) return true;
+  // On Windows the PATH entry point is often a `.cmd`/`.bat` shim (npm installs,
+  // script installers), which Node refuses to spawn without a shell (ENOENT /
+  // EINVAL). A failed *spawn* — not a failed run — gets one retry through the
+  // shell, as a single pre-composed line (DEP0190-safe). Check tokens are
+  // SAFE_CHECK_TOKEN-validated at parse time, so the line cannot inject.
+  if (process.platform === 'win32' && result.error) {
+    const line = composeWin32CommandLine(c.cmd, c.args);
+    const retry = spawnSync(line, { stdio: 'ignore', timeout: 10_000, shell: true });
+    return retry.status === 0;
+  }
+  return false;
 }
 
 // ─── Method selection ────────────────────────────────────────────────────────

--- a/apps/cli/src/lib/platform/exec.ts
+++ b/apps/cli/src/lib/platform/exec.ts
@@ -29,11 +29,17 @@ export function needsWindowsShell(binary: string, platform: NodeJS.Platform = pr
  * Resolve an executable name to its absolute path via the OS PATH search, or
  * `null` if not found. On Windows `where` can return several lines (one per
  * PATHEXT match, e.g. `agents.cmd` and `agents.ps1`) — the first is the one the
- * shell would actually run, matching `which` semantics on POSIX.
+ * shell would actually run, matching `which` semantics on POSIX. stderr is
+ * dropped: a miss is an expected outcome here, and `where.exe` announces every
+ * miss on stderr ("INFO: Could not find files..."), which would otherwise leak
+ * into the caller's terminal once per probe.
  */
 export function findExecutable(name: string, platform: NodeJS.Platform = process.platform): string | null {
   try {
-    const out = execFileSync(whichCommand(platform), [name], { encoding: 'utf-8' });
+    const out = execFileSync(whichCommand(platform), [name], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
     const first = out.trim().split(/\r?\n/)[0]?.trim();
     return first || null;
   } catch {


### PR DESCRIPTION
## Problem

Running `agents doctor` on a fresh Windows 11 install (agents-cli 1.20.50 from npm):

```
INFO: Could not find files for the given pattern(s).   <- x8, once per missed agent probe
...
Host CLIs
  ready  jq          [system]
  miss   linear-cli  [system]  not installed -- run `agents cli install linear-cli`
```

`linear --version` works fine in PowerShell (`linear-cli 0.9.0`), yet doctor permanently reports it missing.

## Root causes

1. **Version checks can't see `.cmd` shims.** `isCliInstalled` runs `spawnSync(cmd, args)` with no shell (`cli-resources.ts`). Node refuses to spawn `.cmd`/`.bat` files without a shell (ENOENT, hardened after CVE-2024-27980), and on Windows the PATH entry point for npm- and script-installed CLIs is almost always a `.cmd` shim. Reproduced: `spawnSync('linear', ['--version'])` -> `status: null, error: ENOENT` while the same command exits 0 in any shell. jq only passed because it ships a real `.exe`.

2. **`hasCommand` needs Git Bash.** It probed PATH via `sh -c 'command -v ...'` -- `sh` doesn't exist on a Windows box without Git for Windows, so every `which`-kind check (and npm/brew/curl install-method selection) was a false negative there.

3. **`findExecutable` leaks `where.exe` stderr.** `execFileSync` passes child stderr through by default; `where.exe` prints `INFO: Could not find files for the given pattern(s).` on every miss. `checkCliAvailable` probes all 9 supported agents at doctor/view time -> 8 noise lines.

## Fix

- `isCliInstalled`: when the direct spawn fails with a spawn *error* (not a non-zero exit) on win32, retry once through the shell as a single pre-composed line via the existing `composeWin32CommandLine` (DEP0190-safe). Injection-safe by construction: check tokens are `SAFE_CHECK_TOKEN`-validated (`/^[a-zA-Z0-9_./-]+$/`) at parse time.
- `hasCommand`: win32 branch probes with `where` via argv; POSIX branch unchanged.
- `findExecutable`: `stdio: ['ignore', 'pipe', 'ignore']` -- a miss is an expected outcome, not something to print.

## After (same machine)

```
Host CLIs
  ready  jq          [system]
  ready  linear-cli  [system]
```

No INFO lines. `agents view` / `agents cli list` fixed by the same paths.

## Tests

- 2 new win32-only tests (`describe.runIf`): a version check backed by a `.cmd` shim passes; a shim exiting 1 still reports not-installed (the retry doesn't mask genuine failures).
- 2 new platform-neutral tests: `hasCommand('node')` true / garbage false; version check on a missing command false.
- All 79 tests across the touched surfaces pass on Windows 11 (`cli-resources`, `platform/exec`, `teams/agents.cli-detection`, `agents`, `mcp`). The 14 failures the full suite shows on this box (`state.test.ts`, `teams-session-id.test.ts`) reproduce identically on unpatched `origin/main` -- pre-existing Windows-environment failures, untouched by this diff.
- This PR touches `apps/cli/src/lib/platform/**`, so the path-filtered `test-windows` job runs the full suite on `windows-latest`.

Session transcript (local): `C:\Users\AmR_A\.claude\jobs\da9007d1`