### PR TITLE
feat(factory): auto-dispatch delegated Linear tickets (opt-in, N per project)

### DIFF
--- a/apps/cli/src/lib/auto-dispatch-linear.ts
+++ b/apps/cli/src/lib/auto-dispatch-linear.ts
@@ -1,0 +1,133 @@
+/**
+ * Concrete Linear gateway for auto-dispatch.
+ *
+ * Talks to the Linear GraphQL API. The API key is read from the LINEAR_API_KEY
+ * env var, falling back to the macOS keychain generic-password `linear-api-key`
+ * (how the rest of the stack stores it). If no key is resolvable, the gateway is
+ * absent and the daemon skips auto-dispatch entirely.
+ *
+ * "Started" (Doing) and "unstarted" (Todo) are Linear state *types*, so we never
+ * hardcode a team's custom state names. `startIssue` resolves the team's first
+ * started-type state (cached per team) and moves the issue there — the existing
+ * factory webhook turns that transition into a real run.
+ */
+
+import { execFileSync } from 'child_process';
+import type { DelegatedIssue, LinearGateway } from './auto-dispatch.js';
+
+const LINEAR_API = 'https://api.linear.app/graphql';
+
+/** Resolve the Linear API key from env or (on macOS) the keychain. Null if absent. */
+export function resolveLinearApiKey(): string | null {
+  const fromEnv = process.env.LINEAR_API_KEY?.trim();
+  if (fromEnv) return fromEnv;
+  if (process.platform === 'darwin') {
+    try {
+      const out = execFileSync('security', ['find-generic-password', '-s', 'linear-api-key', '-w'], {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      const key = out.trim();
+      if (key) return key;
+    } catch {
+      // not in keychain — fall through
+    }
+  }
+  return null;
+}
+
+async function gql<T>(apiKey: string, query: string, variables: Record<string, unknown>): Promise<T> {
+  const res = await fetch(LINEAR_API, {
+    method: 'POST',
+    headers: { Authorization: apiKey, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) throw new Error(`Linear API HTTP ${res.status}`);
+  const json = (await res.json()) as { data?: T; errors?: Array<{ message: string }> };
+  if (json.errors?.length) throw new Error(`Linear API: ${json.errors.map((e) => e.message).join('; ')}`);
+  if (!json.data) throw new Error('Linear API: empty response');
+  return json.data;
+}
+
+interface IssueNode {
+  id: string;
+  identifier: string;
+  priority: number;
+  delegate?: { name: string } | null;
+  team?: { id: string } | null;
+}
+
+/** Build a real Linear gateway, or null when no API key is configured. */
+export function createLinearGateway(): LinearGateway | null {
+  const apiKey = resolveLinearApiKey();
+  if (!apiKey) return null;
+
+  // Cache the resolved started-state id per team so we don't re-query each dispatch.
+  const startedStateByTeam = new Map<string, string>();
+
+  async function resolveStartedState(teamId: string): Promise<string> {
+    const cached = startedStateByTeam.get(teamId);
+    if (cached) return cached;
+    const data = await gql<{ workflowStates: { nodes: Array<{ id: string; type: string; position: number }> } }>(
+      apiKey!,
+      `query($t:String!){ workflowStates(filter:{ team:{ id:{ eq:$t } }, type:{ eq:"started" } }, first:10){ nodes{ id type position } } }`,
+      { t: teamId },
+    );
+    const nodes = data.workflowStates.nodes.slice().sort((a, b) => a.position - b.position);
+    const state = nodes[0];
+    if (!state) throw new Error(`no started-type workflow state for team ${teamId}`);
+    startedStateByTeam.set(teamId, state.id);
+    return state.id;
+  }
+
+  // team id per issue, captured during fetchDelegatedTodo, so startIssue can resolve state.
+  const teamByIssue = new Map<string, string>();
+
+  return {
+    async countInFlight(linearProjectId: string): Promise<number> {
+      const data = await gql<{ issues: { nodes: Array<{ id: string }> } }>(
+        apiKey!,
+        `query($p:ID!){ issues(filter:{ project:{ id:{ eq:$p } }, state:{ type:{ eq:"started" } }, delegate:{ null:false } }, first:250){ nodes{ id } } }`,
+        { p: linearProjectId },
+      );
+      return data.issues.nodes.length;
+    },
+
+    async fetchDelegatedTodo(linearProjectId: string): Promise<DelegatedIssue[]> {
+      const data = await gql<{ issues: { nodes: IssueNode[] } }>(
+        apiKey!,
+        `query($p:ID!){ issues(filter:{ project:{ id:{ eq:$p } }, state:{ type:{ eq:"unstarted" } }, delegate:{ null:false } }, first:50){ nodes{ id identifier priority delegate{ name } team{ id } } } }`,
+        { p: linearProjectId },
+      );
+      const out: DelegatedIssue[] = [];
+      for (const n of data.issues.nodes) {
+        if (!n.delegate?.name) continue;
+        if (n.team?.id) teamByIssue.set(n.id, n.team.id);
+        out.push({ id: n.id, identifier: n.identifier, priority: n.priority ?? 0, delegateName: n.delegate.name });
+      }
+      return out;
+    },
+
+    async startIssue(issueId: string, delegateName: string): Promise<void> {
+      const teamId = teamByIssue.get(issueId);
+      if (!teamId) throw new Error(`unknown team for issue ${issueId} (fetch it first)`);
+      const stateId = await resolveStartedState(teamId);
+      const data = await gql<{ issueUpdate: { success: boolean } }>(
+        apiKey!,
+        `mutation($id:String!,$s:String!){ issueUpdate(id:$id, input:{ stateId:$s }){ success } }`,
+        { id: issueId, s: stateId },
+      );
+      if (!data.issueUpdate.success) throw new Error(`issueUpdate failed for ${issueId}`);
+      // Leave a trail so the auto-dispatch is visible in the ticket history.
+      try {
+        await gql(
+          apiKey!,
+          `mutation($i:String!,$b:String!){ commentCreate(input:{ issueId:$i, body:$b }){ success } }`,
+          { i: issueId, b: `Auto-dispatched to **${delegateName}** by the factory (moved Todo → Doing).` },
+        );
+      } catch {
+        // comment is best-effort — the state change is what matters
+      }
+    },
+  };
+}

--- a/apps/cli/src/lib/auto-dispatch.test.ts
+++ b/apps/cli/src/lib/auto-dispatch.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import {
+  planAutoDispatch,
+  isEligible,
+  priorityRank,
+  autoDispatchTick,
+  type AutoDispatchProject,
+  type DelegatedIssue,
+  type LinearGateway,
+} from './auto-dispatch.js';
+
+const proj = (over: Partial<AutoDispatchProject> = {}): AutoDispatchProject => ({
+  id: 'p1',
+  name: 'Agents CLI',
+  linearProjectId: 'lin-p1',
+  repoSlug: 'phnx-labs/agents-cli',
+  autoDispatch: true,
+  maxAgents: 3,
+  ...over,
+});
+
+const issue = (id: string, priority = 2, delegate = 'Claude'): DelegatedIssue => ({
+  id,
+  identifier: id,
+  delegateName: delegate,
+  priority,
+});
+
+describe('isEligible — opt-in gating', () => {
+  it('is eligible only with autoDispatch=true, positive cap, and a linearProjectId', () => {
+    expect(isEligible(proj())).toBe(true);
+    expect(isEligible(proj({ autoDispatch: false }))).toBe(false);
+    expect(isEligible(proj({ autoDispatch: undefined }))).toBe(false);
+    expect(isEligible(proj({ maxAgents: 0 }))).toBe(false);
+    expect(isEligible(proj({ maxAgents: undefined }))).toBe(false);
+    expect(isEligible(proj({ linearProjectId: undefined }))).toBe(false);
+  });
+});
+
+describe('priorityRank', () => {
+  it('orders urgent first and none last', () => {
+    expect(priorityRank(1)).toBeLessThan(priorityRank(2));
+    expect(priorityRank(4)).toBeLessThan(priorityRank(0)); // none sorts after low
+  });
+});
+
+describe('planAutoDispatch', () => {
+  it('dispatches nothing for a project that has not opted in', () => {
+    const plan = planAutoDispatch(
+      [proj({ autoDispatch: false })],
+      {},
+      { p1: [issue('RUSH-1'), issue('RUSH-2')] },
+    );
+    expect(plan).toEqual([]);
+  });
+
+  it('respects the cap minus in-flight', () => {
+    const plan = planAutoDispatch(
+      [proj({ maxAgents: 3 })],
+      { p1: 1 }, // one already running → 2 slots
+      { p1: [issue('RUSH-1'), issue('RUSH-2'), issue('RUSH-3'), issue('RUSH-4')] },
+    );
+    expect(plan.map((d) => d.identifier)).toEqual(['RUSH-1', 'RUSH-2']);
+  });
+
+  it('dispatches nothing when already at or over the cap', () => {
+    const plan = planAutoDispatch(
+      [proj({ maxAgents: 2 })],
+      { p1: 2 },
+      { p1: [issue('RUSH-1')] },
+    );
+    expect(plan).toEqual([]);
+  });
+
+  it('takes highest-priority issues first', () => {
+    const plan = planAutoDispatch(
+      [proj({ maxAgents: 2 })],
+      { p1: 0 },
+      { p1: [issue('RUSH-low', 4), issue('RUSH-urgent', 1), issue('RUSH-none', 0), issue('RUSH-high', 2)] },
+    );
+    expect(plan.map((d) => d.identifier)).toEqual(['RUSH-urgent', 'RUSH-high']);
+  });
+
+  it('carries the delegate + repo through to the plan', () => {
+    const plan = planAutoDispatch([proj()], { p1: 0 }, { p1: [issue('RUSH-1', 2, 'Codex')] });
+    expect(plan[0]).toMatchObject({ delegateName: 'Codex', repoSlug: 'phnx-labs/agents-cli', issueId: 'RUSH-1' });
+  });
+});
+
+describe('autoDispatchTick', () => {
+  const gw = (over: Partial<LinearGateway> = {}): LinearGateway => ({
+    countInFlight: async () => 0,
+    fetchDelegatedTodo: async () => [issue('RUSH-1'), issue('RUSH-2')],
+    startIssue: async () => {},
+    ...over,
+  });
+
+  it('no-ops when no project is opted in', async () => {
+    let started = 0;
+    const out = await autoDispatchTick({
+      projects: [proj({ autoDispatch: false })],
+      linear: gw({ startIssue: async () => { started++; } }),
+    });
+    expect(out).toEqual([]);
+    expect(started).toBe(0);
+  });
+
+  it('starts the planned issues and returns them', async () => {
+    const startedIds: string[] = [];
+    const out = await autoDispatchTick({
+      projects: [proj({ maxAgents: 5 })],
+      linear: gw({ startIssue: async (id) => { startedIds.push(id); } }),
+    });
+    expect(out.map((d) => d.identifier)).toEqual(['RUSH-1', 'RUSH-2']);
+    expect(startedIds.length).toBe(2);
+  });
+
+  it('fails closed — a Linear read error dispatches nothing for that project', async () => {
+    let started = 0;
+    const out = await autoDispatchTick({
+      projects: [proj()],
+      linear: gw({
+        countInFlight: async () => { throw new Error('linear down'); },
+        startIssue: async () => { started++; },
+      }),
+    });
+    expect(out).toEqual([]);
+    expect(started).toBe(0);
+  });
+});

--- a/apps/cli/src/lib/auto-dispatch.ts
+++ b/apps/cli/src/lib/auto-dispatch.ts
@@ -1,0 +1,175 @@
+/**
+ * Auto-dispatch — pull side of the factory dispatch loop.
+ *
+ * The run pipeline already exists: a Linear webhook fires when an issue moves to
+ * Doing, and the factory spawns an agent on it. What was missing is the *pull*:
+ * nothing picked up tickets that were delegated to an agent but left in Todo.
+ *
+ * This module polls Linear for issues delegated to an agent in a managed project
+ * and, up to a per-project concurrency cap, moves them Todo -> Doing (which the
+ * existing webhook turns into a real run). It reads the shared factory project
+ * registry at ~/.agents/factory/projects.json — the CLI cannot import the factory
+ * package (no cross-package imports), so it reads the JSON directly.
+ *
+ * OPT-IN: a project auto-dispatches ONLY when it has `autoDispatch: true` AND
+ * `maxAgents > 0`. With no project opted in, the tick is a no-op. There is no
+ * global default-on switch.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { homedir } from 'os';
+
+/** The subset of a managed project this module needs (mirror of the shared JSON). */
+export interface AutoDispatchProject {
+  id: string;
+  name: string;
+  linearProjectId?: string;
+  repoSlug?: string; // "owner/repo" — passed through so the run knows its repo
+  autoDispatch?: boolean; // opt-in; default (undefined) = off
+  maxAgents?: number; // per-project concurrency cap; <=0 or undefined = off
+}
+
+/** A Linear issue that is a candidate for dispatch. */
+export interface DelegatedIssue {
+  id: string;
+  identifier: string;
+  delegateName: string; // e.g. "Claude", "Codex" — the agent to run
+  priority: number; // Linear priority (1=urgent … 4=low, 0=none)
+}
+
+/** One planned dispatch: which issue, to which agent, in which project. */
+export interface PlannedDispatch {
+  projectId: string;
+  repoSlug?: string;
+  issueId: string;
+  identifier: string;
+  delegateName: string;
+}
+
+/** Path to the shared factory project registry (written by the factory UI). */
+export function factoryProjectsPath(): string {
+  return path.join(homedir(), '.agents', 'factory', 'projects.json');
+}
+
+/** Read the project registry, keeping only rows that have opted into auto-dispatch. */
+export function readAutoDispatchProjects(): AutoDispatchProject[] {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(factoryProjectsPath(), 'utf-8'));
+  } catch {
+    return []; // no registry yet, or unreadable — nothing to dispatch
+  }
+  if (!Array.isArray(raw)) return [];
+  const out: AutoDispatchProject[] = [];
+  for (const r of raw) {
+    if (!r || typeof r !== 'object') continue;
+    const o = r as Record<string, unknown>;
+    if (typeof o.id !== 'string' || typeof o.name !== 'string') continue;
+    out.push({
+      id: o.id,
+      name: o.name,
+      linearProjectId: typeof o.linearProjectId === 'string' ? o.linearProjectId : undefined,
+      repoSlug: typeof o.repoSlug === 'string' ? o.repoSlug : undefined,
+      autoDispatch: o.autoDispatch === true,
+      maxAgents: typeof o.maxAgents === 'number' ? o.maxAgents : undefined,
+    });
+  }
+  return out;
+}
+
+/** A project is eligible only when it has explicitly opted in with a positive cap. */
+export function isEligible(p: AutoDispatchProject): boolean {
+  return p.autoDispatch === true && typeof p.maxAgents === 'number' && p.maxAgents > 0 && !!p.linearProjectId;
+}
+
+/**
+ * PURE planner. Given the eligible projects, how many agents are already in flight
+ * per project, and the delegated-Todo issues per project, decide exactly which
+ * issues to dispatch — never exceeding `maxAgents` in-flight for a project.
+ *
+ * Highest Linear priority first (urgent=1 < low=4; 0/none sorts last).
+ */
+export function planAutoDispatch(
+  projects: AutoDispatchProject[],
+  inFlightByProject: Record<string, number>,
+  delegatedTodoByProject: Record<string, DelegatedIssue[]>,
+): PlannedDispatch[] {
+  const plan: PlannedDispatch[] = [];
+  for (const p of projects) {
+    if (!isEligible(p)) continue;
+    const cap = p.maxAgents as number;
+    const inFlight = inFlightByProject[p.id] ?? 0;
+    const slots = cap - inFlight;
+    if (slots <= 0) continue;
+    const candidates = (delegatedTodoByProject[p.id] ?? [])
+      .slice()
+      .sort((a, b) => priorityRank(a.priority) - priorityRank(b.priority));
+    for (const issue of candidates.slice(0, slots)) {
+      plan.push({
+        projectId: p.id,
+        repoSlug: p.repoSlug,
+        issueId: issue.id,
+        identifier: issue.identifier,
+        delegateName: issue.delegateName,
+      });
+    }
+  }
+  return plan;
+}
+
+/** Map Linear priority to a sortable rank (urgent first, none last). */
+export function priorityRank(priority: number): number {
+  // Linear: 1=urgent, 2=high, 3=medium, 4=low, 0=no priority.
+  return priority === 0 ? 5 : priority;
+}
+
+/** Linear I/O surface — injected so the planner + tick are testable without network. */
+export interface LinearGateway {
+  /** Count issues in a "started" (Doing) state whose delegate is set, per project id. */
+  countInFlight(linearProjectId: string): Promise<number>;
+  /** Fetch delegated issues in an "unstarted" (Todo) state for a project. */
+  fetchDelegatedTodo(linearProjectId: string): Promise<DelegatedIssue[]>;
+  /** Move an issue Todo -> Doing (the existing webhook turns this into a run). */
+  startIssue(issueId: string, delegateName: string): Promise<void>;
+}
+
+export interface AutoDispatchDeps {
+  projects: AutoDispatchProject[];
+  linear: LinearGateway;
+  log?: (level: 'INFO' | 'WARN' | 'ERROR', msg: string) => void;
+}
+
+/** One tick: read state per eligible project, plan, and start the planned issues. */
+export async function autoDispatchTick(deps: AutoDispatchDeps): Promise<PlannedDispatch[]> {
+  const log = deps.log ?? (() => {});
+  const eligible = deps.projects.filter(isEligible);
+  if (eligible.length === 0) return []; // opt-in: nothing to do
+
+  const inFlight: Record<string, number> = {};
+  const todo: Record<string, DelegatedIssue[]> = {};
+  for (const p of eligible) {
+    const pid = p.linearProjectId as string;
+    try {
+      inFlight[p.id] = await deps.linear.countInFlight(pid);
+      todo[p.id] = await deps.linear.fetchDelegatedTodo(pid);
+    } catch (err) {
+      log('WARN', `auto-dispatch: failed to read Linear state for '${p.name}': ${(err as Error).message}`);
+      inFlight[p.id] = Number.MAX_SAFE_INTEGER; // fail closed: dispatch nothing for this project
+      todo[p.id] = [];
+    }
+  }
+
+  const plan = planAutoDispatch(eligible, inFlight, todo);
+  const dispatched: PlannedDispatch[] = [];
+  for (const d of plan) {
+    try {
+      await deps.linear.startIssue(d.issueId, d.delegateName);
+      dispatched.push(d);
+      log('INFO', `auto-dispatch: started ${d.identifier} (${d.delegateName}) in ${d.projectId}`);
+    } catch (err) {
+      log('WARN', `auto-dispatch: failed to start ${d.identifier}: ${(err as Error).message}`);
+    }
+  }
+  return dispatched;
+}

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -385,6 +385,37 @@ export async function runDaemon(): Promise<void> {
   const healInterval = setInterval(() => { void runHealCheck(); }, 6 * 60 * 60_000);
   const healKickoff = setTimeout(() => { void runHealCheck(); }, 30_000);
 
+  // Auto-dispatch: for any managed project that has opted in (autoDispatch:true +
+  // maxAgents>0 in ~/.agents/factory/projects.json), pick up Linear tickets that
+  // are delegated to an agent and still in Todo, and move them Todo -> Doing so
+  // the existing factory webhook turns each into a run — capped at maxAgents
+  // concurrent per project. OFF unless a project opts in; a machine with no
+  // opted-in project or no LINEAR_API_KEY is a clean no-op. Overlap-guarded like
+  // the probes above. ~every 3 min.
+  let autoDispatching = false;
+  const runAutoDispatch = async () => {
+    if (autoDispatching) return;
+    autoDispatching = true;
+    try {
+      const { readAutoDispatchProjects, isEligible, autoDispatchTick } = await import('./auto-dispatch.js');
+      const projects = readAutoDispatchProjects();
+      if (!projects.some(isEligible)) return; // opt-in: nothing enabled → skip
+      const { createLinearGateway } = await import('./auto-dispatch-linear.js');
+      const linear = createLinearGateway();
+      if (!linear) return; // no LINEAR_API_KEY configured → skip
+      const dispatched = await autoDispatchTick({ projects, linear, log: (lvl, m) => log(lvl, m) });
+      if (dispatched.length) {
+        log('INFO', `auto-dispatch: started ${dispatched.length} delegated ticket(s): ${dispatched.map((d) => d.identifier).join(', ')}`);
+      }
+    } catch (err) {
+      log('ERROR', `auto-dispatch failed: ${(err as Error).message}`);
+    } finally {
+      autoDispatching = false;
+    }
+  };
+  const autoDispatchInterval = setInterval(() => { void runAutoDispatch(); }, 3 * 60_000);
+  const autoDispatchKickoff = setTimeout(() => { void runAutoDispatch(); }, 45_000);
+
   // Device probe: refresh registered devices' reachability and detect newly
   // appeared tailnet nodes, dropping a sentinel per pending device so the
   // menu-bar helper can surface "NEW DEVICES → Register / Ignore". Refresh mode
@@ -484,6 +515,8 @@ export async function runDaemon(): Promise<void> {
     clearInterval(syncInterval);
     clearInterval(healInterval);
     clearTimeout(healKickoff);
+    clearInterval(autoDispatchInterval);
+    clearTimeout(autoDispatchKickoff);
     clearInterval(deviceProbeInterval);
     clearTimeout(deviceProbeKickoff);
     clearInterval(tmuxReconcileInterval);

--- a/apps/factory/src/core/managedProjects.ts
+++ b/apps/factory/src/core/managedProjects.ts
@@ -22,6 +22,8 @@ export interface ManagedProject {
   repoSlug?: string;                          // "owner/repo"
   linearProjectId?: string;
   linearProjectName?: string;                 // for the Linear pill
+  autoDispatch?: boolean;                     // opt-in: auto-pick delegated Todo tickets (default off)
+  maxAgents?: number;                         // cap on concurrent auto-dispatched agents for this project
   confidence: 'high' | 'medium' | 'low';
   source: 'detected' | 'manual';
 }
@@ -77,6 +79,8 @@ export function sanitizeManagedProjects(raw: unknown): ManagedProject[] {
       repoSlug: typeof o.repoSlug === 'string' ? o.repoSlug : undefined,
       linearProjectId: typeof o.linearProjectId === 'string' ? o.linearProjectId : undefined,
       linearProjectName: typeof o.linearProjectName === 'string' ? o.linearProjectName : undefined,
+      autoDispatch: o.autoDispatch === true,
+      maxAgents: typeof o.maxAgents === 'number' ? o.maxAgents : undefined,
       confidence,
       source,
     });

--- a/apps/factory/ui/settings/components/mission-control/floorModel.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.ts
@@ -248,6 +248,8 @@ export interface ManagedProject {
   repoSlug?: string                // "owner/repo"
   linearProjectId?: string
   linearProjectName?: string       // for the Linear pill
+  autoDispatch?: boolean           // opt-in: factory auto-picks delegated Todo tickets (default off)
+  maxAgents?: number               // cap on concurrent auto-dispatched agents for this project
   confidence: 'high' | 'medium' | 'low'
   source: 'detected' | 'manual'
 }


### PR DESCRIPTION
## What

Adds the missing **pull side** of the factory dispatch loop. The run pipeline already exists — a Linear webhook fires when an issue moves to Doing and the factory spawns an agent on it — but nothing picked up tickets that were **delegated to an agent but left in Todo**. You delegate, and nothing happens.

This adds a daemon tick that, for any managed project you've **opted in**, auto-moves delegated Todo tickets to Doing (which the existing webhook turns into runs), capped at **N agents per project**.

## How

- **`apps/cli/src/lib/auto-dispatch.ts`** — pure `planAutoDispatch()` (unit-tested) + `autoDispatchTick()` with an injected `LinearGateway`. Highest Linear priority first; never exceeds `maxAgents - inFlight`.
- **`apps/cli/src/lib/auto-dispatch-linear.ts`** — concrete GraphQL gateway. Key from `LINEAR_API_KEY` or the macOS keychain. Resolves the team's started state **by type**, never hardcoding a custom state name.
- **`apps/cli/src/lib/daemon.ts`** — opt-in tick (~3 min, overlap-guarded like the existing probes) + shutdown cleanup.
- **`apps/factory`** — adds `autoDispatch?` + `maxAgents?` to `ManagedProject` (and its webview mirror in `floorModel.ts`).

## Opt-in / safety

- **OFF by default.** A project auto-dispatches only with `autoDispatch: true` **and** `maxAgents > 0` in `~/.agents/factory/projects.json`. No opted-in project, or no Linear key → clean no-op. No global default-on.
- **Fails closed** — a Linear read error dispatches nothing for that project.
- **No double-pickup** — moving to Doing drops the ticket from the Todo query; no extra state.

## Companion change

The webhook currently dispatches on an `agent:*` label. A follow-up in `prix/api/src/hooks/linear.ts` (dispatch on the `delegate` field directly) lands separately so the moved-to-Doing ticket routes to its delegated agent without label juggling. Until then, enabling this on a project also needs the `agent:*` label path.

## Tests

`10` planner/tick cases (opt-in gating, cap, in-flight subtraction, priority order, fail-closed) + factory `managedProjects` sanitize — all green. `tsc --noEmit` clean on both packages.