### PR TITLE
refactor(factory): auto-dispatch via the cloud-provider abstraction (decouple from Prix)

### DIFF
--- a/apps/cli/src/lib/auto-dispatch-linear.ts
+++ b/apps/cli/src/lib/auto-dispatch-linear.ts
@@ -52,6 +52,7 @@ async function gql<T>(apiKey: string, query: string, variables: Record<string, u
 interface IssueNode {
   id: string;
   identifier: string;
+  title: string;
   priority: number;
   delegate?: { name: string } | null;
   team?: { id: string } | null;
@@ -96,19 +97,19 @@ export function createLinearGateway(): LinearGateway | null {
     async fetchDelegatedTodo(linearProjectId: string): Promise<DelegatedIssue[]> {
       const data = await gql<{ issues: { nodes: IssueNode[] } }>(
         apiKey!,
-        `query($p:ID!){ issues(filter:{ project:{ id:{ eq:$p } }, state:{ type:{ eq:"unstarted" } }, delegate:{ null:false } }, first:50){ nodes{ id identifier priority delegate{ name } team{ id } } } }`,
+        `query($p:ID!){ issues(filter:{ project:{ id:{ eq:$p } }, state:{ type:{ eq:"unstarted" } }, delegate:{ null:false } }, first:50){ nodes{ id identifier title priority delegate{ name } team{ id } } } }`,
         { p: linearProjectId },
       );
       const out: DelegatedIssue[] = [];
       for (const n of data.issues.nodes) {
         if (!n.delegate?.name) continue;
         if (n.team?.id) teamByIssue.set(n.id, n.team.id);
-        out.push({ id: n.id, identifier: n.identifier, priority: n.priority ?? 0, delegateName: n.delegate.name });
+        out.push({ id: n.id, identifier: n.identifier, title: n.title ?? '', priority: n.priority ?? 0, delegateName: n.delegate.name });
       }
       return out;
     },
 
-    async startIssue(issueId: string, delegateName: string): Promise<void> {
+    async markStarted(issueId: string, delegateName: string): Promise<void> {
       const teamId = teamByIssue.get(issueId);
       if (!teamId) throw new Error(`unknown team for issue ${issueId} (fetch it first)`);
       const stateId = await resolveStartedState(teamId);

--- a/apps/cli/src/lib/auto-dispatch-provider.ts
+++ b/apps/cli/src/lib/auto-dispatch-provider.ts
@@ -1,0 +1,28 @@
+/**
+ * Concrete Dispatcher for auto-dispatch — runs a ticket through agents-cli's own
+ * cloud-provider abstraction (`resolveProvider().dispatch()`), the same layer as
+ * `agents cloud run`. Rush (Prix) is one provider among rush/codex/factory; a
+ * project pins its provider via `provider` in projects.json, else the delegate
+ * agent's native cloud is used. This is what removes the hidden Prix coupling —
+ * auto-dispatch no longer depends on the prix/api webhook.
+ */
+
+import { resolveProvider } from './cloud/registry.js';
+import type { Dispatcher } from './auto-dispatch.js';
+
+export function createProviderDispatcher(): Dispatcher {
+  return {
+    async dispatch({ agent, prompt, repo, provider }) {
+      const p = resolveProvider(provider, agent);
+      const caps = p.capabilities();
+      if (!caps.available) {
+        throw new Error(`cloud provider '${p.id}' is not available (auth/binary missing)`);
+      }
+      if (!caps.dispatch) {
+        throw new Error(`cloud provider '${p.id}' does not support dispatch`);
+      }
+      const task = await p.dispatch({ agent, prompt, repo });
+      return { id: task.id };
+    },
+  };
+}

--- a/apps/cli/src/lib/auto-dispatch.test.ts
+++ b/apps/cli/src/lib/auto-dispatch.test.ts
@@ -3,10 +3,12 @@ import {
   planAutoDispatch,
   isEligible,
   priorityRank,
+  dispatchPrompt,
   autoDispatchTick,
   type AutoDispatchProject,
   type DelegatedIssue,
   type LinearGateway,
+  type Dispatcher,
 } from './auto-dispatch.js';
 
 const proj = (over: Partial<AutoDispatchProject> = {}): AutoDispatchProject => ({
@@ -22,6 +24,7 @@ const proj = (over: Partial<AutoDispatchProject> = {}): AutoDispatchProject => (
 const issue = (id: string, priority = 2, delegate = 'Claude'): DelegatedIssue => ({
   id,
   identifier: id,
+  title: `${id} title`,
   delegateName: delegate,
   priority,
 });
@@ -40,35 +43,27 @@ describe('isEligible — opt-in gating', () => {
 describe('priorityRank', () => {
   it('orders urgent first and none last', () => {
     expect(priorityRank(1)).toBeLessThan(priorityRank(2));
-    expect(priorityRank(4)).toBeLessThan(priorityRank(0)); // none sorts after low
+    expect(priorityRank(4)).toBeLessThan(priorityRank(0));
   });
 });
 
 describe('planAutoDispatch', () => {
   it('dispatches nothing for a project that has not opted in', () => {
-    const plan = planAutoDispatch(
-      [proj({ autoDispatch: false })],
-      {},
-      { p1: [issue('RUSH-1'), issue('RUSH-2')] },
-    );
+    const plan = planAutoDispatch([proj({ autoDispatch: false })], {}, { p1: [issue('RUSH-1')] });
     expect(plan).toEqual([]);
   });
 
   it('respects the cap minus in-flight', () => {
     const plan = planAutoDispatch(
       [proj({ maxAgents: 3 })],
-      { p1: 1 }, // one already running → 2 slots
+      { p1: 1 },
       { p1: [issue('RUSH-1'), issue('RUSH-2'), issue('RUSH-3'), issue('RUSH-4')] },
     );
     expect(plan.map((d) => d.identifier)).toEqual(['RUSH-1', 'RUSH-2']);
   });
 
   it('dispatches nothing when already at or over the cap', () => {
-    const plan = planAutoDispatch(
-      [proj({ maxAgents: 2 })],
-      { p1: 2 },
-      { p1: [issue('RUSH-1')] },
-    );
+    const plan = planAutoDispatch([proj({ maxAgents: 2 })], { p1: 2 }, { p1: [issue('RUSH-1')] });
     expect(plan).toEqual([]);
   });
 
@@ -81,9 +76,22 @@ describe('planAutoDispatch', () => {
     expect(plan.map((d) => d.identifier)).toEqual(['RUSH-urgent', 'RUSH-high']);
   });
 
-  it('carries the delegate + repo through to the plan', () => {
-    const plan = planAutoDispatch([proj()], { p1: 0 }, { p1: [issue('RUSH-1', 2, 'Codex')] });
-    expect(plan[0]).toMatchObject({ delegateName: 'Codex', repoSlug: 'phnx-labs/agents-cli', issueId: 'RUSH-1' });
+  it('carries delegate + repo + provider + title through to the plan', () => {
+    const plan = planAutoDispatch([proj({ provider: 'codex' })], { p1: 0 }, { p1: [issue('RUSH-1', 2, 'Codex')] });
+    expect(plan[0]).toMatchObject({
+      delegateName: 'Codex',
+      repoSlug: 'phnx-labs/agents-cli',
+      provider: 'codex',
+      issueId: 'RUSH-1',
+      title: 'RUSH-1 title',
+    });
+  });
+});
+
+describe('dispatchPrompt', () => {
+  it('names the ticket + title', () => {
+    expect(dispatchPrompt('RUSH-1', 'Fix login')).toContain('RUSH-1');
+    expect(dispatchPrompt('RUSH-1', 'Fix login')).toContain('Fix login');
   });
 });
 
@@ -91,40 +99,66 @@ describe('autoDispatchTick', () => {
   const gw = (over: Partial<LinearGateway> = {}): LinearGateway => ({
     countInFlight: async () => 0,
     fetchDelegatedTodo: async () => [issue('RUSH-1'), issue('RUSH-2')],
-    startIssue: async () => {},
+    markStarted: async () => {},
+    ...over,
+  });
+  const disp = (over: Partial<Dispatcher> = {}): Dispatcher => ({
+    dispatch: async () => ({ id: 'task-x' }),
     ...over,
   });
 
   it('no-ops when no project is opted in', async () => {
-    let started = 0;
+    let dispatched = 0;
     const out = await autoDispatchTick({
       projects: [proj({ autoDispatch: false })],
-      linear: gw({ startIssue: async () => { started++; } }),
+      linear: gw(),
+      dispatcher: disp({ dispatch: async () => { dispatched++; return { id: 'x' }; } }),
     });
     expect(out).toEqual([]);
-    expect(started).toBe(0);
+    expect(dispatched).toBe(0);
   });
 
-  it('starts the planned issues and returns them', async () => {
-    const startedIds: string[] = [];
+  it('dispatches via the provider, then marks the ticket started', async () => {
+    const dispatchedAgents: string[] = [];
+    const marked: string[] = [];
     const out = await autoDispatchTick({
       projects: [proj({ maxAgents: 5 })],
-      linear: gw({ startIssue: async (id) => { startedIds.push(id); } }),
+      linear: gw({ markStarted: async (id) => { marked.push(id); } }),
+      dispatcher: disp({ dispatch: async ({ agent }) => { dispatchedAgents.push(agent); return { id: 't' }; } }),
     });
     expect(out.map((d) => d.identifier)).toEqual(['RUSH-1', 'RUSH-2']);
-    expect(startedIds.length).toBe(2);
+    expect(dispatchedAgents).toEqual(['claude', 'claude']); // delegate lower-cased
+    expect(marked).toEqual(['RUSH-1', 'RUSH-2']);
+  });
+
+  it('does NOT mark started if the dispatch itself fails', async () => {
+    let marked = 0;
+    const out = await autoDispatchTick({
+      projects: [proj({ maxAgents: 5 })],
+      linear: gw({ markStarted: async () => { marked++; } }),
+      dispatcher: disp({ dispatch: async () => { throw new Error('provider down'); } }),
+    });
+    expect(out).toEqual([]);
+    expect(marked).toBe(0);
+  });
+
+  it('still counts as dispatched if only the mark-started bookkeeping fails', async () => {
+    const out = await autoDispatchTick({
+      projects: [proj({ maxAgents: 5 })],
+      linear: gw({ markStarted: async () => { throw new Error('linear hiccup'); } }),
+      dispatcher: disp(),
+    });
+    expect(out.map((d) => d.identifier)).toEqual(['RUSH-1', 'RUSH-2']);
   });
 
   it('fails closed — a Linear read error dispatches nothing for that project', async () => {
-    let started = 0;
+    let dispatched = 0;
     const out = await autoDispatchTick({
       projects: [proj()],
-      linear: gw({
-        countInFlight: async () => { throw new Error('linear down'); },
-        startIssue: async () => { started++; },
-      }),
+      linear: gw({ countInFlight: async () => { throw new Error('linear down'); } }),
+      dispatcher: disp({ dispatch: async () => { dispatched++; return { id: 'x' }; } }),
     });
     expect(out).toEqual([]);
-    expect(started).toBe(0);
+    expect(dispatched).toBe(0);
   });
 });

--- a/apps/cli/src/lib/auto-dispatch.ts
+++ b/apps/cli/src/lib/auto-dispatch.ts
@@ -1,19 +1,17 @@
 /**
  * Auto-dispatch — pull side of the factory dispatch loop.
  *
- * The run pipeline already exists: a Linear webhook fires when an issue moves to
- * Doing, and the factory spawns an agent on it. What was missing is the *pull*:
- * nothing picked up tickets that were delegated to an agent but left in Todo.
+ * Polls Linear for issues that are delegated to an agent and still in Todo for a
+ * managed project, and — up to a per-project concurrency cap — DISPATCHES each
+ * through agents-cli's own cloud-provider abstraction (`resolveProvider().dispatch()`),
+ * then marks the ticket Doing so it isn't picked up twice.
  *
- * This module polls Linear for issues delegated to an agent in a managed project
- * and, up to a per-project concurrency cap, moves them Todo -> Doing (which the
- * existing webhook turns into a real run). It reads the shared factory project
- * registry at ~/.agents/factory/projects.json — the CLI cannot import the factory
- * package (no cross-package imports), so it reads the JSON directly.
+ * The dispatch goes through the same provider layer as `agents cloud run`, so Rush
+ * (Prix) is just one provider among rush/codex/factory — NOT a hidden requirement.
+ * A project may pin its provider via `provider` in ~/.agents/factory/projects.json.
  *
- * OPT-IN: a project auto-dispatches ONLY when it has `autoDispatch: true` AND
- * `maxAgents > 0`. With no project opted in, the tick is a no-op. There is no
- * global default-on switch.
+ * OPT-IN: a project auto-dispatches ONLY when `autoDispatch: true` AND `maxAgents > 0`.
+ * Nothing global is on by default.
  */
 
 import * as fs from 'fs';
@@ -25,15 +23,17 @@ export interface AutoDispatchProject {
   id: string;
   name: string;
   linearProjectId?: string;
-  repoSlug?: string; // "owner/repo" — passed through so the run knows its repo
+  repoSlug?: string; // "owner/repo" — the dispatch's target repo
   autoDispatch?: boolean; // opt-in; default (undefined) = off
   maxAgents?: number; // per-project concurrency cap; <=0 or undefined = off
+  provider?: string; // optional pin: 'rush' | 'codex' | 'factory' | ... (else the agent's native cloud)
 }
 
 /** A Linear issue that is a candidate for dispatch. */
 export interface DelegatedIssue {
   id: string;
   identifier: string;
+  title: string;
   delegateName: string; // e.g. "Claude", "Codex" — the agent to run
   priority: number; // Linear priority (1=urgent … 4=low, 0=none)
 }
@@ -42,8 +42,10 @@ export interface DelegatedIssue {
 export interface PlannedDispatch {
   projectId: string;
   repoSlug?: string;
+  provider?: string;
   issueId: string;
   identifier: string;
+  title: string;
   delegateName: string;
 }
 
@@ -52,13 +54,13 @@ export function factoryProjectsPath(): string {
   return path.join(homedir(), '.agents', 'factory', 'projects.json');
 }
 
-/** Read the project registry, keeping only rows that have opted into auto-dispatch. */
+/** Read the project registry rows this module cares about. */
 export function readAutoDispatchProjects(): AutoDispatchProject[] {
   let raw: unknown;
   try {
     raw = JSON.parse(fs.readFileSync(factoryProjectsPath(), 'utf-8'));
   } catch {
-    return []; // no registry yet, or unreadable — nothing to dispatch
+    return [];
   }
   if (!Array.isArray(raw)) return [];
   const out: AutoDispatchProject[] = [];
@@ -73,6 +75,7 @@ export function readAutoDispatchProjects(): AutoDispatchProject[] {
       repoSlug: typeof o.repoSlug === 'string' ? o.repoSlug : undefined,
       autoDispatch: o.autoDispatch === true,
       maxAgents: typeof o.maxAgents === 'number' ? o.maxAgents : undefined,
+      provider: typeof o.provider === 'string' ? o.provider : undefined,
     });
   }
   return out;
@@ -84,11 +87,9 @@ export function isEligible(p: AutoDispatchProject): boolean {
 }
 
 /**
- * PURE planner. Given the eligible projects, how many agents are already in flight
- * per project, and the delegated-Todo issues per project, decide exactly which
- * issues to dispatch — never exceeding `maxAgents` in-flight for a project.
- *
- * Highest Linear priority first (urgent=1 < low=4; 0/none sorts last).
+ * PURE planner. Given eligible projects, in-flight counts, and delegated-Todo
+ * issues per project, decide which issues to dispatch — never exceeding
+ * `maxAgents` in-flight. Highest Linear priority first.
  */
 export function planAutoDispatch(
   projects: AutoDispatchProject[],
@@ -99,8 +100,7 @@ export function planAutoDispatch(
   for (const p of projects) {
     if (!isEligible(p)) continue;
     const cap = p.maxAgents as number;
-    const inFlight = inFlightByProject[p.id] ?? 0;
-    const slots = cap - inFlight;
+    const slots = cap - (inFlightByProject[p.id] ?? 0);
     if (slots <= 0) continue;
     const candidates = (delegatedTodoByProject[p.id] ?? [])
       .slice()
@@ -109,8 +109,10 @@ export function planAutoDispatch(
       plan.push({
         projectId: p.id,
         repoSlug: p.repoSlug,
+        provider: p.provider,
         issueId: issue.id,
         identifier: issue.identifier,
+        title: issue.title,
         delegateName: issue.delegateName,
       });
     }
@@ -120,31 +122,41 @@ export function planAutoDispatch(
 
 /** Map Linear priority to a sortable rank (urgent first, none last). */
 export function priorityRank(priority: number): number {
-  // Linear: 1=urgent, 2=high, 3=medium, 4=low, 0=no priority.
   return priority === 0 ? 5 : priority;
 }
 
-/** Linear I/O surface — injected so the planner + tick are testable without network. */
+/** Build the prompt an auto-dispatched agent receives for a ticket. */
+export function dispatchPrompt(identifier: string, title: string): string {
+  return `Work on Linear ticket ${identifier}: ${title}. Read the ticket for full context, implement it, and open a PR when done.`;
+}
+
+/** Linear I/O surface — discovery + bookkeeping (NOT the dispatch trigger). */
 export interface LinearGateway {
-  /** Count issues in a "started" (Doing) state whose delegate is set, per project id. */
+  /** Count issues in a started ("Doing") state whose delegate is set, per project. */
   countInFlight(linearProjectId: string): Promise<number>;
-  /** Fetch delegated issues in an "unstarted" (Todo) state for a project. */
+  /** Fetch delegated issues in an unstarted ("Todo") state for a project. */
   fetchDelegatedTodo(linearProjectId: string): Promise<DelegatedIssue[]>;
-  /** Move an issue Todo -> Doing (the existing webhook turns this into a run). */
-  startIssue(issueId: string, delegateName: string): Promise<void>;
+  /** After a successful dispatch: move the issue Todo -> Doing so it isn't re-picked. */
+  markStarted(issueId: string, delegateName: string): Promise<void>;
+}
+
+/** Dispatch surface — runs a ticket through agents-cli's cloud/local provider layer. */
+export interface Dispatcher {
+  dispatch(opts: { agent: string; prompt: string; repo?: string; provider?: string }): Promise<{ id: string }>;
 }
 
 export interface AutoDispatchDeps {
   projects: AutoDispatchProject[];
   linear: LinearGateway;
+  dispatcher: Dispatcher;
   log?: (level: 'INFO' | 'WARN' | 'ERROR', msg: string) => void;
 }
 
-/** One tick: read state per eligible project, plan, and start the planned issues. */
+/** One tick: read state per eligible project, plan, dispatch, then mark started. */
 export async function autoDispatchTick(deps: AutoDispatchDeps): Promise<PlannedDispatch[]> {
   const log = deps.log ?? (() => {});
   const eligible = deps.projects.filter(isEligible);
-  if (eligible.length === 0) return []; // opt-in: nothing to do
+  if (eligible.length === 0) return [];
 
   const inFlight: Record<string, number> = {};
   const todo: Record<string, DelegatedIssue[]> = {};
@@ -155,7 +167,7 @@ export async function autoDispatchTick(deps: AutoDispatchDeps): Promise<PlannedD
       todo[p.id] = await deps.linear.fetchDelegatedTodo(pid);
     } catch (err) {
       log('WARN', `auto-dispatch: failed to read Linear state for '${p.name}': ${(err as Error).message}`);
-      inFlight[p.id] = Number.MAX_SAFE_INTEGER; // fail closed: dispatch nothing for this project
+      inFlight[p.id] = Number.MAX_SAFE_INTEGER; // fail closed for this project
       todo[p.id] = [];
     }
   }
@@ -164,11 +176,23 @@ export async function autoDispatchTick(deps: AutoDispatchDeps): Promise<PlannedD
   const dispatched: PlannedDispatch[] = [];
   for (const d of plan) {
     try {
-      await deps.linear.startIssue(d.issueId, d.delegateName);
+      const task = await deps.dispatcher.dispatch({
+        agent: d.delegateName.trim().toLowerCase(),
+        prompt: dispatchPrompt(d.identifier, d.title),
+        repo: d.repoSlug,
+        provider: d.provider,
+      });
+      // Bookkeeping only — dispatch already happened; moving to Doing keeps the
+      // ticket out of the next Todo poll. A failure here is non-fatal.
+      try {
+        await deps.linear.markStarted(d.issueId, d.delegateName);
+      } catch (err) {
+        log('WARN', `auto-dispatch: dispatched ${d.identifier} but failed to mark Doing: ${(err as Error).message}`);
+      }
       dispatched.push(d);
-      log('INFO', `auto-dispatch: started ${d.identifier} (${d.delegateName}) in ${d.projectId}`);
+      log('INFO', `auto-dispatch: dispatched ${d.identifier} to ${d.delegateName} (task ${task.id})`);
     } catch (err) {
-      log('WARN', `auto-dispatch: failed to start ${d.identifier}: ${(err as Error).message}`);
+      log('WARN', `auto-dispatch: failed to dispatch ${d.identifier}: ${(err as Error).message}`);
     }
   }
   return dispatched;

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -387,11 +387,13 @@ export async function runDaemon(): Promise<void> {
 
   // Auto-dispatch: for any managed project that has opted in (autoDispatch:true +
   // maxAgents>0 in ~/.agents/factory/projects.json), pick up Linear tickets that
-  // are delegated to an agent and still in Todo, and move them Todo -> Doing so
-  // the existing factory webhook turns each into a run — capped at maxAgents
-  // concurrent per project. OFF unless a project opts in; a machine with no
-  // opted-in project or no LINEAR_API_KEY is a clean no-op. Overlap-guarded like
-  // the probes above. ~every 3 min.
+  // are delegated to an agent and still in Todo, and DISPATCH each through
+  // agents-cli's own cloud-provider layer (resolveProvider().dispatch(), same as
+  // `agents cloud run`) — then mark it Doing so it isn't re-picked. Capped at
+  // maxAgents concurrent per project. No hidden Prix dependency: Rush is one
+  // provider among rush/codex/factory, pinned per-project via `provider`. OFF
+  // unless a project opts in; no opted-in project or no LINEAR_API_KEY is a clean
+  // no-op. Overlap-guarded like the probes above. ~every 3 min.
   let autoDispatching = false;
   const runAutoDispatch = async () => {
     if (autoDispatching) return;
@@ -403,7 +405,9 @@ export async function runDaemon(): Promise<void> {
       const { createLinearGateway } = await import('./auto-dispatch-linear.js');
       const linear = createLinearGateway();
       if (!linear) return; // no LINEAR_API_KEY configured → skip
-      const dispatched = await autoDispatchTick({ projects, linear, log: (lvl, m) => log(lvl, m) });
+      const { createProviderDispatcher } = await import('./auto-dispatch-provider.js');
+      const dispatcher = createProviderDispatcher();
+      const dispatched = await autoDispatchTick({ projects, linear, dispatcher, log: (lvl, m) => log(lvl, m) });
       if (dispatched.length) {
         log('INFO', `auto-dispatch: started ${dispatched.length} delegated ticket(s): ${dispatched.map((d) => d.identifier).join(', ')}`);
       }


### PR DESCRIPTION
## Why

Follow-up to #841. That poller moved a delegated ticket Todo→Doing and relied on **prix/api's Linear webhook → Factory Floor** to turn it into a run — a **hidden dependency on proprietary Prix** baked into the OSS CLI core. An `agents-cli` user with a Linear key but no Prix would get tickets silently moved and **nothing would run**.

## What

The poller now **dispatches through agents-cli's own provider abstraction** — `resolveProvider(provider, agent).dispatch()` (`cloud/registry.ts` + `cloud/types.ts`), the same layer as `agents cloud run`. Moving the ticket to Doing is now just **bookkeeping** (so it isn't re-picked), not the trigger.

- **Rush (Prix) is one provider among `rush | codex | factory`** — no longer hidden or required.
- A project **pins its provider** via `provider` in `~/.agents/factory/projects.json`; otherwise the delegate agent's native cloud is used.
- The `prix/api` webhook change (#796) is **no longer needed for auto-dispatch** (it stays for the manual move-to-Doing flow).

## Changes

- `auto-dispatch.ts` — new `Dispatcher` seam; `autoDispatchTick` dispatches **then** marks started; a dispatch failure **skips** the mark (retried next tick); a mark failure is **non-fatal**. Planner/config/opt-in unchanged (+ `provider`, + issue `title`).
- `auto-dispatch-provider.ts` (new) — `createProviderDispatcher()` via `resolveProvider`, gated on `capabilities().available/dispatch`.
- `auto-dispatch-linear.ts` — `startIssue` → `markStarted` (bookkeeping); fetch `title`.
- `daemon.ts` — wire the dispatcher; comment corrected.

## Follow-up

`provider: 'local'` → `AgentManager.spawn` (`teams/agents.ts:1630`) for a **fully cloud-free** run — the truly OSS-pure path. Noted for a next PR.

## Tests

13 cases (dispatch-then-mark, dispatch-fail skips mark, mark-fail non-fatal, opt-in gating, cap, priority, fail-closed) — all green. `tsc --noEmit` clean.