### PR TITLE
fix(factory): 0.9.291 — stop the doubled "Thinking…" on idle needs-you cards

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.9.291] - 2026-07-09
+
+### Fixed
+
+- **NEEDS-YOU cards no longer show a doubled, contextless "Thinking…".** A paused/idle
+  card rendered the live-activity fallback string `"Thinking..."` twice — once as the card
+  body and again as the green now-line — because `resp` fell back to the live-activity
+  string when the agent had no last message. `resp` is now strictly the agent's last real
+  message (empty when there is none), and the now-line renders only while an agent is
+  actively working (`running`/`stalled`), so a paused card that's waiting on you shows just
+  its task, progress timeline, and reply box.
+
 ### Added
 
 - **The NEEDS-YOU detail panel now shows why an agent is blocked, the task, and the real

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -3,7 +3,7 @@
   "displayName": "Agents",
   "publisher": "swarmify",
   "description": "Run Claude, Codex, Gemini, Cursor, and other coding agents from one IDE workspace.",
-  "version": "0.9.290",
+  "version": "0.9.291",
   "license": "MIT",
   "author": "Muqsit Nawaz <dev@muqsitnawaz.com>",
   "icon": "assets/agents.png",
@@ -580,7 +580,7 @@
             "Never use tmux; always use a native VS Code editor terminal."
           ],
           "default": "auto",
-          "description": "How agent terminals are launched. 'auto' (default) runs agents inside a tmux session on macOS/Linux for uniform addressing, resume, and tracking — falling back to a native terminal on Windows or when tmux is missing. Cmd+Shift+H/V create tmux panes instead of VS Code editor splits when tmux is active."
+          "description": "How agent terminals are launched. 'auto' (default) runs agents inside a tmux session on macOS/Linux for uniform addressing, resume, and tracking \u2014 falling back to a native terminal on Windows or when tmux is missing. Cmd+Shift+H/V create tmux panes instead of VS Code editor splits when tmux is active."
         },
         "agents.worktreePerTerminal": {
           "type": "boolean",
@@ -600,7 +600,7 @@
         "agents.openaiApiKey": {
           "type": "string",
           "default": "",
-          "description": "OpenAI API key. Used by the Foreman voice coordinator (gpt-realtime-2). Autogit no longer uses this — commit messages are generated via `agents run claude --model haiku`."
+          "description": "OpenAI API key. Used by the Foreman voice coordinator (gpt-realtime-2). Autogit no longer uses this \u2014 commit messages are generated via `agents run claude --model haiku`."
         },
         "agents.commitGenTimeoutMs": {
           "type": "number",

--- a/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
@@ -105,7 +105,12 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
   const showSummary =
     !plain && !!taskLine && taskLine !== a.resp.trim() && taskLine !== nowlineText &&
     !(showTask && taskLine === prompt)
-  const showNowline = !plain && !!a.verb && !(showSummary && taskLine === nowlineText)
+  // The now-line is a LIVE-activity indicator — only meaningful while the agent is
+  // actively working (running) or stuck mid-action (stalled). For an idle / needs-you /
+  // done agent there's no live activity, and the verb is just the "Thinking..." fallback,
+  // so showing it reads as a contextless "Thinking..." on a paused card.
+  const isActive = a.phase === 'running' || a.phase === 'stalled'
+  const showNowline = !plain && isActive && !!a.verb && !(showSummary && taskLine === nowlineText)
 
   const marker =
     a.pr ? (

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
@@ -122,12 +122,24 @@ describe('toFloorAgentFromUnified', () => {
       }),
       { pinned: new Set(), workspaceRepo: 'swarmify', nowMs: NOW },
     )
-    // no agent.last_messages, so resp falls back to activity 'idle' -> not a question,
-    // but phase is waiting from the flag; needs is still true.
+    // no agent.last_messages, so resp is empty (the now-line, not the body, carries the
+    // live activity); phase is waiting from the flag; needs is still true.
     expect(a.phase).toBe('waiting')
     expect(a.needs).toBe(true)
     expect(a.host).toBe('this-mac')
     expect(a.abbr).toBe('CC')
+  })
+
+  test('resp is empty (not the live-activity placeholder) when there is no last message', () => {
+    // Regression: resp used to fall back to u.activity, so a placeholder now-line
+    // ("Thinking...") rendered twice — once as the card body, once as the verb nowline.
+    const a = toFloorAgentFromUnified(
+      baseUnified({ activity: 'Thinking...', status: 'idle', active: false, agent: null }),
+      { pinned: new Set(), workspaceRepo: null, nowMs: NOW },
+    )
+    expect(a.resp).toBe('')
+    // The activity still reaches the card via the verb/target now-line, not the body.
+    expect(a.verb).toBe('Thinking...')
   })
 
   test('local agent keeps host this-mac (routing) but takes hostLabel from localHostName (display)', () => {

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
@@ -305,7 +305,11 @@ export function toFloorAgentFromUnified(
   // The full recent-messages window (up to the CLI's last N) drives the detail Activity
   // feed; the single last one still feeds `resp` (card body / question parsing).
   const messages = (lastMsgs ?? []).filter((m) => typeof m === 'string' && m.trim().length > 0)
-  const resp = (messages.length ? messages[messages.length - 1] ?? '' : '') || u.activity || ''
+  // `resp` is the agent's last real MESSAGE, never the live now-line. Falling back to
+  // `u.activity` here duplicated it: the now-line placeholder ("Thinking...") rendered
+  // once as the card body AND again as the `verb` nowline. The nowline (verb/target,
+  // below) is the sole live-activity surface; the body stays empty when there's no message.
+  const resp = messages.length ? messages[messages.length - 1] ?? '' : ''
   // Original task anchor: a terminal session's first user message, else a headless run's
   // dispatch prompt. Distinct from `resp` (the last message), which drifts as work goes.
   const prompt = firstNonEmptyStr(u.terminal?.firstUserMessage, u.agent?.prompt)

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -100,6 +100,19 @@ const askAgent = agent({
   resp: 'Drop the legacy policy_v1 table, or keep it for rollback?',
   question: dropQuestion, since: '1m',
 })
+// NEEDS YOU — an idle/paused session whose last turn was a thinking block. Its verb is
+// the "Thinking..." live-activity placeholder, but the card must NOT render it (once was
+// shown twice: as the body AND the now-line). Expect: task + timeline + reply, no "Thinking...".
+const idleThinkingAgent = agent({
+  id: 'a-idle', abbr: 'CC', name: 'agents-cli-readiness', project: 'agents-cli', phase: 'waiting',
+  needs: true, verb: 'Thinking...', target: '', resp: '', since: '22h',
+  sessionId: '659a7ec6-2c1a-4f9e-b2d1-7a3c9e10ab55',
+  prompt: 'Is our agents-cli, our skills and factory tooling good enough — like remote agent execution — such that I can dispatch 100 tasks from Linear and the results will be **somewhat good**?',
+  recent: [
+    { name: 'Bash', input: { command: 'cd /Users/muqsit/src/github.com/muqsitnawaz/agents-cli' }, timestamp: new Date(Date.now() - 86_400_000).toISOString() },
+    { name: 'Read', input: { file_path: '/Users/muqsit/CleanShot 2026-07-08 at 16.07.46@2x.png' }, timestamp: new Date(Date.now() - 86_460_000).toISOString() },
+  ],
+})
 
 // RUNNING lane.
 const running: FloorAgent[] = [
@@ -230,9 +243,10 @@ function Feed() {
       />
 
       <div className="feed-sec attn">
-        <Icon name="alert" size={11} /> NEEDS YOU · 4
+        <Icon name="alert" size={11} /> NEEDS YOU · 5
         <span className="ln" />
       </div>
+      <FeedItem agent={idleThinkingAgent} selected={false} plain={false} onSelect={noop} onOption={noop} onFreeText={noop} onAttach={noop} />
       <FeedItem agent={twinA} selected={false} plain={false} onSelect={noop} onOption={noop} onFreeText={noop} onAttach={noop} />
       <FeedItem agent={twinB} selected={false} plain={false} onSelect={noop} onOption={noop} onFreeText={noop} onAttach={noop} />
       <FeedItem agent={askAgent} selected={false} plain={false} onSelect={noop} onOption={noop} onFreeText={noop} onAttach={noop} />


### PR DESCRIPTION
## The bug (user-reported on 0.9.290)

A paused / needs-you card rendered the live-activity fallback string **`"Thinking..."` twice** — once as the gray card body, once as the green now-line — with no real content. For an idle agent that's *waiting on you*, "Thinking…" is also just wrong.

Root cause: one placeholder, two render paths.
- `resp = messages[last] || u.activity` — when there's no last message, `resp` fell back to `u.activity` (the now-line string, e.g. `"Thinking..."`).
- `verb = splitActivity(u.activity)` — the now-line derives from the *same* `u.activity`.

## Fix

- **`floorAdapter`**: `resp` is now strictly the agent's last real message (`''` when none) — never the live now-line string. The now-line (verb/target) is the sole live-activity surface, so it's no longer duplicated as the body.
- **`FeedItem`**: the now-line renders only while an agent is actively working (`running`/`stalled`). An idle/waiting/done card has no live activity, so a paused card shows just its task, progress timeline, and reply box.

## Verification

Reproduced the exact reported card in the preview harness (`?view=feed`, new `idleThinkingAgent` fixture: waiting/needs-you, `verb: 'Thinking...'`, no message) — the card now shows **task + timeline + reply and no "Thinking…"**:

`zion:/private/tmp/claude-501/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/659a7ec6-26a9-4cb4-b545-6afe884dc95e/scratchpad/v291-idle-card-fixed.png`

- Regression test added: `resp` is `''` (not the placeholder) when there's no last message.
- 136 mission-control tests pass; tsc + vite build clean.
- Two failing suites locally (`agentModels` SessionWatcher/resolveAlias, `prompts` fs) are pre-existing environment/E2E tests unrelated to this change — CI runs them on the proper sandbox.

Session transcript (this host): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/c22eeffd-e73a-4ef3-8cae-9758b7953505.jsonl`