### PR TITLE
docs(cli): correct .migrated sentinel ownership; verify the rest of #754 is not drift

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -45,10 +45,13 @@ elsewhere; route through `supports()`.
 
 ### 4. No fallback logic for legacy layouts
 
-[`src/lib/migrate.ts`](src/lib/migrate.ts) folds legacy paths ONCE at install time
-(`runMigration()` writes a `.migrated` sentinel). Downstream code assumes the
-post-fold layout. "Just-in-case" branches re-introduce drift bugs; the migrator is
-the single source of truth for legacy handling.
+[`src/lib/migrate.ts`](src/lib/migrate.ts) folds legacy paths ONCE at install time.
+The bootstrap gate that invokes `runMigration()` then writes the `.migrated` sentinel
+(`MIGRATED_SENTINEL_FILE`, [`src/lib/state.ts`](src/lib/state.ts)), keyed to the
+migration SCHEMA version, so the scan short-circuits next run — `runMigration()` itself
+only relocates a legacy sentinel via `moveFileOnce`, never writes one. Downstream code
+assumes the post-fold layout. "Just-in-case" branches re-introduce drift bugs; the
+migrator is the single source of truth for legacy handling.
 
 ### 5. Hooks live in a single layered `hooks.yaml`
 


### PR DESCRIPTION
Closes #754.

Docs-only. No code changed, so no CHANGELOG entry (repo convention: CHANGELOG tracks user-visible CLI/extension behavior, not doc wording).

## What actually drifted

The tracking issue predates the #724 restructure landing and the #730/parity-port doc rewrites. Re-verifying every claim against HEAD, **exactly one** item is still genuinely stale across the four owned files. Every other listed item is either already resolved on `main` or was never true — receipts below so this PR corrects drift without introducing any.

### Fixed — `apps/cli/AGENTS.md` §4 "No fallback logic for legacy layouts"

Old text: *"`runMigration()` writes a `.migrated` sentinel"* — factually wrong.

- `runMigration()` (`apps/cli/src/lib/migrate.ts:1738`) folds legacy paths; it never writes the sentinel.
- Its only `.migrated` touch is *relocating* a legacy one via `moveFileOnce` inside `migrateRuntimeToCache()` — `apps/cli/src/lib/migrate.ts:1021` and `:1027` (`moveFileOnce(path.join(USER_DIR, '.migrated'), path.join(CACHE_DIR, '.migrated'))`).
- The sentinel is **written by the bootstrap gate** that invokes `runMigration()`: `apps/cli/src/index.ts:1028` — `fs.writeFileSync(sentinel, sentinelValue)` — keyed to the migration SCHEMA version (`sentinelValue = 'v11'`, `src/index.ts:1017`).
- The constant lives at `apps/cli/src/lib/state.ts:134` — `const MIGRATED_SENTINEL_FILE = path.join(CACHE_DIR, '.migrated')`, exposed via `getMigratedSentinelPath()` (`state.ts:476`).

New text attributes the write to the bootstrap gate and cites `MIGRATED_SENTINEL_FILE` in `src/lib/state.ts`, matching the issue's own correction ("the constant now lives at `state.ts`").

## Listed items deliberately NOT changed (verified not drift — changing them WOULD add drift)

**`apps/cli/AGENTS.md` "re-root the Source-layout tree / src/ refs to `apps/cli/src/`"** — the `src/…` references are component-relative and resolve correctly. The file reaches repo-root via `../../` (e.g. `src/index.ts:13`, `:127`, `:139`, `:155`) and uses bare `src/…` for its own component tree. The five markdown links (`AGENTS.md:41,48,71,72,94`, e.g. `[`src/lib/capabilities.ts`](src/lib/capabilities.ts)`) resolve to `apps/cli/src/lib/…`, and **all 22 referenced paths exist there** (verified). Re-pointing them to `apps/cli/src/…` would resolve to `apps/cli/apps/cli/src/…` and break every link. The sibling `apps/factory/AGENTS.md` uses the identical bare-`src/` convention — leaving it consistent.

**`apps/factory/AGENTS.md` — `166 tests`, `Overview/Swarm/Prompts/Guide` tabs, `~/.gemini/sessions`** — none of these strings exist in the current file, and `git log -S'166 tests'` / `-S'Overview'` on the path return nothing: they were never in `apps/factory/AGENTS.md` (it was written fresh in #724 `26a70b0f` + parity port `36227a23`). They described the pre-#724 `swarmify/AGENTS.md`, since replaced. Nothing to fix.

**`apps/factory/AGENTS.md:61` watchdog log `~/.agents/watchdog.log`** — accurate for the extension. The Factory source writes exactly that path: `apps/factory/src/vscode/watchdog.vscode.ts:33`, `apps/factory/src/mcp/watchdog-bridge.ts:12`, `apps/factory/src/core/watchdogLog.ts:2`. The issue's `~/.agents/.cache/logs/watchdog.log` is the **CLI's** migrated location (`migrate.ts:1029`), a different product. Changing it would be new drift.

**`apps/factory/AGENTS.md:60` "Swarm MCP integration" → "Teams"** — accurate for the extension. Both cited files exist: `apps/factory/src/vscode/swarm.vscode.ts` and `apps/factory/src/core/swarm.detect.ts`. The Swarm→teams fold is the **CLI's** migration (`migrateLegacySwarmToTeams`, `apps/cli/src/lib/migrate.ts:1318`), not the extension's. Renaming would mislabel live code.

**Root `AGENTS.md`** — swept, no bare `src/` refs; all paths (`apps/`, `packages/`, `native/`, `docs/`) resolve. Clean.

## Verification

- `apps/cli/CLAUDE.md` / `GEMINI.md` are symlinks to `AGENTS.md` (`ls -la` — factory + root twins are symlinks; `apps/cli` has only `AGENTS.md`), so the one edit propagates.
- Docs-only diff: `apps/cli/AGENTS.md | 7 +++++++ 4 ----`. No `.ts/.cs/.swift` touched.
