### PR TITLE
fix(factory): pause standalone floor poll when hidden (unsubscribeFloor)

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -24,6 +24,14 @@ All notable changes to the Factory extension are documented here. Format follows
   instead of a label the TUI would ignore, so you can unblock without opening the
   terminal. Cloud/team replies stay label-based (semantic-message APIs). (RUSH-453)
 
+### Fixed
+
+- **The standalone Factory app now pauses its floor poll when the floor is hidden.** The
+  Electron host handled `subscribeFloor` but dropped `unsubscribeFloor`, so its 5s poll —
+  which shells out to read agent state and hit the cloud-runs API — kept running even when
+  no floor was visible. It now stops on `unsubscribeFloor` and resumes on `subscribeFloor`,
+  mirroring the VS Code host's `cleanupFloorWatchers` lifecycle. (RUSH-1509)
+
 ## [0.9.290] - 2026-07-08
 
 ### Added

--- a/apps/factory/app/floorPoll.test.ts
+++ b/apps/factory/app/floorPoll.test.ts
@@ -1,0 +1,83 @@
+import { describe, test, expect } from 'bun:test';
+import { FloorPoll } from './floorPoll';
+
+// Deterministic fake timer: start() registers a callback, tick() fires it,
+// stop() unregisters. Lets us assert the poll actually pauses/resumes without
+// wall-clock waits or Electron.
+function fakeTimers() {
+  const cbs = new Map<number, () => void>();
+  let nextId = 1;
+  return {
+    deps: {
+      setInterval: (fn: () => void) => {
+        const id = nextId++;
+        cbs.set(id, fn);
+        return id as unknown as ReturnType<typeof setInterval>;
+      },
+      clearInterval: (handle: ReturnType<typeof setInterval>) => {
+        cbs.delete(handle as unknown as number);
+      },
+    },
+    tickAll: () => cbs.forEach((fn) => fn()),
+    active: () => cbs.size,
+  };
+}
+
+describe('FloorPoll', () => {
+  test('start() begins ticking; stop() pauses it', () => {
+    const timers = fakeTimers();
+    let ticks = 0;
+    const poll = new FloorPoll(5000, () => ticks++, timers.deps);
+
+    expect(poll.running).toBe(false);
+    poll.start();
+    expect(poll.running).toBe(true);
+
+    timers.tickAll();
+    timers.tickAll();
+    expect(ticks).toBe(2);
+
+    poll.stop();
+    expect(poll.running).toBe(false);
+    expect(timers.active()).toBe(0);
+
+    // After stop, no timer remains, so ticks stay frozen — the poll is paused.
+    timers.tickAll();
+    expect(ticks).toBe(2);
+  });
+
+  test('start() is idempotent — no double interval', () => {
+    const timers = fakeTimers();
+    let ticks = 0;
+    const poll = new FloorPoll(5000, () => ticks++, timers.deps);
+
+    poll.start();
+    poll.start();
+    expect(timers.active()).toBe(1);
+
+    timers.tickAll();
+    expect(ticks).toBe(1);
+  });
+
+  test('stop() is a no-op when not running', () => {
+    const timers = fakeTimers();
+    const poll = new FloorPoll(5000, () => {}, timers.deps);
+    expect(() => poll.stop()).not.toThrow();
+    expect(poll.running).toBe(false);
+  });
+
+  test('can resume after stop', () => {
+    const timers = fakeTimers();
+    let ticks = 0;
+    const poll = new FloorPoll(5000, () => ticks++, timers.deps);
+
+    poll.start();
+    poll.stop();
+    poll.start();
+    expect(poll.running).toBe(true);
+    expect(timers.active()).toBe(1);
+
+    timers.tickAll();
+    expect(ticks).toBe(1);
+  });
+});

--- a/apps/factory/app/floorPoll.ts
+++ b/apps/factory/app/floorPoll.ts
@@ -1,0 +1,46 @@
+// The standalone Electron host refreshes floor data on a fixed interval. That
+// poll must PAUSE when the floor is hidden (the UI sends `unsubscribeFloor`) and
+// RESUME when it's shown again (`subscribeFloor`) — mirroring the VS Code host's
+// subscribeFloor / cleanupFloorWatchers lifecycle (settings.vscode.ts).
+//
+// Extracted from main.ts so the start/stop lifecycle is unit-testable without
+// booting Electron: the timer functions are injectable.
+
+type IntervalHandle = ReturnType<typeof setInterval>
+
+export interface FloorPollDeps {
+  setInterval?: (fn: () => void, ms: number) => IntervalHandle
+  clearInterval?: (handle: IntervalHandle) => void
+}
+
+export class FloorPoll {
+  private handle: IntervalHandle | null = null
+  private readonly set: (fn: () => void, ms: number) => IntervalHandle
+  private readonly clear: (handle: IntervalHandle) => void
+
+  constructor(
+    private readonly intervalMs: number,
+    private readonly onTick: () => void,
+    deps: FloorPollDeps = {},
+  ) {
+    this.set = deps.setInterval ?? ((fn, ms) => setInterval(fn, ms))
+    this.clear = deps.clearInterval ?? ((h) => clearInterval(h))
+  }
+
+  get running(): boolean {
+    return this.handle !== null
+  }
+
+  // Idempotent: a second start() while already running does NOT open a second
+  // interval (which would double the poll rate and leak a timer).
+  start(): void {
+    if (this.handle !== null) return
+    this.handle = this.set(() => this.onTick(), this.intervalMs)
+  }
+
+  stop(): void {
+    if (this.handle === null) return
+    this.clear(this.handle)
+    this.handle = null
+  }
+}

--- a/apps/factory/app/main.ts
+++ b/apps/factory/app/main.ts
@@ -9,6 +9,7 @@ import * as path from 'path'
 import * as os from 'os'
 import { getDefaultSettings } from '../src/core/settings'
 import { fetchAllFloorTasks } from './floorData'
+import { FloorPoll } from './floorPoll'
 
 // Resolve UI / preload / assets for both dev and a packaged .app.
 //   dev  (`electron ./dist/main.js`): getAppPath() = <ext>/app/dist; the built
@@ -29,11 +30,15 @@ const ASSETS_DIR = app.isPackaged
 const POLL_MS = 5000
 
 let win: BrowserWindow | null = null
-let pollTimer: ReturnType<typeof setInterval> | null = null
 
 function send(message: unknown): void {
   if (win && !win.isDestroyed()) win.webContents.send('to-renderer', message)
 }
+
+// The floor poll pauses when the floor is hidden and resumes when shown, so a
+// dashboard tab nobody is looking at stops burning CPU/network + `agents` calls
+// every 5s (mirrors the VS Code host's subscribeFloor / cleanupFloorWatchers).
+const floorPoll = new FloorPoll(POLL_MS, () => void pushFloor())
 
 async function pushFloor(): Promise<void> {
   // The standalone app owns no editor terminal tabs, so allTerminalsData is empty
@@ -57,10 +62,22 @@ ipcMain.on('to-host', (_event, message: { type?: string } | null) => {
       dismissedTaskIds: [],
     })
     send({ type: 'panelVisibility', visible: true })
+    floorPoll.start()
     void pushFloor()
     return
   }
-  if (type === 'fetchTasks' || type === 'fetchAllTerminals' || type === 'subscribeFloor') {
+  if (type === 'subscribeFloor') {
+    // Floor shown again — resume the poll and push a fresh snapshot immediately.
+    floorPoll.start()
+    void pushFloor()
+    return
+  }
+  if (type === 'unsubscribeFloor') {
+    // Floor hidden — pause the poll so it stops running while nobody's looking.
+    floorPoll.stop()
+    return
+  }
+  if (type === 'fetchTasks' || type === 'fetchAllTerminals') {
     void pushFloor()
   }
   // Other message types (dispatch, settings, oauth, foreman, ...) are extension-only
@@ -92,13 +109,15 @@ function createWindow(): void {
 
 app.whenReady().then(() => {
   createWindow()
-  pollTimer = setInterval(() => void pushFloor(), POLL_MS)
+  // The floor is visible on launch, so start polling now; subscribe/unsubscribe
+  // from the UI toggle it thereafter.
+  floorPoll.start()
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
   })
 })
 
 app.on('window-all-closed', () => {
-  if (pollTimer) clearInterval(pollTimer)
+  floorPoll.stop()
   if (process.platform !== 'darwin') app.quit()
 })

--- a/apps/factory/app/tsconfig.json
+++ b/apps/factory/app/tsconfig.json
@@ -11,5 +11,5 @@
     "noEmit": true,
     "types": ["node", "electron"]
   },
-  "include": ["main.ts", "preload.ts", "floorData.ts"]
+  "include": ["main.ts", "preload.ts", "floorData.ts", "floorPoll.ts"]
 }


### PR DESCRIPTION
## Problem

The standalone Electron Factory app never stopped its 5s floor poll when the floor was hidden. The UI already sends `unsubscribeFloor` on cleanup (`apps/factory/ui/settings/App.tsx:432`), but the Electron host only handled the subscribe side:

```
apps/factory/app/main.ts:63  if (type === 'fetchTasks' || type === 'fetchAllTerminals' || type === 'subscribeFloor') { ... }
```

`unsubscribeFloor` fell through and was dropped, so the poll — which shells out to read `~/.agents/{teams,swarm}` state and hits the cloud-runs API every 5s — kept running while nobody was looking. The VS Code host handles this correctly via `cleanupFloorWatchers()` (`apps/factory/src/vscode/settings.vscode.ts:1646`).

## Fix

Extracted the poll lifecycle into a small, injectable `FloorPoll` controller (`apps/factory/app/floorPoll.ts`) and wired the message handler:

- `subscribeFloor` -> `floorPoll.start()` + push a fresh snapshot (resume)
- `unsubscribeFloor` -> `floorPoll.stop()` (pause)
- `start()` is idempotent (no double interval); the poll still starts on launch (floor is visible then) and stops on `window-all-closed`.

This mirrors the VS Code host's subscribe / cleanup lifecycle.

## Tests

`apps/factory/app/floorPoll.test.ts` drives the controller with an injected fake timer (no wall-clock, no Electron) and asserts: start begins ticking, stop pauses it (ticks freeze), start is idempotent, stop-when-idle is a no-op, and resume-after-stop works.

```
$ bun test app/floorPoll.test.ts
 4 pass
 0 fail
Ran 4 tests
```

Full mission-scope run (this PR + the sibling floor-data PR share the app dir):

```
$ bun test src/core/cloudStatus.test.ts app/floorData.test.ts app/floorPoll.test.ts
 14 pass
 0 fail
 37 expect() calls
```

`node_modules/.bin/tsc` typechecks `app/floorPoll.ts` + `app/main.ts` clean (the only `tsc -p app` error is a pre-existing "Cannot find type definition file for 'electron'" — electron is not a declared dep in this checkout; the real build bundles via `vite.standalone.config.ts`).

Docs: no user docs cover the standalone poll internals; CHANGELOG updated under `[Unreleased] / Fixed`.
