### PR TITLE
chore(cli): remove dead subsystem exports (#752 batch 2)

### DIFF
--- a/apps/cli/src/lib/cloud/rush.ts
+++ b/apps/cli/src/lib/cloud/rush.ts
@@ -382,52 +382,6 @@ export function buildDispatchBody(input: {
   return body;
 }
 
-/** A single account registered in Rush Cloud's multi-account rotation pool. */
-export interface RemoteAccount {
-  id: string;
-  provider: string;
-  email: string | null;
-  subscription_type: string | null;
-  five_hour_pct: number | null;
-  seven_day_pct: number | null;
-  usage_fetched_at: string | null;
-  created_at: string;
-}
-
-/** Fetch all Claude accounts in this user's Rush Cloud rotation pool (no tokens). */
-export async function listRemoteAccounts(): Promise<RemoteAccount[]> {
-  const token = readToken();
-  const res = await api('GET', '/api/v1/cloud-accounts', token);
-  if (!res.ok) {
-    throw new Error(`Failed to list accounts (${res.status}): ${sanitizeErrorBody(await res.text())}`);
-  }
-  const data = await res.json() as { accounts: RemoteAccount[] };
-  return data.accounts ?? [];
-}
-
-/**
- * Register a CLAUDE_CODE_OAUTH_TOKEN with Rush Cloud's rotation pool.
- * The server validates the token against the Anthropic usage API and stores it
- * encrypted in Vault. Returns the account metadata (no token).
- */
-export async function addRemoteAccount(provider: string, pastedToken: string): Promise<RemoteAccount & { five_hour_pct: number | null; seven_day_pct: number | null }> {
-  const token = readToken();
-  const res = await api('POST', '/api/v1/cloud-accounts', token, { provider, token: pastedToken });
-  if (!res.ok) {
-    throw new Error(`Failed to add account (${res.status}): ${sanitizeErrorBody(await res.text())}`);
-  }
-  return await res.json() as RemoteAccount & { five_hour_pct: number | null; seven_day_pct: number | null };
-}
-
-/** Remove a Claude account from Rush Cloud's rotation pool by its ID. */
-export async function removeRemoteAccount(id: string): Promise<void> {
-  const token = readToken();
-  const res = await api('DELETE', `/api/v1/cloud-accounts/${encodeURIComponent(id)}`, token);
-  if (!res.ok) {
-    throw new Error(`Failed to remove account (${res.status}): ${sanitizeErrorBody(await res.text())}`);
-  }
-}
-
 export class RushCloudProvider implements CloudProvider {
   id = 'rush' as const;
   name = 'Rush Cloud';

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -1104,26 +1104,6 @@ export function topSessionsByCost(
   }));
 }
 
-/** Return the set of all file paths currently tracked in the sessions table. */
-export function getAllFilePaths(): Set<string> {
-  const db = getDB();
-  const rows = db.prepare(`SELECT file_path FROM sessions`).all() as { file_path: string }[];
-  return new Set(rows.map(r => r.file_path));
-}
-
-/** Look up sessions by their source file paths. */
-export function getSessionsByFilePaths(paths: string[]): Map<string, SessionMeta> {
-  if (paths.length === 0) return new Map();
-  const db = getDB();
-  const placeholders = paths.map(() => '?').join(',');
-  const rows = db
-    .prepare(`SELECT * FROM sessions WHERE file_path IN (${placeholders})`)
-    .all(...paths) as SessionRow[];
-  const result = new Map<string, SessionMeta>();
-  for (const row of rows) result.set(row.file_path, rowToMeta(row));
-  return result;
-}
-
 /** Look up a single session by its unique ID. */
 export function getSessionById(id: string): SessionMeta | null {
   const db = getDB();

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -2452,28 +2452,6 @@ function getOpenClawWorkspaceMap(): Map<string, string> {
 // Utilities
 // ---------------------------------------------------------------------------
 
-/** Read up to maxLines non-empty lines from the beginning of a file. */
-export function readFirstLines(filePath: string, maxLines: number): Promise<string[]> {
-  return new Promise((resolve) => {
-    const lines: string[] = [];
-    const stream = fs.createReadStream(filePath, { encoding: 'utf-8' });
-    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
-
-    rl.on('line', (line) => {
-      if (line.trim()) {
-        lines.push(line);
-      }
-      if (lines.length >= maxLines) {
-        rl.close();
-        stream.destroy();
-      }
-    });
-
-    rl.on('close', () => resolve(lines));
-    rl.on('error', () => resolve(lines));
-  });
-}
-
 /** Compute the SHA-256 hex digest of a string. */
 function sha256(input: string): string {
   return crypto.createHash('sha256').update(input).digest('hex');

--- a/apps/cli/src/lib/staleness/types.ts
+++ b/apps/cli/src/lib/staleness/types.ts
@@ -61,7 +61,3 @@ export interface SyncManifest {
   workflows?: Record<string, DirEntry>;
   plugins?:   Record<string, PluginEntry>;
 }
-
-export type ResourceType =
-  | 'commands' | 'skills' | 'hooks' | 'mcp' | 'rules'
-  | 'subagents' | 'workflows' | 'plugins' | 'permissions';


### PR DESCRIPTION
Part of #752 (dead-code sweep), batch 2 of 3: the **subsystems** surface.

## Deleted (re-verified zero callers at HEAD, 8d3c9d6c)

- `apps/cli/src/lib/cloud/rush.ts:398,413,423` — `listRemoteAccounts`, `addRemoteAccount`, `removeRemoteAccount`, plus the `RemoteAccount` interface (`rush.ts:386`) referenced only by them.
- `apps/cli/src/lib/session/db.ts:1108,1115` — `getAllFilePaths`, `getSessionsByFilePaths` (zero refs including tests).
- `apps/cli/src/lib/session/discover.ts:2456` — `readFirstLines`. The only other `readFirstLines` repo-wide is a private local copy in `apps/factory/scripts/bench-fs-watch.ts:96`.
- `apps/cli/src/lib/staleness/types.ts:65` — divergent shadow `ResourceType` (zero importers; zero uses even inside `staleness/`).

## Skipped (re-verification found live callers)

- `getSessionById` (db.ts) — used by `db.names.test.ts:12` and `db.migrate-v10.test.ts:75`.
- `buildFtsQuery` (db.ts) — called internally at `db.ts:1191` and unit-tested directly in `session/__tests__/discover.test.ts:6`; the export stays for the test import.
- The issue's "~10 more listed in the audit" are not enumerated in the issue body, so they were not touched — only explicitly listed items were deleted.

## Verification

Representative zero-caller grep (only hits are the definitions):

```
$ rg -n '\b(listRemoteAccounts|addRemoteAccount|removeRemoteAccount)\b' --type ts
apps/cli/src/lib/cloud/rush.ts:398:export async function listRemoteAccounts(): Promise<RemoteAccount[]> {
apps/cli/src/lib/cloud/rush.ts:413:export async function addRemoteAccount(provider: string, ...
apps/cli/src/lib/cloud/rush.ts:423:export async function removeRemoteAccount(id: string): Promise<void> {
$ rg -nU 'import[^;]*ResourceType[^;]*from[^;]*staleness' apps/cli/src --type ts
(no matches)
```

Build: `bun run build` (tsc) — green.

Tests: `bun run test` — `Test Files 369 passed | 4 skipped (373)`, `Tests 4557 passed | 67 skipped (4624)`.

Internal-only change: no CHANGELOG or docs updates needed — no user-visible flag, command, or behavior touched.