### PR TITLE
chore(cli): remove dead subsystem exports (#752 batch 2)

### DIFF
--- a/apps/cli/src/lib/cloud/rush.ts
+++ b/apps/cli/src/lib/cloud/rush.ts
@@ -382,52 +382,6 @@ export function buildDispatchBody(input: {
   return body;
 }
 
-/** A single account registered in Rush Cloud's multi-account rotation pool. */
-export interface RemoteAccount {
-  id: string;
-  provider: string;
-  email: string | null;
-  subscription_type: string | null;
-  five_hour_pct: number | null;
-  seven_day_pct: number | null;
-  usage_fetched_at: string | null;
-  created_at: string;
-}
-
-/** Fetch all Claude accounts in this user's Rush Cloud rotation pool (no tokens). */
-export async function listRemoteAccounts(): Promise<RemoteAccount[]> {
-  const token = readToken();
-  const res = await api('GET', '/api/v1/cloud-accounts', token);
-  if (!res.ok) {
-    throw new Error(`Failed to list accounts (${res.status}): ${sanitizeErrorBody(await res.text())}`);
-  }
-  const data = await res.json() as { accounts: RemoteAccount[] };
-  return data.accounts ?? [];
-}
-
-/**
- * Register a CLAUDE_CODE_OAUTH_TOKEN with Rush Cloud's rotation pool.
- * The server validates the token against the Anthropic usage API and stores it
- * encrypted in Vault. Returns the account metadata (no token).
- */
-export async function addRemoteAccount(provider: string, pastedToken: string): Promise<RemoteAccount & { five_hour_pct: number | null; seven_day_pct: number | null }> {
-  const token = readToken();
-  const res = await api('POST', '/api/v1/cloud-accounts', token, { provider, token: pastedToken });
-  if (!res.ok) {
-    throw new Error(`Failed to add account (${res.status}): ${sanitizeErrorBody(await res.text())}`);
-  }
-  return await res.json() as RemoteAccount & { five_hour_pct: number | null; seven_day_pct: number | null };
-}
-
-/** Remove a Claude account from Rush Cloud's rotation pool by its ID. */
-export async function removeRemoteAccount(id: string): Promise<void> {
-  const token = readToken();
-  const res = await api('DELETE', `/api/v1/cloud-accounts/${encodeURIComponent(id)}`, token);
-  if (!res.ok) {
-    throw new Error(`Failed to remove account (${res.status}): ${sanitizeErrorBody(await res.text())}`);
-  }
-}
-
 export class RushCloudProvider implements CloudProvider {
   id = 'rush' as const;
   name = 'Rush Cloud';

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -1104,26 +1104,6 @@ export function topSessionsByCost(
   }));
 }
 
-/** Return the set of all file paths currently tracked in the sessions table. */
-export function getAllFilePaths(): Set<string> {
-  const db = getDB();
-  const rows = db.prepare(`SELECT file_path FROM sessions`).all() as { file_path: string }[];
-  return new Set(rows.map(r => r.file_path));
-}
-
-/** Look up sessions by their source file paths. */
-export function getSessionsByFilePaths(paths: string[]): Map<string, SessionMeta> {
-  if (paths.length === 0) return new Map();
-  const db = getDB();
-  const placeholders = paths.map(() => '?').join(',');
-  const rows = db
-    .prepare(`SELECT * FROM sessions WHERE file_path IN (${placeholders})`)
-    .all(...paths) as SessionRow[];
-  const result = new Map<string, SessionMeta>();
-  for (const row of rows) result.set(row.file_path, rowToMeta(row));
-  return result;
-}
-
 /** Look up a single session by its unique ID. */
 export function getSessionById(id: string): SessionMeta | null {
   const db = getDB();

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -2452,28 +2452,6 @@ function getOpenClawWorkspaceMap(): Map<string, string> {
 // Utilities
 // ---------------------------------------------------------------------------
 
-/** Read up to maxLines non-empty lines from the beginning of a file. */
-export function readFirstLines(filePath: string, maxLines: number): Promise<string[]> {
-  return new Promise((resolve) => {
-    const lines: string[] = [];
-    const stream = fs.createReadStream(filePath, { encoding: 'utf-8' });
-    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
-
-    rl.on('line', (line) => {
-      if (line.trim()) {
-        lines.push(line);
-      }
-      if (lines.length >= maxLines) {
-        rl.close();
-        stream.destroy();
-      }
-    });
-
-    rl.on('close', () => resolve(lines));
-    rl.on('error', () => resolve(lines));
-  });
-}
-
 /** Compute the SHA-256 hex digest of a string. */
 function sha256(input: string): string {
   return crypto.createHash('sha256').update(input).digest('hex');

--- a/apps/cli/src/lib/staleness/types.ts
+++ b/apps/cli/src/lib/staleness/types.ts
@@ -61,7 +61,3 @@ export interface SyncManifest {
   workflows?: Record<string, DirEntry>;
   plugins?:   Record<string, PluginEntry>;
 }
-
-export type ResourceType =
-  | 'commands' | 'skills' | 'hooks' | 'mcp' | 'rules'
-  | 'subagents' | 'workflows' | 'plugins' | 'permissions';


### PR DESCRIPTION
Part of #752 (dead-code sweep), **batch 2 of 3**: the subsystem lib surfaces. Every symbol re-verified for zero callers at HEAD before deletion (the issue list is from an older audit; line numbers had already shifted).

## Deleted (re-verified zero callers)

- **`apps/cli/src/lib/cloud/rush.ts`** — remote-account CRUD: `RemoteAccount` interface + `listRemoteAccounts` + `addRemoteAccount` + `removeRemoteAccount`. Zero importers anywhere in `apps/cli`/`apps/factory`.
- **`apps/cli/src/lib/session/db.ts`** — `getAllFilePaths`, `getSessionsByFilePaths`. Zero external and zero internal callers.
- **`apps/cli/src/lib/session/discover.ts`** — `readFirstLines`. Zero importers (the only other `readFirstLines` is a separate local function in `apps/factory/scripts/bench-fs-watch.ts`).
- **`apps/cli/src/lib/staleness/types.ts`** — the divergent shadow `ResourceType` type. Its only occurrence in the whole `staleness/` dir was its own definition; the live `ResourceType` used across the codebase comes from `apps/cli/src/lib/types.ts:508`.

## Skipped (stale on the issue list — gained callers / live since the audit)

The issue lists `session/db.ts:1019-1166` as "4 fns". Two of the four are **not** cleanly dead and were left intact:

- `getSessionById` — imported and used as a read helper by 3 test files (`db.names.test.ts`, `db.migrate-v10.test.ts`); deleting it would break those tests.
- `buildFtsQuery` — called internally at `db.ts` and imported by `__tests__/discover.test.ts`. Live internally + tested → not dead.

(The issue's vaguer "~10 more listed in the audit" subsystem items carry no file:line in the issue body and could not be identified precisely, so they are out of scope for this PR.)

## Verification

Zero-caller grep (each deleted symbol's only hit is its own definition), e.g.:

```
$ rg -n 'listRemoteAccounts|addRemoteAccount|removeRemoteAccount|RemoteAccount' apps/cli/src apps/factory --type ts -g '!*.test.ts'
apps/cli/src/lib/cloud/rush.ts:386:export interface RemoteAccount {   (definition only)
$ rg -n 'ResourceType' apps/cli/src/lib/staleness
apps/cli/src/lib/staleness/types.ts:65:export type ResourceType =    (definition only, now removed)
```

**Build:** `bun run build` (tsc) — green (no orphaned imports).

**Tests:** `bun run test` — the 4 subsystem-adjacent files that briefly showed failures during a heavily-loaded concurrent run (`versions.test.ts`, `shims.session-rewrite.test.ts`, `tests/daemon.test.ts`, `hosts/session-index.test.ts`) are slow subprocess/timing tests that time out under machine thrash (63s+ durations). Re-run in isolation they all pass:

```
$ bunx vitest run src/lib/__tests__/versions.test.ts src/lib/shims.session-rewrite.test.ts tests/daemon.test.ts
 Test Files  3 passed (3)     Tests  29 passed (29)     Duration 11.29s
$ bunx vitest run src/lib/hosts/session-index.test.ts
 Test Files  1 passed (1)     Tests  7 passed (7)       Duration 744ms
```

None of these files reference the deleted symbols. CI (unloaded) is the authoritative signal.

Internal-only change: no CHANGELOG or docs updates needed — no user-visible flag, command, or behavior touched.