### PR TITLE
feat(factory): floor rail flyouts — Projects/Hosts menus, Dispatch button, real Needs-you filter

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+### Changed
+
+- **The collapsed Floor rail's Projects and Hosts buttons are now flyout menus instead of
+  three buttons that all expanded the sidebar.** Click Projects for the curated project
+  list (live agent count + amber waiting count per project, plus any uncurated project
+  that has agents running) and jump straight to that scope; click Hosts for the fleet
+  roster with health dots and per-host counts. The Hosts button carries a red dot whenever
+  any host is offline, a lime **Dispatch** button now sits at the top of the rail, and the
+  `»` chevron is the single expand affordance. Active states are fixed across the board
+  (Backlog lights when the backlog center is showing; a project/host scope lights its
+  button), and the rail-vs-sidebar choice is remembered across reloads.
+
+### Fixed
+
+- **"Needs you" in the rail and sidebar now actually filters the feed.** It used to clear
+  all filters — identical to "All agents" — despite the amber badge. It now toggles the
+  same `needs` status chip the controls bar drives, and "All agents" clears it.
+
 ## [0.9.291] - 2026-07-09
 
 ### Fixed

--- a/apps/factory/ui/settings/components/mission-control/FloorRail.test.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorRail.test.tsx
@@ -1,0 +1,161 @@
+import { expect, test, describe } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { FloorRail, railActive, railProjectRows, type RailScopeState } from './FloorRail'
+import type { FloorAgent, FloorTicket, ManagedProject } from './floorModel'
+
+// Pure, DOM-free tests via renderToStaticMarkup — same convention as
+// FloorSubtabs.test.tsx: no happy-dom register, nothing leaks into siblings.
+
+function makeAgent(overrides: Partial<FloorAgent> = {}): FloorAgent {
+  return {
+    id: 'a1',
+    host: 'this-mac',
+    project: 'swarmify',
+    name: 'auth-refactor',
+    abbr: 'CC',
+    phase: 'running',
+    verb: 'Editing',
+    target: 'src/core/tasks.ts',
+    tok: 0,
+    since: '2s',
+    lastActivityMs: 0,
+    files: 0,
+    tools: 0,
+    needs: false,
+    pinned: false,
+    pr: null,
+    prUrl: null,
+    ci: null,
+    ticket: null,
+    branch: 'feat-auth',
+    worktreeSlug: '',
+    worktreePath: '',
+    resp: '',
+    messages: [],
+    question: null,
+    reply: { kind: 'terminal', host: 'this-mac', terminalId: 'CC-1' },
+    todos: [],
+    summary: '',
+    recent: [],
+    ...overrides,
+  }
+}
+
+function makeProject(overrides: Partial<ManagedProject> = {}): ManagedProject {
+  return {
+    id: 'p1',
+    name: 'swarmify',
+    path: '/repos/swarmify',
+    confidence: 'high',
+    source: 'detected',
+    ...overrides,
+  }
+}
+
+const tickets: FloorTicket[] = []
+
+const base: RailScopeState = { center: 'agents', projFilter: null, hostFilter: null, needsOnly: false }
+
+describe('railActive', () => {
+  test('all is on only with no narrowing on the agents center', () => {
+    expect(railActive('all', base)).toBe(true)
+    expect(railActive('all', { ...base, needsOnly: true })).toBe(false)
+    expect(railActive('all', { ...base, projFilter: 'swarmify' })).toBe(false)
+    expect(railActive('all', { ...base, hostFilter: 'zion' })).toBe(false)
+    expect(railActive('all', { ...base, center: 'backlog' })).toBe(false)
+  })
+
+  test('needs follows the needs chip', () => {
+    expect(railActive('needs', base)).toBe(false)
+    expect(railActive('needs', { ...base, needsOnly: true })).toBe(true)
+  })
+
+  test('queue follows the backlog center regardless of agent filters', () => {
+    expect(railActive('queue', { ...base, center: 'backlog', projFilter: 'swarmify' })).toBe(true)
+    expect(railActive('queue', base)).toBe(false)
+  })
+
+  test('projects/hosts light while their filter narrows the agents center', () => {
+    expect(railActive('projects', { ...base, projFilter: 'swarmify' })).toBe(true)
+    expect(railActive('hosts', { ...base, hostFilter: 'zion' })).toBe(true)
+    // Other centers (host detail, projects manage) do not claim the scope buttons.
+    expect(railActive('projects', { ...base, center: 'projects', projFilter: 'swarmify' })).toBe(false)
+  })
+})
+
+describe('railProjectRows', () => {
+  test('managed projects lead, discovered-but-unmanaged follow busiest-first', () => {
+    const agents = [
+      makeAgent({ id: '1', project: 'swarmify' }),
+      makeAgent({ id: '2', project: 'rogue', needs: true }),
+      makeAgent({ id: '3', project: 'rogue' }),
+      makeAgent({ id: '4', project: 'drifter' }),
+    ]
+    const rows = railProjectRows(agents, [makeProject({ id: 'p1', name: 'swarmify' })])
+    expect(rows.map((r) => r.name)).toEqual(['swarmify', 'rogue', 'drifter'])
+    expect(rows[0]).toMatchObject({ managed: true, run: 1, wait: 0 })
+    expect(rows[1]).toMatchObject({ managed: false, run: 2, wait: 1 })
+  })
+
+  test('managed project with zero agents still gets a row', () => {
+    const rows = railProjectRows([], [makeProject({ name: 'idle-proj' })])
+    expect(rows).toEqual([{ key: 'p1', name: 'idle-proj', run: 0, wait: 0, managed: true }])
+  })
+})
+
+describe('FloorRail render', () => {
+  const agents = [makeAgent({ id: '1' }), makeAgent({ id: '2', needs: true })]
+  const props = {
+    agents,
+    tickets,
+    center: 'agents' as const,
+    projFilter: null,
+    hostFilter: null,
+    needsOnly: false,
+    projects: [makeProject()],
+    devices: [
+      { name: 'zion', online: true, agents: 2 },
+      { name: 'yosemite-s1', online: false, agents: 0 },
+    ],
+    offlineHosts: ['yosemite-s1'],
+    hostPins: ['zion'],
+    localHost: 'zion',
+    onScope: () => {},
+    onDispatch: () => {},
+    onManageProjects: () => {},
+    onExpand: () => {},
+  }
+
+  test('renders dispatch, three scopes, two flyout anchors, one expand — no dupes', () => {
+    const html = renderToStaticMarkup(<FloorRail {...props} />)
+    expect(html).toContain('rail-dispatch')
+    for (const label of ['All agents', 'Needs you', 'Backlog', 'Projects', 'Hosts', 'Expand sidebar']) {
+      expect(html.split(`aria-label="${label}"`).length - 1).toBe(1)
+    }
+  })
+
+  test('flyouts are closed by default and hosts button carries the offline dot', () => {
+    const html = renderToStaticMarkup(<FloorRail {...props} />)
+    expect(html).not.toContain('rail-fly"')
+    expect(html).toContain('rail-off')
+  })
+
+  test('no offline dot when the fleet is healthy', () => {
+    const html = renderToStaticMarkup(
+      <FloorRail {...props} devices={[{ name: 'zion', online: true, agents: 2 }]} offlineHosts={[]} />,
+    )
+    expect(html).not.toContain('rail-off')
+  })
+
+  test('active scope lights exactly one button', () => {
+    const html = renderToStaticMarkup(<FloorRail {...props} needsOnly={true} />)
+    expect(html.split('rail-ib on').length - 1).toBe(1)
+    const needsBtn = html.slice(html.indexOf('aria-label="Needs you"') - 120, html.indexOf('aria-label="Needs you"'))
+    expect(needsBtn).toContain('rail-ib on')
+  })
+
+  test('needs badge is amber and counts needy agents', () => {
+    const html = renderToStaticMarkup(<FloorRail {...props} />)
+    expect(html).toContain('rail-bdg attn')
+  })
+})

--- a/apps/factory/ui/settings/components/mission-control/FloorRail.test.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorRail.test.tsx
@@ -81,6 +81,25 @@ describe('railActive', () => {
     // Other centers (host detail, projects manage) do not claim the scope buttons.
     expect(railActive('projects', { ...base, center: 'projects', projFilter: 'swarmify' })).toBe(false)
   })
+
+  test('at most one button lights for any combined state (prix-cloud repro)', () => {
+    // needs chip lingering alongside a project or host scope: the scope wins.
+    const keys = ['all', 'needs', 'queue', 'projects', 'hosts'] as const
+    const states: RailScopeState[] = [
+      { ...base, needsOnly: true, projFilter: 'swarmify' },
+      { ...base, needsOnly: true, hostFilter: 'zion' },
+      { ...base, needsOnly: true, projFilter: 'swarmify', center: 'backlog' },
+      { ...base, needsOnly: true },
+      base,
+    ]
+    for (const s of states) {
+      const lit = keys.filter((k) => railActive(k, s))
+      expect(lit.length).toBeLessThanOrEqual(1)
+    }
+    expect(railActive('projects', { ...base, needsOnly: true, projFilter: 'swarmify' })).toBe(true)
+    expect(railActive('needs', { ...base, needsOnly: true, projFilter: 'swarmify' })).toBe(false)
+    expect(railActive('needs', { ...base, needsOnly: true, hostFilter: 'zion' })).toBe(false)
+  })
 })
 
 describe('railProjectRows', () => {

--- a/apps/factory/ui/settings/components/mission-control/FloorRail.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorRail.tsx
@@ -1,64 +1,209 @@
-import React from 'react'
-import { Icon } from './icons'
-import type { FloorAgent, FloorTicket } from './floorModel'
+import React, { useEffect, useState } from 'react'
+import { Icon, type IconName } from './icons'
+import {
+  computeHostRows,
+  orderManagedProjects,
+  type CenterMode,
+  type FloorAgent,
+  type FloorTicket,
+  type ManagedProject,
+} from './floorModel'
 
-// Collapsed left nav: a narrow column of icon buttons with count/needs badges, the
-// mockup's default rail. Each button routes via the same onScope the full FloorSidebar
-// uses ('' = all, '__needs', '__queue', a project name); the » button expands back to
-// the full sidebar. Kept intentionally minimal — the rail is a summary, not the roster.
+// Collapsed left nav. Dispatch on top (the floor's primary verb), then the three
+// smart scopes (All / Needs you / Backlog), then Projects and Hosts as FLYOUT menus —
+// click one to scope the feed to a project or host directly, without expanding into
+// the full FloorSidebar. The » button remains the single expand affordance.
+
+export type RailKey = 'all' | 'needs' | 'queue' | 'projects' | 'hosts'
+
+/** The scope state the rail reflects. needsOnly = the 'needs' status chip is active. */
+export interface RailScopeState {
+  center: CenterMode
+  projFilter: string | null
+  hostFilter: string | null
+  needsOnly: boolean
+}
+
+/**
+ * Which rail button reads as active for the current scope. Queue follows the center;
+ * the agent scopes only light while the agents center is showing. 'all' is the
+ * everything-else state: agents center with no project/host/needs narrowing.
+ */
+export function railActive(key: RailKey, s: RailScopeState): boolean {
+  if (key === 'queue') return s.center === 'backlog'
+  if (s.center !== 'agents') return false
+  if (key === 'needs') return s.needsOnly
+  if (key === 'projects') return s.projFilter != null
+  if (key === 'hosts') return s.hostFilter != null
+  return !s.needsOnly && s.projFilter == null && s.hostFilter == null
+}
+
+export interface RailProjectRow {
+  key: string
+  name: string
+  /** Agents currently on the project. */
+  run: number
+  /** Agents on the project waiting on the user (amber). */
+  wait: number
+  /** Curated ManagedProject vs discovered-from-agents only. */
+  managed: boolean
+}
+
+/**
+ * Rows for the Projects flyout: curated projects first (orderManagedProjects), then
+ * any project that has live agents but isn't curated — those must still be scopable
+ * from the rail, busiest first.
+ */
+export function railProjectRows(agents: FloorAgent[], projects: ManagedProject[]): RailProjectRow[] {
+  const run: Record<string, number> = {}
+  const wait: Record<string, number> = {}
+  for (const a of agents) {
+    run[a.project] = (run[a.project] || 0) + 1
+    if (a.needs) wait[a.project] = (wait[a.project] || 0) + 1
+  }
+  const managedNames = new Set(projects.map((p) => p.name))
+  const rows: RailProjectRow[] = orderManagedProjects(projects, run).map((p) => ({
+    key: p.id,
+    name: p.name,
+    run: run[p.name] ?? 0,
+    wait: wait[p.name] ?? 0,
+    managed: true,
+  }))
+  const extras = Object.keys(run)
+    .filter((name) => !managedNames.has(name))
+    .sort((x, y) => (run[y] ?? 0) - (run[x] ?? 0) || x.localeCompare(y))
+    .map((name) => ({ key: `agents:${name}`, name, run: run[name] ?? 0, wait: wait[name] ?? 0, managed: false }))
+  return [...rows, ...extras]
+}
 
 interface FloorRailProps {
   agents: FloorAgent[]
   tickets: FloorTicket[]
-  /** Current scope: null = All agents; '__needs'/'__queue' or a project name otherwise. */
-  scope: string | null
+  center: CenterMode
+  /** Current project filter: null = All agents; a project name otherwise. */
+  projFilter: string | null
+  /** Current host filter: null = no host narrowing. */
+  hostFilter: string | null
+  /** The 'needs' status chip is on — the Needs-you button reflects and toggles it. */
+  needsOnly: boolean
+  /** Curated managed projects for the Projects flyout. */
+  projects?: ManagedProject[]
+  /** Registered device fleet, same shape FloorSidebar receives. */
+  devices?: { name: string; online: boolean; agents: number }[]
+  offlineHosts?: string[]
+  hostPins?: string[]
+  localHost?: string
+  /**
+   * Scope routing, identical to FloorSidebar's: '' = all, '__needs', '__queue',
+   * 'host:<name>', or a project name.
+   */
   onScope: (value: string) => void
+  /** Open the Dispatch panel. */
+  onDispatch?: () => void
+  /** Open the Projects management pane (flyout footer). */
+  onManageProjects?: () => void
   /** Expand to the full text sidebar. */
   onExpand: () => void
 }
 
-type RailButton = {
-  key: string
-  scope: string
-  icon: string
-  label: string
-  badge?: number
-  /** Amber (attention) badge vs neutral count badge. */
-  attn?: boolean
-}
+export function FloorRail({
+  agents,
+  tickets,
+  center,
+  projFilter,
+  hostFilter,
+  needsOnly,
+  projects = [],
+  devices = [],
+  offlineHosts = [],
+  hostPins = [],
+  localHost,
+  onScope,
+  onDispatch,
+  onManageProjects,
+  onExpand,
+}: FloorRailProps) {
+  const [fly, setFly] = useState<null | 'projects' | 'hosts'>(null)
+  useEffect(() => {
+    if (!fly) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setFly(null) }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [fly])
 
-export function FloorRail({ agents, tickets, scope, onScope, onExpand }: FloorRailProps) {
+  const scope = (value: string) => { setFly(null); onScope(value) }
+  const state: RailScopeState = { center, projFilter, hostFilter, needsOnly }
   const needs = agents.filter((a) => a.needs).length
-  const buttons: RailButton[] = [
-    { key: 'all', scope: '', icon: 'radar', label: 'All agents', badge: agents.length },
-    { key: 'needs', scope: '__needs', icon: 'alert', label: 'Needs you', badge: needs || undefined, attn: true },
-    { key: 'queue', scope: '__queue', icon: 'inbox', label: 'Backlog', badge: tickets.length || undefined },
-    { key: 'projects', scope: '__projects', icon: 'folder', label: 'Projects' },
-    { key: 'hosts', scope: '__hosts', icon: 'terminal', label: 'Hosts' },
-  ]
-  const isOn = (b: RailButton) =>
-    b.scope === '' ? scope === null || scope === '' : scope === b.scope
+  const projRows = railProjectRows(agents, projects)
+  const hostRows = computeHostRows(agents, devices, offlineHosts, hostPins, localHost)
+  const anyOffline = hostRows.some((h) => h.offline)
+
+  const iconBtn = (key: RailKey, icon: IconName, label: string, onClick: () => void, badge?: number, attn?: boolean, extra?: React.ReactNode) => (
+    <button
+      type="button"
+      className={`rail-ib${railActive(key, state) ? ' on' : ''}`}
+      title={label}
+      aria-label={label}
+      onClick={onClick}
+    >
+      <Icon name={icon} size={17} />
+      {badge != null && badge > 0 && <span className={`rail-bdg${attn ? ' attn' : ''}`}>{badge}</span>}
+      {extra}
+    </button>
+  )
 
   return (
     <div className="floor-rail">
       <div className="floor-rail-col">
-        {buttons.map((b) => (
-          <button
-            key={b.key}
-            type="button"
-            className={`rail-ib${isOn(b) ? ' on' : ''}`}
-            title={b.label}
-            aria-label={b.label}
-            // Projects/Hosts need the full roster — expand into the sidebar; the
-            // feed scopes route in place.
-            onClick={() => (b.scope === '__projects' || b.scope === '__hosts' ? onExpand() : onScope(b.scope))}
-          >
-            <Icon name={b.icon} size={17} />
-            {b.badge != null && b.badge > 0 && (
-              <span className={`rail-bdg${b.attn ? ' attn' : ''}`}>{b.badge}</span>
-            )}
+        {onDispatch && (
+          <button type="button" className="rail-ib rail-dispatch" title="Dispatch an agent" aria-label="Dispatch an agent" onClick={() => { setFly(null); onDispatch() }}>
+            <Icon name="plus" size={17} />
           </button>
-        ))}
+        )}
+        {iconBtn('all', 'radar', 'All agents', () => scope(''), agents.length)}
+        {iconBtn('needs', 'alert', 'Needs you', () => scope('__needs'), needs || undefined, true)}
+        {iconBtn('queue', 'inbox', 'Backlog', () => scope('__queue'), tickets.length || undefined)}
+
+        <div className="rail-fly-anchor">
+          {iconBtn('projects', 'folder', 'Projects', () => setFly((f) => (f === 'projects' ? null : 'projects')))}
+          {fly === 'projects' && (
+            <div className="rail-fly" role="menu" aria-label="Projects">
+              <div className="fly-sec">Projects</div>
+              {projRows.length === 0 && <div className="fly-empty">No projects yet</div>}
+              {projRows.map((p) => (
+                <button key={p.key} type="button" className={`fly-row${projFilter === p.name ? ' on' : ''}`} onClick={() => scope(p.name)}>
+                  <span className="n">{p.name}</span>
+                  {p.wait > 0 && <span className="w"><Icon name="clock" size={10} />{p.wait}</span>}
+                  <span className="c">{p.run > 0 ? p.run : '—'}</span>
+                </button>
+              ))}
+              {onManageProjects && (
+                <button type="button" className="fly-row fly-manage" onClick={() => { setFly(null); onManageProjects() }}>
+                  <Icon name="cog" size={12} />
+                  <span className="n">Manage projects</span>
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="rail-fly-anchor">
+          {iconBtn('hosts', 'terminal', 'Hosts', () => setFly((f) => (f === 'hosts' ? null : 'hosts')), undefined, false,
+            anyOffline ? <span className="rail-off" title="A host is offline" /> : undefined)}
+          {fly === 'hosts' && (
+            <div className="rail-fly" role="menu" aria-label="Hosts">
+              <div className="fly-sec">Hosts</div>
+              {hostRows.map((h) => (
+                <button key={h.name} type="button" className={`fly-row${hostFilter === h.name ? ' on' : ''}`} onClick={() => scope(`host:${h.name}`)}>
+                  <span className={`fly-hd${h.offline ? ' off' : ''}`} />
+                  <span className="n">{h.name}</span>
+                  <span className="c">{h.offline ? <span style={{ color: 'var(--fail)' }}>offline</span> : h.count}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
         <div className="rail-gap" />
         <button
           type="button"
@@ -70,6 +215,7 @@ export function FloorRail({ agents, tickets, scope, onScope, onExpand }: FloorRa
           <Icon name="chevR" size={16} />
         </button>
       </div>
+      {fly && <div className="rail-fly-backdrop" onClick={() => setFly(null)} />}
     </div>
   )
 }

--- a/apps/factory/ui/settings/components/mission-control/FloorRail.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorRail.tsx
@@ -28,11 +28,16 @@ export interface RailScopeState {
  * Which rail button reads as active for the current scope. Queue follows the center;
  * the agent scopes only light while the agents center is showing. 'all' is the
  * everything-else state: agents center with no project/host/needs narrowing.
+ *
+ * At most one button lights for ANY state: onScope keeps the smart views mutually
+ * exclusive (scoping a project/host drops the needs chip and vice versa), and this
+ * function is defensive about combined states anyway — a project/host scope wins
+ * over a lingering needs chip, so 'needs' only lights with no other narrowing.
  */
 export function railActive(key: RailKey, s: RailScopeState): boolean {
   if (key === 'queue') return s.center === 'backlog'
   if (s.center !== 'agents') return false
-  if (key === 'needs') return s.needsOnly
+  if (key === 'needs') return s.needsOnly && s.projFilter == null && s.hostFilter == null
   if (key === 'projects') return s.projFilter != null
   if (key === 'hosts') return s.hostFilter != null
   return !s.needsOnly && s.projFilter == null && s.hostFilter == null

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -1631,13 +1631,16 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
       const h = value.slice(5)
       setCenter('agents'); setProjFilter(null)
       setHostFilter((cur) => (cur === h ? null : h)) // click again to clear
+      // Scoping to a host replaces the needs narrowing, mirroring how '__needs'
+      // replaces the project/host scope — the smart views are mutually exclusive.
+      setStatusChips((cur) => cur.filter((c) => c !== 'needs'))
       return
     }
     setCenter('agents')
     setHostFilter(null)
     setProjFilter(value || null)
-    // 'All agents' ('') also drops the needs narrowing — All must mean everything.
-    if (!value) setStatusChips((cur) => cur.filter((c) => c !== 'needs'))
+    // Project scope and 'All agents' ('') both drop the needs narrowing too.
+    setStatusChips((cur) => cur.filter((c) => c !== 'needs'))
   }, [])
 
   // Selecting an agent opens its detail rail — the SAME setRightOpen(true) that

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -88,6 +88,8 @@ const REMOTE_POLL_MS = 45_000
 interface FloorPrefs {
   plain: boolean
   sidebar: boolean
+  // Collapsed icon rail (true, the default) vs the full text sidebar.
+  rail: boolean
   right: boolean
   pinned: string[]
   // Ordered pinned host names for the HOSTS sidebar. null = never customized
@@ -96,7 +98,7 @@ interface FloorPrefs {
 }
 
 function defaultFloorPrefs(): FloorPrefs {
-  return { plain: false, sidebar: true, right: true, pinned: [], hostPins: null }
+  return { plain: false, sidebar: true, rail: true, right: true, pinned: [], hostPins: null }
 }
 
 function loadFloorPrefs(): FloorPrefs {
@@ -624,7 +626,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   const [plain, setPlain] = useState(floorPrefs0.plain)
   const [sidebarOpen, setSidebarOpen] = useState(floorPrefs0.sidebar)
   // Collapsed = the icon rail (mockup default); expanded = the full text sidebar.
-  const [railCollapsed, setRailCollapsed] = useState(true)
+  const [railCollapsed, setRailCollapsed] = useState(floorPrefs0.rail)
   const [rightOpen, setRightOpen] = useState(floorPrefs0.right)
   const [pinned, setPinned] = useState<Set<string>>(() => new Set(floorPrefs0.pinned))
   // Ordered pinned HOSTS names (null = default: pin the local machine).
@@ -685,8 +687,8 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
 
   // Persist the durable Floor prefs (pinned set, plain/sidebar/right toggles, group-by, host pins).
   useEffect(() => {
-    saveFloorPrefs({ plain, sidebar: sidebarOpen, right: rightOpen, pinned: [...pinned], hostPins })
-  }, [plain, sidebarOpen, rightOpen, pinned, hostPins])
+    saveFloorPrefs({ plain, sidebar: sidebarOpen, rail: railCollapsed, right: rightOpen, pinned: [...pinned], hostPins })
+  }, [plain, sidebarOpen, railCollapsed, rightOpen, pinned, hostPins])
 
   // Effective HOSTS pins: default to pinning just the local machine until the user
   // customizes. Pin/unpin and drag-reorder always write an explicit list.
@@ -1618,7 +1620,13 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
 
   const onScope = useCallback((value: string) => {
     if (value === '__queue') { setCenter('backlog'); return }
-    if (value === '__needs') { setCenter('agents'); setProjFilter(null); setHostFilter(null); return }
+    if (value === '__needs') {
+      // A REAL needs-only view: toggle the same 'needs' status chip the controls bar
+      // and saved views drive, so one filter mechanism serves all three surfaces.
+      setCenter('agents'); setProjFilter(null); setHostFilter(null)
+      setStatusChips((cur) => (cur.includes('needs') ? cur.filter((c) => c !== 'needs') : ['needs']))
+      return
+    }
     if (value.startsWith('host:')) {
       const h = value.slice(5)
       setCenter('agents'); setProjFilter(null)
@@ -1628,6 +1636,8 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     setCenter('agents')
     setHostFilter(null)
     setProjFilter(value || null)
+    // 'All agents' ('') also drops the needs narrowing — All must mean everything.
+    if (!value) setStatusChips((cur) => cur.filter((c) => c !== 'needs'))
   }, [])
 
   // Selecting an agent opens its detail rail — the SAME setRightOpen(true) that
@@ -2089,8 +2099,22 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
           <FloorRail
             agents={floorAgents}
             tickets={floorTickets}
-            scope={projFilter}
+            center={center}
+            projFilter={projFilter}
+            hostFilter={hostFilter}
+            needsOnly={statusChips.includes('needs')}
+            projects={managedProjects}
+            devices={
+              dispatchDevices.length
+                ? dispatchDevices.map((d) => ({ name: d.name, online: !!d.reachable, agents: d.runningAgents ?? 0 }))
+                : fleetDevices.map((d) => ({ name: d.name, online: d.online, agents: 0 }))
+            }
+            offlineHosts={offlineHosts}
+            hostPins={effectiveHostPins}
+            localHost={localHostName || undefined}
             onScope={onScope}
+            onDispatch={() => openDispatch(selectedTicketId ? { ticketId: selectedTicketId } : undefined)}
+            onManageProjects={() => { setCenter('projects'); setRightOpen(true) }}
             onExpand={() => setRailCollapsed(false)}
           />
         ) : (

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -324,6 +324,26 @@
 .swarmify-root .rail-ib .rail-bdg.attn { background: var(--status-pending); border-color: var(--status-pending); color: #1a1a1a; }
 .swarmify-root .floor-rail .rail-gap { height: 6px; }
 .swarmify-root .rail-ib.rail-expand { color: var(--ds-text-faint); }
+/* Dispatch: the rail's one primary (lime-filled) action, mirroring the .disp pill. */
+.swarmify-root .rail-ib.rail-dispatch { background: var(--brand); border-color: var(--brand); color: #1a1a1a; }
+.swarmify-root .rail-ib.rail-dispatch:hover { filter: brightness(1.06); color: #1a1a1a; }
+/* Offline-host indicator on the Hosts button — status dot, never brand. */
+.swarmify-root .rail-ib .rail-off { position: absolute; bottom: -3px; right: -3px; width: 9px; height: 9px; border-radius: 50%; background: var(--status-failed); border: 2px solid var(--ds-bg); }
+/* Flyout menus for Projects / Hosts: anchored to the button, over the feed. */
+.swarmify-root .rail-fly-anchor { position: relative; }
+.swarmify-root .rail-fly-backdrop { position: fixed; inset: 0; z-index: 40; }
+.swarmify-root .rail-fly { position: absolute; left: calc(100% + 10px); top: -4px; z-index: 41; min-width: 190px; max-width: 280px; max-height: min(50vh, 420px); overflow: auto; background: var(--ds-bg-panel); border: 1px solid var(--ds-border); border-radius: 10px; padding: 6px; box-shadow: 0 8px 24px rgba(0, 0, 0, .18); }
+.swarmify-root .rail-fly .fly-sec { font-size: 9.5px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; color: var(--ds-text-faint); padding: 4px 8px 3px; }
+.swarmify-root .rail-fly .fly-empty { font-size: 12px; color: var(--ds-text-faint); padding: 6px 8px; }
+.swarmify-root .rail-fly .fly-row { display: flex; align-items: center; gap: 8px; width: 100%; padding: 6px 8px; border-radius: 7px; background: none; border: 0; cursor: pointer; color: var(--ds-text); font-size: 12px; text-align: left; }
+.swarmify-root .rail-fly .fly-row:hover { background: var(--ds-bg-recessed); }
+.swarmify-root .rail-fly .fly-row.on { color: var(--brand); }
+.swarmify-root .rail-fly .fly-row .n { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.swarmify-root .rail-fly .fly-row .c { color: var(--ds-text-dim); font-family: "Geist Mono", monospace; font-size: 10.5px; font-variant-numeric: tabular-nums; }
+.swarmify-root .rail-fly .fly-row .w { display: inline-flex; align-items: center; gap: 2px; color: var(--status-pending); font-family: "Geist Mono", monospace; font-size: 10.5px; }
+.swarmify-root .rail-fly .fly-row .fly-hd { flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%; background: var(--status-running); }
+.swarmify-root .rail-fly .fly-row .fly-hd.off { background: var(--status-failed); }
+.swarmify-root .rail-fly .fly-manage { color: var(--ds-text-faint); }
 .swarmify-root .sb-sec .sb-collapse { margin-left: auto; background: none; border: 0; padding: 0 2px; cursor: pointer; color: var(--ds-text-faint); display: inline-flex; align-items: center; }
 .swarmify-root .sb-sec .sb-collapse:hover { color: var(--ds-text); }
 .swarmify-root .sb-sec { font-size: 10px; font-weight: 800; letter-spacing: .05em; color: var(--ds-text-faint); padding: 12px 14px 4px; }

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -406,8 +406,18 @@ function Sidebar() {
     <FloorRail
       agents={sidebarAgents}
       tickets={tickets}
-      scope={null}
+      center="agents"
+      projFilter={null}
+      hostFilter={null}
+      needsOnly={false}
+      projects={managedProjects}
+      devices={devices}
+      offlineHosts={['yosemite-s1']}
+      hostPins={pins}
+      localHost="zion"
       onScope={noop}
+      onDispatch={noop}
+      onManageProjects={noop}
       onExpand={() => setCollapsed(false)}
     />
   ) : (


### PR DESCRIPTION
## Problem

Three of the collapsed Floor rail's six buttons did the same thing: Projects, Hosts, and the `»` chevron all just called `onExpand()` (FloorRail.tsx:54 on main). On top of that:

- **"Needs you" was a no-op filter** — `onScope('__needs')` cleared all filters, making it identical to "All agents" despite the amber badge.
- **Active states were broken** — Backlog/Needs never highlighted; a project or host scope showed nothing on the rail.
- **No fleet health** — `offlineHosts` data existed but a dead host was invisible until you expanded the sidebar.
- **No Dispatch** — the floor's primary action wasn't on the rail.
- **Rail state wasn't persisted** — `railCollapsed` reset on every load, unlike its sibling floorPrefs.

## Change

- **Projects and Hosts are now flyout menus** anchored to the rail: projects with live agent count + amber waiting count (curated first via `orderManagedProjects`, then any uncurated project that has agents running), hosts via the existing unit-tested `computeHostRows` with health dots and per-host counts. Clicking a row scopes the feed directly — no expand needed. Escape or backdrop click closes.
- **Hosts button carries a red dot** whenever any host in the roster is offline.
- **Lime Dispatch button** at the top of the rail, wired to the same `openDispatch` the subtabs use.
- **`__needs` toggles the real `needs` status chip** (the same mechanism the controls bar and saved views drive), and `''` (All agents) clears it — one filter mechanism for all three surfaces.
- **Active states** derive from actual scope via the exported pure `railActive()`; exactly one button lights at a time.
- **`rail` persisted in floorPrefs** alongside `sidebar`/`right`/`plain`.
- `»` chevron remains the single expand affordance.

## Evidence

- `bun test`: 1197 pass / 2 fail — both failures (`agentModels.test.ts` resolveAlias, `sessionWatcher.test.ts` timeout) reproduce identically on clean main; they shell out to the local environment and are unrelated.
- `bun run compile`: clean (tsc + both vite builds).
- New `FloorRail.test.tsx`: 11 tests — `railActive` truth table, `railProjectRows` ordering (managed-first, busiest-first extras, zero-agent managed rows), and static-markup renders (single active button, offline dot presence/absence, flyouts closed by default).
- Verified visually in the committed preview harness (`vite --config vite.preview.config.ts`, `/preview/?view=sidebar`) in light and dark themes, flyouts open and closed, Escape-to-close confirmed in the live DOM. Screenshots on zion: `/tmp/rail-light-default.jpg`, `/tmp/rail-light-projects.jpg`, `/tmp/rail-light-hosts.jpg`, `/tmp/rail-dark-projects.jpg`.

Session transcript (local, zion): `~/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/3a85fdd1-171d-4a73-9c62-64a002948cd0.jsonl`

Part 1 of the Floor tracking series — next up: in-flight ticket linkage (backlog shows who's working each ticket), then work ledger, PR board, project rollups.