### PR TITLE
feat(run): warn when a headless run leaves committed-but-unpushed work

### DIFF
--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -16,6 +16,7 @@ import { parseLoopInterval } from '../lib/loop.js';
 import type { RotateResult } from '../lib/rotate.js';
 import { AGENTS } from '../lib/agents.js';
 import { recordDispatchedRun } from '../lib/audit/log.js';
+import { warnUnpushedWork } from '../lib/warn-unpushed.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -1661,6 +1662,13 @@ export function registerRunCommand(program: Command): void {
         }
         cleanupWorkflowMcpConfig();
         cleanupWorkflowSubagents();
+        // Surface committed-but-unpushed work a headless writable run left
+        // behind, so it isn't silently stranded in a worktree. Advisory only,
+        // never throws; skipped for interactive runs (the human sees the shell)
+        // and read-only plan mode (can't commit).
+        if (mode !== 'plan' && !resolveInteractive(execOptions)) {
+          await warnUnpushedWork(cwd);
+        }
         // Governance chokepoint (#347): every dispatched run finalizes here.
         // ONE tamper-evident audit record per run — non-fatal by contract.
         recordDispatchedRun({ agent: ranAgent, version: ranVersion ?? 'unknown', mode, cwd, exitCode });

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -16,7 +16,7 @@ import { parseLoopInterval } from '../lib/loop.js';
 import type { RotateResult } from '../lib/rotate.js';
 import { AGENTS } from '../lib/agents.js';
 import { recordDispatchedRun } from '../lib/audit/log.js';
-import { warnUnpushedWork } from '../lib/warn-unpushed.js';
+import { warnUnpushedWork, shouldWarnUnpushed } from '../lib/warn-unpushed.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -727,7 +727,7 @@ export function registerRunCommand(program: Command): void {
           exitCode: resumeExit,
         });
         // A resumed loop is always headless; surface any commits it left unpushed.
-        if ((resumeExec.mode ?? 'auto') !== 'plan') await warnUnpushedWork(resumeExec.cwd ?? process.cwd());
+        if (shouldWarnUnpushed(resumeExec.mode ?? 'auto', false)) await warnUnpushedWork(resumeExec.cwd ?? process.cwd());
         process.exit(resumeExit);
       }
 
@@ -1483,7 +1483,7 @@ export function registerRunCommand(program: Command): void {
           // the normal finalize below — record its one audit entry.
           recordDispatchedRun({ agent, version: defaultVersion ?? 'unknown', mode, cwd, exitCode });
           // ACP headless run always has a prompt; surface any unpushed commits.
-          if (mode !== 'plan') await warnUnpushedWork(cwd);
+          if (shouldWarnUnpushed(mode, false)) await warnUnpushedWork(cwd);
           process.exit(exitCode);
         } catch (err) {
           console.error(chalk.red(`ACP run failed for ${agent}: ${(err as Error).message}`));
@@ -1641,7 +1641,7 @@ export function registerRunCommand(program: Command): void {
           const loopExit = loopExitCode(result.stoppedBy);
           recordDispatchedRun({ agent, version: defaultVersion ?? 'unknown', mode, cwd, exitCode: loopExit });
           // A loop is always headless; surface any commits it left unpushed.
-          if (mode !== 'plan') await warnUnpushedWork(cwd);
+          if (shouldWarnUnpushed(mode, false)) await warnUnpushedWork(cwd);
           process.exit(loopExit);
         } catch (err) {
           cleanupWorkflowMcpConfig();
@@ -1672,7 +1672,7 @@ export function registerRunCommand(program: Command): void {
         // behind, so it isn't silently stranded in a worktree. Advisory only,
         // never throws; skipped for interactive runs (the human sees the shell)
         // and read-only plan mode (can't commit).
-        if (mode !== 'plan' && !resolveInteractive(execOptions)) {
+        if (shouldWarnUnpushed(mode, resolveInteractive(execOptions))) {
           await warnUnpushedWork(cwd);
         }
         // Governance chokepoint (#347): every dispatched run finalizes here.
@@ -1684,7 +1684,7 @@ export function registerRunCommand(program: Command): void {
         cleanupWorkflowSubagents();
         // An agent that committed then crashed is the case where stranded work
         // matters most — warn before exiting the error path too.
-        if (mode !== 'plan' && !resolveInteractive(execOptions)) {
+        if (shouldWarnUnpushed(mode, resolveInteractive(execOptions))) {
           await warnUnpushedWork(cwd);
         }
         console.error(chalk.red(`Failed to execute ${agent}: ${(err as Error).message}`));

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -726,6 +726,8 @@ export function registerRunCommand(program: Command): void {
           cwd: resumeExec.cwd ?? process.cwd(),
           exitCode: resumeExit,
         });
+        // A resumed loop is always headless; surface any commits it left unpushed.
+        if ((resumeExec.mode ?? 'auto') !== 'plan') await warnUnpushedWork(resumeExec.cwd ?? process.cwd());
         process.exit(resumeExit);
       }
 
@@ -1480,6 +1482,8 @@ export function registerRunCommand(program: Command): void {
           // Governance chokepoint (#347): the --acp path exits here, bypassing
           // the normal finalize below — record its one audit entry.
           recordDispatchedRun({ agent, version: defaultVersion ?? 'unknown', mode, cwd, exitCode });
+          // ACP headless run always has a prompt; surface any unpushed commits.
+          if (mode !== 'plan') await warnUnpushedWork(cwd);
           process.exit(exitCode);
         } catch (err) {
           console.error(chalk.red(`ACP run failed for ${agent}: ${(err as Error).message}`));
@@ -1636,6 +1640,8 @@ export function registerRunCommand(program: Command): void {
           // the normal finalize below — record its one audit entry.
           const loopExit = loopExitCode(result.stoppedBy);
           recordDispatchedRun({ agent, version: defaultVersion ?? 'unknown', mode, cwd, exitCode: loopExit });
+          // A loop is always headless; surface any commits it left unpushed.
+          if (mode !== 'plan') await warnUnpushedWork(cwd);
           process.exit(loopExit);
         } catch (err) {
           cleanupWorkflowMcpConfig();
@@ -1676,6 +1682,11 @@ export function registerRunCommand(program: Command): void {
       } catch (err) {
         cleanupWorkflowMcpConfig();
         cleanupWorkflowSubagents();
+        // An agent that committed then crashed is the case where stranded work
+        // matters most — warn before exiting the error path too.
+        if (mode !== 'plan' && !resolveInteractive(execOptions)) {
+          await warnUnpushedWork(cwd);
+        }
         console.error(chalk.red(`Failed to execute ${agent}: ${(err as Error).message}`));
         process.exit(1);
       }

--- a/apps/cli/src/lib/warn-unpushed.test.ts
+++ b/apps/cli/src/lib/warn-unpushed.test.ts
@@ -1,0 +1,151 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getUnpushedState, formatUnpushedWarning } from './warn-unpushed.js';
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function git(cwd: string, ...args: string[]): string {
+  const res = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  if (res.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${res.stderr}`);
+  return (res.stdout ?? '').trim();
+}
+
+/** A work repo whose `origin` is a real local bare repo — no network, real push. */
+function makeRepoWithRemote(): { work: string; commit: (subject: string) => void } {
+  const remote = makeTempDir('warn-unpushed-remote-');
+  git(remote, 'init', '--bare', '-b', 'main');
+  const work = makeTempDir('warn-unpushed-work-');
+  git(work, 'init', '-b', 'main');
+  git(work, 'config', 'user.email', 'test@example.com');
+  git(work, 'config', 'user.name', 'Test');
+  git(work, 'remote', 'add', 'origin', remote);
+  const commit = (subject: string) => {
+    fs.writeFileSync(path.join(work, `f-${Date.now()}-${Math.round(performance.now())}.txt`), subject);
+    git(work, 'add', '-A');
+    git(work, 'commit', '-m', subject);
+  };
+  return { work, commit };
+}
+
+afterEach(() => {
+  for (const d of tempDirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+describe('getUnpushedState', () => {
+  it('reports a committed-but-unpushed branch, with no upstream', async () => {
+    const { work, commit } = makeRepoWithRemote();
+    commit('feat: first');
+
+    const state = await getUnpushedState(work);
+    expect(state.isRepo).toBe(true);
+    expect(state.branch).toBe('main');
+    expect(state.hasUpstream).toBe(false);
+    expect(state.unpushed.map((c) => c.subject)).toEqual(['feat: first']);
+  });
+
+  it('reports nothing once the branch is pushed (upstream set)', async () => {
+    const { work, commit } = makeRepoWithRemote();
+    commit('feat: first');
+    git(work, 'push', '-u', 'origin', 'main');
+
+    const state = await getUnpushedState(work);
+    expect(state.hasUpstream).toBe(true);
+    expect(state.unpushed).toEqual([]);
+    expect(formatUnpushedWarning(state, work)).toBeNull();
+  });
+
+  it('does not false-positive when commits are on a remote ref but no upstream is set', async () => {
+    // Push, then delete the local tracking config so @{u} is gone but the
+    // commit is still on origin. --remotes must still see it as pushed.
+    const { work, commit } = makeRepoWithRemote();
+    commit('feat: first');
+    git(work, 'push', 'origin', 'main'); // note: no -u, so no upstream tracking
+    git(work, 'fetch', 'origin');
+
+    const state = await getUnpushedState(work);
+    expect(state.hasUpstream).toBe(false);
+    expect(state.unpushed).toEqual([]); // commit is on origin/main -> not "unpushed"
+  });
+
+  it('preserves commit subjects that contain spaces (no truncation)', async () => {
+    const { work, commit } = makeRepoWithRemote();
+    const subject = 'fix(cli): case-insensitive agent name match in resolvePackageIDWithRegistry';
+    commit(subject);
+
+    const state = await getUnpushedState(work);
+    expect(state.unpushed).toHaveLength(1);
+    expect(state.unpushed[0].subject).toBe(subject);
+  });
+
+  it('stays silent for a repo with no remote configured', async () => {
+    const work = makeTempDir('warn-unpushed-noremote-');
+    git(work, 'init', '-b', 'main');
+    git(work, 'config', 'user.email', 'test@example.com');
+    git(work, 'config', 'user.name', 'Test');
+    fs.writeFileSync(path.join(work, 'a.txt'), 'x');
+    git(work, 'add', '-A');
+    git(work, 'commit', '-m', 'local only');
+
+    const state = await getUnpushedState(work);
+    expect(state.isRepo).toBe(true);
+    expect(state.unpushed).toEqual([]); // nowhere to push -> no warning
+  });
+
+  it('returns an inert state for a non-git directory', async () => {
+    const dir = makeTempDir('warn-unpushed-nogit-');
+    const state = await getUnpushedState(dir);
+    expect(state).toEqual({ isRepo: false, branch: null, hasUpstream: false, unpushed: [] });
+  });
+
+  it('does not warn on a detached HEAD', async () => {
+    const { work, commit } = makeRepoWithRemote();
+    commit('feat: first');
+    commit('feat: second');
+    const head = git(work, 'rev-parse', 'HEAD');
+    git(work, 'checkout', head); // detach
+
+    const state = await getUnpushedState(work);
+    expect(state.branch).toBeNull();
+    expect(formatUnpushedWarning(state, work)).toBeNull();
+  });
+});
+
+describe('formatUnpushedWarning', () => {
+  it('lists commits and the correct push command (no upstream -> push -u)', () => {
+    const warning = formatUnpushedWarning(
+      {
+        isRepo: true,
+        branch: 'agents/foo',
+        hasUpstream: false,
+        unpushed: [{ sha: 'd83c5d4', subject: 'fix: thing' }],
+      },
+      '/repo',
+    );
+    expect(warning).not.toBeNull();
+    expect(warning).toContain("agent left 1 commit on 'agents/foo'");
+    expect(warning).toContain('d83c5d4 fix: thing');
+    expect(warning).toContain('git -C "/repo" push -u origin agents/foo');
+    expect(warning).toContain('gh pr create --head agents/foo');
+  });
+
+  it('uses a bare `git push` when an upstream exists, and caps the list at 5', () => {
+    const unpushed = Array.from({ length: 7 }, (_, i) => ({ sha: `sha${i}`, subject: `c${i}` }));
+    const warning = formatUnpushedWarning(
+      { isRepo: true, branch: 'b', hasUpstream: true, unpushed },
+      '/r',
+    )!;
+    expect(warning).toContain('git -C "/r" push');
+    expect(warning).not.toContain('push -u');
+    expect(warning).toContain('… and 2 more');
+    expect(warning).toContain('agent left 7 commits');
+  });
+});

--- a/apps/cli/src/lib/warn-unpushed.test.ts
+++ b/apps/cli/src/lib/warn-unpushed.test.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { spawnSync } from 'child_process';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getUnpushedState, formatUnpushedWarning, warnUnpushedWork } from './warn-unpushed.js';
+import { getUnpushedState, formatUnpushedWarning, warnUnpushedWork, shouldWarnUnpushed } from './warn-unpushed.js';
 
 const tempDirs: string[] = [];
 
@@ -163,6 +163,23 @@ describe('warnUnpushedWork (wired entry point)', () => {
   it('never throws on a non-git directory', async () => {
     const dir = makeTempDir('warn-unpushed-safe-');
     await expect(warnUnpushedWork(dir)).resolves.toBeUndefined();
+  });
+});
+
+describe('shouldWarnUnpushed (the exit-path gate)', () => {
+  it('fires for writable headless runs', () => {
+    expect(shouldWarnUnpushed('edit', false)).toBe(true);
+    expect(shouldWarnUnpushed('skip', false)).toBe(true);
+    expect(shouldWarnUnpushed('auto', false)).toBe(true);
+  });
+
+  it('stays silent for read-only plan mode, even headless', () => {
+    expect(shouldWarnUnpushed('plan', false)).toBe(false);
+  });
+
+  it('stays silent for interactive runs, even in a writable mode', () => {
+    expect(shouldWarnUnpushed('edit', true)).toBe(false);
+    expect(shouldWarnUnpushed('skip', true)).toBe(false);
   });
 });
 

--- a/apps/cli/src/lib/warn-unpushed.test.ts
+++ b/apps/cli/src/lib/warn-unpushed.test.ts
@@ -2,8 +2,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { spawnSync } from 'child_process';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { getUnpushedState, formatUnpushedWarning } from './warn-unpushed.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getUnpushedState, formatUnpushedWarning, warnUnpushedWork } from './warn-unpushed.js';
 
 const tempDirs: string[] = [];
 
@@ -116,6 +116,53 @@ describe('getUnpushedState', () => {
     const state = await getUnpushedState(work);
     expect(state.branch).toBeNull();
     expect(formatUnpushedWarning(state, work)).toBeNull();
+  });
+
+  it('detects unpushed commits inside a git worktree on a feature branch (the target flow)', async () => {
+    // The primary real-world case: an agent creates a worktree on its own
+    // branch and commits there. The commit is NOT reachable from the main
+    // checkout's HEAD, so inspecting the worktree path is what surfaces it.
+    const { work, commit } = makeRepoWithRemote();
+    commit('chore: base');
+    git(work, 'push', '-u', 'origin', 'main');
+
+    const wt = path.join(work, '.wt-feature');
+    git(work, 'worktree', 'add', '-b', 'agents/feature', wt, 'HEAD');
+    fs.writeFileSync(path.join(wt, 'w.txt'), 'work');
+    git(wt, 'add', '-A');
+    git(wt, '-c', 'user.email=t@e.co', '-c', 'user.name=T', 'commit', '-m', 'feat: work in worktree');
+
+    const state = await getUnpushedState(wt);
+    expect(state.branch).toBe('agents/feature');
+    expect(state.hasUpstream).toBe(false);
+    expect(state.unpushed.map((c) => c.subject)).toEqual(['feat: work in worktree']);
+  });
+});
+
+describe('warnUnpushedWork (wired entry point)', () => {
+  it('writes a warning to stderr for unpushed work, and nothing once pushed', async () => {
+    const { work, commit } = makeRepoWithRemote();
+    commit('feat: only');
+
+    const spy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    try {
+      await warnUnpushedWork(work);
+      const printed = spy.mock.calls.map((c) => String(c[0])).join('');
+      expect(printed).toContain("not pushed to any remote");
+      expect(printed).toContain('feat: only');
+
+      spy.mockClear();
+      git(work, 'push', '-u', 'origin', 'main');
+      await warnUnpushedWork(work);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('never throws on a non-git directory', async () => {
+    const dir = makeTempDir('warn-unpushed-safe-');
+    await expect(warnUnpushedWork(dir)).resolves.toBeUndefined();
   });
 });
 

--- a/apps/cli/src/lib/warn-unpushed.ts
+++ b/apps/cli/src/lib/warn-unpushed.ts
@@ -19,6 +19,16 @@ const execFileAsync = promisify(execFile);
 // a commit subject, so splitting on it never truncates a subject with spaces.
 const SEP = '\x1f';
 
+/**
+ * Whether a just-finished run should be checked for stranded work: only
+ * writable modes can leave commits (plan is read-only), and only non-interactive
+ * runs need the warning (an interactive user sees their own shell). Centralizes
+ * the gate so every exit path in the run command applies it identically.
+ */
+export function shouldWarnUnpushed(mode: string, interactive: boolean): boolean {
+  return mode !== 'plan' && !interactive;
+}
+
 export interface UnpushedState {
   /** cwd is inside a git work tree. */
   isRepo: boolean;

--- a/apps/cli/src/lib/warn-unpushed.ts
+++ b/apps/cli/src/lib/warn-unpushed.ts
@@ -1,0 +1,132 @@
+/**
+ * Post-run guard against silently stranded work.
+ *
+ * A headless `agents run` in a writable mode can end with the agent having
+ * committed on a branch but never pushed it — the CLI's exit path does no git
+ * work, so those commits sit invisible in a worktree until someone audits the
+ * box. This module detects that state and prints a loud stderr warning with the
+ * exact push / PR commands. It is advisory only: it never pushes, never mutates
+ * the repo, and never throws (a non-repo cwd or any git error yields an inert
+ * result), so it can sit on the run's exit path without ever breaking it.
+ */
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import chalk from 'chalk';
+
+const execFileAsync = promisify(execFile);
+
+// Unit-separator byte (0x1f) as the git-log field delimiter: it cannot occur in
+// a commit subject, so splitting on it never truncates a subject with spaces.
+const SEP = '\x1f';
+
+export interface UnpushedState {
+  /** cwd is inside a git work tree. */
+  isRepo: boolean;
+  /** current branch, or null when detached / not a repo. */
+  branch: string | null;
+  /** the branch has an upstream tracking ref configured. */
+  hasUpstream: boolean;
+  /** commits reachable from HEAD but not from any remote-tracking ref. */
+  unpushed: { sha: string; subject: string }[];
+}
+
+const INERT: UnpushedState = { isRepo: false, branch: null, hasUpstream: false, unpushed: [] };
+
+async function git(args: string[], cwd: string): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd });
+  return stdout.trim();
+}
+
+/**
+ * Inspect `cwd` for commits on the current branch that have not reached any
+ * remote. Uses `git log --not --remotes` so it is correct even when the branch
+ * has no upstream set: commits already present on some `origin/*` ref are NOT
+ * reported (no false positive), and a never-pushed branch reports all its
+ * commits. Returns an inert result — never throws — for a non-repo cwd, a
+ * detached HEAD, or a repo with no remotes (nothing to push to).
+ */
+export async function getUnpushedState(cwd: string): Promise<UnpushedState> {
+  let branch: string;
+  try {
+    branch = await git(['rev-parse', '--abbrev-ref', 'HEAD'], cwd);
+  } catch {
+    return INERT; // not a git repo
+  }
+  // Detached HEAD: agents commit on branches; nothing nameable to push.
+  if (!branch || branch === 'HEAD') {
+    return { isRepo: true, branch: null, hasUpstream: false, unpushed: [] };
+  }
+
+  // No remote configured -> `--remotes` matches nothing and would report the
+  // entire history as "unpushed". There's nowhere to push, so stay silent.
+  let hasRemote = false;
+  try {
+    hasRemote = (await git(['remote'], cwd)).length > 0;
+  } catch {
+    hasRemote = false;
+  }
+  if (!hasRemote) {
+    return { isRepo: true, branch, hasUpstream: false, unpushed: [] };
+  }
+
+  let unpushed: { sha: string; subject: string }[] = [];
+  try {
+    // HEAD must precede `--not`: everything after `--not` is negated, so
+    // `--not --remotes HEAD` would negate HEAD too and always return empty.
+    const out = await git(['log', 'HEAD', '--not', '--remotes', `--pretty=format:%h${SEP}%s`], cwd);
+    unpushed = out
+      ? out.split('\n').map((line) => {
+          const idx = line.indexOf(SEP);
+          return idx === -1
+            ? { sha: line, subject: '' }
+            : { sha: line.slice(0, idx), subject: line.slice(idx + 1) };
+        })
+      : [];
+  } catch {
+    return { isRepo: true, branch, hasUpstream: false, unpushed: [] };
+  }
+
+  let hasUpstream = false;
+  try {
+    await git(['rev-parse', '--abbrev-ref', '@{u}'], cwd);
+    hasUpstream = true;
+  } catch {
+    hasUpstream = false;
+  }
+
+  return { isRepo: true, branch, hasUpstream, unpushed };
+}
+
+/**
+ * Render the warning for an unpushed state, or null when there is nothing to
+ * warn about. Split out from the printer so it is directly testable.
+ */
+export function formatUnpushedWarning(state: UnpushedState, cwd: string): string | null {
+  if (!state.isRepo || !state.branch || state.unpushed.length === 0) return null;
+
+  const n = state.unpushed.length;
+  const lines = [`\n⚠ agent left ${n} commit${n === 1 ? '' : 's'} on '${state.branch}' not pushed to any remote:`];
+  for (const c of state.unpushed.slice(0, 5)) lines.push(`    ${c.sha} ${c.subject}`);
+  if (n > 5) lines.push(`    … and ${n - 5} more`);
+
+  const pushCmd = state.hasUpstream
+    ? `git -C "${cwd}" push`
+    : `git -C "${cwd}" push -u origin ${state.branch}`;
+  lines.push(`  push them:  ${pushCmd}`);
+  lines.push(`  open a PR:  gh pr create --head ${state.branch}`);
+  return lines.join('\n');
+}
+
+/**
+ * If the just-finished run left committed-but-unpushed work in `cwd`, print a
+ * loud stderr warning with the exact push / PR commands. Non-fatal by contract:
+ * any failure is swallowed so it can never break a run's exit path.
+ */
+export async function warnUnpushedWork(cwd: string): Promise<void> {
+  try {
+    const warning = formatUnpushedWarning(await getUnpushedState(cwd), cwd);
+    if (warning) process.stderr.write(chalk.yellow(warning) + '\n');
+  } catch {
+    // Advisory only — never break the run over a warning.
+  }
+}

--- a/apps/cli/src/lib/warn-unpushed.ts
+++ b/apps/cli/src/lib/warn-unpushed.ts
@@ -33,7 +33,9 @@ export interface UnpushedState {
 const INERT: UnpushedState = { isRepo: false, branch: null, hasUpstream: false, unpushed: [] };
 
 async function git(args: string[], cwd: string): Promise<string> {
-  const { stdout } = await execFileAsync('git', args, { cwd });
+  // These are all local, non-prompting reads, but the call sits on a run's exit
+  // path — a hard timeout guarantees a wedged git can never delay exit unbounded.
+  const { stdout } = await execFileAsync('git', args, { cwd, timeout: 5000 });
   return stdout.trim();
 }
 


### PR DESCRIPTION
## Problem

A headless `agents run` in a writable mode (`edit`/`skip`) can end with the agent having **committed on a branch but never pushed it**. The run's exit path (`apps/cli/src/commands/exec.ts:1647-1667`) does zero git work — it cleans up workflow config, writes one audit line, and `process.exit`. So committed-but-unpushed work sits **silently stranded** in a worktree until someone audits the box. Nothing in the product enforces or even surfaces the push; whether work escapes depends entirely on what the agent was told to do.

## Fix (advisory warning — the safe default)

After a **non-interactive, writable** run, detect commits on `HEAD` that have not reached any remote and print a loud stderr warning with the exact push / PR commands. Rendered output (real run against a repo with 2 unpushed commits):

```
⚠ agent left 2 commits on 'main' not pushed to any remote:
    0af0dcb test: add regression coverage
    7b69a15 fix(cli): case-insensitive agent name match in resolvePackageIDWithRegistry
  push them:  git -C "/path/to/repo" push -u origin main
  open a PR:  gh pr create --head main
```

Advisory **only**: never pushes, never mutates the repo, never throws (a non-repo cwd or any git error yields an inert result), so it can never break a run's exit path. Skipped for interactive runs (the human sees their shell) and for read-only `plan` mode (can't commit).

## Design notes

- Detection uses `git log HEAD --not --remotes` — correct even when the branch has **no upstream** set: commits already on some `origin/*` ref are not reported (no false positive), a never-pushed branch reports all its commits. (`HEAD` must precede `--not`, or `--not` negates `HEAD` too — the test suite caught exactly this.)
- Repos with **no remote** stay silent (nowhere to push).
- Gated with `resolveInteractive(execOptions)` — the same helper the exec path already uses — so no new notion of "headless" is invented.

## Files
- `apps/cli/src/lib/warn-unpushed.ts` — `getUnpushedState` + `formatUnpushedWarning` + `warnUnpushedWork`
- `apps/cli/src/commands/exec.ts` — one import + one gated call on the exit path
- `apps/cli/src/lib/warn-unpushed.test.ts` — real-git suite (no mocking): unpushed / pushed / no-upstream-but-on-remote / no-remote / non-repo / detached-HEAD / subject-with-spaces

## Verification
- `vitest run warn-unpushed.test.ts` — **9/9 pass**
- `bun run build` (full `tsc`) — clean
- End-to-end: built `dist` module prints the warning above on an unpushed repo, silent after push