### PR TITLE
feat(factory): Recap — a fleet-wide work ledger of finished sessions

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ### Added
 
+- **Recap — a work ledger for "what happened while I was away".** A new Recap center
+  (clock button on the rail, Recap tab in the strip) lists finished sessions across the
+  whole fleet, grouped by day, each with its task line, project · host · branch, ticket,
+  a PR link, and the session's real duration and cost. Day headers roll up sessions,
+  spend, and PRs (e.g. "Today — 12 sessions · $18.40 · 3 PRs"). No new bookkeeping: the
+  CLI's `agents sessions` metrics (`durationMs`, `costUsd`, `tokenCount`) were already
+  computed per session and are now carried through instead of dropped. Live sessions are
+  excluded — the feed owns what's running, the ledger owns what finished.
 - **The backlog now shows who is already working each ticket.** A ticket an agent
   carries gets an in-flight chip on its row (phase dot + agent abbr, `+N` when several
   are on it; hover for the full roster), and the ticket detail pane gains an **In

--- a/apps/factory/src/core/remoteSessions.test.ts
+++ b/apps/factory/src/core/remoteSessions.test.ts
@@ -9,6 +9,7 @@ import {
   resolveProject,
   normalizeActiveSession,
   normalizeActiveSessions,
+  normalizeRecentSession,
   normalizeQuestion,
   dedupeSessions,
   enrichWithSessionContent,
@@ -626,5 +627,34 @@ describe('staleness — long-dead sessions drop out of running / needs-you', () 
     const unknown = mk({ sessionId: 'cccc3333', lastActivityMs: 0, startedAtMs: 0 });
     const kept = filterStaleSessions([fresh, stale, unknown], NOW);
     expect(kept.map((s) => s.sessionId).sort()).toEqual(['aaaa1111', 'cccc3333']);
+  });
+});
+
+describe('normalizeRecentSession outcome metrics', () => {
+  const base = {
+    id: 'abc-123',
+    agent: 'Claude',
+    timestamp: '2026-07-10T10:00:00.000Z',
+    lastActivity: '2026-07-10T10:42:00.000Z',
+    cwd: '/repo',
+    topic: 'Ship the recap',
+  };
+
+  test('carries durationMs / costUsd / tokenCount through, coercing numeric strings', () => {
+    const s = normalizeRecentSession(
+      { ...base, durationMs: '2562344', costUsd: 5.6019435, tokenCount: '2849270' },
+      'zion',
+      Date.parse('2026-07-10T11:00:00.000Z'),
+    );
+    expect(s.durationMs).toBe(2562344);
+    expect(s.costUsd).toBeCloseTo(5.6019435);
+    expect(s.tokenCount).toBe(2849270);
+  });
+
+  test('missing or garbage metrics land as 0, never NaN', () => {
+    const s = normalizeRecentSession({ ...base, costUsd: 'n/a' }, 'zion', Date.now());
+    expect(s.durationMs).toBe(0);
+    expect(s.costUsd).toBe(0);
+    expect(s.tokenCount).toBe(0);
   });
 });

--- a/apps/factory/src/core/remoteSessions.ts
+++ b/apps/factory/src/core/remoteSessions.ts
@@ -201,6 +201,12 @@ export interface RemoteSession {
   /** Where the session is currently being viewed, pre-formatted by the CLI (e.g.
    *  "Codium tab 3", "Ghostty tab 2", "detached"). '' when the CLI supplies none. */
   viewingIn: string;
+  /** Outcome fields, populated only for RECENT (historical) sessions — the flat
+   *  `agents sessions --json` payload carries them; the --active payload does not.
+   *  0 when unknown. These drive the Recap ledger (duration/cost per session). */
+  durationMs?: number;
+  costUsd?: number;
+  tokenCount?: number;
 }
 
 /** One machine's worth of sessions plus its reachability + freshness stamp. */
@@ -304,6 +310,16 @@ const TICKET_RE = /\b[A-Z][A-Z0-9]*-\d+\b/;
  */
 function asStr(v: unknown): string {
   return typeof v === 'string' ? v : '';
+}
+
+/** Coerce a CLI-emitted numeric field (number, or numeric string) to a number; 0 otherwise. */
+function asNum(v: unknown): number {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (typeof v === 'string' && v.trim() !== '') {
+    const n = Number(v);
+    if (Number.isFinite(n)) return n;
+  }
+  return 0;
 }
 
 /**
@@ -483,6 +499,11 @@ export interface RawRecentSession {
   topic?: string;
   label?: string;
   machine?: string;
+  // Outcome metrics the CLI computes per session (may arrive as numeric strings).
+  durationMs?: number | string;
+  costUsd?: number | string;
+  tokenCount?: number | string;
+  messageCount?: number | string;
 }
 
 /** Map a recent (historical, non-active) SessionMeta onto RemoteSession. Recent =
@@ -536,6 +557,11 @@ export function normalizeRecentSession(
     // client to resolve, so both are empty (the required-string default).
     tmuxPane: '',
     viewingIn: '',
+    // Outcome metrics for the Recap ledger. The CLI emits these on the flat
+    // SessionMeta payload; coerce defensively (numeric strings observed in the wild).
+    durationMs: asNum(raw.durationMs),
+    costUsd: asNum(raw.costUsd),
+    tokenCount: asNum(raw.tokenCount),
   };
 }
 

--- a/apps/factory/src/vscode/remoteSessions.vscode.ts
+++ b/apps/factory/src/vscode/remoteSessions.vscode.ts
@@ -347,6 +347,27 @@ export async function fetchRecentForHost(
   }
 }
 
+/**
+ * Recap fan-out: recent (historical) sessions across the WHOLE fleet — the local
+ * machine plus every online registered device — flattened and sorted by last
+ * activity, newest first. Feeds the Floor's Recap ledger ("what happened while I
+ * was away"), so unlike fetchRecentForHost's lazy per-host path this sweeps all
+ * hosts at once. Unreachable hosts contribute nothing (fetchRecentForHost already
+ * swallows per-host failures); the sweep itself never throws.
+ */
+export async function fetchRecapSessions(
+  limitPerHost: number,
+  projectRules: ProjectRule[],
+): Promise<RemoteSession[]> {
+  const hosts = await discoverHosts();
+  const targets = hosts.filter((h) => h.isLocal || h.online);
+  const results = await Promise.allSettled(
+    targets.map((h) => fetchRecentForHost(h.isLocal ? LOCAL_LABEL : h.address, h.isLocal, h.name, limitPerHost, projectRules)),
+  );
+  const sessions = results.flatMap((r) => (r.status === 'fulfilled' ? r.value : []));
+  return sessions.sort((a, b) => (b.lastActivityMs || b.startedAtMs) - (a.lastActivityMs || a.startedAtMs));
+}
+
 export interface HostSessionsResult {
   hosts: HostInfo[];
   sessions: RemoteSession[];

--- a/apps/factory/src/vscode/settings.vscode.ts
+++ b/apps/factory/src/vscode/settings.vscode.ts
@@ -2033,6 +2033,21 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
         }
         break;
       }
+      case 'fetchRecap': {
+        // Recap ledger: recent (ended) sessions across the WHOLE fleet — local +
+        // every online registered device — with the CLI's per-session outcome
+        // metrics (duration/cost/tokens). Fetched lazily when the Recap center
+        // opens; rides its own 'recapSessions' message.
+        try {
+          const { fetchRecapSessions } = await import('./remoteSessions.vscode');
+          const sessions = await fetchRecapSessions(20, getSettings(context).projectRules ?? []);
+          settingsPanel?.webview.postMessage({ type: 'recapSessions', sessions });
+        } catch (err) {
+          console.error('[SETTINGS] Error fetching recap sessions:', err);
+          settingsPanel?.webview.postMessage({ type: 'recapSessions', sessions: [] });
+        }
+        break;
+      }
       case 'fetchHostInventory': {
         // Host detail pane: installed agents/versions/accounts/usage/resources on
         // one host (over SSH for remotes) + registry metadata. Cached per host.

--- a/apps/factory/ui/settings/components/mission-control/FloorRail.test.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorRail.test.tsx
@@ -75,6 +75,13 @@ describe('railActive', () => {
     expect(railActive('queue', base)).toBe(false)
   })
 
+  test('recap follows the recap center', () => {
+    expect(railActive('recap', { ...base, center: 'recap' })).toBe(true)
+    expect(railActive('recap', base)).toBe(false)
+    // A lingering project filter cannot double-light while the recap center shows.
+    expect(railActive('projects', { ...base, center: 'recap', projFilter: 'swarmify' })).toBe(false)
+  })
+
   test('projects/hosts light while their filter narrows the agents center', () => {
     expect(railActive('projects', { ...base, projFilter: 'swarmify' })).toBe(true)
     expect(railActive('hosts', { ...base, hostFilter: 'zion' })).toBe(true)
@@ -84,11 +91,12 @@ describe('railActive', () => {
 
   test('at most one button lights for any combined state (prix-cloud repro)', () => {
     // needs chip lingering alongside a project or host scope: the scope wins.
-    const keys = ['all', 'needs', 'queue', 'projects', 'hosts'] as const
+    const keys = ['all', 'needs', 'queue', 'recap', 'projects', 'hosts'] as const
     const states: RailScopeState[] = [
       { ...base, needsOnly: true, projFilter: 'swarmify' },
       { ...base, needsOnly: true, hostFilter: 'zion' },
       { ...base, needsOnly: true, projFilter: 'swarmify', center: 'backlog' },
+      { ...base, needsOnly: true, projFilter: 'swarmify', center: 'recap' },
       { ...base, needsOnly: true },
       base,
     ]
@@ -148,7 +156,7 @@ describe('FloorRail render', () => {
   test('renders dispatch, three scopes, two flyout anchors, one expand — no dupes', () => {
     const html = renderToStaticMarkup(<FloorRail {...props} />)
     expect(html).toContain('rail-dispatch')
-    for (const label of ['All agents', 'Needs you', 'Backlog', 'Projects', 'Hosts', 'Expand sidebar']) {
+    for (const label of ['All agents', 'Needs you', 'Backlog', 'Recap', 'Projects', 'Hosts', 'Expand sidebar']) {
       expect(html.split(`aria-label="${label}"`).length - 1).toBe(1)
     }
   })

--- a/apps/factory/ui/settings/components/mission-control/FloorRail.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorRail.tsx
@@ -14,7 +14,7 @@ import {
 // click one to scope the feed to a project or host directly, without expanding into
 // the full FloorSidebar. The » button remains the single expand affordance.
 
-export type RailKey = 'all' | 'needs' | 'queue' | 'projects' | 'hosts'
+export type RailKey = 'all' | 'needs' | 'queue' | 'recap' | 'projects' | 'hosts'
 
 /** The scope state the rail reflects. needsOnly = the 'needs' status chip is active. */
 export interface RailScopeState {
@@ -36,6 +36,7 @@ export interface RailScopeState {
  */
 export function railActive(key: RailKey, s: RailScopeState): boolean {
   if (key === 'queue') return s.center === 'backlog'
+  if (key === 'recap') return s.center === 'recap'
   if (s.center !== 'agents') return false
   if (key === 'needs') return s.needsOnly && s.projFilter == null && s.hostFilter == null
   if (key === 'projects') return s.projFilter != null
@@ -168,6 +169,7 @@ export function FloorRail({
         {iconBtn('all', 'radar', 'All agents', () => scope(''), agents.length)}
         {iconBtn('needs', 'alert', 'Needs you', () => scope('__needs'), needs || undefined, true)}
         {iconBtn('queue', 'inbox', 'Backlog', () => scope('__queue'), tickets.length || undefined)}
+        {iconBtn('recap', 'clock', 'Recap', () => scope('__recap'))}
 
         <div className="rail-fly-anchor">
           {iconBtn('projects', 'folder', 'Projects', () => setFly((f) => (f === 'projects' ? null : 'projects')))}

--- a/apps/factory/ui/settings/components/mission-control/RecapPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/RecapPane.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import { Icon } from './icons'
+import { recapCost, type RecapDay, type RecapEntry } from './recapModel'
+
+// Recap ledger — "what happened while I was away". Day-grouped ended sessions
+// across the whole fleet, each with duration/cost from the CLI's session metrics
+// and PR/ticket artifacts. Data comes pre-shaped from buildRecap (recapModel.ts);
+// this component only renders.
+
+interface RecapPaneProps {
+  days: RecapDay[]
+  loading: boolean
+  /** Open a session's PR in the browser (ExtLink-style, raised to the host). */
+  onOpenUrl?: (url: string) => void
+}
+
+function RecapRow({ e, onOpenUrl }: { e: RecapEntry; onOpenUrl?: (url: string) => void }) {
+  const ago = agoLabel(e.lastActivityMs)
+  return (
+    <div className="recap-row">
+      <span className={`av ${e.abbr}`}>{e.abbr}</span>
+      <span className="rc-title" title={e.title}>{e.title}</span>
+      <span className="rc-meta">{e.project} · {e.host}{e.branch ? ` · ${e.branch}` : ''}</span>
+      {e.ticket && <span className="rc-ticket">{e.ticket}</span>}
+      {e.prUrl && (
+        <button type="button" className="rc-pr" title={e.prUrl} onClick={() => onOpenUrl?.(e.prUrl!)}>
+          <Icon name="gitBranch" size={11} /> PR
+        </button>
+      )}
+      {e.durationMs > 0 && <span className="rc-dur">{recapDuration(e.durationMs)}</span>}
+      {recapCost(e.costUsd) && <span className="rc-cost">{recapCost(e.costUsd)}</span>}
+      <span className="rc-ago">{ago}</span>
+    </div>
+  )
+}
+
+/** Minute-granular duration for a ledger row — "43m", "1h 12m". Seconds are noise here. */
+function recapDuration(ms: number): string {
+  const mins = Math.max(1, Math.round(ms / 60_000))
+  if (mins < 60) return `${mins}m`
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`
+}
+
+/** Compact "…ago" stamp for a ledger row (minute floor — seconds churn is noise here). */
+function agoLabel(ms: number): string {
+  const mins = Math.max(1, Math.round((Date.now() - ms) / 60_000))
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.round(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  return `${Math.round(hrs / 24)}d ago`
+}
+
+export function RecapPane({ days, loading, onOpenUrl }: RecapPaneProps) {
+  if (loading && days.length === 0) {
+    return <div className="feed recap-empty">Sweeping the fleet for recent sessions…</div>
+  }
+  if (days.length === 0) {
+    return <div className="feed recap-empty">No finished sessions yet — dispatch something and it lands here when it's done.</div>
+  }
+  return (
+    <div className="feed">
+      {days.map((d) => (
+        <React.Fragment key={d.label}>
+          <div className="feed-sec">
+            {d.label}
+            <span className="rc-rollup">
+              {d.sessions} session{d.sessions === 1 ? '' : 's'}
+              {d.costUsd > 0 ? ` · ${recapCost(d.costUsd)}` : ''}
+              {d.prs > 0 ? ` · ${d.prs} PR${d.prs === 1 ? '' : 's'}` : ''}
+            </span>
+            <span className="ln" />
+          </div>
+          {d.entries.map((e) => (
+            <RecapRow key={e.id} e={e} onOpenUrl={onOpenUrl} />
+          ))}
+        </React.Fragment>
+      ))}
+    </div>
+  )
+}

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -28,6 +28,8 @@ import { FloorSidebar } from './FloorSidebar'
 import { FloorRail } from './FloorRail'
 import { FloorSubtabs, openTaskTab, closeTaskTab, type FixedTab, type TaskTab } from './FloorSubtabs'
 import { BacklogCenter } from './BacklogCenter'
+import { RecapPane } from './RecapPane'
+import { buildRecap } from './recapModel'
 import { TaskDetail } from '../bench/TaskDetail'
 import type { FlatTask } from '../bench/TaskCard'
 import { TicketDetail } from './TicketDetail'
@@ -617,6 +619,9 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   // Recent (historical) sessions per host, fetched lazily only when a host filter has
   // 0 live agents — so an empty host shows recent work instead of a blank pane.
   const [recentByHost, setRecentByHost] = useState<Record<string, RemoteSessionLike[]>>({})
+  // Recap ledger: fleet-wide recent (ended) sessions. null = not fetched yet — the
+  // sweep is expensive (SSH fan-out), so it runs lazily when the Recap center opens.
+  const [recapSessions, setRecapSessions] = useState<RemoteSessionLike[] | null>(null)
   const [floorSort, setFloorSort] = useState<FloorSort>('needs')
   // Group the live feed by an axis (project/host/status/agent). Defaults to 'project'
   // so sessions cluster under the repo/Linear project they're working on (NEEDS YOU
@@ -745,6 +750,8 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
         const rh = typeof msg.host === 'string' ? msg.host : ''
         const recent = Array.isArray(msg.sessions) ? (msg.sessions as RemoteSessionLike[]) : []
         setRecentByHost((p) => ({ ...p, [rh]: recent }))
+      } else if (msg?.type === 'recapSessions') {
+        setRecapSessions(Array.isArray(msg.sessions) ? (msg.sessions as RemoteSessionLike[]) : [])
       }
     }
     window.addEventListener('message', onMsg)
@@ -1468,6 +1475,17 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     [hostFilter, hostHasNoActive, recentByHost, pinned, localHostName, projectRules]
   )
 
+  // Recap ledger: lazy fleet sweep the first time the Recap center opens; live
+  // sessions are excluded (the feed owns what's running, the ledger what finished).
+  useEffect(() => {
+    if (center === 'recap' && recapSessions === null) postMessage({ type: 'fetchRecap' })
+  }, [center, recapSessions])
+  const recapDays = useMemo(() => {
+    if (!recapSessions) return []
+    const liveIds = new Set(floorAgents.map((a) => a.sessionId).filter((id): id is string => !!id))
+    return buildRecap(recapSessions, liveIds, Date.now())
+  }, [recapSessions, floorAgents])
+
   const needsAgents = useMemo(() => scopedAgents.filter((a) => a.needs), [scopedAgents])
   const waitingAgents = useMemo(() => needsAgents.filter((a) => a.phase === 'waiting'), [needsAgents])
   const failedAgents = useMemo(() => needsAgents.filter((a) => a.phase === 'failed'), [needsAgents])
@@ -1624,6 +1642,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
 
   const onScope = useCallback((value: string) => {
     if (value === '__queue') { setCenter('backlog'); return }
+    if (value === '__recap') { setCenter('recap'); return }
     if (value === '__needs') {
       // A REAL needs-only view: toggle the same 'needs' status chip the controls bar
       // and saved views drive, so one filter mechanism serves all three surfaces.
@@ -1828,7 +1847,9 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     { center: 'backlog', label: 'Backlog', count: floorTickets.length },
     { center: 'projects', label: 'Projects', count: managedProjects.length },
     { center: 'host', label: 'Hosts', count: fleetDevices.length },
-  ], [floorAgents.length, needsAgents.length, floorTickets.length, managedProjects.length, fleetDevices.length])
+    // Recap count = today's finished sessions (0 until the lazy sweep has run).
+    { center: 'recap', label: 'Recap', count: recapDays[0]?.label === 'Today' ? recapDays[0].sessions : 0 },
+  ], [floorAgents.length, needsAgents.length, floorTickets.length, managedProjects.length, fleetDevices.length, recapDays])
 
   // Resolve the active task tab (if any) back to a bench FlatTask so its detail renders.
   const activeTab = activeTaskTab ? openTaskTabs.find((t) => t.id === activeTaskTab) ?? null : null
@@ -1875,6 +1896,12 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
       workers={floorWorkers}
       onSelectTicket={(id) => setSelectedTicketId(id)}
       onOpenTask={openTaskFromTicket}
+    />
+  ) : center === 'recap' ? (
+    <RecapPane
+      days={recapDays}
+      loading={recapSessions === null}
+      onOpenUrl={(url) => postMessage({ type: 'openExternal', url })}
     />
   ) : (
     <div className="feed">

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -412,6 +412,19 @@
 .swarmify-root .dflight .pr { font-family: "Geist Mono", monospace; font-size: 10px; color: var(--brand-600); }
 .swarmify-root .dflight-note { font-size: 11px; color: var(--status-pending); margin-top: 8px; }
 .swarmify-root .disp.caution { background: var(--status-pending); }
+/* Recap ledger — day-grouped ended sessions with duration/cost. */
+.swarmify-root .recap-empty { padding: 24px 16px; color: var(--ds-text-faint); font-size: 12.5px; }
+.swarmify-root .feed-sec .rc-rollup { margin-left: 8px; color: var(--ds-text-dim); font-weight: 600; font-size: 10.5px; }
+.swarmify-root .recap-row { display: flex; align-items: center; gap: 9px; padding: 8px 8px; border-bottom: 1px solid var(--ds-border-subtle); border-radius: var(--r-sm); }
+.swarmify-root .recap-row:hover { background: var(--ds-bg-panel); }
+.swarmify-root .recap-row .rc-title { flex: 1; min-width: 0; font-size: 12.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.swarmify-root .recap-row .rc-meta { flex: 0 1 auto; min-width: 0; color: var(--ds-text-dim); font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.swarmify-root .recap-row .rc-ticket { flex: 0 0 auto; font-family: "Geist Mono", monospace; font-size: 10px; color: var(--ds-text-dim); border: 1px solid var(--ds-border); border-radius: 999px; padding: 1px 7px; }
+.swarmify-root .recap-row .rc-pr { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 3px; font-family: "Geist Mono", monospace; font-size: 10px; font-weight: 700; color: var(--brand-600); background: none; border: 1px solid var(--ds-border); border-radius: 999px; padding: 1px 7px; cursor: pointer; }
+.swarmify-root .recap-row .rc-pr:hover { border-color: var(--brand-600); }
+.swarmify-root .recap-row .rc-dur { flex: 0 0 auto; font-family: "Geist Mono", monospace; font-size: 10.5px; color: var(--ds-text-dim); font-variant-numeric: tabular-nums; }
+.swarmify-root .recap-row .rc-cost { flex: 0 0 auto; font-family: "Geist Mono", monospace; font-size: 10.5px; color: var(--ds-text-muted); font-variant-numeric: tabular-nums; }
+.swarmify-root .recap-row .rc-ago { flex: 0 0 auto; width: 64px; text-align: right; color: var(--ds-text-faint); font-size: 10.5px; }
 .swarmify-root .dispatch-panel { background: var(--ds-bg); border: 1px solid var(--ds-border-subtle); border-radius: var(--r-lg); padding: 12px 14px; }
 .swarmify-root .dp-row { display: flex; align-items: center; gap: 10px; margin-top: 8px; }
 .swarmify-root .dp-k { width: 48px; font-size: 11px; color: var(--ds-text-dim); font-weight: 600; }

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
@@ -139,6 +139,9 @@ export interface RemoteSessionLike {
   worktreePath?: string
   sinceMs: number
   startedAtMs: number
+  /** Epoch ms of the most recent observed activity (session-file last write).
+   *  Recent (historical) sessions carry it from the CLI's lastActivity stamp. */
+  lastActivityMs?: number
   topic: string
   context: string
   cloudTaskId: string
@@ -151,6 +154,10 @@ export interface RemoteSessionLike {
   replyMuxSocket: string
   tmuxPane: string
   viewingIn?: string
+  /** Outcome metrics, populated only on RECENT (historical) sessions — Recap ledger. */
+  durationMs?: number
+  costUsd?: number
+  tokenCount?: number
 }
 
 // ---------- primitive helpers ----------

--- a/apps/factory/ui/settings/components/mission-control/floorModel.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.ts
@@ -322,7 +322,7 @@ export interface FloorTicket {
 
 // ---------- controls state ----------
 
-export type CenterMode = 'agents' | 'backlog' | 'host' | 'projects'
+export type CenterMode = 'agents' | 'backlog' | 'host' | 'projects' | 'recap'
 
 // Host detail pane payloads. Mirror of extension/src/core/hostInventory.ts —
 // the webview can't import from src/*, so the shape is redeclared here and

--- a/apps/factory/ui/settings/components/mission-control/recapModel.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/recapModel.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect } from 'bun:test'
+import { buildRecap, recapDayLabel, recapCost } from './recapModel'
+import type { RemoteSessionLike } from './floorAdapter'
+
+const NOW = Date.parse('2026-07-10T18:00:00') // local-time anchor for day labels
+
+function session(over: Partial<RemoteSessionLike>): RemoteSessionLike {
+  return {
+    host: 'zion',
+    sessionId: 's1',
+    agentType: 'claude',
+    cwd: '/repo',
+    project: 'agents-cli',
+    phase: 'idle',
+    activity: '',
+    tokPerSec: 0,
+    waitingForInput: false,
+    lastResponse: '',
+    prUrl: null,
+    ticket: null,
+    branch: 'main',
+    sinceMs: 0,
+    startedAtMs: NOW - 3_600_000,
+    lastActivityMs: NOW - 1_800_000,
+    topic: 'Ship the recap',
+    context: 'recent',
+    cloudTaskId: '',
+    cloudProvider: '',
+    teamName: '',
+    pid: 0,
+    transport: '',
+    replyRail: '',
+    replyMuxTarget: '',
+    replyMuxSocket: '',
+    tmuxPane: '',
+    durationMs: 1_800_000,
+    costUsd: 2.5,
+    tokenCount: 100_000,
+    ...over,
+  }
+}
+
+describe('recapDayLabel', () => {
+  test('today / yesterday / short date', () => {
+    expect(recapDayLabel(NOW - 60_000, NOW)).toBe('Today')
+    expect(recapDayLabel(NOW - 86_400_000, NOW)).toBe('Yesterday')
+    const older = recapDayLabel(NOW - 3 * 86_400_000, NOW)
+    expect(older).not.toBe('Today')
+    expect(older).not.toBe('Yesterday')
+    expect(older.length).toBeGreaterThan(2)
+  })
+})
+
+describe('recapCost', () => {
+  test('two decimals; empty when unknown', () => {
+    expect(recapCost(5.6019)).toBe('$5.60')
+    expect(recapCost(0)).toBe('')
+    expect(recapCost(Number.NaN)).toBe('')
+  })
+})
+
+describe('buildRecap', () => {
+  test('groups by day newest-first with per-day rollups', () => {
+    const days = buildRecap(
+      [
+        session({ sessionId: 'a', costUsd: 2.5, prUrl: 'https://github.com/x/y/pull/1' }),
+        session({ sessionId: 'b', lastActivityMs: NOW - 3_600_000, costUsd: 1.5, prUrl: null }),
+        session({ sessionId: 'c', lastActivityMs: NOW - 86_400_000, costUsd: 4 }),
+      ],
+      new Set(),
+      NOW,
+    )
+    expect(days.map((d) => d.label)).toEqual(['Today', 'Yesterday'])
+    expect(days[0]!.entries.map((e) => e.id)).toEqual(['a', 'b']) // newest first
+    expect(days[0]!.sessions).toBe(2)
+    expect(days[0]!.costUsd).toBeCloseTo(4)
+    expect(days[0]!.prs).toBe(1)
+    expect(days[1]!.sessions).toBe(1)
+  })
+
+  test('excludes live sessions and dedups by id', () => {
+    const days = buildRecap(
+      [session({ sessionId: 'live' }), session({ sessionId: 'x' }), session({ sessionId: 'x' })],
+      new Set(['live']),
+      NOW,
+    )
+    expect(days).toHaveLength(1)
+    expect(days[0]!.entries.map((e) => e.id)).toEqual(['x'])
+  })
+
+  test('drops sessions with no activity signal; falls back title chain', () => {
+    const days = buildRecap(
+      [
+        session({ sessionId: 'no-time', lastActivityMs: 0, startedAtMs: 0 }),
+        session({ sessionId: 'no-topic', topic: '', worktreeSlug: 'fix-rail', branch: 'feat' }),
+      ],
+      new Set(),
+      NOW,
+    )
+    expect(days).toHaveLength(1)
+    expect(days[0]!.entries).toHaveLength(1)
+    expect(days[0]!.entries[0]!.title).toBe('fix-rail')
+    expect(days[0]!.entries[0]!.abbr).toBe('CC')
+  })
+})

--- a/apps/factory/ui/settings/components/mission-control/recapModel.ts
+++ b/apps/factory/ui/settings/components/mission-control/recapModel.ts
@@ -1,0 +1,98 @@
+import { abbrFor, type RemoteSessionLike } from './floorAdapter'
+import type { AgentAbbr } from './floorModel'
+
+// Pure model for the Recap ledger — "what happened while I was away". Turns the
+// fleet-wide recent-session sweep (fetchRecapSessions) into day-grouped entries
+// with per-day rollups. No React, no fetching; unit-tested next to this file.
+
+export interface RecapEntry {
+  id: string
+  abbr: AgentAbbr
+  /** Task line: topic, else worktree slug, else branch, else the session id. */
+  title: string
+  project: string
+  host: string
+  branch: string
+  startedAtMs: number
+  lastActivityMs: number
+  durationMs: number
+  costUsd: number
+  tokenCount: number
+  prUrl: string | null
+  ticket: string | null
+}
+
+export interface RecapDay {
+  /** 'Today' / 'Yesterday' / 'Jul 8' — derived from lastActivity in local time. */
+  label: string
+  entries: RecapEntry[]
+  /** Rollup across the day's entries. */
+  sessions: number
+  costUsd: number
+  prs: number
+}
+
+/** 'Today' / 'Yesterday' / short local date for any older day. */
+export function recapDayLabel(ms: number, nowMs: number): string {
+  const day = new Date(ms)
+  const now = new Date(nowMs)
+  const startOf = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime()
+  const diffDays = Math.round((startOf(now) - startOf(day)) / 86_400_000)
+  if (diffDays <= 0) return 'Today'
+  if (diffDays === 1) return 'Yesterday'
+  return day.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+/** "$5.60" / "$0.42" — always two decimals; '' when unknown (0). */
+export function recapCost(usd: number): string {
+  if (!usd || !Number.isFinite(usd)) return ''
+  return `$${usd.toFixed(2)}`
+}
+
+/**
+ * Build the day-grouped ledger from the recap sweep. `liveIds` (session ids of
+ * agents currently on the live feed) are excluded — the ledger is what FINISHED,
+ * the feed is what's running. Dedup by session id (the same session can surface
+ * from two sweeps), newest activity first, grouped by local calendar day.
+ */
+export function buildRecap(sessions: RemoteSessionLike[], liveIds: Set<string>, nowMs: number): RecapDay[] {
+  const seen = new Set<string>()
+  const entries: RecapEntry[] = []
+  for (const s of sessions) {
+    if (!s.sessionId || liveIds.has(s.sessionId) || seen.has(s.sessionId)) continue
+    seen.add(s.sessionId)
+    const at = s.lastActivityMs || s.startedAtMs
+    if (!at) continue
+    entries.push({
+      id: s.sessionId,
+      abbr: abbrFor(s.agentType),
+      title: s.topic || s.worktreeSlug || s.branch || s.sessionId.slice(0, 8),
+      project: s.project,
+      host: s.host,
+      branch: s.branch,
+      startedAtMs: s.startedAtMs,
+      lastActivityMs: at,
+      durationMs: s.durationMs ?? 0,
+      costUsd: s.costUsd ?? 0,
+      tokenCount: s.tokenCount ?? 0,
+      prUrl: s.prUrl,
+      ticket: s.ticket,
+    })
+  }
+  entries.sort((a, b) => b.lastActivityMs - a.lastActivityMs)
+
+  const days: RecapDay[] = []
+  for (const e of entries) {
+    const label = recapDayLabel(e.lastActivityMs, nowMs)
+    let day = days[days.length - 1]
+    if (!day || day.label !== label) {
+      day = { label, entries: [], sessions: 0, costUsd: 0, prs: 0 }
+      days.push(day)
+    }
+    day.entries.push(e)
+    day.sessions += 1
+    day.costUsd += e.costUsd
+    if (e.prUrl) day.prs += 1
+  }
+  return days
+}

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -24,6 +24,9 @@ import { ProjectsPane } from '../components/mission-control/ProjectsPane'
 import { TerminalExpandedDetail } from '../components/mission-control/TerminalDetail'
 import { AgentDecision } from '../components/mission-control/AgentDecision'
 import { ticketWorkers, type FloorAgent, type FloorTicket, type StructuredQuestion, type FloorSort, type TicketGroupBy, type TicketSort, type CenterMode, type ManagedProject, type LinearProjectLite } from '../components/mission-control/floorModel'
+import { RecapPane } from '../components/mission-control/RecapPane'
+import { buildRecap } from '../components/mission-control/recapModel'
+import type { RemoteSessionLike } from '../components/mission-control/floorAdapter'
 import type { UnifiedTask, TerminalDetail } from '../types'
 import type { InstalledAgent, DispatchHost, DispatchTarget } from '../components/mission-control/dispatch.types'
 
@@ -577,6 +580,31 @@ function Ticket() {
   )
 }
 
+// Recap ledger — day-grouped ended sessions with duration/cost rollups (?view=recap).
+function Recap() {
+  const now = Date.now()
+  const rs = (over: Partial<RemoteSessionLike>): RemoteSessionLike => ({
+    host: 'zion', sessionId: Math.random().toString(36).slice(2), agentType: 'claude', cwd: '/repo',
+    project: 'agents-cli', phase: 'idle', activity: '', tokPerSec: 0, waitingForInput: false,
+    lastResponse: '', prUrl: null, ticket: null, branch: 'main', sinceMs: 0,
+    startedAtMs: now - 3_600_000, lastActivityMs: now - 1_800_000, topic: '', context: 'recent',
+    cloudTaskId: '', cloudProvider: '', teamName: '', pid: 0, transport: '', replyRail: '',
+    replyMuxTarget: '', replyMuxSocket: '', tmuxPane: '',
+    durationMs: 2_562_000, costUsd: 5.6, tokenCount: 2_849_270, ...over,
+  })
+  const days = buildRecap(
+    [
+      rs({ topic: 'Floor rail flyouts — Projects/Hosts menus, Dispatch button', prUrl: 'https://github.com/phnx-labs/agents-cli/pull/862', ticket: 'RUSH-1521', lastActivityMs: now - 40 * 60_000 }),
+      rs({ topic: 'In-flight ticket linkage on the backlog', agentType: 'codex', host: 'yosemite-s0', prUrl: 'https://github.com/phnx-labs/agents-cli/pull/866', costUsd: 3.2, durationMs: 1_100_000, lastActivityMs: now - 2 * 3_600_000 }),
+      rs({ topic: 'Fix PKCE http client pinning', agentType: 'gemini', host: 'mac-mini', project: 'rush', costUsd: 0.8, durationMs: 600_000, lastActivityMs: now - 26 * 3_600_000 }),
+      rs({ topic: 'Deploy agents on mac-mini and sync system repo', costUsd: 1.4, durationMs: 900_000, lastActivityMs: now - 27 * 3_600_000, branch: 'HEAD' }),
+    ],
+    new Set(),
+    now,
+  )
+  return <div className="feed-col"><RecapPane days={days} loading={false} onOpenUrl={noop} /></div>
+}
+
 function Preview() {
   const params = new URLSearchParams(location.search)
   const theme = params.get('theme') === 'light' ? 'theme-light' : 'theme-dark'
@@ -586,7 +614,7 @@ function Preview() {
     <div className={`swarmify-root ${theme}`} style={{ minHeight: '100vh' }}>
       <div className="sw-floor-dashboard" style={{ padding: 0 }}>
         <div className="page" style={{ display: 'flex' }}>
-          {view === 'sidebar' ? <Sidebar /> : view === 'subtabs' ? <Subtabs /> : view === 'projects' ? <div className="feed-col"><Projects /></div> : view === 'detail' ? <Detail /> : view === 'decision' ? <Decision /> : view === 'ticket' ? <Ticket /> : <div className="feed-col">{view === 'backlog' ? <Backlog /> : <Feed />}</div>}
+          {view === 'sidebar' ? <Sidebar /> : view === 'subtabs' ? <Subtabs /> : view === 'projects' ? <div className="feed-col"><Projects /></div> : view === 'detail' ? <Detail /> : view === 'decision' ? <Decision /> : view === 'ticket' ? <Ticket /> : view === 'recap' ? <Recap /> : <div className="feed-col">{view === 'backlog' ? <Backlog /> : <Feed />}</div>}
         </div>
       </div>
       <DispatchPanel


### PR DESCRIPTION
## Problem

Work evaporated when it finished. An agent card exists only while its terminal lives; history surfaced in exactly one place — recent sessions shown when a host filter had zero live agents. There was no "what happened while I was away", no per-day view of shipped work, and the CLI's per-session outcome metrics (`durationMs`, `costUsd`, `tokenCount` — visible in `agents sessions --json`) were parsed nowhere: `normalizeRecentSession` simply dropped them.

## Change

- **Recap center**: clock button on the rail + Recap tab in the strip. Finished sessions across the whole fleet, grouped by day (Today / Yesterday / Jul 8), each row with task line, project · host · branch, ticket chip, PR link (opens externally), minute-granular duration, and cost. Day headers roll up sessions · spend · PRs.
- **No new bookkeeping**: `RawRecentSession`/`normalizeRecentSession` now carry `durationMs`/`costUsd`/`tokenCount` (numeric-string coercion via a new `asNum`), mirrored on `RemoteSessionLike` (which also gains the `lastActivityMs` the wire always carried but the mirror never declared).
- **`fetchRecapSessions`** (vscode layer): `discoverHosts()` + local, `fetchRecentForHost` per target under `Promise.allSettled` — offline hosts contribute nothing, the sweep never throws. New `fetchRecap` message; fetched lazily on first open of the center.
- **Pure model** (`recapModel.ts`): `buildRecap(sessions, liveIds, nowMs)` dedups by session id, excludes live sessions (the feed owns running work, the ledger owns finished work), sorts newest-first, groups by local calendar day with rollups. `recapDayLabel`/`recapCost` alongside.
- Rail/subtab wiring: `CenterMode` gains `'recap'`, `railActive` treats it like backlog (center-following; the exactly-one-lit invariant extended and re-tested), `'__recap'` scope route.

## Evidence

- `bun test ui/settings/components/mission-control/ src/core/remoteSessions.test.ts`: 369 pass / 0 fail (new: buildRecap grouping/rollups/dedup/live-exclusion, day labels, cost formatting, normalizer metric coercion incl. numeric strings and garbage → 0, rail recap active-state).
- `bun run compile`: clean (extension tsc + both vite builds).
- Verified visually in the preview harness: `?view=recap` light + dark (day rollup "2 sessions · $8.80 · 2 PRs", PR/ticket chips, durations as "43m"), and `?view=sidebar` shows the clock button in the rail. Screenshots on zion: `/tmp/recap-light.png`, `/tmp/recap-dark.png`, `/tmp/rail-with-recap.png`.

Known limits (CLI payload, not this PR): no end-timestamp or exit state per session (`lastActivity` approximates "ended"), no files-changed count.

Session transcript (local, zion): `~/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/3a85fdd1-171d-4a73-9c62-64a002948cd0.jsonl`

Part 3 of the Floor tracking series (#862 rail flyouts, #866 in-flight linkage). Next: PR board, project rollups.