### PR TITLE
feat(factory): PR board — aggregate open PRs with CI, review, mergeable, and a guarded Merge

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ### Added
 
+- **PR board — every open PR the floor's agents produced, in one actionable list.**
+  A new PRs center tab aggregates the live feed's PR URLs and shows, per PR: CI
+  state, review decision (approved / changes requested / review required), merge
+  conflicts, a chip for the agent that owns it (jumps to its card), and a **Merge**
+  button that appears only when the PR is open, not draft, approved, CI-green, and
+  conflict-free. Rows are ranked for action: ready-to-merge first, then red CI /
+  conflicts, then changes-requested. Merge runs plain `gh pr merge --rebase` (never
+  `--admin` — branch protection stays in force); refusals surface inline on the row.
+
 - **The backlog now shows who is already working each ticket.** A ticket an agent
   carries gets an in-flight chip on its row (phase dot + agent abbr, `+N` when several
   are on it; hover for the full roster), and the ticket detail pane gains an **In

--- a/apps/factory/src/core/prBoard.test.ts
+++ b/apps/factory/src/core/prBoard.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+import { parsePrStatus } from './prBoard';
+
+const URL = 'https://github.com/phnx-labs/agents-cli/pull/900';
+
+function ghJson(over: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    number: 900,
+    title: 'feat: the thing',
+    state: 'OPEN',
+    isDraft: false,
+    reviewDecision: 'APPROVED',
+    mergeable: 'MERGEABLE',
+    statusCheckRollup: [
+      { status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { state: 'SUCCESS' },
+    ],
+    ...over,
+  });
+}
+
+describe('parsePrStatus', () => {
+  test('open + approved + green + mergeable -> readyToMerge', () => {
+    const s = parsePrStatus(URL, ghJson())!;
+    expect(s.state).toBe('open');
+    expect(s.review).toBe('approved');
+    expect(s.ci).toBe('passed');
+    expect(s.mergeable).toBe('mergeable');
+    expect(s.readyToMerge).toBe(true);
+  });
+
+  test('a pending check run means CI running, never ready', () => {
+    const s = parsePrStatus(URL, ghJson({ statusCheckRollup: [{ status: 'IN_PROGRESS' }, { status: 'COMPLETED', conclusion: 'SUCCESS' }] }))!;
+    expect(s.ci).toBe('running');
+    expect(s.readyToMerge).toBe(false);
+  });
+
+  test('a failed conclusion means CI failed, never ready', () => {
+    const s = parsePrStatus(URL, ghJson({ statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'FAILURE' }] }))!;
+    expect(s.ci).toBe('failed');
+    expect(s.readyToMerge).toBe(false);
+  });
+
+  test('changes requested / review required / conflicting / draft / merged all block the button', () => {
+    expect(parsePrStatus(URL, ghJson({ reviewDecision: 'CHANGES_REQUESTED' }))!.readyToMerge).toBe(false);
+    expect(parsePrStatus(URL, ghJson({ reviewDecision: 'REVIEW_REQUIRED' }))!.readyToMerge).toBe(false);
+    expect(parsePrStatus(URL, ghJson({ mergeable: 'CONFLICTING' }))!.readyToMerge).toBe(false);
+    expect(parsePrStatus(URL, ghJson({ isDraft: true }))!.readyToMerge).toBe(false);
+    expect(parsePrStatus(URL, ghJson({ state: 'MERGED' }))!.readyToMerge).toBe(false);
+  });
+
+  test('no checks at all -> ci null, still mergeable when approved', () => {
+    const s = parsePrStatus(URL, ghJson({ statusCheckRollup: [] }))!;
+    expect(s.ci).toBe(null);
+    expect(s.readyToMerge).toBe(true);
+  });
+
+  test('garbage or empty output -> null, never a fabricated row', () => {
+    expect(parsePrStatus(URL, '')).toBe(null);
+    expect(parsePrStatus(URL, 'not json')).toBe(null);
+    expect(parsePrStatus(URL, '{"title":"no number"}')).toBe(null);
+  });
+});

--- a/apps/factory/src/core/prBoard.ts
+++ b/apps/factory/src/core/prBoard.ts
@@ -1,0 +1,82 @@
+// Pure parsing of `gh pr view --json` into a board row: CI + review + mergeable +
+// a single readyToMerge verdict. The impure gh call + TTL cache live in the vscode
+// layer (prBoard.vscode.ts); this parser is pure so it is unit-tested and reusable.
+
+import { aggregateChecks, type CiStatus } from './prChecks';
+
+export type ReviewDecision = 'approved' | 'changes_requested' | 'review_required' | null;
+export type Mergeable = 'mergeable' | 'conflicting' | 'unknown';
+
+export interface PrStatus {
+  url: string;
+  number: number;
+  title: string;
+  state: 'open' | 'merged' | 'closed';
+  isDraft: boolean;
+  ci: CiStatus;
+  review: ReviewDecision;
+  mergeable: Mergeable;
+  /** Open, not draft, approved, CI not red/running, and no merge conflict — the
+   *  board's Merge button renders only when this is true. */
+  readyToMerge: boolean;
+}
+
+/** gh `statusCheckRollup` rows: CheckRun {status, conclusion} or StatusContext {state}. */
+interface RollupRow {
+  status?: string;
+  conclusion?: string;
+  state?: string;
+}
+
+/** Fold a rollup row onto the shape aggregateChecks (prChecks.ts) already handles. */
+function rollupToCheckRow(row: RollupRow): { state: string } {
+  const status = (row.status || '').toUpperCase();
+  if (status && status !== 'COMPLETED') return { state: 'PENDING' };
+  const conclusion = (row.conclusion || '').toUpperCase();
+  if (conclusion) return { state: conclusion };
+  return { state: (row.state || '').toUpperCase() };
+}
+
+/**
+ * Parse the stdout of
+ * `gh pr view <url> --json number,title,state,isDraft,reviewDecision,mergeable,statusCheckRollup`.
+ * Returns null on any parse failure so a bad gh result never fabricates a row.
+ */
+export function parsePrStatus(url: string, stdout: string): PrStatus | null {
+  const trimmed = stdout.trim();
+  if (!trimmed) return null;
+  try {
+    const d = JSON.parse(trimmed);
+    if (!d || typeof d !== 'object' || typeof d.number !== 'number') return null;
+    const rawState = String(d.state || '').toUpperCase();
+    const state: PrStatus['state'] = rawState === 'MERGED' ? 'merged' : rawState === 'CLOSED' ? 'closed' : 'open';
+    const rawReview = String(d.reviewDecision || '').toUpperCase();
+    const review: ReviewDecision =
+      rawReview === 'APPROVED' ? 'approved'
+      : rawReview === 'CHANGES_REQUESTED' ? 'changes_requested'
+      : rawReview === 'REVIEW_REQUIRED' ? 'review_required'
+      : null;
+    const rawMergeable = String(d.mergeable || '').toUpperCase();
+    const mergeable: Mergeable =
+      rawMergeable === 'MERGEABLE' ? 'mergeable' : rawMergeable === 'CONFLICTING' ? 'conflicting' : 'unknown';
+    const rollup: RollupRow[] = Array.isArray(d.statusCheckRollup) ? d.statusCheckRollup : [];
+    const ci = aggregateChecks(rollup.map(rollupToCheckRow));
+    const isDraft = d.isDraft === true;
+    const readyToMerge =
+      state === 'open' && !isDraft && review === 'approved' &&
+      ci !== 'failed' && ci !== 'running' && mergeable === 'mergeable';
+    return {
+      url,
+      number: d.number,
+      title: typeof d.title === 'string' ? d.title : '',
+      state,
+      isDraft,
+      ci,
+      review,
+      mergeable,
+      readyToMerge,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/factory/src/vscode/prBoard.vscode.ts
+++ b/apps/factory/src/vscode/prBoard.vscode.ts
@@ -1,0 +1,72 @@
+// Impure half of the PR board: `gh pr view` per URL with a short TTL cache and an
+// in-flight guard (mirrors swarm.vscode.ts's ciCache idiom), plus the merge action.
+// The pure JSON -> PrStatus parse lives in core/prBoard.ts.
+
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { parsePrStatus, type PrStatus } from '../core/prBoard';
+
+const execAsync = promisify(exec);
+
+const PR_TTL_MS = 45_000;
+const cache = new Map<string, { at: number; status: PrStatus | null }>();
+const inFlight = new Map<string, Promise<PrStatus | null>>();
+
+const GH_FIELDS = 'number,title,state,isDraft,reviewDecision,mergeable,statusCheckRollup';
+
+async function fetchOne(url: string): Promise<PrStatus | null> {
+  try {
+    const { stdout } = await execAsync(`gh pr view ${JSON.stringify(url)} --json ${GH_FIELDS}`, {
+      timeout: 10_000,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+    return parsePrStatus(url, stdout);
+  } catch {
+    // gh unavailable / auth / 404 — no row rather than a fabricated one.
+    return null;
+  }
+}
+
+/**
+ * Board statuses for a set of PR URLs. Each URL is fetched at most once per TTL
+ * window and never concurrently; misses (gh failure, closed URL) are dropped so
+ * the board only renders rows it can back with real data.
+ */
+export async function fetchPrStatuses(urls: string[]): Promise<PrStatus[]> {
+  const unique = [...new Set(urls.filter((u) => typeof u === 'string' && u.startsWith('https://')))];
+  const results = await Promise.all(
+    unique.map((url) => {
+      const cached = cache.get(url);
+      if (cached && Date.now() - cached.at <= PR_TTL_MS) return Promise.resolve(cached.status);
+      const pending = inFlight.get(url);
+      if (pending) return pending;
+      const p = fetchOne(url)
+        .then((status) => {
+          cache.set(url, { at: Date.now(), status });
+          return status;
+        })
+        .finally(() => inFlight.delete(url));
+      inFlight.set(url, p);
+      return p;
+    }),
+  );
+  return results.filter((s): s is PrStatus => s !== null);
+}
+
+/**
+ * Merge a PR from the board. Plain `gh pr merge --rebase` — deliberately NO
+ * --admin (branch protection stays in force) and no fallback strategy; the board
+ * only offers the button on readyToMerge (approved + green + mergeable), so a
+ * refusal here is a real signal surfaced back to the UI, not something to bypass.
+ */
+export async function mergePr(url: string): Promise<{ ok: boolean; error?: string }> {
+  try {
+    await execAsync(`gh pr merge ${JSON.stringify(url)} --rebase`, { timeout: 30_000 });
+    cache.delete(url);
+    return { ok: true };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // gh prints the useful reason on stderr, which exec folds into the message.
+    return { ok: false, error: msg.slice(0, 400) };
+  }
+}

--- a/apps/factory/src/vscode/settings.vscode.ts
+++ b/apps/factory/src/vscode/settings.vscode.ts
@@ -2033,6 +2033,34 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
         }
         break;
       }
+      case 'fetchPrBoard': {
+        // PR board: CI + review + mergeable per PR URL (TTL-cached gh pr view).
+        const urls = Array.isArray(message.urls) ? message.urls.filter((u: unknown) => typeof u === 'string') : [];
+        try {
+          const { fetchPrStatuses } = await import('./prBoard.vscode');
+          const statuses = await fetchPrStatuses(urls);
+          settingsPanel?.webview.postMessage({ type: 'prBoard', statuses });
+        } catch (err) {
+          console.error('[SETTINGS] Error fetching PR board:', err);
+          settingsPanel?.webview.postMessage({ type: 'prBoard', statuses: [] });
+        }
+        break;
+      }
+      case 'mergePr': {
+        // Board merge action. Plain --rebase, no --admin — branch protection stays
+        // in force; a refusal comes back to the row as an inline error.
+        const mergeUrl = typeof message.url === 'string' ? message.url : '';
+        try {
+          if (!mergeUrl) break;
+          const { mergePr } = await import('./prBoard.vscode');
+          const result = await mergePr(mergeUrl);
+          settingsPanel?.webview.postMessage({ type: 'mergePrResult', url: mergeUrl, ...result });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          settingsPanel?.webview.postMessage({ type: 'mergePrResult', url: mergeUrl, ok: false, error: msg });
+        }
+        break;
+      }
       case 'fetchHostInventory': {
         // Host detail pane: installed agents/versions/accounts/usage/resources on
         // one host (over SSH for remotes) + registry metadata. Cached per host.

--- a/apps/factory/ui/settings/components/mission-control/PrBoardPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/PrBoardPane.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { Icon } from './icons'
+import type { PrBoardRow } from './prBoardModel'
+
+// PR board — every open PR the floor's agents have produced, with CI + review +
+// mergeable state and a Merge button that appears only on readyToMerge rows
+// (approved + green + no conflict). Merging goes through the host's plain
+// `gh pr merge --rebase`; refusals come back as an inline row error.
+
+interface PrBoardPaneProps {
+  rows: PrBoardRow[]
+  loading: boolean
+  /** URLs with a merge in flight (button shows a busy state). */
+  merging: Set<string>
+  /** Per-URL inline merge errors (gh refusals). */
+  errors: Record<string, string>
+  onMerge: (url: string) => void
+  onOpenUrl: (url: string) => void
+  onRefresh: () => void
+  /** Jump to the owning agent's card. */
+  onSelectAgent?: (id: string) => void
+}
+
+function ciBadge(ci: PrBoardRow['ci']) {
+  if (!ci) return null
+  const label = ci === 'passed' ? 'CI passed' : ci === 'failed' ? 'CI failed' : 'CI running'
+  return <span className={`prb-ci ${ci}`}>{label}</span>
+}
+
+function reviewBadge(review: PrBoardRow['review']) {
+  if (!review) return null
+  const label = review === 'approved' ? 'Approved' : review === 'changes_requested' ? 'Changes requested' : 'Review required'
+  return <span className={`prb-rev ${review}`}>{label}</span>
+}
+
+export function PrBoardPane({ rows, loading, merging, errors, onMerge, onOpenUrl, onRefresh, onSelectAgent }: PrBoardPaneProps) {
+  if (loading && rows.length === 0) {
+    return <div className="feed prb-empty">Checking open pull requests…</div>
+  }
+  return (
+    <div className="feed">
+      <div className="feed-sec">
+        Pull requests
+        <span className="prb-count">{rows.filter((r) => r.state === 'open').length} open</span>
+        <span className="ln" />
+        <button type="button" className="prb-refresh" title="Refresh" onClick={onRefresh}>
+          <Icon name="refresh" size={12} />
+        </button>
+      </div>
+      {rows.length === 0 && (
+        <div className="prb-empty">No open PRs from the floor's agents — dispatch something that ships.</div>
+      )}
+      {rows.map((r) => (
+        <React.Fragment key={r.url}>
+          <div className={`prb-row${r.state !== 'open' ? ' settled' : ''}`}>
+            <button type="button" className="prb-num" title={r.url} onClick={() => onOpenUrl(r.url)}>
+              #{r.number}
+            </button>
+            <span className="prb-title" title={r.title}>{r.title}</span>
+            {r.owner && (
+              <button type="button" className="prb-owner" title={`${r.owner.name} · ${r.owner.hostLabel ?? r.owner.host}`} onClick={() => onSelectAgent?.(r.owner!.id)}>
+                {r.owner.abbr}
+              </button>
+            )}
+            {r.isDraft && <span className="prb-draft">draft</span>}
+            {r.state !== 'open' && <span className="prb-state">{r.state}</span>}
+            {ciBadge(r.ci)}
+            {reviewBadge(r.review)}
+            {r.mergeable === 'conflicting' && <span className="prb-conflict">conflicts</span>}
+            {r.readyToMerge && (
+              <button
+                type="button"
+                className="prb-merge"
+                disabled={merging.has(r.url)}
+                onClick={() => onMerge(r.url)}
+              >
+                {merging.has(r.url) ? 'Merging…' : 'Merge'}
+              </button>
+            )}
+          </div>
+          {errors[r.url] && <div className="prb-err" role="alert">{errors[r.url]}</div>}
+        </React.Fragment>
+      ))}
+    </div>
+  )
+}

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -28,6 +28,8 @@ import { FloorSidebar } from './FloorSidebar'
 import { FloorRail } from './FloorRail'
 import { FloorSubtabs, openTaskTab, closeTaskTab, type FixedTab, type TaskTab } from './FloorSubtabs'
 import { BacklogCenter } from './BacklogCenter'
+import { PrBoardPane } from './PrBoardPane'
+import { buildPrBoard, collectPrUrls, type PrStatusLike } from './prBoardModel'
 import { TaskDetail } from '../bench/TaskDetail'
 import type { FlatTask } from '../bench/TaskCard'
 import { TicketDetail } from './TicketDetail'
@@ -617,6 +619,11 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   // Recent (historical) sessions per host, fetched lazily only when a host filter has
   // 0 live agents — so an empty host shows recent work instead of a blank pane.
   const [recentByHost, setRecentByHost] = useState<Record<string, RemoteSessionLike[]>>({})
+  // PR board: statuses for every PR URL the live feed carries. null = not fetched
+  // yet (the gh fan-out runs lazily when the PRs center opens).
+  const [prStatuses, setPrStatuses] = useState<PrStatusLike[] | null>(null)
+  const [prMerging, setPrMerging] = useState<Set<string>>(() => new Set())
+  const [prErrors, setPrErrors] = useState<Record<string, string>>({})
   const [floorSort, setFloorSort] = useState<FloorSort>('needs')
   // Group the live feed by an axis (project/host/status/agent). Defaults to 'project'
   // so sessions cluster under the repo/Linear project they're working on (NEEDS YOU
@@ -745,6 +752,17 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
         const rh = typeof msg.host === 'string' ? msg.host : ''
         const recent = Array.isArray(msg.sessions) ? (msg.sessions as RemoteSessionLike[]) : []
         setRecentByHost((p) => ({ ...p, [rh]: recent }))
+      } else if (msg?.type === 'prBoard') {
+        setPrStatuses(Array.isArray(msg.statuses) ? (msg.statuses as PrStatusLike[]) : [])
+      } else if (msg?.type === 'mergePrResult') {
+        const mu = typeof msg.url === 'string' ? msg.url : ''
+        setPrMerging((prev) => { const next = new Set(prev); next.delete(mu); return next })
+        if (msg.ok === true) {
+          // Merged: refetch so the row settles (and any dependent rows update).
+          setPrStatuses(null)
+        } else {
+          setPrErrors((prev) => ({ ...prev, [mu]: typeof msg.error === 'string' ? msg.error : 'merge failed' }))
+        }
       }
     }
     window.addEventListener('message', onMsg)
@@ -1468,6 +1486,15 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     [hostFilter, hostHasNoActive, recentByHost, pinned, localHostName, projectRules]
   )
 
+  // PR board: lazy gh fan-out over the live feed's PR URLs on first open of the
+  // PRs center (and again after a merge clears prStatuses back to null).
+  useEffect(() => {
+    if (center === 'prs' && prStatuses === null) {
+      postMessage({ type: 'fetchPrBoard', urls: collectPrUrls(floorAgents) })
+    }
+  }, [center, prStatuses, floorAgents])
+  const prRows = useMemo(() => buildPrBoard(prStatuses ?? [], floorAgents), [prStatuses, floorAgents])
+
   const needsAgents = useMemo(() => scopedAgents.filter((a) => a.needs), [scopedAgents])
   const waitingAgents = useMemo(() => needsAgents.filter((a) => a.phase === 'waiting'), [needsAgents])
   const failedAgents = useMemo(() => needsAgents.filter((a) => a.phase === 'failed'), [needsAgents])
@@ -1828,7 +1855,9 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     { center: 'backlog', label: 'Backlog', count: floorTickets.length },
     { center: 'projects', label: 'Projects', count: managedProjects.length },
     { center: 'host', label: 'Hosts', count: fleetDevices.length },
-  ], [floorAgents.length, needsAgents.length, floorTickets.length, managedProjects.length, fleetDevices.length])
+    // PRs count = open rows once fetched; before the first fetch, the URL count.
+    { center: 'prs', label: 'PRs', count: prStatuses === null ? collectPrUrls(floorAgents).length : prRows.filter((r) => r.state === 'open').length },
+  ], [floorAgents, needsAgents.length, floorTickets.length, managedProjects.length, fleetDevices.length, prStatuses, prRows])
 
   // Resolve the active task tab (if any) back to a bench FlatTask so its detail renders.
   const activeTab = activeTaskTab ? openTaskTabs.find((t) => t.id === activeTaskTab) ?? null : null
@@ -1875,6 +1904,21 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
       workers={floorWorkers}
       onSelectTicket={(id) => setSelectedTicketId(id)}
       onOpenTask={openTaskFromTicket}
+    />
+  ) : center === 'prs' ? (
+    <PrBoardPane
+      rows={prRows}
+      loading={prStatuses === null}
+      merging={prMerging}
+      errors={prErrors}
+      onMerge={(url) => {
+        setPrMerging((prev) => new Set(prev).add(url))
+        setPrErrors((prev) => { const { [url]: _gone, ...rest } = prev; return rest })
+        postMessage({ type: 'mergePr', url })
+      }}
+      onOpenUrl={(url) => postMessage({ type: 'openExternal', url })}
+      onRefresh={() => setPrStatuses(null)}
+      onSelectAgent={selectFloorAgent}
     />
   ) : (
     <div className="feed">

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -412,6 +412,30 @@
 .swarmify-root .dflight .pr { font-family: "Geist Mono", monospace; font-size: 10px; color: var(--brand-600); }
 .swarmify-root .dflight-note { font-size: 11px; color: var(--status-pending); margin-top: 8px; }
 .swarmify-root .disp.caution { background: var(--status-pending); }
+/* PR board — CI / review / mergeable per PR, Merge only on ready rows. */
+.swarmify-root .prb-empty { padding: 24px 16px; color: var(--ds-text-faint); font-size: 12.5px; }
+.swarmify-root .feed-sec .prb-count { margin-left: 8px; color: var(--ds-text-dim); font-weight: 600; font-size: 10.5px; }
+.swarmify-root .feed-sec .prb-refresh { background: none; border: 0; padding: 2px; cursor: pointer; color: var(--ds-text-faint); display: inline-flex; }
+.swarmify-root .feed-sec .prb-refresh:hover { color: var(--ds-text); }
+.swarmify-root .prb-row { display: flex; align-items: center; gap: 9px; padding: 8px 8px; border-bottom: 1px solid var(--ds-border-subtle); border-radius: var(--r-sm); }
+.swarmify-root .prb-row:hover { background: var(--ds-bg-panel); }
+.swarmify-root .prb-row.settled { opacity: .55; }
+.swarmify-root .prb-num { flex: 0 0 auto; background: none; border: 0; padding: 0; cursor: pointer; font-family: "Geist Mono", monospace; font-size: 11px; font-weight: 700; color: var(--brand-600); }
+.swarmify-root .prb-title { flex: 1; min-width: 0; font-size: 12.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.swarmify-root .prb-owner { flex: 0 0 auto; background: none; cursor: pointer; font-family: "Geist Mono", monospace; font-size: 10px; font-weight: 700; color: var(--ds-text-dim); border: 1px solid var(--ds-border); border-radius: 999px; padding: 1px 7px; }
+.swarmify-root .prb-owner:hover { color: var(--ds-text); border-color: var(--ds-text-dim); }
+.swarmify-root .prb-draft, .swarmify-root .prb-state { flex: 0 0 auto; font-size: 10px; font-weight: 700; color: var(--ds-text-faint); text-transform: uppercase; letter-spacing: .04em; }
+.swarmify-root .prb-ci { flex: 0 0 auto; font-size: 10px; font-weight: 700; padding: 1px 7px; border-radius: 999px; }
+.swarmify-root .prb-ci.passed { background: var(--status-running-bg); color: var(--status-running); }
+.swarmify-root .prb-ci.failed { background: var(--status-failed-bg); color: var(--status-failed); }
+.swarmify-root .prb-ci.running { background: var(--status-pending-bg); color: var(--status-pending); }
+.swarmify-root .prb-rev { flex: 0 0 auto; font-size: 10px; font-weight: 700; padding: 1px 7px; border-radius: 999px; border: 1px solid var(--ds-border); color: var(--ds-text-dim); }
+.swarmify-root .prb-rev.approved { border-color: var(--status-running); color: var(--status-running); }
+.swarmify-root .prb-rev.changes_requested { border-color: var(--status-pending); color: var(--status-pending); }
+.swarmify-root .prb-conflict { flex: 0 0 auto; font-size: 10px; font-weight: 700; padding: 1px 7px; border-radius: 999px; background: var(--status-failed-bg); color: var(--status-failed); }
+.swarmify-root .prb-merge { flex: 0 0 auto; background: var(--brand); color: #1a1a1a; border: none; border-radius: var(--r-md); padding: 4px 12px; font-weight: 700; font-size: 11px; cursor: pointer; }
+.swarmify-root .prb-merge:disabled { opacity: .6; cursor: default; }
+.swarmify-root .prb-err { margin: 0 8px 6px 8px; padding: 6px 10px; border-radius: var(--r-sm); background: var(--status-failed-bg); color: var(--status-failed); font-size: 11px; font-family: "Geist Mono", monospace; white-space: pre-wrap; word-break: break-word; }
 .swarmify-root .dispatch-panel { background: var(--ds-bg); border: 1px solid var(--ds-border-subtle); border-radius: var(--r-lg); padding: 12px 14px; }
 .swarmify-root .dp-row { display: flex; align-items: center; gap: 10px; margin-top: 8px; }
 .swarmify-root .dp-k { width: 48px; font-size: 11px; color: var(--ds-text-dim); font-weight: 600; }

--- a/apps/factory/ui/settings/components/mission-control/floorModel.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.ts
@@ -322,7 +322,7 @@ export interface FloorTicket {
 
 // ---------- controls state ----------
 
-export type CenterMode = 'agents' | 'backlog' | 'host' | 'projects'
+export type CenterMode = 'agents' | 'backlog' | 'host' | 'projects' | 'prs'
 
 // Host detail pane payloads. Mirror of extension/src/core/hostInventory.ts —
 // the webview can't import from src/*, so the shape is redeclared here and

--- a/apps/factory/ui/settings/components/mission-control/prBoardModel.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/prBoardModel.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect } from 'bun:test'
+import { buildPrBoard, collectPrUrls, type PrStatusLike } from './prBoardModel'
+import type { FloorAgent } from './floorModel'
+
+function makeAgent(overrides: Partial<FloorAgent> = {}): FloorAgent {
+  return {
+    id: 'a1',
+    host: 'this-mac',
+    hostLabel: 'zion',
+    project: 'agents-cli',
+    name: 'rail-flyouts',
+    abbr: 'CC',
+    phase: 'done',
+    verb: '',
+    target: '',
+    tok: 0,
+    since: '2s',
+    lastActivityMs: 0,
+    files: 0,
+    tools: 0,
+    needs: false,
+    pinned: false,
+    pr: '#900',
+    prUrl: 'https://github.com/x/y/pull/900',
+    ci: null,
+    ticket: null,
+    branch: 'feat',
+    worktreeSlug: '',
+    worktreePath: '',
+    resp: '',
+    messages: [],
+    question: null,
+    reply: { kind: 'terminal', host: 'this-mac', terminalId: 'CC-1' },
+    todos: [],
+    summary: '',
+    recent: [],
+    ...overrides,
+  }
+}
+
+function status(over: Partial<PrStatusLike>): PrStatusLike {
+  return {
+    url: 'https://github.com/x/y/pull/900',
+    number: 900,
+    title: 'feat: thing',
+    state: 'open',
+    isDraft: false,
+    ci: 'passed',
+    review: 'approved',
+    mergeable: 'mergeable',
+    readyToMerge: true,
+    ...over,
+  }
+}
+
+describe('collectPrUrls', () => {
+  test('unique URLs, agents without a PR skipped', () => {
+    const urls = collectPrUrls([
+      makeAgent(),
+      makeAgent({ id: 'b', prUrl: 'https://github.com/x/y/pull/901' }),
+      makeAgent({ id: 'c' }), // same URL as a1
+      makeAgent({ id: 'd', pr: null, prUrl: null }),
+    ])
+    expect(urls).toEqual(['https://github.com/x/y/pull/900', 'https://github.com/x/y/pull/901'])
+  })
+})
+
+describe('buildPrBoard', () => {
+  test('orders for action: ready, red/conflicting, changes-requested, running, rest, settled', () => {
+    const rows = buildPrBoard(
+      [
+        status({ url: 'u-running', number: 1, readyToMerge: false, ci: 'running', review: null }),
+        status({ url: 'u-merged', number: 2, state: 'merged', readyToMerge: false }),
+        status({ url: 'u-ready', number: 3 }),
+        status({ url: 'u-changes', number: 4, readyToMerge: false, review: 'changes_requested' }),
+        status({ url: 'u-red', number: 5, readyToMerge: false, ci: 'failed' }),
+        status({ url: 'u-waiting', number: 6, readyToMerge: false, review: 'review_required', ci: 'passed' }),
+      ],
+      [],
+    )
+    expect(rows.map((r) => r.url)).toEqual(['u-ready', 'u-red', 'u-changes', 'u-running', 'u-waiting', 'u-merged'])
+  })
+
+  test('joins the owning agent by URL', () => {
+    const owner = makeAgent()
+    const rows = buildPrBoard([status({}), status({ url: 'u-orphan', number: 7 })], [owner])
+    expect(rows.find((r) => r.number === 900)?.owner?.id).toBe('a1')
+    expect(rows.find((r) => r.number === 7)?.owner).toBe(null)
+  })
+})

--- a/apps/factory/ui/settings/components/mission-control/prBoardModel.ts
+++ b/apps/factory/ui/settings/components/mission-control/prBoardModel.ts
@@ -1,0 +1,50 @@
+import type { FloorAgent } from './floorModel'
+
+// Pure model for the PR board. PrStatusLike mirrors src/core/prBoard.ts PrStatus
+// across the postMessage boundary; the join back to the agent that owns each PR
+// happens here so the board can show who produced the diff and jump to the card.
+
+export interface PrStatusLike {
+  url: string
+  number: number
+  title: string
+  state: 'open' | 'merged' | 'closed'
+  isDraft: boolean
+  ci: 'passed' | 'failed' | 'running' | null
+  review: 'approved' | 'changes_requested' | 'review_required' | null
+  mergeable: 'mergeable' | 'conflicting' | 'unknown'
+  readyToMerge: boolean
+}
+
+export interface PrBoardRow extends PrStatusLike {
+  /** The live agent that carries this PR, when one still does. */
+  owner: FloorAgent | null
+}
+
+/** Unique PR URLs across the live feed — the board's fetch set. */
+export function collectPrUrls(agents: FloorAgent[]): string[] {
+  const urls = new Set<string>()
+  for (const a of agents) if (a.prUrl) urls.add(a.prUrl)
+  return [...urls]
+}
+
+/**
+ * Join fetched statuses back onto their owning agents and order the board for
+ * action: ready-to-merge first, then failing CI, then changes-requested, then the
+ * rest; merged/closed sink to the bottom (they clear on the next fetch).
+ */
+export function buildPrBoard(statuses: PrStatusLike[], agents: FloorAgent[]): PrBoardRow[] {
+  const byUrl = new Map<string, FloorAgent>()
+  for (const a of agents) if (a.prUrl) byUrl.set(a.prUrl, a)
+  const rank = (s: PrStatusLike): number => {
+    if (s.state !== 'open') return 5
+    if (s.readyToMerge) return 0
+    if (s.ci === 'failed' || s.mergeable === 'conflicting') return 1
+    if (s.review === 'changes_requested') return 2
+    if (s.ci === 'running') return 3
+    return 4
+  }
+  return statuses
+    .map((s) => ({ ...s, owner: byUrl.get(s.url) ?? null }))
+    .sort((a, b) => rank(a) - rank(b) || b.number - a.number)
+}

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -19,6 +19,8 @@ import { FeedItem, TicketStrip } from '../components/mission-control/FeedItem'
 import { SavedViews } from '../components/mission-control/SavedViewsBar'
 import { DispatchPanel } from '../components/mission-control/DispatchPanel'
 import { BacklogCenter } from '../components/mission-control/BacklogCenter'
+import { PrBoardPane } from '../components/mission-control/PrBoardPane'
+import { buildPrBoard, type PrStatusLike } from '../components/mission-control/prBoardModel'
 import { TicketDetail } from '../components/mission-control/TicketDetail'
 import { ProjectsPane } from '../components/mission-control/ProjectsPane'
 import { TerminalExpandedDetail } from '../components/mission-control/TerminalDetail'
@@ -577,6 +579,30 @@ function Ticket() {
   )
 }
 
+// PR board — CI/review/mergeable badges + the ready-row Merge button (?view=prs).
+function PrBoard() {
+  const st = (over: Partial<PrStatusLike>): PrStatusLike => ({
+    url: 'https://github.com/phnx-labs/agents-cli/pull/142', number: 142,
+    title: 'feat(factory): floor rail flyouts — Projects/Hosts menus, Dispatch button',
+    state: 'open', isDraft: false, ci: 'passed', review: 'approved', mergeable: 'mergeable', readyToMerge: true,
+    ...over,
+  })
+  const rows = buildPrBoard(
+    [
+      st({}),
+      st({ url: 'u866', number: 866, title: 'feat(factory): in-flight ticket linkage on the backlog', ci: 'running', review: null, readyToMerge: false }),
+      st({ url: 'u869', number: 869, title: 'feat(factory): Recap — fleet-wide work ledger', ci: 'failed', review: 'changes_requested', readyToMerge: false }),
+      st({ url: 'u871', number: 871, title: 'chore: bump deps', mergeable: 'conflicting', review: 'review_required', ci: null, readyToMerge: false }),
+    ],
+    [reviewAgent],
+  )
+  return (
+    <div className="feed-col">
+      <PrBoardPane rows={rows} loading={false} merging={new Set(['u866'])} errors={{ u871: 'GraphQL: Pull Request has merge conflicts (mergePullRequest)' }} onMerge={noop} onOpenUrl={noop} onRefresh={noop} />
+    </div>
+  )
+}
+
 function Preview() {
   const params = new URLSearchParams(location.search)
   const theme = params.get('theme') === 'light' ? 'theme-light' : 'theme-dark'
@@ -586,7 +612,7 @@ function Preview() {
     <div className={`swarmify-root ${theme}`} style={{ minHeight: '100vh' }}>
       <div className="sw-floor-dashboard" style={{ padding: 0 }}>
         <div className="page" style={{ display: 'flex' }}>
-          {view === 'sidebar' ? <Sidebar /> : view === 'subtabs' ? <Subtabs /> : view === 'projects' ? <div className="feed-col"><Projects /></div> : view === 'detail' ? <Detail /> : view === 'decision' ? <Decision /> : view === 'ticket' ? <Ticket /> : <div className="feed-col">{view === 'backlog' ? <Backlog /> : <Feed />}</div>}
+          {view === 'sidebar' ? <Sidebar /> : view === 'subtabs' ? <Subtabs /> : view === 'projects' ? <div className="feed-col"><Projects /></div> : view === 'detail' ? <Detail /> : view === 'decision' ? <Decision /> : view === 'prs' ? <PrBoard /> : view === 'ticket' ? <Ticket /> : <div className="feed-col">{view === 'backlog' ? <Backlog /> : <Feed />}</div>}
         </div>
       </div>
       <DispatchPanel


### PR DESCRIPTION
## Problem

PR state was per-card and shallow: each agent card shows its own CI badge (`passed/failed/running`), but there was no aggregate "5 PRs open, 2 ready to merge" view, review decisions and merge conflicts weren't tracked anywhere, and the end-of-run babysitting (is it approved? did CI settle? does it conflict?) meant opening every PR in a browser tab.

## Change

- **Core (`prBoard.ts`)**: pure `parsePrStatus` over `gh pr view --json number,title,state,isDraft,reviewDecision,mergeable,statusCheckRollup`. Rollup rows (CheckRun status/conclusion + StatusContext state) fold onto the existing `aggregateChecks` from `prChecks.ts` — no duplicate classifier. `readyToMerge` = open ∧ not draft ∧ approved ∧ CI not red/running ∧ mergeable.
- **Host (`prBoard.vscode.ts`)**: `fetchPrStatuses(urls)` with a 45s TTL cache + in-flight guard per URL (the `ciCache` idiom); `mergePr(url)` runs a plain rebase merge — deliberately with NO admin bypass, so branch protection stays in force and a refusal is surfaced, not bypassed. New `fetchPrBoard` / `mergePr` messages.
- **Webview**: `prBoardModel.ts` (pure, tested) collects the feed's unique PR URLs, joins each status back to its owning agent, and ranks rows for action: ready-to-merge > red CI/conflicts > changes-requested > CI running > waiting; merged/closed sink. `PrBoardPane` renders badges + owner chip (jumps to the agent card) + the guarded Merge button with busy state and inline gh error; a PRs tab joins the center strip (`CenterMode` gains `'prs'`).

## Evidence

- `bun test ui/settings/components/mission-control/ src/core/prBoard.test.ts`: 312 pass / 0 fail (new: parsePrStatus truth table incl. pending/failed rollups, draft/merged/conflicting blocking the button, garbage → null; board ranking; owner join; URL collection).
- `bun run compile`: clean; no new strict-tsc errors in touched files.
- Verified visually in the preview harness (`?view=prs`): ready row with owner chip + lime Merge, conflicting row with inline `GraphQL: Pull Request has merge conflicts` error, CI-failed + changes-requested badges, busy "Merging…" state. Screenshot on zion: `/tmp/prboard-light.png`.

Session transcript (local, zion): `~/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/3a85fdd1-171d-4a73-9c62-64a002948cd0.jsonl`

Part 4 of the Floor tracking series (#862 rail flyouts, #866 in-flight linkage, #869 recap). Note: will need a trivial changelog/CenterMode reconcile once #869 lands (same `[Unreleased]` anchor). Next: project rollups.