### PR TITLE
feat(factory): project rollups — the flyout and Projects pane answer 'what's happening here'

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ### Added
 
+- **Project rollups — one glance answers "what's happening in this project".** The
+  rail's Projects flyout rows now carry dim sub-counts (open backlog tickets and
+  distinct open PRs) next to the live agent count, and each card in the Projects
+  pane gains an activity line — "3 running · 1 waiting · 4 backlog · 2 PRs ·
+  active 40m ago" (or "quiet") — all derived in one pass from the live feed and
+  backlog the Floor already holds.
 - **Recap — a work ledger for "what happened while I was away".** A new Recap center
   (clock button on the rail, Recap tab in the strip) lists finished sessions across the
   whole fleet, grouped by day, each with its task line, project · host · branch, ticket,

--- a/apps/factory/ui/settings/components/mission-control/FloorRail.test.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorRail.test.tsx
@@ -126,7 +126,22 @@ describe('railProjectRows', () => {
 
   test('managed project with zero agents still gets a row', () => {
     const rows = railProjectRows([], [makeProject({ name: 'idle-proj' })])
-    expect(rows).toEqual([{ key: 'p1', name: 'idle-proj', run: 0, wait: 0, managed: true }])
+    expect(rows).toEqual([{ key: 'p1', name: 'idle-proj', run: 0, wait: 0, backlog: 0, prs: 0, managed: true }])
+  })
+
+  test('rows carry backlog + distinct-PR rollups; ticket-only projects do not appear as extras', () => {
+    const agents = [
+      makeAgent({ id: '1', project: 'swarmify', prUrl: 'https://github.com/x/y/pull/1' }),
+      makeAgent({ id: '2', project: 'swarmify', prUrl: 'https://github.com/x/y/pull/1' }),
+    ]
+    const tickets = [
+      { id: 'T-1', title: 't', project: 'swarmify', source: 'LN', pri: 'high', status: 'todo', desc: '', labels: [], owner: '' },
+      { id: 'T-2', title: 't', project: 'swarmify', source: 'LN', pri: 'high', status: 'done', desc: '', labels: [], owner: '' },
+      { id: 'T-3', title: 't', project: 'ghost-proj', source: 'GH', pri: 'med', status: 'todo', desc: '', labels: [], owner: '' },
+    ] as FloorTicket[]
+    const rows = railProjectRows(agents, [makeProject({ name: 'swarmify' })], tickets)
+    expect(rows.map((r) => r.name)).toEqual(['swarmify']) // ghost-proj has no agents: not a scopable extra
+    expect(rows[0]).toMatchObject({ run: 2, backlog: 1, prs: 1 }) // done ticket excluded, PR deduped
   })
 })
 

--- a/apps/factory/ui/settings/components/mission-control/FloorRail.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorRail.tsx
@@ -3,6 +3,7 @@ import { Icon, type IconName } from './icons'
 import {
   computeHostRows,
   orderManagedProjects,
+  projectRollups,
   type CenterMode,
   type FloorAgent,
   type FloorTicket,
@@ -51,6 +52,10 @@ export interface RailProjectRow {
   run: number
   /** Agents on the project waiting on the user (amber). */
   wait: number
+  /** Open backlog tickets for the project (dim sub-count). */
+  backlog: number
+  /** Distinct open PRs carried by the project's agents (dim sub-count). */
+  prs: number
   /** Curated ManagedProject vs discovered-from-agents only. */
   managed: boolean
 }
@@ -58,27 +63,23 @@ export interface RailProjectRow {
 /**
  * Rows for the Projects flyout: curated projects first (orderManagedProjects), then
  * any project that has live agents but isn't curated — those must still be scopable
- * from the rail, busiest first.
+ * from the rail, busiest first. Each row carries the full projectRollups counts so
+ * one hover answers "what's happening in this project".
  */
-export function railProjectRows(agents: FloorAgent[], projects: ManagedProject[]): RailProjectRow[] {
+export function railProjectRows(agents: FloorAgent[], projects: ManagedProject[], tickets: FloorTicket[] = []): RailProjectRow[] {
+  const rollups = projectRollups(agents, tickets)
   const run: Record<string, number> = {}
-  const wait: Record<string, number> = {}
-  for (const a of agents) {
-    run[a.project] = (run[a.project] || 0) + 1
-    if (a.needs) wait[a.project] = (wait[a.project] || 0) + 1
-  }
+  for (const [name, r] of Object.entries(rollups)) run[name] = r.run
   const managedNames = new Set(projects.map((p) => p.name))
-  const rows: RailProjectRow[] = orderManagedProjects(projects, run).map((p) => ({
-    key: p.id,
-    name: p.name,
-    run: run[p.name] ?? 0,
-    wait: wait[p.name] ?? 0,
-    managed: true,
-  }))
-  const extras = Object.keys(run)
-    .filter((name) => !managedNames.has(name))
-    .sort((x, y) => (run[y] ?? 0) - (run[x] ?? 0) || x.localeCompare(y))
-    .map((name) => ({ key: `agents:${name}`, name, run: run[name] ?? 0, wait: wait[name] ?? 0, managed: false }))
+  const rowFor = (key: string, name: string, managed: boolean): RailProjectRow => {
+    const r = rollups[name]
+    return { key, name, run: r?.run ?? 0, wait: r?.wait ?? 0, backlog: r?.backlog ?? 0, prs: r?.prs ?? 0, managed }
+  }
+  const rows = orderManagedProjects(projects, run).map((p) => rowFor(p.id, p.name, true))
+  const extras = Object.keys(rollups)
+    .filter((name) => !managedNames.has(name) && (rollups[name]?.run ?? 0) > 0)
+    .sort((x, y) => (rollups[y]?.run ?? 0) - (rollups[x]?.run ?? 0) || x.localeCompare(y))
+    .map((name) => rowFor(`agents:${name}`, name, false))
   return [...rows, ...extras]
 }
 
@@ -140,7 +141,7 @@ export function FloorRail({
   const scope = (value: string) => { setFly(null); onScope(value) }
   const state: RailScopeState = { center, projFilter, hostFilter, needsOnly }
   const needs = agents.filter((a) => a.needs).length
-  const projRows = railProjectRows(agents, projects)
+  const projRows = railProjectRows(agents, projects, tickets)
   const hostRows = computeHostRows(agents, devices, offlineHosts, hostPins, localHost)
   const anyOffline = hostRows.some((h) => h.offline)
 
@@ -181,6 +182,13 @@ export function FloorRail({
                 <button key={p.key} type="button" className={`fly-row${projFilter === p.name ? ' on' : ''}`} onClick={() => scope(p.name)}>
                   <span className="n">{p.name}</span>
                   {p.wait > 0 && <span className="w"><Icon name="clock" size={10} />{p.wait}</span>}
+                  {(p.backlog > 0 || p.prs > 0) && (
+                    <span className="fly-sub">
+                      {p.backlog > 0 ? `${p.backlog} ticket${p.backlog === 1 ? '' : 's'}` : ''}
+                      {p.backlog > 0 && p.prs > 0 ? ' · ' : ''}
+                      {p.prs > 0 ? `${p.prs} PR${p.prs === 1 ? '' : 's'}` : ''}
+                    </span>
+                  )}
                   <span className="c">{p.run > 0 ? p.run : '—'}</span>
                 </button>
               ))}

--- a/apps/factory/ui/settings/components/mission-control/ProjectsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/ProjectsPane.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { Icon } from './icons'
-import type { ManagedProject, LinearProjectLite } from './floorModel'
+import type { ManagedProject, LinearProjectLite, ProjectRollup } from './floorModel'
 
 // Projects management pane. Opens in the detail column when center === 'projects'
 // (via the sidebar cog / "+N more" row) — NOT a modal. Mirrors HostDetail's layout:
@@ -11,6 +11,8 @@ import type { ManagedProject, LinearProjectLite } from './floorModel'
 
 interface ProjectsPaneProps {
   projects: ManagedProject[]
+  /** Per-project activity rollups (projectRollups), keyed by project name. */
+  rollups?: Record<string, ProjectRollup>
   linearProjects: LinearProjectLite[]
   pickedFolder: { path: string; repoSlug?: string; name: string; suggestedLinear?: LinearProjectLite } | null
   onSave: (p: ManagedProject) => void
@@ -21,6 +23,22 @@ interface ProjectsPaneProps {
 
 const VIOLET = '#8b8ce8'
 
+/** "3 running · 1 waiting · 12 backlog · 2 PRs · active 40m ago" — only non-zero
+ *  parts; 'quiet' when the project has no live activity and no backlog. */
+export function rollupLine(r: ProjectRollup | undefined, nowMs: number): string {
+  if (!r) return 'quiet'
+  const parts: string[] = []
+  if (r.run > 0) parts.push(`${r.run} running`)
+  if (r.wait > 0) parts.push(`${r.wait} waiting`)
+  if (r.backlog > 0) parts.push(`${r.backlog} backlog`)
+  if (r.prs > 0) parts.push(`${r.prs} PR${r.prs === 1 ? '' : 's'}`)
+  if (r.lastActivityMs > 0) {
+    const mins = Math.max(1, Math.round((nowMs - r.lastActivityMs) / 60_000))
+    parts.push(`active ${mins < 60 ? `${mins}m` : `${Math.round(mins / 60)}h`} ago`)
+  }
+  return parts.length ? parts.join(' · ') : 'quiet'
+}
+
 /** Truncate a long path in the middle so both the root and the leaf stay visible. */
 function truncateMiddle(s: string, max = 42): string {
   if (s.length <= max) return s
@@ -29,7 +47,7 @@ function truncateMiddle(s: string, max = 42): string {
   return `${s.slice(0, head)}…${s.slice(s.length - tail)}`
 }
 
-export function ProjectsPane({ projects, linearProjects, pickedFolder, onSave, onDelete, onPickFolder, onClose }: ProjectsPaneProps) {
+export function ProjectsPane({ projects, rollups = {}, linearProjects, pickedFolder, onSave, onDelete, onPickFolder, onClose }: ProjectsPaneProps) {
   const [editingId, setEditingId] = useState<string | null>(null)
   const [path, setPath] = useState('')
   const [name, setName] = useState('')
@@ -130,6 +148,9 @@ export function ProjectsPane({ projects, linearProjects, pickedFolder, onSave, o
                   </div>
                   <div className="mono" style={{ color: 'var(--ds-text-dim)', fontSize: 11, marginTop: 2 }} title={p.path}>
                     {truncateMiddle(p.path)}
+                  </div>
+                  <div style={{ color: 'var(--ds-text-faint)', fontSize: 11, marginTop: 2 }}>
+                    {rollupLine(rollups[p.name], Date.now())}
                   </div>
                 </div>
                 <button className="host-btn" onClick={() => startEdit(p)}>Edit</button>

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -44,6 +44,7 @@ import {
   groupAgents,
   sessionTaskLine,
   ticketWorkers,
+  projectRollups,
   type FloorAgent,
   type FloorTicket,
   type CenterMode,
@@ -1442,6 +1443,9 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   // Ticket id -> agents carrying it: the backlog's in-flight chips and the ticket
   // detail's "In flight" block + double-dispatch guard all join on this.
   const floorWorkers = useMemo(() => ticketWorkers(floorAgents), [floorAgents])
+  // Per-project activity rollups: the rail's Projects flyout sub-counts and the
+  // Projects pane's activity line both read from this one derivation.
+  const floorRollups = useMemo(() => projectRollups(floorAgents, floorTickets), [floorAgents, floorTickets])
 
   // Lookup back to the source UnifiedAgent so the right pane can reuse the rich DetailPane.
   const unifiedById = useMemo(() => {
@@ -2068,6 +2072,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   const rightContent = center === 'projects'
     ? <ProjectsPane
         projects={managedProjects}
+        rollups={floorRollups}
         linearProjects={linearProjects}
         pickedFolder={pickedFolder}
         onSave={(p) => postMessage({ type: 'saveManagedProject', project: p })}

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -341,6 +341,7 @@
 .swarmify-root .rail-fly .fly-row .n { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .swarmify-root .rail-fly .fly-row .c { color: var(--ds-text-dim); font-family: "Geist Mono", monospace; font-size: 10.5px; font-variant-numeric: tabular-nums; }
 .swarmify-root .rail-fly .fly-row .w { display: inline-flex; align-items: center; gap: 2px; color: var(--status-pending); font-family: "Geist Mono", monospace; font-size: 10.5px; }
+.swarmify-root .rail-fly .fly-row .fly-sub { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--ds-text-faint); font-size: 10px; }
 .swarmify-root .rail-fly .fly-row .fly-hd { flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%; background: var(--status-running); }
 .swarmify-root .rail-fly .fly-row .fly-hd.off { background: var(--status-failed); }
 .swarmify-root .rail-fly .fly-manage { color: var(--ds-text-faint); }

--- a/apps/factory/ui/settings/components/mission-control/floorModel.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.test.ts
@@ -20,6 +20,7 @@ import {
   groupTickets,
   sortTickets,
   ticketWorkers,
+  projectRollups,
   resolveProject,
   sessionTaskLine,
   todosWithFallback,
@@ -885,5 +886,30 @@ describe('ticketWorkers', () => {
 
   test('empty input yields empty map', () => {
     expect(ticketWorkers([])).toEqual({})
+  })
+})
+
+describe('projectRollups', () => {
+  test('one pass over agents + tickets: run/wait/backlog/prs/lastActivity per project', () => {
+    const by = projectRollups(
+      [
+        makeAgent({ id: 'a', project: 'swarmify', needs: true, lastActivityMs: 100, prUrl: 'https://x/pull/1' }),
+        makeAgent({ id: 'b', project: 'swarmify', lastActivityMs: 900, prUrl: 'https://x/pull/1' }),
+        makeAgent({ id: 'c', project: 'rush', lastActivityMs: 50 }),
+      ],
+      [
+        { id: 'T-1', title: '', project: 'swarmify', source: 'LN', pri: 'high', status: 'todo', desc: '', labels: [], owner: '' },
+        { id: 'T-2', title: '', project: 'swarmify', source: 'LN', pri: 'low', status: 'done', desc: '', labels: [], owner: '' },
+        { id: 'T-3', title: '', project: 'ghost', source: 'GH', pri: 'med', status: 'in-progress', desc: '', labels: [], owner: '' },
+      ],
+    )
+    expect(by['swarmify']).toEqual({ run: 2, wait: 1, backlog: 1, prs: 1, lastActivityMs: 900 })
+    expect(by['rush']).toEqual({ run: 1, wait: 0, backlog: 0, prs: 0, lastActivityMs: 50 })
+    // A ticket-only project still gets a rollup (the Projects pane may manage it).
+    expect(by['ghost']).toEqual({ run: 0, wait: 0, backlog: 1, prs: 0, lastActivityMs: 0 })
+  })
+
+  test('empty inputs yield an empty map', () => {
+    expect(projectRollups([], [])).toEqual({})
   })
 })

--- a/apps/factory/ui/settings/components/mission-control/floorModel.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.ts
@@ -886,6 +886,47 @@ export function ticketWorkers(agents: FloorAgent[]): Record<string, FloorAgent[]
   return by
 }
 
+/** Per-project activity rollup — what the rail flyout and Projects pane summarize. */
+export interface ProjectRollup {
+  /** Agents currently on the project. */
+  run: number
+  /** Of those, agents waiting on the user. */
+  wait: number
+  /** Open (non-done) backlog tickets for the project. */
+  backlog: number
+  /** Distinct open-PR URLs carried by the project's agents. */
+  prs: number
+  /** Most recent agent activity (epoch ms); 0 when unknown/idle. */
+  lastActivityMs: number
+}
+
+/**
+ * Derive every project's rollup from the live feed + backlog in one pass. Keyed by
+ * project name (the same key ManagedProject.name / FloorTicket.project use), so a
+ * consumer can look up curated and discovered projects alike.
+ */
+export function projectRollups(agents: FloorAgent[], tickets: FloorTicket[]): Record<string, ProjectRollup> {
+  const by: Record<string, ProjectRollup> = {}
+  const prSets = new Map<string, Set<string>>()
+  const get = (name: string): ProjectRollup => (by[name] ??= { run: 0, wait: 0, backlog: 0, prs: 0, lastActivityMs: 0 })
+  for (const a of agents) {
+    const r = get(a.project)
+    r.run += 1
+    if (a.needs) r.wait += 1
+    if (a.lastActivityMs > r.lastActivityMs) r.lastActivityMs = a.lastActivityMs
+    if (a.prUrl) {
+      const set = prSets.get(a.project) ?? new Set<string>()
+      set.add(a.prUrl)
+      prSets.set(a.project, set)
+    }
+  }
+  for (const t of tickets) {
+    if (t.status !== 'done') get(t.project).backlog += 1
+  }
+  for (const [name, set] of prSets) get(name).prs = set.size
+  return by
+}
+
 export function sortTickets(tickets: FloorTicket[], by: TicketSort): FloorTicket[] {
   const arr = [...tickets]
   if (by === 'priority') return arr.sort((a, b) => PRI_RANK[a.pri] - PRI_RANK[b.pri])

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -455,6 +455,10 @@ function Projects() {
   return (
     <ProjectsPane
       projects={managedProjects}
+      rollups={{
+        'agents-cli': { run: 3, wait: 1, backlog: 4, prs: 2, lastActivityMs: Date.now() - 40 * 60_000 },
+        rush: { run: 2, wait: 0, backlog: 12, prs: 1, lastActivityMs: Date.now() - 5 * 60_000 },
+      }}
       linearProjects={linearProjectList}
       pickedFolder={null}
       onSave={noop}


### PR DESCRIPTION
## Problem

Projects were only a filter. `ManagedProject` stores id/name/path/links, and nothing anywhere rolled up a project's activity — to answer "what's happening in rush?" you had to scope the feed, then the backlog, then eyeball PR badges card by card.

## Change

- **`projectRollups(agents, tickets)`** (pure, `floorModel.ts`): one pass derives per-project `run` / `wait` / open-`backlog` / distinct open-`prs` / `lastActivityMs`, keyed by the same project-name key ManagedProject and FloorTicket use.
- **Rail Projects flyout**: rows gain dim sub-counts — `4 tickets · 2 PRs` — next to the existing live/waiting counts (`railProjectRows` now folds rollups in; it also stops offering ticket-only projects as scopable extras, since scoping the agents feed to a project with zero agents is a dead end).
- **Projects pane**: each managed-project card gains an activity line — `3 running · 1 waiting · 4 backlog · 2 PRs · active 40m ago`, or `quiet` — via an exported pure `rollupLine`.
- One derivation (`floorRollups` memo in `UnifiedAgentsPane`) feeds both surfaces.

## Evidence

- `bun test ui/settings/components/mission-control/`: 312 pass / 0 fail (new: projectRollups one-pass truth table incl. done-ticket exclusion, PR dedup, ticket-only projects; railProjectRows rollup fields + no ghost extras).
- `bun run compile`: clean.
- Verified visually in the preview harness: flyout rows show the dim sub-counts (`/tmp/rollups-flyout.png` on zion), Projects-pane cards show the activity line and `quiet` fallback (`/tmp/rollups-pane.png` on zion).

Session transcript (local, zion): `~/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/3a85fdd1-171d-4a73-9c62-64a002948cd0.jsonl`

Part 5 (final) of the Floor tracking series (#862 rail flyouts, #866 in-flight linkage, #869 recap, #870 PR board). Will need the usual trivial changelog reconcile if #870 lands first.