### PR TITLE
feat(factory): plan-watch reads CLI session.plan, delete parsePlanFromClaudeJsonl

### DIFF
--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -2109,8 +2109,7 @@ export async function scanClaudeSession(filePath: string): Promise<ClaudeSession
             pendingTicketTools.add(b.id);
           }
           // ExitPlanMode plan markdown — last one wins so a re-planned session
-          // reports its most recent plan (the semantic parsePlanFromClaudeJsonl
-          // implemented in the extension).
+          // reports its most recent plan.
           if (b?.name === 'ExitPlanMode' && typeof b?.input?.plan === 'string') {
             const p = b.input.plan.trim();
             if (p) plan = b.input.plan;

--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -40,6 +40,13 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ### Changed
 
+- **Plan-watch now reads from the CLI's canonical `session.plan` field instead of re-parsing
+  raw JSONL.** `watchForPlan` previously read the session `.jsonl` file and re-implemented the
+  `ExitPlanMode` scanner (`parsePlanFromClaudeJsonl`) — a duplicate of the CLI's session state
+  engine. The CLI now carries `plan` on `SessionMeta` (surfaced via `agents sessions <id>
+  --json`), so the extension polls the CLI directly and `parsePlanFromClaudeJsonl` is deleted.
+  No behavior change for the Floor's plan-ready surface. (RUSH-1505)
+
 - **The collapsed Floor rail's Projects and Hosts buttons are now flyout menus instead of
   three buttons that all expanded the sidebar.** Click Projects for the curated project
   list (live agent count + amber waiting count per project, plus any uncurated project

--- a/apps/factory/src/core/agents.test.ts
+++ b/apps/factory/src/core/agents.test.ts
@@ -7,7 +7,7 @@ import {
   pickLatestVersion,
   STRATEGY_LAUNCH_AGENTS,
   modeFlagForAgent,
-  parsePlanFromClaudeJsonl,
+  extractPlanFromSessionJson,
   planTextToSteps
 } from './agents';
 import { CLAUDE_TITLE, CODEX_TITLE, GEMINI_TITLE, OPENCODE_TITLE, CURSOR_TITLE, SHELL_TITLE } from './utils';
@@ -187,34 +187,38 @@ describe('modeFlagForAgent', () => {
   });
 });
 
-describe('parsePlanFromClaudeJsonl', () => {
-  const exitPlanLine = JSON.stringify({
-    type: 'assistant',
-    message: { content: [{ type: 'tool_use', name: 'ExitPlanMode', input: { plan: '1. First\n2. Second' } }] },
-  });
-
-  test('extracts plan markdown from an ExitPlanMode tool_use', () => {
-    const jsonl = [
-      JSON.stringify({ type: 'user', message: { content: 'hi' } }),
-      exitPlanLine,
-    ].join('\n');
-    expect(parsePlanFromClaudeJsonl(jsonl)).toBe('1. First\n2. Second');
-  });
-
-  test('returns the LAST plan when the agent re-plans', () => {
-    const second = JSON.stringify({
-      type: 'assistant',
-      message: { content: [{ type: 'tool_use', name: 'ExitPlanMode', input: { plan: 'revised plan' } }] },
+describe('extractPlanFromSessionJson', () => {
+  test('extracts plan from CLI JSON output', () => {
+    const json = JSON.stringify({
+      session: { id: 'abc', plan: '1. First\n2. Second' },
+      events: [],
     });
-    expect(parsePlanFromClaudeJsonl([exitPlanLine, second].join('\n'))).toBe('revised plan');
+    expect(extractPlanFromSessionJson(json)).toBe('1. First\n2. Second');
   });
 
-  test('returns null when there is no plan and ignores malformed lines', () => {
-    const jsonl = [
-      'not json',
-      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'thinking' }] } }),
-    ].join('\n');
-    expect(parsePlanFromClaudeJsonl(jsonl)).toBeNull();
+  test('returns null when session has no plan', () => {
+    const json = JSON.stringify({
+      session: { id: 'abc' },
+      events: [],
+    });
+    expect(extractPlanFromSessionJson(json)).toBeNull();
+  });
+
+  test('returns null for empty/whitespace plan', () => {
+    const json = JSON.stringify({
+      session: { id: 'abc', plan: '   ' },
+      events: [],
+    });
+    expect(extractPlanFromSessionJson(json)).toBeNull();
+  });
+
+  test('returns null for unparseable JSON', () => {
+    expect(extractPlanFromSessionJson('not json')).toBeNull();
+  });
+
+  test('returns null for legacy bare-array format (no session wrapper)', () => {
+    const json = JSON.stringify([{ type: 'message', content: 'hi' }]);
+    expect(extractPlanFromSessionJson(json)).toBeNull();
   });
 });
 

--- a/apps/factory/src/core/agents.ts
+++ b/apps/factory/src/core/agents.ts
@@ -67,34 +67,28 @@ export function modeFlagForAgent(_agentKey: string, mode: AgentLaunchMode): stri
 }
 
 // ---- Plan detection (a Plan-mode Claude agent emits a plan) ----------------
-// When a plan-mode agent finishes planning it calls Claude's ExitPlanMode tool,
-// whose input carries the plan markdown. These pure helpers turn the raw
-// session JSONL into the PendingPlan the Floor renders. Kept here (not in the
-// VS Code layer) so they're unit-testable without a live session.
+// The CLI's session state engine (`state.ts`) captures the ExitPlanMode plan
+// markdown and surfaces it as `session.plan` in `agents sessions <id> --json`.
+// These pure helpers read the CLI JSON and turn the plan into the PendingPlan
+// the Floor renders. Kept here (not in the VS Code layer) so they're
+// unit-testable without a live session.
 
 export interface PlanStepData { n: number; text: string }
 
-// Scan a Claude session .jsonl (one JSON object per line) and return the plan
-// markdown from the LAST ExitPlanMode tool call, or null if none present. The
-// last one wins so a re-planned agent surfaces its most recent plan.
-export function parsePlanFromClaudeJsonl(jsonl: string): string | null {
-  let latest: string | null = null;
-  for (const line of jsonl.split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed[0] !== '{') continue;
-    let obj: any;
-    try { obj = JSON.parse(trimmed); } catch { continue; }
-    if (obj?.type !== 'assistant') continue;
-    const blocks = obj?.message?.content;
-    if (!Array.isArray(blocks)) continue;
-    for (const b of blocks) {
-      if (b?.type === 'tool_use' && b?.name === 'ExitPlanMode') {
-        const plan = b?.input?.plan;
-        if (typeof plan === 'string' && plan.trim()) latest = plan;
-      }
-    }
+// Extract the plan markdown from `agents sessions <id> --json` output. The CLI
+// emits `{ session: { plan?: string, ... }, events: [...] }` — this reads
+// `session.plan`, which the state engine populates from the LAST ExitPlanMode
+// tool call at scan time (last one wins so a re-planned session surfaces its
+// most recent plan). Returns null when no plan is present or the JSON is
+// unparseable, matching the polling contract in watchForPlan.
+export function extractPlanFromSessionJson(json: string): string | null {
+  try {
+    const parsed = JSON.parse(json);
+    const plan = parsed?.session?.plan;
+    return typeof plan === 'string' && plan.trim() ? plan : null;
+  } catch {
+    return null;
   }
-  return latest;
 }
 
 // Split plan markdown into ordered steps. Prefers explicit list items

--- a/apps/factory/src/vscode/settings.vscode.ts
+++ b/apps/factory/src/vscode/settings.vscode.ts
@@ -17,7 +17,7 @@ import { openSingleAgentWithQueue, runHeadlessAgent, focusSessionInTerminal } fr
 import { generateClaudeSessionId } from '../core/prewarm.simple';
 import { nudgeSession } from '../mcp/watchdog-bridge';
 import { runAgents } from '../core/agentsBin';
-import { AgentLaunchMode, parsePlanFromClaudeJsonl, planTextToSteps } from '../core/agents';
+import { AgentLaunchMode, extractPlanFromSessionJson, planTextToSteps } from '../core/agents';
 import { CLAUDE_TITLE } from '../core/utils';
 import { discoverRecentSessions, getSessionPathBySessionId } from './sessions.vscode';
 import { formatTerminalTitle, parseTerminalName, getSessionChunk } from '../core/utils';
@@ -417,14 +417,17 @@ export function getDispatchSessionPolicy(sessionId: string): DispatchSessionPoli
   return dispatchSessionPolicies.get(sessionId);
 }
 
-// Watch a plan-mode Claude session's .jsonl for an ExitPlanMode tool call and
-// post `planReady` to the webview once, so the Floor can show the plan for
-// approval. Polls (no fs.watch: the file may not exist yet at spawn) until the
-// plan appears or the budget elapses.
+// Watch a plan-mode Claude session for an ExitPlanMode tool call and post
+// `planReady` to the webview once, so the Floor can show the plan for approval.
+// Polls `agents sessions <id> --json --local` (the CLI's canonical session
+// state engine, which captures the plan markdown at scan time) until the plan
+// appears or the budget elapses. Previous versions read the raw JSONL and
+// re-implemented the ExitPlanMode scanner; the CLI now carries `session.plan`,
+// so the extension consumes it directly.
 function watchForPlan(
   sessionId: string,
   agentId: string,
-  cwd: string,
+  _cwd: string,
   notify: NotifyPrefsMsg,
 ): void {
   const POLL_MS = 2000;
@@ -435,24 +438,19 @@ function watchForPlan(
     if (done) return;
     attempts++;
     try {
-      const filePath = await getSessionPathBySessionId(sessionId, 'claude', cwd);
-      if (filePath) {
-        const jsonl = await fs.promises.readFile(filePath, 'utf8');
-        const planText = parsePlanFromClaudeJsonl(jsonl);
-        if (planText) {
-          done = true;
-          const plan: PendingPlanMsg = { sessionId, agentId, steps: planTextToSteps(planText) };
-          settingsPanel?.webview.postMessage({ type: 'planReady', plan });
-          // notify.events.plan gates whether this also escalates to an external
-          // channel; the in-app Floor surface always receives it.
-          if (notify.events.plan && !notify.dnd) {
-            console.log(`[DISPATCH] plan ready for ${sessionId} — notify via ${notify.channel}`);
-          }
-          return;
+      const { stdout } = await runAgents(`sessions ${sessionId} --json --local`, { timeout: 10_000 });
+      const planText = extractPlanFromSessionJson(stdout);
+      if (planText) {
+        done = true;
+        const plan: PendingPlanMsg = { sessionId, agentId, steps: planTextToSteps(planText) };
+        settingsPanel?.webview.postMessage({ type: 'planReady', plan });
+        if (notify.events.plan && !notify.dnd) {
+          console.log(`[DISPATCH] plan ready for ${sessionId} — notify via ${notify.channel}`);
         }
+        return;
       }
     } catch (err) {
-      console.warn('[DISPATCH] plan watch read failed:', err);
+      console.warn('[DISPATCH] plan watch poll failed:', err);
     }
     if (attempts < MAX_ATTEMPTS) setTimeout(tick, POLL_MS);
   };


### PR DESCRIPTION
## Summary

- **Delete `parsePlanFromClaudeJsonl`** from `apps/factory/src/core/agents.ts` — the duplicate raw-JSONL ExitPlanMode scanner the extension maintained alongside the CLI's canonical session state engine.
- **Add `extractPlanFromSessionJson`** — reads `session.plan` from the CLI's `agents sessions <id> --json` output (the canonical source, populated by the state engine at scan time).
- **Rewrite `watchForPlan`** in `apps/factory/src/vscode/settings.vscode.ts` to poll `agents sessions <id> --json --local` via `runAgents` instead of reading raw JSONL and re-parsing it.

No behavior change for the Floor's plan-ready surface. The CLI already carries `plan` on `SessionMeta` (schema v11, `state.ts` + `discover.ts` + `render.ts`); this PR makes the extension consume it instead of maintaining a second parser.

Closes https://linear.app/getrush/issue/RUSH-1505

## Test plan

- [x] `bun test apps/factory/src/core/agents.test.ts` — 36 pass (5 new `extractPlanFromSessionJson` tests replace 3 old `parsePlanFromClaudeJsonl` tests; `planTextToSteps` tests unchanged)
- [x] `bun test apps/cli/src/lib/session/state.test.ts` — 47 pass (CLI plan extraction via `extractPlanText` + `inferActivity` unchanged)
- [x] `bun test apps/cli/src/lib/session/render.test.ts` — 3 pass (`renderJson` wraps `session.plan` in `{ session, events }`)
- [x] `tsc --noEmit` on `apps/factory/` — clean compile
- [x] Zero remaining references to `parsePlanFromClaudeJsonl` in the codebase (one stale comment in `discover.ts` also cleaned up)