### PR TITLE
fix: align teammate mailbox identity

### DIFF
--- a/apps/cli/src/lib/mailbox-target.test.ts
+++ b/apps/cli/src/lib/mailbox-target.test.ts
@@ -48,6 +48,24 @@ describe('resolveMessageTarget', () => {
     expect(resolveMessageTarget('agent-uuid', [s], noCloud)).toEqual({ kind: 'local', id: 'agent-uuid' });
   });
 
+  it('routes to agentId even when sessionId differs (RUSH-1534 regression)', () => {
+    const s = mk({
+      context: 'teams',
+      agentId: 'teams-minted-uuid',
+      sessionId: 'runtime-session-uuid',
+      teamName: 'feat',
+    });
+    expect(mailboxIdForActiveSession(s)).toBe('teams-minted-uuid');
+    expect(resolveMessageTarget('teams-minted-uuid', [s], noCloud)).toEqual({
+      kind: 'local',
+      id: 'teams-minted-uuid',
+    });
+    expect(resolveMessageTarget('runtime-session-uuid', [s], noCloud)).toEqual({
+      kind: 'local',
+      id: 'teams-minted-uuid',
+    });
+  });
+
   it('collapses multiple rows that share one canonical id (subagents/forks) to a single box', () => {
     const sessions = [
       mk({ sessionId: 'aaaa-1111', pidCount: 2 }),

--- a/apps/cli/src/lib/teams/agents.ts
+++ b/apps/cli/src/lib/teams/agents.ts
@@ -2034,9 +2034,11 @@ export class AgentManager {
 
     if (cwd) cmd.push('--cwd', cwd);
 
-    // Pin Claude's session UUID to our agent_id so its session file lands at
-    // ~/.claude/projects/.../<agent_id>.jsonl — unified identity for status polling.
-    if (agentType === 'claude' && sessionId) {
+    // Pin the session UUID to our agent_id so buildExecEnv keys
+    // AGENTS_MAILBOX_DIR by the same id mailboxIdForActiveSession returns.
+    // Claude also forwards --session-id to its CLI (unified identity);
+    // other agents ignore the flag but still get the correct mailbox dir.
+    if (sessionId) {
       cmd.push('--session-id', sessionId);
     }
 

--- a/apps/cli/tests/teams-session-id.test.ts
+++ b/apps/cli/tests/teams-session-id.test.ts
@@ -218,12 +218,14 @@ describe('AgentProcess: remoteSessionId extraction', () => {
       expect(cmd[idx + 1]).toBe('/tmp/work');
     });
 
-    it('non-Claude agents (Codex) get no --settings / --session-id (but do get --add-dir for ~/.agents)', () => {
+    it('non-Claude agents pin the outer run session for mailbox identity without forwarding settings', () => {
       const mgr = new AgentManager(50, tmpBase);
       // @ts-expect-error — private
       const cmd: string[] = mgr.buildCommand('codex', 'hi', 'edit', 'some-model', '/tmp', 'uuid');
       expect(cmd).not.toContain('--settings');
-      expect(cmd).not.toContain('--session-id');
+      const sessionIdIdx = cmd.indexOf('--session-id');
+      expect(sessionIdIdx).toBeGreaterThan(-1);
+      expect(cmd[sessionIdIdx + 1]).toBe('uuid');
       // Codex gets --add-dir ~/.agents so subprocesses can write to the store.
       const addDirIdx = cmd.indexOf('--add-dir');
       expect(addDirIdx).toBeGreaterThan(-1);


### PR DESCRIPTION
## Outcome

Fixes RUSH-1534 by passing the teams-minted teammate ID into every outer `agents run --session-id` invocation. `buildExecEnv` therefore keys `AGENTS_MAILBOX_DIR` by the same ID that mailbox routing resolves, including Codex and other non-Claude teammates.

The underlying agent CLI behavior remains scoped: only Claude receives its native `--session-id`; other runtimes use the value solely in the agents-cli execution envelope.

This replaces #877, rebased cleanly onto the current default branch after #876 merged.

## Verification

- `bun run build`
- `bunx vitest run src/lib/mailbox-target.test.ts src/lib/mailbox.test.ts tests/teams-session-id.test.ts`
- Result: 3 test files passed, 41 tests passed.
- Installed cross-runtime mailbox delivery evidence will be posted on this PR before merge.

## Documentation

Pure bug fix with no new command, flag, configuration, or user-facing contract; no documentation or changelog entry required.

## Session evidence

Public repository: transcript intentionally omitted. Fleet-local transcript: `zion:/Users/muqsit/.codex/sessions/2026/07/10/rollout-2026-07-10T16-41-07-019f4e68-044c-7872-977c-0f748562dc06.jsonl`.
