### PR TITLE
fix(browser): clear forked endpoint runtime dirs on stop

### DIFF
--- a/apps/cli/src/lib/browser/runtime-state.test.ts
+++ b/apps/cli/src/lib/browser/runtime-state.test.ts
@@ -10,6 +10,7 @@ import {
   clearProfileRuntime,
   removeProfileCache,
   listProfileCacheDirs,
+  listAllProfileSnapshots,
   isProcessAlive,
   reapOrphanedProcesses,
 } from './runtime-state.js';
@@ -245,5 +246,63 @@ describe('isProcessAlive', () => {
 
   it('returns false for a definitely-dead pid', () => {
     expect(isProcessAlive(999999)).toBe(false);
+  });
+});
+
+describe('fork runtime cleanup (RUSH-1528)', () => {
+  it('clearProfileRuntime on a fork name removes stale fork entries from snapshots', () => {
+    const base = uniq('fork-parent');
+    const fork2 = `${base}.2`;
+    const fork3 = `${base}.3`;
+    created.push(fork2, fork3);
+
+    writeProfileRuntime(fork2, { pid: 999990, command: 'chrome' });
+    writeProfileRuntime(fork3, { pid: 999991, command: 'chrome' });
+
+    const beforeClear = listAllProfileSnapshots().filter(
+      (s) => s.name === fork2 || s.name === fork3,
+    );
+    expect(beforeClear).toHaveLength(2);
+
+    clearProfileRuntime(fork2);
+    clearProfileRuntime(fork3);
+
+    const afterClear = listAllProfileSnapshots().filter(
+      (s) => s.name === fork2 || s.name === fork3,
+    );
+    expect(afterClear.every((s) => s.meta === null)).toBe(true);
+  });
+
+  it('listProfileCacheDirs finds composite forks (.N) alongside composites', () => {
+    const base = uniq('forkdir');
+    const composite = `${base}@endpoint-0`;
+    const fork2 = `${composite}.2`;
+    const fork3 = `${composite}.3`;
+    const root = getBrowserRuntimeDir();
+    for (const name of [base, composite, fork2, fork3]) {
+      fs.mkdirSync(path.join(root, name), { recursive: true });
+      created.push(name);
+    }
+
+    const found = listProfileCacheDirs(base).map((p) => path.basename(p)).sort();
+    expect(found).toEqual([base, composite, fork2, fork3].sort());
+  });
+
+  it('repeated fork write + clear leaves no stale snapshots', () => {
+    const base = uniq('repeat');
+    const fork = `${base}.2`;
+    created.push(fork);
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      writeProfileRuntime(fork, { pid: 999980 + cycle, command: 'chrome' });
+      expect(readProfileRuntimeMeta(fork)).not.toBeNull();
+      clearProfileRuntime(fork);
+      expect(readProfileRuntimeMeta(fork)).toBeNull();
+    }
+
+    const stale = listAllProfileSnapshots().filter(
+      (s) => s.name === fork && s.meta !== null,
+    );
+    expect(stale).toHaveLength(0);
   });
 });

--- a/apps/cli/src/lib/browser/service.ts
+++ b/apps/cli/src/lib/browser/service.ts
@@ -20,7 +20,7 @@ import {
 import { killChrome, getRunningChromeInfo, launchBrowser, allocatePort } from './chrome.js';
 import { connectLocal } from './drivers/local.js';
 import { connectSSH, shellQuote } from './drivers/ssh.js';
-import { clearProfileRuntime } from './runtime-state.js';
+import { clearProfileRuntime, listProfileCacheDirs, readProfileRuntimeMeta, isProcessAlive } from './runtime-state.js';
 import { resolveDomainSkill, type ResolvedDomainSkill } from './domain-skills.js';
 import {
   generateTaskId,
@@ -512,6 +512,7 @@ export class BrowserService {
           killChrome(conn.pid);
           conn.cleanup?.();
           this.connections.delete(profileName);
+          clearProfileRuntime(profileName);
         }
 
         return { ok: true, profile: profileName };
@@ -544,19 +545,19 @@ export class BrowserService {
       killChrome(conn.pid);
       conn.cleanup?.();
       this.connections.delete(key);
+      clearProfileRuntime(key);
     }
 
-    const runtimeDir = getProfileRuntimeDir(profileName);
-    const pidFile = path.join(runtimeDir, 'pid');
-    const portFile = path.join(runtimeDir, 'port');
-
-    if (fs.existsSync(pidFile)) {
-      const pid = parseInt(fs.readFileSync(pidFile, 'utf-8').trim(), 10);
-      killChrome(pid);
-      fs.unlinkSync(pidFile);
-    }
-    if (fs.existsSync(portFile)) {
-      fs.unlinkSync(portFile);
+    // Kill stale processes and clean runtime dirs for every composite and
+    // fork entry belonging to this profile (including `.N` forks left by
+    // earlier daemon sessions that the connection loop above didn't cover).
+    for (const dir of listProfileCacheDirs(profileName)) {
+      const dirName = path.basename(dir);
+      const meta = readProfileRuntimeMeta(dirName);
+      if (meta?.pid && meta.pid !== 0 && isProcessAlive(meta.pid, meta.command)) {
+        killChrome(meta.pid);
+      }
+      clearProfileRuntime(dirName);
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix stale `.N` forked browser endpoint entries proliferating in `browser ps` across repeated start/stop cycles
- When `stop()` tears down a fork (last task finished), now calls `clearProfileRuntime` to clean up the on-disk runtime files (pid, port, command, meta.json)
- `stopProfile()` now clears runtime dirs for each connection key being torn down, and sweeps all composite/fork dirs via `listProfileCacheDirs` (replaces the old bare-profileName-only fallback)

## Root cause

`forkElectronProfile()` calls `launchBrowser(forkName, ...)` which writes runtime files via `writeProfileRuntime(forkName, ...)`. When the fork was torn down in `stop()`, the process was killed and the in-memory connection deleted, but the on-disk runtime files were never cleared. `listAllProfileSnapshots()` (used by `browser ps`) reads all dirs under the browser runtime cache, showing these stale entries.

## Test plan

- [x] Added 3 regression tests in `runtime-state.test.ts` under `fork runtime cleanup (RUSH-1528)`:
  - `clearProfileRuntime` on fork names removes stale entries from snapshots
  - `listProfileCacheDirs` finds composite forks (`.N`) alongside composites
  - Repeated fork write + clear leaves no stale snapshots
- [x] All 244 browser tests pass (`vitest run src/lib/browser/`)
- [x] TypeScript typecheck passes (`tsc --noEmit`)
- [x] Full test suite: 4651 passed, 13 failed (all pre-existing, unrelated to browser)

Closes RUSH-1528

Transcript: `yosemite-s1:/home/muqsit/.agents/.history/versions/claude/2.1.186/home/.claude/projects/-home-muqsit--agents-repos-agents-cli-drain-w2--agents-worktrees-rush1528/f679a450-3540-41cb-8349-5fefbac59f79.jsonl`