### PR TITLE
ci: wire the Windows-host e2e suites to a self-hosted tailnet runner

### DIFF
--- a/.github/workflows/tests-windows-host-e2e.yml
+++ b/.github/workflows/tests-windows-host-e2e.yml
@@ -1,0 +1,80 @@
+name: Windows-host e2e (tailnet)
+
+# Runs the live Windows-host integration suites (issue #864, split out of #561):
+# ssh-tunnel.e2e.test.ts and browser/drivers/ssh.e2e.test.ts drive the REAL
+# remote runtime against win-mini over the tailnet — daemon push + scheduled
+# task + ssh -L tunnel + JSON-RPC roundtrip, and the Edge-over-CDP browser path.
+# They are env-gated on AGENTS_TEST_WIN_HOST and skip everywhere else.
+#
+# Runner: the self-hosted `tailnet-win-e2e` runner (yosemite-s0) has fleet SSH
+# reach to win-mini and a device registry entry for it (`agents devices sync`).
+#
+# SECURITY: this repo is public and the runner is self-hosted, so this workflow
+# deliberately has NO pull_request trigger — fork PRs must never execute code on
+# the tailnet runner. Trusted triggers only: push to main (path-filtered),
+# nightly schedule (catches Windows-side drift with no code change), and manual
+# dispatch. Keep it that way.
+#
+# Tool versions are NOT pinned here — setup-bun reads from package.json; dotnet
+# matches computer-helper-win.yml (build-win.sh cross-publishes the win-x64
+# daemon exe from the Linux runner via EnableWindowsTargeting).
+
+on:
+  push:
+    branches: ['main']
+    paths:
+      - 'apps/cli/src/lib/ssh-tunnel.ts'
+      - 'apps/cli/src/lib/ssh-tunnel.e2e.test.ts'
+      - 'apps/cli/src/lib/ssh-exec.ts'
+      - 'apps/cli/src/lib/computer-rpc.ts'
+      - 'apps/cli/src/lib/browser/drivers/ssh.ts'
+      - 'apps/cli/src/lib/browser/drivers/ssh.e2e.test.ts'
+      - 'native/computer-win/**'
+      - '.github/workflows/tests-windows-host-e2e.yml'
+  schedule:
+    - cron: '17 9 * * *'
+  workflow_dispatch:
+
+# One run at a time: the suite mutates real remote state on win-mini (scheduled
+# task, helper exe, tunnel ports). Queue instead of cancel — a killed run could
+# leave the remote half-torn-down.
+concurrency:
+  group: windows-host-e2e
+  cancel-in-progress: false
+
+jobs:
+  win-host-e2e:
+    # Belt-and-braces with the trigger list above: never run from a fork context.
+    if: github.repository == 'phnx-labs/agents-cli'
+    runs-on: [self-hosted, tailnet-win-e2e]
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: apps/cli
+    env:
+      AGENTS_TEST_WIN_HOST: win-mini
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Setup .NET (cross-publish the win-x64 daemon exe)
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: '10.0.x'
+
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-cache-${{ runner.os }}-${{ hashFiles('apps/cli/bun.lock') }}
+          restore-keys: bun-cache-${{ runner.os }}-
+
+      - run: bun install --frozen-lockfile
+
+      # ssh-tunnel.e2e.test.ts pushes this exe to win-mini via scp before it
+      # registers + starts the LOGON scheduled task.
+      - name: Build Windows helper exe
+        run: bash scripts/build-win.sh
+
+      - name: Windows-host e2e suites
+        run: bun run test -- src/lib/ssh-tunnel.e2e.test.ts src/lib/browser/drivers/ssh.e2e.test.ts


### PR DESCRIPTION
Closes muqsitnawaz/agents-cli#864 (follow-up from #561; the suites themselves landed via #863).

## What

Adds `.github/workflows/tests-windows-host-e2e.yml`: runs the two live Windows-host integration suites against win-mini over the tailnet —

```
bun run test -- src/lib/ssh-tunnel.e2e.test.ts src/lib/browser/drivers/ssh.e2e.test.ts
```

with `AGENTS_TEST_WIN_HOST=win-mini`, after cross-publishing the win-x64 daemon exe via `scripts/build-win.sh` (dotnet 10, EnableWindowsTargeting — same toolchain as computer-helper-win.yml).

## Runner provisioning (already live)

- Self-hosted runner **yosemite-s0** registered to this repo, labels `self-hosted, Linux, ARM64, tailnet-win-e2e` — status **online** (verified via `gh api repos/phnx-labs/agents-cli/actions/runners`).
- Runs as a user-level systemd service (`~/.config/systemd/user/actions-runner-agents-cli.service`, linger enabled) — survives reboots, no root.
- Passwordless SSH yosemite-s0 → win-mini verified (`ssh -o BatchMode=yes muqsit@win-mini` → ok).
- Device registry synced on the runner host: `win-mini  windows  muqsit@win-mini.tail1a85a1.ts.net  online` (resolveRemoteDevice requires the entry).

## Security (public repo + self-hosted runner)

No `pull_request` trigger, deliberately — fork PRs must never execute code on the tailnet runner. Trusted events only: path-filtered push to main, nightly cron (catches Windows-side drift), `workflow_dispatch`. Plus an `if: github.repository == 'phnx-labs/agents-cli'` belt-and-braces guard.

## Verification plan

The job can't run pre-merge (no PR trigger, by design). Post-merge I'll trigger `gh workflow run tests-windows-host-e2e.yml` and attach the live run result to muqsitnawaz/agents-cli#864 before closing it.