### PR TITLE
feat(factory): fine-grained todo progress on the agent detail stream (RUSH-1380)

### DIFF
--- a/apps/factory/src/core/session.activity.test.ts
+++ b/apps/factory/src/core/session.activity.test.ts
@@ -3,7 +3,7 @@
 // finished session that signed off with "anything else?" doesn't sit in NEEDS
 // YOU forever (RUSH-1522); the structural AskUserQuestion signal never decays.
 import { describe, test, expect } from 'bun:test';
-import { detectWaitingForInput, PROSE_QUESTION_FRESH_MS } from './session.activity';
+import { detectWaitingForInput, PROSE_QUESTION_FRESH_MS, extractTodoProgress } from './session.activity';
 
 const NOW = Date.parse('2026-06-30T12:00:00.000Z');
 const fresh = { lastWriteMs: NOW - 60_000, nowMs: NOW };
@@ -52,5 +52,100 @@ describe('detectWaitingForInput — prose question freshness decay (RUSH-1522)',
   test('a user reply after the question clears waiting regardless of freshness', () => {
     const content = [claudeText('Prod or staging?'), JSON.stringify({ type: 'user', message: { content: 'prod' } })].join('\n');
     expect(detectWaitingForInput(content, 'claude', fresh)).toBe(false);
+  });
+});
+
+// extractTodoProgress — the fine-grained plan/progress the live feed rides off the
+// per-task detail STREAM (transcript tail), not the floor poll. Claude emits
+// TodoWrite tool_use; Codex emits an update_plan function_call. Latest write wins.
+function claudeTodo(todos: Array<{ content: string; status?: string; activeForm?: string }>): string {
+  return JSON.stringify({
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', name: 'TodoWrite', input: { todos } }] },
+  });
+}
+function codexPlan(plan: Array<{ step: string; status?: string }>): string {
+  return JSON.stringify({
+    type: 'response_item',
+    payload: { type: 'function_call', name: 'update_plan', arguments: JSON.stringify({ plan }) },
+  });
+}
+
+describe('extractTodoProgress — Claude TodoWrite', () => {
+  test('counts pending / in_progress / completed into done/total', () => {
+    const p = extractTodoProgress(claudeTodo([
+      { content: 'Scaffold', status: 'completed' },
+      { content: 'Wire extractor', status: 'completed' },
+      { content: 'Write tests', status: 'in_progress' },
+      { content: 'Open PR', status: 'pending' },
+    ]), 'claude');
+    expect(p).not.toBeNull();
+    expect(p!.total).toBe(4);
+    expect(p!.done).toBe(2);
+    expect(p!.todos[2]).toEqual({ content: 'Write tests', status: 'in_progress' });
+  });
+
+  test('the LATEST TodoWrite fully supersedes earlier ones', () => {
+    const content = [
+      claudeText('working on it'),
+      claudeTodo([{ content: 'a', status: 'pending' }, { content: 'b', status: 'pending' }]),
+      claudeTodo([{ content: 'a', status: 'completed' }, { content: 'b', status: 'completed' }, { content: 'c', status: 'pending' }]),
+    ].join('\n');
+    const p = extractTodoProgress(content, 'claude');
+    expect(p!.total).toBe(3);
+    expect(p!.done).toBe(2);
+  });
+
+  test('carries activeForm when the write includes it', () => {
+    const p = extractTodoProgress(claudeTodo([
+      { content: 'Run tests', status: 'in_progress', activeForm: 'Running tests' },
+    ]), 'claude');
+    expect(p!.todos[0].activeForm).toBe('Running tests');
+  });
+
+  test('normalizes unknown/missing status to pending', () => {
+    const p = extractTodoProgress(claudeTodo([{ content: 'x', status: 'bogus' }, { content: 'y' }]), 'claude');
+    expect(p!.done).toBe(0);
+    expect(p!.todos.every(t => t.status === 'pending')).toBe(true);
+  });
+
+  test('no TodoWrite in the transcript → null', () => {
+    expect(extractTodoProgress(claudeText('just thinking out loud'), 'claude')).toBeNull();
+  });
+
+  test('an empty todos array → null (nothing to show)', () => {
+    expect(extractTodoProgress(claudeTodo([]), 'claude')).toBeNull();
+  });
+
+  test('gemini has no todo tool → null', () => {
+    expect(extractTodoProgress(claudeTodo([{ content: 'x', status: 'pending' }]), 'gemini')).toBeNull();
+  });
+});
+
+describe('extractTodoProgress — Codex update_plan', () => {
+  test('parses plan steps + status into the same shape', () => {
+    const p = extractTodoProgress(codexPlan([
+      { step: 'Read the code', status: 'completed' },
+      { step: 'Make the change', status: 'in_progress' },
+      { step: 'Verify', status: 'pending' },
+    ]), 'codex');
+    expect(p!.total).toBe(3);
+    expect(p!.done).toBe(1);
+    expect(p!.todos[1]).toEqual({ content: 'Make the change', status: 'in_progress' });
+  });
+
+  test('the latest update_plan wins', () => {
+    const content = [
+      codexPlan([{ step: 'a', status: 'pending' }]),
+      codexPlan([{ step: 'a', status: 'completed' }, { step: 'b', status: 'in_progress' }]),
+    ].join('\n');
+    const p = extractTodoProgress(content, 'codex');
+    expect(p!.total).toBe(2);
+    expect(p!.done).toBe(1);
+  });
+
+  test('no update_plan → null', () => {
+    const line = JSON.stringify({ type: 'response_item', payload: { type: 'function_call', name: 'shell', arguments: '{}' } });
+    expect(extractTodoProgress(line, 'codex')).toBeNull();
   });
 });

--- a/apps/factory/src/core/session.activity.ts
+++ b/apps/factory/src/core/session.activity.ts
@@ -23,6 +23,22 @@ export interface CurrentActivity {
 
 type AgentType = 'claude' | 'codex' | 'gemini';
 
+export type TodoProgressStatus = 'pending' | 'in_progress' | 'completed';
+
+/** One item of an agent's task checklist, parsed from its latest plan write. */
+export interface TodoProgressItem {
+  content: string;             // the task text
+  status: TodoProgressStatus;
+  activeForm?: string;         // Claude's present-tense form, when the write carries it
+}
+
+/** An agent's current checklist plus a done/total tally for a live progress pill. */
+export interface TodoProgress {
+  todos: TodoProgressItem[];
+  done: number;                // count of status === 'completed'
+  total: number;               // todos.length
+}
+
 /**
  * Compute output-token throughput over a rolling window.
  *
@@ -110,6 +126,94 @@ export function extractCurrentActivity(
   }
 
   return null;
+}
+
+/**
+ * Extract the agent's CURRENT task checklist + progress from a session transcript.
+ *
+ * Fine-grained progress rides the per-task detail STREAM (the transcript tail the
+ * caller already read for {@link extractCurrentActivity}) — NOT the floor poll — so
+ * this adds no extra I/O.
+ *
+ * The LATEST plan write fully supersedes earlier ones (the agent rewrites the whole
+ * list each time), so we walk from the end and return the first non-empty match:
+ *   - Claude: a `TodoWrite` tool_use with `input.todos: [{content,status,activeForm}]`.
+ *   - Codex:  an `update_plan` function_call with `arguments.plan: [{step,status}]`.
+ *   - Gemini: has no plan/todo tool — always null.
+ * Returns null when there is no plan write or the latest one is empty. Pure so it's
+ * unit-tested.
+ */
+export function extractTodoProgress(
+  sessionContent: string,
+  agentType: AgentType
+): TodoProgress | null {
+  if (agentType !== 'claude' && agentType !== 'codex') return null;
+  const marker = agentType === 'claude' ? 'TodoWrite' : 'update_plan';
+  const lines = sessionContent.split(/\r?\n/);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (!line || line[0] !== '{') continue;
+    if (!line.includes(marker)) continue;
+    let raw: any;
+    try { raw = JSON.parse(line); } catch { continue; }
+    const todos = agentType === 'claude' ? parseClaudeTodos(raw) : parseCodexPlan(raw);
+    if (todos && todos.length > 0) {
+      return {
+        todos,
+        done: todos.filter(t => t.status === 'completed').length,
+        total: todos.length,
+      };
+    }
+  }
+  return null;
+}
+
+function normalizeTodoStatus(s: unknown): TodoProgressStatus {
+  return s === 'completed' || s === 'in_progress' ? s : 'pending';
+}
+
+/** Parse a Claude `TodoWrite` tool_use line into checklist items (null if not one). */
+function parseClaudeTodos(raw: any): TodoProgressItem[] | null {
+  if (raw?.type !== 'assistant') return null;
+  const content = raw?.message?.content;
+  if (!Array.isArray(content)) return null;
+  for (const block of content) {
+    if (block?.type !== 'tool_use' || block?.name !== 'TodoWrite') continue;
+    const list = block?.input?.todos;
+    if (!Array.isArray(list)) return null;
+    const todos: TodoProgressItem[] = [];
+    for (const it of list) {
+      const text = typeof it?.content === 'string' ? it.content.trim() : '';
+      if (!text) continue;
+      const item: TodoProgressItem = { content: text, status: normalizeTodoStatus(it?.status) };
+      if (typeof it?.activeForm === 'string' && it.activeForm.trim()) item.activeForm = it.activeForm.trim();
+      todos.push(item);
+    }
+    return todos;
+  }
+  return null;
+}
+
+/** Parse a Codex `update_plan` function_call line into checklist items (null if not one). */
+function parseCodexPlan(raw: any): TodoProgressItem[] | null {
+  if (raw?.type !== 'response_item') return null;
+  const payload = raw?.payload;
+  if (payload?.type !== 'function_call' || payload?.name !== 'update_plan') return null;
+  let args: any = {};
+  if (typeof payload?.arguments === 'string') {
+    try { args = JSON.parse(payload.arguments); } catch { return null; }
+  } else if (payload?.arguments && typeof payload.arguments === 'object') {
+    args = payload.arguments;
+  }
+  const list = args?.plan;
+  if (!Array.isArray(list)) return null;
+  const todos: TodoProgressItem[] = [];
+  for (const it of list) {
+    const text = typeof it?.step === 'string' ? it.step.trim() : '';
+    if (!text) continue;
+    todos.push({ content: text, status: normalizeTodoStatus(it?.status) });
+  }
+  return todos;
 }
 
 /**

--- a/apps/factory/src/vscode/agentPanel.vscode.ts
+++ b/apps/factory/src/vscode/agentPanel.vscode.ts
@@ -33,7 +33,7 @@ import { getSessionPathBySessionId, getSessionPreviewInfo, SessionPreviewInfo, r
 import { extractLinearTicketId } from '../core/utils';
 import { readPrompts } from './settings.vscode';
 import { BUILT_IN_AGENTS } from '../core/agents';
-import { parseLineForActivity, formatActivity } from '../core/session.activity';
+import { parseLineForActivity, formatActivity, extractTodoProgress, type TodoProgress } from '../core/session.activity';
 import { getSessionToolStatsViaAgentsCli } from '../core/handoff';
 import {
   extractPrUrls as extractPrUrlsHelper,
@@ -122,6 +122,9 @@ interface PanelSnapshot {
   // Conversation
   conversation?: ConversationSummary;
   recentActivity?: ActivityItem[];
+  // Fine-grained task checklist + done/total, from the agent's latest plan write.
+  // Rides the transcript tail already read for recentActivity (no extra I/O).
+  todoProgress?: TodoProgress;
   // Linked artifacts — multi-PR (the agent may have opened several in one session)
   linearIssue?: string;
   pullRequests?: PullRequestRef[];
@@ -478,6 +481,8 @@ class AgentPanelProvider implements vscode.WebviewViewProvider {
 
           const tailLines = await readTailLines(filePath, 80);
           snapshot.recentActivity = collectRecentActivity(tailLines, entry.agentType, 5);
+          // Fine-grained progress rides the SAME tail — no extra read, no floor poll.
+          snapshot.todoProgress = extractTodoProgress(tailLines.join('\n'), entry.agentType as 'claude' | 'codex' | 'gemini') ?? undefined;
           // Scan the full transcript-by-tail PLUS first/last user messages so a
           // PR mentioned in a wrap-up message isn't dropped. extractPrUrls
           // returns every match deduped, not just the first.
@@ -786,6 +791,43 @@ class AgentPanelProvider implements vscode.WebviewViewProvider {
     color: var(--vscode-foreground);
     word-break: break-word;
   }
+  h2 .todo-frac {
+    color: var(--vscode-descriptionForeground);
+    font-weight: 600;
+    font-size: 11px;
+  }
+  .todo-track {
+    height: 3px;
+    border-radius: 2px;
+    background: var(--vscode-editorWidget-border, rgba(128,128,128,0.3));
+    overflow: hidden;
+    margin-bottom: 6px;
+  }
+  .todo-track > i {
+    display: block;
+    height: 100%;
+    background: var(--vscode-progressBar-background, var(--vscode-textLink-foreground));
+  }
+  .todo {
+    display: flex;
+    align-items: baseline;
+    gap: 7px;
+    padding: 1px 0;
+    font-size: 11.5px;
+    line-height: 1.4;
+  }
+  .todo-mk {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    align-self: center;
+    background: var(--vscode-descriptionForeground);
+  }
+  .todo.status-in_progress .todo-mk { background: var(--vscode-charts-yellow, #d7a000); }
+  .todo.status-completed .todo-mk { background: var(--vscode-charts-green, #4caf50); }
+  .todo.status-completed .todo-txt { text-decoration: line-through; color: var(--vscode-descriptionForeground); }
+  .todo-txt { color: var(--vscode-foreground); word-break: break-word; }
   .actions-row {
     display: flex;
     gap: 6px;
@@ -1260,6 +1302,25 @@ function renderActivityCard(s) {
   );
 }
 
+function renderChecklistCard(s) {
+  const p = s.todoProgress;
+  if (!p || !p.total) return '';
+  const pct = Math.round((p.done / p.total) * 100);
+  const rows = p.todos.map((t) => (
+    '<div class="todo status-' + esc(t.status) + '">' +
+      '<span class="todo-mk"></span>' +
+      '<span class="todo-txt">' + esc(truncate(t.content, 100)) + '</span>' +
+    '</div>'
+  )).join('');
+  return (
+    '<h2>Checklist <span class="todo-frac">' + p.done + '/' + p.total + '</span></h2>' +
+    '<div class="card">' +
+      '<div class="todo-track"><i style="width:' + pct + '%"></i></div>' +
+      rows +
+    '</div>'
+  );
+}
+
 function renderPromptsCard(s) {
   const prompts = s.quickPrompts || [];
   if (!prompts.length) return '';
@@ -1480,6 +1541,7 @@ function render(snap) {
     renderActionsCard(snap) +
     renderLinksCard(snap) +
     renderConversationCard(snap) +
+    renderChecklistCard(snap) +
     renderActivityCard(snap) +
     renderRecentFilesCard(snap) +
     renderWorktreesCard(snap) +


### PR DESCRIPTION
Closes RUSH-1380.

## What
Surface each agent's `TodoWrite`/`update_plan` plan + progress as live, fine-grained progress on the single-agent detail panel — riding the **per-task detail STREAM** (the transcript tail), NOT the 5s floor poll (the ticket's perf trap).

## What already existed (built on)
The Factory Floor React card + detail already render poll-sourced todos:
- `floorModel.ts` — `latestTodos(toolCalls)` (latest-write-wins) + `todoProgress(todos)` → `{done,total}` (RUSH-1531, PR #832 "streaming activity + todos").
- `TodoChecklist.tsx` — `CardChecklist` (card `{done}/{total}` bar) and `TodoChecklist` (detail `N/M tasks` header).
- `floorAdapter.ts` — `stickyTodos()` feeds `FloorAgent.todos` from the session-summary tool calls (capped at 24 → `todosWithFallback`).

What was **missing** is the extractor the ticket asked for in `apps/factory/src/core/session.activity.ts` (the transcript/stream parser had no todo support), and any todo display on the focused single-agent detail panel.

## What this adds
- **`session.activity.ts` → `extractTodoProgress(sessionContent, agentType)`** — a pure, unit-tested extractor. Walks the transcript tail from the end and returns the LATEST plan write's checklist + a `{todos, done, total}` tally (latest write fully supersedes earlier ones).
  - Claude: `TodoWrite` tool_use with `input.todos: [{content, status, activeForm}]`.
  - Codex: `update_plan` function_call with `arguments.plan: [{step, status}]` (the Codex equivalent).
  - Gemini: no plan tool → `null`. Empty/absent plan → `null`.
- **`agentPanel.vscode.ts`** — computes `snapshot.todoProgress` off the **same 80-line tail already read** for `recentActivity` (zero extra I/O, per-task stream, not the floor poll), and renders a `Checklist N/M` card with a progress bar + per-status checklist in the detail panel.

## How verified
- `bun test src/core/session.activity.test.ts` → **17 pass / 0 fail** (10 new `extractTodoProgress` cases: pending/in_progress/completed counts, latest-write-wins for both Claude + Codex, `activeForm` capture, unknown-status→pending, no-todos→null, empty-array→null, gemini→null, codex non-plan→null).
- `tsc -p ./` → **0 errors**.
- Full `./src` suite: only pre-existing/environmental failures unrelated to these files (leader-election flake, Cursor SQLite reader, model-alias network resolver).
- Panel render verified with a standalone harness: empty snapshot → no card; filled → `<h2>Checklist <span class="todo-frac">2/3</span></h2>` + 67% bar + per-status rows, content HTML-escaped.

Transcript (private repo): `yosemite-s0:/home/muqsit/.agents/.history/versions/claude/2.1.170/home/.claude/projects/-home-muqsit--agents-repos-prix-cli-1380--agents-worktrees-rush1380cli/1fb6e5b1-0a14-4bd3-887f-39c1a9b136f4.jsonl`

Not self-merging — over to the owner to review + merge.