### PR TITLE
docs(routines): document sandbox:false requirement for headless claude routines

### DIFF
--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -86,6 +86,36 @@ The agent can only:
 - Use tools listed in `allow.tools`
 - Cannot access `~/.ssh`, `~/.gitconfig`, etc.
 
+### Headless claude auth
+
+The sandbox overlay sets `HOME` to the job's overlay directory, which contains
+no claude credentials. A routine whose agent is `claude` — or any routine that
+spawns headless `claude` as a sub-step — will therefore fail to authenticate
+inside the sandbox.
+
+**Current workaround — `sandbox: false`:**
+
+```yaml
+name: my-claude-routine
+agent: claude
+sandbox: false      # skip the HOME overlay; claude reads credentials from your real HOME
+prompt: |
+  ...
+```
+
+Setting `sandbox: false` bypasses `prepareJobHome` entirely (see the `if sandbox≠false`
+branch in the execution flow above) and runs the agent with your real `HOME`, where
+`~/.claude/` and the OAuth session live.
+
+**Why the daemon token alone is not enough:**
+
+The daemon reads `CLAUDE_CODE_OAUTH_TOKEN` from the claude secrets bundle at startup
+and injects it into child processes — but only when the bundle is present in the
+agent's version store. Even with that token injected, the sandboxed process still
+has no `~/.claude/` directory (the overlay is empty), so the claude binary cannot
+fully initialize. `sandbox: false` is therefore the reliable workaround today;
+forwarding credentials into the sandbox overlay is a planned improvement.
+
 ## Execution Flow
 
 Temporal sequence from cron fire to report saved.

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -111,10 +111,11 @@ branch in the execution flow above) and runs the agent with your real `HOME`, wh
 
 The daemon reads `CLAUDE_CODE_OAUTH_TOKEN` from the claude secrets bundle at startup
 and injects it into child processes — but only when the bundle is present in the
-agent's version store. Even with that token injected, the sandboxed process still
-has no `~/.claude/` directory (the overlay is empty), so the claude binary cannot
-fully initialize. `sandbox: false` is therefore the reliable workaround today;
-forwarding credentials into the sandbox overlay is a planned improvement.
+agent's version store. Even with that token injected, the sandboxed process's
+`~/.claude/` contains only a generated `settings.json` with tool permissions (no
+OAuth credentials or session tokens), so the claude binary cannot authenticate.
+`sandbox: false` is therefore the reliable workaround today; forwarding credentials
+into the sandbox overlay is a planned improvement.
 
 ## Execution Flow
 


### PR DESCRIPTION
## Summary

- Adds a `### Headless claude auth` subsection under `## Sandbox Isolation` in `apps/cli/docs/03-routines.md`
- Documents that the sandbox overlay HOME has no claude credentials, causing auth failures for routines that spawn headless claude
- Documents `sandbox: false` as the current workaround
- Explains why the daemon-level `CLAUDE_CODE_OAUTH_TOKEN` injection alone is not sufficient when the overlay HOME is empty

Doc-only change, no code.

Closes RUSH-1590