### PR TITLE
test: hermetic suite — tests can no longer wipe the real secrets broker or pollute the real events log

### DIFF
--- a/apps/cli/src/lib/events.ts
+++ b/apps/cli/src/lib/events.ts
@@ -25,9 +25,12 @@ import { getUserAgentsDir } from './state.js';
 
 // Resolved lazily: events.ts is imported transitively by most CLI surfaces, and
 // import itself must stay side-effect free. Tests may override the exact path.
+// AGENTS_EVENTS_PATH redirects the sink — a test seam like AGENTS_SECRETS_AGENT_DIR:
+// unlike _resetForTest it survives a bare reset AND propagates to CLI subprocesses
+// a test spawns, so fixture events can never land in the user's real log (#910).
 let _eventsPath: string | undefined;
 function eventsPath(): string {
-  return (_eventsPath ??= path.join(getUserAgentsDir(), 'events.jsonl'));
+  return (_eventsPath ??= process.env.AGENTS_EVENTS_PATH || path.join(getUserAgentsDir(), 'events.jsonl'));
 }
 
 function eventsDir(): string {

--- a/apps/cli/src/lib/secrets/__tests__/bundles-storage.test.ts
+++ b/apps/cli/src/lib/secrets/__tests__/bundles-storage.test.ts
@@ -79,6 +79,8 @@ let restore: KeychainBackend | null = null;
 let store: Map<string, StoredItem>;
 let fileTmpDir: string;
 
+let prevNoUsageTrack: string | undefined;
+
 beforeEach(() => {
   const m = makeMemoryBackend();
   store = m.store;
@@ -89,12 +91,19 @@ beforeEach(() => {
   // the secret-service fallback), leaking those into the counts asserted here.
   fileTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-bundles-storage-'));
   _resetFileStoreForTest({ fileDir: fileTmpDir });
+  // The timestamps suite asserts last_used stamping, which the hermetic
+  // default (tests/setup.ts) disables suite-wide. Stamping here only reaches
+  // the injected in-memory backend above, so it is safe to re-enable.
+  prevNoUsageTrack = process.env.AGENTS_NO_USAGE_TRACK;
+  delete process.env.AGENTS_NO_USAGE_TRACK;
 });
 
 afterEach(() => {
   setKeychainBackendForTest(restore);
   _resetFileStoreForTest();
   fs.rmSync(fileTmpDir, { recursive: true, force: true });
+  if (prevNoUsageTrack === undefined) delete process.env.AGENTS_NO_USAGE_TRACK;
+  else process.env.AGENTS_NO_USAGE_TRACK = prevNoUsageTrack;
 });
 
 describe('writeBundle + readBundle round-trip', () => {

--- a/apps/cli/tests/events-audit.test.ts
+++ b/apps/cli/tests/events-audit.test.ts
@@ -38,7 +38,10 @@ function makeTempHome(): string {
 function runCli(home: string, args: string[], extraEnv: Record<string, string> = {}) {
   return spawnSync('node', ['--import', 'tsx', 'src/index.ts', ...args], {
     cwd: REPO_ROOT,
-    env: { ...process.env, HOME: home, SHELL: '/bin/zsh', ...extraEnv },
+    // AGENTS_EVENTS_PATH is inherited from the hermetic fork default
+    // (tests/setup.ts); blank it so the child resolves the canonical
+    // HOME-derived log this suite asserts on ('' is falsy in the resolver).
+    env: { ...process.env, HOME: home, SHELL: '/bin/zsh', AGENTS_EVENTS_PATH: '', ...extraEnv },
     encoding: 'utf-8',
   });
 }

--- a/apps/cli/tests/setup.ts
+++ b/apps/cli/tests/setup.ts
@@ -1,0 +1,57 @@
+/**
+ * Fork-level hermeticity (#910). vitest runs pool:'forks' — this file executes
+ * in every fresh fork BEFORE the test file's imports, so the env it pins is
+ * what state.ts / secrets/agent.ts / events.ts capture. Without it, a suite
+ * run on a dev machine wrote test-fixture `secrets.get` events into the user's
+ * real events log and reached the user's real secrets-agent broker (wiping
+ * every unlocked bundle pre-#909).
+ *
+ * These are the DEFAULT posture, not a cage: tests that need a specific
+ * posture (a live temp broker, event-content assertions, usage-stamp checks)
+ * still override per-test and restore, exactly as they do today — the saved
+ * "previous" value they restore is simply the hermetic default.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterAll } from 'vitest';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-vitest-'));
+
+// Broker: pin the socket dir to a fork-private temp path so nothing in this
+// fork — nor any CLI subprocess it spawns with inherited env — can reach the
+// user's real broker socket; and turn the broker client integration off as
+// the default (the read fast-path, auto-load, and write eviction all honor
+// this, see bundles.ts).
+process.env.AGENTS_SECRETS_AGENT_DIR = path.join(tmp, 'secrets-agent');
+process.env.AGENTS_SECRETS_NO_AGENT = '1';
+
+// Usage stamping writes bundle metadata back to the secret store on reads.
+process.env.AGENTS_NO_USAGE_TRACK = '1';
+
+// Events: redirect the sink to a fork-private file. Redirect, not disable —
+// events.test.ts / logs.test.ts assert on written content and re-point the
+// sink themselves via _resetForTest, which takes precedence over this env.
+process.env.AGENTS_EVENTS_PATH = path.join(tmp, 'events.jsonl');
+
+// Leak tripwire: the REAL events log must not grow while this fork runs.
+// CI-only — on a dev machine live agents append to it concurrently, so the
+// check would false-positive locally; CI homes are quiet.
+const realEventsLog = path.join(process.env.HOME ?? os.homedir(), '.agents', 'events.jsonl');
+const sizeBefore = fs.existsSync(realEventsLog) ? fs.statSync(realEventsLog).size : 0;
+
+afterAll(() => {
+  try {
+    if (process.env.CI) {
+      const sizeAfter = fs.existsSync(realEventsLog) ? fs.statSync(realEventsLog).size : 0;
+      if (sizeAfter > sizeBefore) {
+        throw new Error(
+          `hermeticity leak (#910): the real events log grew by ${sizeAfter - sizeBefore} bytes ` +
+          `during this test file (${realEventsLog}). Some code path bypassed AGENTS_EVENTS_PATH.`,
+        );
+      }
+    }
+  } finally {
+    try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});

--- a/apps/cli/tests/teams-events.test.ts
+++ b/apps/cli/tests/teams-events.test.ts
@@ -34,7 +34,10 @@ function makeTempHome(): string {
 function runCli(home: string, args: string[]) {
   return spawnSync('node', ['--import', 'tsx', 'src/index.ts', ...args], {
     cwd: REPO_ROOT,
-    env: { ...process.env, HOME: home, SHELL: '/bin/zsh', SSH_CONNECTION: '' },
+    // AGENTS_EVENTS_PATH is inherited from the hermetic fork default
+    // (tests/setup.ts); blank it so the child resolves the canonical
+    // HOME-derived log this suite asserts on ('' is falsy in the resolver).
+    env: { ...process.env, HOME: home, SHELL: '/bin/zsh', SSH_CONNECTION: '', AGENTS_EVENTS_PATH: '' },
     encoding: 'utf-8',
   });
 }

--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     pool: 'forks',
+    // Hermeticity (#910): every fork gets a temp-pinned broker socket, events
+    // sink, and broker-off defaults BEFORE the test file's imports run.
+    setupFiles: ['./tests/setup.ts'],
     include: ['tests/**/*.test.ts', 'src/**/__tests__/**/*.test.ts', 'src/**/*.test.ts', 'scripts/**/*.test.ts'],
     testTimeout: 30000,
   },


### PR DESCRIPTION
Closes #910.

## Problem

Running `bun run test` in `apps/cli` on a dev machine touched real machine state, twice observed in one day while root-causing #909:

- **Test-fixture `secrets.get` events** (bundles `prod`, `work`, `rel`, `one`, `two`; callers `test`, `sync push`, `secrets-mcp`, `daemon`, `sessions-sync`) landed in the user's real `~/.agents/events.jsonl`, polluting the `agents logs audit` trail with fixture noise.
- **The real secrets-agent broker got wiped** by suite runs (pre-#909 teardown path), forcing fresh Touch ID prompts for every held bundle afterward.

The seams existed (`AGENTS_SECRETS_AGENT_DIR`, `AGENTS_SECRETS_NO_AGENT`, `_resetForTest`) but were applied per-file, inconsistently — and `_resetForTest` can't cross into CLI subprocesses tests spawn.

## Fix

- **`tests/setup.ts`** (wired via `setupFiles`): runs in every fork before the test file's imports (`pool: 'forks'`), pinning the hermetic default posture — broker socket dir → fork-private temp, `AGENTS_SECRETS_NO_AGENT=1`, `AGENTS_NO_USAGE_TRACK=1`, events sink → fork-private file. Env-based, so it is inherited by any CLI subprocess a test spawns. Plus a **CI-only tripwire**: the fork fails if the real events log grew during the run (dev machines have live agents appending concurrently, so the check would false-positive locally; CI homes are quiet).
- **`events.ts`**: new `AGENTS_EVENTS_PATH` env seam for the sink path — same precedent as `AGENTS_SECRETS_AGENT_DIR`; `''` is falsy in the resolver so a child can blank it to restore HOME-derived resolution.
- **Three suites opt out and restore** (they intentionally exercise the guarded paths): `bundles-storage.test.ts` re-enables usage stamping against its injected in-memory backend; `events-audit.test.ts` / `teams-events.test.ts` blank `AGENTS_EVENTS_PATH` in their child env so the spawned CLI resolves the HOME-derived log they assert on.

## Verification

Full suite run twice on the affected machine (zion):
- **Broker**: `agents secrets status` held bundles (`cloudflare.com`, `hetzner.com`, `linear.app`) intact through both runs — pre-fix, a run wiped them.
- **Events log**: zero fixture-marker lines (`prod`/`rel`/`work`/`one`/`two`/`caller:test`) in the real log's growth delta across the runs; the growth that did occur was live-agent traffic.
- **Tests**: 4786 passed; the 8 failures (codex exec/models, serve server) fail identically on pristine `origin/main` — pre-existing, environment-dependent, untouched here.

Session transcript (local, fleet-readable): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.170/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/bcdd5e00-eb4b-4c08-9678-5d85cc30bfc7.jsonl`