### PR TITLE
fix: preserve structured feed questions

### DIFF
--- a/apps/cli/src/lib/feed.test.ts
+++ b/apps/cli/src/lib/feed.test.ts
@@ -223,6 +223,54 @@ describe('feed store', () => {
     }]);
   });
 
+  it.runIf(hasPython)('real hook keeps AskUserQuestion details when Claude emits its permission notification', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-feed-question-notification-'));
+    const feedDir = path.join(home, '.agents', '.history', 'feed');
+    const question = spawnSync('python3', ['-c', FEED_PUBLISH_HOOK_SCRIPT], {
+      input: JSON.stringify({
+        session_id: 'session-question-notify',
+        hook_event_name: 'PreToolUse',
+        tool_input: {
+          questions: [{
+            question: 'Which environment?',
+            header: 'Deploy',
+            options: [
+              { label: 'Staging', description: 'Deploy to staging' },
+              { label: 'Production', description: 'Deploy to production' },
+            ],
+          }],
+        },
+      }),
+      env: { ...process.env, HOME: home },
+      encoding: 'utf-8',
+    });
+    expect(question.status).toBe(0);
+
+    const notification = spawnSync('python3', ['-c', FEED_PUBLISH_HOOK_SCRIPT], {
+      input: JSON.stringify({
+        session_id: 'session-question-notify',
+        hook_event_name: 'Notification',
+        notification_type: 'permission_prompt',
+        title: 'Permission Prompt',
+        message: 'Claude needs your permission',
+      }),
+      env: { ...process.env, HOME: home },
+      encoding: 'utf-8',
+    });
+    expect(notification.status).toBe(0);
+    expect(listBlocks(feedDir)).toMatchObject([{
+      kind: 'question',
+      questions: [{
+        text: 'Which environment?',
+        header: 'Deploy',
+        options: [
+          { label: 'Staging', description: 'Deploy to staging' },
+          { label: 'Production', description: 'Deploy to production' },
+        ],
+      }],
+    }]);
+  });
+
   it.runIf(hasPython)('real hook ignores notifications that do not represent a wait', () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-feed-notification-ignore-'));
     const result = spawnSync('python3', ['-c', FEED_PUBLISH_HOOK_SCRIPT], {

--- a/apps/cli/src/lib/feed.ts
+++ b/apps/cli/src/lib/feed.ts
@@ -186,6 +186,17 @@ def main():
         notification_type = payload.get("notification_type", "")
         if notification_type not in WAITING_NOTIFICATION_TYPES:
             return
+        # Claude emits a generic permission notification after presenting an
+        # AskUserQuestion. Keep the structured questions and options already
+        # published for this session instead of replacing them with that less
+        # useful notification text.
+        try:
+            with open(target) as existing_file:
+                existing = json.load(existing_file)
+            if existing.get("kind") == "question":
+                return
+        except Exception:
+            pass
         message = payload.get("message", "")
         if not message:
             return


### PR DESCRIPTION
Fixes the installed-flow regression found during RUSH-1473 verification: Claude emits a generic permission notification after AskUserQuestion, which replaced the structured question and options for the same session.

Change:
- Keep an existing question block when a later waiting notification arrives for that session.
- Add a real hook-process regression test for the exact AskUserQuestion -> Notification sequence.

Evidence:
- Installed 0.0.0-dev.6c652f4eb live flow reproduced the bug: the feed rendered only "Claude needs your permission" while the terminal showed Staging and Production.
- bunx vitest run for feed, command feed, remote JSON, remote-active, and passthrough: 45/45 passed.
- bun run build: passed.
- git diff --check: passed.

This is a pure bug fix; existing README and changelog coverage from #914 already describes the intended behavior.