### PR TITLE
fix(runner): handle spawn ENOENT in executeJobDetached to prevent daemon crash

### DIFF
--- a/apps/cli/src/lib/__tests__/runner.test.ts
+++ b/apps/cli/src/lib/__tests__/runner.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { buildJobCommand } from '../runner.js';
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { buildJobCommand, executeJobDetached } from '../runner.js';
+import { readRunMeta } from '../routines.js';
+import { getRunsDir } from '../state.js';
 import type { JobConfig } from '../routines.js';
 
 function baseJob(overrides: Partial<JobConfig> = {}): JobConfig {
@@ -64,5 +68,44 @@ describe('buildJobCommand', () => {
 
   it('kimi plan mode throws (no headless read-only mode)', () => {
     expect(() => buildJobCommand(baseJob({ agent: 'kimi', mode: 'plan' }), 'Do the task.')).toThrow(/read-only/);
+  });
+});
+
+describe('executeJobDetached — spawn error handling', () => {
+  const cleanupJobDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of cleanupJobDirs.splice(0)) {
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+    }
+  });
+
+  it('marks run failed in meta.json on spawn ENOENT without throwing', async () => {
+    // Use 'codex' which is not on PATH in this environment — guaranteed ENOENT.
+    const config: JobConfig = {
+      name: '__runner-test-enoent__',
+      schedule: '0 0 * * *',
+      agent: 'codex',
+      mode: 'plan',
+      effort: 'auto',
+      timeout: '10m',
+      enabled: true,
+      prompt: 'test prompt',
+      sandbox: false,
+    };
+
+    cleanupJobDirs.push(path.join(getRunsDir(), config.name));
+
+    const meta = await executeJobDetached(config);
+    expect(meta.status).toBe('running');
+
+    // Give the async error event time to fire and rewrite meta.json.
+    await new Promise<void>((r) => setTimeout(r, 200));
+
+    const updated = readRunMeta(config.name, meta.runId);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('failed');
+    expect(updated!.exitCode).toBe(1);
+    expect(updated!.completedAt).not.toBeNull();
   });
 });

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -390,6 +390,15 @@ export async function executeJobDetached(config: JobConfig): Promise<RunMeta> {
     env: spawnEnv,
   });
 
+  child.on('error', (err) => {
+    try { fs.closeSync(stdoutFd); } catch { /* fd already closed */ }
+    meta.status = 'failed';
+    meta.exitCode = 1;
+    meta.completedAt = new Date().toISOString();
+    writeRunMeta(meta);
+    process.stderr.write(`[agents] daemon: spawn failed for job "${config.name}": ${err.message}\n`);
+  });
+
   child.unref();
   try { fs.closeSync(stdoutFd); } catch { /* fd already closed */ }
 


### PR DESCRIPTION
## Summary

- `executeJobDetached` had no `child.on('error')` handler — a spawn ENOENT (agent binary not on daemon PATH) emitted an unhandled `error` event and killed the entire daemon process, taking all other scheduled routines with it
- Added error handler that marks the run's `meta.json` as `status: 'failed'` with `exitCode: 1` and `completedAt` set, so the run is not permanently stuck at `running`/`pid: null` which `monitorRunningJobs()` would never reap
- `executeJob` already had an equivalent handler (line 335); this brings `executeJobDetached` to parity
- Added integration test: spawns `codex` (not on PATH in CI) → verifies the function returns without throwing and `meta.json` shows `failed` after the async error fires

## Test plan

- [x] `bun run test src/lib/__tests__/runner.test.ts` — all 8 tests pass, including new ENOENT regression test
- [x] stderr confirms error handler fires: `[agents] daemon: spawn failed for job "__runner-test-enoent__": spawn codex ENOENT`

Fixes: RUSH-1593