### PR TITLE
ci(win-e2e): install dotnet into a user-writable dir on the self-hosted runner

### DIFF
--- a/.github/workflows/tests-windows-host-e2e.yml
+++ b/.github/workflows/tests-windows-host-e2e.yml
@@ -53,6 +53,10 @@ jobs:
         working-directory: apps/cli
     env:
       AGENTS_TEST_WIN_HOST: win-mini
+      # setup-dotnet defaults to /usr/share/dotnet, which needs root the
+      # hosted runners have but this self-hosted (rootless, user-systemd)
+      # runner does not. Install into a user-writable, workspace-local dir.
+      DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 


### PR DESCRIPTION
The first live run of the Windows-host e2e workflow (added in #890, merged) failed at **Setup .NET**:

```
mkdir: cannot create directory '/usr/share/dotnet': Permission denied
##[error]Failed to install dotnet, exit code: 1.
```

`actions/setup-dotnet` defaults to `/usr/share/dotnet`, which GitHub-hosted runners can write as root but this **rootless, user-systemd** self-hosted runner (yosemite-s0) cannot. Fix: set `DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet` so the cross-publish step installs into a user-writable, workspace-local dir.

Verified the same run's later steps (checkout, bun) were fine — dotnet was the only blocker. After merge I'll re-trigger `tests-windows-host-e2e.yml` and attach the green run to #864 before closing it.

Refs #864.