### PR TITLE
RUSH-1532: show human factory session labels

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ### Fixed
 
+- **Factory Floor cards now use human session names instead of UUID slices (RUSH-1532).**
+  Remote sessions preserve explicit labels separately from task topics, and the Floor
+  card header prefers label, topic, branch, ticket, and worktree metadata before falling
+  back to a generic agent title. Cloud single-agent rows now use their configured name
+  or prompt line instead of `agent-019e30a2`-style identifiers.
 - **NEEDS YOU precision — finished/stopped agents no longer masquerade as needing
   input (RUSH-1522).** Two gates tightened. (1) `derivePhase` now checks terminal
   statuses first: a `completed`/`stopped`/`failed` agent can no longer be lifted

--- a/apps/factory/src/core/remoteSessions.test.ts
+++ b/apps/factory/src/core/remoteSessions.test.ts
@@ -240,15 +240,17 @@ describe('normalizeActiveSession', () => {
       ticket: { id: 'RUSH-1262' },
       branch: { id: 'abc' },
       topic: { id: 'xyz' },
+      label: { id: 'manual' },
       prUrl: { id: 'p' },
     } as unknown as RawActiveSession;
     const s = normalizeActiveSession(bad, 'this-mac', FETCHED_AT);
     expect(typeof s.branch).toBe('string');
     expect(typeof s.topic).toBe('string');
+    expect(typeof s.label).toBe('string');
     expect(s.ticket === null || typeof s.ticket === 'string').toBe(true);
     expect(s.prUrl === null || typeof s.prUrl === 'string').toBe(true);
     // No object leaked through under the guise of a string.
-    for (const v of [s.ticket, s.branch, s.topic, s.prUrl]) {
+    for (const v of [s.ticket, s.branch, s.topic, s.label, s.prUrl]) {
       expect(typeof v === 'object' && v !== null).toBe(false);
     }
   });
@@ -494,17 +496,19 @@ describe('groupByHost', () => {
 describe('normalizeActiveSession — topic', () => {
   test('carries the topic (or falls back to the cloud label) so remote cards are not blank', () => {
     const term = normalizeActiveSession(
-      { kind: 'claude', status: 'running', sessionFile: '/x/aaaaaaaa.jsonl', topic: 'Add a pre-commit hook' } as RawActiveSession,
+      { kind: 'claude', status: 'running', sessionFile: '/x/aaaaaaaa.jsonl', topic: 'Add a pre-commit hook', label: 'hooks label' } as RawActiveSession,
       'zion',
       FETCHED_AT
     );
     expect(term.topic).toBe('Add a pre-commit hook');
+    expect(term.label).toBe('hooks label');
     const cloud = normalizeActiveSession(
       { kind: 'codex', status: 'queued', cloudTaskId: 'task_e', label: 'Read README and summarize' } as RawActiveSession,
       'this-mac',
       FETCHED_AT
     );
     expect(cloud.topic).toBe('Read README and summarize');
+    expect(cloud.label).toBe('Read README and summarize');
   });
 });
 

--- a/apps/factory/src/core/remoteSessions.ts
+++ b/apps/factory/src/core/remoteSessions.ts
@@ -169,6 +169,9 @@ export interface RemoteSession {
   /** The session's task/prompt line from the CLI payload (`topic`/`label`). Shown
    *  on the card when Tier-1 has no enriched activity yet (remote hosts). */
   topic: string;
+  /** User-set session label from the CLI payload. Kept separate from topic so UI
+   *  card headers can prefer explicit names over inferred task lines. */
+  label: string;
   /** Absolute session-file path, kept so the fan-out can enrich the deduped
    *  survivor without re-reading the raw record. */
   sessionFile: string;
@@ -457,6 +460,7 @@ export function normalizeActiveSession(
     // sessions. Deliberately NOT startedAtMs — start time is not activity.
     lastActivityMs: 0,
     topic: asStr(raw.topic) || asStr(raw.label),
+    label: asStr(raw.label),
     sessionFile: asStr(raw.sessionFile),
     context: asStr(raw.context),
     cloudTaskId: raw.cloudTaskId || '',
@@ -543,6 +547,7 @@ export function normalizeRecentSession(
     startedAtMs,
     lastActivityMs,
     topic: asStr(raw.topic) || asStr(raw.label),
+    label: asStr(raw.label),
     sessionFile: '',
     context: 'recent',
     cloudTaskId: '',

--- a/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
@@ -73,14 +73,6 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
   const meta = plain
     ? a.project
     : `${a.project} · ${a.hostLabel ?? a.host}${a.ticket ? ` · ${a.ticket}` : ''}${filesLabel}${paneLabel}${viewingLabel}`
-  // Compact provenance chip next to the name: "<agent>·<short session id>", e.g.
-  // "claude·4de7b016" — so a human label ("terminal-race-fix") reads as the title
-  // while the session stays identifiable. Only when the id differs from the shown name.
-  const agentSlug = agentIdFromPrefix(a.abbr) ?? a.abbr.toLowerCase()
-  const shortSid = a.sessionId ? a.sessionId.replace(/-/g, '').slice(0, 8) : ''
-  // Suppress the chip when the name is the fallback hash label ("claude-596c4c07")
-  // that already carries the same id — only show it beside a genuine human label.
-  const sid = shortSid && !a.name.endsWith(shortSid) ? `${agentSlug}·${shortSid}` : ''
   const destructive = a.question?.kind === 'destructive'
   const attn = a.phase === 'failed' ? 'fail' : stalled ? 'stall' : a.needs ? 'attn' : ''
 
@@ -95,10 +87,11 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
   const taskLine = sessionTaskLine(a)
   // The ORIGINAL task anchors the card. When the session carries a prompt, the title
   // reads the task (its first line) and the prompt gets its own TASK block below; the
-  // agent name stays as context in the title's tooltip + the provenance chip. Without a
+  // agent name stays as context in the title tooltip. Without a
   // prompt, the title stays the agent's own display name (prior behavior).
   const prompt = (a.prompt ?? '').trim()
   const title = !plain && prompt ? firstLine(prompt) : a.name
+  const nameTitle = [prompt ? `${a.name} — ${prompt}` : a.name, a.sessionId ? `Session ${a.sessionId}` : ''].filter(Boolean).join('\n')
   const showTask = !plain && !!prompt
   // Only show the rolling summary line when it adds signal beyond the task block, the
   // response body, and the now-line (it merely echoes the prompt when they match).
@@ -144,8 +137,7 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
       <div className="head">
         <span className={`dot ${a.phase}`} />
         <AgentAvatar id={agentIdFromPrefix(a.abbr) ?? a.abbr.toLowerCase()} size={20} title={a.abbr} />
-        <span className="who" title={prompt ? `${a.name} — ${prompt}` : a.name}>{title}</span>
-        {!plain && sid && <span className="sid" title={a.sessionId}>{sid}</span>}
+        <span className="who" title={nameTitle}>{title}</span>
         <span className="path">{meta}</span>
         {!plain && wt && <span className="wtchip mono" title={a.worktreePath || wt}>{wt}</span>}
         <span className="when">

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { TaskSummary, TerminalDetail as TerminalInfo, AgentDetail, UnifiedTask, RecentToolCall, ProjectRule } from '../../types'
-import { AgentAvatar, agentShortChunk } from './AgentAvatar'
+import { AgentAvatar } from './AgentAvatar'
 import { Icon } from './icons'
 import { relTime, taskNameToTitle, swarmOverallStatus, shortDuration } from './types'
 import { postMessage, usePanelVisibility } from '../../hooks'
@@ -133,6 +133,11 @@ type FilterTab = 'all' | 'terminal' | 'cloud' | 'team'
 
 type FactoryTaskType = 'plan' | 'implement' | 'test' | 'review' | 'bugfix' | 'docs'
 
+function compactHumanLabel(text: string | null | undefined): string {
+  const line = (text || '').split('\n').map((l) => l.trim()).find(Boolean) || ''
+  return line.replace(/^#+\s+/, '').replace(/^[-*+]\s+/, '').replace(/[*_`]/g, '').slice(0, 72).trim()
+}
+
 export interface WatchdogEventUI {
   ts: number
   kind: 'tick' | 'decision' | 'nudge' | 'rotate' | 'error'
@@ -152,6 +157,7 @@ interface UnifiedAgent {
   id: string
   agentType: string
   displayName: string
+  sessionId?: string
   activity: string
   active: boolean
   duration: string
@@ -182,20 +188,19 @@ function buildUnifiedList(terminals: TerminalInfo[], tasks: TaskSummary[]): Unif
 
   const now = Date.now()
   for (const t of terminals) {
-    const chunk = agentShortChunk(t.sessionId) || (t.id ?? '').slice(-8)
     const justSpawned = isTerminalJustSpawned(t.createdAt, now)
     const isActive = isTerminalActive(t, now)
     const files: string[] = []
     if (t.recentFiles) files.push(...t.recentFiles.slice(0, 5))
     // Prefer a human label (manual > auto) so a card reads "terminal-race-fix" rather
-    // than "claude-596c4c07"; the hash still identifies the session via the sid chip.
-    const humanLabel = (t.label || t.autoLabel || '').trim()
+    // than "claude-596c4c07"; the full session id stays available on hover.
+    const humanLabel = compactHumanLabel(t.label) || compactHumanLabel(t.autoLabel) || compactHumanLabel(t.firstUserMessage)
     items.push({
       kind: 'terminal',
       id: `term-${t.id}`,
       agentType: t.agentType,
       sessionId: t.sessionId ?? undefined,
-      displayName: humanLabel || `${t.agentType}-${chunk}`,
+      displayName: humanLabel || `${t.agentType} session`,
       activity: t.currentActivity || t.label || (justSpawned ? 'Starting...' : t.status === 'idle' ? 'idle' : t.role ?? 'terminal'),
       active: isActive,
       duration: t.firstMessageTimestamp ? relTime(t.firstMessageTimestamp) : '',
@@ -258,9 +263,7 @@ function buildUnifiedList(terminals: TerminalInfo[], tasks: TaskSummary[]): Unif
         kind: isCloud ? 'cloud' : 'headless',
         id: `agent-${a.agent_id}`,
         agentType: a.agent_type,
-        displayName: isCloud
-          ? `${a.agent_type}-${a.agent_id.slice(0, 8)}`
-          : taskNameToTitle(task.task_name),
+        displayName: a.name?.trim() || promptFirstLine || taskNameToTitle(task.task_name),
         activity,
         active: a.status === 'running',
         duration: a.duration || '',
@@ -1209,7 +1212,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
       for (const a of t.agents) {
         if (a.status !== 'input_required') continue
         const existing = byTeam.get(t.task_name) ?? []
-        existing.push({ teammate: a.name ?? a.agent_id.slice(0, 8), agentId: a.agent_id })
+        existing.push({ teammate: (a.name ?? compactHumanLabel(a.prompt)) || `${a.agent_type} teammate`, agentId: a.agent_id })
         byTeam.set(t.task_name, existing)
       }
     }
@@ -2360,8 +2363,7 @@ function identityLabel(item: UnifiedAgent): IdentityLabel {
   if (item.mode === 'plan') return { text: 'PLAN', variant: 'plan' }
   if (item.mode === 'ralph') return { text: 'RALPH', variant: 'ralph' }
   if (item.mode === 'auto') return { text: 'AUTO', variant: 'auto' }
-  const chunk = agentShortChunk(item.terminal?.sessionId) || item.id.slice(-8)
-  return { text: chunk, variant: 'plain' }
+  return { text: item.terminal?.autoLabel || item.displayName || item.agentType, variant: 'plain' }
 }
 
 function statusPhrase(item: UnifiedAgent): { word: string; tone: 'running' | 'idle' | 'failed' | 'completed' | 'waiting'; when: string } {

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -247,7 +247,6 @@
 .swarmify-root .fitem.fail { border-color: var(--status-failed); box-shadow: 0 0 0 1px var(--status-failed-bg); }
 .swarmify-root .fitem .head { display: flex; align-items: center; gap: 9px; margin-bottom: 8px; }
 .swarmify-root .fitem .who { font-weight: 700; font-size: 13px; }
-.swarmify-root .fitem .sid { font-family: "Geist Mono", monospace; font-size: 10.5px; color: var(--ds-text-faint); background: var(--ds-bg-recessed); border: 1px solid var(--ds-border); border-radius: 5px; padding: 1px 6px; flex: none; }
 .swarmify-root .fitem .path { color: var(--ds-text-dim); font-size: 11px; }
 .swarmify-root .fitem .when { margin-left: auto; color: var(--ds-text-dim); font-size: 11px; display: flex; align-items: center; gap: 8px; }
 .swarmify-root .fitem .resp { font-size: 12.5px; color: var(--ds-text); line-height: 1.5; margin: 2px 0 8px; border-left: 2px solid var(--ds-border); padding-left: 10px; }

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
@@ -486,6 +486,106 @@ describe('toFloorAgentFromRemote', () => {
     // Reply routing still targets the real querier host, unaffected by the display label.
     expect(a.reply.host).toBe('zion')
   })
+
+  test('uses a remote manual label as the card name before topic or ids', () => {
+    const r: RemoteSessionLike = {
+      host: 'yosemite-s0',
+      sessionId: '019e30a2-raw-session-id',
+      agentType: 'codex',
+      cwd: '/home/u/src/app',
+      project: 'app',
+      phase: 'running',
+      activity: 'Editing src/app.ts',
+      tokPerSec: 0,
+      waitingForInput: false,
+      lastResponse: '',
+      prUrl: null,
+      ticket: null,
+      branch: 'feature-branch',
+      sinceMs: 1_000,
+      startedAtMs: NOW - 1_000,
+      label: 'factory floor labels',
+      topic: 'Fix Factory header labels',
+      context: 'terminal',
+      cloudTaskId: '',
+      cloudProvider: '',
+      teamName: '',
+      pid: 1,
+      transport: 'ssh',
+      replyRail: '',
+      replyMuxTarget: '',
+      replyMuxSocket: '',
+    }
+    const a = toFloorAgentFromRemote(r, new Set())
+    expect(a.name).toBe('factory floor labels')
+    expect(a.name).not.toContain('019e30a2')
+  })
+
+  test('falls back to topic, never a raw session id slice, when label is absent', () => {
+    const r: RemoteSessionLike = {
+      host: 'zion',
+      sessionId: '019e30a2-dead-beef',
+      agentType: 'claude',
+      cwd: '',
+      project: '',
+      phase: 'running',
+      activity: '',
+      tokPerSec: 0,
+      waitingForInput: false,
+      lastResponse: '',
+      prUrl: null,
+      ticket: null,
+      branch: '',
+      sinceMs: 1_000,
+      startedAtMs: NOW - 1_000,
+      topic: 'Audit cloud UUID headers',
+      context: 'cloud',
+      cloudTaskId: 'task_123',
+      cloudProvider: 'codex',
+      teamName: '',
+      pid: 0,
+      transport: '',
+      replyRail: '',
+      replyMuxTarget: '',
+      replyMuxSocket: '',
+    }
+    const a = toFloorAgentFromRemote(r, new Set())
+    expect(a.name).toBe('Audit cloud UUID headers')
+    expect(a.name).not.toContain('019e30a2')
+  })
+
+  test('uses a generic agent label instead of a uuid when no human fields exist', () => {
+    const r: RemoteSessionLike = {
+      host: 'zion',
+      sessionId: '019e30a2-dead-beef',
+      agentType: 'claude',
+      cwd: '',
+      project: '',
+      phase: 'running',
+      activity: '',
+      tokPerSec: 0,
+      waitingForInput: false,
+      lastResponse: '',
+      prUrl: null,
+      ticket: null,
+      branch: '',
+      sinceMs: 1_000,
+      startedAtMs: NOW - 1_000,
+      topic: '',
+      context: 'terminal',
+      cloudTaskId: '',
+      cloudProvider: '',
+      teamName: '',
+      pid: 0,
+      transport: '',
+      replyRail: '',
+      replyMuxTarget: '',
+      replyMuxSocket: '',
+    }
+    const a = toFloorAgentFromRemote(r, new Set())
+    expect(a.name).toBe('Claude session')
+    expect(a.name).not.toContain('019e30a2')
+  })
 })
 
 describe('deriveReplyTargetFromRemote', () => {

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
@@ -142,6 +142,8 @@ export interface RemoteSessionLike {
   /** Epoch ms of the most recent observed activity (session-file last write).
    *  Recent (historical) sessions carry it from the CLI's lastActivity stamp. */
   lastActivityMs?: number
+  /** User-set session label from `agents run --name` / session metadata. */
+  label?: string
   topic: string
   context: string
   cloudTaskId: string
@@ -249,6 +251,21 @@ export function floorPrLabel(url: string | null | undefined): string | null {
   if (m) return `#${m[1]}`
   const n = url.match(/#(\d+)\s*$/)
   return n ? `#${n[1]}` : null
+}
+
+function humanRemoteSessionName(r: RemoteSessionLike): string {
+  const label = firstNonEmptyStr(
+    r.label,
+    r.topic,
+    r.branch,
+    r.ticket,
+    r.worktreeSlug ? cleanWorktreeSlug(r.worktreeSlug) : undefined,
+    cleanWorktreeSlug(r.cwd),
+    r.project,
+  )
+  if (label) return label
+  const agent = firstNonEmptyStr(r.agentType)
+  return agent ? `${agent.charAt(0).toUpperCase()}${agent.slice(1)} session` : 'Session'
 }
 
 /**
@@ -389,7 +406,7 @@ export function toFloorAgentFromRemote(r: RemoteSessionLike, pinned: Set<string>
   const needs = deriveNeeds(phase, prOpenUnreviewed, ci)
   const { verb, target } = splitActivity(r.activity)
   const id = `remote-${r.host}-${r.sessionId}`
-  const name = r.branch || r.ticket || r.sessionId.slice(0, 8)
+  const name = humanRemoteSessionName(r)
   // Remote (Tier-1) sessions have no enriched last-response yet — fall back to the
   // session's task line (topic) so the card shows what it's working on, not blank.
   const resp = r.lastResponse || r.topic || ''

--- a/apps/factory/ui/settings/components/mission-control/recapModel.ts
+++ b/apps/factory/ui/settings/components/mission-control/recapModel.ts
@@ -8,7 +8,7 @@ import type { AgentAbbr } from './floorModel'
 export interface RecapEntry {
   id: string
   abbr: AgentAbbr
-  /** Task line: topic, else worktree slug, else branch, else the session id. */
+  /** Task line: label/topic, else worktree slug, else branch, else a generic agent title. */
   title: string
   project: string
   host: string
@@ -49,6 +49,10 @@ export function recapCost(usd: number): string {
   return `$${usd.toFixed(2)}`
 }
 
+function recapTitle(s: RemoteSessionLike): string {
+  return s.label || s.topic || s.worktreeSlug || s.branch || (s.agentType ? `${s.agentType} session` : 'Session')
+}
+
 /**
  * Build the day-grouped ledger from the recap sweep. `liveIds` (session ids of
  * agents currently on the live feed) are excluded — the ledger is what FINISHED,
@@ -66,7 +70,7 @@ export function buildRecap(sessions: RemoteSessionLike[], liveIds: Set<string>, 
     entries.push({
       id: s.sessionId,
       abbr: abbrFor(s.agentType),
-      title: s.topic || s.worktreeSlug || s.branch || s.sessionId.slice(0, 8),
+      title: recapTitle(s),
       project: s.project,
       host: s.host,
       branch: s.branch,

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -74,13 +74,13 @@ function agent(p: Partial<FloorAgent>): FloorAgent {
 // identical, contextless "Edit linux.ts / waiting_input" cards. They now carry the
 // project, the worktree slug, and a distinct task line.
 const twinA = agent({
-  id: 'twin-a', abbr: 'CC', name: '02ebf318', project: 'agents-cli', phase: 'waiting',
+  id: 'twin-a', abbr: 'CC', name: 'byok-keychain-cleanup', project: 'agents-cli', phase: 'waiting',
   needs: true, worktreeSlug: 'headless-secrets-shadow', branch: 'muqsit/headless-secrets',
   verb: 'Edit', target: 'src/lib/secrets/linux.ts',
   summary: 'Removing the stale BYOK resolver and its keychain writes.', since: '0s',
 })
 const twinB = agent({
-  id: 'twin-b', abbr: 'CC', name: 'e3d6852d', project: 'agents-cli', phase: 'waiting',
+  id: 'twin-b', abbr: 'CC', name: 'linux-secret-service', project: 'agents-cli', phase: 'waiting',
   needs: true, worktreeSlug: 'headless-secrets-shadow', branch: 'muqsit/headless-secrets',
   verb: 'Edit', target: 'src/lib/secrets/linux.ts',
   summary: 'Adding the Linux secret-service fallback path + a regression test.', since: '0s',
@@ -544,7 +544,7 @@ const permAgent = agent({
   }, since: '2m',
 })
 const askAgentD = agent({
-  id: 'a-ask-d', abbr: 'CC', name: '659a7ec6', project: 'agents-cli', phase: 'waiting', needs: true,
+  id: 'a-ask-d', abbr: 'CC', name: 'agent-readiness-review', project: 'agents-cli', phase: 'waiting', needs: true,
   prompt: 'Make the NEEDS-YOU panel surface enough to unblock agents at a glance.',
   question: {
     kind: 'choice', reason: 'question', text: 'Ship v0.9.290 with the two follow-ups now, or pull more of the feed-UI backlog into this pass first?',


### PR DESCRIPTION
## What
- Preserve remote session `label` separately from `topic`, then use `label -> topic -> branch -> ticket -> worktree/project -> generic agent session` for Factory Floor card names.
- Remove the visible session-id provenance chip from Floor card headers; the full session id remains available in the name tooltip.
- Replace cloud/headless/local/intake/recap UUID-slice fallbacks with human labels, prompt first lines, task names, or generic agent labels.
- Update the Factory preview fixtures and changelog so the visual harness reflects the no-UUID header behavior.

## Why
RUSH-1532 reports Factory cards showing `019e30a2` / `claude-XXXXXXXX` identifiers instead of session names. The CLI already supplies labels/topics; the UI was dropping or bypassing them in several places.

## Evidence
- `apps/factory/src/core/remoteSessions.ts:172` preserves `label` separately from `topic`; `apps/factory/src/core/remoteSessions.ts:462` and `apps/factory/src/core/remoteSessions.ts:549` populate both active and recent sessions.
- `apps/factory/ui/settings/components/mission-control/floorAdapter.ts:256` chooses a human remote card name before any generic fallback; `apps/factory/ui/settings/components/mission-control/floorAdapter.ts:409` applies it to `FloorAgent.name`.
- `apps/factory/ui/settings/components/mission-control/FeedItem.tsx:94` keeps the full session id in the tooltip; `apps/factory/ui/settings/components/mission-control/FeedItem.tsx:140` renders only the human title in the header.
- `apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx:197`, `apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx:203`, and `apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx:266` remove local/cloud UUID-slice display-name fallbacks.
- `apps/factory/ui/settings/components/mission-control/recapModel.ts:52` and `apps/factory/ui/settings/components/mission-control/recapModel.ts:73` keep Recap rows off raw session-id fallback titles.
- Visual preview screenshot: `/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/rush-1532-session-labels/.agents/artifacts/rush-1532/factory-preview-feed-final.jpg` shows rendered Floor cards with human headers (`byok-keychain-cleanup`, `linux-secret-service`, `supabase-rls-migration`) and no visible `claude-XXXXXXXX` header chip.

## Tests
- `PATH=/home/muqsit/.bun/bin:$PATH /home/muqsit/.bun/bin/bun test ui/settings/components/mission-control/floorAdapter.test.ts ui/settings/components/mission-control/recapModel.test.ts src/core/remoteSessions.test.ts` -> 117 pass, 0 fail, 299 assertions.
- `PATH=/home/muqsit/.bun/bin:$PATH /home/muqsit/.bun/bin/bun run compile` -> `tsc -p ./` plus settings/editor Vite builds passed. Vite emitted only pre-existing chunk-size/eval warnings.
- Preview harness served with `vite.preview.config.ts`, opened on zion in Comet, and captured via `agents computer screenshot` to `/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/rush-1532-session-labels/.agents/artifacts/rush-1532/factory-preview-feed-final.jpg`.
