### PR TITLE
RUSH-607: add keychain payload guard regression

### DIFF
--- a/apps/cli/src/lib/__tests__/usage.test.ts
+++ b/apps/cli/src/lib/__tests__/usage.test.ts
@@ -11,6 +11,7 @@ import {
   formatUsageSummary,
   formatUsageStatusBadge,
   getClaudeKeychainService,
+  loadClaudeOauth,
   getUsageInfoForIdentity,
   readClaudeUsageCache,
   isClaudeUsageOrgMatch,
@@ -21,6 +22,7 @@ import {
   type UsageSnapshot,
   type UsageWindow,
 } from '../usage.js';
+import { deleteKeychainToken, setKeychainToken } from '../secrets/index.js';
 
 function makeAccountInfo(overrides: Partial<AccountInfo> = {}): AccountInfo {
   return {
@@ -198,6 +200,13 @@ describe('usage identity deduping', () => {
 });
 
 describe('Claude usage scoping', () => {
+  const previousPassphrase = process.env.AGENTS_SECRETS_PASSPHRASE;
+
+  afterEach(() => {
+    if (previousPassphrase === undefined) delete process.env.AGENTS_SECRETS_PASSPHRASE;
+    else process.env.AGENTS_SECRETS_PASSPHRASE = previousPassphrase;
+  });
+
   it('uses the shared keychain service without a managed home', () => {
     expect(getClaudeKeychainService()).toBe('Claude Code-credentials');
   });
@@ -213,6 +222,20 @@ describe('Claude usage scoping', () => {
 
   it('does not reuse the shared keychain service for managed Claude homes', () => {
     expect(getClaudeKeychainService('/tmp/claude-a')).not.toBe('Claude Code-credentials');
+  });
+
+  it('ignores malformed keychain payloads without an access token', async () => {
+    process.env.AGENTS_SECRETS_PASSPHRASE = 'usage-test-passphrase';
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-usage-oauth-'));
+    const service = getClaudeKeychainService(home);
+    setKeychainToken(service, JSON.stringify({ claudeAiOauth: { refreshToken: 'refresh-only' } }));
+
+    try {
+      await expect(loadClaudeOauth(home)).resolves.toBeNull();
+    } finally {
+      try { deleteKeychainToken(service); } catch {}
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 
   it('keeps usage eligible when the live org is missing', () => {


### PR DESCRIPTION
## What
- Add a regression test for the Claude keychain payload shape guard so malformed OAuth payloads without `claudeAiOauth.accessToken` return `null`.

## Why
The live code on current `origin/main` already contains the requested runtime guard and several of the originally reported shell sites have been removed or replaced. This PR locks the keychain guard behavior with a real backend round trip instead of mocking it.

## Evidence
- `apps/cli/src/lib/usage.ts:869-870` parses the keychain payload and returns `null` unless `payload.claudeAiOauth.accessToken` is a string.
- `apps/cli/src/lib/__tests__/usage.test.ts:227-238` writes a malformed payload containing only `refreshToken`, calls `loadClaudeOauth(home)`, expects `null`, and deletes the test keychain item.
- `apps/cli/src/commands/daemon.ts:116-120` already uses `followFile(logPath, ...)` for log following instead of shelling out to `tail -f`.
- `apps/cli/src/lib/state.ts:178-184` already documents that `getOptionalUserAgentsDir` returns `null` when `~/.agents/` symlinks to the system dir.

## Tests
- `bun run test src/lib/__tests__/usage.test.ts` -> 1 file passed, 21 tests passed.
- `bun run build` -> passed.

No docs/changelog update: this PR is test-only; the user-visible code behavior is already present on current main.