### PR TITLE
fix(computer-win): screenshot --display no longer requires a pid

### DIFF
--- a/native/computer-win/Screenshot.cs
+++ b/native/computer-win/Screenshot.cs
@@ -27,13 +27,42 @@ public static class Screenshot
     public static Dictionary<string, object?> Capture(JsonElement @params)
     {
         if (@params.ValueKind != JsonValueKind.Object)
-            throw RpcError.Invalid("screenshot needs `pid`");
-        int pid = P.Int(@params, "pid");
+            throw RpcError.Invalid("screenshot needs params");
         bool listOnly = P.BoolOr(@params, "list", false);
         bool display = P.BoolOr(@params, "display", false);
         int? windowId = @params.TryGetProperty("window_id", out var wv) && wv.ValueKind == JsonValueKind.Number
             ? wv.GetInt32() : null;
+        // pid is optional for a full-display capture (mirrors the macOS
+        // `screenshot --display` path, which needs no app). Every other mode
+        // still requires it — enforced below once we know the mode.
+        int? pidOpt = @params.TryGetProperty("pid", out var pv) && pv.ValueKind == JsonValueKind.Number
+            ? pv.GetInt32() : null;
 
+        // Whole-screen capture: with a pid, grab the monitor that pid's window
+        // sits on; without one, grab the primary screen. No process needed.
+        if (display)
+        {
+            Screen screen;
+            if (pidOpt is int dpid)
+            {
+                var dwindows = TopLevelWindows(dpid);
+                if (dwindows.Count == 0) throw RpcError.AppMissing(dpid);
+                var anchor = dwindows.FirstOrDefault(w => !w.Minimized) ?? dwindows[0];
+                screen = Screen.FromHandle(anchor.Hwnd);
+            }
+            else
+            {
+                screen = Screen.PrimaryScreen ?? Screen.AllScreens[0];
+            }
+            return Encode(screen.Bounds, new()
+            {
+                ["mode"] = "display",
+                ["display_id"] = screen.DeviceName,
+            });
+        }
+
+        // list + window capture operate on a specific process's windows.
+        int pid = pidOpt ?? throw RpcError.Invalid("missing int param: pid");
         var windows = TopLevelWindows(pid);
         if (windows.Count == 0) throw RpcError.AppMissing(pid);
 
@@ -56,19 +85,6 @@ public static class Screenshot
                 ["windows"] = entries,
                 ["window_count"] = entries.Count,
             };
-        }
-
-        if (display)
-        {
-            // The display the target window sits on (mirrors the macOS
-            // captureDisplay: whole screen, composites stacked modals).
-            var anchor = windows.FirstOrDefault(w => !w.Minimized) ?? windows[0];
-            var screen = Screen.FromHandle(anchor.Hwnd);
-            return Encode(screen.Bounds, new()
-            {
-                ["mode"] = "display",
-                ["display_id"] = screen.DeviceName,
-            });
         }
 
         WindowInfo target;

--- a/native/computer-win/Screenshot.cs
+++ b/native/computer-win/Screenshot.cs
@@ -9,12 +9,14 @@ using System.Windows.Forms;
 namespace ComputerHelperWin;
 
 /// <summary>
-/// Screen capture, scoped like the macOS helper (Screenshot.swift): the target
-/// pid is required, and the same params pick the mode —
-///   list=true        -> enumerate the pid's top-level windows (no image)
-///   display=true     -> capture the whole display the target window is on
-///   window_id=&lt;hwnd&gt; -> capture exactly that window
-///   (default)        -> capture the pid's largest on-screen window
+/// Screen capture, scoped like the macOS helper (Screenshot.swift). The params
+/// pick the mode; pid is required for every mode EXCEPT a full-display capture,
+/// which needs no target app (mirrors macOS `screenshot --display`) —
+///   list=true        -> enumerate the pid's top-level windows (no image); pid required
+///   display=true     -> capture a whole display: the monitor the target window is
+///                       on when pid is given, else the primary screen (pid optional)
+///   window_id=&lt;hwnd&gt; -> capture exactly that window; pid required
+///   (default)        -> capture the pid's largest on-screen window; pid required
 /// Result keys match what the CLI consumes from the macOS helper
 /// (src/commands/computer.ts): image_data (base64 PNG), width, height,
 /// origin [x,y], scale — plus mode/window_id/title for scoped captures, and


### PR DESCRIPTION
## The bug (surfaced by #864's e2e suite)

The moment the Windows-host e2e suite ran in CI (wired up in #864), it caught a real bug:

```
FAIL src/lib/ssh-tunnel.e2e.test.ts > screenshot --host returns a non-empty PNG over the tunnel
Error: invalid_params: missing int param: pid
```

`Screenshot.Capture` (`native/computer-win/Screenshot.cs`) parsed `pid` with `P.Int(@params, "pid")` **unconditionally**, before dispatching on mode. But a full-display capture (`display: true`) needs no target app — it mirrors the macOS `screenshot --display` whole-screen path. So `agents computer screenshot --display` (no app) always failed on Windows.

## The fix

`pid` is now optional:
- `display: true` **with** a pid → capture the monitor that pid's window sits on (unchanged behavior).
- `display: true` **without** a pid → capture the primary screen.
- `list` and window-capture modes still require `pid`, enforced once the mode is known (`missing int param: pid`).

## Verification (real, end-to-end)

Cross-built the win-x64 helper with the fix (`scripts/build-win.sh`, dotnet 10), and ran the full computer e2e suite against a **live win-mini** over the real `ssh -L` tunnel from zion:

```
AGENTS_TEST_WIN_HOST=win-mini node ./node_modules/vitest/vitest.mjs run src/lib/ssh-tunnel.e2e.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)   ← was 3 passed / 1 failed
```

The `screenshot --host` test now returns a valid PNG (magic `89 50 4E 47`, >1KB) over the tunnel.

Refs #864 (this is the first real bug the e2e suite caught; it takes the suite's CI run from 4/5 to 5/5 green).