### PR TITLE
RUSH-1516: fix Factory AGENTS doc drift

### DIFF
--- a/apps/factory/AGENTS.md
+++ b/apps/factory/AGENTS.md
@@ -57,8 +57,8 @@ bash scripts/install.sh <version>   # Package .vsix and install to Cursor + Code
 | Unified task aggregation (markdown / Linear / GitHub) | `src/core/tasks.ts`, `src/vscode/tasks.vscode.ts` |
 | Handoff across agents | `src/core/handoff.ts` |
 | Custom .md editor (TipTap) | `src/vscode/customEditor.ts`, `/ui/editor/extensions/` |
-| Swarm MCP integration | `src/vscode/swarm.vscode.ts`, `src/core/swarm.detect.ts` |
-| Watchdog MCP bridge (`send_nudge`, `send_to_agent`) | `src/mcp/watchdog-server.ts`, `src/mcp/watchdog-bridge.ts`, `src/mcp/watchdogInstall.ts`. Unix socket `~/.agents/.tmp/watchdog.sock`. Logs `~/.agents/watchdog.log`, `~/.agents/peer-messages.log`. |
+| Teams integration | `src/vscode/swarm.vscode.ts`, `src/core/swarm.detect.ts` |
+| Watchdog MCP bridge (`send_nudge`, `send_to_agent`) | `src/mcp/watchdog-server.ts`, `src/mcp/watchdog-bridge.ts`, `src/mcp/watchdogInstall.ts`. Unix socket `~/.agents/.tmp/watchdog.sock`. Logs `~/.agents/.cache/logs/watchdog.log`, `~/.agents/peer-messages.log`. |
 | Factory Floor (dashboard, dispatch) | `ui/settings/components/mission-control/` |
 | Cloud dispatch resolver (label parsing, repo/owner) | `ui/settings/components/mission-control/dispatch.ts` + `src/vscode/settings.vscode.ts` (`case 'dispatchTask'`) |
 | Foreman voice orb (OpenAI Realtime, mic + speaker pipeline) | `src/vscode/foreman.audio.ts` (audio I/O via ffmpeg/ffplay, mic-gated during TTS to prevent echo loop), `src/vscode/foreman.vscode.ts` (session + tools), `ui/settings/components/foreman/ForemanOrb.tsx` (UI) |

--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ### Fixed
 
+- **Factory watchdog logs now use the canonical cache path documented by AGENTS.** The
+  watchdog bridge, watchdog tick writer, and Factory Floor log reader share one
+  `WATCHDOG_LOG_PATH` at `~/.agents/.cache/logs/watchdog.log`, matching the
+  post-restructure docs and CLI migration target. (RUSH-1516)
 - **Factory Floor cards now use human session names instead of UUID slices (RUSH-1532).**
   Remote sessions preserve explicit labels separately from task topics, and the Floor
   card header prefers label, topic, branch, ticket, and worktree metadata before falling

--- a/apps/factory/src/core/watchdogLog.test.ts
+++ b/apps/factory/src/core/watchdogLog.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'bun:test';
-import { formatEvent, parseEvents, trimToLast, WatchdogEvent } from './watchdogLog';
+import * as path from 'path';
+import { formatEvent, parseEvents, trimToLast, WatchdogEvent, WATCHDOG_LOG_PATH } from './watchdogLog';
+
+describe('WATCHDOG_LOG_PATH', () => {
+  it('uses the cache logs location shared by watchdog readers and writers', () => {
+    expect(WATCHDOG_LOG_PATH.endsWith(path.join('.agents', '.cache', 'logs', 'watchdog.log'))).toBe(true);
+  });
+});
 
 describe('formatEvent', () => {
   it('serializes event to JSON', () => {

--- a/apps/factory/src/core/watchdogLog.ts
+++ b/apps/factory/src/core/watchdogLog.ts
@@ -1,6 +1,11 @@
-// Watchdog event log: pure formatting + parsing for the JSONL feed at
-// ~/.agents/watchdog.log. The webview pulls this file periodically to
-// render the Watchdog activity card on the Factory Floor.
+import * as os from 'os';
+import * as path from 'path';
+
+// Watchdog event log: formatting + parsing for the JSONL feed at
+// ~/.agents/.cache/logs/watchdog.log. The webview pulls this file periodically
+// to render the Watchdog activity card on the Factory Floor.
+
+export const WATCHDOG_LOG_PATH = path.join(os.homedir(), '.agents', '.cache', 'logs', 'watchdog.log');
 
 export type WatchdogEventKind = 'tick' | 'decision' | 'nudge' | 'rotate' | 'error';
 

--- a/apps/factory/src/mcp/watchdog-bridge.ts
+++ b/apps/factory/src/mcp/watchdog-bridge.ts
@@ -5,11 +5,10 @@ import * as os from 'os';
 import * as vscode from 'vscode';
 import { getAllTerminals } from '../vscode/terminals.vscode';
 import { resolvePeerMessage } from '../core/peerMessaging';
-import { trimToLast } from '../core/watchdogLog';
+import { trimToLast, WATCHDOG_LOG_PATH } from '../core/watchdogLog';
 import { runOnLeaderOnly } from '../monitor/gate';
 
 const SOCKET_PATH = path.join(os.homedir(), '.agents', '.tmp', 'watchdog.sock');
-const WATCHDOG_LOG = path.join(os.homedir(), '.agents', 'watchdog.log');
 const PEER_MESSAGES_LOG = path.join(os.homedir(), '.agents', 'peer-messages.log');
 
 // Hot path: append is O(1). Each log is trimmed back to LOG_MAX_LINES only
@@ -100,7 +99,7 @@ async function logNudge(entry: {
     ...entry,
   };
   try {
-    await appendLineTrimmed(WATCHDOG_LOG, JSON.stringify(logEntry) + '\n');
+    await appendLineTrimmed(WATCHDOG_LOG_PATH, JSON.stringify(logEntry) + '\n');
   } catch (err) {
     console.warn('[WATCHDOG] Failed to log nudge:', err);
   }

--- a/apps/factory/src/vscode/settings.vscode.ts
+++ b/apps/factory/src/vscode/settings.vscode.ts
@@ -39,7 +39,7 @@ import { repoSlugFromPath } from '../core/projectIndex';
 import { matchLinearProject } from '../core/linearProjects';
 import { fetchLinearProjects } from './linear.vscode';
 import { resolveForemanTarget, candidateName } from '../core/foreman.target';
-import { parseEvents } from '../core/watchdogLog';
+import { parseEvents, WATCHDOG_LOG_PATH } from '../core/watchdogLog';
 import {
   WATCHDOG_PLAYBOOK_PATH,
   ensureWatchdogPlaybookScaffold,
@@ -2917,9 +2917,8 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
         break;
       }
       case 'getWatchdogLog': {
-        const logPath = path.join(homedir(), '.agents', 'watchdog.log');
         try {
-          const text = fs.readFileSync(logPath, 'utf8');
+          const text = fs.readFileSync(WATCHDOG_LOG_PATH, 'utf8');
           settingsPanel?.webview.postMessage({ type: 'watchdogLogData', events: parseEvents(text) });
         } catch {
           settingsPanel?.webview.postMessage({ type: 'watchdogLogData', events: [] });

--- a/apps/factory/src/vscode/watchdog.vscode.ts
+++ b/apps/factory/src/vscode/watchdog.vscode.ts
@@ -21,7 +21,7 @@ import {
 } from '../core/resumeInBest';
 import { getAllTerminals, getById, EditorTerminal } from './terminals.vscode';
 import { getSessionPathBySessionId, readTailLines } from './sessions.vscode';
-import { formatEvent, trimToLast, WatchdogEvent } from '../core/watchdogLog';
+import { formatEvent, trimToLast, WatchdogEvent, WATCHDOG_LOG_PATH } from '../core/watchdogLog';
 import { detectWaitingForInput } from '../core/session.activity';
 import { summarizeWatchdogTail, TailSummary } from '../core/watchdogTail';
 import {
@@ -30,7 +30,6 @@ import {
   WatchdogWatch,
 } from '../monitor/protocol';
 
-const WATCHDOG_LOG_PATH = path.join(os.homedir(), '.agents', 'watchdog.log');
 const LOG_MAX_LINES = 500;
 
 // User-editable playbook appended to the watchdog's built-in prompt each tick.


### PR DESCRIPTION
## What

- Rename the stale Factory AGENTS row from `Swarm MCP integration` to `Teams integration`.
- Move Factory watchdog event log reads and writes to the canonical cache path, `~/.agents/.cache/logs/watchdog.log`.
- Share that path through `WATCHDOG_LOG_PATH` so the watchdog bridge, watchdog tick writer, and Factory Floor log reader cannot drift again.
- Update Factory AGENTS and CHANGELOG for the runtime path change.

## Why

RUSH-1516 identified post-restructure AGENTS doc drift. The watchdog log path was only accurate if Factory actually wrote and read the cache path, so this PR now changes the runtime path and the docs together instead of documenting a future state.

## Evidence

- `apps/factory/src/core/watchdogLog.ts` exports `WATCHDOG_LOG_PATH` as `~/.agents/.cache/logs/watchdog.log`.
- `apps/factory/src/mcp/watchdog-bridge.ts` writes nudge events via `WATCHDOG_LOG_PATH`.
- `apps/factory/src/vscode/watchdog.vscode.ts` writes tick/decision events via `WATCHDOG_LOG_PATH`.
- `apps/factory/src/vscode/settings.vscode.ts` reads Factory Floor watchdog activity from `WATCHDOG_LOG_PATH`.
- `apps/factory/AGENTS.md:60-61` now uses the Teams label and the cache log path.

## Verification

- `PATH="$HOME/.bun/bin:$PATH" bun test src/core/watchdogLog.test.ts` -> 15 pass, 0 fail.
- `PATH="$HOME/.bun/bin:$PATH" bun run compile` in `apps/factory` after per-package installs -> TypeScript plus settings/editor Vite builds passed.