### PR TITLE
RUSH-1525: surface plan previews in Factory Floor

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -32,6 +32,10 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ### Added
 
+- **Factory Floor cards now surface plan artifacts for preview (RUSH-1525).**
+  Session output, recent worktree files, and attachment refs are scanned for
+  `.html` and `ref-*.md` plan files; matching cards show plan chips that open HTML
+  plans externally and Markdown plans in the editor preview.
 - **Project rollups — one glance answers "what's happening in this project".** The
   rail's Projects flyout rows now carry dim sub-counts (open backlog tickets and
   distinct open PRs) next to the live agent count, and each card in the Projects

--- a/apps/factory/README.md
+++ b/apps/factory/README.md
@@ -59,6 +59,10 @@ Every open agent terminal is fully restorable. Session ID, icon, and custom labe
 
 The dashboard's mission control. A live grid of every agent on the floor — local IDE tabs, background teams, and cloud dispatches — beside your Linear cycle. Compose and dispatch work with the Cmd+K composer, drag issue cards onto agents, or send a ticket straight to the cloud.
 
+Agent cards surface outputs such as PRs, spawned teams, created tickets, and plan
+artifacts. `.html` and `ref-*.md` plans detected in session output, worktree
+files, or attachments appear as one-click preview chips.
+
 ### Foreman Voice Orb
 
 Talk to your factory. Tap the orb in the dashboard and ask "what's running?", "what's left this cycle?", or "dispatch RUSH-557 to the cloud" — a realtime voice model answers out loud with live floor state, and it can dispatch tickets, spawn agents, and file Linear issues for you. Tap to talk, tap again to stop, or press-and-hold to talk only while pressed. A silent-mode toggle under the orb switches replies to text-only transcript.

--- a/apps/factory/src/core/remoteSessions.ts
+++ b/apps/factory/src/core/remoteSessions.ts
@@ -139,6 +139,10 @@ export interface RemoteSession {
   question: RemoteQuestion | null;
   /** Last few assistant turns (most-recent last), one line each — panel context. [] when none. */
   tail: string[];
+  /** Raw CLI output text, when the active-session payload carries it. */
+  output: string;
+  /** Attachment refs/names from the CLI payload, normalized to displayable strings. */
+  attachments: string[];
   prUrl: string | null;
   ticket: string | null;
   /** Tracker refs this session CREATED (Linear create_issue / gh issue create). */
@@ -279,6 +283,8 @@ export interface RawActiveSession {
   question?: { text?: string; reason?: string; options?: Array<{ label?: string; description?: string; key?: string } | null> } | null;
   /** Last few assistant turns (most-recent last), from the CLI state engine. */
   tail?: string[];
+  output?: string;
+  attachments?: unknown[];
   pr?: { url?: string; number?: number } | null;
   worktree?: { slug?: string; path?: string; branch?: string } | null;
   ticket?: string | { id?: string; url?: string } | null;
@@ -443,6 +449,17 @@ export function normalizeActiveSession(
     lastResponse: preview,
     question: normalizeQuestion(raw.question),
     tail: Array.isArray(raw.tail) ? raw.tail.map((t) => asStr(t)).filter(Boolean) : [],
+    output: asStr(raw.output),
+    attachments: Array.isArray(raw.attachments)
+      ? raw.attachments.map((a: unknown) => {
+          if (typeof a === 'string') return a;
+          if (a && typeof a === 'object') {
+            const obj = a as { name?: unknown; ref?: unknown; path?: unknown };
+            return [asStr(obj.name), asStr(obj.ref), asStr(obj.path)].filter(Boolean).join(' ');
+          }
+          return '';
+        }).filter(Boolean)
+      : [],
     // pr is a { url, number } object on the CLI payload; keep top-level prUrl as a
     // fallback for older shapes.
     prUrl: asStr(raw.prUrl) || asStr(raw.pr?.url) || null,
@@ -536,6 +553,8 @@ export function normalizeRecentSession(
     // Recent (historical) sessions are idle — no live decision to surface.
     question: null,
     tail: [],
+    output: '',
+    attachments: [],
     prUrl: asStr(raw.prUrl) || null,
     ticket: asStr(raw.ticketId) || null,
     createdTickets: Array.isArray(raw.createdTickets) ? raw.createdTickets.map((t: unknown) => String(t)) : [],

--- a/apps/factory/src/vscode/settings.vscode.ts
+++ b/apps/factory/src/vscode/settings.vscode.ts
@@ -845,10 +845,36 @@ async function writeFactoryConfigSafe(patch: Record<string, unknown>): Promise<R
 
 function resolveEditorPath(pathValue: string): string | null {
   if (!pathValue) return null;
+  if (pathValue.startsWith('~/')) return path.join(homedir(), pathValue.slice(2));
   if (path.isAbsolute(pathValue)) return pathValue;
   const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
   if (!workspacePath) return null;
   return path.join(workspacePath, pathValue);
+}
+
+async function openPlanPreview(pathValue: string, kind: string | undefined, host: string | undefined): Promise<void> {
+  const target = pathValue.trim();
+  if (!target) return;
+  if (/^https?:\/\//i.test(target)) {
+    await vscode.env.openExternal(vscode.Uri.parse(target));
+    return;
+  }
+  const remoteHost = host && host !== 'this-mac' ? host : '';
+  let resolvedPath = resolveEditorPath(target);
+  if (remoteHost) {
+    const safeHost = remoteHost.replace(/[^a-zA-Z0-9._-]+/g, '-');
+    const destDir = path.join(homedir(), '.agents', '.cache', 'factory-plan-previews', safeHost);
+    await fs.promises.mkdir(destDir, { recursive: true });
+    resolvedPath = path.join(destDir, path.basename(target));
+    await execFileAsync('scp', [`${remoteHost}:${target}`, resolvedPath], { timeout: 20_000 });
+  }
+  if (!resolvedPath || !fs.existsSync(resolvedPath)) return;
+  const uri = vscode.Uri.file(resolvedPath);
+  if (kind === 'markdown' || resolvedPath.toLowerCase().endsWith('.md')) {
+    await vscode.commands.executeCommand('markdown.showPreview', uri);
+    return;
+  }
+  await vscode.env.openExternal(uri);
 }
 
 async function openFileOrDiffInEditor(pathValue: string): Promise<void> {
@@ -2831,6 +2857,11 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
       case 'openTerminalFile':
         if (message.path) {
           await openFileOrDiffInEditor(message.path);
+        }
+        break;
+      case 'openPlanPreview':
+        if (typeof message.path === 'string') {
+          await openPlanPreview(message.path, typeof message.kind === 'string' ? message.kind : undefined, typeof message.host === 'string' ? message.host : undefined);
         }
         break;
       case 'revealFolder':

--- a/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
@@ -9,6 +9,7 @@ import { CardChecklist } from './TodoChecklist'
 import { MiniTimeline } from './Timeline'
 import { renderMarkdown } from '../../utils/markdown'
 import { ExtLink } from '../common/ExtLink'
+import type { PlanFile } from '../../utils/planDetector'
 
 /** First line of a block of text as a plain-text title — strips leading markdown
  *  (ATX headings, list bullets) and inline markers so a prompt like "## Problem"
@@ -47,9 +48,10 @@ interface FeedItemProps {
   onOption: (agent: FloorAgent, option: string) => void
   onFreeText: (agent: FloorAgent, text: string) => void
   onAttach: (agent: FloorAgent) => void
+  onOpenPlan: (agent: FloorAgent, plan: PlanFile) => void
 }
 
-function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeText, onAttach }: FeedItemProps) {
+function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeText, onAttach, onOpenPlan }: FeedItemProps) {
   // Live heartbeat: only a running / stalled agent with a known last-activity stamp ticks.
   // The shared 1s ticker re-renders just this leaf, never the parent list.
   const now = useNow(1000)
@@ -163,8 +165,19 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
       {a.resp && !(a.needs && a.question && a.question.kind !== 'retry' && a.question.text.trim() === a.resp.trim()) && (
         <div className={`resp${destructive ? ' q' : ''}`}>{renderMarkdown(a.resp, { clamp: true })}</div>
       )}
-      {!plain && (a.spawnedTeam || (a.createdTickets?.length ?? 0) > 0) && (
+      {!plain && (a.spawnedTeam || (a.createdTickets?.length ?? 0) > 0 || (a.plans?.length ?? 0) > 0) && (
         <div className="artifacts" onClick={(e) => e.stopPropagation()}>
+          {(a.plans ?? []).map((plan) => (
+            <button
+              key={plan.path}
+              type="button"
+              className="artifact plan"
+              title={`Preview ${plan.path}`}
+              onClick={() => onOpenPlan(a, plan)}
+            >
+              <Icon name="external" size={10} /> {plan.label}
+            </button>
+          ))}
           {a.spawnedTeam && (
             <span className="artifact team" title={`Spawned a team: ${a.spawnedTeam}`}>
               <Icon name="grip" size={10} /> team · {a.spawnedTeam}

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -64,6 +64,7 @@ import {
 import { SavedViews } from './SavedViewsBar'
 import { loadSavedViews, persistSavedViews, upsertView, removeView, viewMatches, type SavedView } from './savedViews'
 import { adaptUnified, adaptRemote, adaptTickets, sinceFromMs, type RemoteSessionLike } from './floorAdapter'
+import type { PlanFile } from '../../utils/planDetector'
 import {
   DispatchPanel,
   type DispatchDevice,
@@ -1631,6 +1632,10 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     postMessage({ type: 'nudgeAgent', sessionId: a.id, host: a.host })
   }, [])
 
+  const openPlanPreview = useCallback((a: FloorAgent, plan: PlanFile) => {
+    postMessage({ type: 'openPlanPreview', path: plan.path, kind: plan.kind, host: a.host })
+  }, [])
+
   // Plan-review actions (Floor after-dispatch): approve as-is/edited, or send back a note.
   const approvePlan = useCallback((sessionId: string, edited?: PlanStep[]) => {
     postMessage({ type: 'approvePlan', sessionId, edited })
@@ -1770,8 +1775,19 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               <div className="sub">host <b>{a.hostLabel ?? a.host}</b>{(a.worktreeSlug || a.branch) ? ` · ${a.worktreeSlug || a.branch}` : ''} · {a.phase}{a.tok ? ` · ${a.tok} tok/s` : ''}{a.ticket ? ` · ${a.ticket}` : ''}</div>
               {/* Artifacts row: the agent's outputs at a glance — the PR (click-through),
                   CI, the team it spawned, and tickets it created. Mirrors the card chips. */}
-              {(a.prUrl || a.ci || a.spawnedTeam || (a.createdTickets?.length ?? 0) > 0) && (
+              {(a.prUrl || a.ci || a.spawnedTeam || (a.createdTickets?.length ?? 0) > 0 || (a.plans?.length ?? 0) > 0) && (
                 <div className="arts">
+                  {(a.plans ?? []).map((plan) => (
+                    <button
+                      key={plan.path}
+                      type="button"
+                      className="art plan"
+                      title={`Preview ${plan.path}`}
+                      onClick={() => openPlanPreview(a, plan)}
+                    >
+                      <Icon name="external" size={10} /> {plan.label}
+                    </button>
+                  ))}
                   {a.prUrl && (
                     <ExtLink href={a.prUrl} className="art pr" style={{ textDecoration: 'none' }}>
                       <Icon name="chevR" size={10} /> PR {a.pr ?? ''}
@@ -1991,6 +2007,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               onOption={onAgentOption}
               onFreeText={replyToAgent}
               onAttach={onAttachScreenshot}
+              onOpenPlan={openPlanPreview}
             />
           ))}
           {failedAgents.map((a) => (
@@ -2012,6 +2029,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               onOption={onAgentOption}
               onFreeText={replyToAgent}
               onAttach={onAttachScreenshot}
+              onOpenPlan={openPlanPreview}
             />
           ))}
         </>
@@ -2042,6 +2060,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               onOption={onAgentOption}
               onFreeText={replyToAgent}
               onAttach={onAttachScreenshot}
+              onOpenPlan={openPlanPreview}
             />
           ))
         : [...groupAgents([...runningFeed, ...doneFeed], floorGroup).entries()].map(([k, arr]) => {
@@ -2070,6 +2089,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
                   onOption={onAgentOption}
                   onFreeText={replyToAgent}
                   onAttach={onAttachScreenshot}
+                  onOpenPlan={openPlanPreview}
                 />
               ))}
             </React.Fragment>
@@ -2088,6 +2108,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               onOption={onAgentOption}
               onFreeText={replyToAgent}
               onAttach={onAttachScreenshot}
+              onOpenPlan={openPlanPreview}
             />
           ))}
         </>
@@ -2108,6 +2129,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               onOption={onAgentOption}
               onFreeText={replyToAgent}
               onAttach={onAttachScreenshot}
+              onOpenPlan={openPlanPreview}
             />
           ))}
         </>

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -226,6 +226,7 @@
 .swarmify-root .detail-col .art.ci.running { color: var(--status-pending); border-color: rgba(245,179,1,0.3); }
 .swarmify-root .detail-col .art.team { color: #b98cff; border-color: rgba(185,140,255,0.35); }
 .swarmify-root .detail-col .art.tk { color: var(--brand); border-color: var(--brand-ring); }
+.swarmify-root .detail-col .art.plan { color: var(--brand-600); border-color: var(--brand-ring); cursor: pointer; }
 /* decision block at top of the right detail when an agent needs you */
 .swarmify-root .decide { background: var(--status-pending-bg); border: 1px solid var(--status-pending); border-radius: var(--r-lg); padding: 12px 14px; margin-bottom: 14px; }
 .swarmify-root .decide .ql { font-size: 10px; font-weight: 800; letter-spacing: .05em; color: var(--status-pending); margin-bottom: 6px; display: flex; align-items: center; gap: 7px; }
@@ -256,6 +257,7 @@
 .swarmify-root .fitem .artifacts { display: flex; flex-wrap: wrap; gap: 5px; margin: 0 0 8px; }
 .swarmify-root .fitem .artifact { display: inline-flex; align-items: center; gap: 4px; font-size: 10px; font-weight: 600; padding: 1px 7px 1px 6px; border-radius: 999px; background: var(--status-running-bg); color: var(--status-running); border: 1px solid transparent; font-variant-numeric: tabular-nums; }
 .swarmify-root .fitem .artifact.team { background: var(--brand-ring); color: var(--brand); }
+.swarmify-root .fitem .artifact.plan { background: var(--ds-bg-recessed); color: var(--brand-600); border-color: var(--brand-ring); cursor: pointer; }
 .swarmify-root .fitem .summary { font-size: 12px; color: var(--ds-text-muted); line-height: 1.4; margin: 0 0 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .swarmify-root .fitem .nowline { font-family: "Geist Mono", monospace; font-size: 11px; color: var(--ds-text-muted); display: flex; align-items: center; gap: 8px; }
 .swarmify-root .fitem .nowline .v { color: var(--brand-600); }

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
@@ -290,6 +290,44 @@ describe('toFloorAgentFromUnified', () => {
     expect(a.worktreeSlug).not.toContain('/')
     expect(a.worktreeSlug).not.toContain('WT=')
   })
+
+  test('detects plan artifacts from output and recent worktree files', () => {
+    const a = toFloorAgentFromUnified(
+      baseUnified({
+        files: ['ref-cycle-18.md'],
+        agent: { last_messages: ['Rendered ref-plan.html'] },
+        terminal: {
+          id: 't1',
+          cwd: '/Users/x/src/github.com/o/agents-cli/.agents/worktrees/rush-1525',
+          recentToolCalls: [{ name: 'Bash', output: 'open .agents/artifacts/ref-review.md' }],
+        },
+      }),
+      { pinned: new Set(), workspaceRepo: null, nowMs: NOW },
+    )
+    expect(a.plans?.map((p) => p.path)).toEqual([
+      '/Users/x/src/github.com/o/agents-cli/.agents/worktrees/rush-1525/ref-plan.html',
+      '/Users/x/src/github.com/o/agents-cli/.agents/worktrees/rush-1525/ref-cycle-18.md',
+      '/Users/x/src/github.com/o/agents-cli/.agents/worktrees/rush-1525/.agents/artifacts/ref-review.md',
+    ])
+  })
+
+  test('ignores plan-like paths that are only mentioned by the user task', () => {
+    const a = toFloorAgentFromUnified(
+      baseUnified({
+        activity: 'Review ref-task.html',
+        terminal: {
+          id: 't1',
+          cwd: '/Users/x/src/github.com/o/agents-cli/.agents/worktrees/rush-1525',
+          firstUserMessage: 'Please render ref-plan.html',
+          lastUserMessage: 'Open ref-review.md when done',
+          currentActivity: 'Thinking about ref-current.html',
+        },
+        agent: { prompt: 'Build a plan named ref-prompt.md', last_messages: [] },
+      }),
+      { pinned: new Set(), workspaceRepo: null, nowMs: NOW },
+    )
+    expect(a.plans).toEqual([])
+  })
 })
 
 describe('cleanWorktreeSlug — kills the WT=<path> leak', () => {
@@ -354,6 +392,79 @@ describe('toFloorAgentFromRemote', () => {
     expect(a.lastActivityMs).toBe(NOW - 42_000)
     // a genuinely-remote host is already its real name — no display override.
     expect(a.hostLabel).toBeUndefined()
+  })
+
+  test('detects remote plan artifacts from output and attachment refs', () => {
+    const r: RemoteSessionLike = {
+      host: 'yosemite-s0',
+      sessionId: 'plan123',
+      agentType: 'codex',
+      cwd: '/home/u/src/agents-cli/.agents/worktrees/rush-1525',
+      project: 'agents-cli',
+      phase: 'running',
+      activity: 'Writing plan',
+      tokPerSec: 0,
+      waitingForInput: false,
+      lastResponse: 'Plan rendered at ref-plan.html',
+      output: 'See ref-cycle.md',
+      attachments: ['capture (/tmp/ref-screenshot.html)'],
+      prUrl: null,
+      ticket: 'RUSH-1525',
+      branch: 'rush-1525',
+      sinceMs: 1000,
+      startedAtMs: NOW - 1000,
+      topic: 'Preview plan files',
+      context: 'terminal',
+      cloudTaskId: '',
+      cloudProvider: '',
+      teamName: '',
+      pid: 4321,
+      transport: 'ssh',
+      replyRail: '',
+      replyMuxTarget: '',
+      replyMuxSocket: '',
+    }
+    const a = toFloorAgentFromRemote(r, new Set())
+    expect(a.plans?.map((p) => p.path)).toEqual([
+      '/home/u/src/agents-cli/.agents/worktrees/rush-1525/ref-plan.html',
+      '/home/u/src/agents-cli/.agents/worktrees/rush-1525/ref-cycle.md',
+      '/tmp/ref-screenshot.html',
+    ])
+  })
+
+  test('ignores remote plan-like paths that are only labels or task topics', () => {
+    const r: RemoteSessionLike = {
+      host: 'yosemite-s0',
+      sessionId: 'plan456',
+      agentType: 'codex',
+      cwd: '/home/u/src/agents-cli/.agents/worktrees/rush-1525',
+      project: 'agents-cli',
+      phase: 'running',
+      activity: 'Reviewing ref-activity.html',
+      tokPerSec: 0,
+      waitingForInput: false,
+      lastResponse: '',
+      output: '',
+      attachments: [],
+      prUrl: null,
+      ticket: 'RUSH-1525',
+      branch: 'rush-1525',
+      sinceMs: 1000,
+      startedAtMs: NOW - 1000,
+      topic: 'Create ref-plan.html',
+      label: 'ref-topic.md',
+      context: 'terminal',
+      cloudTaskId: '',
+      cloudProvider: '',
+      teamName: '',
+      pid: 4321,
+      transport: 'ssh',
+      replyRail: '',
+      replyMuxTarget: '',
+      replyMuxSocket: '',
+    }
+    const a = toFloorAgentFromRemote(r, new Set())
+    expect(a.plans).toEqual([])
   })
 
   test('carries context/sessionId/pid so a headless run gets the bg badge + Focus/Stop', () => {

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
@@ -30,6 +30,7 @@ import {
   type TodoItem,
 } from './floorModel'
 import type { UnifiedTask, RecentToolCall, ProjectRule } from '../../types'
+import { detectPlanFiles, extractPlanCandidates, type PlanFile, type PlanFileCandidate } from '../../utils/planDetector'
 
 // Last non-empty todo set per session, so the checklist survives the recent-tool
 // window cap (see floorModel.todosWithFallback). Keyed by the FloorAgent id, which is
@@ -94,6 +95,7 @@ export interface UnifiedAgentLike {
     currentActivity?: string
     narrative?: string
     recentToolCalls?: RecentToolCall[]
+    recentFiles?: string[]
   } | null
   agent?: {
     cwd?: string | null
@@ -103,6 +105,9 @@ export interface UnifiedAgentLike {
     /** Original dispatch prompt for a headless/background agent. */
     prompt?: string
     last_messages?: string[]
+    files_created?: string[]
+    files_modified?: string[]
+    attachments?: Array<{ name?: string; ref?: string } | string>
   } | null
 }
 
@@ -124,6 +129,8 @@ export interface RemoteSessionLike {
   question?: { text: string; reason: 'question' | 'plan_review' | 'permission'; options: Array<{ label: string; description?: string; key?: string }> } | null
   /** Last few assistant turns (most-recent last) — panel context. */
   tail?: string[]
+  output?: string
+  attachments?: string[]
   prUrl: string | null
   ci?: CiStatus | null
   ticket: string | null
@@ -137,6 +144,7 @@ export interface RemoteSessionLike {
   worktreeSlug?: string
   /** Absolute worktree path, for the Reveal-worktree action. */
   worktreePath?: string
+  plans?: PlanFile[]
   sinceMs: number
   startedAtMs: number
   /** Epoch ms of the most recent observed activity (session-file last write).
@@ -176,6 +184,8 @@ const ABBR_BY_TYPE: Record<string, AgentAbbr> = {
   kimi: 'GK',
 }
 
+type AttachmentLike = { name?: string; ref?: string } | string
+
 /** agentType string -> terminal-tab prefix. Unknown types fall back to Shell. */
 export function abbrFor(agentType: string): AgentAbbr {
   return ABBR_BY_TYPE[(agentType || '').toLowerCase()] ?? 'SH'
@@ -187,6 +197,64 @@ function firstNonEmptyStr(...values: Array<string | null | undefined>): string |
     if (typeof v === 'string' && v.trim()) return v.trim()
   }
   return undefined
+}
+
+function stringifyUnknown(v: unknown): string {
+  if (typeof v === 'string') return v
+  if (v == null) return ''
+  try {
+    return JSON.stringify(v)
+  } catch {
+    return String(v)
+  }
+}
+
+function collectToolCallPlanCandidates(toolCalls: RecentToolCall[] | undefined): PlanFileCandidate[] {
+  const out: PlanFileCandidate[] = []
+  for (const call of toolCalls ?? []) {
+    out.push(...extractPlanCandidates(stringifyUnknown(call.input), 'output'))
+    out.push(...extractPlanCandidates(call.output, 'output'))
+  }
+  return out
+}
+
+function collectAttachmentPlanCandidates(attachments: AttachmentLike[] | undefined): PlanFileCandidate[] {
+  if (!Array.isArray(attachments)) return []
+  const out: PlanFileCandidate[] = []
+  for (const a of attachments) {
+    if (typeof a === 'string') {
+      out.push(...extractPlanCandidates(a, 'attachment'))
+      continue
+    }
+    if (a && typeof a === 'object') {
+      out.push(...extractPlanCandidates(a.name, 'attachment'))
+      out.push(...extractPlanCandidates(a.ref, 'attachment'))
+    }
+  }
+  return out
+}
+
+function detectUnifiedPlans(u: UnifiedAgentLike, worktreePath: string): PlanFile[] {
+  const candidates: PlanFileCandidate[] = []
+  candidates.push(...extractPlanCandidates(u.terminal?.narrative, 'output'))
+  for (const msg of u.agent?.last_messages ?? []) candidates.push(...extractPlanCandidates(msg, 'output'))
+  for (const file of u.files ?? []) candidates.push(...extractPlanCandidates(file, 'worktree'))
+  for (const file of u.terminal?.recentFiles ?? []) candidates.push(...extractPlanCandidates(file, 'worktree'))
+  for (const file of u.agent?.files_created ?? []) candidates.push(...extractPlanCandidates(file, 'worktree'))
+  for (const file of u.agent?.files_modified ?? []) candidates.push(...extractPlanCandidates(file, 'worktree'))
+  candidates.push(...collectToolCallPlanCandidates(u.terminal?.recentToolCalls))
+  candidates.push(...collectAttachmentPlanCandidates(u.agent?.attachments))
+  return detectPlanFiles(candidates, worktreePath || u.terminal?.cwd || u.agent?.cwd || null)
+}
+
+function detectRemotePlans(r: RemoteSessionLike, worktreePath: string): PlanFile[] {
+  if (r.plans?.length) return r.plans
+  const candidates: PlanFileCandidate[] = []
+  candidates.push(...extractPlanCandidates(r.lastResponse, 'output'))
+  candidates.push(...extractPlanCandidates(r.output, 'output'))
+  for (const msg of r.tail ?? []) candidates.push(...extractPlanCandidates(msg, 'output'))
+  for (const attachment of r.attachments ?? []) candidates.push(...extractPlanCandidates(attachment, 'attachment'))
+  return detectPlanFiles(candidates, worktreePath || r.cwd || null)
 }
 
 /**
@@ -339,6 +407,8 @@ export function toFloorAgentFromUnified(
   const prompt = firstNonEmptyStr(u.terminal?.firstUserMessage, u.agent?.prompt)
   const { verb, target } = splitActivity(u.activity)
   const project = deriveProject(u.terminal?.cwd ?? u.agent?.cwd, u.agent?.repo_name, opts.workspaceRepo || '—', opts.projectRules ?? [])
+  const worktreePath = worktreeSlugOf(u.terminal?.cwd ?? u.agent?.cwd) ? (u.terminal?.cwd ?? u.agent?.cwd ?? '') : ''
+  const plans = detectUnifiedPlans(u, worktreePath)
   // Local unified agents ARE this window's terminal tabs, so sendText into the live
   // terminal is the exact reply channel; fall back to 'none' for a tab-less headless row.
   const reply: ReplyTarget = u.terminal?.id
@@ -376,7 +446,8 @@ export function toFloorAgentFromUnified(
     spawnedTeam: u.spawnedTeam || undefined,
     branch: u.terminal?.branch ?? u.agent?.branch ?? '',
     worktreeSlug: cleanWorktreeSlug(u.terminal?.cwd ?? u.agent?.cwd),
-    worktreePath: worktreeSlugOf(u.terminal?.cwd ?? u.agent?.cwd) ? (u.terminal?.cwd ?? u.agent?.cwd ?? '') : '',
+    worktreePath,
+    plans,
     resp,
     prompt,
     messages,
@@ -414,6 +485,8 @@ export function toFloorAgentFromRemote(r: RemoteSessionLike, pinned: Set<string>
   // attributes them to the querier ('zion') for reply routing, but they should NOT
   // fold under that local host in the feed. Give them their own "Cloud" category.
   const isCloud = (r.context || '').toLowerCase() === 'cloud' || !!r.cloudTaskId
+  const worktreePath = r.worktreePath ?? (worktreeSlugOf(r.cwd) ? r.cwd : '')
+  const plans = detectRemotePlans(r, worktreePath)
 
   return {
     id,
@@ -452,7 +525,8 @@ export function toFloorAgentFromRemote(r: RemoteSessionLike, pinned: Set<string>
     branch: r.branch,
     // Prefer the CLI-provided slug; strip any WT= / path leak from either source.
     worktreeSlug: r.worktreeSlug ? cleanWorktreeSlug(r.worktreeSlug) : cleanWorktreeSlug(r.cwd),
-    worktreePath: r.worktreePath ?? (worktreeSlugOf(r.cwd) ? r.cwd : ''),
+    worktreePath,
+    plans,
     resp,
     // Remote (Tier-1) has no first-user-message enrichment yet — the session's task line
     // (topic) is the closest durable anchor for the original task.

--- a/apps/factory/ui/settings/components/mission-control/floorModel.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.ts
@@ -14,6 +14,7 @@
 // so the port is a 1:1 translation, not a redesign.
 
 import type { UnifiedTask, RecentToolCall } from '../../types'
+import type { PlanFile } from '../../utils/planDetector'
 
 export type { RecentToolCall }
 
@@ -151,6 +152,7 @@ export interface FloorAgent {
   ticket: string | null  // "RUSH-812" when linked (injected/worked-on ticket from prompt or branch)
   createdTickets?: string[] // tracker refs this session CREATED (Linear create_issue / gh issue create); [] / undefined when none
   spawnedTeam?: string   // team name this session SPAWNED via `agents teams create/add`; undefined when none
+  plans?: PlanFile[]     // detected ref-*.md / .html plan artifacts available for preview
   branch: string
   worktreeSlug: string   // "<slug>" under .agents/worktrees/; '' when not a worktree. Disambiguates sibling sessions + labels the card when topic/preview are empty.
   worktreePath: string   // absolute worktree path, for the Reveal-worktree action; '' when not a worktree

--- a/apps/factory/ui/settings/hooks/useVscodeApi.ts
+++ b/apps/factory/ui/settings/hooks/useVscodeApi.ts
@@ -61,6 +61,7 @@ export type VsCodeMessageType =
   | 'getWorkspaceConfig'
   | 'openContextFile'
   | 'openTerminalFile'
+  | 'openPlanPreview'
   | 'openSession'
   | 'spawnAgentForTask'
   | 'installSwarmAgent'

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -114,6 +114,10 @@ const idleThinkingAgent = agent({
   needs: true, verb: 'Thinking...', target: '', resp: '', since: '22h',
   sessionId: '659a7ec6-2c1a-4f9e-b2d1-7a3c9e10ab55',
   prompt: 'Is our agents-cli, our skills and factory tooling good enough — like remote agent execution — such that I can dispatch 100 tasks from Linear and the results will be **somewhat good**?',
+  plans: [
+    { path: '/repo/.agents/worktrees/agent-readiness/ref-plan.html', label: 'ref-plan.html', kind: 'html', source: 'output' },
+    { path: '/repo/.agents/worktrees/agent-readiness/ref-review.md', label: 'ref-review.md', kind: 'markdown', source: 'worktree' },
+  ],
   recent: [
     { name: 'Bash', input: { command: 'cd /Users/muqsit/src/github.com/muqsitnawaz/agents-cli' }, timestamp: new Date(Date.now() - 86_400_000).toISOString() },
     { name: 'Read', input: { file_path: '/Users/muqsit/CleanShot 2026-07-08 at 16.07.46@2x.png' }, timestamp: new Date(Date.now() - 86_460_000).toISOString() },
@@ -140,6 +144,10 @@ const running: FloorAgent[] = [
       { name: 'Edit', input: { file_path: '/repo/ui/settings/components/mission-control/BacklogCenter.tsx' }, timestamp: new Date(Date.now() - 40_000).toISOString() },
       { name: 'Edit', input: { file_path: '/repo/ui/settings/components/mission-control/floorAdapter.ts' }, timestamp: new Date(Date.now() - 80_000).toISOString() },
       { name: 'Read', input: { file_path: '/repo/ui/settings/components/mission-control/floorModel.ts' }, timestamp: new Date(Date.now() - 130_000).toISOString() },
+    ],
+    plans: [
+      { path: '/repo/.agents/worktrees/bench-saved-views/ref-plan.html', label: 'ref-plan.html', kind: 'html', source: 'output' },
+      { path: '/repo/.agents/worktrees/bench-saved-views/ref-review.md', label: 'ref-review.md', kind: 'markdown', source: 'worktree' },
     ],
     createdTickets: ['RUSH-1519', 'RUSH-1520'],
     todos: [

--- a/apps/factory/ui/settings/utils/planDetector.test.ts
+++ b/apps/factory/ui/settings/utils/planDetector.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+import { detectPlanFiles, extractPlanCandidates } from './planDetector'
+
+describe('planDetector', () => {
+  test('extracts html and ref markdown plan paths from agent output', () => {
+    const candidates = extractPlanCandidates('Rendered /tmp/ref-plan.html and wrote ./ref-cycle-18.md.')
+    expect(candidates.map((c) => c.value)).toEqual(['/tmp/ref-plan.html', './ref-cycle-18.md'])
+  })
+
+  test('resolves relative plan refs against the worktree path', () => {
+    const plans = detectPlanFiles(
+      [
+        { value: 'ref-plan.md', source: 'output' },
+        { value: 'artifacts/plan.html', source: 'worktree' },
+      ],
+      '/repo/.agents/worktrees/rush-1525',
+    )
+    expect(plans).toEqual([
+      { path: '/repo/.agents/worktrees/rush-1525/ref-plan.md', label: 'ref-plan.md', kind: 'markdown', source: 'output' },
+      { path: '/repo/.agents/worktrees/rush-1525/artifacts/plan.html', label: 'plan.html', kind: 'html', source: 'worktree' },
+    ])
+  })
+
+  test('dedupes the same plan when it appears in output and files', () => {
+    const plans = detectPlanFiles(
+      [
+        { value: '/repo/ref-plan.md', source: 'output' },
+        { value: '/repo/ref-plan.md', source: 'worktree' },
+      ],
+      '/repo',
+    )
+    expect(plans).toHaveLength(1)
+    expect(plans[0].source).toBe('output')
+  })
+
+  test('ignores ordinary markdown files', () => {
+    const plans = detectPlanFiles(
+      [
+        { value: 'README.md', source: 'output' },
+        { value: 'notes.md', source: 'worktree' },
+      ],
+      '/repo',
+    )
+    expect(plans).toEqual([])
+  })
+})
+

--- a/apps/factory/ui/settings/utils/planDetector.ts
+++ b/apps/factory/ui/settings/utils/planDetector.ts
@@ -1,0 +1,85 @@
+export type PlanFileKind = 'html' | 'markdown'
+export type PlanFileSource = 'output' | 'worktree' | 'attachment'
+
+export interface PlanFile {
+  path: string
+  label: string
+  kind: PlanFileKind
+  source: PlanFileSource
+}
+
+export interface PlanFileCandidate {
+  value: string
+  source: PlanFileSource
+}
+
+const PLAN_TOKEN_RE = /(?:file:\/\/)?(?:~|\.{1,2}\/|\/)?[^\s"'`<>()\[\]{}]*?(?:\.html|ref-[^/\s"'`<>()\[\]{}]*?\.md)(?=$|[\s"'`<>()\[\]{},.;!?])/gi
+
+function trimToken(raw: string): string {
+  return raw
+    .trim()
+    .replace(/^["'`(<\[]+/, '')
+    .replace(/[.,;:!?'"`)>\\\]]+$/, '')
+}
+
+function basename(path: string): string {
+  const clean = path.replace(/^file:\/\//, '')
+  return clean.split('/').filter(Boolean).pop() || clean
+}
+
+function isAbsolutePath(path: string): boolean {
+  return path.startsWith('/') || path.startsWith('~/') || /^[A-Za-z]:[\\/]/.test(path)
+}
+
+function joinPath(base: string, child: string): string {
+  const b = base.replace(/\/+$/, '')
+  const c = child.replace(/^\.?\//, '')
+  return b ? `${b}/${c}` : c
+}
+
+function normalizePlanPath(raw: string, basePath?: string | null): string {
+  const token = trimToken(raw)
+  if (!token) return ''
+  if (/^https?:\/\//i.test(token)) return token
+  const noScheme = token.startsWith('file://') ? token.slice('file://'.length) : token
+  if (isAbsolutePath(noScheme)) return noScheme
+  return basePath ? joinPath(basePath, noScheme) : noScheme
+}
+
+function kindOf(path: string): PlanFileKind | null {
+  const name = basename(path).toLowerCase()
+  if (name.endsWith('.html')) return 'html'
+  if (/^ref-[^/]+\.md$/.test(name)) return 'markdown'
+  return null
+}
+
+function toPlanFile(candidate: PlanFileCandidate, basePath?: string | null): PlanFile | null {
+  const path = normalizePlanPath(candidate.value, basePath)
+  const kind = kindOf(path)
+  if (!path || !kind) return null
+  return { path, label: basename(path), kind, source: candidate.source }
+}
+
+export function extractPlanCandidates(text: string | null | undefined, source: PlanFileSource = 'output'): PlanFileCandidate[] {
+  if (!text) return []
+  const out: PlanFileCandidate[] = []
+  for (const match of text.matchAll(PLAN_TOKEN_RE)) {
+    const value = trimToken(match[0] || '')
+    if (value) out.push({ value, source })
+  }
+  return out
+}
+
+export function detectPlanFiles(candidates: PlanFileCandidate[], basePath?: string | null): PlanFile[] {
+  const out: PlanFile[] = []
+  const seen = new Set<string>()
+  for (const candidate of candidates) {
+    const plan = toPlanFile(candidate, basePath)
+    if (!plan) continue
+    const key = plan.path.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(plan)
+  }
+  return out
+}


### PR DESCRIPTION
## What
- Detect `.html` and `ref-*.md` plan references from local and remote session text, tool output, files, and attachments.
- Carry typed `plans` metadata through the Factory Floor model and render one-click plan chips in feed cards and the right rail.
- Add a VS Code host bridge that opens local/http plans directly, previews markdown via `markdown.showPreview`, and copies remote host files before preview.
- Document the Factory Floor plan artifact chips and add the changelog entry.

## Why
Factory Floor could already show session activity, but referenced plan artifacts stayed buried in raw output. This makes rendered implementation plans and `ref-*.md` plan files visible and directly previewable from the session card.

## Evidence
- Detector extracts, normalizes, classifies, and dedupes plan references: `apps/factory/ui/settings/utils/planDetector.ts:16`, `apps/factory/ui/settings/utils/planDetector.ts:40`, `apps/factory/ui/settings/utils/planDetector.ts:73`.
- Local sessions attach detected plans to `FloorAgent.plans`: `apps/factory/ui/settings/components/mission-control/floorAdapter.ts:419`, `apps/factory/ui/settings/components/mission-control/floorAdapter.ts:458`.
- Remote sessions attach detected plans from remote payload output/attachments: `apps/factory/ui/settings/components/mission-control/floorAdapter.ts:496`, `apps/factory/ui/settings/components/mission-control/floorAdapter.ts:497`, `apps/factory/src/core/remoteSessions.ts:142`, `apps/factory/src/core/remoteSessions.ts:144`.
- Feed cards render clickable plan artifact chips: `apps/factory/ui/settings/components/mission-control/FeedItem.tsx:168`, `apps/factory/ui/settings/components/mission-control/FeedItem.tsx:176`.
- Webview sends `openPlanPreview` and the VS Code host opens/copies/previews the selected plan: `apps/factory/src/vscode/settings.vscode.ts:855`, `apps/factory/src/vscode/settings.vscode.ts:862`, `apps/factory/src/vscode/settings.vscode.ts:873`, `apps/factory/src/vscode/settings.vscode.ts:2862`.

## Verification
- `bun test ui/settings/utils/planDetector.test.ts ui/settings/components/mission-control/floorAdapter.test.ts src/core/remoteSessions.test.ts` in `apps/factory`: 118 pass, 0 fail, 286 expect() calls.
- `bun run compile` in `apps/factory`: passed.
- `bunx vite build --config vite.preview.config.ts` in `apps/factory/ui`: passed.
- Visual check: `/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/rush-1525-plan-preview/.agents/artifacts/rush-1525/factory-plan-preview-visible.jpg` shows visible `ref-plan.html` and `ref-review.md` plan chips on the first Factory Floor card with no overlap.