### PR TITLE
RUSH-1533: add verbose startup heal diagnostics

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Startup shim self-heal stays silent by default, with `--verbose` diagnostics on stderr.**
+  The unified shim/shadow/PATH repair path no longer pollutes command stdout, including
+  `agents sessions --active --json`; `agents --verbose <cmd>` now prints a concise
+  startup self-heal summary to stderr for debugging. Source: `apps/cli/src/index.ts`,
+  `apps/cli/src/lib/shim-heal.ts`. (RUSH-1533)
 - **Wire allowlist support for OpenCode.** OpenCode stores per-tool allow/ask/deny rules in `opencode.json`/`opencode.jsonc` under `permission` (bash patterns etc.; present since ~1.1.1). Flip `allowlist: { since: '1.1.1' }` so the existing `convertToOpenCodeFormat` / `applyPermissionsToVersion` / detector path actually runs. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/permissions.ts`. (RUSH-1385)
 - **Wire subagents support for Grok CLI.** Grok discovers agent definitions as Claude-compatible `.md` files under `~/.grok/agents/` (docs: user-guide/16-subagents.md). Flip `subagents: true`, reuse the Claude flatten transform for install/writer paths, and register a detector plus list/diff/remove. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/subagents.ts`, `apps/cli/src/lib/staleness/writers/subagents.ts`, `apps/cli/src/lib/staleness/detectors/subagents.ts`. (RUSH-1384)
 - **Wire subagents support for Kimi CLI.** Kimi Code loads custom agents as YAML under `~/.kimi-code/agents/*.yaml` with a sibling `*.system.md` referenced via `system_prompt_path` (Kimi has no inline `system_prompt` field) and a managed parent `_agents-cli.yaml` that declares `agent.subagents` for `--agent-file`. Flip `subagents: true`, add `transformSubagentForKimi` / `writeKimiSubagentFiles`, list/diff/remove paths, and wire the subagents writer + detector (underscore-prefixed parent excluded from the installed name list). Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/subagents.ts`, `apps/cli/src/lib/staleness/writers/subagents.ts`, `apps/cli/src/lib/staleness/detectors/subagents.ts`. (RUSH-1383)

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -159,6 +159,7 @@ program
   .name('agents')
   .description('Environment manager for AI agents')
   .version(VERSION)
+  .option('--verbose', 'Show startup self-heal details on stderr')
   .helpOption('-h, --help', 'Show help')
   .addHelpCommand(false);
 
@@ -295,6 +296,7 @@ Automation tips:
 Options:
   -V, --version                   Show version number
   -h, --help                      Show help
+  --verbose                       Show startup self-heal details on stderr
 
 System config lives in ~/.agents/.system/. Run 'agents <command> --help' for details.
 `;
@@ -575,8 +577,9 @@ async function checkForUpdates(): Promise<void> {
 async function maybeBootstrapShimIntegration(
   requestedCommand: string | undefined,
   helpOrVersionRequested: boolean,
+  verboseStartup: boolean,
 ): Promise<void> {
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+  if (!verboseStartup && (!process.stdin.isTTY || !process.stdout.isTTY)) {
     return;
   }
   // Pure documentation paths must never trigger interactive repair — mirrors
@@ -599,8 +602,12 @@ async function maybeBootstrapShimIntegration(
   // (a real native binary shadowing the shim) or is worth saying once (a PATH entry
   // just added). Suppression is persistent and keyed to the condition — a new
   // terminal no longer re-nags (the old per-PPID sentinel did, every shell).
-  const { healShimsInteractive } = await import('./lib/shim-heal.js');
-  const noticeLines = await healShimsInteractive();
+  const { runInteractiveShimHeal } = await import('./lib/shim-heal.js');
+  const { summarizeSelfHeal } = await import('./lib/self-heal/registry.js');
+  const { noticeLines, report } = await runInteractiveShimHeal();
+  if (verboseStartup) {
+    process.stderr.write(`[agents] startup self-heal: ${summarizeSelfHeal(report)}\n`);
+  }
   if (noticeLines) {
     for (const line of noticeLines) console.log(chalk.gray(line));
   }
@@ -883,6 +890,7 @@ program.on('command:*', (operands) => {
 // and whether the update check + background sync run at all.
 const passedArgs = process.argv.slice(2);
 const requestedCommand = passedArgs.find((arg) => !arg.startsWith('-'));
+const verboseStartup = passedArgs.includes('--verbose');
 // Help and version output are pure documentation — they must never gate on
 // setup, otherwise `agents <cmd> --help` becomes useless on a fresh box.
 const helpOrVersionRequested = passedArgs.some(
@@ -1050,7 +1058,7 @@ if (passedArgs.length === 0) {
 }
 
 try {
-  await maybeBootstrapShimIntegration(requestedCommand, helpOrVersionRequested);
+  await maybeBootstrapShimIntegration(requestedCommand, helpOrVersionRequested, verboseStartup);
   await program.parseAsync();
 } catch (err) {
   if (err instanceof Error && err.name === 'ExitPromptError') {

--- a/apps/cli/src/lib/shim-heal.ts
+++ b/apps/cli/src/lib/shim-heal.ts
@@ -12,13 +12,19 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { getRuntimeStateDir } from './state.js';
+import type { SelfHealReport } from './self-heal/types.js';
+
+export interface InteractiveShimHealResult {
+  noticeLines: string[] | null;
+  report: SelfHealReport;
+}
 
 /**
- * Heal the shim/shadow/PATH conditions silently, then return the notice lines to
- * print ONCE for whatever is left (a real-binary shadow we won't move; a PATH entry
- * that was just added / needs a reload), or null when there's nothing new to say.
+ * Heal the shim/shadow/PATH conditions silently, then return both the raw report
+ * and the notice lines to print ONCE for whatever is left (a real-binary shadow we
+ * won't move; a PATH entry that was just added / needs a reload).
  */
-export async function healShimsInteractive(): Promise<string[] | null> {
+export async function runInteractiveShimHeal(): Promise<InteractiveShimHealResult> {
   const { runSelfHeal } = await import('./self-heal/registry.js');
   const report = await runSelfHeal({ checks: ['shims', 'shadowing', 'path'], mode: 'safe' });
 
@@ -36,7 +42,7 @@ export async function healShimsInteractive(): Promise<string[] | null> {
 
   const pathState: PathNoticeState = pathAdded ? 'added' : pathReload ? 'reload' : 'ok';
   const signature = computeShimNoticeSignature({ shadowNotes, pathState });
-  if (!shouldSurfaceShimNotice(signature)) return null;
+  if (!shouldSurfaceShimNotice(signature)) return { noticeLines: null, report };
 
   const lines: string[] = [];
   if (pathAdded) {
@@ -50,7 +56,14 @@ export async function healShimsInteractive(): Promise<string[] | null> {
     for (const note of shadowNotes) lines.push(`  ${note}`);
     lines.push("It's a real binary (not a symlink), so agents-cli won't move it — reorder PATH or remove it to hand it over.");
   }
-  return lines.length > 0 ? lines : null;
+  return { noticeLines: lines.length > 0 ? lines : null, report };
+}
+
+/**
+ * Back-compat wrapper for callers that only need the persistent one-time notice.
+ */
+export async function healShimsInteractive(): Promise<string[] | null> {
+  return (await runInteractiveShimHeal()).noticeLines;
 }
 
 // ─── Persistent notice-state (replaces the per-PPID sentinel) ──────────────────


### PR DESCRIPTION
## What

- Add a root `agents --verbose <cmd>` flag for startup self-heal diagnostics.
- Keep normal startup shim/shadow/PATH self-heal silent by default.
- Print the verbose self-heal summary to stderr, not stdout, so JSON command output stays parseable.
- Record the behavior in `apps/cli/CHANGELOG.md`.

## Why

PR #793 already removed the repeated shim/alias stdout spam by moving repair into the unified self-heal path. RUSH-1533 still had one acceptance gap: `agents --verbose <cmd>` was an unknown option. This fills that gap without bringing back foreground shim spam.

## Evidence

- `apps/cli/src/index.ts` registers root `--verbose`, passes it into startup shim integration, and writes `[agents] startup self-heal: ...` to stderr.
- `apps/cli/src/lib/shim-heal.ts` now exposes `runInteractiveShimHeal()` so startup can keep the one-time notice behavior and also summarize the raw self-heal report.
- `apps/cli/CHANGELOG.md` documents the user-visible flag behavior.

## Verification

- `PATH="$HOME/.bun/bin:$PATH" bun test src/lib/shim-heal.test.ts` -> 4 pass, 0 fail.
- `PATH="$HOME/.bun/bin:$PATH" bun run build` -> passed.
- `node dist/index.js sessions --active --json` -> rc 0, stdout parsed as JSON, no shim spam prefix.
- `node dist/index.js --verbose sessions --active --json` -> rc 0, stdout parsed as JSON, stderr contained `[agents] startup self-heal:`.
- `node dist/index.js --help` shows root `--verbose` under Options.