### PR TITLE
RUSH-1526: put filter + group-by in the feed header bar

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+- **Filter + group-by controls live in the feed header bar next to Save view (RUSH-1526).** The feed's own header (`SavedViews` / `feed-header-bar`) now carries Group + status chips (Needs you / Running / Idle / Failed) + agent-abbr chips, so operators filter and group where they are looking — not only from the top FloorControls bar. Source: `ui/settings/components/mission-control/SavedViewsBar.tsx`, `UnifiedAgentsPane.tsx`, `floor.css`.
 - **Floor Group defaults to Outcome (ticket/PR/worktree) instead of Project (RUSH-1479).** Fleet-scale floors collapse agents under the deliverable they serve so the operator sees initiatives, not ~1,100 processes. Source: `ui/settings/components/mission-control/floorModel.ts` (`outcomeLabel`, `FloorGroupBy`), `FloorControls.tsx`, `UnifiedAgentsPane.tsx`.
 - **Internal: `foreman.vscode.ts` reuses the shared `humanElapsed` helper (#753).** Deleted the identical private `humanElapsedFromMs` copy and imported the exported `humanElapsed` from `core/foreman.digest.ts`. No behavior change. Source: `apps/factory/src/vscode/foreman.vscode.ts`.
 - **Windows device dispatch no longer hardcodes `bash -lc`.** `dispatchToDevice` selects the remote shell from the device registry platform (PowerShell `-EncodedCommand` on windows; bash on POSIX), so Dispatch v2 works on win-mini. Source: `apps/factory/src/core/deviceDispatchShell.ts`, `apps/factory/src/vscode/settings.vscode.ts`. (RUSH-1481)

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -928,7 +928,8 @@
     "@types/sql.js": "^1.4.9",
     "@types/vscode": "^1.85.0",
     "@types/ws": "^8.18.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "react-dom": "^19.2.7"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.3",

--- a/apps/factory/ui/settings/components/mission-control/SavedViewsBar.test.tsx
+++ b/apps/factory/ui/settings/components/mission-control/SavedViewsBar.test.tsx
@@ -1,0 +1,75 @@
+import { expect, test, describe } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { SavedViews, FEED_GROUP_OPTS, FEED_STATUS_OPTS } from './SavedViewsBar'
+
+const noop = () => {}
+
+describe('SavedViews feed header bar (RUSH-1526)', () => {
+  test('without feedFilters, only Save view (no group/status chips)', () => {
+    const html = renderToStaticMarkup(
+      <SavedViews views={[]} activeName={null} onApply={noop} onSave={noop} onDelete={noop} />,
+    )
+    expect(html).toContain('Save view')
+    expect(html).toContain('feed-header-bar')
+    expect(html).not.toContain('Group:')
+    expect(html).not.toContain('Needs you')
+  })
+
+  test('with feedFilters, group-by and status filters render next to Save view', () => {
+    const html = renderToStaticMarkup(
+      <SavedViews
+        views={[]}
+        activeName={null}
+        onApply={noop}
+        onSave={noop}
+        onDelete={noop}
+        feedFilters={{
+          group: 'outcome',
+          onGroup: noop,
+          status: ['needs'],
+          onToggleStatus: noop,
+          abbrs: [],
+          availableAbbrs: ['CC', 'CX'],
+          onToggleAbbr: noop,
+        }}
+      />,
+    )
+    expect(html).toContain('Save view')
+    expect(html).toContain('Group:')
+    expect(html).toContain('Outcome')
+    expect(html).toContain('Needs you')
+    expect(html).toContain('Running')
+    expect(html).toContain('feed-header-status on') // needs active
+    expect(html).toContain('>CC<')
+    expect(html).toContain('>CX<')
+    // Group options are present in the select
+    for (const o of FEED_GROUP_OPTS) {
+      expect(html).toContain(`>${o.label}<`)
+    }
+    for (const o of FEED_STATUS_OPTS) {
+      expect(html).toContain(o.label)
+    }
+  })
+
+  test('active agent chips mark .on when selected', () => {
+    const html = renderToStaticMarkup(
+      <SavedViews
+        views={[]}
+        activeName={null}
+        onApply={noop}
+        onSave={noop}
+        onDelete={noop}
+        feedFilters={{
+          group: 'project',
+          onGroup: noop,
+          status: [],
+          onToggleStatus: noop,
+          abbrs: ['CC'],
+          availableAbbrs: ['CC', 'CX'],
+          onToggleAbbr: noop,
+        }}
+      />,
+    )
+    expect(html).toContain('feed-header-agent on')
+  })
+})

--- a/apps/factory/ui/settings/components/mission-control/SavedViewsBar.tsx
+++ b/apps/factory/ui/settings/components/mission-control/SavedViewsBar.tsx
@@ -1,19 +1,61 @@
 import React, { useState } from 'react'
 import { Icon } from './icons'
 import type { SavedView } from './savedViews'
+import type { AgentAbbr, FloorGroupBy } from './floorModel'
+import type { StatusChip } from './FloorControls'
 
-// Saved-view chips over the one stream (the mockup's Today / Engineering / My work
-// row). Clicking a chip applies its filters; the active one is highlighted. The
-// "Save view" affordance captures the current filters under an inline-typed name.
+// Feed header bar: saved-view chips + (when agents center) group-by and status/
+// agent filter controls. Filter/group used to live only on FloorControls (top
+// nav); operators look at the feed itself, so those affordances belong here
+// next to "Save view" (RUSH-1526).
+
+/** Same axes as FloorControls GROUP_OPTS — kept local so the header bar does not
+ *  re-export FloorControls internals. */
+export const FEED_GROUP_OPTS: { value: FloorGroupBy | 'none'; label: string }[] = [
+  { value: 'outcome', label: 'Outcome' },
+  { value: 'none', label: 'None' },
+  { value: 'project', label: 'Project' },
+  { value: 'host', label: 'Host' },
+  { value: 'status', label: 'Status' },
+  { value: 'agent', label: 'Agent' },
+]
+
+export const FEED_STATUS_OPTS: { value: StatusChip; label: string }[] = [
+  { value: 'needs', label: 'Needs you' },
+  { value: 'running', label: 'Running' },
+  { value: 'idle', label: 'Idle' },
+  { value: 'failed', label: 'Failed' },
+]
+
 interface SavedViewsProps {
   views: SavedView[]
   activeName: string | null
   onApply: (v: SavedView) => void
   onSave: (name: string) => void
   onDelete: (name: string) => void
+  /**
+   * When set, render group-by + status/agent filter chips in this same bar
+   * (the feed header). Omit on non-agents surfaces so the bar stays Save-view-only.
+   */
+  feedFilters?: {
+    group: FloorGroupBy | 'none'
+    onGroup: (g: FloorGroupBy | 'none') => void
+    status: StatusChip[]
+    onToggleStatus: (s: StatusChip) => void
+    abbrs: AgentAbbr[]
+    availableAbbrs: AgentAbbr[]
+    onToggleAbbr: (a: AgentAbbr) => void
+  }
 }
 
-export function SavedViews({ views, activeName, onApply, onSave, onDelete }: SavedViewsProps) {
+export function SavedViews({
+  views,
+  activeName,
+  onApply,
+  onSave,
+  onDelete,
+  feedFilters,
+}: SavedViewsProps) {
   const [adding, setAdding] = useState(false)
   const [name, setName] = useState('')
 
@@ -24,16 +66,12 @@ export function SavedViews({ views, activeName, onApply, onSave, onDelete }: Sav
     setAdding(false)
   }
 
-  if (views.length === 0 && !adding) {
-    return (
-      <div className="savedviews">
-        <span className="svadd" onClick={() => setAdding(true)}><Icon name="plus" size={10} /> Save view</span>
-      </div>
-    )
-  }
+  const groupLabel = feedFilters
+    ? (FEED_GROUP_OPTS.find((o) => o.value === feedFilters.group) ?? FEED_GROUP_OPTS[0]!).label
+    : ''
 
   return (
-    <div className="savedviews">
+    <div className="savedviews feed-header-bar" data-testid="feed-header-bar">
       {views.map((v) => (
         <span
           key={v.name}
@@ -61,6 +99,55 @@ export function SavedViews({ views, activeName, onApply, onSave, onDelete }: Sav
         />
       ) : (
         <span className="svadd" onClick={() => setAdding(true)}><Icon name="plus" size={10} /> Save view</span>
+      )}
+
+      {feedFilters && (
+        <>
+          <span className="sv-sep" aria-hidden="true" />
+          <label className="fpill fpill-sel feed-header-group" title="Group the feed">
+            Group: <b>{groupLabel}</b>
+            <select
+              value={feedFilters.group}
+              onChange={(e) => feedFilters.onGroup(e.target.value as FloorGroupBy | 'none')}
+              aria-label="Group feed by"
+            >
+              {FEED_GROUP_OPTS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </label>
+          {FEED_STATUS_OPTS.map((o) => {
+            const on = feedFilters.status.includes(o.value)
+            return (
+              <span
+                key={o.value}
+                className={`chip feed-header-status${on ? ' on' : ''}`}
+                title={on ? `Clear ${o.label} filter` : `Filter: ${o.label}`}
+                onClick={() => feedFilters.onToggleStatus(o.value)}
+              >
+                {o.label}
+              </span>
+            )
+          })}
+          {feedFilters.availableAbbrs.length > 0 && (
+            <>
+              <span className="sv-sep" aria-hidden="true" />
+              {feedFilters.availableAbbrs.map((abbr) => {
+                const on = feedFilters.abbrs.includes(abbr)
+                return (
+                  <span
+                    key={abbr}
+                    className={`chip feed-header-agent${on ? ' on' : ''}`}
+                    title={on ? `Hide ${abbr}` : `Show only ${abbr}`}
+                    onClick={() => feedFilters.onToggleAbbr(abbr)}
+                  >
+                    {abbr}
+                  </span>
+                )
+              })}
+            </>
+          )}
+        </>
       )}
     </div>
   )

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -1977,6 +1977,19 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
         onApply={applyView}
         onSave={saveView}
         onDelete={deleteView}
+        feedFilters={{
+          group: floorGroup,
+          onGroup: setFloorGroup,
+          status: statusChips,
+          onToggleStatus: (s) => setStatusChips((cur) => (
+            cur.includes(s) ? cur.filter((c) => c !== s) : [...cur, s]
+          )),
+          abbrs: abbrChips,
+          availableAbbrs: Array.from(new Set(floorAgents.map((a) => a.abbr))).sort(),
+          onToggleAbbr: (a) => setAbbrChips((cur) => (
+            cur.includes(a) ? cur.filter((c) => c !== a) : [...cur, a]
+          )),
+        }}
       />
       {(needsAgents.length > 0 || pendingPlans.length > 0) && (
         <>

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -296,6 +296,13 @@
 .swarmify-root .pill.cirun { background: var(--status-pending-bg); color: var(--status-pending); }
 .swarmify-root .pill.bg { background: var(--status-pending-bg); color: var(--status-pending); border: 1px solid color-mix(in srgb, var(--status-pending) 45%, transparent); }
 .swarmify-root .savedviews { display: flex; flex-wrap: wrap; gap: 6px; padding: 2px 0 12px; align-items: center; }
+/* Feed header bar (RUSH-1526): Save view + group-by + status/agent filters in one row. */
+.swarmify-root .savedviews.feed-header-bar { gap: 6px; }
+.swarmify-root .savedviews .sv-sep { width: 1px; height: 16px; background: var(--ds-border-subtle); margin: 0 2px; flex: 0 0 auto; }
+.swarmify-root .savedviews .fpill { padding: 4px 10px; font-size: 11px; }
+.swarmify-root .savedviews .chip { font-family: "Geist Mono", monospace; font-size: 11px; color: var(--ds-text-muted); background: var(--ds-bg-recessed); border: 1px solid var(--ds-border); border-radius: 20px; padding: 4px 10px; cursor: pointer; user-select: none; }
+.swarmify-root .savedviews .chip:hover { border-color: var(--ds-text-dim); color: var(--ds-text); }
+.swarmify-root .savedviews .chip.on { color: var(--ds-text); border-color: var(--ds-text-dim); background: var(--ds-bg-elevated, var(--ds-bg)); font-weight: 700; }
 .swarmify-root .svchip { display: inline-flex; align-items: center; gap: 4px; font-size: 11px; font-weight: 600; padding: 3px 9px; border-radius: 999px; border: 1px solid var(--ds-border); color: var(--ds-text-muted); background: var(--ds-bg-panel); cursor: pointer; }
 .swarmify-root .svchip:hover { color: var(--ds-text); border-color: var(--ds-text-muted); }
 .swarmify-root .svchip.on { color: var(--brand); border-color: var(--brand); background: rgba(232, 93, 93, 0.1); }


### PR DESCRIPTION
## What

Filter and group-by controls now live in the **feed header bar** next to Save view (`SavedViews` / `feed-header-bar`), not only in the top FloorControls nav.

- **Group** select (Outcome / None / Project / Host / Status / Agent)
- **Status** chips: Needs you, Running, Idle, Failed (multi-toggle)
- **Agent** abbr chips derived from the live roster (CC, CX, …)

Top FloorControls Group/Sort remain for sort + chrome (sidebar/detail/plain). Feed-header filters drive the same `statusChips` / `abbrChips` / `floorGroup` state.

## Why

RUSH-1526: operators look at the feed (NEEDS YOU · N / Save view). Filter/group only in the top bar meant the controls were not where attention is.

## Evidence

| File | Change |
| --- | --- |
| `SavedViewsBar.tsx` | optional `feedFilters` props; group + status + agent chips |
| `UnifiedAgentsPane.tsx` | wires feedFilters from floor state |
| `floor.css` | feed-header-bar chip/separator styles |

## Tests

```
cd apps/factory && bun test ui/settings/components/mission-control/SavedViewsBar.test.tsx \
  ui/settings/components/mission-control/savedViews.test.ts \
  ui/settings/components/mission-control/FloorControls.test.tsx
# 14 pass
```

## Linear

Closes RUSH-1526