### PR TITLE
chore(release): 1.20.53

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.20.53
+
 - **`agents add <agent>@latest` resolves to a concrete version before installing (no install race).** `latest` (like `oldest`) is now resolved via `npm view` up front and installed as a pinned spec directly into `versions/<agent>/<version>/`. Previously `latest` installed into a shared, well-known `versions/<agent>/latest/` scratch dir and was renamed to the real version only after npm finished — so a concurrent `agents view` reconcile (`reconcileStaleLatestForAgent`) or a second `latest` install could rename that dir out from under npm mid-extraction, corrupting the install with `ENOENT` on the seeded `package.json`. A concrete dir per version has no shared name to race on. Source: `apps/cli/src/lib/versions.ts`.
 - **Native memory sync preserves unmanaged Markdown files (RUSH-1621).** Sync tracks managed fact names in `.agents-cli-memory.json` and only deletes those; user-authored `*.md` under the agent memory dir survive. Source: `apps/cli/src/lib/memory.ts`.
 - **Feed high-consequence authz uses the canonical operator registry (RUSH-1618).** `recordAnswer` no longer looks for `operators.yaml` under the feed root; it resolves operators from `~/.agents/` via `loadOperators()`. Source: `apps/cli/src/lib/feed.ts`.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phnx-labs/agents-cli",
-  "version": "1.20.52",
+  "version": "1.20.53",
   "description": "One CLI for all your AI coding agents - versions, config, cloud dispatch, sessions, and teams (now with first-class Grok Build CLI support)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## 1.20.53

- **Wire subagents support for OpenCode.** OpenCode loads agent markdown from `~/.config/opencode/agents/` with frontmatter `mode: subagent`. Flip `subagents: true`, add `transformSubagentForOpenCode`, wire writer/detector/list/diff/remove. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/subagents.ts`. (RUSH-1386)
- **`agents feed` groups by outcome (ticket/PR/worktree), not by agent (RUSH-1479).** The default human view collapses open blocks under the deliverable they serve — Linear ticket first, then PR, then worktree/epic, then a shared Unassigned bucket — so a 1,100-agent fleet reads as dozens of initiatives (`RUSH-1125 · 4 agents · 1 needs you`). Each block is attributed to exactly one outcome; live session meta fills missing ticket/PR/worktree at list time; `--flat` restores the per-agent list; `--json` stamps each block with its `outcome` ref. Factory Floor's Group control gains an Outcome axis (the new default). Source: `apps/cli/src/lib/feed-outcome.ts`, `apps/cli/src/commands/feed.ts`, `apps/factory/ui/settings/components/mission-control/floorModel.ts`.
- **Menu bar dropdown redesigned around triage: attention floats up, context groups down.** The dropdown used to stack ~11 flat sections at equal weight, so a session waiting on you sat as loud as setup noise. Now: a **⚠ NEEDS YOU strip on top**, sorted by wait-time across all projects (most-stalled first), each row carrying the actual question the session is waiting on plus how long it's waited (`Claude · agents-cli — Claude needs your permission to use Bash · 2h 25m`); **live work grouped by repo** below (`ACTIVE · <repo>` headers, rich rows show the session's own title inline); **ROUTINES expanded** into a glanceable section (next few upcoming + any failing routine inline, `All routines…` for the rest); RECENT TICKETS and RECENT stay dedicated sections; **Setup + Auto-nudge collapse into one System row** (submenu keeps the doctor items and the auto-nudge toggle). A **density toggle** in the footer cycles Auto → Rich → Compact — compact folds rows to one-liners and tucks Recent behind a submenu; Auto (default) is rich while something needs you, compact on a calm machine (`menubarDensity` in UserDefaults, `MENUBAR_DENSITY` env override for dump probes). The question text + wait-time come from the attention sentinel: the Notification hook now writes the notification message as the sentinel content (phnx-labs/.agents-system#74), and the helper reads content + mtime (`LocalState.attentionMarks`); an empty sentinel still renders as "awaiting input". `Session` gained `title`/`question`/`attentionSinceMs`; terminal rows group by working-dir name and carry the live-terminal label as the title. Source: `apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift`, `apps/cli/menubar/Sources/MenubarHelper/LocalState.swift`.
- **Wire allowlist support for OpenCode.** OpenCode stores per-tool allow/ask/deny rules in `opencode.json`/`opencode.jsonc` under `permission` (bash patterns etc.; present since ~1.1.1). Flip `allowlist: { since: '1.1.1' }` so the existing `convertToOpenCodeFormat` / `applyPermissionsToVersion` / detector path actually runs. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/permissions.ts`. (RUSH-1385)
- **Wire subagents support for Grok CLI.** Grok discovers agent definitions as Claude-compatible `.md` files under `~/.grok/agents/` (docs: user-guide/16-subagents.md). Flip `subagents: true`, reuse the Claude flatten transform for install/writer paths, and register a detector plus list/diff/remove. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/subagents.ts`, `apps/cli/src/lib/staleness/writers/subagents.ts`, `apps/cli/src/lib/staleness/detectors/subagents.ts`. (RUSH-1384)
- **Wire subagents support for Kimi CLI.** Kimi Code loads custom agents as YAML under `~/.kimi-code/agents/*.yaml` with a sibling `*.system.md` referenced via `system_prompt_path` (Kimi has no inline `system_prompt` field) and a managed parent `_agents-cli.yaml` that declares `agent.subagents` for `--agent-file`. Flip `subagents: true`, add `transformSubagentForKimi` / `writeKimiSubagentFiles`, list/diff/remove paths, and wire the subagents writer + detector (underscore-prefixed parent excluded from the installed name list). Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/subagents.ts`, `apps/cli/src/lib/staleness/writers/subagents.ts`, `apps/cli/src/lib/staleness/detectors/subagents.ts`. (RUSH-1383)
- **Grok + Antigravity now register dir-form subrule hooks.** The hooks writer excluded `grok` from `registerHooksToSettings`, so subrule-bundled guards (absolute paths outside the central hooks copy set) never reached `~/.grok/hooks/hooks.json`. Grok is now in the gate. Antigravity entries carry `matcher` so guards are tool-scoped. Source: `apps/cli/src/lib/staleness/writers/hooks.ts`, `apps/cli/src/lib/hooks.ts`. (RUSH-1353)
- **Menu-bar Quick Dispatch can now pick agents and fan out autonomous fixes from the screenshot panel.** `Cmd-Shift-O` still supports filing one Linear ticket, but the panel now has a File Ticket / Fix mode control plus a roster picker sourced from the menu-bar agent list. File Ticket runs the selected ticket agent; Fix dispatches every selected agent with `agents run <agent> --mode auto --name quick-<agent>-<timestamp>`, carrying the typed note and selected screenshots into a repo-discovery prompt so those runs surface in normal session/tray views instead of hidden background work. `AGENTS_QUICK_DISPATCH_ROSTER=claude,codex` filters visible agents and `AGENTS_QUICK_DISPATCH_AGENTS=claude,codex` preselects them. Source: `apps/cli/menubar/Sources/MenubarHelper/{LocalState,PromptPanel,AgentsCLI,IssueSelfTest}.swift`, `apps/cli/docs/menubar.md`. (RUSH-1416)
- **Internal: consolidated the drifted provider status-normalizers and git-root helpers (#753).** The three copies of `mapStatus` in `cloud/{rush,codex,antigravity}.ts` — which had drifted (different vocabularies and defaults) — collapse into one exported `normalizeProviderStatus(provider, wireStatus)` in `cloud/types.ts`. Behavior-preserving: each provider's exact vocabulary and default is kept byte-for-byte (rush switch, default `running`, has `allocating`, no `queued`; codex substring, default `running`; antigravity substring, `undefined`-safe, default `completed`); factory's structurally-different `mapResultStatus` is left in place. `getGitRoot` moves to `lib/git.ts` and `commands/worktree.ts` now calls it instead of a private `gitRoot` copy; the two divergent `isGitRepo` variants (synchronous root-only in `git.ts` vs async worktree-correct in `teams/worktree.ts`) are documented and deliberately not merged. Source: `apps/cli/src/lib/cloud/{types,rush,codex,antigravity}.ts`, `apps/cli/src/lib/git.ts`, `apps/cli/src/lib/teams/worktree.ts`, `apps/cli/src/commands/worktree.ts`. (#753)
- **macOS installs now run a Developer-ID-signed + notarized `agents` binary — the primary fix for EDR (CrowdStrike Falcon) blocking the CLI.** The resolved `agents` on macOS was a node-shebang JS file in a user-writable path; unsigned and spawned by editor/Electron children, it matched Falcon's post-exploitation profile and the sessions feature silently died on EDR-enabled Macs (mitigation 1 of #315; the behavioral hardening, mitigations 2-4, shipped earlier). Releases now build a standalone arm64 Mach-O with `bun build --compile` (`scripts/build-bin.sh`), sign it with Developer ID + hardened runtime + the JIT entitlement bun's JavaScriptCore needs under the hardened runtime (`scripts/sign-cli-binary.sh`, `scripts/bun-jit-entitlements.plist`), notarize it with `notarytool`, and ship it in the npm tarball at `dist/bin/agents`. `postinstall` points the alias shims and the `~/.local/bin/agents`/`ag` links at the signed binary — with a run-probe that falls back loudly to the JS entrypoint if the binary is missing, wrong-arch, or blocked — and repoints links an earlier install left at the JS shim. A `prepack` gate (`scripts/verify-cli-binary.sh`) refuses to pack unless the binary matches its sign-run sha pin, embeds the release version, and (on macOS) passes `codesign --verify` with a Developer ID authority. Linux-driven releases build + sign the binary on the mac sign host via `scripts/remote-sign-mac.sh`. Intel Macs and non-mac platforms keep the JS entrypoint. (#315)
- **Codex multi-file apply_patch now surfaces every path.** `parseCodex` used `.match()` on the patch body so only the first `*** Update/Add/Delete File:` path became a tool_use; files 2+ were invisible to artifact discovery. Now `applyPatchTargetPaths` uses `matchAll` and emits one Edit event per file. Source: `apps/cli/src/lib/session/parse.ts`. (RUSH-1410)
- **`memory` is a first-class top-level resource (distinct from `rules`).** `agents memory list|add|remove|view|sync` manages portable knowledge facts under `~/.agents/memory/` (project > user > system; `MEMORY.md` index + one `<slug>.md` per fact). The legacy `agents memory` → `rules` tombstone is gone. Capable agents (claude, codex, openclaw, grok) get facts fanned into version homes on `syncResourcesToVersion` / `agents memory sync`. Plugins can ship a `memory/` dir (surfaced in `pluginResourceGroups`). Note: internal `ResourceSelection.memory` still means the composed *rules* file — rename to `rules` is a follow-up. Source: `apps/cli/src/lib/memory.ts`, `apps/cli/src/commands/memory.ts`, `apps/cli/src/lib/resources/memory.ts`, `apps/cli/src/lib/versions.ts`, `apps/cli/src/lib/plugins.ts`. (RUSH-1330)
- **`agents sessions --active --json` now carries `tokPerSec`, and `agents sessions --roots --json` emits the session-scan directories — one CLI contract the Factory extension consumes instead of re-implementing (issue #741).** Every active row gained `tokPerSec`: live output-token throughput over a rolling 60s window from the transcript tail (Claude assistant `output_tokens`; Codex `token_count` output + reasoning; Gemini output + thoughts), absent when the session is idle or its format reports no usage. The new `agents sessions --roots --json` prints, per on-disk agent, the exact directories the CLI scans for transcripts (every version home + backup mirror), so an external watcher (the Factory Floor's `fs.watch`) tracks the same paths the CLI does instead of hardcoding `~/.claude|.codex|.gemini` — add an on-disk agent to discovery and every consumer watches it automatically. The throughput math and the roots list are now the single source of truth; the extension used to keep parallel copies. Source: `apps/cli/src/lib/session/throughput.ts` (`computeTokPerSec`), `apps/cli/src/lib/session/active.ts` (`ActiveSession.tokPerSec`, `computeLiveSignals`), `apps/cli/src/lib/session/tail.ts` (`readSessionTailWithRaw`), `apps/cli/src/lib/session/discover.ts` (`getSessionRoots`), `apps/cli/src/commands/sessions.ts` (`--roots`).
- **Fix: `agents sessions --active` no longer attaches stale Codex transcripts to live processes.** Codex session lookup now sorts by indexed `last_activity` and refuses to borrow a transcript outside an explicit 24-hour freshness bound, so a desktop app service or unrelated long-lived process cannot light up a months-old session as `running`. Source: `apps/cli/src/lib/session/active.ts`, `apps/cli/src/lib/session/db.ts`. (RUSH-1489)
- **Wire subagents support for Codex CLI.** Codex custom agents are standalone TOML under `~/.codex/agents/*.toml` (required: `name`, `description`, `developer_instructions`; multi-agent plumbing since 0.117.0). Flip `subagents: { since: '0.117.0' }`, add `transformSubagentForCodex`, and wire the subagents writer + install/remove paths. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/subagents.ts`, `apps/cli/src/lib/staleness/writers/subagents.ts`. (RUSH-1382)
- **Routines use the same version/account selection and credit failover as `agents run`.** Scheduled jobs used to spawn a bare `claude`/`codex` name under a sandbox HOME, which could surface as `agents: no version of claude configured` even when installs existed, and never walked past a credit-exhausted default. The runner now resolves a healthy install via the configured run strategy (default `balanced`), pins the absolute binary, injects per-version config dirs + the daemon's `CLAUDE_CODE_OAUTH_TOKEN` into sandboxed spawns, and on foreground `agents routines run` re-dispatches to the next healthy same-agent account when a mid-run rate/usage limit is detected (daemon detached fires use the pre-flight pick only). Diagnostic lines log the pick, skipped accounts, and each failover hop. Source: `apps/cli/src/lib/runner.ts` (`resolveRoutineLaunch`, `pinJobBinary`, `buildRoutineSpawnEnv`), `apps/cli/src/lib/sandbox.ts` (OAuth allowlist), `apps/cli/src/commands/routines.ts` (help). (RUSH-1016)
- **Wire plugin support for Goose.** Goose loads Open Plugins from `$HOME/.agents/plugins/<name>/` (same layout as agents-cli). Flip `plugins: true` and copy each selected plugin into the version home under `.agents/plugins/`. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/plugins.ts` (`installGoosePlugin`). (RUSH-1339)
- **Wire plugin support for Cursor CLI.** Cursor agent plugins use `.cursor-plugin/plugin.json` (re-enabled 2026-05). Flip `plugins: true`, set `pluginManifestDir: '.cursor-plugin'`, and reuse the centralized marketplace mirror path under `~/.cursor/plugins/`. Source: `apps/cli/src/lib/agents.ts`. (RUSH-1338)
- **Wire plugin support for OpenCode.** OpenCode loads JS/TS plugin modules from `$HOME/.config/opencode/plugins/` (not Claude marketplace layout). Flip `plugins: true`, install modules from a plugin's `opencode/` or `plugins/` dir (or root) into the version home, and track install/remove via `isPluginSynced` / `removePluginFromVersion`. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/plugins.ts` (`installOpenCodePlugin`, `openCodePluginsDir`). (RUSH-1336)
- **Wire hooks support for Cursor CLI.** Cursor agent CLI (`cursor-agent`) gained lifecycle hooks on 2026-01-16 (`~/.cursor/hooks.json`, `{ "version": 1, "hooks": {…} }`). Flip the capability, map canonical events to Cursor camelCase (`SessionStart` → `sessionStart`, `UserPromptSubmit` → `beforeSubmitPrompt`, `Stop` → `stop`, …), and merge managed entries into `hooks.json` while preserving user-authored commands outside managed prefixes. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/hooks.ts` (`registerHooksForCursor`, `CURSOR_EVENT_MAP`), `apps/cli/src/lib/staleness/writers/hooks.ts`. (RUSH-1326)
- **Wire hooks support for Goose.** Goose (`block-goose-cli` ≥ 1.34.0) auto-discovers Open Plugins hooks at `$HOME/.agents/plugins/<name>/hooks/hooks.json`. Flip `supportsHooks` and gate `hooks: { since: '1.34.0' }`, write a managed plugin (`agents-cli-hooks`) under the version home with Claude-shaped event groups, and leave user plugins alone. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/hooks.ts` (`registerHooksForGoose`, `GOOSE_EVENT_MAP`), `apps/cli/src/lib/staleness/writers/hooks.ts`. (RUSH-1325)
- **Wire hooks support for Kiro CLI.** Kiro CLI v3 stores standalone hooks under `~/.kiro/hooks/*.json` (`{ "version": "v1", "hooks": [...] }` with command/agent actions); PreToolUse/PostToolUse firing was fixed in kiro-cli 0.10. Flip `supportsHooks` and gate `hooks: { since: '0.10.0' }`, map canonical events to Kiro PascalCase triggers, and write a single managed `agents-cli-hooks.json` on every sync (user-authored sibling files untouched). Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/hooks.ts` (`registerHooksForKiro`, `KIRO_EVENT_MAP`), `apps/cli/src/lib/staleness/writers/hooks.ts`. (RUSH-1324)
- **Wire hooks support for GitHub Copilot CLI.** Copilot GA (`@github/copilot` ≥ 1.x) ships a real hooks system (`~/.copilot/hooks/*.json`, schema `{ "version": 1, "hooks": {…} }`), but agents-cli still declared `hooks: false` so nothing ever installed. Flip the capability, map canonical events to Copilot camelCase (`SessionStart` → `sessionStart`, `PreToolUse` → `preToolUse`, `Stop` → `agentStop`, …), and write a single managed file (`agents-cli-hooks.json`) on every sync so GC is a rewrite and user-authored sibling JSON files are never touched. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/hooks.ts` (`registerHooksForCopilot`, `COPILOT_EVENT_MAP`), `apps/cli/src/lib/staleness/writers/hooks.ts`. (RUSH-1323)
- **`agents run --lease` now shows live progress instead of a 30-90s blank terminal.** After the runtime picker + consent, the lease used to go completely silent while the box provisioned (`crabboxWarmup` was a blocking `spawnSync`, so nothing could animate), then dump crabbox's raw sync/bootstrap log interleaved with the agent's output. Now a spinner animates each previously-silent phase — `Leasing a hetzner box… (Ns)` → `✔ Box <slug> ready (<ip>) · Ns` → `Setting up box — <latest step>` → `✔ Box provisioned — <agent> output:` — and the agent's own output then prints verbatim. The box bootstrap echoes a marker (`LEASE_AGENT_MARKER`) right before the agent run; `createLeaseOutputRouter` splits the crabbox stream on it so setup noise feeds the spinner while the agent output streams clean, and a setup failure dumps the captured setup log so errors are never swallowed. `crabboxWarmup` is now async so the event loop stays free to animate. The spinner is a purpose-built `createSpinner` (NOT `ora`): ora hooks `stream.write` and re-renders on every external write while spinning, which ballooned to multi-GB output when a lease streamed past a live spinner — `createSpinner` writes exactly one short line per fixed tick and nowhere else (a unit test asserts 100k `update()` calls produce zero writes), and on a non-TTY prints each phase label once and stays silent on update (no piped/CI flood). Verified live on Hetzner: animated warmup counter, clean `LOGIN_OK`, box auto-destroyed, 43KB total output. Source: `apps/cli/src/lib/crabbox/progress.ts` (`createSpinner`, `createLeaseOutputRouter`, `LEASE_AGENT_MARKER`), `apps/cli/src/lib/crabbox/{lease,cli}.ts`, `apps/cli/src/commands/exec.ts`.
- **Fix: Grok hooks now respect their `matcher` and no longer run twice per event.** The Grok hook registrar (`registerHooksForGrok`) dropped the manifest `matcher` when writing `~/.grok/hooks/`, so a matcher-scoped hook fired on every tool call — the plan-presentation hook (meant for `ExitPlanMode` only) hard-blocked whole Grok sessions (exit 2 = explicit deny). It also double-registered every hook into BOTH `hooks.json` AND a per-event file (`pretooluse.json`, …); Grok merges all of `~/.grok/hooks/*.json`, so each hook ran twice. Now the registrar emits `matcher` only for the events Grok accepts it on (`PreToolUse`, `PostToolUse`, `Notification` — lifecycle events reject it), groups hooks one-per-distinct-matcher like the Claude writer, translates tool names Grok doesn't auto-alias (`ExitPlanMode` → `ExitPlanMode|exit_plan_mode`, since Grok's plan tool is `exit_plan_mode`), and writes a single `hooks.json`, pruning the stale per-event files an older build left behind so already-synced installs stop double-running. Source: `apps/cli/src/lib/hooks.ts` (`registerHooksForGrok`, `isManagedGrokHookFile`, `GROK_MATCHER_EVENTS`, `GROK_MATCHER_ALIASES`).
- **Agent feed replies now have delivery confirmation and atomic first-answer-wins closure (RUSH-1476).** `agents message` ties a local reply to the agent's current open feed block; if any surface already answered that block, the second attempt is rejected with the surface that won. The feed block records queued → consumed → continued receipts: `queued` when `agents message` enqueues, `consumed` when the mailbox drain archives the message, and `continued` once the agent continues past the block. A human answer typed directly in the terminal is reconciled via the `UserPromptSubmit` hook, which records a terminal answer and removes the visible block within one feed poll cycle. Source: `apps/cli/src/lib/feed.ts` (`recordAnswer`, `recordMessageReceipt`, `recordContinued`, answered-marker lifecycle), `apps/cli/src/lib/mailbox.ts` (`blockId` on `MailboxMessage`, consumed-receipt surfacing), `apps/cli/src/commands/message.ts` (open-block lookup + `--surface`), `apps/cli/src/commands/feed.ts` (receipt rendering).
- **24/7 multi-operator controls for agent feed (RUSH-1480).** Blocks can now carry `blockClass` (`approval`/`decision`), `consequence` (`normal`/`high`), `allowedOperators`, `timeoutMinutes`, `safeDefault`, and `costOfDelay`; the feed-publish hook captures these from the agent's `AskUserQuestion` tool_input. High-consequence answers require a verified operator id known to `~/.agents/operators.yaml` (`agents message --as <operator>`). `agents feed --dispatch` evaluates default-on-no-answer policy loaded from `~/.agents/feed-policy.yaml`: approval blocks resolve to their safe default after the timeout, decision blocks are hard-parked. Urgent blocks (`costOfDelay` at or above the phone threshold) are paged once via the OpenClaw Telegram gateway (`openclaw message send --channel telegram --account default`). Source: `apps/cli/src/lib/operator.ts`, `apps/cli/src/lib/feed-policy.ts`, `apps/cli/src/lib/notify.ts`, `apps/cli/src/lib/feed.ts` (block metadata + authz + parked/defaulted/notified timestamps), `apps/cli/src/commands/message.ts` (`--as`), `apps/cli/src/commands/feed.ts` (`--dispatch`, metadata rendering).
- **Mailbox TTL + liveness/GC so messages never rot in dead-agent inboxes (RUSH-1475).** `enqueue` accepts an optional `ttlSeconds`; expired messages are archived to `consumed/` with `dropped: expired` instead of being returned by `drain`/`peek`. `agents feed --dispatch` runs a liveness sweep against `getActiveSessions()`: boxes whose owning agent is no longer alive are treated as dead, their pending messages are archived with `dropped: dead`, and any feed block tied to that mailbox is removed so the operator never answers a ghost. Old `consumed/` entries are pruned after 24 hours by default. Source: `apps/cli/src/lib/mailbox.ts` (`expiresAt`, `isExpired`, `sweepExpired`), `apps/cli/src/lib/mailbox-gc.ts`, `apps/cli/src/commands/feed.ts` (`--dispatch` liveness sweep).
- **Keychain service names are no longer silently enumerable — items are stored under opaque HMAC-hashed names (macOS).** The helper's `list` never decrypts and never prompts (that's what keeps `agents secrets list` snappy), which meant the service names themselves — `agents-cli.secrets.<bundle>.<KEY>`, `agents-cli.bundles.<name>`, `agents-cli.<provider>.token` — were readable metadata: any same-user process could silently inventory your bundles, keys, and providers before ever popping Touch ID. Every `agents-cli.*` item now lives under an opaque name (`agents-cli.h.<ns>.m` for bundle metadata, `agents-cli.h.<ns>.k.<kh>` for values, `agents-cli.h.o.<ih>` otherwise) keyed by a per-machine random HMAC key (`agents-cli.hmackey`, no-ACL so silent operations stay silent). The structured shape keeps a bundle's items under one hashed prefix, so `secrets exec`/`run --secrets` still resolve metadata + all values behind a single Touch ID. A one-time re-key migrates existing items — automatically on the first interactive keychain use, or via the new `agents secrets rekey` (`--status` to inspect, exit 4 on a cancelled Touch ID; re-running resumes). It is crash-safe end to end: values are batch-read once, hashed copies are written and verified before ANY original is deleted, activation is all-or-nothing, and an interrupted delete phase is finished silently by the next run. A `--prefix`-restricted (partial) run resolves each value item's bundle tier directly from the keychain — scoping a `never`-policy bundle's value items without its metadata item keeps the silent no-ACL tier intact. The signed Swift helper is untouched (it already treats service names as opaque), so no re-notarization or sha re-pin. Caveat: an older agents-cli on the same machine writes/reads cleartext names and won't see re-keyed items — keep all installs current. Source: `apps/cli/src/lib/secrets/index.ts` (`hashedServiceName`, `rekeyServiceNames`), `apps/cli/src/lib/secrets/bundles.ts`, `apps/cli/src/commands/secrets-migrate.ts`, `apps/cli/docs/secrets.md`. (GitHub #316, Finding 1)