### PR TITLE
RUSH-1520: Open/Resume session in terminal on feed cards

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+- **Feed cards get an Open/Resume-in-terminal action (RUSH-1520).** Each card shows a Terminal button that focuses an open tab, attaches a tmux rail, or runs `agents sessions focus <id>` — so the operator jumps into the session instead of only opening the side panel. Source: `ui/settings/components/mission-control/FeedItem.tsx`, `UnifiedAgentsPane.tsx` (`openTerminalForAgent`).
 - **Filter + group-by controls live in the feed header bar next to Save view (RUSH-1526).** The feed's own header (`SavedViews` / `feed-header-bar`) now carries Group + status chips (Needs you / Running / Idle / Failed) + agent-abbr chips, so operators filter and group where they are looking — not only from the top FloorControls bar. Source: `ui/settings/components/mission-control/SavedViewsBar.tsx`, `UnifiedAgentsPane.tsx`, `floor.css`.
 - **Floor Group defaults to Outcome (ticket/PR/worktree) instead of Project (RUSH-1479).** Fleet-scale floors collapse agents under the deliverable they serve so the operator sees initiatives, not ~1,100 processes. Source: `ui/settings/components/mission-control/floorModel.ts` (`outcomeLabel`, `FloorGroupBy`), `FloorControls.tsx`, `UnifiedAgentsPane.tsx`.
 - **Internal: `foreman.vscode.ts` reuses the shared `humanElapsed` helper (#753).** Deleted the identical private `humanElapsedFromMs` copy and imported the exported `humanElapsed` from `core/foreman.digest.ts`. No behavior change. Source: `apps/factory/src/vscode/foreman.vscode.ts`.

--- a/apps/factory/ui/settings/components/mission-control/FeedItem.openTerminal.test.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FeedItem.openTerminal.test.tsx
@@ -1,0 +1,96 @@
+import { expect, test, describe } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { FeedItem } from './FeedItem'
+import type { FloorAgent } from './floorModel'
+
+const noop = () => {}
+
+function agent(over: Partial<FloorAgent> = {}): FloorAgent {
+  return {
+    id: 'a1',
+    host: 'this-mac',
+    project: 'agents-cli',
+    name: 'fix-auth',
+    abbr: 'CC',
+    phase: 'waiting',
+    verb: 'Waiting',
+    target: '',
+    tok: 0,
+    since: '1m',
+    lastActivityMs: 0,
+    files: 0,
+    tools: 0,
+    needs: true,
+    pinned: false,
+    pr: null,
+    prUrl: null,
+    ci: null,
+    ticket: 'RUSH-1',
+    branch: '',
+    worktreeSlug: '',
+    worktreePath: '',
+    resp: 'Which approach?',
+    messages: [],
+    question: { kind: 'choice', text: 'Which approach?', options: ['A'], clusterKey: 'k' },
+    reply: { kind: 'none', host: 'this-mac' },
+    todos: [],
+    summary: '',
+    recent: [],
+    sessionId: 'sess-abc',
+    ...over,
+  }
+}
+
+describe('FeedItem open/resume terminal action (RUSH-1520)', () => {
+  test('renders Terminal button when onOpenTerminal + sessionId are set', () => {
+    const html = renderToStaticMarkup(
+      <FeedItem
+        agent={agent()}
+        selected={false}
+        plain={false}
+        onSelect={noop}
+        onOption={noop}
+        onFreeText={noop}
+        onAttach={noop}
+        onOpenPlan={noop}
+        onOpenTerminal={noop}
+      />,
+    )
+    expect(html).toContain('open-term')
+    expect(html).toContain('Open / resume session in a terminal')
+    expect(html).toContain('Terminal')
+  })
+
+  test('omits Terminal button when no open handler', () => {
+    const html = renderToStaticMarkup(
+      <FeedItem
+        agent={agent()}
+        selected={false}
+        plain={false}
+        onSelect={noop}
+        onOption={noop}
+        onFreeText={noop}
+        onAttach={noop}
+        onOpenPlan={noop}
+      />,
+    )
+    expect(html).not.toContain('open-term')
+  })
+
+  test('shows Terminal for a local terminal reply channel without sessionId', () => {
+    const html = renderToStaticMarkup(
+      <FeedItem
+        agent={agent({ sessionId: undefined, reply: { kind: 'terminal', host: 'this-mac', terminalId: 't1' } })}
+        selected={false}
+        plain={false}
+        onSelect={noop}
+        onOption={noop}
+        onFreeText={noop}
+        onAttach={noop}
+        onOpenPlan={noop}
+        onOpenTerminal={noop}
+      />,
+    )
+    expect(html).toContain('open-term')
+  })
+})

--- a/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
@@ -49,9 +49,14 @@ interface FeedItemProps {
   onFreeText: (agent: FloorAgent, text: string) => void
   onAttach: (agent: FloorAgent) => void
   onOpenPlan: (agent: FloorAgent, plan: PlanFile) => void
+  /**
+   * Open/resume this session in a live terminal (RUSH-1520). Present when the
+   * agent carries a sessionId (or a local terminal id) the host can focus.
+   */
+  onOpenTerminal?: (agent: FloorAgent) => void
 }
 
-function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeText, onAttach, onOpenPlan }: FeedItemProps) {
+function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeText, onAttach, onOpenPlan, onOpenTerminal }: FeedItemProps) {
   // Live heartbeat: only a running / stalled agent with a known last-activity stamp ticks.
   // The shared 1s ticker re-renders just this leaf, never the parent list.
   const now = useNow(1000)
@@ -146,6 +151,16 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
           {marker}
           {bgBadge}
           {ciBadge}
+          {onOpenTerminal && (a.sessionId || a.reply.kind === 'terminal' || a.reply.kind === 'tmux') && (
+            <button
+              type="button"
+              className="open-term"
+              title="Open / resume session in a terminal"
+              onClick={(e) => { e.stopPropagation(); onOpenTerminal(a) }}
+            >
+              <Icon name="external" size={11} /> Terminal
+            </button>
+          )}
           {tok && (
             <span className="tps">{!plain && <Icon name="zap" size={11} />}{tok}</span>
           )}

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -1618,6 +1618,36 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   // no-op (no fake success) rather than pretending it worked. TODO: wire capture path.
   const onAttachScreenshot = useCallback((_a: FloorAgent) => { /* TODO: screenshot transport pending */ }, [])
 
+  /**
+   * Open/resume the session in a real terminal (RUSH-1520). Prefers an already-
+   * open local tab, then a remote tmux rail, then `agents sessions focus <id>`.
+   */
+  const openTerminalForAgent = useCallback((a: FloorAgent) => {
+    if (a.reply.kind === 'terminal' && a.reply.terminalId) {
+      postMessage({ type: 'focusTerminal', terminalId: a.reply.terminalId })
+      return
+    }
+    if (a.reply.kind === 'tmux' && a.reply.muxTarget) {
+      postMessage({
+        type: 'focusRemoteSession',
+        host: a.reply.host,
+        muxSocket: a.reply.muxSocket,
+        muxTarget: a.reply.muxTarget,
+        sessionId: a.reply.sessionId ?? a.sessionId,
+        label: a.name,
+      })
+      return
+    }
+    if (a.sessionId) {
+      postMessage({ type: 'focusSession', sessionId: a.sessionId, host: a.host })
+      return
+    }
+    const u = unifiedById.get(a.id)
+    if (u?.terminal) {
+      postMessage({ type: 'focusTerminal', terminalId: u.terminal.id })
+    }
+  }, [unifiedById])
+
   const onBatchReply = useCallback((cluster: FloorAgent[], option: string) => {
     for (const a of cluster) replyToAgent(a, option)
   }, [replyToAgent])
@@ -2021,6 +2051,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               onFreeText={replyToAgent}
               onAttach={onAttachScreenshot}
               onOpenPlan={openPlanPreview}
+              onOpenTerminal={openTerminalForAgent}
             />
           ))}
           {failedAgents.map((a) => (
@@ -2043,6 +2074,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               onFreeText={replyToAgent}
               onAttach={onAttachScreenshot}
               onOpenPlan={openPlanPreview}
+              onOpenTerminal={openTerminalForAgent}
             />
           ))}
         </>
@@ -2074,6 +2106,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               onFreeText={replyToAgent}
               onAttach={onAttachScreenshot}
               onOpenPlan={openPlanPreview}
+              onOpenTerminal={openTerminalForAgent}
             />
           ))
         : [...groupAgents([...runningFeed, ...doneFeed], floorGroup).entries()].map(([k, arr]) => {
@@ -2103,6 +2136,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
                   onFreeText={replyToAgent}
                   onAttach={onAttachScreenshot}
                   onOpenPlan={openPlanPreview}
+              onOpenTerminal={openTerminalForAgent}
                 />
               ))}
             </React.Fragment>
@@ -2122,6 +2156,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               onFreeText={replyToAgent}
               onAttach={onAttachScreenshot}
               onOpenPlan={openPlanPreview}
+              onOpenTerminal={openTerminalForAgent}
             />
           ))}
         </>
@@ -2143,6 +2178,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               onFreeText={replyToAgent}
               onAttach={onAttachScreenshot}
               onOpenPlan={openPlanPreview}
+              onOpenTerminal={openTerminalForAgent}
             />
           ))}
         </>

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -250,6 +250,9 @@
 .swarmify-root .fitem .who { font-weight: 700; font-size: 13px; }
 .swarmify-root .fitem .path { color: var(--ds-text-dim); font-size: 11px; }
 .swarmify-root .fitem .when { margin-left: auto; color: var(--ds-text-dim); font-size: 11px; display: flex; align-items: center; gap: 8px; }
+/* Open/Resume-in-terminal action on feed cards (RUSH-1520). */
+.swarmify-root .fitem .open-term { display: inline-flex; align-items: center; gap: 4px; font-family: "Geist Mono", monospace; font-size: 10.5px; font-weight: 700; color: var(--brand-600, var(--brand)); background: var(--ds-bg-recessed); border: 1px solid var(--ds-border); border-radius: 20px; padding: 2px 8px; cursor: pointer; }
+.swarmify-root .fitem .open-term:hover { border-color: var(--brand); color: var(--brand); }
 .swarmify-root .fitem .resp { font-size: 12.5px; color: var(--ds-text); line-height: 1.5; margin: 2px 0 8px; border-left: 2px solid var(--ds-border); padding-left: 10px; }
 .swarmify-root .fitem .resp .q { color: var(--status-pending); font-weight: 600; }
 /* Produced-artifact chips: what the agent SPAWNED (a team) or CREATED (tickets),


### PR DESCRIPTION
## What

Each Factory Floor feed card gets a **Terminal** action that opens/resumes the session in a live agent terminal:

1. Local tab → `focusTerminal`
2. tmux rail → `focusRemoteSession`
3. Otherwise → `focusSession` (`agents sessions focus <id>`)

## Why

RUSH-1520: clicking a card only opened a thin side panel; operators want one-click access into the real session.

## Tests

```
cd apps/factory && bun test ui/settings/components/mission-control/FeedItem.openTerminal.test.tsx
```

## Linear

Closes RUSH-1520