### PR TITLE
RUSH-1622: distinct PowerShell dispatch log paths

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **Windows remote dispatch uses distinct PowerShell stdout/stderr log paths (RUSH-1622).** `Start-Process -RedirectStandardOutput` and `-RedirectStandardError` cannot share a file; use `.out.log` / `.err.log`. Source: `apps/factory/src/vscode/settings.vscode.ts`.
+
 # Changelog
 
 All notable changes to the Factory extension are documented here. Format follows

--- a/apps/factory/src/vscode/settings.vscode.ts
+++ b/apps/factory/src/vscode/settings.vscode.ts
@@ -381,11 +381,15 @@ async function dispatchToDevice(input: {
       ? `if (-not (Test-Path (Join-Path $P '.git'))) { New-Item -ItemType Directory -Force -Path (Split-Path $P) | Out-Null; git clone '${cloneUrl.replace(/'/g, "''")}' $P }; `
       : '';
     // Background Start-Process so the ssh hop returns promptly (parity with nohup).
+    // PowerShell rejects redirecting stdout and stderr to the same path — use
+    // distinct .out/.err files (RUSH-1622).
     remote =
       `$tmp = ${logDir}; New-Item -ItemType Directory -Force -Path $tmp | Out-Null; ` +
       `${pAssign}; ${ensureClone}Set-Location -LiteralPath $P; ` +
-      `$log = Join-Path $tmp ("dispatch-" + [DateTimeOffset]::UtcNow.ToUnixTimeSeconds() + ".log"); ` +
-      `Start-Process -FilePath agents -ArgumentList @(${runArgs}) -WorkingDirectory $P -RedirectStandardOutput $log -RedirectStandardError $log -WindowStyle Hidden`;
+      `$stamp = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds(); ` +
+      `$logOut = Join-Path $tmp ("dispatch-" + $stamp + ".out.log"); ` +
+      `$logErr = Join-Path $tmp ("dispatch-" + $stamp + ".err.log"); ` +
+      `Start-Process -FilePath agents -ArgumentList @(${runArgs}) -WorkingDirectory $P -RedirectStandardOutput $logOut -RedirectStandardError $logErr -WindowStyle Hidden`;
   } else {
     const syncShell = buildDeviceSyncShell(syncPolicy);
     const runCmd = `agents run ${shq(agentType)} --mode ${mode} ${shq(prompt)}`;


### PR DESCRIPTION
## Summary
- Windows remote dispatch used the same path for `-RedirectStandardOutput` and `-RedirectStandardError`, which PowerShell rejects.
- Use distinct `.out.log` / `.err.log` files.

## Test plan
- [x] `bun run compile:ext` (tsc)
- Manual: PowerShell Start-Process with distinct redirects succeeds

Closes linear ticket RUSH-1622.