### PR TITLE
RUSH-1623: write OpenCode permissions to loaded config path

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **OpenCode permissions write to the loaded config path (RUSH-1623).** Global config is `~/.config/opencode/opencode.jsonc` (not `~/.opencode/`); project config is `opencode.jsonc` at the project root. Source: `apps/cli/src/lib/permissions.ts`, `apps/cli/src/lib/agents.ts`.
+
 - **Kiro launches with `--v3` so standalone hooks actually fire (RUSH-1612).** Agents-cli writes Kiro hooks as v3 standalone files under `~/.kiro/hooks/*.json`, but those only load on the v3 engine. `AGENT_COMMANDS.kiro.base` now includes `--v3` so `agents run kiro` opts into the engine that reads them. Source: `apps/cli/src/lib/exec.ts`.
 
 - **Ask classifier + stall suppression for the agent feed (RUSH-1477).** Every open block is classified as Decision / Approval / Clarification / Stall / Fyi. Workflow-stalls ("should I…?", "what's next?", "looks good?") are auto-answered and removed so they never render as cards; Decisions and Approvals still surface. `agents feed` reports a digest (`N stalls auto-resolved by policy`); `--all` shows suppressed items; `--json` stamps each block with its `ask` classification. Agent-tagged `blockClass: decision` is never auto-suppressed. Source: `apps/cli/src/lib/ask-classifier.ts`, `apps/cli/src/commands/feed.ts`.

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -1775,8 +1775,8 @@ export function getUserMcpConfigPath(agentId: AgentId): string {
       // Codex uses TOML config
       return path.join(agent.configDir, 'config.toml');
     case 'opencode':
-      // OpenCode uses JSONC config
-      return path.join(agent.configDir, 'opencode.jsonc');
+      // OpenCode loads ~/.config/opencode/opencode.jsonc (not ~/.opencode/)
+      return path.join(HOME, '.config', 'opencode', 'opencode.jsonc');
     case 'cursor':
       // Cursor uses mcp.json
       return path.join(agent.configDir, 'mcp.json');
@@ -1811,7 +1811,7 @@ export function getMcpConfigPathForHome(agentId: AgentId, home: string): string 
     case 'codex':
       return path.join(home, '.codex', 'config.toml');
     case 'opencode':
-      return path.join(home, '.opencode', 'opencode.jsonc');
+      return path.join(home, '.config', 'opencode', 'opencode.jsonc');
     case 'cursor':
       return path.join(home, '.cursor', 'mcp.json');
     case 'openclaw':
@@ -1846,7 +1846,8 @@ function getProjectMcpConfigPath(agentId: AgentId, cwd: string = process.cwd()):
     case 'codex':
       return path.join(cwd, `.${agentId}`, 'config.toml');
     case 'opencode':
-      return path.join(cwd, `.${agentId}`, 'opencode.jsonc');
+      // Project config is opencode.jsonc at project root (not .opencode/)
+      return path.join(cwd, 'opencode.jsonc');
     case 'cursor':
       return path.join(cwd, `.${agentId}`, 'mcp.json');
     case 'openclaw':

--- a/apps/cli/src/lib/mcp.ts
+++ b/apps/cli/src/lib/mcp.ts
@@ -495,7 +495,7 @@ function installMcpToFactoryConfig(server: InstalledMcpServer, versionHome: stri
 }
 
 function installMcpToOpenCodeConfig(server: InstalledMcpServer, versionHome: string): void {
-  const configPath = path.join(versionHome, '.opencode', 'opencode.jsonc');
+  const configPath = path.join(versionHome, '.config', 'opencode', 'opencode.jsonc');
 
   let config: Record<string, unknown> = {};
   if (fs.existsSync(configPath)) {

--- a/apps/cli/src/lib/permissions-opencode-path.test.ts
+++ b/apps/cli/src/lib/permissions-opencode-path.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { openCodeConfigPath } from './permissions.js';
+
+describe('openCodeConfigPath (RUSH-1623)', () => {
+  it('resolves user config under ~/.config/opencode/', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-home-'));
+    const p = openCodeConfigPath('user', undefined, home);
+    expect(p).toBe(path.join(home, '.config', 'opencode', 'opencode.jsonc'));
+  });
+
+  it('prefers existing opencode.json when present', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-home-'));
+    const dir = path.join(home, '.config', 'opencode');
+    fs.mkdirSync(dir, { recursive: true });
+    const json = path.join(dir, 'opencode.json');
+    fs.writeFileSync(json, '{}');
+    expect(openCodeConfigPath('user', undefined, home)).toBe(json);
+  });
+
+  it('resolves project config at project root', () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-proj-'));
+    expect(openCodeConfigPath('project', cwd)).toBe(path.join(cwd, 'opencode.jsonc'));
+  });
+});

--- a/apps/cli/src/lib/permissions.ts
+++ b/apps/cli/src/lib/permissions.ts
@@ -923,9 +923,7 @@ function readOpenCodePermissions(
   options?: { home?: string }
 ): OpenCodePermissions | null {
   const home = options?.home || HOME;
-  const configPath = scope === 'user'
-    ? path.join(home, '.opencode', 'opencode.jsonc')
-    : path.join(cwd || process.cwd(), '.opencode', 'opencode.jsonc');
+  const configPath = openCodeConfigPath(scope, cwd, home);
 
   if (!fs.existsSync(configPath)) {
     return null;
@@ -1063,6 +1061,29 @@ export function applyClaudePermissions(
 }
 
 /**
+ * Path OpenCode actually loads for global config:
+ *   ~/.config/opencode/opencode.jsonc  (or .json)
+ * Project: <cwd>/opencode.jsonc (or .json) at project root — not .opencode/.
+ * See https://opencode.ai/docs/config/
+ */
+export function openCodeConfigPath(scope: 'user' | 'project', cwd?: string, home: string = HOME): string {
+  if (scope === 'project') {
+    const root = cwd || process.cwd();
+    for (const name of ['opencode.jsonc', 'opencode.json']) {
+      const candidate = path.join(root, name);
+      if (fs.existsSync(candidate)) return candidate;
+    }
+    return path.join(root, 'opencode.jsonc');
+  }
+  const globalDir = path.join(home, '.config', 'opencode');
+  for (const name of ['opencode.jsonc', 'opencode.json']) {
+    const candidate = path.join(globalDir, name);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return path.join(globalDir, 'opencode.jsonc');
+}
+
+/**
  * Apply a permission set to OpenCode's opencode.jsonc.
  */
 function applyOpenCodePermissions(
@@ -1071,10 +1092,8 @@ function applyOpenCodePermissions(
   cwd?: string,
   merge: boolean = true
 ): { success: boolean; error?: string } {
-  const configDir = scope === 'user'
-    ? path.join(HOME, '.opencode')
-    : path.join(cwd || process.cwd(), '.opencode');
-  const configPath = path.join(configDir, 'opencode.jsonc');
+  const configPath = openCodeConfigPath(scope, cwd);
+  const configDir = path.dirname(configPath);
 
   try {
     // Ensure directory exists
@@ -1241,7 +1260,10 @@ export function applyPermissionsToVersion(
     }
 
     if (agentId === 'opencode') {
-      const configPath = path.join(configDir, 'opencode.jsonc');
+      // OpenCode loads ~/.config/opencode/opencode.jsonc under the version home
+      // (HOME isolation), not ~/.opencode/opencode.jsonc.
+      const configPath = openCodeConfigPath('user', undefined, versionHome);
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
       let config: Record<string, unknown> = {};
       if (fs.existsSync(configPath)) {
         const content = stripJsonComments(fs.readFileSync(configPath, 'utf-8'));
@@ -1529,7 +1551,7 @@ export function exportPermissionsFromPath(filePath: string): PermissionSet | nul
 
   if (fileName === 'settings.json' && parentDir === '.claude') {
     agentId = 'claude';
-  } else if (fileName === 'opencode.jsonc' || parentDir === '.opencode') {
+  } else if (fileName === 'opencode.jsonc' || fileName === 'opencode.json' || parentDir === 'opencode' || parentDir === '.opencode') {
     agentId = 'opencode';
   } else if (fileName === 'config.toml' && parentDir === '.codex') {
     agentId = 'codex';

--- a/apps/cli/src/lib/resources/mcp.test.ts
+++ b/apps/cli/src/lib/resources/mcp.test.ts
@@ -44,7 +44,7 @@ describe('getMcpConfigPath', () => {
 
   it('returns correct config path for OpenCode', () => {
     const configPath = getMcpConfigPath('opencode', '/home/user');
-    expect(configPath).toBe(path.join('/home/user', '.opencode', 'opencode.jsonc'));
+    expect(configPath).toBe(path.join('/home/user', '.config', 'opencode', 'opencode.jsonc'));
   });
 
   it('returns correct config path for Cursor', () => {
@@ -255,7 +255,7 @@ describe('Claude MCP config format', () => {
 describe('OpenCode MCP config format', () => {
   it('writes local MCP to OpenCode opencode.jsonc format', () => {
     const tempDir = makeTempDir();
-    const configPath = path.join(tempDir, '.opencode', 'opencode.jsonc');
+    const configPath = path.join(tempDir, '.config', 'opencode', 'opencode.jsonc');
 
     const items: McpItem[] = [
       {
@@ -292,7 +292,7 @@ describe('OpenCode MCP config format', () => {
 
   it('writes remote MCP to OpenCode opencode.jsonc format', () => {
     const tempDir = makeTempDir();
-    const configPath = path.join(tempDir, '.opencode', 'opencode.jsonc');
+    const configPath = path.join(tempDir, '.config', 'opencode', 'opencode.jsonc');
 
     const items: McpItem[] = [
       {

--- a/apps/cli/src/lib/resources/mcp.ts
+++ b/apps/cli/src/lib/resources/mcp.ts
@@ -146,7 +146,7 @@ export function getMcpConfigPath(agent: AgentId, versionHome: string): string | 
     case 'codex':
       return path.join(versionHome, '.codex', 'config.toml');
     case 'opencode':
-      return path.join(versionHome, '.opencode', 'opencode.jsonc');
+      return path.join(versionHome, '.config', 'opencode', 'opencode.jsonc');
     case 'cursor':
       return path.join(versionHome, '.cursor', 'mcp.json');
     case 'gemini':

--- a/apps/cli/src/lib/resources/permissions.test.ts
+++ b/apps/cli/src/lib/resources/permissions.test.ts
@@ -294,7 +294,7 @@ describe('PermissionsHandler', () => {
 
     it('returns correct path for OpenCode', () => {
       const result = PermissionsHandler.configPath!('opencode', '/test/home');
-      expect(result).toBe(path.join('/test/home', '.opencode', 'opencode.jsonc'));
+      expect(result).toBe(path.join('/test/home', '.config', 'opencode', 'opencode.jsonc'));
     });
 
     it('returns correct path for Kimi', () => {

--- a/apps/cli/src/lib/resources/permissions.ts
+++ b/apps/cli/src/lib/resources/permissions.ts
@@ -84,7 +84,7 @@ function getAgentConfigPath(agent: AgentId, versionHome: string): string | null 
     case 'codex':
       return path.join(versionHome, '.codex', 'config.toml');
     case 'opencode':
-      return path.join(versionHome, '.opencode', 'opencode.jsonc');
+      return path.join(versionHome, '.config', 'opencode', 'opencode.jsonc');
     case 'kimi':
       return path.join(versionHome, '.kimi-code', 'config.toml');
     default:

--- a/apps/cli/src/lib/staleness/detectors/permissions.ts
+++ b/apps/cli/src/lib/staleness/detectors/permissions.ts
@@ -87,7 +87,7 @@ function buildOpenCodeDetector(): ResourceDetector {
     kind: 'permissions',
     agent: 'opencode',
     list({ versionHome }: DetectArgs): string[] {
-      const opencodeConfigPath = path.join(versionHome, '.opencode', 'opencode.jsonc');
+      const opencodeConfigPath = path.join(versionHome, '.config', 'opencode', 'opencode.jsonc');
       if (!fs.existsSync(opencodeConfigPath)) return [];
       try {
         const content = fs.readFileSync(opencodeConfigPath, 'utf-8');


### PR DESCRIPTION
## Summary
- Permissions/MCP writers target `~/.config/opencode/opencode.jsonc` (loaded path).
- Project scope uses root `opencode.jsonc`.

## Test plan
- [x] openCodeConfigPath tests + permissions/mcp resource tests
- [x] `bun run build`

Closes linear ticket RUSH-1623.