### PR TITLE
RUSH-1613: stop advertising unsupported Goose subagent hooks

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Stop advertising Goose SubagentStart/SubagentStop hooks (RUSH-1613).** Goose does not emit those events; drop them from `GOOSE_EVENT_MAP` so sync no longer installs dead entries. Source: `apps/cli/src/lib/hooks.ts`.
 - **Per-session rate-limit detection + feed badge (RUSH-1523).** The session state engine flags rate/usage-limit text in the transcript (`detectRateLimited`); `ActiveSession.rateLimited` flows through remote fan-out into Factory's `FloorAgent.rateLimited`, which renders a **rate limited** pill on the feed card. Source: `apps/cli/src/lib/session/state.ts`, `apps/factory/.../floorAdapter.ts`, `FeedItem.tsx`.
 - **Kiro launches with `--v3` so standalone hooks actually fire (RUSH-1612).** Agents-cli writes Kiro hooks as v3 standalone files under `~/.kiro/hooks/*.json`, but those only load on the v3 engine. `AGENT_COMMANDS.kiro.base` now includes `--v3` so `agents run kiro` opts into the engine that reads them. Source: `apps/cli/src/lib/exec.ts`.
 

--- a/apps/cli/src/lib/__tests__/hooks.test.ts
+++ b/apps/cli/src/lib/__tests__/hooks.test.ts
@@ -949,6 +949,27 @@ describe('registerHooksToSettings - Goose', () => {
     const marker = path.join(versionHome, '.agents', 'plugins', 'agents-cli-hooks', '.agents-cli-managed');
     expect(fs.existsSync(marker)).toBe(true);
   });
+
+  it('skips SubagentStart/SubagentStop (Goose never emits them) (RUSH-1613)', () => {
+    makeGooseScript('on-subagent.sh');
+    const versionHome = path.join(tmpDir, 'home');
+    const result = registerHooksToSettings(
+      'goose',
+      versionHome,
+      {
+        'on-subagent': {
+          script: 'on-subagent.sh',
+          events: ['SubagentStart', 'SubagentStop', 'SessionStart'],
+        },
+      },
+      agentsDir,
+    );
+    expect(result.registered).toEqual(['on-subagent -> SessionStart']);
+    const parsed = JSON.parse(fs.readFileSync(gooseHooksPath(versionHome), 'utf-8'));
+    expect(parsed.hooks.SubagentStart).toBeUndefined();
+    expect(parsed.hooks.SubagentStop).toBeUndefined();
+    expect(parsed.hooks.SessionStart).toHaveLength(1);
+  });
 });
 
 describe('registerHooksToSettings - Cursor', () => {

--- a/apps/cli/src/lib/hooks.ts
+++ b/apps/cli/src/lib/hooks.ts
@@ -2313,8 +2313,7 @@ const GOOSE_EVENT_MAP: Record<string, string> = {
   AfterFileEdit: 'AfterFileEdit',
   BeforeShellExecution: 'BeforeShellExecution',
   AfterShellExecution: 'AfterShellExecution',
-  SubagentStart: 'SubagentStart',
-  SubagentStop: 'SubagentStop',
+  // SubagentStart/SubagentStop are not emitted by Goose — do not advertise them.
 };
 
 /** Managed Open Plugins directory name under ~/.agents/plugins/. */


### PR DESCRIPTION
## Summary
- Remove SubagentStart/SubagentStop from GOOSE_EVENT_MAP (Goose never emits them).
- Rebased onto latest main after CHANGELOG conflict.

## Test plan
- [x] Goose hooks tests including RUSH-1613
- [x] `bun run build`

Supersedes #990. Closes linear ticket RUSH-1613.