### PR TITLE
RUSH-1614: make mailbox delivery receipts monotonic

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Mailbox delivery receipts are monotonic (RUSH-1614).** `recordMessageReceipt` no longer lets a late `queued` write overwrite an already-recorded `consumed`/`continued` when enqueue races the drain. Source: `apps/cli/src/lib/feed.ts`.
 - **Per-session rate-limit detection + feed badge (RUSH-1523).** The session state engine flags rate/usage-limit text in the transcript (`detectRateLimited`); `ActiveSession.rateLimited` flows through remote fan-out into Factory's `FloorAgent.rateLimited`, which renders a **rate limited** pill on the feed card. Source: `apps/cli/src/lib/session/state.ts`, `apps/factory/.../floorAdapter.ts`, `FeedItem.tsx`.
 - **Kiro launches with `--v3` so standalone hooks actually fire (RUSH-1612).** Agents-cli writes Kiro hooks as v3 standalone files under `~/.kiro/hooks/*.json`, but those only load on the v3 engine. `AGENT_COMMANDS.kiro.base` now includes `--v3` so `agents run kiro` opts into the engine that reads them. Source: `apps/cli/src/lib/exec.ts`.
 

--- a/apps/cli/src/lib/feed.test.ts
+++ b/apps/cli/src/lib/feed.test.ts
@@ -470,6 +470,20 @@ describe('feed store', () => {
     expect(block.continuedAt).toBeTruthy();
   });
 
+  it('recordMessageReceipt is monotonic — queued cannot overwrite consumed (RUSH-1614)', () => {
+    const dir = tmpFeedDir();
+    publishBlock(makeBlock('sess-mono', 'Confirm?'), dir);
+    const blockId = blockIdForSession('sess-mono');
+
+    recordMessageReceipt(blockId, { msgId: 'msg-1', status: 'consumed', at: '2026-01-01T00:00:01.000Z' }, dir);
+    // Late enqueue writer races after drain already recorded consumed.
+    recordMessageReceipt(blockId, { msgId: 'msg-1', status: 'queued', at: '2026-01-01T00:00:02.000Z' }, dir);
+
+    const block = readBlock(blockId, dir)!;
+    expect(block.receipts).toHaveLength(1);
+    expect(block.receipts![0].status).toBe('consumed');
+  });
+
   it('removeBlock clears answered markers and receipts', () => {
     const dir = tmpFeedDir();
     publishBlock(makeBlock('sess-cleanup', 'Clean me?'), dir);

--- a/apps/cli/src/lib/feed.ts
+++ b/apps/cli/src/lib/feed.ts
@@ -228,9 +228,18 @@ export function isBlockAnswered(blockId: string, root?: string): boolean {
   return fs.existsSync(path.join(answeredDir(root ?? getFeedDir()), `${blockId}.json`));
 }
 
+/** Receipt lifecycle rank — higher means further along; never regress. */
+const RECEIPT_STATUS_RANK: Record<MessageReceipt['status'], number> = {
+  queued: 0,
+  consumed: 1,
+  continued: 2,
+};
+
 /**
  * Record a delivery-receipt transition for a message tied to a block.
- * Updates the receipts list in the block file (last receipt per msgId wins).
+ * Updates the receipts list in the block file. Status is monotonic
+ * (queued → consumed → continued): a late `queued` write cannot overwrite
+ * an already-recorded `consumed`/`continued` (race with mailbox drain).
  */
 export function recordMessageReceipt(
   blockId: string,
@@ -242,8 +251,15 @@ export function recordMessageReceipt(
   if (!block) return;
   const receipts = block.receipts ?? [];
   const idx = receipts.findIndex((r) => r.msgId === receipt.msgId);
-  if (idx >= 0) receipts[idx] = receipt;
-  else receipts.push(receipt);
+  if (idx >= 0) {
+    const prev = receipts[idx];
+    if (RECEIPT_STATUS_RANK[receipt.status] < RECEIPT_STATUS_RANK[prev.status]) {
+      return; // do not regress
+    }
+    receipts[idx] = receipt;
+  } else {
+    receipts.push(receipt);
+  }
   block.receipts = receipts;
   publishBlock(block, dir);
 }


### PR DESCRIPTION
## Summary
- Monotonic receipt status (queued < consumed < continued).
- Rebased onto latest main.

Supersedes #992. Closes linear ticket RUSH-1614.