### PR TITLE
RUSH-1620: valid OpenClaw target and message flag for urgent notify

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Urgent OpenClaw notifications use `--target` and `--message` (RUSH-1620).** `openclaw message send` requires a destination and the `--message` flag (not `--text`); without `--target` the send was invalid. Source: `apps/cli/src/lib/notify.ts`.
 - **Per-session rate-limit detection + feed badge (RUSH-1523).** The session state engine flags rate/usage-limit text in the transcript (`detectRateLimited`); `ActiveSession.rateLimited` flows through remote fan-out into Factory's `FloorAgent.rateLimited`, which renders a **rate limited** pill on the feed card. Source: `apps/cli/src/lib/session/state.ts`, `apps/factory/.../floorAdapter.ts`, `FeedItem.tsx`.
 - **Kiro launches with `--v3` so standalone hooks actually fire (RUSH-1612).** Agents-cli writes Kiro hooks as v3 standalone files under `~/.kiro/hooks/*.json`, but those only load on the v3 engine. `AGENT_COMMANDS.kiro.base` now includes `--v3` so `agents run kiro` opts into the engine that reads them. Source: `apps/cli/src/lib/exec.ts`.
 

--- a/apps/cli/src/lib/notify.test.ts
+++ b/apps/cli/src/lib/notify.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { buildOpenClawNotifyArgs } from './notify.js';
+
+describe('buildOpenClawNotifyArgs (RUSH-1620)', () => {
+  it('includes --target and --message (not --text)', () => {
+    const args = buildOpenClawNotifyArgs('hello');
+    expect(args).toEqual([
+      'message',
+      'send',
+      '--channel',
+      'telegram',
+      '--account',
+      'default',
+      '--target',
+      '6078999250',
+      '--message',
+      'hello',
+    ]);
+    expect(args).not.toContain('--text');
+  });
+
+  it('allows overriding target', () => {
+    const args = buildOpenClawNotifyArgs('hi', { target: '123' });
+    expect(args[args.indexOf('--target') + 1]).toBe('123');
+  });
+});

--- a/apps/cli/src/lib/notify.ts
+++ b/apps/cli/src/lib/notify.ts
@@ -15,6 +15,8 @@ const execFileAsync = promisify(execFile);
 export interface NotifyOptions {
   channel?: string;
   account?: string;
+  /** OpenClaw destination (Telegram chat id). Defaults to Muqsit's chat. */
+  target?: string;
   dryRun?: boolean;
 }
 
@@ -32,6 +34,28 @@ function formatBlock(block: OpenBlock): string {
   const cls = block.blockClass ?? 'approval';
   const cost = block.costOfDelay ?? 'low';
   return `🚨 ${cls.toUpperCase()}${host} — ${header}${text} (cost: ${cost}, id: ${block.blockId})`;
+}
+
+/** Build openclaw argv for urgent notify (exported for tests). */
+export function buildOpenClawNotifyArgs(
+  text: string,
+  options: Pick<NotifyOptions, 'channel' | 'account' | 'target'> = {},
+): string[] {
+  const channel = options.channel ?? 'telegram';
+  const account = options.account ?? 'default';
+  const target = options.target ?? '6078999250';
+  return [
+    'message',
+    'send',
+    '--channel',
+    channel,
+    '--account',
+    account,
+    '--target',
+    target,
+    '--message',
+    text,
+  ];
 }
 
 export async function notifyUrgentBlock(
@@ -53,21 +77,10 @@ export async function notifyUrgentBlock(
     return { ok: false, error: 'openclaw CLI not found on PATH' };
   }
 
-  const channel = options.channel ?? 'telegram';
-  const account = options.account ?? 'default';
   const text = formatBlock(block);
 
   try {
-    await execFileAsync('openclaw', [
-      'message',
-      'send',
-      '--channel',
-      channel,
-      '--account',
-      account,
-      '--text',
-      text,
-    ]);
+    await execFileAsync('openclaw', buildOpenClawNotifyArgs(text, options));
     return { ok: true };
   } catch (err) {
     return { ok: false, error: (err as Error).message };


### PR DESCRIPTION
## Summary
- openclaw message send uses --target and --message.
- Rebased onto latest main.

Supersedes #994. Closes linear ticket RUSH-1620.