### PR TITLE
RUSH-1616: isolate per-attempt logs for routine credit failover

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Routine credit-failover scans only the current attempt's log (RUSH-1616).** Each failover spawn writes `stdout.attempt-N.log` and rate-limit detection uses that file alone; prior attempts still append into `stdout.log` for the continuous trail. Source: `apps/cli/src/lib/runner.ts`.
 - **Per-session rate-limit detection + feed badge (RUSH-1523).** The session state engine flags rate/usage-limit text in the transcript (`detectRateLimited`); `ActiveSession.rateLimited` flows through remote fan-out into Factory's `FloorAgent.rateLimited`, which renders a **rate limited** pill on the feed card. Source: `apps/cli/src/lib/session/state.ts`, `apps/factory/.../floorAdapter.ts`, `FeedItem.tsx`.
 - **Kiro launches with `--v3` so standalone hooks actually fire (RUSH-1612).** Agents-cli writes Kiro hooks as v3 standalone files under `~/.kiro/hooks/*.json`, but those only load on the v3 engine. `AGENT_COMMANDS.kiro.base` now includes `--v3` so `agents run kiro` opts into the engine that reads them. Source: `apps/cli/src/lib/exec.ts`.
 

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -368,16 +368,20 @@ interface SpawnAttemptResult {
 }
 
 /**
- * Spawn one attempt, capture logs to `stdoutPath`, enforce timeout.
- * Appends to the log file so failover attempts leave a continuous trail.
+ * Spawn one attempt, capture logs to `attemptLogPath`, enforce timeout.
+ * Rate-limit scanning uses only this attempt's log (not prior failover output).
+ * The attempt log is also appended into `combinedLogPath` for a continuous trail.
  */
 function spawnJobAttempt(
   cmd: string[],
   env: Record<string, string>,
-  stdoutPath: string,
+  attemptLogPath: string,
   timeoutMs: number,
+  combinedLogPath?: string,
 ): Promise<SpawnAttemptResult> {
-  const stdoutFd = fs.openSync(stdoutPath, 'a', 0o600);
+  // Isolate this attempt's output so detectRateLimit never sees prior attempts.
+  fs.writeFileSync(attemptLogPath, '', { mode: 0o600 });
+  const stdoutFd = fs.openSync(attemptLogPath, 'a', 0o600);
   return new Promise((resolve) => {
     const child = spawn(cmd[0], cmd.slice(1), {
       stdio: ['ignore', stdoutFd, stdoutFd],
@@ -392,8 +396,13 @@ function spawnJobAttempt(
       try { fs.closeSync(stdoutFd); } catch { /* fd already closed */ }
       let logText = '';
       try {
-        logText = fs.readFileSync(stdoutPath, 'utf-8');
+        logText = fs.readFileSync(attemptLogPath, 'utf-8');
       } catch { /* missing log */ }
+      if (combinedLogPath) {
+        try {
+          fs.appendFileSync(combinedLogPath, logText);
+        } catch { /* best-effort trail */ }
+      }
       resolve({ ...result, logText });
     };
 
@@ -570,7 +579,8 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
     const elapsed = Date.now() - Date.parse(meta.startedAt);
     const remaining = Math.max(1_000, timeoutMs - (Number.isFinite(elapsed) ? elapsed : 0));
 
-    const attempt = await spawnJobAttempt(cmd, spawnEnv, stdoutPath, remaining);
+    const attemptLogPath = path.join(runDir, `stdout.attempt-${i}.log`);
+    const attempt = await spawnJobAttempt(cmd, spawnEnv, attemptLogPath, remaining, stdoutPath);
     meta.pid = attempt.pid;
     writeRunMeta(meta);
 


### PR DESCRIPTION
Rebased onto main. Closes linear ticket RUSH-1616. Supersedes #996.