### PR TITLE
RUSH-1618: use canonical operator registry for feed authorization

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Feed high-consequence authz uses the canonical operator registry (RUSH-1618).** `recordAnswer` no longer looks for `operators.yaml` under the feed root; it resolves operators from `~/.agents/` via `loadOperators()`. Source: `apps/cli/src/lib/feed.ts`.
 - **Per-session rate-limit detection + feed badge (RUSH-1523).** The session state engine flags rate/usage-limit text in the transcript (`detectRateLimited`); `ActiveSession.rateLimited` flows through remote fan-out into Factory's `FloorAgent.rateLimited`, which renders a **rate limited** pill on the feed card. Source: `apps/cli/src/lib/session/state.ts`, `apps/factory/.../floorAdapter.ts`, `FeedItem.tsx`.
 - **Kiro launches with `--v3` so standalone hooks actually fire (RUSH-1612).** Agents-cli writes Kiro hooks as v3 standalone files under `~/.kiro/hooks/*.json`, but those only load on the v3 engine. `AGENT_COMMANDS.kiro.base` now includes `--v3` so `agents run kiro` opts into the engine that reads them. Source: `apps/cli/src/lib/exec.ts`.
 

--- a/apps/cli/src/lib/feed.test.ts
+++ b/apps/cli/src/lib/feed.test.ts
@@ -430,6 +430,8 @@ describe('feed store', () => {
 
   it('recordAnswer refuses unverified answers to high-consequence blocks', () => {
     const dir = tmpFeedDir();
+    // operators.yaml under the feed root must NOT authorize (RUSH-1618) —
+    // the registry lives at ~/.agents/operators.yaml only.
     fs.writeFileSync(path.join(dir, 'operators.yaml'), 'operators:\n  muqsit:\n    admin: true\n', 'utf-8');
     publishBlock(makeBlock('sess-authz', 'Deploy to prod?', {
       consequence: 'merge',
@@ -443,8 +445,35 @@ describe('feed store', () => {
       expect('unauthorized' in unverified).toBe(true);
     }
 
-    const verified = recordAnswer(blockId, { answeredFrom: 'feed', answeredBy: 'Muqsit', operatorId: 'muqsit', verified: true }, dir);
-    expect(verified.ok).toBe(true);
+    // verified:false still refused even with a known-looking operatorId.
+    const claimed = recordAnswer(blockId, {
+      answeredFrom: 'feed',
+      answeredBy: 'Muqsit',
+      operatorId: 'muqsit',
+      verified: false,
+    }, dir);
+    expect(claimed.ok).toBe(false);
+  });
+
+  it('recordAnswer ignores operators.yaml colocated with the feed store (RUSH-1618)', () => {
+    const dir = tmpFeedDir();
+    // Only the feed root has operators.yaml — the canonical registry is separate.
+    // Claiming verified:true for an id that exists ONLY here must still fail
+    // when that id is not in the real ~/.agents registry. Use a unique id.
+    fs.writeFileSync(
+      path.join(dir, 'operators.yaml'),
+      'operators:\n  feed-only-operator-xyz:\n    admin: true\n',
+      'utf-8',
+    );
+    publishBlock(makeBlock('sess-authz-feed', 'Deploy?', { consequence: 'merge' }), dir);
+    const blockId = blockIdForSession('sess-authz-feed');
+    const result = recordAnswer(blockId, {
+      answeredFrom: 'feed',
+      operatorId: 'feed-only-operator-xyz',
+      verified: true,
+    }, dir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect('unauthorized' in result).toBe(true);
   });
 
   it('recordAnswer permits any answer to normal-consequence blocks', () => {

--- a/apps/cli/src/lib/feed.ts
+++ b/apps/cli/src/lib/feed.ts
@@ -173,7 +173,8 @@ export function recordAnswer(
   const operatorId = answer.operatorId;
 
   if (block?.consequence && block.consequence !== 'normal') {
-    if (!operatorId || answer.verified !== true || !isHighConsequenceAllowed(block.consequence, operatorId, dir)) {
+    // Operators live in ~/.agents/operators.yaml — never the feed store root.
+    if (!operatorId || answer.verified !== true || !isHighConsequenceAllowed(block.consequence, operatorId)) {
       return {
         ok: false,
         unauthorized: true,


### PR DESCRIPTION
Rebased onto main. Closes linear ticket RUSH-1618. Supersedes #998.