### PR TITLE
RUSH-1619: authenticate operator identity before high-consequence answers

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **High-consequence answers require env-proven operator identity (RUSH-1619).** `agents message --as <id>` alone is not verification; `AGENTS_OPERATOR_ID` must match the claimed id (and the id must be in `operators.yaml`). Source: `apps/cli/src/lib/operator.ts`, `apps/cli/src/commands/message.ts`.
 - **Per-session rate-limit detection + feed badge (RUSH-1523).** The session state engine flags rate/usage-limit text in the transcript (`detectRateLimited`); `ActiveSession.rateLimited` flows through remote fan-out into Factory's `FloorAgent.rateLimited`, which renders a **rate limited** pill on the feed card. Source: `apps/cli/src/lib/session/state.ts`, `apps/factory/.../floorAdapter.ts`, `FeedItem.tsx`.
 - **Kiro launches with `--v3` so standalone hooks actually fire (RUSH-1612).** Agents-cli writes Kiro hooks as v3 standalone files under `~/.kiro/hooks/*.json`, but those only load on the v3 engine. `AGENT_COMMANDS.kiro.base` now includes `--v3` so `agents run kiro` opts into the engine that reads them. Source: `apps/cli/src/lib/exec.ts`.
 

--- a/apps/cli/src/commands/message.ts
+++ b/apps/cli/src/commands/message.ts
@@ -33,7 +33,7 @@ import {
   recordMessageReceipt,
   type OpenBlock,
 } from '../lib/feed.js';
-import { getOperator } from '../lib/operator.js';
+import { verifyOperatorIdentity } from '../lib/operator.js';
 import {
   resolveAnswerRoute,
   resumeArgv,
@@ -63,7 +63,9 @@ function claimBlockAnswer(
 ): void {
   if (!block) return;
   const operatorId = opts.as;
-  const verified = operatorId ? getOperator(operatorId) !== undefined : false;
+  // High-consequence answers require env-proven identity (AGENTS_OPERATOR_ID),
+  // not merely a caller-supplied known --as id (RUSH-1619).
+  const verified = verifyOperatorIdentity(operatorId);
   const claim = recordAnswer(block.blockId, {
     answeredBy: opts.from,
     answeredFrom: opts.surface || 'cli',

--- a/apps/cli/src/lib/operator.test.ts
+++ b/apps/cli/src/lib/operator.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { loadOperators, getOperator, isKnownOperator, isAdmin, canPerform, isHighConsequenceAllowed } from './operator.js';
+import { loadOperators, getOperator, isKnownOperator, isAdmin, canPerform, isHighConsequenceAllowed, verifyOperatorIdentity } from './operator.js';
 
 function tmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'agents-operator-test-'));
@@ -60,5 +60,28 @@ describe('operator registry', () => {
 `);
     expect(isHighConsequenceAllowed('deploy', 'boss', dir)).toBe(true);
     expect(isHighConsequenceAllowed('merge', 'boss', dir)).toBe(true);
+  });
+});
+
+describe('verifyOperatorIdentity (RUSH-1619)', () => {
+  const prev = process.env.AGENTS_OPERATOR_ID;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.AGENTS_OPERATOR_ID;
+    else process.env.AGENTS_OPERATOR_ID = prev;
+  });
+
+  it('rejects a known --as id without AGENTS_OPERATOR_ID', () => {
+    const dir = tmpDir();
+    writeOps(dir, `operators:\n  muqsit:\n    admin: true\n`);
+    delete process.env.AGENTS_OPERATOR_ID;
+    expect(verifyOperatorIdentity('muqsit', dir)).toBe(false);
+  });
+
+  it('accepts when env id matches a known operator', () => {
+    const dir = tmpDir();
+    writeOps(dir, `operators:\n  muqsit:\n    admin: true\n`);
+    process.env.AGENTS_OPERATOR_ID = 'muqsit';
+    expect(verifyOperatorIdentity('muqsit', dir)).toBe(true);
+    expect(verifyOperatorIdentity('stranger', dir)).toBe(false);
   });
 });

--- a/apps/cli/src/lib/operator.ts
+++ b/apps/cli/src/lib/operator.ts
@@ -100,3 +100,20 @@ export function isHighConsequenceAllowed(blockConsequence: string | undefined, o
   if (isAdmin(operatorId, root)) return true;
   return canPerform(operatorId, blockConsequence, root);
 }
+
+/**
+ * Prove operator identity for high-consequence answers.
+ *
+ * Knowing an id listed in operators.yaml is not authentication — any same-user
+ * process can pass `--as muqsit`. Require the process environment to claim the
+ * same id via AGENTS_OPERATOR_ID (typically injected by `agents secrets` /
+ * the human's launch context).
+ */
+export function verifyOperatorIdentity(claimedId: string | undefined, root?: string): boolean {
+  if (!claimedId) return false;
+  if (!isKnownOperator(claimedId, root)) return false;
+  const envId = process.env.AGENTS_OPERATOR_ID?.trim();
+  if (!envId) return false;
+  return envId === claimedId;
+}
+


### PR DESCRIPTION
Rebased onto main. Closes linear ticket RUSH-1619. Supersedes #999.