### PR TITLE
RUSH-1631: isolate remote plan previews by session/source path

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- **Remote plan previews are isolated by source path (RUSH-1631).** Cache key is `host/sha1(path)/basename` so two worktrees sharing a plan basename no longer clobber each other. Source: `apps/factory/src/vscode/settings.vscode.ts`.
 - **Windows remote dispatch uses distinct PowerShell stdout/stderr log paths (RUSH-1622).** `Start-Process -RedirectStandardOutput` and `-RedirectStandardError` cannot share a file; use `.out.log` / `.err.log`. Source: `apps/factory/src/vscode/settings.vscode.ts`.
 
 # Changelog

--- a/apps/factory/src/vscode/settings.vscode.ts
+++ b/apps/factory/src/vscode/settings.vscode.ts
@@ -4,6 +4,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import { createHash } from 'crypto';
 import { homedir, hostname } from 'os';
 import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
@@ -867,7 +868,17 @@ async function openPlanPreview(pathValue: string, kind: string | undefined, host
   let resolvedPath = resolveEditorPath(target);
   if (remoteHost) {
     const safeHost = remoteHost.replace(/[^a-zA-Z0-9._-]+/g, '-');
-    const destDir = path.join(homedir(), '.agents', '.cache', 'factory-plan-previews', safeHost);
+    // Isolate by full source path (hash) so two worktrees with the same
+    // plan basename cannot overwrite each other (RUSH-1631).
+    const pathKey = createHash('sha1').update(target).digest('hex').slice(0, 12);
+    const destDir = path.join(
+      homedir(),
+      '.agents',
+      '.cache',
+      'factory-plan-previews',
+      safeHost,
+      pathKey,
+    );
     await fs.promises.mkdir(destDir, { recursive: true });
     resolvedPath = path.join(destDir, path.basename(target));
     await execFileAsync('scp', [`${remoteHost}:${target}`, resolvedPath], { timeout: 20_000 });


### PR DESCRIPTION
Rebased onto main. Closes linear ticket RUSH-1631. Supersedes #1003.