### PR TITLE
RUSH-1635: derive menu-bar repo groups for worktree sessions

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Menu bar groups worktree sessions under the real repo name (RUSH-1635).** Paths under `.agents/worktrees/<slug>` use the enclosing repository directory as the grouping key instead of the worktree slug. Source: `apps/cli/menubar/.../LocalState.swift`.
+
 - **Per-session rate-limit detection + feed badge (RUSH-1523).** The session state engine flags rate/usage-limit text in the transcript (`detectRateLimited`); `ActiveSession.rateLimited` flows through remote fan-out into Factory's `FloorAgent.rateLimited`, which renders a **rate limited** pill on the feed card. Source: `apps/cli/src/lib/session/state.ts`, `apps/factory/.../floorAdapter.ts`, `FeedItem.tsx`.
 - **Kiro launches with `--v3` so standalone hooks actually fire (RUSH-1612).** Agents-cli writes Kiro hooks as v3 standalone files under `~/.kiro/hooks/*.json`, but those only load on the v3 engine. `AGENT_COMMANDS.kiro.base` now includes `--v3` so `agents run kiro` opts into the engine that reads them. Source: `apps/cli/src/lib/exec.ts`.
 

--- a/apps/cli/menubar/Sources/MenubarHelper/LocalState.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/LocalState.swift
@@ -164,6 +164,26 @@ enum LocalState {
         return all
     }
 
+
+    /// Grouping key for the menu: prefer the real git repo name over a worktree
+    /// directory slug. Paths under `.../.agents/worktrees/<slug>` group as the
+    /// enclosing repository (the path component before `.agents`), not `<slug>`.
+    static func repoName(from cwd: String?) -> String? {
+        guard let cwd, !cwd.isEmpty else { return nil }
+        let ns = cwd as NSString
+        let parts = (cwd as NSString).pathComponents
+        // Match .../.agents/worktrees/<slug>[/...]
+        if let agentsIdx = parts.firstIndex(of: ".agents"),
+           agentsIdx + 2 < parts.count,
+           parts[agentsIdx + 1] == "worktrees" {
+            // Enclosing repo root is the component before `.agents`
+            if agentsIdx > 0 {
+                return parts[agentsIdx - 1]
+            }
+        }
+        return ns.lastPathComponent
+    }
+
     // MARK: Terminals
     private static func terminals(attention: [String: AttentionMark]) -> [Session] {
         let path = "\(home)/.agents/.cache/terminals/live-terminals.json"
@@ -183,7 +203,7 @@ enum LocalState {
                 let sid = (e["sessionId"] as? String) ?? ""
                 // repo is the grouping key — always the working-dir name; the
                 // label is the session's own title, carried separately.
-                let repo = cwd.map { ($0 as NSString).lastPathComponent } ?? label
+                let repo = Self.repoName(from: cwd) ?? label
                 let mark = sid.isEmpty ? nil : attention[sid]
                 let status = sessionStatus(sessionId: sid, kind: kind, cwd: cwd,
                                            attention: attentionIds)
@@ -210,7 +230,7 @@ enum LocalState {
             let agent = (m["agentType"] as? String) ?? "agent"
             let cwd = m["cwd"] as? String
             let task = (m["taskName"] as? String) ?? (m["name"] as? String) ?? ""
-            let repo = cwd.map { ($0 as NSString).lastPathComponent } ?? ""
+            let repo = Self.repoName(from: cwd) ?? ""
             out.append(Session(agent: agent, repo: repo, cwd: cwd,
                                status: .running, context: "teams", title: task,
                                question: "", attentionSinceMs: nil))


### PR DESCRIPTION
Rebased onto main. Closes linear ticket RUSH-1635. Supersedes #1004.