### PR TITLE
RUSH-1615: remove stale Cursor hook entries when matcher/event changes

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Cursor hook sync drops stale managed entries when matcher/event change (RUSH-1615).** GC keys managed hooks by `event|command|matcher` instead of command path alone, so a matcher or event edit no longer leaves dead entries. Source: `apps/cli/src/lib/hooks.ts`.
 - **Mailbox delivery receipts are monotonic (RUSH-1614).** `recordMessageReceipt` no longer lets a late `queued` write overwrite an already-recorded `consumed`/`continued` when enqueue races the drain. Source: `apps/cli/src/lib/feed.ts`.
 - **Per-session rate-limit detection + feed badge (RUSH-1523).** The session state engine flags rate/usage-limit text in the transcript (`detectRateLimited`); `ActiveSession.rateLimited` flows through remote fan-out into Factory's `FloorAgent.rateLimited`, which renders a **rate limited** pill on the feed card. Source: `apps/cli/src/lib/session/state.ts`, `apps/factory/.../floorAdapter.ts`, `FeedItem.tsx`.
 - **Kiro launches with `--v3` so standalone hooks actually fire (RUSH-1612).** Agents-cli writes Kiro hooks as v3 standalone files under `~/.kiro/hooks/*.json`, but those only load on the v3 engine. `AGENT_COMMANDS.kiro.base` now includes `--v3` so `agents run kiro` opts into the engine that reads them. Source: `apps/cli/src/lib/exec.ts`.

--- a/apps/cli/src/lib/__tests__/hooks.test.ts
+++ b/apps/cli/src/lib/__tests__/hooks.test.ts
@@ -1047,6 +1047,44 @@ describe('registerHooksToSettings - Cursor', () => {
     const parsed = JSON.parse(fs.readFileSync(path.join(versionHome, '.cursor', 'hooks.json'), 'utf-8'));
     expect(parsed.hooks.preToolUse).toHaveLength(1);
   });
+
+  it('drops managed entries when matcher or event changes (RUSH-1615)', () => {
+    makeCursorScript('guard.sh');
+    const versionHome = path.join(tmpDir, 'home');
+    const outPath = path.join(versionHome, '.cursor', 'hooks.json');
+
+    registerHooksToSettings(
+      'cursor',
+      versionHome,
+      { guard: { script: 'guard.sh', events: ['PreToolUse'], matcher: 'Shell' } },
+      agentsDir,
+    );
+    let parsed = JSON.parse(fs.readFileSync(outPath, 'utf-8'));
+    expect(parsed.hooks.preToolUse).toHaveLength(1);
+    expect(parsed.hooks.preToolUse[0].matcher).toBe('Shell');
+
+    // Matcher change — old Shell entry must not linger.
+    registerHooksToSettings(
+      'cursor',
+      versionHome,
+      { guard: { script: 'guard.sh', events: ['PreToolUse'], matcher: 'Write' } },
+      agentsDir,
+    );
+    parsed = JSON.parse(fs.readFileSync(outPath, 'utf-8'));
+    expect(parsed.hooks.preToolUse).toHaveLength(1);
+    expect(parsed.hooks.preToolUse[0].matcher).toBe('Write');
+
+    // Event change — PreToolUse managed entry must go when only PostToolUse remains.
+    registerHooksToSettings(
+      'cursor',
+      versionHome,
+      { guard: { script: 'guard.sh', events: ['PostToolUse'], matcher: 'Write' } },
+      agentsDir,
+    );
+    parsed = JSON.parse(fs.readFileSync(outPath, 'utf-8'));
+    expect(parsed.hooks.preToolUse).toBeUndefined();
+    expect(parsed.hooks.postToolUse).toHaveLength(1);
+  });
 });
 
 describe('registerHooksToSettings - Antigravity', () => {

--- a/apps/cli/src/lib/hooks.ts
+++ b/apps/cli/src/lib/hooks.ts
@@ -2475,21 +2475,28 @@ function registerHooksForCursor(
     }
   }
 
-  const currentManifestPaths = new Set<string>();
+  // Desired managed entries keyed by event|command|matcher so a matcher or
+  // event change drops the stale entry instead of retaining it by command path alone.
+  const desiredManaged = new Set<string>();
   for (const [hookName, hookDef] of Object.entries(manifest)) {
     if (!hookDef.events || hookDef.events.length === 0) continue;
     const resolved = resolveHookCommand(hookName, hookDef, resolveScript);
-    if (resolved) currentManifestPaths.add(resolved);
+    if (!resolved) continue;
+    for (const event of hookDef.events) {
+      const cursorEvent = CURSOR_EVENT_MAP[event];
+      if (!cursorEvent) continue;
+      desiredManaged.add(`${cursorEvent}|${resolved}|${hookDef.matcher ?? ''}`);
+    }
   }
 
-  // GC managed entries that are no longer in the manifest
+  // GC managed entries that are no longer in the manifest (by event+command+matcher)
   const hooks: Record<string, CursorEntry[]> = {};
   for (const [event, entries] of Object.entries(existing.hooks || {})) {
     if (!Array.isArray(entries)) continue;
     hooks[event] = entries.filter((e) => {
       if (typeof e?.command !== 'string') return true;
       if (!isManagedHookCommand(e.command, managedPrefixes)) return true;
-      return currentManifestPaths.has(e.command);
+      return desiredManaged.has(`${event}|${e.command}|${e.matcher ?? ''}`);
     });
     if (hooks[event].length === 0) delete hooks[event];
   }


### PR DESCRIPTION
Rebased after merge conflict. Closes RUSH-1615. Supersedes #1007.