### PR TITLE
RUSH-1539: make Factory sidebar resizable

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+- **Factory Floor's full sidebar is now resizable (RUSH-1539).** Drag the right
+  edge to widen or narrow the project/host sidebar; the chosen width persists
+  with the existing Floor preferences. Source:
+  `ui/settings/components/mission-control/FloorSidebar.tsx`,
+  `UnifiedAgentsPane.tsx`, `floor.css`.
 - **Per-session rate-limit badge on feed cards (RUSH-1523).** Sessions whose transcript shows a rate/usage limit render a distinct **rate limited** pill so they no longer look like healthy running agents. Source: `floorModel.ts` (`rateLimited`), `floorAdapter.ts` (`detectSessionRateLimited`), `FeedItem.tsx`.
 - **Feed cards get an Open/Resume-in-terminal action (RUSH-1520).** Each card shows a Terminal button that focuses an open tab, attaches a tmux rail, or runs `agents sessions focus <id>` — so the operator jumps into the session instead of only opening the side panel. Source: `ui/settings/components/mission-control/FeedItem.tsx`, `UnifiedAgentsPane.tsx` (`openTerminalForAgent`).
 - **Filter + group-by controls live in the feed header bar next to Save view (RUSH-1526).** The feed's own header (`SavedViews` / `feed-header-bar`) now carries Group + status chips (Needs you / Running / Idle / Failed) + agent-abbr chips, so operators filter and group where they are looking — not only from the top FloorControls bar. Source: `ui/settings/components/mission-control/SavedViewsBar.tsx`, `UnifiedAgentsPane.tsx`, `floor.css`.

--- a/apps/factory/README.md
+++ b/apps/factory/README.md
@@ -61,7 +61,8 @@ The dashboard's mission control. A live grid of every agent on the floor — loc
 
 Agent cards surface outputs such as PRs, spawned teams, created tickets, and plan
 artifacts. `.html` and `ref-*.md` plans detected in session output, worktree
-files, or attachments appear as one-click preview chips.
+files, or attachments appear as one-click preview chips. The expanded project and
+host sidebar can be resized by dragging its right edge.
 
 ### Foreman Voice Orb
 

--- a/apps/factory/ui/settings/components/mission-control/FloorSidebar.test.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorSidebar.test.tsx
@@ -1,0 +1,33 @@
+import { expect, test, describe } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import {
+  FloorSidebar,
+  FLOOR_SIDEBAR_MAX_WIDTH,
+  FLOOR_SIDEBAR_MIN_WIDTH,
+} from './FloorSidebar'
+
+const noop = () => {}
+
+describe('FloorSidebar resizing', () => {
+  test('renders an accessible resize separator with the persisted width', () => {
+    const html = renderToStaticMarkup(
+      <FloorSidebar
+        agents={[]}
+        tickets={[]}
+        projFilter={null}
+        hostPins={[]}
+        projects={[]}
+        sidebarWidth={260}
+        onSidebarWidthChange={noop}
+        onScope={noop}
+      />,
+    )
+
+    expect(html).toContain('sidebar-resize')
+    expect(html).toContain('role="separator"')
+    expect(html).toContain('aria-label="Resize sidebar"')
+    expect(html).toContain(`aria-valuemin="${FLOOR_SIDEBAR_MIN_WIDTH}"`)
+    expect(html).toContain(`aria-valuemax="${FLOOR_SIDEBAR_MAX_WIDTH}"`)
+    expect(html).toContain('aria-valuenow="260"')
+  })
+})

--- a/apps/factory/ui/settings/components/mission-control/FloorSidebar.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorSidebar.tsx
@@ -7,6 +7,10 @@ import { computeHostRows, orderManagedProjects, type FloorAgent, type FloorTicke
 // Projects (with wait-counts), Hosts (with health). Counts are derived from the
 // agents + tickets passed in — no data fetching here.
 
+export const FLOOR_SIDEBAR_DEFAULT_WIDTH = 210
+export const FLOOR_SIDEBAR_MIN_WIDTH = 176
+export const FLOOR_SIDEBAR_MAX_WIDTH = 360
+
 interface FloorSidebarProps {
   agents: FloorAgent[]
   tickets: FloorTicket[]
@@ -44,11 +48,15 @@ interface FloorSidebarProps {
   projects?: ManagedProject[]
   /** Open the Projects management pane (gear + "+N more" row). */
   onManageProjects?: () => void
+  /** Current sidebar width, persisted by the parent shell. */
+  sidebarWidth?: number
+  /** Persist a resized sidebar width. */
+  onSidebarWidthChange?: (width: number) => void
   /** Collapse back to the icon rail. */
   onCollapse?: () => void
 }
 
-export function FloorSidebar({ agents, tickets, projFilter, hostFilter = null, offlineHosts = [], devices = [], hostPins = [], onToggleHostPin, onReorderHostPins, onScope, localHost, projects = [], onManageProjects, onCollapse }: FloorSidebarProps) {
+export function FloorSidebar({ agents, tickets, projFilter, hostFilter = null, offlineHosts = [], devices = [], hostPins = [], onToggleHostPin, onReorderHostPins, onScope, localHost, projects = [], onManageProjects, sidebarWidth = FLOOR_SIDEBAR_DEFAULT_WIDTH, onSidebarWidthChange, onCollapse }: FloorSidebarProps) {
   const byProj: Record<string, number> = {}
   const projWait: Record<string, number> = {}
   for (const a of agents) {
@@ -64,6 +72,51 @@ export function FloorSidebar({ agents, tickets, projFilter, hostFilter = null, o
 
   const [dragName, setDragName] = useState<string | null>(null)
   const [overName, setOverName] = useState<string | null>(null)
+  const [resizing, setResizing] = useState(false)
+
+  const setWidth = (width: number) => {
+    onSidebarWidthChange?.(Math.max(FLOOR_SIDEBAR_MIN_WIDTH, Math.min(FLOOR_SIDEBAR_MAX_WIDTH, Math.round(width))))
+  }
+
+  const startResize = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!onSidebarWidthChange) return
+    e.preventDefault()
+    e.stopPropagation()
+    const startX = e.clientX
+    const startWidth = sidebarWidth
+    const prevCursor = document.documentElement.style.cursor
+    const prevUserSelect = document.documentElement.style.userSelect
+    document.documentElement.style.cursor = 'col-resize'
+    document.documentElement.style.userSelect = 'none'
+    setResizing(true)
+    const onMove = (ev: PointerEvent) => setWidth(startWidth + ev.clientX - startX)
+    const onUp = () => {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      document.documentElement.style.cursor = prevCursor
+      document.documentElement.style.userSelect = prevUserSelect
+      setResizing(false)
+    }
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp, { once: true })
+  }
+
+  const onResizeKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!onSidebarWidthChange) return
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      setWidth(sidebarWidth - (e.shiftKey ? 32 : 16))
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      setWidth(sidebarWidth + (e.shiftKey ? 32 : 16))
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      setWidth(FLOOR_SIDEBAR_MIN_WIDTH)
+    } else if (e.key === 'End') {
+      e.preventDefault()
+      setWidth(FLOOR_SIDEBAR_MAX_WIDTH)
+    }
+  }
 
   // Drop `dragName` immediately before `target` in the persisted pin order.
   const dropBefore = (target: string) => {
@@ -107,7 +160,7 @@ export function FloorSidebar({ agents, tickets, projFilter, hostFilter = null, o
   )
 
   return (
-    <div className="sidebar">
+    <div className={`sidebar${resizing ? ' resizing' : ''}`}>
       <div className="sb-sec" style={{ display: 'flex', alignItems: 'center' }}>
         <span>SMART</span>
         {onCollapse && (
@@ -165,6 +218,19 @@ export function FloorSidebar({ agents, tickets, projFilter, hostFilter = null, o
       {pinnedRows.map(renderHost)}
       {pinnedRows.length > 0 && restRows.length > 0 && <div className="sb-host-div" />}
       {restRows.map(renderHost)}
+      <div
+        className="sidebar-resize"
+        role="separator"
+        aria-label="Resize sidebar"
+        aria-orientation="vertical"
+        aria-valuemin={FLOOR_SIDEBAR_MIN_WIDTH}
+        aria-valuemax={FLOOR_SIDEBAR_MAX_WIDTH}
+        aria-valuenow={Math.round(sidebarWidth)}
+        tabIndex={0}
+        title="Resize sidebar"
+        onPointerDown={startResize}
+        onKeyDown={onResizeKey}
+      />
     </div>
   )
 }

--- a/apps/factory/ui/settings/components/mission-control/FloorSidebar.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorSidebar.tsx
@@ -82,6 +82,9 @@ export function FloorSidebar({ agents, tickets, projFilter, hostFilter = null, o
     if (!onSidebarWidthChange) return
     e.preventDefault()
     e.stopPropagation()
+    const target = e.currentTarget
+    const pointerId = e.pointerId
+    target.setPointerCapture(pointerId)
     const startX = e.clientX
     const startWidth = sidebarWidth
     const prevCursor = document.documentElement.style.cursor
@@ -90,15 +93,21 @@ export function FloorSidebar({ agents, tickets, projFilter, hostFilter = null, o
     document.documentElement.style.userSelect = 'none'
     setResizing(true)
     const onMove = (ev: PointerEvent) => setWidth(startWidth + ev.clientX - startX)
+    let cleaned = false
     const onUp = () => {
+      if (cleaned) return
+      cleaned = true
       window.removeEventListener('pointermove', onMove)
       window.removeEventListener('pointerup', onUp)
+      window.removeEventListener('pointercancel', onUp)
+      if (target.hasPointerCapture(pointerId)) target.releasePointerCapture(pointerId)
       document.documentElement.style.cursor = prevCursor
       document.documentElement.style.userSelect = prevUserSelect
       setResizing(false)
     }
     window.addEventListener('pointermove', onMove)
     window.addEventListener('pointerup', onUp, { once: true })
+    window.addEventListener('pointercancel', onUp, { once: true })
   }
 
   const onResizeKey = (e: React.KeyboardEvent<HTMLDivElement>) => {

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -24,7 +24,7 @@ import {
   type PendingDispatch,
 } from './dispatch'
 import { FloorControls, floorControlsMode, type StatusChip } from './FloorControls'
-import { FloorSidebar } from './FloorSidebar'
+import { FloorSidebar, FLOOR_SIDEBAR_DEFAULT_WIDTH, FLOOR_SIDEBAR_MAX_WIDTH, FLOOR_SIDEBAR_MIN_WIDTH } from './FloorSidebar'
 import { FloorRail } from './FloorRail'
 import { FloorSubtabs, openTaskTab, closeTaskTab, type FixedTab, type TaskTab } from './FloorSubtabs'
 import { BacklogCenter } from './BacklogCenter'
@@ -102,17 +102,25 @@ interface FloorPrefs {
   // Ordered pinned host names for the HOSTS sidebar. null = never customized
   // (the local machine is pinned by default); [] = user explicitly unpinned all.
   hostPins: string[] | null
+  sidebarWidth: number
 }
 
 function defaultFloorPrefs(): FloorPrefs {
-  return { plain: false, sidebar: true, rail: true, right: true, pinned: [], hostPins: null }
+  return { plain: false, sidebar: true, rail: true, right: true, pinned: [], hostPins: null, sidebarWidth: FLOOR_SIDEBAR_DEFAULT_WIDTH }
+}
+
+function clampSidebarWidth(width: unknown): number {
+  const n = typeof width === 'number' ? width : Number(width)
+  if (!Number.isFinite(n)) return FLOOR_SIDEBAR_DEFAULT_WIDTH
+  return Math.max(FLOOR_SIDEBAR_MIN_WIDTH, Math.min(FLOOR_SIDEBAR_MAX_WIDTH, Math.round(n)))
 }
 
 function loadFloorPrefs(): FloorPrefs {
   try {
     const raw = localStorage.getItem(FLOOR_PREFS_KEY)
     if (!raw) return defaultFloorPrefs()
-    return { ...defaultFloorPrefs(), ...JSON.parse(raw) }
+    const parsed = { ...defaultFloorPrefs(), ...JSON.parse(raw) }
+    return { ...parsed, sidebarWidth: clampSidebarWidth(parsed.sidebarWidth) }
   } catch {
     return defaultFloorPrefs()
   }
@@ -647,6 +655,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   const [railCollapsed, setRailCollapsed] = useState(floorPrefs0.rail)
   const [rightOpen, setRightOpen] = useState(floorPrefs0.right)
   const [pinned, setPinned] = useState<Set<string>>(() => new Set(floorPrefs0.pinned))
+  const [sidebarWidth, setSidebarWidth] = useState(floorPrefs0.sidebarWidth)
   // Ordered pinned HOSTS names (null = default: pin the local machine).
   const [hostPins, setHostPins] = useState<string[] | null>(floorPrefs0.hostPins)
   const [statusChips, setStatusChips] = useState<StatusChip[]>([])
@@ -705,8 +714,8 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
 
   // Persist the durable Floor prefs (pinned set, plain/sidebar/right toggles, group-by, host pins).
   useEffect(() => {
-    saveFloorPrefs({ plain, sidebar: sidebarOpen, rail: railCollapsed, right: rightOpen, pinned: [...pinned], hostPins })
-  }, [plain, sidebarOpen, railCollapsed, rightOpen, pinned, hostPins])
+    saveFloorPrefs({ plain, sidebar: sidebarOpen, rail: railCollapsed, right: rightOpen, pinned: [...pinned], hostPins, sidebarWidth })
+  }, [plain, sidebarOpen, railCollapsed, rightOpen, pinned, hostPins, sidebarWidth])
 
   // Effective HOSTS pins: default to pinning just the local machine until the user
   // customizes. Pin/unpin and drag-reorder always write an explicit list.
@@ -2257,7 +2266,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
         />
       )}
 
-      <div className="page" style={{ flex: 1, minHeight: 0, height: 'auto' }}>
+      <div className="page" style={{ flex: 1, minHeight: 0, height: 'auto', '--floor-sidebar-width': `${sidebarWidth}px` } as React.CSSProperties}>
         {sidebarOpen && (railCollapsed ? (
           <FloorRail
             agents={floorAgents}
@@ -2303,6 +2312,8 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
             localHost={localHostName || undefined}
             projects={managedProjects}
             onManageProjects={() => { setCenter('projects'); setRightOpen(true) }}
+            sidebarWidth={sidebarWidth}
+            onSidebarWidthChange={(width) => setSidebarWidth(clampSidebarWidth(width))}
           />
         ))}
         <div className="feed-col">{centerContent}</div>

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -326,7 +326,13 @@
 
 /* page with optional project sidebar */
 .swarmify-root .page { display: flex; height: 100%; min-height: 0; }
-.swarmify-root .sidebar { width: 210px; flex: 0 0 210px; border-right: 1px solid var(--ds-border); overflow: auto; padding: 8px 0; background: var(--ds-bg); }
+.swarmify-root .sidebar { position: relative; width: var(--floor-sidebar-width, 210px); flex: 0 0 var(--floor-sidebar-width, 210px); border-right: 1px solid var(--ds-border); overflow: auto; padding: 8px 0; background: var(--ds-bg); }
+.swarmify-root .sidebar-resize { position: absolute; top: 0; right: 0; bottom: 0; width: 8px; cursor: col-resize; z-index: 3; touch-action: none; }
+.swarmify-root .sidebar-resize::after { content: ""; position: absolute; top: 8px; bottom: 8px; right: 0; width: 1px; background: transparent; transition: background .12s; }
+.swarmify-root .sidebar-resize:hover::after,
+.swarmify-root .sidebar-resize:focus-visible::after,
+.swarmify-root .sidebar.resizing .sidebar-resize::after { background: var(--brand); }
+.swarmify-root .sidebar-resize:focus-visible { outline: 1px solid var(--brand); outline-offset: -2px; }
 /* Icon rail — collapsed left nav (mockup default): a column of 46px rounded icon
    buttons with count/needs badges, active button lime-outlined. */
 .swarmify-root .floor-rail { flex: 0 0 68px; width: 68px; border-right: 1px solid var(--ds-border); background: var(--ds-bg); padding: 16px 0; overflow: visible; }

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -11,7 +11,7 @@ import ReactDOM from 'react-dom/client'
 import '../index.css'
 
 import { Icon } from '../components/mission-control/icons'
-import { FloorSidebar } from '../components/mission-control/FloorSidebar'
+import { FloorSidebar, FLOOR_SIDEBAR_DEFAULT_WIDTH } from '../components/mission-control/FloorSidebar'
 import { FloorRail } from '../components/mission-control/FloorRail'
 import { FloorControls, floorControlsMode } from '../components/mission-control/FloorControls'
 import { FloorSubtabs, openTaskTab, closeTaskTab, type FixedTab, type TaskTab } from '../components/mission-control/FloorSubtabs'
@@ -409,6 +409,7 @@ function Subtabs() {
 // so the host status dots (`.hd`) can be screenshotted at their true size.
 function Sidebar() {
   const [pins, setPins] = useState<string[]>(['zion'])
+  const [sidebarWidth, setSidebarWidth] = useState(FLOOR_SIDEBAR_DEFAULT_WIDTH)
   const sidebarAgents: FloorAgent[] = [
     ...running,
     agent({ id: 's1', hostLabel: 'yosemite-s0', project: 'agents-cli' }),
@@ -442,21 +443,26 @@ function Sidebar() {
       onExpand={() => setCollapsed(false)}
     />
   ) : (
-    <FloorSidebar
-      agents={sidebarAgents}
-      tickets={tickets}
-      projFilter={null}
-      offlineHosts={['yosemite-s1']}
-      devices={devices}
-      hostPins={pins}
-      projects={managedProjects}
-      onManageProjects={noop}
-      onCollapse={() => setCollapsed(true)}
-      onToggleHostPin={(n) => setPins((p) => (p.includes(n) ? p.filter((x) => x !== n) : [...p, n]))}
-      onReorderHostPins={setPins}
-      onScope={noop}
-      localHost="zion"
-    />
+    <div className="page" style={{ height: '100%', '--floor-sidebar-width': `${sidebarWidth}px` } as React.CSSProperties}>
+      <FloorSidebar
+        agents={sidebarAgents}
+        tickets={tickets}
+        projFilter={null}
+        offlineHosts={['yosemite-s1']}
+        devices={devices}
+        hostPins={pins}
+        projects={managedProjects}
+        onManageProjects={noop}
+        sidebarWidth={sidebarWidth}
+        onSidebarWidthChange={setSidebarWidth}
+        onCollapse={() => setCollapsed(true)}
+        onToggleHostPin={(n) => setPins((p) => (p.includes(n) ? p.filter((x) => x !== n) : [...p, n]))}
+        onReorderHostPins={setPins}
+        onScope={noop}
+        localHost="zion"
+      />
+      <div className="feed-col" />
+    </div>
   )
 }
 


### PR DESCRIPTION
## What
- Added a draggable and keyboard-accessible resize separator to the expanded Factory Floor sidebar.
- Persisted the selected sidebar width through the existing Floor preferences key.
- Updated the preview harness, Factory README, changelog, and focused sidebar test coverage.

## Why
Factory Floor users need to widen or narrow the project/host sidebar without losing the preference when the view stays open or reloads.

## Evidence
- `apps/factory/ui/settings/components/mission-control/FloorSidebar.tsx:10` defines default/min/max widths and `FloorSidebar.tsx:222` renders the accessible `Resize sidebar` separator.
- `apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx:86` keeps using `swarmify.floorPrefs.v1`; `UnifiedAgentsPane.tsx:717` saves `sidebarWidth`; `UnifiedAgentsPane.tsx:2316` writes resized widths back through the clamp.
- `apps/factory/ui/settings/components/mission-control/floor.css:330` makes the resize hit target and visible hover/focus/drag line.
- `apps/factory/ui/settings/preview/preview.tsx:412` wires the preview story to exercise width changes.
- `apps/factory/ui/settings/components/mission-control/FloorSidebar.test.tsx:28` asserts the accessible resize separator.
- `apps/factory/README.md:65` and `apps/factory/CHANGELOG.md:13` document the user-visible behavior.

## Verification
- `PATH=/home/muqsit/.bun/bin:$PATH /home/muqsit/.bun/bin/bun test ui/settings/components/mission-control/FloorSidebar.test.tsx ui/settings/components/mission-control/FloorRail.test.tsx` -> 15 pass, 0 fail.
- `PATH=/home/muqsit/.bun/bin:$PATH /home/muqsit/.bun/bin/bun run compile` -> TypeScript compile plus settings/editor Vite builds completed.
- Preview harness visual check: dragged the expanded sidebar from 210px to 290px with no text overlap. Screenshots: `/tmp/rush-1539/sidebar-before.png`, `/tmp/rush-1539/sidebar-after.png`.
