### PR TITLE
RUSH-1616: isolate per-attempt logs for routine credit failover

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Routine credit-failover scans only the current attempt's log (RUSH-1616).** Each failover spawn writes `stdout.attempt-N.log` and rate-limit detection uses that file alone; prior attempts still append into `stdout.log` for the continuous trail. Source: `apps/cli/src/lib/runner.ts`.
 - **Cursor hook sync drops stale managed entries when matcher/event change (RUSH-1615).** GC keys managed hooks by `event|command|matcher` instead of command path alone, so a matcher or event edit no longer leaves dead entries. Source: `apps/cli/src/lib/hooks.ts`.
 - **Stop advertising Goose SubagentStart/SubagentStop hooks (RUSH-1613).** Goose does not emit those events; drop them from `GOOSE_EVENT_MAP` so sync no longer installs dead entries. Source: `apps/cli/src/lib/hooks.ts`.
 - **Mailbox delivery receipts are monotonic (RUSH-1614).** `recordMessageReceipt` no longer lets a late `queued` write overwrite an already-recorded `consumed`/`continued` when enqueue races the drain. Source: `apps/cli/src/lib/feed.ts`.

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -368,16 +368,20 @@ interface SpawnAttemptResult {
 }
 
 /**
- * Spawn one attempt, capture logs to `stdoutPath`, enforce timeout.
- * Appends to the log file so failover attempts leave a continuous trail.
+ * Spawn one attempt, capture logs to `attemptLogPath`, enforce timeout.
+ * Rate-limit scanning uses only this attempt's log (not prior failover output).
+ * The attempt log is also appended into `combinedLogPath` for a continuous trail.
  */
 function spawnJobAttempt(
   cmd: string[],
   env: Record<string, string>,
-  stdoutPath: string,
+  attemptLogPath: string,
   timeoutMs: number,
+  combinedLogPath?: string,
 ): Promise<SpawnAttemptResult> {
-  const stdoutFd = fs.openSync(stdoutPath, 'a', 0o600);
+  // Isolate this attempt's output so detectRateLimit never sees prior attempts.
+  fs.writeFileSync(attemptLogPath, '', { mode: 0o600 });
+  const stdoutFd = fs.openSync(attemptLogPath, 'a', 0o600);
   return new Promise((resolve) => {
     const child = spawn(cmd[0], cmd.slice(1), {
       stdio: ['ignore', stdoutFd, stdoutFd],
@@ -392,8 +396,13 @@ function spawnJobAttempt(
       try { fs.closeSync(stdoutFd); } catch { /* fd already closed */ }
       let logText = '';
       try {
-        logText = fs.readFileSync(stdoutPath, 'utf-8');
+        logText = fs.readFileSync(attemptLogPath, 'utf-8');
       } catch { /* missing log */ }
+      if (combinedLogPath) {
+        try {
+          fs.appendFileSync(combinedLogPath, logText);
+        } catch { /* best-effort trail */ }
+      }
       resolve({ ...result, logText });
     };
 
@@ -570,7 +579,8 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
     const elapsed = Date.now() - Date.parse(meta.startedAt);
     const remaining = Math.max(1_000, timeoutMs - (Number.isFinite(elapsed) ? elapsed : 0));
 
-    const attempt = await spawnJobAttempt(cmd, spawnEnv, stdoutPath, remaining);
+    const attemptLogPath = path.join(runDir, `stdout.attempt-${i}.log`);
+    const attempt = await spawnJobAttempt(cmd, spawnEnv, attemptLogPath, remaining, stdoutPath);
     meta.pid = attempt.pid;
     writeRunMeta(meta);
 


### PR DESCRIPTION
Serial land on latest main. Closes RUSH-1616.