### PR TITLE
RUSH-1618: use canonical operator registry for feed authorization

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Feed high-consequence authz uses the canonical operator registry (RUSH-1618).** `recordAnswer` no longer looks for `operators.yaml` under the feed root; it resolves operators from `~/.agents/` via `loadOperators()`. Source: `apps/cli/src/lib/feed.ts`.
 - **OpenCode plugin install only writes loader-visible direct `.ts`/`.js` files (RUSH-1617).** Drop nested and `.mjs`/`.cjs` installs that OpenCode never scans; multi-module plugins flatten into `~/.config/opencode/plugins/`. Source: `apps/cli/src/lib/plugins.ts`.
 - **Routine credit-failover scans only the current attempt's log (RUSH-1616).** Each failover spawn writes `stdout.attempt-N.log` and rate-limit detection uses that file alone; prior attempts still append into `stdout.log` for the continuous trail. Source: `apps/cli/src/lib/runner.ts`.
 - **Cursor hook sync drops stale managed entries when matcher/event change (RUSH-1615).** GC keys managed hooks by `event|command|matcher` instead of command path alone, so a matcher or event edit no longer leaves dead entries. Source: `apps/cli/src/lib/hooks.ts`.

--- a/apps/cli/src/lib/feed.test.ts
+++ b/apps/cli/src/lib/feed.test.ts
@@ -430,6 +430,8 @@ describe('feed store', () => {
 
   it('recordAnswer refuses unverified answers to high-consequence blocks', () => {
     const dir = tmpFeedDir();
+    // operators.yaml under the feed root must NOT authorize (RUSH-1618) —
+    // the registry lives at ~/.agents/operators.yaml only.
     fs.writeFileSync(path.join(dir, 'operators.yaml'), 'operators:\n  muqsit:\n    admin: true\n', 'utf-8');
     publishBlock(makeBlock('sess-authz', 'Deploy to prod?', {
       consequence: 'merge',
@@ -443,8 +445,35 @@ describe('feed store', () => {
       expect('unauthorized' in unverified).toBe(true);
     }
 
-    const verified = recordAnswer(blockId, { answeredFrom: 'feed', answeredBy: 'Muqsit', operatorId: 'muqsit', verified: true }, dir);
-    expect(verified.ok).toBe(true);
+    // verified:false still refused even with a known-looking operatorId.
+    const claimed = recordAnswer(blockId, {
+      answeredFrom: 'feed',
+      answeredBy: 'Muqsit',
+      operatorId: 'muqsit',
+      verified: false,
+    }, dir);
+    expect(claimed.ok).toBe(false);
+  });
+
+  it('recordAnswer ignores operators.yaml colocated with the feed store (RUSH-1618)', () => {
+    const dir = tmpFeedDir();
+    // Only the feed root has operators.yaml — the canonical registry is separate.
+    // Claiming verified:true for an id that exists ONLY here must still fail
+    // when that id is not in the real ~/.agents registry. Use a unique id.
+    fs.writeFileSync(
+      path.join(dir, 'operators.yaml'),
+      'operators:\n  feed-only-operator-xyz:\n    admin: true\n',
+      'utf-8',
+    );
+    publishBlock(makeBlock('sess-authz-feed', 'Deploy?', { consequence: 'merge' }), dir);
+    const blockId = blockIdForSession('sess-authz-feed');
+    const result = recordAnswer(blockId, {
+      answeredFrom: 'feed',
+      operatorId: 'feed-only-operator-xyz',
+      verified: true,
+    }, dir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect('unauthorized' in result).toBe(true);
   });
 
   it('recordAnswer permits any answer to normal-consequence blocks', () => {

--- a/apps/cli/src/lib/feed.ts
+++ b/apps/cli/src/lib/feed.ts
@@ -173,7 +173,8 @@ export function recordAnswer(
   const operatorId = answer.operatorId;
 
   if (block?.consequence && block.consequence !== 'normal') {
-    if (!operatorId || answer.verified !== true || !isHighConsequenceAllowed(block.consequence, operatorId, dir)) {
+    // Operators live in ~/.agents/operators.yaml — never the feed store root.
+    if (!operatorId || answer.verified !== true || !isHighConsequenceAllowed(block.consequence, operatorId)) {
       return {
         ok: false,
         unauthorized: true,


### PR DESCRIPTION
Serial land on latest main. Closes RUSH-1618.