### PR TITLE
RUSH-559: add Hermes and ForgeCode install targets

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Hermes and ForgeCode are first-class install targets (RUSH-559).** `AgentId` now includes `hermes` and `forge`, with resource capability metadata for skills, rules, and MCP. MCP sync writes Hermes `mcp_servers` YAML in `~/.hermes/config.yaml` and ForgeCode `mcpServers` JSON in `~/.forge/.mcp.json`, so registering these targets no longer requires their CLIs to be installed first. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/mcp.ts`, `apps/cli/src/lib/resources/mcp.ts`.
 - **OpenCode plugin install only writes loader-visible direct `.ts`/`.js` files (RUSH-1617).** Drop nested and `.mjs`/`.cjs` installs that OpenCode never scans; multi-module plugins flatten into `~/.config/opencode/plugins/`. Source: `apps/cli/src/lib/plugins.ts`.
 - **Routine credit-failover scans only the current attempt's log (RUSH-1616).** Each failover spawn writes `stdout.attempt-N.log` and rate-limit detection uses that file alone; prior attempts still append into `stdout.log` for the continuous trail. Source: `apps/cli/src/lib/runner.ts`.
 - **Cursor hook sync drops stale managed entries when matcher/event change (RUSH-1615).** GC keys managed hooks by `event|command|matcher` instead of command path alone, so a matcher or event edit no longer leaves dead entries. Source: `apps/cli/src/lib/hooks.ts`.

--- a/apps/cli/docs/00-concepts.md
+++ b/apps/cli/docs/00-concepts.md
@@ -144,6 +144,10 @@ bridges them one way (device → ssh_config → enrollable as a host). See
 | Roo Code | no | yes | no | yes | yes | no | no | `AGENTS.md` | no |
 | Antigravity | yes | yes | yes | yes | yes | yes | no | `AGENTS.md` | no |
 | Grok | yes | yes | yes | yes | skills ($name) | yes | no | `AGENTS.md` | no |
+| Kimi | yes | yes | yes | yes | no | yes | yes | `AGENTS.md` | no |
+| Droid | yes | yes | no | no | yes | yes | yes | `AGENTS.md` | no |
+| Hermes | no | yes | no | yes | no | no | no | `MEMORY.md` | no |
+| ForgeCode | no | yes | no | yes | no | no | no | `AGENTS.md` | no |
 
 **† Gemini is deprecated.** Google retired the Gemini CLI for free/Pro/Ultra tiers on June 18, 2026 (announced at Google I/O 2026); Antigravity CLI (`antigravity`) is the successor. agents-cli still manages existing Gemini installs but warns on `agents add gemini` / `agents teams add … gemini`.
 

--- a/apps/cli/docs/02-resource-sync.md
+++ b/apps/cli/docs/02-resource-sync.md
@@ -130,6 +130,10 @@ Source: ~/.agents/mcp/*.yaml       Per-agent destinations:
                                             · key: mcp.<name> (TOML)
                                    Grok    → <home>/.grok/config.toml
                                             · key: mcp_servers.<name> (TOML)
+                                   Hermes  → <home>/.hermes/config.yaml
+                                            · key: mcp_servers.<name> (YAML)
+                                   Forge   → <home>/.forge/.mcp.json
+                                            · key: mcpServers.<name> = {command,args,env}
 ```
 
 Behavior rules, per `src/lib/mcp.ts`:

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -15,6 +15,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as TOML from 'smol-toml';
+import * as yaml from 'yaml';
 import chalk from 'chalk';
 import type { AgentConfig, AgentId } from './types.js';
 import { needsWindowsShell } from './platform/index.js';
@@ -606,6 +607,77 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
       workflows: false,
       memory: false,
       modes: ['plan', 'edit', 'auto', 'skip'],
+      rulesImports: false,
+    },
+  },
+  // Nous Hermes Agent. Config lives under ~/.hermes/config.yaml; MCP servers
+  // are YAML `mcp_servers`, skills are local SKILL.md directories, and durable
+  // memory is file-backed.
+  hermes: {
+    id: 'hermes',
+    name: 'Hermes',
+    color: 'cyanBright',
+    cliCommand: 'hermes',
+    npmPackage: '',
+    installScript: 'curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash',
+    configDir: path.join(HOME, '.hermes'),
+    commandsDir: '',
+    commandsSubdir: '',
+    skillsDir: path.join(HOME, '.hermes', 'skills'),
+    hooksDir: 'hooks',
+    instructionsFile: 'MEMORY.md',
+    format: 'markdown',
+    variableSyntax: '$ARGUMENTS',
+    supportsHooks: false,
+    capabilities: {
+      hooks: false,
+      mcp: true,
+      mcpHttp: true,
+      mcpHeaders: false,
+      allowlist: false,
+      skills: true,
+      commands: false,
+      plugins: false,
+      subagents: false,
+      rules: { file: 'MEMORY.md' },
+      workflows: false,
+      memory: true,
+      modes: ['edit'],
+      rulesImports: false,
+    },
+  },
+  // ForgeCode (`forge`) from Tailcall. It reads AGENTS.md project rules,
+  // SKILL.md directories, and MCP servers from `.mcp.json` files.
+  forge: {
+    id: 'forge',
+    name: 'ForgeCode',
+    color: 'greenBright',
+    cliCommand: 'forge',
+    npmPackage: '',
+    installScript: 'curl -fsSL https://forgecode.dev/cli | sh',
+    configDir: path.join(HOME, '.forge'),
+    commandsDir: '',
+    commandsSubdir: '',
+    skillsDir: path.join(HOME, '.forge', 'skills'),
+    hooksDir: 'hooks',
+    instructionsFile: 'AGENTS.md',
+    format: 'markdown',
+    variableSyntax: '$ARGUMENTS',
+    supportsHooks: false,
+    capabilities: {
+      hooks: false,
+      mcp: true,
+      mcpHttp: true,
+      mcpHeaders: false,
+      allowlist: false,
+      skills: true,
+      commands: false,
+      plugins: false,
+      subagents: false,
+      rules: { file: 'AGENTS.md' },
+      workflows: false,
+      memory: false,
+      modes: ['edit'],
       rulesImports: false,
     },
   },
@@ -1441,6 +1513,14 @@ export async function registerMcp(
   if (transport === 'http' && options?.headers && Object.keys(options.headers).length > 0 && !supports(agentId, 'mcpHeaders').ok) {
     return { success: false, error: 'skipped: HTTP MCP headers are only supported for Claude registration' };
   }
+  if (agentId === 'hermes' || agentId === 'forge') {
+    try {
+      writeMcpToConfig(agentId, name, command, scope, transport, options?.home);
+      return { success: true };
+    } catch (err) {
+      return { success: false, error: (err as Error).message };
+    }
+  }
   if (!options?.binary && !(await isCliInstalled(agentId))) {
     return { success: false, error: 'CLI not installed' };
   }
@@ -1484,6 +1564,14 @@ export async function unregisterMcp(
   const agent = AGENTS[agentId];
   if (!agent.capabilities.mcp) {
     return { success: false, error: 'Agent does not support MCP' };
+  }
+  if (agentId === 'hermes' || agentId === 'forge') {
+    try {
+      removeMcpFromConfig(agentId, name, options?.home);
+      return { success: true };
+    } catch (err) {
+      return { success: false, error: (err as Error).message };
+    }
   }
   if (!options?.binary && !(await isCliInstalled(agentId))) {
     return { success: false, error: 'CLI not installed' };
@@ -1585,6 +1673,99 @@ interface McpConfigEntry {
   env?: Record<string, string>;
   type?: string;
   url?: string;
+}
+
+function userMcpConfigPath(agentId: AgentId, home?: string): string {
+  if (home) return getMcpConfigPathForHome(agentId, home);
+  return getUserMcpConfigPath(agentId);
+}
+
+function scopedMcpConfigPath(agentId: AgentId, scope: 'user' | 'project', home?: string): string {
+  if (scope === 'project') return getProjectMcpConfigPath(agentId);
+  return userMcpConfigPath(agentId, home);
+}
+
+function mcpEntryFromCommand(command: string, transport: string): McpConfigEntry {
+  if (transport === 'http') {
+    return { url: command };
+  }
+  const commandArgs = splitCommandLine(command);
+  return {
+    command: commandArgs[0],
+    args: commandArgs.slice(1),
+  };
+}
+
+function readYamlConfig(configPath: string): Record<string, unknown> {
+  if (!fs.existsSync(configPath)) return {};
+  const parsed = yaml.parse(fs.readFileSync(configPath, 'utf-8'));
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? parsed as Record<string, unknown>
+    : {};
+}
+
+function readJsonConfig(configPath: string): Record<string, unknown> {
+  if (!fs.existsSync(configPath)) return {};
+  const content = configPath.endsWith('.jsonc')
+    ? stripJsonComments(fs.readFileSync(configPath, 'utf-8'))
+    : fs.readFileSync(configPath, 'utf-8');
+  const parsed = JSON.parse(content);
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? parsed as Record<string, unknown>
+    : {};
+}
+
+function writeMcpToConfig(
+  agentId: AgentId,
+  name: string,
+  command: string,
+  scope: 'user' | 'project',
+  transport: string,
+  home?: string
+): void {
+  const configPath = scopedMcpConfigPath(agentId, scope, home);
+  const entry = mcpEntryFromCommand(command, transport);
+
+  if (agentId === 'hermes') {
+    const config = readYamlConfig(configPath);
+    if (!config.mcp_servers || typeof config.mcp_servers !== 'object' || Array.isArray(config.mcp_servers)) {
+      config.mcp_servers = {};
+    }
+    (config.mcp_servers as Record<string, unknown>)[name] = entry;
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, yaml.stringify(config), 'utf-8');
+    return;
+  }
+
+  const config = readJsonConfig(configPath);
+  if (!config.mcpServers || typeof config.mcpServers !== 'object' || Array.isArray(config.mcpServers)) {
+    config.mcpServers = {};
+  }
+  (config.mcpServers as Record<string, unknown>)[name] = entry;
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
+}
+
+function removeMcpFromConfig(agentId: AgentId, name: string, home?: string): void {
+  const configPath = userMcpConfigPath(agentId, home);
+  if (!fs.existsSync(configPath)) return;
+
+  if (agentId === 'hermes') {
+    const config = readYamlConfig(configPath);
+    const servers = config.mcp_servers;
+    if (servers && typeof servers === 'object' && !Array.isArray(servers)) {
+      delete (servers as Record<string, unknown>)[name];
+      fs.writeFileSync(configPath, yaml.stringify(config), 'utf-8');
+    }
+    return;
+  }
+
+  const config = readJsonConfig(configPath);
+  const servers = config.mcpServers;
+  if (servers && typeof servers === 'object' && !Array.isArray(servers)) {
+    delete (servers as Record<string, unknown>)[name];
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
+  }
 }
 
 /**
@@ -1717,6 +1898,21 @@ function parseMcpFromTomlConfig(configPath: string): Record<string, McpConfigEnt
   }
 }
 
+function parseMcpFromYamlConfig(configPath: string): Record<string, McpConfigEntry> {
+  if (!fs.existsSync(configPath)) {
+    return {};
+  }
+
+  try {
+    const config = readYamlConfig(configPath);
+    const mcpServers = config.mcp_servers as Record<string, McpConfigEntry> | undefined;
+    return mcpServers || {};
+  } catch {
+    /* YAML config corrupt or unreadable */
+    return {};
+  }
+}
+
 /**
  * Parse MCP servers from OpenCode's JSONC config.
  * OpenCode stores MCPs in the "mcp" object with different structure.
@@ -1795,6 +1991,10 @@ export function getUserMcpConfigPath(agentId: AgentId): string {
     case 'droid':
       // Factory AI Droid stores MCPs in ~/.factory/mcp.json
       return path.join(agent.configDir, 'mcp.json');
+    case 'hermes':
+      return path.join(agent.configDir, 'config.yaml');
+    case 'forge':
+      return path.join(agent.configDir, '.mcp.json');
     default:
       // Gemini and others use settings.json
       return path.join(agent.configDir, 'settings.json');
@@ -1830,6 +2030,10 @@ export function getMcpConfigPathForHome(agentId: AgentId, home: string): string 
       return path.join(home, '.grok', 'config.toml');
     case 'droid':
       return path.join(home, '.factory', 'mcp.json');
+    case 'hermes':
+      return path.join(home, '.hermes', 'config.yaml');
+    case 'forge':
+      return path.join(home, '.forge', '.mcp.json');
     default:
       return path.join(home, agentConfigDirName(agentId), 'settings.json');
   }
@@ -1867,6 +2071,10 @@ function getProjectMcpConfigPath(agentId: AgentId, cwd: string = process.cwd()):
       return path.join(cwd, '.grok', 'config.toml');
     case 'droid':
       return path.join(cwd, '.factory', 'mcp.json');
+    case 'hermes':
+      return path.join(cwd, '.hermes', 'config.yaml');
+    case 'forge':
+      return path.join(cwd, '.mcp.json');
     default:
       return path.join(cwd, `.${agentId}`, 'settings.json');
   }
@@ -1929,6 +2137,8 @@ export function parseMcpConfig(agentId: AgentId, configPath: string): Record<str
       return parseMcpFromOpenCodeConfig(configPath);
     case 'openclaw':
       return parseMcpFromOpenClawConfig(configPath);
+    case 'hermes':
+      return parseMcpFromYamlConfig(configPath);
     default:
       return parseMcpFromJsonConfig(configPath);
   }
@@ -2024,6 +2234,12 @@ export const AGENT_NAME_ALIASES: Record<string, AgentId> = {
   'kimi-code': 'kimi',
   factory: 'droid',
   'factory-ai': 'droid',
+  droid: 'droid',
+  hermes: 'hermes',
+  'hermes-agent': 'hermes',
+  forge: 'forge',
+  forgecode: 'forge',
+  'forge-code': 'forge',
 };
 
 /**

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -590,6 +590,21 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
     jsonFlags: ['-o', 'stream-json'],
     modelFlag: '-m',
   },
+  hermes: {
+    base: ['hermes', 'chat'],
+    promptFlag: 'positional',
+    modeFlags: {
+      edit: [],
+    },
+    modelFlag: '--model',
+  },
+  forge: {
+    base: ['forge'],
+    promptFlag: 'positional',
+    modeFlags: {
+      edit: [],
+    },
+  },
 };
 
 /**

--- a/apps/cli/src/lib/mcp.ts
+++ b/apps/cli/src/lib/mcp.ts
@@ -353,6 +353,25 @@ function registerMcpCommand(
 ): { success: boolean; error?: string } {
   try {
     validateMcpServerName(name);
+    if (agentId === 'hermes' || agentId === 'forge') {
+      const server: InstalledMcpServer = {
+        name,
+        path: '',
+        config: {
+          name,
+          transport: transport === 'http' ? 'http' : 'stdio',
+          ...(transport === 'http'
+            ? { url: commandSpec.command }
+            : { command: commandSpec.command, args: commandSpec.args }),
+        },
+      };
+      if (agentId === 'hermes') {
+        installMcpToHermesConfig(server, options.home || os.homedir());
+      } else {
+        installMcpToForgeConfig(server, options.home || os.homedir());
+      }
+      return { success: true };
+    }
     const bin = options.binary || AGENTS[agentId].cliCommand;
     const commandArgs = [commandSpec.command, ...commandSpec.args];
     const args = agentId === 'claude'
@@ -494,6 +513,67 @@ function installMcpToFactoryConfig(server: InstalledMcpServer, versionHome: stri
   fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
 }
 
+function installMcpToHermesConfig(server: InstalledMcpServer, versionHome: string): void {
+  const configPath = path.join(versionHome, '.hermes', 'config.yaml');
+
+  let config: Record<string, unknown> = {};
+  if (fs.existsSync(configPath)) {
+    const parsed = yaml.parse(fs.readFileSync(configPath, 'utf-8'));
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      config = parsed as Record<string, unknown>;
+    }
+  }
+
+  if (!config.mcp_servers || typeof config.mcp_servers !== 'object' || Array.isArray(config.mcp_servers)) {
+    config.mcp_servers = {};
+  }
+
+  const mcpServers = config.mcp_servers as Record<string, unknown>;
+  if (server.config.transport === 'stdio') {
+    mcpServers[server.name] = {
+      command: server.config.command,
+      args: server.config.args || [],
+      ...(server.config.env && { env: server.config.env }),
+    };
+  } else {
+    mcpServers[server.name] = {
+      url: server.config.url,
+    };
+  }
+
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, yaml.stringify(config), 'utf-8');
+}
+
+function installMcpToForgeConfig(server: InstalledMcpServer, versionHome: string): void {
+  const configPath = path.join(versionHome, '.forge', '.mcp.json');
+
+  let config: Record<string, unknown> = {};
+  if (fs.existsSync(configPath)) {
+    config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  }
+
+  if (!config.mcpServers || typeof config.mcpServers !== 'object' || Array.isArray(config.mcpServers)) {
+    config.mcpServers = {};
+  }
+
+  const mcpServers = config.mcpServers as Record<string, unknown>;
+  if (server.config.transport === 'stdio') {
+    mcpServers[server.name] = {
+      command: server.config.command,
+      args: server.config.args || [],
+      ...(server.config.env && { env: server.config.env }),
+    };
+  } else {
+    mcpServers[server.name] = {
+      url: server.config.url,
+    };
+  }
+
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
+}
+
 function installMcpToOpenCodeConfig(server: InstalledMcpServer, versionHome: string): void {
   const configPath = path.join(versionHome, '.opencode', 'opencode.jsonc');
 
@@ -594,6 +674,12 @@ export function installMcpServers(
         applied.push(server.name);
       } else if (agentId === 'droid') {
         installMcpToFactoryConfig(server, versionHome);
+        applied.push(server.name);
+      } else if (agentId === 'hermes') {
+        installMcpToHermesConfig(server, versionHome);
+        applied.push(server.name);
+      } else if (agentId === 'forge') {
+        installMcpToForgeConfig(server, versionHome);
         applied.push(server.name);
       }
     } catch (err) {

--- a/apps/cli/src/lib/resources/mcp.test.ts
+++ b/apps/cli/src/lib/resources/mcp.test.ts
@@ -62,6 +62,16 @@ describe('getMcpConfigPath', () => {
     expect(configPath).toBe(path.join('/home/user', '.openclaw', 'openclaw.json'));
   });
 
+  it('returns correct config path for Hermes', () => {
+    const configPath = getMcpConfigPath('hermes', '/home/user');
+    expect(configPath).toBe(path.join('/home/user', '.hermes', 'config.yaml'));
+  });
+
+  it('returns correct config path for ForgeCode', () => {
+    const configPath = getMcpConfigPath('forge', '/home/user');
+    expect(configPath).toBe(path.join('/home/user', '.forge', '.mcp.json'));
+  });
+
 });
 
 describe('McpHandler.format', () => {
@@ -79,6 +89,10 @@ describe('McpHandler.format', () => {
 
   it('returns json for Cursor', () => {
     expect(McpHandler.format('cursor')).toBe('json');
+  });
+
+  it('returns yaml for Hermes', () => {
+    expect(McpHandler.format('hermes')).toBe('yaml');
   });
 });
 

--- a/apps/cli/src/lib/resources/mcp.ts
+++ b/apps/cli/src/lib/resources/mcp.ts
@@ -158,6 +158,10 @@ export function getMcpConfigPath(agent: AgentId, versionHome: string): string | 
       return path.join(versionHome, '.gemini', 'antigravity-cli', 'mcp_config.json');
     case 'grok':
       return path.join(versionHome, '.grok', 'mcp.json');
+    case 'hermes':
+      return path.join(versionHome, '.hermes', 'config.yaml');
+    case 'forge':
+      return path.join(versionHome, '.forge', '.mcp.json');
     default:
       return null;
   }
@@ -320,6 +324,40 @@ function syncToGrokConfig(configPath: string, items: McpItem[]): void {
 
   fs.mkdirSync(path.dirname(configPath), { recursive: true });
   fs.writeFileSync(configPath, TOML.stringify(config), 'utf-8');
+}
+
+function syncToHermesConfig(configPath: string, items: McpItem[]): void {
+  let config: Record<string, unknown> = {};
+  if (fs.existsSync(configPath)) {
+    try {
+      const parsed = yaml.parse(fs.readFileSync(configPath, 'utf-8'));
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        config = parsed as Record<string, unknown>;
+      }
+    } catch {
+      config = {};
+    }
+  }
+
+  const mcpServers: Record<string, unknown> = {};
+  for (const item of items) {
+    if (item.transport === 'stdio') {
+      mcpServers[item.name] = {
+        command: item.command,
+        args: item.args || [],
+        ...(item.env && { env: item.env }),
+      };
+    } else {
+      mcpServers[item.name] = {
+        url: item.url,
+      };
+    }
+  }
+
+  config.mcp_servers = mcpServers;
+
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, yaml.stringify(config), 'utf-8');
 }
 
 /**
@@ -575,6 +613,12 @@ export const McpHandler: ResourceHandler<McpItem> = {
       case 'grok':
         syncToGrokConfig(configPath, mcpItems);
         break;
+      case 'hermes':
+        syncToHermesConfig(configPath, mcpItems);
+        break;
+      case 'forge':
+        syncToCursorConfig(configPath, mcpItems);
+        break;
     }
   },
 
@@ -583,6 +627,8 @@ export const McpHandler: ResourceHandler<McpItem> = {
       case 'codex':
       case 'grok':
         return 'toml';
+      case 'hermes':
+        return 'yaml';
       default:
         return 'json';
     }

--- a/apps/cli/src/lib/resources/types.ts
+++ b/apps/cli/src/lib/resources/types.ts
@@ -6,7 +6,7 @@
  * - Override on name conflict: Higher layer wins (project > user > system)
  */
 
-export type AgentId = 'claude' | 'codex' | 'gemini' | 'cursor' | 'opencode' | 'openclaw' | 'antigravity' | 'grok' | 'kimi';
+export type AgentId = 'claude' | 'codex' | 'gemini' | 'cursor' | 'opencode' | 'openclaw' | 'antigravity' | 'grok' | 'kimi' | 'hermes' | 'forge';
 export type Layer = 'system' | 'user' | 'project';
 export type ResourceKind = 'command' | 'hook' | 'skill' | 'rule' | 'mcp' | 'permission' | 'subagent' | 'workflow' | 'memory';
 

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -9,7 +9,7 @@
 import type { CloudProviderId } from './cloud/types.js';
 
 /** Unique identifier for a supported AI coding agent. */
-export type AgentId = 'claude' | 'codex' | 'gemini' | 'cursor' | 'opencode' | 'openclaw' | 'copilot' | 'amp' | 'kiro' | 'goose' | 'antigravity' | 'grok' | 'kimi' | 'droid';
+export type AgentId = 'claude' | 'codex' | 'gemini' | 'cursor' | 'opencode' | 'openclaw' | 'copilot' | 'amp' | 'kiro' | 'goose' | 'antigravity' | 'grok' | 'kimi' | 'droid' | 'hermes' | 'forge';
 
 /** How `agents run <agent>` chooses an installed version when none is pinned. */
 export type RunStrategy = 'pinned' | 'available' | 'balanced';

--- a/apps/cli/tests/agents.test.ts
+++ b/apps/cli/tests/agents.test.ts
@@ -108,6 +108,76 @@ describe('droid (Factory AI)', () => {
   });
 });
 
+describe('Hermes and ForgeCode install targets', () => {
+  it('registers Hermes with skills, MCP, and MEMORY.md rules', () => {
+    expect(ALL_AGENT_IDS).toContain('hermes');
+    expect(capableAgents('mcp')).toContain('hermes');
+    expect(capableAgents('skills')).toContain('hermes');
+    expect(capableAgents('commands')).not.toContain('hermes');
+    expect(capableAgents('hooks')).not.toContain('hermes');
+    expect(AGENTS.hermes.instructionsFile).toBe('MEMORY.md');
+    expect(AGENTS.hermes.capabilities.rules).toEqual({ file: 'MEMORY.md' });
+  });
+
+  it('resolves Hermes MCP config to ~/.hermes/config.yaml and parses mcp_servers YAML', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-hermes-mcp-'));
+    try {
+      const configPath = getMcpConfigPathForHome('hermes', home);
+      expect(configPath).toBe(path.join(home, '.hermes', 'config.yaml'));
+
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(
+        configPath,
+        [
+          'model: openrouter/anthropic/claude-sonnet-4',
+          'mcp_servers:',
+          '  ctx:',
+          '    command: ctx-server',
+          '    args:',
+          '      - --stdio',
+          '',
+        ].join('\n')
+      );
+
+      const parsed = parseMcpConfig('hermes', configPath);
+      expect(parsed.ctx.command).toBe('ctx-server');
+      expect(parsed.ctx.args).toEqual(['--stdio']);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('registers ForgeCode with skills, MCP, and AGENTS.md rules', () => {
+    expect(ALL_AGENT_IDS).toContain('forge');
+    expect(capableAgents('mcp')).toContain('forge');
+    expect(capableAgents('skills')).toContain('forge');
+    expect(capableAgents('commands')).not.toContain('forge');
+    expect(capableAgents('hooks')).not.toContain('forge');
+    expect(AGENTS.forge.instructionsFile).toBe('AGENTS.md');
+    expect(AGENTS.forge.capabilities.rules).toEqual({ file: 'AGENTS.md' });
+  });
+
+  it('resolves ForgeCode MCP config to ~/.forge/.mcp.json and parses mcpServers JSON', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-forge-mcp-'));
+    try {
+      const configPath = getMcpConfigPathForHome('forge', home);
+      expect(configPath).toBe(path.join(home, '.forge', '.mcp.json'));
+
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({ mcpServers: { ctx: { command: 'ctx-server', args: ['--stdio'] } } })
+      );
+
+      const parsed = parseMcpConfig('forge', configPath);
+      expect(parsed.ctx.command).toBe('ctx-server');
+      expect(parsed.ctx.args).toEqual(['--stdio']);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('codex subagents (TOML custom agents)', () => {
   it('is capable of subagents since 0.117.0', () => {
     expect(capableAgents('subagents')).toContain('codex');


### PR DESCRIPTION
## What
- Add `hermes` and `forge` to the CLI `AgentId` union and `AGENTS` registry with skills, rules, MCP, and run-template metadata.
- Add direct MCP config writers/parsers so Hermes and ForgeCode do not require their CLIs to be installed before `agents mcp register` can write config.
- Update the existing capability/resource-sync docs and changelog for the new user-visible targets.

## Why
RUSH-559 noted Hermes was only a session source, not an install/resource-sync target. ForgeCode is included in the same wave after checking current primary docs: ForgeCode installs as `forge`, reads `AGENTS.md`, supports `SKILL.md`, and uses `.mcp.json` with `mcpServers`.

## Evidence
- `AgentId` includes `hermes` and `forge`: `apps/cli/src/lib/types.ts:12`.
- Hermes registry maps CLI/config/skills/rules/capabilities: `apps/cli/src/lib/agents.ts:616`.
- ForgeCode registry maps CLI/config/skills/rules/capabilities: `apps/cli/src/lib/agents.ts:651`.
- `registerMcp` bypasses CLI-installed checks for direct Hermes/Forge config writes: `apps/cli/src/lib/agents.ts:1516`.
- Hermes writes YAML `mcp_servers` in `~/.hermes/config.yaml`: `apps/cli/src/lib/agents.ts:1729`, `apps/cli/src/lib/mcp.ts:516`, `apps/cli/src/lib/resources/mcp.ts:329`.
- ForgeCode writes JSON `mcpServers` in `~/.forge/.mcp.json`: `apps/cli/src/lib/agents.ts:1740`, `apps/cli/src/lib/mcp.ts:548`, `apps/cli/src/lib/resources/mcp.ts:619`.
- MCP path/parser tests cover both new targets: `apps/cli/tests/agents.test.ts:111`, `apps/cli/src/lib/resources/mcp.test.ts:60`.
- Docs/changelog updated: `apps/cli/docs/00-concepts.md:149`, `apps/cli/docs/02-resource-sync.md:133`, `apps/cli/CHANGELOG.md:5`.

Primary-source checks used:
- Hermes config docs: https://hermes-agent.nousresearch.com/docs/user-guide/configuration
- Hermes MCP docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp
- ForgeCode install docs: https://forgecode.dev/docs/
- ForgeCode MCP docs: https://forgecode.dev/docs/mcp-integration/
- ForgeCode skills docs: https://forgecode.dev/docs/skills/
- ForgeCode AGENTS.md docs: https://forgecode.dev/docs/custom-rules/

## Verification
- `PATH="$HOME/.bun/bin:$PATH" bun test tests/agents.test.ts src/lib/resources/mcp.test.ts src/lib/mcp.test.ts` -> 72 pass, 0 fail.
- `PATH="$HOME/.bun/bin:$PATH" bun run build` -> passed.
- CLI probe in an isolated HOME with no `hermes` or `forge` binaries installed:
  - `node dist/index.js mcp add ctx node server.js --agents hermes,forge --scope user`
  - `node dist/index.js mcp register ctx --agents hermes,forge`
  - Output reported `+ Hermes` and `+ ForgeCode`.
  - Wrote `~/.hermes/config.yaml` with `mcp_servers.ctx.command: node` and `args: [server.js]`.
  - Wrote `~/.forge/.mcp.json` with `mcpServers.ctx.command: node` and `args: [server.js]`.