### PR TITLE
RUSH-1630: include repository identity in PR outcome keys

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **PR outcome keys include repository identity (RUSH-1630).** Full GitHub pull URLs normalize to `owner/repo#N` so two repos' PR #10 no longer collide under `pr:#10`. Source: `apps/cli/src/lib/feed-outcome.ts`.
+
 - **Urgent OpenClaw notifications use `--target` and `--message` (RUSH-1620).** `openclaw message send` requires a destination and the `--message` flag (not `--text`); without `--target` the send was invalid. Source: `apps/cli/src/lib/notify.ts`.
 - **High-consequence answers require env-proven operator identity (RUSH-1619).** `agents message --as <id>` alone is not verification; `AGENTS_OPERATOR_ID` must match the claimed id (and the id must be in `operators.yaml`). Source: `apps/cli/src/lib/operator.ts`, `apps/cli/src/commands/message.ts`.
 - **OpenCode plugin install only writes loader-visible direct `.ts`/`.js` files (RUSH-1617).** Drop nested and `.mjs`/`.cjs` installs that OpenCode never scans; multi-module plugins flatten into `~/.config/opencode/plugins/`. Source: `apps/cli/src/lib/plugins.ts`.

--- a/apps/cli/src/lib/feed-outcome.test.ts
+++ b/apps/cli/src/lib/feed-outcome.test.ts
@@ -41,7 +41,7 @@ describe('normalizeTicketRef / normalizePrRef', () => {
     expect(normalizePrRef('#534')).toBe('#534');
     expect(normalizePrRef('PR#534')).toBe('#534');
     expect(normalizePrRef('pr 534')).toBe('#534');
-    expect(normalizePrRef('https://github.com/phnx-labs/agents-cli/pull/534')).toBe('#534');
+    expect(normalizePrRef('https://github.com/phnx-labs/agents-cli/pull/534')).toBe('phnx-labs/agents-cli#534');
   });
 });
 
@@ -87,7 +87,19 @@ describe('deriveOutcome', () => {
     expect(deriveOutcome({ text: 'merge #534?' }).label).toBe('PR#534');
     expect(deriveOutcome({
       text: 'see https://github.com/phnx-labs/agents-cli/pull/999',
-    }).label).toBe('PR#999');
+    })).toEqual({
+      key: 'pr:phnx-labs/agents-cli#999',
+      kind: 'pr',
+      label: 'PR phnx-labs/agents-cli#999',
+    });
+  });
+
+  it('keys PR outcomes by owner/repo when URL is known (RUSH-1630)', () => {
+    const a = deriveOutcome({ pr: 'https://github.com/phnx-labs/agents-cli/pull/10' });
+    const b = deriveOutcome({ pr: 'https://github.com/other/repo/pull/10' });
+    expect(a.key).toBe('pr:phnx-labs/agents-cli#10');
+    expect(b.key).toBe('pr:other/repo#10');
+    expect(a.key).not.toBe(b.key);
   });
 });
 

--- a/apps/cli/src/lib/feed-outcome.ts
+++ b/apps/cli/src/lib/feed-outcome.ts
@@ -52,16 +52,31 @@ const UNASSIGNED: OutcomeRef = {
   label: 'Unassigned',
 };
 
-/** `#123`, `PR#123`, `PR 123`, full GitHub pull URL → canonical `#123`. */
+/**
+ * Normalize a PR ref.
+ * - Full GitHub URL → `owner/repo#N` (repo identity included)
+ * - Bare `#123` / `PR#123` → `#123` (no repo known)
+ */
 export function normalizePrRef(raw: string | null | undefined): string | undefined {
   if (!raw) return undefined;
   const trimmed = raw.trim();
   if (!trimmed) return undefined;
   const fromUrl = extractPrUrl(trimmed);
-  if (fromUrl?.number != null) return `#${fromUrl.number}`;
+  if (fromUrl?.number != null) {
+    const repo = repoFromPrUrl(fromUrl.url);
+    return repo ? `${repo}#${fromUrl.number}` : `#${fromUrl.number}`;
+  }
   const m = /(?:^|\bpr\s*#?\s*|pull\/|#)(\d{1,7})\b/i.exec(trimmed);
   if (m) return `#${m[1]}`;
   return undefined;
+}
+
+/** `https://github.com/owner/repo/pull/N` → `owner/repo`. */
+export function repoFromPrUrl(url: string | null | undefined): string | undefined {
+  if (!url) return undefined;
+  const m = /github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/\d+/i.exec(url);
+  if (!m) return undefined;
+  return `${m[1]}/${m[2]}`;
 }
 
 /** Canonical ticket id (uppercase team key). */
@@ -85,8 +100,11 @@ function prFromSignals(s: OutcomeSignals): string | undefined {
   const direct = normalizePrRef(s.pr ?? undefined);
   if (direct) return direct;
   if (s.text) {
+    // Prefer full URL so keys include owner/repo (RUSH-1630).
     const fromUrl = extractPrUrl(s.text);
-    if (fromUrl?.number != null) return `#${fromUrl.number}`;
+    if (fromUrl?.number != null) {
+      return normalizePrRef(fromUrl.url) ?? `#${fromUrl.number}`;
+    }
     const m = /(?:\bpr\s*#?\s*|#)(\d{1,7})\b/i.exec(s.text);
     if (m) return `#${m[1]}`;
   }
@@ -105,8 +123,11 @@ export function deriveOutcome(signals: OutcomeSignals): OutcomeRef {
 
   const pr = prFromSignals(signals);
   if (pr) {
-    const n = pr.replace(/^#/, '');
-    return { key: `pr:${pr}`, kind: 'pr', label: `PR#${n}` };
+    // pr is either `owner/repo#N` or `#N`
+    const hash = pr.includes('#') ? pr.slice(pr.indexOf('#')) : pr;
+    const n = hash.replace(/^#/, '');
+    const label = pr.includes('/') ? `PR ${pr}` : `PR#${n}`;
+    return { key: `pr:${pr}`, kind: 'pr', label };
   }
 
   const wt = (signals.worktreeSlug ?? '').trim();


### PR DESCRIPTION
Serial land on latest main. Closes RUSH-1630.