### PR TITLE
RUSH-1595: switch routines default permission mode to auto

### DIFF
--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -339,7 +339,7 @@ export function registerRoutinesCommands(program: Command): void {
     .option('-a, --agent <agent>', 'Which agent runs this routine: claude, codex, gemini, cursor, or opencode')
     .option('--workflow <name>', 'Run an installed workflow (~/.agents/workflows/<name>) via `agents run`. Mutually exclusive with --agent.')
     .option('-p, --prompt <prompt>', 'Task instruction for the agent')
-    .option('-m, --mode <mode>', "Execution mode: plan (read-only), edit (can write files), auto (smart classifier), or skip (bypass all permission prompts). 'full' accepted as alias for skip.", 'plan')
+    .option('-m, --mode <mode>', "Execution mode: plan (read-only), edit (can write files), auto (smart classifier), or skip (bypass all permission prompts). 'full' accepted as alias for skip.", 'auto')
     .option('-e, --effort <effort>', 'Reasoning effort: low | medium | high | xhigh | max | auto', 'auto')
     .option('-t, --timeout <timeout>', 'Kill the agent if it runs longer than this (e.g., 10m, 2h, 3d, 1w; max 1w)', '10m')
     .option('--timezone <tz>', 'Interpret schedule in this timezone (e.g., America/Los_Angeles)')
@@ -462,7 +462,7 @@ export function registerRoutinesCommands(program: Command): void {
         }
 
         const config: JobConfig = {
-          mode: 'plan',
+          mode: 'auto',
           effort: 'auto',
           timeout: '10m',
           enabled: true,

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -121,7 +121,7 @@ export interface RunMeta {
 
 /** Default values applied to every job config when fields are omitted. */
 const JOB_DEFAULTS: Partial<JobConfig> = {
-  mode: 'plan',
+  mode: 'auto',
   effort: 'auto',
   timeout: '10m',
   enabled: true,
@@ -207,7 +207,7 @@ export function writeJob(config: JobConfig): void {
   const filePath = safeJoin(jobsDir, config.name + '.yml');
 
   const output: Record<string, unknown> = { ...config };
-  if (output.mode === 'plan') delete output.mode;
+  if (output.mode === 'auto') delete output.mode;
   if (output.effort === 'auto') delete output.effort;
   if (output.timeout === '10m') delete output.timeout;
   if (output.enabled === true) delete output.enabled;

--- a/apps/cli/tests/jobs.test.ts
+++ b/apps/cli/tests/jobs.test.ts
@@ -254,7 +254,7 @@ describe('job CRUD', () => {
       prompt: 'do something',
     } as JobConfig);
     const job = readJob(`${PREFIX}crud-defaults`)!;
-    expect(job.mode).toBe('plan');
+    expect(job.mode).toBe('auto');
     expect(job.effort).toBe('auto');
     expect(job.timeout).toBe('10m');
     expect(job.enabled).toBe(true);


### PR DESCRIPTION
## Summary

- Changes `JOB_DEFAULTS.mode` from `plan` to `auto` so new routines without an explicit `mode:` field run with the smart classifier by default instead of read-only
- Updates `writeJob` to strip `auto` (new default) from YAML output instead of `plan`, so the serialized YAML stays clean
- Updates the `routines add --mode` flag default and the inline load-from-YAML defaults to match
- Updates the `jobs.test.ts` expected default assertion to `auto`

Fixes the kimi breakage (runner.ts throws when kimi is run in plan mode — auto is the minimum viable mode).

## Test plan

- [ ] `bun test tests/jobs.test.ts tests/runner.test.ts tests/scheduler.test.ts tests/run-defaults-command.test.ts` — 76 pass
- [ ] Existing routines stored without a `mode:` field will now default to `auto` (intentional behavior change per decision in RUSH-1595)
- [ ] Routines explicitly setting `mode: plan` in YAML are unaffected

Closes RUSH-1595