### PR TITLE
RUSH-1618: use canonical operator registry for feed authorization

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Feed high-consequence authz uses the canonical operator registry (RUSH-1618).** `recordAnswer` no longer looks for `operators.yaml` under the feed root; it resolves operators from `~/.agents/` via `loadOperators()`. Source: `apps/cli/src/lib/feed.ts`.
 - **Menu bar groups worktree sessions under the real repo name (RUSH-1635).** Paths under `.agents/worktrees/<slug>` use the enclosing repository directory as the grouping key instead of the worktree slug. Source: `apps/cli/menubar/.../LocalState.swift`.
 
 - **PR outcome keys include repository identity (RUSH-1630).** Full GitHub pull URLs normalize to `owner/repo#N` so two repos' PR #10 no longer collide under `pr:#10`. Source: `apps/cli/src/lib/feed-outcome.ts`.

--- a/apps/cli/src/lib/feed.test.ts
+++ b/apps/cli/src/lib/feed.test.ts
@@ -430,6 +430,8 @@ describe('feed store', () => {
 
   it('recordAnswer refuses unverified answers to high-consequence blocks', () => {
     const dir = tmpFeedDir();
+    // operators.yaml under the feed root must NOT authorize (RUSH-1618) —
+    // the registry lives at ~/.agents/operators.yaml only.
     fs.writeFileSync(path.join(dir, 'operators.yaml'), 'operators:\n  muqsit:\n    admin: true\n', 'utf-8');
     publishBlock(makeBlock('sess-authz', 'Deploy to prod?', {
       consequence: 'merge',
@@ -443,8 +445,35 @@ describe('feed store', () => {
       expect('unauthorized' in unverified).toBe(true);
     }
 
-    const verified = recordAnswer(blockId, { answeredFrom: 'feed', answeredBy: 'Muqsit', operatorId: 'muqsit', verified: true }, dir);
-    expect(verified.ok).toBe(true);
+    // verified:false still refused even with a known-looking operatorId.
+    const claimed = recordAnswer(blockId, {
+      answeredFrom: 'feed',
+      answeredBy: 'Muqsit',
+      operatorId: 'muqsit',
+      verified: false,
+    }, dir);
+    expect(claimed.ok).toBe(false);
+  });
+
+  it('recordAnswer ignores operators.yaml colocated with the feed store (RUSH-1618)', () => {
+    const dir = tmpFeedDir();
+    // Only the feed root has operators.yaml — the canonical registry is separate.
+    // Claiming verified:true for an id that exists ONLY here must still fail
+    // when that id is not in the real ~/.agents registry. Use a unique id.
+    fs.writeFileSync(
+      path.join(dir, 'operators.yaml'),
+      'operators:\n  feed-only-operator-xyz:\n    admin: true\n',
+      'utf-8',
+    );
+    publishBlock(makeBlock('sess-authz-feed', 'Deploy?', { consequence: 'merge' }), dir);
+    const blockId = blockIdForSession('sess-authz-feed');
+    const result = recordAnswer(blockId, {
+      answeredFrom: 'feed',
+      operatorId: 'feed-only-operator-xyz',
+      verified: true,
+    }, dir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect('unauthorized' in result).toBe(true);
   });
 
   it('recordAnswer permits any answer to normal-consequence blocks', () => {

--- a/apps/cli/src/lib/feed.ts
+++ b/apps/cli/src/lib/feed.ts
@@ -173,7 +173,8 @@ export function recordAnswer(
   const operatorId = answer.operatorId;
 
   if (block?.consequence && block.consequence !== 'normal') {
-    if (!operatorId || answer.verified !== true || !isHighConsequenceAllowed(block.consequence, operatorId, dir)) {
+    // Operators live in ~/.agents/operators.yaml — never the feed store root.
+    if (!operatorId || answer.verified !== true || !isHighConsequenceAllowed(block.consequence, operatorId)) {
       return {
         ok: false,
         unauthorized: true,


### PR DESCRIPTION
Reland after flaky CI. Closes RUSH-1618.