### PR TITLE
RUSH-1621: preserve unmanaged native memory files during sync

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Native memory sync preserves unmanaged Markdown files (RUSH-1621).** Sync tracks managed fact names in `.agents-cli-memory.json` and only deletes those; user-authored `*.md` under the agent memory dir survive. Source: `apps/cli/src/lib/memory.ts`.
 - **Feed high-consequence authz uses the canonical operator registry (RUSH-1618).** `recordAnswer` no longer looks for `operators.yaml` under the feed root; it resolves operators from `~/.agents/` via `loadOperators()`. Source: `apps/cli/src/lib/feed.ts`.
 - **Menu bar groups worktree sessions under the real repo name (RUSH-1635).** Paths under `.agents/worktrees/<slug>` use the enclosing repository directory as the grouping key instead of the worktree slug. Source: `apps/cli/menubar/.../LocalState.swift`.
 

--- a/apps/cli/src/lib/memory.test.ts
+++ b/apps/cli/src/lib/memory.test.ts
@@ -95,4 +95,25 @@ describe('memory resource (RUSH-1330)', () => {
     expect(fs.readFileSync(target, 'utf-8')).toContain('Always run tests');
     expect(fs.existsSync(path.join(versionHome, memoryTargetDir('claude'), 'MEMORY.md'))).toBe(true);
   });
+
+  it('preserves unmanaged native memory markdown during sync (RUSH-1621)', () => {
+    const home = makeTempHome();
+    runMemory(home, `memory.addMemoryFact('team-conventions', 'Always run tests before push')`);
+    const versionHome = path.join(home, 'version-home');
+    const targetDir = path.join(versionHome, memoryTargetDir('claude'));
+    fs.mkdirSync(targetDir, { recursive: true });
+    const userFact = path.join(targetDir, 'my-personal-notes.md');
+    fs.writeFileSync(userFact, '# personal notes\nkeep me\n', 'utf-8');
+
+    runMemory(
+      home,
+      `memory.syncMemoryToVersionHome('claude', ${JSON.stringify(versionHome)}, ${JSON.stringify(home)})`,
+    );
+
+    expect(fs.existsSync(userFact)).toBe(true);
+    expect(fs.readFileSync(userFact, 'utf-8')).toContain('keep me');
+    expect(fs.existsSync(path.join(targetDir, 'team-conventions.md'))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, '.agents-cli-memory.json'))).toBe(true);
+  });
+
 });

--- a/apps/cli/src/lib/memory.ts
+++ b/apps/cli/src/lib/memory.ts
@@ -244,14 +244,26 @@ export function syncMemoryToVersionHome(
   const targetDir = path.join(versionHome, targetRel);
   fs.mkdirSync(targetDir, { recursive: true });
 
-  // Clear previous managed fact files (keep non-.md).
+  // Managed manifest tracks which fact files *we* wrote. On sync we only
+  // remove previously-managed names that are no longer in the canonical set —
+  // never wipe every .md (user-authored native memory must survive).
+  const managedManifestPath = path.join(targetDir, '.agents-cli-memory.json');
+  let previouslyManaged: string[] = [];
   try {
-    for (const entry of fs.readdirSync(targetDir)) {
-      if (entry.endsWith('.md')) {
-        try { fs.unlinkSync(path.join(targetDir, entry)); } catch { /* ignore */ }
-      }
+    const raw = JSON.parse(fs.readFileSync(managedManifestPath, 'utf-8')) as { facts?: unknown };
+    if (Array.isArray(raw.facts)) {
+      previouslyManaged = raw.facts.filter((f): f is string => typeof f === 'string');
     }
-  } catch { /* target missing */ }
+  } catch { /* missing or corrupt → treat as first managed sync */ }
+
+  const desiredNames = new Set(facts.map((f) => f.name));
+  const managedThisSync = new Set<string>(desiredNames);
+
+  for (const name of previouslyManaged) {
+    if (desiredNames.has(name)) continue;
+    if (name === 'MEMORY') continue; // index rewritten below
+    try { fs.unlinkSync(path.join(targetDir, `${name}.md`)); } catch { /* ignore */ }
+  }
 
   const written: string[] = [];
   for (const fact of facts) {
@@ -273,10 +285,20 @@ export function syncMemoryToVersionHome(
   if (indexSrc) {
     try {
       fs.copyFileSync(indexSrc, path.join(targetDir, 'MEMORY.md'));
+      managedThisSync.add('MEMORY');
     } catch { /* ignore */ }
   } else {
     rebuildMemoryIndex(targetDir);
+    managedThisSync.add('MEMORY');
   }
+
+  try {
+    fs.writeFileSync(
+      managedManifestPath,
+      JSON.stringify({ facts: [...managedThisSync].sort() }, null, 2) + '\n',
+      'utf-8',
+    );
+  } catch { /* best-effort */ }
 
   return written;
 }


### PR DESCRIPTION
Reland after flaky CI. Closes RUSH-1621.