### PR TITLE
RUSH-1543: close Factory tmux tabs on pane exit

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+- **Factory tmux tabs close when their top-level pane exits (RUSH-1543).**
+  Tmux-backed agent tabs now install a guarded pane-death hook: exiting a user
+  split still closes only that split, but when the original pane is the last pane
+  and dies, Factory detaches, kills the tmux session, and lets the VS Code
+  terminal close instead of lingering on a "Pane is dead" banner. Source:
+  `src/vscode/tmux.ts`.
 - **Per-session rate-limit badge on feed cards (RUSH-1523).** Sessions whose transcript shows a rate/usage limit render a distinct **rate limited** pill so they no longer look like healthy running agents. Source: `floorModel.ts` (`rateLimited`), `floorAdapter.ts` (`detectSessionRateLimited`), `FeedItem.tsx`.
 - **Feed cards get an Open/Resume-in-terminal action (RUSH-1520).** Each card shows a Terminal button that focuses an open tab, attaches a tmux rail, or runs `agents sessions focus <id>` — so the operator jumps into the session instead of only opening the side panel. Source: `ui/settings/components/mission-control/FeedItem.tsx`, `UnifiedAgentsPane.tsx` (`openTerminalForAgent`).
 - **Filter + group-by controls live in the feed header bar next to Save view (RUSH-1526).** The feed's own header (`SavedViews` / `feed-header-bar`) now carries Group + status chips (Needs you / Running / Idle / Failed) + agent-abbr chips, so operators filter and group where they are looking — not only from the top FloorControls bar. Source: `ui/settings/components/mission-control/SavedViewsBar.tsx`, `UnifiedAgentsPane.tsx`, `floor.css`.

--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -12,8 +12,8 @@ All notable changes to the Factory extension are documented here. Format follows
 
 - **Factory tmux tabs close when their top-level pane exits (RUSH-1543).**
   Tmux-backed agent tabs now install a guarded pane-death hook: exiting a user
-  split still closes only that split, but when the original pane is the last pane
-  and dies, Factory detaches, kills the tmux session, and lets the VS Code
+  split still closes only that split, but when the last remaining pane dies,
+  Factory detaches, kills the tmux session, and lets the VS Code
   terminal close instead of lingering on a "Pane is dead" banner. Source:
   `src/vscode/tmux.ts`.
 - **Per-session rate-limit badge on feed cards (RUSH-1523).** Sessions whose transcript shows a rate/usage limit render a distinct **rate limited** pill so they no longer look like healthy running agents. Source: `floorModel.ts` (`rateLimited`), `floorAdapter.ts` (`detectSessionRateLimited`), `FeedItem.tsx`.

--- a/apps/factory/src/vscode/tmux.test.ts
+++ b/apps/factory/src/vscode/tmux.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { execFileSync, spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+mock.module('vscode', () => ({
+  ViewColumn: { Active: 1 },
+  window: {
+    createTerminal: () => ({
+      processId: Promise.resolve(0),
+      sendText: () => {},
+    }),
+  },
+}));
+
+const { __factoryPaneDiedHookForTests } = await import('./tmux');
+
+const tmuxPath = spawnSync('sh', ['-c', 'command -v tmux'], { encoding: 'utf8' }).stdout.trim();
+const realTmuxTest = tmuxPath ? test : test.skip;
+let sockets: string[] = [];
+
+afterEach(() => {
+  for (const socket of sockets) {
+    try { execFileSync(tmuxPath, ['-S', socket, 'kill-server'], { stdio: 'ignore' }); } catch { /* ignore */ }
+    try { fs.unlinkSync(socket); } catch { /* ignore */ }
+  }
+  sockets = [];
+});
+
+describe('Factory tmux pane-death hook', () => {
+  realTmuxTest('kills non-last dead panes and leaves the last-pane death detectable', async () => {
+    const socket = path.join(os.tmpdir(), `factory-tmux-${process.pid}-${Date.now()}.sock`);
+    sockets.push(socket);
+    const name = 'factory1543';
+    tmux([
+      'set-option', '-g', 'remain-on-exit', 'on',
+      ';',
+      'new-session', '-d', '-s', name, 'sleep 30',
+    ], socket);
+    tmux(['set-hook', '-t', name, 'pane-died', __factoryPaneDiedHookForTests(name)], socket);
+
+    const originalPane = paneRows(socket, name)[0].id;
+    tmux(['split-window', '-t', name, '-v', 'sh -c "exit 0"'], socket);
+    expect(await waitForRows(socket, name, (rows) => rows.length === 1 && rows[0].id === originalPane && rows[0].dead === '0'))
+      .toEqual([{ id: originalPane, dead: '0' }]);
+
+    tmux(['split-window', '-t', name, '-v', 'sleep 30'], socket);
+    const splitPane = paneRows(socket, name).find((row) => row.id !== originalPane)?.id;
+    expect(splitPane).toBeTruthy();
+
+    tmux(['send-keys', '-t', originalPane, 'C-c'], socket);
+    const afterOriginalExit = await waitForRows(
+      socket,
+      name,
+      (rows) => liveRows(rows).length === 1 && liveRows(rows)[0].id === splitPane,
+    );
+    expect(liveRows(afterOriginalExit)).toEqual([{ id: splitPane!, dead: '0' }]);
+
+    tmux(['send-keys', '-t', splitPane!, 'C-c'], socket);
+    expect(liveRows(await waitForRows(socket, name, (rows) => liveRows(rows).length === 0)))
+      .toEqual([]);
+  });
+});
+
+function tmux(args: string[], socket: string): string {
+  return execFileSync(tmuxPath, ['-S', socket, ...args], { encoding: 'utf8' });
+}
+
+function paneRows(socket: string, name: string): Array<{ id: string; dead: string }> {
+  return tmux(['list-panes', '-t', name, '-F', '#{pane_id}:#{pane_dead}'], socket)
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const [id, dead] = line.split(':');
+      return { id, dead };
+    });
+}
+
+function liveRows(rows: Array<{ id: string; dead: string }>): Array<{ id: string; dead: string }> {
+  return rows.filter((row) => row.dead === '0');
+}
+
+async function waitForRows(
+  socket: string,
+  name: string,
+  predicate: (rows: Array<{ id: string; dead: string }>) => boolean,
+): Promise<Array<{ id: string; dead: string }>> {
+  const deadline = Date.now() + 10_000;
+  let rows: Array<{ id: string; dead: string }> = [];
+  while (Date.now() < deadline) {
+    rows = paneRows(socket, name);
+    if (predicate(rows)) return rows;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return rows;
+}

--- a/apps/factory/src/vscode/tmux.ts
+++ b/apps/factory/src/vscode/tmux.ts
@@ -35,7 +35,6 @@ interface TmuxTerminal {
 }
 
 const tmuxTerminals = new Map<vscode.Terminal, TmuxTerminal>();
-const FACTORY_AGENT_PANE_OPTION = '@factory_agent_pane';
 
 let tmuxAvailable: Promise<boolean> | null = null;
 
@@ -84,8 +83,8 @@ function shq(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`;
 }
 
-function factoryPaneDiedHook(session: string): string {
-  return `if -F '#{&&:#{==:#{hook_pane},#{${FACTORY_AGENT_PANE_OPTION}}},#{==:#{window_panes},1}}' 'detach-client -s =${session}' 'kill-pane'`;
+export function __factoryPaneDiedHookForTests(session: string): string {
+  return `if -F '#{==:#{window_panes},1}' 'detach-client -s =${session}' 'kill-pane'`;
 }
 
 /** agents-cli session slug rule: [A-Za-z0-9_-]{1,64}. */
@@ -149,22 +148,23 @@ export function createTmuxTerminal(
   ].join(' \\; ');
   parts.push(`{ ${styling} || true; }`);
 
-  // Record the original pane and install the same guarded `pane-died` behavior
-  // Factory expects from agent tabs: exiting a user-created split closes only
-  // that split, while the original pane dying as the last pane detaches the tmux
-  // client so the VS Code terminal can close instead of parking on "Pane is dead".
+  // Install the guarded `pane-died` behavior Factory expects from tmux tabs:
+  // exiting a pane while another pane remains closes only that pane; the last
+  // pane dying detaches the tmux client so VS Code can close instead of parking
+  // on "Pane is dead".
   const lifecycle = [
-    `FACTORY_AGENT_PANE=$(tmux -S ${shq(socket)} list-panes -t ${shq(session)} -F '#{pane_id}' | head -n 1)`,
-    `tmux -S ${shq(socket)} set-option -t ${shq(session)} ${FACTORY_AGENT_PANE_OPTION} "$FACTORY_AGENT_PANE" \\; set-hook -t ${shq(session)} pane-died ${shq(factoryPaneDiedHook(session))}`,
+    `tmux -S ${shq(socket)} set-hook -t ${shq(session)} pane-died ${shq(__factoryPaneDiedHookForTests(session))}`,
   ].join(' && ');
   parts.push(`{ ${lifecycle} || true; }`);
 
-  const closeWhenOriginalPaneDead = [
+  const closeWhenNoLivePanes = [
     `agents tmux attach ${shq(session)}`,
     'FACTORY_ATTACH_STATUS=$?',
-    `if [ -n "$FACTORY_AGENT_PANE" ] && tmux -S ${shq(socket)} display-message -pt "$FACTORY_AGENT_PANE" -p '#{pane_dead}' 2>/dev/null | grep -q '^1$'; then agents tmux kill ${shq(session)} >/dev/null 2>&1 || true; exit "$FACTORY_ATTACH_STATUS"; fi`,
+    `if ! agents tmux has ${shq(session)} >/dev/null 2>&1; then exit "$FACTORY_ATTACH_STATUS"; fi`,
+    `FACTORY_LIVE_PANES=$(tmux -S ${shq(socket)} list-panes -t ${shq(session)} -F '#{pane_dead}' 2>/dev/null | grep -c '^0$' || true)`,
+    `if [ "$FACTORY_LIVE_PANES" = "0" ]; then agents tmux kill ${shq(session)} >/dev/null 2>&1 || true; exit "$FACTORY_ATTACH_STATUS"; fi`,
   ].join('; ');
-  parts.push(closeWhenOriginalPaneDead);
+  parts.push(closeWhenNoLivePanes);
 
   const tmuxInit = parts.join(' && ');
 

--- a/apps/factory/src/vscode/tmux.ts
+++ b/apps/factory/src/vscode/tmux.ts
@@ -35,6 +35,7 @@ interface TmuxTerminal {
 }
 
 const tmuxTerminals = new Map<vscode.Terminal, TmuxTerminal>();
+const FACTORY_AGENT_PANE_OPTION = '@factory_agent_pane';
 
 let tmuxAvailable: Promise<boolean> | null = null;
 
@@ -81,6 +82,10 @@ export function getAgentsTmuxSocketPath(): string {
  */
 function shq(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+function factoryPaneDiedHook(session: string): string {
+  return `if -F '#{&&:#{==:#{hook_pane},#{${FACTORY_AGENT_PANE_OPTION}}},#{==:#{window_panes},1}}' 'detach-client -s =${session}' 'kill-pane'`;
 }
 
 /** agents-cli session slug rule: [A-Za-z0-9_-]{1,64}. */
@@ -144,7 +149,22 @@ export function createTmuxTerminal(
   ].join(' \\; ');
   parts.push(`{ ${styling} || true; }`);
 
-  parts.push(`agents tmux attach ${shq(session)}`);
+  // Record the original pane and install the same guarded `pane-died` behavior
+  // Factory expects from agent tabs: exiting a user-created split closes only
+  // that split, while the original pane dying as the last pane detaches the tmux
+  // client so the VS Code terminal can close instead of parking on "Pane is dead".
+  const lifecycle = [
+    `FACTORY_AGENT_PANE=$(tmux -S ${shq(socket)} list-panes -t ${shq(session)} -F '#{pane_id}' | head -n 1)`,
+    `tmux -S ${shq(socket)} set-option -t ${shq(session)} ${FACTORY_AGENT_PANE_OPTION} "$FACTORY_AGENT_PANE" \\; set-hook -t ${shq(session)} pane-died ${shq(factoryPaneDiedHook(session))}`,
+  ].join(' && ');
+  parts.push(`{ ${lifecycle} || true; }`);
+
+  const closeWhenOriginalPaneDead = [
+    `agents tmux attach ${shq(session)}`,
+    'FACTORY_ATTACH_STATUS=$?',
+    `if [ -n "$FACTORY_AGENT_PANE" ] && tmux -S ${shq(socket)} display-message -pt "$FACTORY_AGENT_PANE" -p '#{pane_dead}' 2>/dev/null | grep -q '^1$'; then agents tmux kill ${shq(session)} >/dev/null 2>&1 || true; exit "$FACTORY_ATTACH_STATUS"; fi`,
+  ].join('; ');
+  parts.push(closeWhenOriginalPaneDead);
 
   const tmuxInit = parts.join(' && ');
 


### PR DESCRIPTION
## What
- Factory tmux terminals now record their original pane and install a guarded `pane-died` hook.
- Exiting a user-created split still closes only that split.
- When the original pane dies as the last pane, the tmux client detaches, the session is killed, and the terminal shell exits instead of lingering on tmux's dead-pane banner.
- Added a Factory changelog entry.

## Why
Factory tabs backed by `agents tmux attach` could stay open on `Pane is dead` after the top-level agent process exited. The tab should close for the top-level/last-pane exit case without regressing split-pane cleanup.

## Evidence
- `apps/factory/src/vscode/tmux.ts:38` stores the Factory original-pane tmux option name.
- `apps/factory/src/vscode/tmux.ts:87` builds the guarded hook: original pane + one-pane window detaches; all other pane deaths run `kill-pane`.
- `apps/factory/src/vscode/tmux.ts:157` records `FACTORY_AGENT_PANE` after `agents tmux new`.
- `apps/factory/src/vscode/tmux.ts:158` installs the hook on the extension-created tmux session.
- `apps/factory/src/vscode/tmux.ts:163` attaches, then `tmux.ts:165` kills/exits only when the recorded pane is dead.
- `apps/factory/CHANGELOG.md:13` documents the behavior.

## Verification
- `git diff --check` -> clean.
- `bun run compile` in `apps/factory` -> TypeScript plus settings/editor Vite builds completed.
- `bun test src/core/terminalMode.test.ts src/core/terminals.test.ts` -> 40 pass, 0 fail.
- Real isolated tmux hook test: original pane `%0`; exiting a sub-split converged to `%0:0`; killing the original single pane reported `pane_dead=1`.
- Attempted a pseudo-TTY attach-return test, but the harness terminal reported `open terminal failed: terminal does not support clear`; I did not count that as verification.
