### PR TITLE
RUSH-1547: surface Linear artifacts in Factory

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+- **Factory Floor surfaces agent-created tickets as clickable Linear artifacts (RUSH-1547).**
+  Session cards and detail panes now render linked Linear badges for carried/created
+  ticket refs and include commit chips in the produced-artifacts row, so PRs,
+  tickets, teams, plans, and commits are visible without reading the transcript.
+  Source: `ui/settings/components/mission-control/FeedItem.tsx`,
+  `UnifiedAgentsPane.tsx`.
 - **Factory tmux tabs close when their top-level pane exits (RUSH-1543).**
   Tmux-backed agent tabs now install a guarded pane-death hook: exiting a user
   split still closes only that split, but when the last remaining pane dies,

--- a/apps/factory/ui/settings/components/mission-control/FeedItem.openTerminal.test.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FeedItem.openTerminal.test.tsx
@@ -94,3 +94,26 @@ describe('FeedItem open/resume terminal action (RUSH-1520)', () => {
     expect(html).toContain('open-term')
   })
 })
+
+describe('FeedItem produced artifacts (RUSH-1547)', () => {
+  test('renders linked Linear ticket refs and commit chips', () => {
+    const html = renderToStaticMarkup(
+      <FeedItem
+        agent={agent({
+          createdTickets: ['RUSH-1545'],
+          createdCommits: ['095e588093ca'],
+        })}
+        selected={false}
+        plain={false}
+        onSelect={noop}
+        onOption={noop}
+        onFreeText={noop}
+        onAttach={noop}
+        onOpenPlan={noop}
+      />,
+    )
+    expect(html).toContain('href="https://linear.app/issue/RUSH-1"')
+    expect(html).toContain('href="https://linear.app/issue/RUSH-1545"')
+    expect(html).toContain('095e588093ca')
+  })
+})

--- a/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
@@ -87,7 +87,7 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
   const wt = a.worktreeSlug || a.branch
   const meta = plain
     ? a.project
-    : `${a.project} · ${a.hostLabel ?? a.host}${a.ticket ? ` · ${a.ticket}` : ''}${filesLabel}${paneLabel}${viewingLabel}`
+    : `${a.project} · ${a.hostLabel ?? a.host}${filesLabel}${paneLabel}${viewingLabel}`
   const destructive = a.question?.kind === 'destructive'
   const attn = a.phase === 'failed' ? 'fail' : stalled ? 'stall' : a.needs ? 'attn' : ''
 

--- a/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FeedItem.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Icon } from './icons'
 import { AgentAvatar, agentIdFromPrefix } from './AgentAvatar'
 import { StructuredReply, type ReplyCallbacks } from './StructuredReply'
-import { heartbeatLevel, sessionTaskLine, type FloorAgent, type FloorTicket } from './floorModel'
+import { heartbeatLevel, linearIssueLabel, linearIssueUrl, sessionTaskLine, type FloorAgent, type FloorTicket } from './floorModel'
 import { sinceFromMs } from './floorAdapter'
 import { useNow } from './useNow'
 import { CardChecklist } from './TodoChecklist'
@@ -32,6 +32,14 @@ function firstLine(text: string): string {
 function plainTok(tok: number, plain: boolean): string {
   if (plain) return tok > 120 ? 'fast' : tok > 0 ? 'working' : ''
   return tok ? `${tok} tok/s` : ''
+}
+
+function TicketArtifact({ ticket, className }: { ticket: string; className: string }) {
+  const href = linearIssueUrl(ticket)
+  const label = linearIssueLabel(ticket)
+  return href
+    ? <ExtLink href={href} className={className} title={`Open ${label}`} style={{ textDecoration: 'none' }}><Icon name="plus" size={10} /> {label}</ExtLink>
+    : <span className={className} title={`Created ticket ${label}`}><Icon name="plus" size={10} /> {label}</span>
 }
 
 // Reply callbacks are agent-scoped (they take the FloorAgent, not a pre-bound closure)
@@ -138,6 +146,12 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
   const rateBadge = a.rateLimited
     ? <span className="pill rate" title="This session hit a rate or usage limit">rate limited</span>
     : null
+  const ticketHref = linearIssueUrl(a.ticket)
+  const ticketBadge = a.ticket
+    ? ticketHref
+      ? <ExtLink href={ticketHref} className="pill ticket" title={`Open ${linearIssueLabel(a.ticket)}`} style={{ textDecoration: 'none' }}>{linearIssueLabel(a.ticket)}</ExtLink>
+      : <span className="pill ticket">{linearIssueLabel(a.ticket)}</span>
+    : null
 
   return (
     <div
@@ -153,6 +167,7 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
         {!plain && wt && <span className="wtchip mono" title={a.worktreePath || wt}>{wt}</span>}
         <span className="when">
           {marker}
+          {ticketBadge}
           {bgBadge}
           {rateBadge}
           {ciBadge}
@@ -185,7 +200,7 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
       {a.resp && !(a.needs && a.question && a.question.kind !== 'retry' && a.question.text.trim() === a.resp.trim()) && (
         <div className={`resp${destructive ? ' q' : ''}`}>{renderMarkdown(a.resp, { clamp: true })}</div>
       )}
-      {!plain && (a.spawnedTeam || (a.createdTickets?.length ?? 0) > 0 || (a.plans?.length ?? 0) > 0) && (
+      {!plain && (a.spawnedTeam || (a.createdTickets?.length ?? 0) > 0 || (a.createdCommits?.length ?? 0) > 0 || (a.plans?.length ?? 0) > 0) && (
         <div className="artifacts" onClick={(e) => e.stopPropagation()}>
           {(a.plans ?? []).map((plan) => (
             <button
@@ -204,8 +219,11 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
             </span>
           )}
           {(a.createdTickets ?? []).map((t) => (
-            <span key={t} className="artifact ticket" title={`Created ticket ${t}`}>
-              <Icon name="plus" size={10} /> {t}
+            <TicketArtifact key={t} ticket={t} className="artifact ticket" />
+          ))}
+          {(a.createdCommits ?? []).map((sha) => (
+            <span key={sha} className="artifact commit" title={`Created commit ${sha}`}>
+              <Icon name="gitBranch" size={10} /> {sha}
             </span>
           ))}
         </div>

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -60,6 +60,8 @@ import {
   type CiStatus,
   type ManagedProject,
   type LinearProjectLite,
+  linearIssueLabel,
+  linearIssueUrl,
 } from './floorModel'
 import { SavedViews } from './SavedViewsBar'
 import { loadSavedViews, persistSavedViews, upsertView, removeView, viewMatches, type SavedView } from './savedViews'
@@ -1805,7 +1807,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               <div className="sub">host <b>{a.hostLabel ?? a.host}</b>{(a.worktreeSlug || a.branch) ? ` · ${a.worktreeSlug || a.branch}` : ''} · {a.phase}{a.tok ? ` · ${a.tok} tok/s` : ''}{a.ticket ? ` · ${a.ticket}` : ''}</div>
               {/* Artifacts row: the agent's outputs at a glance — the PR (click-through),
                   CI, the team it spawned, and tickets it created. Mirrors the card chips. */}
-              {(a.prUrl || a.ci || a.spawnedTeam || (a.createdTickets?.length ?? 0) > 0 || (a.plans?.length ?? 0) > 0) && (
+              {(a.prUrl || a.ci || a.spawnedTeam || (a.createdTickets?.length ?? 0) > 0 || (a.createdCommits?.length ?? 0) > 0 || (a.plans?.length ?? 0) > 0) && (
                 <div className="arts">
                   {(a.plans ?? []).map((plan) => (
                     <button
@@ -1825,8 +1827,15 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
                   )}
                   {a.ci && <span className={`art ci ${a.ci}`}>CI {a.ci}</span>}
                   {a.spawnedTeam && <span className="art team"><Icon name="grip" size={10} /> team · {a.spawnedTeam}</span>}
-                  {(a.createdTickets ?? []).map((t) => (
-                    <span key={t} className="art tk"><Icon name="plus" size={10} /> {t}</span>
+                  {(a.createdTickets ?? []).map((t) => {
+                    const href = linearIssueUrl(t)
+                    const label = linearIssueLabel(t)
+                    return href
+                      ? <ExtLink key={t} href={href} className="art tk" style={{ textDecoration: 'none' }}><Icon name="plus" size={10} /> {label}</ExtLink>
+                      : <span key={t} className="art tk"><Icon name="plus" size={10} /> {label}</span>
+                  })}
+                  {(a.createdCommits ?? []).map((sha) => (
+                    <span key={sha} className="art commit"><Icon name="gitBranch" size={10} /> commit {sha}</span>
                   ))}
                 </div>
               )}

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -226,6 +226,7 @@
 .swarmify-root .detail-col .art.ci.running { color: var(--status-pending); border-color: rgba(245,179,1,0.3); }
 .swarmify-root .detail-col .art.team { color: #b98cff; border-color: rgba(185,140,255,0.35); }
 .swarmify-root .detail-col .art.tk { color: var(--brand); border-color: var(--brand-ring); }
+.swarmify-root .detail-col .art.commit { color: var(--ds-text-muted); border-color: var(--ds-border-strong); }
 .swarmify-root .detail-col .art.plan { color: var(--brand-600); border-color: var(--brand-ring); cursor: pointer; }
 /* decision block at top of the right detail when an agent needs you */
 .swarmify-root .decide { background: var(--status-pending-bg); border: 1px solid var(--status-pending); border-radius: var(--r-lg); padding: 12px 14px; margin-bottom: 14px; }
@@ -263,6 +264,8 @@
 .swarmify-root .fitem .artifacts { display: flex; flex-wrap: wrap; gap: 5px; margin: 0 0 8px; }
 .swarmify-root .fitem .artifact { display: inline-flex; align-items: center; gap: 4px; font-size: 10px; font-weight: 600; padding: 1px 7px 1px 6px; border-radius: 999px; background: var(--status-running-bg); color: var(--status-running); border: 1px solid transparent; font-variant-numeric: tabular-nums; }
 .swarmify-root .fitem .artifact.team { background: var(--brand-ring); color: var(--brand); }
+.swarmify-root .fitem .artifact.ticket { background: var(--brand-ring); color: var(--brand); }
+.swarmify-root .fitem .artifact.commit { background: var(--ds-bg-recessed); color: var(--ds-text-muted); border-color: var(--ds-border); font-family: "Geist Mono", monospace; }
 .swarmify-root .fitem .artifact.plan { background: var(--ds-bg-recessed); color: var(--brand-600); border-color: var(--brand-ring); cursor: pointer; }
 .swarmify-root .fitem .summary { font-size: 12px; color: var(--ds-text-muted); line-height: 1.4; margin: 0 0 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .swarmify-root .fitem .nowline { font-family: "Geist Mono", monospace; font-size: 11px; color: var(--ds-text-muted); display: flex; align-items: center; gap: 8px; }
@@ -295,6 +298,7 @@
 @media (prefers-reduced-motion: reduce) { .swarmify-root .sw-todocheck-item.status-in_progress .sw-todocheck-mk::after { animation: none; } }
 .swarmify-root .pill { font-size: 10px; font-weight: 700; padding: 1px 7px; border-radius: 999px; }
 .swarmify-root .pill.pr { background: var(--brand); color: #1a1a1a; }
+.swarmify-root .pill.ticket { background: var(--brand-ring); color: var(--brand); }
 .swarmify-root .pill.run { background: var(--status-running-bg); color: var(--status-running); }
 .swarmify-root .pill.done { background: var(--status-idle-bg); color: var(--ds-text-muted); }
 .swarmify-root .pill.cipass { background: var(--status-running-bg); color: var(--status-running); }

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
@@ -10,6 +10,7 @@ import {
   toFloorAgentFromRemote,
   adaptTickets,
   cleanWorktreeSlug,
+  detectCreatedCommits,
   type UnifiedAgentLike,
   type RemoteSessionLike,
 } from './floorAdapter'
@@ -94,6 +95,22 @@ describe('floorPrLabel', () => {
   })
 })
 
+describe('detectCreatedCommits', () => {
+  test('extracts short commit shas from successful command output', () => {
+    expect(detectCreatedCommits([
+      { name: 'Bash', output: '[rush-1547-linear-artifacts 095e588093ca] RUSH-1547: surface ticket artifacts' },
+      { name: 'Bash', output: '[rush-1547-linear-artifacts 095e588093ca] duplicate line' },
+      { name: 'Bash', output: '[rush-1547-linear-artifacts 1111111] another change' },
+    ])).toEqual(['095e588093ca', '1111111'])
+  })
+
+  test('ignores failed command output', () => {
+    expect(detectCreatedCommits([
+      { name: 'Bash', output: '[rush-1547-linear-artifacts deadbee] failed change', isError: true },
+    ])).toEqual([])
+  })
+})
+
 function baseUnified(over: Partial<UnifiedAgentLike>): UnifiedAgentLike {
   return {
     id: 'term-1',
@@ -128,6 +145,22 @@ describe('toFloorAgentFromUnified', () => {
     expect(a.needs).toBe(true)
     expect(a.host).toBe('this-mac')
     expect(a.abbr).toBe('CC')
+  })
+
+  test('surfaces commit artifacts from recent terminal output', () => {
+    const a = toFloorAgentFromUnified(
+      baseUnified({
+        terminal: {
+          id: 't1',
+          recentToolCalls: [
+            { name: 'Bash', output: '[rush-1547-linear-artifacts abc1234] RUSH-1547: wire ticket links' },
+          ],
+        },
+        agent: null,
+      }),
+      { pinned: new Set(), workspaceRepo: 'agents-cli', nowMs: NOW },
+    )
+    expect(a.createdCommits).toEqual(['abc1234'])
   })
 
   test('a completed agent with a stale waiting flag lands in done, not needs-you (RUSH-1522)', () => {

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
@@ -39,6 +39,7 @@ import { detectPlanFiles, extractPlanCandidates, type PlanFile, type PlanFileCan
 // threading a store through every adapter call. Empty parses fall back to the remembered
 // set; a fresh non-empty parse overwrites it.
 const lastTodosById = new Map<string, TodoItem[]>()
+const GIT_COMMIT_OUTPUT_RE = /^\[[^\]\n]*\s([0-9a-f]{7,40})\]\s+(.+)$/gm
 
 /** Parse fresh todos, remembering the last non-empty set so the checklist doesn't vanish. */
 function stickyTodos(id: string, toolCalls: RecentToolCall[] | undefined): TodoItem[] {
@@ -238,6 +239,23 @@ function collectAttachmentPlanCandidates(attachments: AttachmentLike[] | undefin
   return out
 }
 
+export function detectCreatedCommits(toolCalls: RecentToolCall[] | undefined): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const call of toolCalls ?? []) {
+    if (call.isError || typeof call.output !== 'string') continue
+    GIT_COMMIT_OUTPUT_RE.lastIndex = 0
+    let match: RegExpExecArray | null
+    while ((match = GIT_COMMIT_OUTPUT_RE.exec(call.output)) !== null) {
+      const sha = match[1].slice(0, 12)
+      if (seen.has(sha)) continue
+      seen.add(sha)
+      out.push(sha)
+    }
+  }
+  return out
+}
+
 function detectUnifiedPlans(u: UnifiedAgentLike, worktreePath: string): PlanFile[] {
   const candidates: PlanFileCandidate[] = []
   candidates.push(...extractPlanCandidates(u.terminal?.narrative, 'output'))
@@ -413,6 +431,7 @@ export function toFloorAgentFromUnified(
   const project = deriveProject(u.terminal?.cwd ?? u.agent?.cwd, u.agent?.repo_name, opts.workspaceRepo || '—', opts.projectRules ?? [])
   const worktreePath = worktreeSlugOf(u.terminal?.cwd ?? u.agent?.cwd) ? (u.terminal?.cwd ?? u.agent?.cwd ?? '') : ''
   const plans = detectUnifiedPlans(u, worktreePath)
+  const createdCommits = detectCreatedCommits(u.terminal?.recentToolCalls)
   // Local unified agents ARE this window's terminal tabs, so sendText into the live
   // terminal is the exact reply channel; fall back to 'none' for a tab-less headless row.
   const reply: ReplyTarget = u.terminal?.id
@@ -447,6 +466,7 @@ export function toFloorAgentFromUnified(
     ci,
     ticket: u.linearIssue ?? null,
     createdTickets: u.createdTickets ?? [],
+    createdCommits,
     spawnedTeam: u.spawnedTeam || undefined,
     branch: u.terminal?.branch ?? u.agent?.branch ?? '',
     worktreeSlug: cleanWorktreeSlug(u.terminal?.cwd ?? u.agent?.cwd),
@@ -546,6 +566,7 @@ export function toFloorAgentFromRemote(r: RemoteSessionLike, pinned: Set<string>
     ci,
     ticket: r.ticket,
     createdTickets: r.createdTickets ?? [],
+    createdCommits: [],
     spawnedTeam: r.spawnedTeam || undefined,
     branch: r.branch,
     // Prefer the CLI-provided slug; strip any WT= / path leak from either source.

--- a/apps/factory/ui/settings/components/mission-control/floorModel.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.test.ts
@@ -24,6 +24,8 @@ import {
   resolveProject,
   sessionTaskLine,
   todosWithFallback,
+  linearIssueLabel,
+  linearIssueUrl,
   PHASE_RANK,
   STALL_THRESHOLD_MS,
   type FloorAgent,
@@ -75,6 +77,24 @@ describe('resolveProject', () => {
   test('no rules, no repoRoot -> legacy last-segment', () => {
     expect(resolveProject('/x/y/prix-api')).toBe('prix-api')
     expect(resolveProject('')).toBe('')
+  })
+})
+
+describe('Linear issue refs', () => {
+  test('builds a Linear URL from a ticket id', () => {
+    expect(linearIssueUrl('RUSH-1545')).toBe('https://linear.app/issue/RUSH-1545')
+    expect(linearIssueLabel('RUSH-1545')).toBe('RUSH-1545')
+  })
+
+  test('preserves a Linear issue URL and extracts the display id', () => {
+    const url = 'https://linear.app/getrush/issue/RUSH-1545/file-created-ticket-links'
+    expect(linearIssueUrl(url)).toBe(url)
+    expect(linearIssueLabel(url)).toBe('RUSH-1545')
+  })
+
+  test('returns null for non-Linear refs', () => {
+    expect(linearIssueUrl('#812')).toBeNull()
+    expect(linearIssueUrl('')).toBeNull()
   })
 })
 

--- a/apps/factory/ui/settings/components/mission-control/floorModel.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.ts
@@ -151,6 +151,7 @@ export interface FloorAgent {
   ci: CiStatus           // CI state of the open PR; null when no PR / unknown
   ticket: string | null  // "RUSH-812" when linked (injected/worked-on ticket from prompt or branch)
   createdTickets?: string[] // tracker refs this session CREATED (Linear create_issue / gh issue create); [] / undefined when none
+  createdCommits?: string[] // short git commit SHAs this session CREATED; [] / undefined when none
   spawnedTeam?: string   // team name this session SPAWNED via `agents teams create/add`; undefined when none
   plans?: PlanFile[]     // detected ref-*.md / .html plan artifacts available for preview
   branch: string
@@ -772,6 +773,28 @@ export function outcomeLabel(a: Pick<FloorAgent, 'ticket' | 'pr' | 'worktreeSlug
   }
   if (a.worktreeSlug) return a.worktreeSlug
   return 'Unassigned'
+}
+
+const LINEAR_ID_RE = /\b([A-Z][A-Z0-9]*-\d+)\b/
+const LINEAR_URL_ID_RE = /^https?:\/\/(?:www\.)?linear\.app\/\S*?\/issue\/([A-Z][A-Z0-9]*-\d+)\b/i
+
+/** Display label for a Linear issue ref or URL. */
+export function linearIssueLabel(ref: string): string {
+  const fromUrl = ref.match(LINEAR_URL_ID_RE)?.[1]
+  if (fromUrl) return fromUrl.toUpperCase()
+  const fromText = ref.match(LINEAR_ID_RE)?.[1]
+  return fromText ?? ref
+}
+
+/** External URL for a Linear issue ref or URL. Returns null for non-Linear refs. */
+export function linearIssueUrl(ref: string | null | undefined): string | null {
+  if (!ref) return null
+  const trimmed = ref.trim()
+  if (!trimmed) return null
+  const fromUrl = trimmed.match(LINEAR_URL_ID_RE)
+  if (fromUrl) return trimmed
+  const id = trimmed.match(LINEAR_ID_RE)?.[1]
+  return id ? `https://linear.app/issue/${encodeURIComponent(id)}` : null
 }
 
 /** Group agents by the chosen dimension. Prototype groupKey: factory-floor.html:412. */

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -150,6 +150,7 @@ const running: FloorAgent[] = [
       { path: '/repo/.agents/worktrees/bench-saved-views/ref-review.md', label: 'ref-review.md', kind: 'markdown', source: 'worktree' },
     ],
     createdTickets: ['RUSH-1519', 'RUSH-1520'],
+    createdCommits: ['095e588093ca'],
     todos: [
       { content: 'Merge ticket surfaces', status: 'completed' },
       { content: 'Port group-by control', status: 'in_progress' },


### PR DESCRIPTION
## What
- Adds Linear issue URL/label helpers to the Floor model and renders carried/created Linear refs as clickable badges in session cards and the detail pane.
- Adds commit artifact chips from recent successful command output so the produced-artifacts row shows PRs, tickets, teams, plans, and commits together.
- Updates preview seed data and Factory changelog for the user-visible Floor behavior.

## Evidence
- `apps/factory/ui/settings/components/mission-control/floorModel.ts:153` adds `createdCommits`; `floorModel.ts:781` / `:790` define Linear label and URL helpers.
- `apps/factory/ui/settings/components/mission-control/floorAdapter.ts:242` detects created commit SHAs; `floorAdapter.ts:434` carries them into local Floor agents.
- `apps/factory/ui/settings/components/mission-control/FeedItem.tsx:37` renders created ticket artifacts via `ExtLink`; `FeedItem.tsx:149` renders the primary ticket badge; `FeedItem.tsx:221` / `:224` render created tickets and commits.
- `apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx:1830` renders created tickets as detail-pane links and `:1837` renders commit chips.
- `apps/factory/CHANGELOG.md:14` documents the user-visible change.

## Verification
- `cd apps/factory && PATH=/home/muqsit/.bun/bin:$PATH /home/muqsit/.bun/bin/bun test ui/settings/components/mission-control/floorModel.test.ts ui/settings/components/mission-control/floorAdapter.test.ts ui/settings/components/mission-control/FeedItem.openTerminal.test.tsx` -> `164 pass, 0 fail`.
- `cd apps/factory && PATH=/home/muqsit/.bun/bin:$PATH /home/muqsit/.bun/bin/bun run compile` -> `tsc -p ./` and both settings/editor Vite builds passed.
- Visual verification through the settings preview harness: `/tmp/rush1547-feed.png` and `/tmp/rush1547-feed-full.png` show the ticket pill, created-ticket chips, and commit chip rendering without overlap.