### PR TITLE
Resolve @latest to a concrete version before install (fix install race)

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **`agents add <agent>@latest` resolves to a concrete version before installing (no install race).** `latest` (like `oldest`) is now resolved via `npm view` up front and installed as a pinned spec directly into `versions/<agent>/<version>/`. Previously `latest` installed into a shared, well-known `versions/<agent>/latest/` scratch dir and was renamed to the real version only after npm finished — so a concurrent `agents view` reconcile (`reconcileStaleLatestForAgent`) or a second `latest` install could rename that dir out from under npm mid-extraction, corrupting the install with `ENOENT` on the seeded `package.json`. A concrete dir per version has no shared name to race on. Source: `apps/cli/src/lib/versions.ts`.
 - **Native memory sync preserves unmanaged Markdown files (RUSH-1621).** Sync tracks managed fact names in `.agents-cli-memory.json` and only deletes those; user-authored `*.md` under the agent memory dir survive. Source: `apps/cli/src/lib/memory.ts`.
 - **Feed high-consequence authz uses the canonical operator registry (RUSH-1618).** `recordAnswer` no longer looks for `operators.yaml` under the feed root; it resolves operators from `~/.agents/` via `loadOperators()`. Source: `apps/cli/src/lib/feed.ts`.
 - **Menu bar groups worktree sessions under the real repo name (RUSH-1635).** Paths under `.agents/worktrees/<slug>` use the enclosing repository directory as the grouping key instead of the worktree slug. Source: `apps/cli/menubar/.../LocalState.swift`.

--- a/apps/cli/src/lib/versions.installscripts.test.ts
+++ b/apps/cli/src/lib/versions.installscripts.test.ts
@@ -29,34 +29,50 @@ const npmInstallCapture = vi.hoisted(() => ({ argv: undefined as string[] | unde
 const execCalls = vi.hoisted(() => ({ list: [] as Array<{ file: string; args: string[]; cwd?: string; shell?: boolean }> }));
 // Lets a test force the mocked postinstall to fail, exercising the best-effort path.
 const behavior = vi.hoisted(() => ({ failPostinstall: false }));
+// The version `npm view <pkg> version` returns — lets a test resolve `latest`.
+const npmView = vi.hoisted(() => ({ version: '2.1.187' }));
 
 vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
-  return {
-    ...actual,
-    execFile: vi.fn((file, args, options, callback) => {
-      const cb = typeof options === 'function' ? options : callback;
-      const opts = (typeof options === 'function' ? {} : options) ?? {};
-      const argv: string[] = Array.isArray(args) ? args : [];
-      if (file === 'npm' && argv[0] === 'install') {
-        npmInstallCapture.argv = argv;
-        if (cb) cb(null, 'mock npm install success', '');
-      } else if (file === 'npm' && argv[0] === '--version') {
-        if (cb) cb(null, '10.0.0', '');
-      } else {
-        // Postinstall command string (args=[], shell:true) or a binary --version
-        // probe. Record both; a postinstall is distinguished by shell === true.
-        execCalls.list.push({ file, args: argv, cwd: (opts as any).cwd, shell: (opts as any).shell });
-        const isPostinstall = (opts as any).shell === true && argv.length === 0;
-        if (isPostinstall && behavior.failPostinstall) {
-          if (cb) cb(new Error('mock postinstall failed'), '', 'boom');
-        } else if (cb) {
-          cb(null, '', '');
-        }
+  const { promisify } = await import('util');
+  const execFileMock = vi.fn((file, args, options, callback) => {
+    const cb = typeof options === 'function' ? options : callback;
+    const opts = (typeof options === 'function' ? {} : options) ?? {};
+    const argv: string[] = Array.isArray(args) ? args : [];
+    if (file === 'npm' && argv[0] === 'install') {
+      npmInstallCapture.argv = argv;
+      if (cb) cb(null, 'mock npm install success', '');
+    } else if (file === 'npm' && argv[0] === '--version') {
+      if (cb) cb(null, '10.0.0', '');
+    } else if (file === 'npm' && argv[0] === 'view') {
+      // `npm view <pkg> version` — getLatestNpmVersion resolves `latest` to a
+      // concrete version up front so the install never uses a shared `latest/`
+      // scratch dir.
+      if (cb) cb(null, `${npmView.version}\n`, '');
+    } else {
+      // Postinstall command string (args=[], shell:true) or a binary --version
+      // probe. Record both; a postinstall is distinguished by shell === true.
+      execCalls.list.push({ file, args: argv, cwd: (opts as any).cwd, shell: (opts as any).shell });
+      const isPostinstall = (opts as any).shell === true && argv.length === 0;
+      if (isPostinstall && behavior.failPostinstall) {
+        if (cb) cb(new Error('mock postinstall failed'), '', 'boom');
+      } else if (cb) {
+        cb(null, '', '');
       }
-      return undefined;
-    }),
-  };
+    }
+    return undefined;
+  });
+  // Real child_process.execFile carries a `util.promisify.custom` that resolves
+  // to `{ stdout, stderr }`. A bare vi.fn loses it, so `promisify(execFile)`
+  // would resolve to a single string and `const { stdout } = ...` would be
+  // undefined — breaking getLatestNpmVersion. Restore the faithful shape.
+  (execFileMock as any)[promisify.custom] = (file: string, args: string[], options: unknown) =>
+    new Promise((resolve, reject) => {
+      execFileMock(file, args, options as never, (err: Error | null, stdout: string, stderr: string) =>
+        err ? reject(err) : resolve({ stdout, stderr }),
+      );
+    });
+  return { ...actual, execFile: execFileMock };
 });
 
 beforeEach(() => {
@@ -111,6 +127,60 @@ describe('installVersion npm install argv', () => {
       expect(npmInstallCapture.argv).toContain('install');
       expect(npmInstallCapture.argv).toContain('--ignore-scripts');
     } finally {
+      process.env.HOME = originalHome;
+    }
+  });
+});
+
+describe('installVersion latest-alias resolution', () => {
+  it('resolves `latest` to a concrete version up front and installs a pinned spec (no shared `latest/` dir)', async () => {
+    const home = makeTempHome();
+    const originalHome = process.env.HOME;
+    process.env.HOME = home;
+    try {
+      vi.resetModules();
+      npmView.version = '2.1.187';
+      const { installVersion } = await import('./versions.js');
+      // Stage the on-disk shape npm would leave — but under the CONCRETE version
+      // dir, since the fix installs straight into it (no post-install rename).
+      stageInstall(home, 'claude', '@anthropic-ai/claude-code', '2.1.187');
+
+      const result = await installVersion('claude', 'latest');
+
+      expect(result.success).toBe(true);
+      // The alias resolved to the concrete version, not the literal 'latest'.
+      expect(result.installedVersion).toBe('2.1.187');
+      // npm install ran with a PINNED spec, never the bare package name that the
+      // old (racy) code passed for `latest`.
+      expect(npmInstallCapture.argv).toContain('@anthropic-ai/claude-code@2.1.187');
+      expect(npmInstallCapture.argv).not.toContain('@anthropic-ai/claude-code');
+      // The install landed in the concrete dir; no literal `latest/` dir exists
+      // for a concurrent reconcile/install to race on.
+      const versionsRoot = path.join(home, '.agents', '.history', 'versions', 'claude');
+      expect(fs.existsSync(path.join(versionsRoot, '2.1.187'))).toBe(true);
+      expect(fs.existsSync(path.join(versionsRoot, 'latest'))).toBe(false);
+    } finally {
+      process.env.HOME = originalHome;
+    }
+  });
+
+  it('fails cleanly when npm cannot resolve `latest`', async () => {
+    const home = makeTempHome();
+    const originalHome = process.env.HOME;
+    process.env.HOME = home;
+    try {
+      vi.resetModules();
+      npmView.version = '';
+      const { installVersion } = await import('./versions.js');
+      const result = await installVersion('claude', 'latest');
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Could not resolve the latest/);
+      // Nothing was installed and no `latest/` dir was left behind.
+      expect(npmInstallCapture.argv).toBeUndefined();
+      const versionsRoot = path.join(home, '.agents', '.history', 'versions', 'claude');
+      expect(fs.existsSync(path.join(versionsRoot, 'latest'))).toBe(false);
+    } finally {
+      npmView.version = '2.1.187';
       process.env.HOME = originalHome;
     }
   });

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -1231,19 +1231,28 @@ export async function installVersion(
     return { success: true, installedVersion };
   }
 
-  // Resolve the `oldest` alias to a concrete npm version up front so the rest
-  // of the install path treats it as an ordinary pinned install. (`latest`
-  // keeps its bare-package-name + post-install-rename handling below.)
-  if (version === 'oldest') {
-    const oldest = await getOldestNpmVersion(agent);
-    if (!oldest) {
+  // Resolve the `latest`/`oldest` aliases to a concrete npm version up front so
+  // the rest of the install path treats them as an ordinary pinned install.
+  // This is what keeps concurrent installs safe: resolving `latest` only AFTER
+  // npm finished meant the install ran in a shared, well-known
+  // `versions/<agent>/latest/` scratch dir that was renamed to the real version
+  // at the end — so a concurrent `agents view` reconcile
+  // (reconcileStaleLatestForAgent) or a second `latest` install could rename
+  // that dir out from under npm mid-extraction and corrupt the install (the
+  // seeded package.json and half-extracted node_modules would vanish, yielding
+  // ENOENT). A concrete dir per version has no shared name to race on.
+  if (version === 'latest' || version === 'oldest') {
+    const resolved = version === 'latest'
+      ? await getLatestNpmVersion(agent)
+      : await getOldestNpmVersion(agent);
+    if (!resolved) {
       return {
         success: false,
         installedVersion: version,
-        error: `Could not resolve the oldest published version for ${agentConfig.name} from npm.`,
+        error: `Could not resolve the ${version} published version for ${agentConfig.name} from npm.`,
       };
     }
-    version = oldest;
+    version = resolved;
   }
 
   ensureAgentsDir();
@@ -1270,12 +1279,11 @@ export async function installVersion(
   };
   fs.writeFileSync(path.join(versionDir, 'package.json'), JSON.stringify(packageJson, null, 2));
 
-  // Install the package
-  const packageSpec = version === 'latest'
-    ? agentConfig.npmPackage
-    : `${agentConfig.npmPackage}@${version}`;
-  // The `${agentConfig.npmPackage}@` prefix is load-bearing: it ensures `version`
-  // (which VERSION_RE permits to start with `-`) is never passed as a standalone npm CLI flag.
+  // Install the package. `version` is always concrete here (`latest`/`oldest`
+  // were resolved above), so the spec is always pinned. The `@` prefix is
+  // load-bearing: it ensures `version` (which VERSION_RE permits to start with
+  // `-`) is never passed as a standalone npm CLI flag.
+  const packageSpec = `${agentConfig.npmPackage}@${version}`;
 
   try {
     // Check npm is available
@@ -1291,37 +1299,13 @@ export async function installVersion(
     }
 
     onProgress?.(`Installing ${packageSpec}...`);
-    const { stdout } = await execFileAsync('npm', ['install', packageSpec, '--ignore-scripts'], { cwd: versionDir, shell: winShell });
+    await execFileAsync('npm', ['install', packageSpec, '--ignore-scripts'], { cwd: versionDir, shell: winShell });
 
-    // Determine the actual installed version
-    let installedVersion = version;
-    if (version === 'latest') {
-      const pkgJsonPath = path.join(versionDir, 'node_modules', agentConfig.npmPackage.replace(/^@/, '').split('/')[0], 'package.json');
-      // Try to read the actual version from installed package
-      try {
-        const installedPkgPath = path.join(versionDir, 'node_modules', agentConfig.npmPackage, 'package.json');
-        if (fs.existsSync(installedPkgPath)) {
-          const installedPkg = JSON.parse(fs.readFileSync(installedPkgPath, 'utf-8'));
-          installedVersion = installedPkg.version;
-
-          // Rename the directory to the actual version
-          if (installedVersion !== 'latest') {
-            const actualVersionDir = getVersionDir(agent, installedVersion);
-            if (!fs.existsSync(actualVersionDir)) {
-              fs.renameSync(versionDir, actualVersionDir);
-            } else {
-              // Already exists — drop the 'latest' install artifacts but keep
-              // `home/` (may contain conversation history from sessions that
-              // ran while the user was on `latest`).
-              removeInstallArtifacts(versionDir);
-            }
-          }
-        }
-      } catch (e) {
-        // Failed to determine version - this shouldn't happen
-        throw new Error(`Failed to determine installed version: ${(e as Error).message}`);
-      }
-    }
+    // `version` is concrete (the `latest`/`oldest` aliases were resolved up
+    // front), so the package installed directly into its final versioned dir —
+    // no post-install rename, and no shared `latest/` dir for a concurrent
+    // process to move out from under us.
+    const installedVersion = version;
 
     // Create versioned alias (e.g., claude@2.0.65)
     createVersionedAlias(agent, installedVersion);

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -1337,9 +1337,9 @@ export async function installVersion(
     // binary (postinstall failed, or a platform with no published native dep)
     // fails there with the correct message rather than throwing here.
     if (agentConfig.npmPackage) {
-      // Recompute from installedVersion, not the (possibly renamed) `versionDir`:
-      // the `latest` branch above may have renamed the dir to its concrete version.
-      const pkgRoot = path.join(getVersionDir(agent, installedVersion), 'node_modules', agentConfig.npmPackage);
+      // `installedVersion === version`, so this is exactly `versionDir` — the
+      // install landed in its final dir with no rename to chase.
+      const pkgRoot = path.join(versionDir, 'node_modules', agentConfig.npmPackage);
       try {
         const pkg = JSON.parse(fs.readFileSync(path.join(pkgRoot, 'package.json'), 'utf-8'));
         const postinstall = pkg?.scripts?.postinstall;


### PR DESCRIPTION
## Problem

`ag add claude@latest` failed with:

```
Command failed: npm install @anthropic-ai/claude-code --ignore-scripts
npm error path .../versions/claude/latest/package.json
npm error enoent ENOENT: no such file or directory, open '.../versions/claude/latest/package.json'
```

Root cause: for `@latest`, `installVersion` didn't resolve the version up front. It created a directory **literally named `latest/`**, seeded a `package.json` into it, ran `npm install <bare-package>` with that dir as npm's cwd, and only **after** npm finished read the real version and renamed `latest/` → `2.1.207`.

That `latest/` name is a fixed, shared path. A **different** code path renames the same dir: `reconcileStaleLatestForAgent` (`versions.ts`) → `fs.renameSync(latest/ → concrete/)`, invoked by `agents view` (`commands/view.ts`). When those run concurrently (common on a dev box with the daemon/doctor/view all live), the reconcile renames `latest/` out from under the in-flight npm, so the seeded `package.json` and the half-extracted `node_modules/@anthropic-ai/claude-code-darwin-arm64/` vanish → the ENOENTs above. A file agents-cli wrote milliseconds earlier can only become "no such file" if the directory was moved mid-run.

It's a race, so it works in isolation and reproduces under concurrency. `oldest` was already immune because it resolves to a concrete version up front; `latest` did not.

## Fix

Resolve `latest` (like `oldest`) to a concrete npm version **before** creating any directory, and install a **pinned** spec directly into `versions/<agent>/<version>/`. No shared `latest/` scratch dir, no post-install rename — nothing for a concurrent reconcile/install to race on. Source: `apps/cli/src/lib/versions.ts`.

## Tests

- New unit tests in `versions.installscripts.test.ts`:
  - `latest` resolves to the concrete version, installs the **pinned** spec (`@anthropic-ai/claude-code@2.1.187`, never the bare package), lands in the concrete dir, and creates **no** `latest/` dir. (Fails against the old code.)
  - `latest` fails cleanly when `npm view` can't resolve, leaving no `latest/` dir.
  - The mock now restores `execFile`'s `util.promisify.custom` `{stdout,stderr}` shape so `getLatestNpmVersion` behaves as in production.
- Full `versions.test.ts` + `versions.installscripts.test.ts` suites pass (50 tests).

## End-to-end verification

Real `npm view` + real `npm install` into a throwaway `HOME`:

```
installVersion('claude','latest') → { success: true, installedVersion: "2.1.207" }
progress: "Installing @anthropic-ai/claude-code@2.1.207..."   # pinned spec
versions/claude/  →  2.1.207/            # concrete dir only
                     (no latest/ dir)
2.1.207/node_modules/@anthropic-ai/claude-code/package.json   # package present
```