### PR TITLE
RUSH-1578: refresh Factory backlog while open

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+- **Factory Floor backlog refreshes while the view stays open (RUSH-1578).**
+  The Floor and Bench tabs now re-fetch unified Linear/GitHub tasks on a
+  30-second active-view cadence, so external ticket status changes no longer
+  require closing and reopening Factory. Source: `ui/settings/App.tsx`.
 - **Factory Floor surfaces agent-created tickets as clickable Linear artifacts (RUSH-1547).**
   Session cards and detail panes now render linked Linear badges for carried/created
   ticket refs and include commit chips in the produced-artifacts row, so PRs,

--- a/apps/factory/ui/settings/App.test.tsx
+++ b/apps/factory/ui/settings/App.test.tsx
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+if (typeof (globalThis as { document?: unknown }).document === 'undefined') GlobalRegistrator.register()
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const React = require('react')
+const { act } = require('react')
+const { createRoot } = require('react-dom/client')
+
+type PostedMessage = { type?: string }
+type IntervalEntry = { delay?: number; handler: () => void }
+
+const originalSetInterval = globalThis.setInterval
+const originalClearInterval = globalThis.clearInterval
+const originalDateNow = Date.now
+const originalMatchMedia = window.matchMedia
+
+function installHost(posts: PostedMessage[]) {
+  ;(globalThis as unknown as { acquireVsCodeApi: () => unknown }).acquireVsCodeApi = () => ({
+    postMessage: (message: PostedMessage) => posts.push(message),
+    getState: () => undefined,
+    setState: () => {},
+  })
+}
+
+function installIcons() {
+  ;(window as unknown as { __ICONS__: unknown }).__ICONS__ = {
+    claude: 'claude.svg',
+    codex: { dark: 'codex-dark.svg', light: 'codex-light.svg' },
+    gemini: 'gemini.svg',
+    opencode: 'opencode.svg',
+    cursor: { dark: 'cursor-dark.svg', light: 'cursor-light.svg' },
+    agents: 'agents.svg',
+    shell: 'shell.svg',
+    github: 'github.svg',
+    antigravity: 'antigravity.svg',
+    grok: 'grok.svg',
+  }
+}
+
+function installBrowserShims(intervals: IntervalEntry[]) {
+  window.matchMedia = (() => ({
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  })) as typeof window.matchMedia
+
+  globalThis.setInterval = ((handler: TimerHandler, delay?: number) => {
+    const entry = {
+      delay,
+      handler: () => {
+        if (typeof handler === 'function') handler()
+      },
+    }
+    intervals.push(entry)
+    return intervals.length as unknown as ReturnType<typeof setInterval>
+  }) as typeof setInterval
+  globalThis.clearInterval = (() => {}) as typeof clearInterval
+}
+
+afterEach(() => {
+  globalThis.setInterval = originalSetInterval
+  globalThis.clearInterval = originalClearInterval
+  Date.now = originalDateNow
+  window.matchMedia = originalMatchMedia
+  document.body.innerHTML = ''
+  delete (globalThis as unknown as { acquireVsCodeApi?: unknown }).acquireVsCodeApi
+})
+
+describe('App unified task refresh', () => {
+  test('refreshes backlog tasks while the Floor tab stays open', async () => {
+    const posts: PostedMessage[] = []
+    const intervals: IntervalEntry[] = []
+    let now = 1_000
+    Date.now = () => now
+    installHost(posts)
+    installIcons()
+    installBrowserShims(intervals)
+
+    const { default: App } = await import('./App')
+    const rootElement = document.createElement('div')
+    document.body.appendChild(rootElement)
+    const root = createRoot(rootElement)
+
+    await act(async () => {
+      root.render(React.createElement(App))
+    })
+
+    expect(posts.filter((message) => message.type === 'fetchUnifiedTasks')).toHaveLength(1)
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', { data: { type: 'tasksData', tasks: [] } }))
+      window.dispatchEvent(new MessageEvent('message', { data: { type: 'unifiedTasksData', tasks: [] } }))
+    })
+
+    now += 30_001
+    await act(async () => {
+      for (const interval of intervals.filter((entry) => entry.delay === 30_000)) interval.handler()
+    })
+
+    expect(posts.filter((message) => message.type === 'fetchUnifiedTasks')).toHaveLength(2)
+
+    await act(async () => {
+      root.unmount()
+    })
+  })
+})

--- a/apps/factory/ui/settings/App.tsx
+++ b/apps/factory/ui/settings/App.tsx
@@ -45,6 +45,7 @@ import { ForemanOrb, ForemanCursor } from './components/foreman'
 const vscode = getVsCodeApi()
 const icons = getIcons() as IconConfig
 const BUILT_IN_AGENTS = createBuiltInAgents(icons)
+const UNIFIED_TASKS_REFRESH_MS = 30_000
 
 function getAgentWithHighestRunningCount(runningCounts: RunningCounts): string | null {
   const candidates: Array<[string, number]> = [
@@ -115,6 +116,7 @@ export default function App() {
   const [unifiedTasks, setUnifiedTasks] = useState<UnifiedTask[]>([])
   const [unifiedTasksLoading, setUnifiedTasksLoading] = useState(false)
   const [unifiedTasksLoaded, setUnifiedTasksLoaded] = useState(false)
+  const unifiedTasksRefreshAtRef = useRef(0)
   const [cycleInfo, setCycleInfo] = useState<CycleInfo | null>(null)
   const [availableSources, setAvailableSources] = useState<{ linear: boolean; github: boolean }>({
     linear: false, github: false
@@ -393,6 +395,17 @@ export default function App() {
     }
   }, [activeTab, tasksLoaded, tasksLoading, unifiedTasksLoaded, unifiedTasksLoading, contextLoaded, contextLoading])
 
+  useEffect(() => {
+    if ((activeTab !== 'floor' && activeTab !== 'bench') || !unifiedTasksLoaded) return
+    const interval = setInterval(() => {
+      if (unifiedTasksLoading) return
+      const now = Date.now()
+      if (now - unifiedTasksRefreshAtRef.current < UNIFIED_TASKS_REFRESH_MS) return
+      fetchUnifiedTasks()
+    }, UNIFIED_TASKS_REFRESH_MS)
+    return () => clearInterval(interval)
+  }, [activeTab, unifiedTasksLoaded, unifiedTasksLoading])
+
   // Refetch agent inventories when Panel tab is active and any are missing.
   // The init fetch can fail when agents-cli isn't on PATH yet; this self-heals
   // once the user installs the CLI and revisits the Panel tab.
@@ -511,6 +524,7 @@ export default function App() {
 
   const fetchUnifiedTasks = () => {
     setUnifiedTasksLoading(true)
+    unifiedTasksRefreshAtRef.current = Date.now()
     vscode.postMessage({ type: 'fetchUnifiedTasks' })
   }
 


### PR DESCRIPTION
## What
- Add an active Floor/Bench unified-task refresh cadence so backlog rows re-fetch every 30 seconds while the view stays open.
- Track the last unified-task request at the existing fetch boundary to avoid overlapping refreshes.
- Add a component-level host-message test and changelog entry.

## Evidence
- `apps/factory/ui/settings/App.tsx:48` defines `UNIFIED_TASKS_REFRESH_MS = 30_000`.
- `apps/factory/ui/settings/App.tsx:398` installs the active Floor/Bench refresh interval after unified tasks have loaded.
- `apps/factory/ui/settings/App.tsx:525` records the last fetch time and posts `fetchUnifiedTasks`.
- `apps/factory/ui/settings/App.test.tsx:90` asserts the initial `fetchUnifiedTasks` host message.
- `apps/factory/ui/settings/App.test.tsx:102` asserts a second `fetchUnifiedTasks` after the 30-second interval fires while Floor remains open.
- `apps/factory/CHANGELOG.md:14` documents the user-visible refresh behavior.

## Tests
- `PATH=/home/muqsit/.bun/bin:$PATH bun test settings/App.test.tsx` in `apps/factory/ui` -> 1 pass, 0 fail.
- `PATH=/home/muqsit/.bun/bin:$PATH bun run compile` in `apps/factory` -> TypeScript + settings/editor Vite builds passed.