### PR TITLE
RUSH-1544: add Factory Floor subgroups

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+- **Factory Floor group controls now support Subgroup (RUSH-1544).**
+  The live feed and Backlog controls can render a second grouping axis, excluding
+  the primary axis to avoid duplicate grouping. Nested section headers make
+  combinations like Project -> Host and Project -> Source visible without
+  switching views. Source: `ui/settings/components/mission-control/FloorControls.tsx`,
+  `UnifiedAgentsPane.tsx`, `BacklogCenter.tsx`.
 - **Factory Floor surfaces agent-created tickets as clickable Linear artifacts (RUSH-1547).**
   Session cards and detail panes now render linked Linear badges for carried/created
   ticket refs and include commit chips in the produced-artifacts row, so PRs,

--- a/apps/factory/ui/settings/components/mission-control/BacklogCenter.test.tsx
+++ b/apps/factory/ui/settings/components/mission-control/BacklogCenter.test.tsx
@@ -52,6 +52,7 @@ function render(over?: Partial<Record<'LN' | 'GH', boolean>>, workers?: Record<s
     <BacklogCenter
       tickets={tickets}
       group="project"
+      subgroup="none"
       sort="priority"
       srcFilter={{ LN: true, GH: true, ...over }}
       projFilter={null}
@@ -106,5 +107,31 @@ describe('BacklogCenter in-flight chips', () => {
 
   test('no workers map renders no chips', () => {
     expect(render()).not.toContain('twork')
+  })
+})
+
+describe('BacklogCenter subgrouping', () => {
+  test('renders second-level subgroup headers inside each primary group', () => {
+    const html = renderToStaticMarkup(
+      <BacklogCenter
+        tickets={[
+          ...tickets,
+          { id: 'RUSH-2000', title: 'Second Linear ticket', project: 'rush', source: 'LN', pri: 'high', status: 'todo', desc: '', labels: [], owner: 'Grace' },
+        ]}
+        group="source"
+        subgroup="project"
+        sort="priority"
+        srcFilter={{ LN: true, GH: true }}
+        projFilter={null}
+        search=""
+        selectedTicketId={null}
+        workers={{}}
+        onSelectTicket={noop}
+        onOpenTask={noop}
+      />,
+    )
+    expect(html).toContain('Linear')
+    expect(html).toContain('feed-subsec')
+    expect(html).toContain('rush')
   })
 })

--- a/apps/factory/ui/settings/components/mission-control/BacklogCenter.tsx
+++ b/apps/factory/ui/settings/components/mission-control/BacklogCenter.tsx
@@ -18,6 +18,7 @@ import {
 interface BacklogCenterProps {
   tickets: FloorTicket[]
   group: TicketGroupBy
+  subgroup: TicketGroupBy | 'none'
   sort: TicketSort
   /** Which ticket sources are visible (Linear / GitHub); set from the shared bar. */
   srcFilter: Record<TicketSource, boolean>
@@ -78,7 +79,7 @@ function TicketRow({ ticket: t, selected, workers = [], onSelect, onOpen }: {
 }
 
 export function BacklogCenter({
-  tickets, group, sort, srcFilter, projFilter, search, selectedTicketId, workers = {},
+  tickets, group, subgroup, sort, srcFilter, projFilter, search, selectedTicketId, workers = {},
   onSelectTicket, onOpenTask,
 }: BacklogCenterProps) {
   // Backlog = work you can still dispatch onto, so completed tickets are excluded.
@@ -95,6 +96,7 @@ export function BacklogCenter({
   )
   const sorted = sortTickets(list, sort)
   const groups = groupTickets(sorted, group)
+  const subgroupActive = subgroup !== 'none' && subgroup !== group
 
   return (
     <div className="feed">
@@ -104,16 +106,35 @@ export function BacklogCenter({
             {k} <span style={{ color: 'var(--tx-dim)', fontWeight: 600 }}>· {arr.length}</span>
             <span className="ln" />
           </div>
-          {arr.map((t) => (
-            <TicketRow
-              key={t.id}
-              ticket={t}
-              selected={selectedTicketId === t.id}
-              workers={workers[t.id]}
-              onSelect={onSelectTicket}
-              onOpen={onOpenTask}
-            />
-          ))}
+          {subgroupActive
+            ? [...groupTickets(arr, subgroup).entries()].map(([subKey, subArr]) => (
+                <React.Fragment key={`${k}:${subKey}`}>
+                  <div className="feed-sec feed-subsec">
+                    {subKey} <span style={{ color: 'var(--tx-dim)', fontWeight: 600 }}>· {subArr.length}</span>
+                    <span className="ln" />
+                  </div>
+                  {subArr.map((t) => (
+                    <TicketRow
+                      key={t.id}
+                      ticket={t}
+                      selected={selectedTicketId === t.id}
+                      workers={workers[t.id]}
+                      onSelect={onSelectTicket}
+                      onOpen={onOpenTask}
+                    />
+                  ))}
+                </React.Fragment>
+              ))
+            : arr.map((t) => (
+                <TicketRow
+                  key={t.id}
+                  ticket={t}
+                  selected={selectedTicketId === t.id}
+                  workers={workers[t.id]}
+                  onSelect={onSelectTicket}
+                  onOpen={onOpenTask}
+                />
+              ))}
         </React.Fragment>
       ))}
     </div>

--- a/apps/factory/ui/settings/components/mission-control/FloorControls.test.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorControls.test.tsx
@@ -29,8 +29,12 @@ const common = {
   onSort: noop,
   group: 'project' as const,
   onGroup: noop,
+  subgroup: 'host' as const,
+  onSubgroup: noop,
   ticketGroup: 'project' as const,
   onTicketGroup: noop,
+  ticketSubgroup: 'owner' as const,
+  onTicketSubgroup: noop,
   ticketSort: 'priority' as const,
   onTicketSort: noop,
   srcFilter: { LN: true, GH: true },
@@ -42,6 +46,8 @@ describe('FloorControls contextual bar', () => {
     const html = renderToStaticMarkup(<FloorControls mode="agents" needsCount={3} {...common} />)
     // The agents Sort pill exposes the FloorSort options...
     expect(html).toContain('Needs you first')
+    expect(html).toContain('Subgroup:')
+    expect(html).toContain('Host')
     // ...the ⚑ needs flag pill shows when needsCount > 0...
     expect(html).toContain('fpill-flag')
     // ...and the backlog LN/GH source chips are absent.
@@ -53,6 +59,8 @@ describe('FloorControls contextual bar', () => {
     expect(html).toContain('class="chip on"') // LN + GH both active
     expect(html).toContain('>LN<')
     expect(html).toContain('>GH<')
+    expect(html).toContain('Subgroup:')
+    expect(html).toContain('Owner')
     // Backlog sort options are Priority/ID — the feed's 'Needs you first' must not appear.
     expect(html).not.toContain('Needs you first')
   })
@@ -60,5 +68,13 @@ describe('FloorControls contextual bar', () => {
   test('no Dispatch button — it lives on the sub-tab strip now', () => {
     const html = renderToStaticMarkup(<FloorControls mode="agents" needsCount={0} {...common} />)
     expect(html).not.toContain('Dispatch')
+  })
+
+  test('subgroup select excludes the active primary group axis', () => {
+    const html = renderToStaticMarkup(<FloorControls mode="agents" needsCount={0} {...common} />)
+    const subgroup = html.slice(html.indexOf('Subgroup:'), html.indexOf('Needs you first'))
+    expect(subgroup).toContain('>None<')
+    expect(subgroup).toContain('>Host<')
+    expect(subgroup).not.toContain('>Project<')
   })
 })

--- a/apps/factory/ui/settings/components/mission-control/FloorControls.tsx
+++ b/apps/factory/ui/settings/components/mission-control/FloorControls.tsx
@@ -69,10 +69,14 @@ interface FloorControlsProps {
   /** How the live feed is grouped ('none' = default phase sections). */
   group: FloorGroupBy | 'none'
   onGroup: (g: FloorGroupBy | 'none') => void
+  subgroup: FloorGroupBy | 'none'
+  onSubgroup: (g: FloorGroupBy | 'none') => void
 
   // --- backlog-mode controls ---
   ticketGroup: TicketGroupBy
   onTicketGroup: (by: TicketGroupBy) => void
+  ticketSubgroup: TicketGroupBy | 'none'
+  onTicketSubgroup: (by: TicketGroupBy | 'none') => void
   ticketSort: TicketSort
   onTicketSort: (by: TicketSort) => void
   srcFilter: Record<TicketSource, boolean>
@@ -83,12 +87,23 @@ export function FloorControls({
   mode,
   needsCount = 0,
   sidebarOpen, onToggleSidebar, rightOpen, onToggleRight, plain, onTogglePlain,
-  sort, onSort, group, onGroup,
-  ticketGroup, onTicketGroup, ticketSort, onTicketSort, srcFilter, onToggleSrc,
+  sort, onSort, group, onGroup, subgroup, onSubgroup,
+  ticketGroup, onTicketGroup, ticketSubgroup, onTicketSubgroup, ticketSort, onTicketSort, srcFilter, onToggleSrc,
 }: FloorControlsProps) {
   const groupLabel = (GROUP_OPTS.find((o) => o.value === group) ?? GROUP_OPTS[0]!).label
+  const subgroupValue = group === 'none' || subgroup === group ? 'none' : subgroup
+  const subgroupLabel = (GROUP_OPTS.find((o) => o.value === subgroupValue) ?? GROUP_OPTS[1]!).label
+  const subgroupOpts = GROUP_OPTS.filter((o) => o.value === 'none' || o.value !== group)
   const sortLabel = (SORT_OPTS.find((o) => o.value === sort) ?? SORT_OPTS[0]!).label
   const ticketGroupLabel = (TICKET_GROUP_OPTS.find((o) => o.value === ticketGroup) ?? TICKET_GROUP_OPTS[0]!).label
+  const ticketSubgroupValue = ticketSubgroup === ticketGroup ? 'none' : ticketSubgroup
+  const ticketSubgroupLabel = ticketSubgroupValue === 'none'
+    ? 'None'
+    : (TICKET_GROUP_OPTS.find((o) => o.value === ticketSubgroupValue) ?? TICKET_GROUP_OPTS[0]!).label
+  const ticketSubgroupOpts = [
+    { value: 'none' as const, label: 'None' },
+    ...TICKET_GROUP_OPTS.filter((o) => o.value !== ticketGroup),
+  ]
 
   return (
     <div className="fbar clean">
@@ -100,6 +115,19 @@ export function FloorControls({
             Group: <b>{groupLabel}</b>
             <select value={group} onChange={(e) => onGroup(e.target.value as FloorGroupBy | 'none')}>
               {GROUP_OPTS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </label>
+
+          <label className="fpill fpill-sel" title="Subgroup the feed">
+            Subgroup: <b>{subgroupLabel}</b>
+            <select
+              value={subgroupValue}
+              disabled={group === 'none'}
+              onChange={(e) => onSubgroup(e.target.value as FloorGroupBy | 'none')}
+            >
+              {subgroupOpts.map((o) => (
                 <option key={o.value} value={o.value}>{o.label}</option>
               ))}
             </select>
@@ -124,6 +152,15 @@ export function FloorControls({
             Group: <b>{ticketGroupLabel}</b>
             <select value={ticketGroup} onChange={(e) => onTicketGroup(e.target.value as TicketGroupBy)}>
               {TICKET_GROUP_OPTS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </label>
+
+          <label className="fpill fpill-sel" title="Subgroup the backlog">
+            Subgroup: <b>{ticketSubgroupLabel}</b>
+            <select value={ticketSubgroupValue} onChange={(e) => onTicketSubgroup(e.target.value as TicketGroupBy | 'none')}>
+              {ticketSubgroupOpts.map((o) => (
                 <option key={o.value} value={o.value}>{o.label}</option>
               ))}
             </select>

--- a/apps/factory/ui/settings/components/mission-control/SavedViewsBar.test.tsx
+++ b/apps/factory/ui/settings/components/mission-control/SavedViewsBar.test.tsx
@@ -26,6 +26,8 @@ describe('SavedViews feed header bar (RUSH-1526)', () => {
         feedFilters={{
           group: 'outcome',
           onGroup: noop,
+          subgroup: 'project',
+          onSubgroup: noop,
           status: ['needs'],
           onToggleStatus: noop,
           abbrs: [],
@@ -36,7 +38,9 @@ describe('SavedViews feed header bar (RUSH-1526)', () => {
     )
     expect(html).toContain('Save view')
     expect(html).toContain('Group:')
+    expect(html).toContain('Subgroup:')
     expect(html).toContain('Outcome')
+    expect(html).toContain('Project')
     expect(html).toContain('Needs you')
     expect(html).toContain('Running')
     expect(html).toContain('feed-header-status on') // needs active
@@ -62,6 +66,8 @@ describe('SavedViews feed header bar (RUSH-1526)', () => {
         feedFilters={{
           group: 'project',
           onGroup: noop,
+          subgroup: 'host',
+          onSubgroup: noop,
           status: [],
           onToggleStatus: noop,
           abbrs: ['CC'],

--- a/apps/factory/ui/settings/components/mission-control/SavedViewsBar.tsx
+++ b/apps/factory/ui/settings/components/mission-control/SavedViewsBar.tsx
@@ -40,6 +40,8 @@ interface SavedViewsProps {
   feedFilters?: {
     group: FloorGroupBy | 'none'
     onGroup: (g: FloorGroupBy | 'none') => void
+    subgroup: FloorGroupBy | 'none'
+    onSubgroup: (g: FloorGroupBy | 'none') => void
     status: StatusChip[]
     onToggleStatus: (s: StatusChip) => void
     abbrs: AgentAbbr[]
@@ -69,6 +71,15 @@ export function SavedViews({
   const groupLabel = feedFilters
     ? (FEED_GROUP_OPTS.find((o) => o.value === feedFilters.group) ?? FEED_GROUP_OPTS[0]!).label
     : ''
+  const subgroupValue = feedFilters && feedFilters.group !== 'none' && feedFilters.subgroup !== feedFilters.group
+    ? feedFilters.subgroup
+    : 'none'
+  const subgroupLabel = feedFilters
+    ? (FEED_GROUP_OPTS.find((o) => o.value === subgroupValue) ?? FEED_GROUP_OPTS[1]!).label
+    : ''
+  const subgroupOptions = feedFilters
+    ? FEED_GROUP_OPTS.filter((o) => o.value === 'none' || o.value !== feedFilters.group)
+    : []
 
   return (
     <div className="savedviews feed-header-bar" data-testid="feed-header-bar">
@@ -112,6 +123,19 @@ export function SavedViews({
               aria-label="Group feed by"
             >
               {FEED_GROUP_OPTS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </label>
+          <label className="fpill fpill-sel feed-header-group" title="Subgroup the feed">
+            Subgroup: <b>{subgroupLabel}</b>
+            <select
+              value={subgroupValue}
+              disabled={feedFilters.group === 'none'}
+              onChange={(e) => feedFilters.onSubgroup(e.target.value as FloorGroupBy | 'none')}
+              aria-label="Subgroup feed by"
+            >
+              {subgroupOptions.map((o) => (
                 <option key={o.value} value={o.value}>{o.label}</option>
               ))}
             </select>

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -643,6 +643,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   // (NEEDS YOU -> RUNNING -> DONE). Reuses groupAgents() so the control bar and
   // the feed share one grouping implementation.
   const [floorGroup, setFloorGroup] = useState<FloorGroupBy | 'none'>('outcome')
+  const [floorSubgroup, setFloorSubgroup] = useState<FloorGroupBy | 'none'>('none')
   const [plain, setPlain] = useState(floorPrefs0.plain)
   const [sidebarOpen, setSidebarOpen] = useState(floorPrefs0.sidebar)
   // Collapsed = the icon rail (mockup default); expanded = the full text sidebar.
@@ -683,8 +684,20 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     })
   }, [])
   const [ticketGroup, setTicketGroup] = useState<TicketGroupBy>('project')
+  const [ticketSubgroup, setTicketSubgroup] = useState<TicketGroupBy | 'none'>('none')
   const [ticketSort, setTicketSort] = useState<TicketSort>('priority')
   const [ticketSrc, setTicketSrc] = useState<Record<TicketSource, boolean>>({ LN: true, GH: true })
+
+  const handleFloorGroup = useCallback((next: FloorGroupBy | 'none') => {
+    setFloorGroup(next)
+    setFloorSubgroup((cur) => (next === 'none' || cur === next ? 'none' : cur))
+  }, [])
+
+  const handleTicketGroup = useCallback((next: TicketGroupBy) => {
+    setTicketGroup(next)
+    setTicketSubgroup((cur) => (cur === next ? 'none' : cur))
+  }, [])
+
   const [remoteSessions, setRemoteSessions] = useState<RemoteSessionLike[]>([])
   const [offlineHosts, setOfflineHosts] = useState<string[]>([])
   // Per-agent reply failures (host 'replyResult' with ok=false, or a 'none' channel),
@@ -1978,6 +1991,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     <BacklogCenter
       tickets={floorTickets}
       group={ticketGroup}
+      subgroup={ticketSubgroup}
       sort={ticketSort}
       srcFilter={ticketSrc}
       projFilter={projFilter}
@@ -2018,7 +2032,9 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
         onDelete={deleteView}
         feedFilters={{
           group: floorGroup,
-          onGroup: setFloorGroup,
+          onGroup: handleFloorGroup,
+          subgroup: floorSubgroup,
+          onSubgroup: setFloorSubgroup,
           status: statusChips,
           onToggleStatus: (s) => setStatusChips((cur) => (
             cur.includes(s) ? cur.filter((c) => c !== s) : [...cur, s]
@@ -2089,7 +2105,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
         </>
       )}
 
-      <div className="feed-sec">{floorGroup === 'none' ? `RUNNING · ${runningFeed.length}` : `GROUPED BY ${floorGroup.toUpperCase()} · ${runningFeed.length + doneFeed.length}`}<span className="ln" />
+      <div className="feed-sec">{floorGroup === 'none' ? `RUNNING · ${runningFeed.length}` : `GROUPED BY ${floorGroup.toUpperCase()}${floorSubgroup !== 'none' && floorSubgroup !== floorGroup ? ` / ${floorSubgroup.toUpperCase()}` : ''} · ${runningFeed.length + doneFeed.length}`}<span className="ln" />
         <span
           className={`fresh${syncingHosts ? ' syncing' : ''}${!syncingHosts && lastRemoteSync > 0 && nowMs - lastRemoteSync > 2 * REMOTE_POLL_MS ? ' stale' : ''}`}
           title="Last cross-host sync. Click to refresh now."
@@ -2121,12 +2137,29 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
         : [...groupAgents([...runningFeed, ...doneFeed], floorGroup).entries()].map(([k, arr]) => {
             // When grouped by project, enrich the header: "N agents" + a Linear project
             // link pill (mockup: "agents-cli · 8 agents · RUSH · Agents CLI").
-            const linkedProject = floorGroup === 'project'
-              ? managedProjects.find((p) => p.name === k)?.linearProjectName
-              : undefined
+            const projectPill = (axis: FloorGroupBy | 'none', key: string) => (
+              axis === 'project' ? managedProjects.find((p) => p.name === key)?.linearProjectName : undefined
+            )
+            const linkedProject = projectPill(floorGroup, k)
             const countLabel = floorGroup === 'project'
               ? `${arr.length} agent${arr.length === 1 ? '' : 's'}`
               : `${arr.length}`
+            const subgroupActive = floorSubgroup !== 'none' && floorSubgroup !== floorGroup
+            const subgroups = subgroupActive ? [...groupAgents(arr, floorSubgroup).entries()] : []
+            const renderRows = (rows: FloorAgent[]) => rows.map((a) => (
+              <FeedRow onOpenTask={openTaskFromAgent}
+                key={a.id}
+                agent={a}
+                selected={selectedFloorAgent?.id === a.id}
+                plain={plain}
+                onSelect={selectFloorAgent}
+                onOption={onAgentOption}
+                onFreeText={replyToAgent}
+                onAttach={onAttachScreenshot}
+                onOpenPlan={openPlanPreview}
+                onOpenTerminal={openTerminalForAgent}
+              />
+            ))
             return (
             <React.Fragment key={k}>
               <div className="feed-sec">
@@ -2134,20 +2167,21 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
                 {linkedProject && <span className="proj-lk">{linkedProject}</span>}
                 <span className="ln" />
               </div>
-              {arr.map((a) => (
-                <FeedRow onOpenTask={openTaskFromAgent}
-                  key={a.id}
-                  agent={a}
-                  selected={selectedFloorAgent?.id === a.id}
-                  plain={plain}
-                  onSelect={selectFloorAgent}
-                  onOption={onAgentOption}
-                  onFreeText={replyToAgent}
-                  onAttach={onAttachScreenshot}
-                  onOpenPlan={openPlanPreview}
-              onOpenTerminal={openTerminalForAgent}
-                />
-              ))}
+              {subgroupActive
+                ? subgroups.map(([subKey, subArr]) => {
+                    const linkedSubProject = projectPill(floorSubgroup, subKey)
+                    return (
+                      <React.Fragment key={`${k}:${subKey}`}>
+                        <div className="feed-sec feed-subsec">
+                          {subKey} · {subArr.length}
+                          {linkedSubProject && <span className="proj-lk">{linkedSubProject}</span>}
+                          <span className="ln" />
+                        </div>
+                        {renderRows(subArr)}
+                      </React.Fragment>
+                    )
+                  })
+                : renderRows(arr)}
             </React.Fragment>
           )})}
 
@@ -2256,9 +2290,13 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
           sort={floorSort}
           onSort={setFloorSort}
           group={floorGroup}
-          onGroup={setFloorGroup}
+          onGroup={handleFloorGroup}
+          subgroup={floorSubgroup}
+          onSubgroup={setFloorSubgroup}
           ticketGroup={ticketGroup}
-          onTicketGroup={setTicketGroup}
+          onTicketGroup={handleTicketGroup}
+          ticketSubgroup={ticketSubgroup}
+          onTicketSubgroup={setTicketSubgroup}
           ticketSort={ticketSort}
           onTicketSort={setTicketSort}
           srcFilter={ticketSrc}

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -239,6 +239,7 @@
 .swarmify-root .decide .qtask b { color: var(--ds-text-dim); font-weight: 700; }
 .swarmify-root .decide .qt { font-size: 13.5px; font-weight: 600; margin-bottom: 10px; }
 .swarmify-root .feed-sec { font-size: 11px; font-weight: 800; letter-spacing: .05em; color: var(--ds-text-dim); margin: 18px 4px 8px; display: flex; align-items: center; gap: 8px; }
+.swarmify-root .feed-sec.feed-subsec { margin: 10px 4px 6px 18px; font-size: 10.5px; color: var(--ds-text-muted); }
 .swarmify-root .feed-sec.attn { color: var(--status-pending); }
 /* Linear project link pill in a project group header (mockup: "RUSH · Agents CLI"). */
 .swarmify-root .feed-sec .proj-lk { font-family: "Geist Mono", monospace; font-size: 10.5px; font-weight: 600; letter-spacing: 0; color: #4a8dff; border: 1px solid rgba(74,141,255,0.32); border-radius: 20px; padding: 2px 9px; text-transform: none; }

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -25,7 +25,7 @@ import { TicketDetail } from '../components/mission-control/TicketDetail'
 import { ProjectsPane } from '../components/mission-control/ProjectsPane'
 import { TerminalExpandedDetail } from '../components/mission-control/TerminalDetail'
 import { AgentDecision } from '../components/mission-control/AgentDecision'
-import { ticketWorkers, type FloorAgent, type FloorTicket, type StructuredQuestion, type FloorSort, type TicketGroupBy, type TicketSort, type CenterMode, type ManagedProject, type LinearProjectLite } from '../components/mission-control/floorModel'
+import { ticketWorkers, type FloorAgent, type FloorTicket, type StructuredQuestion, type FloorGroupBy, type FloorSort, type TicketGroupBy, type TicketSort, type CenterMode, type ManagedProject, type LinearProjectLite } from '../components/mission-control/floorModel'
 import { RecapPane } from '../components/mission-control/RecapPane'
 import { buildRecap } from '../components/mission-control/recapModel'
 import type { RemoteSessionLike } from '../components/mission-control/floorAdapter'
@@ -231,7 +231,8 @@ const linearProjectList: LinearProjectLite[] = [
 ]
 
 function Feed() {
-  const [grp, setGrp] = useState<'none' | 'project' | 'host' | 'status' | 'agent'>('project')
+  const [grp, setGrp] = useState<FloorGroupBy | 'none'>('project')
+  const [subgrp, setSubgrp] = useState<FloorGroupBy | 'none'>('host')
   const [srt, setSrt] = useState<'needs' | 'recent' | 'tok' | 'name'>('needs')
   return (
     <div className="feed">
@@ -241,7 +242,9 @@ function Feed() {
         sidebarOpen rightOpen plain={false}
         onToggleSidebar={noop} onToggleRight={noop} onTogglePlain={noop}
         sort={srt} onSort={setSrt} group={grp} onGroup={setGrp}
+        subgroup={subgrp} onSubgroup={setSubgrp}
         ticketGroup="project" onTicketGroup={noop}
+        ticketSubgroup="none" onTicketSubgroup={noop}
         ticketSort="priority" onTicketSort={noop}
         srcFilter={{ LN: true, GH: true }} onToggleSrc={noop}
       />
@@ -296,6 +299,7 @@ function Feed() {
 // group/sort/source controls live in the shared bar now, not a per-view toolbar.
 function Backlog() {
   const [group, setGroup] = useState<TicketGroupBy>('project')
+  const [subgroup, setSubgroup] = useState<TicketGroupBy | 'none'>('source')
   const [sort, setSort] = useState<TicketSort>('priority')
   const [srcFilter, setSrcFilter] = useState<Record<'LN' | 'GH', boolean>>({ LN: true, GH: true })
   const [selected, setSelected] = useState<string | null>(null)
@@ -312,13 +316,16 @@ function Backlog() {
         sidebarOpen rightOpen plain={false}
         onToggleSidebar={noop} onToggleRight={noop} onTogglePlain={noop}
         sort="needs" onSort={noop} group="project" onGroup={noop}
+        subgroup="none" onSubgroup={noop}
         ticketGroup={group} onTicketGroup={setGroup}
+        ticketSubgroup={subgroup} onTicketSubgroup={setSubgroup}
         ticketSort={sort} onTicketSort={setSort}
         srcFilter={srcFilter} onToggleSrc={(s) => setSrcFilter((f) => ({ ...f, [s]: !f[s] }))}
       />
       <BacklogCenter
         tickets={tickets}
         group={group}
+        subgroup={subgroup}
         sort={sort}
         srcFilter={srcFilter}
         projFilter={null}
@@ -344,9 +351,11 @@ function Subtabs() {
     { id: 'RUSH-1262', title: 'PKCE token exchange uses unpinned http client', source: 'LN' },
     { id: '#418', title: 'Kanban / Deadline feed views are stubs', source: 'GH' },
   ])
-  const [grp, setGrp] = useState<'none' | 'project' | 'host' | 'status' | 'agent'>('project')
+  const [grp, setGrp] = useState<FloorGroupBy | 'none'>('project')
+  const [subgrp, setSubgrp] = useState<FloorGroupBy | 'none'>('host')
   const [srt, setSrt] = useState<FloorSort>('needs')
   const [tg, setTg] = useState<TicketGroupBy>('project')
+  const [tsg, setTsg] = useState<TicketGroupBy | 'none'>('source')
   const [ts, setTs] = useState<TicketSort>('priority')
   const [src, setSrc] = useState<Record<'LN' | 'GH', boolean>>({ LN: true, GH: true })
   const [selected, setSelected] = useState<string | null>(null)
@@ -381,7 +390,9 @@ function Subtabs() {
           sidebarOpen rightOpen plain={false}
           onToggleSidebar={noop} onToggleRight={noop} onTogglePlain={noop}
           sort={srt} onSort={setSrt} group={grp} onGroup={setGrp}
+          subgroup={subgrp} onSubgroup={setSubgrp}
           ticketGroup={tg} onTicketGroup={setTg}
+          ticketSubgroup={tsg} onTicketSubgroup={setTsg}
           ticketSort={ts} onTicketSort={setTs}
           srcFilter={src} onToggleSrc={(s) => setSrc((f) => ({ ...f, [s]: !f[s] }))}
         />
@@ -390,6 +401,7 @@ function Subtabs() {
         <BacklogCenter
           tickets={tickets}
           group={tg}
+          subgroup={tsg}
           sort={ts}
           srcFilter={src}
           projFilter={null}


### PR DESCRIPTION
## What
- Added Subgroup selectors to the Factory Floor live-feed controls and Backlog controls.
- Exclude the currently selected primary group axis from subgroup options, with duplicate selections normalized to `None`.
- Render nested section headers for grouped agents and backlog tickets.
- Updated the standalone preview harness and Factory changelog.

## Evidence
- `apps/factory/ui/settings/components/mission-control/FloorControls.tsx:94` normalizes duplicate subgroup selections to `None`.
- `apps/factory/ui/settings/components/mission-control/FloorControls.tsx:96` excludes the active primary group axis from feed subgroup options.
- `apps/factory/ui/settings/components/mission-control/BacklogCenter.tsx:99` enables nested backlog grouping only when subgroup differs from primary group.
- `apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx:691` resets live subgroup when the primary group changes to the same axis.
- `apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx:2147` renders grouped agents through optional second-level groups.
- `apps/factory/CHANGELOG.md:14` documents the user-visible Subgroup control.

## Tests
- `PATH=/home/muqsit/.bun/bin:$PATH bun test settings/components/mission-control/FloorControls.test.tsx settings/components/mission-control/SavedViewsBar.test.tsx settings/components/mission-control/BacklogCenter.test.tsx` in `apps/factory/ui` -> 17 pass, 0 fail.
- `PATH=/home/muqsit/.bun/bin:$PATH bunx vite build --config vite.preview.config.ts` in `apps/factory/ui` -> preview build passed.
- `PATH=/home/muqsit/.bun/bin:$PATH bun run compile` in `apps/factory` -> TypeScript + settings/editor Vite builds passed.

## Visual proof
- Feed controls screenshot: `/tmp/rush1544-feed.png` shows `Group: Project` and `Subgroup: Host`.
- Backlog screenshot: `/tmp/rush1544-backlog.png` shows `Group: Project`, `Subgroup: Source`, and nested Linear/GitHub headers.