### PR TITLE
ci: move Linux jobs to the self-hosted runner pool

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   bench:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     permissions: {}
     defaults:
       run:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   gitleaks:
     name: gitleaks
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     permissions:
       contents: read
       pull-requests: write
@@ -50,5 +50,9 @@ jobs:
           # If unset, the action runs in unlicensed mode and prints a warning.
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
           # Fail the job on any leak; SOC 2 evidence requires a hard gate, not a warning.
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: true
+          # Artifact upload is off: the action roots the upload at $HOME, which on
+          # the self-hosted runner box is not a parent of the workdir, so the upload
+          # throws even on a clean scan (hit on muqsitnawaz/agents, same runner).
+          # The hard gate (exit code) and the step summary carry the evidence.
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
           GITLEAKS_ENABLE_SUMMARY: true

--- a/.github/workflows/tests-windows-noop.yml
+++ b/.github/workflows/tests-windows-noop.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   test-windows:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
   # dist/, so the build never needed to precede the suite -- pulling it onto its
   # own lane takes it off the test critical path while still gating types.
   typecheck:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 15
     defaults:
       run:
@@ -43,7 +43,7 @@ jobs:
   # files on its own runner; fail-fast is off so one failing shard doesn't cancel
   # the others (you see every failure in one run).
   test-shard:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -71,7 +71,7 @@ jobs:
   test:
     needs: [typecheck, test-shard]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
     steps:
       - name: Gate on typecheck + all test shards

--- a/.github/workflows/verify-publish-auth.yml
+++ b/.github/workflows/verify-publish-auth.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     permissions:
       contents: read
 


### PR DESCRIPTION
## Why

GitHub Actions billing lapsed account-wide — every `ubuntu-latest`/`windows-latest` job no-starts with "recent account payments have failed". muqsitnawaz/agents already migrated (its PR #974); this brings agents-cli onto the same self-hosted pool.

## Runners

Two persistent runners are registered for this repo and online: `ci-runner-01-cli-1`, `ci-runner-01-cli-2` (labels `self-hosted, linux, x64`) on the ci-runner-01 box (Hetzner cpx41, shared with the agents repo's 4 ephemeral runners). Ops doc: `infra/ci-runner/RUNBOOK.md` in muqsitnawaz/agents.

## Moved to self-hosted

- tests.yml (3 jobs — the main-PR gate)
- secret-scan.yml (gitleaks; artifact upload disabled — the action roots uploads at $HOME which isn't a workdir parent on this box, same fix that landed in the agents repo)
- bench.yml, tests-windows-noop.yml, verify-publish-auth.yml

## Deliberately left GitHub-hosted

- ci.yml — release-only cross-platform matrix (macos/windows legs can't run on a Linux box)
- tests-windows.yml, computer-helper-win.yml, tests-windows-host-e2e.yml — need a Windows runner

Those stay billing-gated until billing is fixed or a Windows/macOS runner is registered.

## Verification

Self-verifying: this PR's own `test` + `gitleaks` checks run on the new runners.