### PR TITLE
feat(routines): device affinity allowlists and host routing

### DIFF
--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -35,6 +35,8 @@ import {
   getJobPath,
   parseAtTime,
   jobRunsOnThisDevice,
+  normalizeDevices,
+  jobDeviceOwners,
 } from '../lib/routines.js';
 import type { JobConfig } from '../lib/routines.js';
 import { fireWebhookJobs, matchJobsToWebhook, type GithubWebhook } from '../lib/triggers/webhook.js';
@@ -46,6 +48,8 @@ import { JobScheduler } from '../lib/scheduler.js';
 import { detectOverdueJobs } from '../lib/overdue.js';
 import { isInteractiveTerminal, requireInteractiveSelection } from './utils.js';
 import { setHelpSections } from '../lib/help.js';
+import { addHostOption } from '../lib/hosts/option.js';
+import { loadDevicesSync } from '../lib/devices/registry.js';
 
 /**
  * Human-friendly wall-clock a run took (e.g. "  · 3 min", "  · 45 sec"), or ""
@@ -157,9 +161,9 @@ async function pickJob(
 
 /** Register the `agents routines` command tree. */
 export function registerRoutinesCommands(program: Command): void {
-  const routinesCmd = program
+  const routinesCmd = addHostOption(program
     .command('routines')
-    .description('Schedule agents to run on a cron schedule or at a specific time. The scheduler auto-starts on first add.');
+    .description('Schedule agents to run on a cron schedule or at a specific time. The scheduler auto-starts on first add.'));
 
   setHelpSections(routinesCmd, {
     examples: `
@@ -249,6 +253,7 @@ export function registerRoutinesCommands(program: Command): void {
             trigger: job.trigger ?? null,
             timezone: job.timezone ?? null,
             device: job.device ?? null,
+            devices: job.devices ?? null,
             runsHere: jobRunsOnThisDevice(job),
             enabled: job.enabled,
             overdue: overdueSet.has(job.name),
@@ -311,12 +316,13 @@ export function registerRoutinesCommands(program: Command): void {
         const enabledWord = job.enabled ? 'yes' : 'no';
         const enabledPad = Math.max(0, ENABLED_W - enabledWord.length);
 
-        // Unpinned jobs run everywhere; a pin that names another machine is
-        // grayed — this machine never fires it.
-        const deviceWord = job.device || '-';
-        const deviceCell = !job.device
+        const deviceWord = job.devices && job.devices.length > 0
+          ? job.devices.join(',')
+          : job.device || '-';
+        const runsHere = jobRunsOnThisDevice(job);
+        const deviceCell = deviceWord === '-'
           ? chalk.gray('-')
-          : jobRunsOnThisDevice(job)
+          : runsHere
             ? deviceWord
             : chalk.gray(deviceWord);
         const devicePad = Math.max(0, DEVICE_W - deviceWord.length);
@@ -358,6 +364,7 @@ export function registerRoutinesCommands(program: Command): void {
     .option('-t, --timeout <timeout>', 'Kill the agent if it runs longer than this (e.g., 10m, 2h, 3d, 1w; max 1w)', '10m')
     .option('--timezone <tz>', 'Interpret schedule in this timezone (e.g., America/Los_Angeles)')
     .option('--device <name>', 'Pin to one machine (routines are fleet-synced): only the device with this name schedules and fires the job')
+    .option('--devices <names>', 'Allowlist of devices that may execute this routine (comma-separated, e.g. yosemite-s0,mac-mini)')
     .option('--at <time>', 'One-shot mode: run once at this time (e.g., "14:30" or "2026-02-24 09:00"), then disable')
     .option('--end-at <iso>', 'Stop firing on or after this ISO 8601 timestamp (e.g., "2026-12-31T23:59:00Z"); routine auto-disables.')
     .option('--disabled', 'Create the routine but keep it paused (enable later with resume)')
@@ -409,6 +416,10 @@ export function registerRoutinesCommands(program: Command): void {
           process.exit(1);
         }
 
+        const parsedDevices = options.devices
+          ? normalizeDevices(options.devices.split(',').map((s: string) => s.trim()).filter(Boolean))
+          : undefined;
+
         const config: JobConfig = {
           name: nameOrPath,
           schedule,
@@ -421,6 +432,7 @@ export function registerRoutinesCommands(program: Command): void {
           prompt: options.prompt,
           timezone: options.timezone,
           ...(options.device ? { device: options.device } : {}),
+          ...(parsedDevices && parsedDevices.length > 0 ? { devices: parsedDevices } : {}),
           ...(runOnce ? { runOnce: true } : {}),
           ...(options.endAt ? { endAt: options.endAt } : {}),
         };
@@ -641,8 +653,14 @@ export function registerRoutinesCommands(program: Command): void {
       }
 
       if (!jobRunsOnThisDevice(job)) {
-        console.log(chalk.red(`Job '${name}' is pinned to device '${job.device}' and never runs here.`));
-        console.log(chalk.gray(`  Run it there: agents ssh ${job.device} 'agents routines run ${name}'`));
+        const owners = jobDeviceOwners(job);
+        const ownerList = owners.join(', ');
+        console.log(chalk.red(`Job '${name}' is restricted to device(s) ${ownerList} and never runs here.`));
+        if (owners.length === 1) {
+          console.log(chalk.gray(`  Run it there: agents ssh ${owners[0]} 'agents routines run ${name}'`));
+        } else {
+          console.log(chalk.gray(`  Run it on one of them: agents routines run ${name} --host <device>`));
+        }
         process.exit(1);
       }
 
@@ -720,6 +738,72 @@ export function registerRoutinesCommands(program: Command): void {
         }
       }
       console.log(chalk.gray('\nTrack progress with: agents routines runs <name>'));
+    });
+
+  routinesCmd
+    .command('devices [name]')
+    .description('View or update the device allowlist for a routine. Without flags, shows current devices. Use --set to replace or --clear to remove the allowlist.')
+    .option('--set <names>', 'Replace the allowlist with a comma-separated list of device names')
+    .option('--clear', 'Remove the device allowlist (routine becomes unrestricted)')
+    .action(async (name: string | undefined, options: { set?: string; clear?: boolean }) => {
+      if (!name) {
+        name = await pickJob('Select routine', undefined, ['agents routines devices <name>']) ?? undefined;
+        if (!name) return;
+      }
+
+      const job = readJob(name);
+      if (!job) {
+        console.log(chalk.red(`Job '${name}' not found`));
+        process.exit(1);
+      }
+
+      if (!options.set && !options.clear) {
+        // Display mode: show current devices
+        const owners = jobDeviceOwners(job);
+        if (owners.length === 0) {
+          console.log(chalk.gray(`'${name}' has no device restriction (runs on any device)`));
+        } else {
+          console.log(chalk.bold(`Devices for '${name}':\n`));
+          for (const d of owners) {
+            const here = jobRunsOnThisDevice({ devices: [d] }) ? chalk.green(' (this machine)') : '';
+            console.log(`  ${d}${here}`);
+          }
+        }
+        return;
+      }
+
+      if (options.clear) {
+        delete job.device;
+        delete job.devices;
+        writeJob(job);
+        console.log(chalk.green(`Cleared device restriction for '${name}' — runs on any device`));
+        if (isDaemonRunning()) signalDaemonReload();
+        return;
+      }
+
+      if (options.set) {
+        const raw = options.set.split(',').map((s) => s.trim()).filter(Boolean);
+        if (raw.length === 0) {
+          console.log(chalk.red('--set requires at least one device name'));
+          process.exit(1);
+        }
+
+        const normalized = normalizeDevices(raw);
+
+        // Validate against fleet
+        const registry = loadDevicesSync();
+        const known = new Set(Object.keys(registry).map((k) => k.toLowerCase()));
+        const unknown = normalized.filter((d) => !known.has(d));
+        if (unknown.length > 0) {
+          console.log(chalk.yellow(`Unknown device(s): ${unknown.join(', ')} — not in the registry (agents devices). Saving anyway.`));
+        }
+
+        delete job.device;
+        job.devices = normalized;
+        writeJob(job);
+        console.log(chalk.green(`Set devices for '${name}': ${normalized.join(', ')}`));
+        if (isDaemonRunning()) signalDaemonReload();
+      }
     });
 
   routinesCmd

--- a/apps/cli/src/lib/hosts/passthrough.test.ts
+++ b/apps/cli/src/lib/hosts/passthrough.test.ts
@@ -65,4 +65,9 @@ describe('maybeRunOnHost — local short-circuits (no SSH attempted)', () => {
     expect(process.exitCode).toBe(1);
     process.exitCode = 0;
   });
+
+  it('accepts routines as a host-routable command', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    expect(await maybeRunOnHost('routines', ['routines', 'list', '--host', 'mybox'])).toBe(false);
+  });
 });

--- a/apps/cli/src/lib/hosts/passthrough.ts
+++ b/apps/cli/src/lib/hosts/passthrough.ts
@@ -47,6 +47,7 @@ const REMOTE_PASSTHROUGH: Record<string, RemoteSpec> = {
   sync: { nonInteractive: ['--yes'] },
   teams: {},
   message: {},
+  routines: {},
 };
 
 /** `--no-tty` is stripped like the routing flags but carries no value. */

--- a/apps/cli/src/lib/routines.test.ts
+++ b/apps/cli/src/lib/routines.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
-import { validateJob, validateTrigger, normalizeTriggerEvent, writeJob, readJob, deleteJob, jobRunsOnThisDevice, type JobConfig } from './routines.js';
+import { validateJob, validateTrigger, normalizeTriggerEvent, writeJob, readJob, deleteJob, jobRunsOnThisDevice, normalizeDevices, jobDeviceOwners, type JobConfig } from './routines.js';
 import { getRoutinesDir, ensureAgentsDir } from './state.js';
 
 /** Minimal valid schedule-based job. */
@@ -141,6 +141,22 @@ describe('validateJob — device', () => {
   });
 });
 
+describe('validateJob — devices array', () => {
+  it('accepts a job with a devices allowlist', () => {
+    expect(validateJob(baseJob({ schedule: '0 3 * * *', devices: ['yosemite-s0', 'mac-mini'] }))).toEqual([]);
+  });
+
+  it('rejects a non-array devices', () => {
+    const errors = validateJob(baseJob({ schedule: '0 3 * * *', devices: 'yosemite-s0' as never }));
+    expect(errors.some((e) => /devices must be an array/.test(e))).toBe(true);
+  });
+
+  it('rejects an empty-string entry in devices', () => {
+    const errors = validateJob(baseJob({ schedule: '0 3 * * *', devices: ['yosemite-s0', ''] }));
+    expect(errors.some((e) => /each entry in devices must be a non-empty device name/.test(e))).toBe(true);
+  });
+});
+
 describe('jobRunsOnThisDevice', () => {
   const savedId = process.env.AGENTS_SYNC_MACHINE_ID;
 
@@ -168,5 +184,59 @@ describe('jobRunsOnThisDevice', () => {
   it('rejects a pin naming another machine', () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
     expect(jobRunsOnThisDevice({ device: 'yosemite-s0' })).toBe(false);
+  });
+
+  it('matches when this machine is in the devices allowlist', () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'yosemite-s0';
+    expect(jobRunsOnThisDevice({ devices: ['yosemite-s0', 'mac-mini'] })).toBe(true);
+  });
+
+  it('rejects when this machine is not in the devices allowlist', () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+    expect(jobRunsOnThisDevice({ devices: ['yosemite-s0', 'mac-mini'] })).toBe(false);
+  });
+
+  it('devices takes precedence over device', () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+    expect(jobRunsOnThisDevice({ device: 'zion', devices: ['yosemite-s0'] })).toBe(false);
+  });
+
+  it('normalizes devices entries', () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'yosemite-s0';
+    expect(jobRunsOnThisDevice({ devices: ['Yosemite-S0.tailnet.ts.net'] })).toBe(true);
+  });
+
+  it('empty devices array means unrestricted (falls through to device)', () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+    expect(jobRunsOnThisDevice({ devices: [], device: 'zion' })).toBe(true);
+    expect(jobRunsOnThisDevice({ devices: [] })).toBe(true);
+  });
+});
+
+describe('normalizeDevices', () => {
+  it('lowercases, deduplicates, and sorts', () => {
+    expect(normalizeDevices(['Mac-Mini', 'yosemite-s0', 'mac-mini'])).toEqual(['mac-mini', 'yosemite-s0']);
+  });
+
+  it('strips domain suffixes', () => {
+    expect(normalizeDevices(['yosemite-s0.tailnet.ts.net'])).toEqual(['yosemite-s0']);
+  });
+
+  it('returns empty for empty input', () => {
+    expect(normalizeDevices([])).toEqual([]);
+  });
+});
+
+describe('jobDeviceOwners', () => {
+  it('returns devices when set', () => {
+    expect(jobDeviceOwners({ devices: ['Mac-Mini', 'yosemite-s0'] })).toEqual(['mac-mini', 'yosemite-s0']);
+  });
+
+  it('returns device when devices is not set', () => {
+    expect(jobDeviceOwners({ device: 'Yosemite-S0' })).toEqual(['yosemite-s0']);
+  });
+
+  it('returns empty when neither is set', () => {
+    expect(jobDeviceOwners({})).toEqual([]);
   });
 });

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -104,6 +104,14 @@ export interface JobConfig {
    * inert and `run` refuses with an `agents ssh` pointer.
    */
   device?: string;
+  /**
+   * Allowlist of devices that may execute this routine. When set, only devices
+   * whose `machineId()` matches one of the entries (after `normalizeHost`) may
+   * schedule, fire, catch up, or manually run the job. Omitted means
+   * unrestricted (any device may execute). Takes precedence over `device` when
+   * both are set (but setting both is unusual — prefer `devices`).
+   */
+  devices?: string[];
   variables?: Record<string, string>;
   sandbox?: boolean;
   allow?: JobAllowConfig;
@@ -130,14 +138,44 @@ export interface RunMeta {
 }
 
 /**
- * True when the job may execute on this machine: no `device` pin, or the pin
- * names this device. Both sides go through `normalizeHost` so `Yosemite-S0`,
+ * True when the job may execute on this machine. Checks both `devices` (the
+ * allowlist) and `device` (the legacy single pin). When `devices` is set, the
+ * machine must appear in the list. When only `device` is set, the machine must
+ * match the pin. When neither is set, the job is unrestricted and runs
+ * everywhere. Both sides go through `normalizeHost` so `Yosemite-S0`,
  * `yosemite-s0.tailnet.ts.net`, and `yosemite-s0` all agree. Every fire path
  * (cron scheduler, webhook, catchup/overdue, manual run) gates on this.
  */
-export function jobRunsOnThisDevice(config: Pick<JobConfig, 'device'>): boolean {
+export function jobRunsOnThisDevice(config: Pick<JobConfig, 'device' | 'devices'>): boolean {
+  const id = machineId();
+  if (config.devices && config.devices.length > 0) {
+    return config.devices.some((d) => normalizeHost(d) === id);
+  }
   if (!config.device) return true;
-  return normalizeHost(config.device) === machineId();
+  return normalizeHost(config.device) === id;
+}
+
+/**
+ * Normalize and deduplicate a `devices` array: lowercase, strip domain suffix,
+ * collapse duplicates. Returns a new sorted array.
+ */
+export function normalizeDevices(raw: string[]): string[] {
+  const seen = new Set<string>();
+  for (const d of raw) {
+    const n = normalizeHost(d);
+    if (n) seen.add(n);
+  }
+  return [...seen].sort();
+}
+
+/**
+ * Return the list of device names that own a job (for error messages).
+ * Prefers `devices` over `device`.
+ */
+export function jobDeviceOwners(config: Pick<JobConfig, 'device' | 'devices'>): string[] {
+  if (config.devices && config.devices.length > 0) return normalizeDevices(config.devices);
+  if (config.device) return [normalizeHost(config.device)];
+  return [];
 }
 
 /** Default values applied to every job config when fields are omitted. */
@@ -233,6 +271,7 @@ export function writeJob(config: JobConfig): void {
   if (output.timeout === '10m') delete output.timeout;
   if (output.enabled === true) delete output.enabled;
   if (output.runOnce === false || output.runOnce === undefined) delete output.runOnce;
+  if (output.devices && Array.isArray(output.devices) && output.devices.length === 0) delete output.devices;
 
   fs.writeFileSync(filePath, yaml.stringify(output), 'utf-8');
 }
@@ -320,6 +359,18 @@ export function validateJob(config: Partial<JobConfig>): string[] {
   if (config.device !== undefined) {
     if (typeof config.device !== 'string' || config.device.trim() === '') {
       errors.push('device must be a non-empty device name (as shown by `agents devices`, e.g. yosemite-s0)');
+    }
+  }
+  if (config.devices !== undefined) {
+    if (!Array.isArray(config.devices)) {
+      errors.push('devices must be an array of device names');
+    } else {
+      for (const d of config.devices) {
+        if (typeof d !== 'string' || d.trim() === '') {
+          errors.push('each entry in devices must be a non-empty device name');
+          break;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Add `devices?: string[]` allowlist field to `JobConfig` — when set, only listed devices may schedule/fire/catchup/run the routine. Omitted means unrestricted. Takes precedence over the legacy singular `device` pin.
- One centralized `jobRunsOnThisDevice()` enforces eligibility across all paths: cron scheduler, overdue/catchup detection, webhook trigger matching, and manual `routines run`.
- Add `routines` to `REMOTE_PASSTHROUGH` so `agents routines --host <device>` routes over SSH. Register host options on the routines command for local fall-through parsing.
- CLI surface: `routines add --devices yosemite-s0,mac-mini`; `routines devices <name> --set a,b --clear`; list table and JSON output include `devices` array.
- Normalize/dedupe device names via `normalizeDevices()`. Validate CLI selections against fleet registry (warning, not blocking).
- Wrong-host explicit runs fail with owner list and a `--host` hint; automatic paths skip and log.

## Test plan

- [x] `routines.test.ts`: 35 tests pass — covers `devices` validation, `jobRunsOnThisDevice` with array, `normalizeDevices`, `jobDeviceOwners`
- [x] `passthrough.test.ts`: 13 tests pass — covers routines as host-routable command
- [x] `npm run build` succeeds
- [x] Full test suite: all pre-existing passes still pass; 31 failures are pre-existing `bun ENOENT` infrastructure issues

## Evidence

- Transcript: `yosemite-s0:/home/muqsit/.agents/.history/versions/claude/2.1.170/home/.claude/projects/-home-muqsit--agents-repos-routine-device-affinity--agents-worktrees-routine-affinity-code/159199f5-9c9b-4ed5-980c-6812ca6665e6.jsonl`