### PR TITLE
feat(routines): replace singular device with devices allowlist

### DIFF
--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -226,3 +226,49 @@ describe('routines devices no-flags nonTTY names --set/--clear', () => {
     }
   });
 });
+
+describe('routines list --host self runs locally', () => {
+  it('exits 0 and lists when --host matches AGENTS_SYNC_MACHINE_ID', () => {
+    const job = { ...baseJob, devices: ['zion'] };
+    const home = makeHome({ jobs: [job], registry });
+    try {
+      const res = run(home, ['list', '--host', 'zion'], { AGENTS_SYNC_MACHINE_ID: 'zion' });
+      expect(res.status).toBe(0);
+      expect(res.stdout).toContain('test-job');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines --help documents --host and --device', () => {
+  it('help output contains --host and --device', () => {
+    const home = makeHome();
+    try {
+      const res = run(home, ['--help']);
+      const output = res.stdout + res.stderr;
+      expect(output).toContain('--host');
+      expect(output).toContain('--device');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines devices --set and --clear are mutually exclusive', () => {
+  it('exits nonzero without mutation when both are given', () => {
+    const job = { ...baseJob, devices: ['yosemite-s0'] };
+    const home = makeHome({ jobs: [job], registry });
+    try {
+      const before = fs.readFileSync(path.join(home, '.agents', 'routines', 'test-job.yml'), 'utf-8');
+      const res = run(home, ['devices', 'test-job', '--set', 'mac-mini', '--clear']);
+      expect(res.status).not.toBe(0);
+      const output = res.stdout + res.stderr;
+      expect(output).toMatch(/mutually exclusive/);
+      const after = fs.readFileSync(path.join(home, '.agents', 'routines', 'test-job.yml'), 'utf-8');
+      expect(after).toBe(before);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -1,230 +1,228 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { Command } from 'commander';
+/**
+ * End-to-end CLI subprocess tests for `agents routines` device-affinity commands.
+ *
+ * Every test spawns the real CLI (`node --import tsx src/index.ts routines ...`)
+ * against an isolated mkdtemp HOME — no live ~/.agents state, no mocks, no
+ * imported writeJob/readJob. Modeled on `routines-webhook.test.ts`.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
 import * as fs from 'fs';
-import * as path from 'path';
 import * as os from 'os';
+import * as path from 'path';
 import * as yaml from 'yaml';
-import { registerRoutinesCommands } from './routines.js';
-import { readJob, deleteJob, writeJob, listJobs, validateJob, jobRunsOnThisDevice } from '../lib/routines.js';
-import type { JobConfig } from '../lib/routines.js';
-import { getRoutinesDir, ensureAgentsDir } from '../lib/state.js';
+import { fileURLToPath } from 'url';
 
-const tempDirs: string[] = [];
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 
-afterEach(() => {
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop()!;
-    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+/** Provision an isolated HOME with agents.yaml, .system/.git, and optional routines + device registry. */
+function makeHome(opts: {
+  jobs?: Record<string, unknown>[];
+  registry?: Record<string, unknown>;
+} = {}): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-routines-test-'));
+  const agentsDir = path.join(home, '.agents');
+  const routinesDir = path.join(agentsDir, 'routines');
+  fs.mkdirSync(routinesDir, { recursive: true });
+  fs.writeFileSync(path.join(agentsDir, 'agents.yaml'), 'agents: {}\n');
+  fs.mkdirSync(path.join(agentsDir, '.system', '.git'), { recursive: true });
+
+  for (const job of opts.jobs ?? []) {
+    fs.writeFileSync(
+      path.join(routinesDir, `${job.name}.yml`),
+      yaml.stringify(job),
+    );
   }
-  vi.restoreAllMocks();
+
+  if (opts.registry) {
+    const devicesDir = path.join(agentsDir, '.history', 'devices');
+    fs.mkdirSync(devicesDir, { recursive: true });
+    fs.writeFileSync(path.join(devicesDir, 'registry.json'), JSON.stringify(opts.registry));
+  }
+
+  return home;
+}
+
+/** Run `agents routines <args>` against an isolated HOME. */
+function run(home: string, args: string[], extraEnv: Record<string, string> = {}): ReturnType<typeof spawnSync> {
+  return spawnSync('node', ['--import', 'tsx', 'src/index.ts', 'routines', ...args], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      AGENTS_SKIP_MIGRATION: '1',
+      ...extraEnv,
+    },
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+}
+
+function readRoutineYaml(home: string, name: string): Record<string, unknown> | null {
+  const p = path.join(home, '.agents', 'routines', `${name}.yml`);
+  if (!fs.existsSync(p)) return null;
+  return yaml.parse(fs.readFileSync(p, 'utf-8'));
+}
+
+const baseJob = {
+  name: 'test-job',
+  schedule: '0 3 * * *',
+  agent: 'claude',
+  prompt: 'noop',
+};
+
+const registry = {
+  'yosemite-s0': { name: 'yosemite-s0', platform: 'linux' },
+  'mac-mini': { name: 'mac-mini', platform: 'macos' },
+  'zion': { name: 'zion', platform: 'macos' },
+};
+
+describe('routines devices --set persists', () => {
+  it('writes a devices allowlist to the routine YAML', () => {
+    const home = makeHome({ jobs: [baseJob], registry });
+    try {
+      const res = run(home, ['devices', 'test-job', '--set', 'yosemite-s0,mac-mini']);
+      expect(res.status).toBe(0);
+
+      const doc = readRoutineYaml(home, 'test-job');
+      expect(doc).not.toBeNull();
+      expect(doc!.devices).toEqual(['yosemite-s0', 'mac-mini']);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
 });
 
-function makeProgram(): Command {
-  const program = new Command();
-  program.exitOverride();
-  registerRoutinesCommands(program);
-  return program;
-}
-
-function baseConfig(partial: Partial<JobConfig> = {}): JobConfig {
-  return {
-    name: '__test-cmd-routines__',
-    schedule: '0 3 * * *',
-    agent: 'claude',
-    mode: 'auto',
-    effort: 'auto',
-    timeout: '10m',
-    enabled: true,
-    prompt: 'test prompt',
-    ...partial,
-  } as JobConfig;
-}
-
-describe('routines list — devices field in JSON output', () => {
-  it('JSON output includes devices array and runsHere boolean', () => {
-    ensureAgentsDir();
-    const name = '__test-list-devices-json__';
-    const config = baseConfig({ name, devices: ['yosemite-s0', 'mac-mini'] });
-
+describe('routines devices --clear removes allowlist', () => {
+  it('removes the devices field from the routine YAML', () => {
+    const job = { ...baseJob, devices: ['yosemite-s0'] };
+    const home = makeHome({ jobs: [job], registry });
     try {
-      writeJob(config);
+      const res = run(home, ['devices', 'test-job', '--clear']);
+      expect(res.status).toBe(0);
 
-      const chunks: string[] = [];
-      const origWrite = process.stdout.write;
-      process.stdout.write = ((chunk: string | Buffer) => {
-        chunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
-        return true;
-      }) as typeof process.stdout.write;
+      const raw = fs.readFileSync(path.join(home, '.agents', 'routines', 'test-job.yml'), 'utf-8');
+      expect(raw).not.toMatch(/^devices:/m);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
 
-      const program = makeProgram();
-      try {
-        program.parse(['routines', 'list', '--json'], { from: 'user' });
-      } catch { /* commander exitOverride throws on --help */ }
-      process.stdout.write = origWrite;
+describe('routines devices --set unknown is nonzero/no mutation', () => {
+  it('rejects unknown device names and does not mutate the YAML', () => {
+    const job = { ...baseJob, devices: ['yosemite-s0'] };
+    const home = makeHome({ jobs: [job], registry });
+    try {
+      const before = fs.readFileSync(path.join(home, '.agents', 'routines', 'test-job.yml'), 'utf-8');
 
-      const output = chunks.join('');
-      const parsed = JSON.parse(output.trim());
-      const entry = parsed.find((j: Record<string, unknown>) => j.name === name);
+      const res = run(home, ['devices', 'test-job', '--set', 'nonexistent-box']);
+      expect(res.status).not.toBe(0);
+
+      const after = fs.readFileSync(path.join(home, '.agents', 'routines', 'test-job.yml'), 'utf-8');
+      expect(after).toBe(before);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines add --devices unknown is nonzero/no write', () => {
+  it('rejects unknown devices and does not create the routine file', () => {
+    const home = makeHome({ registry });
+    try {
+      const res = run(home, [
+        'add', 'new-job',
+        '--schedule', '0 3 * * *',
+        '--agent', 'claude',
+        '--prompt', 'hi',
+        '--devices', 'nonexistent-box',
+      ]);
+      expect(res.status).not.toBe(0);
+      expect(fs.existsSync(path.join(home, '.agents', 'routines', 'new-job.yml'))).toBe(false);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines list --json has devices+runsHere, no device', () => {
+  it('includes devices array and runsHere, excludes singular device key', () => {
+    const job = { ...baseJob, devices: ['yosemite-s0', 'mac-mini'] };
+    const home = makeHome({ jobs: [job], registry });
+    try {
+      const res = run(home, ['list', '--json'], { AGENTS_SYNC_MACHINE_ID: 'yosemite-s0' });
+      expect(res.status).toBe(0);
+
+      const parsed = JSON.parse(res.stdout.trim());
+      const entry = parsed.find((j: Record<string, unknown>) => j.name === 'test-job');
       expect(entry).toBeDefined();
       expect(entry.devices).toEqual(['yosemite-s0', 'mac-mini']);
       expect(typeof entry.runsHere).toBe('boolean');
+      expect(entry.runsHere).toBe(true);
+      expect('device' in entry).toBe(false);
     } finally {
-      deleteJob(name);
+      fs.rmSync(home, { recursive: true, force: true });
     }
   });
 
-  it('JSON output shows empty devices array when unrestricted', () => {
-    ensureAgentsDir();
-    const name = '__test-list-nodevice-json__';
-    const config = baseConfig({ name });
-
+  it('shows empty devices array and runsHere=true when unrestricted', () => {
+    const home = makeHome({ jobs: [baseJob], registry });
     try {
-      writeJob(config);
+      const res = run(home, ['list', '--json']);
+      expect(res.status).toBe(0);
 
-      const chunks: string[] = [];
-      const origWrite = process.stdout.write;
-      process.stdout.write = ((chunk: string | Buffer) => {
-        chunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
-        return true;
-      }) as typeof process.stdout.write;
-
-      const program = makeProgram();
-      try {
-        program.parse(['routines', 'list', '--json'], { from: 'user' });
-      } catch { /* commander exitOverride */ }
-      process.stdout.write = origWrite;
-
-      const output = chunks.join('');
-      const parsed = JSON.parse(output.trim());
-      const entry = parsed.find((j: Record<string, unknown>) => j.name === name);
+      const parsed = JSON.parse(res.stdout.trim());
+      const entry = parsed.find((j: Record<string, unknown>) => j.name === 'test-job');
       expect(entry).toBeDefined();
       expect(entry.devices).toEqual([]);
       expect(entry.runsHere).toBe(true);
     } finally {
-      deleteJob(name);
+      fs.rmSync(home, { recursive: true, force: true });
     }
   });
 });
 
-describe('routines devices --set and --clear', () => {
-  it('--set writes a devices allowlist to the job YAML', async () => {
-    ensureAgentsDir();
-    const name = '__test-devices-set__';
-    writeJob(baseConfig({ name }));
-
+describe('routines list table has Devices column with bounded ellipsis', () => {
+  it('table header includes Devices', () => {
+    const home = makeHome({ jobs: [baseJob], registry });
     try {
-      const job = readJob(name);
-      expect(job).not.toBeNull();
-      expect(job!.devices).toBeUndefined();
-
-      // Simulate --set by calling parseAndValidateDevices logic through writeJob.
-      // Since parseAndValidateDevices calls loadDevices() and needs a registry,
-      // directly test the data-layer effect: write devices and read them back.
-      job!.devices = ['yosemite-s0', 'mac-mini'];
-      writeJob(job!);
-      const updated = readJob(name);
-      expect(updated!.devices).toEqual(['yosemite-s0', 'mac-mini']);
+      const res = run(home, ['list']);
+      expect(res.status).toBe(0);
+      expect(res.stdout).toContain('Devices');
     } finally {
-      deleteJob(name);
+      fs.rmSync(home, { recursive: true, force: true });
     }
   });
 
-  it('--clear removes the devices field entirely', () => {
-    ensureAgentsDir();
-    const name = '__test-devices-clear__';
-    writeJob(baseConfig({ name, devices: ['yosemite-s0'] }));
-
+  it('long device lists are ellipsized in the table', () => {
+    const job = { ...baseJob, devices: ['yosemite-s0', 'yosemite-s1', 'mac-mini', 'zion'] };
+    const home = makeHome({ jobs: [job], registry });
     try {
-      const job = readJob(name);
-      expect(job!.devices).toEqual(['yosemite-s0']);
-      job!.devices = undefined;
-      writeJob(job!);
-      const updated = readJob(name);
-      // writeJob strips empty/undefined devices — the YAML shouldn't have 'devices:'.
-      const raw = fs.readFileSync(path.join(getRoutinesDir(), name + '.yml'), 'utf-8');
-      expect(raw).not.toMatch(/^devices:/m);
-      // readJob still works, returning undefined for the field.
-      expect(updated!.devices).toBeUndefined();
+      const res = run(home, ['list']);
+      expect(res.status).toBe(0);
+      const stripped = res.stdout.replace(/\x1b\[[0-9;]*m/g, '');
+      const lines = stripped.split('\n').filter((l) => l.includes('test-job'));
+      expect(lines.length).toBeGreaterThan(0);
+      expect(lines[0]).toMatch(/…/);
     } finally {
-      deleteJob(name);
+      fs.rmSync(home, { recursive: true, force: true });
     }
   });
 });
 
-describe('routines add — --devices flag validation', () => {
-  it('validateJob rejects an add with stale singular device key', () => {
-    const config = { ...baseConfig(), device: 'yosemite-s0' } as Record<string, unknown>;
-    const errors = validateJob(config as Partial<JobConfig>);
-    expect(errors.some((e) => /singular "device" key is no longer supported/.test(e))).toBe(true);
-  });
-
-  it('validateJob accepts a valid devices array', () => {
-    const errors = validateJob(baseConfig({ devices: ['yosemite-s0', 'mac-mini'] }));
-    expect(errors).toEqual([]);
-  });
-
-  it('round-trips devices through writeJob and readJob', () => {
-    ensureAgentsDir();
-    const name = '__test-roundtrip-devices__';
+describe('routines devices no-flags nonTTY names --set/--clear', () => {
+  it('non-interactive devices without flags exits nonzero naming --set and --clear', () => {
+    const home = makeHome({ jobs: [baseJob], registry });
     try {
-      writeJob(baseConfig({ name, devices: ['yosemite-s0', 'mac-mini'] }));
-      const job = readJob(name);
-      expect(job!.devices).toEqual(['yosemite-s0', 'mac-mini']);
+      const res = run(home, ['devices', 'test-job']);
+      expect(res.status).not.toBe(0);
+      const output = res.stdout + res.stderr;
+      expect(output).toMatch(/--set/);
+      expect(output).toMatch(/--clear/);
     } finally {
-      deleteJob(name);
+      fs.rmSync(home, { recursive: true, force: true });
     }
-  });
-});
-
-describe('routines run — device eligibility enforcement', () => {
-  afterEach(() => {
-    delete process.env.AGENTS_SYNC_MACHINE_ID;
-  });
-
-  it('run action blocks when this machine is not in the allowlist', () => {
-    process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
-    ensureAgentsDir();
-    const name = '__test-run-blocked__';
-    writeJob(baseConfig({ name, devices: ['yosemite-s0'] }));
-
-    try {
-      const job = readJob(name);
-      expect(job).not.toBeNull();
-      expect(jobRunsOnThisDevice(job!)).toBe(false);
-    } finally {
-      deleteJob(name);
-    }
-  });
-
-  it('run action allows when this machine is in the allowlist', () => {
-    process.env.AGENTS_SYNC_MACHINE_ID = 'yosemite-s0';
-    ensureAgentsDir();
-    const name = '__test-run-allowed__';
-    writeJob(baseConfig({ name, devices: ['yosemite-s0', 'mac-mini'] }));
-
-    try {
-      const job = readJob(name);
-      expect(jobRunsOnThisDevice(job!)).toBe(true);
-    } finally {
-      deleteJob(name);
-    }
-  });
-});
-
-describe('devices table truncation', () => {
-  it('long device lists get ellipsized in table output', () => {
-    const DEVICE_W = 22;
-    const deviceFull = 'yosemite-s0,yosemite-s1,mac-mini,zion';
-    const deviceWord = deviceFull.length > DEVICE_W ? deviceFull.slice(0, DEVICE_W - 1) + '…' : deviceFull;
-    expect(deviceWord.length).toBeLessThanOrEqual(DEVICE_W);
-    expect(deviceWord).toContain('…');
-  });
-
-  it('short device lists are not truncated', () => {
-    const DEVICE_W = 22;
-    const deviceFull = 'yosemite-s0';
-    const deviceWord = deviceFull.length > DEVICE_W ? deviceFull.slice(0, DEVICE_W - 1) + '…' : deviceFull;
-    expect(deviceWord).toBe('yosemite-s0');
-    expect(deviceWord).not.toContain('…');
   });
 });

--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as yaml from 'yaml';
+import { registerRoutinesCommands } from './routines.js';
+import { readJob, deleteJob, writeJob, listJobs, validateJob, jobRunsOnThisDevice } from '../lib/routines.js';
+import type { JobConfig } from '../lib/routines.js';
+import { getRoutinesDir, ensureAgentsDir } from '../lib/state.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()!;
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  }
+  vi.restoreAllMocks();
+});
+
+function makeProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  registerRoutinesCommands(program);
+  return program;
+}
+
+function baseConfig(partial: Partial<JobConfig> = {}): JobConfig {
+  return {
+    name: '__test-cmd-routines__',
+    schedule: '0 3 * * *',
+    agent: 'claude',
+    mode: 'auto',
+    effort: 'auto',
+    timeout: '10m',
+    enabled: true,
+    prompt: 'test prompt',
+    ...partial,
+  } as JobConfig;
+}
+
+describe('routines list — devices field in JSON output', () => {
+  it('JSON output includes devices array and runsHere boolean', () => {
+    ensureAgentsDir();
+    const name = '__test-list-devices-json__';
+    const config = baseConfig({ name, devices: ['yosemite-s0', 'mac-mini'] });
+
+    try {
+      writeJob(config);
+
+      const chunks: string[] = [];
+      const origWrite = process.stdout.write;
+      process.stdout.write = ((chunk: string | Buffer) => {
+        chunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+        return true;
+      }) as typeof process.stdout.write;
+
+      const program = makeProgram();
+      try {
+        program.parse(['routines', 'list', '--json'], { from: 'user' });
+      } catch { /* commander exitOverride throws on --help */ }
+      process.stdout.write = origWrite;
+
+      const output = chunks.join('');
+      const parsed = JSON.parse(output.trim());
+      const entry = parsed.find((j: Record<string, unknown>) => j.name === name);
+      expect(entry).toBeDefined();
+      expect(entry.devices).toEqual(['yosemite-s0', 'mac-mini']);
+      expect(typeof entry.runsHere).toBe('boolean');
+    } finally {
+      deleteJob(name);
+    }
+  });
+
+  it('JSON output shows empty devices array when unrestricted', () => {
+    ensureAgentsDir();
+    const name = '__test-list-nodevice-json__';
+    const config = baseConfig({ name });
+
+    try {
+      writeJob(config);
+
+      const chunks: string[] = [];
+      const origWrite = process.stdout.write;
+      process.stdout.write = ((chunk: string | Buffer) => {
+        chunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+        return true;
+      }) as typeof process.stdout.write;
+
+      const program = makeProgram();
+      try {
+        program.parse(['routines', 'list', '--json'], { from: 'user' });
+      } catch { /* commander exitOverride */ }
+      process.stdout.write = origWrite;
+
+      const output = chunks.join('');
+      const parsed = JSON.parse(output.trim());
+      const entry = parsed.find((j: Record<string, unknown>) => j.name === name);
+      expect(entry).toBeDefined();
+      expect(entry.devices).toEqual([]);
+      expect(entry.runsHere).toBe(true);
+    } finally {
+      deleteJob(name);
+    }
+  });
+});
+
+describe('routines devices --set and --clear', () => {
+  it('--set writes a devices allowlist to the job YAML', async () => {
+    ensureAgentsDir();
+    const name = '__test-devices-set__';
+    writeJob(baseConfig({ name }));
+
+    try {
+      const job = readJob(name);
+      expect(job).not.toBeNull();
+      expect(job!.devices).toBeUndefined();
+
+      // Simulate --set by calling parseAndValidateDevices logic through writeJob.
+      // Since parseAndValidateDevices calls loadDevices() and needs a registry,
+      // directly test the data-layer effect: write devices and read them back.
+      job!.devices = ['yosemite-s0', 'mac-mini'];
+      writeJob(job!);
+      const updated = readJob(name);
+      expect(updated!.devices).toEqual(['yosemite-s0', 'mac-mini']);
+    } finally {
+      deleteJob(name);
+    }
+  });
+
+  it('--clear removes the devices field entirely', () => {
+    ensureAgentsDir();
+    const name = '__test-devices-clear__';
+    writeJob(baseConfig({ name, devices: ['yosemite-s0'] }));
+
+    try {
+      const job = readJob(name);
+      expect(job!.devices).toEqual(['yosemite-s0']);
+      job!.devices = undefined;
+      writeJob(job!);
+      const updated = readJob(name);
+      // writeJob strips empty/undefined devices — the YAML shouldn't have 'devices:'.
+      const raw = fs.readFileSync(path.join(getRoutinesDir(), name + '.yml'), 'utf-8');
+      expect(raw).not.toMatch(/^devices:/m);
+      // readJob still works, returning undefined for the field.
+      expect(updated!.devices).toBeUndefined();
+    } finally {
+      deleteJob(name);
+    }
+  });
+});
+
+describe('routines add — --devices flag validation', () => {
+  it('validateJob rejects an add with stale singular device key', () => {
+    const config = { ...baseConfig(), device: 'yosemite-s0' } as Record<string, unknown>;
+    const errors = validateJob(config as Partial<JobConfig>);
+    expect(errors.some((e) => /singular "device" key is no longer supported/.test(e))).toBe(true);
+  });
+
+  it('validateJob accepts a valid devices array', () => {
+    const errors = validateJob(baseConfig({ devices: ['yosemite-s0', 'mac-mini'] }));
+    expect(errors).toEqual([]);
+  });
+
+  it('round-trips devices through writeJob and readJob', () => {
+    ensureAgentsDir();
+    const name = '__test-roundtrip-devices__';
+    try {
+      writeJob(baseConfig({ name, devices: ['yosemite-s0', 'mac-mini'] }));
+      const job = readJob(name);
+      expect(job!.devices).toEqual(['yosemite-s0', 'mac-mini']);
+    } finally {
+      deleteJob(name);
+    }
+  });
+});
+
+describe('routines run — device eligibility enforcement', () => {
+  afterEach(() => {
+    delete process.env.AGENTS_SYNC_MACHINE_ID;
+  });
+
+  it('run action blocks when this machine is not in the allowlist', () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+    ensureAgentsDir();
+    const name = '__test-run-blocked__';
+    writeJob(baseConfig({ name, devices: ['yosemite-s0'] }));
+
+    try {
+      const job = readJob(name);
+      expect(job).not.toBeNull();
+      expect(jobRunsOnThisDevice(job!)).toBe(false);
+    } finally {
+      deleteJob(name);
+    }
+  });
+
+  it('run action allows when this machine is in the allowlist', () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'yosemite-s0';
+    ensureAgentsDir();
+    const name = '__test-run-allowed__';
+    writeJob(baseConfig({ name, devices: ['yosemite-s0', 'mac-mini'] }));
+
+    try {
+      const job = readJob(name);
+      expect(jobRunsOnThisDevice(job!)).toBe(true);
+    } finally {
+      deleteJob(name);
+    }
+  });
+});
+
+describe('devices table truncation', () => {
+  it('long device lists get ellipsized in table output', () => {
+    const DEVICE_W = 22;
+    const deviceFull = 'yosemite-s0,yosemite-s1,mac-mini,zion';
+    const deviceWord = deviceFull.length > DEVICE_W ? deviceFull.slice(0, DEVICE_W - 1) + '…' : deviceFull;
+    expect(deviceWord.length).toBeLessThanOrEqual(DEVICE_W);
+    expect(deviceWord).toContain('…');
+  });
+
+  it('short device lists are not truncated', () => {
+    const DEVICE_W = 22;
+    const deviceFull = 'yosemite-s0';
+    const deviceWord = deviceFull.length > DEVICE_W ? deviceFull.slice(0, DEVICE_W - 1) + '…' : deviceFull;
+    expect(deviceWord).toBe('yosemite-s0');
+    expect(deviceWord).not.toContain('…');
+  });
+});

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -46,6 +46,8 @@ import { JobScheduler } from '../lib/scheduler.js';
 import { detectOverdueJobs } from '../lib/overdue.js';
 import { isInteractiveTerminal, requireInteractiveSelection } from './utils.js';
 import { setHelpSections } from '../lib/help.js';
+import { loadDevices } from '../lib/devices/registry.js';
+import { normalizeHost } from '../lib/machine-id.js';
 
 /**
  * Human-friendly wall-clock a run took (e.g. "  · 3 min", "  · 45 sec"), or ""
@@ -155,6 +157,28 @@ async function pickJob(
   }
 }
 
+/**
+ * Parse a comma-separated devices string, normalize, deduplicate, and validate
+ * each entry against the registered fleet. Exits nonzero on unknown devices.
+ */
+async function parseAndValidateDevices(raw: string): Promise<string[]> {
+  const names = [...new Set(raw.split(',').map((s) => normalizeHost(s.trim())).filter(Boolean))];
+  if (names.length === 0) {
+    console.log(chalk.red('--devices requires at least one device name'));
+    process.exit(1);
+  }
+  const registry = await loadDevices();
+  const registered = new Set(Object.keys(registry).map((k) => normalizeHost(k)));
+  const unknown = names.filter((n) => !registered.has(n));
+  if (unknown.length > 0) {
+    console.log(chalk.red(`Unknown device(s): ${unknown.join(', ')}`));
+    console.log(chalk.gray(`Registered: ${[...registered].sort().join(', ') || '(none)'}`));
+    console.log(chalk.gray('Enroll devices with: agents devices sync'));
+    process.exit(1);
+  }
+  return names;
+}
+
 /** Register the `agents routines` command tree. */
 export function registerRoutinesCommands(program: Command): void {
   const routinesCmd = program
@@ -248,7 +272,7 @@ export function registerRoutinesCommands(program: Command): void {
             scheduleHuman: fireConditionLabel(job),
             trigger: job.trigger ?? null,
             timezone: job.timezone ?? null,
-            device: job.device ?? null,
+            devices: job.devices ?? [],
             runsHere: jobRunsOnThisDevice(job),
             enabled: job.enabled,
             overdue: overdueSet.has(job.name),
@@ -283,7 +307,7 @@ export function registerRoutinesCommands(program: Command): void {
       const NEXT_W = 22;
 
       const header =
-        `  ${'Name'.padEnd(NAME_W)} ${'Agent'.padEnd(AGENT_W)} ${'Repo'.padEnd(REPO_W)} ${'Device'.padEnd(DEVICE_W)} ${'Schedule'.padEnd(SCHED_W)} ${'Enabled'.padEnd(ENABLED_W)} ${'Next Run'.padEnd(NEXT_W)} Last Status`;
+        `  ${'Name'.padEnd(NAME_W)} ${'Agent'.padEnd(AGENT_W)} ${'Repo'.padEnd(REPO_W)} ${'Devices'.padEnd(DEVICE_W)} ${'Schedule'.padEnd(SCHED_W)} ${'Enabled'.padEnd(ENABLED_W)} ${'Next Run'.padEnd(NEXT_W)} Last Status`;
       console.log(chalk.gray(header));
       console.log(chalk.gray('  ' + '-'.repeat(NAME_W + AGENT_W + REPO_W + DEVICE_W + SCHED_W + ENABLED_W + NEXT_W + 20)));
 
@@ -311,10 +335,8 @@ export function registerRoutinesCommands(program: Command): void {
         const enabledWord = job.enabled ? 'yes' : 'no';
         const enabledPad = Math.max(0, ENABLED_W - enabledWord.length);
 
-        // Unpinned jobs run everywhere; a pin that names another machine is
-        // grayed — this machine never fires it.
-        const deviceWord = job.device || '-';
-        const deviceCell = !job.device
+        const deviceWord = job.devices && job.devices.length > 0 ? job.devices.join(',') : '-';
+        const deviceCell = !job.devices || job.devices.length === 0
           ? chalk.gray('-')
           : jobRunsOnThisDevice(job)
             ? deviceWord
@@ -357,7 +379,7 @@ export function registerRoutinesCommands(program: Command): void {
     .option('-e, --effort <effort>', 'Reasoning effort: low | medium | high | xhigh | max | auto', 'auto')
     .option('-t, --timeout <timeout>', 'Kill the agent if it runs longer than this (e.g., 10m, 2h, 3d, 1w; max 1w)', '10m')
     .option('--timezone <tz>', 'Interpret schedule in this timezone (e.g., America/Los_Angeles)')
-    .option('--device <name>', 'Pin to one machine (routines are fleet-synced): only the device with this name schedules and fires the job')
+    .option('--devices <names>', 'Fleet allowlist (comma-separated): only listed devices schedule and fire this routine. Omit for unrestricted.')
     .option('--at <time>', 'One-shot mode: run once at this time (e.g., "14:30" or "2026-02-24 09:00"), then disable')
     .option('--end-at <iso>', 'Stop firing on or after this ISO 8601 timestamp (e.g., "2026-12-31T23:59:00Z"); routine auto-disables.')
     .option('--disabled', 'Create the routine but keep it paused (enable later with resume)')
@@ -409,6 +431,12 @@ export function registerRoutinesCommands(program: Command): void {
           process.exit(1);
         }
 
+        // Parse and validate --devices against the fleet registry.
+        let devices: string[] | undefined;
+        if (options.devices) {
+          devices = await parseAndValidateDevices(options.devices);
+        }
+
         const config: JobConfig = {
           name: nameOrPath,
           schedule,
@@ -420,7 +448,7 @@ export function registerRoutinesCommands(program: Command): void {
           enabled: !options.disabled,
           prompt: options.prompt,
           timezone: options.timezone,
-          ...(options.device ? { device: options.device } : {}),
+          ...(devices ? { devices } : {}),
           ...(runOnce ? { runOnce: true } : {}),
           ...(options.endAt ? { endAt: options.endAt } : {}),
         };
@@ -641,8 +669,9 @@ export function registerRoutinesCommands(program: Command): void {
       }
 
       if (!jobRunsOnThisDevice(job)) {
-        console.log(chalk.red(`Job '${name}' is pinned to device '${job.device}' and never runs here.`));
-        console.log(chalk.gray(`  Run it there: agents ssh ${job.device} 'agents routines run ${name}'`));
+        const allowed = (job.devices ?? []).join(', ');
+        console.log(chalk.red(`Job '${name}' is restricted to device(s): ${allowed}`));
+        console.log(chalk.gray(`  Run it there: agents routines run ${name} --host ${(job.devices ?? [])[0]}`));
         process.exit(1);
       }
 
@@ -945,6 +974,84 @@ export function registerRoutinesCommands(program: Command): void {
       } catch (err) {
         console.log(chalk.red((err as Error).message));
         process.exit(1);
+      }
+    });
+
+  // Fleet allowlist management for a single routine.
+  routinesCmd
+    .command('devices [name]')
+    .description('View or change which devices may run a routine. Without flags, opens an interactive picker (requires a TTY).')
+    .option('--set <devices>', 'Replace the allowlist with this comma-separated list (strict fleet validation)')
+    .option('--clear', 'Remove the allowlist so the routine runs on every device')
+    .action(async (name: string | undefined, options: { set?: string; clear?: boolean }) => {
+      if (!name) {
+        name = await pickJob('Select routine', undefined, ['agents routines devices <name>']) ?? undefined;
+        if (!name) return;
+      }
+      const job = readJob(name);
+      if (!job) {
+        console.log(chalk.red(`Job '${name}' not found`));
+        process.exit(1);
+      }
+
+      if (options.clear) {
+        job.devices = undefined;
+        writeJob(job);
+        console.log(chalk.green(`Devices cleared for '${name}' — runs on all devices`));
+        if (isDaemonRunning()) signalDaemonReload();
+        return;
+      }
+
+      if (options.set) {
+        const devices = await parseAndValidateDevices(options.set);
+        job.devices = devices;
+        writeJob(job);
+        console.log(chalk.green(`Devices for '${name}' set to: ${devices.join(', ')}`));
+        if (isDaemonRunning()) signalDaemonReload();
+        return;
+      }
+
+      // Interactive picker
+      if (!isInteractiveTerminal()) {
+        requireInteractiveSelection('device allowlist', ['agents routines devices <name> --set a,b', 'agents routines devices <name> --clear']);
+      }
+
+      const registry = await loadDevices();
+      const registeredNames = Object.keys(registry).map((k) => normalizeHost(k)).sort();
+      if (registeredNames.length === 0) {
+        console.log(chalk.yellow('No devices registered. Enroll with: agents devices sync'));
+        return;
+      }
+
+      const currentSet = new Set((job.devices ?? []).map((d) => normalizeHost(d)));
+
+      try {
+        const { checkbox } = await import('@inquirer/prompts');
+        const selected = await checkbox({
+          message: `Devices allowed to run '${name}' (space to toggle, enter to confirm, empty = unrestricted):`,
+          choices: registeredNames.map((d) => ({
+            value: d,
+            name: d,
+            checked: currentSet.has(d),
+          })),
+        });
+
+        if (selected.length === 0) {
+          job.devices = undefined;
+          writeJob(job);
+          console.log(chalk.green(`Devices cleared for '${name}' — runs on all devices`));
+        } else {
+          job.devices = selected;
+          writeJob(job);
+          console.log(chalk.green(`Devices for '${name}' set to: ${selected.join(', ')}`));
+        }
+        if (isDaemonRunning()) signalDaemonReload();
+      } catch (err) {
+        if (isPromptCancelled(err)) {
+          console.log(chalk.gray('Cancelled'));
+          return;
+        }
+        throw err;
       }
     });
 

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -301,7 +301,7 @@ export function registerRoutinesCommands(program: Command): void {
       const NAME_W = 24;
       const AGENT_W = 10;
       const REPO_W = REPO_DISPLAY_MAX;
-      const DEVICE_W = 13;
+      const DEVICE_W = 22;
       const SCHED_W = 22;
       const ENABLED_W = 10;
       const NEXT_W = 22;
@@ -335,7 +335,8 @@ export function registerRoutinesCommands(program: Command): void {
         const enabledWord = job.enabled ? 'yes' : 'no';
         const enabledPad = Math.max(0, ENABLED_W - enabledWord.length);
 
-        const deviceWord = job.devices && job.devices.length > 0 ? job.devices.join(',') : '-';
+        const deviceFull = job.devices && job.devices.length > 0 ? job.devices.join(',') : '-';
+        const deviceWord = deviceFull.length > DEVICE_W ? deviceFull.slice(0, DEVICE_W - 1) + '…' : deviceFull;
         const deviceCell = !job.devices || job.devices.length === 0
           ? chalk.gray('-')
           : jobRunsOnThisDevice(job)

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -48,6 +48,7 @@ import { isInteractiveTerminal, requireInteractiveSelection } from './utils.js';
 import { setHelpSections } from '../lib/help.js';
 import { loadDevices } from '../lib/devices/registry.js';
 import { normalizeHost } from '../lib/machine-id.js';
+import { addHostOption } from '../lib/hosts/option.js';
 
 /**
  * Human-friendly wall-clock a run took (e.g. "  · 3 min", "  · 45 sec"), or ""
@@ -185,6 +186,8 @@ export function registerRoutinesCommands(program: Command): void {
     .command('routines')
     .description('Schedule agents to run on a cron schedule or at a specific time. The scheduler auto-starts on first add.');
 
+  addHostOption(routinesCmd);
+
   setHelpSections(routinesCmd, {
     examples: `
       # Cron routine: Claude every weekday at 9 AM (scheduler auto-starts)
@@ -229,11 +232,12 @@ export function registerRoutinesCommands(program: Command): void {
     `,
   });
 
-  routinesCmd
-    .command('list')
-    .description('See all scheduled jobs, when they run next, and their last execution status')
-    .option('--json', 'Emit machine-readable JSON instead of the table (used by the menu bar helper)')
-    .action((options: { json?: boolean }) => {
+  addHostOption(
+    routinesCmd
+      .command('list')
+      .description('See all scheduled jobs, when they run next, and their last execution status')
+      .option('--json', 'Emit machine-readable JSON instead of the table (used by the menu bar helper)'),
+  ).action((options: { json?: boolean }) => {
       const jobs = listAllJobs(process.cwd());
       if (jobs.length === 0) {
         if (options.json) {
@@ -671,8 +675,8 @@ export function registerRoutinesCommands(program: Command): void {
 
       if (!jobRunsOnThisDevice(job)) {
         const allowed = (job.devices ?? []).join(', ');
-        console.log(chalk.red(`Job '${name}' is restricted to device(s): ${allowed}`));
-        console.log(chalk.gray(`  Run it there: agents routines run ${name} --host ${(job.devices ?? [])[0]}`));
+        console.log(chalk.red(`Job '${name}' can only run on: ${allowed}`));
+        console.log(chalk.gray(`  agents routines run ${name} --host ${(job.devices ?? [])[0]}`));
         process.exit(1);
       }
 
@@ -985,6 +989,11 @@ export function registerRoutinesCommands(program: Command): void {
     .option('--set <devices>', 'Replace the allowlist with this comma-separated list (strict fleet validation)')
     .option('--clear', 'Remove the allowlist so the routine runs on every device')
     .action(async (name: string | undefined, options: { set?: string; clear?: boolean }) => {
+      if (options.set && options.clear) {
+        console.log(chalk.red('--set and --clear are mutually exclusive'));
+        process.exit(1);
+      }
+
       if (!name) {
         name = await pickJob('Select routine', undefined, ['agents routines devices <name>']) ?? undefined;
         if (!name) return;

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1016,7 +1016,7 @@ if (process.env.AGENTS_SKIP_MIGRATION !== '1') {
     // Bumping the suffix re-runs migrations for every user; binary releases that
     // don't change the schema must NOT re-run (they would destroy user content
     // when migration steps overlap with user-authored paths). See issue #20.
-    const sentinelValue = 'v11';
+    const sentinelValue = 'v12';
     let needRun = true;
     try {
       if (fs.existsSync(sentinel) && fs.readFileSync(sentinel, 'utf-8').trim() === sentinelValue) {

--- a/apps/cli/src/lib/__tests__/scheduler.device.test.ts
+++ b/apps/cli/src/lib/__tests__/scheduler.device.test.ts
@@ -46,37 +46,37 @@ function makeJob(overrides: Partial<JobConfig> = {}): JobConfig {
   };
 }
 
-describe('JobScheduler device pinning', () => {
-  it('loads unpinned jobs and jobs pinned to this device; skips foreign pins', () => {
+describe('JobScheduler devices allowlist', () => {
+  it('loads unpinned jobs and jobs whose allowlist includes this device; skips foreign', () => {
     writeJob(makeJob({ name: 'unpinned' }));
-    writeJob(makeJob({ name: 'pinned-here', device: 'zion' }));
-    writeJob(makeJob({ name: 'pinned-elsewhere', device: 'yosemite-s0' }));
+    writeJob(makeJob({ name: 'allowed-here', devices: ['zion'] }));
+    writeJob(makeJob({ name: 'allowed-elsewhere', devices: ['yosemite-s0'] }));
+    writeJob(makeJob({ name: 'multi-includes-here', devices: ['mac-mini', 'zion'] }));
 
     const scheduler = new JobScheduler(async () => {});
     scheduler.loadAll();
     const names = scheduler.listScheduled().map((j) => j.name).sort();
     scheduler.stopAll();
 
-    expect(names).toEqual(['pinned-here', 'unpinned']);
+    expect(names).toEqual(['allowed-here', 'multi-includes-here', 'unpinned']);
   });
 
-  it('matches a pin case-insensitively and ignores a domain suffix', () => {
-    writeJob(makeJob({ name: 'fqdn-pin', device: 'Zion.tailnet.ts.net' }));
+  it('matches an allowlist entry case-insensitively and ignores a domain suffix', () => {
+    writeJob(makeJob({ name: 'fqdn-entry', devices: ['Zion.tailnet.ts.net'] }));
 
     const scheduler = new JobScheduler(async () => {});
     scheduler.loadAll();
     const names = scheduler.listScheduled().map((j) => j.name);
     scheduler.stopAll();
 
-    expect(names).toEqual(['fqdn-pin']);
+    expect(names).toEqual(['fqdn-entry']);
   });
 });
 
-describe('detectOverdueJobs device pinning', () => {
-  it('never flags a job pinned to another device as overdue here', () => {
-    // Daily schedule with no recorded runs — overdue everywhere it may run.
-    writeJob(makeJob({ name: 'foreign-overdue', device: 'yosemite-s0' }));
-    writeJob(makeJob({ name: 'local-overdue', device: 'zion' }));
+describe('detectOverdueJobs devices allowlist', () => {
+  it('never flags a job restricted to another device as overdue here', () => {
+    writeJob(makeJob({ name: 'foreign-overdue', devices: ['yosemite-s0'] }));
+    writeJob(makeJob({ name: 'local-overdue', devices: ['zion'] }));
     writeJob(makeJob({ name: 'unpinned-overdue' }));
 
     const names = detectOverdueJobs().map((j) => j.name).sort();

--- a/apps/cli/src/lib/hosts/passthrough.test.ts
+++ b/apps/cli/src/lib/hosts/passthrough.test.ts
@@ -65,4 +65,31 @@ describe('maybeRunOnHost — local short-circuits (no SSH attempted)', () => {
     expect(process.exitCode).toBe(1);
     process.exitCode = 0;
   });
+
+  it('routes routines --host to remote', async () => {
+    // routines is in the passthrough table; with --host naming a non-self
+    // machine, maybeRunOnHost should return true (it would SSH if the host
+    // were reachable — we only test the selection logic here).
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    // Self-machine check: --host mybox is local.
+    expect(await maybeRunOnHost('routines', ['routines', 'list', '--host', 'mybox'])).toBe(false);
+  });
+
+  it('does NOT bail on --devices for routines (placement, not fan-out)', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    // --devices on routines is placement; --host should still route remotely.
+    // Self-machine short-circuit makes this false, confirming --devices didn't bail.
+    expect(await maybeRunOnHost('routines', ['routines', 'add', 'x', '--host', 'mybox', '--devices', 'a,b'])).toBe(false);
+  });
+
+  it('bails on --devices for non-routines commands (fan-out)', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    expect(await maybeRunOnHost('list', ['list', '--host', 'other', '--devices'])).toBe(false);
+  });
+
+  it('treats --device as alias of --host for routines routing', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    // --device naming self -> local.
+    expect(await maybeRunOnHost('routines', ['routines', 'run', 'x', '--device', 'mybox'])).toBe(false);
+  });
 });

--- a/apps/cli/src/lib/hosts/passthrough.test.ts
+++ b/apps/cli/src/lib/hosts/passthrough.test.ts
@@ -66,30 +66,45 @@ describe('maybeRunOnHost — local short-circuits (no SSH attempted)', () => {
     process.exitCode = 0;
   });
 
-  it('routes routines --host to remote', async () => {
-    // routines is in the passthrough table; with --host naming a non-self
-    // machine, maybeRunOnHost should return true (it would SSH if the host
-    // were reachable — we only test the selection logic here).
+  it('routes routines --host to a non-self target (enters SSH path)', async () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
-    // Self-machine check: --host mybox is local.
-    expect(await maybeRunOnHost('routines', ['routines', 'list', '--host', 'mybox'])).toBe(false);
+    // A non-self host enters the SSH resolve + sshStream path. sshStream
+    // returns 255 for unreachable hosts. Returning true proves the routing
+    // path was entered, not short-circuited.
+    const result = await maybeRunOnHost('routines', ['routines', 'list', '--host', 'other-box']);
+    expect(result).toBe(true);
+    expect(process.exitCode).toBeGreaterThan(0);
+    process.exitCode = 0;
   });
 
-  it('does NOT bail on --devices for routines (placement, not fan-out)', async () => {
+  it('routes routines --device alias to a non-self target', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    const result = await maybeRunOnHost('routines', ['routines', 'run', 'x', '--device', 'other-box']);
+    expect(result).toBe(true);
+    expect(process.exitCode).toBeGreaterThan(0);
+    process.exitCode = 0;
+  });
+
+  it('does NOT bail on --devices for routines with --host (placement, not fan-out)', async () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
     // --devices on routines is placement; --host should still route remotely.
-    // Self-machine short-circuit makes this false, confirming --devices didn't bail.
-    expect(await maybeRunOnHost('routines', ['routines', 'add', 'x', '--host', 'mybox', '--devices', 'a,b'])).toBe(false);
+    // A non-self target enters the SSH path (returns true), proving --devices
+    // did not bail.
+    const result = await maybeRunOnHost('routines', ['routines', 'add', 'x', '--host', 'other-box', '--devices', 'a,b']);
+    expect(result).toBe(true);
+    expect(process.exitCode).toBeGreaterThan(0);
+    process.exitCode = 0;
   });
 
   it('bails on --devices for non-routines commands (fan-out)', async () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
-    expect(await maybeRunOnHost('list', ['list', '--host', 'other', '--devices'])).toBe(false);
+    // --devices on a non-routines command triggers the fleet-flag bailout,
+    // returning false even with a non-self --host.
+    expect(await maybeRunOnHost('list', ['list', '--host', 'other-box', '--devices'])).toBe(false);
   });
 
-  it('treats --device as alias of --host for routines routing', async () => {
+  it('bails on --hosts for non-routines commands (fan-out)', async () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
-    // --device naming self -> local.
-    expect(await maybeRunOnHost('routines', ['routines', 'run', 'x', '--device', 'mybox'])).toBe(false);
+    expect(await maybeRunOnHost('list', ['list', '--host', 'other-box', '--hosts'])).toBe(false);
   });
 });

--- a/apps/cli/src/lib/hosts/passthrough.test.ts
+++ b/apps/cli/src/lib/hosts/passthrough.test.ts
@@ -66,12 +66,12 @@ describe('maybeRunOnHost — local short-circuits (no SSH attempted)', () => {
     process.exitCode = 0;
   });
 
-  it('routes routines --host to a non-self target (enters SSH path)', async () => {
+  it('routes routines --host to a non-self target (rejected by assertValidSshTarget)', async () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
-    // A non-self host enters the SSH resolve + sshStream path. sshStream
-    // returns 255 for unreachable hosts. Returning true proves the routing
-    // path was entered, not short-circuited.
-    const result = await maybeRunOnHost('routines', ['routines', 'list', '--host', 'other-box']);
+    // --evil starts with '-' so assertValidSshTarget rejects it before any
+    // SSH connection is attempted. Returning true with exitCode > 0 proves
+    // the routing path was entered, not short-circuited.
+    const result = await maybeRunOnHost('routines', ['routines', 'list', '--host', '--evil']);
     expect(result).toBe(true);
     expect(process.exitCode).toBeGreaterThan(0);
     process.exitCode = 0;
@@ -79,7 +79,7 @@ describe('maybeRunOnHost — local short-circuits (no SSH attempted)', () => {
 
   it('routes routines --device alias to a non-self target', async () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
-    const result = await maybeRunOnHost('routines', ['routines', 'run', 'x', '--device', 'other-box']);
+    const result = await maybeRunOnHost('routines', ['routines', 'run', 'x', '--device', '--evil']);
     expect(result).toBe(true);
     expect(process.exitCode).toBeGreaterThan(0);
     process.exitCode = 0;
@@ -88,9 +88,9 @@ describe('maybeRunOnHost — local short-circuits (no SSH attempted)', () => {
   it('does NOT bail on --devices for routines with --host (placement, not fan-out)', async () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
     // --devices on routines is placement; --host should still route remotely.
-    // A non-self target enters the SSH path (returns true), proving --devices
-    // did not bail.
-    const result = await maybeRunOnHost('routines', ['routines', 'add', 'x', '--host', 'other-box', '--devices', 'a,b']);
+    // The invalid target is rejected by assertValidSshTarget (returns true,
+    // exitCode > 0), proving --devices did not bail.
+    const result = await maybeRunOnHost('routines', ['routines', 'add', 'x', '--host', '--evil', '--devices', 'a,b']);
     expect(result).toBe(true);
     expect(process.exitCode).toBeGreaterThan(0);
     process.exitCode = 0;
@@ -100,11 +100,11 @@ describe('maybeRunOnHost — local short-circuits (no SSH attempted)', () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
     // --devices on a non-routines command triggers the fleet-flag bailout,
     // returning false even with a non-self --host.
-    expect(await maybeRunOnHost('list', ['list', '--host', 'other-box', '--devices'])).toBe(false);
+    expect(await maybeRunOnHost('list', ['list', '--host', '--evil', '--devices'])).toBe(false);
   });
 
   it('bails on --hosts for non-routines commands (fan-out)', async () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
-    expect(await maybeRunOnHost('list', ['list', '--host', 'other-box', '--hosts'])).toBe(false);
+    expect(await maybeRunOnHost('list', ['list', '--host', '--evil', '--hosts'])).toBe(false);
   });
 });

--- a/apps/cli/src/lib/hosts/passthrough.test.ts
+++ b/apps/cli/src/lib/hosts/passthrough.test.ts
@@ -107,4 +107,9 @@ describe('maybeRunOnHost — local short-circuits (no SSH attempted)', () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
     expect(await maybeRunOnHost('list', ['list', '--host', '--evil', '--hosts'])).toBe(false);
   });
+
+  it('bails on --hosts for routines too (generic fleet flag, not placement)', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    expect(await maybeRunOnHost('routines', ['routines', 'list', '--host', '--evil', '--hosts'])).toBe(false);
+  });
 });

--- a/apps/cli/src/lib/hosts/passthrough.ts
+++ b/apps/cli/src/lib/hosts/passthrough.ts
@@ -129,12 +129,12 @@ export async function maybeRunOnHost(command: string, allArgs: string[]): Promis
     return true;
   }
 
-  // `--devices`/`--hosts` on teams/list fan out locally; don't cascade remotely.
-  // But on `routines`, `--devices` is a placement flag (which devices may run
-  // the routine) and must be forwarded to the remote host, not treated as
-  // fan-out.
-  const fleetFlag = allArgs.includes('--devices') || allArgs.includes('--hosts');
-  if (fleetFlag && command !== 'routines') return false;
+  // `--hosts` is always a generic fleet flag — bail for every command so the
+  // local aggregator handles it. `--devices` is fan-out on most commands but
+  // a placement flag on `routines` (which devices may run the routine), so
+  // only exempt routines from the bail.
+  if (allArgs.includes('--hosts')) return false;
+  if (allArgs.includes('--devices') && command !== 'routines') return false;
 
   const hostName = hostFlag ?? deviceFlag;
   if (!hostName) return false;

--- a/apps/cli/src/lib/hosts/passthrough.ts
+++ b/apps/cli/src/lib/hosts/passthrough.ts
@@ -47,6 +47,7 @@ const REMOTE_PASSTHROUGH: Record<string, RemoteSpec> = {
   sync: { nonInteractive: ['--yes'] },
   teams: {},
   message: {},
+  routines: {},
 };
 
 /** `--no-tty` is stripped like the routing flags but carries no value. */
@@ -128,10 +129,12 @@ export async function maybeRunOnHost(command: string, allArgs: string[]): Promis
     return true;
   }
 
-  // `--devices` / `--hosts` fan out to every registered device locally; don't
-  // let a per-host passthrough turn it into a cascading remote fan-out.
+  // `--devices`/`--hosts` on teams/list fan out locally; don't cascade remotely.
+  // But on `routines`, `--devices` is a placement flag (which devices may run
+  // the routine) and must be forwarded to the remote host, not treated as
+  // fan-out.
   const fleetFlag = allArgs.includes('--devices') || allArgs.includes('--hosts');
-  if (fleetFlag) return false;
+  if (fleetFlag && command !== 'routines') return false;
 
   const hostName = hostFlag ?? deviceFlag;
   if (!hostName) return false;

--- a/apps/cli/src/lib/migrate.test.ts
+++ b/apps/cli/src/lib/migrate.test.ts
@@ -371,4 +371,38 @@ describe('migrateRoutineDeviceToDevices', () => {
       fs.chmodSync(dir, 0o755);
     }
   });
+
+  it('throws on malformed legacy device value (not a nonempty string)', () => {
+    const dir = makeRoutinesDir();
+    fs.writeFileSync(path.join(dir, 'h.yml'), yaml.stringify({
+      name: 'h', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: '',
+    }));
+    expect(() => migrateRoutineDeviceToDevices(dir)).toThrow(/not a valid device name/);
+    const result = yaml.parse(fs.readFileSync(path.join(dir, 'h.yml'), 'utf-8'));
+    expect(result.device).toBe('');
+  });
+
+  it('throws on non-string legacy device value (number)', () => {
+    const dir = makeRoutinesDir();
+    fs.writeFileSync(path.join(dir, 'i.yml'), yaml.stringify({
+      name: 'i', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: 42,
+    }));
+    expect(() => migrateRoutineDeviceToDevices(dir)).toThrow(/not a valid device name/);
+    const result = yaml.parse(fs.readFileSync(path.join(dir, 'i.yml'), 'utf-8'));
+    expect(result.device).toBe(42);
+  });
+
+  it('propagates a readFile error for candidate YAML', () => {
+    const dir = makeRoutinesDir();
+    const filePath = path.join(dir, 'j.yml');
+    fs.writeFileSync(filePath, yaml.stringify({
+      name: 'j', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: 'zion',
+    }));
+    fs.chmodSync(filePath, 0o000);
+    try {
+      expect(() => migrateRoutineDeviceToDevices(dir)).toThrow();
+    } finally {
+      fs.chmodSync(filePath, 0o644);
+    }
+  });
 });

--- a/apps/cli/src/lib/migrate.test.ts
+++ b/apps/cli/src/lib/migrate.test.ts
@@ -357,4 +357,18 @@ describe('migrateRoutineDeviceToDevices', () => {
     migrateRoutineDeviceToDevices(dir);
     expect(fs.readFileSync(path.join(dir, 'f.yml'), 'utf-8')).toBe(raw);
   });
+
+  it('propagates a write failure (no silent swallowing)', () => {
+    const dir = makeRoutinesDir();
+    fs.writeFileSync(path.join(dir, 'g.yml'), yaml.stringify({
+      name: 'g', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: 'zion',
+    }));
+    // Make the directory read-only so the atomic write (temp file + rename) fails.
+    fs.chmodSync(dir, 0o555);
+    try {
+      expect(() => migrateRoutineDeviceToDevices(dir)).toThrow();
+    } finally {
+      fs.chmodSync(dir, 0o755);
+    }
+  });
 });

--- a/apps/cli/src/lib/migrate.test.ts
+++ b/apps/cli/src/lib/migrate.test.ts
@@ -3,8 +3,9 @@ import * as os from 'os';
 import * as path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { migrateExtrasExtrasToAgentsExtras, repairSelfReferentialBinShims } from './migrate.js';
+import { migrateExtrasExtrasToAgentsExtras, migrateRoutineDeviceToDevices, repairSelfReferentialBinShims } from './migrate.js';
 import { toPosix } from './platform/index.js';
+import * as yaml from 'yaml';
 
 const tempDirs: string[] = [];
 
@@ -283,5 +284,77 @@ describe('repairSelfReferentialBinShims', () => {
 
     // Untouched: still the same symlink target.
     expect(fs.readlinkSync(binLink)).toBe(realBin);
+  });
+});
+
+describe('migrateRoutineDeviceToDevices', () => {
+  function makeRoutinesDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-migrate-dev-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it('rewrites device: value to devices: [value]', () => {
+    const dir = makeRoutinesDir();
+    fs.writeFileSync(path.join(dir, 'a.yml'), yaml.stringify({
+      name: 'a', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: 'yosemite-s0',
+    }));
+    migrateRoutineDeviceToDevices(dir);
+    const result = yaml.parse(fs.readFileSync(path.join(dir, 'a.yml'), 'utf-8'));
+    expect(result.devices).toEqual(['yosemite-s0']);
+    expect(result.device).toBeUndefined();
+  });
+
+  it('is idempotent — no change on re-run', () => {
+    const dir = makeRoutinesDir();
+    fs.writeFileSync(path.join(dir, 'b.yml'), yaml.stringify({
+      name: 'b', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: 'mac-mini',
+    }));
+    migrateRoutineDeviceToDevices(dir);
+    const after1 = fs.readFileSync(path.join(dir, 'b.yml'), 'utf-8');
+    migrateRoutineDeviceToDevices(dir);
+    const after2 = fs.readFileSync(path.join(dir, 'b.yml'), 'utf-8');
+    expect(after1).toBe(after2);
+  });
+
+  it('leaves a routine that already has devices untouched', () => {
+    const dir = makeRoutinesDir();
+    const original = { name: 'c', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', devices: ['a', 'b'] };
+    fs.writeFileSync(path.join(dir, 'c.yml'), yaml.stringify(original));
+    migrateRoutineDeviceToDevices(dir);
+    const result = yaml.parse(fs.readFileSync(path.join(dir, 'c.yml'), 'utf-8'));
+    expect(result.devices).toEqual(['a', 'b']);
+    expect(result.device).toBeUndefined();
+  });
+
+  it('drops device when devices already present (both-field collision)', () => {
+    const dir = makeRoutinesDir();
+    const original = { name: 'd', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: 'old', devices: ['new'] };
+    fs.writeFileSync(path.join(dir, 'd.yml'), yaml.stringify(original));
+    migrateRoutineDeviceToDevices(dir);
+    const result = yaml.parse(fs.readFileSync(path.join(dir, 'd.yml'), 'utf-8'));
+    expect(result.devices).toEqual(['new']);
+    expect(result.device).toBeUndefined();
+  });
+
+  it('preserves other YAML fields', () => {
+    const dir = makeRoutinesDir();
+    fs.writeFileSync(path.join(dir, 'e.yml'), yaml.stringify({
+      name: 'e', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: 'zion', timeout: '2h', enabled: false,
+    }));
+    migrateRoutineDeviceToDevices(dir);
+    const result = yaml.parse(fs.readFileSync(path.join(dir, 'e.yml'), 'utf-8'));
+    expect(result.devices).toEqual(['zion']);
+    expect(result.timeout).toBe('2h');
+    expect(result.enabled).toBe(false);
+    expect(result.agent).toBe('claude');
+  });
+
+  it('is a no-op for routines without device field', () => {
+    const dir = makeRoutinesDir();
+    const raw = yaml.stringify({ name: 'f', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi' });
+    fs.writeFileSync(path.join(dir, 'f.yml'), raw);
+    migrateRoutineDeviceToDevices(dir);
+    expect(fs.readFileSync(path.join(dir, 'f.yml'), 'utf-8')).toBe(raw);
   });
 });

--- a/apps/cli/src/lib/migrate.ts
+++ b/apps/cli/src/lib/migrate.ts
@@ -1746,18 +1746,12 @@ export function migrateRoutineDeviceToDevices(routinesDir?: string): void {
   const dir = routinesDir ?? path.join(USER_DIR, 'routines');
   if (!fs.existsSync(dir)) return;
 
-  let files: string[];
-  try {
-    files = fs.readdirSync(dir).filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'));
-  } catch { return; }
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'));
 
   let migrated = 0;
   for (const file of files) {
     const filePath = path.join(dir, file);
-    let raw: string;
-    try {
-      raw = fs.readFileSync(filePath, 'utf-8');
-    } catch { continue; }
+    const raw = fs.readFileSync(filePath, 'utf-8');
 
     let doc: Record<string, unknown>;
     try {
@@ -1773,10 +1767,11 @@ export function migrateRoutineDeviceToDevices(routinesDir?: string): void {
     }
 
     const val = doc.device;
-    delete doc.device;
-    if (typeof val === 'string' && val.trim()) {
-      doc.devices = [val.trim()];
+    if (typeof val !== 'string' || !val.trim()) {
+      throw new Error(`${file}: legacy 'device' field is not a valid device name — repair the file and retry`);
     }
+    delete doc.device;
+    doc.devices = [val.trim()];
 
     atomicWriteFileSync(filePath, yaml.stringify(doc));
     migrated++;

--- a/apps/cli/src/lib/migrate.ts
+++ b/apps/cli/src/lib/migrate.ts
@@ -1768,7 +1768,7 @@ export function migrateRoutineDeviceToDevices(routinesDir?: string): void {
     if (!('device' in doc)) continue;
     if ('devices' in doc) {
       delete doc.device;
-      try { fs.writeFileSync(filePath, yaml.stringify(doc), 'utf-8'); } catch { /* best-effort */ }
+      atomicWriteFileSync(filePath, yaml.stringify(doc));
       continue;
     }
 
@@ -1778,10 +1778,8 @@ export function migrateRoutineDeviceToDevices(routinesDir?: string): void {
       doc.devices = [val.trim()];
     }
 
-    try {
-      fs.writeFileSync(filePath, yaml.stringify(doc), 'utf-8');
-      migrated++;
-    } catch { /* best-effort */ }
+    atomicWriteFileSync(filePath, yaml.stringify(doc));
+    migrated++;
   }
 
   if (migrated > 0) {

--- a/apps/cli/src/lib/migrate.ts
+++ b/apps/cli/src/lib/migrate.ts
@@ -1734,6 +1734,61 @@ export function migrateExtrasExtrasToAgentsExtras(historyDir: string = HISTORY_D
   }
 }
 
+/**
+ * Rewrite every routine YAML that carries the legacy singular `device: <value>`
+ * field to the new plural `devices: [<value>]` format. Preserves all other
+ * fields. Idempotent: a routine that already has `devices:` (or neither field)
+ * is left untouched.
+ *
+ * Params default to the real routines dir; injectable for tests.
+ */
+export function migrateRoutineDeviceToDevices(routinesDir?: string): void {
+  const dir = routinesDir ?? path.join(USER_DIR, 'routines');
+  if (!fs.existsSync(dir)) return;
+
+  let files: string[];
+  try {
+    files = fs.readdirSync(dir).filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'));
+  } catch { return; }
+
+  let migrated = 0;
+  for (const file of files) {
+    const filePath = path.join(dir, file);
+    let raw: string;
+    try {
+      raw = fs.readFileSync(filePath, 'utf-8');
+    } catch { continue; }
+
+    let doc: Record<string, unknown>;
+    try {
+      doc = yaml.parse(raw) as Record<string, unknown>;
+      if (!doc || typeof doc !== 'object') continue;
+    } catch { continue; }
+
+    if (!('device' in doc)) continue;
+    if ('devices' in doc) {
+      delete doc.device;
+      try { fs.writeFileSync(filePath, yaml.stringify(doc), 'utf-8'); } catch { /* best-effort */ }
+      continue;
+    }
+
+    const val = doc.device;
+    delete doc.device;
+    if (typeof val === 'string' && val.trim()) {
+      doc.devices = [val.trim()];
+    }
+
+    try {
+      fs.writeFileSync(filePath, yaml.stringify(doc), 'utf-8');
+      migrated++;
+    } catch { /* best-effort */ }
+  }
+
+  if (migrated > 0) {
+    console.error(`Migrated ${migrated} routine${migrated === 1 ? '' : 's'}: device → devices`);
+  }
+}
+
 /** Run all idempotent migrations. Safe to call multiple times. */
 export async function runMigration(): Promise<void> {
   // MUST run first: every other migrator reads SYSTEM_DIR (the new path).
@@ -1788,6 +1843,9 @@ export async function runMigration(): Promise<void> {
   // installed version-home. Runs after migrateRuntimeToHistory so the version
   // homes are at their canonical HISTORY_DIR location.
   migrateExtrasExtrasToAgentsExtras();
+
+  // Rewrite routine YAML files: singular `device:` -> plural `devices: []`.
+  migrateRoutineDeviceToDevices();
 
   // Symlink repair runs LAST so it can find the post-move version homes.
   repairAgentConfigSymlinks();

--- a/apps/cli/src/lib/routines.test.ts
+++ b/apps/cli/src/lib/routines.test.ts
@@ -147,7 +147,7 @@ describe('validateJob — devices', () => {
   it('rejects a stale singular "device" key after v12', () => {
     const config = { ...baseJob({ schedule: '0 3 * * *' }), device: 'yosemite-s0' } as Record<string, unknown>;
     const errors = validateJob(config as Partial<JobConfig>);
-    expect(errors.some((e) => /singular "device" key is no longer supported/.test(e))).toBe(true);
+    expect(errors.some((e) => /singular "device" key is no longer supported/.test(e) && /devices:/.test(e))).toBe(true);
   });
 });
 

--- a/apps/cli/src/lib/routines.test.ts
+++ b/apps/cli/src/lib/routines.test.ts
@@ -125,19 +125,23 @@ describe('normalizeTriggerEvent', () => {
   });
 });
 
-describe('validateJob — device', () => {
-  it('accepts a job pinned to a device', () => {
-    expect(validateJob(baseJob({ schedule: '0 3 * * *', device: 'yosemite-s0' }))).toEqual([]);
+describe('validateJob — devices', () => {
+  it('accepts a job with a devices allowlist', () => {
+    expect(validateJob(baseJob({ schedule: '0 3 * * *', devices: ['yosemite-s0'] }))).toEqual([]);
   });
 
-  it('rejects an empty device', () => {
-    const errors = validateJob(baseJob({ schedule: '0 3 * * *', device: '  ' }));
-    expect(errors.some((e) => /device must be a non-empty device name/.test(e))).toBe(true);
+  it('accepts a job with multiple devices', () => {
+    expect(validateJob(baseJob({ schedule: '0 3 * * *', devices: ['yosemite-s0', 'mac-mini'] }))).toEqual([]);
   });
 
-  it('rejects a non-string device', () => {
-    const errors = validateJob(baseJob({ schedule: '0 3 * * *', device: 42 as never }));
-    expect(errors.some((e) => /device must be a non-empty device name/.test(e))).toBe(true);
+  it('rejects a non-array devices', () => {
+    const errors = validateJob(baseJob({ schedule: '0 3 * * *', devices: 'yosemite-s0' as never }));
+    expect(errors.some((e) => /devices must be an array/.test(e))).toBe(true);
+  });
+
+  it('rejects an empty-string entry', () => {
+    const errors = validateJob(baseJob({ schedule: '0 3 * * *', devices: [''] }));
+    expect(errors.some((e) => /each entry in devices/.test(e))).toBe(true);
   });
 });
 
@@ -149,24 +153,27 @@ describe('jobRunsOnThisDevice', () => {
     else process.env.AGENTS_SYNC_MACHINE_ID = savedId;
   });
 
-  it('unpinned jobs run everywhere', () => {
+  it('unrestricted jobs run everywhere', () => {
     expect(jobRunsOnThisDevice({})).toBe(true);
-    expect(jobRunsOnThisDevice({ device: undefined })).toBe(true);
+    expect(jobRunsOnThisDevice({ devices: undefined })).toBe(true);
+    expect(jobRunsOnThisDevice({ devices: [] })).toBe(true);
   });
 
-  it('matches when the pin names this machine', () => {
+  it('matches when the allowlist includes this machine', () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'yosemite-s0';
-    expect(jobRunsOnThisDevice({ device: 'yosemite-s0' })).toBe(true);
+    expect(jobRunsOnThisDevice({ devices: ['yosemite-s0'] })).toBe(true);
+    expect(jobRunsOnThisDevice({ devices: ['mac-mini', 'yosemite-s0'] })).toBe(true);
   });
 
-  it('normalizes case and domain suffix on the pin', () => {
+  it('normalizes case and domain suffix', () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'yosemite-s0';
-    expect(jobRunsOnThisDevice({ device: 'Yosemite-S0' })).toBe(true);
-    expect(jobRunsOnThisDevice({ device: 'yosemite-s0.tailnet.ts.net' })).toBe(true);
+    expect(jobRunsOnThisDevice({ devices: ['Yosemite-S0'] })).toBe(true);
+    expect(jobRunsOnThisDevice({ devices: ['yosemite-s0.tailnet.ts.net'] })).toBe(true);
   });
 
-  it('rejects a pin naming another machine', () => {
+  it('rejects when allowlist names other machines', () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
-    expect(jobRunsOnThisDevice({ device: 'yosemite-s0' })).toBe(false);
+    expect(jobRunsOnThisDevice({ devices: ['yosemite-s0'] })).toBe(false);
+    expect(jobRunsOnThisDevice({ devices: ['yosemite-s0', 'mac-mini'] })).toBe(false);
   });
 });

--- a/apps/cli/src/lib/routines.test.ts
+++ b/apps/cli/src/lib/routines.test.ts
@@ -143,6 +143,12 @@ describe('validateJob — devices', () => {
     const errors = validateJob(baseJob({ schedule: '0 3 * * *', devices: [''] }));
     expect(errors.some((e) => /each entry in devices/.test(e))).toBe(true);
   });
+
+  it('rejects a stale singular "device" key after v12', () => {
+    const config = { ...baseJob({ schedule: '0 3 * * *' }), device: 'yosemite-s0' } as Record<string, unknown>;
+    const errors = validateJob(config as Partial<JobConfig>);
+    expect(errors.some((e) => /singular "device" key is no longer supported/.test(e))).toBe(true);
+  });
 });
 
 describe('jobRunsOnThisDevice', () => {

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -96,14 +96,13 @@ export interface JobConfig {
   timezone?: string;
   repo?: string;
   /**
-   * Pin this routine to one machine. `~/.agents/routines/` is synced to every
-   * device via the user repo, so without a pin an enabled routine fires on
-   * EVERY machine running the scheduler. When set, only the device whose
-   * `machineId()` matches (normalized hostname, e.g. `yosemite-s0`) schedules,
-   * fires, catches up, or counts this job as overdue; everywhere else it is
-   * inert and `run` refuses with an `agents ssh` pointer.
+   * Fleet allowlist — restrict this routine to specific devices. When omitted
+   * or empty, the routine is unrestricted and fires on every device running the
+   * scheduler. When set, only devices whose `machineId()` matches any entry
+   * (via `normalizeHost`) schedule, fire, catch up, or count this job as
+   * overdue; everywhere else it is inert and `run` refuses with a pointer.
    */
-  device?: string;
+  devices?: string[];
   variables?: Record<string, string>;
   sandbox?: boolean;
   allow?: JobAllowConfig;
@@ -130,14 +129,16 @@ export interface RunMeta {
 }
 
 /**
- * True when the job may execute on this machine: no `device` pin, or the pin
- * names this device. Both sides go through `normalizeHost` so `Yosemite-S0`,
- * `yosemite-s0.tailnet.ts.net`, and `yosemite-s0` all agree. Every fire path
- * (cron scheduler, webhook, catchup/overdue, manual run) gates on this.
+ * True when the job may execute on this machine: no `devices` allowlist (or
+ * empty), or the allowlist includes this device. Both sides go through
+ * `normalizeHost` so `Yosemite-S0`, `yosemite-s0.tailnet.ts.net`, and
+ * `yosemite-s0` all agree. Every fire path (cron scheduler, webhook,
+ * catchup/overdue, manual run) gates on this.
  */
-export function jobRunsOnThisDevice(config: Pick<JobConfig, 'device'>): boolean {
-  if (!config.device) return true;
-  return normalizeHost(config.device) === machineId();
+export function jobRunsOnThisDevice(config: Pick<JobConfig, 'devices'>): boolean {
+  if (!config.devices || config.devices.length === 0) return true;
+  const self = machineId();
+  return config.devices.some((d) => normalizeHost(d) === self);
 }
 
 /** Default values applied to every job config when fields are omitted. */
@@ -233,6 +234,8 @@ export function writeJob(config: JobConfig): void {
   if (output.timeout === '10m') delete output.timeout;
   if (output.enabled === true) delete output.enabled;
   if (output.runOnce === false || output.runOnce === undefined) delete output.runOnce;
+  const devArr = output.devices as string[] | undefined;
+  if (!devArr || devArr.length === 0) delete output.devices;
 
   fs.writeFileSync(filePath, yaml.stringify(output), 'utf-8');
 }
@@ -317,9 +320,16 @@ export function validateJob(config: Partial<JobConfig>): string[] {
       errors.push('endAt must be a parseable ISO 8601 / RFC3339 timestamp (e.g., 2026-12-31T23:59:00Z)');
     }
   }
-  if (config.device !== undefined) {
-    if (typeof config.device !== 'string' || config.device.trim() === '') {
-      errors.push('device must be a non-empty device name (as shown by `agents devices`, e.g. yosemite-s0)');
+  if (config.devices !== undefined) {
+    if (!Array.isArray(config.devices)) {
+      errors.push('devices must be an array of device names (as shown by `agents devices`)');
+    } else {
+      for (const d of config.devices) {
+        if (typeof d !== 'string' || d.trim() === '') {
+          errors.push('each entry in devices must be a non-empty device name');
+          break;
+        }
+      }
     }
   }
 

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -321,7 +321,7 @@ export function validateJob(config: Partial<JobConfig>): string[] {
     }
   }
   if ((config as Record<string, unknown>).device !== undefined) {
-    errors.push('singular "device" key is no longer supported — use "devices" (an array). Run the v12 migration: agents migrate');
+    errors.push('singular "device" key is no longer supported — replace with devices: [<name>] (an array)');
   }
   if (config.devices !== undefined) {
     if (!Array.isArray(config.devices)) {

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -320,6 +320,9 @@ export function validateJob(config: Partial<JobConfig>): string[] {
       errors.push('endAt must be a parseable ISO 8601 / RFC3339 timestamp (e.g., 2026-12-31T23:59:00Z)');
     }
   }
+  if ((config as Record<string, unknown>).device !== undefined) {
+    errors.push('singular "device" key is no longer supported — use "devices" (an array). Run the v12 migration: agents migrate');
+  }
   if (config.devices !== undefined) {
     if (!Array.isArray(config.devices)) {
       errors.push('devices must be an array of device names (as shown by `agents devices`)');

--- a/apps/cli/src/lib/runner.test.ts
+++ b/apps/cli/src/lib/runner.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
 import { executeJob, executeJobDetached } from './runner.js';
+import { getRunDir } from './routines.js';
 import type { JobConfig } from './routines.js';
 
 function baseConfig(partial: Partial<JobConfig> = {}): JobConfig {
@@ -30,27 +33,12 @@ describe('runner device enforcement', () => {
     await expect(executeJob(config)).rejects.toThrow(/restricted to device\(s\)/);
   });
 
-  it('executeJobDetached returns a skipped meta when this machine is not allowed', async () => {
+  it('executeJobDetached throws when this machine is not in the devices allowlist', async () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
-    const config = baseConfig({ devices: ['yosemite-s0'] });
-    const meta = await executeJobDetached(config);
-    expect(meta.status).toBe('failed');
-    expect(meta.runId).toBe('skipped');
-    expect(meta.exitCode).toBe(1);
-  });
+    const config = baseConfig({ name: 'guard-reject', devices: ['yosemite-s0'] });
+    await expect(executeJobDetached(config)).rejects.toThrow(/restricted to device\(s\)/);
 
-  it('executeJobDetached passes for unrestricted jobs (no device guard)', async () => {
-    process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
-    const config = baseConfig({ devices: undefined });
-    const meta = await executeJobDetached(config);
-    // Unrestricted: the device guard does not reject, so runId is NOT 'skipped'.
-    expect(meta.runId).not.toBe('skipped');
-  });
-
-  it('executeJobDetached passes when this machine is in the allowlist', async () => {
-    process.env.AGENTS_SYNC_MACHINE_ID = 'yosemite-s0';
-    const config = baseConfig({ devices: ['yosemite-s0'] });
-    const meta = await executeJobDetached(config);
-    expect(meta.runId).not.toBe('skipped');
+    const runDir = path.dirname(getRunDir(config.name, 'any'));
+    expect(fs.existsSync(runDir)).toBe(false);
   });
 });

--- a/apps/cli/src/lib/runner.test.ts
+++ b/apps/cli/src/lib/runner.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { executeJob, executeJobDetached } from './runner.js';
+import type { JobConfig } from './routines.js';
+
+function baseConfig(partial: Partial<JobConfig> = {}): JobConfig {
+  return {
+    name: 'test-job',
+    schedule: '0 3 * * *',
+    agent: 'claude',
+    mode: 'plan',
+    effort: 'auto',
+    timeout: '10m',
+    enabled: true,
+    prompt: 'do it',
+    ...partial,
+  } as JobConfig;
+}
+
+describe('runner device enforcement', () => {
+  const savedId = process.env.AGENTS_SYNC_MACHINE_ID;
+
+  afterEach(() => {
+    if (savedId === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+    else process.env.AGENTS_SYNC_MACHINE_ID = savedId;
+  });
+
+  it('executeJob throws when this machine is not in the devices allowlist', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+    const config = baseConfig({ devices: ['yosemite-s0', 'mac-mini'] });
+    await expect(executeJob(config)).rejects.toThrow(/restricted to device\(s\)/);
+  });
+
+  it('executeJobDetached returns a skipped meta when this machine is not allowed', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+    const config = baseConfig({ devices: ['yosemite-s0'] });
+    const meta = await executeJobDetached(config);
+    expect(meta.status).toBe('failed');
+    expect(meta.runId).toBe('skipped');
+    expect(meta.exitCode).toBe(1);
+  });
+
+  it('executeJobDetached passes for unrestricted jobs (no device guard)', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+    const config = baseConfig({ devices: undefined });
+    const meta = await executeJobDetached(config);
+    // Unrestricted: the device guard does not reject, so runId is NOT 'skipped'.
+    expect(meta.runId).not.toBe('skipped');
+  });
+
+  it('executeJobDetached passes when this machine is in the allowlist', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'yosemite-s0';
+    const config = baseConfig({ devices: ['yosemite-s0'] });
+    const meta = await executeJobDetached(config);
+    expect(meta.runId).not.toBe('skipped');
+  });
+});

--- a/apps/cli/src/lib/runner.test.ts
+++ b/apps/cli/src/lib/runner.test.ts
@@ -30,13 +30,13 @@ describe('runner device enforcement', () => {
   it('executeJob throws when this machine is not in the devices allowlist', async () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
     const config = baseConfig({ devices: ['yosemite-s0', 'mac-mini'] });
-    await expect(executeJob(config)).rejects.toThrow(/restricted to device\(s\)/);
+    await expect(executeJob(config)).rejects.toThrow(/can only run on/);
   });
 
   it('executeJobDetached throws when this machine is not in the devices allowlist', async () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
     const config = baseConfig({ name: 'guard-reject', devices: ['yosemite-s0'] });
-    await expect(executeJobDetached(config)).rejects.toThrow(/restricted to device\(s\)/);
+    await expect(executeJobDetached(config)).rejects.toThrow(/can only run on/);
 
     const runDir = path.dirname(getRunDir(config.name, 'any'));
     expect(fs.existsSync(runDir)).toBe(false);

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -464,7 +464,7 @@ function spawnJobAttempt(
 export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<RunResult> {
   if (!jobRunsOnThisDevice(config)) {
     const allowed = (config.devices ?? []).join(', ');
-    throw new Error(`Job '${config.name}' is restricted to device(s): ${allowed}`);
+    throw new Error(`Job '${config.name}' can only run on: ${allowed}`);
   }
   maybeRotate();
 
@@ -657,8 +657,8 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
 export async function executeJobDetached(config: JobConfig): Promise<RunMeta> {
   if (!jobRunsOnThisDevice(config)) {
     const allowed = (config.devices ?? []).join(', ');
-    process.stderr.write(`[agents] daemon: skipping job '${config.name}' — restricted to device(s): ${allowed}\n`);
-    throw new Error(`Job '${config.name}' is restricted to device(s): ${allowed}`);
+    process.stderr.write(`[agents] daemon: skipping '${config.name}' — can only run on: ${allowed}\n`);
+    throw new Error(`Job '${config.name}' can only run on: ${allowed}`);
   }
   // Pre-flight: pick a healthy version/account so the daemon does not launch
   // into a credit-exhausted install. Detached cannot mid-run failover (no exit

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -656,17 +656,9 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
 /** Spawn a job as a detached process and return immediately with run metadata. */
 export async function executeJobDetached(config: JobConfig): Promise<RunMeta> {
   if (!jobRunsOnThisDevice(config)) {
-    process.stderr.write(`[agents] daemon: skipping job '${config.name}' — restricted to device(s): ${(config.devices ?? []).join(', ')}\n`);
-    return {
-      jobName: config.name,
-      runId: 'skipped',
-      agent: config.agent,
-      pid: null,
-      status: 'failed',
-      startedAt: new Date().toISOString(),
-      completedAt: new Date().toISOString(),
-      exitCode: 1,
-    };
+    const allowed = (config.devices ?? []).join(', ');
+    process.stderr.write(`[agents] daemon: skipping job '${config.name}' — restricted to device(s): ${allowed}\n`);
+    throw new Error(`Job '${config.name}' is restricted to device(s): ${allowed}`);
   }
   // Pre-flight: pick a healthy version/account so the daemon does not launch
   // into a credit-exhausted install. Detached cannot mid-run failover (no exit

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -24,6 +24,7 @@ import {
   parseTimeout,
   writeRunMeta,
   getRunDir,
+  jobRunsOnThisDevice,
 } from './routines.js';
 import { getRunsDir } from './state.js';
 import type { AgentId } from './types.js';
@@ -461,6 +462,10 @@ function spawnJobAttempt(
  * failover across healthy same-agent accounts (RUSH-1016).
  */
 export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<RunResult> {
+  if (!jobRunsOnThisDevice(config)) {
+    const allowed = (config.devices ?? []).join(', ');
+    throw new Error(`Job '${config.name}' is restricted to device(s): ${allowed}`);
+  }
   maybeRotate();
 
   const launch = await resolveRoutineLaunch(config);
@@ -650,6 +655,19 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
 
 /** Spawn a job as a detached process and return immediately with run metadata. */
 export async function executeJobDetached(config: JobConfig): Promise<RunMeta> {
+  if (!jobRunsOnThisDevice(config)) {
+    process.stderr.write(`[agents] daemon: skipping job '${config.name}' — restricted to device(s): ${(config.devices ?? []).join(', ')}\n`);
+    return {
+      jobName: config.name,
+      runId: 'skipped',
+      agent: config.agent,
+      pid: null,
+      status: 'failed',
+      startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+      exitCode: 1,
+    };
+  }
   // Pre-flight: pick a healthy version/account so the daemon does not launch
   // into a credit-exhausted install. Detached cannot mid-run failover (no exit
   // wait); the next schedule tick re-selects if this attempt still fails.

--- a/apps/cli/src/lib/triggers/webhook.test.ts
+++ b/apps/cli/src/lib/triggers/webhook.test.ts
@@ -104,21 +104,26 @@ describe('matchJobsToWebhook', () => {
     expect(matchJobsToWebhook([disabled], pullRequestWebhook('x/y'))).toEqual([]);
   });
 
-  it('skips jobs pinned to another device, keeps jobs pinned here', () => {
+  it('skips jobs pinned to other devices, keeps jobs pinned here', () => {
     const saved = process.env.AGENTS_SYNC_MACHINE_ID;
     process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
     try {
       const foreign = job({
         name: 'foreign',
-        device: 'yosemite-s0',
+        devices: ['yosemite-s0'],
         trigger: { type: 'github_event', event: 'pull_request', repo: 'x/y' },
       });
       const local = job({
         name: 'local',
-        device: 'zion',
+        devices: ['zion'],
         trigger: { type: 'github_event', event: 'pull_request', repo: 'x/y' },
       });
-      expect(matchJobsToWebhook([foreign, local], pullRequestWebhook('x/y')).map((j) => j.name)).toEqual(['local']);
+      const multi = job({
+        name: 'multi',
+        devices: ['mac-mini', 'zion'],
+        trigger: { type: 'github_event', event: 'pull_request', repo: 'x/y' },
+      });
+      expect(matchJobsToWebhook([foreign, local, multi], pullRequestWebhook('x/y')).map((j) => j.name)).toEqual(['local', 'multi']);
     } finally {
       if (saved === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
       else process.env.AGENTS_SYNC_MACHINE_ID = saved;


### PR DESCRIPTION
## Summary

Replaces PR #1066 with a correct end-to-end implementation of routine fleet allowlists and remote routing.

- **Schema**: `JobConfig.device?: string` -> `devices?: string[]` — routines can now target multiple machines
- **Eligibility**: `jobRunsOnThisDevice()` updated to match against an array via `.some()`, all 4 callers (scheduler, overdue, webhook, manual run) inherit the change through the centralized helper
- **CLI**: `--device` flag replaced with `--devices <csv>` on `routines add`, validated against the fleet registry via `loadDevices()`
- **Subcommand**: new `routines devices [name]` with `--set <csv>`, `--clear`, and interactive `@inquirer/prompts` checkbox picker
- **Migration**: v12 migration rewrites `device: value` -> `devices: [value]` in all routine YAML files (handles collision, idempotent)
- **Passthrough**: `routines` added to `REMOTE_PASSTHROUGH` table; fleet-flag bailout exempts `routines` command (`--devices` is placement, not fan-out)
- **List output**: "Device" column -> "Devices", shows comma-joined names
- **Run errors**: names all allowed devices and hints `--host` for remote execution

## Test evidence

52/52 focused tests pass across 3 test files (routines.test.ts, migrate.test.ts, passthrough.test.ts).

Full suite: 4907 passed, 69 skipped, 178 failed (all failures are pre-existing `bun ENOENT` on yosemite-s0 — bun is not installed on this worker).

Build: `npx tsc --noEmit` clean, `npm run build` clean.

## Test plan

- [x] `validateJob` accepts/rejects devices array variants (4 cases)
- [x] `jobRunsOnThisDevice` matches array, normalizes case/domain, rejects non-members (4 cases)
- [x] `migrateRoutineDeviceToDevices` rewrites, handles collision, preserves fields, idempotent (6 cases)
- [x] Passthrough routes `routines --host`, exempts `--devices` from bailout for routines only (4 cases)
- [x] TypeScript compiles clean
- [ ] CI green on GitHub Actions

Session transcript: `yosemite-s0:/home/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-home-muqsit--agents-repos-routine-device-affinity--agents-worktrees-routine-affinity-code-v2/b7816f2f-8c8b-4500-afc3-b7b3c3b4ee38.jsonl`