### PR TITLE
feat(routines): daemon self-heal — heartbeat watchdog, opportunistic reap, pid-safe reaper, path guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+- **Heartbeat watchdog** — the daemon writes a heartbeat (timestamp + pid) every
+  monitor tick; `agents routines status` now distinguishes `running` / `wedged` /
+  `stopped`. A wedged daemon (pid alive but heartbeat stale >3 ticks) is reported
+  with a restart hint. (RUSH-1670)
+
+- **Opportunistic orphan reaper** — `agents routines list` and `status` now call
+  `monitorRunningJobs()` on entry (best-effort, swallowed errors), so orphaned
+  `running` records finalize even when the daemon is down. (RUSH-1671)
+
+- **Pid-reuse-safe reaper + max wall-clock** — `monitorRunningJobs()` records
+  `spawnedAt` (epoch ms) at spawn and verifies process identity via `ps` before
+  treating a pid as alive, preventing recycled-pid false positives. Runs exceeding
+  24 hours are finalized as `timeout` regardless of pid state. (RUSH-1672)
+
+- **Daemon binary path guard** — `getDaemonLaunch()` rejects `/$bunfs/root/…`
+  (bun virtual filesystem) paths with a hard error and warns when the resolved
+  binary sits inside `.agents/worktrees/`. `agents routines status` now prints the
+  resolved daemon binary path. (RUSH-1673)

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -15,11 +15,13 @@ import * as yaml from 'yaml';
 
 import {
   isDaemonRunning,
+  isDaemonWedged,
   signalDaemonReload,
   startDaemon,
   stopDaemon,
   readDaemonPid,
   readDaemonLog,
+  getDaemonStatus,
 } from '../lib/daemon.js';
 import { humanizeCron, humanizeNextRun, formatRepoLink, REPO_DISPLAY_MAX } from '../lib/routines-format.js';
 import {
@@ -41,7 +43,7 @@ import { fireWebhookJobs, matchJobsToWebhook, type GithubWebhook } from '../lib/
 import { getRoutinesDir } from '../lib/state.js';
 import { IS_WINDOWS } from '../lib/platform/index.js';
 import { safeJoin } from '../lib/paths.js';
-import { executeJob, executeJobDetached } from '../lib/runner.js';
+import { executeJob, executeJobDetached, monitorRunningJobs } from '../lib/runner.js';
 import { JobScheduler } from '../lib/scheduler.js';
 import { detectOverdueJobs } from '../lib/overdue.js';
 import { isInteractiveTerminal, requireInteractiveSelection } from './utils.js';
@@ -210,6 +212,7 @@ export function registerRoutinesCommands(program: Command): void {
     .description('See all scheduled jobs, when they run next, and their last execution status')
     .option('--json', 'Emit machine-readable JSON instead of the table (used by the menu bar helper)')
     .action((options: { json?: boolean }) => {
+      try { monitorRunningJobs(); } catch { /* best-effort orphan reap */ }
       const jobs = listAllJobs(process.cwd());
       if (jobs.length === 0) {
         if (options.json) {
@@ -980,18 +983,32 @@ export function registerRoutinesCommands(program: Command): void {
     .command('status')
     .description('Show scheduler status, enabled routines, and when each one fires next.')
     .action(() => {
-      const running = isDaemonRunning();
-      const pid = readDaemonPid();
+      try { monitorRunningJobs(); } catch { /* best-effort orphan reap */ }
+      const status = getDaemonStatus();
 
       console.log(chalk.bold('Scheduler\n'));
-      console.log(`  Status:    ${running ? chalk.green('running') : chalk.gray('stopped')}`);
-      if (pid) console.log(`  PID:       ${pid}`);
+      const stateLabel = status.state === 'running'
+        ? chalk.green('running')
+        : status.state === 'wedged'
+          ? chalk.red('wedged')
+          : chalk.gray('stopped');
+      console.log(`  Status:    ${stateLabel}`);
+      if (status.pid) console.log(`  PID:       ${status.pid}`);
+      if (status.binaryPath) console.log(`  Binary:    ${chalk.gray(status.binaryPath)}`);
+      if (status.heartbeat) {
+        const ago = Math.round((Date.now() - Date.parse(status.heartbeat.lastTick)) / 1000);
+        console.log(`  Heartbeat: ${chalk.gray(`${ago} sec ago`)}`);
+      }
 
       const jobs = listAllJobs();
       const enabled = jobs.filter((j) => j.enabled);
       console.log(`  Routines:  ${enabled.length} enabled / ${jobs.length} total`);
 
-      if (running && enabled.length > 0) {
+      if (status.state === 'wedged') {
+        console.log(chalk.red('\n  The daemon is wedged (heartbeat stale). Restart with: agents routines stop && agents routines start'));
+      }
+
+      if (status.running && enabled.length > 0) {
         const scheduler = new JobScheduler(async () => {});
         scheduler.loadAll();
         const scheduled = scheduler.listScheduled();
@@ -1001,7 +1018,7 @@ export function registerRoutinesCommands(program: Command): void {
           console.log(`    ${chalk.cyan(job.name.padEnd(24))} next: ${chalk.gray(next)}`);
         }
         scheduler.stopAll();
-      } else if (!running && jobs.length > 0) {
+      } else if (!status.running && jobs.length > 0) {
         console.log(chalk.gray('\n  Start the scheduler to begin firing routines: agents routines start'));
       }
     });

--- a/apps/cli/src/lib/__tests__/daemon-self-heal.test.ts
+++ b/apps/cli/src/lib/__tests__/daemon-self-heal.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Daemon self-heal: heartbeat, wedged detection, path guard, pid-reuse safety.
+ * RUSH-1669 / RUSH-1670 / RUSH-1672 / RUSH-1673.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  writeHeartbeat,
+  readHeartbeat,
+  removeHeartbeat,
+  isDaemonWedged,
+  writeDaemonPid,
+  readDaemonPid,
+  removeDaemonPid,
+  getDaemonLaunch,
+  validateDaemonBinary,
+  getDaemonStatus,
+} from '../daemon.js';
+import { writeRunMeta, type RunMeta } from '../routines.js';
+import { getRunsDir } from '../state.js';
+import { monitorRunningJobs } from '../runner.js';
+
+// ─── RUSH-1670: Heartbeat + wedged-daemon watchdog ──────────────────────────
+
+describe('heartbeat read/write', () => {
+  afterEach(() => { removeHeartbeat(); });
+
+  it('round-trips a heartbeat to disk', () => {
+    writeHeartbeat(12345);
+    const hb = readHeartbeat();
+    expect(hb).not.toBeNull();
+    expect(hb!.pid).toBe(12345);
+    expect(Date.parse(hb!.lastTick)).toBeGreaterThan(0);
+  });
+
+  it('returns null when no heartbeat file exists', () => {
+    removeHeartbeat();
+    expect(readHeartbeat()).toBeNull();
+  });
+});
+
+describe('isDaemonWedged', () => {
+  let priorPid: number | null;
+  beforeEach(() => { priorPid = readDaemonPid(); });
+  afterEach(() => {
+    removeHeartbeat();
+    if (priorPid === null) removeDaemonPid();
+    else writeDaemonPid(priorPid);
+  });
+
+  it('returns false when daemon is not running', () => {
+    removeDaemonPid();
+    expect(isDaemonWedged()).toBe(false);
+  });
+
+  it('returns false when heartbeat is fresh (pid alive + recent tick)', () => {
+    writeDaemonPid(process.pid);
+    writeHeartbeat(process.pid);
+    expect(isDaemonWedged()).toBe(false);
+  });
+
+  it('returns true when heartbeat is stale (pid alive but tick > 3 minutes old)', () => {
+    writeDaemonPid(process.pid);
+    const stale = new Date(Date.now() - 4 * 60_000).toISOString();
+    const hbPath = path.join(os.homedir(), '.agents', '.cache', 'helpers', 'daemon', 'heartbeat.json');
+    fs.mkdirSync(path.dirname(hbPath), { recursive: true });
+    fs.writeFileSync(hbPath, JSON.stringify({ lastTick: stale, pid: process.pid }));
+    expect(isDaemonWedged()).toBe(true);
+  });
+});
+
+describe('getDaemonStatus', () => {
+  let priorPid: number | null;
+  beforeEach(() => { priorPid = readDaemonPid(); });
+  afterEach(() => {
+    removeHeartbeat();
+    if (priorPid === null) removeDaemonPid();
+    else writeDaemonPid(priorPid);
+  });
+
+  it('reports stopped when no daemon is running', () => {
+    removeDaemonPid();
+    const s = getDaemonStatus();
+    expect(s.state).toBe('stopped');
+    expect(s.running).toBe(false);
+  });
+
+  it('reports running with binary path when daemon is alive and fresh', () => {
+    writeDaemonPid(process.pid);
+    writeHeartbeat(process.pid);
+    const s = getDaemonStatus();
+    expect(s.state).toBe('running');
+    expect(s.binaryPath).toBeTruthy();
+  });
+
+  it('reports wedged when heartbeat is stale', () => {
+    writeDaemonPid(process.pid);
+    const stale = new Date(Date.now() - 4 * 60_000).toISOString();
+    const hbPath = path.join(os.homedir(), '.agents', '.cache', 'helpers', 'daemon', 'heartbeat.json');
+    fs.mkdirSync(path.dirname(hbPath), { recursive: true });
+    fs.writeFileSync(hbPath, JSON.stringify({ lastTick: stale, pid: process.pid }));
+    const s = getDaemonStatus();
+    expect(s.state).toBe('wedged');
+  });
+});
+
+// ─── RUSH-1672: pid-reuse-safe reaper + max wall-clock ──────────────────────
+
+describe('monitorRunningJobs — pid-reuse + max wall-clock', () => {
+  const cleanupDirs: string[] = [];
+  afterEach(() => {
+    for (const d of cleanupDirs.splice(0)) {
+      try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
+    }
+  });
+
+  it('finalizes a run whose pid is dead (basic orphan reap)', () => {
+    const meta: RunMeta = {
+      jobName: '__selfheal-dead-pid__',
+      runId: 'test-dead-1',
+      agent: 'claude',
+      pid: 999999,
+      spawnedAt: Date.now() - 60_000,
+      status: 'running',
+      startedAt: new Date(Date.now() - 60_000).toISOString(),
+      completedAt: null,
+      exitCode: null,
+    };
+    writeRunMeta(meta);
+    cleanupDirs.push(path.join(getRunsDir(), meta.jobName));
+
+    monitorRunningJobs();
+
+    const metaPath = path.join(getRunsDir(), meta.jobName, meta.runId, 'meta.json');
+    const updated: RunMeta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+    expect(updated.status).not.toBe('running');
+    expect(updated.completedAt).not.toBeNull();
+  });
+
+  it('finalizes a run that exceeds the 24h max wall-clock', () => {
+    const meta: RunMeta = {
+      jobName: '__selfheal-wallclock__',
+      runId: 'test-wall-1',
+      agent: 'claude',
+      pid: process.pid,
+      spawnedAt: Date.now(),
+      status: 'running',
+      startedAt: new Date(Date.now() - 25 * 60 * 60_000).toISOString(),
+      completedAt: null,
+      exitCode: null,
+    };
+    writeRunMeta(meta);
+    cleanupDirs.push(path.join(getRunsDir(), meta.jobName));
+
+    monitorRunningJobs();
+
+    const metaPath = path.join(getRunsDir(), meta.jobName, meta.runId, 'meta.json');
+    const updated: RunMeta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+    expect(updated.status).toBe('timeout');
+    expect(updated.completedAt).not.toBeNull();
+  });
+});
+
+// ─── RUSH-1673: path guard (never supervise worktree/bunfs daemon) ──────────
+
+describe('validateDaemonBinary — path guard', () => {
+  it('throws for a /$bunfs/root/ virtual path', () => {
+    expect(() => validateDaemonBinary('/$bunfs/root/agents')).toThrow(/bun virtual path/);
+  });
+
+  it('warns for a binary under .agents/worktrees/', () => {
+    const { warnings } = validateDaemonBinary('/home/user/repo/.agents/worktrees/my-branch/apps/cli/dist/index.js');
+    expect(warnings.some((w) => /worktree/.test(w))).toBe(true);
+  });
+
+  it('warns for a nonexistent native binary', () => {
+    const { warnings } = validateDaemonBinary('/nonexistent/agents-never-exists');
+    expect(warnings.some((w) => /does not exist/.test(w))).toBe(true);
+  });
+
+  it('accepts process.execPath (a real binary) with no warnings', () => {
+    const { warnings } = validateDaemonBinary(process.execPath);
+    expect(warnings).toHaveLength(0);
+  });
+});
+
+describe('getDaemonLaunch — path guard integration', () => {
+  it('throws for a bunfs path', () => {
+    expect(() => getDaemonLaunch('/$bunfs/root/agents')).toThrow(/bun virtual path/);
+  });
+
+  it('emits a warning (not a throw) for a worktree .js path', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agd-wt-'));
+    const wtBin = path.join(tmpDir, '.agents', 'worktrees', 'fix', 'dist', 'index.js');
+    fs.mkdirSync(path.dirname(wtBin), { recursive: true });
+    fs.writeFileSync(wtBin, '');
+    expect(() => getDaemonLaunch(wtBin)).not.toThrow();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -25,10 +25,13 @@ import { redactSecrets } from './redact.js';
 const PID_FILE = 'daemon.pid';
 const LOCK_FILE = 'daemon.lock';
 const LOG_FILE = 'logs.jsonl';
+const HEARTBEAT_FILE = 'heartbeat.json';
 const LOG_MAX_SIZE = 5 * 1024 * 1024; // 5 MB
 const LOG_ROTATE_COUNT = 3;
 const PLIST_NAME = 'com.phnx-labs.agents-daemon';
 const SYSTEMD_UNIT = 'agents-daemon.service';
+const MONITOR_TICK_MS = 60_000;
+const WEDGE_THRESHOLD_TICKS = 3;
 
 // A long-lived `claude setup-token` value stored in this secrets bundle/key is
 // baked into the daemon's service-manager environment so headless routine runs
@@ -122,6 +125,48 @@ export function removeDaemonPid(): void {
   if (fs.existsSync(pidPath)) {
     fs.unlinkSync(pidPath);
   }
+}
+
+export interface DaemonHeartbeat {
+  lastTick: string;
+  pid: number;
+}
+
+function getHeartbeatPath(): string {
+  return path.join(getDaemonDir(), HEARTBEAT_FILE);
+}
+
+export function writeHeartbeat(pid: number = process.pid): void {
+  const hb: DaemonHeartbeat = { lastTick: new Date().toISOString(), pid };
+  try {
+    fs.writeFileSync(getHeartbeatPath(), JSON.stringify(hb), 'utf-8');
+  } catch { /* best effort */ }
+}
+
+export function readHeartbeat(): DaemonHeartbeat | null {
+  try {
+    const raw = fs.readFileSync(getHeartbeatPath(), 'utf-8');
+    const hb = JSON.parse(raw) as DaemonHeartbeat;
+    if (!hb.lastTick || !hb.pid) return null;
+    return hb;
+  } catch {
+    return null;
+  }
+}
+
+export function removeHeartbeat(): void {
+  try { fs.unlinkSync(getHeartbeatPath()); } catch { /* already removed */ }
+}
+
+export function isDaemonWedged(): boolean {
+  const pid = readDaemonPid();
+  if (!pid) return false;
+  if (!isAlive(pid)) return false;
+  const hb = readHeartbeat();
+  if (!hb) return false;
+  if (hb.pid !== pid) return false;
+  const elapsed = Date.now() - Date.parse(hb.lastTick);
+  return elapsed > WEDGE_THRESHOLD_TICKS * MONITOR_TICK_MS;
 }
 
 /** Check if the daemon process is alive by sending signal 0 to the stored PID. */
@@ -319,9 +364,11 @@ export async function runDaemon(): Promise<void> {
     log('ERROR', `Browser IPC failed to start: ${(err as Error).message}`);
   }
 
+  writeHeartbeat();
   const monitorInterval = setInterval(() => {
+    writeHeartbeat();
     monitorRunningJobs();
-  }, 60_000);
+  }, MONITOR_TICK_MS);
 
   // Cross-machine session sync: push this machine's transcripts to R2 and pull
   // every other machine's, ~every 90s. Skipped silently when the r2.backups
@@ -528,6 +575,7 @@ export async function runDaemon(): Promise<void> {
     clearInterval(launchHealthInterval);
     clearTimeout(launchHealthKickoff);
     removeDaemonPid();
+    removeHeartbeat();
     process.exit(0);
   };
 
@@ -848,10 +896,32 @@ export function buildDetachedDaemonEnv(
  * `which agents`), run it directly — it owns its own runtime resolution.
  */
 export function getDaemonLaunch(agentsBin: string = getAgentsBinPath()): { command: string; args: string[] } {
+  const { warnings } = validateDaemonBinary(agentsBin);
+  for (const w of warnings) process.stderr.write(`[agents] ${w}\n`);
   if (/\.(c|m)?js$/.test(agentsBin)) {
     return { command: process.execPath, args: [agentsBin, 'daemon', '_run'] };
   }
   return { command: agentsBin, args: ['daemon', '_run'] };
+}
+
+export function validateDaemonBinary(binPath: string): { warnings: string[] } {
+  const warnings: string[] = [];
+  if (/\/\$bunfs\/root\//.test(binPath)) {
+    throw new Error(
+      `Refusing to supervise daemon: resolved binary is a bun virtual path (${binPath}). ` +
+      `Install agents globally (npm i -g @phnx-labs/agents-cli) and restart.`,
+    );
+  }
+  if (/[/\\]\.agents[/\\]worktrees[/\\]/.test(binPath)) {
+    warnings.push(
+      `Warning: daemon binary is inside a git worktree (${binPath}). ` +
+      `A worktree deletion will wedge the daemon. Use the globally installed binary instead.`,
+    );
+  }
+  if (!fs.existsSync(binPath) && !/\.(c|m)?js$/.test(binPath)) {
+    warnings.push(`Warning: daemon binary does not exist on disk (${binPath}).`);
+  }
+  return { warnings };
 }
 
 interface StartDetachedOptions {
@@ -966,12 +1036,16 @@ export function stopDaemon(): boolean {
 
 /** Get current daemon status including running state, PID, and enabled job count. */
 export function getDaemonStatus(): {
+  state: 'running' | 'wedged' | 'stopped';
   running: boolean;
   pid: number | null;
   jobCount: number;
   logPath: string;
+  binaryPath: string | null;
+  heartbeat: DaemonHeartbeat | null;
 } {
   const running = isDaemonRunning();
+  const wedged = running && isDaemonWedged();
   const pid = readDaemonPid();
 
   let jobCount = 0;
@@ -979,7 +1053,20 @@ export function getDaemonStatus(): {
     jobCount = listAllJobs().filter((j) => j.enabled).length;
   } catch { /* job listing failed */ }
 
-  return { running, pid, jobCount, logPath: getLogPath() };
+  let binaryPath: string | null = null;
+  try {
+    binaryPath = getAgentsBinPath();
+  } catch { /* resolution failed */ }
+
+  return {
+    state: wedged ? 'wedged' : running ? 'running' : 'stopped',
+    running,
+    pid,
+    jobCount,
+    logPath: getLogPath(),
+    binaryPath,
+    heartbeat: readHeartbeat(),
+  };
 }
 
 /** Read the daemon log, optionally limited to the last N lines. */

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -123,6 +123,8 @@ export interface RunMeta {
   agent: AgentId;  // undefined at runtime for workflow jobs
   workflow?: string;
   pid: number | null;
+  /** Process birth time (epoch ms) recorded at spawn for pid-reuse detection. */
+  spawnedAt?: number;
   status: 'running' | 'completed' | 'failed' | 'timeout';
   startedAt: string;
   completedAt: string | null;

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -14,7 +14,7 @@
  * fires once with the pre-flight pick).
  */
 
-import { spawn } from 'child_process';
+import { spawn, execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -498,6 +498,7 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
     agent: effectiveAgent,
     ...(config.workflow ? { workflow: config.workflow } : {}),
     pid: null,
+    spawnedAt: Date.now(),
     status: 'running',
     startedAt: new Date().toISOString(),
     completedAt: null,
@@ -691,6 +692,7 @@ export async function executeJobDetached(config: JobConfig): Promise<RunMeta> {
     agent: effectiveAgent,
     ...(config.workflow ? { workflow: config.workflow } : {}),
     pid: null,
+    spawnedAt: Date.now(),
     status: 'running',
     startedAt: new Date().toISOString(),
     completedAt: null,
@@ -821,6 +823,39 @@ function inferFinalStatusFromLog(
   }
 }
 
+const MAX_WALL_CLOCK_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Verify that a PID still belongs to the process we spawned, not a recycled
+ * OS PID. Uses the recorded `spawnedAt` (epoch ms) from meta.json and
+ * compares against the process's actual start time via `ps`. Returns true
+ * when the PID is alive AND plausibly ours.
+ */
+function isPidOurs(pid: number, spawnedAt: number | undefined): boolean {
+  try {
+    process.kill(pid, 0);
+  } catch {
+    return false;
+  }
+  if (spawnedAt === undefined) return true;
+  if (process.platform === 'win32') return true;
+  try {
+    const etime = execFileSync('ps', ['-p', String(pid), '-o', 'etime='],
+      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    if (!etime) return true;
+    const parts = etime.replace(/-/g, ':').split(':').reverse();
+    let uptimeSec = 0;
+    if (parts[0]) uptimeSec += parseInt(parts[0], 10);
+    if (parts[1]) uptimeSec += parseInt(parts[1], 10) * 60;
+    if (parts[2]) uptimeSec += parseInt(parts[2], 10) * 3600;
+    if (parts[3]) uptimeSec += parseInt(parts[3], 10) * 86400;
+    const processStartMs = Date.now() - uptimeSec * 1000;
+    return Math.abs(processStartMs - spawnedAt) < 30_000;
+  } catch {
+    return true;
+  }
+}
+
 /** Scan all runs marked "running" and finalize any whose process has exited. */
 export function monitorRunningJobs(): void {
   const runsDir = getRunsDir();
@@ -843,14 +878,19 @@ export function monitorRunningJobs(): void {
         if (meta.status !== 'running') continue;
         if (!meta.pid) continue;
 
-        try {
-          process.kill(meta.pid, 0);
-        } catch { /* process no longer running */
-          const runDirPath = path.join(jobRunsPath, runDirEntry.name);
-          const stdoutPath = path.join(runDirPath, 'stdout.log');
+        const runDirPath = path.join(jobRunsPath, runDirEntry.name);
+        const stdoutPath = path.join(runDirPath, 'stdout.log');
 
-          // Prefer the agent's own success/error marker; fall back to "failed"
-          // only when the stream ended without one (process killed mid-run).
+        const wallClockMs = Date.now() - Date.parse(meta.startedAt);
+        if (Number.isFinite(wallClockMs) && wallClockMs > MAX_WALL_CLOCK_MS) {
+          meta.status = 'timeout';
+          meta.completedAt = new Date().toISOString();
+          writeRunMeta(meta);
+          extractAndSaveReport(stdoutPath, meta.agent, runDirPath);
+          continue;
+        }
+
+        if (!isPidOurs(meta.pid, meta.spawnedAt)) {
           const inferred = inferFinalStatusFromLog(stdoutPath, meta.agent);
           if (inferred) {
             meta.status = inferred.status;


### PR DESCRIPTION
## Incident (2026-07-13)

The scheduler on zion was silently dead for hours. The daemon (pid 40527) was a hand-started worktree dev build whose worktree got deleted — its event loop wedged (dead cwd) — `routines status` = `stopped`, 14 routines overdue, two runs frozen at `status: running` forever. launchd `KeepAlive` never fired (a wedged-but-alive process satisfies it), and the plist pointed at a non-executable bun path.

Evidence:
```
lsof -a -p 40527 -d cwd  -> cwd = .../agents-cli/.agents/worktrees/self-heal-win-daemon/apps/cli  (deleted)
meta.json (drain-rush-app) -> { "pid":44662, "status":"running", "completedAt":null }   # pid 44662 was dead
agents routines start -> "Failed to start daemon: spawning '/$bunfs/root/agents' produced no PID"
```

## Changes

### Heartbeat watchdog (RUSH-1670)
- Daemon writes `{lastTick, pid}` to `heartbeat.json` each monitor tick (60s)
- `isDaemonWedged()` detects pid-alive + stale-heartbeat (>3 ticks)
- `getDaemonStatus()` returns `state: 'running' | 'wedged' | 'stopped'`
- `agents routines status` shows state, heartbeat age, and binary path

### Opportunistic reaper (RUSH-1671)
- `monitorRunningJobs()` called at entry of `list` and `status` commands
- Best-effort, errors swallowed — never hangs the CLI command

### Pid-reuse-safe reaper + max wall-clock (RUSH-1672)
- `RunMeta.spawnedAt` (epoch ms) recorded at spawn in both `executeJob` and `executeJobDetached`
- `isPidOurs()` verifies process identity via `ps -o etime=` before treating a pid as alive
- Runs exceeding 24h max wall-clock finalized as `timeout` regardless of pid state

### Path guard (RUSH-1673)
- `validateDaemonBinary()` hard-rejects `/$bunfs/root/` (bun virtual fs) paths
- Warns (does not reject) for binaries under `.agents/worktrees/`
- `agents routines status` prints the resolved daemon binary path

## Test plan
- [x] 16 new unit tests in `daemon-self-heal.test.ts` covering heartbeat r/w, wedged detection, status states, pid-reuse reaper, max wall-clock finalize, and path guard (bunfs/worktree/missing)
- [x] All 15 existing `runner.test.ts` tests pass
- [x] `bun run build` green
- [ ] CI green
- [ ] prix-cloud review

## Coordination

PRs #1066 and #1064 are open and touch `runner.ts`/`commands/routines.ts`. This PR is based on `origin/main` (`dd3e9ed1`). Conflicts expected in `runner.ts` / `commands/routines.ts` if #1066 merges first — straightforward to rebase.

Fixes RUSH-1670, RUSH-1671, RUSH-1672, RUSH-1673
Part of RUSH-1669

Session transcript: `mac-mini:~/.agents/.history/sessions/` (public repo — not inlined)