### PR TITLE
fix(test): daemon systemd-unit assertion survives Windows paths

### DIFF
--- a/apps/cli/src/lib/daemon.test.ts
+++ b/apps/cli/src/lib/daemon.test.ts
@@ -202,8 +202,11 @@ describe('generateSystemdUnit', () => {
     fs.writeFileSync(indexJs, '');
     process.argv[1] = indexJs;
     try {
+      // Mirror systemdExecArg's quoting (backslashes escape for systemd) so
+      // the expectation holds on Windows paths too, not just POSIX ones.
+      const quote = (v: string) => `"${v.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
       expect(generateSystemdUnit()).toContain(
-        `ExecStart="${process.execPath}" "${indexJs}" "daemon" "_run"`,
+        `ExecStart=${[process.execPath, indexJs, 'daemon', '_run'].map(quote).join(' ')}`,
       );
     } finally {
       process.argv[1] = savedArgv1;


### PR DESCRIPTION
The `generateSystemdUnit` test asserted the raw `process.execPath` in the unit body, but the generator (correctly) escapes backslashes via `systemdExecArg`. POSIX paths have no backslashes so the divergence was invisible on the ubuntu-only per-PR CI — it surfaced on the release matrix's windows-latest legs (both node versions) and blocked release PR #1072 across four consecutive attempts.

The expectation now applies the same quoting as the generator, so it holds on any platform's paths. Test-only change; the generator's output is untouched (systemd escaping is the documented ExecStart contract).

Verified: the test passes locally; the real Windows proof is the next release matrix run, which is currently the only CI surface that exercises windows-latest.