### PR TITLE
feat(routines): add fleet device affinity and host routing

### DIFF
--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -272,3 +272,149 @@ describe('routines devices --set and --clear are mutually exclusive', () => {
     }
   });
 });
+
+describe('routines add --devices empty/whitespace fails closed', () => {
+  it('rejects --devices "" and does not create the routine file', () => {
+    const home = makeHome({ registry });
+    try {
+      const res = run(home, [
+        'add', 'new-job',
+        '--schedule', '0 3 * * *',
+        '--agent', 'claude',
+        '--prompt', 'hi',
+        '--devices', '',
+      ]);
+      expect(res.status).not.toBe(0);
+      const output = res.stdout + res.stderr;
+      expect(output).toMatch(/--devices requires at least one non-empty device name/);
+      expect(fs.existsSync(path.join(home, '.agents', 'routines', 'new-job.yml'))).toBe(false);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects --devices "   " and does not create the routine file', () => {
+    const home = makeHome({ registry });
+    try {
+      const res = run(home, [
+        'add', 'space-job',
+        '--schedule', '0 3 * * *',
+        '--agent', 'claude',
+        '--prompt', 'hi',
+        '--devices', '   ',
+      ]);
+      expect(res.status).not.toBe(0);
+      const output = res.stdout + res.stderr;
+      expect(output).toMatch(/--devices requires at least one non-empty device name/);
+      expect(fs.existsSync(path.join(home, '.agents', 'routines', 'space-job.yml'))).toBe(false);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('successfully persists --devices with valid names', () => {
+    const home = makeHome({ registry });
+    try {
+      const res = run(home, [
+        'add', 'placed-job',
+        '--schedule', '0 3 * * *',
+        '--agent', 'claude',
+        '--prompt', 'hi',
+        '--devices', 'yosemite-s0,mac-mini',
+      ]);
+      expect(res.status).toBe(0);
+      const doc = readRoutineYaml(home, 'placed-job');
+      expect(doc).not.toBeNull();
+      expect(doc!.devices).toEqual(['yosemite-s0', 'mac-mini']);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines devices --set empty/whitespace fails closed', () => {
+  it('rejects --set "" without mutating the routine', () => {
+    const job = { ...baseJob, devices: ['yosemite-s0'] };
+    const home = makeHome({ jobs: [job], registry });
+    try {
+      const before = fs.readFileSync(path.join(home, '.agents', 'routines', 'test-job.yml'), 'utf-8');
+      const res = run(home, ['devices', 'test-job', '--set', '']);
+      expect(res.status).not.toBe(0);
+      const output = res.stdout + res.stderr;
+      expect(output).toMatch(/--devices requires at least one non-empty device name/);
+      const after = fs.readFileSync(path.join(home, '.agents', 'routines', 'test-job.yml'), 'utf-8');
+      expect(after).toBe(before);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects --set "" combined with --clear as mutually exclusive', () => {
+    const job = { ...baseJob, devices: ['yosemite-s0'] };
+    const home = makeHome({ jobs: [job], registry });
+    try {
+      const before = fs.readFileSync(path.join(home, '.agents', 'routines', 'test-job.yml'), 'utf-8');
+      const res = run(home, ['devices', 'test-job', '--set', '', '--clear']);
+      expect(res.status).not.toBe(0);
+      const output = res.stdout + res.stderr;
+      expect(output).toMatch(/mutually exclusive/);
+      const after = fs.readFileSync(path.join(home, '.agents', 'routines', 'test-job.yml'), 'utf-8');
+      expect(after).toBe(before);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines run wrong-host exact output', () => {
+  it('prints the canonical message and suggestion then exits nonzero', () => {
+    const job = { ...baseJob, devices: ['yosemite-s0', 'mac-mini'] };
+    const home = makeHome({ jobs: [job], registry });
+    try {
+      const res = run(home, ['run', 'test-job'], { AGENTS_SYNC_MACHINE_ID: 'zion' });
+      expect(res.status).not.toBe(0);
+      const output = res.stdout + res.stderr;
+      expect(output).toContain("Job 'test-job' can only run on: yosemite-s0, mac-mini");
+      expect(output).toContain('  agents routines run test-job --host yosemite-s0');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines list --help documents --host and --device once each', () => {
+  it('lists each routing flag exactly once', () => {
+    const home = makeHome();
+    try {
+      const res = run(home, ['list', '--help']);
+      expect(res.status).toBe(0);
+      const output = res.stdout + res.stderr;
+      expect(output).toContain('--host');
+      expect(output).toContain('--device');
+      const hostMatches = output.match(/^\s+-H, --host /gm) ?? [];
+      const deviceMatches = output.match(/^\s+--device /gm) ?? [];
+      expect(hostMatches.length).toBe(1);
+      expect(deviceMatches.length).toBe(1);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines run --host SELF follows the normal local eligibility path', () => {
+  it('passes device eligibility when self is in the allowlist', () => {
+    const job = { ...baseJob, devices: ['zion'] };
+    const home = makeHome({ jobs: [job], registry });
+    try {
+      const res = run(home, ['run', 'test-job', '--host', 'zion'], { AGENTS_SYNC_MACHINE_ID: 'zion' });
+      // Eligibility passes; the run then fails because no claude version is
+      // configured in the isolated HOME. The important thing is it did not fail
+      // with the device-mismatch message.
+      const output = res.stdout + res.stderr;
+      expect(output).not.toContain("Job 'test-job' can only run on");
+      expect(output).toMatch(/no version of claude configured|not installed|spawn failed/);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -6,7 +6,7 @@
  * imported writeJob/readJob. Modeled on `routines-webhook.test.ts`.
  */
 import { describe, it, expect } from 'vitest';
-import { spawnSync } from 'child_process';
+import { spawnSync, spawn } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -65,6 +65,75 @@ function readRoutineYaml(home: string, name: string): Record<string, unknown> | 
   return yaml.parse(fs.readFileSync(p, 'utf-8'));
 }
 
+function daemonPidPath(home: string): string {
+  return path.join(home, '.agents', '.cache', 'helpers', 'daemon', 'daemon.pid');
+}
+
+function readDaemonPid(home: string): number | null {
+  const pidPath = daemonPidPath(home);
+  if (!fs.existsSync(pidPath)) return null;
+  const raw = fs.readFileSync(pidPath, 'utf-8').trim();
+  const pid = parseInt(raw, 10);
+  return isNaN(pid) ? null : pid;
+}
+
+/** Start the real `agents daemon _run` process against an isolated HOME. */
+function startIsolatedDaemon(home: string): { child: ReturnType<typeof spawn>; pidPromise: Promise<number | null> } {
+  const child = spawn('node', ['--import', 'tsx', 'src/index.ts', 'daemon', '_run'], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      AGENTS_SKIP_MIGRATION: '1',
+    },
+    detached: true,
+    stdio: 'ignore',
+  });
+
+  const pidPromise = new Promise<number | null>((resolve) => {
+    const deadline = Date.now() + 15_000;
+    const interval = setInterval(() => {
+      const pid = readDaemonPid(home);
+      if (pid) {
+        clearInterval(interval);
+        resolve(pid);
+        return;
+      }
+      if (Date.now() >= deadline) {
+        clearInterval(interval);
+        resolve(null);
+      }
+    }, 50);
+  });
+
+  return { child, pidPromise };
+}
+
+/** Terminate a daemon process started by startIsolatedDaemon and wait for it to exit. */
+async function stopIsolatedDaemon(child: ReturnType<typeof spawn>): Promise<void> {
+  if (!child.pid) return;
+  try {
+    process.kill(-child.pid, 'SIGTERM');
+  } catch {
+    // already gone
+  }
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      try {
+        process.kill(-child.pid, 'SIGKILL');
+      } catch {
+        // already gone
+      }
+      resolve();
+    }, 3_000);
+    child.on('close', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
 const baseJob = {
   name: 'test-job',
   schedule: '0 3 * * *',
@@ -83,6 +152,23 @@ describe('routines devices --set persists', () => {
     const home = makeHome({ jobs: [baseJob], registry });
     try {
       const res = run(home, ['devices', 'test-job', '--set', 'yosemite-s0,mac-mini']);
+      expect(res.status).toBe(0);
+
+      const doc = readRoutineYaml(home, 'test-job');
+      expect(doc).not.toBeNull();
+      expect(doc!.devices).toEqual(['yosemite-s0', 'mac-mini']);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines devices --set normalizes mixed case and FQDN duplicates', () => {
+  it('persists one normalized entry per device', () => {
+    const job = { ...baseJob, devices: ['yosemite-s0'] };
+    const home = makeHome({ jobs: [job], registry });
+    try {
+      const res = run(home, ['devices', 'test-job', '--set', 'Yosemite-S0,yosemite-s0.tailnet.ts.net,MAC-MINI']);
       expect(res.status).toBe(0);
 
       const doc = readRoutineYaml(home, 'test-job');
@@ -210,6 +296,22 @@ describe('routines list table has Devices column with bounded ellipsis', () => {
       fs.rmSync(home, { recursive: true, force: true });
     }
   });
+
+  it('renders unrestricted routines with Devices set to "all"', () => {
+    const home = makeHome({ jobs: [baseJob], registry });
+    try {
+      const res = run(home, ['list']);
+      expect(res.status).toBe(0);
+      const stripped = res.stdout.replace(/\x1b\[[0-9;]*m/g, '');
+      const line = stripped.split('\n').find((l) => l.includes('test-job'));
+      expect(line).toBeDefined();
+      // Column layout: 2 spaces + Name(24) + Agent(10) + Repo(24) + Devices(22).
+      const deviceField = line!.slice(60, 82).trim();
+      expect(deviceField).toBe('all');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('routines devices no-flags nonTTY names --set/--clear', () => {
@@ -312,9 +414,14 @@ describe('routines add --devices empty/whitespace fails closed', () => {
     }
   });
 
-  it('successfully persists --devices with valid names', () => {
+  it('successfully persists --devices with valid names against a running daemon', async () => {
     const home = makeHome({ registry });
+    let daemon: ReturnType<typeof startIsolatedDaemon> | undefined;
     try {
+      daemon = startIsolatedDaemon(home);
+      const pid = await daemon.pidPromise;
+      expect(pid).not.toBeNull();
+
       const res = run(home, [
         'add', 'placed-job',
         '--schedule', '0 3 * * *',
@@ -327,6 +434,7 @@ describe('routines add --devices empty/whitespace fails closed', () => {
       expect(doc).not.toBeNull();
       expect(doc!.devices).toEqual(['yosemite-s0', 'mac-mini']);
     } finally {
+      if (daemon) await stopIsolatedDaemon(daemon.child);
       fs.rmSync(home, { recursive: true, force: true });
     }
   });
@@ -395,6 +503,40 @@ describe('routines list --help documents --host and --device once each', () => {
       const deviceMatches = output.match(/^\s+--device /gm) ?? [];
       expect(hostMatches.length).toBe(1);
       expect(deviceMatches.length).toBe(1);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+/** Parse direct subcommand names from `routines --help`. */
+function directSubcommandNames(home: string): string[] {
+  const res = run(home, ['--help']);
+  expect(res.status).toBe(0);
+  const output = res.stdout + res.stderr;
+  const commandsMatch = output.match(/Commands:\n([\s\S]*?)(?=\n(?:Options|Notes|Examples|Arguments):)/);
+  if (!commandsMatch) return [];
+  return commandsMatch[1]
+    .split('\n')
+    .map((line) => line.trim().match(/^([a-z][a-z0-9-]*)/)?.[1])
+    .filter((name): name is string => Boolean(name));
+}
+
+describe('routines subcommand --help documents --host and --device once each', () => {
+  it('derives every direct command from routines --help and checks local help', () => {
+    const home = makeHome();
+    try {
+      const names = directSubcommandNames(home);
+      expect(names.length).toBeGreaterThan(0);
+      for (const name of names) {
+        const res = run(home, [name, '--help']);
+        expect(res.status).toBe(0);
+        const output = res.stdout + res.stderr;
+        const hostMatches = output.match(/^\s+-H, --host /gm) ?? [];
+        const deviceMatches = output.match(/^\s+--device /gm) ?? [];
+        expect(hostMatches.length).toBe(1);
+        expect(deviceMatches.length).toBe(1);
+      }
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -1,0 +1,274 @@
+/**
+ * End-to-end CLI subprocess tests for `agents routines` device-affinity commands.
+ *
+ * Every test spawns the real CLI (`node --import tsx src/index.ts routines ...`)
+ * against an isolated mkdtemp HOME — no live ~/.agents state, no mocks, no
+ * imported writeJob/readJob. Modeled on `routines-webhook.test.ts`.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as yaml from 'yaml';
+import { fileURLToPath } from 'url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/** Provision an isolated HOME with agents.yaml, .system/.git, and optional routines + device registry. */
+function makeHome(opts: {
+  jobs?: Record<string, unknown>[];
+  registry?: Record<string, unknown>;
+} = {}): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-routines-test-'));
+  const agentsDir = path.join(home, '.agents');
+  const routinesDir = path.join(agentsDir, 'routines');
+  fs.mkdirSync(routinesDir, { recursive: true });
+  fs.writeFileSync(path.join(agentsDir, 'agents.yaml'), 'agents: {}\n');
+  fs.mkdirSync(path.join(agentsDir, '.system', '.git'), { recursive: true });
+
+  for (const job of opts.jobs ?? []) {
+    fs.writeFileSync(
+      path.join(routinesDir, `${job.name}.yml`),
+      yaml.stringify(job),
+    );
+  }
+
+  if (opts.registry) {
+    const devicesDir = path.join(agentsDir, '.history', 'devices');
+    fs.mkdirSync(devicesDir, { recursive: true });
+    fs.writeFileSync(path.join(devicesDir, 'registry.json'), JSON.stringify(opts.registry));
+  }
+
+  return home;
+}
+
+/** Run `agents routines <args>` against an isolated HOME. */
+function run(home: string, args: string[], extraEnv: Record<string, string> = {}): ReturnType<typeof spawnSync> {
+  return spawnSync('node', ['--import', 'tsx', 'src/index.ts', 'routines', ...args], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      AGENTS_SKIP_MIGRATION: '1',
+      ...extraEnv,
+    },
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+}
+
+function readRoutineYaml(home: string, name: string): Record<string, unknown> | null {
+  const p = path.join(home, '.agents', 'routines', `${name}.yml`);
+  if (!fs.existsSync(p)) return null;
+  return yaml.parse(fs.readFileSync(p, 'utf-8'));
+}
+
+const baseJob = {
+  name: 'test-job',
+  schedule: '0 3 * * *',
+  agent: 'claude',
+  prompt: 'noop',
+};
+
+const registry = {
+  'yosemite-s0': { name: 'yosemite-s0', platform: 'linux' },
+  'mac-mini': { name: 'mac-mini', platform: 'macos' },
+  'zion': { name: 'zion', platform: 'macos' },
+};
+
+describe('routines devices --set persists', () => {
+  it('writes a devices allowlist to the routine YAML', () => {
+    const home = makeHome({ jobs: [baseJob], registry });
+    try {
+      const res = run(home, ['devices', 'test-job', '--set', 'yosemite-s0,mac-mini']);
+      expect(res.status).toBe(0);
+
+      const doc = readRoutineYaml(home, 'test-job');
+      expect(doc).not.toBeNull();
+      expect(doc!.devices).toEqual(['yosemite-s0', 'mac-mini']);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines devices --clear removes allowlist', () => {
+  it('removes the devices field from the routine YAML', () => {
+    const job = { ...baseJob, devices: ['yosemite-s0'] };
+    const home = makeHome({ jobs: [job], registry });
+    try {
+      const res = run(home, ['devices', 'test-job', '--clear']);
+      expect(res.status).toBe(0);
+
+      const raw = fs.readFileSync(path.join(home, '.agents', 'routines', 'test-job.yml'), 'utf-8');
+      expect(raw).not.toMatch(/^devices:/m);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines devices --set unknown is nonzero/no mutation', () => {
+  it('rejects unknown device names and does not mutate the YAML', () => {
+    const job = { ...baseJob, devices: ['yosemite-s0'] };
+    const home = makeHome({ jobs: [job], registry });
+    try {
+      const before = fs.readFileSync(path.join(home, '.agents', 'routines', 'test-job.yml'), 'utf-8');
+
+      const res = run(home, ['devices', 'test-job', '--set', 'nonexistent-box']);
+      expect(res.status).not.toBe(0);
+
+      const after = fs.readFileSync(path.join(home, '.agents', 'routines', 'test-job.yml'), 'utf-8');
+      expect(after).toBe(before);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines add --devices unknown is nonzero/no write', () => {
+  it('rejects unknown devices and does not create the routine file', () => {
+    const home = makeHome({ registry });
+    try {
+      const res = run(home, [
+        'add', 'new-job',
+        '--schedule', '0 3 * * *',
+        '--agent', 'claude',
+        '--prompt', 'hi',
+        '--devices', 'nonexistent-box',
+      ]);
+      expect(res.status).not.toBe(0);
+      expect(fs.existsSync(path.join(home, '.agents', 'routines', 'new-job.yml'))).toBe(false);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines list --json has devices+runsHere, no device', () => {
+  it('includes devices array and runsHere, excludes singular device key', () => {
+    const job = { ...baseJob, devices: ['yosemite-s0', 'mac-mini'] };
+    const home = makeHome({ jobs: [job], registry });
+    try {
+      const res = run(home, ['list', '--json'], { AGENTS_SYNC_MACHINE_ID: 'yosemite-s0' });
+      expect(res.status).toBe(0);
+
+      const parsed = JSON.parse(res.stdout.trim());
+      const entry = parsed.find((j: Record<string, unknown>) => j.name === 'test-job');
+      expect(entry).toBeDefined();
+      expect(entry.devices).toEqual(['yosemite-s0', 'mac-mini']);
+      expect(typeof entry.runsHere).toBe('boolean');
+      expect(entry.runsHere).toBe(true);
+      expect('device' in entry).toBe(false);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('shows empty devices array and runsHere=true when unrestricted', () => {
+    const home = makeHome({ jobs: [baseJob], registry });
+    try {
+      const res = run(home, ['list', '--json']);
+      expect(res.status).toBe(0);
+
+      const parsed = JSON.parse(res.stdout.trim());
+      const entry = parsed.find((j: Record<string, unknown>) => j.name === 'test-job');
+      expect(entry).toBeDefined();
+      expect(entry.devices).toEqual([]);
+      expect(entry.runsHere).toBe(true);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines list table has Devices column with bounded ellipsis', () => {
+  it('table header includes Devices', () => {
+    const home = makeHome({ jobs: [baseJob], registry });
+    try {
+      const res = run(home, ['list']);
+      expect(res.status).toBe(0);
+      expect(res.stdout).toContain('Devices');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('long device lists are ellipsized in the table', () => {
+    const job = { ...baseJob, devices: ['yosemite-s0', 'yosemite-s1', 'mac-mini', 'zion'] };
+    const home = makeHome({ jobs: [job], registry });
+    try {
+      const res = run(home, ['list']);
+      expect(res.status).toBe(0);
+      const stripped = res.stdout.replace(/\x1b\[[0-9;]*m/g, '');
+      const lines = stripped.split('\n').filter((l) => l.includes('test-job'));
+      expect(lines.length).toBeGreaterThan(0);
+      expect(lines[0]).toMatch(/…/);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines devices no-flags nonTTY names --set/--clear', () => {
+  it('non-interactive devices without flags exits nonzero naming --set and --clear', () => {
+    const home = makeHome({ jobs: [baseJob], registry });
+    try {
+      const res = run(home, ['devices', 'test-job']);
+      expect(res.status).not.toBe(0);
+      const output = res.stdout + res.stderr;
+      expect(output).toMatch(/--set/);
+      expect(output).toMatch(/--clear/);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines list --host self runs locally', () => {
+  it('exits 0 and lists when --host matches AGENTS_SYNC_MACHINE_ID', () => {
+    const job = { ...baseJob, devices: ['zion'] };
+    const home = makeHome({ jobs: [job], registry });
+    try {
+      const res = run(home, ['list', '--host', 'zion'], { AGENTS_SYNC_MACHINE_ID: 'zion' });
+      expect(res.status).toBe(0);
+      expect(res.stdout).toContain('test-job');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines --help documents --host and --device', () => {
+  it('help output contains --host and --device', () => {
+    const home = makeHome();
+    try {
+      const res = run(home, ['--help']);
+      const output = res.stdout + res.stderr;
+      expect(output).toContain('--host');
+      expect(output).toContain('--device');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines devices --set and --clear are mutually exclusive', () => {
+  it('exits nonzero without mutation when both are given', () => {
+    const job = { ...baseJob, devices: ['yosemite-s0'] };
+    const home = makeHome({ jobs: [job], registry });
+    try {
+      const before = fs.readFileSync(path.join(home, '.agents', 'routines', 'test-job.yml'), 'utf-8');
+      const res = run(home, ['devices', 'test-job', '--set', 'mac-mini', '--clear']);
+      expect(res.status).not.toBe(0);
+      const output = res.stdout + res.stderr;
+      expect(output).toMatch(/mutually exclusive/);
+      const after = fs.readFileSync(path.join(home, '.agents', 'routines', 'test-job.yml'), 'utf-8');
+      expect(after).toBe(before);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -198,7 +198,7 @@ describe('routines devices --set on .yaml-only routine', () => {
       const doc = yaml.parse(fs.readFileSync(yamlPath, 'utf-8'));
       expect(doc.devices).toEqual(['yosemite-s0']);
 
-      const listRes = run(home, ['list', '--json']);
+      const listRes = run(home, ['list', '--json'], { AGENTS_SYNC_MACHINE_ID: 'yosemite-s0' });
       expect(listRes.status).toBe(0);
       const parsed = JSON.parse(listRes.stdout.trim());
       const entry = parsed.find((j: Record<string, unknown>) => j.name === 'yaml-only');

--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -110,28 +110,46 @@ function startIsolatedDaemon(home: string): { child: ReturnType<typeof spawn>; p
   return { child, pidPromise };
 }
 
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /** Terminate a daemon process started by startIsolatedDaemon and wait for it to exit. */
 async function stopIsolatedDaemon(child: ReturnType<typeof spawn>): Promise<void> {
   if (!child.pid) return;
-  try {
-    process.kill(-child.pid, 'SIGTERM');
-  } catch {
-    // already gone
-  }
-  await new Promise<void>((resolve) => {
-    const timer = setTimeout(() => {
-      try {
-        process.kill(-child.pid, 'SIGKILL');
-      } catch {
-        // already gone
-      }
+
+  const closePromise = new Promise<void>((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
       resolve();
-    }, 3_000);
-    child.on('close', () => {
-      clearTimeout(timer);
-      resolve();
-    });
+      return;
+    }
+    child.on('close', () => resolve());
   });
+
+  if (child.exitCode !== null || child.signalCode !== null) return;
+
+  const signalProcessGroup = process.platform !== 'win32';
+  const signal = (sig: NodeJS.Signals) => {
+    try {
+      if (signalProcessGroup) {
+        process.kill(-child.pid!, sig);
+      } else {
+        child.kill(sig);
+      }
+    } catch {
+      // already gone
+    }
+  };
+
+  signal('SIGTERM');
+  const timer = setTimeout(() => signal('SIGKILL'), 3_000);
+  await closePromise;
+  clearTimeout(timer);
 }
 
 const baseJob = {
@@ -303,10 +321,16 @@ describe('routines list table has Devices column with bounded ellipsis', () => {
       const res = run(home, ['list']);
       expect(res.status).toBe(0);
       const stripped = res.stdout.replace(/\x1b\[[0-9;]*m/g, '');
-      const line = stripped.split('\n').find((l) => l.includes('test-job'));
+      const lines = stripped.split('\n');
+      const line = lines.find((l) => l.includes('test-job'));
       expect(line).toBeDefined();
-      // Column layout: 2 spaces + Name(24) + Agent(10) + Repo(24) + Devices(22).
-      const deviceField = line!.slice(60, 82).trim();
+      const headerLine = lines.find((l) => l.includes('Devices') && l.includes('Schedule'));
+      expect(headerLine).toBeDefined();
+      const deviceStart = headerLine!.indexOf('Devices');
+      const scheduleStart = headerLine!.indexOf('Schedule');
+      expect(deviceStart).toBeGreaterThan(-1);
+      expect(scheduleStart).toBeGreaterThan(deviceStart);
+      const deviceField = line!.slice(deviceStart, scheduleStart).trim();
       expect(deviceField).toBe('all');
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
@@ -417,9 +441,10 @@ describe('routines add --devices empty/whitespace fails closed', () => {
   it('successfully persists --devices with valid names against a running daemon', async () => {
     const home = makeHome({ registry });
     let daemon: ReturnType<typeof startIsolatedDaemon> | undefined;
+    let pid: number | null = null;
     try {
       daemon = startIsolatedDaemon(home);
-      const pid = await daemon.pidPromise;
+      pid = await daemon.pidPromise;
       expect(pid).not.toBeNull();
 
       const res = run(home, [
@@ -435,6 +460,7 @@ describe('routines add --devices empty/whitespace fails closed', () => {
       expect(doc!.devices).toEqual(['yosemite-s0', 'mac-mini']);
     } finally {
       if (daemon) await stopIsolatedDaemon(daemon.child);
+      if (typeof pid === 'number') expect(isProcessAlive(pid)).toBe(false);
       fs.rmSync(home, { recursive: true, force: true });
     }
   });
@@ -518,7 +544,7 @@ function directSubcommandNames(home: string): string[] {
   if (!commandsMatch) return [];
   return commandsMatch[1]
     .split('\n')
-    .map((line) => line.trim().match(/^([a-z][a-z0-9-]*)/)?.[1])
+    .map((line) => line.match(/^  ([a-z][a-z0-9-]*)/)?.[1])
     .filter((name): name is string => Boolean(name));
 }
 

--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -181,6 +181,36 @@ describe('routines devices --set persists', () => {
   });
 });
 
+describe('routines devices --set on .yaml-only routine', () => {
+  it('updates the .yaml file, creates no .yml sibling, and list --json reports devices+runsHere', () => {
+    const home = makeHome({ registry });
+    try {
+      const yamlPath = path.join(home, '.agents', 'routines', 'yaml-only.yaml');
+      fs.writeFileSync(
+        yamlPath,
+        yaml.stringify({ name: 'yaml-only', schedule: '0 3 * * *', agent: 'claude', prompt: 'noop' }),
+      );
+
+      const setRes = run(home, ['devices', 'yaml-only', '--set', 'yosemite-s0'], { AGENTS_SYNC_MACHINE_ID: 'yosemite-s0' });
+      expect(setRes.status).toBe(0);
+
+      expect(fs.existsSync(path.join(home, '.agents', 'routines', 'yaml-only.yml'))).toBe(false);
+      const doc = yaml.parse(fs.readFileSync(yamlPath, 'utf-8'));
+      expect(doc.devices).toEqual(['yosemite-s0']);
+
+      const listRes = run(home, ['list', '--json']);
+      expect(listRes.status).toBe(0);
+      const parsed = JSON.parse(listRes.stdout.trim());
+      const entry = parsed.find((j: Record<string, unknown>) => j.name === 'yaml-only');
+      expect(entry).toBeDefined();
+      expect(entry.devices).toEqual(['yosemite-s0']);
+      expect(entry.runsHere).toBe(true);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('routines devices --set normalizes mixed case and FQDN duplicates', () => {
   it('persists one normalized entry per device', () => {
     const job = { ...baseJob, devices: ['yosemite-s0'] };

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -93,16 +93,12 @@ function ensureSchedulerRunning(): void {
     console.log(chalk.gray('Scheduler reloaded'));
     return;
   }
-  try {
-    const result = startDaemon();
-    if (result.pid) {
-      console.log(chalk.green(`Scheduler started (PID: ${result.pid}). It will run in the background and fire routines on schedule.`));
-      console.log(chalk.gray(`Stop anytime with: agents routines stop`));
-    } else {
-      console.log(chalk.yellow('Could not start the scheduler. Start it manually with: agents routines start'));
-    }
-  } catch (err) {
-    console.log(chalk.yellow(`Could not start the scheduler: ${(err as Error).message}`));
+  const result = startDaemon();
+  if (result.pid) {
+    console.log(chalk.green(`Scheduler started (PID: ${result.pid}). It will run in the background and fire routines on schedule.`));
+    console.log(chalk.gray(`Stop anytime with: agents routines stop`));
+  } else {
+    console.log(chalk.yellow('Could not start the scheduler. Start it manually with: agents routines start'));
   }
 }
 
@@ -210,6 +206,15 @@ export function registerRoutinesCommands(program: Command): void {
       # List all routines and their next run times
       agents routines list
 
+      # List routines as seen from a specific host (local --host fallback)
+      agents routines list --host yosemite-s0
+
+      # Create a routine restricted to specific devices
+      agents routines add nightly --schedule "0 2 * * *" --agent claude --prompt "Summarize today's commits" --devices yosemite-s0,mac-mini
+
+      # Interactively manage which devices may run a routine
+      agents routines devices nightly
+
       # Run a routine right now in the foreground (ignores schedule)
       agents routines run daily-standup
 
@@ -240,12 +245,11 @@ export function registerRoutinesCommands(program: Command): void {
     `,
   });
 
-  addHostOption(
-    routinesCmd
-      .command('list')
-      .description('See all scheduled jobs, when they run next, and their last execution status')
-      .option('--json', 'Emit machine-readable JSON instead of the table (used by the menu bar helper)'),
-  ).action((options: { json?: boolean }) => {
+  routinesCmd
+    .command('list')
+    .description('See all scheduled jobs, when they run next, and their last execution status')
+    .option('--json', 'Emit machine-readable JSON instead of the table (used by the menu bar helper)')
+    .action((options: { json?: boolean }) => {
       try { monitorRunningJobs(); } catch { /* best-effort orphan reap */ }
       const jobs = listAllJobs(process.cwd());
       if (jobs.length === 0) {
@@ -348,10 +352,13 @@ export function registerRoutinesCommands(program: Command): void {
         const enabledWord = job.enabled ? 'yes' : 'no';
         const enabledPad = Math.max(0, ENABLED_W - enabledWord.length);
 
-        const deviceFull = job.devices && job.devices.length > 0 ? job.devices.join(',') : '-';
-        const deviceWord = deviceFull.length > DEVICE_W ? deviceFull.slice(0, DEVICE_W - 1) + '…' : deviceFull;
+        const deviceWord = !job.devices || job.devices.length === 0
+          ? 'all'
+          : job.devices.join(',').length > DEVICE_W
+            ? job.devices.join(',').slice(0, DEVICE_W - 1) + '…'
+            : job.devices.join(',');
         const deviceCell = !job.devices || job.devices.length === 0
-          ? chalk.gray('-')
+          ? chalk.gray('all')
           : jobRunsOnThisDevice(job)
             ? deviceWord
             : chalk.gray(deviceWord);
@@ -1172,4 +1179,10 @@ export function registerRoutinesCommands(program: Command): void {
         console.log(chalk.gray('No scheduler logs'));
       }
     });
+
+  // Every direct routines subcommand accepts the shared --host family so remote
+  // fall-through works and each subcommand's --help documents the flags.
+  for (const sub of routinesCmd.commands) {
+    addHostOption(sub);
+  }
 }

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -48,6 +48,9 @@ import { JobScheduler } from '../lib/scheduler.js';
 import { detectOverdueJobs } from '../lib/overdue.js';
 import { isInteractiveTerminal, requireInteractiveSelection } from './utils.js';
 import { setHelpSections } from '../lib/help.js';
+import { loadDevices } from '../lib/devices/registry.js';
+import { normalizeHost } from '../lib/machine-id.js';
+import { addHostOption } from '../lib/hosts/option.js';
 
 /**
  * Human-friendly wall-clock a run took (e.g. "  · 3 min", "  · 45 sec"), or ""
@@ -157,11 +160,35 @@ async function pickJob(
   }
 }
 
+/**
+ * Parse a comma-separated devices string, normalize, deduplicate, and validate
+ * each entry against the registered fleet. Exits nonzero on unknown devices.
+ */
+async function parseAndValidateDevices(raw: string): Promise<string[]> {
+  const names = [...new Set(raw.split(',').map((s) => normalizeHost(s.trim())).filter(Boolean))];
+  if (names.length === 0) {
+    console.log(chalk.red('--devices requires at least one device name'));
+    process.exit(1);
+  }
+  const registry = await loadDevices();
+  const registered = new Set(Object.keys(registry).map((k) => normalizeHost(k)));
+  const unknown = names.filter((n) => !registered.has(n));
+  if (unknown.length > 0) {
+    console.log(chalk.red(`Unknown device(s): ${unknown.join(', ')}`));
+    console.log(chalk.gray(`Registered: ${[...registered].sort().join(', ') || '(none)'}`));
+    console.log(chalk.gray('Enroll devices with: agents devices sync'));
+    process.exit(1);
+  }
+  return names;
+}
+
 /** Register the `agents routines` command tree. */
 export function registerRoutinesCommands(program: Command): void {
   const routinesCmd = program
     .command('routines')
     .description('Schedule agents to run on a cron schedule or at a specific time. The scheduler auto-starts on first add.');
+
+  addHostOption(routinesCmd);
 
   setHelpSections(routinesCmd, {
     examples: `
@@ -207,11 +234,12 @@ export function registerRoutinesCommands(program: Command): void {
     `,
   });
 
-  routinesCmd
-    .command('list')
-    .description('See all scheduled jobs, when they run next, and their last execution status')
-    .option('--json', 'Emit machine-readable JSON instead of the table (used by the menu bar helper)')
-    .action((options: { json?: boolean }) => {
+  addHostOption(
+    routinesCmd
+      .command('list')
+      .description('See all scheduled jobs, when they run next, and their last execution status')
+      .option('--json', 'Emit machine-readable JSON instead of the table (used by the menu bar helper)'),
+  ).action((options: { json?: boolean }) => {
       try { monitorRunningJobs(); } catch { /* best-effort orphan reap */ }
       const jobs = listAllJobs(process.cwd());
       if (jobs.length === 0) {
@@ -251,7 +279,7 @@ export function registerRoutinesCommands(program: Command): void {
             scheduleHuman: fireConditionLabel(job),
             trigger: job.trigger ?? null,
             timezone: job.timezone ?? null,
-            device: job.device ?? null,
+            devices: job.devices ?? [],
             runsHere: jobRunsOnThisDevice(job),
             enabled: job.enabled,
             overdue: overdueSet.has(job.name),
@@ -280,13 +308,13 @@ export function registerRoutinesCommands(program: Command): void {
       const NAME_W = 24;
       const AGENT_W = 10;
       const REPO_W = REPO_DISPLAY_MAX;
-      const DEVICE_W = 13;
+      const DEVICE_W = 22;
       const SCHED_W = 22;
       const ENABLED_W = 10;
       const NEXT_W = 22;
 
       const header =
-        `  ${'Name'.padEnd(NAME_W)} ${'Agent'.padEnd(AGENT_W)} ${'Repo'.padEnd(REPO_W)} ${'Device'.padEnd(DEVICE_W)} ${'Schedule'.padEnd(SCHED_W)} ${'Enabled'.padEnd(ENABLED_W)} ${'Next Run'.padEnd(NEXT_W)} Last Status`;
+        `  ${'Name'.padEnd(NAME_W)} ${'Agent'.padEnd(AGENT_W)} ${'Repo'.padEnd(REPO_W)} ${'Devices'.padEnd(DEVICE_W)} ${'Schedule'.padEnd(SCHED_W)} ${'Enabled'.padEnd(ENABLED_W)} ${'Next Run'.padEnd(NEXT_W)} Last Status`;
       console.log(chalk.gray(header));
       console.log(chalk.gray('  ' + '-'.repeat(NAME_W + AGENT_W + REPO_W + DEVICE_W + SCHED_W + ENABLED_W + NEXT_W + 20)));
 
@@ -314,10 +342,9 @@ export function registerRoutinesCommands(program: Command): void {
         const enabledWord = job.enabled ? 'yes' : 'no';
         const enabledPad = Math.max(0, ENABLED_W - enabledWord.length);
 
-        // Unpinned jobs run everywhere; a pin that names another machine is
-        // grayed — this machine never fires it.
-        const deviceWord = job.device || '-';
-        const deviceCell = !job.device
+        const deviceFull = job.devices && job.devices.length > 0 ? job.devices.join(',') : '-';
+        const deviceWord = deviceFull.length > DEVICE_W ? deviceFull.slice(0, DEVICE_W - 1) + '…' : deviceFull;
+        const deviceCell = !job.devices || job.devices.length === 0
           ? chalk.gray('-')
           : jobRunsOnThisDevice(job)
             ? deviceWord
@@ -360,7 +387,7 @@ export function registerRoutinesCommands(program: Command): void {
     .option('-e, --effort <effort>', 'Reasoning effort: low | medium | high | xhigh | max | auto', 'auto')
     .option('-t, --timeout <timeout>', 'Kill the agent if it runs longer than this (e.g., 10m, 2h, 3d, 1w; max 1w)', '10m')
     .option('--timezone <tz>', 'Interpret schedule in this timezone (e.g., America/Los_Angeles)')
-    .option('--device <name>', 'Pin to one machine (routines are fleet-synced): only the device with this name schedules and fires the job')
+    .option('--devices <names>', 'Fleet allowlist (comma-separated): only listed devices schedule and fire this routine. Omit for unrestricted.')
     .option('--at <time>', 'One-shot mode: run once at this time (e.g., "14:30" or "2026-02-24 09:00"), then disable')
     .option('--end-at <iso>', 'Stop firing on or after this ISO 8601 timestamp (e.g., "2026-12-31T23:59:00Z"); routine auto-disables.')
     .option('--disabled', 'Create the routine but keep it paused (enable later with resume)')
@@ -412,6 +439,12 @@ export function registerRoutinesCommands(program: Command): void {
           process.exit(1);
         }
 
+        // Parse and validate --devices against the fleet registry.
+        let devices: string[] | undefined;
+        if (options.devices) {
+          devices = await parseAndValidateDevices(options.devices);
+        }
+
         const config: JobConfig = {
           name: nameOrPath,
           schedule,
@@ -423,7 +456,7 @@ export function registerRoutinesCommands(program: Command): void {
           enabled: !options.disabled,
           prompt: options.prompt,
           timezone: options.timezone,
-          ...(options.device ? { device: options.device } : {}),
+          ...(devices ? { devices } : {}),
           ...(runOnce ? { runOnce: true } : {}),
           ...(options.endAt ? { endAt: options.endAt } : {}),
         };
@@ -644,8 +677,9 @@ export function registerRoutinesCommands(program: Command): void {
       }
 
       if (!jobRunsOnThisDevice(job)) {
-        console.log(chalk.red(`Job '${name}' is pinned to device '${job.device}' and never runs here.`));
-        console.log(chalk.gray(`  Run it there: agents ssh ${job.device} 'agents routines run ${name}'`));
+        const allowed = (job.devices ?? []).join(', ');
+        console.log(chalk.red(`Job '${name}' can only run on: ${allowed}`));
+        console.log(chalk.gray(`  agents routines run ${name} --host ${(job.devices ?? [])[0]}`));
         process.exit(1);
       }
 
@@ -948,6 +982,89 @@ export function registerRoutinesCommands(program: Command): void {
       } catch (err) {
         console.log(chalk.red((err as Error).message));
         process.exit(1);
+      }
+    });
+
+  // Fleet allowlist management for a single routine.
+  routinesCmd
+    .command('devices [name]')
+    .description('View or change which devices may run a routine. Without flags, opens an interactive picker (requires a TTY).')
+    .option('--set <devices>', 'Replace the allowlist with this comma-separated list (strict fleet validation)')
+    .option('--clear', 'Remove the allowlist so the routine runs on every device')
+    .action(async (name: string | undefined, options: { set?: string; clear?: boolean }) => {
+      if (options.set && options.clear) {
+        console.log(chalk.red('--set and --clear are mutually exclusive'));
+        process.exit(1);
+      }
+
+      if (!name) {
+        name = await pickJob('Select routine', undefined, ['agents routines devices <name>']) ?? undefined;
+        if (!name) return;
+      }
+      const job = readJob(name);
+      if (!job) {
+        console.log(chalk.red(`Job '${name}' not found`));
+        process.exit(1);
+      }
+
+      if (options.clear) {
+        job.devices = undefined;
+        writeJob(job);
+        console.log(chalk.green(`Devices cleared for '${name}' — runs on all devices`));
+        if (isDaemonRunning()) signalDaemonReload();
+        return;
+      }
+
+      if (options.set) {
+        const devices = await parseAndValidateDevices(options.set);
+        job.devices = devices;
+        writeJob(job);
+        console.log(chalk.green(`Devices for '${name}' set to: ${devices.join(', ')}`));
+        if (isDaemonRunning()) signalDaemonReload();
+        return;
+      }
+
+      // Interactive picker
+      if (!isInteractiveTerminal()) {
+        requireInteractiveSelection('device allowlist', ['agents routines devices <name> --set a,b', 'agents routines devices <name> --clear']);
+      }
+
+      const registry = await loadDevices();
+      const registeredNames = Object.keys(registry).map((k) => normalizeHost(k)).sort();
+      if (registeredNames.length === 0) {
+        console.log(chalk.yellow('No devices registered. Enroll with: agents devices sync'));
+        return;
+      }
+
+      const currentSet = new Set((job.devices ?? []).map((d) => normalizeHost(d)));
+
+      try {
+        const { checkbox } = await import('@inquirer/prompts');
+        const selected = await checkbox({
+          message: `Devices allowed to run '${name}' (space to toggle, enter to confirm, empty = unrestricted):`,
+          choices: registeredNames.map((d) => ({
+            value: d,
+            name: d,
+            checked: currentSet.has(d),
+          })),
+        });
+
+        if (selected.length === 0) {
+          job.devices = undefined;
+          writeJob(job);
+          console.log(chalk.green(`Devices cleared for '${name}' — runs on all devices`));
+        } else {
+          job.devices = selected;
+          writeJob(job);
+          console.log(chalk.green(`Devices for '${name}' set to: ${selected.join(', ')}`));
+        }
+        if (isDaemonRunning()) signalDaemonReload();
+      } catch (err) {
+        if (isPromptCancelled(err)) {
+          console.log(chalk.gray('Cancelled'));
+          return;
+        }
+        throw err;
       }
     });
 

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -206,7 +206,7 @@ export function registerRoutinesCommands(program: Command): void {
       # List all routines and their next run times
       agents routines list
 
-      # List routines as seen from a specific host (local --host fallback)
+      # List routines on a specific device
       agents routines list --host yosemite-s0
 
       # Create a routine restricted to specific devices
@@ -352,12 +352,13 @@ export function registerRoutinesCommands(program: Command): void {
         const enabledWord = job.enabled ? 'yes' : 'no';
         const enabledPad = Math.max(0, ENABLED_W - enabledWord.length);
 
-        const deviceWord = !job.devices || job.devices.length === 0
+        const deviceFull = job.devices?.join(',') ?? '';
+        const deviceWord = deviceFull.length === 0
           ? 'all'
-          : job.devices.join(',').length > DEVICE_W
-            ? job.devices.join(',').slice(0, DEVICE_W - 1) + '…'
-            : job.devices.join(',');
-        const deviceCell = !job.devices || job.devices.length === 0
+          : deviceFull.length > DEVICE_W
+            ? deviceFull.slice(0, DEVICE_W - 1) + '…'
+            : deviceFull;
+        const deviceCell = deviceFull.length === 0
           ? chalk.gray('all')
           : jobRunsOnThisDevice(job)
             ? deviceWord

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -37,6 +37,7 @@ import {
   getJobPath,
   parseAtTime,
   jobRunsOnThisDevice,
+  checkJobDeviceEligibility,
 } from '../lib/routines.js';
 import type { JobConfig } from '../lib/routines.js';
 import { fireWebhookJobs, matchJobsToWebhook, type GithubWebhook } from '../lib/triggers/webhook.js';
@@ -92,12 +93,16 @@ function ensureSchedulerRunning(): void {
     console.log(chalk.gray('Scheduler reloaded'));
     return;
   }
-  const result = startDaemon();
-  if (result.pid) {
-    console.log(chalk.green(`Scheduler started (PID: ${result.pid}). It will run in the background and fire routines on schedule.`));
-    console.log(chalk.gray(`Stop anytime with: agents routines stop`));
-  } else {
-    console.log(chalk.yellow('Could not start the scheduler. Start it manually with: agents routines start'));
+  try {
+    const result = startDaemon();
+    if (result.pid) {
+      console.log(chalk.green(`Scheduler started (PID: ${result.pid}). It will run in the background and fire routines on schedule.`));
+      console.log(chalk.gray(`Stop anytime with: agents routines stop`));
+    } else {
+      console.log(chalk.yellow('Could not start the scheduler. Start it manually with: agents routines start'));
+    }
+  } catch (err) {
+    console.log(chalk.yellow(`Could not start the scheduler: ${(err as Error).message}`));
   }
 }
 
@@ -162,12 +167,13 @@ async function pickJob(
 
 /**
  * Parse a comma-separated devices string, normalize, deduplicate, and validate
- * each entry against the registered fleet. Exits nonzero on unknown devices.
+ * each entry against the registered fleet. Exits nonzero on empty/whitespace
+ * input or unknown devices.
  */
 async function parseAndValidateDevices(raw: string): Promise<string[]> {
-  const names = [...new Set(raw.split(',').map((s) => normalizeHost(s.trim())).filter(Boolean))];
+  const names = [...new Set(raw.split(',').map((s) => s.trim()).filter(Boolean).map((s) => normalizeHost(s)))];
   if (names.length === 0) {
-    console.log(chalk.red('--devices requires at least one device name'));
+    console.log(chalk.red('--devices requires at least one non-empty device name'));
     process.exit(1);
   }
   const registry = await loadDevices();
@@ -441,7 +447,7 @@ export function registerRoutinesCommands(program: Command): void {
 
         // Parse and validate --devices against the fleet registry.
         let devices: string[] | undefined;
-        if (options.devices) {
+        if (options.devices !== undefined) {
           devices = await parseAndValidateDevices(options.devices);
         }
 
@@ -676,10 +682,10 @@ export function registerRoutinesCommands(program: Command): void {
         process.exit(1);
       }
 
-      if (!jobRunsOnThisDevice(job)) {
-        const allowed = (job.devices ?? []).join(', ');
-        console.log(chalk.red(`Job '${name}' can only run on: ${allowed}`));
-        console.log(chalk.gray(`  agents routines run ${name} --host ${(job.devices ?? [])[0]}`));
+      const eligibility = checkJobDeviceEligibility(job);
+      if (eligibility) {
+        console.log(chalk.red(eligibility.message));
+        console.log(chalk.gray(`  ${eligibility.suggestion}`));
         process.exit(1);
       }
 
@@ -992,7 +998,8 @@ export function registerRoutinesCommands(program: Command): void {
     .option('--set <devices>', 'Replace the allowlist with this comma-separated list (strict fleet validation)')
     .option('--clear', 'Remove the allowlist so the routine runs on every device')
     .action(async (name: string | undefined, options: { set?: string; clear?: boolean }) => {
-      if (options.set && options.clear) {
+      const hasSet = options.set !== undefined;
+      if (hasSet && options.clear) {
         console.log(chalk.red('--set and --clear are mutually exclusive'));
         process.exit(1);
       }
@@ -1015,8 +1022,8 @@ export function registerRoutinesCommands(program: Command): void {
         return;
       }
 
-      if (options.set) {
-        const devices = await parseAndValidateDevices(options.set);
+      if (hasSet) {
+        const devices = await parseAndValidateDevices(options.set!);
         job.devices = devices;
         writeJob(job);
         console.log(chalk.green(`Devices for '${name}' set to: ${devices.join(', ')}`));

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1016,7 +1016,7 @@ if (process.env.AGENTS_SKIP_MIGRATION !== '1') {
     // Bumping the suffix re-runs migrations for every user; binary releases that
     // don't change the schema must NOT re-run (they would destroy user content
     // when migration steps overlap with user-authored paths). See issue #20.
-    const sentinelValue = 'v11';
+    const sentinelValue = 'v12';
     let needRun = true;
     try {
       if (fs.existsSync(sentinel) && fs.readFileSync(sentinel, 'utf-8').trim() === sentinelValue) {

--- a/apps/cli/src/lib/__tests__/scheduler.device.test.ts
+++ b/apps/cli/src/lib/__tests__/scheduler.device.test.ts
@@ -46,37 +46,37 @@ function makeJob(overrides: Partial<JobConfig> = {}): JobConfig {
   };
 }
 
-describe('JobScheduler device pinning', () => {
-  it('loads unpinned jobs and jobs pinned to this device; skips foreign pins', () => {
+describe('JobScheduler devices allowlist', () => {
+  it('loads unpinned jobs and jobs whose allowlist includes this device; skips foreign', () => {
     writeJob(makeJob({ name: 'unpinned' }));
-    writeJob(makeJob({ name: 'pinned-here', device: 'zion' }));
-    writeJob(makeJob({ name: 'pinned-elsewhere', device: 'yosemite-s0' }));
+    writeJob(makeJob({ name: 'allowed-here', devices: ['zion'] }));
+    writeJob(makeJob({ name: 'allowed-elsewhere', devices: ['yosemite-s0'] }));
+    writeJob(makeJob({ name: 'multi-includes-here', devices: ['mac-mini', 'zion'] }));
 
     const scheduler = new JobScheduler(async () => {});
     scheduler.loadAll();
     const names = scheduler.listScheduled().map((j) => j.name).sort();
     scheduler.stopAll();
 
-    expect(names).toEqual(['pinned-here', 'unpinned']);
+    expect(names).toEqual(['allowed-here', 'multi-includes-here', 'unpinned']);
   });
 
-  it('matches a pin case-insensitively and ignores a domain suffix', () => {
-    writeJob(makeJob({ name: 'fqdn-pin', device: 'Zion.tailnet.ts.net' }));
+  it('matches an allowlist entry case-insensitively and ignores a domain suffix', () => {
+    writeJob(makeJob({ name: 'fqdn-entry', devices: ['Zion.tailnet.ts.net'] }));
 
     const scheduler = new JobScheduler(async () => {});
     scheduler.loadAll();
     const names = scheduler.listScheduled().map((j) => j.name);
     scheduler.stopAll();
 
-    expect(names).toEqual(['fqdn-pin']);
+    expect(names).toEqual(['fqdn-entry']);
   });
 });
 
-describe('detectOverdueJobs device pinning', () => {
-  it('never flags a job pinned to another device as overdue here', () => {
-    // Daily schedule with no recorded runs — overdue everywhere it may run.
-    writeJob(makeJob({ name: 'foreign-overdue', device: 'yosemite-s0' }));
-    writeJob(makeJob({ name: 'local-overdue', device: 'zion' }));
+describe('detectOverdueJobs devices allowlist', () => {
+  it('never flags a job restricted to another device as overdue here', () => {
+    writeJob(makeJob({ name: 'foreign-overdue', devices: ['yosemite-s0'] }));
+    writeJob(makeJob({ name: 'local-overdue', devices: ['zion'] }));
     writeJob(makeJob({ name: 'unpinned-overdue' }));
 
     const names = detectOverdueJobs().map((j) => j.name).sort();

--- a/apps/cli/src/lib/__tests__/scheduler.device.test.ts
+++ b/apps/cli/src/lib/__tests__/scheduler.device.test.ts
@@ -1,85 +1,144 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+/**
+ * Device-affinity coverage for the scheduler and overdue detector.
+ *
+ * No mocks, no spies, no fake service seams: every test spawns the real CLI
+ * (`node --import tsx src/index.ts routines ...`) against an isolated mkdtemp
+ * HOME. Scheduling is observed through `routines list --json` (nextRun is
+ * present only when this machine's scheduler loads the job); overdue detection
+ * is observed through the same JSON (`overdue` flag).
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import * as state from '../state.js';
-import { JobScheduler } from '../scheduler.js';
-import { writeJob, type JobConfig } from '../routines.js';
-import { detectOverdueJobs } from '../overdue.js';
+import * as yaml from 'yaml';
+import { fileURLToPath } from 'url';
 
-let tmpDir = '';
-let userRoutinesDir = '';
-let runsDir = '';
-const savedMachineId = process.env.AGENTS_SYNC_MACHINE_ID;
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 
-beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scheduler-device-test-'));
-  userRoutinesDir = path.join(tmpDir, 'routines');
-  runsDir = path.join(tmpDir, 'runs');
-  fs.mkdirSync(userRoutinesDir, { recursive: true });
+/** Provision an isolated HOME with routines and optional run metadata. */
+function makeHome(opts: {
+  jobs?: Record<string, unknown>[];
+  runs?: { jobName: string; runId: string; meta: Record<string, unknown> }[];
+} = {}): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'scheduler-device-test-'));
+  const agentsDir = path.join(home, '.agents');
+  const routinesDir = path.join(agentsDir, 'routines');
+  const runsDir = path.join(agentsDir, '.history', 'runs');
+  fs.mkdirSync(routinesDir, { recursive: true });
   fs.mkdirSync(runsDir, { recursive: true });
+  fs.writeFileSync(path.join(agentsDir, 'agents.yaml'), 'agents: {}\n');
+  fs.mkdirSync(path.join(agentsDir, '.system', '.git'), { recursive: true });
 
-  vi.spyOn(state, 'getRoutinesDir').mockReturnValue(userRoutinesDir);
-  vi.spyOn(state, 'getRunsDir').mockReturnValue(runsDir);
-  vi.spyOn(state, 'ensureAgentsDir').mockImplementation(() => {});
-  process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
-});
+  for (const job of opts.jobs ?? []) {
+    fs.writeFileSync(path.join(routinesDir, `${job.name}.yml`), yaml.stringify(job));
+  }
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  fs.rmSync(tmpDir, { recursive: true, force: true });
-  if (savedMachineId === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
-  else process.env.AGENTS_SYNC_MACHINE_ID = savedMachineId;
-});
+  for (const run of opts.runs ?? []) {
+    const runDir = path.join(runsDir, run.jobName, run.runId);
+    fs.mkdirSync(runDir, { recursive: true });
+    fs.writeFileSync(path.join(runDir, 'meta.json'), JSON.stringify(run.meta, null, 2));
+  }
 
-function makeJob(overrides: Partial<JobConfig> = {}): JobConfig {
-  return {
-    name: 'device-test',
-    schedule: '0 3 * * *',
-    agent: 'claude',
-    mode: 'plan',
-    effort: 'auto',
-    timeout: '10m',
-    enabled: true,
-    prompt: 'noop',
-    ...overrides,
-  };
+  return home;
 }
+
+/** Run `agents routines <args>` against an isolated HOME. */
+function run(home: string, args: string[], extraEnv: Record<string, string> = {}): ReturnType<typeof spawnSync> {
+  return spawnSync('node', ['--import', 'tsx', 'src/index.ts', 'routines', ...args], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      AGENTS_SKIP_MIGRATION: '1',
+      ...extraEnv,
+    },
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+}
+
+function findJob(home: string, args: string[], name: string, extraEnv: Record<string, string> = {}): Record<string, unknown> | undefined {
+  const res = run(home, args, extraEnv);
+  expect(res.status).toBe(0);
+  const parsed = JSON.parse(res.stdout.trim());
+  return parsed.find((j: Record<string, unknown>) => j.name === name);
+}
+
+const baseJob = {
+  name: 'device-test',
+  schedule: '0 3 * * *',
+  agent: 'claude',
+  prompt: 'noop',
+};
 
 describe('JobScheduler devices allowlist', () => {
   it('loads unpinned jobs and jobs whose allowlist includes this device; skips foreign', () => {
-    writeJob(makeJob({ name: 'unpinned' }));
-    writeJob(makeJob({ name: 'allowed-here', devices: ['zion'] }));
-    writeJob(makeJob({ name: 'allowed-elsewhere', devices: ['yosemite-s0'] }));
-    writeJob(makeJob({ name: 'multi-includes-here', devices: ['mac-mini', 'zion'] }));
+    const home = makeHome({
+      jobs: [
+        { ...baseJob, name: 'unpinned' },
+        { ...baseJob, name: 'allowed-here', devices: ['zion'] },
+        { ...baseJob, name: 'allowed-elsewhere', devices: ['yosemite-s0'] },
+        { ...baseJob, name: 'multi-includes-here', devices: ['mac-mini', 'zion'] },
+      ],
+    });
+    try {
+      const entries: Record<string, string | null>[] = [
+        findJob(home, ['list', '--json'], 'unpinned', { AGENTS_SYNC_MACHINE_ID: 'zion' })!,
+        findJob(home, ['list', '--json'], 'allowed-here', { AGENTS_SYNC_MACHINE_ID: 'zion' })!,
+        findJob(home, ['list', '--json'], 'multi-includes-here', { AGENTS_SYNC_MACHINE_ID: 'zion' })!,
+        findJob(home, ['list', '--json'], 'allowed-elsewhere', { AGENTS_SYNC_MACHINE_ID: 'zion' })!,
+      ];
 
-    const scheduler = new JobScheduler(async () => {});
-    scheduler.loadAll();
-    const names = scheduler.listScheduled().map((j) => j.name).sort();
-    scheduler.stopAll();
-
-    expect(names).toEqual(['allowed-here', 'multi-includes-here', 'unpinned']);
+      expect(entries[0].nextRun).not.toBeNull();
+      expect(entries[1].nextRun).not.toBeNull();
+      expect(entries[2].nextRun).not.toBeNull();
+      expect(entries[3].nextRun).toBeNull();
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 
   it('matches an allowlist entry case-insensitively and ignores a domain suffix', () => {
-    writeJob(makeJob({ name: 'fqdn-entry', devices: ['Zion.tailnet.ts.net'] }));
-
-    const scheduler = new JobScheduler(async () => {});
-    scheduler.loadAll();
-    const names = scheduler.listScheduled().map((j) => j.name);
-    scheduler.stopAll();
-
-    expect(names).toEqual(['fqdn-entry']);
+    const home = makeHome({
+      jobs: [{ ...baseJob, name: 'fqdn-entry', devices: ['Zion.tailnet.ts.net'] }],
+    });
+    try {
+      const entry = findJob(home, ['list', '--json'], 'fqdn-entry', { AGENTS_SYNC_MACHINE_ID: 'zion' })!;
+      expect(entry.nextRun).not.toBeNull();
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 });
 
 describe('detectOverdueJobs devices allowlist', () => {
   it('never flags a job restricted to another device as overdue here', () => {
-    writeJob(makeJob({ name: 'foreign-overdue', devices: ['yosemite-s0'] }));
-    writeJob(makeJob({ name: 'local-overdue', devices: ['zion'] }));
-    writeJob(makeJob({ name: 'unpinned-overdue' }));
+    const pastRun = { status: 'completed', exitCode: 0, startedAt: '2020-01-01T00:00:00Z', completedAt: '2020-01-01T00:01:00Z' };
+    const home = makeHome({
+      jobs: [
+        { ...baseJob, name: 'foreign-overdue', devices: ['yosemite-s0'] },
+        { ...baseJob, name: 'local-overdue', devices: ['zion'] },
+        { ...baseJob, name: 'unpinned-overdue' },
+      ],
+      runs: [
+        { jobName: 'foreign-overdue', runId: '2020-01-01T00-00-00-000Z', meta: pastRun },
+        { jobName: 'local-overdue', runId: '2020-01-01T00-00-00-000Z', meta: pastRun },
+        { jobName: 'unpinned-overdue', runId: '2020-01-01T00-00-00-000Z', meta: pastRun },
+      ],
+    });
+    try {
+      const foreign = findJob(home, ['list', '--json'], 'foreign-overdue', { AGENTS_SYNC_MACHINE_ID: 'zion' })!;
+      const local = findJob(home, ['list', '--json'], 'local-overdue', { AGENTS_SYNC_MACHINE_ID: 'zion' })!;
+      const unpinned = findJob(home, ['list', '--json'], 'unpinned-overdue', { AGENTS_SYNC_MACHINE_ID: 'zion' })!;
 
-    const names = detectOverdueJobs().map((j) => j.name).sort();
-    expect(names).toEqual(['local-overdue', 'unpinned-overdue']);
+      expect(foreign.overdue).toBe(false);
+      expect(local.overdue).toBe(true);
+      expect(unpinned.overdue).toBe(true);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/cli/src/lib/hosts/passthrough.test.ts
+++ b/apps/cli/src/lib/hosts/passthrough.test.ts
@@ -65,4 +65,51 @@ describe('maybeRunOnHost — local short-circuits (no SSH attempted)', () => {
     expect(process.exitCode).toBe(1);
     process.exitCode = 0;
   });
+
+  it('routes routines --host to a non-self target (rejected by assertValidSshTarget)', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    // --evil starts with '-' so assertValidSshTarget rejects it before any
+    // SSH connection is attempted. Returning true with exitCode > 0 proves
+    // the routing path was entered, not short-circuited.
+    const result = await maybeRunOnHost('routines', ['routines', 'list', '--host', '--evil']);
+    expect(result).toBe(true);
+    expect(process.exitCode).toBeGreaterThan(0);
+    process.exitCode = 0;
+  });
+
+  it('routes routines --device alias to a non-self target', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    const result = await maybeRunOnHost('routines', ['routines', 'run', 'x', '--device', '--evil']);
+    expect(result).toBe(true);
+    expect(process.exitCode).toBeGreaterThan(0);
+    process.exitCode = 0;
+  });
+
+  it('does NOT bail on --devices for routines with --host (placement, not fan-out)', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    // --devices on routines is placement; --host should still route remotely.
+    // The invalid target is rejected by assertValidSshTarget (returns true,
+    // exitCode > 0), proving --devices did not bail.
+    const result = await maybeRunOnHost('routines', ['routines', 'add', 'x', '--host', '--evil', '--devices', 'a,b']);
+    expect(result).toBe(true);
+    expect(process.exitCode).toBeGreaterThan(0);
+    process.exitCode = 0;
+  });
+
+  it('bails on --devices for non-routines commands (fan-out)', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    // --devices on a non-routines command triggers the fleet-flag bailout,
+    // returning false even with a non-self --host.
+    expect(await maybeRunOnHost('list', ['list', '--host', '--evil', '--devices'])).toBe(false);
+  });
+
+  it('bails on --hosts for non-routines commands (fan-out)', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    expect(await maybeRunOnHost('list', ['list', '--host', '--evil', '--hosts'])).toBe(false);
+  });
+
+  it('bails on --hosts for routines too (generic fleet flag, not placement)', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    expect(await maybeRunOnHost('routines', ['routines', 'list', '--host', '--evil', '--hosts'])).toBe(false);
+  });
 });

--- a/apps/cli/src/lib/hosts/passthrough.ts
+++ b/apps/cli/src/lib/hosts/passthrough.ts
@@ -47,6 +47,7 @@ const REMOTE_PASSTHROUGH: Record<string, RemoteSpec> = {
   sync: { nonInteractive: ['--yes'] },
   teams: {},
   message: {},
+  routines: {},
 };
 
 /** `--no-tty` is stripped like the routing flags but carries no value. */
@@ -128,10 +129,12 @@ export async function maybeRunOnHost(command: string, allArgs: string[]): Promis
     return true;
   }
 
-  // `--devices` / `--hosts` fan out to every registered device locally; don't
-  // let a per-host passthrough turn it into a cascading remote fan-out.
-  const fleetFlag = allArgs.includes('--devices') || allArgs.includes('--hosts');
-  if (fleetFlag) return false;
+  // `--hosts` is always a generic fleet flag — bail for every command so the
+  // local aggregator handles it. `--devices` is fan-out on most commands but
+  // a placement flag on `routines` (which devices may run the routine), so
+  // only exempt routines from the bail.
+  if (allArgs.includes('--hosts')) return false;
+  if (allArgs.includes('--devices') && command !== 'routines') return false;
 
   const hostName = hostFlag ?? deviceFlag;
   if (!hostName) return false;

--- a/apps/cli/src/lib/migrate.test.ts
+++ b/apps/cli/src/lib/migrate.test.ts
@@ -577,6 +577,8 @@ describe('v12 device migration daemon _run failure (POSIX)', () => {
     try {
       daemon = startDaemon(home);
       pid = await daemon.pidPromise;
+      expect(pid).not.toBeNull();
+      expect(isProcessAlive(pid!)).toBe(true);
 
       // Wait long enough for an every-second schedule to fire if the stale job
       // were mistakenly loaded as unrestricted.
@@ -590,7 +592,9 @@ describe('v12 device migration daemon _run failure (POSIX)', () => {
     } finally {
       fs.chmodSync(routinesDir, 0o755);
       if (daemon) await stopDaemon(daemon.child);
-      if (typeof pid === 'number') expect(isProcessAlive(pid)).toBe(false);
+      if (pid !== null) {
+        expect(isProcessAlive(pid)).toBe(false);
+      }
     }
   });
 });

--- a/apps/cli/src/lib/migrate.test.ts
+++ b/apps/cli/src/lib/migrate.test.ts
@@ -3,8 +3,9 @@ import * as os from 'os';
 import * as path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { migrateExtrasExtrasToAgentsExtras, repairSelfReferentialBinShims } from './migrate.js';
+import { migrateExtrasExtrasToAgentsExtras, migrateRoutineDeviceToDevices, repairSelfReferentialBinShims } from './migrate.js';
 import { toPosix } from './platform/index.js';
+import * as yaml from 'yaml';
 
 const tempDirs: string[] = [];
 
@@ -283,5 +284,125 @@ describe('repairSelfReferentialBinShims', () => {
 
     // Untouched: still the same symlink target.
     expect(fs.readlinkSync(binLink)).toBe(realBin);
+  });
+});
+
+describe('migrateRoutineDeviceToDevices', () => {
+  function makeRoutinesDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-migrate-dev-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it('rewrites device: value to devices: [value]', () => {
+    const dir = makeRoutinesDir();
+    fs.writeFileSync(path.join(dir, 'a.yml'), yaml.stringify({
+      name: 'a', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: 'yosemite-s0',
+    }));
+    migrateRoutineDeviceToDevices(dir);
+    const result = yaml.parse(fs.readFileSync(path.join(dir, 'a.yml'), 'utf-8'));
+    expect(result.devices).toEqual(['yosemite-s0']);
+    expect(result.device).toBeUndefined();
+  });
+
+  it('is idempotent — no change on re-run', () => {
+    const dir = makeRoutinesDir();
+    fs.writeFileSync(path.join(dir, 'b.yml'), yaml.stringify({
+      name: 'b', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: 'mac-mini',
+    }));
+    migrateRoutineDeviceToDevices(dir);
+    const after1 = fs.readFileSync(path.join(dir, 'b.yml'), 'utf-8');
+    migrateRoutineDeviceToDevices(dir);
+    const after2 = fs.readFileSync(path.join(dir, 'b.yml'), 'utf-8');
+    expect(after1).toBe(after2);
+  });
+
+  it('leaves a routine that already has devices untouched', () => {
+    const dir = makeRoutinesDir();
+    const original = { name: 'c', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', devices: ['a', 'b'] };
+    fs.writeFileSync(path.join(dir, 'c.yml'), yaml.stringify(original));
+    migrateRoutineDeviceToDevices(dir);
+    const result = yaml.parse(fs.readFileSync(path.join(dir, 'c.yml'), 'utf-8'));
+    expect(result.devices).toEqual(['a', 'b']);
+    expect(result.device).toBeUndefined();
+  });
+
+  it('drops device when devices already present (both-field collision)', () => {
+    const dir = makeRoutinesDir();
+    const original = { name: 'd', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: 'old', devices: ['new'] };
+    fs.writeFileSync(path.join(dir, 'd.yml'), yaml.stringify(original));
+    migrateRoutineDeviceToDevices(dir);
+    const result = yaml.parse(fs.readFileSync(path.join(dir, 'd.yml'), 'utf-8'));
+    expect(result.devices).toEqual(['new']);
+    expect(result.device).toBeUndefined();
+  });
+
+  it('preserves other YAML fields', () => {
+    const dir = makeRoutinesDir();
+    fs.writeFileSync(path.join(dir, 'e.yml'), yaml.stringify({
+      name: 'e', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: 'zion', timeout: '2h', enabled: false,
+    }));
+    migrateRoutineDeviceToDevices(dir);
+    const result = yaml.parse(fs.readFileSync(path.join(dir, 'e.yml'), 'utf-8'));
+    expect(result.devices).toEqual(['zion']);
+    expect(result.timeout).toBe('2h');
+    expect(result.enabled).toBe(false);
+    expect(result.agent).toBe('claude');
+  });
+
+  it('is a no-op for routines without device field', () => {
+    const dir = makeRoutinesDir();
+    const raw = yaml.stringify({ name: 'f', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi' });
+    fs.writeFileSync(path.join(dir, 'f.yml'), raw);
+    migrateRoutineDeviceToDevices(dir);
+    expect(fs.readFileSync(path.join(dir, 'f.yml'), 'utf-8')).toBe(raw);
+  });
+
+  it('propagates a write failure (no silent swallowing)', () => {
+    const dir = makeRoutinesDir();
+    fs.writeFileSync(path.join(dir, 'g.yml'), yaml.stringify({
+      name: 'g', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: 'zion',
+    }));
+    // Make the directory read-only so the atomic write (temp file + rename) fails.
+    fs.chmodSync(dir, 0o555);
+    try {
+      expect(() => migrateRoutineDeviceToDevices(dir)).toThrow();
+    } finally {
+      fs.chmodSync(dir, 0o755);
+    }
+  });
+
+  it('throws on malformed legacy device value (not a nonempty string)', () => {
+    const dir = makeRoutinesDir();
+    fs.writeFileSync(path.join(dir, 'h.yml'), yaml.stringify({
+      name: 'h', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: '',
+    }));
+    expect(() => migrateRoutineDeviceToDevices(dir)).toThrow(/not a valid device name/);
+    const result = yaml.parse(fs.readFileSync(path.join(dir, 'h.yml'), 'utf-8'));
+    expect(result.device).toBe('');
+  });
+
+  it('throws on non-string legacy device value (number)', () => {
+    const dir = makeRoutinesDir();
+    fs.writeFileSync(path.join(dir, 'i.yml'), yaml.stringify({
+      name: 'i', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: 42,
+    }));
+    expect(() => migrateRoutineDeviceToDevices(dir)).toThrow(/not a valid device name/);
+    const result = yaml.parse(fs.readFileSync(path.join(dir, 'i.yml'), 'utf-8'));
+    expect(result.device).toBe(42);
+  });
+
+  it('propagates a readFile error for candidate YAML', () => {
+    const dir = makeRoutinesDir();
+    const filePath = path.join(dir, 'j.yml');
+    fs.writeFileSync(filePath, yaml.stringify({
+      name: 'j', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: 'zion',
+    }));
+    fs.chmodSync(filePath, 0o000);
+    try {
+      expect(() => migrateRoutineDeviceToDevices(dir)).toThrow();
+    } finally {
+      fs.chmodSync(filePath, 0o644);
+    }
   });
 });

--- a/apps/cli/src/lib/migrate.test.ts
+++ b/apps/cli/src/lib/migrate.test.ts
@@ -1,7 +1,9 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { spawnSync, spawn } from 'child_process';
 import { afterEach, describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'url';
 
 import { migrateExtrasExtrasToAgentsExtras, migrateRoutineDeviceToDevices, repairSelfReferentialBinShims } from './migrate.js';
 import { toPosix } from './platform/index.js';
@@ -21,6 +23,8 @@ afterEach(() => {
     try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
   }
 });
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 
 function seedVersionHome(historyDir: string, agentId: string, ver: string): {
   pluginsDir: string;
@@ -403,5 +407,190 @@ describe('migrateRoutineDeviceToDevices', () => {
     // (EISDIR / EACCES) on every platform — no permission-dependent chmod needed.
     fs.mkdirSync(path.join(dir, 'j.yml'), { recursive: true });
     expect(() => migrateRoutineDeviceToDevices(dir)).toThrow();
+  });
+
+  it('successful migration rewrites device to devices atomically with no temp files left behind', () => {
+    const dir = makeRoutinesDir();
+    fs.writeFileSync(path.join(dir, 'k.yml'), yaml.stringify({
+      name: 'k', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: 'zion',
+    }));
+
+    migrateRoutineDeviceToDevices(dir);
+
+    const result = yaml.parse(fs.readFileSync(path.join(dir, 'k.yml'), 'utf-8'));
+    expect(result.devices).toEqual(['zion']);
+    expect(result.device).toBeUndefined();
+    const leftovers = fs.readdirSync(dir).filter((f) => f.includes('.tmp-'));
+    expect(leftovers).toEqual([]);
+  });
+});
+
+describe('v12 device migration CLI startup failure (POSIX)', () => {
+  function makeLegacyHome(schedule: string): string {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-migrate-startup-'));
+    tempDirs.push(home);
+    const agentsDir = path.join(home, '.agents');
+    const routinesDir = path.join(agentsDir, 'routines');
+    fs.mkdirSync(routinesDir, { recursive: true });
+    fs.writeFileSync(path.join(agentsDir, 'agents.yaml'), 'agents: {}\n');
+    fs.mkdirSync(path.join(agentsDir, '.system', '.git'), { recursive: true });
+    fs.writeFileSync(
+      path.join(routinesDir, 'legacy.yaml'),
+      yaml.stringify({ name: 'legacy', schedule, agent: 'claude', prompt: 'noop', device: 'yosemite-s0' }),
+    );
+    return home;
+  }
+
+  function run(home: string, args: string[], extraEnv: Record<string, string> = {}): ReturnType<typeof spawnSync> {
+    return spawnSync('node', ['--import', 'tsx', 'src/index.ts', 'routines', ...args], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        ...extraEnv,
+      },
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+  }
+
+  it('fails closed: a stale routine with a legacy device key is absent/inert, never unrestricted', () => {
+    if (process.platform === 'win32') {
+      // Windows read-only directory semantics do not reliably block writes.
+      return;
+    }
+    const home = makeLegacyHome('0 3 * * *');
+    const routinesDir = path.join(home, '.agents', 'routines');
+    fs.chmodSync(routinesDir, 0o555);
+    try {
+      const res = run(home, ['list', '--json'], { AGENTS_SYNC_MACHINE_ID: 'yosemite-s0' });
+      // The stale routine must not surface as an unrestricted job. The safe
+      // fail-closed outcome is absence/inertness, not a process exit code.
+      const parsed = res.status === 0 ? JSON.parse(res.stdout.trim()) : [];
+      const found = parsed.find((j: Record<string, unknown>) => j.name === 'legacy');
+      expect(found).toBeUndefined();
+      expect(res.stdout + res.stderr).not.toContain('legacy');
+    } finally {
+      fs.chmodSync(routinesDir, 0o755);
+    }
+  });
+});
+
+describe('v12 device migration daemon _run failure (POSIX)', () => {
+  function makeLegacyHome(): string {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-migrate-daemon-'));
+    tempDirs.push(home);
+    const agentsDir = path.join(home, '.agents');
+    const routinesDir = path.join(agentsDir, 'routines');
+    fs.mkdirSync(routinesDir, { recursive: true });
+    fs.writeFileSync(path.join(agentsDir, 'agents.yaml'), 'agents: {}\n');
+    fs.mkdirSync(path.join(agentsDir, '.system', '.git'), { recursive: true });
+    fs.writeFileSync(
+      path.join(routinesDir, 'legacy.yaml'),
+      yaml.stringify({ name: 'legacy', schedule: '* * * * * *', agent: 'claude', prompt: 'noop', device: 'yosemite-s0' }),
+    );
+    return home;
+  }
+
+  function readDaemonPid(home: string): number | null {
+    const pidPath = path.join(home, '.agents', '.cache', 'helpers', 'daemon', 'daemon.pid');
+    if (!fs.existsSync(pidPath)) return null;
+    const raw = fs.readFileSync(pidPath, 'utf-8').trim();
+    const pid = parseInt(raw, 10);
+    return isNaN(pid) ? null : pid;
+  }
+
+  function startDaemon(home: string): { child: ReturnType<typeof spawn>; pidPromise: Promise<number | null> } {
+    const child = spawn('node', ['--import', 'tsx', 'src/index.ts', 'daemon', '_run'], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+      },
+      detached: true,
+      stdio: 'ignore',
+    });
+
+    const pidPromise = new Promise<number | null>((resolve) => {
+      const deadline = Date.now() + 15_000;
+      const interval = setInterval(() => {
+        const pid = readDaemonPid(home);
+        if (pid) {
+          clearInterval(interval);
+          resolve(pid);
+          return;
+        }
+        if (Date.now() >= deadline) {
+          clearInterval(interval);
+          resolve(null);
+        }
+      }, 50);
+    });
+
+    return { child, pidPromise };
+  }
+
+  function isProcessAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async function stopDaemon(child: ReturnType<typeof spawn>): Promise<void> {
+    if (!child.pid) return;
+    const closePromise = new Promise<void>((resolve) => {
+      if (child.exitCode !== null || child.signalCode !== null) {
+        resolve();
+        return;
+      }
+      child.on('close', () => resolve());
+    });
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    try {
+      process.kill(-child.pid, 'SIGTERM');
+    } catch {
+      try { child.kill('SIGTERM'); } catch { /* already gone */ }
+    }
+    const timer = setTimeout(() => {
+      try { process.kill(-child.pid, 'SIGKILL'); } catch { /* already gone */ }
+    }, 3_000);
+    await closePromise;
+    clearTimeout(timer);
+  }
+
+  it('creates no run directory when migration cannot write the legacy fixture', async () => {
+    if (process.platform === 'win32') {
+      // chmod(0o555) is not a reliable write barrier on Windows.
+      return;
+    }
+    const home = makeLegacyHome();
+    const routinesDir = path.join(home, '.agents', 'routines');
+    fs.chmodSync(routinesDir, 0o555);
+
+    let daemon: ReturnType<typeof startDaemon> | undefined;
+    let pid: number | null = null;
+    try {
+      daemon = startDaemon(home);
+      pid = await daemon.pidPromise;
+
+      // Wait long enough for an every-second schedule to fire if the stale job
+      // were mistakenly loaded as unrestricted.
+      await new Promise((resolve) => { setTimeout(resolve, 2_500); });
+
+      const runsDir = path.join(home, '.agents', '.history', 'runs');
+      // The top-level runs bucket is created by daemon startup; the critical
+      // failure mode is a job-specific run directory for the stale routine.
+      const jobRunDirs = fs.existsSync(runsDir) ? fs.readdirSync(runsDir) : [];
+      expect(jobRunDirs).not.toContain('legacy');
+    } finally {
+      fs.chmodSync(routinesDir, 0o755);
+      if (daemon) await stopDaemon(daemon.child);
+      if (typeof pid === 'number') expect(isProcessAlive(pid)).toBe(false);
+    }
   });
 });

--- a/apps/cli/src/lib/migrate.test.ts
+++ b/apps/cli/src/lib/migrate.test.ts
@@ -358,7 +358,12 @@ describe('migrateRoutineDeviceToDevices', () => {
     expect(fs.readFileSync(path.join(dir, 'f.yml'), 'utf-8')).toBe(raw);
   });
 
-  it('propagates a write failure (no silent swallowing)', () => {
+  it('propagates a write failure (POSIX)', () => {
+    // Windows read-only directory semantics do not reliably block writes, so
+    // this test is scoped to POSIX platforms where chmod(0o555) is effective.
+    if (process.platform === 'win32') {
+      return;
+    }
     const dir = makeRoutinesDir();
     fs.writeFileSync(path.join(dir, 'g.yml'), yaml.stringify({
       name: 'g', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: 'zion',
@@ -392,17 +397,11 @@ describe('migrateRoutineDeviceToDevices', () => {
     expect(result.device).toBe(42);
   });
 
-  it('propagates a readFile error for candidate YAML', () => {
+  it('propagates a read error for a directory masquerading as a YAML file', () => {
     const dir = makeRoutinesDir();
-    const filePath = path.join(dir, 'j.yml');
-    fs.writeFileSync(filePath, yaml.stringify({
-      name: 'j', schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: 'zion',
-    }));
-    fs.chmodSync(filePath, 0o000);
-    try {
-      expect(() => migrateRoutineDeviceToDevices(dir)).toThrow();
-    } finally {
-      fs.chmodSync(filePath, 0o644);
-    }
+    // A directory named with a .yml suffix causes fs.readFileSync to throw
+    // (EISDIR / EACCES) on every platform — no permission-dependent chmod needed.
+    fs.mkdirSync(path.join(dir, 'j.yml'), { recursive: true });
+    expect(() => migrateRoutineDeviceToDevices(dir)).toThrow();
   });
 });

--- a/apps/cli/src/lib/migrate.ts
+++ b/apps/cli/src/lib/migrate.ts
@@ -1734,6 +1734,54 @@ export function migrateExtrasExtrasToAgentsExtras(historyDir: string = HISTORY_D
   }
 }
 
+/**
+ * Rewrite every routine YAML that carries the legacy singular `device: <value>`
+ * field to the new plural `devices: [<value>]` format. Preserves all other
+ * fields. Idempotent: a routine that already has `devices:` (or neither field)
+ * is left untouched.
+ *
+ * Params default to the real routines dir; injectable for tests.
+ */
+export function migrateRoutineDeviceToDevices(routinesDir?: string): void {
+  const dir = routinesDir ?? path.join(USER_DIR, 'routines');
+  if (!fs.existsSync(dir)) return;
+
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'));
+
+  let migrated = 0;
+  for (const file of files) {
+    const filePath = path.join(dir, file);
+    const raw = fs.readFileSync(filePath, 'utf-8');
+
+    let doc: Record<string, unknown>;
+    try {
+      doc = yaml.parse(raw) as Record<string, unknown>;
+      if (!doc || typeof doc !== 'object') continue;
+    } catch { continue; }
+
+    if (!('device' in doc)) continue;
+    if ('devices' in doc) {
+      delete doc.device;
+      atomicWriteFileSync(filePath, yaml.stringify(doc));
+      continue;
+    }
+
+    const val = doc.device;
+    if (typeof val !== 'string' || !val.trim()) {
+      throw new Error(`${file}: legacy 'device' field is not a valid device name — repair the file and retry`);
+    }
+    delete doc.device;
+    doc.devices = [val.trim()];
+
+    atomicWriteFileSync(filePath, yaml.stringify(doc));
+    migrated++;
+  }
+
+  if (migrated > 0) {
+    console.error(`Migrated ${migrated} routine${migrated === 1 ? '' : 's'}: device → devices`);
+  }
+}
+
 /** Run all idempotent migrations. Safe to call multiple times. */
 export async function runMigration(): Promise<void> {
   // MUST run first: every other migrator reads SYSTEM_DIR (the new path).
@@ -1788,6 +1836,9 @@ export async function runMigration(): Promise<void> {
   // installed version-home. Runs after migrateRuntimeToHistory so the version
   // homes are at their canonical HISTORY_DIR location.
   migrateExtrasExtrasToAgentsExtras();
+
+  // Rewrite routine YAML files: singular `device:` -> plural `devices: []`.
+  migrateRoutineDeviceToDevices();
 
   // Symlink repair runs LAST so it can find the post-move version homes.
   repairAgentConfigSymlinks();

--- a/apps/cli/src/lib/routines.test.ts
+++ b/apps/cli/src/lib/routines.test.ts
@@ -125,19 +125,29 @@ describe('normalizeTriggerEvent', () => {
   });
 });
 
-describe('validateJob — device', () => {
-  it('accepts a job pinned to a device', () => {
-    expect(validateJob(baseJob({ schedule: '0 3 * * *', device: 'yosemite-s0' }))).toEqual([]);
+describe('validateJob — devices', () => {
+  it('accepts a job with a devices allowlist', () => {
+    expect(validateJob(baseJob({ schedule: '0 3 * * *', devices: ['yosemite-s0'] }))).toEqual([]);
   });
 
-  it('rejects an empty device', () => {
-    const errors = validateJob(baseJob({ schedule: '0 3 * * *', device: '  ' }));
-    expect(errors.some((e) => /device must be a non-empty device name/.test(e))).toBe(true);
+  it('accepts a job with multiple devices', () => {
+    expect(validateJob(baseJob({ schedule: '0 3 * * *', devices: ['yosemite-s0', 'mac-mini'] }))).toEqual([]);
   });
 
-  it('rejects a non-string device', () => {
-    const errors = validateJob(baseJob({ schedule: '0 3 * * *', device: 42 as never }));
-    expect(errors.some((e) => /device must be a non-empty device name/.test(e))).toBe(true);
+  it('rejects a non-array devices', () => {
+    const errors = validateJob(baseJob({ schedule: '0 3 * * *', devices: 'yosemite-s0' as never }));
+    expect(errors.some((e) => /devices must be an array/.test(e))).toBe(true);
+  });
+
+  it('rejects an empty-string entry', () => {
+    const errors = validateJob(baseJob({ schedule: '0 3 * * *', devices: [''] }));
+    expect(errors.some((e) => /each entry in devices/.test(e))).toBe(true);
+  });
+
+  it('rejects a stale singular "device" key after v12', () => {
+    const config = { ...baseJob({ schedule: '0 3 * * *' }), device: 'yosemite-s0' } as Record<string, unknown>;
+    const errors = validateJob(config as Partial<JobConfig>);
+    expect(errors.some((e) => /singular "device" key is no longer supported/.test(e) && /devices:/.test(e))).toBe(true);
   });
 });
 
@@ -149,24 +159,27 @@ describe('jobRunsOnThisDevice', () => {
     else process.env.AGENTS_SYNC_MACHINE_ID = savedId;
   });
 
-  it('unpinned jobs run everywhere', () => {
+  it('unrestricted jobs run everywhere', () => {
     expect(jobRunsOnThisDevice({})).toBe(true);
-    expect(jobRunsOnThisDevice({ device: undefined })).toBe(true);
+    expect(jobRunsOnThisDevice({ devices: undefined })).toBe(true);
+    expect(jobRunsOnThisDevice({ devices: [] })).toBe(true);
   });
 
-  it('matches when the pin names this machine', () => {
+  it('matches when the allowlist includes this machine', () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'yosemite-s0';
-    expect(jobRunsOnThisDevice({ device: 'yosemite-s0' })).toBe(true);
+    expect(jobRunsOnThisDevice({ devices: ['yosemite-s0'] })).toBe(true);
+    expect(jobRunsOnThisDevice({ devices: ['mac-mini', 'yosemite-s0'] })).toBe(true);
   });
 
-  it('normalizes case and domain suffix on the pin', () => {
+  it('normalizes case and domain suffix', () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'yosemite-s0';
-    expect(jobRunsOnThisDevice({ device: 'Yosemite-S0' })).toBe(true);
-    expect(jobRunsOnThisDevice({ device: 'yosemite-s0.tailnet.ts.net' })).toBe(true);
+    expect(jobRunsOnThisDevice({ devices: ['Yosemite-S0'] })).toBe(true);
+    expect(jobRunsOnThisDevice({ devices: ['yosemite-s0.tailnet.ts.net'] })).toBe(true);
   });
 
-  it('rejects a pin naming another machine', () => {
+  it('rejects when allowlist names other machines', () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
-    expect(jobRunsOnThisDevice({ device: 'yosemite-s0' })).toBe(false);
+    expect(jobRunsOnThisDevice({ devices: ['yosemite-s0'] })).toBe(false);
+    expect(jobRunsOnThisDevice({ devices: ['yosemite-s0', 'mac-mini'] })).toBe(false);
   });
 });

--- a/apps/cli/src/lib/routines.test.ts
+++ b/apps/cli/src/lib/routines.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
+import * as yaml from 'yaml';
 import { validateJob, validateTrigger, normalizeTriggerEvent, writeJob, readJob, deleteJob, jobRunsOnThisDevice, checkJobDeviceEligibility, type JobConfig } from './routines.js';
 import { getRoutinesDir, ensureAgentsDir } from './state.js';
 
@@ -243,5 +245,90 @@ describe('checkJobDeviceEligibility', () => {
     expect(result!.allowedLabel).toBe('yosemite-s0, mac-mini');
     expect(result!.firstHost).toBe('yosemite-s0');
     expect(result!.suggestion).toBe("agents routines run backup --host yosemite-s0");
+  });
+});
+
+describe('readJobFile fails closed on legacy singular device key', () => {
+  it('returns null for a YAML file that still contains device:', () => {
+    ensureAgentsDir();
+    const name = '__test-readjob-device__';
+    const file = path.join(getRoutinesDir(), `${name}.yml`);
+    try {
+      fs.writeFileSync(file, yaml.stringify({
+        name, schedule: '0 3 * * *', agent: 'claude', prompt: 'hi', device: 'yosemite-s0',
+      }));
+      expect(readJob(name)).toBeNull();
+    } finally {
+      if (fs.existsSync(file)) fs.unlinkSync(file);
+    }
+  });
+});
+
+describe('writeJob extension handling', () => {
+  function fullConfig(name: string): JobConfig {
+    return {
+      name,
+      schedule: '0 3 * * *',
+      agent: 'claude',
+      prompt: 'extension test',
+      mode: 'auto',
+      effort: 'auto',
+      timeout: '10m',
+      enabled: true,
+    } as JobConfig;
+  }
+
+  it('updates an existing .yaml file and does not create a .yml sibling', () => {
+    ensureAgentsDir();
+    const name = '__test-writejob-yaml__';
+    const yamlFile = path.join(getRoutinesDir(), `${name}.yaml`);
+    const ymlFile = path.join(getRoutinesDir(), `${name}.yml`);
+    try {
+      fs.writeFileSync(yamlFile, yaml.stringify({
+        name, schedule: '0 4 * * *', agent: 'codex', prompt: 'original',
+      }));
+      writeJob(fullConfig(name));
+      expect(fs.existsSync(yamlFile)).toBe(true);
+      expect(fs.existsSync(ymlFile)).toBe(false);
+      const read = readJob(name);
+      expect(read).not.toBeNull();
+      expect(read!.agent).toBe('claude');
+    } finally {
+      if (fs.existsSync(yamlFile)) fs.unlinkSync(yamlFile);
+      if (fs.existsSync(ymlFile)) fs.unlinkSync(ymlFile);
+    }
+  });
+
+  it('creates a new routine as .yml when neither extension exists', () => {
+    ensureAgentsDir();
+    const name = '__test-writejob-new__';
+    const yamlFile = path.join(getRoutinesDir(), `${name}.yaml`);
+    const ymlFile = path.join(getRoutinesDir(), `${name}.yml`);
+    try {
+      writeJob(fullConfig(name));
+      expect(fs.existsSync(ymlFile)).toBe(true);
+      expect(fs.existsSync(yamlFile)).toBe(false);
+      const read = readJob(name);
+      expect(read).not.toBeNull();
+      expect(read!.name).toBe(name);
+    } finally {
+      if (fs.existsSync(yamlFile)) fs.unlinkSync(yamlFile);
+      if (fs.existsSync(ymlFile)) fs.unlinkSync(ymlFile);
+    }
+  });
+
+  it('throws when both .yml and .yaml files exist for the same name', () => {
+    ensureAgentsDir();
+    const name = '__test-writejob-both__';
+    const ymlFile = path.join(getRoutinesDir(), `${name}.yml`);
+    const yamlFile = path.join(getRoutinesDir(), `${name}.yaml`);
+    try {
+      fs.writeFileSync(ymlFile, yaml.stringify({ name, schedule: '0 3 * * *', agent: 'claude', prompt: 'a' }));
+      fs.writeFileSync(yamlFile, yaml.stringify({ name, schedule: '0 4 * * *', agent: 'codex', prompt: 'b' }));
+      expect(() => writeJob(fullConfig(name))).toThrow(/both \.yml and \.yaml/);
+    } finally {
+      if (fs.existsSync(ymlFile)) fs.unlinkSync(ymlFile);
+      if (fs.existsSync(yamlFile)) fs.unlinkSync(yamlFile);
+    }
   });
 });

--- a/apps/cli/src/lib/routines.test.ts
+++ b/apps/cli/src/lib/routines.test.ts
@@ -110,6 +110,39 @@ describe('default execution mode (RUSH-1595: plan -> auto)', () => {
   });
 });
 
+describe('writeJob atomic persistence', () => {
+  it('round-trips a job through an atomic write and leaves no temp files', () => {
+    ensureAgentsDir();
+    const name = '__test-atomic-write-routine__';
+    const routinesDir = getRoutinesDir();
+    const file = path.join(routinesDir, `${name}.yml`);
+    const config: JobConfig = {
+      name,
+      schedule: '0 3 * * *',
+      agent: 'claude',
+      prompt: 'round-trip check',
+      mode: 'plan',
+      effort: 'auto',
+      timeout: '10m',
+      enabled: true,
+    } as JobConfig;
+    try {
+      writeJob(config);
+      const read = readJob(name);
+      expect(read).not.toBeNull();
+      expect(read!.name).toBe(name);
+      expect(read!.agent).toBe('claude');
+      expect(read!.schedule).toBe('0 3 * * *');
+      expect(read!.prompt).toBe('round-trip check');
+
+      const leftovers = fs.readdirSync(routinesDir).filter((f) => f.startsWith(`${name}.yml.tmp-`));
+      expect(leftovers).toEqual([]);
+    } finally {
+      deleteJob(name);
+    }
+  });
+});
+
 describe('normalizeTriggerEvent', () => {
   it('maps canonical names and aliases', () => {
     expect(normalizeTriggerEvent('pull_request')).toBe('pull_request');

--- a/apps/cli/src/lib/routines.test.ts
+++ b/apps/cli/src/lib/routines.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
-import { validateJob, validateTrigger, normalizeTriggerEvent, writeJob, readJob, deleteJob, jobRunsOnThisDevice, type JobConfig } from './routines.js';
+import { validateJob, validateTrigger, normalizeTriggerEvent, writeJob, readJob, deleteJob, jobRunsOnThisDevice, checkJobDeviceEligibility, type JobConfig } from './routines.js';
 import { getRoutinesDir, ensureAgentsDir } from './state.js';
 
 /** Minimal valid schedule-based job. */
@@ -181,5 +181,34 @@ describe('jobRunsOnThisDevice', () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
     expect(jobRunsOnThisDevice({ devices: ['yosemite-s0'] })).toBe(false);
     expect(jobRunsOnThisDevice({ devices: ['yosemite-s0', 'mac-mini'] })).toBe(false);
+  });
+});
+
+describe('checkJobDeviceEligibility', () => {
+  const savedId = process.env.AGENTS_SYNC_MACHINE_ID;
+
+  afterEach(() => {
+    if (savedId === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+    else process.env.AGENTS_SYNC_MACHINE_ID = savedId;
+  });
+
+  it('returns null for unrestricted jobs', () => {
+    expect(checkJobDeviceEligibility({ name: 'j' })).toBeNull();
+    expect(checkJobDeviceEligibility({ name: 'j', devices: [] })).toBeNull();
+  });
+
+  it('returns null when this machine is in the allowlist', () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+    expect(checkJobDeviceEligibility({ name: 'j', devices: ['zion'] })).toBeNull();
+  });
+
+  it('returns normalized message, suggestion, and allowed label for foreign jobs', () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+    const result = checkJobDeviceEligibility({ name: 'backup', devices: ['Yosemite-S0.tailnet.ts.net', 'mac-mini'] });
+    expect(result).not.toBeNull();
+    expect(result!.message).toBe("Job 'backup' can only run on: yosemite-s0, mac-mini");
+    expect(result!.allowedLabel).toBe('yosemite-s0, mac-mini');
+    expect(result!.firstHost).toBe('yosemite-s0');
+    expect(result!.suggestion).toBe("agents routines run backup --host yosemite-s0");
   });
 });

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -96,14 +96,13 @@ export interface JobConfig {
   timezone?: string;
   repo?: string;
   /**
-   * Pin this routine to one machine. `~/.agents/routines/` is synced to every
-   * device via the user repo, so without a pin an enabled routine fires on
-   * EVERY machine running the scheduler. When set, only the device whose
-   * `machineId()` matches (normalized hostname, e.g. `yosemite-s0`) schedules,
-   * fires, catches up, or counts this job as overdue; everywhere else it is
-   * inert and `run` refuses with an `agents ssh` pointer.
+   * Fleet allowlist — restrict this routine to specific devices. When omitted
+   * or empty, the routine is unrestricted and fires on every device running the
+   * scheduler. When set, only devices whose `machineId()` matches any entry
+   * (via `normalizeHost`) schedule, fire, catch up, or count this job as
+   * overdue; everywhere else it is inert and `run` refuses with a pointer.
    */
-  device?: string;
+  devices?: string[];
   variables?: Record<string, string>;
   sandbox?: boolean;
   allow?: JobAllowConfig;
@@ -132,14 +131,16 @@ export interface RunMeta {
 }
 
 /**
- * True when the job may execute on this machine: no `device` pin, or the pin
- * names this device. Both sides go through `normalizeHost` so `Yosemite-S0`,
- * `yosemite-s0.tailnet.ts.net`, and `yosemite-s0` all agree. Every fire path
- * (cron scheduler, webhook, catchup/overdue, manual run) gates on this.
+ * True when the job may execute on this machine: no `devices` allowlist (or
+ * empty), or the allowlist includes this device. Both sides go through
+ * `normalizeHost` so `Yosemite-S0`, `yosemite-s0.tailnet.ts.net`, and
+ * `yosemite-s0` all agree. Every fire path (cron scheduler, webhook,
+ * catchup/overdue, manual run) gates on this.
  */
-export function jobRunsOnThisDevice(config: Pick<JobConfig, 'device'>): boolean {
-  if (!config.device) return true;
-  return normalizeHost(config.device) === machineId();
+export function jobRunsOnThisDevice(config: Pick<JobConfig, 'devices'>): boolean {
+  if (!config.devices || config.devices.length === 0) return true;
+  const self = machineId();
+  return config.devices.some((d) => normalizeHost(d) === self);
 }
 
 /** Default values applied to every job config when fields are omitted. */
@@ -235,6 +236,8 @@ export function writeJob(config: JobConfig): void {
   if (output.timeout === '10m') delete output.timeout;
   if (output.enabled === true) delete output.enabled;
   if (output.runOnce === false || output.runOnce === undefined) delete output.runOnce;
+  const devArr = output.devices as string[] | undefined;
+  if (!devArr || devArr.length === 0) delete output.devices;
 
   fs.writeFileSync(filePath, yaml.stringify(output), 'utf-8');
 }
@@ -319,9 +322,19 @@ export function validateJob(config: Partial<JobConfig>): string[] {
       errors.push('endAt must be a parseable ISO 8601 / RFC3339 timestamp (e.g., 2026-12-31T23:59:00Z)');
     }
   }
-  if (config.device !== undefined) {
-    if (typeof config.device !== 'string' || config.device.trim() === '') {
-      errors.push('device must be a non-empty device name (as shown by `agents devices`, e.g. yosemite-s0)');
+  if ((config as Record<string, unknown>).device !== undefined) {
+    errors.push('singular "device" key is no longer supported — replace with devices: [<name>] (an array)');
+  }
+  if (config.devices !== undefined) {
+    if (!Array.isArray(config.devices)) {
+      errors.push('devices must be an array of device names (as shown by `agents devices`)');
+    } else {
+      for (const d of config.devices) {
+        if (typeof d !== 'string' || d.trim() === '') {
+          errors.push('each entry in devices must be a non-empty device name');
+          break;
+        }
+      }
     }
   }
 

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -143,6 +143,36 @@ export function jobRunsOnThisDevice(config: Pick<JobConfig, 'devices'>): boolean
   return config.devices.some((d) => normalizeHost(d) === self);
 }
 
+/** Human presentation of a device-affinity mismatch for commands and runner. */
+export interface JobEligibilityResult {
+  /** Full human message, e.g. "Job 'NAME' can only run on: a, b". */
+  message: string;
+  /** One-line copy-paste suggestion, e.g. "agents routines run NAME --host a". */
+  suggestion: string;
+  /** Comma-separated allowed devices label, e.g. "a, b". */
+  allowedLabel: string;
+  /** First allowed device (normalized), useful for the suggested host. */
+  firstHost: string;
+}
+
+/**
+ * Return null when the job may run here; otherwise return a structured,
+ * human-friendly eligibility failure. Centralizes the message/suggestion
+ * construction so manual run, executeJob, and executeJobDetached stay in
+ * sync. Scheduler/webhook/overdue paths continue to use jobRunsOnThisDevice.
+ */
+export function checkJobDeviceEligibility(
+  config: Pick<JobConfig, 'name' | 'devices'>,
+): JobEligibilityResult | null {
+  if (jobRunsOnThisDevice(config)) return null;
+  const allowed = (config.devices ?? []).map((d) => normalizeHost(d));
+  const allowedLabel = allowed.join(', ');
+  const firstHost = allowed[0] ?? 'HOST';
+  const message = `Job '${config.name}' can only run on: ${allowedLabel}`;
+  const suggestion = `agents routines run ${config.name} --host ${firstHost}`;
+  return { message, suggestion, allowedLabel, firstHost };
+}
+
 /** Default values applied to every job config when fields are omitted. */
 const JOB_DEFAULTS: Partial<JobConfig> = {
   mode: 'auto',

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -13,6 +13,7 @@ import * as yaml from 'yaml';
 import { Cron } from 'croner';
 import { getRoutinesDir, getRunsDir, ensureAgentsDir, getProjectRoutinesDir } from './state.js';
 import { safeJoin } from './paths.js';
+import { atomicWriteFileSync } from './fs-atomic.js';
 import type { AgentId } from './types.js';
 import { ALL_AGENT_IDS } from './agents.js';
 import type { LoopConfig } from './loop.js';
@@ -269,7 +270,7 @@ export function writeJob(config: JobConfig): void {
   const devArr = output.devices as string[] | undefined;
   if (!devArr || devArr.length === 0) delete output.devices;
 
-  fs.writeFileSync(filePath, yaml.stringify(output), 'utf-8');
+  atomicWriteFileSync(filePath, yaml.stringify(output));
 }
 
 /** Delete a job config file by name. Returns true if the file existed. */

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -245,6 +245,11 @@ function readJobFile(filePath: string): JobConfig | null {
     const parsed = yaml.parse(content);
     if (!parsed || typeof parsed !== 'object') return null;
 
+    // Fail closed on the legacy singular `device` key. A routine that still
+    // carries it after v12 startup migration is unmigrated state and must be
+    // treated as unavailable/inert rather than unrestricted.
+    if (Object.prototype.hasOwnProperty.call(parsed, 'device')) return null;
+
     return {
       ...JOB_DEFAULTS,
       ...parsed,
@@ -255,11 +260,27 @@ function readJobFile(filePath: string): JobConfig | null {
   }
 }
 
-/** Write a job config to disk, omitting fields that match defaults. */
+/** Write a job config to disk, omitting fields that match defaults.
+ *
+ * Updates the one existing supported extension (.yml or .yaml) atomically.
+ * New routines are written as .yml. If both extensions exist for the same
+ * name, the write fails explicitly so we never choose or drop a sibling.
+ */
 export function writeJob(config: JobConfig): void {
   ensureAgentsDir();
   const jobsDir = getRoutinesDir();
-  const filePath = safeJoin(jobsDir, config.name + '.yml');
+  const ymlPath = safeJoin(jobsDir, config.name + '.yml');
+  const yamlPath = safeJoin(jobsDir, config.name + '.yaml');
+  const ymlExists = fs.existsSync(ymlPath);
+  const yamlExists = fs.existsSync(yamlPath);
+
+  if (ymlExists && yamlExists) {
+    throw new Error(
+      `Routine '${config.name}' has both .yml and .yaml files; resolve the ambiguity before editing.`,
+    );
+  }
+
+  const filePath = ymlExists ? ymlPath : yamlExists ? yamlPath : ymlPath;
 
   const output: Record<string, unknown> = { ...config };
   if (output.mode === 'auto') delete output.mode;

--- a/apps/cli/src/lib/runner.test.ts
+++ b/apps/cli/src/lib/runner.test.ts
@@ -27,16 +27,37 @@ describe('runner device enforcement', () => {
     else process.env.AGENTS_SYNC_MACHINE_ID = savedId;
   });
 
-  it('executeJob throws when this machine is not in the devices allowlist', async () => {
+  it('executeJob throws the canonical message when this machine is not in the devices allowlist', async () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
     const config = baseConfig({ devices: ['yosemite-s0', 'mac-mini'] });
-    await expect(executeJob(config)).rejects.toThrow(/can only run on/);
+    await expect(executeJob(config)).rejects.toThrow("Job 'test-job' can only run on: yosemite-s0, mac-mini");
   });
 
-  it('executeJobDetached throws when this machine is not in the devices allowlist', async () => {
+  it('executeJobDetached logs and throws the canonical message; no run directory is created', async () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
     const config = baseConfig({ name: 'guard-reject', devices: ['yosemite-s0'] });
-    await expect(executeJobDetached(config)).rejects.toThrow(/can only run on/);
+
+    const stderrChunks: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Buffer, ...args: unknown[]) => {
+      stderrChunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+      // @ts-expect-error overloaded signature
+      return originalWrite(chunk, ...args);
+    }) as typeof process.stderr.write;
+
+    let err: Error | undefined;
+    try {
+      await executeJobDetached(config);
+    } catch (e) {
+      err = e as Error;
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+
+    expect(err).toBeDefined();
+    expect(err!.message).toBe("Job 'guard-reject' can only run on: yosemite-s0");
+    const stderr = stderrChunks.join('');
+    expect(stderr).toContain("[agents] daemon: skipping 'guard-reject' — Job 'guard-reject' can only run on: yosemite-s0");
 
     const runDir = path.dirname(getRunDir(config.name, 'any'));
     expect(fs.existsSync(runDir)).toBe(false);

--- a/apps/cli/src/lib/runner.test.ts
+++ b/apps/cli/src/lib/runner.test.ts
@@ -33,31 +33,11 @@ describe('runner device enforcement', () => {
     await expect(executeJob(config)).rejects.toThrow("Job 'test-job' can only run on: yosemite-s0, mac-mini");
   });
 
-  it('executeJobDetached logs and throws the canonical message; no run directory is created', async () => {
+  it('executeJobDetached throws the canonical message; no run directory is created', async () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
     const config = baseConfig({ name: 'guard-reject', devices: ['yosemite-s0'] });
 
-    const stderrChunks: string[] = [];
-    const originalWrite = process.stderr.write.bind(process.stderr);
-    process.stderr.write = ((chunk: string | Buffer, ...args: unknown[]) => {
-      stderrChunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
-      // @ts-expect-error overloaded signature
-      return originalWrite(chunk, ...args);
-    }) as typeof process.stderr.write;
-
-    let err: Error | undefined;
-    try {
-      await executeJobDetached(config);
-    } catch (e) {
-      err = e as Error;
-    } finally {
-      process.stderr.write = originalWrite;
-    }
-
-    expect(err).toBeDefined();
-    expect(err!.message).toBe("Job 'guard-reject' can only run on: yosemite-s0");
-    const stderr = stderrChunks.join('');
-    expect(stderr).toContain("[agents] daemon: skipping 'guard-reject' — Job 'guard-reject' can only run on: yosemite-s0");
+    await expect(executeJobDetached(config)).rejects.toThrow("Job 'guard-reject' can only run on: yosemite-s0");
 
     const runDir = path.dirname(getRunDir(config.name, 'any'));
     expect(fs.existsSync(runDir)).toBe(false);

--- a/apps/cli/src/lib/runner.test.ts
+++ b/apps/cli/src/lib/runner.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { executeJob, executeJobDetached } from './runner.js';
+import { getRunDir } from './routines.js';
+import type { JobConfig } from './routines.js';
+
+function baseConfig(partial: Partial<JobConfig> = {}): JobConfig {
+  return {
+    name: 'test-job',
+    schedule: '0 3 * * *',
+    agent: 'claude',
+    mode: 'plan',
+    effort: 'auto',
+    timeout: '10m',
+    enabled: true,
+    prompt: 'do it',
+    ...partial,
+  } as JobConfig;
+}
+
+describe('runner device enforcement', () => {
+  const savedId = process.env.AGENTS_SYNC_MACHINE_ID;
+
+  afterEach(() => {
+    if (savedId === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+    else process.env.AGENTS_SYNC_MACHINE_ID = savedId;
+  });
+
+  it('executeJob throws when this machine is not in the devices allowlist', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+    const config = baseConfig({ devices: ['yosemite-s0', 'mac-mini'] });
+    await expect(executeJob(config)).rejects.toThrow(/can only run on/);
+  });
+
+  it('executeJobDetached throws when this machine is not in the devices allowlist', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+    const config = baseConfig({ name: 'guard-reject', devices: ['yosemite-s0'] });
+    await expect(executeJobDetached(config)).rejects.toThrow(/can only run on/);
+
+    const runDir = path.dirname(getRunDir(config.name, 'any'));
+    expect(fs.existsSync(runDir)).toBe(false);
+  });
+});

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -25,6 +25,7 @@ import {
   writeRunMeta,
   getRunDir,
   jobRunsOnThisDevice,
+  checkJobDeviceEligibility,
 } from './routines.js';
 import { getRunsDir } from './state.js';
 import type { AgentId } from './types.js';
@@ -462,9 +463,9 @@ function spawnJobAttempt(
  * failover across healthy same-agent accounts (RUSH-1016).
  */
 export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<RunResult> {
-  if (!jobRunsOnThisDevice(config)) {
-    const allowed = (config.devices ?? []).join(', ');
-    throw new Error(`Job '${config.name}' can only run on: ${allowed}`);
+  const eligibility = checkJobDeviceEligibility(config);
+  if (eligibility) {
+    throw new Error(eligibility.message);
   }
   maybeRotate();
 
@@ -656,10 +657,10 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
 
 /** Spawn a job as a detached process and return immediately with run metadata. */
 export async function executeJobDetached(config: JobConfig): Promise<RunMeta> {
-  if (!jobRunsOnThisDevice(config)) {
-    const allowed = (config.devices ?? []).join(', ');
-    process.stderr.write(`[agents] daemon: skipping '${config.name}' — can only run on: ${allowed}\n`);
-    throw new Error(`Job '${config.name}' can only run on: ${allowed}`);
+  const eligibility = checkJobDeviceEligibility(config);
+  if (eligibility) {
+    process.stderr.write(`[agents] daemon: skipping '${config.name}' — ${eligibility.message}\n`);
+    throw new Error(eligibility.message);
   }
   // Pre-flight: pick a healthy version/account so the daemon does not launch
   // into a credit-exhausted install. Detached cannot mid-run failover (no exit

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -24,6 +24,7 @@ import {
   parseTimeout,
   writeRunMeta,
   getRunDir,
+  jobRunsOnThisDevice,
 } from './routines.js';
 import { getRunsDir } from './state.js';
 import type { AgentId } from './types.js';
@@ -461,6 +462,10 @@ function spawnJobAttempt(
  * failover across healthy same-agent accounts (RUSH-1016).
  */
 export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<RunResult> {
+  if (!jobRunsOnThisDevice(config)) {
+    const allowed = (config.devices ?? []).join(', ');
+    throw new Error(`Job '${config.name}' can only run on: ${allowed}`);
+  }
   maybeRotate();
 
   const launch = await resolveRoutineLaunch(config);
@@ -651,6 +656,11 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
 
 /** Spawn a job as a detached process and return immediately with run metadata. */
 export async function executeJobDetached(config: JobConfig): Promise<RunMeta> {
+  if (!jobRunsOnThisDevice(config)) {
+    const allowed = (config.devices ?? []).join(', ');
+    process.stderr.write(`[agents] daemon: skipping '${config.name}' — can only run on: ${allowed}\n`);
+    throw new Error(`Job '${config.name}' can only run on: ${allowed}`);
+  }
   // Pre-flight: pick a healthy version/account so the daemon does not launch
   // into a credit-exhausted install. Detached cannot mid-run failover (no exit
   // wait); the next schedule tick re-selects if this attempt still fails.

--- a/apps/cli/src/lib/triggers/webhook.test.ts
+++ b/apps/cli/src/lib/triggers/webhook.test.ts
@@ -104,21 +104,26 @@ describe('matchJobsToWebhook', () => {
     expect(matchJobsToWebhook([disabled], pullRequestWebhook('x/y'))).toEqual([]);
   });
 
-  it('skips jobs pinned to another device, keeps jobs pinned here', () => {
+  it('skips jobs pinned to other devices, keeps jobs pinned here', () => {
     const saved = process.env.AGENTS_SYNC_MACHINE_ID;
     process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
     try {
       const foreign = job({
         name: 'foreign',
-        device: 'yosemite-s0',
+        devices: ['yosemite-s0'],
         trigger: { type: 'github_event', event: 'pull_request', repo: 'x/y' },
       });
       const local = job({
         name: 'local',
-        device: 'zion',
+        devices: ['zion'],
         trigger: { type: 'github_event', event: 'pull_request', repo: 'x/y' },
       });
-      expect(matchJobsToWebhook([foreign, local], pullRequestWebhook('x/y')).map((j) => j.name)).toEqual(['local']);
+      const multi = job({
+        name: 'multi',
+        devices: ['mac-mini', 'zion'],
+        trigger: { type: 'github_event', event: 'pull_request', repo: 'x/y' },
+      });
+      expect(matchJobsToWebhook([foreign, local, multi], pullRequestWebhook('x/y')).map((j) => j.name)).toEqual(['local', 'multi']);
     } finally {
       if (saved === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
       else process.env.AGENTS_SYNC_MACHINE_ID = saved;


### PR DESCRIPTION
## Summary

- Add remote routing to every direct `agents routines` subcommand with `--host`; `--device` is the singular routing alias.
- Add persistent plural `devices:` allowlists, interactive `routines devices` management, strict fleet validation, and v12 migration from legacy `device:`.
- Gate cron, manual, detached, webhook, overdue/catchup, and one-shot execution on the current device.
- Show a Devices column with `all` for unrestricted routines; JSON exposes `devices` and `runsHere`.
- Persist routine mutations through the existing atomic writer.

## User-visible contract

```text
agents routines list --host yosemite-s0
agents routines add nightly --devices yosemite-s0,mac-mini ...
agents routines devices nightly
agents routines devices nightly --set yosemite-s0,mac-mini
agents routines devices nightly --clear
```

An ineligible manual run exits nonzero and prints the allowed devices plus a ready-to-paste routed command:

```text
Job <name> can only run on: yosemite-s0, mac-mini
  agents routines run <name> --host yosemite-s0
```

## Verification

- `npx tsc --noEmit`: passed.
- `npm run build`: passed.
- Focused device-affinity gate: 7 test files, 103 tests passed.
- The add-path test starts the real `agents daemon _run` process under an isolated HOME, then terminates it and proves the PID is dead.
- Every direct routines subcommand is derived from parent help and checked for exactly one local `--host` and `--device` option row.
- `git diff --check origin/main...HEAD`: passed.
- No test daemon remained after the gate.

Session transcript for this public repository is kept local:
`yosemite-s0:/home/muqsit/.kimi-code/sessions/wd_routine-affinity-code-v3_39ba6927a90f/`