### PR TITLE
fix(cli): supervise daemon via physical Bun executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## 1.20.56
+
+### Fixed
+
+- **Installed native CLIs supervise daemons through their physical executable.**
+  Bun standalone binaries expose an embedded `/$bunfs/root/agents` entry at
+  `process.argv[1]` and report that virtual entry as existing. Daemon service
+  manifests now resolve that case through the signed on-disk `process.execPath`,
+  so `agents routines start` works from the published macOS and Linux binaries
+  while the virtual-path safety guard remains enforced.
+
 ## 1.20.55
 
 ### Added

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.20.56
+
+- **Fix native routine schedulers rejecting the published CLI as a Bun virtual path.** Bun's standalone runtime reports the embedded `/$bunfs/root/agents` entry as existing at `process.argv[1]`, while the real signed executable lives at `process.execPath`. Daemon resolution now substitutes that physical executable before generating launchd/systemd manifests or detached launches; the existing virtual-path guard still rejects any virtual path that reaches supervision. Source: `apps/cli/src/lib/daemon.ts`.
+
 ## 1.20.55
 
 - **Routine scheduler health is now observable and self-healing.** `agents routines status` distinguishes `running`, `wedged`, and `stopped`, and reports the daemon binary plus heartbeat age. Routine listing/status opportunistically finalize orphaned runs; PID reuse checks and a 24-hour wall-clock limit prevent stale `running` records; daemon startup rejects bun virtual paths and warns about worktree binaries that can disappear. Source: `apps/cli/src/lib/daemon.ts`, `apps/cli/src/lib/runner.ts`, `apps/cli/src/commands/routines.ts`.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phnx-labs/agents-cli",
-  "version": "1.20.55",
+  "version": "1.20.56",
   "description": "One CLI for all your AI coding agents - versions, config, cloud dispatch, sessions, and teams (now with first-class Grok Build CLI support)",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/cli/src/lib/daemon.test.ts
+++ b/apps/cli/src/lib/daemon.test.ts
@@ -308,6 +308,21 @@ describe('getAgentsBinPath (sibling shim resolution)', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it('resolves a Bun standalone virtual entry to its physical executable', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agd-bun-standalone-'));
+    const physicalBin = path.join(tmpDir, process.platform === 'win32' ? 'agents.exe' : 'agents');
+    fs.writeFileSync(physicalBin, '');
+    expect(getAgentsBinPath('/$bunfs/root/agents', physicalBin)).toBe(physicalBin);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('refuses a Bun standalone virtual entry without a physical executable', () => {
+    const missingBin = path.join(os.tmpdir(), `agents-missing-${process.pid}`);
+    expect(() => getAgentsBinPath('/$bunfs/root/agents', missingBin)).toThrow(
+      `Bun standalone executable not found at ${missingBin}`,
+    );
+  });
+
   it('refuses a sibling shim when its main entry is missing', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agd-shim-'));
     const browserJs = path.join(tmpDir, 'browser.js');

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -704,13 +704,27 @@ Environment=PATH=/usr/local/bin:/usr/bin:/bin:${os.homedir()}/.nvm/versions/node
 WantedBy=default.target`;
 }
 
-export function getAgentsBinPath(): string {
+const BUN_VIRTUAL_ROOT = /[/\\]\$bunfs[/\\]root[/\\]/;
+
+export function getAgentsBinPath(
+  argv1: string | undefined = process.argv[1],
+  execPath: string = process.execPath,
+): string {
   // Prefer the binary actively executing this code. `which agents` returns
   // whatever happens to be first on PATH, which means a side-by-side dev
   // build at ~/.local/bin would silently spawn the registry-installed
-  // daemon and run stale code. process.argv[1] is the absolute path of
-  // the JS entrypoint the user actually invoked.
-  const argv1 = process.argv[1];
+  // daemon and run stale code. For a JS install, process.argv[1] is the
+  // absolute entrypoint the user actually invoked. A Bun standalone instead
+  // exposes its embedded /$bunfs/root entry at argv[1] and its physical signed
+  // executable at process.execPath; Bun reports both as existing paths.
+  if (argv1 && BUN_VIRTUAL_ROOT.test(argv1)) {
+    if (!execPath || BUN_VIRTUAL_ROOT.test(execPath) || !fs.existsSync(execPath)) {
+      throw new Error(
+        `Cannot start agents daemon: Bun standalone executable not found at ${execPath || '(empty path)'}`,
+      );
+    }
+    return execPath;
+  }
   if (argv1 && fs.existsSync(argv1)) {
     // The package's browser/computer entrypoints are sibling shims without a
     // `daemon` command. A daemon started as their IPC side effect must launch
@@ -906,7 +920,7 @@ export function getDaemonLaunch(agentsBin: string = getAgentsBinPath()): { comma
 
 export function validateDaemonBinary(binPath: string): { warnings: string[] } {
   const warnings: string[] = [];
-  if (/\/\$bunfs\/root\//.test(binPath)) {
+  if (BUN_VIRTUAL_ROOT.test(binPath)) {
     throw new Error(
       `Refusing to supervise daemon: resolved binary is a bun virtual path (${binPath}). ` +
       `Install agents globally (npm i -g @phnx-labs/agents-cli) and restart.`,


### PR DESCRIPTION
## Outcome

Published standalone binaries now supervise the routine daemon through the physical signed executable instead of Bun's embedded `/$bunfs/root/agents` entry. This is the 1.20.56 follow-up to the installed-artifact regression found while verifying 1.20.55.

## Root cause

Bun sets `process.argv[1]` to its embedded virtual entry and reports that path as existing. `getAgentsBinPath()` therefore returned it before daemon validation rejected it. The resolver now substitutes `process.execPath` only for Bun virtual entries, verifies that physical path exists, and retains the virtual-path rejection as defense in depth.

## Evidence

- TypeScript build: passed.
- Focused daemon suites: 47/47 passed.
- Compiled standalone: `agents --version` reported `1.20.56`.
- Real standalone lifecycle: start returned PID 56401; status reported `running`, physical `dist/bin/agents`, and a 3-second heartbeat; stop returned `stopped`.
- Monolithic local suite: 5,083 passed, 76 skipped, with eight unrelated host-state failures (inherited session/model environment and serve-server timeouts); GitHub's clean shard matrix is the merge gate.

## Release notes

Both repository changelogs are updated and the npm package version is bumped to 1.20.56.