### PR TITLE
secrets(list): clarify POLICY column labels

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## Unreleased
 
+- **Clarified `agents secrets list` POLICY column labels.** The column previously mixed policy names, runtime state, and implementation jargon (`daily · 7d left`, `always ask`, `never · NO ACL`). It now uses a consistent `policy · state` form: `daily`, `daily · held 7d`, `always · prompt`, and `never · no prompt`. Source: `apps/cli/src/commands/secrets.ts` (`renderPolicyCol`).
+
 ## 1.20.56
 
 - **Fix native routine schedulers rejecting the published CLI as a Bun virtual path.** Bun's standalone runtime reports the embedded `/$bunfs/root/agents` entry as existing at `process.argv[1]`, while the real physical executable lives at `process.execPath`. Daemon resolution now substitutes that physical executable before generating launchd/systemd manifests or detached launches; the existing virtual-path guard still rejects any virtual path that reaches supervision. Source: `apps/cli/src/lib/daemon.ts`.
-
 - **Fix: `agents teams`, `agents message`, and `agents profiles check` work again on the signed standalone binary (regression from #315).** When `agents` resolves to the bun-compiled Mach-O (shipped since 1.20.53), three self-spawn sites relaunched the CLI as `[process.execPath, process.argv[1], …]` — but under a bun standalone executable `process.argv[1]` is the virtual entry `/$bunfs/root/agents`, so the child died with `unknown command '/$bunfs/root/agents'` (or `/bin/sh: /$bunfs/root/agents: No such file or directory`). Every teammate spawned by a compiled-binary install failed in 0s. New shared `getAgentsInvocation(subArgs)` (`apps/cli/src/lib/daemon.ts`) resolves the real on-disk binary — mapping the `/$bunfs/root/…` virtual path to `process.execPath`, running a `.js` entry under node, and a native binary directly — and `teams/agents.ts`, `commands/message.ts`, and `commands/profiles.ts` route through it. Verified end-to-end: a teammate spawned by the freshly-compiled binary runs to `completed` with no `$bunfs` error. Source: `apps/cli/src/lib/daemon.ts` (`getAgentsInvocation`), `apps/cli/src/lib/teams/agents.ts`, `apps/cli/src/commands/{message,profiles}.ts`.
 ## 1.20.55
 

--- a/apps/cli/src/commands/secrets.test.ts
+++ b/apps/cli/src/commands/secrets.test.ts
@@ -116,7 +116,7 @@ describe('renderPolicyCol', () => {
   it('marks a never bundle distinctly and loudly', () => {
     const never = renderPolicyCol(bundle('never'));
     expect(never).toMatch(/never/);
-    expect(never).toMatch(/NO ACL/i);
+    expect(never).toMatch(/no prompt/i);
     // Distinct from the other tiers — the marking is not shared.
     expect(never).not.toBe(renderPolicyCol(bundle('always')));
     expect(never).not.toBe(renderPolicyCol(bundle('daily')));

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -467,15 +467,16 @@ function compactRemaining(expiresAt: number): string {
   return `${Math.round(hours / 24)}d`;
 }
 
-/** The POLICY column for `secrets list`: the prompt policy, plus a "Nh left"
- * hint when a `daily` bundle is currently held by the secrets-agent. `held`
+/** The POLICY column for `secrets list`: the prompt policy, plus a concise
+ * state hint. `daily` shows `held Nh` when the secrets-agent is currently
+ * caching the bundle; `always` and `never` show whether they prompt. `held`
  * maps bundle name → expiry epoch-ms (from agentStatus()). */
 export function renderPolicyCol(b: SecretsBundle, held?: Map<string, number>): string {
   // `never` is loud on purpose — it's the only tier with no user-presence gate.
-  if (bundlePolicy(b) === 'never') return chalk.red.bold('never · NO ACL');
-  if (bundlePolicy(b) === 'always') return chalk.yellow('always ask');
+  if (bundlePolicy(b) === 'never') return chalk.red.bold('never · no prompt');
+  if (bundlePolicy(b) === 'always') return chalk.yellow('always · prompt');
   const exp = held?.get(b.name);
-  return exp ? chalk.green(`daily · ${compactRemaining(exp)} left`) : chalk.gray('daily');
+  return exp ? chalk.green(`daily · held ${compactRemaining(exp)}`) : chalk.gray('daily');
 }
 
 /** Below this width the fixed date columns no longer fit; `list` uses cards. */
@@ -739,7 +740,7 @@ export function registerSecretsCommands(program: Command): void {
         return;
       }
       // Cross-reference the secrets-agent so `daily` bundles that are currently
-      // held can show "· Nh left". Soft-fails to no hint if the broker is down.
+      // held can show "· held Nh". Soft-fails to no hint if the broker is down.
       const held = new Map<string, number>();
       if (process.platform === 'darwin') {
         try {


### PR DESCRIPTION
Cleans up the mixed policy/state/jargon labels in `agents secrets list` so every POLICY cell follows the same `policy · state` pattern.

| Before | After |
|---|---|
| `daily` | `daily` |
| `daily · 7d left` | `daily · held 7d` |
| `always ask` | `always · prompt` |
| `never · NO ACL` | `never · no prompt` |

- "held" matches the help text and `agents secrets status` vocabulary.
- "prompt" / "no prompt" describe the user-visible behavior instead of the internal ACL detail.
- The `renderPolicyCol` test is updated and the change is logged under Unreleased.

Verified: `bun run test src/commands/secrets.test.ts` passes (33/33). The full `bun run test` run shows 8 unrelated pre-existing failures in `exec.test.ts`, `models.test.ts`, and `server.test.ts`; none touch secrets rendering.