### PR TITLE
fix(cli): pin postinstall daemon restart to installed entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## 1.20.57
+
+### Fixed
+
+- **Global npm upgrades restart the scheduler through the installed CLI.** The
+  macOS postinstall self-heal now passes the resolved signed CLI path into daemon
+  startup explicitly. This prevents launchd from recording
+  `scripts/postinstall.js daemon _run`, which exited immediately and left the
+  routine scheduler in a restart loop after an upgrade.
+
+- **Secret policy labels use one `policy · state` vocabulary.**
+  `agents secrets list` now reports `daily`, `daily · held 7d`,
+  `always · prompt`, and `never · no prompt` instead of mixing policy names,
+  runtime state, and implementation terminology.
+
 ## 1.20.56
 
 ### Fixed

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.20.57
+
+- **Fix global npm upgrades restarting the routines daemon through `scripts/postinstall.js`.** The postinstall process is itself `process.argv[1]`, so its daemon self-heal could stamp `node scripts/postinstall.js daemon _run` into launchd; the lifecycle script then printed the local-install message and exited on every restart. Daemon startup now accepts an explicit CLI entry and postinstall passes the resolved signed native binary (or JavaScript entrypoint), with the same value threaded through launchd, systemd, and detached startup. Source: `apps/cli/scripts/postinstall.js`, `apps/cli/src/lib/daemon.ts`.
+
 - **Clarified `agents secrets list` POLICY column labels.** The column previously mixed policy names, runtime state, and implementation jargon (`daily · 7d left`, `always ask`, `never · NO ACL`). It now uses a consistent `policy · state` form: `daily`, `daily · held 7d`, `always · prompt`, and `never · no prompt`. Source: `apps/cli/src/commands/secrets.ts` (`renderPolicyCol`).
 
 ## 1.20.56

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phnx-labs/agents-cli",
-  "version": "1.20.56",
+  "version": "1.20.57",
   "description": "One CLI for all your AI coding agents - versions, config, cloud dispatch, sessions, and teams (now with first-class Grok Build CLI support)",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/cli/scripts/postinstall.js
+++ b/apps/cli/scripts/postinstall.js
@@ -392,7 +392,10 @@ async function healLongRunningProcesses() {
     const d = await import('../dist/lib/daemon.js');
     if (d.isDaemonRunning?.()) {
       d.stopDaemon?.();
-      d.startDaemon?.();
+      // This lifecycle script is process.argv[1] while npm is installing. Pin
+      // the restart to the installed CLI entrypoint so the service manifest
+      // never records scripts/postinstall.js as the daemon command.
+      d.startDaemon?.(AGENTS_BIN);
       console.log('  Restarted the routines daemon onto this version.');
     }
   } catch { /* best effort */ }

--- a/apps/cli/src/lib/daemon.test.ts
+++ b/apps/cli/src/lib/daemon.test.ts
@@ -216,6 +216,32 @@ describe('generateSystemdUnit', () => {
   });
 });
 
+describe('service manifest CLI entry injection', () => {
+  it('uses the explicitly installed CLI entry instead of the lifecycle script entry', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-daemon-postinstall-'));
+    const installedEntry = path.join(tmpDir, 'dist', 'index.js');
+    const postinstallEntry = path.join(tmpDir, 'scripts', 'postinstall.js');
+    fs.mkdirSync(path.dirname(installedEntry), { recursive: true });
+    fs.mkdirSync(path.dirname(postinstallEntry), { recursive: true });
+    fs.writeFileSync(installedEntry, '');
+    fs.writeFileSync(postinstallEntry, '');
+
+    const savedArgv1 = process.argv[1];
+    process.argv[1] = postinstallEntry;
+    try {
+      const plist = generateLaunchdPlist(null, installedEntry);
+      const unit = generateSystemdUnit(null, installedEntry);
+      expect(plist).toContain(`<string>${installedEntry}</string>`);
+      expect(unit).toContain(installedEntry);
+      expect(plist).not.toContain(postinstallEntry);
+      expect(unit).not.toContain(postinstallEntry);
+    } finally {
+      process.argv[1] = savedArgv1;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('buildDetachedDaemonEnv', () => {
   it('injects the token when configured and absent from the base env', () => {
     seedKeychainBacked('sk-ant-oat01-detached');

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -638,8 +638,10 @@ export function writeOwnerOnlyServiceManifest(filePath: string, content: string)
 }
 
 /** Generate a macOS launchd plist for auto-starting the daemon. */
-export function generateLaunchdPlist(oauthToken: string | null = readDaemonClaudeOAuthToken()): string {
-  const agentsBin = getAgentsBinPath();
+export function generateLaunchdPlist(
+  oauthToken: string | null = readDaemonClaudeOAuthToken(),
+  agentsBin: string = getAgentsBinPath(),
+): string {
   const launch = getDaemonLaunch(agentsBin);
   const logPath = getLogPath();
   const oauthEntry = oauthToken
@@ -681,8 +683,10 @@ function systemdExecArg(value: string): string {
 }
 
 /** Generate a Linux systemd user unit for auto-starting the daemon. */
-export function generateSystemdUnit(oauthToken: string | null = readDaemonClaudeOAuthToken()): string {
-  const agentsBin = getAgentsBinPath();
+export function generateSystemdUnit(
+  oauthToken: string | null = readDaemonClaudeOAuthToken(),
+  agentsBin: string = getAgentsBinPath(),
+): string {
   const launch = getDaemonLaunch(agentsBin);
   const execStart = [launch.command, ...launch.args].map(systemdExecArg).join(' ');
   const oauthLine = oauthToken
@@ -779,7 +783,7 @@ function readServiceManagerPid(platform: NodeJS.Platform = os.platform()): numbe
 }
 
 /** Start the daemon via launchd, systemd, or as a detached process. */
-export function startDaemon(): { pid: number | null; method: string } {
+export function startDaemon(agentsBin?: string): { pid: number | null; method: string } {
   if (isDaemonRunning()) {
     const pid = readDaemonPid();
     return { pid, method: 'already-running' };
@@ -793,7 +797,7 @@ export function startDaemon(): { pid: number | null; method: string } {
   }
 
   try {
-    return startDaemonLocked();
+    return startDaemonLocked(agentsBin ?? getAgentsBinPath());
   } finally {
     releaseLock();
   }
@@ -817,7 +821,7 @@ export function ensureDaemonStarted(): { pid: number | null; method: string } | 
   }
 }
 
-function startDaemonLocked(): { pid: number | null; method: string } {
+function startDaemonLocked(agentsBin: string): { pid: number | null; method: string } {
   const platform = os.platform();
 
   if (platform === 'darwin') {
@@ -829,7 +833,7 @@ function startDaemonLocked(): { pid: number | null; method: string } {
       }
       // The plist may embed a long-lived OAuth token in EnvironmentVariables;
       // create owner-only atomically (no world-readable window before chmod).
-      writeOwnerOnlyServiceManifest(plistPath, generateLaunchdPlist());
+      writeOwnerOnlyServiceManifest(plistPath, generateLaunchdPlist(undefined, agentsBin));
 
       try {
         execFileSync('launchctl', ['unload', plistPath], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
@@ -845,7 +849,7 @@ function startDaemonLocked(): { pid: number | null; method: string } {
     } catch {
       // load threw — fall through to detached spawn
     }
-    return startDetached();
+    return startDetached({ agentsBin });
   }
 
   if (platform === 'linux') {
@@ -856,7 +860,7 @@ function startDaemonLocked(): { pid: number | null; method: string } {
         fs.mkdirSync(unitDir, { recursive: true });
       }
       // May embed a long-lived OAuth token in an Environment= line; owner-only.
-      writeOwnerOnlyServiceManifest(unitPath, generateSystemdUnit());
+      writeOwnerOnlyServiceManifest(unitPath, generateSystemdUnit(undefined, agentsBin));
 
       execFileSync('systemctl', ['--user', 'daemon-reload'], { encoding: 'utf-8' });
       execFileSync('systemctl', ['--user', 'enable', SYSTEMD_UNIT], { encoding: 'utf-8' });
@@ -869,10 +873,10 @@ function startDaemonLocked(): { pid: number | null; method: string } {
     } catch {
       // start threw — fall through to detached spawn
     }
-    return startDetached();
+    return startDetached({ agentsBin });
   }
 
-  return startDetached();
+  return startDetached({ agentsBin });
 }
 
 /**


### PR DESCRIPTION
## Outcome

Global npm upgrades now restart the routines daemon through the resolved installed CLI entry instead of inheriting the postinstall lifecycle script path. The explicit entry is threaded through launchd, systemd, and detached startup.

## Release

- bumps @phnx-labs/agents-cli to 1.20.57
- updates the root and CLI changelogs
- includes the already-unreleased secrets POLICY label clarification from main

## Verification

- build/typecheck: passed during bun install
- focused daemon + postinstall tests: 40 passed, 1 skipped
- clean rerun of every environment-sensitive full-suite failure: 253 passed
- full local suite: 5,142 passed; eight harness-contaminated failures all passed in the isolated rerun
- mac-mini scheduler restored and inspected: launchd ProgramArguments point to /opt/homebrew/bin/agents daemon _run

## Confidential session reference

Public repository: transcript omitted. Local fleet path: zion:/Users/muqsit/.codex/sessions/2026/07/13/rollout-2026-07-13T06-02-36-019f5b92-844c-7e52-8eec-ead695e94b9b.jsonl