### PR TITLE
fix: preserve stopped teammate after failed resume launch

### DIFF
--- a/apps/cli/src/lib/hosts/dispatch.test.ts
+++ b/apps/cli/src/lib/hosts/dispatch.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { buildRunForwardedArgs, buildInteractiveRunForwardedArgs } from './dispatch.js';
+import { randomUUID } from 'crypto';
+import { sshExec } from '../ssh-exec.js';
+import {
+  buildRunForwardedArgs,
+  buildInteractiveRunForwardedArgs,
+  terminateDispatchedTask,
+} from './dispatch.js';
+import type { HostTask } from './tasks.js';
 
 describe('buildRunForwardedArgs', () => {
   it('forwards --session-id for a fresh run so the remote session gets our id', () => {
@@ -89,5 +96,53 @@ describe('buildInteractiveRunForwardedArgs', () => {
   it('drops the prompt when interactive mode is not forced', () => {
     const args = buildInteractiveRunForwardedArgs({ agent: 'claude', prompt: 'do a thing' });
     expect(args).toEqual(['run', 'claude']);
+  });
+});
+
+const remoteTarget = process.env.AGENTS_TEST_REMOTE_TARGET;
+
+describe.skipIf(!remoteTarget)('terminateDispatchedTask — real remote process', () => {
+  it('terminates a launched remote process before returning', () => {
+    const id = randomUUID().slice(0, 8);
+    const marker = `agents-dispatch-rollback-${id}`;
+    const remoteLog = `/tmp/${marker}.log`;
+    const remoteExit = `/tmp/${marker}.exit`;
+    const launch = sshExec(
+      remoteTarget!,
+      `nohup bash -lc 'exec -a ${marker} sleep 30' >${remoteLog} 2>&1 & echo $!`,
+      { timeoutMs: 10000, multiplex: true },
+    );
+    expect(launch.code).toBe(0);
+    const pid = Number.parseInt(launch.stdout.trim().split('\n').pop() ?? '', 10);
+    expect(Number.isFinite(pid)).toBe(true);
+
+    const task: HostTask = {
+      id,
+      host: remoteTarget!,
+      target: remoteTarget!,
+      agent: 'test',
+      prompt: marker,
+      pid,
+      remoteLog,
+      remoteExit,
+      status: 'running',
+      createdAt: new Date().toISOString(),
+    };
+
+    try {
+      terminateDispatchedTask(task);
+      const probe = sshExec(
+        remoteTarget!,
+        `kill -0 ${pid} 2>/dev/null && echo ALIVE || echo DEAD`,
+        { timeoutMs: 10000, multiplex: true },
+      );
+      expect(probe.stdout.trim()).toBe('DEAD');
+    } finally {
+      sshExec(
+        remoteTarget!,
+        `kill -KILL ${pid} 2>/dev/null || true; rm -f ${remoteLog} ${remoteExit}`,
+        { timeoutMs: 10000, multiplex: true },
+      );
+    }
   });
 });

--- a/apps/cli/src/lib/hosts/dispatch.ts
+++ b/apps/cli/src/lib/hosts/dispatch.ts
@@ -30,6 +30,29 @@ export interface DispatchResult {
   exitCode?: number;
 }
 
+function terminateRemoteLaunch(task: HostTask): void {
+  if (!task.pid) throw new Error(`Cannot terminate remote task ${task.id}: launch returned no PID.`);
+  const pid = task.pid;
+  const command =
+    `kill -TERM -- -${pid} 2>/dev/null || kill -TERM ${pid} 2>/dev/null; ` +
+    `sleep 1; ` +
+    `kill -KILL -- -${pid} 2>/dev/null || kill -KILL ${pid} 2>/dev/null || true; ` +
+    `rm -f ${task.remoteLog} ${task.remoteExit}`;
+  const result = sshExec(task.target, command, { timeoutMs: 10000, multiplex: true });
+  if (result.code !== 0) {
+    throw new Error(
+      `Failed to terminate remote task ${task.id} on ${task.host}: ` +
+      `${(result.stderr || result.stdout).trim() || 'ssh error'}`,
+    );
+  }
+}
+
+/** Terminate a detached dispatch that its caller could not persist locally. */
+export function terminateDispatchedTask(task: HostTask): void {
+  terminateRemoteLaunch(task);
+  updateTask(task.id, terminalPatch(143));
+}
+
 /** Options shared by every detached dispatch. */
 interface LaunchOptions {
   /** `agents …` args (command name first), each already un-quoted (we quote them). */
@@ -100,7 +123,19 @@ async function launchDetached(host: Host, target: string, opts: LaunchOptions): 
     status: 'running',
     createdAt: new Date().toISOString(),
   };
-  saveTask(task);
+  try {
+    saveTask(task);
+  } catch (err) {
+    try {
+      terminateRemoteLaunch(task);
+    } catch (cleanupErr) {
+      throw new Error(
+        `Failed to persist remote task ${task.id}; cleanup also failed: ${(cleanupErr as Error).message}`,
+        { cause: err },
+      );
+    }
+    throw err;
+  }
 
   if (opts.follow === false) {
     return { task };

--- a/apps/cli/src/lib/teams/agents.resume.test.ts
+++ b/apps/cli/src/lib/teams/agents.resume.test.ts
@@ -161,6 +161,45 @@ describe('resumeTeammate — resume-id guard', () => {
   });
 });
 
+describe.skipIf(IS_WINDOWS)('resumeTeammate — launch failure', () => {
+  it('preserves the stopped teammate metadata and files when relaunch fails', async () => {
+    const base = tmpBase();
+    const id = 'claude-agent-relaunch-failure';
+    const dir = path.join(base, id);
+    const completedAt = new Date('2026-07-13T12:34:56.000Z');
+    fs.mkdirSync(dir, { recursive: true });
+
+    const agent = new AgentProcess(
+      id, 'failure-team', 'claude', 'do a thing',
+      null, 'edit', null, AgentStatus.COMPLETED, new Date(), completedAt, base,
+    );
+    await agent.saveMeta();
+    fs.writeFileSync(path.join(dir, 'prior-turn.log'), 'preserve me');
+    const stdoutPath = path.join(dir, 'stdout.log');
+    fs.writeFileSync(stdoutPath, 'prior stdout');
+    // A read-only stdout mirror produces a real EACCES failure when the local
+    // launcher opens the resume log for writing. AgentManager.get() can still
+    // load and reconcile the stopped teammate before launch reaches that point.
+    fs.chmodSync(stdoutPath, 0o400);
+
+    const mgr = new AgentManager(50, base);
+    try {
+      await expect(mgr.resumeTeammate(id, 'keep going')).rejects.toThrow(/Failed to spawn agent/);
+
+      expect((mgr as any).agents.has(id)).toBe(true);
+      expect(fs.readFileSync(path.join(dir, 'prior-turn.log'), 'utf-8')).toBe('preserve me');
+      expect(fs.readFileSync(stdoutPath, 'utf-8')).toBe('prior stdout');
+      const restored = await AgentProcess.loadFromDisk(id, base);
+      expect(restored).not.toBeNull();
+      expect(restored!.status).toBe(AgentStatus.COMPLETED);
+      expect(restored!.completedAt?.toISOString()).toBe(completedAt.toISOString());
+    } finally {
+      if (fs.existsSync(stdoutPath)) fs.chmodSync(stdoutPath, 0o600);
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
 /**
  * The resume hazard: the status reader re-reads the whole stdout.log from byte 0
  * every poll and marks terminal status from the last `result` event it sees, with

--- a/apps/cli/src/lib/teams/agents.resume.test.ts
+++ b/apps/cli/src/lib/teams/agents.resume.test.ts
@@ -8,7 +8,7 @@
  * builders; resumeTeammate drives a real AgentProcess loaded from disk.
  */
 import { describe, it, expect } from 'vitest';
-import { spawn, type ChildProcess } from 'child_process';
+import { execFileSync, spawn, type ChildProcess } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -162,39 +162,52 @@ describe('resumeTeammate — resume-id guard', () => {
 });
 
 describe.skipIf(IS_WINDOWS)('resumeTeammate — launch failure', () => {
-  it('preserves the stopped teammate metadata and files when relaunch fails', async () => {
+  it('terminates the replacement and restores all prior state when persistence fails after spawn', async () => {
     const base = tmpBase();
     const id = 'claude-agent-relaunch-failure';
     const dir = path.join(base, id);
+    const marker = `resume-transaction-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const startedAt = new Date('2026-07-13T12:00:00.000Z');
     const completedAt = new Date('2026-07-13T12:34:56.000Z');
     fs.mkdirSync(dir, { recursive: true });
 
     const agent = new AgentProcess(
       id, 'failure-team', 'claude', 'do a thing',
-      null, 'edit', null, AgentStatus.COMPLETED, new Date(), completedAt, base,
+      null, 'edit', null, AgentStatus.COMPLETED, startedAt, completedAt, base,
     );
     await agent.saveMeta();
     fs.writeFileSync(path.join(dir, 'prior-turn.log'), 'preserve me');
     const stdoutPath = path.join(dir, 'stdout.log');
     fs.writeFileSync(stdoutPath, 'prior stdout');
-    // A read-only stdout mirror produces a real EACCES failure when the local
-    // launcher opens the resume log for writing. AgentManager.get() can still
-    // load and reconcile the stopped teammate before launch reaches that point.
-    fs.chmodSync(stdoutPath, 0o400);
+    const metaPath = path.join(dir, 'meta.json');
+    const metaTarget = path.join(dir, 'meta-original.json');
+    fs.renameSync(metaPath, metaTarget);
+    fs.chmodSync(metaTarget, 0o400);
+    fs.symlinkSync(path.basename(metaTarget), metaPath);
 
     const mgr = new AgentManager(50, base);
     try {
-      await expect(mgr.resumeTeammate(id, 'keep going')).rejects.toThrow(/Failed to spawn agent/);
+      // The real local launcher reaches spawn, then saveMeta follows the
+      // read-only symlink and fails. The transactional catch must terminate the
+      // detached process before resumeTeammate restores the original lifecycle.
+      await expect(mgr.resumeTeammate(id, marker)).rejects.toThrow();
 
-      expect((mgr as any).agents.has(id)).toBe(true);
+      const retained = (mgr as any).agents.get(id) as AgentProcess | undefined;
+      expect(retained).toBeDefined();
+      expect(retained!.status).toBe(AgentStatus.COMPLETED);
+      expect(retained!.completedAt?.toISOString()).toBe(completedAt.toISOString());
+      expect(retained!.startedAt.toISOString()).toBe(startedAt.toISOString());
+      expect(retained!.pid).toBeNull();
+      expect(retained!.startTime).toBeNull();
       expect(fs.readFileSync(path.join(dir, 'prior-turn.log'), 'utf-8')).toBe('preserve me');
       expect(fs.readFileSync(stdoutPath, 'utf-8')).toBe('prior stdout');
       const restored = await AgentProcess.loadFromDisk(id, base);
       expect(restored).not.toBeNull();
       expect(restored!.status).toBe(AgentStatus.COMPLETED);
       expect(restored!.completedAt?.toISOString()).toBe(completedAt.toISOString());
+      expect(() => execFileSync('pgrep', ['-f', marker], { stdio: 'ignore' })).toThrow();
     } finally {
-      if (fs.existsSync(stdoutPath)) fs.chmodSync(stdoutPath, 0o600);
+      if (fs.existsSync(metaTarget)) fs.chmodSync(metaTarget, 0o600);
       fs.rmSync(base, { recursive: true, force: true });
     }
   });

--- a/apps/cli/src/lib/teams/agents.ts
+++ b/apps/cli/src/lib/teams/agents.ts
@@ -1679,16 +1679,27 @@ export class AgentManager {
     }
 
     const resume = { id: agent.remoteSessionId ?? agent.agentId, message };
+    const priorStatus = agent.status;
+    const priorCompletedAt = agent.completedAt;
     // Flip to RUNNING up front so a concurrent status poll can't reap the
     // teammate between the exit-sentinel clear and the new PID landing; the
-    // launch re-persists with the fresh pid/startTime.
+    // launch re-persists with the fresh pid/startTime. If relaunch fails before
+    // that happens, restore the stopped lifecycle state and keep its existing
+    // metadata/log directory intact so the user can retry.
     agent.status = AgentStatus.RUNNING;
     agent.completedAt = null;
 
-    if (agent.hostName) {
-      await this.launchRemoteProcess(agent, resume);
-    } else {
-      await this.launchProcess(agent, resume);
+    try {
+      if (agent.hostName) {
+        await this.launchRemoteProcess(agent, resume);
+      } else {
+        await this.launchProcess(agent, resume);
+      }
+    } catch (err) {
+      agent.status = priorStatus;
+      agent.completedAt = priorCompletedAt;
+      await agent.saveMeta();
+      throw err;
     }
     return agent;
   }
@@ -1771,7 +1782,10 @@ export class AgentManager {
       agent.startedAt = new Date();
       await agent.saveMeta();
     } catch (err: any) {
-      await this.cleanupPartialAgent(agent);
+      // Fresh spawns own a newly-created directory, so a failed launch removes
+      // that partial record. A resume reuses an existing teammate: its caller
+      // restores the prior terminal state and preserves the directory for retry.
+      if (!resume) await this.cleanupPartialAgent(agent);
       console.error(`Failed to spawn agent ${agent.agentId}:`, err);
       throw new Error(`Failed to spawn agent: ${err.message}`);
     }

--- a/apps/cli/src/lib/teams/agents.ts
+++ b/apps/cli/src/lib/teams/agents.ts
@@ -28,7 +28,7 @@ import { recordRunName } from '../session/run-names.js';
 import { sshExec, shellQuote } from '../ssh-exec.js';
 import { resolveHost } from '../hosts/registry.js';
 import { sshTargetFor } from '../hosts/types.js';
-import { dispatchAgentsCommand } from '../hosts/dispatch.js';
+import { dispatchAgentsCommand, terminateDispatchedTask } from '../hosts/dispatch.js';
 import { ensureHostReady } from '../hosts/ready.js';
 import { remoteShellFor } from '../hosts/remote-cmd.js';
 import { resolveRemoteOsSync } from '../hosts/remote-os.js';
@@ -1288,6 +1288,65 @@ export class AgentProcess {
  */
 export type CloudDispatchFn = (agent: AgentProcess) => Promise<{ cloudSessionId: string }>;
 
+interface ResumeLogTransaction {
+  stdoutPath: string;
+  backupPath: string;
+  hadOriginal: boolean;
+}
+
+async function beginResumeLogTransaction(agent: AgentProcess): Promise<ResumeLogTransaction> {
+  const stdoutPath = await agent.getStdoutPath();
+  const backupPath = `${stdoutPath}.resume-backup-${randomUUID()}`;
+  let hadOriginal = false;
+  try {
+    await fs.rename(stdoutPath, backupPath);
+    hadOriginal = true;
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT') throw err;
+  }
+  return { stdoutPath, backupPath, hadOriginal };
+}
+
+async function commitResumeLogTransaction(transaction: ResumeLogTransaction): Promise<void> {
+  if (transaction.hadOriginal) await fs.rm(transaction.backupPath, { force: true });
+}
+
+async function rollbackResumeLogTransaction(transaction: ResumeLogTransaction): Promise<void> {
+  await fs.rm(transaction.stdoutPath, { force: true });
+  if (transaction.hadOriginal) {
+    await fs.rename(transaction.backupPath, transaction.stdoutPath);
+  }
+}
+
+async function terminateSpawnedProcess(pid: number): Promise<void> {
+  try {
+    process.kill(-pid, 'SIGTERM');
+  } catch {
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch {
+      return;
+    }
+  }
+
+  await new Promise(resolve => setTimeout(resolve, 250));
+  try {
+    process.kill(pid, 0);
+  } catch {
+    return;
+  }
+
+  try {
+    process.kill(-pid, 'SIGKILL');
+  } catch {
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      // The process exited between the liveness check and the signal.
+    }
+  }
+}
+
 export class AgentManager {
   private agents: Map<string, AgentProcess> = new Map();
   private maxAgents: number;
@@ -1679,8 +1738,18 @@ export class AgentManager {
     }
 
     const resume = { id: agent.remoteSessionId ?? agent.agentId, message };
-    const priorStatus = agent.status;
-    const priorCompletedAt = agent.completedAt;
+    const priorRuntime = {
+      status: agent.status,
+      completedAt: agent.completedAt,
+      pid: agent.pid,
+      startTime: agent.startTime,
+      startedAt: agent.startedAt,
+      remotePid: agent.remotePid,
+      remoteLog: agent.remoteLog,
+      remoteExit: agent.remoteExit,
+      remoteLogOffset: agent.remoteLogOffset,
+      worktreePath: agent.worktreePath,
+    };
     // Flip to RUNNING up front so a concurrent status poll can't reap the
     // teammate between the exit-sentinel clear and the new PID landing; the
     // launch re-persists with the fresh pid/startTime. If relaunch fails before
@@ -1696,8 +1765,7 @@ export class AgentManager {
         await this.launchProcess(agent, resume);
       }
     } catch (err) {
-      agent.status = priorStatus;
-      agent.completedAt = priorCompletedAt;
+      Object.assign(agent, priorRuntime);
       await agent.saveMeta();
       throw err;
     }
@@ -1732,8 +1800,13 @@ export class AgentManager {
 
     debug(`Launching ${agent.agentType} agent ${agent.agentId} [${agent.mode}]${resume ? ' (resume)' : ''}: ${cmd.slice(0, 3).join(' ')}...`);
 
+    let childProcess: ChildProcess | null = null;
+    let stdoutFile: fs.FileHandle | null = null;
+    let resumeLog: ResumeLogTransaction | null = null;
+
     try {
-      const stdoutPath = await agent.getStdoutPath();
+      if (resume) resumeLog = await beginResumeLogTransaction(agent);
+      const stdoutPath = resumeLog?.stdoutPath ?? await agent.getStdoutPath();
       // Always TRUNCATE — including on resume. The status reader re-reads the
       // whole log from byte 0 every poll (lastReadPos is in-memory, not
       // persisted) and marks terminal status from the last `result` event it
@@ -1744,7 +1817,7 @@ export class AgentManager {
       // a forked session. Truncating keeps exactly one turn in the log, so the
       // re-read is always correct. The authoritative transcript lives in the
       // agent's own session (resumed via --resume), not this stdout mirror.
-      const stdoutFile = await fs.open(stdoutPath, 'w');
+      stdoutFile = await fs.open(stdoutPath, 'w');
       const stdoutFd = stdoutFile.fd;
 
       // Wrap the teammate command in a shell that records the underlying CLI's
@@ -1760,7 +1833,7 @@ export class AgentManager {
 
       // detached:true makes the shell the process-group leader, so stop()'s
       // `kill(-pid)` still reaches the underlying CLI through the group.
-      const childProcess = spawn('/bin/sh', ['-c', wrappedCmd], {
+      childProcess = spawn('/bin/sh', ['-c', wrappedCmd], {
         stdio: ['ignore', stdoutFd, stdoutFd],
         cwd: agent.cwd || undefined,
         detached: true,
@@ -1769,8 +1842,13 @@ export class AgentManager {
           : sanitizeProcessEnv(process.env),
       });
 
+      await new Promise<void>((resolve, reject) => {
+        childProcess!.once('spawn', resolve);
+        childProcess!.once('error', reject);
+      });
       childProcess.unref();
-      stdoutFile.close().catch(() => {});
+      await stdoutFile.close();
+      stdoutFile = null;
 
       agent.pid = childProcess.pid || null;
       // Capture start-time NOW, while we know the PID is ours. Once the
@@ -1781,7 +1859,11 @@ export class AgentManager {
       agent.status = AgentStatus.RUNNING;
       agent.startedAt = new Date();
       await agent.saveMeta();
+      if (resumeLog) await commitResumeLogTransaction(resumeLog);
     } catch (err: any) {
+      if (stdoutFile) await stdoutFile.close().catch(() => {});
+      if (childProcess?.pid) await terminateSpawnedProcess(childProcess.pid);
+      if (resumeLog) await rollbackResumeLogTransaction(resumeLog);
       // Fresh spawns own a newly-created directory, so a failed launch removes
       // that partial record. A resume reuses an existing teammate: its caller
       // restores the prior terminal state and preserves the directory for retry.
@@ -1857,12 +1939,19 @@ export class AgentManager {
       resume,
     );
 
+    let dispatchedTask: Awaited<ReturnType<typeof dispatchAgentsCommand>>['task'] | null = null;
+    let resumeLog: ResumeLogTransaction | null = null;
     try {
+      if (resume) {
+        resumeLog = await beginResumeLogTransaction(agent);
+        await fs.writeFile(resumeLog.stdoutPath, '');
+      }
       const { task } = await dispatchAgentsCommand(host, {
         forwardedArgs,
         remoteCwd,
         follow: false,
       });
+      dispatchedTask = task;
       agent.remotePid = task.pid ?? null;
       agent.remoteLog = task.remoteLog ?? null;
       agent.remoteExit = task.remoteExit ?? null;
@@ -1871,14 +1960,33 @@ export class AgentManager {
       // syncRemoteMirror appends the delta onto the local mirror. Truncate that
       // mirror first so the prior turn's terminal event can't linger and get
       // re-read as the current status (same hazard the local path truncates for).
-      if (resume) {
-        await fs.writeFile(await agent.getStdoutPath(), '').catch(() => {});
-      }
       agent.status = AgentStatus.RUNNING;
       agent.startedAt = new Date();
       await agent.saveMeta();
+      if (resumeLog) await commitResumeLogTransaction(resumeLog);
     } catch (err: any) {
+      let cleanupError: Error | null = null;
+      if (dispatchedTask) {
+        try {
+          terminateDispatchedTask(dispatchedTask);
+        } catch (cleanupErr) {
+          cleanupError = cleanupErr as Error;
+        }
+      }
+      if (resumeLog) {
+        try {
+          await rollbackResumeLogTransaction(resumeLog);
+        } catch (cleanupErr) {
+          cleanupError = cleanupError ?? cleanupErr as Error;
+        }
+      }
       console.error(`Failed to launch remote teammate ${agent.agentId} on ${agent.hostName}:`, err);
+      if (cleanupError) {
+        throw new Error(
+          `Failed to launch remote teammate: ${err.message}; cleanup failed: ${cleanupError.message}`,
+          { cause: err },
+        );
+      }
       throw new Error(`Failed to launch remote teammate: ${err.message}`);
     }
 


### PR DESCRIPTION
## Summary

- keep an existing teammate entry and its on-disk directory when a resume launch fails
- make local and remote resume launches transactional: if persistence fails after a replacement starts, terminate it before reporting failure
- restore every prior runtime field and stdout mirror; retain destructive directory cleanup only for a newly created partial spawn

Follow-up to the post-merge data-loss finding on #1083. The first independent review found a post-spawn persistence window; the current head closes it for both local and remote launches.

## Verification

- `bun run build`
- `bun run test src/lib/teams/agents.resume.test.ts src/lib/hosts/dispatch.test.ts` — 24 tests passed
- `bun run test src/lib/teams` — 150 tests passed across 19 files
- `AGENTS_TEST_REMOTE_TARGET=yosemite-s0 bun run test src/lib/hosts/dispatch.test.ts` — 14 tests passed against a real SSH worker
- local regression proof: a real post-spawn metadata failure leaves no replacement PID and restores the manager entry, runtime fields, metadata, completion timestamp, stdout mirror, and prior log
- remote regression proof: the production rollback terminates a real detached worker process before returning
- repository-wide run before the transactional follow-up: 5,167 tests passed; 8 unrelated environment-dependent tests failed outside the changed files. GitHub CI is the clean-environment gate.

Session transcript (public repository, local fleet path only): `zion:/Users/muqsit/.agents/.history/versions/codex/0.144.1/home/.codex/sessions/2026/07/13/rollout-2026-07-13T14-41-01-019f5d6d-223a-74d1-938d-a3851b349fa3.jsonl`