### PR TITLE
fix(teams): preserve original launch error when resume restore-write fails

### DIFF
--- a/apps/cli/src/lib/teams/agents.resume.test.ts
+++ b/apps/cli/src/lib/teams/agents.resume.test.ts
@@ -199,7 +199,19 @@ describe.skipIf(IS_WINDOWS)('resumeTeammate — launch failure', () => {
       // The real local launcher reaches spawn, then saveMeta follows the
       // read-only symlink and fails. The transactional catch must terminate the
       // detached process before resumeTeammate restores the original lifecycle.
-      await expect(mgr.resumeTeammate(id, marker)).rejects.toThrow();
+      // The restore's own saveMeta ALSO fails against the read-only symlink, so
+      // the wrapper must preserve the ORIGINAL launch error via `{ cause }` — a
+      // bare restore-write error would erase the informative failure.
+      const rejection = await mgr.resumeTeammate(id, marker).then(
+        () => { throw new Error('expected resumeTeammate to reject'); },
+        (e: unknown) => e as Error,
+      );
+      expect(rejection.message).toMatch(/restoring stopped state also failed/);
+      const originalErr = rejection.cause as Error | undefined;
+      expect(originalErr).toBeDefined();
+      // The original launch failure was the read-only-symlink saveMeta write,
+      // not the restore write — its message must survive on the cause chain.
+      expect(originalErr!.message).not.toMatch(/restoring stopped state also failed/);
 
       const retained = (mgr as any).agents.get(id) as AgentProcess | undefined;
       expect(retained).toBeDefined();

--- a/apps/cli/src/lib/teams/agents.ts
+++ b/apps/cli/src/lib/teams/agents.ts
@@ -1779,7 +1779,14 @@ export class AgentManager {
       }
     } catch (err) {
       Object.assign(agent, priorRuntime);
-      await agent.saveMeta();
+      try {
+        await agent.saveMeta();
+      } catch (restoreErr) {
+        throw new Error(
+          `Failed to resume teammate: ${(err as Error).message}; restoring stopped state also failed: ${(restoreErr as Error).message}`,
+          { cause: err },
+        );
+      }
       throw err;
     }
     return agent;


### PR DESCRIPTION
Follow-up to #1104, which merged with this blocking review issue still open.

## Problem
In `apps/cli/src/lib/teams/agents.ts`, `resumeTeammate`'s outer failure-recovery catch restored the stopped lifecycle then called `saveMeta()` **unguarded**:

```ts
} catch (err) {
  Object.assign(agent, priorRuntime);
  await agent.saveMeta();   // if THIS throws, err is lost
  throw err;
}
```

If the restore write itself fails (the same disk-pressure class that broke the launch), the bare `saveMeta` error propagates and the informative original launch `err` is lost — with no `cause` chain. This is inconsistent with the `{ cause: err }` pattern already used one frame down in `launchRemoteProcess` and in `hosts/dispatch.ts` `launchDetached`.

## Fix
Wrap the restore `saveMeta()` in its own try/catch. On restore-write failure, throw an Error that chains `{ cause: err }` and includes both messages (mirroring `launchRemoteProcess`'s wording). On success, `throw err` as before. The correct transactional behavior is unchanged.

## Test
Strengthened the read-only-restore test (`agents.resume.test.ts`) from a bare `.rejects.toThrow()` to assert the thrown error preserves the **original** launch error on its `.cause` chain. Verified the guard bites: reverting the source fix makes the test fail with `expected 'EACCES: permission denied ...' to match /restoring stopped state also failed/`.

## Validation
- `npx tsc --noEmit` → exit 0
- `vitest run src/lib/teams/agents.resume.test.ts` → 13 passed
- No conflict markers in `apps/cli/src`.