### PR TITLE
docs(run): document --project and --cwd-on-host for --host runs

### DIFF
--- a/apps/cli/docs/hosts.md
+++ b/apps/cli/docs/hosts.md
@@ -348,6 +348,24 @@ secret-injection path works remotely for free** — provided agents-cli + that a
 are installed and authed on the box, which `ensureHostReady` / `agents hosts check`
 guarantee (see Context, below).
 
+**Working directory on the host.** The remote command is prefixed with a
+`cd <dir> &&` computed from the run's flags (see `remoteCdPrefix`,
+`src/lib/hosts/dispatch.ts`):
+
+- `--cwd <dir>` sets the host working directory. A home-anchored path (`~/…`,
+  `$HOME/…`, or a local-home absolute the local shell already expanded) is
+  re-rooted at the **remote** `$HOME`, so it resolves across machines with
+  different homes (`/Users/me` → `/home/me`). Resolution happens locally: the
+  forwarded argv is still a plain `agents run <agent> …`.
+- `-P, --project <slug>[@worktree]` resolves `<slug>` against your projects root
+  (auto-inferred from the launch repo and cached in `agents.yaml`; set via
+  `agents defaults project-root <path>`) and lands on the host home-relative
+  (`~/…`), so the host expands it to its own home. `@worktree` targets
+  `<repo>/.agents/worktrees/<worktree>`.
+- `--remote-cwd <dir>` is the explicit escape hatch — a literal remote path used
+  verbatim (never re-rooted). Precedence: `--remote-cwd` > `--project`/`--cwd`;
+  `--project` is mutually exclusive with `--cwd`/`--remote-cwd`.
+
 Workspace (where the run executes) is a deliberate scoping choice — see Open
 Questions. Phase 1 default: a caller-specified `--remote-cwd` (or the repo's
 existing checkout on the box). The rush per-task git-worktree workspace

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -213,6 +213,32 @@ agents logs <id> -f          # re-attach to a running one and follow
 `agents logs [id]` is the unified viewer over both host-dispatch runs and local
 session transcripts; `agents hosts logs <id>` is the host-only equivalent.
 
+### Working directory on the host
+
+`--cwd` sets the directory the agent runs in **on the host** too — a home-anchored
+path (`~/…`, `$HOME/…`, or a local-home absolute your shell already expanded like
+`/Users/me/…`) is re-rooted at the *remote* `$HOME`, so it resolves across machines
+with different home paths (`/Users/me` → `/home/me`):
+
+```bash
+agents run claude "..." --host gpu-box --cwd ~/src/github.com/me/app
+#   → runs on gpu-box in $HOME/src/github.com/me/app
+```
+
+`-P, --project <slug>[@worktree]` is a shorthand: it resolves `<slug>` against your
+projects root (auto-inferred from the repo you launch inside and cached in
+`agents.yaml`, e.g. `~/src/github.com/<user>`), and `@worktree` targets a git
+worktree under `.agents/worktrees/`:
+
+```bash
+agents run claude "..." --host gpu-box --project app          # → $HOME/…/app
+agents run claude "..." --host gpu-box --project app@fix-bug  # → app/.agents/worktrees/fix-bug
+agents defaults project-root ~/src/github.com/<user>          # set/show the root
+```
+
+`--remote-cwd <dir>` is the explicit escape hatch — a literal remote path, used
+verbatim (not re-rooted). Precedence: `--remote-cwd` > `--project`/`--cwd`.
+
 ## Bounded runs
 
 Kill the agent after a duration. Useful in CI and scheduled jobs.
@@ -292,7 +318,13 @@ agents run claude "refactor shared utils" --add-dir ../shared --add-dir ../other
 
 ```bash
 agents run claude "..." --cwd /path/to/repo
+agents run claude "..." --project app          # shorthand: <root>/app
 ```
+
+`--cwd` sets the working directory locally, and **on the host** for `--host` runs
+(see [Working directory on the host](#working-directory-on-the-host)). `-P, --project
+<slug>[@worktree]` resolves a project name against your cached projects root; set it
+with `agents defaults project-root <path>`.
 
 ## ACP routing
 
@@ -314,7 +346,9 @@ Emits a unified event stream; ndjson when combined with `--json`.
 | `--model <id>` | Override model |
 | `--secrets <bundle>` | Inject keychain bundle (repeatable) |
 | `--env KEY=val` | Pass env var (repeatable) |
-| `--cwd <dir>` | Working directory |
+| `--cwd <dir>` | Working directory (local, or on the host for `--host` runs) |
+| `-P, --project <slug>[@wt]` | Project shorthand → cwd from your projects root |
+| `--remote-cwd <dir>` | Explicit host working directory (`--host`; verbatim) |
 | `--add-dir <dir>` | Extra dir access (Claude, repeatable) |
 | `--json` | ndjson event stream |
 | `--quiet` | Drop preamble |


### PR DESCRIPTION
## Why

#1094 shipped host-aware `--cwd` (re-rooted at the remote `$HOME`) and the new `-P/--project` shorthand, but only updated the CHANGELOG — the user-facing docs and the `run` skill still described `--cwd` as local-only and never mentioned `--project`. This closes that gap.

## Changes

- **`skills/run/SKILL.md`**
  - New "Working directory on the host" subsection under *Offload to another machine* — `--cwd` re-rooting at the remote `$HOME`, `--project`/`@worktree`, `agents defaults project-root`, and `--remote-cwd` precedence.
  - "Working directory" section now notes host behavior + `--project`.
  - Quick-reference flag table gains `-P, --project` and `--remote-cwd`, and clarifies `--cwd`.
- **`apps/cli/docs/hosts.md`** — a "Working directory on the host" paragraph in the remote-execution section covering `--cwd` re-rooting, `--project` resolution, and the verbatim `--remote-cwd` escape hatch (with precedence + mutual-exclusion rules).

Docs-only; no code change.