### PR TITLE
feat(cli): add `agents output` — token burn vs shipped output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@
   and `--host`. Leads with output tokens because the raw session `token_count`
   sums cache-read/-write context re-counted every turn and runs ~100–400× the
   real generation — an honest "work produced" signal, not the inflated total.
+  `--all-hosts` folds in every online device (`ag devices`) over SSH for one
+  fleet-wide burn-vs-output view (unreachable/older machines are labeled, not
+  dropped). `--since` accepts `1h`, `24h`, `7d`, `4w`, `1mo`, `1y`, or an ISO
+  date.
+
+- **`parseTimeFilter` gains month (`mo`) and year (`y`) units.** Additive and
+  non-breaking — `m` still means minutes; `1mo` = 30 days, `1y` = 365 days.
+  Shared by `output`, `cost`, and `sessions --since`.
 
 - **`output_tokens` recorded per session (schema v12).** The session scanners now
   capture real generated tokens separately from `token_count` for claude, codex,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### Added
+
+- **`agents output` — productivity: token burn vs shipped output.** A new command
+  that joins spend (`$` cost, from the offline price table) to what actually
+  shipped: real generated **output tokens** plus **commits across every git
+  identity** and **PRs opened/merged** (`gh`), with burn-vs-output ratios
+  (`$/PR`, `$/commit`, output-tokens/`$`). Supports `--since`, `--by
+  agent|project|day`, `--repos-dir`, `--author`, `--login`, `--no-prs`, `--json`,
+  and `--host`. Leads with output tokens because the raw session `token_count`
+  sums cache-read/-write context re-counted every turn and runs ~100–400× the
+  real generation — an honest "work produced" signal, not the inflated total.
+
+- **`output_tokens` recorded per session (schema v12).** The session scanners now
+  capture real generated tokens separately from `token_count` for claude, codex,
+  gemini, opencode, kimi, and droid, surfaced via `queryUsageRollup`. Existing
+  session databases migrate additively and backfill on the next scan (the first
+  run re-indexes once).
+
 ## 1.20.58
 
 ### Added

--- a/apps/cli/src/commands/output.test.ts
+++ b/apps/cli/src/commands/output.test.ts
@@ -1,0 +1,137 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Isolate the sessions DB (and repo scan root) under a temp HOME before any
+// module that captures the DB path at import time loads.
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-output-test-'));
+process.env.HOME = TEST_HOME;
+
+const { Command } = await import('commander');
+const { registerOutputCommand } = await import('./output.js');
+const { upsertSession, closeDB } = await import('../lib/session/db.js');
+type SessionMeta = import('../lib/session/types.js').SessionMeta;
+
+const FILES_DIR = path.join(TEST_HOME, 'output-cmd-files');
+fs.mkdirSync(FILES_DIR, { recursive: true });
+
+function seed(
+  id: string,
+  agent: SessionMeta['agent'],
+  timestamp: string,
+  costUsd: number,
+  outputTokens: number,
+  tokenCount: number,
+  project: string,
+): void {
+  const filePath = path.join(FILES_DIR, `${id}.jsonl`);
+  fs.writeFileSync(filePath, '');
+  const meta: SessionMeta = {
+    id,
+    shortId: id.slice(0, 8),
+    agent,
+    timestamp,
+    project,
+    cwd: FILES_DIR,
+    filePath,
+    topic: `${agent} work`,
+    costUsd,
+    outputTokens,
+    tokenCount,
+  };
+  upsertSession(meta, '');
+}
+
+/** Run `agents output <args>` capturing stdout (JSON) and console.log (TTY). */
+async function runOutput(args: string[]): Promise<string> {
+  const program = new Command();
+  program.exitOverride();
+  registerOutputCommand(program);
+
+  const chunks: string[] = [];
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((c: any) => {
+    chunks.push(typeof c === 'string' ? c : c.toString());
+    return true;
+  });
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: any[]) => {
+    chunks.push(a.join(' '));
+  });
+  try {
+    await program.parseAsync(['node', 'agents', 'output', ...args]);
+  } finally {
+    writeSpy.mockRestore();
+    logSpy.mockRestore();
+  }
+  return chunks.join('\n');
+}
+
+// A wide --since so the fixed-date seeds are always in-window; --no-prs to keep
+// tests offline (real gh is not mocked — that path is exercised manually).
+const BASE = ['--since', '2020-01-01', '--no-prs'];
+
+describe('agents output', () => {
+  beforeAll(() => {
+    // token_count is deliberately >> outputTokens to model cache-read inflation.
+    seed('big0001', 'claude', '2026-05-20T10:00:00.000Z', 30, 1_000_000, 50_000_000, 'rush');
+    seed('mid0002', 'claude', '2026-05-21T10:00:00.000Z', 10, 400_000, 12_000_000, 'agents-cli');
+    seed('cdx0003', 'codex', '2026-05-21T12:00:00.000Z', 2, 100_000, 3_000_000, 'agents-cli');
+  });
+
+  afterAll(() => {
+    closeDB();
+    fs.rmSync(TEST_HOME, { recursive: true, force: true });
+  });
+
+  it('--json leads with real output tokens, not the inflated total', async () => {
+    const out = await runOutput([...BASE, '--json']);
+    const d = JSON.parse(out);
+    expect(d.pricingVersion).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(d.burn.sessionCount).toBe(3);
+    expect(d.burn.costUsd).toBeCloseTo(42, 5);
+    expect(d.burn.outputTokens).toBe(1_500_000);
+    // The honest metric is far below the cache-inflated total.
+    expect(d.burn.tokenCount).toBe(65_000_000);
+    expect(d.burn.outputTokens).toBeLessThan(d.burn.tokenCount / 10);
+  });
+
+  it('computes burn-vs-output ratios', async () => {
+    const out = await runOutput([...BASE, '--json']);
+    const d = JSON.parse(out);
+    // No PRs/commits in the temp HOME, so per-PR/per-commit are null...
+    expect(d.ratios.costPerPr).toBeNull();
+    expect(d.ratios.costPerCommit).toBeNull();
+    // ...but output-tokens-per-dollar is defined: 1.5M / $42.
+    expect(d.ratios.outputTokensPerUsd).toBeCloseTo(1_500_000 / 42, 2);
+  });
+
+  it('--by agent breakdown carries per-agent output tokens', async () => {
+    const out = await runOutput([...BASE, '--by', 'agent', '--json']);
+    const d = JSON.parse(out);
+    expect(d.breakdown.by).toBe('agent');
+    const byKey = Object.fromEntries(d.breakdown.rows.map((r: any) => [r.key, r]));
+    expect(byKey.claude.outputTokens).toBe(1_400_000);
+    expect(byKey.codex.outputTokens).toBe(100_000);
+  });
+
+  it('--by project groups by project', async () => {
+    const out = await runOutput([...BASE, '--by', 'project', '--json']);
+    const d = JSON.parse(out);
+    const keys = d.breakdown.rows.map((r: any) => r.key);
+    expect(keys).toContain('rush');
+    expect(keys).toContain('agents-cli');
+  });
+
+  it('renders the burn/output table and shipped section in TTY mode', async () => {
+    const out = await runOutput([...BASE]);
+    expect(out).toContain('Output');
+    expect(out).toContain('burned');
+    expect(out).toContain('output tokens');
+    expect(out).toContain('By agent');
+    expect(out).toContain('Shipped');
+    // Compact token formatting (1.5M).
+    expect(out).toMatch(/\dM|\dK/);
+    // Honesty footer present.
+    expect(out).toContain('not counted');
+  });
+});

--- a/apps/cli/src/commands/output.ts
+++ b/apps/cli/src/commands/output.ts
@@ -11,11 +11,16 @@
  * context re-counted every turn and is dominated by cheap re-reads (often ~100x
  * the real generation). `output_tokens` (scanned per-agent into the session DB)
  * is the honest "work produced" signal, and it is what this command leads with.
+ *
+ * `--all-hosts` fans the same rollup across every online device (`ag devices`)
+ * over SSH and merges — one fleet-wide burn-vs-output view.
  */
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import * as os from 'os';
 import * as path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 
 import { addHostOption } from '../lib/hosts/option.js';
 import { discoverSessions, parseTimeFilter } from '../lib/session/discover.js';
@@ -23,7 +28,11 @@ import { queryUsageRollup, type UsageRollupGroup, type QueryOptions } from '../l
 import { formatUsd, PRICING_VERSION } from '../lib/pricing/index.js';
 import { formatDuration } from '../lib/session/render.js';
 import { terminalWidth, truncateToWidth, padToWidth } from '../lib/session/width.js';
-import { collectGitOutput, type GitOutputSummary } from '../lib/output/git-output.js';
+import { collectGitOutput } from '../lib/output/git-output.js';
+import { loadDevices } from '../lib/devices/registry.js';
+import { machineId } from '../lib/session/sync/config.js';
+
+const execFileAsync = promisify(execFile);
 
 interface OutputOptions {
   json?: boolean;
@@ -33,25 +42,67 @@ interface OutputOptions {
   author?: string[];
   login?: string[];
   prs?: boolean; // commander sets `prs: false` for --no-prs
+  allHosts?: boolean;
+}
+
+interface RollupRow {
+  key: string;
+  costUsd: number;
+  durationMs: number;
+  sessionCount: number;
+  tokenCount: number;
+  outputTokens: number;
+}
+
+interface BurnTotals {
+  costUsd: number;
+  outputTokens: number;
+  tokenCount: number;
+  sessionCount: number;
+  durationMs: number;
+}
+
+interface GitOut {
+  commits: number;
+  prsOpened: number;
+  prsMerged: number;
+  reposScanned: number;
+  ghAvailable: boolean;
+  authors: string[];
+  logins: string[];
+}
+
+/** One machine's productivity payload — the `--json` shape, reused across the fleet. */
+interface OutputPayload {
+  machine: string;
+  pricingVersion: string;
+  since: string;
+  burn: BurnTotals;
+  output: GitOut;
+  breakdown: { by: string; rows: RollupRow[] };
+  uncostedAgents: string[];
+  /** Set when a remote machine could not be reached / did not support the command. */
+  error?: string;
 }
 
 export function registerOutputCommand(program: Command): void {
   addHostOption(program.command('output'))
     .description('Productivity rollup — token burn vs shipped output (PRs, commits) across agents')
     .option('--json', 'Output the rollup as JSON')
-    .option('--since <time>', 'Only sessions/commits newer than this (default 7d)')
+    .option('--since <time>', 'Only sessions/commits newer than this: 1h, 24h, 7d, 4w, 1mo, 1y, or ISO date (default 7d)')
     .option('--by <dimension>', 'Group the burn/output breakdown by: agent (default), project, or day')
     .option('--repos-dir <dir>', 'Root scanned for git repos (default ~/src)')
     .option('--author <email...>', 'Count commits by these author emails (default: your git identities)')
     .option('--login <login...>', 'Count PRs for these GitHub logins (default: current gh user)')
     .option('--no-prs', 'Skip the GitHub PR lookup (commits only)')
+    .option('--all-hosts', 'Aggregate across every online device (ag devices) over SSH')
     .addHelpText('after', `
 Examples:
   agents output                       Last 7 days: burn, output tokens, PRs, commits, ratios
-  agents output --since 30d           Last 30 days
+  agents output --since 24h           Last 24 hours
+  agents output --since 1mo           Last month  (units: 1h 24h 7d 4w 1mo 1y, or ISO date)
+  agents output --all-hosts           Fleet-wide, folding in every online machine
   agents output --by day --json       Machine-readable daily burn/output rollup
-  agents output --repos-dir ~/work    Scan a different repo root for commits
-  agents output --login me --login alt-account   Count PRs across multiple accounts
 
 Burn (cost) is computed offline from a versioned per-model price table (${PRICING_VERSION}).
 Output tokens are the real generated tokens — NOT the cache-inflated total token count.
@@ -77,29 +128,33 @@ function formatCompact(n: number): string {
   return String(n);
 }
 
-async function outputAction(options: OutputOptions): Promise<void> {
+function emptyBurn(): BurnTotals {
+  return { costUsd: 0, outputTokens: 0, tokenCount: 0, sessionCount: 0, durationMs: 0 };
+}
+
+function sumBurn(rows: RollupRow[]): BurnTotals {
+  return rows.reduce((acc, r) => {
+    acc.costUsd += r.costUsd;
+    acc.outputTokens += r.outputTokens;
+    acc.tokenCount += r.tokenCount;
+    acc.sessionCount += r.sessionCount;
+    acc.durationMs += r.durationMs;
+    return acc;
+  }, emptyBurn());
+}
+
+/** Compute this machine's payload from the local session DB + git. */
+async function computeLocalPayload(options: OutputOptions, includePrs: boolean): Promise<OutputPayload> {
   const since = options.since ?? '7d';
   const sinceMs = parseTimeFilter(since);
 
-  // Ensure the index is fresh (and migrated to v12 so output_tokens is populated)
-  // before we read the rollup.
+  // Ensure the index is fresh (and migrated to v12 so output_tokens is populated).
   await discoverSessions({ all: true, since, limit: 1 });
 
   const filter: QueryOptions = { sinceMs };
   const groupBy = resolveGroup(options.by);
-  const breakdown = queryUsageRollup({ ...filter, groupBy });
-
-  const totals = breakdown.reduce(
-    (acc, r) => {
-      acc.costUsd += r.costUsd;
-      acc.outputTokens += r.outputTokens;
-      acc.tokenCount += r.tokenCount;
-      acc.sessionCount += r.sessionCount;
-      acc.durationMs += r.durationMs;
-      return acc;
-    },
-    { costUsd: 0, outputTokens: 0, tokenCount: 0, sessionCount: 0, durationMs: 0 },
-  );
+  const breakdown = queryUsageRollup({ ...filter, groupBy }) as RollupRow[];
+  const burn = sumBurn(breakdown);
 
   const reposDir = options.reposDir ?? path.join(os.homedir(), 'src');
   const git = await collectGitOutput({
@@ -107,103 +162,176 @@ async function outputAction(options: OutputOptions): Promise<void> {
     sinceMs,
     authors: options.author,
     logins: options.login,
-    includePrs: options.prs !== false,
+    includePrs,
   });
 
-  const prsTotal = git.prsOpened + git.prsMerged;
-  const ratios = {
-    costPerPr: prsTotal > 0 ? totals.costUsd / prsTotal : null,
-    costPerCommit: git.commits > 0 ? totals.costUsd / git.commits : null,
-    outputTokensPerUsd: totals.costUsd > 0 ? totals.outputTokens / totals.costUsd : null,
+  return {
+    machine: machineId(),
+    pricingVersion: PRICING_VERSION,
+    since,
+    burn,
+    output: {
+      commits: git.commits,
+      prsOpened: git.prsOpened,
+      prsMerged: git.prsMerged,
+      reposScanned: git.reposScanned,
+      ghAvailable: git.ghAvailable,
+      authors: git.authors,
+      logins: git.logins,
+    },
+    breakdown: { by: groupBy, rows: breakdown },
+    uncostedAgents: groupBy === 'agent' ? breakdown.filter(r => r.costUsd === 0).map(r => r.key) : [],
   };
+}
 
-  // Agents whose CLIs record no cost — surfaced so the burn number stays honest.
-  const uncosted = breakdown.filter(r => groupBy === 'agent' && r.costUsd === 0).map(r => r.key);
+/** Fetch one remote device's payload by re-invoking `agents output --json --host <name>`. */
+async function fetchRemotePayload(device: string, options: OutputOptions): Promise<OutputPayload> {
+  const args = ['output', '--json', '--no-prs', '--host', device, '--since', options.since ?? '7d'];
+  if (options.by) args.push('--by', options.by);
+  if (options.reposDir) args.push('--repos-dir', options.reposDir);
+  for (const a of options.author ?? []) args.push('--author', a);
+  try {
+    const { stdout } = await execFileAsync('agents', args, {
+      timeout: 120_000,
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const parsed = JSON.parse(stdout) as OutputPayload;
+    parsed.machine = parsed.machine || device;
+    return parsed;
+  } catch (err: any) {
+    return {
+      machine: device,
+      pricingVersion: PRICING_VERSION,
+      since: options.since ?? '7d',
+      burn: emptyBurn(),
+      output: { commits: 0, prsOpened: 0, prsMerged: 0, reposScanned: 0, ghAvailable: false, authors: [], logins: [] },
+      breakdown: { by: resolveGroup(options.by), rows: [] },
+      uncostedAgents: [],
+      error: (err?.stderr || err?.message || 'unreachable').toString().split('\n')[0].slice(0, 120),
+    };
+  }
+}
+
+async function outputAction(options: OutputOptions): Promise<void> {
+  const includePrs = options.prs !== false;
+
+  if (!options.allHosts) {
+    const payload = await computeLocalPayload(options, includePrs);
+    if (options.json) {
+      process.stdout.write(JSON.stringify(withRatios(payload, [payload]), null, 2) + '\n');
+      return;
+    }
+    renderSingle(payload);
+    return;
+  }
+
+  // Fleet: local payload + every online device, folded in over SSH.
+  const self = machineId();
+  const registry = await loadDevices();
+  const remotes = Object.values(registry)
+    .filter(d => d.tailscale?.online && d.name !== self)
+    .map(d => d.name);
+
+  if (!options.json) console.error(chalk.gray(`Folding in ${remotes.length} online device${remotes.length !== 1 ? 's' : ''}…`));
+
+  // PRs are global (gh search by author, not machine-bound) — compute once, locally.
+  const local = await computeLocalPayload(options, includePrs);
+  const remotePayloads = await Promise.all(remotes.map(d => fetchRemotePayload(d, options)));
+  const machines = [local, ...remotePayloads];
 
   if (options.json) {
-    process.stdout.write(
-      JSON.stringify(
-        {
-          pricingVersion: PRICING_VERSION,
-          since,
-          burn: {
-            costUsd: totals.costUsd,
-            outputTokens: totals.outputTokens,
-            tokenCount: totals.tokenCount,
-            sessionCount: totals.sessionCount,
-            durationMs: totals.durationMs,
-          },
-          output: {
-            commits: git.commits,
-            prsOpened: git.prsOpened,
-            prsMerged: git.prsMerged,
-            reposScanned: git.reposScanned,
-            byAuthor: git.byAuthor,
-            authors: git.authors,
-            logins: git.logins,
-            ghAvailable: git.ghAvailable,
-          },
-          ratios,
-          breakdown: { by: groupBy, rows: breakdown },
-          notCounted: {
-            uncostedAgents: uncosted,
-            ghAvailable: git.ghAvailable,
-            note: 'Cloud runs (Rush/Codex/Factory) and unreachable machines are not included; run with --host <name> per machine.',
-          },
-        },
-        null,
-        2,
-      ) + '\n',
-    );
+    process.stdout.write(JSON.stringify(withRatios(mergeMachines(machines, options), machines), null, 2) + '\n');
     return;
   }
+  renderFleet(machines, options);
+}
 
+/** Merge per-machine payloads into a combined one (burn + commits summed; PRs local-only). */
+function mergeMachines(machines: OutputPayload[], options: OutputOptions): OutputPayload {
+  const burn = emptyBurn();
+  const byKey = new Map<string, RollupRow>();
+  let commits = 0;
+  const uncosted = new Set<string>();
+  for (const m of machines) {
+    burn.costUsd += m.burn.costUsd;
+    burn.outputTokens += m.burn.outputTokens;
+    burn.tokenCount += m.burn.tokenCount;
+    burn.sessionCount += m.burn.sessionCount;
+    burn.durationMs += m.burn.durationMs;
+    commits += m.output.commits;
+    for (const a of m.uncostedAgents) uncosted.add(a);
+    for (const r of m.breakdown.rows) {
+      const cur = byKey.get(r.key) ?? { key: r.key, costUsd: 0, durationMs: 0, sessionCount: 0, tokenCount: 0, outputTokens: 0 };
+      cur.costUsd += r.costUsd;
+      cur.durationMs += r.durationMs;
+      cur.sessionCount += r.sessionCount;
+      cur.tokenCount += r.tokenCount;
+      cur.outputTokens += r.outputTokens;
+      byKey.set(r.key, cur);
+    }
+  }
+  const rows = [...byKey.values()].sort((a, b) => b.costUsd - a.costUsd);
+  // PRs from the local machine only (machines[0]) — gh search is not machine-scoped.
+  const localGit = machines[0].output;
+  return {
+    machine: 'fleet',
+    pricingVersion: PRICING_VERSION,
+    since: options.since ?? '7d',
+    burn,
+    output: { ...localGit, commits },
+    breakdown: { by: resolveGroup(options.by), rows },
+    uncostedAgents: [...uncosted],
+  };
+}
+
+/** Attach burn-vs-output ratios to a payload for JSON output. */
+function withRatios(payload: OutputPayload, machines: OutputPayload[]): unknown {
+  const prsTotal = payload.output.prsOpened + payload.output.prsMerged;
+  return {
+    ...payload,
+    ratios: {
+      costPerPr: prsTotal > 0 ? payload.burn.costUsd / prsTotal : null,
+      costPerCommit: payload.output.commits > 0 ? payload.burn.costUsd / payload.output.commits : null,
+      outputTokensPerUsd: payload.burn.costUsd > 0 ? payload.burn.outputTokens / payload.burn.costUsd : null,
+    },
+    machines: machines.length > 1 ? machines.map(m => ({ machine: m.machine, burn: m.burn, commits: m.output.commits, error: m.error })) : undefined,
+  };
+}
+
+/** Shared header line: burned · output tokens · PRs · commits, plus ratios. */
+function headerLines(payload: OutputPayload): string[] {
+  const prsTotal = payload.output.prsOpened + payload.output.prsMerged;
   const out: string[] = [];
-  out.push(chalk.bold('Output') + chalk.gray(`  ·  pricing ${PRICING_VERSION}  ·  since ${since}`));
   out.push(
     '  ' +
-      `${chalk.green(formatUsd(totals.costUsd))} burned` +
+      `${chalk.green(formatUsd(payload.burn.costUsd))} burned` +
       chalk.gray('  ·  ') +
-      `${chalk.cyan(formatCompact(totals.outputTokens))} output tokens` +
+      `${chalk.cyan(formatCompact(payload.burn.outputTokens))} output tokens` +
       chalk.gray('  ·  ') +
-      `${chalk.yellow(String(prsTotal))} PRs ${chalk.gray(`(${git.prsMerged} merged)`)}` +
+      `${chalk.yellow(String(prsTotal))} PRs ${chalk.gray(`(${payload.output.prsMerged} merged)`)}` +
       chalk.gray('  ·  ') +
-      `${chalk.yellow(String(git.commits))} commits`,
+      `${chalk.yellow(String(payload.output.commits))} commits`,
   );
-  // Burn-vs-output ratios.
-  const ratioParts: string[] = [];
-  if (ratios.costPerPr !== null) ratioParts.push(`${formatUsd(ratios.costPerPr)}/PR`);
-  if (ratios.costPerCommit !== null) ratioParts.push(`${formatUsd(ratios.costPerCommit)}/commit`);
-  if (ratios.outputTokensPerUsd !== null) ratioParts.push(`${formatCompact(Math.round(ratios.outputTokensPerUsd))} out-tok/$`);
-  if (ratioParts.length > 0) out.push(chalk.gray('  ' + ratioParts.join('  ·  ')));
-  out.push('');
+  const ratios: string[] = [];
+  if (prsTotal > 0) ratios.push(`${formatUsd(payload.burn.costUsd / prsTotal)}/PR`);
+  if (payload.output.commits > 0) ratios.push(`${formatUsd(payload.burn.costUsd / payload.output.commits)}/commit`);
+  if (payload.burn.costUsd > 0) ratios.push(`${formatCompact(Math.round(payload.burn.outputTokens / payload.burn.costUsd))} out-tok/$`);
+  if (ratios.length > 0) out.push(chalk.gray('  ' + ratios.join('  ·  ')));
+  return out;
+}
 
-  if (totals.sessionCount === 0) {
-    out.push(chalk.gray('No sessions with cost data found. Run `agents sessions --all` to index, then retry.'));
-    console.log(out.join('\n'));
-    return;
-  }
-
-  // Burn/output breakdown table.
-  const groupLabel = groupBy;
-  out.push(chalk.bold(`By ${groupLabel}`));
+/** Render the per-group burn/output table. */
+function renderBreakdown(rows: RollupRow[], groupBy: string): string[] {
+  const out: string[] = [chalk.bold(`By ${groupBy}`)];
+  if (rows.length === 0) return out;
   const cols = terminalWidth();
-  const burnW = Math.max(...breakdown.map(r => formatUsd(r.costUsd).length), 4);
-  const outW = Math.max(...breakdown.map(r => formatCompact(r.outputTokens).length), 6);
-  const sessW = Math.max(...breakdown.map(r => String(r.sessionCount).length), 3);
+  const burnW = Math.max(...rows.map(r => formatUsd(r.costUsd).length), 4);
+  const outW = Math.max(...rows.map(r => formatCompact(r.outputTokens).length), 6);
+  const sessW = Math.max(...rows.map(r => String(r.sessionCount).length), 3);
   const fixedW = 2 + 2 + burnW + 2 + outW + 2 + sessW + 8;
-  const keyW = Math.max(8, Math.min(Math.max(...breakdown.map(r => r.key.length), groupLabel.length), cols - fixedW));
-  out.push(
-    '  ' +
-      chalk.gray(padToWidth('', keyW)) +
-      '  ' +
-      chalk.gray(padToWidth('burn', burnW)) +
-      '  ' +
-      chalk.gray(padToWidth('output', outW)) +
-      '  ' +
-      chalk.gray('sessions'),
-  );
-  for (const r of breakdown) {
+  const keyW = Math.max(8, Math.min(Math.max(...rows.map(r => r.key.length), groupBy.length), cols - fixedW));
+  out.push('  ' + chalk.gray(padToWidth('', keyW)) + '  ' + chalk.gray(padToWidth('burn', burnW)) + '  ' + chalk.gray(padToWidth('output', outW)) + '  ' + chalk.gray('sessions'));
+  for (const r of rows) {
     out.push(
       '  ' +
         padToWidth(truncateToWidth(r.key, keyW), keyW) +
@@ -215,30 +343,69 @@ async function outputAction(options: OutputOptions): Promise<void> {
         chalk.gray(padToWidth(String(r.sessionCount), sessW)),
     );
   }
-  out.push('');
+  return out;
+}
 
-  // Shipped-work detail.
+function renderSingle(payload: OutputPayload): void {
+  const out: string[] = [];
+  out.push(chalk.bold('Output') + chalk.gray(`  ·  pricing ${payload.pricingVersion}  ·  since ${payload.since}`));
+  out.push(...headerLines(payload));
+  out.push('');
+  if (payload.burn.sessionCount === 0) {
+    out.push(chalk.gray('No sessions with cost data found. Run `agents sessions --all` to index, then retry.'));
+    console.log(out.join('\n'));
+    return;
+  }
+  out.push(...renderBreakdown(payload.breakdown.rows, payload.breakdown.by));
+  out.push('');
   out.push(chalk.bold('Shipped'));
-  out.push(
-    `  ${chalk.yellow(String(git.commits))} commits across ${git.reposScanned} repos` +
-      chalk.gray(`  (authors: ${git.authors.length > 0 ? git.authors.join(', ') : 'none detected'})`),
-  );
-  if (git.ghAvailable) {
-    out.push(
-      `  ${chalk.yellow(String(git.prsOpened))} PRs opened, ${chalk.yellow(String(git.prsMerged))} merged` +
-        chalk.gray(`  (logins: ${git.logins.join(', ')})`),
-    );
+  out.push(`  ${chalk.yellow(String(payload.output.commits))} commits across ${payload.output.reposScanned} repos` + chalk.gray(`  (authors: ${payload.output.authors.length > 0 ? payload.output.authors.join(', ') : 'none detected'})`));
+  if (payload.output.ghAvailable) {
+    out.push(`  ${chalk.yellow(String(payload.output.prsOpened))} PRs opened, ${chalk.yellow(String(payload.output.prsMerged))} merged` + chalk.gray(`  (logins: ${payload.output.logins.join(', ')})`));
   } else {
     out.push(chalk.gray('  PRs: gh unavailable or unauthed — not counted'));
   }
   out.push('');
-
-  // Honesty footer.
-  const notes: string[] = [];
-  if (uncosted.length > 0) notes.push(`no price table for: ${uncosted.join(', ')} (burn undercounts)`);
-  notes.push('cloud runs (Rush/Codex/Factory) and unreachable machines not counted — use --host <name> per machine');
-  out.push(chalk.gray('not counted: ' + notes.join('  ·  ')));
-  if (totals.durationMs > 0) out.push(chalk.gray(`agent wall-clock: ${formatDuration(totals.durationMs)}`));
-
+  out.push(chalk.gray(notCountedLine(payload.uncostedAgents)));
+  if (payload.burn.durationMs > 0) out.push(chalk.gray(`agent wall-clock: ${formatDuration(payload.burn.durationMs)}`));
   console.log(out.join('\n'));
+}
+
+function renderFleet(machines: OutputPayload[], options: OutputOptions): void {
+  const merged = mergeMachines(machines, options);
+  const out: string[] = [];
+  out.push(chalk.bold('Output') + chalk.gray(`  ·  fleet (${machines.length} machines)  ·  pricing ${merged.pricingVersion}  ·  since ${merged.since}`));
+  out.push(...headerLines(merged));
+  out.push('');
+
+  // By machine.
+  out.push(chalk.bold('By machine'));
+  const nameW = Math.max(...machines.map(m => m.machine.length), 7);
+  const burnW = Math.max(...machines.map(m => formatUsd(m.burn.costUsd).length), 4);
+  for (const m of machines) {
+    const note = m.error ? chalk.red(`  (${m.error})`) : '';
+    out.push(
+      '  ' +
+        padToWidth(m.machine, nameW) +
+        '  ' +
+        chalk.green(padToWidth(formatUsd(m.burn.costUsd), burnW)) +
+        '  ' +
+        chalk.cyan(padToWidth(formatCompact(m.burn.outputTokens), 7)) +
+        '  ' +
+        chalk.gray(`${m.burn.sessionCount} sessions, ${m.output.commits} commits`) +
+        note,
+    );
+  }
+  out.push('');
+  out.push(...renderBreakdown(merged.breakdown.rows, merged.breakdown.by));
+  out.push('');
+  out.push(chalk.gray(notCountedLine(merged.uncostedAgents)));
+  console.log(out.join('\n'));
+}
+
+function notCountedLine(uncosted: string[]): string {
+  const notes: string[] = [];
+  if (uncosted.length > 0) notes.push(`no price table for: ${[...new Set(uncosted)].join(', ')} (burn undercounts)`);
+  notes.push('cloud runs (Rush/Codex/Factory) not counted');
+  return 'not counted: ' + notes.join('  ·  ');
 }

--- a/apps/cli/src/commands/output.ts
+++ b/apps/cli/src/commands/output.ts
@@ -64,6 +64,8 @@ interface BurnTotals {
 
 interface GitOut {
   commits: number;
+  /** Deduped commit SHAs — unioned across machines under --all-hosts. */
+  commitShas: string[];
   prsOpened: number;
   prsMerged: number;
   reposScanned: number;
@@ -172,6 +174,7 @@ async function computeLocalPayload(options: OutputOptions, includePrs: boolean):
     burn,
     output: {
       commits: git.commits,
+      commitShas: git.commitShas,
       prsOpened: git.prsOpened,
       prsMerged: git.prsMerged,
       reposScanned: git.reposScanned,
@@ -204,7 +207,7 @@ async function fetchRemotePayload(device: string, options: OutputOptions): Promi
       pricingVersion: PRICING_VERSION,
       since: options.since ?? '7d',
       burn: emptyBurn(),
-      output: { commits: 0, prsOpened: 0, prsMerged: 0, reposScanned: 0, ghAvailable: false, authors: [], logins: [] },
+      output: { commits: 0, commitShas: [], prsOpened: 0, prsMerged: 0, reposScanned: 0, ghAvailable: false, authors: [], logins: [] },
       breakdown: { by: resolveGroup(options.by), rows: [] },
       uncostedAgents: [],
       error: (err?.stderr || err?.message || 'unreachable').toString().split('\n')[0].slice(0, 120),
@@ -250,7 +253,10 @@ async function outputAction(options: OutputOptions): Promise<void> {
 function mergeMachines(machines: OutputPayload[], options: OutputOptions): OutputPayload {
   const burn = emptyBurn();
   const byKey = new Map<string, RollupRow>();
-  let commits = 0;
+  // Union commit SHAs across machines: shared repos (cloned on several boxes)
+  // expose the same commits to `git log` on each, so summing counts would
+  // multi-count. A commit's SHA is its global identity — union, don't add.
+  const allShas = new Set<string>();
   const uncosted = new Set<string>();
   for (const m of machines) {
     burn.costUsd += m.burn.costUsd;
@@ -258,7 +264,7 @@ function mergeMachines(machines: OutputPayload[], options: OutputOptions): Outpu
     burn.tokenCount += m.burn.tokenCount;
     burn.sessionCount += m.burn.sessionCount;
     burn.durationMs += m.burn.durationMs;
-    commits += m.output.commits;
+    for (const s of m.output.commitShas) allShas.add(s);
     for (const a of m.uncostedAgents) uncosted.add(a);
     for (const r of m.breakdown.rows) {
       const cur = byKey.get(r.key) ?? { key: r.key, costUsd: 0, durationMs: 0, sessionCount: 0, tokenCount: 0, outputTokens: 0 };
@@ -278,7 +284,7 @@ function mergeMachines(machines: OutputPayload[], options: OutputOptions): Outpu
     pricingVersion: PRICING_VERSION,
     since: options.since ?? '7d',
     burn,
-    output: { ...localGit, commits },
+    output: { ...localGit, commits: allShas.size, commitShas: [...allShas] },
     breakdown: { by: resolveGroup(options.by), rows },
     uncostedAgents: [...uncosted],
   };

--- a/apps/cli/src/commands/output.ts
+++ b/apps/cli/src/commands/output.ts
@@ -1,0 +1,244 @@
+/**
+ * Output command — productivity: token *burn* vs shipped *output*.
+ *
+ * `agents cost` answers "what did we burn?" (dollars + duration). This joins that
+ * burn to what actually shipped — real generated (output) tokens plus PRs and
+ * commits across every git identity — so you can see burn-vs-output and ratios
+ * like $/PR and output-tokens/$. Pure SQLite + local git/gh, no server, no
+ * telemetry — the same offline spirit as `cost`.
+ *
+ * Why not just show `token_count`? Because that number sums cache-read/-write
+ * context re-counted every turn and is dominated by cheap re-reads (often ~100x
+ * the real generation). `output_tokens` (scanned per-agent into the session DB)
+ * is the honest "work produced" signal, and it is what this command leads with.
+ */
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import * as os from 'os';
+import * as path from 'path';
+
+import { addHostOption } from '../lib/hosts/option.js';
+import { discoverSessions, parseTimeFilter } from '../lib/session/discover.js';
+import { queryUsageRollup, type UsageRollupGroup, type QueryOptions } from '../lib/session/db.js';
+import { formatUsd, PRICING_VERSION } from '../lib/pricing/index.js';
+import { formatDuration } from '../lib/session/render.js';
+import { terminalWidth, truncateToWidth, padToWidth } from '../lib/session/width.js';
+import { collectGitOutput, type GitOutputSummary } from '../lib/output/git-output.js';
+
+interface OutputOptions {
+  json?: boolean;
+  since?: string;
+  by?: string;
+  reposDir?: string;
+  author?: string[];
+  login?: string[];
+  prs?: boolean; // commander sets `prs: false` for --no-prs
+}
+
+export function registerOutputCommand(program: Command): void {
+  addHostOption(program.command('output'))
+    .description('Productivity rollup — token burn vs shipped output (PRs, commits) across agents')
+    .option('--json', 'Output the rollup as JSON')
+    .option('--since <time>', 'Only sessions/commits newer than this (default 7d)')
+    .option('--by <dimension>', 'Group the burn/output breakdown by: agent (default), project, or day')
+    .option('--repos-dir <dir>', 'Root scanned for git repos (default ~/src)')
+    .option('--author <email...>', 'Count commits by these author emails (default: your git identities)')
+    .option('--login <login...>', 'Count PRs for these GitHub logins (default: current gh user)')
+    .option('--no-prs', 'Skip the GitHub PR lookup (commits only)')
+    .addHelpText('after', `
+Examples:
+  agents output                       Last 7 days: burn, output tokens, PRs, commits, ratios
+  agents output --since 30d           Last 30 days
+  agents output --by day --json       Machine-readable daily burn/output rollup
+  agents output --repos-dir ~/work    Scan a different repo root for commits
+  agents output --login me --login alt-account   Count PRs across multiple accounts
+
+Burn (cost) is computed offline from a versioned per-model price table (${PRICING_VERSION}).
+Output tokens are the real generated tokens — NOT the cache-inflated total token count.
+`)
+    .action(async (options: OutputOptions) => {
+      await outputAction(options);
+    });
+}
+
+function resolveGroup(by: string | undefined): UsageRollupGroup {
+  if (by === undefined) return 'agent';
+  if (by === 'agent' || by === 'project' || by === 'day') return by;
+  console.error(chalk.red('error: --by must be one of: agent, project, day'));
+  process.exit(1);
+}
+
+/** Compact token formatter: 38.6M, 4.1K, 10.6B. */
+function formatCompact(n: number): string {
+  const abs = Math.abs(n);
+  if (abs >= 1e9) return `${(n / 1e9).toFixed(1)}B`;
+  if (abs >= 1e6) return `${(n / 1e6).toFixed(1)}M`;
+  if (abs >= 1e3) return `${(n / 1e3).toFixed(1)}K`;
+  return String(n);
+}
+
+async function outputAction(options: OutputOptions): Promise<void> {
+  const since = options.since ?? '7d';
+  const sinceMs = parseTimeFilter(since);
+
+  // Ensure the index is fresh (and migrated to v12 so output_tokens is populated)
+  // before we read the rollup.
+  await discoverSessions({ all: true, since, limit: 1 });
+
+  const filter: QueryOptions = { sinceMs };
+  const groupBy = resolveGroup(options.by);
+  const breakdown = queryUsageRollup({ ...filter, groupBy });
+
+  const totals = breakdown.reduce(
+    (acc, r) => {
+      acc.costUsd += r.costUsd;
+      acc.outputTokens += r.outputTokens;
+      acc.tokenCount += r.tokenCount;
+      acc.sessionCount += r.sessionCount;
+      acc.durationMs += r.durationMs;
+      return acc;
+    },
+    { costUsd: 0, outputTokens: 0, tokenCount: 0, sessionCount: 0, durationMs: 0 },
+  );
+
+  const reposDir = options.reposDir ?? path.join(os.homedir(), 'src');
+  const git = await collectGitOutput({
+    reposDir,
+    sinceMs,
+    authors: options.author,
+    logins: options.login,
+    includePrs: options.prs !== false,
+  });
+
+  const prsTotal = git.prsOpened + git.prsMerged;
+  const ratios = {
+    costPerPr: prsTotal > 0 ? totals.costUsd / prsTotal : null,
+    costPerCommit: git.commits > 0 ? totals.costUsd / git.commits : null,
+    outputTokensPerUsd: totals.costUsd > 0 ? totals.outputTokens / totals.costUsd : null,
+  };
+
+  // Agents whose CLIs record no cost — surfaced so the burn number stays honest.
+  const uncosted = breakdown.filter(r => groupBy === 'agent' && r.costUsd === 0).map(r => r.key);
+
+  if (options.json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          pricingVersion: PRICING_VERSION,
+          since,
+          burn: {
+            costUsd: totals.costUsd,
+            outputTokens: totals.outputTokens,
+            tokenCount: totals.tokenCount,
+            sessionCount: totals.sessionCount,
+            durationMs: totals.durationMs,
+          },
+          output: {
+            commits: git.commits,
+            prsOpened: git.prsOpened,
+            prsMerged: git.prsMerged,
+            reposScanned: git.reposScanned,
+            byAuthor: git.byAuthor,
+            authors: git.authors,
+            logins: git.logins,
+            ghAvailable: git.ghAvailable,
+          },
+          ratios,
+          breakdown: { by: groupBy, rows: breakdown },
+          notCounted: {
+            uncostedAgents: uncosted,
+            ghAvailable: git.ghAvailable,
+            note: 'Cloud runs (Rush/Codex/Factory) and unreachable machines are not included; run with --host <name> per machine.',
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return;
+  }
+
+  const out: string[] = [];
+  out.push(chalk.bold('Output') + chalk.gray(`  ·  pricing ${PRICING_VERSION}  ·  since ${since}`));
+  out.push(
+    '  ' +
+      `${chalk.green(formatUsd(totals.costUsd))} burned` +
+      chalk.gray('  ·  ') +
+      `${chalk.cyan(formatCompact(totals.outputTokens))} output tokens` +
+      chalk.gray('  ·  ') +
+      `${chalk.yellow(String(prsTotal))} PRs ${chalk.gray(`(${git.prsMerged} merged)`)}` +
+      chalk.gray('  ·  ') +
+      `${chalk.yellow(String(git.commits))} commits`,
+  );
+  // Burn-vs-output ratios.
+  const ratioParts: string[] = [];
+  if (ratios.costPerPr !== null) ratioParts.push(`${formatUsd(ratios.costPerPr)}/PR`);
+  if (ratios.costPerCommit !== null) ratioParts.push(`${formatUsd(ratios.costPerCommit)}/commit`);
+  if (ratios.outputTokensPerUsd !== null) ratioParts.push(`${formatCompact(Math.round(ratios.outputTokensPerUsd))} out-tok/$`);
+  if (ratioParts.length > 0) out.push(chalk.gray('  ' + ratioParts.join('  ·  ')));
+  out.push('');
+
+  if (totals.sessionCount === 0) {
+    out.push(chalk.gray('No sessions with cost data found. Run `agents sessions --all` to index, then retry.'));
+    console.log(out.join('\n'));
+    return;
+  }
+
+  // Burn/output breakdown table.
+  const groupLabel = groupBy;
+  out.push(chalk.bold(`By ${groupLabel}`));
+  const cols = terminalWidth();
+  const burnW = Math.max(...breakdown.map(r => formatUsd(r.costUsd).length), 4);
+  const outW = Math.max(...breakdown.map(r => formatCompact(r.outputTokens).length), 6);
+  const sessW = Math.max(...breakdown.map(r => String(r.sessionCount).length), 3);
+  const fixedW = 2 + 2 + burnW + 2 + outW + 2 + sessW + 8;
+  const keyW = Math.max(8, Math.min(Math.max(...breakdown.map(r => r.key.length), groupLabel.length), cols - fixedW));
+  out.push(
+    '  ' +
+      chalk.gray(padToWidth('', keyW)) +
+      '  ' +
+      chalk.gray(padToWidth('burn', burnW)) +
+      '  ' +
+      chalk.gray(padToWidth('output', outW)) +
+      '  ' +
+      chalk.gray('sessions'),
+  );
+  for (const r of breakdown) {
+    out.push(
+      '  ' +
+        padToWidth(truncateToWidth(r.key, keyW), keyW) +
+        '  ' +
+        chalk.green(padToWidth(formatUsd(r.costUsd), burnW)) +
+        '  ' +
+        chalk.cyan(padToWidth(formatCompact(r.outputTokens), outW)) +
+        '  ' +
+        chalk.gray(padToWidth(String(r.sessionCount), sessW)),
+    );
+  }
+  out.push('');
+
+  // Shipped-work detail.
+  out.push(chalk.bold('Shipped'));
+  out.push(
+    `  ${chalk.yellow(String(git.commits))} commits across ${git.reposScanned} repos` +
+      chalk.gray(`  (authors: ${git.authors.length > 0 ? git.authors.join(', ') : 'none detected'})`),
+  );
+  if (git.ghAvailable) {
+    out.push(
+      `  ${chalk.yellow(String(git.prsOpened))} PRs opened, ${chalk.yellow(String(git.prsMerged))} merged` +
+        chalk.gray(`  (logins: ${git.logins.join(', ')})`),
+    );
+  } else {
+    out.push(chalk.gray('  PRs: gh unavailable or unauthed — not counted'));
+  }
+  out.push('');
+
+  // Honesty footer.
+  const notes: string[] = [];
+  if (uncosted.length > 0) notes.push(`no price table for: ${uncosted.join(', ')} (burn undercounts)`);
+  notes.push('cloud runs (Rush/Codex/Factory) and unreachable machines not counted — use --host <name> per machine');
+  out.push(chalk.gray('not counted: ' + notes.join('  ·  ')));
+  if (totals.durationMs > 0) out.push(chalk.gray(`agent wall-clock: ${formatDuration(totals.durationMs)}`));
+
+  console.log(out.join('\n'));
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -113,6 +113,7 @@ import {
   loadFactory,
   loadUsage,
   loadCost,
+  loadOutput,
   loadBudget,
   loadAlias,
   loadPty,
@@ -814,6 +815,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadFactory);
   await reg(loadUsage);
   await reg(loadCost);
+  await reg(loadOutput);
   await reg(loadBudget);
   await reg(loadAlias);
   await reg(loadPty);

--- a/apps/cli/src/lib/hosts/passthrough.ts
+++ b/apps/cli/src/lib/hosts/passthrough.ts
@@ -41,6 +41,7 @@ const REMOTE_PASSTHROUGH: Record<string, RemoteSpec> = {
   view: {},
   usage: {},
   cost: {},
+  output: {},
   doctor: {},
   inspect: {},
   list: {},

--- a/apps/cli/src/lib/output/__tests__/git-output.test.ts
+++ b/apps/cli/src/lib/output/__tests__/git-output.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { findGitRepos, collectCommits, toSearchDate } from '../git-output.js';
+
+let root: string;
+let repo: string;
+
+/** Run a git command in `repo`, optionally stamping author+committer dates. */
+function git(args: string[], dateIso?: string): void {
+  const env = { ...process.env } as Record<string, string>;
+  if (dateIso) {
+    env.GIT_AUTHOR_DATE = dateIso;
+    env.GIT_COMMITTER_DATE = dateIso;
+  }
+  execFileSync('git', ['-C', repo, ...args], { env, stdio: 'pipe' });
+}
+
+/** Commit an empty change authored by `email` at `dateIso`. */
+function commitAs(email: string, name: string, message: string, dateIso: string): void {
+  git(['-c', `user.email=${email}`, '-c', `user.name=${name}`, 'commit', '--allow-empty', '-m', message], dateIso);
+}
+
+function daysAgoIso(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'git-output-test-'));
+  repo = path.join(root, 'nested', 'my-repo');
+  fs.mkdirSync(repo, { recursive: true });
+  execFileSync('git', ['-C', repo, 'init', '-q'], { stdio: 'pipe' });
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('findGitRepos', () => {
+  it('discovers a git repo nested below the root and does not descend into it', () => {
+    // A repo nested two levels down; a decoy non-repo dir alongside.
+    fs.mkdirSync(path.join(root, 'nested', 'not-a-repo'), { recursive: true });
+    const repos = findGitRepos(root, 4);
+    expect(repos).toContain(repo);
+    // The repo's own .git must not be returned as a separate repo.
+    expect(repos.every(r => !r.endsWith('.git'))).toBe(true);
+  });
+
+  it('respects maxDepth', () => {
+    // repo is at depth 2 (nested/my-repo); depth 1 should not find it.
+    expect(findGitRepos(root, 1)).not.toContain(repo);
+  });
+});
+
+describe('collectCommits', () => {
+  beforeEach(() => {
+    // Commit oldest-first so committer dates are monotonic (newest = HEAD), as in
+    // any real repo. `git log --since` stops traversing once it hits a commit
+    // older than the window, so an out-of-order HEAD would hide newer ancestors.
+    commitAs('alice@example.com', 'Alice', 'old by alice', daysAgoIso(30));
+    commitAs('bob@example.com', 'Bob', 'recent by bob', daysAgoIso(2));
+    commitAs('alice@example.com', 'Alice', 'recent by alice', daysAgoIso(1));
+  });
+
+  it('counts commits by all given authors within the window, tallied per author', async () => {
+    const since = daysAgoIso(7);
+    const { total, byAuthor } = await collectCommits([repo], since, ['alice@example.com', 'bob@example.com']);
+    expect(total).toBe(2); // the 30-day-old one is excluded by the window
+    const map = Object.fromEntries(byAuthor.map(a => [a.author, a.commits]));
+    expect(map['alice@example.com']).toBe(1);
+    expect(map['bob@example.com']).toBe(1);
+  });
+
+  it('restricts to the named author', async () => {
+    const since = daysAgoIso(7);
+    const { total } = await collectCommits([repo], since, ['alice@example.com']);
+    expect(total).toBe(1); // bob excluded by author, old-alice excluded by window
+  });
+
+  it('widening the window includes older commits', async () => {
+    const since = daysAgoIso(60);
+    const { total } = await collectCommits([repo], since, ['alice@example.com']);
+    expect(total).toBe(2); // both alice commits now in range
+  });
+
+  it('is case-insensitive on author email', async () => {
+    const since = daysAgoIso(7);
+    const { total } = await collectCommits([repo], since, ['ALICE@EXAMPLE.COM']);
+    expect(total).toBe(1);
+  });
+
+  it('tolerates a non-repo path without throwing', async () => {
+    const { total } = await collectCommits([path.join(root, 'does-not-exist')], daysAgoIso(7), ['alice@example.com']);
+    expect(total).toBe(0);
+  });
+});
+
+describe('toSearchDate', () => {
+  it('formats epoch ms as a UTC YYYY-MM-DD date', () => {
+    expect(toSearchDate(0)).toBe('1970-01-01');
+    expect(toSearchDate(Date.UTC(2026, 6, 13, 23, 59))).toBe('2026-07-13');
+  });
+});

--- a/apps/cli/src/lib/output/__tests__/git-output.test.ts
+++ b/apps/cli/src/lib/output/__tests__/git-output.test.ts
@@ -96,6 +96,18 @@ describe('collectCommits', () => {
     const { total } = await collectCommits([path.join(root, 'does-not-exist')], daysAgoIso(7), ['alice@example.com']);
     expect(total).toBe(0);
   });
+
+  it('dedupes the same commit seen via multiple clones (the --all-hosts fix)', async () => {
+    // A second clone of the repo exposes the identical SHAs to git log. Counting
+    // both clones must NOT double the commits — SHA identity collapses them.
+    const clone = path.join(root, 'clone');
+    execFileSync('git', ['clone', '-q', repo, clone], { stdio: 'pipe' });
+    const since = daysAgoIso(7);
+    const one = await collectCommits([repo], since, ['alice@example.com', 'bob@example.com']);
+    const both = await collectCommits([repo, clone], since, ['alice@example.com', 'bob@example.com']);
+    expect(both.total).toBe(one.total); // deduped, not 2x
+    expect(both.shas.sort()).toEqual(one.shas.sort());
+  });
 });
 
 describe('toSearchDate', () => {

--- a/apps/cli/src/lib/output/git-output.ts
+++ b/apps/cli/src/lib/output/git-output.ts
@@ -1,0 +1,251 @@
+/**
+ * Git / GitHub "output" collector — the shipped-work half of `agents output`.
+ *
+ * `agents cost` answers "what did we burn?"; this answers "what did we ship?".
+ * It counts commits (across every author identity, so multi-account totals stay
+ * correct regardless of which `gh` login is active) and PRs opened / merged in a
+ * time window. Pure `git`/`gh` over child_process — no server, no telemetry,
+ * mirroring the offline spirit of the cost rollup.
+ */
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const execFileAsync = promisify(execFile);
+
+/** Commit tally for one author email. */
+export interface AuthorCommits {
+  author: string;
+  commits: number;
+}
+
+/** The shipped-work rollup for a window. */
+export interface GitOutputSummary {
+  reposScanned: number;
+  commits: number;
+  byAuthor: AuthorCommits[];
+  prsOpened: number;
+  prsMerged: number;
+  /** false when `gh` is missing/unauthed — PR counts are then 0 and not trustworthy. */
+  ghAvailable: boolean;
+  /** Author emails counted as "ours". */
+  authors: string[];
+  /** gh logins queried for PRs. */
+  logins: string[];
+  sinceIso: string;
+}
+
+export interface GitOutputOptions {
+  /** Root scanned for git repos (e.g. ~/src). */
+  reposDir: string;
+  /** Window start, epoch ms. */
+  sinceMs: number;
+  /** Restrict commit authorship to these emails; default: identities discovered from git config. */
+  authors?: string[];
+  /** gh logins to search PRs for; default: the current `gh api user` login. */
+  logins?: string[];
+  /** Repo discovery depth below reposDir (default 4 — covers ~/src/host/org/repo). */
+  maxDepth?: number;
+  /** Query PRs via gh (default true). */
+  includePrs?: boolean;
+}
+
+/** Directory names never descended into during repo discovery. */
+const SKIP_DIRS = new Set(['node_modules', '.git', '.agents', '.worktrees', 'dist', 'build', '.next', '.cache']);
+
+/**
+ * Find git repositories under `root` up to `maxDepth` levels deep. A directory
+ * with a `.git` entry is a repo and is NOT descended into (so nested worktrees
+ * / submodules don't double-count).
+ */
+export function findGitRepos(root: string, maxDepth = 4): string[] {
+  const repos: string[] = [];
+  const walk = (dir: string, depth: number): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return; // unreadable dir — skip
+    }
+    if (entries.some(e => e.name === '.git')) {
+      repos.push(dir);
+      return; // don't descend into a repo
+    }
+    if (depth >= maxDepth) return;
+    for (const e of entries) {
+      if (!e.isDirectory() || e.name.startsWith('.') || SKIP_DIRS.has(e.name)) continue;
+      walk(path.join(dir, e.name), depth + 1);
+    }
+  };
+  walk(root, 0);
+  return repos;
+}
+
+/** git output for one repo, tolerant of empty/broken repos. */
+async function repoLog(repoDir: string, sinceIso: string): Promise<string[]> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['-C', repoDir, 'log', '--all', '--no-merges', `--since=${sinceIso}`, '--pretty=format:%ae'],
+      { maxBuffer: 64 * 1024 * 1024 },
+    );
+    return stdout.split('\n').map(s => s.trim()).filter(Boolean);
+  } catch {
+    return []; // no commits yet / not a real repo / detached weirdness
+  }
+}
+
+/**
+ * Discover the user's own author emails so commit counts exclude teammates.
+ * Union of `git config --global user.email` and each repo's local `user.email`.
+ */
+async function discoverAuthorEmails(repos: string[]): Promise<string[]> {
+  const emails = new Set<string>();
+  try {
+    const { stdout } = await execFileAsync('git', ['config', '--global', 'user.email']);
+    const e = stdout.trim();
+    if (e) emails.add(e.toLowerCase());
+  } catch {
+    /* no global identity */
+  }
+  await Promise.all(
+    repos.map(async repo => {
+      try {
+        const { stdout } = await execFileAsync('git', ['-C', repo, 'config', '--get', 'user.email']);
+        const e = stdout.trim();
+        if (e) emails.add(e.toLowerCase());
+      } catch {
+        /* repo has no local identity */
+      }
+    }),
+  );
+  return [...emails];
+}
+
+/** Count commits by our authors across all repos, tallied per email. */
+export async function collectCommits(
+  repos: string[],
+  sinceIso: string,
+  authors: string[],
+): Promise<{ total: number; byAuthor: AuthorCommits[] }> {
+  const ours = new Set(authors.map(a => a.toLowerCase()));
+  const tally = new Map<string, number>();
+  const logs = await Promise.all(repos.map(r => repoLog(r, sinceIso)));
+  for (const lines of logs) {
+    for (const email of lines) {
+      const key = email.toLowerCase();
+      if (ours.size > 0 && !ours.has(key)) continue;
+      tally.set(key, (tally.get(key) ?? 0) + 1);
+    }
+  }
+  const byAuthor = [...tally.entries()]
+    .map(([author, commits]) => ({ author, commits }))
+    .sort((a, b) => b.commits - a.commits);
+  const total = byAuthor.reduce((s, r) => s + r.commits, 0);
+  return { total, byAuthor };
+}
+
+/** Resolve the current gh login, or null if gh is unavailable/unauthed. */
+async function currentGhLogin(): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('gh', ['api', 'user', '--jq', '.login']);
+    const login = stdout.trim();
+    return login || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Count PRs matching a gh search query (author + date), returning null on failure. */
+async function ghSearchCount(args: string[]): Promise<number | null> {
+  try {
+    const { stdout } = await execFileAsync('gh', [...args, '--limit', '1000', '--json', 'number'], {
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    const rows = JSON.parse(stdout);
+    return Array.isArray(rows) ? rows.length : 0;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Count PRs opened and merged in the window across the given logins. `gh search
+ * prs` searches all of GitHub, so one authed gh can cover multiple accounts'
+ * logins. Returns ghAvailable=false if gh can't be reached at all.
+ */
+export async function collectPrs(
+  logins: string[],
+  sinceDate: string,
+): Promise<{ opened: number; merged: number; logins: string[]; ghAvailable: boolean }> {
+  let resolved = logins;
+  if (resolved.length === 0) {
+    const login = await currentGhLogin();
+    if (!login) return { opened: 0, merged: 0, logins: [], ghAvailable: false };
+    resolved = [login];
+  }
+  let opened = 0;
+  let merged = 0;
+  let anyOk = false;
+  for (const login of resolved) {
+    const o = await ghSearchCount(['search', 'prs', '--author', login, '--created', `>=${sinceDate}`]);
+    const m = await ghSearchCount(['search', 'prs', '--author', login, '--merged', `>=${sinceDate}`]);
+    if (o !== null) {
+      opened += o;
+      anyOk = true;
+    }
+    if (m !== null) {
+      merged += m;
+      anyOk = true;
+    }
+  }
+  return { opened, merged, logins: resolved, ghAvailable: anyOk };
+}
+
+/** Format an epoch-ms as a YYYY-MM-DD date (UTC), for gh's date-range search. */
+export function toSearchDate(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+/**
+ * Collect the full shipped-work summary for a window: commits (across accounts)
+ * plus PRs opened/merged.
+ */
+export async function collectGitOutput(options: GitOutputOptions): Promise<GitOutputSummary> {
+  const reposDir = options.reposDir.replace(/^~(?=$|\/)/, os.homedir());
+  const sinceIso = new Date(options.sinceMs).toISOString();
+  const sinceDate = toSearchDate(options.sinceMs);
+  const repos = findGitRepos(reposDir, options.maxDepth ?? 4);
+
+  const authors = options.authors && options.authors.length > 0
+    ? options.authors.map(a => a.toLowerCase())
+    : await discoverAuthorEmails(repos);
+
+  const { total: commits, byAuthor } = await collectCommits(repos, sinceIso, authors);
+
+  let prsOpened = 0;
+  let prsMerged = 0;
+  let ghAvailable = false;
+  let logins = options.logins ?? [];
+  if (options.includePrs !== false) {
+    const prs = await collectPrs(logins, sinceDate);
+    prsOpened = prs.opened;
+    prsMerged = prs.merged;
+    ghAvailable = prs.ghAvailable;
+    logins = prs.logins;
+  }
+
+  return {
+    reposScanned: repos.length,
+    commits,
+    byAuthor,
+    prsOpened,
+    prsMerged,
+    ghAvailable,
+    authors,
+    logins,
+    sinceIso,
+  };
+}

--- a/apps/cli/src/lib/output/git-output.ts
+++ b/apps/cli/src/lib/output/git-output.ts
@@ -28,6 +28,12 @@ export interface GitOutputSummary {
   byAuthor: AuthorCommits[];
   prsOpened: number;
   prsMerged: number;
+  /**
+   * Deduped commit SHAs authored by us in the window. Carried so `--all-hosts`
+   * can UNION across machines — a repo cloned on several boxes exposes the same
+   * commits to `git log` on each, so summing counts would multi-count.
+   */
+  commitShas: string[];
   /** false when `gh` is missing/unauthed — PR counts are then 0 and not trustworthy. */
   ghAvailable: boolean;
   /** Author emails counted as "ours". */
@@ -83,15 +89,27 @@ export function findGitRepos(root: string, maxDepth = 4): string[] {
   return repos;
 }
 
-/** git output for one repo, tolerant of empty/broken repos. */
-async function repoLog(repoDir: string, sinceIso: string): Promise<string[]> {
+/** One commit's identity: its SHA and author email. */
+interface CommitRef {
+  sha: string;
+  email: string;
+}
+
+/** git log for one repo (SHA + author email per commit), tolerant of empty/broken repos. */
+async function repoLog(repoDir: string, sinceIso: string): Promise<CommitRef[]> {
   try {
     const { stdout } = await execFileAsync(
       'git',
-      ['-C', repoDir, 'log', '--all', '--no-merges', `--since=${sinceIso}`, '--pretty=format:%ae'],
+      ['-C', repoDir, 'log', '--all', '--no-merges', `--since=${sinceIso}`, '--pretty=format:%H%x09%ae'],
       { maxBuffer: 64 * 1024 * 1024 },
     );
-    return stdout.split('\n').map(s => s.trim()).filter(Boolean);
+    const refs: CommitRef[] = [];
+    for (const line of stdout.split('\n')) {
+      const tab = line.indexOf('\t');
+      if (tab < 0) continue;
+      refs.push({ sha: line.slice(0, tab).trim(), email: line.slice(tab + 1).trim() });
+    }
+    return refs;
   } catch {
     return []; // no commits yet / not a real repo / detached weirdness
   }
@@ -124,27 +142,33 @@ async function discoverAuthorEmails(repos: string[]): Promise<string[]> {
   return [...emails];
 }
 
-/** Count commits by our authors across all repos, tallied per email. */
+/**
+ * Count commits by our authors across all repos, deduped by SHA (so the same
+ * commit reachable via multiple repo clones/worktrees on this machine — or, at
+ * the fleet layer, across machines — is counted once), tallied per email.
+ */
 export async function collectCommits(
   repos: string[],
   sinceIso: string,
   authors: string[],
-): Promise<{ total: number; byAuthor: AuthorCommits[] }> {
+): Promise<{ total: number; byAuthor: AuthorCommits[]; shas: string[] }> {
   const ours = new Set(authors.map(a => a.toLowerCase()));
   const tally = new Map<string, number>();
+  const seen = new Set<string>();
   const logs = await Promise.all(repos.map(r => repoLog(r, sinceIso)));
-  for (const lines of logs) {
-    for (const email of lines) {
+  for (const refs of logs) {
+    for (const { sha, email } of refs) {
       const key = email.toLowerCase();
       if (ours.size > 0 && !ours.has(key)) continue;
+      if (seen.has(sha)) continue; // same commit seen via another clone/ref
+      seen.add(sha);
       tally.set(key, (tally.get(key) ?? 0) + 1);
     }
   }
   const byAuthor = [...tally.entries()]
     .map(([author, commits]) => ({ author, commits }))
     .sort((a, b) => b.commits - a.commits);
-  const total = byAuthor.reduce((s, r) => s + r.commits, 0);
-  return { total, byAuthor };
+  return { total: seen.size, byAuthor, shas: [...seen] };
 }
 
 /** Resolve the current gh login, or null if gh is unavailable/unauthed. */
@@ -223,7 +247,7 @@ export async function collectGitOutput(options: GitOutputOptions): Promise<GitOu
     ? options.authors.map(a => a.toLowerCase())
     : await discoverAuthorEmails(repos);
 
-  const { total: commits, byAuthor } = await collectCommits(repos, sinceIso, authors);
+  const { total: commits, byAuthor, shas: commitShas } = await collectCommits(repos, sinceIso, authors);
 
   let prsOpened = 0;
   let prsMerged = 0;
@@ -241,6 +265,7 @@ export async function collectGitOutput(options: GitOutputOptions): Promise<GitOu
     reposScanned: repos.length,
     commits,
     byAuthor,
+    commitShas,
     prsOpened,
     prsMerged,
     ghAvailable,

--- a/apps/cli/src/lib/session/__tests__/db.test.ts
+++ b/apps/cli/src/lib/session/__tests__/db.test.ts
@@ -141,7 +141,7 @@ describe('migration v5 -> v6 adds cost/duration columns', () => {
   it('schema_version is recorded as the current version', () => {
     const db = getDB();
     const row = db.prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string };
-    expect(row.value).toBe('11');
+    expect(row.value).toBe('12');
   });
 
   it('v10 unifies name into label — the separate `name` column is dropped', () => {

--- a/apps/cli/src/lib/session/__tests__/parse-time-filter.test.ts
+++ b/apps/cli/src/lib/session/__tests__/parse-time-filter.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { parseTimeFilter } from '../discover.js';
+
+const MIN = 60_000;
+const HOUR = 3_600_000;
+const DAY = 86_400_000;
+
+/** parseTimeFilter returns an absolute epoch-ms; assert the delta from now. */
+function agoMs(input: string): number {
+  return Date.now() - parseTimeFilter(input);
+}
+
+describe('parseTimeFilter', () => {
+  it('supports minute/hour/day/week units', () => {
+    expect(agoMs('1m')).toBeCloseTo(MIN, -3); // minutes, unchanged
+    expect(agoMs('1h')).toBeCloseTo(HOUR, -4);
+    expect(agoMs('24h')).toBeCloseTo(24 * HOUR, -5);
+    expect(agoMs('7d')).toBeCloseTo(7 * DAY, -6);
+    expect(agoMs('4w')).toBeCloseTo(28 * DAY, -6);
+  });
+
+  it('supports month (mo) and year (y) units', () => {
+    expect(agoMs('1mo')).toBeCloseTo(30 * DAY, -7);
+    expect(agoMs('3mo')).toBeCloseTo(90 * DAY, -7);
+    expect(agoMs('1y')).toBeCloseTo(365 * DAY, -8);
+  });
+
+  it('does not read "1mo" as "1m" + stray text', () => {
+    // 1mo (month) must be far larger than 1m (minute).
+    expect(agoMs('1mo')).toBeGreaterThan(agoMs('1m') * 1000);
+  });
+
+  it('parses ISO dates as absolute timestamps', () => {
+    expect(parseTimeFilter('2026-01-01')).toBe(new Date('2026-01-01').getTime());
+  });
+
+  it('returns 0 for unparseable input', () => {
+    expect(parseTimeFilter('garbage')).toBe(0);
+    expect(parseTimeFilter('5x')).toBe(0);
+  });
+});

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -17,7 +17,7 @@ const SESSIONS_DIR = getSessionsDir();
 const DB_PATH = getSessionsDbPath();
 
 /** Current schema version; bumped when migrations are added. */
-const SCHEMA_VERSION = 11;
+const SCHEMA_VERSION = 12;
 
 /**
  * Canonicalize a file path for use as a scan_ledger key. The same physical
@@ -59,6 +59,7 @@ CREATE TABLE IF NOT EXISTS sessions (
   label TEXT,
   message_count INTEGER,
   token_count INTEGER,
+  output_tokens INTEGER,
   cost_usd REAL,
   duration_ms INTEGER,
   file_path TEXT NOT NULL,
@@ -120,6 +121,7 @@ export interface SessionRow {
   label: string | null;
   message_count: number | null;
   token_count: number | null;
+  output_tokens: number | null;
   cost_usd: number | null;
   duration_ms: number | null;
   file_path: string;
@@ -287,6 +289,16 @@ function migrateSchema(db: Database.Database, fromVersion: number): void {
     // column; rescan to backfill.
     const cols = db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>;
     if (!cols.some(c => c.name === 'plan')) db.exec(`ALTER TABLE sessions ADD COLUMN plan TEXT`);
+    db.exec(`DELETE FROM scan_ledger;`);
+  }
+
+  if (fromVersion < 12) {
+    // v11 → v12: `output_tokens` — the real generated-token count, kept separate
+    // from `token_count` (which sums cache-read/-write and so is dominated by
+    // cheap re-counted context). This is the honest "output" metric powering
+    // `agents output`. Additive column; rescan to backfill from transcripts.
+    const cols = db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>;
+    if (!cols.some(c => c.name === 'output_tokens')) db.exec(`ALTER TABLE sessions ADD COLUMN output_tokens INTEGER`);
     db.exec(`DELETE FROM scan_ledger;`);
   }
 }
@@ -515,13 +527,13 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
   INSERT INTO sessions (
     id, short_id, agent, version, account, timestamp, last_activity,
     project, cwd, git_branch, topic, label, message_count, token_count,
-    cost_usd, duration_ms,
+    output_tokens, cost_usd, duration_ms,
     file_path, file_mtime_ms, file_size, scanned_at, is_team_origin,
     pr_url, pr_number, worktree_slug, ticket_id, plan
   ) VALUES (
     @id, @short_id, @agent, @version, @account, @timestamp, @last_activity,
     @project, @cwd, @git_branch, @topic, @label, @message_count, @token_count,
-    @cost_usd, @duration_ms,
+    @output_tokens, @cost_usd, @duration_ms,
     @file_path, @file_mtime_ms, @file_size, @scanned_at, @is_team_origin,
     @pr_url, @pr_number, @worktree_slug, @ticket_id, @plan
   )
@@ -539,6 +551,7 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     label = excluded.label,
     message_count = excluded.message_count,
     token_count = excluded.token_count,
+    output_tokens = excluded.output_tokens,
     cost_usd = excluded.cost_usd,
     duration_ms = excluded.duration_ms,
     file_path = excluded.file_path,
@@ -597,6 +610,7 @@ export function upsertSession(meta: SessionMeta, content: string, scan?: ScanSta
     label: meta.label ?? null,
     message_count: meta.messageCount ?? null,
     token_count: meta.tokenCount ?? null,
+    output_tokens: meta.outputTokens ?? null,
     cost_usd: meta.costUsd ?? null,
     duration_ms: meta.durationMs ?? null,
     file_path: meta.filePath,
@@ -699,6 +713,7 @@ export function upsertSessionsBatch(
         label: meta.label ?? null,
         message_count: meta.messageCount ?? null,
         token_count: meta.tokenCount ?? null,
+        output_tokens: meta.outputTokens ?? null,
         cost_usd: meta.costUsd ?? null,
         duration_ms: meta.durationMs ?? null,
         file_path: meta.filePath,
@@ -883,6 +898,7 @@ function rowToMeta(row: SessionRow): SessionMeta {
     gitBranch: row.git_branch ?? undefined,
     messageCount: row.message_count ?? undefined,
     tokenCount: row.token_count ?? undefined,
+    outputTokens: row.output_tokens ?? undefined,
     costUsd: row.cost_usd ?? undefined,
     durationMs: row.duration_ms ?? undefined,
     version: row.version ?? undefined,
@@ -1066,6 +1082,8 @@ export interface UsageRollupRow {
   durationMs: number;
   sessionCount: number;
   tokenCount: number;
+  /** Real generated (output) tokens — excludes cache-read/-write context. */
+  outputTokens: number;
 }
 
 /** What to group a usage rollup by. */
@@ -1097,7 +1115,8 @@ export function queryUsageRollup(
       IFNULL(SUM(cost_usd), 0) AS costUsd,
       IFNULL(SUM(duration_ms), 0) AS durationMs,
       COUNT(*) AS sessionCount,
-      IFNULL(SUM(token_count), 0) AS tokenCount
+      IFNULL(SUM(token_count), 0) AS tokenCount,
+      IFNULL(SUM(output_tokens), 0) AS outputTokens
     FROM sessions
     ${clause}
     GROUP BY key

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -2896,7 +2896,9 @@ function parseKimiWireMetrics(sessionDir: string): { messageCount: number; token
 
 /** Parse a time filter string (relative like '7d' or ISO timestamp) into epoch milliseconds. */
 export function parseTimeFilter(input: string): number {
-  const relativeMatch = input.match(/^(\d+)([mhdw])$/i);
+  // Units: m=minute, h=hour, d=day, w=week, mo=month(30d), y=year(365d). `mo`
+  // must precede the single-letter alternatives so "1mo" isn't read as "1m"+"o".
+  const relativeMatch = input.match(/^(\d+)(mo|[mhdwy])$/i);
   if (relativeMatch) {
     const value = parseInt(relativeMatch[1], 10);
     const unit = relativeMatch[2].toLowerCase();
@@ -2904,6 +2906,8 @@ export function parseTimeFilter(input: string): number {
     if (unit === 'h') return Date.now() - value * 3_600_000;
     if (unit === 'd') return Date.now() - value * 86_400_000;
     if (unit === 'w') return Date.now() - value * 7 * 86_400_000;
+    if (unit === 'mo') return Date.now() - value * 30 * 86_400_000;
+    if (unit === 'y') return Date.now() - value * 365 * 86_400_000;
   }
   const ts = new Date(input).getTime();
   return Number.isNaN(ts) ? 0 : ts;

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -940,6 +940,7 @@ export async function readCodexMeta(
     topic: scan.topic,
     messageCount: scan.messageCount,
     tokenCount: scan.tokenCount,
+    outputTokens: scan.outputTokens,
     costUsd: scan.costUsd,
     durationMs: scan.durationMs,
     account: resolveAccount?.(),

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -1391,6 +1391,7 @@ async function scanOpenCodeIncremental(): Promise<void> {
         s.time_updated AS time_updated,
         COALESCE(stats.message_count, 0) AS message_count,
         stats.token_count AS token_count,
+        stats.output_tokens AS output_tokens,
         COALESCE(stats.has_token_data, 0) AS has_token_data
       FROM session s
       LEFT JOIN (

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -106,6 +106,8 @@ interface ClaudeSessionScan {
   topic?: string;
   messageCount: number;
   tokenCount?: number;
+  /** Real generated (output) tokens, excluding cache-read/-write context. */
+  outputTokens?: number;
   /** Total USD cost accumulated from per-(model, direction) token usage. */
   costUsd?: number;
   /** Wall-clock duration in ms between the first and last timestamped event. */
@@ -142,6 +144,8 @@ interface CodexSessionScan {
   topic?: string;
   messageCount: number;
   tokenCount?: number;
+  /** Real generated (output) tokens, excluding cache-read/-write context. */
+  outputTokens?: number;
   costUsd?: number;
   durationMs?: number;
   lastActivity?: string;
@@ -682,6 +686,7 @@ async function readClaudeMeta(
       label,
       messageCount: scan.messageCount,
       tokenCount: scan.tokenCount,
+      outputTokens: scan.outputTokens,
       costUsd: scan.costUsd,
       durationMs: scan.durationMs,
       isTeamOrigin,
@@ -706,6 +711,7 @@ async function readClaudeMeta(
       label,
       messageCount: scan.messageCount,
       tokenCount: scan.tokenCount,
+      outputTokens: scan.outputTokens,
       costUsd: scan.costUsd,
       durationMs: scan.durationMs,
       topic: scan.topic,
@@ -1071,6 +1077,7 @@ function readGeminiMeta(
   let topic: string | undefined;
   let messageCount = 0;
   let tokenCount = 0;
+  let outputTokens = 0;
   let sawTokenCount = false;
   let costUsd = 0;
   let sawCost = false;
@@ -1106,6 +1113,16 @@ function readGeminiMeta(
     if (total !== null) {
       tokenCount += total;
       sawTokenCount = true;
+    }
+    // Output tokens: sum directional generation fields per message (output +
+    // thoughts + tool), mirroring the cost path — never `tokens.total`, which
+    // may be cumulative and would double-count when summed.
+    const gtk = message.tokens;
+    if (gtk && typeof gtk === 'object') {
+      outputTokens +=
+        (typeof gtk.output === 'number' ? gtk.output : 0) +
+        (typeof gtk.thoughts === 'number' ? gtk.thoughts : 0) +
+        (typeof gtk.tool === 'number' ? gtk.tool : 0);
     }
 
     // Per-message cost: directional tokens × this message's model price.
@@ -1146,6 +1163,7 @@ function readGeminiMeta(
     topic,
     messageCount,
     tokenCount: sawTokenCount ? tokenCount : undefined,
+    outputTokens: sawTokenCount ? outputTokens : undefined,
     costUsd: sawCost ? costUsd : undefined,
     durationMs,
   };
@@ -1385,6 +1403,7 @@ async function scanOpenCodeIncremental(): Promise<void> {
             COALESCE(json_extract(data, '$.tokens.cache.read'), 0) +
             COALESCE(json_extract(data, '$.tokens.cache.write'), 0)
           ) AS token_count,
+          SUM(COALESCE(json_extract(data, '$.tokens.output'), 0)) AS output_tokens,
           MAX(CASE WHEN json_type(data, '$.tokens') IS NOT NULL THEN 1 ELSE 0 END) AS has_token_data
         FROM message
         GROUP BY session_id
@@ -1404,6 +1423,7 @@ async function scanOpenCodeIncremental(): Promise<void> {
       time_updated: unknown;
       message_count: unknown;
       token_count: unknown;
+      output_tokens: unknown;
       has_token_data: unknown;
     }>;
 
@@ -1421,6 +1441,7 @@ async function scanOpenCodeIncremental(): Promise<void> {
       const timeUpdated = asInt(row.time_updated);
       const messageCount = asInt(row.message_count);
       const tokenCount = asInt(row.token_count);
+      const outputTokens = asInt(row.output_tokens);
       const hasTokenData = asInt(row.has_token_data) === 1;
       const timestamp = isNaN(timeCreated) ? new Date().toISOString() : new Date(timeCreated).toISOString();
       // OpenCode is one shared DB, not one file per session — its row carries a
@@ -1443,6 +1464,7 @@ async function scanOpenCodeIncremental(): Promise<void> {
         topic,
         messageCount: Number.isNaN(messageCount) ? undefined : messageCount,
         tokenCount: hasTokenData && !Number.isNaN(tokenCount) ? tokenCount : undefined,
+        outputTokens: hasTokenData && !Number.isNaN(outputTokens) ? outputTokens : undefined,
       };
 
       entries.push({ meta, content: topic || '', scan: currentScan });
@@ -1937,6 +1959,7 @@ async function readDroidMeta(
     topic: scan.topic,
     messageCount: scan.messageCount,
     tokenCount,
+    outputTokens: settings.usage?.outputTokens,
     costUsd: costUsd > 0 ? costUsd : undefined,
     durationMs: scan.durationMs,
   };
@@ -2091,6 +2114,7 @@ export async function scanClaudeSession(filePath: string): Promise<ClaudeSession
   let entrypoint: string | undefined;
   let messageCount = 0;
   let tokenCount = 0;
+  let outputTokens = 0;
   let sawTokenCount = false;
   let costUsd = 0;
   let sawCost = false;
@@ -2246,6 +2270,7 @@ export async function scanClaudeSession(filePath: string): Promise<ClaudeSession
         tokenCount += usage;
         sawTokenCount = true;
       }
+      if (typeof usageObj?.output_tokens === 'number') outputTokens += usageObj.output_tokens;
       // Per-assistant-message cost: each event carries its own model, so we
       // multiply that event's raw token directions by that model's price.
       const model = parsed.message?.model;
@@ -2288,6 +2313,7 @@ export async function scanClaudeSession(filePath: string): Promise<ClaudeSession
     entrypoint,
     messageCount,
     tokenCount: sawTokenCount ? tokenCount : undefined,
+    outputTokens: sawTokenCount ? outputTokens : undefined,
     costUsd: sawCost ? costUsd : undefined,
     durationMs,
     lastActivity: lastTsMs !== undefined ? new Date(lastTsMs).toISOString() : undefined,
@@ -2451,6 +2477,9 @@ async function scanCodexSession(filePath: string): Promise<CodexSessionScan> {
     topic,
     messageCount,
     tokenCount,
+    outputTokens: lastTotalTokenUsage
+      ? (lastTotalTokenUsage.output_tokens ?? 0) + (lastTotalTokenUsage.reasoning_output_tokens ?? 0)
+      : undefined,
     costUsd,
     durationMs,
     lastActivity: lastTsMs !== undefined ? new Date(lastTsMs).toISOString() : undefined,
@@ -2806,7 +2835,7 @@ export function readKimiMeta(filePath: string): { meta: SessionMeta; content: st
   }
 
   // Parse wire.jsonl to extract message count and token usage
-  const { messageCount, tokenCount } = parseKimiWireMetrics(sessionDir);
+  const { messageCount, tokenCount, outputTokens } = parseKimiWireMetrics(sessionDir);
 
   const meta: SessionMeta = {
     id: sessionId,
@@ -2818,6 +2847,7 @@ export function readKimiMeta(filePath: string): { meta: SessionMeta; content: st
     topic,
     messageCount,
     tokenCount: tokenCount > 0 ? tokenCount : undefined,
+    outputTokens: outputTokens > 0 ? outputTokens : undefined,
   };
 
   return { meta, content: lastPrompt || '' };
@@ -2827,13 +2857,14 @@ export function readKimiMeta(filePath: string): { meta: SessionMeta; content: st
  * TODO: optimize to stream (like scanClaudeSession) to avoid loading large files into memory.
  * For now, synchronous readFileSync matches the pattern of reading state.json and is acceptable
  * since session dirs are usually fresh in FS cache during incremental scans. */
-function parseKimiWireMetrics(sessionDir: string): { messageCount: number; tokenCount: number } {
+function parseKimiWireMetrics(sessionDir: string): { messageCount: number; tokenCount: number; outputTokens: number } {
   const wirePath = path.join(sessionDir, 'agents', 'main', 'wire.jsonl');
   let messageCount = 0;
   let tokenCount = 0;
+  let outputTokens = 0;
 
   if (!fs.existsSync(wirePath)) {
-    return { messageCount: 0, tokenCount: 0 };
+    return { messageCount: 0, tokenCount: 0, outputTokens: 0 };
   }
 
   try {
@@ -2848,6 +2879,7 @@ function parseKimiWireMetrics(sessionDir: string): { messageCount: number; token
           // Kimi usage structure: inputOther + output + inputCacheRead + inputCacheCreation
           const u = event.usage;
           tokenCount += (u.inputOther || 0) + (u.output || 0) + (u.inputCacheRead || 0) + (u.inputCacheCreation || 0);
+          outputTokens += (u.output || 0);
         }
       } catch {
         // Malformed line, skip
@@ -2857,7 +2889,7 @@ function parseKimiWireMetrics(sessionDir: string): { messageCount: number; token
     // If wire.jsonl can't be read, return 0s (graceful degradation)
   }
 
-  return { messageCount, tokenCount };
+  return { messageCount, tokenCount, outputTokens };
 }
 
 /** Parse a time filter string (relative like '7d' or ISO timestamp) into epoch milliseconds. */

--- a/apps/cli/src/lib/session/types.ts
+++ b/apps/cli/src/lib/session/types.ts
@@ -74,6 +74,8 @@ export interface SessionMeta {
   gitBranch?: string;
   messageCount?: number;
   tokenCount?: number;
+  /** Real generated (output) tokens — excludes cache-read/-write context (issue: `agents output`). */
+  outputTokens?: number;
   /** Total USD cost, computed at scan time from per-model token usage (issue #323). */
   costUsd?: number;
   /** Wall-clock duration in ms (lastTs − firstTs), persisted at scan time. */

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -71,6 +71,7 @@ export const loadDrive: ModuleLoader = async () => (await import('../../commands
 export const loadFactory: ModuleLoader = async () => (await import('../../commands/factory.js')).registerFactoryCommands;
 export const loadUsage: ModuleLoader = async () => (await import('../../commands/usage.js')).registerUsageCommand;
 export const loadCost: ModuleLoader = async () => (await import('../../commands/cost.js')).registerCostCommand;
+export const loadOutput: ModuleLoader = async () => (await import('../../commands/output.js')).registerOutputCommand;
 export const loadBudget: ModuleLoader = async () => (await import('../../commands/budget.js')).registerBudgetCommand;
 export const loadAlias: ModuleLoader = async () => (await import('../../commands/alias.js')).registerAliasCommand;
 export const loadPty: ModuleLoader = async () => (await import('../../commands/pty.js')).registerPtyCommands;
@@ -167,6 +168,7 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   factory: [loadFactory],
   usage: [loadUsage],
   cost: [loadCost],
+  output: [loadOutput],
   budget: [loadBudget],
   alias: [loadAlias],
   pty: [loadPty],


### PR DESCRIPTION
## What

Adds **`agents output`** — a productivity command that shows **token burn vs. shipped output**: money/tokens spent against what actually shipped (real generated output tokens + commits across every git identity + PRs opened/merged), with burn-vs-output ratios (`$/PR`, `$/commit`, output-tokens/`$`).

## Why

Measuring "tokens used" from the session `token_count` is misleading: it sums cache-read/-write context **re-counted every turn**, so it runs **~300–900× the real generation**. On a real 7-day fleet slice:

| agent | output tokens (real) | token_count (inflated) | inflation |
|---|--:|--:|--:|
| claude | 27.2M | 8.64B | 318× |
| codex | 2.9M | 2.54B | 883× |
| kimi | 413.7K | 146.5M | 354× |

So the honest burn metric is **cost**, and the honest work metric is **output tokens + shipped PRs/commits** — never a single summed token count. `agents output` leads with that split.

## What's in it

1. **`output_tokens` per session (schema v12).** Scanners now record real generated tokens separately from `token_count` for claude, codex, gemini, opencode, kimi, and droid; surfaced via `queryUsageRollup`. Additive migration, backfilled on the next scan (first run re-indexes once, same as prior schema bumps).
2. **Git/PR output collector** (`lib/output/git-output.ts`, new + tested against a real temp repo): commits across every author identity (correct multi-account totals regardless of active `gh` login) + PRs opened/merged via `gh search`.
3. **`agents output` command** — reuses `queryUsageRollup` + the pricing table for burn; composes the git output and ratios. Flags: `--since`, `--by agent|project|day`, `--repos-dir`, `--author`, `--login`, `--no-prs`, `--json`, `--host`.

## Sample (real, 7d)

```
Output  ·  pricing 2026-06-24  ·  since 7d
  $7041.78 burned  ·  30.4M output tokens  ·  569 commits
  $12.38/commit  ·  4.3K out-tok/$

By agent
               burn      output  sessions
  claude       $7041.64  27.2M   1091
  codex        $0.00     2.9M    87
  kimi         $0.00     413.7K  8
  opencode     $0.00     50.4K   1
  droid        $0.14     1.2K    1
  antigravity  $0.00     0       11
  rush         $0.00     0       111

Shipped
  569 commits across 4 repos  (authors: muqsitnawaz@gmail.com)

not counted: no price table for codex/kimi/opencode/antigravity/rush (burn undercounts)  ·  cloud runs (Rush/Codex/Factory) and unreachable machines — use --host per machine
```

## Tests

- `src/commands/output.test.ts` and `src/lib/output/__tests__/git-output.test.ts` — 13 new tests, all green (real temp git repo, no mocking; seeded DB for the rollup/ratio math).
- Full suite: the only failures are **pre-existing on `main`** in unrelated domains (`exec.test.ts`, `models.test.ts` codex flag wiring; `serve/server.test.ts` SSE) — none touch the session/token/output path (diff is session/db/discover/pricing-consumer only).

## Out of scope (fast-follow)

- Cloud-run accounting (Rush/Codex/Factory) — needs provider usage APIs.
- A merged `--all-hosts` fleet view (today `--host <name>` targets one machine).
- Pricing table entries for codex/kimi so their burn stops showing `$0`.

Session transcript (confidential): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/4b88e407-5eb1-4939-8eb0-8b32d850438c.jsonl`
