### PR TITLE
fix(release): recover Windows validation before 1.20.59

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- **Catch-up publishes now require the exact merged release PR and its full green matrix.** A package version already present on `main` no longer counts as release validation by itself: `release.sh` finds the merged `release/v<version>` PR, requires its merge SHA to equal current `main`, and rechecks every expected CI context before publishing. This closes the path that let 1.20.58 reach npm before its tag-triggered Windows matrix exposed failures. Source: `apps/cli/scripts/release.sh`.
+- **Windows release validation now matches portable path behavior.** Home-relative project paths normalize native separators to `/` before they are stored as `~/…`, and the systemd-manifest and remote-shell assertions now compare the escaped/quoted forms that the runtime deliberately emits. This restores the Windows Node 22/24 release matrix without weakening command escaping. Source: `apps/cli/src/lib/project-root.ts`, `apps/cli/src/lib/{project-root,daemon}.test.ts`, `apps/cli/src/lib/hosts/dispatch.test.ts`.
 - **OpenCode permissions write to the loaded config path (RUSH-1623).** Global config is `~/.config/opencode/opencode.jsonc` (not `~/.opencode/`); project config is `opencode.jsonc` at the project root. Source: `apps/cli/src/lib/permissions.ts`, `apps/cli/src/lib/agents.ts`.
 ## 1.20.58
 

--- a/apps/cli/scripts/release.sh
+++ b/apps/cli/scripts/release.sh
@@ -408,6 +408,9 @@ if [[ "$(git show "origin/$DEFAULT_BRANCH:apps/cli/package.json" 2>/dev/null | j
   MAIN_AT_TARGET=true   # a prior run already merged the chore(release) PR
 fi
 EXISTING_PR="$(gh pr list --head "$RELEASE_BRANCH" --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+MERGED_RELEASE_JSON="$(gh pr list --head "$RELEASE_BRANCH" --base "$DEFAULT_BRANCH" --state merged --limit 1 --json number,mergeCommit 2>/dev/null || echo '[]')"
+MERGED_RELEASE_PR="$(jq -r '.[0].number // empty' <<<"$MERGED_RELEASE_JSON")"
+MERGED_RELEASE_SHA="$(jq -r '.[0].mergeCommit.oid // empty' <<<"$MERGED_RELEASE_JSON")"
 
 # ----- Bail out here in DRY-RUN mode -----
 if ! $APPLY; then
@@ -418,6 +421,7 @@ if ! $APPLY; then
   gray "  $PHNX_PKG@$TARGET on npm     $($PHNX_TARGET_PUBLISHED && echo yes || echo no)"
   gray "  origin/$DEFAULT_BRANCH at $TARGET   $($MAIN_AT_TARGET && echo yes || echo no)"
   gray "  open release PR           ${EXISTING_PR:-none} ($RELEASE_BRANCH)"
+  gray "  merged release PR         ${MERGED_RELEASE_PR:-none} ($RELEASE_BRANCH)"
   echo
   yellow "Will run on --apply (NPM_TOKEN from npmjs.com bundle, no 2FA prompts):"
   yellow "  1. roll CHANGELOG '## Unreleased' -> '## $TARGET'"
@@ -493,6 +497,19 @@ wait_for_ci_green() {
   (( problem == 0 )) || die "CI not all-green on PR #$pr -- PR left OPEN. Fix on a normal PR to $DEFAULT_BRANCH, then re-run this script."
   green "CI all-green on PR #$pr."
 }
+
+# A prior normal release run can merge its PR and then fail before publishing.
+# Re-running must reuse that exact, already-reviewed tree — never treat a manual
+# package.json bump on main as proof that the full release matrix ran. This is
+# the catch-up hole that let 1.20.58 publish before its Windows tag matrix failed.
+if $MAIN_AT_TARGET && ! $PHNX_TARGET_PUBLISHED; then
+  [[ -n "$MERGED_RELEASE_PR" && -n "$MERGED_RELEASE_SHA" ]] \
+    || die "main is already at $TARGET but no merged $RELEASE_BRANCH PR exists -- refusing an unverified catch-up publish; cut the next patch through the normal release PR flow"
+  [[ "$MERGED_RELEASE_SHA" == "$BASE_SHA" ]] \
+    || die "merged release PR #$MERGED_RELEASE_PR ended at ${MERGED_RELEASE_SHA:0:9}, but main is now ${BASE_SHA:0:9} -- refusing to publish unvalidated commits under $TARGET"
+  bold "Re-validating CI from merged release PR #$MERGED_RELEASE_PR before catch-up publish..."
+  wait_for_ci_green "$MERGED_RELEASE_PR"
+fi
 
 # ----- Open (or reuse) the release PR + merge, unless already merged -----
 if ! $MAIN_AT_TARGET; then

--- a/apps/cli/src/lib/daemon.test.ts
+++ b/apps/cli/src/lib/daemon.test.ts
@@ -33,6 +33,9 @@ import {
   removeDaemonPid,
 } from './daemon.js';
 import { ipcEndpoint } from './platform/index.js';
+
+const systemdQuote = (value: string): string =>
+  `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 import {
   secretsKeychainItem,
   setKeychainToken,
@@ -213,11 +216,8 @@ describe('generateSystemdUnit', () => {
     fs.writeFileSync(indexJs, '');
     process.argv[1] = indexJs;
     try {
-      // Mirror systemdExecArg's quoting (backslashes escape for systemd) so
-      // the expectation holds on Windows paths too, not just POSIX ones.
-      const quote = (v: string) => `"${v.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
       expect(generateSystemdUnit()).toContain(
-        `ExecStart=${[process.execPath, indexJs, 'daemon', '_run'].map(quote).join(' ')}`,
+        `ExecStart=${[process.execPath, indexJs, 'daemon', '_run'].map(systemdQuote).join(' ')}`,
       );
     } finally {
       process.argv[1] = savedArgv1;
@@ -242,9 +242,9 @@ describe('service manifest CLI entry injection', () => {
       const plist = generateLaunchdPlist(null, installedEntry);
       const unit = generateSystemdUnit(null, installedEntry);
       expect(plist).toContain(`<string>${installedEntry}</string>`);
-      expect(unit).toContain(installedEntry);
+      expect(unit).toContain(systemdQuote(installedEntry));
       expect(plist).not.toContain(postinstallEntry);
-      expect(unit).not.toContain(postinstallEntry);
+      expect(unit).not.toContain(systemdQuote(postinstallEntry));
     } finally {
       process.argv[1] = savedArgv1;
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/apps/cli/src/lib/hosts/dispatch.test.ts
+++ b/apps/cli/src/lib/hosts/dispatch.test.ts
@@ -123,7 +123,7 @@ describe('remoteCdPrefix', () => {
 
   it('does NOT re-root a raw local-home absolute — only ~/$HOME anchor here (exec.ts makes --cwd portable)', () => {
     const p = `${LOCAL_HOME}/src/x`;
-    expect(remoteCdPrefix(p)).toBe(`cd ${p} && `);
+    expect(remoteCdPrefix(p)).toBe(`cd ${shellQuote(p)} && `);
   });
 
   it('maps bare ~ / $HOME to "$HOME"', () => {

--- a/apps/cli/src/lib/project-root.test.ts
+++ b/apps/cli/src/lib/project-root.test.ts
@@ -109,8 +109,9 @@ describe('inferProjectRoot', () => {
 
   it('returns the directory ABOVE the git root, resolved from a nested cwd', async () => {
     const root = await inferProjectRoot(path.join(repo, 'sub', 'deep'));
-    // tmp is outside $HOME, so it stays absolute — realpath to dodge /var → /private/var on macOS.
-    expect(root).toBe(fs.realpathSync(tmp));
+    // Windows places os.tmpdir() under HOME; compare through the same portable
+    // storage contract. realpath also dodges /var → /private/var on macOS.
+    expect(root).toBe(toHomeRelative(fs.realpathSync(tmp)));
   });
 
   it('resolves the MAIN repo root from inside a linked worktree (not the worktree dir)', async () => {
@@ -118,7 +119,7 @@ describe('inferProjectRoot', () => {
     fs.mkdirSync(path.dirname(wt), { recursive: true });
     execFileSync('git', ['worktree', 'add', '-q', wt], { cwd: repo });
     // Regression: naive --show-toplevel would yield <repo>/.agents/worktrees here.
-    expect(await inferProjectRoot(wt)).toBe(fs.realpathSync(tmp));
+    expect(await inferProjectRoot(wt)).toBe(toHomeRelative(fs.realpathSync(tmp)));
   });
 
   it('returns undefined when cwd is not inside a git repo', async () => {

--- a/apps/cli/src/lib/project-root.ts
+++ b/apps/cli/src/lib/project-root.ts
@@ -17,6 +17,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { readMeta, updateMeta } from './state.js';
 import { getMainRepoRoot } from './git.js';
+import { toPosix } from './platform/index.js';
 
 const HOME = process.env.HOME ?? os.homedir();
 
@@ -24,7 +25,7 @@ const HOME = process.env.HOME ?? os.homedir();
 export function toHomeRelative(abs: string): string {
   const rel = path.relative(HOME, abs);
   if (rel === '') return '~';
-  if (!rel.startsWith('..') && !path.isAbsolute(rel)) return `~/${rel}`;
+  if (!rel.startsWith('..') && !path.isAbsolute(rel)) return `~/${toPosix(rel)}`;
   return abs;
 }
 


### PR DESCRIPTION
## Outcome

Restores the Windows release matrix exposed by the v1.20.58 tag and prevents an unpublished catch-up release from bypassing its release PR CI.

## Changes

- Normalize home-relative project roots to portable `/` separators.
- Make project-root, dispatch, and daemon expectations platform-correct.
- Require a merged `release/vX.Y.Z` PR at the current main SHA, with green checks, before catch-up publishing.
- Record both recovery fixes in the changelog.

## Evidence

- `bun run build`: pass.
- `bun test src/lib/project-root.test.ts src/lib/hosts/dispatch.test.ts`: 39 pass, 1 skip, 0 fail.
- `bun test src/lib/daemon.test.ts -t "uses the explicitly installed CLI entry"`: 1 pass, 0 fail.
- `bash -n apps/cli/scripts/release.sh`: pass.
- The v1.20.58 tag run failed only the Windows Node 22/24 jobs with the assertions fixed here: https://github.com/phnx-labs/agents-cli/actions/runs/29297079992
- Windows branch validation will be attached before merge.

Public repository: confidential session transcript omitted. Local transcript: `/Users/muqsit/.agents/.history/versions/codex/0.144.1/home/.codex/sessions/2026/07/13/rollout-2026-07-13T15-19-28-019f5d90-5563-7a41-8879-ccaf0c6a60ba.jsonl`