### PR TITLE
release(factory): prepare 0.9.292

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -1,8 +1,3 @@
-## Unreleased
-
-- **Remote plan previews are isolated by source path (RUSH-1631).** Cache key is `host/sha1(path)/basename` so two worktrees sharing a plan basename no longer clobber each other. Source: `apps/factory/src/vscode/settings.vscode.ts`.
-- **Windows remote dispatch uses distinct PowerShell stdout/stderr log paths (RUSH-1622).** `Start-Process -RedirectStandardOutput` and `-RedirectStandardError` cannot share a file; use `.out.log` / `.err.log`. Source: `apps/factory/src/vscode/settings.vscode.ts`.
-
 # Changelog
 
 All notable changes to the Factory extension are documented here. Format follows
@@ -10,6 +5,15 @@ All notable changes to the Factory extension are documented here. Format follows
 `## [<version>]` section for the version being published.
 
 ## [Unreleased]
+
+## [0.9.292] - 2026-07-13
+
+- **Factory recognizes every current agents-cli harness.** The checked-in CLI
+  registry snapshot now includes Hermes and ForgeCode, keeping Factory's agent
+  metadata aligned with the canonical `AgentId` union. Source:
+  `src/core/agents.cli.ts`.
+- **Remote plan previews are isolated by source path (RUSH-1631).** Cache key is `host/sha1(path)/basename` so two worktrees sharing a plan basename no longer clobber each other. Source: `src/vscode/settings.vscode.ts`.
+- **Windows remote dispatch uses distinct PowerShell stdout/stderr log paths (RUSH-1622).** `Start-Process -RedirectStandardOutput` and `-RedirectStandardError` cannot share a file; use `.out.log` / `.err.log`. Source: `src/vscode/settings.vscode.ts`.
 
 - **Factory Floor group controls now support Subgroup (RUSH-1544).**
   The live feed and Backlog controls can render a second grouping axis, excluding

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -3,7 +3,7 @@
   "displayName": "Agents",
   "publisher": "swarmify",
   "description": "Run Claude, Codex, Gemini, Cursor, and other coding agents from one IDE workspace.",
-  "version": "0.9.291",
+  "version": "0.9.292",
   "license": "MIT",
   "author": "Muqsit Nawaz <dev@muqsitnawaz.com>",
   "icon": "assets/agents.png",

--- a/apps/factory/src/core/agents.cli.ts
+++ b/apps/factory/src/core/agents.cli.ts
@@ -29,6 +29,8 @@ export const CLI_AGENT_IDS = [
   'grok',
   'kimi',
   'droid',
+  'hermes',
+  'forge',
 ] as const;
 
 /** Mirror of the CLI's AgentId union. */
@@ -57,6 +59,8 @@ export const CLI_AGENT_META: Record<CliAgentId, CliAgentMeta> = {
   grok: { name: 'Grok', cliCommand: 'grok' },
   kimi: { name: 'Kimi', cliCommand: 'kimi' },
   droid: { name: 'Droid', cliCommand: 'droid' },
+  hermes: { name: 'Hermes', cliCommand: 'hermes' },
+  forge: { name: 'ForgeCode', cliCommand: 'forge' },
 };
 
 /** Type guard against the CLI agent id set. */


### PR DESCRIPTION
## Summary
- move the full Factory Unreleased ledger into `0.9.292` and bump the extension manifest
- repair the malformed changelog preamble so `# Changelog` is the document root again
- align Factory’s checked-in CLI registry with the canonical `AgentId` union by adding Hermes and ForgeCode

## Verification
- `bun test src/core/agents.cli.test.ts`: 2 pass, 0 fail, 50 expectations
- `bun run compile`: extension TypeScript plus both production Vite bundles succeeded
- full Factory suite before the registry repair: 1287 pass; the registry anti-drift failure is fixed here, while the remaining four failures are the existing live watcher/model environment probes
- release UI evidence from merged #1052: `/Users/muqsit/.agents/.cache/browser/sessions/calm-tiger-thistle-d00956e5/1783992312392.jpg`

Publication will be performed locally with `apps/factory/scripts/release.sh 0.9.292 --confirm`, not through a CI release workflow.