### PR TITLE
test(windows): avoid 8.3 home alias in project-root expectations

### DIFF
--- a/apps/cli/src/lib/project-root.test.ts
+++ b/apps/cli/src/lib/project-root.test.ts
@@ -89,6 +89,9 @@ describe('inferProjectRoot', () => {
   let tmp: string;
   let repo: string;
 
+  const expectedRoot = () =>
+    toHomeRelative(process.platform === 'win32' ? tmp : fs.realpathSync(tmp));
+
   beforeAll(() => {
     tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'proot-'));
     repo = path.join(tmp, 'my-repo');
@@ -109,9 +112,9 @@ describe('inferProjectRoot', () => {
 
   it('returns the directory ABOVE the git root, resolved from a nested cwd', async () => {
     const root = await inferProjectRoot(path.join(repo, 'sub', 'deep'));
-    // Windows places os.tmpdir() under HOME; compare through the same portable
-    // storage contract. realpath also dodges /var → /private/var on macOS.
-    expect(root).toBe(toHomeRelative(fs.realpathSync(tmp)));
+    // Windows realpath emits an 8.3 home alias (RUNNER~1) that cannot compare
+    // against HOME; macOS still needs realpath for /var → /private/var.
+    expect(root).toBe(expectedRoot());
   });
 
   it('resolves the MAIN repo root from inside a linked worktree (not the worktree dir)', async () => {
@@ -119,7 +122,7 @@ describe('inferProjectRoot', () => {
     fs.mkdirSync(path.dirname(wt), { recursive: true });
     execFileSync('git', ['worktree', 'add', '-q', wt], { cwd: repo });
     // Regression: naive --show-toplevel would yield <repo>/.agents/worktrees here.
-    expect(await inferProjectRoot(wt)).toBe(toHomeRelative(fs.realpathSync(tmp)));
+    expect(await inferProjectRoot(wt)).toBe(expectedRoot());
   });
 
   it('returns undefined when cwd is not inside a git repo', async () => {


### PR DESCRIPTION
## Summary

- keep the production `inferProjectRoot` portable `~/...` contract
- avoid Windows `realpathSync` rewriting the home directory to an 8.3 alias (`RUNNER~1`) in two test expectations
- retain macOS `/var` → `/private/var` canonicalization

## Evidence

- Release PR #1119 Windows Node 22 and 24 both failed only these two assertions; actual was `~/AppData/Local/Temp/...`, expected used `C:\\Users\\RUNNER~1\\...`
- `bun test src/lib/project-root.test.ts`: 19 passed, 0 failed
- `bun run build`: passed
- CI must confirm the real Windows runners before merge

No changelog entry: test-only correction; runtime behavior is unchanged.

Confidential session transcript (public-repo policy, local fleet path only): `zion:/Users/muqsit/.agents/.history/versions/codex/0.144.1/home/.codex/sessions/2026/07/13/rollout-2026-07-13T17-13-57-019f5df9-276c-77c1-8b97-c467b30c58e0.jsonl`