### PR TITLE
fix(test): canonicalize temp dir for Windows 8.3 short paths in project-root.test.ts

### DIFF
--- a/apps/cli/src/lib/project-root.test.ts
+++ b/apps/cli/src/lib/project-root.test.ts
@@ -90,7 +90,13 @@ describe('inferProjectRoot', () => {
   let repo: string;
 
   beforeAll(() => {
-    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'proot-'));
+    // Canonicalize the temp dir so it matches the long real path git — and thus
+    // inferProjectRoot — resolves to. realpathSync.native resolves BOTH the macOS
+    // /var → /private/var symlink AND Windows 8.3 short names (CI runners hand back
+    // os.tmpdir() as C:\Users\RUNNER~1\..., which would never fold under the
+    // long-form home dir). Without this the home-relative comparison mismatches on
+    // Windows (short vs long) even though inferProjectRoot is correct.
+    tmp = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'proot-')));
     repo = path.join(tmp, 'my-repo');
     fs.mkdirSync(path.join(repo, 'sub', 'deep'), { recursive: true });
     const git = (args: string[]) =>


### PR DESCRIPTION
Pre-existing Windows-only failure surfacing on the release matrix (the windows-latest `build` job runs only on release/tag PRs, so it never gated normal merges — it blocked the 1.20.59 release).

**Root cause:** GitHub Windows runners return `os.tmpdir()` as an 8.3 short path (`C:\Users\RUNNER~1\...`). `inferProjectRoot` resolves the repo root via git, which yields the **long** canonical path, folded to `~/AppData/...` by `toHomeRelative`. The test's expected value used the short path, which never matches the long-form home dir → mismatch. Product code is correct; only the test's temp-dir setup was wrong.

**Fix:** canonicalize the temp dir at creation with `fs.realpathSync.native` — resolves 8.3 short names on Windows AND `/var`→`/private/var` on macOS. One line, test-only.

Verified: `project-root.test.ts` 19/19 pass on macOS; the Windows build matrix will confirm on this PR / the re-run release PR.