### PR TITLE
fix(run): forward @version, --strategy and common flags for --host dispatches

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Fix: `agents run <agent>@<version> --host <host>` now forwards the version pin and most run flags to the remote host.** Previously the `--host` branch stripped `@version` and ignored `--strategy`, `--effort`, `--add-dir`, `--json`, `--verbose`, `--timeout`, `--yes`, and `--acp`, so the remote host applied its own defaults. The local CLI now parses `agent@version` verbatim, normalizes `--strategy`/`--balanced`, makes `--add-dir` paths remote-portable, and forwards all of these flags to the remote `agents run` invocation. `--add-dir` portability uses the same `~`/`$HOME` re-rooting that `--cwd` already uses, so a Linux remote resolves home paths against its own `/home/<user>`. Source: `apps/cli/src/lib/hosts/dispatch.ts`, `apps/cli/src/commands/exec.ts`, `apps/cli/src/lib/hosts/dispatch.test.ts`.
+
 ## 1.20.59
 
 - **Fix: remote secrets now choose the Windows PowerShell wrapper from the original `--host` name, not the resolved `user@ip` SSH target.** Inline enrolled Windows hosts resolve to address-based SSH targets, but the OS registry is keyed by the host name; `agents secrets view/list/exec --host <windows>`, `agents run --secrets bundle@<windows>`, and remote secrets unlock/export paths now pass that original name into command construction so Windows hosts no longer fall back to `bash -lc`. Source: `apps/cli/src/lib/secrets/remote.ts`, `apps/cli/src/commands/secrets.ts`, `apps/cli/src/commands/exec.ts`. (RUSH-1431)

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -637,6 +637,7 @@ export function registerRunCommand(program: Command): void {
         const { resolveHost, resolveHostByCap } = await import('../lib/hosts/registry.js');
         const { dispatchToHost, runInteractiveOnHost } = await import('../lib/hosts/dispatch.js');
         const { registerHostSession, registerInteractiveHostSession } = await import('../lib/hosts/session-index.js');
+        const { normalizeRunStrategy, RUN_STRATEGIES } = await import('../lib/rotate.js');
         // A password-auth device throws DeviceOffloadUnsupportedError here; it's
         // printed cleanly by the top-level catch in index.ts (covers every
         // resolveHost caller), so it never falls through to capability routing.
@@ -660,12 +661,32 @@ export function registerRunCommand(program: Command): void {
           process.exit(1);
         }
         try {
-          const runAgent = agentSpec.split('@')[0];
+          const [runAgent, rawRunVersion] = agentSpec.split('@');
+          // Forward the explicit @version pin verbatim. Resolving aliases like
+          // @latest locally would check local installs, but the remote host may
+          // have versions the laptop does not. The remote agents CLI resolves
+          // aliases against its own installed versions.
+          const runVersion = rawRunVersion || undefined;
+
+          // Normalize the effective strategy exactly like the local path so we
+          // fail fast on invalid input and can forward --balanced/--strategy.
+          const explicitStrategy = options.strategy ? normalizeRunStrategy(options.strategy) : null;
+          if (options.strategy && !explicitStrategy) {
+            console.error(chalk.red(`Invalid strategy: ${options.strategy}. Use ${RUN_STRATEGIES.join(', ')}.`));
+            process.exit(1);
+          }
+          if (options.balanced && explicitStrategy && explicitStrategy !== 'balanced') {
+            console.error(chalk.red('--balanced conflicts with --strategy. Use one strategy override.'));
+            process.exit(1);
+          }
+          const runStrategy = options.balanced ? 'balanced' : explicitStrategy ?? undefined;
+
           // Working directory on the host: an explicit --remote-cwd is used
           // verbatim; --cwd/--project are made portable (a local-home absolute
           // becomes `~/…` so the remote shell re-roots it at ITS home).
           const { toRemotePortable } = await import('../lib/project-root.js');
           const hostCwd = options.remoteCwd ?? (options.cwd ? toRemotePortable(options.cwd) : undefined);
+          const hostAddDirs = options.addDir.length > 0 ? options.addDir.map(toRemotePortable) : undefined;
           // `--resume [id]`: commander yields the string id, or `true` when the
           // flag is passed bare. A bare resume needs the interactive picker,
           // which can't run over a detached remote dispatch — only forward a
@@ -705,9 +726,18 @@ export function registerRunCommand(program: Command): void {
             }
             const exitCode = await runInteractiveOnHost(host, {
               agent: runAgent,
+              version: resumeId ? undefined : runVersion,
+              strategy: resumeId ? undefined : runStrategy,
               prompt,
               mode: options.mode,
               model: options.model,
+              effort: options.effort,
+              addDir: hostAddDirs,
+              json: options.json,
+              verbose: options.verbose,
+              timeout: options.timeout,
+              yes: options.yes,
+              acp: options.acp,
               remoteCwd: hostCwd,
               sessionId: hostSessionId,
               name: options.name,
@@ -728,9 +758,18 @@ export function registerRunCommand(program: Command): void {
           const hostSessionId = runAgent === 'claude' && !resumeId ? randomUUID() : undefined;
           const { task, exitCode } = await dispatchToHost(host, {
             agent: runAgent,
+            version: resumeId ? undefined : runVersion,
+            strategy: resumeId ? undefined : runStrategy,
             prompt,
             mode: options.mode,
             model: options.model,
+            effort: options.effort,
+            addDir: hostAddDirs,
+            json: options.json,
+            verbose: options.verbose,
+            timeout: options.timeout,
+            yes: options.yes,
+            acp: options.acp,
             remoteCwd: hostCwd,
             sessionId: hostSessionId,
             name: options.name,

--- a/apps/cli/src/lib/hosts/dispatch.test.ts
+++ b/apps/cli/src/lib/hosts/dispatch.test.ts
@@ -47,6 +47,55 @@ describe('buildRunForwardedArgs', () => {
     });
     expect(args).toEqual(['run', 'claude', 'p', '--quiet', '--mode', 'plan', '--model', 'opus', '--session-id', 'id-1']);
   });
+
+  it('forwards an explicit version pin as agent@version', () => {
+    const args = buildRunForwardedArgs({ agent: 'claude', prompt: 'p', version: '2.1.207' });
+    expect(args).toEqual(['run', 'claude@2.1.207', 'p', '--quiet']);
+  });
+
+  it('forwards an explicit strategy', () => {
+    const args = buildRunForwardedArgs({ agent: 'claude', prompt: 'p', strategy: 'balanced' });
+    expect(args).toEqual(['run', 'claude', 'p', '--quiet', '--strategy', 'balanced']);
+  });
+
+  it('forwards version and strategy together before session flags', () => {
+    const args = buildRunForwardedArgs({
+      agent: 'claude',
+      prompt: 'p',
+      version: '2.1.207',
+      strategy: 'balanced',
+      sessionId: 'id-1',
+    });
+    expect(args).toEqual([
+      'run', 'claude@2.1.207', 'p', '--quiet',
+      '--strategy', 'balanced', '--session-id', 'id-1',
+    ]);
+  });
+
+  it('forwards common behavioral flags', () => {
+    const args = buildRunForwardedArgs({
+      agent: 'claude',
+      prompt: 'p',
+      effort: 'high',
+      addDir: ['~/notes', '/shared'],
+      json: true,
+      verbose: true,
+      timeout: '30m',
+      yes: true,
+      acp: true,
+    });
+    expect(args).toEqual([
+      'run', 'claude', 'p', '--quiet',
+      '--effort', 'high',
+      '--add-dir', '~/notes',
+      '--add-dir', '/shared',
+      '--json',
+      '--verbose',
+      '--timeout', '30m',
+      '--yes',
+      '--acp',
+    ]);
+  });
 });
 
 describe('buildInteractiveRunForwardedArgs', () => {
@@ -101,6 +150,38 @@ describe('buildInteractiveRunForwardedArgs', () => {
   it('drops the prompt when interactive mode is not forced', () => {
     const args = buildInteractiveRunForwardedArgs({ agent: 'claude', prompt: 'do a thing' });
     expect(args).toEqual(['run', 'claude']);
+  });
+
+  it('forwards version and strategy interactively', () => {
+    const args = buildInteractiveRunForwardedArgs({
+      agent: 'claude',
+      version: '2.1.207',
+      strategy: 'balanced',
+    });
+    expect(args).toEqual(['run', 'claude@2.1.207', '--strategy', 'balanced']);
+  });
+
+  it('forwards common behavioral flags interactively', () => {
+    const args = buildInteractiveRunForwardedArgs({
+      agent: 'claude',
+      effort: 'max',
+      addDir: ['~/notes'],
+      json: true,
+      verbose: true,
+      timeout: '1h',
+      yes: true,
+      acp: true,
+    });
+    expect(args).toEqual([
+      'run', 'claude',
+      '--effort', 'max',
+      '--add-dir', '~/notes',
+      '--json',
+      '--verbose',
+      '--timeout', '1h',
+      '--yes',
+      '--acp',
+    ]);
   });
 });
 

--- a/apps/cli/src/lib/hosts/dispatch.ts
+++ b/apps/cli/src/lib/hosts/dispatch.ts
@@ -208,8 +208,26 @@ async function launchDetached(host: Host, target: string, opts: LaunchOptions): 
 export interface DispatchOptions {
   agent: string;
   prompt: string;
+  /** Explicit agent version pin (e.g. "2.1.207") to forward as `agent@version`. */
+  version?: string;
+  /** Explicit run strategy (e.g. "balanced") to forward as `--strategy <strategy>`. */
+  strategy?: string;
   mode?: string;
   model?: string;
+  /** Reasoning effort to forward as `--effort <effort>`. */
+  effort?: string;
+  /** Additional directories to grant, already made remote-portable. */
+  addDir?: string[];
+  /** Stream events as JSON lines. */
+  json?: boolean;
+  /** Show detailed execution logs. */
+  verbose?: boolean;
+  /** Kill the agent after this duration, forwarded as `--timeout <duration>`. */
+  timeout?: string;
+  /** Skip the interactive budget-confirm prompt. */
+  yes?: boolean;
+  /** Route through the Agent Client Protocol. */
+  acp?: boolean;
   remoteCwd?: string;
   /**
    * Force the remote run's NEW session to use this exact id (Claude only, via
@@ -236,9 +254,20 @@ export interface DispatchOptions {
  * resume wins when — defensively — both are set.
  */
 export function buildRunForwardedArgs(opts: DispatchOptions): string[] {
-  const args = ['run', opts.agent, opts.prompt, '--quiet'];
+  const agentArg = opts.version ? `${opts.agent}@${opts.version}` : opts.agent;
+  const args = ['run', agentArg, opts.prompt, '--quiet'];
+  if (opts.strategy) args.push('--strategy', opts.strategy);
   if (opts.mode) args.push('--mode', opts.mode);
   if (opts.model) args.push('--model', opts.model);
+  if (opts.effort) args.push('--effort', opts.effort);
+  if (opts.addDir) {
+    for (const dir of opts.addDir) args.push('--add-dir', dir);
+  }
+  if (opts.json) args.push('--json');
+  if (opts.verbose) args.push('--verbose');
+  if (opts.timeout) args.push('--timeout', opts.timeout);
+  if (opts.yes) args.push('--yes');
+  if (opts.acp) args.push('--acp');
   if (opts.name) args.push('--name', opts.name);
   if (opts.resume) args.push('--resume', opts.resume);
   else if (opts.sessionId) args.push('--session-id', opts.sessionId);
@@ -247,10 +276,28 @@ export function buildRunForwardedArgs(opts: DispatchOptions): string[] {
 
 export interface InteractiveDispatchOptions {
   agent: string;
+  /** Explicit agent version pin (e.g. "2.1.207") to forward as `agent@version`. */
+  version?: string;
+  /** Explicit run strategy (e.g. "balanced") to forward as `--strategy <strategy>`. */
+  strategy?: string;
   /** Optional prompt — forwarded only when the caller explicitly forced interactive mode. */
   prompt?: string;
   mode?: string;
   model?: string;
+  /** Reasoning effort to forward as `--effort <effort>`. */
+  effort?: string;
+  /** Additional directories to grant, already made remote-portable. */
+  addDir?: string[];
+  /** Stream events as JSON lines. */
+  json?: boolean;
+  /** Show detailed execution logs. */
+  verbose?: boolean;
+  /** Kill the agent after this duration, forwarded as `--timeout <duration>`. */
+  timeout?: string;
+  /** Skip the interactive budget-confirm prompt. */
+  yes?: boolean;
+  /** Route through the Agent Client Protocol. */
+  acp?: boolean;
   remoteCwd?: string;
   sessionId?: string;
   name?: string;
@@ -269,11 +316,22 @@ export interface InteractiveDispatchOptions {
  * infer headless from the prompt).
  */
 export function buildInteractiveRunForwardedArgs(opts: InteractiveDispatchOptions): string[] {
-  const args = ['run', opts.agent];
+  const agentArg = opts.version ? `${opts.agent}@${opts.version}` : opts.agent;
+  const args = ['run', agentArg];
   if (opts.prompt && opts.forceInteractive) args.push(opts.prompt);
   if (opts.forceInteractive) args.push('--interactive');
+  if (opts.strategy) args.push('--strategy', opts.strategy);
   if (opts.mode) args.push('--mode', opts.mode);
   if (opts.model) args.push('--model', opts.model);
+  if (opts.effort) args.push('--effort', opts.effort);
+  if (opts.addDir) {
+    for (const dir of opts.addDir) args.push('--add-dir', dir);
+  }
+  if (opts.json) args.push('--json');
+  if (opts.verbose) args.push('--verbose');
+  if (opts.timeout) args.push('--timeout', opts.timeout);
+  if (opts.yes) args.push('--yes');
+  if (opts.acp) args.push('--acp');
   if (opts.name) args.push('--name', opts.name);
   if (opts.resume) args.push('--resume', opts.resume);
   else if (opts.sessionId) args.push('--session-id', opts.sessionId);


### PR DESCRIPTION
## Problem

When offloading a run to a remote host via `--host`/`--device`, the local CLI stripped the `@version` pin and ignored most run flags. The remote host therefore ran a bare `agents run <agent> ...` and applied its own defaults.

Repro: `ag run claude@2.1.207 --host yosemite-s0 ...` launched `claude@2.1.186` on the remote.

## Fix

Parse the explicit `@version` pin and normalize `--strategy` / `--balanced` in the local `--host` branch, then forward them (plus the common behavioral flags) to the remote `agents run` invocation.

### Flags now forwarded
- `@version` pin (verbatim; aliases like `@latest` are resolved by the remote)
- `--strategy` / `--balanced`
- `--effort`
- `--add-dir` (made remote-portable the same way `--cwd` already is)
- `--json`, `--verbose`, `--timeout`, `--yes`, `--acp`

### Home / cwd note
The existing `remoteCdPrefix` helper already expands `~` / `$HOME` against the *remote* login shell, so a Linux remote gets its own `/home/<user>` regardless of the local home. This is covered by existing tests.

## Files changed
- `apps/cli/src/lib/hosts/dispatch.ts` — accept and emit `version`, `strategy`, and the new behavioral flags in both headless and interactive argv builders.
- `apps/cli/src/commands/exec.ts` — parse `agent@version`, normalize strategy, make `--add-dir` paths remote-portable, and pass everything through to `dispatchToHost` / `runInteractiveOnHost`.
- `apps/cli/src/lib/hosts/dispatch.test.ts` — cover forwarded version, strategy, and common flags.

## Verification

- Build: `cd apps/cli && bun install` passes TypeScript compilation.
- Unit tests: `bun run test -- src/lib/hosts/` → 145 passed, 8 skipped.
- Local run: `node dist/index.js run claude@2.1.207 "say hi" --mode plan --timeout 10s` used the pinned version:

```
[agents] strategy balanced ignored: version 2.1.207 is pinned
Running: /Users/muqsit/.agents/.cache/shims/claude@2.1.207 --permission-mode plan -p say hi
```

Full remote `--host` verification against yosemite-s0 was not possible from this session because that host is not currently reachable; the exact command to confirm on the user's side is:

```
ag run claude@2.1.207 --host yosemite-s0 "echo hello" --mode plan --no-follow
```

Then check `agents hosts logs <handle>` and confirm the remote `Running:` line shows `claude@2.1.207`.
