### PR TITLE
fix(grok): relocate installer-dropped binary into target version home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`agents add grok@latest` now places the Grok binary in the new version's
+  isolated home.** The x.ai installer writes to `~/.grok/downloads`, which
+  resolved to the previous default home during install, leaving `agents view`
+  and `agents run` pointing at the old version. The installer-dropped binary is
+  now relocated into the target version home automatically.
+
 ### Added
 
 - **`agents output` — productivity: token burn vs shipped output.** A new command

--- a/apps/cli/src/lib/versions.test.ts
+++ b/apps/cli/src/lib/versions.test.ts
@@ -570,6 +570,77 @@ describe('installVersion version validation', () => {
   });
 });
 
+function runInstallVersionWithScript(
+  home: string,
+  agent: string,
+  version: string,
+  installScript: string,
+  extraPathDir?: string
+): { ok: boolean; error?: string; result?: { success: boolean; installedVersion?: string; error?: string } } {
+  const moduleUrl = pathToFileURL(path.resolve('src/lib/versions.ts')).href;
+  const agentsUrl = pathToFileURL(path.resolve('src/lib/agents.ts')).href;
+  const tsxBin = path.resolve('node_modules/tsx/dist/cli.mjs');
+  const child = spawnSync(process.execPath, [tsxBin, '-e', `
+    import { installVersion } from ${JSON.stringify(moduleUrl)};
+    import { AGENTS } from ${JSON.stringify(agentsUrl)};
+    (async () => {
+      try {
+        AGENTS[${JSON.stringify(agent)}].installScript = ${JSON.stringify(installScript)};
+        const r = await installVersion(${JSON.stringify(agent)}, ${JSON.stringify(version)});
+        console.log(JSON.stringify({ ok: true, result: r }));
+      } catch (err) {
+        console.log(JSON.stringify({ ok: false, error: err.message }));
+      }
+    })();
+  `], {
+    env: {
+      ...process.env,
+      HOME: home,
+      ...(extraPathDir ? { PATH: `${extraPathDir}${path.delimiter}${process.env.PATH}` } : {}),
+    },
+    encoding: 'utf-8',
+  });
+  expect(child.status, child.stderr).toBe(0);
+  return JSON.parse(child.stdout.trim());
+}
+
+describe('installVersion Grok binary relocation', () => {
+  it.skipIf(process.platform === 'win32')('moves the installer-dropped binary from the previous default home into the target version home', () => {
+    const home = makeTempHome();
+    const oldConfigDir = path.join(home, '.agents', '.history', 'versions', 'grok', '0.2.32', 'home', '.grok');
+    const hostGrok = path.join(home, '.grok');
+    const binDir = path.join(home, 'fakebin');
+
+    fs.mkdirSync(path.join(oldConfigDir, 'downloads'), { recursive: true });
+    fs.symlinkSync(oldConfigDir, hostGrok, 'dir');
+
+    // A `grok` on PATH lets `getCliVersionFromPath` resolve `latest` to 0.2.101.
+    fs.mkdirSync(binDir, { recursive: true });
+    const stub = path.join(binDir, 'grok');
+    fs.writeFileSync(stub, '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "grok 0.2.101"; exit 0; fi\nexit 0\n', 'utf-8');
+    fs.chmodSync(stub, 0o755);
+
+    const script = [
+      'mkdir -p ~/.grok/downloads',
+      'printf \'#!/bin/sh\\nif [ "$1" = "--version" ]; then echo "grok 0.2.101"; exit 0; fi\\nexit 0\\n\' > ~/.grok/downloads/grok-0.2.101-macos-aarch64',
+      'chmod +x ~/.grok/downloads/grok-0.2.101-macos-aarch64',
+      'cp ~/.grok/downloads/grok-0.2.101-macos-aarch64 ~/.grok/downloads/grok-macos-aarch64',
+    ].join(' && ');
+
+    const outcome = runInstallVersionWithScript(home, 'grok', 'latest', script, binDir);
+    expect(outcome.ok).toBe(true);
+    expect(outcome.result?.success).toBe(true);
+    expect(outcome.result?.installedVersion).toBe('0.2.101');
+
+    const targetDownloads = path.join(home, '.agents', '.history', 'versions', 'grok', '0.2.101', 'home', '.grok', 'downloads');
+    expect(fs.existsSync(path.join(targetDownloads, 'grok-0.2.101-macos-aarch64'))).toBe(true);
+    expect(fs.existsSync(path.join(targetDownloads, 'grok-macos-aarch64'))).toBe(true);
+
+    const result = runVersionSync(home, "listInstalledVersions('grok')") as string[];
+    expect(result).toContain('0.2.101');
+  });
+});
+
 // `resolveVersionAlias` is the shared @selector vocabulary (latest / oldest /
 // default / pinned / explicit) every `agents <cmd> agent@<token>` reads. droid
 // installs a single global binary (~/.local/bin/droid) shared across version

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -1232,6 +1232,73 @@ export function setGlobalDefault(agent: AgentId, version: string | undefined): v
 }
 
 /**
+ * Grok's official installer writes into ~/.grok/downloads, which (because we
+ * symlink ~/.grok to the active version home) resolves to the PREVIOUS default
+ * home during `agents add grok@<new>`. Move the freshly-downloaded binary and
+ * its generic platform copy into the target version's isolated home so
+ * `listInstalledVersions` and the shim resolve the right binary.
+ */
+function relocateGrokBinaryToVersionHome(installedVersion: string): void {
+  const hostGrokLink = path.join(getHomeDir(), agentConfigDirName('grok'));
+  let sourceDownloads: string;
+  try {
+    sourceDownloads = path.join(fs.readlinkSync(hostGrokLink), 'downloads');
+  } catch {
+    sourceDownloads = path.join(hostGrokLink, 'downloads');
+  }
+  const targetDownloads = path.join(
+    getVersionHomePath('grok', installedVersion),
+    agentConfigDirName('grok'),
+    'downloads'
+  );
+
+  if (!fs.existsSync(sourceDownloads)) return;
+  if (path.resolve(sourceDownloads) === path.resolve(targetDownloads)) return;
+
+  const entries = fs.readdirSync(sourceDownloads).filter((e) => e.startsWith('grok-'));
+  if (entries.length === 0) return;
+
+  fs.mkdirSync(targetDownloads, { recursive: true });
+
+  const escapedVersion = installedVersion.replace(/\./g, '\\.');
+  const versionedPattern = new RegExp(`^grok-${escapedVersion}-`);
+  const movedPaths: string[] = [];
+
+  // Move the versioned binary first.
+  for (const entry of entries) {
+    if (!versionedPattern.test(entry)) continue;
+    const src = path.join(sourceDownloads, entry);
+    const dst = path.join(targetDownloads, entry);
+    if (fs.existsSync(dst)) continue;
+    try {
+      fs.renameSync(src, dst);
+      movedPaths.push(dst);
+    } catch {
+      /* ignore per-file failures */
+    }
+  }
+
+  if (movedPaths.length === 0) return;
+
+  // The installer also creates a generic platform binary (e.g. grok-macos-aarch64)
+  // that is a copy of the versioned binary. Move it too if its size matches.
+  const movedSize = fs.statSync(movedPaths[0]).size;
+  for (const entry of entries) {
+    if (versionedPattern.test(entry)) continue; // already handled
+    const src = path.join(sourceDownloads, entry);
+    const dst = path.join(targetDownloads, entry);
+    if (fs.existsSync(dst)) continue;
+    try {
+      if (fs.statSync(src).size === movedSize) {
+        fs.renameSync(src, dst);
+      }
+    } catch {
+      /* ignore per-file failures */
+    }
+  }
+}
+
+/**
  * Install a specific version of an agent.
  */
 export async function installVersion(
@@ -1297,6 +1364,13 @@ export async function installVersion(
     const versionDir = getVersionDir(agent, installedVersion);
     fs.mkdirSync(versionDir, { recursive: true });
     fs.mkdirSync(path.join(versionDir, 'home'), { recursive: true });
+
+    // Grok's installer drops the binary into ~/.grok/downloads, which currently
+    // resolves to the PREVIOUS default home. Move it into the target version home
+    // so version isolation is correct.
+    if (agent === 'grok') {
+      relocateGrokBinaryToVersionHome(installedVersion);
+    }
 
     // Symlink the installed binary into the version's node_modules/.bin so
     // listInstalledVersions (which checks getBinaryPath) sees this version as


### PR DESCRIPTION
## Problem

`agents add grok@latest` downloaded Grok 0.2.101, but the binary landed in the previous default version home (0.2.32) instead of the new 0.2.101 home. Because the x.ai installer hard-codes `DOWNLOAD_DIR="$HOME/.grok/downloads"` and agents-cli symlinks `~/.grok` to the active version home, the installer writes into the old home during the install step. Only after install does `setDefaultVersion` repoint `~/.grok` to the new home, leaving the binary behind.

Result: `agents view grok` omitted 0.2.101 and `agents run grok` fell back to 0.2.32.

## Fix

After running the Grok installer and creating the target version home, move the installer-dropped `grok-<version>-<platform>` binary and its generic platform copy (e.g. `grok-macos-aarch64`) from the active `~/.grok/downloads` into the target version's isolated `home/.grok/downloads`.

## Verification

- Local repair: moved the misplaced 0.2.101 binary; `ag view grok` now lists 0.2.101 as default and `ag run grok` starts grok@0.2.101.
- Added test `installVersion Grok binary relocation` in `apps/cli/src/lib/versions.test.ts`.
- `bun run test src/lib/versions.test.ts`: 47 passed.
- `bun run build`: clean.

Full suite has unrelated failures in `models.test.ts` (codex reasoning-level data drift) and `server.test.ts` (timeouts); not touched by this change.