### PR TITLE
feat(routines): add --resume to wake an existing session instead of starting fresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@
   `--prompt` becomes its next turn. Powers self-scheduled wake-ups (an agent that
   hibernates on a long external wait and resumes itself later). Without it, a routine
   spawns a context-less fresh agent, which correctly refuses an opaque instruction it
-  has no memory of. claude/codex (native resume) only.
+  has no memory of. Requires `--agent claude` or `codex` (native resume, validated);
+  the job runs **un-sandboxed** so `--resume` can find the session in the real agent
+  home, and — like workflow jobs — its command is never binary-pinned.
 
 - **`agents output` — productivity: token burn vs shipped output.** A new command
   that joins spend (`$` cost, from the offline price table) to what actually

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
 
 ### Added
 
+- **`agents routines add --resume <sessionId>` — wake an existing session instead
+  of starting fresh.** At fire time the job runs `agents run <agent> --resume <id>`,
+  so the *actual* prior session reopens with its full context and the routine's
+  `--prompt` becomes its next turn. Powers self-scheduled wake-ups (an agent that
+  hibernates on a long external wait and resumes itself later). Without it, a routine
+  spawns a context-less fresh agent, which correctly refuses an opaque instruction it
+  has no memory of. claude/codex (native resume) only.
+
 - **`agents output` — productivity: token burn vs shipped output.** A new command
   that joins spend (`$` cost, from the offline price table) to what actually
   shipped: real generated **output tokens** plus **commits across every git

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -405,6 +405,7 @@ export function registerRoutinesCommands(program: Command): void {
     .option('--at <time>', 'One-shot mode: run once at this time (e.g., "14:30" or "2026-02-24 09:00"), then disable')
     .option('--end-at <iso>', 'Stop firing on or after this ISO 8601 timestamp (e.g., "2026-12-31T23:59:00Z"); routine auto-disables.')
     .option('--disabled', 'Create the routine but keep it paused (enable later with resume)')
+    .option('--resume <sessionId>', 'At fire time, resume this existing session id (via `agents run <agent> --resume`) instead of starting fresh — the actual session reopens with full context and the prompt becomes its next turn. Powers self-scheduled wake-ups (e.g. /hibernate). Use with --agent claude|codex.')
     .action(async (nameOrPath: string | undefined, options) => {
       // Check if inline mode (has flags) or file mode
       const hasInlineFlags = options.schedule || options.agent || options.workflow || options.prompt || options.at;
@@ -473,6 +474,7 @@ export function registerRoutinesCommands(program: Command): void {
           ...(devices ? { devices } : {}),
           ...(runOnce ? { runOnce: true } : {}),
           ...(options.endAt ? { endAt: options.endAt } : {}),
+          ...(options.resume ? { resume: options.resume } : {}),
         };
 
         const errors = validateJob(config);

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -405,7 +405,7 @@ export function registerRoutinesCommands(program: Command): void {
     .option('--at <time>', 'One-shot mode: run once at this time (e.g., "14:30" or "2026-02-24 09:00"), then disable')
     .option('--end-at <iso>', 'Stop firing on or after this ISO 8601 timestamp (e.g., "2026-12-31T23:59:00Z"); routine auto-disables.')
     .option('--disabled', 'Create the routine but keep it paused (enable later with resume)')
-    .option('--resume <sessionId>', 'At fire time, resume this existing session id (via `agents run <agent> --resume`) instead of starting fresh — the actual session reopens with full context and the prompt becomes its next turn. Powers self-scheduled wake-ups (e.g. /hibernate). Use with --agent claude|codex.')
+    .option('--resume <sessionId>', 'At fire time, resume this existing session id (via `agents run <agent> --resume`) instead of starting fresh — the actual session reopens with full context and the prompt becomes its next turn. Powers self-scheduled wake-ups (e.g. /hibernate). Requires --agent claude or codex; runs un-sandboxed (the session store lives in the real home, not the job overlay).')
     .action(async (nameOrPath: string | undefined, options) => {
       // Check if inline mode (has flags) or file mode
       const hasInlineFlags = options.schedule || options.agent || options.workflow || options.prompt || options.at;

--- a/apps/cli/src/lib/__tests__/runner.test.ts
+++ b/apps/cli/src/lib/__tests__/runner.test.ts
@@ -61,6 +61,17 @@ describe('buildJobCommand', () => {
     expect(argv).not.toContain('--non-interactive');
   });
 
+  it('resume emits `agents run <agent> --resume <id>` and reopens the session (not a fresh template)', () => {
+    const argv = buildJobCommand(
+      baseJob({ agent: 'claude', mode: 'skip', resume: 'sess-abc123' }),
+      '<wake prompt>',
+    );
+    expect(argv).toEqual(['agents', 'run', 'claude', '--resume', 'sess-abc123', '<wake prompt>', '--mode', 'skip']);
+    // Resume takes precedence over the fresh-agent template — none of its flags leak in.
+    expect(argv).not.toContain('--permission-mode');
+    expect(argv).not.toContain('--dangerously-skip-permissions');
+  });
+
   // Regression: kimi daemon jobs run headless via `--prompt`, which cannot be
   // combined with --plan/--auto/--yolo (kimi aborts "Cannot combine --prompt
   // with --X"). Write-modes must omit the flag; plan must fail closed.

--- a/apps/cli/src/lib/__tests__/runner.test.ts
+++ b/apps/cli/src/lib/__tests__/runner.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import {
   buildJobCommand,
   buildRoutineSpawnEnv,
+  dispatchesViaAgentsRun,
   executeJobDetached,
   pinJobBinary,
   resolveRoutineLaunch,
@@ -88,6 +89,26 @@ describe('buildJobCommand', () => {
 
   it('kimi plan mode throws (no headless read-only mode)', () => {
     expect(() => buildJobCommand(baseJob({ agent: 'kimi', mode: 'plan' }), 'Do the task.')).toThrow(/read-only/);
+  });
+});
+
+describe('dispatchesViaAgentsRun — pin exclusion for `agents run` commands', () => {
+  // Regression: resume commands start with 'agents' (the dispatcher), so binary-pinning
+  // them rewrites cmd[0] -> the agent binary and yields a broken `<binary> run …`.
+  // executeJob/executeJobDetached must skip pinning for these, exactly like workflow jobs.
+  it('is true for resume and workflow jobs, false for a plain agent job', () => {
+    expect(dispatchesViaAgentsRun(baseJob({ agent: 'claude', resume: 'sess-1' }))).toBe(true);
+    expect(dispatchesViaAgentsRun(baseJob({ workflow: 'autodev', agent: undefined as unknown as 'claude' }))).toBe(true);
+    expect(dispatchesViaAgentsRun(baseJob({ agent: 'claude' }))).toBe(false);
+  });
+
+  it('pinJobBinary would corrupt a resume command — proving why it must be excluded', () => {
+    // A resume command: cmd[0] is the 'agents' dispatcher, not the agent binary.
+    const resumeCmd = buildJobCommand(baseJob({ agent: 'claude', mode: 'skip', resume: 'sess-1' }), '<p>');
+    expect(resumeCmd[0]).toBe('agents');
+    // If pinJobBinary DID run on it and the version were installed, it would clobber
+    // cmd[0] to the binary → `<binary> run claude …`. The guard is what prevents this.
+    expect(dispatchesViaAgentsRun({ resume: 'sess-1' })).toBe(true);
   });
 });
 

--- a/apps/cli/src/lib/routines.test.ts
+++ b/apps/cli/src/lib/routines.test.ts
@@ -50,6 +50,33 @@ describe('validateJob — schedule OR trigger', () => {
   });
 });
 
+describe('validateJob — resume', () => {
+  it('accepts resume with a native-resume agent', () => {
+    expect(validateJob(baseJob({ schedule: '0 3 * * *', agent: 'claude', resume: 'sess-1' }))).toEqual([]);
+    expect(validateJob(baseJob({ schedule: '0 3 * * *', agent: 'codex', resume: 'sess-1' }))).toEqual([]);
+  });
+
+  it('rejects resume on an agent without native --resume', () => {
+    const errors = validateJob(baseJob({ schedule: '0 3 * * *', agent: 'gemini', resume: 'sess-1' }));
+    expect(errors.some((e) => /resume is only supported for agents with native --resume/.test(e))).toBe(true);
+  });
+
+  it('rejects resume combined with a workflow', () => {
+    const errors = validateJob(baseJob({ schedule: '0 3 * * *', agent: undefined, workflow: 'autodev', resume: 'sess-1' }));
+    expect(errors.some((e) => /resume cannot be combined with workflow/.test(e))).toBe(true);
+  });
+
+  it('rejects resume combined with a loop', () => {
+    const errors = validateJob(baseJob({ schedule: '0 3 * * *', agent: 'claude', resume: 'sess-1', loop: { maxIterations: 3 } as never }));
+    expect(errors.some((e) => /resume cannot be combined with loop/.test(e))).toBe(true);
+  });
+
+  it('rejects an empty resume session id', () => {
+    const errors = validateJob(baseJob({ schedule: '0 3 * * *', agent: 'claude', resume: '  ' }));
+    expect(errors.some((e) => /resume must be a non-empty session id/.test(e))).toBe(true);
+  });
+});
+
 describe('validateTrigger', () => {
   it('accepts a well-formed github_event trigger', () => {
     expect(validateTrigger({ type: 'github_event', event: 'pull_request', repo: 'x/y', branch: 'main' })).toEqual([]);

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -112,6 +112,13 @@ export interface JobConfig {
   runOnce?: boolean;
   // RFC3339 timestamp; routine auto-disables at the next fire on/after this time.
   endAt?: string;
+  /**
+   * When set, the job resumes this existing agent session id at fire time
+   * (`agents run <agent> --resume <id>`) instead of starting a fresh conversation,
+   * so the actual session reopens with full context and `prompt` becomes its next
+   * turn. Powers self-scheduled wake-ups (e.g. /hibernate). claude/codex only.
+   */
+  resume?: string;
   /** When set, executeJob runs this job through the loop driver instead of once. */
   loop?: LoopConfig;
 }

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -409,6 +409,24 @@ export function validateJob(config: Partial<JobConfig>): string[] {
       errors.push('workflow must be a lowercase alphanumeric name (hyphens and underscores allowed, e.g. autodev)');
     }
   }
+  if (config.resume !== undefined) {
+    // Only claude/codex support native `--resume`; other agents would emit a resume
+    // flag they don't understand. Resume reopens an agent session, so it is
+    // incompatible with workflow and loop jobs (which have no single session to reopen).
+    const RESUMABLE_AGENTS = ['claude', 'codex'];
+    if (typeof config.resume !== 'string' || config.resume.trim() === '') {
+      errors.push('resume must be a non-empty session id string');
+    }
+    if (hasWorkflow) {
+      errors.push('resume cannot be combined with workflow (resume reopens an existing agent session)');
+    }
+    if (config.loop) {
+      errors.push('resume cannot be combined with loop');
+    }
+    if (hasAgent && config.agent && !RESUMABLE_AGENTS.includes(config.agent)) {
+      errors.push(`resume is only supported for agents with native --resume (${RESUMABLE_AGENTS.join(', ')}); got '${config.agent}'`);
+    }
+  }
   if (config.mode && !['plan', 'edit', 'auto', 'skip', 'full'].includes(config.mode)) {
     errors.push("mode must be plan, edit, auto, or skip ('full' accepted as alias for skip)");
   }

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -342,6 +342,16 @@ export function pinJobBinary(cmd: string[], agent: AgentId, version: string | un
 }
 
 /**
+ * Whether a job's command is dispatched through `agents run` (so `cmd[0] === 'agents'`)
+ * rather than the agent binary directly. True for workflow jobs and for resume jobs.
+ * Such commands must NOT be binary-pinned (pinning rewrites cmd[0] to the agent binary,
+ * producing a broken `<binary> run …`) and must not receive a version-pinned spawn env.
+ */
+export function dispatchesViaAgentsRun(config: Pick<JobConfig, 'workflow' | 'resume'>): boolean {
+  return Boolean(config.workflow || config.resume);
+}
+
+/**
  * Merge sandbox/base env with the canonical per-version exec env
  * (CLAUDE_CONFIG_DIR / CODEX_HOME / …) so routines share account isolation
  * with `agents run`.
@@ -492,7 +502,11 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
 
   const resolvedPrompt = resolveJobPrompt(config);
 
-  const useSandbox = config.sandbox !== false;
+  // Resume must run against the REAL home: `--resume <id>` resolves the session from
+  // the agent's config dir, and the sandbox overlay home has only a freshly-generated
+  // config with no session store. So a resume job is never sandboxed, regardless of
+  // `config.sandbox` (see the resume branch in buildJobCommand).
+  const useSandbox = config.sandbox !== false && !config.resume;
   const overlayHome = useSandbox ? prepareJobHome(config) : undefined;
 
   const runId = generateRunId();
@@ -580,10 +594,11 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
       process.stderr.write(`[agents] routine ${config.name}: running ${label}\n`);
     }
 
-    const cmd = config.workflow
+    const viaAgentsRun = dispatchesViaAgentsRun(config);
+    const cmd = viaAgentsRun
       ? baseCmd
       : pinJobBinary(baseCmd, attemptAgent, attemptVersion);
-    const spawnEnv = config.workflow
+    const spawnEnv = viaAgentsRun
       ? (() => {
           const e = { ...baseEnv };
           if (config.timezone) e.TZ = config.timezone;
@@ -679,11 +694,17 @@ export async function executeJobDetached(config: JobConfig): Promise<RunMeta> {
 
   const resolvedPrompt = resolveJobPrompt(config);
   let cmd = buildJobCommand(config, resolvedPrompt);
-  if (!config.workflow && version) {
+  // workflow AND resume dispatch through `agents run` — never binary-pin them (pinning
+  // rewrites cmd[0] to the agent binary → broken `<binary> run …`).
+  if (!dispatchesViaAgentsRun(config) && version) {
     cmd = pinJobBinary(cmd, config.agent, version);
   }
 
-  const useSandbox = config.sandbox !== false;
+  // Resume must run against the REAL home: `--resume <id>` resolves the session from
+  // the agent's config dir, and the sandbox overlay home has only a freshly-generated
+  // config with no session store. So a resume job is never sandboxed, regardless of
+  // `config.sandbox` (see the resume branch in buildJobCommand).
+  const useSandbox = config.sandbox !== false && !config.resume;
   const overlayHome = useSandbox ? prepareJobHome(config) : undefined;
 
   const runId = generateRunId();
@@ -696,7 +717,7 @@ export async function executeJobDetached(config: JobConfig): Promise<RunMeta> {
   const baseEnv = useSandbox
     ? buildSpawnEnv(overlayHome!)
     : { ...process.env } as Record<string, string>;
-  const spawnEnv = config.workflow
+  const spawnEnv = dispatchesViaAgentsRun(config)
     ? (() => {
         const e = { ...baseEnv };
         if (config.timezone) e.TZ = config.timezone;

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -77,6 +77,15 @@ export function buildJobCommand(config: JobConfig, resolvedPrompt: string): stri
     return cmd;
   }
 
+  // Resume branch: reopen an EXISTING session via `agents run <agent> --resume <id>`
+  // instead of starting fresh. The real session resumes with its full prior context
+  // (index-based lookup, cwd-independent) and `resolvedPrompt` becomes its next turn —
+  // so a self-scheduled wake (e.g. /hibernate) is handled by the session that scheduled
+  // it, not a fresh, context-less agent that would refuse an "opaque" instruction.
+  if (config.resume) {
+    return ['agents', 'run', config.agent, '--resume', config.resume, resolvedPrompt, '--mode', config.mode];
+  }
+
   const template = AGENT_COMMANDS[config.agent];
   if (!template) {
     throw new Error(`Unsupported agent for daemon jobs: ${config.agent}`);


### PR DESCRIPTION
## What

`agents routines add --resume <sessionId>` makes a scheduled job **reopen an existing agent session** at fire time — `agents run <agent> --resume <id>` — instead of spawning a fresh conversation. The real session resumes with its full prior context and the routine's `--prompt` becomes its next turn.

## Why

This is what a **self-scheduled wake-up** needs (an agent that hibernates on a long external wait — a multi-day approval, a deploy soak — and resumes itself later to check on it).

Without `--resume`, a routine fires a *fresh, context-less* agent. Handed a prompt to "resume session X and do Y," that agent has no memory of session X and **correctly refuses it as prompt injection** — good alignment, but it means routines can't wake a hibernated session. With `--resume`, the session that *scheduled* the wake is the one that resumes, so there's nothing to refuse.

## Changes

- `JobConfig.resume?: string`
- `buildJobCommand`: a `resume` branch → `['agents', 'run', <agent>, '--resume', <id>, <prompt>, '--mode', <mode>]`, taking precedence over the fresh-agent template (mirrors the existing `workflow` branch)
- `routines add --resume <sessionId>` option, stored on the job
- Test: `resume` emits the exact argv and none of the fresh-template flags leak in
- CHANGELOG entry under Unreleased / Added

## Notes

- claude/codex only (native `--resume`); other agents resume via `/continue` replay, out of scope here.
- Consumer: the `/hibernate` command currently uses a launchd one-shot for the wake because this feature isn't released yet (the CLI is a compiled binary). Once this ships, `/hibernate` switches to a one-line `routines add --resume` instead.