### PR TITLE
fix(factory): honor configured test command during release

### DIFF
--- a/apps/factory/scripts/release.sh
+++ b/apps/factory/scripts/release.sh
@@ -185,7 +185,7 @@ echo "VSCE PAT verified."
 if [ $SKIP_TESTS -eq 0 ]; then
     echo "${DRY}Running tests..."
     if [ $CONFIRM -eq 1 ]; then
-        bun test
+        bun run test
     fi
 else
     echo "Skipping tests (--skip-tests)."

--- a/apps/factory/scripts/release.test.sh
+++ b/apps/factory/scripts/release.test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Regression tests for release.sh's test gate. The release must delegate to the
+# package's configured test script so its timeout and future test options are not
+# bypassed by a raw `bun test` invocation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FACTORY_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RELEASE_SH="$SCRIPT_DIR/release.sh"
+FAIL=0
+
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1"; FAIL=1; }
+
+echo "Running release.sh regression tests..."
+
+if bash -n "$RELEASE_SH" 2>&1; then
+    pass "release.sh passes bash -n syntax check"
+else
+    fail "release.sh has syntax errors"
+fi
+
+PACKAGE_TEST_COMMAND="$(
+    cd "$FACTORY_ROOT"
+    bun -e 'console.log(require("./package.json").scripts?.test ?? "")'
+)"
+if [ -n "$PACKAGE_TEST_COMMAND" ]; then
+    pass "package.json defines the canonical test command: $PACKAGE_TEST_COMMAND"
+else
+    fail "package.json does not define scripts.test"
+fi
+
+if grep -qE '^[[:space:]]*bun[[:space:]]+run[[:space:]]+test([[:space:]]|$)' "$RELEASE_SH"; then
+    pass "release.sh delegates to the package test script"
+else
+    fail "release.sh bypasses the package test script"
+fi
+
+if grep -qE '^[[:space:]]*bun[[:space:]]+test([[:space:]]|$)' "$RELEASE_SH"; then
+    fail "release.sh contains a raw bun test invocation"
+else
+    pass "release.sh contains no raw bun test invocation"
+fi
+
+echo
+if [ "$FAIL" -eq 0 ]; then
+    echo "All tests passed."
+else
+    echo "Some tests FAILED."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Run the Factory release test gate through the package configured test script.
- Add a matching shell regression test that rejects raw bun test invocations.
- Keep release behavior, versioning, publishing, product code, and docs unchanged.

## Failing then passing evidence

Before the release.sh edit, bash scripts/release.test.sh exited 1 with:

    PASS: package.json defines the canonical test command: bun test --timeout 30000
    FAIL: release.sh bypasses the package test script
    FAIL: release.sh contains a raw bun test invocation

After the edit, the same command exited 0 with:

    PASS: package.json defines the canonical test command: bun test --timeout 30000
    PASS: release.sh delegates to the package test script
    PASS: release.sh contains no raw bun test invocation
    All tests passed.

bash -n and shellcheck pass for both shell files.

The exact full gate now expands to:

    bun test --timeout 30000

The full local suite loaded 112 files and completed 1,292 tests after installing both independent frozen dependency trees. It reported 1,288 passing and four live-path failures that this scoped script diff does not modify: SessionWatcher has its own 5,000 ms wait for a macOS fs.watch warmth event, and three agentModels assertions could not obtain the live Claude catalog. Those release blockers were reported to the release owner separately; this PR fixes the release scripts bypass of package configuration without masking them.

No UI changed, so no visual artifact applies.

## Transcript

Public repository: transcript remains local and confidential at zion:/Users/muqsit/.agents/.history/versions/codex/0.144.1/home/.codex/sessions/2026/07/13/rollout-2026-07-13T17-13-57-019f5df9-276c-77c1-8b97-c467b30c58e0.jsonl