### PR TITLE
fix(factory): normalize session warmth events

### DIFF
--- a/apps/factory/src/monitor/sessionWatcher.test.ts
+++ b/apps/factory/src/monitor/sessionWatcher.test.ts
@@ -116,8 +116,10 @@ describe('SessionWatcher', () => {
       const fact = facts.find((f) => f.forkedFromId === parentId)!;
       expect(fact.agentType).toBe('claude');
       expect(fact.fileSessionId).toBe(forkId);
+      expect(warmth).toHaveLength(0);
+      await sleep(SETTLE_MS);
 
-      // A subsequent write to the same file should produce a warmth signal.
+      // A subsequent write to the parsed file should produce a warmth signal.
       fs.appendFileSync(file, JSON.stringify({ type: 'assistant' }) + '\n');
       await waitFor(
         () => warmth.some((w) => path.basename(w.filePath) === `${forkId}.jsonl`),

--- a/apps/factory/src/monitor/sessionWatcher.ts
+++ b/apps/factory/src/monitor/sessionWatcher.ts
@@ -51,6 +51,7 @@ export class SessionWatcher {
   private readonly debounceMs: number;
   private readonly mounted: MountedWatcher[] = [];
   private readonly debounceTimers = new Map<string, NodeJS.Timeout>();
+  private readonly parsedFiles = new Set<string>();
   private started = false;
 
   constructor(options: SessionWatcherOptions) {
@@ -88,9 +89,9 @@ export class SessionWatcher {
       if (!ensureDirExists(root)) continue;
       let watcher: fs.FSWatcher;
       try {
-        watcher = fs.watch(root, { recursive: true }, (event, filename) => {
+        watcher = fs.watch(root, { recursive: true }, (_event, filename) => {
           if (!filename) return;
-          this.onEvent(root, agentType, event, filename.toString());
+          this.onEvent(root, agentType, filename.toString());
         });
       } catch {
         continue; // some platforms reject recursive watch — skip the root
@@ -111,21 +112,22 @@ export class SessionWatcher {
     this.mounted.length = 0;
     for (const t of this.debounceTimers.values()) clearTimeout(t);
     this.debounceTimers.clear();
+    this.parsedFiles.clear();
   }
 
   private onEvent(
     root: string,
     agentType: SessionFactPayload['agentType'],
-    event: string,
     relative: string,
   ): void {
     const base = path.basename(relative);
     if (!isSessionFilename(base, agentType)) return;
     const full = path.join(root, relative);
 
-    // Warmth is recorded immediately on every write so a follower's dormancy
-    // clock for its tracked file stays accurate (mirrors recordWrite).
-    if (event === 'change') {
+    // macOS can report an append as `rename`. After a session file has been
+    // parsed, any later event while the path still exists is activity for that
+    // tracked session. Deletion events do not extend its dormancy clock.
+    if (this.parsedFiles.has(full) && fs.existsSync(full)) {
       this.emitWarmth({ filePath: full, ts: Date.now() });
     }
 
@@ -150,6 +152,7 @@ export class SessionWatcher {
       return; // file vanished between event and parse
     }
     const parsed = await parseSessionHead(filePath, agentType);
+    this.parsedFiles.add(filePath);
     this.emit({
       agentType,
       filePath,


### PR DESCRIPTION
Summary
- Treat later fs.watch events for an already parsed session file as activity even when macOS labels an append as rename.
- Ignore first-create and deletion events for warmth, preserving the dormancy semantics.
- Separate the real-file test writes across the FSEvents arming/batching boundary.

Verification
- Focused real-file suite: 3 pass, 0 fail; five consecutive runs passed.
- Full Factory suite: 1,292 pass, 0 fail, 3,378 expectations.
- Full TypeScript and UI compile passed.

Release context
- Found while running apps/factory/scripts/release.sh 0.9.292 --confirm; the script correctly stopped before publishing.
- Pure bug fix in internal session activity tracking; no user-facing docs or changelog entry required.

Confidential session transcript remains local because this is a public repository:
/Users/muqsit/.agents/.history/versions/codex/0.144.1/home/.codex/sessions/2026/07/13/rollout-2026-07-13T17-13-57-019f5df9-276c-77c1-8b97-c467b30c58e0.jsonl