### PR TITLE
feat(cli): wire hooks support for Hermes (RUSH-1687)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@
 
 ### Added
 
+- **Hooks support for Hermes Agent (RUSH-1687).** Central hooks now register into
+  Hermes' `~/.hermes/config.yaml` under a `hooks:` block (YAML, gated to Hermes
+  ≥ 0.11.0). The registrar read-modify-writes the shared config so `mcp_servers`
+  and other keys survive, maps canonical events to Hermes' snake_case lifecycle
+  names (`pre_tool_call`, `post_tool_call`, `on_session_start`, `on_session_end`,
+  `pre_llm_call`, `on_session_finalize`, `subagent_stop`), and caps each timeout
+  at 300s. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/hooks.ts`,
+  `apps/cli/src/lib/staleness/writers/hooks.ts`.
+
 - **`agents routines add --resume <sessionId>` — wake an existing session instead
   of starting fresh.** At fire time the job runs `agents run <agent> --resume <id>`,
   so the *actual* prior session reopens with its full context and the routine's

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -109,6 +109,7 @@ Antigravity CLI, Grok CLI, OpenCode — features target these six first.
 | Kiro | `kiro` | ≥0.10 | ✓ | ≥2.8 | ✓ | ✓ | — | ≥1.23 | — |
 | Goose | `goose` | ≥1.34 | ✓ | ✓ | ≥1.25 | — | ✓ | — | ✓ |
 | Droid | `droid` | ✓ | ✓ | ≥0.57.5 | ≥0.26 | ✓ | ✓ | ✓ | — |
+| Hermes | `hermes` | ≥0.11 | ✓ | — | ✓ | — | — | — | — |
 
 ✓ = supported · — = not · version cell = only within that range (out-of-range =
 skipped silently). [`src/lib/agents.ts`](src/lib/agents.ts) is canonical — keep this

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - **Wire subagents support for Cursor CLI (RUSH-1388).** cursor-agent loads custom subagents as Markdown with YAML frontmatter under `~/.cursor/agents/*.md` (project-scoped `.cursor/agents/` also supported natively), same shape as Claude/Droid/Copilot minus the `color` field, gated at `>= 2026.1.22` (cursor-agent's CalVer build tag for Cursor 2.4). Flip Cursor's `subagents`, add `transformSubagentForCursor` (alias of `transformSubagentForDroid`), and wire the install/remove, list, orphan-detection, writer, and detector paths. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/subagents.ts`, `apps/cli/src/lib/staleness/{writers,detectors}/subagents.ts`.
+- **Wire hooks support for Hermes (RUSH-1687).** `agents` now registers central hooks into Hermes Agent's `~/.hermes/config.yaml` under a `hooks:` block (YAML, ≥ 0.11.0). The registrar read-modify-writes that shared config so sibling keys like `mcp_servers` survive, maps canonical events to Hermes' snake_case lifecycle names (`SessionStart→on_session_start`, `SessionEnd→on_session_end`, `PreToolUse→pre_tool_call`, `PostToolUse→post_tool_call`, `SubagentStop→subagent_stop`, `UserPromptSubmit→pre_llm_call`, `Stop→on_session_finalize`), and clamps each hook's timeout to 300s (default 60s). Managed entries are re-synced idempotently while user-authored hooks are preserved. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/hooks.ts`, `apps/cli/src/lib/staleness/writers/hooks.ts`.
 
 ## 1.20.61
 

--- a/apps/cli/docs/hooks.md
+++ b/apps/cli/docs/hooks.md
@@ -183,17 +183,20 @@ Only hooks with `cache:` are instrumented today — that's deliberate. Opting in
 
 | Event | When it fires | Agents |
 |-------|--------------|--------|
-| `SessionStart` | Agent session begins | Claude, Codex, Gemini, Grok, Copilot (`sessionStart`), Kiro, Goose, Cursor (`sessionStart`) |
-| `SessionEnd` | Agent session ends | Claude, Grok, Copilot (`sessionEnd`), Goose, Cursor (`sessionEnd`) |
-| `UserPromptSubmit` | User prompt received before model sees it | Claude, Gemini (as `BeforeAgent`), Grok, Copilot (`userPromptSubmitted`), Kiro, Goose, Cursor (`beforeSubmitPrompt`) |
-| `PreToolUse` | Before a tool call executes | Claude, Codex, Gemini, Antigravity (`before_tool_call`), Copilot (`preToolUse`), Kiro, Goose, Cursor (`preToolUse`) |
-| `PostToolUse` | After a tool call completes | Claude, Codex, Gemini, Antigravity (mapped to `after_model_call`), Copilot (`postToolUse`), Kiro, Goose, Cursor (`postToolUse`) |
+| `SessionStart` | Agent session begins | Claude, Codex, Gemini, Grok, Copilot (`sessionStart`), Kiro, Goose, Cursor (`sessionStart`), Hermes (`on_session_start`) |
+| `SessionEnd` | Agent session ends | Claude, Grok, Copilot (`sessionEnd`), Goose, Cursor (`sessionEnd`), Hermes (`on_session_end`) |
+| `UserPromptSubmit` | User prompt received before model sees it | Claude, Gemini (as `BeforeAgent`), Grok, Copilot (`userPromptSubmitted`), Kiro, Goose, Cursor (`beforeSubmitPrompt`), Hermes (`pre_llm_call`) |
+| `PreToolUse` | Before a tool call executes | Claude, Codex, Gemini, Antigravity (`before_tool_call`), Copilot (`preToolUse`), Kiro, Goose, Cursor (`preToolUse`), Hermes (`pre_tool_call`) |
+| `PostToolUse` | After a tool call completes | Claude, Codex, Gemini, Antigravity (mapped to `after_model_call`), Copilot (`postToolUse`), Kiro, Goose, Cursor (`postToolUse`), Hermes (`post_tool_call`) |
+| `SubagentStop` | A subagent finishes | Claude, Cursor (`subagentStop`), Hermes (`subagent_stop`) |
 | `PreCompact` | Before context compaction | Claude, Grok, Copilot (`preCompact`), Cursor (`preCompact`) |
-| `Stop` | Agent stops (final turn) | Claude, Codex, Antigravity (`on_loop_stop`), Grok, Copilot (`agentStop`), Kiro, Goose, Cursor (`stop`) |
+| `Stop` | Agent stops (final turn) | Claude, Codex, Antigravity (`on_loop_stop`), Grok, Copilot (`agentStop`), Kiro, Goose, Cursor (`stop`), Hermes (`on_session_finalize`) |
 | `Notification` | Agent sends a notification | Claude, Grok, Copilot (`notification`) |
 | `OnError` | Agent encounters an error | Antigravity (`on_error`), Copilot (`errorOccurred`) |
 
-Event name mapping across agents is handled in `src/lib/hooks.ts`: `GEMINI_EVENT_MAP`, `ANTIGRAVITY_EVENT_MAP`, Grok's `eventMap`, `COPILOT_EVENT_MAP`, `KIRO_EVENT_MAP`, `GOOSE_EVENT_MAP`, and `CURSOR_EVENT_MAP`.
+Event name mapping across agents is handled in `src/lib/hooks.ts`: `GEMINI_EVENT_MAP`, `ANTIGRAVITY_EVENT_MAP`, Grok's `eventMap`, `COPILOT_EVENT_MAP`, `KIRO_EVENT_MAP`, `GOOSE_EVENT_MAP`, `CURSOR_EVENT_MAP`, and `HERMES_EVENT_MAP`.
+
+Hermes (Nous Research, ≥ 0.11.0) declares hooks under a `hooks:` block in `~/.hermes/config.yaml` (shared with `mcp_servers`); the registrar read-modify-writes that YAML doc so sibling keys survive. Each entry is `{ command, timeout, matcher? }` (timeout defaults to 60s, capped at 300s).
 
 ## Predicate Matchers
 

--- a/apps/cli/src/lib/__tests__/capabilities.test.ts
+++ b/apps/cli/src/lib/__tests__/capabilities.test.ts
@@ -245,6 +245,11 @@ describe('capableAgents()', () => {
     expect(agents).toContain('cursor');
   });
 
+  it('includes hermes for hooks (Hermes Agent config.yaml hooks since 0.11.0)', () => {
+    const agents = capableAgents('hooks');
+    expect(agents).toContain('hermes');
+  });
+
   it('excludes opencode/amp for hooks', () => {
     const agents = capableAgents('hooks');
     expect(agents).not.toContain('opencode');
@@ -265,6 +270,22 @@ describe('goose hooks version gate', () => {
   it('passes 1.34.0 and above', () => {
     expect(supports('goose', 'hooks', '1.34.0')).toEqual({ ok: true });
     expect(supports('goose', 'hooks', '1.37.0')).toEqual({ ok: true });
+  });
+});
+
+describe('hermes hooks version gate', () => {
+  it('gates versions below 0.11.0 as too_old', () => {
+    const result = supports('hermes', 'hooks', '0.10.0');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('too_old');
+      expect(result.need).toBe('>= 0.11.0');
+    }
+  });
+
+  it('passes 0.11.0 and above', () => {
+    expect(supports('hermes', 'hooks', '0.11.0')).toEqual({ ok: true });
+    expect(supports('hermes', 'hooks', '0.14.2')).toEqual({ ok: true });
   });
 });
 

--- a/apps/cli/src/lib/__tests__/hooks.test.ts
+++ b/apps/cli/src/lib/__tests__/hooks.test.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 
 import { registerHooksToSettings, unmanagedHookNames, computeCodexHookTrustHash, toPortableCommand, pruneVersionHomeHookEntriesFromSettings } from '../hooks.js';
 import * as TOML from 'smol-toml';
+import * as yaml from 'yaml';
 import { CODEX_HOOKS_MIN_VERSION } from '../agents.js';
 import { compareVersions } from '../versions.js';
 import { toPosix } from '../platform/index.js';
@@ -1105,6 +1106,144 @@ describe('registerHooksToSettings - Cursor', () => {
     parsed = JSON.parse(fs.readFileSync(outPath, 'utf-8'));
     expect(parsed.hooks.preToolUse).toBeUndefined();
     expect(parsed.hooks.postToolUse).toHaveLength(1);
+  });
+});
+
+describe('registerHooksToSettings - Hermes', () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-test-'));
+    agentsDir = path.join(tmpDir, '.agents');
+    fs.mkdirSync(path.join(agentsDir, 'hooks'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeHermesScript(name: string): string {
+    const scriptPath = path.join(agentsDir, 'hooks', name);
+    fs.writeFileSync(scriptPath, '#!/bin/sh\necho hello\n', 'utf-8');
+    fs.chmodSync(scriptPath, 0o755);
+    return scriptPath;
+  }
+
+  function readConfig(versionHome: string): Record<string, unknown> {
+    return yaml.parse(
+      fs.readFileSync(path.join(versionHome, '.hermes', 'config.yaml'), 'utf-8')
+    );
+  }
+
+  it('writes ~/.hermes/config.yaml with snake_case events and no version wrapper', () => {
+    makeHermesScript('on-prompt.sh');
+    const versionHome = path.join(tmpDir, 'home');
+    const manifest: Record<string, ManifestHook> = {
+      'on-prompt': {
+        script: 'on-prompt.sh',
+        events: ['UserPromptSubmit', 'SessionStart', 'Stop'],
+        timeout: 45,
+      },
+    };
+
+    const result = registerHooksToSettings('hermes', versionHome, manifest, agentsDir);
+    expect(result.errors).toHaveLength(0);
+    expect(result.registered).toContain('on-prompt -> pre_llm_call');
+    expect(result.registered).toContain('on-prompt -> on_session_start');
+    expect(result.registered).toContain('on-prompt -> on_session_finalize');
+
+    const parsed = readConfig(versionHome);
+    expect(parsed.version).toBeUndefined();
+    const hooks = parsed.hooks as Record<string, Array<{ command: string; timeout: number }>>;
+    expect(hooks.on_session_start).toHaveLength(1);
+    expect(hooks.pre_llm_call[0].timeout).toBe(45);
+    expect(resolvedCommand(hooks.on_session_finalize[0].command)).toContain('on-prompt.sh');
+  });
+
+  it('maps tool events and clamps timeout at 300s', () => {
+    makeHermesScript('guard.sh');
+    const versionHome = path.join(tmpDir, 'home');
+    registerHooksToSettings(
+      'hermes',
+      versionHome,
+      { guard: { script: 'guard.sh', events: ['PreToolUse', 'PostToolUse'], matcher: 'Shell|Write', timeout: 999 } },
+      agentsDir
+    );
+    const hooks = readConfig(versionHome).hooks as Record<
+      string,
+      Array<{ matcher?: string; timeout: number }>
+    >;
+    expect(hooks.pre_tool_call[0].matcher).toBe('Shell|Write');
+    expect(hooks.pre_tool_call[0].timeout).toBe(300);
+    expect(hooks.post_tool_call[0].matcher).toBe('Shell|Write');
+  });
+
+  it('does not duplicate on repeated sync', () => {
+    makeHermesScript('on-prompt.sh');
+    const versionHome = path.join(tmpDir, 'home');
+    const manifest: Record<string, ManifestHook> = {
+      'on-prompt': { script: 'on-prompt.sh', events: ['PreToolUse'] },
+    };
+    registerHooksToSettings('hermes', versionHome, manifest, agentsDir);
+    registerHooksToSettings('hermes', versionHome, manifest, agentsDir);
+    const hooks = readConfig(versionHome).hooks as Record<string, unknown[]>;
+    expect(hooks.pre_tool_call).toHaveLength(1);
+  });
+
+  it('preserves existing mcp_servers key (shared config.yaml)', () => {
+    makeHermesScript('on-prompt.sh');
+    const versionHome = path.join(tmpDir, 'home');
+    const configPath = path.join(versionHome, '.hermes', 'config.yaml');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      yaml.stringify({
+        mcp_servers: { fs: { command: 'mcp-fs', args: ['--root', '/tmp'] } },
+        model: 'hermes-4',
+      }),
+      'utf-8'
+    );
+
+    registerHooksToSettings(
+      'hermes',
+      versionHome,
+      { 'on-prompt': { script: 'on-prompt.sh', events: ['SessionStart'] } },
+      agentsDir
+    );
+
+    const parsed = readConfig(versionHome) as {
+      mcp_servers?: Record<string, unknown>;
+      model?: string;
+      hooks?: Record<string, unknown>;
+    };
+    expect(parsed.mcp_servers).toBeDefined();
+    expect((parsed.mcp_servers as { fs: { command: string } }).fs.command).toBe('mcp-fs');
+    expect(parsed.model).toBe('hermes-4');
+    expect(parsed.hooks?.on_session_start).toBeDefined();
+  });
+
+  it('preserves user-authored entries outside managed prefixes', () => {
+    makeHermesScript('on-prompt.sh');
+    const versionHome = path.join(tmpDir, 'home');
+    const configPath = path.join(versionHome, '.hermes', 'config.yaml');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      yaml.stringify({
+        hooks: { on_session_start: [{ command: '/usr/local/bin/my-custom-hook', timeout: 60 }] },
+      }),
+      'utf-8'
+    );
+
+    registerHooksToSettings(
+      'hermes',
+      versionHome,
+      { 'on-prompt': { script: 'on-prompt.sh', events: ['SessionStart'] } },
+      agentsDir
+    );
+
+    const hooks = readConfig(versionHome).hooks as Record<string, Array<{ command: string }>>;
+    const cmds = hooks.on_session_start.map((h) => h.command);
+    expect(cmds).toContain('/usr/local/bin/my-custom-hook');
+    expect(cmds.some((c) => c.includes('on-prompt') || resolvedCommand(c).includes('on-prompt'))).toBe(true);
   });
 });
 

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -641,9 +641,12 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     instructionsFile: 'MEMORY.md',
     format: 'markdown',
     variableSyntax: '$ARGUMENTS',
-    supportsHooks: false,
+    supportsHooks: true,
     capabilities: {
-      hooks: false,
+      // Lifecycle hooks land in ~/.hermes/config.yaml under a `hooks:` block
+      // (YAML, shared with `mcp_servers`); gated to Hermes ≥ 0.11.0 which
+      // introduced the configurable hook runner.
+      hooks: { since: '0.11.0' },
       mcp: true,
       mcpHttp: true,
       mcpHeaders: false,

--- a/apps/cli/src/lib/hooks.ts
+++ b/apps/cli/src/lib/hooks.ts
@@ -1143,6 +1143,9 @@ export function registerHooksToSettings(
   if (agentId === 'cursor') {
     return registerHooksForCursor(versionHome, manifest, resolveScript, managedPrefixes);
   }
+  if (agentId === 'hermes') {
+    return registerHooksForHermes(versionHome, manifest, resolveScript, managedPrefixes);
+  }
   return { registered: [], errors: [] };
 }
 
@@ -2542,6 +2545,151 @@ function registerHooksForCursor(
     );
   } catch (err) {
     errors.push(`Failed to write hooks.json: ${(err as Error).message}`);
+  }
+
+  return { registered, errors };
+}
+
+/**
+ * Canonical → Hermes (Nous Research) snake_case lifecycle events.
+ *
+ * Hermes ≥ 0.11.0 runs configurable hooks declared under `hooks:` in
+ * ~/.hermes/config.yaml. Only events with a documented Hermes equivalent are
+ * mapped; unmapped canonical events (the manifest may declare events for other
+ * agents) are skipped silently. UserPromptSubmit maps to `pre_llm_call` (the
+ * closest pre-turn phase) and Stop to `on_session_finalize`.
+ */
+const HERMES_EVENT_MAP: Record<string, string> = {
+  SessionStart: 'on_session_start',
+  SessionEnd: 'on_session_end',
+  PreToolUse: 'pre_tool_call',
+  PostToolUse: 'post_tool_call',
+  SubagentStop: 'subagent_stop',
+  UserPromptSubmit: 'pre_llm_call',
+  Stop: 'on_session_finalize',
+};
+
+/** Hermes caps hook timeouts at 300s (default 60s). */
+const HERMES_TIMEOUT_CAP = 300;
+const HERMES_TIMEOUT_DEFAULT = 60;
+
+/**
+ * Register hooks for Hermes Agent (Nous Research ≥ 0.11.0).
+ *
+ * Read-modify-writes the shared `~/.hermes/config.yaml` (under the version
+ * home): it merges a `hooks:` block of the form
+ *   hooks: { <event>: [ { command, timeout, matcher? } ] }
+ * into the YAML doc WITHOUT touching sibling keys (`mcp_servers` in
+ * particular — a naive overwrite would wipe the user's MCP servers). No
+ * `version` wrapper: Hermes' config is a flat YAML map.
+ *
+ * GC: rewrite managed entries by command path under managedPrefixes; preserve
+ * user-authored entries whose command is outside managed roots. Keyed by
+ * event|command|matcher so a matcher or event change drops the stale entry.
+ */
+function registerHooksForHermes(
+  versionHome: string,
+  manifest: Record<string, ManifestHook>,
+  resolveScript: (script: string) => string | null,
+  managedPrefixes: string[]
+): { registered: string[]; errors: string[] } {
+  const registered: string[] = [];
+  const errors: string[] = [];
+
+  const configDir = path.join(versionHome, '.hermes');
+  const configPath = path.join(configDir, 'config.yaml');
+
+  type HermesEntry = { command: string; timeout: number; matcher?: string };
+
+  // Read-modify-write: preserve the full existing YAML doc (mcp_servers, etc.).
+  let config: Record<string, unknown> = {};
+  if (fs.existsSync(configPath)) {
+    try {
+      const parsed = yaml.parse(fs.readFileSync(configPath, 'utf-8'));
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        config = parsed as Record<string, unknown>;
+      }
+    } catch {
+      errors.push('Failed to parse existing config.yaml');
+      return { registered, errors };
+    }
+  }
+
+  const existingHooks =
+    config.hooks && typeof config.hooks === 'object' && !Array.isArray(config.hooks)
+      ? (config.hooks as Record<string, HermesEntry[]>)
+      : {};
+
+  // Desired managed entries keyed by event|command|matcher so a matcher or
+  // event change drops the stale entry instead of retaining it by command alone.
+  const desiredManaged = new Set<string>();
+  for (const [hookName, hookDef] of Object.entries(manifest)) {
+    if (!hookDef.events || hookDef.events.length === 0) continue;
+    const resolved = resolveHookCommand(hookName, hookDef, resolveScript);
+    if (!resolved) continue;
+    for (const event of hookDef.events) {
+      const hermesEvent = HERMES_EVENT_MAP[event];
+      if (!hermesEvent) continue;
+      desiredManaged.add(`${hermesEvent}|${resolved}|${hookDef.matcher ?? ''}`);
+    }
+  }
+
+  // GC managed entries that are no longer in the manifest; preserve user entries.
+  const hooks: Record<string, HermesEntry[]> = {};
+  for (const [event, entries] of Object.entries(existingHooks)) {
+    if (!Array.isArray(entries)) continue;
+    hooks[event] = entries.filter((e) => {
+      if (typeof e?.command !== 'string') return true;
+      if (!isManagedHookCommand(e.command, managedPrefixes)) return true;
+      return desiredManaged.has(`${event}|${e.command}|${e.matcher ?? ''}`);
+    });
+    if (hooks[event].length === 0) delete hooks[event];
+  }
+
+  for (const [name, hookDef] of Object.entries(manifest)) {
+    if (!hookDef.events || hookDef.events.length === 0) continue;
+
+    const commandPath = resolveHookCommand(name, hookDef, resolveScript);
+    if (!commandPath) {
+      errors.push(`${name}: script not found in user or system hooks dir`);
+      continue;
+    }
+
+    const timeout = Math.min(HERMES_TIMEOUT_CAP, hookDef.timeout ?? HERMES_TIMEOUT_DEFAULT);
+
+    for (const event of hookDef.events) {
+      const hermesEvent = HERMES_EVENT_MAP[event];
+      if (!hermesEvent) continue;
+
+      if (!hooks[hermesEvent]) hooks[hermesEvent] = [];
+
+      const entry: HermesEntry = { command: commandPath, timeout };
+      if (hookDef.matcher) entry.matcher = hookDef.matcher;
+
+      const existingIdx = hooks[hermesEvent].findIndex(
+        (h) => h.command === entry.command && (h.matcher ?? '') === (entry.matcher ?? '')
+      );
+      if (existingIdx >= 0) {
+        hooks[hermesEvent][existingIdx] = entry;
+      } else {
+        hooks[hermesEvent].push(entry);
+      }
+
+      registered.push(`${name} -> ${hermesEvent}`);
+    }
+  }
+
+  if (Object.keys(hooks).length > 0) {
+    config.hooks = hooks;
+  } else {
+    delete config.hooks;
+  }
+
+  try {
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(configPath, yaml.stringify(config), 'utf-8');
+  } catch (err) {
+    errors.push(`Failed to write config.yaml: ${(err as Error).message}`);
   }
 
   return { registered, errors };

--- a/apps/cli/src/lib/staleness/writers/hooks.ts
+++ b/apps/cli/src/lib/staleness/writers/hooks.ts
@@ -40,7 +40,7 @@ function buildHooksWriter(agent: AgentId): ResourceWriter<string[]> {
       // registerHooksForGrok — file copy alone only sees top-level available.hooks
       // names (RUSH-1353). Copilot/Kiro/Goose load managed *.json under their
       // hooks dirs the same way.
-      if (agent === 'claude' || agent === 'codex' || agent === 'gemini' || agent === 'antigravity' || agent === 'kimi' || agent === 'droid' || agent === 'copilot' || agent === 'kiro' || agent === 'goose' || agent === 'cursor' || agent === 'grok') {
+      if (agent === 'claude' || agent === 'codex' || agent === 'gemini' || agent === 'antigravity' || agent === 'kimi' || agent === 'droid' || agent === 'copilot' || agent === 'kiro' || agent === 'goose' || agent === 'cursor' || agent === 'grok' || agent === 'hermes') {
         registerHooksToSettings(agent, versionHome);
       }
       return { synced };

--- a/apps/cli/tests/agents.test.ts
+++ b/apps/cli/tests/agents.test.ts
@@ -114,7 +114,7 @@ describe('Hermes and ForgeCode install targets', () => {
     expect(capableAgents('mcp')).toContain('hermes');
     expect(capableAgents('skills')).toContain('hermes');
     expect(capableAgents('commands')).not.toContain('hermes');
-    expect(capableAgents('hooks')).not.toContain('hermes');
+    expect(capableAgents('hooks')).toContain('hermes');
     expect(AGENTS.hermes.instructionsFile).toBe('MEMORY.md');
     expect(AGENTS.hermes.capabilities.rules).toEqual({ file: 'MEMORY.md' });
   });


### PR DESCRIPTION
## Summary

Wires central-hooks registration for **Hermes Agent** (Nous Research). `agents` now writes central hooks into Hermes' `~/.hermes/config.yaml` under a `hooks:` block (YAML), gated to Hermes **≥ 0.11.0** — the release that introduced the configurable hook runner.

The registrar **read-modify-writes** the shared `config.yaml` so sibling keys (notably `mcp_servers`) survive untouched — a naive overwrite would wipe the user's MCP servers. Managed entries re-sync idempotently; user-authored hooks outside managed prefixes are preserved. Each hook timeout is clamped to 300s (default 60s).

## Files changed

- `apps/cli/src/lib/agents.ts` — flip Hermes `supportsHooks: true` and `hooks: { since: '0.11.0' }`
- `apps/cli/src/lib/hooks.ts` — dispatch `hermes` → new `registerHooksForHermes` + `HERMES_EVENT_MAP` (YAML read-modify-write, GC/idempotency modeled on the Cursor registrar)
- `apps/cli/src/lib/staleness/writers/hooks.ts` — add `hermes` to the native-registration list
- `apps/cli/src/lib/__tests__/capabilities.test.ts` — version-gate + `capableAgents('hooks')` membership
- `apps/cli/src/lib/__tests__/hooks.test.ts` — registrar behavior incl. `mcp_servers` preservation, timeout clamp, no-duplicate re-sync, user-entry preservation
- `apps/cli/docs/hooks.md`, `apps/cli/AGENTS.md` — capability snapshot + event mapping table
- `apps/cli/CHANGELOG.md`, `CHANGELOG.md` — Unreleased entries

## Event mapping (canonical → Hermes)

| Canonical | Hermes |
|---|---|
| `SessionStart` | `on_session_start` |
| `SessionEnd` | `on_session_end` |
| `PreToolUse` | `pre_tool_call` |
| `PostToolUse` | `post_tool_call` |
| `SubagentStop` | `subagent_stop` |
| `UserPromptSubmit` | `pre_llm_call` |
| `Stop` | `on_session_finalize` |

Unmapped canonical events are skipped silently.

## End-to-end verification

Ran a scratch script (deleted before commit) that pre-seeded `config.yaml` with an `mcp_servers` block and a `model` key, then registered a real hook manifest via `registerHooksToSettings('hermes', ...)` and read the YAML back:

```yaml
model: hermes-4
mcp_servers:
  filesystem:
    command: mcp-fs
    args:
      - --root
      - /tmp
hooks:
  pre_tool_call:
    - command: /tmp/hermes-e2e-XXXX/.agents/hooks/audit.sh
      timeout: 30
      matcher: Shell
  on_session_start:
    - command: /tmp/hermes-e2e-XXXX/.agents/hooks/audit.sh
      timeout: 30
      matcher: Shell
  on_session_finalize:
    - command: /tmp/hermes-e2e-XXXX/.agents/hooks/audit.sh
      timeout: 30
      matcher: Shell
```

`registered: ["audit -> pre_tool_call","audit -> on_session_start","audit -> on_session_finalize"]`, `errors: []`. `mcp_servers` and `model` survived; the `hooks:` block was written with the correct snake_case event keys.

## Tests

- `bun run tsc --noEmit` — clean (rc=0)
- `bun run vitest run src/lib/__tests__/hooks.test.ts src/lib/__tests__/capabilities.test.ts src/lib/staleness tests/versions.test.ts` — **361 passed (361)**, 15 files
- `bun run vitest run src/lib/agents.test.ts` — **44 passed**