### PR TITLE
fix(run): --resume spawns from the session's origin cwd (unbreaks routines --resume)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`agents run --resume <id>` now spawns from the session's origin directory.**
+  Native resume (claude/codex) resolves the transcript relative to the working
+  directory (`projects/<cwd-hash>/`), but the resolver found the session across all
+  projects and then invoked the agent from the *current* cwd — so a resume from a
+  different directory (most importantly a routine daemon firing `agents run --resume`)
+  failed with "No conversation found with session ID". It now `cd`s to the resolved
+  session's own `cwd` (honoring an explicit `--cwd`). This makes `routines add
+  --resume` (self-scheduled wake-ups) actually reopen the session end-to-end.
+
 ### Added
 
 - **Allowlist (permissions) support for OpenClaw (RUSH-1570).** Permission

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -1257,7 +1257,15 @@ export function registerRunCommand(program: Command): void {
         if (nativeResume(agent)) {
           resumeNative = true;
           resumeSessionId = session.id;
-          if (!options.quiet) process.stderr.write(chalk.gray(`Resuming ${agent} ${session.shortId} (native)${version ? ` @${version}` : ''}\n`));
+          // Native `--resume` (claude/codex) resolves the transcript relative to the
+          // working directory (projects/<cwd-hash>/). The session may have been started
+          // in a different directory than we're standing in now — most importantly when a
+          // routine daemon fires `agents run --resume` from its own cwd. Spawn from the
+          // session's ORIGIN cwd so the resume actually finds it; otherwise the agent
+          // exits "No conversation found with session ID". Honor an explicit --cwd only if
+          // the caller passed one (they're overriding on purpose).
+          if (!options.cwd && session.cwd) options.cwd = session.cwd;
+          if (!options.quiet) process.stderr.write(chalk.gray(`Resuming ${agent} ${session.shortId} (native)${version ? ` @${version}` : ''}${!options.cwd || options.cwd === session.cwd ? ` in ${session.cwd ?? cwd}` : ''}\n`));
         } else {
           // Tier-2: launch fresh with a /continue <id> first message; the agent
           // loads the transcript via `agents sessions <id>` and picks up.


### PR DESCRIPTION
## Problem

`agents run --resume <id>` resolves the session correctly but then can't open it:

```
agents run claude --resume aa3d7a62
  → No match in this project; widened to all projects.   ✅ found it
  → Resuming claude aa3d7a62 (native) @2.1.187            ✅ resolved id + version
  → Running: claude@2.1.187 --resume aa3d7a62-… -p …
  → No conversation found with session ID: aa3d7a62-…     ❌
```

Native `--resume` (claude/codex) resolves the transcript **relative to the working directory** (`projects/<cwd-hash>/`). The resolver widens the id search across all projects and finds the session, but then invokes the agent from the **current** cwd — so a resume from any other directory fails. This is exactly what breaks a **routine daemon firing `agents run --resume`** (`routines add --resume`, self-scheduled wake-ups): the daemon's cwd ≠ the session's origin, so every fire hits "No conversation found."

## Fix

Once the session is resolved, `cd` to its own `session.cwd` (already populated in the session index) before spawning — unless the caller passed an explicit `--cwd`. One line at the resolution site (`commands/exec.ts`).

This mirrors what the `/hibernate` launchd wrapper already does (it `cd`s to the origin cwd before raw `claude --resume`, which is why *that* path works today).

## Impact

Makes `agents routines add --resume` (added in v1.20.61) actually reopen the session end-to-end. Verified live after release (a native resume routine that recalls a prior-turn fact).