### PR TITLE
fix(run): --fallback no longer disables account rotation; cascade on stdout billing refusals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
   and `runWithFallback` now tees a bounded stdout tail per attempt
   (`captureStdoutTail`) and scans it alongside stderr. Output remains mirrored
   to the parent's stdout exactly as before.
+
+- **`agents run --resume <id>` now spawns from the session's origin directory.**
   Native resume (claude/codex) resolves the transcript relative to the working
   directory (`projects/<cwd-hash>/`), but the resolver found the session across all
   projects and then invoked the agent from the *current* cwd — so a resume from a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,27 @@
 
 ### Fixed
 
-- **`agents run --resume <id>` now spawns from the session's origin directory.**
+- **`agents run <agent> --fallback …` no longer disables account rotation.**
+  A `--fallback` chain skipped strategy resolution entirely ("strategy balanced
+  ignored: --fallback pins versions directly"), so the bare primary always ran on
+  the pinned default version — one fixed account, every run. On a multi-account
+  host this silently stopped rotation for exactly the runs that most need it
+  (unattended monitors dispatching with a cross-agent fallback chain). The
+  fallback chain only names where to cascade; it never pinned the primary, so
+  the strategy now resolves the primary's version/account as usual. The
+  same-agent rotation failover (#348) also now composes with an explicit chain:
+  the other healthy accounts are unshifted ahead of the cross-agent entries, so
+  a rate limit exhausts same-agent accounts before switching CLIs. Explicit
+  `@version` pins and profiles keep their pinning behavior.
+
+- **Fallback now cascades on Claude billing refusals ("monthly spend limit",
+  "out of usage credits").** Two gaps: the messages matched no
+  `RATE_LIMIT_PATTERNS` entry, and Claude prints them to **stdout** while the
+  cascade only scanned stderr — so a capped account failed the whole run
+  (exit 1) with codex/droid sitting unused in the chain. Added both patterns,
+  and `runWithFallback` now tees a bounded stdout tail per attempt
+  (`captureStdoutTail`) and scans it alongside stderr. Output remains mirrored
+  to the parent's stdout exactly as before.
   Native resume (claude/codex) resolves the transcript relative to the working
   directory (`projects/<cwd-hash>/`), but the resolver found the session across all
   projects and then invoked the agent from the *current* cwd — so a resume from a

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -1291,15 +1291,17 @@ export function registerRunCommand(program: Command): void {
       }
       const strategy = options.balanced ? 'balanced' : explicitStrategy ?? configuredStrategy;
 
-      // Strategy only applies to bare agent invocations. Explicit @version,
-      // profiles, and fallback chains already define their execution target.
+      // Strategy only applies to bare agent invocations. Explicit @version and
+      // profiles already define their execution target. A --fallback chain does
+      // NOT pin the primary: it only names where to cascade on a rate limit, so
+      // the bare primary still resolves through the strategy — otherwise every
+      // `agents run claude --fallback codex` run lands on the pinned default
+      // account and account rotation silently stops (the gh-monitor heal bug).
       if (strategy !== 'pinned' || options.balanced || explicitStrategy) {
         if (version) {
           process.stderr.write(chalk.yellow(`[agents] strategy ${strategy} ignored: version ${version} is pinned\n`));
         } else if (fromProfile) {
           process.stderr.write(chalk.yellow(`[agents] strategy ${strategy} ignored: profile pins its own version/auth\n`));
-        } else if (options.fallback) {
-          process.stderr.write(chalk.yellow(`[agents] strategy ${strategy} ignored: --fallback pins versions directly\n`));
         } else {
           try {
             const resolved = await resolveRunVersion(agent, strategy, cwd);
@@ -1599,18 +1601,24 @@ export function registerRunCommand(program: Command): void {
       // path (continuing the session via /continue). Because this injects into
       // the same `fallback` array `--fallback` uses, it must only arm for run
       // shapes that accept a fallback chain — shouldArmRotationFailover excludes
-      // acp/loop/resume-checkpoint (which reject a non-empty fallback below),
-      // interactive/no-prompt runs, and runs that already have an explicit or
-      // profile fallback. Pinned/single-account runs stay unchanged because
-      // rotationResult is null or rotationFailoverChain returns []. version is
-      // set here because rotationResult is only populated when resolveRunVersion
-      // picked one.
+      // acp/loop/resume-checkpoint (which reject a non-empty fallback below)
+      // and interactive/no-prompt runs. Pinned/single-account runs stay
+      // unchanged because rotationResult is null or rotationFailoverChain
+      // returns []. version is set here because rotationResult is only
+      // populated when resolveRunVersion picked one.
+      //
+      // Composes with an explicit --fallback chain: the same-agent accounts are
+      // UNSHIFTED ahead of the user's cross-agent entries, so a rate limit
+      // first tries the other accounts of the same agent (cheapest recovery —
+      // same CLI, session continues) and only then cascades to codex/gemini/etc.
+      // Profiles never compose: strategy is skipped for them, rotationResult
+      // stays null. (fromProfile's model-swap unshift above is therefore never
+      // displaced by this one.)
       if (
         shouldArmRotationFailover({
           hasRotation: !!rotationResult,
           hasVersion: !!version,
           hasPrompt: prompt !== undefined,
-          explicitFallback: fallback.length > 0,
           interactive: !!options.interactive,
           acp: !!options.acp,
           loop: !!options.loop,
@@ -1619,7 +1627,7 @@ export function registerRunCommand(program: Command): void {
       ) {
         const failover = rotationFailoverChain(rotationResult!, version!);
         if (failover.length > 0) {
-          fallback.push(...failover);
+          fallback.unshift(...failover);
           if (!options.quiet) {
             const accounts = failover.map(f => `${f.agent}@${f.version}`).join(', ');
             process.stderr.write(chalk.gray(`[agents] rate-limit failover armed: ${accounts}\n`));

--- a/apps/cli/src/lib/__tests__/exec.test.ts
+++ b/apps/cli/src/lib/__tests__/exec.test.ts
@@ -1007,6 +1007,9 @@ describe('detectRateLimit', () => {
     ['429 too many requests', '429: Too Many Requests'],
     ['Anthropic overloaded', 'API Error: Overloaded'],
     ['api_overloaded snake case', 'error_type: api_overloaded'],
+    ['Claude org monthly spend limit (stdout, exit 1)', "You've hit your org's monthly spend limit · run /usage-credits to raise it, or visit claude.ai/admin-settings/usage"],
+    ['Claude out of usage credits (stdout, exit 1)', "You're out of usage credits. /model to switch models."],
+    ['out of credits without "usage"', 'Your account is out of credits.'],
   ])('matches %s', (_label, text) => {
     expect(detectRateLimit(text)).toBe(true);
   });

--- a/apps/cli/src/lib/exec.test.ts
+++ b/apps/cli/src/lib/exec.test.ts
@@ -227,6 +227,16 @@ describe('shouldTapStdout (budget live-watcher attach gating, #346 FIX 3)', () =
     expect(shouldTapStdout(true, false, true)).toBe(false);
     expect(shouldTapStdout(true, true, true)).toBe(false);
   });
+
+  // Fallback chains need a stdout tail: Claude prints billing refusals (spend
+  // limit / out of credits) to stdout, so a stderr-only scan never cascades.
+  it('taps when a fallback chain requests a stdout tail, even at a TTY with no caps', () => {
+    expect(shouldTapStdout(false, false, false, /*captureTail*/ true)).toBe(true);
+  });
+
+  it('captureTail never overrides the interactive guard', () => {
+    expect(shouldTapStdout(true, false, false, true)).toBe(false);
+  });
 });
 
 describe('resolveInteractive (sanity for the gating inputs above)', () => {

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -191,6 +191,15 @@ export interface ExecOptions {
   /** Raw args captured after `--` on the command line, forwarded verbatim to the underlying agent CLI. */
   passthroughArgs?: string[];
   /**
+   * Tee-and-tail the child's stdout even when no budget cap is active, so the
+   * caller can scan it for rate/usage-limit messages. Claude prints billing
+   * refusals ("monthly spend limit", "out of usage credits") to STDOUT, not
+   * stderr — a fallback chain that only inspects stderr never cascades on
+   * them. Set by runWithFallback for every chain entry; harmless elsewhere
+   * (output is mirrored to the parent's stdout exactly like stdio:'inherit').
+   */
+  captureStdoutTail?: boolean;
+  /**
    * Escape hatch for the interactive tmux spawn-wrap (see shouldWrapInTmux):
    * when true, spawn the agent directly instead of inside a shared-socket tmux
    * session. Also forced off by AGENTS_NO_TMUX=1. No effect on headless runs.
@@ -228,11 +237,12 @@ export function resolveInteractive(
  * @param piped        true when the parent's stdout is NOT a TTY (output piped)
  * @param capsActive   true when a budget watcher is attached (caps configured)
  */
-export function shouldTapStdout(interactive: boolean, piped: boolean, capsActive: boolean): boolean {
+export function shouldTapStdout(interactive: boolean, piped: boolean, capsActive: boolean, captureTail = false): boolean {
   if (interactive) return false;
   // Always pipe when the caller pipes us downstream (preserve composability),
-  // OR when caps are active so the watcher can read the stream at a TTY.
-  return piped || capsActive;
+  // when caps are active so the watcher can read the stream at a TTY, or when
+  // a fallback chain needs a stdout tail for rate-limit detection.
+  return piped || capsActive || captureTail;
 }
 
 /** Pattern for valid environment variable names (C identifier rules). */
@@ -964,10 +974,17 @@ export async function execShimPassthrough(
   });
 }
 
-/** Exit code and captured stderr from a spawned agent process. */
+/** Exit code and captured output from a spawned agent process. */
 interface SpawnResult {
   exitCode: number;
   stderr: string;
+  /**
+   * Rolling tail of the child's stdout, captured only when the stream was
+   * tapped (budget watcher, piped caller, or captureStdoutTail). Empty when
+   * stdout was inherited. Used by runWithFallback to detect billing refusals
+   * Claude prints to stdout rather than stderr.
+   */
+  stdout: string;
 }
 
 /** Inputs that decide whether an interactive spawn is wrapped in a shared-socket tmux session. */
@@ -1151,7 +1168,7 @@ async function runInTmux(options: ExecOptions, executable: string, args: string[
       await surfacePaneFailure(before.status, `${options.agent} exited before it could start`);
     }
     await killSession(name, socket).catch(() => {});
-    return { exitCode: before.status ?? 0, stderr: '' };
+    return { exitCode: before.status ?? 0, stderr: '', stdout: '' };
   }
 
   await attachTmux({ socket, args: ['attach-session', '-t', name] });
@@ -1166,10 +1183,10 @@ async function runInTmux(options: ExecOptions, executable: string, args: string[
       await surfacePaneFailure(after.status, `${options.agent} exited`);
     }
     await killSession(name, socket).catch(() => {});
-    return { exitCode: after.status ?? 0, stderr: '' };
+    return { exitCode: after.status ?? 0, stderr: '', stdout: '' };
   }
   // Pane still alive → the user detached; keep the session for `agents focus`.
-  return { exitCode: 0, stderr: '' };
+  return { exitCode: 0, stderr: '', stdout: '' };
 }
 
 /**
@@ -1260,7 +1277,7 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
     // PIPE (and later tee) stdout whenever the live budget watcher must read it
     // — for ALL non-interactive runs when caps are active, regardless of TTY.
     // See shouldTapStdout() for the rationale (FIX 3, issue #346).
-    const tapStdout = shouldTapStdout(interactive, piped, watcherState !== null);
+    const tapStdout = shouldTapStdout(interactive, piped, watcherState !== null, options.captureStdoutTail);
     const stdio: ('inherit' | 'pipe')[] = interactive
       ? ['inherit', 'inherit', 'inherit']
       : ['inherit', tapStdout ? 'pipe' : 'inherit', 'pipe'];
@@ -1301,10 +1318,17 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
 
     let budgetKilled = false;
     let budgetKillTimer: ReturnType<typeof setTimeout> | undefined;
+    let stdoutTail = '';
+    const STDOUT_TAIL_CAP = 16 * 1024;
     if (!interactive && tapStdout && child.stdout) {
       // TEE the child's stdout back to the parent's so the user still sees
       // output (mirrors stdio:'inherit') while we tap the same stream for usage.
       child.stdout.pipe(process.stdout);
+      // Keep a rolling TAIL (billing refusals arrive at the very end of a run)
+      // for the fallback chain's rate-limit scan.
+      child.stdout.on('data', (chunk: Buffer) => {
+        stdoutTail = (stdoutTail + chunk.toString('utf-8')).slice(-STDOUT_TAIL_CAP);
+      });
       // Tap the same stream for budget usage events without consuming the pipe
       // (a 'data' listener and .pipe() both receive every chunk). Kill on breach.
       if (watcherState) {
@@ -1367,7 +1391,7 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
       // teams/cloud can tell a budget termination apart from a normal failure.
       const exitCode = budgetKilled ? BUDGET_KILL_EXIT_CODE : (code ?? 0);
       timer.end({ exitCode, status: budgetKilled ? 'budget_killed' : code === 0 ? 'success' : 'failed' });
-      resolve({ exitCode, stderr: stderrBuffer });
+      resolve({ exitCode, stderr: stderrBuffer, stdout: stdoutTail });
     });
   });
 }
@@ -1462,6 +1486,12 @@ export const RATE_LIMIT_PATTERNS: RegExp[] = [
   /too many requests/i,
   /api[\s_-]?overloaded/i,
   /\boverloaded\b/i,
+  // Claude billing refusals — "You've hit your org's monthly spend limit" and
+  // "You're out of usage credits". Both end the run with exit 1 and are exactly
+  // the condition a fallback chain exists to recover from. Printed to STDOUT,
+  // hence the stdout tail in SpawnResult.
+  /spend[\s-]?limit/i,
+  /out of (?:usage )?credits/i,
 ];
 
 /** Return true if the text contains any known rate-limit or overload indicator. */
@@ -1599,6 +1629,9 @@ export async function runWithFallback(options: FallbackOptions): Promise<number>
       prompt,
       env: envOverride ? { ...(options.env ?? {}), ...envOverride } : options.env,
       sessionId: pinnedSessionId ?? (i === 0 ? options.sessionId : undefined),
+      // Claude prints billing refusals (spend limit / out of credits) to
+      // stdout; tail it so the cascade check below can see them.
+      captureStdoutTail: true,
     };
 
     const label = version ? `${agent}@${version}` : agent;
@@ -1628,7 +1661,7 @@ export async function runWithFallback(options: FallbackOptions): Promise<number>
     const isLast = i === chain.length - 1;
     if (isLast) return result.exitCode;
 
-    if (!detectRateLimit(result.stderr)) {
+    if (!detectRateLimit(result.stderr) && !detectRateLimit(result.stdout)) {
       return result.exitCode;
     }
 

--- a/apps/cli/src/lib/rotate.test.ts
+++ b/apps/cli/src/lib/rotate.test.ts
@@ -98,12 +98,11 @@ describe('rotationFailoverChain (#348 — synthesize a same-agent failover chain
 
 describe('shouldArmRotationFailover (#348 — arming gate; must not trip --acp/--loop guards)', () => {
   // The eligible baseline: a real rotation picked a version, there is a prompt,
-  // no explicit/profile fallback, and the run is a plain headless prompt run.
+  // and the run is a plain headless prompt run.
   const armable: FailoverArmingContext = {
     hasRotation: true,
     hasVersion: true,
     hasPrompt: true,
-    explicitFallback: false,
     interactive: false,
     acp: false,
     loop: false,
@@ -133,9 +132,11 @@ describe('shouldArmRotationFailover (#348 — arming gate; must not trip --acp/-
     expect(shouldArmRotationFailover({ ...armable, hasPrompt: false })).toBe(false);
   });
 
-  it('does NOT arm when an explicit or profile fallback is already set', () => {
-    expect(shouldArmRotationFailover({ ...armable, explicitFallback: true })).toBe(false);
-  });
+  // An explicit --fallback no longer disarms rotation failover: the same-agent
+  // accounts are unshifted ahead of the cross-agent entries (gh-monitor heal
+  // bug — `--fallback codex,droid` pinned every run to one capped account).
+  // The armable baseline above is the explicit-fallback case too: the gate has
+  // no explicitFallback input anymore.
 
   it('does NOT arm for pinned / non-rotation runs (no rotation or no picked version)', () => {
     expect(shouldArmRotationFailover({ ...armable, hasRotation: false })).toBe(false);
@@ -172,6 +173,16 @@ fs.writeFileSync(stateFile, String(n));
 if (mode === 'plain-fail') {
   process.stderr.write('Error: compile failure — not a limit\\n');
   process.exit(1);
+}
+if (mode === 'stdout-spend-limit-then-ok') {
+  // Claude prints billing refusals to STDOUT, not stderr — the cascade must
+  // still detect them (via the SpawnResult stdout tail).
+  if (n === 1) {
+    process.stdout.write("You've hit your org's monthly spend limit \\u00b7 run /usage-credits to raise it\\n");
+    process.exit(1);
+  }
+  process.stdout.write('done\\n');
+  process.exit(0);
 }
 if (n === 1) {
   process.stderr.write('API request failed: 429 Too Many Requests (rate limit exceeded)\\n');
@@ -212,6 +223,26 @@ process.exit(0);
     });
     expect(code).toBe(0);
     // Primary 429'd (call 1), re-dispatched once and succeeded (call 2).
+    expect(fs.readFileSync(stateFile, 'utf8')).toBe('2');
+  });
+
+  it('a billing refusal on STDOUT (spend limit) also cascades — the gh-monitor heal bug', async () => {
+    const { binDir, stateFile } = fakeAmp();
+    const code = await runWithFallback({
+      agent: 'amp',
+      prompt: 'do the task',
+      mode: 'edit',
+      effort: 'auto',
+      headless: true,
+      cwd: binDir,
+      env: {
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+        AGENTS_TEST_MODE: 'stdout-spend-limit-then-ok',
+        AGENTS_TEST_STATE: stateFile,
+      },
+      fallback: [{ agent: 'amp' }],
+    });
+    expect(code).toBe(0);
     expect(fs.readFileSync(stateFile, 'utf8')).toBe('2');
   });
 

--- a/apps/cli/src/lib/rotate.ts
+++ b/apps/cli/src/lib/rotate.ts
@@ -530,10 +530,14 @@ export function rotationFailoverChain(
  *   would break a previously-working `agents run … --loop` / `--acp`.
  * - `resumeCheckpoint` runs take the loop path (same guard).
  * - `interactive` / no-prompt runs can't be re-dispatched headlessly.
- * - `explicitFallback` (a user `--fallback` chain OR a profile fallback already
- *   unshifted) defines its own recovery; don't layer rotation failover on top.
  * - `hasRotation`/`hasVersion` gate on an actual pre-flight rotation having
  *   picked an account, so pinned and non-rotation runs are untouched.
+ *
+ * An explicit `--fallback` chain does NOT disarm rotation failover: the
+ * synthesized same-agent entries are unshifted AHEAD of the user's cross-agent
+ * entries, so a rate limit exhausts the other accounts of the same agent
+ * before cascading to a different CLI. Profile fallbacks never reach here —
+ * strategy resolution is skipped for profiles, so hasRotation is false.
  *
  * Pure so the arming matrix is unit-testable without invoking the run command.
  */
@@ -541,7 +545,6 @@ export interface FailoverArmingContext {
   hasRotation: boolean;
   hasVersion: boolean;
   hasPrompt: boolean;
-  explicitFallback: boolean;
   interactive: boolean;
   acp: boolean;
   loop: boolean;
@@ -553,7 +556,6 @@ export function shouldArmRotationFailover(ctx: FailoverArmingContext): boolean {
     ctx.hasRotation &&
     ctx.hasVersion &&
     ctx.hasPrompt &&
-    !ctx.explicitFallback &&
     !ctx.interactive &&
     !ctx.acp &&
     !ctx.loop &&


### PR DESCRIPTION
## What happened

The gh-monitor heal for turing-api#232 died with `INFRA_FAIL` after 816s: the run landed on a spend-capped Claude account and neither rotated nor cascaded to the `codex,droid` fallback chain.

## Root causes (both fixed here)

**1. `--fallback` disabled account rotation for the bare primary.**
`agents run claude --fallback codex,droid` printed `strategy balanced ignored: --fallback pins versions directly` and ran the pinned default version — one fixed account, every run. The chain only names cascade targets; it never pinned the primary. Strategy resolution now applies to the bare primary as usual (explicit `@version` pins and profiles keep their pinning behavior), and the #348 same-agent rotation failover now composes with an explicit chain — the other healthy accounts are unshifted ahead of the cross-agent entries.

**2. Billing refusals never triggered the cascade.**
Claude prints "You've hit your org's monthly spend limit" / "You're out of usage credits" to **stdout** with exit 1. They matched no `RATE_LIMIT_PATTERNS` entry, and `runWithFallback` only scanned stderr. Added both patterns; each chain attempt now tees a bounded stdout tail (`ExecOptions.captureStdoutTail`, 16 KB rolling) and scans it alongside stderr. Output stays mirrored to the parent's stdout.

## Verification

- `bun run build` (tsc) clean.
- `vitest run src/lib/rotate.test.ts src/lib/exec.test.ts src/lib/__tests__/exec.test.ts`: all new tests pass — arming-gate matrix without `explicitFallback`, `shouldTapStdout` captureTail cases, new `detectRateLimit` cases, and a real-child-process e2e where a stdout spend-limit refusal cascades and succeeds on the next entry (`stdout-spend-limit-then-ok`). The 5 pre-existing codex command-building failures reproduce identically on unmodified `origin/main` (machine-local run defaults leak `--model gpt-5.6-sol` into expected argv) — unrelated.
- E2E on the built dist: `node dist/index.js run claude --fallback codex,droid --mode plan "reply with exactly: ok"` now prints `balanced picked taylor@turingsaas.com · claude@2.1.196 (2 of 3 healthy)` + `rate-limit failover armed: claude@2.1.197` and completes — previously it printed the `strategy balanced ignored` warning and pinned the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)