### PR TITLE
fix(mailbox): archive expired live-box messages in GC (RUSH-1611)

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Fix: mailbox GC actually archives expired messages on live boxes (RUSH-1611).**
+  The live-box branch of `gcMailbox` only incremented `messagesDroppedExpired`
+  without moving the file to `consumed/`, so `agents feed --dispatch` could report
+  drops while leaving expired messages in `inbox/`/`processing/`. GC now reuses
+  `sweepExpired` (the same path as drain/peek). Source: `apps/cli/src/lib/mailbox-gc.ts`.
 - **Fix: Antigravity sign-in detection on Linux when the OAuth grant lives in Secret Service (RUSH-1329).** `agy` uses the Go keyring library, which prefers libsecret (gnome-keyring) over the file fallback whenever a Secret Service daemon is running — so `~/.gemini/antigravity-cli/antigravity-oauth-token` may be absent even when the user is signed in. After the file check, `getAccountInfo` now probes `secret-tool lookup service gemini username antigravity` (exit 0 = present; stdout discarded), mirroring the macOS `security find-generic-password` probe from #506. Missing `secret-tool`, locked collections, and timeouts all read as signed out. Opt out with `AGENTS_NO_KEYCHAIN_PROBE=1`. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/agents.test.ts`.
 - **Extend session sync to Droid, Grok, Kimi, and OpenCode (RUSH-1467).** `agents sessions sync` now includes these four agents in its upload/download matrix. `SyncAgentSpec` gains an optional `ext` field so agents with non-`.jsonl` transcript files (e.g., Kimi `state.json`) are walked correctly. Droid `.jsonl` rollouts, Grok `events.jsonl` streams, and Kimi `state.json` metadata files round-trip through the R2 mirror; OpenCode is slotted in `SYNC_AGENTS` but remains a placeholder because its sessions live in a SQLite DB and still require an SQLite-to-JSONL export step. Source: `apps/cli/src/lib/session/sync/agents.ts`, `apps/cli/src/lib/session/sync/agents.test.ts`, `apps/cli/src/commands/sessions-sync.ts`.
 

--- a/apps/cli/src/lib/mailbox-gc.test.ts
+++ b/apps/cli/src/lib/mailbox-gc.test.ts
@@ -75,4 +75,24 @@ describe('mailbox GC', () => {
     expect(result.consumedPruned).toBe(1);
     expect(fs.existsSync(consumedFile)).toBe(false);
   });
+
+  it('archives expired messages from a live box (not just metrics)', () => {
+    const root = tmpRoot();
+    const box = mailboxDir(BOX, root);
+    const msgId = enqueue(box, { to: BOX, text: 'stale', ttlSeconds: 1 });
+    const inboxFile = path.join(box, 'inbox', `${msgId}.json`);
+    // Force expiry in the past so GC sees it without sleeping.
+    const raw = JSON.parse(fs.readFileSync(inboxFile, 'utf-8'));
+    raw.expiresAt = '2000-01-01T00:00:00.000Z';
+    fs.writeFileSync(inboxFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+    const result = gcMailbox(new Set([BOX]), { root, now: new Date('2026-07-14T00:00:00.000Z') });
+
+    expect(result.messagesDroppedExpired).toBe(1);
+    expect(fs.existsSync(inboxFile)).toBe(false);
+    const consumed = fs.readdirSync(path.join(box, 'consumed'));
+    expect(consumed).toHaveLength(1);
+    const archived = JSON.parse(fs.readFileSync(path.join(box, 'consumed', consumed[0]), 'utf-8'));
+    expect(archived.dropped).toBe('expired');
+  });
 });

--- a/apps/cli/src/lib/mailbox-gc.ts
+++ b/apps/cli/src/lib/mailbox-gc.ts
@@ -13,7 +13,7 @@ import {
   mailboxDir,
   isValidMailboxId,
   readMessage,
-  type MailboxMessage,
+  sweepExpired,
 } from './mailbox.js';
 import { listBlocks, removeBlock } from './feed.js';
 
@@ -162,21 +162,9 @@ export function gcMailbox(
         // ignore
       }
     } else {
-      // Live box: lazy expiry is handled by drain/peek, but sweep here for GC metrics.
-      // We still need to read expired messages; reuse readMessage directly to avoid
-      // importing sweepExpired and duplicating logic.
-      for (const sub of ['inbox', 'processing']) {
-        const dir = path.join(boxDir, sub);
-        for (const file of jsonFiles(dir)) {
-          const msg = readMessage(path.join(dir, file));
-          if (msg && msg.expiresAt) {
-            const ts = Date.parse(msg.expiresAt);
-            if (!Number.isNaN(ts) && ts <= now.getTime()) {
-              result.messagesDroppedExpired++;
-            }
-          }
-        }
-      }
+      // Live box: archive expired messages (same path as drain/peek) so GC does
+      // not leave expired files in inbox/processing while only bumping metrics.
+      result.messagesDroppedExpired += sweepExpired(boxDir, name, now);
       result.consumedPruned += pruneConsumed(boxDir, maxConsumedAgeMinutes, now);
     }
   }


### PR DESCRIPTION
## Summary
- Live-box branch of `gcMailbox` now calls `sweepExpired` so expired messages are archived to `consumed/` (not just counted).
- Test asserts the expired file is gone after `gcMailbox(new Set([box]))`.

Closes Linear RUSH-1611.

## Test plan
- [x] `npx vitest run src/lib/mailbox-gc.test.ts` (4 passed)
- [ ] CI green