### PR TITLE
feat(hosts): stop/kill detached host runs from origin (RUSH-1360)

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ agents hosts check gpu-box              # reachable? which agents-cli version?
 # Run there instead of locally
 agents run claude --host gpu-box "profile this build"   # headless: follows live by default
 agents run claude --host gpu-box                         # no prompt → interactive TTY over SSH (tmux-backed)
+agents hosts ps                         # list dispatched runs + terminal status
+agents hosts stop <id>                  # terminate a hung/detached run (alias: kill)
 agents logs --host gpu-box              # pick a dispatched run — concise summary by default
 agents logs <id> --full                 # the full raw transcript / stdout (token-heavy)
 agents logs <id> -f                     # re-attach to a running one and follow

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **`agents hosts stop <id>` (alias `kill`) terminates a detached host run from the origin machine (RUSH-1360).**
+  Sends SIGTERM to the remote process group, writes exit `143` only when a live
+  group was signaled (or no `.exit` existed), and keeps the remote log for
+  `agents hosts logs <id>`. Source: `apps/cli/src/lib/hosts/dispatch.ts`,
+  `apps/cli/src/commands/hosts.ts`.
 - **Fix: mailbox GC actually archives expired messages on live boxes (RUSH-1611).**
   The live-box branch of `gcMailbox` only incremented `messagesDroppedExpired`
   without moving the file to `consumed/`, so `agents feed --dispatch` could report
@@ -9,6 +14,12 @@
   `sweepExpired` (the same path as drain/peek). Source: `apps/cli/src/lib/mailbox-gc.ts`.
 - **Fix: Antigravity sign-in detection on Linux when the OAuth grant lives in Secret Service (RUSH-1329).** `agy` uses the Go keyring library, which prefers libsecret (gnome-keyring) over the file fallback whenever a Secret Service daemon is running — so `~/.gemini/antigravity-cli/antigravity-oauth-token` may be absent even when the user is signed in. After the file check, `getAccountInfo` now probes `secret-tool lookup service gemini username antigravity` (exit 0 = present; stdout discarded), mirroring the macOS `security find-generic-password` probe from #506. Missing `secret-tool`, locked collections, and timeouts all read as signed out. Opt out with `AGENTS_NO_KEYCHAIN_PROBE=1`. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/agents.test.ts`.
 - **Extend session sync to Droid, Grok, Kimi, and OpenCode (RUSH-1467).** `agents sessions sync` now includes these four agents in its upload/download matrix. `SyncAgentSpec` gains an optional `ext` field so agents with non-`.jsonl` transcript files (e.g., Kimi `state.json`) are walked correctly. Droid `.jsonl` rollouts, Grok `events.jsonl` streams, and Kimi `state.json` metadata files round-trip through the R2 mirror; OpenCode is slotted in `SYNC_AGENTS` but remains a placeholder because its sessions live in a SQLite DB and still require an SQLite-to-JSONL export step. Source: `apps/cli/src/lib/session/sync/agents.ts`, `apps/cli/src/lib/session/sync/agents.test.ts`, `apps/cli/src/commands/sessions-sync.ts`.
+- **`agents hosts stop <id>` (alias `kill`) terminates a detached host run from the origin machine (RUSH-1360).**
+  Sends SIGTERM to the remote process group, writes exit `143` to the remote
+  `.exit` marker so `hosts ps` shows a terminal `failed` status, and keeps the
+  remote log for `agents hosts logs <id>`. Complements the existing on-demand
+  log fetch and `.exit` reconcile that already landed for detached `--no-follow`
+  runs. Source: `apps/cli/src/lib/hosts/dispatch.ts`, `apps/cli/src/commands/hosts.ts`.
 
 ## 1.20.62
 - **Wire Goose commands support (RUSH-1572).** `agents` now syncs slash commands to Goose as recipe YAML files under `~/.config/goose/commands/<name>.yaml`, each registered in `~/.config/goose/config.yaml` under a `slash_commands: [{ command, recipe_path }]` array (Goose has no native slash-command file format — a slash command IS a recipe). The command recipes live in a dir distinct from the workflow recipes dir (`~/.config/goose/recipes/`) so the workflow detector never treats a command recipe as a workflow. Registration is a read-modify-write that preserves every other `config.yaml` key (`mcp_servers`, `extensions`, …) and other `slash_commands` entries, and removal soft-deletes the recipe + unregisters the entry. Flip Goose's `commands` capability and add `goose` branches to install/list/match/remove, the staleness commands writer, and doctor-diff, backed by a new `goose-commands.ts` module + a `markdownToGooseRecipe` converter. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/goose-commands.ts`, `apps/cli/src/lib/commands.ts`, `apps/cli/src/lib/convert.ts`, `apps/cli/src/lib/staleness/writers/commands.ts`, `apps/cli/src/lib/doctor-diff.ts`.

--- a/apps/cli/docs/hosts.md
+++ b/apps/cli/docs/hosts.md
@@ -228,6 +228,12 @@ agents run <agent> ["<task>"] --host <host>
 > `agents sessions` and `agents sessions <name>` resolves it. Omitting `--name` is
 > a no-op — unnamed runs stay id-only, render `-` in the NAME column, and show the
 > `[host/<name>]` tag as their session label.
+>
+> `agents hosts ps` re-probes each still-`running` task against the remote `.exit`
+> marker so a finished (or crashed) run does not stay stuck at `running` after the
+> local follower dies. `agents hosts stop <id>` (alias `kill`) terminates the
+> remote process group from this machine, writes exit `143`, and keeps the log
+> for `agents hosts logs <id>`.
 
 ### Host sources — owned (registered) + leased on demand (crabbox)
 

--- a/apps/cli/src/commands/hosts.ts
+++ b/apps/cli/src/commands/hosts.ts
@@ -241,11 +241,18 @@ async function doStop(ref: string): Promise<void> {
   }
   try {
     const stopped = stopDispatchedTask(task);
+    const statusColor = stopped.status === 'completed' ? chalk.green : chalk.yellow;
+    const exitNote =
+      stopped.exitCode === 143
+        ? 'exit 143 / SIGTERM'
+        : stopped.exitCode !== undefined
+          ? `exit ${stopped.exitCode}`
+          : stopped.status;
     console.log(
       chalk.green(`Stopped ${stopped.id}`) +
         chalk.gray(` on ${stopped.host}`) +
-        chalk.yellow('  failed') +
-        chalk.gray(' (exit 143 / SIGTERM)'),
+        '  ' + statusColor(stopped.status) +
+        chalk.gray(` (${exitNote})`),
     );
     console.log(chalk.gray(`Logs: agents hosts logs ${stopped.id}`));
   } catch (err: any) {

--- a/apps/cli/src/commands/hosts.ts
+++ b/apps/cli/src/commands/hosts.ts
@@ -25,6 +25,7 @@ import { resolveRemoteOsSync } from '../lib/hosts/remote-os.js';
 import { listTasks, loadTask, findTaskByName, findTaskBySessionId } from '../lib/hosts/tasks.js';
 import { reconcileRunningTasks } from '../lib/hosts/reconcile.js';
 import { showHostTaskLog } from '../lib/hosts/logs.js';
+import { stopDispatchedTask } from '../lib/hosts/dispatch.js';
 
 interface AddOptions { cap?: string[]; os?: string; enroll?: boolean; }
 
@@ -220,6 +221,39 @@ async function doLogs(ref: string, follow: boolean, full: boolean): Promise<void
   if (res.exitCode !== undefined) process.exitCode = res.exitCode;
 }
 
+/** Resolve a host-task ref (id, --name handle, or session id) or null. */
+function resolveTaskRef(ref: string) {
+  return loadTask(ref) ?? findTaskByName(ref) ?? findTaskBySessionId(ref);
+}
+
+async function doStop(ref: string): Promise<void> {
+  // Heal first so we don't try to kill a process that already exited.
+  const current = resolveTaskRef(ref);
+  if (!current) {
+    console.log(chalk.red(`Unknown task "${ref}".`));
+    process.exitCode = 1;
+    return;
+  }
+  const task = reconcileRunningTasks([current])[0] ?? current;
+  if (task.status !== 'running') {
+    console.log(chalk.gray(`Task ${task.id} is already ${task.status}` + (task.exitCode !== undefined ? ` (exit ${task.exitCode})` : '') + '.'));
+    return;
+  }
+  try {
+    const stopped = stopDispatchedTask(task);
+    console.log(
+      chalk.green(`Stopped ${stopped.id}`) +
+        chalk.gray(` on ${stopped.host}`) +
+        chalk.yellow('  failed') +
+        chalk.gray(' (exit 143 / SIGTERM)'),
+    );
+    console.log(chalk.gray(`Logs: agents hosts logs ${stopped.id}`));
+  } catch (err: any) {
+    console.error(chalk.red(err?.message ?? err));
+    process.exitCode = 1;
+  }
+}
+
 /** Register the `agents hosts` command tree. */
 export function registerHostsCommand(program: Command): void {
   const hosts = program
@@ -264,4 +298,10 @@ export function registerHostsCommand(program: Command): void {
     .option('-f, --follow', 'Follow live output')
     .option('-m, --full', 'Show the full raw combined-stdout log instead of the concise summary')
     .action((id: string, opts: { follow?: boolean; full?: boolean }) => doLogs(id, !!opts.follow, !!opts.full));
+
+  hosts
+    .command('stop <id>')
+    .alias('kill')
+    .description('Terminate a running host task from this machine (SIGTERM process group; marks failed/143).')
+    .action((id: string) => doStop(id));
 }

--- a/apps/cli/src/lib/hosts/dispatch.test.ts
+++ b/apps/cli/src/lib/hosts/dispatch.test.ts
@@ -6,12 +6,44 @@ import {
   buildDetachedLaunchCommand,
   buildRunForwardedArgs,
   buildInteractiveRunForwardedArgs,
+  buildStopRemoteCommand,
   remoteCdPrefix,
   terminateDispatchedTask,
 } from './dispatch.js';
 import type { HostTask } from './tasks.js';
 
 const LOCAL_HOME = process.env.HOME ?? os.homedir();
+
+describe('buildStopRemoteCommand', () => {
+  const exit = '$HOME/.agents/.cache/hosts/abc12345.exit';
+
+  it('rejects non-positive pids before any remote shell is built', () => {
+    expect(() => buildStopRemoteCommand(0, exit)).toThrow(/Invalid remote task pid/);
+    expect(() => buildStopRemoteCommand(-1, exit)).toThrow(/Invalid remote task pid/);
+    expect(() => buildStopRemoteCommand(1.5, exit)).toThrow(/Invalid remote task pid/);
+  });
+
+  it('writes 143 only after signaling a live group; keeps the log path untouched', () => {
+    const cmd = buildStopRemoteCommand(4242, exit);
+    // Live group: TERM then write 143 and report SIGNALED.
+    expect(cmd).toContain('kill -TERM -- -4242');
+    expect(cmd).toContain(`echo 143 > ${exit}`);
+    expect(cmd).toContain('echo SIGNALED');
+    // Already-dead group with a real exit code: adopt it, never overwrite.
+    expect(cmd).toContain('echo "ALREADY $code"');
+    expect(cmd).toContain(`cat ${exit}`);
+    // Never deletes the log (contrast terminateRemoteLaunch's rm -f).
+    expect(cmd).not.toMatch(/rm\s+-f/);
+    expect(cmd).not.toContain('.log');
+  });
+
+  it('when the group is gone with no .exit, still writes 143 (GONE) without requiring kill success', () => {
+    const cmd = buildStopRemoteCommand(99, exit);
+    expect(cmd).toContain('echo GONE');
+    // GONE branch is under the final else (group dead).
+    expect(cmd).toMatch(/else[\s\S]*echo GONE/);
+  });
+});
 
 describe('buildRunForwardedArgs', () => {
   it('forwards --session-id for a fresh run so the remote session gets our id', () => {

--- a/apps/cli/src/lib/hosts/dispatch.ts
+++ b/apps/cli/src/lib/hosts/dispatch.ts
@@ -103,12 +103,42 @@ export function terminateDispatchedTask(task: HostTask): void {
 }
 
 /**
+ * Build the remote shell used by {@link stopDispatchedTask}. Exported for
+ * unit tests — the keep-log / no-clobber contract lives in this script.
+ *
+ * Protocol (printed to stdout for the local caller):
+ * - `SIGNALED`  — process group was live; SIGTERM/KILL applied; wrote 143
+ * - `ALREADY` + code — group gone; adopted existing `.exit` (never overwrite)
+ * - `GONE` — group gone and no `.exit`; write 143 as the local stop outcome
+ * Exit 1 if the group is still alive after TERM/KILL (can't stop it).
+ */
+export function buildStopRemoteCommand(pid: number, remoteExit: string): string {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new Error(`Invalid remote task pid: ${pid}`);
+  }
+  // Only force-write 143 when we actually signaled a live group (or nothing
+  // left a code). Never `echo 143` over a real completed-run exit code.
+  return (
+    `if kill -TERM -- -${pid} 2>/dev/null; then ` +
+      `sleep 1; kill -KILL -- -${pid} 2>/dev/null || true; ` +
+      `echo 143 > ${remoteExit}; echo SIGNALED; ` +
+    `elif kill -0 -- -${pid} 2>/dev/null; then ` +
+      `exit 1; ` +
+    `else ` +
+      `code=$(cat ${remoteExit} 2>/dev/null | tr -d '[:space:]'); ` +
+      `if [ -n "$code" ]; then echo "ALREADY $code"; ` +
+      `else echo 143 > ${remoteExit}; echo GONE; fi; ` +
+    `fi`
+  );
+}
+
+/**
  * Stop a running host task from the origin machine (`agents hosts stop <id>`).
  *
  * Unlike {@link terminateDispatchedTask} (rollback cleanup after a failed
  * persist), this keeps the remote log so `agents hosts logs <id>` still works,
- * writes a terminal `.exit` marker (143 = SIGTERM) for reconcile, and marks the
- * local record failed.
+ * writes a terminal `.exit` marker only when we actually stopped a live group
+ * (or no code existed), and never clobbers a real completed-run exit code.
  */
 export function stopDispatchedTask(task: HostTask): HostTask {
   if (task.status !== 'running') {
@@ -117,14 +147,7 @@ export function stopDispatchedTask(task: HostTask): HostTask {
   if (!task.pid) {
     throw new Error(`Cannot stop remote task ${task.id}: launch returned no PID.`);
   }
-  const pid = task.pid;
-  // TERM process group, then KILL; write 143 to .exit so `hosts ps`/reconcile
-  // see a terminal state. Keep the log for `hosts logs`.
-  const command =
-    `if kill -TERM -- -${pid} 2>/dev/null; then ` +
-      `sleep 1; kill -KILL -- -${pid} 2>/dev/null || true; ` +
-    `elif kill -0 -- -${pid} 2>/dev/null; then exit 1; fi; ` +
-    `echo 143 > ${task.remoteExit}`;
+  const command = buildStopRemoteCommand(task.pid, task.remoteExit);
   const result = sshExec(task.target, command, { timeoutMs: 10000, multiplex: true });
   if (result.code !== 0) {
     throw new Error(
@@ -132,7 +155,14 @@ export function stopDispatchedTask(task: HostTask): HostTask {
       `${(result.stderr || result.stdout).trim() || 'ssh error'}`,
     );
   }
-  return updateTask(task.id, terminalPatch(143)) ?? { ...task, ...terminalPatch(143) };
+  const line = result.stdout.trim().split('\n').pop() ?? '';
+  let code = 143;
+  if (line.startsWith('ALREADY ')) {
+    const parsed = parseInt(line.slice('ALREADY '.length), 10);
+    if (Number.isFinite(parsed)) code = parsed;
+  }
+  // SIGNALED / GONE / ALREADY all end with a terminal local record.
+  return updateTask(task.id, terminalPatch(code)) ?? { ...task, ...terminalPatch(code) };
 }
 
 /** Options shared by every detached dispatch. */

--- a/apps/cli/src/lib/hosts/dispatch.ts
+++ b/apps/cli/src/lib/hosts/dispatch.ts
@@ -102,6 +102,39 @@ export function terminateDispatchedTask(task: HostTask): void {
   updateTask(task.id, terminalPatch(143));
 }
 
+/**
+ * Stop a running host task from the origin machine (`agents hosts stop <id>`).
+ *
+ * Unlike {@link terminateDispatchedTask} (rollback cleanup after a failed
+ * persist), this keeps the remote log so `agents hosts logs <id>` still works,
+ * writes a terminal `.exit` marker (143 = SIGTERM) for reconcile, and marks the
+ * local record failed.
+ */
+export function stopDispatchedTask(task: HostTask): HostTask {
+  if (task.status !== 'running') {
+    throw new Error(`Task ${task.id} is already ${task.status}`);
+  }
+  if (!task.pid) {
+    throw new Error(`Cannot stop remote task ${task.id}: launch returned no PID.`);
+  }
+  const pid = task.pid;
+  // TERM process group, then KILL; write 143 to .exit so `hosts ps`/reconcile
+  // see a terminal state. Keep the log for `hosts logs`.
+  const command =
+    `if kill -TERM -- -${pid} 2>/dev/null; then ` +
+      `sleep 1; kill -KILL -- -${pid} 2>/dev/null || true; ` +
+    `elif kill -0 -- -${pid} 2>/dev/null; then exit 1; fi; ` +
+    `echo 143 > ${task.remoteExit}`;
+  const result = sshExec(task.target, command, { timeoutMs: 10000, multiplex: true });
+  if (result.code !== 0) {
+    throw new Error(
+      `Failed to stop remote task ${task.id} on ${task.host}: ` +
+      `${(result.stderr || result.stdout).trim() || 'ssh error'}`,
+    );
+  }
+  return updateTask(task.id, terminalPatch(143)) ?? { ...task, ...terminalPatch(143) };
+}
+
 /** Options shared by every detached dispatch. */
 interface LaunchOptions {
   /** `agents …` args (command name first), each already un-quoted (we quote them). */

--- a/skills/devices/SKILL.md
+++ b/skills/devices/SKILL.md
@@ -96,6 +96,7 @@ agents run claude "profile this build" --host gpu-box   # run there, follow live
 agents run claude "..." --host gpu-box --no-follow        # detach
 
 agents hosts ps              # list dispatched runs and their status
+agents hosts stop <id>       # terminate a hung/detached run (alias: kill)
 agents logs --host gpu-box   # pick a run on that host and view its log
 agents logs <id> -f          # re-attach to a running one and follow
 ```
@@ -103,6 +104,8 @@ agents logs <id> -f          # re-attach to a running one and follow
 `agents logs [id]` is the unified viewer — it resolves a host-dispatch run OR a
 local session by id, filters with `--host`/`--agent`/`--version`, and `-f`
 follows a live one. `agents hosts logs <id>` is the host-only equivalent.
+`agents hosts stop <id>` SIGTERMs the remote process group from this machine and
+keeps the log for later inspection.
 
 ## Tips
 

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -209,12 +209,15 @@ agents run claude "profile this build" --host gpu-box   # follows live
 agents run claude "..." --host gpu-box --no-follow       # detach
 
 agents hosts ps          # list dispatched runs
+agents hosts stop <id>   # terminate a hung/detached run (alias: kill)
 agents logs --host gpu-box   # pick one and view its log
 agents logs <id> -f          # re-attach to a running one and follow
 ```
 
 `agents logs [id]` is the unified viewer over both host-dispatch runs and local
 session transcripts; `agents hosts logs <id>` is the host-only equivalent.
+`agents hosts stop <id>` (alias `kill`) terminates the remote process group from
+this machine without deleting the remote log.
 
 ### Working directory on the host
 


### PR DESCRIPTION
## Summary
- Add `agents hosts stop <id>` (alias `kill`) to terminate a detached host run from the origin machine.
- Stop writes exit `143` to the remote `.exit` marker (so `hosts ps` shows terminal `failed`) and keeps the remote log for `hosts logs`.
- Detached-run log fetch + `.exit` reconcile already landed on main; this closes the remaining gap from RUSH-1360 / #579.

Closes Linear RUSH-1360.

## Test plan
- [x] `npx vitest run src/lib/hosts/dispatch.test.ts reconcile.test.ts logs.test.ts` (54 passed)
- [ ] CI green