### PR TITLE
feat(devices): fleet alias + fleet-wide update/run (RUSH-1632)

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- **`agents fleet` alias + fleet-wide rollout (RUSH-1632).** `fleet` is an alias
+  for `devices`. New subcommands `update [version]` and `run <cmd…>` roll out
+  across every online device with a per-device result table. Source:
+  `apps/cli/src/commands/ssh.ts`, `apps/cli/src/lib/devices/fleet.ts`.
 - **`agents hosts stop <id>` (alias `kill`) terminates a detached host run from the origin machine (RUSH-1360).**
   Sends SIGTERM to the remote process group, writes exit `143` only when a live
   group was signaled (or no `.exit` existed), and keeps the remote log for
@@ -14,12 +18,22 @@
   `sweepExpired` (the same path as drain/peek). Source: `apps/cli/src/lib/mailbox-gc.ts`.
 - **Fix: Antigravity sign-in detection on Linux when the OAuth grant lives in Secret Service (RUSH-1329).** `agy` uses the Go keyring library, which prefers libsecret (gnome-keyring) over the file fallback whenever a Secret Service daemon is running — so `~/.gemini/antigravity-cli/antigravity-oauth-token` may be absent even when the user is signed in. After the file check, `getAccountInfo` now probes `secret-tool lookup service gemini username antigravity` (exit 0 = present; stdout discarded), mirroring the macOS `security find-generic-password` probe from #506. Missing `secret-tool`, locked collections, and timeouts all read as signed out. Opt out with `AGENTS_NO_KEYCHAIN_PROBE=1`. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/agents.test.ts`.
 - **Extend session sync to Droid, Grok, Kimi, and OpenCode (RUSH-1467).** `agents sessions sync` now includes these four agents in its upload/download matrix. `SyncAgentSpec` gains an optional `ext` field so agents with non-`.jsonl` transcript files (e.g., Kimi `state.json`) are walked correctly. Droid `.jsonl` rollouts, Grok `events.jsonl` streams, and Kimi `state.json` metadata files round-trip through the R2 mirror; OpenCode is slotted in `SYNC_AGENTS` but remains a placeholder because its sessions live in a SQLite DB and still require an SQLite-to-JSONL export step. Source: `apps/cli/src/lib/session/sync/agents.ts`, `apps/cli/src/lib/session/sync/agents.test.ts`, `apps/cli/src/commands/sessions-sync.ts`.
+<<<<<<< HEAD
 - **`agents hosts stop <id>` (alias `kill`) terminates a detached host run from the origin machine (RUSH-1360).**
   Sends SIGTERM to the remote process group, writes exit `143` to the remote
   `.exit` marker so `hosts ps` shows a terminal `failed` status, and keeps the
   remote log for `agents hosts logs <id>`. Complements the existing on-demand
   log fetch and `.exit` reconcile that already landed for detached `--no-follow`
   runs. Source: `apps/cli/src/lib/hosts/dispatch.ts`, `apps/cli/src/commands/hosts.ts`.
+=======
+- **`agents fleet` alias + fleet-wide rollout (RUSH-1632).** `fleet` is an alias
+  for `devices` (`agents fleet list` == `agents devices list`). New subcommands
+  `update [version]` and `run <cmd…>` roll out `agents upgrade --yes` (or an
+  arbitrary command) to every online registered device and print a per-device
+  result table; offline / no-address devices are skipped with a clear note.
+  Source: `apps/cli/src/commands/ssh.ts`, `apps/cli/src/lib/devices/fleet.ts`,
+  `apps/cli/src/lib/startup/command-registry.ts`, `skills/devices/SKILL.md`.
+>>>>>>> 8ac12843 (feat(devices): fleet alias + fleet-wide update/run (RUSH-1632))
 
 ## 1.20.62
 - **Wire Goose commands support (RUSH-1572).** `agents` now syncs slash commands to Goose as recipe YAML files under `~/.config/goose/commands/<name>.yaml`, each registered in `~/.config/goose/config.yaml` under a `slash_commands: [{ command, recipe_path }]` array (Goose has no native slash-command file format — a slash command IS a recipe). The command recipes live in a dir distinct from the workflow recipes dir (`~/.config/goose/recipes/`) so the workflow detector never treats a command recipe as a workflow. Registration is a read-modify-write that preserves every other `config.yaml` key (`mcp_servers`, `extensions`, …) and other `slash_commands` entries, and removal soft-deletes the recipe + unregisters the entry. Flip Goose's `commands` capability and add `goose` branches to install/list/match/remove, the staleness commands writer, and doctor-diff, backed by a new `goose-commands.ts` module + a `markdownToGooseRecipe` converter. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/goose-commands.ts`, `apps/cli/src/lib/commands.ts`, `apps/cli/src/lib/convert.ts`, `apps/cli/src/lib/staleness/writers/commands.ts`, `apps/cli/src/lib/doctor-diff.ts`.

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -164,7 +164,7 @@ function printFleetResults(results: FleetRunResult[]): void {
       r.status === 'skipped' ? chalk.gray('skipped'.padEnd(8)) :
       chalk.red('failed'.padEnd(8));
     const detail =
-      r.status === 'skipped' ? chalk.gray(skipLabel(r.reason as 'offline' | 'no-address' | 'self-local')) :
+      r.status === 'skipped' ? chalk.gray(skipLabel(r.reason as 'offline' | 'no-address')) :
       r.status === 'failed' ? chalk.red(r.detail || `exit ${r.code ?? '?'}`) :
       chalk.gray(r.code === 0 ? 'exit 0' : '');
     console.log(`${r.name.padEnd(nameW)}  ${status}  ${detail}`);
@@ -380,13 +380,19 @@ Typical workflow:
     .description('Roll out agents-cli to every online registered device (`agents upgrade --yes` on each). Offline devices are skipped.')
     .argument('[version]', 'Target version or dist-tag (default: latest)')
     .action(async (version: string | undefined) => {
+      let cmd: string[];
+      try {
+        cmd = upgradeCommand(version);
+      } catch (err: any) {
+        console.error(chalk.red(err?.message ?? err));
+        process.exit(1);
+      }
       const reg = await loadDevices();
       const targets = planFleetTargets(reg);
       if (targets.length === 0) {
         console.log(chalk.gray("No devices. Run 'agents devices sync' first."));
         return;
       }
-      const cmd = upgradeCommand(version);
       console.log(chalk.gray(`Running \`${cmd.join(' ')}\` on ${targets.filter((t) => !t.skip).length} online device(s)…`));
       const results = runFleet(targets, cmd);
       printFleetResults(results);

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -47,6 +47,13 @@ import {
   buildSshInvocation,
   writeAskpassShim,
 } from '../lib/devices/connect.js';
+import {
+  planFleetTargets,
+  runFleet,
+  skipLabel,
+  upgradeCommand,
+  type FleetRunResult,
+} from '../lib/devices/fleet.js';
 
 /** One-line summary of a device for `list`. `isSelf` marks the machine this
  * command is running on so it stands out from the rest of the tailnet. */
@@ -143,11 +150,38 @@ async function runInteractiveDeviceSync(): Promise<void> {
   console.log(parts.join(chalk.gray(' · ')));
 }
 
-/** Register the `agents devices` command tree. */
+/** Print a per-device result table for fleet update/run. */
+function printFleetResults(results: FleetRunResult[]): void {
+  const nameW = Math.max(8, ...results.map((r) => r.name.length));
+  console.log(
+    chalk.bold('DEVICE'.padEnd(nameW)) + '  ' +
+    chalk.bold('STATUS'.padEnd(8)) + '  ' +
+    chalk.bold('DETAIL'),
+  );
+  for (const r of results) {
+    const status =
+      r.status === 'ok' ? chalk.green('ok'.padEnd(8)) :
+      r.status === 'skipped' ? chalk.gray('skipped'.padEnd(8)) :
+      chalk.red('failed'.padEnd(8));
+    const detail =
+      r.status === 'skipped' ? chalk.gray(skipLabel(r.reason as 'offline' | 'no-address' | 'self-local')) :
+      r.status === 'failed' ? chalk.red(r.detail || `exit ${r.code ?? '?'}`) :
+      chalk.gray(r.code === 0 ? 'exit 0' : '');
+    console.log(`${r.name.padEnd(nameW)}  ${status}  ${detail}`);
+  }
+  const ok = results.filter((r) => r.status === 'ok').length;
+  const failed = results.filter((r) => r.status === 'failed').length;
+  const skipped = results.filter((r) => r.status === 'skipped').length;
+  console.log(chalk.gray(`${ok} ok · ${failed} failed · ${skipped} skipped`));
+  if (failed > 0) process.exitCode = 1;
+}
+
+/** Register the `agents devices` command tree (also aliased as `fleet`). */
 function registerDevicesCommands(program: Command): void {
   const devicesCmd = program
     .command('devices')
-    .description('Registry of SSH device profiles (platform, user, address, auth), self-populated from Tailscale.')
+    .alias('fleet')
+    .description('Registry of SSH device profiles (platform, user, address, auth), self-populated from Tailscale. Alias: fleet.')
     .addHelpText('after', `
 Typical workflow:
   agents devices sync            # curate: pick which tailscale nodes to keep (TTY)
@@ -156,6 +190,10 @@ Typical workflow:
   agents devices ignore ipad165  # dismiss a node so it's never re-suggested
   agents devices set win-mini --auth password --bundle muqsit
   agents devices render --write  # write ~/.ssh/config.d/agents include
+  agents fleet update            # roll out latest agents-cli to every online device
+  agents fleet run uname -a      # run a command on every online device
+
+\`agents fleet\` is an alias for \`agents devices\` — same subcommands.
 `);
 
   devicesCmd
@@ -335,6 +373,43 @@ Typical workflow:
       fs.writeFileSync(file, text, { mode: 0o600 });
       console.log(chalk.green(`Wrote ${file}`));
       console.log(chalk.gray('Add this to ~/.ssh/config (once):  Include config.d/agents'));
+    });
+
+  devicesCmd
+    .command('update')
+    .description('Roll out agents-cli to every online registered device (`agents upgrade --yes` on each). Offline devices are skipped.')
+    .argument('[version]', 'Target version or dist-tag (default: latest)')
+    .action(async (version: string | undefined) => {
+      const reg = await loadDevices();
+      const targets = planFleetTargets(reg);
+      if (targets.length === 0) {
+        console.log(chalk.gray("No devices. Run 'agents devices sync' first."));
+        return;
+      }
+      const cmd = upgradeCommand(version);
+      console.log(chalk.gray(`Running \`${cmd.join(' ')}\` on ${targets.filter((t) => !t.skip).length} online device(s)…`));
+      const results = runFleet(targets, cmd);
+      printFleetResults(results);
+    });
+
+  devicesCmd
+    .command('run <cmd...>')
+    .description('Run a command on every online registered device. Offline devices are skipped. Alias surface: agents fleet run …')
+    .allowUnknownOption()
+    .action(async (cmd: string[]) => {
+      if (!cmd.length) {
+        console.error(chalk.red('Usage: agents fleet run <cmd...>'));
+        process.exit(1);
+      }
+      const reg = await loadDevices();
+      const targets = planFleetTargets(reg);
+      if (targets.length === 0) {
+        console.log(chalk.gray("No devices. Run 'agents devices sync' first."));
+        return;
+      }
+      console.log(chalk.gray(`Running \`${cmd.join(' ')}\` on ${targets.filter((t) => !t.skip).length} online device(s)…`));
+      const results = runFleet(targets, cmd);
+      printFleetResults(results);
     });
 }
 

--- a/apps/cli/src/lib/devices/fleet.test.ts
+++ b/apps/cli/src/lib/devices/fleet.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+  planFleetTargets,
+  runFleet,
+  skipLabel,
+  upgradeCommand,
+  type FleetTarget,
+} from './fleet.js';
+import type { DeviceProfile, DeviceRegistry } from './registry.js';
+
+function device(overrides: Partial<DeviceProfile> & { name: string }): DeviceProfile {
+  const now = '2026-07-14T00:00:00.000Z';
+  return {
+    name: overrides.name,
+    platform: overrides.platform ?? 'linux',
+    shell: overrides.shell ?? 'posix',
+    user: overrides.user ?? 'muqsit',
+    address: overrides.address ?? { via: 'manual', dnsName: `${overrides.name}.ts.net` },
+    auth: overrides.auth ?? { method: 'key' },
+    tailscale: overrides.tailscale,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+  };
+}
+
+describe('planFleetTargets', () => {
+  it('skips Tailscale-offline devices and keeps online ones', () => {
+    const reg: DeviceRegistry = {
+      alive: device({ name: 'alive', tailscale: { online: true, direct: true } }),
+      dead: device({ name: 'dead', tailscale: { online: false, direct: false, lastSeen: 'yesterday' } }),
+      manual: device({ name: 'manual' }), // no tailscale snapshot → try
+    };
+    const plan = planFleetTargets(reg);
+    const byName = Object.fromEntries(plan.map((t) => [t.device.name, t]));
+    expect(byName.alive.skip).toBeUndefined();
+    expect(byName.dead.skip).toBe('offline');
+    expect(byName.manual.skip).toBeUndefined();
+  });
+
+  it('skips devices with no address', () => {
+    const reg: DeviceRegistry = {
+      bare: device({ name: 'bare', address: { via: 'manual' } }),
+    };
+    const plan = planFleetTargets(reg);
+    expect(plan[0].skip).toBe('no-address');
+  });
+});
+
+describe('runFleet', () => {
+  it('skips offline targets and reports per-device ok/failed', () => {
+    const targets: FleetTarget[] = [
+      { device: device({ name: 'a' }) },
+      { device: device({ name: 'b' }), skip: 'offline' },
+      { device: device({ name: 'c' }) },
+    ];
+    const results = runFleet(targets, ['agents', 'upgrade', '--yes'], (d) => {
+      if (d.name === 'a') return { code: 0, stdout: 'ok', stderr: '' };
+      return { code: 1, stdout: '', stderr: 'npm ERR' };
+    });
+    expect(results).toEqual([
+      { name: 'a', status: 'ok', code: 0, detail: undefined },
+      { name: 'b', status: 'skipped', code: null, reason: 'offline' },
+      { name: 'c', status: 'failed', code: 1, detail: 'npm ERR' },
+    ]);
+  });
+});
+
+describe('upgradeCommand', () => {
+  it('defaults to latest with --yes', () => {
+    expect(upgradeCommand()).toEqual(['agents', 'upgrade', '--yes']);
+    expect(upgradeCommand('1.20.62')).toEqual(['agents', 'upgrade', '1.20.62', '--yes']);
+  });
+});
+
+describe('skipLabel', () => {
+  it('labels each reason', () => {
+    expect(skipLabel('offline')).toBe('offline');
+    expect(skipLabel('no-address')).toBe('no address');
+  });
+});

--- a/apps/cli/src/lib/devices/fleet.test.ts
+++ b/apps/cli/src/lib/devices/fleet.test.ts
@@ -63,12 +63,33 @@ describe('runFleet', () => {
       { name: 'c', status: 'failed', code: 1, detail: 'npm ERR' },
     ]);
   });
+
+  it('records a throwing device as failed and continues the rest', () => {
+    const targets: FleetTarget[] = [
+      { device: device({ name: 'a' }) },
+      { device: device({ name: 'b' }) },
+      { device: device({ name: 'c' }) },
+    ];
+    const results = runFleet(targets, ['true'], (d) => {
+      if (d.name === 'b') throw new Error('password auth but no secrets bundle');
+      return { code: 0, stdout: '', stderr: '' };
+    });
+    expect(results.map((r) => r.status)).toEqual(['ok', 'failed', 'ok']);
+    expect(results[1].detail).toMatch(/password auth/);
+  });
 });
 
 describe('upgradeCommand', () => {
   it('defaults to latest with --yes', () => {
     expect(upgradeCommand()).toEqual(['agents', 'upgrade', '--yes']);
     expect(upgradeCommand('1.20.62')).toEqual(['agents', 'upgrade', '1.20.62', '--yes']);
+    expect(upgradeCommand('latest')).toEqual(['agents', 'upgrade', 'latest', '--yes']);
+  });
+
+  it('rejects shell metacharacters in the version pin', () => {
+    expect(() => upgradeCommand('1.0.0; curl evil')).toThrow(/Invalid version/);
+    expect(() => upgradeCommand('$(reboot)')).toThrow(/Invalid version/);
+    expect(() => upgradeCommand('1.0.0 && true')).toThrow(/Invalid version/);
   });
 });
 

--- a/apps/cli/src/lib/devices/fleet.ts
+++ b/apps/cli/src/lib/devices/fleet.ts
@@ -1,0 +1,135 @@
+/**
+ * Fleet-wide device operations — pick online targets and run a command on each.
+ *
+ * Used by `agents fleet update` / `agents fleet run` (aliases of the same
+ * subcommands under `agents devices`). Offline devices are skipped with a
+ * reason so a single dead node never blocks the rest of the rollout.
+ */
+
+import { spawnSync } from 'child_process';
+import { machineId } from '../session/sync/config.js';
+import type { DeviceProfile, DeviceRegistry } from './registry.js';
+import { buildSshInvocation, sshTargetFor, writeAskpassShim } from './connect.js';
+
+export type FleetSkipReason = 'offline' | 'no-address' | 'self-local';
+
+export interface FleetTarget {
+  device: DeviceProfile;
+  /** When set, this device is not reached (skip with reason). */
+  skip?: FleetSkipReason;
+}
+
+export interface FleetRunResult {
+  name: string;
+  status: 'ok' | 'failed' | 'skipped';
+  code: number | null;
+  reason?: FleetSkipReason | string;
+  /** Truncated combined stderr/stdout for failures. */
+  detail?: string;
+}
+
+/**
+ * Classify each registered device for a fleet operation.
+ *
+ * - Tailscale-offline → skip `offline`
+ * - No address → skip `no-address`
+ * - This machine (`machineId`) is included as a normal target when it has an
+ *   address (remote path); callers that want a local-spawn path can detect
+ *   `name === machineId()` themselves. We do **not** skip self by default —
+ *   rolling the CLI out to "every box including this one" is the common case.
+ */
+export function planFleetTargets(reg: DeviceRegistry): FleetTarget[] {
+  const names = Object.keys(reg).sort();
+  return names.map((name) => {
+    const device = reg[name];
+    if (device.tailscale && !device.tailscale.online) {
+      return { device, skip: 'offline' as const };
+    }
+    try {
+      sshTargetFor(device);
+    } catch {
+      return { device, skip: 'no-address' as const };
+    }
+    return { device };
+  });
+}
+
+/** Human label for a skip reason. */
+export function skipLabel(reason: FleetSkipReason): string {
+  switch (reason) {
+    case 'offline':
+      return 'offline';
+    case 'no-address':
+      return 'no address';
+    case 'self-local':
+      return 'this machine';
+  }
+}
+
+/**
+ * Run `cmd` on one device via the same ssh path as `agents ssh <name> …`.
+ * Captures stdout/stderr (not inherited) so the fleet table can summarize.
+ */
+export function runOnDevice(
+  device: DeviceProfile,
+  cmd: string[],
+  opts: { timeoutMs?: number } = {},
+): { code: number | null; stdout: string; stderr: string } {
+  const shim = writeAskpassShim();
+  const { args, env } = buildSshInvocation(device, cmd, shim);
+  const res = spawnSync('ssh', args, {
+    encoding: 'utf-8',
+    env: { ...process.env, ...env },
+    timeout: opts.timeoutMs ?? 600_000,
+  });
+  return {
+    code: res.status,
+    stdout: res.stdout?.toString() ?? '',
+    stderr: (res.stderr?.toString() ?? '') + (res.error ? String(res.error.message) : ''),
+  };
+}
+
+/** Run `agents upgrade --yes` (or a pin) on a device. */
+export function upgradeCommand(version?: string): string[] {
+  return version
+    ? ['agents', 'upgrade', version, '--yes']
+    : ['agents', 'upgrade', '--yes'];
+}
+
+/**
+ * Execute a command across planned targets. Pure orchestration over
+ * {@link runOnDevice}; testable by injecting `runner`.
+ */
+export function runFleet(
+  targets: FleetTarget[],
+  cmd: string[],
+  runner: typeof runOnDevice = runOnDevice,
+): FleetRunResult[] {
+  const results: FleetRunResult[] = [];
+  for (const t of targets) {
+    if (t.skip) {
+      results.push({
+        name: t.device.name,
+        status: 'skipped',
+        code: null,
+        reason: t.skip,
+      });
+      continue;
+    }
+    const res = runner(t.device, cmd);
+    const ok = res.code === 0;
+    const detail = (res.stderr || res.stdout).trim().slice(0, 200);
+    results.push({
+      name: t.device.name,
+      status: ok ? 'ok' : 'failed',
+      code: res.code,
+      detail: ok ? undefined : detail || undefined,
+    });
+  }
+  return results;
+}
+
+/** Whether this process is running on `name` (local machine). Exported for tests. */
+export function isLocalDevice(name: string): boolean {
+  return name === machineId();
+}

--- a/apps/cli/src/lib/devices/fleet.ts
+++ b/apps/cli/src/lib/devices/fleet.ts
@@ -3,15 +3,19 @@
  *
  * Used by `agents fleet update` / `agents fleet run` (aliases of the same
  * subcommands under `agents devices`). Offline devices are skipped with a
- * reason so a single dead node never blocks the rest of the rollout.
+ * reason so a single dead node never blocks the rest of the rollout. Per-device
+ * throws (misconfigured auth, etc.) become `failed` rows — they never abort
+ * the remaining devices.
  */
 
 import { spawnSync } from 'child_process';
-import { machineId } from '../session/sync/config.js';
 import type { DeviceProfile, DeviceRegistry } from './registry.js';
 import { buildSshInvocation, sshTargetFor, writeAskpassShim } from './connect.js';
 
-export type FleetSkipReason = 'offline' | 'no-address' | 'self-local';
+export type FleetSkipReason = 'offline' | 'no-address';
+
+/** npm dist-tags / semver pins only — rejects shell metacharacters. */
+export const FLEET_VERSION_RE = /^[A-Za-z0-9._-]+$/;
 
 export interface FleetTarget {
   device: DeviceProfile;
@@ -33,10 +37,8 @@ export interface FleetRunResult {
  *
  * - Tailscale-offline → skip `offline`
  * - No address → skip `no-address`
- * - This machine (`machineId`) is included as a normal target when it has an
- *   address (remote path); callers that want a local-spawn path can detect
- *   `name === machineId()` themselves. We do **not** skip self by default —
- *   rolling the CLI out to "every box including this one" is the common case.
+ * - Everything else is a target (including this machine, reached over ssh when
+ *   it has a registry address — same path as any other box).
  */
 export function planFleetTargets(reg: DeviceRegistry): FleetTarget[] {
   const names = Object.keys(reg).sort();
@@ -61,44 +63,63 @@ export function skipLabel(reason: FleetSkipReason): string {
       return 'offline';
     case 'no-address':
       return 'no address';
-    case 'self-local':
-      return 'this machine';
   }
 }
 
 /**
  * Run `cmd` on one device via the same ssh path as `agents ssh <name> …`.
  * Captures stdout/stderr (not inherited) so the fleet table can summarize.
+ * Throws from buildSshInvocation are returned as a non-zero result so a single
+ * misconfigured device cannot abort the fleet loop.
  */
 export function runOnDevice(
   device: DeviceProfile,
   cmd: string[],
   opts: { timeoutMs?: number } = {},
 ): { code: number | null; stdout: string; stderr: string } {
-  const shim = writeAskpassShim();
-  const { args, env } = buildSshInvocation(device, cmd, shim);
-  const res = spawnSync('ssh', args, {
-    encoding: 'utf-8',
-    env: { ...process.env, ...env },
-    timeout: opts.timeoutMs ?? 600_000,
-  });
-  return {
-    code: res.status,
-    stdout: res.stdout?.toString() ?? '',
-    stderr: (res.stderr?.toString() ?? '') + (res.error ? String(res.error.message) : ''),
-  };
+  try {
+    const shim = writeAskpassShim();
+    const { args, env } = buildSshInvocation(device, cmd, shim);
+    const res = spawnSync('ssh', args, {
+      encoding: 'utf-8',
+      env: { ...process.env, ...env },
+      timeout: opts.timeoutMs ?? 600_000,
+    });
+    return {
+      code: res.status,
+      stdout: res.stdout?.toString() ?? '',
+      stderr: (res.stderr?.toString() ?? '') + (res.error ? String(res.error.message) : ''),
+    };
+  } catch (err) {
+    return {
+      code: 1,
+      stdout: '',
+      stderr: err instanceof Error ? err.message : String(err),
+    };
+  }
 }
 
-/** Run `agents upgrade --yes` (or a pin) on a device. */
+/**
+ * Build `agents upgrade --yes` argv, optionally pinned to a version/dist-tag.
+ * Rejects anything that is not a plain npm version/tag token so a version pin
+ * cannot inject shell metacharacters into the remote command line.
+ */
 export function upgradeCommand(version?: string): string[] {
-  return version
-    ? ['agents', 'upgrade', version, '--yes']
-    : ['agents', 'upgrade', '--yes'];
+  if (version !== undefined && version !== '') {
+    if (!FLEET_VERSION_RE.test(version)) {
+      throw new Error(
+        `Invalid version '${version}'. Use a semver or dist-tag (letters, digits, . _ - only).`,
+      );
+    }
+    return ['agents', 'upgrade', version, '--yes'];
+  }
+  return ['agents', 'upgrade', '--yes'];
 }
 
 /**
  * Execute a command across planned targets. Pure orchestration over
- * {@link runOnDevice}; testable by injecting `runner`.
+ * {@link runOnDevice}; testable by injecting `runner`. Per-device throws from
+ * the runner are recorded as `failed` so one bad device never aborts the rest.
  */
 export function runFleet(
   targets: FleetTarget[],
@@ -116,20 +137,24 @@ export function runFleet(
       });
       continue;
     }
-    const res = runner(t.device, cmd);
-    const ok = res.code === 0;
-    const detail = (res.stderr || res.stdout).trim().slice(0, 200);
-    results.push({
-      name: t.device.name,
-      status: ok ? 'ok' : 'failed',
-      code: res.code,
-      detail: ok ? undefined : detail || undefined,
-    });
+    try {
+      const res = runner(t.device, cmd);
+      const ok = res.code === 0;
+      const detail = (res.stderr || res.stdout).trim().slice(0, 200);
+      results.push({
+        name: t.device.name,
+        status: ok ? 'ok' : 'failed',
+        code: res.code,
+        detail: ok ? undefined : detail || undefined,
+      });
+    } catch (err) {
+      results.push({
+        name: t.device.name,
+        status: 'failed',
+        code: 1,
+        detail: (err instanceof Error ? err.message : String(err)).slice(0, 200),
+      });
+    }
   }
   return results;
-}
-
-/** Whether this process is running on `name` (local machine). Exported for tests. */
-export function isLocalDevice(name: string): boolean {
-  return name === machineId();
 }

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -181,6 +181,9 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   events: [loadEvents],
   ssh: [loadSsh],
   devices: [loadSsh],
+  // `fleet` is a commander alias of `devices` (see commands/ssh.ts); list it so
+  // lazy registration loads the devices tree when the user types `agents fleet`.
+  fleet: [loadSsh],
   pull: [loadPull],
   push: [loadPush],
   repo: [loadRepo],

--- a/skills/devices/SKILL.md
+++ b/skills/devices/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: devices
 description: "Register and connect to your machines over Tailscale SSH with agents-cli. Use this skill to sync devices from the tailnet, list them, open a shell on another machine, or see agent sessions running across your whole fleet."
-argument-hint: "[sync|list|show|add|set|ssh]"
-allowed-tools: Bash(agents devices*), Bash(agents ssh*), Bash(agents sessions*), Bash(agents run*), Bash(agents hosts*), Bash(agents logs*)
+argument-hint: "[sync|list|show|add|set|ssh|update|run|fleet]"
+allowed-tools: Bash(agents devices*), Bash(agents fleet*), Bash(agents ssh*), Bash(agents sessions*), Bash(agents run*), Bash(agents hosts*), Bash(agents logs*)
 user-invocable: true
 ---
 
@@ -10,8 +10,12 @@ user-invocable: true
 
 Manage a registry of SSH device profiles and reach your other machines. The
 registry self-populates from `tailscale status --json`, so on a tailnet you
-rarely hand-enter a host. This skill teaches the `agents devices` and
-`agents ssh` CLIs, plus the fleet-wide `agents sessions --active` view.
+rarely hand-enter a host. This skill teaches the `agents devices` /
+`agents fleet` (alias) and `agents ssh` CLIs, plus the fleet-wide
+`agents sessions --active` view.
+
+`agents fleet` is a synonym for `agents devices` — every subcommand works under
+either name (`agents fleet list` == `agents devices list`).
 
 ## Register devices
 
@@ -62,6 +66,20 @@ agents ssh <name>
 # Run a one-off command and return.
 agents ssh <name> uname -a
 ```
+
+## Fleet-wide rollout
+
+```bash
+# Roll out the latest agents-cli to every online registered device.
+agents fleet update
+agents fleet update 1.20.62     # pin a version / dist-tag
+
+# Run an arbitrary command on every online device; offline ones are skipped.
+agents fleet run uname -a
+agents fleet run 'agents --version'
+```
+
+Both print a per-device result table (`ok` / `failed` / `skipped`).
 
 To use plain `ssh <name>`, render the registry into your ssh config:
 


### PR DESCRIPTION
## Summary
- `agents fleet` is an alias for `agents devices` (commander + lazy registry).
- `agents fleet update [version]` runs `agents upgrade --yes` on every online device.
- `agents fleet run <cmd…>` runs an arbitrary command fleet-wide with a per-device result table; offline/no-address devices are skipped.

Closes Linear RUSH-1632.

## Test plan
- [x] `npx vitest run src/lib/devices/fleet.test.ts` (5 passed)
- [ ] CI green