### PR TITLE
feat(routines): add signed webhook ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,8 +347,6 @@ agents hosts check gpu-box              # reachable? which agents-cli version?
 # Run there instead of locally
 agents run claude --host gpu-box "profile this build"   # headless: follows live by default
 agents run claude --host gpu-box                         # no prompt → interactive TTY over SSH (tmux-backed)
-agents hosts ps                         # list dispatched runs + terminal status
-agents hosts stop <id>                  # terminate a hung/detached run (alias: kill)
 agents logs --host gpu-box              # pick a dispatched run — concise summary by default
 agents logs <id> --full                 # the full raw transcript / stdout (token-heavy)
 agents logs <id> -f                     # re-attach to a running one and follow
@@ -684,6 +682,13 @@ agents routines add nightly-drain --schedule "0 3 * * *" --agent claude \
 
 agents routines devices nightly-drain --set yosemite-s0,mac-mini  # update allowlist
 agents routines list --host yosemite-s0                            # query another device
+
+# Signed webhook trigger: Linear issue labeled "agent" fires a routine
+agents routines add agent-labeled-issue --on linear:Issue --action update \
+  --team-key RUSH --label agent --agent claude \
+  --prompt "Work the Linear issue that was just labeled agent"
+agents webhook serve --secrets-bundle webhooks --port 8787          # /hooks/linear, /hooks/github
+agents funnel up yosemite-s0 --local-port 8787 --port 443           # public HTTPS ingress
 ```
 
 Jobs run sandboxed -- agents only see directories and tools you explicitly allow.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,40 +2,11 @@
 
 ## Unreleased
 
-- **`agents fleet` alias + fleet-wide rollout (RUSH-1632).** `fleet` is an alias
-  for `devices`. New subcommands `update [version]` and `run <cmd…>` roll out
-  across every online device with a per-device result table. Source:
-  `apps/cli/src/commands/ssh.ts`, `apps/cli/src/lib/devices/fleet.ts`.
-- **`agents hosts stop <id>` (alias `kill`) terminates a detached host run from the origin machine (RUSH-1360).**
-  Sends SIGTERM to the remote process group, writes exit `143` only when a live
-  group was signaled (or no `.exit` existed), and keeps the remote log for
-  `agents hosts logs <id>`. Source: `apps/cli/src/lib/hosts/dispatch.ts`,
-  `apps/cli/src/commands/hosts.ts`.
-- **Fix: mailbox GC actually archives expired messages on live boxes (RUSH-1611).**
-  The live-box branch of `gcMailbox` only incremented `messagesDroppedExpired`
-  without moving the file to `consumed/`, so `agents feed --dispatch` could report
-  drops while leaving expired messages in `inbox/`/`processing/`. GC now reuses
-  `sweepExpired` (the same path as drain/peek). Source: `apps/cli/src/lib/mailbox-gc.ts`.
-- **Fix: Antigravity sign-in detection on Linux when the OAuth grant lives in Secret Service (RUSH-1329).** `agy` uses the Go keyring library, which prefers libsecret (gnome-keyring) over the file fallback whenever a Secret Service daemon is running — so `~/.gemini/antigravity-cli/antigravity-oauth-token` may be absent even when the user is signed in. After the file check, `getAccountInfo` now probes `secret-tool lookup service gemini username antigravity` (exit 0 = present; stdout discarded), mirroring the macOS `security find-generic-password` probe from #506. Missing `secret-tool`, locked collections, and timeouts all read as signed out. Opt out with `AGENTS_NO_KEYCHAIN_PROBE=1`. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/agents.test.ts`.
 - **Extend session sync to Droid, Grok, Kimi, and OpenCode (RUSH-1467).** `agents sessions sync` now includes these four agents in its upload/download matrix. `SyncAgentSpec` gains an optional `ext` field so agents with non-`.jsonl` transcript files (e.g., Kimi `state.json`) are walked correctly. Droid `.jsonl` rollouts, Grok `events.jsonl` streams, and Kimi `state.json` metadata files round-trip through the R2 mirror; OpenCode is slotted in `SYNC_AGENTS` but remains a placeholder because its sessions live in a SQLite DB and still require an SQLite-to-JSONL export step. Source: `apps/cli/src/lib/session/sync/agents.ts`, `apps/cli/src/lib/session/sync/agents.test.ts`, `apps/cli/src/commands/sessions-sync.ts`.
-<<<<<<< HEAD
-- **`agents hosts stop <id>` (alias `kill`) terminates a detached host run from the origin machine (RUSH-1360).**
-  Sends SIGTERM to the remote process group, writes exit `143` to the remote
-  `.exit` marker so `hosts ps` shows a terminal `failed` status, and keeps the
-  remote log for `agents hosts logs <id>`. Complements the existing on-demand
-  log fetch and `.exit` reconcile that already landed for detached `--no-follow`
-  runs. Source: `apps/cli/src/lib/hosts/dispatch.ts`, `apps/cli/src/commands/hosts.ts`.
-=======
-- **`agents fleet` alias + fleet-wide rollout (RUSH-1632).** `fleet` is an alias
-  for `devices` (`agents fleet list` == `agents devices list`). New subcommands
-  `update [version]` and `run <cmd…>` roll out `agents upgrade --yes` (or an
-  arbitrary command) to every online registered device and print a per-device
-  result table; offline / no-address devices are skipped with a clear note.
-  Source: `apps/cli/src/commands/ssh.ts`, `apps/cli/src/lib/devices/fleet.ts`,
-  `apps/cli/src/lib/startup/command-registry.ts`, `skills/devices/SKILL.md`.
->>>>>>> 8ac12843 (feat(devices): fleet alias + fleet-wide update/run (RUSH-1632))
+- **Public signed webhook ingress for routines via Tailscale Funnel (RUSH-1456, RUSH-1459, RUSH-1460, RUSH-1461).** Routines can now declare source-aware webhook triggers: existing GitHub triggers keep `type: github_event`, and Linear triggers use `type: linear_event` with `action`, `teamKey`, and `label` filters for flows like “Linear issue labeled `agent` → run an agent.” `agents webhook serve --secrets-bundle <name>` runs a localhost receiver for `POST /hooks/github` and `/hooks/linear`, verifying raw-body HMAC signatures (`X-Hub-Signature-256` / `Linear-Signature`), rejecting stale Linear timestamps, deduping delivery IDs, and rate-limiting per source. `agents funnel status <host>` and `agents funnel up <host> --local-port N --port 443|8443|10000` wrap the remote Tailscale CLI through existing host/device SSH resolution and validate Funnel’s public-port limits before enabling public HTTPS ingress. Source: `apps/cli/src/lib/triggers/webhook.ts`, `apps/cli/src/commands/webhook.ts`, `apps/cli/src/lib/funnel.ts`, `apps/cli/src/commands/funnel.ts`, `apps/cli/src/lib/routines.ts`, `apps/cli/src/commands/routines.ts`.
 
 ## 1.20.62
+
 - **Wire Goose commands support (RUSH-1572).** `agents` now syncs slash commands to Goose as recipe YAML files under `~/.config/goose/commands/<name>.yaml`, each registered in `~/.config/goose/config.yaml` under a `slash_commands: [{ command, recipe_path }]` array (Goose has no native slash-command file format — a slash command IS a recipe). The command recipes live in a dir distinct from the workflow recipes dir (`~/.config/goose/recipes/`) so the workflow detector never treats a command recipe as a workflow. Registration is a read-modify-write that preserves every other `config.yaml` key (`mcp_servers`, `extensions`, …) and other `slash_commands` entries, and removal soft-deletes the recipe + unregisters the entry. Flip Goose's `commands` capability and add `goose` branches to install/list/match/remove, the staleness commands writer, and doctor-diff, backed by a new `goose-commands.ts` module + a `markdownToGooseRecipe` converter. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/goose-commands.ts`, `apps/cli/src/lib/commands.ts`, `apps/cli/src/lib/convert.ts`, `apps/cli/src/lib/staleness/writers/commands.ts`, `apps/cli/src/lib/doctor-diff.ts`.
 - **Fix: Hermes plugin sync no longer disables a plugin the user explicitly enabled.** The plugin install path (RUSH-1688) unconditionally forced `plugins.enabled` to the exec-surface trust verdict on every sync. An ordinary un-flagged background re-sync computes `enable=false` for a plugin with hooks/tools, so it stripped that plugin from the `~/.hermes/config.yaml` allowlist — clobbering a plugin the user deliberately enabled with `--allow-exec-surfaces`. The install path now enables only when trusted and never down-toggles (matching the marketplace flow's add-if-trusted semantics); removal still unregisters explicitly. Source: `apps/cli/src/lib/plugins.ts`.
 - **Wire Goose subagents support (RUSH-1573).** `agents` now syncs subagents to Goose as recipe YAML files under `~/.config/goose/agents/<name>.yaml` — Goose has no dedicated subagent format, so a named subagent IS a recipe (goose auto-discovers `~/.config/goose/agents/` and delegates to them by name in autonomous mode). `transformSubagentForGoose` emits the same recipe schema agents-cli already uses for Goose workflow recipes (`version`/`title`/`description`/`instructions`/`prompt`, plus optional `settings.goose_model`). Flip Goose's `subagents` capability and wire the install/remove/list/orphan/version-remove branches plus the staleness subagents writer and detector. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/subagents.ts`, `apps/cli/src/lib/staleness/{writers,detectors}/subagents.ts`.

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -73,6 +73,67 @@ agents routines add reminder --at "14:30" --agent claude --prompt "Remind Muqsit
 
 `--at` accepts `"14:30"` (today at that time) or `"2026-02-24 09:00"` (absolute). The daemon converts it to a cron expression with `runOnce: true`.
 
+### Webhook Triggers
+
+Routines can fire from signed GitHub or Linear webhooks instead of a cron
+schedule. The same detached runner path is used as scheduled jobs.
+
+```bash
+agents routines add agent-labeled-issue \
+  --on linear:Issue \
+  --action update \
+  --team-key RUSH \
+  --label agent \
+  --agent claude \
+  --prompt "Work the Linear issue that was just labeled agent"
+```
+
+Equivalent YAML:
+
+```yaml
+name: agent-labeled-issue
+trigger:
+  type: linear_event
+  event: Issue
+  action: update
+  teamKey: RUSH
+  label: agent
+agent: claude
+prompt: "Work the Linear issue that was just labeled agent"
+```
+
+GitHub triggers use `type: github_event` with optional `repo` and `branch`:
+
+```bash
+agents routines add pr-review \
+  --on github:pull_request \
+  --repo phnx-labs/agents-cli \
+  --branch main \
+  --agent claude \
+  --prompt "Review the pull request"
+```
+
+Run the localhost receiver with signing keys from an `agents secrets` bundle:
+
+```bash
+agents webhook serve --secrets-bundle webhooks --port 8787
+```
+
+The bundle may contain `GITHUB_WEBHOOK_SECRET`, `LINEAR_WEBHOOK_SECRET`, or both.
+The receiver accepts `POST /hooks/github` and `POST /hooks/linear`, rejects
+unsigned deliveries, dedupes repeated delivery IDs, rate-limits each source, and
+binds `127.0.0.1` by default.
+
+Expose the receiver publicly from a Linux/macOS Tailscale node with Funnel:
+
+```bash
+agents funnel up yosemite-s0 --local-port 8787 --port 443
+agents funnel status yosemite-s0
+```
+
+Funnel public ports are limited to `443`, `8443`, and `10000`; `agents funnel up`
+validates that before running the remote Tailscale CLI.
+
 ### Device Allowlist
 
 `~/.agents/routines/` rides the user repo, so every routine syncs to every machine —

--- a/apps/cli/docs/README.md
+++ b/apps/cli/docs/README.md
@@ -37,7 +37,7 @@ How agents-cli is laid out on disk and how it decides what to load.
 | [Teams](teams.md) | Multi-agent DAG teams, boundary contracts, `--watch` supervisor, `--worktree` isolation, `--cloud` dispatch. |
 | [Cloud](cloud.md) | Unified dispatch across Rush Cloud / Codex Cloud / Factory. Multi-repo tasks, balanced routing, SSE streaming. |
 | [Hosts](hosts.md) | Offload `agents run` to your own machines over SSH (`--host`); track with `agents hosts ps` and view/follow with `agents logs`. |
-| [Routines](03-routines.md) | Cron-scheduled agent runs with sandboxed permissions and a long-running daemon. |
+| [Routines](03-routines.md) | Cron-scheduled and signed-webhook-triggered agent runs with sandboxed permissions and a long-running daemon. |
 
 ## Extensibility
 

--- a/apps/cli/src/commands/funnel.ts
+++ b/apps/cli/src/commands/funnel.ts
@@ -1,0 +1,67 @@
+/**
+ * `agents funnel` — thin Tailscale Funnel wrapper for webhook ingress nodes.
+ */
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { buildFunnelStatusCommand, buildFunnelUpCommand, parseFunnelPort } from '../lib/funnel.js';
+import { resolveHost } from '../lib/hosts/registry.js';
+import { resolveRemoteOsSync } from '../lib/hosts/remote-os.js';
+import { sshTargetFor } from '../lib/hosts/types.js';
+import { sshExec } from '../lib/ssh-exec.js';
+
+async function resolveIngressHost(name: string) {
+  const host = await resolveHost(name);
+  if (!host) throw new Error(`Unknown host "${name}". Enroll it with agents hosts add, or sync devices first.`);
+  const os = host.os ?? resolveRemoteOsSync(host.name);
+  if (os === 'windows') {
+    throw new Error('Tailscale Funnel requires a host with the Tailscale CLI; Windows cannot host this ingress path.');
+  }
+  return host;
+}
+
+async function runOnHost(hostName: string, command: string): Promise<void> {
+  const host = await resolveIngressHost(hostName);
+  const target = sshTargetFor(host);
+  const result = sshExec(target, command, { timeoutMs: 30_000, multiplex: true });
+  if (result.code !== 0) {
+    throw new Error((result.stderr || result.stdout).trim() || `ssh exited ${result.code ?? 'without a code'}`);
+  }
+  const out = result.stdout.trim();
+  if (out) console.log(out);
+}
+
+export function registerFunnelCommand(program: Command): void {
+  const funnel = program
+    .command('funnel')
+    .description('Manage Tailscale Funnel exposure for a fleet webhook receiver.');
+
+  funnel
+    .command('status <host>')
+    .description('Show Tailscale Funnel status on a fleet host.')
+    .action(async (host: string) => {
+      try {
+        await runOnHost(host, buildFunnelStatusCommand());
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+
+  funnel
+    .command('up <host>')
+    .description('Expose a localhost webhook receiver through Tailscale Funnel.')
+    .requiredOption('--local-port <n>', 'Local receiver port on the remote host')
+    .option('--port <n>', 'Public Funnel port: 443, 8443, or 10000', '443')
+    .action(async (host: string, opts: { port?: string; localPort: string }) => {
+      try {
+        const publicPort = parseFunnelPort(opts.port ?? '443');
+        const localPort = Number.parseInt(opts.localPort, 10);
+        const command = buildFunnelUpCommand(publicPort, localPort);
+        await runOnHost(host, command);
+        console.log(chalk.green(`Funnel enabled on ${host}: public :${publicPort} → localhost:${localPort}`));
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+}

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -39,8 +39,8 @@ import {
   jobRunsOnThisDevice,
   checkJobDeviceEligibility,
 } from '../lib/routines.js';
-import type { JobConfig } from '../lib/routines.js';
-import { fireWebhookJobs, matchJobsToWebhook, type GithubWebhook } from '../lib/triggers/webhook.js';
+import type { GithubTriggerEvent, JobConfig, JobTrigger, LinearTriggerEvent } from '../lib/routines.js';
+import { fireWebhookJobs, matchJobsToWebhook, type IncomingWebhook, type WebhookSource } from '../lib/triggers/webhook.js';
 import { getRoutinesDir } from '../lib/state.js';
 import { IS_WINDOWS } from '../lib/platform/index.js';
 import { safeJoin } from '../lib/paths.js';
@@ -78,12 +78,40 @@ export function formatRunDuration(startedAt: string, completedAt: string | null)
 function fireConditionLabel(job: JobConfig): string {
   if (job.schedule) return humanizeCron(job.schedule, job.timezone);
   if (job.trigger) {
-    const scope = job.trigger.repo
-      ? ` (${job.trigger.repo}${job.trigger.branch ? `@${job.trigger.branch}` : ''})`
-      : '';
-    return `on ${job.trigger.event}${scope}`;
+    if (job.trigger.type === 'github_event') {
+      const scope = job.trigger.repo
+        ? ` (${job.trigger.repo}${job.trigger.branch ? `@${job.trigger.branch}` : ''})`
+        : '';
+      return `on github:${job.trigger.event}${scope}`;
+    }
+    const filters = [
+      job.trigger.action ? `action=${job.trigger.action}` : null,
+      job.trigger.teamKey ? `team=${job.trigger.teamKey}` : null,
+      job.trigger.label ? `label=${job.trigger.label}` : null,
+    ].filter(Boolean).join(', ');
+    return `on linear:${job.trigger.event}${filters ? ` (${filters})` : ''}`;
   }
   return '-';
+}
+
+function parseRoutineTrigger(options: Record<string, unknown>): JobTrigger | undefined {
+  const raw = typeof options.on === 'string' ? options.on : undefined;
+  if (!raw) return undefined;
+  const [sourceMaybe, eventMaybe] = raw.includes(':') ? raw.split(':', 2) : ['github', raw];
+  if (sourceMaybe === 'github') {
+    const trigger: JobTrigger = { type: 'github_event', event: eventMaybe as GithubTriggerEvent };
+    if (typeof options.repo === 'string') trigger.repo = options.repo;
+    if (typeof options.branch === 'string') trigger.branch = options.branch;
+    return trigger;
+  }
+  if (sourceMaybe === 'linear') {
+    const trigger: JobTrigger = { type: 'linear_event', event: eventMaybe as LinearTriggerEvent };
+    if (typeof options.action === 'string') trigger.action = options.action;
+    if (typeof options.teamKey === 'string') trigger.teamKey = options.teamKey;
+    if (typeof options.label === 'string') trigger.label = options.label;
+    return trigger;
+  }
+  throw new Error('--on source must be github or linear');
 }
 
 /** Start or reload the background scheduler so newly-added jobs fire on time. */
@@ -403,12 +431,18 @@ export function registerRoutinesCommands(program: Command): void {
     .option('--timezone <tz>', 'Interpret schedule in this timezone (e.g., America/Los_Angeles)')
     .option('--devices <names>', 'Fleet allowlist (comma-separated): only listed devices schedule and fire this routine. Omit for unrestricted.')
     .option('--at <time>', 'One-shot mode: run once at this time (e.g., "14:30" or "2026-02-24 09:00"), then disable')
+    .option('--on <source:event>', 'Webhook trigger instead of/in addition to a schedule: github:pull_request or linear:Issue')
+    .option('--repo <owner/name>', 'GitHub repo filter for --on github:<event>')
+    .option('--branch <name>', 'GitHub branch filter for --on github:<event>')
+    .option('--action <name>', 'Linear action filter for --on linear:<event> (e.g. update)')
+    .option('--team-key <key>', 'Linear team key filter for --on linear:<event> (e.g. RUSH)')
+    .option('--label <name>', 'Linear issue label filter for --on linear:Issue')
     .option('--end-at <iso>', 'Stop firing on or after this ISO 8601 timestamp (e.g., "2026-12-31T23:59:00Z"); routine auto-disables.')
     .option('--disabled', 'Create the routine but keep it paused (enable later with resume)')
     .option('--resume <sessionId>', 'At fire time, resume this existing session id (via `agents run <agent> --resume`) instead of starting fresh — the actual session reopens with full context and the prompt becomes its next turn. Powers self-scheduled wake-ups (e.g. /hibernate). Requires --agent claude or codex; runs un-sandboxed (the session store lives in the real home, not the job overlay).')
     .action(async (nameOrPath: string | undefined, options) => {
       // Check if inline mode (has flags) or file mode
-      const hasInlineFlags = options.schedule || options.agent || options.workflow || options.prompt || options.at;
+      const hasInlineFlags = options.schedule || options.agent || options.workflow || options.prompt || options.at || options.on;
 
       if (hasInlineFlags) {
         // Inline mode: create job from flags
@@ -425,7 +459,14 @@ export function registerRoutinesCommands(program: Command): void {
         }
 
         let schedule = options.schedule;
+        let trigger: JobTrigger | undefined;
         let runOnce = false;
+        try {
+          trigger = parseRoutineTrigger(options);
+        } catch (err) {
+          console.log(chalk.red((err as Error).message));
+          process.exit(1);
+        }
 
         // Handle --at for one-shot jobs
         if (options.at) {
@@ -439,8 +480,8 @@ export function registerRoutinesCommands(program: Command): void {
           runOnce = parsed.runOnce;
         }
 
-        if (!schedule) {
-          console.log(chalk.red('Schedule is required (use --schedule or --at)'));
+        if (!schedule && !trigger) {
+          console.log(chalk.red('Schedule or trigger is required (use --schedule, --at, or --on)'));
           process.exit(1);
         }
 
@@ -462,7 +503,8 @@ export function registerRoutinesCommands(program: Command): void {
 
         const config: JobConfig = {
           name: nameOrPath,
-          schedule,
+          ...(schedule ? { schedule } : {}),
+          ...(trigger ? { trigger } : {}),
           agent: options.agent,
           ...(options.workflow ? { workflow: options.workflow } : {}),
           mode: options.mode,
@@ -777,11 +819,17 @@ export function registerRoutinesCommands(program: Command): void {
 
   routinesCmd
     .command('webhook')
-    .description('Fire trigger-based routines from a single GitHub webhook payload (read from --file or stdin). One-shot: matches and fires, then exits. For a long-running receiver, run this behind your own HTTP forwarder.')
-    .requiredOption('--event <name>', 'GitHub event name, as sent in the X-GitHub-Event header (e.g. pull_request, push, workflow_run)')
+    .description('Fire trigger-based routines from a single webhook payload (read from --file or stdin). One-shot: matches and fires, then exits.')
+    .option('--source <name>', 'Webhook source: github or linear', 'github')
+    .requiredOption('--event <name>', 'Source event name: GitHub X-GitHub-Event value, or Linear payload type')
     .option('--file <path>', 'Read the webhook JSON payload from this file instead of stdin')
     .option('--dry-run', 'Show which routines would fire without firing them')
-    .action(async (options: { event: string; file?: string; dryRun?: boolean }) => {
+    .action(async (options: { source?: string; event: string; file?: string; dryRun?: boolean }) => {
+      const source = options.source as WebhookSource;
+      if (source !== 'github' && source !== 'linear') {
+        console.log(chalk.red(`Unknown webhook source "${options.source}". Use github or linear.`));
+        process.exit(1);
+      }
       // Load the raw JSON payload: --file wins, else drain stdin.
       let raw: string;
       if (options.file) {
@@ -813,7 +861,7 @@ export function registerRoutinesCommands(program: Command): void {
         process.exit(1);
       }
 
-      const webhook: GithubWebhook = { event: options.event, payload };
+      const webhook: IncomingWebhook = { source, event: options.event, payload };
 
       // Matching is intentionally user-layer only (fireWebhookJobs defaults to
       // listJobs() with no cwd), mirroring `run`/`catchup`: a webhook must never
@@ -822,10 +870,10 @@ export function registerRoutinesCommands(program: Command): void {
       if (options.dryRun) {
         const matched = matchJobsToWebhook(listAllJobs(), webhook);
         if (matched.length === 0) {
-          console.log(chalk.gray(`No routines match a ${options.event} event for this payload.`));
+          console.log(chalk.gray(`No routines match a ${source}:${options.event} event for this payload.`));
           return;
         }
-        console.log(chalk.bold(`${matched.length} routine(s) would fire on ${options.event}:\n`));
+        console.log(chalk.bold(`${matched.length} routine(s) would fire on ${source}:${options.event}:\n`));
         for (const job of matched) {
           console.log(`  ${chalk.cyan(job.name)} — ${fireConditionLabel(job)}`);
         }
@@ -844,11 +892,11 @@ export function registerRoutinesCommands(program: Command): void {
 
       const fired = await fireWebhookJobs(webhook);
       if (fired.length === 0) {
-        console.log(chalk.gray(`No routines match a ${options.event} event for this payload.`));
+        console.log(chalk.gray(`No routines match a ${source}:${options.event} event for this payload.`));
         return;
       }
 
-      console.log(chalk.bold(`Fired ${fired.length} routine(s) on ${options.event}:\n`));
+      console.log(chalk.bold(`Fired ${fired.length} routine(s) on ${source}:${options.event}:\n`));
       for (const f of fired) {
         console.log(`  ${chalk.cyan(f.jobName)} → ${chalk.green('started')} (run: ${f.runId})`);
       }

--- a/apps/cli/src/commands/webhook.ts
+++ b/apps/cli/src/commands/webhook.ts
@@ -1,0 +1,88 @@
+/**
+ * `agents webhook` — localhost receiver for signed public webhook ingress.
+ *
+ * The receiver intentionally binds localhost by default. Public exposure is a
+ * separate `agents funnel up <host>` step so the HTTP process can be tested and
+ * rotated without changing the Tailscale Funnel config.
+ */
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { readAndResolveBundleEnv } from '../lib/secrets/bundles.js';
+import { startWebhookServer, type WebhookSecrets } from '../lib/triggers/webhook.js';
+
+const DEFAULT_HOST = '127.0.0.1';
+const DEFAULT_PORT = 8787;
+
+function positiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function readWebhookSecrets(bundleName: string): WebhookSecrets {
+  const { env } = readAndResolveBundleEnv(bundleName, {
+    caller: 'webhook serve',
+  });
+  const secrets: WebhookSecrets = {};
+  if (env.GITHUB_WEBHOOK_SECRET) secrets.github = env.GITHUB_WEBHOOK_SECRET;
+  if (env.LINEAR_WEBHOOK_SECRET) secrets.linear = env.LINEAR_WEBHOOK_SECRET;
+  if (!secrets.github && !secrets.linear) {
+    throw new Error(
+      `Bundle '${bundleName}' must contain GITHUB_WEBHOOK_SECRET or LINEAR_WEBHOOK_SECRET.`,
+    );
+  }
+  return secrets;
+}
+
+export function registerWebhookCommand(program: Command): void {
+  const webhook = program
+    .command('webhook')
+    .description('Run a localhost signed webhook receiver for routine triggers.');
+
+  webhook
+    .command('serve')
+    .description('Receive signed GitHub/Linear webhooks on /hooks/<source> and fire matching routines.')
+    .requiredOption('--secrets-bundle <name>', 'agents secrets bundle containing GITHUB_WEBHOOK_SECRET and/or LINEAR_WEBHOOK_SECRET')
+    .option('--host <addr>', `Bind address (default ${DEFAULT_HOST})`, DEFAULT_HOST)
+    .option('-p, --port <n>', `Local port (default ${DEFAULT_PORT})`, String(DEFAULT_PORT))
+    .option('--rate-limit <n>', 'Accepted deliveries per source per minute', '60')
+    .action((opts: { secretsBundle: string; host?: string; port?: string; rateLimit?: string }) => {
+      let secrets: WebhookSecrets;
+      try {
+        secrets = readWebhookSecrets(opts.secretsBundle);
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+
+      const port = positiveInt(opts.port, DEFAULT_PORT);
+      const rateLimit = positiveInt(opts.rateLimit, 60);
+
+      try {
+        const server = startWebhookServer({
+          host: opts.host ?? DEFAULT_HOST,
+          port,
+          secrets,
+          rateLimitPerMinute: rateLimit,
+          onDelivery: (webhook, fired) => {
+            console.log(
+              `${new Date().toISOString()} ${webhook.source}:${webhook.event} ` +
+              `${fired.length ? `fired ${fired.map((f) => f.jobName).join(', ')}` : 'no match'}`,
+            );
+          },
+        });
+        const address = server.address();
+        const bound = typeof address === 'object' && address ? address.port : port;
+        console.log(`${chalk.green('agents webhook')} ${chalk.dim('→')} ${chalk.cyan(`http://${opts.host ?? DEFAULT_HOST}:${bound}`)}`);
+        console.log(chalk.dim('signed · localhost by default · endpoints: /hooks/github, /hooks/linear · Ctrl-C to stop'));
+
+        const shutdown = () => {
+          server.close(() => process.exit(0));
+        };
+        process.on('SIGINT', shutdown);
+        process.on('SIGTERM', shutdown);
+      } catch (err) {
+        console.error(chalk.red(`Could not start webhook receiver: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -125,6 +125,8 @@ import {
   loadLogs,
   loadEvents,
   loadAudit,
+  loadWebhook,
+  loadFunnel,
   loadSsh,
   loadPull,
   loadPush,
@@ -263,6 +265,8 @@ Run and dispatch:
   defaults                        Configure run defaults by agent/version selector
   teams                           Coordinate multiple agents on shared work
   routines                        Run agents on a cron schedule (scheduler auto-starts)
+  webhook                         Receive signed GitHub/Linear webhooks for trigger routines
+  funnel                          Expose a webhook receiver through Tailscale Funnel
   sessions                        Browse, search, and replay past runs (live-search in TTY; grouped by workspace)
   logs [id]                       Show a run's log — host-dispatch task or session; -f to follow
   browser                         Automate a browser — navigate, click, screenshot, console, network
@@ -827,6 +831,8 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadLogs);
   await reg(loadEvents);
   await reg(loadAudit);
+  await reg(loadWebhook);
+  await reg(loadFunnel);
   await reg(loadFeed);
   await reg(loadSsh);
   registerJobsCronAliasCommand(program, 'jobs');

--- a/apps/cli/src/lib/funnel.test.ts
+++ b/apps/cli/src/lib/funnel.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { buildFunnelStatusCommand, buildFunnelUpCommand, parseFunnelPort } from './funnel.js';
+
+describe('funnel command builders', () => {
+  it('accepts only Tailscale Funnel public ports', () => {
+    expect(parseFunnelPort('443')).toBe(443);
+    expect(parseFunnelPort('8443')).toBe(8443);
+    expect(parseFunnelPort('10000')).toBe(10000);
+    expect(() => parseFunnelPort('8787')).toThrow(/443, 8443, 10000/);
+  });
+
+  it('builds status and up commands for ssh execution', () => {
+    expect(buildFunnelStatusCommand()).toBe('tailscale funnel status');
+    expect(buildFunnelUpCommand(443, 8787)).toBe('tailscale funnel --bg --https=443 http://localhost:8787');
+    expect(() => buildFunnelUpCommand(443, 70000)).toThrow(/Local port/);
+  });
+});

--- a/apps/cli/src/lib/funnel.ts
+++ b/apps/cli/src/lib/funnel.ts
@@ -1,0 +1,27 @@
+import { shellQuote } from './ssh-exec.js';
+
+export const FUNNEL_PORTS = [443, 8443, 10000] as const;
+export type FunnelPort = typeof FUNNEL_PORTS[number];
+
+export function parseFunnelPort(value: string | number): FunnelPort {
+  const port = typeof value === 'number' ? value : Number.parseInt(value, 10);
+  if (FUNNEL_PORTS.includes(port as FunnelPort)) return port as FunnelPort;
+  throw new Error(`Tailscale Funnel public port must be one of: ${FUNNEL_PORTS.join(', ')}`);
+}
+
+export function buildFunnelStatusCommand(): string {
+  return 'tailscale funnel status';
+}
+
+export function buildFunnelUpCommand(publicPort: FunnelPort, localPort: number): string {
+  if (!Number.isInteger(localPort) || localPort <= 0 || localPort > 65535) {
+    throw new Error('Local port must be between 1 and 65535');
+  }
+  return [
+    'tailscale',
+    'funnel',
+    '--bg',
+    `--https=${publicPort}`,
+    `http://localhost:${localPort}`,
+  ].map(shellQuote).join(' ');
+}

--- a/apps/cli/src/lib/routines.test.ts
+++ b/apps/cli/src/lib/routines.test.ts
@@ -82,8 +82,12 @@ describe('validateTrigger', () => {
     expect(validateTrigger({ type: 'github_event', event: 'pull_request', repo: 'x/y', branch: 'main' })).toEqual([]);
   });
 
+  it('accepts a well-formed linear_event trigger', () => {
+    expect(validateTrigger({ type: 'linear_event', event: 'Issue', action: 'update', teamKey: 'RUSH', label: 'agent' })).toEqual([]);
+  });
+
   it('rejects a bad type', () => {
-    expect(validateTrigger({ type: 'gitlab', event: 'pull_request' })).toContain("trigger.type must be 'github_event'");
+    expect(validateTrigger({ type: 'gitlab', event: 'pull_request' })).toContain("trigger.type must be 'github_event' or 'linear_event'");
   });
 
   it('rejects an unknown event', () => {

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -37,6 +37,18 @@ export const GITHUB_TRIGGER_EVENTS: readonly GithubTriggerEvent[] = [
   'workflow_run',
 ];
 
+/** Linear webhook resource types a routine can be triggered by. */
+export type LinearTriggerEvent = 'Issue' | 'IssueLabel' | 'Comment' | 'Project' | 'Cycle';
+
+/** Canonical set of accepted Linear trigger events — single source for validation. */
+export const LINEAR_TRIGGER_EVENTS: readonly LinearTriggerEvent[] = [
+  'Issue',
+  'IssueLabel',
+  'Comment',
+  'Project',
+  'Cycle',
+];
+
 /**
  * Map a user-facing `--on` alias to a canonical GitHub trigger event.
  * Accepts the canonical names plus friendly shortcuts (e.g. `pr`, `pr_opened`
@@ -60,11 +72,11 @@ export function normalizeTriggerEvent(input: string): GithubTriggerEvent | null 
 
 /**
  * Event-based fire condition for a routine — an alternative (or complement) to
- * `schedule`. Currently only `github_event`: an incoming GitHub webhook whose
- * event (and optional repo/branch) match fires the job through the same
- * dispatch path a cron fire uses. See `src/lib/triggers/webhook.ts`.
+ * `schedule`. Incoming webhooks whose source-specific filters match fire the job
+ * through the same dispatch path a cron fire uses. See
+ * `src/lib/triggers/webhook.ts`.
  */
-export interface JobTrigger {
+export interface GithubJobTrigger {
   type: 'github_event';
   event: GithubTriggerEvent;
   /** `owner/name` — when set, only payloads for this repo match. */
@@ -72,6 +84,19 @@ export interface JobTrigger {
   /** git branch (ref short name) — when set, only payloads for this branch match. */
   branch?: string;
 }
+
+export interface LinearJobTrigger {
+  type: 'linear_event';
+  event: LinearTriggerEvent;
+  /** Linear action, e.g. `create`, `update`, `remove`. */
+  action?: string;
+  /** Issue identifier prefix such as `RUSH`; useful when one webhook spans teams. */
+  teamKey?: string;
+  /** Required issue label name. */
+  label?: string;
+}
+
+export type JobTrigger = GithubJobTrigger | LinearJobTrigger;
 
 /**
  * Full configuration for a routine (persisted as YAML).
@@ -470,17 +495,35 @@ export function validateTrigger(trigger: unknown): string[] {
     return ['trigger must be an object'];
   }
   const t = trigger as Partial<JobTrigger>;
-  if (t.type !== 'github_event') {
-    errors.push("trigger.type must be 'github_event'");
+  if (t.type !== 'github_event' && t.type !== 'linear_event') {
+    errors.push("trigger.type must be 'github_event' or 'linear_event'");
+    return errors;
   }
-  if (!t.event || !GITHUB_TRIGGER_EVENTS.includes(t.event as GithubTriggerEvent)) {
-    errors.push(`trigger.event must be one of: ${GITHUB_TRIGGER_EVENTS.join(', ')}`);
+  if (t.type === 'github_event') {
+    const github = t as Partial<GithubJobTrigger>;
+    if (!github.event || !GITHUB_TRIGGER_EVENTS.includes(github.event as GithubTriggerEvent)) {
+      errors.push(`trigger.event must be one of: ${GITHUB_TRIGGER_EVENTS.join(', ')}`);
+    }
+    if (github.repo !== undefined && (typeof github.repo !== 'string' || !/^[^/\s]+\/[^/\s]+$/.test(github.repo))) {
+      errors.push('trigger.repo must be in owner/name form');
+    }
+    if (github.branch !== undefined && typeof github.branch !== 'string') {
+      errors.push('trigger.branch must be a string');
+    }
+    return errors;
   }
-  if (t.repo !== undefined && (typeof t.repo !== 'string' || !/^[^/\s]+\/[^/\s]+$/.test(t.repo))) {
-    errors.push('trigger.repo must be in owner/name form');
+  const linear = t as Partial<LinearJobTrigger>;
+  if (!linear.event || !LINEAR_TRIGGER_EVENTS.includes(linear.event as LinearTriggerEvent)) {
+    errors.push(`trigger.event must be one of: ${LINEAR_TRIGGER_EVENTS.join(', ')}`);
   }
-  if (t.branch !== undefined && typeof t.branch !== 'string') {
-    errors.push('trigger.branch must be a string');
+  if (linear.action !== undefined && typeof linear.action !== 'string') {
+    errors.push('trigger.action must be a string');
+  }
+  if (linear.teamKey !== undefined && (typeof linear.teamKey !== 'string' || !/^[A-Z][A-Z0-9]*$/.test(linear.teamKey))) {
+    errors.push('trigger.teamKey must be an uppercase Linear team key');
+  }
+  if (linear.label !== undefined && typeof linear.label !== 'string') {
+    errors.push('trigger.label must be a string');
   }
   return errors;
 }

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -94,6 +94,8 @@ export const loadMessage: ModuleLoader = async () => (await import('../../comman
 export const loadFeed: ModuleLoader = async () => (await import('../../commands/feed.js')).registerFeedCommand;
 export const loadServe: ModuleLoader = async () => (await import('../../commands/serve.js')).registerServeCommand;
 export const loadAudit: ModuleLoader = async () => (await import('../../commands/audit.js')).registerAuditCommands;
+export const loadWebhook: ModuleLoader = async () => (await import('../../commands/webhook.js')).registerWebhookCommand;
+export const loadFunnel: ModuleLoader = async () => (await import('../../commands/funnel.js')).registerFunnelCommand;
 
 /**
  * Commands whose modules pull in the SQLite-backed session/cloud stack. They are
@@ -181,9 +183,6 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   events: [loadEvents],
   ssh: [loadSsh],
   devices: [loadSsh],
-  // `fleet` is a commander alias of `devices` (see commands/ssh.ts); list it so
-  // lazy registration loads the devices tree when the user types `agents fleet`.
-  fleet: [loadSsh],
   pull: [loadPull],
   push: [loadPush],
   repo: [loadRepo],
@@ -195,4 +194,6 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   feed: [loadFeed],
   serve: [loadServe],
   audit: [loadAudit],
+  webhook: [loadWebhook],
+  funnel: [loadFunnel],
 };

--- a/apps/cli/src/lib/triggers/webhook.test.ts
+++ b/apps/cli/src/lib/triggers/webhook.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import * as crypto from 'crypto';
+import * as http from 'http';
 import type { JobConfig, RunMeta } from '../routines.js';
 import {
   matchJobsToWebhook,
@@ -6,7 +8,10 @@ import {
   webhookRepo,
   webhookBranches,
   fireWebhookJobs,
-  type GithubWebhook,
+  verifyGithubSignature,
+  verifyLinearSignature,
+  startWebhookServer,
+  type IncomingWebhook,
 } from './webhook.js';
 
 /** Build a JobConfig with sensible defaults for tests. */
@@ -23,8 +28,9 @@ function job(partial: Partial<JobConfig> & Pick<JobConfig, 'name'>): JobConfig {
 }
 
 /** A realistic `pull_request` webhook for repo x/y targeting branch main. */
-function pullRequestWebhook(repoFullName: string, baseRef = 'main', headRef = 'feature'): GithubWebhook {
+function pullRequestWebhook(repoFullName: string, baseRef = 'main', headRef = 'feature'): IncomingWebhook {
   return {
+    source: 'github',
     event: 'pull_request',
     payload: {
       action: 'opened',
@@ -35,10 +41,27 @@ function pullRequestWebhook(repoFullName: string, baseRef = 'main', headRef = 'f
 }
 
 /** A `push` webhook for repo x/y on branch main. */
-function pushWebhook(repoFullName: string, ref = 'refs/heads/main'): GithubWebhook {
+function pushWebhook(repoFullName: string, ref = 'refs/heads/main'): IncomingWebhook {
   return {
+    source: 'github',
     event: 'push',
     payload: { repository: { full_name: repoFullName }, ref },
+  };
+}
+
+function linearIssueWebhook(labels: string[] = ['agent']): IncomingWebhook {
+  return {
+    source: 'linear',
+    event: 'Issue',
+    payload: {
+      type: 'Issue',
+      action: 'update',
+      webhookTimestamp: Date.now(),
+      data: {
+        identifier: 'RUSH-1459',
+        labels: { nodes: labels.map((name) => ({ name })) },
+      },
+    },
   };
 }
 
@@ -102,6 +125,15 @@ describe('matchJobsToWebhook', () => {
       trigger: { type: 'github_event', event: 'pull_request', repo: 'x/y' },
     });
     expect(matchJobsToWebhook([disabled], pullRequestWebhook('x/y'))).toEqual([]);
+  });
+
+  it('matches Linear issue triggers by action, team key, and label', () => {
+    const linear = job({
+      name: 'linear-agent',
+      trigger: { type: 'linear_event', event: 'Issue', action: 'update', teamKey: 'RUSH', label: 'agent' },
+    });
+    expect(jobMatchesWebhook(linear, linearIssueWebhook(['agent']))).toBe(true);
+    expect(jobMatchesWebhook(linear, linearIssueWebhook(['triage']))).toBe(false);
   });
 
   it('skips jobs pinned to other devices, keeps jobs pinned here', () => {
@@ -172,5 +204,81 @@ describe('fireWebhookJobs', () => {
 
     expect(dispatched).toEqual(['pr-job']);
     expect(fired).toEqual([{ jobName: 'pr-job', runId: 'run-pr-job' }]);
+  });
+});
+
+describe('webhook signature verification', () => {
+  it('verifies GitHub and Linear HMAC-SHA256 signatures against the raw body', () => {
+    const secret = 'test-secret';
+    const raw = Buffer.from(JSON.stringify({ hello: 'world' }));
+    const hex = crypto.createHmac('sha256', secret).update(raw).digest('hex');
+
+    expect(verifyGithubSignature({ 'x-hub-signature-256': `sha256=${hex}` }, raw, secret)).toBe(true);
+    expect(verifyGithubSignature({ 'x-hub-signature-256': 'sha256=bad' }, raw, secret)).toBe(false);
+    expect(verifyLinearSignature({ 'linear-signature': hex }, raw, secret)).toBe(true);
+    expect(verifyLinearSignature({ 'linear-signature': 'bad' }, raw, secret)).toBe(false);
+  });
+});
+
+describe('startWebhookServer', () => {
+  it('rejects unsigned public deliveries and accepts signed Linear deliveries once', async () => {
+    const secret = 'linear-secret';
+    const jobs = [
+      job({
+        name: 'linear-agent',
+        trigger: { type: 'linear_event', event: 'Issue', action: 'update', teamKey: 'RUSH', label: 'agent' },
+      }),
+    ];
+    const dispatched: string[] = [];
+    const server = startWebhookServer({
+      secrets: { linear: secret },
+      fire: {
+        jobs,
+        dispatch: async (config: JobConfig): Promise<RunMeta> => {
+          dispatched.push(config.name);
+          return {
+            jobName: config.name,
+            runId: `run-${config.name}`,
+            agent: config.agent,
+            pid: 1234,
+            status: 'running',
+            startedAt: new Date().toISOString(),
+            completedAt: null,
+            exitCode: null,
+          };
+        },
+      },
+    });
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+    const address = server.address();
+    if (!address || typeof address !== 'object') throw new Error('server did not bind');
+    try {
+      const payload = Buffer.from(JSON.stringify(linearIssueWebhook(['agent']).payload));
+      const sig = crypto.createHmac('sha256', secret).update(payload).digest('hex');
+      const send = (headers: Record<string, string>) => new Promise<{ status: number; body: string }>((resolve, reject) => {
+        const req = http.request({
+          host: '127.0.0.1',
+          port: address.port,
+          path: '/hooks/linear',
+          method: 'POST',
+          headers: { 'content-type': 'application/json', 'content-length': String(payload.length), ...headers },
+        }, (res) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (c) => chunks.push(c as Buffer));
+          res.on('end', () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf-8') }));
+        });
+        req.on('error', reject);
+        req.end(payload);
+      });
+
+      expect((await send({})).status).toBe(401);
+      expect((await send({ 'linear-signature': sig, 'linear-delivery': 'delivery-1' })).status).toBe(200);
+      const duplicate = await send({ 'linear-signature': sig, 'linear-delivery': 'delivery-1' });
+      expect(duplicate.status).toBe(200);
+      expect(JSON.parse(duplicate.body).duplicate).toBe(true);
+      expect(dispatched).toEqual(['linear-agent']);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 });

--- a/apps/cli/src/lib/triggers/webhook.ts
+++ b/apps/cli/src/lib/triggers/webhook.ts
@@ -1,33 +1,42 @@
 /**
- * GitHub webhook trigger receiver for routines.
+ * Public webhook trigger receiver for routines.
  *
  * A routine may declare a `trigger` block instead of (or alongside) a cron
  * `schedule` (see `JobConfig.trigger` in `../routines.ts`). This module turns
- * an incoming GitHub webhook into the set of routines it should fire, and
- * dispatches those routines through the exact same path a cron fire uses
+ * incoming GitHub or Linear webhooks into the set of routines they should fire,
+ * and dispatches those routines through the exact same path a cron fire uses
  * (`executeJobDetached`).
  *
- * The matching logic (`matchJobsToWebhook`) is a pure, side-effect-free
- * function so it can be unit-tested without a running daemon or http server.
- * The optional http listener (`startWebhookServer`) is a thin adapter over it.
+ * The matching logic is pure, so it can be unit-tested without a daemon or HTTP
+ * server. The listener adds the public-ingress requirements: raw-body HMAC
+ * verification, idempotency, source allow-listing, and rate limiting.
  */
 
+import * as crypto from 'crypto';
 import * as http from 'http';
-import type { JobConfig, RunMeta } from '../routines.js';
-import { listJobs, jobRunsOnThisDevice } from '../routines.js';
+import type { IncomingHttpHeaders } from 'http';
+import type {
+  GithubJobTrigger,
+  JobConfig,
+  LinearJobTrigger,
+  RunMeta,
+} from '../routines.js';
+import { jobRunsOnThisDevice, listJobs } from '../routines.js';
 import { executeJobDetached } from '../runner.js';
 
-/**
- * A parsed GitHub webhook: the event name (from the `X-GitHub-Event` HTTP
- * header) plus the decoded JSON body. Kept deliberately loose (`payload` is an
- * arbitrary object) because callers may hand us any of GitHub's event shapes.
- */
-export interface GithubWebhook {
-  /** The GitHub event name, e.g. `pull_request`, `push`, `issue_comment`. */
+export type WebhookSource = 'github' | 'linear';
+
+export interface IncomingWebhook {
+  /** Delivery source, derived from `/hooks/<source>` or one-shot command flags. */
+  source: WebhookSource;
+  /** Source event name: GitHub header event or Linear payload `type`. */
   event: string;
-  /** The decoded JSON request body. */
+  /** Decoded JSON request body. */
   payload: Record<string, unknown>;
 }
+
+export type GithubWebhook = IncomingWebhook & { source: 'github' };
+export type LinearWebhook = IncomingWebhook & { source: 'linear' };
 
 /** Read `repository.full_name` (`owner/name`) from a webhook payload, if present. */
 export function webhookRepo(payload: Record<string, unknown>): string | null {
@@ -77,10 +86,32 @@ export function webhookBranches(event: string, payload: Record<string, unknown>)
   return [...branches];
 }
 
-/** True when a single job's trigger matches the given webhook. Pure. */
-export function jobMatchesWebhook(job: JobConfig, webhook: GithubWebhook): boolean {
-  const trigger = job.trigger;
-  if (!trigger || trigger.type !== 'github_event') return false;
+function linearAction(payload: Record<string, unknown>): string | null {
+  return typeof payload.action === 'string' ? payload.action : null;
+}
+
+function linearTeamKey(payload: Record<string, unknown>): string | null {
+  const data = payload.data as Record<string, unknown> | undefined;
+  const identifier = data?.identifier;
+  if (typeof identifier === 'string') {
+    const match = /^([A-Z][A-Z0-9]*)-\d+$/.exec(identifier);
+    if (match) return match[1];
+  }
+  const team = data?.team as { key?: unknown } | undefined;
+  return typeof team?.key === 'string' ? team.key : null;
+}
+
+function linearLabels(payload: Record<string, unknown>): string[] {
+  const data = payload.data as Record<string, unknown> | undefined;
+  const labels = data?.labels as { nodes?: unknown } | undefined;
+  const nodes = Array.isArray(labels?.nodes) ? labels.nodes : [];
+  return nodes
+    .map((n) => (n as { name?: unknown }).name)
+    .filter((n): n is string => typeof n === 'string' && n.length > 0);
+}
+
+function githubTriggerMatches(trigger: GithubJobTrigger, webhook: IncomingWebhook): boolean {
+  if (webhook.source !== 'github') return false;
   if (trigger.event !== webhook.event) return false;
 
   if (trigger.repo) {
@@ -96,16 +127,34 @@ export function jobMatchesWebhook(job: JobConfig, webhook: GithubWebhook): boole
   return true;
 }
 
+function linearTriggerMatches(trigger: LinearJobTrigger, webhook: IncomingWebhook): boolean {
+  if (webhook.source !== 'linear') return false;
+  if (trigger.event !== webhook.event) return false;
+  if (trigger.action && linearAction(webhook.payload) !== trigger.action) return false;
+  if (trigger.teamKey && linearTeamKey(webhook.payload) !== trigger.teamKey) return false;
+  if (trigger.label) {
+    const expected = trigger.label.toLowerCase();
+    if (!linearLabels(webhook.payload).some((name) => name.toLowerCase() === expected)) return false;
+  }
+  return true;
+}
+
+/** True when a single job's trigger matches the given webhook. Pure. */
+export function jobMatchesWebhook(job: JobConfig, webhook: IncomingWebhook): boolean {
+  const trigger = job.trigger;
+  if (!trigger) return false;
+  if (trigger.type === 'github_event') return githubTriggerMatches(trigger, webhook);
+  if (trigger.type === 'linear_event') return linearTriggerMatches(trigger, webhook);
+  return false;
+}
+
 /**
  * Pure matcher: given a set of jobs and an incoming webhook, return the jobs
- * whose `trigger` matches (event + optional repo + optional branch). Jobs
- * without a trigger (schedule-only routines) are never selected — proving
- * time-based jobs are unaffected by webhook delivery.
+ * whose `trigger` matches. Jobs without a trigger (schedule-only routines) are
+ * never selected — proving time-based jobs are unaffected by webhook delivery.
  */
-export function matchJobsToWebhook(jobs: JobConfig[], webhook: GithubWebhook): JobConfig[] {
-  return jobs.filter(
-    (job) => job.enabled !== false && jobRunsOnThisDevice(job) && jobMatchesWebhook(job, webhook)
-  );
+export function matchJobsToWebhook(jobs: JobConfig[], webhook: IncomingWebhook): JobConfig[] {
+  return jobs.filter((job) => job.enabled !== false && jobRunsOnThisDevice(job) && jobMatchesWebhook(job, webhook));
 }
 
 /** Options for firing webhook-matched jobs (dispatch is injectable for tests). */
@@ -131,7 +180,7 @@ export interface FiredJob {
  * through the cron dispatch path. Returns one entry per fired job.
  */
 export async function fireWebhookJobs(
-  webhook: GithubWebhook,
+  webhook: IncomingWebhook,
   options: FireWebhookOptions = {},
 ): Promise<FiredJob[]> {
   const jobs = options.jobs ?? listJobs();
@@ -146,49 +195,204 @@ export async function fireWebhookJobs(
   return fired;
 }
 
+function header(headers: IncomingHttpHeaders, name: string): string | undefined {
+  const value = headers[name.toLowerCase()];
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+function timingSafeHexEqual(received: string | undefined, expected: string): boolean {
+  if (!received || !/^[a-f0-9]+$/i.test(received)) return false;
+  const a = Buffer.from(received, 'hex');
+  const b = Buffer.from(expected, 'hex');
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+function hmacHex(secret: string, rawBody: Buffer): string {
+  return crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+}
+
+export function verifyGithubSignature(headers: IncomingHttpHeaders, rawBody: Buffer, secret: string): boolean {
+  const received = header(headers, 'x-hub-signature-256');
+  const signature = received?.startsWith('sha256=') ? received.slice('sha256='.length) : undefined;
+  return timingSafeHexEqual(signature, hmacHex(secret, rawBody));
+}
+
+export function verifyLinearSignature(headers: IncomingHttpHeaders, rawBody: Buffer, secret: string): boolean {
+  return timingSafeHexEqual(header(headers, 'linear-signature'), hmacHex(secret, rawBody));
+}
+
+export function verifyLinearTimestamp(payload: Record<string, unknown>, now = Date.now(), toleranceMs = 60_000): boolean {
+  const ts = payload.webhookTimestamp;
+  return typeof ts === 'number' && Math.abs(now - ts) <= toleranceMs;
+}
+
+export interface WebhookSecrets {
+  github?: string;
+  linear?: string;
+}
+
+export interface DeliveryStore {
+  seen(id: string): boolean;
+  mark(id: string): void;
+}
+
+export function createMemoryDeliveryStore(maxEntries = 1000): DeliveryStore {
+  const seen = new Map<string, number>();
+  return {
+    seen: (id) => seen.has(id),
+    mark: (id) => {
+      seen.set(id, Date.now());
+      while (seen.size > maxEntries) {
+        const oldest = seen.keys().next().value as string | undefined;
+        if (!oldest) break;
+        seen.delete(oldest);
+      }
+    },
+  };
+}
+
+export interface RateLimiter {
+  take(key: string): boolean;
+}
+
+export function createMemoryRateLimiter(limit: number, windowMs: number): RateLimiter {
+  const buckets = new Map<string, { resetAt: number; count: number }>();
+  return {
+    take: (key) => {
+      const now = Date.now();
+      const current = buckets.get(key);
+      if (!current || now >= current.resetAt) {
+        buckets.set(key, { resetAt: now + windowMs, count: 1 });
+        return true;
+      }
+      if (current.count >= limit) return false;
+      current.count += 1;
+      return true;
+    },
+  };
+}
+
+function deliveryId(source: WebhookSource, headers: IncomingHttpHeaders, rawBody: Buffer): string {
+  const named = source === 'github'
+    ? header(headers, 'x-github-delivery')
+    : header(headers, 'linear-delivery');
+  return `${source}:${named ?? crypto.createHash('sha256').update(rawBody).digest('hex')}`;
+}
+
+function sourceFromPath(pathname: string | undefined): WebhookSource | null {
+  const match = /^\/hooks\/(github|linear)\/?$/.exec(pathname ?? '');
+  return match ? match[1] as WebhookSource : null;
+}
+
+async function readRawBody(req: http.IncomingMessage, maxBytes: number): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of req) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buf.length;
+    if (total > maxBytes) throw new Error(`payload exceeds ${maxBytes} bytes`);
+    chunks.push(buf);
+  }
+  return Buffer.concat(chunks);
+}
+
 /** Options for the local webhook http listener. */
 export interface WebhookServerOptions {
   port?: number;
   host?: string;
+  /** HMAC signing secrets keyed by source. */
+  secrets: WebhookSecrets;
   /** Override the fire options (mainly for tests). */
   fire?: FireWebhookOptions;
   /** Called after each delivery is handled (mainly for tests/observability). */
-  onDelivery?: (event: string, fired: FiredJob[]) => void;
+  onDelivery?: (webhook: IncomingWebhook, fired: FiredJob[]) => void;
+  deliveryStore?: DeliveryStore;
+  rateLimiter?: RateLimiter;
+  rateLimitPerMinute?: number;
+  maxBodyBytes?: number;
 }
 
 /**
- * Start a minimal local webhook receiver. POSTs are read as JSON, the GitHub
- * event is taken from the `X-GitHub-Event` header, and matching routines are
- * fired via {@link fireWebhookJobs}. Returns the underlying server so callers
- * can `close()` it. The heavy lifting is the pure matcher above; this is only
- * the transport.
+ * Start a localhost-bound receiver. It accepts only:
+ *   POST /hooks/github  with X-Hub-Signature-256
+ *   POST /hooks/linear  with Linear-Signature + fresh webhookTimestamp
+ *
+ * Returns the underlying server so callers can `close()` it.
  */
-export function startWebhookServer(options: WebhookServerOptions = {}): http.Server {
-  const server = http.createServer((req, res) => {
-    if (req.method !== 'POST') {
-      res.writeHead(405, { 'content-type': 'text/plain' });
-      res.end('method not allowed');
-      return;
-    }
+export function startWebhookServer(options: WebhookServerOptions): http.Server {
+  const deliveryStore = options.deliveryStore ?? createMemoryDeliveryStore();
+  const rateLimiter = options.rateLimiter ?? createMemoryRateLimiter(options.rateLimitPerMinute ?? 60, 60_000);
+  const maxBodyBytes = options.maxBodyBytes ?? 1024 * 1024;
 
-    const event = (req.headers['x-github-event'] as string | undefined) ?? '';
-    const chunks: Buffer[] = [];
-    req.on('data', (c) => chunks.push(c as Buffer));
-    req.on('end', () => {
-      void (async () => {
-        try {
-          const raw = Buffer.concat(chunks).toString('utf-8');
-          const payload = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
-          const fired = await fireWebhookJobs({ event, payload }, options.fire);
-          options.onDelivery?.(event, fired);
-          res.writeHead(200, { 'content-type': 'application/json' });
-          res.end(JSON.stringify({ ok: true, fired: fired.map((f) => f.jobName) }));
-        } catch (err) {
-          res.writeHead(400, { 'content-type': 'application/json' });
-          res.end(JSON.stringify({ ok: false, error: (err as Error).message }));
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      if (req.method !== 'POST') {
+        res.writeHead(405, { 'content-type': 'text/plain' });
+        res.end('method not allowed');
+        return;
+      }
+
+      const source = sourceFromPath(req.url?.split('?')[0]);
+      if (!source) {
+        res.writeHead(404, { 'content-type': 'text/plain' });
+        res.end('not found');
+        return;
+      }
+
+      const secret = options.secrets[source];
+      if (!secret) {
+        res.writeHead(503, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, error: `missing ${source} webhook secret` }));
+        return;
+      }
+
+      if (!rateLimiter.take(source)) {
+        res.writeHead(429, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, error: 'rate limit exceeded' }));
+        return;
+      }
+
+      try {
+        const rawBody = await readRawBody(req, maxBodyBytes);
+        const valid = source === 'github'
+          ? verifyGithubSignature(req.headers, rawBody, secret)
+          : verifyLinearSignature(req.headers, rawBody, secret);
+        if (!valid) {
+          res.writeHead(401, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ ok: false, error: 'invalid signature' }));
+          return;
         }
-      })();
-    });
+
+        const id = deliveryId(source, req.headers, rawBody);
+        if (deliveryStore.seen(id)) {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, duplicate: true, fired: [] }));
+          return;
+        }
+        deliveryStore.mark(id);
+
+        const payload = rawBody.length > 0 ? JSON.parse(rawBody.toString('utf-8')) as Record<string, unknown> : {};
+        if (source === 'linear' && !verifyLinearTimestamp(payload)) {
+          res.writeHead(401, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ ok: false, error: 'stale linear webhook timestamp' }));
+          return;
+        }
+
+        const webhook: IncomingWebhook = {
+          source,
+          event: source === 'github' ? (header(req.headers, 'x-github-event') ?? '') : String(payload.type ?? ''),
+          payload,
+        };
+        const fired = await fireWebhookJobs(webhook, options.fire);
+        options.onDelivery?.(webhook, fired);
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, fired: fired.map((f) => f.jobName), runs: fired }));
+      } catch (err) {
+        res.writeHead(400, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, error: (err as Error).message }));
+      }
+    })();
   });
 
   server.listen(options.port ?? 0, options.host ?? '127.0.0.1');


### PR DESCRIPTION
## Summary
- Add source-aware routine triggers for GitHub and Linear events, including `agents routines add --on linear:Issue --action ... --team-key ... --label ...`.
- Add `agents webhook serve` for signed localhost webhook delivery on `/hooks/github` and `/hooks/linear`, with raw-body HMAC verification, Linear timestamp checks, rate limiting, and duplicate delivery suppression.
- Add `agents funnel status/up` as a thin Tailscale Funnel SSH wrapper using the existing host/device resolution path.
- Update routines docs, CLI docs index, README, and changelog for RUSH-1456, RUSH-1459, RUSH-1460, and RUSH-1461.

## Verification
- `bun install` in `apps/cli` completed and ran the package build hook successfully.
- `bun test src/lib/routines.test.ts src/lib/triggers/webhook.test.ts src/lib/funnel.test.ts src/commands/routines-webhook.test.ts`
  - Result: `56 pass`, `0 fail`, `109 expect() calls`.
- `bun run build`
  - Result: TypeScript build completed successfully.
- Built CLI E2E from `dist/index.js` with an isolated setup home:
  - `routines add agent-labeled-issue --on linear:Issue --action update --team-key RUSH --label agent ...` exited `0` and wrote the routine.
  - `routines webhook --source linear --event Issue --file linear.json --dry-run` exited `0` and printed `1 routine(s) would fire on linear:Issue` for `agent-labeled-issue`.
  - `webhook --help` exited `0` and showed the `serve` command.
  - `funnel up nowhere --local-port 8787 --port 8787` exited `1` with `Tailscale Funnel public port must be one of: 443, 8443, 10000`.
- Real read-only host wrapper check:
  - `node dist/index.js funnel status yosemite-s0` exited `0` and returned `No serve config`.
- `git diff --check` passed before commit.
- Process cleanup check found no lingering `bun test`, `agents webhook`, or built webhook server process.

## Notes
- Broad `bun test` was attempted earlier and interrupted after unrelated environment/baseline failures, including missing pinned `claude@2.1.207`, Bun/Vitest API mismatches such as `it.runIf`, and `Cannot find module './cjs/index.cjs'`. The changed-surface suite above is green.
- Public repo transcript policy: transcript contents are not attached. Local session path for fleet teammates: `$(hostname):/home/muqsit/.codex/sessions/2026/07/14/rollout-2026-07-14T22-33-56-019f6444-765e-7fc1-920d-2e3d39563de9.jsonl`.
