### PR TITLE
fix(routines): isolate the system layer in project-discovery test

### DIFF
--- a/apps/cli/src/lib/__tests__/routines.project-discovery.test.ts
+++ b/apps/cli/src/lib/__tests__/routines.project-discovery.test.ts
@@ -9,6 +9,7 @@ let tmpDir = '';
 let projectDir = '';
 let projectRoutinesDir = '';
 let userRoutinesDir = '';
+let systemRoutinesDir = '';
 
 function writeRoutine(dir: string, name: string, body: Record<string, unknown>): void {
   fs.mkdirSync(dir, { recursive: true });
@@ -23,14 +24,20 @@ beforeEach(() => {
   projectDir = path.join(tmpDir, 'project');
   projectRoutinesDir = path.join(projectDir, '.agents', 'routines');
   userRoutinesDir = path.join(tmpDir, 'user-routines');
+  // Isolated (empty) system-routines dir so real built-ins shipped to
+  // ~/.agents/.system/routines/ (e.g. check-updates.yml) never leak into these
+  // exact-match job-list assertions.
+  systemRoutinesDir = path.join(tmpDir, 'system-routines');
 
   fs.mkdirSync(projectRoutinesDir, { recursive: true });
   fs.mkdirSync(userRoutinesDir, { recursive: true });
+  fs.mkdirSync(systemRoutinesDir, { recursive: true });
 
   // Route the routines helpers at the temp dirs. ensureAgentsDir() is also
   // called from listJobs/readJob — stub it to a no-op so it doesn't touch
   // the real ~/.agents/ during tests.
   vi.spyOn(state, 'getRoutinesDir').mockReturnValue(userRoutinesDir);
+  vi.spyOn(state, 'getSystemRoutinesDir').mockReturnValue(systemRoutinesDir);
   vi.spyOn(state, 'getProjectRoutinesDir').mockImplementation((cwd?: string) => {
     if (!cwd) return null;
     // Only return the project dir when called from inside our temp project.


### PR DESCRIPTION
Follow-up to #1174 (merged before this fix landed) — addresses prix-cloud finding #2.

`src/lib/__tests__/routines.project-discovery.test.ts` partial-mocks `state` (only `getRoutinesDir` + `getProjectRoutinesDir`), so the **real** `getSystemRoutinesDir()` runs. Its assertions exact-match the full `listJobs()` name list (e.g. `expect(names).toEqual(['user-only'])`). Now that `check-updates.yml` has shipped to `.agents-system` (`routines/`), any machine that ran `agents setup` (and pulled `.system`) would see it in `listJobs()` and fail these tests.

Fix: stub `getSystemRoutinesDir` to an empty temp dir — the same isolation the user/project dirs already get. 6/6 tests pass.