### PR TITLE
feat(lease): make agents run --lease headless & copy the balanced-strategy account (RUSH-1724)

### DIFF
--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -516,15 +516,23 @@ export function registerRunCommand(program: Command): void {
         // Copy the account the run's OWN strategy would pick (default `balanced`:
         // a healthy, non-rate-limited account weighted by remaining headroom) —
         // never the raw default signed-in one, which could be throttled or out of
-        // credits and would boot the box straight into a wall. Best-effort: fall
-        // back to the default account if strategy resolution fails.
+        // credits and would boot the box straight into a wall.
+        //
+        // Only claude's token is account-switched: resolveClaudeCredentialsBlob
+        // honors preferEmail across version-homes. The other runtimes'
+        // buildCredentialScript copies the single currently-active credential file
+        // with no switching, so run the balanced picker only for claude — otherwise
+        // the notice below would name a balanced-picked account that is NOT the one
+        // actually shipped. Best-effort: fall back to the default account on error.
         let leaseEmail = detected.find((d) => d.id === runtime)?.email ?? null;
-        try {
-          const strategy = getConfiguredRunStrategy(runtime, leaseCwd);
-          const { rotation } = await resolveRunVersion(runtime, strategy, leaseCwd);
-          if (rotation?.picked.email) leaseEmail = rotation.picked.email;
-        } catch {
-          /* strategy resolution is best-effort; keep the default signed-in account */
+        if (runtime === 'claude') {
+          try {
+            const strategy = getConfiguredRunStrategy(runtime, leaseCwd);
+            const { rotation } = await resolveRunVersion(runtime, strategy, leaseCwd);
+            if (rotation?.picked.email) leaseEmail = rotation.picked.email;
+          } catch {
+            /* strategy resolution is best-effort; keep the default signed-in account */
+          }
         }
 
         // Headless-by-contract: don't prompt, but print exactly what ships and

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -494,44 +494,57 @@ export function registerRunCommand(program: Command): void {
           process.exit(1);
         }
         const backend = typeof options.lease === 'string' ? options.lease : undefined;
-        const { detectSignedInRuntimes, pickRuntimes, resolveClaudeCredentialsBlob } = await import('../lib/crabbox/runtimes.js');
+        const { detectSignedInRuntimes, resolveClaudeCredentialsBlob, inferLeaseRuntime } = await import('../lib/crabbox/runtimes.js');
         const { leaseAndRun } = await import('../lib/crabbox/lease.js');
-        const { confirm } = await import('@inquirer/prompts');
+        const { getConfiguredRunStrategy, resolveRunVersion } = await import('../lib/rotate.js');
 
         const detected = await detectSignedInRuntimes();
-        const runtimes = await pickRuntimes(detected);
-        if (runtimes.length === 0) {
-          console.error(chalk.yellow('No runtimes selected. Sign into one locally (e.g. run `claude` once) then retry.'));
+        const agentName = agentSpec.split('@')[0];
+        const leaseCwd = options.cwd ?? process.cwd();
+
+        // `--lease` requires a prompt (guarded above), so it is headless by
+        // contract — never block on an interactive picker. Provision exactly the
+        // one runtime this run needs, inferred from the agent, not every
+        // signed-in CLI (which would ship unrelated tokens to a throwaway box).
+        const runtime = inferLeaseRuntime(agentName, detected);
+        if (!runtime) {
+          console.error(chalk.yellow('No signed-in runtime to provision on the box. Sign into one locally (e.g. run `claude` once) then retry.'));
           process.exit(1);
+        }
+        const runtimes = [runtime];
+
+        // Copy the account the run's OWN strategy would pick (default `balanced`:
+        // a healthy, non-rate-limited account weighted by remaining headroom) —
+        // never the raw default signed-in one, which could be throttled or out of
+        // credits and would boot the box straight into a wall. Best-effort: fall
+        // back to the default account if strategy resolution fails.
+        let leaseEmail = detected.find((d) => d.id === runtime)?.email ?? null;
+        try {
+          const strategy = getConfiguredRunStrategy(runtime, leaseCwd);
+          const { rotation } = await resolveRunVersion(runtime, strategy, leaseCwd);
+          if (rotation?.picked.email) leaseEmail = rotation.picked.email;
+        } catch {
+          /* strategy resolution is best-effort; keep the default signed-in account */
         }
 
-        // Security gate: copying auth tokens to an ephemeral cloud box is opt-in
-        // per run. Name the runtimes + accounts so the user sees what ships.
-        const names = runtimes
-          .map((id) => {
-            const d = detected.find((x) => x.id === id);
-            return `${d?.label ?? id}${d?.email ? ` (${d.email})` : ''}`;
-          })
-          .join(', ');
-        // Claude ships its OAuth token (not just the .claude.json config) — name it
-        // explicitly so the consent covers the actual credential transferred.
-        const whatShips = runtimes.includes('claude') ? 'credentials + Claude OAuth token' : 'credentials';
-        const ok = await confirm({
-          message: `Copy ${whatShips} for ${names} to a disposable cloud box, run there, then destroy it?`,
-          default: false,
-        });
-        if (!ok) {
-          console.error(chalk.yellow('Aborted — no credentials pushed, no box leased.'));
-          process.exit(1);
-        }
+        // Headless-by-contract: don't prompt, but print exactly what ships and
+        // where — copying an auth token to a cloud box is a credential transfer.
+        // The box is destroyed after the run, so the credential's lifetime is
+        // bounded by the run.
+        const whatShips = runtime === 'claude' ? 'credentials + Claude OAuth token' : 'credentials';
+        console.error(
+          chalk.gray(
+            `Leasing a ${backend ?? 'hetzner'} box · shipping ${runtime}${leaseEmail ? ` (${leaseEmail})` : ''} ${whatShips}; the box is destroyed after the run.`,
+          ),
+        );
 
         // Read the Claude OAuth token from the local Keychain (silent) so it can be
         // written to ~/.claude/.credentials.json on the box — otherwise Claude boots
-        // "Not logged in". Consent above already covered this transfer.
+        // "Not logged in". `preferEmail` targets the strategy-picked account so the
+        // token matches the account this run resolved to.
         let claudeCredentialsJson: string | null = null;
-        if (runtimes.includes('claude')) {
-          const claudeEmail = detected.find((d) => d.id === 'claude')?.email ?? null;
-          claudeCredentialsJson = await resolveClaudeCredentialsBlob({ preferEmail: claudeEmail });
+        if (runtime === 'claude') {
+          claudeCredentialsJson = await resolveClaudeCredentialsBlob({ preferEmail: leaseEmail });
           if (!claudeCredentialsJson) {
             console.error(chalk.yellow('Warning: could not read the local Claude OAuth token — the box may come up "Not logged in".'));
           }
@@ -543,7 +556,6 @@ export function registerRunCommand(program: Command): void {
         // box-side marker. Rule: only ONE spinner phase is active at a time, and no
         // other output is written to stderr while it spins — so it can never storm.
         const { createLeaseOutputRouter, createSpinner } = await import('../lib/crabbox/progress.js');
-        const agentName = agentSpec.split('@')[0];
         const spinner = createSpinner({ stream: process.stderr });
         let warmupTimer: ReturnType<typeof setInterval> | undefined;
         const stopTimer = () => { if (warmupTimer) { clearInterval(warmupTimer); warmupTimer = undefined; } };

--- a/apps/cli/src/lib/crabbox/runtimes.test.ts
+++ b/apps/cli/src/lib/crabbox/runtimes.test.ts
@@ -15,6 +15,15 @@ describe('inferLeaseRuntime', () => {
     expect(inferLeaseRuntime('codex', [signedIn('codex', null)])).toBe('codex');
   });
 
+  it('returns null when the named runtime is not signed in — never substitutes another', () => {
+    // `run codex --lease` while only claude is signed in must NOT provision claude.
+    expect(inferLeaseRuntime('codex', [signedIn('claude', 'a@b.com')])).toBeNull();
+    expect(inferLeaseRuntime('grok', [
+      { id: 'grok', label: 'Grok CLI', email: null, signedIn: false, credPath: null },
+      signedIn('claude', 'a@b.com'),
+    ])).toBeNull();
+  });
+
   it('falls back to the signed-in runtime (preferring claude) for a custom agent', () => {
     const detected = [signedIn('claude', 'a@b.com'), signedIn('grok', 'g@x.ai')];
     expect(inferLeaseRuntime('my-workflow', detected)).toBe('claude');

--- a/apps/cli/src/lib/crabbox/runtimes.test.ts
+++ b/apps/cli/src/lib/crabbox/runtimes.test.ts
@@ -2,7 +2,43 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
-import { buildCredentialScript, pickRuntimes, resolveClaudeCredentialsBlob, type DetectedRuntime } from './runtimes.js';
+import { buildCredentialScript, pickRuntimes, resolveClaudeCredentialsBlob, inferLeaseRuntime, type DetectedRuntime } from './runtimes.js';
+
+describe('inferLeaseRuntime', () => {
+  const signedIn = (id: DetectedRuntime['id'], email: string | null): DetectedRuntime => ({
+    id, label: id, email, signedIn: true, credPath: `/tmp/${id}.json`,
+  });
+
+  it('uses the agent itself when it is a lease-capable runtime', () => {
+    const detected = [signedIn('claude', 'a@b.com'), signedIn('grok', 'g@x.ai')];
+    expect(inferLeaseRuntime('grok', detected)).toBe('grok');
+    expect(inferLeaseRuntime('codex', [signedIn('codex', null)])).toBe('codex');
+  });
+
+  it('falls back to the signed-in runtime (preferring claude) for a custom agent', () => {
+    const detected = [signedIn('claude', 'a@b.com'), signedIn('grok', 'g@x.ai')];
+    expect(inferLeaseRuntime('my-workflow', detected)).toBe('claude');
+  });
+
+  it('falls back to the only signed-in runtime when claude is absent', () => {
+    expect(inferLeaseRuntime('my-workflow', [signedIn('grok', 'g@x.ai')])).toBe('grok');
+  });
+
+  it('ignores runtimes with no local credential', () => {
+    const detected: DetectedRuntime[] = [
+      { id: 'claude', label: 'Claude Code', email: null, signedIn: true, credPath: null },
+      signedIn('grok', 'g@x.ai'),
+    ];
+    expect(inferLeaseRuntime('my-workflow', detected)).toBe('grok');
+  });
+
+  it('returns null when nothing is signed in', () => {
+    expect(inferLeaseRuntime('my-workflow', [])).toBeNull();
+    expect(inferLeaseRuntime('my-workflow', [
+      { id: 'claude', label: 'Claude Code', email: null, signedIn: false, credPath: null },
+    ])).toBeNull();
+  });
+});
 
 describe('buildCredentialScript', () => {
   let tmpDir: string;

--- a/apps/cli/src/lib/crabbox/runtimes.ts
+++ b/apps/cli/src/lib/crabbox/runtimes.ts
@@ -120,9 +120,15 @@ export async function pickRuntimes(
  * under a non-obvious runtime are resolved separately — see RUSH-1725.
  */
 export function inferLeaseRuntime(agentName: string, detected: DetectedRuntime[]): AgentId | null {
-  const direct = LEASE_RUNTIMES.find((c) => c.id === agentName);
-  if (direct) return direct.id;
   const signedIn = detected.filter((d) => d.signedIn && d.credPath);
+  // The agent names a lease runtime directly: require that runtime to be signed
+  // in — never silently substitute a different one for an explicit `run <runtime>`
+  // (that would lease a billable box only to boot it "Not logged in"). Not signed
+  // in → null, so the caller exits with "sign into it locally first".
+  if (LEASE_RUNTIMES.some((c) => c.id === agentName)) {
+    return signedIn.find((d) => d.id === agentName)?.id ?? null;
+  }
+  // Custom/workflow agent: fall back to the signed-in runtime (preferring claude).
   return signedIn.find((d) => d.id === 'claude')?.id ?? signedIn[0]?.id ?? null;
 }
 

--- a/apps/cli/src/lib/crabbox/runtimes.ts
+++ b/apps/cli/src/lib/crabbox/runtimes.ts
@@ -107,6 +107,25 @@ export async function pickRuntimes(
   return checkbox({ message: 'Provision which runtime(s) on the leased box?', choices });
 }
 
+/**
+ * The lease runtime to provision for a headless run of `agentName`.
+ *
+ * When the agent is itself a lease-capable runtime (claude/codex/gemini/grok)
+ * that IS the runtime to install. Otherwise fall back to the single signed-in
+ * lease runtime (preferring claude), or null when none is signed in. This is the
+ * non-interactive replacement for the runtime checkbox picker: `--lease` requires
+ * a prompt, so it is headless by contract and must never block on a TTY.
+ *
+ * Profile-dispatch agents (kimi/deepseek) and custom workflow agents that run
+ * under a non-obvious runtime are resolved separately — see RUSH-1725.
+ */
+export function inferLeaseRuntime(agentName: string, detected: DetectedRuntime[]): AgentId | null {
+  const direct = LEASE_RUNTIMES.find((c) => c.id === agentName);
+  if (direct) return direct.id;
+  const signedIn = detected.filter((d) => d.signedIn && d.credPath);
+  return signedIn.find((d) => d.id === 'claude')?.id ?? signedIn[0]?.id ?? null;
+}
+
 // A long random sentinel makes an accidental (or malicious) collision with a
 // token's contents effectively impossible, so the quoted heredoc can never be
 // closed early by the credential body.


### PR DESCRIPTION
## What

Makes `agents run --lease` usable unattended — the whole point of a "disposable box for your agents/tasks" — and stops it from shipping the wrong account's token.

Linear: RUSH-1724 (parent epic RUSH-1723).

## Why

An end-to-end walkthrough of the lease flow found the wrapper is **interactive-only**, despite `--lease` requiring a prompt (i.e. it's headless by contract):

- The runtime **checkbox picker** (`Provision which runtime(s)?`) blocks even a prompt-provided run and hangs forever — verified live (a backgrounded `agents run … --lease` stalled on the TUI; piped stdin is ignored by inquirer raw mode).
- A second **confirm** prompt gates the credential copy; `-y/--yes` doesn't cover it.
- The picker **defaults to ALL signed-in runtimes**, so `agents run claude … --lease` shipped Codex + Grok tokens too and installed three CLIs on a throwaway box.
- The credential copied was the **raw default signed-in account** (`getAccountInfo`), *not* the account the run's own `balanced` strategy would pick — so a rate-limited / out-of-credits token could be shipped, booting the box straight into a throttled account.

## Change

- **Infer the one runtime** to provision from the agent being run (`inferLeaseRuntime`) — if the agent is a lease runtime (claude/codex/gemini/grok) use it, else fall back to the signed-in one (preferring claude). No interactive picker, **no new required flag**.
- **Copy the strategy-resolved account**: run `getConfiguredRunStrategy` → `resolveRunVersion` (default `balanced` — a healthy, non-rate-limited account weighted by remaining headroom) and prefer that account's email when reading the Claude OAuth token. Never ships a throttled token. Best-effort: falls back to the default account if resolution throws.
- **Replace the blocking confirm** with a printed notice of exactly what ships where (credential transfer stays transparent; the box is destroyed after the run, bounding the token lifetime).
- The `--host --copy-creds` path is untouched — it keeps the interactive `pickRuntimes` flow.

## Tests

- 5 new `inferLeaseRuntime` unit cases (agent-is-runtime, custom-agent fallback, claude-preference, no-cred skip, none-signed-in → null).
- Full crabbox suite: **33 passing**.
- `tsc --noEmit`: **0 errors**.

Note: I could not complete a live warm→run→stop this session because the Hetzner project hit its `server_limit` (403) with existing `keep=true` boxes occupying the quota — tracked as its own child (idle-reaper / pool cap). The code path was verified by unit tests + typecheck; a live lease still needs a free provider slot.

## Follow-ups (children of RUSH-1723)

- RUSH-1725 — profile-dispatch runtimes (kimi/deepseek) on `--lease`
- RUSH-1726 — idle-box reaper / pool cap so `server_limit` stops blocking leases
- RUSH-1727 — `agents pty` sidecar fails to start
- RUSH-1728 — `--lease` onboarding (default `lease.secretsBundle`), help text, and the skill/docs
