### PR TITLE
feat(lease): reaper + actionable server_limit error, and agents lease gc (RUSH-1726)

### DIFF
--- a/apps/cli/src/commands/lease.ts
+++ b/apps/cli/src/commands/lease.ts
@@ -1,0 +1,96 @@
+/**
+ * `agents lease` — manage the disposable cloud boxes used by `agents run --lease`.
+ *
+ * Today: `agents lease gc`, which stops expired + idle "orphan" boxes that are
+ * holding a provider's server quota (the cause of the `server_limit` 403 a new
+ * lease hits). Reaping is conservative: only boxes whose lease has expired AND
+ * that have been untouched for a safety window are eligible (see `isReapSafe`),
+ * so a box a concurrent run just reused is never stopped.
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { crabboxList, reapSafeOrphans, reapOrphans, type CrabboxBox } from '../lib/crabbox/cli.js';
+
+function fmtIdle(box: CrabboxBox): string {
+  if (box.lastTouchedAt === null) return 'idle ?';
+  const iso = new Date(box.lastTouchedAt * 1000).toISOString().slice(0, 16).replace('T', ' ');
+  return `idle since ${iso}Z`;
+}
+
+export function registerLeaseCommand(program: Command): void {
+  const lease = program
+    .command('lease')
+    .description('Manage the disposable cloud boxes used by `agents run --lease`.');
+
+  lease
+    .command('gc')
+    .description(
+      'Stop expired, idle lease boxes that are holding your provider quota. Safe: never stops a box in active use.',
+    )
+    .option('--dry-run', 'List reap-safe orphan boxes without stopping any', false)
+    .option('--yes', 'Stop them without the interactive confirm', false)
+    .option('--json', 'Output JSON', false)
+    .action(async (opts: { dryRun?: boolean; yes?: boolean; json?: boolean }) => {
+      const boxOpts = { secretsBundle: process.env.AGENTS_LEASE_SECRETS_BUNDLE };
+      const nowSecs = Math.floor(Date.now() / 1000);
+
+      let candidates: CrabboxBox[];
+      try {
+        candidates = reapSafeOrphans(crabboxList(boxOpts), nowSecs);
+      } catch (e) {
+        console.error(chalk.red(`lease gc: ${(e as Error).message}`));
+        process.exit(1);
+        return;
+      }
+
+      if (candidates.length === 0) {
+        if (opts.json) console.log(JSON.stringify({ candidates: [], reaped: [] }));
+        else console.error(chalk.gray('No reap-safe orphan boxes — nothing to collect.'));
+        return;
+      }
+
+      if (!opts.json) {
+        console.error(chalk.bold(`${candidates.length} reap-safe orphan box(es):`));
+        for (const b of candidates) {
+          console.error(`  ${chalk.cyan(b.slug)} ${chalk.dim(`(${b.class ?? '?'}, ${fmtIdle(b)})`)}`);
+        }
+      }
+
+      if (opts.dryRun) {
+        if (opts.json) console.log(JSON.stringify({ candidates, reaped: [] }, null, 2));
+        else console.error(chalk.gray('\n--dry-run: nothing stopped. Re-run with --yes to stop them.'));
+        return;
+      }
+
+      // Destructive: stopping boxes the agent did not create needs an explicit yes.
+      if (!opts.yes) {
+        const { isInteractiveTerminal, isPromptCancelled } = await import('./utils.js');
+        if (!isInteractiveTerminal()) {
+          console.error(chalk.yellow('Refusing to stop boxes without --yes in a non-interactive shell.'));
+          process.exit(1);
+          return;
+        }
+        try {
+          const { confirm } = await import('@inquirer/prompts');
+          const ok = await confirm({ message: `Stop these ${candidates.length} box(es)?`, default: false });
+          if (!ok) {
+            console.error(chalk.yellow('Aborted — no boxes stopped.'));
+            return;
+          }
+        } catch (e) {
+          if (isPromptCancelled(e)) {
+            console.error(chalk.yellow('Aborted — no boxes stopped.'));
+            return;
+          }
+          throw e;
+        }
+      }
+
+      // Re-list at stop time (freshness re-check) so a box touched since the
+      // preview is not stopped out from under an active run.
+      const { candidates: stopped, reaped } = reapOrphans({ ...boxOpts, nowSecs });
+      if (opts.json) console.log(JSON.stringify({ candidates: stopped, reaped }, null, 2));
+      else console.error(chalk.green(`Stopped ${reaped.length}/${stopped.length} box(es): ${reaped.join(', ') || '(none)'}`));
+    });
+}

--- a/apps/cli/src/lib/crabbox/cli.test.ts
+++ b/apps/cli/src/lib/crabbox/cli.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { isReapSafe, reapSafeOrphans, REAP_MIN_IDLE_SECS, type CrabboxBox } from './cli.js';
+
+const NOW = 1_800_000_000; // fixed "now" in unix seconds
+
+function box(over: Partial<CrabboxBox> = {}): CrabboxBox {
+  return {
+    name: 'crabbox-x',
+    status: 'running',
+    slug: 'x',
+    lease: 'cbx_x',
+    state: 'ready',
+    ready: true,
+    keep: true,
+    createdAt: NOW - 10_000,
+    expiresAt: NOW - 8_000, // expired by default
+    lastTouchedAt: NOW - REAP_MIN_IDLE_SECS - 100, // stale by default
+    idleTimeoutSecs: 1800,
+    ...over,
+  };
+}
+
+describe('isReapSafe', () => {
+  it('reaps a genuine orphan: expired lease AND stale touch', () => {
+    expect(isReapSafe(box(), NOW)).toBe(true);
+  });
+
+  it('never reaps a box touched within the safety window (TOCTOU guard)', () => {
+    // Expired lease, but touched 1 minute ago → a concurrent run may be using it.
+    expect(isReapSafe(box({ lastTouchedAt: NOW - 60 }), NOW)).toBe(false);
+  });
+
+  it('never reaps a box whose lease has not expired', () => {
+    expect(isReapSafe(box({ expiresAt: NOW + 1_000 }), NOW)).toBe(false);
+  });
+
+  it('honors max(2×idleTimeout, 1h): a long idle-timeout widens the window', () => {
+    // idleTimeout 40m → window = 80m. Touched 70m ago is still inside it.
+    const b = box({ idleTimeoutSecs: 2400, lastTouchedAt: NOW - 70 * 60 });
+    expect(isReapSafe(b, NOW)).toBe(false);
+    // Touched 90m ago is outside the 80m window.
+    expect(isReapSafe(box({ idleTimeoutSecs: 2400, lastTouchedAt: NOW - 90 * 60 }), NOW)).toBe(true);
+  });
+
+  it('never reaps a box with unknown age (null expiresAt or lastTouchedAt)', () => {
+    expect(isReapSafe(box({ expiresAt: null }), NOW)).toBe(false);
+    expect(isReapSafe(box({ lastTouchedAt: null }), NOW)).toBe(false);
+  });
+});
+
+describe('reapSafeOrphans', () => {
+  it('filters to orphans and sorts most-stale first', () => {
+    const fresh = box({ slug: 'fresh', lastTouchedAt: NOW - 30 });          // in use
+    const active = box({ slug: 'active', expiresAt: NOW + 500 });           // lease live
+    const oldOrphan = box({ slug: 'old', lastTouchedAt: NOW - 100_000 });
+    const newOrphan = box({ slug: 'new', lastTouchedAt: NOW - REAP_MIN_IDLE_SECS - 10 });
+    const out = reapSafeOrphans([fresh, active, newOrphan, oldOrphan], NOW);
+    expect(out.map((b) => b.slug)).toEqual(['old', 'new']); // oldest touch first, in-use/active excluded
+  });
+
+  it('returns empty when nothing is reap-safe', () => {
+    expect(reapSafeOrphans([box({ expiresAt: NOW + 1 })], NOW)).toEqual([]);
+  });
+});

--- a/apps/cli/src/lib/crabbox/cli.ts
+++ b/apps/cli/src/lib/crabbox/cli.ts
@@ -33,6 +33,16 @@ export interface CrabboxBox {
   class?: string;
   /** True when running + bootstrap-complete. */
   ready: boolean;
+  /** crabbox `keep` label — a kept box survives `crabbox cleanup` past its TTL. */
+  keep: boolean;
+  /** Unix seconds the box was created, or null when the label is absent. */
+  createdAt: number | null;
+  /** Unix seconds the lease expires, or null. */
+  expiresAt: number | null;
+  /** Unix seconds the box was last touched (reused / run against), or null. */
+  lastTouchedAt: number | null;
+  /** Idle-timeout window in seconds, or null. */
+  idleTimeoutSecs: number | null;
 }
 
 export interface CrabboxOptions {
@@ -81,6 +91,11 @@ function normalizeBox(raw: Record<string, unknown>): CrabboxBox | null {
   const status = String(raw.status ?? '');
   const state = String(labels.state ?? '');
   const publicNet = (raw.public_net ?? {}) as { ipv4?: { ip?: string } };
+  const num = (v: string | undefined): number | null => {
+    if (v === undefined || v === '') return null;
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  };
   return {
     name: String(raw.name ?? ''),
     status,
@@ -91,6 +106,11 @@ function normalizeBox(raw: Record<string, unknown>): CrabboxBox | null {
     profile: labels.profile,
     class: labels.class,
     ready: status === 'running' && state === 'ready',
+    keep: labels.keep === 'true',
+    createdAt: num(labels.created_at),
+    expiresAt: num(labels.expires_at),
+    lastTouchedAt: num(labels.last_touched_at),
+    idleTimeoutSecs: num(labels.idle_timeout_secs ?? labels.idle_timeout),
   };
 }
 
@@ -156,6 +176,23 @@ export async function crabboxWarmup(opts: WarmupOptions = {}): Promise<CrabboxBo
   });
   if (r.status !== 0) {
     const detail = (r.stderr || r.stdout || '').trim();
+    // A provider `server_limit` / `resource_limit_exceeded` 403 means the account's
+    // box quota is full. Turn the raw 403 into an actionable message that names the
+    // reap-safe orphans + the one-command fix, instead of a generic failure.
+    if (/server_limit|resource_limit_exceeded/i.test(detail)) {
+      let hint = ' Stop unused boxes (`crabbox list`) or raise your provider server limit.';
+      try {
+        const orphans = reapSafeOrphans(crabboxList(opts), Math.floor(Date.now() / 1000));
+        if (orphans.length) {
+          hint =
+            ` ${orphans.length} expired, idle box(es) are holding the quota — free them with ` +
+            `\`agents lease gc\` (or \`crabbox stop ${orphans[0].slug}\`).`;
+        }
+      } catch {
+        /* best-effort hint; fall back to the generic guidance above */
+      }
+      throw new Error(`crabbox warmup failed: provider server limit reached.${hint}`);
+    }
     throw new Error(
       `crabbox warmup failed: ${detail || 'unknown error'}. ` +
         `Check provider access with \`crabbox doctor\`; a missing cloud token often means \`crabbox login\` or a lease.secretsBundle is needed.`,
@@ -279,4 +316,51 @@ export function crabboxStop(slug: string, opts: CrabboxOptions = {}): boolean {
   } catch {
     return false;
   }
+}
+
+/** Never reap a box touched within this many seconds, regardless of idle-timeout. */
+export const REAP_MIN_IDLE_SECS = 3600;
+
+/**
+ * Whether a box is a genuine orphan that is safe to reap.
+ *
+ * Reap-safe ONLY when BOTH hold: the lease has already expired (`expiresAt` in the
+ * past) AND the box has not been touched for a safety window of
+ * `max(2 × idleTimeout, 1h)`. The freshness guard is what makes this safe against
+ * a TOCTOU race: a box a concurrent run just reused (`cbx_acquire_box`) has a
+ * recent `lastTouchedAt` and is never eligible. Reaping by `profile`/`ready` alone
+ * — as `crabbox cleanup` cannot (it skips `keep=true`, which every real orphan is)
+ * — would kill in-use boxes. Boxes with unknown age (`expiresAt`/`lastTouchedAt`
+ * null) are never reaped. `nowSecs` is injected so tests don't wall-clock.
+ */
+export function isReapSafe(box: CrabboxBox, nowSecs: number): boolean {
+  if (box.expiresAt === null || box.lastTouchedAt === null) return false;
+  if (box.expiresAt > nowSecs) return false;
+  const window = Math.max((box.idleTimeoutSecs ?? 0) * 2, REAP_MIN_IDLE_SECS);
+  return nowSecs - box.lastTouchedAt >= window;
+}
+
+/** The reap-safe orphans among `boxes`, most-stale (oldest touch) first. */
+export function reapSafeOrphans(boxes: CrabboxBox[], nowSecs: number): CrabboxBox[] {
+  return boxes
+    .filter((b) => isReapSafe(b, nowSecs))
+    .sort((a, b) => (a.lastTouchedAt ?? 0) - (b.lastTouchedAt ?? 0));
+}
+
+/**
+ * List reap-safe orphans and (unless `dryRun`) stop them. Returns the candidates
+ * considered and the slugs actually stopped. Best-effort per box — a stop failure
+ * is skipped, never thrown. Backs `agents lease gc` and the 403 auto-reap opt-in.
+ */
+export function reapOrphans(
+  opts: CrabboxOptions & { nowSecs?: number; dryRun?: boolean } = {},
+): { candidates: CrabboxBox[]; reaped: string[] } {
+  const nowSecs = opts.nowSecs ?? Math.floor(Date.now() / 1000);
+  const candidates = reapSafeOrphans(crabboxList(opts), nowSecs);
+  if (opts.dryRun) return { candidates, reaped: [] };
+  const reaped: string[] = [];
+  for (const b of candidates) {
+    if (crabboxStop(b.slug, opts)) reaped.push(b.slug);
+  }
+  return { candidates, reaped };
 }

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -80,6 +80,7 @@ export const loadWatchdog: ModuleLoader = async () => (await import('../../comma
 export const loadBrowser: ModuleLoader = async () => (await import('../../commands/browser.js')).registerBrowserCommand;
 export const loadComputer: ModuleLoader = async () => (await import('../../commands/computer.js')).registerComputerCommand;
 export const loadHosts: ModuleLoader = async () => (await import('../../commands/hosts.js')).registerHostsCommand;
+export const loadLease: ModuleLoader = async () => (await import('../../commands/lease.js')).registerLeaseCommand;
 export const loadLogs: ModuleLoader = async () => (await import('../../commands/logs.js')).registerLogsCommand;
 export const loadEvents: ModuleLoader = async () => (await import('../../commands/events.js')).registerEventsCommand;
 export const loadSsh: ModuleLoader = async () => (await import('../../commands/ssh.js')).registerSshCommands;
@@ -179,6 +180,7 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   browser: [loadBrowser],
   computer: [loadComputer],
   hosts: [loadHosts],
+  lease: [loadLease],
   logs: [loadLogs],
   events: [loadEvents],
   ssh: [loadSsh],


### PR DESCRIPTION
## What

Makes `agents run --lease` stop dead-ending on a Hetzner `server_limit` 403, and adds a safe way to reclaim the quota. RUSH-1726 (epic RUSH-1723; sibling of the merged RUSH-1724).

## Why

Once lease boxes pile up, `crabbox warmup` fails with a raw `resource_limit_exceeded` 403 that is caught nowhere. `crabbox cleanup` can't help — it skips `keep=true`, and every real orphan is `keep=true`. And `normalizeBox` dropped the very labels needed to tell an orphan from an in-use box. Observed live: 3 boxes expired ~months ago hold the whole account quota, so every new lease 403s.

## Change

- **Surface the labels** on `CrabboxBox`: `keep`, `createdAt`, `expiresAt`, `lastTouchedAt`, `idleTimeoutSecs` (already in `crabbox list --json`, just not parsed).
- **`isReapSafe(box, now)`** — a box is reap-safe **only** when its lease has expired **AND** it has been untouched for `max(2×idleTimeout, 1h)`. The freshness guard is what makes it safe against a TOCTOU race: a box a concurrent run just reused (`cbx_acquire_box`) has a recent `lastTouchedAt` and is never eligible. Reaping by `profile`/`ready` alone would kill in-use boxes.
- **Actionable 403** — catch `server_limit`/`resource_limit_exceeded` in `crabboxWarmup` and turn it into a message that names the reap-safe orphans + the one-command fix.
- **`agents lease gc [--dry-run|--yes|--json]`** — conservative reaper: lists orphans, and requires an explicit `--yes` (or a TTY confirm) before stopping any box. Stopping boxes the agent didn't create is treated as a destructive op.

## Tests / verification

- 7 new predicate + orphan-filter unit cases (expired+stale → reap; recently-touched → never; lease-active → never; idle-window scaling; unknown-age → never; sort/filter).
- Full crabbox suite: **41 passing**. `tsc --noEmit`: **0 errors**.
- **End-to-end (read-only):** `agents lease gc --dry-run` against the live account correctly flags the 3 expired orphan boxes and stops nothing:
  ```
  3 reap-safe orphan box(es):
    harbor-hermit (cpx62, idle since 2026-07-14 19:26Z)
    pearl-lobster (beast, idle since 2026-07-15 00:17Z)
    golden-hermit (cpx62, idle since 2026-07-15 06:37Z)
  --dry-run: nothing stopped. Re-run with --yes to stop them.
  ```
  I did not run `--yes` — those boxes belong to the user; stopping them is a destructive op left to their explicit call.

## Follow-ups (RUSH-1723 epic)
- RUSH-1728 — `lease.secretsBundle` config key + smart default + `agents lease setup` wizard + docs.
- RUSH-1725 — profile-dispatch runtimes; RUSH-1727 — pty sidecar.
