### PR TITLE
feat(view): show Droid usage bars via Factory billing limits API

### DIFF
--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -1117,7 +1117,7 @@ export interface ViewJsonVersion {
   // outstanding overage credits, undefined means we haven't fetched / can't say.
   overageCredits?: { amount: number; currency: string } | null;
   windows: Array<{
-    key: 'session' | 'week' | 'sonnet_week';
+    key: 'session' | 'week' | 'sonnet_week' | 'month';
     usedPercent: number;
     resetsAt: string | null;
   }>;

--- a/apps/cli/src/lib/__tests__/usage.test.ts
+++ b/apps/cli/src/lib/__tests__/usage.test.ts
@@ -18,6 +18,8 @@ import {
   writeClaudeUsageCache,
   normalizeKimiWindows,
   formatKimiPlan,
+  normalizeDroidWindows,
+  type DroidBillingLimitsResponse,
   type KimiUsagesResponse,
   type UsageSnapshot,
   type UsageWindow,
@@ -450,5 +452,78 @@ describe('normalizeKimiWindows', () => {
     expect(formatKimiPlan(payload)).toBe('Intermediate');
     expect(formatKimiPlan({ subType: 'TYPE_PURCHASE' })).toBe('Purchase');
     expect(formatKimiPlan({})).toBeNull();
+  });
+});
+
+describe('normalizeDroidWindows', () => {
+  // The shape droid itself consumes from GET /api/billing/limits: token-rate-
+  // limit billing exposes fiveHour/weekly/monthly windows, each with a
+  // usedPercent and a windowEnd timestamp.
+  const payload: DroidBillingLimitsResponse = {
+    usesTokenRateLimitsBilling: true,
+    limits: {
+      standard: {
+        fiveHour: { usedPercent: 12, windowEnd: '2026-07-15T18:00:00.000Z' },
+        weekly: { usedPercent: 34, windowEnd: '2026-07-20T00:00:00.000Z' },
+        monthly: { usedPercent: 5, windowEnd: '2026-08-01T00:00:00.000Z' },
+      },
+    },
+  };
+
+  it('maps fiveHour/weekly/monthly to session, week, and month windows', () => {
+    const windows = normalizeDroidWindows(payload);
+    expect(windows.map((w) => w.shortLabel)).toEqual(['S', 'W', 'M']);
+    const session = windows.find((w) => w.key === 'session')!;
+    const week = windows.find((w) => w.key === 'week')!;
+    const month = windows.find((w) => w.key === 'month')!;
+    expect(session.usedPercent).toBe(12);
+    expect(week.usedPercent).toBe(34);
+    expect(month.usedPercent).toBe(5);
+    expect(session.windowMinutes).toBe(300);
+    expect(month.windowMinutes).toBe(43200);
+    expect(session.resetsAt?.toISOString()).toBe('2026-07-15T18:00:00.000Z');
+  });
+
+  it('renders nothing for orgs on the legacy billing model', () => {
+    expect(normalizeDroidWindows({ ...payload, usesTokenRateLimitsBilling: false })).toEqual([]);
+    expect(normalizeDroidWindows({ ...payload, usesTokenRateLimitsBilling: undefined })).toEqual([]);
+  });
+
+  it('renders nothing when limits.standard is missing', () => {
+    expect(normalizeDroidWindows({ usesTokenRateLimitsBilling: true })).toEqual([]);
+    expect(normalizeDroidWindows({ usesTokenRateLimitsBilling: true, limits: {} })).toEqual([]);
+  });
+
+  it('drops a window without a numeric usedPercent and clamps out-of-range values', () => {
+    const windows = normalizeDroidWindows({
+      usesTokenRateLimitsBilling: true,
+      limits: {
+        standard: {
+          fiveHour: { windowEnd: '2026-07-15T18:00:00.000Z' }, // no usedPercent
+          weekly: { usedPercent: 250 },
+        },
+      },
+    });
+    expect(windows.map((w) => w.key)).toEqual(['week']);
+    expect(windows[0].usedPercent).toBe(100);
+  });
+
+  it('keeps the month window out of the compact summary but in the snapshot', () => {
+    const snapshot: UsageSnapshot = {
+      source: 'live',
+      sourceLabel: 'live account data',
+      capturedAt: new Date('2026-07-15T12:00:00Z'),
+      windows: normalizeDroidWindows(payload),
+    };
+    const summary = stripAnsi(formatUsageSummary(null, snapshot));
+    expect(summary).toContain('S:');
+    expect(summary).toContain('W:');
+    expect(summary).not.toContain('M:');
+    // ...but an exhausted month window still flips the account to rate-limited.
+    const exhausted = normalizeDroidWindows({
+      ...payload,
+      limits: { standard: { ...payload.limits!.standard, monthly: { usedPercent: 100 } } },
+    });
+    expect(deriveUsageStatusFromSnapshot({ ...snapshot, windows: exhausted })).toBe('rate_limited');
   });
 });

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -1046,22 +1046,23 @@ function resolveAccountCredentialPath(base: string, ...segments: string[]): stri
   return null;
 }
 
+/** Decrypted contents of Droid's auth.v2.file (subset we consume). */
+export interface DroidAuthPayload {
+  access_token?: string;
+  active_organization_id?: string | null;
+}
+
 /**
  * Factory Droid stores its OAuth credential encrypted at ~/.factory/auth.v2.file
  * (AES-256-GCM, format `ivB64:tagB64:ctB64`) with the 32-byte key base64-stored
  * in ~/.factory/auth.v2.key. On the keyfile-v2 source there is no OS-keychain /
  * device binding — the key is on disk — so we can decrypt locally with no
- * network call. The decrypted JSON credential's `access_token` is a WorkOS JWT
- * carrying an `email` claim (plus org_id / role). We decode the claim WITHOUT
- * verifying `exp`: the email is stable identity for display, not an
- * authorization decision, so an expired token still yields the right address.
- * Every failure (missing key file — e.g. a keyring-v2/legacy login with no
- * on-disk key, a bad GCM tag, malformed JSON, or no email claim) returns null so
- * the caller falls back to the file-presence signed-in signal. Never throws.
+ * network call. Every failure (missing key file — e.g. a keyring-v2/legacy
+ * login with no on-disk key, a bad GCM tag, or malformed JSON) returns null.
+ * Never throws. Shared by account identity below and the Droid usage fetcher
+ * in usage.ts.
  */
-function decryptDroidCredential(
-  base: string
-): { email: string | null; orgId: string | null; role: string | null } | null {
+export function decryptDroidAuthPayload(base: string): DroidAuthPayload | null {
   const filePath = resolveAccountCredentialPath(base, '.factory', 'auth.v2.file');
   const keyPath = resolveAccountCredentialPath(base, '.factory', 'auth.v2.key');
   if (!filePath || !keyPath) return null;
@@ -1078,16 +1079,32 @@ function decryptDroidCredential(
       decipher.final(),
     ]).toString('utf-8');
     const cred = JSON.parse(plaintext);
-    const claims = typeof cred?.access_token === 'string' ? decodeJwtPayload(cred.access_token) : null;
-    if (!claims) return null;
-    return {
-      email: typeof claims.email === 'string' ? claims.email : null,
-      orgId: normalizeIdentityPart(claims.org_id ?? cred.active_organization_id),
-      role: typeof claims.role === 'string' ? claims.role : null,
-    };
+    return cred && typeof cred === 'object' ? (cred as DroidAuthPayload) : null;
   } catch {
     return null;
   }
+}
+
+/**
+ * Derive Droid account identity from the decrypted credential. The
+ * `access_token` is a WorkOS JWT carrying an `email` claim (plus org_id /
+ * role). We decode the claim WITHOUT verifying `exp`: the email is stable
+ * identity for display, not an authorization decision, so an expired token
+ * still yields the right address. Returns null when the credential can't be
+ * decrypted or has no decodable claims, so the caller falls back to the
+ * file-presence signed-in signal.
+ */
+function decryptDroidCredential(
+  base: string
+): { email: string | null; orgId: string | null; role: string | null } | null {
+  const cred = decryptDroidAuthPayload(base);
+  const claims = typeof cred?.access_token === 'string' ? decodeJwtPayload(cred.access_token) : null;
+  if (!claims) return null;
+  return {
+    email: typeof claims.email === 'string' ? claims.email : null,
+    orgId: normalizeIdentityPart(claims.org_id ?? cred?.active_organization_id),
+    role: typeof claims.role === 'string' ? claims.role : null,
+  };
 }
 
 let cachedAgyKeychainSignedIn: boolean | undefined;
@@ -1643,7 +1660,7 @@ export function countSessionFiles(agentId: AgentId): number {
 }
 
 /** Decode the payload section of a JWT token without verifying its signature. */
-function decodeJwtPayload(token: string): Record<string, any> | null {
+export function decodeJwtPayload(token: string): Record<string, any> | null {
   const payload = token.split('.')[1];
   if (!payload) return null;
   try {

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -1,7 +1,8 @@
 /**
- * Usage and rate-limit tracking for Claude and Codex agents.
+ * Usage and rate-limit tracking for Claude, Codex, Kimi, and Droid agents.
  *
- * Fetches live usage data from the Anthropic OAuth API (Claude) or parses
+ * Fetches live usage data from each agent's usage API (Anthropic OAuth for
+ * Claude, Kimi Code /usages, Factory billing limits for Droid) or parses
  * rate-limit events from Codex session logs. Results are normalized into a
  * common UsageSnapshot shape, cached to disk, and rendered as terminal
  * progress bars for the `agents view` command.
@@ -15,7 +16,7 @@ import * as readline from 'readline';
 import { promisify } from 'util';
 import chalk from 'chalk';
 
-import type { AccountInfo } from './agents.js';
+import { decodeJwtPayload, decryptDroidAuthPayload, type AccountInfo } from './agents.js';
 import { walkForFiles } from './fs-walk.js';
 import {
   getKeychainToken,
@@ -45,13 +46,15 @@ const CACHED_CLAUDE_USAGE_SOURCE_LABEL = 'last seen live account data';
 
 const KIMI_USAGES_URL = 'https://api.kimi.com/coding/v1/usages';
 
+const DROID_USAGE_URL = 'https://api.factory.ai/api/billing/limits';
+
 const COMPACT_BAR_LEN = 5;
 const USAGE_BAR_LEN = 10;
 const FULL = '\u2588';
 const EMPTY = '\u2591';
 
 /** Discriminator for usage window types. */
-export type UsageWindowKey = 'session' | 'week' | 'sonnet_week';
+export type UsageWindowKey = 'session' | 'week' | 'sonnet_week' | 'month';
 
 /** A single rate-limit window with utilization percentage and reset time. */
 export interface UsageWindow {
@@ -188,6 +191,8 @@ export async function getUsageInfo(agentId: AgentId, options?: UsageOptions): Pr
       return getCodexUsageInfo(options);
     case 'kimi':
       return getKimiUsageInfo(options);
+    case 'droid':
+      return getDroidUsageInfo(options);
     default:
       return { snapshot: null, error: null };
   }
@@ -279,13 +284,15 @@ const inFlightRefreshes = new Map<string, Promise<void>>();
 export async function getUsageInfoForIdentity(input: UsageIdentityInput): Promise<UsageInfo> {
   const usageKey = getUsageLookupKey(input.info);
 
-  // Agents whose usage comes from a live network call (Claude, Kimi) go through
-  // the stale-while-revalidate cache below so `agents run`/`agents view` stay off
-  // the network on the hot path. Everything else (Codex reads local session
-  // logs) takes the legacy blocking path. The on-disk cache is shared and keyed
-  // by usageKey, which is namespaced per agent (`claude:org=…`, `kimi:user=…`),
-  // so one cache file holds every account without collision.
-  const usesNetworkUsage = input.agentId === 'claude' || input.agentId === 'kimi';
+  // Agents whose usage comes from a live network call (Claude, Kimi, Droid) go
+  // through the stale-while-revalidate cache below so `agents run`/`agents view`
+  // stay off the network on the hot path. Everything else (Codex reads local
+  // session logs) takes the legacy blocking path. The on-disk cache is shared and
+  // keyed by usageKey, which is namespaced per agent (`claude:org=…`,
+  // `kimi:user=…`, `droid:org=…`), so one cache file holds every account without
+  // collision.
+  const usesNetworkUsage =
+    input.agentId === 'claude' || input.agentId === 'kimi' || input.agentId === 'droid';
   if (!usesNetworkUsage || !usageKey) {
     return getUsageInfo(input.agentId, {
       home: input.home,
@@ -375,8 +382,12 @@ export function formatUsageSummary(
   }
 
   if (snapshot) {
+    // Compact rows show the two windows every agent shares (session + week);
+    // extra windows (Claude's Sonnet week, Droid's month) render only in the
+    // full per-version usage section. An exhausted month window still surfaces
+    // here as the rate-limited badge via deriveUsageStatusFromSnapshot.
     const windows = snapshot.windows
-      .filter((window) => window.key !== 'sonnet_week')
+      .filter((window) => window.key === 'session' || window.key === 'week')
       .map((window) =>
       `${chalk.gray(`${window.shortLabel}:`)} ${renderCompactUsageBar(window.usedPercent)}`
     );
@@ -739,6 +750,125 @@ export function formatKimiPlan(data: KimiUsagesResponse): string | null {
   const tail = raw.split('_').pop() || ''; // LEVEL_INTERMEDIATE -> INTERMEDIATE
   if (!tail) return null;
   return tail.charAt(0).toUpperCase() + tail.slice(1).toLowerCase();
+}
+
+/** A single Droid token-rate-limit window from /api/billing/limits. */
+interface DroidLimitWindow {
+  usedPercent?: number | null;
+  windowEnd?: string | null;
+}
+
+/** Response shape from Factory's billing limits endpoint (subset we render). */
+export interface DroidBillingLimitsResponse {
+  usesTokenRateLimitsBilling?: boolean | null;
+  limits?: {
+    standard?: {
+      fiveHour?: DroidLimitWindow | null;
+      weekly?: DroidLimitWindow | null;
+      monthly?: DroidLimitWindow | null;
+    } | null;
+  } | null;
+}
+
+/**
+ * Fetch Droid usage via Factory's billing limits API — the same endpoint the
+ * droid CLI polls for its token-limit banner. The WorkOS access token comes
+ * from the locally decrypted ~/.factory/auth.v2.file (the same credential
+ * account identity in agents.ts reads).
+ *
+ * Deliberately NO token refresh, for a sharper reason than Kimi's: WorkOS
+ * refresh tokens are single-use and rotate on every exchange, so refreshing
+ * here would race a concurrently running droid session and can permanently
+ * invalidate the user's login chain. Droid refreshes its own credential when
+ * it runs; if the stored token is expired we skip the live fetch and let the
+ * SWR cache serve the last-seen snapshot.
+ */
+async function getDroidUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
+  try {
+    const cred = decryptDroidAuthPayload(options?.home || os.homedir());
+    const accessToken = cred?.access_token;
+    if (typeof accessToken !== 'string' || !accessToken) {
+      return { snapshot: null, error: null };
+    }
+
+    const exp = decodeJwtPayload(accessToken)?.exp;
+    if (typeof exp === 'number' && Date.now() / 1000 >= exp) {
+      return { snapshot: null, error: null };
+    }
+
+    const response = await fetch(DROID_USAGE_URL, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(5000),
+    });
+
+    // 401 => revoked/expired token; render nothing rather than a misleading
+    // empty bar.
+    if (!response.ok) {
+      return { snapshot: null, error: null };
+    }
+
+    const data = await response.json() as DroidBillingLimitsResponse;
+    const windows = normalizeDroidWindows(data);
+    if (windows.length === 0) {
+      return { snapshot: null, error: null };
+    }
+
+    return {
+      snapshot: {
+        source: 'live',
+        sourceLabel: 'live account data',
+        capturedAt: new Date(),
+        windows,
+      },
+      error: null,
+    };
+  } catch {
+    return { snapshot: null, error: null };
+  }
+}
+
+/**
+ * Normalize the Factory billing-limits payload into the common UsageWindow
+ * shape. Orgs on the legacy (non token-rate-limit) billing model have no
+ * meaningful windows, so they render nothing — mirrors droid's own gate on
+ * `usesTokenRateLimitsBilling` before it reads `limits.standard`.
+ */
+export function normalizeDroidWindows(data: DroidBillingLimitsResponse): UsageWindow[] {
+  if (data.usesTokenRateLimitsBilling !== true) return [];
+  const standard = data.limits?.standard;
+  if (!standard) return [];
+
+  const windows = [
+    normalizeDroidWindow(standard.fiveHour, 'session', 'Current session', 'S'),
+    normalizeDroidWindow(standard.weekly, 'week', 'Current week', 'W'),
+    normalizeDroidWindow(standard.monthly, 'month', 'Current month', 'M'),
+  ];
+
+  return windows.filter((window): window is UsageWindow => window !== null);
+}
+
+/** Normalize a single Droid billing-limits window. */
+function normalizeDroidWindow(
+  window: DroidLimitWindow | null | undefined,
+  key: UsageWindowKey,
+  label: string,
+  shortLabel: string
+): UsageWindow | null {
+  const usedPercent = normalizePercent(window?.usedPercent);
+  if (usedPercent === null) return null;
+
+  return {
+    key,
+    label,
+    shortLabel,
+    usedPercent,
+    resetsAt: parseDateValue(window?.windowEnd),
+    windowMinutes: inferWindowMinutes(key),
+  };
 }
 
 /** Collect Codex JSONL session files sorted newest-first. */
@@ -1196,6 +1326,8 @@ function inferWindowMinutes(key: UsageWindowKey): number | null {
     case 'week':
     case 'sonnet_week':
       return 10080;
+    case 'month':
+      return 43200;
   }
 }
 


### PR DESCRIPTION
## Problem

Droid rows in `agents view` showed no `S:`/`W:` usage bars — `getUsageInfo` had no droid implementation and fell through to an empty snapshot, so the row rendered only email + last-active.

## Fix

- Fetch `GET https://api.factory.ai/api/billing/limits` — the same endpoint the droid CLI itself polls for its token-limit banner — authenticated with the WorkOS access token decrypted from `~/.factory/auth.v2.file` (the credential path account identity already reads; the decryptor is now shared via `decryptDroidAuthPayload`).
- Normalize `limits.standard.{fiveHour,weekly,monthly}` into the shared `UsageWindow` shape. Session and week render as the compact `S:`/`W:` bars; the new `month` window key renders in the full per-version usage section and still counts toward the rate-limited badge (unlike Claude's model-specific `sonnet_week`, droid's monthly cap blocks the whole account).
- Orgs on the legacy (non token-rate-limit) billing model render nothing, mirroring droid's own `usesTokenRateLimitsBilling` gate.
- Droid joins Claude/Kimi on the stale-while-revalidate usage cache path, keyed `droid:org=…`.

**Deliberately no token refresh** (same stance as Kimi, with a sharper reason): WorkOS refresh tokens are single-use and rotate on every exchange, so refreshing from `agents view` would race a concurrently running droid session and can permanently invalidate the user's login chain. If the stored token is expired the live fetch is skipped and the cache serves the last-seen snapshot.

## Response shape (verified live)

```json
{
  "usesTokenRateLimitsBilling": true,
  "limits": {
    "standard": {
      "fiveHour": { "usedPercent": 6,  "windowEnd": "2026-07-15T22:24:31.083Z", "secondsRemaining": 10118 },
      "weekly":   { "usedPercent": 19, "windowEnd": "2026-07-17T19:26:48.219Z", "secondsRemaining": 172255 },
      "monthly":  { "usedPercent": 26, "windowEnd": "2026-07-24T11:38:08.880Z", "secondsRemaining": 748935 }
    }
  }
}
```

`windowEnd` can be null (observed on the `core` pool windows) — handled by `parseDateValue`.

## Verification

- `bun run test src/lib/__tests__/usage.test.ts` — 26 passed (5 new droid tests: window mapping, legacy-billing gate, missing `limits.standard`, percent clamping, month-window compact/badge behavior).
- `agents.test.ts`, `view.resources.test.ts`, `repo-view.test.ts` — 65 passed. `tsc` clean.
- End-to-end with a valid credential (linux host): droid row renders `S: █░░░░ W: █░░░░` from the live API.
- End-to-end with an expired credential (macOS host): droid row renders gracefully with no bars, no refresh attempted, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)