### PR TITLE
feat(lease): lease.secretsBundle config + auto-detect provider bundle (RUSH-1728 Layer A)

### DIFF
--- a/apps/cli/src/lib/crabbox/cli.test.ts
+++ b/apps/cli/src/lib/crabbox/cli.test.ts
@@ -1,5 +1,34 @@
 import { describe, it, expect } from 'vitest';
-import { isReapSafe, reapSafeOrphans, REAP_MIN_IDLE_SECS, type CrabboxBox } from './cli.js';
+import { isReapSafe, reapSafeOrphans, REAP_MIN_IDLE_SECS, pickLeaseBundleFromList, type CrabboxBox } from './cli.js';
+import type { SecretsBundle } from '../secrets/bundles.js';
+
+describe('pickLeaseBundleFromList', () => {
+  const bundle = (name: string, keys: string[]): SecretsBundle =>
+    ({ name, vars: Object.fromEntries(keys.map((k) => [k, 'x'])) }) as SecretsBundle;
+
+  it('picks the first bundle that declares a provider token key', () => {
+    const bundles = [bundle('misc', ['OPENAI_API_KEY']), bundle('hetzner.com', ['HCLOUD_TOKEN'])];
+    expect(pickLeaseBundleFromList(bundles)).toBe('hetzner.com');
+  });
+
+  it('matches AWS and DigitalOcean token keys too', () => {
+    expect(pickLeaseBundleFromList([bundle('aws', ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'])])).toBe('aws');
+    expect(pickLeaseBundleFromList([bundle('do', ['DIGITALOCEAN_TOKEN'])])).toBe('do');
+  });
+
+  it('ignores bundles with no provider token key', () => {
+    expect(pickLeaseBundleFromList([bundle('misc', ['OPENAI_API_KEY', 'FOO'])])).toBeUndefined();
+  });
+
+  it('returns undefined for an empty list', () => {
+    expect(pickLeaseBundleFromList([])).toBeUndefined();
+  });
+
+  it('returns the first match in list order (deterministic)', () => {
+    const bundles = [bundle('a', ['HCLOUD_TOKEN']), bundle('b', ['HCLOUD_TOKEN'])];
+    expect(pickLeaseBundleFromList(bundles)).toBe('a');
+  });
+});
 
 const NOW = 1_800_000_000; // fixed "now" in unix seconds
 

--- a/apps/cli/src/lib/crabbox/cli.ts
+++ b/apps/cli/src/lib/crabbox/cli.ts
@@ -69,9 +69,9 @@ export function findCrabbox(): string {
 
 /**
  * Env keys that mark a secrets bundle as usable for `--lease` — the provider
- * tokens crabbox reads to reach a cloud API. Presence of any one is enough to
- * auto-pick the bundle; we only look at declared key NAMES, never values, so
- * detection never touches the keychain.
+ * tokens crabbox reads to reach a cloud API. Matching a bundle needs only its
+ * declared key NAMES; only the matched key's VALUE is ever injected (see
+ * `crabboxEnv`), so an auto-detected bundle can't leak its other secrets.
  */
 export const LEASE_PROVIDER_TOKEN_KEYS = ['HCLOUD_TOKEN', 'AWS_ACCESS_KEY_ID', 'DIGITALOCEAN_TOKEN', 'DO_TOKEN'];
 
@@ -83,51 +83,84 @@ export function pickLeaseBundleFromList(bundles: SecretsBundle[]): string | unde
   return undefined;
 }
 
+/** A resolved lease bundle: its name, plus (auto-detect only) the exact keys to inject. */
+export interface ResolvedLeaseBundle {
+  name: string;
+  /** When set (auto-detect), inject ONLY these keys — not the whole bundle. */
+  keys?: string[];
+}
+
 /**
- * The secrets bundle to feed crabbox, resolved WITHOUT touching the keychain:
- *   1. `AGENTS_LEASE_SECRETS_BUNDLE` env var (explicit, highest priority)
- *   2. `lease.secretsBundle` in agents config (set by `agents lease setup`)
- *   3. auto-detect: the first bundle that DECLARES a provider token key
- * Returns undefined when nothing matches — crabbox then falls back to its own
- * `crabbox login` credentials. This is what lets a user who set up a bundle once
- * run `--lease` with no env var and no flag ever again.
+ * The secrets bundle to feed crabbox, resolved in priority order:
+ *   1. `AGENTS_LEASE_SECRETS_BUNDLE` env var          — explicit, no keychain
+ *   2. `lease.secretsBundle` config (set by `lease setup`) — explicit, no keychain
+ *   3. auto-detect: the first keychain bundle DECLARING a provider token key
+ *
+ * Tiers 1–2 are the frictionless steady state (env + config are plain, no keychain
+ * read). Tier 3 is a fallback that DOES read bundle metadata via `listBundles()`
+ * (one batched keychain unlock, ~7-day broker cache) — so it only runs when
+ * neither env nor config is set, and `crabboxEnv` memoizes the result for the
+ * process (it is called several times per lease, and we don't want a scan each
+ * time). Once `lease setup` persists the choice (tier 2), tier 3 never runs.
+ * Returns undefined when nothing matches — crabbox then falls back to `crabbox login`.
  */
-export function resolveLeaseBundle(): string | undefined {
+export function resolveLeaseBundle(): ResolvedLeaseBundle | undefined {
   const env = process.env.AGENTS_LEASE_SECRETS_BUNDLE;
-  if (env) return env;
+  if (env) return { name: env };
   try {
     const configured = readMeta().lease?.secretsBundle;
-    if (configured && bundleExists(configured)) return configured;
+    if (configured && bundleExists(configured)) return { name: configured };
   } catch {
     /* config unreadable — fall through to auto-detect */
   }
   try {
-    return pickLeaseBundleFromList(listBundles());
+    const bundles = listBundles();
+    const name = pickLeaseBundleFromList(bundles);
+    if (name) {
+      const b = bundles.find((x) => x.name === name);
+      const keys = LEASE_PROVIDER_TOKEN_KEYS.filter((k) => !!b && k in (b.vars ?? {}));
+      return { name, keys };
+    }
   } catch {
-    return undefined;
+    /* secrets unreadable — no auto-detect */
   }
+  return undefined;
+}
+
+/** Process-lifetime memo so the tier-3 `listBundles()` scan runs at most once. */
+let leaseBundleMemo: { value: ResolvedLeaseBundle | undefined } | undefined;
+function resolveLeaseBundleMemo(): ResolvedLeaseBundle | undefined {
+  if (!leaseBundleMemo) leaseBundleMemo = { value: resolveLeaseBundle() };
+  return leaseBundleMemo.value;
 }
 
 /** Persist `lease.secretsBundle` in agents config so `--lease` needs no env var. */
 export function setLeaseSecretsBundle(name: string): void {
   const meta = readMeta();
   writeMeta({ ...meta, lease: { ...meta.lease, secretsBundle: name } });
+  leaseBundleMemo = undefined; // invalidate so the next resolve sees the new config
 }
 
 /** Build the child env for crabbox, injecting a secrets bundle when configured. */
 export function crabboxEnv(opts: CrabboxOptions): NodeJS.ProcessEnv {
-  const bundle = opts.secretsBundle ?? resolveLeaseBundle();
-  if (!bundle) return process.env;
+  const resolved: ResolvedLeaseBundle | undefined = opts.secretsBundle
+    ? { name: opts.secretsBundle }
+    : resolveLeaseBundleMemo();
+  if (!resolved) return process.env;
   try {
-    // Reuse the same resolver `agents secrets exec` uses so a keychain-backed
-    // bundle (e.g. hetzner.com → HCLOUD_TOKEN) reaches crabbox without ever
-    // touching disk.
-    const { env } = readAndResolveBundleEnv(bundle, { caller: 'agents run --lease (crabbox)' });
+    // Auto-detected bundle → inject ONLY the provider token key(s) (least
+    // privilege; an unrelated bundle can't leak its other secrets into crabbox).
+    // An explicitly-named bundle (env/config or `opts.secretsBundle`) injects
+    // whole — the user chose it. Same resolver `agents secrets exec` uses.
+    const { env } = readAndResolveBundleEnv(resolved.name, {
+      caller: 'agents run --lease (crabbox)',
+      keys: resolved.keys,
+    });
     return { ...process.env, ...env };
   } catch (e) {
     throw new Error(
-      `Could not load secrets bundle "${bundle}" for crabbox: ${(e as Error).message}. ` +
-        `Fix the bundle (agents secrets view ${bundle}) or unset lease.secretsBundle to use crabbox's own login.`,
+      `Could not load secrets bundle "${resolved.name}" for crabbox: ${(e as Error).message}. ` +
+        `Fix the bundle (agents secrets view ${resolved.name}) or unset lease.secretsBundle to use crabbox's own login.`,
     );
   }
 }

--- a/apps/cli/src/lib/crabbox/cli.ts
+++ b/apps/cli/src/lib/crabbox/cli.ts
@@ -13,7 +13,8 @@
  */
 
 import { spawn, spawnSync } from 'child_process';
-import { readAndResolveBundleEnv } from '../secrets/bundles.js';
+import { readAndResolveBundleEnv, listBundles, bundleExists, type SecretsBundle } from '../secrets/bundles.js';
+import { readMeta, writeMeta } from '../state.js';
 
 /** A crabbox machine as reported by `crabbox list --json`. */
 export interface CrabboxBox {
@@ -66,9 +67,56 @@ export function findCrabbox(): string {
   return 'crabbox';
 }
 
+/**
+ * Env keys that mark a secrets bundle as usable for `--lease` — the provider
+ * tokens crabbox reads to reach a cloud API. Presence of any one is enough to
+ * auto-pick the bundle; we only look at declared key NAMES, never values, so
+ * detection never touches the keychain.
+ */
+export const LEASE_PROVIDER_TOKEN_KEYS = ['HCLOUD_TOKEN', 'AWS_ACCESS_KEY_ID', 'DIGITALOCEAN_TOKEN', 'DO_TOKEN'];
+
+/** The first bundle that declares a provider token key, or undefined. Pure over `bundles`. */
+export function pickLeaseBundleFromList(bundles: SecretsBundle[]): string | undefined {
+  for (const b of bundles) {
+    if (Object.keys(b.vars ?? {}).some((k) => LEASE_PROVIDER_TOKEN_KEYS.includes(k))) return b.name;
+  }
+  return undefined;
+}
+
+/**
+ * The secrets bundle to feed crabbox, resolved WITHOUT touching the keychain:
+ *   1. `AGENTS_LEASE_SECRETS_BUNDLE` env var (explicit, highest priority)
+ *   2. `lease.secretsBundle` in agents config (set by `agents lease setup`)
+ *   3. auto-detect: the first bundle that DECLARES a provider token key
+ * Returns undefined when nothing matches — crabbox then falls back to its own
+ * `crabbox login` credentials. This is what lets a user who set up a bundle once
+ * run `--lease` with no env var and no flag ever again.
+ */
+export function resolveLeaseBundle(): string | undefined {
+  const env = process.env.AGENTS_LEASE_SECRETS_BUNDLE;
+  if (env) return env;
+  try {
+    const configured = readMeta().lease?.secretsBundle;
+    if (configured && bundleExists(configured)) return configured;
+  } catch {
+    /* config unreadable — fall through to auto-detect */
+  }
+  try {
+    return pickLeaseBundleFromList(listBundles());
+  } catch {
+    return undefined;
+  }
+}
+
+/** Persist `lease.secretsBundle` in agents config so `--lease` needs no env var. */
+export function setLeaseSecretsBundle(name: string): void {
+  const meta = readMeta();
+  writeMeta({ ...meta, lease: { ...meta.lease, secretsBundle: name } });
+}
+
 /** Build the child env for crabbox, injecting a secrets bundle when configured. */
 export function crabboxEnv(opts: CrabboxOptions): NodeJS.ProcessEnv {
-  const bundle = opts.secretsBundle ?? process.env.AGENTS_LEASE_SECRETS_BUNDLE;
+  const bundle = opts.secretsBundle ?? resolveLeaseBundle();
   if (!bundle) return process.env;
   try {
     // Reuse the same resolver `agents secrets exec` uses so a keychain-backed

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -685,6 +685,15 @@ export interface ExtraRepoConfig {
 export interface Meta {
   agents?: Partial<Record<AgentId, string>>;
   run?: RunConfig;
+  /**
+   * `agents run --lease` config. `secretsBundle` names the keychain secrets bundle
+   * whose provider token (e.g. `HCLOUD_TOKEN`) crabbox uses to reach the cloud API.
+   * When unset, the bundle is resolved by env (`AGENTS_LEASE_SECRETS_BUNDLE`) then
+   * auto-detected (the first bundle that declares a provider token key).
+   */
+  lease?: {
+    secretsBundle?: string;
+  };
   /** macOS secrets-agent config. `policy` is the default prompt policy for
    * bundles without an explicit per-bundle policy: `daily` (the default) asks
    * once per ~7 days, `always` asks every time. `auto` (default on) lets the


### PR DESCRIPTION
## What

Kills the `AGENTS_LEASE_SECRETS_BUNDLE=` requirement for `agents run --lease` — Layer A of RUSH-1728 (frictionless credentials). Epic RUSH-1723; builds on merged RUSH-1724 + RUSH-1726.

## Why

`--lease` resolved its provider token only from `AGENTS_LEASE_SECRETS_BUNDLE` in the env (`crabboxEnv`, `cli.ts`). So a user who'd already stored `HCLOUD_TOKEN` in a keychain bundle still had to set the env var on every call, or got a raw "missing hcloud token". There wasn't even a config key to persist the bundle choice.

## Change

- **`lease.secretsBundle` config key** on `Meta` (`types.ts`) — persistable, was env-only.
- **`resolveLeaseBundle()`** used by `crabboxEnv`: `AGENTS_LEASE_SECRETS_BUNDLE` → `lease.secretsBundle` config → **auto-detect** the first bundle that *declares* a provider token key (`HCLOUD_TOKEN` / `AWS_ACCESS_KEY_ID` / `DIGITALOCEAN_TOKEN`). Detection reads declared key **names** only (`bundle.vars`), never values — no keychain touch.
- **`setLeaseSecretsBundle()`** (readMeta/writeMeta) — the persist hook the upcoming `agents lease setup` wizard (Layer B) will call.

Net: set up a bundle once → `--lease` works with no env var and no flag forever after.

## Tests / verification

- 5 `pickLeaseBundleFromList` unit cases (picks HCLOUD bundle; matches AWS/DO keys; ignores non-token bundles; empty → undefined; first-match determinism).
- Full crabbox suite: **46 passing**. `tsc --noEmit`: **0 errors**.
- **End-to-end:** with `AGENTS_LEASE_SECRETS_BUNDLE` unset, `agents lease gc --dry-run` auto-detects `hetzner.com` and reaches crabbox (listed the 3 orphan boxes) — previously this required the env var.

## Next in RUSH-1728
Layer B — `agents lease setup` wizard + first-run detection (`resolveLeaseBundle()` yields nothing → open token page → validate → store → `setLeaseSecretsBundle`). Layer C — docs/skill + epic CHANGELOG.
