### PR TITLE
fix(factory): 0.9.294 — bundle runtime deps, guard against dep-less VSIX

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.9.294] - 2026-07-15
+
+- **Fix: extension failed to activate — every `agents.*` command reported "command not found" (e.g. `agents.dispatchTask`, `agents.configure`).** The published `0.9.293` VSIX shipped without its `node_modules`, so `require("yaml")` (in `core/agentInventory`, `sessions.persist`, `swarmifyConfig`) threw during `activate()`, aborting before any command registered. This release is a clean rebuild that bundles the runtime deps. To prevent recurrence, `scripts/build.sh` now unzips the freshly-packaged VSIX and hard-fails the build if `yaml`, `node-pty` (incl. its `darwin-arm64` native prebuild), `sql.js`, or `ws` are absent — a dependency-less package can no longer reach the marketplace. Source: `scripts/build.sh`.
+
 - **Factory Floor shows live plan progress for remote / device-dispatched agents (RUSH-1380).** The CLI now carries each session's latest `TodoWrite` on `ActiveSession.todos`; the remote adapter maps it onto the feed's checklist (previously hardcoded empty for status-only remote sessions), so a headless agent on another machine now renders an N/M pill in its header, the `CardChecklist` in its feed card, and a `TodoChecklist` in its detail pane. When there's no live tool action, the now-line falls back to the in-progress step. Source: `apps/factory/src/core/remoteSessions.ts` (`RemoteSession.todos`, `normalizeTodos`), `ui/settings/components/mission-control/floorAdapter.ts` (`toFloorAgentFromRemote`), `FeedItem.tsx`, `UnifiedAgentsPane.tsx`, `floor.css`.
 
 ## [0.9.292] - 2026-07-13

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -3,7 +3,7 @@
   "displayName": "Agents",
   "publisher": "swarmify",
   "description": "Run Claude, Codex, Gemini, Cursor, and other coding agents from one IDE workspace.",
-  "version": "0.9.292",
+  "version": "0.9.294",
   "license": "MIT",
   "author": "Muqsit Nawaz <dev@muqsitnawaz.com>",
   "icon": "assets/agents.png",
@@ -580,7 +580,7 @@
             "Never use tmux; always use a native VS Code editor terminal."
           ],
           "default": "auto",
-          "description": "How agent terminals are launched. 'auto' (default) runs agents inside a tmux session on macOS/Linux for uniform addressing, resume, and tracking \u2014 falling back to a native terminal on Windows or when tmux is missing. Cmd+Shift+H/V create tmux panes instead of VS Code editor splits when tmux is active."
+          "description": "How agent terminals are launched. 'auto' (default) runs agents inside a tmux session on macOS/Linux for uniform addressing, resume, and tracking — falling back to a native terminal on Windows or when tmux is missing. Cmd+Shift+H/V create tmux panes instead of VS Code editor splits when tmux is active."
         },
         "agents.worktreePerTerminal": {
           "type": "boolean",
@@ -600,7 +600,7 @@
         "agents.openaiApiKey": {
           "type": "string",
           "default": "",
-          "description": "OpenAI API key. Used by the Foreman voice coordinator (gpt-realtime-2). Autogit no longer uses this \u2014 commit messages are generated via `agents run claude --model haiku`."
+          "description": "OpenAI API key. Used by the Foreman voice coordinator (gpt-realtime-2). Autogit no longer uses this — commit messages are generated via `agents run claude --model haiku`."
         },
         "agents.commitGenTimeoutMs": {
           "type": "number",

--- a/apps/factory/scripts/build.sh
+++ b/apps/factory/scripts/build.sh
@@ -43,6 +43,34 @@ echo "Creating dist directory..."
 mkdir -p "$DIST_DIR"
 
 echo "Packaging extension..."
-bunx @vscode/vsce package --out "$DIST_DIR/swarm-ext-${VERSION}.vsix"
+VSIX_OUT="$DIST_DIR/swarm-ext-${VERSION}.vsix"
+bunx @vscode/vsce package --out "$VSIX_OUT"
 
-echo "Build complete: $DIST_DIR/swarm-ext-${VERSION}.vsix"
+# Integrity guard: the extension `require()`s these at activation time (yaml in
+# core/agentInventory, sessions.persist, swarmifyConfig; ws in foreman.audio;
+# node-pty + sql.js in terminals). If vsce ever prunes them from the VSIX the
+# extension throws on activate() and EVERY `agents.*` command becomes
+# "command not found" (this shipped once as 0.9.293). Fail the build here rather
+# than let a dependency-less package escape to the marketplace.
+echo "Verifying packaged runtime dependencies..."
+VSIX_FILES="$(unzip -Z1 "$VSIX_OUT")"
+MISSING=""
+for dep in yaml node-pty sql.js ws; do
+    if ! printf '%s\n' "$VSIX_FILES" | grep -q "^extension/node_modules/${dep}/package.json$"; then
+        MISSING="${MISSING} ${dep}"
+    fi
+done
+# node-pty's native binding for this host's arch must ship or terminals break.
+if ! printf '%s\n' "$VSIX_FILES" | grep -q "^extension/node_modules/node-pty/prebuilds/darwin-arm64/pty.node$"; then
+    MISSING="${MISSING} node-pty/darwin-arm64-prebuild"
+fi
+if [ -n "$MISSING" ]; then
+    echo "Error: VSIX is missing runtime dependencies:${MISSING}" >&2
+    echo "       Run 'bun install' in $PROJECT_ROOT and rebuild — a dependency-less" >&2
+    echo "       package fails to activate (every agents.* command 'not found')." >&2
+    rm -f "$VSIX_OUT"
+    exit 1
+fi
+echo "Runtime dependencies present in VSIX (yaml, node-pty + native, sql.js, ws)."
+
+echo "Build complete: $VSIX_OUT"

--- a/apps/factory/scripts/build.sh
+++ b/apps/factory/scripts/build.sh
@@ -55,14 +55,19 @@ bunx @vscode/vsce package --out "$VSIX_OUT"
 echo "Verifying packaged runtime dependencies..."
 VSIX_FILES="$(unzip -Z1 "$VSIX_OUT")"
 MISSING=""
+# Exact-line literal match (-xF): the deps contain regex metachars (sql.js) and
+# we want the top-level entry, not a substring.
 for dep in yaml node-pty sql.js ws; do
-    if ! printf '%s\n' "$VSIX_FILES" | grep -q "^extension/node_modules/${dep}/package.json$"; then
+    if ! printf '%s\n' "$VSIX_FILES" | grep -qxF "extension/node_modules/${dep}/package.json"; then
         MISSING="${MISSING} ${dep}"
     fi
 done
-# node-pty's native binding for this host's arch must ship or terminals break.
-if ! printf '%s\n' "$VSIX_FILES" | grep -q "^extension/node_modules/node-pty/prebuilds/darwin-arm64/pty.node$"; then
-    MISSING="${MISSING} node-pty/darwin-arm64-prebuild"
+# node-pty ships one prebuilt native binding per platform; `bun install` fetches
+# only the current host's triple. Check for THIS host's arch (not a hardcoded
+# one) so a Linux/x64 CI build doesn't false-fail on an otherwise valid package.
+PTY_ARCH="$(node -e "console.log(process.platform + '-' + process.arch)")"
+if ! printf '%s\n' "$VSIX_FILES" | grep -qxF "extension/node_modules/node-pty/prebuilds/${PTY_ARCH}/pty.node"; then
+    MISSING="${MISSING} node-pty/${PTY_ARCH}-prebuild"
 fi
 if [ -n "$MISSING" ]; then
     echo "Error: VSIX is missing runtime dependencies:${MISSING}" >&2


### PR DESCRIPTION
## Problem (user-visible)

Every new VSCodium/VS Code window showed toast errors like `command 'agents.dispatchTask' not found` and `command 'agents.configure' not found`, and none of the `agents.*` commands worked.

## Root cause (proven from the live exthost log)

The published **0.9.293** VSIX shipped **without `node_modules`**. The extension `require("yaml")` at activation time, so it threw during `activate()` before any command registered:

```
2026-07-15 13:09:42 [error] Activating extension swarmify.swarm-ext failed due to an error:
Error: Cannot find module 'yaml'
Require stack:
- …/swarmify.swarm-ext-0.9.293/out/core/swarmifyConfig.js
- …/out/vscode/swarmifyConfig.vscode.js
- …/out/vscode/extension.js
```

`activate()` aborting means `registerCommand` never runs → every `agents.*` command is "not found".

- `0.9.291` / `0.9.292` VSIX: ship `node_modules/{yaml,node-pty,sql.js,ws}` ✔
- `0.9.293` VSIX: **no `node_modules` at all** ✘

## Fix

- **Clean rebuild → 0.9.294**, bundling `yaml`, `node-pty` (+ `darwin-arm64` native prebuild), `sql.js`, `ws`.
- **`scripts/build.sh` integrity guard**: after `vsce package`, unzip the VSIX and hard-fail the build if any of those runtime deps (or node-pty's native prebuild) is missing. A dependency-less package can no longer reach the marketplace.

## Verification (deterministic)

Same module-resolution root as the failing `swarmifyConfig.js`, against the **installed** dirs:

```
0.9.293 (installed): require("yaml") -> MODULE_NOT_FOUND Cannot find module 'yaml'   # the exact crash
0.9.294 (installed): yaml, ws, sql.js, node-pty  -> all resolve from <ext>/node_modules/…
```

Build guard output on this VSIX: `Runtime dependencies present in VSIX (yaml, node-pty + native, sql.js, ws)` (566 node_modules files, 23.46 MB). Installed to Code + Codium.

Session transcript (confidential): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/7cf76e2b-9811-40fb-82a4-e095f3dd163c.jsonl`