### PR TITLE
feat(lease): agents lease setup wizard + first-run detection (RUSH-1728 Layer B)

### DIFF
--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -494,6 +494,19 @@ export function registerRunCommand(program: Command): void {
           process.exit(1);
         }
         const backend = typeof options.lease === 'string' ? options.lease : undefined;
+
+        // First-run: no provider credential resolves (no env var, no config, no
+        // detectable bundle) → guide the user through one-time setup, then continue.
+        const { resolveLeaseBundle } = await import('../lib/crabbox/cli.js');
+        if (!resolveLeaseBundle()) {
+          const { runLeaseSetup } = await import('./lease.js');
+          const ok = await runLeaseSetup({ provider: backend ?? 'hetzner' });
+          if (!ok) {
+            console.error(chalk.yellow('Leasing needs a cloud provider set up. Run `agents lease setup` and retry.'));
+            process.exit(1);
+          }
+        }
+
         const { detectSignedInRuntimes, resolveClaudeCredentialsBlob, inferLeaseRuntime } = await import('../lib/crabbox/runtimes.js');
         const { leaseAndRun } = await import('../lib/crabbox/lease.js');
         const { getConfiguredRunStrategy, resolveRunVersion } = await import('../lib/rotate.js');

--- a/apps/cli/src/commands/lease.test.ts
+++ b/apps/cli/src/commands/lease.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { validateHetznerToken } from './lease.js';
+
+const fakeFetch = (status: number, throws = false): typeof fetch =>
+  (async () => {
+    if (throws) throw new Error('network down');
+    return { ok: status >= 200 && status < 300, status } as Response;
+  }) as unknown as typeof fetch;
+
+describe('validateHetznerToken', () => {
+  it('returns valid on 200', async () => {
+    expect(await validateHetznerToken('t', fakeFetch(200))).toBe('valid');
+  });
+
+  it('returns invalid on 401 and 403 (bad/insufficient token)', async () => {
+    expect(await validateHetznerToken('t', fakeFetch(401))).toBe('invalid');
+    expect(await validateHetznerToken('t', fakeFetch(403))).toBe('invalid');
+  });
+
+  it('returns unreachable on an unexpected status', async () => {
+    expect(await validateHetznerToken('t', fakeFetch(500))).toBe('unreachable');
+  });
+
+  it('returns unreachable when the request throws (offline)', async () => {
+    expect(await validateHetznerToken('t', fakeFetch(0, true))).toBe('unreachable');
+  });
+});

--- a/apps/cli/src/commands/lease.ts
+++ b/apps/cli/src/commands/lease.ts
@@ -9,8 +9,13 @@
  */
 
 import type { Command } from 'commander';
+import { spawn } from 'child_process';
 import chalk from 'chalk';
-import { crabboxList, reapSafeOrphans, reapOrphans, type CrabboxBox } from '../lib/crabbox/cli.js';
+import { crabboxList, reapSafeOrphans, reapOrphans, setLeaseSecretsBundle, type CrabboxBox } from '../lib/crabbox/cli.js';
+import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
+import { bundleExists, readBundle, writeBundle, keychainRef, bundleItemStore } from '../lib/secrets/bundles.js';
+import { secretsKeychainItem } from '../lib/secrets/index.js';
+import type { SecretsBundle } from '../lib/secrets/bundles.js';
 
 function fmtIdle(box: CrabboxBox): string {
   if (box.lastTouchedAt === null) return 'idle ?';
@@ -18,10 +23,126 @@ function fmtIdle(box: CrabboxBox): string {
   return `idle since ${iso}Z`;
 }
 
+const HETZNER_BUNDLE = 'hetzner.com';
+const HCLOUD_KEY = 'HCLOUD_TOKEN';
+const HETZNER_CONSOLE_URL = 'https://console.hetzner.cloud/';
+
+/** Best-effort: open a URL in the user's default browser. Never throws. */
+function openUrl(url: string): void {
+  const cmd = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'cmd' : 'xdg-open';
+  const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url];
+  try {
+    const p = spawn(cmd, args, { stdio: 'ignore', detached: true });
+    p.on('error', () => {});
+    p.unref();
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Validate a Hetzner token against the live API. Exported for unit tests (fetch injectable). */
+export async function validateHetznerToken(
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<'valid' | 'invalid' | 'unreachable'> {
+  try {
+    const res = await fetchImpl('https://api.hetzner.cloud/v1/servers?per_page=1', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) return 'valid';
+    if (res.status === 401 || res.status === 403) return 'invalid';
+    return 'unreachable';
+  } catch {
+    return 'unreachable';
+  }
+}
+
+/**
+ * One-time credential setup for `agents run --lease` (Hetzner today). Opens the
+ * token page, collects a token, validates it against the live API, stores it in
+ * the keychain bundle `hetzner.com`, and persists it as the default lease bundle
+ * (so `--lease` needs no env var or flag afterward). Returns true on success.
+ * Never throws for expected outcomes (non-interactive, cancel, repeated failure).
+ */
+export async function runLeaseSetup(opts: { provider?: string } = {}): Promise<boolean> {
+  const provider = opts.provider ?? 'hetzner';
+  if (provider !== 'hetzner') {
+    console.error(chalk.yellow(`lease setup: only 'hetzner' is supported today (got '${provider}').`));
+    return false;
+  }
+  if (!isInteractiveTerminal()) {
+    console.error(
+      chalk.red(
+        'lease setup needs an interactive terminal. For CI/headless, set AGENTS_LEASE_SECRETS_BUNDLE ' +
+          'or store HCLOUD_TOKEN in a keychain bundle.',
+      ),
+    );
+    return false;
+  }
+
+  console.error(chalk.bold('\nSet up leasing (Hetzner) — one time (~30s):'));
+  console.error(chalk.dim('Opening the Hetzner console. Create/select a project, then Security → API Tokens →'));
+  console.error(chalk.dim('Generate a token with Read & Write permission, and copy it.\n'));
+  openUrl(HETZNER_CONSOLE_URL);
+
+  const { password } = await import('@inquirer/prompts');
+  const ora = (await import('ora')).default;
+
+  try {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const token = (await password({ message: 'Paste your Hetzner API token:', mask: true })).trim();
+      if (!token) {
+        console.error(chalk.yellow('No token entered.'));
+        continue;
+      }
+
+      const spinner = ora('Validating token against the Hetzner API…').start();
+      const result = await validateHetznerToken(token);
+      if (result === 'invalid') {
+        spinner.fail('Token rejected by Hetzner (401/403). Try again.');
+        continue;
+      }
+      if (result === 'unreachable') spinner.warn('Could not reach the Hetzner API to validate — storing anyway.');
+      else spinner.succeed('Token valid — Hetzner API reachable.');
+
+      // Store into the `hetzner.com` keychain bundle (mirrors writeSyncBundle).
+      const bundle: SecretsBundle = bundleExists(HETZNER_BUNDLE)
+        ? readBundle(HETZNER_BUNDLE)
+        : { name: HETZNER_BUNDLE, description: 'Hetzner Cloud API token for crabbox leases', vars: {} };
+      const store = bundleItemStore(bundle.backend);
+      store.set(secretsKeychainItem(HETZNER_BUNDLE, HCLOUD_KEY), token);
+      bundle.vars[HCLOUD_KEY] = keychainRef(HCLOUD_KEY);
+      writeBundle(bundle);
+
+      setLeaseSecretsBundle(HETZNER_BUNDLE);
+      console.error(chalk.green(`\n✔ Stored in keychain bundle '${HETZNER_BUNDLE}' and set as the default lease provider.`));
+      console.error(chalk.dim('  Run `agents run <agent> "…" --lease` — no env var, no flag needed.'));
+      return true;
+    }
+    console.error(chalk.yellow('lease setup: no valid token after 3 attempts — aborted.'));
+    return false;
+  } catch (e) {
+    if (isPromptCancelled(e)) {
+      console.error(chalk.yellow('lease setup cancelled.'));
+      return false;
+    }
+    throw e;
+  }
+}
+
 export function registerLeaseCommand(program: Command): void {
   const lease = program
     .command('lease')
     .description('Manage the disposable cloud boxes used by `agents run --lease`.');
+
+  lease
+    .command('setup')
+    .description('One-time credential setup so `agents run --lease` works with no env var or flag.')
+    .option('--provider <name>', 'Cloud provider (only hetzner today)', 'hetzner')
+    .action(async (opts: { provider?: string }) => {
+      const ok = await runLeaseSetup({ provider: opts.provider });
+      process.exit(ok ? 0 : 1);
+    });
 
   lease
     .command('gc')


### PR DESCRIPTION
## What

Adds `agents lease setup` and first-run detection so a new user's first `agents run --lease` guides itself through credential setup instead of erroring — Layer B of RUSH-1728. Builds on merged Layer A (config key + auto-detect).

## Why

Before Layer A/B, `--lease` with no credential died with a raw "missing hcloud token". Layer A added the config key + auto-detect; this closes the loop with a guided one-time setup and wires it into the run.

## Change

- **`agents lease setup [--provider hetzner]`** — opens the Hetzner console token page in the browser, prompts for the token (masked), **validates it live** (`GET https://api.hetzner.cloud/v1/servers` — 401/403 → retry, up to 3×), stores it in the `hetzner.com` keychain bundle (mirrors `writeSyncBundle`: `bundleItemStore` + `keychainRef` + `writeBundle`), and persists it as the default lease bundle via `setLeaseSecretsBundle` (the caller Layer A's review noted was missing). After setup, `--lease` needs **no env var and no flag**.
- **First-run detection** in the `--lease` block (`exec.ts`): when `resolveLeaseBundle()` yields nothing, run the wizard, then continue the original run.
- `validateHetznerToken` is exported with an **injectable fetch** for unit testing.
- Non-interactive shells refuse setup with a clear message (use `AGENTS_LEASE_SECRETS_BUNDLE` / a bundle).

## Tests / verification

- 4 `validateHetznerToken` unit cases (200→valid; 401/403→invalid; 500→unreachable; throw→unreachable).
- `tsc --noEmit`: **0 errors** against the merged Layer A `cli.ts`. Full suite: **50 passing**.
- `agents lease setup --help` registers correctly.
- The interactive paste→validate→store flow is verified on the released binary post-release (needs a TTY + a real token).

## Next in RUSH-1728
Layer C — `agents run --lease` skill doc (drafted) + CHANGELOG entry for the epic, then cut the agents-cli release.
