### PR TITLE
security: contain untrusted paths in routine names and session-sync pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Security
+
+- **Path-traversal containment for two untrusted-input filesystem sinks.**
+  - Routine job names (from routine YAML `name:` / file basename, which can arrive via a
+    synced user/system config repo) are now contained to a single path segment beneath
+    the routines dir. A crafted name such as `../../../..` can no longer steer the overlay
+    HOME setup — whose teardown does a recursive `rmSync` — at a path outside
+    `~/.agents/routines`. (`apps/cli/src/lib/sandbox.ts`, validated in
+    `apps/cli/src/lib/routines.ts`.)
+  - Session-sync **pull** now validates the peer-controlled `machine` and `relKey` fields
+    before writing a mirrored transcript, matching the guard the push side already applied.
+    A malicious fleet peer can no longer use a manifest `relKey` like
+    `../../../.ssh/authorized_keys` to write attacker content outside the backups mirror.
+    (`apps/cli/src/lib/session/sync/agents.ts`.)
+  - Shared containment helpers `isSafeSegmentName` / `assertWithin` added to
+    `apps/cli/src/lib/paths.ts`.
+
 ### Added
 
 - **`agents run --lease` is now frictionless end-to-end (RUSH-1723).** Leasing a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,25 @@
 
 ### Security
 
-- **Path-traversal containment for two untrusted-input filesystem sinks.**
+- **Path-traversal containment for untrusted-input filesystem sinks.**
   - Routine job names (from routine YAML `name:` / file basename, which can arrive via a
     synced user/system config repo) are now contained to a single path segment beneath
-    the routines dir. A crafted name such as `../../../..` can no longer steer the overlay
-    HOME setup — whose teardown does a recursive `rmSync` — at a path outside
-    `~/.agents/routines`. (`apps/cli/src/lib/sandbox.ts`, validated in
-    `apps/cli/src/lib/routines.ts`.)
+    the routines dir at **every** sink. A crafted name such as `../../../..` can no longer
+    steer the overlay HOME setup — whose teardown does a recursive `rmSync`
+    (`apps/cli/src/lib/sandbox.ts`) — nor the per-run directory that the daemon's
+    load/schedule path `mkdirSync`s and writes `stdout.log`/`meta.json`/`report.md` into
+    (`getJobRunsDir`/`getRunDir` in `apps/cli/src/lib/routines.ts`, used by
+    `apps/cli/src/lib/runner.ts`), outside `~/.agents/routines` and
+    `~/.agents/.history/runs`. `validateJob` also rejects unsafe names.
   - Session-sync **pull** now validates the peer-controlled `machine` and `relKey` fields
     before writing a mirrored transcript, matching the guard the push side already applied.
     A malicious fleet peer can no longer use a manifest `relKey` like
-    `../../../.ssh/authorized_keys` to write attacker content outside the backups mirror.
-    (`apps/cli/src/lib/session/sync/agents.ts`.)
+    `../../../.ssh/authorized_keys` to write attacker content outside the backups mirror
+    (`apps/cli/src/lib/session/sync/agents.ts`). The new containment rejection is caught
+    per-session in `apps/cli/src/lib/session/sync/sync.ts` and around the umbrella-sync
+    stage in `apps/cli/src/lib/sync-umbrella.ts`, so one malicious manifest entry can't
+    wedge the whole sync tick (skipping `savePullState`) or the `agents sync` reconcile
+    stage for everyone else.
   - Shared containment helpers `isSafeSegmentName` / `assertWithin` added to
     `apps/cli/src/lib/paths.ts`.
 

--- a/apps/cli/src/lib/paths.ts
+++ b/apps/cli/src/lib/paths.ts
@@ -1,6 +1,20 @@
 import * as path from 'path';
 
 /**
+ * True when `name` is a safe single path segment: non-empty, not '.'/'..',
+ * free of path separators and null bytes, and within the filename length limit.
+ * Dot-prefixed names like '.env.example' are allowed.
+ */
+export function isSafeSegmentName(name: string): boolean {
+  return (
+    !!name &&
+    name !== '.' && name !== '..' &&
+    !/[\/\\\x00]/.test(name) &&
+    name.length <= 255
+  );
+}
+
+/**
  * Resolve base + name while preventing path-traversal attacks.
  * Rejects path separators, null bytes, '.' and '..', and any resolved path
  * that escapes the base directory. Dot-prefixed names like '.env.example'
@@ -8,15 +22,25 @@ import * as path from 'path';
  * Allows spaces, unicode, and other common filename characters.
  */
 export function safeJoin(base: string, name: string): string {
-  if (
-    !name ||
-    name === '.' || name === '..' ||
-    /[\/\\\x00]/.test(name) ||
-    name.length > 255
-  ) {
+  if (!isSafeSegmentName(name)) {
     throw new Error(`Invalid name: ${name}`);
   }
   const resolved = path.resolve(base, name);
   if (!resolved.startsWith(path.resolve(base) + path.sep)) throw new Error(`Path escape: ${name}`);
+  return resolved;
+}
+
+/**
+ * Assert that `target` (which may legitimately contain path separators, e.g. a
+ * multi-segment relative key) stays within `root` after normalization. Use this
+ * where a caller must accept nested relative paths but the input is untrusted —
+ * `safeJoin` is stricter and only allows single segments.
+ */
+export function assertWithin(root: string, target: string): string {
+  const base = path.resolve(root);
+  const resolved = path.resolve(target);
+  if (resolved !== base && !resolved.startsWith(base + path.sep)) {
+    throw new Error(`Path escape: ${target}`);
+  }
   return resolved;
 }

--- a/apps/cli/src/lib/routines.test.ts
+++ b/apps/cli/src/lib/routines.test.ts
@@ -3,8 +3,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as yaml from 'yaml';
-import { validateJob, validateTrigger, normalizeTriggerEvent, writeJob, readJob, deleteJob, listJobs, jobRunsOnThisDevice, checkJobDeviceEligibility, type JobConfig } from './routines.js';
-import { getRoutinesDir, getSystemRoutinesDir, ensureAgentsDir } from './state.js';
+import { validateJob, validateTrigger, normalizeTriggerEvent, writeJob, readJob, deleteJob, listJobs, jobRunsOnThisDevice, checkJobDeviceEligibility, getJobRunsDir, getRunDir, type JobConfig } from './routines.js';
+import { getRoutinesDir, getSystemRoutinesDir, getRunsDir, ensureAgentsDir } from './state.js';
 
 /** Minimal valid schedule-based job. */
 function baseJob(partial: Partial<JobConfig> = {}): Partial<JobConfig> {
@@ -408,5 +408,41 @@ describe('writeJob extension handling', () => {
       if (fs.existsSync(ymlFile)) fs.unlinkSync(ymlFile);
       if (fs.existsSync(yamlFile)) fs.unlinkSync(yamlFile);
     }
+  });
+});
+
+describe('routine name path containment (C4)', () => {
+  const runsDir = path.resolve(getRunsDir());
+
+  it('validateJob rejects a traversal name', () => {
+    expect(validateJob(baseJob({ schedule: '0 3 * * *', name: '../../../../etc' })))
+      .toContain(
+        `invalid name "../../../../etc": must be a single path segment ` +
+        `(no '/', '\\\\', or null bytes, and not '.' or '..')`,
+      );
+  });
+
+  it('validateJob rejects a name with a separator', () => {
+    const errs = validateJob(baseJob({ schedule: '0 3 * * *', name: 'a/b' }));
+    expect(errs.some(e => e.startsWith('invalid name'))).toBe(true);
+  });
+
+  it('validateJob accepts a normal single-segment name', () => {
+    expect(validateJob(baseJob({ schedule: '0 3 * * *', name: 'daily-standup' }))).toEqual([]);
+  });
+
+  // getRunDir is the run-directory sink reached on the daemon's load/schedule
+  // path (runner.ts executeJob/executeJobDetached) — which never calls
+  // validateJob — so it must contain the untrusted name itself.
+  it('getJobRunsDir / getRunDir contain a benign name under the runs dir', () => {
+    const p = getRunDir('daily-standup', 'run-1');
+    expect(p).toBe(path.join(runsDir, 'daily-standup', 'run-1'));
+    expect(path.resolve(p).startsWith(runsDir + path.sep)).toBe(true);
+  });
+
+  it('getRunDir rejects a traversal name so mkdirSync/writes cannot escape the runs dir', () => {
+    expect(() => getRunDir('../../../../tmp/evil-routine', 'run-1')).toThrow();
+    expect(() => getJobRunsDir('..')).toThrow();
+    expect(() => getJobRunsDir('a/b')).toThrow();
   });
 });

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import * as yaml from 'yaml';
 import { Cron } from 'croner';
 import { getRoutinesDir, getSystemRoutinesDir, getRunsDir, ensureAgentsDir, getProjectRoutinesDir } from './state.js';
-import { safeJoin } from './paths.js';
+import { safeJoin, isSafeSegmentName } from './paths.js';
 import { atomicWriteFileSync } from './fs-atomic.js';
 import type { AgentId } from './types.js';
 import { ALL_AGENT_IDS } from './agents.js';
@@ -404,6 +404,14 @@ export function validateJob(config: Partial<JobConfig>): string[] {
 
   if (!config.name || typeof config.name !== 'string') {
     errors.push('name is required');
+  } else if (!isSafeSegmentName(config.name)) {
+    // The name becomes a filesystem path segment (overlay HOME under the
+    // routines dir). Reject separators, '.'/'..', and null bytes so a synced
+    // config can't traverse out of ~/.agents/routines.
+    errors.push(
+      `invalid name ${JSON.stringify(config.name)}: must be a single path segment ` +
+      `(no '/', '\\\\', or null bytes, and not '.' or '..')`,
+    );
   }
   const hasSchedule = Boolean(config.schedule && typeof config.schedule === 'string');
   const hasTrigger = config.trigger !== undefined;

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -587,7 +587,7 @@ export function resolveJobPrompt(config: JobConfig): string {
   // Last report (special handling)
   const latestRun = getLatestRun(config.name);
   if (latestRun) {
-    const reportPath = path.join(getRunsDir(), config.name, latestRun.runId, 'report.md');
+    const reportPath = path.join(getJobRunsDir(config.name), latestRun.runId, 'report.md');
     if (fs.existsSync(reportPath)) {
       const report = fs.readFileSync(reportPath, 'utf-8');
       prompt = prompt.replace(/\{last_report\}/g, report);
@@ -625,8 +625,7 @@ export function parseTimeout(timeout: string): number | null {
 
 /** List all run metadata entries for a job, sorted chronologically. */
 export function listRuns(jobName: string): RunMeta[] {
-  const runsDir = getRunsDir();
-  const jobRunsDir = path.join(runsDir, jobName);
+  const jobRunsDir = getJobRunsDir(jobName);
   if (!fs.existsSync(jobRunsDir)) return [];
 
   const entries = fs.readdirSync(jobRunsDir, { withFileTypes: true })
@@ -651,14 +650,14 @@ export function getLatestRun(jobName: string): RunMeta | null {
 /** Persist run metadata to its run directory as meta.json. */
 export function writeRunMeta(meta: RunMeta): void {
   ensureAgentsDir();
-  const runDir = path.join(getRunsDir(), meta.jobName, meta.runId);
+  const runDir = path.join(getJobRunsDir(meta.jobName), meta.runId);
   fs.mkdirSync(runDir, { recursive: true });
   fs.writeFileSync(path.join(runDir, 'meta.json'), JSON.stringify(meta, null, 2), 'utf-8');
 }
 
 /** Read run metadata from disk. Returns null if missing or corrupt. */
 export function readRunMeta(jobName: string, runId: string): RunMeta | null {
-  const metaPath = path.join(getRunsDir(), jobName, runId, 'meta.json');
+  const metaPath = path.join(getJobRunsDir(jobName), runId, 'meta.json');
   if (!fs.existsSync(metaPath)) return null;
   try {
     return JSON.parse(fs.readFileSync(metaPath, 'utf-8')) as RunMeta;
@@ -667,9 +666,21 @@ export function readRunMeta(jobName: string, runId: string): RunMeta | null {
   }
 }
 
+/**
+ * Runs directory for a single job, with the (untrusted) job name contained to a
+ * single segment beneath the runs dir — same guard as `getJobHomePath`. The name
+ * comes from routine YAML and can arrive via a synced config repo; every runs-dir
+ * sink (run dir, meta read/write, last-report read) routes through here so a
+ * crafted `name` like `../../../../tmp/x` can't `mkdirSync`/write `stdout.log`,
+ * `meta.json`, or `report.md` outside `~/.agents/.history/runs`.
+ */
+export function getJobRunsDir(jobName: string): string {
+  return safeJoin(getRunsDir(), jobName);
+}
+
 /** Get the filesystem path for a specific run's directory. */
 export function getRunDir(jobName: string, runId: string): string {
-  return path.join(getRunsDir(), jobName, runId);
+  return path.join(getJobRunsDir(jobName), runId);
 }
 
 /** Discover routine YAML files in a repository's routines/ directory. */

--- a/apps/cli/src/lib/sandbox.test.ts
+++ b/apps/cli/src/lib/sandbox.test.ts
@@ -1,7 +1,7 @@
 
 import { describe, it, expect } from 'vitest';
-import { buildSpawnEnv } from './sandbox.js';
-import { getUserAgentsDir } from './state.js';
+import { buildSpawnEnv, getJobHomePath } from './sandbox.js';
+import { getUserAgentsDir, getRoutinesDir } from './state.js';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -39,5 +39,35 @@ describe('buildSpawnEnv', () => {
       if (prev === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
       else process.env.CLAUDE_CODE_OAUTH_TOKEN = prev;
     }
+  });
+});
+
+describe('getJobHomePath — routine-name path containment (C4)', () => {
+  const routinesDir = path.resolve(getRoutinesDir());
+
+  it('returns a contained overlay path for a normal job name', () => {
+    const p = getJobHomePath('daily-standup');
+    expect(p).toBe(path.join(routinesDir, 'daily-standup', 'home'));
+    expect(p.startsWith(routinesDir + path.sep)).toBe(true);
+  });
+
+  it('allows dot-prefixed names', () => {
+    expect(() => getJobHomePath('.hidden-job')).not.toThrow();
+  });
+
+  // A synced user/system routine YAML controls `name`; without containment,
+  // `../../../..` steers cleanJobHome's recursive rmSync at the user's home.
+  it('rejects parent-traversal names so rmSync cannot escape the routines dir', () => {
+    expect(() => getJobHomePath('../../../../..')).toThrow();
+    expect(() => getJobHomePath('..')).toThrow();
+  });
+
+  it('rejects names containing path separators', () => {
+    expect(() => getJobHomePath('a/b')).toThrow();
+    expect(() => getJobHomePath('a\\b')).toThrow();
+  });
+
+  it('rejects names with null bytes', () => {
+    expect(() => getJobHomePath('evil\x00')).toThrow();
   });
 });

--- a/apps/cli/src/lib/sandbox.ts
+++ b/apps/cli/src/lib/sandbox.ts
@@ -13,6 +13,7 @@ import * as os from 'os';
 import type { JobConfig } from './routines.js';
 import { setGeminiAutoUpdateDisabled, updateGeminiSettings } from './gemini-settings.js';
 import { getRoutinesDir, getUserAgentsDir } from './state.js';
+import { safeJoin } from './paths.js';
 import { createLink } from './platform/index.js';
 
 function resolveRealHome(): string {
@@ -90,9 +91,17 @@ export function buildSpawnEnv(overlayHome: string, extraEnv?: Record<string, str
   return env;
 }
 
-/** Get the overlay HOME directory path for a named job. */
+/**
+ * Get the overlay HOME directory path for a named job.
+ *
+ * The job name originates from routine YAML (`name:` field or file basename),
+ * which can arrive from a synced user/system config repo. `safeJoin` contains
+ * it to a single segment beneath the routines dir so a crafted name such as
+ * `../../../..` cannot steer `prepareJobHome`/`cleanJobHome` (which does a
+ * recursive `rmSync`) at a path outside `~/.agents/routines`.
+ */
 export function getJobHomePath(name: string): string {
-  return path.join(getRoutinesDir(), name, 'home');
+  return path.join(safeJoin(getRoutinesDir(), name), 'home');
 }
 
 /** Create a fresh overlay HOME for a job, including agent config and allowed-dir symlinks. */

--- a/apps/cli/src/lib/session/sync/agents.test.ts
+++ b/apps/cli/src/lib/session/sync/agents.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { SYNC_AGENTS, objectKey, isMergeableFile } from './agents.js';
+import * as path from 'path';
+import { SYNC_AGENTS, objectKey, isMergeableFile, mirrorPath } from './agents.js';
+import { getHistoryDir } from '../../state.js';
 
 function spec(id: string) {
   const s = SYNC_AGENTS.find(a => a.id === id);
@@ -98,5 +100,36 @@ describe('isMergeableFile (append-only union vs mutable-blob LWW)', () => {
   it('file-shaped agents (no mergeableExts): every file unions, as before', () => {
     expect(isMergeableFile(claude, 'proj/abc.jsonl')).toBe(true);
     expect(isMergeableFile(claude, 'proj/whatever.json')).toBe(true);
+  });
+});
+
+describe('mirrorPath — peer-controlled path containment (C1)', () => {
+  const claude = spec('claude');
+  const backupsRoot = path.resolve(getHistoryDir(), 'backups', claude.id);
+
+  it('returns a contained path for a benign machine + relKey', () => {
+    const p = mirrorPath(claude, 'laptop-a', 'projects/sess-1.jsonl');
+    expect(path.resolve(p).startsWith(backupsRoot + path.sep)).toBe(true);
+    expect(p.endsWith(path.join('laptop-a', claude.subdir, 'projects', 'sess-1.jsonl'))).toBe(true);
+  });
+
+  // A malicious fleet peer controls `relKey` in the manifest it PUTs to the
+  // shared bucket; without containment this reaches fs.writeFileSync on the
+  // pulling machine → overwrite ~/.ssh/authorized_keys → fleet compromise.
+  it('rejects a relKey that traverses out of the mirror root', () => {
+    expect(() => mirrorPath(claude, 'evil-peer', '../../../../../../.ssh/authorized_keys')).toThrow();
+  });
+
+  it('rejects a relKey with a mid-path parent escape', () => {
+    expect(() => mirrorPath(claude, 'evil-peer', 'projects/../../../../etc/cron.d/x')).toThrow();
+  });
+
+  it('rejects a machine segment that is itself a traversal', () => {
+    expect(() => mirrorPath(claude, '..', 'sess.jsonl')).toThrow();
+    expect(() => mirrorPath(claude, '../..', 'sess.jsonl')).toThrow();
+  });
+
+  it('rejects a machine segment containing separators', () => {
+    expect(() => mirrorPath(claude, 'a/b', 'sess.jsonl')).toThrow();
   });
 });

--- a/apps/cli/src/lib/session/sync/agents.ts
+++ b/apps/cli/src/lib/session/sync/agents.ts
@@ -18,6 +18,7 @@ import * as path from 'path';
 import { getHistoryDir } from '../../state.js';
 import { getAgentSessionDirs } from '../discover.js';
 import { walkForFiles } from '../../fs-walk.js';
+import { isSafeSegmentName, assertWithin } from '../../paths.js';
 
 const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
 
@@ -197,9 +198,26 @@ export function localSessionIds(spec: SyncAgentSpec): Set<string> {
   return new Set(listLocalTranscripts(spec).map(t => t.sessionId));
 }
 
-/** Absolute mirror path for a remote machine's transcript — lands in a scan root. */
+/**
+ * Absolute mirror path for a remote machine's transcript — lands in a scan root.
+ *
+ * `machine` and `relKey` come from a peer's manifest (untrusted: any peer with
+ * write access to the shared bucket controls them). Unlike the push side, which
+ * already drops `relKey` starting with `..` when building the manifest, the pull
+ * side would otherwise `fs.writeFileSync` at this path with peer-controlled
+ * content. `machine` is constrained to a single segment and `relKey` (which may
+ * legitimately nest, e.g. `projects/x/y.jsonl`) is contained beneath the
+ * per-machine mirror root, so a crafted `relKey` like `../../../.ssh/authorized_keys`
+ * cannot write outside `~/.agents/.history/backups/<agent>/<machine>/<subdir>`.
+ */
 export function mirrorPath(spec: SyncAgentSpec, machine: string, relKey: string): string {
-  return path.join(getHistoryDir(), 'backups', spec.id, machine, spec.subdir, relKey);
+  if (!isSafeSegmentName(machine)) {
+    throw new Error(`Unsafe sync machine segment: ${JSON.stringify(machine)}`);
+  }
+  const machineRoot = path.join(getHistoryDir(), 'backups', spec.id, machine, spec.subdir);
+  const dest = path.join(machineRoot, relKey);
+  assertWithin(machineRoot, dest);
+  return dest;
 }
 
 /**

--- a/apps/cli/src/lib/session/sync/sync.test.ts
+++ b/apps/cli/src/lib/session/sync/sync.test.ts
@@ -87,6 +87,31 @@ describe('resolveMirrorWrite', () => {
   });
 });
 
+describe('resolveMirrorWrite / reconcileCopies — C1 containment propagates to the caller', () => {
+  // mirrorPath() rejects unsafe peer-controlled machine/relKey; that rejection
+  // surfaces here, at the exact call the pullAndReconcile loop now wraps in a
+  // per-session try/catch so one bad manifest entry can't wedge the whole tick.
+  it('resolveMirrorWrite throws on a relKey that escapes the mirror root', () => {
+    const list = [copy('mac', 's1', 'h1', '../../../../../../.ssh/authorized_keys')];
+    expect(() => resolveMirrorWrite(claude, list, ['ssh-ed25519 AAAA...\n'])).toThrow();
+  });
+
+  it('reconcileCopies throws on a traversal relKey (the sync.ts:363 sink)', () => {
+    const list = [copy('mac', 's1', 'h1', 'p/../../../../etc/cron.d/x')];
+    expect(() => reconcileCopies(claude, list, ['* * * * * root sh\n'])).toThrow();
+  });
+
+  it('reconcileCopies throws on a malicious machine segment', () => {
+    const list = [copy('..', 's1', 'h1', 'p/s1.jsonl')];
+    expect(() => reconcileCopies(claude, list, ['x\n'])).toThrow();
+  });
+
+  it('a benign relKey still resolves without throwing', () => {
+    const list = [copy('mac', 's1', 'h1', 'proj/s1.jsonl')];
+    expect(() => resolveMirrorWrite(claude, list, ['x\n'])).not.toThrow();
+  });
+});
+
 describe('reconcileCopies', () => {
   it('all copies present: unions and resolves a write', () => {
     const list = [copy('zion', 's1', 'h1', 'p/zion.jsonl'), copy('s0', 's1', 'h2', 'p/s0.jsonl')];

--- a/apps/cli/src/lib/session/sync/sync.ts
+++ b/apps/cli/src/lib/session/sync/sync.ts
@@ -346,23 +346,35 @@ async function pullAndReconcile(r2: R2Client, me: string, encKey: Buffer | null,
     // rather than materializing half a session and stamping it done.
     const writes: Array<{ dest: string; content: string; merged: boolean }> = [];
     let incomplete = false;
-    for (const group of byRel.values()) {
-      const fetched: Array<string | null> = [];
-      for (const c of group) {
-        try {
-          const body = await r2.get(objectKey(c.machine, agentId, sessionId, spec.dirShaped ? c.entry.relKey : undefined));
-          // Decrypt before the body reaches the CRDT union — merge + mirror always
-          // operate on plaintext. A legacy plaintext object passes through
-          // untouched; an envelope without a key throws (surfaced below).
-          fetched.push(body === null ? null : decryptTranscriptBody(body, encKey));
-        } catch (err) {
-          result.errors.push(`get ${c.machine}/${sessionId}/${c.entry.relKey}: ${(err as Error).message}`);
-          fetched.push(null);
+    try {
+      for (const group of byRel.values()) {
+        const fetched: Array<string | null> = [];
+        for (const c of group) {
+          try {
+            const body = await r2.get(objectKey(c.machine, agentId, sessionId, spec.dirShaped ? c.entry.relKey : undefined));
+            // Decrypt before the body reaches the CRDT union — merge + mirror always
+            // operate on plaintext. A legacy plaintext object passes through
+            // untouched; an envelope without a key throws (surfaced below).
+            fetched.push(body === null ? null : decryptTranscriptBody(body, encKey));
+          } catch (err) {
+            result.errors.push(`get ${c.machine}/${sessionId}/${c.entry.relKey}: ${(err as Error).message}`);
+            fetched.push(null);
+          }
         }
+        const resolved = reconcileCopies(spec, group, fetched);
+        if (!resolved) { incomplete = true; break; }
+        writes.push(resolved);
       }
-      const resolved = reconcileCopies(spec, group, fetched);
-      if (!resolved) { incomplete = true; break; }
-      writes.push(resolved);
+    } catch (err) {
+      // `reconcileCopies` -> `mirrorPath` now rejects unsafe peer-controlled
+      // machine/relKey (C1 containment). That rejection must stay scoped to this
+      // one session: without this catch a single malicious/malformed manifest
+      // entry would throw out of the whole `pending` loop, skip the
+      // `savePullState` below, and re-throw every tick — a peer-triggered DoS on
+      // everyone else's session-sync. Record it and skip; never stamp pull-state
+      // for a rejected entry (so nothing marks the bad session "done").
+      result.errors.push(`resolve mirror ${agentId}/${sessionId}: ${(err as Error).message}`);
+      continue;
     }
     if (incomplete) continue; // retry next tick, session intact
 

--- a/apps/cli/src/lib/sync-umbrella.ts
+++ b/apps/cli/src/lib/sync-umbrella.ts
@@ -74,7 +74,7 @@ export interface UmbrellaResult {
   plan: UmbrellaPlan;
   repos?: { pulled: number; errors: string[] };
   secrets?: { pulled: number; skipped: boolean; reason?: string; errors: string[] };
-  sessions?: { ran: boolean; pushed: number; pulled: number; merged: number };
+  sessions?: { ran: boolean; pushed: number; pulled: number; merged: number; error?: string };
   devices?: { synced: number; pending: number; skipped: boolean };
   reconciled: boolean;
 }
@@ -156,9 +156,19 @@ export async function runUmbrellaSync(args: RunUmbrellaArgs): Promise<UmbrellaRe
     const { isSyncConfigured } = await import('./session/sync/config.js');
     if (isBetaEnabled('session-sync') && isSyncConfigured()) {
       const { syncSessions } = await import('./session/sync/sync.js');
-      const r = await syncSessions();
-      result.sessions = { ran: true, pushed: r.pushed, pulled: r.pulled, merged: r.merged };
-      log(`sessions: pushed ${r.pushed}, pulled ${r.pulled}, merged ${r.merged}`);
+      // Record a failure here instead of letting it throw: like the fetchSecrets
+      // block above, a failure in one fetch stage must not abort the others or
+      // the reconcile below (see this function's doc comment). Without this,
+      // syncSessions() throwing — e.g. via the C1 containment reject on a
+      // malicious peer manifest — would skip `plan.reconcile` entirely.
+      try {
+        const r = await syncSessions();
+        result.sessions = { ran: true, pushed: r.pushed, pulled: r.pulled, merged: r.merged };
+        log(`sessions: pushed ${r.pushed}, pulled ${r.pulled}, merged ${r.merged}`);
+      } catch (err) {
+        result.sessions = { ran: false, pushed: 0, pulled: 0, merged: 0, error: (err as Error).message };
+        log(`sessions: failed — ${(err as Error).message}`);
+      }
     } else {
       result.sessions = { ran: false, pushed: 0, pulled: 0, merged: 0 };
     }


### PR DESCRIPTION
## What

Fixes the two highest-severity path-traversal Criticals from a deep security review of this repo (multi-provider agent swarm: codex / droid / claude / kimi / grok). Both are the same class — an untrusted string reaching a filesystem operation with no containment.

### C4 — routine name → recursive `rmSync` (home-directory deletion)
`sandbox.getJobHomePath` built the overlay HOME with a raw `path.join(getRoutinesDir(), name, 'home')`. The name comes from routine YAML (`name:` field or file basename) and can arrive via a **synced user/system config repo**. `cleanJobHome` does `fs.rmSync(overlayHome, { recursive: true, force: true })`, so a routine `name: "../../../../.."` normalizes to `/home` on a conventional layout and the scheduler wipes the user's home on job prep.

**Fix:** `getJobHomePath` routes the name through the existing `safeJoin` single-segment container; `validateJob` also rejects unsafe names (friendly error at `routines add` / load).

### C1 — session-sync pull → arbitrary file write (fleet-wide compromise)
`mirrorPath` joined peer-controlled `machine`/`relKey` from a remote manifest into the write path with no check, while the **push** side already dropped `relKey` starting with `..` (`agents.ts:176`). A malicious fleet peer with write access to the shared bucket could PUT a manifest with `relKey: "../../../.ssh/authorized_keys"`; the pulling machine's `fs.writeFileSync` then plants attacker content there → peer SSHs in.

**Fix:** `mirrorPath` validates the `machine` segment and contains `relKey` beneath the per-machine mirror root.

Shared `isSafeSegmentName` / `assertWithin` helpers added to `paths.ts` (extracted from `safeJoin`, behavior unchanged).

## Test evidence
- New containment tests in `sandbox.test.ts` (C4) and `session/sync/agents.test.ts` (C1) — malicious inputs throw, benign inputs return contained paths.
- `bunx vitest run` sandbox + sync + routines suites: **all green** (28 + 63 tests).
- `bunx tsc --noEmit`: **rc=0**.

## Scope
Read-only audit surfaced 5 Criticals total; this PR lands the two isolated FS-containment ones. Still open (separate PRs): C2 Windows `computer-helper-win` daemon runs with no auth, C3 plugin exec-gate bypass (clone-to-RCE), C5 browser SSH `-F` option injection. Full findings in the review report.

Session transcript (secret gist): 
