### PR TITLE
test: guard detached command exit-code assertion to posix (Windows CI)

### DIFF
--- a/apps/cli/src/lib/runner.test.ts
+++ b/apps/cli/src/lib/runner.test.ts
@@ -148,10 +148,13 @@ describe('command-mode routines (executeJobDetached — daemon/cron path)', () =
     expect(final.status).toBe('completed');
     expect(final.exitCode).toBe(0);
     expect(final.command).toBe('exit 0');
-    // exit-code file written (restart-recovery source of truth)
-    expect(
-      fs.readFileSync(path.join(getRunDir('cmd-det-ok', meta.runId), 'exit-code'), 'utf-8').trim(),
-    ).toBe('0');
+    // exit-code file is the posix restart-recovery source of truth (the sh subshell
+    // wrapper writes it). Windows records status via child.on('exit') only — no file.
+    if (process.platform !== 'win32') {
+      expect(
+        fs.readFileSync(path.join(getRunDir('cmd-det-ok', meta.runId), 'exit-code'), 'utf-8').trim(),
+      ).toBe('0');
+    }
   });
 
   it('records failed / exitCode 3 on a non-zero detached run', async () => {


### PR DESCRIPTION
Follow-up to #1196. The detached command-routine regression test read `<runDir>/exit-code`, but that file is written only by the **posix** `/bin/sh` subshell wrapper. The win32 path (`cmd /c`) records terminal status via `child.on('exit')` and writes no file — so the assertion failed on `windows-latest` CI with `ENOENT`, blocking the 1.20.64 release.

Guard the exit-code-file assertion to non-win32; the `status`/`exitCode` assertions (the actual bug fix from #1196) still run on every platform. 7/7 runner tests pass on posix.

(The other Windows CI failures in that run — `usage.test.ts` credentials, `mailboxes.test.ts` — are pre-existing/environment, unrelated to this change.)