### PR TITLE
security: validate ssh target before raw ssh spawns in browser driver (C5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Security
 
+- **SSH option-injection containment for `browser` over `ssh://`.** The `user`/`host`
+  from an `ssh://` browser profile endpoint (git-tracked user config) are now validated
+  with `assertValidSshTarget` before every raw `ssh` spawn — the remote-launch
+  (`ensureRemoteBrowser`), remote-kill (`runSSHCommand`), and `-L` tunnel
+  (`startSSHTunnel`) sinks in `apps/cli/src/lib/browser/drivers/ssh.ts` and
+  `apps/cli/src/lib/ssh-tunnel.ts`. A crafted endpoint like `ssh://-Fattacker@victim`
+  can no longer place `-Fattacker` at the ssh target position (parsed as `-F <file>`),
+  which an attacker-supplied ssh config's `ProxyCommand` would have turned into local
+  code execution.
 - **Path-traversal containment for untrusted-input filesystem sinks.**
   - Routine job names (from routine YAML `name:` / file basename, which can arrive via a
     synced user/system config repo) are now contained to a single path segment beneath

--- a/apps/cli/src/lib/browser/drivers/ssh.test.ts
+++ b/apps/cli/src/lib/browser/drivers/ssh.test.ts
@@ -316,4 +316,22 @@ describe('raw-ssh spawns reuse SSH_OPTS so unreachable hosts fail fast (#746)', 
     rec.child.emit('close'); // settle so the 3s kill timer is cleared
     await p;
   });
+
+  // C5: user/host come from a git-tracked ssh:// browser profile. A crafted
+  // endpoint like `ssh://-Fattacker@victim` puts `-Fattacker` at the ssh target
+  // position, where OpenSSH reads it as `-F <file>` and an attacker-supplied ssh
+  // config's ProxyCommand runs locally. The target must be validated before spawn.
+  it('ensureRemoteBrowser rejects an option-injecting target before spawning', async () => {
+    await expect(
+      ensureRemoteBrowser('-Fattacker', 'victim', 'chrome', 9222, 'posix'),
+    ).rejects.toThrow(/Invalid SSH target/);
+    expect(cp.calls.length).toBe(0); // guard runs before the raw ssh spawn
+  });
+
+  it('killRemoteBrowser (runSSHCommand) rejects an option-injecting target before spawning', async () => {
+    await expect(
+      killRemoteBrowser('-Fattacker', 'victim', 'posix', 9222),
+    ).rejects.toThrow(/Invalid SSH target/);
+    expect(cp.calls.length).toBe(0);
+  });
 });

--- a/apps/cli/src/lib/browser/drivers/ssh.ts
+++ b/apps/cli/src/lib/browser/drivers/ssh.ts
@@ -10,7 +10,7 @@ import type { BrowserProfile } from '../types.js';
 // is the shared hardened baseline (BatchMode + ConnectTimeout + keepalive) —
 // reuse it so the raw-ssh spawns below fail fast on an unreachable host instead
 // of hanging on the default ~127s TCP timeout, rather than re-listing options.
-import { shellQuote, SSH_OPTS } from '../../ssh-exec.js';
+import { shellQuote, SSH_OPTS, assertValidSshTarget } from '../../ssh-exec.js';
 export { shellQuote };
 // The `ssh -L` tunnel spawn is shared with `agents computer --host`; it lives in
 // the single ssh-tunnel helper. Calling it with no options preserves this
@@ -348,6 +348,12 @@ export async function ensureRemoteBrowser(
   remoteOs: RemoteOs,
   customBinary?: string
 ): Promise<void> {
+  // `user`/`host` derive from an ssh:// profile endpoint (git-tracked user
+  // config). Validate the composed target before it reaches the raw `ssh` spawn:
+  // an endpoint like `ssh://-Fattack@victim` would otherwise place `-Fattack` at
+  // the target position, where OpenSSH parses it as `-F <file>` and an
+  // attacker-supplied ssh config's ProxyCommand yields local code execution.
+  assertValidSshTarget(`${user}@${host}`);
   const remoteCmd = buildLaunchCmd(remoteOs, browserType, port, customBinary);
 
   return new Promise((resolve, reject) => {
@@ -442,7 +448,17 @@ export function killRemoteBrowser(
 }
 
 function runSSHCommand(user: string, host: string, cmd: string): Promise<void> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
+    // Reject an option-injecting target (e.g. a `-`-leading user from a crafted
+    // ssh:// profile) before it reaches the raw `ssh` spawn. Reject rather than
+    // throw synchronously so `killRemoteBrowser(...).catch()` stays best-effort.
+    // See ensureRemoteBrowser.
+    try {
+      assertValidSshTarget(`${user}@${host}`);
+    } catch (err) {
+      reject(err as Error);
+      return;
+    }
     // Reuse the shared hardened baseline so a hung TCP SYN to an unreachable
     // host is bounded by ConnectTimeout (the local 3s kill below only bounds a
     // connected-but-slow command, not the connect itself). Options precede the

--- a/apps/cli/src/lib/ssh-tunnel.test.ts
+++ b/apps/cli/src/lib/ssh-tunnel.test.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   buildTunnelArgs,
+  startSSHTunnel,
   buildScpArgs,
   buildPushScript,
   buildVerifyPushScript,
@@ -25,6 +26,19 @@ import {
 } from './ssh-tunnel.js';
 import { SSH_OPTS } from './ssh-exec.js';
 import { encodePowerShell } from './browser/drivers/ssh.js';
+
+describe('startSSHTunnel — target validation (C5)', () => {
+  // buildTunnelArgs places `${user}@${host}` before `-N`/SSH_OPTS, so a
+  // `-`-leading user (from a crafted ssh:// profile or device record) would be
+  // parsed by ssh as an option flag. startSSHTunnel must reject before spawning.
+  it('rejects an option-injecting user before spawning ssh', async () => {
+    await expect(startSSHTunnel('-Fattacker', 'victim', 55000, 8765)).rejects.toThrow(/Invalid SSH target/);
+  });
+
+  it('rejects a host containing shell/option metacharacters', async () => {
+    await expect(startSSHTunnel('me', 'a b;rm', 55000, 8765)).rejects.toThrow(/Invalid SSH target/);
+  });
+});
 
 describe('buildTunnelArgs', () => {
   it('forwards localPort to the remote loopback port and stays hardened', () => {

--- a/apps/cli/src/lib/ssh-tunnel.ts
+++ b/apps/cli/src/lib/ssh-tunnel.ts
@@ -25,7 +25,7 @@ import { fileURLToPath } from 'url';
 import { randomBytes, createHash } from 'crypto';
 import { Readable } from 'stream';
 import { pipeline } from 'stream/promises';
-import { sshExec, SSH_OPTS } from './ssh-exec.js';
+import { sshExec, SSH_OPTS, assertValidSshTarget } from './ssh-exec.js';
 import { backgroundSpawnOptions } from './platform/process.js';
 import { encodePowerShell } from './browser/drivers/ssh.js';
 import { getDevice, type DeviceProfile } from './devices/registry.js';
@@ -86,6 +86,17 @@ export function startSSHTunnel(
   opts: StartTunnelOptions = {},
 ): Promise<ChildProcess> {
   return new Promise((resolve, reject) => {
+    // `user`/`host` can originate from a browser ssh:// profile or a device
+    // record. buildTunnelArgs places `${user}@${host}` before `-N`/SSH_OPTS, so
+    // a `-`-leading user would be parsed as an ssh option flag (option
+    // injection). Validate at the spawn sink so every caller is covered; reject
+    // (rather than throw synchronously) to keep the Promise contract.
+    try {
+      assertValidSshTarget(`${user}@${host}`);
+    } catch (err) {
+      reject(err as Error);
+      return;
+    }
     const args = buildTunnelArgs(user, host, localPort, remotePort);
 
     const tunnel = spawn('ssh', args, {


### PR DESCRIPTION
## What

Fixes **C5** from the security review: SSH option-injection in the `browser` driver's `ssh://` transport (codex exec-injection finding #1; corroborated by kimi ssh-fleet #5 on the tunnel).

### The bug
`connectSSH` derives `user`/`host` from a profile endpoint URL — profiles live in git-tracked user config (`~/.agents`, shared via `agents repo push`) — and `${user}@${host}` is placed at the ssh **target** position with no validation across three raw spawns: `ensureRemoteBrowser` (remote launch), `runSSHCommand` (remote kill), and `startSSHTunnel` (the `-L` tunnel, also used by `computer --host`).

A profile endpoint `ssh://-Fattacker@victim` produces target `-Fattacker@victim`, which OpenSSH parses as `-F <file>`. An attacker-supplied ssh config's `ProxyCommand` then executes **locally** — code execution before authenticating to the intended host.

`ssh-exec.ts` already exposes `assertValidSshTarget` (rejects leading `-` and any non-`[A-Za-z0-9._-]` target) and applies it at `sshExec`/`sshStream`/`sshCapture` — these three raw spawns were the sites it was missing from.

### The fix
Apply `assertValidSshTarget(\`${user}@${host}\`)` at all three sinks. The two best-effort/Promise-returning sinks (`runSSHCommand`, `startSSHTunnel`) **reject** rather than throw synchronously, so `killRemoteBrowser(...).catch()` stays best-effort; `ensureRemoteBrowser` is `async` so a top-of-body throw already becomes a rejection.

## Test evidence
- New rejection tests: `ensureRemoteBrowser`/`killRemoteBrowser`/`startSSHTunnel` reject an option-injecting target **before any spawn** (asserted via the existing `cp` spawn stub: `cp.calls` stays empty).
- Existing valid-target tests (`me@203.0.113.1`, `muqsit@win-mini`) unaffected.
- `bunx vitest run` browser ssh + ssh-tunnel: **47 passed**. `bunx tsc --noEmit`: **rc=0**.

## Scope / remaining
Fourth of the review's 5 Criticals. Shipped: C1 + C4 (#1193, merged). Remaining after this: **C3** (plugin exec-gate bypass → clone-to-RCE) and **C2** (Windows `computer-helper-win` daemon no-auth; C#/Windows, I'll build/verify on win-mini).

Session transcript (fleet-local, confidential): zion:/Users/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/c32e4ca2-2377-4282-a94c-f7a2486238b7.jsonl
