### PR TITLE
chore(gitignore): ignore *.bun-build compile-intermediate

### DIFF
--- a/apps/cli/.gitignore
+++ b/apps/cli/.gitignore
@@ -1,2 +1,7 @@
 # Copied from repo-root README.md at prepack time (see package.json). Do not commit.
 /README.md
+
+# `bun build --compile` (scripts/build-bin.sh) drops this compile-intermediate in
+# apps/cli/ and can leave it behind, dirtying the tree and tripping release.sh's
+# clean-tree preflight.
+*.bun-build

--- a/apps/cli/src/lib/__tests__/usage.test.ts
+++ b/apps/cli/src/lib/__tests__/usage.test.ts
@@ -240,13 +240,7 @@ describe('Claude usage scoping', () => {
     }
   });
 
-  // loadClaudeOauth intentionally returns null off darwin/linux (usage.ts), so the
-  // .credentials.json fallback this guards is macOS/Linux-only — asserting it on
-  // Windows fails deterministically. Skip on Windows, and belt-and-suspenders the
-  // runtime skip too, since the release matrix has shown `it.skipIf` alone failing
-  // to keep a test off Windows runners (see secrets.test.ts).
-  it.skipIf(process.platform === 'win32')('falls back to <home>/.claude/.credentials.json when the keychain has no item (Linux/CI)', async () => {
-    if (process.platform === 'win32') return;
+  it('falls back to <home>/.claude/.credentials.json when the keychain has no item (Linux/CI)', async () => {
     // A fresh temp home yields a unique hashed keychain service, so the keychain
     // read misses and loadClaudeOauth must fall back to the file the Linux Claude
     // CLI writes. This is the regression guard for `agents view --host <linux>`

--- a/apps/cli/src/lib/__tests__/usage.test.ts
+++ b/apps/cli/src/lib/__tests__/usage.test.ts
@@ -240,7 +240,13 @@ describe('Claude usage scoping', () => {
     }
   });
 
-  it('falls back to <home>/.claude/.credentials.json when the keychain has no item (Linux/CI)', async () => {
+  // loadClaudeOauth intentionally returns null off darwin/linux (usage.ts), so the
+  // .credentials.json fallback this guards is macOS/Linux-only — asserting it on
+  // Windows fails deterministically. Skip on Windows, and belt-and-suspenders the
+  // runtime skip too, since the release matrix has shown `it.skipIf` alone failing
+  // to keep a test off Windows runners (see secrets.test.ts).
+  it.skipIf(process.platform === 'win32')('falls back to <home>/.claude/.credentials.json when the keychain has no item (Linux/CI)', async () => {
+    if (process.platform === 'win32') return;
     // A fresh temp home yields a unique hashed keychain service, so the keychain
     // read misses and loadClaudeOauth must fall back to the file the Linux Claude
     // CLI writes. This is the regression guard for `agents view --host <linux>`


### PR DESCRIPTION
`bun build --compile` (`scripts/build-bin.sh`) drops a `.<hash>-00000000.bun-build` compile-intermediate into `apps/cli/` and can leave it behind, dirtying the tree and tripping `release.sh`'s clean-tree preflight (hit repeatedly during the 1.20.64 release). Gitignore it.

(Original test-guard change dropped: #1208 already fixed `loadClaudeOauth`'s Windows fallthrough, so the test passes on Windows — skipping it would mask coverage, per review.)