### PR TITLE
security: require auth token for the Windows computer daemon (C2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Security
 
+- **The Windows `computer` daemon now requires authentication.** `computer-helper-win`
+  previously started with `authed = expectedToken == null` and the CLI never provisioned a
+  token, so it ran open on `127.0.0.1` — and loopback TCP on Windows is not user/session
+  scoped, letting **any** local process drive full screen capture, input injection, and
+  program launch. The daemon now **refuses to start without a `--token-file`**
+  (`native/computer-win/Program.cs`), and `agents computer setup --host` generates a
+  shared-secret token, writes it on the remote with an owner-only ACL, registers the task
+  with `--token-file`, and persists it locally so `start --host` authenticates
+  (`apps/cli/src/lib/ssh-tunnel.ts`). Existing token-less setups must re-run
+  `agents computer setup --host <device>` (the daemon will otherwise refuse to start).
 - **SSH option-injection containment for `browser` over `ssh://`.** The `user`/`host`
   from an `ssh://` browser profile endpoint (git-tracked user config) are now validated
   with `assertValidSshTarget` before every raw `ssh` spawn — the remote-launch

--- a/apps/cli/src/lib/computer-rpc.ts
+++ b/apps/cli/src/lib/computer-rpc.ts
@@ -370,7 +370,9 @@ class TcpClient extends BaseClient {
       this.failPending('helper_exited', 'tcp connection closed before reply');
     });
     // Kick off the auth handshake synchronously so its frame (id 1) is the
-    // first thing written. No token → daemon is open (tunnel-gated).
+    // first thing written. The Windows daemon now REQUIRES a token (it refuses to
+    // start without one); a null token here means no auth frame is sent, the
+    // daemon drops the connection, and the caller is told to re-run `setup`.
     this.authReady = token ? this.authenticate(token) : Promise.resolve();
   }
 

--- a/apps/cli/src/lib/ssh-tunnel.test.ts
+++ b/apps/cli/src/lib/ssh-tunnel.test.ts
@@ -9,6 +9,12 @@ import {
   buildPushScript,
   buildVerifyPushScript,
   buildRegisterTaskScript,
+  buildWriteTokenScript,
+  WIN_HELPER_TOKEN_FILE,
+  helperTokenPath,
+  readHelperToken,
+  writeHelperToken,
+  clearHelperToken,
   buildUnregisterTaskScript,
   downloadWinHelperExe,
   parseSha256Asset,
@@ -112,8 +118,10 @@ describe('buildPushScript', () => {
 });
 
 describe('buildRegisterTaskScript', () => {
-  it('registers an interactive LOGON task running the exe with --port', () => {
-    const s = buildRegisterTaskScript(REMOTE_HELPER_PORT, REMOTE_TASK_NAME);
+  const TOKEN_PATH = 'C:\\Users\\me\\AppData\\Local\\agents\\helper-token';
+
+  it('registers an interactive LOGON task running the exe with --port and --token-file', () => {
+    const s = buildRegisterTaskScript(REMOTE_HELPER_PORT, REMOTE_TASK_NAME, TOKEN_PATH);
     expect(s).toContain('-AtLogOn'); // survives ssh disconnect
     expect(s).toContain('-LogonType Interactive'); // real desktop session for UIA/screenshot
     expect(s).toContain('-RunLevel Highest');
@@ -122,6 +130,45 @@ describe('buildRegisterTaskScript', () => {
     expect(s).toContain('Register-ScheduledTask');
     expect(s).toContain('Start-ScheduledTask'); // start now, no logout/in
     expect(s).toContain(WIN_HELPER_EXE);
+    // C2: the daemon requires a token, so the task must point at the token file
+    // (quoted so a path with spaces stays one argv entry).
+    expect(s).toContain(`--token-file "${TOKEN_PATH}"`);
+  });
+});
+
+describe('buildWriteTokenScript', () => {
+  it('writes the token owner-only and echoes the path', () => {
+    const s = buildWriteTokenScript('deadbeefcafe');
+    expect(s).toContain(WIN_HELPER_TOKEN_FILE);
+    expect(s).toContain('Set-Content');
+    expect(s).toContain("'deadbeefcafe'"); // ps-single-quoted token value
+    expect(s).toContain('icacls'); // owner-only ACL, inheritance removed
+    expect(s).toContain('/inheritance:r');
+    expect(s).toContain('Write-Output $tok'); // returns the resolved path
+  });
+});
+
+describe('helper token persistence (C2)', () => {
+  // Uses the real cache dir with a test-only device name (repo convention:
+  // real services, no mocking), cleaned up after each case.
+  const DEV = '__test-tok-device__';
+  afterEach(() => clearHelperToken(DEV));
+
+  it('round-trips a token for a device and clears it', () => {
+    expect(readHelperToken(DEV)).toBeNull();
+    writeHelperToken(DEV, 'sekret-token');
+    expect(readHelperToken(DEV)).toBe('sekret-token');
+    // written owner-only
+    const mode = fs.statSync(helperTokenPath(DEV)).mode & 0o777;
+    expect(mode).toBe(0o600);
+    clearHelperToken(DEV);
+    expect(readHelperToken(DEV)).toBeNull();
+  });
+
+  it('reads null for a missing/empty token', () => {
+    expect(readHelperToken(DEV)).toBeNull();
+    writeHelperToken(DEV, '   ');
+    expect(readHelperToken(DEV)).toBeNull(); // whitespace-only trims to empty
   });
 });
 

--- a/apps/cli/src/lib/ssh-tunnel.ts
+++ b/apps/cli/src/lib/ssh-tunnel.ts
@@ -138,6 +138,9 @@ export const REMOTE_TASK_NAME = 'AgentsComputerHelper';
 /** Basename of the cross-published exe under native/computer-win/dist. */
 export const WIN_HELPER_EXE = 'computer-helper-win.exe';
 
+/** Basename of the daemon's shared-secret token file under %LOCALAPPDATA%\agents. */
+export const WIN_HELPER_TOKEN_FILE = 'helper-token';
+
 /**
  * Locate a locally built Windows daemon exe — a repo-checkout build output from
  * `scripts/build-win.sh`, or one bundled next to the package. Local paths are
@@ -295,6 +298,39 @@ export function clearRemoteState(device: string): void {
   }
 }
 
+/**
+ * Local file holding the shared-secret token for a device's helper daemon.
+ * Written at `setup --host` (0600), read at `start --host` so the RPC client
+ * authenticates. The remote daemon reads the same value from its own
+ * `--token-file`; the CLI is the source of truth and never round-trips it back.
+ */
+export function helperTokenPath(device: string): string {
+  return path.join(remoteStateDir(), `${device}.token`);
+}
+
+export function readHelperToken(device: string): string | null {
+  try {
+    const t = fs.readFileSync(helperTokenPath(device), 'utf-8').trim();
+    return t.length > 0 ? t : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeHelperToken(device: string, token: string): void {
+  const dir = remoteStateDir();
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(helperTokenPath(device), token, { mode: 0o600 });
+}
+
+export function clearHelperToken(device: string): void {
+  try {
+    fs.unlinkSync(helperTokenPath(device));
+  } catch {
+    /* already gone */
+  }
+}
+
 /** Resolve a registered device to its ssh pieces, or throw a clear error. */
 export async function resolveRemoteDevice(
   name: string,
@@ -351,10 +387,27 @@ export function buildVerifyPushScript(remotePath: string, expectedBytes: number)
  * survives ssh disconnect — the same rationale as the browser WMI launch. The
  * task is started immediately so the caller need not log out/in.
  */
-export function buildRegisterTaskScript(port: number, taskName: string): string {
+/**
+ * PowerShell that writes the shared-secret token under %LOCALAPPDATA%\agents
+ * with an owner-only ACL (inheritance removed, read granted only to the current
+ * user) and echoes the resolved path so the caller can pass it to `--token-file`.
+ */
+export function buildWriteTokenScript(token: string): string {
+  return [
+    `$dir = Join-Path $env:LOCALAPPDATA 'agents'`,
+    `New-Item -ItemType Directory -Force -Path $dir | Out-Null`,
+    `$tok = Join-Path $dir '${WIN_HELPER_TOKEN_FILE}'`,
+    `Set-Content -LiteralPath $tok -Value ${psSingleQuote(token)} -NoNewline -Encoding ascii`,
+    `icacls $tok /inheritance:r /grant:r ("$($env:USERNAME):(R)") | Out-Null`,
+    `Write-Output $tok`,
+  ].join('; ');
+}
+
+export function buildRegisterTaskScript(port: number, taskName: string, tokenPath: string): string {
+  const argument = `--port ${port} --token-file "${tokenPath}"`;
   return [
     `$exe = Join-Path (Join-Path $env:LOCALAPPDATA 'agents') '${WIN_HELPER_EXE}'`,
-    `$action = New-ScheduledTaskAction -Execute $exe -Argument '--port ${port}'`,
+    `$action = New-ScheduledTaskAction -Execute $exe -Argument ${psSingleQuote(argument)}`,
     `$trigger = New-ScheduledTaskTrigger -AtLogOn`,
     `$principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Highest`,
     `$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit ([TimeSpan]::Zero)`,
@@ -452,13 +505,30 @@ export async function setupRemoteHelper(name: string): Promise<{ target: string;
     throw new Error(`verifying helper exe on '${name}' failed (exit ${verify.code ?? 'null'}): ${verify.stderr.trim() || verify.stdout.trim()}`);
   }
 
-  // Register + start the LOGON task.
-  const reg = sshExec(target, encodePowerShell(buildRegisterTaskScript(REMOTE_HELPER_PORT, REMOTE_TASK_NAME)), {
+  // Provision the auth token: generate it locally, write it on the remote with
+  // an owner-only ACL, and register the task with --token-file. The daemon now
+  // refuses to start without a token, so a token-less (open-to-any-local-process)
+  // daemon can no longer be stood up through the CLI.
+  const token = generateToken();
+  const tokWrite = sshExec(target, encodePowerShell(buildWriteTokenScript(token)), { timeoutMs: 60_000 });
+  if (tokWrite.code !== 0) {
+    throw new Error(`writing helper token on '${name}' failed (exit ${tokWrite.code ?? 'null'}): ${tokWrite.stderr.trim() || tokWrite.stdout.trim()}`);
+  }
+  const remoteTokenPath = tokWrite.stdout.trim().split(/\r?\n/).filter(Boolean).at(-1);
+  if (!remoteTokenPath) {
+    throw new Error(`writing helper token on '${name}' did not return a destination path`);
+  }
+
+  // Register + start the LOGON task, pointing it at the token file.
+  const reg = sshExec(target, encodePowerShell(buildRegisterTaskScript(REMOTE_HELPER_PORT, REMOTE_TASK_NAME, remoteTokenPath)), {
     timeoutMs: 60_000,
   });
   if (reg.code !== 0) {
     throw new Error(`registering scheduled task on '${name}' failed (exit ${reg.code ?? 'null'}): ${reg.stderr.trim() || reg.stdout.trim()}`);
   }
+
+  // Persist the token locally so `start --host` authenticates to the daemon.
+  writeHelperToken(name, token);
 
   return { target, taskName: REMOTE_TASK_NAME };
 }
@@ -491,9 +561,15 @@ export async function startRemoteTunnel(name: string): Promise<RemoteTunnelState
 
   // Verify the daemon answers through the tunnel before we record it. This is
   // the real end-to-end check: tunnel up + daemon listening + RPC round-trips.
-  const token: string | null = null; // tunnel-gated; the daemon runs token-less
+  // The daemon now requires a token, so the probe must authenticate with the one
+  // provisioned at `setup`. A missing token means setup predates auth — guide
+  // the user to re-run it rather than silently failing the RPC.
+  const token = readHelperToken(name);
   const prevTcp = process.env.COMPUTER_HELPER_TCP;
+  const prevTok = process.env.COMPUTER_HELPER_TOKEN;
   process.env.COMPUTER_HELPER_TCP = `127.0.0.1:${localPort}`;
+  if (token) process.env.COMPUTER_HELPER_TOKEN = token;
+  else delete process.env.COMPUTER_HELPER_TOKEN;
   const client = openComputerClient();
   let ok = false;
   let probeErr = '';
@@ -507,12 +583,16 @@ export async function startRemoteTunnel(name: string): Promise<RemoteTunnelState
     await client.close();
     if (prevTcp === undefined) delete process.env.COMPUTER_HELPER_TCP;
     else process.env.COMPUTER_HELPER_TCP = prevTcp;
+    if (prevTok === undefined) delete process.env.COMPUTER_HELPER_TOKEN;
+    else process.env.COMPUTER_HELPER_TOKEN = prevTok;
   }
   if (!ok) {
     try { if (tunnelPid) process.kill(tunnelPid); } catch { /* gone */ }
+    const hint = token
+      ? `Is it installed? Run: agents computer setup --host ${name}`
+      : `No auth token on record for '${name}' — re-run: agents computer setup --host ${name}`;
     throw new Error(
-      `tunnel to '${name}' opened but the daemon did not answer (${probeErr}). ` +
-        `Is it installed? Run: agents computer setup --host ${name}`,
+      `tunnel to '${name}' opened but the daemon did not answer (${probeErr}). ${hint}`,
     );
   }
 
@@ -556,6 +636,7 @@ export async function stopRemoteHelper(name: string): Promise<{ tunnelKilled: bo
   }
 
   clearRemoteState(name);
+  clearHelperToken(name);
   return { tunnelKilled, taskRemoved };
 }
 

--- a/native/computer-win/Program.cs
+++ b/native/computer-win/Program.cs
@@ -30,13 +30,24 @@ string? expectedToken = null;
 if (tokenFile != null && File.Exists(tokenFile))
     expectedToken = File.ReadAllText(tokenFile).Trim();
 
+// Authentication is mandatory. Loopback TCP on Windows is NOT user/session
+// scoped, so a token-less daemon hands full screen capture + input injection +
+// program launch to ANY local process. Refuse to start unless a shared-secret
+// token file was provided; the CLI (`agents computer setup --host`) provisions
+// one and passes --token-file.
+if (string.IsNullOrEmpty(expectedToken))
+{
+    Console.Error.WriteLine("computer-helper-win: refusing to start — a --token-file with a non-empty token is required (authentication is mandatory).");
+    return 2;
+}
+
 var dispatcher = new Dispatcher();
 
 // Bind loopback only — never expose the daemon to the network. The SSH tunnel
 // is the sole ingress.
 var listener = new TcpListener(IPAddress.Loopback, port);
 listener.Start();
-Console.Error.WriteLine($"computer-helper-win listening on 127.0.0.1:{port} (auth={(expectedToken != null ? "token" : "none")})");
+Console.Error.WriteLine($"computer-helper-win listening on 127.0.0.1:{port} (auth=token)");
 
 while (true)
 {
@@ -51,7 +62,7 @@ async Task HandleConnection(TcpClient client)
     {
         var buffer = new List<byte>();
         var chunk = new byte[8192];
-        bool authed = expectedToken == null; // no token configured → open (tunnel-gated)
+        bool authed = false; // token is mandatory (enforced at startup); require the auth frame
 
         while (true)
         {

--- a/native/computer-win/Program.cs
+++ b/native/computer-win/Program.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using ComputerHelperWin;
@@ -107,7 +108,8 @@ byte[]? HandleLine(byte[] lineBytes, ref bool authed)
         if (method != "auth")
             return null; // silently drop unauthenticated callers
         string? tok = @params.ValueKind == JsonValueKind.Object ? P.StringOpt(@params, "token") : null;
-        if (tok != null && tok == expectedToken)
+        if (tok != null && CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(tok), Encoding.UTF8.GetBytes(expectedToken)))
         {
             authed = true;
             return Encode(idEl, new Dictionary<string, object?> { ["ok"] = true });

--- a/native/computer-win/smoke/smoke.mjs
+++ b/native/computer-win/smoke/smoke.mjs
@@ -9,6 +9,10 @@
 import { spawn } from 'node:child_process';
 import { connect } from 'node:net';
 import { setTimeout as sleep } from 'node:timers/promises';
+import { writeFileSync, rmSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomBytes } from 'node:crypto';
 
 const args = process.argv.slice(2);
 const exe = argVal('--exe');
@@ -113,8 +117,16 @@ async function connectWithRetry(p, tries = 50) {
 const TYPED = `hello-smoke-${process.pid}`;
 
 async function main() {
-  console.log(`spawning daemon: ${exe} --port ${port}`);
-  const daemon = spawn(exe, ['--port', String(port)], { stdio: ['ignore', 'inherit', 'inherit'] });
+  // The daemon requires authentication: provision a token file and pass
+  // --token-file, then send the `auth` frame before any other RPC. (A token-less
+  // daemon refuses to start — that's the security posture this test must honor.)
+  const tokDir = mkdtempSync(join(tmpdir(), 'smoke-tok-'));
+  const tokenFile = join(tokDir, 'token');
+  const token = randomBytes(32).toString('hex');
+  writeFileSync(tokenFile, token, 'utf8');
+
+  console.log(`spawning daemon: ${exe} --port ${port} --token-file <token>`);
+  const daemon = spawn(exe, ['--port', String(port), '--token-file', tokenFile], { stdio: ['ignore', 'inherit', 'inherit'] });
   daemon.on('exit', (code) => {
     if (code !== null && code !== 0) console.error(`daemon exited early: ${code}`);
   });
@@ -123,6 +135,12 @@ async function main() {
   try {
     sock = await connectWithRetry(port);
     const c = new Client(sock);
+
+    // 0. authenticate — mandatory first frame; the daemon drops the connection
+    // for any other method until authed.
+    const authed = await c.call('auth', { token });
+    if (!authed?.ok) fail(`auth did not succeed: ${JSON.stringify(authed)}`);
+    ok('auth');
 
     // 1. ping
     const pong = await c.call('ping');
@@ -361,6 +379,7 @@ async function main() {
   } finally {
     try { sock?.destroy(); } catch {}
     try { daemon.kill(); } catch {}
+    try { rmSync(tokDir, { recursive: true, force: true }); } catch {}
     // best-effort: close notepad so the runner session is clean
     try { spawn('taskkill', ['/IM', 'notepad.exe', '/F'], { stdio: 'ignore' }); } catch {}
   }


### PR DESCRIPTION
## What

Fixes **C2** — the last Critical from the security review (droid native-electron finding): the Windows `computer` daemon ran with **no authentication**.

### The bug
`computer-helper-win` started with `bool authed = expectedToken == null` (`Program.cs`) and the CLI **never provisioned a token** — `generateToken()` was dead code and the scheduled task launched with `--port` only. So the daemon ran open on `127.0.0.1:8765`. Loopback TCP on Windows is **not** user/session scoped, so **any local process** (or a second logged-in user) could connect and drive full screen capture, keystroke/mouse injection, and arbitrary program launch (`launch_app`) with zero auth. (The macOS sibling is correctly gated by peer-auth + an allow-list.)

### The fix (2-sided)
- **Daemon** (`native/computer-win/Program.cs`): refuse to start unless a `--token-file` with a non-empty token is provided (exit 2), and require the `auth` frame on every connection (`authed = false`).
- **CLI** (`apps/cli/src/lib/ssh-tunnel.ts`): `setup --host` now generates a shared-secret token, writes it on the remote with an **owner-only ACL** (`icacls /inheritance:r`), registers the task with `--token-file`, and persists it locally (0600) so `start --host` authenticates. The RPC client already sends `COMPUTER_HELPER_TOKEN` in the first `auth` frame.

## Verified end-to-end on win-mini (rebuilt daemon)
- `scripts/build-win.sh` cross-built the win-x64 daemon; `computer setup --host win-mini` pushed it + provisioned the token + registered the task.
- **Positive**: `computer start --host win-mini` probe authenticated; `computer apps --host win-mini` returned the real window list (incl. the daemon process). Nothing broke.
- **Negative (security proof)**: running the deployed daemon with no `--token-file` prints `refusing to start ... (authentication is mandatory)` and **exits 2**.

## Tests
`buildRegisterTaskScript` includes `--token-file`; `buildWriteTokenScript` writes owner-only + echoes the path; `helper-token` read/write/clear round-trips at 0600. `bunx tsc --noEmit` rc=0; ssh-tunnel suite **22 passed**.

## Note
Existing token-less setups must re-run `agents computer setup --host <device>` (the daemon now refuses to start without a token). Branch is a few commits behind main; only `CHANGELOG.md` needs a trivial rebase before merge (code files auto-merge).

**This completes all 5 Criticals** from the review — C1+C4 (#1193), C5 (#1202), C3 (#1205), C2 (this).

Session transcript (fleet-local, confidential): zion:/Users/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/c32e4ca2-2377-4282-a94c-f7a2486238b7.jsonl
