### PR TITLE
chore(release): 1.20.65

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.20.65
+
 - **`agents apply` / `ag apply` — one-command fleet profile sync.** A new declarative command reconciles every registered device to a profile declared in the `fleet:` block of any `-f` file (default `agents.yaml`): ensure agents installed, sync config, and **propagate login** so a machine that is signed in once seeds the fleet — killing the "6 hosts × ~8 harnesses = ~48 OAuth flows" slog. `--plan`/`--dry-run` renders a device×dimension matrix (agents-cli · agents · config · login) without changing anything; `-y/--yes` skips the confirm; `--device <name>` scopes to one device; `--only agents,config,login` limits dimensions; `--no-login` skips login propagation. Login propagation captures portable credential files on the source (claude, codex, gemini, grok, kimi, opencode, droid, antigravity) and streams them to each target over the existing encrypted SSH channel (`sshExec` stdin, never shell-interpolated); an internal `--recv-auth` receiver validates + materializes them at 0600 and rejects path traversal. **Honest boundary:** macOS keychain-bound tokens (claude, antigravity) can't be read from the ACL-locked keychain — those are surfaced as a one-time manual login, never faked. `fleet:` is additive to the `Meta` schema; project `agents:` version-pins are untouched. Source: `apps/cli/src/commands/apply.ts`, `apps/cli/src/lib/fleet/{types,manifest,apply,auth-sync}.ts` (+ tests), `apps/cli/src/lib/hosts/passthrough.ts` (apply owns `--device`), `apps/cli/src/lib/types.ts` (`Meta.fleet`).
 
 ## 1.20.64

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phnx-labs/agents-cli",
-  "version": "1.20.63",
+  "version": "1.20.65",
   "description": "One CLI for all your AI coding agents - versions, config, cloud dispatch, sessions, and teams (now with first-class Grok Build CLI support)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## 1.20.65

- **`agents apply` / `ag apply` — one-command fleet profile sync.** A new declarative command reconciles every registered device to a profile declared in the `fleet:` block of any `-f` file (default `agents.yaml`): ensure agents installed, sync config, and **propagate login** so a machine that is signed in once seeds the fleet — killing the "6 hosts × ~8 harnesses = ~48 OAuth flows" slog. `--plan`/`--dry-run` renders a device×dimension matrix (agents-cli · agents · config · login) without changing anything; `-y/--yes` skips the confirm; `--device <name>` scopes to one device; `--only agents,config,login` limits dimensions; `--no-login` skips login propagation. Login propagation captures portable credential files on the source (claude, codex, gemini, grok, kimi, opencode, droid, antigravity) and streams them to each target over the existing encrypted SSH channel (`sshExec` stdin, never shell-interpolated); an internal `--recv-auth` receiver validates + materializes them at 0600 and rejects path traversal. **Honest boundary:** macOS keychain-bound tokens (claude, antigravity) can't be read from the ACL-locked keychain — those are surfaced as a one-time manual login, never faked. `fleet:` is additive to the `Meta` schema; project `agents:` version-pins are untouched. Source: `apps/cli/src/commands/apply.ts`, `apps/cli/src/lib/fleet/{types,manifest,apply,auth-sync}.ts` (+ tests), `apps/cli/src/lib/hosts/passthrough.ts` (apply owns `--device`), `apps/cli/src/lib/types.ts` (`Meta.fleet`).