### PR TITLE
docs(apply): document ag apply — fleet profile sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Also available as `ag` -- all commands work with both `agents` and `ag`.
 - [Run any agent](#run-any-agent)
 - [Sessions across agents](#sessions-across-agents)
 - [Control the fleet](#control-the-fleet)
+- [Sync the fleet](#sync-the-fleet)
 - [Run open models through Claude Code](#run-open-models-through-claude-code)
 - [Teams](#teams)
 - [Cloud](#cloud)
@@ -292,6 +293,34 @@ agents watchdog --watch    # daemon loop: a tick every --interval
 ```
 
 `agents watchdog` detects a stalled session, resolves the *exact* terminal split it lives in (tmux, iTerm, VSCodium, or a raw pty), and injects a nudge -- `Continue.` by default, or set `--text`. It's dry by default; `--nudge` acts on a single tick, and `agents watchdog enable` flips global auto-nudge on so `--watch` injects on its own. Steer a single run with `agents watchdog policy <id> off | keep | handsoff`.
+
+---
+
+## Sync the fleet
+
+One machine is set up the way you like it. Make every other machine match -- same agents installed, same config, logins seeded -- in one command.
+
+```yaml
+# agents.yaml -- add a fleet: block
+fleet:
+  devices: all              # every online registered device (minus this one)
+  defaults:
+    agents: [claude@latest, codex@latest, gemini@latest]
+    sync: [user]            # config scopes to reconcile
+    login: sync             # propagate logins where the token is portable
+```
+
+```bash
+agents apply --plan                 # device x dimension matrix; changes nothing
+agents apply                        # reconcile the fleet (confirms first; -y to skip)
+agents apply --device yosemite-s0   # scope to one device
+agents apply --only agents,config   # limit dimensions (agents, config, login)
+agents apply --no-login             # skip login propagation
+```
+
+`agents apply` (`ag apply`) probes every target over the existing SSH transport, then reconciles it to the profile: installs missing agents, upgrades `agents-cli`, syncs the named config scopes, and **propagates logins** so a host signed in once seeds the fleet -- turning "6 hosts x 8 harnesses = 48 OAuth flows" into one. Portable credential files (claude, codex, gemini, grok, kimi, opencode, droid, antigravity) stream to each target over encrypted SSH stdin, never shell-interpolated, and land at `0600`. **Honest boundary:** macOS keychain-bound tokens (claude, antigravity on a Mac target) can't be extracted -- those surface as a one-time manual login, never faked. `--plan` / `--dry-run` shows the full matrix without touching anything.
+
+See [docs/fleet.md](apps/cli/docs/fleet.md) for the manifest schema and reconcile semantics.
 
 ---
 

--- a/apps/cli/docs/README.md
+++ b/apps/cli/docs/README.md
@@ -34,6 +34,7 @@ How agents-cli is laid out on disk and how it decides what to load.
 
 | Doc | What it covers |
 |---|---|
+| [Fleet profile sync](fleet.md) | `agents apply` — reconcile every device to a declared `fleet:` profile: install agents, sync config, propagate logins so one signed-in host seeds the fleet. |
 | [Teams](teams.md) | Multi-agent DAG teams, boundary contracts, `--watch` supervisor, `--worktree` isolation, `--cloud` dispatch. |
 | [Cloud](cloud.md) | Unified dispatch across Rush Cloud / Codex Cloud / Factory. Multi-repo tasks, balanced routing, SSE streaming. |
 | [Hosts](hosts.md) | Offload `agents run` to your own machines over SSH (`--host`); track with `agents hosts ps` and view/follow with `agents logs`. |

--- a/apps/cli/docs/fleet.md
+++ b/apps/cli/docs/fleet.md
@@ -1,0 +1,114 @@
+# Fleet profile sync (`agents apply`)
+
+Reconcile every machine you own to one declared profile: which agents are
+installed, which config scopes are synced, and whether logins propagate. One
+host set up the way you like it becomes the template for the whole fleet.
+
+`agents apply` (alias `ag apply`) is the fleet-wide counterpart to
+[resource sync](02-resource-sync.md): resource sync reconciles resources within
+one machine's version homes; `apply` reconciles *machines* against a profile,
+over the same [SSH transport](09-ssh-transport.md) every `--host` command uses.
+
+Source: `src/commands/apply.ts` (command + plan render),
+`src/lib/fleet/{types,manifest,apply,auth-sync}.ts` (schema, reconcile engine,
+credential propagation).
+
+## The `fleet:` block
+
+The profile is an additive `fleet:` block in `agents.yaml` (or any file passed
+with `-f`). It never affects the existing `agents:` version pins — those stay
+project-local.
+
+```yaml
+fleet:
+  devices: all                # 'all' online registered devices (minus this one),
+                              # or an explicit map of device-name -> override
+  defaults:
+    agents: [claude@latest, codex@latest, gemini@latest]
+    sync: [user]              # config scopes to reconcile on each device
+    login: sync               # 'sync' | 'skip'
+  # Per-device overrides inherit from defaults; any omitted field falls through.
+  # devices:
+  #   yosemite-s0: { agents: [claude@latest], login: skip }
+```
+
+| Field | Meaning |
+|---|---|
+| `devices` | `all` — every online, registered device except the source machine — or a map of `device-name: {override}`. |
+| `defaults.agents` | Agent specs to ensure installed, e.g. `claude@latest`. Missing agents are installed; version drift is left to the pins. |
+| `defaults.sync` | Config sync scopes to reconcile on each device (e.g. `user`). |
+| `defaults.login` | `sync` propagates logins where the credential is portable; `skip` probes and reports but takes no login action. |
+
+`login` accepts **`sync`** or **`skip`** only. (An interactive per-agent
+`prompt` mode is intentionally not offered — it was removed rather than accepted
+as a silent no-op.)
+
+## What a reconcile does
+
+For each targeted, reachable device `apply` probes state, then plans the minimal
+set of actions across four dimensions:
+
+- **agents-cli** — `install-cli` if absent, `upgrade-cli` on a version mismatch.
+- **agents** — `add-agent` for any profile agent not installed.
+- **config** — `sync-config` for the declared `sync:` scopes.
+- **login** — `push-login` where a portable credential can be propagated;
+  `needs-login` where the login is desired but genuinely can't be (see below).
+
+An unreachable device yields no actions. The whole run is idempotent — a device
+already matching the profile plans nothing.
+
+## The plan matrix
+
+`--plan` (or `--dry-run`) renders a device × dimension matrix and exits without
+changing anything:
+
+```
+Fleet profile · 10 device(s) · 3 agent(s) (claude, codex, gemini)
+  device        agents-cli  agents              config    login
+  yosemite-s0   ok 1.20.65  ok 3/3              ↑ sync    2 push · 1 manual
+  win-mini      + install   + 3                 ↑ sync    0 push · 3 manual
+  ...
+```
+
+Run without `--plan` to execute; `apply` confirms first, and `-y/--yes` skips
+the prompt.
+
+## Login propagation
+
+`login: sync` seeds a fresh machine from an already-signed-in one — the point of
+the feature. It turns "6 hosts × ~8 harnesses = ~48 OAuth flows" into a single
+login on the source.
+
+Portable credential files are captured on the source and streamed to each target
+over the encrypted SSH channel (`sshExec` **stdin** — never shell-interpolated) by
+an internal `--recv-auth` receiver that materializes them at `0600` and rejects
+path traversal. Agents with a portable credential:
+
+> `claude`, `codex`, `gemini`, `grok`, `kimi`, `opencode`, `droid`, `antigravity`
+
+**Honest boundary — never faked.** macOS keychain-bound tokens (`claude`,
+`antigravity`) can't be read from the ACL-locked keychain on a **macOS target**,
+and a token that is keychain-bound on the **source** can't be extracted to push.
+Those cases surface as a one-time **manual login** in the plan, not a fake
+success. Agents with no portable credential (e.g. `cursor`), and a source that
+simply isn't signed into an agent, produce no login action at all — the same on
+every OS.
+
+## Flags
+
+| Flag | Effect |
+|---|---|
+| `-f, --file <path>` | Manifest carrying the `fleet:` block (default `agents.yaml`). |
+| `--plan`, `--dry-run` | Show the reconcile plan and exit; change nothing. |
+| `-y, --yes` | Skip the confirmation prompt. |
+| `--device <name>` | Scope the apply to a single device. |
+| `--only <dims>` | Limit to a comma list of `agents,config,login`. |
+| `--no-login` | Do not propagate logins (equivalent to `login: skip` everywhere). |
+
+## Security
+
+Credential transport rides the existing SSH transport and passes bundles via real
+stdin, so credentials never appear in a command line or process list. The receiver
+validates paths and writes at `0600`. Consistent with the repo's rule to never
+transfer auth files without authorization, the live propagation path only runs on
+an explicit (non-`--plan`) `apply`.


### PR DESCRIPTION
Follow-up to #1207, which shipped `agents apply` with a CHANGELOG entry but no user-facing docs.

## What's here
- **README "Sync the fleet" section** (+ TOC entry) — the `fleet:` manifest block, `agents apply` command surface, the plan matrix, and login propagation with the honest macOS-keychain boundary.
- **docs/fleet.md** — source-grounded reference page: manifest schema, the four reconcile dimensions (agents-cli / agents / config / login), the plan matrix, login propagation (portable-agent list `claude, codex, gemini, grok, kimi, opencode, droid, antigravity`, never-faked keychain boundary), flags table, security notes.
- **docs index** entry under Orchestration.

## Not changed
Help text was already complete — `agents apply --help` carries a description and every option (`-f`, `--plan`, `--dry-run`, `-y`, `--device`, `--only`, `--no-login`), so nothing to add there.

## Grounding
Every claim is sourced from `src/commands/apply.ts` and `src/lib/fleet/{types,manifest,apply,auth-sync}.ts` — propagatable-agent list from `FLEET_AUTH_FILES`, keychain-bound set from `KEYCHAIN_BOUND_ON_MAC`, login modes (`sync | skip`) from the current `FleetLoginMode`. Docs-only; no code changes.