### PR TITLE
test: guard POSIX file-mode assertions on Windows (unblock 1.20.65 release matrix)

### DIFF
--- a/apps/cli/src/lib/fleet/auth-sync.test.ts
+++ b/apps/cli/src/lib/fleet/auth-sync.test.ts
@@ -39,8 +39,10 @@ describe('snapshotAuth + materializeAuth round-trip', () => {
 
     expect(fs.readFileSync(path.join(dst, '.codex/auth.json'), 'utf-8')).toBe('{"tokens":"codex-abc"}');
     expect(fs.readFileSync(path.join(dst, '.factory/auth.v2.key'), 'utf-8')).toBe('droid-key');
-    // credential mode preserved at 0600
-    expect(fs.statSync(path.join(dst, '.codex/auth.json')).mode & 0o777).toBe(0o600);
+    // credential mode preserved at 0600 (POSIX only — Windows has no 0600 bit)
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(path.join(dst, '.codex/auth.json')).mode & 0o777).toBe(0o600);
+    }
   });
 
   it('silently skips agents that are not signed in (no file on disk)', () => {

--- a/apps/cli/src/lib/ssh-tunnel.test.ts
+++ b/apps/cli/src/lib/ssh-tunnel.test.ts
@@ -158,9 +158,10 @@ describe('helper token persistence (C2)', () => {
     expect(readHelperToken(DEV)).toBeNull();
     writeHelperToken(DEV, 'sekret-token');
     expect(readHelperToken(DEV)).toBe('sekret-token');
-    // written owner-only
-    const mode = fs.statSync(helperTokenPath(DEV)).mode & 0o777;
-    expect(mode).toBe(0o600);
+    // written owner-only (POSIX only — Windows has no 0600 bit; statSync reports 0666)
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(helperTokenPath(DEV)).mode & 0o777).toBe(0o600);
+    }
     clearHelperToken(DEV);
     expect(readHelperToken(DEV)).toBeNull();
   });


### PR DESCRIPTION
The 1.20.65 release matrix (`build (windows-latest, 22/24)`, release-gated) failed on two `mode & 0o777 === 0o600` assertions — Windows reports `0o666` (writeFileSync mode is a no-op there). Guard both with `process.platform !== 'win32'`, matching `secrets/__tests__/linux.test.ts`.

- `ssh-tunnel.test.ts:163` — C2 helper-token 0600 check
- `fleet/auth-sync.test.ts:43` — fleet auth-materialize 0600 check

Both are release-matrix-only failures (regular PRs run a Windows no-op). The files are still written 0600 on POSIX; the assertion still runs there. macOS: 31 tests pass. Unblocks the `1.20.65` security release (5 Critical fixes).