### PR TITLE
chore: realign package.json version to 1.20.64 (published + tagged)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phnx-labs/agents-cli",
-  "version": "1.20.63",
+  "version": "1.20.64",
   "description": "One CLI for all your AI coding agents - versions, config, cloud dispatch, sessions, and teams (now with first-class Grok Build CLI support)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
`1.20.64` is published to npm and tagged `v1.20.64`, but main's `apps/cli/package.json` was left at `1.20.63`.

Root cause: the premature-bump revert (#1210) was merged after the re-cut release (#1206). The merge resolution kept the `## 1.20.64` CHANGELOG section (correct) but the `package.json` version stayed reverted to `1.20.63`. So the changelog is already right — `## 1.20.64` holds the released entries, `## Unreleased` holds only the newer `agents apply` entry — and this one-liner just realigns the version marker with the registry + tag.

No code, no changelog change. Prevents version confusion on the next release cut.