### PR TITLE
fix(crabbox): guard bare-service Claude token against email mismatch (RUSH-1607)

### DIFF
--- a/apps/cli/src/lib/crabbox/runtimes.test.ts
+++ b/apps/cli/src/lib/crabbox/runtimes.test.ts
@@ -161,6 +161,30 @@ describe('resolveClaudeCredentialsBlob', () => {
     expect(reads.filter((r) => r !== 'bare')[0]).toBe('svc:/home/match');
   });
 
+  itDarwin('returns the bare-service blob when preferEmail matches the bare service account', async () => {
+    const blob = await resolveClaudeCredentialsBlob({
+      preferEmail: 'want@b.com',
+      service: (home) => (home ? `svc:${home}` : 'bare'),
+      readItem: (svc) => (svc === 'bare' ? WRAPPED : (() => { throw new Error('miss'); })()),
+      listVersions: () => [],
+      versionHome: (v) => v,
+      accountEmail: async (_home) => 'want@b.com',
+    });
+    expect(blob).toBe(WRAPPED);
+  });
+
+  itDarwin('falls through bare service and returns null when preferEmail does not match', async () => {
+    const blob = await resolveClaudeCredentialsBlob({
+      preferEmail: 'want@b.com',
+      service: (home) => (home ? `svc:${home}` : 'bare'),
+      readItem: (svc) => (svc === 'bare' ? WRAPPED : (() => { throw new Error('miss'); })()),
+      listVersions: () => [],
+      versionHome: (v) => v,
+      accountEmail: async (_home) => 'other@b.com',
+    });
+    expect(blob).toBeNull();
+  });
+
   itDarwin('rejects a payload without a claudeAiOauth.accessToken', async () => {
     const blob = await resolveClaudeCredentialsBlob({
       service: () => 'bare',

--- a/apps/cli/src/lib/crabbox/runtimes.ts
+++ b/apps/cli/src/lib/crabbox/runtimes.ts
@@ -197,7 +197,15 @@ export async function resolveClaudeCredentialsBlob(opts?: {
   if (process.platform === 'darwin') {
     // 1) Bare service — the default native (non-managed) install.
     const bare = tryRead(service(undefined));
-    if (bare) return bare;
+    if (bare) {
+      if (!opts?.preferEmail) return bare;
+      // preferEmail is set — verify the bare service belongs to the right account
+      // before handing it back; on mismatch fall through to managed installs.
+      const realHome = process.env.AGENTS_REAL_HOME || os.homedir();
+      const bareEmail = await accountEmail(realHome).catch(() => null);
+      if (bareEmail === opts.preferEmail) return bare;
+      // email mismatch — fall through
+    }
 
     // 2) Managed installs — hash-suffixed service keyed to each version home.
     //    Prefer the version whose account email matches the copied config.


### PR DESCRIPTION
When `preferEmail` is provided to `resolveClaudeCredentialsBlob`, the bare-service Keychain read (step 1 — default native install) previously returned immediately without checking whether that credential belongs to the requested account. If the bare service held a different account's token, the wrong OAuth blob was handed back to the lease script.

Fix: after a successful bare-service read, when `preferEmail` is set, call `accountEmail(realHome)` and compare; on mismatch fall through to the managed-install scoring pass (which already ranks by email).

**Test evidence (`bun run test -- src/lib/crabbox/runtimes.test.ts`):**

```
 Test Files  1 passed (1)
      Tests  13 passed | 7 skipped (20)
   Start at  12:29:40
   Duration  950ms
```

Two new `itDarwin` tests assert (a) matching email returns the blob and (b) mismatched email falls through to `null`. The 7 skipped tests are all `itDarwin` assertions that only run on macOS; they will run in CI.

Transcript: yosemite-s0:/home/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-home-muqsit-src-github-com-muqsitnawaz-agents-cli--agents-worktrees-rush-1607-cred-email/db381140-ad80-4db8-95c9-9639f828e4eb.jsonl