### PR TITLE
fix(security): harden webhook ingress + feed dispatch (RUSH-1768)

### DIFF
--- a/apps/cli/src/commands/feed.test.ts
+++ b/apps/cli/src/commands/feed.test.ts
@@ -42,6 +42,14 @@ describe('parseRemoteFeed', () => {
     expect(parseRemoteFeed('login banner\n[]', 'mac-mini')).toEqual([]);
     expect(parseRemoteFeed('{}', 'mac-mini')).toEqual([]);
   });
+
+  it('drops blocks whose mailboxId is not a safe path segment', () => {
+    const valid = block('ok', 'peer', '2026-07-13T00:00:00Z');
+    const crafted = { ...block('evil', 'peer', '2026-07-13T00:00:00Z'), mailboxId: '../../etc/passwd' };
+    const dotdot = { ...block('dots', 'peer', '2026-07-13T00:00:00Z'), mailboxId: '..' };
+    const parsed = parseRemoteFeed(JSON.stringify([valid, crafted, dotdot]), 'mac-mini');
+    expect(parsed.map((b) => b.sessionId)).toEqual(['ok']);
+  });
 });
 
 describe('mergeFeedBlocks', () => {

--- a/apps/cli/src/commands/feed.ts
+++ b/apps/cli/src/commands/feed.ts
@@ -32,6 +32,7 @@ import { gatherRemoteAgentsJson } from '../lib/remote-agents-json.js';
 import { loadPolicy, applyPolicyToBlock, isPhoneUrgent } from '../lib/feed-policy.js';
 import { notifyUrgentBlock } from '../lib/notify.js';
 import { gcMailbox } from '../lib/mailbox-gc.js';
+import { isValidMailboxId } from '../lib/mailbox.js';
 import { getActiveSessions } from '../lib/session/active.js';
 import { mailboxIdForActiveSession } from '../lib/mailbox-target.js';
 import { GLYPH, masthead } from '../lib/comms-render.js';
@@ -62,6 +63,10 @@ export function parseRemoteFeed(stdout: string, machine: string): OpenBlock[] {
     if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
     const block = item as Partial<OpenBlock>;
     if (!block.blockId || !block.sessionId || !block.mailboxId || !block.questions?.length) continue;
+    // A crafted mailboxId (path separators, `.`/`..`) would throw inside
+    // mailboxDir() when policy runs against the block, aborting the whole
+    // dispatch loop — drop it here so a malicious peer can't smuggle one in.
+    if (!isValidMailboxId(block.mailboxId)) continue;
     blocks.push({ ...block, host: machine } as OpenBlock);
   }
   return blocks;
@@ -295,18 +300,25 @@ export function registerFeedCommand(program: Command): void {
         const policy = loadPolicy();
         const now = new Date();
         for (const b of blocks) {
-          const result = applyPolicyToBlock(b, policy, now);
-          if (result.action !== 'none') {
-            console.log(`${chalk.yellow('policy')} ${b.blockId}: ${result.action}`);
-          }
-          if (isPhoneUrgent(b, policy)) {
-            const notifyResult = await notifyUrgentBlock(b, { dryRun: opts.json });
-            if (notifyResult.ok && !notifyResult.skipped) {
-              recordNotified(b.blockId);
-              console.log(`${chalk.green('notified')} ${b.blockId}`);
-            } else if (notifyResult.error) {
-              console.error(chalk.yellow(`Notification failed for ${b.blockId}: ${notifyResult.error}`));
+          // Wrap per-block policy so one malformed block (e.g. a crafted
+          // mailboxId that throws in mailboxDir) can't abort the whole loop and
+          // strand every remaining block's dispatch.
+          try {
+            const result = applyPolicyToBlock(b, policy, now);
+            if (result.action !== 'none') {
+              console.log(`${chalk.yellow('policy')} ${b.blockId}: ${result.action}`);
             }
+            if (isPhoneUrgent(b, policy)) {
+              const notifyResult = await notifyUrgentBlock(b, { dryRun: opts.json });
+              if (notifyResult.ok && !notifyResult.skipped) {
+                recordNotified(b.blockId);
+                console.log(`${chalk.green('notified')} ${b.blockId}`);
+              } else if (notifyResult.error) {
+                console.error(chalk.yellow(`Notification failed for ${b.blockId}: ${notifyResult.error}`));
+              }
+            }
+          } catch (err) {
+            console.error(chalk.yellow(`Skipped block ${b.blockId}: ${(err as Error).message}`));
           }
         }
       }

--- a/apps/cli/src/commands/webhook.ts
+++ b/apps/cli/src/commands/webhook.ts
@@ -7,9 +7,11 @@
  */
 import type { Command } from 'commander';
 import type { Server } from 'http';
+import * as path from 'path';
 import chalk from 'chalk';
 import { readAndResolveBundleEnv, isHeadlessSecretsContext } from '../lib/secrets/bundles.js';
-import { startWebhookServer, type WebhookSecrets } from '../lib/triggers/webhook.js';
+import { createFileDeliveryStore, startWebhookServer, type WebhookSecrets } from '../lib/triggers/webhook.js';
+import { getRuntimeStateDir } from '../lib/state.js';
 
 const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 8787;
@@ -87,6 +89,11 @@ export function registerWebhookCommand(program: Command): void {
           port,
           secrets,
           rateLimitPerMinute: rateLimit,
+          // Durable delivery dedup: replays survive a receiver restart (an
+          // in-memory store would forget every seen delivery on restart).
+          deliveryStore: createFileDeliveryStore(
+            path.join(getRuntimeStateDir(), 'webhook', 'deliveries.json'),
+          ),
           onDelivery: (webhook, fired) => {
             console.log(
               `${new Date().toISOString()} ${webhook.source}:${webhook.event} ` +

--- a/apps/cli/src/lib/triggers/webhook.test.ts
+++ b/apps/cli/src/lib/triggers/webhook.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import * as crypto from 'crypto';
+import * as fs from 'fs';
 import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
 import type { JobConfig, RunMeta } from '../routines.js';
 import {
   matchJobsToWebhook,
@@ -11,6 +14,7 @@ import {
   verifyGithubSignature,
   verifyLinearSignature,
   startWebhookServer,
+  createFileDeliveryStore,
   type IncomingWebhook,
 } from './webhook.js';
 
@@ -485,6 +489,105 @@ describe('startWebhookServer', () => {
       expect(dispatched).toEqual(['linear-agent', 'linear-followup', 'linear-followup']);
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('throttles a per-IP flood before the body read, even with invalid signatures', async () => {
+    const server = startWebhookServer({
+      secrets: { linear: 'linear-secret' },
+      ipRateLimitPerMinute: 2,
+      fire: { jobs: [], dispatch: async (): Promise<RunMeta> => { throw new Error('should not dispatch'); } },
+    });
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+    const address = server.address();
+    if (!address || typeof address !== 'object') throw new Error('server did not bind');
+    try {
+      const payload = Buffer.from(JSON.stringify({ type: 'Issue' }));
+      const send = () => new Promise<number>((resolve, reject) => {
+        const req = http.request({
+          host: '127.0.0.1', port: address.port, path: '/hooks/linear', method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'content-length': String(payload.length),
+            'linear-signature': 'deadbeef',
+          },
+        }, (res) => { res.resume(); res.on('end', () => resolve(res.statusCode ?? 0)); });
+        req.on('error', reject);
+        req.end(payload);
+      });
+      // Bad signatures: first two clear the per-IP gate then fail HMAC (401);
+      // the third is shed by the per-IP limiter BEFORE the body read (429).
+      expect(await send()).toBe(401);
+      expect(await send()).toBe(401);
+      expect(await send()).toBe(429);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('rejects an over-cap declared body before reading it', async () => {
+    const server = startWebhookServer({
+      secrets: { linear: 'linear-secret' },
+      maxBodyBytes: 64,
+      fire: { jobs: [], dispatch: async (): Promise<RunMeta> => { throw new Error('should not dispatch'); } },
+    });
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+    const address = server.address();
+    if (!address || typeof address !== 'object') throw new Error('server did not bind');
+    try {
+      const big = Buffer.alloc(1024, 0x61);
+      const status = await new Promise<number>((resolve, reject) => {
+        const req = http.request({
+          host: '127.0.0.1', port: address.port, path: '/hooks/linear', method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'content-length': String(big.length),
+            'linear-signature': 'deadbeef',
+          },
+        }, (res) => { res.resume(); res.on('end', () => resolve(res.statusCode ?? 0)); });
+        req.on('error', reject);
+        req.end(big);
+      });
+      expect(status).toBe(413);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});
+
+describe('createFileDeliveryStore', () => {
+  it('remembers a completed delivery across a restart (new store, same file)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'webhook-deliveries-'));
+    const file = path.join(dir, 'deliveries.json');
+    try {
+      const first = createFileDeliveryStore(file);
+      expect(first.seen('github:delivery-1')).toBe(false);
+      first.markJob('github:delivery-1', 'job-a');
+      first.mark('github:delivery-1');
+      expect(first.seen('github:delivery-1')).toBe(true);
+
+      // Simulate a receiver restart: a brand-new store loads the persisted file.
+      const restarted = createFileDeliveryStore(file);
+      expect(restarted.seen('github:delivery-1')).toBe(true);
+      expect([...restarted.completedJobs('github:delivery-1')]).toEqual(['job-a']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not resurrect a delivery older than the retention window', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'webhook-deliveries-'));
+    const file = path.join(dir, 'deliveries.json');
+    try {
+      // A persisted entry stamped well beyond the retention window is pruned on
+      // load — an ancient captured delivery cannot be replayed as a duplicate.
+      fs.writeFileSync(file, JSON.stringify({
+        'github:ancient': { complete: true, jobs: [], updatedAt: Date.now() - 10 * 60_000 },
+      }));
+      const store = createFileDeliveryStore(file, 60_000); // 1-minute retention
+      expect(store.seen('github:ancient')).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/apps/cli/src/lib/triggers/webhook.ts
+++ b/apps/cli/src/lib/triggers/webhook.ts
@@ -13,7 +13,9 @@
  */
 
 import * as crypto from 'crypto';
+import * as fs from 'fs';
 import * as http from 'http';
+import * as path from 'path';
 import type { IncomingHttpHeaders } from 'http';
 import type {
   GithubJobTrigger,
@@ -305,6 +307,98 @@ export function createMemoryDeliveryStore(maxEntries = 1000): DeliveryStore {
   };
 }
 
+/** Serialized shape of one durable delivery record on disk. */
+interface PersistedDelivery {
+  complete: boolean;
+  jobs: string[];
+  updatedAt: number;
+}
+
+/**
+ * A durable, disk-backed delivery store. Unlike `createMemoryDeliveryStore`,
+ * seen delivery ids survive a process restart and are bounded by AGE, not by a
+ * fixed entry count — so a captured valid delivery cannot re-fire after a
+ * restart or after count-based LRU eviction would have dropped it.
+ *
+ * `retentionMs` doubles as the replay-acceptance window: a delivery whose id is
+ * still on record (younger than the window) is rejected as a duplicate; entries
+ * older than the window are pruned (keeping the file bounded) since a webhook
+ * source will not legitimately retry a delivery that old.
+ */
+export function createFileDeliveryStore(
+  filePath: string,
+  retentionMs = 14 * 24 * 60 * 60 * 1000,
+): DeliveryStore {
+  const seen = new Map<string, { complete: boolean; jobs: Set<string>; updatedAt: number }>();
+
+  // Load persisted state (best-effort: a corrupt/missing file starts empty).
+  try {
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Record<string, PersistedDelivery>;
+    const loadedAt = Date.now();
+    for (const [id, entry] of Object.entries(raw)) {
+      if (typeof entry?.updatedAt !== 'number' || loadedAt - entry.updatedAt > retentionMs) continue;
+      seen.set(id, {
+        complete: entry.complete === true,
+        jobs: new Set(Array.isArray(entry.jobs) ? entry.jobs : []),
+        updatedAt: entry.updatedAt,
+      });
+    }
+  } catch {
+    // no prior file / unreadable — start empty
+  }
+
+  const persist = () => {
+    const snapshot: Record<string, PersistedDelivery> = {};
+    for (const [id, entry] of seen) {
+      snapshot[id] = { complete: entry.complete, jobs: [...entry.jobs], updatedAt: entry.updatedAt };
+    }
+    try {
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      const tmp = `${filePath}.${process.pid}.tmp`;
+      fs.writeFileSync(tmp, JSON.stringify(snapshot), 'utf-8');
+      fs.renameSync(tmp, filePath);
+    } catch {
+      // best-effort durability; an unwritable dir must not crash ingress
+    }
+  };
+
+  const prune = (now: number) => {
+    for (const [id, entry] of seen) {
+      if (now - entry.updatedAt > retentionMs) seen.delete(id);
+    }
+  };
+
+  const touch = (id: string) => {
+    const now = Date.now();
+    prune(now);
+    let current = seen.get(id);
+    if (!current) {
+      current = { complete: false, jobs: new Set<string>(), updatedAt: now };
+      seen.set(id, current);
+    }
+    current.updatedAt = now;
+    return current;
+  };
+
+  return {
+    seen: (id) => {
+      const entry = seen.get(id);
+      if (!entry) return false;
+      if (Date.now() - entry.updatedAt > retentionMs) return false;
+      return entry.complete === true;
+    },
+    mark: (id) => {
+      touch(id).complete = true;
+      persist();
+    },
+    completedJobs: (id) => new Set(seen.get(id)?.jobs ?? []),
+    markJob: (id, jobName) => {
+      touch(id).jobs.add(jobName);
+      persist();
+    },
+  };
+}
+
 export interface RateLimiter {
   take(key: string): boolean;
 }
@@ -364,6 +458,12 @@ export interface WebhookServerOptions {
   rateLimiter?: RateLimiter;
   rateLimitPerMinute?: number;
   maxBodyBytes?: number;
+  /** Per-IP ingress throttle applied BEFORE the body read (bad-sig flood guard). */
+  ipRateLimiter?: RateLimiter;
+  /** Per-source-IP requests/minute allowed through to the body read. Default 120. */
+  ipRateLimitPerMinute?: number;
+  /** Max concurrent TCP connections the receiver accepts. Default 256. */
+  maxConnections?: number;
 }
 
 /**
@@ -376,6 +476,7 @@ export interface WebhookServerOptions {
 export function startWebhookServer(options: WebhookServerOptions): http.Server {
   const deliveryStore = options.deliveryStore ?? createMemoryDeliveryStore();
   const rateLimiter = options.rateLimiter ?? createMemoryRateLimiter(options.rateLimitPerMinute ?? 60, 60_000);
+  const ipRateLimiter = options.ipRateLimiter ?? createMemoryRateLimiter(options.ipRateLimitPerMinute ?? 120, 60_000);
   const maxBodyBytes = options.maxBodyBytes ?? 1024 * 1024;
 
   const server = http.createServer((req, res) => {
@@ -397,6 +498,24 @@ export function startWebhookServer(options: WebhookServerOptions): http.Server {
       if (!secret) {
         res.writeHead(503, { 'content-type': 'application/json' });
         res.end(JSON.stringify({ ok: false, error: `missing ${source} webhook secret` }));
+        return;
+      }
+
+      // Per-IP throttle + declared-size cap BEFORE the (expensive) body read +
+      // HMAC. A bad-signature flood of 1 MiB POSTs must be rejected without
+      // forcing a full body read and an HMAC per request — the signed-delivery
+      // rate limit further down runs only after a signature passes, so it can't
+      // shed this load on its own.
+      const ip = req.socket.remoteAddress ?? 'unknown';
+      if (!ipRateLimiter.take(ip)) {
+        res.writeHead(429, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, error: 'rate limit exceeded' }));
+        return;
+      }
+      const declaredLength = Number.parseInt(header(req.headers, 'content-length') ?? '', 10);
+      if (Number.isFinite(declaredLength) && declaredLength > maxBodyBytes) {
+        res.writeHead(413, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, error: `payload exceeds ${maxBodyBytes} bytes` }));
         return;
       }
 
@@ -455,6 +574,10 @@ export function startWebhookServer(options: WebhookServerOptions): http.Server {
       }
     })();
   });
+
+  // Connection cap: bound how many concurrent TCP connections the receiver
+  // will hold open, so a flood cannot exhaust file descriptors / memory.
+  server.maxConnections = options.maxConnections ?? 256;
 
   server.listen(options.port ?? 0, options.host ?? '127.0.0.1');
   return server;


### PR DESCRIPTION
Implements 3 of 4 RUSH-1768 (Security LOW) findings; the 4th has no matching code in this tree (see below).

## Findings addressed

**1. Webhook replay across restart/eviction** (`triggers/webhook.ts`) — dedup was an in-memory 1000-entry LRU lost on restart, so a captured valid delivery could re-fire. Added `createFileDeliveryStore`: a durable, disk-backed delivery store bounded by **age** (not entry count), so seen delivery ids survive a restart and aren't dropped by count-based eviction. The retention window doubles as the replay-acceptance bound. `webhook serve` now persists deliveries under the runtime state dir. Linear deliveries keep the existing signed `webhookTimestamp` check (GitHub carries no signed delivery timestamp, so durability is its replay defense).

**2. Invalid-signature flood** (`triggers/webhook.ts`) — `rateLimiter.take(source)` ran only *after* the signature passed, so a bad-sig flood of 1 MiB POSTs forced a full body read + HMAC unthrottled. Added a **per-IP rate limit** and a **Content-Length cap** *before* the body read, plus a `maxConnections` cap on the receiver.

**3. `feed --dispatch` crash** (`commands/feed.ts`) — a crafted `mailboxId` passed `parseRemoteFeed`'s truthy check, then threw in `mailboxDir()` and aborted the whole dispatch loop. Fix: `parseRemoteFeed` now drops blocks failing `isValidMailboxId`, and the per-block policy loop is wrapped in `try/catch` so one bad block can't strand the rest.

**4. Watchdog Unix socket** — **not applicable in this tree.** There is no unauthenticated watchdog socket: the watchdog (`lib/watchdog/`) uses tray-readable state files, not a socket. The only local Unix sockets are `pty.sock` (`lib/pty-server.ts:658-676` — dir `chmod 0o700`, socket `chmod 0o600`, `umask 0o077`) and `computer.sock` (Swift helper `chmod 0o600` + executable-path peer-auth). Both already enforce a permission/auth boundary. Noted here rather than inventing a target.

## Test evidence

New 1:1 tests (would fail without the change):
- `webhook.test.ts` — durable store survives a simulated restart (new store, same file) and prunes entries older than the retention window; per-IP flood is throttled (429) *before* the body read even with invalid signatures; over-cap declared body rejected (413).
- `feed.test.ts` — `parseRemoteFeed` drops blocks whose `mailboxId` is `../../etc/passwd` / `..`.

```
$ node ./node_modules/vitest/vitest.mjs run src/lib/triggers/webhook.test.ts src/commands/feed.test.ts
 Test Files  2 passed (2)
      Tests  33 passed (33)

$ node ./node_modules/typescript/bin/tsc --noEmit
tsc exit=0
```

Full-suite run: `3 failed | 5722 passed | 78 skipped`. The 3 failures are in `exec.test.ts` and `import.test.ts` — files this PR does not touch and that don't reference any changed symbol; they are environmental on the Linux CI box (e.g. a `package.json` existing above `/tmp` on the walk-up, env-var injection state).