### PR TITLE
feat(ios): Fleet Cockpit app — AnchorKit client core + SwiftUI shell (RUSH-1734)

### DIFF
--- a/apps/ios/AnchorKit/.gitignore
+++ b/apps/ios/AnchorKit/.gitignore
@@ -1,0 +1,3 @@
+.build/
+*.xcodeproj/
+DerivedData/

--- a/apps/ios/AnchorKit/Package.swift
+++ b/apps/ios/AnchorKit/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+// AnchorKit — the verified networking core of the Fleet Cockpit iOS/iPadOS app.
+//
+// The client logic (models, SSE parsing, the anchor API client, token storage)
+// lives here as a platform-agnostic SwiftPM library so it can be built and
+// verified headlessly on macOS — no Xcode or simulator required — and reused
+// verbatim by the SwiftUI app target.
+//
+// Verification uses two runnable executables rather than XCTest/swift-testing,
+// because those frameworks ship only with full Xcode (this repo's CI is
+// Node/bun and never builds Swift; a dev machine with Xcode can add XCTest
+// targets later):
+//   • `anchorcheck` — pure-logic assertions (SSE parsing, model coding, token
+//     store). `swift run anchorcheck` exits non-zero on any failure.
+//   • `anchorprobe` — drives AnchorClient against a REAL `agents serve
+//     --control` anchor end to end.
+let package = Package(
+    name: "AnchorKit",
+    platforms: [.macOS(.v13), .iOS(.v16)],
+    products: [
+        .library(name: "AnchorKit", targets: ["AnchorKit"]),
+        .executable(name: "anchorprobe", targets: ["anchorprobe"]),
+        .executable(name: "anchorcheck", targets: ["anchorcheck"]),
+    ],
+    targets: [
+        .target(name: "AnchorKit"),
+        .executableTarget(name: "anchorprobe", dependencies: ["AnchorKit"]),
+        .executableTarget(name: "anchorcheck", dependencies: ["AnchorKit"]),
+    ]
+)

--- a/apps/ios/AnchorKit/Sources/AnchorKit/AnchorClient.swift
+++ b/apps/ios/AnchorKit/Sources/AnchorKit/AnchorClient.swift
@@ -1,0 +1,112 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Typed client for the authenticated `agents serve --control` anchor.
+///
+/// Every request carries the paired bearer token. The four operations mirror the
+/// server surface: read fleet state, dispatch a run, steer a run, and tail a
+/// run's live events. All networking lives here so the SwiftUI layer stays a
+/// thin projection of `AnchorKit` — and so this can be exercised end to end
+/// against a real anchor from `anchorprobe` and the tests.
+public struct AnchorClient: Sendable {
+    public let baseURL: URL
+    public let token: String
+    private let session: URLSession
+
+    public init(baseURL: URL, token: String, session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.token = token
+        self.session = session
+    }
+
+    private func request(_ path: String, method: String = "GET") -> URLRequest {
+        var req = URLRequest(url: baseURL.appendingPathComponent(path))
+        req.httpMethod = method
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        return req
+    }
+
+    private func check(_ response: URLResponse, _ body: Data) throws {
+        guard let http = response as? HTTPURLResponse else { return }
+        guard (200..<300).contains(http.statusCode) else {
+            if http.statusCode == 401 { throw AnchorError.unauthorized }
+            let msg = (try? JSONDecoder().decode([String: String].self, from: body))?["error"]
+            throw AnchorError.http(status: http.statusCode, message: msg)
+        }
+    }
+
+    /// `GET /api/state` — the fleet snapshot backing the Fleet view.
+    public func fetchState() async throws -> FleetState {
+        let (data, response) = try await session.data(for: request("api/state"))
+        try check(response, data)
+        do { return try JSONDecoder().decode(FleetState.self, from: data) }
+        catch { throw AnchorError.decoding("\(error)") }
+    }
+
+    /// `POST /api/run` — dispatch a headless run; returns its addressable ids.
+    public func dispatchRun(_ run: RunRequest) async throws -> RunResult {
+        var req = request("api/run", method: "POST")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONEncoder().encode(run)
+        let (data, response) = try await session.data(for: req)
+        try check(response, data)
+        do { return try JSONDecoder().decode(RunResult.self, from: data) }
+        catch { throw AnchorError.decoding("\(error)") }
+    }
+
+    /// `POST /api/session/:id/message` — steer a running/parked agent.
+    public func sendMessage(sessionId: String, text: String, from: String? = nil) async throws {
+        var req = request("api/session/\(encode(sessionId))/message", method: "POST")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        var body: [String: String] = ["text": text]
+        if let from { body["from"] = from }
+        req.httpBody = try JSONEncoder().encode(body)
+        let (data, response) = try await session.data(for: req)
+        try check(response, data)
+    }
+
+    /// `GET /api/session/:id/stream` — the live SSE event stream, resumable from
+    /// `fromOffset`. Yields normalized events until the terminal `end` frame or
+    /// the task is cancelled.
+    public func events(sessionId: String, fromOffset: Int? = nil) -> AsyncThrowingStream<StreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    var path = "api/session/\(encode(sessionId))/stream"
+                    if let fromOffset { path += "?offset=\(fromOffset)" }
+                    let (bytes, response) = try await session.bytes(for: request(path))
+                    if let http = response as? HTTPURLResponse, http.statusCode == 401 {
+                        throw AnchorError.unauthorized
+                    }
+                    // Split the raw byte stream on \n ourselves — `bytes.lines`
+                    // does not reliably surface the BLANK lines that terminate
+                    // SSE frames, so the parser would never close a frame.
+                    var parser = SSEParser()
+                    var buf: [UInt8] = []
+                    for try await byte in bytes {
+                        if byte == 0x0A { // \n
+                            let line = String(decoding: buf, as: UTF8.self)
+                            buf.removeAll(keepingCapacity: true)
+                            if let ev = parser.feed(line) {
+                                continuation.yield(ev)
+                                if ev.type == "end" { continuation.finish(); return }
+                            }
+                        } else if byte != 0x0D { // drop \r; feed() also tolerates it
+                            buf.append(byte)
+                        }
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    private func encode(_ s: String) -> String {
+        s.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? s
+    }
+}

--- a/apps/ios/AnchorKit/Sources/AnchorKit/Models.swift
+++ b/apps/ios/AnchorKit/Sources/AnchorKit/Models.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// A request to start an agent run on the anchor — the body of `POST /api/run`.
+public struct RunRequest: Codable, Equatable, Sendable {
+    public var agent: String
+    public var prompt: String
+    public var mode: String?
+    public var host: String?
+    public var cwd: String?
+
+    public init(agent: String, prompt: String, mode: String? = nil, host: String? = nil, cwd: String? = nil) {
+        self.agent = agent
+        self.prompt = prompt
+        self.mode = mode
+        self.host = host
+        self.cwd = cwd
+    }
+}
+
+/// The anchor's `POST /api/run` response: the ids by which the run can be
+/// streamed and steered.
+public struct RunResult: Codable, Equatable, Sendable {
+    public let sessionId: String
+    public let name: String
+}
+
+/// A normalized live event decoded from the SSE stream at
+/// `GET /api/session/:id/stream`.
+public struct StreamEvent: Equatable, Sendable {
+    /// The SSE `id:` — the exact byte offset past this event's line, used as the
+    /// resume cursor (`Last-Event-ID` / `?offset=`). `nil` for control frames
+    /// like the terminal `end`.
+    public let id: Int?
+    /// The SSE `event:` — `assistant`, `tool_use`, `result`, `error`, `end`, …
+    public let type: String
+    /// The raw JSON payload from the `data:` line.
+    public let data: String
+
+    public init(id: Int?, type: String, data: String) {
+        self.id = id
+        self.type = type
+        self.data = data
+    }
+
+    /// True for the frames that end a run's stream.
+    public var isTerminal: Bool { type == "end" || type == "result" || type == "error" }
+}
+
+/// A lightweight decode of the anchor's `GET /api/state` snapshot. Enough to
+/// drive the Fleet view's health at a glance; the full panels are decoded by the
+/// UI as needed.
+public struct FleetState: Decodable, Equatable, Sendable {
+    public let generatedAt: String
+    public let teamsOK: Bool
+    public let routinesOK: Bool
+    public let cloudOK: Bool
+
+    private struct Panel: Decodable { let ok: Bool }
+
+    enum CodingKeys: String, CodingKey {
+        case generatedAt = "generated_at"
+        case teams, routines, cloud
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        generatedAt = try c.decode(String.self, forKey: .generatedAt)
+        teamsOK = (try? c.decode(Panel.self, forKey: .teams))?.ok ?? false
+        routinesOK = (try? c.decode(Panel.self, forKey: .routines))?.ok ?? false
+        cloudOK = (try? c.decode(Panel.self, forKey: .cloud))?.ok ?? false
+    }
+}
+
+/// Errors surfaced by ``AnchorClient``.
+public enum AnchorError: Error, Equatable, Sendable {
+    /// Non-2xx HTTP status, with the server-provided message when present.
+    case http(status: Int, message: String?)
+    /// The bearer token was rejected (401).
+    case unauthorized
+    /// A response body could not be decoded.
+    case decoding(String)
+    /// A malformed base URL / request.
+    case badRequest(String)
+}

--- a/apps/ios/AnchorKit/Sources/AnchorKit/SSEParser.swift
+++ b/apps/ios/AnchorKit/Sources/AnchorKit/SSEParser.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Incremental parser for the anchor's Server-Sent Events stream.
+///
+/// Frames are `id:` / `event:` / `data:` lines terminated by a blank line. The
+/// parser accumulates fields line-by-line and emits a ``StreamEvent`` when the
+/// frame closes. It mirrors the server contract in `serve/control.ts`
+/// (`startSessionStream`): one event per frame, `id` = the byte-offset resume
+/// cursor. Unknown fields and comment lines (`:` prefix) are ignored per the SSE
+/// spec.
+public struct SSEParser {
+    private var id: Int?
+    private var event: String?
+    private var data: String?
+
+    public init() {}
+
+    /// Feed one line (without its trailing newline). Returns a ``StreamEvent``
+    /// when this line closes a frame (a blank line), otherwise `nil`.
+    public mutating func feed(_ rawLine: String) -> StreamEvent? {
+        // Strip a single trailing CR (CRLF streams).
+        let line = rawLine.hasSuffix("\r") ? String(rawLine.dropLast()) : rawLine
+
+        if line.isEmpty {
+            // Blank line terminates the frame. A frame with no `event:` and no
+            // `data:` (a keep-alive) yields nothing.
+            defer { id = nil; event = nil; data = nil }
+            guard event != nil || data != nil else { return nil }
+            return StreamEvent(id: id, type: event ?? "message", data: data ?? "")
+        }
+        if line.hasPrefix(":") { return nil } // comment / heartbeat
+
+        guard let colon = line.firstIndex(of: ":") else { return nil }
+        let field = String(line[line.startIndex..<colon])
+        var value = String(line[line.index(after: colon)...])
+        if value.hasPrefix(" ") { value.removeFirst() } // SSE strips one leading space
+
+        switch field {
+        case "id": id = Int(value)
+        case "event": event = value
+        case "data": data = data.map { $0 + "\n" + value } ?? value
+        default: break // ignore unknown fields (e.g. `retry`)
+        }
+        return nil
+    }
+
+    /// Parse a complete SSE text blob into events (convenience for tests).
+    public static func parse(_ text: String) -> [StreamEvent] {
+        var parser = SSEParser()
+        var out: [StreamEvent] = []
+        // Split on \n; feed() handles a trailing \r. A final frame without a
+        // trailing blank line is flushed explicitly below.
+        for line in text.components(separatedBy: "\n") {
+            if let ev = parser.feed(line) { out.append(ev) }
+        }
+        if let ev = parser.feed("") { out.append(ev) } // flush any dangling frame
+        return out
+    }
+}

--- a/apps/ios/AnchorKit/Sources/AnchorKit/TokenStore.swift
+++ b/apps/ios/AnchorKit/Sources/AnchorKit/TokenStore.swift
@@ -1,0 +1,72 @@
+import Foundation
+#if canImport(Security)
+import Security
+#endif
+
+/// Where the cockpit keeps its anchor bearer token. Protocol so the app uses the
+/// Keychain while tests use an in-memory double.
+public protocol TokenStore: Sendable {
+    func load() -> String?
+    func save(_ token: String) throws
+    func clear() throws
+}
+
+/// In-memory token store for tests and previews.
+public final class InMemoryTokenStore: TokenStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: String?
+    public init(_ initial: String? = nil) { value = initial }
+    public func load() -> String? { lock.lock(); defer { lock.unlock() }; return value }
+    public func save(_ token: String) throws { lock.lock(); value = token; lock.unlock() }
+    public func clear() throws { lock.lock(); value = nil; lock.unlock() }
+}
+
+#if canImport(Security)
+/// Keychain-backed token store for the shipping app — the token never touches
+/// `UserDefaults` or disk in the clear.
+public final class KeychainTokenStore: TokenStore, @unchecked Sendable {
+    private let service: String
+    private let account: String
+
+    public init(service: String = "ai.phoenix.cockpit.anchor", account: String = "control-token") {
+        self.service = service
+        self.account = account
+    }
+
+    private func baseQuery() -> [String: Any] {
+        [kSecClass as String: kSecClassGenericPassword,
+         kSecAttrService as String: service,
+         kSecAttrAccount as String: account]
+    }
+
+    public func load() -> String? {
+        var query = baseQuery()
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    public func save(_ token: String) throws {
+        let data = Data(token.utf8)
+        // Delete-then-add keeps it idempotent across re-pairing.
+        SecItemDelete(baseQuery() as CFDictionary)
+        var add = baseQuery()
+        add[kSecValueData as String] = data
+        add[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        let status = SecItemAdd(add as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw AnchorError.badRequest("keychain save failed (OSStatus \(status))")
+        }
+    }
+
+    public func clear() throws {
+        let status = SecItemDelete(baseQuery() as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw AnchorError.badRequest("keychain clear failed (OSStatus \(status))")
+        }
+    }
+}
+#endif

--- a/apps/ios/AnchorKit/Sources/anchorcheck/main.swift
+++ b/apps/ios/AnchorKit/Sources/anchorcheck/main.swift
@@ -1,0 +1,76 @@
+import Foundation
+import AnchorKit
+
+// anchorcheck — headless verification of AnchorKit's pure logic (no XCTest, which
+// needs full Xcode). `swift run anchorcheck` runs every assertion and exits
+// non-zero on the first failure, printing one line per check.
+
+var failures = 0
+func check(_ name: String, _ cond: Bool) {
+    print("\(cond ? "ok  " : "FAIL") \(name)")
+    if !cond { failures += 1 }
+}
+
+// --- SSE parsing ---
+do {
+    let blob = """
+    id: 35
+    event: system
+    data: {"type":"system"}
+
+    id: 83
+    event: assistant
+    data: {"type":"assistant","t":"hi"}
+
+    event: end
+    data: {"ok":true}
+
+    """
+    let e = SSEParser.parse(blob)
+    check("sse: three frames parsed", e.count == 3)
+    check("sse: first id/type/data", e[0].id == 35 && e[0].type == "system" && e[0].data == #"{"type":"system"}"#)
+    check("sse: assistant frame", e[1].id == 83 && e[1].type == "assistant")
+    check("sse: end frame terminal, no id", e[2].type == "end" && e[2].id == nil && e[2].isTerminal)
+
+    let hb = SSEParser.parse(": keep-alive\nretry: 1000\nevent: result\ndata: {}\n\n")
+    check("sse: ignores comments/unknown fields", hb.count == 1 && hb[0].type == "result" && hb[0].isTerminal)
+
+    var p = SSEParser()
+    _ = p.feed("event: assistant\r"); _ = p.feed("data:  two\r")
+    let ev = p.feed("")
+    check("sse: strips one leading space + trailing CR", ev?.type == "assistant" && ev?.data == " two")
+
+    check("sse: concatenates multiple data lines", SSEParser.parse("event: x\ndata: a\ndata: b\n\n").first?.data == "a\nb")
+}
+
+// --- model coding ---
+do {
+    let data = try JSONEncoder().encode(RunRequest(agent: "claude", prompt: "go"))
+    let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    check("model: RunRequest keeps agent/prompt", obj["agent"] as? String == "claude" && obj["prompt"] as? String == "go")
+    check("model: RunRequest omits nil optionals", obj["mode"] == nil && obj["host"] == nil && obj["cwd"] == nil)
+
+    let r = try JSONDecoder().decode(RunResult.self, from: Data(#"{"sessionId":"sid","name":"ios-ab"}"#.utf8))
+    check("model: RunResult decodes", r.sessionId == "sid" && r.name == "ios-ab")
+
+    let s = try JSONDecoder().decode(FleetState.self, from: Data(#"""
+    {"generated_at":"2026-07-16T00:00:00Z","teams":{"ok":true,"data":[]},"routines":{"ok":true,"data":[]},"cloud":{"ok":false,"error":"x"}}
+    """#.utf8))
+    check("model: FleetState decodes generated_at + panel ok", s.generatedAt == "2026-07-16T00:00:00Z" && s.teamsOK && s.routinesOK && !s.cloudOK)
+} catch {
+    check("model: coding threw \(error)", false)
+}
+
+// --- token store ---
+do {
+    let store = InMemoryTokenStore()
+    try store.save("abc")
+    let loaded = store.load()
+    try store.clear()
+    check("token: in-memory round-trip", loaded == "abc" && store.load() == nil)
+} catch {
+    check("token: threw \(error)", false)
+}
+
+print(failures == 0 ? "\nanchorcheck: ALL PASS" : "\nanchorcheck: \(failures) FAILURE(S)")
+exit(failures == 0 ? 0 : 1)

--- a/apps/ios/AnchorKit/Sources/anchorprobe/main.swift
+++ b/apps/ios/AnchorKit/Sources/anchorprobe/main.swift
@@ -1,0 +1,61 @@
+import Foundation
+import AnchorKit
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+// anchorprobe — end-to-end check of AnchorKit against a REAL `agents serve
+// --control` anchor. Not part of the app; a verification harness.
+//
+//   ANCHOR_URL=http://127.0.0.1:4477 ANCHOR_TOKEN=<token> \
+//   ANCHOR_SESSION=<id> swift run anchorprobe
+//
+// Exercises: fetchState (GET /api/state), an optional stream tail
+// (GET /api/session/:id/stream) when ANCHOR_SESSION is set, and a 401 check with
+// a bad token. Prints one line per check and exits non-zero on failure.
+
+let env = ProcessInfo.processInfo.environment
+guard let urlString = env["ANCHOR_URL"], let baseURL = URL(string: urlString) else {
+    FileHandle.standardError.write(Data("set ANCHOR_URL\n".utf8)); exit(2)
+}
+let token = env["ANCHOR_TOKEN"] ?? ""
+
+func fail(_ msg: String) -> Never {
+    FileHandle.standardError.write(Data("FAIL: \(msg)\n".utf8)); exit(1)
+}
+
+let sema = DispatchSemaphore(value: 0)
+Task {
+    let client = AnchorClient(baseURL: baseURL, token: token)
+
+    // 1. fetchState
+    do {
+        let state = try await client.fetchState()
+        print("state OK — generatedAt=\(state.generatedAt) teams=\(state.teamsOK) routines=\(state.routinesOK) cloud=\(state.cloudOK)")
+    } catch { fail("fetchState: \(error)") }
+
+    // 2. 401 with a bad token
+    do {
+        _ = try await AnchorClient(baseURL: baseURL, token: "definitely-wrong").fetchState()
+        fail("bad token was accepted")
+    } catch AnchorError.unauthorized {
+        print("bad-token OK — 401 as expected")
+    } catch { fail("unexpected error on bad token: \(error)") }
+
+    // 3. stream tail (optional)
+    if let session = env["ANCHOR_SESSION"] {
+        var count = 0
+        do {
+            for try await ev in client.events(sessionId: session) {
+                count += 1
+                print("event \(count): id=\(ev.id.map(String.init) ?? "-") type=\(ev.type)")
+                if ev.isTerminal { break }
+            }
+            print("stream OK — \(count) event(s)")
+        } catch { fail("stream: \(error)") }
+    }
+
+    print("anchorprobe: all checks passed")
+    sema.signal()
+}
+sema.wait()

--- a/apps/ios/Cockpit/CockpitApp.swift
+++ b/apps/ios/Cockpit/CockpitApp.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import AnchorKit
+
+// Fleet Cockpit — iOS/iPadOS companion for the agents fleet (RUSH-1734).
+//
+// The app is a thin projection of AnchorKit (built + verified separately): every
+// network effect goes through AppModel → AnchorClient. iOS is a control plane,
+// never a compute worker — this app dispatches, streams, and steers agents that
+// run on the fleet via `agents serve --control`.
+//
+// NOTE: this app target requires full Xcode to build (SwiftUI app bundle +
+// simulator). AnchorKit — the load-bearing logic — is built and tested
+// headlessly and verified live against a real anchor; see apps/ios/README.md.
+
+@main
+struct CockpitApp: App {
+    @StateObject private var model = AppModel()
+    var body: some Scene {
+        WindowGroup {
+            RootView().environmentObject(model)
+        }
+    }
+}
+
+/// Single source of truth for the app: anchor config + the AnchorKit client.
+@MainActor
+final class AppModel: ObservableObject {
+    @Published var anchorURL: String
+    @Published var isPaired: Bool
+    @Published var lastError: String?
+
+    private let tokens: TokenStore
+    private static let urlKey = "cockpit.anchorURL"
+
+    init(tokens: TokenStore = defaultTokenStore()) {
+        self.tokens = tokens
+        self.anchorURL = UserDefaults.standard.string(forKey: Self.urlKey) ?? ""
+        self.isPaired = (tokens.load() != nil) && !(UserDefaults.standard.string(forKey: Self.urlKey) ?? "").isEmpty
+    }
+
+    private static func defaultTokenStore() -> TokenStore {
+        #if canImport(Security)
+        return KeychainTokenStore()
+        #else
+        return InMemoryTokenStore()
+        #endif
+    }
+
+    /// Build a client from the stored config, or nil when unpaired.
+    func client() -> AnchorClient? {
+        guard let token = tokens.load(), let url = URL(string: anchorURL) else { return nil }
+        return AnchorClient(baseURL: url, token: token)
+    }
+
+    /// Save pairing (anchor URL + token from `agents devices pair-ios`).
+    func pair(url: String, token: String) throws {
+        try tokens.save(token)
+        UserDefaults.standard.set(url, forKey: Self.urlKey)
+        anchorURL = url
+        isPaired = !token.isEmpty && !url.isEmpty
+    }
+
+    func unpair() {
+        try? tokens.clear()
+        UserDefaults.standard.removeObject(forKey: Self.urlKey)
+        isPaired = false
+    }
+
+    func report(_ error: Error) { lastError = "\(error)" }
+}

--- a/apps/ios/Cockpit/Views.swift
+++ b/apps/ios/Cockpit/Views.swift
@@ -1,0 +1,180 @@
+import SwiftUI
+import AnchorKit
+
+/// Tab shell: Fleet, Dispatch, Settings. Gates on pairing.
+struct RootView: View {
+    @EnvironmentObject var model: AppModel
+    var body: some View {
+        if model.isPaired {
+            TabView {
+                NavigationStack { FleetView() }
+                    .tabItem { Label("Fleet", systemImage: "square.grid.2x2") }
+                NavigationStack { DispatchView() }
+                    .tabItem { Label("Dispatch", systemImage: "paperplane") }
+                NavigationStack { SettingsView() }
+                    .tabItem { Label("Settings", systemImage: "gearshape") }
+            }
+        } else {
+            NavigationStack { SettingsView() }
+        }
+    }
+}
+
+/// Fleet health from `GET /api/state`.
+struct FleetView: View {
+    @EnvironmentObject var model: AppModel
+    @State private var state: FleetState?
+    @State private var error: String?
+
+    var body: some View {
+        List {
+            if let s = state {
+                Section("Snapshot") { Text("Updated \(s.generatedAt)").font(.footnote).foregroundStyle(.secondary) }
+                Section("Panels") {
+                    row("Teams", s.teamsOK)
+                    row("Routines", s.routinesOK)
+                    row("Cloud", s.cloudOK)
+                }
+            } else if let error {
+                Text(error).foregroundStyle(.red)
+            } else {
+                ProgressView()
+            }
+        }
+        .navigationTitle("Fleet")
+        .refreshable { await load() }
+        .task { await load() }
+    }
+
+    private func row(_ label: String, _ ok: Bool) -> some View {
+        HStack {
+            Text(label)
+            Spacer()
+            Image(systemName: ok ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .foregroundStyle(ok ? .green : .orange)
+        }
+    }
+
+    private func load() async {
+        guard let client = model.client() else { return }
+        do { state = try await client.fetchState(); error = nil }
+        catch { self.error = "\(error)" }
+    }
+}
+
+/// Dispatch a headless run, then stream it.
+struct DispatchView: View {
+    @EnvironmentObject var model: AppModel
+    @State private var agent = "claude"
+    @State private var prompt = ""
+    @State private var mode = "plan"
+    @State private var host = ""
+    @State private var started: String?
+
+    private let agents = ["claude", "codex", "gemini"]
+    private let modes = ["plan", "edit", "auto", "skip"]
+
+    var body: some View {
+        Form {
+            Section("Agent") {
+                Picker("Agent", selection: $agent) { ForEach(agents, id: \.self, content: Text.init) }
+                Picker("Mode", selection: $mode) { ForEach(modes, id: \.self, content: Text.init) }
+                TextField("Executor host (blank = anchor)", text: $host).autocorrectionDisabled()
+            }
+            Section("Prompt") {
+                TextField("What should it do?", text: $prompt, axis: .vertical).lineLimit(3...8)
+            }
+            Section {
+                Button("Dispatch") { Task { await dispatch() } }
+                    .disabled(prompt.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+            if let started {
+                NavigationLink("Watch \(started)") { SessionView(sessionId: started) }
+            }
+        }
+        .navigationTitle("Dispatch")
+    }
+
+    private func dispatch() async {
+        guard let client = model.client() else { return }
+        let req = RunRequest(agent: agent, prompt: prompt, mode: mode,
+                             host: host.isEmpty ? nil : host)
+        do { started = try await client.dispatchRun(req).sessionId }
+        catch { model.report(error) }
+    }
+}
+
+/// Live transcript of a run via the SSE stream, with a steer field.
+struct SessionView: View {
+    @EnvironmentObject var model: AppModel
+    let sessionId: String
+    @State private var events: [StreamEvent] = []
+    @State private var steer = ""
+    @State private var streamTask: Task<Void, Never>?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            List(Array(events.enumerated()), id: \.offset) { _, ev in
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(ev.type).font(.caption.monospaced()).foregroundStyle(.secondary)
+                    Text(ev.data).font(.callout.monospaced()).lineLimit(6)
+                }
+            }
+            HStack {
+                TextField("Steer the agent…", text: $steer)
+                Button("Send") { Task { await send() } }
+                    .disabled(steer.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+            .padding()
+        }
+        .navigationTitle(sessionId)
+        .task { start() }
+        .onDisappear { streamTask?.cancel() }
+    }
+
+    private func start() {
+        guard let client = model.client() else { return }
+        streamTask = Task {
+            do { for try await ev in client.events(sessionId: sessionId) { events.append(ev) } }
+            catch { model.report(error) }
+        }
+    }
+
+    private func send() async {
+        guard let client = model.client() else { return }
+        let text = steer; steer = ""
+        do { try await client.sendMessage(sessionId: sessionId, text: text, from: "cockpit") }
+        catch { model.report(error) }
+    }
+}
+
+/// Pairing: anchor URL + token from `agents devices pair-ios`.
+struct SettingsView: View {
+    @EnvironmentObject var model: AppModel
+    @State private var url = ""
+    @State private var token = ""
+
+    var body: some View {
+        Form {
+            Section("Anchor") {
+                TextField("http://<anchor-tailnet-ip>:4477", text: $url)
+                    .autocorrectionDisabled().textInputAutocapitalization(.never)
+                SecureField("Control token", text: $token)
+            }
+            Section {
+                Button(model.isPaired ? "Update pairing" : "Pair") {
+                    do { try model.pair(url: url, token: token); token = "" }
+                    catch { model.report(error) }
+                }.disabled(url.isEmpty || token.isEmpty)
+                if model.isPaired { Button("Unpair", role: .destructive) { model.unpair() } }
+            } footer: {
+                Text("Run `agents devices pair-ios` on the anchor to mint a token. Keep the anchor on your tailnet.")
+            }
+            if let err = model.lastError {
+                Section("Last error") { Text(err).font(.footnote).foregroundStyle(.red) }
+            }
+        }
+        .navigationTitle("Settings")
+        .onAppear { url = model.anchorURL }
+    }
+}

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -1,0 +1,48 @@
+# Fleet Cockpit (iOS / iPadOS)
+
+Native companion app for the agents fleet. **iOS is a control plane, not a compute
+worker** (Apple disables the hypervisor on iPadOS and grants JIT to browsers only, so no
+Node harness runs on-device). The app dispatches, streams, and steers agents that run on
+the fleet via the authenticated `agents serve --control` **anchor**.
+
+```
+iPhone/iPad  ──HTTPS+SSE over the tailnet──►  anchor (agents serve --control)  ──►  executors
+ (this app)      bearer token, per device        holds SSH keys, runs the CLI     (worker / cloud)
+```
+
+## Layout
+
+| Path | What | Build |
+|---|---|---|
+| `AnchorKit/` | SwiftPM library: models, SSE parser, `AnchorClient`, Keychain token store. The load-bearing logic. | `swift build` / verified headlessly (below) |
+| `Cockpit/` | SwiftUI app (Fleet · Dispatch · Session · Settings) — a thin projection of AnchorKit. | **requires full Xcode** |
+
+## AnchorKit is verified without Xcode
+
+`XCTest`/`swift-testing` ship only with full Xcode, and this repo's CI is Node/bun, so
+AnchorKit ships two runnable verifiers instead:
+
+```bash
+cd apps/ios/AnchorKit
+swift run anchorcheck                       # pure-logic assertions (SSE, model coding, token store)
+# live end-to-end against a REAL anchor:
+ANCHOR_URL=http://127.0.0.1:4477 ANCHOR_TOKEN=<token> ANCHOR_SESSION=<id> swift run anchorprobe
+```
+
+`anchorprobe` was run against a live `agents serve --control` server: `fetchState` decodes,
+a bad token returns `401`, and the SSE stream yields events with byte-offset resume ids and
+terminal detection. See the PR for the transcript.
+
+## Building the app (needs Xcode)
+
+The `Cockpit/` SwiftUI target requires full Xcode (SwiftUI app bundle + simulator/device),
+which the CI-only environment this was authored in does not have — so the **app target is
+source-complete but not compiled here**. On a machine with Xcode: create an iOS App target,
+add the `AnchorKit` package as a local dependency, and add the `Cockpit/*.swift` sources.
+The app consumes only AnchorKit's verified API surface.
+
+## Pairing
+
+On the anchor: `agents devices pair-ios <name>` mints a control token (shown once) and marks
+the device control-only. Enter the anchor URL + token in the app's Settings. Keep the control
+server on the tailnet — never public Funnel.


### PR DESCRIPTION
> **⚠️ Merge order (hard dependency): merge after #1226 and #1227.** This app consumes `GET /api/session/:id/stream` (#1226) and `agents devices pair-ios` (#1227), which are not on `main` yet. The `anchorprobe` transcript was run against a server build with #1226 applied. Do not merge #1229 until #1226 and #1227 land. (No `apps/cli` changes on this branch — Swift only.)

## What

**Phase 4 of the Fleet Cockpit** (follows #1223, #1226, #1227). Adds `apps/ios/` — the native iOS/iPadOS companion. iOS is a **control plane, not a compute worker**; the app dispatches/streams/steers agents that run on the fleet via `agents serve --control`.

| Path | What | Build |
|---|---|---|
| `AnchorKit/` | SwiftPM library: models, SSE parser, `AnchorClient`, Keychain token store — the load-bearing logic | `swift build` — **verified headlessly** |
| `Cockpit/` | SwiftUI app (Fleet · Dispatch · Session · Settings), a thin projection of AnchorKit | **requires full Xcode** |

## Verification — AnchorKit is proven end-to-end

`XCTest`/`swift-testing` ship only with full Xcode and this repo's CI is Node/bun, so AnchorKit carries two **runnable** verifiers instead:

- `swift run anchorcheck` — pure-logic assertions (SSE parsing incl. byte-offset ids / multi-line data / heartbeat skipping, model coding, token store). **12/12 pass.**
- `swift run anchorprobe` — drives `AnchorClient` against a **real** `agents serve --control` server. Live transcript:
```
state OK — generatedAt=2026-07-16T00:00:00Z teams=true routines=true cloud=true
bad-token OK — 401 as expected
event 1: id=35 type=system
event 2: id=76 type=assistant
event 3: id=104 type=result
stream OK — 3 event(s)
anchorprobe: all checks passed
```
(Found + fixed a real bug doing this: `URLSession.AsyncBytes.lines` drops the blank lines that terminate SSE frames, so `events()` now splits raw bytes on `\n` itself.)

## Honest boundary

The `Cockpit/` SwiftUI **app target requires full Xcode** (app bundle + simulator), which the CLI-only environment this was authored in does not have (`xcodebuild` → Command Line Tools only). So the app is **source-complete but not compiled here** — it consumes only AnchorKit's verified API. Build steps in `apps/ios/README.md`. Not adding a CLI changelog entry: `apps/ios` is a separate product from the `@phnx-labs/agents-cli` npm package.

## Fleet Cockpit — all four phases

1. `agents serve --control` anchor — #1223 ✅ merged
2. Live NDJSON event stream — #1226
3. `devices` control role + `pair-ios` — #1227
4. iOS app (this) — AnchorKit verified; SwiftUI shell needs Xcode

Plan: `zion:/tmp/plan-fleet-cockpit.html`.