### PR TITLE
feat(view): surface Claude org identity (type + team name) per account

### DIFF
--- a/apps/cli/src/commands/versions.ts
+++ b/apps/cli/src/commands/versions.ts
@@ -17,6 +17,7 @@ import { select, confirm, checkbox } from '@inquirer/prompts';
 import {
   AGENTS,
   ALL_AGENT_IDS,
+  accountOrgBadge,
   getAccountEmail,
   getAccountInfo,
   agentLabel,
@@ -95,7 +96,12 @@ function fixSessionFilePaths(agent: AgentId, version: string, oldVersionDir: str
 
 function formatAccountHint(info: AccountInfo, usage: UsageSnapshot | null): string {
   const parts: string[] = [];
-  if (info.email) parts.push(info.email);
+  if (info.email) {
+    // Same-email accounts can live in different orgs (personal Max vs a Team
+    // seat) — the badge is what makes the picker disambiguate them.
+    const badge = accountOrgBadge(info);
+    parts.push(badge ? `${info.email} (${badge})` : info.email);
+  }
   const usageSummary = formatUsageSummary(info.plan, usage);
   if (usageSummary) parts.push(usageSummary);
   if (parts.length === 0) return '';

--- a/apps/cli/src/commands/view.account.test.ts
+++ b/apps/cli/src/commands/view.account.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { accountColumnLabel, pruneGroupKey } from './view.js';
+
+describe('accountColumnLabel — organization suffix', () => {
+  it('appends the org badge for a Team seat', () => {
+    expect(accountColumnLabel({
+      email: 'taylor@example.com',
+      accountId: null,
+      signedIn: true,
+      organizationType: 'claude_team',
+      organizationName: 'Turing Labs',
+    })).toBe('taylor@example.com (Turing Labs · Team)');
+  });
+
+  it('appends only the tier label for a personal Max plan', () => {
+    expect(accountColumnLabel({
+      email: 'taylor@example.com',
+      accountId: null,
+      signedIn: true,
+      organizationType: 'claude_max',
+      organizationName: "taylor@example.com's Organization",
+    })).toBe('taylor@example.com (Max)');
+  });
+
+  it('renders the bare email when no organization type is present', () => {
+    expect(accountColumnLabel({
+      email: 'taylor@example.com',
+      accountId: null,
+      signedIn: true,
+      organizationType: null,
+      organizationName: null,
+    })).toBe('taylor@example.com');
+  });
+
+  it('leaves the id: and signed-in branches untouched', () => {
+    expect(accountColumnLabel({
+      email: null,
+      accountId: 'u-123',
+      signedIn: true,
+      organizationType: null,
+      organizationName: null,
+    })).toBe('id:u-123');
+    expect(accountColumnLabel({
+      email: null,
+      accountId: null,
+      signedIn: true,
+      organizationType: null,
+      organizationName: null,
+    })).toBe('signed in');
+  });
+
+  it('renders empty when signed out', () => {
+    expect(accountColumnLabel(null)).toBe('');
+    expect(accountColumnLabel({
+      email: null,
+      accountId: null,
+      signedIn: false,
+      organizationType: null,
+      organizationName: null,
+    })).toBe('');
+  });
+});
+
+describe('pruneGroupKey — duplicate detection identity', () => {
+  it('keeps same-email installs in different orgs in separate prune groups', () => {
+    const max = pruneGroupKey({
+      accountKey: 'claude:account:acc-1:org:org-personal',
+      email: 'taylor@example.com',
+    });
+    const team = pruneGroupKey({
+      accountKey: 'claude:account:acc-1:org:org-team',
+      email: 'taylor@example.com',
+    });
+    expect(max).not.toBeNull();
+    expect(max).not.toBe(team);
+  });
+
+  it('groups installs with the same accountKey together', () => {
+    const a = pruneGroupKey({ accountKey: 'claude:account:acc-1:org:org-1', email: 'a@x.com' });
+    const b = pruneGroupKey({ accountKey: 'claude:account:acc-1:org:org-1', email: 'A@X.COM' });
+    expect(a).toBe(b);
+  });
+
+  it('falls back to the lowercased email when no accountKey exists', () => {
+    expect(pruneGroupKey({ accountKey: null, email: 'Taylor@Example.com' }))
+      .toBe('taylor@example.com');
+  });
+
+  it('returns null when there is no identity at all', () => {
+    expect(pruneGroupKey({ accountKey: null, email: null })).toBeNull();
+  });
+});

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -18,6 +18,7 @@ import * as yaml from 'yaml';
 import {
   AGENTS,
   ALL_AGENT_IDS,
+  accountOrgBadge,
   getAllCliStates,
   getAccountInfo,
   resolveAgentName,
@@ -90,12 +91,24 @@ const SIGNED_IN_LABEL = 'signed in';
  * account id (Kimi's user_id), show `id:<user_id>` so distinct accounts read
  * distinctly instead of a generic "signed in". Falls back to "signed in" when we
  * have neither (Antigravity), and empty when signed out.
+ *
+ * When the account carries a Claude organizationType, the org badge is appended
+ * — "email (Turing Labs · Team)" — so two installs signed into the same email
+ * under different orgs (personal Max vs a Team seat) read distinctly. The
+ * suffix is plain text inside the label so the existing column-width pass
+ * measures and pads it for free.
  */
-function accountColumnLabel(
-  info?: Pick<AccountInfo, 'email' | 'accountId' | 'signedIn'> | null
+export function accountColumnLabel(
+  info?: Pick<
+    AccountInfo,
+    'email' | 'accountId' | 'signedIn' | 'organizationType' | 'organizationName'
+  > | null
 ): string {
   if (!info) return '';
-  if (info.email) return info.email;
+  if (info.email) {
+    const badge = accountOrgBadge(info);
+    return badge ? `${info.email} (${badge})` : info.email;
+  }
   if (info.signedIn) return info.accountId ? `id:${info.accountId}` : SIGNED_IN_LABEL;
   return '';
 }
@@ -1110,6 +1123,12 @@ export interface ViewJsonVersion {
   // Opaque account identifier when the credential exposes one but no email
   // (Kimi's user_id). Optional for backward compatibility with older consumers.
   accountId?: string | null;
+  // Claude-only raw org identity from .claude.json's oauthAccount
+  // ("claude_max", "claude_team", ...). Raw values, no display label baked in —
+  // renderers map them via formatClaudeOrgLabel/accountOrgBadge. Optional for
+  // backward compatibility with older consumers.
+  organizationType?: string | null;
+  organizationName?: string | null;
   plan: string | null;
   usageStatus: 'available' | 'rate_limited' | 'out_of_credits' | null;
   // Optional so existing TypeScript consumers compiled against the prior
@@ -1377,6 +1396,8 @@ async function collectAgentsJson(filterAgentId?: AgentId, resourceSections?: Set
       signedIn: info.signedIn,
       email: info.email,
       accountId: info.accountId,
+      organizationType: info.organizationType ?? null,
+      organizationName: info.organizationName ?? null,
       plan: info.plan,
       usageStatus: info.usageStatus,
       overageCredits: info.overageCredits,
@@ -1440,6 +1461,20 @@ interface AgentPrunePlan {
   skippedDefaults: PrunePlanEntry[];
 }
 
+/**
+ * Identity key for duplicate-install detection. Prefers accountKey — which
+ * encodes account AND org — over the bare email: two installs can share an
+ * email yet belong to different orgs (a personal Max plan and a Team seat),
+ * and grouping those by email alone would propose pruning a live account.
+ * Falls back to the lowercased email for agents whose credentials expose no
+ * identity key. Null when there is no usable identity.
+ */
+export function pruneGroupKey(
+  info: Pick<AccountInfo, 'accountKey' | 'email'>
+): string | null {
+  return info.accountKey ?? info.email?.toLowerCase() ?? null;
+}
+
 async function buildAgentPrunePlan(agentId: AgentId): Promise<AgentPrunePlan> {
   const dirInfos = listInstalledVersionDirs(agentId);
   const entries = await Promise.all(
@@ -1458,16 +1493,17 @@ async function buildAgentPrunePlan(agentId: AgentId): Promise<AgentPrunePlan> {
   // working binary — those are the things that compete for "the live install
   // for this account."
   const installed = entries.filter((e) => e.hasBinary);
-  const byEmail = new Map<string, typeof installed>();
+  const byAccount = new Map<string, typeof installed>();
   for (const e of installed) {
     if (!e.info.email) continue;
-    const key = e.info.email.toLowerCase();
-    const list = byEmail.get(key) ?? [];
+    const key = pruneGroupKey(e.info);
+    if (!key) continue;
+    const list = byAccount.get(key) ?? [];
     list.push(e);
-    byEmail.set(key, list);
+    byAccount.set(key, list);
   }
 
-  for (const [, group] of byEmail) {
+  for (const [, group] of byAccount) {
     if (group.length < 2) continue;
     const sorted = [...group].sort((a, b) => compareVersions(b.version, a.version));
     const keeper = sorted[0].version;

--- a/apps/cli/src/lib/agents.test.ts
+++ b/apps/cli/src/lib/agents.test.ts
@@ -9,8 +9,10 @@ import {
   AGENTS,
   ALL_AGENT_IDS,
   __resetAntigravityKeychainCacheForTest,
+  accountOrgBadge,
   antigravityOsKeyringProbe,
   deprecationNotice,
+  formatClaudeOrgLabel,
   getAccountInfo,
   resolveAgentName,
   resolveLastActive,
@@ -809,5 +811,125 @@ describe('getAccountInfo — grok (nested auth.json)', () => {
   it('treats grok as signed out when auth.json is absent', async () => {
     const info = await getAccountInfo('grok', makeTempDir());
     expect(info.signedIn).toBe(false);
+  });
+});
+
+describe('getAccountInfo — Claude organization identity', () => {
+  // Fixture shapes below mirror real .claude.json oauthAccount payloads: a
+  // personal Max plan carries an auto-generated organizationName while a Team
+  // seat carries the actual org name.
+  function writeClaudeConfig(oauthAccount: Record<string, unknown>): string {
+    const home = makeTempDir();
+    fs.writeFileSync(path.join(home, '.claude.json'), JSON.stringify({ oauthAccount }), 'utf-8');
+    return home;
+  }
+
+  it('extracts organizationType and organizationName from a Team seat', async () => {
+    const home = writeClaudeConfig({
+      accountUuid: 'acc-1',
+      organizationUuid: 'org-team',
+      emailAddress: 'taylor@example.com',
+      billingType: 'stripe_subscription',
+      organizationType: 'claude_team',
+      organizationName: 'Turing Labs',
+      organizationRole: 'user',
+      seatTier: 'team_tier_1',
+    });
+    const info = await getAccountInfo('claude', home);
+    expect(info.organizationType).toBe('claude_team');
+    expect(info.organizationName).toBe('Turing Labs');
+    expect(info.plan).toBe('Pro');
+  });
+
+  it('extracts organizationType from a personal Max plan, keeping the raw boilerplate name', async () => {
+    const home = writeClaudeConfig({
+      accountUuid: 'acc-1',
+      organizationUuid: 'org-personal',
+      emailAddress: 'taylor@example.com',
+      billingType: 'stripe_subscription',
+      organizationType: 'claude_max',
+      organizationName: "taylor@example.com's Organization",
+      organizationRole: 'admin',
+    });
+    const info = await getAccountInfo('claude', home);
+    expect(info.organizationType).toBe('claude_max');
+    // Raw value: display layers decide whether the boilerplate name is shown.
+    expect(info.organizationName).toBe("taylor@example.com's Organization");
+  });
+
+  it('returns nulls when the config predates the organization fields', async () => {
+    const home = writeClaudeConfig({
+      accountUuid: 'acc-1',
+      organizationUuid: 'org-old',
+      emailAddress: 'taylor@example.com',
+      billingType: 'stripe_subscription',
+    });
+    const info = await getAccountInfo('claude', home);
+    expect(info.organizationType).toBeNull();
+    expect(info.organizationName).toBeNull();
+    expect(info.plan).toBe('Pro');
+  });
+
+  it('keeps same-email accounts in different orgs distinguishable via accountKey', async () => {
+    const max = await getAccountInfo('claude', writeClaudeConfig({
+      accountUuid: 'acc-1',
+      organizationUuid: 'org-personal',
+      emailAddress: 'taylor@example.com',
+      organizationType: 'claude_max',
+    }));
+    const team = await getAccountInfo('claude', writeClaudeConfig({
+      accountUuid: 'acc-1',
+      organizationUuid: 'org-team',
+      emailAddress: 'taylor@example.com',
+      organizationType: 'claude_team',
+      organizationName: 'Turing Labs',
+    }));
+    expect(max.email).toBe(team.email);
+    expect(max.accountKey).not.toBe(team.accountKey);
+  });
+});
+
+describe('formatClaudeOrgLabel', () => {
+  it('maps the known organization types to human labels', () => {
+    expect(formatClaudeOrgLabel('claude_max')).toBe('Max');
+    expect(formatClaudeOrgLabel('claude_pro')).toBe('Pro');
+    expect(formatClaudeOrgLabel('claude_team')).toBe('Team');
+    expect(formatClaudeOrgLabel('claude_enterprise')).toBe('Enterprise');
+    expect(formatClaudeOrgLabel('claude_free')).toBe('Free');
+  });
+
+  it('title-cases unknown future types instead of hiding them', () => {
+    expect(formatClaudeOrgLabel('claude_startup_tier_9')).toBe('Startup Tier 9');
+    expect(formatClaudeOrgLabel('gov')).toBe('Gov');
+  });
+
+  it('returns null for missing input', () => {
+    expect(formatClaudeOrgLabel(null)).toBeNull();
+    expect(formatClaudeOrgLabel(undefined)).toBeNull();
+    expect(formatClaudeOrgLabel('')).toBeNull();
+  });
+});
+
+describe('accountOrgBadge', () => {
+  it('shows the org name only for multi-seat org types', () => {
+    expect(accountOrgBadge({ organizationType: 'claude_team', organizationName: 'Turing Labs' }))
+      .toBe('Turing Labs · Team');
+    expect(accountOrgBadge({ organizationType: 'claude_enterprise', organizationName: 'BigCo' }))
+      .toBe('BigCo · Enterprise');
+    // Personal orgs carry auto-generated boilerplate names — label only.
+    expect(accountOrgBadge({
+      organizationType: 'claude_max',
+      organizationName: "taylor@example.com's Organization",
+    })).toBe('Max');
+  });
+
+  it('falls back to the label when a team org has no name', () => {
+    expect(accountOrgBadge({ organizationType: 'claude_team', organizationName: null })).toBe('Team');
+  });
+
+  it('returns null when there is no organization type', () => {
+    expect(accountOrgBadge({ organizationType: null, organizationName: 'Ghost' })).toBeNull();
+    expect(accountOrgBadge(null)).toBeNull();
+    expect(accountOrgBadge(undefined)).toBeNull();
   });
 });

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -1011,6 +1011,56 @@ export interface AccountInfo {
   // we can't surface an address. Callers that only want to know "logged in or
   // not" should read this, not `email`.
   signedIn: boolean;
+  // Claude-only: raw organizationType/organizationName from .claude.json's
+  // oauthAccount ("claude_max", "claude_team", ...). Two installs can share an
+  // email yet belong to different orgs (a personal Max plan and a Team seat);
+  // these fields are what let display layers tell them apart. Optional so the
+  // other agents' return literals stay valid — absent means "not applicable".
+  organizationType?: string | null;
+  organizationName?: string | null;
+}
+
+/**
+ * Human-readable label for a Claude account's organizationType as read from
+ * .claude.json's oauthAccount ("claude_team" -> "Team"). Unrecognized values
+ * (future tiers) are rendered by stripping the "claude_" prefix and
+ * title-casing the rest — an unfamiliar-but-visible label beats silence.
+ * Returns null for missing input.
+ */
+export function formatClaudeOrgLabel(orgType: string | null | undefined): string | null {
+  if (!orgType) return null;
+  const known: Record<string, string> = {
+    claude_max: 'Max',
+    claude_pro: 'Pro',
+    claude_team: 'Team',
+    claude_enterprise: 'Enterprise',
+    claude_free: 'Free',
+  };
+  if (known[orgType]) return known[orgType];
+  return orgType
+    .replace(/^claude_/, '')
+    .split('_')
+    .filter(Boolean)
+    .map((w) => w[0].toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+/**
+ * Short badge identifying which org an account belongs to: "Turing Labs · Team"
+ * for multi-seat orgs, just the tier label ("Max") for personal plans — a
+ * personal org's name is auto-generated boilerplate ("<email>'s Organization"),
+ * not identity. Returns null when the account carries no organizationType
+ * (signed out, non-Claude agents, configs predating the field).
+ */
+export function accountOrgBadge(
+  info?: Pick<AccountInfo, 'organizationType' | 'organizationName'> | null
+): string | null {
+  const label = formatClaudeOrgLabel(info?.organizationType);
+  if (!label) return null;
+  const isMultiSeat =
+    info?.organizationType === 'claude_team' || info?.organizationType === 'claude_enterprise';
+  if (isMultiSeat && info?.organizationName) return `${info.organizationName} · ${label}`;
+  return label;
 }
 
 /** Return the email address associated with the agent's auth config, or null. */
@@ -1328,6 +1378,8 @@ export async function getAccountInfo(
           overageCredits,
           lastActive,
           signedIn: !!email,
+          organizationType: oa?.organizationType ?? null,
+          organizationName: oa?.organizationName ?? null,
         };
       }
       case 'codex': {


### PR DESCRIPTION
## Why

Two Claude installs signed into the same email render identically in `agents view` — a personal **Max** plan and a **Team** seat both show the bare email and the billingType-derived `Pro` label, so you can't tell which install is signed into which org:

```
Claude (balanced)
  2.1.196 (default)  taylor@turingsaas.com   Pro  S: ███░░ W: █░░░░
  2.1.197            taylor@turingsaas.com   Pro  S: ██░░░ W: █░░░░   <- which one is the team seat?
```

The distinguishing data already sits in each version home's `.claude.json` under `oauthAccount` (`organizationType`, `organizationName`) — it was never read anywhere in the codebase.

## What

```
Claude (balanced)
  2.1.200 (default)  taylor.gagne@modsquad.com (ModSquad · Team)  Pro  S: ███░░ W: █░░░░
  2.1.197            taylor@turingsaas.com (Turing Labs · Team)   Pro  S: ██░░░ W: █░░░░
  2.1.196            taylor@turingsaas.com (Max)                  Pro  S: █░░░░ W: █░░░░
```

- **`AccountInfo`** gains raw `organizationType` / `organizationName` (Claude-only, optional fields), populated in `getAccountInfo`'s claude branch. Read from `.claude.json` only — no keychain access, so no macOS ACL prompts (per the existing comment in `agents.ts`).
- **`formatClaudeOrgLabel`** maps known tiers (`claude_max` → Max, `claude_team` → Team, `claude_enterprise` → Enterprise, ...) and title-cases unknown future tiers instead of hiding them.
- **`accountOrgBadge`** shows the org *name* only for team/enterprise seats — a personal org's name is auto-generated boilerplate (`"<email>'s Organization"`), not identity.
- **Terminal**: the badge rides inside the existing account column via `accountColumnLabel`, so the existing width pre-pass measures and pads it for free — no new column, no alignment changes. The `agents use` version-picker hint (`versions.ts`) gets the same badge, since that's the moment you choose between two same-email accounts.
- **`view --json`**: raw `organizationType` / `organizationName` on `ViewJsonVersion` as optional fields (same backward-compat pattern as `accountId`).

## Companion fix: prune duplicate detection

`buildAgentPrunePlan` grouped "duplicate" installs by lowercased email alone — two installs sharing an email but belonging to **different orgs** (exactly the Max + Team scenario above) were treated as duplicates of each other, and `agents view --prune` would propose deleting one. Grouping now keys on `accountKey` (which already encodes account + org), falling back to the lowercased email when no key exists. Regression-tested.

## Testing

- 18 new tests (all red before the implementation, green after): `getAccountInfo` org-field extraction against real-filesystem `.claude.json` fixtures, label mapping incl. unknown-tier fallback, badge rules, `accountColumnLabel` branches (email / `id:` / signed-in / signed-out), and the prune-grouping regression.
- `bun run build` clean; full suite run — the only failures (`models`, `exec`, `routines`) reproduce identically on the unmodified base commit (machine-state-dependent) with zero regressions from this change.
- Verified end-to-end against real version homes: the table above is actual output from the built binary, and `view --json` emits the raw org fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)