### PR TITLE
feat(usage): show every blocking window in compact bars — droid gains M:

### DIFF
--- a/apps/cli/src/lib/__tests__/usage.test.ts
+++ b/apps/cli/src/lib/__tests__/usage.test.ts
@@ -541,7 +541,7 @@ describe('normalizeDroidWindows', () => {
     expect(windows[0].usedPercent).toBe(100);
   });
 
-  it('keeps the month window out of the compact summary but in the snapshot', () => {
+  it('shows the month window in the compact summary — droid meters on it', () => {
     const snapshot: UsageSnapshot = {
       source: 'live',
       sourceLabel: 'live account data',
@@ -551,12 +551,36 @@ describe('normalizeDroidWindows', () => {
     const summary = stripAnsi(formatUsageSummary(null, snapshot));
     expect(summary).toContain('S:');
     expect(summary).toContain('W:');
-    expect(summary).not.toContain('M:');
-    // ...but an exhausted month window still flips the account to rate-limited.
+    // Month is a blocking window (an exhausted month throttles the account),
+    // so the compact row must show it — otherwise a droid account can read as
+    // rate-limited with no visible bar explaining why.
+    expect(summary).toContain('M:');
     const exhausted = normalizeDroidWindows({
       ...payload,
       limits: { standard: { ...payload.limits!.standard, monthly: { usedPercent: 100 } } },
     });
     expect(deriveUsageStatusFromSnapshot({ ...snapshot, windows: exhausted })).toBe('rate_limited');
+  });
+
+  it('keeps the non-blocking sonnet_week window out of the compact summary', () => {
+    const snapshot: UsageSnapshot = {
+      source: 'live',
+      sourceLabel: 'live account data',
+      capturedAt: new Date('2026-07-15T12:00:00Z'),
+      windows: [
+        ...normalizeDroidWindows(payload),
+        {
+          key: 'sonnet_week',
+          label: 'Current week (Sonnet only)',
+          shortLabel: 'So',
+          usedPercent: 40,
+          resetsAt: null,
+          windowMinutes: null,
+        },
+      ],
+    };
+    const summary = stripAnsi(formatUsageSummary(null, snapshot));
+    expect(summary).toContain('M:');
+    expect(summary).not.toContain('So:');
   });
 });

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -382,12 +382,14 @@ export function formatUsageSummary(
   }
 
   if (snapshot) {
-    // Compact rows show the two windows every agent shares (session + week);
-    // extra windows (Claude's Sonnet week, Droid's month) render only in the
-    // full per-version usage section. An exhausted month window still surfaces
-    // here as the rate-limited badge via deriveUsageStatusFromSnapshot.
+    // Compact rows show every BLOCKING window — the same set
+    // deriveUsageStatusFromSnapshot uses for the rate-limited badge — so an
+    // account throttled by its month window (Droid meters on 5h/week/month)
+    // shows the bar that explains why. Claude's Sonnet week is a per-model
+    // sub-limit, not a blocking window; it renders only in the full
+    // per-version usage section.
     const windows = snapshot.windows
-      .filter((window) => window.key === 'session' || window.key === 'week')
+      .filter((window) => window.key !== 'sonnet_week')
       .map((window) =>
       `${chalk.gray(`${window.shortLabel}:`)} ${renderCompactUsageBar(window.usedPercent)}`
     );


### PR DESCRIPTION
## Why

Droid meters usage on **three** windows — 5-hour, weekly, and monthly — the same three Factory's own usage page gives equal billing. The droid fetcher already parses and emits all three (`normalizeDroidWindows` maps `fiveHour`/`weekly`/`monthly` → `session`/`week`/`month`), and `agents usage droid` shows them, but the compact row in `agents view` hard-filtered bars to `session || week`:

```
Droid (balanced)
  0.172.0 (default)  taylor@turingsaas.com  S: █░░░░ W: ██░░░            <- month window invisible
```

The inconsistency bites: `deriveUsageStatusFromSnapshot` already counts the month window as *blocking* (an exhausted month flips the row to rate-limited), so a droid account could read as throttled with no visible bar explaining why.

## What

Align the compact-bar filter with the blocking-window set the rate-limit badge already uses: render every window **except** `sonnet_week` (Claude's per-model sub-limit, the one genuinely non-blocking window). One-line filter change in `formatUsageSummary`.

```
Droid (balanced)
  0.172.0 (default)  taylor@turingsaas.com  S: █░░░░ W: ██░░░ M: █░░░░
```

- Droid rows gain the `M:` bar (real output above, live Factory data: session/week/month).
- Claude, Codex, and Kimi rows are byte-identical — their fetchers emit no `month` window, and `sonnet_week` stays out of the compact row (covered by a new test).
- Row alignment is unaffected: `maxUsageWidth` in `view.ts` is computed from `formatUsageSummary` output, so the wider droid cell pads correctly.

## Testing

- Flipped the existing test that pinned the old behavior (`expect(summary).not.toContain('M:')` → month now asserted present; red before the fix, green after) and added a test pinning `sonnet_week` exclusion.
- `bun run build` clean; full suite — the only failures (`models`, `exec`) reproduce identically on the unmodified base commit (machine-state-dependent), 89/89 in the touched area.
- Verified end-to-end against a live Factory account: droid row shows `S: / W: / M:` matching the Factory usage page (15%/32%/29% at capture time); Claude rows verified unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)