### PR TITLE
fix(sessions): quote win32 resume args to block shell injection (RUSH-1753)

### DIFF
--- a/apps/cli/src/commands/__tests__/sessions.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions.test.ts
@@ -6,8 +6,8 @@ import * as crypto from 'crypto';
 import { spawnSync } from 'child_process';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
-import { buildResumeCommand } from '../sessions.js';
-import { needsWindowsShell } from '../../lib/platform/index.js';
+import { buildResumeCommand, resumeSpawnInvocation } from '../sessions.js';
+import { needsWindowsShell, composeWin32CommandLine } from '../../lib/platform/index.js';
 import type { SessionMeta } from '../../lib/session/types.js';
 
 const repoRoot = process.cwd();
@@ -905,6 +905,42 @@ describe('buildResumeCommand version-pinned resume', () => {
       const launcher = buildResumeCommand(session)![0];
       expect(needsWindowsShell(launcher, 'win32')).toBe(true);
       expect(needsWindowsShell(launcher, 'linux')).toBe(false);
+    }
+  });
+
+  // RUSH-1753: session.id comes from the JSONL filename with no char validation.
+  // spawn(cmd[0], cmd.slice(1), { shell: true }) on win32 concatenates args into
+  // the cmd.exe line unescaped — so id `x&calc.exe&` injects. resumeSpawnInvocation
+  // must compose a quoted line + empty argv when the shell is needed.
+  it('quotes shell metacharacters in session id on win32 resume spawn (RUSH-1753)', () => {
+    const evilId = 'x&calc.exe&';
+    const cmd = buildResumeCommand(baseSession({ id: evilId }))!;
+    expect(cmd).toEqual(['claude', '--resume', evilId]);
+
+    const inv = resumeSpawnInvocation(cmd, 'win32');
+    expect(inv.shell).toBe(true);
+    expect(inv.args).toEqual([]);
+    // Full line is the sole command; & | etc. sit inside quotes (not bare).
+    expect(inv.command).toBe(composeWin32CommandLine(cmd[0], cmd.slice(1)));
+    expect(inv.command).toBe('claude --resume "x&calc.exe&"');
+
+    // Posix path stays a direct exec (no shell, raw argv).
+    const posix = resumeSpawnInvocation(cmd, 'linux');
+    expect(posix).toEqual({ command: 'claude', args: ['--resume', evilId], shell: false });
+  });
+
+  it('quotes shell metacharacters for codex and opencode resume spawn too', () => {
+    const evilId = 'a|b<c>d';
+    for (const session of [
+      baseSession({ agent: 'codex', id: evilId }),
+      baseSession({ agent: 'opencode', id: evilId }),
+    ]) {
+      const cmd = buildResumeCommand(session)!;
+      const inv = resumeSpawnInvocation(cmd, 'win32');
+      expect(inv.shell).toBe(true);
+      expect(inv.args).toEqual([]);
+      expect(inv.command).toBe(composeWin32CommandLine(cmd[0], cmd.slice(1)));
+      expect(inv.command).toContain(`"${evilId}"`);
     }
   });
 });

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -19,7 +19,7 @@ import type { AgentId } from '../lib/types.js';
 import type { SessionAgentId, SessionMeta, ViewMode } from '../lib/session/types.js';
 import { SESSION_AGENTS } from '../lib/session/types.js';
 import { discoverArtifacts, readArtifact, resolveArtifact } from '../lib/session/artifacts.js';
-import { looksLikePath, toComparablePath, homeDir, needsWindowsShell, findExecutable } from '../lib/platform/index.js';
+import { looksLikePath, toComparablePath, homeDir, needsWindowsShell, findExecutable, composeWin32CommandLine } from '../lib/platform/index.js';
 import { getActiveSessions, type ActiveSession } from '../lib/session/active.js';
 import { enumerateGhosttyTabs, assignGhosttyTabs } from '../lib/session/ghostty-tabs.js';
 import { mapPanesToTargets, listClients } from '../lib/tmux/session.js';
@@ -1835,10 +1835,38 @@ export async function resumeSessionInPlace(session: SessionMeta): Promise<void> 
 }
 
 /**
+ * Map a resume argv to the spawn(command, args, {shell}) triple.
+ *
+ * On Windows the agent launcher is a `.cmd`/PATHEXT shim and needs shell:true.
+ * With shell:true, Node concatenates args into the cmd.exe line unescaped
+ * (DEP0190 + injection). A session.id derived from a filename can carry
+ * metacharacters (`&|<>`); compose a fully-quoted line and pass an EMPTY args
+ * array so cmd.exe cannot reparse them (RUSH-1753). See composeWin32CommandLine.
+ *
+ * `platform` is injectable so the win32 shell path is unit-testable on any host.
+ */
+export function resumeSpawnInvocation(
+  cmd: string[],
+  platform: NodeJS.Platform = process.platform,
+): { command: string; args: string[]; shell: boolean } {
+  const shell = needsWindowsShell(cmd[0], platform);
+  if (shell) {
+    return {
+      command: composeWin32CommandLine(cmd[0], cmd.slice(1)),
+      args: [],
+      shell: true,
+    };
+  }
+  return { command: cmd[0], args: cmd.slice(1), shell: false };
+}
+
+/**
  * Spawn a resume command as a foreground takeover (inherited stdio), resolving
  * when it exits. On Windows the agent launcher is a `.cmd`/PATHEXT shim that
  * `spawn` can't exec directly — a bare-name `shell:false` spawn throws
  * `EFTYPE`/`ENOENT` there — so we go through the shell via `needsWindowsShell`.
+ * When shell:true, argv is composed via resumeSpawnInvocation (quoted line +
+ * empty args) so an untrusted session.id cannot inject through cmd.exe.
  * The spawn is guarded because such a failure can be thrown synchronously;
  * without the guard it would surface under an unrelated "Failed to discover
  * sessions" catch upstream instead of a truthful launch error.
@@ -1847,10 +1875,11 @@ function spawnResumeCommand(cmd: string[], cwd: string): Promise<void> {
   return new Promise<void>((resolve) => {
     let child: ChildProcess;
     try {
-      child = spawn(cmd[0], cmd.slice(1), {
+      const { command, args, shell } = resumeSpawnInvocation(cmd);
+      child = spawn(command, args, {
         cwd,
         stdio: 'inherit',
-        shell: needsWindowsShell(cmd[0]),
+        shell,
       });
     } catch (err: any) {
       console.error(chalk.red(`Failed to launch ${cmd[0]}: ${err.message}`));


### PR DESCRIPTION
## Summary
Escape session IDs on Windows resume spawns via `composeWin32CommandLine` + empty argv so metacharacters (`&|<>`) in a filename-derived id cannot inject through cmd.exe (RUSH-1753).

## Test evidence
```
$ bun run test src/commands/__tests__/sessions.test.ts
 ✓ src/commands/__tests__/sessions.test.ts (21 tests)
 Test Files  1 passed (1)
      Tests  21 passed (21)

$ npx --no-install tsc --noEmit --pretty false
TSC_EXIT:0
```