### PR TITLE
fix(self-update): verify tarball SHA-512 integrity before installing (RUSH-1754)

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -40,11 +40,13 @@ import {
   installPackageWithBun,
   verifyInstalledVersion,
   refreshAliasShims,
+  downloadVerifiedTarball,
 } from './lib/self-update.js';
 
 interface NpmPackageMetadata {
   version: string;
   integrity: string;
+  tarball: string;
 }
 
 // Detect dev/working-tree builds and default the noisy startup steps off.
@@ -417,13 +419,17 @@ async function fetchNpmPackageMetadata(versionOrTag = 'latest', timeoutMs = 5000
 
   const data = await response.json() as {
     version?: unknown;
-    dist?: { integrity?: unknown };
+    dist?: { integrity?: unknown; tarball?: unknown };
   };
-  if (typeof data.version !== 'string' || typeof data.dist?.integrity !== 'string') {
-    throw new Error('npm registry response did not include version and integrity');
+  if (
+    typeof data.version !== 'string' ||
+    typeof data.dist?.integrity !== 'string' ||
+    typeof data.dist?.tarball !== 'string'
+  ) {
+    throw new Error('npm registry response did not include version, integrity, and tarball');
   }
 
-  return { version: data.version, integrity: data.dist.integrity };
+  return { version: data.version, integrity: data.dist.integrity, tarball: data.dist.tarball };
 }
 
 function printResolvedPackage(metadata: NpmPackageMetadata): void {
@@ -433,15 +439,29 @@ function printResolvedPackage(metadata: NpmPackageMetadata): void {
 
 async function installResolvedPackage(metadata: NpmPackageMetadata): Promise<void> {
   const packageRoot = path.resolve(__dirname, '..');
-  const spec = `${NPM_PACKAGE_NAME}@${metadata.version}`;
-  // Upgrade with the package manager that owns this install. A bun global
-  // install lives at <bunGlobalDir>/node_modules/... (no `lib` segment), so an
-  // `npm install --prefix` would write to <bunGlobalDir>/lib/node_modules and
-  // never touch the running copy — npm exits 0, the verify below fails.
-  if (detectPackageManager(packageRoot) === 'bun') {
-    await installPackageWithBun(spec);
-  } else {
-    await installPackageIntoPrefix(spec, deriveGlobalPrefix(packageRoot));
+  // Download the published tarball and prove its bytes match the registry
+  // integrity BEFORE installing anything. A `name@version` spec would let the
+  // package manager fetch and install whatever the registry serves with no
+  // hash check on our side; instead we verify here and install the LOCAL, now
+  // trusted .tgz. A mismatch throws and nothing below runs — fail closed.
+  const tarball = await downloadVerifiedTarball(metadata.tarball, metadata.integrity);
+  try {
+    // Upgrade with the package manager that owns this install. A bun global
+    // install lives at <bunGlobalDir>/node_modules/... (no `lib` segment), so an
+    // `npm install --prefix` would write to <bunGlobalDir>/lib/node_modules and
+    // never touch the running copy — npm exits 0, the verify below fails.
+    if (detectPackageManager(packageRoot) === 'bun') {
+      await installPackageWithBun(tarball);
+    } else {
+      await installPackageIntoPrefix(tarball, deriveGlobalPrefix(packageRoot));
+    }
+  } finally {
+    // Best-effort cleanup of the verified tarball and its temp dir.
+    try {
+      fs.rmSync(path.dirname(tarball), { recursive: true, force: true });
+    } catch {
+      /* leave it for the OS temp sweep */
+    }
   }
   verifyInstalledVersion(packageRoot, metadata.version);
   refreshAliasShims(packageRoot);

--- a/apps/cli/src/lib/self-update.test.ts
+++ b/apps/cli/src/lib/self-update.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { execFileSync } from 'child_process';
+import { createHash } from 'crypto';
+import * as http from 'http';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -9,6 +11,7 @@ import {
   deriveGlobalPrefix,
   detectPackageManager,
   dismissUpdateVersion,
+  downloadVerifiedTarball,
   findAgentsCliInstalls,
   installPackageIntoPrefix,
   readInstalledVersion,
@@ -16,6 +19,7 @@ import {
   saveUpdateCheck,
   shouldPromptUpgrade,
   verifyInstalledVersion,
+  verifyTarballIntegrity,
 } from './self-update.js';
 
 const tempDirs: string[] = [];
@@ -184,6 +188,74 @@ describe('installPackageIntoPrefix', () => {
     await installPackageIntoPrefix(packDummyPackage('2.0.0'), prefixB);
 
     expect(() => verifyInstalledVersion(runningRoot, '2.0.0')).toThrow(/still 1\.0\.0 \(expected 2\.0\.0\)/);
+  });
+});
+
+function sriFor(buf: Buffer): string {
+  return `sha512-${createHash('sha512').update(buf).digest('base64')}`;
+}
+
+describe('verifyTarballIntegrity', () => {
+  const tarball = Buffer.from('fake tarball bytes   for integrity check');
+
+  it('accepts a tarball whose bytes match the SRI digest', () => {
+    expect(() => verifyTarballIntegrity(tarball, sriFor(tarball))).not.toThrow();
+  });
+
+  it('rejects a tarball whose bytes do not match the SRI digest (tampered/corrupt)', () => {
+    // The security gate: the registry attested one hash, the delivered bytes
+    // hash to another — self-update must refuse it, not install it.
+    const attested = sriFor(tarball);
+    const tampered = Buffer.concat([tarball, Buffer.from('!')]);
+    expect(() => verifyTarballIntegrity(tampered, attested)).toThrow(/integrity check failed/);
+  });
+
+  it('refuses an algorithm weaker than sha512', () => {
+    const sha1 = `sha1-${createHash('sha1').update(tarball).digest('base64')}`;
+    expect(() => verifyTarballIntegrity(tarball, sha1)).toThrow(/unsupported integrity algorithm 'sha1'/);
+  });
+
+  it('rejects a malformed integrity string', () => {
+    expect(() => verifyTarballIntegrity(tarball, 'not-an-sri')).toThrow(/unsupported integrity algorithm/);
+    expect(() => verifyTarballIntegrity(tarball, 'sha512')).toThrow(/malformed integrity string/);
+  });
+});
+
+describe('downloadVerifiedTarball', () => {
+  const servers: http.Server[] = [];
+  afterEach(async () => {
+    for (const s of servers.splice(0)) await new Promise<void>((r) => s.close(() => r()));
+  });
+
+  function serve(bytes: Buffer): Promise<string> {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/octet-stream' });
+      res.end(bytes);
+    });
+    servers.push(server);
+    return new Promise((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        const addr = server.address() as { port: number };
+        resolve(`http://127.0.0.1:${addr.port}/@phnx-labs/agents-cli/-/agents-cli-9.9.9.tgz`);
+      });
+    });
+  }
+
+  it('writes the tarball to disk when the served bytes match the integrity', async () => {
+    const bytes = Buffer.from('verified package payload');
+    const url = await serve(bytes);
+    const file = await downloadVerifiedTarball(url, sriFor(bytes));
+    expect(fs.readFileSync(file).equals(bytes)).toBe(true);
+    expect(path.basename(file)).toBe('agents-cli-9.9.9.tgz');
+    fs.rmSync(path.dirname(file), { recursive: true, force: true });
+  });
+
+  it('rejects a wrong-hash tarball and writes nothing', async () => {
+    // End-to-end over real HTTP + real crypto: the server delivers bytes that
+    // do not match the attested integrity; the download must reject.
+    const attested = sriFor(Buffer.from('the legitimate published tarball'));
+    const url = await serve(Buffer.from('a malicious substituted tarball'));
+    await expect(downloadVerifiedTarball(url, attested)).rejects.toThrow(/integrity check failed/);
   });
 });
 

--- a/apps/cli/src/lib/self-update.ts
+++ b/apps/cli/src/lib/self-update.ts
@@ -15,6 +15,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { createHash, timingSafeEqual } from 'crypto';
 import { spawnSync } from 'child_process';
 import { compareVersions } from './versions.js';
 import { needsWindowsShell } from './platform/index.js';
@@ -186,7 +187,67 @@ export async function installPackageWithBun(spec: string): Promise<void> {
   const { promisify } = await import('util');
   const execFileAsync = promisify(execFile);
   // On Windows `bun` resolves to `bun.exe`/`bun.cmd`; force shell for the .cmd case.
-  await execFileAsync('bun', ['add', '-g', spec], { shell: needsWindowsShell('bun') });
+  // --ignore-scripts: the tarball has already been integrity-verified, but its
+  // lifecycle scripts must not run at install time (the caller refreshes shims
+  // explicitly via refreshAliasShims()) — same fail-closed posture as the npm path.
+  await execFileAsync('bun', ['add', '-g', spec, '--ignore-scripts'], { shell: needsWindowsShell('bun') });
+}
+
+/**
+ * Verify a downloaded tarball's bytes against a Subresource Integrity (SRI)
+ * string of the form `sha512-<base64>` — npm's `dist.integrity`. Recomputes the
+ * digest over the actual bytes with the named algorithm and compares it, in
+ * constant time, to the decoded expected digest.
+ *
+ * Fails closed: a malformed SRI, an algorithm weaker than sha512, or any digest
+ * mismatch throws. This is the gate that makes self-update refuse a tampered or
+ * corrupted tarball *before* it is ever handed to a package manager to install.
+ */
+export function verifyTarballIntegrity(tarball: Buffer, integrity: string): void {
+  const dash = integrity.indexOf('-');
+  if (dash <= 0) {
+    throw new Error(`malformed integrity string: ${JSON.stringify(integrity)}`);
+  }
+  const algorithm = integrity.slice(0, dash);
+  const expectedBase64 = integrity.slice(dash + 1);
+  // npm publishes sha512 SRI; refuse to verify against anything weaker rather
+  // than silently accepting a downgraded (e.g. sha1) attestation.
+  if (algorithm !== 'sha512') {
+    throw new Error(`unsupported integrity algorithm '${algorithm}' (expected sha512)`);
+  }
+  const expected = Buffer.from(expectedBase64, 'base64');
+  const actual = createHash('sha512').update(tarball).digest();
+  if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) {
+    throw new Error(
+      `integrity check failed: tarball hash sha512-${actual.toString('base64')} ` +
+        `does not match expected ${integrity}`,
+    );
+  }
+}
+
+/**
+ * Download the published tarball at `tarballUrl` and prove its bytes match
+ * `integrity` before returning a path to it on disk. The returned .tgz is safe
+ * to hand to `npm install`/`bun add` — it has been verified byte-for-byte
+ * against the registry attestation. Fails closed: a non-200, a download error,
+ * or a hash mismatch throws and no file path is returned, so the caller never
+ * installs an unverified artifact.
+ */
+export async function downloadVerifiedTarball(
+  tarballUrl: string,
+  integrity: string,
+  timeoutMs = 60_000,
+): Promise<string> {
+  const response = await fetch(tarballUrl, { signal: AbortSignal.timeout(timeoutMs) });
+  if (!response.ok) {
+    throw new Error(`could not download tarball from ${tarballUrl} (HTTP ${response.status})`);
+  }
+  const tarball = Buffer.from(await response.arrayBuffer());
+  verifyTarballIntegrity(tarball, integrity);
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-upgrade-'));
+  const file = path.join(dir, path.basename(new URL(tarballUrl).pathname) || 'package.tgz');
+  fs.writeFileSync(file, tarball);
+  return file;
 }
 
 /** Read the version field of the package.json at `packageRoot`, fresh from disk. */

--- a/apps/cli/tests/package-name-consistency.test.ts
+++ b/apps/cli/tests/package-name-consistency.test.ts
@@ -42,16 +42,18 @@ describe('package-name consistency (@phnx-labs canonical)', () => {
   });
 
   it('upgrade installs are built from the canonical package constant', () => {
-    // The npm install itself lives in src/lib/self-update.ts; index.ts builds
-    // the install spec from the shared NPM_PACKAGE_NAME constant.
+    // The npm install itself lives in src/lib/self-update.ts; index.ts resolves
+    // the package to install from the shared NPM_PACKAGE_NAME constant.
     const selfUpdate = read('src/lib/self-update.ts');
     expect(selfUpdate).toContain(`export const NPM_PACKAGE_NAME = '${NPM_PACKAGE}';`);
     expect(selfUpdate).not.toContain('@companion');
     const src = read('src/index.ts');
-    // The install spec is built once from the shared constant, then handed to
-    // the package-manager-specific installer (npm --prefix or `bun add -g`).
-    const specs = src.match(/const spec = `\$\{NPM_PACKAGE_NAME\}@/g) ?? [];
-    expect(specs.length).toBeGreaterThan(0);
+    // The upgrade resolves the canonical package's registry metadata (version +
+    // integrity + tarball) from the shared constant, then downloads and
+    // integrity-verifies that tarball before installing the local .tgz.
+    const metadataFetches = src.match(/registry\.npmjs\.org\/\$\{NPM_PACKAGE_NAME\}\//g) ?? [];
+    expect(metadataFetches.length).toBeGreaterThan(0);
+    expect(src).toContain('downloadVerifiedTarball(metadata.tarball, metadata.integrity)');
   });
 
   it('src/index.ts version-check URLs target the canonical package', () => {


### PR DESCRIPTION
**Summary:** Self-update fetched `dist.integrity` from the npm registry but only *printed* it — `installResolvedPackage` handed `name@version` straight to bun/npm with no tarball download or hash check (`index.ts:434-446`), so a compromised registry/CDN response could install an unverified artifact (RUSH-1754, Security HIGH).

**Fix:** Before installing, the upgrade path now downloads the published tarball (`dist.tarball`), recomputes its SHA-512 and compares it in constant time to the decoded SRI from `dist.integrity`, then installs the **local verified** `.tgz` with `--ignore-scripts`. Fails closed on any mismatch, malformed SRI, or algorithm weaker than sha512 — nothing is installed unless the bytes match the attestation.

- `src/lib/self-update.ts` — new `verifyTarballIntegrity()` (SRI parse + constant-time SHA-512 compare, rejects non-sha512) and `downloadVerifiedTarball()` (fetch → verify → write local .tgz, fail closed on non-200/mismatch); `installPackageWithBun` now passes `--ignore-scripts`.
- `src/index.ts` — `installResolvedPackage()` downloads+verifies then installs the local tarball; `fetchNpmPackageMetadata` now also returns `dist.tarball`.

**Test evidence:**
- New tests in `src/lib/self-update.test.ts`: a wrong-hash (tampered/substituted) tarball is rejected — both the pure `verifyTarballIntegrity` gate and end-to-end over real HTTP + real crypto via `downloadVerifiedTarball`; plus sha1-downgrade and malformed-SRI rejection.
- Updated the `package-name-consistency` lock test to track the new verified-tarball install path.

```
$ bun run test self-update package-name-consistency
 Test Files  2 passed (2)
      Tests  35 passed (35)
```
`tsc --noEmit`: clean (`TYPECHECK_OK`).

3 unrelated failures remain in the full suite (`exec.test.ts`, `import.test.ts`) — pre-existing artifacts of this shared-`/tmp` Linux runner (a leaked `package.json` under `/tmp` and env-var leakage); those files are untouched by this PR.