### PR TITLE
fix(secrets): stop leaking secret values via tmux SessionMeta.cmd and remote env (RUSH-1758, RUSH-1762)

### DIFF
--- a/apps/cli/src/lib/exec.test.ts
+++ b/apps/cli/src/lib/exec.test.ts
@@ -381,4 +381,20 @@ describe('buildTmuxAgentCommand (env-preserving pane command)', () => {
     expect(cmd).toContain('SET=');
     expect(cmd).not.toContain('UNSET');
   });
+
+  it('redacts secret VALUES but keeps KEY names when redactEnvValues is set (RUSH-1758)', () => {
+    const cmd = buildTmuxAgentCommand(
+      'claude',
+      ['--permission-mode', 'plan'],
+      { ANTHROPIC_API_KEY: 'sk-ant-supersecret', PATH: '/usr/bin:/bin' },
+      { redactEnvValues: true },
+    );
+    // Key names + agent command survive for provenance…
+    expect(cmd).toContain('ANTHROPIC_API_KEY=<redacted>');
+    expect(cmd).toContain('PATH=<redacted>');
+    expect(cmd).toMatch(/ claude --permission-mode plan$/);
+    // …but no real value leaks into the (persisted) string.
+    expect(cmd).not.toContain('sk-ant-supersecret');
+    expect(cmd).not.toContain('/usr/bin:/bin');
+  });
 });

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -1041,11 +1041,22 @@ export function shouldWrapInTmux(ctx: TmuxWrapContext): boolean {
  *     `#{pane_pid}`, clean signal delivery on detach/kill).
  * Keys are filtered to valid identifiers so exported shell functions
  * (`BASH_FUNC_*%%`) can't make `env` choke.
+ *
+ * `redactEnvValues` replaces every value with a `<redacted>` marker while keeping
+ * the KEY names. The env map here carries resolved secrets bundles (options.env),
+ * so the real string would embed secret VALUES — which get persisted verbatim
+ * into SessionMeta.cmd on disk (tmux/session.ts). The launched command uses the
+ * real values; the stored/informational copy uses the redacted form (RUSH-1758).
  */
-export function buildTmuxAgentCommand(executable: string, args: string[], env: NodeJS.ProcessEnv): string {
+export function buildTmuxAgentCommand(
+  executable: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  opts: { redactEnvValues?: boolean } = {},
+): string {
   const envPrefix = Object.entries(env)
     .filter(([k, v]) => v !== undefined && EXEC_ENV_KEY_PATTERN.test(k))
-    .map(([k, v]) => `${k}=${shellQuote(String(v))}`)
+    .map(([k, v]) => `${k}=${opts.redactEnvValues ? '<redacted>' : shellQuote(String(v))}`)
     .join(' ');
   const agentCmd = [executable, ...args].map(shellQuote).join(' ');
   return `exec env ${envPrefix} ${agentCmd}`;
@@ -1095,12 +1106,17 @@ async function runInTmux(options: ExecOptions, executable: string, args: string[
   const cwd = options.cwd || process.cwd();
   const idSeed = (options.sessionId ?? randomUUID()).slice(0, 8);
   const name = slugifyName(`ag-${options.agent}-${idSeed}`);
-  const cmd = buildTmuxAgentCommand(executable, args, buildExecEnv(options));
+  const execEnv = buildExecEnv(options);
+  // Launch with the real env (secret VALUES materialized into the pane); persist
+  // only a value-redacted copy in SessionMeta.cmd so resolved secrets never hit
+  // disk via the informational cmd field (RUSH-1758).
+  const cmd = buildTmuxAgentCommand(executable, args, execEnv);
+  const metaCmd = buildTmuxAgentCommand(executable, args, execEnv, { redactEnvValues: true });
 
   const labels: Record<string, string> = { agent: options.agent };
   if (options.sessionId) labels.sessionId = options.sessionId;
 
-  const meta = await createSession({ name, cmd, cwd, socket, source: 'cli', labels });
+  const meta = await createSession({ name, cmd, metaCmd, cwd, socket, source: 'cli', labels });
   const pane = meta.pane;
 
   if (pane) {

--- a/apps/cli/src/lib/secrets/remote.test.ts
+++ b/apps/cli/src/lib/secrets/remote.test.ts
@@ -33,6 +33,7 @@ import {
   resolveSshTarget,
   remoteSecretsRaw,
   remoteResolveEnv,
+  isDangerousRemoteEnvKey,
 } from './remote.js';
 
 const ok = (stdout: string): SshExecResult => ({ code: 0, stdout, stderr: '', timedOut: false });
@@ -228,5 +229,47 @@ describe('remoteResolveEnv', () => {
   it('throws a clear hint when the remote payload is not JSON', async () => {
     sshExecMock.mockReturnValue(ok('command not found: agents'));
     await expect(remoteResolveEnv('host', 'b')).rejects.toThrow(/--format json/);
+  });
+
+  it('drops dangerous-override keys returned by a peer, keeps benign ones (RUSH-1762)', async () => {
+    // A compromised/misconfigured peer returns keys that would silently reshape
+    // THIS process once merged (proxy MITM, base-url redirect, git/loader hijack).
+    sshExecMock.mockReturnValue(ok(JSON.stringify({
+      FOO: 'bar',                              // benign — kept
+      ANTHROPIC_BASE_URL: 'http://evil.test',  // *_BASE_URL — dropped
+      HTTPS_PROXY: 'http://evil.test:8080',    // *_PROXY — dropped
+      ALL_PROXY: 'socks5://evil.test',         // *_PROXY — dropped
+      GIT_SSH_COMMAND: 'ssh -o Foo=bar',       // GIT_* — dropped
+      GIT_CONFIG_GLOBAL: '/tmp/evil',          // GIT_* — dropped
+      LD_PRELOAD: '/tmp/evil.so',              // LD_* — dropped
+      DYLD_INSERT_LIBRARIES: '/tmp/evil.dylib',// DYLD_* — dropped
+      NODE_OPTIONS: '--require /tmp/evil.js',   // loader — dropped
+    })));
+    const env = await remoteResolveEnv('host', 'b');
+    expect(env).toEqual({ FOO: 'bar' });
+    for (const blocked of [
+      'ANTHROPIC_BASE_URL', 'HTTPS_PROXY', 'ALL_PROXY',
+      'GIT_SSH_COMMAND', 'GIT_CONFIG_GLOBAL',
+      'LD_PRELOAD', 'DYLD_INSERT_LIBRARIES', 'NODE_OPTIONS',
+    ]) {
+      expect(env).not.toHaveProperty(blocked);
+    }
+  });
+});
+
+describe('isDangerousRemoteEnvKey', () => {
+  it('blocks the override classes and passes ordinary secret keys', () => {
+    for (const k of [
+      'LD_PRELOAD', 'DYLD_INSERT_LIBRARIES', 'NODE_OPTIONS',
+      'GIT_SSH_COMMAND', 'GIT_CONFIG_GLOBAL',
+      'HTTP_PROXY', 'HTTPS_PROXY', 'ALL_PROXY', 'NO_PROXY',
+      'ANTHROPIC_BASE_URL', 'OPENAI_BASE_URL',
+    ]) {
+      expect(isDangerousRemoteEnvKey(k)).toBe(true);
+      expect(isDangerousRemoteEnvKey(k.toLowerCase())).toBe(true); // case-insensitive
+    }
+    for (const k of ['FOO', 'ANTHROPIC_API_KEY', 'DATABASE_URL', 'GITHUB_TOKEN', 'MY_PROXYING']) {
+      expect(isDangerousRemoteEnvKey(k)).toBe(false);
+    }
   });
 });

--- a/apps/cli/src/lib/secrets/remote.ts
+++ b/apps/cli/src/lib/secrets/remote.ts
@@ -22,8 +22,34 @@ import { emit } from '../events.js';
 import { sshTargetFor } from '../hosts/types.js';
 import { buildRemoteAgentsInvocation } from '../hosts/remote-cmd.js';
 import { resolveRemoteOsSync } from '../hosts/remote-os.js';
+import { isLoaderOrInterpreterEnv } from './bundles.js';
 
 const REMOTE_TIMEOUT_MS = 30_000;
+
+/**
+ * Trust boundary for a remote-resolved env map. A peer's `secrets export` output
+ * is untrusted input: a compromised or misconfigured host could return keys that
+ * silently reshape THIS process's behavior once merged into the agent env
+ * (bundles.ts:251 `sanitizeProcessEnv` only strips loader vars from process.env,
+ * never the remote bundle). Block the dangerous-override classes here — at the
+ * source — so every consumer (`run --secrets b@host`, `secrets exec --host`) is
+ * protected, not just one call site:
+ *   - LD_* / DYLD_* / NODE_OPTIONS and the other loader/interpreter injections
+ *     (reuses the canonical bundles.ts predicate);
+ *   - GIT_*        — GIT_SSH_COMMAND et al. hijack every git subprocess;
+ *   - *_PROXY      — HTTP(S)_PROXY / ALL_PROXY reroute outbound traffic (MITM);
+ *   - *_BASE_URL   — ANTHROPIC_BASE_URL / OPENAI_BASE_URL redirect the model API.
+ * These keys are already rejected on the ADD side (validateEnvKey for loaders),
+ * so a legitimate bundle never carries them — only a hostile peer would.
+ */
+export function isDangerousRemoteEnvKey(name: string): boolean {
+  const upper = name.toUpperCase();
+  if (isLoaderOrInterpreterEnv(upper)) return true;
+  if (upper.startsWith('GIT_')) return true;
+  if (upper.endsWith('_PROXY')) return true;
+  if (upper.endsWith('_BASE_URL')) return true;
+  return false;
+}
 
 /** Remote OS for a host name or target string. Prefer the original host name
  * because enrolled inline hosts resolve to `user@address`, while the OS
@@ -172,8 +198,21 @@ export async function remoteResolveEnv(
     throw new Error(`Unexpected payload resolving '${bundle}' on ${target}.`);
   }
   const env: Record<string, string> = {};
+  const blocked: string[] = [];
   for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+    // Drop dangerous-override keys returned by the (untrusted) peer before they
+    // can reshape this process — see isDangerousRemoteEnvKey.
+    if (isDangerousRemoteEnvKey(k)) {
+      blocked.push(k);
+      continue;
+    }
     env[k] = typeof v === 'string' ? v : String(v);
+  }
+  if (blocked.length > 0) {
+    process.stderr.write(
+      `[secrets] Dropped ${blocked.length} dangerous key(s) from '${bundle}'@${target} ` +
+        `(remote override blocked): ${blocked.join(', ')}\n`,
+    );
   }
   // The remote host audits its own `secrets export` read; this emit records the
   // event on the INITIATING host too (values were pulled into this process and

--- a/apps/cli/src/lib/tmux/session.test.ts
+++ b/apps/cli/src/lib/tmux/session.test.ts
@@ -84,6 +84,31 @@ describe.skipIf(skipReason)('tmux session lifecycle', () => {
     expect(list[0].meta?.cmd).toBe('sleep 30');
   });
 
+  it('persists the redacted metaCmd to disk while executing the real cmd (RUSH-1758)', async () => {
+    // The real command carries a secret value; the persisted informational copy
+    // must not. Prove: (a) meta.cmd stored on disk is the redacted string,
+    // (b) the secret value never appears in the meta, (c) the REAL cmd still ran.
+    const secret = 'SECRET_VALUE_XYZ789';
+    const outFile = path.join(tempDir, 'ran.txt');
+    const meta = await createSession({
+      name: 'redact',
+      cmd: `sh -c 'printf ${secret} > ${outFile}; sleep 30'`,
+      metaCmd: 'exec env TOKEN=<redacted> claude',
+      socket,
+    });
+    expect(meta.cmd).toBe('exec env TOKEN=<redacted> claude');
+    expect(JSON.stringify(meta)).not.toContain(secret);
+
+    // Read back what actually hit disk (listSessions reads the persisted meta).
+    const list = await listSessions({ socket });
+    expect(list[0].meta?.cmd).toBe('exec env TOKEN=<redacted> claude');
+    expect(JSON.stringify(list[0].meta)).not.toContain(secret);
+
+    // The real cmd (with the secret) still executed in the live pane.
+    await wait(400);
+    expect(fs.readFileSync(outFile, 'utf8')).toContain(secret);
+  });
+
   it('captures live output from a running pane', async () => {
     await createSession({
       name: 'capture-test',

--- a/apps/cli/src/lib/tmux/session.ts
+++ b/apps/cli/src/lib/tmux/session.ts
@@ -42,6 +42,13 @@ export interface SessionMeta {
 export interface CreateSessionOptions {
   name: string;
   cmd?: string;
+  /**
+   * Redacted copy of `cmd` to persist in SessionMeta.cmd instead of the real
+   * command. When set, `cmd` is still executed but only `metaCmd` is written to
+   * disk — used to keep resolved secret values out of the informational cmd
+   * field (see exec.ts buildTmuxAgentCommand, RUSH-1758). Defaults to `cmd`.
+   */
+  metaCmd?: string;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   socket?: string;
@@ -167,7 +174,9 @@ export async function createSession(opts: CreateSessionOptions): Promise<Session
     name: opts.name,
     socket,
     createdAt: Date.now(),
-    cmd: opts.cmd,
+    // Persist the redacted copy when provided so resolved secret values in the
+    // launch command never land on disk (RUSH-1758).
+    cmd: opts.metaCmd ?? opts.cmd,
     cwd: opts.cwd,
     source: opts.source ?? 'cli',
     labels: opts.labels,


### PR DESCRIPTION
Two HIGH secrets-leak fixes on the agent exec path.

**RUSH-1758** — `buildTmuxAgentCommand` (`src/lib/exec.ts`) formatted the full agent env, including resolved secret **values**, into the `exec env KEY=value` launch string, which `createSession` persisted verbatim into `SessionMeta.cmd` on disk (`src/lib/tmux/session.ts`). The pane still launches with real values, but the persisted copy is now value-redacted (`KEY=<redacted>`) via a new optional `metaCmd` field — secrets never reach disk through the informational `cmd` field.

**RUSH-1762** — `remoteResolveEnv` (`src/lib/secrets/remote.ts`) returned every key a peer's `secrets export` emitted, unfiltered, and `commands/exec.ts` spread them straight into the agent env (`sanitizeProcessEnv` only strips loader vars from `process.env`, never the remote bundle). A deny-list now runs **at the source** over the resolved map — blocking `*_BASE_URL`, `*_PROXY`, `GIT_*`, `LD_*`/`DYLD_*`/`NODE_OPTIONS` and the other loader/interpreter injections — so a hostile/misconfigured peer cannot silently reshape this process (proxy MITM, API base-url redirect, git/loader hijack). Dropped keys are reported to stderr; every consumer is protected, not just one call site.

## Tests (added, no mocks on the real path)
- `src/lib/exec.test.ts` — `buildTmuxAgentCommand` redacts values, keeps key names.
- `src/lib/tmux/session.test.ts` — real tmux server: the redacted `metaCmd` is what lands on disk while the real cmd (carrying the secret) still executes.
- `src/lib/secrets/remote.test.ts` — `remoteResolveEnv` drops the dangerous-override classes, keeps benign keys; `isDangerousRemoteEnvKey` unit coverage.

```
Test Files  3 passed (3)
     Tests  99 passed (99)
```
(The 2 pre-existing exec.test.ts failures seen only inside an agent session are ambient env leakage — `AGENTS_MAILBOX_DIR`/`DISABLE_AUTOUPDATER` spread from `process.env` into `buildExecEnv`, a code path this PR does not touch; with those unset exec.test.ts is 48/48.)

`tsc --noEmit`: exit 0.

Pure security bug fixes — no new user-facing flag/command/API surface, so no CHANGELOG entry (per the bug-fix exemption).