### PR TITLE
fix(git): reject option-like branch names on push (RUSH-1765)

### DIFF
--- a/apps/cli/src/lib/git.test.ts
+++ b/apps/cli/src/lib/git.test.ts
@@ -15,12 +15,35 @@ import simpleGit from 'simple-git';
 import {
   adoptRepo,
   assertSafeGitTransport,
+  assertValidBranchName,
   commitAndPush,
   displayHomePath,
   parseSource,
   pullRepo,
+  pushOrigin,
   syncRepoGit,
 } from './git.js';
+
+describe('assertValidBranchName', () => {
+  it('allows ordinary branch names', () => {
+    expect(() => assertValidBranchName('main')).not.toThrow();
+    expect(() => assertValidBranchName('feature/foo')).not.toThrow();
+    expect(() => assertValidBranchName('rush-1765-git-push')).not.toThrow();
+  });
+
+  it('rejects empty names', () => {
+    expect(() => assertValidBranchName('')).toThrow(/empty/);
+    expect(() => assertValidBranchName('   ')).toThrow(/empty/);
+  });
+
+  // RUSH-1765 finding 2: a branch beginning with "-" is parsed as a git push option.
+  it('rejects names that would be parsed as git push options', () => {
+    expect(() => assertValidBranchName('--mirror')).toThrow(/git option/);
+    expect(() => assertValidBranchName('--receive-pack=evil')).toThrow(/git option/);
+    expect(() => assertValidBranchName('-u')).toThrow(/git option/);
+    expect(() => assertValidBranchName('--force')).toThrow(/git option/);
+  });
+});
 
 describe('assertSafeGitTransport', () => {
   const allowed = [
@@ -305,6 +328,20 @@ describe('commitAndPush (clean-but-ahead + dirty)', () => {
     const verify = path.join(root, 'verify-dirty');
     await simpleGit().clone(remote, verify);
     expect(fs.readFileSync(path.join(verify, 'dirty.txt'), 'utf8')).toBe('new\n');
+  });
+
+  // RUSH-1765 finding 2: hostile branch names must never reach git as push options.
+  // Real simple-git instance; pushOrigin validates before any push argv is built.
+  it('refuses to push a hostile branch name that would be a git option', async () => {
+    const git = simpleGit(local);
+    await expect(pushOrigin(git, '--mirror')).rejects.toThrow(/git option/);
+    await expect(pushOrigin(git, '--receive-pack=evil')).rejects.toThrow(/git option/);
+    // Normal branch still pushes via the hardened path (real remote).
+    await commitFile(local, 'safe-push.txt', 'ok\n', 'safe push');
+    await pushOrigin(git, 'main');
+    const verify = path.join(root, 'verify-safe-push');
+    await simpleGit().clone(remote, verify);
+    expect(fs.readFileSync(path.join(verify, 'safe-push.txt'), 'utf8')).toBe('ok\n');
   });
 });
 

--- a/apps/cli/src/lib/git.ts
+++ b/apps/cli/src/lib/git.ts
@@ -63,6 +63,42 @@ export function assertSafeGitTransport(source: string): void {
 }
 
 /**
+ * Validate a branch name before it is passed to `git push` / `git pull`.
+ *
+ * A name beginning with `-` is parsed by git as a command-line option
+ * (e.g. `--mirror`, `--receive-pack=…`), not a ref. Pure string check —
+ * identical on every OS, no spawn.
+ *
+ * @throws Error if the name is empty or would be interpreted as a git option.
+ */
+export function assertValidBranchName(branch: string): void {
+  const b = branch.trim();
+  if (!b) {
+    throw new Error(
+      `Invalid branch name ${JSON.stringify(branch)}: branch name is empty.`,
+    );
+  }
+  if (b.startsWith('-')) {
+    throw new Error(
+      `Invalid branch name ${JSON.stringify(branch)}: a name starting with "-" is interpreted as a git option.`,
+    );
+  }
+}
+
+/**
+ * `git push origin <branch>` with option-injection hardening:
+ *   1. {@link assertValidBranchName} rejects leading `-`
+ *   2. `--` ends option parsing so a hostile ref cannot be read as a flag
+ *
+ * Prefer this over `git.push(remote, branch)` whenever the branch comes from
+ * repo state rather than a hard-coded literal.
+ */
+export async function pushOrigin(git: SimpleGit, branch: string): Promise<void> {
+  assertValidBranchName(branch);
+  await git.raw(['push', '--', 'origin', branch]);
+}
+
+/**
  * Whether installing a cloned/pulled repo's `.githooks/` is enabled.
  *
  * Installing hooks wires those scripts into `.git/hooks/`, so `git` EXECUTES
@@ -452,6 +488,7 @@ export async function commitAndPush(repoPath: string, message: string): Promise<
     const git = simpleGit(repoPath);
     let status = await git.status();
     const branch = status.current || 'main';
+    assertValidBranchName(branch);
 
     let committed = false;
     if (status.files.length > 0) {
@@ -480,7 +517,7 @@ export async function commitAndPush(repoPath: string, message: string): Promise<
       /* origin/<branch> may not exist yet (first push) */
     }
 
-    await git.push('origin', branch);
+    await pushOrigin(git, branch);
 
     let after = '';
     try {
@@ -848,6 +885,7 @@ export async function syncRepoGit(
     }
 
     const branch = status.current || 'main';
+    assertValidBranchName(branch);
     await git.fetch('origin');
     await git.pull('origin', branch, { '--rebase': 'true' });
 
@@ -855,7 +893,7 @@ export async function syncRepoGit(
 
     let pushed = false;
     if (opts.push) {
-      await git.push('origin', branch);
+      await pushOrigin(git, branch);
       pushed = true;
     }
 


### PR DESCRIPTION
## Summary
Hardens `commitAndPush` / `syncRepoGit` so a branch name like `--mirror` or `--receive-pack=…` cannot be parsed as a `git push` option: `assertValidBranchName` rejects leading `-`, and `pushOrigin` uses `git push -- origin <branch>`.

## Test evidence
```
$ bun run test src/lib/git.test.ts
 ✓ src/lib/git.test.ts (38 tests) 4160ms
   ✓ refuses to push a hostile branch name that would be a git option  389ms
 Test Files  1 passed (1)
      Tests  38 passed (38)

$ bun run build
# tsc + dist copy — exit 0
```