### PR TITLE
fix(computer-win): reject UNC/protocol paths in launch_app (RUSH-1763)

### DIFF
--- a/.github/workflows/computer-helper-win.yml
+++ b/.github/workflows/computer-helper-win.yml
@@ -43,7 +43,10 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Build (native win-x64)
-        run: dotnet build -c Release
+        run: dotnet build computer-helper-win.csproj -c Release
+
+      - name: Unit tests (LaunchTarget path safety)
+        run: dotnet test tests/LaunchTarget.Tests.csproj -c Release
 
       - name: Smoke test (UIAutomation roundtrip + screenshot)
         shell: pwsh
@@ -78,7 +81,7 @@ jobs:
 
       # Exact flags scripts/build-win.sh uses, so CI smokes the shipped artifact.
       - name: Publish (self-contained single-file win-x64)
-        run: dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -o dist
+        run: dotnet publish computer-helper-win.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -o dist
 
       - name: Smoke test published single-file exe (UIA roundtrip + screenshot)
         shell: pwsh
@@ -112,7 +115,7 @@ jobs:
 
       # Exact flags scripts/build-win.sh uses — this artifact IS the shipped one.
       - name: Publish (self-contained single-file win-x64)
-        run: dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -o dist
+        run: dotnet publish computer-helper-win.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -o dist
 
       - name: Smoke test the exe being released (UIA roundtrip + screenshot)
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Security
 
+- **`launch_app` on Windows rejects UNC/remote and protocol/URL targets (RUSH-1763).**
+  Explicit `path` values used to flow straight into `ProcessStartInfo` with
+  `UseShellExecute=true`, so a caller could launch `\\server\share\payload.exe`
+  or `http://…` / `ms-settings:…` handlers. `launch_app` now rejects UNC/remote
+  paths, protocol/URL schemes, and `..` path segments; explicit `path` must be
+  a local drive-rooted absolute path (`C:\…`). Short names (`notepad`, `msedge`)
+  still resolve via PATH / App Paths. Source: `native/computer-win/LaunchTarget.cs`,
+  `native/computer-win/Apps.cs`.
 - **The Windows `computer` daemon now requires authentication.** `computer-helper-win`
   previously started with `authed = expectedToken == null` and the CLI never provisioned a
   token, so it ran open on `127.0.0.1` — and loopback TCP on Windows is not user/session

--- a/apps/cli/scripts/build-win.sh
+++ b/apps/cli/scripts/build-win.sh
@@ -40,8 +40,9 @@ fi
 [[ -n "$DOTNET" ]] || die "dotnet not found. Install the .NET 10 SDK: curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 10.0"
 
 # native/ lives at the repo root (siblings of apps/), not under apps/cli.
-PROJECT="../../native/computer-win"
-OUT="$PROJECT/dist"
+# Pin the main daemon csproj — the directory also holds LaunchTarget.Tests.csproj.
+PROJECT="../../native/computer-win/computer-helper-win.csproj"
+OUT="../../native/computer-win/dist"
 
 bold "Build (win-x64)"; echo "  $("$DOTNET" --version) — $PROJECT"
 echo

--- a/native/computer-win/AGENTS.md
+++ b/native/computer-win/AGENTS.md
@@ -14,9 +14,11 @@ Rpc.cs          Method dispatch table (19 methods)
 Automation.cs   UI Automation tree walk + SendInput (click/type/key/scroll/drag) + window focus
 Screenshot.cs   Graphics.CopyFromScreen over the virtual screen
 Apps.cs         Process/window enumeration; launch_app via PATH + App Paths registry
+LaunchTarget.cs Pure path safety for launch_app (UNC/protocol rejection; RUSH-1763)
 ElementCache.cs @eN element handle cache
 smoke/smoke.mjs Smoke test (Unicode-typing regression loops for #554/#581)
 computer-helper-win.csproj   net10.0-windows, WPF + WinForms enabled
+tests/LaunchTarget.Tests.csproj  net10.0 xunit tests for LaunchTarget (cross-platform)
 ```
 
 ## Build

--- a/native/computer-win/Apps.cs
+++ b/native/computer-win/Apps.cs
@@ -62,8 +62,25 @@ public static class Apps
         string target = path ?? name ?? bundleId
             ?? throw RpcError.Invalid("pass one of: bundle_id, path, name");
 
-        if ((name ?? "").Contains("..") || (name ?? "").Contains('/'))
-            throw RpcError.Invalid("name must not contain '/' or '..' — use path instead");
+        // RUSH-1763: never hand UNC/remote, protocol/URL, or traversal-shaped
+        // targets to ShellExecute. Explicit `path` must also be a local
+        // drive-rooted path (C:\...); bare names use name/bundle_id instead.
+        if (path is not null)
+        {
+            string? pathReject = LaunchTarget.RejectReason(path);
+            if (pathReject is not null) throw RpcError.Invalid(pathReject);
+            if (!LaunchTarget.IsLocalRootedPath(path))
+                throw RpcError.Invalid("path must be an absolute local path (e.g. C:\\Windows\\System32\\notepad.exe)");
+        }
+        else
+        {
+            // name / bundle_id: PATH-style short names only — no separators.
+            string shortName = name ?? bundleId ?? "";
+            if (shortName.Contains("..") || shortName.Contains('/') || shortName.Contains('\\'))
+                throw RpcError.Invalid("name must not contain path separators or '..' — use path instead");
+            string? nameReject = LaunchTarget.RejectReason(target);
+            if (nameReject is not null) throw RpcError.Invalid(nameReject);
+        }
 
         try
         {

--- a/native/computer-win/LaunchTarget.Tests.cs
+++ b/native/computer-win/LaunchTarget.Tests.cs
@@ -1,0 +1,106 @@
+using Xunit;
+
+namespace ComputerHelperWin.Tests;
+
+/// <summary>
+/// 1:1 tests for <see cref="LaunchTarget"/> (RUSH-1763). Pure string checks —
+/// no process launch, no mocking. These fail if UNC/protocol rejection is removed.
+/// </summary>
+public class LaunchTargetTests
+{
+    [Theory]
+    [InlineData(@"\\evil\share\payload.exe")]
+    [InlineData("//evil/share/payload.exe")]
+    [InlineData(@"\\?\UNC\evil\share\payload.exe")]
+    [InlineData(@"//?/UNC/evil/share/payload.exe")]
+    [InlineData(@"\\.\PIPE\malicious")]
+    [InlineData(@"//./PIPE/malicious")]
+    public void RejectReason_rejects_unc_and_remote(string target)
+    {
+        string? reason = LaunchTarget.RejectReason(target);
+        Assert.NotNull(reason);
+        Assert.Contains("UNC/remote", reason, StringComparison.Ordinal);
+        Assert.False(LaunchTarget.IsLocalRootedPath(target));
+    }
+
+    [Theory]
+    [InlineData("http://evil.example/payload.exe")]
+    [InlineData("https://evil.example/payload.exe")]
+    [InlineData("file:///C:/Windows/System32/cmd.exe")]
+    [InlineData("file://server/share/payload.exe")]
+    [InlineData("ms-settings:privacy")]
+    [InlineData("shell:AppsFolder\\Something")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("ftp://evil.example/payload.exe")]
+    public void RejectReason_rejects_protocol_and_url(string target)
+    {
+        string? reason = LaunchTarget.RejectReason(target);
+        Assert.NotNull(reason);
+        Assert.Contains("protocol/URL", reason, StringComparison.Ordinal);
+        Assert.False(LaunchTarget.IsLocalRootedPath(target));
+    }
+
+    [Theory]
+    [InlineData(@"C:\Windows\System32\..\..\Users\Public\evil.exe")]
+    [InlineData(@"C:/Windows/System32/../../Users/Public/evil.exe")]
+    [InlineData(@"C:\foo\..\bar\..\baz.exe")]
+    public void RejectReason_rejects_parent_traversal(string target)
+    {
+        string? reason = LaunchTarget.RejectReason(target);
+        Assert.NotNull(reason);
+        Assert.Contains("..", reason, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(@"C:\Windows\System32\notepad.exe")]
+    [InlineData(@"C:/Windows/System32/notepad.exe")]
+    [InlineData(@"c:\Program Files\App\app.exe")]
+    [InlineData(@"D:\Tools\myapp.exe")]
+    [InlineData(@"\\?\C:\Windows\System32\notepad.exe")]
+    public void RejectReason_allows_local_drive_paths(string target)
+    {
+        Assert.Null(LaunchTarget.RejectReason(target));
+    }
+
+    [Theory]
+    [InlineData(@"C:\Windows\System32\notepad.exe")]
+    [InlineData(@"C:/Windows/System32/notepad.exe")]
+    [InlineData(@"d:\app\bin\tool.exe")]
+    public void IsLocalRootedPath_true_for_drive_paths(string target)
+    {
+        Assert.True(LaunchTarget.IsLocalRootedPath(target));
+    }
+
+    [Theory]
+    [InlineData("notepad")]
+    [InlineData("msedge")]
+    [InlineData("notepad.exe")]
+    [InlineData(@"\\evil\share\x.exe")]
+    [InlineData("http://evil.example/x")]
+    [InlineData(@"\Windows\System32\notepad.exe")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void IsLocalRootedPath_false_for_non_drive_targets(string? target)
+    {
+        Assert.False(LaunchTarget.IsLocalRootedPath(target));
+    }
+
+    [Theory]
+    [InlineData("notepad")]
+    [InlineData("msedge")]
+    [InlineData("notepad.exe")]
+    public void RejectReason_allows_short_app_names(string target)
+    {
+        // name/bundle_id resolution path — bare names are not UNC/protocol.
+        Assert.Null(LaunchTarget.RejectReason(target));
+        Assert.False(LaunchTarget.IsLocalRootedPath(target));
+    }
+
+    [Fact]
+    public void RejectReason_rejects_empty()
+    {
+        Assert.Equal("launch target is empty", LaunchTarget.RejectReason(""));
+        Assert.Equal("launch target is empty", LaunchTarget.RejectReason("   "));
+        Assert.Equal("launch target is empty", LaunchTarget.RejectReason(null));
+    }
+}

--- a/native/computer-win/LaunchTarget.cs
+++ b/native/computer-win/LaunchTarget.cs
@@ -1,0 +1,119 @@
+namespace ComputerHelperWin;
+
+/// <summary>
+/// Pure launch-target safety checks for <c>launch_app</c> (RUSH-1763).
+/// Rejects UNC/remote shares and protocol/URL schemes before anything is
+/// handed to <see cref="System.Diagnostics.ProcessStartInfo"/> / ShellExecute.
+/// No Windows APIs — unit-testable on any host.
+/// </summary>
+public static class LaunchTarget
+{
+    /// <summary>
+    /// Returns null when <paramref name="target"/> is safe to consider for
+    /// launch; otherwise a stable human-readable rejection reason.
+    /// </summary>
+    public static string? RejectReason(string? target)
+    {
+        if (string.IsNullOrWhiteSpace(target))
+            return "launch target is empty";
+
+        string t = target.Trim();
+
+        if (IsUncOrRemote(t))
+            return "launch path must be a local path — UNC/remote paths are not allowed";
+
+        if (IsProtocolOrUrl(t))
+            return "launch path must be a local path — protocol/URL targets are not allowed";
+
+        if (HasParentTraversalSegment(t))
+            return "launch path must not contain '..' segments";
+
+        return null;
+    }
+
+    /// <summary>
+    /// True for absolute local Windows paths of the form <c>X:\...</c> or
+    /// <c>X:/...</c>. UNC, schemes, and bare names return false.
+    /// </summary>
+    public static bool IsLocalRootedPath(string? target)
+    {
+        if (string.IsNullOrWhiteSpace(target)) return false;
+        string t = target.Trim();
+        if (IsUncOrRemote(t) || IsProtocolOrUrl(t)) return false;
+        if (t.Length < 3) return false;
+        if (!char.IsAsciiLetter(t[0])) return false;
+        if (t[1] != ':') return false;
+        return t[2] is '\\' or '/';
+    }
+
+    /// <summary>
+    /// UNC / remote share forms: <c>\\server\share</c>, <c>//server/share</c>,
+    /// <c>\\?\UNC\...</c>, and device namespaces <c>\\.\...</c>.
+    /// </summary>
+    public static bool IsUncOrRemote(string t)
+    {
+        if (t.Length < 2) return false;
+
+        // Extended UNC: \\?\UNC\server\share
+        if (t.StartsWith(@"\\?\UNC\", StringComparison.OrdinalIgnoreCase)) return true;
+        if (t.StartsWith(@"//?/UNC/", StringComparison.OrdinalIgnoreCase)) return true;
+
+        // Device namespace / local device path used as a remote-style prefix: \\.\PIPE\...
+        if (t.StartsWith(@"\\.\", StringComparison.Ordinal) || t.StartsWith(@"//./", StringComparison.Ordinal))
+            return true;
+
+        // Standard UNC: \\server\... or //server/...
+        // (\\?\C:\... long-path local form is NOT UNC — handled below.)
+        if (t.StartsWith(@"\\?\", StringComparison.Ordinal))
+        {
+            // \\?\C:\Windows\... is a local long path — not remote.
+            // Anything else under \\?\ that isn't a drive is treated as remote/device.
+            string rest = t.Substring(4);
+            return !(rest.Length >= 2 && char.IsAsciiLetter(rest[0]) && rest[1] == ':');
+        }
+
+        if (t.StartsWith(@"\\", StringComparison.Ordinal) || t.StartsWith("//", StringComparison.Ordinal))
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Protocol / URL targets ShellExecute would hand to a registered handler
+    /// (<c>http:</c>, <c>https:</c>, <c>file:</c>, <c>ms-settings:</c>, …).
+    /// Drive-letter paths (<c>C:\...</c>) are not schemes.
+    /// </summary>
+    public static bool IsProtocolOrUrl(string t)
+    {
+        int colon = t.IndexOf(':');
+        if (colon <= 0) return false;
+
+        // Drive letter: single ASCII letter + ':' + separator (or end).
+        if (colon == 1 && char.IsAsciiLetter(t[0]))
+            return false;
+
+        // Any other "scheme:" form is a protocol/URL target.
+        // Require the scheme to look like a URI scheme (letters + digits + +.-).
+        for (int i = 0; i < colon; i++)
+        {
+            char c = t[i];
+            if (char.IsAsciiLetterOrDigit(c) || c is '+' or '-' or '.') continue;
+            return false;
+        }
+        return true;
+    }
+
+    static bool HasParentTraversalSegment(string t)
+    {
+        // Strip a leading \\?\ long-path prefix so segments parse cleanly.
+        string s = t;
+        if (s.StartsWith(@"\\?\", StringComparison.Ordinal))
+            s = s.Substring(4);
+
+        foreach (string seg in s.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (seg == "..") return true;
+        }
+        return false;
+    }
+}

--- a/native/computer-win/README.md
+++ b/native/computer-win/README.md
@@ -98,6 +98,7 @@ match the mac helper exactly.
 | `Automation.cs` | UI Automation tree walk, `SendInput` click/type/key/scroll/drag, window focus |
 | `Screenshot.cs` | pid-scoped `Graphics.CopyFromScreen` capture: window list / window / display (`window_id` = HWND) |
 | `Apps.cs` | Process/window enumeration; `launch_app` via PATH + App Paths registry |
+| `LaunchTarget.cs` | Pure path safety for `launch_app` — rejects UNC/remote, protocol/URL, `..` (RUSH-1763) |
 | `ElementCache.cs` | `@eN` element handle cache |
 | `smoke/smoke.mjs` | Smoke test (incl. Unicode-typing regression loops for #554/#581) |
 | `computer-helper-win.csproj` | .NET 10 project (`net10.0-windows`, WPF + WinForms) |
@@ -110,7 +111,9 @@ match the mac helper exactly.
   (`TypeSettleMs`). The smoke test guards this.
 - **`bundle_id` is the process image name** (`notepad`, `msedge`), not an
   Apple-style reverse-DNS id — Windows has no bundle IDs. `launch_app` resolves
-  targets via PATH + the App Paths registry.
+  short names via PATH + the App Paths registry. Explicit `path` must be a
+  local drive-rooted absolute path; UNC/remote shares, protocol/URL schemes
+  (`http:`, `ms-settings:`, …), and `..` segments are rejected (RUSH-1763).
 - **`notify` is pass-through only** — there is no Windows Toast call; the Rush
   computer-manager intercepts the return value (mirrors `Notify.swift`).
 - **`background=true` is rejected** (`action_unsupported`) on `click`/`drag`

--- a/native/computer-win/computer-helper-win.csproj
+++ b/native/computer-win/computer-helper-win.csproj
@@ -38,4 +38,11 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <!-- Tests live next to source; project file is under tests/ (isolated obj/bin). -->
+  <ItemGroup>
+    <Compile Remove="LaunchTarget.Tests.cs" />
+    <None Include="LaunchTarget.Tests.cs" />
+    <None Include="tests\**" />
+  </ItemGroup>
+
 </Project>

--- a/native/computer-win/tests/LaunchTarget.Tests.csproj
+++ b/native/computer-win/tests/LaunchTarget.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Unit tests for LaunchTarget path safety (RUSH-1763). Targets plain net10.0
+    so they run on the Linux/macOS build hosts that cross-publish the Windows
+    daemon — no WPF/WinForms/Windows SDK required. Source lives next to
+    LaunchTarget.cs; this project file is under tests/ so obj/bin stay isolated.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>ComputerHelperWin.Tests</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Pure validation unit under test + 1:1 tests (sources sit next to LaunchTarget.cs). -->
+    <Compile Include="..\LaunchTarget.cs" />
+    <Compile Include="..\LaunchTarget.Tests.cs" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
Restrict Windows `launch_app` so explicit paths and short names cannot hand UNC/remote shares or protocol/URL targets to ShellExecute (RUSH-1763).

## Changes
- `LaunchTarget.cs` — pure rejection of UNC/remote (`\\…`, `//…`, `\\?\UNC\…`, `\\.\…`), protocol/URL schemes (`http:`, `file:`, `ms-settings:`, …), and `..` segments; `IsLocalRootedPath` requires `X:\…` for explicit `path`
- `Apps.cs` — gate `LaunchApp` before `ProcessStartInfo`/`UseShellExecute=true`; short names still resolve via PATH/App Paths
- `LaunchTarget.Tests.cs` — 37 xunit cases (would fail if rejection removed)
- Pin `computer-helper-win.csproj` in `build-win.sh` + CI so the sibling test project does not break `dotnet publish`

## Test evidence
```
$ export PATH="$HOME/.dotnet:$PATH"
$ dotnet test native/computer-win/tests/LaunchTarget.Tests.csproj -v q
Passed!  - Failed:     0, Passed:    37, Skipped:     0, Total:    37, Duration: 39 ms - LaunchTarget.Tests.dll (net10.0)

$ bash apps/cli/scripts/build-win.sh
Ready
../../native/computer-win/dist/computer-helper-win.exe
172855201 bytes (~164 MB)
```