### PR TITLE
fix(daemon): stop persisting Claude OAuth token in service manifest (RUSH-1759)

### DIFF
--- a/apps/cli/src/lib/daemon.test.ts
+++ b/apps/cli/src/lib/daemon.test.ts
@@ -1,12 +1,14 @@
 /**
  * Daemon service-manifest generation.
  *
- * The load-bearing behavior under test: a long-lived Claude OAuth token stored
- * in the `claude` secrets bundle is baked into the launchd plist / systemd unit
- * environment, so headless routine runs stop depending on the short-lived
- * interactive Keychain OAuth session. The Keychain itself is swapped for an
- * in-memory backend via setKeychainBackendForTest — the contract here is the
- * generator, not the Keychain wiring (that rides the e2e smoke run).
+ * The load-bearing security contract under test (RUSH-1759): the Claude OAuth
+ * token stored in the `claude` secrets bundle is NEVER written into the launchd
+ * plist / systemd unit, even when one is configured — a persisted service
+ * manifest is a plaintext credential on disk. The daemon obtains the token at
+ * startup from the secure store instead (readDaemonClaudeOAuthToken). The
+ * Keychain itself is swapped for an in-memory backend via
+ * setKeychainBackendForTest so the generators can be exercised with a token
+ * configured and proven to omit it.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -160,8 +162,8 @@ describe('writeOwnerOnlyServiceManifest', () => {
 });
 
 describe('generateLaunchdPlist', () => {
-  it('omits CLAUDE_CODE_OAUTH_TOKEN when none is configured', () => {
-    const plist = generateLaunchdPlist(readDaemonClaudeOAuthToken({ allowPrompt: true }));
+  it('never embeds CLAUDE_CODE_OAUTH_TOKEN, only PATH', () => {
+    const plist = generateLaunchdPlist();
     expect(plist).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
     // The PATH entry is always present so EnvironmentVariables is never empty.
     expect(plist).toContain('<key>PATH</key>');
@@ -171,36 +173,28 @@ describe('generateLaunchdPlist', () => {
     expect(plist).not.toContain('v24.0.0');
   });
 
-  it('injects the token into EnvironmentVariables when configured', () => {
+  it('omits the token even when one is configured in the claude bundle (RUSH-1759)', () => {
     seedKeychainBacked('sk-ant-oat01-abc123');
-    const plist = generateLaunchdPlist(readDaemonClaudeOAuthToken({ allowPrompt: true }));
-    expect(plist).toContain('<key>CLAUDE_CODE_OAUTH_TOKEN</key>');
-    expect(plist).toContain('<string>sk-ant-oat01-abc123</string>');
-    // Must sit inside the EnvironmentVariables dict, after PATH.
-    const envIdx = plist.indexOf('<key>EnvironmentVariables</key>');
-    const tokenIdx = plist.indexOf('<key>CLAUDE_CODE_OAUTH_TOKEN</key>');
-    expect(envIdx).toBeGreaterThan(-1);
-    expect(tokenIdx).toBeGreaterThan(envIdx);
-  });
-
-  it('XML-escapes special characters in the token value', () => {
-    seedKeychainBacked('tok&en<x>');
-    const plist = generateLaunchdPlist(readDaemonClaudeOAuthToken({ allowPrompt: true }));
-    expect(plist).toContain('<string>tok&amp;en&lt;x&gt;</string>');
-    expect(plist).not.toContain('<string>tok&en<x></string>');
+    // Sanity: the token IS resolvable — proving the omission below is the
+    // generator's doing, not an empty bundle.
+    expect(readDaemonClaudeOAuthToken({ allowPrompt: true })).toBe('sk-ant-oat01-abc123');
+    const plist = generateLaunchdPlist();
+    expect(plist).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
+    expect(plist).not.toContain('sk-ant-oat01-abc123');
   });
 });
 
 describe('generateSystemdUnit', () => {
-  it('omits the token Environment line when none is configured', () => {
+  it('never embeds a token Environment line, only PATH', () => {
     expect(generateSystemdUnit()).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
   });
 
-  it('adds an Environment line for the token when configured', () => {
+  it('omits the token even when one is configured in the claude bundle (RUSH-1759)', () => {
     seedKeychainBacked('sk-ant-oat01-abc123');
-    expect(generateSystemdUnit(readDaemonClaudeOAuthToken({ allowPrompt: true }))).toContain(
-      'Environment=CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-abc123',
-    );
+    expect(readDaemonClaudeOAuthToken({ allowPrompt: true })).toBe('sk-ant-oat01-abc123');
+    const unit = generateSystemdUnit();
+    expect(unit).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
+    expect(unit).not.toContain('sk-ant-oat01-abc123');
   });
 
   it('pins the running Node bin dir first on PATH and drops the stale hardcoded nvm version', () => {
@@ -239,8 +233,8 @@ describe('service manifest CLI entry injection', () => {
     const savedArgv1 = process.argv[1];
     process.argv[1] = postinstallEntry;
     try {
-      const plist = generateLaunchdPlist(null, installedEntry);
-      const unit = generateSystemdUnit(null, installedEntry);
+      const plist = generateLaunchdPlist(installedEntry);
+      const unit = generateSystemdUnit(installedEntry);
       expect(plist).toContain(`<string>${installedEntry}</string>`);
       expect(unit).toContain(systemdQuote(installedEntry));
       expect(plist).not.toContain(postinstallEntry);

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -290,6 +290,22 @@ export async function runDaemon(): Promise<void> {
   }
   log('INFO', `Daemon started (PID: ${process.pid})`);
 
+  // RUSH-1759: the launchd plist / systemd unit no longer bake the Claude OAuth
+  // token onto disk. Obtain it here from the secure `claude` secrets bundle and
+  // inject into this process's env so every routine run this daemon spawns still
+  // receives it (via the sandbox allowlist), without the token ever being
+  // persisted in the service manifest. A read from a file-backed store (Linux)
+  // needs no prompt; on macOS it resolves broker-only from an unlocked
+  // secrets-agent and is otherwise absent (leaving the daemon on its existing
+  // interactive OAuth session), matching the detached-start path. Never blocks.
+  if (!process.env.CLAUDE_CODE_OAUTH_TOKEN) {
+    const oauthToken = readDaemonClaudeOAuthToken();
+    if (oauthToken) {
+      process.env.CLAUDE_CODE_OAUTH_TOKEN = oauthToken;
+      log('INFO', 'Loaded Claude OAuth token from secrets bundle for routine runs');
+    }
+  }
+
   // Reap any stray duplicate daemon of this install that slipped past the start
   // lock or was orphaned by a hard-crash — before it can double-fire jobs.
   try {
@@ -664,18 +680,20 @@ export function writeOwnerOnlyServiceManifest(filePath: string, content: string)
   fs.writeFileSync(filePath, content, { encoding: 'utf-8', mode: 0o600 });
 }
 
-/** Generate a macOS launchd plist for auto-starting the daemon. */
+/**
+ * Generate a macOS launchd plist for auto-starting the daemon.
+ *
+ * The plist never embeds the Claude OAuth token (RUSH-1759): a persisted service
+ * manifest is a plaintext credential on disk even at 0600. The daemon instead
+ * obtains the token at startup from the `claude` secrets bundle
+ * (readDaemonClaudeOAuthToken, injected in runDaemon), so it stays in the
+ * Keychain-backed secure store and never touches the unit file.
+ */
 export function generateLaunchdPlist(
-  oauthToken: string | null = readDaemonClaudeOAuthToken(),
   agentsBin: string = getAgentsBinPath(),
 ): string {
   const launch = getDaemonLaunch(agentsBin);
   const logPath = getLogPath();
-  const oauthEntry = oauthToken
-    ? `
-    <key>${DAEMON_OAUTH_KEY}</key>
-    <string>${xmlEscape(oauthToken)}</string>`
-    : '';
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -698,7 +716,7 @@ ${[launch.command, ...launch.args].map((arg) => `    <string>${xmlEscape(arg)}</
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
-    <string>${daemonNodeBinDir()}:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:${os.homedir()}/.bun/bin</string>${oauthEntry}
+    <string>${daemonNodeBinDir()}:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:${os.homedir()}/.bun/bin</string>
   </dict>
 </dict>
 </plist>`;
@@ -709,16 +727,20 @@ function systemdExecArg(value: string): string {
   return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 }
 
-/** Generate a Linux systemd user unit for auto-starting the daemon. */
+/**
+ * Generate a Linux systemd user unit for auto-starting the daemon.
+ *
+ * The unit never embeds the Claude OAuth token (RUSH-1759): a persisted service
+ * manifest is a plaintext credential on disk even at 0600. The daemon instead
+ * obtains the token at startup from the `claude` secrets bundle
+ * (readDaemonClaudeOAuthToken, injected in runDaemon), so it stays in the secure
+ * store and never touches the unit file.
+ */
 export function generateSystemdUnit(
-  oauthToken: string | null = readDaemonClaudeOAuthToken(),
   agentsBin: string = getAgentsBinPath(),
 ): string {
   const launch = getDaemonLaunch(agentsBin);
   const execStart = [launch.command, ...launch.args].map(systemdExecArg).join(' ');
-  const oauthLine = oauthToken
-    ? `\nEnvironment=${DAEMON_OAUTH_KEY}=${oauthToken}`
-    : '';
 
   return `[Unit]
 Description=Agents Daemon - Scheduled Job Runner
@@ -729,7 +751,7 @@ Type=simple
 ExecStart=${execStart}
 Restart=always
 RestartSec=10
-Environment=PATH=${daemonNodeBinDir()}:/usr/local/bin:/usr/bin:/bin${oauthLine}
+Environment=PATH=${daemonNodeBinDir()}:/usr/local/bin:/usr/bin:/bin
 
 [Install]
 WantedBy=default.target`;
@@ -858,9 +880,10 @@ function startDaemonLocked(agentsBin: string): { pid: number | null; method: str
       if (!fs.existsSync(plistDir)) {
         fs.mkdirSync(plistDir, { recursive: true });
       }
-      // The plist may embed a long-lived OAuth token in EnvironmentVariables;
-      // create owner-only atomically (no world-readable window before chmod).
-      writeOwnerOnlyServiceManifest(plistPath, generateLaunchdPlist(undefined, agentsBin));
+      // The plist carries no credential (RUSH-1759 — the daemon reads the OAuth
+      // token itself at startup); still create owner-only atomically to match the
+      // detached path and keep the log/PATH surface owner-private.
+      writeOwnerOnlyServiceManifest(plistPath, generateLaunchdPlist(agentsBin));
 
       try {
         execFileSync('launchctl', ['unload', plistPath], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
@@ -886,8 +909,9 @@ function startDaemonLocked(agentsBin: string): { pid: number | null; method: str
       if (!fs.existsSync(unitDir)) {
         fs.mkdirSync(unitDir, { recursive: true });
       }
-      // May embed a long-lived OAuth token in an Environment= line; owner-only.
-      writeOwnerOnlyServiceManifest(unitPath, generateSystemdUnit(undefined, agentsBin));
+      // Carries no credential (RUSH-1759 — the daemon reads the OAuth token
+      // itself at startup); owner-only to keep the PATH/log surface private.
+      writeOwnerOnlyServiceManifest(unitPath, generateSystemdUnit(agentsBin));
 
       execFileSync('systemctl', ['--user', 'daemon-reload'], { encoding: 'utf-8' });
       execFileSync('systemctl', ['--user', 'enable', SYSTEMD_UNIT], { encoding: 'utf-8' });


### PR DESCRIPTION
**Summary:** RUSH-1759 (Security HIGH) — the launchd plist / systemd unit baked the long-lived Claude OAuth token into the persisted service manifest (`daemon.ts` `generateLaunchdPlist` embedded it as a `<string>` in `EnvironmentVariables`; `generateSystemdUnit` as an `Environment=` line). Even at 0600 that is a plaintext credential on disk. This drops the token from both generators and has the daemon obtain it at startup from the secure `claude` secrets bundle via `readDaemonClaudeOAuthToken`, injecting it into its own process env in `runDaemon` so spawned routine runs still receive it (via the sandbox allowlist) — the token never touches the unit/plist.

**Files touched:**
- `apps/cli/src/lib/daemon.ts` — `generateLaunchdPlist` / `generateSystemdUnit` no longer take/embed the token; `runDaemon` reads it from the bundle and sets `process.env.CLAUDE_CODE_OAUTH_TOKEN` when absent; manifest-write comments updated.
- `apps/cli/src/lib/daemon.test.ts` — updated the "injects token" tests into "omits the token even when one is configured" regression tests for both generators (asserting the seeded token is resolvable but absent from the manifest), and fixed the single-arg signature callers.

**Test evidence:**
```
bun x vitest run src/lib/daemon.test.ts
 Test Files  1 passed (1)
      Tests  38 passed (38)

bun x tsc --noEmit  → TSC_EXIT=0
```
The new tests seed a real token into the `claude` bundle, assert `readDaemonClaudeOAuthToken` resolves it, then assert the generated plist/unit contain neither `CLAUDE_CODE_OAUTH_TOKEN` nor the token value — they would fail against the old embedding generators.