### PR TITLE
test: guard POSIX 0600 mode assertions on Windows (unblock test-windows)

### DIFF
--- a/apps/cli/src/commands/secrets.test.ts
+++ b/apps/cli/src/commands/secrets.test.ts
@@ -371,7 +371,8 @@ describe('exportBundleToFile / importBundleFromFile file round-trip', () => {
     try {
       exportBundleToFile({ KEY: 'val' }, filePath, PASS);
       const stat = fs.statSync(filePath);
-      expect(stat.mode & 0o777).toBe(0o600);
+      // POSIX-only: Windows (NTFS) has no 0600 bit; Node reports 0o666 regardless.
+      if (process.platform !== 'win32') expect(stat.mode & 0o777).toBe(0o600);
       // The raw file must not expose plaintext keys.
       const raw = fs.readFileSync(filePath, 'utf-8');
       expect(raw).not.toContain('KEY');

--- a/apps/cli/src/lib/session/bundle.test.ts
+++ b/apps/cli/src/lib/session/bundle.test.ts
@@ -91,13 +91,14 @@ describe('bundle format', () => {
     const out = path.join(SRC, 'out.bundle');
     B.writeBundleFile(out, wire);
     expect(fs.readFileSync(out, 'utf-8')).toBe(wire);
-    expect(fs.statSync(out).mode & 0o777).toBe(0o600);
+    // POSIX-only: Windows (NTFS) has no 0600 bit; Node reports 0o666 regardless.
+    if (process.platform !== 'win32') expect(fs.statSync(out).mode & 0o777).toBe(0o600);
 
     // Overwriting a pre-existing looser file still clamps to 0600.
     fs.writeFileSync(out, 'stale', { mode: 0o644 });
     fs.chmodSync(out, 0o644);
     B.writeBundleFile(out, wire);
-    expect(fs.statSync(out).mode & 0o777).toBe(0o600);
+    if (process.platform !== 'win32') expect(fs.statSync(out).mode & 0o777).toBe(0o600);
   });
 
   it('encrypted bundle round-trips: body is an envelope, planImport decrypts to the original', () => {


### PR DESCRIPTION
Two security PRs merged this session added `mode & 0o777 === 0o600` file-mode assertions in `session/bundle.test.ts` (writeBundleFile) and `commands/secrets.test.ts` (export) without the `process.platform !== 'win32'` guard the repo already uses (linux.test.ts:95, daemon.test.ts:139, shims.auth-carry.test.ts:86). NTFS reports 0o666, so **test-windows is red on main** and blocks every open PR. This guards those 3 assertions (content/not-plain-JSON checks stay unconditional). Same class as the earlier release-matrix fix (74ed914d5).