### PR TITLE
fix(test): make Windows CI green — perm-bit, symlink, CRLF portability

### DIFF
--- a/apps/cli/scripts/gen-changelog.test.ts
+++ b/apps/cli/scripts/gen-changelog.test.ts
@@ -46,6 +46,9 @@ describe('committed CHANGELOG.md', () => {
   it('is up to date with .changelog/ (regenerate with `npm run changelog`)', () => {
     const regenerated = generate(join(cliRoot, '.changelog'));
     const committed = readFileSync(join(cliRoot, 'CHANGELOG.md'), 'utf-8');
-    expect(committed).toBe(regenerated);
+    // Compare content, not line-endings: a Windows checkout with core.autocrlf
+    // rewrites the committed file to CRLF, while generate() always emits LF.
+    const normalize = (s: string) => s.replace(/\r\n/g, '\n');
+    expect(normalize(committed)).toBe(normalize(regenerated));
   });
 });

--- a/apps/cli/src/lib/plugins.test.ts
+++ b/apps/cli/src/lib/plugins.test.ts
@@ -240,7 +240,10 @@ describe('plugin install strips symlinks escaping the install root (RUSH-1755)',
     expect(fs.readFileSync(marker, 'utf-8')).toContain('plugin=evil');
   });
 
-  it('Goose: drops an external-escaping symlink but keeps an internal one', () => {
+  // Creating symlinks on Windows needs elevation/Developer Mode, so the CI
+  // runner can't set up the internal-symlink fixture; the escape-strip security
+  // behavior is covered on the POSIX runners.
+  it.skipIf(process.platform === 'win32')('Goose: drops an external-escaping symlink but keeps an internal one', () => {
     const secretDir = path.join(tmpDir, 'outside');
     fs.mkdirSync(secretDir, { recursive: true });
     const secret = path.join(secretDir, 'victim');
@@ -269,7 +272,7 @@ describe('plugin install strips symlinks escaping the install root (RUSH-1755)',
     expect(fs.readFileSync(secret, 'utf-8')).toBe('ORIGINAL');
   });
 
-  it('Hermes: drops a plugin.yaml symlink pointing outside destRoot and writes a real manifest instead', () => {
+  it.skipIf(process.platform === 'win32')('Hermes: drops a plugin.yaml symlink pointing outside destRoot and writes a real manifest instead', () => {
     const secretDir = path.join(tmpDir, 'outside');
     fs.mkdirSync(secretDir, { recursive: true });
     const secret = path.join(secretDir, 'victim');

--- a/apps/cli/src/lib/serve/token.test.ts
+++ b/apps/cli/src/lib/serve/token.test.ts
@@ -46,13 +46,15 @@ describe('control-token store', () => {
     for (const t of store.tokens) expect(t.hash).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  it('writes the store 0600 (owner-only)', () => {
+  // Unix permission bits are unenforceable on Windows: Node reports 0o666 for
+  // every file regardless of chmod, so the 0600 assertions only hold on POSIX.
+  it.skipIf(process.platform === 'win32')('writes the store 0600 (owner-only)', () => {
     const storeFile = path.join(tmpHome, '.agents', '.cache', 'serve', 'control-tokens.json');
     const mode = fs.statSync(storeFile).mode & 0o777;
     expect(mode).toBe(0o600);
   });
 
-  it('self-heals 0600 on rewrite if perms were widened externally', () => {
+  it.skipIf(process.platform === 'win32')('self-heals 0600 on rewrite if perms were widened externally', () => {
     const storeFile = path.join(tmpHome, '.agents', '.cache', 'serve', 'control-tokens.json');
     // Simulate an external widen (backup/restore, manual chmod).
     fs.chmodSync(storeFile, 0o644);


### PR DESCRIPTION
## Why

The Windows `build` job on `main` is **red** (both node 22 & 24), which blocks the **release** matrix (`release.sh` requires all-green; it just held PR #1246 / v1.20.65 open for exactly this). macOS, Ubuntu, and `test-windows` all pass — only three test files make Windows-only assumptions that landed via recent merges (RUSH-1731 token perms, RUSH-1755 plugin symlinks).

## Fixes (test-only, no source behavior change)

| File | Windows failure | Fix |
|---|---|---|
| `serve/token.test.ts` | `expected 438 to be 384/420` — Node reports `0o666` for every file on Windows | `it.skipIf(win32)` the two Unix-perm assertions |
| `plugins.test.ts` | `ENOENT lstat …inside-link` — creating symlinks needs elevation on Windows | `it.skipIf(win32)` the two symlink-survival tests (POSIX runners still cover the escape-strip security behavior) |
| `gen-changelog.test.ts` | `'…\r\n…' to be '…\n…'` — Windows checkout rewrites committed file to CRLF | normalize CRLF→LF before comparing content |

POSIX coverage is unchanged — the `skipIf` only fires on `win32`. Verified locally: all 116 tests across the three files pass on macOS.

## Verify

```
bun run test src/lib/serve/token.test.ts scripts/gen-changelog.test.ts src/lib/plugins.test.ts
# Test Files  3 passed (3) · Tests  116 passed (116)
```