### PR TITLE
docs(readme): arcade-grade feature diagrams (10 sections)

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,10 @@ Plugins live in the user repo (`~/.agents/plugins/`), not inside any single vers
 
 ## Browser
 
+<p align="center">
+  <img src="assets/browser.svg" alt="agents browser drives your real, already-installed Chrome over CDP — the CLI issues start / refs / click / type / screenshot; the browser exposes numbered element refs and returns a token-efficient screenshot. Same fingerprint, same IP, so sites can't detect automation — it works where Playwright gets blocked." width="100%" />
+</p>
+
 Give agents access to a real browser — no relay extension, no cloud service, no Playwright getting blocked.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ Write one `AGENTS.md`. It becomes `CLAUDE.md` for Claude Code, `GEMINI.md` for G
 
 ## Run any agent
 
+<p align="center">
+  <img src="assets/run-agent.svg" alt="agents run: one command runs any harness (claude/codex/gemini) against the project-pinned version, with an automatic rate-limit fallback chain." width="100%" />
+</p>
+
+
 ```bash
 agents run claude "Find all auth vulnerabilities in src/"
 agents run codex "Fix the issues Claude found"
@@ -206,6 +211,11 @@ ACP adapters are documented for claude, codex, gemini, cursor, opencode, opencla
 ---
 
 ## Sessions across agents
+
+<p align="center">
+  <img src="assets/sessions.svg" alt="agents sessions: search transcripts across Claude, Codex, Gemini, and OpenCode at once, plus a live --active panel showing each running session's state (working / waiting / idle)." width="100%" />
+</p>
+
 
 When you run multiple agents, conversations scatter across tools. Session search brings them together.
 
@@ -299,6 +309,11 @@ agents watchdog --watch    # daemon loop: a tick every --interval
 
 ## Sync the fleet
 
+<p align="center">
+  <img src="assets/fleet-sync.svg" alt="agents apply: reconcile every device to one profile from agents.yaml — install missing agents, sync config, and propagate logins across the fleet." width="100%" />
+</p>
+
+
 One machine is set up the way you like it. Make every other machine match -- same agents installed, same config, logins seeded -- in one command.
 
 ```yaml
@@ -367,6 +382,11 @@ Profile YAML has no secrets -- safe to `agents repo push` to a shared repo. `age
 
 ## Run on your own machines
 
+<p align="center">
+  <img src="assets/hosts.svg" alt="agents hosts: dispatch agents run and config commands to another machine over plain SSH (no daemon); the Tailscale fleet is auto-discovered." width="100%" />
+</p>
+
+
 Dispatch any read-only or config command -- and `agents run` itself -- to another machine over SSH. No daemon.
 
 ```bash
@@ -417,6 +437,11 @@ Every `--host` command rides one multiplexed SSH engine, tuned for driving a fle
 ---
 
 ## Teams
+
+<p align="center">
+  <img src="assets/teams.svg" alt="agents teams: parallel agents in dependency order, each detached in its own worktree with boundary contracts." width="100%" />
+</p>
+
 
 ```bash
 agents teams create auth-feature
@@ -470,6 +495,11 @@ Auto-routes each `--agent` to its native cloud, or pin the backend with `--provi
 
 ## Workflows
 
+<p align="center">
+  <img src="assets/workflows.svg" alt="agents workflows: bundle an orchestrator prompt with optional subagents, skills, and plugins into a named, reusable pipeline invoked as one agent." width="100%" />
+</p>
+
+
 Bundle an orchestrator prompt with optional subagents, skills, and plugins into a named, reusable pipeline. One bundle, one invocation.
 
 ```bash
@@ -520,6 +550,11 @@ Resolution is project > user > system: a `<repo>/.agents/workflows/<name>/` over
 ---
 
 ## Plugins
+
+<p align="center">
+  <img src="assets/plugins.svg" alt="agents plugins: bundle skills, commands, hooks, and MCP servers under one manifest, mirrored into every installed agent version automatically." width="100%" />
+</p>
+
 
 Bundle skills, commands, hooks, MCP servers, settings, and permissions under a single manifest. One source dir at `~/.agents/plugins/<name>/`, mirrored into every installed Claude / OpenClaw version automatically.
 
@@ -780,6 +815,11 @@ Sources: a command's stdout (`--watch` / `--poll`), an HTTP endpoint (`--poll-ht
 ---
 
 ## PTY
+
+<p align="center">
+  <img src="assets/pty.svg" alt="agents pty: give an agent a real terminal for REPLs and TUIs; a sidecar server holds sessions alive between CLI calls." width="100%" />
+</p>
+
 
 ```bash
 # Give agents a real terminal for REPLs, TUIs, interactive programs.

--- a/README.md
+++ b/README.md
@@ -745,6 +745,10 @@ Jobs run sandboxed -- agents only see directories and tools you explicitly allow
 
 ## Monitors
 
+<p align="center">
+  <img src="assets/monitors.svg" alt="agents monitors: a watched source (poll a command, an HTTP endpoint, or a fleet device) flows into a condition (changed? matched? deduped by a native state store) that fires an action — run an agent with the event in its prompt, kick a routine, or notify. Pin the owner device for exactly-once." width="100%" />
+</p>
+
 ```bash
 # Routines fire on a clock. Monitors fire on a change: watch a source, and when
 # it flips, spawn an agent, kick a routine, or notify. The cross-agent layer --

--- a/README.md
+++ b/README.md
@@ -785,7 +785,7 @@ Jobs run sandboxed -- agents only see directories and tools you explicitly allow
 ## Monitors
 
 <p align="center">
-  <img src="assets/monitors.svg" alt="agents monitors: a watched source (poll a command, an HTTP endpoint, or a fleet device) flows into a condition (changed? matched? deduped by a native state store) that fires an action — run an agent with the event in its prompt, kick a routine, or notify. Pin the owner device for exactly-once." width="100%" />
+  <img src="assets/monitors.svg" alt="agents monitors: a watched source (poll a command, an HTTP endpoint, a file, or a fleet device) flows into a condition (changed? matched? deduped by a native state store) that fires an action — run an agent with the event in its prompt, kick a routine, or notify. Pin the owner device for exactly-once." width="100%" />
 </p>
 
 ```bash

--- a/assets/browser.svg
+++ b/assets/browser.svg
@@ -1,16 +1,16 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" role="img" aria-label="agents browser drives your real, already-installed Chrome over CDP: the CLI issues start / refs / click / type / screenshot; the browser exposes numbered element refs and returns a token-efficient screenshot. Same fingerprint, same IP — sites can't detect automation, so it works where Playwright gets blocked.">
   <defs>
     <radialGradient id="gCyan" cx="10%" cy="0%" r="70%"><stop offset="0%" stop-color="#22d3ee" stop-opacity="0.13"/><stop offset="60%" stop-color="#22d3ee" stop-opacity="0"/></radialGradient>
-    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#a3e635" stop-opacity="0.11"/><stop offset="60%" stop-color="#a3e635" stop-opacity="0"/></radialGradient>
+    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#B6E84A" stop-opacity="0.11"/><stop offset="60%" stop-color="#B6E84A" stop-opacity="0"/></radialGradient>
     <pattern id="grid" width="46" height="46" patternUnits="userSpaceOnUse"><path d="M 46 0 L 0 0 0 46" fill="none" stroke="#6b8dff" stroke-opacity="0.06" stroke-width="1"/></pattern>
-    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#7fe3ff"/><stop offset="55%" stop-color="#22d3ee"/><stop offset="100%" stop-color="#a3e635"/></linearGradient>
+    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#7fe3ff"/><stop offset="55%" stop-color="#22d3ee"/><stop offset="100%" stop-color="#B6E84A"/></linearGradient>
     <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/></linearGradient>
     <linearGradient id="term" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0c1016"/><stop offset="100%" stop-color="#070a0e"/></linearGradient>
     <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
     <filter id="neon" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
     <filter id="halo" x="-30%" y="-60%" width="160%" height="220%"><feGaussianBlur stdDeviation="7"/></filter>
     <marker id="arL" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#22d3ee"/></marker>
-    <marker id="arG" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#a3e635"/></marker>
+    <marker id="arG" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#B6E84A"/></marker>
     <style><![CDATA[
       .kick{font:600 14px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.34em;fill:#22d3ee;}
       .h1{font:800 52px Inter,-apple-system,"SF Pro Display",system-ui,sans-serif;letter-spacing:-.02em;}
@@ -19,13 +19,13 @@
       .m{font:500 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
       .mm{font:500 18px ui-monospace,"SF Mono",Menlo,monospace;fill:#7a80a8;}
       .mc{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#22d3ee;}
-      .ml{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .ml{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#B6E84A;}
       .url{font:500 18px ui-monospace,"SF Mono",Menlo,monospace;fill:#9aa0c8;}
       .pg{font:600 20px Inter,-apple-system,system-ui,sans-serif;fill:#eaf2ff;}
       .ref{font:700 15px ui-monospace,"SF Mono",Menlo,monospace;fill:#08080f;}
       .edge{font:600 13px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.06em;}
       .note{font:400 19px Inter,-apple-system,system-ui,sans-serif;fill:#7a80a8;}
-      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#a3e635;}
+      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#B6E84A;}
     ]]></style>
   </defs>
 
@@ -34,14 +34,14 @@
   <rect width="1600" height="920" fill="url(#gCyan)"/>
   <rect width="1600" height="920" fill="url(#gLime)"/>
 
-  <text x="100" y="98" class="kick">AGENTS BROWSER<tspan fill="#a3e635"> · YOUR REAL BROWSER, OVER CDP</tspan></text>
+  <text x="100" y="98" class="kick">AGENTS BROWSER<tspan fill="#B6E84A"> · YOUR REAL BROWSER, OVER CDP</tspan></text>
   <text x="98" y="162" class="h1" fill="#22d3ee" opacity="0.34" filter="url(#halo)">Drive your real browser. Undetectable.</text>
   <text x="98" y="162" class="h1" fill="url(#title)">Drive your real browser. Undetectable.</text>
   <text x="100" y="204" class="sub">Your already-installed Chrome — same fingerprint, no relay, no cloud, no Playwright flags.</text>
 
   <!-- ===== CLI terminal (left) ===== -->
   <g filter="url(#soft)"><rect x="90" y="280" width="500" height="420" rx="20" fill="url(#term)" stroke="#22d3ee" stroke-opacity="0.3" stroke-width="1.5"/></g>
-  <circle cx="122" cy="314" r="6" fill="#fb7185"/><circle cx="144" cy="314" r="6" fill="#f5c451"/><circle cx="166" cy="314" r="6" fill="#a3e635"/>
+  <circle cx="122" cy="314" r="6" fill="#fb7185"/><circle cx="144" cy="314" r="6" fill="#f5c451"/><circle cx="166" cy="314" r="6" fill="#B6E84A"/>
   <text x="470" y="320" class="lab" text-anchor="end">agents browser</text>
   <line x1="118" y1="336" x2="562" y2="336" stroke="#1a2230" stroke-width="1"/>
   <text x="122" y="384" class="m"><tspan fill="#5ad6c0">$</tspan> start <tspan class="mm">--url app…</tspan></text>
@@ -53,17 +53,17 @@
   <text x="122" y="654" class="mm" font-size="16">token-efficient · CDP · no automation flags</text>
 
   <!-- drive arrow -->
-  <line x1="606" y1="430" x2="700" y2="430" stroke="#22d3ee" stroke-width="3" marker-end="url(#arL)" filter="url(#neon)"/>
+  <line x1="606" y1="430" x2="700" y2="430" stroke="#22d3ee" stroke-width="3" marker-end="url(#arL)"/>
   <text x="653" y="416" class="edge" fill="#22d3ee" text-anchor="middle">DRIVE</text>
   <!-- screenshot return arrow -->
-  <line x1="700" y1="560" x2="606" y2="560" stroke="#a3e635" stroke-width="3" marker-end="url(#arG)" filter="url(#neon)"/>
-  <text x="653" y="592" class="edge" fill="#a3e635" text-anchor="middle">SCREENSHOT</text>
+  <line x1="700" y1="560" x2="606" y2="560" stroke="#B6E84A" stroke-width="3" marker-end="url(#arG)"/>
+  <text x="653" y="592" class="edge" fill="#B6E84A" text-anchor="middle">SCREENSHOT</text>
 
   <!-- ===== Browser window (right) ===== -->
   <g filter="url(#soft)"><rect x="714" y="280" width="796" height="420" rx="20" fill="url(#glass)" stroke="#3a425e" stroke-width="1.5"/></g>
   <!-- chrome bar -->
   <path d="M714 300 a20 20 0 0 1 20 -20 h756 a20 20 0 0 1 20 20 v42 h-796 z" fill="#0e1219"/>
-  <circle cx="742" cy="321" r="6" fill="#fb7185"/><circle cx="764" cy="321" r="6" fill="#f5c451"/><circle cx="786" cy="321" r="6" fill="#a3e635"/>
+  <circle cx="742" cy="321" r="6" fill="#fb7185"/><circle cx="764" cy="321" r="6" fill="#f5c451"/><circle cx="786" cy="321" r="6" fill="#B6E84A"/>
   <rect x="820" y="308" width="640" height="28" rx="14" fill="#161b26"/>
   <text x="842" y="328" class="url">🔒  app.example.com</text>
   <!-- page content -->
@@ -71,14 +71,14 @@
   <!-- input field with ref 15 -->
   <rect x="748" y="416" width="470" height="46" rx="10" fill="#12161f" stroke="#2a3346" stroke-width="1"/>
   <text x="768" y="445" class="mm" font-size="17">email@company.com</text>
-  <rect x="1232" y="424" width="46" height="30" rx="8" fill="#a3e635"/><text x="1255" y="445" class="ref" text-anchor="middle">15</text>
+  <rect x="1232" y="424" width="46" height="30" rx="8" fill="#B6E84A"/><text x="1255" y="445" class="ref" text-anchor="middle">15</text>
   <!-- button with ref 42 -->
   <rect x="748" y="484" width="180" height="50" rx="10" fill="#22d3ee" filter="url(#neon)"/>
   <text x="838" y="516" class="ref" text-anchor="middle" font-size="17">Sign in</text>
-  <rect x="942" y="494" width="46" height="30" rx="8" fill="#a3e635"/><text x="965" y="515" class="ref" text-anchor="middle">42</text>
+  <rect x="942" y="494" width="46" height="30" rx="8" fill="#B6E84A"/><text x="965" y="515" class="ref" text-anchor="middle">42</text>
   <!-- more refs hint -->
   <text x="748" y="588" class="mm" font-size="16">refs 1–58 · click / type by number · smart-resized screenshots</text>
-  <rect x="748" y="612" width="118" height="30" rx="8" fill="#a3e635" fill-opacity="0.12" stroke="#a3e635" stroke-opacity="0.35"/><text x="807" y="632" class="edge" fill="#a3e635" text-anchor="middle">@42 @15 …</text>
+  <rect x="748" y="612" width="118" height="30" rx="8" fill="#B6E84A" fill-opacity="0.12" stroke="#B6E84A" stroke-opacity="0.35"/><text x="807" y="632" class="edge" fill="#B6E84A" text-anchor="middle">@42 @15 …</text>
 
   <!-- footer -->
   <text x="100" y="792" class="note">Same fingerprint, same IP — sites <tspan class="noteA">can't tell it's automation</tspan>. Works where Playwright &amp; Puppeteer get blocked.</text>

--- a/assets/browser.svg
+++ b/assets/browser.svg
@@ -7,7 +7,8 @@
     <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/></linearGradient>
     <linearGradient id="term" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0c1016"/><stop offset="100%" stop-color="#070a0e"/></linearGradient>
     <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="neon" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="neon" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="halo" x="-30%" y="-60%" width="160%" height="220%"><feGaussianBlur stdDeviation="7"/></filter>
     <marker id="arL" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#22d3ee"/></marker>
     <marker id="arG" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#a3e635"/></marker>
     <style><![CDATA[
@@ -34,7 +35,8 @@
   <rect width="1600" height="920" fill="url(#gLime)"/>
 
   <text x="100" y="98" class="kick">AGENTS BROWSER<tspan fill="#a3e635"> · YOUR REAL BROWSER, OVER CDP</tspan></text>
-  <text x="98" y="162" class="h1" fill="url(#title)" filter="url(#neon)">Drive your real browser. Undetectable.</text>
+  <text x="98" y="162" class="h1" fill="#22d3ee" opacity="0.34" filter="url(#halo)">Drive your real browser. Undetectable.</text>
+  <text x="98" y="162" class="h1" fill="url(#title)">Drive your real browser. Undetectable.</text>
   <text x="100" y="204" class="sub">Your already-installed Chrome — same fingerprint, no relay, no cloud, no Playwright flags.</text>
 
   <!-- ===== CLI terminal (left) ===== -->

--- a/assets/browser.svg
+++ b/assets/browser.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" role="img" aria-label="agents browser drives your real, already-installed Chrome over CDP: the CLI issues start / refs / click / type / screenshot; the browser exposes numbered element refs and returns a token-efficient screenshot. Same fingerprint, same IP — sites can't detect automation, so it works where Playwright gets blocked.">
+  <defs>
+    <radialGradient id="gCyan" cx="10%" cy="0%" r="70%"><stop offset="0%" stop-color="#22d3ee" stop-opacity="0.13"/><stop offset="60%" stop-color="#22d3ee" stop-opacity="0"/></radialGradient>
+    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#a3e635" stop-opacity="0.11"/><stop offset="60%" stop-color="#a3e635" stop-opacity="0"/></radialGradient>
+    <pattern id="grid" width="46" height="46" patternUnits="userSpaceOnUse"><path d="M 46 0 L 0 0 0 46" fill="none" stroke="#6b8dff" stroke-opacity="0.06" stroke-width="1"/></pattern>
+    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#7fe3ff"/><stop offset="55%" stop-color="#22d3ee"/><stop offset="100%" stop-color="#a3e635"/></linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/></linearGradient>
+    <linearGradient id="term" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0c1016"/><stop offset="100%" stop-color="#070a0e"/></linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="neon" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <marker id="arL" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#22d3ee"/></marker>
+    <marker id="arG" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#a3e635"/></marker>
+    <style><![CDATA[
+      .kick{font:600 14px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.34em;fill:#22d3ee;}
+      .h1{font:800 52px Inter,-apple-system,"SF Pro Display",system-ui,sans-serif;letter-spacing:-.02em;}
+      .sub{font:400 22px Inter,-apple-system,system-ui,sans-serif;fill:#8a90b8;}
+      .lab{font:600 12px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.24em;fill:#6b7099;}
+      .m{font:500 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
+      .mm{font:500 18px ui-monospace,"SF Mono",Menlo,monospace;fill:#7a80a8;}
+      .mc{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#22d3ee;}
+      .ml{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .url{font:500 18px ui-monospace,"SF Mono",Menlo,monospace;fill:#9aa0c8;}
+      .pg{font:600 20px Inter,-apple-system,system-ui,sans-serif;fill:#eaf2ff;}
+      .ref{font:700 15px ui-monospace,"SF Mono",Menlo,monospace;fill:#08080f;}
+      .edge{font:600 13px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.06em;}
+      .note{font:400 19px Inter,-apple-system,system-ui,sans-serif;fill:#7a80a8;}
+      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#a3e635;}
+    ]]></style>
+  </defs>
+
+  <rect width="1600" height="920" fill="#08080f"/>
+  <rect width="1600" height="920" fill="url(#grid)"/>
+  <rect width="1600" height="920" fill="url(#gCyan)"/>
+  <rect width="1600" height="920" fill="url(#gLime)"/>
+
+  <text x="100" y="98" class="kick">AGENTS BROWSER<tspan fill="#a3e635"> · YOUR REAL BROWSER, OVER CDP</tspan></text>
+  <text x="98" y="162" class="h1" fill="url(#title)" filter="url(#neon)">Drive your real browser. Undetectable.</text>
+  <text x="100" y="204" class="sub">Your already-installed Chrome — same fingerprint, no relay, no cloud, no Playwright flags.</text>
+
+  <!-- ===== CLI terminal (left) ===== -->
+  <g filter="url(#soft)"><rect x="90" y="280" width="500" height="420" rx="20" fill="url(#term)" stroke="#22d3ee" stroke-opacity="0.3" stroke-width="1.5"/></g>
+  <circle cx="122" cy="314" r="6" fill="#fb7185"/><circle cx="144" cy="314" r="6" fill="#f5c451"/><circle cx="166" cy="314" r="6" fill="#a3e635"/>
+  <text x="470" y="320" class="lab" text-anchor="end">agents browser</text>
+  <line x1="118" y1="336" x2="562" y2="336" stroke="#1a2230" stroke-width="1"/>
+  <text x="122" y="384" class="m"><tspan fill="#5ad6c0">$</tspan> start <tspan class="mm">--url app…</tspan></text>
+  <text x="122" y="424" class="m"><tspan fill="#5ad6c0">$</tspan> refs</text>
+  <text x="122" y="464" class="m"><tspan fill="#5ad6c0">$</tspan> click <tspan class="ml">42</tspan></text>
+  <text x="122" y="504" class="m"><tspan fill="#5ad6c0">$</tspan> type <tspan class="ml">15</tspan> <tspan class="mm">--text …</tspan></text>
+  <text x="122" y="544" class="m"><tspan fill="#5ad6c0">$</tspan> screenshot</text>
+  <text x="122" y="584" class="m"><tspan fill="#5ad6c0">$</tspan> done</text>
+  <text x="122" y="654" class="mm" font-size="16">token-efficient · CDP · no automation flags</text>
+
+  <!-- drive arrow -->
+  <line x1="606" y1="430" x2="700" y2="430" stroke="#22d3ee" stroke-width="3" marker-end="url(#arL)" filter="url(#neon)"/>
+  <text x="653" y="416" class="edge" fill="#22d3ee" text-anchor="middle">DRIVE</text>
+  <!-- screenshot return arrow -->
+  <line x1="700" y1="560" x2="606" y2="560" stroke="#a3e635" stroke-width="3" marker-end="url(#arG)" filter="url(#neon)"/>
+  <text x="653" y="592" class="edge" fill="#a3e635" text-anchor="middle">SCREENSHOT</text>
+
+  <!-- ===== Browser window (right) ===== -->
+  <g filter="url(#soft)"><rect x="714" y="280" width="796" height="420" rx="20" fill="url(#glass)" stroke="#3a425e" stroke-width="1.5"/></g>
+  <!-- chrome bar -->
+  <path d="M714 300 a20 20 0 0 1 20 -20 h756 a20 20 0 0 1 20 20 v42 h-796 z" fill="#0e1219"/>
+  <circle cx="742" cy="321" r="6" fill="#fb7185"/><circle cx="764" cy="321" r="6" fill="#f5c451"/><circle cx="786" cy="321" r="6" fill="#a3e635"/>
+  <rect x="820" y="308" width="640" height="28" rx="14" fill="#161b26"/>
+  <text x="842" y="328" class="url">🔒  app.example.com</text>
+  <!-- page content -->
+  <text x="748" y="392" class="pg">Sign in to your account</text>
+  <!-- input field with ref 15 -->
+  <rect x="748" y="416" width="470" height="46" rx="10" fill="#12161f" stroke="#2a3346" stroke-width="1"/>
+  <text x="768" y="445" class="mm" font-size="17">email@company.com</text>
+  <rect x="1232" y="424" width="46" height="30" rx="8" fill="#a3e635"/><text x="1255" y="445" class="ref" text-anchor="middle">15</text>
+  <!-- button with ref 42 -->
+  <rect x="748" y="484" width="180" height="50" rx="10" fill="#22d3ee" filter="url(#neon)"/>
+  <text x="838" y="516" class="ref" text-anchor="middle" font-size="17">Sign in</text>
+  <rect x="942" y="494" width="46" height="30" rx="8" fill="#a3e635"/><text x="965" y="515" class="ref" text-anchor="middle">42</text>
+  <!-- more refs hint -->
+  <text x="748" y="588" class="mm" font-size="16">refs 1–58 · click / type by number · smart-resized screenshots</text>
+  <rect x="748" y="612" width="118" height="30" rx="8" fill="#a3e635" fill-opacity="0.12" stroke="#a3e635" stroke-opacity="0.35"/><text x="807" y="632" class="edge" fill="#a3e635" text-anchor="middle">@42 @15 …</text>
+
+  <!-- footer -->
+  <text x="100" y="792" class="note">Same fingerprint, same IP — sites <tspan class="noteA">can't tell it's automation</tspan>. Works where Playwright &amp; Puppeteer get blocked.</text>
+  <text x="100" y="830" class="note"><tspan class="mm" font-size="17">agents browser profiles create work --browser chrome</tspan>  isolates a named profile from "default".</text>
+</svg>

--- a/assets/fleet-sync.svg
+++ b/assets/fleet-sync.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" role="img" aria-label="agents apply replicates one machine's setup to every other: an agents.yaml fleet block (devices, agents, sync, login) reconciles each device over SSH — installing missing agents, syncing config, and propagating logins so one signed-in host seeds the fleet. Turns 6 hosts x 8 harnesses = 48 logins into one.">
+  <defs>
+    <radialGradient id="gMag" cx="10%" cy="0%" r="70%"><stop offset="0%" stop-color="#e879f9" stop-opacity="0.12"/><stop offset="60%" stop-color="#e879f9" stop-opacity="0"/></radialGradient>
+    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#a3e635" stop-opacity="0.11"/><stop offset="60%" stop-color="#a3e635" stop-opacity="0"/></radialGradient>
+    <pattern id="grid" width="46" height="46" patternUnits="userSpaceOnUse"><path d="M 46 0 L 0 0 0 46" fill="none" stroke="#6b8dff" stroke-opacity="0.06" stroke-width="1"/></pattern>
+    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#f0a6ff"/><stop offset="52%" stop-color="#e879f9"/><stop offset="100%" stop-color="#a3e635"/></linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/></linearGradient>
+    <linearGradient id="term" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0c1016"/><stop offset="100%" stop-color="#070a0e"/></linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="neon" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="halo" x="-30%" y="-60%" width="160%" height="220%"><feGaussianBlur stdDeviation="7"/></filter>
+    <marker id="arM" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#e879f9"/></marker>
+    <style><![CDATA[
+      .kick{font:600 14px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.34em;fill:#e879f9;}
+      .h1{font:800 52px Inter,-apple-system,"SF Pro Display",system-ui,sans-serif;letter-spacing:-.02em;}
+      .sub{font:400 22px Inter,-apple-system,system-ui,sans-serif;fill:#8a90b8;}
+      .lab{font:600 12px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.24em;fill:#6b7099;}
+      .m{font:500 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
+      .mm{font:500 18px ui-monospace,"SF Mono",Menlo,monospace;fill:#7a80a8;}
+      .mk{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#e879f9;}
+      .ml{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .dev{font:700 20px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
+      .chip{font:600 15px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .edge{font:600 13px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.06em;fill:#e879f9;}
+      .big{font:800 34px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .note{font:400 19px Inter,-apple-system,system-ui,sans-serif;fill:#7a80a8;}
+      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#a3e635;}
+    ]]></style>
+  </defs>
+
+  <rect width="1600" height="920" fill="#08080f"/>
+  <rect width="1600" height="920" fill="url(#grid)"/>
+  <rect width="1600" height="920" fill="url(#gMag)"/>
+  <rect width="1600" height="920" fill="url(#gLime)"/>
+
+  <text x="100" y="98" class="kick">AGENTS APPLY<tspan fill="#a3e635"> · ONE SETUP, EVERY MACHINE</tspan></text>
+  <text x="98" y="162" class="h1" fill="#e879f9" opacity="0.34" filter="url(#halo)">Set up one machine. Match them all.</text>
+  <text x="98" y="162" class="h1" fill="url(#title)">Set up one machine. Match them all.</text>
+  <text x="100" y="204" class="sub">Same agents, same config, logins seeded — reconcile the whole fleet in one command.</text>
+
+  <!-- LEFT: agents.yaml fleet block -->
+  <g filter="url(#soft)"><rect x="90" y="284" width="470" height="360" rx="20" fill="url(#term)" stroke="#e879f9" stroke-opacity="0.3" stroke-width="1.5"/></g>
+  <circle cx="122" cy="318" r="6" fill="#fb7185"/><circle cx="144" cy="318" r="6" fill="#f5c451"/><circle cx="166" cy="318" r="6" fill="#a3e635"/>
+  <text x="530" y="324" class="lab" text-anchor="end">agents.yaml</text>
+  <line x1="118" y1="340" x2="532" y2="340" stroke="#1a2230" stroke-width="1"/>
+  <text x="122" y="390" class="mk">fleet:</text>
+  <text x="146" y="428" class="m">devices: <tspan class="ml">all</tspan></text>
+  <text x="146" y="466" class="m">agents: <tspan class="mm">[claude,</tspan></text>
+  <text x="170" y="500" class="mm">codex, gemini]</text>
+  <text x="146" y="538" class="m">sync: <tspan class="mm">[user]</tspan></text>
+  <text x="146" y="576" class="m">login: <tspan class="ml">sync</tspan></text>
+  <text x="122" y="624" class="mm" font-size="16">one profile · every device</text>
+
+  <!-- arrow -->
+  <line x1="576" y1="460" x2="668" y2="460" stroke="#e879f9" stroke-width="3" marker-end="url(#arM)" filter="url(#neon)"/>
+  <text x="622" y="446" class="edge" text-anchor="middle">agents apply</text>
+
+  <!-- RIGHT: reconciled devices -->
+  <g filter="url(#soft)"><rect x="686" y="284" width="824" height="360" rx="20" fill="url(#glass)" stroke="#3a425e" stroke-width="1.5"/></g>
+  <text x="718" y="330" class="lab">RECONCILED · INSTALL AGENTS &#183; SYNC CONFIG &#183; PROPAGATE LOGIN</text>
+  <line x1="718" y1="348" x2="1478" y2="348" stroke="#232a3a" stroke-width="1"/>
+
+  <!-- device rows -->
+  <g>
+    <text x="718" y="400" class="dev">yosemite-s0</text>
+    <g transform="translate(1010,382)">
+      <rect x="0" y="0" width="140" height="34" rx="9" fill="#a3e635" fill-opacity="0.1" stroke="#a3e635" stroke-opacity="0.3"/><text x="70" y="23" class="chip" text-anchor="middle">agents ✓</text>
+      <rect x="152" y="0" width="140" height="34" rx="9" fill="#a3e635" fill-opacity="0.1" stroke="#a3e635" stroke-opacity="0.3"/><text x="222" y="23" class="chip" text-anchor="middle">config ✓</text>
+      <rect x="304" y="0" width="140" height="34" rx="9" fill="#a3e635" fill-opacity="0.1" stroke="#a3e635" stroke-opacity="0.3"/><text x="374" y="23" class="chip" text-anchor="middle">login ✓</text>
+    </g>
+  </g>
+  <line x1="718" y1="426" x2="1478" y2="426" stroke="#1a2030" stroke-width="1"/>
+  <g>
+    <text x="718" y="470" class="dev">mac-mini</text>
+    <g transform="translate(1010,452)">
+      <rect x="0" y="0" width="140" height="34" rx="9" fill="#a3e635" fill-opacity="0.1" stroke="#a3e635" stroke-opacity="0.3"/><text x="70" y="23" class="chip" text-anchor="middle">agents ✓</text>
+      <rect x="152" y="0" width="140" height="34" rx="9" fill="#a3e635" fill-opacity="0.1" stroke="#a3e635" stroke-opacity="0.3"/><text x="222" y="23" class="chip" text-anchor="middle">config ✓</text>
+      <rect x="304" y="0" width="140" height="34" rx="9" fill="#f5c451" fill-opacity="0.1" stroke="#f5c451" stroke-opacity="0.35"/><text x="374" y="23" class="chip" text-anchor="middle" fill="#f5c451" font-size="14">login: manual</text>
+    </g>
+  </g>
+  <line x1="718" y1="496" x2="1478" y2="496" stroke="#1a2030" stroke-width="1"/>
+  <g>
+    <text x="718" y="540" class="dev">win-mini</text>
+    <g transform="translate(1010,522)">
+      <rect x="0" y="0" width="140" height="34" rx="9" fill="#a3e635" fill-opacity="0.1" stroke="#a3e635" stroke-opacity="0.3"/><text x="70" y="23" class="chip" text-anchor="middle">agents ✓</text>
+      <rect x="152" y="0" width="140" height="34" rx="9" fill="#a3e635" fill-opacity="0.1" stroke="#a3e635" stroke-opacity="0.3"/><text x="222" y="23" class="chip" text-anchor="middle">config ✓</text>
+      <rect x="304" y="0" width="140" height="34" rx="9" fill="#a3e635" fill-opacity="0.1" stroke="#a3e635" stroke-opacity="0.3"/><text x="374" y="23" class="chip" text-anchor="middle">login ✓</text>
+    </g>
+  </g>
+
+  <!-- consolidation motif -->
+  <text x="718" y="600" class="mm" font-size="17">48 OAuth flows <tspan class="big" font-size="22" dy="0">→ 1</tspan>  <tspan class="mm">one signed-in host seeds the fleet</tspan></text>
+
+  <!-- footer -->
+  <text x="100" y="792" class="note"><tspan class="mm" font-size="17">agents apply --plan</tspan>  shows the device × dimension matrix — changes nothing.</text>
+  <text x="100" y="830" class="note"><tspan class="noteA">Honest boundary</tspan> — macOS keychain-bound tokens surface as a one-time manual login, never faked.</text>
+</svg>

--- a/assets/fleet-sync.svg
+++ b/assets/fleet-sync.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" role="img" aria-label="agents apply replicates one machine's setup to every other: an agents.yaml fleet block (devices, agents, sync, login) reconciles each device over SSH — installing missing agents, syncing config, and propagating logins so one signed-in host seeds the fleet. Turns 6 hosts x 8 harnesses = 48 logins into one.">
   <defs>
     <radialGradient id="gMag" cx="10%" cy="0%" r="70%"><stop offset="0%" stop-color="#e879f9" stop-opacity="0.12"/><stop offset="60%" stop-color="#e879f9" stop-opacity="0"/></radialGradient>
-    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#a3e635" stop-opacity="0.11"/><stop offset="60%" stop-color="#a3e635" stop-opacity="0"/></radialGradient>
+    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#B6E84A" stop-opacity="0.11"/><stop offset="60%" stop-color="#B6E84A" stop-opacity="0"/></radialGradient>
     <pattern id="grid" width="46" height="46" patternUnits="userSpaceOnUse"><path d="M 46 0 L 0 0 0 46" fill="none" stroke="#6b8dff" stroke-opacity="0.06" stroke-width="1"/></pattern>
-    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#f0a6ff"/><stop offset="52%" stop-color="#e879f9"/><stop offset="100%" stop-color="#a3e635"/></linearGradient>
+    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#f0a6ff"/><stop offset="52%" stop-color="#e879f9"/><stop offset="100%" stop-color="#B6E84A"/></linearGradient>
     <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/></linearGradient>
     <linearGradient id="term" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0c1016"/><stop offset="100%" stop-color="#070a0e"/></linearGradient>
     <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
@@ -18,13 +18,13 @@
       .m{font:500 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
       .mm{font:500 18px ui-monospace,"SF Mono",Menlo,monospace;fill:#7a80a8;}
       .mk{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#e879f9;}
-      .ml{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .ml{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#B6E84A;}
       .dev{font:700 20px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
-      .chip{font:600 15px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .chip{font:600 15px ui-monospace,"SF Mono",Menlo,monospace;fill:#B6E84A;}
       .edge{font:600 13px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.06em;fill:#e879f9;}
-      .big{font:800 34px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .big{font:800 34px ui-monospace,"SF Mono",Menlo,monospace;fill:#B6E84A;}
       .note{font:400 19px Inter,-apple-system,system-ui,sans-serif;fill:#7a80a8;}
-      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#a3e635;}
+      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#B6E84A;}
     ]]></style>
   </defs>
 
@@ -33,14 +33,14 @@
   <rect width="1600" height="920" fill="url(#gMag)"/>
   <rect width="1600" height="920" fill="url(#gLime)"/>
 
-  <text x="100" y="98" class="kick">AGENTS APPLY<tspan fill="#a3e635"> · ONE SETUP, EVERY MACHINE</tspan></text>
+  <text x="100" y="98" class="kick">AGENTS APPLY<tspan fill="#B6E84A"> · ONE SETUP, EVERY MACHINE</tspan></text>
   <text x="98" y="162" class="h1" fill="#e879f9" opacity="0.34" filter="url(#halo)">Set up one machine. Match them all.</text>
   <text x="98" y="162" class="h1" fill="url(#title)">Set up one machine. Match them all.</text>
   <text x="100" y="204" class="sub">Same agents, same config, logins seeded — reconcile the whole fleet in one command.</text>
 
   <!-- LEFT: agents.yaml fleet block -->
   <g filter="url(#soft)"><rect x="90" y="284" width="470" height="360" rx="20" fill="url(#term)" stroke="#e879f9" stroke-opacity="0.3" stroke-width="1.5"/></g>
-  <circle cx="122" cy="318" r="6" fill="#fb7185"/><circle cx="144" cy="318" r="6" fill="#f5c451"/><circle cx="166" cy="318" r="6" fill="#a3e635"/>
+  <circle cx="122" cy="318" r="6" fill="#fb7185"/><circle cx="144" cy="318" r="6" fill="#f5c451"/><circle cx="166" cy="318" r="6" fill="#B6E84A"/>
   <text x="530" y="324" class="lab" text-anchor="end">agents.yaml</text>
   <line x1="118" y1="340" x2="532" y2="340" stroke="#1a2230" stroke-width="1"/>
   <text x="122" y="390" class="mk">fleet:</text>
@@ -52,7 +52,7 @@
   <text x="122" y="624" class="mm" font-size="16">one profile · every device</text>
 
   <!-- arrow -->
-  <line x1="576" y1="460" x2="668" y2="460" stroke="#e879f9" stroke-width="3" marker-end="url(#arM)" filter="url(#neon)"/>
+  <line x1="576" y1="460" x2="668" y2="460" stroke="#e879f9" stroke-width="3" marker-end="url(#arM)"/>
   <text x="622" y="446" class="edge" text-anchor="middle">agents apply</text>
 
   <!-- RIGHT: reconciled devices -->
@@ -64,17 +64,17 @@
   <g>
     <text x="718" y="400" class="dev">yosemite-s0</text>
     <g transform="translate(1010,382)">
-      <rect x="0" y="0" width="140" height="34" rx="9" fill="#a3e635" fill-opacity="0.1" stroke="#a3e635" stroke-opacity="0.3"/><text x="70" y="23" class="chip" text-anchor="middle">agents ✓</text>
-      <rect x="152" y="0" width="140" height="34" rx="9" fill="#a3e635" fill-opacity="0.1" stroke="#a3e635" stroke-opacity="0.3"/><text x="222" y="23" class="chip" text-anchor="middle">config ✓</text>
-      <rect x="304" y="0" width="140" height="34" rx="9" fill="#a3e635" fill-opacity="0.1" stroke="#a3e635" stroke-opacity="0.3"/><text x="374" y="23" class="chip" text-anchor="middle">login ✓</text>
+      <rect x="0" y="0" width="140" height="34" rx="9" fill="#B6E84A" fill-opacity="0.1" stroke="#B6E84A" stroke-opacity="0.3"/><text x="70" y="23" class="chip" text-anchor="middle">agents ✓</text>
+      <rect x="152" y="0" width="140" height="34" rx="9" fill="#B6E84A" fill-opacity="0.1" stroke="#B6E84A" stroke-opacity="0.3"/><text x="222" y="23" class="chip" text-anchor="middle">config ✓</text>
+      <rect x="304" y="0" width="140" height="34" rx="9" fill="#B6E84A" fill-opacity="0.1" stroke="#B6E84A" stroke-opacity="0.3"/><text x="374" y="23" class="chip" text-anchor="middle">login ✓</text>
     </g>
   </g>
   <line x1="718" y1="426" x2="1478" y2="426" stroke="#1a2030" stroke-width="1"/>
   <g>
     <text x="718" y="470" class="dev">mac-mini</text>
     <g transform="translate(1010,452)">
-      <rect x="0" y="0" width="140" height="34" rx="9" fill="#a3e635" fill-opacity="0.1" stroke="#a3e635" stroke-opacity="0.3"/><text x="70" y="23" class="chip" text-anchor="middle">agents ✓</text>
-      <rect x="152" y="0" width="140" height="34" rx="9" fill="#a3e635" fill-opacity="0.1" stroke="#a3e635" stroke-opacity="0.3"/><text x="222" y="23" class="chip" text-anchor="middle">config ✓</text>
+      <rect x="0" y="0" width="140" height="34" rx="9" fill="#B6E84A" fill-opacity="0.1" stroke="#B6E84A" stroke-opacity="0.3"/><text x="70" y="23" class="chip" text-anchor="middle">agents ✓</text>
+      <rect x="152" y="0" width="140" height="34" rx="9" fill="#B6E84A" fill-opacity="0.1" stroke="#B6E84A" stroke-opacity="0.3"/><text x="222" y="23" class="chip" text-anchor="middle">config ✓</text>
       <rect x="304" y="0" width="140" height="34" rx="9" fill="#f5c451" fill-opacity="0.1" stroke="#f5c451" stroke-opacity="0.35"/><text x="374" y="23" class="chip" text-anchor="middle" fill="#f5c451" font-size="14">login: manual</text>
     </g>
   </g>
@@ -82,9 +82,9 @@
   <g>
     <text x="718" y="540" class="dev">win-mini</text>
     <g transform="translate(1010,522)">
-      <rect x="0" y="0" width="140" height="34" rx="9" fill="#a3e635" fill-opacity="0.1" stroke="#a3e635" stroke-opacity="0.3"/><text x="70" y="23" class="chip" text-anchor="middle">agents ✓</text>
-      <rect x="152" y="0" width="140" height="34" rx="9" fill="#a3e635" fill-opacity="0.1" stroke="#a3e635" stroke-opacity="0.3"/><text x="222" y="23" class="chip" text-anchor="middle">config ✓</text>
-      <rect x="304" y="0" width="140" height="34" rx="9" fill="#a3e635" fill-opacity="0.1" stroke="#a3e635" stroke-opacity="0.3"/><text x="374" y="23" class="chip" text-anchor="middle">login ✓</text>
+      <rect x="0" y="0" width="140" height="34" rx="9" fill="#B6E84A" fill-opacity="0.1" stroke="#B6E84A" stroke-opacity="0.3"/><text x="70" y="23" class="chip" text-anchor="middle">agents ✓</text>
+      <rect x="152" y="0" width="140" height="34" rx="9" fill="#B6E84A" fill-opacity="0.1" stroke="#B6E84A" stroke-opacity="0.3"/><text x="222" y="23" class="chip" text-anchor="middle">config ✓</text>
+      <rect x="304" y="0" width="140" height="34" rx="9" fill="#B6E84A" fill-opacity="0.1" stroke="#B6E84A" stroke-opacity="0.3"/><text x="374" y="23" class="chip" text-anchor="middle">login ✓</text>
     </g>
   </g>
 

--- a/assets/hosts.svg
+++ b/assets/hosts.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" role="img" aria-label="agents hosts dispatches agents run and config commands to another machine over plain SSH with no daemon: enroll a host, run there, it executes on the remote box and follows live. Your Tailscale fleet is auto-discovered; credentials stream over encrypted SSH stdin and land 0600.">
   <defs>
     <radialGradient id="gTeal" cx="10%" cy="0%" r="70%"><stop offset="0%" stop-color="#5ad6c0" stop-opacity="0.13"/><stop offset="60%" stop-color="#5ad6c0" stop-opacity="0"/></radialGradient>
-    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#a3e635" stop-opacity="0.11"/><stop offset="60%" stop-color="#a3e635" stop-opacity="0"/></radialGradient>
+    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#B6E84A" stop-opacity="0.11"/><stop offset="60%" stop-color="#B6E84A" stop-opacity="0"/></radialGradient>
     <pattern id="grid" width="46" height="46" patternUnits="userSpaceOnUse"><path d="M 46 0 L 0 0 0 46" fill="none" stroke="#6b8dff" stroke-opacity="0.06" stroke-width="1"/></pattern>
-    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#7ff0dd"/><stop offset="55%" stop-color="#5ad6c0"/><stop offset="100%" stop-color="#a3e635"/></linearGradient>
+    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#7ff0dd"/><stop offset="55%" stop-color="#5ad6c0"/><stop offset="100%" stop-color="#B6E84A"/></linearGradient>
     <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/></linearGradient>
     <linearGradient id="term" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0c1016"/><stop offset="100%" stop-color="#070a0e"/></linearGradient>
     <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
@@ -18,12 +18,12 @@
       .m{font:500 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
       .mm{font:500 18px ui-monospace,"SF Mono",Menlo,monospace;fill:#7a80a8;}
       .mt{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#5ad6c0;}
-      .ml{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .ml{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#B6E84A;}
       .pg{font:700 24px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
       .edge{font:600 13px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.06em;}
       .chip{font:600 15px ui-monospace,"SF Mono",Menlo,monospace;fill:#c7cbe6;}
       .note{font:400 19px Inter,-apple-system,system-ui,sans-serif;fill:#7a80a8;}
-      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#a3e635;}
+      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#B6E84A;}
     ]]></style>
   </defs>
 
@@ -32,14 +32,14 @@
   <rect width="1600" height="920" fill="url(#gTeal)"/>
   <rect width="1600" height="920" fill="url(#gLime)"/>
 
-  <text x="100" y="98" class="kick">AGENTS HOSTS<tspan fill="#a3e635"> · DISPATCH OVER SSH, NO DAEMON</tspan></text>
+  <text x="100" y="98" class="kick">AGENTS HOSTS<tspan fill="#B6E84A"> · DISPATCH OVER SSH, NO DAEMON</tspan></text>
   <text x="98" y="162" class="h1" fill="#5ad6c0" opacity="0.34" filter="url(#halo)">Run on any machine you own.</text>
   <text x="98" y="162" class="h1" fill="url(#title)">Run on any machine you own.</text>
   <text x="100" y="204" class="sub">Dispatch <tspan class="mm" font-size="20">agents run</tspan> and config commands to another host over plain SSH — no daemon, no agent process.</text>
 
   <!-- ===== local terminal ===== -->
   <g filter="url(#soft)"><rect x="90" y="280" width="560" height="330" rx="20" fill="url(#term)" stroke="#5ad6c0" stroke-opacity="0.3" stroke-width="1.5"/></g>
-  <circle cx="122" cy="314" r="6" fill="#fb7185"/><circle cx="144" cy="314" r="6" fill="#f5c451"/><circle cx="166" cy="314" r="6" fill="#a3e635"/>
+  <circle cx="122" cy="314" r="6" fill="#fb7185"/><circle cx="144" cy="314" r="6" fill="#f5c451"/><circle cx="166" cy="314" r="6" fill="#B6E84A"/>
   <text x="622" y="320" class="lab" text-anchor="end">this machine</text>
   <line x1="118" y1="336" x2="622" y2="336" stroke="#1a2230" stroke-width="1"/>
   <text x="122" y="386" class="m"><tspan fill="#5ad6c0">$</tspan> agents hosts add <tspan class="mt">gpu-box</tspan></text>
@@ -49,7 +49,7 @@
   <text x="122" y="576" class="mm" font-size="16">no daemon · headless follows live</text>
 
   <!-- SSH arrow -->
-  <line x1="666" y1="440" x2="762" y2="440" stroke="#5ad6c0" stroke-width="3" marker-end="url(#arT)" filter="url(#neon)"/>
+  <line x1="666" y1="440" x2="762" y2="440" stroke="#5ad6c0" stroke-width="3" marker-end="url(#arT)"/>
   <text x="714" y="426" class="edge" fill="#5ad6c0" text-anchor="middle">SSH</text>
   <text x="714" y="464" class="mm" font-size="13" text-anchor="middle">creds 0600</text>
 
@@ -57,12 +57,12 @@
   <g filter="url(#soft)"><rect x="778" y="280" width="732" height="330" rx="20" fill="url(#glass)" stroke="#5ad6c0" stroke-opacity="0.5" stroke-width="1.6"/></g>
   <!-- server glyph -->
   <g>
-    <rect x="820" y="322" width="150" height="40" rx="8" fill="#12161f" stroke="#2a3346"/><circle cx="842" cy="342" r="5" fill="#a3e635"/><rect x="900" y="338" width="50" height="6" rx="3" fill="#5ad6c0" fill-opacity="0.5"/>
+    <rect x="820" y="322" width="150" height="40" rx="8" fill="#12161f" stroke="#2a3346"/><circle cx="842" cy="342" r="5" fill="#B6E84A"/><rect x="900" y="338" width="50" height="6" rx="3" fill="#5ad6c0" fill-opacity="0.5"/>
     <rect x="820" y="372" width="150" height="40" rx="8" fill="#12161f" stroke="#2a3346"/><circle cx="842" cy="392" r="5" fill="#5ad6c0"/><rect x="900" y="388" width="50" height="6" rx="3" fill="#5ad6c0" fill-opacity="0.5"/>
-    <rect x="820" y="422" width="150" height="40" rx="8" fill="#12161f" stroke="#2a3346"/><circle cx="842" cy="442" r="5" fill="#a3e635"/><rect x="900" y="438" width="50" height="6" rx="3" fill="#5ad6c0" fill-opacity="0.5"/>
+    <rect x="820" y="422" width="150" height="40" rx="8" fill="#12161f" stroke="#2a3346"/><circle cx="842" cy="442" r="5" fill="#B6E84A"/><rect x="900" y="438" width="50" height="6" rx="3" fill="#5ad6c0" fill-opacity="0.5"/>
   </g>
   <text x="1006" y="344" class="pg">gpu-box</text>
-  <circle cx="1018" cy="384" r="7" fill="#a3e635" filter="url(#neon)"/>
+  <circle cx="1018" cy="384" r="7" fill="#B6E84A" filter="url(#neon)"/>
   <text x="1036" y="391" class="mt" font-size="19">running · claude</text>
   <text x="1006" y="438" class="mm">the run executes here, streams back</text>
   <rect x="1006" y="462" width="300" height="34" rx="9" fill="#5ad6c0" fill-opacity="0.1" stroke="#5ad6c0" stroke-opacity="0.3"/>
@@ -71,9 +71,9 @@
   <!-- fleet chips -->
   <text x="100" y="674" class="lab">TAILSCALE FLEET · auto-discovered</text>
   <g>
-    <rect x="100" y="694" width="220" height="46" rx="14" fill="url(#glass)" stroke="#2a3346"/><circle cx="126" cy="717" r="6" fill="#a3e635"/><text x="146" y="723" class="chip">yosemite-s0</text>
-    <rect x="340" y="694" width="200" height="46" rx="14" fill="url(#glass)" stroke="#2a3346"/><circle cx="366" cy="717" r="6" fill="#a3e635"/><text x="386" y="723" class="chip">mac-mini</text>
-    <rect x="560" y="694" width="180" height="46" rx="14" fill="#5ad6c0" fill-opacity="0.08" stroke="#5ad6c0" stroke-opacity="0.4"/><circle cx="586" cy="717" r="6" fill="#a3e635" filter="url(#neon)"/><text x="606" y="723" class="chip" fill="#5ad6c0">gpu-box</text>
+    <rect x="100" y="694" width="220" height="46" rx="14" fill="url(#glass)" stroke="#2a3346"/><circle cx="126" cy="717" r="6" fill="#B6E84A"/><text x="146" y="723" class="chip">yosemite-s0</text>
+    <rect x="340" y="694" width="200" height="46" rx="14" fill="url(#glass)" stroke="#2a3346"/><circle cx="366" cy="717" r="6" fill="#B6E84A"/><text x="386" y="723" class="chip">mac-mini</text>
+    <rect x="560" y="694" width="180" height="46" rx="14" fill="#5ad6c0" fill-opacity="0.08" stroke="#5ad6c0" stroke-opacity="0.4"/><circle cx="586" cy="717" r="6" fill="#B6E84A" filter="url(#neon)"/><text x="606" y="723" class="chip" fill="#5ad6c0">gpu-box</text>
     <text x="770" y="723" class="mm" font-size="16">agents devices sync  ·  agents doctor --devices</text>
   </g>
 

--- a/assets/hosts.svg
+++ b/assets/hosts.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" role="img" aria-label="agents hosts dispatches agents run and config commands to another machine over plain SSH with no daemon: enroll a host, run there, it executes on the remote box and follows live. Your Tailscale fleet is auto-discovered; credentials stream over encrypted SSH stdin and land 0600.">
+  <defs>
+    <radialGradient id="gTeal" cx="10%" cy="0%" r="70%"><stop offset="0%" stop-color="#5ad6c0" stop-opacity="0.13"/><stop offset="60%" stop-color="#5ad6c0" stop-opacity="0"/></radialGradient>
+    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#a3e635" stop-opacity="0.11"/><stop offset="60%" stop-color="#a3e635" stop-opacity="0"/></radialGradient>
+    <pattern id="grid" width="46" height="46" patternUnits="userSpaceOnUse"><path d="M 46 0 L 0 0 0 46" fill="none" stroke="#6b8dff" stroke-opacity="0.06" stroke-width="1"/></pattern>
+    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#7ff0dd"/><stop offset="55%" stop-color="#5ad6c0"/><stop offset="100%" stop-color="#a3e635"/></linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/></linearGradient>
+    <linearGradient id="term" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0c1016"/><stop offset="100%" stop-color="#070a0e"/></linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="neon" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="halo" x="-30%" y="-60%" width="160%" height="220%"><feGaussianBlur stdDeviation="7"/></filter>
+    <marker id="arT" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#5ad6c0"/></marker>
+    <style><![CDATA[
+      .kick{font:600 14px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.34em;fill:#5ad6c0;}
+      .h1{font:800 52px Inter,-apple-system,"SF Pro Display",system-ui,sans-serif;letter-spacing:-.02em;}
+      .sub{font:400 22px Inter,-apple-system,system-ui,sans-serif;fill:#8a90b8;}
+      .lab{font:600 12px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.24em;fill:#6b7099;}
+      .m{font:500 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
+      .mm{font:500 18px ui-monospace,"SF Mono",Menlo,monospace;fill:#7a80a8;}
+      .mt{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#5ad6c0;}
+      .ml{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .pg{font:700 24px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
+      .edge{font:600 13px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.06em;}
+      .chip{font:600 15px ui-monospace,"SF Mono",Menlo,monospace;fill:#c7cbe6;}
+      .note{font:400 19px Inter,-apple-system,system-ui,sans-serif;fill:#7a80a8;}
+      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#a3e635;}
+    ]]></style>
+  </defs>
+
+  <rect width="1600" height="920" fill="#08080f"/>
+  <rect width="1600" height="920" fill="url(#grid)"/>
+  <rect width="1600" height="920" fill="url(#gTeal)"/>
+  <rect width="1600" height="920" fill="url(#gLime)"/>
+
+  <text x="100" y="98" class="kick">AGENTS HOSTS<tspan fill="#a3e635"> · DISPATCH OVER SSH, NO DAEMON</tspan></text>
+  <text x="98" y="162" class="h1" fill="#5ad6c0" opacity="0.34" filter="url(#halo)">Run on any machine you own.</text>
+  <text x="98" y="162" class="h1" fill="url(#title)">Run on any machine you own.</text>
+  <text x="100" y="204" class="sub">Dispatch <tspan class="mm" font-size="20">agents run</tspan> and config commands to another host over plain SSH — no daemon, no agent process.</text>
+
+  <!-- ===== local terminal ===== -->
+  <g filter="url(#soft)"><rect x="90" y="280" width="560" height="330" rx="20" fill="url(#term)" stroke="#5ad6c0" stroke-opacity="0.3" stroke-width="1.5"/></g>
+  <circle cx="122" cy="314" r="6" fill="#fb7185"/><circle cx="144" cy="314" r="6" fill="#f5c451"/><circle cx="166" cy="314" r="6" fill="#a3e635"/>
+  <text x="622" y="320" class="lab" text-anchor="end">this machine</text>
+  <line x1="118" y1="336" x2="622" y2="336" stroke="#1a2230" stroke-width="1"/>
+  <text x="122" y="386" class="m"><tspan fill="#5ad6c0">$</tspan> agents hosts add <tspan class="mt">gpu-box</tspan></text>
+  <text x="122" y="430" class="m"><tspan fill="#5ad6c0">$</tspan> agents run claude \</text>
+  <text x="122" y="470" class="m">    --host <tspan class="mt">gpu-box</tspan> \</text>
+  <text x="122" y="510" class="m">    <tspan fill="#f5c451">"profile this build"</tspan></text>
+  <text x="122" y="576" class="mm" font-size="16">no daemon · headless follows live</text>
+
+  <!-- SSH arrow -->
+  <line x1="666" y1="440" x2="762" y2="440" stroke="#5ad6c0" stroke-width="3" marker-end="url(#arT)" filter="url(#neon)"/>
+  <text x="714" y="426" class="edge" fill="#5ad6c0" text-anchor="middle">SSH</text>
+  <text x="714" y="464" class="mm" font-size="13" text-anchor="middle">creds 0600</text>
+
+  <!-- ===== remote host ===== -->
+  <g filter="url(#soft)"><rect x="778" y="280" width="732" height="330" rx="20" fill="url(#glass)" stroke="#5ad6c0" stroke-opacity="0.5" stroke-width="1.6"/></g>
+  <!-- server glyph -->
+  <g>
+    <rect x="820" y="322" width="150" height="40" rx="8" fill="#12161f" stroke="#2a3346"/><circle cx="842" cy="342" r="5" fill="#a3e635"/><rect x="900" y="338" width="50" height="6" rx="3" fill="#5ad6c0" fill-opacity="0.5"/>
+    <rect x="820" y="372" width="150" height="40" rx="8" fill="#12161f" stroke="#2a3346"/><circle cx="842" cy="392" r="5" fill="#5ad6c0"/><rect x="900" y="388" width="50" height="6" rx="3" fill="#5ad6c0" fill-opacity="0.5"/>
+    <rect x="820" y="422" width="150" height="40" rx="8" fill="#12161f" stroke="#2a3346"/><circle cx="842" cy="442" r="5" fill="#a3e635"/><rect x="900" y="438" width="50" height="6" rx="3" fill="#5ad6c0" fill-opacity="0.5"/>
+  </g>
+  <text x="1006" y="344" class="pg">gpu-box</text>
+  <circle cx="1018" cy="384" r="7" fill="#a3e635" filter="url(#neon)"/>
+  <text x="1036" y="391" class="mt" font-size="19">running · claude</text>
+  <text x="1006" y="438" class="mm">the run executes here, streams back</text>
+  <rect x="1006" y="462" width="300" height="34" rx="9" fill="#5ad6c0" fill-opacity="0.1" stroke="#5ad6c0" stroke-opacity="0.3"/>
+  <text x="1024" y="485" class="mm" font-size="15">agents logs --host gpu-box  -f</text>
+
+  <!-- fleet chips -->
+  <text x="100" y="674" class="lab">TAILSCALE FLEET · auto-discovered</text>
+  <g>
+    <rect x="100" y="694" width="220" height="46" rx="14" fill="url(#glass)" stroke="#2a3346"/><circle cx="126" cy="717" r="6" fill="#a3e635"/><text x="146" y="723" class="chip">yosemite-s0</text>
+    <rect x="340" y="694" width="200" height="46" rx="14" fill="url(#glass)" stroke="#2a3346"/><circle cx="366" cy="717" r="6" fill="#a3e635"/><text x="386" y="723" class="chip">mac-mini</text>
+    <rect x="560" y="694" width="180" height="46" rx="14" fill="#5ad6c0" fill-opacity="0.08" stroke="#5ad6c0" stroke-opacity="0.4"/><circle cx="586" cy="717" r="6" fill="#a3e635" filter="url(#neon)"/><text x="606" y="723" class="chip" fill="#5ad6c0">gpu-box</text>
+    <text x="770" y="723" class="mm" font-size="16">agents devices sync  ·  agents doctor --devices</text>
+  </g>
+
+  <!-- footer -->
+  <text x="100" y="800" class="note">One sign-in <tspan class="noteA">seeds the fleet</tspan> — logins propagate where the token is portable; keychain-bound ones surface a one-time manual login, never faked.</text>
+  <text x="100" y="838" class="note"><tspan class="mm" font-size="17">agents hosts ps · stop · agents view --host</tspan>  inspect, follow, or terminate any dispatched run.</text>
+</svg>

--- a/assets/monitors.svg
+++ b/assets/monitors.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" role="img" aria-label="agents monitors: a watched source (poll a command, an HTTP endpoint, a file, or a fleet device) flows into a condition (changed? matched? deduped by a native state store) that fires an action — run an agent with the event in its prompt, kick a routine, or notify. Pin the owner device for exactly-once. Routines fire on a clock; monitors fire on a change.">
   <defs>
     <radialGradient id="glowLime" cx="12%" cy="2%" r="70%">
-      <stop offset="0%" stop-color="#a3e635" stop-opacity="0.14"/><stop offset="60%" stop-color="#a3e635" stop-opacity="0"/>
+      <stop offset="0%" stop-color="#B6E84A" stop-opacity="0.14"/><stop offset="60%" stop-color="#B6E84A" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="glowCyan" cx="88%" cy="-6%" r="70%">
       <stop offset="0%" stop-color="#22d3ee" stop-opacity="0.12"/><stop offset="60%" stop-color="#22d3ee" stop-opacity="0"/>
@@ -10,21 +10,21 @@
       <path d="M 46 0 L 0 0 0 46" fill="none" stroke="#6b8dff" stroke-opacity="0.06" stroke-width="1"/>
     </pattern>
     <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4">
-      <stop offset="0%" stop-color="#c6ff6b"/><stop offset="50%" stop-color="#a3e635"/><stop offset="100%" stop-color="#5ad6c0"/>
+      <stop offset="0%" stop-color="#c6ff6b"/><stop offset="50%" stop-color="#B6E84A"/><stop offset="100%" stop-color="#5ad6c0"/>
     </linearGradient>
     <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/>
     </linearGradient>
     <linearGradient id="glassLime" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#a3e635" stop-opacity="0.10"/><stop offset="100%" stop-color="#a3e635" stop-opacity="0.02"/>
+      <stop offset="0%" stop-color="#B6E84A" stop-opacity="0.10"/><stop offset="100%" stop-color="#B6E84A" stop-opacity="0.02"/>
     </linearGradient>
     <linearGradient id="barCyan" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#22d3ee"/><stop offset="100%" stop-color="#22d3ee" stop-opacity="0"/></linearGradient>
     <linearGradient id="barAmber" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#f5c451"/><stop offset="100%" stop-color="#f5c451" stop-opacity="0"/></linearGradient>
-    <linearGradient id="barLime" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#a3e635"/><stop offset="100%" stop-color="#a3e635" stop-opacity="0"/></linearGradient>
+    <linearGradient id="barLime" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#B6E84A"/><stop offset="100%" stop-color="#B6E84A" stop-opacity="0"/></linearGradient>
     <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
     <filter id="neonLime" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
     <filter id="halo" x="-30%" y="-60%" width="160%" height="220%"><feGaussianBlur stdDeviation="7"/></filter>
-    <marker id="ar" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#a3e635"/></marker>
+    <marker id="ar" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#B6E84A"/></marker>
     <style><![CDATA[
       .kick { font: 600 14px ui-monospace,"SF Mono",Menlo,monospace; letter-spacing:.34em; fill:#5ad6c0; }
       .h1 { font: 800 52px Inter,-apple-system,"SF Pro Display",system-ui,sans-serif; letter-spacing:-.02em; }
@@ -33,11 +33,11 @@
       .cap { font: 500 15px Inter,-apple-system,system-ui,sans-serif; fill:#6b7099; }
       .m  { font: 500 22px ui-monospace,"SF Mono",Menlo,monospace; fill:#eaf2ff; }
       .mm { font: 500 19px ui-monospace,"SF Mono",Menlo,monospace; fill:#7a80a8; }
-      .ml { font: 600 22px ui-monospace,"SF Mono",Menlo,monospace; fill:#a3e635; }
+      .ml { font: 600 22px ui-monospace,"SF Mono",Menlo,monospace; fill:#B6E84A; }
       .str{ font: 600 20px ui-monospace,"SF Mono",Menlo,monospace; fill:#f5c451; }
       .strc{font: 600 20px ui-monospace,"SF Mono",Menlo,monospace; fill:#5ad6c0; }
       .note{ font: 400 19px Inter,-apple-system,system-ui,sans-serif; fill:#7a80a8; }
-      .noteA{font: 600 19px Inter,-apple-system,system-ui,sans-serif; fill:#a3e635; }
+      .noteA{font: 600 19px Inter,-apple-system,system-ui,sans-serif; fill:#B6E84A; }
     ]]></style>
   </defs>
 
@@ -47,10 +47,10 @@
   <rect width="1600" height="920" fill="url(#glowCyan)"/>
 
   <!-- header -->
-  <text x="100" y="98" class="kick">AGENTS MONITORS<tspan fill="#a3e635"> · EVENT-TRIGGERED WATCHERS</tspan></text>
-  <text x="98" y="162" class="h1" fill="#a3e635" opacity="0.38" filter="url(#halo)">Watch a source. Fire an agent on change.</text>
+  <text x="100" y="98" class="kick">AGENTS MONITORS<tspan fill="#B6E84A"> · EVENT-TRIGGERED WATCHERS</tspan></text>
+  <text x="98" y="162" class="h1" fill="#B6E84A" opacity="0.38" filter="url(#halo)">Watch a source. Fire an agent on change.</text>
   <text x="98" y="162" class="h1" fill="url(#title)">Watch a source. Fire an agent on change.</text>
-  <text x="100" y="204" class="sub">Routines fire on a <tspan fill="#8a90b8" font-style="italic">clock</tspan> — monitors fire on a <tspan fill="#a3e635" font-weight="600">change</tspan>.</text>
+  <text x="100" y="204" class="sub">Routines fire on a <tspan fill="#8a90b8" font-style="italic">clock</tspan> — monitors fire on a <tspan fill="#B6E84A" font-weight="600">change</tspan>.</text>
 
   <!-- ===== SOURCE (cyan) ===== -->
   <g filter="url(#soft)"><rect x="90" y="272" width="410" height="356" rx="24" fill="url(#glass)" stroke="#22d3ee" stroke-opacity="0.28" stroke-width="1.5"/></g>
@@ -62,7 +62,7 @@
   <text x="122" y="530" class="mm">--on · --ws</text>
   <text x="122" y="598" class="cap">what to watch</text>
 
-  <line x1="514" y1="450" x2="600" y2="450" stroke="#a3e635" stroke-width="3" marker-end="url(#ar)" filter="url(#neonLime)"/>
+  <line x1="514" y1="450" x2="600" y2="450" stroke="#B6E84A" stroke-width="3" marker-end="url(#ar)"/>
 
   <!-- ===== CONDITION (amber) ===== -->
   <g filter="url(#soft)"><rect x="614" y="272" width="410" height="356" rx="24" fill="url(#glass)" stroke="#f5c451" stroke-opacity="0.28" stroke-width="1.5"/></g>
@@ -74,12 +74,12 @@
   <text x="646" y="530" class="mm">state.json · silent baseline</text>
   <text x="646" y="598" class="cap">did it change?</text>
 
-  <line x1="1038" y1="450" x2="1124" y2="450" stroke="#a3e635" stroke-width="3" marker-end="url(#ar)" filter="url(#neonLime)"/>
+  <line x1="1038" y1="450" x2="1124" y2="450" stroke="#B6E84A" stroke-width="3" marker-end="url(#ar)"/>
 
   <!-- ===== ACTION (lime, active) ===== -->
-  <g filter="url(#soft)"><rect x="1138" y="272" width="410" height="356" rx="24" fill="url(#glassLime)" stroke="#a3e635" stroke-opacity="0.75" stroke-width="2" filter="url(#neonLime)"/></g>
+  <g filter="url(#soft)"><rect x="1138" y="272" width="410" height="356" rx="24" fill="url(#glassLime)" stroke="#B6E84A" stroke-opacity="0.75" stroke-width="2" filter="url(#neonLime)"/></g>
   <rect x="1170" y="308" width="140" height="6" rx="3" fill="url(#barLime)"/>
-  <text x="1170" y="356" class="meta" fill="#a3e635">ACTION</text>
+  <text x="1170" y="356" class="meta" fill="#B6E84A">ACTION</text>
   <text x="1170" y="410" class="ml">--run claude</text>
   <text x="1170" y="450" class="m">--prompt <tspan class="str">'…{event}…'</tspan></text>
   <text x="1170" y="490" class="mm">--routine · --notify</text>
@@ -87,7 +87,7 @@
   <text x="1170" y="598" class="cap">fire on change</text>
 
   <!-- placement chip -->
-  <rect x="1138" y="652" width="410" height="50" rx="16" fill="#a3e635" fill-opacity="0.06" stroke="#a3e635" stroke-opacity="0.3" stroke-width="1"/>
+  <rect x="1138" y="652" width="410" height="50" rx="16" fill="#B6E84A" fill-opacity="0.06" stroke="#B6E84A" stroke-opacity="0.3" stroke-width="1"/>
   <text x="1170" y="684" class="ml" font-size="19">--device <tspan class="mm">owner · exactly-once</tspan></text>
 
   <!-- footer -->

--- a/assets/monitors.svg
+++ b/assets/monitors.svg
@@ -1,0 +1,110 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 820" role="img" aria-label="agents monitors: a watched source (poll a command, an endpoint, or a fleet device) flows into a condition (changed? matched? deduped by a native state store) which fires an action (run an agent with the event in its prompt, kick a routine, or notify). Routines fire on a clock; monitors fire on a change.">
+  <defs>
+    <radialGradient id="bgVignette" cx="50%" cy="40%" r="80%">
+      <stop offset="0%"  stop-color="#0d0d0d"/>
+      <stop offset="100%" stop-color="#040404"/>
+    </radialGradient>
+    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M 48 0 L 0 0 0 48" fill="none" stroke="#0f0f0f" stroke-width="1"/>
+    </pattern>
+    <linearGradient id="cardFill" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#131313"/>
+      <stop offset="100%" stop-color="#0a0a0a"/>
+    </linearGradient>
+    <linearGradient id="cardFillActive" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#12160b"/>
+      <stop offset="100%" stop-color="#0b0d07"/>
+    </linearGradient>
+    <linearGradient id="cardRim" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2e2e2e"/>
+      <stop offset="50%" stop-color="#242424"/>
+      <stop offset="100%" stop-color="#1c1c1c"/>
+    </linearGradient>
+    <filter id="limeGlow" x="-40%" y="-60%" width="180%" height="220%">
+      <feGaussianBlur stdDeviation="3.5" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softShadow" x="-15%" y="-15%" width="130%" height="140%">
+      <feGaussianBlur stdDeviation="16" result="blur"/>
+      <feOffset dy="12" result="offset"/>
+      <feColorMatrix in="offset" type="matrix" values="0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.55 0" result="shadow"/>
+      <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <marker id="arrowLime" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#B6E84A"/>
+    </marker>
+    <style><![CDATA[
+      .section    { font: 600 13px -apple-system, "SF Pro Display", "Inter", system-ui, sans-serif; letter-spacing: 0.34em; fill: #B6E84A; }
+      .title      { font: 500 40px -apple-system, "SF Pro Display", "Inter", system-ui, sans-serif; fill: #f2f2f2; letter-spacing: -0.02em; }
+      .subtitle   { font: 400 20px -apple-system, "SF Pro Display", "Inter", system-ui, sans-serif; fill: #808080; }
+      .cardmeta   { font: 600 13px ui-monospace, "SF Mono", Menlo, monospace; letter-spacing: 0.26em; fill: #6a6a6a; }
+      .cardmetaA  { font: 600 13px ui-monospace, "SF Mono", Menlo, monospace; letter-spacing: 0.26em; fill: #B6E84A; }
+      .cardcap    { font: 500 15px -apple-system, "SF Pro Display", "Inter", system-ui, sans-serif; fill: #707070; }
+      .mono       { font: 500 21px ui-monospace, "SF Mono", Menlo, monospace; fill: #e6e6e6; }
+      .mono-mut   { font: 500 19px ui-monospace, "SF Mono", Menlo, monospace; fill: #7a7a7a; }
+      .mono-acc   { font: 600 21px ui-monospace, "SF Mono", Menlo, monospace; fill: #B6E84A; }
+      .flag       { font: 600 18px ui-monospace, "SF Mono", Menlo, monospace; fill: #c9d98a; }
+      .edge       { font: 600 12px -apple-system, "SF Pro Display", "Inter", system-ui, sans-serif; letter-spacing: 0.22em; fill: #6a6a6a; }
+      .note       { font: 400 18px -apple-system, "SF Pro Display", "Inter", system-ui, sans-serif; fill: #6f6f6f; }
+      .note-acc   { font: 500 18px -apple-system, "SF Pro Display", "Inter", system-ui, sans-serif; fill: #B6E84A; }
+    ]]></style>
+  </defs>
+
+  <rect width="1600" height="820" fill="url(#bgVignette)"/>
+  <rect width="1600" height="820" fill="url(#grid)"/>
+
+  <!-- header -->
+  <text x="100" y="96" class="section">AGENTS MONITORS</text>
+  <text x="100" y="150" class="title">Watch a source. Fire an agent on change.</text>
+  <text x="100" y="186" class="subtitle">Routines fire on a clock — monitors fire on a change.</text>
+
+  <!-- ============ SOURCE ============ -->
+  <g filter="url(#softShadow)">
+    <rect x="90" y="256" width="400" height="330" rx="22" fill="url(#cardFill)" stroke="url(#cardRim)" stroke-width="1.5"/>
+  </g>
+  <text x="122" y="306" class="cardmeta">SOURCE</text>
+  <line x1="122" y1="326" x2="458" y2="326" stroke="#232323" stroke-width="1"/>
+  <text x="122" y="376" class="mono">--poll <tspan class="flag">'gh pr checks'</tspan></text>
+  <text x="122" y="414" class="mono-mut">--poll-http · --watch-file</text>
+  <text x="122" y="452" class="mono">--watch-device <tspan class="mono-acc">mac-mini</tspan></text>
+  <text x="122" y="490" class="mono-mut">--on · --ws</text>
+  <text x="122" y="556" class="cardcap">what to watch</text>
+
+  <!-- arrow -->
+  <line x1="502" y1="421" x2="586" y2="421" stroke="#B6E84A" stroke-width="2.5" marker-end="url(#arrowLime)" filter="url(#limeGlow)"/>
+
+  <!-- ============ CONDITION ============ -->
+  <g filter="url(#softShadow)">
+    <rect x="600" y="256" width="400" height="330" rx="22" fill="url(#cardFill)" stroke="url(#cardRim)" stroke-width="1.5"/>
+  </g>
+  <text x="632" y="306" class="cardmeta">CONDITION</text>
+  <line x1="632" y1="326" x2="968" y2="326" stroke="#232323" stroke-width="1"/>
+  <text x="632" y="376" class="mono">--on-change <tspan class="mono-mut">(diff)</tspan></text>
+  <text x="632" y="414" class="mono">--match <tspan class="flag">'fail'</tspan></text>
+  <text x="632" y="452" class="mono-mut">--every · --dedupe-key</text>
+  <text x="632" y="490" class="mono-mut">state.json · silent baseline</text>
+  <text x="632" y="556" class="cardcap">did it change?</text>
+
+  <!-- arrow -->
+  <line x1="1012" y1="421" x2="1096" y2="421" stroke="#B6E84A" stroke-width="2.5" marker-end="url(#arrowLime)" filter="url(#limeGlow)"/>
+
+  <!-- ============ ACTION (active) ============ -->
+  <g filter="url(#softShadow)">
+    <rect x="1110" y="256" width="400" height="330" rx="22" fill="url(#cardFillActive)" stroke="#B6E84A" stroke-width="1.6" filter="url(#limeGlow)"/>
+  </g>
+  <text x="1142" y="306" class="cardmetaA">ACTION</text>
+  <line x1="1142" y1="326" x2="1478" y2="326" stroke="#2c3a18" stroke-width="1"/>
+  <text x="1142" y="376" class="mono-acc">--run claude</text>
+  <text x="1142" y="414" class="mono">--prompt <tspan class="flag">'…{event}…'</tspan></text>
+  <text x="1142" y="452" class="mono-mut">--routine · --notify</text>
+  <text x="1142" y="490" class="mono-mut">--webhook-out</text>
+  <text x="1142" y="556" class="cardcap">fire on change</text>
+
+  <!-- placement chip under action -->
+  <rect x="1110" y="612" width="400" height="46" rx="14" fill="#0e120b" stroke="#2c3a18" stroke-width="1"/>
+  <text x="1142" y="641" class="flag">--device <tspan class="mono-mut" style="fill:#7a7a7a">owner · exactly-once</tspan></text>
+
+  <!-- footer note -->
+  <text x="100" y="726" class="note">The cross-agent layer — <tspan class="note-acc">agents watching sources</tspan> (the fleet, other agents) and firing agents in response.</text>
+  <text x="100" y="762" class="note"><tspan class="mono-mut" style="font-size:16px">agents monitors test &lt;name&gt;</tspan>  dry-runs the source once and shows what it would fire — no action taken.</text>
+</svg>

--- a/assets/monitors.svg
+++ b/assets/monitors.svg
@@ -1,110 +1,94 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 820" role="img" aria-label="agents monitors: a watched source (poll a command, an endpoint, or a fleet device) flows into a condition (changed? matched? deduped by a native state store) which fires an action (run an agent with the event in its prompt, kick a routine, or notify). Routines fire on a clock; monitors fire on a change.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" role="img" aria-label="agents monitors: a watched source (poll a command, an HTTP endpoint, a file, or a fleet device) flows into a condition (changed? matched? deduped by a native state store) that fires an action — run an agent with the event in its prompt, kick a routine, or notify. Pin the owner device for exactly-once. Routines fire on a clock; monitors fire on a change.">
   <defs>
-    <radialGradient id="bgVignette" cx="50%" cy="40%" r="80%">
-      <stop offset="0%"  stop-color="#0d0d0d"/>
-      <stop offset="100%" stop-color="#040404"/>
+    <radialGradient id="glowLime" cx="12%" cy="2%" r="70%">
+      <stop offset="0%" stop-color="#a3e635" stop-opacity="0.14"/><stop offset="60%" stop-color="#a3e635" stop-opacity="0"/>
     </radialGradient>
-    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
-      <path d="M 48 0 L 0 0 0 48" fill="none" stroke="#0f0f0f" stroke-width="1"/>
+    <radialGradient id="glowCyan" cx="88%" cy="-6%" r="70%">
+      <stop offset="0%" stop-color="#22d3ee" stop-opacity="0.12"/><stop offset="60%" stop-color="#22d3ee" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid" width="46" height="46" patternUnits="userSpaceOnUse">
+      <path d="M 46 0 L 0 0 0 46" fill="none" stroke="#6b8dff" stroke-opacity="0.06" stroke-width="1"/>
     </pattern>
-    <linearGradient id="cardFill" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#131313"/>
-      <stop offset="100%" stop-color="#0a0a0a"/>
+    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4">
+      <stop offset="0%" stop-color="#c6ff6b"/><stop offset="50%" stop-color="#a3e635"/><stop offset="100%" stop-color="#5ad6c0"/>
     </linearGradient>
-    <linearGradient id="cardFillActive" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#12160b"/>
-      <stop offset="100%" stop-color="#0b0d07"/>
+    <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/>
     </linearGradient>
-    <linearGradient id="cardRim" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#2e2e2e"/>
-      <stop offset="50%" stop-color="#242424"/>
-      <stop offset="100%" stop-color="#1c1c1c"/>
+    <linearGradient id="glassLime" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a3e635" stop-opacity="0.10"/><stop offset="100%" stop-color="#a3e635" stop-opacity="0.02"/>
     </linearGradient>
-    <filter id="limeGlow" x="-40%" y="-60%" width="180%" height="220%">
-      <feGaussianBlur stdDeviation="3.5" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
-    </filter>
-    <filter id="softShadow" x="-15%" y="-15%" width="130%" height="140%">
-      <feGaussianBlur stdDeviation="16" result="blur"/>
-      <feOffset dy="12" result="offset"/>
-      <feColorMatrix in="offset" type="matrix" values="0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.55 0" result="shadow"/>
-      <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
-    </filter>
-    <marker id="arrowLime" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#B6E84A"/>
-    </marker>
+    <linearGradient id="barCyan" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#22d3ee"/><stop offset="100%" stop-color="#22d3ee" stop-opacity="0"/></linearGradient>
+    <linearGradient id="barAmber" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#f5c451"/><stop offset="100%" stop-color="#f5c451" stop-opacity="0"/></linearGradient>
+    <linearGradient id="barLime" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#a3e635"/><stop offset="100%" stop-color="#a3e635" stop-opacity="0"/></linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="neonLime" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <marker id="ar" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#a3e635"/></marker>
     <style><![CDATA[
-      .section    { font: 600 13px -apple-system, "SF Pro Display", "Inter", system-ui, sans-serif; letter-spacing: 0.34em; fill: #B6E84A; }
-      .title      { font: 500 40px -apple-system, "SF Pro Display", "Inter", system-ui, sans-serif; fill: #f2f2f2; letter-spacing: -0.02em; }
-      .subtitle   { font: 400 20px -apple-system, "SF Pro Display", "Inter", system-ui, sans-serif; fill: #808080; }
-      .cardmeta   { font: 600 13px ui-monospace, "SF Mono", Menlo, monospace; letter-spacing: 0.26em; fill: #6a6a6a; }
-      .cardmetaA  { font: 600 13px ui-monospace, "SF Mono", Menlo, monospace; letter-spacing: 0.26em; fill: #B6E84A; }
-      .cardcap    { font: 500 15px -apple-system, "SF Pro Display", "Inter", system-ui, sans-serif; fill: #707070; }
-      .mono       { font: 500 21px ui-monospace, "SF Mono", Menlo, monospace; fill: #e6e6e6; }
-      .mono-mut   { font: 500 19px ui-monospace, "SF Mono", Menlo, monospace; fill: #7a7a7a; }
-      .mono-acc   { font: 600 21px ui-monospace, "SF Mono", Menlo, monospace; fill: #B6E84A; }
-      .flag       { font: 600 18px ui-monospace, "SF Mono", Menlo, monospace; fill: #c9d98a; }
-      .edge       { font: 600 12px -apple-system, "SF Pro Display", "Inter", system-ui, sans-serif; letter-spacing: 0.22em; fill: #6a6a6a; }
-      .note       { font: 400 18px -apple-system, "SF Pro Display", "Inter", system-ui, sans-serif; fill: #6f6f6f; }
-      .note-acc   { font: 500 18px -apple-system, "SF Pro Display", "Inter", system-ui, sans-serif; fill: #B6E84A; }
+      .kick { font: 600 14px ui-monospace,"SF Mono",Menlo,monospace; letter-spacing:.34em; fill:#5ad6c0; }
+      .h1 { font: 800 52px Inter,-apple-system,"SF Pro Display",system-ui,sans-serif; letter-spacing:-.02em; }
+      .sub { font: 400 22px Inter,-apple-system,system-ui,sans-serif; fill:#8a90b8; }
+      .meta { font: 600 13px ui-monospace,"SF Mono",Menlo,monospace; letter-spacing:.24em; }
+      .cap { font: 500 15px Inter,-apple-system,system-ui,sans-serif; fill:#6b7099; }
+      .m  { font: 500 22px ui-monospace,"SF Mono",Menlo,monospace; fill:#eaf2ff; }
+      .mm { font: 500 19px ui-monospace,"SF Mono",Menlo,monospace; fill:#7a80a8; }
+      .ml { font: 600 22px ui-monospace,"SF Mono",Menlo,monospace; fill:#a3e635; }
+      .str{ font: 600 20px ui-monospace,"SF Mono",Menlo,monospace; fill:#f5c451; }
+      .strc{font: 600 20px ui-monospace,"SF Mono",Menlo,monospace; fill:#5ad6c0; }
+      .note{ font: 400 19px Inter,-apple-system,system-ui,sans-serif; fill:#7a80a8; }
+      .noteA{font: 600 19px Inter,-apple-system,system-ui,sans-serif; fill:#a3e635; }
     ]]></style>
   </defs>
 
-  <rect width="1600" height="820" fill="url(#bgVignette)"/>
-  <rect width="1600" height="820" fill="url(#grid)"/>
+  <rect width="1600" height="920" fill="#08080f"/>
+  <rect width="1600" height="920" fill="url(#grid)"/>
+  <rect width="1600" height="920" fill="url(#glowLime)"/>
+  <rect width="1600" height="920" fill="url(#glowCyan)"/>
 
   <!-- header -->
-  <text x="100" y="96" class="section">AGENTS MONITORS</text>
-  <text x="100" y="150" class="title">Watch a source. Fire an agent on change.</text>
-  <text x="100" y="186" class="subtitle">Routines fire on a clock — monitors fire on a change.</text>
+  <text x="100" y="98" class="kick">AGENTS MONITORS<tspan fill="#a3e635"> · EVENT-TRIGGERED WATCHERS</tspan></text>
+  <text x="98" y="162" class="h1" fill="url(#title)" filter="url(#neonLime)">Watch a source. Fire an agent on change.</text>
+  <text x="100" y="204" class="sub">Routines fire on a <tspan fill="#8a90b8" font-style="italic">clock</tspan> — monitors fire on a <tspan fill="#a3e635" font-weight="600">change</tspan>.</text>
 
-  <!-- ============ SOURCE ============ -->
-  <g filter="url(#softShadow)">
-    <rect x="90" y="256" width="400" height="330" rx="22" fill="url(#cardFill)" stroke="url(#cardRim)" stroke-width="1.5"/>
-  </g>
-  <text x="122" y="306" class="cardmeta">SOURCE</text>
-  <line x1="122" y1="326" x2="458" y2="326" stroke="#232323" stroke-width="1"/>
-  <text x="122" y="376" class="mono">--poll <tspan class="flag">'gh pr checks'</tspan></text>
-  <text x="122" y="414" class="mono-mut">--poll-http · --watch-file</text>
-  <text x="122" y="452" class="mono">--watch-device <tspan class="mono-acc">mac-mini</tspan></text>
-  <text x="122" y="490" class="mono-mut">--on · --ws</text>
-  <text x="122" y="556" class="cardcap">what to watch</text>
+  <!-- ===== SOURCE (cyan) ===== -->
+  <g filter="url(#soft)"><rect x="90" y="272" width="410" height="356" rx="24" fill="url(#glass)" stroke="#22d3ee" stroke-opacity="0.28" stroke-width="1.5"/></g>
+  <rect x="122" y="308" width="140" height="6" rx="3" fill="url(#barCyan)"/>
+  <text x="122" y="356" class="meta" fill="#22d3ee">SOURCE</text>
+  <text x="122" y="410" class="m">--poll <tspan class="str">'gh pr checks'</tspan></text>
+  <text x="122" y="450" class="mm">--poll-http · --watch-file</text>
+  <text x="122" y="490" class="m">--watch-device <tspan class="strc">mac-mini</tspan></text>
+  <text x="122" y="530" class="mm">--on · --ws</text>
+  <text x="122" y="598" class="cap">what to watch</text>
 
-  <!-- arrow -->
-  <line x1="502" y1="421" x2="586" y2="421" stroke="#B6E84A" stroke-width="2.5" marker-end="url(#arrowLime)" filter="url(#limeGlow)"/>
+  <line x1="514" y1="450" x2="600" y2="450" stroke="#a3e635" stroke-width="3" marker-end="url(#ar)" filter="url(#neonLime)"/>
 
-  <!-- ============ CONDITION ============ -->
-  <g filter="url(#softShadow)">
-    <rect x="600" y="256" width="400" height="330" rx="22" fill="url(#cardFill)" stroke="url(#cardRim)" stroke-width="1.5"/>
-  </g>
-  <text x="632" y="306" class="cardmeta">CONDITION</text>
-  <line x1="632" y1="326" x2="968" y2="326" stroke="#232323" stroke-width="1"/>
-  <text x="632" y="376" class="mono">--on-change <tspan class="mono-mut">(diff)</tspan></text>
-  <text x="632" y="414" class="mono">--match <tspan class="flag">'fail'</tspan></text>
-  <text x="632" y="452" class="mono-mut">--every · --dedupe-key</text>
-  <text x="632" y="490" class="mono-mut">state.json · silent baseline</text>
-  <text x="632" y="556" class="cardcap">did it change?</text>
+  <!-- ===== CONDITION (amber) ===== -->
+  <g filter="url(#soft)"><rect x="614" y="272" width="410" height="356" rx="24" fill="url(#glass)" stroke="#f5c451" stroke-opacity="0.28" stroke-width="1.5"/></g>
+  <rect x="646" y="308" width="140" height="6" rx="3" fill="url(#barAmber)"/>
+  <text x="646" y="356" class="meta" fill="#f5c451">CONDITION</text>
+  <text x="646" y="410" class="m">--on-change <tspan class="mm">(diff)</tspan></text>
+  <text x="646" y="450" class="m">--match <tspan class="str">'fail'</tspan></text>
+  <text x="646" y="490" class="mm">--every · --dedupe-key</text>
+  <text x="646" y="530" class="mm">state.json · silent baseline</text>
+  <text x="646" y="598" class="cap">did it change?</text>
 
-  <!-- arrow -->
-  <line x1="1012" y1="421" x2="1096" y2="421" stroke="#B6E84A" stroke-width="2.5" marker-end="url(#arrowLime)" filter="url(#limeGlow)"/>
+  <line x1="1038" y1="450" x2="1124" y2="450" stroke="#a3e635" stroke-width="3" marker-end="url(#ar)" filter="url(#neonLime)"/>
 
-  <!-- ============ ACTION (active) ============ -->
-  <g filter="url(#softShadow)">
-    <rect x="1110" y="256" width="400" height="330" rx="22" fill="url(#cardFillActive)" stroke="#B6E84A" stroke-width="1.6" filter="url(#limeGlow)"/>
-  </g>
-  <text x="1142" y="306" class="cardmetaA">ACTION</text>
-  <line x1="1142" y1="326" x2="1478" y2="326" stroke="#2c3a18" stroke-width="1"/>
-  <text x="1142" y="376" class="mono-acc">--run claude</text>
-  <text x="1142" y="414" class="mono">--prompt <tspan class="flag">'…{event}…'</tspan></text>
-  <text x="1142" y="452" class="mono-mut">--routine · --notify</text>
-  <text x="1142" y="490" class="mono-mut">--webhook-out</text>
-  <text x="1142" y="556" class="cardcap">fire on change</text>
+  <!-- ===== ACTION (lime, active) ===== -->
+  <g filter="url(#soft)"><rect x="1138" y="272" width="410" height="356" rx="24" fill="url(#glassLime)" stroke="#a3e635" stroke-opacity="0.75" stroke-width="2" filter="url(#neonLime)"/></g>
+  <rect x="1170" y="308" width="140" height="6" rx="3" fill="url(#barLime)"/>
+  <text x="1170" y="356" class="meta" fill="#a3e635">ACTION</text>
+  <text x="1170" y="410" class="ml">--run claude</text>
+  <text x="1170" y="450" class="m">--prompt <tspan class="str">'…{event}…'</tspan></text>
+  <text x="1170" y="490" class="mm">--routine · --notify</text>
+  <text x="1170" y="530" class="mm">--webhook-out</text>
+  <text x="1170" y="598" class="cap">fire on change</text>
 
-  <!-- placement chip under action -->
-  <rect x="1110" y="612" width="400" height="46" rx="14" fill="#0e120b" stroke="#2c3a18" stroke-width="1"/>
-  <text x="1142" y="641" class="flag">--device <tspan class="mono-mut" style="fill:#7a7a7a">owner · exactly-once</tspan></text>
+  <!-- placement chip -->
+  <rect x="1138" y="652" width="410" height="50" rx="16" fill="#a3e635" fill-opacity="0.06" stroke="#a3e635" stroke-opacity="0.3" stroke-width="1"/>
+  <text x="1170" y="684" class="ml" font-size="19">--device <tspan class="mm">owner · exactly-once</tspan></text>
 
-  <!-- footer note -->
-  <text x="100" y="726" class="note">The cross-agent layer — <tspan class="note-acc">agents watching sources</tspan> (the fleet, other agents) and firing agents in response.</text>
-  <text x="100" y="762" class="note"><tspan class="mono-mut" style="font-size:16px">agents monitors test &lt;name&gt;</tspan>  dry-runs the source once and shows what it would fire — no action taken.</text>
+  <!-- footer -->
+  <text x="100" y="792" class="note">The <tspan class="noteA">cross-agent layer</tspan> — agents watching sources (the fleet, other agents) and firing agents in response.</text>
+  <text x="100" y="830" class="note"><tspan class="mm" font-size="17">agents monitors test &lt;name&gt;</tspan>  dry-runs the source once and shows what it would fire — no action taken.</text>
 </svg>

--- a/assets/monitors.svg
+++ b/assets/monitors.svg
@@ -22,7 +22,8 @@
     <linearGradient id="barAmber" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#f5c451"/><stop offset="100%" stop-color="#f5c451" stop-opacity="0"/></linearGradient>
     <linearGradient id="barLime" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#a3e635"/><stop offset="100%" stop-color="#a3e635" stop-opacity="0"/></linearGradient>
     <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="neonLime" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="neonLime" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="halo" x="-30%" y="-60%" width="160%" height="220%"><feGaussianBlur stdDeviation="7"/></filter>
     <marker id="ar" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#a3e635"/></marker>
     <style><![CDATA[
       .kick { font: 600 14px ui-monospace,"SF Mono",Menlo,monospace; letter-spacing:.34em; fill:#5ad6c0; }
@@ -47,7 +48,8 @@
 
   <!-- header -->
   <text x="100" y="98" class="kick">AGENTS MONITORS<tspan fill="#a3e635"> · EVENT-TRIGGERED WATCHERS</tspan></text>
-  <text x="98" y="162" class="h1" fill="url(#title)" filter="url(#neonLime)">Watch a source. Fire an agent on change.</text>
+  <text x="98" y="162" class="h1" fill="#a3e635" opacity="0.38" filter="url(#halo)">Watch a source. Fire an agent on change.</text>
+  <text x="98" y="162" class="h1" fill="url(#title)">Watch a source. Fire an agent on change.</text>
   <text x="100" y="204" class="sub">Routines fire on a <tspan fill="#8a90b8" font-style="italic">clock</tspan> — monitors fire on a <tspan fill="#a3e635" font-weight="600">change</tspan>.</text>
 
   <!-- ===== SOURCE (cyan) ===== -->

--- a/assets/plugins.svg
+++ b/assets/plugins.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" role="img" aria-label="agents plugins: one plugin directory with a manifest (plugin.json plus skills, commands, hooks, MCP, permissions) is synced and mirrored into every installed Claude and OpenClaw version home, enabled automatically.">
+  <defs>
+    <radialGradient id="gViolet" cx="10%" cy="0%" r="70%"><stop offset="0%" stop-color="#a78bfa" stop-opacity="0.14"/><stop offset="60%" stop-color="#a78bfa" stop-opacity="0"/></radialGradient>
+    <radialGradient id="gCyan" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#22d3ee" stop-opacity="0.10"/><stop offset="60%" stop-color="#22d3ee" stop-opacity="0"/></radialGradient>
+    <pattern id="grid" width="46" height="46" patternUnits="userSpaceOnUse"><path d="M 46 0 L 0 0 0 46" fill="none" stroke="#6b8dff" stroke-opacity="0.06" stroke-width="1"/></pattern>
+    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#c4b5fd"/><stop offset="55%" stop-color="#a78bfa"/><stop offset="100%" stop-color="#22d3ee"/></linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/></linearGradient>
+    <linearGradient id="term" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0e0c16"/><stop offset="100%" stop-color="#08070e"/></linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="neon" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="halo" x="-30%" y="-60%" width="160%" height="220%"><feGaussianBlur stdDeviation="7"/></filter>
+    <marker id="arV" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#a78bfa"/></marker>
+    <style><![CDATA[
+      .kick{font:600 14px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.34em;fill:#a78bfa;}
+      .h1{font:800 52px Inter,-apple-system,"SF Pro Display",system-ui,sans-serif;letter-spacing:-.02em;}
+      .sub{font:400 22px Inter,-apple-system,system-ui,sans-serif;fill:#8a90b8;}
+      .lab{font:600 12px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.24em;fill:#6b7099;}
+      .dir{font:600 19px ui-monospace,"SF Mono",Menlo,monospace;fill:#c4b5fd;}
+      .m{font:500 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
+      .mm{font:500 18px ui-monospace,"SF Mono",Menlo,monospace;fill:#7a80a8;}
+      .mv{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#a78bfa;}
+      .vh{font:700 20px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
+      .ok{font:600 16px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .edge{font:600 13px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.06em;fill:#a78bfa;}
+      .note{font:400 19px Inter,-apple-system,system-ui,sans-serif;fill:#7a80a8;}
+      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#a78bfa;}
+    ]]></style>
+  </defs>
+
+  <rect width="1600" height="920" fill="#08080f"/>
+  <rect width="1600" height="920" fill="url(#grid)"/>
+  <rect width="1600" height="920" fill="url(#gViolet)"/>
+  <rect width="1600" height="920" fill="url(#gCyan)"/>
+
+  <text x="100" y="98" class="kick">AGENTS PLUGINS<tspan fill="#22d3ee"> · ONE MANIFEST, EVERY VERSION</tspan></text>
+  <text x="98" y="162" class="h1" fill="#a78bfa" opacity="0.35" filter="url(#halo)">Bundle it once. Mirrored everywhere.</text>
+  <text x="98" y="162" class="h1" fill="url(#title)">Bundle it once. Mirrored everywhere.</text>
+  <text x="100" y="204" class="sub">Skills, commands, hooks, MCP servers, settings — under a single manifest, synced into every agent version.</text>
+
+  <!-- ===== plugin directory (left) ===== -->
+  <g filter="url(#soft)"><rect x="90" y="278" width="560" height="452" rx="20" fill="url(#term)" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.5"/></g>
+  <circle cx="122" cy="312" r="6" fill="#fb7185"/><circle cx="144" cy="312" r="6" fill="#f5c451"/><circle cx="166" cy="312" r="6" fill="#a78bfa"/>
+  <line x1="118" y1="334" x2="622" y2="334" stroke="#1c1a2a" stroke-width="1"/>
+  <text x="122" y="378" class="dir">~/.agents/plugins/my-plugin/</text>
+  <text x="146" y="424" class="mv">.claude-plugin/plugin.json <tspan class="mm">required</tspan></text>
+  <text x="146" y="464" class="m">skills/&lt;name&gt;/SKILL.md</text>
+  <text x="146" y="504" class="m">commands/*.md</text>
+  <text x="146" y="544" class="m">hooks/hooks.json</text>
+  <text x="146" y="584" class="m">.mcp.json</text>
+  <text x="146" y="624" class="m">permissions/</text>
+  <text x="122" y="694" class="mm" font-size="16">skills · commands · hooks · mcp · settings · permissions</text>
+
+  <!-- SYNC trunk + fan -->
+  <line x1="666" y1="500" x2="726" y2="500" stroke="#a78bfa" stroke-width="3" filter="url(#neon)"/>
+  <text x="748" y="482" class="edge" text-anchor="middle">SYNC</text>
+  <path d="M726 500 L760 348" stroke="#a78bfa" stroke-width="2.5" fill="none" marker-end="url(#arV)" opacity="0.9"/>
+  <path d="M726 500 L760 500" stroke="#a78bfa" stroke-width="2.5" fill="none" marker-end="url(#arV)" opacity="0.9"/>
+  <path d="M726 500 L760 652" stroke="#a78bfa" stroke-width="2.5" fill="none" marker-end="url(#arV)" opacity="0.9"/>
+
+  <!-- ===== version homes (right) ===== -->
+  <g filter="url(#soft)"><rect x="782" y="298" width="726" height="112" rx="16" fill="url(#glass)" stroke="#a78bfa" stroke-opacity="0.3" stroke-width="1.5"/></g>
+  <text x="814" y="342" class="vh">claude <tspan class="mm" font-size="17">2.1.x</tspan></text>
+  <text x="814" y="378" class="mm" font-size="17">…/marketplaces/agents-cli/plugins/my-plugin/</text>
+  <text x="1476" y="360" class="ok" text-anchor="end">✓ enabled</text>
+
+  <g filter="url(#soft)"><rect x="782" y="444" width="726" height="112" rx="16" fill="url(#glass)" stroke="#a78bfa" stroke-opacity="0.3" stroke-width="1.5"/></g>
+  <text x="814" y="488" class="vh">openclaw</text>
+  <text x="814" y="524" class="mm" font-size="17">…/marketplaces/agents-cli/plugins/my-plugin/</text>
+  <text x="1476" y="506" class="ok" text-anchor="end">✓ enabled</text>
+
+  <g filter="url(#soft)"><rect x="782" y="590" width="726" height="112" rx="16" fill="url(#glass)" stroke="#a78bfa" stroke-opacity="0.3" stroke-width="1.5"/></g>
+  <text x="814" y="634" class="vh">claude <tspan class="mm" font-size="17">2.0.x</tspan></text>
+  <text x="814" y="670" class="mm" font-size="17">…/marketplaces/agents-cli/plugins/my-plugin/</text>
+  <text x="1476" y="652" class="ok" text-anchor="end">✓ enabled</text>
+
+  <!-- footer -->
+  <text x="100" y="792" class="note"><tspan class="mm" font-size="17">agents plugins install &lt;git-url|path&gt;</tspan>  ·  <tspan class="mm" font-size="17">sync &lt;name&gt; [agent]</tspan></text>
+  <text x="100" y="830" class="note">Copied into each version's marketplace and <tspan class="noteA">enabled automatically</tspan> — one source dir, every agent.</text>
+</svg>

--- a/assets/plugins.svg
+++ b/assets/plugins.svg
@@ -51,7 +51,7 @@
   <text x="122" y="694" class="mm" font-size="16">skills · commands · hooks · mcp · settings · permissions</text>
 
   <!-- SYNC trunk + fan -->
-  <line x1="666" y1="500" x2="726" y2="500" stroke="#a78bfa" stroke-width="3" filter="url(#neon)"/>
+  <line x1="666" y1="500" x2="726" y2="500" stroke="#a78bfa" stroke-width="3"/>
   <text x="748" y="482" class="edge" text-anchor="middle">SYNC</text>
   <path d="M726 500 L760 348" stroke="#a78bfa" stroke-width="2.5" fill="none" marker-end="url(#arV)" opacity="0.9"/>
   <path d="M726 500 L760 500" stroke="#a78bfa" stroke-width="2.5" fill="none" marker-end="url(#arV)" opacity="0.9"/>

--- a/assets/plugins.svg
+++ b/assets/plugins.svg
@@ -20,7 +20,7 @@
       .mm{font:500 18px ui-monospace,"SF Mono",Menlo,monospace;fill:#7a80a8;}
       .mv{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#a78bfa;}
       .vh{font:700 20px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
-      .ok{font:600 16px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .ok{font:600 16px ui-monospace,"SF Mono",Menlo,monospace;fill:#B6E84A;}
       .edge{font:600 13px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.06em;fill:#a78bfa;}
       .note{font:400 19px Inter,-apple-system,system-ui,sans-serif;fill:#7a80a8;}
       .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#a78bfa;}

--- a/assets/pty.svg
+++ b/assets/pty.svg
@@ -18,7 +18,7 @@
       .m{font:500 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
       .mm{font:500 18px ui-monospace,"SF Mono",Menlo,monospace;fill:#7a80a8;}
       .mp{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#fb7185;}
-      .out{font:500 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .out{font:500 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#B6E84A;}
       .edge{font:600 13px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.06em;}
       .note{font:400 19px Inter,-apple-system,system-ui,sans-serif;fill:#7a80a8;}
       .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#fb7185;}
@@ -37,7 +37,7 @@
 
   <!-- terminal window -->
   <g filter="url(#soft)"><rect x="90" y="280" width="1030" height="420" rx="20" fill="url(#term)" stroke="#fb7185" stroke-opacity="0.3" stroke-width="1.5"/></g>
-  <circle cx="122" cy="314" r="6" fill="#fb7185"/><circle cx="144" cy="314" r="6" fill="#f5c451"/><circle cx="166" cy="314" r="6" fill="#a3e635"/>
+  <circle cx="122" cy="314" r="6" fill="#fb7185"/><circle cx="144" cy="314" r="6" fill="#f5c451"/><circle cx="166" cy="314" r="6" fill="#B6E84A"/>
   <text x="1088" y="320" class="lab" text-anchor="end">agents pty · python3</text>
   <line x1="118" y1="336" x2="1092" y2="336" stroke="#1a2230" stroke-width="1"/>
   <text x="122" y="384" class="m"><tspan fill="#5ad6c0">$</tspan> SID=$(agents pty start)</text>
@@ -49,8 +49,8 @@
   <text x="122" y="654" class="mm" font-size="16">write · screen · stop — drive it programmatically</text>
 
   <!-- sidecar node -->
-  <line x1="1136" y1="450" x2="1224" y2="450" stroke="#fb7185" stroke-width="3" marker-end="url(#arP)" filter="url(#neon)"/>
-  <line x1="1224" y1="470" x2="1136" y2="470" stroke="#fb7185" stroke-width="3" marker-end="url(#arP)" filter="url(#neon)"/>
+  <line x1="1136" y1="450" x2="1224" y2="450" stroke="#fb7185" stroke-width="3" marker-end="url(#arP)"/>
+  <line x1="1224" y1="470" x2="1136" y2="470" stroke="#fb7185" stroke-width="3" marker-end="url(#arP)"/>
   <text x="1180" y="436" class="edge" fill="#fb7185" text-anchor="middle">PTY</text>
   <g filter="url(#soft)"><rect x="1240" y="330" width="270" height="240" rx="20" fill="url(#glass)" stroke="#fb7185" stroke-opacity="0.4" stroke-width="1.6"/></g>
   <text x="1375" y="392" class="lab" text-anchor="middle" fill="#fb7185">SIDECAR SERVER</text>

--- a/assets/pty.svg
+++ b/assets/pty.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" role="img" aria-label="agents pty gives an agent a real terminal for REPLs, TUIs, and interactive programs. A sidecar server holds the pty session alive between CLI calls: start a session, exec python3, write to it, and screen it back as clean ANSI-free text. Sessions auto-clean after 30 minutes idle.">
+  <defs>
+    <radialGradient id="gPink" cx="10%" cy="0%" r="70%"><stop offset="0%" stop-color="#fb7185" stop-opacity="0.13"/><stop offset="60%" stop-color="#fb7185" stop-opacity="0"/></radialGradient>
+    <radialGradient id="gAmber" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#f5c451" stop-opacity="0.10"/><stop offset="60%" stop-color="#f5c451" stop-opacity="0"/></radialGradient>
+    <pattern id="grid" width="46" height="46" patternUnits="userSpaceOnUse"><path d="M 46 0 L 0 0 0 46" fill="none" stroke="#6b8dff" stroke-opacity="0.06" stroke-width="1"/></pattern>
+    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#fda4af"/><stop offset="55%" stop-color="#fb7185"/><stop offset="100%" stop-color="#f5c451"/></linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/></linearGradient>
+    <linearGradient id="term" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0c1016"/><stop offset="100%" stop-color="#070a0e"/></linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="neon" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="halo" x="-30%" y="-60%" width="160%" height="220%"><feGaussianBlur stdDeviation="7"/></filter>
+    <marker id="arP" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#fb7185"/></marker>
+    <style><![CDATA[
+      .kick{font:600 14px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.34em;fill:#fb7185;}
+      .h1{font:800 52px Inter,-apple-system,"SF Pro Display",system-ui,sans-serif;letter-spacing:-.02em;}
+      .sub{font:400 22px Inter,-apple-system,system-ui,sans-serif;fill:#8a90b8;}
+      .lab{font:600 12px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.24em;fill:#6b7099;}
+      .m{font:500 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
+      .mm{font:500 18px ui-monospace,"SF Mono",Menlo,monospace;fill:#7a80a8;}
+      .mp{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#fb7185;}
+      .out{font:500 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .edge{font:600 13px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.06em;}
+      .note{font:400 19px Inter,-apple-system,system-ui,sans-serif;fill:#7a80a8;}
+      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#fb7185;}
+    ]]></style>
+  </defs>
+
+  <rect width="1600" height="920" fill="#08080f"/>
+  <rect width="1600" height="920" fill="url(#grid)"/>
+  <rect width="1600" height="920" fill="url(#gPink)"/>
+  <rect width="1600" height="920" fill="url(#gAmber)"/>
+
+  <text x="100" y="98" class="kick">AGENTS PTY<tspan fill="#f5c451"> · A REAL TERMINAL FOR AGENTS</tspan></text>
+  <text x="98" y="162" class="h1" fill="#fb7185" opacity="0.34" filter="url(#halo)">Give an agent a real terminal.</text>
+  <text x="98" y="162" class="h1" fill="url(#title)">Give an agent a real terminal.</text>
+  <text x="100" y="204" class="sub">REPLs, TUIs, interactive programs — held alive by a sidecar between CLI calls.</text>
+
+  <!-- terminal window -->
+  <g filter="url(#soft)"><rect x="90" y="280" width="1030" height="420" rx="20" fill="url(#term)" stroke="#fb7185" stroke-opacity="0.3" stroke-width="1.5"/></g>
+  <circle cx="122" cy="314" r="6" fill="#fb7185"/><circle cx="144" cy="314" r="6" fill="#f5c451"/><circle cx="166" cy="314" r="6" fill="#a3e635"/>
+  <text x="1088" y="320" class="lab" text-anchor="end">agents pty · python3</text>
+  <line x1="118" y1="336" x2="1092" y2="336" stroke="#1a2230" stroke-width="1"/>
+  <text x="122" y="384" class="m"><tspan fill="#5ad6c0">$</tspan> SID=$(agents pty start)</text>
+  <text x="122" y="424" class="m"><tspan fill="#5ad6c0">$</tspan> agents pty exec $SID <tspan class="mm">"python3"</tspan></text>
+  <text x="122" y="470" class="mp">&gt;&gt;&gt; <tspan class="m">print('hello')</tspan></text>
+  <text x="122" y="508" class="out">hello</text>
+  <text x="122" y="554" class="m"><tspan fill="#5ad6c0">$</tspan> agents pty screen $SID</text>
+  <text x="122" y="592" class="mm" font-size="17">clean text, no ANSI — what a human sees</text>
+  <text x="122" y="654" class="mm" font-size="16">write · screen · stop — drive it programmatically</text>
+
+  <!-- sidecar node -->
+  <line x1="1136" y1="450" x2="1224" y2="450" stroke="#fb7185" stroke-width="3" marker-end="url(#arP)" filter="url(#neon)"/>
+  <line x1="1224" y1="470" x2="1136" y2="470" stroke="#fb7185" stroke-width="3" marker-end="url(#arP)" filter="url(#neon)"/>
+  <text x="1180" y="436" class="edge" fill="#fb7185" text-anchor="middle">PTY</text>
+  <g filter="url(#soft)"><rect x="1240" y="330" width="270" height="240" rx="20" fill="url(#glass)" stroke="#fb7185" stroke-opacity="0.4" stroke-width="1.6"/></g>
+  <text x="1375" y="392" class="lab" text-anchor="middle" fill="#fb7185">SIDECAR SERVER</text>
+  <rect x="1300" y="418" width="150" height="52" rx="12" fill="#fb7185" fill-opacity="0.1" stroke="#fb7185" stroke-opacity="0.35"/>
+  <text x="1375" y="450" class="mp" font-size="19" text-anchor="middle">$SID</text>
+  <text x="1375" y="512" class="mm" font-size="15" text-anchor="middle">holds sessions alive</text>
+  <text x="1375" y="536" class="mm" font-size="15" text-anchor="middle">xterm-headless</text>
+
+  <!-- footer -->
+  <text x="100" y="792" class="note">A <tspan class="noteA">sidecar server</tspan> keeps the pty alive between calls — so an agent can start a REPL, walk away, and come back to it.</text>
+  <text x="100" y="830" class="note"><tspan class="mm" font-size="17">agents pty write $SID "…"</tspan>  feeds input;  sessions auto-clean after 30 minutes idle.</text>
+</svg>

--- a/assets/run-agent.svg
+++ b/assets/run-agent.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" role="img" aria-label="agents run: one command runs any harness at its project-pinned version with skills, MCP and permissions synced. When Claude hits a rate limit, the run falls back to Codex, then Gemini, automatically — same project, same config.">
+  <defs>
+    <radialGradient id="gCyan" cx="10%" cy="0%" r="70%"><stop offset="0%" stop-color="#22d3ee" stop-opacity="0.10"/><stop offset="60%" stop-color="#22d3ee" stop-opacity="0"/></radialGradient>
+    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#a3e635" stop-opacity="0.13"/><stop offset="60%" stop-color="#a3e635" stop-opacity="0"/></radialGradient>
+    <pattern id="grid" width="46" height="46" patternUnits="userSpaceOnUse"><path d="M 46 0 L 0 0 0 46" fill="none" stroke="#6b8dff" stroke-opacity="0.06" stroke-width="1"/></pattern>
+    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#c6ff6b"/><stop offset="55%" stop-color="#a3e635"/><stop offset="100%" stop-color="#5ad6c0"/></linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/></linearGradient>
+    <linearGradient id="term" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0c1016"/><stop offset="100%" stop-color="#070a0e"/></linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="neon" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="halo" x="-30%" y="-60%" width="160%" height="220%"><feGaussianBlur stdDeviation="7"/></filter>
+    <marker id="arG" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#a3e635"/></marker>
+    <style><![CDATA[
+      .kick{font:600 14px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.34em;fill:#5ad6c0;}
+      .h1{font:800 52px Inter,-apple-system,"SF Pro Display",system-ui,sans-serif;letter-spacing:-.02em;}
+      .sub{font:400 22px Inter,-apple-system,system-ui,sans-serif;fill:#8a90b8;}
+      .lab{font:600 12px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.24em;fill:#6b7099;}
+      .m{font:500 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
+      .mm{font:500 18px ui-monospace,"SF Mono",Menlo,monospace;fill:#7a80a8;}
+      .ml{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .hn{font:700 30px ui-monospace,"SF Mono",Menlo,monospace;}
+      .st{font:600 15px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.08em;}
+      .edge{font:600 13px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.08em;}
+      .note{font:400 19px Inter,-apple-system,system-ui,sans-serif;fill:#7a80a8;}
+      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#a3e635;}
+    ]]></style>
+  </defs>
+
+  <rect width="1600" height="920" fill="#08080f"/>
+  <rect width="1600" height="920" fill="url(#grid)"/>
+  <rect width="1600" height="920" fill="url(#gCyan)"/>
+  <rect width="1600" height="920" fill="url(#gLime)"/>
+
+  <text x="100" y="98" class="kick">AGENTS RUN<tspan fill="#a3e635"> · ONE COMMAND, ANY HARNESS</tspan></text>
+  <text x="98" y="162" class="h1" fill="#a3e635" opacity="0.35" filter="url(#halo)">Run any agent. Fall back on rate limits.</text>
+  <text x="98" y="162" class="h1" fill="url(#title)">Run any agent. Fall back on rate limits.</text>
+  <text x="100" y="204" class="sub">Each run resolves to the project-pinned version — skills, MCP, and permissions already synced.</text>
+
+  <!-- ===== terminal (left) ===== -->
+  <g filter="url(#soft)"><rect x="90" y="286" width="520" height="252" rx="20" fill="url(#term)" stroke="#a3e635" stroke-opacity="0.3" stroke-width="1.5"/></g>
+  <circle cx="122" cy="320" r="6" fill="#fb7185"/><circle cx="144" cy="320" r="6" fill="#f5c451"/><circle cx="166" cy="320" r="6" fill="#a3e635"/>
+  <text x="582" y="326" class="lab" text-anchor="end">agents run</text>
+  <line x1="118" y1="342" x2="582" y2="342" stroke="#1a2230" stroke-width="1"/>
+  <text x="122" y="392" class="m"><tspan fill="#5ad6c0">$</tspan> agents run <tspan class="ml">claude</tspan></text>
+  <text x="150" y="430" class="mm">"refactor auth module"</text>
+  <text x="150" y="468" class="mm">--mode edit --fallback <tspan class="ml">codex,gemini</tspan></text>
+  <text x="122" y="512" class="mm" font-size="16">project-pinned · skills · MCP · permissions</text>
+
+  <!-- chips -->
+  <rect x="90" y="566" width="256" height="42" rx="13" fill="#a3e635" fill-opacity="0.06" stroke="#a3e635" stroke-opacity="0.28"/><text x="112" y="593" class="edge" fill="#a3e635">--strategy balanced</text>
+  <rect x="362" y="566" width="248" height="42" rx="13" fill="#5ad6c0" fill-opacity="0.05" stroke="#5ad6c0" stroke-opacity="0.24"/><text x="384" y="593" class="edge" fill="#5ad6c0">chain: claude | codex</text>
+
+  <!-- ===== fallback chain (right) ===== -->
+  <text x="1085" y="264" class="lab" text-anchor="middle">RATE-LIMIT FALLBACK CHAIN</text>
+
+  <!-- claude (rate-limited) -->
+  <g filter="url(#soft)"><rect x="660" y="300" width="230" height="210" rx="20" fill="url(#glass)" stroke="#f5c451" stroke-opacity="0.4" stroke-width="1.5"/></g>
+  <circle cx="852" cy="336" r="7" fill="#f5c451"/>
+  <text x="775" y="415" class="hn" fill="#eaeecf" text-anchor="middle" opacity="0.7">claude</text>
+  <text x="775" y="458" class="st" fill="#f5c451" text-anchor="middle">rate-limited</text>
+
+  <line x1="892" y1="405" x2="948" y2="405" stroke="#a3e635" stroke-width="3" marker-end="url(#arG)" filter="url(#neon)"/>
+  <text x="920" y="388" class="edge" fill="#a3e635" text-anchor="middle">429</text>
+
+  <!-- codex (active) -->
+  <g filter="url(#soft)"><rect x="950" y="300" width="230" height="210" rx="20" fill="#a3e635" fill-opacity="0.08" stroke="#a3e635" stroke-opacity="0.8" stroke-width="2" filter="url(#neon)"/></g>
+  <circle cx="1142" cy="336" r="7" fill="#a3e635"/>
+  <text x="1065" y="415" class="hn" fill="#a3e635" text-anchor="middle">codex</text>
+  <text x="1065" y="458" class="st" fill="#a3e635" text-anchor="middle">running →</text>
+
+  <line x1="1182" y1="405" x2="1238" y2="405" stroke="#3a425e" stroke-width="3" marker-end="url(#arG)"/>
+
+  <!-- gemini (standby) -->
+  <g filter="url(#soft)"><rect x="1240" y="300" width="230" height="210" rx="20" fill="url(#glass)" stroke="#3a425e" stroke-width="1.5"/></g>
+  <circle cx="1432" cy="336" r="7" fill="#4a5170"/>
+  <text x="1355" y="415" class="hn" fill="#8a90b8" text-anchor="middle" opacity="0.6">gemini</text>
+  <text x="1355" y="458" class="st" fill="#6b7099" text-anchor="middle">standby</text>
+
+  <!-- footer -->
+  <text x="100" y="792" class="note">Same project, same config — the <tspan class="noteA">next agent picks up seamlessly</tspan> when one runs dry.</text>
+  <text x="100" y="830" class="note">Single-typo names auto-correct — <tspan class="mm" font-size="17">agents view cladue</tspan> resolves to <tspan class="mm" font-size="17" style="fill:#a3e635">claude</tspan>.</text>
+</svg>

--- a/assets/run-agent.svg
+++ b/assets/run-agent.svg
@@ -1,15 +1,15 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" role="img" aria-label="agents run: one command runs any harness at its project-pinned version with skills, MCP and permissions synced. When Claude hits a rate limit, the run falls back to Codex, then Gemini, automatically — same project, same config.">
   <defs>
     <radialGradient id="gCyan" cx="10%" cy="0%" r="70%"><stop offset="0%" stop-color="#22d3ee" stop-opacity="0.10"/><stop offset="60%" stop-color="#22d3ee" stop-opacity="0"/></radialGradient>
-    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#a3e635" stop-opacity="0.13"/><stop offset="60%" stop-color="#a3e635" stop-opacity="0"/></radialGradient>
+    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#B6E84A" stop-opacity="0.13"/><stop offset="60%" stop-color="#B6E84A" stop-opacity="0"/></radialGradient>
     <pattern id="grid" width="46" height="46" patternUnits="userSpaceOnUse"><path d="M 46 0 L 0 0 0 46" fill="none" stroke="#6b8dff" stroke-opacity="0.06" stroke-width="1"/></pattern>
-    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#c6ff6b"/><stop offset="55%" stop-color="#a3e635"/><stop offset="100%" stop-color="#5ad6c0"/></linearGradient>
+    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#c6ff6b"/><stop offset="55%" stop-color="#B6E84A"/><stop offset="100%" stop-color="#5ad6c0"/></linearGradient>
     <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/></linearGradient>
     <linearGradient id="term" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0c1016"/><stop offset="100%" stop-color="#070a0e"/></linearGradient>
     <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
     <filter id="neon" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
     <filter id="halo" x="-30%" y="-60%" width="160%" height="220%"><feGaussianBlur stdDeviation="7"/></filter>
-    <marker id="arG" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#a3e635"/></marker>
+    <marker id="arG" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#B6E84A"/></marker>
     <style><![CDATA[
       .kick{font:600 14px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.34em;fill:#5ad6c0;}
       .h1{font:800 52px Inter,-apple-system,"SF Pro Display",system-ui,sans-serif;letter-spacing:-.02em;}
@@ -17,12 +17,12 @@
       .lab{font:600 12px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.24em;fill:#6b7099;}
       .m{font:500 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
       .mm{font:500 18px ui-monospace,"SF Mono",Menlo,monospace;fill:#7a80a8;}
-      .ml{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .ml{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#B6E84A;}
       .hn{font:700 30px ui-monospace,"SF Mono",Menlo,monospace;}
       .st{font:600 15px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.08em;}
       .edge{font:600 13px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.08em;}
       .note{font:400 19px Inter,-apple-system,system-ui,sans-serif;fill:#7a80a8;}
-      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#a3e635;}
+      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#B6E84A;}
     ]]></style>
   </defs>
 
@@ -31,14 +31,14 @@
   <rect width="1600" height="920" fill="url(#gCyan)"/>
   <rect width="1600" height="920" fill="url(#gLime)"/>
 
-  <text x="100" y="98" class="kick">AGENTS RUN<tspan fill="#a3e635"> · ONE COMMAND, ANY HARNESS</tspan></text>
-  <text x="98" y="162" class="h1" fill="#a3e635" opacity="0.35" filter="url(#halo)">Run any agent. Fall back on rate limits.</text>
+  <text x="100" y="98" class="kick">AGENTS RUN<tspan fill="#B6E84A"> · ONE COMMAND, ANY HARNESS</tspan></text>
+  <text x="98" y="162" class="h1" fill="#B6E84A" opacity="0.35" filter="url(#halo)">Run any agent. Fall back on rate limits.</text>
   <text x="98" y="162" class="h1" fill="url(#title)">Run any agent. Fall back on rate limits.</text>
   <text x="100" y="204" class="sub">Each run resolves to the project-pinned version — skills, MCP, and permissions already synced.</text>
 
   <!-- ===== terminal (left) ===== -->
-  <g filter="url(#soft)"><rect x="90" y="286" width="520" height="252" rx="20" fill="url(#term)" stroke="#a3e635" stroke-opacity="0.3" stroke-width="1.5"/></g>
-  <circle cx="122" cy="320" r="6" fill="#fb7185"/><circle cx="144" cy="320" r="6" fill="#f5c451"/><circle cx="166" cy="320" r="6" fill="#a3e635"/>
+  <g filter="url(#soft)"><rect x="90" y="286" width="520" height="252" rx="20" fill="url(#term)" stroke="#B6E84A" stroke-opacity="0.3" stroke-width="1.5"/></g>
+  <circle cx="122" cy="320" r="6" fill="#fb7185"/><circle cx="144" cy="320" r="6" fill="#f5c451"/><circle cx="166" cy="320" r="6" fill="#B6E84A"/>
   <text x="582" y="326" class="lab" text-anchor="end">agents run</text>
   <line x1="118" y1="342" x2="582" y2="342" stroke="#1a2230" stroke-width="1"/>
   <text x="122" y="392" class="m"><tspan fill="#5ad6c0">$</tspan> agents run <tspan class="ml">claude</tspan></text>
@@ -47,7 +47,7 @@
   <text x="122" y="512" class="mm" font-size="16">project-pinned · skills · MCP · permissions</text>
 
   <!-- chips -->
-  <rect x="90" y="566" width="256" height="42" rx="13" fill="#a3e635" fill-opacity="0.06" stroke="#a3e635" stroke-opacity="0.28"/><text x="112" y="593" class="edge" fill="#a3e635">--strategy balanced</text>
+  <rect x="90" y="566" width="256" height="42" rx="13" fill="#B6E84A" fill-opacity="0.06" stroke="#B6E84A" stroke-opacity="0.28"/><text x="112" y="593" class="edge" fill="#B6E84A">--strategy balanced</text>
   <rect x="362" y="566" width="248" height="42" rx="13" fill="#5ad6c0" fill-opacity="0.05" stroke="#5ad6c0" stroke-opacity="0.24"/><text x="384" y="593" class="edge" fill="#5ad6c0">chain: claude | codex</text>
 
   <!-- ===== fallback chain (right) ===== -->
@@ -59,14 +59,14 @@
   <text x="775" y="415" class="hn" fill="#eaeecf" text-anchor="middle" opacity="0.7">claude</text>
   <text x="775" y="458" class="st" fill="#f5c451" text-anchor="middle">rate-limited</text>
 
-  <line x1="892" y1="405" x2="948" y2="405" stroke="#a3e635" stroke-width="3" marker-end="url(#arG)" filter="url(#neon)"/>
-  <text x="920" y="388" class="edge" fill="#a3e635" text-anchor="middle">429</text>
+  <line x1="892" y1="405" x2="948" y2="405" stroke="#B6E84A" stroke-width="3" marker-end="url(#arG)"/>
+  <text x="920" y="388" class="edge" fill="#B6E84A" text-anchor="middle">429</text>
 
   <!-- codex (active) -->
-  <g filter="url(#soft)"><rect x="950" y="300" width="230" height="210" rx="20" fill="#a3e635" fill-opacity="0.08" stroke="#a3e635" stroke-opacity="0.8" stroke-width="2" filter="url(#neon)"/></g>
-  <circle cx="1142" cy="336" r="7" fill="#a3e635"/>
-  <text x="1065" y="415" class="hn" fill="#a3e635" text-anchor="middle">codex</text>
-  <text x="1065" y="458" class="st" fill="#a3e635" text-anchor="middle">running →</text>
+  <g filter="url(#soft)"><rect x="950" y="300" width="230" height="210" rx="20" fill="#B6E84A" fill-opacity="0.08" stroke="#B6E84A" stroke-opacity="0.8" stroke-width="2" filter="url(#neon)"/></g>
+  <circle cx="1142" cy="336" r="7" fill="#B6E84A"/>
+  <text x="1065" y="415" class="hn" fill="#B6E84A" text-anchor="middle">codex</text>
+  <text x="1065" y="458" class="st" fill="#B6E84A" text-anchor="middle">running →</text>
 
   <line x1="1182" y1="405" x2="1238" y2="405" stroke="#3a425e" stroke-width="3" marker-end="url(#arG)"/>
 
@@ -78,5 +78,5 @@
 
   <!-- footer -->
   <text x="100" y="792" class="note">Same project, same config — the <tspan class="noteA">next agent picks up seamlessly</tspan> when one runs dry.</text>
-  <text x="100" y="830" class="note">Single-typo names auto-correct — <tspan class="mm" font-size="17">agents view cladue</tspan> resolves to <tspan class="mm" font-size="17" style="fill:#a3e635">claude</tspan>.</text>
+  <text x="100" y="830" class="note">Single-typo names auto-correct — <tspan class="mm" font-size="17">agents view cladue</tspan> resolves to <tspan class="mm" font-size="17" style="fill:#B6E84A">claude</tspan>.</text>
 </svg>

--- a/assets/sessions.svg
+++ b/assets/sessions.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" role="img" aria-label="agents sessions searches every agent's transcripts at once — Claude, Codex, Gemini, OpenCode — from one query, backed by a SQLite+FTS5 index; --active shows every live run and what it is doing right now (working, waiting for input, or idle) with the PR and worktree it owns.">
   <defs>
     <radialGradient id="gAmber" cx="10%" cy="0%" r="70%"><stop offset="0%" stop-color="#f5c451" stop-opacity="0.12"/><stop offset="60%" stop-color="#f5c451" stop-opacity="0"/></radialGradient>
-    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#a3e635" stop-opacity="0.10"/><stop offset="60%" stop-color="#a3e635" stop-opacity="0"/></radialGradient>
+    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#B6E84A" stop-opacity="0.10"/><stop offset="60%" stop-color="#B6E84A" stop-opacity="0"/></radialGradient>
     <pattern id="grid" width="46" height="46" patternUnits="userSpaceOnUse"><path d="M 46 0 L 0 0 0 46" fill="none" stroke="#6b8dff" stroke-opacity="0.06" stroke-width="1"/></pattern>
-    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#f7d47a"/><stop offset="52%" stop-color="#f5c451"/><stop offset="100%" stop-color="#a3e635"/></linearGradient>
+    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#f7d47a"/><stop offset="52%" stop-color="#f5c451"/><stop offset="100%" stop-color="#B6E84A"/></linearGradient>
     <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/></linearGradient>
     <linearGradient id="term" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0c1016"/><stop offset="100%" stop-color="#070a0e"/></linearGradient>
     <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
@@ -30,7 +30,7 @@
   <rect width="1600" height="920" fill="url(#gAmber)"/>
   <rect width="1600" height="920" fill="url(#gLime)"/>
 
-  <text x="100" y="98" class="kick">AGENTS SESSIONS<tspan fill="#a3e635"> · SEARCH + LIVE STATE, EVERY AGENT</tspan></text>
+  <text x="100" y="98" class="kick">AGENTS SESSIONS<tspan fill="#B6E84A"> · SEARCH + LIVE STATE, EVERY AGENT</tspan></text>
   <text x="98" y="162" class="h1" fill="#f5c451" opacity="0.34" filter="url(#halo)">Every conversation. Every agent. One search.</text>
   <text x="98" y="162" class="h1" fill="url(#title)">Every conversation. Every agent. One search.</text>
   <text x="100" y="204" class="sub">Claude, Codex, Gemini, OpenCode — searched together; live runs shown by what they're doing now.</text>
@@ -44,7 +44,7 @@
 
   <!-- result rows -->
   <g>
-    <rect x="122" y="392" width="86" height="32" rx="8" fill="#a3e635" fill-opacity="0.14" stroke="#a3e635" stroke-opacity="0.4"/><text x="165" y="414" class="chip" fill="#a3e635" text-anchor="middle">claude</text>
+    <rect x="122" y="392" width="86" height="32" rx="8" fill="#B6E84A" fill-opacity="0.14" stroke="#B6E84A" stroke-opacity="0.4"/><text x="165" y="414" class="chip" fill="#B6E84A" text-anchor="middle">claude</text>
     <text x="226" y="414" class="snip">…rotate the auth-middleware token before…</text>
     <text x="878" y="414" class="mm" text-anchor="end">2d</text>
   </g>
@@ -69,16 +69,16 @@
   <text x="122" y="668" class="mm">SQLite + FTS5 · warm reads ~100ms · --json / --markdown</text>
 
   <!-- ===== LIVE (right) ===== -->
-  <g filter="url(#soft)"><rect x="930" y="272" width="580" height="430" rx="20" fill="url(#term)" stroke="#a3e635" stroke-opacity="0.5" stroke-width="1.6"/></g>
-  <circle cx="962" cy="310" r="6" fill="#a3e635" filter="url(#neon)"/>
-  <text x="984" y="316" class="lab" fill="#a3e635">LIVE · agents sessions --active</text>
+  <g filter="url(#soft)"><rect x="930" y="272" width="580" height="430" rx="20" fill="url(#term)" stroke="#B6E84A" stroke-opacity="0.5" stroke-width="1.6"/></g>
+  <circle cx="962" cy="310" r="6" fill="#B6E84A" filter="url(#neon)"/>
+  <text x="984" y="316" class="lab" fill="#B6E84A">LIVE · agents sessions --active</text>
   <line x1="962" y1="336" x2="1478" y2="336" stroke="#1e2717" stroke-width="1"/>
 
   <!-- working -->
-  <circle cx="972" cy="392" r="8" fill="#a3e635" filter="url(#neon)"/>
+  <circle cx="972" cy="392" r="8" fill="#B6E84A" filter="url(#neon)"/>
   <text x="996" y="398" class="st">refactor-auth</text>
-  <text x="996" y="424" class="sm" fill="#a3e635">working · editing auth.ts</text>
-  <rect x="1330" y="378" width="148" height="30" rx="8" fill="#a3e635" fill-opacity="0.12" stroke="#a3e635" stroke-opacity="0.3"/><text x="1404" y="398" class="sm" fill="#a3e635" text-anchor="middle">PR #1249</text>
+  <text x="996" y="424" class="sm" fill="#B6E84A">working · editing auth.ts</text>
+  <rect x="1330" y="378" width="148" height="30" rx="8" fill="#B6E84A" fill-opacity="0.12" stroke="#B6E84A" stroke-opacity="0.3"/><text x="1404" y="398" class="sm" fill="#B6E84A" text-anchor="middle">PR #1249</text>
   <line x1="962" y1="456" x2="1478" y2="456" stroke="#161b26" stroke-width="1"/>
   <!-- waiting -->
   <circle cx="972" cy="504" r="8" fill="#f5c451"/>

--- a/assets/sessions.svg
+++ b/assets/sessions.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" role="img" aria-label="agents sessions searches every agent's transcripts at once — Claude, Codex, Gemini, OpenCode — from one query, backed by a SQLite+FTS5 index; --active shows every live run and what it is doing right now (working, waiting for input, or idle) with the PR and worktree it owns.">
+  <defs>
+    <radialGradient id="gAmber" cx="10%" cy="0%" r="70%"><stop offset="0%" stop-color="#f5c451" stop-opacity="0.12"/><stop offset="60%" stop-color="#f5c451" stop-opacity="0"/></radialGradient>
+    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#a3e635" stop-opacity="0.10"/><stop offset="60%" stop-color="#a3e635" stop-opacity="0"/></radialGradient>
+    <pattern id="grid" width="46" height="46" patternUnits="userSpaceOnUse"><path d="M 46 0 L 0 0 0 46" fill="none" stroke="#6b8dff" stroke-opacity="0.06" stroke-width="1"/></pattern>
+    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#f7d47a"/><stop offset="52%" stop-color="#f5c451"/><stop offset="100%" stop-color="#a3e635"/></linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/></linearGradient>
+    <linearGradient id="term" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0c1016"/><stop offset="100%" stop-color="#070a0e"/></linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="neon" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="halo" x="-30%" y="-60%" width="160%" height="220%"><feGaussianBlur stdDeviation="7"/></filter>
+    <style><![CDATA[
+      .kick{font:600 14px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.34em;fill:#f5c451;}
+      .h1{font:800 52px Inter,-apple-system,"SF Pro Display",system-ui,sans-serif;letter-spacing:-.02em;}
+      .sub{font:400 22px Inter,-apple-system,system-ui,sans-serif;fill:#8a90b8;}
+      .lab{font:600 12px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.24em;fill:#6b7099;}
+      .m{font:500 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
+      .mm{font:500 17px ui-monospace,"SF Mono",Menlo,monospace;fill:#7a80a8;}
+      .chip{font:700 14px ui-monospace,"SF Mono",Menlo,monospace;}
+      .snip{font:500 18px ui-monospace,"SF Mono",Menlo,monospace;fill:#c7cde8;}
+      .st{font:600 18px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
+      .sm{font:500 15px ui-monospace,"SF Mono",Menlo,monospace;fill:#7a80a8;}
+      .note{font:400 19px Inter,-apple-system,system-ui,sans-serif;fill:#7a80a8;}
+      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#f5c451;}
+    ]]></style>
+  </defs>
+
+  <rect width="1600" height="920" fill="#08080f"/>
+  <rect width="1600" height="920" fill="url(#grid)"/>
+  <rect width="1600" height="920" fill="url(#gAmber)"/>
+  <rect width="1600" height="920" fill="url(#gLime)"/>
+
+  <text x="100" y="98" class="kick">AGENTS SESSIONS<tspan fill="#a3e635"> · SEARCH + LIVE STATE, EVERY AGENT</tspan></text>
+  <text x="98" y="162" class="h1" fill="#f5c451" opacity="0.34" filter="url(#halo)">Every conversation. Every agent. One search.</text>
+  <text x="98" y="162" class="h1" fill="url(#title)">Every conversation. Every agent. One search.</text>
+  <text x="100" y="204" class="sub">Claude, Codex, Gemini, OpenCode — searched together; live runs shown by what they're doing now.</text>
+
+  <!-- ===== SEARCH + RESULTS (left) ===== -->
+  <g filter="url(#soft)"><rect x="90" y="272" width="812" height="430" rx="20" fill="url(#glass)" stroke="#f5c451" stroke-opacity="0.28" stroke-width="1.5"/></g>
+  <text x="870" y="312" class="lab" text-anchor="end">SEARCH</text>
+  <rect x="122" y="300" width="708" height="52" rx="12" fill="#12161f" stroke="#2a3346" stroke-width="1"/>
+  <circle cx="152" cy="326" r="9" fill="none" stroke="#f5c451" stroke-width="2.4"/><line x1="159" y1="333" x2="167" y2="341" stroke="#f5c451" stroke-width="2.4"/>
+  <text x="184" y="333" class="m" font-size="20">agents sessions <tspan fill="#f5c451">"auth middleware"</tspan></text>
+
+  <!-- result rows -->
+  <g>
+    <rect x="122" y="392" width="86" height="32" rx="8" fill="#a3e635" fill-opacity="0.14" stroke="#a3e635" stroke-opacity="0.4"/><text x="165" y="414" class="chip" fill="#a3e635" text-anchor="middle">claude</text>
+    <text x="226" y="414" class="snip">…rotate the auth-middleware token before…</text>
+    <text x="878" y="414" class="mm" text-anchor="end">2d</text>
+  </g>
+  <line x1="122" y1="440" x2="878" y2="440" stroke="#1a2130" stroke-width="1"/>
+  <g>
+    <rect x="122" y="456" width="86" height="32" rx="8" fill="#22d3ee" fill-opacity="0.14" stroke="#22d3ee" stroke-opacity="0.4"/><text x="165" y="478" class="chip" fill="#22d3ee" text-anchor="middle">codex</text>
+    <text x="226" y="478" class="snip">fixed the 401 on refresh — see auth.ts…</text>
+    <text x="878" y="478" class="mm" text-anchor="end">5h</text>
+  </g>
+  <line x1="122" y1="504" x2="878" y2="504" stroke="#1a2130" stroke-width="1"/>
+  <g>
+    <rect x="122" y="520" width="86" height="32" rx="8" fill="#f5c451" fill-opacity="0.14" stroke="#f5c451" stroke-opacity="0.4"/><text x="165" y="542" class="chip" fill="#f5c451" text-anchor="middle">gemini</text>
+    <text x="226" y="542" class="snip">wrote tests for the middleware edge cases…</text>
+    <text x="878" y="542" class="mm" text-anchor="end">1d</text>
+  </g>
+  <line x1="122" y1="568" x2="878" y2="568" stroke="#1a2130" stroke-width="1"/>
+  <g>
+    <rect x="122" y="584" width="86" height="32" rx="8" fill="#e879f9" fill-opacity="0.14" stroke="#e879f9" stroke-opacity="0.4"/><text x="165" y="606" class="chip" fill="#e879f9" text-anchor="middle">opencode</text>
+    <text x="226" y="606" class="snip">migrated session store off the old auth…</text>
+    <text x="878" y="606" class="mm" text-anchor="end">3d</text>
+  </g>
+  <text x="122" y="668" class="mm">SQLite + FTS5 · warm reads ~100ms · --json / --markdown</text>
+
+  <!-- ===== LIVE (right) ===== -->
+  <g filter="url(#soft)"><rect x="930" y="272" width="580" height="430" rx="20" fill="url(#term)" stroke="#a3e635" stroke-opacity="0.5" stroke-width="1.6"/></g>
+  <circle cx="962" cy="310" r="6" fill="#a3e635" filter="url(#neon)"/>
+  <text x="984" y="316" class="lab" fill="#a3e635">LIVE · agents sessions --active</text>
+  <line x1="962" y1="336" x2="1478" y2="336" stroke="#1e2717" stroke-width="1"/>
+
+  <!-- working -->
+  <circle cx="972" cy="392" r="8" fill="#a3e635" filter="url(#neon)"/>
+  <text x="996" y="398" class="st">refactor-auth</text>
+  <text x="996" y="424" class="sm" fill="#a3e635">working · editing auth.ts</text>
+  <rect x="1330" y="378" width="148" height="30" rx="8" fill="#a3e635" fill-opacity="0.12" stroke="#a3e635" stroke-opacity="0.3"/><text x="1404" y="398" class="sm" fill="#a3e635" text-anchor="middle">PR #1249</text>
+  <line x1="962" y1="456" x2="1478" y2="456" stroke="#161b26" stroke-width="1"/>
+  <!-- waiting -->
+  <circle cx="972" cy="504" r="8" fill="#f5c451"/>
+  <text x="996" y="510" class="st">migrate-store</text>
+  <text x="996" y="536" class="sm" fill="#f5c451">waiting_input · plan review</text>
+  <rect x="1310" y="490" width="168" height="30" rx="8" fill="#f5c451" fill-opacity="0.10" stroke="#f5c451" stroke-opacity="0.3"/><text x="1394" y="510" class="sm" fill="#f5c451" text-anchor="middle">wt/migrate</text>
+  <line x1="962" y1="568" x2="1478" y2="568" stroke="#161b26" stroke-width="1"/>
+  <!-- idle -->
+  <circle cx="972" cy="616" r="8" fill="#6b7099"/>
+  <text x="996" y="622" class="st" fill="#c7cde8">nightly-drain</text>
+  <text x="996" y="648" class="sm">idle · queue empty</text>
+  <rect x="1350" y="602" width="128" height="30" rx="8" fill="#ffffff" fill-opacity="0.04" stroke="#3a425e"/><text x="1414" y="622" class="sm" text-anchor="middle">RUSH-1782</text>
+
+  <!-- footer -->
+  <text x="100" y="792" class="note">One index across every harness — <tspan class="noteA">search the past, watch the present</tspan>, from anywhere on the fleet.</text>
+  <text x="100" y="830" class="note"><tspan class="mm" font-size="17">agents sessions focus &lt;id&gt;</tspan>  jumps back into a live run in place — the tmux split, locally or over SSH.</text>
+</svg>

--- a/assets/teams.svg
+++ b/assets/teams.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" role="img" aria-label="agents teams: a supervisor (teams start) fans out to three teammate agents that run in dependency order — researcher (claude), then migrator (codex, --after researcher), then tester (claude, --after migrator). Each runs detached in its own git worktree with explicit file ownership.">
+  <defs>
+    <radialGradient id="gMag" cx="10%" cy="0%" r="70%"><stop offset="0%" stop-color="#e879f9" stop-opacity="0.13"/><stop offset="60%" stop-color="#e879f9" stop-opacity="0"/></radialGradient>
+    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#a3e635" stop-opacity="0.10"/><stop offset="60%" stop-color="#a3e635" stop-opacity="0"/></radialGradient>
+    <pattern id="grid" width="46" height="46" patternUnits="userSpaceOnUse"><path d="M 46 0 L 0 0 0 46" fill="none" stroke="#6b8dff" stroke-opacity="0.06" stroke-width="1"/></pattern>
+    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#f0a6ff"/><stop offset="55%" stop-color="#e879f9"/><stop offset="100%" stop-color="#a3e635"/></linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/></linearGradient>
+    <linearGradient id="term" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#120c16"/><stop offset="100%" stop-color="#0a070e"/></linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="neon" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="halo" x="-30%" y="-60%" width="160%" height="220%"><feGaussianBlur stdDeviation="7"/></filter>
+    <marker id="arM" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#e879f9"/></marker>
+    <style><![CDATA[
+      .kick{font:600 14px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.34em;fill:#e879f9;}
+      .h1{font:800 52px Inter,-apple-system,"SF Pro Display",system-ui,sans-serif;letter-spacing:-.02em;}
+      .sub{font:400 22px Inter,-apple-system,system-ui,sans-serif;fill:#8a90b8;}
+      .lab{font:600 12px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.22em;fill:#6b7099;}
+      .nm{font:700 24px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
+      .role{font:500 17px ui-monospace,"SF Mono",Menlo,monospace;fill:#8a90b8;}
+      .task{font:500 18px Inter,-apple-system,system-ui,sans-serif;fill:#c8cce8;}
+      .dep{font:600 15px ui-monospace,"SF Mono",Menlo,monospace;fill:#e879f9;}
+      .wt{font:600 14px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .sup{font:700 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#e879f9;}
+      .edge{font:600 13px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.14em;}
+      .note{font:400 19px Inter,-apple-system,system-ui,sans-serif;fill:#7a80a8;}
+      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#a3e635;}
+    ]]></style>
+  </defs>
+
+  <rect width="1600" height="920" fill="#08080f"/>
+  <rect width="1600" height="920" fill="url(#grid)"/>
+  <rect width="1600" height="920" fill="url(#gMag)"/>
+  <rect width="1600" height="920" fill="url(#gLime)"/>
+
+  <text x="100" y="98" class="kick">AGENTS TEAMS<tspan fill="#a3e635"> · PARALLEL AGENTS, DEPENDENCY-ORDERED</tspan></text>
+  <text x="98" y="162" class="h1" fill="#e879f9" opacity="0.36" filter="url(#halo)">A team of agents. Boundary contracts. One task.</text>
+  <text x="98" y="162" class="h1" fill="url(#title)">A team of agents. Boundary contracts. One task.</text>
+  <text x="100" y="204" class="sub">Teammates run detached in their own worktrees — close your terminal, they keep working.</text>
+
+  <!-- supervisor -->
+  <g filter="url(#soft)"><rect x="96" y="366" width="230" height="150" rx="20" fill="url(#term)" stroke="#e879f9" stroke-opacity="0.5" stroke-width="1.6"/></g>
+  <text x="128" y="420" class="lab" fill="#e879f9">SUPERVISOR</text>
+  <text x="128" y="462" class="sup">teams start</text>
+  <text x="128" y="494" class="role" font-size="15">fires ready deps →</text>
+
+  <!-- fan arrows from supervisor to the 3 cards -->
+  <path d="M330 420 C 400 420 400 400 470 400" stroke="#e879f9" stroke-width="2.5" fill="none" marker-end="url(#arM)" filter="url(#neon)"/>
+
+  <!-- teammate 1: researcher -->
+  <g filter="url(#soft)"><rect x="486" y="300" width="330" height="196" rx="20" fill="url(#glass)" stroke="#a3e635" stroke-opacity="0.4" stroke-width="1.5"/></g>
+  <circle cx="516" cy="340" r="8" fill="#a3e635" filter="url(#neon)"/>
+  <text x="540" y="348" class="nm">researcher</text>
+  <text x="518" y="392" class="role">claude · working</text>
+  <text x="518" y="430" class="task">"Research auth libraries"</text>
+  <rect x="518" y="450" width="196" height="30" rx="8" fill="#a3e635" fill-opacity="0.1" stroke="#a3e635" stroke-opacity="0.3"/><text x="530" y="470" class="wt">worktree · owns src/auth</text>
+
+  <!-- dep arrow 1->2 -->
+  <line x1="820" y1="398" x2="864" y2="398" stroke="#e879f9" stroke-width="2.5" marker-end="url(#arM)" filter="url(#neon)"/>
+  <text x="842" y="384" class="dep" text-anchor="middle" font-size="13">--after</text>
+
+  <!-- teammate 2: migrator -->
+  <g filter="url(#soft)"><rect x="880" y="300" width="330" height="196" rx="20" fill="url(#glass)" stroke="#22d3ee" stroke-opacity="0.35" stroke-width="1.5"/></g>
+  <circle cx="910" cy="340" r="8" fill="#6b7099"/>
+  <text x="934" y="348" class="nm">migrator</text>
+  <text x="912" y="392" class="role">codex · queued</text>
+  <text x="912" y="430" class="task">"Draft the migration"</text>
+  <rect x="912" y="450" width="150" height="30" rx="8" fill="#22d3ee" fill-opacity="0.08" stroke="#22d3ee" stroke-opacity="0.28"/><text x="924" y="470" class="wt" fill="#5ad6c0">--after researcher</text>
+
+  <!-- dep arrow 2->3 -->
+  <line x1="1214" y1="398" x2="1258" y2="398" stroke="#e879f9" stroke-width="2.5" marker-end="url(#arM)" filter="url(#neon)"/>
+  <text x="1236" y="384" class="dep" text-anchor="middle" font-size="13">--after</text>
+
+  <!-- teammate 3: tester -->
+  <g filter="url(#soft)"><rect x="1274" y="300" width="236" height="196" rx="20" fill="url(#glass)" stroke="#f5c451" stroke-opacity="0.32" stroke-width="1.5"/></g>
+  <circle cx="1304" cy="340" r="8" fill="#6b7099"/>
+  <text x="1328" y="348" class="nm">tester</text>
+  <text x="1306" y="392" class="role">claude · queued</text>
+  <text x="1306" y="430" class="task">"Write tests"</text>
+  <rect x="1306" y="450" width="150" height="30" rx="8" fill="#f5c451" fill-opacity="0.08" stroke="#f5c451" stroke-opacity="0.26"/><text x="1318" y="470" class="wt" fill="#f5c451">--after migrator</text>
+
+  <!-- footer -->
+  <text x="100" y="792" class="note">Each teammate <tspan class="noteA">owns explicit files</tspan> — one canonical owner per shared dep. No cross-writes.</text>
+  <text x="100" y="830" class="note"><tspan class="role" font-size="17" fill="#8a90b8">agents teams status</tspan>  —  who's working, what they changed, and what they said.</text>
+</svg>

--- a/assets/teams.svg
+++ b/assets/teams.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" role="img" aria-label="agents teams: a supervisor (teams start) fans out to three teammate agents that run in dependency order — researcher (claude), then migrator (codex, --after researcher), then tester (claude, --after migrator). Each runs detached in its own git worktree with explicit file ownership.">
   <defs>
     <radialGradient id="gMag" cx="10%" cy="0%" r="70%"><stop offset="0%" stop-color="#e879f9" stop-opacity="0.13"/><stop offset="60%" stop-color="#e879f9" stop-opacity="0"/></radialGradient>
-    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#a3e635" stop-opacity="0.10"/><stop offset="60%" stop-color="#a3e635" stop-opacity="0"/></radialGradient>
+    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#B6E84A" stop-opacity="0.10"/><stop offset="60%" stop-color="#B6E84A" stop-opacity="0"/></radialGradient>
     <pattern id="grid" width="46" height="46" patternUnits="userSpaceOnUse"><path d="M 46 0 L 0 0 0 46" fill="none" stroke="#6b8dff" stroke-opacity="0.06" stroke-width="1"/></pattern>
-    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#f0a6ff"/><stop offset="55%" stop-color="#e879f9"/><stop offset="100%" stop-color="#a3e635"/></linearGradient>
+    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#f0a6ff"/><stop offset="55%" stop-color="#e879f9"/><stop offset="100%" stop-color="#B6E84A"/></linearGradient>
     <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/></linearGradient>
     <linearGradient id="term" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#120c16"/><stop offset="100%" stop-color="#0a070e"/></linearGradient>
     <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
@@ -19,11 +19,11 @@
       .role{font:500 17px ui-monospace,"SF Mono",Menlo,monospace;fill:#8a90b8;}
       .task{font:500 18px Inter,-apple-system,system-ui,sans-serif;fill:#c8cce8;}
       .dep{font:600 15px ui-monospace,"SF Mono",Menlo,monospace;fill:#e879f9;}
-      .wt{font:600 14px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .wt{font:600 14px ui-monospace,"SF Mono",Menlo,monospace;fill:#B6E84A;}
       .sup{font:700 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#e879f9;}
       .edge{font:600 13px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.14em;}
       .note{font:400 19px Inter,-apple-system,system-ui,sans-serif;fill:#7a80a8;}
-      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#a3e635;}
+      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#B6E84A;}
     ]]></style>
   </defs>
 
@@ -32,7 +32,7 @@
   <rect width="1600" height="920" fill="url(#gMag)"/>
   <rect width="1600" height="920" fill="url(#gLime)"/>
 
-  <text x="100" y="98" class="kick">AGENTS TEAMS<tspan fill="#a3e635"> · PARALLEL AGENTS, DEPENDENCY-ORDERED</tspan></text>
+  <text x="100" y="98" class="kick">AGENTS TEAMS<tspan fill="#B6E84A"> · PARALLEL AGENTS, DEPENDENCY-ORDERED</tspan></text>
   <text x="98" y="162" class="h1" fill="#e879f9" opacity="0.36" filter="url(#halo)">A team of agents. Boundary contracts. One task.</text>
   <text x="98" y="162" class="h1" fill="url(#title)">A team of agents. Boundary contracts. One task.</text>
   <text x="100" y="204" class="sub">Teammates run detached in their own worktrees — close your terminal, they keep working.</text>
@@ -44,18 +44,18 @@
   <text x="128" y="494" class="role" font-size="15">fires ready deps →</text>
 
   <!-- fan arrows from supervisor to the 3 cards -->
-  <path d="M330 420 C 400 420 400 400 470 400" stroke="#e879f9" stroke-width="2.5" fill="none" marker-end="url(#arM)" filter="url(#neon)"/>
+  <path d="M330 420 C 400 420 400 400 470 400" stroke="#e879f9" stroke-width="2.5" fill="none" marker-end="url(#arM)"/>
 
   <!-- teammate 1: researcher -->
-  <g filter="url(#soft)"><rect x="486" y="300" width="330" height="196" rx="20" fill="url(#glass)" stroke="#a3e635" stroke-opacity="0.4" stroke-width="1.5"/></g>
-  <circle cx="516" cy="340" r="8" fill="#a3e635" filter="url(#neon)"/>
+  <g filter="url(#soft)"><rect x="486" y="300" width="330" height="196" rx="20" fill="url(#glass)" stroke="#B6E84A" stroke-opacity="0.4" stroke-width="1.5"/></g>
+  <circle cx="516" cy="340" r="8" fill="#B6E84A" filter="url(#neon)"/>
   <text x="540" y="348" class="nm">researcher</text>
   <text x="518" y="392" class="role">claude · working</text>
   <text x="518" y="430" class="task">"Research auth libraries"</text>
-  <rect x="518" y="450" width="196" height="30" rx="8" fill="#a3e635" fill-opacity="0.1" stroke="#a3e635" stroke-opacity="0.3"/><text x="530" y="470" class="wt">worktree · owns src/auth</text>
+  <rect x="518" y="450" width="196" height="30" rx="8" fill="#B6E84A" fill-opacity="0.1" stroke="#B6E84A" stroke-opacity="0.3"/><text x="530" y="470" class="wt">worktree · owns src/auth</text>
 
   <!-- dep arrow 1->2 -->
-  <line x1="820" y1="398" x2="864" y2="398" stroke="#e879f9" stroke-width="2.5" marker-end="url(#arM)" filter="url(#neon)"/>
+  <line x1="820" y1="398" x2="864" y2="398" stroke="#e879f9" stroke-width="2.5" marker-end="url(#arM)"/>
   <text x="842" y="384" class="dep" text-anchor="middle" font-size="13">--after</text>
 
   <!-- teammate 2: migrator -->
@@ -67,7 +67,7 @@
   <rect x="912" y="450" width="150" height="30" rx="8" fill="#22d3ee" fill-opacity="0.08" stroke="#22d3ee" stroke-opacity="0.28"/><text x="924" y="470" class="wt" fill="#5ad6c0">--after researcher</text>
 
   <!-- dep arrow 2->3 -->
-  <line x1="1214" y1="398" x2="1258" y2="398" stroke="#e879f9" stroke-width="2.5" marker-end="url(#arM)" filter="url(#neon)"/>
+  <line x1="1214" y1="398" x2="1258" y2="398" stroke="#e879f9" stroke-width="2.5" marker-end="url(#arM)"/>
   <text x="1236" y="384" class="dep" text-anchor="middle" font-size="13">--after</text>
 
   <!-- teammate 3: tester -->

--- a/assets/workflows.svg
+++ b/assets/workflows.svg
@@ -1,16 +1,16 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" role="img" aria-label="agents workflows: a reusable bundle directory (WORKFLOW.md orchestrator prompt plus optional subagents, skills, and plugins) is invoked as one agent — agents run code-review — and the orchestrator fans work out to its subagents. One bundle, one invocation.">
   <defs>
     <radialGradient id="gCyan" cx="10%" cy="0%" r="70%"><stop offset="0%" stop-color="#22d3ee" stop-opacity="0.13"/><stop offset="60%" stop-color="#22d3ee" stop-opacity="0"/></radialGradient>
-    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#a3e635" stop-opacity="0.11"/><stop offset="60%" stop-color="#a3e635" stop-opacity="0"/></radialGradient>
+    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#B6E84A" stop-opacity="0.11"/><stop offset="60%" stop-color="#B6E84A" stop-opacity="0"/></radialGradient>
     <pattern id="grid" width="46" height="46" patternUnits="userSpaceOnUse"><path d="M 46 0 L 0 0 0 46" fill="none" stroke="#6b8dff" stroke-opacity="0.06" stroke-width="1"/></pattern>
-    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#7fe3ff"/><stop offset="55%" stop-color="#22d3ee"/><stop offset="100%" stop-color="#a3e635"/></linearGradient>
+    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#7fe3ff"/><stop offset="55%" stop-color="#22d3ee"/><stop offset="100%" stop-color="#B6E84A"/></linearGradient>
     <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/></linearGradient>
     <linearGradient id="term" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0c1016"/><stop offset="100%" stop-color="#070a0e"/></linearGradient>
     <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
     <filter id="neon" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
     <filter id="halo" x="-30%" y="-60%" width="160%" height="220%"><feGaussianBlur stdDeviation="7"/></filter>
     <marker id="arL" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#22d3ee"/></marker>
-    <marker id="arG" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#a3e635"/></marker>
+    <marker id="arG" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#B6E84A"/></marker>
     <style><![CDATA[
       .kick{font:600 14px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.34em;fill:#22d3ee;}
       .h1{font:800 52px Inter,-apple-system,"SF Pro Display",system-ui,sans-serif;letter-spacing:-.02em;}
@@ -19,13 +19,13 @@
       .m{font:500 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
       .mm{font:500 18px ui-monospace,"SF Mono",Menlo,monospace;fill:#7a80a8;}
       .mc{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#22d3ee;}
-      .ml{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .ml{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#B6E84A;}
       .tree{font:500 20px ui-monospace,"SF Mono",Menlo,monospace;fill:#7a80a8;}
       .pg{font:600 20px Inter,-apple-system,system-ui,sans-serif;fill:#eaf2ff;}
       .chip{font:700 19px ui-monospace,"SF Mono",Menlo,monospace;fill:#08080f;}
       .edge{font:600 13px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.06em;}
       .note{font:400 19px Inter,-apple-system,system-ui,sans-serif;fill:#7a80a8;}
-      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#a3e635;}
+      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#B6E84A;}
     ]]></style>
   </defs>
 
@@ -34,14 +34,14 @@
   <rect width="1600" height="920" fill="url(#gCyan)"/>
   <rect width="1600" height="920" fill="url(#gLime)"/>
 
-  <text x="100" y="98" class="kick">AGENTS WORKFLOWS<tspan fill="#a3e635"> · ONE BUNDLE, ONE INVOCATION</tspan></text>
+  <text x="100" y="98" class="kick">AGENTS WORKFLOWS<tspan fill="#B6E84A"> · ONE BUNDLE, ONE INVOCATION</tspan></text>
   <text x="98" y="162" class="h1" fill="#22d3ee" opacity="0.34" filter="url(#halo)">Bundle a pipeline. Invoke it like an agent.</text>
   <text x="98" y="162" class="h1" fill="url(#title)">Bundle a pipeline. Invoke it like an agent.</text>
   <text x="100" y="204" class="sub">An orchestrator prompt plus optional subagents, skills, and plugins — named and reusable.</text>
 
   <!-- ===== bundle dir (left) ===== -->
   <g filter="url(#soft)"><rect x="90" y="280" width="560" height="430" rx="20" fill="url(#term)" stroke="#22d3ee" stroke-opacity="0.3" stroke-width="1.5"/></g>
-  <circle cx="122" cy="314" r="6" fill="#fb7185"/><circle cx="144" cy="314" r="6" fill="#f5c451"/><circle cx="166" cy="314" r="6" fill="#a3e635"/>
+  <circle cx="122" cy="314" r="6" fill="#fb7185"/><circle cx="144" cy="314" r="6" fill="#f5c451"/><circle cx="166" cy="314" r="6" fill="#B6E84A"/>
   <text x="620" y="320" class="lab" text-anchor="end">workflow bundle</text>
   <line x1="118" y1="336" x2="622" y2="336" stroke="#1a2230" stroke-width="1"/>
   <text x="122" y="384" class="mc">~/.agents/workflows/code-review/</text>
@@ -54,7 +54,7 @@
   <text x="122" y="676" class="mm" font-size="16">add gh:yourteam/code-review · list · view</text>
 
   <!-- arrow -->
-  <line x1="666" y1="440" x2="752" y2="440" stroke="#22d3ee" stroke-width="3" marker-end="url(#arL)" filter="url(#neon)"/>
+  <line x1="666" y1="440" x2="752" y2="440" stroke="#22d3ee" stroke-width="3" marker-end="url(#arL)"/>
   <text x="709" y="426" class="edge" fill="#22d3ee" text-anchor="middle">RUN</text>
 
   <!-- ===== invocation + fan-out (right) ===== -->
@@ -62,12 +62,12 @@
   <text x="798" y="344" class="m"><tspan fill="#5ad6c0">$</tspan> agents run <tspan class="ml">code-review</tspan> <tspan class="mm">"review PR #42"</tspan></text>
 
   <!-- orchestrator node -->
-  <rect x="1000" y="384" width="276" height="60" rx="16" fill="#a3e635" fill-opacity="0.10" stroke="#a3e635" stroke-opacity="0.7" stroke-width="1.6" filter="url(#neon)"/>
+  <rect x="1000" y="384" width="276" height="60" rx="16" fill="#B6E84A" fill-opacity="0.10" stroke="#B6E84A" stroke-opacity="0.7" stroke-width="1.6" filter="url(#neon)"/>
   <text x="1138" y="422" class="ml" text-anchor="middle">orchestrator</text>
 
   <!-- fan-out arrows -->
-  <path d="M1080 448 C 1080 500, 940 500, 940 548" stroke="#a3e635" stroke-width="2.5" fill="none" marker-end="url(#arG)"/>
-  <path d="M1196 448 C 1196 500, 1336 500, 1336 548" stroke="#a3e635" stroke-width="2.5" fill="none" marker-end="url(#arG)"/>
+  <path d="M1080 448 C 1080 500, 940 500, 940 548" stroke="#B6E84A" stroke-width="2.5" fill="none" marker-end="url(#arG)"/>
+  <path d="M1196 448 C 1196 500, 1336 500, 1336 548" stroke="#B6E84A" stroke-width="2.5" fill="none" marker-end="url(#arG)"/>
 
   <!-- subagent chips -->
   <rect x="838" y="552" width="204" height="60" rx="16" fill="#22d3ee"/><text x="940" y="590" class="chip" text-anchor="middle">security</text>

--- a/assets/workflows.svg
+++ b/assets/workflows.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" role="img" aria-label="agents workflows: a reusable bundle directory (WORKFLOW.md orchestrator prompt plus optional subagents, skills, and plugins) is invoked as one agent — agents run code-review — and the orchestrator fans work out to its subagents. One bundle, one invocation.">
+  <defs>
+    <radialGradient id="gCyan" cx="10%" cy="0%" r="70%"><stop offset="0%" stop-color="#22d3ee" stop-opacity="0.13"/><stop offset="60%" stop-color="#22d3ee" stop-opacity="0"/></radialGradient>
+    <radialGradient id="gLime" cx="92%" cy="-6%" r="70%"><stop offset="0%" stop-color="#a3e635" stop-opacity="0.11"/><stop offset="60%" stop-color="#a3e635" stop-opacity="0"/></radialGradient>
+    <pattern id="grid" width="46" height="46" patternUnits="userSpaceOnUse"><path d="M 46 0 L 0 0 0 46" fill="none" stroke="#6b8dff" stroke-opacity="0.06" stroke-width="1"/></pattern>
+    <linearGradient id="title" x1="0" y1="0" x2="1" y2="0.4"><stop offset="0%" stop-color="#7fe3ff"/><stop offset="55%" stop-color="#22d3ee"/><stop offset="100%" stop-color="#a3e635"/></linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffffff" stop-opacity="0.05"/><stop offset="100%" stop-color="#ffffff" stop-opacity="0.015"/></linearGradient>
+    <linearGradient id="term" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0c1016"/><stop offset="100%" stop-color="#070a0e"/></linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="150%"><feGaussianBlur stdDeviation="18" result="b"/><feOffset dy="14" result="o"/><feColorMatrix in="o" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" result="s"/><feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="neon" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="halo" x="-30%" y="-60%" width="160%" height="220%"><feGaussianBlur stdDeviation="7"/></filter>
+    <marker id="arL" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#22d3ee"/></marker>
+    <marker id="arG" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#a3e635"/></marker>
+    <style><![CDATA[
+      .kick{font:600 14px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.34em;fill:#22d3ee;}
+      .h1{font:800 52px Inter,-apple-system,"SF Pro Display",system-ui,sans-serif;letter-spacing:-.02em;}
+      .sub{font:400 22px Inter,-apple-system,system-ui,sans-serif;fill:#8a90b8;}
+      .lab{font:600 12px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.24em;fill:#6b7099;}
+      .m{font:500 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#eaf2ff;}
+      .mm{font:500 18px ui-monospace,"SF Mono",Menlo,monospace;fill:#7a80a8;}
+      .mc{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#22d3ee;}
+      .ml{font:600 21px ui-monospace,"SF Mono",Menlo,monospace;fill:#a3e635;}
+      .tree{font:500 20px ui-monospace,"SF Mono",Menlo,monospace;fill:#7a80a8;}
+      .pg{font:600 20px Inter,-apple-system,system-ui,sans-serif;fill:#eaf2ff;}
+      .chip{font:700 19px ui-monospace,"SF Mono",Menlo,monospace;fill:#08080f;}
+      .edge{font:600 13px ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.06em;}
+      .note{font:400 19px Inter,-apple-system,system-ui,sans-serif;fill:#7a80a8;}
+      .noteA{font:600 19px Inter,-apple-system,system-ui,sans-serif;fill:#a3e635;}
+    ]]></style>
+  </defs>
+
+  <rect width="1600" height="920" fill="#08080f"/>
+  <rect width="1600" height="920" fill="url(#grid)"/>
+  <rect width="1600" height="920" fill="url(#gCyan)"/>
+  <rect width="1600" height="920" fill="url(#gLime)"/>
+
+  <text x="100" y="98" class="kick">AGENTS WORKFLOWS<tspan fill="#a3e635"> · ONE BUNDLE, ONE INVOCATION</tspan></text>
+  <text x="98" y="162" class="h1" fill="#22d3ee" opacity="0.34" filter="url(#halo)">Bundle a pipeline. Invoke it like an agent.</text>
+  <text x="98" y="162" class="h1" fill="url(#title)">Bundle a pipeline. Invoke it like an agent.</text>
+  <text x="100" y="204" class="sub">An orchestrator prompt plus optional subagents, skills, and plugins — named and reusable.</text>
+
+  <!-- ===== bundle dir (left) ===== -->
+  <g filter="url(#soft)"><rect x="90" y="280" width="560" height="430" rx="20" fill="url(#term)" stroke="#22d3ee" stroke-opacity="0.3" stroke-width="1.5"/></g>
+  <circle cx="122" cy="314" r="6" fill="#fb7185"/><circle cx="144" cy="314" r="6" fill="#f5c451"/><circle cx="166" cy="314" r="6" fill="#a3e635"/>
+  <text x="620" y="320" class="lab" text-anchor="end">workflow bundle</text>
+  <line x1="118" y1="336" x2="622" y2="336" stroke="#1a2230" stroke-width="1"/>
+  <text x="122" y="384" class="mc">~/.agents/workflows/code-review/</text>
+  <text x="122" y="428" class="ml">├─ WORKFLOW.md<tspan class="mm">   orchestrator</tspan></text>
+  <text x="122" y="468" class="tree">├─ subagents/</text>
+  <text x="160" y="506" class="m" font-size="19">│   ├─ security.md</text>
+  <text x="160" y="542" class="m" font-size="19">│   └─ style.md</text>
+  <text x="122" y="580" class="tree">├─ skills/</text>
+  <text x="122" y="618" class="tree">└─ plugins/</text>
+  <text x="122" y="676" class="mm" font-size="16">add gh:yourteam/code-review · list · view</text>
+
+  <!-- arrow -->
+  <line x1="666" y1="440" x2="752" y2="440" stroke="#22d3ee" stroke-width="3" marker-end="url(#arL)" filter="url(#neon)"/>
+  <text x="709" y="426" class="edge" fill="#22d3ee" text-anchor="middle">RUN</text>
+
+  <!-- ===== invocation + fan-out (right) ===== -->
+  <g filter="url(#soft)"><rect x="766" y="280" width="744" height="430" rx="20" fill="url(#glass)" stroke="#3a425e" stroke-width="1.5"/></g>
+  <text x="798" y="344" class="m"><tspan fill="#5ad6c0">$</tspan> agents run <tspan class="ml">code-review</tspan> <tspan class="mm">"review PR #42"</tspan></text>
+
+  <!-- orchestrator node -->
+  <rect x="1000" y="384" width="276" height="60" rx="16" fill="#a3e635" fill-opacity="0.10" stroke="#a3e635" stroke-opacity="0.7" stroke-width="1.6" filter="url(#neon)"/>
+  <text x="1138" y="422" class="ml" text-anchor="middle">orchestrator</text>
+
+  <!-- fan-out arrows -->
+  <path d="M1080 448 C 1080 500, 940 500, 940 548" stroke="#a3e635" stroke-width="2.5" fill="none" marker-end="url(#arG)"/>
+  <path d="M1196 448 C 1196 500, 1336 500, 1336 548" stroke="#a3e635" stroke-width="2.5" fill="none" marker-end="url(#arG)"/>
+
+  <!-- subagent chips -->
+  <rect x="838" y="552" width="204" height="60" rx="16" fill="#22d3ee"/><text x="940" y="590" class="chip" text-anchor="middle">security</text>
+  <rect x="1234" y="552" width="204" height="60" rx="16" fill="#22d3ee"/><text x="1336" y="590" class="chip" text-anchor="middle">style</text>
+  <text x="1138" y="672" class="mm" text-anchor="middle" font-size="17">one invocation runs the whole pipeline</text>
+
+  <!-- footer -->
+  <text x="100" y="792" class="note">A workflow is a <tspan class="noteA">directory</tspan> — the name goes in the agent slot, and the orchestrator drives its subagents.</text>
+  <text x="100" y="830" class="note"><tspan class="mm" font-size="17">agents workflows add gh:yourteam/code-review</tspan>  ·  install from GitHub or a local path.</text>
+</svg>


### PR DESCRIPTION
Follow-up to the Monitors README section: adds a hand-authored **`assets/monitors.svg`** diagram and embeds it at the top of the section, for visual parity with the existing `fleet-control.svg`.

The diagram renders the **source → condition → action** flow as three gradient cards (the action card lime-glowing), in the repo's terminal-coded house style (grid + vignette background, `#B6E84A` lime, glow/shadow filters, SF/mono typography), with a `--device owner · exactly-once` chip and the cross-agent framing. Rendered + eyeballed at 1600px before commit.

Docs/asset only.