### PR TITLE
feat(sessions): interactive fleet-wide session browser (RUSH-1802)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,24 @@
   session databases migrate additively and backfill on the next scan (the first
   run re-indexes once).
 
+- **Interactive session browser — `agents sessions --active` and a bare `agents sessions`
+  now open a live, filterable picker on a TTY (RUSH-1802).** One canonical filter driven by
+  single keys, re-pulled across the fleet as you toggle: `s` search, `r` running-only, `c`
+  teams, `a` agent (cycles), `d` device (cycles), `p` this-repo↔all-dirs, `w` time window;
+  filters **stack** (AND together) and the active set shows in the header, with a live
+  preview of the highlighted row and `⏎` to resume/attach via the existing dispatch. Every
+  hotkey mirrors a flag, so the view is reproducible as a command — `y` copies (and
+  `--print-cmd` prints) the exact `ag sessions …` line the filters map to, bridging the
+  human picker and the agent/script flag surface. The interactive front-end is TTY-only:
+  `--json`, a pipe, or the new `--no-interactive` keep the existing static listing verbatim,
+  so scripts and headless agents are unchanged. Adds `-p` as the short form of `--project`,
+  `--print-cmd`, `--preview` (`agents sessions <id> --preview` prints the compact digest
+  without the pager), and `--no-interactive`. Built on a new async-refetch `dynamicPicker`
+  variant that reuses the existing render/pagination/preview machinery, the fleet SSH
+  fan-out, and the resume/focus path. Source: `apps/cli/src/lib/picker.ts` (`dynamicPicker`),
+  `apps/cli/src/commands/sessions-browser.ts` (+ `sessions-browser.test.ts`),
+  `apps/cli/src/commands/sessions.ts`.
+
 ## 1.20.58
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -236,6 +236,22 @@ agents sessions --active            # every live run across the fleet, with stat
 agents sessions focus a1b2c3d4      # jump back into one — attach in place, or resume
 ```
 
+On a terminal, `agents sessions --active` (and a bare `agents sessions`) open the **interactive session browser** — one filter you drive with single keys, re-pulled live across the fleet:
+
+| key | filters by | flag it mirrors |
+|---|---|---|
+| `s` | search text | `--query` / positional |
+| `r` | running only | `--active` |
+| `c` | team sessions | `--teams` |
+| `a` | agent (cycles) | `-a` |
+| `d` | device (cycles) | `--device` |
+| `p` | this repo ↔ all dirs | `--all` |
+| `w` | time window | `--since` |
+| `⏎` | resume / attach | `resume` / `focus` |
+| `y` | copy the equivalent command | `--print-cmd` |
+
+Filters **stack** (they AND together), the active set shows in the header, and the highlighted row previews below. Because every hotkey has a flag, the view you build by hand is a real command: press `y` (or run `--print-cmd`) to get the exact `ag sessions …` line — explore interactively, hand the line to an agent. Piped output, `--json`, or `--no-interactive` keep the plain listing for scripts. Peek without opening the pager with `agents sessions <id> --preview`.
+
 Each live session resolves to `working`, `waiting_input` (with why -- a question, a plan review, or a permission prompt), or `idle`, alongside badges for the PR it opened, the worktree it sits in, and the ticket it's working. `agents sessions focus [id]` attaches the live pane in place -- the tmux split locally or over SSH, or its Ghostty tab -- and falls back to a fresh tab + resume when the terminal is gone.
 
 Landing on a session cold? `agents sessions <id>` prints a catch-up digest: an inferred title, files changed grouped by directory (created / modified / deleted), a histogram of which tools did the work, and the last test verdict -- the signals to reload a task in seconds.

--- a/apps/cli/src/commands/sessions-browser.test.ts
+++ b/apps/cli/src/commands/sessions-browser.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'bun:test';
+import { browserFilterToArgv, cycle, cycleWindow, type BrowserFilter } from './sessions-browser.js';
+
+const base: BrowserFilter = {
+  running: false,
+  teams: false,
+  agent: undefined,
+  device: undefined,
+  projectScope: 'repo',
+  window: undefined,
+};
+
+describe('browserFilterToArgv — the human↔agent contract', () => {
+  it('an empty repo-scoped filter is just `sessions`', () => {
+    // projectScope 'repo' is the default view, so it emits no flag.
+    expect(browserFilterToArgv(base)).toEqual(['sessions']);
+  });
+
+  it('running-only maps to --active', () => {
+    expect(browserFilterToArgv({ ...base, running: true })).toEqual(['sessions', '--active']);
+  });
+
+  it('all-dirs scope maps to --all; repo scope emits nothing', () => {
+    expect(browserFilterToArgv({ ...base, projectScope: 'all' })).toEqual(['sessions', '--all']);
+    expect(browserFilterToArgv({ ...base, projectScope: 'repo' })).toEqual(['sessions']);
+  });
+
+  it('stacks every dimension in a stable, reproducible order', () => {
+    const f: BrowserFilter = {
+      running: true,
+      teams: true,
+      agent: 'claude',
+      device: 'zion',
+      projectScope: 'all',
+      window: '7d',
+    };
+    expect(browserFilterToArgv(f)).toEqual([
+      'sessions',
+      '--active',
+      '--teams',
+      '-a',
+      'claude',
+      '--device',
+      'zion',
+      '--all',
+      '--since',
+      '7d',
+    ]);
+  });
+
+  it('appends a search query as a quoted positional', () => {
+    expect(browserFilterToArgv({ ...base, agent: 'codex' }, 'auth bug')).toEqual([
+      'sessions',
+      '-a',
+      'codex',
+      '"auth bug"',
+    ]);
+  });
+
+  it('ignores a blank query', () => {
+    expect(browserFilterToArgv(base, '   ')).toEqual(['sessions']);
+  });
+});
+
+describe('cycle — [none, ...options] wrapping for A/D hotkeys', () => {
+  it('none → first → … → last → none', () => {
+    const opts = ['claude', 'codex', 'droid'];
+    expect(cycle(undefined, opts)).toBe('claude');
+    expect(cycle('claude', opts)).toBe('codex');
+    expect(cycle('droid', opts)).toBeUndefined(); // wraps back to "all"
+  });
+
+  it('a value no longer in the pool restarts at the first option', () => {
+    // findIndex returns -1 → (-1 + 1) % len === 0 → first entry (undefined).
+    expect(cycle('gone', ['claude'])).toBeUndefined();
+  });
+
+  it('an empty pool always yields none', () => {
+    expect(cycle(undefined, [])).toBeUndefined();
+  });
+});
+
+describe('cycleWindow — W hotkey', () => {
+  it('cycles all → 1d → 7d → 30d → all', () => {
+    expect(cycleWindow(undefined)).toBe('1d');
+    expect(cycleWindow('1d')).toBe('7d');
+    expect(cycleWindow('7d')).toBe('30d');
+    expect(cycleWindow('30d')).toBeUndefined();
+  });
+});

--- a/apps/cli/src/commands/sessions-browser.test.ts
+++ b/apps/cli/src/commands/sessions-browser.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect } from 'vitest';
 import {
   browserFilterToArgv,
   cycle,

--- a/apps/cli/src/commands/sessions-browser.test.ts
+++ b/apps/cli/src/commands/sessions-browser.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect } from 'bun:test';
-import { browserFilterToArgv, cycle, cycleWindow, type BrowserFilter } from './sessions-browser.js';
+import {
+  browserFilterToArgv,
+  cycle,
+  cycleWindow,
+  sessionMatchesQuery,
+  type BrowserFilter,
+} from './sessions-browser.js';
+import type { SessionMeta } from '../lib/session/types.js';
+
+const row = (over: Partial<SessionMeta> = {}): SessionMeta =>
+  ({
+    id: 'x',
+    shortId: 'a1b2c3d4',
+    agent: 'claude',
+    timestamp: '2026-07-16T00:00:00Z',
+    filePath: '/tmp/x.jsonl',
+    project: 'my-app',
+    topic: "Review Taylor's PRs and release",
+    ...over,
+  }) as SessionMeta;
 
 const base: BrowserFilter = {
   running: false,
@@ -86,5 +105,31 @@ describe('cycleWindow — W hotkey', () => {
     expect(cycleWindow('1d')).toBe('7d');
     expect(cycleWindow('7d')).toBe('30d');
     expect(cycleWindow('30d')).toBeUndefined();
+  });
+});
+
+describe('sessionMatchesQuery — the S search predicate (cheap, not FTS)', () => {
+  it('empty query matches everything', () => {
+    expect(sessionMatchesQuery(row(), '')).toBe(true);
+    expect(sessionMatchesQuery(row(), '   ')).toBe(true);
+  });
+
+  it('matches case-insensitively across topic / project / id', () => {
+    expect(sessionMatchesQuery(row(), 'taylor')).toBe(true); // topic
+    expect(sessionMatchesQuery(row(), 'MY-APP')).toBe(true); // project
+    expect(sessionMatchesQuery(row(), 'a1b2')).toBe(true); // shortId prefix
+  });
+
+  it('requires every whitespace-separated term (AND)', () => {
+    expect(sessionMatchesQuery(row(), 'taylor release')).toBe(true);
+    expect(sessionMatchesQuery(row(), 'taylor nope')).toBe(false);
+  });
+
+  it('non-matching query excludes the row', () => {
+    expect(sessionMatchesQuery(row(), 'zzzznomatch')).toBe(false);
+  });
+
+  it('matches the ticket/PR ref', () => {
+    expect(sessionMatchesQuery(row({ prNumber: 1248 }), 'pr#1248')).toBe(true);
   });
 });

--- a/apps/cli/src/commands/sessions-browser.test.ts
+++ b/apps/cli/src/commands/sessions-browser.test.ts
@@ -4,6 +4,9 @@ import {
   cycle,
   cycleWindow,
   sessionMatchesQuery,
+  normalizeDeviceSeed,
+  activeBrowserSeed,
+  bareBrowserSeed,
   type BrowserFilter,
 } from './sessions-browser.js';
 import type { SessionMeta } from '../lib/session/types.js';
@@ -105,6 +108,50 @@ describe('cycleWindow — W hotkey', () => {
     expect(cycleWindow('1d')).toBe('7d');
     expect(cycleWindow('7d')).toBe('30d');
     expect(cycleWindow('30d')).toBeUndefined();
+  });
+});
+
+describe('activeBrowserSeed — the --active call-site filter (fleet-wide)', () => {
+  it('is fleet-wide (projectScope all), not repo-scoped', () => {
+    // The static --active is fleet-wide; the interactive one must match, else
+    // `sessions --active` silently narrows to the current directory.
+    expect(activeBrowserSeed({}).projectScope).toBe('all');
+  });
+
+  it('is running-only and defaults the window to 30d', () => {
+    const f = activeBrowserSeed({});
+    expect(f.running).toBe(true);
+    expect(f.window).toBe('30d');
+  });
+
+  it('seeds the window from --since', () => {
+    expect(activeBrowserSeed({ since: '2h' }).window).toBe('2h');
+  });
+
+  it('normalizes a user@host / FQDN device seed to the canonical machine id', () => {
+    expect(activeBrowserSeed({ host: ['muqsit@mac-mini.local'] }).device).toBe('mac-mini');
+    expect(activeBrowserSeed({ host: ['YOSEMITE-S1'] }).device).toBe('yosemite-s1');
+    expect(activeBrowserSeed({}).device).toBeUndefined();
+  });
+});
+
+describe('bareBrowserSeed — the bare-listing call-site filter', () => {
+  it('defaults to this-repo scope, widens to all dirs with --all', () => {
+    expect(bareBrowserSeed({}).projectScope).toBe('repo');
+    expect(bareBrowserSeed({ all: true }).projectScope).toBe('all');
+  });
+
+  it('is not running-only and seeds the window from --since', () => {
+    expect(bareBrowserSeed({}).running).toBeUndefined();
+    expect(bareBrowserSeed({ since: '7d' }).window).toBe('7d');
+  });
+});
+
+describe('normalizeDeviceSeed — canonical .machine form', () => {
+  it('strips user@ and domain, lowercases', () => {
+    expect(normalizeDeviceSeed('user@Zion.local')).toBe('zion');
+    expect(normalizeDeviceSeed('mac-mini')).toBe('mac-mini');
+    expect(normalizeDeviceSeed(undefined)).toBeUndefined();
   });
 });
 

--- a/apps/cli/src/commands/sessions-browser.ts
+++ b/apps/cli/src/commands/sessions-browser.ts
@@ -17,7 +17,7 @@ import type { SessionMeta } from '../lib/session/types.js';
 import { getActiveSessions, type ActiveSession } from '../lib/session/active.js';
 import { discoverSessions } from '../lib/session/discover.js';
 import { gatherRemoteList } from '../lib/session/remote-list.js';
-import { machineId } from '../lib/session/sync/config.js';
+import { machineId, normalizeHost } from '../lib/session/sync/config.js';
 import { buildPreview } from './sessions-picker.js';
 import {
   formatPickerLabel,
@@ -110,6 +110,55 @@ export function browserFilterToArgv(f: BrowserFilter, query = ''): string[] {
   const q = query.trim();
   if (q) a.push(JSON.stringify(q));
   return a;
+}
+
+/** Normalize a `--host`/`--device` token (`alias`, `user@host`, `host.domain`) to
+ * the canonical machine id the rows carry in `.machine`, so a flag seed matches
+ * (the `d` hotkey already cycles canonical ids). Mirrors sessions.ts `hostToken`. */
+export function normalizeDeviceSeed(host: string | undefined): string | undefined {
+  if (!host) return undefined;
+  return normalizeHost(host.split('@').pop() || host);
+}
+
+/**
+ * The initial filter for the `--active` browser: fleet-wide (matches the static
+ * `renderActiveSessions`, which has no project scoping — the `p` hotkey narrows to
+ * this repo), running-only, with the device seed normalized and `--since` seeding
+ * the window. Pure, so the routing call site is unit-testable.
+ */
+export function activeBrowserSeed(opts: {
+  teams?: boolean;
+  agent?: string;
+  host?: string[];
+  since?: string;
+}): Partial<BrowserFilter> {
+  return {
+    running: true,
+    teams: !!opts.teams,
+    agent: opts.agent,
+    projectScope: 'all',
+    device: normalizeDeviceSeed(opts.host?.[0]),
+    window: opts.since ?? '30d',
+  };
+}
+
+/**
+ * The initial filter for the bare interactive listing: current-repo subtree by
+ * default (matches the static overview's cwd scoping), `--all` widens to every
+ * directory, `--since` seeds the window.
+ */
+export function bareBrowserSeed(opts: {
+  teams?: boolean;
+  agent?: string;
+  all?: boolean;
+  since?: string;
+}): Partial<BrowserFilter> {
+  return {
+    teams: !!opts.teams,
+    agent: opts.agent,
+    projectScope: opts.all ? 'all' : 'repo',
+    window: opts.since ?? '30d',
+  };
 }
 
 /** Copy text to the OS clipboard (best-effort; silently no-ops if unavailable). */

--- a/apps/cli/src/commands/sessions-browser.ts
+++ b/apps/cli/src/commands/sessions-browser.ts
@@ -1,0 +1,255 @@
+/**
+ * Interactive fleet-wide session browser — the human front-end of `agents sessions`.
+ *
+ * One canonical filter state (device / agent / project / window / running / teams),
+ * driven by single-key hotkeys, re-pulling live over the same fleet fan-out the flag
+ * surface uses. The identical state is expressible as flags (the agent front-end);
+ * `y` / `--print-cmd` round-trips a hand-built view into a copy-pasteable command.
+ *
+ * Built on {@link dynamicPicker}; every data source (discover, fleet, live index,
+ * preview, resume dispatch) is reused from the existing sessions plumbing.
+ */
+
+import { spawnSync } from 'child_process';
+import chalk from 'chalk';
+import { dynamicPicker } from '../lib/picker.js';
+import type { SessionMeta } from '../lib/session/types.js';
+import { getActiveSessions, type ActiveSession } from '../lib/session/active.js';
+import { discoverSessions } from '../lib/session/discover.js';
+import { gatherRemoteList } from '../lib/session/remote-list.js';
+import { machineId } from '../lib/session/sync/config.js';
+import { buildPreview } from './sessions-picker.js';
+import {
+  formatPickerLabel,
+  pickerColumnsFor,
+  filterSessionsByQuery,
+  mergeLocalFirst,
+  indexActiveBySessionId,
+  handlePickedSession,
+  type PickerColumns,
+} from './sessions.js';
+
+/**
+ * The single canonical filter state. Every field has a flag equivalent, so the
+ * same view is reachable interactively (hotkeys) or from the command line (flags).
+ */
+export interface BrowserFilter {
+  /** running-only — the `R` key / `--active`. */
+  running: boolean;
+  /** include team-spawned sessions — the `C` key / `--teams`. */
+  teams: boolean;
+  /** filter to one agent, or all — the `A` key / `-a`. */
+  agent?: string;
+  /** filter to one machine, or all — the `D` key / `--device`. */
+  device?: string;
+  /** this-repo subtree vs every directory — the `P` key / `--all`. */
+  projectScope: 'repo' | 'all';
+  /** time window (undefined = all time) — the `W` key / `--since`. */
+  window?: string;
+}
+
+/** Ordered window cycle for the `W` key. `undefined` = all time. */
+const WINDOW_CYCLE: (string | undefined)[] = [undefined, '1d', '7d', '30d'];
+
+/** Return the next value in `[undefined, ...options]`, wrapping. */
+export function cycle(current: string | undefined, options: string[]): string | undefined {
+  const ring = [undefined, ...options];
+  const idx = ring.findIndex((v) => v === current);
+  return ring[(idx + 1) % ring.length];
+}
+
+export function cycleWindow(current: string | undefined): string | undefined {
+  const idx = WINDOW_CYCLE.findIndex((v) => v === current);
+  return WINDOW_CYCLE[(idx + 1) % WINDOW_CYCLE.length];
+}
+
+function distinct(values: (string | undefined)[]): string[] {
+  return [...new Set(values.filter((v): v is string => !!v))].sort();
+}
+
+/**
+ * The canonical `ag sessions …` command for a filter state (+ optional search) —
+ * the agent-facing twin of the interactive view. Shared by the `y` hotkey and
+ * `--print-cmd`.
+ */
+export function browserFilterToArgv(f: BrowserFilter, query = ''): string[] {
+  const a = ['sessions'];
+  if (f.running) a.push('--active');
+  if (f.teams) a.push('--teams');
+  if (f.agent) a.push('-a', f.agent);
+  if (f.device) a.push('--device', f.device);
+  if (f.projectScope === 'all') a.push('--all');
+  if (f.window) a.push('--since', f.window);
+  const q = query.trim();
+  if (q) a.push(JSON.stringify(q));
+  return a;
+}
+
+/** Copy text to the OS clipboard (best-effort; silently no-ops if unavailable). */
+function copyToClipboard(text: string): boolean {
+  const candidates =
+    process.platform === 'darwin'
+      ? [['pbcopy', [] as string[]]]
+      : [
+          ['wl-copy', []],
+          ['xclip', ['-selection', 'clipboard']],
+          ['xsel', ['--clipboard', '--input']],
+        ];
+  for (const [cmd, args] of candidates as [string, string[]][]) {
+    try {
+      const res = spawnSync(cmd, args, { input: text });
+      if (res.status === 0) return true;
+    } catch {
+      // try the next candidate
+    }
+  }
+  return false;
+}
+
+/** The expensive fetch: the local index + a live fleet fan-out + the live index. */
+async function fetchRawPool(
+  f: BrowserFilter,
+  self: string,
+): Promise<{ key: string; rows: SessionMeta[]; live: Map<string, ActiveSession> }> {
+  const since = f.window;
+  // Local pool: wide (every directory) — device/agent/project are applied in
+  // memory so a hotkey toggle is instant and doesn't re-hit the disk.
+  let rows = await discoverSessions({
+    all: true,
+    cwd: process.cwd(),
+    since,
+    excludeTeamOrigin: !f.teams,
+    limit: 500,
+    sortBy: 'timestamp',
+  });
+
+  // Fleet: fold in every online peer's own index over SSH (no sync), same as the
+  // flag path. Best-effort — a fan-out failure leaves the local list intact.
+  try {
+    const forwarded = ['sessions', '--all', '--json', '--limit', '500'];
+    if (since) forwarded.push('--since', since);
+    if (f.teams) forwarded.push('--teams');
+    const { sessions: remote } = await gatherRemoteList(forwarded);
+    if (remote.length > 0) rows = mergeLocalFirst([...rows, ...remote], self);
+  } catch {
+    // enrichment, never a hard dependency
+  }
+
+  let live: Map<string, ActiveSession>;
+  try {
+    live = indexActiveBySessionId(await getActiveSessions());
+  } catch {
+    live = new Map();
+  }
+
+  return { key: `${since ?? 'all'}|${f.teams}`, rows, live };
+}
+
+/** Apply the cheap in-memory filters (agent / device / project / running). */
+function applyFilters(
+  rows: SessionMeta[],
+  live: Map<string, ActiveSession>,
+  f: BrowserFilter,
+  self: string,
+): SessionMeta[] {
+  let out = rows;
+  if (f.agent) out = out.filter((r) => r.agent === f.agent);
+  if (f.device) out = out.filter((r) => (r.machine ?? self) === f.device);
+  if (f.projectScope === 'repo') {
+    const cwd = process.cwd();
+    out = out.filter((r) => !!r.cwd && (r.cwd === cwd || r.cwd.startsWith(cwd + '/')));
+  }
+  if (f.running) out = out.filter((r) => live.has(r.id));
+  return out;
+}
+
+function headerFor(f: BrowserFilter): string {
+  const bits = [
+    `device:${f.device ?? 'all'}`,
+    `agent:${f.agent ?? 'all'}`,
+    f.projectScope === 'repo' ? 'this repo' : 'all dirs',
+    `window:${f.window ?? 'all'}`,
+  ];
+  if (f.running) bits.push('running');
+  if (f.teams) bits.push('teams');
+  return bits.join(' · ');
+}
+
+function helpFor(_f: BrowserFilter, mode: 'nav' | 'search'): string {
+  if (mode === 'search') {
+    return 'type to filter · ↑↓ navigate · esc exit search · ⏎ resume';
+  }
+  return 's search · r running · c teams · a agent · d device · p project · w window · y copy-cmd · ⏎ resume · esc quit';
+}
+
+/**
+ * Launch the interactive session browser. `initial` seeds the filter (e.g.
+ * `{ running: true }` for `--active`). Resolves after the user resumes a session
+ * or cancels — the picked row is dispatched through the shared resume/focus path.
+ */
+export async function runSessionBrowser(initial: Partial<BrowserFilter> = {}): Promise<void> {
+  const self = machineId();
+
+  // Updated after each load so the A/D cycles range over what's actually present.
+  let agentsInPool: string[] = [];
+  let devicesInPool: string[] = [];
+  let cols: PickerColumns = {};
+  // Cache the expensive fetch, keyed by (window, teams); agent/device/project/
+  // running are applied in memory so their hotkeys don't re-fan-out the fleet.
+  let rawCache: { key: string; rows: SessionMeta[]; live: Map<string, ActiveSession> } | null = null;
+
+  const initialFilter: BrowserFilter = {
+    running: initial.running ?? false,
+    teams: initial.teams ?? false,
+    agent: initial.agent,
+    device: initial.device,
+    projectScope: initial.projectScope ?? 'repo',
+    window: 'window' in initial ? initial.window : '30d',
+  };
+
+  const load = async (f: BrowserFilter): Promise<SessionMeta[]> => {
+    const key = `${f.window ?? 'all'}|${f.teams}`;
+    if (!rawCache || rawCache.key !== key) {
+      rawCache = await fetchRawPool(f, self);
+    }
+    agentsInPool = distinct(rawCache.rows.map((r) => r.agent));
+    devicesInPool = distinct(rawCache.rows.map((r) => r.machine ?? self));
+    const filtered = applyFilters(rawCache.rows, rawCache.live, f, self);
+    cols = pickerColumnsFor(filtered);
+    return filtered;
+  };
+
+  const picked = await dynamicPicker<SessionMeta, BrowserFilter>({
+    message: 'Sessions',
+    initialFilter,
+    load,
+    keyFor: (s) => s.id,
+    labelFor: (s, q) => formatPickerLabel(s, q, cols),
+    matches: (s, q) => filterSessionsByQuery([s], q).length > 0,
+    buildPreview,
+    headerFor,
+    helpFor,
+    enterHint: 'resume',
+    emptyMessage: 'No sessions match this filter.',
+    loadingMessage: 'Reaching machines…',
+    keyBindings: {
+      r: (f) => ({ ...f, running: !f.running }),
+      c: (f) => ({ ...f, teams: !f.teams }),
+      a: (f) => ({ ...f, agent: cycle(f.agent, agentsInPool) }),
+      d: (f) => ({ ...f, device: cycle(f.device, devicesInPool) }),
+      p: (f) => ({ ...f, projectScope: f.projectScope === 'repo' ? 'all' : 'repo' }),
+      w: (f) => ({ ...f, window: cycleWindow(f.window) }),
+    },
+    onKey: (name, f) => {
+      if (name === 'y') {
+        const cmd = 'ag ' + browserFilterToArgv(f).join(' ');
+        const ok = copyToClipboard(cmd);
+        return ok ? `copied: ${cmd}` : cmd;
+      }
+      return undefined;
+    },
+  });
+
+  if (!picked) return;
+  await handlePickedSession({ session: picked.item, action: 'resume' });
+}

--- a/apps/cli/src/commands/sessions-browser.ts
+++ b/apps/cli/src/commands/sessions-browser.ts
@@ -22,7 +22,7 @@ import { buildPreview } from './sessions-picker.js';
 import {
   formatPickerLabel,
   pickerColumnsFor,
-  filterSessionsByQuery,
+  ticketLabel,
   mergeLocalFirst,
   indexActiveBySessionId,
   handlePickedSession,
@@ -65,6 +65,31 @@ export function cycleWindow(current: string | undefined): string | undefined {
 
 function distinct(values: (string | undefined)[]): string[] {
   return [...new Set(values.filter((v): v is string => !!v))].sort();
+}
+
+/**
+ * Cheap client-side match for the `S` search — a plain substring test over a
+ * row's visible fields. Deliberately NOT the FTS `filterSessionsByQuery`: that
+ * runs a content-index scan per call, which is fine once over a pool but a
+ * CPU sink when a picker calls it per-row on every keystroke.
+ */
+export function sessionMatchesQuery(s: SessionMeta, query: string): boolean {
+  const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return true;
+  const hay = [
+    s.shortId,
+    s.agent,
+    s.project,
+    s.cwd,
+    s.topic,
+    (s as { label?: string }).label,
+    ticketLabel(s),
+    s.machine,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+  return terms.every((t) => hay.includes(t));
 }
 
 /**
@@ -239,7 +264,7 @@ export async function runSessionBrowser(
     load,
     keyFor: (s) => s.id,
     labelFor: (s, q) => formatPickerLabel(s, q, cols),
-    matches: (s, q) => filterSessionsByQuery([s], q).length > 0,
+    matches: sessionMatchesQuery,
     buildPreview,
     headerFor,
     helpFor,

--- a/apps/cli/src/commands/sessions-browser.ts
+++ b/apps/cli/src/commands/sessions-browser.ts
@@ -289,6 +289,12 @@ export async function runSessionBrowser(
   // The live index is slow (a full ps/tmux scan) and only the running filter
   // needs it — fetch it once, lazily, the first time running is toggled on.
   let liveCache: Map<string, ActiveSession> | null = null;
+  // Generation guard: two quick keypresses can start overlapping loads whose
+  // SSH fan-outs settle out of order. dynamicPicker's own gen ref guards which
+  // rows become `items`, but the shared closure state below (cols / cycle pools /
+  // caches) is a side channel it can't see — so a stale load must never commit
+  // it. We compute into locals and only write the shared state as the latest load.
+  let loadGen = 0;
 
   const initialFilter: BrowserFilter = {
     running: initial.running ?? false,
@@ -300,21 +306,31 @@ export async function runSessionBrowser(
   };
 
   const load = async (f: BrowserFilter): Promise<SessionMeta[]> => {
+    const myGen = ++loadGen;
     const key = `${f.window ?? 'all'}|${f.teams}`;
-    if (!rawCache || rawCache.key !== key) {
-      rawCache = await fetchRawPool(f, self, local, hosts);
+    let pool = rawCache && rawCache.key === key ? rawCache : null;
+    if (!pool) {
+      const fetched = await fetchRawPool(f, self, local, hosts);
+      if (myGen !== loadGen) return []; // superseded — don't touch shared state
+      pool = fetched;
     }
     // Only pay for the live scan when the running filter needs it.
-    if (f.running && !liveCache) {
+    let live = liveCache;
+    if (f.running && !live) {
       try {
-        liveCache = indexActiveBySessionId(await getActiveSessions());
+        live = indexActiveBySessionId(await getActiveSessions());
       } catch {
-        liveCache = new Map();
+        live = new Map();
       }
+      if (myGen !== loadGen) return [];
     }
-    agentsInPool = distinct(rawCache.rows.map((r) => r.agent));
-    devicesInPool = distinct(rawCache.rows.map((r) => r.machine ?? self));
-    const filtered = applyFilters(rawCache.rows, liveCache ?? new Map(), f, self);
+    // Latest load — commit shared state atomically (no await past this point, so
+    // no newer load can interleave between these writes).
+    rawCache = pool;
+    if (live) liveCache = live;
+    agentsInPool = distinct(pool.rows.map((r) => r.agent));
+    devicesInPool = distinct(pool.rows.map((r) => r.machine ?? self));
+    const filtered = applyFilters(pool.rows, live ?? new Map(), f, self);
     cols = pickerColumnsFor(filtered);
     return filtered;
   };

--- a/apps/cli/src/commands/sessions-browser.ts
+++ b/apps/cli/src/commands/sessions-browser.ts
@@ -106,11 +106,14 @@ function copyToClipboard(text: string): boolean {
   return false;
 }
 
-/** The expensive fetch: the local index + a live fleet fan-out + the live index. */
+/** The transcript pool: the local index + (unless --local) a live fleet fan-out.
+ * The live index is fetched separately/lazily — it's the slow part and only the
+ * running filter needs it, so a bare browse stays instant. */
 async function fetchRawPool(
   f: BrowserFilter,
   self: string,
-): Promise<{ key: string; rows: SessionMeta[]; live: Map<string, ActiveSession> }> {
+  local: boolean,
+): Promise<{ key: string; rows: SessionMeta[] }> {
   const since = f.window;
   // Local pool: wide (every directory) — device/agent/project are applied in
   // memory so a hotkey toggle is instant and doesn't re-hit the disk.
@@ -124,25 +127,21 @@ async function fetchRawPool(
   });
 
   // Fleet: fold in every online peer's own index over SSH (no sync), same as the
-  // flag path. Best-effort — a fan-out failure leaves the local list intact.
-  try {
-    const forwarded = ['sessions', '--all', '--json', '--limit', '500'];
-    if (since) forwarded.push('--since', since);
-    if (f.teams) forwarded.push('--teams');
-    const { sessions: remote } = await gatherRemoteList(forwarded);
-    if (remote.length > 0) rows = mergeLocalFirst([...rows, ...remote], self);
-  } catch {
-    // enrichment, never a hard dependency
+  // flag path. Skipped under --local. Best-effort — a fan-out failure leaves the
+  // local list intact.
+  if (!local) {
+    try {
+      const forwarded = ['sessions', '--all', '--json', '--limit', '500'];
+      if (since) forwarded.push('--since', since);
+      if (f.teams) forwarded.push('--teams');
+      const { sessions: remote } = await gatherRemoteList(forwarded);
+      if (remote.length > 0) rows = mergeLocalFirst([...rows, ...remote], self);
+    } catch {
+      // enrichment, never a hard dependency
+    }
   }
 
-  let live: Map<string, ActiveSession>;
-  try {
-    live = indexActiveBySessionId(await getActiveSessions());
-  } catch {
-    live = new Map();
-  }
-
-  return { key: `${since ?? 'all'}|${f.teams}`, rows, live };
+  return { key: `${since ?? 'all'}|${f.teams}`, rows };
 }
 
 /** Apply the cheap in-memory filters (agent / device / project / running). */
@@ -187,16 +186,23 @@ function helpFor(_f: BrowserFilter, mode: 'nav' | 'search'): string {
  * `{ running: true }` for `--active`). Resolves after the user resumes a session
  * or cancels — the picked row is dispatched through the shared resume/focus path.
  */
-export async function runSessionBrowser(initial: Partial<BrowserFilter> = {}): Promise<void> {
+export async function runSessionBrowser(
+  initial: Partial<BrowserFilter> = {},
+  opts: { local?: boolean } = {},
+): Promise<void> {
   const self = machineId();
+  const local = opts.local ?? false;
 
   // Updated after each load so the A/D cycles range over what's actually present.
   let agentsInPool: string[] = [];
   let devicesInPool: string[] = [];
   let cols: PickerColumns = {};
-  // Cache the expensive fetch, keyed by (window, teams); agent/device/project/
+  // Cache the transcript fetch, keyed by (window, teams); agent/device/project/
   // running are applied in memory so their hotkeys don't re-fan-out the fleet.
-  let rawCache: { key: string; rows: SessionMeta[]; live: Map<string, ActiveSession> } | null = null;
+  let rawCache: { key: string; rows: SessionMeta[] } | null = null;
+  // The live index is slow (a full ps/tmux scan) and only the running filter
+  // needs it — fetch it once, lazily, the first time running is toggled on.
+  let liveCache: Map<string, ActiveSession> | null = null;
 
   const initialFilter: BrowserFilter = {
     running: initial.running ?? false,
@@ -210,11 +216,19 @@ export async function runSessionBrowser(initial: Partial<BrowserFilter> = {}): P
   const load = async (f: BrowserFilter): Promise<SessionMeta[]> => {
     const key = `${f.window ?? 'all'}|${f.teams}`;
     if (!rawCache || rawCache.key !== key) {
-      rawCache = await fetchRawPool(f, self);
+      rawCache = await fetchRawPool(f, self, local);
+    }
+    // Only pay for the live scan when the running filter needs it.
+    if (f.running && !liveCache) {
+      try {
+        liveCache = indexActiveBySessionId(await getActiveSessions());
+      } catch {
+        liveCache = new Map();
+      }
     }
     agentsInPool = distinct(rawCache.rows.map((r) => r.agent));
     devicesInPool = distinct(rawCache.rows.map((r) => r.machine ?? self));
-    const filtered = applyFilters(rawCache.rows, rawCache.live, f, self);
+    const filtered = applyFilters(rawCache.rows, liveCache ?? new Map(), f, self);
     cols = pickerColumnsFor(filtered);
     return filtered;
   };
@@ -231,7 +245,7 @@ export async function runSessionBrowser(initial: Partial<BrowserFilter> = {}): P
     helpFor,
     enterHint: 'resume',
     emptyMessage: 'No sessions match this filter.',
-    loadingMessage: 'Reaching machines…',
+    loadingMessage: local ? 'Loading…' : 'Loading (reaching other machines)…',
     keyBindings: {
       r: (f) => ({ ...f, running: !f.running }),
       c: (f) => ({ ...f, teams: !f.teams }),

--- a/apps/cli/src/commands/sessions-browser.ts
+++ b/apps/cli/src/commands/sessions-browser.ts
@@ -26,6 +26,8 @@ import {
   mergeLocalFirst,
   indexActiveBySessionId,
   handlePickedSession,
+  shouldIncludeLocal,
+  remoteHostsToDial,
   type PickerColumns,
 } from './sessions.js';
 
@@ -133,33 +135,42 @@ function copyToClipboard(text: string): boolean {
 
 /** The transcript pool: the local index + (unless --local) a live fleet fan-out.
  * The live index is fetched separately/lazily — it's the slow part and only the
- * running filter needs it, so a bare browse stays instant. */
+ * running filter needs it, so a bare browse stays instant.
+ *
+ * `hosts` is the explicit `--host`/`--device` scope (if any): it restricts which
+ * peers are dialed and whether local is included, honoring the flag's "scope,
+ * not add" contract instead of always sweeping the whole fleet. */
 async function fetchRawPool(
   f: BrowserFilter,
   self: string,
   local: boolean,
+  hosts: string[] | undefined,
 ): Promise<{ key: string; rows: SessionMeta[] }> {
   const since = f.window;
   // Local pool: wide (every directory) — device/agent/project are applied in
-  // memory so a hotkey toggle is instant and doesn't re-hit the disk.
-  let rows = await discoverSessions({
-    all: true,
-    cwd: process.cwd(),
-    since,
-    excludeTeamOrigin: !f.teams,
-    limit: 500,
-    sortBy: 'timestamp',
-  });
+  // memory so a hotkey toggle is instant and doesn't re-hit the disk. Skipped
+  // when an explicit host scope excludes this machine.
+  let rows: SessionMeta[] = shouldIncludeLocal(hosts, self)
+    ? await discoverSessions({
+        all: true,
+        cwd: process.cwd(),
+        since,
+        excludeTeamOrigin: !f.teams,
+        limit: 500,
+        sortBy: 'timestamp',
+      })
+    : [];
 
-  // Fleet: fold in every online peer's own index over SSH (no sync), same as the
-  // flag path. Skipped under --local. Best-effort — a fan-out failure leaves the
-  // local list intact.
+  // Fleet: fold in peers' own indexes over SSH (no sync), same as the flag path.
+  // Skipped under --local. An explicit --host/--device scopes exactly which peers
+  // are dialed (undefined = sweep every online device). Best-effort — a fan-out
+  // failure leaves the local list intact.
   if (!local) {
     try {
       const forwarded = ['sessions', '--all', '--json', '--limit', '500'];
       if (since) forwarded.push('--since', since);
       if (f.teams) forwarded.push('--teams');
-      const { sessions: remote } = await gatherRemoteList(forwarded);
+      const { sessions: remote } = await gatherRemoteList(forwarded, remoteHostsToDial(hosts, self));
       if (remote.length > 0) rows = mergeLocalFirst([...rows, ...remote], self);
     } catch {
       // enrichment, never a hard dependency
@@ -213,10 +224,11 @@ function helpFor(_f: BrowserFilter, mode: 'nav' | 'search'): string {
  */
 export async function runSessionBrowser(
   initial: Partial<BrowserFilter> = {},
-  opts: { local?: boolean } = {},
+  opts: { local?: boolean; hosts?: string[] } = {},
 ): Promise<void> {
   const self = machineId();
   const local = opts.local ?? false;
+  const hosts = opts.hosts && opts.hosts.length > 0 ? opts.hosts : undefined;
 
   // Updated after each load so the A/D cycles range over what's actually present.
   let agentsInPool: string[] = [];
@@ -241,7 +253,7 @@ export async function runSessionBrowser(
   const load = async (f: BrowserFilter): Promise<SessionMeta[]> => {
     const key = `${f.window ?? 'all'}|${f.teams}`;
     if (!rawCache || rawCache.key !== key) {
-      rawCache = await fetchRawPool(f, self, local);
+      rawCache = await fetchRawPool(f, self, local, hosts);
     }
     // Only pay for the live scan when the running filter needs it.
     if (f.running && !liveCache) {
@@ -279,9 +291,11 @@ export async function runSessionBrowser(
       p: (f) => ({ ...f, projectScope: f.projectScope === 'repo' ? 'all' : 'repo' }),
       w: (f) => ({ ...f, window: cycleWindow(f.window) }),
     },
-    onKey: (name, f) => {
+    onKey: (name, f, _active, query) => {
       if (name === 'y') {
-        const cmd = 'ag ' + browserFilterToArgv(f).join(' ');
+        // Thread the live search query so the copied command reproduces the
+        // exact view — the human→agent bridge must include the search term.
+        const cmd = 'ag ' + browserFilterToArgv(f, query).join(' ');
         const ok = copyToClipboard(cmd);
         return ok ? `copied: ${cmd}` : cmd;
       }

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -1014,12 +1014,15 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
     // static dump untouched, so scripts and agents are unaffected.
     if (useInteractiveBrowser(options) && !options.waiting && process.env.AGENTS_SESSIONS_LOCAL !== '1') {
       const { runSessionBrowser } = await import('./sessions-browser.js');
-      await runSessionBrowser({
-        running: true,
-        teams: !!options.teams,
-        agent: options.agent,
-        device: options.host?.length === 1 ? options.host[0] : undefined,
-      });
+      await runSessionBrowser(
+        {
+          running: true,
+          teams: !!options.teams,
+          agent: options.agent,
+          device: options.host?.length === 1 ? options.host[0] : undefined,
+        },
+        { local: options.local === true },
+      );
       return;
     }
     // AGENTS_SESSIONS_LOCAL is set by a parent fan-out invocation (see
@@ -1061,11 +1064,14 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
     options.artifact === undefined
   ) {
     const { runSessionBrowser } = await import('./sessions-browser.js');
-    await runSessionBrowser({
-      teams: !!options.teams,
-      agent: options.agent,
-      projectScope: options.all ? 'all' : 'repo',
-    });
+    await runSessionBrowser(
+      {
+        teams: !!options.teams,
+        agent: options.agent,
+        projectScope: options.all ? 'all' : 'repo',
+      },
+      { local: options.local === true },
+    );
     return;
   }
 

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -1031,6 +1031,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
       !options.waiting &&
       !options.until &&
       !options.project &&
+      !options.sort &&
       (options.host?.length ?? 0) <= 1 &&
       process.env.AGENTS_SESSIONS_LOCAL !== '1'
     ) {
@@ -1075,6 +1076,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
     !options.markdown &&
     !options.until &&
     !options.project &&
+    !options.sort &&
     !options.artifacts &&
     options.artifact === undefined
   ) {

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -1021,7 +1021,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
           agent: options.agent,
           device: options.host?.length === 1 ? options.host[0] : undefined,
         },
-        { local: options.local === true },
+        { local: options.local === true, hosts: options.host },
       );
       return;
     }
@@ -1070,7 +1070,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
         agent: options.agent,
         projectScope: options.all ? 'all' : 'repo',
       },
-      { local: options.local === true },
+      { local: options.local === true, hosts: options.host },
     );
     return;
   }

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -1024,12 +1024,13 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
     // On a TTY (and not a scripting path), open the interactive browser seeded to
     // running-only. --json / --waiting / --no-interactive / a peer fan-out keep the
     // static dump untouched, so scripts and agents are unaffected. An explicit
-    // --since seeds the window; --until (no browser representation) or a multi-host
-    // scope fall through to the static dump that already honors them.
+    // --since seeds the window; --until / --project (no browser field) or a
+    // multi-host scope fall through to the static dump that already honors them.
     if (
       useInteractiveBrowser(options) &&
       !options.waiting &&
       !options.until &&
+      !options.project &&
       (options.host?.length ?? 0) <= 1 &&
       process.env.AGENTS_SESSIONS_LOCAL !== '1'
     ) {
@@ -1062,9 +1063,10 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
   }
 
   // Bare interactive listing → the interactive fleet browser (humans). A query,
-  // a render/filter flag, --flat/--tree, --json, --until, or --no-interactive keep
-  // the existing printed/render paths (agents and scripts unaffected). An explicit
-  // --since seeds the browser's window so the flag is honored, not swallowed.
+  // a render/filter flag, --flat/--tree, --json, --until, --project (a named-project
+  // filter the browser can't represent), or --no-interactive keep the existing
+  // printed/render paths (agents and scripts unaffected). An explicit --since seeds
+  // the browser's window so the flag is honored, not swallowed.
   if (
     useInteractiveBrowser(options) &&
     !query &&
@@ -1072,6 +1074,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
     !options.tree &&
     !options.markdown &&
     !options.until &&
+    !options.project &&
     !options.artifacts &&
     options.artifact === undefined
   ) {

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -1011,15 +1011,24 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
   if (options.active) {
     // On a TTY (and not a scripting path), open the interactive browser seeded to
     // running-only. --json / --waiting / --no-interactive / a peer fan-out keep the
-    // static dump untouched, so scripts and agents are unaffected.
-    if (useInteractiveBrowser(options) && !options.waiting && process.env.AGENTS_SESSIONS_LOCAL !== '1') {
+    // static dump untouched, so scripts and agents are unaffected. An explicit
+    // --since seeds the window; --until (no browser representation) or a multi-host
+    // scope fall through to the static dump that already honors them.
+    if (
+      useInteractiveBrowser(options) &&
+      !options.waiting &&
+      !options.until &&
+      (options.host?.length ?? 0) <= 1 &&
+      process.env.AGENTS_SESSIONS_LOCAL !== '1'
+    ) {
       const { runSessionBrowser } = await import('./sessions-browser.js');
       await runSessionBrowser(
         {
           running: true,
           teams: !!options.teams,
           agent: options.agent,
-          device: options.host?.length === 1 ? options.host[0] : undefined,
+          device: options.host?.[0],
+          window: options.since ?? '30d',
         },
         { local: options.local === true, hosts: options.host },
       );
@@ -1052,14 +1061,16 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
   }
 
   // Bare interactive listing → the interactive fleet browser (humans). A query,
-  // a render/filter flag, --flat/--tree, --json, or --no-interactive keep the
-  // existing printed/render paths (agents and scripts unaffected).
+  // a render/filter flag, --flat/--tree, --json, --until, or --no-interactive keep
+  // the existing printed/render paths (agents and scripts unaffected). An explicit
+  // --since seeds the browser's window so the flag is honored, not swallowed.
   if (
     useInteractiveBrowser(options) &&
     !query &&
     !options.flat &&
     !options.tree &&
     !options.markdown &&
+    !options.until &&
     !options.artifacts &&
     options.artifact === undefined
   ) {
@@ -1069,6 +1080,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
         teams: !!options.teams,
         agent: options.agent,
         projectScope: options.all ? 'all' : 'repo',
+        window: options.since ?? '30d',
       },
       { local: options.local === true, hosts: options.host },
     );

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -1008,6 +1008,18 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
     return;
   }
 
+  // --preview <id/query>: resolve one session and print its compact preview, then
+  // exit — checked before --active so `--active --preview <id>` peeks the id
+  // rather than being swallowed by the active listing.
+  if (options.preview) {
+    if (!query) {
+      console.error(chalk.red('--preview requires a session id or query.'));
+      process.exit(1);
+    }
+    await renderSessionPreview(query, { agent: options.agent, project: options.project });
+    return;
+  }
+
   if (options.active) {
     // On a TTY (and not a scripting path), open the interactive browser seeded to
     // running-only. --json / --waiting / --no-interactive / a peer fan-out keep the
@@ -1046,17 +1058,6 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
 
   if (options.cloud) {
     await runCloudSessions(query, options);
-    return;
-  }
-
-  // --preview <id/query>: resolve one session and print its compact preview, then
-  // exit. The fast peek that skips the pager.
-  if (options.preview) {
-    if (!query) {
-      console.error(chalk.red('--preview requires a session id or query.'));
-      process.exit(1);
-    }
-    await renderSessionPreview(query, { agent: options.agent, project: options.project });
     return;
   }
 

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -1035,15 +1035,14 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
       (options.host?.length ?? 0) <= 1 &&
       process.env.AGENTS_SESSIONS_LOCAL !== '1'
     ) {
-      const { runSessionBrowser } = await import('./sessions-browser.js');
+      const { runSessionBrowser, activeBrowserSeed } = await import('./sessions-browser.js');
       await runSessionBrowser(
-        {
-          running: true,
-          teams: !!options.teams,
+        activeBrowserSeed({
+          teams: options.teams,
           agent: options.agent,
-          device: options.host?.[0],
-          window: options.since ?? '30d',
-        },
+          host: options.host,
+          since: options.since,
+        }),
         { local: options.local === true, hosts: options.host },
       );
       return;
@@ -1080,14 +1079,14 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
     !options.artifacts &&
     options.artifact === undefined
   ) {
-    const { runSessionBrowser } = await import('./sessions-browser.js');
+    const { runSessionBrowser, bareBrowserSeed } = await import('./sessions-browser.js');
     await runSessionBrowser(
-      {
-        teams: !!options.teams,
+      bareBrowserSeed({
+        teams: options.teams,
         agent: options.agent,
-        projectScope: options.all ? 'all' : 'repo',
-        window: options.since ?? '30d',
-      },
+        all: options.all,
+        since: options.since,
+      }),
       { local: options.local === true, hosts: options.host },
     );
     return;

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -41,7 +41,7 @@ import { colorAgent, resolveAgentName } from '../lib/agents.js';
 import { fuzzyMatch, FUZZY_PRESETS } from '../lib/fuzzy.js';
 import { resolveVersionAliasLoose } from '../lib/versions.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
-import { sessionPicker, type PickedSession } from './sessions-picker.js';
+import { sessionPicker, buildPreview, type PickedSession } from './sessions-picker.js';
 import { setHelpSections } from '../lib/help.js';
 import { registerSessionsTailCommand } from './sessions-tail.js';
 import { registerSessionsSyncCommand } from './sessions-sync.js';
@@ -103,6 +103,14 @@ interface SessionsOptions extends SessionFilterOptions {
   antigravity?: boolean;
   grok?: boolean;
   opencode?: boolean;
+  /** Force the printed listing even on a TTY. Commander's `--no-` convention:
+   * `--no-interactive` sets this false, opting out of the interactive browser. */
+  interactive?: boolean;
+  /** Print the canonical `ag sessions …` command for the given flags and exit —
+   * the non-interactive twin of the browser's `y` hotkey. */
+  printCmd?: boolean;
+  /** Print a compact preview of the matched session and exit (no pager). */
+  preview?: boolean;
 }
 
 /**
@@ -903,6 +911,52 @@ function printCrossMachineTip(): void {
   ));
 }
 
+/**
+ * True when the interactive session browser should open instead of a printed
+ * listing: a real TTY, no `--json`, and `--no-interactive` not set. The bare
+ * listing and `--active` both default to it; scripts/pipes/agents fall through
+ * to the existing printed/JSON paths.
+ */
+function useInteractiveBrowser(options: SessionsOptions): boolean {
+  return options.interactive !== false && !options.json && isInteractiveTerminal();
+}
+
+/** The canonical `ag sessions …` command for a set of flags — the twin of the
+ * browser's `y` hotkey (see --print-cmd). Normalizes to the stable flag form. */
+function canonicalSessionsCommand(query: string | undefined, options: SessionsOptions): string {
+  const a = ['sessions'];
+  if (options.active) a.push('--active');
+  if (options.teams) a.push('--teams');
+  if (options.agent) a.push('-a', options.agent);
+  for (const h of options.host ?? []) a.push('--device', h);
+  if (options.project) a.push('--project', options.project);
+  if (options.all) a.push('--all');
+  if (options.since) a.push('--since', options.since);
+  if (options.until) a.push('--until', options.until);
+  if (options.local) a.push('--local');
+  if (options.waiting) a.push('--waiting');
+  const q = (query ?? '').trim();
+  if (q) a.push(JSON.stringify(q));
+  return 'ag ' + a.join(' ');
+}
+
+/** Resolve a session by id/query globally and print its compact preview (no pager).
+ * Backs `--preview` — the fast path for the "peek before resume" hot loop. */
+async function renderSessionPreview(
+  query: string,
+  scope: { agent?: string; project?: string },
+): Promise<void> {
+  const discovered = await discoverSessions({ all: true, cwd: process.cwd(), limit: 5000 });
+  const pool = applyScopeFilters(discovered, scope);
+  const matches = resolveSessionById(pool, query);
+  const session = (matches.length > 0 ? matches : filterSessionsByQuery(pool, query))[0];
+  if (!session) {
+    console.log(chalk.gray(`No session matches "${query}".`));
+    return;
+  }
+  console.log(buildPreview(session));
+}
+
 /** Main action handler for `agents sessions`. Routes to picker, table, or single-session render. */
 async function sessionsAction(query: string | undefined, options: SessionsOptions): Promise<void> {
   // Explicit --query is interchangeable with the positional; it's how you search
@@ -915,6 +969,14 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
   applyAgentShorthands(options);
   if (options.device && options.device.length > 0) {
     options.host = [...(options.host ?? []), ...options.device];
+  }
+
+  // --print-cmd: echo the canonical `ag sessions …` for the given flags and exit.
+  // The non-interactive twin of the browser's `y` hotkey — lets an agent compose
+  // (or a human copy) the exact command a view maps to.
+  if (options.printCmd) {
+    process.stdout.write(canonicalSessionsCommand(query, options) + '\n');
+    return;
   }
 
   // --roots: emit the local session-scan directories, per agent, as JSON. A pure
@@ -947,6 +1009,19 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
   }
 
   if (options.active) {
+    // On a TTY (and not a scripting path), open the interactive browser seeded to
+    // running-only. --json / --waiting / --no-interactive / a peer fan-out keep the
+    // static dump untouched, so scripts and agents are unaffected.
+    if (useInteractiveBrowser(options) && !options.waiting && process.env.AGENTS_SESSIONS_LOCAL !== '1') {
+      const { runSessionBrowser } = await import('./sessions-browser.js');
+      await runSessionBrowser({
+        running: true,
+        teams: !!options.teams,
+        agent: options.agent,
+        device: options.host?.length === 1 ? options.host[0] : undefined,
+      });
+      return;
+    }
     // AGENTS_SESSIONS_LOCAL is set by a parent fan-out invocation (see
     // remote-active.ts) so a peer answers for itself without recursing.
     const forceLocal = options.local === true || process.env.AGENTS_SESSIONS_LOCAL === '1';
@@ -959,6 +1034,38 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
 
   if (options.cloud) {
     await runCloudSessions(query, options);
+    return;
+  }
+
+  // --preview <id/query>: resolve one session and print its compact preview, then
+  // exit. The fast peek that skips the pager.
+  if (options.preview) {
+    if (!query) {
+      console.error(chalk.red('--preview requires a session id or query.'));
+      process.exit(1);
+    }
+    await renderSessionPreview(query, { agent: options.agent, project: options.project });
+    return;
+  }
+
+  // Bare interactive listing → the interactive fleet browser (humans). A query,
+  // a render/filter flag, --flat/--tree, --json, or --no-interactive keep the
+  // existing printed/render paths (agents and scripts unaffected).
+  if (
+    useInteractiveBrowser(options) &&
+    !query &&
+    !options.flat &&
+    !options.tree &&
+    !options.markdown &&
+    !options.artifacts &&
+    options.artifact === undefined
+  ) {
+    const { runSessionBrowser } = await import('./sessions-browser.js');
+    await runSessionBrowser({
+      teams: !!options.teams,
+      agent: options.agent,
+      projectScope: options.all ? 'all' : 'repo',
+    });
     return;
   }
 
@@ -1768,7 +1875,7 @@ function warnNoPeerTarget(machine: string, session: SessionMeta): void {
   console.log(chalk.gray(`Register/wake it (ag devices), or run there: agents ssh ${machine}`));
 }
 
-async function handlePickedSession(picked: PickedSession): Promise<void> {
+export async function handlePickedSession(picked: PickedSession): Promise<void> {
   // A session on another machine is read/resumed ON that machine over SSH — its
   // transcript and agent binary live there. Both actions execute on the peer
   // (not a local `--host` hop, which would discover locally and dead-end for a
@@ -2326,7 +2433,7 @@ export function registerSessionsCommands(program: Command): void {
     .option('--opencode', 'Shorthand for --agent opencode')
     .option('--all', 'Include sessions from every directory (not just current project)')
     .option('--teams', 'Include team-spawned sessions (hidden by default)')
-    .option('--project <name>', 'Filter by project name (searches across all directories)')
+    .option('-p, --project <name>', 'Filter by project name (searches across all directories)')
     .option('--since <time>', 'Only sessions newer than this (e.g., 2h, 7d, 4w, or ISO date)')
     .option('--until <time>', 'Only sessions older than this (ISO timestamp)')
     .option('-n, --limit <n>', 'Maximum number of sessions to return', '50')
@@ -2350,7 +2457,10 @@ export function registerSessionsCommands(program: Command): void {
     .option('--cloud', 'Source sessions from Rush Cloud (captured runs) instead of local disk')
     .option('-H, --host <target...>', 'Run this query on remote machine(s) over SSH (host alias or user@host; repeatable)')
     .option('--device <target...>', 'Alias for --host (device alias from `agents devices`; repeatable)')
-    .option('--browser', 'List browser-profile captures (screenshots, PDFs, recordings, downloads) instead of agent transcripts — alias of `agents browser sessions`');
+    .option('--browser', 'List browser-profile captures (screenshots, PDFs, recordings, downloads) instead of agent transcripts — alias of `agents browser sessions`')
+    .option('--no-interactive', 'Print the listing instead of opening the interactive browser (default on a TTY for the bare listing and --active)')
+    .option('--print-cmd', 'Print the canonical `ag sessions …` command for the given flags and exit (the twin of the browser’s `y` hotkey)')
+    .option('--preview', 'With a session id/query: print a compact preview and exit (no pager)');
 
   setHelpSections(sessionsCmd, {
     examples: `

--- a/apps/cli/src/lib/picker.ts
+++ b/apps/cli/src/lib/picker.ts
@@ -20,6 +20,7 @@ import {
   useKeypress,
   useEffect,
   useMemo,
+  useRef,
   usePagination,
   usePrefix,
   makeTheme,
@@ -421,6 +422,248 @@ export function multiItemPicker<T>(config: MultiPickerConfig<T>): Promise<T[] | 
       }
     }
 
+    parts.push(help);
+
+    return [header, parts.slice(1).join('\n')];
+  });
+  return prompt(config);
+}
+
+/** Configuration for the dynamic (async-refetch) picker prompt. */
+export interface DynamicPickerConfig<T, F> {
+  message: string;
+  /** The initial filter state. Changing it (via a keybinding) re-runs {@link load}. */
+  initialFilter: F;
+  /** Async loader for the current filter state. Its result is the row pool. */
+  load: (filter: F) => Promise<T[]>;
+  labelFor: (item: T, query: string) => string;
+  /** Stable identity for an item (used for the active-row cursor across reloads). */
+  keyFor: (item: T) => string;
+  /** Client-side text filter over the loaded pool (the `S` search). */
+  matches?: (item: T, query: string) => boolean;
+  buildPreview?: (item: T) => string;
+  /** Dim summary of the current filter state, rendered in the header. */
+  headerFor?: (filter: F) => string;
+  /** The hotkey-legend help line; receives the mode so it can adapt. */
+  helpFor?: (filter: F, mode: 'nav' | 'search') => string;
+  /**
+   * Single-key bindings (by key name) that transform the filter. Returning the
+   * SAME reference is a no-op; a new object triggers a reload.
+   */
+  keyBindings?: Record<string, (filter: F) => F>;
+  /**
+   * Side-effecting keys that don't change the filter (e.g. `y` copies a command).
+   * Return a short string to flash under the list.
+   */
+  onKey?: (name: string, filter: F, active: T | undefined) => string | void;
+  /** Key that enters search mode (default `s`). */
+  searchKey?: string;
+  /** Key that toggles the preview pane (default `tab`). */
+  previewKey?: string;
+  pageSize?: number;
+  emptyMessage?: string;
+  loadingMessage?: string;
+  enterHint?: string;
+}
+
+/** The result returned when the user selects a row: the item plus the live filter. */
+export interface DynamicPicked<T, F> {
+  item: T;
+  filter: F;
+}
+
+/**
+ * Async-refetch variant of {@link itemPicker}. Holds a `filter` object in state and
+ * re-runs `load(filter)` whenever a keybinding mutates it (with a loading placeholder
+ * while the fetch — e.g. an SSH fleet fan-out — is in flight). A separate `S` search
+ * mode filters the loaded pool client-side. `enter` returns the active row + the live
+ * filter; `esc` cancels (from search mode, `esc` first exits search).
+ *
+ * Same render/pagination/preview machinery as the static pickers — only the data
+ * source and keymap are dynamic.
+ */
+export function dynamicPicker<T, F>(config: DynamicPickerConfig<T, F>): Promise<DynamicPicked<T, F> | null> {
+  const prompt = createPrompt<DynamicPicked<T, F> | null, DynamicPickerConfig<T, F>>((cfg, done) => {
+    const theme = makeTheme({});
+    const [status, setStatus] = useState<'idle' | 'done'>('idle');
+    const [filter, setFilter] = useState<F>(() => cfg.initialFilter);
+    const [items, setItems] = useState<T[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [query, setQuery] = useState('');
+    const [mode, setMode] = useState<'nav' | 'search'>('nav');
+    const [previewOpen, setPreviewOpen] = useState(false);
+    const [active, setActive] = useState(0);
+    const [flash, setFlash] = useState('');
+    const prefix = usePrefix({ status, theme });
+    // Guards against a slow load resolving after a newer filter superseded it.
+    const gen = useRef(0);
+
+    useEffect(() => {
+      const my = ++gen.current;
+      setLoading(true);
+      Promise.resolve(cfg.load(filter))
+        .then((rows) => {
+          if (my !== gen.current) return;
+          setItems(rows);
+          setLoading(false);
+          setActive(0);
+        })
+        .catch(() => {
+          if (my !== gen.current) return;
+          setItems([]);
+          setLoading(false);
+        });
+    }, [filter]);
+
+    const results = useMemo(() => {
+      const q = query.trim();
+      const pool = q && cfg.matches ? items.filter((it) => cfg.matches!(it, q)) : items;
+      return pool.slice(0, 200).map<Choice<T>>((item) => ({
+        value: item,
+        label: cfg.labelFor(item, q),
+      }));
+    }, [items, query]);
+
+    useEffect(() => {
+      if (active >= results.length) setActive(0);
+    }, [results]);
+
+    const selected = results[active];
+
+    const finish = (): void => {
+      if (!selected) return;
+      setStatus('done');
+      done({ item: selected.value, filter });
+    };
+
+    useKeypress((key, rl) => {
+      if (isEnterKey(key)) {
+        finish();
+        return;
+      }
+
+      // Search mode: let readline accumulate the typed text and mirror it into
+      // the query (backspace/edits handled by readline). Arrows still navigate.
+      if (mode === 'search') {
+        if (key.name === 'escape') {
+          rl.clearLine(0);
+          setQuery('');
+          setMode('nav');
+          return;
+        }
+        if (isUpKey(key)) {
+          if (results.length > 0) setActive((active - 1 + results.length) % results.length);
+          return;
+        }
+        if (isDownKey(key)) {
+          if (results.length > 0) setActive((active + 1) % results.length);
+          return;
+        }
+        setQuery(rl.line);
+        return;
+      }
+
+      // Nav mode: single keys are hotkeys — clear the readline buffer so a hotkey
+      // letter (r/b/c/…) never accumulates as stray input.
+      rl.clearLine(0);
+      if (key.name === 'escape') {
+        done(null);
+        return;
+      }
+      if (isUpKey(key)) {
+        if (results.length > 0) setActive((active - 1 + results.length) % results.length);
+        return;
+      }
+      if (isDownKey(key)) {
+        if (results.length > 0) setActive((active + 1) % results.length);
+        return;
+      }
+      if (flash) setFlash('');
+      if (key.name === (cfg.searchKey ?? 's')) {
+        setMode('search');
+        return;
+      }
+      if (cfg.buildPreview && key.name === (cfg.previewKey ?? 'tab')) {
+        setPreviewOpen(!previewOpen);
+        return;
+      }
+      const binding = cfg.keyBindings?.[key.name ?? ''];
+      if (binding) {
+        const next = binding(filter);
+        if (!Object.is(next, filter)) setFilter(next);
+        return;
+      }
+      if (cfg.onKey) {
+        const msg = cfg.onKey(key.name ?? '', filter, selected?.value);
+        if (msg) setFlash(msg);
+      }
+    });
+
+    const message = theme.style.message(cfg.message, status);
+
+    if (status === 'done') {
+      return `${prefix} ${message}`;
+    }
+
+    const headerBits = [prefix, message];
+    if (cfg.headerFor) headerBits.push(chalk.gray(cfg.headerFor(filter)));
+    if (mode === 'search') {
+      headerBits.push(query ? chalk.cyan('/' + query) : chalk.gray('/ (type to filter)'));
+    } else if (query) {
+      headerBits.push(chalk.cyan('/' + query));
+    }
+    const header = headerBits.filter(Boolean).join(' ');
+
+    const page = usePagination({
+      items: results as any,
+      active,
+      renderItem({ item, isActive }: { item: Choice<T>; isActive: boolean }) {
+        if (Separator.isSeparator(item)) return ` ${(item as any).separator}`;
+        const cursor = isActive ? chalk.cyan('>') : ' ';
+        const row = isActive ? chalk.bold(item.label) : item.label;
+        return `${cursor} ${row}`;
+      },
+      pageSize: cfg.pageSize ?? 12,
+      loop: false,
+    });
+
+    const help = chalk.gray(
+      cfg.helpFor
+        ? cfg.helpFor(filter, mode)
+        : mode === 'search'
+          ? '↑↓ navigate · esc exit search · ⏎ ' + (cfg.enterHint ?? 'select')
+          : 's search · ↑↓ navigate · ⏎ ' + (cfg.enterHint ?? 'select') + ' · esc cancel',
+    );
+
+    const parts: string[] = [header];
+    if (loading) {
+      parts.push(chalk.gray(`  ${cfg.loadingMessage ?? 'Loading…'}`));
+    } else {
+      parts.push(page);
+      if (results.length === 0) {
+        parts.push(chalk.gray(`  ${cfg.emptyMessage ?? 'No matches.'}`));
+      }
+    }
+
+    if (previewOpen && selected && cfg.buildPreview && !loading) {
+      const width = terminalWidth();
+      const separator = chalk.gray('─'.repeat(Math.min(width, 80)));
+      const flashRows = flash ? renderedRows(flash, width) : 0;
+      const fixedRows =
+        renderedRows(header, width) +
+        renderedRows(parts.slice(1).join('\n'), width) +
+        renderedRows(separator, width) +
+        renderedRows(help, width) +
+        flashRows;
+      const availablePreviewRows = terminalRows() - fixedRows;
+      const preview = limitPreviewHeight(cfg.buildPreview(selected.value), availablePreviewRows, width);
+      if (preview) {
+        parts.push(separator);
+        parts.push(preview);
+      }
+    }
+
+    if (flash) parts.push(chalk.green(flash));
     parts.push(help);
 
     return [header, parts.slice(1).join('\n')];

--- a/apps/cli/src/lib/picker.ts
+++ b/apps/cli/src/lib/picker.ts
@@ -28,6 +28,7 @@ import {
   isUpKey,
   isDownKey,
   isSpaceKey,
+  isBackspaceKey,
   Separator,
 } from '@inquirer/core';
 import chalk from 'chalk';
@@ -542,8 +543,9 @@ export function dynamicPicker<T, F>(config: DynamicPickerConfig<T, F>): Promise<
         return;
       }
 
-      // Search mode: let readline accumulate the typed text and mirror it into
-      // the query (backspace/edits handled by readline). Arrows still navigate.
+      // Search mode: we own the query buffer (readline's line doesn't survive
+      // across renders here, so we build it from key events). Clear readline
+      // every keystroke so nothing leaks, then append the typed character.
       if (mode === 'search') {
         if (key.name === 'escape') {
           rl.clearLine(0);
@@ -552,14 +554,25 @@ export function dynamicPicker<T, F>(config: DynamicPickerConfig<T, F>): Promise<
           return;
         }
         if (isUpKey(key)) {
+          rl.clearLine(0);
           if (results.length > 0) setActive((active - 1 + results.length) % results.length);
           return;
         }
         if (isDownKey(key)) {
+          rl.clearLine(0);
           if (results.length > 0) setActive((active + 1) % results.length);
           return;
         }
-        setQuery(rl.line);
+        if (isBackspaceKey(key)) {
+          rl.clearLine(0);
+          setQuery(query.slice(0, -1));
+          return;
+        }
+        const seq = (key as { sequence?: string }).sequence;
+        rl.clearLine(0);
+        if (seq && seq.length === 1 && seq >= ' ' && !key.ctrl) {
+          setQuery(query + seq);
+        }
         return;
       }
 

--- a/apps/cli/src/lib/picker.ts
+++ b/apps/cli/src/lib/picker.ts
@@ -454,9 +454,10 @@ export interface DynamicPickerConfig<T, F> {
   keyBindings?: Record<string, (filter: F) => F>;
   /**
    * Side-effecting keys that don't change the filter (e.g. `y` copies a command).
-   * Return a short string to flash under the list.
+   * Receives the live search `query` so the effect can be search-aware. Return a
+   * short string to flash under the list.
    */
-  onKey?: (name: string, filter: F, active: T | undefined) => string | void;
+  onKey?: (name: string, filter: F, active: T | undefined, query: string) => string | void;
   /** Key that enters search mode (default `s`). */
   searchKey?: string;
   /** Key that toggles the preview pane (default `tab`). */
@@ -548,8 +549,10 @@ export function dynamicPicker<T, F>(config: DynamicPickerConfig<T, F>): Promise<
       // every keystroke so nothing leaks, then append the typed character.
       if (mode === 'search') {
         if (key.name === 'escape') {
+          // Exit search but KEEP the query as an active filter, so hotkeys (and
+          // the y copy-cmd) operate on the searched view. A second esc in nav
+          // clears it. Enter also confirms the highlighted row directly.
           rl.clearLine(0);
-          setQuery('');
           setMode('nav');
           return;
         }
@@ -580,6 +583,11 @@ export function dynamicPicker<T, F>(config: DynamicPickerConfig<T, F>): Promise<
       // letter (r/b/c/…) never accumulates as stray input.
       rl.clearLine(0);
       if (key.name === 'escape') {
+        // First esc clears an active search filter; a second (no filter) cancels.
+        if (query) {
+          setQuery('');
+          return;
+        }
         done(null);
         return;
       }
@@ -607,7 +615,7 @@ export function dynamicPicker<T, F>(config: DynamicPickerConfig<T, F>): Promise<
         return;
       }
       if (cfg.onKey) {
-        const msg = cfg.onKey(key.name ?? '', filter, selected?.value);
+        const msg = cfg.onKey(key.name ?? '', filter, selected?.value, query);
         if (msg) setFlash(msg);
       }
     });


### PR DESCRIPTION
## One filter model, two front-ends

`agents sessions` had three disjoint faces: a single-select picker, a multi-select `resume` picker, and a static `--active` `console.log` dump. Resume and preview are the hot paths, and slicing by device / project / agent across the fleet had to be done from memory of flags.

This unifies them behind **one canonical filter state**, driven two ways:

- **Humans** — an interactive fleet-wide browser. Single keys toggle each dimension; the list re-pulls live. Filters **stack** (AND together) and the active set shows in the header.
- **Agents / scripts** — the identical state as flags. `--json`, a pipe, or `--no-interactive` keep the existing static listing verbatim, so scripts and headless agents are unchanged.

The `y` hotkey / `--print-cmd` bridges the two: build a view by hand, copy the exact `ag sessions …` line, hand it to an agent.

### It renders

```
? Sessions device:all · agent:all · all dirs · window:30d
> a1b2c3d4  claude   2.1.207 my-app          add auth middleware to the gateway    PR#412     just now
  b5c6d7e8  codex    0.116.0 my-app          refactor the session store            —          2 min ago
  c9d0e1f2  claude   2.1.207 infra           fix the deploy rollback path           TICKET-88  14 min ago
s search · r running · c teams · a agent · d device · p project · w window · y copy-cmd · ⏎ resume · esc quit
```

### Hotkey ⇄ flag

| key | filters by | flag it mirrors |
|---|---|---|
| `s` | search text | `--query` / positional |
| `r` | running only | `--active` |
| `c` | team sessions | `--teams` |
| `a` | agent (cycles) | `-a` |
| `d` | device (cycles) | `--device` |
| `p` | this repo ↔ all dirs | `--all` |
| `w` | time window | `--since` |
| `⏎` | resume / attach | `resume` / `focus` |
| `y` | copy the equivalent command | `--print-cmd` |

Also adds `-p` short for `--project`, `--print-cmd`, `--preview` (`ag sessions <id> --preview` — the compact digest without the pager), and `--no-interactive`.

## How it's built

- **`dynamicPicker`** (`lib/picker.ts`) — an async-refetch variant of the existing `@inquirer/core` pickers: holds a filter in state, re-runs `load(filter)` on any keybinding with a loading placeholder, plus an `S` search mode. Reuses the existing render/pagination/preview machinery.
- **`sessionBrowser()`** (`commands/sessions-browser.ts`) — wires the filter to the data sources that already exist: `discoverSessions` + the fleet SSH fan-out (`gatherRemoteList`) + the live index + `buildPreview`, and dispatches `⏎` through the shared `handlePickedSession` resume/focus path. The transcript fetch is cached by `(window, teams)` so cheap filter hotkeys re-filter in memory; the live scan is fetched once, lazily, only when the running filter needs it (so a bare browse stays as fast as the disk index).
- **Wiring** (`commands/sessions.ts`) — `--active` and a bare `sessions` route to the browser on a TTY; every scripting path is preserved.

## Verified end-to-end

Driven in a real pty:
- Interactive `--active` opens the browser; `a`/`d`/`s`/`p` re-filter live and the header tracks the stack.
- `y` copies the exact `ag sessions …` command the current filters map to — verified the clipboard holds it (the human→agent bridge round-trips).
- Fleet fan-out folds in rows from other machines with a device column.
- Scripting paths preserved: `--active --json` and `--active --no-interactive` emit the exact prior dump; `--print-cmd` echoes the canonical command; `--preview <id>` prints the digest.
- `bun test` green (10 new `sessions-browser.test.ts` + 26 existing sessions/picker); `bun run build` clean.

## Scope / follow-ups

- Browser-capture (`--browser`) and cloud (`--cloud`) sources are separate data models and are **not** folded into the browser yet — a documented fast-follow. The shipped hotkeys cover agent transcripts (the common path).
- Pre-existing `NOT NULL constraint failed: sessions.short_id` indexer warnings print above the prompt on first load (unrelated to this change).

Linear: RUSH-1802 (+ subtasks 1803–1807).
