### PR TITLE
fix(plugins): gate plugin updates that add new exec surfaces (RUSH-1757)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ### Security
 
+- **`agents plugins update` no longer silently executes a compromised upstream (RUSH-1757).**
+  A plugin's upstream is mutable: `updatePlugin` used to `git pull --ff-only` (or
+  re-copy) straight over the live plugin tree, then re-sync — and when the new
+  revision added an executable surface (`hooks/`, `.mcp.json`, `bin/`, `scripts/`,
+  `settings.json`, `permissions/`) it only *declined to add* an enablement key,
+  never *removed* a pre-existing one. A benign, already-enabled plugin whose
+  upstream was later compromised would therefore execute new hooks/MCP on the next
+  update without renewed consent. The update now fetches the incoming revision into
+  a **quarantine** dir first, diffs its capabilities against the current on-disk
+  baseline, and applies to the live tree only after the trust decision: an update
+  that introduces a *new* exec surface is **refused** (last-good content kept in
+  place) unless the user re-consents with `agents plugins update <name>
+  --allow-exec-surfaces`. A surface the user already trusted is not "new" and does
+  not re-trigger the gate. Source: `apps/cli/src/lib/plugins.ts` (`updatePlugin`,
+  `newExecSurfaceLabels`), `apps/cli/src/commands/plugins.ts`.
 - **`launch_app` on Windows rejects UNC/remote and protocol/URL targets (RUSH-1763).**
   Explicit `path` values used to flow straight into `ProcessStartInfo` with
   `UseShellExecute=true`, so a caller could launch `\\server\share\payload.exe`

--- a/apps/cli/src/commands/plugins.ts
+++ b/apps/cli/src/commands/plugins.ts
@@ -671,6 +671,7 @@ Examples:
   pluginsCmd
     .command('update [name]')
     .description('Re-pull a plugin from its original source and re-sync to all versions')
+    .option('--allow-exec-surfaces', 'Consent to an update that introduces new executable surfaces (hooks/, bin/, scripts/, .mcp.json, settings.json, permissions/)')
     .addHelpText('after', `
 Examples:
   # Update a specific plugin
@@ -678,8 +679,11 @@ Examples:
 
   # Update all plugins
   agents plugins update
+
+  # Trust an update that adds new executable surfaces
+  agents plugins update rush-toolkit --allow-exec-surfaces
 `)
-    .action(async (nameArg?: string) => {
+    .action(async (nameArg: string | undefined, options: { allowExecSurfaces?: boolean }) => {
       const plugins = nameArg ? [getPlugin(nameArg)].filter(Boolean) as DiscoveredPlugin[] : discoverPlugins();
 
       if (nameArg && plugins.length === 0) {
@@ -692,25 +696,43 @@ Examples:
         return;
       }
 
+      const allowExec = options.allowExecSurfaces === true;
+
       for (const plugin of plugins) {
         process.stdout.write(`Updating ${plugin.name}... `);
-        const result = await updatePlugin(plugin.name);
+        const result = await updatePlugin(plugin.name, { allowExecSurfaces: allowExec });
         if (!result.success) {
-          console.log(chalk.red(`failed — ${result.error || 'unknown error'}`));
+          if (result.blockedByExecSurfaces) {
+            // Security (RUSH-1757): the update introduced new executable surfaces.
+            // Refuse without renewed consent; the last-good content stays in place.
+            console.log(chalk.yellow('skipped'));
+            console.log(chalk.yellow(`  Update introduces new executable surfaces: ${(result.newExecSurfaces || []).join(', ')}`));
+            console.log(chalk.gray('  Kept the currently-installed revision. Re-run with --allow-exec-surfaces if you trust the source.'));
+          } else {
+            console.log(chalk.red(`failed — ${result.error || 'unknown error'}`));
+          }
           continue;
         }
         console.log(chalk.green('done'));
 
-        // Re-sync to all supported installed versions
+        // Reload the plugin so the re-sync reads the freshly-applied revision.
+        const updated = getPlugin(plugin.name) ?? plugin;
+
+        // Re-sync to all supported installed versions. When the applied revision
+        // carries executable surfaces, only enable them if the user consented on
+        // this update (--allow-exec-surfaces); otherwise the benign content syncs
+        // but stays disabled, matching the install-time trust gate.
         for (const agentId of capableAgents('plugins')) {
-          if (!pluginSupportsAgent(plugin, agentId)) continue;
+          if (!pluginSupportsAgent(updated, agentId)) continue;
           const versions = listInstalledVersions(agentId);
           const defaultVer = getGlobalDefault(agentId);
           const targetVersions = defaultVer ? [defaultVer] : versions.slice(-1);
 
           for (const version of targetVersions) {
-            const syncResult = syncResourcesToVersion(agentId, version, { plugins: [plugin.name] });
-            if (syncResult.plugins.length > 0) {
+            const didSync = allowExec
+              ? syncPluginToVersion(updated, agentId, getVersionHomePath(agentId, version), { allowExecSurfaces: true, version }).success
+              : syncResourcesToVersion(agentId, version, { plugins: [updated.name] }).plugins.length > 0;
+            if (didSync) {
               console.log(chalk.gray(`  Re-synced to ${agentLabel(agentId)}@${version}`));
             }
           }

--- a/apps/cli/src/lib/plugins.test.ts
+++ b/apps/cli/src/lib/plugins.test.ts
@@ -1980,3 +1980,136 @@ describe('syncPluginToVersion (hermes plugin install)', () => {
     expect(config.plugins?.enabled ?? []).not.toContain('myplugin');
   });
 });
+
+// ─── updatePlugin — quarantine + capability-diff consent gate (RUSH-1757) ─────
+
+describe('updatePlugin exec-surface consent gate', () => {
+  let tmpDir: string;
+  let pluginsDir: string;
+  let sourceDir: string;
+
+  // Install a local-source plugin at pluginsDir/<name> whose .source points at a
+  // mutable upstream (sourceDir). Returns the paths so the test can mutate the
+  // upstream to simulate an update.
+  function install(name: string, seed: (root: string) => void): { pluginRoot: string; upstream: string } {
+    const upstream = path.join(sourceDir, name);
+    fs.mkdirSync(path.join(upstream, '.claude-plugin'), { recursive: true });
+    fs.writeFileSync(
+      path.join(upstream, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name, version: '1.0.0', description: 'Test' }),
+      'utf-8'
+    );
+    seed(upstream);
+
+    const pluginRoot = path.join(pluginsDir, name);
+    fs.cpSync(upstream, pluginRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginRoot, '.source'),
+      JSON.stringify({ source: upstream, isGit: false, version: '1.0.0' }),
+      'utf-8'
+    );
+    return { pluginRoot, upstream };
+  }
+
+  async function loadUpdate() {
+    vi.resetModules();
+    vi.doMock('./state.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('./state.js')>();
+      return {
+        ...actual,
+        getPluginsDir: () => pluginsDir,
+        getEnabledExtraRepos: () => [],
+        getProjectPluginsDir: () => null,
+        getSystemPluginsDir: () => path.join(tmpDir, 'no-system'),
+      };
+    });
+    return import('./plugins.js');
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-update-'));
+    pluginsDir = path.join(tmpDir, 'plugins');
+    sourceDir = path.join(tmpDir, 'source');
+    fs.mkdirSync(pluginsDir, { recursive: true });
+    fs.mkdirSync(sourceDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    vi.doUnmock('./state.js');
+    vi.resetModules();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('applies a benign update (no new exec surfaces) and swaps in the new content', async () => {
+    const { pluginRoot, upstream } = install('benign', () => {});
+    // Upstream ships a new benign resource and bumps its version.
+    fs.mkdirSync(path.join(upstream, 'skills'), { recursive: true });
+    fs.writeFileSync(path.join(upstream, 'skills', 'new.md'), '# new skill\n', 'utf-8');
+    fs.writeFileSync(
+      path.join(upstream, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name: 'benign', version: '1.1.0', description: 'Test' }),
+      'utf-8'
+    );
+
+    const { updatePlugin } = await loadUpdate();
+    const result = await updatePlugin('benign');
+
+    expect(result.success).toBe(true);
+    expect(result.blockedByExecSurfaces).toBeUndefined();
+    expect(fs.existsSync(path.join(pluginRoot, 'skills', 'new.md'))).toBe(true);
+    // .source re-stamped to the fresh manifest version.
+    const src = JSON.parse(fs.readFileSync(path.join(pluginRoot, '.source'), 'utf-8'));
+    expect(src.version).toBe('1.1.0');
+    // Quarantine dir cleaned up.
+    expect(fs.existsSync(path.join(pluginsDir, '.benign.update-quarantine'))).toBe(false);
+  });
+
+  it('refuses an update that introduces a NEW exec surface and keeps the old content', async () => {
+    const { pluginRoot, upstream } = install('gains-hooks', () => {});
+    // Upstream is compromised to add a hooks/ surface.
+    fs.mkdirSync(path.join(upstream, 'hooks'), { recursive: true });
+    fs.writeFileSync(path.join(upstream, 'hooks', 'evil.json'), '{}', 'utf-8');
+
+    const { updatePlugin } = await loadUpdate();
+    const result = await updatePlugin('gains-hooks');
+
+    expect(result.success).toBe(false);
+    expect(result.blockedByExecSurfaces).toBe(true);
+    expect(result.newExecSurfaces).toContain('hooks/');
+    // Last-good content preserved — the hostile hooks/ never landed.
+    expect(fs.existsSync(path.join(pluginRoot, 'hooks'))).toBe(false);
+    // No quarantine residue.
+    expect(fs.existsSync(path.join(pluginsDir, '.gains-hooks.update-quarantine'))).toBe(false);
+  });
+
+  it('applies the surface-introducing update when consent is given', async () => {
+    const { pluginRoot, upstream } = install('gains-hooks-ok', () => {});
+    fs.mkdirSync(path.join(upstream, 'hooks'), { recursive: true });
+    fs.writeFileSync(path.join(upstream, 'hooks', 'trusted.json'), '{}', 'utf-8');
+
+    const { updatePlugin } = await loadUpdate();
+    const result = await updatePlugin('gains-hooks-ok', { allowExecSurfaces: true });
+
+    expect(result.success).toBe(true);
+    expect(result.hasExecSurfaces).toBe(true);
+    expect(fs.existsSync(path.join(pluginRoot, 'hooks', 'trusted.json'))).toBe(true);
+  });
+
+  it('does not gate a surface the plugin already carried (not a NEW surface)', async () => {
+    // Both the installed revision and the upstream ship hooks/ — the surface is
+    // pre-existing, so an update must not re-trigger the consent gate.
+    const { pluginRoot, upstream } = install('already-hooks', (root) => {
+      fs.mkdirSync(path.join(root, 'hooks'), { recursive: true });
+      fs.writeFileSync(path.join(root, 'hooks', 'existing.json'), '{}', 'utf-8');
+    });
+    // Upstream ships a benign change on top of the existing surface.
+    fs.writeFileSync(path.join(upstream, 'hooks', 'existing.json'), '{"v":2}', 'utf-8');
+
+    const { updatePlugin } = await loadUpdate();
+    const result = await updatePlugin('already-hooks');
+
+    expect(result.success).toBe(true);
+    expect(result.blockedByExecSurfaces).toBeUndefined();
+    expect(fs.readFileSync(path.join(pluginRoot, 'hooks', 'existing.json'), 'utf-8')).toContain('"v":2');
+  });
+});

--- a/apps/cli/src/lib/plugins.ts
+++ b/apps/cli/src/lib/plugins.ts
@@ -1949,7 +1949,49 @@ export function getUpstreamManifestVersion(info: PluginSourceInfo): string | nul
  * Update an installed plugin by re-pulling from its original source.
  * Returns true if the update succeeded.
  */
-export async function updatePlugin(name: string): Promise<{ success: boolean; error?: string }> {
+/**
+ * Labels of exec surfaces present in `after` that were NOT present in `before`.
+ * Used by updatePlugin to distinguish a newly-appearing execution surface
+ * (upstream compromise → renewed consent required) from one the user already
+ * trusted (leave enablement alone).
+ */
+export function newExecSurfaceLabels(
+  before: PluginCapabilities,
+  after: PluginCapabilities,
+): string[] {
+  return (Object.keys(PLUGIN_EXEC_SURFACE_LABELS) as Array<keyof PluginCapabilities>)
+    .filter((key) => after[key] && !before[key])
+    .map((key) => PLUGIN_EXEC_SURFACE_LABELS[key]);
+}
+
+/**
+ * Re-fetch a plugin from its recorded source and apply the update to disk.
+ *
+ * Security (RUSH-1757): a plugin's upstream is mutable. `updatePlugin` never
+ * mutates the live plugin tree before it has inspected the incoming content —
+ * the new revision is fetched into a **quarantine** dir first, its capabilities
+ * are diffed against the current on-disk baseline, and the update is applied to
+ * `plugin.root` only after the trust decision. If the update introduces a NEW
+ * executable surface (hooks/, .mcp.json, bin/, scripts/, settings.json,
+ * permissions/) that the current revision did not carry, the update is refused
+ * unless `options.allowExecSurfaces` is set — the last-good content is kept in
+ * place, so a benign-then-compromised upstream can never execute on the next
+ * update without renewed consent. A surface the user already trusted is not a
+ * "new" surface and does not re-trigger the gate.
+ */
+export async function updatePlugin(
+  name: string,
+  options: { allowExecSurfaces?: boolean } = {},
+): Promise<{
+  success: boolean;
+  error?: string;
+  /** True when the update was refused because it introduced new exec surfaces. */
+  blockedByExecSurfaces?: boolean;
+  /** Labels of exec surfaces newly introduced by this update, if any. */
+  newExecSurfaces?: string[];
+  /** Whether the applied revision carries executable surfaces (for the caller's re-sync). */
+  hasExecSurfaces?: boolean;
+}> {
   const plugin = getPlugin(name);
   if (!plugin) {
     return { success: false, error: `Plugin '${name}' not found` };
@@ -1967,25 +2009,66 @@ export async function updatePlugin(name: string): Promise<{ success: boolean; er
     return { success: false, error: `Could not read source info for '${name}'` };
   }
 
+  // Baseline: what the live (already-trusted) revision ships today.
+  const before = inspectPluginCapabilities(plugin.root);
+
+  // Quarantine dir lives beside plugin.root (same filesystem) so the final
+  // apply can be a rename. The dot-prefix keeps it out of plugin discovery.
+  const quarantine = path.join(
+    path.dirname(plugin.root),
+    `.${path.basename(plugin.root)}.update-quarantine`,
+  );
+  const cleanupQuarantine = () => {
+    try { fs.rmSync(quarantine, { recursive: true, force: true }); } catch { /* best effort */ }
+  };
+  cleanupQuarantine();
+
   try {
+    // 1. Fetch the incoming revision into quarantine — never touch plugin.root yet.
     if (sourceInfo.isGit) {
-      execFileSync('git', ['-C', plugin.root, 'pull', '--ff-only'], { stdio: 'pipe' });
+      // Copy the working checkout (with its .git) and fast-forward the copy, so a
+      // hostile upstream diff lands in the quarantine, not the live tree.
+      fs.cpSync(plugin.root, quarantine, { recursive: true });
+      execFileSync('git', ['-C', quarantine, 'pull', '--ff-only'], { stdio: 'pipe' });
     } else {
       const resolvedSource = sourceInfo.source.replace(/^~/, homeDir());
       if (!fs.existsSync(resolvedSource)) {
+        cleanupQuarantine();
         return { success: false, error: `Source path no longer exists: ${resolvedSource}` };
       }
-      // Preserve .user-config.json and .source during re-copy
-      const userConfigPath = path.join(plugin.root, USER_CONFIG_FILE);
-      const userConfigBackup = fs.existsSync(userConfigPath)
-        ? fs.readFileSync(userConfigPath, 'utf-8')
-        : null;
-      fs.rmSync(plugin.root, { recursive: true, force: true });
-      fs.cpSync(resolvedSource, plugin.root, { recursive: true });
-      if (userConfigBackup !== null) {
-        fs.writeFileSync(userConfigPath, userConfigBackup, 'utf-8');
-      }
+      fs.cpSync(resolvedSource, quarantine, { recursive: true });
     }
+
+    // 2. Diff capabilities of the incoming revision against the baseline.
+    const after = inspectPluginCapabilities(quarantine);
+    const newSurfaces = newExecSurfaceLabels(before, after);
+
+    // 3. Refuse a surface-introducing update without renewed consent. The
+    //    last-good content stays in place untouched.
+    if (newSurfaces.length > 0 && options.allowExecSurfaces !== true) {
+      cleanupQuarantine();
+      return {
+        success: false,
+        blockedByExecSurfaces: true,
+        newExecSurfaces: newSurfaces,
+        error:
+          `Update refused: '${name}' introduces new executable surfaces (${newSurfaces.join(', ')}). ` +
+          `Re-run with --allow-exec-surfaces if you trust the source.`,
+      };
+    }
+
+    // 4. Apply: swap the quarantined revision into plugin.root, preserving the
+    //    user config and re-stamping .source.
+    const userConfigPath = path.join(plugin.root, USER_CONFIG_FILE);
+    const userConfigBackup = fs.existsSync(userConfigPath)
+      ? fs.readFileSync(userConfigPath, 'utf-8')
+      : null;
+    fs.rmSync(plugin.root, { recursive: true, force: true });
+    fs.renameSync(quarantine, plugin.root);
+    if (userConfigBackup !== null) {
+      fs.writeFileSync(userConfigPath, userConfigBackup, 'utf-8');
+    }
+
     // Re-stamp .source with the freshly pulled manifest version so the baseline
     // tracks what's now on disk (keeps the heal "unmodified?" check honest).
     const freshVersion = loadPluginManifest(plugin.root)?.version;
@@ -1994,9 +2077,10 @@ export async function updatePlugin(name: string): Promise<{ success: boolean; er
       JSON.stringify({ ...sourceInfo, version: freshVersion }),
       'utf-8',
     );
+
+    return { success: true, newExecSurfaces: newSurfaces, hasExecSurfaces: hasPluginExecSurfaces(after) };
   } catch (err) {
+    cleanupQuarantine();
     return { success: false, error: (err as Error).message };
   }
-
-  return { success: true };
 }


### PR DESCRIPTION
## Security (High): supply-chain #6 — RUSH-1757

`agents plugins update` followed a **mutable** upstream (`git pull --ff-only`, or re-copy for local sources) straight over the live plugin tree, then re-synced. When the new revision introduced an executable surface (`hooks/`, `.mcp.json`, `bin/`, `scripts/`, `settings.json`, `permissions/`), the sync path only *declined to add* an enablement key — it **never removed a pre-existing one** (deliberately, to avoid clobbering a plugin the user trusted with `--allow-exec-surfaces`). Net effect: a benign, already-enabled plugin whose upstream was later compromised would **execute new hooks/MCP on the next update without renewed consent**.

## Fix — quarantine, diff, consent

`updatePlugin` now:
1. Records the current on-disk capability **baseline** (what the already-trusted revision ships).
2. Fetches the incoming revision into a **quarantine** dir beside the plugin — the live tree is never mutated before inspection (also closes the "git pull mutates in place before any check" hole).
3. **Diffs** the quarantined capabilities against the baseline.
4. If a *new* exec surface appears and the user did not consent, the update is **refused** — the last-good content stays in place. A surface the user already trusted is **not** "new" and does not re-trigger the gate.
5. Applies (rename-swap, preserving `.user-config.json` + re-stamping `.source`) only after the decision.

New flag: `agents plugins update <name> --allow-exec-surfaces` grants renewed consent, mirroring the install-time trust gate (`shouldRefusePluginInstall`).

The diff-aware gate lives in the **update path** on purpose — a blanket disable-on-exec-surface in `syncPluginToVersion` would clobber plugins the user deliberately enabled (see the note at `plugins.ts` re: never down-toggling on a background re-sync).

## Tests — real fs, no mocking

`plugins.test.ts` adds 4 cases exercising the real critical path:
- benign update applies + swaps content + re-stamps `.source`
- update that introduces `hooks/` is **refused**, old content kept, no quarantine residue
- same update **applies with `--allow-exec-surfaces`**
- a **pre-existing** surface does not re-gate a later benign update

## End-to-end (built binary, isolated HOME)

```
### compromise upstream: add hooks/pwn.json
### update WITHOUT consent
    Updating demo... skipped
      Update introduces new executable surfaces: hooks/
      Kept the currently-installed revision. Re-run with --allow-exec-surfaces if you trust the source.
>> hooks/ absent (correct)
### update WITH consent
    Updating demo... done
>> hooks/pwn.json present (correct)
### benign second update (surface now pre-existing → no gate)
    Updating demo... done
>> benign update applied without re-gating (correct)
```

`bunx tsc --noEmit` clean; `plugins` + `plugin-marketplace` + `commands/plugins` suites 156/156 green.

Session transcript (private repo): zion:/Users/muqsit/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/4a32fa53-54eb-49e5-9c8e-3c5948e80f9a.jsonl