### PR TITLE
fix(secrets): store bare keychain items correctly on macOS (RUSH-1764 regression from #1240)

### DIFF
--- a/apps/cli/src/lib/secrets/index.test.ts
+++ b/apps/cli/src/lib/secrets/index.test.ts
@@ -37,9 +37,11 @@ describe('buildAddGenericPasswordArgs (RUSH-1764: value never in argv)', () => {
     // The whole point: the value must not appear anywhere in the command line.
     expect(args.some((a) => a.includes(secret))).toBe(false);
     expect(args).not.toContain(secret);
-    // Still the right item write: upsert (-U), account (-a), service (-s), no -w.
-    expect(args).toEqual(['add-generic-password', '-U', '-a', 'alice', '-s', 'linear-api-key']);
-    expect(args).not.toContain('-w');
+    // Still the right item write: upsert (-U), account (-a), service (-s), and a
+    // BARE `-w` last so security prompts and reads the value from stdin -- the flag
+    // carries no value, so the secret is still absent from argv.
+    expect(args).toEqual(['add-generic-password', '-U', '-a', 'alice', '-s', 'linear-api-key', '-w']);
+    expect(args[args.length - 1]).toBe('-w');
   });
 });
 

--- a/apps/cli/src/lib/secrets/index.ts
+++ b/apps/cli/src/lib/secrets/index.ts
@@ -932,7 +932,7 @@ function parseBatchRecords(out: string, record: (service: string, value: string)
  * a `ps` snapshot. Exported so a test can assert the value is absent from argv.
  */
 export function buildAddGenericPasswordArgs(account: string, item: string): string[] {
-  return ['add-generic-password', '-U', '-a', account, '-s', item];
+  return ['add-generic-password', '-U', '-a', account, '-s', item, '-w'];
 }
 
 export function setKeychainToken(item: string, value: string, opts?: { noAcl?: boolean }): void {
@@ -956,17 +956,19 @@ export function setKeychainToken(item: string, value: string, opts?: { noAcl?: b
   // sheet. -U upserts so repeated sets overwrite in place.
   if (!isOurItem(item)) {
     // The secret VALUE must never appear in argv — a `ps` snapshot on a shared
-    // host would leak it (RUSH-1764). `security add-generic-password` reads the
-    // password from stdin when `-w` is omitted (readpassphrase(3) falls back to
-    // fd 0 when it has no controlling terminal), so we pipe the value instead of
-    // passing it on the command line. The item stays ACL-free (no biometry gate),
-    // so the no-prompt /usr/bin/security read path in getKeychainToken still
-    // works. Values are newline-free on darwin (assertValueStorable above), so
-    // one stdin line carries the whole secret. `timeout` bounds the call so a
-    // context that unexpectedly wants a TTY prompt fails loudly instead of
-    // hanging — never a silent fall-through that would re-expose the value.
+    // host would leak it (RUSH-1764). `security add-generic-password` has no
+    // stdin-password flag; instead a BARE `-w` as the LAST option makes it prompt
+    // ("password data for new item:" / "retype...") and read the secret from fd 0
+    // via readpassphrase(3) -- so the value travels over stdin, never on the
+    // command line. The prompt asks twice (enter + confirm), so we pipe the value
+    // TWICE; a single line fails the confirm and would store an empty secret. The
+    // item stays ACL-free (no biometry gate), so the no-prompt /usr/bin/security
+    // read path in getKeychainToken still works. Values are newline-free on darwin
+    // (assertValueStorable above), so each line carries the whole secret verbatim
+    // (no shell/quoting layer). `timeout` bounds the call so a context that cannot
+    // read the prompt fails loudly instead of hanging.
     const sec = spawnSync('/usr/bin/security', buildAddGenericPasswordArgs(os.userInfo().username, item), {
-      input: `${value}\n`,
+      input: `${value}\n${value}\n`,
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 10_000,
     });


### PR DESCRIPTION
## Problem — merged #1240 silently stores EMPTY secrets on macOS

#1240 (RUSH-1760/1764) changed `setKeychainToken` to call
`security add-generic-password` **without `-w`**, piping the secret on one stdin
line, on the premise (comment + a test asserting `-w` absent) that *"security
reads the password from stdin when `-w` is omitted (readpassphrase falls back to
fd 0)."*

**That premise is false.** This path couldn't run in the Linux CI, and the
required macOS smoke test wasn't done before merge. On macOS, omitting `-w`
creates the item with **no password** and returns `0` — so every bare item (e.g.
`linear-api-key` via `agents secrets set`) is silently stored **empty**. Worse
than a hang: it looks like success.

## Root cause (verified on macOS, isolated throwaway keychains)

`security add-generic-password` has **no stdin-password flag**. Only a **bare
`-w` as the last option** makes it prompt (`password data for new item:` /
`retype…`) and read the value **raw** from stdin via `readpassphrase(3)`. The
prompt asks **twice**, so the value must be piped twice — a single line fails the
confirm and stores empty.

| form | result |
|---|---|
| no `-w`, 1 line (merged #1240) | **empty** |
| no `-w`, 2 lines | **empty** |
| `-w value` in argv (old, leaky) | works, but leaks in `ps` |
| **bare `-w` last, value piped ×2** | **works, value never in argv** |

Round-trip confirmed across adversarial values (spaces, `'`, `"`, `\`, `$`, mixed) — all 7 pass.

## Fix

- args: `[…, '-s', item, '-w']` — bare `-w` last; the flag carries no value, so
  the secret is **still absent from argv** (RUSH-1764's goal preserved).
- input: `` `${value}\n${value}\n` `` — satisfies the enter+retype prompt.
- corrected the false-premise comment and the `-w` test assertion.

`tsc --noEmit` clean; `src/lib/secrets/index.test.ts` — 31/31 pass.