### PR TITLE
docs(changelog): file session-browser note as a .changelog fragment (RUSH-1802)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,24 @@
   session databases migrate additively and backfill on the next scan (the first
   run re-indexes once).
 
+- **Interactive session browser — `agents sessions --active` and a bare `agents sessions`
+  now open a live, filterable picker on a TTY (RUSH-1802).** One canonical filter driven by
+  single keys, re-pulled across the fleet as you toggle: `s` search, `r` running-only, `c`
+  teams, `a` agent (cycles), `d` device (cycles), `p` this-repo↔all-dirs, `w` time window;
+  filters **stack** (AND together) and the active set shows in the header, with a live
+  preview of the highlighted row and `⏎` to resume/attach via the existing dispatch. Every
+  hotkey mirrors a flag, so the view is reproducible as a command — `y` copies (and
+  `--print-cmd` prints) the exact `ag sessions …` line the filters map to, bridging the
+  human picker and the agent/script flag surface. The interactive front-end is TTY-only:
+  `--json`, a pipe, or the new `--no-interactive` keep the existing static listing verbatim,
+  so scripts and headless agents are unchanged. Adds `-p` as the short form of `--project`,
+  `--print-cmd`, `--preview` (`agents sessions <id> --preview` prints the compact digest
+  without the pager), and `--no-interactive`. Built on a new async-refetch `dynamicPicker`
+  variant that reuses the existing render/pagination/preview machinery, the fleet SSH
+  fan-out, and the resume/focus path. Source: `apps/cli/src/lib/picker.ts` (`dynamicPicker`),
+  `apps/cli/src/commands/sessions-browser.ts` (+ `sessions-browser.test.ts`),
+  `apps/cli/src/commands/sessions.ts`.
+
 ## 1.20.58
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,24 +217,6 @@
   session databases migrate additively and backfill on the next scan (the first
   run re-indexes once).
 
-- **Interactive session browser — `agents sessions --active` and a bare `agents sessions`
-  now open a live, filterable picker on a TTY (RUSH-1802).** One canonical filter driven by
-  single keys, re-pulled across the fleet as you toggle: `s` search, `r` running-only, `c`
-  teams, `a` agent (cycles), `d` device (cycles), `p` this-repo↔all-dirs, `w` time window;
-  filters **stack** (AND together) and the active set shows in the header, with a live
-  preview of the highlighted row and `⏎` to resume/attach via the existing dispatch. Every
-  hotkey mirrors a flag, so the view is reproducible as a command — `y` copies (and
-  `--print-cmd` prints) the exact `ag sessions …` line the filters map to, bridging the
-  human picker and the agent/script flag surface. The interactive front-end is TTY-only:
-  `--json`, a pipe, or the new `--no-interactive` keep the existing static listing verbatim,
-  so scripts and headless agents are unchanged. Adds `-p` as the short form of `--project`,
-  `--print-cmd`, `--preview` (`agents sessions <id> --preview` prints the compact digest
-  without the pager), and `--no-interactive`. Built on a new async-refetch `dynamicPicker`
-  variant that reuses the existing render/pagination/preview machinery, the fleet SSH
-  fan-out, and the resume/focus path. Source: `apps/cli/src/lib/picker.ts` (`dynamicPicker`),
-  `apps/cli/src/commands/sessions-browser.ts` (+ `sessions-browser.test.ts`),
-  `apps/cli/src/commands/sessions.ts`.
-
 ## 1.20.58
 
 ### Added

--- a/apps/cli/.changelog/next/RUSH-1802.md
+++ b/apps/cli/.changelog/next/RUSH-1802.md
@@ -1,0 +1,17 @@
+- **Interactive session browser — `agents sessions --active` and a bare `agents sessions`
+  now open a live, filterable picker on a TTY (RUSH-1802).** One canonical filter driven by
+  single keys, re-pulled across the fleet as you toggle: `s` search, `r` running-only, `c`
+  teams, `a` agent (cycles), `d` device (cycles), `p` this-repo↔all-dirs, `w` time window;
+  filters **stack** (AND together) and the active set shows in the header, with a live
+  preview of the highlighted row and `⏎` to resume/attach via the existing dispatch. Every
+  hotkey mirrors a flag, so the view is reproducible as a command — `y` copies (and
+  `--print-cmd` prints) the exact `ag sessions …` line the filters map to, bridging the
+  human picker and the agent/script flag surface. The interactive front-end is TTY-only:
+  `--json`, a pipe, or the new `--no-interactive` keep the existing static listing verbatim,
+  so scripts and headless agents are unchanged. Adds `-p` as the short form of `--project`,
+  `--print-cmd`, `--preview` (`agents sessions <id> --preview` prints the compact digest
+  without the pager), and `--no-interactive`. Built on a new async-refetch `dynamicPicker`
+  variant that reuses the existing render/pagination/preview machinery, the fleet SSH
+  fan-out, and the resume/focus path. Source: `apps/cli/src/lib/picker.ts` (`dynamicPicker`),
+  `apps/cli/src/commands/sessions-browser.ts` (+ `sessions-browser.test.ts`),
+  `apps/cli/src/commands/sessions.ts`.


### PR DESCRIPTION
## What

PR #1256 (interactive session browser, RUSH-1802) filed its changelog note by hand-editing the **repo-root `/CHANGELOG.md`**. Two problems with that: (1) the repo uses the conflict-free `.changelog/` fragment system where notes belong in `.changelog/next/<ticket>.md`, and (2) `/CHANGELOG.md` isn't even the tooled file — `gen-changelog.ts`/`release-changelog.ts` maintain **`apps/cli/CHANGELOG.md`** (the one shipped in the tarball and read by `agents upgrade`). So the note was orphaned in a stale root file that hasn't been folded since ~1.20.58.

## Fix (the real one)

- **Add `apps/cli/.changelog/next/RUSH-1802.md`** — the proper fragment. `release-changelog.ts` folds it into `apps/cli/CHANGELOG.md`'s section at the next release. This is the fix.

## Also

- Remove the stray 18-line entry my #1256 added to the **root `/CHANGELOG.md`** (a manual deletion — undoing that mistake). To be clear, this is NOT a `gen-changelog.ts` regeneration: that script writes `apps/cli/CHANGELOG.md`, which I confirmed is already current (running it produces no diff). The root `/CHANGELOG.md` is separately stale (missing 1.20.59–1.20.66); that's a pre-existing issue this PR does not try to fix.

## Notes

- The feature's **code** is already in `main` and the `1.20.66` bump (#1262); this only corrects the changelog note's placement.
- Since the fragment folds into the **next** release, the note lands in whatever version publishes next (npm is `1.20.65`; `1.20.66` is bumped but untagged/unpublished). If you'd rather back-fill it into `1.20.66`'s section specifically, I can add `apps/cli/.changelog/1.20.66.md` and regenerate `apps/cli/CHANGELOG.md` instead.
