### PR TITLE
fix(exec): kimi/grok headless plan auto-downgrades to auto (RUSH-1810)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-1810.md
+++ b/apps/cli/.changelog/next/RUSH-1810.md
@@ -1,0 +1,12 @@
+- **kimi/grok headless `--mode plan` now auto-downgrades to `auto` instead of
+  crashing or stalling (RUSH-1810).** kimi's headless `-p` refuses to combine with
+  `--plan` (it hard-failed at spawn) and grok's `--permission-mode plan` silently
+  stalls a headless run at its ExitPlanMode gate. Both now model this honestly with
+  a `capabilities.headlessPlan: false` flag: a headless plan request degrades to
+  `auto` (kimi `-p` auto-runs; grok maps `auto`→`edit`) with a one-line stderr
+  warning, mirroring the graceful plan→edit degrade cursor/antigravity already get.
+  Interactive plan is unchanged, and claude/codex/droid/opencode keep read-only
+  plan headless. The same downgrade covers `agents run`, `agents teams add`
+  teammates, and routine jobs. Source: `apps/cli/src/lib/exec.ts`
+  (`resolveHeadlessMode`), `apps/cli/src/lib/runner.ts`, `apps/cli/src/lib/agents.ts`,
+  `apps/cli/src/lib/types.ts`.

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -524,6 +524,12 @@ export function registerRunCommand(program: Command): void {
         skip  bypass every permission prompt (dangerously-skip-permissions)
         Legacy 'full' is silently rewritten to 'skip'.
 
+      Headless plan support (a prompt makes the run headless):
+        plan works headless on claude, codex, droid, opencode.
+        kimi, grok, cursor, antigravity have no headless plan mode — a headless
+        --mode plan auto-downgrades to --mode auto (with a stderr warning).
+        Interactive plan (omit the prompt) works everywhere it is listed.
+
       Run strategy (set via --strategy or run.<agent>.strategy in agents.yaml):
         pinned     use the workspace/global pinned version
         available  use pinned if it can run right now; otherwise switch to another signed-in version

--- a/apps/cli/src/commands/teams.ts
+++ b/apps/cli/src/commands/teams.ts
@@ -1246,7 +1246,7 @@ export function registerTeamsCommands(program: Command): void {
     .alias('a')
     .description("Add a teammate to work on a task. Runs in background; returns immediately. Use 'status' to check in.")
     .option('-n, --name <name>', 'Friendly name for this teammate (e.g. alice). Required if using --after. Unique within team.')
-    .option('-m, --mode <mode>', `Permissions: plan (read-only) | edit (can write files) | auto (smart classifier auto-approves safe ops) | skip (bypass all permission prompts). 'full' accepted as alias for skip.`, 'edit')
+    .option('-m, --mode <mode>', `Permissions: plan (read-only) | edit (can write files) | auto (smart classifier auto-approves safe ops) | skip (bypass all permission prompts). 'full' accepted as alias for skip. Teammates run headless: plan works headless on claude/codex/droid/opencode; kimi/grok/cursor/antigravity have no headless plan mode and auto-downgrade a plan request to auto.`, 'edit')
     .option('-e, --effort <effort>', `Reasoning intensity: ${VALID_EFFORTS.join('|')}`, 'medium')
     .option('--model <model>', 'Override the effort tier and use this specific model (e.g. claude-opus-4-6)')
     .option(

--- a/apps/cli/src/lib/__tests__/exec.test.ts
+++ b/apps/cli/src/lib/__tests__/exec.test.ts
@@ -9,6 +9,7 @@ import {
   parseExecEnv,
   normalizeMode,
   resolveMode,
+  resolveHeadlessMode,
   defaultModeFor,
   headlessPlanStallCommand,
   type ExecOptions,
@@ -204,8 +205,10 @@ describe('buildExecCommand', () => {
       expect(cmd).toContain('--autopilot');
     });
 
-    it('grok plan produces --permission-mode plan', () => {
-      const cmd = buildExecCommand(opts({ agent: 'grok', mode: 'plan' }));
+    it('grok plan (interactive TUI) produces --permission-mode plan', () => {
+      // grok's --permission-mode plan works interactively; headless it stalls, so
+      // this pins the interactive mapping (headless downgrade tested below).
+      const cmd = buildExecCommand(opts({ agent: 'grok', mode: 'plan', prompt: undefined, interactive: true }));
       expect(cmd).toContain('--permission-mode');
       expect(cmd[cmd.indexOf('--permission-mode') + 1]).toBe('plan');
       expect(cmd).not.toContain('--mode');
@@ -264,10 +267,50 @@ describe('buildExecCommand', () => {
         expect(cmd).not.toContain('--yolo');
       });
 
-      it('headless plan throws (kimi has no read-only -p mode)', () => {
-        expect(() => buildExecCommand(opts({ agent: 'kimi', mode: 'plan' }))).toThrow(/read-only/);
+      it('headless plan downgrades to auto — no throw, no --plan (RUSH-1810)', () => {
+        // kimi's headlessPlan:false: a headless plan request degrades to auto, which
+        // for kimi -p carries no flag. Must not throw and must not emit --plan.
+        let cmd: string[] = [];
+        expect(() => {
+          cmd = buildExecCommand(opts({ agent: 'kimi', mode: 'plan' }));
+        }).not.toThrow();
+        expect(cmd).not.toContain('--plan');
+        expect(cmd).not.toContain('--auto');
+        expect(cmd).toContain('-p');
       });
     });
+
+    // Regression: grok launched headless with `-p` under --mode plan pushed
+    // `--permission-mode plan`, which silently stalls at grok's ExitPlanMode gate
+    // (no TTY to approve). Headless plan must degrade to auto→edit (no flag).
+    describe('grok headless -p cannot carry --permission-mode plan (RUSH-1810)', () => {
+      it('headless plan downgrades to edit — no --permission-mode', () => {
+        let cmd: string[] = [];
+        expect(() => {
+          cmd = buildExecCommand(opts({ agent: 'grok', mode: 'plan' }));
+        }).not.toThrow();
+        expect(cmd).not.toContain('--permission-mode');
+        expect(cmd).toContain('-p');
+      });
+    });
+
+    // The write-capable agents keep read-only plan headless — the downgrade is
+    // scoped to headlessPlan:false agents only.
+    it.each(['claude', 'codex', 'droid', 'opencode'] as const)(
+      '%s headless plan is unchanged (read-only preserved)',
+      (agent) => {
+        const cmd = buildExecCommand(opts({ agent, mode: 'plan', headless: true }));
+        if (agent === 'claude') {
+          expect(cmd[cmd.indexOf('--permission-mode') + 1]).toBe('plan');
+        } else if (agent === 'codex') {
+          expect(cmd[cmd.indexOf('--sandbox') + 1]).toBe('read-only');
+        } else if (agent === 'opencode') {
+          expect(cmd[cmd.indexOf('--agent') + 1]).toBe('plan');
+        }
+        // droid plan carries no flag (its exec default is read-only) — the
+        // assertion is simply that the build did not throw or downgrade.
+      },
+    );
 
     it('kimi json adds --output-format stream-json', () => {
       const cmd = buildExecCommand(opts({ agent: 'kimi', prompt: 'do the thing', mode: 'edit', json: true }));
@@ -1114,6 +1157,35 @@ describe('resolveMode', () => {
   it("throws on 'skip' for kiro (edit-only agent)", () => {
     expect(() => resolveMode('kiro', 'skip'))
       .toThrow(/kiro does not support 'skip' mode\. Supported modes: edit\./);
+  });
+});
+
+describe('resolveHeadlessMode (RUSH-1810)', () => {
+  it('downgrades headless plan to auto for kimi (headlessPlan:false → kimi keeps auto)', () => {
+    expect(AGENTS.kimi.capabilities.headlessPlan).toBe(false);
+    expect(resolveHeadlessMode('kimi', 'plan', false)).toBe('auto');
+  });
+
+  it('downgrades headless plan to edit for grok (auto→edit via resolveMode)', () => {
+    expect(AGENTS.grok.capabilities.headlessPlan).toBe(false);
+    // grok has no native auto; the auto downgrade resolves onward to edit.
+    expect(resolveHeadlessMode('grok', 'plan', false)).toBe('edit');
+  });
+
+  it('keeps interactive plan for kimi/grok (only headless downgrades)', () => {
+    expect(resolveHeadlessMode('kimi', 'plan', true)).toBe('plan');
+    expect(resolveHeadlessMode('grok', 'plan', true)).toBe('plan');
+  });
+
+  it('leaves headless plan untouched for agents with headlessPlan absent (claude/codex)', () => {
+    expect(AGENTS.claude.capabilities.headlessPlan).toBeUndefined();
+    expect(resolveHeadlessMode('claude', 'plan', false)).toBe('plan');
+    expect(resolveHeadlessMode('codex', 'plan', false)).toBe('plan');
+  });
+
+  it('passes non-plan modes straight through resolveMode (headless kimi skip → skip)', () => {
+    expect(resolveHeadlessMode('kimi', 'skip', false)).toBe('skip');
+    expect(resolveHeadlessMode('kimi', 'edit', false)).toBe('edit');
   });
 });
 

--- a/apps/cli/src/lib/__tests__/runner.test.ts
+++ b/apps/cli/src/lib/__tests__/runner.test.ts
@@ -87,8 +87,16 @@ describe('buildJobCommand', () => {
     expect(argv).not.toContain('--auto');
   });
 
-  it('kimi plan mode throws (no headless read-only mode)', () => {
-    expect(() => buildJobCommand(baseJob({ agent: 'kimi', mode: 'plan' }), 'Do the task.')).toThrow(/read-only/);
+  it('kimi plan mode downgrades to auto — no throw, no --plan (RUSH-1810)', () => {
+    // Routines run headless; kimi's headlessPlan:false makes a plan request degrade
+    // to auto (kimi -p auto-runs, carrying no startup-mode flag). Must not throw.
+    let argv: string[] = [];
+    expect(() => {
+      argv = buildJobCommand(baseJob({ agent: 'kimi', mode: 'plan' }), 'Do the task.');
+    }).not.toThrow();
+    expect(argv).toContain('--prompt');
+    expect(argv).not.toContain('--plan');
+    expect(argv).not.toContain('--auto');
   });
 });
 

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -528,6 +528,10 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
       workflows: false,
       memory: true,
       modes: ['plan', 'edit', 'skip'],
+      // grok's `--permission-mode plan` silently stalls a headless `-p` run at
+      // its ExitPlanMode gate (no TTY to approve). Headless plan auto-downgrades
+      // to auto (→ edit via resolveMode). Interactive plan is unaffected.
+      headlessPlan: false,
       rulesImports: true,
     },
   },
@@ -567,6 +571,10 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
       workflows: true,
       memory: false,
       modes: ['plan', 'edit', 'auto', 'skip'],
+      // kimi's headless `-p` refuses to combine with `--plan` (`Cannot combine
+      // --prompt with --plan`). Headless plan auto-downgrades to auto (kimi -p
+      // auto-runs). Interactive plan is unaffected.
+      headlessPlan: false,
       rulesImports: false,
     },
   },

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -119,6 +119,29 @@ export function resolveMode(agent: AgentId, requested: Mode): Mode {
 }
 
 /**
+ * Resolve a requested mode for a run, honoring whether the run is HEADLESS.
+ *
+ * Wraps resolveMode with one extra rule: an agent may list `plan` in its modes
+ * (so interactive plan works) yet declare `capabilities.headlessPlan === false`
+ * because plan is broken in a headless `--prompt`/`-p` run — kimi refuses
+ * `--prompt` + `--plan`, and grok's `--permission-mode plan` silently stalls at
+ * its ExitPlanMode gate. For those agents, a headless plan request degrades to
+ * `auto` (kimi -p auto-runs; grok maps auto→edit via resolveMode) with a visible
+ * one-line stderr warning, mirroring the graceful plan→edit degrade cursor and
+ * antigravity get for having no plan flag at all. Interactive runs are never
+ * downgraded. This is the single source of truth shared by buildExecCommand
+ * (agents run / teams) and the routine runner.
+ */
+export function resolveHeadlessMode(agent: AgentId, requested: Mode, interactive: boolean): Mode {
+  const mode = resolveMode(agent, requested);
+  if (!interactive && mode === 'plan' && AGENTS[agent].capabilities.headlessPlan === false) {
+    process.stderr.write(`warning: ${agent} has no headless plan mode; running --mode auto instead\n`);
+    return resolveMode(agent, 'auto');
+  }
+  return mode;
+}
+
+/**
  * The mode an agent should run in when the caller has no preference.
  *
  * Returns the first entry in the agent's `capabilities.modes` table — the
@@ -701,9 +724,11 @@ export function buildExecCommand(options: ExecOptions): string[] {
   // Resolve the requested mode against the agent's capability table.
   // - `auto` on an agent without auto support → silently degrades to `edit`
   // - `plan` on an agent without a read-only mode → degrades to modes[0]
+  // - headless `plan` on an agent with headlessPlan:false (kimi, grok) →
+  //   degrades to `auto` with a stderr warning (see resolveHeadlessMode)
   // - `skip` on an unsupported agent → throws a clear error
-  // After resolveMode, the chosen mode is guaranteed to be in template.modeFlags.
-  const resolvedMode = resolveMode(options.agent, normalizeMode(options.mode));
+  // After resolution, the chosen mode is guaranteed to be in template.modeFlags.
+  const resolvedMode = resolveHeadlessMode(options.agent, normalizeMode(options.mode), interactive);
   const modeFlags = template.modeFlags[resolvedMode];
   if (!modeFlags) {
     // Defense in depth: would only fire if AGENTS.capabilities.modes and
@@ -736,12 +761,13 @@ export function buildExecCommand(options: ExecOptions): string[] {
     // all abort with "Cannot combine --prompt with --X" (verified against the live
     // kimi CLI). The write-capable modes (edit/auto/skip) all collapse to kimi's
     // default `-p` behavior, which already auto-approves tool calls, so we emit no
-    // mode flag. Plan (read-only) has no headless equivalent, so fail closed rather
-    // than silently letting a plan-mode run mutate the workspace.
+    // mode flag. Plan can't reach here headless — resolveHeadlessMode already
+    // downgraded it to auto (kimi's headlessPlan:false); this asserts that
+    // invariant so a plan-mode run can never silently mutate the workspace.
     if (resolvedMode === 'plan') {
       throw new Error(
-        'kimi has no headless read-only mode: `--prompt` cannot be combined with `--plan`. ' +
-          'Run kimi in plan mode interactively (omit the prompt), or use --mode edit, auto, or skip.',
+        `Internal error: kimi reached headless command build with resolved mode 'plan'; ` +
+          `resolveHeadlessMode should have downgraded it to auto (capabilities.headlessPlan is false).`,
       );
     }
     // edit/auto/skip: emit no mode flag — `kimi -p` auto-runs.

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -34,6 +34,7 @@ import { resolveModel, buildReasoningFlags } from './models.js';
 import { createTimer, maybeRotate, redactPrompt } from './events.js';
 import {
   normalizeMode,
+  resolveHeadlessMode,
   buildExecEnv,
   detectRateLimit,
   type ExecOptions,
@@ -164,14 +165,11 @@ export function buildJobCommand(config: JobConfig, resolvedPrompt: string): stri
     // kimi daemon jobs always run headless via `--prompt`, which cannot be
     // combined with any startup-mode flag (--plan/--auto/--yolo all abort with
     // "Cannot combine --prompt with --X"). edit/auto/skip reduce to kimi's default
-    // headless auto-run, so emit no flag; plan has no headless read-only
-    // equivalent, so fail closed rather than silently allowing writes.
-    if (mode === 'plan') {
-      throw new Error(
-        'kimi has no headless read-only mode: routine jobs cannot run kimi with --mode plan ' +
-          '(kimi rejects --prompt + --plan). Use --mode edit, auto, or skip.',
-      );
-    }
+    // headless auto-run, so emit no flag. plan has no headless read-only
+    // equivalent, so resolveHeadlessMode downgrades a plan request to auto with a
+    // stderr warning (kimi's headlessPlan is false) — routines run headless, so
+    // interactive is always false here. The returned mode carries no flag either.
+    resolveHeadlessMode('kimi', mode, false);
 
     appendModelAndReasoning(cmd, config);
   }

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -172,6 +172,16 @@ export interface AgentConfig {
      */
     modes: Mode[];
     /**
+     * Whether `plan` mode works in a HEADLESS run (`--prompt`/`-p`). Some CLIs
+     * list a `plan` mode that only works interactively — kimi refuses `--prompt`
+     * combined with `--plan`, and grok's `--permission-mode plan` silently stalls
+     * a headless run at its ExitPlanMode gate. Absent (undefined) means true:
+     * headless plan is assumed to work unless a agent opts out with `false`, in
+     * which case a headless `--mode plan` request auto-downgrades to `auto`
+     * (see resolveHeadlessMode). Interactive plan is unaffected.
+     */
+    headlessPlan?: boolean;
+    /**
      * Whether the agent natively resolves `@path/to/file` imports inside its
      * rules file at session start. If false, agents-cli must pre-compile the
      * rules file (inline all @-imports) when syncing it into the version home.


### PR DESCRIPTION
## Problem (RUSH-1810)

`capabilities.modes` conflated **interactive** plan with **headless** plan. kimi and
grok both list `plan` in their modes (true interactively), but plan is broken in a
headless `--prompt`/`-p` run:

- **kimi** hard-failed at command build — `throw new Error('kimi has no headless read-only mode: --prompt cannot be combined with --plan …')`. Since `--mode plan` is the CLI default, a bare `agents run kimi "…"` / a kimi `agents teams` teammate / a kimi routine all crashed at spawn.
- **grok** silently stalled — `--permission-mode plan` sits forever at grok's ExitPlanMode gate (no TTY to approve), ending in `stopReason: Cancelled`.

cursor/antigravity were already modeled correctly (they omit `plan`, so `resolveMode`
degrades plan→edit).

## Fix

1. **Model it honestly** — new optional `capabilities.headlessPlan?: boolean` (absent = true), set `false` on kimi and grok. Interactive plan still works (they keep `plan` in `modes`).
2. **Single-source downgrade** — new `resolveHeadlessMode(agent, requested, interactive)` wraps `resolveMode`: for a headless run whose resolved mode is `plan` on an agent with `headlessPlan === false`, it degrades to `auto` (kimi `-p` auto-runs; grok maps `auto`→`edit`) and writes a one-line stderr warning. `buildExecCommand` (agents run / teams) and the routine `runner` both route through it, replacing kimi's throw and grok's stall. kimi's headless throw remains only as a now-unreachable internal-invariant assertion.
3. **Docs** — `agents run --help` and `agents teams add --help` document per-agent headless plan support; `.changelog/next/RUSH-1810.md` added.

## Per-agent headless `--mode plan` behavior

| Agent | Before | After |
|---|---|---|
| claude | read-only plan | read-only plan (unchanged) |
| codex | read-only plan | read-only plan (unchanged) |
| droid | read-only plan | read-only plan (unchanged) |
| opencode | read-only plan | read-only plan (unchanged) |
| **kimi** | **hard crash at spawn** | **downgrades → auto (`-p`), warns** |
| **grok** | **silent stall → Cancelled** | **downgrades → edit (`-p`), warns** |
| cursor | degrades → edit | degrades → edit (unchanged) |
| antigravity | degrades → edit | degrades → edit (unchanged) |

## Verification (end-to-end, worktree dev build)

```
$ agents run kimi "reply with exactly: OK" --mode plan
warning: kimi has no headless plan mode; running --mode auto instead
Running: …/kimi@0.19.2 -p reply with exactly: OK
• OK                                            RC=0   (was: crash)

$ agents run grok "reply with exactly: OK" --mode plan
warning: grok has no headless plan mode; running --mode auto instead
Running: …/grok@0.2.101 -p reply with exactly: OK
OK                                              RC=0   (was: stall→Cancelled)

$ agents run claude "reply with exactly: OK" --mode plan
Running: …/claude@2.1.170 --permission-mode plan -p reply with exactly: OK
OK                                              RC=0   (read-only preserved)

$ agents run codex  "reply with exactly: OK" --mode plan
OK                                              RC=0   (read-only preserved)
```

Tests: `bun run build` clean; new `resolveHeadlessMode` unit tests + kimi/grok
headless-plan build tests + runner job test all green. (The 10 unrelated failures in
the full local run are host-environment-dependent — codex reading the host
`~/.codex/config.toml`/model catalog, and serve-server network timeouts — none touch
the changed files: `exec.ts`, `runner.ts`, `agents.ts`, `types.ts`, the two help
strings.)

Session transcript (public repo — path reference, not inlined): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli--agents-worktrees-headless-mode/5b47e688-bdd5-41da-b2d4-89d9df5bc7dd.jsonl`
