### PR TITLE
teams: reject 'teams add --remote-cwd' with guidance; fix the --remote-cwd/placement traps

### DIFF
--- a/apps/cli/.changelog/next/teams-remote-cwd-guidance.md
+++ b/apps/cli/.changelog/next/teams-remote-cwd-guidance.md
@@ -1,0 +1,10 @@
+- **`teams add --remote-cwd` now fails loud instead of silently doing nothing.** The
+  flag rides the shared `--host` option family but `teams add` treats
+  `--host`/`--device` as placement and never reads it, so passing it used to be a
+  silent no-op that misled you into thinking it set the teammate's repo path. It is
+  now rejected with guidance (place with `--device`, set the code with the team's
+  `--repo`, one team per repo). The shared `--remote-cwd` help also warns that a
+  local `~` expands on your machine, not the remote host — pass a single-quoted
+  `'$HOME/…'` path or a valid remote absolute path. Teams docs + skill lead with
+  this. Source: `apps/cli/src/commands/teams.ts` (`remoteCwdOnAddError`),
+  `apps/cli/src/lib/hosts/option.ts`, `apps/cli/docs/teams.md`, `skills/teams/SKILL.md`.

--- a/apps/cli/docs/teams.md
+++ b/apps/cli/docs/teams.md
@@ -88,8 +88,36 @@ PENDING ──deps resolved──▶ spawned ──▶ RUNNING ──exit 0─�
 | `--enable-worktrees` | Each teammate works in its own git worktree |
 | `--use-worktree <path>` | All teammates share this existing worktree path |
 | `--devices <a,b,c>` | Distributed teams: pool of machines the team may run teammates on (alias `--hosts`). See [Distributed teams](#distributed-teams). |
-| `--repo <url\|path>` | How each device gets the code (git URL to clone, or a path). Defaults to the local checkout's `origin`. |
+| `--repo <url\|path>` | How each **remote** (`--device`) teammate gets the code — one git URL/path for the whole team. Defaults to the local checkout's `origin`. **A team is single-repo:** for work spanning repos, make one team per repo. See [Placement & repos](#placement-and-repos). |
 | `--json` | Machine-readable JSON |
+
+### Placement and repos
+
+*The part people get wrong* — the trap that turns one team into a teardown-and-rebuild.
+
+**`--remote-cwd` does NOT place a teammate or set its repo.** It rides the shared
+`--host` option family but is ignored on `teams add` (now **rejected** with
+guidance, so you find out at once instead of after building a whole team on the
+wrong model). A teammate's directory is the team's repo plus its `--worktree` —
+there is no per-teammate repo/path override. Place with `--device <host>`; set
+the code with the team's `--repo`.
+
+**A team's `--repo` is one clone source** shared by all its remote teammates
+(local teammates work in the checkout you run `add` from). If your tasks span two
+repos (e.g. `agents-cli` + a monorepo), create **one team per repo** rather than
+one team you tear down and rebuild:
+
+```bash
+agents teams create wave-cli  --repo ~/src/.../agents-cli --enable-worktrees
+agents teams create wave-mono --repo ~/src/.../monorepo   --enable-worktrees
+agents teams add  wave-cli claude "…" --name mcp --device yosemite-s0 --worktree mcp
+```
+
+For a **raw `--host` run** (not teams), `--remote-cwd` resolves on the host and is
+used verbatim: pass a single-quoted `'$HOME/…'` path (an unquoted `~` expands
+*locally* — `/Users/you` won't exist on a Linux worker) or a valid remote absolute
+path. `--cwd` is the friendlier option — it re-roots a local-home path onto the
+remote home for you.
 
 ### `teams add` options
 
@@ -230,6 +258,16 @@ Each teammate gets its own checkout of the branch. Worktrees are cleaned up on
 `teams stop` or `teams disband` unless uncommitted changes are present, in
 which case the worktree is kept and reported.
 
+**What the worktree forks from** differs by placement, and the difference bites:
+
+| Teammate | Base of the new worktree branch |
+|---|---|
+| **local** (no `--device`) | your **current local `HEAD`** — no fetch is run first (`createWorktree`). Sync the checkout (`git fetch && git merge --ff-only origin/<default>`) **before** `add`, or every teammate forks off stale code. |
+| **remote** (`--device host`) | the host's **freshly-fetched `origin/<default>`** (`createRemoteWorktree` fetches first) — no manual sync needed. |
+
+So the pre-flight for a **local** worktree team is: fast-forward your checkout to
+the default branch first. A remote team handles this itself.
+
 ## Distributed teams
 
 Teammates can run on **different machines** across your fleet, not just the box
@@ -272,6 +310,12 @@ agents teams start feat --watch
 checkout is reused, otherwise it is cloned into `~/.agents/repos/<team>`. With
 `--enable-worktrees`, each remote teammate also gets its own worktree on the host,
 branched off the freshly-fetched default branch, and cleaned up on stop/disband.
+
+`--repo` is **one** clone source for the whole team — see
+[Placement & repos](#placement-and-repos). Tasks spanning two repos need two teams
+(e.g. `wave-cli --repo …/agents-cli` and `wave-mono --repo …/monorepo`), each
+teammate placed with its own `--device`. Don't try to point individual teammates
+at different repos with `--remote-cwd` — that flag has no effect on `teams add`.
 
 `teams status` and `teams logs` show which host each teammate is on and stream its
 output back (the local log mirror is capped so a large fleet can't blow up the

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -468,7 +468,7 @@ export function registerRunCommand(program: Command): void {
       '--device <name>',
       'Alias of --host: offload this run onto a registered device (from `agents devices`).',
     )
-    .option('--remote-cwd <dir>', 'Explicit host working directory for --host runs (overrides --cwd; usually --cwd suffices).')
+    .option('--remote-cwd <dir>', "Explicit host working directory for --host runs, used VERBATIM (overrides --cwd; usually --cwd suffices — it re-roots a local-home path onto the remote home). Pass a single-quoted '$HOME/…' or a valid remote absolute path; a local ~ expands here and won't exist there (/Users/you vs /home/you).")
     .option('--no-follow', 'With --host, dispatch detached and return immediately (track via `agents hosts ps/logs`).')
     .option('--any', 'With --host <cap> (a capability tag), pick any matching host instead of erroring when several match.')
     .option(

--- a/apps/cli/src/commands/teams.remote-cwd.test.ts
+++ b/apps/cli/src/commands/teams.remote-cwd.test.ts
@@ -1,0 +1,28 @@
+/**
+ * `teams add --remote-cwd` is a no-op trap: the flag rides the shared --host
+ * option family but `teams add` treats --host/--device as placement, so it is
+ * never read. Rather than silently ignore it (which misleads you into thinking
+ * it set the teammate's repo path), the command rejects it with guidance. These
+ * pin the guidance so it can't regress into a bare/empty error.
+ */
+import { describe, it, expect } from 'vitest';
+import { remoteCwdOnAddError } from './teams.js';
+
+describe('remoteCwdOnAddError', () => {
+  it('states the flag has no effect on teams add', () => {
+    const msg = remoteCwdOnAddError('wave-cli');
+    expect(msg).toContain('--remote-cwd');
+    expect(msg).toMatch(/no effect on 'teams add'/);
+  });
+
+  it('points at --device for placement and create --repo for the code', () => {
+    const msg = remoteCwdOnAddError('wave-cli');
+    expect(msg).toContain('--device');
+    expect(msg).toContain('agents teams create wave-cli --repo');
+  });
+
+  it('threads the actual team name into the suggested commands', () => {
+    expect(remoteCwdOnAddError('wave-mono')).toContain('agents teams create wave-mono --repo');
+    expect(remoteCwdOnAddError('wave-mono')).toContain('agents teams add wave-mono');
+  });
+});

--- a/apps/cli/src/commands/teams.ts
+++ b/apps/cli/src/commands/teams.ts
@@ -1306,8 +1306,9 @@ export function registerTeamsCommands(program: Command): void {
     }) => {
       // `--remote-cwd` rides the shared --host option family but is never read by
       // `teams add` (placement, not routing). Fail loud with guidance rather than
-      // silently ignoring it — see remoteCwdOnAddError.
-      if (opts.remoteCwd) {
+      // silently ignoring it — see remoteCwdOnAddError. `!== undefined` so even an
+      // explicit empty value (`--remote-cwd ""`) is rejected, not silently dropped.
+      if (opts.remoteCwd !== undefined) {
         die(remoteCwdOnAddError(team));
       }
       if (!(VALID_MODES as readonly string[]).includes(opts.mode)) {

--- a/apps/cli/src/commands/teams.ts
+++ b/apps/cli/src/commands/teams.ts
@@ -982,6 +982,26 @@ async function pickTeamOr(
   }
 }
 
+/**
+ * `teams add --remote-cwd` is a no-op trap. `--remote-cwd` comes from the shared
+ * `--host` option family (option.ts) and is meaningful for commands that *route*
+ * to a host, but `teams add` special-cases `--host`/`--device` as PLACEMENT, so
+ * the flag is never read — a teammate's directory is the team's repo plus its
+ * `--worktree`, not a path passed here. Silently ignoring it misleads you into
+ * thinking it set the teammate's repo path (the exact wrong model that turns one
+ * team into a teardown-and-rebuild). Reject with guidance instead. Exported for
+ * the unit test that pins the message.
+ */
+export function remoteCwdOnAddError(team: string): string {
+  return (
+    `--remote-cwd has no effect on 'teams add' — it does not set a teammate's repo or directory.\n` +
+    `  A teammate works in the team's repo plus its own --worktree:\n` +
+    `    • Set the repo once, on the team:  agents teams create ${team} --repo <url|path>\n` +
+    `    • Place the teammate on a machine: agents teams add ${team} <agent> "<task>" --device <host> --worktree <name>\n` +
+    `  (Remote worktrees fork from the host's freshly-fetched origin/<default> automatically.)`
+  );
+}
+
 /** Register the `agents teams` command tree (list, create, add, status, start, remove, disband, logs, doctor). */
 export function registerTeamsCommands(program: Command): void {
   const teams = program
@@ -1026,6 +1046,20 @@ export function registerTeamsCommands(program: Command): void {
         'claude@2.1.112'   a specific installed version (see 'agents view')
         '<profile>'        a profile from 'agents view' — runs through 'agents
                            run <profile>' with the profile's host harness
+
+      Placement & repos (the part people get wrong):
+        --remote-cwd does NOT place a teammate or set its repo — it is ignored on
+        'teams add' (and rejected, so you find out immediately). A teammate's
+        directory is the team's repo plus its --worktree:
+          --device <host>     run THIS teammate on <host>
+          create --repo <r>   ONE repo for the whole team (defaults to this
+                              checkout's origin). Work spanning repos → one team
+                              per repo — don't build a cross-repo team then rebuild.
+        With --enable-worktrees each teammate gets its own worktree + branch:
+          local teammate      forks from your CURRENT local HEAD — no fetch, so
+                              pull/sync the checkout first or it forks stale
+          remote (--device)   forks from the freshly-fetched origin/<default> on
+                              the host (no manual sync needed)
 
       Short aliases:
         teams c  = create    teams a  = add       teams s  = status
@@ -1167,7 +1201,7 @@ export function registerTeamsCommands(program: Command): void {
     .option('--use-worktree <path>', 'All teammates share this existing worktree path (mutually exclusive with --enable-worktrees)')
     .option('--devices <list>', 'Pool of machines this team may run teammates on (comma-separated). Enables distributed auto-scheduling.')
     .option('--hosts <list>', 'Alias for --devices.')
-    .option('--repo <urlOrPath>', 'How each device gets the code (git URL to clone, or a path). Defaults to the local checkout origin.')
+    .option('--repo <urlOrPath>', 'How each remote (--device) teammate gets the code — ONE git URL/path for the whole team (existing checkout reused, else cloned). A team is single-repo; for work across repos, make one team per repo. Defaults to this checkout origin.')
     .option('--json', 'Output machine-readable JSON')
     .action(async (team: string, opts: { description?: string; enableWorktrees?: boolean; useWorktree?: string; devices?: string; hosts?: string; repo?: string; json?: boolean }) => {
       try {
@@ -1268,7 +1302,14 @@ export function registerTeamsCommands(program: Command): void {
       name?: string; mode: string; effort: string; model?: string; env: string[];
       cwd?: string; worktree?: string; after?: string; json?: boolean;
       taskType?: string; cloud?: string; host?: string; device?: string; repo?: string; branch?: string; force?: boolean;
+      remoteCwd?: string;
     }) => {
+      // `--remote-cwd` rides the shared --host option family but is never read by
+      // `teams add` (placement, not routing). Fail loud with guidance rather than
+      // silently ignoring it — see remoteCwdOnAddError.
+      if (opts.remoteCwd) {
+        die(remoteCwdOnAddError(team));
+      }
       if (!(VALID_MODES as readonly string[]).includes(opts.mode)) {
         die(`Invalid mode '${opts.mode}'. Use one of: ${VALID_MODES.join(', ')}`);
       }

--- a/apps/cli/src/lib/hosts/option.ts
+++ b/apps/cli/src/lib/hosts/option.ts
@@ -20,7 +20,7 @@ export function addHostOption(cmd: Command): Command {
       'Run this command on another machine over SSH instead of locally — a device, a registered host, or user@host. See `agents devices` / `agents hosts`.',
     )
     .option('--device <name>', 'Alias of --host: run this command on a registered device (from `agents devices`).')
-    .option('--remote-cwd <dir>', 'Working directory on the host for --host runs.')
+    .option('--remote-cwd <dir>', "Working directory on the host for --host runs. Resolves on the REMOTE host — pass a '$HOME'-relative path (single-quoted so your local shell doesn't expand it) or a valid remote absolute path; a local ~ expands here and won't exist there (/Users/you vs /home/you). No effect on 'teams add'.")
     .option('--no-tty', 'Force non-interactive output for --host runs even from a terminal.')
     .option('--any', 'With --host <cap> (a capability tag), pick any matching host instead of erroring when several match.');
 }

--- a/skills/teams/SKILL.md
+++ b/skills/teams/SKILL.md
@@ -94,6 +94,37 @@ agents teams add feat claude "..." --name w2 --device yosemite-s0    # or pin
 - `status` / `logs` show each teammate's host. **POSIX hosts only** in v1 (Windows
   hosts are rejected with a clear message).
 
+## Placement & Repos (read before a distributed or worktree team)
+
+The trap that turns one team into a teardown-and-rebuild — get these right up front:
+
+1. **`--remote-cwd` does NOT place a teammate or set its repo.** It rides the shared
+   `--host` flag family but `teams add` ignores it (and now **rejects** it with
+   guidance). Place a teammate with `--device <host>`; the code comes from the
+   team's `--repo`. There is **no per-teammate repo/path override** — don't reach
+   for `--remote-cwd` to send one teammate to a different repo.
+
+2. **One team = one repo.** A team's `--repo` is a single clone source shared by all
+   its remote teammates; local teammates work in the checkout you run `add` from.
+   Tasks spanning two repos → **one team per repo**, not a cross-repo team:
+
+   ```bash
+   agents teams create wave-cli  --repo ~/src/.../agents-cli --enable-worktrees
+   agents teams create wave-mono --repo ~/src/.../monorepo   --enable-worktrees
+   agents teams add  wave-cli claude "…" --name mcp --device yosemite-s0 --worktree mcp
+   ```
+
+3. **Worktree fork point differs by placement — and it bites.**
+   - **local** teammate → forks from your **current local `HEAD`, with no fetch**.
+     Fast-forward the checkout first (`git fetch && git merge --ff-only origin/<default>`)
+     or every teammate forks off stale code.
+   - **remote** (`--device`) teammate → forks from the host's **freshly-fetched
+     `origin/<default>`** automatically — no manual sync needed.
+
+4. **For a raw `--host` run (not teams), `--remote-cwd` resolves on the host.** Pass a
+   single-quoted `'$HOME/…'` path (an unquoted `~` expands *locally* — `/Users/you`
+   won't exist on a Linux worker) or a valid remote absolute path.
+
 ## Modes
 
 | Mode | Use When |


### PR DESCRIPTION
## Why

A fleet session (`83e4626c`) burned a long stretch trying to dispatch 6 tickets across two repos and two hosts. The root cause wasn't worktrees or repos — it was **`--remote-cwd`**, which traps in two distinct ways:

1. **`agents run --host s0 --remote-cwd "$CLI0/…"`** — `$CLI0=~/src/…` expands *locally on the laptop* to `/Users/muqsit/…`, so a macOS path reached a Linux worker. `--remote-cwd` is used **verbatim** (`exec.ts:811`; `--cwd` gets `toRemotePortable`, but `--remote-cwd` doesn't), so `cd /Users/muqsit/…` failed on Linux — **silently, at launch**. All 6 jobs "failed" with no useful message.
2. **`agents teams add … --remote-cwd`** — the flag rides the shared `--host` option family but `teams add` treats `--host`/`--device` as *placement* and **never reads it** (`teams.ts` action; the working dir is derived from the team repo/worktree at `agents.ts:1936`). It was a **silent no-op** — and its presence in `--help` led the agent to build a whole 6-teammate model around "`--remote-cwd` = per-teammate repo path," then tear it down and rebuild as one-team-per-repo.

## What changed

- **`teams add --remote-cwd` now fails loud with guidance** instead of silently ignoring it (`remoteCwdOnAddError`, unit-tested). Points you at `--device` for placement and the team's `--repo` for the code.
- **`--remote-cwd` help clarified where it traps** — both the shared `--host` option (`option.ts`) and `agents run`'s own option (`exec.ts`): a local `~` expands here, not on the remote; pass a single-quoted `'$HOME/…'` or a valid remote absolute path.
- **`teams create --repo` help** now states a team is single-repo → one team per repo for cross-repo work.
- **Docs (`docs/teams.md`) + skill (`skills/teams/SKILL.md`)** lead with placement/repo/worktree-fork rules, including the local-HEAD-vs-remote-origin worktree fork difference.

## Verified live (built CLI)

```
$ agents teams add wave-cli claude "do the thing" --name mcp --device s0 --remote-cwd /home/muqsit/src/x
--remote-cwd has no effect on 'teams add' — it does not set a teammate's repo or directory.
  A teammate works in the team's repo plus its own --worktree:
    • Set the repo once, on the team:  agents teams create wave-cli --repo <url|path>
    • Place the teammate on a machine: agents teams add wave-cli <agent> "<task>" --device <host> --worktree <name>
  (Remote worktrees fork from the host's freshly-fetched origin/<default> automatically.)
$ echo $?   # 1
```
Guard doesn't over-fire without the flag; `tsc` clean; teams + changelog tests green.

## Noted follow-up (not in this PR)

`agents run --host … --remote-cwd <dir>` still fails *silently* when `<dir>` is absent on the host — a pre-flight `test -d` over SSH with a clear error would surface the mistake at dispatch. Left out here because it touches the shared dispatch hot path (routines/cloud/detached/Windows) and deserves its own change.
