### PR TITLE
fix(factory): scroll edit form into view, focus, and highlight edited row (RUSH-1529)

### DIFF
--- a/apps/factory/ui/settings/components/mission-control/ProjectsPane.test.tsx
+++ b/apps/factory/ui/settings/components/mission-control/ProjectsPane.test.tsx
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+if (typeof (globalThis as { document?: unknown }).document === 'undefined') GlobalRegistrator.register()
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const React = require('react')
+const { act } = require('react')
+const { createRoot } = require('react-dom/client')
+const { ProjectsPane } = require('./ProjectsPane')
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('ProjectsPane edit interaction', () => {
+  test('clicking Edit highlights the row, focuses the folder input, and scrolls the form into view', async () => {
+    const projects = [
+      { id: 'a', name: 'Alpha', path: '/alpha', confidence: 'high' as const, source: 'manual' as const },
+      { id: 'b', name: 'Beta', path: '/beta', confidence: 'high' as const, source: 'manual' as const },
+    ]
+
+    const rootElement = document.createElement('div')
+    document.body.appendChild(rootElement)
+    const root = createRoot(rootElement)
+
+    await act(async () => {
+      root.render(
+        React.createElement(ProjectsPane, {
+          projects,
+          linearProjects: [],
+          pickedFolder: null,
+          onSave: () => {},
+          onDelete: () => {},
+          onPickFolder: () => {},
+          onClose: () => {},
+        }),
+      )
+    })
+
+    const editButtons = Array.from(rootElement.querySelectorAll('button')).filter(
+      (b) => b.textContent === 'Edit',
+    )
+    expect(editButtons).toHaveLength(2)
+
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView
+    const scrolledElements: Element[] = []
+    HTMLElement.prototype.scrollIntoView = function (this: Element) {
+      scrolledElements.push(this)
+    }
+
+    try {
+      await act(async () => {
+        editButtons[1].click()
+      })
+
+      const highlightedRows = Array.from(rootElement.querySelectorAll('.dispatch-panel.editing'))
+      expect(highlightedRows).toHaveLength(1)
+      expect(highlightedRows[0].querySelector('span')?.textContent).toBe('Beta')
+
+      const folderInput = rootElement.querySelector(
+        'input[placeholder="/absolute/path/to/repo"]',
+      ) as HTMLInputElement
+      expect(document.activeElement).toBe(folderInput)
+
+      const formContainer = folderInput.closest('.dispatch-panel')?.parentElement
+      expect(scrolledElements).toContain(formContainer)
+    } finally {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView
+      await act(async () => {
+        root.unmount()
+      })
+    }
+  })
+})

--- a/apps/factory/ui/settings/components/mission-control/ProjectsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/ProjectsPane.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Icon } from './icons'
 import type { ManagedProject, LinearProjectLite, ProjectRollup } from './floorModel'
 
@@ -53,6 +53,20 @@ export function ProjectsPane({ projects, rollups = {}, linearProjects, pickedFol
   const [name, setName] = useState('')
   const [repoSlug, setRepoSlug] = useState('')
   const [linearProjectId, setLinearProjectId] = useState('')
+
+  const formRef = useRef<HTMLDivElement>(null)
+  const folderInputRef = useRef<HTMLInputElement>(null)
+  const rowRefs = useRef(new Map<string, HTMLDivElement>())
+
+  // When the user clicks Edit on a long project list, the form sits below the fold.
+  // Scroll it into view, focus the first field, and keep the edited row highlighted.
+  useEffect(() => {
+    if (!editingId) return
+    const row = rowRefs.current.get(editingId)
+    row?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    formRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    folderInputRef.current?.focus()
+  }, [editingId])
 
   const resetForm = () => {
     setEditingId(null)
@@ -132,7 +146,8 @@ export function ProjectsPane({ projects, rollups = {}, linearProjects, pickedFol
             projects.map((p) => (
               <div
                 key={p.id}
-                className="dispatch-panel"
+                ref={(el) => { if (el) rowRefs.current.set(p.id, el); else rowRefs.current.delete(p.id) }}
+                className={`dispatch-panel${editingId === p.id ? ' editing' : ''}`}
                 style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}
               >
                 <div style={{ minWidth: 0, flex: 1 }}>
@@ -161,13 +176,14 @@ export function ProjectsPane({ projects, rollups = {}, linearProjects, pickedFol
         </div>
 
         {/* Add / edit form */}
-        <div>
+        <div ref={formRef}>
           <div className="lbl">{editingId ? 'Edit project' : 'Add project'}</div>
           <div className="dispatch-panel" style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
             <div>
               <div className="host-meta-k" style={{ marginBottom: 4 }}>Folder</div>
               <div style={{ display: 'flex', gap: 8 }}>
                 <input
+                  ref={folderInputRef}
                   className="host-caps-input"
                   style={{ flex: 1 }}
                   placeholder="/absolute/path/to/repo"

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -484,6 +484,7 @@
 .swarmify-root .recap-row .rc-cost { flex: 0 0 auto; font-family: "Geist Mono", monospace; font-size: 10.5px; color: var(--ds-text-muted); font-variant-numeric: tabular-nums; }
 .swarmify-root .recap-row .rc-ago { flex: 0 0 auto; width: 64px; text-align: right; color: var(--ds-text-faint); font-size: 10.5px; }
 .swarmify-root .dispatch-panel { background: var(--ds-bg); border: 1px solid var(--ds-border-subtle); border-radius: var(--r-lg); padding: 12px 14px; }
+.swarmify-root .dispatch-panel.editing { border-color: var(--brand); box-shadow: inset 3px 0 0 var(--brand); background: var(--ds-bg-panel); }
 .swarmify-root .dp-row { display: flex; align-items: center; gap: 10px; margin-top: 8px; }
 .swarmify-root .dp-k { width: 48px; font-size: 11px; color: var(--ds-text-dim); font-weight: 600; }
 


### PR DESCRIPTION
Fixes RUSH-1529.

In the Factory Projects pane, clicking Edit populated the edit form but left it off-screen below the project list. This change:

- Scrolls the edited row and the edit form into view.
- Focuses the Folder input so the user can start editing immediately.
- Highlights the edited project row with a brand-colored border + inset accent.

Also adds a DOM test covering the Edit-click interaction.