### PR TITLE
fix(win): silence PowerShell progress stream so remote agents output isn't CLIXML

### DIFF
--- a/apps/cli/.changelog/next/win-clixml-progress.md
+++ b/apps/cli/.changelog/next/win-clixml-progress.md
@@ -1,0 +1,8 @@
+- **No more CLIXML blobs from Windows hosts.** A remote `agents …` invocation
+  routed to a Windows box (`--host win-mini`, `agents doctor --devices`,
+  `agents fleet status`) no longer comes back wrapped in a raw `#< CLIXML <Objs …>`
+  envelope. PowerShell 5.1 serializes its progress stream ("Preparing modules for
+  first use.") to CLIXML when stderr is a captured pipe rather than a console; the
+  Windows command builder now silences that stream (`$ProgressPreference =
+  'SilentlyContinue'`) so failures read as plain text for humans and the JSON
+  parsers that consume the output. Source: `apps/cli/src/lib/hosts/remote-cmd.ts`.

--- a/apps/cli/src/lib/hosts/ready.test.ts
+++ b/apps/cli/src/lib/hosts/ready.test.ts
@@ -88,7 +88,7 @@ describe('ready commands — Windows branch speaks PowerShell', () => {
     // Parser keys off the sentinel substring — this output must still parse.
     const script = decodeWindows(buildReadyProbeCommand('windows'));
     expect(script).toBe(
-      `agents --version 2>$null; Write-Output "${MARK}"; agents view 2>$null; if ($LASTEXITCODE -ne 0) { agents list 2>$null }`,
+      `$ProgressPreference = 'SilentlyContinue'; agents --version 2>$null; Write-Output "${MARK}"; agents view 2>$null; if ($LASTEXITCODE -ne 0) { agents list 2>$null }`,
     );
     // The script's stdout shape (marker on its own line) round-trips through parseReadyProbe.
     const p = parseReadyProbe(`2.1.170\n${MARK}\nClaude (balanced)\n`);
@@ -99,7 +99,8 @@ describe('ready commands — Windows branch speaks PowerShell', () => {
   it('bootstrap uses Select-Object -Last / Test-Path, never tail / [ -d ]', () => {
     const script = decodeWindows(buildBootstrapCommand('@phnx-labs/agents-cli@2.1.170', 'windows'));
     expect(script).toBe(
-      "npm install -g '@phnx-labs/agents-cli@2.1.170' 2>&1 | Select-Object -Last 3; " +
+      "$ProgressPreference = 'SilentlyContinue'; " +
+        "npm install -g '@phnx-labs/agents-cli@2.1.170' 2>&1 | Select-Object -Last 3; " +
         'if (-not (Test-Path "$HOME/.agents/.system")) { agents setup 2>&1 | Select-Object -Last 3 }; agents --version',
     );
     expect(script).not.toContain('tail -3');

--- a/apps/cli/src/lib/hosts/ready.test.ts
+++ b/apps/cli/src/lib/hosts/ready.test.ts
@@ -81,7 +81,7 @@ describe('ready commands — Windows branch speaks PowerShell', () => {
   });
 
   it('version probe runs `agents --version` via PowerShell', () => {
-    expect(decodeWindows(buildRemoteVersionCommand('windows'))).toBe("& 'agents' '--version'; exit $LASTEXITCODE");
+    expect(decodeWindows(buildRemoteVersionCommand('windows'))).toBe("$ProgressPreference = 'SilentlyContinue'; & 'agents' '--version'; exit $LASTEXITCODE");
   });
 
   it('readyProbe emits the sentinel with Write-Output and branches on $LASTEXITCODE', () => {

--- a/apps/cli/src/lib/hosts/ready.ts
+++ b/apps/cli/src/lib/hosts/ready.ts
@@ -12,7 +12,7 @@ import { fileURLToPath } from 'url';
 import { sshExec, shellQuote } from '../ssh-exec.js';
 import type { Host } from './types.js';
 import { sshTargetFor } from './types.js';
-import { remoteShellFor, buildWindowsAgentsCommand, encodePowershell, powershellQuote } from './remote-cmd.js';
+import { remoteShellFor, buildWindowsAgentsCommand, encodePowershell, powershellQuote, POWERSHELL_PROGRESS_SILENCE } from './remote-cmd.js';
 import { resolveRemoteOsSync } from './remote-os.js';
 
 /** Resolve this CLI's own version by walking up to the nearest package.json. */
@@ -78,6 +78,7 @@ export function remoteAgentsVersion(target: string, os?: string): string | null 
 export function buildBootstrapCommand(spec: string, os?: string): string {
   if (remoteShellFor(os) === 'powershell') {
     const script =
+      `${POWERSHELL_PROGRESS_SILENCE}; ` +
       `npm install -g ${powershellQuote(spec)} 2>&1 | Select-Object -Last 3; ` +
       `if (-not (Test-Path "$HOME/.agents/.system")) { agents setup 2>&1 | Select-Object -Last 3 }; ` +
       `agents --version`;
@@ -127,6 +128,7 @@ export interface ReadyProbe {
 export function buildReadyProbeCommand(os?: string): string {
   if (remoteShellFor(os) === 'powershell') {
     const script =
+      `${POWERSHELL_PROGRESS_SILENCE}; ` +
       `agents --version 2>$null; Write-Output "${READY_MARKER}"; ` +
       `agents view 2>$null; if ($LASTEXITCODE -ne 0) { agents list 2>$null }`;
     return `powershell -NoProfile -EncodedCommand ${encodePowershell(script)}`;

--- a/apps/cli/src/lib/hosts/remote-cmd.test.ts
+++ b/apps/cli/src/lib/hosts/remote-cmd.test.ts
@@ -258,6 +258,9 @@ describe('buildRemoteAgentsInvocation — Windows targets speak PowerShell', () 
 describe('buildWindowsStdinImportCommand', () => {
   it('bridges ssh stdin through a temp file (never a hanging --from -)', () => {
     const script = decodeWindows(buildWindowsStdinImportCommand('linear.app', { force: true }));
+    // Silences the progress stream first, same CLIXML guard as windowsAgentsScript —
+    // this builder also runs `& agents …` and its stderr is shown to the user on failure.
+    expect(script.startsWith("$ProgressPreference = 'SilentlyContinue'; ")).toBe(true);
     // Reads the piped .env in PowerShell (the shim can't forward stdin to node).
     expect(script).toContain('[Console]::In.ReadToEnd()');
     expect(script).toContain('[System.IO.Path]::GetTempFileName()');

--- a/apps/cli/src/lib/hosts/remote-cmd.test.ts
+++ b/apps/cli/src/lib/hosts/remote-cmd.test.ts
@@ -140,7 +140,7 @@ describe('secrets export --host push command (cross-platform)', () => {
   it('Windows target: PowerShell EncodedCommand runs the same import (no bash, no /dev/stdin)', () => {
     const cmd = buildRemoteAgentsInvocation(importArgs, undefined, 'windows');
     const script = decodeWindows(cmd);
-    expect(script).toBe(`& 'agents' 'secrets' 'import' 'mybundle' '--from' '-'; exit $LASTEXITCODE`);
+    expect(script).toBe(`$ProgressPreference = 'SilentlyContinue'; & 'agents' 'secrets' 'import' 'mybundle' '--from' '-'; exit $LASTEXITCODE`);
     expect(script).not.toContain('/dev/stdin');
     expect(script).not.toContain('|| true');
     expect(script).not.toContain('bash');
@@ -207,17 +207,24 @@ describe('buildRemoteAgentsInvocation — Windows targets speak PowerShell', () 
     const cmd = buildRemoteAgentsInvocation(['view', 'claude'], undefined, 'windows');
     expect(cmd.startsWith('powershell -NoProfile -EncodedCommand ')).toBe(true);
     expect(cmd).not.toContain('bash -lc');
-    expect(decodeWindows(cmd)).toBe("& 'agents' 'view' 'claude'; exit $LASTEXITCODE");
+    expect(decodeWindows(cmd)).toBe("$ProgressPreference = 'SilentlyContinue'; & 'agents' 'view' 'claude'; exit $LASTEXITCODE");
+  });
+
+  it('suppresses CLIXML by silencing the progress stream (PowerShell 5.1 serializes it on a redirected pipe)', () => {
+    // Without this, a remote agents failure comes back as a raw `#< CLIXML <Objs …>`
+    // blob instead of a readable message — verified against a live win-mini.
+    const script = decodeWindows(buildWindowsAgentsCommand({ args: ['doctor', '--json'] }));
+    expect(script.startsWith("$ProgressPreference = 'SilentlyContinue'; ")).toBe(true);
   });
 
   it('prefixes Set-Location for --remote-cwd', () => {
     const cmd = buildRemoteAgentsInvocation(['view'], 'C:\\srv\\app', 'windows');
-    expect(decodeWindows(cmd)).toBe("Set-Location -LiteralPath 'C:\\srv\\app'; & 'agents' 'view'; exit $LASTEXITCODE");
+    expect(decodeWindows(cmd)).toBe("$ProgressPreference = 'SilentlyContinue'; Set-Location -LiteralPath 'C:\\srv\\app'; & 'agents' 'view'; exit $LASTEXITCODE");
   });
 
   it('neutralizes injection — metacharacters are literal inside single quotes', () => {
     const cmd = buildRemoteAgentsInvocation(['view', '$(whoami); rm -rf /', '--json'], undefined, 'windows');
-    expect(decodeWindows(cmd)).toBe("& 'agents' 'view' '$(whoami); rm -rf /' '--json'; exit $LASTEXITCODE");
+    expect(decodeWindows(cmd)).toBe("$ProgressPreference = 'SilentlyContinue'; & 'agents' 'view' '$(whoami); rm -rf /' '--json'; exit $LASTEXITCODE");
   });
 
   it('carries env vars through buildRemoteAgentsInvocation on Windows', () => {
@@ -228,7 +235,7 @@ describe('buildRemoteAgentsInvocation — Windows targets speak PowerShell', () 
       { PATH: '$HOME/.agents/.cache/shims:$HOME/.local/bin:$PATH' },
     );
     expect(decodeWindows(cmd)).toBe(
-      "$env:PATH = '$HOME/.agents/.cache/shims:$HOME/.local/bin:$PATH'; & 'agents' 'teams' 'doctor' '--json'; exit $LASTEXITCODE",
+      "$ProgressPreference = 'SilentlyContinue'; $env:PATH = '$HOME/.agents/.cache/shims:$HOME/.local/bin:$PATH'; & 'agents' 'teams' 'doctor' '--json'; exit $LASTEXITCODE",
     );
   });
 
@@ -238,13 +245,13 @@ describe('buildRemoteAgentsInvocation — Windows targets speak PowerShell', () 
       env: { AGENTS_SESSIONS_LOCAL: '1', COLUMNS: '120' },
     });
     expect(decodeWindows(cmd)).toBe(
-      "$env:AGENTS_SESSIONS_LOCAL = '1'; $env:COLUMNS = '120'; & 'agents' 'sessions' '--active' '--json'; exit $LASTEXITCODE",
+      "$ProgressPreference = 'SilentlyContinue'; $env:AGENTS_SESSIONS_LOCAL = '1'; $env:COLUMNS = '120'; & 'agents' 'sessions' '--active' '--json'; exit $LASTEXITCODE",
     );
   });
 
   it('can drop the exit-code propagation for sentinel-based probes', () => {
     const cmd = buildWindowsAgentsCommand({ args: ['--version'], propagateExit: false });
-    expect(decodeWindows(cmd)).toBe("& 'agents' '--version'");
+    expect(decodeWindows(cmd)).toBe("$ProgressPreference = 'SilentlyContinue'; & 'agents' '--version'");
   });
 });
 

--- a/apps/cli/src/lib/hosts/remote-cmd.ts
+++ b/apps/cli/src/lib/hosts/remote-cmd.ts
@@ -248,6 +248,14 @@ export interface WindowsAgentsCommand {
 export function windowsAgentsScript(cmd: WindowsAgentsCommand): string {
   const { args, env, cwd, propagateExit = true } = cmd;
   const parts: string[] = [];
+  // Silence the progress stream. PowerShell 5.1 serializes progress records
+  // ("Preparing modules for first use.") to CLIXML when stderr is a redirected pipe
+  // (an ssh capture, not a console), so a remote `agents …` result otherwise comes
+  // back wrapped in a raw `#< CLIXML <Objs …>` blob — unreadable to humans and to the
+  // JSON parsers that consume doctor / fleet-status output. Verified against a live
+  // win-mini (PowerShell 5.1): this clears it. (`-OutputFormat Text` does NOT — that
+  // governs object serialization of the success stream, not the progress stream.)
+  parts.push("$ProgressPreference = 'SilentlyContinue'");
   if (env) for (const [k, v] of Object.entries(env)) parts.push(`$env:${k} = ${powershellQuote(v)}`);
   if (cwd) parts.push(`Set-Location -LiteralPath ${powershellQuote(cwd)}`);
   parts.push(`& ${['agents', ...args].map(powershellQuote).join(' ')}`);

--- a/apps/cli/src/lib/hosts/remote-cmd.ts
+++ b/apps/cli/src/lib/hosts/remote-cmd.ts
@@ -245,17 +245,22 @@ export interface WindowsAgentsCommand {
  * `& agents …` invokes the CLI from the machine PATH (Windows has no login
  * shell, so there is no `bash -lc` equivalent — the shim is simply on PATH).
  */
+/**
+ * PowerShell prelude that silences the progress stream. PowerShell 5.1 serializes
+ * progress records ("Preparing modules for first use.") to CLIXML when stderr is a
+ * redirected pipe (an ssh capture, not a console), so a remote `agents …` result
+ * otherwise comes back wrapped in a raw `#< CLIXML <Objs …>` blob — unreadable to
+ * humans and to the JSON parsers that consume doctor / fleet-status output. Prepend
+ * this to EVERY Windows script that invokes `agents` (there is more than one builder
+ * in this file). Verified against a live win-mini (PowerShell 5.1): this clears it.
+ * (`-OutputFormat Text` does NOT — it governs success-stream object serialization,
+ * not the progress stream.)
+ */
+export const POWERSHELL_PROGRESS_SILENCE = "$ProgressPreference = 'SilentlyContinue'";
+
 export function windowsAgentsScript(cmd: WindowsAgentsCommand): string {
   const { args, env, cwd, propagateExit = true } = cmd;
-  const parts: string[] = [];
-  // Silence the progress stream. PowerShell 5.1 serializes progress records
-  // ("Preparing modules for first use.") to CLIXML when stderr is a redirected pipe
-  // (an ssh capture, not a console), so a remote `agents …` result otherwise comes
-  // back wrapped in a raw `#< CLIXML <Objs …>` blob — unreadable to humans and to the
-  // JSON parsers that consume doctor / fleet-status output. Verified against a live
-  // win-mini (PowerShell 5.1): this clears it. (`-OutputFormat Text` does NOT — that
-  // governs object serialization of the success stream, not the progress stream.)
-  parts.push("$ProgressPreference = 'SilentlyContinue'");
+  const parts: string[] = [POWERSHELL_PROGRESS_SILENCE];
   if (env) for (const [k, v] of Object.entries(env)) parts.push(`$env:${k} = ${powershellQuote(v)}`);
   if (cwd) parts.push(`Set-Location -LiteralPath ${powershellQuote(cwd)}`);
   parts.push(`& ${['agents', ...args].map(powershellQuote).join(' ')}`);
@@ -293,6 +298,9 @@ export function buildWindowsStdinImportCommand(bundle: string, opts: { force?: b
   // the secret-bearing temp file would otherwise be left behind (RUSH-1764). $tmp
   // starts null so a GetTempFileName that itself throws leaves nothing to remove.
   const script = [
+    // Same CLIXML guard as windowsAgentsScript — this builder also runs `& agents …`
+    // and its raw stderr is printed to the user on failure (secrets export --host <win>).
+    POWERSHELL_PROGRESS_SILENCE,
     '$in = [Console]::In.ReadToEnd()',
     '$tmp = $null',
     `try { $tmp = [System.IO.Path]::GetTempFileName(); [System.IO.File]::WriteAllText($tmp, $in); ` +


### PR DESCRIPTION
## What

A remote `agents …` invocation routed to a Windows host — `agents <cmd> --host win-mini`, `agents doctor --devices`, `agents fleet status` — came back wrapped in a raw CLIXML envelope instead of readable text:

```
#< CLIXML
Unknown agent 'no-such-agent-xyz'. Valid agents: claude, codex, …
<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" …>Preparing modules for first use.</Obj></Objs>
```

**Root cause:** PowerShell 5.1 serializes its *progress* stream ("Preparing modules for first use.") to CLIXML when stderr is a captured pipe (an ssh capture) rather than a console. `windowsAgentsScript` now prepends `$ProgressPreference = 'SilentlyContinue'` so the output is plain text — for humans and for the JSON parsers that consume doctor/fleet-status output.

The plan originally guessed `-OutputFormat Text` — that was wrong: it governs the *success* stream's object serialization, not the progress stream, and does **not** fix this (proven on the box).

## Verification (end-to-end, live win-mini · PowerShell 5.1.26100.8875)

Ran the exact command the built CLI generates for a failing remote `agents view`, over ssh with a captured pipe (the real user path):

**Before** (`powershell -NoProfile -EncodedCommand <& 'agents' 'view' …>`):
```
#< CLIXML
Unknown agent 'no-such-agent-xyz'. …
<Objs …><Obj S="progress">…Preparing modules for first use.…</Obj></Objs>
```

**After** (script now starts `$ProgressPreference = 'SilentlyContinue'; …`):
```
Unknown agent 'no-such-agent-xyz'. Valid agents: claude, codex, gemini, …
```
No CLIXML envelope. Same exit behavior.

## Tests

- New unit test asserts the generated Windows command's decoded script starts with `$ProgressPreference = 'SilentlyContinue'; `.
- Updated the decoded-script assertions across `remote-cmd.test.ts` / `ready.test.ts` for the new prefix.
- `vitest run src/lib/hosts src/lib/secrets` → 515 pass, 2 skipped (win-host-gated e2e), 0 fail. `tsc --noEmit` clean.

Part of the fleet-ops consistency plan (WS2 of 5; WS1 fleet status shipped in #1269). Scoped to `buildWindowsAgentsCommand` / `windowsAgentsScript` — the shared path every `--host` Windows route uses.