### PR TITLE
feat(cli): --json for repos list and plugins list

### DIFF
--- a/apps/cli/.changelog/next/repos-plugins-list-json.md
+++ b/apps/cli/.changelog/next/repos-plugins-list-json.md
@@ -1,0 +1,6 @@
+- **`--json` for `repos list` and `plugins list`.** Both list commands now emit
+  machine-readable JSON with `--json`, matching the `repos view --json` /
+  `plugins marketplaces --json` that already existed — so an agent can enumerate
+  registered repos (with per-repo sync/drift state) and installed plugins (with
+  per-agent-version sync targets) without scraping the human table. Source:
+  `apps/cli/src/commands/repo.ts`, `apps/cli/src/commands/plugins.ts`.

--- a/apps/cli/src/commands/list-json.test.ts
+++ b/apps/cli/src/commands/list-json.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * Real-CLI contract test for the machine-readable `--json` output of the two
+ * "list" commands (`repos list`, `plugins list`). No mocks: we run the actual
+ * command tree in a subprocess against a guarded temp HOME and assert stdout
+ * parses as JSON.
+ *
+ * This exists to catch a specific wiring regression: declaring `--json` on both a
+ * parent command and its subcommand makes commander bind the flag to the parent,
+ * so `plugins list --json` silently falls back to the human table. A unit test on
+ * the action can't see that — only driving the parsed command tree does.
+ */
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const INDEX = path.join(REPO_ROOT, 'src', 'index.ts');
+const ANSI_ESCAPE = String.fromCharCode(27); // the ESC byte chalk color codes start with
+
+let testHome: string;
+
+afterEach(() => {
+  if (testHome) fs.rmSync(testHome, { recursive: true, force: true });
+});
+
+/** A temp HOME with the network/update probes guarded so the CLI runs offline. */
+function guardedHome(): void {
+  testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-listjson-home-'));
+  const systemDir = path.join(testHome, '.agents', '.system');
+  fs.mkdirSync(path.join(systemDir, '.git'), { recursive: true });
+  fs.writeFileSync(
+    path.join(systemDir, '.update-check'),
+    JSON.stringify({ lastCheck: 4102444800000, latestVersion: '0.0.0' }),
+  );
+}
+
+function run(args: string[]): { stdout: string; status: number | null } {
+  const r = spawnSync('bun', [INDEX, ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, HOME: testHome, AGENTS_NO_UPDATE_CHECK: '1' },
+  });
+  return { stdout: r.stdout ?? '', status: r.status };
+}
+
+describe('list commands emit valid JSON with --json (not the human table)', () => {
+  it('repos list --json prints a JSON array with no ANSI color leaking in', () => {
+    guardedHome();
+    const { stdout } = run(['repos', 'list', '--json']);
+    const parsed = JSON.parse(stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+    // The `raw` field for a missing/no-git repo is chalk-colored in the human view;
+    // --json must strip it so downstream parsers get clean strings.
+    expect(stdout).not.toContain(ANSI_ESCAPE);
+  });
+
+  it('plugins list --json prints a JSON array — the flag reaches the subcommand action', () => {
+    guardedHome();
+    const { stdout } = run(['plugins', 'list', '--json']);
+    const parsed = JSON.parse(stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+    // The regression this guards: a table would start with the "Name" header, not JSON.
+    expect(stdout.trimStart().startsWith('[')).toBe(true);
+  });
+});

--- a/apps/cli/src/commands/plugins.ts
+++ b/apps/cli/src/commands/plugins.ts
@@ -101,8 +101,15 @@ When to use:
 `);
 
   // Shared list implementation — reused by `list` and the bare `agents plugins` default.
-  const runList = async () => {
+  const runList = async (options: { json?: boolean } = {}) => {
     const plugins = discoverPlugins();
+
+    if (options.json) {
+      // Structured dump (name/description + per-agent-version sync targets) — the
+      // same rows the table is built from, mirroring `plugins marketplaces --json`.
+      console.log(JSON.stringify(plugins.length === 0 ? [] : buildPluginRows(plugins), null, 2));
+      return;
+    }
 
     if (plugins.length === 0) {
       console.log(chalk.gray('No plugins found in ~/.agents/plugins/'));
@@ -121,13 +128,16 @@ When to use:
     });
   };
 
-  // Bare `agents plugins` → same as `list`.
+  // Bare `agents plugins` → same as `list`. (--json lives on the explicit `list`
+  // subcommand only; declaring it on both parent + child makes commander bind the
+  // flag to the parent for `plugins list --json`, dropping it from the subcommand.)
   pluginsCmd.action(runList);
 
   // agents plugins list
   pluginsCmd
     .command('list')
     .description('Show plugins in a table with sync status across agent versions')
+    .option('--json', 'Emit machine-readable JSON')
     .action(runList);
 
   // agents plugins marketplaces

--- a/apps/cli/src/commands/repo.ts
+++ b/apps/cli/src/commands/repo.ts
@@ -13,6 +13,7 @@
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import { visibleWidth, padVisible } from '../lib/format.js';
+import { stripAnsi } from '../lib/session/width.js';
 import ora from 'ora';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -540,18 +541,31 @@ function renderCards(rows: RepoRow[], cols: number): void {
  * CHANGES cells; a narrow one gets one card per repo with wrapping detail;
  * `--verbose` forces the full-detail table at any width.
  */
-async function listRepos(alias: string | undefined, opts: { verbose?: boolean } = {}): Promise<void> {
+async function listRepos(alias: string | undefined, opts: { verbose?: boolean; json?: boolean } = {}): Promise<void> {
   const targets = collectRepoTargets(alias);
   if (!targets) {
     process.exitCode = 1;
     return;
   }
   if (targets.length === 0) {
+    if (opts.json) {
+      console.log('[]');
+      return;
+    }
     console.log(chalk.gray('No repos to show.'));
     return;
   }
 
   const rows = await Promise.all(targets.map(renderRepoRow));
+
+  if (opts.json) {
+    // Structured dump of the same rows so agents can enumerate repos + sync state.
+    // `raw` (the missing / no-git-remote human label) is the only colored field —
+    // strip ANSI so the JSON stays clean; every other field is already structured.
+    const clean = rows.map((r) => (r.raw !== undefined ? { ...r, raw: stripAnsi(r.raw) } : r));
+    console.log(JSON.stringify(clean, null, 2));
+    return;
+  }
   // TTY width when interactive; fall back to $COLUMNS (honored when piped) then 80.
   const cols = process.stdout.columns || Number(process.env.COLUMNS) || 80;
 
@@ -790,7 +804,8 @@ export function registerRepoCommands(program: Command): void {
     .alias('ls')
     .description('Show all repos with resource-level sync (skills/commands/plugins to pull or push) and local changes.')
     .option('-v, --verbose', 'Full per-resource detail in a table, regardless of terminal width')
-    .action(async (alias: string | undefined, options: { verbose?: boolean }) => {
+    .option('--json', 'machine-readable JSON output')
+    .action(async (alias: string | undefined, options: { verbose?: boolean; json?: boolean }) => {
       await listRepos(alias, options);
     });
 
@@ -1062,7 +1077,8 @@ export function registerRepoCommands(program: Command): void {
     .command('status [alias]', { hidden: true })
     .description('Alias of `list` (kept for muscle memory).')
     .option('-v, --verbose', 'Full per-resource detail in a table, regardless of terminal width')
-    .action(async (alias: string | undefined, options: { verbose?: boolean }) => {
+    .option('--json', 'machine-readable JSON output')
+    .action(async (alias: string | undefined, options: { verbose?: boolean; json?: boolean }) => {
       await listRepos(alias, options);
     });
 }


### PR DESCRIPTION
## What

`repos list` and `plugins list` now support `--json`, closing the machine-readability gap the fleet-ops plan flagged: `repos view` and `plugins marketplaces` already had `--json`, but the *list* commands (the ones an agent reaches for to enumerate) did not, so scripts had to scrape the human table.

- **`agents repos list --json`** → array of structured rows (`alias`, `branch`, `tracking`, `pull`/`push` deltas, `clean`, `local` changes, `url`, `commit`). The one chalk-colored field (`raw`, only set for a missing / no-git-remote repo) is ANSI-stripped so the output is clean.
- **`agents plugins list --json`** → `buildPluginRows()` (name, description, per-agent-version sync targets) — the same rows the table is built from, mirroring `plugins marketplaces --json`.

## A wiring subtlety worth calling out

`--json` is declared on the explicit `list` subcommand only. Declaring it on **both** the parent `plugins` command and the `list` subcommand makes commander bind the flag to the parent, so `plugins list --json` silently falls back to the human table. Caught end-to-end (unit tests on the action can't see it) and fixed.

## Verification (end-to-end, against the real local install)

```
$ agents repos list --json | python3 -c 'import sys,json; d=json.load(sys.stdin); print([r["alias"] for r in d])'
['system', 'user']

$ agents plugins list --json | python3 -c 'import sys,json; print(len(json.load(sys.stdin)))'
17

$ agents plugins list          # no --json → human table unchanged
Name           Version    Marketplace   …
```

## Tests

- New real-CLI subprocess test `list-json.test.ts` runs both commands against a guarded temp HOME and asserts stdout parses as a JSON array (and that no ANSI leaks into `repos list --json`). This is the test that catches the parent/child `--json` wiring regression.
- `vitest run src/commands/{repo,plugins,list-json}.test.ts` → 24 pass, 0 fail. `tsc --noEmit` clean.

Part of the fleet-ops consistency plan (WS5 of 5; WS1 fleet status merged in #1269, WS2 Windows CLIXML in #1270). Note: `plugins info --json` (a single-item detail view) is intentionally out of scope — the scriptable surface is the list.