### PR TITLE
feat(repos): adopt an existing checkout in 'repos add' instead of hard-erroring

### DIFF
--- a/apps/cli/.changelog/next/repos-add-adopt.md
+++ b/apps/cli/.changelog/next/repos-add-adopt.md
@@ -1,0 +1,8 @@
+- **`agents repos add` adopts an existing checkout instead of dead-ending.** When
+  the target `~/.agents-<alias>/` already holds a git repo whose origin matches the
+  requested source, `repos add` now registers it in place (no re-clone) rather than
+  erroring `Directory already exists`. A repo with a *different* origin is left
+  untouched unless you pass `--adopt`. This removes the trap that forced a second,
+  inconsistent install method when a repo had been cloned by hand. Remote matching
+  is transport-agnostic (SSH and HTTPS forms of the same repo compare equal). Source:
+  `apps/cli/src/commands/repo.ts`, `apps/cli/src/lib/git.ts`.

--- a/apps/cli/src/commands/repo.ts
+++ b/apps/cli/src/commands/repo.ts
@@ -64,6 +64,8 @@ import {
   isGitRepo,
   isSystemRepoOrigin,
   adoptRepo,
+  getRemoteUrl,
+  sameGitRemote,
   displayHomePath,
 } from '../lib/git.js';
 import { DEFAULT_SYSTEM_REPO } from '../lib/types.js';
@@ -709,7 +711,8 @@ export function registerRepoCommands(program: Command): void {
     .command('add <source>')
     .description('Register an existing local repo or clone a remote repo into ~/.agents-<alias>/')
     .option('--as <alias>', 'Override the auto-derived alias (letters, digits, _ or -)')
-    .action(async (source: string, options: { as?: string }) => {
+    .option('--adopt', 'If the target directory already holds a git checkout, register it in place instead of erroring (even if its origin differs)')
+    .action(async (source: string, options: { as?: string; adopt?: boolean }) => {
       const meta = readMeta();
       const extras: Record<string, ExtraRepoConfig> = { ...(meta.extraRepos || {}) };
 
@@ -749,7 +752,36 @@ export function registerRepoCommands(program: Command): void {
       ensureAgentsDir();
       const targetDir = getExtraRepoDir(alias);
       if (fs.existsSync(targetDir)) {
-        console.log(chalk.red(`Directory already exists: ${targetDir}`));
+        // Adopt an existing checkout instead of hard-erroring. The common case:
+        // the user already cloned ~/.agents-<alias> by hand, then ran `repos add`
+        // and hit a dead end — which forced a second, inconsistent install method.
+        // If it's already a git repo whose origin matches the requested source,
+        // register it in place (no re-clone); adopt a mismatched/remoteless repo
+        // only with an explicit --adopt.
+        if (isGitRepo(targetDir)) {
+          const existingUrl = await getRemoteUrl(targetDir);
+          const matches = sameGitRemote(existingUrl, parsed.url);
+          if (matches || options.adopt) {
+            const log = await simpleGit(targetDir).log({ maxCount: 1 }).catch(() => null);
+            const commit = log?.latest?.hash.slice(0, 8) || 'unknown';
+            extras[alias] = { url: parsed.url, path: targetDir, enabled: true };
+            updateMeta({ extraRepos: extras });
+            syncExtraAliasAcrossVersions(alias, true);
+            syncMarketplacesForDefaults();
+            console.log(chalk.green(`Adopted existing repo "${alias}" -> ${targetDir} (${commit})`));
+            if (!matches) {
+              console.log(chalk.gray(`  note: its origin is ${existingUrl ?? '(none)'}, not ${parsed.url} — adopted via --adopt.`));
+            }
+            console.log(chalk.gray(`Skills and commands from this repo will be picked up the next time you launch any agent.`));
+            return;
+          }
+          console.log(chalk.red(`Directory already exists and is a different repo: ${targetDir}`));
+          console.log(chalk.gray(`  its origin is ${existingUrl ?? '(none)'}, not ${parsed.url}.`));
+          console.log(chalk.gray('  Adopt it anyway with --adopt, or pick a different alias with --as.'));
+          process.exitCode = 1;
+          return;
+        }
+        console.log(chalk.red(`Directory already exists (and is not a git repo): ${targetDir}`));
         console.log(chalk.gray('Remove it manually or pick a different alias with --as.'));
         process.exitCode = 1;
         return;

--- a/apps/cli/src/lib/git.test.ts
+++ b/apps/cli/src/lib/git.test.ts
@@ -16,11 +16,13 @@ import {
   adoptRepo,
   assertSafeGitTransport,
   assertValidBranchName,
+  canonicalGitRemote,
   commitAndPush,
   displayHomePath,
   parseSource,
   pullRepo,
   pushOrigin,
+  sameGitRemote,
   syncRepoGit,
 } from './git.js';
 
@@ -442,5 +444,32 @@ describe('adoptRepo guards', () => {
     // A rejected adopt leaves no .git and no leftover temp.
     expect(fs.existsSync(path.join(target, '.git'))).toBe(false);
     expect(fs.existsSync(path.join(target, '.git-adopt-temp'))).toBe(false);
+  });
+});
+
+describe('sameGitRemote (adopt-existing repo matching)', () => {
+  it('treats the same repo cloned over SSH vs HTTPS as equal', () => {
+    // parseSource normalizes every github form to https://…/repo.git, but a
+    // hand-cloned checkout's origin may be the SSH form — they must still match
+    // so `repos add` adopts it instead of erroring.
+    expect(sameGitRemote('git@github.com:phnx-labs/.agents-extras.git', 'https://github.com/phnx-labs/.agents-extras.git')).toBe(true);
+    expect(sameGitRemote('ssh://git@github.com/acme/team-skills', 'https://github.com/acme/team-skills.git')).toBe(true);
+    expect(sameGitRemote('https://user@github.com/acme/team-skills.git', 'https://github.com/acme/team-skills')).toBe(true);
+  });
+
+  it('is case-insensitive on host/owner and tolerates trailing slash + .git', () => {
+    expect(sameGitRemote('https://GitHub.com/Acme/Team-Skills.git/', 'https://github.com/acme/team-skills')).toBe(true);
+  });
+
+  it('distinguishes different repos and refuses null/empty', () => {
+    expect(sameGitRemote('git@github.com:acme/a.git', 'git@github.com:acme/b.git')).toBe(false);
+    expect(sameGitRemote('https://github.com/acme/a', 'https://gitlab.com/acme/a')).toBe(false);
+    expect(sameGitRemote(null, 'https://github.com/acme/a')).toBe(false);
+    expect(sameGitRemote('https://github.com/acme/a', undefined)).toBe(false);
+  });
+
+  it('canonicalizes to host/owner/repo', () => {
+    expect(canonicalGitRemote('git@github.com:phnx-labs/.agents-extras.git')).toBe('github.com/phnx-labs/.agents-extras');
+    expect(canonicalGitRemote('https://github.com/phnx-labs/.agents-extras')).toBe('github.com/phnx-labs/.agents-extras');
   });
 });

--- a/apps/cli/src/lib/git.ts
+++ b/apps/cli/src/lib/git.ts
@@ -435,6 +435,30 @@ export async function getRemoteUrl(repoPath: string): Promise<string | null> {
 }
 
 /**
+ * Canonical `host/owner/repo` form of a git remote, transport-agnostic, so the
+ * same repo cloned over SSH vs HTTPS compares equal. Strips protocol, any
+ * `user@`, a trailing `.git`, and folds the scp-style `host:owner/repo` colon to
+ * a slash. Lower-cased. Used to decide whether an existing checkout is "the same
+ * repo" as a requested source before adopting it.
+ */
+export function canonicalGitRemote(url: string): string {
+  return url
+    .trim()
+    .replace(/\/+$/, '') // trailing slashes first, so a trailing-slash-after-.git still strips
+    .replace(/\.git$/i, '')
+    .replace(/^[a-z][a-z0-9+.-]*:\/\//i, '') // strip scheme (https://, ssh://, git://)
+    .replace(/^[^@/]+@/, '') // strip user@ (git@, ssh user)
+    .replace(':', '/') // scp-style host:owner/repo → host/owner/repo (first colon only)
+    .toLowerCase();
+}
+
+/** True when two git remote URLs point at the same repo across transport forms. */
+export function sameGitRemote(a: string | null | undefined, b: string | null | undefined): boolean {
+  if (!a || !b) return false;
+  return canonicalGitRemote(a) === canonicalGitRemote(b);
+}
+
+/**
  * Set the remote URL for origin in a git repo.
  */
 export async function setRemoteUrl(repoPath: string, url: string): Promise<void> {


### PR DESCRIPTION
## What

`agents repos add <source>` hard-errored `Directory already exists` when `~/.agents-<alias>/` was already present — even when it was already a valid clone of the very repo being added. That trap forced a second, inconsistent install method (this session hit it live rolling a repo across the fleet: some boxes registered via `repos add`, others were hand-cloned, and the two never reconciled).

Now `repos add` **adopts** an existing checkout:

- Target dir is a git repo whose **origin matches** the requested source → register it in place (no re-clone), same as a fresh add would.
- Target dir is a git repo with a **different origin** → error and explain, unless `--adopt` is passed to force it.
- Target dir exists but is **not** a git repo → unchanged (still errors; nothing to adopt).

Remote matching is transport-agnostic: `parseSource` normalizes every GitHub form to `https://…/repo.git`, but a hand clone's origin is often the SSH form — new `sameGitRemote()` / `canonicalGitRemote()` (in `git.ts`) fold both to a canonical `host/owner/repo` so they compare equal.

## Verification (end-to-end, temp HOME)

```
# A — dir is a git repo, SSH origin matches the gh: source → ADOPTS + registers
$ repos add gh:phnx-labs/.agents-extras --as m1
Adopted existing repo "m1" -> …/.agents-m1 (f796e1c3)
  → agents.yaml extraRepos.m1 = { url: https://github.com/phnx-labs/.agents-extras.git, path: …, enabled: true }

# B — dir is a git repo with a DIFFERENT origin, no --adopt → errors, no clobber (exit 1)
$ repos add gh:phnx-labs/.agents-extras --as m2
Directory already exists and is a different repo: …/.agents-m2
  its origin is https://github.com/someone/other.git, not https://github.com/phnx-labs/.agents-extras.git.

# C — same, WITH --adopt → adopts anyway, with a note
$ repos add gh:phnx-labs/.agents-extras --as m2 --adopt
Adopted existing repo "m2" -> …/.agents-m2 (4282c17a)
  note: its origin is https://github.com/someone/other.git, not …/.agents-extras.git — adopted via --adopt.
```

## Tests

- `sameGitRemote` / `canonicalGitRemote` unit tests in `git.test.ts`: SSH vs HTTPS equal, case-insensitive, trailing-slash + `.git` tolerant, different repos + null/empty refused. (Caught an ordering bug — `.git/` needs trailing-slash stripped first.)
- `tsc --noEmit` clean; `repo.test.ts` + the new git tests pass.

Part of the fleet-ops consistency plan (WS3 of 5; WS1 fleet status #1269, WS2 CLIXML #1270, WS5 repos/plugins `--json` #1271 all merged). WS4 (remote-flag error-message polish) is intentionally deferred — lowest value, and it touches the passthrough routing choke point every remote command flows through, so it deserves its own careful change rather than riding along here.