### PR TITLE
Fix SSH browser profile binary validation

### DIFF
--- a/apps/cli/src/lib/browser/profiles.test.ts
+++ b/apps/cli/src/lib/browser/profiles.test.ts
@@ -22,7 +22,7 @@ import {
   createProfile,
   ensureDefaultBrowserProfile,
 } from './profiles.js';
-import { findFirstInstalledBrowser, isPortInUse } from './chrome.js';
+import { findBrowserPath, findFirstInstalledBrowser, isPortInUse } from './chrome.js';
 import type { BrowserProfile } from './types.js';
 import type { BrowserProfileConfig } from '../types.js';
 import { readMeta, writeMeta } from '../state.js';
@@ -305,6 +305,24 @@ describe('profile YAML round-trip', () => {
       })
     ).resolves.toBeUndefined();
     expect(store.browser['remote-comet'].binary).toBe('/Applications/Comet Beta.app/Contents/MacOS/Comet Beta');
+  });
+
+  it('skips local browser binary validation for ssh endpoints', async () => {
+    const store: { browser: Record<string, BrowserProfileConfig> } = { browser: {} };
+    vi.mocked(readMeta).mockImplementation(() => store as any);
+    vi.mocked(writeMeta).mockImplementation((meta: any) => {
+      store.browser = (meta.browser ?? {}) as Record<string, BrowserProfileConfig>;
+    });
+
+    await createProfile({
+      name: 'remote-linux-chrome',
+      browser: 'custom',
+      binary: '/opt/google/chrome/chrome',
+      endpoints: ['ssh://linux-box?port=9222'],
+    });
+
+    expect(findBrowserPath).not.toHaveBeenCalled();
+    expect(store.browser['remote-linux-chrome'].binary).toBe('/opt/google/chrome/chrome');
   });
 
   it('rejects shell metacharacters in browser binaries used by ssh endpoints', async () => {

--- a/apps/cli/src/lib/browser/profiles.ts
+++ b/apps/cli/src/lib/browser/profiles.ts
@@ -242,29 +242,6 @@ function hasSshEndpoint(endpoints: BrowserProfileConfig['endpoints']): boolean {
   });
 }
 
-/**
- * True when any endpoint is an `ssh://…?os=windows` target — i.e. the browser
- * lives on a remote Windows host. Such a profile's binary (`msedge.exe`) will
- * never exist on this Mac, so create-time local-binary validation must be
- * skipped; the binary is resolved on the remote at connect time instead.
- */
-function hasRemoteWindowsEndpoint(endpoints: BrowserProfileConfig['endpoints']): boolean {
-  const targets = Array.isArray(endpoints)
-    ? endpoints
-    : Object.values(endpoints).map((preset) => preset.target);
-  return targets.some((target) => {
-    try {
-      const url = new URL(target);
-      return (
-        url.protocol === 'ssh:' &&
-        (url.searchParams.get('os') || '').toLowerCase() === 'windows'
-      );
-    } catch {
-      return false;
-    }
-  });
-}
-
 export async function createProfile(profile: BrowserProfile): Promise<void> {
   const meta = readMeta();
   if (meta.browser?.[profile.name]) {
@@ -296,10 +273,10 @@ export async function createProfile(profile: BrowserProfile): Promise<void> {
   // deferring the failure to the first task. `findBrowserPath` short-circuits
   // for browser=custom without a binary by throwing — same outcome.
   //
-  // Skip for remote-Windows profiles: the browser is `msedge.exe` on the
-  // remote box, never on this Mac, so a local lookup would always (wrongly)
-  // fail. The remote launcher resolves it at connect time via App Paths.
-  if (!hasRemoteWindowsEndpoint(profile.endpoints)) {
+  // Skip for SSH profiles: the browser binary lives on the remote host, so a
+  // local lookup would validate the wrong machine. The remote launcher resolves
+  // it at connect time.
+  if (!hasSshEndpoint(profile.endpoints)) {
     findBrowserPath(profile.browser, profile.binary);
   }
 


### PR DESCRIPTION
## Summary
- Skip local browser binary lookup for every `ssh://` browser profile endpoint, because the binary path belongs to the remote host.
- Keep existing remote binary metacharacter validation, and add a regression test that asserts `createProfile` does not call `findBrowserPath` for SSH endpoints.

## Verification
- `TMPDIR=/tmp TEMP=/tmp TMP=/tmp XDG_CACHE_HOME=/tmp/bun-cache BUN_INSTALL_CACHE_DIR=/tmp/bun-install-cache bun run test src/lib/browser/profiles.test.ts` -> 47 passed
- `TMPDIR=/tmp TEMP=/tmp TMP=/tmp XDG_CACHE_HOME=/tmp/bun-cache BUN_INSTALL_CACHE_DIR=/tmp/bun-install-cache bun run build` -> passed
- Built CLI real flow: isolated temp HOME + setup marker, `node dist/index.js browser profiles create remote-linux --browser custom --binary /definitely/remote/chrome --endpoint ssh://linux-box?port=9333`, then `profiles show --json` returned the profile with that SSH endpoint and binary path.

## Full suite note
- `bun run test` with isolated writable HOME reached 455 passed files / 6,015 passed tests, with 2 unrelated baseline failures: `tests/project-resources-pipeline.test.ts` expected no `/tmp/.agents`, and `tests/non-interactive.test.ts` expected a temp `.codex` symlink.
- Earlier full-suite run without isolated HOME failed broadly from sandbox read-only writes under `/home/muqsit/.agents`, confirming the isolated HOME run is the useful baseline.

Session transcript: omitted because this is a public repository.