### PR TITLE
feat(routines): add errorMessage and duration to RunMeta (RUSH-1281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,13 @@
 
 ### Added
 
+- **Routine `meta.json` now includes `duration` and `errorMessage` (RUSH-1281).**
+  `RunMeta` records wall-clock `duration` in milliseconds and a machine-readable
+  `errorMessage` on failure paths (spawn errors, timeouts, loop errors, host-reconcile
+  failures, and monitor-reaped runs). Populated on every terminal state in
+  `apps/cli/src/lib/runner.ts` via the new `finalizeRunMeta` helper in
+  `apps/cli/src/lib/routines.ts`.
+
 - **`agents run --lease` is now frictionless end-to-end (RUSH-1723).** Leasing a
   disposable cloud box to run an agent — the BYO-your-own-cloud way to offload heavy
   work when local CPU cores are exhausted — no longer needs an env var, a flag, or a

--- a/apps/cli/src/lib/routines.test.ts
+++ b/apps/cli/src/lib/routines.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as yaml from 'yaml';
-import { validateJob, validateTrigger, normalizeTriggerEvent, writeJob, readJob, deleteJob, listJobs, jobRunsOnThisDevice, checkJobDeviceEligibility, getJobRunsDir, getRunDir, type JobConfig } from './routines.js';
+import { validateJob, validateTrigger, normalizeTriggerEvent, writeJob, readJob, deleteJob, listJobs, jobRunsOnThisDevice, checkJobDeviceEligibility, getJobRunsDir, getRunDir, finalizeRunMeta, type JobConfig, type RunMeta } from './routines.js';
 import { getRoutinesDir, getSystemRoutinesDir, getRunsDir, ensureAgentsDir } from './state.js';
 
 /** Minimal valid schedule-based job. */
@@ -507,5 +507,62 @@ describe('routine name path containment (C4)', () => {
     expect(() => getRunDir('../../../../tmp/evil-routine', 'run-1')).toThrow();
     expect(() => getJobRunsDir('..')).toThrow();
     expect(() => getJobRunsDir('a/b')).toThrow();
+  });
+});
+
+describe('finalizeRunMeta', () => {
+  function makeMeta(startedAt: string): RunMeta {
+    return {
+      jobName: 'j',
+      runId: 'r1',
+      agent: 'claude',
+      pid: null,
+      status: 'running',
+      startedAt,
+      completedAt: null,
+      exitCode: null,
+    };
+  }
+
+  it('sets completedAt, exitCode, status, and computes duration from startedAt', () => {
+    const startedAt = new Date(Date.now() - 1234).toISOString();
+    const meta = makeMeta(startedAt);
+    finalizeRunMeta(meta, 'completed', 0);
+    expect(meta.status).toBe('completed');
+    expect(meta.exitCode).toBe(0);
+    expect(meta.completedAt).not.toBeNull();
+    expect(meta.duration).toBeGreaterThanOrEqual(1234);
+    expect(meta.errorMessage).toBeUndefined();
+  });
+
+  it('records errorMessage on failure when provided', () => {
+    const meta = makeMeta(new Date().toISOString());
+    finalizeRunMeta(meta, 'failed', 1, { errorMessage: 'spawn failed' });
+    expect(meta.status).toBe('failed');
+    expect(meta.exitCode).toBe(1);
+    expect(meta.errorMessage).toBe('spawn failed');
+    expect(meta.duration).toBeGreaterThanOrEqual(0);
+  });
+
+  it('uses a provided completedAt override and computes duration from it', () => {
+    const startedAt = new Date('2026-01-01T00:00:00.000Z').toISOString();
+    const completedAt = new Date('2026-01-01T00:00:05.000Z').toISOString();
+    const meta = makeMeta(startedAt);
+    finalizeRunMeta(meta, 'completed', 0, { completedAt });
+    expect(meta.completedAt).toBe(completedAt);
+    expect(meta.duration).toBe(5000);
+  });
+
+  it('clears a stale errorMessage when finalizing successfully', () => {
+    const meta = makeMeta(new Date().toISOString());
+    meta.errorMessage = 'stale';
+    finalizeRunMeta(meta, 'completed', 0);
+    expect(meta.errorMessage).toBeUndefined();
+  });
+
+  it('falls back to zero duration when startedAt is unparseable', () => {
+    const meta = makeMeta('not-a-date');
+    finalizeRunMeta(meta, 'failed', 1);
+    expect(meta.duration).toBe(0);
   });
 });

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -182,11 +182,41 @@ export interface RunMeta {
   startedAt: string;
   completedAt: string | null;
   exitCode: number | null;
+  /** Machine-readable failure reason when the run did not complete successfully. */
+  errorMessage?: string;
+  /** Wall-clock duration of the run in milliseconds (set when the run finishes). */
+  duration?: number;
   /** Set for `host:`-placed runs — where the job body executes (no local pid). */
   host?: string;
   /** The host-task sidecar id backing a `host:` run; the daemon monitor
    *  finalizes the run by reconciling it against the remote `.exit`. */
   hostTaskId?: string;
+}
+
+/**
+ * Finalize a run record with a terminal status, computing `duration` from
+ * `startedAt` and the completion timestamp. Keeps failure-reason population
+ * centralized so every completion path writes the same machine-readable fields.
+ */
+export function finalizeRunMeta(
+  meta: RunMeta,
+  status: RunMeta['status'],
+  exitCode: number | null,
+  opts?: { errorMessage?: string; completedAt?: string },
+): void {
+  meta.status = status;
+  meta.exitCode = exitCode;
+  meta.completedAt = opts?.completedAt ?? new Date().toISOString();
+  const started = Date.parse(meta.startedAt);
+  const completed = Date.parse(meta.completedAt);
+  meta.duration = Number.isFinite(started) && Number.isFinite(completed) && completed >= started
+    ? completed - started
+    : 0;
+  if (opts?.errorMessage) {
+    meta.errorMessage = opts.errorMessage;
+  } else {
+    delete meta.errorMessage;
+  }
 }
 
 /**

--- a/apps/cli/src/lib/runner.test.ts
+++ b/apps/cli/src/lib/runner.test.ts
@@ -143,6 +143,8 @@ describe('command-mode routines (executeJob foreground)', () => {
     expect(result.meta.exitCode).toBe(0);
     expect(result.meta.command).toBe('exit 0');
     expect(result.meta.agent).toBeUndefined();
+    expect(result.meta.duration).toBeGreaterThanOrEqual(0);
+    expect(result.meta.errorMessage).toBeUndefined();
     expect(result.reportPath).toBeNull();
 
     // A real run record was written and is readable from disk.
@@ -152,6 +154,8 @@ describe('command-mode routines (executeJob foreground)', () => {
     expect(metaOnDisk.status).toBe('completed');
     expect(metaOnDisk.command).toBe('exit 0');
     expect(metaOnDisk.agent).toBeUndefined();
+    expect(metaOnDisk.duration).toBeGreaterThanOrEqual(0);
+    expect(metaOnDisk.errorMessage).toBeUndefined();
   });
 
   it('propagates a non-zero exit → status failed, exitCode preserved', async () => {
@@ -162,6 +166,8 @@ describe('command-mode routines (executeJob foreground)', () => {
     expect(result.meta.exitCode).toBe(3);
     expect(result.meta.command).toBe('exit 3');
     expect(result.meta.agent).toBeUndefined();
+    expect(result.meta.duration).toBeGreaterThanOrEqual(0);
+    expect(result.meta.errorMessage).toBeUndefined();
   });
 
   it('captures command stdout to the run log', async () => {
@@ -211,6 +217,8 @@ describe('command-mode routines (executeJobDetached — daemon/cron path)', () =
     expect(final.status).toBe('completed');
     expect(final.exitCode).toBe(0);
     expect(final.command).toBe('exit 0');
+    expect(final.duration).toBeGreaterThanOrEqual(0);
+    expect(final.errorMessage).toBeUndefined();
     // exit-code file is the posix restart-recovery source of truth (the sh subshell
     // wrapper writes it). Windows records status via child.on('exit') only — no file.
     if (process.platform !== 'win32') {
@@ -225,5 +233,7 @@ describe('command-mode routines (executeJobDetached — daemon/cron path)', () =
     const final = await waitTerminal('cmd-det-fail', meta.runId);
     expect(final.status).toBe('failed');
     expect(final.exitCode).toBe(3);
+    expect(final.duration).toBeGreaterThanOrEqual(0);
+    expect(final.errorMessage).toBeUndefined();
   });
 });

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -26,6 +26,7 @@ import {
   getRunDir,
   jobRunsOnThisDevice,
   checkJobDeviceEligibility,
+  finalizeRunMeta,
 } from './routines.js';
 import { getRunsDir } from './state.js';
 import type { AgentId } from './types.js';
@@ -629,9 +630,13 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
       agent: effectiveAgent,
       version: primaryVersion,
     }, deps);
-    meta.status = loopResult.stoppedBy === 'error' ? 'failed' : 'completed';
-    meta.completedAt = new Date().toISOString();
-    meta.exitCode = loopResult.stoppedBy === 'error' ? 1 : 0;
+    const loopFailed = loopResult.stoppedBy === 'error';
+    finalizeRunMeta(
+      meta,
+      loopFailed ? 'failed' : 'completed',
+      loopFailed ? 1 : 0,
+      loopFailed ? { errorMessage: `loop stopped: ${loopResult.stoppedBy}` } : undefined,
+    );
     writeRunMeta(meta);
     timer.end({ status: meta.status, exitCode: meta.exitCode ?? undefined, runId });
     return { meta, reportPath: null };
@@ -682,8 +687,7 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
     writeRunMeta(meta);
 
     if (attempt.status === 'timeout') {
-      meta.status = 'timeout';
-      meta.completedAt = new Date().toISOString();
+      finalizeRunMeta(meta, 'timeout', null, { errorMessage: 'run timed out' });
       writeRunMeta(meta);
       timer.end({ status: 'timeout', runId });
       const reportPath = extractAndSaveReport(stdoutPath, effectiveAgent, runDir);
@@ -691,9 +695,7 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
     }
 
     if (attempt.status === 'completed') {
-      meta.exitCode = 0;
-      meta.status = 'completed';
-      meta.completedAt = new Date().toISOString();
+      finalizeRunMeta(meta, 'completed', 0);
       writeRunMeta(meta);
       timer.end({ status: 'completed', exitCode: 0, runId });
       const reportPath = extractAndSaveReport(stdoutPath, effectiveAgent, runDir);
@@ -722,9 +724,7 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
       );
     }
 
-    meta.exitCode = attempt.exitCode ?? 1;
-    meta.status = 'failed';
-    meta.completedAt = new Date().toISOString();
+    finalizeRunMeta(meta, 'failed', attempt.exitCode ?? 1, attempt.error ? { errorMessage: attempt.error } : undefined);
     writeRunMeta(meta);
     timer.end({
       status: 'failed',
@@ -737,9 +737,7 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
   }
 
   // Unreachable: chain is always non-empty, but keep a safe fallback.
-  meta.status = 'failed';
-  meta.exitCode = 1;
-  meta.completedAt = new Date().toISOString();
+  finalizeRunMeta(meta, 'failed', 1);
   writeRunMeta(meta);
   timer.end({ status: 'failed', exitCode: 1, runId });
   return { meta, reportPath: null };
@@ -802,9 +800,7 @@ async function executeJobOnHost(config: JobConfig, opts: { detached: boolean }):
   // Sync path: a real exit code finalizes now. -1 (follow window closed) and
   // the detached path leave the meta `running` for the monitor to reconcile.
   if (!opts.detached && exitCode !== null && exitCode !== undefined && exitCode !== -1) {
-    meta.status = exitCode === 0 ? 'completed' : 'failed';
-    meta.exitCode = exitCode;
-    meta.completedAt = new Date().toISOString();
+    finalizeRunMeta(meta, exitCode === 0 ? 'completed' : 'failed', exitCode);
   }
   writeRunMeta(meta);
   timer.end({ status: meta.status, exitCode: meta.exitCode ?? undefined, runId });
@@ -887,9 +883,12 @@ async function executeCommandJobForeground(config: JobConfig): Promise<RunResult
     });
   });
 
-  meta.status = result.status;
-  meta.exitCode = result.exitCode ?? (result.status === 'completed' ? 0 : 1);
-  meta.completedAt = new Date().toISOString();
+  finalizeRunMeta(
+    meta,
+    result.status,
+    result.exitCode ?? (result.status === 'completed' ? 0 : 1),
+    result.error ? { errorMessage: result.error } : undefined,
+  );
   writeRunMeta(meta);
 
   if (result.error) {
@@ -990,9 +989,7 @@ export async function executeJobDetached(config: JobConfig): Promise<RunMeta> {
 
   child.on('error', (err) => {
     try { fs.closeSync(stdoutFd); } catch { /* fd already closed */ }
-    meta.status = 'failed';
-    meta.exitCode = 1;
-    meta.completedAt = new Date().toISOString();
+    finalizeRunMeta(meta, 'failed', 1, { errorMessage: err.message });
     writeRunMeta(meta);
     process.stderr.write(`[agents] daemon: spawn failed for job "${config.name}": ${err.message}\n`);
   });
@@ -1056,17 +1053,15 @@ function executeCommandJobDetached(config: JobConfig): RunMeta {
   // fire-and-forget call, so the exit event fires here. (monitorRunningJobs no
   // longer force-fails command jobs; it reads exit-code only on the restart edge.)
   let settled = false;
-  const settle = (status: RunMeta['status'], exitCode: number) => {
+  const settle = (status: RunMeta['status'], exitCode: number, errorMessage?: string) => {
     if (settled) return;
     settled = true;
-    meta.status = status;
-    meta.exitCode = exitCode;
-    meta.completedAt = new Date().toISOString();
+    finalizeRunMeta(meta, status, exitCode, errorMessage ? { errorMessage } : undefined);
     writeRunMeta(meta);
   };
   child.on('exit', (code) => settle(code === 0 ? 'completed' : 'failed', code ?? 1));
   child.on('error', (err) => {
-    settle('failed', 1);
+    settle('failed', 1, err.message);
     process.stderr.write(`[agents] daemon: command spawn failed for job "${config.name}": ${err.message}\n`);
   });
 
@@ -1223,9 +1218,12 @@ function finalizeHostRun(meta: RunMeta): void {
     if (!task) return;
     const healed = reconcileHostTask(task);
     if (healed.status !== 'completed' && healed.status !== 'failed') return;
-    meta.status = healed.status;
-    meta.exitCode = healed.exitCode ?? (healed.status === 'completed' ? 0 : 1);
-    meta.completedAt = healed.finishedAt ?? new Date().toISOString();
+    finalizeRunMeta(
+      meta,
+      healed.status,
+      healed.exitCode ?? (healed.status === 'completed' ? 0 : 1),
+      { completedAt: healed.finishedAt ?? undefined },
+    );
     writeRunMeta(meta);
   } catch { /* unreachable host or unreadable sidecar — retry next sweep */ }
 }
@@ -1270,8 +1268,7 @@ export function monitorRunningJobs(): void {
 
         const wallClockMs = Date.now() - Date.parse(meta.startedAt);
         if (Number.isFinite(wallClockMs) && wallClockMs > MAX_WALL_CLOCK_MS) {
-          meta.status = 'timeout';
-          meta.completedAt = new Date().toISOString();
+          finalizeRunMeta(meta, 'timeout', null, { errorMessage: 'exceeded max wall clock' });
           writeRunMeta(meta);
           if (!isCommandRun) extractAndSaveReport(stdoutPath, meta.agent!, runDirPath);
           continue;
@@ -1285,18 +1282,15 @@ export function monitorRunningJobs(): void {
             // missed the exit event — recover the true code from the exit-code file
             // the child wrote; its absence means the child was killed/crashed.
             const ec = readCommandExitCode(runDirPath);
-            meta.status = ec === 0 ? 'completed' : 'failed';
-            meta.exitCode = ec;
+            finalizeRunMeta(meta, ec === 0 ? 'completed' : 'failed', ec);
           } else {
             const inferred = inferFinalStatusFromLog(stdoutPath, meta.agent!);
             if (inferred) {
-              meta.status = inferred.status;
-              meta.exitCode = inferred.exitCode;
+              finalizeRunMeta(meta, inferred.status, inferred.exitCode);
             } else {
-              meta.status = 'failed';
+              finalizeRunMeta(meta, 'failed', null, { errorMessage: 'process exited before final status could be inferred' });
             }
           }
-          meta.completedAt = new Date().toISOString();
           writeRunMeta(meta);
 
           if (!isCommandRun) extractAndSaveReport(stdoutPath, meta.agent!, runDirPath);


### PR DESCRIPTION
Adds `errorMessage` and `duration` to routine `RunMeta`, populated on every terminal completion/failure path via a new `finalizeRunMeta` helper.

- `duration` is wall-clock milliseconds from `startedAt` to completion.
- `errorMessage` is set for spawn errors, timeouts, loop errors, host-reconcile failures, and monitor-reaped runs with no inferable status.
- All terminal write sites in `runner.ts` now use the helper so the fields are consistent.
- Added unit tests for `finalizeRunMeta` and extended command-mode runner tests to assert the new fields.

Closes RUSH-1281.