### PR TITLE
fix(ssh): propagate terminfo so Ghostty/kitty/WezTerm work over `agents ssh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,24 @@
 
 ### Fixed
 
+- **`agents ssh` no longer lands you in a broken remote session from Ghostty,
+  kitty, or WezTerm.** These emulators ship their own terminfo entry and export
+  an exotic `$TERM` (`xterm-ghostty`, `xterm-kitty`, `wezterm`, …). A plain
+  interactive `ssh -tt` forwards that `$TERM` to the remote, and if the remote's
+  terminfo database has no matching entry every ncurses program breaks —
+  `clear`, `tput`, `vim`, `less`, `tmux`, and the shell line editor all error
+  with `'xterm-ghostty': unknown terminal type`. `agents ssh` now handles this
+  the way the emulators themselves do: on an interactive login to a POSIX device
+  it **propagates** the local terminfo entry to the remote (`infocmp` piped into
+  `tic`, installed under the remote user's `~/.terminfo`) so the real `$TERM`
+  works with full fidelity, and **falls back** to a universally-present
+  `xterm-256color` when propagation can't happen (the local box has no entry to
+  copy, or the remote lacks `tic`). The propagation decision is cached per
+  (host, terminal) so the handshake is a once-per-host cost. Set
+  `AGENTS_SSH_TERM=<value>` to force a specific remote `$TERM`, or
+  `AGENTS_SSH_TERM=keep` to forward the local one unchanged. Source:
+  `apps/cli/src/lib/devices/terminfo.ts`, `apps/cli/src/lib/devices/connect.ts`,
+  `apps/cli/src/commands/ssh.ts`.
 - **`agents run <agent> --fallback …` no longer disables account rotation.**
   A `--fallback` chain skipped strategy resolution entirely ("strategy balanced
   ignored: --fallback pins versions directly"), so the bare primary always ran on

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -53,6 +53,13 @@ import {
 } from '../lib/devices/connect.js';
 import { ensureManagedKnownHostsDir, isHostPinned } from '../lib/devices/known-hosts.js';
 import {
+  isManagedTerm,
+  propagateTerminfo,
+  readTerminfoDecision,
+  resolveLoginTerm,
+  writeTerminfoDecision,
+} from '../lib/devices/terminfo.js';
+import {
   fanOutDevices,
   planFleetTargets,
   remoteFleetTargets,
@@ -704,6 +711,53 @@ Typical workflow:
     });
 }
 
+/**
+ * Decide the `$TERM` an interactive login should request on the remote, fixing
+ * the "exotic terminal → broken remote session" problem (Ghostty/kitty/WezTerm
+ * forward an `xterm-ghostty`/`xterm-kitty`/… the remote can't render). Returns
+ * an override to force, or undefined to forward the local `$TERM` unchanged.
+ *
+ * Only interactive logins to POSIX devices are handled — a remote command gets
+ * no pty (so no `$TERM` is sent) and Windows/PowerShell doesn't use terminfo.
+ * `AGENTS_SSH_TERM` is an escape hatch: a literal value forces that `$TERM`;
+ * `keep` disables all handling and forwards the local one verbatim.
+ */
+function resolveInteractiveTerm(
+  device: DeviceProfile,
+  cmd: string[],
+  shim: string,
+  hostKey: { pinned?: boolean },
+): string | undefined {
+  if (cmd.length > 0 || device.shell === 'powershell') return undefined;
+
+  const forced = process.env.AGENTS_SSH_TERM;
+  if (forced) return forced === 'keep' ? undefined : forced;
+
+  const localTerm = process.env.TERM;
+  if (!isManagedTerm(localTerm)) return undefined;
+
+  const host = hostNameFor(device) ?? device.name;
+  const cached = readTerminfoDecision(host, localTerm);
+  const propagated =
+    cached !== null
+      ? cached === 'ok'
+      : (() => {
+          const ok = propagateTerminfo(device, localTerm, shim, hostKey);
+          writeTerminfoDecision(host, localTerm, ok ? 'ok' : 'downgrade');
+          return ok;
+        })();
+
+  const override = resolveLoginTerm(localTerm, propagated);
+  if (override) {
+    console.error(
+      chalk.gray(
+        `Terminal '${localTerm}' isn't installed on '${device.name}' — using ${override} for this session.`,
+      ),
+    );
+  }
+  return override;
+}
+
 /** Register the `agents ssh` smart wrapper. */
 function registerSshWrapper(program: Command): void {
   const sshCmd = program
@@ -718,6 +772,11 @@ Examples:
 
 Devices come from 'agents devices'. Password auth pulls the secret from a
 secrets bundle via an askpass shim — the password never touches argv.
+
+From a Ghostty/kitty/WezTerm terminal, an interactive login propagates your
+local terminfo entry to the remote (or falls back to xterm-256color) so clear,
+vim, less and tmux work. Override with AGENTS_SSH_TERM=<value>, or
+AGENTS_SSH_TERM=keep to forward your local \$TERM unchanged.
 `)
     .action(async (name: string, cmd: string[]) => {
       // Hidden askpass bridge: ssh execs the shim, which re-invokes us here.
@@ -755,7 +814,8 @@ secrets bundle via an askpass shim — the password never touches argv.
         ensureManagedKnownHostsDir();
         const addr = hostNameFor(device);
         const pinned = addr ? isHostPinned(addr) : false;
-        const { args, env } = buildSshInvocation(device, cmd, shim, { pinned });
+        const term = resolveInteractiveTerm(device, cmd, shim, { pinned });
+        const { args, env } = buildSshInvocation(device, cmd, shim, { pinned, term });
         const res = spawnSync('ssh', args, {
           stdio: 'inherit',
           env: { ...process.env, ...env },

--- a/apps/cli/src/lib/devices/connect.test.ts
+++ b/apps/cli/src/lib/devices/connect.test.ts
@@ -90,6 +90,13 @@ describe('buildSshInvocation', () => {
     expect(args[args.length - 1]).toBe('me@i.ts.net');
   });
 
+  it('term override sets env.TERM; absent leaves it untouched', () => {
+    const withTerm = buildSshInvocation(dev({ name: 't', user: 'me' }), [], '/shim', { term: 'xterm-256color' });
+    expect(withTerm.env.TERM).toBe('xterm-256color');
+    const noTerm = buildSshInvocation(dev({ name: 't', user: 'me' }), [], '/shim');
+    expect(noTerm.env.TERM).toBeUndefined();
+  });
+
   it('password auth without a bundle is a hard error', () => {
     expect(() => buildSshInvocation(dev({ name: 'b', auth: { method: 'password' } }), [], '/shim')).toThrow(/no secrets bundle/);
   });

--- a/apps/cli/src/lib/devices/connect.ts
+++ b/apps/cli/src/lib/devices/connect.ts
@@ -69,6 +69,14 @@ export interface SshHostKeyOptions {
   pinned?: boolean;
   /** Managed known_hosts path override (tests). Defaults to the CLI-managed store. */
   knownHostsFile?: string;
+  /**
+   * Override the `$TERM` the ssh child requests for the remote pty. Set by the
+   * interactive login path when the local terminal's terminfo entry is missing
+   * on the remote and couldn't be propagated — a universally-present
+   * `xterm-256color` is forced so ncurses programs work. Undefined leaves the
+   * inherited `$TERM` alone. See `terminfo.ts`.
+   */
+  term?: string;
 }
 
 /**
@@ -107,6 +115,12 @@ export function buildSshInvocation(
   } else {
     args.push('-o', 'BatchMode=yes');
   }
+
+  // Force a working remote pty terminal type when the caller resolved one
+  // (an exotic local $TERM the remote can't render — see terminfo.ts). ssh
+  // derives the pty's terminal type from the client env's $TERM, so overriding
+  // it here is what the remote sees.
+  if (hostKey.term) env.TERM = hostKey.term;
 
   // An interactive login (no remote command) needs a real tty.
   if (!remote) args.push('-tt');

--- a/apps/cli/src/lib/devices/terminfo.test.ts
+++ b/apps/cli/src/lib/devices/terminfo.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Terminal-type handling for `agents ssh` interactive logins.
+ *
+ * The real bugs here are connectivity-shaped: an exotic local `$TERM` must be
+ * recognized as "needs handling" (else the remote session breaks), a safe
+ * `$TERM` must be left alone (else we pay a pointless round-trip), the
+ * downgrade decision must be pure and correct, and the (host,term) cache must
+ * round-trip so the propagation handshake is a once-per-host cost. `localTerminfoSource`
+ * is exercised against the real local terminfo database (no mocking).
+ */
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  FALLBACK_TERM,
+  isManagedTerm,
+  localTerminfoSource,
+  readTerminfoDecision,
+  remoteTicCommand,
+  resolveLoginTerm,
+  writeTerminfoDecision,
+} from './terminfo.js';
+
+describe('isManagedTerm', () => {
+  it('treats exotic terminals as managed and universal ones as pass-through', () => {
+    for (const t of ['xterm-ghostty', 'xterm-kitty', 'wezterm', 'foot', 'rio']) {
+      expect(isManagedTerm(t)).toBe(true);
+    }
+    for (const t of ['xterm', 'xterm-256color', 'screen-256color', 'tmux-256color', 'vt100', 'linux', 'dumb']) {
+      expect(isManagedTerm(t)).toBe(false);
+    }
+  });
+
+  it('rejects empty and injection-shaped values', () => {
+    expect(isManagedTerm(undefined)).toBe(false);
+    expect(isManagedTerm('')).toBe(false);
+    expect(isManagedTerm('foo; rm -rf /')).toBe(false);
+    expect(isManagedTerm('$(evil)')).toBe(false);
+    expect(isManagedTerm('-bad')).toBe(false);
+  });
+});
+
+describe('resolveLoginTerm', () => {
+  it('keeps a safe term as-is regardless of propagation', () => {
+    expect(resolveLoginTerm('xterm-256color', false)).toBeUndefined();
+    expect(resolveLoginTerm('xterm-256color', true)).toBeUndefined();
+    expect(resolveLoginTerm(undefined, false)).toBeUndefined();
+  });
+
+  it('keeps an exotic term when propagated, downgrades when not', () => {
+    expect(resolveLoginTerm('xterm-ghostty', true)).toBeUndefined();
+    expect(resolveLoginTerm('xterm-ghostty', false)).toBe(FALLBACK_TERM);
+    expect(resolveLoginTerm('xterm-kitty', false)).toBe('xterm-256color');
+  });
+});
+
+describe('remoteTicCommand', () => {
+  it('installs under ~/.terminfo and self-verifies the entry', () => {
+    const cmd = remoteTicCommand('xterm-ghostty');
+    expect(cmd).toContain('tic -x -o "$HOME/.terminfo" -');
+    expect(cmd).toContain('infocmp -x xterm-ghostty');
+  });
+});
+
+describe('localTerminfoSource', () => {
+  it('produces source for a universally-present term and null for a bogus one', () => {
+    // xterm-256color ships in every terminfo database, so infocmp must resolve it.
+    const src = localTerminfoSource('xterm-256color');
+    expect(src).not.toBeNull();
+    expect(src).toMatch(/xterm-256color/);
+    // A name that cannot exist in any database resolves to null (no throw).
+    expect(localTerminfoSource('definitely-not-a-real-terminal-xyz')).toBeNull();
+  });
+
+  it('refuses an invalid terminfo name without shelling out', () => {
+    expect(localTerminfoSource('foo; echo pwned')).toBeNull();
+  });
+});
+
+describe('terminfo decision cache', () => {
+  it('round-trips a decision and returns null for an unknown pair', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'terminfo-cache-'));
+    try {
+      expect(readTerminfoDecision('host-a', 'xterm-ghostty', dir)).toBeNull();
+      writeTerminfoDecision('host-a', 'xterm-ghostty', 'ok', dir);
+      expect(readTerminfoDecision('host-a', 'xterm-ghostty', dir)).toBe('ok');
+      writeTerminfoDecision('host-b', 'xterm-kitty', 'downgrade', dir);
+      expect(readTerminfoDecision('host-b', 'xterm-kitty', dir)).toBe('downgrade');
+      // Distinct pairs don't collide.
+      expect(readTerminfoDecision('host-a', 'xterm-ghostty', dir)).toBe('ok');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/src/lib/devices/terminfo.ts
+++ b/apps/cli/src/lib/devices/terminfo.ts
@@ -1,0 +1,176 @@
+/**
+ * Terminal-type (`$TERM` / terminfo) handling for `agents ssh` interactive logins.
+ *
+ * Modern terminal emulators — Ghostty, kitty, WezTerm, foot, rio — ship their
+ * own terminfo entry and export an exotic `$TERM` (`xterm-ghostty`,
+ * `xterm-kitty`, `wezterm`, …). A plain `ssh -tt` forwards that `$TERM` to the
+ * remote through the pty request. If the remote's terminfo database has no
+ * matching entry, every ncurses program breaks — `clear`, `tput`, `vim`,
+ * `less`, `tmux`, and the shell's line editor all error with
+ * `'xterm-ghostty': unknown terminal type`. That is why a bare `agents ssh`
+ * from one of these terminals lands you in a session where nothing renders.
+ *
+ * We fix it the way the emulators themselves do:
+ *  1. **Propagate** the local terminfo entry to the remote — pipe `infocmp`
+ *     here into `tic` there, installing it under the remote user's
+ *     `~/.terminfo`. The remote then understands the real `$TERM` with full
+ *     fidelity (extended capabilities — styled underlines, the kitty keyboard
+ *     protocol — intact).
+ *  2. **Fall back** to a universally-present `$TERM` (`xterm-256color`) when
+ *     propagation can't happen: the local box has no entry to copy, `tic` is
+ *     absent on the remote, or the remote is Windows. A degraded-but-working
+ *     session always beats a broken one.
+ *
+ * Terminals whose entry ships in every base terminfo database (`xterm`,
+ * `xterm-256color`, `screen`, `tmux`, `vt100`, `linux`, …) are left untouched:
+ * no round-trip, no override. The per-(host,term) decision is cached so the
+ * propagation handshake happens at most once per host+terminal.
+ */
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { getCacheDir } from '../state.js';
+import { buildSshInvocation, type SshHostKeyOptions } from './connect.js';
+import { type DeviceProfile } from './registry.js';
+
+/**
+ * Terminals present in essentially every POSIX terminfo database. When the
+ * local `$TERM` is one of these there is nothing to fix — ssh forwards it and
+ * the remote already understands it.
+ */
+const SAFE_TERMS = new Set([
+  'xterm',
+  'xterm-color',
+  'xterm-256color',
+  'screen',
+  'screen-256color',
+  'tmux',
+  'tmux-256color',
+  'vt100',
+  'vt220',
+  'ansi',
+  'linux',
+  'dumb',
+  'rxvt',
+  'rxvt-unicode',
+  'rxvt-unicode-256color',
+]);
+
+/** The compatibility `$TERM` used when the real one can't be made to work remotely. */
+export const FALLBACK_TERM = 'xterm-256color';
+
+/**
+ * A valid terminfo name: begins with a letter, then letters/digits and the
+ * punctuation terminfo uses (`-`, `+`, `.`, `_`). This is both a correctness
+ * check and an injection guard — the name is interpolated into a remote shell
+ * command and passed to local `infocmp`, so anything outside this set is refused.
+ */
+const TERM_NAME_RE = /^[A-Za-z][A-Za-z0-9._+-]*$/;
+
+/**
+ * True when `term` is an exotic terminal worth handling — non-empty, a valid
+ * terminfo name, and NOT one of the universally-present {@link SAFE_TERMS}.
+ * Everything a plain `agents ssh` already handles correctly returns false.
+ */
+export function isManagedTerm(term: string | undefined): term is string {
+  return !!term && TERM_NAME_RE.test(term) && !SAFE_TERMS.has(term);
+}
+
+/**
+ * The local terminfo source for `term`, as portable text, or null when it
+ * can't be produced (no `infocmp`, or the local database has no such entry).
+ * `-x` keeps user-defined/extended capabilities (the whole point for kitty/
+ * Ghostty); `-q -0` yields a compact single-line-per-entry form `tic` accepts.
+ */
+export function localTerminfoSource(term: string): string | null {
+  if (!TERM_NAME_RE.test(term)) return null;
+  const res = spawnSync('infocmp', ['-x', '-q', '-0', term], {
+    encoding: 'utf-8',
+    windowsHide: true,
+  });
+  if (res.status !== 0 || !res.stdout || !res.stdout.trim()) return null;
+  return res.stdout;
+}
+
+/**
+ * The remote command that installs a piped terminfo source under `~/.terminfo`
+ * and then verifies the entry is readable. Self-verifying (`&& infocmp`) so a
+ * zero exit genuinely means "the remote now understands this `$TERM`", not just
+ * "tic ran". `term` is validated by the callers ({@link isManagedTerm}) before
+ * it reaches here.
+ */
+export function remoteTicCommand(term: string): string {
+  return `tic -x -o "$HOME/.terminfo" - && infocmp -x ${term} >/dev/null 2>&1`;
+}
+
+/**
+ * The override `$TERM` to force on the ssh child, or undefined to leave the
+ * inherited value alone. Pure: safe terminals and successfully-propagated
+ * exotic terminals keep their real `$TERM` (undefined); an exotic terminal we
+ * could not propagate is downgraded to {@link FALLBACK_TERM}.
+ */
+export function resolveLoginTerm(localTerm: string | undefined, propagated: boolean): string | undefined {
+  if (!isManagedTerm(localTerm)) return undefined; // safe/absent term — forward as-is
+  return propagated ? undefined : FALLBACK_TERM;
+}
+
+type TerminfoDecision = 'ok' | 'downgrade';
+
+function terminfoCacheDir(): string {
+  return path.join(getCacheDir(), 'devices', 'terminfo');
+}
+
+/** Filesystem-safe sentinel name for a (host, term) pair. */
+function cacheKey(host: string, term: string): string {
+  return `${host}__${term}`.replace(/[^A-Za-z0-9._+-]/g, '_');
+}
+
+/**
+ * The cached propagation decision for a (host, term), or null if we've never
+ * connected with this terminal to this host. Caching makes the propagation
+ * handshake a once-per-host+term cost; steady-state logins pay nothing.
+ */
+export function readTerminfoDecision(host: string, term: string, dir = terminfoCacheDir()): TerminfoDecision | null {
+  try {
+    const val = fs.readFileSync(path.join(dir, cacheKey(host, term)), 'utf-8').trim();
+    return val === 'ok' || val === 'downgrade' ? val : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the propagation decision for a (host, term). Best-effort. */
+export function writeTerminfoDecision(host: string, term: string, decision: TerminfoDecision, dir = terminfoCacheDir()): void {
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, cacheKey(host, term)), decision);
+  } catch {
+    /* best-effort — a missing cache just re-runs the (idempotent) handshake next time */
+  }
+}
+
+/**
+ * Try to install the local terminfo entry for `term` on `device`, reusing the
+ * device's exact auth/host-key posture via {@link buildSshInvocation}. Returns
+ * true only when the remote confirms the entry is now readable. Any failure
+ * (no local source, no remote `tic`, unreachable) returns false so the caller
+ * downgrades `$TERM` instead.
+ */
+export function propagateTerminfo(
+  device: DeviceProfile,
+  term: string,
+  askpassShimPath: string,
+  hostKey: SshHostKeyOptions = {},
+): boolean {
+  const source = localTerminfoSource(term);
+  if (!source) return false; // nothing to copy — the local box lacks this entry
+  const { args, env } = buildSshInvocation(device, [remoteTicCommand(term)], askpassShimPath, hostKey);
+  const res = spawnSync('ssh', args, {
+    input: source,
+    env: { ...process.env, ...env },
+    stdio: ['pipe', 'ignore', 'ignore'],
+    timeout: 20_000,
+    windowsHide: true,
+  });
+  return res.status === 0;
+}


### PR DESCRIPTION
## Problem

Launching an interactive `agents ssh <host>` from **Ghostty, kitty, or WezTerm** drops you into a broken remote session. These emulators ship their own terminfo entry and export an exotic `$TERM` (`xterm-ghostty`, `xterm-kitty`, `wezterm`, …). A plain `ssh -tt` forwards that `$TERM` to the remote via the pty request; if the remote's terminfo database has no matching entry, every ncurses program breaks.

Reproduced exactly (raw `ssh -tt`, identical to what `agents ssh` does on interactive login):

```
$ TERM=xterm-kitty ssh -tt yosemite-s0 '...'
REMOTE_TERM=xterm-kitty
'xterm-kitty': unknown terminal type.
tput: unknown terminal "xterm-kitty"
```

`clear`, `tput`, `vim`, `less`, `tmux`, and the shell line editor all fail. Breakage is per-host and unpredictable (a recent-ncurses box may have `xterm-ghostty` but not `xterm-kitty`), which is why it has to be handled at the wrapper.

## Fix

`agents ssh` now handles exotic terminals the way the emulators themselves do (Ghostty's `ssh-terminfo`/`ssh-env`, kitty's `kitten ssh`):

1. **Propagate** — on an interactive login to a POSIX device, copy the local terminfo entry to the remote (`infocmp -x` piped into `tic -x`, installed under the remote user's `~/.terminfo`). The remote then understands the real `$TERM` with full fidelity (extended capabilities intact). Self-verifying: the decision is `ok` only when the remote confirms the entry is readable.
2. **Fall back** — downgrade to a universally-present `xterm-256color` when propagation can't happen (the local box has no entry to copy, or the remote lacks `tic`/is Windows). A degraded-but-working session beats a broken one.

Universally-present terminals (`xterm-256color`, `screen`, `tmux`, `vt100`, `linux`, …) are left untouched — no round-trip. The per-`(host, terminal)` decision is cached so the propagation handshake is a once-per-host cost. `AGENTS_SSH_TERM=<value>` forces a specific remote `$TERM`; `AGENTS_SSH_TERM=keep` forwards the local one unchanged.

## Verification (end-to-end, real CLI)

**Downgrade** — `TERM=xterm-kitty` (missing locally + on remote) → real `agents ssh yosemite-s0`:
```
Terminal 'xterm-kitty' isn't installed on 'yosemite-s0' — using xterm-256color for this session.
MARKER_REMOTE_TERM=xterm-256color
MARKER_clear=OK
MARKER_tput=OK
```

**Propagation** — `TERM=xterm-ghostty` (present locally, MISSING on yosemite-m1) → real `agents ssh yosemite-m1`:
```
PRE=MISSING
MARKER_terminfo=PRESENT        # installed at ~/.terminfo/x/xterm-ghostty
MARKER_clear=OK
MARKER_REMOTE_TERM=xterm-ghostty   # real $TERM kept — full fidelity
cache decision: ok             # second login reuses cache, no round-trip
```

Non-interactive commands and safe `$TERM`s are untouched (no cache write, no override).

## Tests

- New `terminfo.test.ts` — `isManagedTerm` (incl. injection-shaped values), `resolveLoginTerm`, `remoteTicCommand`, `localTerminfoSource` (against the real local terminfo DB), and the decision-cache round-trip.
- `connect.test.ts` — new case: `term` override sets `env.TERM`, absent leaves it unset.
- `tsc --noEmit` clean; **134/134** devices-lib + ssh-exec tests green.

Session transcript (secret gist): yosemite-s1:/home/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-home-muqsit-src-github-com-muqsitnawaz/978673a2-1ace-4e39-944f-f5e8bb191a4d.jsonl