### PR TITLE
fix(view): accurate account tier + legible usage limits in `agents view`

### DIFF
--- a/apps/cli/.changelog/next/ag-view-status.md
+++ b/apps/cli/.changelog/next/ag-view-status.md
@@ -1,0 +1,9 @@
+- **Accurate account tier and legible usage limits in `agents view`.** Each row's plan
+  tier is now derived from `organizationType` (Max/Pro/Team/Enterprise) instead of a
+  billingType guess that mislabelled every Max account as "Pro", and the redundant tier
+  badge next to the email is dropped for personal plans (multi-seat orgs keep their org
+  name, which is real identity). The compact `S:`/`W:` usage bars now show the exact
+  percentage and a compact reset hint (`S: ███░░ 58% (3d)`), a signed-in account whose
+  usage can't be fetched reads `usage unavailable` instead of a blank gauge, and a new
+  `agents view --refresh` (`-r`) forces a live usage refresh past the cache. Source:
+  `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/usage.ts`, `apps/cli/src/commands/view.ts`.

--- a/apps/cli/src/commands/view.account.test.ts
+++ b/apps/cli/src/commands/view.account.test.ts
@@ -2,24 +2,24 @@ import { describe, expect, it } from 'vitest';
 import { accountColumnLabel, pruneGroupKey } from './view.js';
 
 describe('accountColumnLabel — organization suffix', () => {
-  it('appends the org badge for a Team seat', () => {
+  it('appends the org NAME (identity) for a Team seat — the tier shows in the plan column', () => {
     expect(accountColumnLabel({
       email: 'taylor@example.com',
       accountId: null,
       signedIn: true,
       organizationType: 'claude_team',
       organizationName: 'Turing Labs',
-    })).toBe('taylor@example.com (Turing Labs · Team)');
+    })).toBe('taylor@example.com (Turing Labs)');
   });
 
-  it('appends only the tier label for a personal Max plan', () => {
+  it('renders the bare email for a personal Max plan — no badge, tier is in the plan column', () => {
     expect(accountColumnLabel({
       email: 'taylor@example.com',
       accountId: null,
       signedIn: true,
       organizationType: 'claude_max',
       organizationName: "taylor@example.com's Organization",
-    })).toBe('taylor@example.com (Max)');
+    })).toBe('taylor@example.com');
   });
 
   it('renders the bare email when no organization type is present', () => {

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -29,6 +29,7 @@ import {
 import type { AccountInfo } from '../lib/agents.js';
 import type { AgentId } from '../lib/types.js';
 import {
+  agentReportsUsage,
   deriveUsageStatusFromSnapshot,
   formatUsageSection,
   formatUsageSummary,
@@ -328,7 +329,10 @@ function renderHostClisSection(cwd: string): void {
   }
 }
 
-async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
+async function showInstalledVersions(
+  filterAgentId?: AgentId,
+  viewOpts?: { forceRefresh?: boolean },
+): Promise<void> {
   const spinnerText = filterAgentId
     ? `Checking ${agentLabel(filterAgentId)} agents...`
     : 'Checking installed agents...';
@@ -419,7 +423,7 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
       cliVersion,
       info,
     })),
-  ]);
+  ], { forceRefresh: viewOpts?.forceRefresh });
 
   const mergeCanonical = (info: AccountInfo): AccountInfo => {
     const key = getUsageLookupKey(info);
@@ -512,7 +516,8 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
         const info = rawInfo ? mergeCanonical(rawInfo) : undefined;
         const usageKey = getUsageLookupKey(info);
         const usageInfo = usageKey ? usageByKey.get(usageKey) : undefined;
-        const usageStr = formatUsageSummary(info?.plan || null, usageInfo?.snapshot || null, maxPlanWidth);
+        const usageUnavailable = agentReportsUsage(agentId) && !!info?.signedIn && !usageInfo?.snapshot;
+        const usageStr = formatUsageSummary(info?.plan || null, usageInfo?.snapshot || null, maxPlanWidth, { unavailable: usageUnavailable });
         maxUsageWidth = Math.max(maxUsageWidth, visibleWidth(usageStr));
         const statusStr = formatUsageStatusBadge(info?.usageStatus);
         maxStatusWidth = Math.max(maxStatusWidth, visibleWidth(statusStr));
@@ -555,7 +560,8 @@ async function showInstalledVersions(filterAgentId?: AgentId): Promise<void> {
         const parts = [`    ${label}`];
         const hasEmail = !!vInfo?.email;
         const signedIn = !!vInfo?.signedIn;
-        const usageStr = formatUsageSummary(vInfo?.plan || null, usageInfo?.snapshot || null, maxPlanWidth);
+        const usageUnavailable = agentReportsUsage(agentId) && signedIn && !usageInfo?.snapshot;
+        const usageStr = formatUsageSummary(vInfo?.plan || null, usageInfo?.snapshot || null, maxPlanWidth, { unavailable: usageUnavailable });
         const hasUsage = usageStr.length > 0;
         // Only show lastActive for versions with an actual logged-in account.
         // Otherwise it reflects install time (misleading "just now" for fresh installs).
@@ -1696,6 +1702,7 @@ export async function viewAction(
     dryRun?: boolean;
     resources?: string | boolean;
     detailed?: boolean;
+    refresh?: boolean;
   } & ViewSectionFilter,
 ): Promise<void> {
   // --resources / --detailed imply --json (they only shape structured output).
@@ -1740,7 +1747,7 @@ export async function viewAction(
       return;
     }
     // No argument: show all installed versions
-    await showInstalledVersions();
+    await showInstalledVersions(undefined, { forceRefresh: options?.refresh === true });
     return;
   }
 
@@ -1802,7 +1809,7 @@ export async function viewAction(
     await showAgentResources(agentId, 'default', filter);
   } else {
     // Just agent name: show versions for that agent
-    await showInstalledVersions(agentId);
+    await showInstalledVersions(agentId, { forceRefresh: options?.refresh === true });
   }
 }
 
@@ -1813,6 +1820,7 @@ export function registerViewCommand(program: Command): void {
     .option('--json', 'Emit machine-readable JSON (version list, usage, signed-in status).')
     .option('--resources [sections]', 'In --json mode, include each version\'s resources: "all" (default) or a comma list (skills,plugins,mcp,commands,workflows,memory,hooks). Implies --json.')
     .option('--detailed', 'Include all resources in --json output (alias for --resources all). Implies --json.')
+    .option('-r, --refresh', 'Force a live usage refresh, bypassing the cache (slower). Repopulates the S:/W: limit bars for every account whose token is reachable.')
     .option('--prune', 'Remove older installed versions that share an account with a newer installed version. Skips the global default.')
     .option('--dry-run', 'With --prune, show duplicate versions without deleting')
     .option('-y, --yes', 'Skip the prune confirmation prompt.')
@@ -1880,6 +1888,7 @@ Output:
         dryRun?: boolean;
         resources?: string | boolean;
         detailed?: boolean;
+        refresh?: boolean;
       } & ViewSectionFilter,
     ) => viewAction(agentArg, options));
 }

--- a/apps/cli/src/lib/__tests__/usage.test.ts
+++ b/apps/cli/src/lib/__tests__/usage.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AccountInfo } from '../agents.js';
 import * as state from '../state.js';
 import {
+  agentReportsUsage,
   buildCanonicalUsageContext,
   deriveUsageStatusFromSnapshot,
   formatUsageSummary,
@@ -86,6 +87,62 @@ describe('usage formatting', () => {
     expect(summary).toContain('S:');
     expect(summary).toContain('W:');
     expect(summary).not.toContain('So:');
+  });
+
+  it('appends the exact percentage and a compact reset hint to each bar', () => {
+    const snapshot: UsageSnapshot = {
+      source: 'live',
+      sourceLabel: 'live account data',
+      capturedAt: new Date(),
+      windows: [
+        {
+          key: 'session',
+          label: 'Current session',
+          shortLabel: 'S',
+          usedPercent: 34,
+          resetsAt: new Date(Date.now() + 2 * 60 * 60 * 1000), // 2h out
+          windowMinutes: 300,
+        },
+        {
+          key: 'week',
+          label: 'Current week',
+          shortLabel: 'W',
+          usedPercent: 58,
+          resetsAt: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000), // 3d out
+          windowMinutes: 10080,
+        },
+      ],
+    };
+    const summary = stripAnsi(formatUsageSummary(null, snapshot));
+    expect(summary).toContain('S:');
+    expect(summary).toContain('34% (2h)');
+    expect(summary).toContain('58% (3d)');
+  });
+
+  it('shows "usage unavailable" only when the opt is set and there is no snapshot', () => {
+    // A signed-in account we could not fetch: explicit label, not a fake-empty bar.
+    expect(stripAnsi(formatUsageSummary('Max', null, 3, { unavailable: true })))
+      .toContain('usage unavailable');
+    // Without the opt, a null snapshot renders just the plan (legacy behaviour).
+    expect(stripAnsi(formatUsageSummary('Max', null, 3))).not.toContain('usage unavailable');
+    // A real snapshot never shows the placeholder even if the opt is set.
+    const snapshot: UsageSnapshot = {
+      source: 'live',
+      sourceLabel: 'live account data',
+      capturedAt: new Date(),
+      windows: [{ key: 'session', label: 'S', shortLabel: 'S', usedPercent: 0, resetsAt: null, windowMinutes: 300 }],
+    };
+    expect(stripAnsi(formatUsageSummary('Max', snapshot, 3, { unavailable: true })))
+      .not.toContain('usage unavailable');
+  });
+
+  it('agentReportsUsage flags only the agents that expose usage data', () => {
+    for (const a of ['claude', 'codex', 'kimi', 'droid'] as const) {
+      expect(agentReportsUsage(a)).toBe(true);
+    }
+    for (const a of ['antigravity', 'grok', 'opencode', 'gemini'] as const) {
+      expect(agentReportsUsage(a)).toBe(false);
+    }
   });
 
   it('formatUsageStatusBadge renders only for throttled states', () => {

--- a/apps/cli/src/lib/agents.test.ts
+++ b/apps/cli/src/lib/agents.test.ts
@@ -848,7 +848,9 @@ describe('getAccountInfo — Claude organization identity', () => {
     const info = await getAccountInfo('claude', home);
     expect(info.organizationType).toBe('claude_team');
     expect(info.organizationName).toBe('Turing Labs');
-    expect(info.plan).toBe('Pro');
+    // Plan tier is derived from organizationType, so a Team seat reads "Team" —
+    // not the billingType-derived "Pro" that mislabelled every subscription.
+    expect(info.plan).toBe('Team');
   });
 
   it('extracts organizationType from a personal Max plan, keeping the raw boilerplate name', async () => {
@@ -863,6 +865,8 @@ describe('getAccountInfo — Claude organization identity', () => {
     });
     const info = await getAccountInfo('claude', home);
     expect(info.organizationType).toBe('claude_max');
+    // The whole point of the fix: a Max account reads "Max", not "Pro".
+    expect(info.plan).toBe('Max');
     // Raw value: display layers decide whether the boilerplate name is shown.
     expect(info.organizationName).toBe("taylor@example.com's Organization");
   });
@@ -921,20 +925,28 @@ describe('formatClaudeOrgLabel', () => {
 });
 
 describe('accountOrgBadge', () => {
-  it('shows the org name only for multi-seat org types', () => {
+  it('shows just the org NAME for multi-seat org types', () => {
+    // The tier label (Team/Enterprise) now lives in the plan column, so the badge
+    // carries only the org name — the identity that disambiguates a Team seat.
     expect(accountOrgBadge({ organizationType: 'claude_team', organizationName: 'Turing Labs' }))
-      .toBe('Turing Labs · Team');
+      .toBe('Turing Labs');
     expect(accountOrgBadge({ organizationType: 'claude_enterprise', organizationName: 'BigCo' }))
-      .toBe('BigCo · Enterprise');
-    // Personal orgs carry auto-generated boilerplate names — label only.
+      .toBe('BigCo');
+  });
+
+  it('returns null for personal plans — the tier shows in the plan column instead', () => {
+    // Personal orgs carry auto-generated boilerplate names, and the tier already
+    // renders in the aligned column, so no badge (avoids the duplicate "(Max) … Max").
     expect(accountOrgBadge({
       organizationType: 'claude_max',
       organizationName: "taylor@example.com's Organization",
-    })).toBe('Max');
+    })).toBeNull();
+    expect(accountOrgBadge({ organizationType: 'claude_pro', organizationName: 'x' })).toBeNull();
+    expect(accountOrgBadge({ organizationType: 'claude_free', organizationName: 'x' })).toBeNull();
   });
 
-  it('falls back to the label when a team org has no name', () => {
-    expect(accountOrgBadge({ organizationType: 'claude_team', organizationName: null })).toBe('Team');
+  it('returns null when a multi-seat org has no name to show', () => {
+    expect(accountOrgBadge({ organizationType: 'claude_team', organizationName: null })).toBeNull();
   });
 
   it('returns null when there is no organization type', () => {

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -1054,21 +1054,21 @@ export function formatClaudeOrgLabel(orgType: string | null | undefined): string
 }
 
 /**
- * Short badge identifying which org an account belongs to: "Turing Labs · Team"
- * for multi-seat orgs, just the tier label ("Max") for personal plans — a
- * personal org's name is auto-generated boilerplate ("<email>'s Organization"),
- * not identity. Returns null when the account carries no organizationType
- * (signed out, non-Claude agents, configs predating the field).
+ * Short badge identifying which ORG an account belongs to — "Turing Labs" for a
+ * multi-seat Team/Enterprise org, whose name is real identity that disambiguates
+ * a Team seat from a same-email personal plan. Returns null for personal plans
+ * (Max/Pro/Free): the tier label now lives in the aligned plan column, so a badge
+ * would only duplicate it, and a personal org's name is auto-generated boilerplate
+ * ("<email>'s Organization"), not identity. Also null when the account carries no
+ * organizationType (signed out, non-Claude agents, configs predating the field).
  */
 export function accountOrgBadge(
   info?: Pick<AccountInfo, 'organizationType' | 'organizationName'> | null
 ): string | null {
-  const label = formatClaudeOrgLabel(info?.organizationType);
-  if (!label) return null;
   const isMultiSeat =
     info?.organizationType === 'claude_team' || info?.organizationType === 'claude_enterprise';
-  if (isMultiSeat && info?.organizationName) return `${info.organizationName} · ${label}`;
-  return label;
+  if (isMultiSeat && info?.organizationName) return info.organizationName;
+  return null;
 }
 
 /** Return the email address associated with the agent's auth config, or null. */
@@ -1414,18 +1414,22 @@ export async function getAccountInfo(
         ]);
         const usageKey = buildIdentityKey(agentId, [['org', organizationId]]);
 
-        // Plan is derived from .claude.json's billingType only. Reading
-        // subscriptionType from the keychain item ("Claude Code-credentials-<hash>")
-        // forces a macOS Keychain ACL prompt on every `agents run` (one prompt per
-        // installed version under balanced rotation) because Claude Code writes its
-        // credentials with its own process in the ACL — our helper isn't trusted by
-        // that item. Callers that genuinely need subscriptionType (e.g. detailed
-        // `agents view`) should call loadClaudeOauth() directly.
-        let plan: string | null = null;
-        if (oa?.billingType === 'stripe_subscription') {
-          plan = 'Pro';
-        } else if (oa?.billingType) {
-          plan = oa.billingType;
+        // Plan tier is derived from .claude.json's organizationType, which carries
+        // the TRUE tier (claude_max → "Max", claude_pro → "Pro", claude_team →
+        // "Team") and is already in-hand from the config we just read — no Keychain
+        // prompt. billingType only distinguishes "has a Stripe subscription" and so
+        // mislabels every Max account as "Pro"; keep it as a fallback for older
+        // configs predating organizationType. (Reading subscriptionType from the
+        // keychain item would force a macOS Keychain ACL prompt on every `agents
+        // run`, so we deliberately avoid it — organizationType gives us the tier
+        // without that cost.)
+        let plan: string | null = formatClaudeOrgLabel(oa?.organizationType);
+        if (!plan) {
+          if (oa?.billingType === 'stripe_subscription') {
+            plan = 'Pro';
+          } else if (oa?.billingType) {
+            plan = oa.billingType;
+          }
         }
 
         // usageStatus is NOT derived from cachedExtraUsageDisabledReason. That

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -239,8 +239,22 @@ export function buildCanonicalUsageContext(inputs: UsageIdentityInput[]): {
   return { canonicalByUsageKey, usageFetchInputs };
 }
 
+/**
+ * Whether an agent exposes usage/limit data we can render — Claude/Kimi/Droid via
+ * a live API, Codex via local session logs. Everything else has no usage concept,
+ * so callers use this to decide whether a missing snapshot is worth flagging as
+ * "usage unavailable" (a signed-in Claude account with no data) versus simply not
+ * applicable (Antigravity, Grok, OpenCode).
+ */
+export function agentReportsUsage(agentId: AgentId): boolean {
+  return agentId === 'claude' || agentId === 'codex' || agentId === 'kimi' || agentId === 'droid';
+}
+
 /** Fetch usage info for all unique accounts in parallel, keyed by usage key. */
-export async function getUsageInfoByIdentity(inputs: UsageIdentityInput[]): Promise<{
+export async function getUsageInfoByIdentity(
+  inputs: UsageIdentityInput[],
+  opts?: { forceRefresh?: boolean }
+): Promise<{
   canonicalByUsageKey: Map<string, AccountInfo>;
   usageByKey: Map<string, UsageInfo>;
 }> {
@@ -253,7 +267,7 @@ export async function getUsageInfoByIdentity(inputs: UsageIdentityInput[]): Prom
         home: input.home,
         cliVersion: input.cliVersion,
         info: canonicalByUsageKey.get(key)!,
-      }),
+      }, opts),
     }))
   );
 
@@ -281,8 +295,12 @@ const inFlightRefreshes = new Map<string, Promise<void>>();
  * cache; every run after that returns instantly while the cache silently
  * refreshes in the background.
  */
-export async function getUsageInfoForIdentity(input: UsageIdentityInput): Promise<UsageInfo> {
+export async function getUsageInfoForIdentity(
+  input: UsageIdentityInput,
+  opts?: { forceRefresh?: boolean }
+): Promise<UsageInfo> {
   const usageKey = getUsageLookupKey(input.info);
+  const forceRefresh = opts?.forceRefresh === true;
 
   // Agents whose usage comes from a live network call (Claude, Kimi, Droid) go
   // through the stale-while-revalidate cache below so `agents run`/`agents view`
@@ -304,16 +322,21 @@ export async function getUsageInfoForIdentity(input: UsageIdentityInput): Promis
   const cached = readClaudeUsageCache(usageKey);
   const ageMs = cached?.capturedAt ? Date.now() - cached.capturedAt.getTime() : Infinity;
 
-  // Fresh: cache is recent enough, skip network entirely.
-  if (cached && ageMs < USAGE_CACHE_FRESH_MS) {
-    return { snapshot: cached, error: null };
-  }
+  // `--refresh` (forceRefresh) skips both cache short-circuits and blocks on a
+  // live fetch below, so `agents view --refresh` repopulates every account we can
+  // actually reach a token for.
+  if (!forceRefresh) {
+    // Fresh: cache is recent enough, skip network entirely.
+    if (cached && ageMs < USAGE_CACHE_FRESH_MS) {
+      return { snapshot: cached, error: null };
+    }
 
-  // Stale-while-revalidate: cache exists and isn't ancient, return it now and
-  // refresh in the background so the next invocation has fresh data.
-  if (cached && ageMs < USAGE_CACHE_SWR_MS) {
-    triggerBackgroundUsageRefresh(input, usageKey);
-    return { snapshot: cached, error: null };
+    // Stale-while-revalidate: cache exists and isn't ancient, return it now and
+    // refresh in the background so the next invocation has fresh data.
+    if (cached && ageMs < USAGE_CACHE_SWR_MS) {
+      triggerBackgroundUsageRefresh(input, usageKey);
+      return { snapshot: cached, error: null };
+    }
   }
 
   // Cold cache or > 24h old: block on live fetch.
@@ -373,7 +396,8 @@ function triggerBackgroundUsageRefresh(input: UsageIdentityInput, usageKey: stri
 export function formatUsageSummary(
   plan: string | null,
   snapshot: UsageSnapshot | null,
-  planWidth = 3
+  planWidth = 3,
+  opts?: { unavailable?: boolean }
 ): string {
   const parts: string[] = [];
 
@@ -387,15 +411,24 @@ export function formatUsageSummary(
     // account throttled by its month window (Droid meters on 5h/week/month)
     // shows the bar that explains why. Claude's Sonnet week is a per-model
     // sub-limit, not a blocking window; it renders only in the full
-    // per-version usage section.
+    // per-version usage section. Each window reads "S: ███░░ 58% (3d)" — the
+    // gauge, the exact percentage, and a compact hint of when it resets.
     const windows = snapshot.windows
       .filter((window) => window.key !== 'sonnet_week')
-      .map((window) =>
-      `${chalk.gray(`${window.shortLabel}:`)} ${renderCompactUsageBar(window.usedPercent)}`
-    );
+      .map((window) => {
+        const bar = renderCompactUsageBar(window.usedPercent);
+        const pct = colorUsage(`${Math.round(window.usedPercent)}%`, window.usedPercent);
+        const reset = window.resetsAt ? chalk.dim(` (${formatResetHint(window.resetsAt)})`) : '';
+        return `${chalk.gray(`${window.shortLabel}:`)} ${bar} ${pct}${reset}`;
+      });
     if (windows.length > 0) {
-      parts.push(windows.join(' '));
+      parts.push(windows.join('  '));
     }
+  } else if (opts?.unavailable) {
+    // Signed-in account we could NOT fetch usage for (no live token in a reachable
+    // home / org mismatch / fetch error). Say so explicitly instead of drawing a
+    // blank gauge that reads like "0% used".
+    parts.push(chalk.dim('usage unavailable'));
   }
 
   return parts.join('  ');
@@ -1433,6 +1466,23 @@ function getUsageColor(usedPercent: number): (text: string) => string {
 function formatPercent(value: number): string {
   const rounded = Math.round(value * 10) / 10;
   return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}
+
+/**
+ * Compact "time until reset" hint for the inline usage bars: "5m", "2h", "3d",
+ * or "now" once elapsed. Deliberately coarse (single unit, whole numbers) so it
+ * fits after a bar without wrapping the row — the detailed section
+ * (`formatResetAt`) carries the precise clock time.
+ */
+function formatResetHint(date: Date): string {
+  const diffMs = date.getTime() - Date.now();
+  if (diffMs <= 0) return 'now';
+  const mins = Math.round(diffMs / 60000);
+  if (mins < 60) return `${Math.max(1, mins)}m`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.round(hours / 24);
+  return `${days}d`;
 }
 
 /** Format a reset timestamp as a human-readable relative or absolute time. */


### PR DESCRIPTION
## Problem

The `agents view` "Installed Agent CLIs" screen rendered the account/limits/status block poorly:

1. **Tier shown twice, one copy wrong.** Each Claude row showed an accurate `(Max)` badge next to the email **and** a hardcoded `Pro` column. `plan` was derived from `billingType === 'stripe_subscription'`, which is true for both Pro *and* Max — so every Max account mislabelled as "Pro".
2. **Limit bars carried no numbers.** The `S:`/`W:` bars were a bare 5-cell gauge — no percentage, no reset time.
3. **Blank bars were ambiguous.** A signed-in account with no usage snapshot drew an empty gauge that reads like "0% used".

## Changes

- **Accurate tier from `organizationType`** (`Max`/`Pro`/`Team`/`Enterprise`) — already read from `.claude.json`, so no Keychain prompt. `billingType` stays a fallback for older configs. Fixes the wrong "Pro" everywhere `plan` is shown (view, versions picker, `--json`).
- **`accountOrgBadge` deduped** — returns just the org **name** for multi-seat orgs (real identity that disambiguates a Team seat) and **nothing** for personal plans, since the tier now lives in the aligned column.
- **Legible bars** — `S: ███░░ 58% (3d)`: gauge + exact percent + a compact reset hint (`formatResetHint`).
- **Honest empty state** — a signed-in, usage-capable account with no snapshot renders `usage unavailable` instead of a blank gauge. A new `agentReportsUsage` predicate gates this so non-usage agents (Grok, Antigravity, OpenCode) stay clean.
- **`agents view --refresh` (`-r`)** — bypasses the stale-while-revalidate cache and blocks on a live fetch to repopulate every reachable account.

## Before / after (emails redacted)

```
BEFORE
  2.1.207 (default)  user@example.com (Max)   Pro   S:█░░░░ W:██░░░   6m ago
  2.1.186            user2@example.com (Max)  Pro   S:     W:          5m ago   ← blank, no numbers

AFTER
  2.1.207 (default)  user@example.com    Max   S: █░░░░ 2% (4h)   W: █░░░░ 21% (2d)   11m ago
  2.1.186            user2@example.com   Max   S: █░░░░ 16% (2h)  W: █░░░░ 9% (6d)    25m ago
```

Verified end-to-end against real accounts: `node dist/index.js view` shows `Max` (not `Pro`) with `NN% (reset)` on every bar; `--refresh` triggers a live re-fetch (session values update); `--json` reports `plan:"Max"`. Codex/Kimi/Droid keep their tiers and gain `%`+reset; Grok/Antigravity show no spurious "usage unavailable".

## Tests

`bun test` for the three affected files is green (98 passing): updated `accountOrgBadge` / `accountColumnLabel` / `getAccountInfo` tier assertions to the new behavior; added coverage for the percent + reset hint, the `usage unavailable` placeholder, and `agentReportsUsage`. `tsc --noEmit` clean.

Changelog: `apps/cli/.changelog/next/ag-view-status.md`.

Session transcript (public repo — not attached): `yosemite-s1:/home/muqsit/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-home-muqsit-src-github-com-muqsitnawaz/5c4e2980-83f7-460d-a617-bfb5a8254433.jsonl`
