### PR TITLE
feat(versions): isolated installs that never touch the local agent config

### DIFF
--- a/apps/cli/docs/01-version-management.md
+++ b/apps/cli/docs/01-version-management.md
@@ -151,6 +151,53 @@ Key behaviors:
 - Subsequent switches just update the symlink target (no new backups)
 - Each version has isolated auth in its `home/` directory
 
+## Isolated Installs
+
+`agents add <agent>@<version> --isolated` installs a fully self-contained copy
+that never touches the user's existing setup. It is the escape hatch for "give me
+a clean, separate <agent> without disturbing my current one."
+
+An isolated install deliberately SKIPS every adopting side effect of a normal
+install:
+
+- No global default is set or offered (`setGlobalDefault()` is never called).
+- No bare `<agent>` shim is created, so nothing on `PATH` is shadowed.
+- The real `~/.<agent>` is never backed up or replaced with a symlink
+  (`switchConfigSymlink()` is never called).
+- No settings carry-over and no resource sync — the copy starts pristine, with
+  its own `home/` config and its own login.
+
+What it DOES create is just enough to launch the copy explicitly:
+
+```
+agents add claude@2.1.112 --isolated
+           │
+           ▼
+  installVersion()                 # same npm install into versions/claude/2.1.112/
+  createVersionedAlias()           # ~/.agents-system/shims/claude@2.1.112
+  markVersionIsolated()            # writes versions/claude/2.1.112/.isolated
+```
+
+Run it with an explicit version selector (PATH-independent):
+
+```
+agents run claude@2.1.112 "your prompt"
+```
+
+The `.isolated` sentinel lives at the version-dir root, so it travels to trash on
+removal and is restored intact. Two consequences follow from the marker:
+
+- `removeVersion()` never auto-promotes an isolated version to the global
+  default; if the only survivors are isolated, it clears the default instead.
+- `agents remove <agent>@<version> --isolated` refuses to remove anything that is
+  NOT an isolated install, and its picker only lists isolated versions — so a
+  normal/default install (and the real `~/.<agent>`) can never be removed by
+  accident. Removal is still a soft-delete to trash, recoverable via
+  `agents trash restore`.
+
+`--isolated` cannot be combined with `--project` (an isolated copy is
+global-but-separate; a project pin selects a shared install for one directory).
+
 ## Resource Syncing
 
 `syncResourcesToVersion()` links central `~/.agents/` resources into version homes:

--- a/apps/cli/src/commands/versions.ts
+++ b/apps/cli/src/commands/versions.ts
@@ -751,8 +751,11 @@ export function registerVersionsCommands(program: Command): void {
         let selectedVersion = version;
 
         if (!version) {
-          // Interactive version picker
-          const versions = listInstalledVersions(agentId);
+          // Interactive version picker. Isolated installs are walled off from the
+          // real ~/.<agent> on purpose, so they must never be selectable here —
+          // setting one as the default would repoint the real config at it. Filter
+          // them out (same as the `remove` picker), leaving only usable versions.
+          const versions = listInstalledVersions(agentId).filter((v) => !isVersionIsolated(agentId, v));
           if (versions.length === 0) {
             console.log(chalk.red(`No versions of ${agentLabel(agentConfig.id)} installed`));
             console.log(chalk.gray(`Run: agents add ${agentId}@latest`));
@@ -824,6 +827,20 @@ export function registerVersionsCommands(program: Command): void {
 
         // selectedVersion is guaranteed to be defined after the check above
         const finalVersion = selectedVersion;
+
+        // An isolated install is deliberately walled off from the real
+        // ~/.<agent>. `agents use` would repoint the real config symlink at it
+        // (switchConfigSymlink) and carry settings forward INTO it
+        // (carryForwardSettings) — a direct breach of the isolation guarantee.
+        // Refuse for both the explicit `use <agent>@<isolated>` path (the picker
+        // above already filters isolated versions out of the interactive path).
+        // Isolated copies are launched explicitly via `agents run <agent>@<v>`.
+        if (isVersionIsolated(agentId, finalVersion)) {
+          console.log(chalk.red(`${agentLabel(agentConfig.id)}@${finalVersion} is an isolated install and can't be set as your active version.`));
+          console.log(chalk.gray(`Isolated copies stay walled off from your real ${agentConfig.configDir}. Run it directly: agents run ${agentId}@${finalVersion}`));
+          console.log(chalk.gray(`To install this version normally: agents add ${agentId}@${finalVersion}`));
+          return;
+        }
 
         if (options.project) {
           // Set in project manifest

--- a/apps/cli/src/commands/versions.ts
+++ b/apps/cli/src/commands/versions.ts
@@ -66,6 +66,8 @@ import { carryForwardSettings } from '../lib/settings-manifest.js';
 import {
   createShim,
   createVersionedAlias,
+  supportsIsolatedInstall,
+  CONFIG_ENV_ISOLATED_AGENTS,
   removeShim,
   shimExists,
   getShimsDir,
@@ -208,6 +210,13 @@ async function versionPruneAction(
 
     const { agent, version } = parsed;
     const agentConfig = AGENTS[agent];
+
+    // --isolated only ever applies to agents that can BE installed isolated;
+    // for the rest no isolated version can exist, so say so plainly.
+    if (isIsolated && !supportsIsolatedInstall(agent)) {
+      console.log(chalk.gray(`${agentLabel(agentConfig.id)} has no isolated installs (--isolated is not supported for it).`));
+      continue;
+    }
 
     // Script-installed agents (droid, grok) can have a *literal* `latest`
     // version dir on disk when the post-install version probe failed. An
@@ -426,6 +435,17 @@ export function registerVersionsCommands(program: Command): void {
         const agentConfig = AGENTS[agent];
 
         warnAgentDeprecated(agent);
+
+        // Isolation relies on a config-dir env var to redirect the copy away
+        // from the user's real ~/.<agent>. Agents without one isolate only by
+        // adopting ~/.<agent> (which --isolated skips), so an isolated copy
+        // would silently read/write the real config. Refuse rather than lie.
+        if (isIsolated && !supportsIsolatedInstall(agent)) {
+          console.log(chalk.red(`${agentLabel(agentConfig.id)} does not support --isolated installs.`));
+          console.log(chalk.gray(`  It has no config-directory env var, so it can only isolate by adopting ${agentConfig.configDir} — which --isolated deliberately avoids.`));
+          console.log(chalk.gray(`  Supported with --isolated: ${CONFIG_ENV_ISOLATED_AGENTS.join(', ')}.`));
+          continue;
+        }
 
         if (!agentConfig.npmPackage && !agentConfig.installScript) {
           console.log(chalk.yellow(`${agentLabel(agentConfig.id)} has no npm package. Install manually.`));

--- a/apps/cli/src/commands/versions.ts
+++ b/apps/cli/src/commands/versions.ts
@@ -45,6 +45,8 @@ import {
   isOldestInstalled,
   getGlobalDefault,
   setGlobalDefault,
+  markVersionIsolated,
+  isVersionIsolated,
   getVersionHomePath,
   getVersionDir,
   syncResourcesToVersion,
@@ -161,14 +163,39 @@ function warnIfShimShadowed(agent: AgentId): void {
   console.log(chalk.gray(`  ${result.reloadHint}`));
 }
 
+/**
+ * Install an isolated copy of an agent version: a fully self-contained install
+ * that never touches the user's existing setup.
+ *
+ * Unlike a normal install it does NOT set (or offer to set) the global default,
+ * does NOT create/replace the bare `<agent>` shim, does NOT back up or symlink
+ * the user's real `~/.<agent>`, and does NOT carry over settings or resources.
+ * It only creates the versioned alias (so the copy is launchable) and records
+ * the isolated marker. Invoke the copy explicitly with `agents run <agent>@<v>`.
+ */
+function finalizeIsolatedInstall(agent: AgentId, version: string): void {
+  const agentConfig = AGENTS[agent];
+  const label = agentLabel(agentConfig.id);
+
+  createVersionedAlias(agent, version);
+  markVersionIsolated(agent, version);
+
+  console.log(chalk.green(`  Installed ${label}@${version} as an isolated copy.`));
+  console.log(chalk.gray(`  Your existing ${agentConfig.configDir} and default ${label} are untouched.`));
+  console.log(chalk.gray(`  Run it:     agents run ${agent}@${version} "your prompt"`));
+  console.log(chalk.gray(`  It has its own config and login — sign in the first time you run it.`));
+  console.log(chalk.gray(`  Remove it:  agents remove ${agent}@${version} --isolated`));
+}
+
 type VersionPruneVerb = 'prune' | 'remove';
 
 async function versionPruneAction(
   specs: string[],
-  options: { project?: boolean },
+  options: { project?: boolean; isolated?: boolean },
   commandName: VersionPruneVerb,
 ): Promise<void> {
   const isProject = options.project;
+  const isIsolated = options.isolated;
   const moved: Array<{ agent: AgentId; version: string }> = [];
 
   for (const spec of specs) {
@@ -191,9 +218,14 @@ async function versionPruneAction(
       version === 'latest' && spec.includes('@') && isVersionInstalled(agent, 'latest');
 
     if (!isLiteralLatestInstalled && (version === 'latest' || version === 'oldest' || !spec.includes('@'))) {
-      const versions = listInstalledVersions(agent);
+      // With --isolated, only isolated installs are eligible for the picker, so
+      // a normal/default install can never be selected here by accident.
+      const versions = listInstalledVersions(agent)
+        .filter((v) => !isIsolated || isVersionIsolated(agent, v));
       if (versions.length === 0) {
-        console.log(chalk.gray(`No versions of ${agentLabel(agentConfig.id)} installed`));
+        console.log(chalk.gray(isIsolated
+          ? `No isolated ${agentLabel(agentConfig.id)} installs`
+          : `No versions of ${agentLabel(agentConfig.id)} installed`));
         continue;
       }
 
@@ -235,6 +267,9 @@ async function versionPruneAction(
           }
           fixSessionFilePaths(agent, v, versionDir);
           console.log(chalk.green(`Moved ${agentLabel(agentConfig.id)}@${v} to trash`));
+          if (isIsolated) {
+            console.log(chalk.gray(`  Your real ${agentConfig.configDir} and default ${agentLabel(agentConfig.id)} were untouched.`));
+          }
           moved.push({ agent, version: v });
         }
 
@@ -254,6 +289,12 @@ async function versionPruneAction(
       }
     } else if (!isVersionInstalled(agent, version)) {
       console.log(chalk.gray(`${agentLabel(agentConfig.id)}@${version} not installed`));
+    } else if (isIsolated && !isVersionIsolated(agent, version)) {
+      // Safety guard: `--isolated` refuses to remove a normal/default install,
+      // so an accidental `remove <agent>@<default> --isolated` can never delete
+      // the user's primary version or disturb their real ~/.<agent>.
+      console.log(chalk.yellow(`${agentLabel(agentConfig.id)}@${version} is not an isolated install; refusing to remove it under --isolated.`));
+      console.log(chalk.gray(`  Drop --isolated to remove a normal version: agents ${commandName} ${agent}@${version}`));
     } else {
       const versionDir = getVersionDir(agent, version);
       const removed = removeVersion(agent, version);
@@ -263,6 +304,9 @@ async function versionPruneAction(
       }
       fixSessionFilePaths(agent, version, versionDir);
       console.log(chalk.green(`Moved ${agentLabel(agentConfig.id)}@${version} to trash`));
+      if (isIsolated) {
+        console.log(chalk.gray(`  Your real ${agentConfig.configDir} and default ${agentLabel(agentConfig.id)} were untouched.`));
+      }
       moved.push({ agent, version });
 
       const remaining = listInstalledVersions(agent);
@@ -293,7 +337,8 @@ function configureVersionPruneCommand(cmd: Command, commandName: VersionPruneVer
     .description(isAlias
       ? 'Alias for agents prune. Uninstalls agent CLI versions.'
       : 'Uninstall agent CLI versions. Moves version data to trash for recovery.')
-    .option('-p, --project', 'Also clear the pinned version from .agents/agents.yaml in the current project');
+    .option('-p, --project', 'Also clear the pinned version from .agents/agents.yaml in the current project')
+    .option('--isolated', 'Only act on isolated installs (created with `agents add --isolated`). Refuses to remove a normal/default install and never touches your real ~/.<agent>.');
 
   setHelpSections(cmd, {
     examples: `
@@ -305,11 +350,15 @@ function configureVersionPruneCommand(cmd: Command, commandName: VersionPruneVer
 
       # Prune and also clear the project pin
       agents ${commandName} claude@2.0.50 --project
+
+      # Cleanly remove an isolated copy, leaving your normal install alone
+      agents ${commandName} claude@2.1.112 --isolated
     `,
     notes: `
       - Pruned version directories move to trash with their home/ data intact.
       - Session file paths are rewritten so session history remains readable.
       - Removing the default version unsets the default; run 'agents use' to pick a new one.
+      - --isolated restricts the operation to isolated installs and refuses to remove a normal/default version, so your existing setup is never disturbed.
       - Reinstall any time with 'agents add'.
     `,
   });
@@ -323,6 +372,7 @@ export function registerVersionsCommands(program: Command): void {
     .command('add <specs...>')
     .description('Download and install agent CLI versions. Enables subsidized API usage through managed binaries.')
     .option('-p, --project', 'Lock this version to the current project directory only, stored in project-root agents.yaml')
+    .option('--isolated', 'Install a fully self-contained copy that never touches your existing ~/.<agent> or default. Launch it explicitly with `agents run <agent>@<version>`. Cannot be combined with --project.')
     .option('-y, --yes', 'Auto-accept defaults without prompting (useful for scripts and CI)');
 
   setHelpSections(addCmd, {
@@ -341,17 +391,28 @@ export function registerVersionsCommands(program: Command): void {
 
       # Lock a version to this project only (won't affect global default)
       agents add claude@2.1.100 --project
+
+      # Install a clean, separate copy that leaves your existing setup alone
+      agents add claude@2.1.112 --isolated
     `,
     notes: `
       - The first version you install becomes the default automatically.
       - 'add' does NOT change the default if a default already exists. Use 'agents use' to switch.
       - Multi-account: each installed version has separate auth, so you can install the same agent twice for two accounts.
+      - --isolated installs a self-contained copy: it never sets the default, never creates the bare '<agent>' shim, and never backs up or symlinks your real ~/.<agent>. Run it with 'agents run <agent>@<version>' and remove it with 'agents remove <agent>@<version> --isolated'. Mutually exclusive with --project.
     `,
   });
 
   addCmd.action(async (specs: string[], options) => {
       const isProject = options.project;
+      const isIsolated = options.isolated;
       const skipPrompts = options.yes || !isInteractiveTerminal();
+
+      if (isIsolated && isProject) {
+        console.log(chalk.red('--isolated and --project cannot be combined.'));
+        console.log(chalk.gray('An isolated copy is global-but-separate; a project pin selects a shared install for one directory.'));
+        return;
+      }
 
       for (const spec of specs) {
         const parsed = parseAgentSpec(spec);
@@ -391,6 +452,19 @@ export function registerVersionsCommands(program: Command): void {
         }
 
         if (alreadyInstalled) {
+          if (isIsolated) {
+            if (!isVersionIsolated(agent, installedAsVersion)) {
+              // A normal and an isolated install of the SAME version share one
+              // on-disk dir, so they can't coexist. Refuse rather than silently
+              // convert the user's existing (possibly default) install.
+              console.log(chalk.yellow(`${agentLabel(agentConfig.id)}@${installedAsVersion} is already installed as a normal (default-eligible) version.`));
+              console.log(chalk.gray(`  Remove it first (agents remove ${agent}@${installedAsVersion}) then re-add with --isolated, or pick a different version.`));
+              continue;
+            }
+            // Already isolated: re-affirm the alias + marker idempotently.
+            finalizeIsolatedInstall(agent, installedAsVersion);
+            continue;
+          }
           console.log(chalk.gray(`${agentLabel(agentConfig.id)}@${installedAsVersion} already installed`));
 
           // Ensure shim exists (in case it was deleted or needs updating)
@@ -405,16 +479,25 @@ export function registerVersionsCommands(program: Command): void {
           if (result.success) {
             spinner.succeed(`Installed ${agentLabel(agentConfig.id)}@${result.installedVersion}`);
 
+            const installedVersion = result.installedVersion || version;
+            // Track the concrete version so a `--project` pin records it instead
+            // of the `latest`/`oldest` alias.
+            installedAsVersion = installedVersion;
+
+            // Isolated installs stop here: no bare shim, no settings carry-over,
+            // no resource sync, no default switch, no PATH edits. Just a
+            // launchable versioned alias + the isolated marker, leaving the
+            // user's real ~/.<agent> and default untouched.
+            if (isIsolated) {
+              finalizeIsolatedInstall(agent, installedVersion);
+              continue;
+            }
+
             // Create shim if first install
             if (!shimExists(agent)) {
               createShim(agent);
               console.log(chalk.gray(`  Created shim: ${getShimsDir()}/${agentConfig.cliCommand}`));
             }
-
-            const installedVersion = result.installedVersion || version;
-            // Track the concrete version so a `--project` pin records it instead
-            // of the `latest`/`oldest` alias.
-            installedAsVersion = installedVersion;
 
             // Seed the fresh version home with user settings from the current
             // default version (settings.json, keybindings, codex config/auth).

--- a/apps/cli/src/lib/__tests__/shims.isolation-capability.test.ts
+++ b/apps/cli/src/lib/__tests__/shims.isolation-capability.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  CONFIG_ENV_ISOLATED_AGENTS,
+  supportsIsolatedInstall,
+  generateVersionedAliasScript,
+} from '../shims.js';
+import { ALL_AGENT_IDS } from '../agents.js';
+import type { AgentId } from '../types.js';
+
+// The env var each isolation-capable agent's versioned alias must export to
+// redirect the copy's config away from the user's real ~/.<agent>. This is the
+// contract that makes `agents add --isolated` safe for these agents.
+const CONFIG_ENV_BY_AGENT: Record<(typeof CONFIG_ENV_ISOLATED_AGENTS)[number], string> = {
+  claude: 'CLAUDE_CONFIG_DIR',
+  codex: 'CODEX_HOME',
+  copilot: 'COPILOT_HOME',
+  grok: 'GROK_HOME',
+  kimi: 'KIMI_CODE_HOME',
+};
+const ALL_CONFIG_ENVS = Object.values(CONFIG_ENV_BY_AGENT);
+
+// A version string that passes assertSafeVersion.
+const V = '1.0.0';
+
+describe('isolated-install capability', () => {
+  it('supportsIsolatedInstall matches the CONFIG_ENV_ISOLATED_AGENTS set', () => {
+    for (const agent of ALL_AGENT_IDS) {
+      expect(supportsIsolatedInstall(agent)).toBe(CONFIG_ENV_ISOLATED_AGENTS.includes(agent));
+    }
+  });
+
+  it('every isolation-capable agent exports its config-dir env var in the versioned alias', () => {
+    for (const agent of CONFIG_ENV_ISOLATED_AGENTS) {
+      const script = generateVersionedAliasScript(agent, V);
+      expect(script).toContain(`export ${CONFIG_ENV_BY_AGENT[agent]}=`);
+    }
+  });
+
+  // The load-bearing coupling test: if someone adds (or removes) a config-dir
+  // env var in generateVersionedAliasScript without updating the capability
+  // list, the two drift and --isolated would either over- or under-promise.
+  // This locks them together: an agent emits a config-dir env export IFF it is
+  // declared isolation-capable.
+  it('the alias generator and the capability list stay in sync', () => {
+    for (const agent of ALL_AGENT_IDS) {
+      const script = generateVersionedAliasScript(agent, V);
+      const emitsConfigEnv = ALL_CONFIG_ENVS.some((env) => script.includes(`export ${env}=`));
+      expect(emitsConfigEnv).toBe(supportsIsolatedInstall(agent));
+    }
+  });
+
+  it('agents without an env var export none in the versioned alias', () => {
+    const unsupported: AgentId[] = ALL_AGENT_IDS.filter((a) => !supportsIsolatedInstall(a));
+    for (const agent of unsupported) {
+      const script = generateVersionedAliasScript(agent, V);
+      for (const env of ALL_CONFIG_ENVS) {
+        expect(script).not.toContain(`export ${env}=`);
+      }
+    }
+  });
+});

--- a/apps/cli/src/lib/__tests__/versions.test.ts
+++ b/apps/cli/src/lib/__tests__/versions.test.ts
@@ -6,7 +6,7 @@ import * as crypto from 'crypto';
 import { execFileSync } from 'child_process';
 import { fileURLToPath } from 'url';
 
-import { getProjectVersion, removeVersion } from '../versions.js';
+import { getProjectVersion, removeVersion, getVersionDir, markVersionIsolated, isVersionIsolated } from '../versions.js';
 import { getVersionsDir, getTrashVersionsDir } from '../state.js';
 import { getDB, updateSessionFilePaths } from '../session/db.js';
 import type { AgentId } from '../types.js';
@@ -321,5 +321,119 @@ describe('updateSessionFilePaths rewrites file_path after soft-delete to trash',
 
     // The file must actually exist at the new path
     expect(fs.existsSync(row!.file_path)).toBe(true);
+  });
+});
+
+// An isolated install (`agents add --isolated`) is tagged with a `.isolated`
+// sentinel at the version-dir root. The marker is what keeps every "adopting"
+// code path away from the copy, so the roundtrip and the unmarked-default case
+// must both be exact.
+describe('isolated install markers', () => {
+  it('marks a version isolated, reads it back, and leaves other versions unmarked', () => {
+    const agent: AgentId = 'claude';
+    const isoVersion = `0.0.0-iso-${crypto.randomBytes(4).toString('hex')}`;
+    const normalVersion = `0.0.0-norm-${crypto.randomBytes(4).toString('hex')}`;
+    const isoDir = getVersionDir(agent, isoVersion);
+    const normalDir = getVersionDir(agent, normalVersion);
+
+    try {
+      fs.mkdirSync(isoDir, { recursive: true });
+      fs.mkdirSync(normalDir, { recursive: true });
+
+      // Absent marker -> not isolated.
+      expect(isVersionIsolated(agent, isoVersion)).toBe(false);
+
+      markVersionIsolated(agent, isoVersion);
+
+      expect(isVersionIsolated(agent, isoVersion)).toBe(true);
+      // A sibling version is unaffected.
+      expect(isVersionIsolated(agent, normalVersion)).toBe(false);
+
+      // The marker sits at the version-dir root so it travels to trash with the
+      // whole dir on soft-delete (and is restored intact).
+      expect(fs.existsSync(path.join(isoDir, '.isolated'))).toBe(true);
+    } finally {
+      fs.rmSync(isoDir, { recursive: true, force: true });
+      fs.rmSync(normalDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// Regression guard: removing the global default must NEVER auto-promote an
+// isolated install to be the new default (that would silently make `<agent>`
+// resolve to the isolated copy and let a later `use` adopt its home into
+// ~/.<agent>). Run in a subprocess with an isolated HOME so the real
+// ~/.agents/agents.yaml default pointer is never touched.
+describe('removeVersion never promotes an isolated install to the global default', () => {
+  // Shared preamble: fake a claude install whose real bin target exists, so
+  // isVersionInstalled/listInstalledVersions recognise it without hitting npm.
+  const preamble = String.raw`
+    import * as fs from 'fs';
+    import * as path from 'path';
+    import { AGENTS } from './src/lib/agents.ts';
+    import {
+      getVersionDir, setGlobalDefault, getGlobalDefault, removeVersion, markVersionIsolated,
+    } from './src/lib/versions.ts';
+
+    function fakeInstall(agent, version) {
+      const cfg = AGENTS[agent];
+      const pkgRoot = path.join(getVersionDir(agent, version), 'node_modules', cfg.npmPackage);
+      fs.mkdirSync(pkgRoot, { recursive: true });
+      fs.writeFileSync(path.join(pkgRoot, 'package.json'), JSON.stringify({ bin: { [cfg.cliCommand]: 'cli.js' } }));
+      fs.writeFileSync(path.join(pkgRoot, 'cli.js'), '#!/usr/bin/env node\n');
+    }
+  `;
+
+  it('clears the default when the only survivor is isolated', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'iso-default-clear-'));
+    try {
+      const script = preamble + String.raw`
+        fakeInstall('claude', '1.0.0');   // normal default
+        fakeInstall('claude', '2.0.0');    // isolated survivor
+        markVersionIsolated('claude', '2.0.0');
+        setGlobalDefault('claude', '1.0.0');
+
+        removeVersion('claude', '1.0.0');
+
+        console.log(JSON.stringify({ afterDefault: getGlobalDefault('claude') }));
+      `;
+      const out = execFileSync('bun', ['--eval', script], {
+        cwd: repoRoot,
+        env: { ...process.env, HOME: home },
+        encoding: 'utf-8',
+      });
+      const result = JSON.parse(out.trim().split('\n').at(-1) ?? '{}') as { afterDefault: string | null };
+      // NOT '2.0.0' — the isolated survivor must not be adopted as the default.
+      expect(result.afterDefault).toBeNull();
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('promotes the newest NON-isolated survivor, skipping a newer isolated one', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'iso-default-skip-'));
+    try {
+      const script = preamble + String.raw`
+        fakeInstall('claude', '1.0.0');   // normal default (to be removed)
+        fakeInstall('claude', '1.5.0');    // normal survivor
+        fakeInstall('claude', '2.0.0');    // isolated survivor (newer)
+        markVersionIsolated('claude', '2.0.0');
+        setGlobalDefault('claude', '1.0.0');
+
+        removeVersion('claude', '1.0.0');
+
+        console.log(JSON.stringify({ afterDefault: getGlobalDefault('claude') }));
+      `;
+      const out = execFileSync('bun', ['--eval', script], {
+        cwd: repoRoot,
+        env: { ...process.env, HOME: home },
+        encoding: 'utf-8',
+      });
+      const result = JSON.parse(out.trim().split('\n').at(-1) ?? '{}') as { afterDefault: string | null };
+      // The newer 2.0.0 is isolated, so the newest promotable version is 1.5.0.
+      expect(result.afterDefault).toBe('1.5.0');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/cli/src/lib/shims.ts
+++ b/apps/cli/src/lib/shims.ts
@@ -833,6 +833,31 @@ function assertSafeVersion(version: string): void {
 }
 
 /**
+ * Agents whose config directory can be relocated by an environment variable
+ * (the per-agent `managedEnv` block in `generateVersionedAliasScript` below).
+ *
+ * Only these can be installed with `agents add --isolated`: the versioned alias
+ * points that env var at the copy's private home, so the copy never reads or
+ * writes the user's real `~/.<agent>`. Every other agent isolates ONLY by
+ * adopting `~/.<agent>` via a symlink — which an isolated install deliberately
+ * skips — so an isolated copy would silently fall back to (and mutate) the real
+ * config dir. For those agents `--isolated` is refused up front.
+ *
+ * KEEP IN SYNC with the `managedEnv` switch in `generateVersionedAliasScript`.
+ * The colocated test `shims.isolation-capability.test.ts` enforces this.
+ */
+export const CONFIG_ENV_ISOLATED_AGENTS: readonly AgentId[] = ['claude', 'codex', 'copilot', 'grok', 'kimi'];
+
+/**
+ * Whether an agent supports a clean `--isolated` install — i.e. its config
+ * location can be redirected by an env var so the isolated copy stays fully
+ * separate from the user's real `~/.<agent>`. See {@link CONFIG_ENV_ISOLATED_AGENTS}.
+ */
+export function supportsIsolatedInstall(agent: AgentId): boolean {
+  return CONFIG_ENV_ISOLATED_AGENTS.includes(agent);
+}
+
+/**
  * Generate a versioned alias script that directly execs a specific version.
  * e.g., claude@2.0.65 -> directly runs that version's binary
  */

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -1232,6 +1232,40 @@ export function setGlobalDefault(agent: AgentId, version: string | undefined): v
 }
 
 /**
+ * Path to the sentinel file that marks a version as an isolated install.
+ *
+ * It lives at the version-dir root (a sibling of `home/`), so it is carried
+ * along when `softDeleteVersionDir` moves the whole directory to trash and is
+ * restored intact by `agents trash restore`. Its mere presence is the marker;
+ * the contents are an informational timestamp only.
+ */
+function getIsolatedMarkerPath(agent: AgentId, version: string): string {
+  return path.join(getVersionDir(agent, version), '.isolated');
+}
+
+/**
+ * Mark an installed version as an isolated install (`agents add --isolated`).
+ *
+ * Isolated versions are fully self-contained: they never become the global
+ * default and never own the user's real `~/.<agent>` config directory. This
+ * flag is what keeps every "adopting" code path away from them.
+ */
+export function markVersionIsolated(agent: AgentId, version: string): void {
+  fs.writeFileSync(getIsolatedMarkerPath(agent, version), `${new Date().toISOString()}\n`, { mode: 0o600 });
+}
+
+/**
+ * Whether a version was installed as an isolated install (`agents add --isolated`).
+ *
+ * Used to exclude such versions from global-default promotion and from any
+ * flow that would touch the user's real `~/.<agent>` directory, and to gate the
+ * `--isolated` safety check on `agents remove`.
+ */
+export function isVersionIsolated(agent: AgentId, version: string): boolean {
+  return fs.existsSync(getIsolatedMarkerPath(agent, version));
+}
+
+/**
  * Grok's official installer writes into ~/.grok/downloads, which (because we
  * symlink ~/.grok to the active version home) resolves to the PREVIOUS default
  * home during `agents add grok@<new>`. Move the freshly-downloaded binary and
@@ -1797,13 +1831,19 @@ export function removeVersion(agent: AgentId, version: string): boolean {
   // broke every launcher after removing the pinned default.
   if (getGlobalDefault(agent) === version) {
     const remaining = listInstalledVersions(agent);
-    if (remaining.length > 0) {
-      const newestRemaining = remaining[remaining.length - 1];
+    // Never auto-promote an isolated install to the global default: it was
+    // installed to stay separate from the user's setup, and promoting it would
+    // silently make `<agent>` resolve to it (and let a later `use` adopt its
+    // home into `~/.<agent>`). Prefer the newest NON-isolated survivor; if every
+    // survivor is isolated, clear the default rather than adopt one.
+    const promotable = remaining.filter((v) => !isVersionIsolated(agent, v));
+    if (promotable.length > 0) {
+      const newestRemaining = promotable[promotable.length - 1];
       setGlobalDefault(agent, newestRemaining);
       console.log(chalk.yellow(`Default ${agent} was ${version} (removed); reassigned to ${newestRemaining}. Change it with: agents use ${agent}@<version>`));
     } else {
       setGlobalDefault(agent, undefined);
-      console.log(chalk.yellow(`Removed the last installed ${agent} version and cleared its default. Reinstall with: agents add ${agent}, then set one with: agents use ${agent}@<version>`));
+      console.log(chalk.yellow(`Removed the last non-isolated ${agent} version and cleared its default. Reinstall with: agents add ${agent}, then set one with: agents use ${agent}@<version>`));
     }
   }
 

--- a/apps/cli/tests/non-interactive.test.ts
+++ b/apps/cli/tests/non-interactive.test.ts
@@ -465,6 +465,29 @@ describe.skipIf(process.platform === 'win32')('non-interactive CLI usage', () =>
     expect(fs.lstatSync(codexSymlink).isSymbolicLink()).toBe(true);
   });
 
+  it('refuses to `use` an isolated install as the active version (never repoints the real config)', () => {
+    const home = makeTempHome();
+    tempHomes.push(home);
+    writeFakeManagedVersion(home, 'codex', '0.1.0', 'codex');
+    // Mark it isolated the way `agents add --isolated` does: a `.isolated` marker
+    // in the version dir. `agents use codex@0.1.0` must refuse it rather than
+    // repoint the real ~/.codex at (and carry settings into) an isolated home.
+    fs.writeFileSync(
+      path.join(home, '.agents', '.history', 'versions', 'codex', '0.1.0', '.isolated'),
+      '',
+    );
+
+    const result = runAgents(home, ['use', 'codex@0.1.0']);
+    const codexSymlink = path.join(home, '.codex');
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('isolated install');
+    // The isolation guarantee: the real ~/.codex is never created/repointed and
+    // no default pin is written for the isolated version.
+    expect(fs.existsSync(codexSymlink)).toBe(false);
+    expect(fs.existsSync(devicePinsPath(home))).toBe(false);
+  });
+
   it('does not switch an existing default during non-interactive add', () => {
     const home = makeTempHome();
     tempHomes.push(home);


### PR DESCRIPTION
## Problem

Installing or selecting a version today can adopt the user's real config: the first `agents add` (and every `agents use`) backs up `~/.<agent>` and replaces it with a symlink into the version home (`switchConfigSymlink`), sets the global default, and syncs resources. There's no way to say *"give me a clean, separate copy of claude/codex for a moment, without disturbing my current setup."* Users who just want to try another version — or keep a throwaway account — have to accept changes to their primary install.

## What this adds

A `--isolated` mode on `agents add` and `agents remove`.

**`agents add <agent>@<version> --isolated`** installs a fully self-contained copy and deliberately skips every adopting side effect:
- never sets (or offers) the global default,
- never creates the bare `<agent>` shim, so nothing on `PATH` is shadowed,
- never backs up or symlinks the real `~/.<agent>` (`switchConfigSymlink` is not called),
- carries over no settings and syncs no resources — the copy starts pristine with its own `home/` config and its own login.

It only creates the versioned alias and writes a `.isolated` sentinel at the version-dir root. Launch it explicitly:

```
agents run claude@2.1.112 "your prompt"
```

**Removal is safe by construction:**
- `removeVersion` no longer auto-promotes an isolated version to the global default when the previous default is removed. It promotes the newest **non-isolated** survivor, or clears the default if every survivor is isolated (previously it could silently make `<agent>` resolve to an isolated copy).
- `agents remove <agent>@<version> --isolated` refuses to remove anything that is not an isolated install, and its interactive picker lists only isolated versions — so a normal/default install and the real `~/.<agent>` can never be removed by accident. Removal stays a soft-delete to trash (recoverable via `agents trash restore`).

`--isolated` is mutually exclusive with `--project`.

## Why it's low-risk

Isolation and safe-removal are already primitives in the codebase — this PR just exposes them as an install mode. The only code that touches `~/.<agent>` is `switchConfigSymlink`, which the isolated path never calls; and `removeVersion` already refuses to unlink `~/.<agent>` unless it is a symlink pointing at exactly that version (`getConfigSymlinkVersion`). The one real gap — default-promotion picking an isolated version — is fixed here.

## Tests

- `markVersionIsolated`/`isVersionIsolated` roundtrip (in-process, real fs).
- Two subprocess tests under an isolated `HOME` proving `removeVersion` never promotes an isolated install to the global default (clears it, or picks the newest non-isolated survivor).
- `bun run build` (typecheck) clean; existing version suites pass.

Also verified end-to-end against a throwaway `HOME`: a real `--isolated` install created **no `~/.claude`**, no bare shim, and no global default — only the versioned alias + `.isolated` marker; `remove --isolated` cleanly trashed it and left the config untouched; and the guard refused to remove a normal install.

## Docs

New "Isolated Installs" section in `docs/01-version-management.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)