### PR TITLE
feat(uninstall): complete `agents uninstall` that restores adopted configs

### DIFF
--- a/apps/cli/docs/01-version-management.md
+++ b/apps/cli/docs/01-version-management.md
@@ -151,6 +151,48 @@ Key behaviors:
 - Subsequent switches just update the symlink target (no new backups)
 - Each version has isolated auth in its `home/` directory
 
+## Uninstalling (reversing adoption)
+
+`agents uninstall` is the reverse of `agents setup`: it completely removes
+agents-cli **and restores the config directories adoption took over**, so the
+machine is left as it was before agents-cli was installed.
+
+The ordering matters — the config backups live inside `~/.agents`, so restore
+runs before disposal:
+
+```
+agents uninstall
+    │
+    ▼
+  1. Restore each adopted ~/.<agent>          (lib/uninstall.ts: planUninstall/executeUninstall)
+       owned symlink? (getConfigSymlinkVersion != null)
+         → newest backup exists  → move backups/<agent>/<ts> back to ~/.<agent>
+         → else (importAgent)     → copy the symlink target (version home) back
+       real, un-adopted dir?      → LEFT UNTOUCHED
+  2. Restore owned home files      (~/.claude.json, ...)
+  3. releaseAdoptedLauncher()      restore native binaries on PATH
+  4. stripShimPathLines()          remove the shim dir from every shell rc file
+  5. dispose ~/.agents             move aside to ~/.agents.removed-<ts> (default)
+                                    or hard-delete with --purge
+  6. print `npm uninstall -g @phnx-labs/agents-cli`   (a CLI can't delete its own binary)
+```
+
+Guarantees:
+- **A `~/.<agent>` that agents-cli never adopted is never touched.** Ownership is
+  decided structurally by `getConfigSymlinkVersion()` (non-null only for a symlink
+  into the versions dir) — the same check `removeVersion()` uses.
+- **Recoverable by default.** `~/.agents` (installed versions, session history,
+  secrets metadata) is moved to `~/.agents.removed-<timestamp>`, not deleted.
+  `--purge` hard-deletes it instead.
+- **`--dry-run`** prints the full plan (what is restored, what is left untouched,
+  what is removed) without changing anything.
+- `uninstall` is exempt from the setup gate, so it runs even from a broken or
+  half-initialized state.
+
+Note: with `--purge`, macOS Keychain items created by `agents secrets` are not
+removed (they are managed by the signed helper app); remove those with
+`agents secrets` before uninstalling if you want them gone.
+
 ## Resource Syncing
 
 `syncResourcesToVersion()` links central `~/.agents/` resources into version homes:

--- a/apps/cli/src/commands/uninstall.ts
+++ b/apps/cli/src/commands/uninstall.ts
@@ -1,0 +1,173 @@
+/**
+ * `agents uninstall` — completely remove agents-cli and restore the user's
+ * original agent configs. The reverse of `agents setup`.
+ *
+ * Thin command layer: the restore/teardown logic lives in `lib/uninstall.ts`
+ * (planUninstall / executeUninstall) so it can be tested against a real temp
+ * HOME without the CLI wrapper.
+ */
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { confirm } from '@inquirer/prompts';
+
+import { setHelpSections } from '../lib/help.js';
+import { planUninstall, executeUninstall, type UninstallPlan, type UninstallResult } from '../lib/uninstall.js';
+import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
+
+interface UninstallOptions {
+  purge?: boolean;
+  dryRun?: boolean;
+  yes?: boolean;
+}
+
+/** Render the read-only plan so the user sees exactly what will change. */
+function printPlan(plan: UninstallPlan, purge: boolean): void {
+  const restores = plan.configs.filter((c) => c.kind === 'restore-backup' || c.kind === 'restore-version-home');
+  const dangling = plan.configs.filter((c) => c.kind === 'remove-dangling');
+  const untouched = plan.configs.filter((c) => c.kind === 'leave-real' || c.kind === 'leave-foreign');
+
+  console.log(chalk.bold('\nagents uninstall — planned changes\n'));
+
+  if (restores.length > 0) {
+    console.log(chalk.green('Restore your original config (adopted by agents-cli):'));
+    for (const c of restores) {
+      const how = c.kind === 'restore-backup' ? 'from backup' : 'from version home';
+      console.log(chalk.gray(`  ${c.realPath}  ${chalk.dim(`(${how})`)}`));
+    }
+  }
+  if (dangling.length > 0) {
+    console.log(chalk.yellow('Remove dangling symlink (no original found to restore):'));
+    for (const c of dangling) console.log(chalk.gray(`  ${c.realPath}`));
+  }
+  if (untouched.length > 0) {
+    console.log(chalk.cyan('Left untouched (real, un-adopted configs — never modified):'));
+    for (const c of untouched) console.log(chalk.gray(`  ${c.realPath}`));
+  }
+  if (plan.homeFiles.length > 0) {
+    console.log(chalk.green('Restore home files:'));
+    for (const hf of plan.homeFiles) console.log(chalk.gray(`  ${hf.realPath}`));
+  }
+  if (plan.launchers.length > 0) {
+    console.log(chalk.green('Release adopted launchers (restore native binaries on PATH):'));
+    console.log(chalk.gray(`  ${plan.launchers.join(', ')}`));
+  }
+  if (plan.rcFiles.length > 0) {
+    console.log(chalk.green('Remove the shim directory from PATH in:'));
+    for (const rc of plan.rcFiles) console.log(chalk.gray(`  ${rc}`));
+  }
+
+  console.log(chalk.bold('\nData:'));
+  if (purge) {
+    console.log(chalk.red(`  Permanently delete ${plan.agentsDir} (installed versions, session history, secrets metadata).`));
+    if (plan.legacySymlink) console.log(chalk.red(`  Permanently delete ${plan.legacySymlink}.`));
+  } else {
+    console.log(chalk.gray(`  Move ${plan.agentsDir} aside to ${plan.agentsDir}.removed-<timestamp> (recoverable).`));
+    if (plan.legacySymlink) console.log(chalk.gray(`  Remove the legacy symlink ${plan.legacySymlink}.`));
+    console.log(chalk.gray('  Use --purge to hard-delete instead.'));
+  }
+  console.log();
+}
+
+/** Report what actually happened, then the final manual npm step. */
+function printResult(result: UninstallResult, cleanedPath: boolean): void {
+  for (const r of result.restoredConfigs) console.log(chalk.green(`Restored ${r.realPath}`));
+  for (const r of result.removedDanglingConfigs) console.log(chalk.yellow(`Removed dangling symlink ${r.realPath}`));
+  for (const f of result.restoredHomeFiles) console.log(chalk.green(`Restored ${f}`));
+  if (result.releasedLaunchers.length > 0) console.log(chalk.green(`Released launchers: ${result.releasedLaunchers.join(', ')}`));
+  for (const rc of result.cleanedRcFiles) console.log(chalk.green(`Cleaned shim PATH entry from ${rc}`));
+
+  if (result.agentsDir.disposition === 'moved') {
+    console.log(chalk.gray(`Moved ${result.agentsDir.path} to ${result.agentsDir.movedTo}`));
+  } else if (result.agentsDir.disposition === 'purged') {
+    console.log(chalk.gray(`Deleted ${result.agentsDir.path}`));
+  }
+
+  for (const e of result.errors) console.log(chalk.red(`  ! ${e}`));
+
+  console.log(chalk.bold('\nFinish by removing the CLI package:'));
+  console.log(chalk.gray('  npm uninstall -g @phnx-labs/agents-cli    # or: bun remove -g @phnx-labs/agents-cli'));
+  if (cleanedPath) {
+    console.log(chalk.gray('Open a new shell (or re-source your rc file) so the removed PATH entry takes effect.'));
+  }
+  if (result.agentsDir.disposition === 'moved') {
+    console.log(chalk.gray(`Your data is still at ${result.agentsDir.movedTo} — delete it once you are sure.`));
+  }
+}
+
+/** Register `agents uninstall`. */
+export function registerUninstallCommands(program: Command): void {
+  const cmd = program
+    .command('uninstall')
+    .description('Completely remove agents-cli and restore your original agent configs. Reverses `agents setup`.')
+    .option('--purge', 'Hard-delete ~/.agents (installed versions, sessions, secrets metadata) instead of moving it aside')
+    .option('--dry-run', 'Show exactly what would change without modifying anything')
+    .option('-y, --yes', 'Skip the confirmation prompt (required to run non-interactively)');
+
+  setHelpSections(cmd, {
+    examples: `
+      # Preview everything that would change, without touching anything
+      agents uninstall --dry-run
+
+      # Restore your configs and move ~/.agents aside (recoverable)
+      agents uninstall
+
+      # Same, but hard-delete ~/.agents (no recovery)
+      agents uninstall --purge
+    `,
+    notes: `
+      - Restores every ~/.<agent> that agents-cli adopted; a real config it never adopted is left untouched.
+      - Releases adopted launchers and strips the shim directory from your shell PATH.
+      - Without --purge, ~/.agents is moved to ~/.agents.removed-<timestamp> so nothing is lost.
+      - The CLI cannot delete its own running binary; it prints the final 'npm uninstall -g' step for you.
+    `,
+  });
+
+  cmd.action(async (options: UninstallOptions) => {
+    // We are tearing ~/.agents down. Silence the JSONL audit log for the rest
+    // of this process so a late emit() (its events path is memoized to the old
+    // location) can't re-create ~/.agents after we move it aside.
+    process.env.AGENTS_DISABLE_EVENT_LOG = '1';
+
+    const plan = planUninstall();
+
+    if (!plan.isInstalled) {
+      console.log(chalk.gray('agents-cli is not set up (no ~/.agents directory) — nothing to uninstall.'));
+      return;
+    }
+
+    printPlan(plan, !!options.purge);
+
+    if (options.dryRun) {
+      console.log(chalk.gray('Dry run — nothing was changed.'));
+      return;
+    }
+
+    if (!options.yes) {
+      if (!isInteractiveTerminal()) {
+        console.log(chalk.red('Refusing to uninstall non-interactively. Re-run with --yes to confirm.'));
+        return;
+      }
+      try {
+        const ok = await confirm({
+          message: options.purge
+            ? 'Permanently remove agents-cli and restore your original configs?'
+            : 'Remove agents-cli (data moved to a recoverable directory) and restore your original configs?',
+          default: false,
+        });
+        if (!ok) {
+          console.log(chalk.gray('Cancelled.'));
+          return;
+        }
+      } catch (err) {
+        if (isPromptCancelled(err)) {
+          console.log(chalk.gray('Cancelled.'));
+          return;
+        }
+        throw err;
+      }
+    }
+
+    const result = executeUninstall(plan, { purge: options.purge, timestamp: Date.now() });
+    printResult(result, result.cleanedRcFiles.length > 0);
+  });
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -136,6 +136,7 @@ import {
   loadPush,
   loadRepo,
   loadSetup,
+  loadUninstall,
   loadShare,
   loadFeed,
   loadMailboxes,
@@ -870,6 +871,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadPush);
   await reg(loadRepo);
   await reg(loadSetup);
+  await reg(loadUninstall);
 }
 
 /** Calculate the Levenshtein edit distance between two strings. */
@@ -1011,8 +1013,9 @@ if (firstRun) {
 }
 
 // Every command requires the system repo to be cloned first. `setup` is the
-// only exemption — it's the command that does the cloning.
-const SETUP_EXEMPT_COMMANDS = new Set(['setup', 'help']);
+// command that does the cloning; `uninstall` is its reverse and must run even
+// from a broken/half-setup state (that is exactly when you want to tear down).
+const SETUP_EXEMPT_COMMANDS = new Set(['setup', 'help', 'uninstall']);
 
 // Fold legacy ~/.agents-system/ into ~/.agents/.system/ BEFORE ensureInitialized
 // runs. ensureInitialized checks for .git inside the new path; if the user is

--- a/apps/cli/src/lib/__tests__/uninstall.test.ts
+++ b/apps/cli/src/lib/__tests__/uninstall.test.ts
@@ -46,9 +46,13 @@ function runInHome(body: string): Record<string, unknown> {
     }
     ${body}
   `;
+  // Pin BOTH HOME and AGENTS_REAL_HOME to the test dir. state.ts derives
+  // ~/.agents from HOME while getAgentConfigPath honors AGENTS_REAL_HOME; if a
+  // stale AGENTS_REAL_HOME leaks in from the outer env the two diverge and the
+  // test breaks. Setting both keeps this subprocess hermetic regardless.
   const out = execFileSync('bun', ['--eval', script], {
     cwd: repoRoot,
-    env: { ...process.env, HOME: home },
+    env: { ...process.env, HOME: home, AGENTS_REAL_HOME: home },
     encoding: 'utf-8',
   });
   return JSON.parse(out.trim().split('\n').at(-1) ?? '{}');

--- a/apps/cli/src/lib/__tests__/uninstall.test.ts
+++ b/apps/cli/src/lib/__tests__/uninstall.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { execFileSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+let home: string;
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'uninstall-test-'));
+});
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+// Run a script under an isolated HOME so state.ts derives ~/.agents inside it.
+// Real fs, no mocking (repo convention). Returns the parsed last JSON line.
+function runInHome(body: string): Record<string, unknown> {
+  const script = String.raw`
+    import * as fs from 'fs';
+    import * as path from 'path';
+    import { planUninstall, executeUninstall } from './src/lib/uninstall.ts';
+    const home = process.env.HOME;
+    const userDir = path.join(home, '.agents');
+    const versionsRoot = path.join(userDir, '.history', 'versions');
+    const backupsRoot = path.join(userDir, '.history', 'backups');
+    const shimsDir = path.join(userDir, '.cache', 'shims');
+    // Minimal ~/.agents so planUninstall sees an install.
+    fs.mkdirSync(shimsDir, { recursive: true });
+
+    // Helper: adopt <agent> — a ~/.<agent> symlink into a version home.
+    function adopt(agent, configDirName, version, managedContent) {
+      const versionHome = path.join(versionsRoot, agent, version, 'home', configDirName);
+      fs.mkdirSync(versionHome, { recursive: true });
+      fs.writeFileSync(path.join(versionHome, 'marker'), managedContent);
+      fs.symlinkSync(versionHome, path.join(home, configDirName));
+      return versionHome;
+    }
+    function backup(agent, ts, originalContent) {
+      const dir = path.join(backupsRoot, agent, String(ts));
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'marker'), originalContent);
+    }
+    ${body}
+  `;
+  const out = execFileSync('bun', ['--eval', script], {
+    cwd: repoRoot,
+    env: { ...process.env, HOME: home },
+    encoding: 'utf-8',
+  });
+  return JSON.parse(out.trim().split('\n').at(-1) ?? '{}');
+}
+
+describe('uninstall restores adopted configs and never touches un-adopted ones', () => {
+  it('restores an adopted config from its backup and leaves a real un-adopted dir untouched', () => {
+    const result = runInHome(String.raw`
+      adopt('claude', '.claude', '1.0.0', 'MANAGED');
+      backup('claude', 1700000000000, 'ORIGINAL_CLAUDE');
+
+      // A real ~/.codex that agents-cli never adopted.
+      fs.mkdirSync(path.join(home, '.codex'), { recursive: true });
+      fs.writeFileSync(path.join(home, '.codex', 'config.toml'), 'ORIGINAL_CODEX');
+
+      // An rc file carrying the shim PATH line.
+      const rc = path.join(home, '.zshrc');
+      fs.writeFileSync(rc, '# agents-cli: version-managed agent CLIs\nexport PATH="' + shimsDir + ':$PATH"\nexport KEEP=1\n');
+
+      const plan = planUninstall();
+      const res = executeUninstall(plan, { purge: false, timestamp: 42 });
+
+      const claudePath = path.join(home, '.claude');
+      const rcAfter = fs.readFileSync(rc, 'utf-8');
+      console.log(JSON.stringify({
+        codexKind: plan.configs.find(c => c.agent === 'codex').kind,
+        claudeKind: plan.configs.find(c => c.agent === 'claude').kind,
+        claudeIsRealDir: fs.lstatSync(claudePath).isDirectory() && !fs.lstatSync(claudePath).isSymbolicLink(),
+        claudeContent: fs.readFileSync(path.join(claudePath, 'marker'), 'utf-8'),
+        codexContent: fs.readFileSync(path.join(home, '.codex', 'config.toml'), 'utf-8'),
+        agentsMovedAside: fs.existsSync(userDir + '.removed-42') && !fs.existsSync(userDir),
+        rcStrippedButKept: !rcAfter.includes('version-managed') && rcAfter.includes('KEEP=1'),
+        errors: res.errors,
+      }));
+    `);
+
+    expect(result.claudeKind).toBe('restore-backup');
+    // The un-adopted real dir must be classified untouchable and left as-is.
+    expect(result.codexKind).toBe('leave-real');
+    expect(result.claudeIsRealDir).toBe(true);
+    expect(result.claudeContent).toBe('ORIGINAL_CLAUDE');
+    expect(result.codexContent).toBe('ORIGINAL_CODEX');
+    expect(result.agentsMovedAside).toBe(true);
+    expect(result.rcStrippedButKept).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('restores from the version home when there is no backup (importAgent case)', () => {
+    const result = runInHome(String.raw`
+      adopt('claude', '.claude', '2.0.0', 'IMPORTED_ORIGINAL');   // no backup() call
+      const plan = planUninstall();
+      const res = executeUninstall(plan, { purge: false, timestamp: 7 });
+      const claudePath = path.join(home, '.claude');
+      console.log(JSON.stringify({
+        kind: plan.configs.find(c => c.agent === 'claude').kind,
+        isRealDir: fs.lstatSync(claudePath).isDirectory() && !fs.lstatSync(claudePath).isSymbolicLink(),
+        content: fs.readFileSync(path.join(claudePath, 'marker'), 'utf-8'),
+        errors: res.errors,
+      }));
+    `);
+    expect(result.kind).toBe('restore-version-home');
+    expect(result.isRealDir).toBe(true);
+    expect(result.content).toBe('IMPORTED_ORIGINAL');
+    expect(result.errors).toEqual([]);
+  });
+
+  it('planUninstall is read-only — a dry run mutates nothing', () => {
+    const result = runInHome(String.raw`
+      adopt('claude', '.claude', '1.0.0', 'MANAGED');
+      backup('claude', 1700000000000, 'ORIGINAL');
+      const before = fs.lstatSync(path.join(home, '.claude')).isSymbolicLink();
+      const plan = planUninstall();   // must not touch disk
+      console.log(JSON.stringify({
+        stillSymlink: fs.lstatSync(path.join(home, '.claude')).isSymbolicLink(),
+        wasSymlink: before,
+        agentsIntact: fs.existsSync(userDir),
+        claudeToRestore: plan.configs.find(c => c.agent === 'claude').kind,
+      }));
+    `);
+    expect(result.wasSymlink).toBe(true);
+    expect(result.stillSymlink).toBe(true);
+    expect(result.agentsIntact).toBe(true);
+    expect(result.claudeToRestore).toBe('restore-backup');
+  });
+});

--- a/apps/cli/src/lib/shims.ts
+++ b/apps/cli/src/lib/shims.ts
@@ -1099,7 +1099,7 @@ export function versionedAliasExists(agent: AgentId, version: string): boolean {
  * Get the path to the agent's config directory in HOME.
  * e.g., ~/.claude for claude, ~/.codex for codex
  */
-function getAgentConfigPath(agent: AgentId): string {
+export function getAgentConfigPath(agent: AgentId): string {
   const agentConfig = AGENTS[agent];
   const home = process.env.AGENTS_REAL_HOME || os.homedir();
   return agentConfig.configDir.replace(os.homedir(), home);
@@ -2309,7 +2309,7 @@ function isShimPathCommandLine(line: string, shimsDir: string): boolean {
   return trimmed.startsWith('export PATH=') || trimmed.startsWith('fish_add_path ');
 }
 
-function stripShimPathLines(content: string, shimsDir: string): string {
+export function stripShimPathLines(content: string, shimsDir: string): string {
   const lines = content.split('\n');
   const kept: string[] = [];
 

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -90,6 +90,7 @@ export const loadPull: ModuleLoader = async () => (await import('../../commands/
 export const loadPush: ModuleLoader = async () => (await import('../../commands/push.js')).registerPushCommand;
 export const loadRepo: ModuleLoader = async () => (await import('../../commands/repo.js')).registerRepoCommands;
 export const loadSetup: ModuleLoader = async () => (await import('../../commands/setup.js')).registerSetupCommand;
+export const loadUninstall: ModuleLoader = async () => (await import('../../commands/uninstall.js')).registerUninstallCommands;
 export const loadSessions: ModuleLoader = async () => (await import('../../commands/sessions.js')).registerSessionsCommands;
 export const loadTeams: ModuleLoader = async () => (await import('../../commands/teams.js')).registerTeamsCommands;
 export const loadCloud: ModuleLoader = async () => (await import('../../commands/cloud.js')).registerCloudCommands;
@@ -202,6 +203,7 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   repos: [loadRepo],
   repo: [loadRepo],
   setup: [loadSetup],
+  uninstall: [loadUninstall],
   sessions: [loadSessions],
   teams: [loadTeams],
   cloud: [loadCloud],

--- a/apps/cli/src/lib/uninstall.ts
+++ b/apps/cli/src/lib/uninstall.ts
@@ -1,0 +1,316 @@
+/**
+ * Complete teardown of agents-cli — the reverse of `agents setup`.
+ *
+ * The hard part is undoing "adoption": normal installs move the user's real
+ * `~/.<agent>` aside and replace it with a symlink into agents-cli's version
+ * homes (see `switchConfigSymlink` / `importAgent`). A clean uninstall must put
+ * those real directories back, release any adopted launchers, strip the shim
+ * directory from the user's PATH, and only then dispose of `~/.agents`.
+ *
+ * Safety invariant: a `~/.<agent>` that agents-cli never adopted is a REAL user
+ * directory and is never touched. Ownership is decided structurally by
+ * `getConfigSymlinkVersion` (non-null only for a symlink into our versions dir),
+ * exactly as `removeVersion` does it — no marker files, no guessing.
+ *
+ * This module is split into a read-only {@link planUninstall} and a mutating
+ * {@link executeUninstall} so `--dry-run` and the real run share one code path.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { AGENTS, ALL_AGENT_IDS } from './agents.js';
+import type { AgentId } from './types.js';
+import {
+  getAgentConfigPath,
+  getConfigSymlinkVersion,
+  stripShimPathLines,
+  releaseAdoptedLauncher,
+} from './shims.js';
+import {
+  getUserAgentsDir,
+  getBackupsDir,
+  getHistoryDir,
+  getShimsDir,
+  getLegacySystemAgentsDir,
+} from './state.js';
+
+/** What the uninstall intends to do with one agent's config directory. */
+export type ConfigAction =
+  | { agent: AgentId; realPath: string; kind: 'restore-backup'; source: string }
+  | { agent: AgentId; realPath: string; kind: 'restore-version-home'; source: string }
+  | { agent: AgentId; realPath: string; kind: 'remove-dangling' }
+  | { agent: AgentId; realPath: string; kind: 'leave-real' }
+  | { agent: AgentId; realPath: string; kind: 'leave-foreign' }
+  | { agent: AgentId; realPath: string; kind: 'absent' };
+
+/** A home-level file symlink (e.g. `~/.claude.json`) agents-cli owns. */
+export interface HomeFileAction {
+  realPath: string;
+  /** Resolved symlink target whose contents are copied back to `realPath`. */
+  source: string;
+}
+
+/** The full, read-only plan describing what an uninstall would change. */
+export interface UninstallPlan {
+  isInstalled: boolean;
+  agentsDir: string;
+  legacySymlink: string | null;
+  configs: ConfigAction[];
+  homeFiles: HomeFileAction[];
+  launchers: string[];
+  rcFiles: string[];
+}
+
+/** Structured result of an executed uninstall (for reporting). */
+export interface UninstallResult {
+  restoredConfigs: Array<{ agent: AgentId; realPath: string }>;
+  removedDanglingConfigs: Array<{ agent: AgentId; realPath: string }>;
+  restoredHomeFiles: string[];
+  releasedLaunchers: string[];
+  cleanedRcFiles: string[];
+  agentsDir: { path: string; disposition: 'moved' | 'purged' | 'absent'; movedTo?: string };
+  legacySymlinkRemoved: boolean;
+  errors: string[];
+}
+
+/** Home dir honoring the AGENTS_REAL_HOME test/override, mirroring shims.ts. */
+function realHome(): string {
+  return process.env.AGENTS_REAL_HOME || os.homedir();
+}
+
+/** Newest timestamped backup dir under `<backups>/<agent>/`, or null. */
+function newestBackupDir(agent: AgentId): string | null {
+  const dir = path.join(getBackupsDir(), agent);
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir).filter((n) => /^\d+$/.test(n));
+  } catch {
+    return null;
+  }
+  if (entries.length === 0) return null;
+  entries.sort((a, b) => Number(a) - Number(b));
+  return path.join(dir, entries[entries.length - 1]);
+}
+
+/** Absolute target of a symlink, or null if `p` is not a readable symlink. */
+function symlinkTarget(p: string): string | null {
+  try {
+    const raw = fs.readlinkSync(p);
+    return path.resolve(path.dirname(p), raw);
+  } catch {
+    return null;
+  }
+}
+
+/** Classify one agent's config dir without mutating anything. */
+function planConfig(agent: AgentId): ConfigAction {
+  const realPath = getAgentConfigPath(agent);
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(realPath);
+  } catch {
+    return { agent, realPath, kind: 'absent' };
+  }
+  // A real directory means agents-cli never adopted it — leave it alone.
+  if (!stat.isSymbolicLink()) return { agent, realPath, kind: 'leave-real' };
+  // A symlink we don't own (target not under our versions dir) — leave it alone.
+  if (getConfigSymlinkVersion(agent) === null) return { agent, realPath, kind: 'leave-foreign' };
+
+  // Owned symlink: prefer the timestamped backup (switchConfigSymlink moved the
+  // real dir there); otherwise the symlink target itself holds the user's data
+  // (importAgent renamed the real dir INTO the version home).
+  const backup = newestBackupDir(agent);
+  if (backup) return { agent, realPath, kind: 'restore-backup', source: backup };
+  const target = symlinkTarget(realPath);
+  if (target && fs.existsSync(target)) {
+    return { agent, realPath, kind: 'restore-version-home', source: target };
+  }
+  return { agent, realPath, kind: 'remove-dangling' };
+}
+
+/** Owned home-file symlinks (e.g. `~/.claude.json`) to copy back as real files. */
+function planHomeFiles(): HomeFileAction[] {
+  const home = realHome();
+  const userDir = getUserAgentsDir();
+  const out: HomeFileAction[] = [];
+  for (const agent of ALL_AGENT_IDS) {
+    const homeFiles = AGENTS[agent].homeFiles;
+    if (!homeFiles) continue;
+    for (const fileName of homeFiles) {
+      const realPath = path.join(home, fileName);
+      let stat: fs.Stats;
+      try {
+        stat = fs.lstatSync(realPath);
+      } catch {
+        continue;
+      }
+      if (!stat.isSymbolicLink()) continue;
+      const target = symlinkTarget(realPath);
+      // Only ours (points into ~/.agents) and only if the target still exists.
+      if (target && target.startsWith(userDir + path.sep) && fs.existsSync(target)) {
+        out.push({ realPath, source: target });
+      }
+    }
+  }
+  return out;
+}
+
+/** cliCommand basenames that have an adopted-launcher record to release. */
+function planLaunchers(): string[] {
+  const dir = path.join(getHistoryDir(), 'adopted-launchers');
+  try {
+    return fs.readdirSync(dir).filter((n) => !n.startsWith('.'));
+  } catch {
+    return [];
+  }
+}
+
+/** Candidate shell rc files that currently contain a shim PATH entry. */
+function planRcFiles(): string[] {
+  const home = realHome();
+  const shimsDir = getShimsDir();
+  const candidates = ['.zshrc', '.bashrc', '.bash_profile', '.profile', path.join('.config', 'fish', 'config.fish')];
+  const out: string[] = [];
+  for (const rel of candidates) {
+    const rc = path.join(home, rel);
+    let content: string;
+    try {
+      content = fs.readFileSync(rc, 'utf-8');
+    } catch {
+      continue;
+    }
+    if (stripShimPathLines(content, shimsDir) !== content) out.push(rc);
+  }
+  return out;
+}
+
+/**
+ * Build a read-only plan of everything a complete uninstall would change.
+ * Performs no mutations; safe to run for `--dry-run` and to print for confirm.
+ */
+export function planUninstall(): UninstallPlan {
+  const agentsDir = getUserAgentsDir();
+  const legacy = getLegacySystemAgentsDir();
+  let legacySymlink: string | null = null;
+  try {
+    fs.lstatSync(legacy);
+    legacySymlink = legacy;
+  } catch {
+    legacySymlink = null;
+  }
+  return {
+    isInstalled: fs.existsSync(agentsDir),
+    agentsDir,
+    legacySymlink,
+    configs: ALL_AGENT_IDS.map(planConfig),
+    homeFiles: planHomeFiles(),
+    launchers: planLaunchers(),
+    rcFiles: planRcFiles(),
+  };
+}
+
+/**
+ * Execute a plan built by {@link planUninstall}. Restores adopted config dirs
+ * and home files, releases adopted launchers, strips shim PATH lines, then
+ * disposes of `~/.agents` — moved aside to `~/.agents.removed-<ts>` (recoverable)
+ * by default, or hard-deleted when `purge` is set. Config restore always runs
+ * before disposal because the backups live inside `~/.agents`.
+ */
+export function executeUninstall(plan: UninstallPlan, opts: { purge?: boolean; timestamp: number }): UninstallResult {
+  const result: UninstallResult = {
+    restoredConfigs: [],
+    removedDanglingConfigs: [],
+    restoredHomeFiles: [],
+    releasedLaunchers: [],
+    cleanedRcFiles: [],
+    agentsDir: { path: plan.agentsDir, disposition: 'absent' },
+    legacySymlinkRemoved: false,
+    errors: [],
+  };
+
+  // 1. Restore adopted config directories (reads backups inside ~/.agents).
+  for (const c of plan.configs) {
+    try {
+      if (c.kind === 'restore-backup') {
+        fs.unlinkSync(c.realPath);
+        fs.renameSync(c.source, c.realPath);
+        result.restoredConfigs.push({ agent: c.agent, realPath: c.realPath });
+      } else if (c.kind === 'restore-version-home') {
+        fs.unlinkSync(c.realPath);
+        fs.cpSync(c.source, c.realPath, { recursive: true });
+        result.restoredConfigs.push({ agent: c.agent, realPath: c.realPath });
+      } else if (c.kind === 'remove-dangling') {
+        fs.unlinkSync(c.realPath);
+        result.removedDanglingConfigs.push({ agent: c.agent, realPath: c.realPath });
+      }
+      // leave-real / leave-foreign / absent: intentionally untouched.
+    } catch (err) {
+      result.errors.push(`config ${c.agent} (${c.realPath}): ${(err as Error).message}`);
+    }
+  }
+
+  // 2. Restore owned home-file symlinks as real files (e.g. ~/.claude.json).
+  for (const hf of plan.homeFiles) {
+    try {
+      fs.unlinkSync(hf.realPath);
+      fs.cpSync(hf.source, hf.realPath, { recursive: true });
+      result.restoredHomeFiles.push(hf.realPath);
+    } catch (err) {
+      result.errors.push(`home file ${hf.realPath}: ${(err as Error).message}`);
+    }
+  }
+
+  // 3. Release adopted launchers (reads records inside ~/.agents).
+  const byCli = new Map(ALL_AGENT_IDS.map((a) => [AGENTS[a].cliCommand, a]));
+  for (const cli of plan.launchers) {
+    const agent = byCli.get(cli);
+    if (!agent) continue;
+    try {
+      releaseAdoptedLauncher(agent);
+      result.releasedLaunchers.push(cli);
+    } catch (err) {
+      result.errors.push(`launcher ${cli}: ${(err as Error).message}`);
+    }
+  }
+
+  // 4. Strip the shim directory from the user's PATH across all rc files.
+  const shimsDir = getShimsDir();
+  for (const rc of plan.rcFiles) {
+    try {
+      const content = fs.readFileSync(rc, 'utf-8');
+      fs.writeFileSync(rc, stripShimPathLines(content, shimsDir));
+      result.cleanedRcFiles.push(rc);
+    } catch (err) {
+      result.errors.push(`rc file ${rc}: ${(err as Error).message}`);
+    }
+  }
+
+  // 5. Remove the legacy back-compat symlink, if present.
+  if (plan.legacySymlink) {
+    try {
+      fs.rmSync(plan.legacySymlink, { recursive: true, force: true });
+      result.legacySymlinkRemoved = true;
+    } catch (err) {
+      result.errors.push(`legacy ${plan.legacySymlink}: ${(err as Error).message}`);
+    }
+  }
+
+  // 6. Dispose of ~/.agents LAST (its backups fed step 1).
+  if (fs.existsSync(plan.agentsDir)) {
+    try {
+      if (opts.purge) {
+        fs.rmSync(plan.agentsDir, { recursive: true, force: true });
+        result.agentsDir = { path: plan.agentsDir, disposition: 'purged' };
+      } else {
+        const movedTo = `${plan.agentsDir}.removed-${opts.timestamp}`;
+        fs.renameSync(plan.agentsDir, movedTo);
+        result.agentsDir = { path: plan.agentsDir, disposition: 'moved', movedTo };
+      }
+    } catch (err) {
+      result.errors.push(`dispose ${plan.agentsDir}: ${(err as Error).message}`);
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Problem

There is no way to fully uninstall agents-cli. Setup adopts the user's real config: `switchConfigSymlink` / `importAgent` move `~/.<agent>` aside and replace it with a symlink into the version homes. But **no code path ever restores the backup** — `getBackupsDir()` is only ever written to. So `npm uninstall -g @phnx-labs/agents-cli` leaves `~/.agents` behind, `~/.claude` a dangling symlink, and the user's original config stranded under `~/.agents/.history/backups/`. Removing the CLI actively disturbs the user's local setup.

## What this adds

A first-class **`agents uninstall`** — the reverse of `agents setup`. It removes agents-cli *and* restores the machine to its pre-install state.

Flow (restore before disposal, since the backups live inside `~/.agents`):

1. **Restore each adopted `~/.<agent>`** — newest timestamped backup if present, else the symlink target (the `importAgent` case, where the original was renamed into the version home). **A real, un-adopted directory is left untouched.**
2. **Restore owned home files** (`~/.claude.json`, …).
3. **Release adopted launchers** — restore native binaries on `PATH` (`releaseAdoptedLauncher`).
4. **Strip the shim dir from every shell rc file** (reuses `stripShimPathLines`).
5. **Dispose of `~/.agents`** — moved aside to `~/.agents.removed-<timestamp>` (recoverable) by default, or hard-deleted with `--purge`.
6. **Print the final `npm uninstall -g …`** — a running CLI can't reliably delete its own binary.

## Safety

- **Never touches an un-adopted config.** Ownership is decided structurally by `getConfigSymlinkVersion()` (non-null only for a symlink into the versions dir) — the exact check `removeVersion` already uses. A real `~/.claude` agents-cli never adopted is classified `leave-real` and never modified.
- **`--dry-run`** prints the full plan (restored / left-untouched / removed) and changes nothing.
- **Refuses to run non-interactively without `--yes`.**
- **Recoverable by default** (`~/.agents` moved aside, not deleted).
- Exempt from the setup gate, so it runs even from a broken/half-initialized state.
- Silences the event log for the run so a late `emit()` (whose events path is memoized) can't re-create `~/.agents` after it is moved.

## Implementation

- `lib/uninstall.ts` — read-only `planUninstall()` + mutating `executeUninstall()` so `--dry-run` and the real run share one path.
- `commands/uninstall.ts` — thin command (plan → confirm → execute → print npm step).
- Exports `getAgentConfigPath` + `stripShimPathLines` from `shims.ts` for reuse (no duplication).
- Registers the command (`command-registry.ts`, `index.ts`) and adds it to `SETUP_EXEMPT_COMMANDS`.

## Tests

Subprocess tests against a real temp `HOME` (repo's no-mocking convention): restore-from-backup, restore-from-version-home, **un-adopted dir left untouched**, PATH strip, and `planUninstall` being read-only. `bun run build` clean; existing `shims` suite passes.

Verified end-to-end: a pre-existing real `~/.claude` adopted by a normal install is restored to its original content on uninstall; an un-adopted `~/.codex` is untouched; the shim PATH line is removed; `~/.agents` is moved aside; and `--purge` hard-deletes while still restoring.

## Scope note

macOS Keychain items created by `agents secrets` are managed by the signed helper app and are **not** removed even under `--purge` (documented in the notes). Bulk-Keychain teardown could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)