### PR TITLE
fix(secrets): broker fails to start on the compiled binary; diagnose dropped OG covers

### DIFF
--- a/apps/cli/src/lib/cli-entry.test.ts
+++ b/apps/cli/src/lib/cli-entry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect } from 'vitest';
 import { getCliLaunch, isNodeScriptEntry } from './cli-entry.js';
 
 // Regression for the secrets-broker "Could not start the secrets broker" hang and

--- a/apps/cli/src/lib/cli-entry.test.ts
+++ b/apps/cli/src/lib/cli-entry.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'bun:test';
+import { getCliLaunch, isNodeScriptEntry } from './cli-entry.js';
+
+// Regression for the secrets-broker "Could not start the secrets broker" hang and
+// the #315 compiled-binary self-spawn bug. The broker spawn (secrets/agent.ts
+// cliSpawn) and every self-relaunch (daemon, teams, message, profiles) route
+// through getCliLaunch. The old hand-rolled `[process.execPath, process.argv[1],
+// …]` broke on the Bun standalone binary, where process.argv[1] is the virtual
+// entry `/$bunfs/root/agents` — passed as an argv element it made the child die
+// with "unknown command '/$bunfs/root/agents'", so the broker never bound.
+describe('getCliLaunch', () => {
+  it('launches a .js entry through the Node runtime', () => {
+    const { command, args } = getCliLaunch(['secrets', '_agent-run'], '/opt/agents/dist/index.js');
+    expect(command).toBe(process.execPath);
+    expect(args).toEqual(['/opt/agents/dist/index.js', 'secrets', '_agent-run']);
+  });
+
+  it('runs a compiled binary directly — never re-passes its own path as an arg', () => {
+    const { command, args } = getCliLaunch(['secrets', '_agent-run'], '/Users/me/.local/bin/agents');
+    expect(command).toBe('/Users/me/.local/bin/agents');
+    expect(args).toEqual(['secrets', '_agent-run']);
+  });
+
+  it('resolves a bun virtual entry to the physical executable, never spawns the $bunfs path', () => {
+    const { command, args } = getCliLaunch(['secrets', '_agent-run'], '/$bunfs/root/agents');
+    // process.execPath (the real bun/node binary) — never the un-exec-able bunfs path.
+    expect(command).toBe(process.execPath);
+    expect(command.includes('$bunfs')).toBe(false);
+    expect(args).toEqual(['secrets', '_agent-run']);
+    expect(args.some((a) => a.includes('$bunfs'))).toBe(false);
+  });
+
+  it('does not mutate the caller-supplied sub array', () => {
+    const sub = ['secrets', '_agent-run'];
+    getCliLaunch(sub, '/opt/agents/dist/index.js');
+    expect(sub).toEqual(['secrets', '_agent-run']);
+  });
+});
+
+describe('isNodeScriptEntry', () => {
+  it('treats .js/.cjs/.mjs entries as node scripts', () => {
+    expect(isNodeScriptEntry('/x/index.js')).toBe(true);
+    expect(isNodeScriptEntry('/x/index.cjs')).toBe(true);
+    expect(isNodeScriptEntry('/x/index.mjs')).toBe(true);
+  });
+
+  it('treats a non-existent extensionless path as a direct binary (no node wrapper)', () => {
+    expect(isNodeScriptEntry('/nonexistent/bin/agents')).toBe(false);
+  });
+});

--- a/apps/cli/src/lib/cli-entry.ts
+++ b/apps/cli/src/lib/cli-entry.ts
@@ -1,0 +1,123 @@
+/**
+ * Resolve how to re-invoke THIS `agents` CLI as a child process, correctly across
+ * both install shapes:
+ *
+ *   1. **JS install** — `agents` is a `dist/index.js` (or a symlink / `#!node`
+ *      shim to it). `process.execPath` is `node`, `process.argv[1]` is the script.
+ *      Relaunch as `node <entry> <sub…>`.
+ *   2. **Bun standalone binary** (#315) — `agents` is a compiled Mach-O/ELF/PE.
+ *      `process.execPath` is the physical signed binary, and `process.argv[1]` is
+ *      the *virtual* embedded entry `/$bunfs/root/agents`, which Bun reports as an
+ *      existing path. Passing that virtual path as an argv element makes the CLI
+ *      receive it as a subcommand and die with `unknown command '/$bunfs/root/agents'`.
+ *      Relaunch by executing the physical binary directly: `<binary> <sub…>`.
+ *
+ * Both `getDaemonLaunch` (daemon.ts) and the secrets-broker `cliSpawn`
+ * (secrets/agent.ts) route through here so the two never drift. This module is a
+ * leaf — it imports nothing from `lib/` — so it can be pulled into either without
+ * an import cycle (daemon.ts ↔ secrets/agent.ts already form one).
+ */
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export const BUN_VIRTUAL_ROOT = /[/\\]\$bunfs[/\\]root[/\\]/;
+
+function resolveBunStandaloneEntry(entry: string, execPath: string): string {
+  if (!BUN_VIRTUAL_ROOT.test(entry)) return entry;
+  if (!execPath || BUN_VIRTUAL_ROOT.test(execPath) || !fs.existsSync(execPath)) {
+    throw new Error(
+      `Cannot resolve agents CLI: Bun standalone executable not found at ${execPath || '(empty path)'}`,
+    );
+  }
+  return execPath;
+}
+
+export function getAgentsBinPath(
+  argv1: string | undefined = process.argv[1],
+  execPath: string = process.execPath,
+): string {
+  // Prefer the binary actively executing this code. `which agents` returns
+  // whatever happens to be first on PATH, which means a side-by-side dev
+  // build at ~/.local/bin would silently spawn the registry-installed
+  // daemon and run stale code. For a JS install, process.argv[1] is the
+  // absolute entrypoint the user actually invoked. A Bun standalone instead
+  // exposes its embedded /$bunfs/root entry at argv[1] and its physical signed
+  // executable at process.execPath; Bun reports both as existing paths.
+  const runningEntry = argv1 ? resolveBunStandaloneEntry(argv1, execPath) : undefined;
+  if (runningEntry && fs.existsSync(runningEntry)) {
+    // The package's browser/computer entrypoints are sibling shims without a
+    // `daemon` command. A daemon started as their IPC side effect must launch
+    // through the main agents entrypoint instead of replaying the shim path.
+    const entryName = path.basename(runningEntry);
+    const compiledShim = /^(browser|computer)\.(c|m)?js$/.test(entryName);
+    const installedShim = /^(browser|computer)$/.test(entryName);
+    if (compiledShim || installedShim) {
+      const agentsEntry = path.join(path.dirname(runningEntry), compiledShim ? 'index.js' : 'agents');
+      if (!fs.existsSync(agentsEntry)) {
+        throw new Error(`Cannot start agents daemon: main CLI entry not found at ${agentsEntry}`);
+      }
+      return agentsEntry;
+    }
+    return runningEntry;
+  }
+  try {
+    return execFileSync('which', ['agents'], { encoding: 'utf-8' }).trim();
+  } catch {
+    return 'agents';
+  }
+}
+
+/**
+ * A CLI entry must be launched through the Node runtime when it is a Node
+ * script — a `.js`/`.cjs`/`.mjs` file, OR a symlink/extension-less shim whose
+ * shebang names `node`. Package installs link `bin/agents` to a `dist/index.js`
+ * (a symlink) or drop an extension-less `#!/usr/bin/env node` shim, so an
+ * extension check alone misses them and they get run directly. A real compiled
+ * binary (Mach-O/ELF/PE) has no `#!node` shebang, so it takes the direct branch
+ * and owns its own runtime resolution.
+ */
+export function isNodeScriptEntry(agentsBin: string): boolean {
+  let resolved = agentsBin;
+  try {
+    resolved = fs.realpathSync(agentsBin);
+  } catch {
+    // Unresolvable (e.g. a template path that does not exist on this box): fall
+    // back to the extension check on the path as given.
+  }
+  if (/\.(c|m)?js$/.test(resolved)) return true;
+  try {
+    const fd = fs.openSync(resolved, 'r');
+    try {
+      const buf = Buffer.alloc(128);
+      const n = fs.readSync(fd, buf, 0, 128, 0);
+      const firstLine = buf.toString('utf-8', 0, n).split('\n', 1)[0];
+      return firstLine.startsWith('#!') && /\bnode\b/.test(firstLine);
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build the `{ command, args }` to re-invoke this CLI with `sub` as its argv,
+ * resolving the JS-vs-standalone shape above. This is the single primitive behind
+ * both the daemon launch and the secrets-broker spawn — never hand-roll
+ * `[process.execPath, process.argv[1], …]`, which appends the bun virtual entry
+ * as a bogus subcommand on standalone builds.
+ */
+export function getCliLaunch(
+  sub: string[],
+  agentsBin: string = getAgentsBinPath(),
+): { command: string; args: string[] } {
+  // Resolve a bun virtual entry to the physical executable even when a caller
+  // passes agentsBin explicitly (getAgentsBinPath already does this for the
+  // default), so a `/$bunfs/root/agents` never becomes the command or an argv.
+  const bin = resolveBunStandaloneEntry(agentsBin, process.execPath);
+  if (isNodeScriptEntry(bin)) {
+    return { command: process.execPath, args: [bin, ...sub] };
+  }
+  return { command: bin, args: [...sub] };
+}

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -22,6 +22,7 @@ import { BrowserService } from './browser/service.js';
 import { BrowserIPCServer } from './browser/ipc.js';
 import { readAndResolveBundleEnv } from './secrets/bundles.js';
 import { redactSecrets } from './redact.js';
+import { getAgentsBinPath, getCliLaunch, BUN_VIRTUAL_ROOT } from './cli-entry.js';
 
 const PID_FILE = 'daemon.pid';
 const LOCK_FILE = 'daemon.lock';
@@ -774,52 +775,11 @@ Environment=PATH=${daemonNodeBinDir()}:/usr/local/bin:/usr/bin:/bin
 WantedBy=default.target`;
 }
 
-const BUN_VIRTUAL_ROOT = /[/\\]\$bunfs[/\\]root[/\\]/;
-
-function resolveBunStandaloneEntry(entry: string, execPath: string): string {
-  if (!BUN_VIRTUAL_ROOT.test(entry)) return entry;
-  if (!execPath || BUN_VIRTUAL_ROOT.test(execPath) || !fs.existsSync(execPath)) {
-    throw new Error(
-      `Cannot resolve agents CLI: Bun standalone executable not found at ${execPath || '(empty path)'}`,
-    );
-  }
-  return execPath;
-}
-
-export function getAgentsBinPath(
-  argv1: string | undefined = process.argv[1],
-  execPath: string = process.execPath,
-): string {
-  // Prefer the binary actively executing this code. `which agents` returns
-  // whatever happens to be first on PATH, which means a side-by-side dev
-  // build at ~/.local/bin would silently spawn the registry-installed
-  // daemon and run stale code. For a JS install, process.argv[1] is the
-  // absolute entrypoint the user actually invoked. A Bun standalone instead
-  // exposes its embedded /$bunfs/root entry at argv[1] and its physical signed
-  // executable at process.execPath; Bun reports both as existing paths.
-  const runningEntry = argv1 ? resolveBunStandaloneEntry(argv1, execPath) : undefined;
-  if (runningEntry && fs.existsSync(runningEntry)) {
-    // The package's browser/computer entrypoints are sibling shims without a
-    // `daemon` command. A daemon started as their IPC side effect must launch
-    // through the main agents entrypoint instead of replaying the shim path.
-    const entryName = path.basename(runningEntry);
-    const compiledShim = /^(browser|computer)\.(c|m)?js$/.test(entryName);
-    const installedShim = /^(browser|computer)$/.test(entryName);
-    if (compiledShim || installedShim) {
-      const agentsEntry = path.join(path.dirname(runningEntry), compiledShim ? 'index.js' : 'agents');
-      if (!fs.existsSync(agentsEntry)) {
-        throw new Error(`Cannot start agents daemon: main CLI entry not found at ${agentsEntry}`);
-      }
-      return agentsEntry;
-    }
-    return runningEntry;
-  }
-  try {
-    return execFileSync('which', ['agents'], { encoding: 'utf-8' }).trim();
-  } catch {
-    return 'agents';
-  }
-}
+// Binary-resolution helpers (getAgentsBinPath / isNodeScriptEntry / getCliLaunch)
+// live in ./cli-entry.js — a leaf module the secrets broker also imports without
+// forming a cycle. Re-exported so existing `from './daemon.js'` importers of
+// getAgentsBinPath keep resolving.
+export { getAgentsBinPath };
 
 /**
  * Ask the service manager for the daemon's live PID. Used as a fallback when
@@ -987,46 +947,7 @@ export function buildDetachedDaemonEnv(
 export function getDaemonLaunch(agentsBin: string = getAgentsBinPath()): { command: string; args: string[] } {
   const { warnings } = validateDaemonBinary(agentsBin);
   for (const w of warnings) process.stderr.write(`[agents] ${w}\n`);
-  if (isNodeScriptEntry(agentsBin)) {
-    return { command: process.execPath, args: [agentsBin, 'daemon', '_run'] };
-  }
-  return { command: agentsBin, args: ['daemon', '_run'] };
-}
-
-/**
- * A daemon entry must be launched through the Node runtime when it is a Node
- * script — a `.js`/`.cjs`/`.mjs` file, OR a symlink/extension-less shim whose
- * shebang names `node`. Package installs link `bin/agents` to a `dist/index.js`
- * (a symlink) or drop an extension-less `#!/usr/bin/env node` shim, so an
- * extension check alone misses them and they get run directly. Executing such an
- * entry then relies on the shebang resolving `node` off the daemon's PATH — and
- * when that PATH points at a pruned nvm version (or an ancient system node), the
- * daemon crash-loops at import (`node:util` has no `styleText` on Node 18). A
- * real compiled binary (Mach-O/ELF/PE) has no `#!node` shebang, so it takes the
- * direct branch and owns its own runtime resolution.
- */
-function isNodeScriptEntry(agentsBin: string): boolean {
-  let resolved = agentsBin;
-  try {
-    resolved = fs.realpathSync(agentsBin);
-  } catch {
-    // Unresolvable (e.g. a template path that does not exist on this box): fall
-    // back to the extension check on the path as given.
-  }
-  if (/\.(c|m)?js$/.test(resolved)) return true;
-  try {
-    const fd = fs.openSync(resolved, 'r');
-    try {
-      const buf = Buffer.alloc(128);
-      const n = fs.readSync(fd, buf, 0, 128, 0);
-      const firstLine = buf.toString('utf-8', 0, n).split('\n', 1)[0];
-      return firstLine.startsWith('#!') && /\bnode\b/.test(firstLine);
-    } finally {
-      fs.closeSync(fd);
-    }
-  } catch {
-    return false;
-  }
+  return getCliLaunch(['daemon', '_run'], agentsBin);
 }
 
 /**
@@ -1059,11 +980,7 @@ export function getAgentsInvocation(
   subArgs: string[],
   agentsBin: string = getAgentsBinPath(),
 ): { command: string; args: string[] } {
-  const resolvedBin = resolveBunStandaloneEntry(agentsBin, process.execPath);
-  if (/\.(c|m)?js$/.test(resolvedBin)) {
-    return { command: process.execPath, args: [resolvedBin, ...subArgs] };
-  }
-  return { command: resolvedBin, args: subArgs };
+  return getCliLaunch(subArgs, agentsBin);
 }
 
 export function validateDaemonBinary(binPath: string): { warnings: string[] } {

--- a/apps/cli/src/lib/secrets/agent.ts
+++ b/apps/cli/src/lib/secrets/agent.ts
@@ -34,6 +34,7 @@ import { getHelpersDir, readMeta } from '../state.js';
 import { isAlive } from '../platform/process.js';
 import { getKeychainHelperPath } from './install-helper.js';
 import { getCliVersion, getCliVersionFresh } from '../version.js';
+import { getCliLaunch } from '../cli-entry.js';
 import type { SecretsBundle } from './bundles.js';
 
 /** Bumped when the wire protocol changes; a client that pings a mismatched
@@ -174,19 +175,18 @@ function writeAgentToken(): string {
 
 /**
  * Argv for re-invoking THIS cli with a hidden subcommand, so a side-by-side dev
- * build spawns its own helpers rather than the registry-installed one. We always
- * go through `process.execPath` (the node binary) with the JS entrypoint as the
- * first arg — the entrypoint isn't reliably executable in dev builds (invoked as
- * `node dist/index.js`, no +x), so spawning it directly EACCES'd.
+ * build spawns its own helpers rather than the registry-installed one. Routed
+ * through the shared getCliLaunch so it handles both install shapes — a JS entry
+ * (`node dist/index.js …`) and a Bun standalone binary (run directly). The old
+ * hand-rolled `[process.execPath, process.argv[1], …]` broke on standalone builds:
+ * process.argv[1] is the bun virtual entry `/$bunfs/root/agents` (fs.existsSync
+ * reports it as present), so it was passed as an argv element and the broker died
+ * with `unknown command '/$bunfs/root/agents'` — the daemon-hosted broker never
+ * bound its socket and every unlock reported "Could not start the secrets broker".
  */
 function cliSpawn(sub: string[]): { cmd: string; args: string[] } {
-  const argv1 = process.argv[1];
-  const entry = argv1 && fs.existsSync(argv1) ? argv1 : null;
-  if (entry) return { cmd: process.execPath, args: [entry, ...sub] };
-  // No resolvable entrypoint (unusual) — fall back to the PATH shim.
-  let bin = 'agents';
-  try { bin = execFileSync('which', ['agents'], { encoding: 'utf-8' }).trim(); } catch { /* default */ }
-  return { cmd: bin, args: sub };
+  const { command, args } = getCliLaunch(sub);
+  return { cmd: command, args };
 }
 
 function brokerSpawn(): { cmd: string; args: string[] } {

--- a/apps/cli/src/lib/share/capture.ts
+++ b/apps/cli/src/lib/share/capture.ts
@@ -106,7 +106,20 @@ export async function captureCover(htmlPath: string, timeoutMs = 15_000): Promis
   if (!fs.existsSync(abs)) return null;
   const fileUrl = `file://${abs.split('/').map(encodeURIComponent).join('/')}`;
 
-  for (const bin of candidateBrowsers()) {
+  const candidates = candidateBrowsers();
+  if (candidates.length === 0) {
+    // A silently-dropped cover reads as "the CLI decided this page needs none",
+    // when in fact no headless browser was found. Say so and point at the escape
+    // hatch instead of leaving the publish coverless with no explanation.
+    process.stderr.write(
+      '[agents share] no headless browser found for the OG cover — install Chrome/Chromium ' +
+        'or set AGENTS_SHARE_BROWSER=/path/to/chrome. Publishing without a preview image.\n',
+    );
+    return null;
+  }
+
+  let lastFailure = '';
+  for (const bin of candidates) {
     const outPng = path.join(os.tmpdir(), `agents-share-cover-${process.pid}-${Date.now()}.png`);
     const userDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-share-chrome-'));
     try {
@@ -136,13 +149,22 @@ export async function captureCover(htmlPath: string, timeoutMs = 15_000): Promis
         const buf = fs.readFileSync(outPng);
         // A valid PNG starts with the 8-byte signature; guard against 0-byte writes.
         if (buf.length > 8 && buf[0] === 0x89 && buf[1] === 0x50) return buf;
+        lastFailure = `${path.basename(bin)}: produced no valid PNG`;
+      } else {
+        lastFailure = `${path.basename(bin)}: no screenshot written`;
       }
-    } catch {
-      // try the next candidate
+    } catch (err) {
+      lastFailure = `${path.basename(bin)}: ${(err as Error).message}`;
     } finally {
       fs.rmSync(outPng, { force: true });
       fs.rmSync(userDir, { recursive: true, force: true });
     }
   }
+  // Every candidate ran but none yielded a cover — surface the last reason so a
+  // missing preview card is diagnosable (timeout, crash, bad binary) rather than silent.
+  process.stderr.write(
+    `[agents share] OG cover capture failed (${lastFailure || 'unknown error'}) — ` +
+      'publishing without a preview image. Set AGENTS_SHARE_BROWSER to override.\n',
+  );
   return null;
 }


### PR DESCRIPTION
## Two bugs, found while trying to `agents share` an HTML report on a machine running the signed standalone binary.

### 1. `agents secrets unlock` → "Could not start the secrets broker" (the real bug)

`cliSpawn` (`secrets/agent.ts`) built the broker relaunch as
`[process.execPath, process.argv[1], ...]`. On the **Bun standalone binary**
(`dist/bin/agents`, #315) `process.argv[1]` is the *virtual* embedded entry
`/$bunfs/root/agents`, which `fs.existsSync` reports as present — so it was passed
as an argv element and the broker child died with **`unknown command '/$bunfs/root/agents'`**.
The daemon-hosted broker never bound its socket, and every `agents secrets unlock`
reported *"Could not start the secrets broker."* (A one-off `agents share` fallback
spawn hit the same wall and hung.)

This is the exact failure the daemon already guards against — `getDaemonLaunch`
resolves the bunfs entry via `getAgentsBinPath` + `isNodeScriptEntry`. The broker
just wasn't using it.

**Fix:** extract the binary-resolution helpers into a leaf module `lib/cli-entry.ts`
(`getAgentsBinPath`, `isNodeScriptEntry`, `getCliLaunch`) so `secrets/agent.ts` can
reuse them without the `daemon.ts ↔ secrets/agent.ts` import cycle. `cliSpawn` now
routes through `getCliLaunch`, which resolves the bunfs virtual entry to the physical
executable and runs it directly. `getDaemonLaunch` **and** `getAgentsInvocation` (which
had a *separate*, weaker extension-only reimplementation) now both delegate to the one
`getCliLaunch` — three launch builders collapsed to one.

### 2. A dropped OG cover is silent (diagnosability)

`captureCover` returned `null` with zero output when no headless browser was found
or every candidate failed, so `agents share` published a coverless page with no hint
why. Now it writes a stderr line on both the no-candidate and all-candidates-failed
paths, naming the last failure and the `AGENTS_SHARE_BROWSER` override. Still never
throws — a cover stays a nice-to-have. (Logging-only; no unit test, since forcing zero
browsers on a machine with a Playwright Chromium in cache would be flaky ceremony.)

## Tests
- New `lib/cli-entry.test.ts` — locks `getCliLaunch`/`isNodeScriptEntry` across all
  three install shapes (JS entry, compiled binary, bunfs virtual entry), incl. the
  regression that the `$bunfs` path never lands in `command` or `args`.
- Existing `getAgentsInvocation` / `getDaemonLaunch` / `getAgentsBinPath` unit suites
  still green after the unification.
- `bun run build` (tsc) clean. The 3 daemon/broker **integration** tests that spawn a
  real daemon / need `tsx` fail identically on `origin/main` in this env (pre-existing,
  not from this change).

## Field note
This surfaced on a box whose global npm prefix points at Hermes' bundled Node
(`~/.hermes/node`), so `npm i -g` globals — including a stale agents-cli 1.20.65 —
land there and shadow on the daemon's PATH. That divergence made the broker crash-loop
*louder*, but the argv bug above is the root cause and is environment-independent.