### PR TITLE
feat(fork): `agents fork` to branch a session into a new independent copy

### DIFF
--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -224,6 +224,36 @@ cases a live pull can't reach: a machine that is **offline / asleep / decommissi
   on-demand `--host` reads and explicit export/import; reach for sync only when you want
   a passive always-on mirror (further below).
 
+## Forking (branch a conversation)
+
+`agents fork <session>` branches an existing conversation into a NEW, independent
+session. Where `resume` continues the *same* thread (same id, same file — it
+appends), `fork` copies the transcript under a fresh id, so continuing the fork
+diverges instead of mutating the original. It is the "git branch" of
+conversations — useful for exploring an alternative approach from a point you
+already reached, or fanning a promising session into two directions.
+
+```bash
+# Fork by (partial) id, then continue the copy — the original is untouched
+agents fork 4f3a9c21
+agents resume <new-id>
+
+# Name the fork
+agents fork 4f3a9c21 --name "try redis instead"
+```
+
+Mechanics (`lib/session/fork.ts`): a Claude session id *is* its `<id>.jsonl`
+filename, so a fork copies the transcript to a new-uuid file in the same
+directory, rewrites the embedded per-line `sessionId`, registers the new row via
+`upsertSession`, and labels it (`fork of <original>` by default, via the same
+run-name sidecar as `agents run --name`). The fork resolves immediately by
+`agents sessions` / `agents resume` and is version-pinned like any other session.
+
+Scope: v1 supports **Claude** (single-file transcript, native `--resume`). Codex
+(single-file) is a natural next step; multi-file agents (grok, kimi) and DB-only
+agents (opencode) need per-agent handling and are refused up front with a clear
+message.
+
 ## Export / Import (portable bundles)
 
 `agents sessions export` bundles selected sessions into a portable, self-describing

--- a/apps/cli/src/commands/fork.ts
+++ b/apps/cli/src/commands/fork.ts
@@ -1,0 +1,86 @@
+/**
+ * `agents fork <session>` — branch an existing conversation into a new,
+ * independent session you can continue separately. The original is untouched.
+ *
+ * Thin command layer; the copy/register logic lives in `lib/session/fork.ts`.
+ */
+import type { Command } from 'commander';
+import chalk from 'chalk';
+
+import { setHelpSections } from '../lib/help.js';
+import { findSessionsById } from '../lib/session/db.js';
+import { discoverSessions } from '../lib/session/discover.js';
+import { forkSession, isForkableAgent, FORKABLE_AGENTS } from '../lib/session/fork.js';
+
+interface ForkOptions {
+  name?: string;
+}
+
+/** Register the top-level `agents fork` command. */
+export function registerForkCommand(program: Command): void {
+  const cmd = program
+    .command('fork <session>')
+    .description('Branch a session into a new, independent copy you can continue separately. The original is untouched.')
+    .option('--name <label>', 'Label for the fork (default: "fork of <original>")');
+
+  setHelpSections(cmd, {
+    examples: `
+      # Fork a session by (partial) id, then continue the fork
+      agents fork 4f3a9c21
+      agents resume <new-id>
+
+      # Give the fork a name
+      agents fork 4f3a9c21 --name "try redis instead"
+    `,
+    notes: `
+      - 'resume' continues the SAME conversation; 'fork' copies it under a new id so the two diverge.
+      - The fork is a full copy of the conversation so far; continuing it never touches the original.
+      - Resolve the session the same way as resume: an exact or prefix id fragment.
+      - Currently supports: ${FORKABLE_AGENTS.join(', ')}. Other agents are a planned follow-up.
+    `,
+  });
+
+  cmd.action(async (sessionArg: string, options: ForkOptions) => {
+    // Resolve the source. Try the index first; only pay for a rescan if the id
+    // isn't found yet (mirrors the resume path's freshen-then-lookup).
+    let matches = findSessionsById(sessionArg, {});
+    if (matches.length === 0) {
+      await discoverSessions({});
+      matches = findSessionsById(sessionArg, {});
+    }
+
+    if (matches.length === 0) {
+      console.log(chalk.red(`No session matching "${sessionArg}".`));
+      console.log(chalk.gray('List candidates with: agents sessions'));
+      return;
+    }
+    if (matches.length > 1) {
+      console.log(chalk.yellow(`"${sessionArg}" is ambiguous — ${matches.length} sessions match. Use a longer id:`));
+      for (const m of matches.slice(0, 8)) {
+        console.log(chalk.gray(`  ${m.shortId}  ${m.agent}  ${m.label || m.topic || ''}`));
+      }
+      return;
+    }
+
+    const source = matches[0];
+
+    if (!isForkableAgent(source.agent)) {
+      console.log(chalk.yellow(`fork does not support ${source.agent} sessions yet.`));
+      console.log(chalk.gray(`  Supported: ${FORKABLE_AGENTS.join(', ')}.`));
+      return;
+    }
+
+    let result;
+    try {
+      result = forkSession(source, { name: options.name });
+    } catch (err) {
+      console.log(chalk.red(`Could not fork ${source.shortId}: ${(err as Error).message}`));
+      return;
+    }
+
+    console.log(chalk.green(`Forked ${source.shortId} -> ${result.shortId}`));
+    console.log(chalk.gray(`  Label:    ${result.label}`));
+    console.log(chalk.gray(`  Continue: agents resume ${result.shortId}`));
+    console.log(chalk.gray(`  Original ${source.shortId} is untouched.`));
+  });
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -95,6 +95,7 @@ import {
   loadRoutines,
   loadMonitors,
   loadRun,
+  loadFork,
   loadDefaults,
   loadModels,
   loadPrune,
@@ -823,6 +824,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadRoutines);
   await reg(loadMonitors);
   await reg(loadRun);
+  await reg(loadFork);
   await reg(loadDefaults);
   await reg(loadModels);
   await reg(loadPrune);

--- a/apps/cli/src/lib/session/__tests__/fork.test.ts
+++ b/apps/cli/src/lib/session/__tests__/fork.test.ts
@@ -1,0 +1,82 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Set HOME (and AGENTS_REAL_HOME) before db.js / fork.js load so their
+// module-level base dirs resolve inside an isolated temp HOME. Running
+// in-process under vitest uses the same node:sqlite driver as the real CLI
+// (a `bun --eval` subprocess would use bun:sqlite, which binds differently).
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'fork-test-'));
+process.env.HOME = TEST_HOME;
+process.env.AGENTS_REAL_HOME = TEST_HOME;
+
+const { forkSession } = await import('../fork.js');
+const { getSessionById } = await import('../db.js');
+type SessionMeta = import('../types.js').SessionMeta;
+
+afterAll(() => {
+  fs.rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+/** Write a Claude transcript under TEST_HOME and return its metadata. `tag`
+ *  is an 8-char prefix so the derived shortId is predictable. */
+function makeSource(tag: string): SessionMeta {
+  const id = `${tag}-2222-3333-4444-555555555555`;
+  const proj = path.join(TEST_HOME, '.claude', 'projects', '-tmp-x');
+  fs.mkdirSync(proj, { recursive: true });
+  const filePath = path.join(proj, `${id}.jsonl`);
+  fs.writeFileSync(filePath, [
+    JSON.stringify({ type: 'user', sessionId: id, cwd: '/tmp/x', message: { role: 'user', content: [{ type: 'text', text: 'hello world' }] } }),
+    JSON.stringify({ type: 'assistant', sessionId: id, message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] } }),
+  ].join('\n'));
+  return {
+    id, shortId: id.slice(0, 8), agent: 'claude',
+    timestamp: '2026-01-01T00:00:00.000Z', filePath, cwd: '/tmp/x',
+  };
+}
+
+describe('forkSession', () => {
+  it('copies the transcript under a new id, leaves the original untouched, and registers the fork', () => {
+    const source = makeSource('aaaaaaaa');
+    const res = forkSession(source, { now: '2026-07-18T00:00:00.000Z' });
+
+    const origAfter = fs.readFileSync(source.filePath, 'utf-8');
+    const forkContent = fs.readFileSync(res.filePath, 'utf-8');
+
+    // New file, named by the new id, beside the original.
+    expect(fs.existsSync(res.filePath)).toBe(true);
+    expect(path.basename(res.filePath)).toBe(`${res.newId}.jsonl`);
+    expect(path.dirname(res.filePath)).toBe(path.dirname(source.filePath));
+
+    // Original untouched.
+    expect(origAfter).toContain('hello world');
+    expect(origAfter).toContain(source.id);
+    expect(origAfter).not.toContain(res.newId);
+
+    // Fork is a copy with the embedded id rewritten.
+    expect(forkContent).toContain('hello world');
+    expect(forkContent).toContain(res.newId);
+    expect(forkContent).not.toContain(source.id);
+
+    // Registered in the index and resolvable immediately.
+    const row = getSessionById(res.newId);
+    expect(row).not.toBeNull();
+    expect(row!.filePath).toBe(res.filePath);
+    expect(res.label).toBe('fork of aaaaaaaa');
+    expect(row!.label).toBe('fork of aaaaaaaa');
+  });
+
+  it('honors an explicit --name label', () => {
+    const source = makeSource('bbbbbbbb');
+    const res = forkSession(source, { name: 'try redis instead' });
+    expect(res.label).toBe('try redis instead');
+    expect(getSessionById(res.newId)!.label).toBe('try redis instead');
+  });
+
+  it('throws when the source transcript is missing', () => {
+    const source = makeSource('cccccccc');
+    fs.rmSync(source.filePath);
+    expect(() => forkSession(source)).toThrow(/transcript not found/);
+  });
+});

--- a/apps/cli/src/lib/session/fork.ts
+++ b/apps/cli/src/lib/session/fork.ts
@@ -1,0 +1,123 @@
+/**
+ * Session forking — branch an existing conversation into a new, independent
+ * session that can be continued separately, leaving the original untouched.
+ *
+ * `resume` continues the SAME conversation (same id, same file — it appends).
+ * `fork` copies the transcript under a FRESH session id, so continuing the fork
+ * diverges from the original instead of mutating it. This is the "git branch"
+ * of conversations.
+ *
+ * v1 supports Claude, whose session id IS its `<id>.jsonl` filename and which
+ * resumes natively via `--resume`. A fork is therefore: copy the transcript to
+ * a new-uuid filename in the same directory, rewrite the embedded `sessionId`
+ * on each line, register the new session in the index, and label it. Other
+ * agents (codex single-file; grok/kimi multi-file; opencode DB-only) are a
+ * natural follow-up and are refused up front for now.
+ */
+import { randomUUID } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { SessionMeta } from './types.js';
+import { upsertSession } from './db.js';
+import { recordRunName } from './run-names.js';
+
+/** Agents that `fork` can branch today (see the module doc for why). */
+export const FORKABLE_AGENTS = ['claude'] as const;
+
+/** Whether a session's agent can be forked by {@link forkSession}. */
+export function isForkableAgent(agent: string): boolean {
+  return (FORKABLE_AGENTS as readonly string[]).includes(agent);
+}
+
+/** Outcome of a successful fork. */
+export interface ForkResult {
+  /** The new session's full id. */
+  newId: string;
+  /** The new session's short id (first 8 chars), for display/resume. */
+  shortId: string;
+  /** Absolute path of the copied transcript. */
+  filePath: string;
+  /** The label applied to the fork. */
+  label: string;
+}
+
+/**
+ * Rewrite the per-line `sessionId` field of a Claude JSONL transcript to a new
+ * id. Claude resolves a conversation by its filename, so this is belt-and-braces
+ * (keeps the in-file id consistent with the new filename); malformed lines are
+ * passed through untouched.
+ */
+function rewriteSessionId(transcript: string, newId: string): string {
+  return transcript
+    .split('\n')
+    .map((line) => {
+      if (!line.trim()) return line;
+      try {
+        const obj = JSON.parse(line) as Record<string, unknown>;
+        if (typeof obj.sessionId === 'string') {
+          obj.sessionId = newId;
+          return JSON.stringify(obj);
+        }
+        return line;
+      } catch {
+        return line;
+      }
+    })
+    .join('\n');
+}
+
+/**
+ * Fork a Claude session into a new, independent one.
+ *
+ * Copies `source.filePath` to a new `<uuid>.jsonl` beside it, rewrites the
+ * embedded session id, registers the new session in the index, and records a
+ * `--name`-style label. Returns the new ids/path. Throws if the source
+ * transcript is missing.
+ *
+ * @param source  The resolved metadata of the session being forked.
+ * @param opts.name  Optional explicit label; defaults to `fork of <original>`.
+ * @param now  ISO timestamp to stamp the fork with (injectable for tests).
+ */
+export function forkSession(source: SessionMeta, opts: { name?: string; now?: string } = {}): ForkResult {
+  if (!fs.existsSync(source.filePath)) {
+    throw new Error(`transcript not found for session ${source.shortId}: ${source.filePath}`);
+  }
+
+  const newId = randomUUID();
+  const shortId = newId.slice(0, 8);
+  const dir = path.dirname(source.filePath);
+  const filePath = path.join(dir, `${newId}.jsonl`);
+
+  const transcript = fs.readFileSync(source.filePath, 'utf-8');
+  const rewritten = rewriteSessionId(transcript, newId);
+  fs.writeFileSync(filePath, rewritten);
+
+  const original = source.label || source.topic || source.shortId;
+  const label = opts.name || `fork of ${original}`;
+
+  // Label sidecar (seeds the DB label; survives rescans until an agent title
+  // supersedes it), mirroring `agents run --name`.
+  recordRunName({ sessionId: newId, name: label, agent: source.agent, cwd: source.cwd });
+
+  // Register the new session so it resolves immediately (by `agents resume`,
+  // `agents sessions`, etc.) without waiting for the next scan.
+  const stamp = opts.now ?? new Date().toISOString();
+  const meta: SessionMeta = {
+    ...source,
+    id: newId,
+    shortId,
+    filePath,
+    label,
+    timestamp: stamp,
+    lastActivity: stamp,
+    // The fork has not opened its own PR / team; drop origin-specific refs.
+    prUrl: undefined,
+    prNumber: undefined,
+    teamOrigin: undefined,
+    spawnedTeam: undefined,
+  };
+  upsertSession(meta, rewritten);
+
+  return { newId, shortId, filePath, label };
+}

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -51,6 +51,7 @@ export const loadDaemon: ModuleLoader = async () => (await import('../../command
 export const loadRoutines: ModuleLoader = async () => (await import('../../commands/routines.js')).registerRoutinesCommands;
 export const loadMonitors: ModuleLoader = async () => (await import('../../commands/monitors.js')).registerMonitorsCommands;
 export const loadRun: ModuleLoader = async () => (await import('../../commands/exec.js')).registerRunCommand;
+export const loadFork: ModuleLoader = async () => (await import('../../commands/fork.js')).registerForkCommand;
 export const loadDefaults: ModuleLoader = async () => (await import('../../commands/defaults.js')).registerDefaultsCommands;
 export const loadModels: ModuleLoader = async () => (await import('../../commands/models.js')).registerModelsCommand;
 export const loadPrune: ModuleLoader = async () => (await import('../../commands/prune.js')).registerPruneCommand;
@@ -156,6 +157,7 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   routines: [loadRoutines],
   monitors: [loadMonitors],
   run: [loadRun],
+  fork: [loadFork],
   defaults: [loadDefaults],
   models: [loadModels],
   trash: [loadTrash],


### PR DESCRIPTION
## Problem

There's no way to *branch* a conversation. `agents resume` continues the **same** session in place (same id, same file — it appends), `worktree` manages git worktrees, and `split` is tmux panes — but nothing diverges a **copy** of a conversation. So you can't explore an alternative approach from a point you already reached without clobbering the original thread.

## What this adds

A top-level **`agents fork <session>`** — the "git branch" of conversations.

```bash
# Fork by (partial) id, then continue the copy — the original is untouched
agents fork 4f3a9c21
agents resume <new-id>

# Name the fork
agents fork 4f3a9c21 --name "try redis instead"
```

`resume` continues the same thread; `fork` copies it under a fresh id so the two diverge.

## How it works

A Claude session id **is** its `<id>.jsonl` filename, and Claude resumes natively via `--resume`. So `forkSession` (`lib/session/fork.ts`):
1. copies the transcript to a new-uuid file **in the same directory**,
2. rewrites the embedded per-line `sessionId` (belt-and-braces; the filename is what Claude resolves on),
3. registers the new session via `upsertSession` so it resolves **immediately** by `agents sessions` / `agents resume`,
4. labels it `fork of <original>` (or `--name`) via the same run-name sidecar as `agents run --name`.

The original transcript and its DB row are never modified.

## Scope

v1 supports **Claude** (single-file transcript, native `--resume`) — implemented, tested, and verified end-to-end. Codex (also single-file) is the natural next step; multi-file agents (grok, kimi) and DB-only agents (opencode) need per-agent handling and are **refused up front with a clear message** rather than silently mishandled — same "gate to what's actually supported" discipline as the sibling `--isolated` PR.

## Tests

In-process under vitest (**node:sqlite — the same driver as the real CLI**; a `bun --eval` subprocess would use `bun:sqlite`, which binds the `upsert` params differently and would not exercise the real path):
- copies under a new id, leaves the original untouched, rewrites the embedded id, registers the row, and applies the default `fork of <original>` label;
- `--name` override;
- missing source transcript throws.

Verified end-to-end against a real Claude transcript: `agents fork` produced a new `<uuid>.jsonl` beside the original, the original was byte-for-byte untouched, and both showed in `agents sessions --all` (original `build me a widget`, fork `try redis instead`).

## Registration

New `commands/fork.ts` + a loader in `command-registry.ts` (`COMMAND_LOADERS.fork`) + the eager list in `index.ts` — the standard 3-touch pattern. Docs added to `docs/05-sessions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)