### PR TITLE
fix(build): ssh.ts static package.json import breaks the standalone binary compile

### DIFF
--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -17,7 +17,7 @@ import * as os from 'os';
 import * as path from 'path';
 import chalk from 'chalk';
 import ora from 'ora';
-import packageJson from '../../package.json' with { type: 'json' };
+import { getCliVersion } from '../lib/version.js';
 import { readAndResolveBundleEnv, isHeadlessSecretsContext } from '../lib/secrets/bundles.js';
 import { machineId } from '../lib/session/sync/config.js';
 import {
@@ -304,7 +304,7 @@ function localHealthRow(self: string, stats?: DeviceStats): FleetHealthRow {
   return {
     name: self,
     platform: process.platform === 'darwin' ? 'macos' : process.platform,
-    version: packageJson.version,
+    version: getCliVersion(),
     stats,
     clis: checkAllClis(),
     sync: checkSyncStatus(process.cwd()),


### PR DESCRIPTION
## Release blocker — `main` cannot currently be released.

`scripts/release.sh` (dry-run and apply) aborts at **"CLI binary sign/notarize failed"**:

```
Building standalone binary (bun build --compile, arm64)...
error: Could not resolve: "../../package.json"
    at .../dist/bin/.compile-src/src/commands/ssh.ts:20:25
```

### Root cause
Commit `0dbacff1` ("Add fleet health status") added
`import packageJson from '../../package.json' with { type: 'json' }` to `ssh.ts`,
used only for `.version` in the fleet-health payload (`ssh.ts:307`).

`scripts/build-bin.sh` copies **only `src/`** into `dist/bin/.compile-src/` and
patches `index.ts` to read the version at runtime — it does not stage
`package.json`. So `bun build --compile` can't resolve the static
`../../package.json` import from `.compile-src/src/commands/ssh.ts`, and the release
dies before signing.

CI never runs `bun build --compile` (it's release-only, macOS-only — see
`apps/cli/CLAUDE.md`), so this shipped un-caught after `v1.20.67`. Every release
attempt since is blocked.

### Fix
Use the compile-safe `getCliVersion()` from `lib/version.js` (a runtime `fs` read
wrapped in try/catch — the same source `browser.ts` and the rest of the CLI use)
instead of a static package.json import. It was the **only** static
`import … from '…package.json'` in `src/`; the other package.json references are all
runtime `fs`/`URL` reads and compile fine.

### Verification
- `tsc --noEmit` clean.
- `bash scripts/build-bin.sh` → **`bun build --compile` succeeds** (69 MB arm64
  Mach-O produced) where it failed before.
- `./dist/bin/agents --version` → `1.20.67` (confirms `getCliVersion()` resolves the
  bundled package.json in the compiled binary, not `unknown`).

Unblocks cutting the next release (which also carries the secrets-broker fix from #1283).