### PR TITLE
fix(test): skip POSIX ssh-stub suite on Windows (unblocks release CI)

### DIFF
--- a/apps/cli/src/lib/ssh-exec.test.ts
+++ b/apps/cli/src/lib/ssh-exec.test.ts
@@ -100,7 +100,12 @@ describe('controlOpts (connection multiplexing)', () => {
   });
 });
 
-describe('sshExecAsync (real spawn via a PATH ssh stub — no mocks)', () => {
+// POSIX-only: the stub is a `#!/bin/sh` script, which Windows cannot exec (the
+// spawn produces no output — `expected '' to contain 'OUT_OK'`). The product code
+// (sshExecAsync) is cross-platform; only this shell-stub harness is not, so the
+// whole suite is skipped on Windows. The full Windows matrix runs only on release
+// PRs, so this surfaced there rather than on a normal PR to main.
+describe.skipIf(process.platform === 'win32')('sshExecAsync (real spawn via a PATH ssh stub — no mocks)', () => {
   // Put a genuine executable named `ssh` first on PATH so sshExecAsync's spawn('ssh')
   // runs it: a real subprocess round-trip that exercises stdout/stderr capture,
   // exit-code propagation, and the timeout -> SIGTERM path — the primitive the fleet


### PR DESCRIPTION
## Problem
The full cross-platform CI matrix (Windows) runs **only on release PRs**, and it fails on `build (windows-latest, 22/24)`:

- `ssh-exec.test.ts > sshExecAsync … > captures stdout/stderr …` → `AssertionError: expected '' to contain 'OUT_OK'`
- `… > does not crash on EPIPE …` → `expected false to be true`

Root cause: the suite's `withStubSsh` writes a `#!/bin/sh` script as the fake `ssh`, which **Windows cannot exec** — the spawn produces no output. This landed via the fleet-health work (`0dbacff1`, `6a62a96c`) and passed its normal PR to main (no Windows there), then blocked the v1.20.68 release PR.

## Fix
The product code (`sshExecAsync`) is cross-platform; only the shell-stub *harness* is POSIX. Guard the whole suite with `describe.skipIf(process.platform === 'win32')`. Non-Windows keeps full coverage (verified: 15/15 pass on macOS); Windows skips the 3 stub-dependent tests instead of failing.

## Verification
`npx vitest run src/lib/ssh-exec.test.ts` → 15 passed on macOS. Windows effect is self-evident (skipIf). The real proof is the next release PR's Windows matrix going green.