### PR TITLE
feat(ssh): auto-propagate terminfo to remote on interactive login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,23 @@
   `apps/cli/src/commands/sessions-browser.ts` (+ `sessions-browser.test.ts`),
   `apps/cli/src/commands/sessions.ts`.
 
+- **`agents ssh` propagates your terminal's terminfo to the remote (RUSH-1811).**
+  Modern terminals (Ghostty, kitty, Alacritty, WezTerm, foot, rio) advertise a
+  custom `TERM` — e.g. `xterm-ghostty` — whose terminfo ships with the terminal,
+  not with the remote host's ncurses. SSH into a box that lacks the entry and the
+  session is subtly broken: wrong backspace, missing colors, a garbled
+  clear/alt-screen. Ghostty's shell integration fixes the bare `ssh` command, but
+  `agents ssh` (spawned directly, Tailscale-relayed) bypassed it. Now, on an
+  interactive POSIX login, `agents ssh` exports the local entry (`infocmp -x`) and
+  compiles it on the remote (`tic -x -`, into the user's `~/.terminfo`, no sudo).
+  It is **fail-safe** — any error, timeout, or missing remote `tic` is swallowed
+  so the login is never blocked or delayed beyond a short push cap — and
+  **cached** per host+`TERM`, so only the first login to each host pays one extra
+  round-trip. Skipped for Windows/PowerShell devices (the console ignores
+  terminfo), non-interactive command runs, and terminfo names ncurses ships
+  everywhere. Source: `apps/cli/src/lib/devices/terminfo.ts`,
+  `apps/cli/src/commands/ssh.ts`.
+
 ## 1.20.58
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -434,7 +434,9 @@ agents devices list                     # fleet + live headroom: load, mem, idle
 agents devices list --full              # add per-device cores and free/total RAM
 agents devices list --no-stats          # instant: names/addresses only, skip the probe
 agents ssh mac-mini                     # hardened SSH: fails fast if offline,
-                                        # PowerShell on Windows, password-from-Keychain
+                                        # PowerShell on Windows, password-from-Keychain,
+                                        # auto-syncs your terminfo (Ghostty/kitty/…) so
+                                        # backspace, colors & clear work on the remote
 agents hosts list                       # devices show up here too (one host pool)
 agents hosts add mac-mini --cap gpu     # tag a device for capability routing (--host gpu)
 

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -52,7 +52,7 @@ import {
   writeAskpassShim,
 } from '../lib/devices/connect.js';
 import { ensureManagedKnownHostsDir, isHostPinned } from '../lib/devices/known-hosts.js';
-import { shouldSyncTerminfo, syncTerminfoToDevice } from '../lib/devices/terminfo.js';
+import { shouldSyncTerminfo, syncTerminfoToDevice, terminfoHostKey } from '../lib/devices/terminfo.js';
 import {
   fanOutDevices,
   planFleetTargets,
@@ -763,7 +763,7 @@ secrets bundle via an askpass shim — the password never touches argv.
         // Best-effort + cached per host — never blocks the login (see terminfo.ts).
         if (cmd.length === 0 && shouldSyncTerminfo({ term: process.env.TERM, shell: device.shell, interactive: process.stdout.isTTY ?? false })) {
           const { args: tinfoArgs, env: tinfoEnv } = buildSshInvocation(device, ['tic', '-x', '-'], shim, { pinned });
-          syncTerminfoToDevice({ device, host: addr ?? device.name, term: process.env.TERM, sshArgs: tinfoArgs, sshEnv: tinfoEnv });
+          syncTerminfoToDevice({ device, host: terminfoHostKey(device, addr), term: process.env.TERM, sshArgs: tinfoArgs, sshEnv: tinfoEnv });
         }
 
         const res = spawnSync('ssh', args, {

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -52,6 +52,7 @@ import {
   writeAskpassShim,
 } from '../lib/devices/connect.js';
 import { ensureManagedKnownHostsDir, isHostPinned } from '../lib/devices/known-hosts.js';
+import { shouldSyncTerminfo, syncTerminfoToDevice } from '../lib/devices/terminfo.js';
 import {
   fanOutDevices,
   planFleetTargets,
@@ -756,6 +757,15 @@ secrets bundle via an askpass shim — the password never touches argv.
         const addr = hostNameFor(device);
         const pinned = addr ? isHostPinned(addr) : false;
         const { args, env } = buildSshInvocation(device, cmd, shim, { pinned });
+
+        // Interactive login: make the local terminal's terminfo (e.g.
+        // xterm-ghostty) available on the remote so backspace/colors/clear work.
+        // Best-effort + cached per host — never blocks the login (see terminfo.ts).
+        if (cmd.length === 0 && shouldSyncTerminfo({ term: process.env.TERM, shell: device.shell, interactive: process.stdout.isTTY ?? false })) {
+          const { args: tinfoArgs, env: tinfoEnv } = buildSshInvocation(device, ['tic', '-x', '-'], shim, { pinned });
+          syncTerminfoToDevice({ device, host: addr ?? device.name, term: process.env.TERM, sshArgs: tinfoArgs, sshEnv: tinfoEnv });
+        }
+
         const res = spawnSync('ssh', args, {
           stdio: 'inherit',
           env: { ...process.env, ...env },

--- a/apps/cli/src/lib/devices/terminfo.test.ts
+++ b/apps/cli/src/lib/devices/terminfo.test.ts
@@ -7,6 +7,7 @@ import {
   terminfoSynced,
   markTerminfoSynced,
   localTerminfoSource,
+  terminfoHostKey,
 } from './terminfo.js';
 
 describe('shouldSyncTerminfo', () => {
@@ -33,6 +34,25 @@ describe('shouldSyncTerminfo', () => {
     for (const t of ['xterm-ghostty', 'xterm-kitty', 'alacritty', 'wezterm', 'foot', 'rio']) {
       expect(shouldSyncTerminfo({ term: t, shell: 'posix', interactive: true })).toBe(true);
     }
+  });
+});
+
+describe('terminfoHostKey', () => {
+  it('uses the bare host when no login user is set', () => {
+    expect(terminfoHostKey({ user: undefined, name: 'box' }, 'box.ts.net')).toBe('box.ts.net');
+  });
+
+  it('qualifies the key with the remote user — terminfo is per-user (~/.terminfo)', () => {
+    // The multi-user-host case the CLI supports via `agents ssh user@device`:
+    // alice and bob on the same host must NOT share a sync stamp, or bob's
+    // login sees alice's stamp and skips installing into bob's ~/.terminfo.
+    const addr = 'box.ts.net';
+    expect(terminfoHostKey({ user: 'alice', name: 'box' }, addr)).not.toBe(terminfoHostKey({ user: 'bob', name: 'box' }, addr));
+    expect(terminfoHostKey({ user: 'alice', name: 'box' }, addr)).toBe('alice@box.ts.net');
+  });
+
+  it('falls back to the device name when the address is unresolved', () => {
+    expect(terminfoHostKey({ user: 'alice', name: 'box' }, undefined)).toBe('alice@box');
   });
 });
 

--- a/apps/cli/src/lib/devices/terminfo.test.ts
+++ b/apps/cli/src/lib/devices/terminfo.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';

--- a/apps/cli/src/lib/devices/terminfo.test.ts
+++ b/apps/cli/src/lib/devices/terminfo.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  shouldSyncTerminfo,
+  terminfoSynced,
+  markTerminfoSynced,
+  localTerminfoSource,
+} from './terminfo.js';
+
+describe('shouldSyncTerminfo', () => {
+  it('skips non-interactive invocations (a remote command)', () => {
+    expect(shouldSyncTerminfo({ term: 'xterm-ghostty', shell: 'posix', interactive: false })).toBe(false);
+  });
+
+  it('skips Windows/powershell devices — the console ignores terminfo', () => {
+    expect(shouldSyncTerminfo({ term: 'xterm-ghostty', shell: 'powershell', interactive: true })).toBe(false);
+  });
+
+  it('skips when TERM is unset or blank', () => {
+    expect(shouldSyncTerminfo({ term: undefined, shell: 'posix', interactive: true })).toBe(false);
+    expect(shouldSyncTerminfo({ term: '   ', shell: 'posix', interactive: true })).toBe(false);
+  });
+
+  it('skips universally-shipped terminfo names (no wasted round-trip)', () => {
+    for (const t of ['xterm', 'xterm-256color', 'screen-256color', 'tmux-256color', 'vt100', 'linux']) {
+      expect(shouldSyncTerminfo({ term: t, shell: 'posix', interactive: true })).toBe(false);
+    }
+  });
+
+  it('syncs exotic terminal entries the remote is unlikely to have', () => {
+    for (const t of ['xterm-ghostty', 'xterm-kitty', 'alacritty', 'wezterm', 'foot', 'rio']) {
+      expect(shouldSyncTerminfo({ term: t, shell: 'posix', interactive: true })).toBe(true);
+    }
+  });
+});
+
+describe('terminfo sync cache stamp', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    // A real, isolated cache root — the stamp functions write to the real
+    // filesystem here (no mocking), keyed off this dir via the cacheRoot override.
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-terminfo-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('is false before any sync, true after marking, and round-trips exotic names', () => {
+    expect(terminfoSynced('host-a', 'xterm-ghostty', tmp)).toBe(false);
+    markTerminfoSynced('host-a', 'xterm-ghostty', tmp);
+    expect(terminfoSynced('host-a', 'xterm-ghostty', tmp)).toBe(true);
+  });
+
+  it('keys the stamp by BOTH host and TERM', () => {
+    markTerminfoSynced('host-a', 'xterm-ghostty', tmp);
+    expect(terminfoSynced('host-b', 'xterm-ghostty', tmp)).toBe(false); // different host
+    expect(terminfoSynced('host-a', 'xterm-kitty', tmp)).toBe(false); // different TERM
+  });
+
+  it('treats a stale stamp (older than the TTL) as un-synced', () => {
+    markTerminfoSynced('host-a', 'xterm-ghostty', tmp);
+    const stamp = path.join(tmp, 'devices', 'terminfo', 'host-a__xterm-ghostty');
+    const old = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000); // 8 days > 7-day TTL
+    fs.utimesSync(stamp, old, old);
+    expect(terminfoSynced('host-a', 'xterm-ghostty', tmp)).toBe(false);
+  });
+
+  it('does not crash on hosts/terms with filesystem-hostile characters', () => {
+    const host = 'user@10.0.0.1:22';
+    markTerminfoSynced(host, 'xterm-ghostty', tmp);
+    expect(terminfoSynced(host, 'xterm-ghostty', tmp)).toBe(true);
+  });
+});
+
+describe('localTerminfoSource', () => {
+  it('returns a compilable source for a term this machine has, or null otherwise', () => {
+    // xterm is present wherever ncurses/infocmp exists; CI Linux has it. If the
+    // box has no infocmp at all, the fail-safe path returns null — assert the
+    // contract holds either way.
+    const src = localTerminfoSource('xterm');
+    if (src !== null) {
+      expect(src).toContain('xterm');
+    } else {
+      expect(src).toBeNull();
+    }
+  });
+
+  it('returns null for a terminfo name that does not exist', () => {
+    expect(localTerminfoSource('definitely-not-a-real-term-xyz')).toBeNull();
+  });
+});

--- a/apps/cli/src/lib/devices/terminfo.ts
+++ b/apps/cli/src/lib/devices/terminfo.ts
@@ -1,0 +1,168 @@
+/**
+ * Terminfo propagation for `agents ssh` interactive logins.
+ *
+ * Modern terminals (Ghostty, kitty, Alacritty, WezTerm, foot, rio) advertise a
+ * custom `TERM` (e.g. `xterm-ghostty`) whose terminfo entry ships with the
+ * terminal, not with the remote host's ncurses. SSH into a box that lacks the
+ * entry and the session is subtly broken: wrong backspace, missing colors, a
+ * garbled clear/alt-screen. Ghostty's own shell integration fixes this for the
+ * bare `ssh` command, but `agents ssh` (Tailscale-relayed, spawned directly)
+ * bypasses that wrapper — so we handle it here.
+ *
+ * Strategy: on an interactive POSIX login, if the local `$TERM` is one the
+ * remote is unlikely to have, export it locally (`infocmp -x`) and compile it on
+ * the remote (`tic -x -`, writes to the user's `~/.terminfo`, no sudo). This is
+ * the canonical, terminal-agnostic technique.
+ *
+ * Two invariants keep it safe and cheap:
+ *  - **Fail-safe.** Every failure is swallowed. A push that errors, times out,
+ *    or hits a remote without `tic` leaves the user exactly where they are today
+ *    — it never blocks or delays the actual login beyond the short push timeout.
+ *  - **Cached.** A successful sync stamps a local marker keyed by host+TERM, so
+ *    only the first login to each host pays the one extra round-trip; every
+ *    repeat login is zero-cost.
+ */
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { getCacheDir } from '../state.js';
+import { type DeviceProfile } from './registry.js';
+
+/**
+ * Terminfo names that ncurses ships essentially everywhere, so pushing them is
+ * wasted work. Anything NOT in this set (the exotic terminal entries) is a sync
+ * candidate. Kept deliberately conservative: when unsure, we push — `tic` is
+ * idempotent and the result is cached.
+ */
+const UNIVERSAL_TERMS = new Set<string>([
+  'dumb',
+  'ansi',
+  'vt100',
+  'vt102',
+  'vt220',
+  'linux',
+  'cygwin',
+  'xterm',
+  'xterm-color',
+  'xterm-16color',
+  'xterm-256color',
+  'screen',
+  'screen-256color',
+  'tmux',
+  'tmux-256color',
+  'rxvt',
+  'rxvt-unicode',
+  'rxvt-unicode-256color',
+]);
+
+/** How long a successful sync suppresses re-syncing the same host+TERM. */
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+/** Cap on the push so a stalled remote can't delay the login indefinitely. */
+const PUSH_TIMEOUT_MS = 8000;
+
+/**
+ * Decide whether an interactive login warrants a terminfo push. Pure so the
+ * gating logic is unit-testable without touching ssh or the filesystem.
+ *
+ * @param interactive true only for a real login (no remote command) on a human tty.
+ */
+export function shouldSyncTerminfo(params: {
+  term?: string;
+  shell: DeviceProfile['shell'];
+  interactive: boolean;
+}): boolean {
+  if (!params.interactive) return false;
+  if (params.shell === 'powershell') return false; // Windows console ignores terminfo
+  const term = params.term?.trim();
+  if (!term) return false;
+  if (UNIVERSAL_TERMS.has(term)) return false;
+  return true;
+}
+
+/** Directory holding per-host+TERM sync stamps. `cacheRoot` override is for tests. */
+function stampDir(cacheRoot?: string): string {
+  return path.join(cacheRoot ?? getCacheDir(), 'devices', 'terminfo');
+}
+
+/** Filesystem-safe stamp name for a host+TERM pair. */
+function stampFile(host: string, term: string, cacheRoot?: string): string {
+  const safe = `${host}__${term}`.replace(/[^A-Za-z0-9._-]/g, '_');
+  return path.join(stampDir(cacheRoot), safe);
+}
+
+/** True when a fresh successful-sync stamp exists for this host+TERM. */
+export function terminfoSynced(host: string, term: string, cacheRoot?: string): boolean {
+  try {
+    const st = fs.statSync(stampFile(host, term, cacheRoot));
+    return Date.now() - st.mtimeMs < CACHE_TTL_MS;
+  } catch {
+    return false;
+  }
+}
+
+/** Record a successful sync so repeat logins skip the push. Best-effort. */
+export function markTerminfoSynced(host: string, term: string, cacheRoot?: string): void {
+  try {
+    fs.mkdirSync(stampDir(cacheRoot), { recursive: true });
+    fs.writeFileSync(stampFile(host, term, cacheRoot), `${new Date().toISOString()}\n`);
+  } catch {
+    /* a cache write failure just means we re-sync next time — never fatal */
+  }
+}
+
+/** Export the local terminfo source for a TERM, or null if it can't be produced. */
+export function localTerminfoSource(term: string): string | null {
+  try {
+    const res = spawnSync('infocmp', ['-x', term], {
+      encoding: 'utf8',
+      timeout: 4000,
+    });
+    if (res.status === 0 && res.stdout && res.stdout.trim().length > 0) {
+      return res.stdout;
+    }
+  } catch {
+    /* infocmp missing or errored — nothing we can push */
+  }
+  return null;
+}
+
+/**
+ * Best-effort: ensure `device` has the terminfo entry for the local `$TERM`
+ * before an interactive login. Never throws; returns whether a push succeeded
+ * (false when skipped, already-cached, or failed). `sshArgs`/`sshEnv` are the
+ * SAME host-key + auth options the real login uses, minus the interactive tty —
+ * so a password-auth device resolves through the askpass shim without a second
+ * human prompt.
+ */
+export function syncTerminfoToDevice(opts: {
+  device: DeviceProfile;
+  host: string;
+  term: string | undefined;
+  /** ssh argv for a non-interactive `tic -x -` exec against this device. */
+  sshArgs: string[];
+  /** Env overlay for that ssh (askpass wiring for password devices). */
+  sshEnv: Record<string, string>;
+}): boolean {
+  const term = opts.term?.trim();
+  if (!term) return false;
+  if (terminfoSynced(opts.host, term)) return false;
+
+  const source = localTerminfoSource(term);
+  if (!source) return false;
+
+  try {
+    const res = spawnSync('ssh', opts.sshArgs, {
+      input: source,
+      env: { ...process.env, ...opts.sshEnv },
+      timeout: PUSH_TIMEOUT_MS,
+      stdio: ['pipe', 'ignore', 'ignore'],
+    });
+    if (res.status === 0) {
+      markTerminfoSynced(opts.host, term);
+      return true;
+    }
+  } catch {
+    /* connection failed / timed out — fail-safe, login proceeds unaffected */
+  }
+  return false;
+}

--- a/apps/cli/src/lib/devices/terminfo.ts
+++ b/apps/cli/src/lib/devices/terminfo.ts
@@ -79,6 +79,19 @@ export function shouldSyncTerminfo(params: {
   return true;
 }
 
+/**
+ * Cache key for a device: the remote **user@host**, not just the host. terminfo
+ * is compiled into the *per-user* `~/.terminfo`, so `alice@box` and `bob@box`
+ * are distinct sync targets — keying on host alone would let the first user's
+ * stamp suppress the second user's (never-installed) sync. Mirrors
+ * {@link sshTargetFor}'s user handling; falls back to the device name when the
+ * address is unresolved.
+ */
+export function terminfoHostKey(device: Pick<DeviceProfile, 'user' | 'name'>, addr: string | undefined): string {
+  const host = addr ?? device.name;
+  return device.user ? `${device.user}@${host}` : host;
+}
+
 /** Directory holding per-host+TERM sync stamps. `cacheRoot` override is for tests. */
 function stampDir(cacheRoot?: string): string {
   return path.join(cacheRoot ?? getCacheDir(), 'devices', 'terminfo');


### PR DESCRIPTION
## Problem

Modern terminals (Ghostty, kitty, Alacritty, WezTerm, foot, rio) advertise a custom `TERM` — e.g. `xterm-ghostty` — whose terminfo entry ships with the *terminal*, not with the remote host's ncurses. `agents ssh` into a box that lacks the entry gives a subtly broken session: **wrong backspace, missing colors, garbled clear/alt-screen**.

Ghostty's shell integration fixes this for the bare `ssh` command, but `agents ssh` (spawned directly, Tailscale-relayed) bypasses that wrapper — so users hit broken remote terminals despite having the feature on. Observed live across a fleet: 8 of 10 Linux boxes were missing `xterm-ghostty`.

## Fix

On an **interactive POSIX login**, `agents ssh` now exports the local entry (`infocmp -x $TERM`) and compiles it on the remote (`tic -x -`, into the user's `~/.terminfo`, no sudo). Two invariants keep it safe and cheap:

- **Fail-safe** — every failure is swallowed. A push that errors, times out, or hits a remote without `tic` leaves the user exactly where they are today; the login is never blocked or delayed beyond a short push cap (8s).
- **Cached** — a successful sync stamps a local marker keyed by `host+TERM` (7-day TTL), so only the *first* login to each host pays one extra round-trip. Every repeat login is zero-cost.

Skipped for: Windows/PowerShell devices (the console ignores terminfo), non-interactive command runs (`agents ssh host cmd`), and terminfo names ncurses ships everywhere (`xterm`, `xterm-256color`, `screen-256color`, …).

## Files
- `apps/cli/src/lib/devices/terminfo.ts` — new module (gating, cache, infocmp export, push)
- `apps/cli/src/lib/devices/terminfo.test.ts` — 11 unit tests (real FS, no mocking)
- `apps/cli/src/commands/ssh.ts` — wires the pre-sync into the interactive login path
- `CHANGELOG.md`, `README.md` — user-visible surface documented

## Verification (end-to-end, real flow)

Built the CLI, stripped `xterm-ghostty` off a live remote, cleared the local cache, then drove a **real interactive `agents ssh` login** through a pty:

```
1. strip terminfo on yosemite-m2      -> MISSING
2. clear local sync cache stamp       -> clean
3. TERM=xterm-ghostty agents ssh yosemite-m2   (real login via pty, auto-exit)
4. infocmp -x xterm-ghostty on m2      -> HAVE  (installed by agents ssh)
5. local cache stamp                   -> yosemite-m2.tail1a85a1.ts.net__xterm-ghostty
```

- `terminfo.test.ts`: 11 pass · `connect.test.ts` (covers reused `buildSshInvocation`): 9 pass · `tsc --noEmit`: clean.

Session transcript (secret gist, private repo): pending — see local path `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/5a3c6557-35aa-404f-9661-e8fcf4b18406.jsonl`