### PR TITLE
docs(changelog): add fragment for agents fork (#1286)

### DIFF
--- a/apps/cli/.changelog/next/session-fork.md
+++ b/apps/cli/.changelog/next/session-fork.md
@@ -1,0 +1,6 @@
+- **`agents fork` — branch a session into a new independent copy.** Copies a Claude
+  session transcript to a fresh session id (rewriting only the `sessionId` field so the
+  per-message uuid chain stays intact) beside the original, then registers it so it
+  resumes independently from the same cwd and version — the original is left untouched.
+  `--name` labels the fork. Source: `apps/cli/src/lib/session/fork.ts`,
+  `apps/cli/src/commands/fork.ts`.


### PR DESCRIPTION
Adds the missing `.changelog/next/` fragment for `agents fork`, merged in #1286. The fork PR came from a fork and didn't include a changelog note; per `.changelog/next/README.md` every user-visible PR drops one fragment, so this backfills it to keep the generated `CHANGELOG.md` complete at the next release.

No code change — one doc fragment.