### PR TITLE
feat: add safe trailing-at account picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,17 @@
 
 ### Added
 
+- **`agents run <agent>@` now opens a safe per-run account picker.** The picker
+  shows one row per installed version with account identity, exact version,
+  login state, plan, and available session/weekly/monthly capacity. Logged-out,
+  rate-limited, and out-of-credit rows stay visible but cannot be selected;
+  signed-in rows without provider quota data remain selectable and say `limits
+  unavailable`. The selected version is pinned for that run only. Ambiguous
+  combinations (`--resume`, strategy overrides, leases, remote hosts, profiles,
+  and workflows) fail before dispatch. Source:
+  `apps/cli/src/commands/run-account-picker.ts`,
+  `apps/cli/src/commands/exec.ts`, `apps/cli/src/lib/rotate.ts`.
+
 - **Routine `meta.json` now includes `duration` and `errorMessage` (RUSH-1281).**
   `RunMeta` records wall-clock `duration` in milliseconds and a machine-readable
   `errorMessage` on failure paths (spawn errors, timeouts, loop errors, host-reconcile

--- a/README.md
+++ b/README.md
@@ -151,9 +151,17 @@ agents run claude "refactor auth module" --mode edit --fallback codex,gemini
 ```bash
 # Picks the signed-in account you haven't used recently.
 agents run claude "summarize recent commits" --strategy balanced
+
+# Or choose one account/version interactively for only this run.
+agents run claude@
+agents run codex@ "review this branch"
 ```
 
 `--strategy balanced` spreads work across available versions of the same agent -- useful when you have multiple accounts and want to avoid burning through one.
+
+A trailing `@` opens an account picker before either an interactive or prompt-based run. Each installed version shows its account identity, exact version, login state, plan, and every available session, weekly, or monthly limit. Logged-out, rate-limited, and out-of-credit accounts remain visible with the reason they cannot be selected; signed-in accounts whose provider does not expose quota data stay selectable and say `limits unavailable`. The choice pins only that run and does not change your default version.
+
+Account selection is available for Claude, Codex, Gemini, Grok, Antigravity, Kimi, Droid, and OpenCode. It requires a terminal and cannot be combined with `--resume`, `--strategy`/`--balanced`, `--lease`, or `--host`/`--device`; profiles and workflows must use their concrete host agent instead.
 
 ### Chain agents
 

--- a/apps/cli/.changelog/next/account-picker.md
+++ b/apps/cli/.changelog/next/account-picker.md
@@ -1,0 +1,7 @@
+- **Choose a safe account with `agents run <agent>@`.** A trailing `@` opens a
+  per-run picker showing each installed version's account identity, login state,
+  plan, and available session/weekly/monthly capacity. Logged-out, rate-limited,
+  and out-of-credit accounts remain visible but disabled; signed-in accounts
+  without quota data remain selectable and say `limits unavailable`. Source:
+  `apps/cli/src/commands/run-account-picker.ts`,
+  `apps/cli/src/commands/exec.ts`, `apps/cli/src/lib/rotate.ts`.

--- a/apps/cli/src/commands/exec.test.ts
+++ b/apps/cli/src/commands/exec.test.ts
@@ -19,10 +19,44 @@ import { describe, expect, it } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { decideCopyCredsGate } from './exec.js';
+import {
+  decideCopyCredsGate,
+  parseRunAccountPickerRequest,
+  runAccountPickerConflicts,
+} from './exec.js';
 import { isHostPinned, recordScannedKeys } from '../lib/devices/known-hosts.js';
 
 const KEY = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI0000000000000000000000000000000000000000000';
+
+describe('trailing-@ account picker request', () => {
+  it('distinguishes a terminal picker marker from a concrete version pin', () => {
+    expect(parseRunAccountPickerRequest('claude@')).toEqual({
+      requested: true,
+      normalizedAgentSpec: 'claude',
+      valid: true,
+    });
+    expect(parseRunAccountPickerRequest('claude@2.1.207')).toEqual({
+      requested: false,
+      normalizedAgentSpec: 'claude@2.1.207',
+      valid: true,
+    });
+    expect(parseRunAccountPickerRequest('claude@@')).toMatchObject({
+      requested: true,
+      valid: false,
+    });
+  });
+
+  it('fails loud for every routing option that would override the selected account', () => {
+    expect(runAccountPickerConflicts({
+      resume: true,
+      strategy: 'balanced',
+      balanced: true,
+      lease: true,
+      device: 'yosemite-s0',
+    })).toEqual(['--resume', '--strategy', '--balanced', '--lease', '--host/--device']);
+    expect(runAccountPickerConflicts({})).toEqual([]);
+  });
+});
 
 /** A fresh, empty managed store in a temp dir; caller cleans up. */
 function mkStore(): { dir: string; file: string } {

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -82,6 +82,43 @@ interface ExecCommandActionOptions {
   allowExpired?: boolean; // --allow-expired: skip expiry pre-run abort for secrets
 }
 
+export interface RunAccountPickerRequest {
+  requested: boolean;
+  normalizedAgentSpec: string;
+  valid: boolean;
+}
+
+/** Distinguish a terminal account-picker marker from an explicit @version pin. */
+export function parseRunAccountPickerRequest(agentSpec: string): RunAccountPickerRequest {
+  const requested = agentSpec.endsWith('@');
+  const normalizedAgentSpec = requested ? agentSpec.slice(0, -1) : agentSpec;
+  return {
+    requested,
+    normalizedAgentSpec,
+    valid: !requested || (!!normalizedAgentSpec && !normalizedAgentSpec.includes('@')),
+  };
+}
+
+/** Return every option whose routing semantics conflict with a local account choice. */
+export function runAccountPickerConflicts(options: {
+  resume?: string | boolean;
+  strategy?: string;
+  balanced?: boolean;
+  lease?: string | boolean;
+  host?: string;
+  device?: string;
+  on?: string;
+  computer?: string;
+}): string[] {
+  const conflicts: string[] = [];
+  if (options.resume !== undefined) conflicts.push('--resume');
+  if (options.strategy !== undefined) conflicts.push('--strategy');
+  if (options.balanced) conflicts.push('--balanced');
+  if (options.lease) conflicts.push('--lease');
+  if (options.host || options.device || options.on || options.computer) conflicts.push('--host/--device');
+  return conflicts;
+}
+
 /** Type guard that narrows a string to a known AgentId. */
 function isValidAgent(agent: string): agent is AgentId {
   return agent in AGENTS;
@@ -506,6 +543,9 @@ export function registerRunCommand(program: Command): void {
       # Interactive (TUI) with the pinned default version
       agents run claude
 
+      # Pick a signed-in account/version for only this run
+      agents run claude@
+
       # Pipe JSON events to a parser (--quiet drops the preamble)
       agents run claude "..." --json --quiet | jq
 
@@ -540,6 +580,10 @@ export function registerRunCommand(program: Command): void {
         A version/account is skipped when it is rate-limited right now — any usage window (incl. the 5-hour session window) at 100%, matching the 'agents view' badge.
         --balanced is shorthand for --strategy balanced. Ignored when @version is pinned, when a profile is used, or with --fallback.
 
+      Account picker: append @ with no version (agents run claude@) to choose one
+        installed account for this run. Rows show identity, login state, plan,
+        and available limits; unsafe accounts stay visible but disabled.
+
       Fallback: --fallback codex,gemini retries on rate-limit failure via /continue handoff. Each entry accepts @version.
 
       Resume: --resume <id> continues a prior conversation (full or partial id; omit to pick interactively). claude/codex resume natively; others replay via a /continue first message. Add a prompt to continue headlessly.
@@ -572,6 +616,27 @@ export function registerRunCommand(program: Command): void {
         prompt = undefined;
       }
 
+      // A trailing @ is an explicit request to choose one installed account.
+      // Strip only that terminal marker; concrete agent@version pins retain
+      // their existing meaning in every dispatch path below.
+      const accountPicker = parseRunAccountPickerRequest(agentSpec);
+      const accountPickerRequested = accountPicker.requested;
+      const normalizedAgentSpec = accountPicker.normalizedAgentSpec;
+      if (!accountPicker.valid) {
+        console.error(chalk.red(`Invalid account picker target: ${agentSpec}. Use agents run <agent>@.`));
+        process.exit(1);
+      }
+      if (accountPickerRequested) {
+        const conflicts = runAccountPickerConflicts(options);
+        if (conflicts.length > 0) {
+          console.error(chalk.red(
+            `Account selection with ${agentSpec} cannot be combined with ${conflicts.join(', ')}. ` +
+            'Pick the account locally, or use an explicit agent@version target.',
+          ));
+          process.exit(1);
+        }
+      }
+
       // --lease: invent a disposable cloud box for this run (via crabbox), run
       // the agent there, then tear it down. Unlike --host, nothing is registered.
       if (options.lease) {
@@ -598,7 +663,7 @@ export function registerRunCommand(program: Command): void {
         const { getConfiguredRunStrategy, resolveRunVersion } = await import('../lib/rotate.js');
 
         const detected = await detectSignedInRuntimes();
-        const agentName = agentSpec.split('@')[0];
+        const agentName = normalizedAgentSpec.split('@')[0];
         const leaseCwd = options.cwd ?? process.cwd();
 
         // `--lease` requires a prompt (guarded above), so it is headless by
@@ -793,7 +858,7 @@ export function registerRunCommand(program: Command): void {
           throw e;
         }
         try {
-          const [runAgent, rawRunVersion] = agentSpec.split('@');
+          const [runAgent, rawRunVersion] = normalizedAgentSpec.split('@');
           // Forward the explicit @version pin verbatim. Resolving aliases like
           // @latest locally would check local installs, but the remote host may
           // have versions the laptop does not. The remote agents CLI resolves
@@ -1109,7 +1174,7 @@ export function registerRunCommand(program: Command): void {
 
       const [
         { buildExecCommand, parseExecEnv, execAgent, runWithFallback, normalizeMode, resolveMode, headlessPlanStallCommand, nativeResume, resolveInteractive },
-        { ALL_AGENT_IDS },
+        { ALL_AGENT_IDS, ACCOUNT_INSPECTION_AGENT_IDS, agentLabel, supportsAccountInspection },
         { profileExists, resolveProfileForRun },
         { readAndResolveBundleEnv, describeBundle, assertRemoteBundleFlagsUnsupported, isHeadlessSecretsContext },
         { splitBundleRef, resolveSshTarget, remoteResolveEnv },
@@ -1137,7 +1202,7 @@ export function registerRunCommand(program: Command): void {
       const isValidAgent = (agent: string): agent is AgentId => ALL_AGENT_IDS.includes(agent as AgentId);
 
       // Parse agent@version
-      const [rawAgent, rawVersion] = agentSpec.split('@');
+      const [rawAgent, rawVersion] = normalizedAgentSpec.split('@');
       let agent: AgentId;
       let version: string | undefined = rawVersion || undefined;
       let profileEnv: Record<string, string> | undefined;
@@ -1165,6 +1230,21 @@ export function registerRunCommand(program: Command): void {
       // degenerates to a no-op ("I'll wait for the completion notification").
       let workflowHasSubagents = false;
       const cwd = options.cwd ?? process.cwd();
+
+      if (accountPickerRequested && !isValidAgent(rawAgent)) {
+        if (profileExists(rawAgent)) {
+          console.error(chalk.red(
+            `Account selection is not available for profile '${rawAgent}'. Run its concrete host agent with @ instead.`,
+          ));
+          process.exit(1);
+        }
+        if (resolveWorkflowRef(rawAgent, cwd)) {
+          console.error(chalk.red(
+            `Account selection is not available for workflow '${rawAgent}'. Run a concrete agent with @ instead.`,
+          ));
+          process.exit(1);
+        }
+      }
 
       if (isValidAgent(rawAgent)) {
         agent = rawAgent;
@@ -1396,6 +1476,33 @@ export function registerRunCommand(program: Command): void {
         }
       }
 
+      if (accountPickerRequested) {
+        if (!supportsAccountInspection(agent)) {
+          console.error(chalk.red(
+            `${agentLabel(agent)} does not expose local account state, so agents-cli cannot safely select an account.`,
+          ));
+          console.error(chalk.gray(
+            `Supported account pickers: ${ACCOUNT_INSPECTION_AGENT_IDS.join(', ')}`,
+          ));
+          process.exit(1);
+        }
+        try {
+          const { pickRunAccountCandidate } = await import('./run-account-picker.js');
+          const selected = await pickRunAccountCandidate(agent);
+          if (!selected) return;
+          version = selected.version;
+          if (!options.quiet) {
+            const identity = selected.accountLabel || 'signed-in account';
+            process.stderr.write(chalk.gray(
+              `[agents] selected ${identity} · ${agent}@${selected.version} for this run\n`,
+            ));
+          }
+        } catch (err) {
+          console.error(chalk.red((err as Error).message));
+          process.exit(1);
+        }
+      }
+
       version = resolveVersionAlias(agent, version);
 
       // --resume: resolve a prior conversation and rewrite the run target to
@@ -1524,7 +1631,7 @@ export function registerRunCommand(program: Command): void {
       // the bare primary still resolves through the strategy — otherwise every
       // `agents run claude --fallback codex` run lands on the pinned default
       // account and account rotation silently stops (the gh-monitor heal bug).
-      if (strategy !== 'pinned' || options.balanced || explicitStrategy) {
+      if (!accountPickerRequested && (strategy !== 'pinned' || options.balanced || explicitStrategy)) {
         if (version) {
           process.stderr.write(chalk.yellow(`[agents] strategy ${strategy} ignored: version ${version} is pinned\n`));
         } else if (fromProfile) {
@@ -1602,7 +1709,7 @@ export function registerRunCommand(program: Command): void {
           json: options.json,
           quiet: options.quiet,
           authCheckDisabled: options.authCheck === false || process.env.AGENTS_NO_AUTH_CHECK === '1',
-          rotated: !!rotationResult,
+          rotated: !!rotationResult || accountPickerRequested,
         });
         if (preflight) {
           try {

--- a/apps/cli/src/commands/run-account-picker.test.ts
+++ b/apps/cli/src/commands/run-account-picker.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import type { RotateCandidate } from '../lib/rotate.js';
+import type { UsageSnapshot, UsageWindowKey } from '../lib/usage.js';
+import { buildRunAccountChoices, formatAccountLimits } from './run-account-picker.js';
+
+function snapshot(windows: Array<[UsageWindowKey, number]>, plan: string | null = null): UsageSnapshot {
+  return {
+    source: 'live',
+    sourceLabel: 'live',
+    capturedAt: null,
+    plan,
+    windows: windows.map(([key, usedPercent]) => ({
+      key,
+      label: key,
+      shortLabel: key,
+      usedPercent,
+      resetsAt: null,
+      windowMinutes: null,
+    })),
+  };
+}
+
+function candidate(overrides: Partial<RotateCandidate> = {}): RotateCandidate {
+  return {
+    agent: 'claude',
+    version: '2.1.0',
+    accountKey: 'claude:account=one',
+    accountLabel: 'one@example.com',
+    email: 'one@example.com',
+    usageKey: 'claude:org=one',
+    usageStatus: 'available',
+    usageSnapshot: snapshot([['session', 25], ['week', 60], ['month', 90]]),
+    usageError: null,
+    plan: 'Max',
+    signedIn: true,
+    lastActive: null,
+    ...overrides,
+  };
+}
+
+describe('formatAccountLimits', () => {
+  it('shows remaining session, weekly, and monthly capacity in human terms', () => {
+    expect(formatAccountLimits(candidate())).toBe(
+      'Session 75% left · Week 40% left · Month 10% left',
+    );
+  });
+
+  it('states when signed-in usage data is unavailable instead of implying zero use', () => {
+    expect(formatAccountLimits(candidate({ usageSnapshot: null, usageError: 'unavailable' })))
+      .toBe('limits unavailable');
+  });
+});
+
+describe('buildRunAccountChoices', () => {
+  it('puts usable accounts first and shows identity, exact version, login, plan, and limits', () => {
+    const choices = buildRunAccountChoices([
+      candidate({
+        version: '2.0.0',
+        accountLabel: '',
+        email: null,
+        signedIn: false,
+        usageSnapshot: null,
+      }),
+      candidate({ version: '2.1.0' }),
+    ], '2.1.0');
+
+    expect(choices[0].ready).toBe(true);
+    expect(choices[0].name).toContain('one@example.com');
+    expect(choices[0].name).toContain('2.1.0 (default)');
+    expect(choices[0].name).toContain('logged in');
+    expect(choices[0].name).toContain('Max');
+    expect(choices[0].name).toContain('Session 75% left');
+    expect(choices[1]).toMatchObject({ ready: false, disabled: 'logged out' });
+    expect(choices[1].name).toContain('logged out');
+  });
+
+  it('disables exhausted accounts with the exact blocking windows', () => {
+    const [choice] = buildRunAccountChoices([
+      candidate({ usageSnapshot: snapshot([['session', 100], ['week', 100]]) }),
+    ], null);
+    expect(choice).toMatchObject({
+      ready: false,
+      disabled: 'Session and Week limits reached',
+    });
+    expect(choice.name).toContain('Session exhausted');
+    expect(choice.name).toContain('Week exhausted');
+  });
+
+  it('keeps a signed-in account selectable when quota data is unavailable', () => {
+    const [choice] = buildRunAccountChoices([
+      candidate({ usageSnapshot: null, usageError: 'network unavailable' }),
+    ], null);
+    expect(choice.ready).toBe(true);
+    expect(choice.disabled).toBeUndefined();
+    expect(choice.name).toContain('limits unavailable');
+  });
+
+  it('does not disable a usable account solely because the Sonnet sub-limit is exhausted', () => {
+    const [choice] = buildRunAccountChoices([
+      candidate({ usageSnapshot: snapshot([['session', 20], ['week', 30], ['sonnet_week', 100]]) }),
+    ], null);
+    expect(choice.ready).toBe(true);
+    expect(choice.name).toContain('Sonnet week exhausted');
+  });
+
+  it('uses a usage-reported plan when the credential has no plan claim', () => {
+    const [choice] = buildRunAccountChoices([
+      candidate({ plan: null, usageSnapshot: snapshot([['session', 10]], 'Team') }),
+    ], null);
+    expect(choice.name).toContain('Team');
+  });
+});

--- a/apps/cli/src/commands/run-account-picker.ts
+++ b/apps/cli/src/commands/run-account-picker.ts
@@ -1,0 +1,152 @@
+import { select } from '@inquirer/prompts';
+import type { AgentId } from '../lib/types.js';
+import { agentLabel } from '../lib/agents.js';
+import {
+  collectRunCandidates,
+  readinessFromCandidate,
+  type RotateCandidate,
+} from '../lib/rotate.js';
+import { compareVersions, getGlobalDefault } from '../lib/versions.js';
+import { isInteractiveTerminal, isPromptCancelled, requireInteractiveSelection } from './utils.js';
+
+const CANCEL_SELECTION = '__agents_cancel_account_selection__';
+
+export interface RunAccountChoice {
+  name: string;
+  value: string;
+  disabled?: string;
+  ready: boolean;
+}
+
+const WINDOW_ORDER = ['session', 'week', 'sonnet_week', 'month'] as const;
+const WINDOW_LABELS = {
+  session: 'Session',
+  week: 'Week',
+  sonnet_week: 'Sonnet week',
+  month: 'Month',
+} as const;
+
+function formatPercent(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}
+
+/** Human-readable remaining capacity for every window the provider exposes. */
+export function formatAccountLimits(candidate: RotateCandidate): string {
+  const windows = candidate.usageSnapshot?.windows;
+  if (!windows || windows.length === 0) return 'limits unavailable';
+
+  return [...windows]
+    .sort((a, b) => WINDOW_ORDER.indexOf(a.key) - WINDOW_ORDER.indexOf(b.key))
+    .map((window) => {
+      const left = Math.max(0, 100 - window.usedPercent);
+      return left === 0
+        ? `${WINDOW_LABELS[window.key]} exhausted`
+        : `${WINDOW_LABELS[window.key]} ${formatPercent(left)}% left`;
+    })
+    .join(' · ');
+}
+
+function disabledReason(candidate: RotateCandidate): string | undefined {
+  const readiness = readinessFromCandidate(candidate);
+  if (readiness.ready) return undefined;
+  if (readiness.reason === 'signed_out') return 'logged out';
+  if (readiness.reason === 'out_of_credits') return 'out of credits';
+
+  const windows = candidate.usageSnapshot?.windows ?? [];
+  const blocking = windows.filter((window) => window.key !== 'sonnet_week');
+  const considered = blocking.length > 0 ? blocking : windows;
+  const exhausted = considered
+    .filter((window) => window.usedPercent >= 100)
+    .map((window) => WINDOW_LABELS[window.key]);
+  return exhausted.length > 0
+    ? `${exhausted.join(' and ')} ${exhausted.length === 1 ? 'limit' : 'limits'} reached`
+    : 'rate limit reached';
+}
+
+/** Build aligned picker rows with usable accounts first and unsafe rows disabled. */
+export function buildRunAccountChoices(
+  candidates: RotateCandidate[],
+  globalDefault: string | null,
+): RunAccountChoice[] {
+  const rows = candidates.map((candidate) => {
+    const disabled = disabledReason(candidate);
+    const version = candidate.version === globalDefault
+      ? `${candidate.version} (default)`
+      : candidate.version;
+    return {
+      candidate,
+      account: candidate.accountLabel || 'account unavailable',
+      version,
+      status: candidate.signedIn ? 'logged in' : 'logged out',
+      plan: candidate.usageSnapshot?.plan ?? candidate.plan ?? 'plan unavailable',
+      limits: formatAccountLimits(candidate),
+      disabled,
+      ready: disabled === undefined,
+    };
+  });
+
+  rows.sort((a, b) => {
+    if (a.ready !== b.ready) return a.ready ? -1 : 1;
+    const aDefault = a.candidate.version === globalDefault;
+    const bDefault = b.candidate.version === globalDefault;
+    if (aDefault !== bDefault) return aDefault ? -1 : 1;
+    return compareVersions(b.candidate.version, a.candidate.version);
+  });
+
+  const accountWidth = Math.max(0, ...rows.map((row) => row.account.length));
+  const versionWidth = Math.max(0, ...rows.map((row) => row.version.length));
+  const statusWidth = Math.max(0, ...rows.map((row) => row.status.length));
+  const planWidth = Math.max(0, ...rows.map((row) => row.plan.length));
+
+  return rows.map((row) => ({
+    name: [
+      row.account.padEnd(accountWidth),
+      row.version.padEnd(versionWidth),
+      row.status.padEnd(statusWidth),
+      row.plan.padEnd(planWidth),
+      row.limits,
+    ].join('  '),
+    value: row.candidate.version,
+    disabled: row.disabled,
+    ready: row.ready,
+  }));
+}
+
+/** Prompt for one safe installed account/version. A cancelled picker launches nothing. */
+export async function pickRunAccountCandidate(agent: AgentId): Promise<RotateCandidate | null> {
+  if (!isInteractiveTerminal()) {
+    requireInteractiveSelection(`Selecting a ${agentLabel(agent)} account`, [
+      `agents run ${agent}@<version>`,
+      `agents view ${agent}`,
+    ]);
+  }
+
+  const candidates = await collectRunCandidates(agent);
+  if (candidates.length === 0) {
+    throw new Error(`No installed ${agentLabel(agent)} versions are available. Run: agents add ${agent}@latest`);
+  }
+
+  const choices = buildRunAccountChoices(candidates, getGlobalDefault(agent));
+  const hasReadyAccount = choices.some((choice) => choice.ready);
+  const promptChoices = choices.map(({ ready: _ready, ...choice }) => choice);
+  if (!hasReadyAccount) {
+    promptChoices.push({
+      name: 'No usable accounts — cancel',
+      value: CANCEL_SELECTION,
+    });
+  }
+
+  try {
+    const version = await select({
+      message: `Select a ${agentLabel(agent)} account for this run:`,
+      choices: promptChoices,
+      loop: false,
+    });
+    if (version === CANCEL_SELECTION) return null;
+    return candidates.find((candidate) => candidate.version === version) ?? null;
+  } catch (err) {
+    if (isPromptCancelled(err)) return null;
+    throw err;
+  }
+}

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -18,7 +18,7 @@ import * as yaml from 'yaml';
 import {
   AGENTS,
   ALL_AGENT_IDS,
-  accountOrgBadge,
+  accountDisplayLabel,
   getAllCliStates,
   getAccountInfo,
   resolveAgentName,
@@ -83,37 +83,8 @@ import { confirm } from '@inquirer/prompts';
 import { formatPath, isInteractiveTerminal, isPromptCancelled } from './utils.js';
 import { terminalWidth, truncateToWidth, stringWidth } from '../lib/session/width.js';
 
-// Shown in the email column for agents that are signed in but expose no email
-// address locally (Antigravity stores an opaque OAuth grant with no identity).
-const SIGNED_IN_LABEL = 'signed in';
-
-/**
- * Text for the account (email) column. Prefers the real email; otherwise, for a
- * signed-in agent whose credential carries no email but does carry an opaque
- * account id (Kimi's user_id), show `id:<user_id>` so distinct accounts read
- * distinctly instead of a generic "signed in". Falls back to "signed in" when we
- * have neither (Antigravity), and empty when signed out.
- *
- * When the account carries a Claude organizationType, the org badge is appended
- * — "email (Turing Labs · Team)" — so two installs signed into the same email
- * under different orgs (personal Max vs a Team seat) read distinctly. The
- * suffix is plain text inside the label so the existing column-width pass
- * measures and pads it for free.
- */
-export function accountColumnLabel(
-  info?: Pick<
-    AccountInfo,
-    'email' | 'accountId' | 'signedIn' | 'organizationType' | 'organizationName'
-  > | null
-): string {
-  if (!info) return '';
-  if (info.email) {
-    const badge = accountOrgBadge(info);
-    return badge ? `${info.email} (${badge})` : info.email;
-  }
-  if (info.signedIn) return info.accountId ? `id:${info.accountId}` : SIGNED_IN_LABEL;
-  return '';
-}
+/** Shared account identity formatter, re-exported for the view-specific tests. */
+export const accountColumnLabel = accountDisplayLabel;
 
 /**
  * Group profile summaries by their host harness, optionally filtered to a

--- a/apps/cli/src/lib/__tests__/rotate.test.ts
+++ b/apps/cli/src/lib/__tests__/rotate.test.ts
@@ -63,11 +63,15 @@ function cand(overrides: Partial<RotateCandidate>): RotateCandidate {
   return {
     agent: 'claude',
     version: '0.0.0',
+    accountKey: null,
+    accountLabel: 'a@b.com',
     email: 'a@b.com',
     usageKey: null,
     usageStatus: 'available',
     usageSnapshot: null,
-    authValid: true,
+    usageError: null,
+    plan: 'Max',
+    signedIn: true,
     lastActive: new Date('2026-01-01T00:00:00Z'),
     ...overrides,
   };
@@ -76,8 +80,8 @@ function cand(overrides: Partial<RotateCandidate>): RotateCandidate {
 describe('pickBalancedCandidate', () => {
   it('returns null when nothing is signed in', () => {
     const result = pickBalancedCandidate([
-      cand({ version: '1.0.0', email: null }),
-      cand({ version: '2.0.0', email: null }),
+      cand({ version: '1.0.0', email: null, signedIn: false }),
+      cand({ version: '2.0.0', email: null, signedIn: false }),
     ]);
     expect(result).toBeNull();
   });
@@ -115,22 +119,34 @@ describe('pickBalancedCandidate', () => {
 
   it('excludes not-signed-in versions (fresh installs with no auth)', () => {
     const healthy = cand({ version: '2.1.113' });
-    const notAuthed = cand({ version: '2.1.120', email: null, lastActive: null });
+    const notAuthed = cand({ version: '2.1.120', email: null, signedIn: false, lastActive: null });
 
     const result = pickBalancedCandidate([healthy, notAuthed]);
     expect(result!.picked.version).toBe('2.1.113');
     expect(result!.excluded).toHaveLength(1);
   });
 
-  it('excludes accounts with invalid auth tokens', () => {
+  it('excludes accounts whose credential is not signed in', () => {
     const valid = cand({ version: '2.1.110', lastActive: new Date('2026-04-20T10:00:00Z') });
-    const expired = cand({ version: '2.1.112', authValid: false, lastActive: new Date('2026-04-15T00:00:00Z') });
+    const expired = cand({ version: '2.1.112', signedIn: false, lastActive: new Date('2026-04-15T00:00:00Z') });
 
     const result = pickBalancedCandidate([valid, expired]);
     expect(result!.picked.version).toBe('2.1.110');
     expect(result!.healthy).toHaveLength(1);
     expect(result!.excluded).toHaveLength(1);
     expect(result!.excluded[0].version).toBe('2.1.112');
+  });
+
+  it('keeps an opaque signed-in account eligible when it has no email claim', () => {
+    const opaque = cand({
+      agent: 'kimi',
+      version: '1.0.0',
+      accountKey: 'kimi:user=opaque-123',
+      accountLabel: 'id:opaque-123',
+      email: null,
+      signedIn: true,
+    });
+    expect(pickBalancedCandidate([opaque])?.picked.version).toBe('1.0.0');
   });
 
   it('excludes rate-limited accounts from selection', () => {

--- a/apps/cli/src/lib/__tests__/runner.test.ts
+++ b/apps/cli/src/lib/__tests__/runner.test.ts
@@ -238,11 +238,15 @@ describe('credit/rate-limit detect + failover chain composition (RUSH-1016)', ()
   function candidate(over: Partial<RotateCandidate> & { version: string }): RotateCandidate {
     return {
       agent: 'claude',
+      accountKey: `claude:account=${over.version}`,
+      accountLabel: `${over.version}@example.com`,
       email: `${over.version}@example.com`,
       usageKey: `claude:org=${over.version}`,
       usageStatus: 'available',
       usageSnapshot: null,
-      authValid: true,
+      usageError: null,
+      plan: 'Max',
+      signedIn: true,
       lastActive: null,
       ...over,
     };

--- a/apps/cli/src/lib/agents.test.ts
+++ b/apps/cli/src/lib/agents.test.ts
@@ -7,6 +7,7 @@ import { spawnSync } from 'child_process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   AGENTS,
+  ACCOUNT_INSPECTION_AGENT_IDS,
   ALL_AGENT_IDS,
   __resetAntigravityKeychainCacheForTest,
   accountOrgBadge,
@@ -16,12 +17,32 @@ import {
   getAccountInfo,
   resolveAgentName,
   resolveLastActive,
+  supportsAccountInspection,
   warnAgentDeprecated,
 } from './agents.js';
 import { IS_WINDOWS, execFileShellSpec } from './platform/index.js';
 import type { CapabilityName } from './types.js';
 
 const tempDirs: string[] = [];
+
+describe('account inspection support', () => {
+  it('matches the credential formats getAccountInfo can inspect safely', () => {
+    expect(ACCOUNT_INSPECTION_AGENT_IDS).toEqual([
+      'claude',
+      'codex',
+      'gemini',
+      'grok',
+      'antigravity',
+      'kimi',
+      'droid',
+      'opencode',
+    ]);
+    for (const agent of ACCOUNT_INSPECTION_AGENT_IDS) {
+      expect(supportsAccountInspection(agent)).toBe(true);
+    }
+    expect(supportsAccountInspection('amp')).toBe(false);
+  });
+});
 
 function makeTempDir(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-agents-'));

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -1071,6 +1071,45 @@ export function accountOrgBadge(
   return null;
 }
 
+/** Agents whose local credential formats expose enough state for account selection. */
+export const ACCOUNT_INSPECTION_AGENT_IDS = [
+  'claude',
+  'codex',
+  'gemini',
+  'grok',
+  'antigravity',
+  'kimi',
+  'droid',
+  'opencode',
+] as const satisfies readonly AgentId[];
+
+const ACCOUNT_INSPECTION_AGENTS = new Set<AgentId>(ACCOUNT_INSPECTION_AGENT_IDS);
+
+/** Whether agents-cli can determine this agent's per-version sign-in state. */
+export function supportsAccountInspection(agentId: AgentId): boolean {
+  return ACCOUNT_INSPECTION_AGENTS.has(agentId);
+}
+
+/**
+ * Human-readable account identity shared by every account-aware surface.
+ * Prefer email, append a multi-seat Claude organization name when present,
+ * then fall back to a non-secret account id or a generic signed-in label.
+ */
+export function accountDisplayLabel(
+  info?: Pick<
+    AccountInfo,
+    'email' | 'accountId' | 'signedIn' | 'organizationType' | 'organizationName'
+  > | null
+): string {
+  if (!info) return '';
+  if (info.email) {
+    const badge = accountOrgBadge(info);
+    return badge ? `${info.email} (${badge})` : info.email;
+  }
+  if (info.signedIn) return info.accountId ? `id:${info.accountId}` : 'signed in';
+  return '';
+}
+
 /** Return the email address associated with the agent's auth config, or null. */
 export async function getAccountEmail(
   agentId: AgentId,

--- a/apps/cli/src/lib/rotate.test.ts
+++ b/apps/cli/src/lib/rotate.test.ts
@@ -16,18 +16,22 @@ import { runWithFallback } from './exec.js';
 import type { UsageSnapshot, UsageWindowKey } from './usage.js';
 
 /**
- * Build a healthy RotateCandidate (email present, auth valid, no live snapshot
+ * Build a healthy RotateCandidate (signed in, no live snapshot
  * => treated as full capacity). Pass overrides — e.g. `usageStatus:
  * 'rate_limited'` — to make it unhealthy.
  */
 function candidate(over: Partial<RotateCandidate> & { version: string }): RotateCandidate {
   return {
     agent: 'claude',
+    accountKey: `claude:account=${over.version}`,
+    accountLabel: `${over.version}@example.com`,
     email: `${over.version}@example.com`,
     usageKey: `claude:org=${over.version}`,
     usageStatus: 'available',
     usageSnapshot: null,
-    authValid: true,
+    usageError: null,
+    plan: 'Max',
+    signedIn: true,
     lastActive: null,
     ...over,
   };
@@ -328,15 +332,15 @@ describe('readinessFromCandidate (pre-flight warning for version-pinned teammate
     expect(readinessFromCandidate(c)).toEqual({ ready: true });
   });
 
-  it('no email => not ready, reason signed_out (before any usage check)', () => {
+  it('opaque signed-in credential without an email remains ready', () => {
     expect(
       readinessFromCandidate(candidate({ version: '1.0.0', email: null })),
-    ).toEqual({ ready: false, reason: 'signed_out', email: null });
+    ).toEqual({ ready: true });
   });
 
-  it('invalid auth => not ready, reason signed_out even with usage headroom', () => {
+  it('signed-out credential is rejected even with usage headroom', () => {
     expect(
-      readinessFromCandidate(candidate({ version: '1.0.0', authValid: false })),
+      readinessFromCandidate(candidate({ version: '1.0.0', signedIn: false })),
     ).toEqual({ ready: false, reason: 'signed_out', email: '1.0.0@example.com' });
   });
 });

--- a/apps/cli/src/lib/rotate.ts
+++ b/apps/cli/src/lib/rotate.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { AgentId, RunStrategy } from './types.js';
 import type { FallbackEntry } from './exec.js';
-import { getAccountInfo, type AccountInfo } from './agents.js';
+import { accountDisplayLabel, getAccountInfo, type AccountInfo } from './agents.js';
 import { readMeta, writeMeta, getHelpersDir } from './state.js';
 import { listInstalledVersions, getVersionHomePath, resolveVersion } from './versions.js';
 import { getProjectRunConfigs } from './run-config.js';
@@ -30,6 +30,8 @@ function getRotateDir(): string {
 export interface RotateCandidate {
   agent: AgentId;
   version: string;
+  accountKey: string | null;
+  accountLabel: string;
   email: string | null;
   /**
    * Per-org usage/quota key (e.g. `claude:org=<orgUuid>`) — the unit rate
@@ -40,7 +42,9 @@ export interface RotateCandidate {
   usageKey: string | null;
   usageStatus: AccountInfo['usageStatus'];
   usageSnapshot: UsageSnapshot | null;
-  authValid: boolean;
+  usageError: string | null;
+  plan: string | null;
+  signedIn: boolean;
   lastActive: Date | null;
 }
 
@@ -103,15 +107,11 @@ export function setGlobalRunStrategy(agent: AgentId, strategy: RunStrategy): voi
 }
 
 function isRotationEligible(candidate: RotateCandidate): boolean {
-  return !!candidate.email
-    && candidate.authValid
-    && hasUsageAvailable(candidate);
+  return candidate.signedIn && hasUsageAvailable(candidate);
 }
 
 function isAvailableEligible(candidate: RotateCandidate): boolean {
-  return !!candidate.email
-    && candidate.authValid
-    && hasUsageAvailable(candidate);
+  return isRotationEligible(candidate);
 }
 
 function hasUsageAvailable(candidate: RotateCandidate): boolean {
@@ -138,7 +138,7 @@ function hasUsageAvailable(candidate: RotateCandidate): boolean {
 
 /**
  * Whether a specific account can serve a run right now, and — when it can't —
- * why. `signed_out` covers no-email / invalid-auth; `rate_limited` and
+ * why. `signed_out` covers a missing usable credential; `rate_limited` and
  * `out_of_credits` name the throttle. Used to pre-warn on a version-pinned
  * teammate whose account rotation won't route around (a pin IS the target).
  */
@@ -148,7 +148,7 @@ export type AccountReadiness =
 
 /**
  * Pure decision reusing the router's own eligibility gate (`hasUsageAvailable`
- * + email/auth, i.e. `isRotationEligible`), so a pre-flight warning can NEVER
+ * + canonical signed-in state, i.e. `isRotationEligible`), so a pre-flight warning can NEVER
  * disagree with what rotation would actually do. The `reason` combines the two
  * signals `hasUsageAvailable` reads: the live snapshot (session-inclusive
  * rate-limit) and the coarse cached `usageStatus` (out-of-credits, which a
@@ -157,7 +157,7 @@ export type AccountReadiness =
  * reported while the account is actually serving requests.
  */
 export function readinessFromCandidate(candidate: RotateCandidate): AccountReadiness {
-  if (!candidate.email || !candidate.authValid) {
+  if (!candidate.signedIn) {
     return { ready: false, reason: 'signed_out', email: candidate.email };
   }
   if (hasUsageAvailable(candidate)) {
@@ -217,7 +217,7 @@ function compareCandidates(a: RotateCandidate, b: RotateCandidate): number {
  * key; fall back to email only when no usage identity is available.
  */
 function candidateIdentity(c: RotateCandidate): string {
-  return c.usageKey ?? c.email!;
+  return c.usageKey ?? c.accountKey ?? c.email ?? `${c.agent}@${c.version}`;
 }
 
 function dedupeAndSortCandidates(candidates: RotateCandidate[]): RotateCandidate[] {
@@ -246,17 +246,16 @@ function dedupeAndSortCandidates(candidates: RotateCandidate[]): RotateCandidate
  * headroom, with no stampede on the lowest-usage one. Stateless — parallel
  * callers naturally fan out via the random roll.
  *
- * Eligibility: signed in (email present), auth valid, and not currently
+ * Eligibility: signed in according to AccountInfo and not currently
  * rate-limited — no blocking window (session OR weekly) at 100%, matching the
  * `agents view` badge; or the local cached status is usable when no live
  * snapshot exists. Note the split: eligibility considers the session window
  * (a session-maxed account can't run now), but the capacity *weight* above is
  * driven by weekly headroom so a brief session spike doesn't distort routing.
  *
- * Dedupe: when multiple versions share an email, collapse to one candidate
- * per email (the least-recently-active version). Prevents two parallel pods
- * from "balancing" to different versions but hitting the same Anthropic
- * account and both 429ing.
+ * Dedupe: when multiple versions share a usage/account identity, collapse to
+ * one candidate (the least-recently-active version). The org-scoped usage key
+ * wins over email so same-email personal and Team accounts remain distinct.
  *
  * Returns null if no candidate is eligible — callers fall back to the pinned
  * version so behavior stays predictable.
@@ -340,13 +339,12 @@ export function pickAvailableCandidate(
   return { picked: preferred ?? sorted[0], healthy: sorted, excluded };
 }
 
-async function collectRunCandidates(agent: AgentId): Promise<RotateCandidate[]> {
+export async function collectRunCandidates(agent: AgentId): Promise<RotateCandidate[]> {
   const versions = listInstalledVersions(agent);
   const rows = await Promise.all(
     versions.map(async (version) => {
       const home = getVersionHomePath(agent, version);
       const info = await getAccountInfo(agent, home);
-      // `info.email` (from .claude.json's oauthAccount) is the auth heuristic.
       // We used to additionally call isClaudeAuthValid(home), which reads
       // "Claude Code-credentials-<hash>" from the system keychain. That item is
       // written by Claude Code itself with its own process in the ACL, so our
@@ -354,15 +352,17 @@ async function collectRunCandidates(agent: AgentId): Promise<RotateCandidate[]> 
       // one per installed version, every time `agents run` cold-starts. If
       // claude's stored token has actually expired, the spawned agent detects
       // it at its own startup and re-auths; that's the correct UX.
-      const authValid = info.email != null;
       return {
         agent,
         version,
         home,
         info,
+        accountKey: info.accountKey,
+        accountLabel: accountDisplayLabel(info),
         email: info.email,
         usageStatus: info.usageStatus,
-        authValid,
+        plan: info.plan,
+        signedIn: info.signedIn,
         lastActive: info.lastActive,
       };
     })
@@ -379,10 +379,13 @@ async function collectRunCandidates(agent: AgentId): Promise<RotateCandidate[]> 
 
   return rows.map(({ home: _home, info, ...candidate }) => {
     const usageKey = getUsageLookupKey(info);
-    const usageSnapshot = usageKey
-      ? usageByKey.get(usageKey)?.snapshot ?? null
-      : null;
-    return { ...candidate, usageKey, usageSnapshot };
+    const usage = usageKey ? usageByKey.get(usageKey) : undefined;
+    return {
+      ...candidate,
+      usageKey,
+      usageSnapshot: usage?.snapshot ?? null,
+      usageError: usage?.error ?? null,
+    };
   });
 }
 


### PR DESCRIPTION
## Outcome

`agents run <agent>@` now opens a per-run account picker for both interactive and prompt-based runs. Each installed version shows account identity, exact version, login state, plan, and every quota window the provider exposes.

- Logged-out, rate-limited, and out-of-credit rows remain visible but disabled.
- Signed-in rows without quota data remain selectable and say `limits unavailable`.
- The selected version is pinned only for this run; defaults and normal balancing are unchanged.
- Ambiguous routes fail before dispatch: resume, strategy overrides, leases, remote hosts, profiles, workflows, and agents without account inspection.
- Account inspection is supported for Claude, Codex, Gemini, Grok, Antigravity, Kimi, Droid, and OpenCode.

## Installed-artifact acceptance

Installed dev artifact: `0.0.0-dev.ea3c72c5f`

```text
? Select a Claude account for this run:
❯ account-a  2.1.170 (default)  logged in  Max  Session 70% left · Week 82% left
  account-b  2.1.207            logged in  Max  Session 88% left · Week 72% left
  account-c  2.1.187            logged in  Max  Session 96% left · Week 70% left
  account-d  2.1.181            logged in  Max  Session 84% left · Week 56% left

Selected: account-c · claude@2.1.187
Running: ~/.agents/.cache/shims/claude@2.1.187 --permission-mode plan --version
2.1.187 (Claude Code)
```

## Verification

- `bun run build` — clean TypeScript/build output.
- Focused regression suite — `7` files, `152/152` tests passed.
- Installed CLI conflict probes verified non-TTY, unsupported-agent, and strategy-conflict failures before dispatch.
- Broader local suite — `456` files passed and `6` skipped; `6,046` tests passed and `77` skipped. Its remaining `10` failures were inherited-session model/env assertions and sandbox-local serve timeouts; the PR CI matrix runs these in clean Linux/macOS Node 22/24 jobs.
- README, root Unreleased changelog, and package changelog fragment updated.

Session transcript (fleet-local reference; repository is public):
`zion:/Users/muqsit/.codex/sessions/2026/07/17/rollout-2026-07-17T13-30-03-019f71c5-9b59-70c0-8815-20d4f6a614eb.jsonl`
