### PR TITLE
test: close session DB before fork cleanup

### DIFF
--- a/apps/cli/src/lib/session/__tests__/fork.test.ts
+++ b/apps/cli/src/lib/session/__tests__/fork.test.ts
@@ -12,10 +12,11 @@ process.env.HOME = TEST_HOME;
 process.env.AGENTS_REAL_HOME = TEST_HOME;
 
 const { forkSession } = await import('../fork.js');
-const { getSessionById } = await import('../db.js');
+const { closeDB, getSessionById } = await import('../db.js');
 type SessionMeta = import('../types.js').SessionMeta;
 
 afterAll(() => {
+  closeDB();
   fs.rmSync(TEST_HOME, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary

Closes the process-wide session SQLite handle before the fork test removes its isolated HOME.

## Evidence

- Release PR #1296 failed on Windows Node 22 with EBUSY unlinking sessions.db and on Node 24 with EPERM removing the same temp tree.
- Focused test: 3/3 passed.
- TypeScript build passed.
- The change mirrors the existing closeDB-before-rm cleanup contract in db.test.ts, cost.test.ts, and output.test.ts.

## Release impact

Test-only cleanup fix; no user-facing docs or changelog entry required. This unblocks the fail-closed 1.20.69 release matrix.

Session transcript: zion:/Users/muqsit/.codex/sessions/2026/07/17/rollout-2026-07-17T13-30-03-019f71c5-9b59-70c0-8815-20d4f6a614eb.jsonl