### PR TITLE
fix(computer-mac): build universal helper without requiring full Xcode

### DIFF
--- a/native/computer-mac/scripts/build.sh
+++ b/native/computer-mac/scripts/build.sh
@@ -11,8 +11,18 @@ MODE="${1:-debug}"
 HELPER_VERSION="${HELPER_VERSION:-0.1.0}"
 
 if [ "$MODE" = "release" ]; then
-    swift build -c release --arch arm64 --arch x86_64
-    SRC=".build/apple/Products/Release/ComputerHelper"
+    # Universal build WITHOUT full Xcode. SwiftPM's `--arch arm64 --arch x86_64`
+    # routes through Xcode's xcbuild, which is absent on Command-Line-Tools-only
+    # hosts (`swift build --arch ...` → "xcbuild ... does not exist"). Build each
+    # slice separately via --triple (works on CLT) and lipo them into one binary,
+    # so the signed/notarized release asset can be produced on any Mac with the
+    # toolchain + signing identity, not only ones with Xcode installed.
+    swift build -c release --triple arm64-apple-macosx14.0
+    swift build -c release --triple x86_64-apple-macosx14.0
+    SRC=".build/ComputerHelper-universal"
+    lipo -create -output "$SRC" \
+        ".build/arm64-apple-macosx/release/ComputerHelper" \
+        ".build/x86_64-apple-macosx/release/ComputerHelper"
 else
     swift build
     SRC=".build/debug/ComputerHelper"


### PR DESCRIPTION
## What

`native/computer-mac/scripts/build.sh release` produced the universal helper with `swift build -c release --arch arm64 --arch x86_64`, which routes through Xcode's `xcbuild`. On a **Command-Line-Tools-only** Mac (no full Xcode) that fails:

```
error: xcbuild executable at '.../XCBuild.framework/.../xcbuild' does not exist or is not executable
```

Since the signed + notarized `ComputerHelper.app.zip` asset (added in #1293) is built at release time on a Mac with the signing identity — not necessarily one with Xcode — this could silently skip publishing the asset (the `release.sh` hook is best-effort), leaving fresh `npm i -g` machines unable to download the helper.

## Fix

Build each slice separately via `--triple` (which works on CLT) and `lipo` them into one universal binary:

```sh
swift build -c release --triple arm64-apple-macosx14.0
swift build -c release --triple x86_64-apple-macosx14.0
lipo -create -output .build/ComputerHelper-universal .build/{arm64,x86_64}-apple-macosx/release/ComputerHelper
```

Debug mode is unchanged; the sign/notarize/staple/asset-emit path is unchanged.

## Verified (on a CLT-only host)

`bash scripts/build.sh release` →
- `lipo -info` on the built `.app` binary: `x86_64 arm64` (universal) ✓
- signed: `Developer ID Application: Muqit Nawaz (2HTP252L87)` ✓
- notarization correctly skipped only because Apple creds weren't exported in that shell (unchanged path) ✓

No user-visible surface change (internal build mechanics) — no changelog fragment.

Session transcript (confidential; not uploaded per public-repo convention): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/f2314c23-cca7-436a-8535-3bb177497c15.jsonl`
