### PR TITLE
fix(menubar): build a true universal binary without full Xcode

### DIFF
--- a/apps/cli/.changelog/next/menubar-universal-build.md
+++ b/apps/cli/.changelog/next/menubar-universal-build.md
@@ -1,0 +1,8 @@
+- **The bundled macOS menu-bar helper is now a true universal binary on
+  Xcode-less release hosts.** `menubar/scripts/build.sh release` used
+  `swift build --arch arm64 --arch x86_64` (needs Xcode's xcbuild) and, on a
+  Command-Line-Tools-only host, silently fell back to a **single-arch** build —
+  shipping an arm64-only `MenubarHelper.app` in the tarball that could not run on
+  Intel Macs. It now builds each slice via `--triple` and `lipo`s them into one
+  universal binary, matching the computer helper. Source:
+  `apps/cli/menubar/scripts/build.sh`.

--- a/apps/cli/menubar/scripts/build.sh
+++ b/apps/cli/menubar/scripts/build.sh
@@ -6,16 +6,17 @@ cd "$(dirname "$0")/.."
 MODE="${1:-debug}"
 
 if [ "$MODE" = "release" ]; then
-    # Universal build needs Xcode's xcbuild. Fall back to a native single-arch
-    # release build when only the Command Line Tools are installed, so a release
-    # can still be cut on a machine without full Xcode.
-    if swift build -c release --arch arm64 --arch x86_64 2>/dev/null; then
-        SRC=".build/apple/Products/Release/MenubarHelper"
-    else
-        echo "  universal build unavailable (no Xcode/xcbuild); building native single-arch release"
-        swift build -c release
-        SRC="$(swift build -c release --show-bin-path)/MenubarHelper"
-    fi
+    # SwiftPM's `--arch arm64 --arch x86_64` routes through Xcode's xcbuild, which
+    # is absent on Command-Line-Tools-only hosts. Build each slice separately via
+    # --triple (works on CLT) and lipo them into one universal binary, so a
+    # release cut on a machine without full Xcode still ships a TRUE universal
+    # menu-bar helper (not a silent single-arch fallback that breaks Intel Macs).
+    swift build -c release --triple arm64-apple-macosx14.0
+    swift build -c release --triple x86_64-apple-macosx14.0
+    SRC=".build/MenubarHelper-universal"
+    lipo -create -output "$SRC" \
+        ".build/arm64-apple-macosx/release/MenubarHelper" \
+        ".build/x86_64-apple-macosx/release/MenubarHelper"
 else
     swift build
     SRC=".build/debug/MenubarHelper"


### PR DESCRIPTION
## What

Sibling fix to #1298, flagged by `prix-cloud` in that review. `menubar/scripts/build.sh release` used `swift build --arch arm64 --arch x86_64` (routes through Xcode's `xcbuild`) and, on a **Command-Line-Tools-only** host, silently fell back to a **single-arch** release build — shipping an **arm64-only** `MenubarHelper.app` in the npm tarball that can't run on Intel Macs.

## Fix

Build each slice via `--triple` and `lipo` into one universal binary (identical approach to the computer helper in #1298). Debug path and downstream sign/bundle steps unchanged.

## Verified (CLT-only host)

`bash menubar/scripts/build.sh release` → `lipo -info` on the built `.app` binary: `x86_64 arm64` (universal), Developer ID signed (`2HTP252L87`).

Changelog fragment added (user-visible: fixes Intel-Mac menu-bar helper).

Session transcript (confidential; not uploaded per public-repo convention): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/f2314c23-cca7-436a-8535-3bb177497c15.jsonl`