### PR TITLE
fix(computer): read codesign -dv from stderr so valid helpers verify (1.20.69 regression)

### DIFF
--- a/apps/cli/.changelog/next/computer-helper-verify-stderr.md
+++ b/apps/cli/.changelog/next/computer-helper-verify-stderr.md
@@ -1,0 +1,9 @@
+- **Fix `agents setup computer` / `agents computer setup` refusing to install a
+  valid downloaded helper.** The signature check read `codesign -dv` from stdout,
+  but that command writes its details to **stderr** on success — so the Team-ID
+  check saw an empty string, found no `TeamIdentifier`, and rejected every
+  validly-signed, notarized helper with "signed by unexpected Team (none)". It now
+  reads both streams via `spawnSync`. Verified end-to-end against the real
+  published `v1.20.69` release asset (download → sha256 → extract → codesign +
+  Team `2HTP252L87` + `spctl` notarization → install). Source:
+  `apps/cli/src/lib/computer/download.ts`.

--- a/apps/cli/src/lib/computer/download.test.ts
+++ b/apps/cli/src/lib/computer/download.test.ts
@@ -6,8 +6,30 @@ import {
   MAC_HELPER_APP_NAME,
   macHelperAssetUrls,
   macHelperCacheDir,
+  parseTeamId,
 } from './download.js';
 import { getCacheDir } from '../state.js';
+
+describe('parseTeamId (verifyMacHelper Team-ID extraction)', () => {
+  // `codesign -dv --verbose=4` writes this block to STDERR even on success — the
+  // verifier must read stderr, or every validly-signed helper is falsely rejected.
+  const realOutput = [
+    'Executable=/x/ComputerHelper.app/Contents/MacOS/ComputerHelper',
+    'Identifier=com.phnx-labs.computer-helper',
+    'CodeDirectory v=20500 size=969 flags=0x10000(runtime)',
+    'Authority=Developer ID Application: Muqit Nawaz (2HTP252L87)',
+    'TeamIdentifier=2HTP252L87',
+  ].join('\n');
+
+  it('extracts the Team ID from real codesign -dv output', () => {
+    expect(parseTeamId(realOutput)).toBe('2HTP252L87');
+  });
+
+  it('returns null for ad-hoc / unsigned output (no TeamIdentifier) and for empty input', () => {
+    expect(parseTeamId('Identifier=x\nTeamIdentifier=not set\n')).toBeNull();
+    expect(parseTeamId('')).toBeNull(); // the old bug: reading empty stdout -> null -> false reject
+  });
+});
 
 describe('mac helper release-asset download', () => {
   it('builds asset URLs pinned to the exact v<version> tag', () => {

--- a/apps/cli/src/lib/computer/download.ts
+++ b/apps/cli/src/lib/computer/download.ts
@@ -14,7 +14,7 @@
  * we extract it with `ditto -x -k` after the checksum passes.
  */
 
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -46,6 +46,12 @@ export function macHelperAssetUrls(version: string): { zip: string; sha256: stri
   return { zip: `${base}/${MAC_HELPER_ASSET}`, sha256: `${base}/${MAC_HELPER_ASSET}.sha256` };
 }
 
+/** Extract `TeamIdentifier=XXXX` from `codesign -dv --verbose=4` output (which is
+ * emitted on stderr). Returns null when absent (ad-hoc / unsigned). */
+export function parseTeamId(codesignInfo: string): string | null {
+  return codesignInfo.match(/TeamIdentifier=([A-Z0-9]+)/)?.[1] ?? null;
+}
+
 /**
  * Verify a helper `.app` bundle is intact, signed by the expected Developer ID
  * Team, and notarized (Gatekeeper-accepted). Throws with an actionable message
@@ -60,15 +66,13 @@ export function verifyMacHelper(appPath: string): void {
   }
 
   // 2. Team identity — must be our Developer ID, not some other valid signer.
-  let info = '';
-  try {
-    info = execFileSync('/usr/bin/codesign', ['-dv', '--verbose=4', appPath], { stdio: 'pipe' }).toString();
-  } catch (e) {
-    // codesign -dv writes to stderr; capture whatever it emitted.
-    info = ((e as { stderr?: Buffer }).stderr?.toString() ?? '') + ((e as { stdout?: Buffer }).stdout?.toString() ?? '');
-    if (!info) throw new Error(`could not read code signature of ${appPath}: ${(e as Error).message}`);
-  }
-  const team = info.match(/TeamIdentifier=([A-Z0-9]+)/)?.[1];
+  // `codesign -dv` writes its details to STDERR even on success (exit 0), so we
+  // must read stderr, not stdout. spawnSync captures both streams regardless of
+  // exit code; execFileSync would return only (empty) stdout and the Team check
+  // would falsely reject every validly-signed helper.
+  const dv = spawnSync('/usr/bin/codesign', ['-dv', '--verbose=4', appPath], { encoding: 'utf8' });
+  const info = `${dv.stdout ?? ''}${dv.stderr ?? ''}`;
+  const team = parseTeamId(info);
   if (team !== EXPECTED_TEAM_ID) {
     throw new Error(
       `helper signed by unexpected Team (${team ?? 'none'}), expected ${EXPECTED_TEAM_ID}. Refusing to install.`,


### PR DESCRIPTION
## Critical — the computer-helper download is broken in 1.20.69

While proving the shipped feature end-to-end against the **real published `v1.20.69` asset**, `agents setup computer` downloaded the helper and then **refused to install it**:

```
helper signed by unexpected Team (none), expected 2HTP252L87. Refusing to install.
```

The asset is actually **perfectly signed + notarized** (`codesign -dv` → `TeamIdentifier=2HTP252L87`, `spctl` → `Notarized Developer ID`, universal x86_64+arm64). The bug is in the client: `verifyMacHelper` read `codesign -dv --verbose=4` from **stdout**, but that command writes its details to **stderr** on success — so the Team-ID check saw an empty string, found no `TeamIdentifier`, and rejected every valid helper. So `agents computer setup` / `agents setup computer` on 1.20.69 can never install the downloaded helper.

## Fix

- Read both streams via `spawnSync` (execFileSync returns only the empty stdout).
- Extract the Team ID via a new testable `parseTeamId()`; add unit tests (incl. the empty-input → null case that reproduces the bug class).

## Verified end-to-end (real published asset)

```
node -e "download.js → downloadMacHelperApp('1.20.69')"
Downloading ComputerHelper.app.zip v1.20.69 from GitHub releases...
FULL PATH PASS: download -> sha256 -> extract -> verify -> .../v1.20.69/ComputerHelper.app
verifyMacHelper: PASS (codesign + team 2HTP252L87 + spctl)
```

Should ship in the next release (1.20.70) so the feature actually works on fresh machines. `tsc` clean; download tests pass; changelog fragment added.

Session transcript (confidential; not uploaded per public-repo convention): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/f2314c23-cca7-436a-8535-3bb177497c15.jsonl`