### PR TITLE
feat(devices): cache-first fleet list/status + honest Auth column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,6 +296,31 @@
   everywhere. Source: `apps/cli/src/lib/devices/terminfo.ts`,
   `apps/cli/src/commands/ssh.ts`.
 
+- **`agents devices list` / `agents fleet status` are cache-first now — instant by
+  default, `--refresh` (alias `--live`) for a live probe.** Both used to live-SSH
+  every registered box for load/mem on every call, so a glance at a dozen-device
+  fleet (a few cold or timing out) hung for seconds. Resource stats now serve from
+  a small on-disk cache (`.fleet-stats.json`) that the daemon warms ~every 3 min;
+  a default read probes only *this* machine (locally, no ssh) plus any device
+  missing from the cache. Pass `--refresh`/`--live` to force a full live probe.
+  Cache-served output carries an "`updated … — pass --refresh (--live)`" age note.
+  `agents view` (usage already stale-while-revalidate cached) gains the same
+  `--live` alias for its `--refresh`. Source: `apps/cli/src/lib/devices/stats-cache.ts`,
+  `apps/cli/src/commands/ssh.ts`, `apps/cli/src/commands/view.ts`,
+  `apps/cli/src/lib/daemon.ts`.
+
+- **`agents fleet status` gains an Auth column — see which accounts are actually
+  logged in, per device.** Reads the shared auth-health cache (no network) and
+  rolls each host up into four honest buckets so it never cries wolf:
+  `●live` (verified), `·present` (signed in but the agent has no live-probe
+  endpoint — codex/grok/antigravity/opencode — benign), `◐degraded`
+  (soft/self-healing: expired/limited/error), `○revoked` (server rejected —
+  re-login now). Remote hosts self-report their rollup through `doctor --json`, so
+  the column is current without a fleet-wide `agents fleet ping`. The daemon also
+  refreshes this host's auth verdicts alongside the stats warm. Source:
+  `apps/cli/src/lib/auth-health.ts` (`summarizeHostAuth`),
+  `apps/cli/src/lib/devices/health-report.ts`, `apps/cli/src/commands/doctor.ts`.
+
 ## 1.20.58
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -432,13 +432,15 @@ agents sync --host gpu-box              # make the remote machine current
 agents doctor --devices                 # readiness matrix for every registered device
 agents doctor --devices --json          # machine-readable fleet readiness
 agents doctor --device mac-mini         # same matrix, scoped to one device
-agents fleet status                     # warnings rollup + health/sync/version matrix
+agents fleet status                     # warnings rollup + health/sync/version/Auth matrix (cache-first)
+agents fleet status --live              # force a live resource probe (alias of --refresh)
 agents fleet status --json --strict     # scriptable fleet health gate
 agents check --devices                  # CI drift gate across every registered device
 
 # Your Tailscale fleet, auto-discovered
 agents devices sync                     # ingest `tailscale status`
-agents devices list                     # fleet + live headroom: load, mem, idle/busy — which box has room
+agents devices list                     # fleet + headroom: load, mem, idle/busy — which box has room (cache-first)
+agents devices list --live              # force a live probe of every device (alias of --refresh)
 agents devices list --full              # add per-device cores and free/total RAM
 agents devices list --no-stats          # instant: names/addresses only, skip the probe
 agents ssh mac-mini                     # hardened SSH: fails fast if offline,
@@ -453,11 +455,22 @@ agents cloud run "nightly benchmark" --host gpu-box --agent claude   # task in c
 agents routines add nightly -s "0 2 * * *" -a claude -p "run the sweep" --run-on gpu-box
 ```
 
-`agents devices list` probes every reachable box in parallel (bounded timeout, so a
-slow node degrades to `—` instead of hanging) and shows normalized load, memory
-pressure, and an idle/light/busy/loaded headroom badge, plus a fleet-capacity summary
+`agents devices list` shows normalized load, memory pressure, and an
+idle/light/busy/loaded headroom badge, plus a fleet-capacity summary
 (`164 cores · 421G free / 518G RAM`). It answers "which machine has room right now?" —
-the utilization signal the teammate scheduler doesn't yet see.
+the utilization signal the teammate scheduler doesn't yet see. It's **cache-first**:
+reads serve instantly from a stats cache the daemon warms (~every 3 min), probing only
+this machine locally plus any device missing from the cache; pass `--refresh` (or the
+shorter `--live`) to force a full live probe of every box. Cache-served output notes its
+age (`updated 2m ago — pass --refresh (--live) for a live probe`).
+
+`agents fleet status` adds an **Auth column** — which agent accounts are actually
+logged in, per device, read from the auth-health cache (no network). Four buckets keep
+it from crying wolf: `●live` (verified), `·present` (signed in but the agent has no
+live-probe endpoint — e.g. codex/grok — benign), `◐degraded` (soft/self-healing:
+expired-but-refreshing, rate-limited), and `○revoked` (server rejected — re-login now).
+Only `○` means a real re-login is needed. Run `agents fleet ping` to force a live
+re-verification across the fleet.
 
 **Hosts** (`agents hosts`) are git-synced dispatch targets in `agents.yaml`; **devices** (`agents devices`) are your Tailscale machines in a local registry. Both ride SSH and feed one host pool: devices appear in `agents hosts list` and capability routing without a second enrollment. On `--host` runs every `agents run` option is either forwarded (`--effort --env --timeout --loop …`), rejected loud (`--secrets` never crosses SSH implicitly), or consumed locally — nothing silently drops. See [docs/00-concepts.md](apps/cli/docs/00-concepts.md#devices--hosts).
 

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -51,6 +51,7 @@ import {
   type VersionResourceReport,
 } from '../lib/doctor-diff.js';
 import { checkSyncStatus, countOrphans, type SyncStatusRow, type OrphanRow } from '../lib/drift.js';
+import { readAuthHealthCache, summarizeHostAuth } from '../lib/auth-health.js';
 import { unifiedDiff, colorizeUnifiedDiff } from '../lib/diff-text.js';
 import { listCliStatus } from '../lib/cli-resources.js';
 import { setHelpSections } from '../lib/help.js';
@@ -830,6 +831,10 @@ export function registerDoctorCommand(program: Command): void {
           console.log(JSON.stringify({
             clis,
             signIn,
+            // Cached auth-health rollup for THIS host — lets `agents fleet status`
+            // show a live-verified Auth column from the same fan-out it already
+            // runs, without a separate fleet-wide `fleet ping`.
+            auth: summarizeHostAuth(readAuthHealthCache(), machineId()),
             sync: syncRows,
             orphans: orphanRows,
             hostClis: {

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -67,8 +67,6 @@ import {
   fleetCapacity,
   fmtBytes,
   headroom,
-  probeLocalStats,
-  probeFleetStats,
   type DeviceStats,
   type Headroom,
 } from '../lib/devices/health.js';
@@ -78,6 +76,7 @@ import {
   renderFleetWarnings,
   type FleetHealthRow,
 } from '../lib/devices/health-report.js';
+import { loadFleetStats, readStatsCache } from '../lib/devices/stats-cache.js';
 import { checkSyncStatus, countOrphans } from '../lib/drift.js';
 import { checkAllClis } from '../lib/teams/agents.js';
 import { buildRemoteAgentsInvocation } from '../lib/hosts/remote-cmd.js';
@@ -87,6 +86,8 @@ import {
   formatCheckedAge,
   isDeadVerdict,
   probeLocalFleetAuth,
+  readAuthHealthCache,
+  summarizeHostAuth,
   summarizeVerdicts,
   verdictLabel,
   writeFleetAuthRows,
@@ -306,6 +307,7 @@ interface RemoteDoctorJson {
   clis?: FleetHealthRow['clis'];
   sync?: FleetHealthRow['sync'];
   orphans?: FleetHealthRow['orphans'];
+  auth?: FleetHealthRow['auth'];
 }
 
 interface FleetStatusTarget extends FanOutDeviceTarget {
@@ -342,20 +344,24 @@ async function probeRemoteHealth(target: FleetStatusTarget): Promise<Omit<FleetH
     clis: parsed.clis ?? {},
     sync: parsed.sync ?? [],
     orphans: parsed.orphans ?? [],
+    // The remote self-reports its own cached auth rollup (fresh via its daemon),
+    // so the Auth column is current without a prior fleet-wide `fleet ping`.
+    // Older remotes that don't emit it fall back to this host's cache below.
+    auth: parsed.auth,
   };
 }
 
-async function runFleetStatus(opts: { json?: boolean; strict?: boolean; stats?: boolean }): Promise<void> {
+async function runFleetStatus(opts: { json?: boolean; strict?: boolean; stats?: boolean; refresh?: boolean; live?: boolean }): Promise<void> {
   const reg = await loadDevices();
   const self = machineId();
+  const forceRefresh = Boolean(opts.refresh || opts.live);
   const planned = planFleetTargets(reg);
   const probeable = planned.filter((t) => !t.skip).map((t) => t.device);
+  // Cache-first: serve remote stats from the daemon-warmed cache (instant),
+  // probe this machine locally, and only ssh out for missing/forced rows.
   const statsMap = opts.stats === false
     ? new Map<string, DeviceStats>()
-    : await probeFleetStats(probeable, { selfName: self });
-  if (opts.stats !== false && !statsMap.has(self)) {
-    statsMap.set(self, await probeLocalStats(self));
-  }
+    : (await loadFleetStats(probeable, { forceRefresh, selfName: self })).stats;
 
   const rows: FleetHealthRow[] = [localHealthRow(self, statsMap.get(self))];
   const remoteTargets: FleetStatusTarget[] = remoteFleetTargets(planned, self)
@@ -386,6 +392,15 @@ async function runFleetStatus(opts: { json?: boolean; strict?: boolean; stats?: 
         orphans: [],
       });
     }
+  }
+
+  // Auth column: remote rows already carry the host's self-reported rollup from
+  // its `doctor --json`. Fill the rest (this machine; older remotes that don't
+  // emit it) from this host's local cache — written by `agents fleet ping` and
+  // the daemon's local refresh. A never-probed host rolls up to "—". No network.
+  const authCache = readAuthHealthCache();
+  for (const row of rows) {
+    if (!row.auth) row.auth = summarizeHostAuth(authCache, row.name);
   }
 
   const report = buildFleetHealthReport(rows);
@@ -643,8 +658,10 @@ Typical workflow:
     .description('List registered devices with platform, address, reachability, and live resource headroom.')
     .option('--json', 'output the registry as a JSON array (for scripts and hooks)')
     .option('--no-stats', 'skip the live resource probe (instant; names/addresses only)')
+    .option('--refresh', 'force a live probe of every device, bypassing the cache')
+    .option('--live', 'alias of --refresh (shorter to type)')
     .option('-f, --full', 'full mode: add per-device core count and free/total memory')
-    .action(async (opts: { json?: boolean; stats?: boolean; full?: boolean }) => {
+    .action(async (opts: { json?: boolean; stats?: boolean; full?: boolean; refresh?: boolean; live?: boolean }) => {
       const reg = await loadDevices();
       const names = Object.keys(reg).sort();
       if (opts.json) {
@@ -657,19 +674,27 @@ Typical workflow:
         return;
       }
       const self = machineId();
+      const forceRefresh = Boolean(opts.refresh || opts.live);
 
       let statsMap: Map<string, DeviceStats> | undefined;
+      let freshness: { oldestFetchedAt: number | null; servedFromCache: boolean } | undefined;
       if (opts.stats !== false) {
-        // Probe only reachable devices, in parallel, bounded by the per-probe
-        // timeout — a slow box degrades to "—", it never hangs the table.
+        // Cache-first: serve remote devices from the daemon-warmed cache
+        // (instant), probe this machine locally, and only ssh out for missing or
+        // forced (--refresh/--live) rows — so a warm read never hangs on a box.
         const probeable = planFleetTargets(reg)
           .filter((t) => !t.skip)
           .map((t) => t.device);
-        const spinner = isInteractiveTerminal()
+        // Only spin when we'll actually ssh (forced, or a cold/partial cache).
+        const cache = readStatsCache();
+        const willSsh = forceRefresh || probeable.some((d) => d.name !== self && !cache[d.name]);
+        const spinner = willSsh && isInteractiveTerminal()
           ? ora(`Probing ${probeable.length} device${probeable.length === 1 ? '' : 's'}…`).start()
           : undefined;
         try {
-          statsMap = await probeFleetStats(probeable, { selfName: self });
+          const res = await loadFleetStats(probeable, { forceRefresh, selfName: self });
+          statsMap = res.stats;
+          freshness = res;
         } finally {
           spinner?.stop();
         }
@@ -677,6 +702,9 @@ Typical workflow:
 
       console.log(chalk.bold(`Devices (${names.length})`));
       for (const line of renderDeviceTable(reg, names, self, statsMap, opts.full)) console.log(line);
+      if (freshness?.servedFromCache && freshness.oldestFetchedAt != null) {
+        console.log(chalk.gray(`  updated ${formatCheckedAge(freshness.oldestFetchedAt)} — pass --refresh (--live) for a live probe`));
+      }
     });
 
   devicesCmd
@@ -685,7 +713,9 @@ Typical workflow:
     .option('--json', 'output machine-readable JSON')
     .option('--strict', 'exit non-zero when any device has drift or is unreachable')
     .option('--no-stats', 'skip the live resource probe')
-    .action(async (opts: { json?: boolean; strict?: boolean; stats?: boolean }) => {
+    .option('--refresh', 'force a live probe of every device, bypassing the cache')
+    .option('--live', 'alias of --refresh (shorter to type)')
+    .action(async (opts: { json?: boolean; strict?: boolean; stats?: boolean; refresh?: boolean; live?: boolean }) => {
       await runFleetStatus(opts);
     });
 

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -1699,8 +1699,11 @@ export async function viewAction(
     resources?: string | boolean;
     detailed?: boolean;
     refresh?: boolean;
+    live?: boolean;
   } & ViewSectionFilter,
 ): Promise<void> {
+  // --live is a shorter-to-type alias of --refresh; both force a live probe.
+  const forceRefresh = options?.refresh === true || options?.live === true;
   // --resources / --detailed imply --json (they only shape structured output).
   const explicitResources = options?.detailed === true || options?.resources !== undefined;
   const json = options?.json === true || explicitResources;
@@ -1743,7 +1746,7 @@ export async function viewAction(
       return;
     }
     // No argument: show all installed versions
-    await showInstalledVersions(undefined, { forceRefresh: options?.refresh === true });
+    await showInstalledVersions(undefined, { forceRefresh });
     return;
   }
 
@@ -1805,7 +1808,7 @@ export async function viewAction(
     await showAgentResources(agentId, 'default', filter);
   } else {
     // Just agent name: show versions for that agent
-    await showInstalledVersions(agentId, { forceRefresh: options?.refresh === true });
+    await showInstalledVersions(agentId, { forceRefresh });
   }
 }
 
@@ -1817,6 +1820,7 @@ export function registerViewCommand(program: Command): void {
     .option('--resources [sections]', 'In --json mode, include each version\'s resources: "all" (default) or a comma list (skills,plugins,mcp,commands,workflows,memory,hooks). Implies --json.')
     .option('--detailed', 'Include all resources in --json output (alias for --resources all). Implies --json.')
     .option('-r, --refresh', 'Force a live usage refresh, bypassing the cache (slower). Repopulates the S:/W: limit bars for every account whose token is reachable.')
+    .option('--live', 'Alias of --refresh (shorter to type).')
     .option('--prune', 'Remove older installed versions that share an account with a newer installed version. Skips the global default.')
     .option('--dry-run', 'With --prune, show duplicate versions without deleting')
     .option('-y, --yes', 'Skip the prune confirmation prompt.')

--- a/apps/cli/src/lib/auth-health.test.ts
+++ b/apps/cli/src/lib/auth-health.test.ts
@@ -7,10 +7,12 @@ import {
   mergeAuthHealthEntries,
   formatCheckedAge,
   probeDetail,
+  summarizeHostAuth,
   summarizeVerdicts,
   verdictFromProbe,
   verdictGlyph,
   verdictLabel,
+  type AuthHealth,
   type AuthVerdict,
 } from './auth-health.js';
 
@@ -122,6 +124,42 @@ describe('mergeAuthHealthEntries', () => {
   });
   it('an error on a brand-new key is still recorded (nothing prior to keep)', () => {
     expect(mergeAuthHealthEntries({}, { k: { verdict: 'error' as const, checkedAt: 200 } }).k.verdict).toBe('error');
+  });
+});
+
+describe('summarizeHostAuth', () => {
+  const h = (verdict: AuthVerdict, checkedAt: number): AuthHealth => ({ verdict, checkedAt });
+  const cache: Record<string, AuthHealth> = {
+    'zion:claude:1.0.0': h('live', 5000),
+    'zion:claude:1.1.0': h('live', 3000),
+    'zion:codex:0.1.0': h('unverified', 7000),   // signed in, no probe → present
+    'zion:opencode:0.1.0': h('revoked', 4000),   // server rejected → revoked
+    'zion:kimi:0.1.0': h('expired', 6000),        // soft/self-healing → degraded
+    'zion-2:claude:1.0.0': h('revoked', 1000),   // sibling host, must not bleed into 'zion'
+    'yosemite-s1:claude:1.0.0': h('live', 9000),
+  };
+
+  it('splits present/degraded/revoked into distinct buckets and tracks oldest', () => {
+    const r = summarizeHostAuth(cache, 'zion');
+    // 5 zion rows — the 'zion-2' row (a `zion` substring) is excluded.
+    expect(r).toEqual({
+      live: 2,       // two claude
+      present: 1,    // codex unverified — NOT counted as degraded
+      degraded: 1,   // kimi expired (soft)
+      revoked: 1,    // opencode revoked (the only real re-login)
+      total: 5,
+      oldestCheckedAt: 3000, // not zion-2's 1000
+    });
+  });
+
+  it('matches on the host prefix, not a substring (no cross-host bleed)', () => {
+    const r = summarizeHostAuth(cache, 'yosemite-s1');
+    expect(r).toEqual({ live: 1, present: 0, degraded: 0, revoked: 0, total: 1, oldestCheckedAt: 9000 });
+  });
+
+  it('returns an empty summary for a host with no cached rows', () => {
+    const r = summarizeHostAuth(cache, 'never-probed');
+    expect(r).toEqual({ live: 0, present: 0, degraded: 0, revoked: 0, total: 0, oldestCheckedAt: null });
   });
 });
 

--- a/apps/cli/src/lib/auth-health.ts
+++ b/apps/cli/src/lib/auth-health.ts
@@ -5,9 +5,12 @@
  * The rest of the CLI reports "signed in" from a local heuristic — a credential
  * file is present and its email decodes — which cannot distinguish a good token
  * from a revoked-but-unexpired one. This module completes a real request per
- * (agent, account) and records the verdict in a small cache that `agents view`,
- * `agents fleet status`, and the run rotation all read. The daemon and
- * `agents fleet ping` are the writers; everyone else reads.
+ * (agent, account) and records the verdict in a small cache that `agents view`
+ * (per-version chip), `agents fleet status` (the per-host Auth column, via
+ * {@link summarizeHostAuth}), and the run rotation all read. The writers are
+ * the daemon (a periodic local refresh) and `agents fleet ping` (which also
+ * fans out to write remote hosts' rows into the local cache); everyone else
+ * reads.
  *
  * The network probes themselves live in lib/usage.ts (where the per-provider
  * token loaders + endpoints already are); this module classifies their result,
@@ -143,6 +146,65 @@ export function summarizeVerdicts(verdicts: AuthVerdict[]): VerdictSummary {
 /** Verdicts that mean "this token was rejected by the server — re-login required". */
 export function isDeadVerdict(verdict: AuthVerdict): boolean {
   return verdict === 'revoked';
+}
+
+/**
+ * A host's rolled-up auth state for the `fleet status` Auth column.
+ *
+ * The four display buckets are deliberately finer-grained than
+ * {@link VerdictSummary}'s live/bad/warn: they separate "present but this agent
+ * has no live probe" (`unverified`) and "soft, self-healing expiry"
+ * (`expired`/`rate_limited`) from a genuine server rejection (`revoked`). The
+ * old three-bucket rollup lumped all of those into `warn` and the column painted
+ * them one alarming yellow — so a fleet of perfectly logged-in accounts on
+ * codex/grok/etc (which can NEVER be probed live) read as half-degraded. These
+ * buckets let the renderer show `unverified` as neutral and reserve red for the
+ * only verdict that actually means "re-login now" ({@link isDeadVerdict}).
+ */
+export interface HostAuthSummary {
+  /** Live-verified accounts (a real 2xx). */
+  live: number;
+  /** Signed in but this agent has no live-probe endpoint — benign, neutral. */
+  present: number;
+  /** Soft/degraded: expired (self-healing) / rate_limited / error. Mild warning. */
+  degraded: number;
+  /** Server rejected the token — genuinely needs re-login. */
+  revoked: number;
+  /** Total cached rows for this host (0 → the renderer shows "—"). */
+  total: number;
+  /** Oldest `checkedAt` (epoch ms) among this host's cached rows, or null when none. */
+  oldestCheckedAt: number | null;
+}
+
+/**
+ * Roll every cached (agent, version) row for one host into a {@link HostAuthSummary}
+ * plus the age of its stalest entry. Pure — reads the map the caller already
+ * loaded via {@link readAuthHealthCache}, so `fleet status` renders the Auth
+ * column without any network probe. A host with no cached rows yields an empty
+ * summary (total 0), which the renderer shows as "—".
+ *
+ * Keys are `host:agent:version` ({@link authCacheKey}); we match on the `host:`
+ * prefix so agent/version segments can never be mistaken for a host.
+ */
+export function summarizeHostAuth(
+  cache: Record<string, AuthHealth>,
+  host: string,
+): HostAuthSummary {
+  const prefix = `${host}:`;
+  let live = 0, present = 0, degraded = 0, revoked = 0, total = 0;
+  let oldest: number | null = null;
+  for (const [key, health] of Object.entries(cache)) {
+    if (!key.startsWith(prefix)) continue;
+    total++;
+    switch (health.verdict) {
+      case 'live': live++; break;
+      case 'unverified': present++; break;      // signed in, no probe — benign
+      case 'revoked': revoked++; break;          // server said no — re-login
+      default: degraded++; break;                // expired / rate_limited / error — soft
+    }
+    if (oldest === null || health.checkedAt < oldest) oldest = health.checkedAt;
+  }
+  return { live, present, degraded, revoked, total, oldestCheckedAt: oldest };
 }
 
 /** Human "3m ago" style age for a checkedAt timestamp. */

--- a/apps/cli/src/lib/auth-health.ts
+++ b/apps/cli/src/lib/auth-health.ts
@@ -195,6 +195,10 @@ export function summarizeHostAuth(
   let oldest: number | null = null;
   for (const [key, health] of Object.entries(cache)) {
     if (!key.startsWith(prefix)) continue;
+    // `unconfigured` = no credential at all — not a probed account. Writers
+    // already drop these before they reach the cache; skip here too so a stray
+    // one never counts toward total or the freshness age (belt-and-suspenders).
+    if (health.verdict === 'unconfigured') continue;
     total++;
     switch (health.verdict) {
       case 'live': live++; break;

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -602,6 +602,41 @@ export async function runDaemon(): Promise<void> {
   const launchHealthInterval = setInterval(() => { void runLaunchHealthCheck(); }, 6 * 60 * 60_000);
   const launchHealthKickoff = setTimeout(() => { void runLaunchHealthCheck(); }, 90_000);
 
+  // Fleet cache warm: keep the caches that `agents devices list`, `fleet status`,
+  // and `agents view` read cache-first actually fresh, so a default read never
+  // has to ssh out. Two cheap refreshes: (1) this host's auth-health verdicts
+  // (also feeds the `doctor --json` Auth rollup other hosts read), and (2) the
+  // fleet resource-stats cache (one bounded parallel probe of the tailnet). Both
+  // best-effort + overlap-guarded like the probes above. ~every 3 min, plus once
+  // ~60s after startup (staggered off launch).
+  let warmingFleetCache = false;
+  const runFleetCacheWarm = async () => {
+    if (warmingFleetCache) return;
+    warmingFleetCache = true;
+    try {
+      const { machineId } = await import('./machine-id.js');
+      const self = machineId();
+      const { probeLocalFleetAuth, writeFleetAuthRows } = await import('./auth-health.js');
+      const { getCliVersion } = await import('./version.js');
+      const authRows = await probeLocalFleetAuth({ cliVersion: getCliVersion() });
+      writeFleetAuthRows(self, authRows);
+
+      const { loadDevices } = await import('./devices/registry.js');
+      const { planFleetTargets } = await import('./devices/fleet.js');
+      const { loadFleetStats } = await import('./devices/stats-cache.js');
+      const reg = await loadDevices();
+      const probeable = planFleetTargets(reg).filter((t) => !t.skip).map((t) => t.device);
+      const res = await loadFleetStats(probeable, { forceRefresh: true, selfName: self });
+      log('INFO', `fleet cache warm: ${authRows.length} auth row(s), ${res.stats.size} device stat(s)`);
+    } catch (err) {
+      log('ERROR', `fleet cache warm failed: ${(err as Error).message}`);
+    } finally {
+      warmingFleetCache = false;
+    }
+  };
+  const fleetCacheInterval = setInterval(() => { void runFleetCacheWarm(); }, 3 * 60_000);
+  const fleetCacheKickoff = setTimeout(() => { void runFleetCacheWarm(); }, 60_000);
+
   const handleReload = () => {
     log('INFO', 'Reloading jobs (SIGHUP)');
     scheduler.reloadAll();
@@ -634,6 +669,8 @@ export async function runDaemon(): Promise<void> {
     clearTimeout(tmuxReconcileKickoff);
     clearInterval(launchHealthInterval);
     clearTimeout(launchHealthKickoff);
+    clearInterval(fleetCacheInterval);
+    clearTimeout(fleetCacheKickoff);
     hostedBroker?.close();
     removeDaemonPid();
     removeHeartbeat();

--- a/apps/cli/src/lib/devices/health-report.test.ts
+++ b/apps/cli/src/lib/devices/health-report.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildFleetHealthReport,
+  freshnessFooter,
   renderFleetMatrix,
   renderFleetWarnings,
   type FleetHealthRow,
@@ -22,6 +23,7 @@ function row(overrides: Partial<FleetHealthRow> & { name: string }): FleetHealth
       { agent: 'codex', version: '0.1.0', status: 'fresh', isDefault: true },
     ],
     orphans: overrides.orphans ?? [],
+    auth: overrides.auth,
   };
 }
 
@@ -74,5 +76,51 @@ describe('fleet health renderers', () => {
     const header = mlines.find((l) => l.includes('Device'))!;
     const dataRow = mlines.find((l) => l.includes('fresh-box'))!;
     expect(header.indexOf('Device')).toBe(dataRow.indexOf('fresh-box'));
+  });
+});
+
+describe('Auth column + freshness', () => {
+  it('renders a compact per-host auth cell and includes an Auth header', () => {
+    const report = buildFleetHealthReport([
+      row({ name: 'live-box', auth: { live: 4, present: 0, degraded: 0, revoked: 0, total: 4, oldestCheckedAt: 1000 } }),
+      row({ name: 'mixed-box', auth: { live: 2, present: 3, degraded: 1, revoked: 1, total: 7, oldestCheckedAt: 1000 } }),
+      row({ name: 'nocache-box' }), // no auth rollup → em dash
+    ]);
+    const lines = renderFleetMatrix(report).map(stripAnsi);
+    expect(lines.find((l) => l.includes('Device'))).toContain('Auth');
+    expect(lines.find((l) => l.includes('live-box'))).toContain('●4');
+    const mixed = lines.find((l) => l.includes('mixed-box'))!;
+    expect(mixed).toContain('●2');
+    expect(mixed).toContain('·3'); // present (signed in, unprobeable) — neutral, not alarming
+    expect(mixed).toContain('◐1'); // degraded (soft)
+    expect(mixed).toContain('○1'); // revoked (re-login)
+    expect(lines.find((l) => l.includes('nocache-box'))).toContain('—');
+  });
+
+  it('does not paint present (unverified) accounts as degraded ◐', () => {
+    // The bug this guards: a fleet of signed-in codex/grok accounts (all
+    // `unverified`) must not read as degraded. Only `·` should appear, no `◐`.
+    const report = buildFleetHealthReport([
+      row({ name: 'unprobeable', auth: { live: 0, present: 6, degraded: 0, revoked: 0, total: 6, oldestCheckedAt: 1000 } }),
+    ]);
+    const cell = renderFleetMatrix(report).map(stripAnsi).find((l) => l.includes('unprobeable'))!;
+    expect(cell).toContain('·6');
+    expect(cell).not.toContain('◐'); // never rendered as degraded
+  });
+
+  it('freshnessFooter dates both stats and auth and points at --refresh', () => {
+    const now = 100_000;
+    const foot = freshnessFooter([
+      row({ name: 'a', stats: { host: 'a', reachable: true, fetchedAt: now - 120_000 } as never,
+            auth: { live: 1, present: 0, degraded: 0, revoked: 0, total: 1, oldestCheckedAt: now - 300_000 } }),
+    ], now);
+    expect(foot).toContain('stats 2m ago');
+    expect(foot).toContain('auth 5m ago');
+    expect(foot).toContain('--refresh');
+    expect(foot).toContain('--live');
+  });
+
+  it('freshnessFooter returns null when no row carries a timestamp', () => {
+    expect(freshnessFooter([row({ name: 'a' })])).toBeNull();
   });
 });

--- a/apps/cli/src/lib/devices/health-report.test.ts
+++ b/apps/cli/src/lib/devices/health-report.test.ts
@@ -97,6 +97,21 @@ describe('Auth column + freshness', () => {
     expect(lines.find((l) => l.includes('nocache-box'))).toContain('—');
   });
 
+  it('sizes the Auth column so a wide mixed-auth cell never misaligns later columns', () => {
+    // Regression: a full `●2 ·3 ◐1 ○1` cell (11 display cells) overflowed a
+    // hard-coded 9-wide slot, shoving Version/Load-Mem/Note right on that row.
+    // Same name width + same version → the Version value must start at the same
+    // column in both the wide-auth row and the em-dash row.
+    const report = buildFleetHealthReport([
+      row({ name: 'aaaa', version: '9.9.9', auth: { live: 2, present: 3, degraded: 1, revoked: 1, total: 7, oldestCheckedAt: 1 } }),
+      row({ name: 'bbbb', version: '9.9.9' }), // no auth → '—'
+    ]);
+    const lines = renderFleetMatrix(report).map(stripAnsi);
+    const wide = lines.find((l) => l.includes('aaaa'))!;
+    const narrow = lines.find((l) => l.includes('bbbb'))!;
+    expect(wide.indexOf('9.9.9')).toBe(narrow.indexOf('9.9.9'));
+  });
+
   it('does not paint present (unverified) accounts as degraded ◐', () => {
     // The bug this guards: a fleet of signed-in codex/grok accounts (all
     // `unverified`) must not read as degraded. Only `·` should appear, no `◐`.

--- a/apps/cli/src/lib/devices/health-report.ts
+++ b/apps/cli/src/lib/devices/health-report.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { padToWidth, terminalWidth, truncateToWidth } from '../session/width.js';
+import { padToWidth, stringWidth, terminalWidth, truncateToWidth } from '../session/width.js';
 import { fmtBytes, headroom, type DeviceStats } from './health.js';
 import { formatCheckedAge, type HostAuthSummary } from '../auth-health.js';
 
@@ -228,16 +228,20 @@ export function renderFleetMatrix(report: FleetHealthReport): string[] {
     14,
     Math.max(7, ...report.devices.map((r) => (r.version ?? '-').length)),
   );
+  // Auth cells are variable-length (up to four space-separated buckets, e.g.
+  // `●2 ·3 ◐1 ○1`); size the column to the widest so a mixed-auth row can't
+  // overflow the fixed slot and shove every later column out of alignment.
+  const authW = Math.max(9, ...report.devices.map((r) => stringWidth(authLabel(r))));
   const width = terminalWidth();
   // 4 = leading "  " + the per-row status glyph + its trailing space (rows prefix
   // `  ${statusGlyph} `; the header reserves the same 4 cols so every column lines up).
-  // Columns: Device, OS(8), Health(9), Sync(9), CLI(9), Auth(9), Version, Load/Mem(9), then Note.
-  const fixed = 4 + nameW + 2 + 8 + 2 + 9 + 2 + 9 + 2 + 9 + 2 + 9 + 2 + versionW + 2 + 9;
+  // Columns: Device, OS(8), Health(9), Sync(9), CLI(9), Auth(authW), Version, Load/Mem(9), then Note.
+  const fixed = 4 + nameW + 2 + 8 + 2 + 9 + 2 + 9 + 2 + 9 + 2 + authW + 2 + versionW + 2 + 9;
   const noteW = Math.max(12, width - fixed);
   const lines = [
     chalk.bold('Fleet status'),
     chalk.gray(
-      `    ${padToWidth('Device', nameW)}  ${padToWidth('OS', 8)}  ${padToWidth('Health', 9)}  ${padToWidth('Sync', 9)}  ${padToWidth('CLI', 9)}  ${padToWidth('Auth', 9)}  ${padToWidth('Version', versionW)}  ${padToWidth('Load/Mem', 9)}  Note`,
+      `    ${padToWidth('Device', nameW)}  ${padToWidth('OS', 8)}  ${padToWidth('Health', 9)}  ${padToWidth('Sync', 9)}  ${padToWidth('CLI', 9)}  ${padToWidth('Auth', authW)}  ${padToWidth('Version', versionW)}  ${padToWidth('Load/Mem', 9)}  Note`,
     ),
   ];
   for (const row of report.devices) {
@@ -248,7 +252,7 @@ export function renderFleetMatrix(report: FleetHealthReport): string[] {
       `${padToWidth(headroomLabel(row), 9)}  ` +
       `${padToWidth(driftLabel(row), 9)}  ` +
       `${padToWidth(cliLabel(row), 9)}  ` +
-      `${padToWidth(authLabel(row), 9)}  ` +
+      `${padToWidth(authLabel(row), authW)}  ` +
       `${padToWidth(truncateToWidth(row.version ?? '-', versionW), versionW)}  ` +
       `${padToWidth(loadLabel(row.stats), 9)}  ` +
       chalk.gray(truncateToWidth(note || `free ${fmtBytes(row.stats?.memFreeBytes)}`, noteW)),

--- a/apps/cli/src/lib/devices/health-report.ts
+++ b/apps/cli/src/lib/devices/health-report.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import { padToWidth, terminalWidth, truncateToWidth } from '../session/width.js';
 import { fmtBytes, headroom, type DeviceStats } from './health.js';
+import { formatCheckedAge, type HostAuthSummary } from '../auth-health.js';
 
 export interface FleetCliStatus {
   installed: boolean;
@@ -34,6 +35,9 @@ export interface FleetHealthRow {
   clis: Record<string, FleetCliStatus>;
   sync: FleetSyncStatus[];
   orphans: FleetOrphanStatus[];
+  /** Cached auth-health rollup for this host (the Auth column). Undefined when
+   *  the host has never been probed (`agents fleet ping`) or the cache is cold. */
+  auth?: HostAuthSummary;
 }
 
 export interface FleetWarning {
@@ -171,6 +175,41 @@ function loadLabel(stats: DeviceStats | undefined): string {
   return `${load}/${mem}`;
 }
 
+/**
+ * Compact per-host auth cell. Four buckets, deliberately distinct so the column
+ * doesn't cry wolf on healthy accounts:
+ *   `●{live}`     green  — live-verified
+ *   `·{present}`  gray   — signed in but no live probe (codex/grok/…): benign
+ *   `◐{degraded}` yellow — soft/self-healing (expired/limited/error)
+ *   `○{revoked}`  red    — server rejected the token: re-login now
+ * A host with no cached auth rows shows "—"; an unreachable/skipped row shows
+ * "-" like the other probe columns.
+ */
+function authLabel(row: FleetHealthRow): string {
+  if (row.error || row.skipped) return chalk.gray('-');
+  const s = row.auth;
+  if (!s || s.total === 0) return chalk.gray('—');
+  const parts: string[] = [];
+  if (s.live > 0) parts.push(chalk.green(`●${s.live}`));
+  if (s.present > 0) parts.push(chalk.gray(`·${s.present}`));
+  if (s.degraded > 0) parts.push(chalk.yellow(`◐${s.degraded}`));
+  if (s.revoked > 0) parts.push(chalk.red(`○${s.revoked}`));
+  // All-zero can't happen (total > 0); but if only present/degraded exist we
+  // still lead with them — never show an empty cell for a probed host.
+  return parts.length > 0 ? parts.join(' ') : chalk.gray('—');
+}
+
+/** Oldest epoch-ms timestamp across rows for a field, or null when none present. */
+function oldestAcross(rows: FleetHealthRow[], pick: (r: FleetHealthRow) => number | null | undefined): number | null {
+  let oldest: number | null = null;
+  for (const row of rows) {
+    const t = pick(row);
+    if (t == null) continue;
+    if (oldest === null || t < oldest) oldest = t;
+  }
+  return oldest;
+}
+
 export function renderFleetWarnings(report: FleetHealthReport): string[] {
   if (report.warnings.length === 0) return [chalk.green('Fleet warnings: none')];
   return [
@@ -192,12 +231,13 @@ export function renderFleetMatrix(report: FleetHealthReport): string[] {
   const width = terminalWidth();
   // 4 = leading "  " + the per-row status glyph + its trailing space (rows prefix
   // `  ${statusGlyph} `; the header reserves the same 4 cols so every column lines up).
-  const fixed = 4 + nameW + 2 + 8 + 2 + 9 + 2 + 9 + 2 + versionW + 2 + 9 + 2 + 9;
+  // Columns: Device, OS(8), Health(9), Sync(9), CLI(9), Auth(9), Version, Load/Mem(9), then Note.
+  const fixed = 4 + nameW + 2 + 8 + 2 + 9 + 2 + 9 + 2 + 9 + 2 + 9 + 2 + versionW + 2 + 9;
   const noteW = Math.max(12, width - fixed);
   const lines = [
     chalk.bold('Fleet status'),
     chalk.gray(
-      `    ${padToWidth('Device', nameW)}  ${padToWidth('OS', 8)}  ${padToWidth('Health', 9)}  ${padToWidth('Sync', 9)}  ${padToWidth('CLI', 9)}  ${padToWidth('Version', versionW)}  ${padToWidth('Load/Mem', 9)}  Note`,
+      `    ${padToWidth('Device', nameW)}  ${padToWidth('OS', 8)}  ${padToWidth('Health', 9)}  ${padToWidth('Sync', 9)}  ${padToWidth('CLI', 9)}  ${padToWidth('Auth', 9)}  ${padToWidth('Version', versionW)}  ${padToWidth('Load/Mem', 9)}  Note`,
     ),
   ];
   for (const row of report.devices) {
@@ -208,11 +248,30 @@ export function renderFleetMatrix(report: FleetHealthReport): string[] {
       `${padToWidth(headroomLabel(row), 9)}  ` +
       `${padToWidth(driftLabel(row), 9)}  ` +
       `${padToWidth(cliLabel(row), 9)}  ` +
+      `${padToWidth(authLabel(row), 9)}  ` +
       `${padToWidth(truncateToWidth(row.version ?? '-', versionW), versionW)}  ` +
       `${padToWidth(loadLabel(row.stats), 9)}  ` +
       chalk.gray(truncateToWidth(note || `free ${fmtBytes(row.stats?.memFreeBytes)}`, noteW)),
     );
   }
-  lines.push(chalk.gray('  ● fresh · ◐ drift · ○ unreachable/skipped'));
+  lines.push(chalk.gray('  ● fresh · ◐ drift · ○ unreachable/skipped · Auth ●live ·present ◐degraded ○revoked'));
+  const foot = freshnessFooter(report.devices);
+  if (foot) lines.push(chalk.gray(foot));
   return lines;
+}
+
+/**
+ * "as of …" line so cache-served output is honest about age and points at the
+ * refresh flag. Stats age comes from `stats.fetchedAt`, auth age from the
+ * cached rollup's `oldestCheckedAt`; either may be absent. Returns null when the
+ * table carries no timestamped data at all (nothing to date).
+ */
+export function freshnessFooter(rows: FleetHealthRow[], now: number = Date.now()): string | null {
+  const oldestStats = oldestAcross(rows, (r) => r.stats?.fetchedAt);
+  const oldestAuth = oldestAcross(rows, (r) => r.auth?.oldestCheckedAt);
+  const parts: string[] = [];
+  if (oldestStats != null) parts.push(`stats ${formatCheckedAge(oldestStats, now)}`);
+  if (oldestAuth != null) parts.push(`auth ${formatCheckedAge(oldestAuth, now)}`);
+  if (parts.length === 0) return null;
+  return `  updated ${parts.join(' · ')} — pass --refresh (--live) for a live probe`;
 }

--- a/apps/cli/src/lib/devices/stats-cache.test.ts
+++ b/apps/cli/src/lib/devices/stats-cache.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+
+import { loadFleetStats } from './stats-cache.js';
+import type { DeviceStats } from './health.js';
+import type { DeviceProfile } from './registry.js';
+
+function dev(name: string): DeviceProfile {
+  return { name, platform: 'linux' } as DeviceProfile;
+}
+
+function stat(host: string, fetchedAt: number, loadPercent = 10): DeviceStats {
+  return { host, reachable: true, loadPercent, memPercent: 20, ncpu: 4, fetchedAt };
+}
+
+/** A probe stub that records which devices it was asked to probe. */
+function fakeProbe(now: number, probed: string[]) {
+  return (async (devices: DeviceProfile[]) => {
+    const m = new Map<string, DeviceStats>();
+    for (const d of devices) {
+      probed.push(d.name);
+      m.set(d.name, stat(d.name, now));
+    }
+    return m;
+  }) as unknown as Parameters<typeof loadFleetStats>[1]['probeFleet'];
+}
+
+describe('loadFleetStats', () => {
+  it('serves cached remotes and never ssh-probes them (default path)', async () => {
+    const probed: string[] = [];
+    const cache = { a: stat('a', 1000), b: stat('b', 1000) };
+    const res = await loadFleetStats([dev('a'), dev('b')], {
+      selfName: 'z', // not in the list — no local probe needed either
+      readCache: () => ({ ...cache }),
+      writeCache: () => {},
+      probeFleet: fakeProbe(2000, probed),
+      probeLocal: (async (h: string) => stat(h, 2000)) as never,
+    });
+    expect(probed).toEqual([]); // both served from cache
+    expect(res.servedFromCache).toBe(true);
+    expect(res.stats.get('a')?.fetchedAt).toBe(1000);
+    expect(res.oldestFetchedAt).toBe(1000);
+  });
+
+  it('always probes THIS machine locally even when cached', async () => {
+    const probed: string[] = [];
+    const cache = { z: stat('z', 1000) };
+    const res = await loadFleetStats([dev('z')], {
+      selfName: 'z',
+      readCache: () => ({ ...cache }),
+      writeCache: () => {},
+      probeFleet: fakeProbe(2000, probed),
+      probeLocal: (async (h: string) => stat(h, 2000)) as never,
+    });
+    // self went through probeFleet (which handles selfName locally); it is never
+    // served stale from cache.
+    expect(probed).toContain('z');
+    expect(res.stats.get('z')?.fetchedAt).toBe(2000);
+  });
+
+  it('probes only the devices missing from the cache (gap-fill) and persists them', async () => {
+    const probed: string[] = [];
+    const written: Record<string, DeviceStats>[] = [];
+    const cache = { a: stat('a', 1000) };
+    const res = await loadFleetStats([dev('a'), dev('b')], {
+      selfName: 'z',
+      readCache: () => ({ ...cache }),
+      writeCache: (e) => { written.push(e); },
+      probeFleet: fakeProbe(2000, probed),
+      probeLocal: (async (h: string) => stat(h, 2000)) as never,
+    });
+    expect(probed).toEqual(['b']);            // only the uncached one
+    expect(res.stats.get('a')?.fetchedAt).toBe(1000); // cached
+    expect(res.stats.get('b')?.fetchedAt).toBe(2000); // fresh
+    expect(written).toHaveLength(1);
+    expect(Object.keys(written[0])).toEqual(['b']);   // only fresh rows persisted
+  });
+
+  it('forceRefresh bypasses the cache and probes every device', async () => {
+    const probed: string[] = [];
+    const cache = { a: stat('a', 1000), b: stat('b', 1000) };
+    const res = await loadFleetStats([dev('a'), dev('b')], {
+      forceRefresh: true,
+      selfName: 'z',
+      readCache: () => ({ ...cache }),
+      writeCache: () => {},
+      probeFleet: fakeProbe(2000, probed),
+      probeLocal: (async (h: string) => stat(h, 2000)) as never,
+    });
+    expect(probed.sort()).toEqual(['a', 'b']);
+    expect(res.servedFromCache).toBe(false);
+    expect(res.oldestFetchedAt).toBe(2000);
+  });
+
+  it('falls back to a local probe for a self not present in the device list', async () => {
+    const res = await loadFleetStats([], {
+      selfName: 'z',
+      readCache: () => ({}),
+      writeCache: () => {},
+      probeFleet: fakeProbe(2000, []),
+      probeLocal: (async (h: string) => stat(h, 3000)) as never,
+    });
+    expect(res.stats.get('z')?.fetchedAt).toBe(3000);
+  });
+});

--- a/apps/cli/src/lib/devices/stats-cache.ts
+++ b/apps/cli/src/lib/devices/stats-cache.ts
@@ -15,8 +15,8 @@
  * - **`--refresh` / `--live`:** skip the cache and live-probe every device,
  *   rewriting the cache.
  *
- * The daemon's device probe warms this cache (~every 3 min, see
- * `lib/daemon.ts runDeviceProbe`), so in steady state a default read has zero
+ * The daemon warms this cache (~every 3 min, see `lib/daemon.ts
+ * runFleetCacheWarm`), so in steady state a default read has zero
  * remote ssh round-trips and returns immediately with data that is at most a
  * few minutes old — surfaced to the user as an "as of …" freshness note.
  */

--- a/apps/cli/src/lib/devices/stats-cache.ts
+++ b/apps/cli/src/lib/devices/stats-cache.ts
@@ -1,0 +1,150 @@
+/**
+ * Disk cache for fleet {@link DeviceStats} so `agents devices list` and
+ * `agents fleet status` render instantly from the last probe instead of
+ * live-SSHing every registered box on every invocation.
+ *
+ * The old behaviour probed the whole fleet over ssh on every call
+ * ({@link probeFleetStats}) — with a dozen devices, a few of them cold or
+ * timing out, that turned a status glance into a multi-second hang. This module
+ * makes the reads cache-first:
+ *
+ * - **Default:** serve remote devices from the cache (instant); always probe
+ *   *this* machine locally (no ssh, sub-ms) so the "this machine" row is live;
+ *   probe only the remote devices missing from the cache (first run / a
+ *   newly-added box), then persist them.
+ * - **`--refresh` / `--live`:** skip the cache and live-probe every device,
+ *   rewriting the cache.
+ *
+ * The daemon's device probe warms this cache (~every 3 min, see
+ * `lib/daemon.ts runDeviceProbe`), so in steady state a default read has zero
+ * remote ssh round-trips and returns immediately with data that is at most a
+ * few minutes old — surfaced to the user as an "as of …" freshness note.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { getCacheDir } from '../state.js';
+import { probeFleetStats, probeLocalStats, type DeviceStats } from './health.js';
+import type { DeviceProfile } from './registry.js';
+
+const CACHE_FILE = '.fleet-stats.json';
+
+interface StatsCacheFile {
+  version: 1;
+  entries: Record<string, DeviceStats>;
+}
+
+function cacheFilePath(): string {
+  return path.join(getCacheDir(), CACHE_FILE);
+}
+
+/** Read the whole cache (best-effort; a missing/corrupt file yields an empty map). */
+export function readStatsCache(): Record<string, DeviceStats> {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cacheFilePath(), 'utf-8')) as StatsCacheFile;
+    if (parsed && parsed.entries && typeof parsed.entries === 'object') return parsed.entries;
+  } catch {
+    // missing or corrupt — treat as empty
+  }
+  return {};
+}
+
+/**
+ * Merge freshly-probed rows into the on-disk cache (best-effort write). Rows for
+ * devices not in `entries` are preserved, so a partial probe (gap-fill, or a
+ * single-device refresh) never drops the rest of the fleet's cached stats.
+ */
+export function writeStatsCache(entries: Record<string, DeviceStats>): void {
+  try {
+    const dir = getCacheDir();
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const merged: StatsCacheFile = {
+      version: 1,
+      entries: { ...readStatsCache(), ...entries },
+    };
+    fs.writeFileSync(cacheFilePath(), JSON.stringify(merged, null, 2));
+  } catch {
+    // best-effort; a failed write just means the next read falls back to a live probe
+  }
+}
+
+export interface FleetStatsResult {
+  /** name → stats for every requested device (cache-served + freshly probed). */
+  stats: Map<string, DeviceStats>;
+  /** Oldest `fetchedAt` among the returned rows, or null when empty. Drives the
+   *  "as of …" freshness note. */
+  oldestFetchedAt: number | null;
+  /** True when at least one row was served from cache rather than probed this call. */
+  servedFromCache: boolean;
+}
+
+export interface LoadFleetStatsOptions {
+  /** Skip the cache and live-probe every device (the `--refresh`/`--live` path). */
+  forceRefresh?: boolean;
+  /** Device name of THIS machine — always probed locally (no ssh), never cached-served. */
+  selfName?: string;
+  /** Injectable probes + cache IO for tests (default to the real ssh/local/disk ones). */
+  probeFleet?: typeof probeFleetStats;
+  probeLocal?: typeof probeLocalStats;
+  readCache?: typeof readStatsCache;
+  writeCache?: typeof writeStatsCache;
+}
+
+/**
+ * Load fleet stats cache-first. See the module doc for the default vs
+ * `--refresh` behaviour. Never throws — an unreachable box degrades to a
+ * `reachable: false` row exactly as the live probe does.
+ */
+export async function loadFleetStats(
+  devices: DeviceProfile[],
+  opts: LoadFleetStatsOptions = {},
+): Promise<FleetStatsResult> {
+  const probeFleet = opts.probeFleet ?? probeFleetStats;
+  const probeLocal = opts.probeLocal ?? probeLocalStats;
+  const readCache = opts.readCache ?? readStatsCache;
+  const writeCache = opts.writeCache ?? writeStatsCache;
+  const self = opts.selfName;
+  const cache = opts.forceRefresh ? {} : readCache();
+
+  const stats = new Map<string, DeviceStats>();
+  const toProbe: DeviceProfile[] = [];
+  let servedFromCache = false;
+
+  for (const d of devices) {
+    if (d.name === self) {
+      // This machine is always probed locally — cheap, no ssh, always live.
+      toProbe.push(d);
+      continue;
+    }
+    const cached = cache[d.name];
+    if (cached) {
+      stats.set(d.name, cached);
+      servedFromCache = true;
+    } else {
+      toProbe.push(d);
+    }
+  }
+
+  if (toProbe.length > 0) {
+    const probed = await probeFleet(toProbe, { selfName: self });
+    const fresh: Record<string, DeviceStats> = {};
+    for (const [name, s] of probed) {
+      stats.set(name, s);
+      fresh[name] = s;
+    }
+    if (Object.keys(fresh).length > 0) writeCache(fresh);
+  }
+
+  // Guarantee a row for this machine even when it isn't in the passed device
+  // list (e.g. self not registered as an ssh target) — matches the old callers'
+  // explicit local fallback.
+  if (self && !stats.has(self)) {
+    stats.set(self, await probeLocal(self));
+  }
+
+  let oldest: number | null = null;
+  for (const s of stats.values()) {
+    if (oldest === null || s.fetchedAt < oldest) oldest = s.fetchedAt;
+  }
+  return { stats, oldestFetchedAt: oldest, servedFromCache };
+}


### PR DESCRIPTION
## Why

Two problems on the fleet/devices surface:

1. **`agents devices list` / `agents fleet status` were slow** — both live-SSH'd every registered box for load/mem on *every* call. On a dozen-device fleet with a few cold/timing-out nodes, a glance hung for seconds.
2. **`agents fleet status` didn't show login state at all** — the auth-health system existed (`fleet ping`) but was a separate command; the status table had no Auth column.

## What

**Cache-first reads + `--refresh`/`--live`:**
- New `.fleet-stats.json` cache (`lib/devices/stats-cache.ts`). Default reads serve remote devices from cache, probe only *this* machine locally + any device missing from cache. `--refresh` (alias **`--live`**, shorter to type) forces a full live probe. Cache-served output notes its age (`updated 2m ago — pass --refresh (--live) …`).
- The daemon warms the stats cache **and** this host's auth verdicts ~every 3 min, so cached reads stay fresh.
- `agents view` gains the `--live` alias for its existing `--refresh` (usage was already stale-while-revalidate cached).

**Auth column on `agents fleet status`** — which accounts are actually logged in, per device, from the auth-health cache (no network). Remote hosts self-report their rollup via `doctor --json`, so it's current without a fleet-wide `fleet ping`.

## The Auth column has to be honest — before/after

`summarizeHostAuth()` rolls each host into **four** buckets instead of the old three, which lumped `unverified` + `expired` + `error` into one alarming yellow `◐`. That made a fleet of **perfectly logged-in** codex/grok/kimi accounts read as broken:

```
before:   ◐ zion   …   Auth: ●5 ◐8      ← looks half-degraded
after:    ◐ zion   …   Auth: ●5 ·6 ◐2   ← 0 revoked = nothing to re-login
```

Legend: `●live · present(signed in, no live-probe endpoint — codex/grok/…, benign) ◐degraded(soft/self-healing: expired/limited/error) ○revoked(server rejected — re-login now)`. **Only `○` means a real re-login is needed.**

Root cause of a "why are 8 of my accounts degraded?!" report (they weren't): `codex/grok/antigravity/opencode` have no live-probe endpoint (`LIVE_PROBE_AGENTS = {claude,kimi,droid}`), so a signed-in account is `unverified` — benign, but the old rollup painted it `◐`. `kimi expired` is a local access-token clock read; its refresh token self-heals on next launch. Verified independently by two blind code-tracers.

## Tests
- `stats-cache.test.ts` (new): cache-served vs probed, self always local, gap-fill, `forceRefresh`, self-fallback.
- `auth-health.test.ts`: `summarizeHostAuth` bucket split + host-prefix isolation (no `zion` / `zion-2` bleed).
- `health-report.test.ts`: Auth column render, `·present` never shown as `◐`, freshness footer.
- Full suite green (208 passed), typecheck clean, verified end-to-end against the live fleet (screenshots of real output in the description above).

Session transcript (fleet host): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/7c6db62d-2f6f-46b3-ae5d-8ce38a9f3cd7.jsonl`