### PR TITLE
fix(sessions): redact secrets in --json by default; make --no-redact actually work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,18 @@
     stage for everyone else.
   - Shared containment helpers `isSafeSegmentName` / `assertWithin` added to
     `apps/cli/src/lib/paths.ts`.
+- **`agents sessions <id> --json` now redacts secrets by default.** The JSON render
+  path emitted raw transcript events with no redaction, while `--markdown` masked
+  them by default — so the output format an agent scripts against was the one that
+  leaked credentials. `renderJson` now runs the whole payload (events *and* the
+  session meta, including `topic`/`plan` — verbatim message excerpts) through the
+  same `redactSecrets` pass as markdown, covering the JSON-only leak vector of raw
+  tool-call `args`. Additionally, `--no-redact` now actually works: it read the
+  wrong Commander property (`options.noRedact`, never populated) so the flag was a
+  dead no-op for **both** formats; it now reads `--no-redact`'s real `redact`
+  property and genuinely disables redaction when passed. Source:
+  `apps/cli/src/lib/session/render.ts` (`renderJson`, `redactDeep`),
+  `apps/cli/src/commands/sessions.ts`.
 
 ### Added
 

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -70,7 +70,8 @@ interface SessionsOptions extends SessionFilterOptions {
   sort?: string;
   json?: boolean;
   markdown?: boolean;
-  noRedact?: boolean;
+  /** Commander populates this from `--no-redact`: true by default, false when the flag is passed. */
+  redact?: boolean;
   include?: string;
   exclude?: string;
   first?: string;
@@ -1136,7 +1137,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
   // When the user explicitly asks to render (via mode flag), resolve the
   // query globally so sessions outside the default cwd/30d window are found.
   if (wantsRender && searchQuery) {
-    await renderOneSession(searchQuery, mode, { agent: options.agent, project: options.project, filter: filterOpts, noRedact: options.noRedact });
+    await renderOneSession(searchQuery, mode, { agent: options.agent, project: options.project, filter: filterOpts, redact: options.redact });
     return;
   }
 
@@ -1215,7 +1216,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
         return;
       }
       if (idMatches.length === 0 && looksLikeSessionId(searchQuery)) {
-        await renderOneSession(searchQuery, mode, { agent: options.agent, project: options.project, filter: filterOpts, noRedact: options.noRedact });
+        await renderOneSession(searchQuery, mode, { agent: options.agent, project: options.project, filter: filterOpts, redact: options.redact });
         return;
       }
     }
@@ -1597,7 +1598,7 @@ async function renderSession(
   session: SessionMeta,
   mode: ViewMode,
   filters: FilterOptions,
-  options: Pick<SessionsOptions, 'noRedact'> = {},
+  options: { redact?: boolean } = {},
 ): Promise<void> {
   // OpenCode stores sessions in SQLite; filePath is "db_path#session_id"
   const realPath = session.filePath.split('#')[0];
@@ -1658,7 +1659,7 @@ async function renderSession(
       (session.account ? chalk.gray(` (${session.account})`) : '')
     );
     console.log(chalk.gray('─'.repeat(60)));
-    process.stdout.write(renderMarkdown(renderConversationMarkdown(events, { redact: options.noRedact !== true })));
+    process.stdout.write(renderMarkdown(renderConversationMarkdown(events, { redact: options.redact !== false })));
     return;
   }
 
@@ -1670,7 +1671,9 @@ async function renderSession(
   // checklist reflects true session state regardless of any `--include` filter;
   // it lets the Factory panel read the CLI's checklist instead of re-parsing.
   const todos = inferSessionState(parsedEvents, { cwd: session.cwd }).todos;
-  process.stdout.write(renderJson(events, todos ? { ...session, todos } : session));
+  process.stdout.write(
+    renderJson(events, todos ? { ...session, todos } : session, { redact: options.redact !== false }),
+  );
 }
 
 function renderTopicCell(
@@ -2360,7 +2363,7 @@ async function renderArtifactsGlobal(
 async function renderOneSession(
   query: string,
   mode: ViewMode,
-  scope: { agent?: string; project?: string; filter: FilterOptions; noRedact?: boolean },
+  scope: { agent?: string; project?: string; filter: FilterOptions; redact?: boolean },
 ): Promise<void> {
   const spinner = ora().start();
   const tracker = createScanProgressTracker(FIND_VERBS, 'session', spinner);
@@ -2430,7 +2433,7 @@ async function renderOneSession(
     }
 
     spinner.stop();
-    await renderSession(session, mode, scope.filter, { noRedact: scope.noRedact });
+    await renderSession(session, mode, scope.filter, { redact: scope.redact });
   } catch (err: any) {
     if (isPromptCancelled(err)) return;
     tracker.stop();
@@ -2462,7 +2465,7 @@ export function registerSessionsCommands(program: Command): void {
     .option('-n, --limit <n>', 'Maximum number of sessions to return', '50')
     .option('--sort <field>', 'Sort the list by: recent (default), cost, or duration')
     .option('--markdown', 'Render the session as markdown (user, assistant, thinking, tool calls)')
-    .option('--no-redact', 'Disable default secret redaction in markdown session output')
+    .option('--no-redact', 'Disable default secret redaction in rendered session output (--markdown and --json)')
     .option('--json', 'Output JSON (session list when browsing, event array when rendering one session)')
     .option('--include <roles>', 'Only include these roles (comma-separated): user, assistant, thinking, tools')
     .option('--exclude <roles>', 'Exclude these roles (comma-separated): user, assistant, thinking, tools')

--- a/apps/cli/src/lib/session/__tests__/render.test.ts
+++ b/apps/cli/src/lib/session/__tests__/render.test.ts
@@ -17,6 +17,7 @@ import {
   filterEvents,
   parseRoleList,
   renderConversationMarkdown,
+  renderJson,
 } from '../render.js';
 import type { SessionEvent } from '../types.js';
 
@@ -212,6 +213,74 @@ describe('renderConversationMarkdown', () => {
     ];
     const out = renderConversationMarkdown(events, { redact: false });
     expect(out).toContain('TOKEN=abc123 deploy');
+  });
+});
+
+// ── renderJson redaction ──────────────────────────────────────────────────────
+// The JSON path is the one an agent scripts against, so it must not be the
+// output format that leaks credentials. It redacts by default.
+
+describe('renderJson redaction', () => {
+  const token = 'sk-' + 'a'.repeat(40);
+  const awsKey = 'AKIA' + '1234567890ABCDEF';
+
+  it('redacts secrets in content, command, and output by default', () => {
+    const events: SessionEvent[] = [
+      { type: 'message', agent: 'claude', timestamp: 't0', role: 'user', content: `my key ${token}` },
+      { type: 'tool_use', agent: 'claude', timestamp: 't1', tool: 'Bash', args: {}, command: 'TOKEN=abc123 deploy' },
+      { type: 'tool_result', agent: 'claude', timestamp: 't2', content: `leaked ${awsKey}`, output: `also ${token}` },
+    ];
+    const out = renderJson(events);
+    expect(out).not.toContain(token);
+    expect(out).not.toContain('AKIA1234567890ABCDEF');
+    expect(out).not.toContain('TOKEN=abc123');
+    expect(out).toContain('[REDACTED_API_KEY]');
+    expect(out).toContain('[REDACTED_AWS_KEY]');
+  });
+
+  it('redacts secrets nested inside tool_use args — the JSON-only leak vector', () => {
+    const events: SessionEvent[] = [
+      { type: 'tool_use', agent: 'claude', timestamp: 't0', tool: 'Http', args: { headers: { authorization: `Bearer ${token}` }, tries: [{ key: token }] } },
+    ];
+    const out = renderJson(events);
+    expect(out).not.toContain(token);
+    expect(out).toContain('[REDACTED_API_KEY]');
+    // structure is preserved, only the secret substring is masked
+    const parsed = JSON.parse(out);
+    expect(parsed[0].args.headers.authorization).toContain('Bearer');
+    expect(Array.isArray(parsed[0].args.tries)).toBe(true);
+  });
+
+  it('leaves secrets intact when redaction is explicitly disabled', () => {
+    const events: SessionEvent[] = [
+      { type: 'tool_use', agent: 'claude', timestamp: 't0', tool: 'Bash', args: { token }, command: 'TOKEN=abc123 deploy' },
+    ];
+    const out = renderJson(events, undefined, { redact: false });
+    expect(out).toContain('TOKEN=abc123 deploy');
+    expect(out).toContain(token);
+  });
+
+  it('wraps events under output.session/events when meta is provided', () => {
+    const events: SessionEvent[] = [
+      { type: 'message', agent: 'claude', timestamp: 't0', role: 'user', content: `key ${token}` },
+    ];
+    const out = renderJson(events, { agent: 'claude', timestamp: 't0' } as any);
+    const parsed = JSON.parse(out);
+    expect(parsed.session.agent).toBe('claude');
+    expect(parsed.events[0].content).not.toContain(token);
+  });
+
+  it('redacts free-text meta fields (topic/plan) — a first-message excerpt leaks otherwise', () => {
+    const events: SessionEvent[] = [
+      { type: 'message', agent: 'claude', timestamp: 't0', role: 'user', content: `use ${awsKey}` },
+    ];
+    const meta = { agent: 'claude', timestamp: 't0', topic: `use ${awsKey} now`, plan: `step: token ${token}` } as any;
+    const out = renderJson(events, meta);
+    expect(out).not.toContain(awsKey);
+    expect(out).not.toContain(token);
+    const parsed = JSON.parse(out);
+    expect(parsed.session.topic).toContain('[REDACTED_AWS_KEY]');
+    expect(parsed.session.plan).toContain('[REDACTED_API_KEY]');
   });
 });
 

--- a/apps/cli/src/lib/session/render.ts
+++ b/apps/cli/src/lib/session/render.ts
@@ -1024,17 +1024,50 @@ export function renderConversationMarkdown(
 }
 
 /**
+ * Deep-redact every string reachable from a JSON value, preserving structure.
+ * `redactSecrets` only rewrites secret-shaped substrings, so non-secret strings
+ * (paths, URLs, ids) and non-strings (numbers, booleans) pass through unchanged.
+ * Applied to the whole `--json` payload so every free-text field — event
+ * `content`/`command`/`output`/`args`, and meta `topic`/`label`/`plan`/`todos`
+ * — is covered, including fields added later.
+ */
+function redactDeep<T>(value: T, sanitize: (text: string) => string): T {
+  if (typeof value === 'string') return sanitize(value) as unknown as T;
+  if (Array.isArray(value)) return value.map((item) => redactDeep(item, sanitize)) as unknown as T;
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) out[key] = redactDeep(val, sanitize);
+    return out as T;
+  }
+  return value;
+}
+
+/**
  * Render one session's JSON output — the shape `agents sessions <id> --json`
  * emits. When `meta` is provided (the standard path), returns a
  * `{ session, events }` wrapper so top-level fields (`plan`, `prUrl`, …) that
  * live on `SessionMeta` are visible without re-parsing events. Legacy
  * callers that pass no meta still get a bare `SessionEvent[]` array.
+ *
+ * Secrets are redacted by default (`opts.redact !== false`), matching
+ * `renderConversationMarkdown` — the JSON path must not be the one output
+ * format that leaks credentials. Redaction covers both events AND the session
+ * meta (e.g. `topic`, a verbatim first-message excerpt). Pass `{ redact: false }`
+ * for `--no-redact`.
  */
-export function renderJson(events: SessionEvent[], meta?: SessionMeta): string {
-  if (!meta) return JSON.stringify(events, null, 2);
+export function renderJson(
+  events: SessionEvent[],
+  meta?: SessionMeta,
+  opts: { redact?: boolean } = {},
+): string {
+  const redact = opts.redact !== false;
+  const sanitize = (text: string): string => redactSecrets(text);
+  const safeEvents = redact ? events.map((event) => redactDeep(event, sanitize)) : events;
+  if (!meta) return JSON.stringify(safeEvents, null, 2);
   // Strip internal-only bookkeeping fields the listing --json path also strips.
-  const { _matchedTerms, _bm25Score, _remote, ...session } = meta;
-  return JSON.stringify({ session, events }, null, 2);
+  const { _matchedTerms, _bm25Score, _remote, ...rest } = meta;
+  const session = redact ? redactDeep(rest, sanitize) : rest;
+  return JSON.stringify({ session, events: safeEvents }, null, 2);
 }
 
 /** Replace the home directory prefix with ~ for trace display. */


### PR DESCRIPTION
## Problem

`agents sessions <id> --json` emitted **raw transcript events with no redaction**, while `--markdown` redacts by default. The output format an agent scripts against was the one that leaked credentials — surfaced in an API-surface audit as the single security-severity finding.

While fixing it, a **second, pre-existing bug** turned up: `--no-redact` read `options.noRedact`, but Commander populates a `--no-x` flag as `options.redact` (never `noRedact`). So `--no-redact` was a **dead no-op for both `--markdown` and `--json`** — redaction could never actually be disabled.

## Fix

- `renderJson` now runs the whole `--json` payload through the same `redactSecrets` pass as markdown — **events *and* the session meta**. Meta matters: `topic`/`plan` are verbatim message excerpts (a first-message secret leaks via `session.topic` otherwise). A single `redactDeep` walk also covers the JSON-only leak vector of **raw tool-call `args`** (which markdown only summarizes).
- `--no-redact` now reads the real `redact` property end-to-end (the internal threading is renamed off the misleading `noRedact`), so it genuinely disables redaction — for both formats.

`redactSecrets` only rewrites secret-shaped substrings, so paths/URLs/ids/numbers pass through untouched and future meta fields are covered automatically.

## Verified end-to-end (built binary, real session with a planted secret)

| invocation | raw-secret hits | expected |
|---|---|---|
| `sessions <id> --json` (default) | **0** | 0 — redacted |
| `sessions <id> --json --no-redact` | 2 | >0 — flag now works |
| `sessions <id> --markdown` (default) | **0** | 0 — redacted |
| `sessions <id> --markdown --no-redact` | 1 | >0 — was a dead flag, now works |

- New unit tests in `render.test.ts`: content/command/output redaction, nested `args` redaction, meta `topic`/`plan` redaction, and `{ redact: false }` passthrough.
- `render.test.ts` 93 passed; session/commands batch 628 passed; `tsc` + build clean.

## Scope

`apps/cli/src/lib/session/render.ts` (`renderJson`, `redactDeep`), `apps/cli/src/commands/sessions.ts` (thread the real `redact` property), tests, CHANGELOG (Security).

Session transcript (this repo is public — path only, not attached): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/bde29883-386c-4cdd-8d8b-056693c42a50.jsonl`