### PR TITLE
feat(fleet): capture the whole environment into agents.yaml; apply replicates it privacy-preservingly

### DIFF
--- a/apps/cli/.changelog/next/fleet-capture-replicate.md
+++ b/apps/cli/.changelog/next/fleet-capture-replicate.md
@@ -1,0 +1,15 @@
+- **Capture your whole fleet into `agents.yaml`, then rebuild it anywhere with
+  `agents apply` (#1305).** New `agents fleet capture` (alias `agents devices
+  capture`) snapshots the live environment into the portable `fleet:` block — the
+  device roster (**names only**), the source's agents as `defaults`, secrets-bundle
+  **names**, and routine **names**. It commits **zero** Tailscale IPs or usernames:
+  `agents apply` reconstructs a fresh machine's roster by resolving each device
+  name **live from Tailscale** (`ensureDevicesRegistered`), so `git clone` +
+  `agents apply` replicates the fleet with nothing sensitive in the repo. `apply`
+  now also passes declared `sync:` scopes through to `agents sync <scope>`
+  (previously a bare `sync`) and surfaces declared secrets-bundle names to recreate
+  on each device (values stay keychain-local, never pushed). Browser profiles are
+  intentionally not duplicated into `fleet:` — they already sync via the central
+  `browser:` block. Source: `apps/cli/src/commands/fleet-capture.ts`,
+  `apps/cli/src/lib/fleet/capture.ts`, `apps/cli/src/lib/devices/sync.ts`,
+  `apps/cli/src/lib/fleet/{types,manifest,apply}.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,23 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- **Capture your whole fleet into `agents.yaml`, then rebuild it anywhere with
-  `agents apply`.** New `agents fleet capture` (alias `agents devices capture`)
-  snapshots the live environment into the portable `fleet:` block — the device
-  roster (**names only**), the source's agents as `defaults`, secrets-bundle
-  **names**, and routine **names**. It commits **zero** Tailscale IPs or
-  usernames: `agents apply` reconstructs a fresh machine's roster by resolving
-  each device name **live from Tailscale** (`ensureDevicesRegistered`), so
-  `git clone` + `agents apply` replicates the fleet with nothing sensitive in the
-  repo. `apply` now also passes declared `sync:` scopes through to
-  `agents sync <scope>` (previously a bare `sync`) and surfaces declared
-  secrets-bundle names to recreate on each device (values stay keychain-local,
-  never pushed). Browser profiles are intentionally not duplicated into `fleet:`
-  — they already sync via the central `browser:` block. Source:
-  `apps/cli/src/commands/fleet-capture.ts`, `apps/cli/src/lib/fleet/capture.ts`,
-  `apps/cli/src/lib/devices/sync.ts`, `apps/cli/src/lib/fleet/{types,manifest,apply}.ts`.
-
 ## 1.20.70
 
 - **Fix `agents setup computer` / `agents computer setup` refusing to install a

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+- **Capture your whole fleet into `agents.yaml`, then rebuild it anywhere with
+  `agents apply`.** New `agents fleet capture` (alias `agents devices capture`)
+  snapshots the live environment into the portable `fleet:` block — the device
+  roster (**names only**), the source's agents as `defaults`, secrets-bundle
+  **names**, and routine **names**. It commits **zero** Tailscale IPs or
+  usernames: `agents apply` reconstructs a fresh machine's roster by resolving
+  each device name **live from Tailscale** (`ensureDevicesRegistered`), so
+  `git clone` + `agents apply` replicates the fleet with nothing sensitive in the
+  repo. `apply` now also passes declared `sync:` scopes through to
+  `agents sync <scope>` (previously a bare `sync`) and surfaces declared
+  secrets-bundle names to recreate on each device (values stay keychain-local,
+  never pushed). Browser profiles are intentionally not duplicated into `fleet:`
+  — they already sync via the central `browser:` block. Source:
+  `apps/cli/src/commands/fleet-capture.ts`, `apps/cli/src/lib/fleet/capture.ts`,
+  `apps/cli/src/lib/devices/sync.ts`, `apps/cli/src/lib/fleet/{types,manifest,apply}.ts`.
+
 ## 1.20.69
 
 - **Choose a safe account with `agents run <agent>@`.** A trailing `@` opens a

--- a/apps/cli/docs/fleet.md
+++ b/apps/cli/docs/fleet.md
@@ -43,6 +43,45 @@ fleet:
 `prompt` mode is intentionally not offered — it was removed rather than accepted
 as a silent no-op.)
 
+Two more additive, capture-only fields let a fresh machine reconstruct the whole
+environment — both are **names only, never values**:
+
+| Field | Meaning |
+|---|---|
+| `secrets.bundles` | Secrets-bundle **names** to ensure exist. Values live in the OS keychain and are never captured or pushed; `apply` surfaces missing bundles to recreate manually. |
+| `routines` | Routine **names** that should be active on the fleet (the routine files themselves sync via the repo). |
+
+> Browser profiles are **not** captured into `fleet:` — the central `browser:`
+> block already syncs verbatim via `agents repo push/pull`, and its `ssh://`
+> endpoints can carry `user@host`, which must never be copied into a second
+> location.
+
+## Capturing the profile (`agents fleet capture`)
+
+Hand-authoring `fleet:` is optional — `agents fleet capture` (alias of
+`agents devices capture`) snapshots the live environment into it:
+
+```
+agents fleet capture              # write agents.yaml → fleet:
+agents fleet capture --dry-run    # print the block, write nothing
+agents fleet capture --from-pins  # record per-device agents from devices/<name>/agents.yaml
+```
+
+It records device **names** (the roster), the source machine's own agents as
+`defaults`, secrets-bundle **names**, and routine **names** — and writes them to
+the central, portable `fleet:` block via `updateMeta`. It never touches the
+per-device `agents:` pins, and never writes an IP or username. Source:
+`src/commands/fleet-capture.ts`, `src/lib/fleet/capture.ts`.
+
+**Fresh-machine bootstrap.** The roster (`~/.agents/.history/devices/registry.json`)
+is machine-local and gitignored — so a freshly-cloned `agents.yaml` names devices
+this machine has never registered. `agents apply` handles that: for any device in
+an explicit `devices:` map that isn't in the local registry, it resolves the name
+**live from Tailscale** (`ensureDevicesRegistered`, `src/lib/devices/sync.ts`) and
+registers it before reconciling. So `git clone` + `agents apply` reconstructs the
+fleet with zero committed connection details. Names not on the tailnet are
+reported as unresolved rather than aborting the run.
+
 ## What a reconcile does
 
 For each targeted, reachable device `apply` probes state, then plans the minimal

--- a/apps/cli/src/commands/apply.ts
+++ b/apps/cli/src/commands/apply.ts
@@ -16,6 +16,7 @@ import chalk from 'chalk';
 import { setHelpSections } from '../lib/help.js';
 import { machineId } from '../lib/session/sync/config.js';
 import { loadDevices, isControlDevice, type DeviceProfile } from '../lib/devices/registry.js';
+import { ensureDevicesRegistered } from '../lib/devices/sync.js';
 import { readFleetFile, resolveDesired } from '../lib/fleet/manifest.js';
 import { snapshotAuth, materializeAuth, parseAuthBundle, KEYCHAIN_BOUND_ON_MAC } from '../lib/fleet/auth-sync.js';
 import {
@@ -146,6 +147,15 @@ function renderPlan(plan: FleetPlan): void {
   if (noToken.length > 0) {
     console.log(chalk.yellow(`  manual login needed (no portable token on source): ${noToken.join(', ')}`));
   }
+  // Secrets bundles are declared once for the fleet; surface the distinct set to
+  // recreate on any device missing them (values are keychain-local, never pushed).
+  const bundles = [...new Set(rows.flatMap((r) => r.secretsNeeded))];
+  if (bundles.length > 0) {
+    const shown = bundles.slice(0, 12);
+    const more = bundles.length - shown.length;
+    const list = shown.join(', ') + (more > 0 ? `, +${more} more` : '');
+    console.log(chalk.yellow(`  ${bundles.length} secrets bundle(s) to recreate where missing (keychain-local, never pushed): ${list}`));
+  }
 }
 
 /** padEnd on the visible width, ignoring chalk color codes. Exported for tests. */
@@ -162,6 +172,23 @@ async function runApply(opts: ApplyOptions): Promise<void> {
   const file = opts.file ?? 'agents.yaml';
   const manifest = readFleetFile(path.resolve(file));
   const source = machineId();
+
+  // Fresh-machine bootstrap: an explicit `devices:` map may name boxes this
+  // machine has never registered (e.g. a freshly-cloned agents.yaml). Resolve
+  // those names live from Tailscale and register them BEFORE resolveDesired
+  // validates the roster — so replication needs only the repo, never committed
+  // IPs/usernames. `devices: all` needs no bootstrap (it targets what's already
+  // registered + online).
+  if (manifest.devices !== 'all') {
+    const wanted = Object.keys(manifest.devices).filter((n) => n !== source);
+    const boot = await ensureDevicesRegistered(wanted);
+    if (boot.registered.length > 0) {
+      console.log(chalk.gray(`Registered ${boot.registered.length} device(s) from Tailscale: ${boot.registered.join(', ')}`));
+    }
+    if (boot.unresolved.length > 0) {
+      console.log(chalk.yellow(`Not resolvable on Tailscale (skipped): ${boot.unresolved.join(', ')}`));
+    }
+  }
 
   const registry = await loadDevices();
   // Control devices (a cockpit) never run agents — exclude them from the
@@ -204,7 +231,7 @@ async function runApply(opts: ApplyOptions): Promise<void> {
   const probes = new Map<string, DeviceProbe>(probeList.map((p) => [p.device, p]));
 
   const targetCliVersion = localCliVersion();
-  let plan = diffFleet(desired, probes, { targetCliVersion, sourceAuth });
+  let plan = diffFleet(desired, probes, { targetCliVersion, sourceAuth, secretsBundles: manifest.secrets?.bundles });
 
   // --only filter.
   if (opts.only) {
@@ -222,7 +249,10 @@ async function runApply(opts: ApplyOptions): Promise<void> {
 
   const isDry = opts.plan || opts.dryRun;
   if (isDry) return;
-  if (plan.actions.filter((a) => a.kind !== 'needs-login').length === 0) {
+  // `needs-login`/`needs-secret` are surfaced manual reminders, not executable
+  // mutations — exclude them so an otherwise-converged fleet still says "nothing
+  // to do" instead of looping forever on un-actionable surfacing.
+  if (plan.actions.filter((a) => a.kind !== 'needs-login' && a.kind !== 'needs-secret').length === 0) {
     console.log(chalk.green('\nNothing to do — fleet already matches the profile.'));
     return;
   }

--- a/apps/cli/src/commands/apply.ts
+++ b/apps/cli/src/commands/apply.ts
@@ -179,14 +179,16 @@ async function runApply(opts: ApplyOptions): Promise<void> {
   // validates the roster — so replication needs only the repo, never committed
   // IPs/usernames. `devices: all` needs no bootstrap (it targets what's already
   // registered + online).
+  let unresolved: string[] = [];
   if (manifest.devices !== 'all') {
     const wanted = Object.keys(manifest.devices).filter((n) => n !== source);
     const boot = await ensureDevicesRegistered(wanted);
+    unresolved = boot.unresolved;
     if (boot.registered.length > 0) {
       console.log(chalk.gray(`Registered ${boot.registered.length} device(s) from Tailscale: ${boot.registered.join(', ')}`));
     }
     if (boot.unresolved.length > 0) {
-      console.log(chalk.yellow(`Not resolvable on Tailscale (skipped): ${boot.unresolved.join(', ')}`));
+      console.log(chalk.yellow(`Not resolvable on Tailscale — skipped, reconcile continues for the rest: ${boot.unresolved.join(', ')}`));
     }
   }
 
@@ -198,7 +200,9 @@ async function runApply(opts: ApplyOptions): Promise<void> {
   const online = all.filter((d) => d.tailscale?.online === true).map((d) => d.name);
   const registered = all.map((d) => d.name);
 
-  let desired = resolveDesired(manifest, { onlineDevices: online, registeredDevices: registered, source });
+  // Unresolved names are skipped (surfaced above), never fatal — a manifest
+  // naming an asleep box must not abort the reconcile for every other device.
+  let desired = resolveDesired(manifest, { onlineDevices: online, registeredDevices: registered, source, unresolved });
   if (opts.device) {
     desired = desired.filter((d) => d.device === opts.device);
     if (desired.length === 0) throw new Error(`Device '${opts.device}' is not a target in this manifest.`);

--- a/apps/cli/src/commands/fleet-capture.ts
+++ b/apps/cli/src/commands/fleet-capture.ts
@@ -1,0 +1,125 @@
+/**
+ * `agents fleet capture` (alias surface of `agents devices capture`) — snapshot
+ * the live environment into the `fleet:` block of `agents.yaml` so a fresh
+ * machine can reconstruct it with `agents apply`.
+ *
+ * Local-read + local-write, zero SSH. Records device NAMES only (never IPs or
+ * usernames — those are re-resolved live from Tailscale at apply-time), plus the
+ * source's own agents as defaults, browser profiles, secrets-bundle names, and
+ * routine names. The heavy lifting is the pure `captureFleet` builder; this
+ * command just gathers inputs and persists via `updateMeta`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { Command } from 'commander';
+import chalk from 'chalk';
+import * as yaml from 'yaml';
+import { loadDevices, isControlDevice } from '../lib/devices/registry.js';
+import { readMeta, updateMeta, getDeviceMetaPath } from '../lib/state.js';
+import { listBundles } from '../lib/secrets/bundles.js';
+import { listJobs } from '../lib/routines.js';
+import { captureFleet, type CaptureInputs } from '../lib/fleet/capture.js';
+import type { FleetDefaults } from '../lib/fleet/types.js';
+
+interface CaptureOptions {
+  dryRun?: boolean;
+  fromPins?: boolean;
+  device?: string;
+}
+
+/** The committed per-device pin dir: `~/.agents/devices/`. Derived from the
+ * device-meta path so it honors any AGENTS_HOME override the same way. */
+function devicesPinDir(): string {
+  return path.dirname(path.dirname(getDeviceMetaPath()));
+}
+
+/** Read `devices/<name>/agents.yaml` pin files into `name -> [id@latest]`. Only
+ * used with `--from-pins`; keeps capture zero-SSH by reading committed state. */
+function agentsFromPins(names: string[]): Record<string, string[]> {
+  const dir = devicesPinDir();
+  const out: Record<string, string[]> = {};
+  for (const name of names) {
+    const p = path.join(dir, name, 'agents.yaml');
+    if (!fs.existsSync(p)) continue;
+    try {
+      const doc = yaml.parse(fs.readFileSync(p, 'utf-8')) as { agents?: Record<string, unknown> };
+      const ids = doc?.agents ? Object.keys(doc.agents) : [];
+      if (ids.length > 0) out[name] = ids.map((id) => `${id}@latest`);
+    } catch {
+      /* skip an unparsable pin file — capture is best-effort per device */
+    }
+  }
+  return out;
+}
+
+async function runCapture(opts: CaptureOptions): Promise<void> {
+  const meta = readMeta();
+
+  // Roster: registered, non-control device names only.
+  const registry = await loadDevices();
+  let names = Object.values(registry)
+    .filter((d) => !isControlDevice(d))
+    .map((d) => d.name)
+    .sort();
+  if (opts.device) {
+    names = names.filter((n) => n === opts.device);
+    if (names.length === 0) throw new Error(`Device '${opts.device}' is not a registered device.`);
+  }
+
+  // Defaults seeded from the source machine's own installed agents.
+  const sourceAgents = Object.keys(meta.agents ?? {}).sort();
+  const defaults: FleetDefaults = {
+    agents: sourceAgents.map((id) => `${id}@latest`),
+    sync: ['user'],
+    login: 'sync',
+  };
+
+  const inputs: CaptureInputs = {
+    devices: names,
+    defaults,
+    agentsByDevice: opts.fromPins ? agentsFromPins(names) : undefined,
+    // Browser profiles are intentionally NOT captured — the central `browser:`
+    // block already syncs via the repo, and its ssh:// endpoints can carry
+    // `user@host`, which must never be copied into the fleet: block.
+    secretsBundles: listBundles().map((b) => b.name),
+    routines: listJobs().map((j) => j.name),
+  };
+
+  const next = captureFleet(meta.fleet, inputs);
+
+  if (opts.dryRun) {
+    console.log(chalk.gray('# agents.yaml fleet: block (dry run — not written)'));
+    console.log(yaml.stringify({ fleet: next }).trimEnd());
+    return;
+  }
+
+  updateMeta((m) => ({ ...m, fleet: next }));
+  const deviceCount = Object.keys(next.devices === 'all' ? {} : next.devices).length;
+  console.log(
+    chalk.green('Captured fleet profile') +
+      chalk.gray(
+        ` — ${deviceCount} device(s), ${defaults.agents?.length ?? 0} agent(s), ` +
+          `${inputs.secretsBundles?.length ?? 0} secret bundle(s), ${inputs.routines?.length ?? 0} routine(s).`,
+      ),
+  );
+  console.log(chalk.gray('  Wrote agents.yaml → fleet:. Push it (`agents repo push`) and run `agents apply` on any machine.'));
+}
+
+/** Attach `capture` to the `devices`/`fleet` command tree. */
+export function registerFleetCaptureCommand(devicesCmd: Command): void {
+  devicesCmd
+    .command('capture')
+    .description('Snapshot the live environment (roster names, agents, browser, secret-bundle names, routines) into agents.yaml fleet:.')
+    .option('--dry-run', 'print the fleet: block that would be written, and exit')
+    .option('--from-pins', 'record per-device agents from committed devices/<name>/agents.yaml')
+    .option('--device <name>', 'capture a single device')
+    .action(async (opts: CaptureOptions) => {
+      try {
+        await runCapture(opts);
+      } catch (e) {
+        console.error(chalk.red((e as Error).message));
+        process.exit(1);
+      }
+    });
+}

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -20,6 +20,7 @@ import ora from 'ora';
 import { getCliVersion } from '../lib/version.js';
 import { readAndResolveBundleEnv, isHeadlessSecretsContext } from '../lib/secrets/bundles.js';
 import { machineId } from '../lib/session/sync/config.js';
+import { registerFleetCaptureCommand } from './fleet-capture.js';
 import {
   addIgnored,
   getDevice,
@@ -603,6 +604,9 @@ Typical workflow:
         process.exit(1);
       }
     });
+
+  // `agents fleet capture` — snapshot live state into agents.yaml fleet:.
+  registerFleetCaptureCommand(devicesCmd);
 
   devicesCmd
     .command('register <name>')

--- a/apps/cli/src/lib/devices/sync.test.ts
+++ b/apps/cli/src/lib/devices/sync.test.ts
@@ -7,7 +7,7 @@
  *   3. A genuinely-new, non-ignored node IS surfaced.
  */
 import { describe, expect, it } from 'vitest';
-import { computePendingDevices, planDeviceReconciliation, sanitizeLoginUser, selectNodesToUpsert, withDefaultUser } from './sync.js';
+import { computePendingDevices, partitionWantedDevices, planDeviceReconciliation, sanitizeLoginUser, selectNodesToUpsert, withDefaultUser } from './sync.js';
 import type { TailscaleNode } from './tailscale.js';
 import type { DeviceInput } from './registry.js';
 
@@ -133,5 +133,35 @@ describe('planDeviceReconciliation', () => {
     const plan = planDeviceReconciliation(['mac-mini'], [], [], []);
     expect(plan.toRemove).toEqual([]);
     expect(plan.toIgnore).toEqual(['mac-mini']);
+  });
+});
+
+describe('partitionWantedDevices (fresh-machine bootstrap)', () => {
+  const registered = new Set(['zion']);
+  const tailnet = new Set(['zion', 'yosemite-s0', 'yosemite-s1', 'ipad165']);
+  const ignored = new Set(['ipad165']);
+
+  it('registers a wanted name that is on the tailnet but not yet in the registry', () => {
+    const p = partitionWantedDevices(['yosemite-s0'], registered, tailnet, ignored);
+    expect(p.toRegister).toEqual(['yosemite-s0']);
+    expect(p.unresolved).toEqual([]);
+  });
+
+  it('marks a wanted name absent from the tailnet as unresolved (no committed IP to fall back on)', () => {
+    const p = partitionWantedDevices(['ghost-box'], registered, tailnet, ignored);
+    expect(p.toRegister).toEqual([]);
+    expect(p.unresolved).toEqual(['ghost-box']);
+  });
+
+  it('treats an ignored tailnet node as unresolved, never silently re-adding it', () => {
+    const p = partitionWantedDevices(['ipad165'], registered, tailnet, ignored);
+    expect(p.toRegister).toEqual([]);
+    expect(p.unresolved).toEqual(['ipad165']);
+  });
+
+  it('skips names already in the registry (nothing to do)', () => {
+    const p = partitionWantedDevices(['zion', 'yosemite-s1'], registered, tailnet, ignored);
+    expect(p.toRegister).toEqual(['yosemite-s1']);
+    expect(p.unresolved).toEqual([]);
   });
 });

--- a/apps/cli/src/lib/devices/sync.ts
+++ b/apps/cli/src/lib/devices/sync.ts
@@ -176,6 +176,80 @@ export async function runDeviceSync(
   }
 }
 
+export interface EnsureDevicesResult {
+  /** Names newly resolved from Tailscale and upserted into the registry. */
+  registered: string[];
+  /** Names that could not be resolved (not on the tailnet / tailscale absent). */
+  unresolved: string[];
+}
+
+/**
+ * Pure decision for `ensureDevicesRegistered`: split the wanted names into those
+ * to resolve+register (missing from the registry, present on the tailnet, not
+ * ignored) vs. unresolved (missing and either off-tailnet or ignored). Already-
+ * registered names need nothing. Pure so the bootstrap's filter matrix is
+ * unit-testable without a tailnet or registry writes.
+ */
+export interface WantedPartition {
+  toRegister: string[];
+  unresolved: string[];
+}
+
+export function partitionWantedDevices(
+  wanted: string[],
+  registered: Set<string>,
+  tailscaleNames: Set<string>,
+  ignored: Set<string>,
+): WantedPartition {
+  const out: WantedPartition = { toRegister: [], unresolved: [] };
+  for (const name of wanted) {
+    if (registered.has(name)) continue;
+    if (tailscaleNames.has(name) && !ignored.has(name)) out.toRegister.push(name);
+    else out.unresolved.push(name);
+  }
+  return out;
+}
+
+/**
+ * Fresh-machine bootstrap for `agents apply`: given the device names a `fleet:`
+ * manifest wants, register any that aren't in the local registry by resolving
+ * them LIVE from Tailscale — so a freshly-cloned `agents.yaml` (which carries
+ * names only, never IPs/usernames) reconstructs its roster with zero committed
+ * connection details. Soft by design: a missing tailscale binary or an offline
+ * name yields `unresolved` rather than throwing, so `apply` degrades to "these
+ * devices aren't reachable yet" instead of aborting. Reuses the same
+ * parse→withDefaultUser→upsert path as `runDeviceSync`, so a bootstrapped device
+ * is identical to a synced one.
+ */
+export async function ensureDevicesRegistered(wantedNames: string[]): Promise<EnsureDevicesResult> {
+  const registryBefore = await loadDevices();
+  const registered = new Set(Object.keys(registryBefore));
+  const missing = wantedNames.filter((n) => !registered.has(n));
+  if (missing.length === 0) return { registered: [], unresolved: [] };
+
+  let nodes: TailscaleNode[];
+  try {
+    nodes = parseTailscaleStatus(tailscaleStatusJson());
+  } catch {
+    // Tailscale absent/unreachable — nothing resolvable; report all missing.
+    return { registered: [], unresolved: missing };
+  }
+
+  const ignored = await loadIgnored();
+  const tailscaleNames = new Set(nodes.map((n) => n.name));
+  const { toRegister, unresolved } = partitionWantedDevices(missing, registered, tailscaleNames, ignored);
+
+  const byName = new Map(nodes.map((n) => [n.name, n]));
+  const localUser = localLoginUser();
+  const done: string[] = [];
+  for (const name of toRegister) {
+    const input = withDefaultUser(nodeToDeviceInput(byName.get(name)!), registryBefore[name]?.user, localUser);
+    await upsertDevice(name, input);
+    done.push(name);
+  }
+  return { registered: done, unresolved };
+}
+
 /**
  * The register/remove/ignore decision for the interactive curation picker.
  * Pure so the highest-risk reconcile logic is unit-testable without a tailnet

--- a/apps/cli/src/lib/fleet/apply.test.ts
+++ b/apps/cli/src/lib/fleet/apply.test.ts
@@ -153,3 +153,45 @@ describe('diffFleet', () => {
     expect(plan.actions).toEqual([]);
   });
 });
+
+describe('diffFleet — secrets surfacing', () => {
+  const desired: DeviceDesired[] = [
+    { device: 's1', agents: ['codex@latest'], sync: ['user'], login: 'skip' },
+  ];
+  const converged = new Map<string, DeviceProbe>([
+    ['s1', { device: 's1', reachable: true, platform: 'linux', cliVersion: CLI, installedAgents: ['codex'] }],
+  ]);
+
+  it('surfaces declared bundles as needs-secret (not executable), one per bundle', () => {
+    const plan = diffFleet(desired, converged, {
+      targetCliVersion: CLI,
+      sourceAuth: srcAuth(['codex']),
+      secretsBundles: ['attio', 'ssh-keys'],
+    });
+    const secretActs = plan.actions.filter((a) => a.kind === 'needs-secret');
+    expect(secretActs).toHaveLength(2);
+    expect(plan.devices[0].secretsNeeded).toEqual(['attio', 'ssh-keys']);
+    // sync-config still fires (scopes declared) but there is nothing executable
+    // beyond it — needs-secret must be excluded from the "actions to run" count.
+    const executable = plan.actions.filter((a) => a.kind !== 'needs-login' && a.kind !== 'needs-secret');
+    expect(executable.map((a) => a.kind)).toEqual(['sync-config']);
+  });
+
+  it('emits nothing for secrets when the profile declares no bundles', () => {
+    const plan = diffFleet(desired, converged, { targetCliVersion: CLI, sourceAuth: srcAuth(['codex']) });
+    expect(plan.actions.filter((a) => a.kind === 'needs-secret')).toEqual([]);
+    expect(plan.devices[0].secretsNeeded).toEqual([]);
+  });
+
+  it('does not surface secrets on an unreachable device', () => {
+    const offline = new Map<string, DeviceProbe>([
+      ['s1', { device: 's1', reachable: false, installedAgents: [] }],
+    ]);
+    const plan = diffFleet(desired, offline, {
+      targetCliVersion: CLI,
+      sourceAuth: srcAuth(['codex']),
+      secretsBundles: ['attio'],
+    });
+    expect(plan.devices[0].secretsNeeded).toEqual([]);
+  });
+});

--- a/apps/cli/src/lib/fleet/apply.ts
+++ b/apps/cli/src/lib/fleet/apply.ts
@@ -60,6 +60,10 @@ export interface DiffContext {
   /** agents-cli version the source is on — the fleet target version. */
   targetCliVersion: string;
   sourceAuth: SourceAuth;
+  /** Secrets-bundle names the profile declares. Values are keychain-local and
+   * can't be pushed, so each reachable device surfaces them as a manual recreate
+   * (`needs-secret`) — informational, never an executed mutation. */
+  secretsBundles?: string[];
 }
 
 /** Pure: desired vs probed -> per-device diff + flat action list. */
@@ -76,6 +80,7 @@ export function diffFleet(desired: DeviceDesired[], probes: Map<string, DevicePr
     };
     const rowActions: FleetAction[] = [];
     const loginBlocked: string[] = [];
+    const secretsNeeded: string[] = [];
 
     if (probe.reachable) {
       // agents-cli presence.
@@ -115,9 +120,19 @@ export function diffFleet(desired: DeviceDesired[], probes: Map<string, DevicePr
           }
         }
       }
+      // secrets — surfaced, never pushed (values are keychain-local). Declared
+      // once at the manifest level, so every reachable device gets the same
+      // manual-recreate reminder. Not an executable action (see idempotence
+      // check in commands/apply.ts, which excludes needs-* kinds).
+      if (ctx.secretsBundles && ctx.secretsBundles.length > 0) {
+        for (const bundle of ctx.secretsBundles) {
+          secretsNeeded.push(bundle);
+          rowActions.push({ device: d.device, kind: 'needs-secret', detail: `recreate secrets bundle '${bundle}' (\`agents secrets create ${bundle}\`)` });
+        }
+      }
     }
 
-    devices.push({ device: d.device, desired: d, probe, actions: rowActions, loginBlocked });
+    devices.push({ device: d.device, desired: d, probe, actions: rowActions, loginBlocked, secretsNeeded });
     actions.push(...rowActions);
   }
 
@@ -224,11 +239,18 @@ export function reconcileDevice(row: DeviceDiff, device: DeviceProfile, ctx: Exe
     ok = ok && r.code === 0;
   }
 
-  // 3. config sync.
+  // 3. config sync — one `agents sync <scope>` per declared scope. Each scope is
+  // a positional repo target (system/user/project/alias); a bare `agents sync`
+  // would ignore the profile's declared scopes entirely.
   if (row.actions.some((a) => a.kind === 'sync-config')) {
-    const r = sshAgents(['sync']);
-    steps.push({ kind: 'sync-config', ok: r.code === 0, detail: `sync config` });
-    ok = ok && r.code === 0;
+    const scopes = row.desired.sync.length > 0 ? row.desired.sync : [''];
+    let syncOk = true;
+    for (const scope of scopes) {
+      const r = sshAgents(scope ? ['sync', scope] : ['sync']);
+      syncOk = syncOk && r.code === 0;
+    }
+    steps.push({ kind: 'sync-config', ok: syncOk, detail: `sync config (${row.desired.sync.join(', ') || 'default'})` });
+    ok = ok && syncOk;
   }
 
   // 4. login propagation — one bundle for all pushable agents on this device.
@@ -245,6 +267,11 @@ export function reconcileDevice(row: DeviceDiff, device: DeviceProfile, ctx: Exe
   // Surface blocked logins as (non-fatal) informational steps.
   for (const blocked of row.loginBlocked) {
     steps.push({ kind: 'needs-login', ok: false, detail: `${blocked} needs a manual login (\`agents ssh ${row.device} -- ${blocked}\`)` });
+  }
+  // Surface declared secrets bundles as (non-fatal) manual-recreate reminders —
+  // values are keychain-local, never captured or pushed.
+  for (const bundle of row.secretsNeeded) {
+    steps.push({ kind: 'needs-secret', ok: false, detail: `secrets bundle '${bundle}' must exist on ${row.device} (\`agents ssh ${row.device} -- secrets create ${bundle}\`)` });
   }
 
   return { device: row.device, ok, steps };

--- a/apps/cli/src/lib/fleet/capture.test.ts
+++ b/apps/cli/src/lib/fleet/capture.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import * as yaml from 'yaml';
+import { captureFleet } from './capture.js';
+import type { FleetManifest } from './types.js';
+
+describe('captureFleet', () => {
+  const inputs = {
+    devices: ['mac-mini', 'yosemite-s0'],
+    defaults: { agents: ['claude@latest', 'codex@latest'], sync: ['user'], login: 'sync' as const },
+    agentsByDevice: { 'mac-mini': ['claude@latest', 'droid@latest'] },
+    secretsBundles: ['ssh-keys', 'attio'],
+    routines: ['review-open-prs', 'cycle-hygiene'],
+  };
+
+  it('serializes device names + desired state (no connection details)', () => {
+    const m = captureFleet(undefined, inputs);
+    expect(m.devices).not.toBe('all');
+    const map = m.devices as Record<string, { agents?: string[] }>;
+    expect(Object.keys(map).sort()).toEqual(['mac-mini', 'yosemite-s0']);
+    // per-device agents from --from-pins land on the device; the other inherits.
+    expect(map['mac-mini'].agents).toEqual(['claude@latest', 'droid@latest']);
+    expect(map['yosemite-s0'].agents).toBeUndefined();
+    expect(m.defaults?.agents).toEqual(['claude@latest', 'codex@latest']);
+    expect(m.secrets?.bundles).toEqual(['attio', 'ssh-keys']); // sorted, names only
+    expect(m.routines).toEqual(['cycle-hygiene', 'review-open-prs']);
+  });
+
+  it('PRIVACY: the serialized fleet: block carries no IP, username, host, or browser endpoint', () => {
+    // The live registry has addresses (100.x), users (`muqsit`), and the browser
+    // block has ssh://user@host endpoints. NONE may leak into agents.yaml fleet:.
+    const m = captureFleet(undefined, inputs);
+    const out = yaml.stringify({ fleet: m });
+    expect(out).not.toMatch(/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/); // no IPv4
+    expect(out).not.toMatch(/address:/);
+    expect(out).not.toMatch(/\buser:/);
+    expect(out).not.toMatch(/ssh:\/\//); // no browser ssh endpoints
+    // The only legit `@` is an agent version spec (`claude@latest`, `codex@1.2`).
+    // Strip those, then any remaining `@` would be a leaked user@host.
+    const stripped = out.replace(/@latest/g, '').replace(/@\d[\w.-]*/g, '');
+    expect(stripped).not.toMatch(/@/);
+  });
+
+  it('never records a browser: block (browser syncs via the central block, not fleet:)', () => {
+    const m = captureFleet(undefined, inputs);
+    expect((m as Record<string, unknown>).browser).toBeUndefined();
+  });
+
+  it('is additive: a hand-authored per-device override is preserved', () => {
+    const prev: FleetManifest = {
+      defaults: { agents: ['claude@latest'], sync: ['user'], login: 'sync' },
+      devices: { 'mac-mini': { agents: ['gemini@latest'], login: 'skip' } },
+    };
+    const m = captureFleet(prev, inputs);
+    const map = m.devices as Record<string, { agents?: string[]; login?: string }>;
+    // hand-authored agents + login on mac-mini win over the captured pins.
+    expect(map['mac-mini'].agents).toEqual(['gemini@latest']);
+    expect(map['mac-mini'].login).toBe('skip');
+    // the newly-seen device is still added.
+    expect(map['yosemite-s0']).toBeDefined();
+    // hand-authored defaults are kept, not overwritten by inputs.defaults.
+    expect(m.defaults?.agents).toEqual(['claude@latest']);
+  });
+
+  it('omits empty extras rather than writing empty keys', () => {
+    const m = captureFleet(undefined, { devices: ['s0'], secretsBundles: [], routines: [] });
+    expect(m.secrets).toBeUndefined();
+    expect(m.routines).toBeUndefined();
+  });
+});

--- a/apps/cli/src/lib/fleet/capture.ts
+++ b/apps/cli/src/lib/fleet/capture.ts
@@ -1,0 +1,74 @@
+/**
+ * Serialize the live environment into a `fleet:` manifest.
+ *
+ * `captureFleet` is PURE — it takes the previous manifest plus already-gathered
+ * inputs (device names, per-device agent specs, browser profiles, secret-bundle
+ * names, routine names) and returns the new manifest. All I/O (registry read,
+ * `agents secrets`/`routines` enumeration, YAML write) happens in the command
+ * (`commands/fleet-capture.ts`); keeping this pure makes the privacy contract —
+ * NAMES ONLY, never IPs/usernames — trivially unit-testable.
+ *
+ * Additive by design: it merges OVER an existing manifest and never clobbers a
+ * hand-authored per-device override (`agents:` you set by hand wins over a
+ * captured one). The captured roster reflects live state, so it becomes the
+ * source of truth for WHICH devices exist.
+ */
+
+import type {
+  FleetManifest,
+  FleetDefaults,
+  FleetDeviceOverride,
+} from './types.js';
+
+export interface CaptureInputs {
+  /** Registered, non-control device names to record (the roster — names only). */
+  devices: string[];
+  /** Optional per-device agent specs (e.g. from `--from-pins`), keyed by name. */
+  agentsByDevice?: Record<string, string[]>;
+  /** Fleet defaults to seed when the manifest has none (source's own agents). */
+  defaults?: FleetDefaults;
+  /** Secrets-bundle NAMES to ensure exist (values stay in the keychain). */
+  secretsBundles?: string[];
+  /** Routine NAMES that should be active on the fleet. */
+  routines?: string[];
+}
+
+/**
+ * Build the new `fleet:` manifest from the previous one and captured inputs.
+ * Pure — no SSH, no filesystem, no registry. The returned object carries device
+ * names + desired state only; a caller that serializes it to YAML can assert no
+ * address/username ever appears.
+ */
+export function captureFleet(prev: FleetManifest | undefined, inputs: CaptureInputs): FleetManifest {
+  const prevDevices = prev && prev.devices !== 'all' && typeof prev.devices === 'object'
+    ? prev.devices
+    : {};
+
+  // Roster: explicit map of the captured names. A hand-authored override for a
+  // device that still exists is preserved; a captured agent list only fills in
+  // when the manifest didn't already pin one for that device.
+  const devices: Record<string, FleetDeviceOverride> = {};
+  for (const name of inputs.devices) {
+    const prevOverride = prevDevices[name] ?? {};
+    const override: FleetDeviceOverride = { ...prevOverride };
+    const captured = inputs.agentsByDevice?.[name];
+    if (override.agents === undefined && captured && captured.length > 0) {
+      override.agents = captured;
+    }
+    devices[name] = override;
+  }
+
+  const manifest: FleetManifest = {
+    // Keep hand-authored defaults; otherwise seed from the source snapshot.
+    defaults: prev?.defaults ?? inputs.defaults ?? {},
+    devices,
+  };
+
+  const bundles = inputs.secretsBundles ?? prev?.secrets?.bundles;
+  if (bundles && bundles.length > 0) manifest.secrets = { bundles: [...bundles].sort() };
+
+  const routines = inputs.routines ?? prev?.routines;
+  if (routines && routines.length > 0) manifest.routines = [...routines].sort();
+
+  return manifest;
+}

--- a/apps/cli/src/lib/fleet/manifest.test.ts
+++ b/apps/cli/src/lib/fleet/manifest.test.ts
@@ -106,6 +106,19 @@ describe('resolveDesired', () => {
     expect(() => resolveDesired(m, ctx)).toThrow(/not a registered device/);
   });
 
+  it('SKIPS an unresolved device instead of aborting the whole reconcile', () => {
+    // bootstrap could not register `ghost-box` (off-tailnet) — the run must still
+    // reconcile the resolvable devices, not throw for every one of them.
+    const m = parseFleetManifest({ defaults: { agents: ['claude@latest'] }, devices: { s1: {}, 'ghost-box': {} } });
+    const out = resolveDesired(m, { ...ctx, unresolved: ['ghost-box'] });
+    expect(out.map((d) => d.device)).toEqual(['s1']); // ghost-box skipped, s1 kept
+  });
+
+  it('still throws for an unregistered name that is NOT unresolved (genuine misconfig, no bootstrap)', () => {
+    const m = parseFleetManifest({ defaults: {}, devices: { s1: {}, 'typo-box': {} } });
+    expect(() => resolveDesired(m, ctx)).toThrow(/typo-box/);
+  });
+
   it('never targets the source machine', () => {
     const m = parseFleetManifest({ defaults: { agents: ['claude@latest'] }, devices: { s0: {}, s1: {} } });
     const out = resolveDesired(m, ctx);

--- a/apps/cli/src/lib/fleet/manifest.test.ts
+++ b/apps/cli/src/lib/fleet/manifest.test.ts
@@ -112,3 +112,29 @@ describe('resolveDesired', () => {
     expect(out.map((d) => d.device)).toEqual(['s1']);
   });
 });
+
+describe('parseFleetManifest — additive capture fields', () => {
+  it('accepts secrets.bundles and routines', () => {
+    const m = parseFleetManifest({
+      devices: 'all',
+      secrets: { bundles: ['attio', 'ssh-keys'] },
+      routines: ['review-open-prs'],
+    });
+    expect(m.secrets?.bundles).toEqual(['attio', 'ssh-keys']);
+    expect(m.routines).toEqual(['review-open-prs']);
+  });
+
+  it('is backward-compatible: a manifest with none of the new fields still parses', () => {
+    const m = parseFleetManifest({ defaults: { agents: ['claude@latest'] }, devices: 'all' });
+    expect(m.secrets).toBeUndefined();
+    expect(m.routines).toBeUndefined();
+  });
+
+  it('rejects non-string secrets.bundles', () => {
+    expect(() => parseFleetManifest({ devices: 'all', secrets: { bundles: [1] } })).toThrow(/secrets\.bundles/);
+  });
+
+  it('rejects non-string routines', () => {
+    expect(() => parseFleetManifest({ devices: 'all', routines: [1, 2] })).toThrow(/routines/);
+  });
+});

--- a/apps/cli/src/lib/fleet/manifest.ts
+++ b/apps/cli/src/lib/fleet/manifest.ts
@@ -77,7 +77,27 @@ export function parseFleetManifest(raw: unknown): FleetManifest {
     throw new Error(`fleet: devices must be the string 'all' or a mapping of device -> overrides (got ${JSON.stringify(o.devices)}).`);
   }
 
-  return { defaults, devices };
+  const manifest: FleetManifest = { defaults, devices };
+
+  // Additive, backward-compatible extras (captured by `agents fleet capture`).
+  if (o.secrets !== undefined) {
+    if (typeof o.secrets !== 'object' || o.secrets === null || Array.isArray(o.secrets)) {
+      throw new Error('fleet: secrets must be a mapping with a `bundles:` list.');
+    }
+    const bundles = (o.secrets as Record<string, unknown>).bundles;
+    if (bundles !== undefined && !isStringArray(bundles)) {
+      throw new Error('fleet: secrets.bundles must be a list of bundle names (e.g. [attio]).');
+    }
+    manifest.secrets = { bundles: bundles as string[] | undefined };
+  }
+  if (o.routines !== undefined) {
+    if (!isStringArray(o.routines)) {
+      throw new Error('fleet: routines must be a list of routine names.');
+    }
+    manifest.routines = o.routines;
+  }
+
+  return manifest;
 }
 
 /** Read a YAML file and extract + validate its `fleet:` block. */

--- a/apps/cli/src/lib/fleet/manifest.ts
+++ b/apps/cli/src/lib/fleet/manifest.ts
@@ -138,6 +138,12 @@ export interface ResolveContext {
   registeredDevices: string[];
   /** The source machine, always excluded from the target set. */
   source: string;
+  /** Names the bootstrap could not resolve from Tailscale (off-tailnet, ignored,
+   * or a typo). These are SKIPPED with the caller's warning rather than aborting
+   * the whole reconcile — a manifest naming an asleep laptop must not hard-fail
+   * every other device. Without a bootstrap, this is empty and an unregistered
+   * name still throws (genuine misconfig, caught early). */
+  unresolved?: string[];
 }
 
 /**
@@ -158,8 +164,12 @@ export function resolveDesired(manifest: FleetManifest, ctx: ResolveContext): De
     return out;
   }
 
+  const unresolved = new Set(ctx.unresolved ?? []);
   for (const [name, override] of Object.entries(manifest.devices)) {
     if (name === ctx.source) continue;
+    // Bootstrap couldn't register this name (off-tailnet / ignored / typo) —
+    // skip it (the caller already surfaced it) instead of aborting the run.
+    if (unresolved.has(name)) continue;
     if (!ctx.registeredDevices.includes(name)) {
       throw new Error(`fleet: device '${name}' is not a registered device. Run \`agents devices add ${name}\` or fix the manifest.`);
     }

--- a/apps/cli/src/lib/fleet/types.ts
+++ b/apps/cli/src/lib/fleet/types.ts
@@ -46,6 +46,21 @@ export interface FleetDeviceOverride {
 export interface FleetManifest {
   defaults?: FleetDefaults;
   devices: 'all' | Record<string, FleetDeviceOverride>;
+  /**
+   * Fleet-wide extras captured by `agents fleet capture` so a fresh machine can
+   * reconstruct the whole environment, not just installed agents. All additive,
+   * portable, and LEAK-FREE — names only, never connection details.
+   *
+   * (Browser profiles are deliberately NOT captured here: the central `browser:`
+   * block already syncs verbatim via `agents repo push/pull`, so duplicating it
+   * would be redundant — and its ssh:// endpoints can carry `user@host`, which
+   * must never be copied into a second location.)
+   */
+  /** Secrets-bundle NAMES to ensure exist — values live in the keychain and are
+   * never captured or pushed; `apply` surfaces missing bundles to recreate. */
+  secrets?: { bundles?: string[] };
+  /** Routine NAMES that should be active on the fleet (files sync via the repo). */
+  routines?: string[];
 }
 
 /**
@@ -87,7 +102,10 @@ export type FleetActionKind =
   | 'add-agent'
   | 'sync-config'
   | 'push-login'
-  | 'needs-login';
+  | 'needs-login'
+  /** Secrets bundles the profile declares but that can't be pushed (values are
+   * keychain-local) — surfaced as a manual recreate, like `needs-login`. */
+  | 'needs-secret';
 
 export interface FleetAction {
   device: string;
@@ -117,6 +135,9 @@ export interface DeviceDiff {
   /** Agents that must be logged in on the device but can't be propagated
    * (source token is device-bound, e.g. macOS keychain). Surfaced, not faked. */
   loginBlocked: string[];
+  /** Secrets-bundle names the profile declares that must be recreated on the
+   * device (values are keychain-local — never captured or pushed). Surfaced. */
+  secretsNeeded: string[];
 }
 
 /** A portable auth file captured from a source agent home, ready to propagate. */


### PR DESCRIPTION
## What

Makes `agents apply` reconstruct a user's **whole fleet environment** from `agents.yaml`, storing everything in the additive `fleet:` block — and doing it **without committing a single Tailscale IP or username**.

Three gaps closed:
1. **`fleet:` was hand-authored** — nothing captured live state into it.
2. **The roster is machine-local + gitignored** (`.history/devices/registry.json`) — a cloned `agents.yaml` had no devices, and `apply` *errored* on unknown names.
3. **`sync:` scopes were display-only** — `apply` ran a bare `agents sync`.

## Changes

- **`agents fleet capture`** (new; alias of `agents devices capture`) — snapshots the live environment into `fleet:`: the device roster (**names only**), the source's agents as `defaults`, secrets-bundle **names**, and routine **names**. Writes via `updateMeta` → central, portable `agents.yaml`. `--dry-run`, `--from-pins`, `--device` flags. Pure `captureFleet` builder.
- **Fresh-machine bootstrap** — `ensureDevicesRegistered` resolves a manifest's device names **live from Tailscale** and registers them before `resolveDesired`, so `git clone` + `agents apply` rebuilds the roster with zero committed connection details. Off-tailnet names are reported unresolved, not fatal.
- **`sync:` scopes made real** — `apply` now runs `agents sync <scope>` per declared scope.
- **Secrets surfaced, not pushed** — declared bundle names surface as `needs-secret` manual-recreate reminders (values stay keychain-local); excluded from the executable/idempotence count like `needs-login`.

## Privacy contract (the load-bearing constraint)

Everything lands in the machineId-scoped, additive `fleet:` block — central `agents.yaml` stays portable **by construction** (`writeMetaUnlocked` strips only `{agents, versions, defaultBrowserProfile}` to device-local). The captured block is **names only**. A round-trip test asserts no IPv4 / `address:` / `user:` / `ssh://` / `user@host` ever appears.

**Browser profiles are deliberately NOT captured** — the central `browser:` block already syncs verbatim via `agents repo push/pull`, and its `ssh://` endpoints can carry `user@host`. Duplicating it into `fleet:` would be redundant *and* leaky. (Discovered while verifying capture output against the real 12-device fleet — the live `browser:` block held `ssh://muqsit@mac-mini`.)

## Verified end-to-end on the real 12-device fleet

- `agents fleet capture --dry-run` → produces a `fleet:` block of 12 device **names**, 6 agents, 55 secret-bundle **names**, 25 routine names. Privacy grep for IP/user/host/`ssh://`: **clean**.
- `agents apply --plan -f <captured> --device yosemite-s0` → probes, renders config sync (`↑ sync`), login propagation, and the capped secrets-recreate line. No errors.
- **73 tests pass**, `tsc --noEmit` clean. New/extended suites: `capture.test.ts` (round-trip + privacy), `manifest.test.ts` (new fields + backward-compat), `sync.test.ts` (bootstrap partition), `apply.test.ts` (secrets surfacing).

## Out of scope

The committed `devices/<machine>/agents.yaml` pull-wedge is a **separate PR** (this only reads those files with `--from-pins`; it writes exclusively to central `Meta.fleet`).