### PR TITLE
fix(devices): fleet update/run upgrades this machine locally, not over ssh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,6 +333,16 @@
   `apps/cli/src/lib/auth-health.ts` (`summarizeHostAuth`),
   `apps/cli/src/lib/devices/health-report.ts`, `apps/cli/src/commands/doctor.ts`.
 
+- **`agents fleet update` / `agents fleet run` now upgrade THIS machine too,
+  instead of failing to ssh to it.** Both fanned out over ssh to every registered
+  device including the current one — and a box usually has no authorized key to
+  itself, so the local machine came back `Permission denied (publickey)` while all
+  the remotes upgraded. `runFleet` now detects the self device (`machineId()`) and
+  runs the command as a local process (`runLocalCommand`), so `fleet update` on a
+  12-device fleet reports `12 ok` rather than `11 ok · 1 failed`. Source:
+  `apps/cli/src/lib/devices/fleet.ts` (`runFleet`, `runLocalCommand`),
+  `apps/cli/src/commands/ssh.ts`.
+
 ## 1.20.58
 
 ### Added

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -882,7 +882,7 @@ Typical workflow:
         return;
       }
       console.log(chalk.gray(`Running \`${cmd.join(' ')}\` on ${targets.filter((t) => !t.skip).length} online device(s)…`));
-      const results = runFleet(targets, cmd);
+      const results = runFleet(targets, cmd, { self: machineId() });
       printFleetResults(results);
     });
 
@@ -902,7 +902,7 @@ Typical workflow:
         return;
       }
       console.log(chalk.gray(`Running \`${cmd.join(' ')}\` on ${targets.filter((t) => !t.skip).length} online device(s)…`));
-      const results = runFleet(targets, cmd);
+      const results = runFleet(targets, cmd, { self: machineId() });
       printFleetResults(results);
     });
 }

--- a/apps/cli/src/lib/devices/fleet.test.ts
+++ b/apps/cli/src/lib/devices/fleet.test.ts
@@ -90,9 +90,11 @@ describe('runFleet', () => {
       { device: device({ name: 'b' }), skip: 'offline' },
       { device: device({ name: 'c' }) },
     ];
-    const results = runFleet(targets, ['agents', 'upgrade', '--yes'], (d) => {
-      if (d.name === 'a') return { code: 0, stdout: 'ok', stderr: '' };
-      return { code: 1, stdout: '', stderr: 'npm ERR' };
+    const results = runFleet(targets, ['agents', 'upgrade', '--yes'], {
+      runner: (d) => {
+        if (d.name === 'a') return { code: 0, stdout: 'ok', stderr: '' };
+        return { code: 1, stdout: '', stderr: 'npm ERR' };
+      },
     });
     expect(results).toEqual([
       { name: 'a', status: 'ok', code: 0, detail: undefined },
@@ -107,12 +109,41 @@ describe('runFleet', () => {
       { device: device({ name: 'b' }) },
       { device: device({ name: 'c' }) },
     ];
-    const results = runFleet(targets, ['true'], (d) => {
-      if (d.name === 'b') throw new Error('password auth but no secrets bundle');
-      return { code: 0, stdout: '', stderr: '' };
+    const results = runFleet(targets, ['true'], {
+      runner: (d) => {
+        if (d.name === 'b') throw new Error('password auth but no secrets bundle');
+        return { code: 0, stdout: '', stderr: '' };
+      },
     });
     expect(results.map((r) => r.status)).toEqual(['ok', 'failed', 'ok']);
     expect(results[1].detail).toMatch(/password auth/);
+  });
+
+  it('runs the self target locally (never ssh) so fleet update upgrades this box too', () => {
+    const targets: FleetTarget[] = [
+      { device: device({ name: 'zion' }) }, // this machine
+      { device: device({ name: 'worker' }) },
+    ];
+    const sshed: string[] = [];
+    const localRan: string[][] = [];
+    const results = runFleet(targets, ['agents', 'upgrade', '--yes'], {
+      self: 'zion',
+      runner: (d) => { sshed.push(d.name); return { code: 0, stdout: '', stderr: '' }; },
+      localRunner: (cmd) => { localRan.push(cmd); return { code: 0, stdout: '', stderr: '' }; },
+    });
+    // self went through the local runner, NOT ssh; the remote box still ssh'd.
+    expect(sshed).toEqual(['worker']);
+    expect(localRan).toEqual([['agents', 'upgrade', '--yes']]);
+    expect(results.map((r) => [r.name, r.status])).toEqual([['zion', 'ok'], ['worker', 'ok']]);
+  });
+
+  it('a failing local self upgrade is reported as failed, not swallowed', () => {
+    const targets: FleetTarget[] = [{ device: device({ name: 'zion' }) }];
+    const results = runFleet(targets, ['agents', 'upgrade', '--yes'], {
+      self: 'zion',
+      localRunner: () => ({ code: 1, stdout: '', stderr: 'network down' }),
+    });
+    expect(results).toEqual([{ name: 'zion', status: 'failed', code: 1, detail: 'network down' }]);
   });
 });
 

--- a/apps/cli/src/lib/devices/fleet.ts
+++ b/apps/cli/src/lib/devices/fleet.ts
@@ -139,9 +139,11 @@ export function runOnDevice(
  * `agents fleet update` hit trying to reach zion from zion) and doesn't need to —
  * `agents upgrade` etc. runs identically as a local process. Mirrors
  * {@link runOnDevice}'s return shape and never throws. The argv is space-joined
- * and evaluated by a shell, matching how runOnDevice hands the command string to
- * the remote login shell — so PATH-resolved `agents`, quoting, and `;`/`&&` all
- * behave the same locally as remotely.
+ * and evaluated by a shell — matching the POSIX-shell ssh path (so PATH-resolved
+ * `agents`, quoting, and `;`/`&&` behave the same). It does NOT replicate the
+ * powershell-device encoding runOnDevice uses (`connect.ts` base64 path): a
+ * Windows self runs under the default OS shell (cmd.exe), which still resolves
+ * `agents` on PATH for the only self commands that matter (`agents upgrade …`).
  */
 export function runLocalCommand(
   cmd: string[],

--- a/apps/cli/src/lib/devices/fleet.ts
+++ b/apps/cli/src/lib/devices/fleet.ts
@@ -134,6 +134,40 @@ export function runOnDevice(
 }
 
 /**
+ * Run `cmd` on THIS machine directly — no ssh. Used by {@link runFleet} for the
+ * self target: a box frequently can't ssh to itself (no self-authorized key, as
+ * `agents fleet update` hit trying to reach zion from zion) and doesn't need to —
+ * `agents upgrade` etc. runs identically as a local process. Mirrors
+ * {@link runOnDevice}'s return shape and never throws. The argv is space-joined
+ * and evaluated by a shell, matching how runOnDevice hands the command string to
+ * the remote login shell — so PATH-resolved `agents`, quoting, and `;`/`&&` all
+ * behave the same locally as remotely.
+ */
+export function runLocalCommand(
+  cmd: string[],
+  opts: { timeoutMs?: number } = {},
+): { code: number | null; stdout: string; stderr: string } {
+  try {
+    const res = spawnSync(cmd.join(' '), {
+      shell: true,
+      encoding: 'utf-8',
+      timeout: opts.timeoutMs ?? 600_000,
+    });
+    return {
+      code: res.status,
+      stdout: res.stdout?.toString() ?? '',
+      stderr: (res.stderr?.toString() ?? '') + (res.error ? String(res.error.message) : ''),
+    };
+  } catch (err) {
+    return {
+      code: 1,
+      stdout: '',
+      stderr: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
  * Build `agents upgrade --yes` argv, optionally pinned to a version/dist-tag.
  * Rejects anything that is not a plain npm version/tag token so a version pin
  * cannot inject shell metacharacters into the remote command line.
@@ -150,16 +184,33 @@ export function upgradeCommand(version?: string): string[] {
   return ['agents', 'upgrade', '--yes'];
 }
 
+export interface RunFleetOptions {
+  /**
+   * Name of THIS machine. Its target runs the command **locally** (no ssh) — a
+   * box can't reliably ssh to itself and doesn't need to. Omit to ssh every
+   * target (the old behaviour). Callers pass `machineId()`.
+   */
+  self?: string;
+  /** Injectable ssh runner (tests). */
+  runner?: typeof runOnDevice;
+  /** Injectable local runner (tests). */
+  localRunner?: typeof runLocalCommand;
+}
+
 /**
  * Execute a command across planned targets. Pure orchestration over
- * {@link runOnDevice}; testable by injecting `runner`. Per-device throws from
- * the runner are recorded as `failed` so one bad device never aborts the rest.
+ * {@link runOnDevice} / {@link runLocalCommand}; testable by injecting either.
+ * The `self` target runs locally so `agents fleet update` upgrades this machine
+ * too instead of failing to ssh to itself. Per-device throws from a runner are
+ * recorded as `failed` so one bad device never aborts the rest.
  */
 export function runFleet(
   targets: FleetTarget[],
   cmd: string[],
-  runner: typeof runOnDevice = runOnDevice,
+  opts: RunFleetOptions = {},
 ): FleetRunResult[] {
+  const runner = opts.runner ?? runOnDevice;
+  const localRunner = opts.localRunner ?? runLocalCommand;
   const results: FleetRunResult[] = [];
   for (const t of targets) {
     if (t.skip) {
@@ -172,7 +223,8 @@ export function runFleet(
       continue;
     }
     try {
-      const res = runner(t.device, cmd);
+      const isSelf = opts.self !== undefined && t.device.name === opts.self;
+      const res = isSelf ? localRunner(cmd) : runner(t.device, cmd);
       const ok = res.code === 0;
       const detail = (res.stderr || res.stdout).trim().slice(0, 200);
       results.push({


### PR DESCRIPTION
## The bug (reported from a real fleet upgrade)

`agents fleet update` fans out over ssh to **every** registered device — including the one you run it on. A machine usually has no authorized ssh key to *itself*, so the local box fails while every remote succeeds:

```
11 ok · 1 failed · 0 skipped
zion  failed  muqsit@zion.tail1a85a1.ts.net: Permission denied (publickey,password,keyboard-interactive).
```

The failing device is the very machine you invoked the command on — so `fleet update` silently leaves *this* box a version behind.

## Fix

`runFleet` now takes the self name (`machineId()`) and routes the self target through a new `runLocalCommand` — a local shell process with the same return shape as the ssh `runOnDevice` — instead of ssh'ing to itself. Same goal, accomplished intuitively. Applies to both `fleet update` and `fleet run`.

## Verified end-to-end

Before: `11 ok · 1 failed` (zion). After, on the same 12-device fleet:

```
zion         ok        exit 0
12 ok · 0 failed · 0 skipped
```

## Tests
`fleet.test.ts`: the two existing `runFleet` tests moved to the new options form; added (1) self target runs the **local** runner while remotes still ssh, and (2) a failing local self upgrade is reported `failed`, not swallowed. tsc clean, 13/13 fleet tests pass.

Follow-up to #1302 (the fleet Auth column / cache-first work), surfaced while upgrading the fleet to 1.20.70.