### PR TITLE
fix(cli): agent-friendliness bug-kills — fork exit codes, dead tail --json, usage --json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -332,6 +332,21 @@
   refreshes this host's auth verdicts alongside the stats warm. Source:
   `apps/cli/src/lib/auth-health.ts` (`summarizeHostAuth`),
   `apps/cli/src/lib/devices/health-report.ts`, `apps/cli/src/commands/doctor.ts`.
+- **`agents usage --json`.** `usage` was the only per-account numeric command with
+  no machine-readable output (its siblings `cost`/`budget`/`view`/`doctor`/`models`
+  all have `--json`), forcing a scripting agent to scrape colored text. It now emits
+  a per-agent snapshot array (`{ agent, label, status, email?, usage? }`); the text
+  and JSON renderers share one `collectAgentUsage` data path. Source:
+  `apps/cli/src/commands/usage.ts`.
+- **`agents fork` now exits non-zero on failure.** Every failure path (no match,
+  ambiguous id, unforkable agent, fork error) printed to stdout and returned exit
+  code **0**, so `agents fork <id> && agents resume <new>` proceeded on a *failed*
+  fork. Failures now write to stderr and set exit code 1. Source:
+  `apps/cli/src/commands/fork.ts`.
+- **Removed the dead `--json` flag on `agents sessions tail`.** It was declared but
+  never read — output is always raw JSONL — so it advertised a toggle that did
+  nothing. Dropped from the surface; tail output is unchanged. Source:
+  `apps/cli/src/commands/sessions-tail.ts`.
 
 ## 1.20.58
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,7 +345,9 @@
   `apps/cli/src/commands/fork.ts`.
 - **Removed the dead `--json` flag on `agents sessions tail`.** It was declared but
   never read — output is always raw JSONL — so it advertised a toggle that did
-  nothing. Dropped from the surface; tail output is unchanged. Source:
+  nothing. Dropped from `tail`'s own surface (and its `TailOptions` type); output is
+  unchanged, and a script still passing `--json` is unaffected since the parent
+  `sessions --json` option keeps it a recognized (no-op) flag. Source:
   `apps/cli/src/commands/sessions-tail.ts`.
 
 ## 1.20.58

--- a/apps/cli/src/commands/fork.ts
+++ b/apps/cli/src/commands/fork.ts
@@ -50,23 +50,28 @@ export function registerForkCommand(program: Command): void {
     }
 
     if (matches.length === 0) {
-      console.log(chalk.red(`No session matching "${sessionArg}".`));
-      console.log(chalk.gray('List candidates with: agents sessions'));
+      // Errors go to stderr and set a non-zero exit code so a script chaining on
+      // `agents fork <id> && agents resume <new>` doesn't proceed on a failed fork.
+      console.error(chalk.red(`No session matching "${sessionArg}".`));
+      console.error(chalk.gray('List candidates with: agents sessions'));
+      process.exitCode = 1;
       return;
     }
     if (matches.length > 1) {
-      console.log(chalk.yellow(`"${sessionArg}" is ambiguous — ${matches.length} sessions match. Use a longer id:`));
+      console.error(chalk.yellow(`"${sessionArg}" is ambiguous — ${matches.length} sessions match. Use a longer id:`));
       for (const m of matches.slice(0, 8)) {
-        console.log(chalk.gray(`  ${m.shortId}  ${m.agent}  ${m.label || m.topic || ''}`));
+        console.error(chalk.gray(`  ${m.shortId}  ${m.agent}  ${m.label || m.topic || ''}`));
       }
+      process.exitCode = 1;
       return;
     }
 
     const source = matches[0];
 
     if (!isForkableAgent(source.agent)) {
-      console.log(chalk.yellow(`fork does not support ${source.agent} sessions yet.`));
-      console.log(chalk.gray(`  Supported: ${FORKABLE_AGENTS.join(', ')}.`));
+      console.error(chalk.yellow(`fork does not support ${source.agent} sessions yet.`));
+      console.error(chalk.gray(`  Supported: ${FORKABLE_AGENTS.join(', ')}.`));
+      process.exitCode = 1;
       return;
     }
 
@@ -74,7 +79,8 @@ export function registerForkCommand(program: Command): void {
     try {
       result = forkSession(source, { name: options.name });
     } catch (err) {
-      console.log(chalk.red(`Could not fork ${source.shortId}: ${(err as Error).message}`));
+      console.error(chalk.red(`Could not fork ${source.shortId}: ${(err as Error).message}`));
+      process.exitCode = 1;
       return;
     }
 

--- a/apps/cli/src/commands/sessions-tail.ts
+++ b/apps/cli/src/commands/sessions-tail.ts
@@ -144,7 +144,6 @@ export async function tailFile(
 
 interface TailOptions {
   latest?: boolean;
-  json?: boolean;
   fromStart?: boolean;
 }
 

--- a/apps/cli/src/commands/sessions-tail.ts
+++ b/apps/cli/src/commands/sessions-tail.ts
@@ -237,8 +237,7 @@ export function registerSessionsTailCommand(sessionsCmd: Command): void {
     .command('tail [sessionId]')
     .description('Stream JSONL events from a session file as they are written, one event per line. Long-running: Ctrl+C to stop. Claude and Codex only.')
     .option('--latest', 'Tail the most recent tailable session (claude or codex)')
-    .option('--from-start', 'Emit the full file first, then follow (default: start at EOF)')
-    .option('--json', 'Raw JSONL passthrough (default)');
+    .option('--from-start', 'Emit the full file first, then follow (default: start at EOF)');
 
   setHelpSections(tailCmd, {
     examples: `

--- a/apps/cli/src/commands/usage.test.ts
+++ b/apps/cli/src/commands/usage.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatAgentUsage, type AgentUsageRecord } from './usage.js';
+
+// Locks the text-path output of the collect/format refactor: `formatAgentUsage`
+// must render each status branch exactly as the old inline `renderAgentUsage` did,
+// so adding `--json` never drifted the human table. Pure over the record — no
+// network, no real accounts.
+describe('formatAgentUsage', () => {
+  it('unsupported → "does not publish usage data"', () => {
+    const rec: AgentUsageRecord = { agent: 'gemini', label: 'Gemini', status: 'unsupported' };
+    const out = formatAgentUsage(rec);
+    expect(out).toContain('Gemini');
+    expect(out).toContain('does not publish usage data.');
+  });
+
+  it('no-version → "No version installed."', () => {
+    const rec: AgentUsageRecord = { agent: 'claude', label: 'Claude', status: 'no-version' };
+    const out = formatAgentUsage(rec);
+    expect(out).toContain('Claude');
+    expect(out).toContain('No version installed.');
+  });
+
+  it('not-signed-in → "Not signed in."', () => {
+    const rec: AgentUsageRecord = { agent: 'claude', label: 'Claude', status: 'not-signed-in' };
+    expect(formatAgentUsage(rec)).toContain('Not signed in.');
+  });
+
+  it('ok with empty usage → heading, email, and the no-data line', () => {
+    const rec: AgentUsageRecord = {
+      agent: 'claude',
+      label: 'Claude',
+      status: 'ok',
+      email: 'user@example.com',
+      // Empty UsageInfo: formatUsageSection returns [] when there's no snapshot/error.
+      usage: {} as AgentUsageRecord['usage'],
+    };
+    const out = formatAgentUsage(rec);
+    expect(out).toContain('Claude');
+    expect(out).toContain('user@example.com');
+    expect(out).toContain('No usage data available right now.');
+  });
+
+  it('ok without email → omits the email line but still renders', () => {
+    const rec: AgentUsageRecord = {
+      agent: 'claude',
+      label: 'Claude',
+      status: 'ok',
+      usage: {} as AgentUsageRecord['usage'],
+    };
+    const out = formatAgentUsage(rec);
+    expect(out).toContain('Claude');
+    expect(out).toContain('No usage data available right now.');
+  });
+});

--- a/apps/cli/src/commands/usage.ts
+++ b/apps/cli/src/commands/usage.ts
@@ -36,6 +36,7 @@ const USAGE_SUPPORTED: ReadonlySet<AgentId> = new Set<AgentId>(['claude', 'codex
 /** One agent's usage snapshot — the unit the text and --json renderers share. */
 export interface AgentUsageRecord {
   agent: AgentId;
+  /** Plain agent name (no ANSI) — safe to emit in --json; the text table colorizes it. */
   label: string;
   status: 'unsupported' | 'no-version' | 'not-signed-in' | 'ok';
   email?: string;
@@ -91,7 +92,9 @@ Examples:
 
 /** Gather one agent's usage snapshot as structured data (shared by both renderers). */
 async function collectAgentUsage(agentId: AgentId): Promise<AgentUsageRecord> {
-  const label = agentLabel(agentId);
+  // Plain name — color is applied only at text-render time (formatAgentUsage), so
+  // `--json` never emits ANSI escapes in `label` (e.g. under FORCE_COLOR=1).
+  const label = AGENTS[agentId].name;
 
   if (!USAGE_SUPPORTED.has(agentId)) {
     return { agent: agentId, label, status: 'unsupported' };
@@ -116,15 +119,18 @@ async function collectAgentUsage(agentId: AgentId): Promise<AgentUsageRecord> {
 /** Render one usage record as the human table section. */
 export function formatAgentUsage(rec: AgentUsageRecord): string {
   const cfg = AGENTS[rec.agent];
+  // Colorize the heading here (not in the record) so the plain `label` stays
+  // clean for --json while the text table keeps its per-agent color.
+  const heading = agentLabel(rec.agent);
   switch (rec.status) {
     case 'unsupported':
-      return [rec.label, `  ${chalk.dim(`${cfg.name} CLI does not publish usage data.`)}`].join('\n');
+      return [heading, `  ${chalk.dim(`${cfg.name} CLI does not publish usage data.`)}`].join('\n');
     case 'no-version':
-      return [rec.label, `  ${chalk.dim('No version installed.')}`].join('\n');
+      return [heading, `  ${chalk.dim('No version installed.')}`].join('\n');
     case 'not-signed-in':
-      return [rec.label, `  ${chalk.dim('Not signed in.')}`].join('\n');
+      return [heading, `  ${chalk.dim('Not signed in.')}`].join('\n');
     case 'ok': {
-      const lines = [rec.label];
+      const lines = [heading];
       if (rec.email) lines.push(`  ${chalk.dim(rec.email)}`);
       const section = formatUsageSection(rec.usage!);
       if (section.length === 0) {

--- a/apps/cli/src/commands/usage.ts
+++ b/apps/cli/src/commands/usage.ts
@@ -34,7 +34,7 @@ import { formatUsageSection, getUsageInfoForIdentity } from '../lib/usage.js';
 const USAGE_SUPPORTED: ReadonlySet<AgentId> = new Set<AgentId>(['claude', 'codex', 'kimi', 'droid']);
 
 /** One agent's usage snapshot — the unit the text and --json renderers share. */
-interface AgentUsageRecord {
+export interface AgentUsageRecord {
   agent: AgentId;
   label: string;
   status: 'unsupported' | 'no-version' | 'not-signed-in' | 'ok';
@@ -114,7 +114,7 @@ async function collectAgentUsage(agentId: AgentId): Promise<AgentUsageRecord> {
 }
 
 /** Render one usage record as the human table section. */
-function formatAgentUsage(rec: AgentUsageRecord): string {
+export function formatAgentUsage(rec: AgentUsageRecord): string {
   const cfg = AGENTS[rec.agent];
   switch (rec.status) {
     case 'unsupported':

--- a/apps/cli/src/commands/usage.ts
+++ b/apps/cli/src/commands/usage.ts
@@ -33,16 +33,27 @@ import { formatUsageSection, getUsageInfoForIdentity } from '../lib/usage.js';
  */
 const USAGE_SUPPORTED: ReadonlySet<AgentId> = new Set<AgentId>(['claude', 'codex', 'kimi', 'droid']);
 
+/** One agent's usage snapshot — the unit the text and --json renderers share. */
+interface AgentUsageRecord {
+  agent: AgentId;
+  label: string;
+  status: 'unsupported' | 'no-version' | 'not-signed-in' | 'ok';
+  email?: string;
+  usage?: Awaited<ReturnType<typeof getUsageInfoForIdentity>>;
+}
+
 export function registerUsageCommand(program: Command): void {
   addHostOption(program.command('usage [agent]'))
     .description('Show rate-limit / quota usage per agent')
+    .option('--json', 'Emit machine-readable JSON (per-agent usage snapshot) instead of the table')
     .addHelpText('after', `
 Examples:
   agents usage              Show usage for all installed agents
   agents usage claude       Show usage for Claude only
   agents usage codex        Show usage for Codex only
+  agents usage --json       Machine-readable snapshot for scripts
 `)
-    .action(async (agentFilter?: string) => {
+    .action(async (agentFilter: string | undefined, options: { json?: boolean }) => {
       let filter: AgentId | undefined;
       if (agentFilter) {
         const resolved = resolveAgentName(agentFilter);
@@ -57,55 +68,71 @@ Examples:
         : ALL_AGENT_IDS.filter((id) => listInstalledVersions(id).length > 0);
 
       if (targets.length === 0) {
+        if (options.json) {
+          console.log('[]');
+          return;
+        }
         console.log(chalk.gray('No agents installed. Run `agents add <agent>` first.'));
         return;
       }
 
-      const sections = await Promise.all(
-        targets.map(async (agentId) => renderAgentUsage(agentId as AgentId))
+      const records = await Promise.all(
+        targets.map((agentId) => collectAgentUsage(agentId as AgentId))
       );
 
-      console.log(sections.filter(Boolean).join('\n\n'));
+      if (options.json) {
+        console.log(JSON.stringify(records, null, 2));
+        return;
+      }
+
+      console.log(records.map(formatAgentUsage).filter(Boolean).join('\n\n'));
     });
 }
 
-async function renderAgentUsage(agentId: AgentId): Promise<string> {
-  const cfg = AGENTS[agentId];
-  const heading = agentLabel(agentId);
+/** Gather one agent's usage snapshot as structured data (shared by both renderers). */
+async function collectAgentUsage(agentId: AgentId): Promise<AgentUsageRecord> {
+  const label = agentLabel(agentId);
 
   if (!USAGE_SUPPORTED.has(agentId)) {
-    return [
-      `${heading}`,
-      `  ${chalk.dim(`${cfg.name} CLI does not publish usage data.`)}`,
-    ].join('\n');
+    return { agent: agentId, label, status: 'unsupported' };
   }
 
   const versions = listInstalledVersions(agentId);
   const version = getGlobalDefault(agentId) || versions[0];
   if (!version) {
-    return [`${heading}`, `  ${chalk.dim('No version installed.')}`].join('\n');
+    return { agent: agentId, label, status: 'no-version' };
   }
   const home = getVersionHomePath(agentId, version);
 
   const info = await getAccountInfo(agentId, home);
   if (!info.usageKey && !info.accountKey) {
-    return [`${heading}`, `  ${chalk.dim('Not signed in.')}`].join('\n');
+    return { agent: agentId, label, status: 'not-signed-in' };
   }
 
-  const usage = await getUsageInfoForIdentity({
-    agentId,
-    home,
-    info,
-    cliVersion: null,
-  });
+  const usage = await getUsageInfoForIdentity({ agentId, home, info, cliVersion: null });
+  return { agent: agentId, label, status: 'ok', email: info.email ?? undefined, usage };
+}
 
-  const lines = [heading];
-  if (info.email) lines.push(`  ${chalk.dim(info.email)}`);
-  const section = formatUsageSection(usage);
-  if (section.length === 0) {
-    lines.push(`  ${chalk.dim('No usage data available right now.')}`);
-  } else {
-    lines.push(...section);
+/** Render one usage record as the human table section. */
+function formatAgentUsage(rec: AgentUsageRecord): string {
+  const cfg = AGENTS[rec.agent];
+  switch (rec.status) {
+    case 'unsupported':
+      return [rec.label, `  ${chalk.dim(`${cfg.name} CLI does not publish usage data.`)}`].join('\n');
+    case 'no-version':
+      return [rec.label, `  ${chalk.dim('No version installed.')}`].join('\n');
+    case 'not-signed-in':
+      return [rec.label, `  ${chalk.dim('Not signed in.')}`].join('\n');
+    case 'ok': {
+      const lines = [rec.label];
+      if (rec.email) lines.push(`  ${chalk.dim(rec.email)}`);
+      const section = formatUsageSection(rec.usage!);
+      if (section.length === 0) {
+        lines.push(`  ${chalk.dim('No usage data available right now.')}`);
+      } else {
+        lines.push(...section);
+      }
+      return lines.join('\n');
+    }
   }
-  return lines.join('\n');
 }


### PR DESCRIPTION
Three small, independent agent-friendliness fixes from the API-surface audit (batched to keep one review/merge). Each is a separate commit.

## 1. `agents fork` exited 0 on every failure  → now exits 1
Every failure path (no match, ambiguous id, unforkable agent, fork error) printed to **stdout** and `return`ed with exit code **0**, so `agents fork <id> && agents resume <new>` proceeded on a *failed* fork. Failures now go to **stderr** and set **exit 1**.
`apps/cli/src/commands/fork.ts`

## 2. Removed the dead `--json` flag on `agents sessions tail`
Declared at registration but **never read** — tail output is always raw JSONL — so it advertised a toggle that does nothing. Dropped from the surface; output unchanged. (The CLI's `allowUnknownOption` means any script still passing `--json` is unaffected.)
`apps/cli/src/commands/sessions-tail.ts`

## 3. Added `agents usage --json`
`usage` was the only per-account numeric command with no machine-readable output — its siblings `cost`/`budget`/`view`/`doctor`/`models` all have `--json` — forcing an agent to scrape colored text. Now emits a per-agent snapshot array; text and JSON share one `collectAgentUsage` data path (no duplication).
`apps/cli/src/commands/usage.ts`

## Verified end-to-end (built binary)
```
fork <nomatch>        → exit=1, error on stderr, stdout empty   (was exit 0)
sessions tail --help  → no --json listed (only --latest/--from-start)
usage --json          → valid JSON array, 7 records, parsed OK
```
`tsc` + build clean; 596 tests pass across the touched surfaces (`src/commands/usage`, `src/lib/session`, `src/commands/models`); the `usage` refactor rename is internal-only (nothing imports the old `renderAgentUsage`).

Deferred as follow-ups (need more than a trivial change): `logs <id> --json` (needs a schema for host-task vs session logs) and the TTY-guard hangs (`run --copy-creds`, `hosts add` — need real headless-hang testing).

Context: part of the agent-friendliness bug-kills identified in the agents-cli API-surface audit (the `sessions --json` secret-redaction fix landed in #1304).

Session transcript (public repo — path only, not attached): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/bde29883-386c-4cdd-8d8b-056693c42a50.jsonl`