### PR TITLE
fix(devices): probe fleet health as the device's registry user, not the local login

### DIFF
--- a/apps/cli/src/commands/check.ts
+++ b/apps/cli/src/commands/check.ts
@@ -17,7 +17,7 @@ import { AGENTS, ALL_AGENT_IDS } from '../lib/agents.js';
 import { setHelpSections } from '../lib/help.js';
 import { computeDrift, type SyncStatusRow } from '../lib/drift.js';
 import { loadDevices } from '../lib/devices/registry.js';
-import { fanOutDevices, planFleetTargets, remoteFleetTargets, type FanOutDeviceTarget } from '../lib/devices/fleet.js';
+import { fanOutDevices, fleetProbeTargets, planFleetTargets, type FleetProbeTarget } from '../lib/devices/fleet.js';
 import { machineId } from '../lib/session/sync/config.js';
 import { buildRemoteAgentsInvocation } from '../lib/hosts/remote-cmd.js';
 import { sshExecAsync } from '../lib/ssh-exec.js';
@@ -146,11 +146,7 @@ function checkPayload(device: string, drift: ReturnType<typeof computeDrift>): D
   };
 }
 
-interface CheckFanOutTarget extends FanOutDeviceTarget {
-  platform?: string;
-}
-
-async function probeDeviceCheck(target: CheckFanOutTarget): Promise<DeviceCheckResult> {
+async function probeDeviceCheck(target: FleetProbeTarget): Promise<DeviceCheckResult> {
   const isWin = /^win/i.test((target.platform ?? '').trim());
   const remoteCmd = buildRemoteAgentsInvocation(
     ['check', '--json'],
@@ -158,7 +154,7 @@ async function probeDeviceCheck(target: CheckFanOutTarget): Promise<DeviceCheckR
     isWin ? 'windows' : undefined,
     isWin ? undefined : { PATH: '$HOME/.agents/.cache/shims:$HOME/.local/bin:$PATH' },
   );
-  const res = await sshExecAsync(target.name, remoteCmd, { timeoutMs: 30000, multiplex: true });
+  const res = await sshExecAsync(target.sshTarget, remoteCmd, { timeoutMs: 30000, multiplex: true });
   if (res.code !== 0 && !res.stdout.trim()) {
     throw new Error(res.timedOut ? 'timed out' : (res.stderr.trim() || `exit ${res.code ?? 'unknown'}`));
   }
@@ -181,12 +177,7 @@ async function runDevicesCheck(opts: CheckOptions, cwd: string): Promise<void> {
   const self = machineId();
   const planned = planFleetTargets(registry);
   const local = checkPayload(self, computeDrift(cwd));
-  const remoteTargets: CheckFanOutTarget[] = remoteFleetTargets(planned, self)
-    .map((t) => ({
-      name: t.device.name,
-      platform: t.device.platform,
-      skip: t.skip,
-    }));
+  const remoteTargets = fleetProbeTargets(planned, self);
   const remote = await fanOutDevices(remoteTargets, probeDeviceCheck);
   const devices: DeviceCheckResult[] = [local];
   for (const result of remote) {

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -56,12 +56,12 @@ import { ensureManagedKnownHostsDir, isHostPinned } from '../lib/devices/known-h
 import { shouldSyncTerminfo, syncTerminfoToDevice, terminfoHostKey } from '../lib/devices/terminfo.js';
 import {
   fanOutDevices,
+  fleetProbeTargets,
   planFleetTargets,
-  remoteFleetTargets,
   runFleet,
   skipLabel,
   upgradeCommand,
-  type FanOutDeviceTarget,
+  type FleetProbeTarget,
   type FleetRunResult,
 } from '../lib/devices/fleet.js';
 import {
@@ -311,10 +311,6 @@ interface RemoteDoctorJson {
   auth?: FleetHealthRow['auth'];
 }
 
-interface FleetStatusTarget extends FanOutDeviceTarget {
-  platform?: string;
-}
-
 function localHealthRow(self: string, stats?: DeviceStats): FleetHealthRow {
   return {
     name: self,
@@ -327,15 +323,15 @@ function localHealthRow(self: string, stats?: DeviceStats): FleetHealthRow {
   };
 }
 
-async function probeRemoteHealth(target: FleetStatusTarget): Promise<Omit<FleetHealthRow, 'name' | 'platform' | 'stats'>> {
+async function probeRemoteHealth(target: FleetProbeTarget): Promise<Omit<FleetHealthRow, 'name' | 'platform' | 'stats'>> {
   const isWin = /^win/i.test((target.platform ?? '').trim());
   const env = isWin ? undefined : { PATH: '$HOME/.agents/.cache/shims:$HOME/.local/bin:$PATH' };
   const versionCmd = buildRemoteAgentsInvocation(['--version'], undefined, isWin ? 'windows' : undefined, env);
-  const versionRes = await sshExecAsync(target.name, versionCmd, { timeoutMs: 15000, multiplex: true });
+  const versionRes = await sshExecAsync(target.sshTarget, versionCmd, { timeoutMs: 15000, multiplex: true });
   const version = versionRes.code === 0 ? versionRes.stdout.trim().split(/\s+/)[0] || null : null;
 
   const doctorCmd = buildRemoteAgentsInvocation(['doctor', '--json'], undefined, isWin ? 'windows' : undefined, env);
-  const doctorRes = await sshExecAsync(target.name, doctorCmd, { timeoutMs: 30000, multiplex: true });
+  const doctorRes = await sshExecAsync(target.sshTarget, doctorCmd, { timeoutMs: 30000, multiplex: true });
   if (doctorRes.code !== 0) {
     throw new Error(doctorRes.timedOut ? 'timed out' : (doctorRes.stderr.trim() || `exit ${doctorRes.code ?? 'unknown'}`));
   }
@@ -365,12 +361,7 @@ async function runFleetStatus(opts: { json?: boolean; strict?: boolean; stats?: 
     : (await loadFleetStats(probeable, { forceRefresh, selfName: self })).stats;
 
   const rows: FleetHealthRow[] = [localHealthRow(self, statsMap.get(self))];
-  const remoteTargets: FleetStatusTarget[] = remoteFleetTargets(planned, self)
-    .map((t) => ({
-      name: t.device.name,
-      platform: t.device.platform,
-      skip: t.skip,
-    }));
+  const remoteTargets = fleetProbeTargets(planned, self);
   const remote = await fanOutDevices(remoteTargets, probeRemoteHealth);
   for (const result of remote) {
     const profile = reg[result.name];
@@ -423,11 +414,11 @@ interface FleetPingHostResult {
 }
 
 /** SSH into a host and run its local auth probe, returning its rows. */
-async function probeRemoteAuth(target: FleetStatusTarget): Promise<AuthProbeRow[]> {
+async function probeRemoteAuth(target: FleetProbeTarget): Promise<AuthProbeRow[]> {
   const isWin = /^win/i.test((target.platform ?? '').trim());
   const env = isWin ? undefined : { PATH: '$HOME/.agents/.cache/shims:$HOME/.local/bin:$PATH' };
   const cmd = buildRemoteAgentsInvocation(['devices', 'ping', '--local', '--json'], undefined, isWin ? 'windows' : undefined, env);
-  const res = await sshExecAsync(target.name, cmd, { timeoutMs: 60000, multiplex: true });
+  const res = await sshExecAsync(target.sshTarget, cmd, { timeoutMs: 60000, multiplex: true });
   if (res.code !== 0) {
     throw new Error(res.timedOut ? 'timed out' : (res.stderr.trim() || `exit ${res.code ?? 'unknown'}`));
   }
@@ -463,16 +454,12 @@ async function runFleetPing(opts: { json?: boolean; local?: boolean; verbose?: b
   writeFleetAuthRows(self, localRows);
   results.push({ host: self, rows: localRows });
 
-  const remoteTargets: FleetStatusTarget[] = remoteFleetTargets(planned, self).map((t) => ({
-    name: t.device.name,
-    platform: t.device.platform,
-    skip: t.skip,
-  }));
+  const remoteTargets = fleetProbeTargets(planned, self);
   const probeable = remoteTargets.filter((t) => !t.skip).length;
   const spinner = isInteractiveTerminal() && !opts.json
     ? ora(`Pinging ${probeable} device${probeable === 1 ? '' : 's'}…`).start()
     : undefined;
-  let remote: Awaited<ReturnType<typeof fanOutDevices<AuthProbeRow[], FleetStatusTarget>>>;
+  let remote: Awaited<ReturnType<typeof fanOutDevices<AuthProbeRow[], FleetProbeTarget>>>;
   try {
     remote = await fanOutDevices(remoteTargets, probeRemoteAuth);
   } finally {

--- a/apps/cli/src/lib/devices/fleet.test.ts
+++ b/apps/cli/src/lib/devices/fleet.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   planFleetTargets,
   remoteFleetTargets,
+  fleetProbeTargets,
   fanOutDevices,
   runFleet,
   skipLabel,
@@ -80,6 +81,41 @@ describe('remoteFleetTargets (fleet health/drift gate targeting)', () => {
     expect(byName.zion).toBeUndefined(); // self is probed in-process, not fanned out
     expect(byName.worker.skip).toBeUndefined(); // a real probe target
     expect(byName.dead.skip).toBe('offline'); // genuine fault — kept, surfaces as unreachable
+  });
+});
+
+describe('fleetProbeTargets (fleet status / ping / check remote probe targets)', () => {
+  it('resolves each device to its registry user@host ssh target, not the bare name', () => {
+    // The regression: fleet status/ping/check used to fan out on the bare device
+    // NAME, so ssh fell back to the caller's local login user — a device whose
+    // remote OS user differs (a Linux peer `taylor` reached from a macOS caller
+    // `taylorgagne`) was probed as the wrong user and reported unreachable, even
+    // though the stats probe (which honors device.user) reached it fine.
+    const reg: DeviceRegistry = {
+      zion: device({ name: 'zion', tailscale: { online: true, direct: true } }), // self
+      mars: device({ name: 'mars', user: 'taylor', tailscale: { online: true, direct: true } }),
+    };
+    const targets = fleetProbeTargets(planFleetTargets(reg), 'zion');
+    expect(targets).toHaveLength(1);
+    expect(targets[0].name).toBe('mars');
+    // user@host — carries the per-device user, so ssh reaches the box correctly.
+    expect(targets[0].sshTarget).toBe('taylor@mars.ts.net');
+    expect(targets[0].platform).toBe('linux');
+  });
+
+  it('leaves skipped devices with an empty sshTarget (never probed) instead of throwing', () => {
+    const reg: DeviceRegistry = {
+      zion: device({ name: 'zion', tailscale: { online: true, direct: true } }), // self
+      offline: device({ name: 'offline', tailscale: { online: false, direct: false, lastSeen: 'y' } }),
+      bare: device({ name: 'bare', address: { via: 'manual' } }), // no-address
+    };
+    const byName = Object.fromEntries(
+      fleetProbeTargets(planFleetTargets(reg), 'zion').map((t) => [t.name, t]),
+    );
+    expect(byName.offline.skip).toBe('offline');
+    expect(byName.offline.sshTarget).toBe('');
+    expect(byName.bare.skip).toBe('no-address');
+    expect(byName.bare.sshTarget).toBe('');
   });
 });
 

--- a/apps/cli/src/lib/devices/fleet.ts
+++ b/apps/cli/src/lib/devices/fleet.ts
@@ -37,6 +37,24 @@ export interface FanOutDeviceTarget {
   skip?: FleetSkipReason | string;
 }
 
+/**
+ * A remote fleet health/drift probe target: a {@link FanOutDeviceTarget} plus
+ * the device platform and its registry-resolved ssh target. Shared by
+ * `fleet status`, `fleet ping`, and `check --devices`.
+ */
+export interface FleetProbeTarget extends FanOutDeviceTarget {
+  platform?: string;
+  /**
+   * Resolved `user@host` ssh target for this device (from the registry `user`).
+   * Remote probes MUST ssh to this, never the bare `name`: a bare name has no
+   * `user@`, so ssh falls back to the caller's local login user and a device
+   * whose remote OS user differs (macOS caller `taylorgagne` → Linux peer
+   * `taylor`) is reached as the wrong user and rejected by tailscaled. Empty
+   * string for skipped devices, which {@link fanOutDevices} never probes.
+   */
+  sshTarget: string;
+}
+
 export interface FanOutDeviceResult<T> {
   name: string;
   status: 'ok' | 'failed' | 'skipped';
@@ -86,6 +104,24 @@ export function planFleetTargets(reg: DeviceRegistry): FleetTarget[] {
  */
 export function remoteFleetTargets(planned: FleetTarget[], self: string): FleetTarget[] {
   return planned.filter((t) => t.device.name !== self && t.skip !== 'control');
+}
+
+/**
+ * Build the fan-out targets for the fleet health/drift probes — the shared shape
+ * consumed by `fleet status`, `fleet ping`, and `check --devices`. Each carries
+ * the registry-resolved `user@host` ssh target (see {@link FleetProbeTarget.sshTarget})
+ * so the remote probe reaches the device as its configured user, matching the
+ * stats/`agents ssh` path. Skipped devices (offline / no-address / control)
+ * carry an empty `sshTarget`; {@link fanOutDevices} short-circuits them before
+ * any ssh, so `sshTargetFor` is only evaluated where it is known to succeed.
+ */
+export function fleetProbeTargets(planned: FleetTarget[], self: string): FleetProbeTarget[] {
+  return remoteFleetTargets(planned, self).map((t) => ({
+    name: t.device.name,
+    platform: t.device.platform,
+    skip: t.skip,
+    sshTarget: t.skip ? '' : sshTargetFor(t.device),
+  }));
 }
 
 /** Human label for a skip reason. */


### PR DESCRIPTION
Fixes #1299

## Summary

`agents fleet status`, `fleet ping`, and `check --devices` report a correctly-configured, reachable device as **unreachable / drifted** when its remote OS user differs from the caller's local username (the common macOS caller `taylorgagne` → Linux peer `taylor`). Their readiness/drift probe fanned out on the **bare device name**:

```ts
await sshExecAsync(target.name, cmd, …)   // "mars" — no user@ → ssh uses the LOCAL login user
```

so ssh had no `user@` prefix and fell back to the caller's local login user. tailscaled then rejects it:

```
mars:
  note: tailscale: failed to look up local user "taylorgagne"
        Connection closed by 100.82.141.80 port 22
```

The tell that only the readiness probe was affected: the **resource-stats** probe on the very same command already honors `device.user` (via `buildSshInvocation`), so `fleet status --json` showed a device `reachable: true` with real load/mem numbers sitting right next to a `clis: {}` and a `failed to look up local user` error.

`--strict` then exits non-zero on the false unreachable, breaking CI drift gates (`check --devices --strict`, `fleet status --strict`) for any fleet with a non-matching remote username.

## Fix

Resolve the ssh target the same way every other ssh caller (stats, `agents ssh`, `doctor`'s fan-out) does — through `sshTargetFor(device)` → `user@host`.

A new shared `fleetProbeTargets()` helper builds the fan-out targets with a resolved `sshTarget`, replacing the identical target-mapping that was duplicated across all three call sites and the two per-file `*FanOutTarget` interfaces (now one shared `FleetProbeTarget`). Skipped devices (offline / no-address / control) carry an empty `sshTarget`; `fanOutDevices` short-circuits them before any ssh, so `sshTargetFor` is only evaluated where it cannot throw.

Touched: `lib/devices/fleet.ts` (helper + type), `commands/ssh.ts` (`fleet status`, `fleet ping`), `commands/check.ts` (`check --devices`).

## Verification

- `tsc --noEmit` clean.
- `fleet.test.ts` + `check.test.ts`: 20 passed (new tests cover `user@host` resolution and the empty-`sshTarget` skip path).
- **End-to-end against a live tailnet:** `mars` (Linux user `taylor`, reached from a macOS caller whose local user is `taylorgagne`) now probes green — `error` gone, remote CLI version read over ssh, and `clis` resolved under `/home/taylor/.agents/…`, proving ssh connected as `taylor`, not `taylorgagne`.

Fixes the fleet-status device-user issue (probe SSHes as the wrong user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)