### PR TITLE
feat(secrets): persist unlock across upgrade + sleep (--durable), cross-platform

### DIFF
--- a/apps/cli/.changelog/next/secrets-durable-unlock.md
+++ b/apps/cli/.changelog/next/secrets-durable-unlock.md
@@ -1,0 +1,16 @@
+- **`agents secrets unlock` now stays unlocked across an agents-cli upgrade (and,
+  with `--durable`, across sleep + reboot).** The macOS secrets broker held an
+  unlock only in RAM, so it evaporated every time the daemon restarted (upgrade)
+  or the machine slept — forcing a Touch ID re-tap and breaking headless reads
+  with "not unlocked in the secrets agent". An unlock now also persists a
+  device-local, non-biometry keychain session item that the broker **rehydrates on
+  start** and that reads **fall back to** silently. Split default: it survives
+  upgrade/restart automatically; pass `--durable` (or set `secrets.agent.durable:
+  true`) to also survive sleep/reboot — otherwise a bundle re-locks on sleep as
+  before. `lock` / rotate / delete clear it. On Linux and Windows `unlock` is now a
+  friendly no-op (secrets already resolve durably from the OS store with no
+  prompt), so the command behaves the same on all three platforms. Source:
+  `apps/cli/src/lib/secrets/session-store.ts` (new),
+  `apps/cli/src/lib/secrets/agent.ts`, `apps/cli/src/lib/secrets/bundles.ts`,
+  `apps/cli/src/lib/secrets/index.ts`, `apps/cli/src/commands/secrets.ts`,
+  `apps/cli/src/lib/types.ts`.

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -209,6 +209,7 @@ The Windows push bridge is `buildWindowsStdinImportCommand` in
 | `secrets unlock [names...]` | Read a bundle once (one Touch ID) and hold it in the secrets-agent so later runs read it silently | `agents secrets unlock prod` |
 | `secrets unlock --all` | Unlock every configured bundle | `agents secrets unlock --all` |
 | `secrets unlock <name> --ttl <dur>` | Hold for a custom lifetime (default 7d) | `agents secrets unlock prod --ttl 30m` |
+| `secrets unlock <name> --durable` | Also survive sleep + reboot (default: survives upgrade/restart, re-locks on sleep) | `agents secrets unlock prod --durable` |
 | `secrets lock [names...]` | Wipe held bundles from the agent (default: all) — next read re-prompts | `agents secrets lock` |
 | `secrets status` | Show which bundles the agent holds and when they lock | `agents secrets status` |
 | `secrets policy <bundle> [policy]` | Show or set a bundle's prompt policy: `daily` (default), `always`, or `never` (silent, no biometry ACL — needs `--i-understand`) | `agents secrets policy signing always` |
@@ -476,7 +477,8 @@ The secrets-agent is the ssh-agent answer:
 
 - `agents secrets unlock <bundle>` reads the bundle from the keychain **once** (one Touch ID) and hands the resolved env to a small local broker that holds it in memory.
 - Every later resolution of that bundle — by any `agents run`, teammate, browser profile, or the routines daemon — is served from the broker over a user-only Unix socket (dir `~/.agents/.cache/helpers/secrets-agent/`, mode `0700`). No prompt.
-- The hold ends when its TTL expires (default 7d, `--ttl` to change), you run `agents secrets lock`, the machine sleeps, or you log out. A bare screen-lock does **not** drop it — the login password already gates a locked screen, and re-prompting after every lock would defeat the ~7-day window. Nothing is ever written to disk.
+- The hold ends when its TTL expires (default 7d, `--ttl` to change), you run `agents secrets lock`, or the machine sleeps. A bare screen-lock does **not** drop it — the login password already gates a locked screen, and re-prompting after every lock would defeat the ~7-day window.
+- **The unlock survives an agents-cli upgrade / daemon restart.** The resolved env is also persisted as a device-local, non-biometry keychain session item that the broker **rehydrates on start** and that reads fall back to silently — so a restart (which empties the broker's memory) no longer forces a re-tap, and a headless read no longer fails with "not unlocked in the secrets agent". It still re-locks on sleep by default; pass **`--durable`** (or set `secrets.agent.durable: true`) to survive sleep + reboot as well. `lock`, rotate, and delete clear the session item. Audit reads served from it tag `"source":"session"`.
 
 It is **opt-in by construction**: if you never run `unlock`, resolution is byte-for-byte today's keychain path. Audit events tag broker-served reads with `"source":"agent"` so you can tell them apart from real keychain reads.
 
@@ -508,7 +510,8 @@ Change the **default** for all bundles globally in `agents.yaml` (`secrets.polic
 secrets:
   policy: daily   # default prompt policy for bundles without an explicit one (this IS the default)
   agent:
-    auto: false   # opt OUT of daily-policy self-caching (on by default)
+    auto: false     # opt OUT of daily-policy self-caching (on by default)
+    durable: true   # make every unlock survive sleep + reboot too (default: survives upgrade/restart, re-locks on sleep)
 ```
 
 Auto-cache is **on by default** and only ever applies to `daily`-policy bundles — an `always` bundle is never auto-held, and a `never` bundle needs no agent at all (it is already silent). The `never` policy (items stored without the biometry ACL for fully silent reads with no broker) is the global downgrade the agent is otherwise designed to avoid, so it stays gated behind an explicit confirmation and a signed helper with the `set-no-acl` write path; see the [security model](#security-model). Tracked in [issue #421](https://github.com/phnx-labs/agents-cli/issues/421).
@@ -517,7 +520,7 @@ Auto-cache is **on by default** and only ever applies to `daily`-policy bundles 
 
 Snapshot semantics: `unlock` stores the **resolved** env, so a bundle's dynamic refs (`exec:`, `env:`, `file:`) are frozen at unlock time until you re-unlock. Keychain and literal values — the overwhelming majority — are unaffected.
 
-Source: `src/lib/secrets/agent.ts`. Auto-lock on sleep uses the signed keychain helper's `watch-lock` mode (`src/lib/secrets/keychain-helper.swift`) — a bare screen-lock does **not** wipe the hold (the login password already gates a locked screen); with an older helper that predates `watch-lock`, the agent degrades to TTL-only locking.
+Source: `src/lib/secrets/agent.ts`, `src/lib/secrets/session-store.ts`. Auto-lock on sleep uses the signed keychain helper's `watch-lock` mode (`src/lib/secrets/keychain-helper.swift`) — a bare screen-lock does **not** wipe the hold (the login password already gates a locked screen); with an older helper that predates `watch-lock`, the agent degrades to TTL-only locking. On SLEEP the broker also deletes non-`--durable` session items so those bundles re-lock; `--durable` items survive. **Durable-unlock security note:** a `--durable` (or `secrets.agent.durable`) session extends the silent-read window from "until the next sleep" to "up to the TTL, across sleeps and reboots" — the same same-user trust boundary the trade-off above describes, held longer. It is off by default for that reason. **Off macOS** this whole layer is a no-op: Linux (libsecret) and Windows (Credential Manager) resolve secrets durably from the OS store on every read with no prompt and no broker, so `agents secrets unlock` there is a friendly no-op and reads never re-prompt.
 
 ## Linux: headless servers and the encrypted-file fallback
 

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -71,6 +71,7 @@ import {
 } from '../lib/onepassword.js';
 import {
   secretsHoldMs,
+  secretsAgentDurable,
   agentLoad,
   agentLock,
   agentPing,
@@ -80,6 +81,7 @@ import {
   runSecretsAgent,
   uninstallSecretsAgentService,
 } from '../lib/secrets/agent.js';
+import { saveSession, deleteSession, deleteAllSessions } from '../lib/secrets/session-store.js';
 import { getCliVersionFresh } from '../lib/version.js';
 import { readMeta } from '../lib/state.js';
 import { parseDuration } from '../lib/hooks/cache.js';
@@ -1962,9 +1964,10 @@ Examples:
     .command('unlock [names...]')
     .description('Hold a bundle in the secrets-agent after one Touch ID, so concurrent runs read it without re-prompting (macOS). With --host, unlock FILE-backed bundle(s) on a remote (the passphrase prompt surfaces over the SSH TTY); keychain/biometry bundles are GUI-only and can\'t be remote-unlocked.')
     .option('--ttl <duration>', 'How long to hold it (e.g. 30m, 8h, 3d). Default 7d.')
+    .option('--durable', 'Keep the unlock across sleep + reboot too (default: survives upgrade/restart but re-locks on sleep). Set secrets.agent.durable in agents.yaml to make this the default.')
     .option('--all', 'Unlock every configured bundle')
     .option('--host <target>', 'Unlock the bundle(s) on this remote machine over SSH instead of locally (file-backed bundles only — the remote\'s passphrase prompt surfaces on your terminal over a -tt session). Single-valued (NOT variadic) so it never swallows the bundle name: `unlock <name> --host <machine>`.')
-    .action(async (names: string[], opts: { ttl?: string; all?: boolean; host?: string }) => {
+    .action(async (names: string[], opts: { ttl?: string; durable?: boolean; all?: boolean; host?: string }) => {
       // Single-valued (not variadic): a variadic --host greedily consumes the
       // positional bundle name (`unlock --host mac wztest` -> host=[mac,wztest],
       // names=[]). Unlock targets one remote at a time anyway.
@@ -2000,8 +2003,12 @@ Examples:
         return;
       }
       if (process.platform !== 'darwin') {
-        console.error(chalk.red('secrets-agent is macOS-only (no biometry prompt to deduplicate elsewhere).'));
-        process.exit(1);
+        // No broker + no biometry prompt off darwin: secrets already resolve
+        // durably from the OS store (libsecret / Credential Manager) on every
+        // read with no prompt, so an unlock is a friendly no-op — not an error.
+        // Accept --durable as a documented no-op so the command is uniform.
+        console.log(chalk.gray('Nothing to unlock: secrets already persist on this OS — reads never re-prompt.'));
+        return;
       }
       let targets = opts.all ? listBundles().map((b) => b.name) : names;
       if (!targets || targets.length === 0) {
@@ -2035,6 +2042,14 @@ Examples:
           const { bundle, env } = readAndResolveBundleEnv(name, { noAgent: true, caller: 'unlock' });
           if (await agentLoad(name, bundle, env, ttlMs)) {
             loaded++;
+            // Persist a durable session snapshot so the unlock survives a daemon
+            // restart / upgrade (and sleep too, with --durable). session-store.ts.
+            saveSession(name, {
+              bundle,
+              env,
+              expiresAt: Date.now() + ttlMs,
+              sleepPersist: opts.durable ?? secretsAgentDurable(),
+            });
             console.log(`${chalk.green('unlocked')} ${chalk.cyan(name)} ${chalk.gray(`(${Object.keys(env).length} keys, ${humanRemaining(Date.now() + ttlMs)})`)}`);
           } else {
             console.error(chalk.red(`Failed to load '${name}' into the agent.`));
@@ -2058,10 +2073,14 @@ Examples:
       if (process.platform !== 'darwin') return; // nothing to lock off darwin
       if (names && names.length > 0 && !opts.all) {
         let total = 0;
-        for (const name of names) total += await agentLock(name);
+        for (const name of names) {
+          total += await agentLock(name);
+          deleteSession(name); // also drop the durable snapshot, or a restart re-warms it
+        }
         console.log(total > 0 ? chalk.green(`Locked ${total} bundle(s).`) : chalk.gray('Nothing to lock.'));
       } else {
         const wiped = await agentLock();
+        deleteAllSessions();
         console.log(wiped > 0 ? chalk.green(`Locked ${wiped} bundle(s).`) : chalk.gray('Nothing to lock.'));
       }
     });

--- a/apps/cli/src/lib/secrets/agent.ts
+++ b/apps/cli/src/lib/secrets/agent.ts
@@ -36,6 +36,7 @@ import { getKeychainHelperPath } from './install-helper.js';
 import { getCliVersion, getCliVersionFresh } from '../version.js';
 import { getCliLaunch } from '../cli-entry.js';
 import type { SecretsBundle } from './bundles.js';
+import { rehydrateSessions, pruneSessionsOnSleep } from './session-store.js';
 
 /** Bumped when the wire protocol changes; a client that pings a mismatched
  * server kills and respawns it rather than talking a stale dialect. */
@@ -118,6 +119,21 @@ export interface AgentStatusEntry {
 
 function onDarwin(): boolean {
   return process.platform === 'darwin';
+}
+
+/**
+ * Build the broker's in-memory store, REHYDRATED from the durable session store
+ * (session-store.ts) so an unlock survives a daemon restart / agents-cli upgrade.
+ * Expired sessions are dropped; `--durable` and default entries alike come back
+ * (SLEEP already pruned the non-durable ones from the keychain while the broker
+ * was alive). Empty off darwin or when nothing was held.
+ */
+function rehydrateStore(now: number = Date.now()): Map<string, StoredBundle> {
+  const store = new Map<string, StoredBundle>();
+  for (const { name, entry } of rehydrateSessions(now)) {
+    store.set(name, { bundle: entry.bundle, env: entry.env, expiresAt: entry.expiresAt });
+  }
+  return store;
 }
 
 /** Broker runtime dir under the regenerable cache, locked to the user (0700).
@@ -479,7 +495,7 @@ export async function runSecretsAgent(
     }
   }
 
-  const store = new Map<string, StoredBundle>();
+  const store = rehydrateStore();
   // emptySince tracks the last moment the store held something; the sweep exits
   // the process once it's been empty for IDLE_EXIT_MS so no idle broker lingers.
   let emptySince = Date.now();
@@ -616,6 +632,9 @@ export async function runSecretsAgent(
       if (shouldWipeOnWatchEvent(chunk)) {
         store.clear();
         emptySince = Date.now();
+        // Split default: delete non-`--durable` durable sessions too, so a default
+        // unlock re-locks on sleep; `--durable` ones survive (session-store.ts).
+        pruneSessionsOnSleep();
       }
     });
     watcher.on('error', () => { watcher = null; });
@@ -654,7 +673,7 @@ export async function runSecretsAgent(
 export async function startHostedBroker(): Promise<{ close(): void } | null> {
   if (!onDarwin()) return null;
 
-  const store = new Map<string, StoredBundle>();
+  const store = rehydrateStore();
   const sock = socketPath(); // agentDir() creates the 0700 dir as a side effect
 
   const handle = (req: Request): Response => handleAgentRequest(store, req);
@@ -679,7 +698,10 @@ export async function startHostedBroker(): Promise<{ close(): void } | null> {
     watcher = spawn(getKeychainHelperPath(), ['watch-lock'], { stdio: ['ignore', 'pipe', 'ignore'] });
     watcher.stdout?.setEncoding('utf-8');
     watcher.stdout?.on('data', (chunk: string) => {
-      if (shouldWipeOnWatchEvent(chunk)) store.clear();
+      if (shouldWipeOnWatchEvent(chunk)) {
+        store.clear();
+        pruneSessionsOnSleep(); // split default — see runSecretsAgent's handler
+      }
     });
     watcher.on('error', () => { watcher = null; });
   } catch {
@@ -918,6 +940,18 @@ export function secretsAgentAutoEnabled(): boolean {
     return readMeta().secrets?.agent?.auto !== false;
   } catch {
     return true;
+  }
+}
+
+/** Default `sleepPersist` for a new unlock when `--durable` is not passed. OFF by
+ * default (the secure split default: survive restart, re-lock on sleep); set
+ * `secrets.agent.durable: true` in agents.yaml to make every unlock sleep-durable.
+ * Best-effort; an unreadable meta reads as off. */
+export function secretsAgentDurable(): boolean {
+  try {
+    return readMeta().secrets?.agent?.durable === true;
+  } catch {
+    return false;
   }
 }
 

--- a/apps/cli/src/lib/secrets/bundles.test.ts
+++ b/apps/cli/src/lib/secrets/bundles.test.ts
@@ -19,6 +19,7 @@ import {
   setKeychainToken,
   type KeychainBackend,
 } from './index.js';
+import { saveSession } from './session-store.js';
 
 /**
  * Regression tests for the two least-privilege bypasses on the
@@ -293,5 +294,76 @@ describe('bundles under hashed service names (#316)', () => {
     const item = secretsKeychainItem('prod', 'API_KEY');
     expect(deleteKeychainToken(item)).toBe(true);
     expect(() => readAndResolveBundleEnv('prod', {})).toThrow(/stored item .* not found/);
+  });
+});
+
+// The durable-session read fallback (Correction B): after a restart the broker
+// RAM is empty, so the fast-path misses; a persisted unlock session must satisfy
+// the read silently instead of throwing / re-prompting.
+describe('durable session read fallback', () => {
+  class MemBackend implements KeychainBackend {
+    store = new Map<string, string>();
+    has(item: string) { return this.store.has(item); }
+    get(item: string) {
+      const v = this.store.get(item);
+      if (v === undefined) throw new Error(`missing ${item}`);
+      return v;
+    }
+    set(item: string, value: string) { this.store.set(item, value); }
+    delete(item: string) { return this.store.delete(item); }
+    list(prefix: string) { return [...this.store.keys()].filter((k) => k.startsWith(prefix)); }
+  }
+
+  let mem: MemBackend;
+  let prev: KeychainBackend | null = null;
+  const prevNoAgent = process.env.AGENTS_SECRETS_NO_AGENT;
+  const prevNoUsage = process.env.AGENTS_NO_USAGE_TRACK;
+
+  beforeEach(() => {
+    mem = new MemBackend();
+    prev = setKeychainBackendForTest(mem);
+    // The fallback is gated behind the agent path — do NOT set NO_AGENT here (the
+    // other suite does). There is no broker socket in CI, so agentGetSync misses
+    // and we fall through to the session store.
+    delete process.env.AGENTS_SECRETS_NO_AGENT;
+    process.env.AGENTS_NO_USAGE_TRACK = '1';
+  });
+  afterEach(() => {
+    setKeychainBackendForTest(prev);
+    if (prevNoAgent === undefined) delete process.env.AGENTS_SECRETS_NO_AGENT;
+    else process.env.AGENTS_SECRETS_NO_AGENT = prevNoAgent;
+    if (prevNoUsage === undefined) delete process.env.AGENTS_NO_USAGE_TRACK;
+    else process.env.AGENTS_NO_USAGE_TRACK = prevNoUsage;
+  });
+
+  function seed(name: string, vars: Record<string, string>): { bundle: SecretsBundle; env: Record<string, string> } {
+    const bundle: SecretsBundle = { name, vars: {} };
+    for (const [k, v] of Object.entries(vars)) {
+      setKeychainToken(secretsKeychainItem(name, k), v);
+      bundle.vars[k] = `keychain:${k}`;
+    }
+    writeBundle(bundle);
+    return readAndResolveBundleEnv(name, { noAgent: true, caller: 'seed' });
+  }
+
+  it('a headless read resolves from a live session instead of throwing "not unlocked"', () => {
+    const { bundle, env } = seed('apple.com', { APPLE_TEAM_ID: '2HTP252L87' });
+    // No session yet → the headless (agentOnly) read must throw.
+    expect(() => readAndResolveBundleEnv('apple.com', { agentOnly: true })).toThrow(/not unlocked in the secrets agent/);
+    // Persist an unlock → the SAME headless read now resolves silently.
+    saveSession('apple.com', { bundle, env, expiresAt: Date.now() + 60_000, sleepPersist: false });
+    expect(readAndResolveBundleEnv('apple.com', { agentOnly: true }).env).toEqual({ APPLE_TEAM_ID: '2HTP252L87' });
+  });
+
+  it('honors --keys subset from the session snapshot', () => {
+    const { bundle, env } = seed('multi', { A: '1', B: '2' });
+    saveSession('multi', { bundle, env, expiresAt: Date.now() + 60_000, sleepPersist: true });
+    expect(readAndResolveBundleEnv('multi', { agentOnly: true, keys: ['A'] }).env).toEqual({ A: '1' });
+  });
+
+  it('an expired session does not satisfy the read', () => {
+    const { bundle, env } = seed('stale', { T: 'x' });
+    saveSession('stale', { bundle, env, expiresAt: Date.now() - 1000, sleepPersist: true });
+    expect(() => readAndResolveBundleEnv('stale', { agentOnly: true })).toThrow(/not unlocked/);
   });
 });

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -42,6 +42,7 @@ import { fileStore } from './filestore.js';
 import { emit } from '../events.js';
 import { readMeta } from '../state.js';
 import { agentGetSync, agentAutoLoadSync, agentGetMetaSync, agentAutoLoadMetaSync, agentEvictSync, secretsAgentAutoEnabled, secretsHoldMs } from './agent.js';
+import { loadSession, deleteSession } from './session-store.js';
 import { createHash } from 'node:crypto';
 
 /** Which store carries a bundle's items. */
@@ -483,6 +484,9 @@ export function writeBundle(bundle: SecretsBundle, opts: WriteBundleOptions = {}
   // re-resolves from the keychain instead of serving stale values.
   if (shouldEvictAfterBundleWrite(Boolean(opts.skipBrokerEviction), process.env.AGENTS_SECRETS_NO_AGENT, isKeychainBackendOverridden())) {
     agentEvictSync(bundle.name);
+    // Also drop any durable session snapshot, or a broker restart would rehydrate
+    // the stale env after a rotate/rename (session-store.ts).
+    deleteSession(bundle.name);
   }
 }
 
@@ -493,6 +497,7 @@ export function deleteBundle(name: string): boolean {
     emit('secrets.delete', { module: 'secrets', bundle: name });
     if (shouldEvictAfterBundleWrite(false, process.env.AGENTS_SECRETS_NO_AGENT, isKeychainBackendOverridden())) {
       agentEvictSync(name);
+      deleteSession(name); // a deleted bundle must not be rehydratable
     }
   }
   return deleted;
@@ -961,6 +966,30 @@ export function readAndResolveBundleEnv(
         operation: opts.caller,
         status: 'success',
         source: 'agent',
+        keyCount: Object.keys(filtered.env).length,
+      });
+      return filtered;
+    }
+
+    // Durable-session fallback (Correction B). After a daemon restart / agents-cli
+    // upgrade the broker RAM is empty, so the fast-path above misses — but the
+    // unlock persisted a no-ACL session item (session-store.ts) that reads with NO
+    // Touch ID. Serve from it and re-warm the broker, so a warm bundle stays warm
+    // across restart — this fixes BOTH the interactive re-prompt and the headless
+    // throw below (which now fires only when there is genuinely no session).
+    const session = loadSession(name);
+    if (session) {
+      const filtered = filterAgentHitBySubsetAndExpiry({ bundle: session.bundle, env: session.env }, opts);
+      stampLastUsed(filtered.bundle);
+      // Re-warm the broker with the remaining TTL so later reads hit RAM and
+      // `agents secrets status` is honest. Best-effort; no-ops off darwin.
+      agentAutoLoadSync(name, session.bundle, session.env, Math.max(1, session.expiresAt - Date.now()));
+      emit('secrets.get', {
+        module: 'secrets',
+        bundle: name,
+        operation: opts.caller,
+        status: 'success',
+        source: 'session',
         keyCount: Object.keys(filtered.env).length,
       });
       return filtered;

--- a/apps/cli/src/lib/secrets/index.test.ts
+++ b/apps/cli/src/lib/secrets/index.test.ts
@@ -257,6 +257,8 @@ describe('computeRekeyPlan', () => {
       'agents-cli.bundles.prod',
       'agents-cli.secrets.prod.API_KEY',
       'agents-cli.anthropic.token',
+      'agents-cli.session.apple.com',
+      'agents-cli.session.index',
     ];
     const values = new Map([
       ['agents-cli.bundles.autobot', JSON.stringify({ tier: 'none', vars: { CRON_TOKEN: 'keychain:CRON_TOKEN' } })],
@@ -264,6 +266,8 @@ describe('computeRekeyPlan', () => {
       ['agents-cli.bundles.prod', JSON.stringify({ tier: 'session', vars: {} })],
       ['agents-cli.secrets.prod.API_KEY', 'sk'],
       ['agents-cli.anthropic.token', 'tok'],
+      ['agents-cli.session.apple.com', JSON.stringify({ env: {}, expiresAt: 0, sleepPersist: false })],
+      ['agents-cli.session.index', JSON.stringify({ bundles: {} })],
     ]);
     const { items, unreadable } = computeRekeyPlan(services, values, key);
     expect(unreadable).toEqual([]);
@@ -273,6 +277,10 @@ describe('computeRekeyPlan', () => {
     expect(byOld['agents-cli.bundles.prod'].noAcl).toBe(false);
     expect(byOld['agents-cli.secrets.prod.API_KEY'].noAcl).toBe(false);
     expect(byOld['agents-cli.anthropic.token'].noAcl).toBe(false);
+    // Correction D: durable session items must stay no-ACL through a rekey, or
+    // their silent (no-Touch-ID) reads break.
+    expect(byOld['agents-cli.session.apple.com'].noAcl).toBe(true);
+    expect(byOld['agents-cli.session.index'].noAcl).toBe(true);
     expect(JSON.parse(byOld['agents-cli.bundles.prod'].payload!).name).toBe('prod');
     expect(byOld['agents-cli.anthropic.token'].newService).toMatch(HASHED_OTHER);
   });

--- a/apps/cli/src/lib/secrets/index.ts
+++ b/apps/cli/src/lib/secrets/index.ts
@@ -587,6 +587,10 @@ export function computeRekeyPlan(
       const dot = rest.lastIndexOf('.');
       if (dot > 0) noAcl = bundleNoAcl(rest.slice(0, dot));
     }
+    // Durable "unlocked session" items (agents-cli.session.*, see session-store.ts)
+    // are always no-ACL — re-wrapping them in a biometry ACL on rekey would break
+    // their silent (no-Touch-ID) reads that the rehydrate/fallback paths depend on.
+    if (service.startsWith('agents-cli.session.')) noAcl = true;
     items.push({ oldService: service, newService: hashedServiceName(service, key), noAcl });
   }
   return { items, unreadable };

--- a/apps/cli/src/lib/secrets/session-store.test.ts
+++ b/apps/cli/src/lib/secrets/session-store.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { randomBytes } from 'node:crypto';
+import {
+  KeychainBackend,
+  setKeychainBackendForTest,
+  setKeychainServiceHashingForTest,
+} from './index.js';
+import type { SecretsBundle } from './bundles.js';
+import {
+  selectRehydratable,
+  pruneOnSleep,
+  pruneExpired,
+  upsertEntry,
+  removeEntry,
+  saveSession,
+  loadSession,
+  deleteSession,
+  deleteAllSessions,
+  rehydrateSessions,
+  pruneSessionsOnSleep,
+  readIndex,
+  type SessionIndex,
+  type SessionEntry,
+} from './session-store.js';
+
+const FAR = 10 * 24 * 60 * 60 * 1000; // 10 days out
+const bundle = (name: string) => ({ name, description: '', vars: {}, policy: 'daily' } as unknown as SecretsBundle);
+const entry = (name: string, expiresAt: number, sleepPersist: boolean): SessionEntry => ({
+  bundle: bundle(name),
+  env: { TOKEN: `secret-${name}` },
+  expiresAt,
+  sleepPersist,
+});
+
+// ─── Pure core (no backend, any platform) ────────────────────────────────────
+
+describe('session-store pure core', () => {
+  const idx = (bundles: SessionIndex['bundles']): SessionIndex => ({ bundles });
+
+  it('selectRehydratable keeps only entries within TTL', () => {
+    const now = 1000;
+    const i = idx({ a: { expiresAt: 2000, sleepPersist: false }, b: { expiresAt: 500, sleepPersist: true } });
+    expect(selectRehydratable(i, now).sort()).toEqual(['a']);
+  });
+
+  it('pruneOnSleep keeps sleepPersist=true, reports the rest', () => {
+    const i = idx({ a: { expiresAt: FAR, sleepPersist: false }, b: { expiresAt: FAR, sleepPersist: true } });
+    const { survivors, deletedNames } = pruneOnSleep(i);
+    expect(Object.keys(survivors.bundles)).toEqual(['b']);
+    expect(deletedNames).toEqual(['a']);
+  });
+
+  it('pruneExpired drops entries past TTL', () => {
+    const now = 1000;
+    const i = idx({ a: { expiresAt: 2000, sleepPersist: false }, b: { expiresAt: 500, sleepPersist: false } });
+    const { survivors, expiredNames } = pruneExpired(i, now);
+    expect(Object.keys(survivors.bundles)).toEqual(['a']);
+    expect(expiredNames).toEqual(['b']);
+  });
+
+  it('upsert/remove are pure and non-mutating', () => {
+    const i = idx({ a: { expiresAt: FAR, sleepPersist: false } });
+    const up = upsertEntry(i, 'b', { expiresAt: FAR, sleepPersist: true });
+    expect(Object.keys(up.bundles).sort()).toEqual(['a', 'b']);
+    expect(Object.keys(i.bundles)).toEqual(['a']); // original untouched
+    expect(Object.keys(removeEntry(up, 'a').bundles)).toEqual(['b']);
+  });
+});
+
+// ─── Adapter against an in-memory keychain (Linux-CI safe) ────────────────────
+
+class MemBackend implements KeychainBackend {
+  store = new Map<string, string>();
+  has(item: string) { return this.store.has(item); }
+  get(item: string) {
+    const v = this.store.get(item);
+    if (v === undefined) throw new Error(`missing ${item}`);
+    return v;
+  }
+  set(item: string, value: string) { this.store.set(item, value); }
+  delete(item: string) { return this.store.delete(item); }
+  list(prefix: string) { return [...this.store.keys()].filter((k) => k.startsWith(prefix)); }
+}
+
+// Run the whole adapter suite twice: cleartext names AND #316-hashed names. The
+// hashed pass is the Correction-A regression guard — all I/O is by known name, so
+// it must round-trip even when `list('agents-cli.session.')` would match nothing.
+describe.each([
+  { label: 'cleartext names', hash: false },
+  { label: 'hashed names (#316)', hash: true },
+])('session-store adapter · $label', ({ hash }) => {
+  let mem: MemBackend;
+  let prev: KeychainBackend | null = null;
+
+  beforeEach(() => {
+    mem = new MemBackend();
+    prev = setKeychainBackendForTest(mem);
+    if (hash) setKeychainServiceHashingForTest(randomBytes(32));
+  });
+  afterEach(() => {
+    if (hash) setKeychainServiceHashingForTest(null);
+    setKeychainBackendForTest(prev);
+  });
+
+  it('save → load round-trips the full entry by known name', () => {
+    saveSession('apple.com', entry('apple.com', FAR + Date.now(), false));
+    const got = loadSession('apple.com');
+    expect(got?.env.TOKEN).toBe('secret-apple.com');
+    expect(got?.bundle.name).toBe('apple.com');
+    // index reflects the hold
+    expect(Object.keys(readIndex().bundles)).toEqual(['apple.com']);
+  });
+
+  it('delete removes both the blob and the index entry', () => {
+    saveSession('npmjs.com', entry('npmjs.com', FAR + Date.now(), true));
+    deleteSession('npmjs.com');
+    expect(loadSession('npmjs.com')).toBeNull();
+    expect(readIndex().bundles).toEqual({});
+  });
+
+  it('loadSession drops an expired blob and returns null', () => {
+    const now = Date.now();
+    saveSession('stale', entry('stale', now + 1000, false));
+    expect(loadSession('stale', now + 5000)).toBeNull();
+    expect(readIndex().bundles.stale).toBeUndefined(); // pruned on read
+  });
+
+  it('rehydrateSessions returns unexpired entries and drops expired', () => {
+    const now = Date.now();
+    saveSession('live', entry('live', now + FAR, false));
+    saveSession('dead', entry('dead', now + 1000, false));
+    const out = rehydrateSessions(now + 5000);
+    expect(out.map((o) => o.name)).toEqual(['live']);
+    expect(out[0].entry.env.TOKEN).toBe('secret-live');
+    expect(readIndex().bundles.dead).toBeUndefined();
+  });
+
+  it('pruneSessionsOnSleep deletes non-durable, keeps --durable', () => {
+    const now = Date.now();
+    saveSession('def', entry('def', now + FAR, false));      // default → re-locks on sleep
+    saveSession('dur', entry('dur', now + FAR, true));        // --durable → survives
+    pruneSessionsOnSleep();
+    expect(loadSession('def')).toBeNull();
+    expect(loadSession('dur')?.bundle.name).toBe('dur');
+    expect(Object.keys(readIndex().bundles)).toEqual(['dur']);
+  });
+
+  it('deleteAllSessions clears everything', () => {
+    saveSession('a', entry('a', now(), false));
+    saveSession('b', entry('b', now(), true));
+    deleteAllSessions();
+    expect(readIndex().bundles).toEqual({});
+    expect(loadSession('a')).toBeNull();
+    expect(loadSession('b')).toBeNull();
+  });
+});
+
+function now(): number { return Date.now() + FAR; }

--- a/apps/cli/src/lib/secrets/session-store.ts
+++ b/apps/cli/src/lib/secrets/session-store.ts
@@ -1,0 +1,230 @@
+/**
+ * Durable "unlocked session" store (macOS).
+ *
+ * The secrets broker (agent.ts) holds unlocked bundles only in RAM, so an
+ * `agents secrets unlock` grant is lost whenever that process dies: on an
+ * agents-cli upgrade (the postinstall bounces the daemon) and on system SLEEP.
+ * This module persists the resolved bundle+env of an unlocked bundle as a
+ * NO-ACL keychain item — the `set-no-acl` write path, `kSecAttrAccessibleAfter-
+ * FirstUnlockThisDeviceOnly`, whose reads never pop Touch ID — so the broker can
+ * REHYDRATE it on start and reads can FALL BACK to it when the broker RAM misses.
+ *
+ * Split-default posture: `sleepPersist` is false by default — the item is deleted
+ * on SLEEP so the bundle re-locks on sleep but survives restart/upgrade; the
+ * `--durable` flag sets it true so it survives sleep too. Both expire at the TTL.
+ *
+ * Cross-platform: a NO-OP off macOS. Linux (secret-service) and Windows
+ * (Credential Manager) have no broker and resolve secrets durably from the OS
+ * store on every read with no prompt (see agent.ts:onDarwin gates) — there is no
+ * ephemeral unlock to persist.
+ *
+ * NEVER enumerate session items: once keychain-name hashing (#316) is active a
+ * `list('agents-cli.session.')` matches nothing. All I/O is by KNOWN name — one
+ * fixed-name index item lists the held bundles + their metadata, and one blob per
+ * bundle holds the env. Every adapter call is best-effort and never throws;
+ * persistence is an optimization, not a correctness dependency.
+ */
+
+import { getKeychainToken, setKeychainToken, deleteKeychainToken, isKeychainBackendOverridden } from './index.js';
+import type { SecretsBundle } from './bundles.js';
+
+/** Prefix for all durable session items (device-local, no-ACL). */
+export const SESSION_ITEM_PREFIX = 'agents-cli.session.';
+/** Fixed-name index item — the ONLY thing we ever need to find without a known
+ * bundle name, so it is read/written by this exact name (never enumerated). */
+export const SESSION_INDEX_ITEM = 'agents-cli.session.index';
+
+/** One persisted unlocked bundle (mirrors the broker's StoredBundle + posture). */
+export interface SessionEntry {
+  bundle: SecretsBundle;
+  env: Record<string, string>;
+  /** epoch ms; the entry is dead once Date.now() passes this. */
+  expiresAt: number;
+  /** true only for `--durable` unlocks — survives SLEEP. */
+  sleepPersist: boolean;
+}
+
+/** Metadata for one held bundle, kept in the index so we can rehydrate / prune
+ * without reading every blob. */
+export interface SessionIndexMeta {
+  expiresAt: number;
+  sleepPersist: boolean;
+}
+export interface SessionIndex {
+  bundles: Record<string, SessionIndexMeta>;
+}
+
+// ─── Pure core (no I/O — unit-testable on any platform) ─────────────────────
+
+/** The bundle names in the index that are still within their TTL at `now`. */
+export function selectRehydratable(index: SessionIndex, now: number): string[] {
+  return Object.entries(index.bundles)
+    .filter(([, m]) => now < m.expiresAt)
+    .map(([name]) => name);
+}
+
+/** Split an index on a SLEEP event: keep `sleepPersist` entries, report the rest
+ * (which the caller deletes from the keychain). Default entries re-lock on sleep. */
+export function pruneOnSleep(index: SessionIndex): { survivors: SessionIndex; deletedNames: string[] } {
+  const survivors: SessionIndex = { bundles: {} };
+  const deletedNames: string[] = [];
+  for (const [name, m] of Object.entries(index.bundles)) {
+    if (m.sleepPersist) survivors.bundles[name] = m;
+    else deletedNames.push(name);
+  }
+  return { survivors, deletedNames };
+}
+
+/** Drop entries past their TTL; report which were dropped so the caller can
+ * delete their blobs. */
+export function pruneExpired(index: SessionIndex, now: number): { survivors: SessionIndex; expiredNames: string[] } {
+  const survivors: SessionIndex = { bundles: {} };
+  const expiredNames: string[] = [];
+  for (const [name, m] of Object.entries(index.bundles)) {
+    if (now < m.expiresAt) survivors.bundles[name] = m;
+    else expiredNames.push(name);
+  }
+  return { survivors, expiredNames };
+}
+
+/** Insert/replace one bundle in the index (pure). */
+export function upsertEntry(index: SessionIndex, name: string, meta: SessionIndexMeta): SessionIndex {
+  return { bundles: { ...index.bundles, [name]: meta } };
+}
+
+/** Remove one bundle from the index (pure). */
+export function removeEntry(index: SessionIndex, name: string): SessionIndex {
+  const { [name]: _drop, ...rest } = index.bundles;
+  void _drop;
+  return { bundles: rest };
+}
+
+// ─── Keychain adapter (macOS only; best-effort, never throws) ────────────────
+
+/** Whether to actually persist. macOS in production; also whenever a test
+ * keychain backend is installed, so the adapter is exercisable on Linux CI
+ * against an in-memory store (mirrors the broker's hermetic-test gating). In real
+ * Linux/Windows production this is false — secrets already persist in the OS store
+ * with no broker, so there is nothing to mirror. */
+function shouldPersist(): boolean {
+  return process.platform === 'darwin' || isKeychainBackendOverridden();
+}
+
+function sessionBlobItem(name: string): string {
+  return `${SESSION_ITEM_PREFIX}${name}`;
+}
+
+/** Read the session index by its fixed name. `{bundles:{}}` when absent/unreadable. */
+export function readIndex(): SessionIndex {
+  try {
+    const raw = getKeychainToken(SESSION_INDEX_ITEM);
+    const parsed = JSON.parse(raw) as SessionIndex;
+    if (parsed && typeof parsed === 'object' && parsed.bundles) return parsed;
+  } catch {
+    /* absent or malformed → empty */
+  }
+  return { bundles: {} };
+}
+
+/** Persist the index as a no-ACL item. Deletes the item when empty (tidy). */
+export function writeIndex(index: SessionIndex): void {
+  try {
+    if (Object.keys(index.bundles).length === 0) {
+      deleteKeychainToken(SESSION_INDEX_ITEM);
+      return;
+    }
+    setKeychainToken(SESSION_INDEX_ITEM, JSON.stringify(index), { noAcl: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Persist one unlocked bundle: write its blob no-ACL and record it in the index. */
+export function saveSession(name: string, entry: SessionEntry): void {
+  if (!shouldPersist()) return;
+  try {
+    setKeychainToken(sessionBlobItem(name), JSON.stringify(entry), { noAcl: true });
+    writeIndex(upsertEntry(readIndex(), name, { expiresAt: entry.expiresAt, sleepPersist: entry.sleepPersist }));
+  } catch {
+    /* best-effort — persistence is an optimization */
+  }
+}
+
+/** Read one session blob by known name. Null when absent/expired/malformed. */
+export function loadSession(name: string, now: number = Date.now()): SessionEntry | null {
+  if (!shouldPersist()) return null;
+  try {
+    const raw = getKeychainToken(sessionBlobItem(name));
+    const entry = JSON.parse(raw) as SessionEntry;
+    if (!entry || typeof entry !== 'object' || !entry.bundle || !entry.env) return null;
+    if (now >= entry.expiresAt) {
+      deleteSession(name); // drop expired on read, mirroring the broker's get handler
+      return null;
+    }
+    return entry;
+  } catch {
+    return null;
+  }
+}
+
+/** Delete one bundle's session blob and prune it from the index. */
+export function deleteSession(name: string): void {
+  if (!shouldPersist()) return;
+  try {
+    deleteKeychainToken(sessionBlobItem(name));
+    writeIndex(removeEntry(readIndex(), name));
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Delete every session blob + the index (for `secrets lock --all`). */
+export function deleteAllSessions(): void {
+  if (!shouldPersist()) return;
+  try {
+    for (const name of Object.keys(readIndex().bundles)) {
+      try { deleteKeychainToken(sessionBlobItem(name)); } catch { /* keep going */ }
+    }
+    deleteKeychainToken(SESSION_INDEX_ITEM);
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Rehydrate every unexpired session into `[name, entry]` pairs for the broker to
+ * load on start; prunes expired index entries + blobs as a side effect. Survives
+ * upgrade/restart. Empty off darwin or when nothing is held. */
+export function rehydrateSessions(now: number = Date.now()): Array<{ name: string; entry: SessionEntry }> {
+  if (!shouldPersist()) return [];
+  const out: Array<{ name: string; entry: SessionEntry }> = [];
+  try {
+    const index = readIndex();
+    const { survivors, expiredNames } = pruneExpired(index, now);
+    for (const name of expiredNames) {
+      try { deleteKeychainToken(sessionBlobItem(name)); } catch { /* keep going */ }
+    }
+    if (expiredNames.length) writeIndex(survivors);
+    for (const name of selectRehydratable(survivors, now)) {
+      const entry = loadSession(name, now);
+      if (entry) out.push({ name, entry });
+    }
+  } catch {
+    /* best-effort */
+  }
+  return out;
+}
+
+/** On a SLEEP event: delete every non-`--durable` session (blob + index entry),
+ * keep the durable ones. Default bundles thus re-lock on sleep. */
+export function pruneSessionsOnSleep(): void {
+  if (!shouldPersist()) return;
+  try {
+    const { survivors, deletedNames } = pruneOnSleep(readIndex());
+    for (const name of deletedNames) {
+      try { deleteKeychainToken(sessionBlobItem(name)); } catch { /* keep going */ }
+    }
+    writeIndex(survivors);
+  } catch {
+    /* best-effort */
+  }
+}

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -725,12 +725,16 @@ export interface Meta {
    * concurrent runs read silently — set it `false` to force a prompt on every read.
    * `holdMs` caps how long an unlocked/auto-cached bundle is held before the next
    * read re-prompts (default 7 days; e.g. 86400000 for a 24h cap). Clamped to
-   * [1 minute, 30 days]. */
+   * [1 minute, 30 days]. `durable` (default off) makes every `agents secrets
+   * unlock` survive sleep + reboot as well as upgrade/restart — the same effect as
+   * passing `--durable` per unlock; off means the secure split default (survive
+   * upgrade/restart, re-lock on sleep). */
   secrets?: {
     policy?: 'always' | 'daily';
     agent?: {
       auto?: boolean;
       holdMs?: number;
+      durable?: boolean;
     };
   };
   /** Spend guardrails (issue #346). User-global caps; project agents.yaml overrides. */


### PR DESCRIPTION
## What

An `agents secrets unlock` grant lived **only in the macOS broker's RAM**, so it evaporated on every agents-cli upgrade (the postinstall bounces the daemon) and on sleep — forcing a Touch ID re-tap and breaking headless reads with `not unlocked in the secrets agent`. (This bit us all through the release + fleet work in this session.)

Persist the resolved bundle+env as a **device-local, non-biometry keychain session item** (the existing `set-no-acl` path — reads never prompt) that the broker **rehydrates on start** and that reads **fall back to** when the broker RAM misses.

**Split default** (chosen posture): survives upgrade/daemon-restart **by default**; pass **`--durable`** (or set `secrets.agent.durable: true`) to survive **sleep + reboot** too — otherwise a bundle re-locks on sleep as before. `lock` / rotate / delete clear it.

**Cross-platform:** this is a macOS-only concern — Linux (libsecret) and Windows (Credential Manager) already resolve secrets durably from the OS store with no broker and no prompt, so `agents secrets unlock` there is now a **friendly no-op** and the command behaves the same on all three OSes.

## Design (validated; 4 review-caught corrections baked in)
- **A** — never enumerate `session.*` (breaks under `#316` hashing); a fixed-name `session.index` + per-bundle blobs, all read by known name.
- **B** — the read fallback is on the **normal** path (not just the headless-throw branch), so interactive reads don't re-prompt after restart.
- **C** — `lock` + every evict site also `deleteSession`.
- **D** — `rekey` keeps `agents-cli.session.*` no-ACL.

## Files
`lib/secrets/session-store.ts` (new), `agent.ts` (rehydrate + sleep-prune + `secretsAgentDurable`), `bundles.ts` (fallback + evict), `index.ts` (rekey), `commands/secrets.ts` (`--durable` + off-darwin no-op), `types.ts` (`secrets.agent.durable`).

## Verified
- `tsc` clean; **114 secrets tests pass** (new `session-store.test.ts` incl. the `#316`-hashed pass, the `bundles.ts` read-fallback resolving instead of throwing, and the rekey no-ACL guard). Run on Linux CI via the `KeychainBackend` in-memory seam.
- Full suite: only pre-existing unrelated flakes (codex `exec`/`models`, a 135s SSE `serve` test) — my diff touches none of those files.

**Ships in 1.20.71**, then the fleet gets `agents devices update`.

Session transcript (confidential; not uploaded per public-repo convention): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/f2314c23-cca7-436a-8535-3bb177497c15.jsonl`