### PR TITLE
fix(git): auto-commit own device-meta before pull so per-machine pins never wedge `agents repo pull`

### DIFF
--- a/apps/cli/.changelog/next/pull-wedge-device-meta.md
+++ b/apps/cli/.changelog/next/pull-wedge-device-meta.md
@@ -1,0 +1,8 @@
+- **`agents repo pull` no longer wedges on per-machine pin drift.** The committed
+  `devices/<machineId>/agents.yaml` (each box's agent version pins) is rewritten
+  whenever a pin changes, leaving the working tree perpetually dirty — so
+  `agents repo pull`, which refuses a dirty tree, kept failing until the file was
+  hand-committed. `pullRepo` now durably commits **just that one path** (explicit
+  pathspec) before pulling, via `commitOwnDeviceMeta`. Genuine uncommitted edits to
+  any other file still (correctly) block the pull. No-op for the system/extra repos
+  that don't own the path. Source: `apps/cli/src/lib/git.ts`.

--- a/apps/cli/src/lib/git.test.ts
+++ b/apps/cli/src/lib/git.test.ts
@@ -18,6 +18,7 @@ import {
   assertValidBranchName,
   canonicalGitRemote,
   commitAndPush,
+  commitOwnDeviceMeta,
   displayHomePath,
   parseSource,
   pullRepo,
@@ -219,6 +220,56 @@ describe('displayHomePath', () => {
   it('leaves a path outside the home directory unchanged (bar slash normalization)', () => {
     expect(displayHomePath('/opt/other/repo')).toBe('/opt/other/repo');
     expect(displayHomePath('C:\\some\\win\\path')).toBe('C:/some/win/path');
+  });
+});
+
+describe('commitOwnDeviceMeta (unwedge the pull from per-machine pin drift)', () => {
+  const tmpDirs: string[] = [];
+  afterEach(() => {
+    for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true });
+    tmpDirs.length = 0;
+  });
+
+  async function initRepo(): Promise<string> {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'own-meta-'));
+    tmpDirs.push(repo);
+    const g = simpleGit(repo);
+    await g.init(['-b', 'main']);
+    await g.addConfig('user.email', 'test@example.com');
+    await g.addConfig('user.name', 'Test');
+    await g.addConfig('commit.gpgsign', 'false');
+    fs.mkdirSync(path.join(repo, 'devices', 'zion'), { recursive: true });
+    fs.writeFileSync(path.join(repo, 'devices', 'zion', 'agents.yaml'), 'agents:\n  claude: 1.0.0\n');
+    await g.add('-A');
+    await g.commit('init');
+    return repo;
+  }
+
+  it('commits ONLY the dirty device-meta, leaving a real user edit uncommitted (still blocks the pull)', async () => {
+    const repo = await initRepo();
+    const meta = path.join(repo, 'devices', 'zion', 'agents.yaml');
+    fs.writeFileSync(meta, 'agents:\n  claude: 2.0.0\n'); // pin drift
+    fs.writeFileSync(path.join(repo, 'hooks.yaml'), 'a real user edit\n'); // genuine work
+
+    const committed = await commitOwnDeviceMeta(repo, meta);
+    expect(committed).toBe('devices/zion/agents.yaml');
+
+    const st = await simpleGit(repo).status();
+    // device-meta is now clean (committed); the user edit is still dirty.
+    expect(st.files.map((f) => f.path)).toContain('hooks.yaml');
+    expect(st.files.map((f) => f.path)).not.toContain('devices/zion/agents.yaml');
+  });
+
+  it('is a no-op when the device-meta is clean', async () => {
+    const repo = await initRepo();
+    const meta = path.join(repo, 'devices', 'zion', 'agents.yaml');
+    expect(await commitOwnDeviceMeta(repo, meta)).toBeNull();
+  });
+
+  it('is a no-op when the device-meta lives outside the repo (system/extra repos)', async () => {
+    const repo = await initRepo();
+    const outside = path.join(os.tmpdir(), 'somewhere-else', 'devices', 'x', 'agents.yaml');
+    expect(await commitOwnDeviceMeta(repo, outside)).toBeNull();
   });
 });
 

--- a/apps/cli/src/lib/git.ts
+++ b/apps/cli/src/lib/git.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { IS_WINDOWS, isWindowsAbsolutePath } from './platform/index.js';
-import { getPackageLocalPath } from './state.js';
+import { getPackageLocalPath, getDeviceMetaPath } from './state.js';
 import { DEFAULT_SYSTEM_REPO, systemRepoSlug } from './types.js';
 
 /**
@@ -842,11 +842,51 @@ export function displayHomePath(dir: string): string {
  * branch reconciles instead of failing with "Need to specify how to reconcile
  * divergent branches".
  */
+/**
+ * Auto-commit the machine's OWN generated per-device meta file
+ * (`devices/<machineId>/agents.yaml`) if it's the dirty state blocking a pull.
+ *
+ * That file is committed + synced (so every machine can introspect every other
+ * machine's pins), but each box rewrites its own copy whenever a pin changes —
+ * leaving the tree perpetually dirty and wedging `agents repo pull` (which
+ * refuses a dirty tree). This durably commits just that one path (explicit
+ * pathspec) so the pull can proceed; genuine user edits to OTHER files are left
+ * untouched and still (correctly) block the pull. No-op when the meta path isn't
+ * inside `dir` (system/extra repos) or isn't dirty. Returns the committed rel
+ * path, or null. `metaAbs` is injectable for tests; defaults to the live path.
+ */
+export async function commitOwnDeviceMeta(
+  dir: string,
+  metaAbs: string = getDeviceMetaPath(),
+): Promise<string | null> {
+  const resolvedDir = path.resolve(dir);
+  const resolvedMeta = path.resolve(metaAbs);
+  if (resolvedMeta !== resolvedDir && !resolvedMeta.startsWith(resolvedDir + path.sep)) {
+    return null; // meta lives outside this repo — not ours to commit here
+  }
+  const rel = path.relative(resolvedDir, resolvedMeta).split(path.sep).join('/');
+  try {
+    const git = simpleGit(dir);
+    const status = await git.status();
+    const dirty = status.files.some((f) => f.path === rel);
+    if (!dirty) return null;
+    await git.add([rel]);
+    const machine = path.basename(path.dirname(resolvedMeta));
+    await git.commit(`chore(devices): snapshot ${machine} agent pins`, [rel]);
+    return rel;
+  } catch {
+    return null; // best-effort — never let this block the pull path
+  }
+}
+
 export async function pullRepo(
   dir: string,
 ): Promise<{ success: boolean; commit: string; error?: string; branch?: string }> {
   try {
     const git = simpleGit(dir);
+    // Commit this machine's own device-meta first so a per-machine pin change
+    // never wedges the pull. Genuine edits elsewhere still block below.
+    await commitOwnDeviceMeta(dir);
     const status = await git.status();
 
     if (!status.isClean()) {


### PR DESCRIPTION
## Problem

`devices/<machineId>/agents.yaml` — each machine's agent version pins — is **committed and synced** (so every box can introspect every other box's pins; this is the deliberate `migrate.ts` split that made central `agents.yaml` portable). But each machine **rewrites its own copy** whenever a pin changes (`agents use …`), leaving the working tree perpetually dirty. `agents repo pull` refuses a dirty tree, so it kept failing with *"Working tree has uncommitted changes"* until the file was hand-committed — a recurring wedge (observed across multiple sessions).

## Fix

`pullRepo` (`apps/cli/src/lib/git.ts`) now calls `commitOwnDeviceMeta(dir)` before the clean check: if this machine's own `devices/<machineId>/agents.yaml` is dirty **and inside the repo being pulled**, it durably commits **just that one path** (explicit pathspec, `chore(devices): snapshot <machine> agent pins`). Then:
- **Genuine uncommitted edits to any other file still block the pull** — correct: the user has real uncommitted work.
- **No-op** when the path isn't dirty, or lives outside `dir` (the system repo `~/.agents/.system` and extra repos `~/.agents-*` never own it).

This preserves the committed cross-machine introspection the split intended, and it's a durable commit — not a `skip-worktree`/stash band-aid.

## Tests (real git repos, no mocks)

Added to `git.test.ts`:
- commits **only** the dirty device-meta, leaving a real `hooks.yaml` edit uncommitted (still dirty → still blocks).
- clean device-meta → no-op (returns null).
- device-meta outside the repo → no-op.

`45 passed` in `git.test.ts`; `tsc --noEmit` clean; gen-changelog guard green.

## Scope

This closes the **recurring device-meta wedge specifically**. A given machine's tree may still be dirty from *other* sources (e.g. rotated `events.*.jsonl.gz`, or a machine mid-reconcile) — those are separate and correctly still block. This is the second of the two PRs split from the fleet-replication work (#1305 was the first).