### PR TITLE
fix(doctor/prune): clear phantom drift and stop prune from deleting source-managed resources

### DIFF
--- a/apps/cli/.changelog/next/doctor-prune-source-managed.md
+++ b/apps/cli/.changelog/next/doctor-prune-source-managed.md
@@ -1,0 +1,11 @@
+- **Stop `agents doctor` from reporting phantom drift and `agents prune` from
+  deleting source-managed resources.** Three reconciler false positives are
+  fixed: the instruction file (`CLAUDE.md`/`AGENTS.md`) is now compared against
+  the composed active-preset output the rules writer actually emits — not the raw
+  whole-repo `rules/AGENTS.md` — so a correctly-synced home no longer shows as
+  permanent drift; plugin-bundled commands installed as `<plugin>-<command>`
+  command-skills (e.g. `swarm-plan`, `code-review`) are no longer flagged as
+  orphans/extras that `prune cleanup` would delete; and command-as-skill wrappers
+  (the `agents_command` marker) are no longer miscounted as skills and surfaced as
+  deletable skill orphans. Source: `apps/cli/src/lib/staleness/`,
+  `apps/cli/src/lib/commands.ts`, `apps/cli/src/lib/skills.ts`.

--- a/apps/cli/src/lib/__tests__/doctor-diff.test.ts
+++ b/apps/cli/src/lib/__tests__/doctor-diff.test.ts
@@ -118,11 +118,27 @@ describe('diffVersionResources — hooks ignore project layer', () => {
 });
 
 describe('diffVersionResources — rules', () => {
-  it('compares AGENTS.md byte-for-byte for import-capable agents (claude)', () => {
+  // The instruction file (CLAUDE.md/GEMINI.md/AGENTS.md) is COMPOSED from
+  // `subrules/` for the active preset — the same rendering the rules writer
+  // emits. The diff must compare against that composition, not the raw
+  // `rules/AGENTS.md` whole-repo doc (which a preset composition deliberately
+  // never equals), or a correctly-synced home file is held as drift forever.
+  function seedRules(body: string, extra = 'the whole-repo AGENTS doc, deliberately different\n'): void {
+    const rulesDir = path.join(userDir, 'rules');
+    fs.mkdirSync(path.join(rulesDir, 'subrules'), { recursive: true });
+    // Presence of AGENTS.md makes the row exist and fixes its source layer; its
+    // content is intentionally NOT what the home file is compared against.
+    fs.writeFileSync(path.join(rulesDir, 'AGENTS.md'), extra);
+    fs.writeFileSync(path.join(rulesDir, 'rules.yaml'), 'presets:\n  default:\n    subrules: [core]\n');
+    fs.writeFileSync(path.join(rulesDir, 'subrules', 'core.md'), body);
+  }
+
+  it('reconciles the instruction file against the composed active-preset rules, not raw AGENTS.md (claude)', () => {
     const home = makeVersionHome('claude', '2.0.0');
     const configDir = path.join(home, '.claude');
-    fs.mkdirSync(path.join(userDir, 'rules'), { recursive: true });
-    fs.writeFileSync(path.join(userDir, 'rules', 'AGENTS.md'), 'rules body\n');
+    seedRules('rules body\n');
+    // Home matches the COMPOSED preset (what the writer emits) → ok, even though
+    // it differs from the longer raw AGENTS.md.
     fs.writeFileSync(path.join(configDir, 'CLAUDE.md'), 'rules body\n');
 
     const report = runDiff(projectDir, 'claude', '2.0.0', ['rules']);
@@ -130,28 +146,27 @@ describe('diffVersionResources — rules', () => {
     expect(agents).toMatchObject({ status: 'ok', source: 'user' });
   });
 
-  it('compares AGENTS.md against compiled (header-prefixed) content for non-import agents (codex)', () => {
+  it('flags the instruction file as diff when it does not match the composed preset (claude)', () => {
+    const home = makeVersionHome('claude', '2.0.0');
+    const configDir = path.join(home, '.claude');
+    seedRules('composed body\n');
+    // Stale content matching neither the raw AGENTS.md nor the composition.
+    fs.writeFileSync(path.join(configDir, 'CLAUDE.md'), 'stale body\n');
+
+    const report = runDiff(projectDir, 'claude', '2.0.0', ['rules']);
+    expect(report.kinds.rules.find((r) => r.name === 'AGENTS')?.status).toBe('diff');
+  });
+
+  it('compares against the composed preset for non-import agents too — no compiled header (codex)', () => {
     const home = makeVersionHome('codex', '0.100.0');
     const configDir = path.join(home, '.codex');
-    fs.mkdirSync(path.join(userDir, 'rules'), { recursive: true });
-    fs.writeFileSync(path.join(userDir, 'rules', 'AGENTS.md'), 'plain rules\n');
-
-    // A raw byte copy of the source would be wrong — codex needs the compiled
-    // header. Simulate the bad state to confirm doctor flags it as DIFF.
+    seedRules('plain rules\n');
+    // codex's instruction file is AGENTS.md; the writer composes the SAME bytes
+    // (no compiled header), so a plain composed copy reconciles as ok.
     fs.writeFileSync(path.join(configDir, 'AGENTS.md'), 'plain rules\n');
 
     const report = runDiff(projectDir, 'codex', '0.100.0', ['rules']);
-    const agents = report.kinds.rules.find((r) => r.name === 'AGENTS');
-    expect(agents?.status).toBe('diff');
-
-    // With the compiled header in place, status flips to ok.
-    const COMPILED_HEADER =
-      '<!-- Auto-compiled by agents-cli from ~/.agents/rules/AGENTS.md + imports.\n' +
-      '     Edit the source files under ~/.agents/rules/ — edits to this file will be overwritten on next sync. -->\n\n';
-    fs.writeFileSync(path.join(configDir, 'AGENTS.md'), COMPILED_HEADER + 'plain rules\n');
-    const report2 = runDiff(projectDir, 'codex', '0.100.0', ['rules']);
-    const agents2 = report2.kinds.rules.find((r) => r.name === 'AGENTS');
-    expect(agents2?.status).toBe('ok');
+    expect(report.kinds.rules.find((r) => r.name === 'AGENTS')?.status).toBe('ok');
   });
 });
 

--- a/apps/cli/src/lib/__tests__/doctor-diff.test.ts
+++ b/apps/cli/src/lib/__tests__/doctor-diff.test.ts
@@ -170,6 +170,23 @@ describe('diffVersionResources — rules', () => {
   });
 });
 
+describe('diffVersionResources — native ~/.agents/skills agents', () => {
+  // Gemini reads central skills directly; the orchestrator deletes its
+  // version-home skills dir and registers no skills writer. diffSkills must
+  // return no rows, or every central skill is false-reported `missing` and held
+  // as unreconcilable forever (drift never clears).
+  it('reports no skill rows for a nativeAgentsSkillsDir agent even with a central source skill', () => {
+    makeVersionHome('gemini', '1.0.0');
+    // A central source skill that a non-native agent WOULD report as missing.
+    const skillDir = path.join(systemDir, 'skills', 'demo');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '---\ndescription: demo\n---\nbody\n');
+
+    const report = runDiff(projectDir, 'gemini', '1.0.0', ['skills']);
+    expect(report.kinds.skills).toEqual([]);
+  });
+});
+
 describe('diffVersionResources — command-as-skill agents', () => {
   // Kimi (and Codex >= 0.117, Grok) install commands as SKILL wrappers, not
   // native command files. The diff must compare against the wrapper or it

--- a/apps/cli/src/lib/commands.test.ts
+++ b/apps/cli/src/lib/commands.test.ts
@@ -29,6 +29,7 @@ function runCommandsExpression(home: string, expression: string): unknown {
       diffVersionCommands,
       installCommandToVersion,
       listCommandsInVersionHome,
+      listPluginCommandNames,
       removeCommandFromVersion,
     } from ${JSON.stringify(moduleUrl)};
     const home = ${JSON.stringify(home)};
@@ -157,6 +158,50 @@ Report versions.`);
     };
     expect(diff.toRemove).toEqual(['version']);
     expect(diff.toAdd).not.toContain('version');
+  });
+});
+
+describe('diffVersionCommands — plugin-bundled commands are source-managed', () => {
+  /** Plant a discoverable user-marketplace plugin with one command. */
+  function writePluginCommand(home: string, plugin: string, cmd: string): void {
+    const root = path.join(home, '.agents', 'plugins', plugin);
+    fs.mkdirSync(path.join(root, '.claude-plugin'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name: plugin, version: '1.0.0', description: `${plugin} plugin` }),
+    );
+    fs.mkdirSync(path.join(root, 'commands'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'commands', `${cmd}.md`), `# /${plugin}-${cmd}\n`, 'utf-8');
+  }
+
+  it('listPluginCommandNames flattens plugin commands to <plugin>-<command>', () => {
+    const home = makeTempHome();
+    writePluginCommand(home, 'swarm', 'plan');
+    const names = runCommandsExpression(home, '[...listPluginCommandNames()]') as string[];
+    expect(names).toContain('swarm-plan');
+  });
+
+  it('does NOT flag a plugin-provided command-skill as an orphan', () => {
+    const home = makeTempHome();
+    writePluginCommand(home, 'swarm', 'plan');
+    scaffoldInstalledVersion(home, 'codex', '0.117.0');
+
+    // Simulate the plugin command installed as a command-skill wrapper
+    // (syncPluginToVersion writes `${plugin}-${cmd}` with the agents_command marker).
+    const skillDir = path.join(versionHomePath(home, 'codex', '0.117.0'), '.codex', 'skills', 'swarm-plan');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(skillDir, 'SKILL.md'),
+      `---\nname: "swarm-plan"\ndescription: plan\nagents_command: "swarm-plan"\n---\n\n# /swarm-plan\n`,
+      'utf-8',
+    );
+
+    const listed = runCommandsExpression(home, "listCommandsInVersionHome('codex', '0.117.0')") as string[];
+    const diff = runCommandsExpression(home, "diffVersionCommands('codex', '0.117.0')") as { orphans: string[] };
+    // The wrapper IS present in the version home…
+    expect(listed).toContain('swarm-plan');
+    // …but it is source-managed by the plugin, so it must not be an orphan.
+    expect(diff.orphans).not.toContain('swarm-plan');
   });
 });
 

--- a/apps/cli/src/lib/commands.ts
+++ b/apps/cli/src/lib/commands.ts
@@ -15,6 +15,7 @@ import { capableAgents, isCapable, supports } from './capabilities.js';
 import { markdownToToml } from './convert.js';
 import { getCommandsDir, getUserCommandsDir, getEnabledExtraRepos, getProjectAgentsDir, getSkillsDir, getTrashCommandsDir } from './state.js';
 import { getEffectiveHome, getVersionHomePath, listInstalledVersions, resolveVersion } from './versions.js';
+import { discoverPlugins } from './plugins.js';
 import type { AgentId, CommandInstallation } from './types.js';
 import {
   commandSkillMatches,
@@ -436,8 +437,26 @@ export interface VersionCommandDiff {
 /**
  * Compare a version home's commands against central. Returns the reconciliation diff.
  */
+/**
+ * Flattened names of plugin-bundled commands (`<plugin>-<command>`), matching
+ * exactly how `syncPluginToVersion` installs a plugin's `commands/<cmd>.md` as a
+ * command-skill (plugins.ts → `installCommandSkillToVersion(agentDir,
+ * `${plugin.name}-${cmd}`, …)`). These are source-managed by their plugin, so
+ * the orphan detector must NOT flag them — else `prune cleanup` proposes
+ * deleting live plugin commands (swarm-plan, code-review, …). Scans user +
+ * system + extra marketplaces (no project layer), matching the trusted sources.
+ */
+export function listPluginCommandNames(): Set<string> {
+  const names = new Set<string>();
+  for (const plugin of discoverPlugins()) {
+    for (const cmd of plugin.commands) names.add(`${plugin.name}-${cmd}`);
+  }
+  return names;
+}
+
 export function diffVersionCommands(agent: AgentId, version: string): VersionCommandDiff {
   const central = new Set(listCentralCommands());
+  const pluginCommands = listPluginCommandNames();
   const installed = new Set(listCommandsInVersionHome(agent, version));
 
   const toAdd: string[] = [];
@@ -461,15 +480,19 @@ export function diffVersionCommands(agent: AgentId, version: string): VersionCom
   }
 
   for (const name of installed) {
-    if (!central.has(name)) {
-      orphans.push(name);
+    if (central.has(name)) {
+      const sourcePath = path.join(getCommandsDir(), `${name}.md`);
+      const metadata = parseCommandMetadata(sourcePath);
+      if (!commandAppliesTo(agent, version, metadata).ok) {
+        toRemove.push(name);
+      }
       continue;
     }
-    const sourcePath = path.join(getCommandsDir(), `${name}.md`);
-    const metadata = parseCommandMetadata(sourcePath);
-    if (!commandAppliesTo(agent, version, metadata).ok) {
-      toRemove.push(name);
-    }
+    // A plugin-bundled command (installed as `<plugin>-<cmd>`) is source-managed
+    // by its plugin — not an orphan. Only a name with no central AND no plugin
+    // source is genuinely unmanaged.
+    if (pluginCommands.has(name)) continue;
+    orphans.push(name);
   }
 
   return {

--- a/apps/cli/src/lib/doctor-diff.ts
+++ b/apps/cli/src/lib/doctor-diff.ts
@@ -290,6 +290,13 @@ function dirsContentMatch(src: string, dst: string): boolean {
 }
 
 function diffSkills(agent: AgentId, version: string, cwd: string, excludeProject = false): ResourceDiff[] {
+  // Native ~/.agents/skills consumers (Gemini, …) read central skills directly.
+  // The orchestrator DELETES their version-home skills dir (syncResourcesToVersion)
+  // and registers no skills writer, so there is nothing in the version home to
+  // reconcile. Mirror diffVersionSkills' native gate (skills.ts) — without it
+  // every central skill is false-reported `missing` and held as unreconcilable
+  // forever (drift never clears for these agents).
+  if (AGENTS[agent].nativeAgentsSkillsDir) return [];
   const homeDir = getVersionSkillsDir(agent, version);
   const installed = new Set(listSkillsInVersionHome(agent, version));
   const layerBases = buildLayerBases(cwd, 'skills', { excludeProject });

--- a/apps/cli/src/lib/doctor-diff.ts
+++ b/apps/cli/src/lib/doctor-diff.ts
@@ -33,7 +33,9 @@ import {
   getUserRulesDir,
   getPromptcutsPath,
   getEffectivePromptcutsPath,
+  getActiveRulesPreset,
 } from './state.js';
+import { composeRulesFromState } from './rules/compose.js';
 import {
   getAvailableResources,
   getActuallySyncedResources,
@@ -44,7 +46,6 @@ import { discoverPlugins, marketplaceSpecForName } from './plugins.js';
 import type { DiscoveredPlugin } from './types.js';
 import { pluginInstallDir, repairableManifestFields } from './plugin-marketplace.js';
 import { markdownToToml } from './convert.js';
-import { resolveImports, supportsRulesImports } from './rules/compile.js';
 import { listCommandsInVersionHome, getVersionCommandsDir } from './commands.js';
 import { shouldInstallCommandAsSkill, commandSkillMatches, commandSkillName } from './command-skills.js';
 import { gooseCommandMatches, gooseCommandsDir } from './goose-commands.js';
@@ -53,9 +54,6 @@ import { listSkillsInVersionHome, getVersionSkillsDir } from './skills.js';
 import { listHooksInVersionHome, getVersionHooksDir, listHookEntriesFromDir } from './hooks.js';
 
 const RULES_DOC_FILENAME = 'README.md';
-const COMPILED_HEADER =
-  '<!-- Auto-compiled by agents-cli from ~/.agents/rules/AGENTS.md + imports.\n' +
-  '     Edit the source files under ~/.agents/rules/ — edits to this file will be overwritten on next sync. -->\n\n';
 
 export type DoctorKind =
   | 'commands'
@@ -424,17 +422,26 @@ function listRulesNames(cwd: string, excludeProject = false): Map<string, Source
   return out;
 }
 
-function expectedRuleContent(agent: AgentId, name: string, sourcePath: string): string | null {
-  // AGENTS.md on agents without native @-import support is compiled with imports inlined.
-  if (name === 'AGENTS' && !supportsRulesImports(agent)) {
-    const root = readSafe(sourcePath);
-    if (root == null) return null;
-    // Compile relative to the source's own dir so project-layer AGENTS.md resolves
-    // its imports relative to the project rules dir, not the user one.
-    const baseDir = path.dirname(sourcePath);
-    const { content } = resolveImports(root, baseDir);
-    return COMPILED_HEADER + content;
+function expectedRuleContent(agent: AgentId, name: string, version: string, sourcePath: string): string | null {
+  // The instruction file (AGENTS → the agent's CLAUDE.md/GEMINI.md/AGENTS.md)
+  // is COMPOSED from `subrules/` fragments for the version's active preset —
+  // that is exactly what the rules writer emits (see
+  // staleness/writers/rules.ts → composeRulesFromState). Compare against the
+  // same rendering so a correctly-synced home file reconciles instead of being
+  // held forever against the raw `rules/AGENTS.md` (the whole-repo doc, which a
+  // preset composition deliberately never equals — system subrules don't
+  // auto-append). The `agent` is not part of the rendering (every capable agent
+  // gets identical composed bytes); it is kept for symmetry with the writer's
+  // per-agent dispatch and future per-agent presets.
+  if (name === 'AGENTS') {
+    try {
+      return composeRulesFromState({ preset: getActiveRulesPreset(agent, version) }).content;
+    } catch {
+      // No rules.yaml / unknown preset — the writer skips too; treat as unknown.
+      return null;
+    }
   }
+  // Any sibling top-level rules file syncs as a raw copy.
   return readSafe(sourcePath);
 }
 
@@ -465,7 +472,7 @@ function diffRules(agent: AgentId, version: string, cwd: string, excludeProject 
       rows.push({ kind: 'rules', name, status: 'missing', source: src.layer, sourcePath: src.path });
       continue;
     }
-    const expected = expectedRuleContent(agent, name, src.path);
+    const expected = expectedRuleContent(agent, name, version, src.path);
     const actual = readSafe(homePath);
     if (expected == null || actual == null) {
       rows.push({ kind: 'rules', name, status: 'diff', source: src.layer, sourcePath: src.path, homePath });

--- a/apps/cli/src/lib/doctor-diff.ts
+++ b/apps/cli/src/lib/doctor-diff.ts
@@ -46,7 +46,7 @@ import { discoverPlugins, marketplaceSpecForName } from './plugins.js';
 import type { DiscoveredPlugin } from './types.js';
 import { pluginInstallDir, repairableManifestFields } from './plugin-marketplace.js';
 import { markdownToToml } from './convert.js';
-import { listCommandsInVersionHome, getVersionCommandsDir } from './commands.js';
+import { listCommandsInVersionHome, getVersionCommandsDir, listPluginCommandNames } from './commands.js';
 import { shouldInstallCommandAsSkill, commandSkillMatches, commandSkillName } from './command-skills.js';
 import { gooseCommandMatches, gooseCommandsDir } from './goose-commands.js';
 import { supports } from './capabilities.js';
@@ -241,8 +241,14 @@ function diffCommands(agent: AgentId, version: string, cwd: string, excludeProje
     });
   }
 
+  // Plugin-bundled commands (installed as `<plugin>-<cmd>`) are source-managed by
+  // their plugin, tracked under the `plugins` kind — not extras. Without this,
+  // `agents doctor` shows every plugin command (swarm-plan, code-review, …) as an
+  // unmanaged extra, mirroring the orphan false-positive the prune path had.
+  const pluginCommands = listPluginCommandNames();
   for (const name of installed) {
     if (seen.has(name)) continue;
+    if (pluginCommands.has(name)) continue;
     const extraHome = asSkill
       ? path.join(agentDir, 'skills', commandSkillName(name), 'SKILL.md')
       : agent === 'goose'

--- a/apps/cli/src/lib/skills.test.ts
+++ b/apps/cli/src/lib/skills.test.ts
@@ -330,6 +330,32 @@ describe('diffVersionSkills — orphan detection', () => {
     expect(result.orphans).toHaveLength(0);
   });
 
+  it('does NOT flag a command-as-skill wrapper (agents_command marker) as a skill orphan', () => {
+    const home = makeTempHome();
+    const agent = 'claude';
+    const version = '2.0.0';
+
+    // A command-runtime install writes commands as skill wrappers carrying the
+    // `agents_command` marker. It is a command (reconciled by the commands diff),
+    // NOT a skill — it must never surface as a skill orphan, or `prune cleanup`
+    // would delete a live command (tickets, swarm-plan, …).
+    const skillsDir = path.join(home, '.agents', '.history', 'versions', agent, version, 'home', `.${agent}`, 'skills');
+    fs.mkdirSync(path.join(skillsDir, 'tickets'), { recursive: true });
+    fs.writeFileSync(
+      path.join(skillsDir, 'tickets', 'SKILL.md'),
+      `---\nname: "tickets"\ndescription: ticket wrapper\nagents_command: "tickets"\n---\n\n# /tickets\n`,
+      'utf-8'
+    );
+
+    const result = runSkills(
+      home,
+      `skills.diffVersionSkills('${agent}', '${version}')`
+    ) as { orphans: string[] };
+
+    expect(result.orphans).not.toContain('tickets');
+    expect(result.orphans).toHaveLength(0);
+  });
+
   it('reports central skills as matched for Goose without a per-version copy', () => {
     const home = makeTempHome();
     const version = '1.43.0';

--- a/apps/cli/src/lib/skills.ts
+++ b/apps/cli/src/lib/skills.ts
@@ -16,6 +16,7 @@ import { AGENTS, ensureSkillsDir, agentConfigDirName } from './agents.js';
 import { capableAgents, isCapable } from './capabilities.js';
 import { getAgentsDir, getUserSkillsDir, getSkillsDir as getSystemSkillsDir, getProjectAgentsDir, getEnabledExtraRepos, getTrashSkillsDir } from './state.js';
 import { getEffectiveHome, getVersionHomePath, listInstalledVersions } from './versions.js';
+import { listCommandSkillsInVersion } from './command-skills.js';
 import { emit } from './events.js';
 
 const HOME = os.homedir();
@@ -461,15 +462,26 @@ export function getVersionSkillsDir(agent: AgentId, version: string): string {
 }
 
 /**
- * List skill names installed in a specific version home.
+ * List real skill names installed in a specific version home.
+ *
+ * Command-as-skill WRAPPERS (a `skills/<name>/SKILL.md` carrying the
+ * `agents_command` marker — how command-runtime agents like Codex/Kimi install
+ * commands) are excluded: they are commands, reconciled by the commands diff
+ * against the command source, not skills. Counting them here made the skill
+ * orphan/extra detectors flag every command wrapper (tickets, prune, swarm-plan,
+ * …) as an unmanaged skill — a false positive that `prune cleanup` would delete.
  */
 export function listSkillsInVersionHome(agent: AgentId, version: string): string[] {
   const dir = getVersionSkillsDir(agent, version);
   if (!fs.existsSync(dir)) return [];
+  const commandWrappers = new Set(
+    listCommandSkillsInVersion(path.join(getVersionHomePath(agent, version), agentConfigDirName(agent))),
+  );
   return fs.readdirSync(dir, { withFileTypes: true })
     .filter((e) => e.isDirectory() && !e.name.startsWith('.'))
     .filter((e) => fs.existsSync(path.join(dir, e.name, 'SKILL.md')))
     .map((e) => e.name)
+    .filter((name) => !commandWrappers.has(name))
     .sort();
 }
 


### PR DESCRIPTION
Fixes #1311

## Summary

Two independent root causes behind the reconciler/prune disagreement in #1311, both verified end-to-end against a live multi-agent install. (The original "reconciler flags X but prune doesn't" framing turned out to be inverted for the second half — see below.)

## Root cause A — drift never clears (`doctor --fix` holds resources as "unreconcilable")

The **diff** and the **writer** rendered the same target with *different* functions, so the writer's output could never equal what the diff expected — every pass re-wrote identical bytes, re-diffed, still saw a mismatch, and reported *"couldn't reconcile — source/home mismatch the writer can't satisfy."*

- **`rules/AGENTS`** (headline): `diffRules` compared each agent's instruction file (CLAUDE.md/GEMINI.md/AGENTS.md) against the raw `rules/AGENTS.md` whole-repo doc (or a `COMPILED_HEADER`+`resolveImports` render for non-import agents). But the rules writer emits `composeRulesFromState({ preset })` — the active preset's `subrules/` composition. A preset composition **deliberately** excludes system subrules that the whole-repo doc inlines, so they never match. Fixed by comparing against the same `composeRulesFromState`. *Proof: on a live machine the home CLAUDE.md is byte-for-byte equal (normalized) to the composed default preset; `rules/AGENTS` now reports `ok` for claude, codex (no more phantom compiled header), and gemini.*
- **native `~/.agents/skills` agents (Gemini)**: the orchestrator deletes their version-home skills dir and registers no skills writer, but `diffSkills` reported every central skill `missing`. The prune-path `diffVersionSkills` already gates these; mirrored that gate. *Live: gemini skill drift 44 → 0.*

## Root cause B — `prune cleanup -y` would delete live, source-managed resources

Not a prune-vs-doctor mismatch (doctor labels them `EXTRA` too) — a **shared source-scan blind spot**:

- **Plugin-bundled commands**: `syncPluginToVersion` installs a plugin's `commands/<cmd>.md` as a command-skill named `<plugin>-<cmd>` (swarm-plan, code-review, …), but the orphan enumerators only scanned top-level `commands/`, never `plugins/*/commands/`. Added `listPluginCommandNames()` (matching the installer's flattening exactly) and excluded them from the command orphan set — and from doctor's `diffCommands` extras, so both enumerators agree.
- **Command-as-skill wrappers double-counted as skills**: `listSkillsInVersionHome` was marker-blind and returned every `agents_command` wrapper (tickets, prune, swarm-plan, …) as an installed *skill*, so the skill orphan detector flagged each as unmanaged. Excluded them — they're commands, reconciled by the commands diff.

*Live: codex command orphans 24 → 0, codex skill orphans 41 → 0, codex doctor extras 26 → 2 (residual 2 are MCP servers). The `prune cleanup --dry-run` census drops 145 → 80, with **zero** command/skill orphans remaining — the data-loss class (swarm-plan, tickets, code-review, git-tag-release, …) is fully cleared.*

## Deliberately scoped out (documented, not speculatively patched)

- **Hooks sidecar asymmetry** (a latent part of root cause A): no reproduction exists (zero source hooks carry a sidecar; zero held hooks), and a correct fix spans the writer **and** the orphan-sweep (`trustedHookNames`) on security-sensitive hook code where two installers (`copyHook` vs the staleness writer) disagree on whether version homes should carry hook sidecars — a maintainer design decision. Not patched without a repro to verify against.
- **Residual 80 prune "orphans"**: a *registration-based* hooks census (`listUnmanagedHooksInVersionHome`, incl. `*_test` fixtures) and Claude-Code-owned marketplace `plugins`/`subagents` — a separate subsystem / ownership question, not a source-scan false positive.
- **No deletion guard added**: the fix is at the enumerators (the source), so plugin/wrapper resources never reach prune's delete path — a standalone guard would be dead code.

## Verification

- `tsc --noEmit` clean.
- New/updated tests: `doctor-diff.test.ts` (composed-preset rules for import + non-import agents, native-skills gate), `skills.test.ts` (command-skill wrapper is not a skill orphan), `commands.test.ts` (plugin command flattening + not-an-orphan). All pass.
- Full suite: 6114 passed; the 15 failures are pre-existing and unrelated (env-contaminated `exec`/`models`/`version-duplicates`/`cost`/`defaults`/`non-interactive` tests that assert on the host's real install/model/version state — zero overlap with the changed files).
- End-to-end against a live install as described inline above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)