### PR TITLE
fix(cli): bootout + bootstrap menubar helper on auto-heal

### DIFF
--- a/apps/cli/.changelog/next/menubar-autorestart.md
+++ b/apps/cli/.changelog/next/menubar-autorestart.md
@@ -1,0 +1,11 @@
+- **Fix the macOS menu-bar auto-heal so upgrades actually restart the helper.**
+  `agents` has an on-startup self-heal that re-copies `MenubarHelper.app` when
+  the CLI version changes, but on modern macOS `launchctl bootstrap` fails when
+  the job is already bootstrapped, and the deprecated `launchctl load -w`
+  fallback plus `kickstart -k` did not recover a job that launchd had stopped
+  respawning after a `WindowServer event port death`. The helper would stay
+  updated on disk but invisible in the menu bar. `enableMenubarService` now
+  boots the old job out, bootstraps the fresh plist, and kickstarts it — the
+  same sequence that reliably restores the icon by hand. Source:
+  `apps/cli/src/lib/menubar/install-menubar.ts`,
+  `apps/cli/src/lib/menubar/install-menubar.test.ts`.

--- a/apps/cli/src/lib/menubar/install-menubar.test.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { isMenubarStale, menubarPlistNeedsRepoint } from './install-menubar.js';
+import { describe, expect, it, vi } from 'vitest';
+import { isMenubarStale, menubarPlistNeedsRepoint, restartMenubarLaunchAgent } from './install-menubar.js';
 
 // Regression guard for the upgrade self-heal: before this, the helper was only
 // (re)installed when no service existed, so `npm update` left the menu bar
@@ -52,5 +52,36 @@ describe('menubarPlistNeedsRepoint', () => {
 
   it('re-points a plist that has no baked entry yet (older install)', () => {
     expect(menubarPlistNeedsRepoint({ plistEntry: null, plistNode: null, activeEntry: bun, activeNode: bunNode })).toBe(true);
+  });
+});
+
+// Regression guard for the auto-heal restart sequence: without a `bootout` first,
+// `bootstrap` fails on modern macOS when the job is already loaded, leaving the
+// helper in a dead state after a WindowServer disconnect.
+describe('restartMenubarLaunchAgent', () => {
+  it('boots out the old job, bootstraps the plist, then kickstarts the service', () => {
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const exec = (cmd: string, args: readonly string[]) => {
+      calls.push({ cmd, args: args as string[] });
+      return Buffer.alloc(0);
+    };
+
+    restartMenubarLaunchAgent(501, '/tmp/com.phnx-labs.agents-menubar.plist', exec);
+
+    expect(calls).toHaveLength(3);
+    expect(calls[0]).toEqual({ cmd: 'launchctl', args: ['bootout', 'gui/501/com.phnx-labs.agents-menubar'] });
+    expect(calls[1]).toEqual({ cmd: 'launchctl', args: ['bootstrap', 'gui/501', '/tmp/com.phnx-labs.agents-menubar.plist'] });
+    expect(calls[2]).toEqual({ cmd: 'launchctl', args: ['kickstart', 'gui/501/com.phnx-labs.agents-menubar'] });
+  });
+
+  it('continues through launchctl errors so a partially-loaded job still gets restarted', () => {
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const exec = (cmd: string, args: readonly string[]) => {
+      calls.push({ cmd, args: args as string[] });
+      throw new Error('launchctl failed');
+    };
+
+    expect(() => restartMenubarLaunchAgent(501, '/tmp/com.phnx-labs.agents-menubar.plist', exec)).not.toThrow();
+    expect(calls).toHaveLength(3);
   });
 });

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -225,6 +225,27 @@ ${envXml}
 }
 
 /**
+ * Restart the menu-bar launchd agent from a clean state.
+ *
+ * Always `bootout` first: on modern macOS `bootstrap` fails when the job is
+ * already bootstrapped, and the deprecated `load -w` fallback is unreliable.
+ * A prior WindowServer disconnect can leave the job throttled so that a plain
+ * `kickstart -k` does not bring it back; booting it out and bootstrapping fresh
+ * is the only sequence that reliably re-attaches the status item.
+ */
+export function restartMenubarLaunchAgent(
+  uid: number,
+  plist: string,
+  exec: (cmd: string, args: readonly string[], opts: { stdio: ['ignore', 'ignore', 'ignore'] }) => Buffer = execFileSync,
+): void {
+  const serviceTarget = `gui/${uid}/${SERVICE_LABEL}`;
+  const opts: { stdio: ['ignore', 'ignore', 'ignore'] } = { stdio: ['ignore', 'ignore', 'ignore'] };
+  try { exec('launchctl', ['bootout', serviceTarget], opts); } catch { /* may not be loaded */ }
+  try { exec('launchctl', ['bootstrap', `gui/${uid}`, plist], opts); } catch { /* best effort */ }
+  try { exec('launchctl', ['kickstart', serviceTarget], opts); } catch { /* best effort */ }
+}
+
+/**
  * Install + start the menu-bar helper as a launchd user service (idempotent).
  * Clears the sticky opt-out, installs the .app, writes the plist, and
  * bootstraps it into the GUI domain. Returns false on non-darwin or when no
@@ -244,12 +265,7 @@ export function enableMenubarService(opts: { clearOptOut?: boolean } = { clearOp
   fs.writeFileSync(plist, generateServicePlist(exec));
 
   const uid = process.getuid?.() ?? 0;
-  try {
-    execFileSync('launchctl', ['bootstrap', `gui/${uid}`, plist], { stdio: ['ignore', 'ignore', 'ignore'] });
-  } catch {
-    try { execFileSync('launchctl', ['load', '-w', plist], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* may already be loaded */ }
-  }
-  try { execFileSync('launchctl', ['kickstart', '-k', `gui/${uid}/${SERVICE_LABEL}`], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* best effort */ }
+  restartMenubarLaunchAgent(uid, plist);
 
   // Stamp the version we just installed so the upgrade self-heal can tell when
   // a later release ships a newer helper that needs reinstalling.


### PR DESCRIPTION
## Problem

The agents-cli menu bar icon can disappear after a CLI upgrade or a `WindowServer event port death`. The on-startup auto-heal copies the new `MenubarHelper.app` and rewrites the launchd plist, but it doesn't reliably restart the service, so the icon stays missing.

## Root cause

`enableMenubarService()` used:

1. `launchctl bootstrap` — fails on modern macOS when the job is already bootstrapped.
2. Deprecated `launchctl load -w` fallback.
3. `launchctl kickstart -k` — too gentle to recover a job that launchd has stopped respawning after repeated WindowServer disconnects.

The result: the helper binary is updated on disk, but the process is not running and the status item never re-attaches.

## Fix

Extract `restartMenubarLaunchAgent()` and use the sequence that reliably restores the icon:

```
launchctl bootout   gui/<uid>/com.phnx-labs.agents-menubar
launchctl bootstrap gui/<uid> <plist>
launchctl kickstart gui/<uid>/com.phnx-labs.agents-menubar
```

Each step is best-effort (errors swallowed) so a partially-loaded job still gets restarted.

## Verification

- Reproduced on this machine: `agents menubar status` showed `running: false` after the auto-heal updated the bundle to `1.20.70`.
- Ran the new sequence by hand; `agents menubar status` now reports `running: true` and `launchctl list` shows a live PID.
- Added regression tests in `install-menubar.test.ts` asserting the bootout → bootstrap → kickstart order and error tolerance.
- `bun test src/lib/menubar/install-menubar.test.ts` passes (11/11).
- `bun run build` passes.

## Files

- `apps/cli/src/lib/menubar/install-menubar.ts`
- `apps/cli/src/lib/menubar/install-menubar.test.ts`
- `apps/cli/.changelog/next/menubar-autorestart.md`

## Session transcript

https://gist.github.com/muqsitnawaz/a2cb28dbafa0fc5fd2f2be8657240c44
