### PR TITLE
fix(secrets): forward --durable to remote unlock (--host)

### DIFF
--- a/apps/cli/src/commands/secrets.test.ts
+++ b/apps/cli/src/commands/secrets.test.ts
@@ -324,6 +324,13 @@ describe('buildRemoteUnlockArgs (unlock --host wiring)', () => {
   it('--all wins over any stray names', () => {
     expect(buildRemoteUnlockArgs(['x'], { all: true })).toEqual(['unlock', '--all']);
   });
+
+  it('forwards --durable so the remote honors it (not silently downgraded)', () => {
+    expect(buildRemoteUnlockArgs(['a'], { durable: true })).toEqual(['unlock', 'a', '--durable']);
+    expect(buildRemoteUnlockArgs([], { all: true, ttl: '2h', durable: true }))
+      .toEqual(['unlock', '--all', '--ttl', '2h', '--durable']);
+    expect(buildRemoteUnlockArgs(['a'], {})).not.toContain('--durable');
+  });
 });
 
 describe('exportBundleToFile / importBundleFromFile file round-trip', () => {

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -329,11 +329,14 @@ function maybePrintSyncedHint(name: string): void {
  * defaults). Shared with the command action so the wiring is unit-testable
  * without a live SSH session.
  */
-export function buildRemoteUnlockArgs(names: string[], opts: { all?: boolean; ttl?: string }): string[] {
+export function buildRemoteUnlockArgs(names: string[], opts: { all?: boolean; ttl?: string; durable?: boolean }): string[] {
   return [
     'unlock',
     ...(opts.all ? ['--all'] : names),
     ...(opts.ttl ? ['--ttl', opts.ttl] : []),
+    // Forward --durable so a remote unlock honors it too; without this the remote
+    // silently falls back to its own secrets.agent.durable default (off).
+    ...(opts.durable ? ['--durable'] : []),
   ];
 }
 


### PR DESCRIPTION
Fast follow-up to #1313, flagged in its review. `buildRemoteUnlockArgs` forwarded `--all`/`--ttl` but not `--durable`, so `agents secrets unlock <b> --host <m> --durable` silently fell back to the remote's `secrets.agent.durable` default. Forward the flag (one line) + test. Completes the unreleased `--durable` feature so it lands whole in 1.20.71. `tsc` clean, 42 secrets-command tests pass.