### PR TITLE
fix(cli): TTY-guard run --copy-creds and hosts add against headless hangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -359,6 +359,14 @@
   12-device fleet reports `12 ok` rather than `11 ok · 1 failed`. Source:
   `apps/cli/src/lib/devices/fleet.ts` (`runFleet`, `runLocalCommand`),
   `apps/cli/src/commands/ssh.ts`.
+- **`run --copy-creds` and `hosts add` no longer hang a headless caller.** Both
+  ran an interactive `@inquirer` prompt (a runtime picker + a confirm; a bootstrap
+  install/upgrade confirm) with no TTY guard, so a non-TTY/piped invocation blocked
+  forever on stdin. `run --copy-creds` now fails clean via `requireInteractiveSelection`
+  in a non-TTY shell (it ships live credentials, so it deliberately stays
+  interactive-only rather than auto-selecting), and `hosts add`'s best-effort
+  bootstrap reports the version state and returns instead of prompting. Source:
+  `apps/cli/src/commands/exec.ts`, `apps/cli/src/commands/hosts.ts`.
 
 ## 1.20.58
 

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -13,6 +13,7 @@ import type { AgentId } from '../lib/types.js';
 import type { DetectedRuntime } from '../lib/crabbox/runtimes.js';
 import type { ResolvedRunDefaults } from '../lib/run-defaults.js';
 import { setHelpSections } from '../lib/help.js';
+import { isInteractiveTerminal, requireInteractiveSelection } from './utils.js';
 import { parseLoopInterval } from '../lib/loop.js';
 import type { RotateResult } from '../lib/rotate.js';
 import { AGENTS } from '../lib/agents.js';
@@ -922,6 +923,18 @@ export function registerRunCommand(program: Command): void {
                     `Make sure the host is reachable over SSH, then re-run with --copy-creds.`,
               ));
               process.exit(1);
+            }
+
+            // --copy-creds ships live credentials to a host, so it deliberately
+            // requires an interactive terminal to pick which signed-in runtimes to
+            // send and to confirm the transfer. Fail clean in a non-TTY/headless
+            // shell instead of hanging on the picker/confirm below — auto-shipping
+            // every signed-in token without consent would defeat the gate's purpose.
+            if (!isInteractiveTerminal()) {
+              requireInteractiveSelection(
+                '--copy-creds (choosing which credentials to ship and confirming the transfer)',
+                [`agents run <agent> --host ${host.name} --copy-creds "..."   # from an interactive terminal`],
+              );
             }
 
             const { detectSignedInRuntimes, pickRuntimes, resolveClaudeCredentialsBlob } = await import('../lib/crabbox/runtimes.js');

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -931,9 +931,12 @@ export function registerRunCommand(program: Command): void {
             // shell instead of hanging on the picker/confirm below — auto-shipping
             // every signed-in token without consent would defeat the gate's purpose.
             if (!isInteractiveTerminal()) {
+              // No non-interactive form: --copy-creds must pick which signed-in
+              // runtimes to ship and confirm the transfer, so pass no alternatives
+              // (an empty list prints just the "needs an interactive terminal" line).
               requireInteractiveSelection(
-                '--copy-creds (choosing which credentials to ship and confirming the transfer)',
-                [`agents run <agent> --host ${host.name} --copy-creds "..."   # from an interactive terminal`],
+                '--copy-creds (it selects which credentials to ship and confirms the transfer)',
+                [],
               );
             }
 

--- a/apps/cli/src/commands/hosts.ts
+++ b/apps/cli/src/commands/hosts.ts
@@ -11,6 +11,7 @@ import type { Command } from 'commander';
 import chalk from 'chalk';
 import { terminalWidth, truncateToWidth, stringWidth } from '../lib/session/width.js';
 import { checkbox, confirm } from '@inquirer/prompts';
+import { isInteractiveTerminal } from './utils.js';
 import { assertValidSshTarget } from '../lib/ssh-exec.js';
 import { getProvider, listAllHosts, resolveHost } from '../lib/hosts/registry.js';
 import { getDevice } from '../lib/devices/registry.js';
@@ -56,6 +57,12 @@ async function maybeBootstrap(
   const remoteVer = remoteAgentsVersion(target, os);
   const localVer = localCliVersion();
   if (!remoteVer) {
+    // Non-TTY: this is a best-effort bootstrap prompt, so report and return
+    // instead of hanging on confirm() in a headless/piped shell.
+    if (!isInteractiveTerminal()) {
+      console.log(chalk.gray(`  agents-cli not found on ${hostName} — install it there, then: agents hosts check ${hostName}`));
+      return;
+    }
     const ok = await confirm({ message: `  agents-cli not found on ${hostName}. Install ${localVer ? `v${localVer}` : 'latest'} now?`, default: true });
     if (ok) {
       console.log(chalk.gray('  Installing agents-cli on the host…'));
@@ -66,6 +73,10 @@ async function maybeBootstrap(
   }
   const remoteClean = remoteVer.replace(/^v/, '');
   if (localVer && remoteClean !== localVer) {
+    if (!isInteractiveTerminal()) {
+      console.log(chalk.gray(`  ${hostName} has agents-cli ${remoteClean}, you have ${localVer} — versions differ; upgrade the host to match when convenient.`));
+      return;
+    }
     const ok = await confirm({ message: `  ${hostName} has agents-cli ${remoteClean}, you have ${localVer}. Upgrade to match?`, default: false });
     if (ok) {
       const r = bootstrapAgentsCli(target, localVer, os);


### PR DESCRIPTION
Phase 1 of the API-surface remediation — the real agent-hang bugs from the audit.

## Problem
Two commands ran an interactive `@inquirer` prompt with **no TTY guard**, so a non-TTY / piped / headless invocation blocked forever on stdin (the audit's sharpest agent-blocking finding):
- `run --copy-creds` — `pickRuntimes` (a `checkbox`) then a `confirm` (`exec.ts`), with zero `isInteractiveTerminal()` check.
- `hosts add` — `maybeBootstrap`'s install/upgrade `confirm()`s (`hosts.ts`), unconditional even with explicit `name`+`target`.

## Fix
- **`run --copy-creds`**: ships *live credentials*, so it deliberately stays interactive-only — in a non-TTY shell it now fails clean via `requireInteractiveSelection` (exit 1 + the exact interactive form) instead of hanging or auto-selecting every signed-in token (which would defeat the security gate).
- **`hosts add`**: best-effort bootstrap now **reports the version state and returns** in a non-TTY shell instead of prompting.

Both use the canonical `isInteractiveTerminal()` helper (39 other command files already do).

## Verification
- `tsc` + build clean; both guards confirmed compiled into `dist/`.
- No new test failures — the 3 pre-existing `exec.test.ts` failures reproduce identically on pristine `origin/main` (local codex-version-sensitive tests that pass on CI's Linux runners; that's why prior PR CI was green).
- E2E of the guards themselves is gated by remote state (a pinned host / a host missing agents-cli) and, for `--copy-creds`, the credential-shipping permission gate — so correctness rests on the canonical pattern + typecheck + CI + review. The guards are 3-line applications of the same `isInteractiveTerminal()`/`requireInteractiveSelection()` pattern used across the codebase.

Part of the agent-friendliness remediation (see `delivery-plan.html`); follows merged #1304 (redaction) and #1307 (fork/tail/usage).

Session transcript (public repo — path only): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/bde29883-386c-4cdd-8d8b-056693c42a50.jsonl`