### PR TITLE
feat(cli): resolveSurface() — centralize the human/agent I/O split (Phase 2 keystone)

### DIFF
--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -16,6 +16,7 @@ import { AgentId } from '../lib/types.js';
 import { setHelpSections } from '../lib/help.js';
 import { computeSyncStatus, type AgentVersionStatus } from '../lib/sync-status.js';
 import { promptDriftSync } from '../lib/drift-sync.js';
+import { resolveSurface } from './utils.js';
 
 interface StatusOptions {
   json?: boolean;
@@ -57,10 +58,15 @@ export function registerStatusCommand(program: Command): void {
     `,
   });
 
-  cmd.action(async (opts: StatusOptions) => {
+  cmd.action(async (opts: StatusOptions, command: Command) => {
+    // Centralized surface read (the human/agent split in one place). Note we still
+    // pass the *raw* `opts.yes` to promptDriftSync below — it distinguishes an
+    // explicit `--yes` (act) from a non-TTY shell (report only), so `surface.assumeYes`
+    // (which conflates the two) would wrongly auto-reconcile in a plain pipe.
+    const surface = resolveSurface(command);
     const cwd = opts.cwd ?? process.cwd();
 
-    if (opts.json) {
+    if (surface.json) {
       const status = await computeSyncStatus({ cwd });
       console.log(JSON.stringify(status, null, 2));
       return;

--- a/apps/cli/src/commands/utils.test.ts
+++ b/apps/cli/src/commands/utils.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import type { Command } from 'commander';
+
+import { resolveSurface } from './utils.js';
+
+// A minimal stand-in for the parts of Command resolveSurface reads.
+function fakeCmd(opts: Record<string, unknown>): Command {
+  return { optsWithGlobals: () => opts } as unknown as Command;
+}
+
+// resolveSurface folds in the real terminal state via isInteractiveTerminal(),
+// which reads process.std*.isTTY — drive those directly (no service mocking).
+const origIn = process.stdin.isTTY;
+const origOut = process.stdout.isTTY;
+function setTty(v: boolean): void {
+  (process.stdin as { isTTY?: boolean }).isTTY = v;
+  (process.stdout as { isTTY?: boolean }).isTTY = v;
+}
+afterEach(() => {
+  (process.stdin as { isTTY?: boolean }).isTTY = origIn;
+  (process.stdout as { isTTY?: boolean }).isTTY = origOut;
+});
+
+describe('resolveSurface', () => {
+  it('reads --json / --quiet / --yes from the merged option set', () => {
+    setTty(true);
+    const s = resolveSurface(fakeCmd({ json: true, quiet: true, yes: true }));
+    expect(s.json).toBe(true);
+    expect(s.quiet).toBe(true);
+    expect(s.assumeYes).toBe(true);
+  });
+
+  it('assumeYes is true in a non-interactive shell even without --yes (no one to prompt)', () => {
+    setTty(false);
+    const s = resolveSurface(fakeCmd({}));
+    expect(s.assumeYes).toBe(true);
+    expect(s.interactive).toBe(false);
+  });
+
+  it('assumeYes is false at a TTY without --yes (a human should be asked)', () => {
+    setTty(true);
+    const s = resolveSurface(fakeCmd({}));
+    expect(s.assumeYes).toBe(false);
+    expect(s.interactive).toBe(true);
+  });
+
+  it('--json forces interactive=false even at a real TTY (a JSON consumer is a machine)', () => {
+    setTty(true);
+    const s = resolveSurface(fakeCmd({ json: true }));
+    expect(s.json).toBe(true);
+    expect(s.interactive).toBe(false);
+  });
+
+  it('defaults are all false/off when no flags and no TTY info', () => {
+    setTty(false);
+    const s = resolveSurface(fakeCmd({}));
+    expect(s.json).toBe(false);
+    expect(s.quiet).toBe(false);
+    expect(s.interactive).toBe(false);
+    expect(s.assumeYes).toBe(true); // non-TTY ⇒ assume yes
+  });
+});

--- a/apps/cli/src/commands/utils.ts
+++ b/apps/cli/src/commands/utils.ts
@@ -10,6 +10,7 @@ import { spawnSync } from 'child_process';
 import chalk from 'chalk';
 import ora from 'ora';
 import { confirm } from '@inquirer/prompts';
+import type { Command } from 'commander';
 import type { AgentId } from '../lib/types.js';
 import { AGENTS, agentLabel, resolveAgentName } from '../lib/agents.js';
 import {
@@ -58,6 +59,46 @@ export function isPromptCancelled(err: unknown): boolean {
  */
 export function isInteractiveTerminal(): boolean {
   return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+}
+
+/** The resolved I/O surface for one command invocation — the human/agent split. */
+export interface Surface {
+  /** Machine-readable output was requested (`--json`). */
+  json: boolean;
+  /** Skip confirmation prompts — explicit `--yes`/`-y`, or a non-interactive shell. */
+  assumeYes: boolean;
+  /** Suppress non-essential human chrome (`--quiet`). */
+  quiet: boolean;
+  /**
+   * Safe to show an interactive picker/prompt: a real terminal AND not asking for
+   * `--json` (a JSON consumer is a machine and never wants a picker).
+   */
+  interactive: boolean;
+}
+
+/**
+ * Compute a command's I/O surface once, in one place, instead of each command
+ * re-deriving the human-vs-agent split (and raw-sniffing `process.std*.isTTY`
+ * with inconsistent stream choices — the audit's R4). Reads the merged option
+ * set via `optsWithGlobals()`, so it sees the command's own flags and any
+ * inherited global ones, and folds in the terminal state:
+ *
+ *   - `assumeYes` = explicit `--yes` OR a non-interactive shell (no one to prompt).
+ *   - `interactive` = a real TTY AND not `--json`.
+ *
+ * Adopt incrementally: a command switches its ad-hoc `isTTY`/`options.yes` checks
+ * to a single `const s = resolveSurface(cmd)` without changing its flag surface.
+ */
+export function resolveSurface(cmd: Command): Surface {
+  const opts = cmd.optsWithGlobals() as { json?: boolean; yes?: boolean; quiet?: boolean };
+  const tty = isInteractiveTerminal();
+  const json = opts.json === true;
+  return {
+    json,
+    assumeYes: opts.yes === true || !tty,
+    quiet: opts.quiet === true,
+    interactive: tty && !json,
+  };
 }
 
 /**


### PR DESCRIPTION
Phase 2 of the API-surface remediation — the **keystone**, introduced as a safe foundation.

## Why not "global --json/--yes"
The delivery plan called for global flags, but I empirically found commander makes that unsafe: a root `--json`/`--yes` **shadows** the 49/4 commands that declare their own — parsed value routes to the parent, so the command's `opts.json`/`opts.yes` read `undefined` and **breaks**. A parent option is only visible via `optsWithGlobals()`, never plain `opts`.

## What this does instead
`resolveSurface(cmd)` — one place that computes the human/agent split from the **merged** option set + terminal state:
```ts
interface Surface { json; assumeYes; quiet; interactive }
// assumeYes = --yes OR non-TTY (no one to prompt)
// interactive = a real TTY AND not --json (a JSON consumer is a machine)
```
It reads `cmd.optsWithGlobals()`, so it works whether a flag is local or (future) global — no flag-surface change, no shadowing. Commands adopt it incrementally, each adoption also folding in that command's ad-hoc `isTTY` sniff (the audit's R4: 17 files raw-sniff `process.std*.isTTY` on inconsistent streams).

## First adoption (proof, not dead code)
`status.ts` now routes `--json` through `resolveSurface` — **verified e2e**: `agents status --json` emits the same `{system, agents, totals}` contract. Deliberately **keeps the raw `opts.yes`** for `promptDriftSync`, which distinguishes explicit `--yes` (act) from non-TTY (report only) — a case where `surface.assumeYes` would over-reach. That subtlety is exactly why adoption is per-command careful, and it's documented inline.

## Verification
- 5 new `utils.test.ts` cases (json/quiet/yes reads, non-TTY⇒assumeYes, TTY⇒prompt, --json⇒non-interactive). `tsc` + build clean.
- `agents status --json` e2e: valid JSON, unchanged shape.
- No user-visible behavior change (internal foundation) → changelog-exempt.

Follows merged Phase 1 (#1304/#1307/#1319/#1322). Next: adopt `resolveSurface` across the raw-`isTTY` commands, then the Phase 3 resource-factory batch.

Session transcript (public repo — path only): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/bde29883-386c-4cdd-8d8b-056693c42a50.jsonl`