### PR TITLE
fix(teams): defuse date-bomb in resume rollback test (unblocks CI on main)

### DIFF
--- a/apps/cli/src/lib/teams/agents.resume.test.ts
+++ b/apps/cli/src/lib/teams/agents.resume.test.ts
@@ -176,8 +176,14 @@ describe.skipIf(IS_WINDOWS)('resumeTeammate — launch failure', () => {
     const id = 'claude-agent-relaunch-failure';
     const dir = path.join(base, id);
     const marker = `resume-transaction-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-    const startedAt = new Date('2026-07-13T12:00:00.000Z');
-    const completedAt = new Date('2026-07-13T12:34:56.000Z');
+    // Recent, not a hardcoded calendar date: the manager's cleanupAgeDays (7)
+    // sweep deletes any teammate dir older than the cutoff during init, so a
+    // fixed past date turns this into a time bomb that starts failing exactly 7
+    // days after it was written (the teammate is reaped before resumeTeammate can
+    // find it → "No teammate with id"). Anchor to `now` so it stays in-window;
+    // the exact values are still asserted for preservation below.
+    const startedAt = new Date(Date.now() - 60 * 60 * 1000);
+    const completedAt = new Date(Date.now() - 30 * 60 * 1000);
     fs.mkdirSync(dir, { recursive: true });
 
     const agent = new AgentProcess(


### PR DESCRIPTION
## main is red — this fixes it

`src/lib/teams/agents.resume.test.ts > "terminates the replacement and restores all prior state when persistence fails after spawn"` fails **deterministically** on `main` as of **2026-07-20**, blocking CI (`test-shard (2)`) for every open PR.

## Root cause: a hardcoded-date time bomb
The test hardcoded `startedAt/completedAt = 2026-07-13`. `AgentManager`'s init runs a `cleanupAgeDays` (7) sweep that `fs.rm`s any teammate dir older than the cutoff (`agents.ts:1465` → `1482`). So starting exactly **7 days after 2026-07-13 = 2026-07-20**, the sweep **reaps the teammate before `resumeTeammate` can find it** — and the assertion sees `"No teammate with id claude-agent-relaunch-failure"` instead of the expected compound restore error.

It passed when written and for 6 days (incl. #1322's CI hours ago), then went red. **Not a code regression** — a latent test bug. The sibling tests in the same file already use `new Date()`; this was the only one pinned to a calendar date.

## Fix
Anchor the two dates to `now` (`Date.now() - 1h` / `- 30m`) so the teammate stays inside the cleanup window. The exact values are still asserted for preservation below, so coverage is unchanged.

## Verified
- The previously-failing test: **13/13 passed, 3 consecutive runs** locally.
- Traced the mechanism end-to-end with a direct repro: `loadFromDisk(id, base)` = FOUND but `mgr.get(id)` = NULL because `readdir(agentsDir)` was `[]` — the dir had been swept.

Test-only, no product change → changelog-exempt. Merging this unblocks CI for #1325 (Phase 2 keystone) and the rest of the API-surface remediation.

Session transcript (public repo — path only): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/bde29883-386c-4cdd-8d8b-056693c42a50.jsonl`