### PR TITLE
feat(resources): --json on skills/commands/mcp/subagents list (shared helper)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -375,6 +375,14 @@
   --json` produces, via a shared renderer, so there's one session JSON contract, not
   two. Source: `apps/cli/src/commands/logs.ts`, `apps/cli/src/commands/sessions.ts`
   (`renderSessionLogJson`), `apps/cli/src/lib/hosts/logs.ts` (`hostTaskLogJson`).
+- **`--json` on resource `list` commands (`skills`/`commands`/`mcp`/`subagents`).**
+  The config-authoring commands were table/picker-only, so an agent enumerating
+  installed resources had to scrape colored text. `--json` is added at the source —
+  the shared `showResourceList` helper (`apps/cli/src/commands/resource-view.ts`)
+  now emits each row's metadata + per-agent-version sync targets as JSON — so every
+  command built on it inherits one machine-readable contract. Wired into `skills`,
+  `commands`, `mcp`, and `subagents` `list`. (`rules`/`permissions`/`hooks`, which
+  render bespoke, follow next.)
 
 ## 1.20.58
 

--- a/apps/cli/src/commands/commands.ts
+++ b/apps/cli/src/commands/commands.ts
@@ -99,6 +99,7 @@ When to use:
 
   commandsCmd
     .command('list [agent]')
+    .option('--json', 'Emit machine-readable JSON instead of the table/picker')
     .description('Show which slash commands are installed and which agent versions they are synced to')
     .option('-a, --agent <agent>', 'Filter to a specific agent (alternative to positional arg)')
     .action(async (agentArg, options) => {
@@ -134,6 +135,7 @@ When to use:
         centralPath: getCommandsDir(),
         filterAgent,
         filterVersion,
+        json: options.json,
       });
     });
 

--- a/apps/cli/src/commands/list-json.test.ts
+++ b/apps/cli/src/commands/list-json.test.ts
@@ -65,4 +65,19 @@ describe('list commands emit valid JSON with --json (not the human table)', () =
     // The regression this guards: a table would start with the "Name" header, not JSON.
     expect(stdout.trimStart().startsWith('[')).toBe(true);
   });
+
+  // The resource commands wired onto the shared showResourceList helper (#1327).
+  // On an empty guarded HOME each yields `[]`; the point is that the flag reaches
+  // the subcommand action (no parent/child shadowing) and stdout is clean JSON.
+  for (const cmd of ['skills', 'commands', 'mcp', 'subagents']) {
+    it(`${cmd} list --json prints a clean JSON array (flag reaches the subcommand)`, () => {
+      guardedHome();
+      const { stdout, status } = run([cmd, 'list', '--json']);
+      expect(status).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(stdout.trimStart().startsWith('[')).toBe(true);
+      expect(stdout).not.toContain(ANSI_ESCAPE);
+    });
+  }
 });

--- a/apps/cli/src/commands/mcp.ts
+++ b/apps/cli/src/commands/mcp.ts
@@ -223,6 +223,7 @@ When to use:
     .command('list [agent]')
     .description('Show which MCP servers are registered and which agent versions they are synced to')
     .option('-a, --agent <agent>', 'Filter to a specific agent (alternative to positional arg)')
+    .option('--json', 'Emit machine-readable JSON instead of the table/picker')
     .action(async (agentArg, options) => {
       const spinner = ora({ text: 'Loading...', isSilent: !process.stdout.isTTY }).start();
 
@@ -257,6 +258,7 @@ When to use:
         centralPath: getMcpDir(),
         filterAgent,
         filterVersion,
+        json: options.json,
       });
     });
 

--- a/apps/cli/src/commands/resource-view.ts
+++ b/apps/cli/src/commands/resource-view.ts
@@ -44,10 +44,21 @@ export interface ResourceViewOptions {
   /** When the user specified agent or agent@version, we scope per-agent. */
   filterAgent?: AgentId;
   filterVersion?: string;
+  /** Emit machine-readable JSON instead of the picker/table (for agents/scripts). */
+  json?: boolean;
 }
 
 /** Display a resource list: interactive picker in TTY mode, plain table otherwise. */
 export async function showResourceList(opts: ResourceViewOptions): Promise<void> {
+  if (opts.json) {
+    // Strip the non-serializable buildDetail thunk; emit the row metadata plus
+    // each resource's per-agent-version sync targets. One shared JSON contract
+    // for every resource `list` built on this helper.
+    const rows = opts.rows.map(({ buildDetail, ...row }) => row);
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+
   if (opts.rows.length === 0) {
     console.log(chalk.gray(opts.emptyMessage));
     return;

--- a/apps/cli/src/commands/skills.ts
+++ b/apps/cli/src/commands/skills.ts
@@ -102,6 +102,7 @@ When to use:
     .command('list [agent]')
     .description('Show which skills are installed and which agent versions they are synced to')
     .option('-a, --agent <agent>', 'Filter to a specific agent (alternative to positional arg)')
+    .option('--json', 'Emit machine-readable JSON instead of the table/picker')
     .action(async (agentArg, options) => {
       const spinner = ora({ text: 'Loading...', isSilent: !process.stdout.isTTY }).start();
 
@@ -136,6 +137,7 @@ When to use:
         centralPath: getSkillsDir(),
         filterAgent,
         filterVersion,
+        json: options.json,
       });
     });
 

--- a/apps/cli/src/commands/subagents.ts
+++ b/apps/cli/src/commands/subagents.ts
@@ -91,7 +91,7 @@ When to use:
 `);
 
   // Shared list implementation, registered as `list` and hidden `view` alias.
-  const runList = async () => {
+  const runList = async (opts?: { json?: boolean }) => {
     const rows = buildSubagentRows();
     await showResourceList({
       resourcePlural: 'subagents',
@@ -100,6 +100,7 @@ When to use:
       rows,
       emptyMessage: 'No subagents in ~/.agents/subagents/. Add one with: agents subagents add gh:user/repo',
       centralPath: getSubagentsDir(),
+      json: opts?.json,
     });
   };
 
@@ -107,6 +108,7 @@ When to use:
   subagentsCmd
     .command('list')
     .description('Show subagents in a table with sync status across agent versions')
+    .option('--json', 'Emit machine-readable JSON instead of the table/picker')
     .addHelpText('after', `
 Examples:
   # Interactive picker (TTY) or sync-status table (piped)


### PR DESCRIPTION
Phase 3 of the API-surface remediation — resource-layer `--json` coverage.

## Problem (audit R2)
The config-authoring `list` commands were table/picker-only, so an agent enumerating installed resources had to scrape colored text. `agents skills list --json` → `error: unknown option '--json'`.

## Fix — at the source, not per-command
The shared `showResourceList` helper (`resource-view.ts`, used by skills/commands/mcp/subagents/plugins/workflows) now emits each row's metadata + per-agent-version **sync targets** as JSON when `--json` is passed. So the machine-readable contract lives in **one place**, and any resource command built on the helper inherits it. Wired into 4 `list` commands this PR.

```diff
 export async function showResourceList(opts: ResourceViewOptions): Promise<void> {
+  if (opts.json) {
+    const rows = opts.rows.map(({ buildDetail, ...row }) => row);
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
```

## Verified end-to-end (built binary)
```
skills    list --json → valid JSON, 33 rows
commands  list --json → valid JSON, 30 rows
mcp       list --json → valid JSON,  5 rows
subagents list --json → valid JSON,  0 rows (empty array)
```
`tsc` + build clean.

## Scope
`rules`/`permissions`/`hooks` render bespoke (not via the shared helper) and get `--json` in a focused follow-up. `plugins` already has it.

Follows the merged keystone #1325 (`resolveSurface`). Part of the agent-friendliness remediation (`delivery-plan.html`).

Session transcript (public repo — path only): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/bde29883-386c-4cdd-8d8b-056693c42a50.jsonl`