### PR TITLE
fix(logs): emit the reconciled task in `logs <id> --json`

### DIFF
--- a/apps/cli/.changelog/next/logs-json-reconcile.md
+++ b/apps/cli/.changelog/next/logs-json-reconcile.md
@@ -1,0 +1,8 @@
+- **`agents logs <id> --json` now reports the true final status of a host task.**
+  For a run that finished remotely between dispatch and the one-shot `--json`
+  read, the payload emitted a stale `status: "running"` with no `exitCode` — even
+  though the completed log was already present — because `hostTaskLogJson`
+  discarded the reconciled record `reconcileTask` returns (it heals a new object
+  rather than mutating in place). It now emits the reconciled task, so a polling
+  agent sees `completed`/`failed` + `exitCode` + `finishedAt`. Source:
+  `apps/cli/src/lib/hosts/logs.ts`.

--- a/apps/cli/src/lib/hosts/logs.test.ts
+++ b/apps/cli/src/lib/hosts/logs.test.ts
@@ -193,6 +193,57 @@ describe.skipIf(!LOCALHOST_SSH)('detached-run log fetch over real ssh (localhost
   });
 });
 
+// hostTaskLogJson must emit the RECONCILED record: a task that finished remotely
+// between dispatch and this one-shot --json read has to surface its terminal
+// status/exitCode, not the stale 'running' it was saved with. Drives a real
+// `ssh localhost cat <.exit>` reconcile, so it's gated on localhost SSH like the
+// fetch tests above.
+describe.skipIf(!LOCALHOST_SSH)('hostTaskLogJson reconciles a finished run before emitting (real ssh)', () => {
+  it('surfaces terminal status + exitCode for a running record whose remote .exit is now set', () => {
+    // A real local file the ssh-localhost `cat` reads as the remote `.exit`.
+    const remoteExitFile = join(CACHE_ROOT, 'remote-recon01.exit');
+    writeFileSync(remoteExitFile, '0\n');
+
+    const task = makeTask({
+      id: 'recon001',
+      status: 'running',
+      target: 'localhost',
+      remoteExit: remoteExitFile,
+    });
+    saveTask(task);
+    writeFileSync(localLogPath(task.id), 'done output\n');
+
+    const res = hostTaskLogJson(task.id);
+
+    expect(res.found).toBe(true);
+    // The bug this guards: emitting the pre-reconcile `task` reports 'running'
+    // with no exitCode even though the run just completed.
+    expect(res.task?.status).toBe('completed');
+    expect(res.task?.exitCode).toBe(0);
+    expect(res.task?.finishedAt).toBeTruthy();
+    expect(res.log).toBe('done output\n');
+  });
+
+  it('leaves a still-running record running when its remote .exit is empty', () => {
+    const remoteExitFile = join(CACHE_ROOT, 'remote-recon02.exit');
+    writeFileSync(remoteExitFile, ''); // no exit code yet — still running
+
+    const task = makeTask({
+      id: 'recon002',
+      status: 'running',
+      target: 'localhost',
+      remoteExit: remoteExitFile,
+    });
+    saveTask(task);
+
+    const res = hostTaskLogJson(task.id);
+
+    expect(res.found).toBe(true);
+    expect(res.task?.status).toBe('running');
+    expect(res.task?.exitCode).toBeUndefined();
+  });
+});
+
 // tailLines is the concise-by-default view for host-task stdout: it must bound
 // the output and never silently drop lines without saying so.
 describe('tailLines', () => {

--- a/apps/cli/src/lib/hosts/logs.ts
+++ b/apps/cli/src/lib/hosts/logs.ts
@@ -75,8 +75,13 @@ export async function showHostTaskLog(id: string, follow: boolean, full = false)
 export function hostTaskLogJson(id: string): { found: boolean; task?: HostTask; log?: string | null } {
   const task = loadTask(id);
   if (!task) return { found: false };
-  reconcileTask(task);
-  return { found: true, task, log: readTaskLog(task) };
+  // reconcileTask returns the healed record; it does NOT mutate its argument in
+  // place. Emit the reconciled task so a run that finished between dispatch and
+  // this one-shot read surfaces its terminal status/exitCode, not a stale
+  // 'running'. (The text path can discard the return — it only reads the log by
+  // id — but this JSON payload carries task.status straight to the consumer.)
+  const reconciled = reconcileTask(task);
+  return { found: true, task: reconciled, log: readTaskLog(reconciled) };
 }
 
 /** Read the task's combined-stdout — local mirror first, else fetch+cache remote. */


### PR DESCRIPTION
Follow-up to #1322, which merged with a defect the automated review flagged (`Changes requested`) but was merged before the fix landed — so the bug is currently on `main`.

## The bug
`hostTaskLogJson` (`apps/cli/src/lib/hosts/logs.ts`) called `reconcileTask(task)` and then returned the **original** `task`. `reconcileTask` doesn't mutate in place — it heals a *new* record (via `updateTask`) and returns it. So `agents logs <id> --json` for a host run that finished remotely between dispatch and the one-shot read reported `status: "running"` with no `exitCode`, even though the completed log was right there in the payload. That's exactly the polling case the `--json` view exists for.

## The fix
Use the return value:
```ts
const reconciled = reconcileTask(task);
return { found: true, task: reconciled, log: readTaskLog(reconciled) };
```
The text path (`showHostTaskLog`) can keep discarding the return — it only reads the log by id and relies on reconcile's disk side-effect — but the JSON payload carries `task.status` straight to the consumer, so it must use the reconciled object.

## Test
Adds a real-ssh (localhost-gated, matching the sibling fetch tests) case for the `running`→`done` reconcile-then-emit path the original tests missed — their `makeTask` default is `status: 'completed'`, which short-circuits `reconcileTask` (`reconcile.ts:54`), so none exercised it.

## Verification
Verified end-to-end against a fleet host (yosemite-m0): staged a remote `.exit` of `0`, ran a `running` task through the real `hostTaskLogJson` (real ssh reconcile) →
```
{"found":true,"status":"completed","exitCode":0,"finishedAt":true}
```
Typecheck clean; `logs.test.ts` green (the two new cases skip only where localhost SSH is unavailable, as the existing real-ssh tests do).