### PR TITLE
feat(share): harden default link nonce 24-bit → 64-bit (RUSH-1821)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-1821.md
+++ b/apps/cli/.changelog/next/RUSH-1821.md
@@ -1,0 +1,10 @@
+- **`agents share` default links are much harder to guess (RUSH-1821).** The random
+  tail of an auto-generated share slug is now a 64-bit nonce (`randomBytes(8)`, 16 hex
+  chars) instead of the old 24-bit / 6-hex tail — closing a `~16.7M`-possibility space
+  that was small enough to brute-force. Since share reads are public (the URL is the only
+  capability), the nonce is the whole defense, so it now carries the full 64 bits.
+  Passed-in `--slug` values and existing links are unchanged. `docs/share.md` now states
+  the security model explicitly (unlisted-not-secret; reads are public; use `--expire`
+  for sensitive content; an opt-in auth-gated read is a future option). Source:
+  `apps/cli/src/lib/share/publish.ts` (`defaultSlug`), `apps/cli/src/lib/share/publish.test.ts`,
+  `apps/cli/docs/share.md`.

--- a/apps/cli/docs/share.md
+++ b/apps/cli/docs/share.md
@@ -45,8 +45,9 @@ agent makes plan.html
   no central render service and no extra cost. No headless browser available → the cover
   is skipped and the plain link still publishes. Opt out with `--no-cover`.
 - **Slugs.** With no `--slug`, the default is `<project>-<feature>-<hash>` (e.g.
-  `agents-cli-fleet-cockpit-3a6687`): the repo name scopes the link and a short random
-  tail keeps it unguessable and collision-free. Pass `--slug` for a stable, exact name.
+  `agents-cli-fleet-cockpit-9f3c1a8b7d2e4056`): the repo name scopes the link and a
+  random 64-bit tail (16 hex chars) keeps it unguessable and collision-free. Pass
+  `--slug` for a stable, exact name.
 
 ## Where things live
 
@@ -70,11 +71,33 @@ Push it to a peer with `agents secrets export share --host <box>`.
 
 ## Security
 
-Reads are public by design (share links). Writes require the bearer `WRITE_TOKEN` (held by
-the Worker as an encrypted CF secret; the client sends it from the `share` bundle). The
-Worker's constant-time-ish compare avoids leaking the token by timing. The token is a
-32-byte random hex; rotate by re-running `setup` (mints a new one) — old links keep
-serving until they expire.
+**The security model is _unlisted, not secret_.** A share link is an
+[unguessable-URL capability](https://en.wikipedia.org/wiki/Capability-based_security):
+the URL _is_ the credential. There is no read-side auth — anyone who has (or guesses)
+the link can read the content, and the Worker serves it to them.
+
+- **Reads are public by design.** `GET /<slug>` is unauthenticated. Do not treat a
+  share link as a private channel: if the URL leaks (a forwarded chat, a proxy log, a
+  referrer header, browser history on a shared machine), the content is exposed. Anything
+  that must be _actually_ private should not be published here as-is.
+- **The default slug is hard to guess, not a secret.** The random tail is a 64-bit
+  nonce (`randomBytes(8)`, 16 hex chars) — `~1.8e19` possibilities, infeasible to
+  brute-force. (It was a 24-bit / 6-hex tail before RUSH-1821, only `~1.7e7` — small
+  enough to enumerate; that's now fixed.) The `<project>-<feature>-` prefix is predictable,
+  so the nonce is doing all the work — which is exactly why it needs the full 64 bits.
+- **Use `--expire` for sensitive content.** There is no default expiry. `--expire 30d`
+  (or `12h`, or an absolute `2026-08-01`) bounds the window in which a leaked link is
+  live; the Worker `410`s and lazily deletes past that instant. Shorter is safer.
+- **A true auth-gated read is a future option, not shipped.** For content that must be
+  genuinely private rather than merely unlisted, the intended path is an opt-in,
+  auth-gated read — a bearer token or a signed, short-lived link required to _view_ (not
+  just to publish). That is deliberately not implemented today; until it lands, only
+  publish here what you're comfortable being world-readable-if-the-URL-leaks.
+
+Writes require the bearer `WRITE_TOKEN` (held by the Worker as an encrypted CF secret; the
+client sends it from the `share` bundle). The Worker's constant-time-ish compare avoids
+leaking the token by timing. The token is a 32-byte random hex; rotate by re-running
+`setup` (mints a new one) — old links keep serving until they expire.
 
 Source: `src/commands/share.ts`, `src/lib/share/{worker-template,provision,publish,config}.ts`,
 `Meta.share` in `src/lib/types.ts`.

--- a/apps/cli/src/lib/share/publish.test.ts
+++ b/apps/cli/src/lib/share/publish.test.ts
@@ -69,12 +69,20 @@ describe('detectProject / defaultSlug', () => {
     expect(detectProject(d)).toBe(expectedProject(d));
   });
 
-  it('builds <project>-<feature>-<6hex> and drops a redundant leading plan-', () => {
+  it('builds <project>-<feature>-<16hex> and drops a redundant leading plan-', () => {
     const d = mkdtempSync(join(tmpdir(), 'projx-'));
     const slug = defaultSlug('/somewhere/plan-fleet-cockpit.html', d);
-    expect(slug).toMatch(/-fleet-cockpit-[0-9a-f]{6}$/);
+    // 16 hex chars = 8 random bytes = 64-bit nonce (hardened from 24-bit, RUSH-1821).
+    expect(slug).toMatch(/-fleet-cockpit-[0-9a-f]{16}$/);
     expect(slug).not.toContain('plan-fleet-cockpit');
     expect(slug.startsWith(expectedProject(d) + '-')).toBe(true);
+  });
+
+  it('the random tail is a full 64-bit (16 hex char) nonce, not the old 24-bit one', () => {
+    const d = mkdtempSync(join(tmpdir(), 'projn-'));
+    const tail = defaultSlug('/x/report.html', d).split('-').pop()!;
+    expect(tail).toMatch(/^[0-9a-f]{16}$/);
+    expect(tail).toHaveLength(16);
   });
 
   it('two publishes of the same file get distinct (hashed) slugs', () => {

--- a/apps/cli/src/lib/share/publish.ts
+++ b/apps/cli/src/lib/share/publish.ts
@@ -83,13 +83,18 @@ export function detectProject(dir: string = process.cwd()): string {
 }
 
 /**
- * Notion-style default slug: `<project>-<feature>-<6hex>`. Project scopes the link
+ * Notion-style default slug: `<project>-<feature>-<16hex>`. Project scopes the link
  * to the repo the agent is in; the random tail keeps it unguessable + collision-free.
  * A leading `plan-` on the filename is dropped (it's redundant under the project).
+ *
+ * The tail is 8 random bytes (64-bit, 16 hex chars). Reads are public — the URL is
+ * the only capability — so the nonce must be genuinely infeasible to brute-force,
+ * not merely unlisted; 64 bits puts a blind guess out of reach. (See docs/share.md
+ * §Security for the threat model and `--expire` for sensitive content.)
  */
 export function defaultSlug(filePath: string, dir?: string): string {
   const feature = slugify(filePath).replace(/^plan-/, '') || 'page';
-  return `${detectProject(dir)}-${feature}-${randomBytes(3).toString('hex')}`;
+  return `${detectProject(dir)}-${feature}-${randomBytes(8).toString('hex')}`;
 }
 
 function guessContentType(filePath: string): string {


### PR DESCRIPTION
## What

`agents share` publishes to `<project>-<feature>-<random>`. The random tail was `randomBytes(3).toString('hex')` — **6 hex = 24 bits (~16.7M)**, small enough to brute-force, while the `project-feature` prefix is predictable. Reads are fully public (the URL is the only capability), so the nonce is the entire defense.

This is the cheap, high-value fix from RUSH-1821: bump the tail to `randomBytes(8)` = **64-bit (16 hex chars, ~1.8e19)** — negligible URL-length cost, genuinely infeasible to guess.

- `apps/cli/src/lib/share/publish.ts` — `defaultSlug` nonce `randomBytes(3)` → `randomBytes(8)` + doc.
- `apps/cli/src/lib/share/publish.test.ts` — assert the 16-hex/64-bit tail (regex + explicit length check); existing distinctness/`plan-`-drop/pass-through slug tests unchanged.
- `apps/cli/docs/share.md` — §Security now states the model explicitly: **unlisted, not secret** (reads are public; the URL is the credential), the 64-bit nonce rationale, `--expire` for sensitive content, and that a true auth-gated read is a future option.
- `apps/cli/.changelog/next/RUSH-1821.md` — changelog fragment (CHANGELOG.md is generated; not hand-edited).

Passed-in `--slug` values and existing published links are unchanged — only newly auto-generated slugs get the longer tail.

## Verification

- `npx tsc --noEmit` — clean (rc=0).
- `node ./node_modules/vitest/vitest.mjs run src/lib/share/` — **31 passed**.
- Changelog drift test (`scripts/gen-changelog`) — **5 passed**; `npm run changelog` leaves CHANGELOG.md unchanged (next/ fragments aren't rendered until release).
- End-to-end: `defaultSlug('/tmp/plan-fleet-cockpit.html', '/tmp/my-project')` → `my-project-fleet-cockpit-f434268e6b8f4114` — 16-hex tail, distinct per call, `plan-` prefix dropped.

## Follow-up (NOT in this PR)

Option 2 from the ticket — **real privacy**, not just unlisted: an opt-in, auth-gated read (a bearer token or a signed, short-lived link required to *view*, not only to publish) for content that must actually be private. That's a Worker + CLI change and is deliberately out of scope here; this PR closes the brute-force gap for the default unlisted link. Documented as a future option in `docs/share.md` §Security.