### PR TITLE
test: stabilize flaky Windows CI (RUSH-1746)

### DIFF
--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -630,7 +630,9 @@ describe('routines subcommand --help documents --host and --device once each', (
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }
-  }, 30_000);
+    // ~15 subcommands, each a cold `node --import tsx` boot; Windows subprocess
+    // spawn is slow enough to tip the aggregate over the 30s global timeout.
+  }, 90_000);
 });
 
 describe('routines run --host SELF follows the normal local eligibility path', () => {

--- a/apps/cli/src/lib/__tests__/runner.test.ts
+++ b/apps/cli/src/lib/__tests__/runner.test.ts
@@ -157,10 +157,16 @@ describe('executeJobDetached — spawn error handling', () => {
       const meta = await executeJobDetached(config);
       expect(meta.status).toBe('running');
 
-      // Give the async error event time to fire and rewrite meta.json.
-      await new Promise<void>((r) => setTimeout(r, 300));
+      // The spawn error event is async and rewrites meta.json off the event
+      // loop. A fixed sleep flakes on slow Windows CI (the event lands after
+      // the window); poll for the terminal state up to 10s instead.
+      let updated = readRunMeta(config.name, meta.runId);
+      const deadline = Date.now() + 10_000;
+      while ((updated?.status ?? 'running') === 'running' && Date.now() < deadline) {
+        await new Promise<void>((r) => setTimeout(r, 50));
+        updated = readRunMeta(config.name, meta.runId);
+      }
 
-      const updated = readRunMeta(config.name, meta.runId);
       expect(updated).not.toBeNull();
       expect(updated!.status).toBe('failed');
       expect(updated!.exitCode).toBe(1);


### PR DESCRIPTION
Closes RUSH-1746.

Windows CI is broadly flaky and fails the fail-closed release gate with different unrelated tests each run — none tied to the change under release (the 1.20.64 release needed rerun-gambling). Two genuine timing flakes fixed:

## 1. `runner.test.ts` — spawn-error test (`src/lib/__tests__/runner.test.ts`)
The `executeJobDetached` spawn-error handler rewrites `meta.json` from an async `error` event off the event loop. The test waited a **fixed 300ms** for that — too short on slow Windows subprocess spawn, so `status` was still `running` when asserted ("spawn blew up" symptom). Now **polls** for the terminal state up to 10s (50ms interval).

## 2. `routines.test.ts` — `--help` matrix (`src/commands/routines.test.ts`)
"derives every direct command from routines --help" spawns `agents <sub> --help` for ~15 subcommands, each a **cold `node --import tsx` boot**. Aggregate is 18s on macOS; Windows subprocess spawn tips it past the 30s global timeout. Bumped this test's budget to **90s**.

## On the reported "usage.test.ts 429"
Misattribution. That string (`API request failed: 429 Too Many Requests`) is a **deliberate fake-binary fixture in `rotate.test.ts`** exercising the rate-limit cascade. `usage.test.ts` stubs `globalThis.fetch` and hits no real endpoint — nothing to fix there.

## Verification (macOS, this branch)
```
runner.test.ts      18 passed (18)
routines.test.ts    25 passed (25)   Duration 18.04s
```
Test-only change (changelog-exempt).

Session transcript (private repo): available on zion at `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/de6d2a9f-a694-4a31-bd6c-09c6780dd381.jsonl`