### PR TITLE
fix(daemon): self-heal secrets broker when a deferred standalone dies (RUSH-1817)

### DIFF
--- a/apps/cli/src/lib/daemon.test.ts
+++ b/apps/cli/src/lib/daemon.test.ts
@@ -33,6 +33,7 @@ import {
   readDaemonPid,
   writeDaemonPid,
   removeDaemonPid,
+  shouldTakeOverBroker,
 } from './daemon.js';
 import { ipcEndpoint } from './platform/index.js';
 
@@ -665,5 +666,25 @@ describe('ensureDaemonStarted (#415: always-on beyond routines)', () => {
 
     // The pid file still points at the single owning process throughout.
     expect(readDaemonPid()).toBe(process.pid);
+  });
+});
+
+describe('shouldTakeOverBroker (RUSH-1817: daemon self-heals a dead standalone)', () => {
+  it('takes over ONLY when not hosting and no healthy broker answers', () => {
+    // The regression that wedged secrets on zion: the daemon deferred to a
+    // standalone at startup (not hosting) and that standalone later died
+    // (unreachable) — the one state where self-heal must fire.
+    expect(shouldTakeOverBroker(false, false)).toBe(true);
+  });
+
+  it('never takes over while the daemon is already hosting', () => {
+    // Our in-process broker is alive as long as the daemon is; re-hosting would
+    // fight our own socket. True regardless of the ping result.
+    expect(shouldTakeOverBroker(true, false)).toBe(false);
+    expect(shouldTakeOverBroker(true, true)).toBe(false);
+  });
+
+  it('never clobbers a reachable (healthy) standalone broker', () => {
+    expect(shouldTakeOverBroker(false, true)).toBe(false);
   });
 });

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -42,6 +42,18 @@ const WEDGE_THRESHOLD_TICKS = 3;
 const DAEMON_OAUTH_BUNDLE = 'claude';
 const DAEMON_OAUTH_KEY = 'CLAUDE_CODE_OAUTH_TOKEN';
 
+/**
+ * RUSH-1817: decide whether the daemon should (re)take over hosting the secrets
+ * broker. The startup host decision is one-shot; this drives the periodic
+ * self-heal re-check. Take over ONLY when the daemon is not already hosting AND
+ * no healthy broker answers a ping — i.e. a standalone the daemon deferred to at
+ * start has since died or crash-looped. Never take over while our in-process
+ * broker is hosting, and never clobber a reachable (healthy) broker.
+ */
+export function shouldTakeOverBroker(isHosting: boolean, brokerReachable: boolean): boolean {
+  return !isHosting && !brokerReachable;
+}
+
 function getDaemonDir(): string {
   const dir = getDaemonDirRoot();
   fs.mkdirSync(dir, { recursive: true });
@@ -637,6 +649,34 @@ export async function runDaemon(): Promise<void> {
   const fleetCacheInterval = setInterval(() => { void runFleetCacheWarm(); }, 3 * 60_000);
   const fleetCacheKickoff = setTimeout(() => { void runFleetCacheWarm(); }, 60_000);
 
+  // RUSH-1817: the startup host decision above is one-shot. If a standalone
+  // broker answered agentPing() at daemon start, the daemon declined to host —
+  // but should that standalone later die or crash-loop, nothing takes over and
+  // every `agents secrets unlock|export|start` fails until a manual restart
+  // (this wedged all keychain-backed secrets on zion and blocked a release).
+  // Re-probe on a cadence: whenever the daemon is NOT itself hosting AND no
+  // healthy broker answers a ping, take over hosting. startHostedBroker binds
+  // the socket only when it is free, so a take-over never races a live broker.
+  let selfHealingBroker = false;
+  const runBrokerSelfHeal = async () => {
+    if (selfHealingBroker) return;
+    selfHealingBroker = true;
+    try {
+      const { agentPing, startHostedBroker } = await import('./secrets/agent.js');
+      const reachable = (await agentPing()).reachable;
+      if (!shouldTakeOverBroker(hostedBroker != null, reachable)) return;
+      hostedBroker = await startHostedBroker();
+      if (hostedBroker) {
+        log('WARN', 'Secrets broker was unreachable; daemon took over hosting (self-heal)');
+      }
+    } catch (err) {
+      log('WARN', `Secrets broker self-heal skipped: ${(err as Error).message}`);
+    } finally {
+      selfHealingBroker = false;
+    }
+  };
+  const brokerSelfHealInterval = setInterval(() => { void runBrokerSelfHeal(); }, 60_000);
+
   const handleReload = () => {
     log('INFO', 'Reloading jobs (SIGHUP)');
     scheduler.reloadAll();
@@ -671,6 +711,7 @@ export async function runDaemon(): Promise<void> {
     clearTimeout(launchHealthKickoff);
     clearInterval(fleetCacheInterval);
     clearTimeout(fleetCacheKickoff);
+    clearInterval(brokerSelfHealInterval);
     hostedBroker?.close();
     removeDaemonPid();
     removeHeartbeat();


### PR DESCRIPTION
Closes RUSH-1817.

## The bug
The daemon hosts the secrets broker socket-first, but **only when no broker is already reachable at startup** (`daemon.ts` — `if ((await agentPing()).reachable) … not hosting it`). That decision is **one-shot**. If a standalone broker answered the ping at daemon-start, the daemon logged `Secrets broker already running (standalone); daemon not hosting it` and never re-checked. When that standalone later died / crash-looped, nothing took over — every `agents secrets unlock|export|start` failed with `Could not start the secrets broker` until a manual `secrets stop` + `launchctl kickstart`. This wedged all keychain-backed secrets on zion and blocked a release (2026-07-18).

`agentPing()` is already a real health probe (sends `ping`, checks `ok` + `cmd` + `PROTOCOL_VERSION`), so the defect is purely the **missing periodic re-check**, not a fake-liveness signal.

## The fix
A periodic (60s) health-gated self-heal in the daemon's existing interval loop (beside `syncInterval`, `healInterval`, etc.), cleared on shutdown like the others:

- When the daemon is **not** itself hosting **and** no healthy broker answers a ping → take over via `startHostedBroker()`.
- `startHostedBroker` binds the socket only when it is free (existing behavior, covered by `agent.test.ts` "never clobbers a live broker" + "takes over after the hosted broker stops"), so a take-over never races a live broker.
- The decision is factored into `shouldTakeOverBroker(isHosting, reachable)` and covered by a **truth-table test** so a future condition inversion can't silently re-open the outage.

## Scope
Per the ticket: *"the daemon should self-heal regardless of why a standalone is unhealthy."* The upstream trigger (a Hermes-node install spawning the standalone as `node <compiled-binary>`) is already handled by `getCliLaunch` resolving the bun standalone entry (documented at `agent.ts:195-204`). Any residual spawn-resolution hardening is a separable follow-up, not this PR.

## Verification (this branch)
```
tsc --noEmit               clean
daemon.test.ts             41 passed (incl. 3 new shouldTakeOverBroker cases)
secrets/agent.test.ts      42 passed (broker lifecycle unaffected)
```
Bug fix (changelog-exempt; changelog is auto-generated from the `fix:` commit).

**Rollout note:** live end-to-end validation (kill the running daemon's broker, watch it re-host within 60s) means disrupting the live secrets daemon on a real machine — best done deliberately at deploy, not folded into this PR.

Session transcript (private repo): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/de6d2a9f-a694-4a31-bd6c-09c6780dd381.jsonl`