### PR TITLE
ci(tests): smoke-test the compiled standalone binary

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,3 +85,41 @@ jobs:
             echo "::error::one or more test shards failed"; exit 1
           fi
           echo "typecheck + all shards green"
+
+  # Smoke-test the COMPILED standalone binary (`bun build --compile`), which the
+  # vitest suite never exercises: on the Bun standalone, process.argv[1] /
+  # process.execPath are the virtual embedded entry (/$bunfs/root/agents), not a
+  # real path -- so an argv-shape regression (e.g. the ssh askpass shim) can pass
+  # every unit test yet break the shipped binary. Build it on Linux and confirm it
+  # actually runs. NOT wired into the required `test` aggregate -- this is a
+  # standalone, non-required check for now; promote it once it has proven stable.
+  compiled-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: apps/cli
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-cache-${{ runner.os }}-${{ hashFiles('apps/cli/bun.lock') }}
+          restore-keys: bun-cache-${{ runner.os }}-
+      - run: bun install --frozen-lockfile
+      - name: Build the standalone binary
+        run: bash scripts/build-bin.sh
+      - name: Run the compiled binary (argv/execPath must resolve on /$bunfs)
+        run: |
+          set -euo pipefail
+          ver=$(./dist/bin/agents --version)
+          echo "compiled binary version: $ver"
+          [ -n "$ver" ] || { echo "::error::--version produced no output"; exit 1; }
+          # Exercises command routing on the standalone (the class of bug that only
+          # surfaces on the compiled binary, e.g. 'unknown command /$bunfs/...').
+          ./dist/bin/agents --help >/dev/null
+          echo "compiled binary runs: version + help OK"


### PR DESCRIPTION
## What & why

Deferred item 1 from the agents-cli session audit ([muqsitnawaz/.agents #119](https://github.com/muqsitnawaz/.agents/pull/119)).

The askpass fix itself already shipped and is unit-tested (`buildAskpassShimBody` / `getCliLaunch`, `connect.test.ts`, `cli-entry.test.ts`). But those tests inject a synthetic `/$bunfs/root/agents` argument — **they never run inside a real compiled binary**. On the Bun standalone (`bun build --compile`), `process.argv[1]` / `process.execPath` are the virtual embedded entry, not a real path, so an argv-shape regression can pass every unit test yet break the shipped binary. That exact class of bug reached a user once (the ssh askpass shim died with `unknown command '/$bunfs/root/agents'`).

## The change

New standalone `compiled-smoke` job in `tests.yml`:
- Builds `dist/bin/agents` on Linux via `scripts/build-bin.sh` (one line: `bun build --compile`; no signing/notarization — those are macOS-only release steps, not needed to *run* the binary).
- Runs `./dist/bin/agents --version` and `--help` to prove argv/execPath resolution + command routing work on the compiled binary.

**Deliberately NOT wired into the required `test` aggregate** — the required-check context name `test` is load-bearing (branch protection + `scripts/release.sh` EXPECTED_CHECKS depend on it). This is a non-required check for now; promote to required once it has proven stable.

## Verification

Built locally (macOS): `build-bin.sh` compiles in ~250ms; `./dist/bin/agents --version` → `1.20.70`, `--help` → exit 0. This PR also dogfoods the job against itself in CI.
