### PR TITLE
feat(agi-cli): @phnx-labs/agi-cli front-brand alias package

### DIFF
--- a/packages/agi-cli/README.md
+++ b/packages/agi-cli/README.md
@@ -1,0 +1,25 @@
+# @phnx-labs/agi-cli
+
+**agi-cli — one CLI for every coding agent.** Your agents, your subscription, ten at once.
+
+This is the front-brand alias of [`@phnx-labs/agents-cli`](https://www.npmjs.com/package/@phnx-labs/agents-cli). Installing it gives you the exact same tool, exposed as three interchangeable commands: `agents`, `ag`, and `agi`.
+
+```bash
+curl -fsSL agi-cli.sh | sh
+# or
+npm install -g @phnx-labs/agi-cli
+```
+
+Then run any of:
+
+```bash
+agi --help
+ag --help
+agents --help
+```
+
+Run Claude Code, Codex, Gemini and every coding agent from one place — on the subscription you already pay for. Parallel teams, browser & desktop control, Touch ID secrets, routines, monitors.
+
+Docs and source: <https://agi-cli.sh> · <https://github.com/phnx-labs/agents-cli>
+
+Apache-2.0 © Phoenix Labs

--- a/packages/agi-cli/bin/cli.js
+++ b/packages/agi-cli/bin/cli.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+// agi-cli is the front-brand alias of @phnx-labs/agents-cli. The commands
+// `agents`, `ag`, and `agi` all resolve here and exec the exact same tool.
+//
+// We spawn the canonical entry as the process' main module (rather than
+// importing it in-process) so that any `argv[1]`-based main-module guard in
+// the canonical CLI fires correctly, regardless of how it was invoked.
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+// Resolve the canonical package's `.` export (ESM-only, so import.meta.resolve —
+// not require.resolve, whose subpath/require condition the exports map blocks).
+const entry = fileURLToPath(import.meta.resolve("@phnx-labs/agents-cli"));
+
+const result = spawnSync(process.execPath, [entry, ...process.argv.slice(2)], {
+  stdio: "inherit"
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);

--- a/packages/agi-cli/package.json
+++ b/packages/agi-cli/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@phnx-labs/agi-cli",
+  "version": "1.20.70",
+  "description": "agi-cli — one CLI for every coding agent. Front-brand alias of @phnx-labs/agents-cli; installs the same tool as agents, ag, and agi.",
+  "type": "module",
+  "bin": {
+    "agents": "bin/cli.js",
+    "ag": "bin/cli.js",
+    "agi": "bin/cli.js"
+  },
+  "dependencies": {
+    "@phnx-labs/agents-cli": "^1.20.70"
+  },
+  "files": [
+    "bin/**",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "keywords": [
+    "agi-cli",
+    "agents-cli",
+    "coding agent",
+    "claude code",
+    "codex",
+    "gemini cli",
+    "cli"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/phnx-labs/agents-cli.git",
+    "directory": "packages/agi-cli"
+  },
+  "homepage": "https://agi-cli.sh",
+  "bugs": {
+    "url": "https://github.com/phnx-labs/agents-cli/issues"
+  }
+}

--- a/packages/agi-cli/package.json
+++ b/packages/agi-cli/package.json
@@ -16,7 +16,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.5.0"
   },
   "keywords": [
     "agi-cli",


### PR DESCRIPTION
## What
New `packages/agi-cli` → publishes **`@phnx-labs/agi-cli`**, the front-brand alias of `@phnx-labs/agents-cli`. Installing it exposes the same tool as three interchangeable commands: **`agents`, `ag`, `agi`**.

## How
- Depends on `@phnx-labs/agents-cli` (`^1.20.70`) → every install of the alias folds download credit into the canonical package.
- Bin stub re-execs the canonical entry via `spawnSync`, locating it with `import.meta.resolve` (the canonical `exports` is ESM-only and blocks `require.resolve` of the dist subpath — this was a real bug caught in testing).
- Reuses the established `packages/swarmify-mirror` alias pattern; inverts the messaging (agi-cli is the preferred front brand, not deprecated).

## Verified end-to-end
`npm pack` → isolated global install (`--prefix` mktemp, so it can't shadow the real `agents`) → `agi --version` / `ag --version` / `agents --version` all print `1.20.71`; `agi --help` runs the full CLI.

## Note
Publishing to npm happens alongside this (name is available).