### PR TITLE
fix(usage): stop the health probe from rotating Claude's OAuth token (RUSH-1822)

### DIFF
--- a/apps/cli/src/lib/usage.test.ts
+++ b/apps/cli/src/lib/usage.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+
+import { claudeAccessTokenNeedsRefresh } from './usage.js';
+
+const LEEWAY_MS = 5 * 60 * 1000;
+const NOW = 1_800_000_000_000; // fixed epoch ms so the tests are deterministic
+
+describe('claudeAccessTokenNeedsRefresh', () => {
+  it('treats a missing expiry as still-fresh (never force a refresh)', () => {
+    // A token with no known expiry must not trigger a refresh — that is what
+    // kept the health probe from rotating tokens with an unknown lifetime.
+    expect(claudeAccessTokenNeedsRefresh(null, NOW)).toBe(false);
+    expect(claudeAccessTokenNeedsRefresh(undefined, NOW)).toBe(false);
+  });
+
+  it('is false while the token is comfortably in the future', () => {
+    expect(claudeAccessTokenNeedsRefresh(NOW + LEEWAY_MS + 60_000, NOW)).toBe(false);
+  });
+
+  it('is true once the token is within the refresh leeway of expiry', () => {
+    // The stampede fix depends on this comparison direction: a near-expiry
+    // token reports `expired` from the probe (non-fatal) instead of refreshing.
+    expect(claudeAccessTokenNeedsRefresh(NOW + LEEWAY_MS - 1, NOW)).toBe(true);
+  });
+
+  it('is true exactly at the leeway boundary (>=, not >)', () => {
+    expect(claudeAccessTokenNeedsRefresh(NOW + LEEWAY_MS, NOW)).toBe(true);
+  });
+
+  it('is true for an already-expired token', () => {
+    expect(claudeAccessTokenNeedsRefresh(NOW - 60_000, NOW)).toBe(true);
+  });
+});

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -33,6 +33,25 @@ const CLAUDE_TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
 const CLAUDE_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 const CLAUDE_OAUTH_BETA_HEADER = 'oauth-2025-04-20';
 const CLAUDE_REFRESH_LEEWAY_MS = 5 * 60 * 1000;
+
+/**
+ * True when a Claude OAuth access token is within the refresh leeway of expiry
+ * (or already expired) — i.e. it "would need a refresh" before the next use.
+ *
+ * Single source of truth for the expiry gate, shared by the two callers that
+ * must agree on it but act differently: the run/usage hot path
+ * (`getClaudeAccessToken`) refreshes when this is true; the health probe
+ * (`probeClaudeStatus`) must NOT refresh and instead reports the non-fatal
+ * `expired` state (RUSH-1822). A missing `expiresAt` is treated as "still
+ * fresh" (never force a refresh on a token with no known expiry).
+ */
+export function claudeAccessTokenNeedsRefresh(
+  expiresAt: number | null | undefined,
+  nowMs: number = Date.now(),
+): boolean {
+  if (expiresAt == null) return false;
+  return nowMs + CLAUDE_REFRESH_LEEWAY_MS >= expiresAt;
+}
 const CLAUDE_SCOPES = [
   'user:profile',
   'user:inference',
@@ -887,21 +906,25 @@ export interface ProviderProbe {
 /** Probe Claude's OAuth token against the usage endpoint. Refreshes an expired access token (safe for Claude). */
 export async function probeClaudeStatus(home?: string, cliVersion?: string | null): Promise<ProviderProbe> {
   const oauth = await loadClaudeOauth(home);
-  if (!oauth?.accessToken) return { status: null, token: 'missing' };
-  let access: string | null = null;
-  try {
-    access = await getClaudeAccessToken(oauth, home);
-  } catch {
-    access = null;
+  const accessToken = oauth?.accessToken?.trim();
+  if (!accessToken) return { status: null, token: 'missing' };
+  // Never refresh from a health probe. Claude's refresh token is single-use and
+  // rotates on every refresh; with one account signed into several machines the
+  // daemon's every-3-min fleet-cache warm (probeLocalFleetAuth -> here) would
+  // stampede that one rotating token and silently invalidate every other
+  // holder, dropping the fleet to "run /login" (RUSH-1822). Mirror the sibling
+  // Kimi/Droid probes, which never refresh: if the stored token is within the
+  // refresh leeway of expiry, report the non-fatal `expired` state ("would need
+  // a refresh") instead of rotating it, and leave the single legitimate refresh
+  // to the run/usage hot path (getClaudeAccessToken).
+  if (claudeAccessTokenNeedsRefresh(oauth?.expiresAt ?? null)) {
+    return { status: null, token: 'expired' };
   }
-  // Fall back to the stored (possibly stale) token so the server returns the
-  // real verdict — a 401 here IS the revoked/expired signal we want to surface.
-  const bearer = access || oauth.accessToken.trim();
   try {
     const response = await fetch(CLAUDE_USAGE_URL, {
       method: 'GET',
       headers: {
-        Authorization: `Bearer ${bearer}`,
+        Authorization: `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
         'anthropic-beta': CLAUDE_OAUTH_BETA_HEADER,
         'User-Agent': getClaudeUserAgent(cliVersion),
@@ -1390,8 +1413,7 @@ async function getClaudeAccessToken(oauth: ClaudeOauthCredentials, home?: string
     return null;
   }
 
-  const expiresAt = oauth.expiresAt ?? null;
-  if (expiresAt === null || Date.now() + CLAUDE_REFRESH_LEEWAY_MS < expiresAt) {
+  if (!claudeAccessTokenNeedsRefresh(oauth.expiresAt ?? null)) {
     return accessToken;
   }
 

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -903,7 +903,7 @@ export interface ProviderProbe {
   error?: string;
 }
 
-/** Probe Claude's OAuth token against the usage endpoint. Refreshes an expired access token (safe for Claude). */
+/** Probe Claude's OAuth token against the usage endpoint. Never refreshes — reports `expired` for a near-expiry token; see the comment below (RUSH-1822). */
 export async function probeClaudeStatus(home?: string, cliVersion?: string | null): Promise<ProviderProbe> {
   const oauth = await loadClaudeOauth(home);
   const accessToken = oauth?.accessToken?.trim();


### PR DESCRIPTION
## Problem (RUSH-1822)

Claude repeatedly drops to **"Not logged in / run /login"** across the fleet. Root cause: Claude's OAuth **refresh token rotates** (each refresh invalidates the prior one), and agents-cli refreshes it from multiple places on every box. The **dominant amplifier** is the daemon's fleet-cache warm — every ~3 min, every box, unconditionally:

```
daemon runFleetCacheWarm -> probeLocalFleetAuth -> probeAuthHealth
  -> probeClaudeStatus -> getClaudeAccessToken -> refreshClaudeToken   ← rotates the token
```

With one account signed into 3–4 machines, these refreshers stampede one rotating token: first-to-refresh wins, every other holder's stored token is silently invalidated → next refresh 401 → verdict `revoked` → `/login`. A health *probe* has no business rotating the auth token.

## Fix (ticket's fix #1 — "the biggest win, pure agents-cli")

Make `probeClaudeStatus` **never refresh**, matching its sibling probes `probeKimiStatus` / `probeDroidStatus` (both documented *"Never refreshes — single-use rotation"*). If the stored access token is within the refresh leeway of expiry, the probe now returns the **already-modelled, non-fatal `expired` verdict** ("would need a refresh") instead of rotating the token. The single legitimate refresh stays on the run/usage hot path (`getClaudeUsageInfo -> getClaudeAccessToken`), untouched.

Extracted `claudeAccessTokenNeedsRefresh()` as the one shared expiry gate so the probe and the run path can't drift apart.

## Why this is the right shape, not a band-aid

- It removes a refresher that was **duplicating** the run path's job — the probe already fell back to the stored token and treated 401 as the real verdict, so refreshing inside it was always redundant.
- It makes Claude's probe **consistent** with Kimi's and Droid's (which already never refresh), rather than special-casing one provider.
- `token: 'expired'` → verdict `expired` is a pre-existing, distinct, non-fatal state (separate from `revoked`) — no new state machine.

## Test

`apps/cli/src/lib/usage.test.ts` — pure, no-mock unit test of the leeway boundary (`>=`, not `>`; missing-expiry → never refresh; already-expired → refresh). An off-by-one there silently re-arms the stampede.

```
Test Files  2 passed (auth-health + usage)
     Tests  31 passed
tsc --noEmit: exit 0
```

## Scope

This lands fix #1 (the dominant every-3-min-per-box stampede). The ticket's hardening follow-ups (#2 single-writer refresh lock, #3 discourage one identity across machines, #4 tolerate a rotated-out token) are separate, lower-amplitude refreshers — tracked as follow-up, not in this PR.