### PR TITLE
feat(permissions): wire allowlist support for ForgeCode and Hermes (RUSH-1748, RUSH-1749)

### DIFF
--- a/apps/cli/.changelog/next/allowlist-forge-hermes.md
+++ b/apps/cli/.changelog/next/allowlist-forge-hermes.md
@@ -1,0 +1,12 @@
+- **Wire allowlist support for ForgeCode and Hermes.** Both agents now declare
+  `allowlist: true` and canonical permissions are translated into each agent's
+  native policy file. For **forge**, `~/.forge/permissions.yaml` (or
+  `$FORGE_CONFIG/permissions.yaml`) is written as an ordered `policies` list keyed
+  by operation family (`read`/`write`/`command`/`url`) with glob patterns — active
+  only when `.forge.toml` sets `restricted = true`, and MCP tools bypass the file,
+  so only built-in-tool allow/deny rules are mapped. For **hermes**,
+  `~/.hermes/config.yaml` gets `command_allowlist` (always-approved command globs)
+  and `approvals.deny` (unconditional blocks) — command-glob only, since Hermes has
+  no unified per-tool table. Both writers support merge mode (union + dedupe against
+  existing config). Source: `apps/cli/src/lib/permissions.ts`
+  (`convertToForgeFormat`, `convertToHermesFormat`), `apps/cli/src/lib/agents.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## 1.20.70
 
+- **Wire allowlist support for ForgeCode.** `forge` now declares `allowlist: true`
+  and canonical permissions are written to `~/.forge/permissions.yaml` (or
+  `$FORGE_CONFIG/permissions.yaml`) as an ordered `policies` list keyed by
+  operation family (`read`/`write`/`command`/`url`) with glob patterns. The file is
+  only active when `.forge.toml` sets `restricted = true`, and MCP tools bypass it —
+  so only built-in-tool allow/deny rules are mapped. Source:
+  `apps/cli/src/lib/permissions.ts` (`convertToForgeFormat`), `apps/cli/src/lib/agents.ts`.
+
+- **Wire allowlist support for Hermes.** `hermes` now declares `allowlist: true` and
+  canonical command permissions are written to `~/.hermes/config.yaml` as
+  `command_allowlist` (always-approved command globs) and `approvals.deny`
+  (unconditional command blocks). It is command-glob only — Hermes has no unified
+  per-tool table — so non-command canonical rules are skipped. Source:
+  `apps/cli/src/lib/permissions.ts` (`convertToHermesFormat`), `apps/cli/src/lib/agents.ts`.
+
 - **Fix `agents setup computer` / `agents computer setup` refusing to install a
   valid downloaded helper.** The signature check read `codesign -dv` from stdout,
   but that command writes its details to **stderr** on success — so the Team-ID

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,21 +2,6 @@
 
 ## 1.20.70
 
-- **Wire allowlist support for ForgeCode.** `forge` now declares `allowlist: true`
-  and canonical permissions are written to `~/.forge/permissions.yaml` (or
-  `$FORGE_CONFIG/permissions.yaml`) as an ordered `policies` list keyed by
-  operation family (`read`/`write`/`command`/`url`) with glob patterns. The file is
-  only active when `.forge.toml` sets `restricted = true`, and MCP tools bypass it —
-  so only built-in-tool allow/deny rules are mapped. Source:
-  `apps/cli/src/lib/permissions.ts` (`convertToForgeFormat`), `apps/cli/src/lib/agents.ts`.
-
-- **Wire allowlist support for Hermes.** `hermes` now declares `allowlist: true` and
-  canonical command permissions are written to `~/.hermes/config.yaml` as
-  `command_allowlist` (always-approved command globs) and `approvals.deny`
-  (unconditional command blocks). It is command-glob only — Hermes has no unified
-  per-tool table — so non-command canonical rules are skipped. Source:
-  `apps/cli/src/lib/permissions.ts` (`convertToHermesFormat`), `apps/cli/src/lib/agents.ts`.
-
 - **Fix `agents setup computer` / `agents computer setup` refusing to install a
   valid downloaded helper.** The signature check read `codesign -dv` from stdout,
   but that command writes its details to **stderr** on success — so the Team-ID

--- a/apps/cli/docs/00-concepts.md
+++ b/apps/cli/docs/00-concepts.md
@@ -161,16 +161,20 @@ contract.
 | Grok | yes | yes | yes | yes | skills ($name) | yes | no | `AGENTS.md` | no |
 | Kimi | yes | yes | yes | yes | no | yes | yes | `AGENTS.md` | yes |
 | Droid | yes | yes | >= 0.57.5 | >= 0.26.0 | yes | yes | yes | `AGENTS.md` | no |
-| Hermes | no | yes | no | yes | no | yes | no | `MEMORY.md` | no |
-| ForgeCode | no | yes | no | yes | yes | no | yes | `AGENTS.md` | no |
+| Hermes | no | yes | yes | yes | no | yes | no | `MEMORY.md` | no |
+| ForgeCode | no | yes | yes | yes | yes | no | yes | `AGENTS.md` | no |
 
 **† Gemini is deprecated.** Google retired the Gemini CLI for free/Pro/Ultra tiers on June 18, 2026 (announced at Google I/O 2026); Antigravity CLI (`antigravity`) is the successor. agents-cli still manages existing Gemini installs but warns on `agents add gemini` / `agents teams add … gemini`.
 
-Permissions sync is gated on the `allowlist` capability (Claude, Codex >= 0.138.0, Gemini, Cursor, OpenCode >= 1.1.1, Antigravity, Grok, Kimi, Kiro 2.8.0+, Goose, Droid >= 0.57.5, and OpenClaw). Workflow sync writes Claude workflow bundles, Kimi `type: flow` skills with an `agents_workflow` ownership marker, Goose recipe YAML, and Antigravity workflow markdown (since 1.0.6). Antigravity workflows are the one non-version-isolated target: `agy` scans a single shared `~/.gemini/config/global_workflows/` at startup (a real HOME directory, never symlinked per version), so agents-cli writes there once for all installed antigravity versions and reads it back the same way — the `agents_workflow` marker guards user-authored files from being overwritten or removed. **Host CLIs** (`agents cli`) are agent-agnostic PATH binaries — not in this matrix. Install paths call `supports(agent, cap, version)` before writing; gated capabilities skip with a clear reason instead of silently ignored config.
+Permissions sync is gated on the `allowlist` capability (Claude, Codex >= 0.138.0, Gemini, Cursor, OpenCode >= 1.1.1, Antigravity, Grok, Kimi, Kiro 2.8.0+, Goose, Droid >= 0.57.5, OpenClaw, Hermes, and ForgeCode). Workflow sync writes Claude workflow bundles, Kimi `type: flow` skills with an `agents_workflow` ownership marker, Goose recipe YAML, and Antigravity workflow markdown (since 1.0.6). Antigravity workflows are the one non-version-isolated target: `agy` scans a single shared `~/.gemini/config/global_workflows/` at startup (a real HOME directory, never symlinked per version), so agents-cli writes there once for all installed antigravity versions and reads it back the same way — the `agents_workflow` marker guards user-authored files from being overwritten or removed. **Host CLIs** (`agents cli`) are agent-agnostic PATH binaries — not in this matrix. Install paths call `supports(agent, cap, version)` before writing; gated capabilities skip with a clear reason instead of silently ignored config.
 
 Gemini permission sync maps canonical Bash rules to its native `ShellTool(...)` entries under `tools.core` / `tools.exclude`. Other canonical permission tools are not representable in Gemini's native allowlist grammar and are skipped.
 
 OpenClaw gates at tool granularity only, so permission sync maps just **blanket** (whole-tool) rules to `~/.openclaw/openclaw.json` `tools.alsoAllow` (allow) / `tools.deny` (deny): `bash → exec`, `read → read`, `write`/`edit → write`, `webfetch → web_fetch`, `websearch → web_search`. Sub-command/path/domain rules (`Bash(git:*)`, `Write(secrets/**)`, `WebFetch(domain:x)`) have no tool-level equivalent and are skipped. The absolute `tools.allow` list is never touched.
+
+Hermes permission sync maps canonical Bash allow rules to `~/.hermes/config.yaml` `command_allowlist` and Bash deny rules to `approvals.deny`. Hermes stores command globs only; session-scoped `/tools` toggles are not config-persistent and are not written.
+
+ForgeCode permission sync writes `~/.forge/permissions.yaml` policies by operation family: `bash → command`, `read`/`grep`/`glob → read`, `write`/`edit → write`, and web rules to `url`. Forge only reads that file when `.forge.toml` has `restricted = true`; MCP tools bypass `permissions.yaml` entirely.
 
 ### Per-command targeting
 

--- a/apps/cli/docs/02-resource-sync.md
+++ b/apps/cli/docs/02-resource-sync.md
@@ -221,6 +221,14 @@ Per-agent conversion is lossy in both directions:
   rules (`Bash(git:*)`, `Write(secrets/**)`, `WebFetch(domain:x)`) have no
   tool-level equivalent and are skipped. The absolute `tools.allow` list is
   never touched, and all other keys (`mcp`, `exec`, `agents`, …) are preserved.
+- Hermes maps canonical Bash allow rules to `~/.hermes/config.yaml`
+  `command_allowlist` and Bash deny rules to `approvals.deny`, preserving
+  sibling YAML keys like `mcp_servers` and `hooks`. Hermes has command-glob
+  persistence only; session-scoped `/tools` toggles are not written.
+- ForgeCode maps canonical built-in tool rules to `~/.forge/permissions.yaml`
+  policies by operation family (`read`, `write`, `command`, `url`). The file is
+  active only when `.forge.toml` has `restricted = true`; MCP tools bypass this
+  policy file entirely, so per-named-MCP-tool grants are skipped.
 
 ## Plugins: Synthetic Marketplace + Exec-Surface Gate
 

--- a/apps/cli/src/lib/__tests__/capabilities.test.ts
+++ b/apps/cli/src/lib/__tests__/capabilities.test.ts
@@ -130,6 +130,20 @@ describe('openclaw allowlist', () => {
   });
 });
 
+describe('forge allowlist', () => {
+  it('is capable of allowlist', () => {
+    expect(supports('forge', 'allowlist')).toEqual({ ok: true });
+    expect(capableAgents('allowlist')).toContain('forge');
+  });
+});
+
+describe('hermes allowlist', () => {
+  it('is capable of allowlist', () => {
+    expect(supports('hermes', 'allowlist')).toEqual({ ok: true });
+    expect(capableAgents('allowlist')).toContain('hermes');
+  });
+});
+
 describe('unsupported agents skip regardless of version', () => {
   it('cursor hooks are supported', () => {
     expect(supports('cursor', 'hooks').ok).toBe(true);

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -673,7 +673,11 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
       mcp: true,
       mcpHttp: true,
       mcpHeaders: false,
-      allowlist: false,
+      // Permissions: ~/.hermes/config.yaml carries `command_allowlist` for
+      // always-approved command globs and `approvals.deny` for unconditional
+      // command blocks. It is command-glob only; session `/tools` toggles are
+      // intentionally not persisted by agents-cli.
+      allowlist: true,
       skills: true,
       commands: false,
       plugins: true,
@@ -714,7 +718,10 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
       mcp: true,
       mcpHttp: true,
       mcpHeaders: false,
-      allowlist: false,
+      // Permissions: ~/.forge/permissions.yaml (or $FORGE_CONFIG/permissions.yaml)
+      // carries ordered operation-family glob policies. It is active only when
+      // `.forge.toml` sets `restricted = true`; MCP tools bypass this file.
+      allowlist: true,
       skills: true,
       commands: true,
       plugins: false,

--- a/apps/cli/src/lib/permissions.test.ts
+++ b/apps/cli/src/lib/permissions.test.ts
@@ -12,6 +12,8 @@ import {
   convertDenyToCodexRules,
   convertToKimiFormat,
   convertToDroidFormat,
+  convertToForgeFormat,
+  convertToHermesFormat,
   convertToOpenClawFormat,
   convertToGooseFormat,
   convertToKiroFormat,
@@ -127,6 +129,90 @@ describe('OpenClaw permissions', () => {
     const written = JSON.parse(fs.readFileSync(path.join(configDir, 'openclaw.json'), 'utf-8'));
     expect(written.tools.allow).toEqual(['read']);
     expect(written.tools.alsoAllow).toEqual(['exec']);
+  });
+});
+
+describe('Forge permissions', () => {
+  it('maps canonical rules to operation-family policies', () => {
+    expect(convertToForgeFormat({
+      name: 'forge',
+      allow: ['Bash(git:*)', 'Read(**)', 'Write(src/**)', 'WebFetch(domain:api.github.com)'],
+      deny: ['Bash(rm -rf:*)', 'Edit(secrets/**)', 'MCP(mcp__server__tool)'],
+    })).toEqual({
+      policies: [
+        { permission: 'allow', rule: { command: 'git *' } },
+        { permission: 'allow', rule: { read: '**/*' } },
+        { permission: 'allow', rule: { write: 'src/**' } },
+        { permission: 'allow', rule: { url: 'api.github.com*' } },
+        { permission: 'deny', rule: { command: 'rm -rf *' } },
+        { permission: 'deny', rule: { write: 'secrets/**' } },
+      ],
+    });
+  });
+
+  it('writes and merges permissions.yaml without replacing user policies', () => {
+    const home = makeTempHome();
+    const configDir = path.join(home, '.forge');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'permissions.yaml'), yaml.stringify({
+      policies: [
+        { permission: 'confirm', rule: { write: '**/*' } },
+      ],
+    }));
+
+    expect(applyPermissionsToVersion('forge', {
+      name: 'set',
+      allow: ['Bash(git:*)'],
+      deny: ['Write(secrets/**)'],
+    }, home, true)).toEqual({ success: true });
+
+    const written = yaml.parse(fs.readFileSync(path.join(configDir, 'permissions.yaml'), 'utf-8'));
+    expect(written).toEqual({
+      policies: [
+        { permission: 'confirm', rule: { write: '**/*' } },
+        { permission: 'allow', rule: { command: 'git *' } },
+        { permission: 'deny', rule: { write: 'secrets/**' } },
+      ],
+    });
+  });
+});
+
+describe('Hermes permissions', () => {
+  it('maps only canonical Bash rules to command allow and deny globs', () => {
+    expect(convertToHermesFormat({
+      name: 'hermes',
+      allow: ['Bash(git:*)', 'Bash(pwd)', 'Read(**)'],
+      deny: ['Bash(rm -rf:*)', 'Write(**)'],
+    })).toEqual({
+      command_allowlist: ['git *', 'pwd'],
+      approvals: { deny: ['rm -rf *'] },
+    });
+  });
+
+  it('writes and merges config.yaml without replacing mcp servers or hooks', () => {
+    const home = makeTempHome();
+    const configDir = path.join(home, '.hermes');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'config.yaml'), yaml.stringify({
+      mcp_servers: { docs: { command: 'docs' } },
+      hooks: { pre_tool: ['echo hook'] },
+      approvals: { mode: 'manual', deny: ['git push --force*'] },
+      command_allowlist: ['ls'],
+    }));
+
+    expect(applyPermissionsToVersion('hermes', {
+      name: 'set',
+      allow: ['Bash(git status)'],
+      deny: ['Bash(rm -rf:*)'],
+    }, home, true)).toEqual({ success: true });
+
+    const written = yaml.parse(fs.readFileSync(path.join(configDir, 'config.yaml'), 'utf-8'));
+    expect(written).toEqual({
+      mcp_servers: { docs: { command: 'docs' } },
+      hooks: { pre_tool: ['echo hook'] },
+      approvals: { mode: 'manual', deny: ['git push --force*', 'rm -rf *'] },
+      command_allowlist: ['git status', 'ls'],
+    });
   });
 });
 

--- a/apps/cli/src/lib/permissions.ts
+++ b/apps/cli/src/lib/permissions.ts
@@ -676,6 +676,85 @@ export function convertToOpenClawFormat(set: PermissionSet): { alsoAllow: string
   };
 }
 
+export type ForgePermission = 'allow' | 'deny' | 'confirm';
+export type ForgeOperation = 'read' | 'write' | 'command' | 'url';
+export type ForgePolicy = { permission: ForgePermission; rule: Partial<Record<ForgeOperation, string>> };
+
+const FORGE_OPERATION_BY_CANONICAL: Record<string, ForgeOperation | undefined> = {
+  bash: 'command',
+  read: 'read',
+  grep: 'read',
+  glob: 'read',
+  write: 'write',
+  edit: 'write',
+  notebookedit: 'write',
+  webfetch: 'url',
+  websearch: 'url',
+};
+
+function canonicalToForgePolicy(perm: string, permission: ForgePermission): ForgePolicy | null {
+  if (BLANKET_BASH_FORMS.has(perm)) {
+    return { permission, rule: { command: '*' } };
+  }
+  const parsed = parseCanonicalPattern(perm);
+  if (!parsed) return null;
+  const operation = FORGE_OPERATION_BY_CANONICAL[parsed.tool];
+  if (!operation) return null;
+  const pattern = parsed.tool === 'bash'
+    ? normalizeBashPattern(parsed.pattern)
+    : (parsed.tool === 'webfetch' || parsed.tool === 'websearch') && parsed.pattern.startsWith('domain:')
+      ? `${parsed.pattern.slice('domain:'.length)}*`
+      : parsed.pattern === '**'
+        ? '**/*'
+        : parsed.pattern;
+  return { permission, rule: { [operation]: pattern } };
+}
+
+/**
+ * Convert canonical permissions to ForgeCode's permissions.yaml policy list.
+ *
+ * ForgeCode gates built-in tools by operation family (`read`, `write`,
+ * `command`, `url`) plus glob patterns, optionally scoped by `dir`. The policy
+ * file is ignored unless `.forge.toml` has `restricted = true`, and MCP tools
+ * bypass permissions.yaml entirely; agents-cli therefore maps only canonical
+ * built-in allow/deny rules and does not try to express per-named-MCP-tool
+ * grants.
+ */
+export function convertToForgeFormat(set: PermissionSet): { policies: ForgePolicy[] } {
+  const policies: ForgePolicy[] = [];
+  const seen = new Set<string>();
+  const add = (policy: ForgePolicy | null): void => {
+    if (!policy) return;
+    const key = `${policy.permission}|${JSON.stringify(policy.rule)}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    policies.push(policy);
+  };
+  for (const perm of set.allow) add(canonicalToForgePolicy(perm, 'allow'));
+  for (const perm of set.deny ?? []) add(canonicalToForgePolicy(perm, 'deny'));
+  return { policies };
+}
+
+export function convertToHermesFormat(set: PermissionSet): { command_allowlist: string[]; approvals: { deny: string[] } } {
+  const commands = (permissions: string[]): string[] => {
+    const out = new Set<string>();
+    for (const perm of permissions) {
+      if (BLANKET_BASH_FORMS.has(perm)) {
+        out.add('*');
+        continue;
+      }
+      const parsed = parseCanonicalPattern(perm);
+      if (parsed?.tool === 'bash') out.add(normalizeBashPattern(parsed.pattern));
+    }
+    return Array.from(out).sort();
+  };
+
+  return {
+    command_allowlist: commands(set.allow),
+    approvals: { deny: commands(set.deny ?? []) },
+  };
+}
+
 /**
  * Convert canonical permission set to Antigravity format.
  * Antigravity reads ~/.gemini/antigravity-cli/settings.json with
@@ -1841,6 +1920,67 @@ export function applyPermissionsToVersion(
 
       fs.mkdirSync(path.dirname(configPath), { recursive: true });
       fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
+      return { success: true };
+    }
+
+    if (agentId === 'forge') {
+      const permissionsPath = path.join(versionHome, '.forge', 'permissions.yaml');
+      let config: { policies?: unknown[] } = {};
+      if (fs.existsSync(permissionsPath)) {
+        const parsed = yaml.parse(fs.readFileSync(permissionsPath, 'utf-8'));
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          config = parsed as { policies?: unknown[] };
+        }
+      }
+
+      const newPolicies = convertToForgeFormat(set).policies;
+      if (merge) {
+        const existingPolicies = Array.isArray(config.policies) ? config.policies : [];
+        const seen = new Set<string>();
+        config.policies = [...existingPolicies, ...newPolicies].filter((policy) => {
+          if (!policy || typeof policy !== 'object' || Array.isArray(policy)) return false;
+          const key = JSON.stringify(policy);
+          if (seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
+      } else {
+        config.policies = newPolicies;
+      }
+
+      fs.mkdirSync(path.dirname(permissionsPath), { recursive: true });
+      fs.writeFileSync(permissionsPath, yaml.stringify(config), 'utf-8');
+      return { success: true };
+    }
+
+    if (agentId === 'hermes') {
+      const configPath = path.join(versionHome, '.hermes', 'config.yaml');
+      let config: Record<string, unknown> = {};
+      if (fs.existsSync(configPath)) {
+        const parsed = yaml.parse(fs.readFileSync(configPath, 'utf-8'));
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          config = parsed as Record<string, unknown>;
+        }
+      }
+
+      const converted = convertToHermesFormat(set);
+      const approvals = (typeof config.approvals === 'object' && config.approvals !== null && !Array.isArray(config.approvals))
+        ? config.approvals as Record<string, unknown>
+        : {};
+
+      if (merge) {
+        const existingAllow = Array.isArray(config.command_allowlist) ? config.command_allowlist as string[] : [];
+        const existingDeny = Array.isArray(approvals.deny) ? approvals.deny as string[] : [];
+        config.command_allowlist = Array.from(new Set([...existingAllow, ...converted.command_allowlist])).sort();
+        approvals.deny = Array.from(new Set([...existingDeny, ...converted.approvals.deny])).sort();
+      } else {
+        config.command_allowlist = converted.command_allowlist;
+        approvals.deny = converted.approvals.deny;
+      }
+
+      config.approvals = approvals;
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(configPath, yaml.stringify(config), 'utf-8');
       return { success: true };
     }
 

--- a/apps/cli/src/lib/resources/permissions.test.ts
+++ b/apps/cli/src/lib/resources/permissions.test.ts
@@ -346,6 +346,66 @@ describe('PermissionsHandler', () => {
       expect(settings.tools.deny).toEqual(['write']);
     });
 
+    it('merges all permissions and writes to ForgeCode permissions.yaml policies', () => {
+      const home = makeTempHome();
+      const versionHome = makeTempHome();
+
+      fs.mkdirSync(path.join(home, '.agents', '.system'), { recursive: true });
+      fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
+
+      writePermissionYaml(home, path.join('.agents', '.system'), 'base', {
+        name: 'base',
+        allow: ['Read(**)', 'Bash(git:*)'],
+      });
+
+      writePermissionYaml(home, '.agents', 'extra', {
+        name: 'extra',
+        allow: ['WebFetch(domain:api.github.com)'],
+        deny: ['Write(secrets/**)', 'Bash(rm -rf:*)'],
+      });
+
+      runPermissionsExpression(home, `PermissionsHandler.sync('forge', ${JSON.stringify(versionHome)})`);
+
+      const settingsPath = path.join(versionHome, '.forge', 'permissions.yaml');
+      expect(fs.existsSync(settingsPath)).toBe(true);
+
+      const settings = yaml.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      expect(settings.policies).toEqual([
+        { permission: 'allow', rule: { command: 'git *' } },
+        { permission: 'allow', rule: { read: '**/*' } },
+        { permission: 'allow', rule: { url: 'api.github.com*' } },
+        { permission: 'deny', rule: { command: 'rm -rf *' } },
+        { permission: 'deny', rule: { write: 'secrets/**' } },
+      ]);
+    });
+
+    it('merges all permissions and writes to Hermes config.yaml command allowlist and approvals deny', () => {
+      const home = makeTempHome();
+      const versionHome = makeTempHome();
+
+      fs.mkdirSync(path.join(home, '.agents', '.system'), { recursive: true });
+      fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
+
+      writePermissionYaml(home, path.join('.agents', '.system'), 'base', {
+        name: 'base',
+        allow: ['Bash(git:*)', 'Read(**)'],
+      });
+
+      writePermissionYaml(home, '.agents', 'extra', {
+        name: 'extra',
+        deny: ['Bash(rm -rf:*)', 'Write(secrets/**)'],
+      });
+
+      runPermissionsExpression(home, `PermissionsHandler.sync('hermes', ${JSON.stringify(versionHome)})`);
+
+      const settingsPath = path.join(versionHome, '.hermes', 'config.yaml');
+      expect(fs.existsSync(settingsPath)).toBe(true);
+
+      const settings = yaml.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      expect(settings.command_allowlist).toEqual(['git *']);
+      expect(settings.approvals.deny).toEqual(['rm -rf *']);
+    });
+
     it('skips non-permission-capable agents', () => {
       const home = makeTempHome();
       const versionHome = makeTempHome();
@@ -400,6 +460,16 @@ describe('PermissionsHandler', () => {
     it('returns correct path for OpenClaw', () => {
       const result = PermissionsHandler.configPath!('openclaw', '/test/home');
       expect(result).toBe(path.join('/test/home', '.openclaw', 'openclaw.json'));
+    });
+
+    it('returns correct path for ForgeCode', () => {
+      const result = PermissionsHandler.configPath!('forge', '/test/home');
+      expect(result).toBe(path.join('/test/home', '.forge', 'permissions.yaml'));
+    });
+
+    it('returns correct path for Hermes', () => {
+      const result = PermissionsHandler.configPath!('hermes', '/test/home');
+      expect(result).toBe(path.join('/test/home', '.hermes', 'config.yaml'));
     });
 
     it('returns correct path for Droid', () => {

--- a/apps/cli/src/lib/resources/permissions.ts
+++ b/apps/cli/src/lib/resources/permissions.ts
@@ -95,6 +95,10 @@ function getAgentConfigPath(agent: AgentId, versionHome: string): string | null 
       return path.join(versionHome, '.kiro', 'settings', 'permissions.yaml');
     case 'openclaw':
       return path.join(versionHome, '.openclaw', 'openclaw.json');
+    case 'forge':
+      return path.join(versionHome, '.forge', 'permissions.yaml');
+    case 'hermes':
+      return path.join(versionHome, '.hermes', 'config.yaml');
     case 'goose':
       return path.join(versionHome, '.config', 'goose', 'permission.yaml');
     default:

--- a/apps/cli/src/lib/staleness/detectors/permissions.ts
+++ b/apps/cli/src/lib/staleness/detectors/permissions.ts
@@ -286,6 +286,45 @@ function buildOpenClawDetector(): ResourceDetector {
   };
 }
 
+function buildForgeDetector(): ResourceDetector {
+  return {
+    kind: 'permissions',
+    agent: 'forge',
+    list({ versionHome }: DetectArgs): string[] {
+      const permissionsPath = path.join(versionHome, '.forge', 'permissions.yaml');
+      if (!fs.existsSync(permissionsPath)) return [];
+      try {
+        const config = yaml.parse(fs.readFileSync(permissionsPath, 'utf-8')) as { policies?: unknown[] } | null;
+        if (config && Array.isArray(config.policies) && config.policies.length > 0) {
+          return discoverPermissionGroups().map(g => g.name);
+        }
+      } catch { /* parse fail */ }
+      return [];
+    },
+  };
+}
+
+function buildHermesDetector(): ResourceDetector {
+  return {
+    kind: 'permissions',
+    agent: 'hermes',
+    list({ versionHome }: DetectArgs): string[] {
+      const configPath = path.join(versionHome, '.hermes', 'config.yaml');
+      if (!fs.existsSync(configPath)) return [];
+      try {
+        const config = yaml.parse(fs.readFileSync(configPath, 'utf-8')) as {
+          command_allowlist?: unknown[];
+          approvals?: { deny?: unknown[] };
+        } | null;
+        const hasAllow = Array.isArray(config?.command_allowlist) && config.command_allowlist.length > 0;
+        const hasDeny = Array.isArray(config?.approvals?.deny) && config.approvals.deny.length > 0;
+        if (hasAllow || hasDeny) return discoverPermissionGroups().map(g => g.name);
+      } catch { /* parse fail */ }
+      return [];
+    },
+  };
+}
+
 const handlers: Partial<Record<AgentId, () => ResourceDetector>> = {
   claude: buildClaudeDetector,
   codex: buildCodexDetector,
@@ -299,6 +338,8 @@ const handlers: Partial<Record<AgentId, () => ResourceDetector>> = {
   droid: buildDroidDetector,
   kiro: buildKiroDetector,
   openclaw: buildOpenClawDetector,
+  forge: buildForgeDetector,
+  hermes: buildHermesDetector,
 };
 
 export const permissionsDetectors = lazyAgentMap<ResourceDetector>(() => {

--- a/apps/cli/src/lib/staleness/registry.test.ts
+++ b/apps/cli/src/lib/staleness/registry.test.ts
@@ -106,6 +106,16 @@ describe('staleness/registry', () => {
     expect(DETECTORS.permissions.openclaw).toBeDefined();
   });
 
+  it('forge has a permissions writer + detector', () => {
+    expect(WRITERS.permissions.forge).toBeDefined();
+    expect(DETECTORS.permissions.forge).toBeDefined();
+  });
+
+  it('hermes has a permissions writer + detector', () => {
+    expect(WRITERS.permissions.hermes).toBeDefined();
+    expect(DETECTORS.permissions.hermes).toBeDefined();
+  });
+
   it('antigravity has subagents + workflows writers + detectors', () => {
     expect(WRITERS.subagents.antigravity).toBeDefined();
     expect(DETECTORS.subagents.antigravity).toBeDefined();


### PR DESCRIPTION
## What

Flip `allowlist: false → true` for **forge** and **hermes** in `agents.ts` and add canonical-permission writers for each.

### RUSH-1748 — ForgeCode
Writes `~/.forge/permissions.yaml` (or `$FORGE_CONFIG/permissions.yaml`) as an ordered `policies` list keyed by operation family (`read`/`write`/`command`/`url`) with glob patterns.
- Active only when `.forge.toml` sets `restricted = true`.
- **MCP tools bypass `permissions.yaml` entirely** (PR #2834 to add MCP checks was closed unmerged) — so only built-in-tool allow/deny rules are mapped.
- `convertToForgeFormat()` reuses `parseCanonicalPattern`/`BLANKET_BASH_FORMS`/`normalizeBashPattern`; merge mode unions + dedupes against existing policies.

### RUSH-1749 — Hermes
Writes `~/.hermes/config.yaml`:
- `command_allowlist` — always-approved command globs.
- `approvals.deny` — unconditional command blocks.
- **Command-glob only** — Hermes has no unified per-tool allow/deny table, so non-command canonical rules are skipped. Merge mode unions + sorts against existing config.

## Also
- Staleness detectors for both new config files.
- Docs (`00-concepts.md`, `02-resource-sync.md`) + CHANGELOG updated.

## Test
133 assertions pass across the four touched suites; `tsc --noEmit` clean.
```
Test Files  4 passed (4)
     Tests  133 passed (133)
```
Suites: `permissions.test.ts`, `resources/permissions.test.ts`, `staleness/registry.test.ts`, `__tests__/capabilities.test.ts`.