### PR TITLE
fix(triggers): Linear --label filter matches nothing (reads {nodes} connection, webhook sends flat array)

### DIFF
--- a/apps/cli/.changelog/next/linear-label-webhook-flat-array.md
+++ b/apps/cli/.changelog/next/linear-label-webhook-flat-array.md
@@ -1,0 +1,9 @@
+- **Fix the Linear `--label` trigger filter matching nothing.** `routines` and
+  `monitors` jobs triggered on `linear:Issue` with `--label <name>` never fired:
+  the matcher read `data.labels.nodes[].name` (the GraphQL-query connection
+  shape), but Linear webhook bodies flatten list relations — `data.labels` is a
+  flat array of label objects. The `.nodes` read always yielded `[]`, so every
+  label filter silently failed to match. It now reads the flat array. The prior
+  unit test fixtured the same wrong shape, so the suite was green while the
+  integration was dead; the fixture now uses the real webhook shape and a
+  regression test locks it. Source: `apps/cli/src/lib/triggers/webhook.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,17 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- **Fix the Linear `--label` trigger filter matching nothing.** `routines` and
-  `monitors` jobs triggered on `linear:Issue` with `--label <name>` never fired:
-  the matcher read `data.labels.nodes[].name` (the GraphQL-query connection
-  shape), but Linear webhook bodies flatten list relations — `data.labels` is a
-  flat array of label objects. The `.nodes` read always yielded `[]`, so every
-  label filter silently failed to match. It now reads the flat array. The prior
-  unit test fixtured the same wrong shape, so the suite was green while the
-  integration was dead; the fixture now uses the real webhook shape and a
-  regression test locks it. Source: `apps/cli/src/lib/triggers/webhook.ts`.
-
 ## 1.20.70
 
 - **Fix `agents setup computer` / `agents computer setup` refusing to install a

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+- **Fix the Linear `--label` trigger filter matching nothing.** `routines` and
+  `monitors` jobs triggered on `linear:Issue` with `--label <name>` never fired:
+  the matcher read `data.labels.nodes[].name` (the GraphQL-query connection
+  shape), but Linear webhook bodies flatten list relations — `data.labels` is a
+  flat array of label objects. The `.nodes` read always yielded `[]`, so every
+  label filter silently failed to match. It now reads the flat array. The prior
+  unit test fixtured the same wrong shape, so the suite was green while the
+  integration was dead; the fixture now uses the real webhook shape and a
+  regression test locks it. Source: `apps/cli/src/lib/triggers/webhook.ts`.
+
 ## 1.20.70
 
 - **Fix `agents setup computer` / `agents computer setup` refusing to install a

--- a/apps/cli/src/lib/triggers/webhook.test.ts
+++ b/apps/cli/src/lib/triggers/webhook.test.ts
@@ -63,7 +63,9 @@ function linearIssueWebhook(labels: string[] = ['agent']): IncomingWebhook {
       webhookTimestamp: Date.now(),
       data: {
         identifier: 'RUSH-1459',
-        labels: { nodes: labels.map((name) => ({ name })) },
+        // Real Linear webhook shape: `data.labels` is a flat array of label
+        // objects, NOT the `{ nodes: [...] }` GraphQL connection.
+        labels: labels.map((name) => ({ id: `lbl-${name}`, name })),
       },
     },
   };
@@ -138,6 +140,26 @@ describe('matchJobsToWebhook', () => {
     });
     expect(jobMatchesWebhook(linear, linearIssueWebhook(['agent']))).toBe(true);
     expect(jobMatchesWebhook(linear, linearIssueWebhook(['triage']))).toBe(false);
+  });
+
+  it('reads labels from the flat webhook array, not a {nodes} connection', () => {
+    // Regression: Linear webhook bodies send `data.labels` as a flat array.
+    // Reading `.nodes` (the GraphQL connection shape) made every --label filter
+    // match nothing. Lock the flat-array read and prove the stale shape fails.
+    const linear = job({
+      name: 'linear-agent',
+      trigger: { type: 'linear_event', event: 'Issue', action: 'update', teamKey: 'RUSH', label: 'agent' },
+    });
+    const staleConnectionShape: IncomingWebhook = {
+      source: 'linear',
+      event: 'Issue',
+      payload: {
+        type: 'Issue',
+        action: 'update',
+        data: { identifier: 'RUSH-1459', labels: { nodes: [{ name: 'agent' }] } },
+      },
+    };
+    expect(jobMatchesWebhook(linear, staleConnectionShape)).toBe(false);
   });
 
   it('skips jobs pinned to other devices, keeps jobs pinned here', () => {

--- a/apps/cli/src/lib/triggers/webhook.ts
+++ b/apps/cli/src/lib/triggers/webhook.ts
@@ -104,10 +104,13 @@ function linearTeamKey(payload: Record<string, unknown>): string | null {
 }
 
 function linearLabels(payload: Record<string, unknown>): string[] {
+  // Linear webhook bodies flatten list relations: an Issue event carries
+  // `data.labels` as a flat array of label objects (`[{ id, name, color }]`),
+  // NOT the `{ nodes: [...] }` connection shape returned by the GraphQL API.
+  // Reading `.nodes` here made every `--label` filter match nothing.
   const data = payload.data as Record<string, unknown> | undefined;
-  const labels = data?.labels as { nodes?: unknown } | undefined;
-  const nodes = Array.isArray(labels?.nodes) ? labels.nodes : [];
-  return nodes
+  const labels = Array.isArray(data?.labels) ? (data?.labels as unknown[]) : [];
+  return labels
     .map((n) => (n as { name?: unknown }).name)
     .filter((n): n is string => typeof n === 'string' && n.length > 0);
 }


### PR DESCRIPTION
## Problem

`routines` and `monitors` jobs triggered on `linear:Issue` with `--label <name>` **never fire**. The label matcher reads the wrong payload shape:

\`\`\`ts
// apps/cli/src/lib/triggers/webhook.ts (before)
const labels = data?.labels as { nodes?: unknown } | undefined;
const nodes = Array.isArray(labels?.nodes) ? labels.nodes : [];
\`\`\`

`data.labels.nodes` is the **GraphQL-query connection** shape. Linear **webhook** bodies flatten list relations — an Issue event carries `data.labels` as a **flat array** of label objects (`[{ id, name, color }]`) and `data.labelIds` as a flat string array. So `labels.nodes` is always `undefined`, `linearLabels()` returns `[]`, and every `--label` filter silently matches nothing.

This was observed in a live session ("the `--label` flag isn't filtering — shows the whole cycle").

## Why the tests didn't catch it

The unit fixture encoded the **same** wrong `{ nodes: [...] }` shape, so the suite was green while the real integration was dead — the classic "test passes with a broken implementation" trap.

## Fix

- `linearLabels()` now reads `data.labels` as a flat array (`webhook.ts`).
- The test fixture now uses the real flat-array webhook shape, turning the existing label test into a genuine regression test.
- Added a test asserting the stale `{ nodes }` connection shape no longer matches, locking the fix against regressions.

## Verification

Negative control — reintroducing the `.nodes` read fails 3 tests; the fix makes all 23 green:

\`\`\`
 23 pass  0 fail  55 expect() calls   (bun test src/lib/triggers/webhook.test.ts)
\`\`\`

`bunx tsc --noEmit`: no type errors.

Payload-shape evidence: Linear Issue webhooks send `data.labelIds` as a flat string array and `data.labels` as a flat array of label objects — the `{nodes}` connection shape only appears in GraphQL API responses, never in webhook bodies.

Session transcript (fleet-local): zion:/Users/muqsit/.agents/.history/versions/claude/2.1.170/... (kimi session 437d9e45 surfaced the bug; continued in this Claude session).