### PR TITLE
feat(menubar): populate Delegate on quick-capture Linear tickets (RUSH-1636)

### DIFF
--- a/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
@@ -240,7 +240,7 @@ enum AgentsCLI {
         reproduction path, or at minimum a crisp problem statement. Do NOT over-investigate; \
         a couple of focused reads is enough.
         4. Determine the best delegate agent for this ticket:
-           - The workspace agent roster is: Antigravity, Claude, ChatGPT Codex, Droid, Grok, Kimi, OpenClaw.
+           - The workspace agent roster is: Antigravity, Claude, Codex, Droid, Grok, Kimi, OpenClaw.
            - Run `agents sessions --active` and cross-check the roster against actually active local sessions.
            - Pick the agent whose recent work and strengths best fit the ticket content. Use your own judgment; do not ask the user.
            - If no agent clearly fits better than the others, default to `claude`.

--- a/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
@@ -214,7 +214,7 @@ enum AgentsCLI {
         let attachmentStep: String
         if screenshotPaths.isEmpty {
             shots = "No screenshots were attached; work from the note alone."
-            attachmentStep = "5. No user-provided files were attached; skip attachment handling."
+            attachmentStep = "6. No user-provided files were attached; skip attachment handling."
         } else if screenshotPaths.count == 1 {
             shots = "The user attached this screenshot for the ticket: \(screenshotPaths[0]) — read it first with your image tools."
             attachmentStep = ticketAttachmentStep(linear: linear, paths: screenshotPaths)
@@ -239,18 +239,26 @@ enum AgentsCLI {
         3. Do a brief investigation for real context — name the likely file/area, a \
         reproduction path, or at minimum a crisp problem statement. Do NOT over-investigate; \
         a couple of focused reads is enough.
-        4. File the ticket, piping a proper multi-line description via stdin:
+        4. Determine the best delegate agent for this ticket:
+           - The workspace agent roster is: Antigravity, Claude, ChatGPT Codex, Droid, Grok, Kimi, OpenClaw.
+           - Run `agents sessions --active` and cross-check the roster against actually active local sessions.
+           - Pick the agent whose recent work and strengths best fit the ticket content. Use your own judgment; do not ask the user.
+           - If no agent clearly fits better than the others, default to `claude`.
+           - If delegate resolution fails or produces no available candidate, omit the `--delegate` flag from the next step instead of failing.
+        5. File the ticket, piping a proper multi-line description via stdin:
 
            printf '%s' "<your markdown description>" | \\
              \(linear) create "<crisp imperative title>" \\
                --priority <urgent|high|medium|low> \\
                --project "<Linear project name matching the repo>" \\
                --label "repo:<repo-name>" \\
+               --delegate <agent> \\
                --description-file -
 
            Pick an HONEST priority. Keep the title short and specific.
+           Omit `--delegate <agent>` entirely if delegate resolution in step 4 failed or produced no candidate.
         \(attachmentStep)
-        6. Print the resulting `Created RUSH-###: <title>` line, then on the NEXT line print
+        7. Print the resulting `Created RUSH-###: <title>` line, then on the NEXT line print
         the ticket's Linear URL as `URL: https://linear.app/…` (the `linear create` output or
         `\(linear) tasks <id>` gives it). Nothing else — no commentary.
         """
@@ -260,7 +268,7 @@ enum AgentsCLI {
         let proofArgs = paths.map { "             --proof \(shellQuote($0))" }
             .joined(separator: " \\\n")
         return """
-        5. Make sure every user-provided file is uploaded to the resulting Linear issue — do \
+        6. Make sure every user-provided file is uploaded to the resulting Linear issue — do \
         not merely mention its local filesystem path. Use whatever placement best communicates \
         the issue: description, comment, or another appropriate attachment surface. The reliable \
         CLI default is:

--- a/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
@@ -112,6 +112,16 @@ enum IssueSelfTest {
         check("no-screenshot prompt has no /tmp path", !noShot.contains("/tmp/"))
         check("no-screenshot prompt has no upload command", !noShot.contains("--proof"))
         check("no-screenshot prompt skips attachment handling", noShot.contains("skip attachment handling"))
+
+        // RUSH-1636: the ticket agent must assign a delegate via linear create --delegate.
+        let delegate = AgentsCLI.ticketAgentPrompt(note: "assign a delegate", screenshotPaths: ["/tmp/a.png"])
+        check("prompt instructs delegate resolution", delegate.contains("agents sessions --active"))
+        check("prompt lists the workspace delegate roster",
+              delegate.contains("Antigravity") && delegate.contains("OpenClaw"))
+        check("prompt templates --delegate on linear create", delegate.contains("--delegate <agent>"))
+        check("prompt defaults to claude when inconclusive", delegate.contains("default to `claude`"))
+        check("prompt omits --delegate on resolution failure",
+              delegate.contains("omit the `--delegate` flag"))
     }
 
     // The autonomous fix path must carry screenshots through and name runs with


### PR DESCRIPTION
## What

The menubar quick-capture ticket agent now assigns a Delegate when filing Linear tickets via `linear create`.

## Changes

- Added a delegate-resolution step to the ticket-agent prompt:
  - Cross-checks the workspace roster (Antigravity, Claude, ChatGPT Codex, Droid, Grok, Kimi, OpenClaw) against actually-active sessions via `agents sessions --active`.
  - Picks the best-fit agent using the filing agent's own judgment.
  - Defaults to `claude` when inconclusive.
  - Omits `--delegate` rather than failing if resolution errors out.
- Templates `--delegate <agent>` onto the `linear create` invocation.
- Renumbered the subsequent prompt steps and added self-test assertions covering the new contract.

## Verification

Swift / macOS build tooling is not available in this environment, so verification is via the prompt template and the existing `MENUBAR_ISSUE_TEST` self-test assertions, which now assert the delegate instructions and `--delegate` flag are present.

Closes RUSH-1636.
